### PR TITLE
GH#28656: Add approval-bound Reddit provider operations

### DIFF
--- a/.agents/aidevops/knowledge-plane/05-social-operations.md
+++ b/.agents/aidevops/knowledge-plane/05-social-operations.md
@@ -39,7 +39,9 @@ workspace owner. Recipient `knowledge.read` and `knowledge.write` grants never
 become posting authority.
 
 Create a draft from a mode-0600 UTF-8 body file, then approve its exact immutable
-intent. Omit `--scheduled-at` for an immediately due operation:
+intent. The connection selects the allowlisted outbound provider; callers cannot
+substitute a provider at execution time. Omit `--scheduled-at` for an immediately
+due X operation:
 
 ```bash
 knowledge-social-helper.sh operation-create --alias workspace:example \
@@ -51,11 +53,39 @@ knowledge-social-helper.sh operation-approve --alias workspace:example \
   --operation-id OPERATION_ID --expires-at EPOCH
 ```
 
-The intent binds the operation ID, connection, stable account ID, action, target,
-body digest, local app/account selectors, schedule, creator, and provider. Reply
-uses `--target-id POST_ID --body-file FILE`; like and bookmark use only
-`--target-id POST_ID`. Revoke approval or cancel before a claim with
-`operation-revoke` or `operation-cancel`.
+The versioned intent binds the operation ID, connection, stable account ID,
+provider, action, target, destination, body and subject digests, local auth/account
+selectors, schedule, and creator. Reply uses `--target-id POST_ID` with
+`--body-file FILE`; like and bookmark use only `--target-id POST_ID`. Revoke
+approval or cancel before a claim with `operation-revoke` or `operation-cancel`.
+
+Reddit uses the same queue. Install PRAW outside the agent session and store one
+credential set per named profile as `REDDIT_<PROFILE>_CLIENT_ID`,
+`REDDIT_<PROFILE>_CLIENT_SECRET`, `REDDIT_<PROFILE>_USERNAME`,
+`REDDIT_<PROFILE>_PASSWORD`, and `REDDIT_<PROFILE>_USER_AGENT`. For example, a
+`work` profile creates a self-post with a separately protected one-line subject:
+
+```bash
+knowledge-social-helper.sh operation-create --alias workspace:example \
+  --connection-id REDDIT_CONNECTION_ID --account-id STABLE_REDDIT_ACCOUNT_ID \
+  --action post --destination-id SUBREDDIT_NAME --subject-file subject.txt \
+  --body-file approved-post.txt --profile work
+```
+
+Reddit reply, like, and bookmark targets use stable `t1_...` comment or `t3_...`
+submission fullnames. Like maps to PRAW `upvote()` and bookmark maps to `save()`.
+Run the approved operation through the secret execution context so the selected
+profile variables exist only in the child environment:
+
+```bash
+aidevops secret REDDIT_WORK_CLIENT_ID REDDIT_WORK_CLIENT_SECRET \
+  REDDIT_WORK_USERNAME REDDIT_WORK_PASSWORD REDDIT_WORK_USER_AGENT -- \
+  knowledge-social-helper.sh operation-run --alias workspace:example \
+  --operation-id OPERATION_ID
+```
+
+Credential values never belong in command arguments, operation rows, receipts,
+or logs.
 
 A private routine may invoke the bounded due runner:
 
@@ -64,10 +94,12 @@ knowledge-social-helper.sh operations-run-due --alias workspace:example \
   --executor-id EXECUTOR_ID --claim-seconds 300 --limit 10
 ```
 
-Each runner atomically claims an operation, verifies `xurl whoami` against the
-approved stable account immediately before execution, records a durable provider
-boundary, and invokes only mapped `post`, `reply`, `like`, or `bookmark` helper
-commands. Competing runners cannot create another local attempt. Any timeout,
+Each runner atomically claims an operation, resolves the stored provider through
+the fixed registry, verifies the provider's current identity against the approved
+stable account immediately before execution, records a durable provider boundary,
+and invokes only mapped `post`, `reply`, `like`, or `bookmark` operations. X uses
+the guarded official `xurl` helper; Reddit uses a bounded privacy-safe PRAW child
+process. Competing runners cannot create another local attempt. Any timeout,
 non-zero exit, malformed receipt, or executor loss after the provider boundary is
 `unknown`, never retryable. Resolve it only after external verification:
 

--- a/.agents/content/social-reddit.md
+++ b/.agents/content/social-reddit.md
@@ -37,17 +37,22 @@ curl -s "https://www.reddit.com/search.json?q=aidevops&sort=relevance" | jq '.da
 
 ## PRAW (Authenticated)
 
-OAuth app: https://www.reddit.com/prefs/apps → create "script" type → `aidevops secret set REDDIT_CLIENT_ID`.
+OAuth app: https://www.reddit.com/prefs/apps → create "script" type. Store a
+named profile with `aidevops secret set REDDIT_DEFAULT_CLIENT_ID` and matching
+`CLIENT_SECRET`, `USERNAME`, `PASSWORD`, and `USER_AGENT` entries; never put the
+values in a command or repository file.
 
 ```python
+import os
+
 import praw
 
 reddit = praw.Reddit(
-    client_id="YOUR_CLIENT_ID",
-    client_secret="YOUR_CLIENT_SECRET",
-    user_agent="aidevops/1.0",
-    username="YOUR_USERNAME",
-    password="YOUR_PASSWORD"
+    client_id=os.environ["REDDIT_DEFAULT_CLIENT_ID"],
+    client_secret=os.environ["REDDIT_DEFAULT_CLIENT_SECRET"],
+    user_agent=os.environ["REDDIT_DEFAULT_USER_AGENT"],
+    username=os.environ["REDDIT_DEFAULT_USERNAME"],
+    password=os.environ["REDDIT_DEFAULT_PASSWORD"],
 )
 
 # Read subreddit
@@ -62,7 +67,35 @@ comment = reddit.comment("COMMENT_ID")
 comment.reply("Reply text")
 ```
 
+## Approval-bound outbound operations
+
+Automated writes use the owner-only social operation queue rather than direct
+PRAW snippets. The connection fixes provider `reddit` and its stable account ID;
+`--profile default` selects only `REDDIT_DEFAULT_*` environment variables. Every
+immutable draft requires a separate owner approval before execution.
+
+```bash
+# Self-post: subject and body remain in separate mode-0600 files until execution.
+knowledge-social-helper.sh operation-create --alias workspace:example \
+  --connection-id REDDIT_CONNECTION_ID --account-id STABLE_REDDIT_ACCOUNT_ID \
+  --action post --destination-id SUBREDDIT_NAME --subject-file subject.txt \
+  --body-file post.txt --profile default
+
+# Reply targets t1_ comments or t3_ submissions. Like maps to upvote; bookmark to save.
+knowledge-social-helper.sh operation-create --alias workspace:example \
+  --connection-id REDDIT_CONNECTION_ID --account-id STABLE_REDDIT_ACCOUNT_ID \
+  --action reply --target-id t1_COMMENT_ID --body-file reply.txt \
+  --profile default
+```
+
+Execution verifies `reddit.user.me().id` against the approved stable account
+before recording the provider boundary. A timeout or provider failure after that
+boundary becomes `unknown` and requires external reconciliation; it is never
+blindly retried. Multiple accounts use separate profile slugs and separate
+`REDDIT_<PROFILE>_*` secret sets.
+
 ## Related
 
 - `scripts/x-helper.sh` - X/Twitter fetching via fxtwitter
+- `aidevops/knowledge-plane/05-social-operations.md` - approval, scheduling, receipts, and reconciliation
 - `tools/browser/curl-copy.md` - Authenticated scraping workflow

--- a/.agents/content/social-reddit.md
+++ b/.agents/content/social-reddit.md
@@ -59,13 +59,14 @@ reddit = praw.Reddit(
 for post in reddit.subreddit("devops").hot(limit=10):
     print(f"{post.score}: {post.title}")
 
-# Submit post
-reddit.subreddit("test").submit("Title", selftext="Body text")
-
-# Reply to comment
+# Read one comment
 comment = reddit.comment("COMMENT_ID")
-comment.reply("Reply text")
+print(comment.body)
 ```
+
+Use direct PRAW calls for reads only. Every automated post, reply, upvote, or
+save must use the owner-only queue through `operation-create`; never call PRAW
+write methods directly from automation.
 
 ## Approval-bound outbound operations
 

--- a/.agents/scripts/_knowledge_social_outbound.py
+++ b/.agents/scripts/_knowledge_social_outbound.py
@@ -33,6 +33,7 @@ FAILURE_CLASSES = (
 )
 MAX_PAYLOAD_BYTES = 16 * 1024
 MAX_SUBJECT_BYTES = 4 * 1024
+MAX_REDDIT_SUBJECT_CHARS = 300
 MAX_SELECTOR_BYTES = 256
 MAX_APPROVAL_SECONDS = 31 * 24 * 60 * 60
 CURRENT_INTENT_VERSION = 2
@@ -133,6 +134,10 @@ def _validated_subject(provider: str, action: str, subject: str | None) -> str |
             raise SocialStoreError("Reddit posts require a non-empty private subject file")
         if any(marker in subject for marker in ("\x00", "\n", "\r")):
             raise SocialStoreError("outbound subject must be one non-empty line")
+        if len(subject) > MAX_REDDIT_SUBJECT_CHARS:
+            raise SocialStoreError(
+                "Reddit post subject exceeds the 300-character title limit"
+            )
         if len(subject.encode("utf-8")) > MAX_SUBJECT_BYTES:
             raise SocialStoreError("outbound subject exceeds the private subject limit")
         return subject

--- a/.agents/scripts/_knowledge_social_outbound.py
+++ b/.agents/scripts/_knowledge_social_outbound.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import hashlib
+import re
 import sqlite3
 import time
 import uuid
@@ -16,6 +17,10 @@ from knowledge_social_import import canonical_json
 from knowledge_social_store import SocialStoreError, validate_opaque
 
 ACTIONS = ("post", "reply", "like", "bookmark")
+OUTBOUND_PROVIDER_ACTIONS = {
+    "reddit": ACTIONS,
+    "xapi": ACTIONS,
+}
 TERMINAL_STATES = ("succeeded", "failed", "unknown", "cancelled")
 FAILURE_CLASSES = (
     "authorization",
@@ -27,8 +32,13 @@ FAILURE_CLASSES = (
     "validation",
 )
 MAX_PAYLOAD_BYTES = 16 * 1024
+MAX_SUBJECT_BYTES = 4 * 1024
 MAX_SELECTOR_BYTES = 256
 MAX_APPROVAL_SECONDS = 31 * 24 * 60 * 60
+CURRENT_INTENT_VERSION = 2
+REDDIT_TARGET_ID = re.compile(r"^t[13]_[A-Za-z0-9]+$")
+REDDIT_PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+REDDIT_DESTINATION_ID = re.compile(r"^[A-Za-z0-9_]{3,21}$")
 
 
 @dataclass(frozen=True)
@@ -44,6 +54,8 @@ class OperationIntent:
     username: str | None
     scheduled_at: int
     created_by: str
+    destination_remote_id: str | None = None
+    subject: str | None = None
     operation_id: str | None = None
     created_at: int | None = None
 
@@ -63,10 +75,13 @@ class ClaimedOperation:
     """Private operation values needed for exactly one provider attempt."""
 
     operation_id: str
+    provider: str
     action: str
     remote_account_id: str
     target_remote_id: str | None
+    destination_remote_id: str | None
     payload: str | None
+    subject: str | None
     app_profile: str | None
     username: str | None
     claim_token: int
@@ -112,19 +127,52 @@ def _validated_payload(action: str, payload: str | None) -> str | None:
     return None
 
 
-def _validated_target(action: str, target: str | None) -> str | None:
+def _validated_subject(provider: str, action: str, subject: str | None) -> str | None:
+    if provider == "reddit" and action == "post":
+        if subject is None or not subject.strip():
+            raise SocialStoreError("Reddit posts require a non-empty private subject file")
+        if any(marker in subject for marker in ("\x00", "\n", "\r")):
+            raise SocialStoreError("outbound subject must be one non-empty line")
+        if len(subject.encode("utf-8")) > MAX_SUBJECT_BYTES:
+            raise SocialStoreError("outbound subject exceeds the private subject limit")
+        return subject
+    if subject is not None:
+        raise SocialStoreError("this outbound operation does not accept a subject")
+    return None
+
+
+def _validated_destination(
+    provider: str, action: str, destination: str | None
+) -> str | None:
+    if provider == "reddit" and action == "post":
+        if destination is None:
+            raise SocialStoreError("Reddit posts require a destination subreddit ID")
+        destination = validate_opaque(destination, "destination_remote_id")
+        if REDDIT_DESTINATION_ID.fullmatch(destination) is None:
+            raise SocialStoreError("Reddit destination subreddit ID is invalid")
+        return destination
+    if destination is not None:
+        raise SocialStoreError("this outbound operation does not accept a destination")
+    return None
+
+
+def _validated_target(provider: str, action: str, target: str | None) -> str | None:
     if action == "post":
         if target is not None:
             raise SocialStoreError("post does not accept a target")
         return None
     if target is None:
         raise SocialStoreError(f"{action} requires a target post ID")
-    return validate_opaque(target, "target_remote_id")
+    target = validate_opaque(target, "target_remote_id")
+    if provider == "reddit" and REDDIT_TARGET_ID.fullmatch(target) is None:
+        raise SocialStoreError("Reddit targets require a t1_ or t3_ fullname")
+    return target
 
 
 def _intent_document(values: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "version": 1,
+    version = int(values["intent_version"])
+    document = {
+        "version": version,
         "operation_id": values["operation_id"],
         "provider": values["provider"],
         "connection_id": values["connection_id"],
@@ -137,6 +185,16 @@ def _intent_document(values: dict[str, Any]) -> dict[str, Any]:
         "scheduled_at": values["scheduled_at"],
         "created_by": values["created_by"],
     }
+    if version == 2:
+        document.update(
+            {
+                "destination_remote_id": values["destination_remote_id"],
+                "subject_sha256": values["subject_sha256"],
+            }
+        )
+    elif version != 1:
+        raise SocialStoreError("unsupported outbound intent version")
+    return document
 
 
 def _intent_sha256(values: dict[str, Any]) -> str:
@@ -147,6 +205,19 @@ def _verify_operation_row(row: sqlite3.Row) -> sqlite3.Row:
     payload_sha256 = _digest(row["payload"] or "")
     if payload_sha256 != row["payload_sha256"]:
         raise SocialStoreError("outbound operation payload integrity check failed")
+    intent_version = int(row["intent_version"])
+    if intent_version == 1:
+        if any(
+            row[field] is not None
+            for field in ("destination_remote_id", "subject", "subject_sha256")
+        ):
+            raise SocialStoreError("legacy outbound operation has unbound provider fields")
+    elif intent_version == 2:
+        subject_sha256 = _digest(row["subject"] or "")
+        if subject_sha256 != row["subject_sha256"]:
+            raise SocialStoreError("outbound operation subject integrity check failed")
+    else:
+        raise SocialStoreError("unsupported outbound intent version")
     values = dict(row)
     values["payload_sha256"] = payload_sha256
     if _intent_sha256(values) != row["intent_sha256"]:
@@ -154,48 +225,80 @@ def _verify_operation_row(row: sqlite3.Row) -> sqlite3.Row:
     return row
 
 
-def _operation_values(intent: OperationIntent, operation_id: str) -> dict[str, Any]:
-    if intent.action not in ACTIONS:
+def _connection_values(
+    database: sqlite3.Connection, intent: OperationIntent
+) -> tuple[str, str, str, str | None]:
+    connection_id = validate_opaque(intent.connection_id, "connection_id")
+    remote_account_id = validate_opaque(intent.remote_account_id, "remote_account_id")
+    row = database.execute(
+        "SELECT provider,remote_account_id,auth_profile_ref FROM connections "
+        "WHERE connection_id=?",
+        (connection_id,),
+    ).fetchone()
+    if row is None:
+        raise SocialStoreError("outbound connection is unavailable")
+    if row["remote_account_id"] != remote_account_id:
+        raise SocialStoreError("outbound connection does not match the account")
+    provider = validate_opaque(str(row["provider"]), "provider")
+    if provider not in OUTBOUND_PROVIDER_ACTIONS:
+        raise SocialStoreError("outbound connection provider is unsupported")
+    return provider, connection_id, remote_account_id, row["auth_profile_ref"]
+
+
+def _operation_values(
+    intent: OperationIntent,
+    operation_id: str,
+    provider: str,
+    connection_id: str,
+    remote_account_id: str,
+    auth_profile_ref: str | None,
+) -> dict[str, Any]:
+    if intent.action not in OUTBOUND_PROVIDER_ACTIONS[provider]:
         raise SocialStoreError("unsupported outbound action")
     if intent.scheduled_at < 0:
         raise SocialStoreError("scheduled_at must be a non-negative epoch")
     payload = _validated_payload(intent.action, intent.payload)
+    profile = intent.app_profile if intent.app_profile is not None else auth_profile_ref
+    app_profile = _optional_selector(profile, "app_profile")
+    username = _optional_selector(intent.username, "username")
+    if provider == "reddit":
+        if app_profile is None:
+            raise SocialStoreError("Reddit operations require a named auth profile")
+        if REDDIT_PROFILE_NAME.fullmatch(app_profile) is None:
+            raise SocialStoreError(
+                "Reddit auth profile must be a lowercase environment-safe slug"
+            )
+        if username is not None:
+            raise SocialStoreError("Reddit identity is selected only by its auth profile")
+    subject = _validated_subject(provider, intent.action, intent.subject)
     return {
         "operation_id": validate_opaque(operation_id, "operation_id"),
-        "provider": "xapi",
-        "connection_id": validate_opaque(intent.connection_id, "connection_id"),
-        "remote_account_id": validate_opaque(
-            intent.remote_account_id, "remote_account_id"
-        ),
+        "provider": provider,
+        "connection_id": connection_id,
+        "remote_account_id": remote_account_id,
         "action": intent.action,
         "target_remote_id": _validated_target(
-            intent.action, intent.target_remote_id
+            provider, intent.action, intent.target_remote_id
+        ),
+        "destination_remote_id": _validated_destination(
+            provider, intent.action, intent.destination_remote_id
         ),
         "payload": payload,
         "payload_sha256": _digest(payload or ""),
-        "app_profile": _optional_selector(intent.app_profile, "app_profile"),
-        "username": _optional_selector(intent.username, "username"),
+        "subject": subject,
+        "subject_sha256": _digest(subject or ""),
+        "intent_version": CURRENT_INTENT_VERSION,
+        "app_profile": app_profile,
+        "username": username,
         "scheduled_at": intent.scheduled_at,
         "created_by": validate_opaque(intent.created_by, "created_by"),
     }
 
 
-def _assert_connection(database: sqlite3.Connection, values: dict[str, Any]) -> None:
-    row = database.execute(
-        "SELECT provider,remote_account_id FROM connections WHERE connection_id=?",
-        (values["connection_id"],),
-    ).fetchone()
-    if row is None:
-        raise SocialStoreError("outbound connection is unavailable")
-    if row["provider"] != "xapi" or row["remote_account_id"] != values[
-        "remote_account_id"
-    ]:
-        raise SocialStoreError("outbound connection does not match the X account")
-
-
 def _public_operation(row: sqlite3.Row) -> dict[str, Any]:
     return {
         "operation_id": str(row["operation_id"]),
+        "provider": str(row["provider"]),
         "action": str(row["action"]),
         "state": str(row["state"]),
         "scheduled_at": int(row["scheduled_at"]),
@@ -223,9 +326,10 @@ def _insert_operation(
     database.execute(
         """INSERT INTO outbound_operations(
             operation_id,provider,connection_id,remote_account_id,action,
-            target_remote_id,payload,payload_sha256,intent_sha256,app_profile,
+            target_remote_id,destination_remote_id,payload,payload_sha256,
+            subject,subject_sha256,intent_version,intent_sha256,app_profile,
             username,scheduled_at,state,created_by,created_at,updated_at)
-           VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+           VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
         (
             values["operation_id"],
             values["provider"],
@@ -233,8 +337,12 @@ def _insert_operation(
             values["remote_account_id"],
             values["action"],
             values["target_remote_id"],
+            values["destination_remote_id"],
             values["payload"],
             values["payload_sha256"],
+            values["subject"],
+            values["subject_sha256"],
+            values["intent_version"],
             values["intent_sha256"],
             values["app_profile"],
             values["username"],
@@ -253,11 +361,20 @@ def create_operation(
     """Create or idempotently recover one immutable draft operation."""
     operation_id = intent.operation_id or _new_id("op")
     created_at = now_epoch() if intent.created_at is None else intent.created_at
-    values = _operation_values(intent, operation_id)
-    values["intent_sha256"] = _intent_sha256(values)
     database.execute("BEGIN IMMEDIATE")
     try:
-        _assert_connection(database, values)
+        provider, connection_id, remote_account_id, auth_profile_ref = (
+            _connection_values(database, intent)
+        )
+        values = _operation_values(
+            intent,
+            operation_id,
+            provider,
+            connection_id,
+            remote_account_id,
+            auth_profile_ref,
+        )
+        values["intent_sha256"] = _intent_sha256(values)
         existing = _existing_public_operation(
             database, operation_id, str(values["intent_sha256"])
         )
@@ -272,6 +389,7 @@ def create_operation(
         raise
     return {
         "operation_id": operation_id,
+        "provider": str(values["provider"]),
         "action": intent.action,
         "state": "draft",
         "scheduled_at": intent.scheduled_at,

--- a/.agents/scripts/_knowledge_social_outbound_provider.py
+++ b/.agents/scripts/_knowledge_social_outbound_provider.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-"""Fixed-argv X provider adapter for approved outbound operations."""
+"""Registry-backed provider adapters for approved outbound operations."""
 
 from __future__ import annotations
 
 import json
+import os
 import subprocess
+import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Callable, Protocol
 
 from _knowledge_social_outbound import ClaimedOperation
 from _knowledge_social_x import XAdapterError, response_status
-from knowledge_social_import import reject_credentials
+from _knowledge_social_x_reader import GuardedXurl, verified_identity
+from knowledge_social_import import canonical_json, reject_credentials
 from knowledge_social_store import SocialStoreError, validate_opaque
 
 WRITE_TIMEOUT_SECONDS = 120
@@ -20,6 +25,20 @@ MAX_PROVIDER_OUTPUT_BYTES = 1024 * 1024
 
 class ProviderAdapterError(RuntimeError):
     """Raised when an approved operation cannot be mapped to safe provider argv."""
+
+
+class ProviderIdentityError(RuntimeError):
+    """Raised when the selected provider account cannot be verified safely."""
+
+
+class PreparedProvider(Protocol):
+    """One validated provider selection for an immutable claimed operation."""
+
+    def verify_identity(self) -> None:
+        """Verify the selected provider identity before the write boundary."""
+
+    def invoke(self) -> tuple[str | None, str | None]:
+        """Invoke one approved write and return only a safe receipt classification."""
 
 
 def _profile_args(claimed: ClaimedOperation) -> list[str]:
@@ -108,3 +127,214 @@ def invoke_provider(
         return _provider_remote_id(claimed, completed.stdout), None
     except (ProviderAdapterError, SocialStoreError, UnicodeError, XAdapterError):
         return None, "validation"
+
+
+@dataclass(frozen=True)
+class XPreparedProvider:
+    """Prepared official X CLI invocation for one claimed operation."""
+
+    helper: Path
+    claimed: ClaimedOperation
+
+    def verify_identity(self) -> None:
+        try:
+            identity_reader = GuardedXurl(
+                self.helper, self.claimed.app_profile, self.claimed.username
+            )
+            verified_identity(
+                identity_reader.identity(), self.claimed.remote_account_id
+            )
+        except (
+            OSError,
+            SocialStoreError,
+            subprocess.SubprocessError,
+            XAdapterError,
+        ) as error:
+            raise ProviderIdentityError(
+                "selected provider identity could not be verified"
+            ) from error
+
+    def invoke(self) -> tuple[str | None, str | None]:
+        return invoke_provider(self.helper, self.claimed)
+
+
+def _reddit_response_id(output: str) -> str:
+    if len(output.encode("utf-8")) > MAX_PROVIDER_OUTPUT_BYTES:
+        raise ProviderAdapterError("Reddit write response exceeds the safety limit")
+    try:
+        response = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise ProviderAdapterError("Reddit write response is not valid JSON") from error
+    if not isinstance(response, dict):
+        raise ProviderAdapterError("Reddit write response root must be an object")
+    reject_credentials(response)
+    data = response.get("data")
+    remote_id = data.get("id") if isinstance(data, dict) else None
+    if not isinstance(remote_id, str):
+        raise ProviderAdapterError("Reddit write response has no stable remote ID")
+    return validate_opaque(remote_id, "provider_remote_id")
+
+
+@dataclass(frozen=True)
+class RedditPreparedProvider:
+    """Prepared bounded PRAW subprocess invocation for one claimed operation."""
+
+    helper: Path
+    claimed: ClaimedOperation
+
+    def _environment(self) -> dict[str, str]:
+        if self.claimed.app_profile is None:
+            raise ProviderAdapterError("Reddit operation has no auth profile")
+        profile_prefix = f"REDDIT_{self.claimed.app_profile.upper()}_"
+        credential_names = {
+            f"{profile_prefix}{field}"
+            for field in (
+                "CLIENT_ID",
+                "CLIENT_SECRET",
+                "PASSWORD",
+                "USER_AGENT",
+                "USERNAME",
+            )
+        }
+        inherited = {
+            "HOME",
+            "HTTPS_PROXY",
+            "HTTP_PROXY",
+            "LANG",
+            "LC_ALL",
+            "NO_PROXY",
+            "PATH",
+            "REQUESTS_CA_BUNDLE",
+            "SSL_CERT_FILE",
+            "TMPDIR",
+            "https_proxy",
+            "http_proxy",
+            "no_proxy",
+        }
+        environment = {
+            key: value
+            for key, value in os.environ.items()
+            if key in inherited or key in credential_names
+        }
+        if os.environ.get("AIDEVOPS_TEST_MODE") == "1":
+            for key in (
+                "AIDEVOPS_TEST_MODE",
+                "PYTHONPATH",
+                "REDDIT_LOG",
+                "REDDIT_MODE",
+            ):
+                if key in os.environ:
+                    environment[key] = os.environ[key]
+        return environment
+
+    def _run(
+        self, request: dict[str, str], *, confirm_write: bool
+    ) -> subprocess.CompletedProcess[str]:
+        if self.claimed.app_profile is None:
+            raise ProviderAdapterError("Reddit operation has no auth profile")
+        command = [
+            sys.executable,
+            str(self.helper),
+            "--profile",
+            self.claimed.app_profile,
+        ]
+        if confirm_write:
+            command.append("--confirm-write")
+        return subprocess.run(  # nosec B603 -- fixed local helper and fixed argv
+            command,
+            check=False,
+            capture_output=True,
+            input=canonical_json(request),
+            env=self._environment(),
+            text=True,
+            timeout=WRITE_TIMEOUT_SECONDS,
+        )
+
+    def verify_identity(self) -> None:
+        try:
+            completed = self._run({"action": "identity"}, confirm_write=False)
+            if completed.returncode != 0:
+                raise ProviderIdentityError(
+                    "selected provider identity could not be verified"
+                )
+            remote_id = _reddit_response_id(completed.stdout)
+            if remote_id != self.claimed.remote_account_id:
+                raise ProviderIdentityError(
+                    "selected provider identity does not match the approved account"
+                )
+        except ProviderIdentityError:
+            raise
+        except (
+            OSError,
+            ProviderAdapterError,
+            SocialStoreError,
+            subprocess.SubprocessError,
+            UnicodeError,
+        ) as error:
+            raise ProviderIdentityError(
+                "selected provider identity could not be verified"
+            ) from error
+
+    def _write_request(self) -> dict[str, str]:
+        request = {"action": self.claimed.action}
+        if self.claimed.action == "post":
+            if (
+                self.claimed.destination_remote_id is None
+                or self.claimed.subject is None
+                or self.claimed.payload is None
+            ):
+                raise ProviderAdapterError("Reddit post has an invalid action shape")
+            request.update(
+                {
+                    "destination": self.claimed.destination_remote_id,
+                    "subject": self.claimed.subject,
+                    "payload": self.claimed.payload,
+                }
+            )
+            return request
+        if self.claimed.target_remote_id is None:
+            raise ProviderAdapterError("Reddit engagement has no target ID")
+        request["target"] = self.claimed.target_remote_id
+        if self.claimed.action == "reply":
+            if self.claimed.payload is None:
+                raise ProviderAdapterError("Reddit reply has no body")
+            request["payload"] = self.claimed.payload
+        elif self.claimed.action not in ("like", "bookmark"):
+            raise ProviderAdapterError("Reddit outbound action is unsupported")
+        return request
+
+    def invoke(self) -> tuple[str | None, str | None]:
+        try:
+            completed = self._run(self._write_request(), confirm_write=True)
+        except (OSError, ProviderAdapterError, subprocess.SubprocessError, UnicodeError):
+            return None, "provider_unavailable"
+        if completed.returncode != 0:
+            return None, "provider_unavailable"
+        try:
+            return _reddit_response_id(completed.stdout), None
+        except (ProviderAdapterError, SocialStoreError, UnicodeError):
+            return None, "validation"
+
+
+def _prepare_x(claimed: ClaimedOperation) -> PreparedProvider:
+    return XPreparedProvider(Path(__file__).with_name("xurl-helper.sh"), claimed)
+
+
+def _prepare_reddit(claimed: ClaimedOperation) -> PreparedProvider:
+    return RedditPreparedProvider(
+        Path(__file__).with_name("_knowledge_social_reddit_provider.py"), claimed
+    )
+
+
+PROVIDER_FACTORIES: dict[str, Callable[[ClaimedOperation], PreparedProvider]] = {
+    "reddit": _prepare_reddit,
+    "xapi": _prepare_x,
+}
+
+
+def prepare_provider(claimed: ClaimedOperation) -> PreparedProvider:
+    """Resolve one allowlisted provider without accepting executable input."""
+    factory = PROVIDER_FACTORIES.get(claimed.provider)
+    if factory is None:
+        raise ProviderAdapterError("approved outbound provider is unsupported")
+    return factory(claimed)

--- a/.agents/scripts/_knowledge_social_outbound_runtime.py
+++ b/.agents/scripts/_knowledge_social_outbound_runtime.py
@@ -154,15 +154,18 @@ def claim_operation(
             database.execute("ROLLBACK")
         raise
     return ClaimedOperation(
-        request.operation_id,
-        str(row["action"]),
-        str(row["remote_account_id"]),
-        row["target_remote_id"],
-        row["payload"],
-        row["app_profile"],
-        row["username"],
-        claim_token,
-        attempt_id,
+        operation_id=request.operation_id,
+        provider=str(row["provider"]),
+        action=str(row["action"]),
+        remote_account_id=str(row["remote_account_id"]),
+        target_remote_id=row["target_remote_id"],
+        destination_remote_id=row["destination_remote_id"],
+        payload=row["payload"],
+        subject=row["subject"],
+        app_profile=row["app_profile"],
+        username=row["username"],
+        claim_token=claim_token,
+        attempt_id=attempt_id,
     )
 
 

--- a/.agents/scripts/_knowledge_social_reddit_provider.py
+++ b/.agents/scripts/_knowledge_social_reddit_provider.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Privacy-safe PRAW subprocess boundary for approved Reddit operations."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.metadata
+import json
+import os
+import re
+import sys
+from typing import Any
+
+MAX_REQUEST_BYTES = 32 * 1024
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+TARGET_FULLNAME = re.compile(r"^(t1|t3)_([A-Za-z0-9]+)$")
+OPAQUE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{2,127}$")
+WRITE_ACTIONS = ("post", "reply", "like", "bookmark")
+REQUIRED_CREDENTIALS = (
+    "CLIENT_ID",
+    "CLIENT_SECRET",
+    "USERNAME",
+    "PASSWORD",
+    "USER_AGENT",
+)
+
+
+class RedditProviderError(RuntimeError):
+    """Raised for a privacy-safe local Reddit provider failure."""
+
+
+def _profile_prefix(profile: str) -> str:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise RedditProviderError("Reddit auth profile name is invalid")
+    return f"REDDIT_{profile.upper()}"
+
+
+def _credentials(profile: str) -> dict[str, str]:
+    prefix = _profile_prefix(profile)
+    credentials = {
+        field.lower(): os.environ.get(f"{prefix}_{field}", "")
+        for field in REQUIRED_CREDENTIALS
+    }
+    if any(not value for value in credentials.values()):
+        raise RedditProviderError("Reddit auth profile credentials are incomplete")
+    return credentials
+
+
+def _praw_factory() -> Any:
+    try:
+        praw = importlib.import_module("praw")
+    except ImportError as error:
+        raise RedditProviderError(
+            "PRAW is unavailable; install it outside the agent session"
+        ) from error
+    factory = getattr(praw, "Reddit", None)
+    version = getattr(praw, "__version__", None)
+    if not isinstance(version, str) or not version:
+        try:
+            version = importlib.metadata.version("praw")
+        except importlib.metadata.PackageNotFoundError as error:
+            raise RedditProviderError("PRAW version metadata is unavailable") from error
+    if not callable(factory):
+        raise RedditProviderError("PRAW does not export the required Reddit client")
+    return factory
+
+
+def _client(profile: str) -> Any:
+    credentials = _credentials(profile)
+    return _praw_factory()(
+        client_id=credentials["client_id"],
+        client_secret=credentials["client_secret"],
+        username=credentials["username"],
+        password=credentials["password"],
+        user_agent=credentials["user_agent"],
+    )
+
+
+def _request() -> dict[str, Any]:
+    payload = sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1)
+    if len(payload) > MAX_REQUEST_BYTES:
+        raise RedditProviderError("Reddit provider request exceeds the safety limit")
+    try:
+        request = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise RedditProviderError("Reddit provider request is not valid JSON") from error
+    if not isinstance(request, dict):
+        raise RedditProviderError("Reddit provider request root must be an object")
+    return request
+
+
+def _exact_keys(request: dict[str, Any], expected: set[str]) -> None:
+    if set(request) != expected:
+        raise RedditProviderError("Reddit provider request has an invalid action shape")
+
+
+def _text(request: dict[str, Any], field: str) -> str:
+    value = request.get(field)
+    if not isinstance(value, str) or not value.strip() or "\x00" in value:
+        raise RedditProviderError("Reddit provider request has invalid text")
+    return value
+
+
+def _target(client: Any, fullname: str) -> Any:
+    match = TARGET_FULLNAME.fullmatch(fullname)
+    if match is None:
+        raise RedditProviderError("Reddit target fullname is invalid")
+    kind, remote_id = match.groups()
+    if kind == "t1":
+        return client.comment(remote_id)
+    return client.submission(id=remote_id)
+
+
+def _fullname(value: Any, prefix: str) -> str:
+    fullname = getattr(value, "fullname", None)
+    if isinstance(fullname, str) and OPAQUE_ID.fullmatch(fullname):
+        return fullname
+    remote_id = getattr(value, "id", None)
+    if not isinstance(remote_id, str) or not remote_id:
+        raise RedditProviderError("Reddit response has no stable remote ID")
+    fullname = f"{prefix}_{remote_id}"
+    if OPAQUE_ID.fullmatch(fullname) is None:
+        raise RedditProviderError("Reddit response remote ID is invalid")
+    return fullname
+
+
+def _identity(client: Any, request: dict[str, Any]) -> str:
+    _exact_keys(request, {"action"})
+    identity = client.user.me()
+    remote_id = getattr(identity, "id", None)
+    if not isinstance(remote_id, str) or OPAQUE_ID.fullmatch(remote_id) is None:
+        raise RedditProviderError("Reddit identity has no stable account ID")
+    return remote_id
+
+
+def _write(client: Any, request: dict[str, Any]) -> str:
+    action = request.get("action")
+    if action == "post":
+        _exact_keys(request, {"action", "destination", "payload", "subject"})
+        result = client.subreddit(_text(request, "destination")).submit(
+            _text(request, "subject"), selftext=_text(request, "payload")
+        )
+        return _fullname(result, "t3")
+    if action == "reply":
+        _exact_keys(request, {"action", "payload", "target"})
+        result = _target(client, _text(request, "target")).reply(
+            _text(request, "payload")
+        )
+        return _fullname(result, "t1")
+    if action in ("like", "bookmark"):
+        _exact_keys(request, {"action", "target"})
+        target = _target(client, _text(request, "target"))
+        if action == "like":
+            target.upvote()
+        else:
+            target.save()
+        return _text(request, "target")
+    raise RedditProviderError("Reddit provider action is unsupported")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    parser.add_argument("--confirm-write", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        request = _request()
+        action = request.get("action")
+        if not isinstance(action, str):
+            raise RedditProviderError("Reddit provider action is missing")
+        if action in WRITE_ACTIONS and not args.confirm_write:
+            raise RedditProviderError("Reddit writes require explicit confirmation")
+        client = _client(args.profile)
+        remote_id = (
+            _identity(client, request)
+            if action == "identity"
+            else _write(client, request)
+        )
+        print(json.dumps({"data": {"id": remote_id}}, sort_keys=True))
+        return 0
+    except RedditProviderError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:
+        print("ERROR: Reddit provider request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_reddit_provider.py
+++ b/.agents/scripts/_knowledge_social_reddit_provider.py
@@ -188,7 +188,7 @@ def main() -> int:
     except RedditProviderError as error:
         print(f"ERROR: {error}", file=sys.stderr)
         return 1
-    except Exception:
+    except Exception:  # noqa: BLE001 - intentionally redact provider internals
         print("ERROR: Reddit provider request failed", file=sys.stderr)
         return 1
 

--- a/.agents/scripts/knowledge_social_operations.py
+++ b/.agents/scripts/knowledge_social_operations.py
@@ -9,7 +9,6 @@ import argparse
 import json
 import os
 import sqlite3
-import subprocess
 import sys
 import time
 import uuid
@@ -25,6 +24,7 @@ from _knowledge_social_notifications import (
 from _knowledge_social_outbound import (
     ACTIONS,
     MAX_PAYLOAD_BYTES,
+    MAX_SUBJECT_BYTES,
     ClaimedOperation,
     OperationIntent,
     approve_operation,
@@ -32,7 +32,11 @@ from _knowledge_social_outbound import (
     create_operation,
     revoke_approval,
 )
-from _knowledge_social_outbound_provider import ProviderAdapterError, invoke_provider
+from _knowledge_social_outbound_provider import (
+    ProviderAdapterError,
+    ProviderIdentityError,
+    prepare_provider,
+)
 from _knowledge_social_outbound_reconciliation import (
     ReconciliationRequest,
     list_operations,
@@ -47,8 +51,6 @@ from _knowledge_social_outbound_runtime import (
     finalize_operation,
     mark_provider_started,
 )
-from _knowledge_social_x import XAdapterError
-from _knowledge_social_x_reader import GuardedXurl, verified_identity
 from knowledge_corpus_catalog import DEFAULT_ALIAS, authorized_scope
 from knowledge_corpus_context import CatalogError, validate_private_file
 from knowledge_social_store import (
@@ -122,6 +124,15 @@ def _read_private_body(path: Path) -> str:
         raise OperationsError("outbound body must be UTF-8") from error
 
 
+def _read_private_subject(path: Path) -> str:
+    subject = _read_private_body(path)
+    if subject.endswith("\n"):
+        subject = subject[:-1]
+        if subject.endswith("\r"):
+            subject = subject[:-1]
+    return subject
+
+
 def _managed_context(args: argparse.Namespace) -> tuple[str, Path]:
     principal_id, corpora = authorized_scope(
         args.base or DEFAULT_BASE, "knowledge.manage", args.alias
@@ -169,13 +180,15 @@ def _execute_claimed(
     executor_id: str,
     args: argparse.Namespace,
 ) -> dict[str, Any]:
-    helper = Path(__file__).with_name("xurl-helper.sh")
     try:
-        identity_reader = GuardedXurl(
-            helper, claimed.app_profile, claimed.username
+        provider = prepare_provider(claimed)
+    except ProviderAdapterError:
+        return _pre_provider_failure(
+            database, claimed, executor_id, "validation", args
         )
-        verified_identity(identity_reader.identity(), claimed.remote_account_id)
-    except (OSError, SocialStoreError, subprocess.SubprocessError, XAdapterError):
+    try:
+        provider.verify_identity()
+    except ProviderIdentityError:
         return _pre_provider_failure(
             database, claimed, executor_id, "identity", args
         )
@@ -189,7 +202,7 @@ def _execute_claimed(
             database, claimed, executor_id, "authorization", args
         )
 
-    provider_remote_id, failure_class = invoke_provider(helper, claimed)
+    provider_remote_id, failure_class = provider.invoke()
     if failure_class is not None:
         return _unknown_provider_outcome(
             database, claimed, executor_id, failure_class, args
@@ -271,6 +284,9 @@ def _handle_operation_create(
 ) -> dict[str, Any]:
     created_at = _required_now(current_time)
     payload = _read_private_body(args.body_file) if args.body_file else None
+    subject = _read_private_subject(args.subject_file) if args.subject_file else None
+    if subject is not None and len(subject.encode("utf-8")) > MAX_SUBJECT_BYTES:
+        raise OperationsError("outbound subject exceeds the private subject limit")
     return create_operation(
         database,
         OperationIntent(
@@ -287,6 +303,8 @@ def _handle_operation_create(
                 else created_at
             ),
             created_by=principal_id,
+            destination_remote_id=args.destination_id,
+            subject=subject,
             operation_id=args.operation_id,
             created_at=created_at,
         ),
@@ -479,8 +497,10 @@ def _add_create_command(commands: Any) -> None:
     create.add_argument("--account-id", required=True)
     create.add_argument("--action", choices=ACTIONS, required=True)
     create.add_argument("--target-id")
+    create.add_argument("--destination-id")
     create.add_argument("--body-file", type=Path)
-    create.add_argument("--app")
+    create.add_argument("--subject-file", type=Path)
+    create.add_argument("--app", "--profile", dest="app")
     create.add_argument("--username")
     create.add_argument("--scheduled-at", type=int)
     create.add_argument("--operation-id")
@@ -573,10 +593,9 @@ def main() -> int:
         OSError,
         OperationsError,
         ProviderAdapterError,
+        ProviderIdentityError,
         SocialStoreError,
-        XAdapterError,
         sqlite3.Error,
-        subprocess.SubprocessError,
         ValueError,
     ) as error:
         print(f"ERROR: {error}", file=sys.stderr)

--- a/.agents/scripts/knowledge_social_store.py
+++ b/.agents/scripts/knowledge_social_store.py
@@ -18,8 +18,8 @@ from knowledge_corpus_context import (
     validate_private_file,
 )
 
-SCHEMA_VERSION = 3
-SCHEMA_VERSION_SQL = "PRAGMA user_version=3"
+SCHEMA_VERSION = 4
+SCHEMA_VERSION_SQL = "PRAGMA user_version=4"
 OPAQUE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{2,127}$")
 SQLITE_MUTABLE_SIDECARS = ("-journal", "-shm", "-wal")
 
@@ -181,7 +181,10 @@ def _tables() -> tuple[str, ...]:
             operation_id TEXT PRIMARY KEY, provider TEXT NOT NULL,
             connection_id TEXT NOT NULL, remote_account_id TEXT NOT NULL,
             action TEXT NOT NULL CHECK(action IN ('post','reply','like','bookmark')),
-            target_remote_id TEXT, payload TEXT, payload_sha256 TEXT NOT NULL,
+            target_remote_id TEXT, destination_remote_id TEXT,
+            payload TEXT, payload_sha256 TEXT NOT NULL,
+            subject TEXT, subject_sha256 TEXT,
+            intent_version INTEGER NOT NULL DEFAULT 2 CHECK(intent_version IN (1,2)),
             intent_sha256 TEXT NOT NULL UNIQUE, app_profile TEXT, username TEXT,
             scheduled_at INTEGER NOT NULL, state TEXT NOT NULL
                 CHECK(state IN ('draft','approved','claimed','succeeded','failed','unknown','cancelled')),
@@ -268,6 +271,32 @@ def _add_sync_run_v2_columns(connection: sqlite3.Connection) -> None:
         connection.execute("ALTER TABLE sync_runs ADD COLUMN request_hash TEXT")
 
 
+def _add_outbound_v4_columns(connection: sqlite3.Connection) -> None:
+    columns = {
+        str(row["name"])
+        for row in connection.execute("PRAGMA table_info(outbound_operations)").fetchall()
+    }
+    additions = (
+        (
+            "destination_remote_id",
+            "ALTER TABLE outbound_operations ADD COLUMN destination_remote_id TEXT",
+        ),
+        ("subject", "ALTER TABLE outbound_operations ADD COLUMN subject TEXT"),
+        (
+            "subject_sha256",
+            "ALTER TABLE outbound_operations ADD COLUMN subject_sha256 TEXT",
+        ),
+        (
+            "intent_version",
+            "ALTER TABLE outbound_operations ADD COLUMN "
+            "intent_version INTEGER NOT NULL DEFAULT 1",
+        ),
+    )
+    for column, statement in additions:
+        if column not in columns:
+            connection.execute(statement)
+
+
 def migrate(connection: sqlite3.Connection) -> None:
     current = connection.execute("PRAGMA user_version").fetchone()[0]
     if current < 0 or current > SCHEMA_VERSION:
@@ -278,6 +307,8 @@ def migrate(connection: sqlite3.Connection) -> None:
             connection.execute(statement)
         if current < 2:
             _add_sync_run_v2_columns(connection)
+        if current < 4:
+            _add_outbound_v4_columns(connection)
         connection.execute(
             "CREATE INDEX IF NOT EXISTS idx_sync_runs_connection "
             "ON sync_runs(connection_id,stream,run_kind,started_at)"

--- a/.agents/tests/test-knowledge-social-operations.sh
+++ b/.agents/tests/test-knowledge-social-operations.sh
@@ -19,10 +19,14 @@ MIGRATION_BASE="${TMP_DIR}/migration"
 MIGRATION_ROOT="${MIGRATION_BASE}/_knowledge"
 FAKE_BIN="${TMP_DIR}/bin"
 XURL_LOG="${TMP_DIR}/xurl.log"
+REDDIT_LOG="${TMP_DIR}/reddit.log"
 ARCHIVE="${TMP_DIR}/archive.json"
+REDDIT_ARCHIVE="${TMP_DIR}/reddit-archive.json"
 POST_BODY="${TMP_DIR}/post.txt"
 REPLY_BODY="${TMP_DIR}/reply.txt"
 OPTION_BODY="${TMP_DIR}/option.txt"
+REDDIT_POST_BODY="${TMP_DIR}/reddit-post.txt"
+REDDIT_SUBJECT="${TMP_DIR}/reddit-subject.txt"
 PASS=0
 FAIL=0
 
@@ -117,6 +121,19 @@ PY
 	return 0
 }
 
+reddit_log_count() {
+	local needle="$1"
+	python3 - "$REDDIT_LOG" "$needle" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+lines = path.read_text(encoding="utf-8").splitlines() if path.exists() else []
+print(sum(sys.argv[2] in line for line in lines))
+PY
+	return 0
+}
+
 create_and_approve() {
 	local operation_id="$1"
 	local action="$2"
@@ -140,11 +157,34 @@ create_and_approve() {
 	return 0
 }
 
+create_reddit_and_approve() {
+	local operation_id="$1"
+	local action="$2"
+	local target_id="$3"
+	local body_file="$4"
+	local arguments=(
+		operation-create --base "$BASE" --connection-id conn_reddit
+		--account-id acct_reddit_42 --action "$action" --scheduled-at 1000
+		--operation-id "$operation_id" --profile fixture --now-epoch 1000
+	)
+	if [[ "$target_id" != "none" ]]; then
+		arguments+=(--target-id "$target_id")
+	fi
+	if [[ "$body_file" != "none" ]]; then
+		arguments+=(--body-file "$body_file")
+	fi
+	"$HELPER" "${arguments[@]}" >/dev/null
+	"$HELPER" operation-approve --base "$BASE" --operation-id "$operation_id" \
+		--expires-at 2000 --now-epoch 1000 >/dev/null
+	return 0
+}
+
 mkdir -p "$ROOT" "$FAKE_BIN" "$RESTORE_ROOT" "$MIGRATION_ROOT"
 chmod 0700 "$BASE" "$ROOT" "$FAKE_BIN" "$RESTORE_ROOT" \
 	"$MIGRATION_BASE" "$MIGRATION_ROOT"
 : >"$XURL_LOG"
-chmod 0600 "$XURL_LOG"
+: >"$REDDIT_LOG"
+chmod 0600 "$XURL_LOG" "$REDDIT_LOG"
 
 cat >"${FAKE_BIN}/xurl" <<'FAKE'
 #!/usr/bin/env bash
@@ -186,6 +226,118 @@ FAKE
 chmod 0700 "${FAKE_BIN}/xurl"
 export XURL_LOG
 export PATH="${FAKE_BIN}:${PATH}"
+
+cat >"${TMP_DIR}/praw.py" <<'PY'
+import os
+from pathlib import Path
+
+__version__ = "fixture"
+
+
+def log(*values):
+    path = Path(os.environ["REDDIT_LOG"])
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(" ".join(values) + "\n")
+
+
+def maybe_fail():
+    if os.environ.get("REDDIT_MODE") == "write-fail":
+        raise RuntimeError("fixture provider failure")
+
+
+class Identity:
+    @property
+    def id(self):
+        if os.environ.get("REDDIT_MODE") == "identity-mismatch":
+            return "acct_reddit_other"
+        return "acct_reddit_42"
+
+
+class User:
+    def me(self):
+        return Identity()
+
+
+class Thing:
+    def __init__(self, fullname):
+        self.fullname = fullname
+        self.id = fullname.split("_", 1)[1]
+
+    def reply(self, payload):
+        log("reply", self.fullname, payload)
+        maybe_fail()
+        return Thing("t1_created_reply")
+
+    def upvote(self):
+        log("like", self.fullname)
+        maybe_fail()
+
+    def save(self):
+        log("bookmark", self.fullname)
+        maybe_fail()
+
+
+class Subreddit:
+    def __init__(self, name):
+        self.name = name
+
+    def submit(self, subject, selftext):
+        log("post", self.name, subject, selftext)
+        maybe_fail()
+        return Thing("t3_created_post")
+
+
+class Reddit:
+    def __init__(self, **credentials):
+        required = {"client_id", "client_secret", "username", "password", "user_agent"}
+        if set(credentials) != required or any(not value for value in credentials.values()):
+            raise RuntimeError("fixture credentials missing")
+        if "UNRELATED_PROVIDER_TOKEN" in os.environ:
+            raise RuntimeError("unrelated credential reached provider child")
+        self.user = User()
+
+    def subreddit(self, name):
+        return Subreddit(name)
+
+    def comment(self, remote_id):
+        return Thing(f"t1_{remote_id}")
+
+    def submission(self, *, id):
+        return Thing(f"t3_{id}")
+PY
+export PYTHONPATH="${TMP_DIR}:${SCRIPT_DIR}/../scripts"
+export REDDIT_LOG
+export REDDIT_FIXTURE_CLIENT_ID="fixture-client-id"
+export REDDIT_FIXTURE_CLIENT_SECRET="fixture-client-secret"
+export REDDIT_FIXTURE_USERNAME="fixture-user"
+export REDDIT_FIXTURE_PASSWORD="fixture-password"
+export REDDIT_FIXTURE_USER_AGENT="fixture-user-agent"
+export UNRELATED_PROVIDER_TOKEN="fixture-unrelated-token"
+
+AIDEVOPS_TEST_MODE=0 python3 - <<'PY'
+from pathlib import Path
+
+from _knowledge_social_outbound import ClaimedOperation
+from _knowledge_social_outbound_provider import RedditPreparedProvider
+
+claimed = ClaimedOperation(
+    operation_id="op_environment_check",
+    provider="reddit",
+    action="like",
+    remote_account_id="acct_reddit_42",
+    target_remote_id="t3_environment_check",
+    destination_remote_id=None,
+    payload=None,
+    subject=None,
+    app_profile="fixture",
+    username=None,
+    claim_token=1,
+    attempt_id="att_environment_check",
+)
+environment = RedditPreparedProvider(Path("provider-helper"), claimed)._environment()
+if "PYTHONPATH" in environment or "UNRELATED_PROVIDER_TOKEN" in environment:
+    raise SystemExit("production Reddit child environment inherited unrelated values")
+PY
 
 cat >"$ARCHIVE" <<'JSON'
 {
@@ -229,10 +381,30 @@ cat >"$ARCHIVE" <<'JSON'
   "coverage": []
 }
 JSON
+cat >"$REDDIT_ARCHIVE" <<'JSON'
+{
+  "provider": "reddit",
+  "connection_id": "conn_reddit",
+  "remote_account_id": "acct_reddit_42",
+  "exported_at": "2026-07-25T12:00:00Z",
+  "enabled_streams": [],
+  "policy": {},
+  "accounts": [
+    {"remote_id":"acct_reddit_42","observed_at":"2026-07-25T12:00:00Z"}
+  ],
+  "objects": [],
+  "activities": [],
+  "media": [],
+  "coverage": []
+}
+JSON
 printf '%s\n' 'private post fixture marker' >"$POST_BODY"
 printf '%s\n' 'private reply fixture marker' >"$REPLY_BODY"
 printf '%s' '--app' >"$OPTION_BODY"
-chmod 0600 "$ARCHIVE" "$POST_BODY" "$REPLY_BODY" "$OPTION_BODY"
+printf '%s\n' 'private reddit post fixture marker' >"$REDDIT_POST_BODY"
+printf '%s\n' 'Reddit subject fixture' >"$REDDIT_SUBJECT"
+chmod 0600 "$ARCHIVE" "$REDDIT_ARCHIVE" "$POST_BODY" "$REPLY_BODY" \
+	"$OPTION_BODY" "$REDDIT_POST_BODY" "$REDDIT_SUBJECT"
 
 printf 'Approval-bound social operations tests\n'
 "$CORPUS_HELPER" provision --base "$MIGRATION_BASE" >/dev/null
@@ -246,17 +418,21 @@ with sqlite3.connect(sys.argv[1]) as database:
     database.execute("DROP TABLE outbound_attempts")
     database.execute("DROP TABLE outbound_approvals")
     database.execute("DROP TABLE outbound_operations")
-    database.execute("DELETE FROM schema_meta WHERE version=3")
+    database.execute("DELETE FROM schema_meta WHERE version>=3")
     database.execute("PRAGMA user_version=2")
 PY
 "$HELPER" provision --base "$MIGRATION_BASE" >/dev/null
 assert_eq "schema v2 migrates additively to all local operation tables" \
 	"$(sql_value "$MIGRATION_ROOT/index/social.db" "SELECT (SELECT user_version FROM pragma_user_version) || ':' || count(*) FROM sqlite_master WHERE name IN ('outbound_operations','outbound_approvals','outbound_attempts','notification_state')")" \
-	"3:4"
+	"4:4"
+assert_eq "schema v4 adds provider-neutral subject and destination fields" \
+	"$(sql_value "$MIGRATION_ROOT/index/social.db" "SELECT count(*) FROM pragma_table_info('outbound_operations') WHERE name IN ('destination_remote_id','subject','subject_sha256','intent_version')")" \
+	"4"
 
 "$CORPUS_HELPER" provision --base "$BASE" >/dev/null
 "$HELPER" provision --base "$BASE" >/dev/null
 "$HELPER" import-archive --base "$BASE" --archive "$ARCHIVE" >/dev/null
+"$HELPER" import-archive --base "$BASE" --archive "$REDDIT_ARCHIVE" >/dev/null
 
 create_result=$("$HELPER" operation-create --base "$BASE" \
 	--connection-id conn_ops --account-id acct42 --action post \
@@ -351,6 +527,77 @@ status_result=$(XURL_MODE=status-error "$HELPER" operation-run --base "$BASE" \
 assert_eq "provider error JSON cannot masquerade as engagement success" \
 	"$(json_field "$status_result" state)" "unknown"
 
+reddit_create=$(
+	"$HELPER" operation-create --base "$BASE" --connection-id conn_reddit \
+		--account-id acct_reddit_42 --action post --body-file "$REDDIT_POST_BODY" \
+		--subject-file "$REDDIT_SUBJECT" --destination-id aidevops \
+		--profile fixture --scheduled-at 1000 --operation-id op_reddit_post \
+		--now-epoch 1000
+)
+assert_eq "Reddit connection selects the provider without a provider CLI argument" \
+	"$(json_field "$reddit_create" provider)" "reddit"
+assert_absent "Reddit draft receipts omit private post text" \
+	"$reddit_create" "private reddit post fixture marker"
+"$HELPER" operation-approve --base "$BASE" --operation-id op_reddit_post \
+	--expires-at 2000 --now-epoch 1000 >/dev/null
+reddit_post_result=$(
+	"$HELPER" operation-run --base "$BASE" --operation-id op_reddit_post \
+		--executor-id exe_reddit_post --now-epoch 1200
+)
+assert_eq "approved Reddit posts return a stable fullname receipt" \
+	"$(json_field "$reddit_post_result" provider_remote_id)" "t3_created_post"
+assert_eq "Reddit post mapping binds destination, subject, and private body" \
+	"$(reddit_log_count 'post aidevops Reddit subject fixture private reddit post fixture marker')" "1"
+assert_eq "Reddit provider fields use the versioned immutable intent" \
+	"$(sql_value "$ROOT/index/social.db" "SELECT provider || ':' || intent_version || ':' || destination_remote_id FROM outbound_operations WHERE operation_id='op_reddit_post'")" \
+	"reddit:2:aidevops"
+
+expect_failure "Reddit operations require an explicit named auth profile" \
+	"named auth profile" "$HELPER" operation-create --base "$BASE" \
+	--connection-id conn_reddit --account-id acct_reddit_42 --action like \
+	--target-id t3_missing_profile --operation-id op_reddit_no_profile \
+	--now-epoch 1000
+expect_failure "Reddit targets reject non-fullname identifiers" \
+	"t1_ or t3_ fullname" "$HELPER" operation-create --base "$BASE" \
+	--connection-id conn_reddit --account-id acct_reddit_42 --action like \
+	--target-id post_plain_id --profile fixture \
+	--operation-id op_reddit_bad_target --now-epoch 1000
+
+create_reddit_and_approve op_reddit_reply reply t1_comment001 "$REPLY_BODY"
+create_reddit_and_approve op_reddit_like like t3_submission001 none
+create_reddit_and_approve op_reddit_bookmark bookmark t1_comment002 none
+reddit_due_result=$(
+	"$HELPER" operations-run-due --base "$BASE" --executor-id exe_reddit_due \
+		--limit 10 --now-epoch 1200
+)
+assert_eq "Reddit reply, upvote, and save share the approval queue" \
+	"$(python3 -c 'import json,sys; print(len(json.loads(sys.argv[1])["results"]))' "$reddit_due_result")" "3"
+assert_eq "Reddit reply maps to a comment fullname" \
+	"$(reddit_log_count 'reply t1_comment001 private reply fixture marker')" "1"
+assert_eq "Reddit like maps to one upvote" \
+	"$(reddit_log_count 'like t3_submission001')" "1"
+assert_eq "Reddit bookmark maps to one save" \
+	"$(reddit_log_count 'bookmark t1_comment002')" "1"
+
+create_reddit_and_approve op_reddit_identity like t3_submission002 none
+reddit_identity_result=$(REDDIT_MODE=identity-mismatch "$HELPER" operation-run \
+	--base "$BASE" --operation-id op_reddit_identity \
+	--executor-id exe_reddit_identity --now-epoch 1200)
+assert_eq "Reddit identity mismatch fails before the provider boundary" \
+	"$(json_field "$reddit_identity_result" state):$(json_field "$reddit_identity_result" failure_class)" \
+	"failed:identity"
+assert_eq "Reddit identity mismatch performs no upvote" \
+	"$(reddit_log_count 'like t3_submission002')" "0"
+
+create_reddit_and_approve op_reddit_unknown bookmark t3_submission003 none
+reddit_unknown_result=$(REDDIT_MODE=write-fail "$HELPER" operation-run \
+	--base "$BASE" --operation-id op_reddit_unknown \
+	--executor-id exe_reddit_unknown --now-epoch 1200)
+assert_eq "Reddit write failures after the boundary remain unknown" \
+	"$(json_field "$reddit_unknown_result" state)" "unknown"
+assert_eq "ambiguous Reddit writes execute at most once" \
+	"$(reddit_log_count 'bookmark t3_submission003')" "1"
+
 create_and_approve op_cancel_001 bookmark post_target_006 none
 "$HELPER" operation-revoke --base "$BASE" --operation-id op_cancel_001 \
 	--now-epoch 1100 >/dev/null
@@ -370,6 +617,7 @@ from pathlib import Path
 
 from _knowledge_social_outbound import (
     OperationIntent,
+    _intent_sha256,
     approve_operation,
     create_operation,
 )
@@ -424,9 +672,14 @@ def intent(
 
 tampering = (
     ("payload", "changed body"),
+    ("provider", "reddit"),
     ("connection_id", "conn_other"),
     ("remote_account_id", "acct_other"),
     ("target_remote_id", "post_changed_001"),
+    ("destination_remote_id", "changed_destination"),
+    ("subject", "changed subject"),
+    ("subject_sha256", "0" * 64),
+    ("intent_version", 1),
     ("app_profile", "changed-profile"),
     ("username", "changed-user"),
     ("scheduled_at", 999),
@@ -461,6 +714,33 @@ database.execute("UPDATE outbound_operations SET action='bookmark' WHERE operati
 rejected(lambda: due_operation_ids(database, principal, 1200, 100))
 database.execute(
     "UPDATE outbound_operations SET state='cancelled' WHERE operation_id='op_tamper_action'"
+)
+
+create_operation(
+    database,
+    intent("op_legacy_intent", "post_legacy_intent"),
+)
+legacy = dict(
+    database.execute(
+        "SELECT * FROM outbound_operations WHERE operation_id='op_legacy_intent'"
+    ).fetchone()
+)
+legacy["intent_version"] = 1
+legacy["destination_remote_id"] = None
+legacy["subject"] = None
+legacy["subject_sha256"] = None
+legacy_hash = _intent_sha256(legacy)
+database.execute(
+    """UPDATE outbound_operations
+          SET intent_version=1,destination_remote_id=NULL,subject=NULL,
+              subject_sha256=NULL,intent_sha256=?
+        WHERE operation_id='op_legacy_intent'""",
+    (legacy_hash,),
+)
+approve_operation(database, "op_legacy_intent", principal, 2000, approved_at=1000)
+assert "op_legacy_intent" in due_operation_ids(database, principal, 1200, 100)
+database.execute(
+    "UPDATE outbound_operations SET state='cancelled' WHERE operation_id='op_legacy_intent'"
 )
 
 create_operation(

--- a/.agents/tests/test-knowledge-social-operations.sh
+++ b/.agents/tests/test-knowledge-social-operations.sh
@@ -27,6 +27,7 @@ REPLY_BODY="${TMP_DIR}/reply.txt"
 OPTION_BODY="${TMP_DIR}/option.txt"
 REDDIT_POST_BODY="${TMP_DIR}/reddit-post.txt"
 REDDIT_SUBJECT="${TMP_DIR}/reddit-subject.txt"
+REDDIT_LONG_SUBJECT="${TMP_DIR}/reddit-long-subject.txt"
 PASS=0
 FAIL=0
 
@@ -403,8 +404,14 @@ printf '%s\n' 'private reply fixture marker' >"$REPLY_BODY"
 printf '%s' '--app' >"$OPTION_BODY"
 printf '%s\n' 'private reddit post fixture marker' >"$REDDIT_POST_BODY"
 printf '%s\n' 'Reddit subject fixture' >"$REDDIT_SUBJECT"
+python3 - "$REDDIT_LONG_SUBJECT" <<'PY'
+import sys
+from pathlib import Path
+
+Path(sys.argv[1]).write_text("x" * 301, encoding="utf-8")
+PY
 chmod 0600 "$ARCHIVE" "$REDDIT_ARCHIVE" "$POST_BODY" "$REPLY_BODY" \
-	"$OPTION_BODY" "$REDDIT_POST_BODY" "$REDDIT_SUBJECT"
+	"$OPTION_BODY" "$REDDIT_POST_BODY" "$REDDIT_SUBJECT" "$REDDIT_LONG_SUBJECT"
 
 printf 'Approval-bound social operations tests\n'
 "$CORPUS_HELPER" provision --base "$MIGRATION_BASE" >/dev/null
@@ -552,6 +559,12 @@ assert_eq "Reddit provider fields use the versioned immutable intent" \
 	"$(sql_value "$ROOT/index/social.db" "SELECT provider || ':' || intent_version || ':' || destination_remote_id FROM outbound_operations WHERE operation_id='op_reddit_post'")" \
 	"reddit:2:aidevops"
 
+expect_failure "Reddit post titles reject more than 300 characters" \
+	"300-character title limit" "$HELPER" operation-create --base "$BASE" \
+	--connection-id conn_reddit --account-id acct_reddit_42 --action post \
+	--body-file "$REDDIT_POST_BODY" --subject-file "$REDDIT_LONG_SUBJECT" \
+	--destination-id aidevops --profile fixture \
+	--operation-id op_reddit_long_subject --now-epoch 1000
 expect_failure "Reddit operations require an explicit named auth profile" \
 	"named auth profile" "$HELPER" operation-create --base "$BASE" \
 	--connection-id conn_reddit --account-id acct_reddit_42 --action like \

--- a/.agents/tests/test-knowledge-social-sync.sh
+++ b/.agents/tests/test-knowledge-social-sync.sh
@@ -64,7 +64,7 @@ chmod 0700 "$BASE" "$ROOT"
 "$HELPER" provision --base "$BASE" --alias personal:default >/dev/null
 
 printf 'Social sync routine tests\n'
-assert_eq "current schema is active" "$(sql_value 'PRAGMA user_version')" "3"
+assert_eq "current schema is active" "$(sql_value 'PRAGMA user_version')" "4"
 assert_eq "lease and reconciliation tables are provisioned" \
 	"$(sql_value "SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ('collector_lease_generations','collector_leases','reconciliation_items')")" \
 	"3"
@@ -474,7 +474,7 @@ from knowledge_social_store import connect, migrate
 database = connect(root)
 migrate(database)
 columns = {row[1] for row in database.execute("PRAGMA table_info(sync_runs)")}
-if database.execute("PRAGMA user_version").fetchone()[0] != 3:
+if database.execute("PRAGMA user_version").fetchone()[0] != 4:
     raise SystemExit("v1 database did not migrate to the current schema")
 required = {
     "stream",
@@ -498,7 +498,7 @@ print(connection.execute("PRAGMA user_version").fetchone()[0])
 connection.close()
 PY
 )
-assert_eq "existing v1 stores migrate without replacement" "$migration_version" "3"
+assert_eq "existing v1 stores migrate without replacement" "$migration_version" "4"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/.agents/tests/test-knowledge-social.sh
+++ b/.agents/tests/test-knowledge-social.sh
@@ -94,7 +94,7 @@ mkdir -p "$CORPUS_ROOT"
 chmod 0700 "$BASE" "$CORPUS_ROOT"
 "$CORPUS_HELPER" provision --base "$BASE" >/dev/null
 "$HELPER" provision --base "$BASE" --alias personal:default >/dev/null
-assert_eq "schema is versioned" "$(sql_value 'PRAGMA user_version')" "3"
+assert_eq "schema is versioned" "$(sql_value 'PRAGMA user_version')" "4"
 assert_eq "all provider-neutral and local-operation tables exist" "$(sql_value "SELECT count(*) FROM sqlite_master WHERE name IN ('connections','accounts','objects','activities','media','fetch_batches','sync_cursors','sync_runs','tombstones','annotations','coverage_records','objects_fts','outbound_operations','outbound_approvals','outbound_attempts','notification_state')")" "16"
 
 first_result=$("$HELPER" import-archive --base "$BASE" --alias personal:default --archive "$ARCHIVE")
@@ -219,7 +219,7 @@ python3 - "$CORPUS_ROOT/index/social.db" <<'PY'
 import sqlite3
 import sys
 connection = sqlite3.connect(sys.argv[1])
-connection.execute("PRAGMA user_version=3")
+connection.execute("PRAGMA user_version=4")
 connection.close()
 PY
 

--- a/README.md
+++ b/README.md
@@ -688,7 +688,7 @@ See `.agents/tools/terminal/terminal-title.md` for customization options.
 
 - **SimpleX bot** - Channel-agnostic gateway with SimpleX Chat as first adapter for AI agent dispatch (`simplex-bot/`)
 - **Matterbridge** - Multi-platform chat bridge connecting 20+ platforms including Matrix, Discord, Telegram, Slack, IRC, WhatsApp, XMPP (`matterbridge-helper.sh`)
-- **X API via xurl** - Official X/Twitter API operations through guarded `xurl` workflows for search, timelines, bookmarks, posting, replies, DMs, media, and raw API reads, plus an owner-only approval-bound queue for immediate/scheduled shared-account posts, replies, likes, bookmarks, receipts, and mention/reply workflow state. Supports multiple X developer apps/subscription tiers with `--app` and multiple authenticated accounts with `--username`; model-provider auth such as OpenCode xAI/Grok remains separate from X API OAuth (`content/social-xurl.md`, `knowledge-social-helper.sh`, `xurl-helper.sh`)
+- **Approval-bound social operations** - Owner-only immediate/scheduled posts, replies, likes/upvotes, bookmarks/saves, receipts, reconciliation, and mention/reply workflow state through a fixed provider registry. X uses the guarded official `xurl` CLI with multiple apps/accounts; Reddit uses named PRAW profiles with stable-account verification and separately protected post subjects/destinations. Model-provider auth such as OpenCode xAI/Grok remains separate from social API OAuth (`content/social-xurl.md`, `content/social-reddit.md`, `knowledge-social-helper.sh`)
 - **Localdev** - Local development environment manager with dnsmasq, Traefik, mkcert for production-like `.local` domains with HTTPS (`localdev-helper.sh`)
 
 **MCP Toolkit:**


### PR DESCRIPTION
## Summary

Add a fixed Reddit provider adapter to the owner-only approval queue; version immutable intents for provider-neutral destination and subject fields; preserve X and legacy intent behavior; isolate named-profile credentials in a bounded PRAW child.

## Files Changed

.agents/aidevops/knowledge-plane/05-social-operations.md, .agents/content/social-reddit.md, .agents/scripts/_knowledge_social_outbound.py, .agents/scripts/_knowledge_social_outbound_provider.py, .agents/scripts/_knowledge_social_outbound_runtime.py, .agents/scripts/_knowledge_social_reddit_provider.py, .agents/scripts/knowledge_social_operations.py, .agents/scripts/knowledge_social_store.py, .agents/tests/test-knowledge-social-operations.sh, .agents/tests/test-knowledge-social-sync.sh, .agents/tests/test-knowledge-social.sh, README.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified with all seven social suites (263 passing assertions), fake-PRAW subprocess coverage for identity, post, reply, upvote, save, environment isolation and ambiguous outcomes, focused ShellCheck/Python compilation, pulse canary, and linters-local.sh --full.

Resolves #28656


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.181 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 1d 14h and 12,840,793 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added approval-bound social operations for Reddit, including posts, replies, likes, upvotes, bookmarks, and saves.
  * Added support for scheduled or immediately due operations with destination and subject details.
  * Added stable account verification before execution and privacy-safe receipts and failure handling.
  * Added provider-neutral support for X and Reddit through fixed, approved integrations.

* **Documentation**
  * Updated setup guidance for Reddit OAuth profiles, credential handling, approval workflows, and execution safeguards.
  * Updated capability documentation to describe supported social operations and provider behavior.

* **Bug Fixes**
  * Improved protection against identity mismatches, tampered operation details, duplicate execution, and ambiguous provider failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->