### PR TITLE
GH#28654: Attribute remaining Pulse quota operations

### DIFF
--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -550,21 +550,25 @@ _dep_labels_has_active_status() {
 _dep_validate_issue_target() {
 	local slug="$1"
 	local issue_num="$2"
-	local repository_id="" issue_json="" resolved_num="" issue_id=""
+	local repository_id="" resolved_num="" issue_id=""
 	[[ "$slug" =~ ^[^/[:space:]]+/[^/[:space:]]+$ && "$issue_num" =~ ^[1-9][0-9]*$ ]] || return 1
 	if [[ "$_DEP_CACHED_REPO_SLUG" == "$slug" && -n "$_DEP_CACHED_REPO_ID" ]]; then
 		repository_id="$_DEP_CACHED_REPO_ID"
 	else
-		repository_id=$(gh api "repos/${slug}" --jq '.node_id // ""' || true)
+		repository_id=$(AIDEVOPS_GH_QUOTA_COST=1 \
+			AIDEVOPS_GH_ROUTE_DECISION="pulse-dep-repository-identity-rest" \
+			gh api "repos/${slug}" --jq '.node_id // ""' || true)
 		if [[ -n "$repository_id" ]]; then
 			_DEP_CACHED_REPO_SLUG="$slug"
 			_DEP_CACHED_REPO_ID="$repository_id"
 		fi
 	fi
 	[[ -n "$repository_id" ]] || return 1
-	issue_json=$(gh issue view "$issue_num" --repo "$slug" --json id,number 2>/dev/null || true)
 	IFS=$'\t' read -r resolved_num issue_id < <(
-		printf '%s' "$issue_json" | jq -r '[.number // "", .id // ""] | @tsv'
+		AIDEVOPS_GH_QUOTA_COST=1 \
+			AIDEVOPS_GH_ROUTE_DECISION="pulse-dep-issue-identity-rest" \
+			gh api "repos/${slug}/issues/${issue_num}" \
+				--jq '[.number // "", .node_id // ""] | @tsv' 2>/dev/null || true
 	)
 	[[ "$resolved_num" == "$issue_num" && -n "$issue_id" ]]
 	return $?
@@ -947,9 +951,11 @@ _blocked_by_check_native_relationships() {
 	repo_name="${repo_slug#*/}"
 	[[ -n "$owner" && -n "$repo_name" ]] || return 1
 
-	local rel_states=""
+	local response="" reported_cost="" rel_states=""
 	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub, not shell.
-	if ! rel_states=$(gh api graphql \
+	if ! response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="pulse-blocked-by-exact-cost" \
+		gh api graphql \
 		-f query='
 query($owner:String!,$name:String!,$number:Int!) {
   repository(owner:$owner, name:$name) {
@@ -960,13 +966,26 @@ query($owner:String!,$name:String!,$number:Int!) {
       }
     }
   }
+	rateLimit { cost }
 }' \
 		-F owner="$owner" -F name="$repo_name" -F number="$issue_number" \
-		--jq '.data.repository.issue.blockedBy as $b | (if $b.pageInfo.hasNextPage then "__TRUNCATED__:UNKNOWN" else empty end), ($b.nodes[]? | "\(.number):\(.state)")' \
 		2>/dev/null); then
 		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} native blockedBy lookup unavailable — checking body fallback (GH#24576)" >>"$LOGFILE"
 		return 3
 	fi
+	reported_cost=$(printf '%s' "$response" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
+	if [[ ! "$reported_cost" =~ ^[1-9][0-9]*$ ]]; then
+		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} native blockedBy cost unavailable — checking body fallback (GH#27777)" >>"$LOGFILE"
+		return 3
+	fi
+	rel_states=$(printf '%s' "$response" | jq -r '
+		.data.repository.issue.blockedBy as $b
+		| (if $b.pageInfo.hasNextPage then "__TRUNCATED__:UNKNOWN" else empty end),
+		  ($b.nodes[]? | "\(.number):\(.state)")
+	' 2>/dev/null) || {
+		echo "[pulse-wrapper] is_blocked_by_unresolved: #${issue_number} native blockedBy response invalid — checking body fallback (GH#24576)" >>"$LOGFILE"
+		return 3
+	}
 
 	local rel_state="" rel_num="" state="" saw_relationship="${DEP_FALSE}"
 	while IFS= read -r rel_state; do

--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -146,6 +146,100 @@ _trusted_dependabot_dependency_allowed() {
 }
 
 #######################################
+# Fetch the fixed trusted-Dependabot trust snapshot with operation-owned cost.
+# Native `gh pr view` hides its GraphQL cost. This query includes rateLimit in
+# the same response, rejects partial connections, and projects the established
+# gh JSON contract consumed by the trust-boundary checks below.
+# Args: $1=pr_number, $2=repo_slug
+# Output: projected PR JSON
+# Returns: 0=complete exact-cost snapshot, 1=API/parse/pagination failure
+#######################################
+_trusted_dependabot_pr_json_graphql() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local owner="${repo_slug%%/*}"
+	local name="${repo_slug##*/}"
+	local response="" reported_cost="" pr_json=""
+
+	[[ "$pr_number" =~ ^[0-9]+$ && -n "$owner" && -n "$name" ]] || return 1
+	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub.
+	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="pulse-trusted-dependabot-exact-cost" \
+		gh api graphql -F owner="$owner" -F name="$name" -F pr="$pr_number" -f query='
+		query($owner: String!, $name: String!, $pr: Int!) {
+			repository(owner: $owner, name: $name) {
+				pullRequest(number: $pr) {
+					author { login }
+					body
+					headRepository { nameWithOwner }
+					headRepositoryOwner { login }
+					commits(first: 100) {
+						pageInfo { hasNextPage }
+						nodes {
+							commit {
+								authors(first: 100) {
+									pageInfo { hasNextPage }
+									nodes { user { login } }
+								}
+							}
+						}
+					}
+					files(first: 100) { pageInfo { hasNextPage } nodes { path } }
+					statusCheckRollup {
+						contexts(first: 100) {
+							pageInfo { hasNextPage }
+							nodes {
+								__typename
+								... on CheckRun {
+									name
+									conclusion
+									status
+									checkSuite { workflowRun { workflow { name } } }
+								}
+								... on StatusContext { context state }
+							}
+						}
+					}
+				}
+			}
+			rateLimit { cost }
+		}' 2>/dev/null) || return 1
+	reported_cost=$(printf '%s' "$response" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || return 1
+	[[ "$reported_cost" =~ ^[1-9][0-9]*$ ]] || return 1
+	pr_json=$(printf '%s' "$response" | jq -c '
+		.data.repository.pullRequest as $pr
+		| if $pr == null then error("pull request unavailable")
+		  elif (($pr.commits.pageInfo.hasNextPage // false)
+			or ($pr.files.pageInfo.hasNextPage // false)
+			or ($pr.statusCheckRollup.contexts.pageInfo.hasNextPage // false)
+			or ([$pr.commits.nodes[]?.commit.authors.pageInfo.hasNextPage // false] | any))
+		  then error("trusted Dependabot snapshot is paginated")
+		  else {
+			author: $pr.author,
+			body: ($pr.body // ""),
+			headRepository: $pr.headRepository,
+			headRepositoryOwner: $pr.headRepositoryOwner,
+			commits: [$pr.commits.nodes[]? | {
+				authors: [.commit.authors.nodes[]? | {login: (.user.login // "")}]
+			}],
+			files: [$pr.files.nodes[]? | {path}],
+			statusCheckRollup: [$pr.statusCheckRollup.contexts.nodes[]?
+				| if .__typename == "CheckRun" then {
+					name,
+					conclusion,
+					status,
+					workflowName: .checkSuite.workflowRun.workflow.name
+				  }
+				  elif .__typename == "StatusContext" then {context, state}
+				  else empty end]
+		  } end
+	' 2>/dev/null) || return 1
+	[[ -n "$pr_json" ]] || return 1
+	printf '%s\n' "$pr_json"
+	return 0
+}
+
+#######################################
 # Verify a Dependabot PR is an authentic, maintainer-allowed version update.
 #
 # This is intentionally narrow: it only grants the collaborator/review-bot
@@ -175,9 +269,7 @@ _is_trusted_dependabot_update_pr() {
 	esac
 
 	local pr_json
-	pr_json=$(gh pr view "$pr_number" --repo "$repo_slug" \
-		--json author,body,commits,files,headRepository,headRepositoryOwner,statusCheckRollup \
-		2>/dev/null) || return 1
+	pr_json=$(_trusted_dependabot_pr_json_graphql "$pr_number" "$repo_slug") || return 1
 	[[ -n "$pr_json" && "$pr_json" != "null" ]] || return 1
 
 	local repo_owner="${repo_slug%%/*}"
@@ -241,7 +333,7 @@ _trusted_dependabot_non_review_checks_green() {
 
 	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 1
 	if [[ -z "$pr_json" ]]; then
-		pr_json=$(gh pr view "$pr_number" --repo "$repo_slug" --json statusCheckRollup 2>/dev/null) || return 1
+		pr_json=$(_trusted_dependabot_pr_json_graphql "$pr_number" "$repo_slug") || return 1
 	fi
 	[[ -n "$pr_json" && "$pr_json" != "null" ]] || return 1
 

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -229,7 +229,9 @@ _pmrc_review_thread_resolution_required() {
 	[[ -n "$repo_slug" && -n "$base_branch" ]] || return 1
 	encoded_branch=$(jq -nr --arg branch "$base_branch" '$branch | @uri') || return 1
 	[[ -n "$encoded_branch" ]] || return 1
-	rules_json=$(_pmrc_gh_read gh api "repos/${repo_slug}/rules/branches/${encoded_branch}" 2>/dev/null) || {
+	rules_json=$(AIDEVOPS_GH_QUOTA_COST=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="pulse-effective-rules-rest" \
+		_pmrc_gh_read gh api "repos/${repo_slug}/rules/branches/${encoded_branch}" 2>/dev/null) || {
 		echo "[pulse-merge] pre-merge snapshot: effective rules fetch failed for ${repo_slug} branch ${base_branch} — failing closed (GH#28130)" >>"$log_target"
 		return 1
 	}

--- a/.agents/scripts/pulse-simplification-scan.sh
+++ b/.agents/scripts/pulse-simplification-scan.sh
@@ -111,6 +111,27 @@ _complexity_scan_tree_changed() {
 	return 0
 }
 
+# Run a fixed GraphQL scalar query with operation-owned response cost.
+# Arguments: $1 - route decision, $2 - query, $3 - jq scalar filter
+# Output: non-negative integer scalar
+_complexity_graphql_scalar_exact() {
+	local route_decision="$1"
+	local query="$2"
+	local jq_filter="$3"
+	local response="" reported_cost="" value=""
+
+	[[ "$route_decision" == pulse-complexity-*-exact-cost ]] || return 1
+	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="$route_decision" \
+		gh api graphql -f query="$query" 2>/dev/null) || return 1
+	reported_cost=$(printf '%s' "$response" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || return 1
+	[[ "$reported_cost" =~ ^[1-9][0-9]*$ ]] || return 1
+	value=$(printf '%s' "$response" | jq -r "$jq_filter" 2>/dev/null) || return 1
+	[[ "$value" =~ ^[0-9]+$ ]] || return 1
+	printf '%s\n' "$value"
+	return 0
+}
+
 # Count recently closed function-complexity-debt issues for throughput-aware stall checks.
 # Arguments: $1 - now_epoch, $2 - aidevops_slug, $3 - window_seconds
 # Outputs: integer closure count
@@ -130,9 +151,10 @@ _complexity_recent_debt_closures() {
 		return 0
 	fi
 
-	recent_closures=$(gh api graphql \
-		-f query="query { search(query:\"repo:${aidevops_slug} label:function-complexity-debt is:issue is:closed closed:>${since_date}\", type:ISSUE) { issueCount } }" \
-		--jq '.data.search.issueCount' 2>/dev/null) || recent_closures="0"
+	recent_closures=$(_complexity_graphql_scalar_exact \
+		"pulse-complexity-closures-exact-cost" \
+		"query { search(query:\"repo:${aidevops_slug} label:function-complexity-debt is:issue is:closed closed:>${since_date}\", type:ISSUE) { issueCount } rateLimit { cost } }" \
+		'.data.search.issueCount') || recent_closures="0"
 	[[ "$recent_closures" =~ ^[0-9]+$ ]] || recent_closures="0"
 	printf '%s\n' "$recent_closures"
 	return 0
@@ -162,10 +184,11 @@ _complexity_llm_sweep_due() {
 	fi
 
 	# Fetch current open debt count
-	local current_count
-	current_count=$(gh api graphql \
-		-f query="query { repository(owner:\"${aidevops_slug%%/*}\", name:\"${aidevops_slug##*/}\") { issues(labels:[\"function-complexity-debt\"], states:OPEN) { totalCount } } }" \
-		--jq '.data.repository.issues.totalCount' 2>/dev/null) || current_count=""
+	local current_count=""
+	current_count=$(_complexity_graphql_scalar_exact \
+		"pulse-complexity-open-count-exact-cost" \
+		"query { repository(owner:\"${aidevops_slug%%/*}\", name:\"${aidevops_slug##*/}\") { issues(labels:[\"function-complexity-debt\"], states:OPEN) { totalCount } } rateLimit { cost } }" \
+		'.data.repository.issues.totalCount') || current_count=""
 	[[ "$current_count" =~ ^[0-9]+$ ]] || return 1
 
 	# Compare against last recorded count
@@ -507,9 +530,11 @@ _complexity_scan_check_open_cap() {
 	local cap="${2:-200}"
 	local log_prefix="${3:-Complexity scan}"
 
-	local total_open
-	total_open=$(gh api graphql -f query="query { repository(owner:\"${aidevops_slug%%/*}\", name:\"${aidevops_slug##*/}\") { issues(labels:[\"function-complexity-debt\"], states:OPEN) { totalCount } } }" \
-		--jq '.data.repository.issues.totalCount' 2>/dev/null) || total_open="0"
+	local total_open=""
+	total_open=$(_complexity_graphql_scalar_exact \
+		"pulse-complexity-cap-exact-cost" \
+		"query { repository(owner:\"${aidevops_slug%%/*}\", name:\"${aidevops_slug##*/}\") { issues(labels:[\"function-complexity-debt\"], states:OPEN) { totalCount } } rateLimit { cost } }" \
+		'.data.repository.issues.totalCount') || total_open="0"
 	if [[ "${total_open:-0}" -ge "$cap" ]]; then
 		echo "[pulse-wrapper] ${log_prefix}: skipping — ${total_open} open function-complexity-debt issues (cap: ${cap})" >>"$LOGFILE"
 		return 1

--- a/.agents/scripts/shared-gh-collaborator-permission.sh
+++ b/.agents/scripts/shared-gh-collaborator-permission.sh
@@ -49,7 +49,9 @@ _gh_collaborator_permission_lookup() {
 		return 2
 	fi
 
-	api_response=$(_rest_api_call read gh api -i "$perm_url" 2>&1)
+	api_response=$(AIDEVOPS_GH_QUOTA_COST=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="collaborator-permission-rest" \
+		_rest_api_call read gh api -i "$perm_url" 2>&1)
 	rc=$?
 	while IFS= read -r line; do
 		line="${line%$'\r'}"

--- a/.agents/scripts/tests/test-gh-current-user-write-guard.sh
+++ b/.agents/scripts/tests/test-gh-current-user-write-guard.sh
@@ -11,6 +11,8 @@ PARENT_DIR="${SCRIPT_DIR}/.."
 TESTS_RUN=0
 TESTS_FAILED=0
 CURRENT_LOGIN="owner"
+ATTRIBUTION_LOG=$(mktemp)
+trap 'rm -f "$ATTRIBUTION_LOG"' EXIT
 
 print_result() {
 	local name="$1"
@@ -42,6 +44,8 @@ _rest_api_call() {
 	local api_subcommand="${2:-}"
 	local flag="${3:-}"
 	local path="${4:-}"
+	printf '%s|%s\n' "${AIDEVOPS_GH_QUOTA_COST:-}" \
+		"${AIDEVOPS_GH_ROUTE_DECISION:-}" >>"$ATTRIBUTION_LOG"
 	[[ "$class_name" == "read" && "$command_name" == "gh" && "$api_subcommand" == "api" && "$flag" == "-i" ]] || return 1
 	if [[ "$path" == */collaborators/owner/permission ]]; then
 		printf 'HTTP/2.0 200 OK\n\n{"permission":"write"}\n'
@@ -69,6 +73,19 @@ if _gh_current_user_allows_repo_write "example/repo"; then
 	print_result "rotated outsider token is not allowed after owner token" 1
 else
 	print_result "rotated outsider token is not allowed after owner token" 0
+fi
+
+CURRENT_LOGIN="missing"
+if _gh_current_user_allows_repo_write "example/repo"; then
+	print_result "missing collaborator remains denied on HTTP 404" 1
+else
+	print_result "missing collaborator remains denied on HTTP 404" 0
+fi
+
+if grep -qF '1|collaborator-permission-rest' "$ATTRIBUTION_LOG"; then
+	print_result "collaborator permission lookup declares exact REST cost" 0
+else
+	print_result "collaborator permission lookup declares exact REST cost" 1
 fi
 
 printf '%d test(s), %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-pulse-dep-graph-stale-label-cleanup.sh
+++ b/.agents/scripts/tests/test-pulse-dep-graph-stale-label-cleanup.sh
@@ -62,9 +62,23 @@ teardown_test() {
 gh() {
 	local top_command="${1:-}"
 	shift || true
+	if [[ "$top_command" == "api" ]]; then
+		printf 'api|%s|%s|%s|%s\n' \
+			"${AIDEVOPS_GH_QUOTA_COST:-}" \
+			"${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" \
+			"${AIDEVOPS_GH_ROUTE_DECISION:-}" "$*" >>"$GH_LOG"
+	fi
+	if [[ "$top_command" == "api" && "${1:-}" == "graphql" ]]; then
+		printf '%s\n' '{"data":{"repository":{"issue":{"blockedBy":{"nodes":[{"number":2,"state":"CLOSED"}],"pageInfo":{"hasNextPage":false}}}},"rateLimit":{"cost":1}}}'
+		return 0
+	fi
 	if [[ "$top_command" == "api" && "${1:-}" == "repos/example/repo" ]]; then
-		printf 'api %s\n' "$*" >>"$GH_LOG"
 		printf '%s\n' R_example
+		return 0
+	fi
+	if [[ "$top_command" == "api" && "${1:-}" == repos/example/repo/issues/* ]]; then
+		local issue_num="${1##*/}"
+		printf '%s\tI_%s\n' "$issue_num" "$issue_num"
 		return 0
 	fi
 	if [[ "$top_command" == "issue" ]]; then
@@ -74,10 +88,6 @@ gh() {
 		view)
 			local issue_num="${1:-}"
 			shift || true
-			if [[ "$*" == *"--json id,number"* ]]; then
-				printf '{"id":"I_%s","number":%s}\n' "$issue_num" "$issue_num"
-				return 0
-			fi
 			if [[ "$*" == *"--json labels"* ]]; then
 				printf '%s\n' "$GH_LABELS_CSV"
 				return 0
@@ -116,9 +126,29 @@ test_repository_identity_is_cached() {
 	_dep_validate_issue_target "example/repo" "3"
 	_dep_validate_issue_target "example/repo" "4"
 	while IFS= read -r line; do
-		[[ "$line" == api\ * ]] && api_calls=$((api_calls + 1))
+		if [[ "$line" == *'|repos/example/repo --jq .node_id // ""' ]]; then
+			api_calls=$((api_calls + 1))
+		fi
 	done <"$GH_LOG"
 	[[ "$api_calls" -eq 1 ]] && print_result "repository identity is cached" 0 || print_result "repository identity is cached" 1 "expected 1 API call; got ${api_calls}"
+	assert_log_contains "issue identity uses exact-cost REST" "$GH_LOG" \
+		"api|1||pulse-dep-issue-identity-rest|repos/example/repo/issues/3"
+	assert_log_not_contains "issue identity avoids native GraphQL view" "$GH_LOG" \
+		"--json id,number"
+	return 0
+}
+
+test_native_relationships_use_response_cost() {
+	local rc=0
+	reset_logs
+	_blocked_by_check_native_relationships "example/repo" "3" || rc=$?
+	if [[ "$rc" -eq 2 ]]; then
+		print_result "closed native relationship resolves positively" 0
+	else
+		print_result "closed native relationship resolves positively" 1 "expected rc=2; got ${rc}"
+	fi
+	assert_log_contains "native relationship query reports response-owned cost" "$GH_LOG" \
+		"api||1|pulse-blocked-by-exact-cost|graphql"
 	return 0
 }
 
@@ -222,6 +252,7 @@ source "$DEP_GRAPH"
 test_label_only_blocker_enters_graph
 test_unvalidated_repository_fails_closed
 test_repository_identity_is_cached
+test_native_relationships_use_response_cost
 test_available_issue_stale_label_removed
 test_blocked_issue_label_removed_and_status_available
 test_defer_marker_preserves_label

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -23,7 +23,9 @@ RERUN_CALLS=0
 TESTS_RUN=0
 TESTS_FAILED=0
 EVIDENCE_LOG="${TEST_ROOT}/efficiency-evidence.log"
+RULES_ATTRIBUTION_LOG="${TEST_ROOT}/rules-attribution.log"
 : >"$EVIDENCE_LOG"
+: >"$RULES_ATTRIBUTION_LOG"
 
 gh_record_efficiency_evidence() {
 	local name="$1"
@@ -152,6 +154,8 @@ gh() {
 		fi
 		;;
 	repos/owner/repo/rules/branches/*)
+		printf '%s|%s|%s\n' "${AIDEVOPS_GH_QUOTA_COST:-}" \
+			"${AIDEVOPS_GH_ROUTE_DECISION:-}" "$endpoint" >>"$RULES_ATTRIBUTION_LOG"
 		stub_effective_rules "$endpoint"
 		return $?
 		;;
@@ -333,6 +337,23 @@ assert_human_review_thread_rules() {
 	return 0
 }
 
+assert_effective_rules_have_exact_rest_cost() {
+	local rc=0
+	SNAPSHOT_MODE="human_rules_error"
+	: >"$RULES_ATTRIBUTION_LOG"
+	_pmrc_review_thread_resolution_required "owner/repo" "main" >/dev/null 2>&1 || rc=$?
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 1 ]] \
+		&& grep -qF '1|pulse-effective-rules-rest|repos/owner/repo/rules/branches/main' \
+			"$RULES_ATTRIBUTION_LOG"; then
+		printf 'PASS failed effective-rules reads retain exact REST cost\n'
+		return 0
+	fi
+	printf 'FAIL failed effective-rules read lacked exact REST cost (rc=%s)\n' "$rc"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
 set_live_evidence() {
 	local status="$1"
 	local head_sha="${2:-sha-reviewed}"
@@ -439,6 +460,7 @@ assert_review_and_head_snapshot_cases() {
 main() {
 	assert_infrastructure_rerun_unset_defaults_safe
 	assert_infrastructure_rerun_unset_logfile_safe
+	assert_effective_rules_have_exact_rest_cost
 	assert_snapshot_acquisition_failures_are_audited
 	assert_gate "large paginated check payload streams without argument overflow" large_payload 0
 	assert_large_bot_activity_streams

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -59,10 +59,37 @@ write_pr_fixture() {
 	"statusCheckRollup": [
 		{"name": "Socket Security: Pull Request Alerts", "conclusion": "${security_conclusion}", "status": "COMPLETED"},
 		{"name": "Framework Validation", "conclusion": "${framework_conclusion}", "status": "COMPLETED"},
-		{"name": "gate / review-bot-gate", "workflowName": "Review Bot Gate", "conclusion": "FAILURE", "status": "COMPLETED"}
+		{"name": "review status", "workflowName": "Review Bot Gate", "conclusion": "FAILURE", "status": "COMPLETED"}
 	]
 }
 EOF
+	jq '{data:{
+		repository:{pullRequest:{
+			author:.author,
+			body:.body,
+			headRepository:.headRepository,
+			headRepositoryOwner:.headRepositoryOwner,
+			commits:{
+				nodes:[.commits[] | {commit:{authors:{
+					nodes:[.authors[] | {user:{login:.login}}],
+					pageInfo:{hasNextPage:false}
+				}}}],
+				pageInfo:{hasNextPage:false}
+			},
+			files:{nodes:.files,pageInfo:{hasNextPage:false}},
+			statusCheckRollup:{contexts:{
+				nodes:[.statusCheckRollup[] | {
+					__typename:"CheckRun",
+					name,
+					conclusion,
+					status,
+					checkSuite:{workflowRun:{workflow:{name:(.workflowName // null)}}}
+				}],
+				pageInfo:{hasNextPage:false}
+			}}
+		}},
+		rateLimit:{cost:2}
+	}}' "${TEST_ROOT}/pr.json" >"${TEST_ROOT}/graphql.json"
 	return 0
 }
 
@@ -82,7 +109,14 @@ setup_test_env() {
 
 	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
 #!/usr/bin/env bash
-printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
+printf '%s|%s|gh %s\n' \
+	"${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" \
+	"${AIDEVOPS_GH_ROUTE_DECISION:-}" "$*" >>"${GH_LOG:-/dev/null}"
+
+if [[ "${1:-}" == "api" && "${2:-}" == "graphql" ]]; then
+	cat "${TEST_ROOT}/graphql.json"
+	exit 0
+fi
 
 if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
 	cat "${TEST_ROOT}/pr.json"
@@ -144,6 +178,7 @@ define_helpers_under_test() {
 	dependabot_src=$(awk '
 		/^_trusted_dependabot_updates_conf\(\) \{/,/^}$/ { print }
 		/^_trusted_dependabot_dependency_allowed\(\) \{/,/^}$/ { print }
+		/^_trusted_dependabot_pr_json_graphql\(\) \{/,/^}$/ { print }
 		/^_is_trusted_dependabot_update_pr\(\) \{/,/^}$/ { print }
 		/^_trusted_dependabot_non_review_checks_green\(\) \{/,/^}$/ { print }
 	' "$GATES_SCRIPT")
@@ -163,6 +198,32 @@ define_helpers_under_test() {
 	eval "$trusted_approval_src"
 	# shellcheck disable=SC1090
 	eval "$approve_src"
+	return 0
+}
+
+test_trusted_dependabot_uses_response_metered_graphql() {
+	write_pr_fixture "dependabot[bot]" "dependabot[bot]" "requirements-lock.txt" "SUCCESS"
+	: >"$GH_LOG"
+	if _is_trusted_dependabot_update_pr "24473" "owner/repo" "dependabot[bot]" \
+		&& grep -qF '1|pulse-trusted-dependabot-exact-cost|gh api graphql' "$GH_LOG" \
+		&& ! grep -qF '|gh pr view 24473' "$GH_LOG"; then
+		print_result "trusted Dependabot snapshot reports operation-owned GraphQL cost" 0
+		return 0
+	fi
+	print_result "trusted Dependabot snapshot reports operation-owned GraphQL cost" 1 "gh log: $(<"$GH_LOG")"
+	return 0
+}
+
+test_trusted_dependabot_rejects_paginated_snapshot() {
+	write_pr_fixture "dependabot[bot]" "dependabot[bot]" "requirements-lock.txt" "SUCCESS"
+	jq '.data.repository.pullRequest.files.pageInfo.hasNextPage = true' \
+		"${TEST_ROOT}/graphql.json" >"${TEST_ROOT}/graphql-paginated.json"
+	mv "${TEST_ROOT}/graphql-paginated.json" "${TEST_ROOT}/graphql.json"
+	if _is_trusted_dependabot_update_pr "24473" "owner/repo" "dependabot[bot]"; then
+		print_result "paginated trusted Dependabot snapshot fails closed" 1
+		return 0
+	fi
+	print_result "paginated trusted Dependabot snapshot fails closed" 0
 	return 0
 }
 
@@ -228,18 +289,18 @@ test_review_bot_failure_is_ignored_when_other_checks_green() {
 	return 0
 }
 
-test_precomputed_status_rollup_skips_pr_view() {
+test_precomputed_status_rollup_skips_graphql() {
 	local pr_json=""
 
 	write_pr_fixture "dependabot[bot]" "dependabot[bot]" "requirements-lock.txt" "SUCCESS" "SUCCESS"
 	pr_json=$(<"${TEST_ROOT}/pr.json")
 	: >"$GH_LOG"
 	if _trusted_dependabot_non_review_checks_green "24473" "owner/repo" "$pr_json" \
-		&& ! grep -qF 'gh pr view 24473' "$GH_LOG"; then
-		print_result "precomputed status rollup skips PR view" 0
+		&& ! grep -qF 'gh api graphql' "$GH_LOG"; then
+		print_result "precomputed status rollup skips GraphQL fetch" 0
 		return 0
 	fi
-	print_result "precomputed status rollup skips PR view" 1 "Expected no gh pr view call. gh log: $(<"$GH_LOG")"
+	print_result "precomputed status rollup skips GraphQL fetch" 1 "Expected no GraphQL call. gh log: $(<"$GH_LOG")"
 	return 0
 }
 
@@ -258,12 +319,14 @@ main() {
 	trap teardown_test_env EXIT
 	define_helpers_under_test
 	test_trusted_dependabot_passes
+	test_trusted_dependabot_uses_response_metered_graphql
+	test_trusted_dependabot_rejects_paginated_snapshot
 	test_spoofed_author_fails
 	test_security_failure_fails
 	test_non_dependency_file_fails
 	test_trusted_dependabot_can_be_approved
 	test_review_bot_failure_is_ignored_when_other_checks_green
-	test_precomputed_status_rollup_skips_pr_view
+	test_precomputed_status_rollup_skips_graphql
 	test_non_review_failure_blocks_required_check_bypass
 
 	printf '\nTests run: %s\n' "$TESTS_RUN"

--- a/.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh
@@ -18,7 +18,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
-WRAPPER_SCRIPT="${SCRIPT_DIR}/../pulse-wrapper.sh"
+SCAN_SCRIPT="${SCRIPT_DIR}/../pulse-simplification-scan.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -29,6 +29,7 @@ TESTS_FAILED=0
 TEST_ROOT=""
 ORIGINAL_HOME="${HOME}"
 ORIGINAL_PATH="${PATH}"
+GH_GRAPHQL_LOG=""
 
 print_result() {
 	local test_name="$1"
@@ -50,13 +51,23 @@ print_result() {
 }
 
 setup_test_env() {
-	TEST_ROOT=$(mktemp -d)
+	local temp_base="${AIDEVOPS_TEMP_DIR:-${ORIGINAL_HOME}/.aidevops/.agent-workspace/tmp}"
+	mkdir -p "$temp_base"
+	TEST_ROOT=$(mktemp -d "${temp_base%/}/pulse-complexity-test.XXXXXX")
 	export HOME="${TEST_ROOT}/home"
 	mkdir -p "${HOME}/.aidevops/logs"
 	LOGFILE="${HOME}/.aidevops/logs/pulse.log"
-	export LOGFILE
+	GH_GRAPHQL_LOG="${TEST_ROOT}/graphql.log"
+	COMPLEXITY_SCAN_LAST_RUN="${HOME}/.aidevops/logs/complexity-scan-last-run"
+	COMPLEXITY_SCAN_INTERVAL=900
+	COMPLEXITY_SCAN_TREE_HASH_FILE="${HOME}/.aidevops/logs/complexity-scan-tree-hash"
+	COMPLEXITY_LLM_SWEEP_LAST_RUN="${HOME}/.aidevops/logs/complexity-llm-sweep-last-run"
+	COMPLEXITY_LLM_SWEEP_INTERVAL=21600
+	COMPLEXITY_DEBT_COUNT_FILE="${HOME}/.aidevops/logs/complexity-debt-count"
+	: >"$GH_GRAPHQL_LOG"
+	export LOGFILE GH_GRAPHQL_LOG
 	# shellcheck source=/dev/null
-	source "$WRAPPER_SCRIPT"
+	source "$SCAN_SCRIPT"
 	return 0
 }
 
@@ -69,15 +80,26 @@ teardown_test_env() {
 	return 0
 }
 
+# Disposable fixture repositories bypass the production canonical-repository shim.
+_fixture_git() {
+	/usr/bin/git "$@"
+	return $?
+}
+
+gh_issue_list() {
+	gh issue list "$@"
+	return $?
+}
+
 make_test_repo() {
 	local repo_path="$1"
 	mkdir -p "${repo_path}/.agents/scripts"
-	git -C "$repo_path" init -q 2>/dev/null
-	git -C "$repo_path" config user.email "test@test.com" 2>/dev/null
-	git -C "$repo_path" config user.name "Test" 2>/dev/null
+	_fixture_git -C "$repo_path" init -q --initial-branch=test-fixture 2>/dev/null
 	printf '#!/usr/bin/env bash\n# test file\necho hello\n' >"${repo_path}/.agents/scripts/test.sh"
-	git -C "$repo_path" add . 2>/dev/null
-	git -C "$repo_path" commit -q -m "init" 2>/dev/null
+	_fixture_git -C "$repo_path" add . 2>/dev/null
+	GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="test@example.invalid" \
+		GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="test@example.invalid" \
+		_fixture_git -C "$repo_path" commit -q -m "init" 2>/dev/null
 	return 0
 }
 
@@ -92,10 +114,15 @@ args="$*"
 case "$cmd" in
 	api)
 		if [[ "$subcmd" == "graphql" ]]; then
+			printf '%s|%s|%s\n' \
+				"${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" \
+				"${AIDEVOPS_GH_ROUTE_DECISION:-}" "$args" >>"${GH_GRAPHQL_LOG}"
 			if [[ "$args" == *"search(query"* ]]; then
-				printf '%s\n' "${GH_RECENT_CLOSURES:-0}"
+				printf '{"data":{"search":{"issueCount":%s},"rateLimit":{"cost":1}}}\n' \
+					"${GH_RECENT_CLOSURES:-0}"
 			else
-				printf '%s\n' "${GH_OPEN_DEBT_COUNT:-0}"
+				printf '{"data":{"repository":{"issues":{"totalCount":%s}},"rateLimit":{"cost":1}}}\n' \
+					"${GH_OPEN_DEBT_COUNT:-0}"
 			fi
 			exit 0
 		fi
@@ -111,6 +138,29 @@ exit 0
 EOF
 	chmod +x "${stub_dir}/gh"
 	export PATH="${stub_dir}:${ORIGINAL_PATH}"
+	return 0
+}
+
+test_graphql_reads_report_operation_owned_cost() {
+	install_fake_gh_for_sweep
+	: >"$GH_GRAPHQL_LOG"
+	export GH_RECENT_CLOSURES=2 GH_OPEN_DEBT_COUNT=0
+	local recent_closures=""
+	recent_closures=$(_complexity_recent_debt_closures "100000" "test/repo" "3600")
+	rm -f "$COMPLEXITY_LLM_SWEEP_LAST_RUN"
+	_complexity_llm_sweep_due "100000" "test/repo" >/dev/null 2>&1 || true
+	_complexity_scan_check_open_cap "test/repo" "10" "test" >/dev/null 2>&1 || true
+	if [[ "$recent_closures" == "2" ]] \
+		&& grep -qF '1|pulse-complexity-closures-exact-cost|api graphql' "$GH_GRAPHQL_LOG" \
+		&& grep -qF '1|pulse-complexity-open-count-exact-cost|api graphql' "$GH_GRAPHQL_LOG" \
+		&& grep -qF '1|pulse-complexity-cap-exact-cost|api graphql' "$GH_GRAPHQL_LOG" \
+		&& grep -qF 'rateLimit { cost }' "$GH_GRAPHQL_LOG"; then
+		print_result "complexity GraphQL reads report operation-owned cost" 0
+	else
+		print_result "complexity GraphQL reads report operation-owned cost" 1 \
+			"value=${recent_closures}; calls=$(<"$GH_GRAPHQL_LOG")"
+	fi
+	unset GH_RECENT_CLOSURES GH_OPEN_DEBT_COUNT
 	return 0
 }
 
@@ -182,8 +232,10 @@ test_tree_changed_after_commit_returns_changed() {
 	_complexity_scan_tree_changed "$repo_path" >/dev/null 2>&1 || true
 	# Modify and commit a file
 	printf '#!/usr/bin/env bash\n# modified\necho world\n' >"${repo_path}/.agents/scripts/test.sh"
-	git -C "$repo_path" add . 2>/dev/null
-	git -C "$repo_path" commit -q -m "modify" 2>/dev/null
+	_fixture_git -C "$repo_path" add . 2>/dev/null
+	GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="test@example.invalid" \
+		GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="test@example.invalid" \
+		_fixture_git -C "$repo_path" commit -q -m "modify" 2>/dev/null
 	# Should return 0 (changed)
 	if _complexity_scan_tree_changed "$repo_path"; then
 		print_result "_complexity_scan_tree_changed: returns changed after commit" 0
@@ -359,6 +411,7 @@ main() {
 	test_tree_changed_first_call_returns_changed
 	test_tree_changed_second_call_returns_unchanged
 	test_tree_changed_after_commit_returns_changed
+	test_graphql_reads_report_operation_owned_cost
 	test_llm_sweep_not_due_when_interval_not_elapsed
 	test_llm_sweep_check_interval_guard
 	test_llm_sweep_skips_when_recent_closures_exist


### PR DESCRIPTION
## Summary

Replace residual native and unmetered GitHub reads with operation-owned REST costs or same-response GraphQL rate costs across merge trust, dependency, rules, permission, and complexity paths.

## Files Changed

.agents/scripts/pulse-dep-graph.sh, .agents/scripts/pulse-merge-gates.sh, .agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/pulse-simplification-scan.sh, .agents/scripts/shared-gh-collaborator-permission.sh, .agents/scripts/tests/test-gh-current-user-write-guard.sh, .agents/scripts/tests/test-pulse-dep-graph-stale-label-cleanup.sh, .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh, .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh, .agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Targeted shell suites passed (127 assertions); local linters passed; live GitHub REST and GraphQL route probes validated issue identity, blockedBy, effective rules, collaborator permission, complexity counts, and the Dependabot query schema.

Resolves #28654


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.181 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.5 spent 9d 13h and 34,744,008 tokens on this with the user in an interactive session.