### PR TITLE
GH#28677: Fix issue-brief transport token matching

### DIFF
--- a/.agents/scripts/log-issue-helper.sh
+++ b/.agents/scripts/log-issue-helper.sh
@@ -393,9 +393,11 @@ _brief_is_causal_investigation() {
 
 _brief_asserts_transport_cause() {
 	local body="$1"
-	local failure='hang|hung|timeout|timed out|rate.?limit|API.?budget|transport'
+	local failure='(^|[^[:alnum:]_])(hang|hung|timeout|timed[[:space:]]+out|rate[[:space:]_-]?limit|api[[:space:]_-]?budget|transport)([^[:alnum:]_]|$)'
+	local rate_limit='(^|[^[:alnum:]_])rate[[:space:]_-]?limit([^[:alnum:]_]|$)'
+	local stalled='(^|[^[:alnum:]_])(hang|hung|timeout)([^[:alnum:]_]|$)'
 	local causal='because|due to|root cause|cause(d|s)?|results? in|leads? to|triggers?'
-	if grep -Eqi "(${causal}).{0,120}(${failure})|(${failure}).{0,120}(${causal})|rate.?limit.{0,120}(hang|hung|timeout)|[→]" <<<"$body"; then
+	if grep -Eqi "(${causal}).{0,120}(${failure})|(${failure}).{0,120}(${causal})|(${rate_limit}).{0,120}(${stalled})|[→]" <<<"$body"; then
 		return 0
 	fi
 	return 1

--- a/.agents/scripts/tests/test-verify-brief.sh
+++ b/.agents/scripts/tests/test-verify-brief.sh
@@ -508,6 +508,56 @@ else
 fi
 
 # =============================================================================
+# Class G: transport-cause terms use portable token boundaries (GH#28677)
+# =============================================================================
+
+printf '\n%sClass G: transport-cause token boundaries%s\n' "$TEST_BLUE" "$TEST_NC"
+
+cat >"$TMP/brief-transport-near-misses.md" <<'BRIEF'
+## Reproducer
+**Symptom command**: `aidevops review`
+**Actual output**: `reviewDecision=CHANGES_REQUESTED`
+**Causal status**: confirmed
+**Production entry point**: review.sh:42 reads the review decision
+**Call chain**: review_tick -> read_decision -> classify_review
+**Integrated verification**: test-review.sh exercises the confirmed path
+The root cause is the mixed-case CHANGES_REQUESTED value, not the hanger,
+transporter, timeoutSeconds, rate_limiter, or api_budgeter metadata nearby.
+BRIEF
+
+output=$(bash "$HELPER" validate-brief "$TMP/brief-transport-near-misses.md" 2>&1)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+	pass "G1 transport substrings and CHANGES_REQUESTED do not require transport evidence"
+else
+	fail "G1 transport token boundaries" "expected rc=0, got rc=$rc; output: $output"
+fi
+
+for transport_claim in \
+	"The root cause is a hang." \
+	"The worker HUNG because the scheduler stopped." \
+	"The root cause is a TiMeOuT." \
+	"The request timed out because the backend stalled." \
+	"The root cause is the RATE-LIMIT state." \
+	"The rate limit state preceded a hang." \
+	"The root cause is the Api Budget state." \
+	"The root cause is a TRANSPORT failure."; do
+	cat >"$TMP/brief-real-transport-claim.md" <<BRIEF
+## Reproducer
+**Symptom command**: \`aidevops pulse\`
+**Actual output**: the operation stopped
+${transport_claim}
+BRIEF
+	output=$(bash "$HELPER" validate-brief "$TMP/brief-real-transport-claim.md" 2>&1)
+	rc=$?
+	if [[ $rc -ne 0 && "$output" == *"require **Blocked command** and **Backend state**"* ]]; then
+		pass "G2 genuine transport claim is rejected without evidence: $transport_claim"
+	else
+		fail "G2 genuine transport claim detection: $transport_claim" "expected transport-evidence rejection, got rc=$rc; output: $output"
+	fi
+done
+
+# =============================================================================
 # Summary
 # =============================================================================
 

--- a/.agents/tests/log-issue-helper.bats
+++ b/.agents/tests/log-issue-helper.bats
@@ -149,6 +149,29 @@ _source_helper() {
 	[[ "$output" == *"require **Blocked command** and **Backend state**"* ]]
 }
 
+@test "validate brief ignores transport-like substrings in confirmed causes" {
+	_source_helper
+	local body
+	body="$(printf '## Reproducer\n**Symptom command**: aidevops review\n**Actual output**: reviewDecision=CHANGES_REQUESTED\n**Causal status**: confirmed\n**Production entry point**: review.sh:42 reads the review decision\n**Call chain**: review_tick -> read_decision -> classify_review\n**Integrated verification**: test-review.sh exercises the confirmed path\nThe root cause is CHANGES_REQUESTED, not hanger, transporter, timeoutSeconds, rate_limiter, or api_budgeter.')"
+	run validate_brief_has_reproducer "$body"
+	[ "$status" -eq 0 ]
+}
+
+@test "validate brief detects mixed-case transport tokens and explicit arrows" {
+	_source_helper
+	local claim body
+	for claim in "root cause is a HANG" "worker HuNg because backend stopped" \
+		"root cause is a Timeout" "request TIMED OUT because backend stopped" \
+		"root cause is a Rate_Limit" "rate limit state preceded a hang" \
+		"root cause is an API-BUDGET" \
+		"root cause is a TrAnSpOrT failure" "pulse → gh api remained blocked"; do
+		body="$(printf '## Reproducer\n**Symptom command**: aidevops pulse\n**Actual output**: operation stopped\n%s' "$claim")"
+		run validate_brief_has_reproducer "$body"
+		[ "$status" -eq 1 ]
+		[[ "$output" == *"require **Blocked command** and **Backend state**"* ]]
+	done
+}
+
 @test "validate brief accepts investigation framing without causal proof" {
 	_source_helper
 	local body


### PR DESCRIPTION
## Summary

Make transport-cause detection token-aware and add CLI/Bats regression coverage for CHANGES_REQUESTED, near misses, mixed case, and genuine transport claims.

## Files Changed

.agents/scripts/log-issue-helper.sh, .agents/scripts/tests/test-verify-brief.sh, .agents/tests/log-issue-helper.bats

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — .agents/scripts/tests/test-verify-brief.sh; ShellCheck on changed shell files (Bats runner unavailable on PATH)

Resolves #28677


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.181 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 3m and 71,922 tokens on this as a headless worker.