### PR TITLE
GH#28666: Add live YouTube account knowledge ingestion

### DIFF
--- a/.agents/aidevops/knowledge-plane/05-social-operations.md
+++ b/.agents/aidevops/knowledge-plane/05-social-operations.md
@@ -46,7 +46,8 @@ the previous checkpoint. Snapshot streams never infer deletion from partial
 coverage.
 
 X collection uses the guarded official `xurl` helper. Reddit collection uses an
-optional PRAW 8 child with a filtered environment and fixed read-only routing:
+optional PRAW 8 child. YouTube collection uses a standard-library HTTP child and
+OAuth user identity; it never reuses the service-account research helper:
 
 ```bash
 knowledge-social-helper.sh sync-x --alias personal:default \
@@ -59,6 +60,11 @@ aidevops secret REDDIT_DEFAULT_CLIENT_ID REDDIT_DEFAULT_CLIENT_SECRET \
   --connection-id REDDIT_CONNECTION_ID \
   --account-id STABLE_REDDIT_ACCOUNT_ID \
   --stream authored_comments --profile default --budget 10 --page-size 100
+
+aidevops secret YOUTUBE_PERSONAL_ACCESS_TOKEN -- \
+  knowledge-social-helper.sh sync-youtube --alias personal:default \
+  --connection-id YOUTUBE_CONNECTION_ID --account-id STABLE_CHANNEL_ID \
+  --stream authored_videos --profile personal --budget 11 --page-size 50
 ```
 
 Every Reddit stream has an independent cursor. Authored content, inbox activity,
@@ -71,6 +77,17 @@ retention boundary rather than complete account history.
 Named Reddit profile selectors and handles remain local. The child receives only
 the selected `REDDIT_<PROFILE>_*` variables, emits an explicit serialized field
 allowlist, and cannot reach the separate approval-bound mutation provider.
+
+YouTube requires `youtube.readonly` user OAuth. The child receives only
+`YOUTUBE_<PROFILE>_ACCESS_TOKEN`, verifies `channels.list(mine=true)` before each
+page, and allows only list endpoints. Uploaded videos, bounded channel activity,
+owned playlists and membership, outbound subscriptions, channel-related comments
+and complete API-visible replies, and liked videos have independent checkpoints.
+Every page reserves one identity plus one list quota unit. Watch history, Watch
+Later, saved third-party playlists, and complete authored-comment history remain
+explicit unavailable/export-unverified coverage. API metadata carries the current
+30-day refresh/delete retention boundary. Details and official evidence:
+`.agents/content/social-youtube.md`.
 
 ## Approval-bound account operations
 

--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -32,7 +32,7 @@ a claim that the route is enabled.
 |---|---|---|---|---|---|---|
 | X | **Live** posts | **Live** likes and bookmarks | **Live** mentions | **Live** followers and following | **No** in the current adapter | Maintain the six guarded `xurl` streams; investigate lists separately. |
 | Reddit | **Live** submissions and comments | **Live** saved, votes, and hidden | **Live** mentions, replies, inbox, and sent | **Live** subreddit and account relationships | **Live** multireddits and membership | PRAW 8, bounded one-page reads, independent cursors, and provider-window coverage. |
-| YouTube | **API/Gate/Export** | **API/Gate/Export** | **API/Gate/Export** comments | **API/Gate/Export** subscriptions | **API/Gate/Export** playlists | Child must verify OAuth user routes separately from existing service-account research tooling. |
+| YouTube | **Live** uploads; **Live/Partial** activity | **Live** likes; **No/Export** watch history and Watch Later | **Live/Gate** channel-related comments and replies; **No/Export** complete authored history | **Live** outbound subscriptions | **Live** owned playlists and membership; **No/Export** saved playlists | `youtube.readonly` user OAuth, identity recheck per page, bounded list quota, 30-day refresh/delete boundary, and explicit gap rows. |
 | LinkedIn | **Gate/Export** | **Gate/Export** | **Export** | **Gate/Export** | **Export/No** | Treat member access as restricted; do not reuse browser engagement automation as a collector. |
 | Facebook | **Gate/Export** | **Gate/Export** | **Gate/Export** | **Gate/Export** | **Gate/Export** | Shared Meta authorization needs app-review and product-specific evidence. |
 | Instagram | **Gate/Export** media | **Gate/Export** | **Gate/Export** comments and mentions | **Gate/Export** | **Export/No** | Verify Professional versus personal-account coverage before implementation. |
@@ -64,6 +64,13 @@ a claim that the route is enabled.
   `.agents/scripts/_knowledge_social_reddit*.py`, and
   `.agents/tests/test-knowledge-social-reddit.sh` prove the stream allowlist,
   read-only boundary, cursor behavior, snapshots, and sanitized failures.
+- **Live YouTube:** `.agents/scripts/knowledge_social_youtube.py`,
+  `.agents/scripts/_knowledge_social_youtube*.py`, and
+  `.agents/tests/test-knowledge-social-youtube.sh` prove OAuth-owned identity,
+  quota accounting, compound playlist/comment checkpoints, explicit gaps, and a
+  GET-only provider boundary. `.agents/content/social-youtube.md` records the
+  official route, scope, retention, export, and unsupported evidence checked on
+  2026-07-26.
 - **All candidate rows:** the provider child owns current official documentation,
   account/export samples, auth scopes, dependency versions, local exported
   symbols, retention evidence, and explicit unsupported findings.

--- a/.agents/content/social-youtube.md
+++ b/.agents/content/social-youtube.md
@@ -1,0 +1,107 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# YouTube Account Knowledge Collection
+
+`knowledge-social-helper.sh sync-youtube` collects bounded account-visible
+YouTube Data API v3 metadata into the social corpus. It is an OAuth **user**
+collector. The service-account flow in `youtube-helper.sh` remains public channel
+research tooling and is not evidence that a personal channel was selected.
+
+## Runtime and authorization contract
+
+The collector uses Python's standard-library `urllib.request.Request`,
+`urllib.request.urlopen`, and `urllib.parse.urlencode` exports. It does not depend
+on or install `google-api-python-client`; the implementation was verified with
+Python 3.14.3 and validates the required exports before a live request.
+
+Authorize only the documented read scope:
+
+```text
+https://www.googleapis.com/auth/youtube.readonly
+```
+
+Store a current user OAuth access token as
+`YOUTUBE_<PROFILE>_ACCESS_TOKEN`. Token issuance and refresh happen outside the
+collector; refresh tokens and OAuth client secrets never enter its process. Run a
+profile through the secret execution context, for example:
+
+```bash
+aidevops secret YOUTUBE_PERSONAL_ACCESS_TOKEN -- \
+  knowledge-social-helper.sh sync-youtube --alias personal:default \
+  --connection-id YOUTUBE_CONNECTION_ID --account-id STABLE_CHANNEL_ID \
+  --stream authored_videos --profile personal --budget 11 --page-size 50
+```
+
+The child receives only the selected access-token variable plus a small runtime
+environment allowlist. It calls `channels.list(mine=true)` before collection and
+again before every page. A changed or unowned channel ID fails before evidence or
+checkpoint persistence.
+
+## Implemented streams
+
+| Stream | Official route | Coverage |
+|---|---|---|
+| `authored_videos` | `channels.list(mine=true)` uploads ID, then `playlistItems.list` | Uploaded-video metadata, newest-ID watermark, resumable page tokens. |
+| `channel_activity` | `activities.list(mine=true)` | Documented activity resource types only; not a complete account audit log. |
+| `owned_playlists` | `playlists.list(mine=true)`, then `playlistItems.list` per playlist | Owned playlists and explicit playlist-to-video membership. Third-party saved playlists are not represented. |
+| `subscriptions` | `subscriptions.list(mine=true)` | Outbound direction: selected channel to subscribed channel. |
+| `comments` | `commentThreads.list(allThreadsRelatedToChannelId=...)`, then paginated `comments.list(parentId=...)` | Channel-related comments and all API-visible replies. Visibility/moderation gates remain partial coverage. |
+| `liked_videos` | `videos.list(myRating=like)` | Videos exposed by the authenticated user's current rating route. |
+
+Every list call costs one documented quota unit. The initial identity request
+reserves one unit; each page reserves two units for identity rebinding defence
+and its selected list route. `--budget` is a hard 1-1000-unit allowance and
+`--page-size` is limited to 1-50. Each stream owns an independent cursor. The
+compound playlist and comment cursors commit one API response plus the next phase
+atomically under the final lease fence.
+
+The boundary serializes only allowlisted text, IDs, timestamps, direction, count,
+position, and privacy-status fields. It never downloads audiovisual media and has
+no write endpoint or mutation action.
+
+## Explicit gaps and retention
+
+Every successful page also records unavailable coverage for:
+
+- `watch_history`: the Data API explicitly does not expose watch history;
+- `watch_later`: the Data API explicitly does not expose Watch Later items;
+- `saved_playlists`: `playlists.list(mine=true)` lists owned, not merely saved,
+  playlists;
+- `authored_comments_elsewhere`: no complete account-wide authored-comment
+  history is documented.
+
+These rows use stable unsupported reasons and never turn an empty API response
+into successful coverage. A Google account export remains the next candidate,
+but no archive importer is enabled until a current private sample validates the
+format and category completeness. Browser collection still requires a separate
+approved private gap record.
+
+YouTube API Services policy requires most stored authorized API data to be
+deleted or refreshed within 30 calendar days and imposes revocation/deletion
+obligations. Coverage therefore records
+`youtube_api_data_refresh_or_delete_within_30_days`. Operators must keep the
+connection authorized and refreshed, and remove data when authorization or the
+source ends. Immutable raw batches are evidence for a fetch; immutability does
+not override provider deletion obligations.
+
+## Official evidence checked 2026-07-26
+
+- [Authentication and OAuth](https://developers.google.com/youtube/v3/guides/authentication)
+- [OAuth server-side scopes](https://developers.google.com/youtube/v3/guides/auth/server-side-web-apps#OAuth2_0_Scopes)
+- [Channels list](https://developers.google.com/youtube/v3/docs/channels/list)
+- [Channels resource](https://developers.google.com/youtube/v3/docs/channels)
+- [Activities list](https://developers.google.com/youtube/v3/docs/activities/list)
+- [Activities resource](https://developers.google.com/youtube/v3/docs/activities)
+- [Playlists list](https://developers.google.com/youtube/v3/docs/playlists/list)
+- [Playlist items list](https://developers.google.com/youtube/v3/docs/playlistItems/list)
+- [Subscriptions list](https://developers.google.com/youtube/v3/docs/subscriptions/list)
+- [Subscriptions resource](https://developers.google.com/youtube/v3/docs/subscriptions)
+- [Comment threads list](https://developers.google.com/youtube/v3/docs/commentThreads/list)
+- [Comment threads resource](https://developers.google.com/youtube/v3/docs/commentThreads)
+- [Comments list](https://developers.google.com/youtube/v3/docs/comments/list)
+- [Videos list](https://developers.google.com/youtube/v3/docs/videos/list)
+- [Pagination](https://developers.google.com/youtube/v3/guides/implementation/pagination)
+- [Quota costs](https://developers.google.com/youtube/v3/determine_quota_cost)
+- [Developer policies](https://developers.google.com/youtube/terms/developer-policies)
+- [Google account export](https://support.google.com/accounts/answer/3024190)

--- a/.agents/scripts/_knowledge_social_collect_persist.py
+++ b/.agents/scripts/_knowledge_social_collect_persist.py
@@ -27,6 +27,7 @@ from knowledge_social_import import (
     canonical_json,
     import_accounts,
     import_activities,
+    import_coverage,
     import_media,
     import_objects,
     reject_credentials,
@@ -264,6 +265,9 @@ def persist_page(context: CollectionContext, page: SuccessfulPage) -> int:
         import_objects(database, page.archive, provider, raw.batch_id)
         import_activities(database, page.archive, provider, raw.batch_id)
         import_media(database, page.archive, provider, raw.batch_id)
+        import_coverage(
+            database, page.archive, provider, context.connection_id, raw.batch_id
+        )
         _refresh_fts(database, provider, page.archive)
         resource_count = sum(
             len(page.archive[key])

--- a/.agents/scripts/_knowledge_social_youtube.py
+++ b/.agents/scripts/_knowledge_social_youtube.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""YouTube stream capabilities and durable checkpoint calculation."""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from knowledge_social_import import canonical_json, reject_credentials
+from knowledge_social_store import SocialStoreError
+
+PROVIDER = "youtube"
+CURSOR_PREFIX = "youtube-v1:"
+YOUTUBE_ID = re.compile(r"^[A-Za-z0-9_-]{3,128}$")
+API_RETENTION = "youtube_api_data_refresh_or_delete_within_30_days"
+
+
+class YouTubeAdapterError(SocialStoreError):
+    """Raised when guarded YouTube collection cannot continue safely."""
+
+
+class YouTubeProviderUnavailableError(YouTubeAdapterError):
+    """Raised when the bounded OAuth child cannot complete a read."""
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    """Static collection and coverage policy for one YouTube stream."""
+
+    resource_kind: str
+    activity_mode: str
+    pagination: str
+    incremental: bool
+    retention_limit: str | None
+    coverage_status: str | None = None
+    unavailable_reason: str | None = None
+    cost_units: int = 2
+
+
+STREAMS = {
+    "authored_videos": StreamSpec(
+        "video", "content_author", "listing", True, API_RETENTION
+    ),
+    "channel_activity": StreamSpec(
+        "activity",
+        "selected_account",
+        "listing",
+        True,
+        API_RETENTION,
+        "partial",
+        "youtube_activity_feed_is_not_complete_history",
+    ),
+    "owned_playlists": StreamSpec(
+        "playlist",
+        "selected_account",
+        "compound_snapshot",
+        False,
+        API_RETENTION,
+        "partial",
+        "saved_third_party_playlists_are_not_listable",
+    ),
+    "subscriptions": StreamSpec(
+        "subscription", "selected_account", "snapshot", False, API_RETENTION
+    ),
+    "comments": StreamSpec(
+        "comment",
+        "content_author",
+        "compound_listing",
+        True,
+        API_RETENTION,
+        "partial",
+        "channel_related_visible_comments_only",
+    ),
+    "liked_videos": StreamSpec(
+        "video", "selected_account", "snapshot", False, API_RETENTION
+    ),
+}
+
+
+@dataclass(frozen=True)
+class PageRequest:
+    """Allowlisted bounded request passed to the OAuth subprocess."""
+
+    stream: str
+    account_id: str
+    uploads_playlist_id: str
+    cursor: dict[str, Any] | None
+    stop_at: str | None
+    limit: int
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "page",
+            "stream": self.stream,
+            "account_id": self.account_id,
+            "uploads_playlist_id": self.uploads_playlist_id,
+            "cursor": self.cursor,
+            "stop_at": self.stop_at,
+            "limit": self.limit,
+        }
+
+    def evidence_key(self) -> str:
+        return canonical_json(self.payload())
+
+
+def youtube_id(value: Any, field: str, *, optional: bool = False) -> str | None:
+    """Validate one provider-stable YouTube resource ID."""
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or YOUTUBE_ID.fullmatch(value) is None:
+        raise YouTubeAdapterError(f"YouTube {field} must be a stable ID")
+    return value
+
+
+def _encode_cursor(cursor: dict[str, Any]) -> str:
+    reject_credentials(cursor)
+    payload = canonical_json(cursor).encode("utf-8")
+    if len(payload) > 4096:
+        raise YouTubeAdapterError("YouTube checkpoint exceeds the safety limit")
+    encoded = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+    return f"{CURSOR_PREFIX}{encoded}"
+
+
+def _decode_cursor(cursor: str) -> dict[str, Any]:
+    if not cursor.startswith(CURSOR_PREFIX):
+        raise YouTubeAdapterError("stored YouTube cursor has an unsupported version")
+    encoded = cursor.removeprefix(CURSOR_PREFIX)
+    try:
+        padding = "=" * (-len(encoded) % 4)
+        parsed = json.loads(base64.urlsafe_b64decode(encoded + padding))
+    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+        raise YouTubeAdapterError("stored YouTube cursor is invalid") from error
+    if not isinstance(parsed, dict):
+        raise YouTubeAdapterError("stored YouTube cursor has an invalid shape")
+    reject_credentials(parsed)
+    return parsed
+
+
+def page_request(
+    stream: str,
+    account: dict[str, Any],
+    state: CursorState,
+    limit: int,
+) -> PageRequest:
+    """Build one allowlisted request from durable per-stream state."""
+    spec = STREAMS[stream]
+    account_id = youtube_id(account.get("id"), "account ID")
+    uploads_id = youtube_id(account.get("uploads_playlist_id"), "uploads playlist ID")
+    if account_id is None or uploads_id is None:
+        raise YouTubeAdapterError("verified YouTube identity is incomplete")
+    cursor = _decode_cursor(state.cursor) if state.cursor else None
+    stop_at = (
+        youtube_id(state.watermark, "watermark", optional=True)
+        if spec.incremental and state.backfill_complete and cursor is None
+        else None
+    )
+    return PageRequest(stream, account_id, uploads_id, cursor, stop_at, limit)
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    """Return a validated HTTP-like status from a YouTube read response."""
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise YouTubeAdapterError("YouTube response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return a validated provider data array."""
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise YouTubeAdapterError("YouTube page data must be an array")
+    return data
+
+
+def _page_meta(payload: dict[str, Any]) -> dict[str, Any]:
+    meta = payload.get("meta")
+    if not isinstance(meta, dict):
+        raise YouTubeAdapterError("YouTube page meta must be an object")
+    reject_credentials(meta)
+    return meta
+
+
+def _meta_boolean(meta: dict[str, Any], field: str) -> bool:
+    value = meta.get(field)
+    if not isinstance(value, bool):
+        raise YouTubeAdapterError("YouTube page completion metadata is invalid")
+    return value
+
+
+def page_checkpoint(
+    payload: dict[str, Any],
+    state: CursorState,
+    request: PageRequest,
+) -> tuple[PageCheckpoint, bool]:
+    """Calculate a resumable cursor and stable newest-resource watermark."""
+    spec = STREAMS[request.stream]
+    meta = _page_meta(payload)
+    next_value = meta.get("next_cursor")
+    if next_value is not None and not isinstance(next_value, dict):
+        raise YouTubeAdapterError("YouTube next cursor must be an object")
+    newest = youtube_id(meta.get("newest_id"), "newest ID", optional=True)
+    reached = _meta_boolean(meta, "reached_watermark")
+    complete = _meta_boolean(meta, "complete") or reached
+    snapshot = meta.get("snapshot")
+    if not isinstance(snapshot, bool) or snapshot != (not spec.incremental):
+        raise YouTubeAdapterError("YouTube page pagination metadata is invalid")
+    if complete == (next_value is not None):
+        message = (
+            "complete YouTube page cannot have a next cursor"
+            if complete
+            else "partial YouTube page requires a next cursor"
+        )
+        raise YouTubeAdapterError(message)
+    watermark = state.watermark
+    if spec.incremental and request.cursor is None and newest is not None:
+        watermark = newest
+    next_cursor = _encode_cursor(next_value) if next_value is not None else None
+    return PageCheckpoint(next_cursor, watermark), complete

--- a/.agents/scripts/_knowledge_social_youtube_contract.py
+++ b/.agents/scripts/_knowledge_social_youtube_contract.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validation and serialization for the bounded YouTube OAuth subprocess."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+MAX_TEXT_BYTES = 256 * 1024
+STABLE_ID = re.compile(r"^[A-Za-z0-9_-]{3,128}$")
+
+
+class YouTubeReadProviderError(RuntimeError):
+    """Raised for a privacy-safe local YouTube provider failure."""
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    """One bounded HTTP result without provider error-body disclosure."""
+
+    status: int
+    payload: dict[str, Any]
+    retry_after: int | None = None
+
+
+def observed_at() -> str:
+    """Return a stable UTC timestamp for one bounded provider response."""
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def exact_keys(request: dict[str, Any], expected: set[str]) -> None:
+    """Reject request shapes outside the allowlisted read contract."""
+    if set(request) != expected:
+        raise YouTubeReadProviderError(
+            "YouTube read request has an invalid action shape"
+        )
+
+
+def object_value(value: Any, field: str) -> dict[str, Any]:
+    """Validate one provider object."""
+    if not isinstance(value, dict):
+        raise YouTubeReadProviderError(f"YouTube {field} must be an object")
+    return value
+
+
+def optional_object(value: Any, field: str) -> dict[str, Any]:
+    """Validate an optional provider object, returning an empty object."""
+    if value is None:
+        return {}
+    return object_value(value, field)
+
+
+def optional_text(value: Any, field: str) -> str | None:
+    """Validate one bounded optional text field."""
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value:
+        raise YouTubeReadProviderError(f"YouTube {field} must be text")
+    if len(value.encode("utf-8")) > MAX_TEXT_BYTES:
+        raise YouTubeReadProviderError(f"YouTube {field} exceeds the safety limit")
+    return value
+
+
+def required_text(value: Any, field: str) -> str:
+    """Validate one non-empty bounded text field."""
+    text = optional_text(value, field)
+    if not text:
+        raise YouTubeReadProviderError(f"YouTube {field} is required")
+    return text
+
+
+def stable_id(value: Any, field: str) -> str:
+    """Validate one provider-stable resource ID."""
+    text = required_text(value, field)
+    if STABLE_ID.fullmatch(text) is None:
+        raise YouTubeReadProviderError(f"YouTube {field} is invalid")
+    return text
+
+
+def optional_id(value: Any, field: str) -> str | None:
+    """Validate one optional provider-stable resource ID."""
+    if value is None:
+        return None
+    return stable_id(value, field)
+
+
+def integer(value: Any, field: str) -> int:
+    """Validate a non-negative integer."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise YouTubeReadProviderError(f"YouTube {field} must be a non-negative integer")
+    return value
+
+
+def response_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return a validated YouTube list-response item array."""
+    items = payload.get("items", [])
+    if not isinstance(items, list) or any(not isinstance(item, dict) for item in items):
+        raise YouTubeReadProviderError("YouTube API items must be an array")
+    return items
+
+
+def next_page_token(payload: dict[str, Any]) -> str | None:
+    """Return a validated provider page token."""
+    token = optional_text(payload.get("nextPageToken"), "next page token")
+    if token is not None and (not token or len(token.encode("utf-8")) > 2048):
+        raise YouTubeReadProviderError("YouTube next page token is invalid")
+    return token
+
+
+def terminal_payload(result: ApiResult) -> dict[str, Any]:
+    """Build a sanitized terminal envelope from one HTTP result."""
+    payload: dict[str, Any] = {"status": result.status, "observed_at": observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload
+
+
+def identity_value(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    """Select and serialize the explicitly configured OAuth-owned channel."""
+    expected = stable_id(expected_id, "account ID")
+    selected = next(
+        (
+            item
+            for item in response_items(payload)
+            if item.get("id") == expected
+        ),
+        None,
+    )
+    if selected is None:
+        raise YouTubeReadProviderError(
+            "selected YouTube channel does not match the configured connection"
+        )
+    snippet = optional_object(selected.get("snippet"), "channel snippet")
+    details = object_value(selected.get("contentDetails"), "channel content details")
+    related = object_value(details.get("relatedPlaylists"), "related playlists")
+    return {
+        "id": expected,
+        "title": optional_text(snippet.get("title"), "channel title"),
+        "handle": optional_text(snippet.get("customUrl"), "channel handle"),
+        "uploads_playlist_id": stable_id(
+            related.get("uploads"), "uploads playlist ID"
+        ),
+    }
+
+
+def _snippet(item: dict[str, Any], kind: str) -> dict[str, Any]:
+    return object_value(item.get("snippet"), f"{kind} snippet")
+
+
+def _resource_video_id(snippet: dict[str, Any], details: dict[str, Any]) -> str:
+    resource = optional_object(snippet.get("resourceId"), "video resource ID")
+    candidate = details.get("videoId") or resource.get("videoId")
+    return stable_id(candidate, "video ID")
+
+
+def serialize_uploaded_video(item: dict[str, Any]) -> dict[str, Any]:
+    """Serialize one uploads-playlist item as authored video knowledge."""
+    snippet = _snippet(item, "playlist item")
+    details = optional_object(item.get("contentDetails"), "playlist item details")
+    status = optional_object(item.get("status"), "playlist item status")
+    return {
+        "kind": "video",
+        "remote_id": _resource_video_id(snippet, details),
+        "playlist_item_id": stable_id(item.get("id"), "playlist item ID"),
+        "title": optional_text(snippet.get("title"), "video title"),
+        "description": optional_text(snippet.get("description"), "video description"),
+        "published_at": optional_text(snippet.get("publishedAt"), "video timestamp"),
+        "channel_id": optional_id(snippet.get("channelId"), "channel ID"),
+        "channel_title": optional_text(snippet.get("channelTitle"), "channel title"),
+        "position": integer(snippet.get("position", 0), "playlist position"),
+        "privacy_status": optional_text(status.get("privacyStatus"), "privacy status"),
+    }
+
+
+def serialize_video(item: dict[str, Any]) -> dict[str, Any]:
+    """Serialize one liked-video resource."""
+    snippet = _snippet(item, "video")
+    status = optional_object(item.get("status"), "video status")
+    return {
+        "kind": "video",
+        "remote_id": stable_id(item.get("id"), "video ID"),
+        "title": optional_text(snippet.get("title"), "video title"),
+        "description": optional_text(snippet.get("description"), "video description"),
+        "published_at": optional_text(snippet.get("publishedAt"), "video timestamp"),
+        "channel_id": optional_id(snippet.get("channelId"), "channel ID"),
+        "channel_title": optional_text(snippet.get("channelTitle"), "channel title"),
+        "privacy_status": optional_text(status.get("privacyStatus"), "privacy status"),
+    }
+
+
+def serialize_playlist(item: dict[str, Any]) -> dict[str, Any]:
+    """Serialize one OAuth-owned playlist."""
+    snippet = _snippet(item, "playlist")
+    details = object_value(item.get("contentDetails"), "playlist details")
+    status = optional_object(item.get("status"), "playlist status")
+    return {
+        "kind": "playlist",
+        "remote_id": stable_id(item.get("id"), "playlist ID"),
+        "title": optional_text(snippet.get("title"), "playlist title"),
+        "description": optional_text(snippet.get("description"), "playlist description"),
+        "published_at": optional_text(snippet.get("publishedAt"), "playlist timestamp"),
+        "channel_id": optional_id(snippet.get("channelId"), "channel ID"),
+        "channel_title": optional_text(snippet.get("channelTitle"), "channel title"),
+        "item_count": integer(details.get("itemCount", 0), "playlist item count"),
+        "privacy_status": optional_text(status.get("privacyStatus"), "privacy status"),
+    }
+
+
+def serialize_playlist_item(
+    item: dict[str, Any], playlist_id: str
+) -> dict[str, Any]:
+    """Serialize one explicit owned-playlist membership."""
+    snippet = _snippet(item, "playlist item")
+    details = optional_object(item.get("contentDetails"), "playlist item details")
+    status = optional_object(item.get("status"), "playlist item status")
+    return {
+        "kind": "playlist_item",
+        "remote_id": stable_id(item.get("id"), "playlist item ID"),
+        "playlist_id": stable_id(playlist_id, "playlist ID"),
+        "video_id": _resource_video_id(snippet, details),
+        "title": optional_text(snippet.get("title"), "video title"),
+        "description": optional_text(snippet.get("description"), "video description"),
+        "published_at": optional_text(snippet.get("publishedAt"), "membership timestamp"),
+        "position": integer(snippet.get("position", 0), "playlist position"),
+        "privacy_status": optional_text(status.get("privacyStatus"), "privacy status"),
+    }
+
+
+def serialize_subscription(item: dict[str, Any]) -> dict[str, Any]:
+    """Serialize one outbound subscription with explicit direction."""
+    snippet = _snippet(item, "subscription")
+    resource = object_value(snippet.get("resourceId"), "subscription resource ID")
+    return {
+        "kind": "subscription",
+        "remote_id": stable_id(item.get("id"), "subscription ID"),
+        "subscriber_channel_id": stable_id(
+            snippet.get("channelId"), "subscriber channel ID"
+        ),
+        "subscribed_channel_id": stable_id(
+            resource.get("channelId"), "subscribed channel ID"
+        ),
+        "title": optional_text(snippet.get("title"), "subscribed channel title"),
+        "description": optional_text(
+            snippet.get("description"), "subscribed channel description"
+        ),
+        "published_at": optional_text(
+            snippet.get("publishedAt"), "subscription timestamp"
+        ),
+    }
+
+
+def serialize_comment(item: dict[str, Any], parent_id: str | None) -> dict[str, Any]:
+    """Serialize one top-level comment or reply."""
+    snippet = _snippet(item, "comment")
+    author = optional_object(snippet.get("authorChannelId"), "comment author channel")
+    resolved_parent = optional_id(
+        snippet.get("parentId", parent_id), "comment parent ID"
+    )
+    return {
+        "kind": "comment",
+        "remote_id": stable_id(item.get("id"), "comment ID"),
+        "parent_id": resolved_parent,
+        "video_id": optional_id(snippet.get("videoId"), "comment video ID"),
+        "channel_id": optional_id(snippet.get("channelId"), "comment channel ID"),
+        "author_channel_id": optional_id(author.get("value"), "author channel ID"),
+        "author_display_name": optional_text(
+            snippet.get("authorDisplayName"), "comment author name"
+        ),
+        "text": optional_text(
+            snippet.get("textOriginal", snippet.get("textDisplay")), "comment text"
+        ),
+        "published_at": optional_text(
+            snippet.get("publishedAt"), "comment timestamp"
+        ),
+        "updated_at": optional_text(snippet.get("updatedAt"), "comment update time"),
+    }
+
+
+def serialize_comment_thread(item: dict[str, Any]) -> tuple[dict[str, Any], int]:
+    """Serialize a thread's top-level comment and declared reply count."""
+    snippet = _snippet(item, "comment thread")
+    top_level = object_value(snippet.get("topLevelComment"), "top-level comment")
+    return (
+        serialize_comment(top_level, None),
+        integer(snippet.get("totalReplyCount", 0), "reply count"),
+    )
+
+
+def serialize_activity(item: dict[str, Any]) -> dict[str, Any]:
+    """Serialize one documented channel activity resource."""
+    snippet = _snippet(item, "activity")
+    details = optional_object(item.get("contentDetails"), "activity details")
+    activity_type = required_text(snippet.get("type"), "activity type")
+    detail = optional_object(details.get(activity_type), "activity type details")
+    resource = optional_object(detail.get("resourceId"), "activity resource ID")
+    subject_id = None
+    subject_kind = optional_text(resource.get("kind"), "activity resource kind")
+    for candidate in (
+        detail.get("videoId"),
+        detail.get("playlistId"),
+        resource.get("videoId"),
+        resource.get("channelId"),
+        resource.get("playlistId"),
+    ):
+        if candidate is not None:
+            subject_id = stable_id(candidate, "activity subject ID")
+            break
+    return {
+        "kind": "activity",
+        "remote_id": stable_id(item.get("id"), "activity ID"),
+        "activity_type": activity_type,
+        "title": optional_text(snippet.get("title"), "activity title"),
+        "description": optional_text(snippet.get("description"), "activity description"),
+        "published_at": optional_text(snippet.get("publishedAt"), "activity timestamp"),
+        "channel_id": optional_id(snippet.get("channelId"), "channel ID"),
+        "channel_title": optional_text(snippet.get("channelTitle"), "channel title"),
+        "subject_id": subject_id,
+        "subject_kind": subject_kind,
+    }

--- a/.agents/scripts/_knowledge_social_youtube_normalize.py
+++ b/.agents/scripts/_knowledge_social_youtube_normalize.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize sanitized YouTube pages into provider-neutral social records."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_youtube import (
+    API_RETENTION,
+    PROVIDER,
+    YouTubeAdapterError,
+    page_data,
+)
+from knowledge_social_import import reject_credentials
+
+
+@dataclass(frozen=True)
+class PageContext:
+    """Validated connection policy needed to normalize one YouTube page."""
+
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+@dataclass
+class NormalizedRows:
+    """Mutable normalized row sets for one bounded page."""
+
+    accounts: dict[str, dict[str, Any]]
+    objects: dict[tuple[str, str], dict[str, Any]]
+    activities: dict[tuple[str, str], dict[str, Any]]
+
+
+def observation_time(payload: dict[str, Any]) -> str:
+    value = payload.get("observed_at")
+    if not isinstance(value, str) or not value:
+        raise YouTubeAdapterError("YouTube page observed_at must be text")
+    return value
+
+
+def _required_text(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        raise YouTubeAdapterError(f"YouTube record requires {key}")
+    return value
+
+
+def _optional_text(record: dict[str, Any], key: str) -> str | None:
+    value = record.get(key)
+    if value is not None and not isinstance(value, str):
+        raise YouTubeAdapterError(f"YouTube record {key} must be text")
+    return value
+
+
+def _joined_text(record: dict[str, Any], *keys: str) -> str | None:
+    values = [_optional_text(record, key) for key in keys]
+    return "\n\n".join(value for value in values if value) or None
+
+
+def _account(
+    remote_id: str,
+    observed_at: str,
+    *,
+    handle: str | None = None,
+    display_name: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "remote_id": remote_id,
+        "handle": handle,
+        "display_name": display_name,
+        "observed_at": observed_at,
+        "provider_json": {},
+    }
+
+
+def _selected_account(account: dict[str, Any], observed_at: str) -> dict[str, Any]:
+    remote_id = account.get("id")
+    if not isinstance(remote_id, str) or not remote_id:
+        raise YouTubeAdapterError("YouTube selected account requires an ID")
+    handle = account.get("handle")
+    title = account.get("title")
+    if handle is not None and not isinstance(handle, str):
+        raise YouTubeAdapterError("YouTube selected account handle must be text")
+    if title is not None and not isinstance(title, str):
+        raise YouTubeAdapterError("YouTube selected account title must be text")
+    return _account(remote_id, observed_at, handle=handle, display_name=title)
+
+
+def _activity(
+    activity_type: str,
+    remote_id: str,
+    actor_id: str,
+    object_id: str | None,
+    observed_at: str,
+    occurred_at: str | None,
+    provider_json: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "activity_type": activity_type,
+        "remote_id": remote_id,
+        "actor_remote_id": actor_id,
+        "object_remote_id": object_id,
+        "occurred_at": occurred_at,
+        "observed_at": observed_at,
+        "state": "active",
+        "provider_json": provider_json or {},
+    }
+
+
+def _object(
+    object_type: str,
+    remote_id: str,
+    account_id: str | None,
+    text: str | None,
+    created_at: str | None,
+    observed_at: str,
+    evidence_class: str,
+    provider_json: dict[str, Any],
+) -> dict[str, Any]:
+    reject_credentials(provider_json)
+    return {
+        "object_type": object_type,
+        "remote_id": remote_id,
+        "account_remote_id": account_id,
+        "text": text,
+        "created_at": created_at,
+        "observed_at": observed_at,
+        "evidence_class": evidence_class,
+        "provider_json": provider_json,
+    }
+
+
+def _channel_reference(
+    record: dict[str, Any], rows: NormalizedRows, observed_at: str
+) -> str | None:
+    channel_id = _optional_text(record, "channel_id")
+    if channel_id is None:
+        return None
+    rows.accounts[channel_id] = _account(
+        channel_id,
+        observed_at,
+        display_name=_optional_text(record, "channel_title"),
+    )
+    return channel_id
+
+
+def _normalize_video(
+    record: dict[str, Any],
+    context: PageContext,
+    observed_at: str,
+    rows: NormalizedRows,
+) -> None:
+    remote_id = _required_text(record, "remote_id")
+    channel_id = _channel_reference(record, rows, observed_at)
+    if context.stream == "authored_videos":
+        channel_id = context.account["id"]
+        evidence_class = "authored"
+    else:
+        evidence_class = "weak_signal"
+    video = _object(
+        "video",
+        remote_id,
+        channel_id,
+        _joined_text(record, "title", "description"),
+        _optional_text(record, "published_at"),
+        observed_at,
+        evidence_class,
+        {
+            key: record[key]
+            for key in ("playlist_item_id", "position", "privacy_status")
+            if record.get(key) is not None
+        },
+    )
+    rows.objects[("video", remote_id)] = video
+    activity = _activity(
+        context.stream,
+        f"{context.account['id']}-{context.stream}-{remote_id}",
+        context.account["id"],
+        remote_id,
+        observed_at,
+        video["created_at"],
+    )
+    rows.activities[(activity["activity_type"], activity["remote_id"])] = activity
+
+
+def _normalize_playlist(
+    record: dict[str, Any],
+    context: PageContext,
+    observed_at: str,
+    rows: NormalizedRows,
+) -> None:
+    remote_id = _required_text(record, "remote_id")
+    playlist = _object(
+        "playlist",
+        remote_id,
+        context.account["id"],
+        _joined_text(record, "title", "description"),
+        _optional_text(record, "published_at"),
+        observed_at,
+        "authored",
+        {
+            key: record[key]
+            for key in ("item_count", "privacy_status")
+            if record.get(key) is not None
+        },
+    )
+    rows.objects[("playlist", remote_id)] = playlist
+    activity = _activity(
+        "owned_playlist",
+        f"{context.account['id']}-owns-{remote_id}",
+        context.account["id"],
+        remote_id,
+        observed_at,
+        playlist["created_at"],
+    )
+    rows.activities[(activity["activity_type"], activity["remote_id"])] = activity
+
+
+def _normalize_playlist_item(
+    record: dict[str, Any], observed_at: str, rows: NormalizedRows
+) -> None:
+    membership_id = _required_text(record, "remote_id")
+    playlist_id = _required_text(record, "playlist_id")
+    video_id = _required_text(record, "video_id")
+    video = _object(
+        "video",
+        video_id,
+        None,
+        _joined_text(record, "title", "description"),
+        None,
+        observed_at,
+        "observed",
+        {
+            key: record[key]
+            for key in ("privacy_status",)
+            if record.get(key) is not None
+        },
+    )
+    rows.objects[("video", video_id)] = video
+    membership = _activity(
+        "playlist_membership",
+        membership_id,
+        playlist_id,
+        video_id,
+        observed_at,
+        _optional_text(record, "published_at"),
+        {"position": record.get("position")},
+    )
+    rows.activities[(membership["activity_type"], membership_id)] = membership
+
+
+def _normalize_subscription(
+    record: dict[str, Any],
+    context: PageContext,
+    observed_at: str,
+    rows: NormalizedRows,
+) -> None:
+    remote_id = _required_text(record, "remote_id")
+    subscriber_id = _required_text(record, "subscriber_channel_id")
+    target_id = _required_text(record, "subscribed_channel_id")
+    if subscriber_id != context.account["id"]:
+        raise YouTubeAdapterError("YouTube subscription direction is invalid")
+    rows.accounts[target_id] = _account(
+        target_id,
+        observed_at,
+        display_name=_optional_text(record, "title"),
+    )
+    activity = _activity(
+        "subscription",
+        remote_id,
+        subscriber_id,
+        target_id,
+        observed_at,
+        _optional_text(record, "published_at"),
+        {"direction": "selected_account_to_subscribed_channel"},
+    )
+    rows.activities[(activity["activity_type"], remote_id)] = activity
+
+
+def _comment_author(
+    record: dict[str, Any], observed_at: str, rows: NormalizedRows
+) -> str:
+    author_id = _optional_text(record, "author_channel_id")
+    if author_id is None:
+        digest = hashlib.sha256(_required_text(record, "remote_id").encode()).hexdigest()
+        author_id = f"unknown_comment_author_{digest}"
+    rows.accounts[author_id] = _account(
+        author_id,
+        observed_at,
+        display_name=_optional_text(record, "author_display_name"),
+    )
+    return author_id
+
+
+def _normalize_comment(
+    record: dict[str, Any],
+    context: PageContext,
+    observed_at: str,
+    rows: NormalizedRows,
+) -> None:
+    remote_id = _required_text(record, "remote_id")
+    parent_id = _optional_text(record, "parent_id")
+    author_id = _comment_author(record, observed_at, rows)
+    comment = _object(
+        "comment",
+        remote_id,
+        author_id,
+        _optional_text(record, "text"),
+        _optional_text(record, "published_at"),
+        observed_at,
+        "authored" if author_id == context.account["id"] else "observed",
+        {
+            key: record[key]
+            for key in ("parent_id", "video_id", "channel_id", "updated_at")
+            if record.get(key) is not None
+        },
+    )
+    rows.objects[("comment", remote_id)] = comment
+    activity_type = "comment_reply" if parent_id else "comment"
+    activity = _activity(
+        activity_type,
+        remote_id,
+        author_id,
+        remote_id,
+        observed_at,
+        comment["created_at"],
+        {"parent_id": parent_id} if parent_id else {},
+    )
+    rows.activities[(activity_type, remote_id)] = activity
+
+
+def _normalize_activity(
+    record: dict[str, Any],
+    context: PageContext,
+    observed_at: str,
+    rows: NormalizedRows,
+) -> None:
+    remote_id = _required_text(record, "remote_id")
+    value = _object(
+        "activity",
+        remote_id,
+        context.account["id"],
+        _joined_text(record, "title", "description"),
+        _optional_text(record, "published_at"),
+        observed_at,
+        "observed",
+        {
+            key: record[key]
+            for key in ("activity_type", "subject_id", "subject_kind")
+            if record.get(key) is not None
+        },
+    )
+    rows.objects[("activity", remote_id)] = value
+    activity = _activity(
+        "channel_activity",
+        remote_id,
+        context.account["id"],
+        remote_id,
+        observed_at,
+        value["created_at"],
+        {"provider_activity_type": record.get("activity_type")},
+    )
+    rows.activities[("channel_activity", remote_id)] = activity
+
+
+def _gap_coverage(observed_at: str) -> list[dict[str, Any]]:
+    gaps = {
+        "watch_history": "youtube_data_api_watch_history_not_accessible_export_unverified",
+        "watch_later": "youtube_data_api_watch_later_not_accessible_export_unverified",
+        "saved_playlists": "youtube_data_api_saved_playlists_not_listable_export_unverified",
+        "authored_comments_elsewhere": "youtube_data_api_has_no_complete_account_comment_history",
+    }
+    return [
+        {
+            "stream": stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": API_RETENTION,
+            "unavailable_reason": reason,
+            "status": "unavailable",
+            "observed_at": observed_at,
+        }
+        for stream, reason in gaps.items()
+    ]
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    """Validate one successful YouTube page and build provider-neutral rows."""
+    reject_credentials(payload)
+    observed_at = observation_time(payload)
+    rows = NormalizedRows({}, {}, {})
+    selected = _selected_account(context.account, observed_at)
+    rows.accounts[selected["remote_id"]] = selected
+    for item in page_data(payload):
+        reject_credentials(item)
+        kind = item.get("kind")
+        if kind == "video":
+            _normalize_video(item, context, observed_at, rows)
+        elif kind == "playlist":
+            _normalize_playlist(item, context, observed_at, rows)
+        elif kind == "playlist_item":
+            _normalize_playlist_item(item, observed_at, rows)
+        elif kind == "subscription":
+            _normalize_subscription(item, context, observed_at, rows)
+        elif kind == "comment":
+            _normalize_comment(item, context, observed_at, rows)
+        elif kind == "activity":
+            _normalize_activity(item, context, observed_at, rows)
+        else:
+            raise YouTubeAdapterError("YouTube page contains an unsupported item kind")
+    return {
+        "provider": PROVIDER,
+        "connection_id": context.connection_id,
+        "remote_account_id": context.account["id"],
+        "exported_at": observed_at,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": context.policy,
+        "accounts": list(rows.accounts.values()),
+        "objects": list(rows.objects.values()),
+        "activities": list(rows.activities.values()),
+        "media": [],
+        "coverage": _gap_coverage(observed_at),
+    }

--- a/.agents/scripts/_knowledge_social_youtube_provider.py
+++ b/.agents/scripts/_knowledge_social_youtube_provider.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded read-only OAuth subprocess for YouTube account collection."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import sys
+import time
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from _knowledge_social_youtube_contract import (
+    ApiResult,
+    YouTubeReadProviderError,
+    exact_keys,
+    identity_value,
+    observed_at,
+    stable_id,
+    terminal_payload,
+)
+from _knowledge_social_youtube_routes import READ_ENDPOINTS, page, page_request
+
+API_BASE = "https://www.googleapis.com/youtube/v3"
+MAX_REQUEST_BYTES = 32 * 1024
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+HTTP_TIMEOUT_SECONDS = 60
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+UrlOpen = Callable[..., Any]
+
+
+def _profile_prefix(profile: str) -> str:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise YouTubeReadProviderError("YouTube OAuth profile name is invalid")
+    return f"YOUTUBE_{profile.upper()}"
+
+
+def _access_token(profile: str) -> str:
+    token = os.environ.get(f"{_profile_prefix(profile)}_ACCESS_TOKEN", "")
+    if not token or "\x00" in token or len(token.encode("utf-8")) > 16 * 1024:
+        raise YouTubeReadProviderError(
+            "YouTube OAuth profile access token is missing"
+        )
+    return token
+
+
+def _http_exports() -> UrlOpen:
+    if not callable(Request) or not callable(urlopen) or not callable(urlencode):
+        raise YouTubeReadProviderError("Python urllib HTTP exports are unavailable")
+    return urlopen
+
+
+def _request() -> dict[str, Any]:
+    payload = sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1)
+    if len(payload) > MAX_REQUEST_BYTES:
+        raise YouTubeReadProviderError("YouTube read request exceeds the safety limit")
+    try:
+        request = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise YouTubeReadProviderError("YouTube read request is not valid JSON") from error
+    if not isinstance(request, dict):
+        raise YouTubeReadProviderError("YouTube read request root must be an object")
+    return request
+
+
+def _retry_epoch(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    return int(time.time() + math.ceil(seconds))
+
+
+def _decode_response(payload: bytes) -> dict[str, Any]:
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise YouTubeReadProviderError("YouTube read response exceeds the safety limit")
+    try:
+        decoded = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise YouTubeReadProviderError(
+            "YouTube read provider returned no valid JSON"
+        ) from error
+    if not isinstance(decoded, dict):
+        raise YouTubeReadProviderError("YouTube API response root must be an object")
+    return decoded
+
+
+def _api(token: str, opener: UrlOpen, endpoint: str, params: dict[str, str]) -> ApiResult:
+    if endpoint not in READ_ENDPOINTS:
+        raise YouTubeReadProviderError("YouTube API endpoint is not allowlisted")
+    url = f"{API_BASE}/{endpoint}?{urlencode(params)}"
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "aidevops-youtube-knowledge/1",
+        },
+        method="GET",
+    )
+    try:
+        with opener(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", 200)
+            if isinstance(status, bool) or not isinstance(status, int):
+                raise YouTubeReadProviderError("YouTube HTTP status is invalid")
+            payload = response.read(MAX_RESPONSE_BYTES + 1)
+            if not isinstance(payload, bytes):
+                raise YouTubeReadProviderError("YouTube HTTP response is invalid")
+            return ApiResult(status, _decode_response(payload))
+    except HTTPError as error:
+        status = error.code
+        if isinstance(status, bool) or not isinstance(status, int):
+            raise YouTubeReadProviderError("YouTube HTTP status is invalid") from error
+        retry_after = _retry_epoch(error.headers.get("Retry-After"))
+        return ApiResult(status, {}, retry_after)
+    except (TimeoutError, URLError, OSError) as error:
+        raise YouTubeReadProviderError("YouTube read provider request failed") from error
+
+
+def _identity(
+    api: Callable[[str, dict[str, str]], ApiResult], expected_id: str
+) -> dict[str, Any]:
+    result = api(
+        "channels",
+        {
+            "part": "id,snippet,contentDetails",
+            "mine": "true",
+            "maxResults": "50",
+        },
+    )
+    if result.status != 200:
+        return terminal_payload(result)
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": identity_value(result.payload, expected_id),
+    }
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode("utf-8")) > MAX_RESPONSE_BYTES:
+        raise YouTubeReadProviderError("YouTube read response exceeds the safety limit")
+    print(encoded)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        raw_request = _request()
+        action = raw_request.get("action")
+        if action not in ("identity", "page"):
+            raise YouTubeReadProviderError("YouTube read action is unsupported")
+        token = _access_token(args.profile)
+        opener = _http_exports()
+        api = lambda endpoint, params: _api(token, opener, endpoint, params)
+        if action == "identity":
+            exact_keys(raw_request, {"action", "account_id"})
+            expected_id = stable_id(raw_request.get("account_id"), "account ID")
+            payload = _identity(api, expected_id)
+        else:
+            request = page_request(raw_request)
+            identity = _identity(api, request.account_id)
+            if identity.get("status") != 200:
+                payload = identity
+            else:
+                data = identity.get("data")
+                if not isinstance(data, dict):
+                    raise YouTubeReadProviderError(
+                        "YouTube account verification returned no channel"
+                    )
+                if data.get("uploads_playlist_id") != request.uploads_playlist_id:
+                    raise YouTubeReadProviderError(
+                        "selected YouTube channel does not match the configured connection"
+                    )
+                payload = page(api, request)
+        _emit(payload)
+        return 0
+    except YouTubeReadProviderError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - intentionally redact provider internals
+        print("ERROR: YouTube read provider request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_youtube_reader.py
+++ b/.agents/scripts/_knowledge_social_youtube_reader.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and fixture readers for the read-only YouTube adapter."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Protocol
+
+from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_youtube import (
+    PageRequest,
+    YouTubeAdapterError,
+    YouTubeProviderUnavailableError,
+    youtube_id,
+)
+from knowledge_social_import import canonical_json, reject_credentials
+
+READ_TIMEOUT_SECONDS = 120
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+SAFE_PROVIDER_FAILURES = (
+    "Python urllib HTTP exports are unavailable",
+    "YouTube OAuth profile access token is missing",
+    "YouTube OAuth profile name is invalid",
+    "selected YouTube channel does not match the configured connection",
+)
+
+
+class YouTubeReader(Protocol):
+    """Minimal read-only provider surface used by YouTube collection."""
+
+    def identity(self, expected_id: str) -> dict[str, Any]: ...
+
+    def page(self, request: PageRequest) -> dict[str, Any]: ...
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    if len(output.encode("utf-8")) > MAX_RESPONSE_BYTES:
+        raise YouTubeAdapterError("YouTube read response exceeds the safety limit")
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise YouTubeAdapterError("YouTube read provider returned no valid JSON") from error
+    if not isinstance(payload, dict):
+        raise YouTubeAdapterError("YouTube read response root must be an object")
+    return payload
+
+
+def _provider_failure(stderr: str) -> YouTubeProviderUnavailableError:
+    for message in SAFE_PROVIDER_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return YouTubeProviderUnavailableError(message)
+    return YouTubeProviderUnavailableError("YouTube read provider is unavailable")
+
+
+class GuardedYouTubeOAuth:
+    """Execute only identity and allowlisted page reads in a bounded child."""
+
+    def __init__(self, helper: Path, profile: str) -> None:
+        if PROFILE_NAME.fullmatch(profile) is None:
+            raise YouTubeProviderUnavailableError("YouTube OAuth profile name is invalid")
+        if helper.is_symlink() or not helper.is_file():
+            raise YouTubeProviderUnavailableError("YouTube read provider is unavailable")
+        self.helper = helper
+        self.profile = profile
+
+    def _environment(self) -> dict[str, str]:
+        token_name = f"YOUTUBE_{self.profile.upper()}_ACCESS_TOKEN"
+        inherited = {
+            "HOME",
+            "HTTPS_PROXY",
+            "HTTP_PROXY",
+            "LANG",
+            "LC_ALL",
+            "NO_PROXY",
+            "PATH",
+            "REQUESTS_CA_BUNDLE",
+            "SSL_CERT_FILE",
+            "TMPDIR",
+            "https_proxy",
+            "http_proxy",
+            "no_proxy",
+        }
+        environment = {
+            key: value
+            for key, value in os.environ.items()
+            if key in inherited or key == token_name
+        }
+        if os.environ.get("AIDEVOPS_TEST_MODE") == "1":
+            for key in (
+                "AIDEVOPS_TEST_MODE",
+                "PYTHONPATH",
+                "YOUTUBE_READ_LOG",
+            ):
+                if key in os.environ:
+                    environment[key] = os.environ[key]
+        return environment
+
+    def _run(self, request: dict[str, Any]) -> dict[str, Any]:
+        try:
+            completed = subprocess.run(  # nosec B603 -- fixed helper and fixed argv
+                [sys.executable, str(self.helper), "--profile", self.profile],
+                check=False,
+                capture_output=True,
+                input=canonical_json(request),
+                env=self._environment(),
+                shell=False,
+                text=True,
+                timeout=READ_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise YouTubeProviderUnavailableError(
+                "YouTube read provider timed out"
+            ) from error
+        except OSError as error:
+            raise YouTubeProviderUnavailableError(
+                "YouTube read provider is unavailable"
+            ) from error
+        if completed.returncode != 0:
+            raise _provider_failure(completed.stderr)
+        return _decode_output(completed.stdout)
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        return self._run({"action": "identity", "account_id": expected_id})
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        return self._run(request.payload())
+
+
+def _fixture_page(entry: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    expectation = entry.get("expect_request", {})
+    if not isinstance(expectation, dict):
+        raise YouTubeAdapterError("YouTube fixture request expectation must be an object")
+    actual = request.payload()
+    if any(actual.get(key) != value for key, value in expectation.items()):
+        raise YouTubeAdapterError(
+            "YouTube request did not resume at the expected checkpoint"
+        )
+    response = entry.get("response", entry)
+    if not isinstance(response, dict):
+        raise YouTubeAdapterError("YouTube fixture page response must be an object")
+    return response
+
+
+class FixtureYouTube:
+    """Deterministic OAuth substitute for pagination and failure fixtures."""
+
+    def __init__(self, path: Path) -> None:
+        self.fixture = FixtureSequence(path, "YouTube", YouTubeAdapterError)
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        del expected_id
+        return self.fixture.identity()
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        return _fixture_page(self.fixture.next_page(), request)
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    """Validate OAuth identity without allowing credential-shaped fields through."""
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise YouTubeAdapterError("YouTube account verification returned no channel")
+    remote_id = youtube_id(data.get("id"), "account ID")
+    uploads_id = youtube_id(data.get("uploads_playlist_id"), "uploads playlist ID")
+    title = data.get("title")
+    handle = data.get("handle")
+    if title is not None and (not isinstance(title, str) or not title):
+        raise YouTubeAdapterError("YouTube channel title must be text")
+    if handle is not None and (not isinstance(handle, str) or not handle):
+        raise YouTubeAdapterError("YouTube channel handle must be text")
+    if remote_id != expected_id:
+        raise YouTubeAdapterError(
+            "selected YouTube channel does not match the configured connection"
+        )
+    return {
+        "id": remote_id,
+        "uploads_playlist_id": uploads_id,
+        "title": title,
+        "handle": handle,
+    }

--- a/.agents/scripts/_knowledge_social_youtube_routes.py
+++ b/.agents/scripts/_knowledge_social_youtube_routes.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Allowlisted YouTube Data API v3 read routes and page construction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from _knowledge_social_youtube_contract import (
+    ApiResult,
+    YouTubeReadProviderError,
+    exact_keys,
+    next_page_token,
+    observed_at,
+    optional_text,
+    response_items,
+    serialize_activity,
+    serialize_comment,
+    serialize_comment_thread,
+    serialize_playlist,
+    serialize_playlist_item,
+    serialize_subscription,
+    serialize_uploaded_video,
+    serialize_video,
+    stable_id,
+    terminal_payload,
+)
+
+ApiCall = Callable[[str, dict[str, str]], ApiResult]
+READ_ENDPOINTS = {
+    "activities",
+    "channels",
+    "comments",
+    "commentThreads",
+    "playlistItems",
+    "playlists",
+    "subscriptions",
+    "videos",
+}
+STREAMS = {
+    "authored_videos",
+    "channel_activity",
+    "owned_playlists",
+    "subscriptions",
+    "comments",
+    "liked_videos",
+}
+
+
+@dataclass(frozen=True)
+class ProviderPageRequest:
+    """Validated request fields for one bounded provider page."""
+
+    stream: str
+    account_id: str
+    uploads_playlist_id: str
+    cursor: dict[str, Any] | None
+    stop_at: str | None
+    limit: int
+
+
+def page_request(request: dict[str, Any]) -> ProviderPageRequest:
+    """Validate the complete parent-to-child page request."""
+    exact_keys(
+        request,
+        {
+            "action",
+            "stream",
+            "account_id",
+            "uploads_playlist_id",
+            "cursor",
+            "stop_at",
+            "limit",
+        },
+    )
+    stream = request.get("stream")
+    cursor = request.get("cursor")
+    limit = request.get("limit")
+    if not isinstance(stream, str) or stream not in STREAMS:
+        raise YouTubeReadProviderError("YouTube read stream is unsupported")
+    if cursor is not None and not isinstance(cursor, dict):
+        raise YouTubeReadProviderError("YouTube read cursor must be an object")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 50:
+        raise YouTubeReadProviderError(
+            "YouTube read limit must be between 1 and 50"
+        )
+    return ProviderPageRequest(
+        stream,
+        stable_id(request.get("account_id"), "account ID"),
+        stable_id(request.get("uploads_playlist_id"), "uploads playlist ID"),
+        cursor,
+        stable_id(request["stop_at"], "watermark")
+        if request.get("stop_at") is not None
+        else None,
+        limit,
+    )
+
+
+def _token(cursor: dict[str, Any] | None) -> str | None:
+    if cursor is None:
+        return None
+    if set(cursor) != {"page_token"}:
+        raise YouTubeReadProviderError("YouTube page cursor has an invalid shape")
+    token = optional_text(cursor.get("page_token"), "page token")
+    if not token:
+        raise YouTubeReadProviderError("YouTube page cursor is empty")
+    return token
+
+
+def _params(**values: str | int | None) -> dict[str, str]:
+    return {key: str(value) for key, value in values.items() if value is not None}
+
+
+def _meta(
+    next_cursor: dict[str, Any] | None,
+    newest_id: str | None,
+    reached: bool,
+    *,
+    snapshot: bool,
+) -> dict[str, Any]:
+    return {
+        "next_cursor": next_cursor,
+        "newest_id": newest_id,
+        "reached_watermark": reached,
+        "complete": reached or next_cursor is None,
+        "snapshot": snapshot,
+    }
+
+
+def _success(
+    data: list[dict[str, Any]], meta: dict[str, Any]
+) -> dict[str, Any]:
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": data,
+        "meta": meta,
+    }
+
+
+def _listed_records(
+    records: list[dict[str, Any]], stop_at: str | None
+) -> tuple[list[dict[str, Any]], str | None, bool]:
+    newest = records[0].get("remote_id") if records else None
+    if newest is not None:
+        newest = stable_id(newest, "newest resource ID")
+    accepted: list[dict[str, Any]] = []
+    reached = False
+    for record in records:
+        if stop_at is not None and record.get("remote_id") == stop_at:
+            reached = True
+            break
+        accepted.append(record)
+    return accepted, newest, reached
+
+
+def _simple_page(
+    api: ApiCall,
+    request: ProviderPageRequest,
+    endpoint: str,
+    params: dict[str, str],
+    serializer: Callable[[dict[str, Any]], dict[str, Any]],
+    *,
+    incremental: bool,
+) -> dict[str, Any]:
+    page_token = _token(request.cursor)
+    if page_token is not None:
+        params["pageToken"] = page_token
+    result = api(endpoint, params)
+    if result.status != 200:
+        return terminal_payload(result)
+    records = [serializer(item) for item in response_items(result.payload)]
+    records, newest, reached = _listed_records(
+        records, request.stop_at if incremental else None
+    )
+    provider_next = next_page_token(result.payload)
+    next_cursor = (
+        {"page_token": provider_next}
+        if provider_next is not None and not reached
+        else None
+    )
+    return _success(
+        records,
+        _meta(next_cursor, newest, reached, snapshot=not incremental),
+    )
+
+
+def _authored_videos(api: ApiCall, request: ProviderPageRequest) -> dict[str, Any]:
+    return _simple_page(
+        api,
+        request,
+        "playlistItems",
+        _params(
+            part="snippet,contentDetails,status",
+            playlistId=request.uploads_playlist_id,
+            maxResults=request.limit,
+        ),
+        serialize_uploaded_video,
+        incremental=True,
+    )
+
+
+def _channel_activity(api: ApiCall, request: ProviderPageRequest) -> dict[str, Any]:
+    return _simple_page(
+        api,
+        request,
+        "activities",
+        _params(part="snippet,contentDetails", mine="true", maxResults=request.limit),
+        serialize_activity,
+        incremental=True,
+    )
+
+
+def _subscriptions(api: ApiCall, request: ProviderPageRequest) -> dict[str, Any]:
+    return _simple_page(
+        api,
+        request,
+        "subscriptions",
+        _params(part="snippet,contentDetails", mine="true", maxResults=request.limit),
+        serialize_subscription,
+        incremental=False,
+    )
+
+
+def _liked_videos(api: ApiCall, request: ProviderPageRequest) -> dict[str, Any]:
+    return _simple_page(
+        api,
+        request,
+        "videos",
+        _params(part="id,snippet,status", myRating="like", maxResults=request.limit),
+        serialize_video,
+        incremental=False,
+    )
+
+
+def _phase(cursor: dict[str, Any], expected: set[str]) -> None:
+    if set(cursor) != expected:
+        raise YouTubeReadProviderError("YouTube compound cursor has an invalid shape")
+
+
+def _owned_playlist_page(
+    api: ApiCall,
+    request: ProviderPageRequest,
+    page_token: str | None,
+) -> dict[str, Any]:
+    result = api(
+        "playlists",
+        _params(
+            part="id,snippet,contentDetails,status",
+            mine="true",
+            maxResults=1,
+            pageToken=page_token,
+        ),
+    )
+    if result.status != 200:
+        return terminal_payload(result)
+    items = response_items(result.payload)
+    if not items:
+        return _success([], _meta(None, None, False, snapshot=True))
+    playlist = serialize_playlist(items[0])
+    provider_next = next_page_token(result.payload)
+    if playlist["item_count"] > 0:
+        next_cursor = {
+            "phase": "items",
+            "playlist_id": playlist["remote_id"],
+            "item_token": None,
+            "playlists_token": provider_next,
+        }
+    elif provider_next is not None:
+        next_cursor = {"phase": "playlists", "page_token": provider_next}
+    else:
+        next_cursor = None
+    return _success([playlist], _meta(next_cursor, None, False, snapshot=True))
+
+
+def _owned_playlist_items(
+    api: ApiCall,
+    request: ProviderPageRequest,
+    cursor: dict[str, Any],
+) -> dict[str, Any]:
+    _phase(
+        cursor,
+        {"phase", "playlist_id", "item_token", "playlists_token"},
+    )
+    playlist_id = stable_id(cursor.get("playlist_id"), "playlist ID")
+    item_token = optional_text(cursor.get("item_token"), "playlist item token")
+    playlists_token = optional_text(
+        cursor.get("playlists_token"), "playlists page token"
+    )
+    result = api(
+        "playlistItems",
+        _params(
+            part="snippet,contentDetails,status",
+            playlistId=playlist_id,
+            maxResults=request.limit,
+            pageToken=item_token,
+        ),
+    )
+    if result.status != 200:
+        return terminal_payload(result)
+    records = [
+        serialize_playlist_item(item, playlist_id)
+        for item in response_items(result.payload)
+    ]
+    provider_next = next_page_token(result.payload)
+    if provider_next is not None:
+        next_cursor = {
+            "phase": "items",
+            "playlist_id": playlist_id,
+            "item_token": provider_next,
+            "playlists_token": playlists_token,
+        }
+    elif playlists_token is not None:
+        next_cursor = {"phase": "playlists", "page_token": playlists_token}
+    else:
+        next_cursor = None
+    return _success(records, _meta(next_cursor, None, False, snapshot=True))
+
+
+def _owned_playlists(api: ApiCall, request: ProviderPageRequest) -> dict[str, Any]:
+    cursor = request.cursor
+    if cursor is None:
+        return _owned_playlist_page(api, request, None)
+    phase = cursor.get("phase")
+    if phase == "playlists":
+        _phase(cursor, {"phase", "page_token"})
+        token = optional_text(cursor.get("page_token"), "playlists page token")
+        if not token:
+            raise YouTubeReadProviderError("YouTube playlists cursor is empty")
+        return _owned_playlist_page(api, request, token)
+    if phase == "items":
+        return _owned_playlist_items(api, request, cursor)
+    raise YouTubeReadProviderError("YouTube playlists cursor phase is invalid")
+
+
+def _comment_thread_page(
+    api: ApiCall,
+    request: ProviderPageRequest,
+    page_token: str | None,
+) -> dict[str, Any]:
+    result = api(
+        "commentThreads",
+        _params(
+            part="snippet",
+            allThreadsRelatedToChannelId=request.account_id,
+            maxResults=1,
+            pageToken=page_token,
+        ),
+    )
+    if result.status != 200:
+        return terminal_payload(result)
+    items = response_items(result.payload)
+    if not items:
+        return _success([], _meta(None, None, False, snapshot=False))
+    comment, reply_count = serialize_comment_thread(items[0])
+    newest = comment["remote_id"]
+    if request.stop_at is not None and newest == request.stop_at:
+        return _success([], _meta(None, newest, True, snapshot=False))
+    threads_token = next_page_token(result.payload)
+    if reply_count > 0:
+        next_cursor = {
+            "phase": "replies",
+            "parent_id": newest,
+            "reply_token": None,
+            "threads_token": threads_token,
+        }
+    elif threads_token is not None:
+        next_cursor = {"phase": "threads", "page_token": threads_token}
+    else:
+        next_cursor = None
+    return _success([comment], _meta(next_cursor, newest, False, snapshot=False))
+
+
+def _comment_replies(
+    api: ApiCall,
+    request: ProviderPageRequest,
+    cursor: dict[str, Any],
+) -> dict[str, Any]:
+    _phase(cursor, {"phase", "parent_id", "reply_token", "threads_token"})
+    parent_id = stable_id(cursor.get("parent_id"), "parent comment ID")
+    reply_token = optional_text(cursor.get("reply_token"), "reply page token")
+    threads_token = optional_text(cursor.get("threads_token"), "threads page token")
+    result = api(
+        "comments",
+        _params(
+            part="snippet",
+            parentId=parent_id,
+            maxResults=request.limit,
+            pageToken=reply_token,
+        ),
+    )
+    if result.status != 200:
+        return terminal_payload(result)
+    records = [
+        serialize_comment(item, parent_id) for item in response_items(result.payload)
+    ]
+    provider_next = next_page_token(result.payload)
+    if provider_next is not None:
+        next_cursor = {
+            "phase": "replies",
+            "parent_id": parent_id,
+            "reply_token": provider_next,
+            "threads_token": threads_token,
+        }
+    elif threads_token is not None:
+        next_cursor = {"phase": "threads", "page_token": threads_token}
+    else:
+        next_cursor = None
+    return _success(records, _meta(next_cursor, None, False, snapshot=False))
+
+
+def _comments(api: ApiCall, request: ProviderPageRequest) -> dict[str, Any]:
+    cursor = request.cursor
+    if cursor is None:
+        return _comment_thread_page(api, request, None)
+    phase = cursor.get("phase")
+    if phase == "threads":
+        _phase(cursor, {"phase", "page_token"})
+        token = optional_text(cursor.get("page_token"), "threads page token")
+        if not token:
+            raise YouTubeReadProviderError("YouTube comments cursor is empty")
+        return _comment_thread_page(api, request, token)
+    if phase == "replies":
+        return _comment_replies(api, request, cursor)
+    raise YouTubeReadProviderError("YouTube comments cursor phase is invalid")
+
+
+ROUTES: dict[
+    str, Callable[[ApiCall, ProviderPageRequest], dict[str, Any]]
+] = {
+    "authored_videos": _authored_videos,
+    "channel_activity": _channel_activity,
+    "owned_playlists": _owned_playlists,
+    "subscriptions": _subscriptions,
+    "comments": _comments,
+    "liked_videos": _liked_videos,
+}
+
+
+def page(
+    api: ApiCall,
+    request: ProviderPageRequest,
+) -> dict[str, Any]:
+    """Execute exactly one allowlisted YouTube list request."""
+    route = ROUTES.get(request.stream)
+    if route is None:
+        raise YouTubeReadProviderError("YouTube read stream is unsupported")
+    return route(api, request)

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -9,6 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PYTHON_HELPER="${SCRIPT_DIR}/knowledge_social_import.py"
 X_HELPER="${SCRIPT_DIR}/knowledge_social_x.py"
 REDDIT_HELPER="${SCRIPT_DIR}/knowledge_social_reddit.py"
+YOUTUBE_HELPER="${SCRIPT_DIR}/knowledge_social_youtube.py"
 QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
 SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
 SHARE_HELPER="${SCRIPT_DIR}/knowledge_social_share.py"
@@ -67,6 +68,14 @@ Reddit synchronization:
   snapshots have a hard 1000-item safety limit. --budget permits 1-1000 request
   units. Collection is read-only and cannot invoke the approval-bound write path.
 
+YouTube synchronization:
+  sync-youtube verifies an OAuth user-owned channel, then reads one allowlisted
+  stream: authored_videos, channel_activity, owned_playlists, subscriptions,
+  comments, or liked_videos. The initial identity request costs one quota unit;
+  every page reserves two more units for account rebinding defence plus one list
+  read. --budget is a hard 1-1000 unit limit and --page-size is 1-50 items.
+  Collection uses youtube.readonly user OAuth and never the service-account helper.
+
 EOF
 	return 0
 }
@@ -89,6 +98,10 @@ Usage:
   knowledge-social-helper.sh sync-reddit [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id ID --stream STREAM --profile PROFILE \
     [--budget UNITS] [--page-size 1-100] [--collector-id ID] \
+    [--lease-seconds SECONDS]
+  knowledge-social-helper.sh sync-youtube [--base PATH] [--alias ALIAS] \
+    --connection-id ID --account-id CHANNEL_ID --stream STREAM --profile PROFILE \
+    [--budget UNITS] [--page-size 1-50] [--collector-id ID] \
     [--lease-seconds SECONDS]
   knowledge-social-helper.sh sync-due [--base PATH] [--alias ALIAS] \
     [--now-epoch EPOCH] [--interval-seconds SECONDS]
@@ -247,6 +260,14 @@ main() {
 			return 1
 		fi
 		python3 "$REDDIT_HELPER" "$@" || return 1
+		;;
+	sync-youtube)
+		require_runtime || return 1
+		if [[ ! -r "$YOUTUBE_HELPER" ]]; then
+			printf 'ERROR: YouTube social adapter missing: %s\n' "$YOUTUBE_HELPER" >&2
+			return 1
+		fi
+		python3 "$YOUTUBE_HELPER" "$@" || return 1
 		;;
 	query | annotate)
 		require_runtime || return 1

--- a/.agents/scripts/knowledge_social_youtube.py
+++ b/.agents/scripts/knowledge_social_youtube.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one read-only OAuth YouTube account stream into a social corpus."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import subprocess
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+from _knowledge_social_collect import (
+    CollectionContext,
+    CollectionProgress,
+    ContextRequest,
+    CursorState,
+    SuccessfulPage,
+    TerminalDecision,
+    terminal_decision_for_status,
+)
+from _knowledge_social_collect_cli import run_collector
+from _knowledge_social_collect_persist import (
+    persist_page,
+    record_bounded_stop,
+    record_terminal,
+)
+from _knowledge_social_collect_state import load_context
+from _knowledge_social_lease import (
+    RunLeaseRequest,
+    SocialLeaseLostError,
+    acquire_run_lease,
+    fail_active_run,
+    release_run_lease,
+    renew_run_lease,
+)
+from _knowledge_social_youtube import (
+    PROVIDER,
+    STREAMS,
+    PageRequest,
+    YouTubeAdapterError,
+    YouTubeProviderUnavailableError,
+    page_checkpoint,
+    page_request,
+    response_status,
+)
+from _knowledge_social_youtube_normalize import PageContext, normalize_page
+from _knowledge_social_youtube_reader import (
+    FixtureYouTube,
+    GuardedYouTubeOAuth,
+    YouTubeReader,
+    verified_identity,
+)
+from knowledge_corpus_catalog import DEFAULT_ALIAS
+from knowledge_social_import import reject_credentials
+from knowledge_social_store import validate_opaque
+
+IDENTITY_COST_UNITS = 1
+
+
+def youtube_runner(args: argparse.Namespace) -> YouTubeReader:
+    """Select the guarded OAuth reader or a test-only fixture reader."""
+    if args.fixture and os.environ.get("AIDEVOPS_TEST_MODE") != "1":
+        raise YouTubeAdapterError("YouTube fixtures are disabled outside the test harness")
+    if args.fixture:
+        return FixtureYouTube(args.fixture)
+    helper = Path(__file__).with_name("_knowledge_social_youtube_provider.py")
+    return GuardedYouTubeOAuth(helper, args.profile)
+
+
+def terminal_decision(payload: dict[str, Any]) -> TerminalDecision | None:
+    """Map terminal provider status codes to sanitized local run states."""
+    return terminal_decision_for_status(response_status(payload))
+
+
+def _page_context(context: CollectionContext) -> PageContext:
+    return PageContext(
+        context.connection_id,
+        context.account,
+        context.stream,
+        context.config.enabled_streams,
+        context.config.policy,
+    )
+
+
+def _result(
+    status: str,
+    progress: CollectionProgress,
+    **extra: Any,
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "pages": progress.pages,
+        "resources": progress.resources,
+        "budget_units": progress.budget_units,
+        **extra,
+    }
+
+
+def _terminal_result(
+    context: CollectionContext,
+    payload: dict[str, Any],
+    request: PageRequest,
+    decision: TerminalDecision,
+    progress: CollectionProgress,
+) -> dict[str, Any]:
+    retry_after = record_terminal(
+        context, payload, request.evidence_key(), decision
+    )
+    stopped = CollectionProgress(
+        progress.pages,
+        progress.resources,
+        progress.budget_units + context.spec.cost_units,
+    )
+    return _result(
+        decision.output_status,
+        stopped,
+        failure_class=decision.failure_class,
+        retry_after=retry_after,
+        run_id=context.lease.run_id if context.lease else None,
+    )
+
+
+def _persist_success(
+    context: CollectionContext,
+    payload: dict[str, Any],
+    request: PageRequest,
+) -> tuple[CollectionContext, int, bool]:
+    checkpoint, complete = page_checkpoint(payload, context.state, request)
+    archive = normalize_page(payload, _page_context(context))
+    page = SuccessfulPage(
+        payload,
+        request.evidence_key(),
+        archive,
+        checkpoint,
+        complete,
+        context.spec.cost_units,
+        retention_limit=context.spec.retention_limit,
+        unavailable_reason=context.spec.unavailable_reason,
+        coverage_status=context.spec.coverage_status,
+    )
+    resources = persist_page(context, page)
+    state = CursorState(checkpoint.next_cursor, checkpoint.watermark, complete)
+    return replace(context, state=state), resources, complete
+
+
+def collect_pages(
+    args: argparse.Namespace, runner: YouTubeReader, initial: CollectionContext
+) -> dict[str, Any]:
+    """Collect successful YouTube pages until completion, failure, or budget stop."""
+    context = initial
+    progress = CollectionProgress(budget_units=IDENTITY_COST_UNITS)
+    while progress.budget_units + context.spec.cost_units <= args.budget:
+        if context.lease is None:
+            raise YouTubeAdapterError("YouTube collection requires a collector lease")
+        context = replace(
+            context,
+            lease=renew_run_lease(
+                context.root, context.lease, args.lease_seconds
+            ),
+        )
+        request = page_request(
+            context.stream,
+            context.account,
+            context.state,
+            args.page_size,
+        )
+        payload = runner.page(request)
+        reject_credentials(payload)
+        decision = terminal_decision(payload)
+        if decision:
+            return _terminal_result(context, payload, request, decision, progress)
+        context, resources, complete = _persist_success(context, payload, request)
+        progress = progress.advance(resources, context.spec.cost_units)
+        if complete:
+            return _result(
+                "complete",
+                progress,
+                run_id=context.lease.run_id if context.lease else None,
+            )
+    record_bounded_stop(context, "paused", "budget")
+    return _result(
+        "budget_exhausted",
+        progress,
+        run_id=context.lease.run_id if context.lease else None,
+    )
+
+
+def _failure_class(error: Exception) -> str:
+    if isinstance(error, YouTubeProviderUnavailableError):
+        return "provider"
+    if isinstance(error, YouTubeAdapterError):
+        return "validation"
+    if isinstance(error, sqlite3.Error):
+        return "storage"
+    if isinstance(error, subprocess.SubprocessError):
+        return "provider"
+    return "runtime"
+
+
+def collect(
+    args: argparse.Namespace, root: Path, collector_id: str
+) -> dict[str, Any]:
+    """Verify the selected OAuth channel and collect one configured stream."""
+    connection_id = validate_opaque(args.connection_id, "connection_id")
+    account_id = validate_opaque(args.account_id, "account_id")
+    lease = acquire_run_lease(
+        root,
+        RunLeaseRequest(
+            connection_id,
+            args.stream,
+            collector_id,
+            "sync",
+            args.lease_seconds,
+        ),
+    )
+    try:
+        runner = youtube_runner(args)
+        account = verified_identity(runner.identity(account_id), account_id)
+        context = replace(
+            load_context(
+                root,
+                ContextRequest(
+                    PROVIDER, connection_id, account, args.stream, "none"
+                ),
+                STREAMS,
+            ),
+            lease=lease,
+        )
+        return collect_pages(args, runner, context)
+    except Exception as error:
+        try:
+            fail_active_run(root, lease, _failure_class(error))
+        except SocialLeaseLostError:
+            pass
+        raise
+    finally:
+        release_run_lease(root, lease)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", type=Path)
+    parser.add_argument("--alias", default=DEFAULT_ALIAS)
+    parser.add_argument("--connection-id", required=True)
+    parser.add_argument("--account-id", required=True)
+    parser.add_argument("--stream", required=True, choices=tuple(STREAMS))
+    parser.add_argument("--profile", required=True)
+    parser.add_argument("--budget", type=int, default=11)
+    parser.add_argument("--page-size", type=int, default=50)
+    parser.add_argument("--collector-id")
+    parser.add_argument("--lease-seconds", type=int, default=300)
+    parser.add_argument("--fixture", type=Path, help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    if args.budget < 1 or args.budget > 1000:
+        parser.error("--budget must be between 1 and 1000 quota units")
+    if args.page_size < 1 or args.page_size > 50:
+        parser.error("--page-size must be between 1 and 50 items")
+    if args.lease_seconds < 1 or args.lease_seconds > 86400:
+        parser.error("--lease-seconds must be between 1 and 86400")
+    return args
+
+
+def main() -> int:
+    return run_collector(parse_args(), collect)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/tests/test-knowledge-social-youtube.sh
+++ b/.agents/tests/test-knowledge-social-youtube.sh
@@ -1,0 +1,612 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-youtube.sh — Guarded YouTube OAuth collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' \
+			"$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c \
+		'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_count() {
+	python3 - "$ROOT/sources/social/raw" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+print(len(list(root.rglob("*.json.gz"))) if root.exists() else 0)
+PY
+	return 0
+}
+
+expect_sync_failure() {
+	local description="$1"
+	local fixture="$2"
+	local stream="$3"
+	if "$HELPER" sync-youtube --base "$BASE" --alias personal:default \
+		--connection-id conn_youtube --account-id channel42 \
+		--stream "$stream" --profile fixture --fixture "$fixture" \
+		>/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+run_terminal_fixture() {
+	local name="$1"
+	local status="$2"
+	local expected_failure="$3"
+	local fixture="${TMP_DIR}/${name}.json"
+	python3 - "$fixture" "$status" <<'PY'
+import json
+import sys
+
+payload = {
+    "identity": {"data": {
+        "id": "channel42", "uploads_playlist_id": "uploads42",
+        "title": "Private channel", "handle": "@private",
+    }},
+    "pages": [{
+        "status": int(sys.argv[2]),
+        "observed_at": f"2026-07-26T10:{int(sys.argv[2]) % 60:02d}:00Z",
+    }],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+	local result=""
+	result=$("$HELPER" sync-youtube --base "$BASE" --alias personal:default \
+		--connection-id conn_youtube --account-id channel42 \
+		--stream authored_videos --profile fixture --fixture "$fixture")
+	assert_eq "${status} response is terminal" \
+		"$(json_field "$result" status)" failed
+	assert_eq "${status} response has a sanitized failure class" \
+		"$(json_field "$result" failure_class)" "$expected_failure"
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'YouTube social collector tests\n'
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+from _knowledge_social_youtube import STREAMS
+from _knowledge_social_youtube_provider import API_BASE, _http_exports
+from _knowledge_social_youtube_routes import READ_ENDPOINTS, ROUTES
+
+expected = {
+    "authored_videos", "channel_activity", "owned_playlists",
+    "subscriptions", "comments", "liked_videos",
+}
+assert set(STREAMS) == expected == set(ROUTES)
+assert READ_ENDPOINTS == {
+    "activities", "channels", "comments", "commentThreads",
+    "playlistItems", "playlists", "subscriptions", "videos",
+}
+assert API_BASE == "https://www.googleapis.com/youtube/v3"
+assert callable(_http_exports())
+assert importlib.util.find_spec("googleapiclient") is None
+
+sources = [
+    path.read_text(encoding="utf-8")
+    for path in sorted(scripts.glob("_knowledge_social_youtube*.py"))
+]
+calls = [
+    node
+    for source in sources
+    for node in ast.walk(ast.parse(source))
+    if isinstance(node, ast.Call)
+]
+request_calls = [
+    node for node in calls
+    if isinstance(node.func, ast.Name) and node.func.id == "Request"
+]
+assert request_calls
+for node in request_calls:
+    methods = [
+        keyword.value.value
+        for keyword in node.keywords
+        if keyword.arg == "method" and isinstance(keyword.value, ast.Constant)
+    ]
+    assert methods == ["GET"]
+PY
+assert_eq "stream registry, stdlib transport, and GET-only endpoints are guarded" \
+	verified verified
+
+cat >"$TMP_DIR/videos-1.json" <<'JSON'
+{
+  "identity":{"data":{"id":"channel42","uploads_playlist_id":"uploads42","title":"Private channel","handle":"@private"}},
+  "pages":[{
+    "expect_request":{"cursor":null,"stop_at":null,"limit":1},
+    "response":{"status":200,"observed_at":"2026-07-26T10:00:00Z",
+      "data":[{"kind":"video","remote_id":"video_new","playlist_item_id":"upload_item_new","title":"Newest knowledge","description":"bounded YouTube page","published_at":"2026-07-26T09:00:00Z","channel_id":"channel42","channel_title":"Private channel","position":0,"privacy_status":"public"}],
+      "meta":{"next_cursor":{"page_token":"nextVideos"},"newest_id":"video_new","reached_watermark":false,"complete":false,"snapshot":false}}
+  }]
+}
+JSON
+first_result=$("$HELPER" sync-youtube --base "$BASE" --alias personal:default \
+	--connection-id conn_youtube --account-id channel42 \
+	--stream authored_videos --profile fixture --budget 3 --page-size 1 \
+	--fixture "$TMP_DIR/videos-1.json")
+assert_eq "one-page quota pauses initial YouTube backfill" \
+	"$(json_field "$first_result" status)" budget_exhausted
+assert_eq "identity and one guarded page reserve three quota units" \
+	"$(json_field "$first_result" budget_units)" 3
+assert_eq "partial video page advances only its stream cursor" \
+	"$(sql_value "SELECT backfill_complete FROM sync_cursors WHERE connection_id='conn_youtube' AND stream='authored_videos'")" 0
+assert_eq "YouTube video text reaches the shared FTS projection" \
+	"$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'bounded'")" 1
+assert_eq "API coverage records the 30-day refresh/delete boundary" \
+	"$(sql_value "SELECT retention_limit || ':' || status FROM coverage_records WHERE connection_id='conn_youtube' AND stream='authored_videos'")" \
+	"youtube_api_data_refresh_or_delete_within_30_days:paused"
+assert_eq "unsupported account categories are durable gap evidence" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE connection_id='conn_youtube' AND stream IN ('watch_history','watch_later','saved_playlists','authored_comments_elsewhere') AND status='unavailable'")" 4
+assert_eq "private channel metadata is absent from collector output" \
+	"$([[ "$first_result" == *Private* || "$first_result" == *@private* ]] && printf present || printf absent)" absent
+
+cat >"$TMP_DIR/videos-2.json" <<'JSON'
+{
+  "identity":{"data":{"id":"channel42","uploads_playlist_id":"uploads42"}},
+  "pages":[{
+    "expect_request":{"cursor":{"page_token":"nextVideos"},"stop_at":null},
+    "response":{"status":200,"observed_at":"2026-07-26T10:01:00Z",
+      "data":[{"kind":"video","remote_id":"video_old","playlist_item_id":"upload_item_old","title":"Older knowledge","description":"resumed page","published_at":"2026-07-25T09:00:00Z","channel_id":"channel42","position":1}],
+      "meta":{"next_cursor":null,"newest_id":"video_old","reached_watermark":false,"complete":true,"snapshot":false}}
+  }]
+}
+JSON
+second_result=$("$HELPER" sync-youtube --base "$BASE" --alias personal:default \
+	--connection-id conn_youtube --account-id channel42 \
+	--stream authored_videos --profile fixture --fixture "$TMP_DIR/videos-2.json")
+assert_eq "YouTube backfill resumes from its opaque page cursor" \
+	"$(json_field "$second_result" status)" complete
+assert_eq "backfill exhaustion preserves the first-page watermark" \
+	"$(sql_value "SELECT coalesce(cursor,'done') || ':' || watermark || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_youtube' AND stream='authored_videos'")" \
+	"done:video_new:1"
+
+cat >"$TMP_DIR/videos-delta.json" <<'JSON'
+{
+  "identity":{"data":{"id":"channel42","uploads_playlist_id":"uploads42"}},
+  "pages":[{
+    "expect_request":{"cursor":null,"stop_at":"video_new"},
+    "response":{"status":200,"observed_at":"2026-07-26T10:02:00Z",
+      "data":[{"kind":"video","remote_id":"video_latest","playlist_item_id":"upload_item_latest","title":"Latest delta","published_at":"2026-07-26T10:00:00Z","channel_id":"channel42","position":0}],
+      "meta":{"next_cursor":null,"newest_id":"video_latest","reached_watermark":true,"complete":true,"snapshot":false}}
+  }]
+}
+JSON
+"$HELPER" sync-youtube --base "$BASE" --alias personal:default \
+	--connection-id conn_youtube --account-id channel42 \
+	--stream authored_videos --profile fixture \
+	--fixture "$TMP_DIR/videos-delta.json" >/dev/null
+assert_eq "incremental completion advances the stable video watermark" \
+	"$(sql_value "SELECT watermark FROM sync_cursors WHERE connection_id='conn_youtube' AND stream='authored_videos'")" \
+	video_latest
+
+cat >"$TMP_DIR/subscriptions.json" <<'JSON'
+{
+  "identity":{"data":{"id":"channel42","uploads_playlist_id":"uploads42"}},
+  "pages":[{"status":200,"observed_at":"2026-07-26T10:03:00Z",
+    "data":[{"kind":"subscription","remote_id":"subscription42","subscriber_channel_id":"channel42","subscribed_channel_id":"target_channel","title":"Target channel","published_at":"2026-07-20T10:00:00Z"}],
+    "meta":{"next_cursor":null,"newest_id":"subscription42","reached_watermark":false,"complete":true,"snapshot":true}}]
+}
+JSON
+"$HELPER" sync-youtube --base "$BASE" --alias personal:default \
+	--connection-id conn_youtube --account-id channel42 --stream subscriptions \
+	--profile fixture --fixture "$TMP_DIR/subscriptions.json" >/dev/null
+assert_eq "subscription direction is selected channel to subscribed channel" \
+	"$(sql_value "SELECT actor_remote_id || ':' || object_remote_id FROM activities WHERE provider='youtube' AND activity_type='subscription'")" \
+	"channel42:target_channel"
+
+cat >"$TMP_DIR/playlist.json" <<'JSON'
+{
+  "identity":{"data":{"id":"channel42","uploads_playlist_id":"uploads42"}},
+  "pages":[{"status":200,"observed_at":"2026-07-26T10:04:00Z",
+    "data":[{"kind":"playlist","remote_id":"playlist42","title":"Owned research","description":"playlist knowledge","published_at":"2026-07-01T10:00:00Z","channel_id":"channel42","item_count":1,"privacy_status":"private"}],
+    "meta":{"next_cursor":{"phase":"items","playlist_id":"playlist42","item_token":null,"playlists_token":null},"newest_id":null,"reached_watermark":false,"complete":false,"snapshot":true}}]
+}
+JSON
+"$HELPER" sync-youtube --base "$BASE" --alias personal:default \
+	--connection-id conn_youtube --account-id channel42 --stream owned_playlists \
+	--profile fixture --budget 3 --fixture "$TMP_DIR/playlist.json" >/dev/null
+cat >"$TMP_DIR/playlist-items.json" <<'JSON'
+{
+  "identity":{"data":{"id":"channel42","uploads_playlist_id":"uploads42"}},
+  "pages":[{
+    "expect_request":{"cursor":{"phase":"items","playlist_id":"playlist42","item_token":null,"playlists_token":null}},
+    "response":{"status":200,"observed_at":"2026-07-26T10:05:00Z",
+      "data":[{"kind":"playlist_item","remote_id":"membership42","playlist_id":"playlist42","video_id":"playlist_video","title":"Member video","published_at":"2026-07-02T10:00:00Z","position":0,"privacy_status":"public"}],
+      "meta":{"next_cursor":null,"newest_id":null,"reached_watermark":false,"complete":true,"snapshot":true}}
+  }]
+}
+JSON
+"$HELPER" sync-youtube --base "$BASE" --alias personal:default \
+	--connection-id conn_youtube --account-id channel42 --stream owned_playlists \
+	--profile fixture --fixture "$TMP_DIR/playlist-items.json" >/dev/null
+assert_eq "owned playlist membership retains playlist-to-video direction" \
+	"$(sql_value "SELECT actor_remote_id || ':' || object_remote_id FROM activities WHERE provider='youtube' AND activity_type='playlist_membership'")" \
+	"playlist42:playlist_video"
+assert_eq "saved third-party playlists remain explicit partial coverage" \
+	"$(sql_value "SELECT status || ':' || unavailable_reason FROM coverage_records WHERE connection_id='conn_youtube' AND stream='owned_playlists'")" \
+	"partial:saved_third_party_playlists_are_not_listable"
+
+playlist_batches=$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_youtube' AND stream='owned_playlists'")
+python3 - "$TMP_DIR/playlist.json" "$TMP_DIR/playlist-items.json" \
+	"$TMP_DIR/playlist-replay.json" <<'PY'
+import json
+import sys
+
+first = json.load(open(sys.argv[1], encoding="utf-8"))
+second = json.load(open(sys.argv[2], encoding="utf-8"))
+with open(sys.argv[3], "w", encoding="utf-8") as target:
+    json.dump({"identity": first["identity"], "pages": first["pages"] + second["pages"]}, target)
+PY
+"$HELPER" sync-youtube --base "$BASE" --alias personal:default \
+	--connection-id conn_youtube --account-id channel42 --stream owned_playlists \
+	--profile fixture --budget 5 --fixture "$TMP_DIR/playlist-replay.json" >/dev/null
+assert_eq "exact compound snapshot replay is content-addressed and idempotent" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_youtube' AND stream='owned_playlists'")" \
+	"$playlist_batches"
+
+cat >"$TMP_DIR/comments-thread.json" <<'JSON'
+{
+  "identity":{"data":{"id":"channel42","uploads_playlist_id":"uploads42"}},
+  "pages":[{"status":200,"observed_at":"2026-07-26T10:06:00Z",
+    "data":[
+      {"kind":"comment","remote_id":"comment_top","parent_id":null,"video_id":"video_new","channel_id":"channel42","author_channel_id":"author42","author_display_name":"Commenter","text":"Top-level knowledge","published_at":"2026-07-25T10:00:00Z"},
+      {"kind":"comment","remote_id":"comment_unknown","parent_id":null,"video_id":"video_new","channel_id":"channel42","text":"Unknown author knowledge","published_at":"2026-07-25T10:30:00Z"}
+    ],
+    "meta":{"next_cursor":{"phase":"replies","parent_id":"comment_top","reply_token":null,"threads_token":null},"newest_id":"comment_top","reached_watermark":false,"complete":false,"snapshot":false}}]
+}
+JSON
+"$HELPER" sync-youtube --base "$BASE" --alias personal:default \
+	--connection-id conn_youtube --account-id channel42 --stream comments \
+	--profile fixture --budget 3 --fixture "$TMP_DIR/comments-thread.json" >/dev/null
+cat >"$TMP_DIR/comments-replies.json" <<'JSON'
+{
+  "identity":{"data":{"id":"channel42","uploads_playlist_id":"uploads42"}},
+  "pages":[{
+    "expect_request":{"cursor":{"phase":"replies","parent_id":"comment_top","reply_token":null,"threads_token":null}},
+    "response":{"status":200,"observed_at":"2026-07-26T10:07:00Z",
+      "data":[{"kind":"comment","remote_id":"comment_reply","parent_id":"comment_top","video_id":"video_new","channel_id":"channel42","author_channel_id":"channel42","author_display_name":"Owner","text":"Visible reply","published_at":"2026-07-25T11:00:00Z"}],
+      "meta":{"next_cursor":null,"newest_id":null,"reached_watermark":false,"complete":true,"snapshot":false}}
+  }]
+}
+JSON
+"$HELPER" sync-youtube --base "$BASE" --alias personal:default \
+	--connection-id conn_youtube --account-id channel42 --stream comments \
+	--profile fixture --fixture "$TMP_DIR/comments-replies.json" >/dev/null
+assert_eq "comment threads and complete replies use independent compound checkpoints" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='youtube' AND object_type='comment' AND remote_id IN ('comment_top','comment_reply')")" 2
+assert_eq "comment evidence distinguishes owner, third-party, and unknown authors" \
+	"$(sql_value "SELECT group_concat(remote_id || ':' || evidence_class, ',') FROM (SELECT remote_id, evidence_class FROM objects WHERE provider='youtube' AND object_type='comment' AND remote_id IN ('comment_reply','comment_top','comment_unknown') ORDER BY remote_id)")" \
+	"comment_reply:authored,comment_top:observed,comment_unknown:observed"
+assert_eq "channel-related comments remain explicit partial coverage" \
+	"$(sql_value "SELECT status || ':' || unavailable_reason FROM coverage_records WHERE connection_id='conn_youtube' AND stream='comments'")" \
+	"partial:channel_related_visible_comments_only"
+
+cursor_before=$(sql_value "SELECT watermark FROM sync_cursors WHERE connection_id='conn_youtube' AND stream='authored_videos'")
+cat >"$TMP_DIR/rate-limit.json" <<'JSON'
+{"identity":{"data":{"id":"channel42","uploads_playlist_id":"uploads42"}},"pages":[{"status":429,"observed_at":"2026-07-26T10:08:00Z","retry_after":1785150000}]}
+JSON
+rate_result=$("$HELPER" sync-youtube --base "$BASE" --alias personal:default \
+	--connection-id conn_youtube --account-id channel42 --stream authored_videos \
+	--profile fixture --fixture "$TMP_DIR/rate-limit.json")
+assert_eq "YouTube rate limits pause one invocation" \
+	"$(json_field "$rate_result" status)" rate_limited
+assert_eq "terminal response preserves the prior YouTube checkpoint" \
+	"$(sql_value "SELECT watermark FROM sync_cursors WHERE connection_id='conn_youtube' AND stream='authored_videos'")" \
+	"$cursor_before"
+assert_eq "rate receipt contains only sanitized stream diagnostics" \
+	"$(sql_value "SELECT failure_class || ':' || retry_after || ':' || diagnostics FROM sync_runs WHERE connection_id='conn_youtube' ORDER BY rowid DESC LIMIT 1")" \
+	'rate_limit:1785150000:{"stream":"authored_videos"}'
+
+run_terminal_fixture unauthorized 401 authorization
+run_terminal_fixture forbidden 403 authorization
+run_terminal_fixture missing 404 unavailable
+run_terminal_fixture provider 500 provider
+
+batch_count=$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='youtube'")
+cat >"$TMP_DIR/malformed.json" <<'JSON'
+{"identity":{"data":{"id":"channel42","uploads_playlist_id":"uploads42"}},"pages":[{"status":200,"observed_at":"2026-07-26T10:09:00Z","data":{},"meta":{}}]}
+JSON
+expect_sync_failure "malformed YouTube pages fail before persistence" \
+	"$TMP_DIR/malformed.json" authored_videos
+assert_eq "malformed YouTube page advances no batch" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='youtube'")" "$batch_count"
+
+cat >"$TMP_DIR/credential.json" <<'JSON'
+{"identity":{"data":{"id":"channel42","uploads_playlist_id":"uploads42"}},"pages":[{"status":200,"observed_at":"2026-07-26T10:10:00Z","access_token":"must-not-persist","data":[],"meta":{"next_cursor":null,"newest_id":null,"reached_watermark":false,"complete":true,"snapshot":false}}]}
+JSON
+expect_sync_failure "credential-shaped YouTube pages are rejected" \
+	"$TMP_DIR/credential.json" authored_videos
+assert_eq "credential rejection creates no raw evidence" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='youtube'")" "$batch_count"
+
+cat >"$TMP_DIR/wrong-account.json" <<'JSON'
+{"identity":{"data":{"id":"other_channel","uploads_playlist_id":"other_uploads"}},"pages":[]}
+JSON
+raw_before_mismatch=$(raw_count)
+expect_sync_failure "selected YouTube account mismatch fails before collection" \
+	"$TMP_DIR/wrong-account.json" authored_videos
+assert_eq "identity mismatch creates no raw evidence" \
+	"$(raw_count)" "$raw_before_mismatch"
+
+python3 - "$ROOT" "$SCRIPT_DIR/../scripts" <<'PY'
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[2])
+from _knowledge_social_collect import (
+    CollectionContext,
+    ConnectionConfig,
+    CursorState,
+    PageCheckpoint,
+    SuccessfulPage,
+)
+from _knowledge_social_collect_persist import persist_page
+from _knowledge_social_lease import (
+    RunLeaseRequest,
+    SocialLeaseLostError,
+    acquire_run_lease,
+    release_run_lease,
+)
+from _knowledge_social_youtube import STREAMS
+
+root = Path(sys.argv[1])
+old = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_youtube_fence", "liked_videos", "old_runner", "sync", 1),
+    now_epoch=9000,
+)
+new = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_youtube_fence", "liked_videos", "new_runner", "sync", 10),
+    now_epoch=9001,
+)
+context = CollectionContext(
+    root,
+    "conn_youtube_fence",
+    {"id": "channel42", "uploads_playlist_id": "uploads42"},
+    "liked_videos",
+    "none",
+    ConnectionConfig(("liked_videos",), {"media_hydration": "none"}),
+    CursorState(None, None, False),
+    STREAMS["liked_videos"],
+    old,
+    "youtube",
+)
+archive = {
+    "provider": "youtube",
+    "connection_id": "conn_youtube_fence",
+    "remote_account_id": "channel42",
+    "exported_at": "2026-07-26T10:10:30Z",
+    "enabled_streams": ["liked_videos"],
+    "policy": {"media_hydration": "none"},
+    "accounts": [],
+    "objects": [],
+    "activities": [],
+    "media": [],
+    "coverage": [],
+}
+page = SuccessfulPage(
+    {
+        "status": 200,
+        "observed_at": archive["exported_at"],
+        "data": [],
+        "meta": {},
+    },
+    '{"stream":"liked_videos"}',
+    archive,
+    PageCheckpoint(None, None),
+    True,
+    2,
+)
+os.environ["AIDEVOPS_SOCIAL_NOW_EPOCH"] = "9001"
+try:
+    persist_page(context, page)
+except SocialLeaseLostError:
+    pass
+else:
+    raise SystemExit("stale YouTube collector advanced persistence")
+with sqlite3.connect(root / "index" / "social.db") as database:
+    cursor = database.execute(
+        "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_youtube_fence'"
+    ).fetchone()[0]
+assert cursor == 0
+release_run_lease(root, new)
+PY
+assert_eq "stale YouTube lease cannot commit evidence or a cursor" verified verified
+
+mkdir -p "$TMP_DIR/fake-youtube"
+cat >"$TMP_DIR/fake-youtube/sitecustomize.py" <<'PY'
+import json
+import os
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+import urllib.request
+
+
+class Response:
+    status = 200
+
+    def __init__(self, payload):
+        self.payload = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, _limit):
+        return self.payload
+
+
+def fake_urlopen(request, timeout):
+    parsed = urlparse(request.full_url)
+    endpoint = parsed.path.rsplit("/", 1)[-1]
+    query = parse_qs(parsed.query)
+    log_path = Path(os.environ["YOUTUBE_READ_LOG"])
+    row = {
+        "endpoint": endpoint,
+        "method": request.get_method(),
+        "maxResults": query.get("maxResults", [None])[0],
+        "bearer": request.get_header("Authorization", "").startswith("Bearer "),
+        "unrelated_secret": "UNRELATED_PROVIDER_TOKEN" in os.environ,
+        "timeout": timeout,
+    }
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row, sort_keys=True) + "\n")
+    if endpoint == "channels":
+        channel_calls = sum(
+            json.loads(line)["endpoint"] == "channels"
+            for line in log_path.read_text(encoding="utf-8").splitlines()
+        )
+        rebound = log_path.name == "youtube-rebind.log" and channel_calls > 1
+        channel_id = "other_channel" if rebound else "live_channel42"
+        uploads_id = "other_uploads" if rebound else "live_uploads42"
+        return Response({"items": [{
+            "id": channel_id,
+            "snippet": {"title": "Private live channel", "customUrl": "@private-live"},
+            "contentDetails": {"relatedPlaylists": {"uploads": uploads_id}},
+        }]})
+    if endpoint == "playlistItems":
+        return Response({"items": [{
+            "id": "live_upload_item",
+            "snippet": {
+                "title": "Guarded live page", "description": "read boundary marker",
+                "publishedAt": "2026-07-26T10:11:00Z", "channelId": "live_channel42",
+                "channelTitle": "Private live channel", "position": 0,
+                "resourceId": {"videoId": "live_video42"},
+            },
+            "contentDetails": {"videoId": None},
+            "status": {"privacyStatus": "public"},
+        }]})
+    raise RuntimeError("unexpected endpoint")
+
+
+urllib.request.urlopen = fake_urlopen
+PY
+: >"$TMP_DIR/youtube-read.log"
+chmod 0600 "$TMP_DIR/youtube-read.log"
+live_result=$(
+	PYTHONPATH="$TMP_DIR/fake-youtube" YOUTUBE_READ_LOG="$TMP_DIR/youtube-read.log" \
+		YOUTUBE_FIXTURE_ACCESS_TOKEN=fixture-token UNRELATED_PROVIDER_TOKEN=unrelated \
+		"$HELPER" sync-youtube --base "$BASE" --alias personal:default \
+		--connection-id conn_youtube_live --account-id live_channel42 \
+		--stream authored_videos --profile fixture --budget 3 --page-size 7
+)
+assert_eq "guarded live OAuth boundary persists one readable page" \
+	"$(json_field "$live_result" status)" complete
+assert_eq "uploaded videos fall back to the snippet resource ID when details are null" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='youtube' AND object_type='video' AND remote_id='live_video42'")" 1
+live_guard=$(
+	python3 - "$TMP_DIR/youtube-read.log" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+rows = [json.loads(line) for line in Path(sys.argv[1]).read_text().splitlines()]
+channels = [row for row in rows if row["endpoint"] == "channels"]
+pages = [row for row in rows if row["endpoint"] == "playlistItems"]
+safe = (
+    len(channels) == 2
+    and len(pages) == 1
+    and pages[0]["maxResults"] == "7"
+    and all(row["method"] == "GET" and row["bearer"] for row in rows)
+    and all(not row["unrelated_secret"] for row in rows)
+)
+print("bounded-read-only" if safe else "unsafe")
+PY
+)
+assert_eq "live boundary revalidates identity and passes only selected credentials" \
+	"$live_guard" bounded-read-only
+assert_eq "live boundary never prints private channel metadata" \
+	"$([[ "$live_result" == *Private* || "$live_result" == *@private-live* ]] && printf present || printf absent)" absent
+
+: >"$TMP_DIR/youtube-rebind.log"
+chmod 0600 "$TMP_DIR/youtube-rebind.log"
+raw_before_rebind=$(raw_count)
+if PYTHONPATH="$TMP_DIR/fake-youtube" YOUTUBE_READ_LOG="$TMP_DIR/youtube-rebind.log" \
+	YOUTUBE_FIXTURE_ACCESS_TOKEN=fixture-token \
+	"$HELPER" sync-youtube --base "$BASE" --alias personal:default \
+	--connection-id conn_youtube_rebind --account-id live_channel42 \
+	--stream authored_videos --profile fixture --budget 3 --page-size 7 \
+	>/dev/null 2>&1; then
+	rebind_result=accepted
+else
+	rebind_result=rejected
+fi
+assert_eq "live boundary rejects account rebinding before a page read" \
+	"$rebind_result" rejected
+assert_eq "per-page identity mismatch creates no raw evidence" \
+	"$(raw_count)" "$raw_before_rebind"
+assert_eq "per-page identity mismatch advances no cursor" \
+	"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_youtube_rebind'")" 0
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/README.md
+++ b/README.md
@@ -688,7 +688,7 @@ See `.agents/tools/terminal/terminal-title.md` for customization options.
 
 - **SimpleX bot** - Channel-agnostic gateway with SimpleX Chat as first adapter for AI agent dispatch (`simplex-bot/`)
 - **Matterbridge** - Multi-platform chat bridge connecting 20+ platforms including Matrix, Discord, Telegram, Slack, IRC, WhatsApp, XMPP (`matterbridge-helper.sh`)
-- **Approval-bound social operations** - Owner-only immediate/scheduled posts, replies, likes/upvotes, bookmarks/saves, receipts, reconciliation, and mention/reply workflow state through a fixed provider registry. X uses the guarded official `xurl` CLI with multiple apps/accounts; Reddit uses named PRAW profiles with stable-account verification and separately protected post subjects/destinations. Model-provider auth such as OpenCode xAI/Grok remains separate from social API OAuth (`content/social-xurl.md`, `content/social-reddit.md`, `knowledge-social-helper.sh`)
+- **Account knowledge and approval-bound social operations** - Bounded account collection uses guarded X, named PRAW Reddit, and `youtube.readonly` user-OAuth YouTube adapters with stable identity, independent checkpoints, and explicit unsupported coverage. Owner-only immediate/scheduled posts, replies, likes/upvotes, bookmarks/saves, receipts, reconciliation, and mention/reply workflow state remain a separate fixed-provider subsystem. Model-provider auth such as OpenCode xAI/Grok remains separate from social API OAuth (`content/social-xurl.md`, `content/social-reddit.md`, `content/social-youtube.md`, `knowledge-social-helper.sh`)
 - **Localdev** - Local development environment manager with dnsmasq, Traefik, mkcert for production-like `.local` domains with HTTPS (`localdev-helper.sh`)
 
 **MCP Toolkit:**


### PR DESCRIPTION
## Summary

Add a bounded, read-only YouTube user-OAuth account collector with stable identity checks, allowlisted list routes, independent checkpoints, quota and lease fencing, provider-neutral persistence, explicit capability gaps, and operator guidance.

## Files Changed

- `.agents/scripts/knowledge_social_youtube.py` and `_knowledge_social_youtube*.py`: guarded collector, provider boundary, route contracts, serialization, and normalization
- `.agents/scripts/_knowledge_social_collect_persist.py` and `knowledge-social-helper.sh`: atomic coverage import and CLI dispatch
- `.agents/tests/test-knowledge-social-youtube.sh`: quota, cursor, replay, terminal-state, identity, lease, and live-boundary regressions
- `.agents/content/social-youtube.md`, knowledge-plane references, and `README.md`: scopes, quotas, retention, capability gaps, and operator workflow

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — YouTube collector 43/43, social sync 33/33, corpus 31/31, X 51/51, and Reddit 43/43 passed
- Guarded live OAuth child simulation, Python compilation, ShellCheck, independent exact-head review, and `.agents/scripts/linters-local.sh --changed` passed
- Review evidence: `aidevops.review-evidence/v1` bundle digest `f686d9dda621ba6743f3249fd68eb647dd082f0158036b94f8e7aa8eb10c4a51`; all actionable findings were resolved and independently re-reviewed

Resolves #28666

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.181 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 59m and 592,297 tokens on this as a headless worker.
