### PR TITLE
GH#28676: reconcile superseded CodeRabbit reviews

### DIFF
--- a/.agents/reference/review-bot-gate.md
+++ b/.agents/reference/review-bot-gate.md
@@ -40,6 +40,24 @@ check and completion behaviour are consistent across CI and in-agent merge paths
 
 Workers MUST use `full-loop-helper.sh merge` — direct `gh pr merge` bypasses the gate (GH#17541).
 
+## Superseded CodeRabbit change requests
+
+The full-loop readiness gate may dismiss a stale CodeRabbit `CHANGES_REQUESTED`
+review only when every active blocker is the exact `coderabbitai[bot]` identity,
+each blocking review names a non-current commit, and the trusted bot subsequently
+posts both the addressed marker and the deterministic “no blocking findings”
+message for the exact current SHA. The current SHA must also have a terminal-
+success `CodeRabbit` status context from a trusted PR author.
+
+The helper reduces each reviewer's history to their latest state-changing review,
+re-reads the head immediately before each dismissal, and re-reads the aggregate
+review decision afterward. The merge transport checks the exact-head aggregate
+again immediately before mutation. Human or mixed reviewers, current-head
+requests, head drift, malformed evidence, missing/failed/pending status, and
+untrusted authors remain blocking. This is separate from the maintainer-applied
+`coderabbit-nits-ok` cosmetic override; the shared helper independently verifies
+that label while reusing reviewer enumeration and dismissal mechanics.
+
 ## Workflow
 
 - Before merging, run `review-bot-gate-helper.sh check <PR_NUMBER>` to collect

--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -110,16 +110,65 @@ _full_loop_query_required_checks() {
 	return 0
 }
 
+_full_loop_review_bot_gate_helper_path() {
+	local helper_path="${SCRIPT_DIR}/review-bot-gate-helper.sh"
+
+	if [[ ! -f "$helper_path" ]]; then
+		helper_path="${HOME}/.aidevops/agents/scripts/review-bot-gate-helper.sh"
+	fi
+	[[ -f "$helper_path" ]] || return 1
+	printf '%s\n' "$helper_path"
+	return 0
+}
+
+_full_loop_reconcile_stale_coderabbit_review() {
+	local pr_number="$1"
+	local repo="$2"
+	local expected_head="$3"
+	local rbg_helper=""
+	local refreshed_json=""
+
+	FULL_LOOP_RECONCILED_PR_JSON=""
+	rbg_helper=$(_full_loop_review_bot_gate_helper_path) || {
+		print_error "review-bot-gate-helper.sh not found — cannot reconcile stale CodeRabbit review state"
+		return 1
+	}
+	print_info "Checking whether CodeRabbit's blocking review is superseded at exact head ${expected_head}..."
+	if ! bash "$rbg_helper" reconcile-stale-coderabbit "$pr_number" "$repo" "$expected_head"; then
+		print_error "PR #${pr_number} retains changes-requested review state; automatic reconciliation was not authorized"
+		return 1
+	fi
+	refreshed_json=$(gh pr view "$pr_number" --repo "$repo" \
+		--json state,isDraft,reviewDecision,headRefOid,headRefName 2>/dev/null) || {
+		print_error "Cannot refresh PR #${pr_number} after CodeRabbit reconciliation"
+		return 1
+	}
+	if [[ "$(printf '%s' "$refreshed_json" | jq -r '.headRefOid // empty')" != "$expected_head" ]]; then
+		print_error "PR #${pr_number} head changed during CodeRabbit reconciliation"
+		return 1
+	fi
+	FULL_LOOP_RECONCILED_PR_JSON="$refreshed_json"
+	return 0
+}
+
 _full_loop_verify_pr_readiness() {
 	local pr_number="$1"
 	local repo="$2"
 	local pr_json=""
+	local verified_head=""
+	local review_decision=""
 
 	pr_json=$(gh pr view "$pr_number" --repo "$repo" \
 		--json state,isDraft,reviewDecision,headRefOid,headRefName 2>/dev/null) || {
 		print_error "Cannot read PR #${pr_number} readiness evidence"
 		return 1
 	}
+	verified_head=$(printf '%s' "$pr_json" | jq -r '.headRefOid // empty')
+	review_decision=$(printf '%s' "$pr_json" | jq -r '(.reviewDecision // "") | ascii_upcase')
+	if [[ "$review_decision" == "CHANGES_REQUESTED" && -n "$verified_head" ]]; then
+		_full_loop_reconcile_stale_coderabbit_review "$pr_number" "$repo" "$verified_head" || return 1
+		pr_json="$FULL_LOOP_RECONCILED_PR_JSON"
+	fi
 
 	if ! printf '%s' "$pr_json" | jq -e '
 		def up(v): (v // "" | ascii_upcase);
@@ -131,7 +180,6 @@ _full_loop_verify_pr_readiness() {
 		print_error "PR #${pr_number} is not remotely verified: require OPEN, non-draft, no changes requested, and a stable head"
 		return 1
 	fi
-	local verified_head=""
 	verified_head=$(printf '%s' "$pr_json" | jq -r '.headRefOid // empty')
 	local pr_head_ref=""
 	pr_head_ref=$(printf '%s' "$pr_json" | jq -r '.headRefName // empty')
@@ -213,13 +261,8 @@ cmd_pre_merge_gate() {
 
 	_full_loop_verify_pr_readiness "$pr_number" "$repo" || return 1
 
-	local rbg_helper="${SCRIPT_DIR}/review-bot-gate-helper.sh"
-	if [[ ! -f "$rbg_helper" ]]; then
-		# Fallback to deployed location
-		rbg_helper="${HOME}/.aidevops/agents/scripts/review-bot-gate-helper.sh"
-	fi
-
-	if [[ ! -f "$rbg_helper" ]]; then
+	local rbg_helper=""
+	if ! rbg_helper=$(_full_loop_review_bot_gate_helper_path); then
 		print_error "review-bot-gate-helper.sh not found — refusing an unreviewed merge"
 		return 1
 	fi

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -675,6 +675,30 @@ _merge_resolve_match_head() {
 	return 0
 }
 
+_merge_review_state_still_clear() {
+	local pr_number="$1"
+	local repo="$2"
+	local expected_head="$3"
+	local review_json=""
+
+	review_json=$(gh pr view "$pr_number" --repo "$repo" \
+		--json state,isDraft,reviewDecision,headRefOid 2>/dev/null) || {
+		print_error "Could not refresh PR #${pr_number} review state immediately before merge"
+		return 1
+	}
+	#aidevops:trust-boundary — admin and REST merge paths must not bypass a review added after readiness verification.
+	if ! printf '%s\n' "$review_json" | jq -e --arg head "$expected_head" '
+		.state == "OPEN"
+		and .isDraft != true
+		and (.headRefOid // "") == $head
+		and ((.reviewDecision // "") | ascii_upcase) != "CHANGES_REQUESTED"
+	' >/dev/null 2>&1; then
+		print_error "PR #${pr_number} review or head state changed after readiness verification; refusing merge"
+		return 1
+	fi
+	return 0
+}
+
 _merge_execute() {
 	local pr_number="$1"
 	local repo="$2"
@@ -696,6 +720,7 @@ _merge_execute() {
 		print_error "Cannot bind merge to a remotely verified PR head SHA"
 		return 1
 	}
+	_merge_review_state_still_clear "$pr_number" "$repo" "$match_head_sha" || return 1
 	#aidevops:trust-boundary GH#17671/GH#28622 -- every merge mode, including
 	# --auto and the non-admin REST transport fallback, must pass the same live
 	# external/fork and exact-head cryptographic authority check.

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -518,10 +518,8 @@ _resolve_pr_mergeable_status() {
 # Auto-dismiss CodeRabbit-only CHANGES_REQUESTED reviews when the
 # coderabbit-nits-ok PR label has been applied by a maintainer (t2179).
 #
-# Enumerates all CHANGES_REQUESTED reviews on the PR. If any reviewer is
-# NOT coderabbitai[bot], returns 1 immediately — human reviewers are never
-# auto-dismissed. Otherwise dismisses each CodeRabbit review via the GitHub
-# reviews/dismissals API and returns 0.
+# Delegates reviewer enumeration and dismissal to review-bot-gate-helper.sh so
+# the maintainer override and exact-head reconciliation share one trust boundary.
 #
 # Returns: 0 if all CR reviews dismissed (or none existed)
 #          1 if a non-CR human review is blocking dismissal
@@ -531,37 +529,18 @@ _resolve_pr_mergeable_status() {
 _pulse_merge_dismiss_coderabbit_nits() {
 	local pr_number="$1"
 	local repo_slug="$2"
-	local reviews_json review_count has_human ids review_id
+	local review_helper="${AIDEVOPS_REVIEW_BOT_GATE_HELPER:-${_PULSE_MERGE_PROCESS_DIR}/review-bot-gate-helper.sh}"
+	local helper_output=""
 
-	# Fetch all CHANGES_REQUESTED reviews as id+login pairs.
-	reviews_json=$(gh api "repos/${repo_slug}/pulls/${pr_number}/reviews" \
-		--jq '[.[] | select(.state=="CHANGES_REQUESTED") | {id: .id, login: .user.login}]' \
-		2>/dev/null) || reviews_json="[]"
-
-	# No CHANGES_REQUESTED reviews — nothing to dismiss, safe to proceed.
-	review_count=$(printf '%s' "$reviews_json" | jq 'length' 2>/dev/null) || review_count=0
-	if [[ "$review_count" -eq 0 ]]; then
-		return 0
+	if [[ ! -f "$review_helper" ]]; then
+		review_helper="${HOME}/.aidevops/agents/scripts/review-bot-gate-helper.sh"
 	fi
-
-	# If any CHANGES_REQUESTED reviewer is not coderabbitai[bot], bail immediately.
-	# Human reviewers are never auto-dismissed regardless of the label.
-	has_human=$(printf '%s' "$reviews_json" | \
-		jq -r '[.[] | select(.login != "coderabbitai[bot]")] | length' 2>/dev/null) || has_human=0
-	if [[ "$has_human" -gt 0 ]]; then
+	[[ -f "$review_helper" ]] || return 1
+	if ! helper_output=$(bash "$review_helper" dismiss-coderabbit-nits "$pr_number" "$repo_slug" 2>&1); then
+		[[ -n "$helper_output" ]] && printf '%s\n' "$helper_output" >>"$LOGFILE"
 		return 1
 	fi
-
-	# All CHANGES_REQUESTED reviews are from coderabbitai[bot] — dismiss each.
-	ids=$(printf '%s' "$reviews_json" | jq -r '.[].id' 2>/dev/null) || ids=""
-	while IFS= read -r review_id; do
-		[[ -z "$review_id" ]] && continue
-		gh api -X PUT \
-			"repos/${repo_slug}/pulls/${pr_number}/reviews/${review_id}/dismissals" \
-			-f message="Auto-dismissed: coderabbit-nits-ok label applied by maintainer (PR #${pr_number})" \
-			>/dev/null 2>&1 || true
-		echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — dismissed CodeRabbit review ${review_id} (t2179)" >>"$LOGFILE"
-	done <<<"$ids"
+	[[ -n "$helper_output" ]] && printf '%s\n' "$helper_output" >>"$LOGFILE"
 
 	return 0
 }

--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -12,6 +12,8 @@
 #   review-bot-gate-helper.sh request-retry <PR_NUMBER> [REPO]
 #   review-bot-gate-helper.sh status-json   <PR_NUMBER> [REPO]
 #   review-bot-gate-helper.sh batch-retry   [REPO]
+#   review-bot-gate-helper.sh reconcile-stale-coderabbit <PR_NUMBER> [REPO] [EXPECTED_HEAD_SHA]
+#   review-bot-gate-helper.sh dismiss-coderabbit-nits <PR_NUMBER> [REPO]
 #
 # Commands:
 #   check          — Check once, return PASS/PASS_ADVISORY/PASS_RATE_LIMITED/WAITING/SKIP
@@ -25,6 +27,9 @@
 #   batch-retry    — Process all open PRs with 0 formal reviews, request retries
 #                     for rate-limited ones. Staggers requests to avoid re-triggering
 #                     rate limits. (GH#3932)
+#   reconcile-stale-coderabbit — Dismiss only superseded CodeRabbit change
+#                     requests after trusted clean exact-head evidence
+#   dismiss-coderabbit-nits — Preserve the maintainer-labelled cosmetic override
 #
 # Output values for check/wait:
 #   PASS              — At least one bot posted a real review
@@ -83,6 +88,13 @@ RBG_PASS_ADVISORY="PASS_ADVISORY"
 RBG_PASS_RATE_LIMITED="PASS_RATE_LIMITED"
 RBG_FALSE="false"
 RBG_COMPLETION_STRICT="strict"
+RBG_CODERABBIT_LOGIN="coderabbitai[bot]"
+RBG_CODERABBIT_STATUS_CONTEXT="coderabbit"
+RBG_CODERABBIT_ADDRESSED_MARKER='<!-- <review_comment_addressed> -->'
+RBG_CODERABBIT_NITS_LABEL="coderabbit-nits-ok"
+RBG_RECONCILE_MODE_NITS="nits"
+RBG_RECONCILE_MODE_SUPERSEDED="superseded"
+RBG_AUTHOR_CLASS_TRUSTED="trusted"
 
 # Rate-limit / quota notice patterns — entries that indicate the bot tried to
 # review but was capacity-constrained. Used by grace-period logic
@@ -172,7 +184,7 @@ _RBG_EVIDENCE_SNAPSHOT_READY=0
 # --- Functions ---
 
 usage() {
-	echo "Usage: $(basename "$0") {check|event-check|classify-infra-rate-limit|wait|list|request-retry|status-json|batch-retry} <PR_NUMBER> [REPO] [MAX_WAIT]"
+	echo "Usage: $(basename "$0") {check|event-check|classify-infra-rate-limit|wait|list|request-retry|status-json|batch-retry|reconcile-stale-coderabbit|dismiss-coderabbit-nits} <PR_NUMBER> [REPO] [EXTRA]"
 	echo ""
 	echo "Commands:"
 	echo "  check          Check once for bot reviews (returns PASS/PASS_ADVISORY/PASS_RATE_LIMITED/WAITING/SKIP)"
@@ -183,6 +195,8 @@ usage() {
 	echo "  request-retry  Request review retry if bots were rate-limited (idempotent)"
 	echo "  status-json    Print machine-readable gate status"
 	echo "  batch-retry    Process all open PRs with 0 reviews, request retries (GH#3932)"
+	echo "  reconcile-stale-coderabbit  Reconcile a stale CodeRabbit-only change request"
+	echo "  dismiss-coderabbit-nits  Dismiss CodeRabbit-only reviews under the maintainer label"
 	return 0
 }
 
@@ -549,6 +563,204 @@ _rbg_fetch_evidence_collection() {
 		return 1
 	fi
 	printf '%s\n' "$records_json"
+	return 0
+}
+
+_rbg_pr_reconciliation_snapshot() {
+	local pr_number="$1"
+	local repo="$2"
+	local pr_json=""
+	local pull_endpoint=""
+
+	printf -v pull_endpoint 'repos/%s/pulls/%s' "$repo" "$pr_number"
+	pr_json=$(gh api "$pull_endpoint" 2>/dev/null) || return 1
+	printf '%s\n' "$pr_json" | jq -ce '{
+		head:(.head.sha // ""),
+		state:(.state // ""),
+		association:(.author_association // ""),
+		labels:[.labels[]? | .name // empty]
+	}' || return 1
+	return 0
+}
+
+_rbg_changes_requested_reviews() {
+	local pr_number="$1"
+	local repo="$2"
+	local reviews_json=""
+
+	reviews_json=$(_rbg_fetch_evidence_collection "$pr_number" "$repo" reviews) || return 1
+	printf '%s\n' "$reviews_json" | jq -ce '
+		def state_changing: .state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED";
+		if any(.[]?; state_changing and (
+			(.user | type) != "object"
+			or (.user.login | type) != "string"
+			or (.user.login | length) == 0
+			or (.submitted_at | type) != "string"
+			or (.submitted_at | length) == 0
+			or (.id | type) != "number"
+		)) then error("malformed state-changing review")
+		else map(select(state_changing))
+		| group_by(.user.login)
+		| map(max_by([.submitted_at, .id]))
+		| map(select(.state == "CHANGES_REQUESTED")
+			| {id,login:.user.login,user_type:(.user.type // ""),commit_id:(.commit_id // ""),submitted_at})
+		| sort_by(.id)
+		end
+	' || return 1
+	return 0
+}
+
+_rbg_coderabbit_status_is_terminal_success() {
+	local repo="$1"
+	local head_sha="$2"
+	local status_json=""
+
+	status_json=$(gh api "repos/${repo}/commits/${head_sha}/status?per_page=100" 2>/dev/null) || return 1
+	#aidevops:trust-boundary — accept only the exact CodeRabbit context on this immutable head.
+	printf '%s\n' "$status_json" | jq -e \
+		--arg context "$RBG_CODERABBIT_STATUS_CONTEXT" \
+		--arg login "$RBG_CODERABBIT_LOGIN" '
+		[.statuses[]? | select(((.context // "") | ascii_downcase) == $context)] as $matches
+		| ($matches | length) > 0
+		and all($matches[];
+			((.state // "") | ascii_downcase) == "success"
+			and (.creator == null or (
+				(.creator.login // "") == $login
+				and (.creator.type // "") == "Bot"
+			))
+		)
+	' >/dev/null 2>&1 || return 1
+	return 0
+}
+
+_rbg_exact_head_clean_coderabbit_evidence() {
+	local pr_number="$1"
+	local repo="$2"
+	local head_sha="$3"
+	local reviews_json="$4"
+	local comments_json=""
+	local latest_stale_at=""
+	local completion_marker=""
+	local evidence_id=""
+
+	latest_stale_at=$(printf '%s\n' "$reviews_json" | jq -er '[.[].submitted_at | select(. != "")] | max // empty') || return 1
+	comments_json=$(_rbg_fetch_evidence_collection "$pr_number" "$repo" issue-comments) || return 1
+	completion_marker="Re-review of exact head \`${head_sha}\` complete — **no blocking findings**."
+	#aidevops:trust-boundary — prose is evidence only from the exact GitHub bot identity with both deterministic markers.
+	evidence_id=$(printf '%s\n' "$comments_json" | jq -er \
+		--arg login "$RBG_CODERABBIT_LOGIN" \
+		--arg addressed "$RBG_CODERABBIT_ADDRESSED_MARKER" \
+		--arg completion "$completion_marker" \
+		--arg after "$latest_stale_at" '
+		[.[] | select(
+			(.user.login // "") == $login
+			and (.user.type // "") == "Bot"
+			and (.created_at // "") > $after
+			and ((.body // "") | contains($addressed))
+			and ((.body // "") | contains($completion))
+		) | .id] | first // empty
+	') || return 1
+	[[ -n "$evidence_id" ]] || return 1
+	printf '%s\n' "$evidence_id"
+	return 0
+}
+
+_rbg_dismiss_coderabbit_reviews() {
+	local mode="$1"
+	local pr_number="$2"
+	local repo="$3"
+	local head_sha="$4"
+	local reviews_json="$5"
+	local records=""
+	local review_id=""
+	local stale_sha=""
+	local snapshot=""
+	local snapshot_head=""
+	local snapshot_state=""
+	local message=""
+	local pull_endpoint=""
+
+	printf -v pull_endpoint 'repos/%s/pulls/%s' "$repo" "$pr_number"
+	records=$(printf '%s\n' "$reviews_json" | jq -er '.[] | [(.id | tostring),.commit_id] | @tsv') || return 1
+	while IFS=$'\t' read -r review_id stale_sha; do
+		[[ "$review_id" =~ ^[0-9]+$ ]] || return 1
+		snapshot=$(_rbg_pr_reconciliation_snapshot "$pr_number" "$repo") || return 1
+		snapshot_head=$(printf '%s\n' "$snapshot" | jq -r '.head')
+		snapshot_state=$(printf '%s\n' "$snapshot" | jq -r '.state | ascii_downcase')
+		[[ "$snapshot_state" == "open" && "$snapshot_head" == "$head_sha" ]] || {
+			printf 'ERROR: PR #%s head drifted before CodeRabbit review %s dismissal\n' "$pr_number" "$review_id" >&2
+			return 1
+		}
+		if [[ "$mode" == "$RBG_RECONCILE_MODE_NITS" ]]; then
+			message="Auto-dismissed: coderabbit-nits-ok label applied by maintainer (PR #${pr_number})"
+		else
+			message="Auto-dismissed superseded CodeRabbit review ${review_id}: stale head ${stale_sha}; clean exact-head re-review confirmed at ${head_sha}."
+		fi
+		gh api -X PUT "${pull_endpoint}/reviews/${review_id}/dismissals" \
+			-f message="$message" >/dev/null 2>&1 || return 1
+		printf 'dismissed CodeRabbit review %s: stale head %s; current head %s\n' "$review_id" "${stale_sha:-unknown}" "$head_sha" >&2
+	done <<<"$records"
+	return 0
+}
+
+do_reconcile_coderabbit_reviews() {
+	local mode="$1"
+	local pr_number="$2"
+	local repo="$3"
+	local expected_head="${4:-}"
+	local snapshot=""
+	local head_sha=""
+	local state=""
+	local association=""
+	local reviews_json=""
+	local fresh_reviews_json=""
+	local review_count=0
+	local post_json=""
+
+	[[ "$mode" == "$RBG_RECONCILE_MODE_SUPERSEDED" || "$mode" == "$RBG_RECONCILE_MODE_NITS" ]] || return 2
+	snapshot=$(_rbg_pr_reconciliation_snapshot "$pr_number" "$repo") || return 1
+	head_sha=$(printf '%s\n' "$snapshot" | jq -r '.head')
+	state=$(printf '%s\n' "$snapshot" | jq -r '.state | ascii_downcase')
+	association=$(printf '%s\n' "$snapshot" | jq -r '.association | ascii_upcase')
+	[[ "$state" == "open" && "$head_sha" =~ ^[0-9a-fA-F]{40}$ ]] || return 1
+	[[ -z "$expected_head" || "$expected_head" == "$head_sha" ]] || return 1
+	if [[ "$mode" == "$RBG_RECONCILE_MODE_NITS" ]]; then
+		#aidevops:trust-boundary — the cosmetic override is inert without its explicit maintainer label.
+		printf '%s\n' "$snapshot" | jq -e --arg label "$RBG_CODERABBIT_NITS_LABEL" \
+			'any(.labels[]?; . == $label)' >/dev/null 2>&1 || return 1
+	fi
+	if [[ "$mode" == "$RBG_RECONCILE_MODE_SUPERSEDED" ]]; then
+		#aidevops:trust-boundary — automatic reconciliation is restricted to trusted PR authors.
+		case "$association" in OWNER | MEMBER | COLLABORATOR) ;; *) return 1 ;; esac
+	fi
+
+	reviews_json=$(_rbg_changes_requested_reviews "$pr_number" "$repo") || return 1
+	review_count=$(printf '%s\n' "$reviews_json" | jq 'length') || return 1
+	if [[ "$review_count" -eq 0 ]]; then
+		[[ "$mode" == "$RBG_RECONCILE_MODE_NITS" ]] && return 0
+		return 1
+	fi
+	#aidevops:trust-boundary — never dismiss a human, lookalike, or malformed reviewer identity.
+	printf '%s\n' "$reviews_json" | jq -e --arg login "$RBG_CODERABBIT_LOGIN" '
+		all(.[]; (.id | type) == "number" and .login == $login and .user_type == "Bot")
+	' >/dev/null 2>&1 || return 1
+
+	if [[ "$mode" == "$RBG_RECONCILE_MODE_SUPERSEDED" ]]; then
+		printf '%s\n' "$reviews_json" | jq -e --arg head "$head_sha" '
+			all(.[]; (.commit_id | test("^[0-9a-fA-F]{40}$")) and .commit_id != $head and .submitted_at != "")
+		' >/dev/null 2>&1 || return 1
+		_rbg_exact_head_clean_coderabbit_evidence "$pr_number" "$repo" "$head_sha" "$reviews_json" >/dev/null || return 1
+		_rbg_coderabbit_status_is_terminal_success "$repo" "$head_sha" || return 1
+	fi
+
+	fresh_reviews_json=$(_rbg_changes_requested_reviews "$pr_number" "$repo") || return 1
+	[[ "$(printf '%s\n' "$reviews_json" | jq -cS .)" == "$(printf '%s\n' "$fresh_reviews_json" | jq -cS .)" ]] || return 1
+	_rbg_dismiss_coderabbit_reviews "$mode" "$pr_number" "$repo" "$head_sha" "$reviews_json" || return 1
+	post_json=$(gh pr view "$pr_number" --repo "$repo" --json headRefOid,reviewDecision 2>/dev/null) || return 1
+	printf '%s\n' "$post_json" | jq -e --arg head "$head_sha" '
+		(.headRefOid // "") == $head and ((.reviewDecision // "") | ascii_upcase) != "CHANGES_REQUESTED"
+	' >/dev/null 2>&1 || return 1
+	printf 'RECONCILED_CODERABBIT_REVIEW head=%s reviews=%s mode=%s\n' "$head_sha" "$review_count" "$mode"
 	return 0
 }
 
@@ -1342,7 +1554,7 @@ do_status_json() {
 	fi
 	jq -e --arg label "$SKIP_LABEL" '[.labels[]?.name] | index($label) != null' <<<"$pr_json" >/dev/null 2>&1 && skip_label_present_after="true"
 	case "$author_association" in
-	OWNER | MEMBER | COLLABORATOR) author_class="trusted" ;;
+	OWNER | MEMBER | COLLABORATOR) author_class="$RBG_AUTHOR_CLASS_TRUSTED" ;;
 	esac
 
 	# #aidevops:trust-boundary — SKIP, advisory completion, and rate-limit grace are trusted-author
@@ -1356,7 +1568,7 @@ do_status_json() {
 		fi
 		;;
 	SKIP)
-		if [[ "$author_class" == "trusted" && "$head_stable" == "true" && "$skip_label_present_after" == "true" ]]; then
+		if [[ "$author_class" == "$RBG_AUTHOR_CLASS_TRUSTED" && "$head_stable" == "true" && "$skip_label_present_after" == "true" ]]; then
 			permitted="true"
 			reason="trusted_skip"
 		else
@@ -1364,7 +1576,7 @@ do_status_json() {
 		fi
 		;;
 	P[A]SS_RATE_LIMITED)
-		if [[ "$author_class" == "trusted" && "$head_stable" == "true" ]]; then
+		if [[ "$author_class" == "$RBG_AUTHOR_CLASS_TRUSTED" && "$head_stable" == "true" ]]; then
 			permitted="true"
 			reason="trusted_rate_limit_grace"
 		else
@@ -1372,7 +1584,7 @@ do_status_json() {
 		fi
 		;;
 	P[A]SS_ADVISORY)
-		if [[ "$author_class" == "trusted" && "$head_stable" == "true" ]]; then
+		if [[ "$author_class" == "$RBG_AUTHOR_CLASS_TRUSTED" && "$head_stable" == "true" ]]; then
 			permitted="true"
 			reason="trusted_advisory_default"
 		else
@@ -1763,6 +1975,12 @@ main() {
 		;;
 	status-json)
 		do_status_json "$pr_number" "$repo"
+		;;
+	reconcile-stale-coderabbit)
+		do_reconcile_coderabbit_reviews "$RBG_RECONCILE_MODE_SUPERSEDED" "$pr_number" "$repo" "$max_wait"
+		;;
+	dismiss-coderabbit-nits)
+		do_reconcile_coderabbit_reviews "$RBG_RECONCILE_MODE_NITS" "$pr_number" "$repo"
 		;;
 	-h | --help | help)
 		usage

--- a/.agents/scripts/tests/test-full-loop-helper-coderabbit-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-helper-coderabbit-reconcile.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="${SCRIPT_DIR}/.."
+REVIEW_HELPER="${SCRIPTS_DIR}/review-bot-gate-helper.sh"
+TEST_ROOT=$(mktemp -d)
+CURRENT_HEAD="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+STALE_HEAD="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+DRIFT_HEAD="cccccccccccccccccccccccccccccccccccccccc"
+GH_LOG="${TEST_ROOT}/gh.log"
+TESTS_RUN=0
+TESTS_FAILED=0
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+mkdir -p "${TEST_ROOT}/bin"
+
+cat >"${TEST_ROOT}/bin/gh" <<'GH_STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "gh $*" >>"$GH_LOG"
+
+if [[ "${1:-}" == "api" && "$*" == *"dismissals"* ]]; then
+	[[ "${DISMISS_FAIL:-0}" == "1" ]] && exit 1
+	exit 0
+fi
+if [[ "${1:-}" == "api" && "$*" == *"/pulls/"*"/reviews"* ]]; then
+	cat "$REVIEWS_FILE"
+	exit 0
+fi
+if [[ "${1:-}" == "api" && "$*" == *"/issues/"*"/comments"* ]]; then
+	cat "$COMMENTS_FILE"
+	exit 0
+fi
+if [[ "${1:-}" == "api" && "$*" == *"/commits/"*"/status"* ]]; then
+	printf '{"sha":"%s","statuses":[{"context":"CodeRabbit","state":"%s","creator":%s}]}\n' "$CURRENT_HEAD" "$STATUS_STATE" "$STATUS_CREATOR_JSON"
+	exit 0
+fi
+if [[ "${1:-}" == "api" && "$*" == *"/pulls/"* ]]; then
+	count=0
+	[[ -f "$SNAPSHOT_COUNT_FILE" ]] && count=$(<"$SNAPSHOT_COUNT_FILE")
+	count=$((count + 1))
+	printf '%s\n' "$count" >"$SNAPSHOT_COUNT_FILE"
+	head_sha="$CURRENT_HEAD"
+	if [[ "${HEAD_DRIFT:-0}" == "1" && "$count" -ge 2 ]]; then
+		head_sha="$DRIFT_HEAD"
+	fi
+	printf '{"state":"open","head":{"sha":"%s"},"author_association":"%s"}\n' "$head_sha" "$AUTHOR_ASSOCIATION"
+	exit 0
+fi
+if [[ "${1:-}" == "pr" && "${2:-}" == "checks" ]]; then
+	printf '%s\n' '[{"name":"required-ci","state":"SUCCESS","bucket":"pass"}]'
+	exit 0
+fi
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" && " $* " == *" --jq "* ]]; then
+	printf '%s\n' "$CURRENT_HEAD"
+	exit 0
+fi
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" && "$*" == *"state,isDraft,reviewDecision,headRefOid,headRefName"* ]]; then
+	review_decision="CHANGES_REQUESTED"
+	if grep -q "dismissals" "$GH_LOG"; then
+		review_decision=""
+	fi
+	printf '{"state":"OPEN","isDraft":false,"reviewDecision":"%s","headRefOid":"%s","headRefName":"remote-branch"}\n' "$review_decision" "$CURRENT_HEAD"
+	exit 0
+fi
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+	printf '{"headRefOid":"%s","reviewDecision":"%s"}\n' "$CURRENT_HEAD" "${POST_REVIEW_DECISION:-}"
+	exit 0
+fi
+exit 1
+GH_STUB
+chmod +x "${TEST_ROOT}/bin/gh"
+
+export PATH="${TEST_ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin"
+export GH_LOG CURRENT_HEAD DRIFT_HEAD
+export REVIEWS_FILE="${TEST_ROOT}/reviews.json"
+export COMMENTS_FILE="${TEST_ROOT}/comments.json"
+export SNAPSHOT_COUNT_FILE="${TEST_ROOT}/snapshot-count"
+
+reset_fixture() {
+	: >"$GH_LOG"
+	rm -f "$SNAPSHOT_COUNT_FILE"
+	export AUTHOR_ASSOCIATION="COLLABORATOR"
+	export STATUS_STATE="success"
+	export STATUS_CREATOR_JSON="null"
+	export HEAD_DRIFT=0
+	export DISMISS_FAIL=0
+	export POST_REVIEW_DECISION=""
+	cat >"$REVIEWS_FILE" <<EOF
+[{"id":4782275476,"user":{"login":"coderabbitai[bot]","type":"Bot"},"state":"CHANGES_REQUESTED","commit_id":"${STALE_HEAD}","submitted_at":"2026-07-26T17:52:52Z"}]
+EOF
+	cat >"$COMMENTS_FILE" <<EOF
+[{"id":5084683322,"user":{"login":"coderabbitai[bot]","type":"Bot"},"created_at":"2026-07-26T17:53:09Z","body":"\`@maintainer\` Re-review of exact head \`${CURRENT_HEAD}\` complete — **no blocking findings**.\n<!-- <review_comment_addressed> -->"}]
+EOF
+	return 0
+}
+
+record_result() {
+	local name="$1"
+	local passed="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+	else
+		printf 'FAIL %s\n' "$name"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+run_reconcile() {
+	bash "$REVIEW_HELPER" reconcile-stale-coderabbit 42 owner/repo "$CURRENT_HEAD" >/dev/null 2>&1
+	return $?
+}
+
+assert_blocked_without_dismissal() {
+	local name="$1"
+	local rc=0
+	run_reconcile || rc=$?
+	if [[ "$rc" -ne 0 ]] && ! grep -q "dismissals" "$GH_LOG"; then
+		record_result "$name" 0
+	else
+		record_result "$name" 1
+	fi
+	return 0
+}
+
+test_valid_reconciliation() {
+	reset_fixture
+	local rc=0
+	run_reconcile || rc=$?
+	if [[ "$rc" -eq 0 ]] && grep -q "reviews/4782275476/dismissals" "$GH_LOG" \
+		&& grep -q "$STALE_HEAD" "$GH_LOG" && grep -q "$CURRENT_HEAD" "$GH_LOG"; then
+		record_result "stale CodeRabbit request reconciles with audited SHAs" 0
+	else
+		record_result "stale CodeRabbit request reconciles with audited SHAs" 1
+	fi
+	return 0
+}
+
+test_latest_review_state_reduction() {
+	reset_fixture
+	cat >"$REVIEWS_FILE" <<EOF
+[{"id":1,"user":{"login":"coderabbitai[bot]","type":"Bot"},"state":"CHANGES_REQUESTED","commit_id":"${STALE_HEAD}","submitted_at":"2026-07-26T17:52:52Z"},{"id":2,"user":{"login":"human-reviewer","type":"User"},"state":"CHANGES_REQUESTED","commit_id":"${STALE_HEAD}","submitted_at":"2026-07-26T17:52:53Z"},{"id":3,"user":{"login":"human-reviewer","type":"User"},"state":"APPROVED","commit_id":"${CURRENT_HEAD}","submitted_at":"2026-07-26T17:53:00Z"}]
+EOF
+	local rc=0
+	run_reconcile || rc=$?
+	if [[ "$rc" -eq 0 ]] && grep -q "reviews/1/dismissals" "$GH_LOG" \
+		&& ! grep -q "reviews/2/dismissals" "$GH_LOG"; then
+		record_result "latest state-changing review defines each active blocker" 0
+	else
+		record_result "latest state-changing review defines each active blocker" 1
+	fi
+	return 0
+}
+
+test_fail_closed_cases() {
+	reset_fixture
+	cat >"$REVIEWS_FILE" <<EOF
+[{"id":1,"user":{"login":"coderabbitai[bot]","type":"Bot"},"state":"CHANGES_REQUESTED","commit_id":"${STALE_HEAD}","submitted_at":"2026-07-26T17:52:52Z"},{"id":2,"user":{"login":"human-reviewer","type":"User"},"state":"CHANGES_REQUESTED","commit_id":"${STALE_HEAD}","submitted_at":"2026-07-26T17:52:53Z"}]
+EOF
+	assert_blocked_without_dismissal "mixed human and bot blockers fail closed"
+
+	reset_fixture
+	jq --arg head "$CURRENT_HEAD" '.[0].commit_id = $head' "$REVIEWS_FILE" >"${REVIEWS_FILE}.new"
+	mv "${REVIEWS_FILE}.new" "$REVIEWS_FILE"
+	assert_blocked_without_dismissal "current-head CodeRabbit request fails closed"
+
+	reset_fixture
+	jq '.[0].user.type = "User"' "$REVIEWS_FILE" >"${REVIEWS_FILE}.new"
+	mv "${REVIEWS_FILE}.new" "$REVIEWS_FILE"
+	assert_blocked_without_dismissal "forged CodeRabbit actor fails closed"
+
+	reset_fixture
+	jq '.[0].body = "No issues found"' "$COMMENTS_FILE" >"${COMMENTS_FILE}.new"
+	mv "${COMMENTS_FILE}.new" "$COMMENTS_FILE"
+	assert_blocked_without_dismissal "ambiguous bot prose fails closed"
+
+	local status=""
+	for status in pending failure; do
+		reset_fixture
+		export STATUS_STATE="$status"
+		assert_blocked_without_dismissal "CodeRabbit status ${status} fails closed"
+	done
+
+	reset_fixture
+	export STATUS_CREATOR_JSON='{"login":"attacker","type":"User"}'
+	assert_blocked_without_dismissal "forged CodeRabbit status creator fails closed"
+
+	reset_fixture
+	export HEAD_DRIFT=1
+	assert_blocked_without_dismissal "head drift before dismissal fails closed"
+
+	reset_fixture
+	export AUTHOR_ASSOCIATION="CONTRIBUTOR"
+	assert_blocked_without_dismissal "untrusted PR author fails closed"
+	return 0
+}
+
+test_aggregate_reread() {
+	reset_fixture
+	export POST_REVIEW_DECISION="CHANGES_REQUESTED"
+	local rc=0
+	run_reconcile || rc=$?
+	if [[ "$rc" -ne 0 ]] && grep -q "dismissals" "$GH_LOG"; then
+		record_result "aggregate review state is re-read after dismissal" 0
+	else
+		record_result "aggregate review state is re-read after dismissal" 1
+	fi
+	return 0
+}
+
+test_full_loop_readiness_integration() {
+	reset_fixture
+	SCRIPT_DIR="$SCRIPTS_DIR"
+	print_error() { return 0; }
+	print_info() { return 0; }
+	print_success() { return 0; }
+	print_warning() { return 0; }
+	# shellcheck source=../full-loop-helper-commit.sh
+	source "${SCRIPTS_DIR}/full-loop-helper-commit.sh"
+	local rc=0
+	_full_loop_verify_pr_readiness 42 owner/repo >/dev/null 2>&1 || rc=$?
+	if [[ "$rc" -eq 0 ]] && grep -q "dismissals" "$GH_LOG" \
+		&& grep -q "pr checks 42" "$GH_LOG"; then
+		record_result "full-loop readiness reconciles before required checks" 0
+	else
+		record_result "full-loop readiness reconciles before required checks" 1
+	fi
+	return 0
+}
+
+main() {
+	test_valid_reconciliation
+	test_latest_review_state_reduction
+	test_fail_closed_cases
+	test_aggregate_reread
+	test_full_loop_readiness_integration
+	printf 'Ran %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]] || return 1
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -146,6 +146,12 @@ write_gh_stub_pr_issue_views() {
 	cat >>"${TEST_ROOT}/bin/gh" <<GHSTUB
 
 	if [[ "\$_gh_cmd" == "pr" && "\$_gh_sub" == "view" ]]; then
+	if [[ "\$*" == *"--json state,isDraft,reviewDecision,headRefOid"* ]]; then
+		_review_decision=""
+		[[ "$mode" == "late-review-block" ]] && _review_decision="CHANGES_REQUESTED"
+		printf '{"state":"OPEN","isDraft":false,"reviewDecision":"%s","headRefOid":"abc123headsha"}\n' "\$_review_decision"
+		exit 0
+	fi
 	if [[ "\$*" == *"--json state,mergedAt,mergeCommit"* ]]; then
 		_evidence_count=0
 		if [[ -f "${TEST_ROOT}/logs/evidence-count.txt" ]]; then
@@ -546,6 +552,19 @@ test_other_error_no_fallback() {
 	fi
 	print_result "other error: no signaling artifacts" "$any_signaling"
 
+	return 0
+}
+
+test_late_review_blocks_every_merge_transport() {
+	rm -f "${TEST_ROOT}/logs/"*.txt
+	create_gh_stub "late-review-block"
+
+	local exit_code=0
+	run_merge_execute "42" "testorg/testrepo" "--squash" "1" "0" >/dev/null 2>&1 || exit_code=$?
+	local merge_calls=0
+	merge_calls=$(grep -c '^gh pr merge' "${TEST_ROOT}/logs/gh-calls.txt" 2>/dev/null || true)
+	print_result "late review: live CHANGES_REQUESTED blocks merge" "$((exit_code == 0 ? 1 : 0))"
+	print_result "late review: admin merge transport is never invoked" "$((merge_calls == 0 ? 0 : 1))" "merge_calls=$merge_calls"
 	return 0
 }
 
@@ -981,6 +1000,7 @@ main() {
 	test_admin_fallback_blocks_needs_maintainer_review_issue
 	test_explicit_admin_no_signaling
 	test_other_error_no_fallback
+	test_late_review_blocks_every_merge_transport
 	test_graphql_rate_limit_rest_fallback
 	test_graphql_rate_limit_cmd_merge_phase_autofile
 	test_graphql_rate_limit_auto_no_rest_fallback

--- a/.agents/scripts/tests/test-pulse-merge-coderabbit-nits-ok.sh
+++ b/.agents/scripts/tests/test-pulse-merge-coderabbit-nits-ok.sh
@@ -51,10 +51,11 @@ print_result() {
 # Reset review fixture to the default (two CR-only CHANGES_REQUESTED reviews).
 reset_mock_state() {
 	: >"$GH_LOG"
+	export PR_HAS_NITS_LABEL=1
 	cat >"${TEST_ROOT}/reviews.json" <<'EOF'
 [
-  {"id": 1001, "user": {"login": "coderabbitai[bot]"}, "state": "CHANGES_REQUESTED"},
-  {"id": 1002, "user": {"login": "coderabbitai[bot]"}, "state": "CHANGES_REQUESTED"}
+  {"id": 1001, "user": {"login": "coderabbitai[bot]", "type": "Bot"}, "state": "CHANGES_REQUESTED", "commit_id": "1111111111111111111111111111111111111111", "submitted_at": "2026-07-26T10:00:00Z"},
+  {"id": 1002, "user": {"login": "coderabbitai[bot]", "type": "Bot"}, "state": "CHANGES_REQUESTED", "commit_id": "2222222222222222222222222222222222222222", "submitted_at": "2026-07-26T10:01:00Z"}
 ]
 EOF
 	return 0
@@ -65,6 +66,7 @@ setup_test_env() {
 	mkdir -p "${TEST_ROOT}/bin"
 	export PATH="${TEST_ROOT}/bin:${PATH}"
 	export LOGFILE="${TEST_ROOT}/pulse.log"
+	export AIDEVOPS_REVIEW_BOT_GATE_HELPER="${SCRIPT_DIR}/../review-bot-gate-helper.sh"
 	: >"$LOGFILE"
 	GH_LOG="${TEST_ROOT}/gh-calls.log"
 	: >"$GH_LOG"
@@ -101,6 +103,19 @@ if [[ "${1:-}" == "api" ]]; then
 	if [[ "$*" == *"dismissals"* || "$*" == *"-X PUT"* ]]; then
 		exit 0
 	fi
+
+	# GET /pulls/<number> snapshot used for the pre-dismiss head-drift guard.
+	if [[ "$*" == *"/pulls/"* && "$*" != *"/reviews"* ]]; then
+		_labels='[]'
+		[[ "${PR_HAS_NITS_LABEL:-0}" == "1" ]] && _labels='[{"name":"coderabbit-nits-ok"}]'
+		printf '%s\n' "{\"state\":\"open\",\"head\":{\"sha\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"},\"author_association\":\"CONTRIBUTOR\",\"labels\":${_labels}}"
+		exit 0
+	fi
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+	printf '%s\n' '{"headRefOid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","reviewDecision":""}'
+	exit 0
 fi
 
 exit 0
@@ -175,8 +190,8 @@ test_case_b_mixed_reviewers_returns_1_no_dismissals() {
 	# Override fixture: one CR review + one human review.
 	cat >"${TEST_ROOT}/reviews.json" <<'EOF'
 [
-  {"id": 2001, "user": {"login": "coderabbitai[bot]"}, "state": "CHANGES_REQUESTED"},
-  {"id": 2002, "user": {"login": "human-reviewer"}, "state": "CHANGES_REQUESTED"}
+  {"id": 2001, "user": {"login": "coderabbitai[bot]", "type": "Bot"}, "state": "CHANGES_REQUESTED", "commit_id": "1111111111111111111111111111111111111111", "submitted_at": "2026-07-26T10:00:00Z"},
+  {"id": 2002, "user": {"login": "human-reviewer", "type": "User"}, "state": "CHANGES_REQUESTED", "commit_id": "2222222222222222222222222222222222222222", "submitted_at": "2026-07-26T10:01:00Z"}
 ]
 EOF
 	: >"$GH_LOG"
@@ -209,7 +224,7 @@ test_case_c_no_changes_requested_reviews_returns_0() {
 	# Override fixture: no CHANGES_REQUESTED reviews (e.g. already dismissed).
 	cat >"${TEST_ROOT}/reviews.json" <<'EOF'
 [
-  {"id": 3001, "user": {"login": "coderabbitai[bot]"}, "state": "APPROVED"}
+  {"id": 3001, "user": {"login": "coderabbitai[bot]", "type": "Bot"}, "state": "APPROVED", "commit_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "submitted_at": "2026-07-26T10:00:00Z"}
 ]
 EOF
 	: >"$GH_LOG"
@@ -260,6 +275,24 @@ test_case_d_empty_reviews_array_returns_0() {
 	return 0
 }
 
+# =============================================================================
+# Case E: shared helper must enforce the explicit maintainer label itself.
+# =============================================================================
+
+test_case_e_missing_label_returns_1_no_dismissals() {
+	reset_mock_state
+	export PR_HAS_NITS_LABEL=0
+	local result=0
+	_pulse_merge_dismiss_coderabbit_nits "500" "owner/repo" || result=$?
+	if [[ "$result" -ne 0 ]] && ! grep -q "dismissals" "$GH_LOG"; then
+		print_result "Case E: missing nits label — returns 1, no dismissals" 0
+	else
+		print_result "Case E: missing nits label — returns 1, no dismissals" 1 \
+			"Expected fail-closed result without dismissal. Log: $(cat "$GH_LOG")"
+	fi
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -273,6 +306,7 @@ main() {
 	test_case_b_mixed_reviewers_returns_1_no_dismissals
 	test_case_c_no_changes_requested_reviews_returns_0
 	test_case_d_empty_reviews_array_returns_0
+	test_case_e_missing_label_returns_1_no_dismissals
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Automatically reconcile superseded CodeRabbit `CHANGES_REQUESTED` reviews only when a trusted-author PR has deterministic clean re-review evidence and a successful CodeRabbit status on the exact current head.

- Reduce each reviewer's history to the latest state-changing review, preserving active human and current-head blockers.
- Share guarded dismissal mechanics with the explicit `coderabbit-nits-ok` override while independently verifying that label.
- Fail closed on malformed evidence, untrusted authors, forged status creators, head drift, aggregate blockers, and late review changes before merge transport.

## Files Changed

- `.agents/scripts/review-bot-gate-helper.sh`
- `.agents/scripts/full-loop-helper-commit.sh`
- `.agents/scripts/full-loop-helper-merge.sh`
- `.agents/scripts/pulse-merge-process.sh`
- `.agents/scripts/tests/test-full-loop-helper-coderabbit-reconcile.sh`
- `.agents/scripts/tests/test-full-loop-merge.sh`
- `.agents/scripts/tests/test-pulse-merge-coderabbit-nits-ok.sh`
- `.agents/reference/review-bot-gate.md`

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — ShellCheck; `.agents/scripts/linters-local.sh --changed`; 13 reconciliation tests; 5 nits-label tests; 56 merge tests; remote-evidence, orchestration, Pulse CI/review-thread, and review-bot snapshot/completion regression suites.

Resolves #28676

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.181 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 37m and 559,788 tokens on this as a headless worker.
