### PR TITLE
GH#28681: Align dependent child auto-dispatch

### DIFF
--- a/.agents/reference/parent-task-lifecycle.md
+++ b/.agents/reference/parent-task-lifecycle.md
@@ -55,6 +55,20 @@ Env override: `PARENT_DECOMPOSITION_ESCALATION_HOURS` (default 168). Capped at `
 
 `.agents/scripts/tests/test-parent-prose-child-detection.sh`, `test-parent-task-application-warn.sh`, `test-parent-decomposition-escalation.sh`, `test-auto-decomposer-scanner.sh`, `test-auto-decomposer-per-parent-gate.sh` (84+ structural assertions total).
 
+## Child Dispatch Contract
+
+- The roadmap issue keeps `parent-task` and never receives `auto-dispatch`.
+- Independent worker-ready children use `auto-dispatch,status:available` and may
+  run in parallel.
+- In an ordered chain, only the first ready child is available. Every later
+  worker-ready child keeps `auto-dispatch,status:blocked` plus a verified native
+  `blockedBy` relationship and an auditable textual marker.
+- Issue publication must fail closed: never expose a dependent child as
+  available before its native edge is verified.
+- Pulse owns the handoff. When every blocker closes, dependency reconciliation
+  changes the next child to `status:available`; the completing worker closes
+  only its own issue and does not remove successor blockers or labels manually.
+
 ## Sequential Phase Auto-File (t2740, enabled by default since t2787)
 
 The sequential phase auto-file mechanism reads phase declarations from the parent-task issue body and files the **next unfiled phase** as a child issue automatically once the prior phase's PR merges.
@@ -69,7 +83,7 @@ Two formats are supported. Both are parsed by `_extract_sequential_phases` in `s
 
 **List format (preferred — auto-fire enabled by default):**
 
-```
+```markdown
 - Phase 1 - description [auto-fire:on-prior-merge]
 - Phase 2 - description [auto-fire:on-prior-merge]
 - Phase 3 - description
@@ -77,14 +91,14 @@ Two formats are supported. Both are parsed by `_extract_sequential_phases` in `s
 
 Bullet-wrapped bold headings are also accepted, which is the common parent-brief style:
 
-```
+```markdown
 - **Phase 1 — description**: optional detail text.
 - **Phase 2 — design CLI `new|list|status` surface**: pipes in CLI prose are text, not child references.
 ```
 
 **Narrative bold-heading format (for prose-style decomposition plans):**
 
-```
+```markdown
 **Phase 1 — description [auto-fire:on-prior-merge]**
 Detailed implementation notes for Phase 1...
 

--- a/.agents/reference/task-lifecycle.md
+++ b/.agents/reference/task-lifecycle.md
@@ -37,10 +37,14 @@ Dependency rule: when a TODO/issue declares ordered work with `blocked-by:*`
 or `blocks:*`, preserve the text marker for human/reconciliation context and
 sync it into GitHub's native issue relationship field. The native `blockedBy`
 relationship is the primary dispatch gate; body/TODO markers are fallback intent
-and repair signals. If the relationship cannot be created or verified, keep the
-dependent task non-dispatchable (`status:blocked`, no `#auto-dispatch`) until the
-blocker is positively linked or resolved. `issue-sync-relationships.sh` performs
-the normal TODO-to-GitHub relationship backfill.
+and repair signals. Worker-ready ordered leaves retain `#auto-dispatch`: the
+first ready leaf is `status:available`, while every unresolved dependent is
+`status:blocked` after its native edge is verified. If an edge cannot be created
+or verified, fail closed by retaining `status:blocked` and never exposing the
+dependent to the available queue. `issue-sync-relationships.sh` performs the
+normal TODO-to-GitHub relationship backfill and status normalization; Pulse
+changes the next leaf to `status:available` after all blockers close. Workers
+complete only their own leaf and do not manually edit successors.
 
 Task IDs: `/new-task` or `claim-task-id.sh`. NEVER grep TODO.md for next ID.
 
@@ -131,7 +135,7 @@ Do not end a save flow with only "start anytime" when the task is worker-ready; 
   - decomposition or human-decision work;
   - hardware or external service setup;
   - investigation/evaluation without a clear deliverable;
-  - incomplete dependencies; or
+  - dependencies that cannot yet be resolved to verified native relationships; or
   - explicit user preference for interactive/manual handling.
 
   Dispatch-path files are **not** excluded post-t2920; they auto-dispatch with opus-4-7 elevation. Canonical blocker label set: `reference/dispatch-blockers.md`.

--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -379,10 +379,7 @@ mutation($blocked:ID!,$blocking:ID!) {
 	return 1
 }
 
-# Keep a dependency-bearing issue out of the available queue when native
-# relationship repair cannot complete. This is intentionally label-only and
-# retryable: the next relationship pass can repair the edge, while the pulse
-# dependency resolver supplies the positive proof required to unblock it.
+# Keep dependency status normalization from overwriting active lifecycle state.
 _dependency_sync_has_active_status() {
 	local labels_csv="$1"
 	local padded_labels=",${labels_csv},"
@@ -401,7 +398,10 @@ _relationship_task_line() {
 	return 0
 }
 
-_hold_dependency_sync_retry() {
+# Move an inactive dependency-bearing issue out of the available queue. This is
+# intentionally label-only: auto-dispatch remains attached so Pulse can promote
+# the issue after every native blocker closes.
+_ensure_dependency_status_blocked() {
 	local issue_num="$1"
 	local repo="$2"
 	local reason="$3"
@@ -410,14 +410,14 @@ _hold_dependency_sync_retry() {
 	[[ "$issue_num" =~ ^[0-9]+$ && "$repo" == */* ]] || return 1
 	current_labels=$(_gh_with_timeout read gh issue view "$issue_num" --repo "$repo" \
 		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || {
-		log_verbose "$issue_num: dependency_relationship_sync_retryable reason=${reason}_status_read_failed"
+		log_verbose "$issue_num: dependency_status_sync_failed reason=${reason}_status_read_failed"
 		return 1
 	}
 	[[ ",${current_labels}," == *",status:available,"* ]] || return 0
 	_dependency_sync_has_active_status "$current_labels" && return 0
 	if ! _gh_with_timeout write gh issue edit "$issue_num" --repo "$repo" \
 		--remove-label "status:available" --add-label "status:blocked" >/dev/null 2>&1; then
-		log_verbose "$issue_num: dependency_relationship_sync_retryable reason=${reason}_status_write_failed"
+		log_verbose "$issue_num: dependency_status_sync_failed reason=${reason}_status_write_failed"
 		return 1
 	fi
 	# A dispatcher may have advanced state between the read and edit. Repair any
@@ -427,6 +427,21 @@ _hold_dependency_sync_retry() {
 	if _dependency_sync_has_active_status "$current_labels" && \
 		[[ ",${current_labels}," == *",status:blocked,"* ]]; then
 		_gh_with_timeout write gh issue edit "$issue_num" --repo "$repo" --remove-label "status:blocked" >/dev/null 2>&1 || true
+	fi
+	log_verbose "$issue_num: dependency_status_blocked reason=${reason}"
+	return 0
+}
+
+# Keep a dependency-bearing issue out of the available queue when native
+# relationship repair cannot complete. The next relationship pass can repair
+# the edge, while Pulse supplies the positive proof required to unblock it.
+_hold_dependency_sync_retry() {
+	local issue_num="$1"
+	local repo="$2"
+	local reason="$3"
+	if ! _ensure_dependency_status_blocked "$issue_num" "$repo" "$reason"; then
+		log_verbose "$issue_num: dependency_relationship_sync_retryable reason=${reason}_status_sync_failed"
+		return 1
 	fi
 	log_verbose "$issue_num: dependency_relationship_sync_retryable reason=${reason}"
 	return 0
@@ -594,6 +609,10 @@ _sync_declared_blocked_by_edges() {
 			fi
 			if ! _relationship_edge_should_attempt "$this_gh_num" "$dep_gh_num"; then
 				log_verbose "$task_id: skipping duplicate native edge #$this_gh_num blocked-by #$dep_gh_num"
+				if [[ "$DRY_RUN" != "true" ]] && ! _ensure_dependency_status_blocked \
+					"$this_gh_num" "$repo" "native_relationship_already_attempted"; then
+					retryable_errors=$((retryable_errors + 1))
+				fi
 				continue
 			fi
 			local dep_node_id
@@ -601,6 +620,7 @@ _sync_declared_blocked_by_edges() {
 			if [[ -z "$dep_node_id" ]]; then
 				_relationship_record_outcome "$_REL_OUTCOME_FAILED_RESOLUTION"
 				retryable_errors=$((retryable_errors + 1))
+				_hold_dependency_sync_retry "$this_gh_num" "$repo" "blocking_node_unresolved"
 				continue
 			fi
 
@@ -620,8 +640,13 @@ _sync_declared_blocked_by_edges() {
 			elif _gh_add_blocked_by "$this_node_id" "$dep_node_id"; then
 				log_verbose "$task_id (#$this_gh_num) blocked-by $dep_task_id (#$dep_gh_num) ✓"
 				rels_set=$((rels_set + 1))
+				if ! _ensure_dependency_status_blocked \
+					"$this_gh_num" "$repo" "native_relationship_linked"; then
+					retryable_errors=$((retryable_errors + 1))
+				fi
 			else
 				retryable_errors=$((retryable_errors + 1))
+				_hold_dependency_sync_retry "$this_gh_num" "$repo" "native_relationship_write_failed"
 			fi
 	done
 	IFS="$saved_ifs"
@@ -657,6 +682,10 @@ _sync_declared_blocks_edges() {
 			[[ "$dep_gh_num" == "$this_gh_num" ]] && continue
 			if ! _relationship_edge_should_attempt "$dep_gh_num" "$this_gh_num"; then
 				log_verbose "$task_id: skipping duplicate native edge #$dep_gh_num blocked-by #$this_gh_num"
+				if [[ "$DRY_RUN" != "true" ]] && ! _ensure_dependency_status_blocked \
+					"$dep_gh_num" "$repo" "native_relationship_already_attempted"; then
+					retryable_errors=$((retryable_errors + 1))
+				fi
 				continue
 			fi
 			local dep_node_id
@@ -685,6 +714,10 @@ _sync_declared_blocks_edges() {
 			elif _gh_add_blocked_by "$dep_node_id" "$this_node_id"; then
 				log_verbose "$dep_task_id (#$dep_gh_num) blocked-by $task_id (#$this_gh_num) ✓"
 				rels_set=$((rels_set + 1))
+				if ! _ensure_dependency_status_blocked \
+					"$dep_gh_num" "$repo" "native_relationship_linked"; then
+					retryable_errors=$((retryable_errors + 1))
+				fi
 			else
 				retryable_errors=$((retryable_errors + 1))
 				_hold_dependency_sync_retry "$dep_gh_num" "$repo" "native_relationship_write_failed"
@@ -1874,7 +1907,7 @@ cmd_backfill_cross_phase_blocked_by() {
 			continue
 		fi
 
-		if _backfill_cross_phase_pair "$_bn" "$_lr" "$child_node" "$blocker_node"; then
+		if _backfill_cross_phase_pair "$_bn" "$_lr" "$child_node" "$blocker_node" "$repo"; then
 			pairs_set=$((pairs_set + 1))
 		else
 			pairs_skipped=$((pairs_skipped + 1))
@@ -1888,12 +1921,17 @@ cmd_backfill_cross_phase_blocked_by() {
 
 _backfill_cross_phase_pair() {
 	local blocked_num="$1" blocker_num="$2" child_node="$3" blocker_node="$4"
+	local repo="$5"
 	if [[ "$DRY_RUN" == "true" ]]; then
 		print_info "[DRY-RUN] Would set #$blocked_num blocked-by #$blocker_num"
 		return 0
 	fi
 	if _gh_add_blocked_by "$child_node" "$blocker_node"; then
 		log_verbose "#$blocked_num blocked-by #$blocker_num ✓"
+		if ! _ensure_dependency_status_blocked \
+			"$blocked_num" "$repo" "cross_phase_native_relationship_linked"; then
+			return 1
+		fi
 		return 0
 	fi
 	return 1

--- a/.agents/scripts/tests/test-dependency-readiness-normalization.sh
+++ b/.agents/scripts/tests/test-dependency-readiness-normalization.sh
@@ -45,6 +45,27 @@ assert_true() {
 # shellcheck disable=SC1090
 source "${SCRIPTS_DIR}/pulse-dep-graph.sh"
 
+_test_dep_identity_api() {
+	local endpoint="$1"
+	case "$endpoint" in
+	repos/owner/repo) printf 'R_owner_repo\n' ;;
+	repos/owner/repo/issues/20) printf '20\tI_20\n' ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
+_test_render_args() {
+	local rendered=""
+	local arg=""
+	for arg in "$@"; do
+		[[ -z "$rendered" ]] || rendered="${rendered} "
+		rendered="${rendered}${arg}"
+	done
+	printf '%s' "$rendered"
+	return 0
+}
+
 acc='{"open_nums":[],"closed_nums":[],"known_nums":[],"task_to_issue":{},"blocked_by_map":{},"defer_flags_map":{}}'
 # shellcheck disable=SC2016  # Markdown backticks are literal fixture content.
 issue='{"number":20,"title":"t20: roadmap child","state":"OPEN","body":"**Blocked by:** `t20`, #20, #10","labels":[]}'
@@ -76,14 +97,15 @@ assert_eq "active lifecycle wins blocked available conflict" "in-review" "$(_pic
 status_write=""
 current_status="status:available"
 gh() {
-	if [[ "$1 $2" == "api repos/owner/repo" ]]; then
-		printf 'R_owner_repo\n'
-	elif [[ "$1 $2" == "issue view" && "$*" == *"--json id,number"* ]]; then
-		printf '{"id":"I_20","number":20}\n'
-	elif [[ "$1 $2" == "issue view" ]]; then
+	local command="$1"
+	local target="${2:-}"
+	if [[ "$command" == "api" ]]; then
+		_test_dep_identity_api "$target"
+		return $?
+	elif [[ "$command $target" == "issue view" ]]; then
 		printf '%s\n' "$current_status"
-	elif [[ "$1 $2" == "issue edit" ]]; then
-		status_write="$*"
+	elif [[ "$command $target" == "issue edit" ]]; then
+		status_write=$(_test_render_args "$@")
 		current_status="status:blocked"
 	fi
 	return 0
@@ -95,11 +117,12 @@ assert_eq "available issue normalized blocked" "issue edit 20 --repo owner/repo 
 status_write=""
 current_status="status:available,status:queued"
 gh() {
-	if [[ "$1 $2" == "api repos/owner/repo" ]]; then
-		printf 'R_owner_repo\n'
-	elif [[ "$1 $2" == "issue view" && "$*" == *"--json id,number"* ]]; then
-		printf '{"id":"I_20","number":20}\n'
-	elif [[ "$1 $2" == "issue view" ]]; then
+	local command="$1"
+	local target="${2:-}"
+	if [[ "$command" == "api" ]]; then
+		_test_dep_identity_api "$target"
+		return $?
+	elif [[ "$command $target" == "issue view" ]]; then
 		printf '%s\n' "$current_status"
 	fi
 	return 0
@@ -112,11 +135,12 @@ status_write=""
 view_counter_file="${TMP_ROOT}/view-count"
 printf '0\n' >"$view_counter_file"
 gh() {
-	if [[ "$1 $2" == "api repos/owner/repo" ]]; then
-		printf 'R_owner_repo\n'
-	elif [[ "$1 $2" == "issue view" && "$*" == *"--json id,number"* ]]; then
-		printf '{"id":"I_20","number":20}\n'
-	elif [[ "$1 $2" == "issue view" ]]; then
+	local command="$1"
+	local target="${2:-}"
+	if [[ "$command" == "api" ]]; then
+		_test_dep_identity_api "$target"
+		return $?
+	elif [[ "$command $target" == "issue view" ]]; then
 		local view_count=""
 		view_count=$(<"$view_counter_file")
 		view_count=$((view_count + 1))
@@ -126,8 +150,8 @@ gh() {
 		else
 			printf 'status:queued,status:blocked\n'
 		fi
-	elif [[ "$1 $2" == "issue edit" ]]; then
-		status_write="${status_write}${*}"$'\n'
+	elif [[ "$command $target" == "issue edit" ]]; then
+		status_write="${status_write}$(_test_render_args "$@")"$'\n'
 	fi
 	return 0
 }
@@ -158,6 +182,111 @@ source "${SCRIPTS_DIR}/issue-sync-lib-parse.sh"
 # shellcheck disable=SC1090
 source "${SCRIPTS_DIR}/issue-sync-relationships.sh"
 assert_true "concurrent native relationship write is idempotent" _gh_add_blocked_by "I_blocked" "I_blocker"
+
+dependency_status="status:available,auto-dispatch"
+dependency_status_writes=""
+gh() {
+	local command="$1"
+	local target="${2:-}"
+	if [[ "$command $target" == "issue view" ]]; then
+		printf '%s\n' "$dependency_status"
+	elif [[ "$command $target" == "issue edit" ]]; then
+		dependency_status_writes="${dependency_status_writes}$(_test_render_args "$@")"$'\n'
+		dependency_status="status:blocked,auto-dispatch"
+	fi
+	return 0
+}
+export -f gh
+assert_true "linked dependency moves available issue to blocked" \
+	_ensure_dependency_status_blocked "20" "owner/repo" "native_relationship_linked"
+assert_true "dependency status edit preserves auto-dispatch" \
+	grep -Fq -- "issue edit 20 --repo owner/repo --remove-label status:available --add-label status:blocked" \
+	<<<"$dependency_status_writes"
+assert_eq "auto-dispatch remains attached after dependency status edit" \
+	"status:blocked,auto-dispatch" "$dependency_status"
+
+dependency_status="status:available,status:in-progress,auto-dispatch"
+dependency_status_writes=""
+assert_true "active dependency lifecycle is left unchanged" \
+	_ensure_dependency_status_blocked "20" "owner/repo" "native_relationship_linked"
+assert_eq "active dependency lifecycle receives no status write" "" "$dependency_status_writes"
+
+_run_relationship_status_sync_cases() (
+	local dependency_status="status:available,auto-dispatch"
+	local dependency_status_writes=""
+	local cross_phase_rc=0
+
+	_relationship_deadline_expired() {
+		return 1
+	}
+	resolve_task_gh_number() {
+		local task_id="$1"
+		case "$task_id" in
+		t10) printf '10\n' ;;
+		t20) printf '20\n' ;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
+	_relationship_edge_should_attempt() {
+		return 0
+	}
+	_cached_node_id() {
+		local issue_num="$1"
+		printf 'I_%s\n' "$issue_num"
+		return 0
+	}
+	_dependency_cycle_should_skip_edge() {
+		return 1
+	}
+	_gh_add_blocked_by() {
+		return 0
+	}
+	_relationship_record_outcome() {
+		return 0
+	}
+	gh() {
+		local command="$1"
+		local target="${2:-}"
+		if [[ "$command $target" == "issue view" ]]; then
+			printf '%s\n' "$dependency_status"
+		elif [[ "$command $target" == "issue edit" ]]; then
+			dependency_status_writes="${dependency_status_writes}$(_test_render_args "$@")"$'\n'
+			dependency_status="status:blocked,auto-dispatch"
+		fi
+		return 0
+	}
+	DRY_RUN="false"
+
+	_sync_declared_blocked_by_edges "t20" "/dev/null" "owner/repo" "20" "I_20" "t10" \
+		>"${TMP_ROOT}/direct-blocked-by.out"
+	printf '%s' "$dependency_status_writes" >"${TMP_ROOT}/direct-blocked-by-writes.out"
+
+	dependency_status="status:available,auto-dispatch"
+	dependency_status_writes=""
+	_sync_declared_blocks_edges "t10" "/dev/null" "owner/repo" "10" "I_10" "t20" \
+		>"${TMP_ROOT}/inverse-blocks.out"
+	printf '%s' "$dependency_status_writes" >"${TMP_ROOT}/inverse-blocks-writes.out"
+
+	dependency_status="status:available,auto-dispatch"
+	dependency_status_writes=""
+	_backfill_cross_phase_pair "20" "10" "I_20" "I_10" "owner/repo" || cross_phase_rc=$?
+	printf '%s' "$dependency_status_writes" >"${TMP_ROOT}/cross-phase-writes.out"
+	return "$cross_phase_rc"
+)
+
+relationship_sync_rc=0
+_run_relationship_status_sync_cases || relationship_sync_rc=$?
+assert_true "direct blocked-by sync normalizes the dependent issue" \
+	grep -Fq -- "issue edit 20 --repo owner/repo --remove-label status:available --add-label status:blocked" \
+	"${TMP_ROOT}/direct-blocked-by-writes.out"
+assert_true "inverse blocks sync normalizes the dependent issue" \
+	grep -Fq -- "issue edit 20 --repo owner/repo --remove-label status:available --add-label status:blocked" \
+	"${TMP_ROOT}/inverse-blocks-writes.out"
+assert_eq "cross-phase sync succeeds" "0" "$relationship_sync_rc"
+assert_true "cross-phase sync normalizes the dependent issue" \
+	grep -Fq -- "issue edit 20 --repo owner/repo --remove-label status:available --add-label status:blocked" \
+	"${TMP_ROOT}/cross-phase-writes.out"
 
 gh() {
 	if [[ "$*" == *"query("* ]]; then
@@ -318,11 +447,12 @@ status_write=""
 view_counter_file="${TMP_ROOT}/unblock-view-count"
 printf '0\n' >"$view_counter_file"
 gh() {
-	if [[ "$1 $2" == "api repos/owner/repo" ]]; then
-		printf 'R_owner_repo\n'
-	elif [[ "$1 $2" == "issue view" && "$*" == *"--json id,number"* ]]; then
-		printf '{"id":"I_20","number":20}\n'
-	elif [[ "$1 $2" == "issue view" ]]; then
+	local command="$1"
+	local target="${2:-}"
+	if [[ "$command" == "api" ]]; then
+		_test_dep_identity_api "$target"
+		return $?
+	elif [[ "$command $target" == "issue view" ]]; then
 		local view_count=""
 		view_count=$(<"$view_counter_file")
 		view_count=$((view_count + 1))
@@ -331,8 +461,8 @@ gh() {
 			1 | 2) printf 'status:blocked\n' ;;
 			*) printf 'status:queued,status:available\n' ;;
 		esac
-	elif [[ "$1 $2" == "issue edit" ]]; then
-		status_write="${status_write}${*}"$'\n'
+	elif [[ "$command $target" == "issue edit" ]]; then
+		status_write="${status_write}$(_test_render_args "$@")"$'\n'
 	fi
 	return 0
 }

--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -28,7 +28,7 @@ mode: subagent
 - **Session:** {app}:{session-id}
 - **Created by:** {author} (human | ai-supervisor | ai-interactive)
 - **Parent task:** {parent_id} (if subtask)
-- **Blocked by:** {GitHub issue relationship(s) + optional `blocked-by:tNNN/#NNN` marker; if unresolved, keep `status:blocked` and omit `#auto-dispatch`}
+- **Blocked by:** {GitHub native relationship(s) + optional `blocked-by:tNNN/#NNN` marker; worker-ready ordered leaves keep `#auto-dispatch` plus `status:blocked` after the relationship is verified, while unverifiable edges stay blocked and out of the available queue}
 - **Conversation context:** {1-2 sentence summary of what was discussed that led to this task}
 
 ## What

--- a/.agents/tests/test-pulse-dep-graph-blocked-by.sh
+++ b/.agents/tests/test-pulse-dep-graph-blocked-by.sh
@@ -122,25 +122,27 @@ gh_issue_list() {
 }
 
 gh() {
-	if [[ "${1:-}" == "api" && "${2:-}" == "graphql" ]]; then
+	local command="${1:-}"
+	local target="${2:-}"
+	if [[ "$command" == "api" && "$target" == "graphql" ]]; then
 		case "${TEST_GH_RELATIONSHIP_MODE:-clear}" in
 			fail)
 				return 1
 				;;
 			open)
-				printf '1000:OPEN\n'
+				printf '%s\n' '{"data":{"repository":{"issue":{"blockedBy":{"nodes":[{"number":1000,"state":"OPEN"}],"pageInfo":{"hasNextPage":false}}}},"rateLimit":{"cost":1}}}'
 				return 0
 				;;
 			closed)
-				printf '1000:CLOSED\n'
+				printf '%s\n' '{"data":{"repository":{"issue":{"blockedBy":{"nodes":[{"number":1000,"state":"CLOSED"}],"pageInfo":{"hasNextPage":false}}}},"rateLimit":{"cost":1}}}'
 				return 0
 				;;
 			unknown)
-				printf '1000:\n'
+				printf '%s\n' '{"data":{"repository":{"issue":{"blockedBy":{"nodes":[{"number":1000,"state":null}],"pageInfo":{"hasNextPage":false}}}},"rateLimit":{"cost":1}}}'
 				return 0
 				;;
 			*)
-				printf '\n'
+				printf '%s\n' '{"data":{"repository":{"issue":{"blockedBy":{"nodes":[],"pageInfo":{"hasNextPage":false}}}},"rateLimit":{"cost":1}}}'
 				return 0
 				;;
 		esac

--- a/.agents/workflows/brief.md
+++ b/.agents/workflows/brief.md
@@ -133,9 +133,17 @@ When composing TODOs or issues that must run in sequence, include the textual
 `blocked-by:*` or `blocks:*` marker for auditability and ensure the GitHub native
 issue relationship is or will be synced. Treat GitHub's `blockedBy` relationship
 as the primary dispatch gate; body markers are fallback intent for
-`issue-sync-relationships.sh` and pulse repair. If a blocker cannot be resolved
-to a GitHub issue relationship, mark the dependent issue `status:blocked` and do
-not add `#auto-dispatch` until the relationship exists or the blocker is closed.
+`issue-sync-relationships.sh` and Pulse repair.
+
+For an ordered worker-ready chain, the first leaf uses `#auto-dispatch` with
+`status:available`; every later leaf uses `#auto-dispatch` with `status:blocked`
+after its native relationship is verified. During publication, fail closed:
+never expose a dependent leaf as available before the edge is verified. If the
+edge cannot be resolved, retain `status:blocked` and repair the relationship.
+Once every blocker closes, Pulse changes the next leaf to `status:available`;
+the completing worker closes only its own leaf and does not edit its successor.
+Independent children may remain `status:available` for parallel dispatch, while
+the roadmap parent keeps `parent-task` and never receives `#auto-dispatch`.
 
 ## Seeded Draft PR Decision
 

--- a/.agents/workflows/new-task.md
+++ b/.agents/workflows/new-task.md
@@ -120,7 +120,7 @@ After the brief is worker-ready, consider an optional implementation-seeded draf
 Run `task-decompose-helper.sh classify "{title}"` if available. Skip with `--no-decompose` or if helper missing (t1408.1).
 
 - **Atomic (default):** Proceed to Step 4.
-- **Composite:** Present decomposition tree. If approved: allocate `{task_id}.N` IDs via `claim-task-id.sh`, create brief per subtask, add `blocked-by:` edges, mark parent `status:blocked`. Each subtask brief must (1) reference parent, (2) inherit parent context, (3) include supervisor session ID, (4) set `blocked-by:` from `depends_on`. `batch_strategy` (depth-first/breadth-first) informs pulse dispatch ordering.
+- **Composite:** Present decomposition tree. If approved: allocate `{task_id}.N` IDs via `claim-task-id.sh`, create a brief per subtask, add textual and native `blockedBy` edges, and mark the parent `parent-task`. Each subtask brief must (1) reference the parent, (2) inherit parent context, (3) include the supervisor session ID, and (4) set `blocked-by:` from `depends_on`. Worker-ready roots and independent children use `#auto-dispatch` plus `status:available`; worker-ready dependent children use `#auto-dispatch` plus `status:blocked` after their native edges are verified. `batch_strategy` (depth-first/breadth-first) informs Pulse ordering. Pulse promotes resolved dependents; workers do not edit successors manually.
 
 ### Step 3.6: Declare Phases for Parent Tasks
 
@@ -188,7 +188,7 @@ If any readiness element is missing, finish the brief before filing/queueing; if
 - Decomposition or human-decision work
 - Hardware or external service setup
 - Investigation/evaluation without a clear deliverable
-- Incomplete dependencies
+- Dependencies that cannot yet be resolved to verified native relationships
 - Explicit user preference for interactive/manual handling
 
 Canonical dispatch-blocker labels: `reference/dispatch-blockers.md`.


### PR DESCRIPTION
## Summary

- keep worker-ready ordered children auto-dispatchable while native dependency status gates execution
- normalize inactive dependent issues from `status:available` to `status:blocked` after direct, inverse, duplicate, and cross-phase relationship synchronization
- preserve active lifecycle races, propagate retryable status failures, and align canonical issue-authoring guidance
- refresh native `blockedBy` test fixtures to the current cost-bearing GraphQL response contract

## Testing

- `bash .agents/scripts/tests/test-dependency-readiness-normalization.sh` — 42 passed
- `bash .agents/tests/test-pulse-dep-graph-blocked-by.sh` — 31 passed
- `bash .agents/scripts/tests/test-dependency-event-reconciler.sh` — 40 passed
- `bash .agents/scripts/tests/test-issue-sync-relationship-deadline.sh` — passed
- `.agents/scripts/linters-local.sh --changed` — passed

Resolves #28681

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.181 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 1d 19h and 15,956,576 tokens on this with the user in an interactive session.