### PR TITLE
GH#28684: Deduplicate GUI job refresh polling

### DIFF
--- a/packages/gui-web/src/InventorySurfaces.tsx
+++ b/packages/gui-web/src/InventorySurfaces.tsx
@@ -3,6 +3,7 @@ import { type CSSProperties, type Dispatch, type FocusEvent as ReactFocusEvent, 
 import { ManagedAppPanel } from "./ManagedAppPanel";
 import { text } from "./app-model";
 import { RecommendedAppsSurface, nextRecommendedFilterValue, recommendedAppMatchesFilters, recommendedApps, type RecommendedOsId, type RecommendedPlatformFilterId } from "./RecommendedAppsSurface";
+import { useRunningJobRefresh } from "./useRunningJobRefresh";
 
 export { EditableInventorySurface, InstallationSurface } from "./InventoryEditorSurfaces";
 export { nextRecommendedFilterValue } from "./RecommendedAppsSurface";
@@ -32,23 +33,7 @@ export function AppsSurface({ status }: { status: GuiStatusData }): ReactElement
   }, [firstVisibleManagedAppId]);
 
   const runningJobIdsKey = Object.values(jobs).filter((job) => job.status === "running").map((job) => job.id).sort().join("|");
-
-  useEffect(() => {
-    const runningJobIds = runningJobIdsKey.split("|").filter(Boolean);
-    if (runningJobIds.length === 0) {
-      return undefined;
-    }
-
-    const refreshRunningJobs = () => {
-      for (const jobId of runningJobIds) {
-        void refreshJob(jobId, setJobs);
-      }
-    };
-    refreshRunningJobs();
-    const timer = window.setInterval(refreshRunningJobs, 1_500);
-
-    return () => window.clearInterval(timer);
-  }, [runningJobIdsKey]);
+  useRunningJobRefresh(runningJobIdsKey, refreshJob, setJobs);
 
   return (
     <section className="apps-surface" aria-label={text.apps} onBlur={() => setTooltip(null)} onFocus={showFocusedAppTooltip(setTooltip)} onPointerLeave={() => setTooltip(null)} onPointerMove={showPointedAppTooltip(setTooltip)}>

--- a/packages/gui-web/src/PulseWorkersSurface.tsx
+++ b/packages/gui-web/src/PulseWorkersSurface.tsx
@@ -1,7 +1,8 @@
-import { type CSSProperties, type Dispatch, type ReactElement, type SetStateAction, useEffect, useState } from "react";
+import { type CSSProperties, type Dispatch, type ReactElement, type SetStateAction, useState } from "react";
 import type { GuiPulseWorkerActionJobSummary, GuiPulseWorkerActionSummary, GuiPulseWorkerActivityEvent, GuiPulseWorkerChartSeries, GuiResponseEnvelope, GuiStatusData } from "../../gui-shared/src";
 import { AppActionTerminal } from "./AppActionTerminal";
 import { text } from "./app-model";
+import { useRunningJobRefresh } from "./useRunningJobRefresh";
 
 type PulseEvent = GuiPulseWorkerActivityEvent;
 type PulseFilterGroup = { label: string; values: string[] };
@@ -20,23 +21,7 @@ export function PulseWorkersSurface({ status }: { status: GuiStatusData }): Reac
   const chartSeries = pulse.charts.slice(0, 4);
   const sampleSize = pulse.kpis.reduce((total, kpi) => total + (kpi.sample_size ?? 0), 0);
   const runningJobIdsKey = Object.values(jobs).filter((job) => job.status === "running").map((job) => job.id).sort().join("|");
-
-  useEffect(() => {
-    const runningJobIds = runningJobIdsKey.split("|").filter(Boolean);
-    if (runningJobIds.length === 0) {
-      return undefined;
-    }
-
-    const refreshRunningJobs = () => {
-      for (const jobId of runningJobIds) {
-        void refreshPulseWorkerJob(jobId, setJobs);
-      }
-    };
-    refreshRunningJobs();
-    const timer = window.setInterval(refreshRunningJobs, 1_500);
-
-    return () => window.clearInterval(timer);
-  }, [runningJobIdsKey]);
+  useRunningJobRefresh(runningJobIdsKey, refreshPulseWorkerJob, setJobs);
 
   return (
     <section className="pulse-workers-surface" aria-label={text.workers}>

--- a/packages/gui-web/src/useRunningJobRefresh.ts
+++ b/packages/gui-web/src/useRunningJobRefresh.ts
@@ -1,0 +1,30 @@
+import { type Dispatch, type SetStateAction, useEffect } from "react";
+
+type JobState<Job> = Record<string, Job>;
+type RefreshJob<Job> = (
+  jobId: string,
+  setJobs: Dispatch<SetStateAction<JobState<Job>>>,
+) => Promise<void>;
+
+export function useRunningJobRefresh<Job>(
+  runningJobIdsKey: string,
+  refreshJob: RefreshJob<Job>,
+  setJobs: Dispatch<SetStateAction<JobState<Job>>>,
+): void {
+  useEffect(() => {
+    const runningJobIds = runningJobIdsKey.split("|").filter(Boolean);
+    if (runningJobIds.length === 0) {
+      return undefined;
+    }
+
+    const refreshRunningJobs = () => {
+      for (const jobId of runningJobIds) {
+        void refreshJob(jobId, setJobs);
+      }
+    };
+    refreshRunningJobs();
+    const timer = window.setInterval(refreshRunningJobs, 1_500);
+
+    return () => window.clearInterval(timer);
+  }, [refreshJob, runningJobIdsKey, setJobs]);
+}


### PR DESCRIPTION
## Summary

- extract the duplicated running-job polling effect into a shared typed React hook
- preserve immediate refresh, 1.5-second polling, empty-job no-op, and cleanup behavior in both GUI surfaces
- reduce repository-wide Qlty smells from 55 to the enforced threshold of 53 without changing the ratchet

## Verification

- `npm run gui:typecheck`
- `npm run gui:test:components` — 45 passed
- `npm run gui:build`
- `./.agents/scripts/qlty-smell-threshold-helper.sh .agents/configs/complexity-thresholds.conf` — 53/53
- `./.agents/scripts/linters-local.sh --changed`

Resolves #28684

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.182 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 1d 20h and 16,592,975 tokens on this with the user in an interactive session.