### PR TITLE
GH#28687: Remove unused Reddit stream imports

### DIFF
--- a/.agents/scripts/_knowledge_social_reddit_read_provider.py
+++ b/.agents/scripts/_knowledge_social_reddit_read_provider.py
@@ -23,11 +23,7 @@ from _knowledge_social_reddit_read_contract import (
     identity_value,
     observed_at,
 )
-from _knowledge_social_reddit_read_routes import (
-    LISTING_STREAMS,
-    SNAPSHOT_STREAMS,
-    page as read_page,
-)
+from _knowledge_social_reddit_read_routes import page as read_page
 
 MAX_REQUEST_BYTES = 32 * 1024
 MAX_RESPONSE_BYTES = 8 * 1024 * 1024

--- a/.agents/tests/test-knowledge-social-reddit.sh
+++ b/.agents/tests/test-knowledge-social-reddit.sh
@@ -129,9 +129,10 @@ from pathlib import Path
 
 sys.path.insert(0, sys.argv[1])
 from _knowledge_social_reddit import STREAMS
-from _knowledge_social_reddit_read_provider import LISTING_STREAMS, SNAPSHOT_STREAMS
 from _knowledge_social_reddit_read_routes import (
+    LISTING_STREAMS,
     ProviderPageRequest,
+    SNAPSHOT_STREAMS,
     _listing_generator,
     _snapshot_values,
 )


### PR DESCRIPTION
## Summary

Removed unused stream-set imports from the Reddit read provider and updated the regression test to import those constants from their owning routes module.

## Files Changed

.agents/scripts/_knowledge_social_reddit_read_provider.py, .agents/tests/test-knowledge-social-reddit.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — python3 -m py_compile .agents/scripts/_knowledge_social_reddit_read_provider.py; shellcheck .agents/tests/test-knowledge-social-reddit.sh; bash .agents/tests/test-knowledge-social-reddit.sh (43 passed)

Resolves #28687


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.183 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 2m and 47,867 tokens on this as a headless worker.