### PR TITLE
GH#28691: fix: migrate actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -445,7 +445,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: '3.12'
 
@@ -889,7 +889,7 @@ jobs:
 
     - name: SonarCloud Scan
       if: env.SONAR_TOKEN != ''
-      uses: SonarSource/sonarqube-scan-action@40f5b61913e891f9d316696628698051136015be
+      uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
       # SonarCloud may fail on fork PR merge refs even when SONAR_TOKEN is
       # available (e.g., maintainer re-runs). Non-fatal — other quality tools
       # (Codacy, CodeFactor, Qlty) still provide coverage.
@@ -954,7 +954,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: '20'
 
@@ -1032,7 +1032,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: '20'
 

--- a/.github/workflows/code-review-monitoring.yml
+++ b/.github/workflows/code-review-monitoring.yml
@@ -45,7 +45,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     
     - name: 🐍 Setup Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: '3.11'
     

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -33,7 +33,7 @@ jobs:
             --repo "$GITHUB_REPOSITORY"
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # Node 24 ships npm 11.5+ which natively supports OIDC Trusted Publishers.
           # Do NOT downgrade to 22 + `npm install -g npm@latest` — that self-replaces


### PR DESCRIPTION
## Summary

Update setup-python to v7.0.0, setup-node to v7.0.0, and SonarQube Scan Action to v8.2.1 at official immutable release SHAs; preserve workflow permissions, credentials boundaries, and publication provenance controls.

## Files Changed

.github/workflows/code-quality.yml, .github/workflows/code-review-monitoring.yml, .github/workflows/publish-packages.yml

## Runtime Testing

- **Risk level:** Low
- **Verification:** runtime-verified — Verified the deprecated SHAs have no remaining workflow matches; actionlint passed all three changed workflows; changed-file linters, code-review-monitoring workflow tests, and release-publication workflow tests passed.

Resolves #28691


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.183 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 6m and 75,237 tokens on this as a headless worker.