### PR TITLE
GH#28667: Close X lists and custom-feed account knowledge gaps

### DIFF
--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -30,7 +30,7 @@ a claim that the route is enabled.
 
 | Provider | Authored content | Interactions and curation | Mentions or messages | Relationships and subscriptions | Lists or custom feeds | Current disposition |
 |---|---|---|---|---|---|---|
-| X | **Live** posts | **Live** likes and bookmarks | **Live** mentions | **Live** followers and following | **No** in the current adapter | Maintain the six guarded `xurl` streams; investigate lists separately. |
+| X | **Live** posts | **Live** likes and bookmarks | **Live** mentions | **Live** followers and following | **Live** owned/followed Lists and account memberships; **No** List timelines | Nine guarded `xurl` streams; bounded List snapshots rescan without inferring deletion. |
 | Reddit | **Live** submissions and comments | **Live** saved, votes, and hidden | **Live** mentions, replies, inbox, and sent | **Live** subreddit and account relationships | **Live** multireddits and membership | PRAW 8, bounded one-page reads, independent cursors, and provider-window coverage. |
 | YouTube | **Live** uploads; **Live/Partial** activity | **Live** likes; **No/Export** watch history and Watch Later | **Live/Gate** channel-related comments and replies; **No/Export** complete authored history | **Live** outbound subscriptions | **Live** owned playlists and membership; **No/Export** saved playlists | `youtube.readonly` user OAuth, identity recheck per page, bounded list quota, 30-day refresh/delete boundary, and explicit gap rows. |
 | LinkedIn | **Gate/Export** | **Gate/Export** | **Export** | **Gate/Export** | **Export/No** | Treat member access as restricted; do not reuse browser engagement automation as a collector. |
@@ -59,7 +59,13 @@ a claim that the route is enabled.
 ## Evidence and update discipline
 
 - **Live X:** `.agents/scripts/knowledge_social_x.py` and
-  `.agents/tests/test-knowledge-social-x.sh` prove the six implemented streams.
+  `.agents/tests/test-knowledge-social-x.sh` prove nine implemented streams,
+  including independently checkpointed owned, followed, and membership List
+  snapshots with stable relationship direction. The 2026-07-26 dependency check
+  found no worker-local `xurl`; official v1.3.1 source exposes generic raw GETs
+  but no List shortcut. Official endpoints require `list.read`, `tweet.read`,
+  and `users.read`; List timelines and archive coverage remain explicitly
+  unimplemented.
 - **Live Reddit:** `.agents/scripts/knowledge_social_reddit.py`,
   `.agents/scripts/_knowledge_social_reddit*.py`, and
   `.agents/tests/test-knowledge-social-reddit.sh` prove the stream allowlist,

--- a/.agents/content/social-xurl.md
+++ b/.agents/content/social-xurl.md
@@ -104,10 +104,33 @@ rejects an account mismatch before collection and does not allow an existing
 connection to be rebound to another account.
 
 Supported streams are `authored`, `mentions`, `likes`, `bookmarks`, `followers`,
-and `following`. Each stream owns an independent pagination cursor and
-watermark. After initial backfill, authored and mentions use the official
-`since_id` delta parameter. Streams without an official delta parameter report
-`delta_unavailable` and record the coverage gap without issuing a page request.
+`following`, `owned_lists`, `followed_lists`, and `list_memberships`. Each stream
+owns an independent pagination cursor and watermark. After initial backfill,
+authored and mentions use the official `since_id` delta parameter. The three
+List streams are bounded snapshots that rescan after completion without claiming
+that an absent relationship was deleted. Other streams without an official
+delta parameter report `delta_unavailable` without issuing a page request.
+
+List support was revalidated on 2026-07-26. The implementation worker had no
+installed `xurl` executable, so no local version is claimed; the reviewed
+official upstream baseline was [v1.3.1](https://github.com/xdevplatform/xurl/releases/tag/v1.3.1).
+That release exposes generic raw GET requests but no dedicated List shortcuts.
+The collector therefore allowlists only the official [owned Lists](https://docs.x.com/x-api/users/get-owned-lists.md),
+[followed Lists](https://docs.x.com/x-api/users/get-followed-lists.md), and
+[List memberships](https://docs.x.com/x-api/users/get-list-memberships.md)
+routes. Each accepts 1-100 results, an opaque `pagination_token`, and OAuth user
+scopes `list.read`, `tweet.read`, and `users.read`. Stock `xurl` v1.3.1 requests
+additional write scopes during OAuth, so use an isolated local profile even
+though collector reachability is limited to `whoami` plus exact GET paths.
+
+List timelines and arbitrary List-member expansion remain disabled: they would
+widen content volume and have no documented delta boundary. Account-archive List
+coverage also remains unverified, so there is no archive fallback. Stored X
+evidence remains subject to the current [Developer Agreement](https://docs.x.com/developer-terms/agreement)
+and [Developer Policy](https://docs.x.com/developer-terms/policy): keep offline
+content synchronized with deletion, protection, withholding, and modification;
+honour applicable removal requests within 24 hours; secure private content; and
+do not use API content to train a foundation or frontier model.
 
 `--budget` is a bounded request-cost allowance from 1 to 1000 units, not a retry
 count. Terminal authorization, not-found, rate-limit, and provider failures
@@ -118,7 +141,9 @@ content.
 Media policy `none` stores no media rows. `metadata` stores references and
 content links only; the adapter never downloads media binaries. The provider
 route is externally read-only: it can reach only guarded `whoami` and allowlisted
-official raw-read endpoints, never posting or engagement commands.
+official raw-read endpoints, never posting or engagement commands. The guarded
+raw helper also treats `-d`/`--data` and `-F`/`--file` as write-capable arguments
+because `xurl` turns request bodies into POST requests.
 
 Fixture and fake-executable tests verify pagination, resume, terminal failures,
 credential rejection, and the guarded command route. They do not prove live X

--- a/.agents/scripts/_knowledge_social_x.py
+++ b/.agents/scripts/_knowledge_social_x.py
@@ -28,6 +28,7 @@ class StreamSpec:
     activity_mode: str
     supports_since_id: bool
     cost_units: int = 1
+    refresh_after_complete: bool = False
 
 
 STREAMS = {
@@ -48,6 +49,27 @@ STREAMS = {
     ),
     "following": StreamSpec(
         "/2/users/{account_id}/following", "account", "selected_follows_remote", False
+    ),
+    "owned_lists": StreamSpec(
+        "/2/users/{account_id}/owned_lists",
+        "custom_feed",
+        "selected_owns_remote",
+        False,
+        refresh_after_complete=True,
+    ),
+    "followed_lists": StreamSpec(
+        "/2/users/{account_id}/followed_lists",
+        "custom_feed",
+        "selected_follows_remote",
+        False,
+        refresh_after_complete=True,
+    ),
+    "list_memberships": StreamSpec(
+        "/2/users/{account_id}/list_memberships",
+        "custom_feed",
+        "remote_contains_selected",
+        False,
+        refresh_after_complete=True,
     ),
 }
 
@@ -109,8 +131,14 @@ def stream_endpoint(stream: str, account_id: str, state: CursorState) -> str:
                 "media.fields": "media_key,type",
             }
         )
-    else:
+    elif spec.resource_kind == "account":
         params["user.fields"] = "id,name,username"
+    elif spec.resource_kind == "custom_feed":
+        params["list.fields"] = (
+            "created_at,description,follower_count,member_count,owner_id,private"
+        )
+    else:
+        raise XAdapterError("X stream resource kind is unsupported")
     if state.cursor:
         params["pagination_token"] = state.cursor
     elif state.backfill_complete and state.watermark and spec.supports_since_id:

--- a/.agents/scripts/_knowledge_social_x_normalize.py
+++ b/.agents/scripts/_knowledge_social_x_normalize.py
@@ -120,19 +120,56 @@ def _tweet_object(
     }
 
 
+def _list_object(
+    item: dict[str, Any], remote_id: str, observed_at: str
+) -> dict[str, Any]:
+    """Normalize one allowlisted X List without retaining unknown fields."""
+    name = item.get("name")
+    if not isinstance(name, str) or not name:
+        raise XAdapterError("X List requires a name")
+    description = item.get("description")
+    if description is not None and not isinstance(description, str):
+        raise XAdapterError("X List description must be text")
+    created_at = item.get("created_at")
+    if created_at is not None and not isinstance(created_at, str):
+        raise XAdapterError("X List created_at must be text")
+    owner_id = item.get("owner_id")
+    if owner_id is not None and (not isinstance(owner_id, str) or not owner_id):
+        raise XAdapterError("X List owner_id must be text")
+    for key in ("follower_count", "member_count"):
+        value = item.get(key)
+        if value is not None and (
+            isinstance(value, bool) or not isinstance(value, int) or value < 0
+        ):
+            raise XAdapterError(f"X List {key} must be a non-negative integer")
+    private = item.get("private")
+    if private is not None and not isinstance(private, bool):
+        raise XAdapterError("X List private must be boolean")
+    provider_fields = ("follower_count", "member_count", "owner_id", "private")
+    return {
+        "object_type": "custom_feed",
+        "remote_id": remote_id,
+        "account_remote_id": owner_id,
+        "text": "\n\n".join(value for value in (name, description) if value),
+        "created_at": created_at,
+        "observed_at": observed_at,
+        "evidence_class": "observed",
+        "provider_json": {key: item[key] for key in provider_fields if key in item},
+    }
+
+
 def _activity_participants(
     spec: StreamSpec, item: dict[str, Any], account_id: str, remote_id: str
 ) -> tuple[str, str | None]:
+    actor_id, target_id = account_id, remote_id
     if spec.activity_mode == "content_author":
         author_id = item.get("author_id")
         if not isinstance(author_id, str) or not author_id:
             raise XAdapterError("X activity author_id must be text")
-        return author_id, remote_id
-    if spec.activity_mode == "remote_follows_selected":
-        return remote_id, account_id
-    if spec.activity_mode == "selected_follows_remote":
-        return account_id, remote_id
-    return account_id, remote_id
+        actor_id = author_id
+    elif spec.activity_mode in {"remote_follows_selected", "remote_contains_selected"}:
+        actor_id, target_id = remote_id, account_id
+    return actor_id, target_id
 
 
 def page_resources(
@@ -145,9 +182,10 @@ def page_resources(
         remote_id = item.get("id")
         if not isinstance(remote_id, str) or not remote_id:
             raise XAdapterError("X resource requires an ID")
-        object_id = remote_id if spec.resource_kind == "tweet" else None
-        if object_id:
+        if spec.resource_kind == "tweet":
             objects.append(_tweet_object(item, remote_id, stream, observed_at))
+        elif spec.resource_kind == "custom_feed":
+            objects.append(_list_object(item, remote_id, observed_at))
         actor_id, target_id = _activity_participants(
             spec, item, account_id, remote_id
         )
@@ -157,7 +195,9 @@ def page_resources(
                 "remote_id": f"{account_id}-{stream}-{remote_id}",
                 "actor_remote_id": actor_id,
                 "object_remote_id": target_id,
-                "occurred_at": item.get("created_at"),
+                "occurred_at": (
+                    item.get("created_at") if spec.resource_kind == "tweet" else None
+                ),
                 "observed_at": observed_at,
                 "state": "active",
             }

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -57,9 +57,11 @@ usage_sync() {
 	cat <<'EOF'
 X synchronization:
   sync-x verifies the selected xurl account, then reads one official stream:
-  authored, mentions, likes, bookmarks, followers, or following. --budget is a
-  bounded request-cost allowance from 1 to 1000 units. Media policy none stores
-  no media rows; metadata stores references only, never binary media.
+  authored, mentions, likes, bookmarks, followers, following, owned_lists,
+  followed_lists, or list_memberships. List streams are bounded snapshots with
+  independent cursors. --budget is a request-cost allowance from 1 to 1000
+  units. Media policy none stores no media rows; metadata stores references
+  only, never binary media.
 
 Reddit synchronization:
   sync-reddit verifies the selected PRAW profile, then reads one explicitly

--- a/.agents/scripts/knowledge_social_x.py
+++ b/.agents/scripts/knowledge_social_x.py
@@ -200,7 +200,11 @@ def collect(
             ),
             lease=lease,
         )
-        if context.state.backfill_complete and not context.spec.supports_since_id:
+        if (
+            context.state.backfill_complete
+            and not context.spec.supports_since_id
+            and not context.spec.refresh_after_complete
+        ):
             record_bounded_stop(context, "unavailable", "delta_not_supported")
             return _result(
                 "delta_unavailable",

--- a/.agents/scripts/xurl-helper.sh
+++ b/.agents/scripts/xurl-helper.sh
@@ -77,6 +77,10 @@ raw_args_are_mutating() {
 		-XPOST | -Xpost | -XPUT | -Xput | -XPATCH | -Xpatch | -XDELETE | -Xdelete | --request=POST | --request=post | --request=PUT | --request=put | --request=PATCH | --request=patch | --request=DELETE | --request=delete)
 			return 0
 			;;
+		-d | -d?* | --data | --data=* | -F | -F?* | --file | --file=*)
+			# xurl v1.3.1 treats request data as POST and files as multipart writes.
+			return 0
+			;;
 		esac
 		previous="${arg}"
 	done

--- a/.agents/tests/test-knowledge-social-x.sh
+++ b/.agents/tests/test-knowledge-social-x.sh
@@ -9,6 +9,7 @@ export AIDEVOPS_TEST_MODE=1
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
 CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+XURL_HELPER="${SCRIPT_DIR}/../scripts/xurl-helper.sh"
 TMP_DIR=$(mktemp -d)
 BASE="${TMP_DIR}/knowledge"
 ROOT="${BASE}/_knowledge"
@@ -95,6 +96,34 @@ mkdir -p "$ROOT"
 chmod 0700 "$BASE" "$ROOT"
 "$CORPUS_HELPER" provision --base "$BASE" >/dev/null
 "$HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import sys
+
+sys.path.insert(0, sys.argv[1])
+from _knowledge_social_x import CursorState, STREAMS, stream_endpoint
+
+expected = {
+    "authored", "mentions", "likes", "bookmarks", "followers", "following",
+    "owned_lists", "followed_lists", "list_memberships",
+}
+assert set(STREAMS) == expected
+routes = {
+    "owned_lists": "/2/users/acct42/owned_lists?",
+    "followed_lists": "/2/users/acct42/followed_lists?",
+    "list_memberships": "/2/users/acct42/list_memberships?",
+}
+for stream, route in routes.items():
+    endpoint = stream_endpoint(stream, "acct42", CursorState(None, None, True))
+    assert route in endpoint
+    assert "max_results=100" in endpoint
+    assert "list.fields=" in endpoint
+    assert "pagination_token=" not in endpoint
+    assert not any(flag in endpoint for flag in ("-X", "--request", "-d", "--data"))
+    assert STREAMS[stream].refresh_after_complete
+PY
+assert_eq "X stream allowlist exposes only the three official List snapshots" \
+	verified verified
 
 cat >"$TMP_DIR/page-1.json" <<'JSON'
 {
@@ -263,6 +292,158 @@ JSON
 assert_eq "following activity preserves relationship direction" \
 	"$(sql_value "SELECT actor_remote_id || ':' || object_remote_id FROM activities WHERE activity_type='following'")" "acct42:target88"
 
+cat >"$TMP_DIR/owned-lists-1.json" <<'JSON'
+{
+  "identity": {"data": {"id": "acct42"}},
+  "pages": [{
+    "expect_endpoint_contains": ["/2/users/acct42/owned_lists?", "max_results=100", "list.fields="],
+    "response": {
+      "status": 200,
+      "observed_at": "2026-07-25T05:07:00Z",
+      "data": [{
+        "id": "9002", "name": "Research", "description": "Private sources",
+        "created_at": "2026-07-20T10:00:00Z", "owner_id": "acct42",
+        "private": true, "follower_count": 4, "member_count": 12,
+        "unexpected_field": "discarded"
+      }],
+      "meta": {"next_token": "owned-cursor"}
+    }
+  }]
+}
+JSON
+owned_first=$(
+	"$HELPER" sync-x --base "$BASE" --alias personal:default \
+		--connection-id conn_lists --account-id acct42 --stream owned_lists \
+		--budget 1 --fixture "$TMP_DIR/owned-lists-1.json"
+)
+assert_eq "owned Lists stop at the request budget with a resumable cursor" \
+	"$(json_field "$owned_first" status):$(sql_value "SELECT cursor || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_lists' AND stream='owned_lists'")" \
+	"budget_exhausted:owned-cursor:0"
+assert_eq "X Lists normalize only allowlisted fields into a custom feed" \
+	"$(sql_value "SELECT object_type || ':' || provider_json FROM objects WHERE provider='xapi' AND remote_id='9002'")" \
+	'custom_feed:{"follower_count":4,"member_count":12,"owner_id":"acct42","private":true}'
+assert_eq "owned List relationships preserve account-to-list direction" \
+	"$(sql_value "SELECT actor_remote_id || ':' || object_remote_id || ':' || coalesce(occurred_at,'observed') FROM activities WHERE activity_type='owned_lists' AND remote_id='acct42-owned_lists-9002'")" \
+	"acct42:9002:observed"
+
+cat >"$TMP_DIR/owned-lists-2.json" <<'JSON'
+{
+  "identity": {"data": {"id": "acct42"}},
+  "pages": [{
+    "expect_endpoint_contains": ["pagination_token=owned-cursor"],
+    "response": {
+      "status": 200,
+      "observed_at": "2026-07-25T05:08:00Z",
+      "data": [{
+        "id": "9001", "name": "Operations", "owner_id": "acct42",
+        "private": false, "follower_count": 2, "member_count": 8
+      }],
+      "meta": {}
+    }
+  }]
+}
+JSON
+owned_second=$(
+	"$HELPER" sync-x --base "$BASE" --alias personal:default \
+		--connection-id conn_lists --account-id acct42 --stream owned_lists \
+		--fixture "$TMP_DIR/owned-lists-2.json"
+)
+assert_eq "owned List pagination resumes and preserves its first watermark" \
+	"$(json_field "$owned_second" status):$(sql_value "SELECT coalesce(cursor,'done') || ':' || watermark || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_lists' AND stream='owned_lists'")" \
+	"complete:done:9002:1"
+assert_eq "both owned Lists are searchable provider-neutral custom feeds" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='xapi' AND object_type='custom_feed' AND remote_id IN ('9001','9002')")" "2"
+
+cat >"$TMP_DIR/owned-lists-snapshot.json" <<'JSON'
+{
+  "identity": {"data": {"id": "acct42"}},
+  "pages": [{
+    "expect_endpoint_contains": ["/2/users/acct42/owned_lists?"],
+    "response": {
+      "status": 200,
+      "observed_at": "2026-07-25T05:09:00Z",
+      "data": [{
+        "id": "9002", "name": "Research", "description": "Private sources",
+        "created_at": "2026-07-20T10:00:00Z", "owner_id": "acct42",
+        "private": true, "follower_count": 4, "member_count": 12
+      }],
+      "meta": {}
+    }
+  }]
+}
+JSON
+owned_batches_before=$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_lists' AND stream='owned_lists'")
+"$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_lists --account-id acct42 --stream owned_lists \
+	--fixture "$TMP_DIR/owned-lists-snapshot.json" >/dev/null
+owned_batches_once=$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_lists' AND stream='owned_lists'")
+"$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_lists --account-id acct42 --stream owned_lists \
+	--fixture "$TMP_DIR/owned-lists-snapshot.json" >/dev/null
+owned_batches_replayed=$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_lists' AND stream='owned_lists'")
+assert_eq "completed List snapshots rescan from the beginning" \
+	"$((owned_batches_once - owned_batches_before)):$(sql_value "SELECT backfill_complete || ':' || coalesce(cursor,'reset') FROM sync_cursors WHERE connection_id='conn_lists' AND stream='owned_lists'")" \
+	"1:1:reset"
+assert_eq "exact List snapshot replay is content-addressed and idempotent" \
+	"$owned_batches_replayed" "$owned_batches_once"
+
+cat >"$TMP_DIR/followed-lists.json" <<'JSON'
+{
+  "identity": {"data": {"id": "acct42"}},
+  "pages": [{
+    "expect_endpoint_contains": ["/2/users/acct42/followed_lists?"],
+    "response": {
+      "status": 200, "observed_at": "2026-07-25T05:10:00Z",
+      "data": [{"id": "9100", "name": "Followed feed", "owner_id": "owner77", "private": false}],
+      "meta": {}
+    }
+  }]
+}
+JSON
+"$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_lists --account-id acct42 --stream followed_lists \
+	--fixture "$TMP_DIR/followed-lists.json" >/dev/null
+assert_eq "followed List relationships preserve selected-account direction" \
+	"$(sql_value "SELECT actor_remote_id || ':' || object_remote_id FROM activities WHERE activity_type='followed_lists'")" \
+	"acct42:9100"
+
+cat >"$TMP_DIR/list-memberships.json" <<'JSON'
+{
+  "identity": {"data": {"id": "acct42"}},
+  "pages": [{
+    "expect_endpoint_contains": ["/2/users/acct42/list_memberships?"],
+    "response": {
+      "status": 200, "observed_at": "2026-07-25T05:11:00Z",
+      "data": [{"id": "9200", "name": "Member feed", "owner_id": "owner88", "private": true}],
+      "meta": {}
+    }
+  }]
+}
+JSON
+"$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_lists --account-id acct42 --stream list_memberships \
+	--fixture "$TMP_DIR/list-memberships.json" >/dev/null
+assert_eq "List membership direction is stable from list to selected account" \
+	"$(sql_value "SELECT actor_remote_id || ':' || object_remote_id FROM activities WHERE activity_type='list_memberships'")" \
+	"9200:acct42"
+assert_eq "each X List category owns an independent checkpoint" \
+	"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_lists'")" "3"
+
+list_batches_before=$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_lists'")
+cat >"$TMP_DIR/malformed-list.json" <<'JSON'
+{"identity":{"data":{"id":"acct42"}},"pages":[{"status":200,"observed_at":"2026-07-25T05:12:00Z","data":[{"id":"9300","name":42}],"meta":{}}]}
+JSON
+if "$HELPER" sync-x --base "$BASE" --alias personal:default \
+	--connection-id conn_lists --account-id acct42 --stream owned_lists \
+	--fixture "$TMP_DIR/malformed-list.json" >/dev/null 2>&1; then
+	assert_eq "malformed X Lists fail before persistence" accepted rejected
+else
+	assert_eq "malformed X Lists fail before persistence" rejected rejected
+fi
+assert_eq "malformed X Lists leave prior evidence and checkpoints safe" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_lists'"):$(sql_value "SELECT watermark FROM sync_cursors WHERE connection_id='conn_lists' AND stream='owned_lists'")" \
+	"${list_batches_before}:9002"
+
 cursor_before=$(sql_value "SELECT watermark FROM sync_cursors WHERE connection_id='conn_authored' AND stream='authored'")
 cat >"$TMP_DIR/rate-limit.json" <<'JSON'
 {
@@ -387,26 +568,59 @@ case "$*" in
 *"/2/users/acct42/tweets?"*)
 	printf '%s\n' '{"status":200,"observed_at":"2026-07-25T05:08:00Z","data":[{"id":"301","author_id":"acct42","text":"guarded path","created_at":"2026-07-25T05:08:00Z"}],"meta":{}}'
 	;;
+*"/2/users/acct42/owned_lists?"*)
+	printf '%s\n' '{"status":200,"observed_at":"2026-07-25T05:13:00Z","data":[{"id":"9401","name":"Owned fixture","owner_id":"acct42"}],"meta":{}}'
+	;;
+*"/2/users/acct42/followed_lists?"*)
+	printf '%s\n' '{"status":200,"observed_at":"2026-07-25T05:14:00Z","data":[{"id":"9402","name":"Followed fixture","owner_id":"owner77"}],"meta":{}}'
+	;;
+*"/2/users/acct42/list_memberships?"*)
+	printf '%s\n' '{"status":200,"observed_at":"2026-07-25T05:15:00Z","data":[{"id":"9403","name":"Membership fixture","owner_id":"owner88"}],"meta":{}}'
+	;;
 *)
 	exit 7
 	;;
 esac
 SH
 chmod 0700 "$TMP_DIR/bin/xurl"
+if XURL_LOG="$TMP_DIR/xurl.log" PATH="$TMP_DIR/bin:$PATH" \
+	"$XURL_HELPER" run -- /2/lists -d '{}' >/dev/null 2>&1; then
+	assert_eq "raw xurl request bodies cannot bypass write confirmation" accepted rejected
+else
+	assert_eq "raw xurl request bodies cannot bypass write confirmation" rejected rejected
+fi
 XURL_LOG="$TMP_DIR/xurl.log" PATH="$TMP_DIR/bin:$PATH" \
 	"$HELPER" sync-x --base "$BASE" --alias personal:default \
 	--connection-id conn_guarded --account-id acct42 --stream authored \
 	--app fixture-app --username @fixture >/dev/null
+for list_stream in owned_lists followed_lists list_memberships; do
+	XURL_LOG="$TMP_DIR/xurl.log" PATH="$TMP_DIR/bin:$PATH" \
+		"$HELPER" sync-x --base "$BASE" --alias personal:default \
+		--connection-id conn_guarded_lists --account-id acct42 \
+		--stream "$list_stream" --app fixture-app --username @fixture >/dev/null
+done
 guard_result=$(
 	python3 - "$TMP_DIR/xurl.log" <<'PY'
 import sys
 from pathlib import Path
 lines = Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
-writes = {"post", "reply", "quote", "delete", "like", "follow", "dm", "media", "--confirm-write"}
+writes = {
+    "post", "reply", "quote", "delete", "like", "follow", "dm", "media",
+    "--confirm-write", "-X", "--request", "-d", "--data", "-F", "--file",
+}
+routes = [
+    "/2/users/acct42/tweets?",
+    "/2/users/acct42/owned_lists?",
+    "/2/users/acct42/followed_lists?",
+    "/2/users/acct42/list_memberships?",
+]
+identities = [line for line in lines if line.endswith(" whoami")]
+reads = [line for line in lines if not line.endswith(" whoami")]
 safe = (
-    len(lines) == 2
-    and lines[0].endswith(" whoami")
-    and "/2/users/acct42/tweets?" in lines[1]
+    len(lines) == 8
+    and len(identities) == 4
+    and len(reads) == 4
+    and all(route in line for route, line in zip(routes, reads, strict=True))
     and not any(word in line.split() for word in writes for line in lines)
 )
 print("read-only" if safe else "unsafe")
@@ -415,6 +629,8 @@ PY
 assert_eq "live adapter route reaches only guarded whoami and raw-read commands" "$guard_result" "read-only"
 assert_eq "guarded route persists searchable provider content" \
 	"$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'guarded'")" "1"
+assert_eq "guarded live List routes persist only the three allowlisted feeds" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='xapi' AND object_type='custom_feed' AND remote_id IN ('9401','9402','9403')")" "3"
 
 assert_eq "all immutable raw paths remain opaque" \
 	"$(


### PR DESCRIPTION
## Summary

Add bounded account-centric X List snapshots through exact read-only routes, normalize Lists as custom feeds with stable relationship direction and independent checkpoints, harden raw xurl write detection, and document scopes, retention, terms, and unsupported gaps.

## Files Changed

.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md, .agents/content/social-xurl.md, .agents/scripts/_knowledge_social_x.py, .agents/scripts/_knowledge_social_x_normalize.py, .agents/scripts/knowledge-social-helper.sh, .agents/scripts/knowledge_social_x.py, .agents/scripts/xurl-helper.sh, .agents/tests/test-knowledge-social-x.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified: all 9 tracked social knowledge shell suites passed (378 assertions), changed-file lint passed, and the Qlty smell threshold returned to 53/53; the official provider network was not invoked because xurl is unavailable locally.

Resolves #28667


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.183 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 51m and 583,952 tokens on this as a headless worker.