### PR TITLE
GH#28685: Stream large comment payloads via stdin

### DIFF
--- a/.agents/scripts/coderabbit-collector-helper.sh
+++ b/.agents/scripts/coderabbit-collector-helper.sh
@@ -466,9 +466,9 @@ collect_comments() {
 
 	# Merge both arrays, marking issue comments with negative IDs
 	local merged_json
-	merged_json=$(jq -n \
-		--argjson pr_comments "$comments_json" \
-		--argjson issue_comments "$issue_comments_json" '
+	merged_json=$(printf '%s\n%s\n' "$comments_json" "$issue_comments_json" | jq -nc '
+		input as $pr_comments |
+		input as $issue_comments |
         [($pr_comments // [])[] | . + {"_source": "pr"}] +
         [($issue_comments // [])[] | . + {"_source": "issue", "id": (-.id), "path": "", "line": 0, "side": ""}]
     ')

--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -573,9 +573,8 @@ _fetch_claims() {
 	# t2401: version is an optional trailing field; legacy pre-t2401 claims
 	# lack it and parse as "unknown".
 	local parsed
-	parsed=$(printf '%s' "$claims_only" | jq -c --argjson now "$now_epoch" \
+	parsed=$(printf '%s\n%s\n' "$claims_only" "$comments_json" | jq -nc --argjson now "$now_epoch" \
 		--argjson max_age "$DISPATCH_CLAIM_MAX_AGE" --argjson include_terminal false \
-		--argjson comments "$comments_json" \
 		-f "${DISPATCH_CLAIM_HELPER_DIR}/dispatch-lease-claims.jq" 2>/dev/null) || {
 		echo "Error: failed to parse claim comments" >&2
 		return 1
@@ -630,7 +629,7 @@ _filter_orphan_prelaunch_claims() {
 
 	local filtered_claims removed_count remaining_count
 	filtered_claims=$(_filter_claims_with_launch_evidence "$parsed_claims" "$comments_json")
-	removed_count=$(jq -n --argjson before "$parsed_claims" --argjson after "$filtered_claims" '$before|length - ($after|length)' 2>/dev/null) || removed_count=0
+	removed_count=$(printf '%s\n%s\n' "$parsed_claims" "$filtered_claims" | jq -nr 'input as $before | input as $after | $before | length - ($after | length)' 2>/dev/null) || removed_count=0
 	remaining_count=$(printf '%s' "$filtered_claims" | jq 'length' 2>/dev/null) || remaining_count=0
 	if [[ "$removed_count" -gt 0 && "$remaining_count" -eq 0 ]]; then
 		_post_orphan_claim_release "$issue_number" "$repo_slug" "$self_runner" "$removed_count" || true
@@ -648,10 +647,11 @@ _filter_claims_with_launch_evidence() {
 	local parsed_claims="$1"
 	local comments_json="$2"
 
-	printf '%s' "$parsed_claims" | jq -c \
-		--argjson comments "$comments_json" \
+	printf '%s\n%s\n' "$parsed_claims" "$comments_json" | jq -nc \
 		--argjson orphan_grace "$DISPATCH_CLAIM_ORPHAN_GRACE" '
-		[.[]
+		input as $claims |
+		input as $comments |
+		[$claims[]
 		| . as $claim
 		| ([ $comments[]
 			| select((.created_at // "") > ($claim.created_at // ""))

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -2290,9 +2290,9 @@ _dd_has_matching_terminal_lease() {
 		2>/dev/null) || return 1
 	[[ "$claims_json" != "[]" ]] || return 1
 	now_epoch=$(date -u '+%s')
-	parsed_claims=$(printf '%s' "$claims_json" | jq -c \
+	parsed_claims=$(printf '%s\n%s\n' "$claims_json" "$comments_json" | jq -nc \
 		--argjson now "$now_epoch" --argjson max_age 2147483647 \
-		--argjson include_terminal true --argjson comments "$comments_json" \
+		--argjson include_terminal true \
 		-f "$lease_filter" 2>/dev/null) || return 1
 
 	if printf '%s' "$parsed_claims" | jq -e \

--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -158,8 +158,8 @@ _stale_recovery_final_evidence_recheck() {
 	local comments="" claims="" parsed=""
 	comments=$(printf '%s' "$pages" | jq -c '[.[] | .[]?]' 2>/dev/null) || return 1
 	claims=$(printf '%s' "$comments" | jq -c '[.[] | select((.body // "") | contains("DISPATCH_CLAIM nonce="))]' 2>/dev/null) || return 1
-	parsed=$(printf '%s' "$claims" | jq -c --argjson now "$now_epoch" --argjson max_age 2147483647 \
-		--argjson include_terminal false --argjson comments "$comments" \
+	parsed=$(printf '%s\n%s\n' "$claims" "$comments" | jq -nc --argjson now "$now_epoch" --argjson max_age 2147483647 \
+		--argjson include_terminal false \
 		-f "${SCRIPT_DIR}/dispatch-lease-claims.jq" 2>/dev/null) || return 1
 	if printf '%s' "$parsed" | jq -e 'any(.lease_phase == "ready")' >/dev/null 2>&1; then
 		return 1

--- a/.agents/scripts/dispatch-lease-claims.jq
+++ b/.agents/scripts/dispatch-lease-claims.jq
@@ -1,4 +1,6 @@
-[.[] |
+input as $claims |
+input as $comments |
+[$claims[] |
     (.body | capture("nonce=(?<nonce>[^ ]+) runner=(?<runner>[^ ]+) ts=(?<ts>[^ ]+)(?: max_age_s=[^ ]+)?(?: version=(?<version>[^ ]+))?")) as $fields |
     ((.body | try capture("lease_token=(?<value>[^ ]+)").value catch "") // "") as $token |
     ((.body | try capture("device=(?<value>[^ ]+)").value catch "") // "") as $device |

--- a/.agents/scripts/tests/test-coderabbit-collector-large-comments.sh
+++ b/.agents/scripts/tests/test-coderabbit-collector-large-comments.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="${TEST_DIR}/.."
+TEST_ROOT=$(mktemp -d)
+SQL_STATE="${TEST_ROOT}/sql-state"
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+export HOME="$TEST_ROOT"
+export AIDEVOPS_TEST_MODE=1
+# shellcheck source=../coderabbit-collector-helper.sh
+source "${SCRIPTS_DIR}/coderabbit-collector-helper.sh" help >/dev/null 2>&1
+
+gh() {
+	local command="$1"
+	local endpoint="$2"
+	[[ "$command" == "api" ]] || return 1
+	if [[ "$endpoint" == repos/*/pulls/*/comments ]]; then
+		python3 - <<'PY'
+import json
+
+print(json.dumps([{
+    "id": 101,
+    "pull_request_review_id": 201,
+    "path": "large.sh",
+    "line": 10,
+    "side": "RIGHT",
+    "body": "x" * 2_200_000,
+    "created_at": "2026-07-26T20:00:00Z",
+}]))
+PY
+		return 0
+	fi
+	if [[ "$endpoint" == repos/*/issues/*/comments ]]; then
+		printf '%s\n' '[{"id":102,"body":"CodeRabbit summary","created_at":"2026-07-26T20:01:00Z"}]'
+		return 0
+	fi
+	return 1
+}
+
+db() {
+	local _database="$1"
+	shift
+	: "$_database"
+	if [[ "$#" -eq 0 ]]; then
+		local sql=""
+		sql=$(</dev/stdin)
+		if [[ "$sql" == *"101"* && "$sql" == *"-102"* && "$sql" == *"large.sh"* ]]; then
+			printf 'ok\n' >"$SQL_STATE"
+		fi
+		return 0
+	fi
+	if [[ -f "$SQL_STATE" ]]; then
+		printf '2\n'
+	else
+		printf '0\n'
+	fi
+	return 0
+}
+
+output=$(collect_comments owner/repo 42 7)
+if [[ "$output" != "2" ]]; then
+	printf 'FAIL oversized CodeRabbit comments were not merged: %s\n' "$output" >&2
+	exit 1
+fi
+if grep -Fq -- '--argjson pr_comments' "${SCRIPTS_DIR}/coderabbit-collector-helper.sh"; then
+	printf 'FAIL CodeRabbit PR comments still enter jq argv\n' >&2
+	exit 1
+fi
+if grep -Fq -- '--argjson issue_comments' "${SCRIPTS_DIR}/coderabbit-collector-helper.sh"; then
+	printf 'FAIL CodeRabbit issue comments still enter jq argv\n' >&2
+	exit 1
+fi
+
+printf 'PASS oversized CodeRabbit comment payloads avoid argv transport\n'
+exit 0

--- a/.agents/scripts/tests/test-dispatch-atomic-lease.sh
+++ b/.agents/scripts/tests/test-dispatch-atomic-lease.sh
@@ -91,6 +91,64 @@ claim_token() {
 	return 0
 }
 
+write_large_claim_history() {
+	local comments_file="$1"
+	local mode="$2"
+	mkdir -p "$(dirname "$comments_file")"
+	python3 - "$comments_file" "$mode" <<'PY'
+from datetime import datetime, timedelta, timezone
+import json
+import sys
+
+comments_file, mode = sys.argv[1:]
+now = datetime.now(timezone.utc)
+claim_at = now - timedelta(seconds=300)
+dispatch_at = now - timedelta(seconds=250)
+terminal_at = now - timedelta(seconds=200)
+expires_at = int((now + timedelta(seconds=600)).timestamp())
+stamp = lambda value: value.strftime("%Y-%m-%dT%H:%M:%SZ")
+token = "large-token"
+comments = [
+    {
+        "id": 1,
+        "body": (
+            f"DISPATCH_CLAIM nonce={token} runner=shared-login ts={stamp(claim_at)} "
+            f"max_age_s=600 version=test lease_token={token} device=device-large "
+            f"session=issue-49 phase=prelaunch expires_at={expires_at}"
+        ),
+        "created_at": stamp(claim_at),
+        "user": {"login": "shared-login"},
+        "author_association": "MEMBER",
+    },
+    {
+        "id": 2,
+        "body": "Dispatching worker (deterministic). " + ("x" * 2_200_000),
+        "created_at": stamp(dispatch_at),
+        "user": {"login": "shared-login"},
+        "author_association": "MEMBER",
+    },
+]
+if mode == "terminal":
+    comments.append(
+        {
+            "id": 3,
+            "body": (
+                f"DISPATCH_LEASE phase=terminal lease_token={token} device=device-large "
+                f"session=issue-49 expires_at=0 ts={stamp(terminal_at)}"
+            ),
+            "created_at": stamp(terminal_at),
+            "user": {"login": "shared-login"},
+            "author_association": "MEMBER",
+        }
+    )
+with open(comments_file, "w", encoding="utf-8") as handle:
+    for comment in comments:
+        json.dump(comment, handle, separators=(",", ":"))
+        handle.write("\n")
+PY
+	return $?
+}
+
 test_local_ledger_guards() {
 	local ledger_dir="${TMP_DIR}/ledger"
 	export AIDEVOPS_DISPATCH_LEDGER_DIR="$ledger_dir"
@@ -267,6 +325,41 @@ test_untrusted_dispatch_identity_cannot_replace_active_lock() {
 	return 0
 }
 
+test_large_comment_history_avoids_argv_limits() {
+	local root="${TMP_DIR}/large-history" output="" exit_code=0 dispatch_ts=""
+	create_mock_gh "$root"
+	write_large_claim_history "$root/state/comments.jsonl" active
+
+	set +e
+	output=$(PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" \
+		DISPATCH_CLAIM_MAX_AGE=600 DISPATCH_CLAIM_ORPHAN_GRACE=120 \
+		"$CLAIM" check 49 owner/repo 2>&1)
+	exit_code=$?
+	set -e
+	[[ "$exit_code" -eq 0 && "$output" == *"ACTIVE_CLAIM"* ]] ||
+		fail "oversized active claim history failed: exit=${exit_code} output=${output}"
+	pass "oversized claim history preserves launch evidence without argv transport"
+
+	write_large_claim_history "$root/state/comments.jsonl" terminal
+	set +e
+	output=$(PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" \
+		DISPATCH_CLAIM_MAX_AGE=600 "$CLAIM" check 49 owner/repo 2>&1)
+	exit_code=$?
+	set -e
+	[[ "$exit_code" -eq 1 && "$output" != *"failed to parse claim comments"* ]] ||
+		fail "oversized terminal claim history failed: exit=${exit_code} output=${output}"
+	if PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" DISPATCH_COMMENT_MAX_AGE=600 \
+		"$DEDUP" has-dispatch-comment 49 owner/repo shared-login >/dev/null 2>&1; then
+		fail "oversized terminal history did not release dispatch dedup"
+	fi
+	dispatch_ts=$(jq -sr '[.[] | select(.body | contains("Dispatching worker"))] | last.created_at' "$root/state/comments.jsonl")
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" \
+		_stale_recovery_final_evidence_recheck 49 owner/repo "$dispatch_ts" ||
+		fail "oversized terminal history blocked stale final evidence recheck"
+	pass "oversized terminal history preserves dedup and stale-recovery semantics"
+	return 0
+}
+
 test_prelaunch_renewal_covers_slow_startup() {
 	local root="${TMP_DIR}/renewal" token="" renewal_call=""
 	create_mock_gh "$root"
@@ -320,6 +413,7 @@ test_local_ledger_guards
 test_concurrent_same_login_devices
 test_launch_crash_ready_terminal_race
 test_untrusted_dispatch_identity_cannot_replace_active_lock
+test_large_comment_history_avoids_argv_limits
 test_prelaunch_renewal_covers_slow_startup
 test_invalid_device_not_public
 test_takeover_recheck_precedes_mutation


### PR DESCRIPTION
## Summary

Replace unbounded jq --argjson comment-array transport with two JSON documents streamed through stdin across dispatch claim, dedup/stale, and CodeRabbit parsing paths; add oversized regression coverage.

## Files Changed

.agents/scripts/coderabbit-collector-helper.sh, .agents/scripts/dispatch-claim-helper.sh, .agents/scripts/dispatch-dedup-helper.sh, .agents/scripts/dispatch-dedup-stale.sh, .agents/scripts/dispatch-lease-claims.jq, .agents/scripts/tests/test-coderabbit-collector-large-comments.sh, .agents/scripts/tests/test-dispatch-atomic-lease.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — ShellCheck passed; 63 claim tests, atomic lease suite including 2.2 MB histories, 5 pagination tests, 3 terminal-evidence tests, CodeRabbit 2.2 MB regression, and linters-local.sh all passed.

Resolves #28685


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.183 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 49m and 413,451 tokens on this with the user in an interactive session.