### PR TITLE
GH#28710: Enforce framework bug brief validation

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -26,9 +26,9 @@
 # Design principles
 # -----------------
 #   1. Fast path: non-write subcommands pay a single case-match then exec.
-#   2. Fail-open: if anything goes wrong (missing helper, sourcing failure,
-#      malformed args), exec the real gh without modification. A broken
-#      shim must never break `gh` for the user.
+#   2. Fail-open infrastructure: missing helpers and malformed internal state
+#      preserve native `gh` behaviour. Deterministic write-policy violations
+#      still fail closed when their validator is available.
 #   3. Recursion guard: if the shim somehow re-enters (subprocess inherits
 #      PATH), the second invocation short-circuits to the real gh.
 #   4. Single source of truth: uses the same marker (`<!-- aidevops:sig -->`)
@@ -1519,6 +1519,187 @@ _shim_issue_create_has_type_label() {
 	return 1
 }
 
+_shim_title_is_internal_tracking_issue() {
+	local title="$1"
+	[[ "$title" =~ ^(t[0-9]+(\.[0-9]+)*|GH#[0-9]+):[[:space:]] ]]
+	return $?
+}
+
+_shim_framework_bug_candidate() {
+	local title="$1"
+	local body="$2"
+	local has_bug_label="$3"
+	_shim_title_is_internal_tracking_issue "$title" && return 1
+	[[ "$has_bug_label" == "1" ]] && return 0
+	[[ "$title" =~ ^[[:space:]]*[Bb][Uu][Gg]([^[:alnum:]_]|$) ]] && return 0
+	grep -Eqi '^## Reproducer[[:space:]]*$' <<<"$body" && return 0
+	return 1
+}
+
+_shim_validate_framework_bug_body() {
+	local body="$1"
+	local body_file="$2"
+	local validator="${_SHIM_DIR}/log-issue-helper.sh"
+	local validation_target=""
+	local temporary_body=""
+	local validation_output=""
+
+	# Keep the shim's infrastructure fail-open contract when the adjacent
+	# validator is unavailable. Installed framework bundles ship both files.
+	[[ -f "$validator" ]] || return 0
+
+	if [[ -n "$body_file" && -f "$body_file" ]]; then
+		validation_target="$body_file"
+	else
+		temporary_body=$(mktemp -t aidevops-gh-issue-brief.XXXXXX 2>/dev/null) || return 0
+		if ! printf '%s' "$body" >"$temporary_body"; then
+			rm -f "$temporary_body"
+			return 0
+		fi
+		validation_target="$temporary_body"
+	fi
+
+	if validation_output=$(bash "$validator" validate-brief "$validation_target" 2>&1); then
+		[[ -z "$temporary_body" ]] || rm -f "$temporary_body"
+		return 0
+	fi
+
+	[[ -z "$temporary_body" ]] || rm -f "$temporary_body"
+	printf '[aidevops][issue-brief][BLOCK] Canonical aidevops framework-bug report failed final-body validation.\n' >&2
+	[[ -z "$validation_output" ]] || printf '%s\n' "$validation_output" >&2
+	printf '  Add substantive ## Reproducer evidence or explicitly frame the report as an unconfirmed investigation, then retry.\n' >&2
+	return 1
+}
+
+_SHIM_ISSUE_BODY=""
+_SHIM_ISSUE_BODY_FILE=""
+
+_shim_issue_create_collect_body() {
+	local idx=0
+	local arg=""
+	_SHIM_ISSUE_BODY=""
+	_SHIM_ISSUE_BODY_FILE=""
+	while [[ $idx -lt ${#_modified_args[@]} ]]; do
+		arg="${_modified_args[$idx]}"
+		case "$arg" in
+		--body)
+			_SHIM_ISSUE_BODY="${_modified_args[idx + 1]:-}"
+			_SHIM_ISSUE_BODY_FILE=""
+			idx=$((idx + 2))
+			continue
+			;;
+		--body=*) _SHIM_ISSUE_BODY="${arg#--body=}"; _SHIM_ISSUE_BODY_FILE="" ;;
+		--body-file)
+			_SHIM_ISSUE_BODY_FILE="${_modified_args[idx + 1]:-}"
+			_SHIM_ISSUE_BODY=""
+			idx=$((idx + 2))
+			continue
+			;;
+		--body-file=*) _SHIM_ISSUE_BODY_FILE="${arg#--body-file=}"; _SHIM_ISSUE_BODY="" ;;
+		esac
+		idx=$((idx + 1))
+	done
+	if [[ -n "$_SHIM_ISSUE_BODY_FILE" && -f "$_SHIM_ISSUE_BODY_FILE" ]]; then
+		_SHIM_ISSUE_BODY=$(<"$_SHIM_ISSUE_BODY_FILE") || _SHIM_ISSUE_BODY=""
+	fi
+	return 0
+}
+
+_shim_validate_cli_issue_create_if_needed() {
+	[[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "issue:create" ]] || return 0
+	local repo_slug=""
+	local normalized_repo=""
+	local title=""
+	local has_bug_label=0
+	repo_slug=$(_shim_target_repo_slug "${_modified_args[@]}" 2>/dev/null || true)
+	normalized_repo=$(printf '%s' "$repo_slug" | tr '[:upper:]' '[:lower:]')
+	[[ "$normalized_repo" == "marcusquinn/aidevops" ]] || return 0
+	title=$(_shim_issue_create_get_title 2>/dev/null || true)
+	_shim_title_is_internal_tracking_issue "$title" && return 0
+	_shim_issue_create_collect_body
+	_shim_issue_create_has_label "bug" && has_bug_label=1
+	_shim_framework_bug_candidate "$title" "$_SHIM_ISSUE_BODY" "$has_bug_label" || return 0
+	_shim_validate_framework_bug_body "$_SHIM_ISSUE_BODY" "$_SHIM_ISSUE_BODY_FILE"
+	return $?
+}
+
+_SHIM_API_ISSUE_METHOD=""
+_SHIM_API_ISSUE_PATH=""
+_SHIM_API_ISSUE_TITLE=""
+_SHIM_API_ISSUE_BODY=""
+_SHIM_API_ISSUE_BODY_FILE=""
+_SHIM_API_ISSUE_HAS_BUG_LABEL=0
+
+_shim_api_issue_create_collect_fields() {
+	local idx=0
+	local arg=""
+	local field=""
+	_SHIM_API_ISSUE_METHOD=""
+	_SHIM_API_ISSUE_PATH=""
+	_SHIM_API_ISSUE_TITLE=""
+	_SHIM_API_ISSUE_BODY=""
+	_SHIM_API_ISSUE_BODY_FILE=""
+	_SHIM_API_ISSUE_HAS_BUG_LABEL=0
+	while [[ $idx -lt ${#_modified_args[@]} ]]; do
+		arg="${_modified_args[$idx]}"
+		field=""
+		case "$arg" in
+		-X | --method)
+			_SHIM_API_ISSUE_METHOD="${_modified_args[idx + 1]:-}"
+			idx=$((idx + 2))
+			continue
+			;;
+		-X*) _SHIM_API_ISSUE_METHOD="${arg#-X}" ;;
+		--method=*) _SHIM_API_ISSUE_METHOD="${arg#--method=}" ;;
+		/repos/* | repos/*) [[ -z "$_SHIM_API_ISSUE_PATH" ]] && _SHIM_API_ISSUE_PATH="$arg" ;;
+		-f | -F | --field | --raw-field)
+			field="${_modified_args[idx + 1]:-}"
+			idx=$((idx + 1))
+			;;
+		-f*) field="${arg#-f}" ;;
+		-F*) field="${arg#-F}" ;;
+		--field=*) field="${arg#--field=}" ;;
+		--raw-field=*) field="${arg#--raw-field=}" ;;
+		esac
+		case "$field" in
+		title=*) _SHIM_API_ISSUE_TITLE="${field#title=}" ;;
+		body=@*) _SHIM_API_ISSUE_BODY_FILE="${field#body=@}"; _SHIM_API_ISSUE_BODY="" ;;
+		body=*) _SHIM_API_ISSUE_BODY="${field#body=}"; _SHIM_API_ISSUE_BODY_FILE="" ;;
+		labels\[\]=bug) _SHIM_API_ISSUE_HAS_BUG_LABEL=1 ;;
+		esac
+		idx=$((idx + 1))
+	done
+	if [[ -n "$_SHIM_API_ISSUE_BODY_FILE" && -f "$_SHIM_API_ISSUE_BODY_FILE" ]]; then
+		_SHIM_API_ISSUE_BODY=$(<"$_SHIM_API_ISSUE_BODY_FILE") || _SHIM_API_ISSUE_BODY=""
+	fi
+	return 0
+}
+
+_shim_validate_api_issue_create_if_needed() {
+	[[ "${_modified_args[0]:-}" == "api" ]] || return 0
+	_shim_api_issue_create_collect_fields
+	local normalized_path=""
+	normalized_path=$(printf '%s' "${_SHIM_API_ISSUE_PATH#/}" | tr '[:upper:]' '[:lower:]')
+	[[ "$_SHIM_API_ISSUE_METHOD" == "POST" ]] || return 0
+	[[ "$normalized_path" == "repos/marcusquinn/aidevops/issues" ]] || return 0
+	_shim_title_is_internal_tracking_issue "$_SHIM_API_ISSUE_TITLE" && return 0
+	_shim_framework_bug_candidate "$_SHIM_API_ISSUE_TITLE" "$_SHIM_API_ISSUE_BODY" "$_SHIM_API_ISSUE_HAS_BUG_LABEL" || return 0
+	_shim_validate_framework_bug_body "$_SHIM_API_ISSUE_BODY" "$_SHIM_API_ISSUE_BODY_FILE"
+	return $?
+}
+
+_shim_validate_framework_bug_issue_create_if_needed() {
+	if [[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "issue:create" ]]; then
+		_shim_validate_cli_issue_create_if_needed
+		return $?
+	fi
+	if [[ "${_modified_args[0]:-}" == "api" ]]; then
+		_shim_validate_api_issue_create_if_needed
+		return $?
+	fi
+	return 0
+}
+
 _shim_normalize_interactive_tracking_issue_create() {
 	[[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "issue:create" ]] || return 0
 	[[ -z "${FULL_LOOP_HEADLESS:-}${AIDEVOPS_HEADLESS:-}${OPENCODE_HEADLESS:-}${GITHUB_ACTIONS:-}" ]] || return 0
@@ -1719,6 +1900,10 @@ _shim_block_pr_create_without_linked_issue_if_needed() {
 }
 
 if ! _shim_block_pr_create_without_linked_issue_if_needed; then
+	exit 1
+fi
+
+if ! _shim_validate_framework_bug_issue_create_if_needed; then
 	exit 1
 fi
 

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -13,6 +13,7 @@
 #   6. `gh pr create --body` without marker gets sig appended
 #   7. `AIDEVOPS_GH_SHIM_DISABLE=1` bypasses the shim entirely
 #   8. Recursion guard: `_AIDEVOPS_GH_SHIM_ACTIVE=1` fails closed immediately
+#   9. Canonical aidevops framework-bug briefs are validated before transport
 #
 # Strategy: run the shim against a stub `gh` binary that logs its args, and
 # a stub `gh-signature-helper.sh` that emits a predictable footer. Assert
@@ -193,6 +194,10 @@ cp "$REPO_DIR/.agents/scripts/gh-quota-attribution-lib.sh" "$TMP/scripts/gh-quot
 cp "$REPO_DIR/.agents/scripts/gh-quota-debug-filter.py" "$TMP/scripts/gh-quota-debug-filter.py"
 cp "$REPO_DIR/.agents/scripts/shared-gh-wrappers-rest-fallback.sh" "$TMP/scripts/shared-gh-wrappers-rest-fallback.sh"
 cp "$REPO_DIR/.agents/scripts/shared-gh-wrappers-rest-read-semantics.sh" "$TMP/scripts/shared-gh-wrappers-rest-read-semantics.sh"
+cp "$REPO_DIR/.agents/scripts/log-issue-helper.sh" "$TMP/scripts/log-issue-helper.sh"
+mkdir -p "$TMP/scripts/lib"
+cp "$REPO_DIR/.agents/scripts/lib/version.sh" "$TMP/scripts/lib/version.sh"
+cp "$REPO_DIR/.agents/scripts/lib/issue-fingerprint.sh" "$TMP/scripts/lib/issue-fingerprint.sh"
 
 # Put stub gh in PATH (for shim's REAL_GH discovery) and the shim in
 # $TMP/scripts (for direct invocation in tests).
@@ -1118,6 +1123,187 @@ if [[ "$(_read_attempt_quota "$response_missing_log")" == "unknown" ]]; then
 	_pass "missing GraphQL response cost remains unknown"
 else
 	_fail "missing response-cost fail-closed behavior" "log: $(cat "$response_missing_log" 2>/dev/null || true)"
+fi
+
+# =============================================================================
+# Test 25: canonical aidevops framework-bug briefs are validated before writes
+# =============================================================================
+echo ""
+echo "Test 25: executable framework-bug brief validation"
+
+malformed_brief="$TMP/malformed-framework-bug.md"
+cat >"$malformed_brief" <<'EOF'
+## Description
+
+The review reported a cleanup bug.
+
+## Reproducer
+
+The session inferred a cause but omitted exact evidence fields.
+EOF
+cp "$malformed_brief" "$TMP/malformed-framework-bug.original"
+
+_reset_log
+if "$SHIM_RUN" issue create --repo marcusquinn/aidevops \
+	--title "bug(cleanup): malformed report" --label bug \
+	--body-file "$malformed_brief" 2>"$TMP/malformed-file.err"; then
+	_fail "malformed framework-bug body-file guard" "write unexpectedly passed"
+elif [[ ! -s "$STUB_GH_LOG" ]] && cmp -s "$malformed_brief" "$TMP/malformed-framework-bug.original" &&
+	grep -q '\[aidevops\]\[issue-brief\]\[BLOCK\]' "$TMP/malformed-file.err" &&
+	grep -q 'Reproducer requires' "$TMP/malformed-file.err"; then
+	_pass "malformed body-file is blocked before transport without source mutation"
+else
+	_fail "malformed framework-bug body-file guard" "argv: $(_read_argv) err: $(cat "$TMP/malformed-file.err" 2>/dev/null || true)"
+fi
+
+_reset_log
+malformed_inline=$(<"$malformed_brief")
+if "$SHIM_RUN" issue create --repo marcusquinn/aidevops \
+	--title "bug(shim): malformed inline report" --body "$malformed_inline" \
+	2>"$TMP/malformed-inline.err"; then
+	_fail "malformed inline framework-bug guard" "write unexpectedly passed"
+elif [[ ! -s "$STUB_GH_LOG" ]] && grep -q 'Reproducer requires' "$TMP/malformed-inline.err"; then
+	_pass "malformed inline body is blocked before transport"
+else
+	_fail "malformed inline framework-bug guard" "argv: $(_read_argv) err: $(cat "$TMP/malformed-inline.err" 2>/dev/null || true)"
+fi
+
+valid_investigation="$TMP/valid-framework-investigation.md"
+cat >"$valid_investigation" <<'EOF'
+## Description
+
+The issue-create guard accepts a substantive investigation.
+
+## Reproducer
+
+**Symptom command**: `aidevops status`
+
+**Actual output**: `status was inconsistent`
+
+**Expected output**: `status was consistent`
+
+**Causal status**: unconfirmed investigation
+EOF
+cp "$valid_investigation" "$TMP/valid-framework-investigation.original"
+
+_reset_log
+"$SHIM_RUN" issue create --repo marcusquinn/aidevops \
+	--title "bug(status): valid investigation" --label bug \
+	--body-file "$valid_investigation" 2>"$TMP/valid-investigation.err"
+argv=$(_read_argv)
+if [[ "$argv" == *$'issue\ncreate'* ]] && cmp -s "$valid_investigation" "$TMP/valid-framework-investigation.original"; then
+	_pass "valid unconfirmed body-file passes normal signing and transport unchanged"
+else
+	_fail "valid unconfirmed body-file pass-through" "argv: $argv err: $(cat "$TMP/valid-investigation.err" 2>/dev/null || true)"
+fi
+
+valid_confirmed_file="$TMP/valid-confirmed-framework-bug.md"
+cat >"$valid_confirmed_file" <<'EOF'
+## Description
+
+The issue-create guard accepts a proven bug report.
+
+## Reproducer
+
+**Symptom command**: `gh issue create --repo marcusquinn/aidevops`
+
+**Actual output**: `the malformed write reached the stub`
+
+**Expected output**: `the malformed write is rejected`
+
+**Causal status**: confirmed
+
+**Production entry point**: `.agents/scripts/gh` receives the issue-create command
+
+**Call chain**: issue creation enters the shim and validates before the native CLI
+
+**Integrated verification**: this hermetic command reaches the transport stub only after validation
+EOF
+valid_confirmed=$(<"$valid_confirmed_file")
+_reset_log
+"$SHIM_RUN" issue create --repo marcusquinn/aidevops \
+	--title "bug(guard): valid confirmed report" --label bug --body "$valid_confirmed" \
+	2>"$TMP/valid-confirmed.err"
+argv=$(_read_argv)
+if [[ "$argv" == *$'issue\ncreate'* ]] && [[ "$argv" == *"<!-- aidevops:sig -->"* ]]; then
+	_pass "valid confirmed inline report passes normal signing and transport"
+else
+	_fail "valid confirmed inline pass-through" "argv: $argv err: $(cat "$TMP/valid-confirmed.err" 2>/dev/null || true)"
+fi
+
+_reset_log
+"$SHIM_RUN" issue create --repo marcusquinn/aidevops \
+	--title "t28710: internal tracking brief" --label bug --body "$malformed_inline" 2>/dev/null
+argv=$(_read_argv)
+if [[ "$argv" == *$'issue\ncreate'* ]]; then
+	_pass "tNNN internal tracking issue remains exempt"
+else
+	_fail "tNNN internal tracking exemption" "argv: $argv"
+fi
+
+_reset_log
+"$SHIM_RUN" issue create --repo marcusquinn/aidevops \
+	--title "GH#28710: internal follow-up" --label bug --body "$malformed_inline" 2>/dev/null
+argv=$(_read_argv)
+if [[ "$argv" == *$'issue\ncreate'* ]]; then
+	_pass "GH#NNN internal tracking issue remains exempt"
+else
+	_fail "GH#NNN internal tracking exemption" "argv: $argv"
+fi
+
+_reset_log
+"$SHIM_RUN" issue create --repo owner/repo \
+	--title "bug(external): malformed report" --label bug --body "$malformed_inline" 2>/dev/null
+argv=$(_read_argv)
+if [[ "$argv" == *$'issue\ncreate'* ]]; then
+	_pass "non-aidevops issue creation remains exempt"
+else
+	_fail "non-aidevops issue exemption" "argv: $argv"
+fi
+
+_reset_log
+"$SHIM_RUN" issue create --repo marcusquinn/aidevops \
+	--title "Request a new capability" --label enhancement --body "## Description
+
+Add a supported capability." 2>/dev/null
+argv=$(_read_argv)
+if [[ "$argv" == *$'issue\ncreate'* ]]; then
+	_pass "canonical non-bug issue shape remains exempt"
+else
+	_fail "canonical non-bug issue exemption" "argv: $argv"
+fi
+
+mv "$TMP/scripts/log-issue-helper.sh" "$TMP/scripts/log-issue-helper.sh.disabled"
+_reset_log
+"$SHIM_RUN" issue create --repo marcusquinn/aidevops \
+	--title "bug(helper): unavailable validator" --label bug --body "$malformed_inline" 2>/dev/null
+mv "$TMP/scripts/log-issue-helper.sh.disabled" "$TMP/scripts/log-issue-helper.sh"
+argv=$(_read_argv)
+if [[ "$argv" == *$'issue\ncreate'* ]]; then
+	_pass "missing adjacent validator preserves fail-open shim behavior"
+else
+	_fail "missing validator fail-open behavior" "argv: $argv"
+fi
+
+_reset_log
+if "$SHIM_RUN" api /repos/marcusquinn/aidevops/issues -X POST \
+	-f "title=bug(rest): malformed fallback report" -F "body=@$malformed_brief" \
+	-f 'labels[]=bug' 2>"$TMP/malformed-rest.err"; then
+	_fail "malformed REST fallback guard" "write unexpectedly passed"
+elif [[ ! -s "$STUB_GH_LOG" ]] && grep -q 'Reproducer requires' "$TMP/malformed-rest.err"; then
+	_pass "malformed REST fallback body is blocked before transport"
+else
+	_fail "malformed REST fallback guard" "argv: $(_read_argv) err: $(cat "$TMP/malformed-rest.err" 2>/dev/null || true)"
+fi
+
+_reset_log
+resolved_output=$(SHIM_TEST_MODE=1 "$SHIM_RUN" issue create --repo marcusquinn/aidevops \
+	--title "bug(test-mode): valid report" --label bug --body-file "$valid_investigation" 2>/dev/null)
+if [[ "$resolved_output" == resolved_body_file=* ]] &&
+	cmp -s "$valid_investigation" "$TMP/valid-framework-investigation.original"; then
+	_pass "valid SHIM_TEST_MODE path remains available and source-safe"
+else
+	_fail "SHIM_TEST_MODE compatibility" "output: $resolved_output"
 fi
 
 # =============================================================================

--- a/.agents/workflows/log-issue-aidevops.md
+++ b/.agents/workflows/log-issue-aidevops.md
@@ -327,6 +327,13 @@ Do not validate an earlier draft or inline copy:
 If validation fails, correct the evidence or explicitly reframe the report as an
 unconfirmed investigation. Do not run `gh issue create` until validation passes.
 
+The aidevops `gh` PATH shim repeats this final-body validation at exec time for
+non-tracking framework-bug reports targeting `marcusquinn/aidevops`. This is a
+deterministic backstop for raw and wrapped `gh issue create` calls, not a
+replacement for the workflow check above. A blocked write leaves the caller's
+body file unchanged; apply the validator's remediation and retry. Internal
+`tNNN:` / `GH#NNN:` tracking tasks and non-bug issue shapes are exempt.
+
 ```bash
 gh issue create -R marcusquinn/aidevops \
   --title "TITLE" \


### PR DESCRIPTION
## Summary

Validate canonical non-tracking aidevops framework-bug reports at the gh executable boundary before signing or transport, including REST fallback writes.

## Files Changed

.agents/scripts/gh, .agents/scripts/tests/test-gh-shim.sh, .agents/workflows/log-issue-aidevops.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — test-gh-shim.sh: 82 passed; test-verify-brief.sh: 30 passed; ShellCheck clean; linters-local.sh --changed passed; review bundle 495be7d0737571e10b6dfd3d50b63df1782286554b5aca319c99134e96bf6522 clean.

Resolves #28710


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.183 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 59m and 851,597 tokens on this with the user in an interactive session.