### PR TITLE
GH#28713: Preserve issue publication and normalize dispatch labels

### DIFF
--- a/.agents/reference/task-lifecycle.md
+++ b/.agents/reference/task-lifecycle.md
@@ -128,7 +128,7 @@ Do not end a save flow with only "start anytime" when the task is worker-ready; 
   - automatable verification; and
   - 2+ acceptance criteria beyond generic tests/lint.
 
-  If readiness is missing, finish the brief first or mark the work `#parent`/blocked instead of filing a non-dispatchable implementation issue. See `workflows/plans.md` "Auto-Dispatch Tagging".
+  If readiness is missing, improve the brief when practical, but do not suppress useful issue publication. Publish without `#auto-dispatch`, state the missing information, and leave the issue recorded for enrichment; use `#parent`/blocked only when those semantics are true. Do not add `#no-auto-dispatch` merely because readiness is incomplete—that label is reserved for durable manual intent. See `workflows/plans.md` "Auto-Dispatch Tagging".
 - **Exclusions**: Omit `#auto-dispatch` only for:
   - blocker labels;
   - credentials, accounts, or purchases;
@@ -141,6 +141,7 @@ Do not end a save flow with only "start anytime" when the task is worker-ready; 
   Dispatch-path files are **not** excluded post-t2920; they auto-dispatch with opus-4-7 elevation. Canonical blocker label set: `reference/dispatch-blockers.md`.
 - **Dispatch-path advisory (t2821, t2832, t2920)**: When a task's `### Files Scope` or `## How` section references a file in `.agents/configs/self-hosting-files.conf`, use `#auto-dispatch` as normal. The t2819 detector auto-elevates these workers to `tier:thinking`; runtime routing chooses the concrete model and reasoning level. Worker isolation, CI gates, watchdog kills, and the t2690 circuit breaker replace the historical `no-auto-dispatch` default. **Opt-out (rare):** use `#no-auto-dispatch #interactive` only when intentionally observing the running system. Full decision tree: `reference/auto-dispatch.md` "Dispatch-Path Default (t2821 / t2920)".
 - **Quality gate**: Same readiness definition as `#auto-dispatch` above; do not maintain a second criteria list.
+- **Dispatch-label mutual exclusion**: `#auto-dispatch` and `#no-auto-dispatch` must never coexist. Managed issue-create/edit paths normalize conflicts without suppressing publication: an explicit manual hold wins a same-command conflict, and adding either label removes its opposite.
 - **Interactive workflow**: Add `assignee:` before pushing if working interactively.
 - **Server-side safety net (t2798)**: `.github/workflows/apply-status-available-default.yml` applies `status:available` to issues that carry `auto-dispatch` but have no `status:*` label — catches bypass-path creations (bare `gh issue create`, web UI) that skip `claim-task-id.sh`.
 

--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -26,9 +26,9 @@
 # Design principles
 # -----------------
 #   1. Fast path: non-write subcommands pay a single case-match then exec.
-#   2. Fail-open infrastructure: missing helpers and malformed internal state
-#      preserve native `gh` behaviour. Deterministic write-policy violations
-#      still fail closed when their validator is available.
+#   2. Fail-open infrastructure: missing helpers and report-quality findings
+#      preserve native `gh` behaviour. Deterministic security/write-policy
+#      violations still fail closed; conflicting metadata is normalized.
 #   3. Recursion guard: if the shim somehow re-enters (subprocess inherits
 #      PATH), the second invocation short-circuits to the real gh.
 #   4. Single source of truth: uses the same marker (`<!-- aidevops:sig -->`)
@@ -1536,7 +1536,7 @@ _shim_framework_bug_candidate() {
 	return 1
 }
 
-_shim_validate_framework_bug_body() {
+_shim_advise_framework_bug_body() {
 	local body="$1"
 	local body_file="$2"
 	local validator="${_SHIM_DIR}/log-issue-helper.sh"
@@ -1565,10 +1565,10 @@ _shim_validate_framework_bug_body() {
 	fi
 
 	[[ -z "$temporary_body" ]] || rm -f "$temporary_body"
-	printf '[aidevops][issue-brief][BLOCK] Canonical aidevops framework-bug report failed final-body validation.\n' >&2
+	printf '[aidevops][issue-brief][WARN] Canonical aidevops framework-bug report failed final-body validation; publishing it for later enrichment.\n' >&2
 	[[ -z "$validation_output" ]] || printf '%s\n' "$validation_output" >&2
-	printf '  Add substantive ## Reproducer evidence or explicitly frame the report as an unconfirmed investigation, then retry.\n' >&2
-	return 1
+	printf '  Add substantive ## Reproducer evidence or explicitly frame the report as an unconfirmed investigation when practical.\n' >&2
+	return 0
 }
 
 _SHIM_ISSUE_BODY=""
@@ -1605,7 +1605,7 @@ _shim_issue_create_collect_body() {
 	return 0
 }
 
-_shim_validate_cli_issue_create_if_needed() {
+_shim_advise_cli_issue_create_if_needed() {
 	[[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "issue:create" ]] || return 0
 	local repo_slug=""
 	local normalized_repo=""
@@ -1619,7 +1619,7 @@ _shim_validate_cli_issue_create_if_needed() {
 	_shim_issue_create_collect_body
 	_shim_issue_create_has_label "bug" && has_bug_label=1
 	_shim_framework_bug_candidate "$title" "$_SHIM_ISSUE_BODY" "$has_bug_label" || return 0
-	_shim_validate_framework_bug_body "$_SHIM_ISSUE_BODY" "$_SHIM_ISSUE_BODY_FILE"
+	_shim_advise_framework_bug_body "$_SHIM_ISSUE_BODY" "$_SHIM_ISSUE_BODY_FILE"
 	return $?
 }
 
@@ -1675,7 +1675,7 @@ _shim_api_issue_create_collect_fields() {
 	return 0
 }
 
-_shim_validate_api_issue_create_if_needed() {
+_shim_advise_api_issue_create_if_needed() {
 	[[ "${_modified_args[0]:-}" == "api" ]] || return 0
 	_shim_api_issue_create_collect_fields
 	local normalized_path=""
@@ -1684,18 +1684,224 @@ _shim_validate_api_issue_create_if_needed() {
 	[[ "$normalized_path" == "repos/marcusquinn/aidevops/issues" ]] || return 0
 	_shim_title_is_internal_tracking_issue "$_SHIM_API_ISSUE_TITLE" && return 0
 	_shim_framework_bug_candidate "$_SHIM_API_ISSUE_TITLE" "$_SHIM_API_ISSUE_BODY" "$_SHIM_API_ISSUE_HAS_BUG_LABEL" || return 0
-	_shim_validate_framework_bug_body "$_SHIM_API_ISSUE_BODY" "$_SHIM_API_ISSUE_BODY_FILE"
+	_shim_advise_framework_bug_body "$_SHIM_API_ISSUE_BODY" "$_SHIM_API_ISSUE_BODY_FILE"
 	return $?
 }
 
-_shim_validate_framework_bug_issue_create_if_needed() {
+_shim_advise_framework_bug_issue_create_if_needed() {
 	if [[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "issue:create" ]]; then
-		_shim_validate_cli_issue_create_if_needed
+		_shim_advise_cli_issue_create_if_needed
 		return $?
 	fi
 	if [[ "${_modified_args[0]:-}" == "api" ]]; then
-		_shim_validate_api_issue_create_if_needed
+		_shim_advise_api_issue_create_if_needed
 		return $?
+	fi
+	return 0
+}
+
+# Dispatch intent is mechanically mutually exclusive. Preserve issue
+# publication and fail safe to the explicit manual hold when one write requests
+# both labels. For issue edits, adding either intent also removes its opposite.
+_SHIM_DISPATCH_AUTO_LABEL="auto-dispatch"
+_SHIM_DISPATCH_MANUAL_LABEL="no-auto-dispatch"
+_SHIM_FILTERED_LABEL_CSV=""
+
+_shim_filter_label_csv() {
+	local labels="$1"
+	local unwanted="$2"
+	local label=""
+	local joined=""
+	local label_array=()
+	local IFS=,
+	_SHIM_FILTERED_LABEL_CSV=""
+	read -ra label_array <<< "$labels"
+	for label in "${label_array[@]}"; do
+		label="${label#"${label%%[![:space:]]*}"}"
+		label="${label%"${label##*[![:space:]]}"}"
+		[[ -n "$label" && "$label" != "$unwanted" ]] || continue
+		joined="${joined}${joined:+,}${label}"
+	done
+	_SHIM_FILTERED_LABEL_CSV="$joined"
+	return 0
+}
+
+_shim_cli_label_action_has() {
+	local action_flag="$1"
+	local wanted="$2"
+	local idx=0
+	local arg=""
+	local value=""
+	while [[ $idx -lt ${#_modified_args[@]} ]]; do
+		arg="${_modified_args[$idx]}"
+		value=""
+		if [[ "$arg" == "$action_flag" ]] ||
+			[[ "$action_flag" == "--label" && "$arg" == "-l" ]]; then
+			value="${_modified_args[idx + 1]:-}"
+			idx=$((idx + 2))
+		elif [[ "$arg" == "${action_flag}="* ]]; then
+			value="${arg#*=}"
+			idx=$((idx + 1))
+		elif [[ "$action_flag" == "--label" && "$arg" == -l?* ]]; then
+			value="${arg#-l}"
+			idx=$((idx + 1))
+		else
+			idx=$((idx + 1))
+			continue
+		fi
+		_shim_arg_labels_contain "$value" "$wanted" && return 0
+	done
+	return 1
+}
+
+_shim_filter_cli_label_action() {
+	local action_flag="$1"
+	local unwanted="$2"
+	local idx=0
+	local arg=""
+	local value=""
+	local -a rebuilt=()
+	while [[ $idx -lt ${#_modified_args[@]} ]]; do
+		arg="${_modified_args[$idx]}"
+		if [[ "$arg" == "$action_flag" ]] ||
+			[[ "$action_flag" == "--label" && "$arg" == "-l" ]]; then
+			value="${_modified_args[idx + 1]:-}"
+			_shim_filter_label_csv "$value" "$unwanted"
+			[[ -z "$_SHIM_FILTERED_LABEL_CSV" ]] || rebuilt+=("$arg" "$_SHIM_FILTERED_LABEL_CSV")
+			idx=$((idx + 2))
+			continue
+		fi
+		if [[ "$arg" == "${action_flag}="* ]]; then
+			value="${arg#*=}"
+			_shim_filter_label_csv "$value" "$unwanted"
+			[[ -z "$_SHIM_FILTERED_LABEL_CSV" ]] || rebuilt+=("${action_flag}=${_SHIM_FILTERED_LABEL_CSV}")
+			idx=$((idx + 1))
+			continue
+		fi
+		if [[ "$action_flag" == "--label" && "$arg" == -l?* ]]; then
+			value="${arg#-l}"
+			_shim_filter_label_csv "$value" "$unwanted"
+			[[ -z "$_SHIM_FILTERED_LABEL_CSV" ]] || rebuilt+=("-l${_SHIM_FILTERED_LABEL_CSV}")
+			idx=$((idx + 1))
+			continue
+		fi
+		rebuilt+=("$arg")
+		idx=$((idx + 1))
+	done
+	_modified_args=("${rebuilt[@]}")
+	return 0
+}
+
+_shim_api_has_label_field() {
+	local wanted="$1"
+	local idx=0
+	local arg=""
+	local field=""
+	while [[ $idx -lt ${#_modified_args[@]} ]]; do
+		arg="${_modified_args[$idx]}"
+		field=""
+		case "$arg" in
+		-f | -F | --field | --raw-field)
+			field="${_modified_args[idx + 1]:-}"
+			idx=$((idx + 2))
+			;;
+		-f* | -F*) field="${arg:2}"; idx=$((idx + 1)) ;;
+		--field=* | --raw-field=*) field="${arg#*=}"; idx=$((idx + 1)) ;;
+		*) idx=$((idx + 1)); continue ;;
+		esac
+		if [[ "$field" == "labels[]=${wanted}" || "$field" == "labels=${wanted}" ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+_shim_filter_api_label_field() {
+	local unwanted="$1"
+	local idx=0
+	local arg=""
+	local field=""
+	local -a rebuilt=()
+	while [[ $idx -lt ${#_modified_args[@]} ]]; do
+		arg="${_modified_args[$idx]}"
+		field=""
+		case "$arg" in
+		-f | -F | --field | --raw-field)
+			field="${_modified_args[idx + 1]:-}"
+			if [[ "$field" != "labels[]=${unwanted}" && "$field" != "labels=${unwanted}" ]]; then
+				rebuilt+=("$arg" "$field")
+			fi
+			idx=$((idx + 2))
+			;;
+		-f* | -F*)
+			field="${arg:2}"
+			[[ "$field" == "labels[]=${unwanted}" || "$field" == "labels=${unwanted}" ]] || rebuilt+=("$arg")
+			idx=$((idx + 1))
+			;;
+		--field=* | --raw-field=*)
+			field="${arg#*=}"
+			[[ "$field" == "labels[]=${unwanted}" || "$field" == "labels=${unwanted}" ]] || rebuilt+=("$arg")
+			idx=$((idx + 1))
+			;;
+		*) rebuilt+=("$arg"); idx=$((idx + 1)) ;;
+		esac
+	done
+	_modified_args=("${rebuilt[@]}")
+	return 0
+}
+
+_shim_warn_dispatch_label_conflict() {
+	printf '[aidevops][dispatch-labels][NORMALIZE] Removed %s because %s was requested in the same issue write; publication continues.\n' \
+		"$_SHIM_DISPATCH_AUTO_LABEL" "$_SHIM_DISPATCH_MANUAL_LABEL" >&2
+	return 0
+}
+
+_shim_normalize_dispatch_labels() {
+	local has_auto=0
+	local has_manual=0
+	case "${_modified_args[0]:-}:${_modified_args[1]:-}" in
+	issue:create)
+		_shim_cli_label_action_has "--label" "$_SHIM_DISPATCH_AUTO_LABEL" && has_auto=1
+		_shim_cli_label_action_has "--label" "$_SHIM_DISPATCH_MANUAL_LABEL" && has_manual=1
+		if [[ $has_auto -eq 1 && $has_manual -eq 1 ]]; then
+			_shim_filter_cli_label_action "--label" "$_SHIM_DISPATCH_AUTO_LABEL"
+			_shim_warn_dispatch_label_conflict
+		fi
+		return 0
+		;;
+	issue:edit)
+		_shim_cli_label_action_has "--add-label" "$_SHIM_DISPATCH_AUTO_LABEL" && has_auto=1
+		_shim_cli_label_action_has "--add-label" "$_SHIM_DISPATCH_MANUAL_LABEL" && has_manual=1
+		if [[ $has_manual -eq 1 ]]; then
+			_shim_filter_cli_label_action "--add-label" "$_SHIM_DISPATCH_AUTO_LABEL"
+			_shim_filter_cli_label_action "--remove-label" "$_SHIM_DISPATCH_MANUAL_LABEL"
+			_shim_cli_label_action_has "--remove-label" "$_SHIM_DISPATCH_AUTO_LABEL" ||
+				_modified_args+=(--remove-label "$_SHIM_DISPATCH_AUTO_LABEL")
+			[[ $has_auto -eq 0 ]] || _shim_warn_dispatch_label_conflict
+		elif [[ $has_auto -eq 1 ]]; then
+			_shim_filter_cli_label_action "--remove-label" "$_SHIM_DISPATCH_AUTO_LABEL"
+			_shim_cli_label_action_has "--remove-label" "$_SHIM_DISPATCH_MANUAL_LABEL" ||
+				_modified_args+=(--remove-label "$_SHIM_DISPATCH_MANUAL_LABEL")
+		fi
+		return 0
+		;;
+	esac
+
+	[[ "${_modified_args[0]:-}" == "api" ]] || return 0
+	_shim_api_issue_create_collect_fields
+	local normalized_path=""
+	local normalized_method=""
+	normalized_path=$(printf '%s' "${_SHIM_API_ISSUE_PATH#/}" | tr '[:upper:]' '[:lower:]')
+	normalized_method=$(printf '%s' "$_SHIM_API_ISSUE_METHOD" | tr '[:lower:]' '[:upper:]')
+	# gh api infers POST when fields are supplied and no method is explicit.
+	[[ -n "$normalized_method" ]] || normalized_method="POST"
+	[[ "$normalized_method" == "POST" || "$normalized_method" == "PATCH" ]] || return 0
+	[[ "$normalized_path" =~ ^repos/[^/]+/[^/]+/issues(/[0-9]+(/labels)?)?$ ]] || return 0
+	_shim_api_has_label_field "$_SHIM_DISPATCH_AUTO_LABEL" && has_auto=1
+	_shim_api_has_label_field "$_SHIM_DISPATCH_MANUAL_LABEL" && has_manual=1
+	if [[ $has_auto -eq 1 && $has_manual -eq 1 ]]; then
+		_shim_filter_api_label_field "$_SHIM_DISPATCH_AUTO_LABEL"
+		_shim_warn_dispatch_label_conflict
 	fi
 	return 0
 }
@@ -1715,6 +1921,7 @@ _shim_normalize_interactive_tracking_issue_create() {
 }
 
 _shim_normalize_interactive_tracking_issue_create
+_shim_normalize_dispatch_labels
 
 _shim_normalize_pr_create_origin() {
 	[[ "${_modified_args[0]:-}:${_modified_args[1]:-}" == "pr:create" ]] || return 0
@@ -1903,9 +2110,7 @@ if ! _shim_block_pr_create_without_linked_issue_if_needed; then
 	exit 1
 fi
 
-if ! _shim_validate_framework_bug_issue_create_if_needed; then
-	exit 1
-fi
+_shim_advise_framework_bug_issue_create_if_needed
 
 if _shim_is_content_write_command "${_modified_args[@]}"; then
 	if ! _shim_block_headless_external_write_if_needed "${_modified_args[@]}"; then

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -13,7 +13,8 @@
 #   6. `gh pr create --body` without marker gets sig appended
 #   7. `AIDEVOPS_GH_SHIM_DISABLE=1` bypasses the shim entirely
 #   8. Recursion guard: `_AIDEVOPS_GH_SHIM_ACTIVE=1` fails closed immediately
-#   9. Canonical aidevops framework-bug briefs are validated before transport
+#   9. Framework-bug validation advises without blocking issue publication
+#  10. Conflicting dispatch-intent labels are normalized before transport
 #
 # Strategy: run the shim against a stub `gh` binary that logs its args, and
 # a stub `gh-signature-helper.sh` that emits a predictable footer. Assert
@@ -251,6 +252,19 @@ _read_sig_argv() {
 	}
 	cat "${STUB_SIG_LOG:-}"
 	return 0
+}
+
+_argv_has_pair() {
+	local flag="$1"
+	local value="$2"
+	if awk -v flag="$flag" -v value="$value" '
+		previous == flag && $0 == value { found = 1 }
+		{ previous = $0 }
+		END { exit found ? 0 : 1 }
+	' "$STUB_GH_LOG"; then
+		return 0
+	fi
+	return 1
 }
 
 # =============================================================================
@@ -1126,10 +1140,10 @@ else
 fi
 
 # =============================================================================
-# Test 25: canonical aidevops framework-bug briefs are validated before writes
+# Test 25: framework-bug validation advises without blocking publication
 # =============================================================================
 echo ""
-echo "Test 25: executable framework-bug brief validation"
+echo "Test 25: advisory framework-bug brief validation"
 
 malformed_brief="$TMP/malformed-framework-bug.md"
 cat >"$malformed_brief" <<'EOF'
@@ -1147,13 +1161,15 @@ _reset_log
 if "$SHIM_RUN" issue create --repo marcusquinn/aidevops \
 	--title "bug(cleanup): malformed report" --label bug \
 	--body-file "$malformed_brief" 2>"$TMP/malformed-file.err"; then
-	_fail "malformed framework-bug body-file guard" "write unexpectedly passed"
-elif [[ ! -s "$STUB_GH_LOG" ]] && cmp -s "$malformed_brief" "$TMP/malformed-framework-bug.original" &&
-	grep -q '\[aidevops\]\[issue-brief\]\[BLOCK\]' "$TMP/malformed-file.err" &&
-	grep -q 'Reproducer requires' "$TMP/malformed-file.err"; then
-	_pass "malformed body-file is blocked before transport without source mutation"
+	if [[ -s "$STUB_GH_LOG" ]] && cmp -s "$malformed_brief" "$TMP/malformed-framework-bug.original" &&
+		grep -q '\[aidevops\]\[issue-brief\]\[WARN\]' "$TMP/malformed-file.err" &&
+		grep -q 'Reproducer requires' "$TMP/malformed-file.err"; then
+		_pass "malformed body-file warns and reaches transport without source mutation"
+	else
+		_fail "malformed framework-bug body-file advisory" "argv: $(_read_argv) err: $(cat "$TMP/malformed-file.err" 2>/dev/null || true)"
+	fi
 else
-	_fail "malformed framework-bug body-file guard" "argv: $(_read_argv) err: $(cat "$TMP/malformed-file.err" 2>/dev/null || true)"
+	_fail "malformed framework-bug body-file advisory" "write was blocked"
 fi
 
 _reset_log
@@ -1161,11 +1177,14 @@ malformed_inline=$(<"$malformed_brief")
 if "$SHIM_RUN" issue create --repo marcusquinn/aidevops \
 	--title "bug(shim): malformed inline report" --body "$malformed_inline" \
 	2>"$TMP/malformed-inline.err"; then
-	_fail "malformed inline framework-bug guard" "write unexpectedly passed"
-elif [[ ! -s "$STUB_GH_LOG" ]] && grep -q 'Reproducer requires' "$TMP/malformed-inline.err"; then
-	_pass "malformed inline body is blocked before transport"
+	if [[ -s "$STUB_GH_LOG" ]] && grep -q '\[aidevops\]\[issue-brief\]\[WARN\]' "$TMP/malformed-inline.err" &&
+		grep -q 'Reproducer requires' "$TMP/malformed-inline.err"; then
+		_pass "malformed inline body warns and reaches transport"
+	else
+		_fail "malformed inline framework-bug advisory" "argv: $(_read_argv) err: $(cat "$TMP/malformed-inline.err" 2>/dev/null || true)"
+	fi
 else
-	_fail "malformed inline framework-bug guard" "argv: $(_read_argv) err: $(cat "$TMP/malformed-inline.err" 2>/dev/null || true)"
+	_fail "malformed inline framework-bug advisory" "write was blocked"
 fi
 
 valid_investigation="$TMP/valid-framework-investigation.md"
@@ -1207,17 +1226,17 @@ The issue-create guard accepts a proven bug report.
 
 **Symptom command**: `gh issue create --repo marcusquinn/aidevops`
 
-**Actual output**: `the malformed write reached the stub`
+**Actual output**: `the issue write reached the transport stub`
 
-**Expected output**: `the malformed write is rejected`
+**Expected output**: `validated reports and incomplete reports can both be published`
 
 **Causal status**: confirmed
 
 **Production entry point**: `.agents/scripts/gh` receives the issue-create command
 
-**Call chain**: issue creation enters the shim and validates before the native CLI
+**Call chain**: issue creation enters the shim and validates advisorially before the native CLI
 
-**Integrated verification**: this hermetic command reaches the transport stub only after validation
+**Integrated verification**: this hermetic command reaches the transport stub after advisory validation
 EOF
 valid_confirmed=$(<"$valid_confirmed_file")
 _reset_log
@@ -1289,11 +1308,14 @@ _reset_log
 if "$SHIM_RUN" api /repos/marcusquinn/aidevops/issues -X POST \
 	-f "title=bug(rest): malformed fallback report" -F "body=@$malformed_brief" \
 	-f 'labels[]=bug' 2>"$TMP/malformed-rest.err"; then
-	_fail "malformed REST fallback guard" "write unexpectedly passed"
-elif [[ ! -s "$STUB_GH_LOG" ]] && grep -q 'Reproducer requires' "$TMP/malformed-rest.err"; then
-	_pass "malformed REST fallback body is blocked before transport"
+	if [[ -s "$STUB_GH_LOG" ]] && grep -q '\[aidevops\]\[issue-brief\]\[WARN\]' "$TMP/malformed-rest.err" &&
+		grep -q 'Reproducer requires' "$TMP/malformed-rest.err"; then
+		_pass "malformed REST fallback body warns and reaches transport"
+	else
+		_fail "malformed REST fallback advisory" "argv: $(_read_argv) err: $(cat "$TMP/malformed-rest.err" 2>/dev/null || true)"
+	fi
 else
-	_fail "malformed REST fallback guard" "argv: $(_read_argv) err: $(cat "$TMP/malformed-rest.err" 2>/dev/null || true)"
+	_fail "malformed REST fallback advisory" "write was blocked"
 fi
 
 _reset_log
@@ -1304,6 +1326,70 @@ if [[ "$resolved_output" == resolved_body_file=* ]] &&
 	_pass "valid SHIM_TEST_MODE path remains available and source-safe"
 else
 	_fail "SHIM_TEST_MODE compatibility" "output: $resolved_output"
+fi
+
+# =============================================================================
+# Test 26: dispatch-intent labels are mutually exclusive at transport
+# =============================================================================
+echo ""
+echo "Test 26: dispatch-intent label normalization"
+
+_reset_log
+"$SHIM_RUN" issue create --repo owner/repo --title "Dispatch intent conflict" \
+	--body "Capture the issue." --label "bug,auto-dispatch" --label no-auto-dispatch \
+	2>"$TMP/dispatch-create.err"
+if grep -Fxq 'no-auto-dispatch' "$STUB_GH_LOG" &&
+	! grep -Eq '(^|,)auto-dispatch(,|$)' "$STUB_GH_LOG" &&
+	grep -q '\[aidevops\]\[dispatch-labels\]\[NORMALIZE\]' "$TMP/dispatch-create.err"; then
+	_pass "issue creation keeps the manual hold when both dispatch labels are requested"
+else
+	_fail "issue-create dispatch conflict normalization" "argv: $(_read_argv) err: $(cat "$TMP/dispatch-create.err" 2>/dev/null || true)"
+fi
+
+_reset_log
+"$SHIM_RUN" issue edit 42 --repo owner/repo --add-label no-auto-dispatch \
+	--remove-label no-auto-dispatch 2>/dev/null
+if _argv_has_pair "--add-label" "no-auto-dispatch" &&
+	_argv_has_pair "--remove-label" "auto-dispatch" &&
+	! _argv_has_pair "--remove-label" "no-auto-dispatch"; then
+	_pass "adding no-auto-dispatch removes auto-dispatch and preserves the requested hold"
+else
+	_fail "manual dispatch-intent issue edit" "argv: $(_read_argv)"
+fi
+
+_reset_log
+"$SHIM_RUN" issue edit 42 --repo owner/repo --add-label auto-dispatch \
+	--remove-label auto-dispatch 2>/dev/null
+if _argv_has_pair "--add-label" "auto-dispatch" &&
+	_argv_has_pair "--remove-label" "no-auto-dispatch" &&
+	! _argv_has_pair "--remove-label" "auto-dispatch"; then
+	_pass "adding auto-dispatch removes no-auto-dispatch and preserves automation intent"
+else
+	_fail "automatic dispatch-intent issue edit" "argv: $(_read_argv)"
+fi
+
+_reset_log
+"$SHIM_RUN" issue edit 42 --repo owner/repo --add-label auto-dispatch \
+	--add-label no-auto-dispatch 2>"$TMP/dispatch-edit.err"
+if _argv_has_pair "--add-label" "no-auto-dispatch" &&
+	! _argv_has_pair "--add-label" "auto-dispatch" &&
+	_argv_has_pair "--remove-label" "auto-dispatch" &&
+	grep -q '\[aidevops\]\[dispatch-labels\]\[NORMALIZE\]' "$TMP/dispatch-edit.err"; then
+	_pass "same-command issue-edit conflict fails safe to no-auto-dispatch"
+else
+	_fail "issue-edit dispatch conflict normalization" "argv: $(_read_argv) err: $(cat "$TMP/dispatch-edit.err" 2>/dev/null || true)"
+fi
+
+_reset_log
+"$SHIM_RUN" api /repos/owner/repo/issues -f 'title=REST dispatch conflict' \
+	-f 'body=Capture the issue.' -f 'labels[]=auto-dispatch' -f 'labels[]=no-auto-dispatch' \
+	2>"$TMP/dispatch-rest.err"
+if _argv_has_pair "-f" "labels[]=no-auto-dispatch" &&
+	! _argv_has_pair "-f" "labels[]=auto-dispatch" &&
+	grep -q '\[aidevops\]\[dispatch-labels\]\[NORMALIZE\]' "$TMP/dispatch-rest.err"; then
+	_pass "REST issue creation cannot transport both dispatch-intent labels"
+else
+	_fail "REST dispatch conflict normalization" "argv: $(_read_argv) err: $(cat "$TMP/dispatch-rest.err" 2>/dev/null || true)"
 fi
 
 # =============================================================================

--- a/.agents/workflows/log-issue-aidevops.md
+++ b/.agents/workflows/log-issue-aidevops.md
@@ -325,14 +325,21 @@ Do not validate an earlier draft or inline copy:
 ```
 
 If validation fails, correct the evidence or explicitly reframe the report as an
-unconfirmed investigation. Do not run `gh issue create` until validation passes.
+unconfirmed investigation when practical. Do not suppress a useful issue solely
+because its report is incomplete: publish it without `auto-dispatch`, retain the
+validator output as enrichment guidance, and let later triage improve the body.
 
 The aidevops `gh` PATH shim repeats this final-body validation at exec time for
 non-tracking framework-bug reports targeting `marcusquinn/aidevops`. This is a
-deterministic backstop for raw and wrapped `gh issue create` calls, not a
-replacement for the workflow check above. A blocked write leaves the caller's
-body file unchanged; apply the validator's remediation and retry. Internal
-`tNNN:` / `GH#NNN:` tracking tasks and non-bug issue shapes are exempt.
+non-blocking quality advisory for raw and wrapped `gh issue create` calls, not a
+publication gate or a replacement for the workflow check above. The shim leaves
+the caller's body file unchanged. Internal `tNNN:` / `GH#NNN:` tracking tasks and
+non-bug issue shapes are exempt.
+
+The same shim deterministically normalizes mutually exclusive dispatch intent:
+`auto-dispatch` and `no-auto-dispatch` never reach issue transport together. An
+explicit `no-auto-dispatch` hold wins a same-command conflict; adding either
+label to an existing issue removes its opposite without blocking the edit.
 
 ```bash
 gh issue create -R marcusquinn/aidevops \


### PR DESCRIPTION
## Summary

Make aidevops framework-bug brief validation advisory so incomplete reports still publish; normalize mutually exclusive dispatch labels for CLI and REST issue creation and CLI issue edits; document enrichment and durable-hold semantics.

## Files Changed

.agents/reference/task-lifecycle.md, .agents/scripts/gh, .agents/scripts/tests/test-gh-shim.sh, .agents/workflows/log-issue-aidevops.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified: bash .agents/scripts/tests/test-gh-shim.sh completed with 87 passed and 0 failed; shellcheck passed; .agents/scripts/linters-local.sh --changed reported all local checks passed.

Resolves #28713


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.184 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 1h 2m and 861,358 tokens on this with the user in an interactive session.