### PR TITLE
GH#28689: Clean up orphaned pulse benign-block ledgers

### DIFF
--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -20,6 +20,7 @@
 # Dependencies:
 #   - shared-constants.sh (LOGFILE, color/status helpers, gh wrappers)
 #   - worker-lifecycle-common.sh (capacity helpers, model resolution)
+#   - portable-stat.sh (legacy scratch age checks)
 #
 # Part of aidevops framework: https://aidevops.sh
 
@@ -34,6 +35,10 @@ _PULSE_DISPATCH_LIB_DIR="${BASH_SOURCE[0]%/*}"
 [[ "$_PULSE_DISPATCH_LIB_DIR" == "${BASH_SOURCE[0]}" ]] && _PULSE_DISPATCH_LIB_DIR="."
 # shellcheck source=shared-runner-identity.sh
 source "${_PULSE_DISPATCH_LIB_DIR}/shared-runner-identity.sh"
+if ! command -v _file_mtime_epoch >/dev/null 2>&1; then
+	# shellcheck source=portable-stat.sh
+	source "${_PULSE_DISPATCH_LIB_DIR}/portable-stat.sh"
+fi
 
 # --- Helper functions and module-level round-state vars (extracted) ---
 
@@ -57,6 +62,9 @@ _DISPATCH_THROTTLE_FILE=""
 _DISPATCH_CANARY_CACHE=""
 _DISPATCH_BENIGN_BLOCKS_FILE=""
 _DISPATCH_BENIGN_BLOCKS_FILE_OWNED="0"
+_DISPATCH_BENIGN_BLOCKS_SCRATCH_DIR=""
+_DISPATCH_BENIGN_BLOCKS_LEGACY_MIN_AGE_SECONDS="${AIDEVOPS_PULSE_BENIGN_BLOCKS_LEGACY_MIN_AGE_SECONDS:-3600}"
+[[ "$_DISPATCH_BENIGN_BLOCKS_LEGACY_MIN_AGE_SECONDS" =~ ^[0-9]+$ ]] || _DISPATCH_BENIGN_BLOCKS_LEGACY_MIN_AGE_SECONDS=3600
 # Out-parameter set by _dispatch_process_candidate when a successful launch clears
 # the throttle file. The orchestrator loop reads this and restores
 # _effective_slots to the unthrottled available_slots value.
@@ -309,6 +317,122 @@ PY
 }
 
 #######################################
+# Parse the creator PID from an exact framework-managed benign-ledger name.
+#
+# Arguments:
+#   $1 - file basename
+# Stdout: creator PID
+# Returns: 0 for an exact managed name, 1 otherwise
+#######################################
+_dispatch_benign_blocks_owner_pid() {
+	local basename="$1"
+	if [[ "$basename" =~ ^benign-blocks\.([1-9][0-9]*)\.([[:alnum:]]{6}|[0-9]{1,5})$ ]]; then
+		printf '%s\n' "${BASH_REMATCH[1]}"
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Remove exact framework-managed ledgers whose creator PID is no longer alive.
+# Live-owner files, symlinks, foreign-owned files, and near-matches survive.
+#
+# Arguments:
+#   $1 - private managed scratch directory
+# Returns: 0 on a safe scan, 1 when the directory boundary is unsafe
+#######################################
+_dispatch_cleanup_managed_benign_blocks() {
+	local scratch_dir="$1"
+	local candidate=""
+	local basename=""
+	local owner_pid=""
+	[[ -d "$scratch_dir" && ! -L "$scratch_dir" && -O "$scratch_dir" ]] || return 1
+	for candidate in "$scratch_dir"/benign-blocks.*.*; do
+		[[ -f "$candidate" && ! -L "$candidate" && -O "$candidate" ]] || continue
+		basename="${candidate##*/}"
+		owner_pid=$(_dispatch_benign_blocks_owner_pid "$basename") || continue
+		if ! kill -0 "$owner_pid" 2>/dev/null; then
+			rm -f "$candidate" 2>/dev/null || true
+		fi
+	done
+	return 0
+}
+
+#######################################
+# Remove age-qualified legacy ledgers whose old names carry no reliable owner.
+# The exact historical mktemp and numeric-fallback grammars are the only files
+# eligible for migration cleanup.
+#
+# Returns: 0 always; migration cleanup must never block pulse startup
+#######################################
+_dispatch_cleanup_legacy_benign_blocks() {
+	local logs_dir="${HOME}/.aidevops/logs"
+	local candidate=""
+	local basename=""
+	local modified=""
+	local now=""
+	local age=0
+	[[ -d "$logs_dir" ]] || return 0
+	command -v _file_mtime_epoch >/dev/null 2>&1 || return 0
+	now=$(date +%s 2>/dev/null) || return 0
+	[[ "$now" =~ ^[0-9]+$ ]] || return 0
+	for candidate in "$logs_dir"/pulse-dispatch-benign-blocks.*; do
+		[[ -f "$candidate" && ! -L "$candidate" && -O "$candidate" ]] || continue
+		basename="${candidate##*/}"
+		if [[ "$basename" =~ ^pulse-dispatch-benign-blocks\.[[:alnum:]]{6}$ ]]; then
+			:
+		elif [[ "$basename" =~ ^pulse-dispatch-benign-blocks\.[1-9][0-9]*\.[0-9]{1,5}$ ]]; then
+			:
+		else
+			continue
+		fi
+		modified=$(_file_mtime_epoch "$candidate") || continue
+		[[ "$modified" =~ ^[0-9]+$ && "$now" -ge "$modified" ]] || continue
+		age=$((now - modified))
+		[[ "$age" -ge "$_DISPATCH_BENIGN_BLOCKS_LEGACY_MIN_AGE_SECONDS" ]] || continue
+		rm -f "$candidate" 2>/dev/null || true
+	done
+	return 0
+}
+
+#######################################
+# Reap stale managed and legacy benign ledgers at the exclusive startup gate.
+#
+# Returns: 0 always; stale-file cleanup is best effort
+#######################################
+_dispatch_cleanup_stale_benign_blocks() {
+	local scratch_dir="${HOME}/.aidevops/logs/.pulse-dispatch-benign-blocks"
+	if [[ -d "$scratch_dir" && ! -L "$scratch_dir" && -O "$scratch_dir" ]]; then
+		_dispatch_cleanup_managed_benign_blocks "$scratch_dir" || true
+	fi
+	_dispatch_cleanup_legacy_benign_blocks || true
+	return 0
+}
+
+#######################################
+# Prepare the private scratch boundary used by framework-managed ledgers.
+#
+# Returns: 0 when the directory is safe, 1 otherwise
+#######################################
+_dispatch_prepare_benign_blocks_scratch_dir() {
+	local logs_dir="${HOME}/.aidevops/logs"
+	local scratch_dir="${logs_dir}/.pulse-dispatch-benign-blocks"
+	if ! mkdir -p "$logs_dir"; then
+		return 1
+	fi
+	if [[ ! -e "$scratch_dir" && ! -L "$scratch_dir" ]]; then
+		if ! (umask 077 && mkdir "$scratch_dir" 2>/dev/null); then
+			[[ -d "$scratch_dir" && ! -L "$scratch_dir" ]] || return 1
+		fi
+	fi
+	[[ -d "$scratch_dir" && ! -L "$scratch_dir" && -O "$scratch_dir" ]] || return 1
+	chmod 0700 "$scratch_dir" 2>/dev/null || return 1
+	_DISPATCH_BENIGN_BLOCKS_SCRATCH_DIR="$scratch_dir"
+	_dispatch_cleanup_managed_benign_blocks "$scratch_dir" || return 1
+	return 0
+}
+
+#######################################
 # Start a cycle-local benign block ledger. Reinitializing the ledger for every
 # dispatch_max cycle prevents stale active-claim blocks from a long-running
 # pulse-wrapper process from suppressing later cycles after the claim clears.
@@ -319,14 +443,17 @@ PY
 _dispatch_begin_benign_blocks_cycle() {
 	local ledger_file=""
 	local ledger_managed_by_dispatch="0"
+	local owner_pid="${BASHPID:-$$}"
 	if [[ -n "${AIDEVOPS_PULSE_BENIGN_BLOCKS_FILE:-}" ]]; then
 		ledger_file="$AIDEVOPS_PULSE_BENIGN_BLOCKS_FILE"
 	else
 		ledger_managed_by_dispatch="1"
-		if ! mkdir -p "${HOME}/.aidevops/logs"; then
-			printf 'Failed to create benign block ledger directory: %s\n' "${HOME}/.aidevops/logs" >&2
+		[[ "$owner_pid" =~ ^[1-9][0-9]*$ ]] || owner_pid="$$"
+		if ! _dispatch_prepare_benign_blocks_scratch_dir; then
+			printf 'Failed to prepare benign block ledger scratch directory: %s\n' "${HOME}/.aidevops/logs/.pulse-dispatch-benign-blocks" >&2
+		else
+			ledger_file=$(mktemp "${_DISPATCH_BENIGN_BLOCKS_SCRATCH_DIR}/benign-blocks.${owner_pid}.XXXXXX" 2>/dev/null || printf '%s\n' "${_DISPATCH_BENIGN_BLOCKS_SCRATCH_DIR}/benign-blocks.${owner_pid}.${RANDOM}")
 		fi
-		ledger_file=$(mktemp "${HOME}/.aidevops/logs/pulse-dispatch-benign-blocks.XXXXXX" || printf '%s\n' "${HOME}/.aidevops/logs/pulse-dispatch-benign-blocks.$$.$RANDOM")
 	fi
 	if [[ -z "$ledger_file" ]]; then
 		printf 'Failed to resolve benign block ledger file path\n' >&2
@@ -343,6 +470,9 @@ _dispatch_begin_benign_blocks_cycle() {
 	fi
 	if ! : >"$ledger_file"; then
 		printf 'Failed to initialize benign block ledger file: %s\n' "$ledger_file" >&2
+	fi
+	if [[ "$ledger_managed_by_dispatch" == "1" ]] && ! chmod 0600 "$ledger_file" 2>/dev/null; then
+		printf 'Failed to secure benign block ledger file: %s\n' "$ledger_file" >&2
 	fi
 	_DISPATCH_BENIGN_BLOCKS_FILE="$ledger_file"
 	_DISPATCH_BENIGN_BLOCKS_FILE_OWNED="$ledger_managed_by_dispatch"

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1638,11 +1638,12 @@ main() {
 	# Register EXIT trap BEFORE acquiring the lock so the lock is always
 	# released on exit — including set -e aborts, SIGTERM, and return paths.
 	# SIGKILL cannot be trapped; stale-lock detection handles that case.
-	trap '_pulse_release_llm_lock; _pulse_cycle_state_finish_interrupted; _pulse_efficiency_cycle_finish; release_instance_lock; aidevops_runtime_bundle_lease_release' EXIT
+	trap '_dispatch_cleanup_benign_blocks_cycle; _pulse_release_llm_lock; _pulse_cycle_state_finish_interrupted; _pulse_efficiency_cycle_finish; release_instance_lock; aidevops_runtime_bundle_lease_release' EXIT
 
 	if ! acquire_instance_lock; then
 		return 0
 	fi
+	_dispatch_cleanup_stale_benign_blocks || true
 
 	# GH#22525: enable REST-first read routing before any post-lock pulse gate
 	# runs. GH#22507 originally flipped this after session/dedup gates, leaving
@@ -1684,6 +1685,7 @@ main() {
 		push_cleanup '_pulse_efficiency_cycle_finish'
 		push_cleanup '_pulse_cycle_state_finish_interrupted'
 		push_cleanup '_pulse_release_llm_lock'
+		push_cleanup '_dispatch_cleanup_benign_blocks_cycle'
 		# GH#23728: keep EXIT (not RETURN) for SIGTERM/set -e lock safety, but
 		# register release_instance_lock before replacing the direct EXIT trap.
 		trap '_run_cleanups' EXIT
@@ -1706,6 +1708,7 @@ main() {
 			push_cleanup '_pulse_efficiency_cycle_finish'
 			push_cleanup '_pulse_cycle_state_finish_interrupted'
 			push_cleanup '_pulse_release_llm_lock'
+			push_cleanup '_dispatch_cleanup_benign_blocks_cycle'
 			# GH#23728: keep EXIT (not RETURN) for SIGTERM/set -e lock safety, but
 			# register release_instance_lock before replacing the direct EXIT trap.
 			trap '_run_cleanups' EXIT

--- a/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-guardrails.sh
@@ -290,19 +290,146 @@ test_deterministic_block_reasons_are_benign() {
 test_benign_block_ledger_is_cycle_local_and_cleaned() {
 	reset_guardrail_env
 	local first_ledger second_ledger lingering_reason=""
+	local scratch_dir="${HOME}/.aidevops/logs/.pulse-dispatch-benign-blocks"
+	local first_basename=""
+	local scratch_mode=""
+	local ledger_mode=""
 	_dispatch_begin_benign_blocks_cycle >/dev/null
 	first_ledger="$_DISPATCH_BENIGN_BLOCKS_FILE"
+	first_basename="${first_ledger##*/}"
+	scratch_mode=$(_file_perms "$scratch_dir") || scratch_mode=""
+	ledger_mode=$(_file_perms "$first_ledger") || ledger_mode=""
 	_dispatch_mark_benign_blocked_candidate 23541 marcusquinn/aidevops dedup_active_claim
 	_dispatch_cleanup_benign_blocks_cycle
 	_dispatch_begin_benign_blocks_cycle >/dev/null
 	second_ledger="$_DISPATCH_BENIGN_BLOCKS_FILE"
 	lingering_reason=$(_dispatch_benign_blocked_candidate_reason 23541 marcusquinn/aidevops 2>/dev/null || true)
 	_dispatch_cleanup_benign_blocks_cycle
-	if [[ "$first_ledger" != "$second_ledger" && ! -e "$first_ledger" && ! -e "$second_ledger" && -z "$lingering_reason" ]]; then
+	if [[ "$first_ledger" != "$second_ledger" && ! -e "$first_ledger" && ! -e "$second_ledger" && -z "$lingering_reason" ]] &&
+		[[ "$first_ledger" == "$scratch_dir"/benign-blocks.*.* ]] &&
+		_dispatch_benign_blocks_owner_pid "$first_basename" >/dev/null &&
+		[[ "$scratch_mode" == "700" && "$ledger_mode" == "600" ]]; then
 		print_result "guardrail: benign block ledger is cycle-local and cleaned" 0
 	else
-		print_result "guardrail: benign block ledger is cycle-local and cleaned" 1 "first=${first_ledger} second=${second_ledger} lingering=${lingering_reason}"
+		print_result "guardrail: benign block ledger is cycle-local and cleaned" 1 "first=${first_ledger} second=${second_ledger} lingering=${lingering_reason} scratch_mode=${scratch_mode} ledger_mode=${ledger_mode}"
 	fi
+	return 0
+}
+
+test_stale_benign_block_ledgers_are_reaped_safely() {
+	reset_guardrail_env
+	local scratch_dir="${HOME}/.aidevops/logs/.pulse-dispatch-benign-blocks"
+	local logs_dir="${HOME}/.aidevops/logs"
+	local dead_pid=999999999
+	local live_pid="${BASHPID:-$$}"
+	local saved_min_age="$_DISPATCH_BENIGN_BLOCKS_LEGACY_MIN_AGE_SECONDS"
+	while kill -0 "$dead_pid" 2>/dev/null; do
+		dead_pid=$((dead_pid - 1))
+	done
+	_dispatch_prepare_benign_blocks_scratch_dir || {
+		print_result "guardrail: stale benign block cleanup is exact and owner-aware" 1 "scratch setup failed"
+		return 0
+	}
+
+	local dead_file="${scratch_dir}/benign-blocks.${dead_pid}.ABC123"
+	local live_file="${scratch_dir}/benign-blocks.${live_pid}.LIVE12"
+	local invalid_file="${scratch_dir}/benign-blocks.${dead_pid}.ABC12_"
+	local unrelated_file="${scratch_dir}/unrelated.${dead_pid}.ABC123"
+	local symlink_target="${TEST_ROOT}/managed-symlink-target"
+	local managed_symlink="${scratch_dir}/benign-blocks.${dead_pid}.SYM123"
+	local legacy_mktemp="${logs_dir}/pulse-dispatch-benign-blocks.LEG123"
+	local legacy_fallback="${logs_dir}/pulse-dispatch-benign-blocks.${dead_pid}.12345"
+	local legacy_recent="${logs_dir}/pulse-dispatch-benign-blocks.NEW123"
+	local legacy_near_match="${logs_dir}/pulse-dispatch-benign-blocks.TOOLONG"
+	local legacy_symlink_target="${TEST_ROOT}/legacy-symlink-target"
+	local legacy_symlink="${logs_dir}/pulse-dispatch-benign-blocks.SYM123"
+
+	printf 'dead\n' >"$dead_file"
+	printf 'live\n' >"$live_file"
+	printf 'invalid\n' >"$invalid_file"
+	printf 'unrelated\n' >"$unrelated_file"
+	printf 'target\n' >"$symlink_target"
+	ln -s "$symlink_target" "$managed_symlink"
+	printf 'legacy mktemp\n' >"$legacy_mktemp"
+	printf 'legacy fallback\n' >"$legacy_fallback"
+	printf 'legacy recent\n' >"$legacy_recent"
+	printf 'legacy near match\n' >"$legacy_near_match"
+	printf 'legacy target\n' >"$legacy_symlink_target"
+	ln -s "$legacy_symlink_target" "$legacy_symlink"
+	touch -t 200001010000 "$legacy_mktemp" "$legacy_fallback" "$legacy_near_match"
+	_DISPATCH_BENIGN_BLOCKS_LEGACY_MIN_AGE_SECONDS=3600
+	_dispatch_cleanup_stale_benign_blocks
+	_DISPATCH_BENIGN_BLOCKS_LEGACY_MIN_AGE_SECONDS="$saved_min_age"
+
+	if [[ ! -e "$dead_file" && -f "$live_file" && -f "$invalid_file" && -f "$unrelated_file" ]] &&
+		[[ -L "$managed_symlink" && -f "$symlink_target" ]] &&
+		[[ ! -e "$legacy_mktemp" && ! -e "$legacy_fallback" && -f "$legacy_recent" && -f "$legacy_near_match" ]] &&
+		[[ -L "$legacy_symlink" && -f "$legacy_symlink_target" ]]; then
+		print_result "guardrail: stale benign block cleanup is exact and owner-aware" 0
+	else
+		print_result "guardrail: stale benign block cleanup is exact and owner-aware" 1 "dead=$([[ -e "$dead_file" ]] && printf yes || printf no) live=$([[ -f "$live_file" ]] && printf yes || printf no) legacy=$([[ -e "$legacy_mktemp" ]] && printf yes || printf no)"
+	fi
+	return 0
+}
+
+test_benign_block_ledger_crash_recovery() {
+	reset_guardrail_env
+	local lib_file="${SCRIPT_DIR}/pulse-dispatch-lib.sh"
+	local graceful_marker="${TEST_ROOT}/graceful-ledger-path"
+	local killed_marker="${TEST_ROOT}/killed-ledger-path"
+	local kill_runner="${TEST_ROOT}/run-benign-ledger-sigkill"
+	local graceful_status=0
+	local killed_status=0
+	local graceful_ledger=""
+	local killed_ledger=""
+	local killed_was_present=0
+
+	LEDGER_MARKER="$graceful_marker" bash -c '
+		source "$1"
+		trap "_dispatch_cleanup_benign_blocks_cycle" EXIT
+		_dispatch_begin_benign_blocks_cycle >/dev/null
+		printf "%s\n" "$_DISPATCH_BENIGN_BLOCKS_FILE" >"$LEDGER_MARKER"
+		exit 23
+	' _ "$lib_file" >/dev/null 2>&1 || graceful_status=$?
+	[[ -f "$graceful_marker" ]] && read -r graceful_ledger <"$graceful_marker"
+
+	cat >"$kill_runner" <<'EOF_KILL_RUNNER'
+#!/usr/bin/env bash
+bash -c '
+	source "$1"
+	_dispatch_begin_benign_blocks_cycle >/dev/null
+	printf "%s\n" "$_DISPATCH_BENIGN_BLOCKS_FILE" >"$LEDGER_MARKER"
+	kill -KILL "${BASHPID:-$$}"
+' _ "$1"
+child_status=$?
+exit "$child_status"
+EOF_KILL_RUNNER
+	chmod +x "$kill_runner"
+	LEDGER_MARKER="$killed_marker" "$kill_runner" "$lib_file" >/dev/null 2>&1 || killed_status=$?
+	[[ -f "$killed_marker" ]] && read -r killed_ledger <"$killed_marker"
+	[[ -n "$killed_ledger" && -f "$killed_ledger" ]] && killed_was_present=1
+	_dispatch_cleanup_stale_benign_blocks
+
+	if [[ "$graceful_status" -eq 23 && -n "$graceful_ledger" && ! -e "$graceful_ledger" ]] &&
+		[[ "$killed_status" -eq 137 && "$killed_was_present" -eq 1 && -n "$killed_ledger" && ! -e "$killed_ledger" ]]; then
+		print_result "guardrail: EXIT cleanup and next-start SIGKILL recovery remove managed ledgers" 0
+	else
+		print_result "guardrail: EXIT cleanup and next-start SIGKILL recovery remove managed ledgers" 1 "graceful_status=${graceful_status} killed_status=${killed_status} killed_present=${killed_was_present}"
+	fi
+	return 0
+}
+
+test_wrapper_registers_benign_block_cleanup() {
+	local wrapper_file="${SCRIPT_DIR}/pulse-wrapper.sh"
+	local cleanup_stack_count=""
+	cleanup_stack_count=$(grep -c "push_cleanup '_dispatch_cleanup_benign_blocks_cycle'" "$wrapper_file" 2>/dev/null || true)
+	if grep -Fq "trap '_dispatch_cleanup_benign_blocks_cycle;" "$wrapper_file" &&
+		grep -Fq $'\t_dispatch_cleanup_stale_benign_blocks || true' "$wrapper_file" &&
+		[[ "$cleanup_stack_count" == "2" ]]; then
+		print_result "guardrail: pulse wrapper registers graceful and startup benign-ledger cleanup" 0
+		return 0
+	fi
+	print_result "guardrail: pulse wrapper registers graceful and startup benign-ledger cleanup" 1 "cleanup_stack_count=${cleanup_stack_count}"
 	return 0
 }
 
@@ -506,6 +633,9 @@ test_interactive_hold_reason_is_classified
 test_pr_target_reason_is_classified_as_benign_block
 test_deterministic_block_reasons_are_benign
 test_benign_block_ledger_is_cycle_local_and_cleaned
+test_stale_benign_block_ledgers_are_reaped_safely
+test_benign_block_ledger_crash_recovery
+test_wrapper_registers_benign_block_cleanup
 test_external_benign_block_ledger_is_preserved_and_refreshed
 test_dispatch_max_exports_benign_ledger_for_direct_callers
 test_apply_dispatch_max_preserves_benign_ledger_across_refill


### PR DESCRIPTION
## Summary

Move framework-managed benign-block ledgers into a private PID-tagged scratch directory, remove only exact dead-owner or age-qualified legacy files after the exclusive startup lock, and register graceful EXIT cleanup while preserving caller-owned ledger paths.

## Files Changed

.agents/scripts/pulse-dispatch-lib.sh, .agents/scripts/pulse-wrapper.sh, .agents/scripts/tests/test-pulse-current-state-guardrails.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — bash .agents/scripts/linters-local.sh --changed; bash and /bin/bash .agents/scripts/tests/test-pulse-current-state-guardrails.sh; bash and /bin/bash .agents/scripts/tests/test-pulse-wrapper-canary.sh; bash .agents/scripts/tests/test-pulse-wrapper-characterization.sh; bash .agents/scripts/lint-shell-portability.sh on all changed files

Resolves #28689


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.184 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 32m and 480,853 tokens on this with the user in an interactive session.