### PR TITLE
GH#28699: Route PR conversation locks through gh pr

### DIFF
--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -823,7 +823,7 @@ _merge_unlock_resources() {
 	local pr_number="$1"
 	local repo="$2"
 
-	gh issue unlock "$pr_number" --repo "$repo" >/dev/null 2>&1 || true
+	gh pr unlock "$pr_number" --repo "$repo" >/dev/null 2>&1 || true
 
 	# Find and unlock the issue linked via "Resolves/Closes/Fixes #NNN" in the PR body.
 	local _linked_issue=""

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -262,7 +262,7 @@ _lock_linked_prs() {
 	local pr_num
 	while IFS= read -r pr_num; do
 		[[ -n "$pr_num" && "$pr_num" =~ ^[0-9]+$ ]] || continue
-		gh issue lock "$pr_num" --repo "$slug" --reason "$reason" >/dev/null 2>&1 || true
+		gh pr lock "$pr_num" --repo "$slug" --reason "$reason" >/dev/null 2>&1 || true
 		echo "[pulse-wrapper] Locked PR #${pr_num} in ${slug} (linked to issue #${issue_num}) (t1934)" >>"$LOGFILE"
 	done <<<"$pr_numbers"
 
@@ -307,7 +307,7 @@ _unlock_linked_prs() {
 	local pr_num
 	while IFS= read -r pr_num; do
 		[[ -n "$pr_num" && "$pr_num" =~ ^[0-9]+$ ]] || continue
-		gh issue unlock "$pr_num" --repo "$slug" >/dev/null 2>&1 || true
+		gh pr unlock "$pr_num" --repo "$slug" >/dev/null 2>&1 || true
 		echo "[pulse-wrapper] Unlocked PR #${pr_num} in ${slug} (linked to issue #${issue_num}) (t1934)" >>"$LOGFILE"
 	done <<<"$pr_numbers"
 

--- a/.agents/scripts/tests/test-pr-conversation-lock-routing.sh
+++ b/.agents/scripts/tests/test-pr-conversation-lock-routing.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test: PR conversation lock operations must use the PR-specific gh
+# commands while linked issue operations retain the issue-specific commands.
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+CALL_LOG="${TEST_ROOT}/gh-calls.log"
+export HOME="${TEST_ROOT}/home"
+export LOGFILE="${TEST_ROOT}/pulse.log"
+mkdir -p "$HOME"
+: >"$CALL_LOG"
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+fail() {
+	local message="$1"
+	printf 'FAIL %s\n' "$message" >&2
+	return 1
+}
+
+pass() {
+	local message="$1"
+	printf 'PASS %s\n' "$message"
+	return 0
+}
+
+reset_calls() {
+	: >"$CALL_LOG"
+	return 0
+}
+
+assert_call() {
+	local expected="$1"
+	grep -Fxq "$expected" "$CALL_LOG"
+	return $?
+}
+
+assert_no_call() {
+	local rejected="$1"
+	if grep -Fxq "$rejected" "$CALL_LOG"; then
+		return 1
+	fi
+	return 0
+}
+
+# Source production functions before installing command stubs.
+SCRIPT_DIR="$SCRIPTS_DIR"
+# shellcheck source=../shared-constants.sh
+source "${SCRIPTS_DIR}/shared-constants.sh"
+# shellcheck source=../worker-lifecycle-common.sh
+source "${SCRIPTS_DIR}/worker-lifecycle-common.sh"
+# shellcheck source=../pulse-dispatch-core.sh
+source "${SCRIPTS_DIR}/pulse-dispatch-core.sh"
+# shellcheck source=../full-loop-helper-merge.sh
+source "${SCRIPTS_DIR}/full-loop-helper-merge.sh"
+# shellcheck source=../worker-watchdog-kill.sh
+source "${SCRIPTS_DIR}/worker-watchdog-kill.sh"
+
+gh_pr_list() {
+	printf '77\n'
+	return 0
+}
+
+gh() {
+	local group="${1:-}"
+	local action="${2:-}"
+	shift 2 || true
+	printf '%s %s' "$group" "$action" >>"$CALL_LOG"
+	if [[ $# -gt 0 ]]; then
+		printf ' %s' "$*" >>"$CALL_LOG"
+	fi
+	printf '\n' >>"$CALL_LOG"
+
+	if [[ "$group" == "pr" && "$action" == "list" ]]; then
+		printf '77\n'
+		return 0
+	fi
+	if [[ "$group" == "pr" && "$action" == "view" ]]; then
+		printf 'Resolves #42\n'
+		return 0
+	fi
+	return 0
+}
+
+log_msg() {
+	local message="$1"
+	printf '%s\n' "$message" >>"$LOGFILE"
+	return 0
+}
+
+reset_calls
+_lock_linked_prs "42" "owner/repo" "resolved"
+if ! assert_call "pr lock 77 --repo owner/repo --reason resolved" ||
+	! assert_no_call "issue lock 77 --repo owner/repo --reason resolved"; then
+	fail "pulse linked-PR locking did not use gh pr lock" || true
+	exit 1
+fi
+pass "pulse linked-PR locking uses gh pr lock"
+
+reset_calls
+_unlock_linked_prs "42" "owner/repo"
+if ! assert_call "pr unlock 77 --repo owner/repo" ||
+	! assert_no_call "issue unlock 77 --repo owner/repo"; then
+	fail "pulse linked-PR cleanup did not use gh pr unlock" || true
+	exit 1
+fi
+pass "pulse linked-PR cleanup uses gh pr unlock"
+
+reset_calls
+_merge_unlock_resources "88" "owner/repo"
+if ! assert_call "pr unlock 88 --repo owner/repo" ||
+	! assert_call "issue unlock 42 --repo owner/repo" ||
+	! assert_no_call "issue unlock 88 --repo owner/repo"; then
+	fail "full-loop merge cleanup did not preserve PR/issue command routing" || true
+	exit 1
+fi
+pass "full-loop merge cleanup routes PR and issue unlocks separately"
+
+reset_calls
+_watchdog_unlock_issue_and_prs "42" "owner/repo"
+if ! assert_call "issue unlock 42 --repo owner/repo" ||
+	! assert_call "pr unlock 77 --repo owner/repo" ||
+	! assert_no_call "issue unlock 77 --repo owner/repo"; then
+	fail "watchdog cleanup did not preserve PR/issue command routing" || true
+	exit 1
+fi
+pass "watchdog cleanup routes PR and issue unlocks separately"
+
+printf 'Tests run: 4\nTests failed: 0\n'

--- a/.agents/scripts/worker-watchdog-kill.sh
+++ b/.agents/scripts/worker-watchdog-kill.sh
@@ -220,7 +220,7 @@ _watchdog_unlock_issue_and_prs() {
 	local pr_num
 	while IFS= read -r pr_num; do
 		[[ -n "$pr_num" && "$pr_num" =~ ^[0-9]+$ ]] || continue
-		gh issue unlock "$pr_num" --repo "$repo_slug" >/dev/null 2>&1 || true
+		gh pr unlock "$pr_num" --repo "$repo_slug" >/dev/null 2>&1 || true
 		log_msg "Unlocked PR #${pr_num} in ${repo_slug} (linked to issue #${issue_number}) (t1934)"
 	done <<<"$pr_numbers"
 


### PR DESCRIPTION
## Summary

Route linked pull-request lock and unlock operations through gh pr while preserving gh issue operations for actual issues; add regression coverage across pulse, merge cleanup, and watchdog paths.

## Files Changed

.agents/scripts/full-loop-helper-merge.sh, .agents/scripts/pulse-dispatch-core.sh, .agents/scripts/tests/test-pr-conversation-lock-routing.sh, .agents/scripts/worker-watchdog-kill.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Changed-file quality gate; ShellCheck; bash syntax checks; four-case PR routing regression test; release-unlock, review-thread scanner, merge-cleanup, and pulse characterization suites.

Resolves #28699


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.185 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 41m and 452,358 tokens on this with the user in an interactive session.