### PR TITLE
GH#28625: Bind release jobs to protected environment

### DIFF
--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -33,7 +33,8 @@ recovery operation must use an existing tag that passes the same verifier.
 
 Repository default permissions can move from `write` to `read` only after every
 workflow declares its needs. The repository audit found eight callers without an
-explicit `permissions` block; this code checkpoint makes all eight explicit.
+explicit `permissions` block; the merged code-hardening checkpoint made all eight
+explicit.
 
 | Workflow | Required permission | Reason |
 |---|---|---|
@@ -56,21 +57,70 @@ setting can be disabled after the read-default change is verified.
 Apply these operations only through an audited, explicitly approved settings
 session. Do not create a release, package, deployment, or test tag as validation.
 
+### Pre-mutation state and rollback matrix
+
+Read-only inventory on 2026-07-27 confirmed the original exposure remains live.
+Capture a fresh machine-readable snapshot immediately before mutation with
+`release-publication-settings-helper.sh snapshot`; do not rely on this dated
+summary if the live state has changed.
+
+| Control | Pre-mutation state | Approved target | Exact rollback input |
+|---|---|---|---|
+| Actions defaults | `default_workflow_permissions=write`; workflow PR approval enabled | `read`; PR approval disabled | Restore both values from `actions.workflow_permissions` in the snapshot. |
+| Actions policy | Actions enabled; all actions allowed | No change in this checkpoint | Preserve `actions.policy` unchanged. |
+| Workflow permissions | All 55 workflows declare `permissions`; the eight previous default-dependent callers are listed above | Keep every declaration explicit | Revert code normally; do not compensate by restoring broad defaults. |
+| Release tag rules | No repository rulesets | One active tag ruleset named `Protect aidevops release tags`, targeting `refs/tags/v*`, restricting creation, update, and deletion, with one specific release-author user as the only bypass | Delete only the created ruleset by its response ID; never delete or replace unrelated rulesets. |
+| Environments | No environments | Protected `release` environment; independent reviewer(s), self-review prevented, admin bypass disabled, and one selected tag policy `v*` | Delete only the created environment if the snapshot proves it did not exist; otherwise restore the captured detail and policies. |
+| npm Trusted Publisher | Existing GitHub Actions publisher; environment binding must be checked in npmjs.com | `marcusquinn/aidevops`, `publish-packages.yml`, environment `release`, `npm publish` only | Restore the exact pre-change publisher fields captured in the npm UI; npm exposes no supported management API for this configuration. |
+
+The current release author and independent reviewer identities are consequential
+live-policy choices and are intentionally not guessed or committed here. The
+release author must be the single ruleset bypass actor. At least one different
+repository collaborator must review the `release` environment, and GitHub's
+"Prevent self-review" and "Disallow admin bypass" controls must remain enabled.
+
+The GitHub snapshot and verifier are read-only:
+
+```bash
+snapshot_dir="${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}"
+.agents/scripts/release-publication-settings-helper.sh snapshot \
+  --repo marcusquinn/aidevops \
+  --output "${snapshot_dir}/release-publication-settings-before.json"
+
+.agents/scripts/release-publication-settings-helper.sh verify-github \
+  --repo marcusquinn/aidevops \
+  --release-author '<approved-login>' \
+  --reviewer '<independent-reviewer-login>'
+```
+
+`verify-github` deliberately reports two manual checks rather than claiming
+unsupported API evidence: GitHub's documented environment REST API does not
+expose the admin-bypass toggle, and npm documents Trusted Publisher management
+only through package settings on npmjs.com. Capture those UI values before and
+after mutation. npm also states that saving a publisher does not validate it;
+this issue forbids using a real publication as a test, so exact field review is
+the terminal non-publishing evidence.
+
+### Mutation order
+
 1. Re-run actionlint and required CI after the explicit-permission changes merge.
-2. Set default Actions workflow permissions to read and disable workflow-authored
-   pull-request approval. Verify required workflows still receive their declared
-   permissions through completed non-release runs.
-3. Create a protected `v*` tag ruleset that blocks creation, update, and deletion
-   except for the narrowly documented maintainer release authority. Record the
-   prior ruleset response and the exact rollback operation before mutation.
-4. Create a `release` environment with required maintainer review and a deployment
-   ref policy limited to protected release tags.
-5. In a follow-up code checkpoint, bind GitHub release, npm, and Homebrew jobs to
-   the `release` environment. Configure npm Trusted Publisher to require the same
-   workflow and environment identity where the registry supports that binding.
-6. Verify Actions defaults, rulesets, environment protection, and Trusted Publisher
-   identity through read-only APIs. Negative verification must use fixture or
-   non-publishing paths.
+2. Capture the GitHub snapshot and npm publisher fields, record the ruleset and
+   environment deletion rollback, and verify fresh operation approval.
+3. Create the protected `v*` tag ruleset with one specific release-author bypass.
+4. Create the `release` environment, independent reviewer policy, self-review
+   prevention, disabled admin bypass, and selected `v*` tag policy before merging
+   workflows that reference it. Otherwise a workflow run can implicitly create an
+   unprotected environment.
+5. Bind npm Trusted Publisher to `publish-packages.yml`, environment `release`, and
+   the `npm publish` action. Do not enable staged or broader actions in this scope.
+6. Set default Actions workflow permissions to read and disable workflow-authored
+   pull-request approval. Verify required non-release workflows still receive
+   their declared permissions.
+7. Run the read-only GitHub verifier and compare npm UI fields to the recorded
+   values. Negative verification uses fixtures only; do not create a tag, release,
+   package, Homebrew update, or deployment.
+8. Merge the code checkpoint that binds the GitHub release, npm, and Homebrew jobs
+   to the already-protected environment.
 
 Rollback restores only values captured in the pre-mutation matrix. Code changes
 are reverted normally; live settings are never guessed or broadly reset.

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -70,22 +70,29 @@ summary if the live state has changed.
 | Actions policy | Actions enabled; all actions allowed | No change in this checkpoint | Preserve `actions.policy` unchanged. |
 | Workflow permissions | All 55 workflows declare `permissions`; the eight previous default-dependent callers are listed above | Keep every declaration explicit | Revert code normally; do not compensate by restoring broad defaults. |
 | Release tag rules | No repository rulesets | One active tag ruleset named `Protect aidevops release tags`; exact `refs/tags/v*` include with no exclusions; creation, update, and deletion restrictions only; one specific release-author user as the only bypass | Delete only the created ruleset by its response ID; never delete or replace unrelated rulesets. |
-| Environments | No environments | Protected `release` environment; exact independent user reviewer set with no team reviewers, self-review prevented, admin bypass disabled, and one selected tag policy `v*` | Delete only the created environment if the snapshot proves it did not exist; otherwise restore the captured detail and policies. |
+| Environments | No environments | Protected `release` environment; the approved release-author user as the sole reviewer, no team reviewers, self-review allowed, admin bypass disabled, and one selected tag policy `v*` | Delete only the created environment if the snapshot proves it did not exist; otherwise restore the captured detail and policies. |
 | npm Trusted Publisher | Existing GitHub Actions publisher; environment binding must be checked in npmjs.com | `marcusquinn/aidevops`, `publish-packages.yml`, environment `release`, `npm publish` only | Restore the exact pre-change publisher fields captured in the npm UI; npm exposes no supported management API for this configuration. |
 
-The current release author and independent reviewer identities are consequential
-live-policy choices and are intentionally not guessed or committed here. The
-current GitHub REST schema explicitly supports a `User` repository-ruleset bypass
-actor on personal repositories, so the release author can be the single bypass
-principal rather than granting bypass to an entire repository role. At least one
-different repository collaborator must review the `release` environment, and
-GitHub's "Prevent self-review" and "Disallow admin bypass" controls must remain
-enabled.
+The release-author identity is a consequential live-policy choice and is not
+guessed here. The current GitHub REST schema explicitly supports a `User`
+repository-ruleset bypass actor on personal repositories, so the approved release
+author can be the single bypass principal rather than granting bypass to an entire
+repository role.
+
+This maintainer-operated repository uses the same aidevops/model process across
+its maintainer accounts, so selecting another account would not create a
+meaningfully independent review boundary. The approved release-author user is
+therefore also the sole `release` environment reviewer. Keep "Prevent self-review"
+disabled so that reviewer can authorize a deployment they initiated, but keep
+"Disallow admin bypass" enabled so every publication job still pauses for an
+explicit environment approval. This is a deliberate confirmation gate rather
+than separation of duties; a genuinely independent human reviewer can replace it
+later if the repository's operating model changes.
 
 Operationally, the GitHub release, npm publication, and Homebrew update jobs each
 reference `release` and can prompt for approval separately; the Homebrew job waits
-for npm first. GitHub treats the reviewer list as an allow-list rather than a
-quorum, so one listed reviewer can approve each pending deployment.
+for npm first. The designated release-author reviewer must explicitly approve each
+pending deployment.
 
 The GitHub snapshot and verifier are read-only:
 
@@ -98,7 +105,7 @@ snapshot_dir="${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}"
 .agents/scripts/release-publication-settings-helper.sh verify-github \
   --repo marcusquinn/aidevops \
   --release-author '<approved-login>' \
-  --reviewer '<independent-reviewer-login>'
+  --reviewer '<approved-login>'
 ```
 
 `verify-github` deliberately reports two manual checks rather than claiming
@@ -115,10 +122,10 @@ the terminal non-publishing evidence.
 2. Capture the GitHub snapshot and npm publisher fields, record the ruleset and
    environment deletion rollback, and verify fresh operation approval.
 3. Create the protected `v*` tag ruleset with one specific release-author bypass.
-4. Create the `release` environment, independent reviewer policy, self-review
-   prevention, disabled admin bypass, and selected `v*` tag policy before merging
-   workflows that reference it. Otherwise a workflow run can implicitly create an
-   unprotected environment.
+4. Create the `release` environment with the approved release author as its sole
+   reviewer, self-review allowed, admin bypass disabled, and the selected `v*` tag
+   policy before merging workflows that reference it. Otherwise a workflow run
+   can implicitly create an unprotected environment.
 5. Bind npm Trusted Publisher to `publish-packages.yml`, environment `release`, and
    the `npm publish` action. Do not enable staged or broader actions in this scope.
 6. Set default Actions workflow permissions to read and disable workflow-authored

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -127,6 +127,9 @@ the terminal non-publishing evidence.
 7. Run the read-only GitHub verifier and compare npm UI fields to the recorded
    values. Negative verification uses fixtures only; do not create a tag, release,
    package, Homebrew update, or deployment.
+   Any API assertion or UI comparison mismatch is a hard stop: do not merge, apply
+   the captured rollback inputs, and investigate before taking a new snapshot and
+   requesting approval again.
 8. Merge the code checkpoint that binds the GitHub release, npm, and Homebrew jobs
    to the already-protected environment.
 

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -82,6 +82,11 @@ different repository collaborator must review the `release` environment, and
 GitHub's "Prevent self-review" and "Disallow admin bypass" controls must remain
 enabled.
 
+Operationally, the GitHub release, npm publication, and Homebrew update jobs each
+reference `release` and can prompt for approval separately; the Homebrew job waits
+for npm first. GitHub treats the reviewer list as an allow-list rather than a
+quorum, so one listed reviewer can approve each pending deployment.
+
 The GitHub snapshot and verifier are read-only:
 
 ```bash

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -69,15 +69,18 @@ summary if the live state has changed.
 | Actions defaults | `default_workflow_permissions=write`; workflow PR approval enabled | `read`; PR approval disabled | Restore both values from `actions.workflow_permissions` in the snapshot. |
 | Actions policy | Actions enabled; all actions allowed | No change in this checkpoint | Preserve `actions.policy` unchanged. |
 | Workflow permissions | All 55 workflows declare `permissions`; the eight previous default-dependent callers are listed above | Keep every declaration explicit | Revert code normally; do not compensate by restoring broad defaults. |
-| Release tag rules | No repository rulesets | One active tag ruleset named `Protect aidevops release tags`, targeting `refs/tags/v*`, restricting creation, update, and deletion, with one specific release-author user as the only bypass | Delete only the created ruleset by its response ID; never delete or replace unrelated rulesets. |
-| Environments | No environments | Protected `release` environment; independent reviewer(s), self-review prevented, admin bypass disabled, and one selected tag policy `v*` | Delete only the created environment if the snapshot proves it did not exist; otherwise restore the captured detail and policies. |
+| Release tag rules | No repository rulesets | One active tag ruleset named `Protect aidevops release tags`; exact `refs/tags/v*` include with no exclusions; creation, update, and deletion restrictions only; one specific release-author user as the only bypass | Delete only the created ruleset by its response ID; never delete or replace unrelated rulesets. |
+| Environments | No environments | Protected `release` environment; exact independent user reviewer set with no team reviewers, self-review prevented, admin bypass disabled, and one selected tag policy `v*` | Delete only the created environment if the snapshot proves it did not exist; otherwise restore the captured detail and policies. |
 | npm Trusted Publisher | Existing GitHub Actions publisher; environment binding must be checked in npmjs.com | `marcusquinn/aidevops`, `publish-packages.yml`, environment `release`, `npm publish` only | Restore the exact pre-change publisher fields captured in the npm UI; npm exposes no supported management API for this configuration. |
 
 The current release author and independent reviewer identities are consequential
 live-policy choices and are intentionally not guessed or committed here. The
-release author must be the single ruleset bypass actor. At least one different
-repository collaborator must review the `release` environment, and GitHub's
-"Prevent self-review" and "Disallow admin bypass" controls must remain enabled.
+current GitHub REST schema explicitly supports a `User` repository-ruleset bypass
+actor on personal repositories, so the release author can be the single bypass
+principal rather than granting bypass to an entire repository role. At least one
+different repository collaborator must review the `release` environment, and
+GitHub's "Prevent self-review" and "Disallow admin bypass" controls must remain
+enabled.
 
 The GitHub snapshot and verifier are read-only:
 

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -118,7 +118,9 @@ the terminal non-publishing evidence.
 
 ### Mutation order
 
-1. Re-run actionlint and required CI after the explicit-permission changes merge.
+1. Confirm the code-hardening and explicit-permission checkpoint, PR #28642, is
+   merged. Re-run actionlint and required CI for the separate environment-binding
+   checkpoint, PR #28722, but keep PR #28722 unmerged until step 8.
 2. Capture the GitHub snapshot and npm publisher fields, record the ruleset and
    environment deletion rollback, and verify fresh operation approval.
 3. Create the protected `v*` tag ruleset with one specific release-author bypass.
@@ -137,8 +139,9 @@ the terminal non-publishing evidence.
    Any API assertion or UI comparison mismatch is a hard stop: do not merge, apply
    the captured rollback inputs, and investigate before taking a new snapshot and
    requesting approval again.
-8. Merge the code checkpoint that binds the GitHub release, npm, and Homebrew jobs
-   to the already-protected environment.
+8. Merge environment-binding checkpoint PR #28722 only after the live `release`
+   environment is protected and verification passes. That checkpoint binds the
+   GitHub release, npm, and Homebrew jobs to `environment: release`.
 
 Rollback restores only values captured in the pre-mutation matrix. Code changes
 are reverted normally; live settings are never guessed or broadly reset.

--- a/.agents/scripts/release-publication-settings-helper.sh
+++ b/.agents/scripts/release-publication-settings-helper.sh
@@ -15,6 +15,7 @@ readonly RELEASE_REF_PATTERN="refs/tags/v*"
 readonly RELEASE_DEPLOYMENT_PATTERN="v*"
 readonly SNAPSHOT_SCHEMA="aidevops.release-publication-settings/v1"
 readonly REQUIRED_REVIEWERS_RULE="required_reviewers"
+readonly USER_ACTOR_TYPE="User"
 
 _release_settings_error() {
 	local message="$1"
@@ -273,16 +274,16 @@ _release_settings_verify_ruleset() {
 	ruleset_detail=$(_release_settings_release_ruleset "$repo_slug") || return 1
 	if ! jq -e \
 		--arg pattern "$RELEASE_REF_PATTERN" \
+		--arg user_type "$USER_ACTOR_TYPE" \
 		--argjson author_id "$author_id" '
 		.target == "tag"
 		and .enforcement == "active"
-		and ((.conditions.ref_name.include // []) | index($pattern) != null)
-		and (([.rules[]?.type] | index("creation")) != null)
-		and (([.rules[]?.type] | index("update")) != null)
-		and (([.rules[]?.type] | index("deletion")) != null)
+		and ((.conditions.ref_name.include // []) == [$pattern])
+		and ((.conditions.ref_name.exclude // []) == [])
+		and (([.rules[]?.type] | sort) == (["creation", "update", "deletion"] | sort))
 		and ([.bypass_actors[]?] | length == 1)
 		and any(.bypass_actors[]?;
-		  .actor_type == "User" and .actor_id == $author_id and .bypass_mode == "always")
+		  .actor_type == $user_type and .actor_id == $author_id and .bypass_mode == "always")
 	' <<<"$ruleset_detail" >/dev/null; then
 		_release_settings_error "release tag ruleset does not match the fail-closed policy"
 		return 1
@@ -295,37 +296,41 @@ _release_settings_verify_reviewers() {
 	local release_author="$2"
 	shift 2
 	local expected_count="$#"
-	local actual_count=""
 	local reviewer=""
+	local seen_reviewers=" "
 
-	actual_count=$(jq --arg rule "$REQUIRED_REVIEWERS_RULE" '[.protection_rules[]?
-		| select(.type == $rule)
-		| .reviewers[]? | .reviewer.login] | unique | length' \
-		<<<"$environment_detail") || return 1
-	if [[ "$actual_count" -ne "$expected_count" ]]; then
+	if ! jq -e --arg rule "$REQUIRED_REVIEWERS_RULE" \
+		--arg user_type "$USER_ACTOR_TYPE" --argjson count "$expected_count" '
+		[.protection_rules[]? | select(.type == $rule)] as $rules
+		| ($rules | length) == 1
+		and $rules[0].prevent_self_review == true
+		and (($rules[0].reviewers // []) | length) == $count
+		and all($rules[0].reviewers[]?;
+		  .type == $user_type and (.reviewer.login | type == "string"))
+	' <<<"$environment_detail" >/dev/null; then
 		_release_settings_error "release environment reviewer set is not exact"
 		return 1
 	fi
 	for reviewer in "$@"; do
 		_release_settings_validate_login "$reviewer" || return 1
+		if [[ "$seen_reviewers" == *" ${reviewer} "* ]]; then
+			_release_settings_error "duplicate required reviewer: ${reviewer}"
+			return 1
+		fi
+		seen_reviewers+="${reviewer} "
 		if [[ "$reviewer" == "$release_author" ]]; then
 			_release_settings_error "release author cannot be an independent reviewer"
 			return 1
 		fi
 		if ! jq -e --arg login "$reviewer" --arg rule "$REQUIRED_REVIEWERS_RULE" \
+			--arg user_type "$USER_ACTOR_TYPE" \
 			'any(.protection_rules[]?; .type == $rule
-			and any(.reviewers[]?; .reviewer.login == $login))' \
+			and any(.reviewers[]?; .type == $user_type and .reviewer.login == $login))' \
 			<<<"$environment_detail" >/dev/null; then
 			_release_settings_error "missing required reviewer: ${reviewer}"
 			return 1
 		fi
 	done
-	if ! jq -e --arg rule "$REQUIRED_REVIEWERS_RULE" \
-		'any(.protection_rules[]?; .type == $rule and .prevent_self_review == true)' \
-		<<<"$environment_detail" >/dev/null; then
-		_release_settings_error "release environment does not prevent self-review"
-		return 1
-	fi
 	return 0
 }
 

--- a/.agents/scripts/release-publication-settings-helper.sh
+++ b/.agents/scripts/release-publication-settings-helper.sh
@@ -1,0 +1,427 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Read-only inventory and verification for GitHub release publication controls.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+readonly RELEASE_ENVIRONMENT="release"
+readonly RELEASE_RULESET_NAME="Protect aidevops release tags"
+readonly RELEASE_REF_PATTERN="refs/tags/v*"
+readonly RELEASE_DEPLOYMENT_PATTERN="v*"
+readonly SNAPSHOT_SCHEMA="aidevops.release-publication-settings/v1"
+
+_release_settings_error() {
+	local message="$1"
+	printf 'release-settings: %s\n' "$message" >&2
+	return 1
+}
+
+_release_settings_usage() {
+	cat <<'USAGE'
+Usage:
+  release-publication-settings-helper.sh snapshot --repo OWNER/REPO [--output FILE]
+  release-publication-settings-helper.sh verify-github --repo OWNER/REPO \
+    --release-author LOGIN --reviewer LOGIN [--reviewer LOGIN ...]
+
+Commands are read-only. snapshot records rollback inputs before a live settings
+change. verify-github checks API-visible GitHub controls after an approved change.
+npm Trusted Publisher identity and the environment admin-bypass toggle require
+separate npmjs.com/GitHub UI verification because their supported management APIs
+do not expose those settings.
+USAGE
+	return 0
+}
+
+_release_settings_require_dependencies() {
+	local dependency=""
+	for dependency in gh jq; do
+		if ! command -v "$dependency" >/dev/null 2>&1; then
+			_release_settings_error "missing dependency: ${dependency}"
+			return 1
+		fi
+	done
+	return 0
+}
+
+_release_settings_validate_repo() {
+	local repo_slug="$1"
+	if [[ ! "$repo_slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+		_release_settings_error "repository must be OWNER/REPO"
+		return 1
+	fi
+	return 0
+}
+
+_release_settings_validate_login() {
+	local login="$1"
+	if [[ ! "$login" =~ ^[A-Za-z0-9-]+$ ]]; then
+		_release_settings_error "invalid GitHub login: ${login}"
+		return 1
+	fi
+	return 0
+}
+
+_release_settings_api_read() {
+	local endpoint="$1"
+	gh api --method GET "$endpoint"
+	return $?
+}
+
+_release_settings_ruleset_details() {
+	local repo_slug="$1"
+	local ruleset_list="$2"
+	local details='[]'
+	local ruleset_id=""
+	local detail=""
+
+	while IFS= read -r ruleset_id; do
+		[[ -n "$ruleset_id" ]] || continue
+		detail=$(_release_settings_api_read "repos/${repo_slug}/rulesets/${ruleset_id}") || return 1
+		details=$(jq -cn --argjson current "$details" --argjson item "$detail" \
+			'$current + [$item]') || return 1
+	done < <(jq -r '.[].id // empty' <<<"$ruleset_list")
+
+	printf '%s\n' "$details"
+	return 0
+}
+
+_release_settings_environment_snapshot() {
+	local repo_slug="$1"
+	local environment_list="$2"
+	local environment_detail='null'
+	local deployment_policies='{"total_count":0,"branch_policies":[]}'
+
+	if jq -e --arg name "$RELEASE_ENVIRONMENT" \
+		'.environments | any(.name == $name)' <<<"$environment_list" >/dev/null; then
+		environment_detail=$(_release_settings_api_read \
+			"repos/${repo_slug}/environments/${RELEASE_ENVIRONMENT}") || return 1
+		deployment_policies=$(_release_settings_api_read \
+			"repos/${repo_slug}/environments/${RELEASE_ENVIRONMENT}/deployment-branch-policies") || return 1
+	fi
+
+	jq -cn --argjson detail "$environment_detail" --argjson policies "$deployment_policies" \
+		'{detail:$detail, deployment_policies:$policies}'
+	return $?
+}
+
+_release_settings_capture_snapshot() {
+	local repo_slug="$1"
+	local repository_state=""
+	local workflow_permissions=""
+	local actions_policy=""
+	local ruleset_list=""
+	local ruleset_details=""
+	local environment_list=""
+	local environment_state=""
+
+	repository_state=$(_release_settings_api_read "repos/${repo_slug}") || return 1
+	workflow_permissions=$(_release_settings_api_read \
+		"repos/${repo_slug}/actions/permissions/workflow") || return 1
+	actions_policy=$(_release_settings_api_read "repos/${repo_slug}/actions/permissions") || return 1
+	ruleset_list=$(_release_settings_api_read "repos/${repo_slug}/rulesets") || return 1
+	ruleset_details=$(_release_settings_ruleset_details "$repo_slug" "$ruleset_list") || return 1
+	environment_list=$(_release_settings_api_read "repos/${repo_slug}/environments") || return 1
+	environment_state=$(_release_settings_environment_snapshot \
+		"$repo_slug" "$environment_list") || return 1
+
+	jq -n \
+		--arg schema "$SNAPSHOT_SCHEMA" \
+		--arg captured_at "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+		--arg repo "$repo_slug" \
+		--argjson repository "$repository_state" \
+		--argjson workflow_permissions "$workflow_permissions" \
+		--argjson actions_policy "$actions_policy" \
+		--argjson ruleset_list "$ruleset_list" \
+		--argjson ruleset_details "$ruleset_details" \
+		--argjson environment_list "$environment_list" \
+		--argjson release_environment "$environment_state" \
+		'{schema:$schema, captured_at:$captured_at, repository:$repo,
+		  repository_state:{default_branch:$repository.default_branch,
+		    visibility:$repository.visibility, permissions:$repository.permissions},
+		  actions:{workflow_permissions:$workflow_permissions, policy:$actions_policy},
+		  rulesets:{list:$ruleset_list, details:$ruleset_details},
+		  environments:{list:$environment_list, release:$release_environment}}'
+	return $?
+}
+
+_release_settings_write_snapshot() {
+	local snapshot="$1"
+	local output_file="$2"
+	local parent_dir="."
+
+	if [[ "$output_file" == */* ]]; then
+		parent_dir="${output_file%/*}"
+	fi
+	[[ -d "$parent_dir" ]] || {
+		_release_settings_error "snapshot parent directory does not exist: ${parent_dir}"
+		return 1
+	}
+	[[ ! -e "$output_file" ]] || {
+		_release_settings_error "refusing to overwrite snapshot: ${output_file}"
+		return 1
+	}
+	umask 077
+	printf '%s\n' "$snapshot" >"$output_file"
+	printf 'SNAPSHOT_FILE=%s\n' "$output_file"
+	return 0
+}
+
+_release_settings_snapshot_command() {
+	local repo_slug=""
+	local output_file=""
+
+	while [[ $# -gt 0 ]]; do
+		local option="$1"
+		shift
+		case "$option" in
+		--repo)
+			local repo_arg="${1:-}"
+			repo_slug="$repo_arg"
+			shift || true
+			;;
+		--output)
+			local output_arg="${1:-}"
+			output_file="$output_arg"
+			shift || true
+			;;
+		*)
+			_release_settings_error "unknown snapshot option: ${option}"
+			return 1
+			;;
+		esac
+	done
+
+	_release_settings_validate_repo "$repo_slug" || return 1
+	local snapshot=""
+	snapshot=$(_release_settings_capture_snapshot "$repo_slug") || return 1
+	if [[ -n "$output_file" ]]; then
+		_release_settings_write_snapshot "$snapshot" "$output_file"
+		return $?
+	fi
+	jq '.' <<<"$snapshot"
+	return $?
+}
+
+_release_settings_resolve_user_id() {
+	local login="$1"
+	_release_settings_validate_login "$login" || return 1
+	_release_settings_api_read "users/${login}" | jq -er '.id'
+	return $?
+}
+
+_release_settings_verify_release_author() {
+	local repo_slug="$1"
+	local release_author="$2"
+	local permission_state=""
+
+	permission_state=$(_release_settings_api_read \
+		"repos/${repo_slug}/collaborators/${release_author}/permission") || return 1
+	if ! jq -e --arg login "$release_author" '
+		.user.login == $login and (.permission == "admin" or .role_name == "admin")
+	' <<<"$permission_state" >/dev/null; then
+		_release_settings_error "release author must retain repository admin authority"
+		return 1
+	fi
+	return 0
+}
+
+_release_settings_verify_actions() {
+	local repo_slug="$1"
+	local workflow_permissions=""
+
+	workflow_permissions=$(_release_settings_api_read \
+		"repos/${repo_slug}/actions/permissions/workflow") || return 1
+	if ! jq -e '.default_workflow_permissions == "read"
+		and .can_approve_pull_request_reviews == false' \
+		<<<"$workflow_permissions" >/dev/null; then
+		_release_settings_error "Actions defaults are not read-only with PR approval disabled"
+		return 1
+	fi
+	return 0
+}
+
+_release_settings_release_ruleset() {
+	local repo_slug="$1"
+	local ruleset_list=""
+	local ruleset_id=""
+
+	ruleset_list=$(_release_settings_api_read "repos/${repo_slug}/rulesets") || return 1
+	ruleset_id=$(jq -er --arg name "$RELEASE_RULESET_NAME" '
+		map(select(.name == $name and .target == "tag" and .enforcement == "active"))
+		| if length == 1 then .[0].id else error("expected exactly one release ruleset") end
+	' <<<"$ruleset_list") || {
+		_release_settings_error "active release tag ruleset is missing or ambiguous"
+		return 1
+	}
+	_release_settings_api_read "repos/${repo_slug}/rulesets/${ruleset_id}"
+	return $?
+}
+
+_release_settings_verify_ruleset() {
+	local repo_slug="$1"
+	local release_author="$2"
+	local author_id=""
+	local ruleset_detail=""
+
+	author_id=$(_release_settings_resolve_user_id "$release_author") || return 1
+	ruleset_detail=$(_release_settings_release_ruleset "$repo_slug") || return 1
+	if ! jq -e \
+		--arg pattern "$RELEASE_REF_PATTERN" \
+		--argjson author_id "$author_id" '
+		.target == "tag"
+		and .enforcement == "active"
+		and ((.conditions.ref_name.include // []) | index($pattern) != null)
+		and (([.rules[]?.type] | index("creation")) != null)
+		and (([.rules[]?.type] | index("update")) != null)
+		and (([.rules[]?.type] | index("deletion")) != null)
+		and ([.bypass_actors[]?] | length == 1)
+		and any(.bypass_actors[]?;
+		  .actor_type == "User" and .actor_id == $author_id and .bypass_mode == "always")
+	' <<<"$ruleset_detail" >/dev/null; then
+		_release_settings_error "release tag ruleset does not match the fail-closed policy"
+		return 1
+	fi
+	return 0
+}
+
+_release_settings_verify_reviewers() {
+	local environment_detail="$1"
+	local release_author="$2"
+	shift 2
+	local expected_count="$#"
+	local actual_count=""
+	local reviewer=""
+
+	actual_count=$(jq '[.protection_rules[]?
+		| select(.type == "required_reviewers")
+		| .reviewers[]? | .reviewer.login] | unique | length' \
+		<<<"$environment_detail") || return 1
+	if [[ "$actual_count" -ne "$expected_count" ]]; then
+		_release_settings_error "release environment reviewer set is not exact"
+		return 1
+	fi
+	for reviewer in "$@"; do
+		_release_settings_validate_login "$reviewer" || return 1
+		if [[ "$reviewer" == "$release_author" ]]; then
+			_release_settings_error "release author cannot be an independent reviewer"
+			return 1
+		fi
+		if ! jq -e --arg login "$reviewer" 'any(.protection_rules[]?;
+			.type == "required_reviewers"
+			and any(.reviewers[]?; .reviewer.login == $login))' \
+			<<<"$environment_detail" >/dev/null; then
+			_release_settings_error "missing required reviewer: ${reviewer}"
+			return 1
+		fi
+	done
+	if ! jq -e 'any(.protection_rules[]?;
+		.type == "required_reviewers" and .prevent_self_review == true)' \
+		<<<"$environment_detail" >/dev/null; then
+		_release_settings_error "release environment does not prevent self-review"
+		return 1
+	fi
+	return 0
+}
+
+_release_settings_verify_environment() {
+	local repo_slug="$1"
+	local release_author="$2"
+	shift 2
+	local environment_detail=""
+	local deployment_policies=""
+
+	environment_detail=$(_release_settings_api_read \
+		"repos/${repo_slug}/environments/${RELEASE_ENVIRONMENT}") || return 1
+	if ! jq -e '.deployment_branch_policy.protected_branches == false
+		and .deployment_branch_policy.custom_branch_policies == true' \
+		<<<"$environment_detail" >/dev/null; then
+		_release_settings_error "release environment does not use custom ref policies"
+		return 1
+	fi
+	_release_settings_verify_reviewers "$environment_detail" "$release_author" "$@" || return 1
+
+	deployment_policies=$(_release_settings_api_read \
+		"repos/${repo_slug}/environments/${RELEASE_ENVIRONMENT}/deployment-branch-policies") || return 1
+	if ! jq -e --arg pattern "$RELEASE_DEPLOYMENT_PATTERN" '
+		(.branch_policies | length) == 1
+		and any(.branch_policies[]?; .name == $pattern and .type == "tag")
+	' <<<"$deployment_policies" >/dev/null; then
+		_release_settings_error "release environment is not limited to the v* tag policy"
+		return 1
+	fi
+	return 0
+}
+
+_release_settings_verify_command() {
+	local repo_slug=""
+	local release_author=""
+	local -a reviewers=()
+
+	while [[ $# -gt 0 ]]; do
+		local option="$1"
+		shift
+		case "$option" in
+		--repo)
+			local repo_arg="${1:-}"
+			repo_slug="$repo_arg"
+			shift || true
+			;;
+		--release-author)
+			local author_arg="${1:-}"
+			release_author="$author_arg"
+			shift || true
+			;;
+		--reviewer)
+			local reviewer_arg="${1:-}"
+			reviewers+=("$reviewer_arg")
+			shift || true
+			;;
+		*)
+			_release_settings_error "unknown verify option: ${option}"
+			return 1
+			;;
+		esac
+	done
+
+	_release_settings_validate_repo "$repo_slug" || return 1
+	_release_settings_validate_login "$release_author" || return 1
+	if [[ "${#reviewers[@]}" -eq 0 ]]; then
+		_release_settings_error "at least one independent --reviewer is required"
+		return 1
+	fi
+	_release_settings_verify_release_author "$repo_slug" "$release_author" || return 1
+	_release_settings_verify_actions "$repo_slug" || return 1
+	_release_settings_verify_ruleset "$repo_slug" "$release_author" || return 1
+	_release_settings_verify_environment \
+		"$repo_slug" "$release_author" "${reviewers[@]}" || return 1
+
+	printf 'GITHUB_RELEASE_CONTROLS=verified\n'
+	printf 'MANUAL_CHECK_REQUIRED=environment_admin_bypass_disabled\n'
+	printf 'MANUAL_CHECK_REQUIRED=npm_trusted_publisher_workflow_and_environment\n'
+	return 0
+}
+
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	_release_settings_require_dependencies || return 1
+	case "$command" in
+	snapshot) _release_settings_snapshot_command "$@" ;;
+	verify-github) _release_settings_verify_command "$@" ;;
+	help | --help | -h) _release_settings_usage ;;
+	*)
+		_release_settings_error "unknown command: ${command}"
+		_release_settings_usage >&2
+		return 1
+		;;
+	esac
+	return $?
+}
+
+main "$@"

--- a/.agents/scripts/release-publication-settings-helper.sh
+++ b/.agents/scripts/release-publication-settings-helper.sh
@@ -74,6 +74,20 @@ _release_settings_api_read() {
 	return $?
 }
 
+_release_settings_api_array_list() {
+	local endpoint="$1"
+	gh api --method GET --paginate "$endpoint" | jq -cs 'add'
+	return $?
+}
+
+_release_settings_api_environment_list() {
+	local endpoint="$1"
+	gh api --method GET --paginate "$endpoint" | jq -cs '
+		{total_count: ([.[].environments[]?] | length),
+		 environments: [.[].environments[]?]}'
+	return $?
+}
+
 _release_settings_ruleset_details() {
 	local repo_slug="$1"
 	local ruleset_list="$2"
@@ -125,9 +139,10 @@ _release_settings_capture_snapshot() {
 	workflow_permissions=$(_release_settings_api_read \
 		"repos/${repo_slug}/actions/permissions/workflow") || return 1
 	actions_policy=$(_release_settings_api_read "repos/${repo_slug}/actions/permissions") || return 1
-	ruleset_list=$(_release_settings_api_read "repos/${repo_slug}/rulesets") || return 1
+	ruleset_list=$(_release_settings_api_array_list "repos/${repo_slug}/rulesets") || return 1
 	ruleset_details=$(_release_settings_ruleset_details "$repo_slug" "$ruleset_list") || return 1
-	environment_list=$(_release_settings_api_read "repos/${repo_slug}/environments") || return 1
+	environment_list=$(_release_settings_api_environment_list \
+		"repos/${repo_slug}/environments") || return 1
 	environment_state=$(_release_settings_environment_snapshot \
 		"$repo_slug" "$environment_list") || return 1
 
@@ -167,8 +182,14 @@ _release_settings_write_snapshot() {
 		_release_settings_error "refusing to overwrite snapshot: ${output_file}"
 		return 1
 	}
-	umask 077
-	printf '%s\n' "$snapshot" >"$output_file"
+	if ! (
+		umask 077
+		set -o noclobber
+		printf '%s\n' "$snapshot" >"$output_file"
+	); then
+		_release_settings_error "refusing to overwrite snapshot: ${output_file}"
+		return 1
+	fi
 	printf 'SNAPSHOT_FILE=%s\n' "$output_file"
 	return 0
 }
@@ -252,7 +273,7 @@ _release_settings_release_ruleset() {
 	local ruleset_list=""
 	local ruleset_id=""
 
-	ruleset_list=$(_release_settings_api_read "repos/${repo_slug}/rulesets") || return 1
+	ruleset_list=$(_release_settings_api_array_list "repos/${repo_slug}/rulesets") || return 1
 	ruleset_id=$(jq -er --arg name "$RELEASE_RULESET_NAME" '
 		map(select(.name == $name and .target == "tag" and .enforcement == "active"))
 		| if length == 1 then .[0].id else error("expected exactly one release ruleset") end

--- a/.agents/scripts/release-publication-settings-helper.sh
+++ b/.agents/scripts/release-publication-settings-helper.sh
@@ -314,8 +314,7 @@ _release_settings_verify_ruleset() {
 
 _release_settings_verify_reviewers() {
 	local environment_detail="$1"
-	local release_author="$2"
-	shift 2
+	shift
 	local expected_count="$#"
 	local reviewer=""
 	local seen_reviewers=" "
@@ -324,7 +323,7 @@ _release_settings_verify_reviewers() {
 		--arg user_type "$USER_ACTOR_TYPE" --argjson count "$expected_count" '
 		[.protection_rules[]? | select(.type == $rule)] as $rules
 		| ($rules | length) == 1
-		and $rules[0].prevent_self_review == true
+		and $rules[0].prevent_self_review == false
 		and (($rules[0].reviewers // []) | length) == $count
 		and all($rules[0].reviewers[]?;
 		  .type == $user_type and (.reviewer.login | type == "string"))
@@ -339,10 +338,6 @@ _release_settings_verify_reviewers() {
 			return 1
 		fi
 		seen_reviewers+="${reviewer} "
-		if [[ "$reviewer" == "$release_author" ]]; then
-			_release_settings_error "release author cannot be an independent reviewer"
-			return 1
-		fi
 		if ! jq -e --arg login "$reviewer" --arg rule "$REQUIRED_REVIEWERS_RULE" \
 			--arg user_type "$USER_ACTOR_TYPE" \
 			'any(.protection_rules[]?; .type == $rule
@@ -357,8 +352,7 @@ _release_settings_verify_reviewers() {
 
 _release_settings_verify_environment() {
 	local repo_slug="$1"
-	local release_author="$2"
-	shift 2
+	shift
 	local environment_detail=""
 	local deployment_policies=""
 
@@ -370,7 +364,7 @@ _release_settings_verify_environment() {
 		_release_settings_error "release environment does not use custom ref policies"
 		return 1
 	fi
-	_release_settings_verify_reviewers "$environment_detail" "$release_author" "$@" || return 1
+	_release_settings_verify_reviewers "$environment_detail" "$@" || return 1
 
 	deployment_policies=$(_release_settings_api_read \
 		"repos/${repo_slug}/environments/${RELEASE_ENVIRONMENT}/deployment-branch-policies") || return 1
@@ -418,14 +412,13 @@ _release_settings_verify_command() {
 	_release_settings_validate_repo "$repo_slug" || return 1
 	_release_settings_validate_login "$release_author" || return 1
 	if [[ "${#reviewers[@]}" -eq 0 ]]; then
-		_release_settings_error "at least one independent --reviewer is required"
+		_release_settings_error "at least one designated --reviewer is required"
 		return 1
 	fi
 	_release_settings_verify_release_author "$repo_slug" "$release_author" || return 1
 	_release_settings_verify_actions "$repo_slug" || return 1
 	_release_settings_verify_ruleset "$repo_slug" "$release_author" || return 1
-	_release_settings_verify_environment \
-		"$repo_slug" "$release_author" "${reviewers[@]}" || return 1
+	_release_settings_verify_environment "$repo_slug" "${reviewers[@]}" || return 1
 
 	printf 'GITHUB_RELEASE_CONTROLS=verified\n'
 	printf 'MANUAL_CHECK_REQUIRED=environment_admin_bypass_disabled\n'

--- a/.agents/scripts/release-publication-settings-helper.sh
+++ b/.agents/scripts/release-publication-settings-helper.sh
@@ -14,6 +14,7 @@ readonly RELEASE_RULESET_NAME="Protect aidevops release tags"
 readonly RELEASE_REF_PATTERN="refs/tags/v*"
 readonly RELEASE_DEPLOYMENT_PATTERN="v*"
 readonly SNAPSHOT_SCHEMA="aidevops.release-publication-settings/v1"
+readonly REQUIRED_REVIEWERS_RULE="required_reviewers"
 
 _release_settings_error() {
 	local message="$1"
@@ -297,8 +298,8 @@ _release_settings_verify_reviewers() {
 	local actual_count=""
 	local reviewer=""
 
-	actual_count=$(jq '[.protection_rules[]?
-		| select(.type == "required_reviewers")
+	actual_count=$(jq --arg rule "$REQUIRED_REVIEWERS_RULE" '[.protection_rules[]?
+		| select(.type == $rule)
 		| .reviewers[]? | .reviewer.login] | unique | length' \
 		<<<"$environment_detail") || return 1
 	if [[ "$actual_count" -ne "$expected_count" ]]; then
@@ -311,16 +312,16 @@ _release_settings_verify_reviewers() {
 			_release_settings_error "release author cannot be an independent reviewer"
 			return 1
 		fi
-		if ! jq -e --arg login "$reviewer" 'any(.protection_rules[]?;
-			.type == "required_reviewers"
+		if ! jq -e --arg login "$reviewer" --arg rule "$REQUIRED_REVIEWERS_RULE" \
+			'any(.protection_rules[]?; .type == $rule
 			and any(.reviewers[]?; .reviewer.login == $login))' \
 			<<<"$environment_detail" >/dev/null; then
 			_release_settings_error "missing required reviewer: ${reviewer}"
 			return 1
 		fi
 	done
-	if ! jq -e 'any(.protection_rules[]?;
-		.type == "required_reviewers" and .prevent_self_review == true)' \
+	if ! jq -e --arg rule "$REQUIRED_REVIEWERS_RULE" \
+		'any(.protection_rules[]?; .type == $rule and .prevent_self_review == true)' \
 		<<<"$environment_detail" >/dev/null; then
 		_release_settings_error "release environment does not prevent self-review"
 		return 1
@@ -402,7 +403,7 @@ _release_settings_verify_command() {
 
 	printf 'GITHUB_RELEASE_CONTROLS=verified\n'
 	printf 'MANUAL_CHECK_REQUIRED=environment_admin_bypass_disabled\n'
-	printf 'MANUAL_CHECK_REQUIRED=npm_trusted_publisher_workflow_and_environment\n'
+	printf 'MANUAL_CHECK_REQUIRED=publisher_workflow_and_environment\n'
 	return 0
 }
 

--- a/.agents/scripts/tests/test-release-publication-workflows.sh
+++ b/.agents/scripts/tests/test-release-publication-workflows.sh
@@ -161,11 +161,11 @@ repos/test/repo/environments/release)
 	if [[ "$mode" == "bad-environment" ]]; then
 		printf '%s\n' '{"name":"release","protection_rules":[],"deployment_branch_policy":null}'
 	elif [[ "$mode" == "bad-reviewer-team" ]]; then
-		printf '%s\n' '{"name":"release","protection_rules":[{"type":"required_reviewers","prevent_self_review":true,"reviewers":[{"type":"User","reviewer":{"login":"reviewer"}},{"type":"Team","reviewer":{"slug":"release-team"}}]}],"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}'
+		printf '%s\n' '{"name":"release","protection_rules":[{"type":"required_reviewers","prevent_self_review":false,"reviewers":[{"type":"User","reviewer":{"login":"releaser"}},{"type":"Team","reviewer":{"slug":"release-team"}}]}],"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}'
 	elif [[ "$mode" == "bad-self-review" ]]; then
-		printf '%s\n' '{"name":"release","protection_rules":[{"type":"required_reviewers","prevent_self_review":false,"reviewers":[{"type":"User","reviewer":{"login":"reviewer"}}]}],"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}'
+		printf '%s\n' '{"name":"release","protection_rules":[{"type":"required_reviewers","prevent_self_review":true,"reviewers":[{"type":"User","reviewer":{"login":"releaser"}}]}],"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}'
 	else
-		printf '%s\n' '{"name":"release","protection_rules":[{"type":"required_reviewers","prevent_self_review":true,"reviewers":[{"type":"User","reviewer":{"login":"reviewer"}}]}],"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}'
+		printf '%s\n' '{"name":"release","protection_rules":[{"type":"required_reviewers","prevent_self_review":false,"reviewers":[{"type":"User","reviewer":{"login":"releaser"}}]}],"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}'
 	fi
 	;;
 repos/test/repo/environments/release/deployment-branch-policies)
@@ -274,7 +274,7 @@ fi
 printf 'PASS settings snapshot output is atomic and private\n'
 
 verify_output=$(run_settings_helper valid verify-github --repo test/repo \
-	--release-author releaser --reviewer reviewer) || {
+	--release-author releaser --reviewer releaser) || {
 	printf 'FAIL valid GitHub release settings were rejected\n'
 	exit 1
 }
@@ -287,7 +287,7 @@ for expected_marker in \
 		exit 1
 	fi
 done
-printf 'PASS valid GitHub release settings are accepted\n'
+printf 'PASS valid GitHub release settings permit explicit maintainer self-approval\n'
 
 for invalid_mode in bad-author bad-actions bad-ruleset bad-ruleset-exclusion \
 	bad-bypass-actor bad-environment bad-reviewer-team bad-self-review \
@@ -309,7 +309,7 @@ for invalid_mode in bad-author bad-actions bad-ruleset bad-ruleset-exclusion \
 	esac
 	invalid_output=""
 	if invalid_output=$(run_settings_helper "$invalid_mode" verify-github --repo test/repo \
-		--release-author releaser --reviewer reviewer 2>&1); then
+		--release-author releaser --reviewer releaser 2>&1); then
 		printf 'FAIL invalid settings mode was accepted: %s\n' "$invalid_mode"
 		exit 1
 	fi

--- a/.agents/scripts/tests/test-release-publication-workflows.sh
+++ b/.agents/scripts/tests/test-release-publication-workflows.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)" || exit 1
 RELEASE_WORKFLOW="${REPO_ROOT}/.github/workflows/release.yml"
 PACKAGE_WORKFLOW="${REPO_ROOT}/.github/workflows/publish-packages.yml"
+SETTINGS_HELPER="${REPO_ROOT}/.agents/scripts/release-publication-settings-helper.sh"
 
 assert_contains() {
 	local name="$1"
@@ -61,11 +62,136 @@ assert_order "release provenance precedes release creation" \
 assert_order "package provenance precedes npm publication" \
 	"release-provenance-helper.sh verify" "npm publish --provenance" "$PACKAGE_WORKFLOW"
 
+release_environment_count=$(grep -cF 'environment: release' "$RELEASE_WORKFLOW" || true)
+package_environment_count=$(grep -cF 'environment: release' "$PACKAGE_WORKFLOW" || true)
+if [[ "$release_environment_count" -ne 1 || "$package_environment_count" -ne 2 ]]; then
+	printf 'FAIL all release and publication jobs must use the release environment\n'
+	exit 1
+fi
+printf 'PASS all release and publication jobs use the release environment\n'
+
 verification_count=$(grep -cF 'release-provenance-helper.sh verify' "$PACKAGE_WORKFLOW" || true)
 if [[ "$verification_count" -ne 2 ]]; then
 	printf 'FAIL npm and Homebrew jobs must each verify provenance\n'
 	exit 1
 fi
 printf 'PASS npm and Homebrew jobs each verify provenance\n'
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+TEST_BIN="${TEST_ROOT}/bin"
+mkdir -p "$TEST_BIN"
+
+cat >"${TEST_BIN}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -u
+if [[ "${1:-}" != "api" ]]; then
+	exit 1
+fi
+shift
+if [[ "${1:-}" == "--method" ]]; then
+	shift 2
+fi
+endpoint="${1:-}"
+mode="${SETTINGS_TEST_MODE:-valid}"
+case "$endpoint" in
+repos/test/repo)
+	printf '%s\n' '{"default_branch":"main","visibility":"public","permissions":{"admin":true}}'
+	;;
+repos/test/repo/actions/permissions/workflow)
+	if [[ "$mode" == "bad-actions" ]]; then
+		printf '%s\n' '{"default_workflow_permissions":"write","can_approve_pull_request_reviews":true}'
+	else
+		printf '%s\n' '{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}'
+	fi
+	;;
+repos/test/repo/actions/permissions)
+	printf '%s\n' '{"enabled":true,"allowed_actions":"all"}'
+	;;
+repos/test/repo/rulesets)
+	if [[ "$mode" == "snapshot-empty" ]]; then
+		printf '%s\n' '[]'
+	else
+		printf '%s\n' '[{"id":99,"name":"Protect aidevops release tags","target":"tag","enforcement":"active"}]'
+	fi
+	;;
+repos/test/repo/rulesets/99)
+	if [[ "$mode" == "bad-ruleset" ]]; then
+		printf '%s\n' '{"target":"tag","enforcement":"active","conditions":{"ref_name":{"include":["refs/tags/v*"]}},"rules":[{"type":"deletion"}],"bypass_actors":[]}'
+	else
+		printf '%s\n' '{"target":"tag","enforcement":"active","conditions":{"ref_name":{"include":["refs/tags/v*"]}},"rules":[{"type":"creation"},{"type":"update"},{"type":"deletion"}],"bypass_actors":[{"actor_id":7,"actor_type":"User","bypass_mode":"always"}]}'
+	fi
+	;;
+repos/test/repo/environments)
+	if [[ "$mode" == "snapshot-empty" ]]; then
+		printf '%s\n' '{"total_count":0,"environments":[]}'
+	else
+		printf '%s\n' '{"total_count":1,"environments":[{"name":"release"}]}'
+	fi
+	;;
+repos/test/repo/environments/release)
+	if [[ "$mode" == "bad-environment" ]]; then
+		printf '%s\n' '{"name":"release","protection_rules":[],"deployment_branch_policy":null}'
+	else
+		printf '%s\n' '{"name":"release","protection_rules":[{"type":"required_reviewers","prevent_self_review":true,"reviewers":[{"type":"User","reviewer":{"login":"reviewer"}}]}],"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}'
+	fi
+	;;
+repos/test/repo/environments/release/deployment-branch-policies)
+	printf '%s\n' '{"total_count":1,"branch_policies":[{"id":8,"name":"v*","type":"tag"}]}'
+	;;
+users/releaser)
+	printf '%s\n' '{"id":7,"login":"releaser"}'
+	;;
+repos/test/repo/collaborators/releaser/permission)
+	if [[ "$mode" == "bad-author" ]]; then
+		printf '%s\n' '{"permission":"write","role_name":"write","user":{"login":"releaser"}}'
+	else
+		printf '%s\n' '{"permission":"admin","role_name":"admin","user":{"login":"releaser"}}'
+	fi
+	;;
+*)
+	printf 'unexpected endpoint: %s\n' "$endpoint" >&2
+	exit 1
+	;;
+esac
+exit 0
+STUB
+chmod +x "${TEST_BIN}/gh"
+
+run_settings_helper() {
+	local mode="$1"
+	shift
+	SETTINGS_TEST_MODE="$mode" PATH="${TEST_BIN}:${PATH}" bash "$SETTINGS_HELPER" "$@"
+	return $?
+}
+
+snapshot=$(run_settings_helper snapshot-empty snapshot --repo test/repo) || {
+	printf 'FAIL settings snapshot rejected readable empty live state\n'
+	exit 1
+}
+if ! jq -e '.schema == "aidevops.release-publication-settings/v1"
+	and .actions.workflow_permissions.default_workflow_permissions == "read"
+	and (.rulesets.details | length) == 0
+	and .environments.release.detail == null' <<<"$snapshot" >/dev/null; then
+	printf 'FAIL settings snapshot omitted rollback state\n'
+	exit 1
+fi
+printf 'PASS settings snapshot records rollback state\n'
+
+if ! run_settings_helper valid verify-github --repo test/repo \
+	--release-author releaser --reviewer reviewer >/dev/null; then
+	printf 'FAIL valid GitHub release settings were rejected\n'
+	exit 1
+fi
+printf 'PASS valid GitHub release settings are accepted\n'
+
+for invalid_mode in bad-author bad-actions bad-ruleset bad-environment; do
+	if run_settings_helper "$invalid_mode" verify-github --repo test/repo \
+		--release-author releaser --reviewer reviewer >/dev/null 2>&1; then
+		printf 'FAIL invalid settings mode was accepted: %s\n' "$invalid_mode"
+		exit 1
+	fi
+done
+printf 'PASS malformed GitHub release settings fail closed\n'
 
 exit 0

--- a/.agents/scripts/tests/test-release-publication-workflows.sh
+++ b/.agents/scripts/tests/test-release-publication-workflows.sh
@@ -117,9 +117,11 @@ repos/test/repo/rulesets)
 	;;
 repos/test/repo/rulesets/99)
 	if [[ "$mode" == "bad-ruleset" ]]; then
-		printf '%s\n' '{"target":"tag","enforcement":"active","conditions":{"ref_name":{"include":["refs/tags/v*"]}},"rules":[{"type":"deletion"}],"bypass_actors":[]}'
+		printf '%s\n' '{"target":"tag","enforcement":"active","conditions":{"ref_name":{"include":["refs/tags/v*"],"exclude":[]}},"rules":[{"type":"deletion"}],"bypass_actors":[]}'
+	elif [[ "$mode" == "bad-ruleset-exclusion" ]]; then
+		printf '%s\n' '{"target":"tag","enforcement":"active","conditions":{"ref_name":{"include":["refs/tags/v*"],"exclude":["refs/tags/v*"]}},"rules":[{"type":"creation"},{"type":"update"},{"type":"deletion"}],"bypass_actors":[{"actor_id":7,"actor_type":"User","bypass_mode":"always"}]}'
 	else
-		printf '%s\n' '{"target":"tag","enforcement":"active","conditions":{"ref_name":{"include":["refs/tags/v*"]}},"rules":[{"type":"creation"},{"type":"update"},{"type":"deletion"}],"bypass_actors":[{"actor_id":7,"actor_type":"User","bypass_mode":"always"}]}'
+		printf '%s\n' '{"target":"tag","enforcement":"active","conditions":{"ref_name":{"include":["refs/tags/v*"],"exclude":[]}},"rules":[{"type":"creation"},{"type":"update"},{"type":"deletion"}],"bypass_actors":[{"actor_id":7,"actor_type":"User","bypass_mode":"always"}]}'
 	fi
 	;;
 repos/test/repo/environments)
@@ -132,6 +134,8 @@ repos/test/repo/environments)
 repos/test/repo/environments/release)
 	if [[ "$mode" == "bad-environment" ]]; then
 		printf '%s\n' '{"name":"release","protection_rules":[],"deployment_branch_policy":null}'
+	elif [[ "$mode" == "bad-reviewer-team" ]]; then
+		printf '%s\n' '{"name":"release","protection_rules":[{"type":"required_reviewers","prevent_self_review":true,"reviewers":[{"type":"User","reviewer":{"login":"reviewer"}},{"type":"Team","reviewer":{"slug":"release-team"}}]}],"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}'
 	else
 		printf '%s\n' '{"name":"release","protection_rules":[{"type":"required_reviewers","prevent_self_review":true,"reviewers":[{"type":"User","reviewer":{"login":"reviewer"}}]}],"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}'
 	fi
@@ -185,7 +189,8 @@ if ! run_settings_helper valid verify-github --repo test/repo \
 fi
 printf 'PASS valid GitHub release settings are accepted\n'
 
-for invalid_mode in bad-author bad-actions bad-ruleset bad-environment; do
+for invalid_mode in bad-author bad-actions bad-ruleset bad-ruleset-exclusion \
+	bad-environment bad-reviewer-team; do
 	if run_settings_helper "$invalid_mode" verify-github --repo test/repo \
 		--release-author releaser --reviewer reviewer >/dev/null 2>&1; then
 		printf 'FAIL invalid settings mode was accepted: %s\n' "$invalid_mode"

--- a/.agents/scripts/tests/test-release-publication-workflows.sh
+++ b/.agents/scripts/tests/test-release-publication-workflows.sh
@@ -8,6 +8,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)" || exit 1
 RELEASE_WORKFLOW="${REPO_ROOT}/.github/workflows/release.yml"
 PACKAGE_WORKFLOW="${REPO_ROOT}/.github/workflows/publish-packages.yml"
 SETTINGS_HELPER="${REPO_ROOT}/.agents/scripts/release-publication-settings-helper.sh"
+readonly SNAPSHOT_MODE="snapshot-empty"
 
 assert_contains() {
 	local name="$1"
@@ -62,8 +63,10 @@ assert_order "release provenance precedes release creation" \
 assert_order "package provenance precedes npm publication" \
 	"release-provenance-helper.sh verify" "npm publish --provenance" "$PACKAGE_WORKFLOW"
 
-release_environment_count=$(grep -cF 'environment: release' "$RELEASE_WORKFLOW" || true)
-package_environment_count=$(grep -cF 'environment: release' "$PACKAGE_WORKFLOW" || true)
+release_environment_count=$(grep -cE \
+	'^[[:space:]]*environment:[[:space:]]*release[[:space:]]*$' "$RELEASE_WORKFLOW" || true)
+package_environment_count=$(grep -cE \
+	'^[[:space:]]*environment:[[:space:]]*release[[:space:]]*$' "$PACKAGE_WORKFLOW" || true)
 if [[ "$release_environment_count" -ne 1 || "$package_environment_count" -ne 2 ]]; then
 	printf 'FAIL all release and publication jobs must use the release environment\n'
 	exit 1
@@ -89,10 +92,23 @@ if [[ "${1:-}" != "api" ]]; then
 	exit 1
 fi
 shift
-if [[ "${1:-}" == "--method" ]]; then
-	shift 2
-fi
-endpoint="${1:-}"
+endpoint=""
+paginate="false"
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--method)
+		shift 2
+		;;
+	--paginate)
+		paginate="true"
+		shift
+		;;
+	*)
+		endpoint="$1"
+		shift
+		;;
+	esac
+done
 mode="${SETTINGS_TEST_MODE:-valid}"
 case "$endpoint" in
 repos/test/repo)
@@ -109,6 +125,10 @@ repos/test/repo/actions/permissions)
 	printf '%s\n' '{"enabled":true,"allowed_actions":"all"}'
 	;;
 repos/test/repo/rulesets)
+	if [[ "$paginate" != "true" ]]; then
+		printf 'rulesets endpoint was not paginated\n' >&2
+		exit 1
+	fi
 	if [[ "$mode" == "snapshot-empty" ]]; then
 		printf '%s\n' '[]'
 	else
@@ -120,11 +140,17 @@ repos/test/repo/rulesets/99)
 		printf '%s\n' '{"target":"tag","enforcement":"active","conditions":{"ref_name":{"include":["refs/tags/v*"],"exclude":[]}},"rules":[{"type":"deletion"}],"bypass_actors":[]}'
 	elif [[ "$mode" == "bad-ruleset-exclusion" ]]; then
 		printf '%s\n' '{"target":"tag","enforcement":"active","conditions":{"ref_name":{"include":["refs/tags/v*"],"exclude":["refs/tags/v*"]}},"rules":[{"type":"creation"},{"type":"update"},{"type":"deletion"}],"bypass_actors":[{"actor_id":7,"actor_type":"User","bypass_mode":"always"}]}'
+	elif [[ "$mode" == "bad-bypass-actor" ]]; then
+		printf '%s\n' '{"target":"tag","enforcement":"active","conditions":{"ref_name":{"include":["refs/tags/v*"],"exclude":[]}},"rules":[{"type":"creation"},{"type":"update"},{"type":"deletion"}],"bypass_actors":[{"actor_id":7,"actor_type":"User","bypass_mode":"always"},{"actor_id":8,"actor_type":"User","bypass_mode":"always"}]}'
 	else
 		printf '%s\n' '{"target":"tag","enforcement":"active","conditions":{"ref_name":{"include":["refs/tags/v*"],"exclude":[]}},"rules":[{"type":"creation"},{"type":"update"},{"type":"deletion"}],"bypass_actors":[{"actor_id":7,"actor_type":"User","bypass_mode":"always"}]}'
 	fi
 	;;
 repos/test/repo/environments)
+	if [[ "$paginate" != "true" ]]; then
+		printf 'environments endpoint was not paginated\n' >&2
+		exit 1
+	fi
 	if [[ "$mode" == "snapshot-empty" ]]; then
 		printf '%s\n' '{"total_count":0,"environments":[]}'
 	else
@@ -136,12 +162,18 @@ repos/test/repo/environments/release)
 		printf '%s\n' '{"name":"release","protection_rules":[],"deployment_branch_policy":null}'
 	elif [[ "$mode" == "bad-reviewer-team" ]]; then
 		printf '%s\n' '{"name":"release","protection_rules":[{"type":"required_reviewers","prevent_self_review":true,"reviewers":[{"type":"User","reviewer":{"login":"reviewer"}},{"type":"Team","reviewer":{"slug":"release-team"}}]}],"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}'
+	elif [[ "$mode" == "bad-self-review" ]]; then
+		printf '%s\n' '{"name":"release","protection_rules":[{"type":"required_reviewers","prevent_self_review":false,"reviewers":[{"type":"User","reviewer":{"login":"reviewer"}}]}],"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}'
 	else
 		printf '%s\n' '{"name":"release","protection_rules":[{"type":"required_reviewers","prevent_self_review":true,"reviewers":[{"type":"User","reviewer":{"login":"reviewer"}}]}],"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}'
 	fi
 	;;
 repos/test/repo/environments/release/deployment-branch-policies)
-	printf '%s\n' '{"total_count":1,"branch_policies":[{"id":8,"name":"v*","type":"tag"}]}'
+	if [[ "$mode" == "bad-deployment-policy" ]]; then
+		printf '%s\n' '{"total_count":2,"branch_policies":[{"id":8,"name":"v*","type":"tag"},{"id":9,"name":"main","type":"branch"}]}'
+	else
+		printf '%s\n' '{"total_count":1,"branch_policies":[{"id":8,"name":"v*","type":"tag"}]}'
+	fi
 	;;
 users/releaser)
 	printf '%s\n' '{"id":7,"login":"releaser"}'
@@ -169,7 +201,7 @@ run_settings_helper() {
 	return $?
 }
 
-snapshot=$(run_settings_helper snapshot-empty snapshot --repo test/repo) || {
+snapshot=$(run_settings_helper "$SNAPSHOT_MODE" snapshot --repo test/repo) || {
 	printf 'FAIL settings snapshot rejected readable empty live state\n'
 	exit 1
 }
@@ -182,18 +214,108 @@ if ! jq -e '.schema == "aidevops.release-publication-settings/v1"
 fi
 printf 'PASS settings snapshot records rollback state\n'
 
-if ! run_settings_helper valid verify-github --repo test/repo \
-	--release-author releaser --reviewer reviewer >/dev/null; then
-	printf 'FAIL valid GitHub release settings were rejected\n'
+snapshot_file="${TEST_ROOT}/release-settings.json"
+snapshot_output=$(run_settings_helper "$SNAPSHOT_MODE" snapshot --repo test/repo \
+	--output "$snapshot_file") || {
+	printf 'FAIL settings snapshot output path was rejected\n'
+	exit 1
+}
+if [[ "$snapshot_output" != "SNAPSHOT_FILE=${snapshot_file}" ]] ||
+	! jq -e '.schema == "aidevops.release-publication-settings/v1"' "$snapshot_file" >/dev/null; then
+	printf 'FAIL settings snapshot output contract is invalid\n'
 	exit 1
 fi
+snapshot_mode=""
+if snapshot_mode=$(stat -f '%Lp' "$snapshot_file" 2>/dev/null); then
+	:
+elif snapshot_mode=$(stat -c '%a' "$snapshot_file" 2>/dev/null); then
+	:
+else
+	printf 'FAIL settings snapshot mode could not be read\n'
+	exit 1
+fi
+if [[ "$snapshot_mode" != "600" ]]; then
+	printf 'FAIL settings snapshot permissions are %s, expected 600\n' "$snapshot_mode"
+	exit 1
+fi
+overwrite_output=""
+if overwrite_output=$(run_settings_helper "$SNAPSHOT_MODE" snapshot --repo test/repo \
+	--output "$snapshot_file" 2>&1); then
+	printf 'FAIL settings snapshot overwrote an existing file\n'
+	exit 1
+fi
+if ! grep -qF 'release-settings: refusing to overwrite snapshot:' <<<"$overwrite_output"; then
+	printf 'FAIL settings snapshot overwrite failed for an unexpected reason\n'
+	exit 1
+fi
+missing_parent_output=""
+if missing_parent_output=$(run_settings_helper "$SNAPSHOT_MODE" snapshot --repo test/repo \
+	--output "${TEST_ROOT}/missing/release-settings.json" 2>&1); then
+	printf 'FAIL settings snapshot created a missing parent directory\n'
+	exit 1
+fi
+if ! grep -qF 'release-settings: snapshot parent directory does not exist:' \
+	<<<"$missing_parent_output"; then
+	printf 'FAIL settings snapshot parent check failed for an unexpected reason\n'
+	exit 1
+fi
+dangling_snapshot="${TEST_ROOT}/dangling-release-settings.json"
+ln -s "${TEST_ROOT}/missing-target.json" "$dangling_snapshot"
+dangling_output=""
+if dangling_output=$(run_settings_helper "$SNAPSHOT_MODE" snapshot --repo test/repo \
+	--output "$dangling_snapshot" 2>&1); then
+	printf 'FAIL settings snapshot followed a dangling symlink\n'
+	exit 1
+fi
+if ! grep -qF 'release-settings: refusing to overwrite snapshot:' <<<"$dangling_output"; then
+	printf 'FAIL dangling snapshot failed for an unexpected reason\n'
+	exit 1
+fi
+printf 'PASS settings snapshot output is atomic and private\n'
+
+verify_output=$(run_settings_helper valid verify-github --repo test/repo \
+	--release-author releaser --reviewer reviewer) || {
+	printf 'FAIL valid GitHub release settings were rejected\n'
+	exit 1
+}
+for expected_marker in \
+	'GITHUB_RELEASE_CONTROLS=verified' \
+	'MANUAL_CHECK_REQUIRED=environment_admin_bypass_disabled' \
+	'MANUAL_CHECK_REQUIRED=publisher_workflow_and_environment'; do
+	if ! grep -qxF "$expected_marker" <<<"$verify_output"; then
+		printf 'FAIL verify-github omitted marker: %s\n' "$expected_marker"
+		exit 1
+	fi
+done
 printf 'PASS valid GitHub release settings are accepted\n'
 
 for invalid_mode in bad-author bad-actions bad-ruleset bad-ruleset-exclusion \
-	bad-environment bad-reviewer-team; do
-	if run_settings_helper "$invalid_mode" verify-github --repo test/repo \
-		--release-author releaser --reviewer reviewer >/dev/null 2>&1; then
+	bad-bypass-actor bad-environment bad-reviewer-team bad-self-review \
+	bad-deployment-policy; do
+	expected_error=""
+	case "$invalid_mode" in
+	bad-author) expected_error="release author must retain repository admin authority" ;;
+	bad-actions) expected_error="Actions defaults are not read-only with PR approval disabled" ;;
+	bad-ruleset | bad-ruleset-exclusion | bad-bypass-actor)
+		expected_error="release tag ruleset does not match the fail-closed policy"
+		;;
+	bad-environment) expected_error="release environment does not use custom ref policies" ;;
+	bad-reviewer-team | bad-self-review)
+		expected_error="release environment reviewer set is not exact"
+		;;
+	bad-deployment-policy)
+		expected_error="release environment is not limited to the v* tag policy"
+		;;
+	esac
+	invalid_output=""
+	if invalid_output=$(run_settings_helper "$invalid_mode" verify-github --repo test/repo \
+		--release-author releaser --reviewer reviewer 2>&1); then
 		printf 'FAIL invalid settings mode was accepted: %s\n' "$invalid_mode"
+		exit 1
+	fi
+	if ! grep -qF "release-settings: ${expected_error}" <<<"$invalid_output"; then
+		printf 'FAIL mode %s failed for an unexpected reason: %s\n' \
+			"$invalid_mode" "$invalid_output"
 		exit 1
 	fi
 done

--- a/.agents/scripts/tests/test-release-publication-workflows.sh
+++ b/.agents/scripts/tests/test-release-publication-workflows.sh
@@ -161,7 +161,7 @@ repos/test/repo/environments/release)
 	if [[ "$mode" == "bad-environment" ]]; then
 		printf '%s\n' '{"name":"release","protection_rules":[],"deployment_branch_policy":null}'
 	elif [[ "$mode" == "bad-reviewer-team" ]]; then
-		printf '%s\n' '{"name":"release","protection_rules":[{"type":"required_reviewers","prevent_self_review":false,"reviewers":[{"type":"User","reviewer":{"login":"releaser"}},{"type":"Team","reviewer":{"slug":"release-team"}}]}],"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}'
+		printf '%s\n' '{"name":"release","protection_rules":[{"type":"required_reviewers","prevent_self_review":false,"reviewers":[{"type":"Team","reviewer":{"slug":"release-team"}}]}],"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}'
 	elif [[ "$mode" == "bad-self-review" ]]; then
 		printf '%s\n' '{"name":"release","protection_rules":[{"type":"required_reviewers","prevent_self_review":true,"reviewers":[{"type":"User","reviewer":{"login":"releaser"}}]}],"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}'
 	else

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -12,6 +12,7 @@ jobs:
   publish-npm:
     name: Publish to npm
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       id-token: write
@@ -81,6 +82,7 @@ jobs:
   update-homebrew-tap:
     name: Update Homebrew Tap
     runs-on: ubuntu-latest
+    environment: release
     needs: publish-npm
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary

Bind GitHub release, npm, and Homebrew jobs to the protected release environment; add a read-only live-settings snapshot/verifier; document exact rollout, approval, and rollback controls.

## Files Changed

.agents/reference/release-publication-controls.md, .agents/scripts/release-publication-settings-helper.sh, .agents/scripts/tests/test-release-publication-workflows.sh, .github/workflows/publish-packages.yml, .github/workflows/release.yml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Bash syntax, ShellCheck, actionlint, focused release-publication fixtures, linters-local.sh, and closeout review evidence 064f619d67df36ed87b34ccafb958fb74d999ea9d0a9054da0650434a07711f8.

Resolves #28625


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.185 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 33m and 520,034 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only helper to capture and fail-closed verify GitHub release publication controls, including rollback readiness.
  * Updated the release and package publishing workflows to run in the protected `release` environment.
* **Documentation**
  * Refined the release controls guide with clearer verification wording, a pre-change state/rollback matrix, and an updated rollout sequence.
* **Tests**
  * Strengthened workflow validation to confirm exact environment usage and provenance helper usage, plus stricter snapshot/rollback and fail-closed verification checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->