### PR TITLE
GH#28717: fix: reconcile verified NMR approval races

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -83,6 +83,7 @@ readonly PERMISSION_JSON_ARRAY_TYPE="array"
 readonly PERMISSION_JSON_STRING_TYPE="string"
 readonly _APPROVAL_NMR_LABEL="needs-maintainer-review"
 readonly _APPROVAL_AUTO_DISPATCH_LABEL="auto-dispatch"
+readonly _APPROVAL_MISSING_FIELD="__missing__"
 readonly _PERMISSION_BLOCKER_STATUS="blocked"
 readonly _PERMISSION_BLOCKER_TRUE="true"
 readonly _PERMISSION_APPROVAL_REJECTED_EVENT="permission_approval_rejected"
@@ -770,6 +771,19 @@ _post_issue_approval_updates() {
 		return $?
 	fi
 	_approval_apply_pr_lifecycle_updates "$target_number" "$slug"
+	return $?
+}
+
+_approval_restore_nmr_hold() {
+	local target_type="$1"
+	local target_number="$2"
+	local slug="$3"
+
+	if [[ "$target_type" == "issue" ]]; then
+		gh_issue_edit_safe "$target_number" --repo "$slug" --add-label "$_APPROVAL_NMR_LABEL"
+		return $?
+	fi
+	gh_pr_edit_safe "$target_number" --repo "$slug" --add-label "$_APPROVAL_NMR_LABEL"
 	return $?
 }
 
@@ -1615,6 +1629,50 @@ cmd_pr_approved() {
 
 # ── Verify Approval ──────────────────────────────────────────────────────────
 
+#######################################
+# Verify that a signed approval comment belongs to the currently authenticated
+# actor and that GitHub reports maintainer-equivalent authority for that actor.
+# OWNER/MEMBER associations are authoritative repository-scoped API fields;
+# CONTRIBUTOR/COLLABORATOR associations require a current permission lookup.
+# Bot, mismatched, malformed, and permission-uncertain identities fail closed.
+#
+# Args: repo slug, required actor, commenter, user type, author association
+# Returns: 0 trusted, 1 untrusted, 2 authority lookup uncertainty
+#######################################
+_approval_comment_has_required_authority() {
+	local slug="$1"
+	local required_actor="$2"
+	local commenter="$3"
+	local user_type="$4"
+	local association="$5"
+	local normalized_required=""
+	local normalized_commenter=""
+	local permission=""
+
+	[[ "$slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || return 1
+	[[ "$required_actor" =~ ^[A-Za-z0-9_.-]+$ ]] || return 1
+	[[ "$commenter" =~ ^[A-Za-z0-9_.-]+$ ]] || return 1
+	[[ "$user_type" == "User" ]] || return 1
+	normalized_required=$(printf '%s' "$required_actor" | tr '[:upper:]' '[:lower:]')
+	normalized_commenter=$(printf '%s' "$commenter" | tr '[:upper:]' '[:lower:]')
+	[[ "$normalized_required" == "$normalized_commenter" ]] || return 1
+
+	case "$association" in
+	OWNER | MEMBER)
+		return 0
+		;;
+	CONTRIBUTOR | COLLABORATOR)
+		permission=$(gh api "repos/${slug}/collaborators/${commenter}/permission" \
+			--jq '.permission // "none"' 2>/dev/null) || return 2
+		case "$permission" in
+		admin | maintain | write) return 0 ;;
+		esac
+		return 1
+		;;
+	esac
+	return 1
+}
+
 _approval_classify_marked_comments() {
 	local target_type="$1"
 	local target_number="$2"
@@ -1623,7 +1681,8 @@ _approval_classify_marked_comments() {
 	local pub_key="$5"
 	local expected_head_sha="${6:-}"
 	local comment_count="$7"
-	local saw_api_error=0 saw_stale=0 saw_legacy=0 saw_malformed=0
+	local required_actor="${8:-}"
+	local saw_api_error=0 saw_stale=0 saw_legacy=0 saw_untrusted=0 saw_malformed=0
 	local comment_rows=""
 	local base64_decode_flag="-d"
 	[[ "$(uname -s)" == "Darwin" ]] && base64_decode_flag="-D"
@@ -1632,17 +1691,23 @@ _approval_classify_marked_comments() {
 		printf 'MALFORMED_APPROVAL\n'
 		return 5
 	fi
-	comment_rows=$(jq -r '
+	comment_rows=$(jq -r --arg missing "$_APPROVAL_MISSING_FIELD" '
 		reverse[]
-		| [((.id // "") | tostring), ((.body // "") | @base64)]
+		| [
+			((.id // "") | tostring),
+			((.body // "") | @base64),
+			(.user.login // $missing),
+			(.user.type // $missing),
+			(.author_association // $missing)
+		]
 		| @tsv
 	' <<<"$comments_json") || {
 		printf 'MALFORMED_APPROVAL\n'
 		return 5
 	}
 
-	while IFS=$'\t' read -r comment_id encoded_body; do
-		local body="" classification
+	while IFS=$'\t' read -r comment_id encoded_body commenter user_type association; do
+		local body="" classification="" authority_rc=0
 		body=$(printf '%s' "$encoded_body" | base64 "$base64_decode_flag") || {
 			saw_malformed=1
 			continue
@@ -1650,6 +1715,18 @@ _approval_classify_marked_comments() {
 		if [[ ! "$comment_id" =~ ^[0-9]+$ ]]; then
 			saw_malformed=1
 			continue
+		fi
+		if [[ -n "$required_actor" ]]; then
+			_approval_comment_has_required_authority "$slug" "$required_actor" \
+				"$commenter" "$user_type" "$association" || authority_rc=$?
+			if [[ "$authority_rc" -eq 2 ]]; then
+				saw_api_error=1
+				continue
+			fi
+			if [[ "$authority_rc" -ne 0 ]]; then
+				saw_untrusted=1
+				continue
+			fi
 		fi
 		classification=$(_approval_classify_signed_comment "$target_type" "$target_number" "$slug" "$comment_id" "$body" "$pub_key" "$expected_head_sha")
 		case "$classification" in
@@ -1664,6 +1741,7 @@ _approval_classify_marked_comments() {
 	[[ "$saw_api_error" -eq 0 ]] || { printf 'API_ERROR\n'; return 6; }
 	[[ "$saw_stale" -eq 0 ]] || { printf 'STALE_APPROVAL\n'; return 4; }
 	[[ "$saw_legacy" -eq 0 ]] || { printf 'LEGACY_APPROVAL\n'; return 3; }
+	[[ "$saw_untrusted" -eq 0 ]] || { printf 'UNTRUSTED_APPROVAL\n'; return 7; }
 	[[ "$saw_malformed" -eq 1 ]] || saw_malformed=1
 	printf 'MALFORMED_APPROVAL\n'
 	return 5
@@ -1758,6 +1836,7 @@ cmd_verify() {
 	fi
 	local target_number="${1:-}"
 	local slug=""
+	local require_authority=0
 	shift 2>/dev/null || true
 	if [[ $# -gt 0 && "$1" != --* ]]; then
 		slug="$1"
@@ -1770,6 +1849,10 @@ cmd_verify() {
 			expected_head_sha="${2:-}"
 			shift 2
 			;;
+		--require-authority)
+			require_authority=1
+			shift
+			;;
 		*)
 			printf 'MALFORMED_APPROVAL\n'
 			return 5
@@ -1781,8 +1864,20 @@ cmd_verify() {
 		return 5
 	fi
 
-	_require_number_arg "$target_number" "$target_type" "Usage: aidevops approve verify [issue|pr] <number> [owner/repo] [--expect-head SHA]" || return 5
+	_require_number_arg "$target_number" "$target_type" "Usage: aidevops approve verify [issue|pr] <number> [owner/repo] [--expect-head SHA] [--require-authority]" || return 5
 	slug=$(_resolve_slug_or_fail "$slug" "Could not detect repo slug") || return 1
+
+	local required_actor=""
+	if [[ "$require_authority" -eq 1 ]]; then
+		required_actor=$(gh api user --jq '.login // empty' 2>/dev/null) || {
+			printf 'API_ERROR\n'
+			return 6
+		}
+		if ! [[ "$required_actor" =~ ^[A-Za-z0-9_.-]+$ ]]; then
+			printf 'API_ERROR\n'
+			return 6
+		fi
+	fi
 
 	local comment_pages="" comments_json="" endpoint=""
 	endpoint=$(_permission_comments_endpoint "$slug" "$target_number")
@@ -1819,8 +1914,90 @@ cmd_verify() {
 		return 2
 	fi
 
-	_approval_classify_marked_comments "$target_type" "$target_number" "$slug" "$comments_json" "$pub_key" "$expected_head_sha" "$comment_count"
+	_approval_classify_marked_comments "$target_type" "$target_number" "$slug" "$comments_json" "$pub_key" "$expected_head_sha" "$comment_count" "$required_actor"
 	return $?
+}
+
+# Reconcile an approval that GitHub Actions conservatively re-blocked after the
+# original local lifecycle transition. This command never signs or posts a new
+# approval. It observes a live NMR hold, independently re-verifies the existing
+# V2 signature against current target state and the authenticated actor's
+# maintainer authority, then reuses the normal issue/PR lifecycle writers.
+cmd_reconcile() {
+	local target_type="${1:-}"
+	local target_number="${2:-}"
+	local slug="${3:-}"
+	local usage="Usage: aidevops approve reconcile issue|pr <number> [owner/repo]"
+	local issue_json=""
+	local actual_type=""
+	local target_state=""
+	local nmr_rc=0
+	local verification=""
+	local verify_rc=0
+
+	if [[ "$target_type" != "issue" && "$target_type" != "pr" ]]; then
+		printf 'MALFORMED_APPROVAL\n'
+		return 5
+	fi
+	_require_number_arg "$target_number" "$target_type" "$usage" >/dev/null 2>&1 || {
+		printf 'MALFORMED_APPROVAL\n'
+		return 5
+	}
+	slug=$(_resolve_slug_or_fail "$slug" "$usage") || {
+		printf 'API_ERROR\n'
+		return 6
+	}
+
+	issue_json=$(_approval_fetch_issue_json "$target_number" "$slug") || {
+		printf 'API_ERROR\n'
+		return 6
+	}
+	actual_type=$(printf '%s' "$issue_json" | jq -r 'if type != "object" then "invalid" elif .pull_request? != null then "pr" else "issue" end' 2>/dev/null) || actual_type="invalid"
+	if [[ "$actual_type" != "$target_type" ]]; then
+		printf 'TARGET_MISMATCH\n'
+		return 5
+	fi
+	target_state=$(printf '%s' "$issue_json" | jq -r '.state // "" | ascii_downcase' 2>/dev/null) || target_state=""
+	if [[ "$target_state" == "closed" ]]; then
+		printf 'TARGET_CLOSED\n'
+		return 0
+	fi
+	if [[ "$target_state" != "open" ]]; then
+		printf 'API_ERROR\n'
+		return 6
+	fi
+	printf '%s' "$issue_json" | jq -e --arg label "$_APPROVAL_NMR_LABEL" \
+		'(.labels // []) | any(.name == $label)' >/dev/null 2>&1 || nmr_rc=$?
+	if [[ "$nmr_rc" -eq 1 ]]; then
+		printf 'NO_NMR\n'
+		return 3
+	fi
+	if [[ "$nmr_rc" -ne 0 ]]; then
+		printf 'API_ERROR\n'
+		return 6
+	fi
+
+	# #aidevops:trust-boundary GH#28717 — current-state V2 verification and
+	# authenticated actor authority are mandatory immediately before mutation.
+	verification=$(cmd_verify "$target_type" "$target_number" "$slug" --require-authority 2>/dev/null) || verify_rc=$?
+	if [[ "$verification" != "VERIFIED" || "$verify_rc" -ne 0 ]]; then
+		printf '%s\n' "${verification:-API_ERROR}"
+		if [[ "$verify_rc" -ne 0 ]]; then
+			return "$verify_rc"
+		fi
+		return 6
+	fi
+
+	if ! _post_issue_approval_updates "$target_type" "$target_number" "$slug" >/dev/null 2>&1; then
+		# A lifecycle writer may fail after partially clearing NMR (for example,
+		# issue label mutation succeeds but its advisory lock fails). Reassert the
+		# conservative hold before reporting uncertainty to the bounded caller.
+		_approval_restore_nmr_hold "$target_type" "$target_number" "$slug" >/dev/null 2>&1 || true
+		printf 'UPDATE_FAILED\n'
+		return 8
+	fi
+	printf 'RECONCILED\n'
+	return 0
 }
 
 # ── Status ───────────────────────────────────────────────────────────────────
@@ -1872,8 +2049,9 @@ cmd_help() {
 	echo "  permissions issue|pr <number> [slug] --request perm-<id>"
 	echo ""
 	echo "Commands (no sudo needed):"
-	echo "  verify [issue|pr] <number> [slug] [--expect-head SHA]"
+	echo "  verify [issue|pr] <number> [slug] [--expect-head SHA] [--require-authority]"
 	echo "  verify-permissions issue|pr <number> [slug]"
+	echo "  reconcile issue|pr <number> [slug]"
 	echo "  status                     Show approval key setup status"
 	echo "  help                       Show this help"
 	echo ""
@@ -1902,6 +2080,7 @@ main() {
 	permissions) cmd_permissions "$@" ;;
 	verify-permissions) cmd_verify_permissions "$@" ;;
 	verify) cmd_verify "$@" ;;
+	reconcile) cmd_reconcile "$@" ;;
 	status) cmd_status "$@" ;;
 	help | --help | -h) cmd_help ;;
 	*)
@@ -1910,6 +2089,7 @@ main() {
 		return 1
 		;;
 	esac
+	return $?
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/.agents/scripts/pulse-approval-reconcile.sh
+++ b/.agents/scripts/pulse-approval-reconcile.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# pulse-approval-reconcile.sh — bounded exact-target NMR approval recovery.
+
+[[ -n "${_PULSE_APPROVAL_RECONCILE_LOADED:-}" ]] && return 0
+_PULSE_APPROVAL_RECONCILE_LOADED=1
+
+_pulse_approval_reconcile_log() {
+	local message="$1"
+	local log_file="${LOGFILE:-${HOME:-.}/.aidevops/logs/pulse.log}"
+	local timestamp=""
+
+	timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date)
+	printf '[%s] approval-reconcile: %s\n' "$timestamp" "$message" >>"$log_file" 2>/dev/null || true
+	return 0
+}
+
+_pulse_reconcile_bounded_integer() {
+	local value="$1"
+	local default_value="$2"
+	local minimum="$3"
+	local maximum="$4"
+
+	case "$value" in
+	'' | *[!0-9]*) value="$default_value" ;;
+	*) value=$((10#$value)) ;;
+	esac
+	if [[ "$value" -lt "$minimum" || "$value" -gt "$maximum" ]]; then
+		value="$default_value"
+	fi
+	printf '%s' "$value"
+	return 0
+}
+
+#######################################
+# Reconcile one issue or PR after GitHub Actions may have conservatively
+# restored needs-maintainer-review. The approval helper owns current-state V2
+# signature verification, authenticated actor authority, and the appropriate
+# issue/PR lifecycle writer. This wrapper only owns a short bounded race window.
+#
+# Args: target type (issue|pr), target number, repo slug
+# Returns: 0 reconciled/closed/no restored hold; 1 invalid or still blocked
+#######################################
+_pulse_reconcile_verified_approval_target() {
+	local target_type="${1:-}"
+	local target_number="${2:-}"
+	local slug="${3:-}"
+	local approval_helper="${AGENTS_DIR:-${HOME:-}/.aidevops/agents}/scripts/approval-helper.sh"
+	local attempts="${AIDEVOPS_NMR_RECONCILE_ATTEMPTS:-6}"
+	local delay_seconds="${AIDEVOPS_NMR_RECONCILE_DELAY_SECONDS:-1}"
+	local attempt=1
+	local result=""
+	local reconcile_rc=0
+	local reconciled=0
+	local saw_mutation_uncertainty=0
+
+	if [[ "$target_type" != "issue" && "$target_type" != "pr" ]]; then
+		_pulse_approval_reconcile_log "rejected invalid target type '${target_type}'"
+		return 1
+	fi
+	if ! [[ "$target_number" =~ ^[0-9]+$ ]]; then
+		_pulse_approval_reconcile_log "rejected invalid ${target_type} number '${target_number}'"
+		return 1
+	fi
+	if ! [[ "$slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+		_pulse_approval_reconcile_log "rejected invalid repository slug '${slug}'"
+		return 1
+	fi
+	if [[ ! -f "$approval_helper" ]]; then
+		_pulse_approval_reconcile_log "approval helper unavailable for ${slug} ${target_type} #${target_number}"
+		return 1
+	fi
+
+	attempts=$(_pulse_reconcile_bounded_integer "$attempts" 6 1 8)
+	delay_seconds=$(_pulse_reconcile_bounded_integer "$delay_seconds" 1 0 8)
+
+	while [[ "$attempt" -le "$attempts" ]]; do
+		reconcile_rc=0
+		result=$(bash "$approval_helper" reconcile "$target_type" "$target_number" "$slug" 2>/dev/null) || reconcile_rc=$?
+		case "$result" in
+		RECONCILED)
+			if [[ "$reconcile_rc" -eq 0 ]]; then
+				_pulse_approval_reconcile_log "restored ${slug} ${target_type} #${target_number} on attempt ${attempt}/${attempts}"
+				reconciled=1
+			else
+				saw_mutation_uncertainty=1
+			fi
+			;;
+		TARGET_CLOSED)
+			if [[ "$reconcile_rc" -eq 0 ]]; then
+				_pulse_approval_reconcile_log "target already closed: ${slug} ${target_type} #${target_number}"
+				return 0
+			else
+				saw_mutation_uncertainty=1
+			fi
+			;;
+		NO_NMR)
+			if [[ "$reconcile_rc" -ne 3 ]]; then
+				_pulse_approval_reconcile_log "unexpected NO_NMR status for ${slug} ${target_type} #${target_number} on attempt ${attempt}: rc=${reconcile_rc}"
+				saw_mutation_uncertainty=1
+			elif [[ "$reconciled" -eq 1 ]]; then
+				_pulse_approval_reconcile_log "restored state remained stable for ${slug} ${target_type} #${target_number}"
+				return 0
+			elif [[ "$attempt" -eq "$attempts" && "$saw_mutation_uncertainty" -eq 0 ]]; then
+				_pulse_approval_reconcile_log "no restored NMR observed for ${slug} ${target_type} #${target_number} after ${attempts} bounded attempt(s)"
+				return 0
+			fi
+			;;
+		API_ERROR)
+			# Transient read uncertainty may recover inside the bounded window.
+			;;
+		UPDATE_FAILED)
+			# Do not treat a later absent hold as a clean no-op: the lifecycle writer
+			# may have partially cleared NMR before reporting its failed mutation.
+			saw_mutation_uncertainty=1
+			;;
+		NO_APPROVAL | NO_KEY | STALE_APPROVAL | LEGACY_APPROVAL | MALFORMED_APPROVAL | UNTRUSTED_APPROVAL | TARGET_MISMATCH)
+			_pulse_approval_reconcile_log "blocked ${slug} ${target_type} #${target_number}: ${result}"
+			return 1
+			;;
+		*)
+			_pulse_approval_reconcile_log "unexpected result for ${slug} ${target_type} #${target_number} on attempt ${attempt}: ${result:-empty} (rc=${reconcile_rc})"
+			;;
+		esac
+
+		if [[ "$attempt" -ge "$attempts" ]]; then
+			break
+		fi
+		if [[ "$delay_seconds" -gt 0 ]]; then
+			sleep "$delay_seconds"
+			if [[ "$delay_seconds" -lt 8 ]]; then
+				delay_seconds=$((delay_seconds * 2))
+				[[ "$delay_seconds" -le 8 ]] || delay_seconds=8
+			fi
+		fi
+		attempt=$((attempt + 1))
+	done
+
+	_pulse_approval_reconcile_log "bounded recovery exhausted for ${slug} ${target_type} #${target_number}: ${result:-empty} (rc=${reconcile_rc})"
+	return 1
+}

--- a/.agents/scripts/pulse-wrapper-bootstrap.sh
+++ b/.agents/scripts/pulse-wrapper-bootstrap.sh
@@ -255,15 +255,16 @@ _pulse_run_merge_only() {
 #
 # Drains ~/.aidevops/cache/pulse-merge-trigger.txt — the marker file written
 # by approval-helper.sh::_kick_pulse_after_approval after each successful
-# crypto-approval — and processes each listed PR via pulse-merge.sh's
+# crypto-approval. Each valid record first runs bounded exact-target NMR
+# reconciliation, then processes any listed/linked PR via pulse-merge.sh's
 # existing process_pr() entry point.
 #
 # File format (one record per line, tab-separated):
 #   <slug>\t<num>\t<type>\t<iso8601_ts>
 #
 # - slug: owner/repo (validated via regex)
-# - num:  PR or issue number (digits only). Issue records resolve the linked
-#         PR via _resolve_linked_pr_for_issue (best-effort; skipped if none).
+# - num:  PR or issue number (digits only). Every issue is reconciled directly;
+#         issue records then resolve a linked PR for optional merge processing.
 # - type: "issue" or "pr" (other values rejected)
 # - ts:   UTC ISO-8601 timestamp (informational only, not parsed)
 #
@@ -275,13 +276,53 @@ _pulse_run_merge_only() {
 #
 # Robustness:
 #   - Malformed lines are logged and skipped — never abort the drain.
-#   - process_pr failures are logged and ignored — non-fatal, the next
-#     pulse cycle's full merge pass picks up anything that slipped through.
+#   - Exact duplicate targets are ignored after their first valid record.
+#   - Reconciliation/process_pr failures are logged and ignored — NMR remains
+#     fail-closed and the scheduled Pulse fallback can retry later.
 #
 # Bypass: AIDEVOPS_SKIP_TRIGGER_DRAIN=1 (used by tests for negative cases).
 #
 # Exit code: always 0 (drain is best-effort).
 # ---------------------------------------------------------------------------
+_process_approval_trigger_record() {
+	local slug="$1"
+	local target_number="$2"
+	local target_type="$3"
+	local pr_number=""
+	local record_rc=0
+
+	# GH#28717: observe the post-approval Actions race before merge routing.
+	# The target helper independently re-verifies current V2 authority/state.
+	if declare -F _pulse_reconcile_verified_approval_target >/dev/null 2>&1; then
+		_pulse_reconcile_verified_approval_target "$target_type" "$target_number" "$slug" || record_rc=1
+	else
+		printf '[%s] _drain_merge_trigger_file_if_present: target reconciliation unavailable for %s %s #%s — preserving fail-closed scheduled fallback\n' \
+			"$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date)" "$slug" "$target_type" "$target_number" \
+			>>"${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}" 2>/dev/null || true
+		record_rc=1
+	fi
+
+	# Issue recovery never requires a linked PR. Resolve one only for optional
+	# merge routing after the exact issue lifecycle has been reconciled.
+	if [[ "$target_type" == "issue" ]]; then
+		pr_number=$(_resolve_linked_pr_for_issue "$slug" "$target_number" 2>/dev/null || printf '')
+		if [[ -z "$pr_number" ]]; then
+			printf '[%s] _drain_merge_trigger_file_if_present: %s issue #%s has no linked open PR yet — merge routing skipped\n' \
+				"$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date)" "$slug" "$target_number" \
+				>>"${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}" 2>/dev/null || true
+			return "$record_rc"
+		fi
+	else
+		pr_number="$target_number"
+	fi
+
+	printf '[%s] _drain_merge_trigger_file_if_present: process_pr %s #%s (from approve %s #%s)\n' \
+		"$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date)" "$slug" "$pr_number" "$target_type" "$target_number" \
+		>>"${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}" 2>/dev/null || true
+	process_pr "$slug" "$pr_number" || record_rc=1
+	return "$record_rc"
+}
+
 _drain_merge_trigger_file_if_present() {
 	if [[ "${AIDEVOPS_SKIP_TRIGGER_DRAIN:-0}" == "1" ]]; then
 		return 0
@@ -317,7 +358,8 @@ _drain_merge_trigger_file_if_present() {
 
 	local _drain_count=0
 	local _drain_failed=0
-	local slug="" num="" type="" ts="" pr_number=""
+	local slug="" num="" type="" ts="" target_key=""
+	local seen_targets="|"
 	while IFS=$'\t' read -r slug num type ts || [[ -n "$slug" ]]; do
 		# Skip blank lines and comment lines.
 		[[ -z "$slug" || "${slug:0:1}" == "#" ]] && continue
@@ -343,30 +385,15 @@ _drain_merge_trigger_file_if_present() {
 		fi
 		# ts is informational; use a sentinel so unused-variable lints stay quiet.
 		: "${ts:-unknown}"
-
-		# Resolve issue records to their linked PR. process_pr only operates
-		# on PRs, so an "issue" record needs PR resolution first. Fail-open:
-		# if no PR is linked, skip rather than blocking the rest of the drain.
-		if [[ "$type" == "issue" ]]; then
-			pr_number=$(_resolve_linked_pr_for_issue "$slug" "$num" 2>/dev/null || printf '')
-			if [[ -z "$pr_number" ]]; then
-				printf '[%s] _drain_merge_trigger_file_if_present: %s issue #%s has no linked open PR yet — skipping\n' \
-					"$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date)" "$slug" "$num" \
-					>>"${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}" 2>/dev/null || true
-				continue
-			fi
-		else
-			pr_number="$num"
+		target_key="|${type}:${slug}#${num}|"
+		if [[ "$seen_targets" == *"$target_key"* ]]; then
+			printf '[%s] _drain_merge_trigger_file_if_present: skipping duplicate target %s %s #%s\n' \
+				"$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date)" "$slug" "$type" "$num" \
+				>>"${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}" 2>/dev/null || true
+			continue
 		fi
-
-		printf '[%s] _drain_merge_trigger_file_if_present: process_pr %s #%s (from approve %s #%s)\n' \
-			"$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date)" "$slug" "$pr_number" "$type" "$num" \
-			>>"${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}" 2>/dev/null || true
-
-		# Call process_pr — it has its own internal logging and error
-		# handling. Non-zero return is informational (gate failure, not
-		# mergeable yet, conflict closed); not a drain failure.
-		if ! process_pr "$slug" "$pr_number"; then
+		seen_targets="${seen_targets}${type}:${slug}#${num}|"
+		if ! _process_approval_trigger_record "$slug" "$num" "$type"; then
 			_drain_failed=$((_drain_failed + 1))
 		fi
 		_drain_count=$((_drain_count + 1))
@@ -375,7 +402,7 @@ _drain_merge_trigger_file_if_present() {
 	rm -f "$processing_file" 2>/dev/null || true
 
 	if [[ "$_drain_count" -gt 0 ]]; then
-		printf '[%s] _drain_merge_trigger_file_if_present: drained %d record(s), %d non-merge outcomes\n' \
+		printf '[%s] _drain_merge_trigger_file_if_present: handled %d exact target(s), %d non-success outcomes\n' \
 			"$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date)" "$_drain_count" "$_drain_failed" \
 			>>"${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}" 2>/dev/null || true
 	fi

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -310,6 +310,10 @@ source "${SCRIPT_DIR}/pulse-pr-list-cache.sh"
 source "${SCRIPT_DIR}/pulse-queue-governor.sh"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/pulse-nmr-approval.sh"
+# GH#28717: bounded exact-target recovery for cryptographically approved NMR
+# targets that Actions conservatively re-blocks after a transient API failure.
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/pulse-approval-reconcile.sh"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/pulse-dep-graph.sh"
 # shellcheck source=./dependency-event-reconciler.sh

--- a/.agents/scripts/tests/test-approval-helper-content-binding.sh
+++ b/.agents/scripts/tests/test-approval-helper-content-binding.sh
@@ -48,7 +48,9 @@ if [[ -n "${GH_FAIL_ENDPOINT:-}" && "$endpoint" == *"${GH_FAIL_ENDPOINT}"* ]]; t
 	exit 1
 fi
 case "$endpoint" in
-repos/owner/repo/issues/41) cat "${FIXTURES}/issue-41.json" ;;
+	user) printf '%s\n' "${GH_AUTH_USER:-maintainer}" ;;
+	repos/owner/repo/collaborators/trusted-collab/permission) printf '%s\n' "${GH_PERMISSION:-write}" ;;
+	repos/owner/repo/issues/41) cat "${FIXTURES}/issue-41.json" ;;
 repos/owner/repo/issues/41/comments*) cat "${FIXTURES}/comments-41.json" ;;
 repos/owner/repo/issues/41/timeline*) cat "${FIXTURES}/timeline-41.json" ;;
 repos/owner/repo/issues/42) cat "${FIXTURES}/issue-42.json" ;;
@@ -160,6 +162,16 @@ run_verify() {
 	return $?
 }
 
+run_verify_with_authority() {
+	local kind="$1"
+	local number="$2"
+	local auth_user="${3:-maintainer}"
+	HOME="$TEST_HOME" PATH="${TEST_ROOT}/bin:$PATH" FIXTURES="$FIXTURES" \
+		GH_AUTH_USER="$auth_user" AIDEVOPS_APPROVAL_PUB="${TEST_ROOT}/approval.pub" \
+		"$APPROVAL_HELPER" verify "$kind" "$number" owner/repo --require-authority 2>/dev/null
+	return $?
+}
+
 assert_verify() {
 	local description="$1"
 	local kind="$2"
@@ -183,6 +195,71 @@ reset_and_sign() {
 	write_baseline_fixtures
 	append_signed_comment "$kind" "$number" "2026-01-01T00:05:00Z"
 	return $?
+}
+
+test_authority_bound_verification() {
+	local output=""
+	local rc=0
+	local updated=""
+
+	reset_and_sign issue 41
+	output=$(run_verify_with_authority issue 41) || rc=$?
+	if [[ "$output" == "VERIFIED" && "$rc" -eq 0 ]]; then
+		print_result "authority-bound issue verification accepts current OWNER signer" 0
+	else
+		print_result "authority-bound issue verification accepts current OWNER signer" 1 "output=${output}, rc=${rc}"
+	fi
+
+	reset_and_sign pr 42
+	rc=0
+	output=$(run_verify_with_authority pr 42) || rc=$?
+	if [[ "$output" == "VERIFIED" && "$rc" -eq 0 ]]; then
+		print_result "authority-bound PR verification accepts current OWNER signer" 0
+	else
+		print_result "authority-bound PR verification accepts current OWNER signer" 1 "output=${output}, rc=${rc}"
+	fi
+
+	reset_and_sign issue 41
+	updated=$(jq -c '.[0][-1].user.login = "other-maintainer"' "${FIXTURES}/comments-41.json")
+	printf '%s\n' "$updated" >"${FIXTURES}/comments-41.json"
+	rc=0
+	output=$(run_verify_with_authority issue 41) || rc=$?
+	if [[ "$output" == "UNTRUSTED_APPROVAL" && "$rc" -eq 7 ]]; then
+		print_result "authority-bound verification rejects a different actor" 0
+	else
+		print_result "authority-bound verification rejects a different actor" 1 "output=${output}, rc=${rc}"
+	fi
+
+	reset_and_sign issue 41
+	updated=$(jq -c '.[0][-1].user.type = "Bot"' "${FIXTURES}/comments-41.json")
+	printf '%s\n' "$updated" >"${FIXTURES}/comments-41.json"
+	rc=0
+	output=$(run_verify_with_authority issue 41) || rc=$?
+	if [[ "$output" == "UNTRUSTED_APPROVAL" && "$rc" -eq 7 ]]; then
+		print_result "authority-bound verification rejects bot-authored evidence" 0
+	else
+		print_result "authority-bound verification rejects bot-authored evidence" 1 "output=${output}, rc=${rc}"
+	fi
+
+	reset_and_sign issue 41
+	updated=$(jq -c '.[0][-1].user.login = "trusted-collab" | .[0][-1].author_association = "COLLABORATOR"' "${FIXTURES}/comments-41.json")
+	printf '%s\n' "$updated" >"${FIXTURES}/comments-41.json"
+	rc=0
+	output=$(run_verify_with_authority issue 41 trusted-collab) || rc=$?
+	if [[ "$output" == "VERIFIED" && "$rc" -eq 0 ]]; then
+		print_result "authority-bound verification accepts current write collaborator" 0
+	else
+		print_result "authority-bound verification accepts current write collaborator" 1 "output=${output}, rc=${rc}"
+	fi
+
+	rc=0
+	output=$(GH_FAIL_ENDPOINT="collaborators/trusted-collab/permission" run_verify_with_authority issue 41 trusted-collab) || rc=$?
+	if [[ "$output" == "API_ERROR" && "$rc" -eq 6 ]]; then
+		print_result "authority-bound verification fails closed on permission uncertainty" 0
+	else
+		print_result "authority-bound verification fails closed on permission uncertainty" 1 "output=${output}, rc=${rc}"
+	fi
+	return 0
 }
 
 file_mode() {
@@ -303,6 +380,7 @@ main() {
 	test_large_snapshots_avoid_argv_limits
 	ssh-keygen -t ed25519 -N '' -f "${TEST_ROOT}/approval.key" -q
 	cp "${TEST_ROOT}/approval.key.pub" "${TEST_ROOT}/approval.pub"
+	test_authority_bound_verification
 
 	reset_and_sign issue 41
 	assert_verify "unchanged issue V2 snapshot verifies" issue 41 VERIFIED 0

--- a/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
+++ b/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
@@ -286,6 +286,195 @@ assert_contains "post-approval failure suppresses final success" "$LAST_OUTPUT" 
 assert_not_contains "post-approval failure does not print success" "$LAST_OUTPUT" "Issue #123 approved and signed"
 assert_not_contains "post-approval failure does not kick pulse" "$LAST_OUTPUT" "SHOULD_NOT_KICK"
 
+# GH#28717: target reconciliation accepts only the current authenticated actor's
+# signed comment when that actor has maintainer-equivalent authority.
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "current OWNER approval author is trusted" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_approval_comment_has_required_authority marcusquinn/aidevops marcusquinn marcusquinn User OWNER
+' 0
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "different approval author is rejected" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_approval_comment_has_required_authority marcusquinn/aidevops marcusquinn another-maintainer User OWNER
+' 1
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "bot approval author is rejected" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_approval_comment_has_required_authority marcusquinn/aidevops github-actions github-actions Bot OWNER
+' 1
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "write collaborator approval author is trusted" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	gh() {
+		local command="${1:-}"
+		local endpoint="${2:-}"
+		if [[ "$command" == "api" && "$endpoint" == "repos/marcusquinn/aidevops/collaborators/trusted-collab/permission" ]]; then
+			printf "write\n"
+			return 0
+		fi
+		return 1
+	}
+	_approval_comment_has_required_authority marcusquinn/aidevops trusted-collab trusted-collab User COLLABORATOR
+' 0
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "unverifiable collaborator approval author fails closed" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	gh() { return 1; }
+	_approval_comment_has_required_authority marcusquinn/aidevops trusted-collab trusted-collab User COLLABORATOR
+' 2
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "issue recovery reasserts NMR through the issue lifecycle writer" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	gh_issue_edit_safe() { printf "%s\n" "$*"; return 0; }
+	_approval_restore_nmr_hold issue 123 marcusquinn/aidevops
+' 0
+assert_contains "issue recovery reasserts the conservative label" "$LAST_OUTPUT" "--add-label needs-maintainer-review"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "PR recovery reasserts NMR through the PR lifecycle writer" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	gh_pr_edit_safe() { printf "%s\n" "$*"; return 0; }
+	_approval_restore_nmr_hold pr 456 marcusquinn/aidevops
+' 0
+assert_contains "PR recovery reasserts the conservative label" "$LAST_OUTPUT" "--add-label needs-maintainer-review"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "reconcile re-verifies authority immediately before issue lifecycle restore" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	trace=$(mktemp)
+	_require_number_arg() { return 0; }
+	_resolve_slug_or_fail() { local slug="${1:-}"; printf "%s" "$slug"; return 0; }
+	_approval_fetch_issue_json() {
+		local target_number="${1:-}"
+		local slug="${2:-}"
+		: "$target_number" "$slug"
+		printf "%s" "{\"state\":\"open\",\"labels\":[{\"name\":\"needs-maintainer-review\"}]}"
+		return 0
+	}
+	cmd_verify() {
+		local target_type="${1:-}"
+		local target_number="${2:-}"
+		local slug="${3:-}"
+		local authority_flag="${4:-}"
+		printf "VERIFY %s %s %s %s\n" "$target_type" "$target_number" "$slug" "$authority_flag" >>"$trace"
+		printf "VERIFIED\n"
+		return 0
+	}
+	_post_issue_approval_updates() {
+		local target_type="${1:-}"
+		local target_number="${2:-}"
+		local slug="${3:-}"
+		printf "APPLY %s %s %s\n" "$target_type" "$target_number" "$slug" >>"$trace"
+		return 0
+	}
+	rc=0
+	cmd_reconcile issue 123 marcusquinn/aidevops || rc=$?
+	cat "$trace"
+	rm -f "$trace"
+	exit "$rc"
+' 0
+assert_contains "reconcile requires authenticated approval authority" "$LAST_OUTPUT" "VERIFY issue 123 marcusquinn/aidevops --require-authority"
+assert_contains "reconcile restores the issue-specific lifecycle" "$LAST_OUTPUT" "APPLY issue 123 marcusquinn/aidevops"
+assert_contains "reconcile reports success" "$LAST_OUTPUT" "RECONCILED"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "partial reconciliation failure reasserts NMR before returning" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	trace=$(mktemp)
+	_require_number_arg() { return 0; }
+	_resolve_slug_or_fail() { local slug="${1:-}"; printf "%s" "$slug"; return 0; }
+	_approval_fetch_issue_json() {
+		local target_number="${1:-}"
+		local slug="${2:-}"
+		: "$target_number" "$slug"
+		printf "%s" "{\"state\":\"open\",\"labels\":[{\"name\":\"needs-maintainer-review\"}]}"
+		return 0
+	}
+	cmd_verify() { printf "VERIFIED\n"; return 0; }
+	_post_issue_approval_updates() { return 1; }
+	_approval_restore_nmr_hold() {
+		local target_type="${1:-}"
+		local target_number="${2:-}"
+		local slug="${3:-}"
+		printf "RESTORE %s %s %s\n" "$target_type" "$target_number" "$slug" >>"$trace"
+		return 0
+	}
+	rc=0
+	cmd_reconcile issue 123 marcusquinn/aidevops || rc=$?
+	cat "$trace"
+	rm -f "$trace"
+	exit "$rc"
+' 8
+assert_contains "partial reconciliation failure reasserts the exact issue hold" "$LAST_OUTPUT" "RESTORE issue 123 marcusquinn/aidevops"
+assert_contains "partial reconciliation failure remains explicit" "$LAST_OUTPUT" "UPDATE_FAILED"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "reconcile leaves an unchanged approved target as a no-op" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_require_number_arg() { return 0; }
+	_resolve_slug_or_fail() { local slug="${1:-}"; printf "%s" "$slug"; return 0; }
+	_approval_fetch_issue_json() {
+		local target_number="${1:-}"
+		local slug="${2:-}"
+		: "$target_number" "$slug"
+		printf "%s" "{\"state\":\"open\",\"labels\":[{\"name\":\"auto-dispatch\"}]}"
+		return 0
+	}
+	cmd_verify() { printf "SHOULD_NOT_VERIFY\n"; return 1; }
+	_post_issue_approval_updates() { printf "SHOULD_NOT_APPLY\n"; return 1; }
+	cmd_reconcile issue 123 marcusquinn/aidevops
+' 3
+assert_contains "no-op reconciliation reports absent restored hold" "$LAST_OUTPUT" "NO_NMR"
+assert_not_contains "no-op reconciliation skips signature work" "$LAST_OUTPUT" "SHOULD_NOT_VERIFY"
+assert_not_contains "no-op reconciliation skips lifecycle mutation" "$LAST_OUTPUT" "SHOULD_NOT_APPLY"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "reconcile preserves NMR when authority verification fails" '
+	set -uo pipefail
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_require_number_arg() { return 0; }
+	_resolve_slug_or_fail() { local slug="${1:-}"; printf "%s" "$slug"; return 0; }
+	_approval_fetch_issue_json() {
+		local target_number="${1:-}"
+		local slug="${2:-}"
+		: "$target_number" "$slug"
+		printf "%s" "{\"state\":\"open\",\"pull_request\":{},\"labels\":[{\"name\":\"needs-maintainer-review\"}]}"
+		return 0
+	}
+	cmd_verify() { printf "UNTRUSTED_APPROVAL\n"; return 7; }
+	_post_issue_approval_updates() { printf "SHOULD_NOT_APPLY\n"; return 1; }
+	cmd_reconcile pr 456 marcusquinn/aidevops
+' 7
+assert_contains "failed authority remains explicit" "$LAST_OUTPUT" "UNTRUSTED_APPROVAL"
+assert_not_contains "failed authority never mutates PR lifecycle" "$LAST_OUTPUT" "SHOULD_NOT_APPLY"
+
 printf '\n==============================================\n'
 printf 'Results: %s passed, %s failed\n' "$PASS" "$FAIL"
 

--- a/.agents/scripts/tests/test-approve-kicks-pulse.sh
+++ b/.agents/scripts/tests/test-approve-kicks-pulse.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 # =============================================================================
-# Test: t3068 — approve writes trigger file; pulse drains it.
+# Test: t3068 / GH#28717 — approval triggers target reconciliation and merge.
 # =============================================================================
 #
 # Covers two contracts that together collapse the up-to-120s window between
@@ -12,12 +12,12 @@
 #   1. approval-helper.sh::_kick_pulse_after_approval writes a TSV record
 #      to ~/.aidevops/cache/pulse-merge-trigger.txt on every approval.
 #   2. pulse-wrapper-bootstrap.sh::_drain_merge_trigger_file_if_present
-#      atomically rotates the marker, processes each record, and removes
-#      the rotated file — so the same record never executes twice.
+#      atomically rotates the marker, reconciles the exact approved target,
+#      then processes any linked PR. Exact duplicate records execute once.
 #
 # The test isolates the marker file via the PULSE_MERGE_TRIGGER_FILE env
-# var and mocks process_pr to a stub that records calls into a log. No
-# real GitHub state is touched.
+# var and mocks reconciliation/process_pr into logs. No real GitHub state is
+# touched.
 #
 # Bypass env vars exercised:
 #   AIDEVOPS_SKIP_APPROVE_KICK_PULSE=1   — disable the helper entirely
@@ -30,6 +30,8 @@
 #   - Drain is a no-op when marker is missing (cold start)
 #   - Atomic rotation: a stub `process_pr` that re-checks the marker sees
 #     it gone (no double-processing on race)
+#   - Issues without linked PRs still receive exact-target reconciliation
+#   - Exact duplicate records do not repeat reconciliation or merge attempts
 #   - Bypass flags neutralise both halves cleanly
 
 set -uo pipefail
@@ -44,6 +46,8 @@ FAIL=0
 TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/test-t3068-XXXXXX") || exit 1
 TRIGGER_FILE="${TMPROOT}/pulse-merge-trigger.txt"
 PROCESS_LOG="${TMPROOT}/process-pr.log"
+RECONCILE_LOG="${TMPROOT}/reconcile.log"
+EVENT_LOG="${TMPROOT}/events.log"
 
 cleanup() {
 	rm -rf "$TMPROOT" 2>/dev/null || true
@@ -58,13 +62,28 @@ trap cleanup EXIT
 load_drain_with_stubs() {
 	# Reset both files for this test case.
 	: >"$PROCESS_LOG"
+	: >"$RECONCILE_LOG"
+	: >"$EVENT_LOG"
 
 	# shellcheck disable=SC1091
 	source "${PARENT_DIR}/pulse-wrapper-bootstrap.sh" >/dev/null 2>&1
 
 	# Stub process_pr — record args, never call gh.
 	process_pr() {
-		printf 'process_pr %s %s\n' "${1:-}" "${2:-}" >>"$PROCESS_LOG"
+		local slug="${1:-}"
+		local pr_number="${2:-}"
+		printf 'process_pr %s %s\n' "$slug" "$pr_number" >>"$PROCESS_LOG"
+		printf 'process_pr %s %s\n' "$slug" "$pr_number" >>"$EVENT_LOG"
+		return 0
+	}
+
+	# Stub the trusted exact-target recovery owned by pulse-approval-reconcile.sh.
+	_pulse_reconcile_verified_approval_target() {
+		local target_type="${1:-}"
+		local target_number="${2:-}"
+		local slug="${3:-}"
+		printf 'reconcile %s %s %s\n' "$target_type" "$target_number" "$slug" >>"$RECONCILE_LOG"
+		printf 'reconcile %s %s %s\n' "$target_type" "$target_number" "$slug" >>"$EVENT_LOG"
 		return 0
 	}
 
@@ -233,6 +252,10 @@ else
 	assert_fail "process_pr called with slug + PR number" "process log empty"
 fi
 
+event_order=$(cat "$EVENT_LOG" 2>/dev/null || true)
+assert_eq "exact-target reconciliation runs before PR processing" \
+	$'reconcile pr 21806 marcusquinn/aidevops\nprocess_pr marcusquinn/aidevops 21806' "$event_order"
+
 echo ""
 
 # -----------------------------------------------------------------------------
@@ -264,6 +287,8 @@ assert_file_absent "marker file removed after mixed-record drain" "$TRIGGER_FILE
 
 valid_calls=$(wc -l <"$PROCESS_LOG" 2>/dev/null | tr -d ' ' || echo "0")
 assert_eq "drain processed 2 valid records (skipped 4 malformed)" "2" "$valid_calls"
+reconcile_calls=$(wc -l <"$RECONCILE_LOG" 2>/dev/null | tr -d ' ' || echo "0")
+assert_eq "drain reconciled only the 2 valid records" "2" "$reconcile_calls"
 
 echo ""
 
@@ -341,10 +366,12 @@ echo "=================================================="
 	# proves _drain_merge_trigger_file_if_present rotated atomically before
 	# invoking process_pr (so a parallel drain would find an empty path).
 	process_pr() {
+		local slug="${1:-}"
+		local pr_number="${2:-}"
 		if [[ -f "$TRIGGER_FILE" ]]; then
-			printf 'STILL_PRESENT %s %s\n' "${1:-}" "${2:-}" >>"$PROCESS_LOG"
+			printf 'STILL_PRESENT %s %s\n' "$slug" "$pr_number" >>"$PROCESS_LOG"
 		else
-			printf 'ROTATED %s %s\n' "${1:-}" "${2:-}" >>"$PROCESS_LOG"
+			printf 'ROTATED %s %s\n' "$slug" "$pr_number" >>"$PROCESS_LOG"
 		fi
 		return 0
 	}
@@ -384,6 +411,15 @@ echo "=================================================="
 
 calls=$(wc -l <"$PROCESS_LOG" 2>/dev/null | tr -d ' ' || echo "0")
 assert_eq "drain processed 1 issue→PR record (skipped 1 unlinked)" "1" "$calls"
+
+reconcile_calls=$(wc -l <"$RECONCILE_LOG" 2>/dev/null | tr -d ' ' || echo "0")
+assert_eq "both linked and unlinked issues receive target reconciliation" "2" "$reconcile_calls"
+if grep -q '^reconcile issue 99998 marcusquinn/aidevops$' "$RECONCILE_LOG" 2>/dev/null; then
+	assert_pass "unlinked issue is reconciled without requiring a PR"
+else
+	assert_fail "unlinked issue is reconciled without requiring a PR" \
+		"reconcile log contained: $(cat "$RECONCILE_LOG")"
+fi
 
 logged_call=$(head -1 "$PROCESS_LOG" 2>/dev/null || echo "")
 assert_eq "issue 12345 resolved to PR 99999 by stub" \
@@ -474,6 +510,32 @@ if [[ -s "$raw_fallback_log" ]]; then
 else
 	assert_fail "resolver fallback called raw gh without wrapper" "raw gh log empty"
 fi
+
+echo ""
+
+# -----------------------------------------------------------------------------
+# Test 10: exact duplicate records reconcile and process only once.
+# -----------------------------------------------------------------------------
+echo "Test 10: duplicate target records are idempotent"
+echo "================================================"
+
+(
+	load_drain_with_stubs
+
+	{
+		printf 'marcusquinn/aidevops\t21806\tpr\t2026-04-30T12:00:00Z\n'
+		printf 'marcusquinn/aidevops\t21806\tpr\t2026-04-30T12:00:01Z\n'
+	} >"$TRIGGER_FILE"
+
+	_drain_merge_trigger_file_if_present || exit 1
+)
+drain_rc=$?
+
+assert_eq "duplicate drain returns 0" "0" "$drain_rc"
+reconcile_calls=$(wc -l <"$RECONCILE_LOG" 2>/dev/null | tr -d ' ' || echo "0")
+process_calls=$(wc -l <"$PROCESS_LOG" 2>/dev/null | tr -d ' ' || echo "0")
+assert_eq "duplicate target reconciles once" "1" "$reconcile_calls"
+assert_eq "duplicate target processes its PR once" "1" "$process_calls"
 
 echo ""
 

--- a/.agents/scripts/tests/test-pulse-nmr-approval.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-approval.sh
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# Tests for NMR approval notification helpers in pulse-nmr-approval.sh
-# (GH#21752 / t3049).
+# Tests for NMR approval notification and exact-target recovery helpers in
+# pulse-nmr-approval.sh (GH#21752 / t3049 / GH#28717).
 #
 # Verifies that the notification helper correctly:
 #   a. Posts a notification when stale-recovery NMR + OWNER-authored approved
@@ -16,11 +16,13 @@
 #   g. Does NOT post for cost-circuit-breaker:fired NMR
 #   h. Does NOT post a duplicate when the marker already exists
 #   i. Includes the repo slug in generated sudo approval commands
+#   j. Re-verifies exact approved targets through bounded, fail-closed retries
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 NMR_SCRIPT="${SCRIPT_DIR}/../pulse-nmr-approval.sh"
+RECONCILE_SCRIPT="${SCRIPT_DIR}/../pulse-approval-reconcile.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -226,8 +228,8 @@ define_helper_under_test() {
 	ever_notify_src=$(awk '
 		/^notify_ever_nmr_without_approval\(\) \{/,/^}$/ { print }
 	' "$NMR_SCRIPT")
-	if [[ -z "$finder_src" || -z "$notify_src" || -z "$ever_notify_src" ]]; then
-		printf 'ERROR: could not extract helpers from %s\n' "$NMR_SCRIPT" >&2
+	if [[ -z "$finder_src" || -z "$notify_src" || -z "$ever_notify_src" || ! -f "$RECONCILE_SCRIPT" ]]; then
+		printf 'ERROR: could not extract helpers from %s and %s\n' "$NMR_SCRIPT" "$RECONCILE_SCRIPT" >&2
 		return 1
 	fi
 	# shellcheck disable=SC1090
@@ -236,6 +238,8 @@ define_helper_under_test() {
 	eval "$notify_src"
 	# shellcheck disable=SC1090
 	eval "$ever_notify_src"
+	# shellcheck disable=SC1090
+	source "$RECONCILE_SCRIPT"
 	return 0
 }
 
@@ -530,6 +534,200 @@ test_k_graphql_cost_drift_no_candidate() {
 	return 0
 }
 
+# Case L: approval recovery watches the exact target through a bounded race
+# window. API uncertainty retries; untrusted evidence stops fail-closed; a
+# target that never regains NMR finishes as an idempotent no-op.
+setup_reconcile_helper_fixture() {
+	local agents_dir="$1"
+	local helper="${agents_dir}/scripts/approval-helper.sh"
+
+	mkdir -p "${agents_dir}/scripts"
+	cat >"$helper" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+printf '%s\n' "$*" >>"$STUB_RECONCILE_CALLS"
+count=$(cat "$STUB_RECONCILE_COUNT" 2>/dev/null || printf '0')
+count=$((count + 1))
+printf '%s\n' "$count" >"$STUB_RECONCILE_COUNT"
+case "${STUB_RECONCILE_SCENARIO:-}" in
+	race)
+		if [[ "$count" -lt 3 ]]; then printf 'NO_NMR\n'; exit 3; fi
+		if [[ "$count" -eq 3 ]]; then printf 'RECONCILED\n'; exit 0; fi
+		printf 'NO_NMR\n'
+		exit 3
+		;;
+	api-once)
+		if [[ "$count" -eq 1 ]]; then printf 'API_ERROR\n'; exit 6; fi
+		if [[ "$count" -eq 2 ]]; then printf 'RECONCILED\n'; exit 0; fi
+		printf 'NO_NMR\n'
+		exit 3
+		;;
+	no-nmr) printf 'NO_NMR\n'; exit 3 ;;
+	no-nmr-error) printf 'NO_NMR\n'; exit 6 ;;
+	untrusted) printf 'UNTRUSTED_APPROVAL\n'; exit 7 ;;
+	reapplied) printf 'RECONCILED\n'; exit 0 ;;
+	update-then-missing)
+		if [[ "$count" -eq 1 ]]; then printf 'UPDATE_FAILED\n'; exit 8; fi
+		printf 'NO_NMR\n'
+		exit 3
+		;;
+	reconciled-error-then-missing)
+		if [[ "$count" -eq 1 ]]; then printf 'RECONCILED\n'; exit 6; fi
+		printf 'NO_NMR\n'
+		exit 3
+		;;
+	pr-success)
+		if [[ "$count" -eq 1 ]]; then printf 'RECONCILED\n'; exit 0; fi
+		printf 'NO_NMR\n'
+		exit 3
+		;;
+	*) printf 'MALFORMED_APPROVAL\n'; exit 5 ;;
+esac
+EOF
+	chmod +x "$helper"
+	return 0
+}
+
+test_m_reconciliation_protocol_uncertainty_stays_fail_closed() {
+	local agents_dir="${TEST_ROOT}/agents-protocol"
+	local calls_file="${TEST_ROOT}/protocol-calls.log"
+	local count_file="${TEST_ROOT}/protocol-count"
+	local rc=0
+	local call_count="0"
+
+	setup_reconcile_helper_fixture "$agents_dir"
+	export AGENTS_DIR="$agents_dir"
+	export STUB_RECONCILE_CALLS="$calls_file"
+	export STUB_RECONCILE_COUNT="$count_file"
+	export AIDEVOPS_NMR_RECONCILE_DELAY_SECONDS=0
+	export AIDEVOPS_NMR_RECONCILE_ATTEMPTS=3
+	: >"$calls_file"
+
+	printf '0\n' >"$count_file"
+	export STUB_RECONCILE_SCENARIO=no-nmr-error
+	_pulse_reconcile_verified_approval_target issue 28717 owner/repo || rc=$?
+	call_count=$(cat "$count_file")
+	if [[ "$rc" -eq 1 && "$call_count" == "3" ]]; then
+		print_result "Case M1: mismatched NO_NMR protocol status remains fail-closed" 0
+	else
+		print_result "Case M1: mismatched NO_NMR protocol status remains fail-closed" 1 "rc=${rc}, calls=${call_count}"
+	fi
+
+	printf '0\n' >"$count_file"
+	export STUB_RECONCILE_SCENARIO=update-then-missing
+	rc=0
+	_pulse_reconcile_verified_approval_target issue 28717 owner/repo || rc=$?
+	call_count=$(cat "$count_file")
+	if [[ "$rc" -eq 1 && "$call_count" == "3" ]]; then
+		print_result "Case M2: partial update cannot become an absent-hold success" 0
+	else
+		print_result "Case M2: partial update cannot become an absent-hold success" 1 "rc=${rc}, calls=${call_count}"
+	fi
+
+	printf '0\n' >"$count_file"
+	export STUB_RECONCILE_SCENARIO=reconciled-error-then-missing
+	rc=0
+	_pulse_reconcile_verified_approval_target issue 28717 owner/repo || rc=$?
+	call_count=$(cat "$count_file")
+	if [[ "$rc" -eq 1 && "$call_count" == "3" ]]; then
+		print_result "Case M3: mismatched mutation status cannot become no-op success" 0
+	else
+		print_result "Case M3: mismatched mutation status cannot become no-op success" 1 "rc=${rc}, calls=${call_count}"
+	fi
+
+	unset AGENTS_DIR STUB_RECONCILE_CALLS STUB_RECONCILE_COUNT STUB_RECONCILE_SCENARIO
+	unset AIDEVOPS_NMR_RECONCILE_ATTEMPTS AIDEVOPS_NMR_RECONCILE_DELAY_SECONDS
+	return 0
+}
+
+test_l_exact_target_reconciliation_is_bounded_and_fail_closed() {
+	local agents_dir="${TEST_ROOT}/agents"
+	local calls_file="${TEST_ROOT}/reconcile-calls.log"
+	local count_file="${TEST_ROOT}/reconcile-count"
+	local rc=0
+	local call_count="0"
+
+	setup_reconcile_helper_fixture "$agents_dir"
+	export AGENTS_DIR="$agents_dir"
+	export STUB_RECONCILE_CALLS="$calls_file"
+	export STUB_RECONCILE_COUNT="$count_file"
+	export AIDEVOPS_NMR_RECONCILE_DELAY_SECONDS=0
+	: >"$calls_file"
+
+	printf '0\n' >"$count_file"
+	export STUB_RECONCILE_SCENARIO=race
+	export AIDEVOPS_NMR_RECONCILE_ATTEMPTS=4
+	rc=0
+	_pulse_reconcile_verified_approval_target issue 28717 owner/repo || rc=$?
+	call_count=$(cat "$count_file")
+	if [[ "$rc" -eq 0 && "$call_count" == "4" ]]; then
+		print_result "Case L1: restored NMR race reconciles within bounded retries" 0
+	else
+		print_result "Case L1: restored NMR race reconciles within bounded retries" 1 "rc=${rc}, calls=${call_count}"
+	fi
+
+	printf '0\n' >"$count_file"
+	export STUB_RECONCILE_SCENARIO=api-once
+	rc=0
+	_pulse_reconcile_verified_approval_target issue 28717 owner/repo || rc=$?
+	call_count=$(cat "$count_file")
+	if [[ "$rc" -eq 0 && "$call_count" == "3" ]]; then
+		print_result "Case L2: transient API uncertainty retries exact target" 0
+	else
+		print_result "Case L2: transient API uncertainty retries exact target" 1 "rc=${rc}, calls=${call_count}"
+	fi
+
+	printf '0\n' >"$count_file"
+	export STUB_RECONCILE_SCENARIO=no-nmr
+	export AIDEVOPS_NMR_RECONCILE_ATTEMPTS=3
+	rc=0
+	_pulse_reconcile_verified_approval_target issue 28717 owner/repo || rc=$?
+	call_count=$(cat "$count_file")
+	if [[ "$rc" -eq 0 && "$call_count" == "3" ]]; then
+		print_result "Case L3: unchanged approved target is bounded idempotent no-op" 0
+	else
+		print_result "Case L3: unchanged approved target is bounded idempotent no-op" 1 "rc=${rc}, calls=${call_count}"
+	fi
+
+	printf '0\n' >"$count_file"
+	export STUB_RECONCILE_SCENARIO=untrusted
+	rc=0
+	_pulse_reconcile_verified_approval_target issue 28717 owner/repo || rc=$?
+	call_count=$(cat "$count_file")
+	if [[ "$rc" -eq 1 && "$call_count" == "1" ]]; then
+		print_result "Case L4: untrusted approval evidence stops fail-closed" 0
+	else
+		print_result "Case L4: untrusted approval evidence stops fail-closed" 1 "rc=${rc}, calls=${call_count}"
+	fi
+
+	printf '0\n' >"$count_file"
+	export STUB_RECONCILE_SCENARIO=reapplied
+	export AIDEVOPS_NMR_RECONCILE_ATTEMPTS=3
+	rc=0
+	_pulse_reconcile_verified_approval_target issue 28717 owner/repo || rc=$?
+	call_count=$(cat "$count_file")
+	if [[ "$rc" -eq 1 && "$call_count" == "3" ]]; then
+		print_result "Case L5: repeated conservative restoration stops at the retry bound" 0
+	else
+		print_result "Case L5: repeated conservative restoration stops at the retry bound" 1 "rc=${rc}, calls=${call_count}"
+	fi
+
+	printf '0\n' >"$count_file"
+	: >"$calls_file"
+	export STUB_RECONCILE_SCENARIO=pr-success
+	rc=0
+	_pulse_reconcile_verified_approval_target pr 28718 owner/repo || rc=$?
+	if [[ "$rc" -eq 0 ]] && grep -q '^reconcile pr 28718 owner/repo$' "$calls_file"; then
+		print_result "Case L6: PR recovery remains exact-target and type-specific" 0
+	else
+		print_result "Case L6: PR recovery remains exact-target and type-specific" 1 "rc=${rc}, calls=$(cat "$calls_file")"
+	fi
+
+	unset AGENTS_DIR STUB_RECONCILE_CALLS STUB_RECONCILE_COUNT STUB_RECONCILE_SCENARIO
+	unset AIDEVOPS_NMR_RECONCILE_ATTEMPTS AIDEVOPS_NMR_RECONCILE_DELAY_SECONDS
+	return 0
+}
+
 # ============================================================
 # Main
 # ============================================================
@@ -554,6 +752,8 @@ main() {
 	test_i_empty_nmr_timestamp_no_candidate
 	test_j_ever_nmr_remediation_includes_repo_slug
 	test_k_graphql_cost_drift_no_candidate
+	test_l_exact_target_reconciliation_is_bounded_and_fail_closed
+	test_m_reconciliation_protocol_uncertainty_stays_fail_closed
 
 	printf '\n%d tests run, %d failures\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Recover exact-target verified NMR approvals after transient Actions comment-read failures while preserving authority checks and fail-closed lifecycle behavior.

## Files Changed

.agents/scripts/approval-helper.sh, .agents/scripts/pulse-approval-reconcile.sh, .agents/scripts/pulse-wrapper-bootstrap.sh, .agents/scripts/pulse-wrapper.sh, .agents/scripts/tests/test-approval-helper-content-binding.sh, .agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh, .agents/scripts/tests/test-approve-kicks-pulse.sh, .agents/scripts/tests/test-pulse-nmr-approval.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Focused approval, Pulse NMR, trigger, and REST-lock regression suites pass; targeted bash -n and ShellCheck pass; changed-file lint passes; Pulse self-check reports 51 canonical functions and 36 module guards; git diff --check passes.

Resolves #28717


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.185 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 41m and 799,129 tokens on this with the user in an interactive session.