### PR TITLE
GH#28661: Make OpenCode ai-research provider-agnostic

### DIFF
--- a/.agents/aidevops/architecture.md
+++ b/.agents/aidevops/architecture.md
@@ -46,8 +46,17 @@ Files in `.opencode/tool/` are **OpenCode plugin tools** — TypeScript modules 
 
 | File | Purpose |
 |------|---------|
-| `ai-research.ts` | Spawns research queries via Anthropic API |
+| `ai-research.ts` | Routes isolated research queries through configured OpenCode providers |
 | `session-rename.ts` | Renames sessions via direct SQLite write — no HTTP API exists |
+
+The native `ai_research` tool uses canonical `simple`, `standard`, and `thinking`
+workload tiers. The headless OpenCode runtime owns model availability, provider
+selection, credential isolation, and inference transport. A per-child ceiling
+reduces the `research-only` profile to inference-only because the parent supplies
+all requested agent and file context in a private bounded artifact. Legacy
+`haiku`, `sonnet`, and `opus` inputs remain aliases; exact provider-neutral token
+usage and output-token enforcement are reported as unavailable or advisory when
+the selected runtime does not expose them.
 
 ## Judgment and Deterministic Enforcement
 

--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -573,6 +573,7 @@ function registerAgents(config, agentsDir) {
 }
 
 const RESEARCH_ONLY_AGENT_NAME = "research-only";
+const AI_RESEARCH_TOOL_CEILING_ENV = "AIDEVOPS_AI_RESEARCH_TOOL_CEILING";
 const UNSAFE_FRONTMATTER_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 const RESEARCH_ONLY_FALLBACK_PROMPT = `# Research-only subagent
 
@@ -651,9 +652,17 @@ function researchOnlyProfile(agentsDir) {
  * @param {string} agentsDir
  * @returns {number} Number of enforced profiles
  */
-export function registerResearchOnlyAgent(config, agentsDir) {
+export function registerResearchOnlyAgent(config, agentsDir, env = process.env) {
   if (!config.agent) config.agent = {};
-  config.agent[RESEARCH_ONLY_AGENT_NAME] = researchOnlyProfile(agentsDir);
+  const profile = researchOnlyProfile(agentsDir);
+  if (env[AI_RESEARCH_TOOL_CEILING_ENV] === "1") {
+    // The native ai_research tool supplies all context up front. Its nested
+    // runtime needs inference only, so fail closed even against read-only tools
+    // that the general research-only profile normally permits.
+    profile.tools = { "*": false };
+    profile.permission = "deny";
+  }
+  config.agent[RESEARCH_ONLY_AGENT_NAME] = profile;
   return 1;
 }
 

--- a/.agents/plugins/opencode-aidevops/tests/test-research-only-profile.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-research-only-profile.mjs
@@ -81,3 +81,41 @@ test("research-only profile fails closed when canonical frontmatter is invalid",
     rmSync(agentsDir, { recursive: true, force: true });
   }
 });
+
+test("native ai-research child receives an inference-only tool ceiling", () => {
+  const agentsDir = mkdtempSync(join(tmpdir(), "aidevops-research-only-"));
+  const sourceDir = join(agentsDir, "tools", "ai-assistants");
+  mkdirSync(sourceDir, { recursive: true });
+  writeFileSync(join(sourceDir, "research-only.md"), `---
+name: research-only
+description: Canonical research profile
+mode: subagent
+tools:
+  "*": false
+  read: true
+  webfetch: true
+permission:
+  "*": deny
+  read: allow
+  webfetch: allow
+---
+
+Canonical research prompt.
+`);
+
+  try {
+    const config = { agent: {} };
+    assert.equal(registerResearchOnlyAgent(
+      config,
+      agentsDir,
+      { AIDEVOPS_AI_RESEARCH_TOOL_CEILING: "1" },
+    ), 1);
+    const profile = config.agent["research-only"];
+
+    assert.deepEqual(profile.tools, { "*": false });
+    assert.equal(profile.permission, "deny");
+    assert.equal(profile.prompt, "Canonical research prompt.");
+  } finally {
+    rmSync(agentsDir, { recursive: true, force: true });
+  }
+});

--- a/.agents/prompts/worker-efficiency-protocol.md
+++ b/.agents/prompts/worker-efficiency-protocol.md
@@ -62,9 +62,13 @@ fi
 ai_research(prompt: "Find all functions that dispatch workers in pulse-wrapper.sh. Return: function name, line number, key variables.", domain: "orchestration")
 ```
 
-- Rate limit: 10 per session. Default model: haiku.
+- Rate limit: 10 per session. Default workload tier: `simple`; OpenCode selects
+  an available configured provider/model through canonical routing.
 - Domain shorthand auto-loads agent files: `git=git-workflow,github-cli,conflict-resolution`; `planning=plans,beads`; `code=code-standards,code-simplifier`; `seo=seo,dataforseo,google-search-console`; `content=content,research,writing`; `wordpress=wp-dev,mainwp`; `browser=browser-automation,playwright`; `deploy=coolify,coolify-cli,vercel`; `security=tirith,encryption-stack`; `mcp=build-mcp,server-patterns`; `agent=build-agent,agent-review`; `framework=architecture,setup`; `release=release,version-bump`; `pr=pr,preflight`; `orchestration=headless-dispatch`; `context=model-routing,toon,mcp-discovery`; `video=video-prompt-design,remotion,wavespeed`; `voice=speech-to-speech,voice-bridge`; `mobile=agent-device,maestro,serve-sim`; `hosting=hostinger,cloudflare,hetzner`; `email=email-testing,email-delivery-test`; `accessibility=accessibility,accessibility-audit`; `containers=orbstack`; `vision=overview,image-generation`.
 - Parameters: `prompt` required; optional `domain`, `agents` (paths relative to `~/.aidevops/agents/`), `files` (line ranges allowed, e.g. `src/foo.ts:10-50`), `model` (`simple|standard|thinking`), `max_tokens` (default 500, max 4096).
+- `haiku|sonnet|opus` remain compatibility aliases. `max_tokens` is an advisory
+  generation budget plus a bounded transport ceiling when the selected OpenCode
+  provider does not expose exact output-token controls or usage.
 
 ## 3. Avoid wasted execution
 

--- a/.opencode/lib/ai-research.test.ts
+++ b/.opencode/lib/ai-research.test.ts
@@ -1,0 +1,403 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { access, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  buildSystemPrompt,
+  createOpenCodeRuntimeAdapter,
+  extractAIContext,
+  formatResearchResult,
+  getCallsRemaining,
+  normalizeMaxTokens,
+  normalizeResearchTier,
+  parseOpenCodeRuntimeOutput,
+  research,
+  ResearchRuntimeError,
+  resetRateLimit,
+  type CommandResult,
+  type ResearchRuntimeAdapter,
+  type ResearchRuntimeErrorCode,
+  type ResearchRuntimeRequest,
+} from "./ai-research"
+
+const temporaryDirectories: string[] = []
+
+async function temporaryDirectory(prefix: string): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), prefix))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+function commandResult(overrides: Partial<CommandResult> = {}): CommandResult {
+  return {
+    stdout: "",
+    stderr: "",
+    exitCode: 0,
+    timedOut: false,
+    aborted: false,
+    outputLimitExceeded: false,
+    spawnFailed: false,
+    ...overrides,
+  }
+}
+
+function runtimeRequest(overrides: Partial<ResearchRuntimeRequest> = {}): ResearchRuntimeRequest {
+  return {
+    prompt: "Return the key fact.",
+    systemPrompt: "Use the supplied fixture context.",
+    tier: "simple",
+    maxTokens: 100,
+    cwd: process.cwd(),
+    ...overrides,
+  }
+}
+
+function fixedRuntime(content = "Focused answer"): ResearchRuntimeAdapter {
+  return {
+    async run() {
+      return {
+        content,
+        model: "openai/test-model",
+        input_tokens: 12,
+        output_tokens: 3,
+        usage_available: true,
+      }
+    },
+  }
+}
+
+async function expectRuntimeError(
+  operation: Promise<unknown>,
+  code: ResearchRuntimeErrorCode,
+): Promise<ResearchRuntimeError> {
+  try {
+    await operation
+  } catch (error) {
+    expect(error).toBeInstanceOf(ResearchRuntimeError)
+    expect((error as ResearchRuntimeError).code).toBe(code)
+    return error as ResearchRuntimeError
+  }
+  throw new Error(`Expected ResearchRuntimeError(${code})`)
+}
+
+beforeEach(() => {
+  resetRateLimit()
+})
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map(directory =>
+    rm(directory, { recursive: true, force: true })
+  ))
+})
+
+describe("canonical workload routing", () => {
+  test("uses canonical tiers and preserves every legacy alias", () => {
+    expect(normalizeResearchTier(undefined)).toBe("simple")
+    expect(normalizeResearchTier("simple")).toBe("simple")
+    expect(normalizeResearchTier("standard")).toBe("standard")
+    expect(normalizeResearchTier("thinking")).toBe("thinking")
+    expect(normalizeResearchTier("haiku")).toBe("simple")
+    expect(normalizeResearchTier("sonnet")).toBe("standard")
+    expect(normalizeResearchTier("opus")).toBe("thinking")
+    expect(() => normalizeResearchTier("provider/model")).toThrow("canonical")
+  })
+
+  test("clamps the provider-neutral response budget", () => {
+    expect(normalizeMaxTokens(undefined)).toBe(500)
+    expect(normalizeMaxTokens(1)).toBe(50)
+    expect(normalizeMaxTokens(123.9)).toBe(123)
+    expect(normalizeMaxTokens(10_000)).toBe(4096)
+    expect(() => normalizeMaxTokens(Number.NaN)).toThrow("finite")
+  })
+})
+
+describe("context assembly", () => {
+  test("extracts marked agent context and requested file line ranges", async () => {
+    const root = await temporaryDirectory("aidevops-ai-research-context-")
+    const agentsBase = join(root, "agents")
+    const project = join(root, "project")
+    await mkdir(agentsBase, { recursive: true })
+    await mkdir(join(agentsBase, "workflows"), { recursive: true })
+    await mkdir(project, { recursive: true })
+    await writeFile(join(agentsBase, "fixture.md"), [
+      "outside-before",
+      "<!-- AI-CONTEXT-START -->",
+      "inside-agent-context",
+      "<!-- AI-CONTEXT-END -->",
+      "outside-after",
+    ].join("\n"))
+    await writeFile(join(agentsBase, "workflows", "git-workflow.md"), "domain-context")
+    await writeFile(join(project, "source.txt"), "line-one\nline-two\nline-three\nline-four\n")
+
+    const prompt = await buildSystemPrompt({
+      agents: ["fixture.md"],
+      domain: "git",
+      files: ["source.txt:2-3"],
+    }, { agentsBase, cwd: project })
+
+    expect(prompt).toContain("inside-agent-context")
+    expect(prompt).not.toContain("outside-before")
+    expect(prompt).toContain("domain-context")
+    expect(prompt).toContain("line-two\nline-three")
+    expect(prompt).not.toContain("line-one")
+  })
+
+  test("falls back to complete content when markers are incomplete", () => {
+    const source = "before\n<!-- AI-CONTEXT-START -->\nafter"
+    expect(extractAIContext(source)).toBe(source)
+  })
+})
+
+describe("OpenCode event parsing", () => {
+  test("parses response text, selected model, and provider-neutral usage", () => {
+    const output = [
+      "[lifecycle] post_model_select session=test model=openai/fallback-model pid=1",
+      JSON.stringify({ type: "text", part: { type: "text", text: "First fact." } }),
+      JSON.stringify({ type: "text", part: { type: "text", text: "Second fact." } }),
+      JSON.stringify({
+        type: "step_finish",
+        part: {
+          providerID: "openai",
+          modelID: "gpt-test",
+          tokens: { input: 42, output: 9 },
+        },
+      }),
+    ].join("\n")
+
+    expect(parseOpenCodeRuntimeOutput(output)).toEqual({
+      content: "First fact.\nSecond fact.",
+      model: "openai/gpt-test",
+      input_tokens: 42,
+      output_tokens: 9,
+      usage_available: true,
+    })
+  })
+
+  test("reports unavailable usage honestly when events omit it", () => {
+    const output = [
+      "[lifecycle] post_model_select session=test model=zai-coding-plan/glm-test pid=1",
+      JSON.stringify({ type: "text", part: { text: "Provider-neutral answer" } }),
+    ].join("\n")
+    const result = parseOpenCodeRuntimeOutput(output)
+
+    expect(result.model).toBe("zai-coding-plan/glm-test")
+    expect(result.input_tokens).toBe(0)
+    expect(result.output_tokens).toBe(0)
+    expect(result.usage_available).toBe(false)
+  })
+
+  test("fails with an actionable parse diagnostic when text is absent", () => {
+    expect(() => parseOpenCodeRuntimeOutput('{"type":"step_start"}')).toThrow(
+      "parseable research response",
+    )
+  })
+})
+
+describe("research API compatibility", () => {
+  test("maps aliases before invoking an injectable runtime and preserves the footer", async () => {
+    let observed: ResearchRuntimeRequest | undefined
+    const runtime: ResearchRuntimeAdapter = {
+      async run(request) {
+        observed = request
+        return fixedRuntime().run(request)
+      },
+    }
+
+    const result = await research({
+      prompt: "Summarise the fixture.",
+      model: "sonnet",
+      max_tokens: 12,
+    }, { runtime, cwd: "/fixture/project" })
+
+    expect(observed?.tier).toBe("standard")
+    expect(observed?.maxTokens).toBe(50)
+    expect(observed?.cwd).toBe("/fixture/project")
+    expect(result.calls_remaining).toBe(9)
+    expect(formatResearchResult(result)).toBe(
+      "Focused answer\n\n" +
+      "--- ai-research: openai/test-model | in:12 out:3 | " +
+      "max_tokens:advisory | 9 calls remaining ---",
+    )
+  })
+
+  test("keeps the ten-call session limiter", async () => {
+    const runtime = fixedRuntime()
+    for (let call = 0; call < 10; call++) {
+      await research({ prompt: `query-${call}` }, { runtime })
+    }
+    expect(getCallsRemaining()).toBe(0)
+    await expect(research({ prompt: "query-11" }, { runtime })).rejects.toThrow(
+      "Rate limit reached",
+    )
+  })
+
+  test("fails closed when provider output exceeds the conservative ceiling", async () => {
+    const error = await expectRuntimeError(
+      research(
+        { prompt: "large response", max_tokens: 50 },
+        { runtime: fixedRuntime("x".repeat(401)) },
+      ),
+      "OUTPUT_LIMIT",
+    )
+    expect(error.message).toContain("max_tokens=50")
+  })
+
+  test("marks unavailable usage in the footer instead of inventing counts", async () => {
+    const runtime: ResearchRuntimeAdapter = {
+      async run() {
+        return {
+          content: "Answer",
+          model: "google/test-model",
+          input_tokens: 0,
+          output_tokens: 0,
+          usage_available: false,
+        }
+      },
+    }
+    const result = await research({ prompt: "query" }, { runtime })
+    expect(formatResearchResult(result)).toContain("usage:unavailable")
+  })
+})
+
+describe("isolated OpenCode runtime adapter", () => {
+  test("uses canonical tier routing, a private prompt artifact, and the no-tools profile", async () => {
+    const root = await temporaryDirectory("aidevops-ai-research-runtime-")
+    const project = join(root, "project")
+    const tempRoot = join(root, "managed-temp")
+    await mkdir(project, { recursive: true })
+    let requestFile = ""
+
+    const adapter = createOpenCodeRuntimeAdapter({
+      helperPath: "/fixture/headless-runtime-helper.sh",
+      tempRoot,
+      env: {
+        AIDEVOPS_DISPATCH_LEASE_TOKEN: "parent-lease",
+        AIDEVOPS_PERMISSION_GRANT_FILE: "/parent/grant.json",
+        AIDEVOPS_WORKTREE_OWNER_SESSION: "issue-28661",
+        WORKER_ISSUE_NUMBER: "28661",
+        WORKER_WORKTREE_PATH: project,
+      },
+      commandRunner: async invocation => {
+        expect(invocation.command.slice(0, 2)).toEqual([
+          "/fixture/headless-runtime-helper.sh",
+          "run",
+        ])
+        expect(invocation.command).toContain("triage")
+        expect(invocation.command).toContain("simple")
+        expect(invocation.command).toContain("research-only")
+        expect(invocation.command).not.toContain("anthropic")
+        expect(invocation.env.AIDEVOPS_AI_RESEARCH_TOOL_CEILING).toBe("1")
+        expect(invocation.env.AIDEVOPS_HEADLESS_AUTH_ISOLATION).toBe("1")
+        for (const lifecycleKey of [
+          "AIDEVOPS_DISPATCH_LEASE_TOKEN",
+          "AIDEVOPS_PERMISSION_GRANT_FILE",
+          "AIDEVOPS_WORKTREE_OWNER_SESSION",
+          "WORKER_ISSUE_NUMBER",
+          "WORKER_WORKTREE_PATH",
+        ]) {
+          expect(invocation.env[lifecycleKey]).toBeUndefined()
+        }
+
+        requestFile = invocation.command[invocation.command.indexOf("--prompt-file") + 1]
+        const isolatedDirectory = invocation.command[invocation.command.indexOf("--dir") + 1]
+        expect(isolatedDirectory).toBe(invocation.cwd)
+        expect(isolatedDirectory).not.toBe(project)
+        expect(requestFile.startsWith(`${isolatedDirectory}/`)).toBe(true)
+        const requestStat = await stat(requestFile)
+        expect(requestStat.mode & 0o777).toBe(0o600)
+        const document = await readFile(requestFile, "utf8")
+        expect(document).toContain("Use the supplied fixture context.")
+        expect(document).toContain("Return the key fact.")
+        expect(document).toContain("headless nested inference call")
+        expect(document).toContain("approximately 100 tokens")
+
+        return commandResult({
+          stderr: "[lifecycle] post_model_select session=test model=openai/gpt-test pid=1",
+          stdout: JSON.stringify({ type: "text", part: { text: "OpenAI-only answer" } }),
+        })
+      },
+    })
+
+    const result = await adapter.run(runtimeRequest({ cwd: project }))
+    expect(result.content).toBe("OpenAI-only answer")
+    expect(result.model).toBe("openai/gpt-test")
+    await expect(access(requestFile)).rejects.toThrow()
+  })
+
+  test("maps auth failures without returning credential-bearing output", async () => {
+    const root = await temporaryDirectory("aidevops-ai-research-auth-")
+    const adapter = createOpenCodeRuntimeAdapter({
+      tempRoot: root,
+      commandRunner: async () => commandResult({
+        exitCode: 1,
+        stderr: "Unauthorized credential secret-value-must-not-escape",
+      }),
+    })
+    const error = await expectRuntimeError(adapter.run(runtimeRequest()), "AUTH_FAILED")
+    expect(error.message).toContain("opencode auth")
+    expect(error.message).not.toContain("secret-value-must-not-escape")
+  })
+
+  test("distinguishes model resolution, provider, and model failures", async () => {
+    const resolutionRoot = await temporaryDirectory("aidevops-ai-research-resolution-")
+    const resolutionAdapter = createOpenCodeRuntimeAdapter({
+      tempRoot: resolutionRoot,
+      commandRunner: async () => commandResult({ exitCode: 1, stderr: "No available model" }),
+    })
+    await expectRuntimeError(resolutionAdapter.run(runtimeRequest()), "MODEL_RESOLUTION_FAILED")
+
+    const providerRoot = await temporaryDirectory("aidevops-ai-research-provider-")
+    const providerAdapter = createOpenCodeRuntimeAdapter({
+      tempRoot: providerRoot,
+      commandRunner: async () => commandResult({ exitCode: 1, stderr: "Provider unavailable" }),
+    })
+    await expectRuntimeError(providerAdapter.run(runtimeRequest()), "PROVIDER_FAILED")
+
+    const modelRoot = await temporaryDirectory("aidevops-ai-research-model-")
+    const modelAdapter = createOpenCodeRuntimeAdapter({
+      tempRoot: modelRoot,
+      commandRunner: async () => commandResult({ exitCode: 1, stderr: "Model not found" }),
+    })
+    await expectRuntimeError(modelAdapter.run(runtimeRequest()), "MODEL_FAILED")
+  })
+
+  test("returns bounded timeout and transport-limit diagnostics", async () => {
+    const timeoutRoot = await temporaryDirectory("aidevops-ai-research-timeout-")
+    const timeoutAdapter = createOpenCodeRuntimeAdapter({
+      tempRoot: timeoutRoot,
+      timeoutMs: 1234,
+      commandRunner: async () => commandResult({ timedOut: true, exitCode: 143 }),
+    })
+    const timeoutError = await expectRuntimeError(
+      timeoutAdapter.run(runtimeRequest()),
+      "RUNTIME_TIMEOUT",
+    )
+    expect(timeoutError.message).toContain("1 seconds")
+
+    const outputRoot = await temporaryDirectory("aidevops-ai-research-output-")
+    const outputAdapter = createOpenCodeRuntimeAdapter({
+      tempRoot: outputRoot,
+      commandRunner: async () => commandResult({
+        outputLimitExceeded: true,
+        exitCode: 143,
+      }),
+    })
+    await expectRuntimeError(outputAdapter.run(runtimeRequest()), "OUTPUT_LIMIT")
+  })
+
+  test("reports a missing runtime helper without leaking spawn details", async () => {
+    const root = await temporaryDirectory("aidevops-ai-research-missing-")
+    const adapter = createOpenCodeRuntimeAdapter({
+      tempRoot: root,
+      commandRunner: async () => commandResult({ spawnFailed: true, exitCode: 127 }),
+    })
+    const error = await expectRuntimeError(
+      adapter.run(runtimeRequest()),
+      "RUNTIME_UNAVAILABLE",
+    )
+    expect(error.message).toContain("headless runtime helper")
+  })
+})

--- a/.opencode/lib/ai-research.test.ts
+++ b/.opencode/lib/ai-research.test.ts
@@ -177,8 +177,10 @@ describe("OpenCode event parsing", () => {
   })
 
   test("reports unavailable usage honestly when events omit it", () => {
+    const ansiEscape = String.fromCharCode(27)
     const output = [
-      "[lifecycle] post_model_select session=test model=zai-coding-plan/glm-test pid=1",
+      `${ansiEscape}[32m[lifecycle] post_model_select ` +
+        `session=test model=zai-coding-plan/glm-test pid=1${ansiEscape}[0m`,
       JSON.stringify({ type: "text", part: { text: "Provider-neutral answer" } }),
     ].join("\n")
     const result = parseOpenCodeRuntimeOutput(output)

--- a/.opencode/lib/ai-research.ts
+++ b/.opencode/lib/ai-research.ts
@@ -126,6 +126,10 @@ const OUTPUT_CHARACTERS_PER_TOKEN_CEILING = 8
 const DEFAULT_RUNTIME_TIMEOUT_MS = 120_000
 const MIN_TRANSPORT_OUTPUT_BYTES = 64 * 1024
 const MAX_TRANSPORT_OUTPUT_BYTES = 1024 * 1024
+const ANSI_ESCAPE_PATTERN = new RegExp(
+  `${String.fromCharCode(27)}\\[[0-9;?]*[ -/]*[@-~]`,
+  "g",
+)
 const NESTED_LIFECYCLE_ENV_KEYS = [
   "AIDEVOPS_ATTEMPT_ID",
   "AIDEVOPS_ATTEMPT_STARTED_AT",
@@ -554,7 +558,7 @@ function transportOutputLimit(maxTokens: number): number {
 }
 
 function stripAnsi(value: string): string {
-  return value.replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, "")
+  return value.replace(ANSI_ESCAPE_PATTERN, "")
 }
 
 type JsonRecord = Record<string, unknown>

--- a/.opencode/lib/ai-research.ts
+++ b/.opencode/lib/ai-research.ts
@@ -716,15 +716,15 @@ export function createOpenCodeRuntimeAdapter(
 
       await mkdir(tempRoot, { recursive: true, mode: 0o700 })
       const requestDir = await mkdtemp(join(tempRoot, "ai-research-"))
-      await chmod(requestDir, 0o700)
       const requestFile = join(requestDir, "request.md")
-      await writeFile(requestFile, runtimeDocument(request), {
-        encoding: "utf8",
-        flag: "wx",
-        mode: 0o600,
-      })
 
       try {
+        await chmod(requestDir, 0o700)
+        await writeFile(requestFile, runtimeDocument(request), {
+          encoding: "utf8",
+          flag: "wx",
+          mode: 0o600,
+        })
         const sessionKey = `ai-research-${process.pid}-${randomUUID().replaceAll("-", "")}`
         const result = await runner({
           command: [

--- a/.opencode/lib/ai-research.ts
+++ b/.opencode/lib/ai-research.ts
@@ -1,29 +1,30 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
 /**
- * AI Research - Lightweight sub-worker for OpenCode workers
+ * Provider-neutral AI research runtime for OpenCode.
  *
- * Spawns focused research queries via the Anthropic API without burning
- * the caller's context window. Accepts agent files as system context so
- * the sub-worker inherits domain expertise.
- *
- * Key features:
- * - Domain shorthand auto-resolves to relevant agents via subagent-index.toon
- * - Extracts AI-CONTEXT-START/END sections to minimise tokens
- * - Rate-limited to 10 calls per session
- * - Auth: reads OAuth token from ~/.local/share/opencode/auth.json (primary),
- *   falls back to ANTHROPIC_API_KEY env var. OAuth uses the anthropic-beta
- *   header (oauth-2025-04-20) for direct API access.
+ * The parent tool assembles bounded context, then delegates inference to an
+ * isolated OpenCode child through the canonical headless runtime. OpenCode owns
+ * provider selection and credentials; this module never reads or writes auth
+ * files and never calls a provider endpoint directly.
  */
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+import { randomUUID } from "node:crypto"
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { homedir } from "node:os"
+import { isAbsolute, join, resolve as resolvePath } from "node:path"
+
+export type CanonicalResearchTier = "simple" | "standard" | "thinking"
+export type LegacyResearchModel = "haiku" | "sonnet" | "opus"
+export type ResearchModel = CanonicalResearchTier | LegacyResearchModel
 
 export interface ResearchRequest {
   prompt: string
   agents?: string[]
   domain?: string
   files?: string[]
-  model?: "haiku" | "sonnet" | "opus"
+  model?: ResearchModel
   max_tokens?: number
 }
 
@@ -32,27 +33,139 @@ export interface ResearchResult {
   model: string
   input_tokens: number
   output_tokens: number
+  usage_available: boolean
+  max_tokens_exact: false
   calls_remaining: number
 }
 
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
+export interface ResearchRuntimeRequest {
+  prompt: string
+  systemPrompt: string
+  tier: CanonicalResearchTier
+  maxTokens: number
+  cwd: string
+  signal?: AbortSignal
+}
 
-const AGENTS_BASE = `${process.env.HOME || "~"}/.aidevops/agents`
+export interface ResearchRuntimeResult {
+  content: string
+  model: string
+  input_tokens: number
+  output_tokens: number
+  usage_available: boolean
+}
 
-const MODEL_MAP: Record<string, string> = {
-  haiku: "claude-haiku-4-5",
-  sonnet: "claude-sonnet-4-6",
-  opus: "claude-opus-4-6",
+export interface ResearchRuntimeAdapter {
+  run(request: ResearchRuntimeRequest): Promise<ResearchRuntimeResult>
+}
+
+export interface CommandInvocation {
+  command: string[]
+  cwd: string
+  env: Record<string, string>
+  timeoutMs: number
+  maxOutputBytes: number
+  signal?: AbortSignal
+}
+
+export interface CommandResult {
+  stdout: string
+  stderr: string
+  exitCode: number
+  timedOut: boolean
+  aborted: boolean
+  outputLimitExceeded: boolean
+  spawnFailed: boolean
+}
+
+export type CommandRunner = (invocation: CommandInvocation) => Promise<CommandResult>
+
+export interface OpenCodeRuntimeOptions {
+  commandRunner?: CommandRunner
+  env?: Record<string, string | undefined>
+  helperPath?: string
+  tempRoot?: string
+  timeoutMs?: number
+}
+
+export interface ResearchOptions {
+  runtime?: ResearchRuntimeAdapter
+  cwd?: string
+  agentsBase?: string
+  signal?: AbortSignal
+  runtimeOptions?: OpenCodeRuntimeOptions
+}
+
+export type ResearchRuntimeErrorCode =
+  | "RUNTIME_UNAVAILABLE"
+  | "MODEL_RESOLUTION_FAILED"
+  | "AUTH_FAILED"
+  | "PROVIDER_FAILED"
+  | "MODEL_FAILED"
+  | "RUNTIME_FAILED"
+  | "RUNTIME_TIMEOUT"
+  | "RUNTIME_CANCELLED"
+  | "RUNTIME_PARSE_FAILED"
+  | "OUTPUT_LIMIT"
+
+export class ResearchRuntimeError extends Error {
+  readonly code: ResearchRuntimeErrorCode
+
+  constructor(code: ResearchRuntimeErrorCode, message: string) {
+    super(message)
+    this.name = "ResearchRuntimeError"
+    this.code = code
+  }
 }
 
 const MAX_CALLS_PER_SESSION = 10
+const DEFAULT_MAX_TOKENS = 500
+const MIN_MAX_TOKENS = 50
+const MAX_MAX_TOKENS = 4096
+const OUTPUT_CHARACTERS_PER_TOKEN_CEILING = 8
+const DEFAULT_RUNTIME_TIMEOUT_MS = 120_000
+const MIN_TRANSPORT_OUTPUT_BYTES = 64 * 1024
+const MAX_TRANSPORT_OUTPUT_BYTES = 1024 * 1024
+const NESTED_LIFECYCLE_ENV_KEYS = [
+  "AIDEVOPS_ATTEMPT_ID",
+  "AIDEVOPS_ATTEMPT_STARTED_AT",
+  "AIDEVOPS_CORRELATION_ID",
+  "AIDEVOPS_DISPATCH_LEASE_DEVICE",
+  "AIDEVOPS_DISPATCH_LEASE_TOKEN",
+  "AIDEVOPS_PARENT_WORKER_ID",
+  "AIDEVOPS_PERMISSION_GRANT_FILE",
+  "AIDEVOPS_PERMISSION_REQUEST_ID",
+  "AIDEVOPS_ROOT_WORKER_ID",
+  "AIDEVOPS_RUN_ID",
+  "AIDEVOPS_VERBOSE_LIFECYCLE",
+  "AIDEVOPS_WORKER_ID",
+  "AIDEVOPS_WORKER_PREFLIGHT_SENTINEL",
+  "AIDEVOPS_WORKER_PREWARM_DIR",
+  "AIDEVOPS_WORKTREE_OWNER_PATH",
+  "AIDEVOPS_WORKTREE_OWNER_PID",
+  "AIDEVOPS_WORKTREE_OWNER_SESSION",
+  "AIDEVOPS_WORKTREE_OWNER_TASK",
+  "AIDEVOPS_WORKTREE_OWNER_TRANSFER_MODE",
+  "DISPATCH_REPO_SLUG",
+  "WORKER_ISSUE_NUMBER",
+  "WORKER_NO_EXIT_PUSH",
+  "WORKER_REPO_SLUG",
+  "WORKER_TARGET_BRANCH",
+  "WORKER_WORKTREE_PATH",
+  "_WORKER_WORKTREE_PATH",
+] as const
+
+const MODEL_ALIASES: Record<ResearchModel, CanonicalResearchTier> = {
+  simple: "simple",
+  standard: "standard",
+  thinking: "thinking",
+  haiku: "simple",
+  sonnet: "standard",
+  opus: "thinking",
+}
 
 /**
- * Compact domain -> agent file mapping.
- * Derived from subagent-index.toon. Each domain resolves to 1-3 key agent
- * files that give the sub-worker enough context for that domain.
+ * Compact domain -> agent file mapping derived from subagent-index.toon.
  */
 export const DOMAIN_AGENTS: Record<string, string[]> = {
   git: [
@@ -94,22 +207,13 @@ export const DOMAIN_AGENTS: Record<string, string[]> = {
     "tools/voice/speech-to-speech.md",
     "tools/voice/voice-bridge.md",
   ],
-  mobile: [
-    "tools/mobile/agent-device.md",
-    "tools/mobile/maestro.md",
-  ],
-  mcp: [
-    "tools/build-mcp/build-mcp.md",
-    "tools/build-mcp/server-patterns.md",
-  ],
+  mobile: ["tools/mobile/agent-device.md", "tools/mobile/maestro.md"],
+  mcp: ["tools/build-mcp/build-mcp.md", "tools/build-mcp/server-patterns.md"],
   agent: [
     "tools/build-agent/build-agent.md",
     "tools/build-agent/agent-review.md",
   ],
-  framework: [
-    "aidevops/architecture.md",
-    "aidevops/setup.md",
-  ],
+  framework: ["aidevops/architecture.md", "aidevops/setup.md"],
   hosting: [
     "services/hosting/hostinger.md",
     "services/hosting/cloudflare.md",
@@ -124,25 +228,16 @@ export const DOMAIN_AGENTS: Record<string, string[]> = {
     "services/accessibility/accessibility-audit.md",
   ],
   containers: ["tools/containers/orbstack.md"],
-  orchestration: [
-    "tools/ai-assistants/headless-dispatch.md",
-  ],
+  orchestration: ["tools/ai-assistants/headless-dispatch.md"],
   context: [
     "tools/context/model-routing.md",
     "tools/context/toon.md",
     "tools/context/mcp-discovery.md",
   ],
-  vision: [
-    "tools/vision/overview.md",
-    "tools/vision/image-generation.md",
-  ],
+  vision: ["tools/vision/overview.md", "tools/vision/image-generation.md"],
   release: ["workflows/release.md", "workflows/version-bump.md"],
   pr: ["workflows/pr.md", "workflows/preflight.md"],
 }
-
-// ---------------------------------------------------------------------------
-// Session-scoped rate limiter
-// ---------------------------------------------------------------------------
 
 let callCount = 0
 
@@ -150,7 +245,7 @@ function checkRateLimit(): void {
   if (callCount >= MAX_CALLS_PER_SESSION) {
     throw new Error(
       `Rate limit reached: ${MAX_CALLS_PER_SESSION} ai-research calls per session. ` +
-        "Consolidate your queries or start a new session."
+        "Consolidate your queries or start a new session.",
     )
   }
   callCount++
@@ -164,352 +259,594 @@ export function resetRateLimit(): void {
   callCount = 0
 }
 
-// ---------------------------------------------------------------------------
-// Agent file loading
-// ---------------------------------------------------------------------------
+export function normalizeResearchTier(model: string | undefined): CanonicalResearchTier {
+  const requested = model || "simple"
+  const tier = MODEL_ALIASES[requested as ResearchModel]
+  if (!tier) {
+    throw new Error(
+      `Unknown model tier: ${requested}. Use canonical tiers simple, standard, thinking, ` +
+        "or the legacy aliases haiku, sonnet, opus.",
+    )
+  }
+  return tier
+}
 
-/**
- * Extract content between AI-CONTEXT-START and AI-CONTEXT-END markers.
- * Falls back to full content if markers are absent.
- */
+export function normalizeMaxTokens(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_MAX_TOKENS
+  if (!Number.isFinite(value)) throw new Error("max_tokens must be a finite number")
+  return Math.min(Math.max(Math.trunc(value), MIN_MAX_TOKENS), MAX_MAX_TOKENS)
+}
+
+/** Extract AI-specific context markers, falling back to the full source. */
 export function extractAIContext(content: string): string {
   const startMarker = "<!-- AI-CONTEXT-START -->"
   const endMarker = "<!-- AI-CONTEXT-END -->"
-
   const startIdx = content.indexOf(startMarker)
   if (startIdx === -1) return content
-
   const endIdx = content.indexOf(endMarker, startIdx)
   if (endIdx === -1) return content
-
   return content.slice(startIdx + startMarker.length, endIdx).trim()
 }
 
-/**
- * Load an agent file, extracting AI-CONTEXT section if present.
- * Paths are resolved relative to AGENTS_BASE.
- */
-async function loadAgentFile(path: string): Promise<string | null> {
-  const fullPath = path.startsWith("/") ? path : `${AGENTS_BASE}/${path}`
-  const file = Bun.file(fullPath)
-
-  if (!(await file.exists())) return null
-
-  const content = await file.text()
-  return extractAIContext(content)
-}
-
-/**
- * Resolve domain shorthand to agent file paths.
- */
 export function resolveDomain(domain: string): string[] {
   const key = domain.toLowerCase().replace(/[^a-z]/g, "")
   return DOMAIN_AGENTS[key] || []
 }
 
-/**
- * Load a file with optional line range (format: "path:10-50" or "path:10").
- */
-async function loadFileWithRange(spec: string): Promise<string | null> {
+function defaultAgentsBase(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.AIDEVOPS_ACTIVE_AGENTS_DIR) return env.AIDEVOPS_ACTIVE_AGENTS_DIR
+  const aidevopsDir = env.AIDEVOPS_DIR || join(env.HOME || homedir(), ".aidevops")
+  return join(aidevopsDir, "agents")
+}
+
+async function loadAgentFile(path: string, agentsBase: string): Promise<string | null> {
+  const fullPath = isAbsolute(path) ? path : join(agentsBase, path)
+  const file = Bun.file(fullPath)
+  if (!(await file.exists())) return null
+  return extractAIContext(await file.text())
+}
+
+async function loadFileWithRange(spec: string, cwd: string): Promise<string | null> {
   const match = spec.match(/^(.+?)(?::(\d+)(?:-(\d+))?)?$/)
   if (!match) return null
 
-  const [, filePath, startLine, endLine] = match
-  const file = Bun.file(filePath)
-
+  const [, requestedPath, startLine, endLine] = match
+  const fullPath = isAbsolute(requestedPath)
+    ? requestedPath
+    : resolvePath(cwd, requestedPath)
+  const file = Bun.file(fullPath)
   if (!(await file.exists())) return null
 
   const content = await file.text()
-
   if (!startLine) return content
 
   const lines = content.split("\n")
-  const start = Math.max(0, parseInt(startLine, 10) - 1)
-  const end = endLine ? parseInt(endLine, 10) : start + 1
-
+  const start = Math.max(0, Number.parseInt(startLine, 10) - 1)
+  const end = endLine ? Number.parseInt(endLine, 10) : start + 1
   return lines.slice(start, end).join("\n")
 }
 
-// ---------------------------------------------------------------------------
-// System prompt assembly
-// ---------------------------------------------------------------------------
-
 const BASE_INSTRUCTION =
   "You are a focused research sub-worker. Answer the query concisely " +
-  "using the provided context. Do not explain your reasoning process " +
-  "unless asked. Return actionable information: file paths, line numbers, " +
-  "function names, config values, or brief explanations."
+  "using only the supplied context and your model knowledge. Do not use tools, " +
+  "ask follow-up questions, or explain your reasoning process unless asked. " +
+  "Return actionable information: file paths, line numbers, function names, " +
+  "config values, or brief explanations."
 
-async function buildDomainSection(domain: string): Promise<string[]> {
+async function buildDomainSection(domain: string, agentsBase: string): Promise<string[]> {
   const parts: string[] = []
-  const domainPaths = resolveDomain(domain)
-  for (const p of domainPaths) {
-    const content = await loadAgentFile(p)
-    if (content) parts.push(`--- ${p} ---\n${content}`)
+  for (const path of resolveDomain(domain)) {
+    const content = await loadAgentFile(path, agentsBase)
+    if (content) parts.push(`--- ${path} ---\n${content}`)
   }
   return parts
 }
 
-async function buildAgentsSection(agents: string[]): Promise<string[]> {
+async function buildAgentsSection(agents: string[], agentsBase: string): Promise<string[]> {
   const parts: string[] = []
-  for (const a of agents) {
-    const content = await loadAgentFile(a)
-    if (content) parts.push(`--- ${a} ---\n${content}`)
+  for (const path of agents) {
+    const content = await loadAgentFile(path, agentsBase)
+    if (content) parts.push(`--- ${path} ---\n${content}`)
   }
   return parts
 }
 
-async function buildFilesSection(files: string[]): Promise<string[]> {
+async function buildFilesSection(files: string[], cwd: string): Promise<string[]> {
   const parts: string[] = []
-  for (const f of files) {
-    const content = await loadFileWithRange(f)
-    if (content) parts.push(`--- ${f} ---\n${content}`)
+  for (const spec of files) {
+    const content = await loadFileWithRange(spec, cwd)
+    if (content) parts.push(`--- ${spec} ---\n${content}`)
   }
   return parts
 }
 
-async function buildSystemPrompt(
-  agents?: string[],
-  domain?: string,
-  files?: string[]
+export async function buildSystemPrompt(
+  request: Pick<ResearchRequest, "agents" | "domain" | "files">,
+  options: Pick<ResearchOptions, "agentsBase" | "cwd"> = {},
 ): Promise<string> {
+  const cwd = options.cwd || process.cwd()
+  const agentsBase = options.agentsBase || defaultAgentsBase()
   const parts: string[] = [BASE_INSTRUCTION]
 
-  if (domain) parts.push(...await buildDomainSection(domain))
-  if (agents?.length) parts.push(...await buildAgentsSection(agents))
-  if (files?.length) parts.push(...await buildFilesSection(files))
-
+  if (request.domain) parts.push(...await buildDomainSection(request.domain, agentsBase))
+  if (request.agents?.length) {
+    parts.push(...await buildAgentsSection(request.agents, agentsBase))
+  }
+  if (request.files?.length) parts.push(...await buildFilesSection(request.files, cwd))
   return parts.join("\n\n")
 }
 
-// ---------------------------------------------------------------------------
-// OAuth token management
-// ---------------------------------------------------------------------------
-
-const AUTH_FILE = `${process.env.HOME || "~"}/.local/share/opencode/auth.json`
-const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-const OAUTH_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
-const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
-
-interface OAuthAuth {
-  type: "oauth"
-  refresh: string
-  access: string
-  expires: number
-}
-
-interface ApiAuth {
-  type: "api"
-  key: string
-}
-
-type AuthEntry = OAuthAuth | ApiAuth
-
-/**
- * Read the Anthropic auth entry from OpenCode's auth.json.
- * Returns null if the file doesn't exist or has no anthropic entry.
- */
-async function readAuthFile(): Promise<AuthEntry | null> {
-  try {
-    const file = Bun.file(AUTH_FILE)
-    if (!(await file.exists())) return null
-    const data = await file.json()
-    return data.anthropic || null
-  } catch {
-    return null
+function createEnvironment(
+  overrides: Record<string, string | undefined> = {},
+): Record<string, string> {
+  const environment: Record<string, string> = {}
+  for (const [name, value] of Object.entries(process.env)) {
+    if (value !== undefined) environment[name] = value
   }
+  for (const [name, value] of Object.entries(overrides)) {
+    if (value === undefined) delete environment[name]
+    else environment[name] = value
+  }
+  return environment
 }
 
-/**
- * Refresh an expired OAuth access token using the refresh token.
- * Updates auth.json with the new tokens.
- */
-async function refreshOAuthToken(auth: OAuthAuth): Promise<string> {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 15_000)
-  let response: Response
-  try {
-    response = await fetch(
-      OAUTH_TOKEN_URL,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          grant_type: "refresh_token",
-          refresh_token: auth.refresh,
-          client_id: OAUTH_CLIENT_ID,
-        }),
-        signal: controller.signal,
+function nestedRuntimeEnvironment(
+  overrides: Record<string, string | undefined>,
+): Record<string, string> {
+  const environment = createEnvironment(overrides)
+  for (const name of NESTED_LIFECYCLE_ENV_KEYS) delete environment[name]
+  return environment
+}
+
+async function readLimitedStream(
+  stream: ReadableStream<Uint8Array>,
+  limit: number,
+  onLimit: () => void,
+): Promise<string> {
+  const reader = stream.getReader()
+  const chunks: Uint8Array[] = []
+  let storedBytes = 0
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    const remaining = limit - storedBytes
+    if (value.byteLength > remaining) {
+      if (remaining > 0) {
+        chunks.push(value.slice(0, remaining))
+        storedBytes += remaining
       }
-    )
+      onLimit()
+      await reader.cancel()
+      break
+    }
+    chunks.push(value)
+    storedBytes += value.byteLength
+  }
+
+  const merged = new Uint8Array(storedBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    merged.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return new TextDecoder().decode(merged)
+}
+
+export const runCommand: CommandRunner = async invocation => {
+  if (invocation.signal?.aborted) {
+    return {
+      stdout: "",
+      stderr: "",
+      exitCode: 130,
+      timedOut: false,
+      aborted: true,
+      outputLimitExceeded: false,
+      spawnFailed: false,
+    }
+  }
+
+  let child: ReturnType<typeof Bun.spawn>
+  try {
+    child = Bun.spawn(invocation.command, {
+      cwd: invocation.cwd,
+      env: invocation.env,
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+  } catch {
+    return {
+      stdout: "",
+      stderr: "",
+      exitCode: 127,
+      timedOut: false,
+      aborted: false,
+      outputLimitExceeded: false,
+      spawnFailed: true,
+    }
+  }
+
+  let timedOut = false
+  let aborted = false
+  let outputLimitExceeded = false
+  const stop = () => {
+    if (child.exitCode === null) child.kill()
+  }
+  const timeout = setTimeout(() => {
+    timedOut = true
+    stop()
+  }, invocation.timeoutMs)
+  const abort = () => {
+    aborted = true
+    stop()
+  }
+  invocation.signal?.addEventListener("abort", abort, { once: true })
+  const markOutputLimit = () => {
+    outputLimitExceeded = true
+    stop()
+  }
+
+  try {
+    const [stdout, stderr, exitCode] = await Promise.all([
+      readLimitedStream(
+        child.stdout as ReadableStream<Uint8Array>,
+        invocation.maxOutputBytes,
+        markOutputLimit,
+      ),
+      readLimitedStream(
+        child.stderr as ReadableStream<Uint8Array>,
+        invocation.maxOutputBytes,
+        markOutputLimit,
+      ),
+      child.exited,
+    ])
+    return {
+      stdout,
+      stderr,
+      exitCode,
+      timedOut,
+      aborted,
+      outputLimitExceeded,
+      spawnFailed: false,
+    }
   } finally {
     clearTimeout(timeout)
+    invocation.signal?.removeEventListener("abort", abort)
   }
-
-  if (!response.ok) {
-    throw new Error(`OAuth token refresh failed (${response.status})`)
-  }
-
-  const json = (await response.json()) as {
-    access_token: string
-    refresh_token: string
-    expires_in: number
-  }
-
-  // Update auth.json with new tokens
-  try {
-    const file = Bun.file(AUTH_FILE)
-    const data = await file.json()
-    data.anthropic = {
-      type: "oauth",
-      refresh: json.refresh_token,
-      access: json.access_token,
-      expires: Date.now() + json.expires_in * 1000,
-    }
-    await Bun.write(AUTH_FILE, JSON.stringify(data, null, 2))
-  } catch (err) {
-    // Non-fatal: token still works for this request even if we can't persist.
-    // Log so persistent write failures are visible (e.g., permissions, disk full).
-    console.error(`[ai-research] Warning: failed to persist refreshed OAuth token: ${err}`)
-  }
-
-  return json.access_token
 }
 
-// ---------------------------------------------------------------------------
-// Auth resolution
-// ---------------------------------------------------------------------------
-
-interface ResolvedAuth {
-  method: "oauth" | "api-key"
-  token: string
+function runtimeDocument(request: ResearchRuntimeRequest): string {
+  return [
+    "# Focused AI research request",
+    "",
+    "The child runtime has no tools. Use only this attached request and model knowledge.",
+    "This is a headless nested inference call, not an interactive conversation. " +
+      "Do not emit a session greeting, version or status banner, progress update, " +
+      "or invitation for follow-up.",
+    `Keep the answer within approximately ${request.maxTokens} tokens. ` +
+      "The provider-neutral OpenCode adapter treats this as an instruction and " +
+      "applies a conservative transport ceiling because exact provider output-token " +
+      "controls are not exposed consistently.",
+    "",
+    "## System context",
+    request.systemPrompt,
+    "",
+    "## Query",
+    request.prompt,
+  ].join("\n")
 }
 
-/**
- * Resolve authentication. Priority:
- * 1. OAuth from auth.json (primary — no API key needed)
- * 2. ANTHROPIC_API_KEY env var (fallback)
- */
-async function resolveAuth(): Promise<ResolvedAuth> {
-  // Try OAuth from auth.json first
-  const auth = await readAuthFile()
+function defaultRuntimeHelperPath(env: Record<string, string>): string {
+  const aidevopsDir = env.AIDEVOPS_DIR || join(env.HOME || homedir(), ".aidevops")
+  return join(aidevopsDir, "agents", "scripts", "headless-runtime-helper.sh")
+}
 
-  if (auth?.type === "oauth") {
-    let accessToken = auth.access
-    // Refresh 5 minutes before expiry to avoid using near-expired tokens
-    const EXPIRY_BUFFER_MS = 5 * 60 * 1000
-    if (!accessToken || auth.expires < Date.now() + EXPIRY_BUFFER_MS) {
-      accessToken = await refreshOAuthToken(auth)
-    }
-    return { method: "oauth", token: accessToken }
-  }
+function defaultTempRoot(env: Record<string, string>): string {
+  return env.AIDEVOPS_TEMP_DIR ||
+    join(env.HOME || homedir(), ".aidevops", ".agent-workspace", "tmp")
+}
 
-  // auth.json has an API key entry
-  if (auth?.type === "api" && (auth as ApiAuth).key) {
-    return { method: "api-key", token: (auth as ApiAuth).key }
-  }
-
-  // Fall back to env var
-  const envKey = process.env.ANTHROPIC_API_KEY
-  if (envKey) {
-    return { method: "api-key", token: envKey }
-  }
-
-  throw new Error(
-    "No Anthropic auth found. Either:\n" +
-      "  1. Run `opencode auth` to set up OAuth (recommended)\n" +
-      "  2. Set ANTHROPIC_API_KEY environment variable"
+function transportOutputLimit(maxTokens: number): number {
+  return Math.min(
+    MAX_TRANSPORT_OUTPUT_BYTES,
+    Math.max(MIN_TRANSPORT_OUTPUT_BYTES, maxTokens * 64),
   )
 }
 
-// ---------------------------------------------------------------------------
-// Anthropic API call
-// ---------------------------------------------------------------------------
+function stripAnsi(value: string): string {
+  return value.replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, "")
+}
 
-/**
- * Call the Anthropic Messages API with resolved auth.
- * OAuth uses Bearer token + anthropic-beta header.
- * API key uses x-api-key header.
- */
-async function callAnthropic(
-  req: ResearchRequest,
-  auth: ResolvedAuth,
-  modelId: string,
-  systemPrompt: string
-): Promise<ResearchResult> {
-  const maxTokens = req.max_tokens || 500
+type JsonRecord = Record<string, unknown>
 
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    "anthropic-version": "2023-06-01",
+function asRecord(value: unknown): JsonRecord | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as JsonRecord
+    : null
+}
+
+function stringValue(record: JsonRecord, ...keys: string[]): string {
+  for (const key of keys) {
+    if (typeof record[key] === "string" && record[key]) return record[key] as string
+  }
+  return ""
+}
+
+function numberValue(record: JsonRecord, ...keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === "number" && Number.isFinite(value)) return value
+  }
+  return undefined
+}
+
+function modelFromRecord(record: JsonRecord): string {
+  const nested = asRecord(record.model)
+  const provider = stringValue(record, "providerID", "provider") ||
+    (nested ? stringValue(nested, "providerID", "provider") : "")
+  const model = stringValue(record, "modelID") ||
+    (nested ? stringValue(nested, "modelID", "id") : "")
+  if (!model) return ""
+  return model.includes("/") || !provider ? model : `${provider}/${model}`
+}
+
+function usageFromRecord(record: JsonRecord): {
+  input: number
+  output: number
+} | null {
+  const tokens = asRecord(record.tokens)
+  const usage = asRecord(record.usage)
+  const source = tokens || usage
+  if (!source) return null
+  const input = numberValue(source, "input", "input_tokens", "prompt_tokens")
+  const output = numberValue(source, "output", "output_tokens", "completion_tokens")
+  if (input === undefined && output === undefined) return null
+  return { input: Math.max(0, input || 0), output: Math.max(0, output || 0) }
+}
+
+export function parseOpenCodeRuntimeOutput(rawOutput: string): ResearchRuntimeResult {
+  const cleanOutput = stripAnsi(rawOutput)
+  const texts: string[] = []
+  let model = ""
+  let inputTokens = 0
+  let outputTokens = 0
+  let usageAvailable = false
+
+  for (const line of cleanOutput.split("\n")) {
+    const selectedModel = line.match(/post_model_select\b[^\n]*\bmodel=([^\s]+)/)?.[1]
+    if (selectedModel) model = selectedModel
+
+    const trimmed = line.trim()
+    if (!trimmed.startsWith("{")) continue
+    let event: JsonRecord
+    try {
+      const parsed = asRecord(JSON.parse(trimmed))
+      if (!parsed) continue
+      event = parsed
+    } catch {
+      continue
+    }
+
+    const part = asRecord(event.part)
+    const eventType = stringValue(event, "type")
+    const partType = part ? stringValue(part, "type") : ""
+    const text = part ? stringValue(part, "text") : stringValue(event, "text")
+    if (text && (eventType === "text" || partType === "text")) texts.push(text)
+
+    const records = [part, asRecord(event.info), asRecord(event.message), event]
+      .filter((record): record is JsonRecord => record !== null)
+    for (const record of records) {
+      const discoveredModel = modelFromRecord(record)
+      if (discoveredModel) model = discoveredModel
+      const usage = usageFromRecord(record)
+      if (usage) {
+        inputTokens = usage.input
+        outputTokens = usage.output
+        usageAvailable = true
+      }
+    }
   }
 
-  let url = ANTHROPIC_API_URL
-
-  if (auth.method === "oauth") {
-    headers["authorization"] = `Bearer ${auth.token}`
-    headers["anthropic-beta"] = "oauth-2025-04-20"
-    url += "?beta=true"
-  } else {
-    headers["x-api-key"] = auth.token
+  const content = texts.join("\n").trim()
+  if (!content) {
+    throw new ResearchRuntimeError(
+      "RUNTIME_PARSE_FAILED",
+      "OpenCode completed without a parseable research response. Retry the query " +
+        "or inspect the OpenCode runtime logs.",
+    )
   }
-
-  const response = await fetch(url, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({
-      model: modelId,
-      max_tokens: maxTokens,
-      system: systemPrompt,
-      messages: [{ role: "user", content: req.prompt }],
-    }),
-  })
-
-  if (!response.ok) {
-    const body = await response.text()
-    throw new Error(`Anthropic API error (${response.status}): ${body}`)
-  }
-
-  const data = (await response.json()) as {
-    content: Array<{ type: string; text: string }>
-    usage: { input_tokens: number; output_tokens: number }
-  }
-
-  const text = data.content
-    .filter((c) => c.type === "text")
-    .map((c) => c.text)
-    .join("")
 
   return {
-    content: text,
-    model: modelId,
-    input_tokens: data.usage.input_tokens,
-    output_tokens: data.usage.output_tokens,
+    content,
+    model: model || "runtime-selected",
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    usage_available: usageAvailable,
+  }
+}
+
+function runtimeFailure(result: CommandResult, tier: CanonicalResearchTier): ResearchRuntimeError {
+  const diagnostic = `${result.stdout}\n${result.stderr}`.toLowerCase()
+  if (/no (configured |available )?model|failed to resolve[^\n]*model/.test(diagnostic)) {
+    return new ResearchRuntimeError(
+      "MODEL_RESOLUTION_FAILED",
+      `No configured OpenCode model is available for the ${tier} tier. ` +
+        "Authenticate a supported provider or update the canonical routing table.",
+    )
+  }
+  if (/unauthori[sz]ed|authentication|credential|no auth|sign in|http 401|http 403/.test(diagnostic)) {
+    return new ResearchRuntimeError(
+      "AUTH_FAILED",
+      `OpenCode could not authenticate an available provider for the ${tier} tier. ` +
+        "Run `opencode auth` for a supported provider and retry.",
+    )
+  }
+  if (/provider[^\n]*(not found|unsupported|unavailable|disabled)|no available provider/.test(diagnostic)) {
+    return new ResearchRuntimeError(
+      "PROVIDER_FAILED",
+      `OpenCode could not run an available provider for the ${tier} tier. ` +
+        "Check provider availability and canonical routing, then retry.",
+    )
+  }
+  if (/model[^\n]*(not found|unsupported|unavailable)/.test(diagnostic)) {
+    return new ResearchRuntimeError(
+      "MODEL_FAILED",
+      `OpenCode could not run an available model for the ${tier} tier. ` +
+        "Check the canonical routing table and configured provider models.",
+    )
+  }
+  return new ResearchRuntimeError(
+    "RUNTIME_FAILED",
+    `OpenCode research failed for the ${tier} tier. Retry the query or inspect ` +
+      "credential-free OpenCode runtime diagnostics.",
+  )
+}
+
+export function createOpenCodeRuntimeAdapter(
+  options: OpenCodeRuntimeOptions = {},
+): ResearchRuntimeAdapter {
+  const runner = options.commandRunner || runCommand
+
+  return {
+    async run(request): Promise<ResearchRuntimeResult> {
+      const environment = createEnvironment(options.env)
+      const helperPath = options.helperPath || defaultRuntimeHelperPath(environment)
+      const tempRoot = options.tempRoot || defaultTempRoot(environment)
+      const timeoutMs = options.timeoutMs || DEFAULT_RUNTIME_TIMEOUT_MS
+
+      await mkdir(tempRoot, { recursive: true, mode: 0o700 })
+      const requestDir = await mkdtemp(join(tempRoot, "ai-research-"))
+      await chmod(requestDir, 0o700)
+      const requestFile = join(requestDir, "request.md")
+      await writeFile(requestFile, runtimeDocument(request), {
+        encoding: "utf8",
+        flag: "wx",
+        mode: 0o600,
+      })
+
+      try {
+        const sessionKey = `ai-research-${process.pid}-${randomUUID().replaceAll("-", "")}`
+        const result = await runner({
+          command: [
+            helperPath,
+            "run",
+            "--role",
+            "triage",
+            "--session-key",
+            sessionKey,
+            "--dir",
+            requestDir,
+            "--title",
+            `AI research (${request.tier})`,
+            "--prompt-file",
+            requestFile,
+            "--tier",
+            request.tier,
+            "--agent",
+            "research-only",
+            "--runtime",
+            "opencode",
+          ],
+          cwd: requestDir,
+          env: nestedRuntimeEnvironment({
+            ...options.env,
+            AIDEVOPS_AI_RESEARCH_TOOL_CEILING: "1",
+            AIDEVOPS_HEADLESS: "1",
+            AIDEVOPS_HEADLESS_AUTH_ISOLATION: "1",
+            AIDEVOPS_SESSION_ORIGIN: "ai-research",
+          }),
+          timeoutMs,
+          maxOutputBytes: transportOutputLimit(request.maxTokens),
+          signal: request.signal,
+        })
+
+        if (result.spawnFailed) {
+          throw new ResearchRuntimeError(
+            "RUNTIME_UNAVAILABLE",
+            "The canonical OpenCode headless runtime helper is unavailable. " +
+              "Deploy aidevops and confirm OpenCode is installed, then retry.",
+          )
+        }
+        if (result.aborted) {
+          throw new ResearchRuntimeError(
+            "RUNTIME_CANCELLED",
+            "The OpenCode research request was cancelled before completion.",
+          )
+        }
+        if (result.timedOut) {
+          throw new ResearchRuntimeError(
+            "RUNTIME_TIMEOUT",
+            `OpenCode research exceeded ${Math.round(timeoutMs / 1000)} seconds. ` +
+              "Narrow the query or retry with a lower workload tier.",
+          )
+        }
+        if (result.outputLimitExceeded) {
+          throw new ResearchRuntimeError(
+            "OUTPUT_LIMIT",
+            "OpenCode research exceeded the bounded transport output. Narrow the " +
+              "query or raise max_tokens within the 4096-token limit.",
+          )
+        }
+        if (result.exitCode !== 0) throw runtimeFailure(result, request.tier)
+        return parseOpenCodeRuntimeOutput(`${result.stderr}\n${result.stdout}`)
+      } finally {
+        await rm(requestDir, { recursive: true, force: true })
+      }
+    },
+  }
+}
+
+function enforceOutputCeiling(content: string, maxTokens: number): void {
+  const maximumCharacters = maxTokens * OUTPUT_CHARACTERS_PER_TOKEN_CEILING
+  if (Array.from(content).length <= maximumCharacters) return
+  throw new ResearchRuntimeError(
+    "OUTPUT_LIMIT",
+    `OpenCode returned more than the conservative ${maximumCharacters}-character ` +
+      `ceiling for max_tokens=${maxTokens}. Narrow the query or raise max_tokens.`,
+  )
+}
+
+export async function research(
+  request: ResearchRequest,
+  options: ResearchOptions = {},
+): Promise<ResearchResult> {
+  checkRateLimit()
+  if (!request.prompt.trim()) throw new Error("Research prompt is required")
+
+  const tier = normalizeResearchTier(request.model)
+  const maxTokens = normalizeMaxTokens(request.max_tokens)
+  const cwd = options.cwd || process.cwd()
+  const systemPrompt = await buildSystemPrompt(request, {
+    agentsBase: options.agentsBase,
+    cwd,
+  })
+  const runtime = options.runtime || createOpenCodeRuntimeAdapter(options.runtimeOptions)
+  const result = await runtime.run({
+    prompt: request.prompt,
+    systemPrompt,
+    tier,
+    maxTokens,
+    cwd,
+    signal: options.signal,
+  })
+  enforceOutputCeiling(result.content, maxTokens)
+
+  return {
+    ...result,
+    input_tokens: Math.max(0, Math.trunc(result.input_tokens || 0)),
+    output_tokens: Math.max(0, Math.trunc(result.output_tokens || 0)),
+    max_tokens_exact: false,
     calls_remaining: getCallsRemaining(),
   }
 }
 
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
-
-export async function research(req: ResearchRequest): Promise<ResearchResult> {
-  checkRateLimit()
-
-  const modelTier = req.model || "haiku"
-  const modelId = MODEL_MAP[modelTier]
-  if (!modelId) {
-    throw new Error(
-      `Unknown model tier: ${modelTier}. Use: haiku, sonnet, or opus`
-    )
-  }
-
-  const systemPrompt = await buildSystemPrompt(
-    req.agents,
-    req.domain,
-    req.files
+export function formatResearchResult(result: ResearchResult): string {
+  const usage = result.usage_available
+    ? `in:${result.input_tokens} out:${result.output_tokens}`
+    : "usage:unavailable"
+  return (
+    `${result.content}\n\n` +
+    `--- ai-research: ${result.model} | ${usage} | max_tokens:advisory | ` +
+    `${result.calls_remaining} calls remaining ---`
   )
-
-  const auth = await resolveAuth()
-  return callAnthropic(req, auth, modelId, systemPrompt)
 }

--- a/.opencode/tool/ai-research.ts
+++ b/.opencode/tool/ai-research.ts
@@ -1,9 +1,9 @@
 /**
  * AI Research Tool for OpenCode Workers
  *
- * Lightweight sub-worker that spawns focused research queries via the
- * Anthropic API without burning the caller's context window. Workers call
- * this to get domain-specific answers using agent files as system context.
+ * Lightweight sub-worker that routes focused research through OpenCode's
+ * configured providers without burning the caller's context window. Workers
+ * call this to get domain-specific answers using agent files as context.
  *
  * Rate limit: 10 calls per session.
  *
@@ -15,6 +15,7 @@
 
 import { tool } from "@opencode-ai/plugin"
 import {
+  formatResearchResult,
   research,
   getCallsRemaining,
   DOMAIN_AGENTS,
@@ -22,9 +23,9 @@ import {
 
 export default tool({
   description:
-    "Spawn a focused research query via Anthropic API without burning your context. " +
+    "Spawn a focused provider-neutral research query through OpenCode without burning your context. " +
     "Accepts agent files as system context for domain expertise. " +
-    "Rate limit: 10 calls per session. Default model: haiku (cheapest).",
+    "Rate limit: 10 calls per session. Default workload tier: simple.",
   args: {
     prompt: tool.schema
       .string()
@@ -52,17 +53,21 @@ export default tool({
           "(e.g. 'src/index.ts:10-50,README.md')"
       ),
     model: tool.schema
-      .enum(["haiku", "sonnet", "opus"])
+      .enum(["simple", "standard", "thinking", "haiku", "sonnet", "opus"])
       .optional()
       .describe(
-        "Model tier: haiku (default, cheapest), sonnet (code), opus (complex reasoning)"
+        "Workload tier: simple (default), standard, or thinking. " +
+          "Legacy aliases haiku, sonnet, and opus remain supported."
       ),
     max_tokens: tool.schema
       .number()
       .optional()
-      .describe("Max response tokens (default: 500, max: 4096)"),
+      .describe(
+        "Approximate response-token budget (default: 500, max: 4096). " +
+          "OpenCode providers may not expose exact output-token enforcement."
+      ),
   },
-  async execute(args) {
+  async execute(args, context) {
     try {
       // Parse comma-separated lists
       const agents = args.agents
@@ -82,16 +87,14 @@ export default tool({
         agents,
         domain: args.domain,
         files,
-        model: args.model as "haiku" | "sonnet" | "opus" | undefined,
+        model: args.model,
         max_tokens: maxTokens,
+      }, {
+        cwd: context.directory,
+        signal: context.abort,
       })
 
-      return (
-        `${result.content}\n\n` +
-        `--- ai-research: ${result.model} | ` +
-        `in:${result.input_tokens} out:${result.output_tokens} | ` +
-        `${result.calls_remaining} calls remaining ---`
-      )
+      return formatResearchResult(result)
     } catch (error) {
       const remaining = getCallsRemaining()
       const message = error instanceof Error ? error.message : String(error)

--- a/README.md
+++ b/README.md
@@ -554,6 +554,8 @@ See `.agents/tools/git/opencode-github-security.md` for the full security docume
 
 **Supported AI tool:** [OpenCode](https://opencode.ai/) is the recommended and tested AI coding tool for aidevops. All features, agents, and workflows are designed and tested for OpenCode first. We recommend OpenAI models for the best current results across all agent tiers: GPT-5.4 mini for fast triage/routine work and GPT-5.5 for complex implementation, review, and reasoning. [Claude](https://claude.ai/) models (Anthropic) remain fully supported, and other providers are tested as their capabilities change.
 
+The native `ai_research` tool uses OpenCode's configured providers and canonical `simple`, `standard`, and `thinking` workload tiers; it does not require a specific provider credential.
+
 **Recommended stack:**
 
 - **[OpenCode](https://opencode.ai/)** - The recommended AI coding agent. Powerful agentic TUI/CLI with native MCP support, Tab-based agent switching, LSP integration, plugin ecosystem, and excellent DX. All aidevops features are designed and tested for OpenCode first.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
     "types": ["bun"]
   },
   "include": [
+    ".opencode/lib/ai-research.ts",
+    ".opencode/lib/ai-research.test.ts",
     ".opencode/lib/session-rename-guards.ts",
     ".opencode/lib/session-title-suffix.ts",
     ".opencode/lib/terminal-title.ts",


### PR DESCRIPTION
## Summary

Route native ai_research inference through canonical OpenCode workload tiers with runtime-owned provider credentials, an inference-only child profile, isolated private context artifacts, legacy tier aliases, and provider-neutral diagnostics.

## Files Changed

.agents/aidevops/architecture.md, .agents/plugins/opencode-aidevops/config-hook.mjs, .agents/plugins/opencode-aidevops/tests/test-research-only-profile.mjs, .agents/prompts/worker-efficiency-protocol.md, .opencode/lib/ai-research.test.ts, .opencode/lib/ai-research.ts, .opencode/tool/ai-research.ts, README.md, tsconfig.json

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — 16 Bun tests; 3 Node profile-isolation tests; 6 shell OAuth-pool compatibility tests; root and native-tool TypeScript checks; explicit full local lint; OpenAI-only runtime smoke on openai/gpt-5.6-terra.

Resolves #28661


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.185 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 43m and 609,709 tokens on this with the user in an interactive session.