### PR TITLE
GH#28685: Aggregate authorized release sources

### DIFF
--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -59,6 +59,14 @@ rewriting the published branch. The follow-up commit message carries the same
 trailers so the repository's squash-merge commit preserves the reviewed
 manifest consumed by the release verifier.
 
+PR #28725 reviews this recovery manifest:
+
+```text
+Aidevops-Release-Aggregator-PR: 28725
+Aidevops-Release-Aggregates: 28701@a8f2cf28004aabdbd774cf3157d984eaafad7cee
+Aidevops-Release-Aggregates: 28720@00faf1c84be08457b27bd7ba64c8773b2837726c
+```
+
 Manual arbitrary-version package publication is intentionally unsupported. A
 recovery operation must use an existing tag that passes the same verifier.
 

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -52,6 +52,13 @@ commit. A failed pre-publication attempt records both the requested and current
 source SHAs as actionable failure evidence, but creates no tag or publication.
 Retries reconcile terminal receipts and cannot publish twice.
 
+The aggregation PR must expose a durable review record before merge. Create it
+as a draft from an initial documentation commit, then add the allocated PR
+number and every authorized `PR@MERGE_SHA` source in a follow-up commit without
+rewriting the published branch. The follow-up commit message carries the same
+trailers so the repository's squash-merge commit preserves the reviewed
+manifest consumed by the release verifier.
+
 Manual arbitrary-version package publication is intentionally unsupported. A
 recovery operation must use an existing tag that passes the same verifier.
 

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -57,7 +57,9 @@ as a draft from an initial documentation commit, then add the allocated PR
 number and every authorized `PR@MERGE_SHA` source in a follow-up commit without
 rewriting the published branch. The follow-up commit message carries the same
 trailers so the repository's squash-merge commit preserves the reviewed
-manifest consumed by the release verifier.
+manifest consumed by the release verifier. Keep the trailer lines contiguous in
+one terminal commit-message block so `git interpret-trailers --parse` retains
+the aggregator identity and every repeated source.
 
 PR #28725 reviews this recovery manifest:
 


### PR DESCRIPTION
## Summary

Create the reviewed release-aggregation source required to settle the authorized release lifecycles for PR #28701 and PR #28720 after intervening `main` commits.

The draft-first sequence records the allocated PR number and exact reviewed `PR@MERGE_SHA` manifest without rewriting the published branch.

## Authorized sources

- PR #28701 at `a8f2cf28004aabdbd774cf3157d984eaafad7cee`
- PR #28720 at `00faf1c84be08457b27bd7ba64c8773b2837726c`

## Verification

- Changed-file local gates: passed.
- `git interpret-trailers --parse` retains aggregator PR #28725 and both exact source entries.
- Required CI and review gates: pending.

Resolves #28685
Ref #28707
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.185 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 4h 28m and 706,878 tokens on this with the user in an interactive session.