### PR TITLE
GH#28665: stop post-merge deployment from pulling canonical main

### DIFF
--- a/.agents/scripts/deploy-agents-on-merge.sh
+++ b/.agents/scripts/deploy-agents-on-merge.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 #   --full              Run full setup.sh --non-interactive instead
 #   --dry-run           Show what would be deployed without doing it
 #   --diff <commit>     Validate/detect agent changes since <commit>
+#   --expected-sha <sha> Require the source checkout to match this exact commit
 #   --quiet             Suppress non-error output
 #   --help              Show this help
 #
@@ -65,6 +66,8 @@ SCRIPTS_ONLY=false
 FULL_DEPLOY=false
 DRY_RUN=false
 DIFF_COMMIT=""
+EXPECTED_SOURCE_SHA=""
+SOURCE_LOCK_DIR=""
 PLUGIN_NAMESPACES=()
 
 sanitize_plugin_namespace() {
@@ -101,14 +104,19 @@ collect_plugin_namespaces() {
 }
 
 parse_args() {
+	local arg=""
+	local option_value=""
+
 	while [[ $# -gt 0 ]]; do
-		case "$1" in
+		arg="$1"
+		case "$arg" in
 		--repo)
 			[[ $# -lt 2 ]] && {
 				log_error "--repo requires a path"
 				return 1
 			}
-			REPO_DIR="$2"
+			option_value="$2"
+			REPO_DIR="$option_value"
 			shift 2
 			;;
 		--scripts-only)
@@ -128,7 +136,17 @@ parse_args() {
 				log_error "--diff requires a commit"
 				return 1
 			}
-			DIFF_COMMIT="$2"
+			option_value="$2"
+			DIFF_COMMIT="$option_value"
+			shift 2
+			;;
+		--expected-sha)
+			[[ $# -lt 2 ]] && {
+				log_error "--expected-sha requires a full commit SHA"
+				return 1
+			}
+			option_value="$2"
+			EXPECTED_SOURCE_SHA="$option_value"
 			shift 2
 			;;
 		--quiet)
@@ -140,11 +158,122 @@ parse_args() {
 			exit 0
 			;;
 		*)
-			log_error "Unknown option: $1"
+			log_error "Unknown option: $arg"
 			return 1
 			;;
 		esac
 	done
+	return 0
+}
+
+release_source_lock() {
+	local lock_dir="${SOURCE_LOCK_DIR:-}"
+
+	if [[ -n "$lock_dir" && -d "$lock_dir" ]]; then
+		rmdir "$lock_dir" 2>/dev/null || true
+	fi
+	SOURCE_LOCK_DIR=""
+	return 0
+}
+
+acquire_source_lock() {
+	local git_dir=""
+	local common_dir=""
+
+	git_dir=$(git -C "$REPO_DIR" rev-parse --path-format=absolute --git-dir 2>/dev/null) || {
+		log_error "Cannot resolve source Git directory: $REPO_DIR"
+		return 1
+	}
+	common_dir=$(git -C "$REPO_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || {
+		log_error "Cannot resolve source Git common directory: $REPO_DIR"
+		return 1
+	}
+
+	if [[ "$git_dir" == "$common_dir" ]]; then
+		# Share the audited canonical-recovery lock so a concurrent mirror sync
+		# cannot change the source between exact-SHA validation and activation.
+		SOURCE_LOCK_DIR="$common_dir/aidevops-canonical-recovery.lock"
+	else
+		SOURCE_LOCK_DIR="$git_dir/aidevops-source-deploy.lock"
+	fi
+	if ! mkdir "$SOURCE_LOCK_DIR" 2>/dev/null; then
+		log_error "Source checkout is changing or another deployment is active; active bundle was not changed"
+		SOURCE_LOCK_DIR=""
+		return 1
+	fi
+	return 0
+}
+
+validate_source_provenance() {
+	local expected_sha="$EXPECTED_SOURCE_SHA"
+	local resolved_sha=""
+	local head_sha=""
+	local source_status=""
+	local git_dir=""
+	local common_dir=""
+	local current_branch=""
+	local branch_sha=""
+	local upstream_ref=""
+	local upstream_sha=""
+
+	if [[ ! "$expected_sha" =~ ^([0-9a-f]{40}|[0-9a-f]{64})$ ]]; then
+		log_error "Exact source provenance is required: pass --expected-sha with a full commit SHA"
+		return 1
+	fi
+	resolved_sha=$(git -C "$REPO_DIR" rev-parse --verify "${expected_sha}^{commit}" 2>/dev/null) || {
+		log_error "Expected source commit cannot be resolved: $expected_sha"
+		return 1
+	}
+	if [[ "$resolved_sha" != "$expected_sha" ]]; then
+		log_error "Expected source SHA is not the exact resolved commit: $expected_sha"
+		return 1
+	fi
+	head_sha=$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null) || {
+		log_error "Source checkout HEAD cannot be resolved"
+		return 1
+	}
+	if [[ "$head_sha" != "$expected_sha" ]]; then
+		log_error "Source checkout is stale: HEAD ${head_sha:0:12} does not match expected ${expected_sha:0:12}; active bundle was not changed"
+		return 1
+	fi
+	source_status=$(git -C "$REPO_DIR" status --porcelain=v1 --untracked-files=all 2>/dev/null) || {
+		log_error "Source checkout state cannot be inspected safely"
+		return 1
+	}
+	if [[ -n "$source_status" ]]; then
+		log_error "Source checkout is dirty; synchronize or use a clean immutable checkout before retrying. Active bundle was not changed"
+		return 1
+	fi
+
+	git_dir=$(git -C "$REPO_DIR" rev-parse --path-format=absolute --git-dir 2>/dev/null) || return 1
+	common_dir=$(git -C "$REPO_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+	if [[ "$git_dir" == "$common_dir" ]]; then
+		current_branch=$(git -C "$REPO_DIR" symbolic-ref --quiet --short HEAD 2>/dev/null) || {
+			log_error "Canonical deployment source is detached; active bundle was not changed"
+			return 1
+		}
+		branch_sha=$(git -C "$REPO_DIR" rev-parse --verify "refs/heads/${current_branch}^{commit}" 2>/dev/null) || {
+			log_error "Canonical deployment branch cannot be resolved: $current_branch"
+			return 1
+		}
+		if [[ "$branch_sha" != "$expected_sha" ]]; then
+			log_error "Canonical deployment branch changed during validation; active bundle was not changed"
+			return 1
+		fi
+		upstream_ref=$(git -C "$REPO_DIR" rev-parse --symbolic-full-name '@{upstream}' 2>/dev/null || true)
+		if [[ -n "$upstream_ref" ]]; then
+			upstream_sha=$(git -C "$REPO_DIR" rev-parse --verify "${upstream_ref}^{commit}" 2>/dev/null) || {
+				log_error "Canonical deployment upstream cannot be resolved: $upstream_ref"
+				return 1
+			}
+			if [[ "$upstream_sha" != "$expected_sha" ]]; then
+				log_error "Canonical deployment source diverges from $upstream_ref; run audited mirror synchronization before retrying"
+				return 1
+			fi
+		fi
+	fi
+
+	log_info "Verified immutable source commit ${expected_sha:0:12} before bundle staging"
 	return 0
 }
 
@@ -175,25 +304,6 @@ validate_stable_target() {
 		log_error "Refusing deployment outside the stable agents target: $TARGET_DIR"
 		return 1
 	fi
-	return 0
-}
-
-# Pull latest main (fast-forward only)
-pull_latest() {
-	local current_branch
-	current_branch=$(git -C "$REPO_DIR" branch --show-current 2>/dev/null || echo "")
-
-	if [[ "$current_branch" != "main" ]]; then
-		log_warn "Repo is on branch '$current_branch', not main — skipping pull"
-		return 0
-	fi
-
-	log_info "Pulling latest main..."
-	if ! git -C "$REPO_DIR" pull --ff-only origin main --quiet 2>/dev/null; then
-		log_warn "Fast-forward pull failed — trying regular pull"
-		git -C "$REPO_DIR" pull origin main --quiet 2>/dev/null || true
-	fi
-
 	return 0
 }
 
@@ -672,27 +782,39 @@ _run_dry_run_deploy() {
 
 main() {
 	local diff_exit=0
+	local deploy_exit=0
 
 	parse_args "$@" || return 1
 	validate_repo || return 1
 	validate_stable_target || return 1
 	collect_plugin_namespaces || return 1
+	acquire_source_lock || return 1
+	trap 'release_source_lock' EXIT
+	trap 'release_source_lock; exit 130' INT
+	trap 'release_source_lock; exit 143' TERM
+	if ! validate_source_provenance; then
+		release_source_lock
+		trap - EXIT INT TERM
+		return 1
+	fi
 	if [[ "$FULL_DEPLOY" == "true" ]]; then
-		_run_full_deploy
-		return $?
+		_run_full_deploy || deploy_exit=$?
+	elif [[ "$DRY_RUN" == "true" ]]; then
+		_run_dry_run_deploy || deploy_exit=$?
+	else
+		if [[ -n "$DIFF_COMMIT" ]]; then
+			_validate_transactional_diff || diff_exit=$?
+			if [[ "$diff_exit" -ne 0 ]]; then
+				deploy_exit="$diff_exit"
+			fi
+		fi
+		if [[ "$deploy_exit" -eq 0 ]]; then
+			run_transactional_incremental_deploy || deploy_exit=$?
+		fi
 	fi
-
-	pull_latest
-	if [[ "$DRY_RUN" == "true" ]]; then
-		_run_dry_run_deploy
-		return $?
-	fi
-	if [[ -n "$DIFF_COMMIT" ]]; then
-		_validate_transactional_diff || diff_exit=$?
-		[[ "$diff_exit" -eq 0 ]] || return "$diff_exit"
-	fi
-	run_transactional_incremental_deploy
-	return $?
+	release_source_lock
+	trap - EXIT INT TERM
+	return "$deploy_exit"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/.agents/scripts/github-cli-helper.sh
+++ b/.agents/scripts/github-cli-helper.sh
@@ -472,7 +472,12 @@ merge_pr() {
 
 	if [[ $merge_exit -eq 0 ]]; then
 		print_success "$SUCCESS_PR_MERGED"
-		trigger_aidevops_post_merge_sync "$owner/$repo_name"
+		local merged_sha=""
+		if ! merged_sha=$(resolve_merged_pr_sha "$owner/$repo_name" "$pr_number"); then
+			print_warning "Merged PR #$pr_number, but exact merged-commit provenance could not be verified; post-merge deployment was skipped"
+			return 0
+		fi
+		trigger_aidevops_post_merge_sync "$owner/$repo_name" "$merged_sha" "$pr_number"
 		return 0
 	fi
 
@@ -487,21 +492,66 @@ merge_pr() {
 	return 1
 }
 
+resolve_merged_pr_sha() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local pr_json=""
+
+	[[ "$pr_number" =~ ^[0-9]+$ ]] || return 1
+	pr_json=$(gh pr view "$pr_number" --repo "$repo_slug" \
+		--json state,mergedAt,mergeCommit 2>/dev/null) || return 1
+	printf '%s' "$pr_json" | jq -er '
+		select(.state == "MERGED")
+		| select((.mergedAt // "") | length > 0)
+		| .mergeCommit.oid
+		| select(test("^([0-9a-f]{40}|[0-9a-f]{64})$"))
+	'
+	return $?
+}
+
+is_canonical_aidevops_repo_dir() {
+	local candidate="$1"
+	local git_dir=""
+	local common_dir=""
+
+	[[ -d "$candidate/.agents" ]] || return 1
+	git_dir=$(git -C "$candidate" rev-parse --path-format=absolute --git-dir 2>/dev/null) || return 1
+	common_dir=$(git -C "$candidate" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+	[[ "$git_dir" == "$common_dir" ]] || return 1
+	return 0
+}
+
 resolve_aidevops_sync_repo_dir() {
-	if [[ -n "${AIDEVOPS_SYNC_REPO_PATH:-}" ]] && [[ -d "$AIDEVOPS_SYNC_REPO_PATH/.agents" ]]; then
+	if [[ -n "${AIDEVOPS_SYNC_REPO_PATH:-}" ]] && is_canonical_aidevops_repo_dir "$AIDEVOPS_SYNC_REPO_PATH"; then
 		printf '%s\n' "$AIDEVOPS_SYNC_REPO_PATH"
 		return 0
 	fi
 
-	local current_repo_root
+	local current_repo_root=""
+	local current_common_dir=""
+	local canonical_from_common=""
 	current_repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
-	if [[ -n "$current_repo_root" ]] && [[ "$(basename "$current_repo_root")" == "aidevops" ]] && [[ -d "$current_repo_root/.agents" ]]; then
+	if [[ -n "$current_repo_root" ]] && [[ "$(basename "$current_repo_root")" == "aidevops" ]] &&
+		is_canonical_aidevops_repo_dir "$current_repo_root"; then
 		printf '%s\n' "$current_repo_root"
 		return 0
 	fi
+	if [[ -n "$current_repo_root" ]]; then
+		current_common_dir=$(git -C "$current_repo_root" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+		case "$current_common_dir" in
+		*/.git)
+			canonical_from_common="${current_common_dir%/.git}"
+			if [[ "$(basename "$canonical_from_common")" == "aidevops" ]] &&
+				is_canonical_aidevops_repo_dir "$canonical_from_common"; then
+				printf '%s\n' "$canonical_from_common"
+				return 0
+			fi
+			;;
+		esac
+	fi
 
 	local default_repo_path="$HOME/Git/aidevops"
-	if [[ -d "$default_repo_path/.agents" ]]; then
+	if is_canonical_aidevops_repo_dir "$default_repo_path"; then
 		printf '%s\n' "$default_repo_path"
 		return 0
 	fi
@@ -511,14 +561,60 @@ resolve_aidevops_sync_repo_dir() {
 
 trigger_aidevops_post_merge_sync() {
 	local repo_slug="$1"
+	local expected_sha="${2:-}"
+	local pr_number="${3:-}"
 
 	if [[ "$repo_slug" != "marcusquinn/aidevops" ]]; then
+		return 0
+	fi
+	if [[ ! "$expected_sha" =~ ^([0-9a-f]{40}|[0-9a-f]{64})$ ]] || [[ ! "$pr_number" =~ ^[0-9]+$ ]]; then
+		print_warning "Post-merge aidevops sync requires an exact merged commit SHA and numeric PR reference; deployment was skipped"
 		return 0
 	fi
 
 	local repo_dir
 	if ! repo_dir=$(resolve_aidevops_sync_repo_dir); then
-		print_warning "Merged aidevops PR but could not locate local aidevops repo for sync"
+		print_warning "Merged aidevops PR but could not locate the canonical aidevops mirror for audited synchronization"
+		return 0
+	fi
+
+	local recovery_helper="${AIDEVOPS_SYNC_RECOVERY_HELPER:-$SCRIPT_DIR/canonical-recovery-helper.sh}"
+	if [[ ! -f "$recovery_helper" || ! -r "$recovery_helper" ]]; then
+		print_warning "Post-merge canonical recovery helper is unavailable; deployment was skipped: $recovery_helper"
+		return 0
+	fi
+	local canonical_branch=""
+	local pre_sync_status=""
+	canonical_branch=$(git -C "$repo_dir" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+	if ! pre_sync_status=$(git -C "$repo_dir" status --porcelain=v1 --untracked-files=all 2>/dev/null); then
+		print_warning "Post-merge canonical mirror status could not be inspected safely; deployment was skipped"
+		return 0
+	fi
+	if [[ -z "$canonical_branch" || -n "$pre_sync_status" ]]; then
+		print_warning "Post-merge canonical mirror is detached or dirty; deployment was skipped. Preserve and review local state, then use audited sync-mirror recovery explicitly"
+		return 0
+	fi
+	local recovery_output=""
+	local recovery_exit=0
+	recovery_output=$(bash "$recovery_helper" fast-forward-current \
+		--repo "$repo_dir" \
+		--branch "$canonical_branch" \
+		--issue "$pr_number" \
+		--confirm FAST_FORWARD_CANONICAL_BRANCH 2>&1) || recovery_exit=$?
+	if [[ "$recovery_exit" -ne 0 ]]; then
+		print_warning "Post-merge audited canonical fast-forward failed (non-blocking, active bundle preserved). Review local divergence and use sync-mirror recovery explicitly when preservation is required: $recovery_output"
+		return 0
+	fi
+
+	local synchronized_sha=""
+	local synchronized_status=""
+	synchronized_sha=$(git -C "$repo_dir" rev-parse HEAD 2>/dev/null || true)
+	if ! synchronized_status=$(git -C "$repo_dir" status --porcelain=v1 --untracked-files=all 2>/dev/null); then
+		print_warning "Post-merge canonical mirror status could not be verified after synchronization; deployment was skipped"
+		return 0
+	fi
+	if [[ "$synchronized_sha" != "$expected_sha" || -n "$synchronized_status" ]]; then
+		print_warning "Post-merge canonical mirror did not converge cleanly to expected commit ${expected_sha:0:12}; deployment was skipped and the active bundle was preserved"
 		return 0
 	fi
 
@@ -527,17 +623,41 @@ trigger_aidevops_post_merge_sync() {
 		print_warning "Post-merge sync script not found: $deploy_script"
 		return 0
 	fi
-
-	local sync_output=""
-	local sync_exit=0
-	sync_output=$(bash "$deploy_script" --repo "$repo_dir" --quiet 2>&1) || sync_exit=$?
-
-	if [[ "$sync_exit" -eq 0 || "$sync_exit" -eq 2 ]]; then
-		print_success "Post-merge aidevops agent sync completed"
+	local runtime_verifier="${AIDEVOPS_SYNC_RUNTIME_VERIFIER:-$SCRIPT_DIR/runtime-bundle-verifier.sh}"
+	if [[ ! -f "$runtime_verifier" || ! -r "$runtime_verifier" ]]; then
+		print_warning "Post-merge runtime bundle verifier is unavailable; deployment was skipped: $runtime_verifier"
+		return 0
+	fi
+	# shellcheck source=./runtime-bundle-verifier.sh disable=SC1090
+	if ! source "$runtime_verifier"; then
+		print_warning "Post-merge runtime bundle verifier could not be loaded; deployment was skipped"
 		return 0
 	fi
 
-	print_warning "Post-merge aidevops agent sync failed (non-blocking): $sync_output"
+	local sync_output=""
+	local sync_exit=0
+	sync_output=$(env -u AIDEVOPS_AGENTS_DIR -u AGENTS_DIR \
+		AIDEVOPS_DEPLOY_TARGET="$HOME/.aidevops/agents" \
+		bash "$deploy_script" --repo "$repo_dir" --expected-sha "$expected_sha" --quiet 2>&1) || sync_exit=$?
+
+	if [[ "$sync_exit" -ne 0 && "$sync_exit" -ne 2 ]]; then
+		print_warning "Post-merge aidevops agent sync failed (non-blocking, active bundle preserved): $sync_output"
+		return 0
+	fi
+	if ! verify_aidevops_runtime_bundle_convergence \
+		"$repo_dir" \
+		"$expected_sha" \
+		"$HOME/.aidevops/agents" \
+		"$HOME/.aidevops/.deployed-sha"; then
+		print_warning "Post-merge deployment returned exit $sync_exit but exact runtime convergence was not verified"
+		return 0
+	fi
+	if [[ "$sync_exit" -eq 2 ]]; then
+		print_success "Post-merge aidevops runtime was already converged to ${expected_sha:0:12} (verified no-op)"
+	else
+		print_success "Post-merge aidevops agent sync completed at ${expected_sha:0:12} with verified runtime convergence"
+	fi
+
 	return 0
 }
 

--- a/.agents/scripts/tests/test-agent-auto-sync.sh
+++ b/.agents/scripts/tests/test-agent-auto-sync.sh
@@ -14,6 +14,7 @@ TESTS_PASSED=0
 TESTS_FAILED=0
 TEST_DIR=""
 TEST_HOME=""
+TEST_REPO_SHA=""
 
 print_result() {
 	local test_name="$1"
@@ -34,12 +35,10 @@ print_result() {
 	return 0
 }
 
-setup() {
-	TEST_DIR=$(mktemp -d)
-	TEST_HOME="$TEST_DIR/home"
-	trap teardown EXIT
-	mkdir -p "$TEST_DIR/repo/.agents/scripts" "$TEST_HOME/.aidevops"
-	cat >"$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh" <<'EOF'
+write_mock_deploy_helper() {
+	local deploy_path="$1"
+
+	cat >"$deploy_path" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'AIDEVOPS_AGENTS_DIR=%s\n' "${AIDEVOPS_AGENTS_DIR-unset}" >>"${SYNC_ENV_LOG_PATH:?SYNC_ENV_LOG_PATH must be set}"
@@ -53,17 +52,23 @@ if [[ "${MOCK_DEPLOY_SKIP_ACTIVATION:-0}" == "1" ]]; then
 fi
 
 repo_root=""
+expected_sha=""
 while [[ $# -gt 0 ]]; do
 	case "$1" in
 	--repo)
 		repo_root="$2"
 		shift 2
 		;;
+	--expected-sha)
+		expected_sha="$2"
+		shift 2
+		;;
 	*) shift ;;
 	esac
 done
-[[ -n "$repo_root" ]]
+[[ -n "$repo_root" && -n "$expected_sha" ]]
 source_sha=$(git -C "$repo_root" rev-parse HEAD)
+[[ "$source_sha" == "$expected_sha" ]]
 bundle_sha="$source_sha"
 stamp_sha="$source_sha"
 if [[ "${MOCK_DEPLOY_MODE:-current}" == "stale-active" ]]; then
@@ -119,9 +124,90 @@ fi
 printf '%s\n' "$stamp_sha" >"$HOME/.aidevops/.deployed-sha"
 exit 0
 EOF
-	chmod +x "$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh"
+	chmod +x "$deploy_path"
+	return 0
+}
+
+create_sync_fixture_repo() {
+	local repo_root="$1"
+
+	mkdir -p "$repo_root/.agents/scripts/setup/modules"
+	write_mock_deploy_helper "$repo_root/.agents/scripts/deploy-agents-on-merge.sh"
+	printf '#!/usr/bin/env bash\nexit 0\n' >"$repo_root/setup.sh"
+	printf '#!/usr/bin/env bash\nprintf \"fixture cli\\n\"\n' >"$repo_root/aidevops.sh"
+	printf '9.9.9\n' >"$repo_root/VERSION"
+	printf 'release fixture\n' >"$repo_root/.agents/scripts/version-manager-release.sh"
+	printf 'verifier fixture\n' >"$repo_root/.agents/scripts/runtime-bundle-verifier.sh"
+	printf 'agent deploy fixture\n' >"$repo_root/.agents/scripts/setup/modules/agent-deploy.sh"
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git init -q "$repo_root"
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_root" config user.email test@example.invalid
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_root" config user.name Test
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_root" config commit.gpgsign false
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_root" add .
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_root" commit -qm fixture
+	TEST_REPO_SHA=$(PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_root" rev-parse HEAD)
+	return 0
+}
+
+write_mock_recovery_helper() {
+	local helper_path="$1"
+
+	cat >"$helper_path" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${SYNC_RECOVERY_LOG_PATH:?SYNC_RECOVERY_LOG_PATH must be set}"
+if [[ "${MOCK_RECOVERY_EXIT_CODE:-0}" -ne 0 ]]; then
+	exit "$MOCK_RECOVERY_EXIT_CODE"
+fi
+repo_root=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--repo)
+		repo_root="$2"
+		shift 2
+		;;
+	*) shift ;;
+	esac
+done
+[[ -n "$repo_root" ]]
+printf 'SYNCHRONIZED_CANONICAL_MIRROR=true\n'
+printf 'NEW_SHA=%s\n' "$(git -C "$repo_root" rev-parse HEAD)"
+exit 0
+EOF
+	chmod +x "$helper_path"
+	return 0
+}
+
+write_mock_git_wrapper() {
+	local git_path="$1"
+
+	cat >"$git_path" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+repo_root=""
+if [[ "${1:-}" == "-C" ]]; then
+	repo_root="${2:-}"
+fi
+if [[ "${MOCK_GIT_STATUS_FAIL:-0}" == "1" && "$repo_root" == "${SYNC_FIXTURE_REPO:-}" && "$*" == *" status "* ]]; then
+	exit 128
+fi
+exec /usr/bin/git "$@"
+EOF
+	chmod +x "$git_path"
+	return 0
+}
+
+setup() {
+	TEST_DIR=$(mktemp -d)
+	TEST_HOME="$TEST_DIR/home"
+	trap teardown EXIT
+	mkdir -p "$TEST_HOME/.aidevops" "$TEST_DIR/bin"
+	create_sync_fixture_repo "$TEST_DIR/repo"
+	write_mock_recovery_helper "$TEST_DIR/canonical-recovery-helper.sh"
+	write_mock_git_wrapper "$TEST_DIR/bin/git"
 	: >"$TEST_DIR/sync.log"
 	: >"$TEST_DIR/sync-env.log"
+	: >"$TEST_DIR/recovery.log"
 	return 0
 }
 
@@ -134,13 +220,22 @@ teardown() {
 
 invoke_github_sync() {
 	local repo_slug="$1"
+	local expected_sha="${2:-$TEST_REPO_SHA}"
+	local pr_number="${3:-28665}"
 	AIDEVOPS_SYNC_REPO_PATH="$TEST_DIR/repo" \
 		AIDEVOPS_SYNC_DEPLOY_SCRIPT="$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh" \
-		MOCK_DEPLOY_SKIP_ACTIVATION=1 \
+		AIDEVOPS_SYNC_RECOVERY_HELPER="$TEST_DIR/canonical-recovery-helper.sh" \
+		HOME="$TEST_HOME" \
+		PATH="$TEST_DIR/bin:$PATH" \
 		SYNC_LOG_PATH="$TEST_DIR/sync.log" \
 		SYNC_ENV_LOG_PATH="$TEST_DIR/sync-env.log" \
+		SYNC_RECOVERY_LOG_PATH="$TEST_DIR/recovery.log" \
+		SYNC_FIXTURE_REPO="$TEST_DIR/repo" \
+		MOCK_GIT_STATUS_FAIL="${MOCK_GIT_STATUS_FAIL:-0}" \
+		MOCK_RECOVERY_EXIT_CODE="${MOCK_RECOVERY_EXIT_CODE:-0}" \
 		MOCK_DEPLOY_EXIT_CODE="${MOCK_DEPLOY_EXIT_CODE:-0}" \
-		bash -c 'source "$1" && trigger_aidevops_post_merge_sync "$2"' _ "$GITHUB_HELPER" "$repo_slug"
+		bash -c 'source "$1" && trigger_aidevops_post_merge_sync "$2" "$3" "$4"' _ \
+		"$GITHUB_HELPER" "$repo_slug" "$expected_sha" "$pr_number"
 	return 0
 }
 
@@ -185,12 +280,159 @@ create_fake_repo() {
 
 test_merge_sync_triggers_for_aidevops() {
 	: >"$TEST_DIR/sync.log"
+	: >"$TEST_DIR/recovery.log"
 	invoke_github_sync "marcusquinn/aidevops"
 
-	if grep -q -- "--repo $TEST_DIR/repo --quiet" "$TEST_DIR/sync.log"; then
-		print_result "merge sync triggers for aidevops slug" 0
+	if grep -q -- "--repo $TEST_DIR/repo --expected-sha $TEST_REPO_SHA --quiet" "$TEST_DIR/sync.log" &&
+		grep -q -- "fast-forward-current --repo $TEST_DIR/repo --branch" "$TEST_DIR/recovery.log" &&
+		grep -q -- "--issue 28665 --confirm FAST_FORWARD_CANONICAL_BRANCH" "$TEST_DIR/recovery.log"; then
+		print_result "merge sync propagates exact SHA through audited canonical fast-forward and deployment" 0
 	else
-		print_result "merge sync triggers for aidevops slug" 1 "Sync command was not recorded"
+		print_result "merge sync propagates exact SHA through audited canonical fast-forward and deployment" 1 "Expected recovery or deployment arguments were not recorded"
+	fi
+	return 0
+}
+
+test_merge_pr_resolves_and_propagates_merge_sha() {
+	local propagation_log="$TEST_DIR/merge-propagation.log"
+	local output=""
+	: >"$propagation_log"
+	if ! output=$(MERGE_PROPAGATION_LOG="$propagation_log" MERGED_SHA="$TEST_REPO_SHA" \
+		bash -c '
+			source "$1"
+			get_account_config() {
+				local account_name="$1"
+				[[ -n "$account_name" ]] || return 1
+				printf "%s\n" "{\"owner\":\"marcusquinn\"}"
+				return 0
+			}
+			gh() {
+				local command_name="$1"
+				local subcommand_name="$2"
+				if [[ "$command_name" == "pr" && "$subcommand_name" == "merge" ]]; then
+					return 0
+				fi
+				if [[ "$command_name" == "pr" && "$subcommand_name" == "view" ]]; then
+					printf "{\"state\":\"MERGED\",\"mergedAt\":\"2026-07-27T00:00:00Z\",\"mergeCommit\":{\"oid\":\"%s\"}}\n" "$MERGED_SHA"
+					return 0
+				fi
+				return 1
+			}
+			trigger_aidevops_post_merge_sync() {
+				local repo_slug="$1"
+				local expected_sha="$2"
+				local pr_number="$3"
+				printf "%s|%s|%s\n" "$repo_slug" "$expected_sha" "$pr_number" >"$MERGE_PROPAGATION_LOG"
+				return 0
+			}
+			merge_pr fixture aidevops 77 squash
+		' _ "$GITHUB_HELPER" 2>&1); then
+		print_result "merge helper resolves the observed merge commit before post-merge sync" 1 "$output"
+		return 0
+	fi
+
+	local propagated=""
+	propagated=$(<"$propagation_log")
+	if [[ "$propagated" == "marcusquinn/aidevops|$TEST_REPO_SHA|77" ]]; then
+		print_result "merge helper resolves the observed merge commit before post-merge sync" 0
+	else
+		print_result "merge helper resolves the observed merge commit before post-merge sync" 1 "Propagated: $propagated"
+	fi
+	return 0
+}
+
+test_merge_sync_accepts_verified_noop() {
+	: >"$TEST_DIR/sync.log"
+	local output=""
+	output=$(MOCK_DEPLOY_EXIT_CODE=2 invoke_github_sync "marcusquinn/aidevops" 2>&1)
+
+	if [[ "$output" == *"verified no-op"* ]] &&
+		grep -q -- "--expected-sha $TEST_REPO_SHA" "$TEST_DIR/sync.log"; then
+		print_result "merge sync distinguishes a verified no-op from deployment failure" 0
+	else
+		print_result "merge sync distinguishes a verified no-op from deployment failure" 1 "$output"
+	fi
+	return 0
+}
+
+test_merge_sync_skips_after_failed_recovery() {
+	: >"$TEST_DIR/sync.log"
+	local active_before=""
+	local active_after=""
+	local output=""
+	active_before=$(cd "$TEST_HOME/.aidevops/agents" && pwd -P)
+	output=$(MOCK_RECOVERY_EXIT_CODE=1 invoke_github_sync "marcusquinn/aidevops" 2>&1)
+	active_after=$(cd "$TEST_HOME/.aidevops/agents" && pwd -P)
+
+	if [[ ! -s "$TEST_DIR/sync.log" && "$active_before" == "$active_after" &&
+		"$output" == *"canonical fast-forward failed"* ]]; then
+		print_result "failed audited synchronization preserves the active bundle and skips deployment" 0
+	else
+		print_result "failed audited synchronization preserves the active bundle and skips deployment" 1 "$output"
+	fi
+	return 0
+}
+
+test_merge_sync_skips_dirty_canonical_mirror() {
+	: >"$TEST_DIR/sync.log"
+	: >"$TEST_DIR/recovery.log"
+	local active_before=""
+	local active_after=""
+	local dirty_blob_before=""
+	local dirty_blob_after=""
+	local output=""
+	active_before=$(cd "$TEST_HOME/.aidevops/agents" && pwd -P)
+	printf '%s\n' '# unexpected canonical edit' >>"$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh"
+	dirty_blob_before=$(/usr/bin/git hash-object "$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh")
+	output=$(invoke_github_sync "marcusquinn/aidevops" 2>&1)
+	active_after=$(cd "$TEST_HOME/.aidevops/agents" && pwd -P)
+	dirty_blob_after=$(/usr/bin/git hash-object "$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh")
+	/usr/bin/git -C "$TEST_DIR/repo" checkout -- .agents/scripts/deploy-agents-on-merge.sh
+
+	if [[ ! -s "$TEST_DIR/sync.log" && ! -s "$TEST_DIR/recovery.log" &&
+		"$active_before" == "$active_after" && "$dirty_blob_before" == "$dirty_blob_after" &&
+		"$output" == *"detached or dirty"* ]]; then
+		print_result "dirty canonical mirror remains byte-preserved and never reaches synchronization or deployment" 0
+	else
+		print_result "dirty canonical mirror remains byte-preserved and never reaches synchronization or deployment" 1 "$output"
+	fi
+	return 0
+}
+
+test_merge_sync_fails_closed_when_status_is_unreadable() {
+	: >"$TEST_DIR/sync.log"
+	: >"$TEST_DIR/recovery.log"
+	local active_before=""
+	local active_after=""
+	local output=""
+	active_before=$(cd "$TEST_HOME/.aidevops/agents" && pwd -P)
+	output=$(MOCK_GIT_STATUS_FAIL=1 invoke_github_sync "marcusquinn/aidevops" 2>&1)
+	active_after=$(cd "$TEST_HOME/.aidevops/agents" && pwd -P)
+
+	if [[ ! -s "$TEST_DIR/sync.log" && ! -s "$TEST_DIR/recovery.log" &&
+		"$active_before" == "$active_after" && "$output" == *"status could not be inspected safely"* ]]; then
+		print_result "unreadable canonical status fails closed before synchronization or deployment" 0
+	else
+		print_result "unreadable canonical status fails closed before synchronization or deployment" 1 "$output"
+	fi
+	return 0
+}
+
+test_merge_sync_skips_concurrent_sha_mismatch() {
+	: >"$TEST_DIR/sync.log"
+	local active_before=""
+	local active_after=""
+	local output=""
+	local concurrent_sha="1111111111111111111111111111111111111111"
+	active_before=$(cd "$TEST_HOME/.aidevops/agents" && pwd -P)
+	output=$(invoke_github_sync "marcusquinn/aidevops" "$concurrent_sha" 28666 2>&1)
+	active_after=$(cd "$TEST_HOME/.aidevops/agents" && pwd -P)
+
+	if [[ ! -s "$TEST_DIR/sync.log" && "$active_before" == "$active_after" &&
+		"$output" == *"did not converge cleanly to expected commit"* ]]; then
+		print_result "post-sync SHA mismatch fails closed instead of deploying whichever commit is present" 0
+	else
+		print_result "post-sync SHA mismatch fails closed instead of deploying whichever commit is present" 1 "$output"
 	fi
 	return 0
 }
@@ -213,7 +455,7 @@ test_release_sync_triggers_for_aidevops_remote() {
 	repo_path=$(create_fake_repo "release-aidevops" "https://github.com/marcusquinn/aidevops.git")
 	invoke_release_sync "$repo_path"
 
-	if grep -q -- "--repo $repo_path --quiet" "$TEST_DIR/sync.log" && ! grep -q -- "--full" "$TEST_DIR/sync.log"; then
+	if grep -q -- "--repo $repo_path --quiet --expected-sha" "$TEST_DIR/sync.log" && ! grep -q -- "--full" "$TEST_DIR/sync.log"; then
 		print_result "release sync defaults to incremental for aidevops remote" 0
 	else
 		print_result "release sync triggers for aidevops remote" 1 "Release sync command was not recorded"
@@ -226,7 +468,7 @@ test_release_sync_explicit_full() {
 	local repo_path
 	repo_path=$(create_fake_repo "release-full" "https://github.com/marcusquinn/aidevops.git")
 	invoke_release_sync "$repo_path" full
-	if grep -q -- "--repo $repo_path --quiet --full" "$TEST_DIR/sync.log"; then
+	if grep -q -- "--repo $repo_path --quiet --full --expected-sha" "$TEST_DIR/sync.log"; then
 		print_result "release sync supports explicit full deployment" 0
 	else
 		print_result "release sync supports explicit full deployment" 1 "Full sync command was not recorded"
@@ -343,7 +585,13 @@ main() {
 	echo "Running agent auto-sync regression tests"
 	setup
 
+	test_merge_pr_resolves_and_propagates_merge_sha
 	test_merge_sync_triggers_for_aidevops
+	test_merge_sync_accepts_verified_noop
+	test_merge_sync_skips_after_failed_recovery
+	test_merge_sync_skips_dirty_canonical_mirror
+	test_merge_sync_fails_closed_when_status_is_unreadable
+	test_merge_sync_skips_concurrent_sha_mismatch
 	test_merge_sync_skips_other_repos
 	test_release_sync_triggers_for_aidevops_remote
 	test_release_sync_explicit_full

--- a/.agents/scripts/tests/test-incremental-deploy-runtime-config.sh
+++ b/.agents/scripts/tests/test-incremental-deploy-runtime-config.sh
@@ -20,8 +20,10 @@ cleanup() {
 trap cleanup EXIT
 
 mkdir -p "$FIXTURE_REPO/.agents/scripts" "$OLD_BUNDLE/scripts"
-git -C "$FIXTURE_REPO" init -q
-printf '%s\n' 'ref: refs/heads/fixture' >"$FIXTURE_REPO/.git/HEAD"
+/usr/bin/git -C "$FIXTURE_REPO" init -q
+/usr/bin/git -C "$FIXTURE_REPO" config user.email test@example.invalid
+/usr/bin/git -C "$FIXTURE_REPO" config user.name Test
+/usr/bin/git -C "$FIXTURE_REPO" config commit.gpgsign false
 printf '%s\n' '3.32.107' >"$FIXTURE_REPO/VERSION"
 printf '%s\n' 'old immutable sentinel' >"$OLD_BUNDLE/scripts/example-helper.sh"
 ln -s "$OLD_BUNDLE" "$TEST_HOME/.aidevops/agents"
@@ -62,11 +64,14 @@ fi
 exit 0
 EOF_SETUP
 chmod +x "$FIXTURE_REPO/setup.sh"
+/usr/bin/git -C "$FIXTURE_REPO" add .
+/usr/bin/git -C "$FIXTURE_REPO" commit -qm fixture
+SOURCE_SHA=$(/usr/bin/git -C "$FIXTURE_REPO" rev-parse HEAD)
 
 HOME="$TEST_HOME" SETUP_CALLS="$SETUP_CALLS" \
 	AIDEVOPS_AGENTS_DIR="$OLD_BUNDLE" AGENTS_DIR="$OLD_BUNDLE" \
 	bash "$REPO_ROOT/.agents/scripts/deploy-agents-on-merge.sh" \
-	--repo "$FIXTURE_REPO" --scripts-only --quiet
+	--repo "$FIXTURE_REPO" --expected-sha "$SOURCE_SHA" --scripts-only --quiet
 grep -Fxq 'all' "$MARKER"
 grep -Fxq -- '--stage ai-session' "$SETUP_CALLS"
 grep -Fxq 'AIDEVOPS_AGENTS_DIR=unset' "$SETUP_CALLS"
@@ -91,9 +96,12 @@ cat >"$FIXTURE_REPO/.agents/scripts/generate-runtime-config.sh" <<'EOF_FAILURE'
 #!/usr/bin/env bash
 exit 9
 EOF_FAILURE
+/usr/bin/git -C "$FIXTURE_REPO" add .agents/scripts/generate-runtime-config.sh
+/usr/bin/git -C "$FIXTURE_REPO" commit -qm "break runtime config fixture"
+SOURCE_SHA=$(/usr/bin/git -C "$FIXTURE_REPO" rev-parse HEAD)
 if HOME="$TEST_HOME" SETUP_CALLS="$SETUP_CALLS" \
 	bash "$REPO_ROOT/.agents/scripts/deploy-agents-on-merge.sh" \
-	--repo "$FIXTURE_REPO" --scripts-only --quiet; then
+	--repo "$FIXTURE_REPO" --expected-sha "$SOURCE_SHA" --scripts-only --quiet; then
 	printf '%s\n' 'FAIL: incremental deploy ignored runtime config regeneration failure' >&2
 	exit 1
 fi

--- a/.agents/scripts/version-manager-release.sh
+++ b/.agents/scripts/version-manager-release.sh
@@ -443,6 +443,7 @@ run_post_release_agent_sync() {
 		print_error "Post-release deployment gate cannot resolve the release checkout commit"
 		return 1
 	}
+	deploy_args+=(--expected-sha "$release_sha")
 
 	print_info "Running post-release aidevops agent sync..."
 	local sync_output=""
@@ -451,7 +452,7 @@ run_post_release_agent_sync() {
 		AIDEVOPS_DEPLOY_TARGET="$HOME/.aidevops/agents" \
 		bash "$deploy_script" "${deploy_args[@]}" 2>&1) || sync_exit=$?
 
-	if [[ "$sync_exit" -ne 0 ]]; then
+	if [[ "$sync_exit" -ne 0 && "$sync_exit" -ne 2 ]]; then
 		print_error "Post-release aidevops deployment or CLI convergence failed: $sync_output"
 		return 1
 	fi
@@ -464,7 +465,11 @@ run_post_release_agent_sync() {
 		return 1
 	fi
 
-	print_success "Post-release aidevops deployment and CLI convergence completed"
+	if [[ "$sync_exit" -eq 2 ]]; then
+		print_success "Post-release aidevops runtime was already converged to ${release_sha:0:12} (verified no-op)"
+	else
+		print_success "Post-release aidevops deployment and CLI convergence completed"
+	fi
 	return 0
 }
 

--- a/tests/test-deploy-agents-on-merge.sh
+++ b/tests/test-deploy-agents-on-merge.sh
@@ -55,6 +55,18 @@ assert_contains() {
 	return 0
 }
 
+assert_not_contains() {
+	local haystack="$1"
+	local needle="$2"
+	local name="$3"
+	if [[ "$haystack" != *"$needle"* ]]; then
+		pass "$name"
+	else
+		fail "$name" "Unexpected substring: $needle"
+	fi
+	return 0
+}
+
 create_base_repo() {
 	local dir="$1"
 	/usr/bin/git init "$dir" >/dev/null 2>&1
@@ -68,6 +80,11 @@ create_base_repo() {
 	cat >"$dir/setup.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ "${MOCK_REQUIRE_SOURCE_LOCK:-0}" == "1" ]]; then
+	[[ -d "$repo_root/.git/aidevops-canonical-recovery.lock" ]]
+	printf 'source-lock=held\n'
+fi
 printf 'setup:%s\n' "$*"
 [[ -z "${AIDEVOPS_AGENTS_DIR+x}" && -z "${AGENTS_DIR+x}" ]]
 exit "${MOCK_SETUP_EXIT_CODE:-0}"
@@ -80,8 +97,10 @@ EOF
 
 run_script() {
 	local repo="$1"
+	local expected_sha=""
 	shift
-	bash "$SCRIPT_PATH" --repo "$repo" "$@" 2>&1
+	expected_sha=$(/usr/bin/git -C "$repo" rev-parse HEAD)
+	bash "$SCRIPT_PATH" --repo "$repo" --expected-sha "$expected_sha" "$@" 2>&1
 	return $?
 }
 
@@ -116,6 +135,10 @@ if [[ "$1" == "-C" ]]; then
 	shift 2
 else
 	repo_path=""
+fi
+
+if [[ -n "${GIT_COMMAND_LOG:-}" ]]; then
+	printf '%s\n' "$*" >>"$GIT_COMMAND_LOG"
 fi
 
 if [[ "$1" == "diff" && "$2" == "--name-only" ]]; then
@@ -156,7 +179,93 @@ assert_eq "$changed_status" "0" "Changed script deploy exits with status 0"
 assert_contains "$changed_output" "using fast scripts-only deploy" "Changed script deploy selects scripts-only path"
 assert_contains "$changed_output" "setup:--stage ai-session" "Changed script deploy routes through transactional setup"
 
-# Test 4: Full deploy must isolate immutable session pins from setup.sh
+# Test 4: Exact source provenance is mandatory before any setup mutation
+TEST_REPO_REQUIRED="$TMP_DIR/repo-required"
+create_base_repo "$TEST_REPO_REQUIRED"
+
+set +e
+required_output="$(bash "$SCRIPT_PATH" --repo "$TEST_REPO_REQUIRED" --scripts-only --quiet 2>&1)"
+required_status=$?
+set -e
+
+assert_eq "$required_status" "1" "Missing --expected-sha fails before deployment"
+assert_contains "$required_output" "Exact source provenance is required" "Missing provenance reports the recovery contract"
+
+# Test 5: A stale expected SHA fails closed and preserves the active bundle
+TEST_REPO_STALE="$TMP_DIR/repo-stale"
+create_base_repo "$TEST_REPO_STALE"
+stale_expected=$(/usr/bin/git -C "$TEST_REPO_STALE" rev-parse HEAD)
+printf '%s\n' 'new source' >"$TEST_REPO_STALE/.agents/scripts/new.sh"
+/usr/bin/git -C "$TEST_REPO_STALE" add .agents/scripts/new.sh
+/usr/bin/git -C "$TEST_REPO_STALE" commit -m "advance source" >/dev/null 2>&1
+mkdir -p "$HOME/.aidevops/agents"
+printf '%s\n' 'active-before-stale-check' >"$HOME/.aidevops/agents/active-sentinel"
+
+set +e
+stale_output="$(bash "$SCRIPT_PATH" --repo "$TEST_REPO_STALE" --expected-sha "$stale_expected" --scripts-only --quiet 2>&1)"
+stale_status=$?
+set -e
+
+assert_eq "$stale_status" "1" "Stale source checkout fails closed"
+assert_contains "$stale_output" "Source checkout is stale" "Stale source reports exact-SHA mismatch"
+active_after_stale=$(<"$HOME/.aidevops/agents/active-sentinel")
+assert_eq "$active_after_stale" "active-before-stale-check" "Stale source leaves active bundle bytes unchanged"
+assert_not_contains "$stale_output" "setup:" "Stale source fails before setup staging"
+
+# Test 6: Dirty source state fails before activation
+TEST_REPO_DIRTY="$TMP_DIR/repo-dirty"
+create_base_repo "$TEST_REPO_DIRTY"
+dirty_expected=$(/usr/bin/git -C "$TEST_REPO_DIRTY" rev-parse HEAD)
+printf '%s\n' 'uncommitted source' >>"$TEST_REPO_DIRTY/.agents/scripts/example.sh"
+printf '%s\n' 'active-before-dirty-check' >"$HOME/.aidevops/agents/active-sentinel"
+
+set +e
+dirty_output="$(bash "$SCRIPT_PATH" --repo "$TEST_REPO_DIRTY" --expected-sha "$dirty_expected" --scripts-only --quiet 2>&1)"
+dirty_status=$?
+set -e
+
+assert_eq "$dirty_status" "1" "Dirty source checkout fails closed"
+assert_contains "$dirty_output" "Source checkout is dirty" "Dirty source reports provenance failure"
+active_after_dirty=$(<"$HOME/.aidevops/agents/active-sentinel")
+assert_eq "$active_after_dirty" "active-before-dirty-check" "Dirty source leaves active bundle bytes unchanged"
+assert_not_contains "$dirty_output" "setup:" "Dirty source fails before setup staging"
+
+# Test 7: Canonical source lock remains held through transactional setup
+TEST_REPO_LOCK="$TMP_DIR/repo-lock"
+create_base_repo "$TEST_REPO_LOCK"
+set +e
+lock_output="$(MOCK_REQUIRE_SOURCE_LOCK=1 run_script "$TEST_REPO_LOCK" --scripts-only)"
+lock_status=$?
+set -e
+
+assert_eq "$lock_status" "0" "Canonical source lock permits one deployment"
+assert_contains "$lock_output" "source-lock=held" "Canonical recovery lock is held through activation"
+
+# Test 8: Successful deployment performs no Git mutation command
+TEST_REPO_READ_ONLY="$TMP_DIR/repo-read-only"
+create_base_repo "$TEST_REPO_READ_ONLY"
+GIT_COMMAND_LOG="$TMP_DIR/git-commands.log"
+: >"$GIT_COMMAND_LOG"
+
+set +e
+read_only_output="$(GIT_COMMAND_LOG="$GIT_COMMAND_LOG" PATH="$FAKE_BIN:/usr/bin:/bin" run_script "$TEST_REPO_READ_ONLY" --scripts-only --quiet)"
+read_only_status=$?
+set -e
+
+assert_eq "$read_only_status" "0" "Read-only source deployment succeeds"
+git_commands=$(<"$GIT_COMMAND_LOG")
+forbidden_git_command=""
+while IFS= read -r git_command; do
+	case "$git_command" in
+	pull* | merge* | reset* | clean* | checkout* | switch* | worktree*)
+		forbidden_git_command="$git_command"
+		break
+		;;
+	esac
+done <<<"$git_commands"
+assert_eq "$forbidden_git_command" "" "Deployment executes no pull, merge, reset, clean, checkout, switch, or worktree mutation"
+
+# Test 9: Full deploy must isolate immutable session pins from setup.sh
 TEST_REPO_FULL="$TMP_DIR/repo-full"
 create_base_repo "$TEST_REPO_FULL"
 cat >"$TEST_REPO_FULL/setup.sh" <<'EOF'
@@ -164,6 +273,8 @@ cat >"$TEST_REPO_FULL/setup.sh" <<'EOF'
 [[ -z "${AIDEVOPS_AGENTS_DIR+x}" && -z "${AGENTS_DIR+x}" ]]
 EOF
 chmod +x "$TEST_REPO_FULL/setup.sh"
+/usr/bin/git -C "$TEST_REPO_FULL" add setup.sh
+/usr/bin/git -C "$TEST_REPO_FULL" commit -m "update full setup fixture" >/dev/null 2>&1
 
 set +e
 full_output="$(HOME="$TMP_DIR/home" AIDEVOPS_AGENTS_DIR="$TMP_DIR/home/.aidevops/runtime-bundles/old/agents" AGENTS_DIR="$TMP_DIR/home/.aidevops/runtime-bundles/old/agents" run_script "$TEST_REPO_FULL" --full)"
@@ -172,7 +283,7 @@ set -e
 
 assert_eq "$full_status" "0" "Full deploy unsets inherited runtime pins"
 
-# Test 5: Invalid stable HOME fails before setup mutation
+# Test 10: Invalid stable HOME fails before setup mutation
 set +e
 invalid_home_output="$(HOME='' AIDEVOPS_AGENTS_DIR="/tmp/runtime-bundles/old/agents" run_script "$TEST_REPO_FULL" --full)"
 invalid_home_status=$?


### PR DESCRIPTION
## Summary

Remove raw canonical pulls, route clean post-merge synchronization through the audited fast-forward helper, require an exact clean source SHA under a concurrency lock before staging, and verify exact runtime convergence including no-op deployments.

## Files Changed

.agents/scripts/deploy-agents-on-merge.sh, .agents/scripts/github-cli-helper.sh, .agents/scripts/tests/test-agent-auto-sync.sh, .agents/scripts/tests/test-incremental-deploy-runtime-config.sh, .agents/scripts/version-manager-release.sh, tests/test-deploy-agents-on-merge.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: deployment and post-merge fixture suites exercise exact-SHA propagation, dirty/stale/concurrent failure paths, immutable active-bundle preservation, release convergence, and transactional activation; ShellCheck, version validation, and changed-file local gates pass.

Resolves #28665


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.185 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 29m and 303,992 tokens on this with the user in an interactive session.