### PR TITLE
GH#28702: Add forensic OCR repair for mirrored and rotated PDFs

### DIFF
--- a/.agents/scripts/document-creation-convert-lib.sh
+++ b/.agents/scripts/document-creation-convert-lib.sh
@@ -353,7 +353,7 @@ _convert_ocr_preprocess() {
 		ocr_scanned_pdf "${_input}" "$provider" "$ocr_text"
 		printf -v "${input_ref}" '%s' "$ocr_text"
 		printf -v "${from_ext_ref}" '%s' "txt"
-		log_info "Proceeding with OCR text as input"
+		log_info "Proceeding with page-cited OCR text as input"
 	elif [[ "${_from_ext}" =~ ^(png|jpg|jpeg|tiff|tif|bmp|webp)$ ]]; then
 		local ocr_text="${ocr_work}/ocr-text-$$.txt"
 		log_info "Running OCR on image with ${provider}..."

--- a/.agents/scripts/document-creation-core-lib.sh
+++ b/.agents/scripts/document-creation-core-lib.sh
@@ -67,6 +67,29 @@ has_cmd() {
 	command -v "$bin_name" &>/dev/null
 }
 
+replace_file_atomically() {
+	local source="$1"
+	local destination="$2"
+
+	if ! has_cmd python3 || [[ ! -f "$source" ]] || [[ -d "$destination" ]]; then
+		return 1
+	fi
+	if python3 -c '
+import os
+import sys
+
+source, destination = sys.argv[1:3]
+if not os.path.isfile(source) or os.path.isdir(destination):
+    raise SystemExit(1)
+os.replace(source, destination)
+if not os.path.isfile(destination):
+    raise SystemExit(1)
+' "$source" "$destination"; then
+		return 0
+	fi
+	return 1
+}
+
 # Get human-readable file size without using ls (SC2012)
 human_filesize() {
 	local file="$1"
@@ -170,6 +193,102 @@ is_scanned_pdf() {
 	return 1 # Has text content
 }
 
+# Return the number of pages in a PDF.
+pdf_page_count() {
+	local file="$1"
+	local count=""
+
+	if ! has_cmd pdfinfo; then
+		return 1
+	fi
+	count=$(pdfinfo "$file" 2>/dev/null | awk '$1 == "Pages:" { value = $2 } END { print value }')
+	if [[ ! "$count" =~ ^[0-9]+$ ]] || [[ "$count" -lt 1 ]]; then
+		return 1
+	fi
+	printf '%s' "$count"
+	return 0
+}
+
+# Return one PDF page's width and height in points as WIDTHxHEIGHT.
+pdf_page_dimensions() {
+	local file="$1"
+	local page="$2"
+	local dimensions=""
+
+	if ! has_cmd pdfinfo; then
+		return 1
+	fi
+	dimensions=$(pdfinfo -f "$page" -l "$page" "$file" 2>/dev/null | awk -v expected="$page" '
+		BEGIN { one = 1; two = 2; three = 3; four = 4; five = 5; six = 6 }
+		$one == "Page" && $two == expected && $three == "size:" { print $four "x" $six; exit }
+		$one == "Page" && $two == "size:" { print $three "x" $five; exit }
+	')
+	if [[ ! "$dimensions" =~ ^[0-9]+([.][0-9]+)?x[0-9]+([.][0-9]+)?$ ]]; then
+		return 1
+	fi
+	printf '%s' "$dimensions"
+	return 0
+}
+
+# Extract one PDF page's text layer to a file.
+extract_pdf_page_text() {
+	local file="$1"
+	local page="$2"
+	local output="$3"
+
+	if ! has_cmd pdftotext; then
+		return 1
+	fi
+	if pdftotext -f "$page" -l "$page" "$file" "$output" 2>/dev/null; then
+		return 0
+	fi
+	return 1
+}
+
+# Render one complete PDF page rather than extracting its component images.
+render_pdf_page() {
+	local file="$1"
+	local page="$2"
+	local output_prefix="$3"
+	local dpi="${4:-300}"
+
+	if ! has_cmd pdftoppm; then
+		return 1
+	fi
+	if pdftoppm -f "$page" -l "$page" -singlefile -r "$dpi" -png \
+		"$file" "$output_prefix" >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
+# Report the local OCR backend version for provenance manifests.
+ocr_provider_version() {
+	local provider="$1"
+	local version="unknown"
+
+	case "$provider" in
+	tesseract)
+		if has_cmd tesseract; then
+			version=$(tesseract --version 2>&1 | awk 'NR == 1 { value = $0 } END { print value }')
+		fi
+		;;
+	easyocr)
+		if has_cmd python3; then
+			version=$(python3 -c 'import importlib.metadata; print(importlib.metadata.version("easyocr"))' 2>/dev/null || printf 'unknown')
+		fi
+		;;
+	glm-ocr)
+		if has_cmd ollama; then
+			version=$(ollama --version 2>/dev/null || printf 'unknown')
+		fi
+		;;
+	esac
+
+	printf '%s' "$version"
+	return 0
+}
+
 # Select the best available OCR provider
 select_ocr_provider() {
 	local preferred="${1:-auto}"
@@ -221,6 +340,7 @@ select_ocr_provider() {
 run_ocr() {
 	local image_file="$1"
 	local provider="$2"
+	local ocr_rc=0
 
 	case "${provider}" in
 	tesseract)
@@ -233,35 +353,51 @@ run_ocr() {
 			tess_input="${work_dir}/ocr-input-$$.$(get_ext "$image_file")"
 			cp "$image_file" "$tess_input"
 		fi
-		tesseract "$tess_input" stdout 2>/dev/null
+		if ! tesseract "$tess_input" stdout 2>/dev/null; then
+			ocr_rc=1
+		fi
 		# Clean up temp copy
 		if [[ "$tess_input" != "$image_file" ]]; then
 			rm -f "$tess_input"
 		fi
 		;;
 	easyocr)
-		activate_venv 2>/dev/null
-		python3 -c "
+		if ! activate_venv 2>/dev/null; then
+			return 1
+		fi
+		if ! python3 -c "
 import easyocr, sys
 reader = easyocr.Reader(['en'], verbose=False)
 results = reader.readtext(sys.argv[1], detail=0)
 print('\n'.join(results))
-" "$image_file" 2>/dev/null
+" "$image_file" 2>/dev/null; then
+			ocr_rc=1
+		fi
 		;;
 	glm-ocr)
 		# GLM-OCR via Ollama API
 		local b64
-		b64=$(base64 <"$image_file")
+		if ! b64=$(base64 <"$image_file"); then
+			return 1
+		fi
 		local response
-		response=$(curl -s http://localhost:11434/api/generate \
-			-d "{\"model\":\"glm-ocr\",\"prompt\":\"Extract all text from this image.\",\"images\":[\"${b64}\"],\"stream\":false}" 2>/dev/null)
-		printf '%s' "$response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('response',''))" 2>/dev/null
+		if ! response=$(curl -s http://localhost:11434/api/generate \
+			-d "{\"model\":\"glm-ocr\",\"prompt\":\"Extract all text from this image.\",\"images\":[\"${b64}\"],\"stream\":false}" 2>/dev/null); then
+			return 1
+		fi
+		if ! printf '%s' "$response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('response',''))" 2>/dev/null; then
+			ocr_rc=1
+		fi
 		;;
 	*)
 		die "Unknown OCR provider: ${provider}"
+		return 1
 		;;
 	esac
 
+	if [[ "$ocr_rc" -ne 0 ]]; then
+		return 1
+	fi
 	return 0
 }
 
@@ -270,37 +406,68 @@ ocr_scanned_pdf() {
 	local input="$1"
 	local provider="$2"
 	local output_text="$3"
-
-	# Use workspace dir instead of /tmp to avoid macOS Leptonica sandbox issues
-	local tmp_dir="${HOME}/.aidevops/.agent-workspace/tmp/ocr-$$"
-	mkdir -p "${tmp_dir}"
-	local img_dir="${tmp_dir}/pages"
-	mkdir -p "${img_dir}"
-
-	log_info "Extracting page images from scanned PDF..."
-	pdfimages -png "$input" "${img_dir}/page" 2>/dev/null
-
-	local img_count
-	img_count=$(find "${img_dir}" -name "*.png" -type f 2>/dev/null | wc -l | tr -d ' ')
-
-	if [[ "${img_count}" -eq 0 ]]; then
-		die "No images extracted from PDF. File may be empty."
+	if [[ -d "$output_text" ]]; then
+		die "OCR text output path is a directory."
+		return 1
 	fi
 
-	log_info "OCR processing ${img_count} page images with ${provider}..."
+	# Use workspace dir instead of /tmp to avoid macOS Leptonica sandbox issues
+	local temp_root="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+	local tmp_dir=""
+	mkdir -p "$temp_root"
+	tmp_dir=$(mktemp -d "${temp_root%/}/ocr.XXXXXX") || return 1
+	local img_dir="${tmp_dir}/pages"
+	mkdir -p "${img_dir}"
+	local staged_output="${tmp_dir}/ocr-output.txt"
+	local publish_tmp=""
 
-	# Process each image and combine
-	: >"$output_text"
-	local img_file
-	for img_file in "${img_dir}"/page-*.png; do
-		[[ -f "$img_file" ]] || continue
-		log_info "  OCR: $(basename "$img_file")"
-		run_ocr "$img_file" "$provider" >>"$output_text"
-		printf '\n\n' >>"$output_text"
+	local page_count=""
+	if ! page_count=$(pdf_page_count "$input"); then
+		rm -rf "${tmp_dir}"
+		die "Unable to determine PDF page count."
+		return 1
+	fi
+
+	log_info "OCR processing ${page_count} rendered PDF pages with ${provider}..."
+
+	# Process complete rendered pages so page boundaries and citations survive.
+	: >"$staged_output"
+	local page=1
+	while [[ "$page" -le "$page_count" ]]; do
+		local page_id=""
+		printf -v page_id '%04d' "$page"
+		local page_prefix="${img_dir}/page-${page_id}"
+		local img_file="${page_prefix}.png"
+		if ! render_pdf_page "$input" "$page" "$page_prefix" 300; then
+			rm -rf "${tmp_dir}"
+			die "Unable to render PDF page ${page}."
+			return 1
+		fi
+		log_info "  OCR: page ${page}"
+		printf '===== Page %s =====\n' "$page" >>"$staged_output"
+		if ! run_ocr "$img_file" "$provider" >>"$staged_output"; then
+			rm -rf "${tmp_dir}"
+			die "OCR failed on PDF page ${page}."
+			return 1
+		fi
+		printf '\n\n' >>"$staged_output"
+		page=$((page + 1))
 	done
 
 	local text_len
-	text_len=$(wc -c <"$output_text" | tr -d ' ')
+	text_len=$(wc -c <"$staged_output" | tr -d ' ')
+	publish_tmp=$(mktemp "${output_text}.tmp.XXXXXX") || {
+		rm -rf "${tmp_dir}"
+		die "Unable to stage OCR text output beside its destination."
+		return 1
+	}
+	if ! cp "$staged_output" "$publish_tmp" || \
+		! replace_file_atomically "$publish_tmp" "$output_text"; then
+		rm -f "$publish_tmp"
+		rm -rf "${tmp_dir}"
+		die "Unable to publish OCR text output."
+		return 1
+	fi
 	log_ok "OCR complete: ${text_len} bytes extracted"
 
 	# Clean up

--- a/.agents/scripts/document-creation-helper.sh
+++ b/.agents/scripts/document-creation-helper.sh
@@ -5,7 +5,7 @@
 # Part of aidevops framework: https://aidevops.sh
 #
 # Usage: document-creation-helper.sh <command> [options]
-# Commands: convert, create, template, normalise, pageindex, install, formats, status, help
+# Commands: convert, forensics, create, template, normalise, pageindex, install, formats, status, help
 
 set -euo pipefail
 
@@ -25,16 +25,21 @@ TEMPLATE_DIR="${HOME}/.aidevops/.agent-workspace/templates"
 LOG_DIR="${HOME}/.aidevops/logs"
 export LOG_DIR
 
-# Colour output (disable if not a terminal)
-if [[ -t 1 ]]; then
-	RED='\033[0;31m'
-	GREEN='\033[0;32m'
-	YELLOW='\033[1;33m'
-	BLUE='\033[0;34m'
-	BOLD='\033[1m'
-	NC='\033[0m'
-else
-	RED='' GREEN='' YELLOW='' BLUE='' BOLD='' NC=''
+# Colour output fallback when shared-constants.sh is unavailable.
+if [[ -z "${RED+x}" ]]; then
+	if [[ -t 1 ]]; then
+		RED='\033[0;31m'
+		GREEN='\033[0;32m'
+		YELLOW='\033[1;33m'
+		BLUE='\033[0;34m'
+		BOLD='\033[1m'
+		NC='\033[0m'
+	else
+		RED='' GREEN='' YELLOW='' BLUE='' BOLD='' NC=''
+	fi
+fi
+if [[ -z "${BOLD+x}" ]]; then
+	[[ -t 1 ]] && BOLD='\033[1m' || BOLD=''
 fi
 
 # ============================================================================
@@ -71,6 +76,29 @@ die() {
 has_cmd() {
 	local bin_name="$1"
 	command -v "$bin_name" &>/dev/null
+}
+
+replace_file_atomically() {
+	local source="$1"
+	local destination="$2"
+
+	if ! has_cmd python3 || [[ ! -f "$source" ]] || [[ -d "$destination" ]]; then
+		return 1
+	fi
+	if python3 -c '
+import os
+import sys
+
+source, destination = sys.argv[1:3]
+if not os.path.isfile(source) or os.path.isdir(destination):
+    raise SystemExit(1)
+os.replace(source, destination)
+if not os.path.isfile(destination):
+    raise SystemExit(1)
+' "$source" "$destination"; then
+		return 0
+	fi
+	return 1
 }
 
 # Get human-readable file size without using ls (SC2012)
@@ -176,6 +204,102 @@ is_scanned_pdf() {
 	return 1 # Has text content
 }
 
+# Return the number of pages in a PDF.
+pdf_page_count() {
+	local file="$1"
+	local count=""
+
+	if ! has_cmd pdfinfo; then
+		return 1
+	fi
+	count=$(pdfinfo "$file" 2>/dev/null | awk '$1 == "Pages:" { value = $2 } END { print value }')
+	if [[ ! "$count" =~ ^[0-9]+$ ]] || [[ "$count" -lt 1 ]]; then
+		return 1
+	fi
+	printf '%s' "$count"
+	return 0
+}
+
+# Return one PDF page's width and height in points as WIDTHxHEIGHT.
+pdf_page_dimensions() {
+	local file="$1"
+	local page="$2"
+	local dimensions=""
+
+	if ! has_cmd pdfinfo; then
+		return 1
+	fi
+	dimensions=$(pdfinfo -f "$page" -l "$page" "$file" 2>/dev/null | awk -v expected="$page" '
+		BEGIN { one = 1; two = 2; three = 3; four = 4; five = 5; six = 6 }
+		$one == "Page" && $two == expected && $three == "size:" { print $four "x" $six; exit }
+		$one == "Page" && $two == "size:" { print $three "x" $five; exit }
+	')
+	if [[ ! "$dimensions" =~ ^[0-9]+([.][0-9]+)?x[0-9]+([.][0-9]+)?$ ]]; then
+		return 1
+	fi
+	printf '%s' "$dimensions"
+	return 0
+}
+
+# Extract one PDF page's text layer to a file.
+extract_pdf_page_text() {
+	local file="$1"
+	local page="$2"
+	local output="$3"
+
+	if ! has_cmd pdftotext; then
+		return 1
+	fi
+	if pdftotext -f "$page" -l "$page" "$file" "$output" 2>/dev/null; then
+		return 0
+	fi
+	return 1
+}
+
+# Render one complete PDF page rather than extracting its component images.
+render_pdf_page() {
+	local file="$1"
+	local page="$2"
+	local output_prefix="$3"
+	local dpi="${4:-300}"
+
+	if ! has_cmd pdftoppm; then
+		return 1
+	fi
+	if pdftoppm -f "$page" -l "$page" -singlefile -r "$dpi" -png \
+		"$file" "$output_prefix" >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
+# Report the local OCR backend version for provenance manifests.
+ocr_provider_version() {
+	local provider="$1"
+	local version="unknown"
+
+	case "$provider" in
+	tesseract)
+		if has_cmd tesseract; then
+			version=$(tesseract --version 2>&1 | awk 'NR == 1 { value = $0 } END { print value }')
+		fi
+		;;
+	easyocr)
+		if has_cmd python3; then
+			version=$(python3 -c 'import importlib.metadata; print(importlib.metadata.version("easyocr"))' 2>/dev/null || printf 'unknown')
+		fi
+		;;
+	glm-ocr)
+		if has_cmd ollama; then
+			version=$(ollama --version 2>/dev/null || printf 'unknown')
+		fi
+		;;
+	esac
+
+	printf '%s' "$version"
+	return 0
+}
+
 # Select the best available OCR provider
 select_ocr_provider() {
 	local preferred="${1:-auto}"
@@ -227,6 +351,7 @@ select_ocr_provider() {
 run_ocr() {
 	local image_file="$1"
 	local provider="$2"
+	local ocr_rc=0
 
 	case "${provider}" in
 	tesseract)
@@ -239,35 +364,51 @@ run_ocr() {
 			tess_input="${work_dir}/ocr-input-$$.$(get_ext "$image_file")"
 			cp "$image_file" "$tess_input"
 		fi
-		tesseract "$tess_input" stdout 2>/dev/null
+		if ! tesseract "$tess_input" stdout 2>/dev/null; then
+			ocr_rc=1
+		fi
 		# Clean up temp copy
 		if [[ "$tess_input" != "$image_file" ]]; then
 			rm -f "$tess_input"
 		fi
 		;;
 	easyocr)
-		activate_venv 2>/dev/null
-		python3 -c "
+		if ! activate_venv 2>/dev/null; then
+			return 1
+		fi
+		if ! python3 -c "
 import easyocr, sys
 reader = easyocr.Reader(['en'], verbose=False)
 results = reader.readtext(sys.argv[1], detail=0)
 print('\n'.join(results))
-" "$image_file" 2>/dev/null
+" "$image_file" 2>/dev/null; then
+			ocr_rc=1
+		fi
 		;;
 	glm-ocr)
 		# GLM-OCR via Ollama API
 		local b64
-		b64=$(base64 <"$image_file")
+		if ! b64=$(base64 <"$image_file"); then
+			return 1
+		fi
 		local response
-		response=$(curl -s http://localhost:11434/api/generate \
-			-d "{\"model\":\"glm-ocr\",\"prompt\":\"Extract all text from this image.\",\"images\":[\"${b64}\"],\"stream\":false}" 2>/dev/null)
-		printf '%s' "$response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('response',''))" 2>/dev/null
+		if ! response=$(curl -s http://localhost:11434/api/generate \
+			-d "{\"model\":\"glm-ocr\",\"prompt\":\"Extract all text from this image.\",\"images\":[\"${b64}\"],\"stream\":false}" 2>/dev/null); then
+			return 1
+		fi
+		if ! printf '%s' "$response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('response',''))" 2>/dev/null; then
+			ocr_rc=1
+		fi
 		;;
 	*)
 		die "Unknown OCR provider: ${provider}"
+		return 1
 		;;
 	esac
 
+	if [[ "$ocr_rc" -ne 0 ]]; then
+		return 1
+	fi
 	return 0
 }
 
@@ -276,37 +417,68 @@ ocr_scanned_pdf() {
 	local input="$1"
 	local provider="$2"
 	local output_text="$3"
-
-	# Use workspace dir instead of /tmp to avoid macOS Leptonica sandbox issues
-	local tmp_dir="${HOME}/.aidevops/.agent-workspace/tmp/ocr-$$"
-	mkdir -p "${tmp_dir}"
-	local img_dir="${tmp_dir}/pages"
-	mkdir -p "${img_dir}"
-
-	log_info "Extracting page images from scanned PDF..."
-	pdfimages -png "$input" "${img_dir}/page" 2>/dev/null
-
-	local img_count
-	img_count=$(find "${img_dir}" -name "*.png" -type f 2>/dev/null | wc -l | tr -d ' ')
-
-	if [[ "${img_count}" -eq 0 ]]; then
-		die "No images extracted from PDF. File may be empty."
+	if [[ -d "$output_text" ]]; then
+		die "OCR text output path is a directory."
+		return 1
 	fi
 
-	log_info "OCR processing ${img_count} page images with ${provider}..."
+	# Use workspace dir instead of /tmp to avoid macOS Leptonica sandbox issues
+	local temp_root="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+	local tmp_dir=""
+	mkdir -p "$temp_root"
+	tmp_dir=$(mktemp -d "${temp_root%/}/ocr.XXXXXX") || return 1
+	local img_dir="${tmp_dir}/pages"
+	mkdir -p "${img_dir}"
+	local staged_output="${tmp_dir}/ocr-output.txt"
+	local publish_tmp=""
 
-	# Process each image and combine
-	: >"$output_text"
-	local img_file
-	for img_file in "${img_dir}"/page-*.png; do
-		[[ -f "$img_file" ]] || continue
-		log_info "  OCR: $(basename "$img_file")"
-		run_ocr "$img_file" "$provider" >>"$output_text"
-		printf '\n\n' >>"$output_text"
+	local page_count=""
+	if ! page_count=$(pdf_page_count "$input"); then
+		rm -rf "${tmp_dir}"
+		die "Unable to determine PDF page count."
+		return 1
+	fi
+
+	log_info "OCR processing ${page_count} rendered PDF pages with ${provider}..."
+
+	# Process complete rendered pages so page boundaries and citations survive.
+	: >"$staged_output"
+	local page=1
+	while [[ "$page" -le "$page_count" ]]; do
+		local page_id=""
+		printf -v page_id '%04d' "$page"
+		local page_prefix="${img_dir}/page-${page_id}"
+		local img_file="${page_prefix}.png"
+		if ! render_pdf_page "$input" "$page" "$page_prefix" 300; then
+			rm -rf "${tmp_dir}"
+			die "Unable to render PDF page ${page}."
+			return 1
+		fi
+		log_info "  OCR: page ${page}"
+		printf '===== Page %s =====\n' "$page" >>"$staged_output"
+		if ! run_ocr "$img_file" "$provider" >>"$staged_output"; then
+			rm -rf "${tmp_dir}"
+			die "OCR failed on PDF page ${page}."
+			return 1
+		fi
+		printf '\n\n' >>"$staged_output"
+		page=$((page + 1))
 	done
 
 	local text_len
-	text_len=$(wc -c <"$output_text" | tr -d ' ')
+	text_len=$(wc -c <"$staged_output" | tr -d ' ')
+	publish_tmp=$(mktemp "${output_text}.tmp.XXXXXX") || {
+		rm -rf "${tmp_dir}"
+		die "Unable to stage OCR text output beside its destination."
+		return 1
+	}
+	if ! cp "$staged_output" "$publish_tmp" || \
+		! replace_file_atomically "$publish_tmp" "$output_text"; then
+		rm -f "$publish_tmp"
+		rm -rf "${tmp_dir}"
+		die "Unable to publish OCR text output."
+		return 1
+	fi
 	log_ok "OCR complete: ${text_len} bytes extracted"
 
 	# Clean up
@@ -643,6 +815,10 @@ source "${SCRIPT_DIR}/document-creation-convert-lib.sh"
 # shellcheck source=./document-creation-email-lib.sh
 # shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
 source "${SCRIPT_DIR}/document-creation-email-lib.sh"
+
+# shellcheck source=./document-forensics-lib.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
+source "${SCRIPT_DIR}/document-forensics-lib.sh"
 
 # NOTE: The conversion engine (EML/MIME helpers, tool selection, conversion
 # backends) and the email import pipeline (mbox splitting, contact extraction,
@@ -1827,6 +2003,7 @@ cmd_help() {
 	printf "Usage: %s <command> [options]\n\n" "${SCRIPT_NAME}"
 	printf '%b\n' "${BOLD}Commands:${NC}"
 	printf "  convert           Convert between document formats\n"
+	printf "  forensics         Audit/repair mirrored and rotated PDF scans\n"
 	printf "  import-emails     Batch import .eml directory or mbox file to markdown\n"
 	printf "  create            Create a document from a template + data\n"
 	printf "  template          Manage document templates (list, draft)\n"
@@ -1851,6 +2028,7 @@ cmd_help() {
 	printf "  %s import-emails archive.mbox --output ./imported\n" "${SCRIPT_NAME}"
 	printf "  %s generate-manifest ./imported\n" "${SCRIPT_NAME}"
 	printf "  %s convert scanned.pdf --to odt --ocr tesseract\n" "${SCRIPT_NAME}"
+	printf "  %s forensics scans.pdf --output ./audit --write-readable\n" "${SCRIPT_NAME}"
 	printf "  %s convert screenshot.png --to md --ocr auto\n" "${SCRIPT_NAME}"
 	printf "  %s convert report.pdf --to md --no-normalise\n" "${SCRIPT_NAME}"
 	printf "  %s normalise document.md --output clean.md\n" "${SCRIPT_NAME}"
@@ -1885,6 +2063,7 @@ main() {
 
 	case "${cmd}" in
 	convert) cmd_convert "$@" ;;
+	forensics | audit) cmd_document_forensics "$@" ;;
 	import-emails) cmd_import_emails "$@" ;;
 	generate-manifest) cmd_generate_manifest "$@" ;;
 	create) cmd_create "$@" ;;

--- a/.agents/scripts/document-forensics-lib.sh
+++ b/.agents/scripts/document-forensics-lib.sh
@@ -1,0 +1,1362 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Document Forensics Library -- conservative page-level PDF OCR repair
+# =============================================================================
+# Usage: source after document-creation-core-lib.sh (or equivalent functions).
+# Provides cmd_document_forensics for document-creation-helper.sh.
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+
+[[ -n "${_DOCUMENT_FORENSICS_LIB_LOADED:-}" ]] && return 0
+_DOCUMENT_FORENSICS_LIB_LOADED=1
+
+DOCUMENT_FORENSICS_SCHEMA="aidevops.document-forensics/v1"
+_DF_VALUE_AUTO="auto"
+_DF_VALUE_NULL="null"
+_DF_VALUE_UNKNOWN="unknown"
+_DF_STATUS_FAILED="failed"
+_DF_TRANSFORM_ORIGINAL="original"
+_DF_CLASS_SEARCHABLE="searchable"
+_DF_CLASS_UNCERTAIN="uncertain"
+_DF_TEXT_LAYER_SUSPECT="suspect"
+_DF_PROVIDER_UNAVAILABLE="unavailable"
+_DF_TRANSACTION_SCHEMA="aidevops.document-forensics.transaction/v1"
+_DF_TRANSACTION_PREPARED="prepared"
+
+_DF_TMP_DIR=""
+_DF_INPUT=""
+_DF_OUTPUT_DIR=""
+_DF_STEM=""
+_DF_PROVIDER=""
+_DF_DPI=300
+_DF_MIN_TEXT_CHARS=50
+_DF_MIN_IMPROVEMENT=15
+_DF_MIN_WORDS=4
+_DF_WRITE_READABLE=false
+_DF_PAGE_COUNT=0
+_DF_PAGE_SUCCESS_COUNT=0
+_DF_PAGE_FAILED_COUNT=0
+_DF_FAILURE_COUNT=0
+_DF_SIDECAR_TMP=""
+_DF_SIDECAR_PATH=""
+_DF_MANIFEST_PATH=""
+_DF_READABLE_PATH=""
+_DF_READABLE_TMP=""
+_DF_FINAL_STATUS="$_DF_STATUS_FAILED"
+_DF_ARG_INPUT=""
+_DF_ARG_OUTPUT=""
+_DF_ARG_PROVIDER="$_DF_VALUE_AUTO"
+_DF_HELP_REQUESTED=false
+_DF_SOURCE_HASH_BEFORE=""
+_DF_SOURCE_HASH_AFTER=""
+_DF_BACKEND_VERSION="$_DF_VALUE_UNKNOWN"
+_DF_LOCK_DIR=""
+_DF_LOCK_TOKEN=""
+_DF_LOCK_OWNED=false
+_DF_TRANSACTION_DIR=""
+
+_df_cleanup() {
+	if [[ "${_DF_LOCK_OWNED:-false}" == true ]] && [[ -n "${_DF_TRANSACTION_DIR:-}" ]]; then
+		_df_recover_interrupted_publication || true
+	fi
+	_df_release_output_lock || true
+	if [[ -n "${_DF_TMP_DIR:-}" ]] && [[ -d "$_DF_TMP_DIR" ]]; then
+		rm -rf "$_DF_TMP_DIR"
+	fi
+	return 0
+}
+
+_df_reset_state() {
+	_df_cleanup
+	_DF_TMP_DIR=""
+	_DF_INPUT=""
+	_DF_OUTPUT_DIR=""
+	_DF_STEM=""
+	_DF_PROVIDER=""
+	_DF_DPI=300
+	_DF_MIN_TEXT_CHARS=50
+	_DF_MIN_IMPROVEMENT=15
+	_DF_MIN_WORDS=4
+	_DF_WRITE_READABLE=false
+	_DF_PAGE_COUNT=0
+	_DF_PAGE_SUCCESS_COUNT=0
+	_DF_PAGE_FAILED_COUNT=0
+	_DF_FAILURE_COUNT=0
+	_DF_SIDECAR_TMP=""
+	_DF_SIDECAR_PATH=""
+	_DF_MANIFEST_PATH=""
+	_DF_READABLE_PATH=""
+	_DF_READABLE_TMP=""
+	_DF_FINAL_STATUS="$_DF_STATUS_FAILED"
+	_DF_ARG_INPUT=""
+	_DF_ARG_OUTPUT=""
+	_DF_ARG_PROVIDER="$_DF_VALUE_AUTO"
+	_DF_HELP_REQUESTED=false
+	_DF_SOURCE_HASH_BEFORE=""
+	_DF_SOURCE_HASH_AFTER=""
+	_DF_BACKEND_VERSION="$_DF_VALUE_UNKNOWN"
+	_DF_LOCK_DIR=""
+	_DF_LOCK_TOKEN=""
+	_DF_LOCK_OWNED=false
+	_DF_TRANSACTION_DIR=""
+	return 0
+}
+
+_df_release_output_lock() {
+	local current_owner=""
+
+	if [[ "$_DF_LOCK_OWNED" != true ]] || [[ -z "$_DF_LOCK_DIR" ]]; then
+		return 0
+	fi
+	if [[ -f "${_DF_LOCK_DIR}/owner" ]]; then
+		current_owner=$(<"${_DF_LOCK_DIR}/owner")
+	fi
+	if [[ "$current_owner" == "$_DF_LOCK_TOKEN" ]]; then
+		rm -rf "$_DF_LOCK_DIR" || return 1
+	fi
+	_DF_LOCK_OWNED=false
+	return 0
+}
+
+_df_write_lock_owner() {
+	if printf '%s\n' "$_DF_LOCK_TOKEN" >"${_DF_LOCK_DIR}/owner"; then
+		_DF_LOCK_OWNED=true
+		return 0
+	fi
+	rm -rf "$_DF_LOCK_DIR" 2>/dev/null || true
+	return 1
+}
+
+_df_lock_owner_is_live() {
+	local owner="$1"
+	local owner_pid="${owner%%:*}"
+	local observed_pid=""
+
+	if [[ ! "$owner_pid" =~ ^[0-9]+$ ]]; then
+		return 1
+	fi
+	if kill -0 "$owner_pid" 2>/dev/null; then
+		return 0
+	fi
+	if ! has_cmd ps; then
+		return 0
+	fi
+	observed_pid=$(ps -p "$owner_pid" -o pid= 2>/dev/null | tr -d '[:space:]') || true
+	if [[ "$observed_pid" == "$owner_pid" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+_df_move_directory_atomically() {
+	local source="$1"
+	local destination="$2"
+
+	if ! has_cmd python3 || [[ ! -d "$source" ]] || [[ -L "$source" ]] || \
+		[[ -e "$destination" ]] || [[ -L "$destination" ]]; then
+		return 1
+	fi
+	if python3 -c '
+import os
+import sys
+
+source, destination = sys.argv[1:3]
+if not os.path.isdir(source) or os.path.islink(source) or os.path.lexists(destination):
+    raise SystemExit(1)
+os.rename(source, destination)
+' "$source" "$destination"; then
+		return 0
+	fi
+	return 1
+}
+
+_df_acquire_output_lock() {
+	local owner=""
+	local observed_owner=""
+	local stale_dir=""
+	local lock_age=0
+	local lock_mtime=0
+	local lock_owner=""
+	local current_user=""
+
+	_DF_LOCK_DIR="${_DF_OUTPUT_DIR}/.${_DF_STEM}.forensics.lock"
+	_DF_LOCK_TOKEN="$$:${_DF_TMP_DIR##*/}"
+	if mkdir "$_DF_LOCK_DIR" 2>/dev/null; then
+		_df_write_lock_owner
+		return $?
+	fi
+	if [[ -f "${_DF_LOCK_DIR}/owner" ]]; then
+		owner=$(<"${_DF_LOCK_DIR}/owner")
+	fi
+	if _df_lock_owner_is_live "$owner"; then
+		die "Another document-forensics run owns this output set"
+		return 1
+	fi
+	if [[ -z "$owner" ]]; then
+		if declare -F _file_mtime_epoch >/dev/null 2>&1; then
+			lock_mtime=$(_file_mtime_epoch "$_DF_LOCK_DIR" 2>/dev/null || printf '0')
+			lock_age=$(($(date +%s) - lock_mtime))
+		fi
+		if [[ "$lock_mtime" -eq 0 ]] || [[ "$lock_age" -lt 300 ]]; then
+			die "Document-forensics output lock has no verifiable owner"
+			return 1
+		fi
+	fi
+
+	if ! declare -F _file_owner >/dev/null 2>&1 || ! has_cmd id; then
+		die "Unable to verify stale document-forensics lock ownership"
+		return 1
+	fi
+	lock_owner=$(_file_owner "$_DF_LOCK_DIR" 2>/dev/null || true)
+	current_user=$(id -un 2>/dev/null || true)
+	if [[ -z "$lock_owner" ]] || [[ "$lock_owner" == "$_DF_VALUE_UNKNOWN" ]] || [[ "$lock_owner" != "$current_user" ]]; then
+		die "Refusing to reclaim a document-forensics lock owned by another user"
+		return 1
+	fi
+	if [[ -f "${_DF_LOCK_DIR}/owner" ]]; then
+		observed_owner=$(<"${_DF_LOCK_DIR}/owner")
+	fi
+	if [[ "$observed_owner" != "$owner" ]] || _df_lock_owner_is_live "$observed_owner"; then
+		die "Document-forensics output lock changed during stale-lock recovery"
+		return 1
+	fi
+	stale_dir="${_DF_LOCK_DIR}.stale.${_DF_TMP_DIR##*.}"
+	if ! _df_move_directory_atomically "$_DF_LOCK_DIR" "$stale_dir"; then
+		die "Unable to move the stale document-forensics output lock"
+		return 1
+	fi
+	if ! mkdir "$_DF_LOCK_DIR" 2>/dev/null; then
+		rm -rf "$stale_dir"
+		die "Another document-forensics run won the output lock race"
+		return 1
+	fi
+	if _df_write_lock_owner; then
+		rm -rf "$stale_dir"
+		return 0
+	fi
+	rm -rf "$stale_dir"
+	return 1
+}
+
+_df_sha256() {
+	local file="$1"
+	local digest=""
+
+	if has_cmd sha256sum; then
+		digest=$(sha256sum "$file" 2>/dev/null | awk '{ value = $1 } END { print value }') || return 1
+	elif has_cmd shasum; then
+		digest=$(shasum -a 256 "$file" 2>/dev/null | awk '{ value = $1 } END { print value }') || return 1
+	else
+		return 1
+	fi
+	if [[ ! "$digest" =~ ^[0-9a-fA-F]{64}$ ]]; then
+		return 1
+	fi
+	printf '%s' "$digest"
+	return 0
+}
+
+_df_nonspace_chars() {
+	local file="$1"
+	local count="0"
+	count=$(tr -d '[:space:]' <"$file" | wc -c | tr -d ' ')
+	printf '%s' "${count:-0}"
+	return 0
+}
+
+_df_alpha_chars() {
+	local file="$1"
+	local count="0"
+	count=$(LC_ALL=C tr -cd '[:alpha:]' <"$file" | wc -c | tr -d ' ')
+	printf '%s' "${count:-0}"
+	return 0
+}
+
+_df_word_count() {
+	local file="$1"
+	local count="0"
+	count=$(wc -w <"$file" | tr -d ' ')
+	printf '%s' "${count:-0}"
+	return 0
+}
+
+_df_record_failure() {
+	local page="$1"
+	local transform="$2"
+	local message="$3"
+	local failure_id=""
+	local failure_file=""
+
+	_DF_FAILURE_COUNT=$((_DF_FAILURE_COUNT + 1))
+	printf -v failure_id '%04d' "$_DF_FAILURE_COUNT"
+	failure_file="${_DF_TMP_DIR}/failures/${failure_id}.json"
+	jq -n \
+		--argjson page "$page" \
+		--arg transform "$transform" \
+		--arg message "$message" \
+		'{page: (if $page == 0 then null else $page end), transform: (if $transform == "" then null else $transform end), message: $message}' \
+		>"$failure_file"
+	return 0
+}
+
+_df_write_candidate_failure() {
+	local transform="$1"
+	local output_json="$2"
+	local message="$3"
+
+	jq -n \
+		--arg transform "$transform" \
+		--arg message "$message" \
+		'{transform: $transform, success: false, score: null, confidence: null, text_chars: 0, alpha_chars: 0, word_count: 0, evidence_sufficient: false, backend_evidence: null, failure: $message}' \
+		>"$output_json"
+	return 0
+}
+
+_df_image_dimensions() {
+	local image="$1"
+	local dimensions=""
+
+	if has_cmd magick; then
+		dimensions=$(magick identify -format '%wx%h' "$image" 2>/dev/null || printf '')
+	elif has_cmd identify; then
+		dimensions=$(identify -format '%wx%h' "$image" 2>/dev/null || printf '')
+	fi
+	if [[ ! "$dimensions" =~ ^[0-9]+x[0-9]+$ ]]; then
+		return 1
+	fi
+	printf '%s' "$dimensions"
+	return 0
+}
+
+_df_transform_image() {
+	local input="$1"
+	local transform="$2"
+	local output="$3"
+	local dpi="$4"
+	local runner="${DOCUMENT_FORENSICS_IMAGE_RUNNER:-}"
+	local dimensions=""
+	local degrees=""
+
+	if [[ -n "$runner" ]]; then
+		if "$runner" "$input" "$transform" "$output" "$dpi"; then
+			return 0
+		fi
+		return 1
+	fi
+
+	if [[ "$transform" == "$_DF_TRANSFORM_ORIGINAL" ]]; then
+		if cp "$input" "$output"; then
+			return 0
+		fi
+		return 1
+	fi
+
+	if ! dimensions=$(_df_image_dimensions "$input"); then
+		return 1
+	fi
+
+	case "$transform" in
+	flip-horizontal)
+		if has_cmd magick; then
+			magick "$input" -flop -units PixelsPerInch -density "$dpi" "$output" >/dev/null 2>&1 && return 0
+		elif has_cmd convert; then
+			convert "$input" -flop -units PixelsPerInch -density "$dpi" "$output" >/dev/null 2>&1 && return 0
+		fi
+		;;
+	rotate-90) degrees="90" ;;
+	rotate-180) degrees="180" ;;
+	rotate-270) degrees="270" ;;
+	*) return 1 ;;
+	esac
+
+	if [[ -n "$degrees" ]] && has_cmd magick; then
+		if magick "$input" -background white -rotate "$degrees" -resize "$dimensions" \
+			-gravity center -extent "$dimensions" -units PixelsPerInch -density "$dpi" "$output" >/dev/null 2>&1; then
+			return 0
+		fi
+	elif [[ -n "$degrees" ]] && has_cmd convert; then
+		if convert "$input" -background white -rotate "$degrees" -resize "$dimensions" \
+			-gravity center -extent "$dimensions" -units PixelsPerInch -density "$dpi" "$output" >/dev/null 2>&1; then
+			return 0
+		fi
+	fi
+	return 1
+}
+
+_df_tesseract_confidence() {
+	local image="$1"
+	local confidence="$_DF_VALUE_NULL"
+	local tsv_file="${_DF_TMP_DIR}/tesseract-confidence-$$.tsv"
+
+	if has_cmd tesseract && tesseract "$image" stdout tsv >"$tsv_file" 2>/dev/null; then
+		confidence=$(awk -F '\t' '
+			NR > 1 && $11 ~ /^[0-9]+([.][0-9]+)?$/ && $11 >= 0 { total += $11; count += 1 }
+			END { if (count > 0) printf "%.2f", total / count }
+		' "$tsv_file")
+		[[ -z "$confidence" ]] && confidence="$_DF_VALUE_NULL"
+	fi
+	rm -f "$tsv_file"
+	printf '%s' "$confidence"
+	return 0
+}
+
+_df_evaluate_candidate() {
+	local image="$1"
+	local provider="$2"
+	local transform="$3"
+	local prefix="$4"
+	local text_file="${prefix}.txt"
+	local evidence_file="${prefix}.evidence.json"
+	local output_json="${prefix}.json"
+	local runner="${DOCUMENT_FORENSICS_OCR_RUNNER:-}"
+	local confidence="$_DF_VALUE_NULL"
+	local confidence_int=0
+	local text_chars=0
+	local alpha_chars=0
+	local word_count=0
+	local word_bonus=0
+	local alpha_bonus=0
+	local score=0
+	local evidence_sufficient=false
+	local backend_evidence="{}"
+
+	if [[ -n "$runner" ]]; then
+		if ! "$runner" "$image" "$provider" "$text_file" "$evidence_file"; then
+			_df_write_candidate_failure "$transform" "$output_json" "OCR runner failed"
+			return 1
+		fi
+	else
+		if [[ "$provider" == "$_DF_PROVIDER_UNAVAILABLE" ]]; then
+			_df_write_candidate_failure "$transform" "$output_json" "No local OCR backend is available"
+			return 1
+		fi
+		if ! run_ocr "$image" "$provider" >"$text_file"; then
+			_df_write_candidate_failure "$transform" "$output_json" "OCR backend failed"
+			return 1
+		fi
+		if [[ "$provider" == "tesseract" ]]; then
+			confidence=$(_df_tesseract_confidence "$image")
+		fi
+		jq -n --argjson confidence "$confidence" \
+			'{confidence: $confidence, source: (if $confidence == null then "text-quality" else "tesseract-tsv" end)}' \
+			>"$evidence_file"
+	fi
+
+	if [[ ! -f "$text_file" ]] || [[ ! -f "$evidence_file" ]] || ! jq -e 'type == "object"' "$evidence_file" >/dev/null 2>&1; then
+		_df_write_candidate_failure "$transform" "$output_json" "OCR evidence is incomplete"
+		return 1
+	fi
+
+	confidence=$(jq -r 'if (.confidence | type) == "number" then .confidence else null end' "$evidence_file")
+	if [[ "$confidence" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+		confidence_int=$(awk -v value="$confidence" 'BEGIN { printf "%.0f", value }')
+	fi
+	text_chars=$(_df_nonspace_chars "$text_file")
+	alpha_chars=$(_df_alpha_chars "$text_file")
+	word_count=$(_df_word_count "$text_file")
+	word_bonus="$word_count"
+	[[ "$word_bonus" -gt 20 ]] && word_bonus=20
+	alpha_bonus=$((alpha_chars / 10))
+	[[ "$alpha_bonus" -gt 10 ]] && alpha_bonus=10
+	score=$((confidence_int + word_bonus + alpha_bonus))
+	if [[ "$word_count" -ge "$_DF_MIN_WORDS" ]] && [[ "$alpha_chars" -ge 20 ]]; then
+		evidence_sufficient=true
+	fi
+	backend_evidence=$(jq -c '.' "$evidence_file")
+
+	jq -n \
+		--arg transform "$transform" \
+		--argjson score "$score" \
+		--argjson confidence "$confidence" \
+		--argjson text_chars "$text_chars" \
+		--argjson alpha_chars "$alpha_chars" \
+		--argjson word_count "$word_count" \
+		--argjson evidence_sufficient "$evidence_sufficient" \
+		--argjson backend_evidence "$backend_evidence" \
+		'{transform: $transform, success: true, score: $score, confidence: $confidence, text_chars: $text_chars, alpha_chars: $alpha_chars, word_count: $word_count, evidence_sufficient: $evidence_sufficient, backend_evidence: $backend_evidence, failure: null}' \
+		>"$output_json"
+	return 0
+}
+
+_df_append_sidecar() {
+	local page="$1"
+	local classification="$2"
+	local transform="$3"
+	local text_file="$4"
+
+	printf '===== Page %s [classification=%s transform=%s] =====\n' \
+		"$page" "$classification" "$transform" >>"$_DF_SIDECAR_TMP"
+	if [[ -f "$text_file" ]]; then
+		while IFS= read -r line || [[ -n "$line" ]]; do
+			printf '%s\n' "$line" >>"$_DF_SIDECAR_TMP"
+		done <"$text_file"
+	fi
+	printf '\n' >>"$_DF_SIDECAR_TMP"
+	return 0
+}
+
+_df_extract_original_page_pdf() {
+	local page="$1"
+	local output="$2"
+	local extract_dir="${_DF_TMP_DIR}/source-pages"
+	local pattern="${extract_dir}/source-%d.pdf"
+	local extracted="${extract_dir}/source-${page}.pdf"
+
+	if ! has_cmd pdfseparate; then
+		return 1
+	fi
+	if ! pdfseparate -f "$page" -l "$page" "$_DF_INPUT" "$pattern" >/dev/null 2>&1; then
+		return 1
+	fi
+	if [[ ! -f "$extracted" ]]; then
+		return 1
+	fi
+	if mv "$extracted" "$output"; then
+		return 0
+	fi
+	return 1
+}
+
+_df_make_ocr_page_pdf() {
+	local image="$1"
+	local text_file="$2"
+	local output="$3"
+	local runner="${DOCUMENT_FORENSICS_PDF_RUNNER:-}"
+	local output_base="${output%.pdf}"
+
+	if [[ -n "$runner" ]]; then
+		if "$runner" "$image" "$text_file" "$output" "$_DF_DPI"; then
+			return 0
+		fi
+		return 1
+	fi
+	if ! has_cmd tesseract; then
+		return 1
+	fi
+	if tesseract "$image" "$output_base" pdf >/dev/null 2>&1 && [[ -f "$output" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+_df_write_failed_page() {
+	local page="$1"
+	local message="$2"
+	local candidates_json="$3"
+	local page_id=""
+	local empty_text="${_DF_TMP_DIR}/empty.txt"
+	printf -v page_id '%04d' "$page"
+	: >"$empty_text"
+	jq -n \
+		--argjson page "$page" \
+		--arg message "$message" \
+		--arg failed "$_DF_STATUS_FAILED" \
+		--arg original "$_DF_TRANSFORM_ORIGINAL" \
+		--arg text_layer "$_DF_TEXT_LAYER_SUSPECT" \
+		--argjson candidates "$candidates_json" \
+		'{page: $page, text_layer: $text_layer, classification: $failed, selected_transform: $original, improvement: null, ocr: {performed: false}, candidates: $candidates, failure: $message}' \
+		>"${_DF_TMP_DIR}/pages/${page_id}.json"
+	_df_append_sidecar "$page" "$_DF_STATUS_FAILED" "$_DF_TRANSFORM_ORIGINAL" "$empty_text"
+	_DF_PAGE_FAILED_COUNT=$((_DF_PAGE_FAILED_COUNT + 1))
+	if [[ "$_DF_WRITE_READABLE" == true ]] && \
+		! _df_extract_original_page_pdf "$page" "${_DF_TMP_DIR}/page-pdfs/${page_id}.pdf"; then
+		_df_record_failure "$page" "$_DF_TRANSFORM_ORIGINAL" "Unable to preserve failed source page in readable derivative"
+	fi
+	return 0
+}
+
+_df_write_uncertain_original_page() {
+	local page="$1"
+	local page_id="$2"
+	local improvement="$3"
+	local candidates_json="$4"
+	local empty_text="${_DF_TMP_DIR}/uncertain-${page_id}.txt"
+	local page_pdf="${_DF_TMP_DIR}/page-pdfs/${page_id}.pdf"
+
+	: >"$empty_text"
+	_df_append_sidecar "$page" "$_DF_CLASS_UNCERTAIN" "$_DF_TRANSFORM_ORIGINAL" "$empty_text"
+	jq -n \
+		--argjson page "$page" \
+		--arg uncertain "$_DF_CLASS_UNCERTAIN" \
+		--arg original "$_DF_TRANSFORM_ORIGINAL" \
+		--arg text_layer "$_DF_TEXT_LAYER_SUSPECT" \
+		--argjson improvement "$improvement" \
+		--argjson candidates "$candidates_json" \
+		'{page: $page, text_layer: $text_layer, classification: $uncertain, selected_transform: $original, improvement: $improvement, ocr: {performed: false}, candidates: $candidates, failure: null}' \
+		>"${_DF_TMP_DIR}/pages/${page_id}.json"
+	_DF_PAGE_SUCCESS_COUNT=$((_DF_PAGE_SUCCESS_COUNT + 1))
+	if [[ "$_DF_WRITE_READABLE" == true ]] && ! _df_extract_original_page_pdf "$page" "$page_pdf"; then
+		_df_record_failure "$page" "$_DF_TRANSFORM_ORIGINAL" "Unable to preserve uncertain source page in readable derivative"
+	fi
+	return 0
+}
+
+_df_process_searchable_page() {
+	local page="$1"
+	local page_id="$2"
+	local text_file="$3"
+	local text_chars="$4"
+	local page_pdf="${_DF_TMP_DIR}/page-pdfs/${page_id}.pdf"
+
+	_df_append_sidecar "$page" "$_DF_CLASS_SEARCHABLE" "$_DF_TRANSFORM_ORIGINAL" "$text_file"
+	jq -n \
+		--argjson page "$page" \
+		--argjson text_chars "$text_chars" \
+		--arg searchable "$_DF_CLASS_SEARCHABLE" \
+		--arg original "$_DF_TRANSFORM_ORIGINAL" \
+		'{page: $page, text_layer: $searchable, classification: $searchable, selected_transform: $original, improvement: 0, ocr: {performed: false, text_chars: $text_chars}, candidates: [], failure: null}' \
+		>"${_DF_TMP_DIR}/pages/${page_id}.json"
+	_DF_PAGE_SUCCESS_COUNT=$((_DF_PAGE_SUCCESS_COUNT + 1))
+
+	if [[ "$_DF_WRITE_READABLE" == true ]] && ! _df_extract_original_page_pdf "$page" "$page_pdf"; then
+		_df_record_failure "$page" "$_DF_TRANSFORM_ORIGINAL" "Unable to preserve searchable source page in readable derivative"
+	fi
+	return 0
+}
+
+_df_collect_page_candidates() {
+	local page="$1"
+	local page_id="$2"
+	local rendered_image="$3"
+	local candidate_dir="${_DF_TMP_DIR}/candidates"
+	local transform=""
+	local candidate_prefix=""
+	local candidate_image=""
+	local candidate_json=""
+	local candidate_score=0
+	local original_score=0
+	local original_success=false
+	local best_score=-1
+	local best_transform="$_DF_TRANSFORM_ORIGINAL"
+	local best_prefix=""
+	local success_count=0
+	local candidates_json="[]"
+	local summary_file="${candidate_dir}/${page_id}.summary.json"
+	local -a candidate_files=()
+
+	for transform in original flip-horizontal rotate-90 rotate-180 rotate-270; do
+		candidate_prefix="${candidate_dir}/${page_id}.${transform}"
+		candidate_image="${candidate_prefix}.png"
+		candidate_json="${candidate_prefix}.json"
+		candidate_files+=("$candidate_json")
+
+		if ! _df_transform_image "$rendered_image" "$transform" "$candidate_image" "$_DF_DPI"; then
+			_df_write_candidate_failure "$transform" "$candidate_json" "Image transform unavailable"
+			_df_record_failure "$page" "$transform" "Image transform unavailable"
+			continue
+		fi
+		if ! _df_evaluate_candidate "$candidate_image" "$_DF_PROVIDER" "$transform" "$candidate_prefix"; then
+			_df_record_failure "$page" "$transform" "OCR candidate evaluation failed"
+			continue
+		fi
+
+		success_count=$((success_count + 1))
+		candidate_score=$(jq -r '.score' "$candidate_json")
+		if [[ "$transform" == "$_DF_TRANSFORM_ORIGINAL" ]]; then
+			original_score="$candidate_score"
+			original_success=true
+		fi
+		if [[ "$candidate_score" -gt "$best_score" ]]; then
+			best_score="$candidate_score"
+			best_transform="$transform"
+			best_prefix="$candidate_prefix"
+		fi
+	done
+
+	candidates_json=$(jq -s '.' "${candidate_files[@]}")
+	jq -n \
+		--argjson success_count "$success_count" \
+		--argjson original_score "$original_score" \
+		--argjson original_success "$original_success" \
+		--argjson best_score "$best_score" \
+		--arg best_transform "$best_transform" \
+		--arg best_prefix "$best_prefix" \
+		--argjson candidates "$candidates_json" \
+		'{success_count: $success_count, original_score: $original_score, original_success: $original_success, best_score: $best_score, best_transform: $best_transform, best_prefix: $best_prefix, candidates: $candidates}' \
+		>"$summary_file"
+	return 0
+}
+
+_df_write_suspect_page_result() {
+	local page="$1"
+	local page_id="$2"
+	local classification="$3"
+	local selected_transform="$4"
+	local selected_prefix="$5"
+	local improvement="$6"
+	local candidates_json="$7"
+	local selected_image="${selected_prefix}.png"
+	local selected_ocr=""
+	local page_pdf="${_DF_TMP_DIR}/page-pdfs/${page_id}.pdf"
+
+	selected_ocr=$(jq '{performed: true, score: .score, confidence: .confidence, text_chars: .text_chars, alpha_chars: .alpha_chars, word_count: .word_count, evidence_sufficient: .evidence_sufficient, backend_evidence: .backend_evidence}' "${selected_prefix}.json")
+	_df_append_sidecar "$page" "$classification" "$selected_transform" "${selected_prefix}.txt"
+	jq -n \
+		--argjson page "$page" \
+		--arg classification "$classification" \
+		--arg selected_transform "$selected_transform" \
+		--argjson improvement "$improvement" \
+		--argjson selected_ocr "$selected_ocr" \
+		--argjson candidates "$candidates_json" \
+		--arg text_layer "$_DF_TEXT_LAYER_SUSPECT" \
+		'{page: $page, text_layer: $text_layer, classification: $classification, selected_transform: $selected_transform, improvement: $improvement, ocr: $selected_ocr, candidates: $candidates, failure: null}' \
+		>"${_DF_TMP_DIR}/pages/${page_id}.json"
+	_DF_PAGE_SUCCESS_COUNT=$((_DF_PAGE_SUCCESS_COUNT + 1))
+
+	if [[ "$_DF_WRITE_READABLE" == true ]] && ! _df_make_ocr_page_pdf "$selected_image" "${selected_prefix}.txt" "$page_pdf"; then
+		_df_record_failure "$page" "$selected_transform" "Unable to create searchable readable PDF page"
+	fi
+	return 0
+}
+
+_df_process_suspect_page() {
+	local page="$1"
+	local page_id="$2"
+	local render_prefix="${_DF_TMP_DIR}/rendered/page-${page_id}"
+	local rendered_image="${render_prefix}.png"
+	local summary_file="${_DF_TMP_DIR}/candidates/${page_id}.summary.json"
+	local success_count=0
+	local original_score=0
+	local original_success=false
+	local best_score=-1
+	local best_transform="$_DF_TRANSFORM_ORIGINAL"
+	local best_prefix=""
+	local candidates_json="[]"
+	local best_sufficient=false
+	local improvement="$_DF_VALUE_NULL"
+	local classification="$_DF_CLASS_UNCERTAIN"
+	local selected_transform="$_DF_TRANSFORM_ORIGINAL"
+	local selected_prefix=""
+
+	if ! render_pdf_page "$_DF_INPUT" "$page" "$render_prefix" "$_DF_DPI"; then
+		_df_record_failure "$page" "$_DF_TRANSFORM_ORIGINAL" "Unable to render PDF page"
+		_df_write_failed_page "$page" "Unable to render PDF page" "[]"
+		return 0
+	fi
+	_df_collect_page_candidates "$page" "$page_id" "$rendered_image"
+	success_count=$(jq -r '.success_count' "$summary_file")
+	candidates_json=$(jq '.candidates' "$summary_file")
+	if [[ "$success_count" -eq 0 ]]; then
+		_df_record_failure "$page" "" "All OCR candidates failed"
+		_df_write_failed_page "$page" "All OCR candidates failed" "$candidates_json"
+		return 0
+	fi
+
+	original_score=$(jq -r '.original_score' "$summary_file")
+	original_success=$(jq -r '.original_success' "$summary_file")
+	best_score=$(jq -r '.best_score' "$summary_file")
+	best_transform=$(jq -r '.best_transform' "$summary_file")
+	best_prefix=$(jq -r '.best_prefix' "$summary_file")
+	best_sufficient=$(jq -r '.evidence_sufficient' "${best_prefix}.json")
+	selected_prefix="${_DF_TMP_DIR}/candidates/${page_id}.original"
+	if [[ "$original_success" != true ]]; then
+		_df_write_uncertain_original_page "$page" "$page_id" "$improvement" "$candidates_json"
+		return 0
+	fi
+	improvement=$((best_score - original_score))
+
+	if [[ "$best_transform" == "$_DF_TRANSFORM_ORIGINAL" ]]; then
+		selected_prefix="$best_prefix"
+		if [[ "$best_sufficient" == true ]]; then
+			classification="normal"
+		fi
+	elif [[ "$best_sufficient" == true ]] && [[ "$improvement" -ge "$_DF_MIN_IMPROVEMENT" ]]; then
+		selected_transform="$best_transform"
+		selected_prefix="$best_prefix"
+		case "$best_transform" in
+		flip-horizontal) classification="mirrored" ;;
+		rotate-*) classification="rotated" ;;
+		esac
+	fi
+
+	_df_write_suspect_page_result "$page" "$page_id" "$classification" \
+		"$selected_transform" "$selected_prefix" "$improvement" "$candidates_json"
+	return 0
+}
+
+_df_annotate_page_dimensions() {
+	local page="$1"
+	local page_id="$2"
+	local source_dimensions=""
+	local source_width=""
+	local source_height=""
+	local derived_dimensions=""
+	local derived_width=""
+	local derived_height=""
+	local derived_json="$_DF_VALUE_NULL"
+	local page_file="${_DF_TMP_DIR}/pages/${page_id}.json"
+	local annotated_file="${page_file}.annotated"
+	local page_pdf="${_DF_TMP_DIR}/page-pdfs/${page_id}.pdf"
+
+	if ! source_dimensions=$(pdf_page_dimensions "$_DF_INPUT" "$page"); then
+		_df_record_failure "$page" "" "Unable to determine source page dimensions"
+		jq '. + {source_dimensions_points: null, derived_dimensions_points: null}' \
+			"$page_file" >"$annotated_file"
+	else
+		source_width="${source_dimensions%x*}"
+		source_height="${source_dimensions#*x}"
+		if [[ "$_DF_WRITE_READABLE" == true ]] && [[ -f "$page_pdf" ]]; then
+			if derived_dimensions=$(pdf_page_dimensions "$page_pdf" 1); then
+				derived_width="${derived_dimensions%x*}"
+				derived_height="${derived_dimensions#*x}"
+				derived_json=$(jq -n --arg width "$derived_width" --arg height "$derived_height" \
+					'{width: ($width | tonumber), height: ($height | tonumber)}')
+				if [[ "$derived_dimensions" != "$source_dimensions" ]]; then
+					_df_record_failure "$page" "" "Readable page dimensions differ from the source"
+				fi
+			else
+				_df_record_failure "$page" "" "Unable to measure readable page dimensions"
+			fi
+		fi
+		jq --arg width "$source_width" --arg height "$source_height" --argjson derived "$derived_json" \
+			'. + {
+				source_dimensions_points: {width: ($width | tonumber), height: ($height | tonumber)},
+				derived_dimensions_points: $derived
+			}' "$page_file" >"$annotated_file"
+	fi
+	if mv "$annotated_file" "$page_file"; then
+		return 0
+	fi
+	return 1
+}
+
+_df_process_page() {
+	local page="$1"
+	local page_id=""
+	local text_file=""
+	local text_chars=0
+
+	printf -v page_id '%04d' "$page"
+	text_file="${_DF_TMP_DIR}/text-layer/${page_id}.txt"
+	if ! extract_pdf_page_text "$_DF_INPUT" "$page" "$text_file"; then
+		: >"$text_file"
+	fi
+	text_chars=$(_df_nonspace_chars "$text_file")
+	if [[ "$text_chars" -ge "$_DF_MIN_TEXT_CHARS" ]]; then
+		_df_process_searchable_page "$page" "$page_id" "$text_file" "$text_chars"
+	else
+		_df_process_suspect_page "$page" "$page_id"
+	fi
+	_df_annotate_page_dimensions "$page" "$page_id" || return 1
+	return 0
+}
+
+_df_verify_readable_pdf() {
+	local output="$1"
+	local output_pages=""
+	local page=1
+	local source_dimensions=""
+	local derived_dimensions=""
+
+	if ! output_pages=$(pdf_page_count "$output") || [[ "$output_pages" -ne "$_DF_PAGE_COUNT" ]]; then
+		_df_record_failure 0 "" "Readable PDF page count differs from the source"
+		return 1
+	fi
+	while [[ "$page" -le "$_DF_PAGE_COUNT" ]]; do
+		if ! source_dimensions=$(pdf_page_dimensions "$_DF_INPUT" "$page") || \
+			! derived_dimensions=$(pdf_page_dimensions "$output" "$page") || \
+			[[ "$source_dimensions" != "$derived_dimensions" ]]; then
+			_df_record_failure "$page" "" "Readable PDF page dimensions differ from the source"
+			return 1
+		fi
+		page=$((page + 1))
+	done
+	return 0
+}
+
+_df_publish_atomic_file() {
+	local source="$1"
+	local destination="$2"
+	local staged=""
+
+	if [[ ! -f "$source" ]] || [[ -d "$destination" ]]; then
+		return 1
+	fi
+	staged=$(mktemp "${destination}.tmp.XXXXXX") || return 1
+	if ! cp "$source" "$staged"; then
+		rm -f "$staged"
+		return 1
+	fi
+	if replace_file_atomically "$staged" "$destination"; then
+		return 0
+	fi
+	rm -f "$staged"
+	return 1
+}
+
+_df_transaction_is_owned() {
+	local transaction_dir="$1"
+	local schema=""
+
+	if [[ ! -d "$transaction_dir" ]] || [[ -L "$transaction_dir" ]] || \
+		[[ ! -f "${transaction_dir}/schema" ]]; then
+		return 1
+	fi
+	schema=$(<"${transaction_dir}/schema")
+	if [[ "$schema" == "$_DF_TRANSACTION_SCHEMA" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+_df_cleanup_committed_transactions() {
+	local candidate=""
+
+	for candidate in "${_DF_TRANSACTION_DIR}.committed."*; do
+		if [[ ! -e "$candidate" ]] && [[ ! -L "$candidate" ]]; then
+			continue
+		fi
+		if ! _df_transaction_is_owned "$candidate"; then
+			log_error "Refusing to remove an unrecognized forensic transaction artifact"
+			return 1
+		fi
+		rm -rf "$candidate" || return 1
+	done
+	return 0
+}
+
+_df_backup_transaction_output() {
+	local destination="$1"
+	local marker="$2"
+	local backup="$3"
+
+	if [[ ! -e "$destination" ]] && [[ ! -L "$destination" ]]; then
+		return 0
+	fi
+	if [[ -d "$destination" ]] || ! cp "$destination" "$backup"; then
+		return 1
+	fi
+	if : >"$marker"; then
+		return 0
+	fi
+	return 1
+}
+
+_df_restore_transaction_output() {
+	local marker="$1"
+	local backup="$2"
+	local destination="$3"
+
+	if [[ -f "$marker" ]]; then
+		if [[ -f "$backup" ]]; then
+			_df_publish_atomic_file "$backup" "$destination"
+			return $?
+		fi
+		if [[ -f "$destination" ]]; then
+			return 0
+		fi
+		return 1
+	fi
+	if [[ -d "$destination" ]]; then
+		return 1
+	fi
+	rm -f "$destination"
+	return $?
+}
+
+_df_recover_interrupted_publication() {
+	local rollback_ok=true
+
+	if [[ ! -e "$_DF_TRANSACTION_DIR" ]] && [[ ! -L "$_DF_TRANSACTION_DIR" ]]; then
+		return 0
+	fi
+	if ! _df_transaction_is_owned "$_DF_TRANSACTION_DIR"; then
+		log_error "Refusing to recover an unrecognized forensic output transaction"
+		return 1
+	fi
+	if [[ ! -f "${_DF_TRANSACTION_DIR}/${_DF_TRANSACTION_PREPARED}" ]]; then
+		rm -rf "$_DF_TRANSACTION_DIR"
+		return $?
+	fi
+	_df_restore_transaction_output "${_DF_TRANSACTION_DIR}/had-sidecar" \
+		"${_DF_TRANSACTION_DIR}/sidecar.backup" "$_DF_SIDECAR_PATH" || rollback_ok=false
+	_df_restore_transaction_output "${_DF_TRANSACTION_DIR}/had-readable" \
+		"${_DF_TRANSACTION_DIR}/readable.backup" "$_DF_READABLE_PATH" || rollback_ok=false
+	_df_restore_transaction_output "${_DF_TRANSACTION_DIR}/had-manifest" \
+		"${_DF_TRANSACTION_DIR}/manifest.backup" "$_DF_MANIFEST_PATH" || rollback_ok=false
+	if [[ "$rollback_ok" == true ]]; then
+		rm -rf "$_DF_TRANSACTION_DIR"
+		return $?
+	fi
+	log_error "Forensic output recovery failed; the durable transaction was retained"
+	return 1
+}
+
+_df_prepare_output_transaction() {
+	if ! _df_recover_interrupted_publication; then
+		return 1
+	fi
+	if ! mkdir "$_DF_TRANSACTION_DIR" 2>/dev/null; then
+		return 1
+	fi
+	if ! printf '%s\n' "$_DF_TRANSACTION_SCHEMA" >"${_DF_TRANSACTION_DIR}/schema" || \
+		! _df_backup_transaction_output "$_DF_SIDECAR_PATH" \
+			"${_DF_TRANSACTION_DIR}/had-sidecar" "${_DF_TRANSACTION_DIR}/sidecar.backup" || \
+		! _df_backup_transaction_output "$_DF_READABLE_PATH" \
+			"${_DF_TRANSACTION_DIR}/had-readable" "${_DF_TRANSACTION_DIR}/readable.backup" || \
+		! _df_backup_transaction_output "$_DF_MANIFEST_PATH" \
+			"${_DF_TRANSACTION_DIR}/had-manifest" "${_DF_TRANSACTION_DIR}/manifest.backup"; then
+		rm -rf "$_DF_TRANSACTION_DIR"
+		return 1
+	fi
+	if : >"${_DF_TRANSACTION_DIR}/${_DF_TRANSACTION_PREPARED}"; then
+		return 0
+	fi
+	rm -rf "$_DF_TRANSACTION_DIR"
+	return 1
+}
+
+_df_commit_output_transaction() {
+	local committed_dir="${_DF_TRANSACTION_DIR}.committed.${_DF_TMP_DIR##*.}"
+
+	if ! _df_move_directory_atomically "$_DF_TRANSACTION_DIR" "$committed_dir"; then
+		return 1
+	fi
+	if ! rm -rf "$committed_dir"; then
+		log_warn "Committed forensic transaction backup cleanup was deferred"
+	fi
+	return 0
+}
+
+_df_publish_forensic_outputs() {
+	local manifest_tmp="$1"
+	local publication_ok=false
+
+	_df_prepare_output_transaction || return 1
+	if _df_publish_atomic_file "$_DF_SIDECAR_TMP" "$_DF_SIDECAR_PATH"; then
+		if [[ -n "$_DF_READABLE_TMP" ]] && [[ -f "$_DF_READABLE_TMP" ]]; then
+			_df_publish_atomic_file "$_DF_READABLE_TMP" "$_DF_READABLE_PATH" && publication_ok=true
+		elif rm -f "$_DF_READABLE_PATH"; then
+			publication_ok=true
+		fi
+	fi
+	if [[ "$publication_ok" == true ]] && _df_publish_atomic_file "$manifest_tmp" "$_DF_MANIFEST_PATH" && \
+		_df_commit_output_transaction; then
+		return 0
+	fi
+	if ! _df_recover_interrupted_publication; then
+		log_error "Forensic output publication failed and requires transaction recovery"
+	fi
+	return 1
+}
+
+_df_assemble_readable_pdf() {
+	local output_tmp="${_DF_TMP_DIR}/${_DF_STEM}.readable.pdf"
+	local page=1
+	local page_id=""
+	local page_file=""
+	local -a page_files=()
+
+	while [[ "$page" -le "$_DF_PAGE_COUNT" ]]; do
+		printf -v page_id '%04d' "$page"
+		page_file="${_DF_TMP_DIR}/page-pdfs/${page_id}.pdf"
+		if [[ ! -f "$page_file" ]]; then
+			_df_record_failure "$page" "" "Readable derivative is missing a page"
+			return 1
+		fi
+		page_files+=("$page_file")
+		page=$((page + 1))
+	done
+
+	if [[ -n "${DOCUMENT_FORENSICS_PDF_ASSEMBLER:-}" ]]; then
+		if ! "${DOCUMENT_FORENSICS_PDF_ASSEMBLER}" "$output_tmp" "${page_files[@]}"; then
+			_df_record_failure 0 "" "Readable PDF assembly failed"
+			return 1
+		fi
+	elif has_cmd pdfunite; then
+		if ! pdfunite "${page_files[@]}" "$output_tmp" >/dev/null 2>&1; then
+			_df_record_failure 0 "" "Readable PDF assembly failed"
+			return 1
+		fi
+	else
+		_df_record_failure 0 "" "pdfunite is unavailable"
+		return 1
+	fi
+
+	if [[ ! -f "$output_tmp" ]]; then
+		_df_record_failure 0 "" "Readable PDF output was not created"
+		return 1
+	fi
+	if ! _df_verify_readable_pdf "$output_tmp"; then
+		rm -f "$output_tmp"
+		return 1
+	fi
+	_DF_READABLE_TMP="$output_tmp"
+	return 0
+}
+
+_df_finalize_manifest() {
+	local source_hash_before="$1"
+	local source_hash_after="$2"
+	local backend_version="$3"
+	local pages_json="[]"
+	local failures_json="[]"
+	local sidecar_hash=""
+	local readable_hash=""
+	local readable_json="$_DF_VALUE_NULL"
+	local manifest_tmp="${_DF_TMP_DIR}/manifest.json"
+
+	pages_json=$(jq -s 'sort_by(.page)' "${_DF_TMP_DIR}"/pages/*.json)
+	if [[ "$_DF_FAILURE_COUNT" -gt 0 ]]; then
+		failures_json=$(jq -s '.' "${_DF_TMP_DIR}"/failures/*.json)
+	fi
+	sidecar_hash=$(_df_sha256 "$_DF_SIDECAR_TMP") || return 1
+	if [[ "$_DF_WRITE_READABLE" == true ]] && [[ -f "$_DF_READABLE_TMP" ]]; then
+		readable_hash=$(_df_sha256 "$_DF_READABLE_TMP") || return 1
+		readable_json=$(jq -n \
+			--arg path "readable/${_DF_STEM}.pdf" \
+			--arg sha256 "$readable_hash" \
+			'{path: $path, sha256: $sha256}')
+	fi
+
+	if [[ "$source_hash_before" != "$source_hash_after" ]] || [[ "$_DF_PAGE_SUCCESS_COUNT" -eq 0 ]]; then
+		_DF_FINAL_STATUS="$_DF_STATUS_FAILED"
+	elif [[ "$_DF_PAGE_FAILED_COUNT" -gt 0 ]] || [[ "$_DF_FAILURE_COUNT" -gt 0 ]]; then
+		_DF_FINAL_STATUS="partial"
+	else
+		_DF_FINAL_STATUS="complete"
+	fi
+
+	jq -n \
+		--arg schema "$DOCUMENT_FORENSICS_SCHEMA" \
+		--arg status "$_DF_FINAL_STATUS" \
+		--arg source_name "$(basename "$_DF_INPUT")" \
+		--arg source_hash_before "$source_hash_before" \
+		--arg source_hash_after "$source_hash_after" \
+		--argjson page_count "$_DF_PAGE_COUNT" \
+		--arg provider "$_DF_PROVIDER" \
+		--arg backend_version "$backend_version" \
+		--argjson dpi "$_DF_DPI" \
+		--argjson min_text_chars "$_DF_MIN_TEXT_CHARS" \
+		--argjson min_improvement "$_DF_MIN_IMPROVEMENT" \
+		--argjson min_words "$_DF_MIN_WORDS" \
+		--arg text_path "${_DF_STEM}.txt" \
+		--arg text_hash "$sidecar_hash" \
+		--arg manifest_path "${_DF_STEM}.manifest.json" \
+		--argjson readable "$readable_json" \
+		--argjson pages "$pages_json" \
+		--argjson failures "$failures_json" \
+		'{
+			schema: $schema,
+			status: $status,
+			source: {name: $source_name, sha256: $source_hash_before, sha256_after: $source_hash_after, page_count: $page_count},
+			backend: {provider: $provider, version: $backend_version, network_used: false},
+			thresholds: {render_dpi: $dpi, min_text_chars: $min_text_chars, min_transform_improvement: $min_improvement, min_words: $min_words},
+			outputs: {text: {path: $text_path, sha256: $text_hash}, readable_pdf: $readable, manifest: {path: $manifest_path}},
+			pages: $pages,
+			failures: $failures
+		}' >"$manifest_tmp"
+	if _df_publish_forensic_outputs "$manifest_tmp"; then
+		return 0
+	fi
+	return 1
+}
+
+_df_validate_integer() {
+	local value="$1"
+	local minimum="$2"
+
+	if [[ ! "$value" =~ ^[0-9]+$ ]] || [[ "$value" -lt "$minimum" ]]; then
+		return 1
+	fi
+	return 0
+}
+
+_df_first_arg() {
+	local value="$1"
+	printf '%s' "$value"
+	return 0
+}
+
+_df_second_arg() {
+	local value="$2"
+	printf '%s' "$value"
+	return 0
+}
+
+_df_parse_forensics_args() {
+	local current=""
+	local value=""
+
+	while [[ $# -gt 0 ]]; do
+		current=$(_df_first_arg "$@")
+		case "$current" in
+		--output | -o | --provider | --ocr | --min-improvement | --min-text-chars | --dpi)
+			if [[ $# -lt 2 ]]; then
+				die "Missing value for ${current}"
+				return 1
+			fi
+			value=$(_df_second_arg "$@")
+			case "$current" in
+			--output | -o) _DF_ARG_OUTPUT="$value" ;;
+			--provider | --ocr) _DF_ARG_PROVIDER="$value" ;;
+			--min-improvement)
+				_df_validate_integer "$value" 1 || { die "--min-improvement must be a positive integer"; return 1; }
+				_DF_MIN_IMPROVEMENT="$value"
+				;;
+			--min-text-chars)
+				_df_validate_integer "$value" 1 || { die "--min-text-chars must be a positive integer"; return 1; }
+				_DF_MIN_TEXT_CHARS="$value"
+				;;
+			--dpi)
+				_df_validate_integer "$value" 72 || { die "--dpi must be an integer of at least 72"; return 1; }
+				_DF_DPI="$value"
+				;;
+			esac
+			shift 2
+			;;
+		--write-readable)
+			_DF_WRITE_READABLE=true
+			shift
+			;;
+		--help | -h)
+			printf 'Usage: %s forensics <input.pdf> [--output DIR] [--provider NAME] [--write-readable] [--min-improvement N] [--dpi N]\n' "$SCRIPT_NAME"
+			_DF_HELP_REQUESTED=true
+			return 0
+			;;
+		--*)
+			die "Unknown forensics option: ${current}"
+			return 1
+			;;
+		*)
+			if [[ -z "$_DF_ARG_INPUT" ]]; then
+				_DF_ARG_INPUT="$current"
+			else
+				die "Only one PDF input is supported"
+				return 1
+			fi
+			shift
+			;;
+		esac
+	done
+	return 0
+}
+
+_df_prepare_run() {
+	local input_dir=""
+	local input_name=""
+	local temp_root="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+
+	if [[ -z "$_DF_ARG_INPUT" ]] || [[ ! -f "$_DF_ARG_INPUT" ]]; then
+		die "PDF input not found: ${_DF_ARG_INPUT:-<missing>}"
+		return 1
+	fi
+	if [[ "$(get_ext "$_DF_ARG_INPUT")" != "pdf" ]]; then
+		die "Document forensics currently supports PDF input only"
+		return 1
+	fi
+	if ! has_cmd jq || ! has_cmd python3 || ! has_cmd pdfinfo || ! has_cmd pdftotext || ! has_cmd pdftoppm; then
+		die "Document forensics requires jq, Python 3, and Poppler (pdfinfo, pdftotext, pdftoppm)"
+		return 1
+	fi
+	if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+		die "Document forensics requires a supported SHA-256 command"
+		return 1
+	fi
+
+	if [[ -n "${DOCUMENT_FORENSICS_OCR_RUNNER:-}" ]]; then
+		_DF_PROVIDER="$_DF_ARG_PROVIDER"
+		[[ "$_DF_PROVIDER" == "$_DF_VALUE_AUTO" ]] && _DF_PROVIDER="fixture"
+	elif [[ "$_DF_ARG_PROVIDER" == "$_DF_VALUE_AUTO" ]]; then
+		if has_cmd tesseract; then
+			_DF_PROVIDER="tesseract"
+		elif has_python_pkg easyocr 2>/dev/null; then
+			_DF_PROVIDER="easyocr"
+		elif has_cmd ollama && ollama list 2>/dev/null | grep -q "glm-ocr"; then
+			_DF_PROVIDER="glm-ocr"
+		else
+			_DF_PROVIDER="$_DF_PROVIDER_UNAVAILABLE"
+		fi
+	else
+		_DF_PROVIDER=$(select_ocr_provider "$_DF_ARG_PROVIDER") || return 1
+	fi
+
+	input_dir=$(cd "$(dirname "$_DF_ARG_INPUT")" && pwd)
+	input_name=$(basename "$_DF_ARG_INPUT")
+	_DF_INPUT="${input_dir}/${input_name}"
+	_DF_STEM="${input_name%.*}"
+	if [[ -z "$_DF_ARG_OUTPUT" ]]; then
+		_DF_ARG_OUTPUT="${input_dir}/forensics/${_DF_STEM}"
+	fi
+	_DF_OUTPUT_DIR="$_DF_ARG_OUTPUT"
+	_DF_SIDECAR_PATH="${_DF_OUTPUT_DIR}/${_DF_STEM}.txt"
+	_DF_MANIFEST_PATH="${_DF_OUTPUT_DIR}/${_DF_STEM}.manifest.json"
+	_DF_READABLE_PATH="${_DF_OUTPUT_DIR}/readable/${_DF_STEM}.pdf"
+	_DF_TRANSACTION_DIR="${_DF_OUTPUT_DIR}/.${_DF_STEM}.forensics.transaction"
+
+	mkdir -p "$temp_root" "$_DF_OUTPUT_DIR"
+	if [[ "$_DF_WRITE_READABLE" == true ]]; then
+		mkdir -p "${_DF_OUTPUT_DIR}/readable"
+	fi
+	_DF_TMP_DIR=$(mktemp -d "${temp_root%/}/document-forensics.XXXXXX") || return 1
+	trap '_df_cleanup' EXIT
+	mkdir -p "${_DF_TMP_DIR}/candidates" "${_DF_TMP_DIR}/failures" \
+		"${_DF_TMP_DIR}/page-pdfs" "${_DF_TMP_DIR}/pages" \
+		"${_DF_TMP_DIR}/rendered" "${_DF_TMP_DIR}/source-pages" \
+		"${_DF_TMP_DIR}/text-layer"
+	_DF_SIDECAR_TMP="${_DF_TMP_DIR}/${_DF_STEM}.txt"
+	: >"$_DF_SIDECAR_TMP"
+	if ! _df_acquire_output_lock; then
+		_df_cleanup
+		return 1
+	fi
+	if ! _df_cleanup_committed_transactions || ! _df_recover_interrupted_publication; then
+		_df_cleanup
+		return 1
+	fi
+
+	_DF_SOURCE_HASH_BEFORE=$(_df_sha256 "$_DF_INPUT") || { _df_cleanup; return 1; }
+	if ! _DF_PAGE_COUNT=$(pdf_page_count "$_DF_INPUT"); then
+		_df_cleanup
+		die "Unable to determine PDF page count"
+		return 1
+	fi
+	if [[ -n "${DOCUMENT_FORENSICS_OCR_VERSION:-}" ]]; then
+		_DF_BACKEND_VERSION="$DOCUMENT_FORENSICS_OCR_VERSION"
+	else
+		_DF_BACKEND_VERSION=$(ocr_provider_version "$_DF_PROVIDER")
+	fi
+	return 0
+}
+
+_df_execute_run() {
+	local page=1
+
+	log_info "Auditing ${_DF_PAGE_COUNT} PDF pages with ${_DF_PROVIDER}"
+	while [[ "$page" -le "$_DF_PAGE_COUNT" ]]; do
+		_df_process_page "$page"
+		page=$((page + 1))
+	done
+
+	if [[ "$_DF_WRITE_READABLE" == true ]]; then
+		_df_assemble_readable_pdf || true
+	fi
+	_DF_SOURCE_HASH_AFTER=$(_df_sha256 "$_DF_INPUT") || { _df_cleanup; return 1; }
+	if [[ "$_DF_SOURCE_HASH_BEFORE" != "$_DF_SOURCE_HASH_AFTER" ]]; then
+		_df_record_failure 0 "" "Source PDF hash changed during processing"
+	fi
+	if ! _df_finalize_manifest "$_DF_SOURCE_HASH_BEFORE" "$_DF_SOURCE_HASH_AFTER" "$_DF_BACKEND_VERSION"; then
+		_df_cleanup
+		return 1
+	fi
+
+	log_ok "Document forensics ${_DF_FINAL_STATUS}: ${_DF_MANIFEST_PATH}"
+	_df_cleanup
+	_DF_TMP_DIR=""
+	case "$_DF_FINAL_STATUS" in
+	complete) return 0 ;;
+	partial) return 2 ;;
+	*) return 1 ;;
+	esac
+}
+
+cmd_document_forensics() {
+	_df_reset_state
+	_df_parse_forensics_args "$@" || return 1
+	[[ "$_DF_HELP_REQUESTED" == true ]] && return 0
+	_df_prepare_run || return 1
+	_df_execute_run
+	return $?
+}

--- a/.agents/scripts/tests/fixtures/document-forensics/failing-tesseract.sh
+++ b/.agents/scripts/tests/fixtures/document-forensics/failing-tesseract.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+exit 9

--- a/.agents/scripts/tests/fixtures/document-forensics/image-runner.sh
+++ b/.agents/scripts/tests/fixtures/document-forensics/image-runner.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+fixture_field() {
+	local field="$1"
+	local file="$2"
+	awk -F '=' -v wanted="$field" '$1 == wanted { value = $2 } END { print value }' "$file"
+	return 0
+}
+
+input="$1"
+transform="$2"
+output="$3"
+dpi="$4"
+kind=$(fixture_field KIND "$input")
+page=$(fixture_field PAGE "$input")
+canvas=$(fixture_field CANVAS "$input")
+printf 'KIND=%s\nPAGE=%s\nTRANSFORM=%s\nCANVAS=%s\nDPI=%s\n' \
+	"$kind" "$page" "$transform" "$canvas" "$dpi" >"$output"

--- a/.agents/scripts/tests/fixtures/document-forensics/ocr-runner.sh
+++ b/.agents/scripts/tests/fixtures/document-forensics/ocr-runner.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+fixture_field() {
+	local field="$1"
+	local file="$2"
+	awk -F '=' -v wanted="$field" '$1 == wanted { value = $2 } END { print value }' "$file"
+	return 0
+}
+
+image="$1"
+provider="$2"
+text_output="$3"
+evidence_output="$4"
+kind=$(fixture_field KIND "$image")
+page=$(fixture_field PAGE "$image")
+transform=$(fixture_field TRANSFORM "$image")
+confidence=10
+
+case "$kind" in
+mirrored)
+	[[ "$transform" == "flip-horizontal" ]] && confidence=94
+	[[ "$transform" == "original" ]] && confidence=18
+	;;
+rotated)
+	[[ "$transform" == "rotate-90" ]] && confidence=95
+	[[ "$transform" == "original" ]] && confidence=16
+	;;
+normal-scan)
+	[[ "$transform" == "original" ]] && confidence=91
+	;;
+mixed)
+	if [[ "$page" -eq 2 ]] && [[ "$transform" == "flip-horizontal" ]]; then
+		confidence=93
+	elif [[ "$page" -eq 3 ]] && [[ "$transform" == "rotate-180" ]]; then
+		confidence=96
+	elif [[ "$transform" == "original" ]]; then
+		confidence=14
+	fi
+	;;
+sparse)
+	[[ "$transform" == "flip-horizontal" ]] && confidence=30
+	[[ "$transform" == "original" ]] && confidence=10
+	;;
+partial)
+	if [[ "$transform" == "rotate-270" ]]; then
+		exit 7
+	fi
+	[[ "$transform" == "original" ]] && confidence=88
+	;;
+mixed-failure)
+	exit 7
+	;;
+original-fails)
+	if [[ "$transform" == "original" ]]; then
+		exit 7
+	fi
+	[[ "$transform" == "flip-horizontal" ]] && confidence=95
+	;;
+esac
+
+if [[ "$kind" == "sparse" ]]; then
+	printf 'x y\n' >"$text_output"
+else
+	printf 'Readable forensic fixture text for %s page %s using %s with enough words for conservative evidence.\n' \
+		"$kind" "$page" "$transform" >"$text_output"
+fi
+jq -n --argjson confidence "$confidence" --arg fixture "$kind" \
+	--arg transform "$transform" --arg provider "$provider" \
+	'{confidence: $confidence, fixture: $fixture, transform: $transform, provider: $provider}' \
+	>"$evidence_output"

--- a/.agents/scripts/tests/fixtures/document-forensics/pdf-assembler.sh
+++ b/.agents/scripts/tests/fixtures/document-forensics/pdf-assembler.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+output="$1"
+shift
+: >"$output"
+for page_file in "$@"; do
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		printf '%s\n' "$line" >>"$output"
+	done <"$page_file"
+done

--- a/.agents/scripts/tests/fixtures/document-forensics/pdf-runner.sh
+++ b/.agents/scripts/tests/fixtures/document-forensics/pdf-runner.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+fixture_field() {
+	local field="$1"
+	local file="$2"
+	awk -F '=' -v wanted="$field" '$1 == wanted { value = $2 } END { print value }' "$file"
+	return 0
+}
+
+file_hash() {
+	local file="$1"
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$file" | awk '{ value = $1 } END { print value }'
+		return 0
+	fi
+	if command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$file" | awk '{ value = $1 } END { print value }'
+		return 0
+	fi
+	return 1
+}
+
+image="$1"
+text_file="$2"
+output="$3"
+dpi="$4"
+if [[ "${DOCUMENT_FORENSICS_PDF_RUNNER_FAIL:-0}" == "1" ]]; then
+	exit 8
+fi
+kind=$(fixture_field KIND "$image")
+page=$(fixture_field PAGE "$image")
+transform=$(fixture_field TRANSFORM "$image")
+canvas=$(fixture_field CANVAS "$image")
+dimensions="${DOCUMENT_FORENSICS_PDF_DIMENSIONS:-612x792}"
+text_hash=$(file_hash "$text_file")
+printf 'PAGE_PDF kind=%s page=%s transform=%s canvas=%s dimensions=%s dpi=%s text_sha256=%s\n' \
+	"$kind" "$page" "$transform" "$canvas" "$dimensions" "$dpi" "$text_hash" >"$output"

--- a/.agents/scripts/tests/fixtures/document-forensics/poppler-stub.sh
+++ b/.agents/scripts/tests/fixtures/document-forensics/poppler-stub.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+fixture_field() {
+	local field="$1"
+	local file="$2"
+	awk -F '=' -v wanted="$field" '$1 == wanted { value = $2 } END { print value }' "$file"
+	return 0
+}
+
+write_text_output() {
+	local output="$1"
+	local text="$2"
+	if [[ "$output" == "-" ]]; then
+		printf '%s\n' "$text"
+	else
+		printf '%s\n' "$text" >"$output"
+	fi
+	return 0
+}
+
+tool="${0##*/}"
+page=1
+input=""
+output=""
+prefix=""
+pattern=""
+current=""
+
+case "$tool" in
+pdfinfo)
+	while [[ $# -gt 0 ]]; do
+		current="$1"
+		case "$current" in
+		-f)
+			page="$2"
+			shift 2
+			;;
+		-l)
+			shift 2
+			;;
+		*)
+			input="$current"
+			shift
+			;;
+		esac
+	done
+	pages=$(fixture_field PAGES "$input")
+	if [[ ! "$pages" =~ ^[0-9]+$ ]]; then
+		pages=$(awk '/^(SOURCE_PAGE|PAGE_PDF)/ { count += 1 } END { print count + 0 }' "$input")
+	fi
+	dimensions=$(awk -v wanted="$page" '
+		/^(SOURCE_PAGE|PAGE_PDF)/ {
+			count += 1
+			if (count == wanted) {
+				for (field = 1; field <= NF; field += 1) {
+					if ($field ~ /^dimensions=/) {
+						sub(/^dimensions=/, "", $field)
+						print $field
+						exit
+					}
+				}
+			}
+		}
+	' "$input")
+	[[ "$dimensions" =~ ^[0-9]+x[0-9]+$ ]] || dimensions="612x792"
+	width="${dimensions%x*}"
+	height="${dimensions#*x}"
+	printf 'Pages: %s\n' "$pages"
+	printf 'Page %s size: %s x %s pts\n' "$page" "$width" "$height"
+	;;
+pdftotext)
+	while [[ $# -gt 0 ]]; do
+		current="$1"
+		case "$current" in
+		-f)
+			page="$2"
+			shift 2
+			;;
+		-l)
+			shift 2
+			;;
+		-*) shift ;;
+		*)
+			if [[ -z "$input" ]]; then
+				input="$current"
+			else
+				output="$current"
+			fi
+			shift
+			;;
+		esac
+	done
+	kind=$(fixture_field KIND "$input")
+	text=""
+	if [[ "$kind" == "searchable" ]] || \
+		{ [[ "$kind" == "mixed" || "$kind" == "mixed-failure" ]] && [[ "$page" -eq 1 ]]; }; then
+		text="Searchable source text for fixture ${kind} page ${page}. This page already has a healthy embedded text layer and must remain unchanged."
+	fi
+	write_text_output "$output" "$text"
+	;;
+pdftoppm)
+	while [[ $# -gt 0 ]]; do
+		current="$1"
+		case "$current" in
+		-f)
+			page="$2"
+			shift 2
+			;;
+		-l | -r) shift 2 ;;
+		-singlefile | -png) shift ;;
+		*)
+			if [[ -z "$input" ]]; then
+				input="$current"
+			else
+				prefix="$current"
+			fi
+			shift
+			;;
+		esac
+	done
+	kind=$(fixture_field KIND "$input")
+	printf 'KIND=%s\nPAGE=%s\nTRANSFORM=rendered\nCANVAS=1200x1600\n' "$kind" "$page" >"${prefix}.png"
+	;;
+pdfseparate)
+	while [[ $# -gt 0 ]]; do
+		current="$1"
+		case "$current" in
+		-f)
+			page="$2"
+			shift 2
+			;;
+		-l) shift 2 ;;
+		*)
+			if [[ -z "$input" ]]; then
+				input="$current"
+			else
+				pattern="$current"
+			fi
+			shift
+			;;
+		esac
+	done
+	kind=$(fixture_field KIND "$input")
+	output="${pattern/\%d/$page}"
+	printf 'SOURCE_PAGE kind=%s page=%s dimensions=612x792\n' "$kind" "$page" >"$output"
+	;;
+*)
+	printf 'Unsupported fixture command: %s\n' "$tool" >&2
+	exit 1
+	;;
+esac

--- a/.agents/scripts/tests/test-document-forensics-helper.sh
+++ b/.agents/scripts/tests/test-document-forensics-helper.sh
@@ -1,0 +1,483 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../document-creation-helper.sh"
+CORE_LIB="${SCRIPT_DIR}/../document-creation-core-lib.sh"
+FORENSICS_LIB="${SCRIPT_DIR}/../document-forensics-lib.sh"
+FIXTURE_SOURCE_DIR="${SCRIPT_DIR}/fixtures/document-forensics"
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+RUNNER_DIR="${TMPDIR_TEST}/runners"
+BIN_DIR="${TMPDIR_TEST}/bin"
+FIXTURE_DIR="${TMPDIR_TEST}/fixtures with spaces"
+OUTPUT_DIR="${TMPDIR_TEST}/outputs with spaces"
+export AIDEVOPS_TEMP_DIR="${TMPDIR_TEST}/workspace"
+mkdir -p "$RUNNER_DIR" "$BIN_DIR" "$FIXTURE_DIR" "$OUTPUT_DIR" "$AIDEVOPS_TEMP_DIR"
+cp "${FIXTURE_SOURCE_DIR}"/*.sh "$RUNNER_DIR/"
+chmod 700 "${RUNNER_DIR}"/*.sh
+ln -s "${RUNNER_DIR}/poppler-stub.sh" "${BIN_DIR}/pdfinfo"
+ln -s "${RUNNER_DIR}/poppler-stub.sh" "${BIN_DIR}/pdftotext"
+ln -s "${RUNNER_DIR}/poppler-stub.sh" "${BIN_DIR}/pdftoppm"
+ln -s "${RUNNER_DIR}/poppler-stub.sh" "${BIN_DIR}/pdfseparate"
+ln -s "${RUNNER_DIR}/failing-tesseract.sh" "${BIN_DIR}/tesseract"
+
+export PATH="${BIN_DIR}:${PATH}"
+export DOCUMENT_FORENSICS_IMAGE_RUNNER="${RUNNER_DIR}/image-runner.sh"
+export DOCUMENT_FORENSICS_OCR_RUNNER="${RUNNER_DIR}/ocr-runner.sh"
+export DOCUMENT_FORENSICS_OCR_VERSION="fixture-1"
+export DOCUMENT_FORENSICS_PDF_RUNNER="${RUNNER_DIR}/pdf-runner.sh"
+export DOCUMENT_FORENSICS_PDF_ASSEMBLER="${RUNNER_DIR}/pdf-assembler.sh"
+
+pass_count=0
+fail_count=0
+
+pass() {
+	local name="$1"
+	printf 'PASS: %s\n' "$name"
+	pass_count=$((pass_count + 1))
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	printf 'FAIL: %s%s\n' "$name" "${detail:+ — $detail}"
+	fail_count=$((fail_count + 1))
+	return 0
+}
+
+create_fixture() {
+	local name="$1"
+	local kind="$2"
+	local pages="$3"
+	printf 'PAGES=%s\nKIND=%s\n' "$pages" "$kind" >"${FIXTURE_DIR}/${name}.pdf"
+	return 0
+}
+
+file_hash() {
+	local file="$1"
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$file" | awk '{ value = $1 } END { print value }'
+		return 0
+	fi
+	if command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$file" | awk '{ value = $1 } END { print value }'
+		return 0
+	fi
+	return 1
+}
+
+assert_jq() {
+	local name="$1"
+	local file="$2"
+	local expression="$3"
+	if jq -e "$expression" "$file" >/dev/null 2>&1; then
+		pass "$name"
+	else
+		fail "$name" "jq expression failed: ${expression}"
+	fi
+	return 0
+}
+
+assert_file_exists() {
+	local name="$1"
+	local file="$2"
+	if [[ -f "$file" ]]; then
+		pass "$name"
+	else
+		fail "$name" "missing ${file}"
+	fi
+	return 0
+}
+
+assert_file_absent() {
+	local name="$1"
+	local file="$2"
+	if [[ ! -e "$file" ]]; then
+		pass "$name"
+	else
+		fail "$name" "unexpected ${file}"
+	fi
+	return 0
+}
+
+assert_contains() {
+	local name="$1"
+	local file="$2"
+	local expected="$3"
+	if grep -Fq "$expected" "$file"; then
+		pass "$name"
+	else
+		fail "$name" "missing ${expected}"
+	fi
+	return 0
+}
+
+assert_source_unchanged() {
+	local name="$1"
+	local file="$2"
+	local before="$3"
+	local after=""
+	after=$(file_hash "$file")
+	if [[ "$before" == "$after" ]]; then
+		pass "$name"
+	else
+		fail "$name" "source hash changed"
+	fi
+	return 0
+}
+
+run_forensics() {
+	local name="$1"
+	local fixture="$2"
+	local output="$3"
+	local expected_rc="$4"
+	shift 4
+	local rc=0
+	set +e
+	"$HELPER" forensics "$fixture" --output "$output" "$@" >/dev/null 2>&1
+	rc=$?
+	set -e
+	if [[ "$rc" -eq "$expected_rc" ]]; then
+		pass "${name}: expected exit ${expected_rc}"
+	else
+		fail "${name}: expected exit ${expected_rc}" "got ${rc}"
+	fi
+	return 0
+}
+
+assert_no_temp_artifacts() {
+	local candidate=""
+	for candidate in "${AIDEVOPS_TEMP_DIR}"/document-forensics.*; do
+		if [[ -e "$candidate" ]]; then
+			fail "temporary forensic workspaces are cleaned" "found ${candidate}"
+			return 0
+		fi
+	done
+	pass "temporary forensic workspaces are cleaned"
+	return 0
+}
+
+assert_ocr_failure_propagates() {
+	local image="$1"
+	local rc=0
+	set +e
+	(
+		SCRIPT_DIR="${SCRIPT_DIR}/.."
+		VENV_DIR="${TMPDIR_TEST}/venv"
+		TEMPLATE_DIR="${TMPDIR_TEST}/templates"
+		LOG_DIR="${TMPDIR_TEST}/logs"
+		RED='' GREEN='' YELLOW='' BLUE='' BOLD='' NC=''
+		# shellcheck source=../document-creation-core-lib.sh
+		# shellcheck disable=SC1090
+		source "$CORE_LIB"
+		run_ocr "$image" tesseract >/dev/null
+	)
+	rc=$?
+	set -e
+	if [[ "$rc" -ne 0 ]]; then
+		pass "OCR backend failures propagate to callers"
+	else
+		fail "OCR backend failures propagate to callers"
+	fi
+	return 0
+}
+
+assert_scanned_ocr_is_atomic() {
+	local fixture="$1"
+	local output="${TMPDIR_TEST}/existing-ocr-output.txt"
+	local rc=0
+	local content=""
+	printf 'preserve existing output\n' >"$output"
+	set +e
+	(
+		SCRIPT_DIR="${SCRIPT_DIR}/.."
+		VENV_DIR="${TMPDIR_TEST}/venv"
+		TEMPLATE_DIR="${TMPDIR_TEST}/templates"
+		LOG_DIR="${TMPDIR_TEST}/logs"
+		RED='' GREEN='' YELLOW='' BLUE='' BOLD='' NC=''
+		# shellcheck source=../document-creation-core-lib.sh
+		# shellcheck disable=SC1090
+		source "$CORE_LIB"
+		ocr_scanned_pdf "$fixture" tesseract "$output" >/dev/null 2>&1
+	)
+	rc=$?
+	set -e
+	content=$(<"$output")
+	if [[ "$rc" -ne 0 ]] && [[ "$content" == "preserve existing output" ]]; then
+		pass "scanned-PDF OCR publishes output atomically"
+	else
+		fail "scanned-PDF OCR publishes output atomically" "rc=${rc} content=${content}"
+	fi
+	return 0
+}
+
+assert_scanned_ocr_rejects_directory() {
+	local fixture="$1"
+	local output="${TMPDIR_TEST}/ocr-output-directory"
+	local rc=0
+	mkdir -p "$output"
+	set +e
+	(
+		SCRIPT_DIR="${SCRIPT_DIR}/.."
+		VENV_DIR="${TMPDIR_TEST}/venv"
+		TEMPLATE_DIR="${TMPDIR_TEST}/templates"
+		LOG_DIR="${TMPDIR_TEST}/logs"
+		RED='' GREEN='' YELLOW='' BLUE='' BOLD='' NC=''
+		# shellcheck source=../document-creation-core-lib.sh
+		# shellcheck disable=SC1090
+		source "$CORE_LIB"
+		ocr_scanned_pdf "$fixture" tesseract "$output" >/dev/null 2>&1
+	)
+	rc=$?
+	set -e
+	if [[ "$rc" -ne 0 ]] && [[ -d "$output" ]]; then
+		pass "scanned-PDF OCR rejects a directory output path"
+	else
+		fail "scanned-PDF OCR rejects a directory output path" "rc=${rc}"
+	fi
+	return 0
+}
+
+assert_unverifiable_lock_owner_is_live() {
+	local rc=0
+	set +e
+	(
+		SCRIPT_DIR="${SCRIPT_DIR}/.."
+		VENV_DIR="${TMPDIR_TEST}/venv"
+		TEMPLATE_DIR="${TMPDIR_TEST}/templates"
+		LOG_DIR="${TMPDIR_TEST}/logs"
+		RED='' GREEN='' YELLOW='' BLUE='' BOLD='' NC=''
+		# shellcheck source=../document-creation-core-lib.sh
+		# shellcheck disable=SC1090
+		source "$CORE_LIB"
+		# shellcheck source=../document-forensics-lib.sh
+		# shellcheck disable=SC1090
+		source "$FORENSICS_LIB"
+		kill() { return 1; }
+		ps() { printf '424242\n'; return 0; }
+		_df_lock_owner_is_live '424242:test'
+	)
+	rc=$?
+	set -e
+	if [[ "$rc" -eq 0 ]]; then
+		pass "output lock treats an observable permission-denied PID as live"
+	else
+		fail "output lock treats an observable permission-denied PID as live"
+	fi
+	return 0
+}
+
+create_fixture searchable searchable 1
+create_fixture mirrored mirrored 1
+create_fixture rotated rotated 1
+create_fixture mixed mixed 3
+create_fixture sparse sparse 1
+create_fixture normal-scan normal-scan 1
+create_fixture partial partial 1
+create_fixture mixed-failure mixed-failure 2
+create_fixture original-fails original-fails 1
+create_fixture invalid invalid 0
+assert_ocr_failure_propagates "${FIXTURE_DIR}/mirrored.pdf"
+assert_scanned_ocr_is_atomic "${FIXTURE_DIR}/mirrored.pdf"
+assert_scanned_ocr_rejects_directory "${FIXTURE_DIR}/mirrored.pdf"
+assert_unverifiable_lock_owner_is_live
+
+preflight_output="${OUTPUT_DIR}/invalid"
+preflight_readable="${preflight_output}/readable/invalid.pdf"
+preflight_manifest="${preflight_output}/invalid.manifest.json"
+mkdir -p "${preflight_output}/readable"
+printf 'previous readable derivative\n' >"$preflight_readable"
+printf '{"status":"complete"}\n' >"$preflight_manifest"
+preflight_readable_hash=$(file_hash "$preflight_readable")
+preflight_manifest_hash=$(file_hash "$preflight_manifest")
+run_forensics "invalid preflight" "${FIXTURE_DIR}/invalid.pdf" "$preflight_output" 1 --write-readable
+assert_source_unchanged "invalid preflight: readable output is preserved" "$preflight_readable" "$preflight_readable_hash"
+assert_source_unchanged "invalid preflight: manifest is preserved" "$preflight_manifest" "$preflight_manifest_hash"
+preflight_sidecar="${preflight_output}/invalid.txt"
+preflight_transaction="${preflight_output}/.invalid.forensics.transaction"
+mkdir "$preflight_transaction"
+printf 'aidevops.document-forensics.transaction/v1\n' >"${preflight_transaction}/schema"
+printf 'restored sidecar\n' >"${preflight_transaction}/sidecar.backup"
+printf 'restored readable\n' >"${preflight_transaction}/readable.backup"
+printf '{"status":"restored"}\n' >"${preflight_transaction}/manifest.backup"
+: >"${preflight_transaction}/had-sidecar"
+: >"${preflight_transaction}/had-readable"
+: >"${preflight_transaction}/had-manifest"
+: >"${preflight_transaction}/prepared"
+preflight_sidecar_hash=$(file_hash "${preflight_transaction}/sidecar.backup")
+preflight_readable_hash=$(file_hash "${preflight_transaction}/readable.backup")
+preflight_manifest_hash=$(file_hash "${preflight_transaction}/manifest.backup")
+printf 'interrupted sidecar\n' >"$preflight_sidecar"
+printf 'interrupted readable\n' >"$preflight_readable"
+printf '{"status":"interrupted"}\n' >"$preflight_manifest"
+run_forensics "interrupted publication recovery" "${FIXTURE_DIR}/invalid.pdf" "$preflight_output" 1 --write-readable
+assert_source_unchanged "interrupted publication: sidecar is restored" "$preflight_sidecar" "$preflight_sidecar_hash"
+assert_source_unchanged "interrupted publication: readable PDF is restored" "$preflight_readable" "$preflight_readable_hash"
+assert_source_unchanged "interrupted publication: manifest is restored" "$preflight_manifest" "$preflight_manifest_hash"
+assert_file_absent "interrupted publication: transaction is cleared" "$preflight_transaction"
+
+searchable_fixture="${FIXTURE_DIR}/searchable.pdf"
+searchable_output="${OUTPUT_DIR}/searchable"
+searchable_hash=$(file_hash "$searchable_fixture")
+run_forensics searchable "$searchable_fixture" "$searchable_output" 0
+searchable_manifest="${searchable_output}/searchable.manifest.json"
+assert_jq "searchable: schema and complete status" "$searchable_manifest" '.schema == "aidevops.document-forensics/v1" and .status == "complete"'
+assert_jq "searchable: healthy page remains unchanged" "$searchable_manifest" '.pages[0].classification == "searchable" and .pages[0].selected_transform == "original" and (.pages[0].ocr.performed | not)'
+assert_jq "searchable: no repaired PDF by default" "$searchable_manifest" '.outputs.readable_pdf == null'
+assert_file_absent "searchable: repaired copy is not emitted" "${searchable_output}/readable/searchable.pdf"
+assert_source_unchanged "searchable: source hash unchanged" "$searchable_fixture" "$searchable_hash"
+manifest_hash_before=$(file_hash "$searchable_manifest")
+run_forensics "searchable rerun" "$searchable_fixture" "$searchable_output" 0
+manifest_hash_after=$(file_hash "$searchable_manifest")
+if [[ "$manifest_hash_before" == "$manifest_hash_after" ]]; then
+	pass "searchable: rerun is manifest-idempotent"
+else
+	fail "searchable: rerun is manifest-idempotent"
+fi
+searchable_lock="${searchable_output}/.searchable.forensics.lock"
+mkdir "$searchable_lock"
+printf '%s:test\n' "$$" >"${searchable_lock}/owner"
+locked_manifest_hash=$(file_hash "$searchable_manifest")
+run_forensics "searchable live lock" "$searchable_fixture" "$searchable_output" 1
+assert_source_unchanged "searchable: live lock preserves manifest" "$searchable_manifest" "$locked_manifest_hash"
+if [[ -d "$searchable_lock" ]]; then
+	pass "searchable: live owner lock is not removed"
+else
+	fail "searchable: live owner lock is not removed"
+fi
+rm -rf "$searchable_lock"
+mkdir "$searchable_lock"
+printf '99999999:stale\n' >"${searchable_lock}/owner"
+run_forensics "searchable stale lock" "$searchable_fixture" "$searchable_output" 0
+assert_file_absent "searchable: stale output lock is reclaimed" "$searchable_lock"
+stale_lock_artifact=false
+for candidate in "${searchable_lock}.stale."*; do
+	[[ -e "$candidate" ]] && stale_lock_artifact=true
+done
+if [[ "$stale_lock_artifact" == false ]]; then
+	pass "searchable: stale-lock rename leaves no blocking marker"
+else
+	fail "searchable: stale-lock rename leaves no blocking marker"
+fi
+
+mirrored_fixture="${FIXTURE_DIR}/mirrored.pdf"
+mirrored_output="${OUTPUT_DIR}/mirrored"
+mirrored_hash=$(file_hash "$mirrored_fixture")
+run_forensics mirrored "$mirrored_fixture" "$mirrored_output" 0 --write-readable
+mirrored_manifest="${mirrored_output}/mirrored.manifest.json"
+assert_jq "mirrored: horizontal repair selected" "$mirrored_manifest" '.pages[0].classification == "mirrored" and .pages[0].selected_transform == "flip-horizontal" and .pages[0].improvement >= 15'
+assert_jq "mirrored: all bounded candidates recorded" "$mirrored_manifest" '.pages[0].candidates | length == 5'
+assert_jq "mirrored: dimensions are preserved" "$mirrored_manifest" '.pages[0].source_dimensions_points == {"width":612,"height":792} and .pages[0].derived_dimensions_points == .pages[0].source_dimensions_points'
+assert_jq "mirrored: portable manifest paths" "$mirrored_manifest" '[.. | strings | select(startswith("/"))] | length == 0'
+assert_file_exists "mirrored: searchable readable PDF emitted" "${mirrored_output}/readable/mirrored.pdf"
+assert_contains "mirrored: sidecar cites page and transform" "${mirrored_output}/mirrored.txt" 'Page 1 [classification=mirrored transform=flip-horizontal]'
+assert_source_unchanged "mirrored: source hash unchanged" "$mirrored_fixture" "$mirrored_hash"
+export DOCUMENT_FORENSICS_PDF_RUNNER_FAIL=1
+run_forensics "mirrored failed regeneration" "$mirrored_fixture" "$mirrored_output" 2 --write-readable
+unset DOCUMENT_FORENSICS_PDF_RUNNER_FAIL
+assert_file_absent "mirrored: failed regeneration removes stale readable PDF" "${mirrored_output}/readable/mirrored.pdf"
+assert_jq "mirrored: failed regeneration does not report stale output" "$mirrored_manifest" '.status == "partial" and .outputs.readable_pdf == null'
+
+rotated_fixture="${FIXTURE_DIR}/rotated.pdf"
+rotated_output="${OUTPUT_DIR}/rotated"
+rotated_hash=$(file_hash "$rotated_fixture")
+run_forensics rotated "$rotated_fixture" "$rotated_output" 0 --write-readable
+rotated_manifest="${rotated_output}/rotated.manifest.json"
+assert_jq "rotated: 90-degree repair selected" "$rotated_manifest" '.pages[0].classification == "rotated" and .pages[0].selected_transform == "rotate-90"'
+assert_file_exists "rotated: corrected PDF emitted" "${rotated_output}/readable/rotated.pdf"
+assert_source_unchanged "rotated: source hash unchanged" "$rotated_fixture" "$rotated_hash"
+run_forensics "rotated no-readable rerun" "$rotated_fixture" "$rotated_output" 0
+assert_file_absent "rotated: mode change removes stale readable PDF" "${rotated_output}/readable/rotated.pdf"
+assert_jq "rotated: mode change reports no readable PDF" "$rotated_manifest" '.outputs.readable_pdf == null'
+
+dimension_output="${OUTPUT_DIR}/dimension-mismatch"
+export DOCUMENT_FORENSICS_PDF_DIMENSIONS="700x792"
+run_forensics "dimension mismatch" "$rotated_fixture" "$dimension_output" 2 --write-readable
+unset DOCUMENT_FORENSICS_PDF_DIMENSIONS
+dimension_manifest="${dimension_output}/rotated.manifest.json"
+assert_jq "dimension mismatch: measured dimensions are recorded" "$dimension_manifest" '.status == "partial" and .pages[0].source_dimensions_points.width == 612 and .pages[0].derived_dimensions_points.width == 700'
+assert_file_absent "dimension mismatch: invalid readable PDF is removed" "${dimension_output}/readable/rotated.pdf"
+
+directory_output="${OUTPUT_DIR}/directory-destination"
+directory_sidecar="${directory_output}/rotated.txt"
+directory_readable="${directory_output}/readable/rotated.pdf"
+directory_manifest="${directory_output}/rotated.manifest.json"
+mkdir -p "${directory_output}/readable" "$directory_manifest"
+printf 'previous sidecar\n' >"$directory_sidecar"
+printf 'previous readable\n' >"$directory_readable"
+directory_sidecar_hash=$(file_hash "$directory_sidecar")
+directory_readable_hash=$(file_hash "$directory_readable")
+run_forensics "directory destination" "$rotated_fixture" "$directory_output" 1 --write-readable
+assert_source_unchanged "directory destination: sidecar rollback succeeds" "$directory_sidecar" "$directory_sidecar_hash"
+assert_source_unchanged "directory destination: readable rollback succeeds" "$directory_readable" "$directory_readable_hash"
+if [[ -d "$directory_manifest" ]]; then
+	pass "directory destination: manifest directory is not accepted as output"
+else
+	fail "directory destination: manifest directory is not accepted as output"
+fi
+
+mixed_fixture="${FIXTURE_DIR}/mixed.pdf"
+mixed_output="${OUTPUT_DIR}/mixed"
+mixed_hash=$(file_hash "$mixed_fixture")
+run_forensics mixed "$mixed_fixture" "$mixed_output" 0 --write-readable
+mixed_manifest="${mixed_output}/mixed.manifest.json"
+assert_jq "mixed: classifications are page-level and ordered" "$mixed_manifest" '[.pages[].classification] == ["searchable","mirrored","rotated"]'
+assert_jq "mixed: transforms are page-level and ordered" "$mixed_manifest" '[.pages[].selected_transform] == ["original","flip-horizontal","rotate-180"]'
+assert_jq "mixed: corrected PDF hash is recorded" "$mixed_manifest" '.outputs.readable_pdf.sha256 | length == 64'
+mixed_readable="${mixed_output}/readable/mixed.pdf"
+assert_file_exists "mixed: corrected PDF emitted" "$mixed_readable"
+if awk 'NR == 1 && /page=1/ { one=1 } NR == 2 && /page=2/ { two=1 } NR == 3 && /page=3/ { three=1 } END { exit !(one && two && three && NR == 3) }' "$mixed_readable"; then
+	pass "mixed: readable PDF preserves page count and order"
+else
+	fail "mixed: readable PDF preserves page count and order"
+fi
+assert_source_unchanged "mixed: source hash unchanged" "$mixed_fixture" "$mixed_hash"
+
+sparse_fixture="${FIXTURE_DIR}/sparse.pdf"
+sparse_output="${OUTPUT_DIR}/sparse"
+sparse_hash=$(file_hash "$sparse_fixture")
+run_forensics sparse "$sparse_fixture" "$sparse_output" 0 --write-readable
+sparse_manifest="${sparse_output}/sparse.manifest.json"
+assert_jq "sparse: weak evidence remains uncertain" "$sparse_manifest" '.pages[0].classification == "uncertain" and .pages[0].selected_transform == "original" and (.pages[0].ocr.evidence_sufficient | not)'
+assert_source_unchanged "sparse: source hash unchanged" "$sparse_fixture" "$sparse_hash"
+
+normal_output="${OUTPUT_DIR}/normal-scan"
+run_forensics "normal scan" "${FIXTURE_DIR}/normal-scan.pdf" "$normal_output" 0
+assert_jq "normal scan: original candidate retained" "${normal_output}/normal-scan.manifest.json" '.pages[0].classification == "normal" and .pages[0].selected_transform == "original"'
+
+partial_output="${OUTPUT_DIR}/partial"
+run_forensics partial "${FIXTURE_DIR}/partial.pdf" "$partial_output" 2
+partial_manifest="${partial_output}/partial.manifest.json"
+assert_jq "partial: successful page evidence is retained" "$partial_manifest" '.status == "partial" and .pages[0].classification == "normal" and (.failures | length) == 1'
+assert_jq "partial: failure identifies candidate" "$partial_manifest" '.failures[0].page == 1 and .failures[0].transform == "rotate-270"'
+
+mixed_failure_output="${OUTPUT_DIR}/mixed-failure"
+run_forensics "mixed failed page" "${FIXTURE_DIR}/mixed-failure.pdf" "$mixed_failure_output" 2 --write-readable
+mixed_failure_manifest="${mixed_failure_output}/mixed-failure.manifest.json"
+assert_jq "mixed failed page: original page fills readable derivative" "$mixed_failure_manifest" '[.pages[].classification] == ["searchable","failed"] and (.outputs.readable_pdf.sha256 | length) == 64'
+mixed_failure_readable="${mixed_failure_output}/readable/mixed-failure.pdf"
+assert_file_exists "mixed failed page: readable derivative keeps all pages" "$mixed_failure_readable"
+if awk 'NR == 1 && /page=1/ { one=1 } NR == 2 && /page=2/ { two=1 } END { exit !(one && two && NR == 2) }' "$mixed_failure_readable"; then
+	pass "mixed failed page: readable derivative preserves order"
+else
+	fail "mixed failed page: readable derivative preserves order"
+fi
+
+original_fails_output="${OUTPUT_DIR}/original-fails"
+run_forensics "original candidate fails" "${FIXTURE_DIR}/original-fails.pdf" "$original_fails_output" 2 --write-readable
+original_fails_manifest="${original_fails_output}/original-fails.manifest.json"
+assert_jq "original candidate failure: transform remains conservative" "$original_fails_manifest" '.pages[0].classification == "uncertain" and .pages[0].selected_transform == "original" and .pages[0].improvement == null and (.pages[0].ocr.performed | not)'
+assert_file_exists "original candidate failure: original page is preserved" "${original_fails_output}/readable/original-fails.pdf"
+
+assert_no_temp_artifacts
+
+printf '%s passed, %s failed\n' "$pass_count" "$fail_count"
+if [[ "$fail_count" -ne 0 ]]; then
+	exit 1
+fi

--- a/.agents/tools/document/document-creation.md
+++ b/.agents/tools/document/document-creation.md
@@ -24,7 +24,7 @@ tools:
 
 - **Purpose**: Convert between document formats and create documents from templates
 - **Helper**: `scripts/document-creation-helper.sh`
-- **Commands**: `convert`, `create`, `template`, `install`, `formats`, `status`
+- **Commands**: `convert`, `forensics`, `create`, `template`, `install`, `formats`, `status`
 - **OCR**: Auto-detects scanned PDFs; supports Tesseract, EasyOCR, GLM-OCR, Vision LLM
 - **Formats**: ODT, DOCX, PDF, MD, HTML, EPUB, PPTX, ODP, XLSX, ODS, RTF, CSV, TSV
 - **Report rendering**: `scripts/report-render-helper.sh render report.md --output report.html` keeps Markdown canonical and creates browser/PDF-ready HTML with sticky TOC, print CSS, source cards, and evidence badges
@@ -35,6 +35,7 @@ document-creation-helper.sh install --minimal                         # pandoc +
 document-creation-helper.sh install --standard                        # + odfpy, python-docx, openpyxl
 document-creation-helper.sh install --full                            # + LibreOffice headless
 document-creation-helper.sh convert report.pdf --to odt               # convert
+document-creation-helper.sh forensics scans.pdf --output ./audit       # page-level OCR audit
 document-creation-helper.sh create template.odt --data fields.json --output letter.odt
 document-creation-helper.sh formats                                   # list supported conversions
 document-creation-helper.sh template list
@@ -173,6 +174,12 @@ Thread metadata in frontmatter: `thread_id`, `thread_position`, `thread_length`.
 
 For screenshot/image input: keep as image, extract text (OCR), or both (image + text caption).
 
+### PDF Forensics
+
+`document-creation-helper.sh forensics input.pdf --output ./audit [--write-readable]` audits every page's text layer, then compares bounded local OCR candidates (`original`, horizontal flip, and 90/180/270-degree rotations) only for suspect pages. A transform is selected only when text evidence is sufficient and its score clears the improvement threshold; sparse or ambiguous pages remain `uncertain` and retain the original representation.
+
+Outputs are deterministic paths under the explicit/default audit root: `<name>.txt`, `<name>.manifest.json`, and optional `readable/<name>.pdf`. The `aidevops.document-forensics/v1` manifest records source/derived hashes, page dimensions/order, classifications, candidate confidence/evidence, backend version, failures, and portable relative output paths. Publication is serialized per output set and uses a durable transaction so interrupted runs restore the last consistent sidecar, readable PDF, and manifest. Sources are never overwritten; partial results return exit 2 with a non-success manifest. Processing requires Poppler, jq, and Python 3 and stays local unless a caller separately chooses another approved OCR workflow.
+
 **Related OCR agents**: `tools/ocr/glm-ocr.md`, `tools/ocr/ocr-research.md`, `tools/document/document-extraction.md`, `tools/conversion/mineru.md`
 
 ## Document Creation from Templates
@@ -265,6 +272,7 @@ document-creation-helper.sh convert report.pdf --to odt --template company-templ
 # OCR
 document-creation-helper.sh convert scanned.pdf --to odt --ocr tesseract
 document-creation-helper.sh convert screenshot.png --to md --ocr auto
+document-creation-helper.sh forensics damaged-scans.pdf --output ./audit --write-readable
 ```
 
 ## Limitations

--- a/.agents/tools/ocr/overview.md
+++ b/.agents/tools/ocr/overview.md
@@ -20,6 +20,7 @@ tools:
 | Input | Tool | Strengths | Limits |
 |-------|------|-----------|--------|
 | Screenshot / photo / sign | **PaddleOCR** (Baidu, 71k, Apache-2.0) | Best scene-text accuracy; bounding boxes; PP-StructureV3 tables; PaddleOCR-VL (0.9B); MCP server (v3.1.0+); 100+ languages | ~500MB dep; not for doc-to-markdown → use MinerU; invoices → Docling; PDF forms → LibPDF |
+| Mirrored / rotated PDF scan | **Document forensics** (`document-creation-helper.sh forensics`) | Page-level text-layer audit; conservative flip/rotation scoring; cited sidecar; versioned manifest; optional searchable readable copy; originals remain immutable | Poppler + jq + Python 3 required; transforms need ImageMagick; readable repaired PDFs need Tesseract; weak/sparse evidence remains `uncertain` |
 | Complex PDF (tables, columns, formulas) | **MinerU** (OpenDataLab, 53k, AGPL-3.0) | Layout-aware; multi-column, tables, formulas, LaTeX; strips headers/footers; 109 languages; JSON reading order; pipeline/hybrid/VLM backends | PDF-only; AGPL copyleft; screenshots → PaddleOCR; schema extraction → Docling; simple PDFs → Pandoc |
 | Invoice / receipt / form | **Docling + ExtractThinker** (IBM, 52.7k, MIT) | Schema-mapped Pydantic output; PDF/DOCX/PPTX/XLSX/HTML/images; PII redaction (Presidio); local/edge/cloud privacy; UK VAT + QuickFile; MCP server | Requires LLM; three-component setup; slower than pure OCR; screenshots → PaddleOCR/GLM-OCR |
 | Any image (quick, local) | **GLM-OCR** (THUDM/Ollama, MIT) | Zero-config (`ollama pull glm-ocr`); fully local; Peekaboo screen capture integration | No bounding boxes or structured JSON; weaker scene text; ~2GB model → PaddleOCR for accuracy |
@@ -49,6 +50,9 @@ ollama run glm-ocr "Extract all text" --images screenshot.png  # simplest, Ollam
 mineru -p document.pdf -o output_dir                      # complex layouts, tables, formulas
 pandoc document.pdf -o document.md                        # simple text PDFs, fastest
 
+# Audit damaged scans; add --write-readable for a separate searchable PDF
+document-creation-helper.sh forensics scans.pdf --output ./audit
+
 # Invoice to structured JSON
 document-extraction-helper.sh extract invoice.pdf --schema purchase-invoice --privacy local
 
@@ -56,6 +60,7 @@ document-extraction-helper.sh extract invoice.pdf --schema purchase-invoice --pr
 for img in ./images/*.png; do paddleocr-helper.sh ocr "$img"; done
 
 # Pipelines: image → PaddleOCR → raw text or ExtractThinker → structured JSON
+#            damaged PDF → local forensic candidates → sidecar + manifest + optional readable PDF
 #            PDF → MinerU → markdown → LLM
 #            PDF → Docling → ExtractThinker → structured JSON → QuickFile
 # PaddleOCR and Docling MCP servers plug into Claude Desktop / the agent framework.


### PR DESCRIPTION
## Summary

- Add deterministic page-level PDF text-layer auditing and bounded OCR candidates for original, mirrored, and 90/180/270-degree rotations.
- Produce page-cited sidecar text, an `aidevops.document-forensics/v1` provenance manifest, and an optional page-order-preserving searchable PDF without modifying the source.
- Publish sidecar, readable PDF, and manifest as a serialized recoverable output set, including stale-lock recovery and interrupted-transaction rollback.
- Preserve original pages when evidence is weak or OCR fails, and report partial results instead of choosing an unverified transform.

## Testing

- `bash .agents/scripts/tests/test-document-forensics-helper.sh` — 74 passed, 0 failed.
- `.agents/scripts/linters-local.sh` — all local checks passed.
- ShellCheck and `bash -n` across the changed shell implementation and fixtures.
- `markdownlint-cli2 .agents/tools/ocr/overview.md .agents/tools/document/document-creation.md`.
- `bun run typecheck`.
- Real audit of `_reports/examples/style-previews/basic-a4.pdf`: five searchable pages, complete manifest, no unnecessary readable copy, source unchanged.

## Runtime Testing

- Risk: Medium.
- Evidence: runtime-verified with deterministic fixtures plus a real five-page PDF.
- Processing remained local; no network OCR backend was used.

## Design Decisions

- Keep source PDFs immutable and write all artifacts beneath an explicit/default audit root.
- Select a transformed candidate only when evidence is sufficient and the score exceeds the configured improvement threshold.
- Retain the original representation for uncertain or failed pages.
- Treat the manifest as the final publication marker and recover interrupted output-set transactions before a new run.

Resolves #28702

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.186 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 1h 31m and 1,155,888 tokens on this as a headless worker. Solved in 5h 33m.
