### PR TITLE
GH#28704: docs: preserve reusable tooling capabilities

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -40,6 +40,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 - Every prompt, issue, PR, comment, and brief is mentorship: include file, pattern, and verification context.
 - For non-trivial work, state the goal, constraints, evidence, trade-offs, and recommendation. Ask only when materially blocked, destructive, security/billing-relevant, or requiring unknown secrets.
 - Capture worker-dispatchable fixable findings as tasks immediately. Worker triage and advisory-trap details: `reference/worker-discipline.md`.
+- When completing an objective required inventing, composing, or materially adapting tooling, offer to brief a reusable-capability TODO/issue for future similar work; if accepted, deduplicate and file it with observed evidence, target files or explicitly unknown paths, and verification.
 - Treat observed failures, efficiency losses, and productivity lessons as same-session work: fix them now when safe and in scope; if materially larger, deduplicate and file a dedicated issue with evidence, files, and verification. Preserve non-actionable learning in memory or references. Details: `reference/self-improvement.md`.
 
 ### Task and completion discipline

--- a/.agents/plugins/opencode-aidevops/shell-env.mjs
+++ b/.agents/plugins/opencode-aidevops/shell-env.mjs
@@ -51,6 +51,30 @@ function getSessionId(input) {
   return candidates.find((value) => value) || "";
 }
 
+function isBareModelId(model) {
+  if (typeof model !== "string") {
+    return false;
+  }
+  return !model.includes("/");
+}
+
+function modelStringOrEmpty(model) {
+  if (typeof model !== "string") {
+    return "";
+  }
+  return model;
+}
+
+function getModelValue(input) {
+  const candidates = [
+    input?.model?.modelID,
+    input?.model?.id,
+    input?.modelID,
+    input?.model,
+  ];
+  return candidates.find((value) => value) || "";
+}
+
 /**
  * Extract the current model ID from hook input variants.
  * @param {object} input
@@ -58,12 +82,15 @@ function getSessionId(input) {
  */
 function getModelId(input) {
   const provider = input?.model?.providerID || input?.provider?.id || "";
-  const model = input?.model?.modelID || input?.model?.id || input?.modelID || input?.model || "";
+  const model = getModelValue(input);
 
-  if (provider && model && typeof model === "string" && !model.includes("/")) {
+  if (!provider) {
+    return modelStringOrEmpty(model);
+  }
+  if (isBareModelId(model)) {
     return `${provider}/${model}`;
   }
-  return typeof model === "string" ? model : "";
+  return modelStringOrEmpty(model);
 }
 
 /**

--- a/.agents/scripts/_knowledge_social_outbound.py
+++ b/.agents/scripts/_knowledge_social_outbound.py
@@ -62,6 +62,16 @@ class OperationIntent:
 
 
 @dataclass(frozen=True)
+class ConnectionValues:
+    """Validated connection values used to create an outbound operation."""
+
+    provider: str
+    connection_id: str
+    remote_account_id: str
+    auth_profile_ref: str | None
+
+
+@dataclass(frozen=True)
 class ApprovalDecision:
     """Normalized approval authority for one exact stored intent."""
 
@@ -232,7 +242,7 @@ def _verify_operation_row(row: sqlite3.Row) -> sqlite3.Row:
 
 def _connection_values(
     database: sqlite3.Connection, intent: OperationIntent
-) -> tuple[str, str, str, str | None]:
+) -> ConnectionValues:
     connection_id = validate_opaque(intent.connection_id, "connection_id")
     remote_account_id = validate_opaque(intent.remote_account_id, "remote_account_id")
     row = database.execute(
@@ -247,23 +257,30 @@ def _connection_values(
     provider = validate_opaque(str(row["provider"]), "provider")
     if provider not in OUTBOUND_PROVIDER_ACTIONS:
         raise SocialStoreError("outbound connection provider is unsupported")
-    return provider, connection_id, remote_account_id, row["auth_profile_ref"]
+    return ConnectionValues(
+        provider=provider,
+        connection_id=connection_id,
+        remote_account_id=remote_account_id,
+        auth_profile_ref=row["auth_profile_ref"],
+    )
 
 
 def _operation_values(
     intent: OperationIntent,
     operation_id: str,
-    provider: str,
-    connection_id: str,
-    remote_account_id: str,
-    auth_profile_ref: str | None,
+    connection: ConnectionValues,
 ) -> dict[str, Any]:
+    provider = connection.provider
     if intent.action not in OUTBOUND_PROVIDER_ACTIONS[provider]:
         raise SocialStoreError("unsupported outbound action")
     if intent.scheduled_at < 0:
         raise SocialStoreError("scheduled_at must be a non-negative epoch")
     payload = _validated_payload(intent.action, intent.payload)
-    profile = intent.app_profile if intent.app_profile is not None else auth_profile_ref
+    profile = (
+        intent.app_profile
+        if intent.app_profile is not None
+        else connection.auth_profile_ref
+    )
     app_profile = _optional_selector(profile, "app_profile")
     username = _optional_selector(intent.username, "username")
     if provider == "reddit":
@@ -279,8 +296,8 @@ def _operation_values(
     return {
         "operation_id": validate_opaque(operation_id, "operation_id"),
         "provider": provider,
-        "connection_id": connection_id,
-        "remote_account_id": remote_account_id,
+        "connection_id": connection.connection_id,
+        "remote_account_id": connection.remote_account_id,
         "action": intent.action,
         "target_remote_id": _validated_target(
             provider, intent.action, intent.target_remote_id
@@ -368,17 +385,8 @@ def create_operation(
     created_at = now_epoch() if intent.created_at is None else intent.created_at
     database.execute("BEGIN IMMEDIATE")
     try:
-        provider, connection_id, remote_account_id, auth_profile_ref = (
-            _connection_values(database, intent)
-        )
-        values = _operation_values(
-            intent,
-            operation_id,
-            provider,
-            connection_id,
-            remote_account_id,
-            auth_profile_ref,
-        )
+        connection = _connection_values(database, intent)
+        values = _operation_values(intent, operation_id, connection)
         values["intent_sha256"] = _intent_sha256(values)
         existing = _existing_public_operation(
             database, operation_id, str(values["intent_sha256"])


### PR DESCRIPTION
## Summary

Added the reusable-capability offer rule and reduced two existing Qlty baseline smells so the absolute threshold passes.

## Files Changed

.agents/AGENTS.md, .agents/plugins/opencode-aidevops/shell-env.mjs, .agents/scripts/_knowledge_social_outbound.py

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --check .agents/plugins/opencode-aidevops/shell-env.mjs; python3 -m py_compile .agents/scripts/_knowledge_social_outbound.py; .agents/scripts/qlty-smell-threshold-helper.sh .agents/configs/complexity-thresholds.conf; npm run typecheck unavailable because tsc is not installed

Resolves #28704


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.186 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra spent 40m and 210,722 tokens on this as a headless worker.