### PR TITLE
GH#28625: Enforce protected release publication

### DIFF
--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -160,7 +160,9 @@ later if the repository's operating model changes.
 Operationally, the GitHub release, npm publication, and Homebrew update jobs each
 reference `release` and can prompt for approval separately; the Homebrew job waits
 for npm first. The designated release-author reviewer must explicitly approve each
-pending deployment.
+pending deployment. The canonical release helper waits for the exact-commit
+GitHub Actions runs to complete and never creates the GitHub release directly for
+this repository, so local maintainer credentials cannot bypass the environment.
 
 The GitHub snapshot and verifier are read-only:
 

--- a/.agents/scripts/tests/test-hot-deploy-flow.sh
+++ b/.agents/scripts/tests/test-hot-deploy-flow.sh
@@ -318,6 +318,7 @@ print_success() { return 0; }
 print_warning() { return 0; }
 _create_hotfix_tag() { local version="$1"; printf "hotfix:%s\n" "$version" >>"$EVENTS_FILE"; return 0; }
 run_post_release_agent_sync() { printf "deploy\n" >>"$EVENTS_FILE"; return 1; }
+release_source_pr_required() { return 1; }
 run_post_publication_gates 9.8.7 1
 ' _ "$RELEASE_LIB" "$SCRIPT_DIR/../../.." 2>&1) || exit_code=$?
 
@@ -338,7 +339,7 @@ test_publication_disables_rollback_before_local_gates() {
 	local rollback_disable_line=""
 	local post_gate_line=""
 	# shellcheck disable=SC2016 # Match the literal source expression.
-	publication_line=$(grep -n 'if ! create_github_release "$new_version"' "$VM_SCRIPT" | cut -d: -f1)
+	publication_line=$(grep -n 'if ! _publish_github_release "$new_version"' "$VM_SCRIPT" | cut -d: -f1)
 	rollback_disable_line=$(grep -n '_release_disable_failure_rollback' "$VM_SCRIPT" | while IFS=: read -r line_number _; do
 		if [[ "$line_number" -gt "$publication_line" ]]; then
 			printf '%s\n' "$line_number"

--- a/.agents/scripts/tests/test-release-publication-workflows.sh
+++ b/.agents/scripts/tests/test-release-publication-workflows.sh
@@ -58,6 +58,7 @@ assert_contains "release workflow verifies provenance" "release-provenance-helpe
 # shellcheck disable=SC2016 # Intentional literal GitHub Actions expression.
 assert_contains "package workflow checks out release tag" 'ref: ${{ github.event.release.tag_name }}' "$PACKAGE_WORKFLOW"
 assert_contains "Homebrew job has read-only repository permission" "contents: read" "$PACKAGE_WORKFLOW"
+assert_absent "Homebrew publication failures are not masked" "continue-on-error: true" "$PACKAGE_WORKFLOW"
 assert_order "release provenance precedes release creation" \
 	"release-provenance-helper.sh verify" "github-release-helper.sh create" "$RELEASE_WORKFLOW"
 assert_order "package provenance precedes npm publication" \

--- a/.agents/scripts/tests/test-version-manager-protected-publication.sh
+++ b/.agents/scripts/tests/test-version-manager-protected-publication.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Verify aidevops publication waits for exact protected workflow runs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "$HOME" "${TEST_ROOT}/bin" "${TEST_ROOT}/repo"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1"
+	local passed="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" == "true" ]]; then
+		printf 'PASS %s\n' "$name"
+	else
+		printf 'FAIL %s: %s\n' "$name" "$detail"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+cat >"${TEST_ROOT}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >>"${FAKE_GH_LOG:?}"
+args=" $* "
+if [[ "$args" == *"actions/workflows/release.yml/runs"* ]]; then
+	printf '%s\n' "${FAKE_RELEASE_RUNS_JSON:?}"
+	exit 0
+fi
+if [[ "$args" == *"actions/workflows/publish-packages.yml/runs"* ]]; then
+	printf '%s\n' "${FAKE_PACKAGE_RUNS_JSON:?}"
+	exit 0
+fi
+if [[ "$args" == *"actions/runs/501"* ]]; then
+	printf '%s\n' "${FAKE_RELEASE_RUN_JSON:?}"
+	exit 0
+fi
+if [[ "$args" == *"actions/runs/502"* ]]; then
+	printf '%s\n' "${FAKE_PACKAGE_RUN_JSON:?}"
+	exit 0
+fi
+if [[ "$args" == *"releases/tags/v1.2.4"* ]]; then
+	printf '%s\n' '{"tag_name":"v1.2.4"}'
+	exit 0
+fi
+exit 1
+STUB
+chmod +x "${TEST_ROOT}/bin/gh"
+export PATH="${TEST_ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export FAKE_GH_LOG="${TEST_ROOT}/gh.log"
+
+cd "${TEST_ROOT}/repo"
+git init -q -b main
+git config user.email 'test@example.com'
+git config user.name 'Test Runner'
+git config commit.gpgsign false
+git remote add origin 'git@github.com:marcusquinn/aidevops.git'
+printf 'fixture\n' >fixture.txt
+git add fixture.txt
+git commit -q -m 'fixture'
+git tag v1.2.4
+TAG_COMMIT=$(git rev-parse HEAD)
+
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/version-manager.sh"
+set +e
+
+export AIDEVOPS_RELEASE_WORKFLOW_TIMEOUT_SECONDS=3
+export AIDEVOPS_RELEASE_WORKFLOW_POLL_SECONDS=1
+export FAKE_RELEASE_RUNS_JSON="{\"workflow_runs\":[{\"id\":501,\"event\":\"push\",\"head_sha\":\"${TAG_COMMIT}\",\"status\":\"waiting\",\"conclusion\":null,\"created_at\":\"2026-07-27T00:00:00Z\",\"html_url\":\"\"}]}"
+export FAKE_RELEASE_RUN_JSON="{\"id\":501,\"event\":\"push\",\"head_sha\":\"${TAG_COMMIT}\",\"status\":\"completed\",\"conclusion\":\"success\",\"html_url\":\"\"}"
+export FAKE_PACKAGE_RUNS_JSON="{\"workflow_runs\":[{\"id\":502,\"event\":\"release\",\"head_sha\":\"${TAG_COMMIT}\",\"status\":\"waiting\",\"conclusion\":null,\"created_at\":\"2026-07-27T00:00:01Z\",\"html_url\":\"\"}]}"
+export FAKE_PACKAGE_RUN_JSON="{\"id\":502,\"event\":\"release\",\"head_sha\":\"${TAG_COMMIT}\",\"status\":\"completed\",\"conclusion\":\"success\",\"html_url\":\"\"}"
+
+rc=0
+_release_wait_exact_workflow '1.2.4' 'release.yml' 'push' 'GitHub release' >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]] && grep -q 'actions/runs/501' "$FAKE_GH_LOG"; then
+	print_result 'exact release workflow reaches terminal success' true
+else
+	print_result 'exact release workflow reaches terminal success' false "rc=${rc}"
+fi
+
+rc=0
+_release_wait_exact_workflow '1.2.4' 'publish-packages.yml' 'release' 'package publication' >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]] && grep -q 'actions/runs/502' "$FAKE_GH_LOG"; then
+	print_result 'exact package workflow reaches terminal success' true
+else
+	print_result 'exact package workflow reaches terminal success' false "rc=${rc}"
+fi
+
+route_log="${TEST_ROOT}/route.log"
+release_source_pr_required() { return 0; }
+_wait_for_protected_github_release() {
+	local version="$1"
+	printf 'protected:%s\n' "$version" >>"$route_log"
+	return 0
+}
+create_github_release() {
+	local version="$1"
+	printf 'direct:%s\n' "$version" >>"$route_log"
+	return 0
+}
+_publish_github_release '1.2.4'
+if grep -qx 'protected:1.2.4' "$route_log" && ! grep -q '^direct:' "$route_log"; then
+	print_result 'aidevops release cannot use direct GitHub release creation' true
+else
+	print_result 'aidevops release cannot use direct GitHub release creation' false "$(tr '\n' ' ' <"$route_log")"
+fi
+
+: >"$route_log"
+release_source_pr_required() { return 1; }
+_publish_github_release '1.2.4'
+if grep -qx 'direct:1.2.4' "$route_log"; then
+	print_result 'non-aidevops release retains direct publication compatibility' true
+else
+	print_result 'non-aidevops release retains direct publication compatibility' false "$(tr '\n' ' ' <"$route_log")"
+fi
+
+: >"$route_log"
+release_source_pr_required() { return 0; }
+_wait_for_protected_package_publication() {
+	local version="$1"
+	printf 'package:%s\n' "$version" >>"$route_log"
+	return 0
+}
+run_post_release_agent_sync() {
+	printf 'deploy\n' >>"$route_log"
+	return 0
+}
+rc=0
+run_post_publication_gates '1.2.4' 0 >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 && "$(tr '\n' ',' <"$route_log")" == 'package:1.2.4,deploy,' ]]; then
+	print_result 'protected package publication completes before local deployment' true
+else
+	print_result 'protected package publication completes before local deployment' false "rc=${rc} events=$(tr '\n' ' ' <"$route_log")"
+fi
+
+: >"$route_log"
+_wait_for_protected_package_publication() {
+	local version="$1"
+	printf 'package-failed:%s\n' "$version" >>"$route_log"
+	return 1
+}
+rc=0
+run_post_publication_gates '1.2.4' 0 >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -ne 0 ]] && ! grep -q '^deploy$' "$route_log"; then
+	print_result 'failed protected package publication blocks local completion' true
+else
+	print_result 'failed protected package publication blocks local completion' false "rc=${rc} events=$(tr '\n' ' ' <"$route_log")"
+fi
+
+printf '\nTests run: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-version-manager-protected-publication.sh
+++ b/.agents/scripts/tests/test-version-manager-protected-publication.sh
@@ -110,11 +110,15 @@ create_github_release() {
 	printf 'direct:%s\n' "$version" >>"$route_log"
 	return 0
 }
-_publish_github_release '1.2.4'
+get_current_version() {
+	printf '1.2.4\n'
+	return 0
+}
+main github-release
 if grep -qx 'protected:1.2.4' "$route_log" && ! grep -q '^direct:' "$route_log"; then
-	print_result 'aidevops release cannot use direct GitHub release creation' true
+	print_result 'aidevops github-release recovery cannot create a release directly' true
 else
-	print_result 'aidevops release cannot use direct GitHub release creation' false "$(tr '\n' ' ' <"$route_log")"
+	print_result 'aidevops github-release recovery cannot create a release directly' false "$(tr '\n' ' ' <"$route_log")"
 fi
 
 : >"$route_log"

--- a/.agents/scripts/version-manager-release.sh
+++ b/.agents/scripts/version-manager-release.sh
@@ -128,6 +128,144 @@ _github_release_recover_with_rest() {
 	return 1
 }
 
+_release_find_exact_workflow_run() {
+	local slug="$1"
+	local workflow_file="$2"
+	local event_name="$3"
+	local tag_commit="$4"
+	local deadline="$5"
+	local poll_seconds="$6"
+	local runs_json=""
+	local run_json=""
+	local now=""
+
+	while true; do
+		now=$(date +%s) || return 1
+		if [[ "$now" -ge "$deadline" ]]; then
+			print_error "Timed out waiting for ${workflow_file} to start at ${tag_commit}" >&2
+			return 1
+		fi
+		if runs_json=$(gh api --method GET \
+			"repos/${slug}/actions/workflows/${workflow_file}/runs" \
+			-f "event=${event_name}" -F per_page=20 2>/dev/null); then
+			run_json=$(jq -c --arg sha "$tag_commit" --arg event "$event_name" '
+				[.workflow_runs[]? | select(.head_sha == $sha and .event == $event)]
+				| sort_by(.created_at // "") | last // empty
+			' <<<"$runs_json") || return 1
+			if [[ -n "$run_json" && "$run_json" != "null" ]]; then
+				printf '%s\n' "$run_json"
+				return 0
+			fi
+		fi
+		sleep "$poll_seconds"
+	done
+}
+
+_release_wait_workflow_run() {
+	local slug="$1"
+	local run_json="$2"
+	local workflow_label="$3"
+	local deadline="$4"
+	local poll_seconds="$5"
+	local run_id=""
+	local run_url=""
+	local status=""
+	local conclusion=""
+	local now=""
+
+	run_id=$(jq -er '.id' <<<"$run_json") || return 1
+	run_url=$(jq -r '.html_url // ""' <<<"$run_json") || return 1
+	print_info "Protected ${workflow_label} workflow run ${run_id} is awaiting completion"
+	[[ -z "$run_url" ]] || print_info "Approve each pending release-environment deployment at ${run_url}"
+
+	while true; do
+		status=$(jq -r '.status // ""' <<<"$run_json") || return 1
+		conclusion=$(jq -r '.conclusion // ""' <<<"$run_json") || return 1
+		if [[ "$status" == "completed" ]]; then
+			if [[ "$conclusion" == "success" ]]; then
+				print_success "Protected ${workflow_label} workflow completed successfully"
+				return 0
+			fi
+			print_error "Protected ${workflow_label} workflow concluded ${conclusion:-unknown}"
+			return 1
+		fi
+		now=$(date +%s) || return 1
+		if [[ "$now" -ge "$deadline" ]]; then
+			print_error "Timed out waiting for protected ${workflow_label} workflow run ${run_id}"
+			return 1
+		fi
+		sleep "$poll_seconds"
+		run_json=$(gh api "repos/${slug}/actions/runs/${run_id}" 2>/dev/null) || continue
+	done
+}
+
+_release_wait_exact_workflow() {
+	local version="$1"
+	local workflow_file="$2"
+	local event_name="$3"
+	local workflow_label="$4"
+	local timeout_seconds="${AIDEVOPS_RELEASE_WORKFLOW_TIMEOUT_SECONDS:-1800}"
+	local poll_seconds="${AIDEVOPS_RELEASE_WORKFLOW_POLL_SECONDS:-15}"
+	local slug=""
+	local tag_commit=""
+	local started_at=""
+	local deadline=""
+	local run_json=""
+
+	if ! [[ "$timeout_seconds" =~ ^[1-9][0-9]*$ && "$poll_seconds" =~ ^[1-9][0-9]*$ ]]; then
+		print_error "Release workflow wait settings must be positive integers"
+		return 1
+	fi
+	slug=$(_version_manager_repo_slug)
+	[[ -n "$slug" ]] || {
+		print_error "Cannot wait for ${workflow_label}: repository slug is unavailable"
+		return 1
+	}
+	tag_commit=$(git -C "$REPO_ROOT" rev-parse "refs/tags/v${version}^{commit}" 2>/dev/null) || {
+		print_error "Cannot wait for ${workflow_label}: release tag commit is unavailable"
+		return 1
+	}
+	started_at=$(date +%s) || return 1
+	deadline=$((started_at + timeout_seconds))
+	print_info "Waiting for protected ${workflow_label} workflow at ${tag_commit}"
+	run_json=$(_release_find_exact_workflow_run "$slug" "$workflow_file" "$event_name" \
+		"$tag_commit" "$deadline" "$poll_seconds") || return 1
+	_release_wait_workflow_run "$slug" "$run_json" "$workflow_label" "$deadline" "$poll_seconds"
+	return $?
+}
+
+_wait_for_protected_github_release() {
+	local version="$1"
+	local tag_name="v${version}"
+	local slug=""
+
+	_release_wait_exact_workflow "$version" "release.yml" "push" "GitHub release" || return 1
+	_verify_github_release_provenance "$version" || return 1
+	slug=$(_version_manager_repo_slug)
+	if ! _github_release_rest_view "$slug" "$tag_name"; then
+		print_error "Protected workflow succeeded but GitHub release ${tag_name} is unavailable"
+		return 1
+	fi
+	return 0
+}
+
+_wait_for_protected_package_publication() {
+	local version="$1"
+	_release_wait_exact_workflow "$version" "publish-packages.yml" "release" \
+		"npm and Homebrew publication"
+	return $?
+}
+
+_publish_github_release() {
+	local version="$1"
+	if release_source_pr_required; then
+		_wait_for_protected_github_release "$version"
+		return $?
+	fi
+	create_github_release "$version"
+	return $?
+}
+
 _release_tag_message() {
 	local version="$1"
 	local source_pr="${VERSION_MANAGER_SOURCE_PR:-}"
@@ -473,6 +611,15 @@ run_post_publication_gates() {
 	local hotfix_flag="$2"
 	local hotfix_exit=0
 	local deployment_exit=0
+	local package_exit=0
+
+	if release_source_pr_required; then
+		_wait_for_protected_package_publication "$version" || package_exit=$?
+	fi
+	if [[ "$package_exit" -ne 0 ]]; then
+		print_error "PARTIAL RELEASE SUCCESS: GitHub release v$version remains published; protected package publication failed"
+		return 1
+	fi
 
 	# Publication is already durable at this point. Hotfix propagation must run
 	# before machine-local convergence so a local PATH problem cannot prevent

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -661,7 +661,7 @@ main() {
 	"github-release")
 		local version
 		version=$(get_current_version)
-		create_github_release "$version"
+		_publish_github_release "$version"
 		;;
 	"post-release")
 		local version

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -347,7 +347,7 @@ _release_handle_push_failure() {
 	exit 1
 }
 
-# Perform the version bump, file updates, tag, push, and GitHub release.
+# Perform the version bump, file updates, tag, push, and protected publication.
 # Arguments: bump_type new_version hotfix_flag
 _release_execute() {
 	local bump_type="$1"
@@ -393,7 +393,7 @@ _release_execute() {
 		if ! push_changes "$new_version"; then
 			_release_handle_push_failure "$new_version"
 		fi
-		if ! create_github_release "$new_version"; then
+		if ! _publish_github_release "$new_version"; then
 			print_error "GitHub release publication failed for v$new_version"
 			print_error "release:failed"
 			return 1

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -138,7 +138,6 @@ jobs:
           user_email: 'github-actions[bot]@users.noreply.github.com'
           user_name: 'github-actions[bot]'
           commit_message: 'Update aidevops to v${{ steps.release.outputs.version }}'
-        continue-on-error: true
       
       - name: Summary
         env:


### PR DESCRIPTION
## Summary

Make canonical aidevops releases wait for the exact protected GitHub release and package-publication workflow runs instead of creating releases with local maintainer credentials.

## Files Changed

.agents/reference/release-publication-controls.md, .agents/scripts/tests/test-hot-deploy-flow.sh, .agents/scripts/tests/test-version-manager-protected-publication.sh, .agents/scripts/version-manager-release.sh, .agents/scripts/version-manager.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime harness executed the committed protected-publication paths (6/6), including exact-run success and failure-blocking behavior; ShellCheck, local linters, hot-deploy 14/14, release workflow, REST fallback, provenance, and full-loop release suites passed.

Resolves #28625


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.186 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 3h 49m and 2,033,235 tokens on this with the user in an interactive session.