### PR TITLE
GH#28506: Avoid synthetic issue-sync refs

### DIFF
--- a/.agents/scripts/tests/test-forge-event-workflow.sh
+++ b/.agents/scripts/tests/test-forge-event-workflow.sh
@@ -27,6 +27,7 @@ assert "task-publication-worker-helper.sh" in normal
 assert "forge-coordinator-state-helper.sh" in normal
 assert "upload-artifact" in normal
 projection_checkout = next(step for step in jobs["forge-event"]["steps"] if step.get("name") == "Checkout repository projection")
+assert projection_checkout["with"]["ref"] == "${{ github.event_name == 'push' && github.sha || github.event.repository.default_branch }}"
 assert projection_checkout["with"]["token"] == "${{ secrets.GITHUB_TOKEN }}"
 ingest = next(step for step in jobs["forge-event"]["steps"] if step.get("name") == "Ingest event and execute publication queue")
 assert ingest["env"]["GH_TOKEN"] == "${{ secrets.GITHUB_TOKEN }}"
@@ -38,7 +39,11 @@ PY
 
 for caller in "$SELF_CALLER" "$CALLER_TEMPLATE"; do
 	grep -q 'types: \[opened, edited, assigned, closed, reopened\]' "$caller"
-	grep -q 'types: \[opened, edited, closed, reopened\]' "$caller"
+	grep -q 'types: \[closed\]' "$caller"
+	if grep -q 'types: \[opened, edited, closed, reopened\]' "$caller"; then
+		printf 'FAIL unsupported pull-request actions remain canonical in %s\n' "$caller" >&2
+		exit 1
+	fi
 	grep -q 'subject_id:' "$caller"
 	grep -q 'cursor:' "$caller"
 	grep -q 'task_id:' "$caller"

--- a/.agents/scripts/tests/test-reusable-workflow-caller.sh
+++ b/.agents/scripts/tests/test-reusable-workflow-caller.sh
@@ -162,12 +162,14 @@ if [[ -f "$DOWNSTREAM_TEMPLATE" ]]; then
 			"expected 'uses: marcusquinn/aidevops/.github/workflows/issue-sync-reusable.yml@<ref>' in $DOWNSTREAM_TEMPLATE"
 	fi
 
-	# Also check secrets: inherit (otherwise SYNC_PAT won't propagate)
-	if grep -Eq "secrets:\s*inherit" "$DOWNSTREAM_TEMPLATE"; then
-		_pass "downstream template uses 'secrets: inherit'"
+	# Cross-account reusable workflows require explicit secret forwarding. Keep
+	# SYNC_PAT available only to the reusable workflow's write paths.
+	# shellcheck disable=SC2016
+	if grep -qF 'SYNC_PAT: ${{ secrets.SYNC_PAT }}' "$DOWNSTREAM_TEMPLATE"; then
+		_pass "downstream template explicitly forwards SYNC_PAT"
 	else
-		_fail "downstream template uses 'secrets: inherit'" \
-			"missing 'secrets: inherit' — SYNC_PAT won't reach the reusable workflow"
+		_fail "downstream template explicitly forwards SYNC_PAT" \
+			"missing explicit SYNC_PAT forwarding for cross-account write paths"
 	fi
 fi
 

--- a/.agents/templates/workflows/issue-sync-caller.yml
+++ b/.agents/templates/workflows/issue-sync-caller.yml
@@ -35,7 +35,7 @@ on:
       - 'todo/PLANS.md'
       - 'todo/tasks/**'
   pull_request:
-    types: [opened, edited, closed, reopened]
+    types: [closed]
   issues:
     types: [opened, edited, assigned, closed, reopened]
   workflow_dispatch:
@@ -74,7 +74,8 @@ jobs:
     # Cross-account consumers (every downstream user) receive empty values for any
     # caller-repo secret when using `secrets: inherit` against a cross-account
     # reusable workflow. Explicit pass-through is required for secrets to resolve.
-    # If a new secret is added to issue-sync-reusable.yml, add it here too.
+    # Keep explicit cross-account forwarding limited to write paths. Read-only
+    # forge-event projection checkout uses the caller's GITHUB_TOKEN.
     secrets:
       SYNC_PAT: ${{ secrets.SYNC_PAT }}
     with:

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -73,6 +73,10 @@ jobs:
       - name: Checkout repository projection
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          # Push events must project the immutable triggering revision. Other
+          # supported events read canonical TODO.md state and must not infer a
+          # synthetic refs/pull/*/merge checkout.
+          ref: ${{ github.event_name == 'push' && github.sha || github.event.repository.default_branch }}
           fetch-depth: 1
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -17,7 +17,7 @@ on:
       - 'todo/tasks/**'
   pull_request_target:
     branches: [main]
-    types: [opened, edited, closed, reopened]
+    types: [closed]
   issues:
     types: [opened, edited, assigned, closed, reopened]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Make forge projection checkout event-aware, preserve immutable push revisions, and restrict canonical PR triggers to closed events while retaining explicit SYNC_PAT forwarding for write paths.

## Files Changed

.agents/scripts/tests/test-forge-event-workflow.sh, .agents/scripts/tests/test-reusable-workflow-caller.sh, .agents/templates/workflows/issue-sync-caller.yml, .github/workflows/issue-sync-reusable.yml, .github/workflows/issue-sync.yml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused forge-event mapping/reconciliation suites pass; reusable caller suite passes; ShellCheck and pre-commit workflow validation pass.

Resolves #28506


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.187 plugin for [OpenCode](https://opencode.ai) v1.18.6 with gpt-5.6-sol spent 4m and 127,451 tokens on this with the user in an interactive session.