### PR TITLE
GH#28738: Explicitly dispatch protected package publication

### DIFF
--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -166,8 +166,14 @@ Operationally, the GitHub release, npm publication, and Homebrew update jobs eac
 reference `release` and can prompt for approval separately; the Homebrew job waits
 for npm first. The designated release-author reviewer must explicitly approve each
 pending deployment. The canonical release helper waits for the exact-commit
-GitHub Actions runs to complete and never creates the GitHub release directly for
-this repository, so local maintainer credentials cannot bypass the environment.
+GitHub release workflow, verifies the published release object, then explicitly
+dispatches `publish-packages.yml` at the same signed tag. It reuses an existing
+exact-tag package run instead of dispatching a duplicate. This handoff does not
+depend on a workflow-token-created release recursively starting another workflow;
+the retained `release: published` trigger supports external and recovery events.
+Both trigger paths verify the published release and immutable tag provenance.
+Local maintainer credentials can request the workflow but cannot bypass the
+environment approval.
 
 The GitHub snapshot and verifier are read-only:
 

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -168,12 +168,20 @@ for npm first. The designated release-author reviewer must explicitly approve ea
 pending deployment. The canonical release helper waits for the exact-commit
 GitHub release workflow, verifies the published release object, then explicitly
 dispatches `publish-packages.yml` at the same signed tag. It reuses an existing
-exact-tag package run instead of dispatching a duplicate. This handoff does not
-depend on a workflow-token-created release recursively starting another workflow;
-the retained `release: published` trigger supports external and recovery events.
+exact-tag package run instead of dispatching a duplicate, and API uncertainty
+fails closed before dispatch. A correlated dispatch binds its input tag, event
+ref, and event SHA before publication. Registry uncertainty also fails closed;
+an exact package version already present on npm is reused rather than published
+again.
+
+This handoff does not depend on a workflow-token-created release recursively
+starting another workflow. The retained `release: published` trigger supports
+external events and immutable tags that predate the dispatch trigger. In
+particular, v3.32.188 recovery re-publishes its existing verified release only
+after explicit maintainer approval; it does not delete or move the signed tag.
 Both trigger paths verify the published release and immutable tag provenance.
-Local maintainer credentials can request the workflow but cannot bypass the
-environment approval.
+Local maintainer credentials can request or recover the workflow but cannot
+bypass the environment approval.
 
 The GitHub snapshot and verifier are read-only:
 

--- a/.agents/scripts/tests/test-release-publication-workflows.sh
+++ b/.agents/scripts/tests/test-release-publication-workflows.sh
@@ -52,11 +52,22 @@ assert_order() {
 	return 0
 }
 
-assert_absent "manual arbitrary-version publication is removed" "workflow_dispatch:" "$PACKAGE_WORKFLOW"
+assert_contains "package workflow exposes provenance-bound dispatch" "workflow_dispatch:" "$PACKAGE_WORKFLOW"
+assert_contains "package dispatch requires an existing signed tag" \
+	"Existing signed aidevops release tag" "$PACKAGE_WORKFLOW"
 assert_absent "package metadata is not rewritten before publish" "--no-git-tag-version" "$PACKAGE_WORKFLOW"
 assert_contains "release workflow verifies provenance" "release-provenance-helper.sh verify" "$RELEASE_WORKFLOW"
 # shellcheck disable=SC2016 # Intentional literal GitHub Actions expression.
-assert_contains "package workflow checks out release tag" 'ref: ${{ github.event.release.tag_name }}' "$PACKAGE_WORKFLOW"
+assert_contains "package workflow checks out the resolved release tag" \
+	'ref: ${{ inputs.tag || github.event.release.tag_name }}' "$PACKAGE_WORKFLOW"
+assert_contains "package runs expose their immutable tag identity" \
+	"run-name: Publish packages for \${{ inputs.tag || github.event.release.tag_name }}" "$PACKAGE_WORKFLOW"
+assert_contains "package jobs verify a published GitHub release" \
+	"releases/tags/\$RELEASE_TAG" "$PACKAGE_WORKFLOW"
+assert_contains "duplicate dispatches never cancel in-flight publication" \
+	"cancel-in-progress: false" "$PACKAGE_WORKFLOW"
+assert_absent "in-flight package publication cannot be cancelled" \
+	"cancel-in-progress: true" "$PACKAGE_WORKFLOW"
 assert_contains "Homebrew job has read-only repository permission" "contents: read" "$PACKAGE_WORKFLOW"
 assert_absent "Homebrew publication failures are not masked" "continue-on-error: true" "$PACKAGE_WORKFLOW"
 assert_order "release provenance precedes release creation" \

--- a/.agents/scripts/tests/test-release-publication-workflows.sh
+++ b/.agents/scripts/tests/test-release-publication-workflows.sh
@@ -55,15 +55,25 @@ assert_order() {
 assert_contains "package workflow exposes provenance-bound dispatch" "workflow_dispatch:" "$PACKAGE_WORKFLOW"
 assert_contains "package dispatch requires an existing signed tag" \
 	"Existing signed aidevops release tag" "$PACKAGE_WORKFLOW"
+assert_contains "package dispatch requires a correlation identity" \
+	"Non-secret dispatch correlation identifier" "$PACKAGE_WORKFLOW"
 assert_absent "package metadata is not rewritten before publish" "--no-git-tag-version" "$PACKAGE_WORKFLOW"
 assert_contains "release workflow verifies provenance" "release-provenance-helper.sh verify" "$RELEASE_WORKFLOW"
 # shellcheck disable=SC2016 # Intentional literal GitHub Actions expression.
 assert_contains "package workflow checks out the resolved release tag" \
 	'ref: ${{ inputs.tag || github.event.release.tag_name }}' "$PACKAGE_WORKFLOW"
 assert_contains "package runs expose their immutable tag identity" \
-	"run-name: Publish packages for \${{ inputs.tag || github.event.release.tag_name }}" "$PACKAGE_WORKFLOW"
+	"inputs.request_id && format('Publish packages for {0} ({1})'" "$PACKAGE_WORKFLOW"
 assert_contains "package jobs verify a published GitHub release" \
 	"releases/tags/\$RELEASE_TAG" "$PACKAGE_WORKFLOW"
+assert_contains "package input is bound to the event tag ref" \
+	"\"\$GITHUB_REF\" != \"refs/tags/\$RELEASE_TAG\"" "$PACKAGE_WORKFLOW"
+assert_contains "package input is bound to the event commit" \
+	"\"\$GITHUB_SHA\" != \"\$TAG_COMMIT\"" "$PACKAGE_WORKFLOW"
+assert_contains "existing exact npm versions are reused" \
+	"already-published=true" "$PACKAGE_WORKFLOW"
+assert_contains "npm publication skips an existing exact version" \
+	"if: steps.npm-state.outputs.already-published != 'true'" "$PACKAGE_WORKFLOW"
 assert_contains "duplicate dispatches never cancel in-flight publication" \
 	"cancel-in-progress: false" "$PACKAGE_WORKFLOW"
 assert_absent "in-flight package publication cannot be cancelled" \

--- a/.agents/scripts/tests/test-version-manager-protected-publication.sh
+++ b/.agents/scripts/tests/test-version-manager-protected-publication.sh
@@ -38,6 +38,9 @@ if [[ "$args" == *"actions/workflows/release.yml/runs"* ]]; then
 	exit 0
 fi
 if [[ "$args" == *"actions/workflows/publish-packages.yml/runs"* ]]; then
+	if [[ "${FAKE_PACKAGE_RUNS_API_FAILURE:-0}" == "1" ]]; then
+		exit 1
+	fi
 	if grep -q 'actions/workflows/publish-packages.yml/dispatches' "${FAKE_GH_LOG:?}" 2>/dev/null &&
 		[[ -n "${FAKE_PACKAGE_RUNS_AFTER_DISPATCH_JSON:-}" ]]; then
 		printf '%s\n' "$FAKE_PACKAGE_RUNS_AFTER_DISPATCH_JSON"
@@ -57,7 +60,7 @@ if [[ "$args" == *"actions/runs/502"* ]]; then
 	printf '%s\n' "${FAKE_PACKAGE_RUN_JSON:?}"
 	exit 0
 fi
-if [[ "$args" == *"releases/tags/v1.2.4"* ]]; then
+if [[ "$args" == *"releases/tags/v1.2."* ]]; then
 	printf '%s\n' "${FAKE_RELEASE_JSON:?}"
 	exit 0
 fi
@@ -76,6 +79,12 @@ git remote add origin 'git@github.com:marcusquinn/aidevops.git'
 printf 'fixture\n' >fixture.txt
 git add fixture.txt
 git commit -q -m 'fixture'
+git tag v1.2.3
+OLD_TAG_COMMIT=$(git rev-parse HEAD)
+mkdir -p .github/workflows
+printf 'on:\n  workflow_dispatch:\n' >.github/workflows/publish-packages.yml
+git add .github/workflows/publish-packages.yml
+git commit -q -m 'add protected package dispatch'
 git tag v1.2.4
 TAG_COMMIT=$(git rev-parse HEAD)
 
@@ -91,6 +100,15 @@ export FAKE_PACKAGE_RUNS_JSON="{\"workflow_runs\":[{\"id\":502,\"event\":\"relea
 export FAKE_PACKAGE_RUN_JSON="{\"id\":502,\"event\":\"release\",\"head_sha\":\"${TAG_COMMIT}\",\"status\":\"completed\",\"conclusion\":\"success\",\"html_url\":\"\"}"
 export FAKE_PACKAGE_RUNS_AFTER_DISPATCH_JSON=""
 export FAKE_RELEASE_JSON='{"tag_name":"v1.2.4","draft":false,"published_at":"2026-07-27T00:00:00Z"}'
+export FAKE_PACKAGE_RUNS_API_FAILURE=0
+export AIDEVOPS_RELEASE_DISPATCH_REQUEST_ID='request-123'
+
+if _release_package_dispatch_supported_at_tag 'v1.2.4' &&
+	! _release_package_dispatch_supported_at_tag 'v1.2.3'; then
+	print_result 'dispatch support is read from the immutable tag workflow' true
+else
+	print_result 'dispatch support is read from the immutable tag workflow' false
+fi
 
 rc=0
 _release_wait_exact_workflow '1.2.4' 'release.yml' 'push' 'GitHub release' >/dev/null 2>&1 || rc=$?
@@ -110,8 +128,8 @@ fi
 
 : >"$FAKE_GH_LOG"
 export FAKE_PACKAGE_RUNS_JSON='{"workflow_runs":[]}'
-export FAKE_PACKAGE_RUNS_AFTER_DISPATCH_JSON="{\"workflow_runs\":[{\"id\":502,\"event\":\"workflow_dispatch\",\"head_sha\":\"${TAG_COMMIT}\",\"display_title\":\"Publish packages for v1.2.4\",\"status\":\"waiting\",\"conclusion\":null,\"created_at\":\"2026-07-27T00:00:02Z\",\"html_url\":\"\"}]}"
-export FAKE_PACKAGE_RUN_JSON="{\"id\":502,\"event\":\"workflow_dispatch\",\"head_sha\":\"${TAG_COMMIT}\",\"display_title\":\"Publish packages for v1.2.4\",\"status\":\"completed\",\"conclusion\":\"success\",\"html_url\":\"\"}"
+export FAKE_PACKAGE_RUNS_AFTER_DISPATCH_JSON="{\"workflow_runs\":[{\"id\":502,\"event\":\"workflow_dispatch\",\"head_sha\":\"${TAG_COMMIT}\",\"display_title\":\"Publish packages for v1.2.4 (request-123)\",\"status\":\"waiting\",\"conclusion\":null,\"created_at\":\"2026-07-27T00:00:02Z\",\"html_url\":\"\"}]}"
+export FAKE_PACKAGE_RUN_JSON="{\"id\":502,\"event\":\"workflow_dispatch\",\"head_sha\":\"${TAG_COMMIT}\",\"display_title\":\"Publish packages for v1.2.4 (request-123)\",\"status\":\"completed\",\"conclusion\":\"success\",\"html_url\":\"\"}"
 _verify_github_release_provenance() { return 0; }
 rc=0
 # shellcheck disable=SC2218 # Loaded from version-manager.sh before the later route-test stub.
@@ -119,7 +137,8 @@ _wait_for_protected_package_publication '1.2.4' >/dev/null 2>&1 || rc=$?
 if [[ "$rc" -eq 0 ]] &&
 	grep -q 'actions/workflows/publish-packages.yml/dispatches' "$FAKE_GH_LOG" &&
 	grep -q 'ref=v1.2.4' "$FAKE_GH_LOG" &&
-	grep -q 'inputs\[tag\]=v1.2.4' "$FAKE_GH_LOG"; then
+	grep -q 'inputs\[tag\]=v1.2.4' "$FAKE_GH_LOG" &&
+	grep -q 'inputs\[request_id\]=request-123' "$FAKE_GH_LOG"; then
 	print_result 'package publication explicitly dispatches the signed tag' true
 else
 	print_result 'package publication explicitly dispatches the signed tag' false "rc=${rc} log=$(tr '\n' ' ' <"$FAKE_GH_LOG")"
@@ -139,6 +158,19 @@ else
 fi
 
 : >"$FAKE_GH_LOG"
+export FAKE_RELEASE_JSON='{"tag_name":"v1.2.3","draft":false,"published_at":"2026-07-27T00:00:00Z"}'
+export FAKE_PACKAGE_RUNS_JSON="{\"workflow_runs\":[{\"id\":502,\"event\":\"release\",\"head_sha\":\"${OLD_TAG_COMMIT}\",\"status\":\"waiting\",\"conclusion\":null,\"created_at\":\"2026-07-27T00:00:01Z\",\"html_url\":\"\"}]}"
+export FAKE_PACKAGE_RUN_JSON="{\"id\":502,\"event\":\"release\",\"head_sha\":\"${OLD_TAG_COMMIT}\",\"status\":\"completed\",\"conclusion\":\"success\",\"html_url\":\"\"}"
+rc=0
+# shellcheck disable=SC2218 # Loaded from version-manager.sh before the later route-test stub.
+_wait_for_protected_package_publication '1.2.3' >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]] && ! grep -q '/dispatches' "$FAKE_GH_LOG"; then
+	print_result 'historical tag reuses the retained release-event recovery' true
+else
+	print_result 'historical tag reuses the retained release-event recovery' false "rc=${rc} log=$(tr '\n' ' ' <"$FAKE_GH_LOG")"
+fi
+
+: >"$FAKE_GH_LOG"
 export FAKE_RELEASE_JSON='{"tag_name":"v1.2.4","draft":true,"published_at":null}'
 export FAKE_PACKAGE_RUNS_JSON='{"workflow_runs":[]}'
 rc=0
@@ -150,6 +182,30 @@ else
 	print_result 'unpublished GitHub release blocks package dispatch' false "rc=${rc} log=$(tr '\n' ' ' <"$FAKE_GH_LOG")"
 fi
 export FAKE_RELEASE_JSON='{"tag_name":"v1.2.4","draft":false,"published_at":"2026-07-27T00:00:00Z"}'
+
+: >"$FAKE_GH_LOG"
+export FAKE_PACKAGE_RUNS_API_FAILURE=1
+rc=0
+# shellcheck disable=SC2218 # Loaded from version-manager.sh before the later route-test stub.
+_wait_for_protected_package_publication '1.2.4' >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -ne 0 ]] && ! grep -q '/dispatches' "$FAKE_GH_LOG"; then
+	print_result 'package-run API failure blocks dispatch' true
+else
+	print_result 'package-run API failure blocks dispatch' false "rc=${rc} log=$(tr '\n' ' ' <"$FAKE_GH_LOG")"
+fi
+export FAKE_PACKAGE_RUNS_API_FAILURE=0
+
+: >"$FAKE_GH_LOG"
+_verify_github_release_provenance() { return 1; }
+rc=0
+# shellcheck disable=SC2218 # Loaded from version-manager.sh before the later route-test stub.
+_wait_for_protected_package_publication '1.2.4' >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -ne 0 ]] && ! grep -q '/dispatches' "$FAKE_GH_LOG"; then
+	print_result 'provenance failure blocks package dispatch' true
+else
+	print_result 'provenance failure blocks package dispatch' false "rc=${rc} log=$(tr '\n' ' ' <"$FAKE_GH_LOG")"
+fi
+_verify_github_release_provenance() { return 0; }
 
 route_log="${TEST_ROOT}/route.log"
 release_source_pr_required() { return 0; }

--- a/.agents/scripts/tests/test-version-manager-protected-publication.sh
+++ b/.agents/scripts/tests/test-version-manager-protected-publication.sh
@@ -41,6 +41,17 @@ if [[ "$args" == *"actions/workflows/publish-packages.yml/runs"* ]]; then
 	if [[ "${FAKE_PACKAGE_RUNS_API_FAILURE:-0}" == "1" ]]; then
 		exit 1
 	fi
+	case "${FAKE_PACKAGE_RUNS_SCHEMA_MODE:-valid}" in
+	empty) exit 0 ;;
+	object)
+		printf '%s\n' '{}'
+		exit 0
+		;;
+	malformed)
+		printf '%s\n' '{'
+		exit 0
+		;;
+	esac
 	if grep -q 'actions/workflows/publish-packages.yml/dispatches' "${FAKE_GH_LOG:?}" 2>/dev/null &&
 		[[ -n "${FAKE_PACKAGE_RUNS_AFTER_DISPATCH_JSON:-}" ]]; then
 		printf '%s\n' "$FAKE_PACKAGE_RUNS_AFTER_DISPATCH_JSON"
@@ -101,6 +112,7 @@ export FAKE_PACKAGE_RUN_JSON="{\"id\":502,\"event\":\"release\",\"head_sha\":\"$
 export FAKE_PACKAGE_RUNS_AFTER_DISPATCH_JSON=""
 export FAKE_RELEASE_JSON='{"tag_name":"v1.2.4","draft":false,"published_at":"2026-07-27T00:00:00Z"}'
 export FAKE_PACKAGE_RUNS_API_FAILURE=0
+export FAKE_PACKAGE_RUNS_SCHEMA_MODE=valid
 export AIDEVOPS_RELEASE_DISPATCH_REQUEST_ID='request-123'
 
 if _release_package_dispatch_supported_at_tag 'v1.2.4' &&
@@ -142,6 +154,31 @@ if [[ "$rc" -eq 0 ]] &&
 	print_result 'package publication explicitly dispatches the signed tag' true
 else
 	print_result 'package publication explicitly dispatches the signed tag' false "rc=${rc} log=$(tr '\n' ' ' <"$FAKE_GH_LOG")"
+fi
+
+: >"$FAKE_GH_LOG"
+export FAKE_PACKAGE_RUNS_JSON="{\"workflow_runs\":[{\"id\":502,\"event\":\"workflow_dispatch\",\"head_sha\":\"${TAG_COMMIT}\",\"display_title\":\"Publish packages for v1.2.4 (request-123)\",\"status\":\"waiting\",\"conclusion\":null,\"created_at\":\"2026-07-27T00:00:02Z\",\"html_url\":\"\"}]}"
+export FAKE_PACKAGE_RUNS_AFTER_DISPATCH_JSON=""
+export FAKE_PACKAGE_RUN_JSON="{\"id\":502,\"event\":\"workflow_dispatch\",\"head_sha\":\"${TAG_COMMIT}\",\"display_title\":\"Publish packages for v1.2.4 (request-123)\",\"status\":\"completed\",\"conclusion\":\"success\",\"html_url\":\"\"}"
+rc=0
+# shellcheck disable=SC2218 # Loaded from version-manager.sh before the later route-test stub.
+_wait_for_protected_package_publication '1.2.4' >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]] && ! grep -q '/dispatches' "$FAKE_GH_LOG"; then
+	print_result 'same request identity reuses its exact dispatch run' true
+else
+	print_result 'same request identity reuses its exact dispatch run' false "rc=${rc} log=$(tr '\n' ' ' <"$FAKE_GH_LOG")"
+fi
+
+: >"$FAKE_GH_LOG"
+export FAKE_PACKAGE_RUNS_JSON="{\"workflow_runs\":[{\"id\":502,\"event\":\"workflow_dispatch\",\"head_sha\":\"${TAG_COMMIT}\",\"display_title\":\"Publish packages for v1.2.4 (different-request)\",\"status\":\"waiting\",\"conclusion\":null,\"created_at\":\"2026-07-27T00:00:02Z\",\"html_url\":\"\"}]}"
+export FAKE_PACKAGE_RUNS_AFTER_DISPATCH_JSON="{\"workflow_runs\":[{\"id\":502,\"event\":\"workflow_dispatch\",\"head_sha\":\"${TAG_COMMIT}\",\"display_title\":\"Publish packages for v1.2.4 (request-123)\",\"status\":\"waiting\",\"conclusion\":null,\"created_at\":\"2026-07-27T00:00:03Z\",\"html_url\":\"\"}]}"
+rc=0
+# shellcheck disable=SC2218 # Loaded from version-manager.sh before the later route-test stub.
+_wait_for_protected_package_publication '1.2.4' >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]] && grep -q '/dispatches' "$FAKE_GH_LOG"; then
+	print_result 'wrong dispatch title cannot satisfy request correlation' true
+else
+	print_result 'wrong dispatch title cannot satisfy request correlation' false "rc=${rc} log=$(tr '\n' ' ' <"$FAKE_GH_LOG")"
 fi
 
 : >"$FAKE_GH_LOG"
@@ -194,6 +231,20 @@ else
 	print_result 'package-run API failure blocks dispatch' false "rc=${rc} log=$(tr '\n' ' ' <"$FAKE_GH_LOG")"
 fi
 export FAKE_PACKAGE_RUNS_API_FAILURE=0
+
+for schema_mode in empty object malformed; do
+	: >"$FAKE_GH_LOG"
+	export FAKE_PACKAGE_RUNS_SCHEMA_MODE="$schema_mode"
+	rc=0
+	# shellcheck disable=SC2218 # Loaded from version-manager.sh before the later route-test stub.
+	_wait_for_protected_package_publication '1.2.4' >/dev/null 2>&1 || rc=$?
+	if [[ "$rc" -ne 0 ]] && ! grep -q '/dispatches' "$FAKE_GH_LOG"; then
+		print_result "${schema_mode} package-run response blocks dispatch" true
+	else
+		print_result "${schema_mode} package-run response blocks dispatch" false "rc=${rc} log=$(tr '\n' ' ' <"$FAKE_GH_LOG")"
+	fi
+done
+export FAKE_PACKAGE_RUNS_SCHEMA_MODE=valid
 
 : >"$FAKE_GH_LOG"
 _verify_github_release_provenance() { return 1; }

--- a/.agents/scripts/tests/test-version-manager-protected-publication.sh
+++ b/.agents/scripts/tests/test-version-manager-protected-publication.sh
@@ -38,7 +38,15 @@ if [[ "$args" == *"actions/workflows/release.yml/runs"* ]]; then
 	exit 0
 fi
 if [[ "$args" == *"actions/workflows/publish-packages.yml/runs"* ]]; then
-	printf '%s\n' "${FAKE_PACKAGE_RUNS_JSON:?}"
+	if grep -q 'actions/workflows/publish-packages.yml/dispatches' "${FAKE_GH_LOG:?}" 2>/dev/null &&
+		[[ -n "${FAKE_PACKAGE_RUNS_AFTER_DISPATCH_JSON:-}" ]]; then
+		printf '%s\n' "$FAKE_PACKAGE_RUNS_AFTER_DISPATCH_JSON"
+	else
+		printf '%s\n' "${FAKE_PACKAGE_RUNS_JSON:?}"
+	fi
+	exit 0
+fi
+if [[ "$args" == *"actions/workflows/publish-packages.yml/dispatches"* ]]; then
 	exit 0
 fi
 if [[ "$args" == *"actions/runs/501"* ]]; then
@@ -50,7 +58,7 @@ if [[ "$args" == *"actions/runs/502"* ]]; then
 	exit 0
 fi
 if [[ "$args" == *"releases/tags/v1.2.4"* ]]; then
-	printf '%s\n' '{"tag_name":"v1.2.4"}'
+	printf '%s\n' "${FAKE_RELEASE_JSON:?}"
 	exit 0
 fi
 exit 1
@@ -81,6 +89,8 @@ export FAKE_RELEASE_RUNS_JSON="{\"workflow_runs\":[{\"id\":501,\"event\":\"push\
 export FAKE_RELEASE_RUN_JSON="{\"id\":501,\"event\":\"push\",\"head_sha\":\"${TAG_COMMIT}\",\"status\":\"completed\",\"conclusion\":\"success\",\"html_url\":\"\"}"
 export FAKE_PACKAGE_RUNS_JSON="{\"workflow_runs\":[{\"id\":502,\"event\":\"release\",\"head_sha\":\"${TAG_COMMIT}\",\"status\":\"waiting\",\"conclusion\":null,\"created_at\":\"2026-07-27T00:00:01Z\",\"html_url\":\"\"}]}"
 export FAKE_PACKAGE_RUN_JSON="{\"id\":502,\"event\":\"release\",\"head_sha\":\"${TAG_COMMIT}\",\"status\":\"completed\",\"conclusion\":\"success\",\"html_url\":\"\"}"
+export FAKE_PACKAGE_RUNS_AFTER_DISPATCH_JSON=""
+export FAKE_RELEASE_JSON='{"tag_name":"v1.2.4","draft":false,"published_at":"2026-07-27T00:00:00Z"}'
 
 rc=0
 _release_wait_exact_workflow '1.2.4' 'release.yml' 'push' 'GitHub release' >/dev/null 2>&1 || rc=$?
@@ -97,6 +107,49 @@ if [[ "$rc" -eq 0 ]] && grep -q 'actions/runs/502' "$FAKE_GH_LOG"; then
 else
 	print_result 'exact package workflow reaches terminal success' false "rc=${rc}"
 fi
+
+: >"$FAKE_GH_LOG"
+export FAKE_PACKAGE_RUNS_JSON='{"workflow_runs":[]}'
+export FAKE_PACKAGE_RUNS_AFTER_DISPATCH_JSON="{\"workflow_runs\":[{\"id\":502,\"event\":\"workflow_dispatch\",\"head_sha\":\"${TAG_COMMIT}\",\"display_title\":\"Publish packages for v1.2.4\",\"status\":\"waiting\",\"conclusion\":null,\"created_at\":\"2026-07-27T00:00:02Z\",\"html_url\":\"\"}]}"
+export FAKE_PACKAGE_RUN_JSON="{\"id\":502,\"event\":\"workflow_dispatch\",\"head_sha\":\"${TAG_COMMIT}\",\"display_title\":\"Publish packages for v1.2.4\",\"status\":\"completed\",\"conclusion\":\"success\",\"html_url\":\"\"}"
+_verify_github_release_provenance() { return 0; }
+rc=0
+# shellcheck disable=SC2218 # Loaded from version-manager.sh before the later route-test stub.
+_wait_for_protected_package_publication '1.2.4' >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]] &&
+	grep -q 'actions/workflows/publish-packages.yml/dispatches' "$FAKE_GH_LOG" &&
+	grep -q 'ref=v1.2.4' "$FAKE_GH_LOG" &&
+	grep -q 'inputs\[tag\]=v1.2.4' "$FAKE_GH_LOG"; then
+	print_result 'package publication explicitly dispatches the signed tag' true
+else
+	print_result 'package publication explicitly dispatches the signed tag' false "rc=${rc} log=$(tr '\n' ' ' <"$FAKE_GH_LOG")"
+fi
+
+: >"$FAKE_GH_LOG"
+export FAKE_PACKAGE_RUNS_JSON="{\"workflow_runs\":[{\"id\":502,\"event\":\"release\",\"head_sha\":\"${TAG_COMMIT}\",\"status\":\"waiting\",\"conclusion\":null,\"created_at\":\"2026-07-27T00:00:01Z\",\"html_url\":\"\"}]}"
+export FAKE_PACKAGE_RUNS_AFTER_DISPATCH_JSON=""
+export FAKE_PACKAGE_RUN_JSON="{\"id\":502,\"event\":\"release\",\"head_sha\":\"${TAG_COMMIT}\",\"status\":\"completed\",\"conclusion\":\"success\",\"html_url\":\"\"}"
+rc=0
+# shellcheck disable=SC2218 # Loaded from version-manager.sh before the later route-test stub.
+_wait_for_protected_package_publication '1.2.4' >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]] && ! grep -q '/dispatches' "$FAKE_GH_LOG"; then
+	print_result 'existing exact package run suppresses duplicate dispatch' true
+else
+	print_result 'existing exact package run suppresses duplicate dispatch' false "rc=${rc} log=$(tr '\n' ' ' <"$FAKE_GH_LOG")"
+fi
+
+: >"$FAKE_GH_LOG"
+export FAKE_RELEASE_JSON='{"tag_name":"v1.2.4","draft":true,"published_at":null}'
+export FAKE_PACKAGE_RUNS_JSON='{"workflow_runs":[]}'
+rc=0
+# shellcheck disable=SC2218 # Loaded from version-manager.sh before the later route-test stub.
+_wait_for_protected_package_publication '1.2.4' >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -ne 0 ]] && ! grep -q '/dispatches' "$FAKE_GH_LOG"; then
+	print_result 'unpublished GitHub release blocks package dispatch' true
+else
+	print_result 'unpublished GitHub release blocks package dispatch' false "rc=${rc} log=$(tr '\n' ' ' <"$FAKE_GH_LOG")"
+fi
+export FAKE_RELEASE_JSON='{"tag_name":"v1.2.4","draft":false,"published_at":"2026-07-27T00:00:00Z"}'
 
 route_log="${TEST_ROOT}/route.log"
 release_source_pr_required() { return 0; }

--- a/.agents/scripts/version-manager-release.sh
+++ b/.agents/scripts/version-manager-release.sh
@@ -78,6 +78,21 @@ _github_release_rest_view() {
 	return $?
 }
 
+_github_release_rest_published() {
+	local slug="$1"
+	local tag_name="$2"
+	local release_json=""
+
+	[[ -n "$slug" && "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+	release_json=$(gh api "repos/${slug}/releases/tags/${tag_name}" 2>/dev/null) || return 1
+	jq -e --arg tag "$tag_name" '
+		.tag_name == $tag
+		and .draft == false
+		and ((.published_at // "") | length > 0)
+	' <<<"$release_json" >/dev/null
+	return $?
+}
+
 _github_release_rest_create() {
 	local slug="$1"
 	local tag_name="$2"
@@ -128,34 +143,51 @@ _github_release_recover_with_rest() {
 	return 1
 }
 
+_release_lookup_exact_workflow_run() {
+	local slug="$1"
+	local workflow_file="$2"
+	local event_name="$3"
+	local expected_commit="$4"
+	local expected_title="${5:-}"
+	local runs_json=""
+	local run_json=""
+
+	runs_json=$(gh api --method GET \
+		"repos/${slug}/actions/workflows/${workflow_file}/runs" \
+		-f "event=${event_name}" -F per_page=20 2>/dev/null) || return 1
+	run_json=$(jq -c --arg sha "$expected_commit" --arg event "$event_name" \
+		--arg title "$expected_title" '
+		[.workflow_runs[]?
+			| select(.head_sha == $sha and .event == $event)
+			| select($title == "" or (.display_title // "") == $title)]
+		| sort_by(.created_at // "") | last // empty
+	' <<<"$runs_json") || return 1
+	[[ -n "$run_json" && "$run_json" != "null" ]] || return 1
+	printf '%s\n' "$run_json"
+	return 0
+}
+
 _release_find_exact_workflow_run() {
 	local slug="$1"
 	local workflow_file="$2"
 	local event_name="$3"
-	local tag_commit="$4"
+	local expected_commit="$4"
 	local deadline="$5"
 	local poll_seconds="$6"
-	local runs_json=""
+	local expected_title="${7:-}"
 	local run_json=""
 	local now=""
 
 	while true; do
 		now=$(date +%s) || return 1
 		if [[ "$now" -ge "$deadline" ]]; then
-			print_error "Timed out waiting for ${workflow_file} to start at ${tag_commit}" >&2
+			print_error "Timed out waiting for ${workflow_file} to start at ${expected_commit}" >&2
 			return 1
 		fi
-		if runs_json=$(gh api --method GET \
-			"repos/${slug}/actions/workflows/${workflow_file}/runs" \
-			-f "event=${event_name}" -F per_page=20 2>/dev/null); then
-			run_json=$(jq -c --arg sha "$tag_commit" --arg event "$event_name" '
-				[.workflow_runs[]? | select(.head_sha == $sha and .event == $event)]
-				| sort_by(.created_at // "") | last // empty
-			' <<<"$runs_json") || return 1
-			if [[ -n "$run_json" && "$run_json" != "null" ]]; then
-				printf '%s\n' "$run_json"
-				return 0
-			fi
+		if run_json=$(_release_lookup_exact_workflow_run "$slug" "$workflow_file" \
+			"$event_name" "$expected_commit" "$expected_title"); then
+			printf '%s\n' "$run_json"
+			return 0
 		fi
 		sleep "$poll_seconds"
 	done
@@ -204,6 +236,7 @@ _release_wait_exact_workflow() {
 	local workflow_file="$2"
 	local event_name="$3"
 	local workflow_label="$4"
+	local expected_title="${5:-}"
 	local timeout_seconds="${AIDEVOPS_RELEASE_WORKFLOW_TIMEOUT_SECONDS:-1800}"
 	local poll_seconds="${AIDEVOPS_RELEASE_WORKFLOW_POLL_SECONDS:-15}"
 	local slug=""
@@ -229,7 +262,7 @@ _release_wait_exact_workflow() {
 	deadline=$((started_at + timeout_seconds))
 	print_info "Waiting for protected ${workflow_label} workflow at ${tag_commit}"
 	run_json=$(_release_find_exact_workflow_run "$slug" "$workflow_file" "$event_name" \
-		"$tag_commit" "$deadline" "$poll_seconds") || return 1
+		"$tag_commit" "$deadline" "$poll_seconds" "$expected_title") || return 1
 	_release_wait_workflow_run "$slug" "$run_json" "$workflow_label" "$deadline" "$poll_seconds"
 	return $?
 }
@@ -251,8 +284,51 @@ _wait_for_protected_github_release() {
 
 _wait_for_protected_package_publication() {
 	local version="$1"
-	_release_wait_exact_workflow "$version" "publish-packages.yml" "release" \
-		"npm and Homebrew publication"
+	local tag_name=""
+	local workflow_file="publish-packages.yml"
+	local workflow_label="npm and Homebrew publication"
+	local dispatch_title=""
+	local slug=""
+	local tag_commit=""
+	local run_json=""
+	local event_name=""
+	local expected_title=""
+
+	printf -v tag_name 'v%s' "$version"
+	dispatch_title="Publish packages for ${tag_name}"
+	_verify_github_release_provenance "$version" || return 1
+	slug=$(_version_manager_repo_slug)
+	[[ -n "$slug" ]] || {
+		print_error "Cannot dispatch package publication: repository slug is unavailable"
+		return 1
+	}
+	if ! _github_release_rest_published "$slug" "$tag_name"; then
+		print_error "Cannot dispatch package publication: GitHub release ${tag_name} is not published"
+		return 1
+	fi
+	tag_commit=$(git -C "$REPO_ROOT" rev-parse "refs/tags/${tag_name}^{commit}" 2>/dev/null) || return 1
+
+	for event_name in workflow_dispatch release; do
+		expected_title=""
+		[[ "$event_name" == "workflow_dispatch" ]] && expected_title="$dispatch_title"
+		run_json=$(_release_lookup_exact_workflow_run "$slug" "$workflow_file" \
+			"$event_name" "$tag_commit" "$expected_title" 2>/dev/null || true)
+		if [[ -n "$run_json" ]]; then
+			print_info "Reusing existing protected package workflow for ${tag_name}"
+			_release_wait_exact_workflow "$version" "$workflow_file" "$event_name" \
+				"$workflow_label" "$expected_title"
+			return $?
+		fi
+	done
+
+	print_info "Dispatching protected package publication for ${tag_name}"
+	if ! gh api --method POST "repos/${slug}/actions/workflows/${workflow_file}/dispatches" \
+		-f "ref=${tag_name}" -f "inputs[tag]=${tag_name}" >/dev/null; then
+		print_error "Failed to dispatch protected package publication for ${tag_name}"
+		return 1
+	fi
+	_release_wait_exact_workflow "$version" "$workflow_file" "workflow_dispatch" \
+		"$workflow_label" "$dispatch_title"
 	return $?
 }
 

--- a/.agents/scripts/version-manager-release.sh
+++ b/.agents/scripts/version-manager-release.sh
@@ -155,6 +155,9 @@ _release_lookup_exact_workflow_run() {
 	runs_json=$(gh api --method GET \
 		"repos/${slug}/actions/workflows/${workflow_file}/runs" \
 		-f "event=${event_name}" -F per_page=20 2>/dev/null) || return 1
+	[[ -n "$runs_json" ]] || return 1
+	jq -e 'type == "object" and (.workflow_runs | type == "array")' \
+		<<<"$runs_json" >/dev/null || return 1
 	run_json=$(jq -c --arg sha "$expected_commit" --arg event "$event_name" \
 		--arg title "$expected_title" '
 		[.workflow_runs[]?
@@ -331,6 +334,7 @@ _wait_for_protected_package_publication() {
 
 	for event_name in workflow_dispatch release; do
 		expected_title=""
+		[[ "$event_name" == "workflow_dispatch" ]] && expected_title="$dispatch_title"
 		lookup_rc=0
 		run_json=$(_release_lookup_exact_workflow_run "$slug" "$workflow_file" \
 			"$event_name" "$tag_commit" "$expected_title" 2>/dev/null) || lookup_rc=$?

--- a/.agents/scripts/version-manager-release.sh
+++ b/.agents/scripts/version-manager-release.sh
@@ -162,9 +162,21 @@ _release_lookup_exact_workflow_run() {
 			| select($title == "" or (.display_title // "") == $title)]
 		| sort_by(.created_at // "") | last // empty
 	' <<<"$runs_json") || return 1
-	[[ -n "$run_json" && "$run_json" != "null" ]] || return 1
+	[[ -n "$run_json" && "$run_json" != "null" ]] || return 3
 	printf '%s\n' "$run_json"
 	return 0
+}
+
+_release_package_dispatch_supported_at_tag() {
+	local tag_name="$1"
+	local workflow_path=".github/workflows/publish-packages.yml"
+
+	[[ "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+	if git -C "$REPO_ROOT" show "refs/tags/${tag_name}:${workflow_path}" 2>/dev/null |
+		grep -qE '^[[:space:]]+workflow_dispatch:'; then
+		return 0
+	fi
+	return 1
 }
 
 _release_find_exact_workflow_run() {
@@ -293,9 +305,18 @@ _wait_for_protected_package_publication() {
 	local run_json=""
 	local event_name=""
 	local expected_title=""
+	local lookup_rc=0
+	local dispatch_request_id="${AIDEVOPS_RELEASE_DISPATCH_REQUEST_ID:-}"
 
 	printf -v tag_name 'v%s' "$version"
-	dispatch_title="Publish packages for ${tag_name}"
+	if [[ -z "$dispatch_request_id" ]]; then
+		printf -v dispatch_request_id '%s-%s-%s' "$tag_name" "$(date +%s)" "$$"
+	fi
+	[[ "$dispatch_request_id" =~ ^[A-Za-z0-9._-]{1,100}$ ]] || {
+		print_error "Package dispatch request identity is malformed"
+		return 1
+	}
+	dispatch_title="Publish packages for ${tag_name} (${dispatch_request_id})"
 	_verify_github_release_provenance "$version" || return 1
 	slug=$(_version_manager_repo_slug)
 	[[ -n "$slug" ]] || {
@@ -310,20 +331,30 @@ _wait_for_protected_package_publication() {
 
 	for event_name in workflow_dispatch release; do
 		expected_title=""
-		[[ "$event_name" == "workflow_dispatch" ]] && expected_title="$dispatch_title"
+		lookup_rc=0
 		run_json=$(_release_lookup_exact_workflow_run "$slug" "$workflow_file" \
-			"$event_name" "$tag_commit" "$expected_title" 2>/dev/null || true)
-		if [[ -n "$run_json" ]]; then
+			"$event_name" "$tag_commit" "$expected_title" 2>/dev/null) || lookup_rc=$?
+		if [[ "$lookup_rc" -eq 0 ]]; then
 			print_info "Reusing existing protected package workflow for ${tag_name}"
 			_release_wait_exact_workflow "$version" "$workflow_file" "$event_name" \
 				"$workflow_label" "$expected_title"
 			return $?
 		fi
+		if [[ "$lookup_rc" -ne 3 ]]; then
+			print_error "Cannot inspect existing package workflows for ${tag_name}; refusing duplicate dispatch"
+			return 1
+		fi
 	done
 
+	if ! _release_package_dispatch_supported_at_tag "$tag_name"; then
+		print_error "Release tag ${tag_name} predates explicit package dispatch"
+		print_error "Use the reviewed release-event recovery path without moving the signed tag"
+		return 1
+	fi
 	print_info "Dispatching protected package publication for ${tag_name}"
 	if ! gh api --method POST "repos/${slug}/actions/workflows/${workflow_file}/dispatches" \
-		-f "ref=${tag_name}" -f "inputs[tag]=${tag_name}" >/dev/null; then
+		-f "ref=${tag_name}" -f "inputs[tag]=${tag_name}" \
+		-f "inputs[request_id]=${dispatch_request_id}" >/dev/null; then
 		print_error "Failed to dispatch protected package publication for ${tag_name}"
 		return 1
 	fi

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -3,10 +3,18 @@ name: Publish Packages
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing signed aidevops release tag'
+        required: true
+        type: string
+
+run-name: Publish packages for ${{ inputs.tag || github.event.release.tag_name }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ inputs.tag || github.event.release.tag_name }}
+  cancel-in-progress: false
 
 jobs:
   publish-npm:
@@ -22,13 +30,23 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ inputs.tag || github.event.release.tag_name }}
 
-      - name: Verify immutable release provenance
+      - name: Verify published release and immutable provenance
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
         run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid release tag: $RELEASE_TAG"
+            exit 1
+          fi
+          RELEASE_JSON=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG")
+          jq -e --arg tag "$RELEASE_TAG" '
+            .tag_name == $tag
+            and .draft == false
+            and ((.published_at // "") | length > 0)
+          ' <<<"$RELEASE_JSON" >/dev/null
           bash .agents/scripts/release-provenance-helper.sh verify \
             --tag "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY"
@@ -92,13 +110,23 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ inputs.tag || github.event.release.tag_name }}
 
-      - name: Verify immutable release provenance
+      - name: Verify published release and immutable provenance
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
         run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid release tag: $RELEASE_TAG"
+            exit 1
+          fi
+          RELEASE_JSON=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG")
+          jq -e --arg tag "$RELEASE_TAG" '
+            .tag_name == $tag
+            and .draft == false
+            and ((.published_at // "") | length > 0)
+          ' <<<"$RELEASE_JSON" >/dev/null
           bash .agents/scripts/release-provenance-helper.sh verify \
             --tag "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -9,8 +9,12 @@ on:
         description: 'Existing signed aidevops release tag'
         required: true
         type: string
+      request_id:
+        description: 'Non-secret dispatch correlation identifier'
+        required: true
+        type: string
 
-run-name: Publish packages for ${{ inputs.tag || github.event.release.tag_name }}
+run-name: ${{ inputs.request_id && format('Publish packages for {0} ({1})', inputs.tag, inputs.request_id) || format('Publish packages for {0}', github.event.release.tag_name) }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.tag || github.event.release.tag_name }}
@@ -36,9 +40,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
+          DISPATCH_REQUEST_ID: ${{ inputs.request_id }}
         run: |
           if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Invalid release tag: $RELEASE_TAG"
+            exit 1
+          fi
+          if [[ "$GITHUB_REF" != "refs/tags/$RELEASE_TAG" ]]; then
+            echo "::error::Release input $RELEASE_TAG does not match event ref $GITHUB_REF"
+            exit 1
+          fi
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && ! "$DISPATCH_REQUEST_ID" =~ ^[A-Za-z0-9._-]{1,100}$ ]]; then
+            echo "::error::Invalid package dispatch request identity"
+            exit 1
+          fi
+          TAG_COMMIT=$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")
+          if [[ "$GITHUB_SHA" != "$TAG_COMMIT" ]]; then
+            echo "::error::Release event SHA $GITHUB_SHA does not match tag commit $TAG_COMMIT"
             exit 1
           fi
           RELEASE_JSON=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG")
@@ -78,9 +96,33 @@ jobs:
         id: version
         run: |
           echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
+
+      - name: Check npm publication state
+        id: npm-state
+        env:
+          PKG_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          VIEW_OUTPUT=""
+          if VIEW_OUTPUT=$(npm view "aidevops@$PKG_VERSION" version --json 2>&1); then
+            PUBLISHED_VERSION=$(jq -er 'if type == "array" then .[0] else . end' <<<"$VIEW_OUTPUT")
+            if [[ "$PUBLISHED_VERSION" != "$PKG_VERSION" ]]; then
+              echo "::error::Registry returned $PUBLISHED_VERSION for requested version $PKG_VERSION"
+              exit 1
+            fi
+            echo "already-published=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if grep -qE 'E404|No match found' <<<"$VIEW_OUTPUT"; then
+            echo "already-published=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::error::Unable to determine npm publication state"
+          printf '%s\n' "$VIEW_OUTPUT" >&2
+          exit 1
       
       # No token needed - uses OIDC Trusted Publisher authentication
       - name: Publish to npm
+        if: steps.npm-state.outputs.already-published != 'true'
         run: npm publish --provenance --access public
       
       - name: Summary
@@ -116,9 +158,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
+          DISPATCH_REQUEST_ID: ${{ inputs.request_id }}
         run: |
           if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Invalid release tag: $RELEASE_TAG"
+            exit 1
+          fi
+          if [[ "$GITHUB_REF" != "refs/tags/$RELEASE_TAG" ]]; then
+            echo "::error::Release input $RELEASE_TAG does not match event ref $GITHUB_REF"
+            exit 1
+          fi
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && ! "$DISPATCH_REQUEST_ID" =~ ^[A-Za-z0-9._-]{1,100}$ ]]; then
+            echo "::error::Invalid package dispatch request identity"
+            exit 1
+          fi
+          TAG_COMMIT=$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")
+          if [[ "$GITHUB_SHA" != "$TAG_COMMIT" ]]; then
+            echo "::error::Release event SHA $GITHUB_SHA does not match tag commit $TAG_COMMIT"
             exit 1
           fi
           RELEASE_JSON=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG")


### PR DESCRIPTION
## Summary

Explicitly dispatch package publication from a verified signed tag, fail closed on ambiguous run discovery, bind dispatch ref/SHA/request identity, preserve historical release-event recovery, and make npm retries idempotent.

## Files Changed

.agents/reference/release-publication-controls.md, .agents/scripts/tests/test-release-publication-workflows.sh, .agents/scripts/tests/test-version-manager-protected-publication.sh, .agents/scripts/version-manager-release.sh, .github/workflows/publish-packages.yml

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Exact-object security review PASS at fa0d707b9; actionlint; changed-file local linters; protected-publication 18/18; workflow controls 24/24; release provenance, full-loop release, GitHub release idempotence, and hot-deploy suites passed.

Resolves #28738


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.186 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 15h 7m and 7,891,491 tokens on this with the user in an interactive session.