### PR TITLE
GH#28737: Reconcile releases from immutable tag checkouts

### DIFF
--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -22,6 +22,20 @@ _full_loop_release_tag_body() {
 	return $?
 }
 
+_full_loop_release_verify_tag_provenance() {
+	local repo="$1"
+	local tag_name="$2"
+	local verifier="${SCRIPT_DIR}/release-provenance-helper.sh"
+
+	[[ -x "$verifier" ]] || return 1
+	_full_loop_release_prepare_tag_worktree "$tag_name" || return 1
+	(
+		cd "$_FULL_LOOP_RELEASE_PATH" || exit 1
+		bash "$verifier" verify --tag "$tag_name" --repo "$repo" >/dev/null
+	)
+	return $?
+}
+
 _full_loop_release_find_tag_for_pr() {
 	local repo="$1"
 	local requested_pr="$2"
@@ -29,7 +43,6 @@ _full_loop_release_find_tag_for_pr() {
 	local tag_body=""
 	local trailer=""
 	local matched=0
-	local verifier="${SCRIPT_DIR}/release-provenance-helper.sh"
 
 	_FULL_LOOP_RELEASE_FOUND_TAG=""
 	git -C "$REPO_ROOT" fetch origin --tags --quiet || return 1
@@ -46,8 +59,7 @@ _full_loop_release_find_tag_for_pr() {
 			esac
 		done <<<"$tag_body"
 		[[ "$matched" -eq 1 ]] || continue
-		[[ -x "$verifier" ]] || return 1
-		bash "$verifier" verify --tag "$candidate_tag" --repo "$repo" >/dev/null || return 1
+		_full_loop_release_verify_tag_provenance "$repo" "$candidate_tag" || return 1
 		_FULL_LOOP_RELEASE_FOUND_TAG="$candidate_tag"
 		return 0
 	done < <(git -C "$REPO_ROOT" tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname)
@@ -319,6 +331,17 @@ _full_loop_release_verify_channels() {
 	return 0
 }
 
+_full_loop_release_resolve_tag_commit() {
+	local tag_name="$1"
+	local tag_ref="refs/tags/${tag_name}^{commit}"
+	local tag_commit=""
+
+	tag_commit=$(git -C "$REPO_ROOT" rev-parse "$tag_ref" 2>/dev/null) || return 1
+	[[ "$tag_commit" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+	printf '%s\n' "$tag_commit"
+	return 0
+}
+
 _full_loop_release_inspect_remote() {
 	local repo="$1"
 	local tag_name="$2"
@@ -328,7 +351,7 @@ _full_loop_release_inspect_remote() {
 	local run_url=""
 	local find_rc=0
 
-	tag_commit=$(git -C "$REPO_ROOT" rev-parse "refs/tags/${tag_name}^{commit}" 2>/dev/null) || return 1
+	tag_commit=$(_full_loop_release_resolve_tag_commit "$tag_name") || return 1
 	_full_loop_release_find_workflow_run "$repo" "$tag_name" "$tag_commit" || find_rc=$?
 	if [[ "$find_rc" -eq 3 ]]; then
 		printf 'RELEASE_TAG=%s\nWORKFLOW_STATUS=absent\n' "$tag_name"
@@ -359,8 +382,7 @@ _full_loop_release_dispatch_recovery() {
 	local tag_commit=""
 	local correlation=""
 
-	tag_commit=$(git -C "$REPO_ROOT" rev-parse "refs/tags/${tag_name}^{commit}" 2>/dev/null) || return 1
-	[[ "$tag_commit" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+	tag_commit=$(_full_loop_release_resolve_tag_commit "$tag_name") || return 1
 	correlation="$tag_commit"
 
 	if [[ -x "$audit_helper" ]]; then
@@ -379,9 +401,27 @@ _full_loop_release_prepare_tag_worktree() {
 	local tag_name="$1"
 	local worktree_base="${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME}/Git/_worktrees}"
 	local release_path="${worktree_base}/aidevops-release-reconcile-${tag_name#v}-$$"
+	local tag_commit=""
+	local checkout_commit=""
 
+	[[ "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
 	[[ -d "$worktree_base" ]] || return 1
+	tag_commit=$(_full_loop_release_resolve_tag_commit "$tag_name") || return 1
+	if [[ -n "${_FULL_LOOP_RELEASE_PATH:-}" ]]; then
+		[[ -d "$_FULL_LOOP_RELEASE_PATH" ]] || return 1
+		checkout_commit=$(git -C "$_FULL_LOOP_RELEASE_PATH" rev-parse HEAD 2>/dev/null) || return 1
+		[[ "$checkout_commit" == "$tag_commit" ]] || return 1
+		return 0
+	fi
 	git -C "$REPO_ROOT" worktree add --detach "$release_path" "$tag_name" >/dev/null || return 1
+	checkout_commit=$(git -C "$release_path" rev-parse HEAD 2>/dev/null) || {
+		git -C "$REPO_ROOT" worktree remove "$release_path" >/dev/null 2>&1 || true
+		return 1
+	}
+	if [[ "$checkout_commit" != "$tag_commit" ]]; then
+		git -C "$REPO_ROOT" worktree remove "$release_path" >/dev/null 2>&1 || true
+		return 1
+	fi
 	_FULL_LOOP_RELEASE_PATH="$release_path"
 	trap 'cleanup_release_worktree' EXIT
 	return 0
@@ -396,6 +436,7 @@ _full_loop_release_finalize_reconciliation() {
 	local source_merge=""
 	local requested_present=""
 	local version_manager=""
+	local deploy_helper=""
 
 	source_json=$(_full_loop_release_source_json_from_tag "$tag_name") || return 1
 	source_pr=$(jq -er '.source_pr' <<<"$source_json") || return 1
@@ -405,12 +446,16 @@ _full_loop_release_finalize_reconciliation() {
 	[[ "$requested_present" == "true" ]] || return 1
 	_full_loop_validate_release_candidates "$repo" "$source_json" || return 1
 	_full_loop_release_prepare_tag_worktree "$tag_name" || return 1
-	version_manager="${_FULL_LOOP_RELEASE_PATH}/.agents/scripts/version-manager.sh"
+	version_manager="${SCRIPT_DIR}/version-manager.sh"
+	deploy_helper="${SCRIPT_DIR}/deploy-agents-on-merge.sh"
 	[[ -f "$version_manager" ]] || return 1
+	[[ -f "$deploy_helper" ]] || return 1
 	(
 		cd "$_FULL_LOOP_RELEASE_PATH" || exit 1
 		AIDEVOPS_RELEASE_INTENT_TRUSTED=1 \
 			AIDEVOPS_TRUSTED_ISSUE_PRIORITY="${AIDEVOPS_TRUSTED_ISSUE_PRIORITY:-}" \
+			AIDEVOPS_SYNC_REPO_ROOT="$_FULL_LOOP_RELEASE_PATH" \
+			AIDEVOPS_SYNC_DEPLOY_SCRIPT="$deploy_helper" \
 			bash "$version_manager" post-release
 	) || return 1
 	_full_loop_persist_release_success "$repo" "$_FULL_LOOP_RELEASE_PATH" "$source_json" \

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -43,6 +43,110 @@ if ! jq -e '.source_pr == 90
 fi
 printf 'PASS signed tag trailers reconstruct release provenance\n'
 
+mkdir -p "${TEST_ROOT}/worktrees" "${TEST_ROOT}/tag-checkout" \
+	"${TEST_ROOT}/runtime" "${TEST_ROOT}/tag-checkout/.agents/scripts"
+export AIDEVOPS_WORKTREE_BASE_DIR="${TEST_ROOT}/worktrees"
+PREPARE_GIT_LOG="${TEST_ROOT}/prepare-git.log"
+export PREPARE_GIT_LOG
+_FULL_LOOP_RELEASE_PATH="${TEST_ROOT}/tag-checkout"
+git() {
+	local args="$*"
+	case "$args" in
+	*" rev-parse refs/tags/v1.2.3^{commit}" | *" rev-parse HEAD")
+		printf '%s\n' '3333333333333333333333333333333333333333'
+		return 0
+		;;
+	*" worktree add "*)
+		printf '%s\n' "$args" >>"$PREPARE_GIT_LOG"
+		return 1
+		;;
+	esac
+	return 1
+}
+if ! _full_loop_release_prepare_tag_worktree v1.2.3 || [[ -e "$PREPARE_GIT_LOG" ]]; then
+	printf 'FAIL exact detached tag checkout was not reused safely\n'
+	exit 1
+fi
+unset -f git
+printf 'PASS exact detached tag checkout is reused across discovery and finalization\n'
+
+FAKE_VERIFY_LOG="${TEST_ROOT}/verify.log"
+FAKE_POST_RELEASE_LOG="${TEST_ROOT}/post-release.log"
+FAKE_PERSIST_LOG="${TEST_ROOT}/persist.log"
+FAKE_OLD_RUNTIME_LOG="${TEST_ROOT}/old-runtime.log"
+export FAKE_VERIFY_LOG FAKE_POST_RELEASE_LOG FAKE_PERSIST_LOG FAKE_OLD_RUNTIME_LOG
+cat >"${TEST_ROOT}/runtime/release-provenance-helper.sh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$PWD" >"${FAKE_VERIFY_LOG:?}"
+printf '%s\n' "$*" >>"${FAKE_VERIFY_LOG:?}"
+STUB
+cat >"${TEST_ROOT}/runtime/version-manager.sh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'cwd=%s\naction=%s\nsync_root=%s\ndeploy_helper=%s\n' \
+	"$PWD" "$*" "${AIDEVOPS_SYNC_REPO_ROOT:-}" \
+	"${AIDEVOPS_SYNC_DEPLOY_SCRIPT:-}" >"${FAKE_POST_RELEASE_LOG:?}"
+STUB
+cat >"${TEST_ROOT}/tag-checkout/.agents/scripts/version-manager.sh" <<'STUB'
+#!/usr/bin/env bash
+printf 'obsolete tag runtime invoked\n' >"${FAKE_OLD_RUNTIME_LOG:?}"
+exit 1
+STUB
+printf '#!/usr/bin/env bash\nexit 0\n' \
+	>"${TEST_ROOT}/runtime/deploy-agents-on-merge.sh"
+chmod +x "${TEST_ROOT}/runtime/release-provenance-helper.sh" \
+	"${TEST_ROOT}/runtime/version-manager.sh" \
+	"${TEST_ROOT}/runtime/deploy-agents-on-merge.sh" \
+	"${TEST_ROOT}/tag-checkout/.agents/scripts/version-manager.sh"
+
+saved_script_dir="$SCRIPT_DIR"
+SCRIPT_DIR="${TEST_ROOT}/runtime"
+_full_loop_release_prepare_tag_worktree() {
+	local tag_name="$1"
+	[[ "$tag_name" == "v1.2.3" ]] || return 1
+	_FULL_LOOP_RELEASE_PATH="${TEST_ROOT}/tag-checkout"
+	return 0
+}
+if ! _full_loop_release_verify_tag_provenance test/repo v1.2.3 ||
+	! grep -qx "${TEST_ROOT}/tag-checkout" "$FAKE_VERIFY_LOG" ||
+	! grep -qx 'verify --tag v1.2.3 --repo test/repo' "$FAKE_VERIFY_LOG"; then
+	printf 'FAIL release provenance was not verified from the detached tag checkout\n'
+	exit 1
+fi
+printf 'PASS release provenance verification runs from the detached tag checkout\n'
+
+_full_loop_validate_release_candidates() {
+	local repo="$1"
+	local source_json="$2"
+	[[ -n "$repo" && -n "$source_json" ]]
+	return $?
+}
+_full_loop_persist_release_success() {
+	local repo="$1"
+	local release_path="$2"
+	local source_json="$3"
+	local source_pr="$4"
+	local source_merge="$5"
+	printf '%s|%s|%s|%s|%s\n' \
+		"$repo" "$release_path" "$source_json" "$source_pr" "$source_merge" \
+		>"$FAKE_PERSIST_LOG"
+	return 0
+}
+if ! _full_loop_release_finalize_reconciliation test/repo 90 v1.2.3 ||
+	! grep -qx "cwd=${TEST_ROOT}/tag-checkout" "$FAKE_POST_RELEASE_LOG" ||
+	! grep -qx 'action=post-release' "$FAKE_POST_RELEASE_LOG" ||
+	! grep -qx "sync_root=${TEST_ROOT}/tag-checkout" "$FAKE_POST_RELEASE_LOG" ||
+	! grep -qx "deploy_helper=${TEST_ROOT}/runtime/deploy-agents-on-merge.sh" \
+		"$FAKE_POST_RELEASE_LOG" ||
+	[[ -e "$FAKE_OLD_RUNTIME_LOG" || ! -s "$FAKE_PERSIST_LOG" ]]; then
+	printf 'FAIL reconciliation did not finalize with current hardened runtime against the tag checkout\n'
+	exit 1
+fi
+SCRIPT_DIR="$saved_script_dir"
+_FULL_LOOP_RELEASE_PATH=""
+printf 'PASS reconciliation uses current hardened runtime against immutable tag content\n'
+
 cat >"${TEST_ROOT}/bin/gh" <<'STUB'
 #!/usr/bin/env bash
 args=" $* "


### PR DESCRIPTION
## Summary

Make release status and reconciliation verify provenance from an exact detached tag checkout, safely reuse that checkout, and execute the current hardened post-release runtime against immutable tag content.

## Files Changed

.agents/scripts/full-loop-release-reconcile.sh, .agents/scripts/tests/test-full-loop-release-reconcile.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused reconciliation, release command, provenance, protected-publication, and release-root suites pass; ShellCheck and shfmt pass; .agents/scripts/linters-local.sh passes.

Resolves #28737


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.186 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 15h 17m and 4,485,230 tokens on this with the user in an interactive session.