### PR TITLE
GH#28737: Keep deployed CLI helper dispatch coherent

### DIFF
--- a/.agents/scripts/tests/test-aidevops-release-command.sh
+++ b/.agents/scripts/tests/test-aidevops-release-command.sh
@@ -15,12 +15,25 @@ git -C "${TEST_ROOT}/other-repo" init -q
 
 IFS= read -r repo_version <"${REPO_ROOT}/VERSION"
 printf '%s\n' "$repo_version" >"${TEST_ROOT}/agents/VERSION"
+cp "$AIDEVOPS_SH" "${TEST_ROOT}/agents/aidevops.sh"
+cp -R "${REPO_ROOT}/.agents/scripts/aidevops-cli" "${TEST_ROOT}/agents/scripts/"
+cp "${REPO_ROOT}/.agents/scripts/plugin-source-trust-lib.sh" "${TEST_ROOT}/agents/scripts/"
+cp "${REPO_ROOT}/.agents/scripts/runtime-bundle-verifier.sh" "${TEST_ROOT}/agents/scripts/"
 
 run_cli() {
 	(
 		cd "${TEST_ROOT}/other-repo" || exit 1
 		HOME="${TEST_ROOT}/home" AIDEVOPS_AGENTS_DIR="${TEST_ROOT}/agents" \
 			AIDEVOPS_REPO_PATH="$REPO_ROOT" bash "$AIDEVOPS_SH" "$@"
+	)
+	return $?
+}
+
+run_deployed_cli() {
+	(
+		cd "${TEST_ROOT}/other-repo" || exit 1
+		HOME="${TEST_ROOT}/home" AIDEVOPS_AGENTS_DIR="${TEST_ROOT}/agents" \
+			AIDEVOPS_REPO_PATH="$REPO_ROOT" bash "${TEST_ROOT}/agents/aidevops.sh" "$@"
 	)
 	return $?
 }
@@ -47,5 +60,31 @@ if [[ "$release_rc" -ne 1 ]]; then
 	exit 1
 fi
 printf 'PASS release helper validation exit code is preserved\n'
+
+mkdir -p "${TEST_ROOT}/home/Git/aidevops/.agents/scripts/aidevops-cli"
+cat >"${TEST_ROOT}/home/Git/aidevops/.agents/scripts/full-loop-release-helper.sh" <<'STUB'
+#!/usr/bin/env bash
+printf 'stale canonical helper invoked\n'
+exit 71
+STUB
+printf '# canonical module marker\n' \
+	>"${TEST_ROOT}/home/Git/aidevops/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh"
+cat >"${TEST_ROOT}/agents/scripts/full-loop-release-helper.sh" <<'STUB'
+#!/usr/bin/env bash
+printf 'deployed release helper: %s\n' "$*"
+exit "${FAKE_DEPLOYED_HELPER_RC:-0}"
+STUB
+chmod +x "${TEST_ROOT}/home/Git/aidevops/.agents/scripts/full-loop-release-helper.sh" \
+	"${TEST_ROOT}/agents/scripts/full-loop-release-helper.sh"
+
+deployed_rc=0
+deployed_output=$(FAKE_DEPLOYED_HELPER_RC=23 run_deployed_cli release status 90) || deployed_rc=$?
+if [[ "$deployed_output" != *"deployed release helper: status 90"* ]] ||
+	[[ "$deployed_output" == *"stale canonical helper invoked"* ]] ||
+	[[ "$deployed_rc" -ne 23 ]]; then
+	printf 'FAIL deployed CLI did not preserve coherent helper selection and exit status\n'
+	exit 1
+fi
+printf 'PASS deployed CLI ignores stale canonical helpers and preserves helper exit status\n'
 
 exit 0

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1251,20 +1251,16 @@ cmd_version() {
 _dispatch_helper() {
 	local script_name="$1" error_name="$2"
 	shift 2
-	local source_hp="$INSTALL_DIR/.agents/scripts/$script_name"
+	local coherent_hp="${AIDEVOPS_CLI_MODULES_DIR%/aidevops-cli}/$script_name"
 	local deployed_hp="$AGENTS_DIR/scripts/$script_name"
-	local hp="$deployed_hp"
-	if [[ -f "$source_hp" && -f "$INSTALL_DIR/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh" ]]; then
-		hp="$source_hp"
-	fi
-	[[ ! -f "$hp" ]] && hp="$source_hp"
+	local hp="$coherent_hp"
+	[[ ! -f "$hp" ]] && hp="$deployed_hp"
 	if [[ -f "$hp" ]]; then
 		bash "$hp" "$@"
-	else
-		print_error "$error_name not found. Run: aidevops update"
-		exit 1
+		return $?
 	fi
-	return 0
+	print_error "$error_name not found. Run: aidevops update"
+	return 1
 }
 
 _dispatch_config() {


### PR DESCRIPTION
## Summary

Make generic CLI helper dispatch follow the same coherent runtime root as the loaded CLI modules, so setup-deployed commands cannot fall back to stale canonical helpers, and preserve helper exit status explicitly.

## Files Changed

.agents/scripts/tests/test-aidevops-release-command.sh, aidevops.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Deployed-vs-stale-canonical regression passes; release, launcher, schedule, portability, CLI convergence, setup mutex, and runtime integrity suites pass; ShellCheck and .agents/scripts/linters-local.sh pass.

Resolves #28737


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 15h 49m and 4,619,343 tokens on this with the user in an interactive session.