### PR TITLE
GH#28741: route interactive issue starts through authority helper

### DIFF
--- a/.agents/scripts/tests/test-interactive-start-helper.sh
+++ b/.agents/scripts/tests/test-interactive-start-helper.sh
@@ -7,6 +7,8 @@ set -uo pipefail
 scripts_dir="$(cd "$(dirname "$0")/.." && pwd)"
 helper="${scripts_dir}/interactive-start-helper.sh"
 full_loop_helper="${scripts_dir}/full-loop-helper.sh"
+command_workflow="${scripts_dir}/commands/full-loop.md"
+canonical_workflow="${scripts_dir}/../workflows/full-loop.md"
 test_root=$(mktemp -d)
 trap 'rm -rf "$test_root"' EXIT
 stub_dir="${test_root}/bin"
@@ -33,6 +35,13 @@ assert_log_line() {
 	grep -Fxq "$expected" "$call_log" || fail "missing call log line: $expected"
 	return 0
 }
+
+for workflow_path in "$command_workflow" "$canonical_workflow"; do
+	grep -Fq "interactive-start-helper.sh \\" "$workflow_path" ||
+		fail "issue-started workflow does not route through interactive-start-helper: $workflow_path"
+	grep -Fq "This route preserves" "$workflow_path" ||
+		fail "issue-started workflow does not preserve no-auto-dispatch: $workflow_path"
+done
 
 git init -q -b main "$canonical_root" || fail "could not initialize canonical fixture"
 git -C "$canonical_root" worktree add -q --orphan -b feature/interactive-start-test "$linked_worktree" ||

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -70,6 +70,20 @@ Extract first positional arg; if ` -- ` present, use suffix (t158). Resolve `t\d
 
 ## Step 1: Auto-Worktree Setup
 
+For an issue-started interactive implementation, use the authority-bearing
+entrypoint instead of calling `full-loop-helper.sh start` directly:
+
+```bash
+~/.aidevops/agents/scripts/interactive-start-helper.sh \
+  --issue "$ISSUE_NUMBER" --repo "$REPO" --task "$ARGUMENTS" \
+  ${ISSUE_HAS_AUTO_DISPATCH:+--auto-dispatch}
+```
+
+This route preserves `no-auto-dispatch` so unattended pickup stays blocked while
+exporting interactive implementation authority to the local full-loop child.
+Never translate interactive authority into a blanket non-headless exemption.
+The direct pre-edit/start sequence below is for non-issue work.
+
 ```bash
 ~/.aidevops/agents/scripts/pre-edit-check.sh --loop-mode --task "$ARGUMENTS"
 ```

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -75,8 +75,7 @@ entrypoint instead of calling `full-loop-helper.sh start` directly:
 
 ```bash
 ~/.aidevops/agents/scripts/interactive-start-helper.sh \
-  --issue "$ISSUE_NUMBER" --repo "$REPO" --task "$ARGUMENTS" \
-  ${ISSUE_HAS_AUTO_DISPATCH:+--auto-dispatch}
+  --issue "$ISSUE_NUMBER" --repo "$REPO" --task "$ARGUMENTS"
 ```
 
 This route preserves `no-auto-dispatch` so unattended pickup stays blocked while


### PR DESCRIPTION
## Summary

Route issue-started interactive full-loop sessions through interactive-start-helper while preserving no-auto-dispatch and existing headless blockers.

## Files Changed

.agents/scripts/tests/test-interactive-start-helper.sh, .agents/workflows/full-loop.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Focused interactive-start test, ShellCheck, and changed-file linters passed; review bundle 2aa42ed29d60d095129e41fdaceef06dae97d6f99a8672f74b73bbe82a07f6e9 clean.

Resolves #28741


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 24m and 181,517 tokens on this with the user in an interactive session.