### PR TITLE
GH#28737: Isolate release control from canonical checkout

### DIFF
--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -37,17 +37,50 @@ REPO_ROOT=$(_full_loop_release_resolve_repo_root) || {
 	exit 1
 }
 _FULL_LOOP_RELEASE_PATH=""
-source "${SCRIPT_DIR}/full-loop-helper-state.sh"
-# shellcheck source=./full-loop-release-reconcile.sh
-source "${SCRIPT_DIR}/full-loop-release-reconcile.sh"
+_FULL_LOOP_RELEASE_CONTROL_PATH=""
 
 cleanup_release_worktree() {
 	local release_path="${_FULL_LOOP_RELEASE_PATH:-}"
-	if [[ -n "$release_path" && -d "$release_path" ]]; then
+	local control_path="${_FULL_LOOP_RELEASE_CONTROL_PATH:-}"
+	if [[ -n "$release_path" && "$release_path" != "$control_path" && -d "$release_path" ]]; then
 		git -C "$REPO_ROOT" worktree remove "$release_path" >/dev/null 2>&1 || true
+	fi
+	if [[ -n "$control_path" && -d "$control_path" ]]; then
+		git -C "$control_path" worktree remove "$control_path" >/dev/null 2>&1 || true
 	fi
 	return 0
 }
+
+_full_loop_release_prepare_control_worktree() {
+	local repository_root="$1"
+	local worktree_base="${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME}/Git/_worktrees}"
+	local control_path="${worktree_base}/aidevops-release-control-$$"
+	local source_commit=""
+	local checkout_commit=""
+
+	[[ -d "$repository_root/.git" && -d "$worktree_base" ]] || return 1
+	source_commit=$(git -C "$repository_root" rev-parse HEAD 2>/dev/null) || return 1
+	[[ "$source_commit" =~ ^[0-9a-f]{40}$ ]] || return 1
+	git -C "$repository_root" worktree add --detach "$control_path" "$source_commit" >/dev/null || return 1
+	checkout_commit=$(git -C "$control_path" rev-parse HEAD 2>/dev/null || true)
+	if [[ ! -f "$control_path/.git" || "$checkout_commit" != "$source_commit" ]]; then
+		git -C "$control_path" worktree remove "$control_path" >/dev/null 2>&1 || true
+		return 1
+	fi
+	_FULL_LOOP_RELEASE_CONTROL_PATH="$control_path"
+	REPO_ROOT="$control_path"
+	trap 'cleanup_release_worktree' EXIT
+	return 0
+}
+
+if [[ -d "$REPO_ROOT/.git" ]] && ! _full_loop_release_prepare_control_worktree "$REPO_ROOT"; then
+	printf 'Cannot prepare a linked release control worktree.\n' >&2
+	exit 1
+fi
+
+source "${SCRIPT_DIR}/full-loop-helper-state.sh"
+# shellcheck source=./full-loop-release-reconcile.sh
+source "${SCRIPT_DIR}/full-loop-release-reconcile.sh"
 
 _FULL_LOOP_RESOLVED_SOURCE_JSON=""
 _FULL_LOOP_RESOLVED_SOURCE_PR=""

--- a/.agents/scripts/tests/test-full-loop-release-helper.sh
+++ b/.agents/scripts/tests/test-full-loop-release-helper.sh
@@ -7,7 +7,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit
 ROOT=$(mktemp -d)
 trap 'rm -rf "$ROOT"' EXIT
-mkdir -p "$ROOT/bin" "$ROOT/repo/linked-branch" "$ROOT/repo/.agents/scripts" "$ROOT/worktrees"
+mkdir -p "$ROOT/bin" "$ROOT/repo/linked-branch" "$ROOT/repo/.agents/scripts" \
+	"$ROOT/repo/.git" "$ROOT/worktrees"
 : >"$ROOT/repo/aidevops.sh"
 : >"$ROOT/repo/.agents/scripts/version-manager.sh"
 
@@ -20,7 +21,12 @@ case "$*" in
 *rev-parse\ HEAD*) printf '%040d\n' 0 ;;
 *worktree\ add*)
 	for arg in "$@"; do
-		case "$arg" in */aidevops-release-*) mkdir -p "$arg" ;; esac
+		case "$arg" in
+		*/aidevops-release-*)
+			mkdir -p "$arg"
+			: >"$arg/.git"
+			;;
+		esac
 	done
 	;;
 *worktree\ remove*)
@@ -102,6 +108,17 @@ grep -qx 'intent=1' "$ROOT/vm.log"
 grep -qx 'priority=critical' "$ROOT/vm.log"
 grep -qx 'deploy=full' "$ROOT/vm.log"
 grep -qx 'published' "$ROOT/receipts/marcusquinn_aidevops-42.status"
+if grep -Fq -- "-C $ROOT/repo fetch " "$ROOT/git.log" ||
+	! grep -Eq -- "-C ${ROOT}/worktrees/aidevops-release-control-[0-9]+ fetch origin (main|--tags)" \
+		"$ROOT/git.log"; then
+	printf 'FAIL canonical release Git mutations did not move into a linked control worktree\n'
+	exit 1
+fi
+if compgen -G "$ROOT/worktrees/aidevops-release-control-*" >/dev/null; then
+	printf 'FAIL linked release control worktree was not removed\n'
+	exit 1
+fi
+printf 'PASS canonical release Git mutations use a temporary linked control worktree\n'
 if compgen -G "$ROOT/worktrees/aidevops-release-42-*" >/dev/null; then
 	printf 'FAIL detached release worktree was not removed\n'
 	exit 1
@@ -109,7 +126,7 @@ fi
 printf 'PASS detached release runner persists publication receipt after successful gates\n'
 
 cp "$ROOT/vm.log" "$ROOT/vm-after-publication.log"
-worktree_adds_before=$(grep -c 'worktree add --detach' "$ROOT/git.log")
+worktree_adds_before=$(grep -c 'worktree add --detach .*/aidevops-release-42-' "$ROOT/git.log")
 (
 	cd "$ROOT/repo/linked-branch"
 	PATH="$ROOT/bin:/usr/bin:/bin" \
@@ -124,7 +141,7 @@ worktree_adds_before=$(grep -c 'worktree add --detach' "$ROOT/git.log")
 		bash "$SCRIPT_DIR/full-loop-release-helper.sh" minor 42 full
 )
 cmp -s "$ROOT/vm.log" "$ROOT/vm-after-publication.log"
-worktree_adds_after=$(grep -c 'worktree add --detach' "$ROOT/git.log")
+worktree_adds_after=$(grep -c 'worktree add --detach .*/aidevops-release-42-' "$ROOT/git.log")
 [[ "$worktree_adds_after" -eq "$worktree_adds_before" ]]
 printf 'PASS repeated detached release reconciliation skips duplicate publication\n'
 


### PR DESCRIPTION
## Summary

When release commands resolve a canonical aidevops checkout, create an exact detached linked control worktree first, run fetch and all subsequent mutable Git operations there, and clean both control and tag worktrees on exit.

## Files Changed

.agents/scripts/full-loop-release-helper.sh, .agents/scripts/tests/test-full-loop-release-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Canonical-session live status probe against v3.32.188 passed without mutating canonical state and left no temporary worktrees; release helper/reconciliation/provenance/publication suites pass; ShellCheck, shfmt, and .agents/scripts/linters-local.sh pass.

Resolves #28737


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 16h 9m and 4,695,870 tokens on this with the user in an interactive session.