### PR TITLE
GH#28742: make interactive start help terminal

### DIFF
--- a/.agents/scripts/interactive-start-helper.sh
+++ b/.agents/scripts/interactive-start-helper.sh
@@ -121,6 +121,7 @@ _interactive_start_parse_args() {
 	_INTERACTIVE_START_TASK=""
 	_INTERACTIVE_START_AUTO_DISPATCH=0
 	_INTERACTIVE_START_BACKGROUND=0
+	_INTERACTIVE_START_HELP_REQUESTED=0
 	while [[ $# -gt 0 ]]; do
 		local arg="$1"
 		shift
@@ -155,6 +156,7 @@ _interactive_start_parse_args() {
 		--auto-dispatch) _INTERACTIVE_START_AUTO_DISPATCH=1 ;;
 		--background | --bg) _INTERACTIVE_START_BACKGROUND=1 ;;
 		--help | -h)
+			_INTERACTIVE_START_HELP_REQUESTED=1
 			_usage
 			return 0
 			;;
@@ -173,6 +175,9 @@ _interactive_start_parse_args() {
 
 main() {
 	_interactive_start_parse_args "$@" || return $?
+	if [[ "$_INTERACTIVE_START_HELP_REQUESTED" -eq 1 ]]; then
+		return 0
+	fi
 	local issue="$_INTERACTIVE_START_ISSUE"
 	local repo="$_INTERACTIVE_START_REPO"
 	local task="$_INTERACTIVE_START_TASK"

--- a/.agents/scripts/tests/test-interactive-start-helper.sh
+++ b/.agents/scripts/tests/test-interactive-start-helper.sh
@@ -106,6 +106,25 @@ exit 0
 STUB
 chmod +x "${stub_dir}/interactive-session-helper.sh" "${stub_dir}/pre-edit-check.sh" "${stub_dir}/full-loop-helper.sh"
 
+assert_help_only() {
+	local description="$1"
+	shift
+	local help_output=""
+	local help_rc=0
+	local usage_count=0
+	: >"$call_log"
+	help_output=$(PATH="${stub_dir}:$PATH" "$helper" "$@" 2>&1) || help_rc=$?
+	[[ "$help_rc" -eq 0 ]] || fail "${description} returned ${help_rc}"
+	usage_count=$(printf '%s\n' "$help_output" | grep -c '^Usage:')
+	[[ "$usage_count" -eq 1 ]] || fail "${description} printed usage ${usage_count} times"
+	[[ ! -s "$call_log" ]] || fail "${description} invoked a lifecycle helper"
+	return 0
+}
+
+assert_help_only "long help" --help
+assert_help_only "short help" -h
+assert_help_only "help after options" --issue 42 --repo owner/repo --help --task "ignored task"
+
 (
 	cd "$canonical_root" || exit 1
 	PRE_EDIT_MODE=valid PATH="${stub_dir}:$PATH" \


### PR DESCRIPTION
## Summary

Represent help as an explicit terminal-success parser outcome so --help and -h cannot reach claim, pre-edit, marker export, or full-loop startup.

## Files Changed

.agents/scripts/interactive-start-helper.sh, .agents/scripts/tests/test-interactive-start-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused interactive-start test covers long, short, and after-option help; ShellCheck and changed-file linters passed; review bundle 4110ea7c679588e97f72c30d5874957455294fce7b5990e83e58e4d77f9a1828 clean.

Resolves #28742


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 38m and 213,687 tokens on this with the user in an interactive session.