### PR TITLE
GH#28737: Bind release commands to aidevops repository

### DIFF
--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -78,6 +78,17 @@ if [[ -d "$REPO_ROOT/.git" ]] && ! _full_loop_release_prepare_control_worktree "
 	exit 1
 fi
 
+_full_loop_release_bind_repo_context() {
+	local repo="${AIDEVOPS_FULL_LOOP_REPO:-}"
+	if [[ -z "$repo" ]]; then
+		repo=$(cd "$REPO_ROOT" && gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null) || return 1
+	fi
+	[[ "$repo" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || return 1
+	AIDEVOPS_FULL_LOOP_REPO="$repo"
+	export AIDEVOPS_FULL_LOOP_REPO
+	return 0
+}
+
 source "${SCRIPT_DIR}/full-loop-helper-state.sh"
 # shellcheck source=./full-loop-release-reconcile.sh
 source "${SCRIPT_DIR}/full-loop-release-reconcile.sh"
@@ -234,6 +245,7 @@ main() {
 			_full_loop_release_usage >&2
 			return 1
 		}
+		_full_loop_release_bind_repo_context || return 1
 		_full_loop_release_existing_command "$release_type" "$source_pr"
 		return $?
 		;;
@@ -241,6 +253,7 @@ main() {
 	case "$release_type" in patch | minor | major) ;; *) return 1 ;; esac
 	case "$deployment_scope" in incremental | full) ;; *) return 1 ;; esac
 	[[ "$source_pr" =~ ^[0-9]+$ ]] || return 1
+	_full_loop_release_bind_repo_context || return 1
 	local repo=""
 	local existing_state_rc=0
 	repo=$(_full_loop_resolve_repo "${AIDEVOPS_FULL_LOOP_REPO:-}") || return 1

--- a/.agents/scripts/tests/test-full-loop-release-helper.sh
+++ b/.agents/scripts/tests/test-full-loop-release-helper.sh
@@ -41,6 +41,14 @@ chmod +x "$ROOT/bin/git"
 
 cat >"$ROOT/bin/gh" <<'STUB'
 #!/usr/bin/env bash
+if [[ "${1:-}" == "repo" && "${2:-}" == "view" ]]; then
+	printf 'repo-view-cwd=%s\n' "$PWD" >>"${GH_CALL_LOG:?}"
+	case "$PWD" in
+	"${FAKE_CONTROL_PARENT:?}"/aidevops-release-control-*) printf 'marcusquinn/aidevops\n' ;;
+	*) printf 'wrong/caller-repo\n' ;;
+	esac
+	exit 0
+fi
 if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
 	printf '{"state":"MERGED","mergedAt":"2026-07-27T00:00:00Z","baseRefName":"main","mergeCommit":{"oid":"%040d"}}\n' 1
 	exit 0
@@ -89,13 +97,14 @@ chmod +x "$ROOT/source-resolver.sh"
 	cd "$ROOT/repo/linked-branch"
 	PATH="$ROOT/bin:/usr/bin:/bin" \
 		GIT_CALL_LOG="$ROOT/git.log" \
+		GH_CALL_LOG="$ROOT/gh.log" \
 		VM_CALL_LOG="$ROOT/vm.log" \
 		FAKE_REPO_ROOT="$ROOT/repo" \
+		FAKE_CONTROL_PARENT="$ROOT/worktrees" \
 		AIDEVOPS_WORKTREE_BASE_DIR="$ROOT/worktrees" \
 		AIDEVOPS_FULL_LOOP_VERSION_MANAGER="../../version-manager.sh" \
 		AIDEVOPS_FULL_LOOP_SOURCE_RESOLVER="$ROOT/source-resolver.sh" \
 		AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$ROOT/receipts" \
-		AIDEVOPS_FULL_LOOP_REPO=marcusquinn/aidevops \
 		AIDEVOPS_TRUSTED_ISSUE_PRIORITY=critical \
 		bash "$SCRIPT_DIR/full-loop-release-helper.sh" minor 42 full
 )
@@ -108,6 +117,7 @@ grep -qx 'intent=1' "$ROOT/vm.log"
 grep -qx 'priority=critical' "$ROOT/vm.log"
 grep -qx 'deploy=full' "$ROOT/vm.log"
 grep -qx 'published' "$ROOT/receipts/marcusquinn_aidevops-42.status"
+grep -Eq "^repo-view-cwd=${ROOT}/worktrees/aidevops-release-control-[0-9]+$" "$ROOT/gh.log"
 if grep -Fq -- "-C $ROOT/repo fetch " "$ROOT/git.log" ||
 	! grep -Eq -- "-C ${ROOT}/worktrees/aidevops-release-control-[0-9]+ fetch origin (main|--tags)" \
 		"$ROOT/git.log"; then


### PR DESCRIPTION
## Summary

Resolve and export release repository identity from the trusted aidevops control worktree rather than the caller's current directory, preserving explicit overrides and validating owner/repository shape.

## Files Changed

.agents/scripts/full-loop-release-helper.sh, .agents/scripts/tests/test-full-loop-release-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Live reconcile from an unrelated repository returned the published receipt, verified GitHub/npm/Homebrew, and remained idempotent; repository-context/control-worktree/reconciliation/provenance/CLI suites pass; ShellCheck, shfmt, and .agents/scripts/linters-local.sh pass.

Resolves #28737


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 16h 35m and 4,750,813 tokens on this with the user in an interactive session.