### PR TITLE
GH#28743: Recover clean orphans under degraded CWD visibility

### DIFF
--- a/.agents/scripts/pulse-cleanup-degraded-orphans.sh
+++ b/.agents/scripts/pulse-cleanup-degraded-orphans.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Recoverable Pass 2 cleanup for clean, zero-ahead no-PR worktrees when Linux
+# process-CWD visibility is degraded. This module is sourced by pulse-cleanup.sh.
+
+[[ -n "${_PULSE_CLEANUP_DEGRADED_ORPHANS_LOADED:-}" ]] && return 0
+_PULSE_CLEANUP_DEGRADED_ORPHANS_LOADED=1
+
+_PCDO_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "${_PCDO_SCRIPT_DIR}/worktree-clean-lib.sh" ]]; then
+	# Reuse the cleanup lease and recoverable-move primitives. Their remaining
+	# dependencies are resolved only when the corresponding functions are called.
+	# shellcheck source=worktree-clean-lib.sh
+	source "${_PCDO_SCRIPT_DIR}/worktree-clean-lib.sh"
+fi
+
+_pcdo_open_pr_absent_verified() {
+	local repo_slug="$1"
+	local branch_name="$2"
+	local pr_number=""
+
+	[[ -n "$repo_slug" && -n "$branch_name" ]] || return 1
+	pr_number=$(gh_pr_list --repo "$repo_slug" --head "$branch_name" --state open \
+		--limit 1 --json number --jq '.[].number // empty') || return 1
+	[[ -z "$pr_number" ]] || return 1
+	return 0
+}
+
+_pcdo_release_removal_lease() {
+	local wt_path="$1"
+	unregister_worktree_if_owner_pid "$wt_path" "$$" 2>/dev/null || true
+	return 0
+}
+
+_pcdo_post_lease_owner_or_claim_exists() {
+	local wt_path="$1"
+	local wt_branch="$2"
+
+	if pgrep -f "$wt_path" >/dev/null 2>&1; then
+		return 0
+	fi
+	if _clean_removal_lease_owned_by_others "$wt_path"; then
+		return 0
+	fi
+	if _branch_has_active_interactive_claim "$wt_path" "$wt_branch"; then
+		return 0
+	fi
+	return 1
+}
+
+_pcdo_fresh_candidate_state_is_safe() {
+	local rp_age="$1"
+	local wt_path_age="$2"
+	local wt_branch_age="$3"
+	local now_epoch="$4"
+	local repo_slug_age="$5"
+	local main_branch="$6"
+	local orphan_issue_num="$7"
+	local repo_name_age="$8"
+	local audit_context="$9"
+	local wt_created=0
+	local wt_age_secs=0
+	local commits_ahead=0
+	local dirty_count=0
+	local age_grace="${ORPHAN_WORKTREE_GRACE_SECS:-1800}"
+
+	[[ -d "$wt_path_age" ]] || return 1
+	wt_created=$(_worktree_creation_epoch "$wt_path_age" "$wt_branch_age")
+	[[ "$wt_created" -gt 0 ]] || return 1
+	wt_age_secs=$((now_epoch - wt_created))
+	[[ "$wt_age_secs" -ge "$age_grace" ]] || return 1
+	commits_ahead=$(_pc_commits_ahead_from_default "$rp_age" "$wt_path_age" "$main_branch") || return 1
+	[[ "$commits_ahead" -eq 0 ]] || return 1
+	dirty_count=$(git -C "$wt_path_age" status --porcelain 2>/dev/null | wc -l | tr -d ' ') || return 1
+	[[ "$dirty_count" -eq 0 ]] || return 1
+	_pcdo_open_pr_absent_verified "$repo_slug_age" "$wt_branch_age" || return 1
+	_pc_assert_no_uncommitted_work "$wt_path_age" "$wt_branch_age" "$dirty_count" \
+		"$orphan_issue_num" "$wt_age_secs" "$repo_name_age" "$audit_context" || return 1
+	return 0
+}
+
+_pcdo_fresh_cwd_state_allows_recovery() {
+	local wt_path_age="$1"
+	local guard_status=0
+
+	if worktree_removal_guard "$wt_path_age" "$_WTAR_PC_CALLER" "degraded-cwd-orphan-recoverable"; then
+		guard_status=0
+	else
+		guard_status=$?
+	fi
+	if [[ "$guard_status" -eq 0 || "$guard_status" -eq "${_WT_CWD_CAPTURE_DEGRADED_RC:-2}" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+_pc_remove_degraded_orphan_recoverably() {
+	local rp_age="$1"
+	local wt_path_age="$2"
+	local wt_branch_age="$3"
+	local now_epoch="$4"
+	local repo_slug_age="$5"
+	local main_branch="$6"
+	local orphan_issue_num="$7"
+	local repo_name_age="$8"
+	local commits_ahead="$9"
+	local dirty_count="${10}"
+	local wt_age_secs="${11}"
+	local reason="${12}"
+	local audit_context=""
+
+	[[ "$commits_ahead" -eq 0 && "$dirty_count" -eq 0 ]] || return 1
+	[[ "$reason" == *"crashed worker"* ]] || return 1
+	_pcdo_open_pr_absent_verified "$repo_slug_age" "$wt_branch_age" || return 1
+	if ! _clean_acquire_removal_lease "$wt_path_age" "$wt_branch_age"; then
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" \
+			"cleanup-lease-skip" "skipped"
+		return 1
+	fi
+
+	audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" \
+		"$commits_ahead" "$dirty_count" "$wt_age_secs" "none" "clear" "degraded" \
+		"clear" "recoverable-trash")
+	if _pcdo_post_lease_owner_or_claim_exists "$wt_path_age" "$wt_branch_age" ||
+		! _pcdo_fresh_candidate_state_is_safe "$rp_age" "$wt_path_age" "$wt_branch_age" \
+			"$now_epoch" "$repo_slug_age" "$main_branch" "$orphan_issue_num" \
+			"$repo_name_age" "$audit_context" ||
+		! _pcdo_fresh_cwd_state_allows_recovery "$wt_path_age"; then
+		_pcdo_release_removal_lease "$wt_path_age"
+		return 1
+	fi
+
+	if ! _clean_move_worktree_recoverably "$wt_path_age"; then
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" \
+			"recoverable-move-failed" "skipped" \
+			"$audit_context recoverable_backends=${_WT_CLEAN_RECOVERABLE_FAILURE_DETAIL:-unknown}"
+		_pcdo_release_removal_lease "$wt_path_age"
+		return 1
+	fi
+	if ! prune_missing_worktree_metadata "$rp_age" "$wt_path_age"; then
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" \
+			"metadata-prune-failed" "partial-cleanup" "$audit_context"
+		_pcdo_release_removal_lease "$wt_path_age"
+		return 1
+	fi
+
+	unregister_worktree "$wt_path_age" 2>/dev/null || true
+	log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_PC_CALLER" "$wt_path_age" \
+		"degraded-cwd-orphan-recoverable" "recoverable-trash" "$audit_context"
+	if declare -F full_loop_mark_cleanup_cleaned_for_worktree >/dev/null 2>&1; then
+		full_loop_mark_cleanup_cleaned_for_worktree "$wt_path_age" || true
+	fi
+	echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): recoverably removed ${wt_branch_age:-detached} — $reason" >>"$LOGFILE"
+	return 0
+}

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -85,6 +85,10 @@ if [[ -n "$_PULSE_CLEANUP_SCRIPT_DIR" && -f "$_PULSE_CLEANUP_SCRIPT_DIR/pulse-te
 	# shellcheck source=pulse-temp-worktree-cleanup.sh
 	source "$_PULSE_CLEANUP_SCRIPT_DIR/pulse-temp-worktree-cleanup.sh"
 fi
+if [[ -n "$_PULSE_CLEANUP_SCRIPT_DIR" && -f "$_PULSE_CLEANUP_SCRIPT_DIR/pulse-cleanup-degraded-orphans.sh" ]]; then
+	# shellcheck source=pulse-cleanup-degraded-orphans.sh
+	source "$_PULSE_CLEANUP_SCRIPT_DIR/pulse-cleanup-degraded-orphans.sh"
+fi
 # GH#23677 / t3700: Do NOT `unset _PULSE_CLEANUP_SCRIPT_DIR`. The previous
 # version unset this immediately after sourcing the four sibling helpers,
 # but _cleanup_merged_prs_for_all_repos() (line ~251) reads it later to
@@ -1485,6 +1489,37 @@ _pc_skip_recent_worker_metric_cleanup() {
 	return 0
 }
 
+_pc_permanently_remove_eligible_orphan() {
+	local rp_age="$1"
+	local wt_path_age="$2"
+	local wt_branch_age="$3"
+	local reason="$4"
+	local dirty_count="$5"
+	local repo_slug_age="$6"
+	local repo_name_age="$7"
+	local audit_context="$8"
+
+	echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): removing ${wt_branch_age:-detached} — $reason" >>"$LOGFILE"
+	if [[ "$reason" == *"crashed worker"* && -n "$wt_branch_age" && -n "$repo_slug_age" ]]; then
+		_record_orphan_crash_classification "$wt_branch_age" "$dirty_count" "$repo_slug_age"
+	fi
+	if ! remove_worktree_path_permanently "$wt_path_age" "$_WTAR_PC_CALLER" "$_PC_REASON_AGE_ELIGIBLE" "$audit_context"; then
+		if git -C "$rp_age" worktree remove --force "$wt_path_age" 2>/dev/null; then
+			log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_PC_CALLER" "$wt_path_age" \
+				"$_PC_REASON_AGE_ELIGIBLE" "permanent" "$audit_context"
+		else
+			return 1
+		fi
+	fi
+	git -C "$rp_age" worktree prune 2>/dev/null || true
+	unregister_worktree "$wt_path_age" 2>/dev/null || true
+	if [[ -n "$wt_branch_age" ]]; then
+		git -C "$rp_age" branch -D "$wt_branch_age" 2>/dev/null || true
+		git -C "$rp_age" push origin --delete "$wt_branch_age" 2>/dev/null || true
+	fi
+	return 0
+}
+
 #######################################
 # Per-worktree age-based orphan cleanup decision and removal.
 #
@@ -1527,7 +1562,14 @@ _cleanup_single_worktree() {
 	commits_ahead=$(_pc_commits_ahead_from_default "$rp_age" "$wt_path_age" "$main_branch") || return 1
 	local dirty_count=0
 	dirty_count=$(git -C "$wt_path_age" status --porcelain 2>/dev/null | wc -l | tr -d ' ') || return 1
-	if ! worktree_removal_guard "$wt_path_age" "$_WTAR_PC_CALLER" "$_PC_REASON_AGE_ELIGIBLE"; then
+	local removal_guard_status=0
+	if worktree_removal_guard "$wt_path_age" "$_WTAR_PC_CALLER" "$_PC_REASON_AGE_ELIGIBLE"; then
+		removal_guard_status=0
+	else
+		removal_guard_status=$?
+	fi
+	if [[ "$removal_guard_status" -ne 0 &&
+		"$removal_guard_status" -ne "${_WT_CWD_CAPTURE_DEGRADED_RC:-2}" ]]; then
 		return 1
 	fi
 
@@ -1575,37 +1617,16 @@ _cleanup_single_worktree() {
 	if ! _pc_assert_no_uncommitted_work "$wt_path_age" "$wt_branch_age" "$dirty_count" "$orphan_issue_num" "$wt_age_secs" "$repo_name_age" "$audit_context"; then
 		return 1
 	fi
-
-	echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): removing ${wt_branch_age:-detached} — $reason" >>"$LOGFILE"
-
-	# Step 5a: crash classification for the fast-path "crashed worker" case
-	if [[ "$reason" == *"crashed worker"* && -n "$wt_branch_age" && -n "$repo_slug_age" ]]; then
-		_record_orphan_crash_classification "$wt_branch_age" "$dirty_count" "$repo_slug_age"
+	if [[ "$removal_guard_status" -eq "${_WT_CWD_CAPTURE_DEGRADED_RC:-2}" ]]; then
+		_pc_remove_degraded_orphan_recoverably "$rp_age" "$wt_path_age" "$wt_branch_age" \
+			"$now_epoch" "$repo_slug_age" "$main_branch" "$orphan_issue_num" \
+			"$repo_name_age" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$reason"
+		return $?
 	fi
 
-	# Step 5b: perform removal (guarded permanent delete + deregister + branch cleanup)
-	# Age/PR/dirty gates above prove this orphaned worktree is disposable; remove
-	# permanently to avoid growing system Trash.
-	if ! remove_worktree_path_permanently "$wt_path_age" "$_WTAR_PC_CALLER" "$_PC_REASON_AGE_ELIGIBLE" "$audit_context"; then
-		if git -C "$rp_age" worktree remove --force "$wt_path_age" 2>/dev/null; then
-			log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_PC_CALLER" "$wt_path_age" "$_PC_REASON_AGE_ELIGIBLE" "permanent" "$audit_context"
-		else
-			return 1
-		fi
-	fi
-	# Prune git's worktree registry for the now-missing directory
-	git -C "$rp_age" worktree prune 2>/dev/null || true
-	# t2860: deregister from SQLite ownership registry to prevent stale entries.
-	# Without this call, pulse-cleanup destroys the worktree directory but leaves
-	# a row in worktree_owners pointing to a non-existent path with a recycled PID.
-	# Mirrors the pattern in worktree-helper.sh:1224 (cmd_remove path).
-	# Fail-open: registry deregistration must never block cleanup.
-	unregister_worktree "$wt_path_age" 2>/dev/null || true
-	if [[ -n "$wt_branch_age" ]]; then
-		git -C "$rp_age" branch -D "$wt_branch_age" 2>/dev/null || true
-		git -C "$rp_age" push origin --delete "$wt_branch_age" 2>/dev/null || true
-	fi
-	return 0
+	_pc_permanently_remove_eligible_orphan "$rp_age" "$wt_path_age" "$wt_branch_age" \
+		"$reason" "$dirty_count" "$repo_slug_age" "$repo_name_age" "$audit_context"
+	return $?
 }
 
 #######################################

--- a/.agents/scripts/tests/test-pulse-cleanup-unregister.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-unregister.sh
@@ -90,6 +90,53 @@ test_orphan_removal_unregisters() {
 	return 0
 }
 
+test_degraded_orphan_removal_is_recoverable() {
+	local repo_path="${TEST_ROOT}/repo-degraded"
+	local wt_path="${TEST_ROOT}/wt-degraded"
+	local trash_root="${TEST_ROOT}/recoverable-trash"
+	make_repo_with_worktree "$repo_path" "$wt_path" "feature/degraded"
+	mkdir -p "$trash_root"
+
+	worktree_removal_guard() {
+		local candidate_path="$1"
+		local caller="$2"
+		local reason="$3"
+		: "$candidate_path" "$caller" "$reason"
+		WORKTREE_REMOVAL_GUARD_REASON="cwd-visibility-degraded"
+		return 2
+	}
+	gh_pr_list() {
+		return 0
+	}
+	claim_worktree_ownership() {
+		return 0
+	}
+	unregister_worktree_if_owner_pid() {
+		return 0
+	}
+	is_worktree_owned_by_others_for_pid() {
+		return 1
+	}
+	_branch_has_active_interactive_claim() {
+		return 1
+	}
+
+	AIDEVOPS_WORKTREE_TRASH_ROOT="$trash_root" \
+		_cleanup_single_worktree "$repo_path" "$wt_path" "feature/degraded" \
+		"$(date +%s)" "owner/repo" "main" ||
+		fail "degraded eligible orphan was not removed recoverably"
+
+	[[ ! -e "$wt_path" ]] || fail "degraded orphan source path still exists"
+	if /usr/bin/git -C "$repo_path" worktree list --porcelain | grep -Fqx "worktree $wt_path"; then
+		fail "degraded orphan metadata remains registered"
+	fi
+	grep -Fxq "$wt_path" "$UNREGISTER_LOG" || fail "degraded orphan unregister was not called"
+	grep -q 'degraded-cwd-orphan-recoverable.*mode=recoverable-trash' "$AIDEVOPS_CLEANUP_LOG" ||
+		fail "recoverable degraded removal was not audited"
+	pass "pulse cleanup recoverably removes a degraded clean zero-ahead no-PR orphan"
+	return 0
+}
+
 write_kill_stub() {
 	local bin_dir="$1"
 	mkdir -p "$bin_dir"
@@ -366,5 +413,6 @@ test_zombie_reaper_requires_ledger_repo
 test_zombie_reaper_uses_ledger_repo_and_pid
 test_zombie_reaper_rejects_unverified_completion
 test_zombie_reaper_fails_closed_on_stale_or_indeterminate_evidence
+test_degraded_orphan_removal_is_recoverable
 
 exit 0


### PR DESCRIPTION
## Summary

Adds a tightly gated, recoverable-trash fallback for clean zero-ahead no-PR orphan worktrees when process-CWD visibility is degraded, with post-lease state revalidation and audited metadata cleanup.

## Files Changed

.agents/scripts/pulse-cleanup-degraded-orphans.sh, .agents/scripts/pulse-cleanup.sh, .agents/scripts/tests/test-pulse-cleanup-unregister.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused pulse cleanup regression suite passes; ShellCheck passes; local required lint, portability, secret, and complexity gates pass.

Resolves #28743


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 1h 5m and 484,506 tokens on this with the user in an interactive session.