### PR TITLE
GH#28668: Add safe LinkedIn account knowledge ingestion

### DIFF
--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -33,7 +33,7 @@ a claim that the route is enabled.
 | X | **Live** posts | **Live** likes and bookmarks | **Live** mentions | **Live** followers and following | **Live** owned/followed Lists and account memberships; **No** List timelines | Nine guarded `xurl` streams; bounded List snapshots rescan without inferring deletion. |
 | Reddit | **Live** submissions and comments | **Live** saved, votes, and hidden | **Live** mentions, replies, inbox, and sent | **Live** subreddit and account relationships | **Live** multireddits and membership | PRAW 8, bounded one-page reads, independent cursors, and provider-window coverage. |
 | YouTube | **Live** uploads; **Live/Partial** activity | **Live** likes; **No/Export** watch history and Watch Later | **Live/Gate** channel-related comments and replies; **No/Export** complete authored history | **Live** outbound subscriptions | **Live** owned playlists and membership; **No/Export** saved playlists | `youtube.readonly` user OAuth, identity recheck per page, bounded list quota, 30-day refresh/delete boundary, and explicit gap rows. |
-| LinkedIn | **Gate/Export** | **Gate/Export** | **Export** | **Gate/Export** | **Export/No** | Treat member access as restricted; do not reuse browser engagement automation as a collector. |
+| LinkedIn | **Live/Gate/Export** posts and articles | **Live/Gate/Export** comments, reactions, and saved items | **Live/Gate/Export** messages | **Live/Gate/Export** follows, connections, company follows, and groups | **No** newsletter subscriptions | Ten GET-only Member Snapshot streams for eligible EEA/Swiss members; account download remains an unwired export fallback. |
 | Facebook | **Gate/Export** | **Gate/Export** | **Gate/Export** | **Gate/Export** | **Gate/Export** | Shared Meta authorization needs app-review and product-specific evidence. |
 | Instagram | **Gate/Export** media | **Gate/Export** | **Gate/Export** comments and mentions | **Gate/Export** | **Export/No** | Verify Professional versus personal-account coverage before implementation. |
 | Threads | **API/Gate/Export** | **API/Gate/Export** | **API/Gate/Export** replies | **Gate/Export** | **No** until verified | Keep authorization and gaps distinct from Facebook and Instagram despite shared Meta identity. |
@@ -77,6 +77,15 @@ a claim that the route is enabled.
   GET-only provider boundary. `.agents/content/social-youtube.md` records the
   official route, scope, retention, export, and unsupported evidence checked on
   2026-07-26.
+- **Live LinkedIn:** `.agents/scripts/knowledge_social_linkedin.py`,
+  `.agents/scripts/_knowledge_social_linkedin*.py`, and
+  `.agents/tests/test-knowledge-social-linkedin.sh` prove ten independently
+  checkpointed Member Snapshot domains, identity rebinding, content-addressed
+  replay, credential rejection, bounded GET-only transport, consent/deletion
+  coverage, and static isolation from browser mutation tooling.
+  `.agents/content/social-linkedin.md` records the official regional/product
+  gates, `202312` endpoint version, 28-day changelog boundary, account export,
+  storage terms, and explicit newsletter disposition checked on 2026-07-27.
 - **All candidate rows:** the provider child owns current official documentation,
   account/export samples, auth scopes, dependency versions, local exported
   symbols, retention evidence, and explicit unsupported findings.

--- a/.agents/content/social-linkedin.md
+++ b/.agents/content/social-linkedin.md
@@ -18,9 +18,11 @@ tools:
 
 ## Quick Reference
 
-- **API**: Community Management API (v2) via OAuth 2.0
+- **Publishing API**: Community Management API via OAuth 2.0; vetted access
+- **Read collector**: Member Data Portability Member Snapshot API; EEA/Swiss gate
 - **Docs**: https://learn.microsoft.com/en-us/linkedin/marketing/
-- **Auth**: OAuth 2.0 three-legged flow, scopes: `w_member_social`, `r_organization_social`
+- **Collector**: `knowledge-social-helper.sh sync-linkedin`
+- **Auth**: Externally provisioned member OAuth token; never a browser session
 - **Related**: [bird.md](bird.md) (X/Twitter), [reddit.md](reddit.md) (Reddit)
 
 **Post types**: Text (3k chars), Article (long-form), Carousel (PDF, 300p), Document (PDF/PPT/DOC, 100MB), Poll (2-4 options, 1-2 wks), Image (up to 9), Video (10 min max)
@@ -47,6 +49,108 @@ curl -X POST -H "Authorization: Bearer $TOKEN" \
   "https://api.linkedin.com/v2/posts" \
   -d '{"author":"urn:li:person:ID","lifecycleState":"PUBLISHED","visibility":"PUBLIC","commentary":"Post text here","distribution":{"feedDistribution":"MAIN_FEED"}}'
 ```
+
+## Read-only account knowledge
+
+Evidence was revalidated against official documentation on 2026-07-27. The
+collector deliberately does not import, invoke, or share credentials with
+`linkedin-automation.py`.
+
+### Route decision
+
+- Community Management is a vetted product. Its documented read scopes cover
+  administered organizations and member analytics, not a general personal
+  history reader. LinkedIn also states that `r_member_social` is closed to new
+  access requests. See
+  https://learn.microsoft.com/en-us/linkedin/marketing/increasing-access and
+  https://learn.microsoft.com/en-us/linkedin/marketing/community-management/community-management-overview.
+- Member Data Portability is the verified personal-data route. Third-party apps
+  require business verification/review and `r_dma_portability_3rd_party`; only
+  EEA members can consent. The member product is available to EEA and Swiss
+  members. See
+  https://learn.microsoft.com/en-us/linkedin/dma/member-data-portability/member-data-portability-3rd-party/
+  and
+  https://learn.microsoft.com/en-us/linkedin/dma/member-data-portability/member-data-portability-member/.
+- The Member Snapshot endpoint is GET-only, historical, and fixed to LinkedIn
+  API version `202312`. Its `total` and paging links can omit data from offline
+  systems, so the collector advances `start` after every successful page and
+  completes only on the documented `No data found for this memberId` response. See
+  https://learn.microsoft.com/en-us/linkedin/dma/member-data-portability/shared/member-snapshot-api.
+- The changelog route retains only the preceding 28 days, recommends hourly
+  reads, and allows `count` from 1 through 50. It is not used by the first
+  collector because snapshots provide the narrower historical route. See
+  https://learn.microsoft.com/en-us/linkedin/dma/member-data-portability/shared/member-changelog-api.
+
+The member-product overview names `r_dma_portability_self_serve`, while the
+Snapshot API permission table names `r_dma_portability_member`. The collector
+does not guess between these official names or implement OAuth provisioning; it
+accepts only an already provisioned token and verifies its member authorization
+before the first read and again before every page.
+
+### Implemented streams
+
+| Stream | Official snapshot domain | Disposition |
+|---|---|---|
+| `authored_posts` | `MEMBER_SHARE_INFO` | Live/Gate |
+| `authored_articles` | `ARTICLES` | Live/Gate |
+| `comments` | `ALL_COMMENTS` | Live/Gate |
+| `reactions` | `ALL_LIKES` | Live/Gate |
+| `saved_items` | `ACTOR_SAVE_ITEM` | Live/Gate |
+| `messages` | `INBOX` | Live/Gate |
+| `following` | `MEMBER_FOLLOWING` | Live/Gate |
+| `connections` | `CONNECTIONS` | Live/Gate |
+| `company_follows` | `COMPANY_FOLLOWS` | Live/Gate |
+| `groups` | `GROUPS` | Live/Gate |
+| Newsletter subscriptions | None listed | No |
+
+The authoritative domain list is
+https://learn.microsoft.com/en-us/linkedin/dma/member-data-portability/shared/snapshot-domain.
+The collector stores each successful response as immutable raw evidence. Because
+the official domain page does not define each record's field schema, normalized
+rows contain only a content-addressed identity and provenance, not guessed or
+bulk-copied fields. Credential-shaped keys fail before raw or normalized
+persistence.
+
+### Account archive fallback
+
+LinkedIn's account download is a validated export fallback, including Articles,
+Comments, Connections, Groups, Member Follows, Messages, Reactions, Saved Items,
+Shares, and Company Follows. Specific categories can arrive within 10 minutes;
+the larger archive and several activity categories can take up to 48 hours, and
+the download remains available for 72 hours. See
+https://www.linkedin.com/help/linkedin/answer/a1339364.
+
+No archive importer is exposed yet: the official page documents categories but
+not a stable file schema, and no private sample was accepted into git. This is an
+explicit Export disposition, not simulated live coverage. The current official
+lists do not identify newsletter subscriptions as a snapshot or archive
+category.
+
+### Safety and retention
+
+- Store the selected token outside git as
+  `LINKEDIN_<PROFILE>_ACCESS_TOKEN`; use `aidevops secret set` rather than a
+  plaintext project file.
+- Pass the opaque token portion of the authorized member URN as `--account-id`;
+  do not use a profile URL slug.
+- Member Portability data may be stored with the member's consent and a
+  continuing legal basis, and must be deleted on member request or linked
+  account closure. See https://www.linkedin.com/legal/l/portability-api-terms.
+- Marketing API member social activity has a separate 48-hour storage boundary;
+  do not mix Marketing and Portability data. See
+  https://learn.microsoft.com/en-us/linkedin/marketing/data-storage-requirements.
+- LinkedIn's API terms prohibit scraping, crawling, browser-derived unofficial
+  content, and credential proxying. See
+  https://www.linkedin.com/legal/l/api-terms-of-use.
+
+```bash
+knowledge-social-helper.sh sync-linkedin \
+  --connection-id conn_linkedin --account-id MEMBER_ID \
+  --stream authored_posts --profile personal --budget 11 --page-size 10
+```
+
+Python 3.14.3 and the local `urllib.request` exports (`Request`, `urlopen`) were
+verified before implementation; no LinkedIn SDK was installed or imported.
 
 ## Content Best Practices
 

--- a/.agents/scripts/_knowledge_social_collect_cli.py
+++ b/.agents/scripts/_knowledge_social_collect_cli.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sqlite3
 import subprocess
 import sys
@@ -23,6 +24,23 @@ Collector = Callable[[argparse.Namespace, Path, str], dict[str, Any]]
 EnvironmentFactory = Callable[[], dict[str, str]]
 OutputDecoder = Callable[[str], dict[str, Any]]
 ProviderFailure = Callable[[str], Exception]
+READER_ENVIRONMENT_KEYS = frozenset(
+    {
+        "HOME",
+        "HTTPS_PROXY",
+        "HTTP_PROXY",
+        "LANG",
+        "LC_ALL",
+        "NO_PROXY",
+        "PATH",
+        "REQUESTS_CA_BUNDLE",
+        "SSL_CERT_FILE",
+        "TMPDIR",
+        "https_proxy",
+        "http_proxy",
+        "no_proxy",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -74,6 +92,22 @@ class GuardedReaderProcess:
         if completed.returncode != 0:
             raise self.provider_failure(completed.stderr)
         return self.decode_output(completed.stdout)
+
+
+def guarded_reader_environment(
+    token_name: str, test_keys: tuple[str, ...] = ()
+) -> dict[str, str]:
+    """Expose only one provider token and bounded runtime support variables."""
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if key in READER_ENVIRONMENT_KEYS or key == token_name
+    }
+    if os.environ.get("AIDEVOPS_TEST_MODE") == "1":
+        for key in ("AIDEVOPS_TEST_MODE", "PYTHONPATH", *test_keys):
+            if key in os.environ:
+                environment[key] = os.environ[key]
+    return environment
 
 
 def parse_collector_args(policy: CollectorCliPolicy) -> argparse.Namespace:

--- a/.agents/scripts/_knowledge_social_linkedin.py
+++ b/.agents/scripts/_knowledge_social_linkedin.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""LinkedIn Member Snapshot stream policy and durable checkpoints."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from knowledge_social_import import canonical_json, reject_credentials
+from knowledge_social_store import SocialStoreError
+
+PROVIDER = "linkedin"
+API_VERSION = "202312"
+CURSOR_PREFIX = "linkedin-snapshot-v1:"
+MEMBER_ID = re.compile(r"^[A-Za-z0-9_-]{3,128}$")
+PORTABILITY_RETENTION = (
+    "member_consent_and_delete_on_request_or_linked_account_closure"
+)
+
+
+class LinkedInAdapterError(SocialStoreError):
+    """Raised when guarded LinkedIn collection cannot continue safely."""
+
+
+class LinkedInProviderUnavailableError(LinkedInAdapterError):
+    """Raised when the bounded LinkedIn OAuth child cannot complete a read."""
+
+
+ADAPTER_ERROR = LinkedInAdapterError
+PROVIDER_UNAVAILABLE_ERROR = LinkedInProviderUnavailableError
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    """Static policy for one documented Member Snapshot domain."""
+
+    snapshot_domain: str
+    resource_kind: str
+    activity_mode: str
+    retention_limit: str | None = PORTABILITY_RETENTION
+    coverage_status: str | None = None
+    unavailable_reason: str | None = None
+    cost_units: int = 2
+
+
+STREAMS = {
+    "authored_posts": StreamSpec("MEMBER_SHARE_INFO", "post", "content_author"),
+    "authored_articles": StreamSpec("ARTICLES", "article", "content_author"),
+    "comments": StreamSpec("ALL_COMMENTS", "comment", "content_author"),
+    "reactions": StreamSpec("ALL_LIKES", "reaction", "selected_account"),
+    "saved_items": StreamSpec("ACTOR_SAVE_ITEM", "saved_item", "selected_account"),
+    "messages": StreamSpec("INBOX", "message", "selected_account"),
+    "following": StreamSpec("MEMBER_FOLLOWING", "member_follow", "selected_account"),
+    "connections": StreamSpec("CONNECTIONS", "connection", "selected_account"),
+    "company_follows": StreamSpec(
+        "COMPANY_FOLLOWS", "company_follow", "selected_account"
+    ),
+    "groups": StreamSpec("GROUPS", "group_membership", "selected_account"),
+}
+
+
+@dataclass(frozen=True)
+class PageRequest:
+    """One allowlisted, bounded Member Snapshot request."""
+
+    stream: str
+    account_id: str
+    domain: str
+    start: int
+    limit: int
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "page",
+            "stream": self.stream,
+            "account_id": self.account_id,
+            "domain": self.domain,
+            "start": self.start,
+            "limit": self.limit,
+        }
+
+    def evidence_key(self) -> str:
+        return canonical_json(self.payload())
+
+
+def member_id(value: Any, field: str) -> str:
+    """Validate the opaque token portion of a LinkedIn member URN."""
+    if not isinstance(value, str) or MEMBER_ID.fullmatch(value) is None:
+        raise LinkedInAdapterError(f"LinkedIn {field} must be a stable member ID")
+    return value
+
+
+def _decode_cursor(cursor: str) -> int:
+    if not cursor.startswith(CURSOR_PREFIX):
+        raise LinkedInAdapterError("stored LinkedIn cursor has an unsupported version")
+    value = cursor.removeprefix(CURSOR_PREFIX)
+    if not value.isascii() or not value.isdigit():
+        raise LinkedInAdapterError("stored LinkedIn cursor is invalid")
+    start = int(value)
+    if start <= 0 or start > 1_000_000_000:
+        raise LinkedInAdapterError("stored LinkedIn cursor is outside the safety limit")
+    return start
+
+
+def page_request(
+    stream: str,
+    account: dict[str, Any],
+    state: CursorState,
+    limit: int,
+) -> PageRequest:
+    """Build one snapshot request from durable per-stream state."""
+    spec = STREAMS[stream]
+    account_id = member_id(account.get("id"), "account ID")
+    start = _decode_cursor(state.cursor) if state.cursor else 0
+    return PageRequest(stream, account_id, spec.snapshot_domain, start, limit)
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    """Return a validated HTTP-like status from a LinkedIn response."""
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise LinkedInAdapterError("LinkedIn response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return a validated Member Snapshot record array."""
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise LinkedInAdapterError("LinkedIn snapshot data must be an array of objects")
+    reject_credentials(data)
+    return data
+
+
+def page_checkpoint(
+    payload: dict[str, Any],
+    state: CursorState,
+    request: PageRequest,
+) -> tuple[PageCheckpoint, bool]:
+    """Calculate the next resumable Member Snapshot page."""
+    del state
+    meta = payload.get("meta")
+    if not isinstance(meta, dict):
+        raise LinkedInAdapterError("LinkedIn page metadata must be an object")
+    reject_credentials(meta)
+    if meta.get("domain") != request.domain or meta.get("snapshot") is not True:
+        raise LinkedInAdapterError("LinkedIn page domain metadata is invalid")
+    complete = meta.get("complete")
+    next_start = meta.get("next_start")
+    if not isinstance(complete, bool):
+        raise LinkedInAdapterError("LinkedIn page completion metadata is invalid")
+    if next_start is not None:
+        if isinstance(next_start, bool) or not isinstance(next_start, int):
+            raise LinkedInAdapterError("LinkedIn next page is invalid")
+        if next_start <= request.start or next_start > 1_000_000_000:
+            raise LinkedInAdapterError("LinkedIn next page is invalid")
+    if complete == (next_start is not None):
+        message = (
+            "complete LinkedIn page cannot have a next cursor"
+            if complete
+            else "partial LinkedIn page requires a next cursor"
+        )
+        raise LinkedInAdapterError(message)
+    cursor = f"{CURSOR_PREFIX}{next_start}" if next_start is not None else None
+    return PageCheckpoint(cursor, None), complete

--- a/.agents/scripts/_knowledge_social_linkedin_contract.py
+++ b/.agents/scripts/_knowledge_social_linkedin_contract.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validation for the bounded LinkedIn Member Snapshot subprocess."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import parse_qs, urlsplit
+
+from _knowledge_social_linkedin import MEMBER_ID
+from knowledge_social_import import reject_credentials
+
+MAX_TEXT_BYTES = 256 * 1024
+MEMBER_URN_PREFIX = "urn:li:person:"
+
+
+class LinkedInReadProviderError(RuntimeError):
+    """Raised for a privacy-safe local LinkedIn provider failure."""
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    """One bounded HTTP result without provider error-body disclosure."""
+
+    status: int
+    payload: dict[str, Any]
+    retry_after: int | None = None
+    no_data: bool = False
+
+
+def observed_at() -> str:
+    """Return a stable UTC timestamp for one provider response."""
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def exact_keys(request: dict[str, Any], expected: set[str]) -> None:
+    """Reject parent requests outside the allowlisted read contract."""
+    if set(request) != expected:
+        raise LinkedInReadProviderError(
+            "LinkedIn read request has an invalid action shape"
+        )
+
+
+def optional_text(value: Any, field: str) -> str | None:
+    """Validate bounded provider text."""
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value:
+        raise LinkedInReadProviderError(f"LinkedIn {field} must be text")
+    if len(value.encode("utf-8")) > MAX_TEXT_BYTES:
+        raise LinkedInReadProviderError(f"LinkedIn {field} exceeds the safety limit")
+    return value
+
+
+def stable_member_id(value: Any, field: str) -> str:
+    """Validate an opaque LinkedIn member ID without accepting a full URN."""
+    text = optional_text(value, field)
+    if not text or MEMBER_ID.fullmatch(text) is None:
+        raise LinkedInReadProviderError(f"LinkedIn {field} is invalid")
+    return text
+
+
+def member_urn_id(value: Any, field: str) -> str:
+    """Validate one person URN and return its opaque token."""
+    text = optional_text(value, field)
+    if not text or not text.startswith(MEMBER_URN_PREFIX):
+        raise LinkedInReadProviderError(f"LinkedIn {field} is invalid")
+    return stable_member_id(text.removeprefix(MEMBER_URN_PREFIX), field)
+
+
+def _objects(value: Any, field: str) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise LinkedInReadProviderError(f"LinkedIn {field} must be an array of objects")
+    reject_credentials(value)
+    return value
+
+
+def identity_value(payload: dict[str, Any], expected_id: str) -> dict[str, str]:
+    """Verify that the token is bound to exactly the configured member."""
+    expected = stable_member_id(expected_id, "account ID")
+    members: set[str] = set()
+    for item in _objects(payload.get("elements", []), "authorization elements"):
+        key = item.get("memberComplianceAuthorizationKey")
+        if not isinstance(key, dict):
+            raise LinkedInReadProviderError(
+                "LinkedIn authorization has no member binding"
+            )
+        members.add(member_urn_id(key.get("member"), "authorization member"))
+    if members != {expected}:
+        raise LinkedInReadProviderError(
+            "selected LinkedIn member does not match the configured connection"
+        )
+    return {"id": expected}
+
+
+def terminal_payload(result: ApiResult) -> dict[str, Any]:
+    """Build a sanitized terminal response envelope."""
+    payload: dict[str, Any] = {"status": result.status, "observed_at": observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload
+
+
+def _next_start(
+    payload: dict[str, Any], domain: str, current_start: int
+) -> int:
+    paging = payload.get("paging", {})
+    if not isinstance(paging, dict):
+        raise LinkedInReadProviderError("LinkedIn snapshot paging must be an object")
+    links = paging.get("links", [])
+    if not isinstance(links, list) or any(not isinstance(link, dict) for link in links):
+        raise LinkedInReadProviderError("LinkedIn snapshot links must be an array")
+    next_links = [link for link in links if link.get("rel") == "next"]
+    if len(next_links) > 1:
+        raise LinkedInReadProviderError("LinkedIn snapshot has multiple next links")
+    if not next_links:
+        start = current_start + 1
+        if start > 1_000_000_000:
+            raise LinkedInReadProviderError(
+                "LinkedIn snapshot next page exceeds the safety limit"
+            )
+        return start
+    href = optional_text(next_links[0].get("href"), "snapshot next link")
+    if not href or len(href.encode("utf-8")) > 4096:
+        raise LinkedInReadProviderError("LinkedIn snapshot next link is invalid")
+    parsed = urlsplit(href)
+    if parsed.scheme or parsed.netloc or parsed.fragment:
+        raise LinkedInReadProviderError("LinkedIn snapshot next link must be relative")
+    if parsed.path != "/rest/memberSnapshotData":
+        raise LinkedInReadProviderError("LinkedIn snapshot next endpoint is not allowlisted")
+    query = parse_qs(parsed.query, keep_blank_values=True, strict_parsing=True)
+    if query.get("q") != ["criteria"] or query.get("domain") != [domain]:
+        raise LinkedInReadProviderError("LinkedIn snapshot next query is invalid")
+    starts = query.get("start")
+    if starts is None or len(starts) != 1 or not starts[0].isascii() or not starts[0].isdigit():
+        raise LinkedInReadProviderError("LinkedIn snapshot next page is invalid")
+    start = int(starts[0])
+    if start <= current_start or start > 1_000_000_000:
+        raise LinkedInReadProviderError("LinkedIn snapshot next page is invalid")
+    return start
+
+
+def snapshot_page(
+    result: ApiResult,
+    domain: str,
+    start: int,
+    limit: int,
+) -> dict[str, Any]:
+    """Serialize one documented Member Snapshot page without field guessing."""
+    if result.no_data and result.status == 404:
+        return {
+            "status": 200,
+            "observed_at": observed_at(),
+            "data": [],
+            "meta": {
+                "domain": domain,
+                "next_start": None,
+                "complete": True,
+                "snapshot": True,
+            },
+        }
+    if result.status != 200:
+        return terminal_payload(result)
+    elements = _objects(result.payload.get("elements"), "snapshot elements")
+    if len(elements) != 1:
+        raise LinkedInReadProviderError(
+            "LinkedIn snapshot response must contain exactly one domain"
+        )
+    element = elements[0]
+    if element.get("snapshotDomain") != domain:
+        raise LinkedInReadProviderError("LinkedIn snapshot domain does not match")
+    records = _objects(element.get("snapshotData"), "snapshot data")
+    if len(records) > limit:
+        raise LinkedInReadProviderError("LinkedIn snapshot page exceeds the item limit")
+    next_start = _next_start(result.payload, domain, start)
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": records,
+        "meta": {
+            "domain": domain,
+            "next_start": next_start,
+            "complete": False,
+            "snapshot": True,
+        },
+    }

--- a/.agents/scripts/_knowledge_social_linkedin_http.py
+++ b/.agents/scripts/_knowledge_social_linkedin_http.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded LinkedIn HTTP response decoding and terminal metadata."""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from typing import Any
+from urllib.error import HTTPError
+
+from _knowledge_social_linkedin_contract import ApiResult, LinkedInReadProviderError
+
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+NO_DATA_MESSAGE = "No data found for this memberId"
+
+
+def retry_epoch(value: str | None) -> int | None:
+    """Convert a bounded Retry-After duration to an absolute epoch."""
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    return int(time.time() + math.ceil(seconds))
+
+
+def decode_response(payload: bytes) -> dict[str, Any]:
+    """Decode one bounded LinkedIn JSON response object."""
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise LinkedInReadProviderError("LinkedIn read response exceeds the safety limit")
+    try:
+        decoded = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise LinkedInReadProviderError(
+            "LinkedIn read provider returned no valid JSON"
+        ) from error
+    if not isinstance(decoded, dict):
+        raise LinkedInReadProviderError("LinkedIn API response root must be an object")
+    return decoded
+
+
+def _contains_no_data(value: Any) -> bool:
+    if isinstance(value, str):
+        return NO_DATA_MESSAGE in value
+    if isinstance(value, dict):
+        return any(_contains_no_data(child) for child in value.values())
+    if isinstance(value, list):
+        return any(_contains_no_data(child) for child in value)
+    return False
+
+
+def _no_data_body(body: Any) -> bool:
+    if not isinstance(body, bytes):
+        return False
+    if len(body) > MAX_RESPONSE_BYTES:
+        return False
+    try:
+        return _contains_no_data(decode_response(body))
+    except LinkedInReadProviderError:
+        return False
+
+
+def http_error_result(error: HTTPError) -> ApiResult:
+    """Return sanitized metadata for one bounded HTTP error response."""
+    status = error.code
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise LinkedInReadProviderError("LinkedIn HTTP status is invalid") from error
+    body = error.read(MAX_RESPONSE_BYTES + 1)
+    no_data = _no_data_body(body) if status == 404 else False
+    headers = error.headers
+    retry_after = retry_epoch(headers.get("Retry-After")) if headers else None
+    return ApiResult(status, {}, retry_after, no_data)

--- a/.agents/scripts/_knowledge_social_linkedin_normalize.py
+++ b/.agents/scripts/_knowledge_social_linkedin_normalize.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize LinkedIn snapshots without guessing undocumented field mappings."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_linkedin import (
+    API_VERSION,
+    PROVIDER,
+    STREAMS,
+    LinkedInAdapterError,
+    page_data,
+)
+from knowledge_social_import import canonical_json, reject_credentials
+
+PROVENANCE = "linkedin_member_snapshot_api"
+
+
+@dataclass(frozen=True)
+class PageContext:
+    """Validated connection policy needed to normalize one snapshot page."""
+
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def _observation_time(payload: dict[str, Any]) -> str:
+    value = payload.get("observed_at")
+    if not isinstance(value, str) or not value:
+        raise LinkedInAdapterError("LinkedIn page observed_at must be text")
+    return value
+
+
+def _record_id(
+    account_id: str, domain: str, record: dict[str, Any]
+) -> tuple[str, str]:
+    reject_credentials(record)
+    record_digest = hashlib.sha256(canonical_json(record).encode("utf-8")).hexdigest()
+    identity_digest = hashlib.sha256(
+        f"{account_id}\x00{domain}\x00{record_digest}".encode("utf-8")
+    ).hexdigest()
+    return f"li_snapshot_{identity_digest}", record_digest
+
+
+def _gap_coverage(observed_at: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "stream": "newsletter_subscriptions",
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": None,
+            "unavailable_reason": (
+                "linkedin_member_snapshot_domains_do_not_list_newsletter_subscriptions"
+            ),
+            "status": "unavailable",
+            "observed_at": observed_at,
+        }
+    ]
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    """Build provider-neutral rows plus immutable raw snapshot evidence."""
+    reject_credentials(payload)
+    observed_at = _observation_time(payload)
+    account_id = context.account.get("id")
+    if not isinstance(account_id, str) or not account_id:
+        raise LinkedInAdapterError("LinkedIn selected account requires an ID")
+    spec = STREAMS[context.stream]
+    meta = payload.get("meta")
+    if not isinstance(meta, dict) or meta.get("domain") != spec.snapshot_domain:
+        raise LinkedInAdapterError("LinkedIn snapshot provenance is invalid")
+    objects: list[dict[str, Any]] = []
+    activities: list[dict[str, Any]] = []
+    for record in page_data(payload):
+        remote_id, digest = _record_id(account_id, spec.snapshot_domain, record)
+        evidence_class = (
+            "authored" if spec.activity_mode == "content_author" else "observed"
+        )
+        provenance = {
+            "snapshot_domain": spec.snapshot_domain,
+            "record_sha256": digest,
+            "source": PROVENANCE,
+        }
+        objects.append(
+            {
+                "object_type": spec.resource_kind,
+                "remote_id": remote_id,
+                "account_remote_id": account_id,
+                "text": None,
+                "created_at": None,
+                "observed_at": observed_at,
+                "evidence_class": evidence_class,
+                "provider_json": provenance,
+            }
+        )
+        activities.append(
+            {
+                "activity_type": context.stream,
+                "remote_id": f"{account_id}-{context.stream}-{digest}",
+                "actor_remote_id": account_id,
+                "object_remote_id": remote_id,
+                "occurred_at": None,
+                "observed_at": observed_at,
+                "state": "active",
+                "provider_json": provenance,
+            }
+        )
+    policy = dict(context.policy)
+    policy.update(
+        {
+            "linkedin_api_version": API_VERSION,
+            "linkedin_provenance": PROVENANCE,
+        }
+    )
+    return {
+        "provider": PROVIDER,
+        "connection_id": context.connection_id,
+        "remote_account_id": account_id,
+        "exported_at": observed_at,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": policy,
+        "accounts": [
+            {
+                "remote_id": account_id,
+                "handle": None,
+                "display_name": None,
+                "observed_at": observed_at,
+                "provider_json": {"source": PROVENANCE},
+            }
+        ],
+        "objects": objects,
+        "activities": activities,
+        "media": [],
+        "coverage": _gap_coverage(observed_at),
+    }

--- a/.agents/scripts/_knowledge_social_linkedin_provider.py
+++ b/.agents/scripts/_knowledge_social_linkedin_provider.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded GET-only OAuth subprocess for LinkedIn Member Snapshot reads."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from _knowledge_social_linkedin import API_VERSION, STREAMS
+from _knowledge_social_linkedin_contract import (
+    ApiResult,
+    LinkedInReadProviderError,
+    exact_keys,
+    identity_value,
+    observed_at,
+    snapshot_page,
+    stable_member_id,
+    terminal_payload,
+)
+from _knowledge_social_linkedin_http import (
+    MAX_RESPONSE_BYTES,
+    NO_DATA_MESSAGE,
+    decode_response,
+    http_error_result,
+)
+
+API_BASE = "https://api.linkedin.com/rest"
+READ_ENDPOINTS = {"memberAuthorizations", "memberSnapshotData"}
+MAX_REQUEST_BYTES = 32 * 1024
+HTTP_TIMEOUT_SECONDS = 60
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+UrlOpen = Callable[..., Any]
+
+
+def _profile_prefix(profile: str) -> str:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise LinkedInReadProviderError("LinkedIn OAuth profile name is invalid")
+    return f"LINKEDIN_{profile.upper()}"
+
+
+def _access_token(profile: str) -> str:
+    token = os.environ.get(f"{_profile_prefix(profile)}_ACCESS_TOKEN", "")
+    if not token or "\x00" in token or len(token.encode("utf-8")) > 16 * 1024:
+        raise LinkedInReadProviderError(
+            "LinkedIn OAuth profile access token is missing"
+        )
+    return token
+
+
+def _http_exports() -> UrlOpen:
+    if not callable(Request) or not callable(urlopen) or not callable(urlencode):
+        raise LinkedInReadProviderError("Python urllib HTTP exports are unavailable")
+    return urlopen
+
+
+def _request() -> dict[str, Any]:
+    payload = sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1)
+    if len(payload) > MAX_REQUEST_BYTES:
+        raise LinkedInReadProviderError("LinkedIn read request exceeds the safety limit")
+    try:
+        request = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise LinkedInReadProviderError(
+            "LinkedIn read request is not valid JSON"
+        ) from error
+    if not isinstance(request, dict):
+        raise LinkedInReadProviderError("LinkedIn read request root must be an object")
+    return request
+
+
+def _api(token: str, opener: UrlOpen, endpoint: str, params: dict[str, str]) -> ApiResult:
+    if endpoint not in READ_ENDPOINTS:
+        raise LinkedInReadProviderError("LinkedIn API endpoint is not allowlisted")
+    url = f"{API_BASE}/{endpoint}?{urlencode(params)}"
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Linkedin-Version": API_VERSION,
+            "User-Agent": "aidevops-linkedin-knowledge/1",
+        },
+        method="GET",
+    )
+    try:
+        with opener(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", 200)
+            if isinstance(status, bool) or not isinstance(status, int):
+                raise LinkedInReadProviderError("LinkedIn HTTP status is invalid")
+            payload = response.read(MAX_RESPONSE_BYTES + 1)
+            if not isinstance(payload, bytes):
+                raise LinkedInReadProviderError("LinkedIn HTTP response is invalid")
+            return ApiResult(status, decode_response(payload))
+    except HTTPError as error:
+        return http_error_result(error)
+    except (TimeoutError, URLError, OSError) as error:
+        raise LinkedInReadProviderError("LinkedIn read provider request failed") from error
+
+
+def _identity(
+    api: Callable[[str, dict[str, str]], ApiResult], expected_id: str
+) -> dict[str, Any]:
+    result = api("memberAuthorizations", {"q": "memberAndApplication"})
+    if result.status != 200:
+        return terminal_payload(result)
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": identity_value(result.payload, expected_id),
+    }
+
+
+def _page_request(request: dict[str, Any]) -> tuple[str, str, str, int, int]:
+    exact_keys(
+        request,
+        {"action", "stream", "account_id", "domain", "start", "limit"},
+    )
+    stream = request.get("stream")
+    if not isinstance(stream, str) or stream not in STREAMS:
+        raise LinkedInReadProviderError("LinkedIn read stream is unsupported")
+    domain = request.get("domain")
+    if domain != STREAMS[stream].snapshot_domain:
+        raise LinkedInReadProviderError("LinkedIn snapshot domain is unsupported")
+    start = request.get("start")
+    limit = request.get("limit")
+    if isinstance(start, bool) or not isinstance(start, int) or not 0 <= start <= 1_000_000_000:
+        raise LinkedInReadProviderError("LinkedIn read start is invalid")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 50:
+        raise LinkedInReadProviderError("LinkedIn read limit must be between 1 and 50")
+    return (
+        stream,
+        stable_member_id(request.get("account_id"), "account ID"),
+        domain,
+        start,
+        limit,
+    )
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode("utf-8")) > MAX_RESPONSE_BYTES:
+        raise LinkedInReadProviderError("LinkedIn read response exceeds the safety limit")
+    print(encoded)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        raw_request = _request()
+        action = raw_request.get("action")
+        if action not in ("identity", "page"):
+            raise LinkedInReadProviderError("LinkedIn read action is unsupported")
+        token = _access_token(args.profile)
+        opener = _http_exports()
+        api = lambda endpoint, params: _api(token, opener, endpoint, params)
+        if action == "identity":
+            exact_keys(raw_request, {"action", "account_id"})
+            expected_id = stable_member_id(raw_request.get("account_id"), "account ID")
+            payload = _identity(api, expected_id)
+        else:
+            _stream, account_id, domain, start, limit = _page_request(raw_request)
+            identity = _identity(api, account_id)
+            if identity.get("status") != 200:
+                payload = identity
+            else:
+                data = identity.get("data")
+                if not isinstance(data, dict) or data.get("id") != account_id:
+                    raise LinkedInReadProviderError(
+                        "selected LinkedIn member does not match the configured connection"
+                    )
+                result = api(
+                    "memberSnapshotData",
+                    {
+                        "q": "criteria",
+                        "domain": domain,
+                        "start": str(start),
+                        "count": str(limit),
+                    },
+                )
+                payload = snapshot_page(result, domain, start, limit)
+        _emit(payload)
+        return 0
+    except LinkedInReadProviderError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - intentionally redact provider internals
+        print("ERROR: LinkedIn read provider request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_linkedin_reader.py
+++ b/.agents/scripts/_knowledge_social_linkedin_reader.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and fixture readers for LinkedIn Member Snapshot data."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_linkedin import (
+    LinkedInAdapterError,
+    LinkedInProviderUnavailableError,
+    PageRequest,
+    member_id,
+)
+from _knowledge_social_oauth_reader import (
+    GuardedOAuthPolicy,
+    GuardedOAuthReader,
+)
+from knowledge_social_import import reject_credentials
+
+READ_TIMEOUT_SECONDS = 120
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+SAFE_PROVIDER_FAILURES = (
+    "Python urllib HTTP exports are unavailable",
+    "LinkedIn OAuth profile access token is missing",
+    "LinkedIn OAuth profile name is invalid",
+    "selected LinkedIn member does not match the configured connection",
+)
+
+
+class LinkedInReader(Protocol):
+    """Minimal GET-only provider surface used by collection."""
+
+    def identity(self, expected_id: str) -> dict[str, Any]: ...
+
+    def page(self, request: PageRequest) -> dict[str, Any]: ...
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    if len(output.encode("utf-8")) > MAX_RESPONSE_BYTES:
+        raise LinkedInAdapterError("LinkedIn read response exceeds the safety limit")
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise LinkedInAdapterError(
+            "LinkedIn read provider returned no valid JSON"
+        ) from error
+    if not isinstance(payload, dict):
+        raise LinkedInAdapterError("LinkedIn read response root must be an object")
+    return payload
+
+
+def _provider_failure(stderr: str) -> LinkedInProviderUnavailableError:
+    for message in SAFE_PROVIDER_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return LinkedInProviderUnavailableError(message)
+    return LinkedInProviderUnavailableError("LinkedIn read provider is unavailable")
+
+
+LINKEDIN_OAUTH_POLICY = GuardedOAuthPolicy(
+    "LinkedIn",
+    "LINKEDIN",
+    "LINKEDIN_READ_LOG",
+    READ_TIMEOUT_SECONDS,
+    _decode_output,
+    _provider_failure,
+    LinkedInProviderUnavailableError,
+)
+
+
+class GuardedLinkedInOAuth(GuardedOAuthReader):
+    """Execute only identity and allowlisted snapshot GETs in a bounded child."""
+
+    def __init__(self, helper: Path, profile: str) -> None:
+        super().__init__(helper, profile, LINKEDIN_OAUTH_POLICY)
+
+
+def _fixture_page(entry: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    expectation = entry.get("expect_request", {})
+    if not isinstance(expectation, dict):
+        raise LinkedInAdapterError(
+            "LinkedIn fixture request expectation must be an object"
+        )
+    actual = request.payload()
+    if any(actual.get(key) != value for key, value in expectation.items()):
+        raise LinkedInAdapterError(
+            "LinkedIn request did not resume at the expected checkpoint"
+        )
+    response = entry.get("response", entry)
+    if not isinstance(response, dict):
+        raise LinkedInAdapterError("LinkedIn fixture page response must be an object")
+    return response
+
+
+class FixtureLinkedIn:
+    """Deterministic OAuth substitute for pagination and failure fixtures."""
+
+    def __init__(self, path: Path) -> None:
+        self.fixture = FixtureSequence(path, "LinkedIn", LinkedInAdapterError)
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        del expected_id
+        return self.fixture.identity()
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        return _fixture_page(self.fixture.next_page(), request)
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, str]:
+    """Validate token identity without allowing credential-shaped fields through."""
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise LinkedInAdapterError("LinkedIn account verification returned no member")
+    remote_id = member_id(data.get("id"), "account ID")
+    if remote_id != expected_id:
+        raise LinkedInAdapterError(
+            "selected LinkedIn member does not match the configured connection"
+        )
+    return {"id": remote_id}

--- a/.agents/scripts/_knowledge_social_oauth_collector.py
+++ b/.agents/scripts/_knowledge_social_oauth_collector.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Shared execution loop for identity-bound OAuth social collectors."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import subprocess
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+from _knowledge_social_collect import (
+    CollectionContext,
+    CollectionProgress,
+    ContextRequest,
+    CursorState,
+    PageCheckpoint,
+    SuccessfulPage,
+    TerminalDecision,
+    collection_result,
+    terminal_decision_for_status,
+)
+from _knowledge_social_collect_cli import (
+    CollectorCliPolicy,
+    parse_collector_args,
+    run_collector,
+)
+from _knowledge_social_collect_persist import (
+    persist_page,
+    record_bounded_stop,
+    record_terminal_result,
+)
+from _knowledge_social_collect_state import load_context
+from _knowledge_social_lease import (
+    RunLease,
+    RunLeaseRequest,
+    RunReceiptUpdate,
+    SocialLeaseLostError,
+    acquire_run_lease,
+    fail_active_run,
+    finish_active_run,
+    release_run_lease,
+    renew_run_lease,
+)
+from knowledge_social_import import reject_credentials
+from knowledge_social_store import validate_opaque
+
+IDENTITY_COST_UNITS = 1
+
+
+class EvidenceRequest(Protocol):
+    """Minimum provider request contract needed for immutable evidence."""
+
+    def evidence_key(self) -> str: ...
+
+
+class OAuthReader(Protocol):
+    """Identity and page reads exposed by a guarded provider adapter."""
+
+    def identity(self, expected_id: str) -> dict[str, Any]: ...
+
+    def page(self, request: Any) -> dict[str, Any]: ...
+
+
+class OAuthProviderModule(Protocol):
+    """Provider policy surface consumed by the shared collector."""
+
+    PROVIDER: str
+    STREAMS: dict[str, Any]
+    ADAPTER_ERROR: type[Exception]
+    PROVIDER_UNAVAILABLE_ERROR: type[Exception]
+
+    def page_request(
+        self, stream: str, account: dict[str, Any], state: CursorState, limit: int
+    ) -> EvidenceRequest: ...
+
+    def page_checkpoint(
+        self, payload: dict[str, Any], state: CursorState, request: Any
+    ) -> tuple[PageCheckpoint, bool]: ...
+
+    def response_status(self, payload: dict[str, Any]) -> int: ...
+
+
+@dataclass(frozen=True)
+class OAuthCollectorPolicy:
+    """Provider-specific callbacks consumed by the shared OAuth loop."""
+
+    display_name: str
+    provider_module: OAuthProviderModule
+    helper: Path
+    fixture_reader: Callable[[Path], OAuthReader]
+    live_reader: Callable[[Path, str], OAuthReader]
+    page_context: Callable[..., Any]
+    normalize_page: Callable[[dict[str, Any], Any], dict[str, Any]]
+    verified_identity: Callable[[dict[str, Any], str], dict[str, Any]]
+    budget_unit: str
+    default_budget: int = 11
+    min_budget: int = 3
+    max_page_size: int = 50
+
+
+@dataclass
+class OAuthCollector:
+    """Run one provider policy under shared lease and persistence rules."""
+
+    policy: OAuthCollectorPolicy
+    args: argparse.Namespace
+
+    def _runner(self) -> OAuthReader:
+        if self.args.fixture and os.environ.get("AIDEVOPS_TEST_MODE") != "1":
+            raise self.policy.provider_module.ADAPTER_ERROR(
+                f"{self.policy.display_name} fixtures are disabled outside the test harness"
+            )
+        if self.args.fixture:
+            return self.policy.fixture_reader(self.args.fixture)
+        return self.policy.live_reader(self.policy.helper, self.args.profile)
+
+    def _decision(self, payload: dict[str, Any]) -> TerminalDecision | None:
+        status = self.policy.provider_module.response_status(payload)
+        return terminal_decision_for_status(status)
+
+    def _page_context(self, context: CollectionContext) -> Any:
+        return self.policy.page_context(
+            context.connection_id,
+            context.account,
+            context.stream,
+            context.config.enabled_streams,
+            context.config.policy,
+        )
+
+    def _persist_success(
+        self,
+        context: CollectionContext,
+        payload: dict[str, Any],
+        request: EvidenceRequest,
+    ) -> tuple[CollectionContext, int, bool]:
+        checkpoint, complete = self.policy.provider_module.page_checkpoint(
+            payload, context.state, request
+        )
+        archive = self.policy.normalize_page(payload, self._page_context(context))
+        page = SuccessfulPage(
+            payload,
+            request.evidence_key(),
+            archive,
+            checkpoint,
+            complete,
+            context.spec.cost_units,
+            retention_limit=context.spec.retention_limit,
+            unavailable_reason=context.spec.unavailable_reason,
+            coverage_status=context.spec.coverage_status,
+        )
+        resources = persist_page(context, page)
+        state = CursorState(checkpoint.next_cursor, checkpoint.watermark, complete)
+        return replace(context, state=state), resources, complete
+
+    def _collect_pages(
+        self, runner: OAuthReader, initial: CollectionContext
+    ) -> dict[str, Any]:
+        context = initial
+        progress = CollectionProgress(budget_units=IDENTITY_COST_UNITS)
+        while progress.budget_units + context.spec.cost_units <= self.args.budget:
+            if context.lease is None:
+                raise self.policy.provider_module.ADAPTER_ERROR(
+                    f"{self.policy.display_name} collection requires a collector lease"
+                )
+            context = replace(
+                context,
+                lease=renew_run_lease(
+                    context.root, context.lease, self.args.lease_seconds
+                ),
+            )
+            request = self.policy.provider_module.page_request(
+                context.stream,
+                context.account,
+                context.state,
+                self.args.page_size,
+            )
+            payload = runner.page(request)
+            reject_credentials(payload)
+            decision = self._decision(payload)
+            if decision:
+                return record_terminal_result(
+                    context, payload, request.evidence_key(), decision, progress
+                )
+            context, resources, complete = self._persist_success(
+                context, payload, request
+            )
+            progress = progress.advance(resources, context.spec.cost_units)
+            if complete:
+                return collection_result(
+                    "complete", progress, run_id=context.lease.run_id
+                )
+        record_bounded_stop(context, "paused", "budget")
+        return collection_result(
+            "budget_exhausted",
+            progress,
+            run_id=context.lease.run_id if context.lease else None,
+        )
+
+    def _failure_class(self, error: Exception) -> str:
+        if isinstance(error, self.policy.provider_module.PROVIDER_UNAVAILABLE_ERROR):
+            return "provider"
+        if isinstance(error, self.policy.provider_module.ADAPTER_ERROR):
+            return "validation"
+        if isinstance(error, sqlite3.Error):
+            return "storage"
+        if isinstance(error, subprocess.SubprocessError):
+            return "provider"
+        return "runtime"
+
+    def _identity_terminal_result(
+        self, root: Path, lease: RunLease, payload: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        reject_credentials(payload)
+        decision = self._decision(payload)
+        if decision is None:
+            return None
+        retry_value = payload.get("retry_after")
+        if retry_value is not None:
+            if isinstance(retry_value, bool) or not isinstance(
+                retry_value, (int, str)
+            ):
+                raise self.policy.provider_module.ADAPTER_ERROR(
+                    f"{self.policy.display_name} retry_after must be text or an integer"
+                )
+        retry_after = str(retry_value) if retry_value is not None else None
+        finish_active_run(
+            root,
+            lease,
+            RunReceiptUpdate(
+                decision.run_status,
+                failure_class=decision.failure_class,
+                retry_after=retry_after,
+            ),
+        )
+        return collection_result(
+            decision.output_status,
+            CollectionProgress(budget_units=IDENTITY_COST_UNITS),
+            failure_class=decision.failure_class,
+            retry_after=retry_after,
+            run_id=lease.run_id,
+        )
+
+    def collect(
+        self,
+        args: argparse.Namespace,
+        root: Path,
+        collector_id: str,
+    ) -> dict[str, Any]:
+        del args
+        connection_id = validate_opaque(self.args.connection_id, "connection_id")
+        account_id = validate_opaque(self.args.account_id, "account_id")
+        lease = acquire_run_lease(
+            root,
+            RunLeaseRequest(
+                connection_id,
+                self.args.stream,
+                collector_id,
+                "sync",
+                self.args.lease_seconds,
+            ),
+        )
+        try:
+            runner = self._runner()
+            identity = runner.identity(account_id)
+            terminal = self._identity_terminal_result(root, lease, identity)
+            if terminal is not None:
+                return terminal
+            account = self.policy.verified_identity(identity, account_id)
+            context = replace(
+                load_context(
+                    root,
+                    ContextRequest(
+                        self.policy.provider_module.PROVIDER,
+                        connection_id,
+                        account,
+                        self.args.stream,
+                        "none",
+                    ),
+                    self.policy.provider_module.STREAMS,
+                ),
+                lease=lease,
+            )
+            return self._collect_pages(runner, context)
+        except Exception as error:
+            try:
+                fail_active_run(root, lease, self._failure_class(error))
+            except SocialLeaseLostError:
+                pass
+            raise
+        finally:
+            release_run_lease(root, lease)
+
+
+def run_oauth_collector(policy: OAuthCollectorPolicy, description: str) -> int:
+    """Parse one provider CLI and execute its shared OAuth collector."""
+    cli_policy = CollectorCliPolicy(
+        description=description,
+        streams=tuple(policy.provider_module.STREAMS),
+        default_budget=policy.default_budget,
+        min_budget=policy.min_budget,
+        max_page_size=policy.max_page_size,
+        budget_unit=policy.budget_unit,
+    )
+    args = parse_collector_args(cli_policy)
+    collector = OAuthCollector(policy, args)
+    return run_collector(args, collector.collect)

--- a/.agents/scripts/_knowledge_social_oauth_reader.py
+++ b/.agents/scripts/_knowledge_social_oauth_reader.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Shared guarded child-process adapter for OAuth social readers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+from _knowledge_social_collect_cli import (
+    GuardedReaderProcess,
+    guarded_reader_environment,
+)
+
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+
+
+class PagePayload(Protocol):
+    """Minimum request contract consumed by a guarded OAuth reader."""
+
+    def payload(self) -> dict[str, Any]: ...
+
+
+@dataclass(frozen=True)
+class GuardedOAuthPolicy:
+    """Provider-specific child-process boundaries for one OAuth reader."""
+
+    display_name: str
+    environment_prefix: str
+    test_log_key: str
+    timeout_seconds: int
+    decode_output: Callable[[str], dict[str, Any]]
+    provider_failure: Callable[[str], Exception]
+    unavailable_error: type[Exception]
+
+
+class GuardedOAuthReader:
+    """Execute only identity and allowlisted page reads in a bounded child."""
+
+    def __init__(self, helper: Path, profile: str, policy: GuardedOAuthPolicy) -> None:
+        if PROFILE_NAME.fullmatch(profile) is None:
+            raise policy.unavailable_error(
+                f"{policy.display_name} OAuth profile name is invalid"
+            )
+        if helper.is_symlink() or not helper.is_file():
+            raise policy.unavailable_error(
+                f"{policy.display_name} read provider is unavailable"
+            )
+        self.profile = profile
+        self.policy = policy
+        self.process = GuardedReaderProcess(
+            helper=helper,
+            profile=profile,
+            environment=self._environment,
+            timeout_seconds=policy.timeout_seconds,
+            decode_output=policy.decode_output,
+            provider_failure=policy.provider_failure,
+            unavailable_error=policy.unavailable_error,
+            provider_name=policy.display_name,
+        )
+
+    def _environment(self) -> dict[str, str]:
+        token_name = (
+            f"{self.policy.environment_prefix}_{self.profile.upper()}_ACCESS_TOKEN"
+        )
+        return guarded_reader_environment(token_name, (self.policy.test_log_key,))
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        return self.process.run({"action": "identity", "account_id": expected_id})
+
+    def page(self, request: PagePayload) -> dict[str, Any]:
+        return self.process.run(request.payload())

--- a/.agents/scripts/_knowledge_social_youtube.py
+++ b/.agents/scripts/_knowledge_social_youtube.py
@@ -29,6 +29,10 @@ class YouTubeProviderUnavailableError(YouTubeAdapterError):
     """Raised when the bounded OAuth child cannot complete a read."""
 
 
+ADAPTER_ERROR = YouTubeAdapterError
+PROVIDER_UNAVAILABLE_ERROR = YouTubeProviderUnavailableError
+
+
 @dataclass(frozen=True)
 class StreamSpec:
     """Static collection and coverage policy for one YouTube stream."""

--- a/.agents/scripts/_knowledge_social_youtube_reader.py
+++ b/.agents/scripts/_knowledge_social_youtube_reader.py
@@ -6,13 +6,14 @@
 from __future__ import annotations
 
 import json
-import os
-import re
 from pathlib import Path
 from typing import Any, Protocol
 
-from _knowledge_social_collect_cli import GuardedReaderProcess
 from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_oauth_reader import (
+    GuardedOAuthPolicy,
+    GuardedOAuthReader,
+)
 from _knowledge_social_youtube import (
     PageRequest,
     YouTubeAdapterError,
@@ -23,7 +24,6 @@ from knowledge_social_import import reject_credentials
 
 READ_TIMEOUT_SECONDS = 120
 MAX_RESPONSE_BYTES = 8 * 1024 * 1024
-PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
 SAFE_PROVIDER_FAILURES = (
     "Python urllib HTTP exports are unavailable",
     "YouTube OAuth profile access token is missing",
@@ -59,63 +59,22 @@ def _provider_failure(stderr: str) -> YouTubeProviderUnavailableError:
     return YouTubeProviderUnavailableError("YouTube read provider is unavailable")
 
 
-class GuardedYouTubeOAuth:
+YOUTUBE_OAUTH_POLICY = GuardedOAuthPolicy(
+    "YouTube",
+    "YOUTUBE",
+    "YOUTUBE_READ_LOG",
+    READ_TIMEOUT_SECONDS,
+    _decode_output,
+    _provider_failure,
+    YouTubeProviderUnavailableError,
+)
+
+
+class GuardedYouTubeOAuth(GuardedOAuthReader):
     """Execute only identity and allowlisted page reads in a bounded child."""
 
     def __init__(self, helper: Path, profile: str) -> None:
-        if PROFILE_NAME.fullmatch(profile) is None:
-            raise YouTubeProviderUnavailableError("YouTube OAuth profile name is invalid")
-        if helper.is_symlink() or not helper.is_file():
-            raise YouTubeProviderUnavailableError("YouTube read provider is unavailable")
-        self.profile = profile
-        self.process = GuardedReaderProcess(
-            helper=helper,
-            profile=profile,
-            environment=self._environment,
-            timeout_seconds=READ_TIMEOUT_SECONDS,
-            decode_output=_decode_output,
-            provider_failure=_provider_failure,
-            unavailable_error=YouTubeProviderUnavailableError,
-            provider_name="YouTube",
-        )
-
-    def _environment(self) -> dict[str, str]:
-        token_name = f"YOUTUBE_{self.profile.upper()}_ACCESS_TOKEN"
-        inherited = {
-            "HOME",
-            "HTTPS_PROXY",
-            "HTTP_PROXY",
-            "LANG",
-            "LC_ALL",
-            "NO_PROXY",
-            "PATH",
-            "REQUESTS_CA_BUNDLE",
-            "SSL_CERT_FILE",
-            "TMPDIR",
-            "https_proxy",
-            "http_proxy",
-            "no_proxy",
-        }
-        environment = {
-            key: value
-            for key, value in os.environ.items()
-            if key in inherited or key == token_name
-        }
-        if os.environ.get("AIDEVOPS_TEST_MODE") == "1":
-            for key in (
-                "AIDEVOPS_TEST_MODE",
-                "PYTHONPATH",
-                "YOUTUBE_READ_LOG",
-            ):
-                if key in os.environ:
-                    environment[key] = os.environ[key]
-        return environment
-
-    def identity(self, expected_id: str) -> dict[str, Any]:
-        return self.process.run({"action": "identity", "account_id": expected_id})
-
-    def page(self, request: PageRequest) -> dict[str, Any]:
-        return self.process.run(request.payload())
+        super().__init__(helper, profile, YOUTUBE_OAUTH_POLICY)
 
 
 def _fixture_page(entry: dict[str, Any], request: PageRequest) -> dict[str, Any]:

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -10,6 +10,7 @@ PYTHON_HELPER="${SCRIPT_DIR}/knowledge_social_import.py"
 X_HELPER="${SCRIPT_DIR}/knowledge_social_x.py"
 REDDIT_HELPER="${SCRIPT_DIR}/knowledge_social_reddit.py"
 YOUTUBE_HELPER="${SCRIPT_DIR}/knowledge_social_youtube.py"
+LINKEDIN_HELPER="${SCRIPT_DIR}/knowledge_social_linkedin.py"
 QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
 SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
 SHARE_HELPER="${SCRIPT_DIR}/knowledge_social_share.py"
@@ -78,6 +79,13 @@ YouTube synchronization:
   --budget is a hard 3-1000 unit limit and --page-size is 1-50 items.
   Collection uses youtube.readonly user OAuth and never the service-account helper.
 
+LinkedIn synchronization:
+  sync-linkedin verifies the selected member authorization, then reads one
+  documented Member Snapshot domain. Access is limited to eligible EEA or Swiss
+  members and a provisioned Member Data Portability product. The initial identity
+  request costs one unit; every page reserves two units for identity rebinding and
+  one GET-only snapshot read. --budget is 3-1000 and --page-size is 1-50.
+
 EOF
 	return 0
 }
@@ -103,6 +111,10 @@ Usage:
     [--lease-seconds SECONDS]
   knowledge-social-helper.sh sync-youtube [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id CHANNEL_ID --stream STREAM --profile PROFILE \
+    [--budget UNITS] [--page-size 1-50] [--collector-id ID] \
+    [--lease-seconds SECONDS]
+  knowledge-social-helper.sh sync-linkedin [--base PATH] [--alias ALIAS] \
+    --connection-id ID --account-id MEMBER_ID --stream STREAM --profile PROFILE \
     [--budget UNITS] [--page-size 1-50] [--collector-id ID] \
     [--lease-seconds SECONDS]
   knowledge-social-helper.sh sync-due [--base PATH] [--alias ALIAS] \
@@ -270,6 +282,14 @@ main() {
 			return 1
 		fi
 		python3 "$YOUTUBE_HELPER" "$@" || return 1
+		;;
+	sync-linkedin)
+		require_runtime || return 1
+		if [[ ! -r "$LINKEDIN_HELPER" ]]; then
+			printf 'ERROR: LinkedIn social adapter missing: %s\n' "$LINKEDIN_HELPER" >&2
+			return 1
+		fi
+		python3 "$LINKEDIN_HELPER" "$@" || return 1
 		;;
 	query | annotate)
 		require_runtime || return 1

--- a/.agents/scripts/knowledge_social_linkedin.py
+++ b/.agents/scripts/knowledge_social_linkedin.py
@@ -1,34 +1,34 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-"""Collect one read-only OAuth YouTube account stream into a social corpus."""
+"""Collect one LinkedIn Member Snapshot domain into a social corpus."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
-import _knowledge_social_youtube as youtube
+import _knowledge_social_linkedin as linkedin
+from _knowledge_social_linkedin_normalize import PageContext, normalize_page
+from _knowledge_social_linkedin_reader import (
+    FixtureLinkedIn,
+    GuardedLinkedInOAuth,
+    verified_identity,
+)
 from _knowledge_social_oauth_collector import (
     OAuthCollectorPolicy,
     run_oauth_collector,
 )
-from _knowledge_social_youtube_normalize import PageContext, normalize_page
-from _knowledge_social_youtube_reader import (
-    FixtureYouTube,
-    GuardedYouTubeOAuth,
-    verified_identity,
-)
 
 COLLECTOR_POLICY = OAuthCollectorPolicy(
-    display_name="YouTube",
-    provider_module=youtube,
-    helper=Path(__file__).with_name("_knowledge_social_youtube_provider.py"),
-    fixture_reader=FixtureYouTube,
-    live_reader=GuardedYouTubeOAuth,
+    display_name="LinkedIn",
+    provider_module=linkedin,
+    helper=Path(__file__).with_name("_knowledge_social_linkedin_provider.py"),
+    fixture_reader=FixtureLinkedIn,
+    live_reader=GuardedLinkedInOAuth,
     page_context=PageContext,
     normalize_page=normalize_page,
     verified_identity=verified_identity,
-    budget_unit="quota",
+    budget_unit="request",
 )
 
 

--- a/.agents/tests/test-knowledge-social-linkedin.sh
+++ b/.agents/tests/test-knowledge-social-linkedin.sh
@@ -1,0 +1,606 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-linkedin.sh — LinkedIn Member Snapshot collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' \
+			"$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c \
+		'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_count() {
+	python3 - "$ROOT/sources/social/raw/linkedin" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+print(len(list(root.rglob("*.json.gz"))) if root.exists() else 0)
+PY
+	return 0
+}
+
+expect_sync_failure() {
+	local description="$1"
+	local fixture="$2"
+	local stream="$3"
+	if "$HELPER" sync-linkedin --base "$BASE" --alias personal:default \
+		--connection-id conn_linkedin --account-id member42 \
+		--stream "$stream" --profile fixture --fixture "$fixture" \
+		>/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+run_terminal_fixture() {
+	local name="$1"
+	local status="$2"
+	local expected_failure="$3"
+	local fixture="${TMP_DIR}/${name}.json"
+	python3 - "$fixture" "$status" <<'PY'
+import json
+import sys
+
+status = int(sys.argv[2])
+page = {"status": status, "observed_at": "2026-07-27T10:10:00Z"}
+if status == 429:
+    page["retry_after"] = 1785232800
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump({"identity": {"data": {"id": "member42"}}, "pages": [page]}, target)
+PY
+	local result=""
+	result=$("$HELPER" sync-linkedin --base "$BASE" --alias personal:default \
+		--connection-id conn_linkedin --account-id member42 \
+		--stream authored_posts --profile fixture --fixture "$fixture")
+	local expected_status="failed"
+	[[ "$status" == "429" ]] && expected_status="rate_limited"
+	assert_eq "LinkedIn ${status} response is terminal" \
+		"$(json_field "$result" status)" "$expected_status"
+	assert_eq "LinkedIn ${status} response is sanitized" \
+		"$(json_field "$result" failure_class)" "$expected_failure"
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'LinkedIn social collector tests\n'
+
+help_output=$("$HELPER" help)
+if [[ "$help_output" == *"eligible EEA or Swiss"* && "$help_output" == *"sync-linkedin"* ]]; then
+	assert_eq "LinkedIn help exposes the region-gated snapshot route" advertised advertised
+else
+	assert_eq "LinkedIn help exposes the region-gated snapshot route" missing advertised
+fi
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import ast
+import importlib.util
+import json
+import sys
+from email.message import Message
+from io import BytesIO
+from pathlib import Path
+from urllib.error import HTTPError
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+from _knowledge_social_linkedin import API_VERSION, STREAMS
+from _knowledge_social_linkedin_contract import ApiResult, snapshot_page
+from _knowledge_social_linkedin_provider import (
+    API_BASE, NO_DATA_MESSAGE, READ_ENDPOINTS, _api, _http_exports,
+)
+
+expected = {
+    "authored_posts": "MEMBER_SHARE_INFO",
+    "authored_articles": "ARTICLES",
+    "comments": "ALL_COMMENTS",
+    "reactions": "ALL_LIKES",
+    "saved_items": "ACTOR_SAVE_ITEM",
+    "messages": "INBOX",
+    "following": "MEMBER_FOLLOWING",
+    "connections": "CONNECTIONS",
+    "company_follows": "COMPANY_FOLLOWS",
+    "groups": "GROUPS",
+}
+assert {name: spec.snapshot_domain for name, spec in STREAMS.items()} == expected
+assert API_VERSION == "202312"
+assert API_BASE == "https://api.linkedin.com/rest"
+assert READ_ENDPOINTS == {"memberAuthorizations", "memberSnapshotData"}
+assert callable(_http_exports())
+
+sources = [
+    path.read_text(encoding="utf-8")
+    for path in sorted(scripts.glob("*knowledge_social_linkedin*.py"))
+]
+assert all("linkedin-automation" not in source for source in sources)
+trees = [ast.parse(source) for source in sources]
+imports = {
+    alias.name
+    for tree in trees
+    for node in ast.walk(tree)
+    if isinstance(node, (ast.Import, ast.ImportFrom))
+    for alias in (
+        node.names if isinstance(node, ast.Import) else [ast.alias(node.module or "")]
+    )
+}
+assert all("linkedin_automation" not in name for name in imports)
+request_calls = [
+    node
+    for tree in trees
+    for node in ast.walk(tree)
+    if isinstance(node, ast.Call)
+    and isinstance(node.func, ast.Name)
+    and node.func.id == "Request"
+]
+assert request_calls
+for node in request_calls:
+    methods = [
+        keyword.value.value
+        for keyword in node.keywords
+        if keyword.arg == "method" and isinstance(keyword.value, ast.Constant)
+    ]
+    assert methods == ["GET"]
+
+
+def no_data_opener(request, timeout):
+    assert request.get_method() == "GET"
+    assert timeout == 60
+    body = json.dumps({"message": NO_DATA_MESSAGE}).encode()
+    raise HTTPError(request.full_url, 404, "Not Found", Message(), BytesIO(body))
+
+
+result = _api(
+    "test-token",
+    no_data_opener,
+    "memberSnapshotData",
+    {"q": "criteria", "domain": "ARTICLES", "start": "1", "count": "10"},
+)
+assert result.no_data is True
+page = snapshot_page(result, "ARTICLES", 1, 10)
+assert page["status"] == 200 and page["meta"]["complete"] is True
+
+successful = ApiResult(200, {
+    "paging": {"start": 1, "count": 10, "links": [], "total": 1},
+    "elements": [{"snapshotDomain": "ARTICLES", "snapshotData": [{"id": "one"}]}],
+})
+partial = snapshot_page(successful, "ARTICLES", 1, 10)
+assert partial["meta"]["complete"] is False
+assert partial["meta"]["next_start"] == 2
+
+
+def unauthorized_no_data_opener(request, timeout):
+    assert request.get_method() == "GET"
+    assert timeout == 60
+    body = json.dumps({"message": NO_DATA_MESSAGE}).encode()
+    raise HTTPError(request.full_url, 401, "Unauthorized", Message(), BytesIO(body))
+
+
+unauthorized = _api(
+    "test-token",
+    unauthorized_no_data_opener,
+    "memberSnapshotData",
+    {"q": "criteria", "domain": "ARTICLES", "start": "1", "count": "10"},
+)
+assert unauthorized.no_data is False
+assert snapshot_page(unauthorized, "ARTICLES", 1, 10)["status"] == 401
+PY
+assert_eq "stream registry, GET-only transport, and status-bound no-data completion are guarded" \
+	verified verified
+
+cat >"$TMP_DIR/minimum-budget.json" <<'JSON'
+{"identity":{"data":{"id":"member42"}},"pages":[]}
+JSON
+for budget in 1 2; do
+	if "$HELPER" sync-linkedin --base "$BASE" --alias personal:default \
+		--connection-id "conn_budget_${budget}" --account-id member42 \
+		--stream authored_posts --profile fixture \
+		--fixture "$TMP_DIR/minimum-budget.json" --budget "$budget" \
+		>/dev/null 2>&1; then
+		assert_eq "LinkedIn budget ${budget} is rejected" accepted rejected
+	else
+		assert_eq "LinkedIn budget ${budget} is rejected" rejected rejected
+	fi
+done
+
+cat >"$TMP_DIR/posts-1.json" <<'JSON'
+{
+  "identity":{"data":{"id":"member42"}},
+  "pages":[{
+    "expect_request":{"domain":"MEMBER_SHARE_INFO","start":0,"limit":1},
+    "response":{"status":200,"observed_at":"2026-07-27T10:00:00Z",
+      "data":[{"Post Link":"private-post-reference-1","ShareCommentary":"bounded knowledge"}],
+      "meta":{"domain":"MEMBER_SHARE_INFO","next_start":1,"complete":false,"snapshot":true}}
+  }]
+}
+JSON
+first_result=$("$HELPER" sync-linkedin --base "$BASE" --alias personal:default \
+	--connection-id conn_linkedin --account-id member42 \
+	--stream authored_posts --profile fixture --budget 3 --page-size 1 \
+	--fixture "$TMP_DIR/posts-1.json")
+assert_eq "one LinkedIn page pauses at the hard request budget" \
+	"$(json_field "$first_result" status)" budget_exhausted
+assert_eq "identity and one guarded page reserve three units" \
+	"$(json_field "$first_result" budget_units)" 3
+assert_eq "partial LinkedIn snapshot advances only its stream cursor" \
+	"$(sql_value "SELECT backfill_complete FROM sync_cursors WHERE connection_id='conn_linkedin' AND stream='authored_posts'")" 0
+assert_eq "snapshot records use content-addressed stable identities" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='linkedin' AND object_type='post' AND remote_id LIKE 'li_snapshot_%'")" 1
+assert_eq "normalized rows retain provenance but not undocumented private fields" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='linkedin' AND provider_json LIKE '%linkedin_member_snapshot_api%' AND provider_json NOT LIKE '%bounded knowledge%'")" 1
+assert_eq "LinkedIn consent and deletion obligations are durable coverage" \
+	"$(sql_value "SELECT retention_limit || ':' || status FROM coverage_records WHERE connection_id='conn_linkedin' AND stream='authored_posts'")" \
+	"member_consent_and_delete_on_request_or_linked_account_closure:paused"
+assert_eq "newsletter subscriptions remain explicit unavailable evidence" \
+	"$(sql_value "SELECT status FROM coverage_records WHERE connection_id='conn_linkedin' AND stream='newsletter_subscriptions'")" unavailable
+
+cat >"$TMP_DIR/posts-2.json" <<'JSON'
+{
+  "identity":{"data":{"id":"member42"}},
+  "pages":[{
+    "expect_request":{"domain":"MEMBER_SHARE_INFO","start":1},
+    "response":{"status":200,"observed_at":"2026-07-27T10:01:00Z",
+      "data":[{"Post Link":"private-post-reference-2","ShareCommentary":"resumed evidence"}],
+      "meta":{"domain":"MEMBER_SHARE_INFO","next_start":null,"complete":true,"snapshot":true}}
+  }]
+}
+JSON
+second_result=$("$HELPER" sync-linkedin --base "$BASE" --alias personal:default \
+	--connection-id conn_linkedin --account-id member42 \
+	--stream authored_posts --profile fixture --page-size 1 \
+	--fixture "$TMP_DIR/posts-2.json")
+assert_eq "LinkedIn snapshot resumes from its independent page cursor" \
+	"$(json_field "$second_result" status)" complete
+assert_eq "snapshot exhaustion clears the cursor and marks backfill complete" \
+	"$(sql_value "SELECT coalesce(cursor,'done') || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_linkedin' AND stream='authored_posts'")" \
+	"done:1"
+
+post_batches=$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_linkedin' AND stream='authored_posts'")
+python3 - "$TMP_DIR/posts-1.json" "$TMP_DIR/posts-2.json" \
+	"$TMP_DIR/posts-replay.json" <<'PY'
+import json
+import sys
+
+first = json.load(open(sys.argv[1], encoding="utf-8"))
+second = json.load(open(sys.argv[2], encoding="utf-8"))
+with open(sys.argv[3], "w", encoding="utf-8") as target:
+    json.dump({"identity": first["identity"], "pages": first["pages"] + second["pages"]}, target)
+PY
+"$HELPER" sync-linkedin --base "$BASE" --alias personal:default \
+	--connection-id conn_linkedin --account-id member42 \
+	--stream authored_posts --profile fixture --budget 5 --page-size 1 \
+	--fixture "$TMP_DIR/posts-replay.json" >/dev/null
+assert_eq "exact LinkedIn snapshot replay is content-addressed and idempotent" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_linkedin' AND stream='authored_posts'")" \
+	"$post_batches"
+assert_eq "snapshot replay preserves exactly two normalized post records" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='linkedin' AND object_type='post'")" 2
+
+cat >"$TMP_DIR/posts-other-account.json" <<'JSON'
+{
+  "identity":{"data":{"id":"member43"}},
+  "pages":[{"status":200,"observed_at":"2026-07-27T10:01:30Z",
+    "data":[{"Post Link":"private-post-reference-1","ShareCommentary":"bounded knowledge"}],
+    "meta":{"domain":"MEMBER_SHARE_INFO","next_start":null,"complete":true,"snapshot":true}}]
+}
+JSON
+"$HELPER" sync-linkedin --base "$BASE" --alias personal:default \
+	--connection-id conn_linkedin_other --account-id member43 \
+	--stream authored_posts --profile fixture \
+	--fixture "$TMP_DIR/posts-other-account.json" >/dev/null
+assert_eq "content-addressed LinkedIn records remain scoped to the verified account" \
+	"$(sql_value "SELECT count(DISTINCT remote_id) || ':' || count(DISTINCT account_remote_id) FROM objects WHERE provider='linkedin' AND object_type='post'")" \
+	"3:2"
+
+cat >"$TMP_DIR/messages.json" <<'JSON'
+{
+  "identity":{"data":{"id":"member42"}},
+  "pages":[{"status":200,"observed_at":"2026-07-27T10:02:00Z",
+    "data":[{"Conversation ID":"conversation42","Content":"private message"}],
+    "meta":{"domain":"INBOX","next_start":null,"complete":true,"snapshot":true}}]
+}
+JSON
+"$HELPER" sync-linkedin --base "$BASE" --alias personal:default \
+	--connection-id conn_linkedin --account-id member42 \
+	--stream messages --profile fixture --fixture "$TMP_DIR/messages.json" >/dev/null
+assert_eq "message snapshots keep an independent complete checkpoint" \
+	"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_linkedin' AND stream IN ('authored_posts','messages') AND backfill_complete=1")" 2
+
+cursor_before=$(sql_value "SELECT backfill_complete FROM sync_cursors WHERE connection_id='conn_linkedin' AND stream='authored_posts'")
+run_terminal_fixture quota 429 rate_limit
+run_terminal_fixture unauthorized 401 authorization
+run_terminal_fixture forbidden 403 authorization
+run_terminal_fixture missing 404 unavailable
+run_terminal_fixture provider 500 provider
+assert_eq "terminal LinkedIn failures preserve the prior checkpoint" \
+	"$(sql_value "SELECT backfill_complete FROM sync_cursors WHERE connection_id='conn_linkedin' AND stream='authored_posts'")" \
+	"$cursor_before"
+
+batch_count=$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='linkedin'")
+cat >"$TMP_DIR/malformed.json" <<'JSON'
+{"identity":{"data":{"id":"member42"}},"pages":[{"status":200,"observed_at":"2026-07-27T10:03:00Z","data":{},"meta":{"domain":"ARTICLES","next_start":null,"complete":true,"snapshot":true}}]}
+JSON
+expect_sync_failure "malformed LinkedIn snapshots fail before persistence" \
+	"$TMP_DIR/malformed.json" authored_articles
+assert_eq "malformed LinkedIn data advances no batch" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='linkedin'")" "$batch_count"
+
+cat >"$TMP_DIR/credential.json" <<'JSON'
+{"identity":{"data":{"id":"member42"}},"pages":[{"status":200,"observed_at":"2026-07-27T10:04:00Z","data":[{"access_token":"must-not-persist"}],"meta":{"domain":"ARTICLES","next_start":null,"complete":true,"snapshot":true}}]}
+JSON
+expect_sync_failure "credential-shaped LinkedIn snapshots are rejected" \
+	"$TMP_DIR/credential.json" authored_articles
+assert_eq "credential rejection creates no raw evidence" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='linkedin'")" "$batch_count"
+
+cat >"$TMP_DIR/wrong-account.json" <<'JSON'
+{"identity":{"data":{"id":"other_member"}},"pages":[]}
+JSON
+raw_before_mismatch=$(raw_count)
+expect_sync_failure "selected LinkedIn member mismatch fails before collection" \
+	"$TMP_DIR/wrong-account.json" authored_articles
+assert_eq "identity mismatch creates no LinkedIn raw evidence" \
+	"$(raw_count)" "$raw_before_mismatch"
+
+python3 - "$ROOT" "$SCRIPT_DIR/../scripts" <<'PY'
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[2])
+from _knowledge_social_collect import (
+    CollectionContext, ConnectionConfig, CursorState, PageCheckpoint, SuccessfulPage,
+)
+from _knowledge_social_collect_persist import persist_page
+from _knowledge_social_lease import (
+    RunLeaseRequest, SocialLeaseLostError, acquire_run_lease, release_run_lease,
+)
+from _knowledge_social_linkedin import STREAMS
+
+root = Path(sys.argv[1])
+old = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_linkedin_fence", "connections", "old_runner", "sync", 1),
+    now_epoch=9000,
+)
+new = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_linkedin_fence", "connections", "new_runner", "sync", 10),
+    now_epoch=9001,
+)
+context = CollectionContext(
+    root,
+    "conn_linkedin_fence",
+    {"id": "member42"},
+    "connections",
+    "none",
+    ConnectionConfig(("connections",), {"media_hydration": "none"}),
+    CursorState(None, None, False),
+    STREAMS["connections"],
+    old,
+    "linkedin",
+)
+archive = {
+    "provider": "linkedin",
+    "connection_id": "conn_linkedin_fence",
+    "remote_account_id": "member42",
+    "exported_at": "2026-07-27T10:05:00Z",
+    "enabled_streams": ["connections"],
+    "policy": {"media_hydration": "none"},
+    "accounts": [], "objects": [], "activities": [], "media": [], "coverage": [],
+}
+page = SuccessfulPage(
+    {"status": 200, "observed_at": archive["exported_at"], "data": [], "meta": {}},
+    '{"stream":"connections"}',
+    archive,
+    PageCheckpoint(None, None),
+    True,
+    2,
+)
+os.environ["AIDEVOPS_SOCIAL_NOW_EPOCH"] = "9001"
+try:
+    persist_page(context, page)
+except SocialLeaseLostError:
+    pass
+else:
+    raise SystemExit("stale LinkedIn collector advanced persistence")
+with sqlite3.connect(root / "index" / "social.db") as database:
+    cursor = database.execute(
+        "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_linkedin_fence'"
+    ).fetchone()[0]
+assert cursor == 0
+release_run_lease(root, new)
+PY
+assert_eq "stale LinkedIn lease cannot commit evidence or a cursor" verified verified
+
+mkdir -p "$TMP_DIR/fake-linkedin"
+cat >"$TMP_DIR/fake-linkedin/sitecustomize.py" <<'PY'
+import json
+import os
+from email.message import Message
+from io import BytesIO
+from pathlib import Path
+from urllib.error import HTTPError
+from urllib.parse import parse_qs, urlparse
+import urllib.request
+
+
+class Response:
+    status = 200
+
+    def __init__(self, payload):
+        self.payload = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, _limit):
+        return self.payload
+
+
+def fake_urlopen(request, timeout):
+    parsed = urlparse(request.full_url)
+    endpoint = parsed.path.rsplit("/", 1)[-1]
+    query = parse_qs(parsed.query)
+    log_path = Path(os.environ["LINKEDIN_READ_LOG"])
+    headers = {key.lower(): value for key, value in request.header_items()}
+    row = {
+        "endpoint": endpoint,
+        "method": request.get_method(),
+        "count": query.get("count", [None])[0],
+        "start": query.get("start", [None])[0],
+        "bearer": headers.get("authorization", "").startswith("Bearer "),
+        "version": headers.get("linkedin-version"),
+        "unrelated_secret": "UNRELATED_PROVIDER_TOKEN" in os.environ,
+        "timeout": timeout,
+    }
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row, sort_keys=True) + "\n")
+    if endpoint == "memberAuthorizations":
+        calls = sum(
+            json.loads(line)["endpoint"] == endpoint
+            for line in log_path.read_text(encoding="utf-8").splitlines()
+        )
+        rebound = log_path.name == "linkedin-rebind.log" and calls > 1
+        member = "other_member" if rebound else "live_member42"
+        return Response({"elements": [{
+            "memberComplianceAuthorizationKey": {
+                "developerApplication": "urn:li:developerApplication:fixture",
+                "member": f"urn:li:person:{member}",
+            },
+            "memberComplianceScopes": ["DMA"],
+        }]})
+    if endpoint == "memberSnapshotData":
+        domain = query["domain"][0]
+        if query.get("start", ["0"])[0] != "0":
+            body = json.dumps({"message": "No data found for this memberId"}).encode()
+            raise HTTPError(
+                request.full_url, 404, "Not Found", Message(), BytesIO(body)
+            )
+        return Response({
+            "paging": {"start": 0, "count": int(query["count"][0]), "links": []},
+            "elements": [{
+                "snapshotDomain": domain,
+                "snapshotData": [{"Synthetic Label": "guarded live evidence"}],
+            }],
+        })
+    raise RuntimeError("unexpected endpoint")
+
+
+urllib.request.urlopen = fake_urlopen
+PY
+: >"$TMP_DIR/linkedin-read.log"
+chmod 0600 "$TMP_DIR/linkedin-read.log"
+live_result=$(
+	PYTHONPATH="$TMP_DIR/fake-linkedin" LINKEDIN_READ_LOG="$TMP_DIR/linkedin-read.log" \
+		LINKEDIN_FIXTURE_ACCESS_TOKEN=fixture-token UNRELATED_PROVIDER_TOKEN=unrelated \
+		"$HELPER" sync-linkedin --base "$BASE" --alias personal:default \
+		--connection-id conn_linkedin_live --account-id live_member42 \
+		--stream authored_articles --profile fixture --budget 5 --page-size 7
+)
+assert_eq "guarded live LinkedIn boundary persists one snapshot page" \
+	"$(json_field "$live_result" status)" complete
+live_guard=$(
+	python3 - "$TMP_DIR/linkedin-read.log" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+rows = [json.loads(line) for line in Path(sys.argv[1]).read_text().splitlines()]
+identities = [row for row in rows if row["endpoint"] == "memberAuthorizations"]
+pages = [row for row in rows if row["endpoint"] == "memberSnapshotData"]
+safe = (
+    len(identities) == 3
+    and len(pages) == 2
+    and pages[0]["count"] == "7"
+    and [row["start"] for row in pages] == ["0", "1"]
+    and all(row["method"] == "GET" and row["bearer"] for row in rows)
+    and all(row["version"] == "202312" for row in rows)
+    and all(not row["unrelated_secret"] for row in rows)
+)
+print("bounded-read-only" if safe else "unsafe")
+PY
+)
+assert_eq "live boundary revalidates identity and passes only selected credentials" \
+	"$live_guard" bounded-read-only
+
+: >"$TMP_DIR/linkedin-rebind.log"
+chmod 0600 "$TMP_DIR/linkedin-rebind.log"
+raw_before_rebind=$(raw_count)
+if PYTHONPATH="$TMP_DIR/fake-linkedin" LINKEDIN_READ_LOG="$TMP_DIR/linkedin-rebind.log" \
+	LINKEDIN_FIXTURE_ACCESS_TOKEN=fixture-token \
+	"$HELPER" sync-linkedin --base "$BASE" --alias personal:default \
+	--connection-id conn_linkedin_rebind --account-id live_member42 \
+	--stream authored_articles --profile fixture --budget 3 --page-size 7 \
+	>/dev/null 2>&1; then
+	rebind_result=accepted
+else
+	rebind_result=rejected
+fi
+assert_eq "live boundary rejects LinkedIn account rebinding before snapshot read" \
+	"$rebind_result" rejected
+assert_eq "per-page LinkedIn identity mismatch creates no raw evidence" \
+	"$(raw_count)" "$raw_before_rebind"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -ne 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Add ten GET-only LinkedIn Member Snapshot streams for eligible EEA or Swiss member accounts.
- Bind every read and persisted object to the revalidated selected member identity.
- Preserve independent resumable checkpoints, immutable raw evidence, and explicit Gate/Export/No coverage dispositions.
- Reuse shared OAuth collector and guarded-reader primitives across LinkedIn and YouTube without changing provider-specific policies.

## Files Changed

- `.agents/scripts/_knowledge_social_linkedin*.py`: stream contracts, guarded HTTP provider, reader isolation, normalization, and terminal handling.
- `.agents/scripts/_knowledge_social_oauth_{collector,reader}.py` and `_knowledge_social_collect_cli.py`: shared lease, persistence, subprocess, and environment boundaries.
- `.agents/scripts/knowledge_social_{linkedin,youtube}.py`: declarative provider entrypoints using the shared orchestration.
- `.agents/tests/test-knowledge-social-linkedin.sh`: identity, paging, terminal status, replay, credential, and lease-fencing coverage.
- `.agents/content/social-linkedin.md` and the provider capability matrix: official route, access, retention, export, and unsupported-feature evidence.

## Safety Decisions

- Keep the provider transport GET-only and allowlist only `memberAuthorizations` and `memberSnapshotData`.
- Pass only the selected profile token plus bounded runtime variables to the child process; reject credential-shaped response data before persistence.
- Revalidate member identity before each snapshot page and fail before cursor or evidence mutation on account rebinding.
- Treat only the documented 404 `No data found for this memberId` response as snapshot completion; paging links alone do not prove offline data exhaustion.
- Scope content-addressed identities by verified account and snapshot domain while retaining the raw-record digest as provenance.

## Runtime Testing

- **Risk level:** critical
- **Verification:** runtime-verified — guarded provider fixture boundaries and persistence paths passed: LinkedIn 39/39, YouTube 55/55, social sync 33/33, social corpus 31/31, Reddit 43/43, and X 66/66.
- Python `compileall`, changed-file linters, ShellCheck, secret scanning, whitespace checks, and complexity regression checks passed.

## Quality and Review

- Qlty 0.636.0 reports 53 smells at both base and head: no regression.
- Qlty new-file gate reports zero smells across nine eligible new source files.
- Independent closeout review is CLEAN for exact head `d3b64f30f95d13cc62470aa6becd76b35dcc1125`, evidence digest `d6e0e259b08ee098e692b74890f63d2f2d92bb6a757a4bae208a148d93c3f990`.

Resolves #28668
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 1h 30m and 995,293 tokens on this as a headless worker.