### PR TITLE
GH#28752: Recover isolated TODO-sync workspaces

### DIFF
--- a/.agents/scripts/pulse-temp-worktree-cleanup.sh
+++ b/.agents/scripts/pulse-temp-worktree-cleanup.sh
@@ -13,6 +13,12 @@ _PTWC_LOCK_OWNER_PID=""
 _PTWC_LOCK_OWNER_START=""
 _PTWC_RECLAIM_GUARD_TOKEN=""
 
+_PTWC_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "${_PTWC_SCRIPT_DIR}/pulse-todo-sync-workspace.sh" ]]; then
+	# shellcheck source=pulse-todo-sync-workspace.sh
+	source "${_PTWC_SCRIPT_DIR}/pulse-todo-sync-workspace.sh"
+fi
+
 _ptwc_is_temp_fixture_path() {
 	local wt_path="$1"
 	case "$wt_path" in
@@ -488,6 +494,8 @@ cleanup_stale_temp_worktrees() {
 	local repo_paths=""
 	local repo_path=""
 	local repo_removed=0
+	local todo_sync_removed=0
+	local worktree_removed=0
 	local total_removed=0
 	local remaining_removals=0
 
@@ -498,9 +506,14 @@ cleanup_stale_temp_worktrees() {
 		return 0
 	fi
 	lock_dir="$_PTWC_LOCK_DIR"
+	if declare -F _ptsw_sweep_stale_workspaces >/dev/null 2>&1; then
+		todo_sync_removed=$(_ptsw_sweep_stale_workspaces) || todo_sync_removed=0
+		[[ "$todo_sync_removed" =~ ^[0-9]+$ ]] || todo_sync_removed=0
+		total_removed=$((total_removed + todo_sync_removed))
+	fi
 	if [[ ! -f "$repos_json" ]] || ! command -v jq >/dev/null 2>&1; then
 		_ptwc_lock_release "$lock_dir"
-		printf '0\n'
+		printf '%s\n' "$total_removed"
 		return 0
 	fi
 	now_epoch=$(date +%s)
@@ -508,16 +521,17 @@ cleanup_stale_temp_worktrees() {
 		"$repos_json" 2>/dev/null) || repo_paths=""
 	while IFS= read -r repo_path; do
 		[[ -n "$repo_path" ]] || continue
-		[[ "$total_removed" -lt "$max_removals" ]] || break
+		[[ "$worktree_removed" -lt "$max_removals" ]] || break
 		git -C "$repo_path" rev-parse --git-dir >/dev/null 2>&1 || continue
-		remaining_removals=$((max_removals - total_removed))
+		remaining_removals=$((max_removals - worktree_removed))
 		repo_removed=$(_ptwc_cleanup_repo "$repo_path" "$now_epoch" "$grace_secs" "$remaining_removals")
 		[[ "$repo_removed" =~ ^[0-9]+$ ]] || repo_removed=0
+		worktree_removed=$((worktree_removed + repo_removed))
 		total_removed=$((total_removed + repo_removed))
 	done <<<"$repo_paths"
 	_ptwc_lock_release "$lock_dir"
-	if [[ "$total_removed" -gt 0 ]]; then
-		printf '%s\n' "[pulse-wrapper] Temp worktree cleanup total: ${total_removed} stale detached fixture(s) removed" >>"${LOGFILE:-/dev/null}"
+	if [[ "$worktree_removed" -gt 0 ]]; then
+		printf '%s\n' "[pulse-wrapper] Temp worktree cleanup total: ${worktree_removed} stale detached fixture(s) removed" >>"${LOGFILE:-/dev/null}"
 	fi
 	printf '%s\n' "$total_removed"
 	return 0

--- a/.agents/scripts/pulse-todo-sync-workspace.sh
+++ b/.agents/scripts/pulse-todo-sync-workspace.sh
@@ -8,6 +8,8 @@ _PULSE_TODO_SYNC_WORKSPACE_LOADED=1
 
 _PTSW_OWNER_MARKER=".aidevops-pulse-todo-sync-owner"
 _PTSW_MARKER_VERSION="v1"
+_PTSW_OUTCOME_SKIPPED="skipped"
+_PTSW_OWNER_STALE="stale"
 _PTSW_VALIDATION_REASON=""
 _PTSW_OWNER_PID=""
 _PTSW_OWNER_START=""
@@ -221,7 +223,7 @@ _ptsw_classify_owner() {
 		if [[ "$current_start" == "$owner_start" ]]; then
 			_PTSW_OWNER_STATE="active"
 		else
-			_PTSW_OWNER_STATE="stale"
+			_PTSW_OWNER_STATE="$_PTSW_OWNER_STALE"
 		fi
 		return 0
 	fi
@@ -233,7 +235,7 @@ _ptsw_classify_owner() {
 	observed_pid=$(LC_ALL=C ps -p "$owner_pid" -o pid= 2>/dev/null) || ps_rc=$?
 	observed_pid="${observed_pid//[[:space:]]/}"
 	if [[ "$ps_rc" -eq 1 && -z "$observed_pid" ]]; then
-		_PTSW_OWNER_STATE="stale"
+		_PTSW_OWNER_STATE="$_PTSW_OWNER_STALE"
 	fi
 	return 0
 }
@@ -297,6 +299,7 @@ _ptsw_sweep_stale_workspaces() {
 	local owner_pid=""
 	local owner_start=""
 	local owner_created=""
+	local owner_detail=""
 	[[ "$max_recoveries" =~ ^[1-9][0-9]*$ ]] || max_recoveries=5
 	temp_root=$(_ptsw_resolve_temp_root 0) || {
 		printf '0\n'
@@ -314,39 +317,40 @@ _ptsw_sweep_stale_workspaces() {
 		[[ -e "$workspace_root" || -L "$workspace_root" ]] || continue
 		safe_identity=$(_ptsw_safe_identity "$workspace_root")
 		if ! _ptsw_validate_workspace_path "$workspace_root" 1; then
-			_ptsw_log_sweep_outcome "skipped" "${_PTSW_VALIDATION_REASON:-invalid-candidate}" "$safe_identity"
+			_ptsw_log_sweep_outcome "$_PTSW_OUTCOME_SKIPPED" "${_PTSW_VALIDATION_REASON:-invalid-candidate}" "$safe_identity"
 			continue
 		fi
 		identity="${workspace_root##*/}"
 		if ! _ptsw_read_owner_marker "$workspace_root"; then
-			_ptsw_log_sweep_outcome "skipped" "malformed-owner-marker" "$identity"
+			_ptsw_log_sweep_outcome "$_PTSW_OUTCOME_SKIPPED" "malformed-owner-marker" "$identity"
 			continue
 		fi
 		owner_pid="$_PTSW_OWNER_PID"
 		owner_start="$_PTSW_OWNER_START"
 		owner_created="$_PTSW_OWNER_CREATED"
+		owner_detail="owner_pid=${owner_pid}"
 		age_secs=$((now_epoch - owner_created))
 		if [[ "$age_secs" -lt 0 ]]; then
-			_ptsw_log_sweep_outcome "skipped" "future-owner-marker" "$identity"
+			_ptsw_log_sweep_outcome "$_PTSW_OUTCOME_SKIPPED" "future-owner-marker" "$identity"
 			continue
 		fi
 		if [[ "$age_secs" -lt "$grace_secs" ]]; then
-			_ptsw_log_sweep_outcome "skipped" "grace-period" "$identity" "age=${age_secs}s grace=${grace_secs}s"
+			_ptsw_log_sweep_outcome "$_PTSW_OUTCOME_SKIPPED" "grace-period" "$identity" "age=${age_secs}s grace=${grace_secs}s"
 			continue
 		fi
 		_ptsw_classify_owner "$owner_pid" "$owner_start"
 		case "$_PTSW_OWNER_STATE" in
 		active)
-			_ptsw_log_sweep_outcome "skipped" "active-owner" "$identity" "owner_pid=${owner_pid}"
+			_ptsw_log_sweep_outcome "$_PTSW_OUTCOME_SKIPPED" "active-owner" "$identity" "$owner_detail"
 			continue
 			;;
 		unknown)
-			_ptsw_log_sweep_outcome "skipped" "owner-visibility-unknown" "$identity" "owner_pid=${owner_pid}"
+			_ptsw_log_sweep_outcome "$_PTSW_OUTCOME_SKIPPED" "owner-visibility-unknown" "$identity" "$owner_detail"
 			continue
 			;;
 		esac
 		if [[ "$removed" -ge "$max_recoveries" ]]; then
-			_ptsw_log_sweep_outcome "skipped" "recovery-cap" "$identity" "cap=${max_recoveries}"
+			_ptsw_log_sweep_outcome "$_PTSW_OUTCOME_SKIPPED" "recovery-cap" "$identity" "cap=${max_recoveries}"
 			continue
 		fi
 		# Recheck the mutable ownership record immediately before the move.
@@ -354,19 +358,19 @@ _ptsw_sweep_stale_workspaces() {
 			! _ptsw_read_owner_marker "$workspace_root" || \
 			[[ "$_PTSW_OWNER_PID" != "$owner_pid" || "$_PTSW_OWNER_START" != "$owner_start" || \
 				"$_PTSW_OWNER_CREATED" != "$owner_created" ]]; then
-			_ptsw_log_sweep_outcome "skipped" "owner-marker-changed" "$identity"
+			_ptsw_log_sweep_outcome "$_PTSW_OUTCOME_SKIPPED" "owner-marker-changed" "$identity"
 			continue
 		fi
 		_ptsw_classify_owner "$owner_pid" "$owner_start"
-		if [[ "$_PTSW_OWNER_STATE" != "stale" ]]; then
-			_ptsw_log_sweep_outcome "skipped" "owner-state-changed" "$identity"
+		if [[ "$_PTSW_OWNER_STATE" != "$_PTSW_OWNER_STALE" ]]; then
+			_ptsw_log_sweep_outcome "$_PTSW_OUTCOME_SKIPPED" "owner-state-changed" "$identity"
 			continue
 		fi
 		if _ptsw_move_to_recoverable_trash "$workspace_root" "$identity"; then
 			removed=$((removed + 1))
 			_ptsw_log_sweep_outcome "removed" "dead-owner" "$identity" "age=${age_secs}s owner_pid=${owner_pid} mode=trash"
 		else
-			_ptsw_log_sweep_outcome "failure" "trash-move-failed" "$identity" "owner_pid=${owner_pid}"
+			_ptsw_log_sweep_outcome "failure" "trash-move-failed" "$identity" "$owner_detail"
 		fi
 	done
 	printf '%s\n' "$removed"

--- a/.agents/scripts/pulse-todo-sync-workspace.sh
+++ b/.agents/scripts/pulse-todo-sync-workspace.sh
@@ -1,0 +1,374 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# pulse-todo-sync-workspace.sh — Owned lifecycle for isolated TODO-sync clones.
+
+[[ -n "${_PULSE_TODO_SYNC_WORKSPACE_LOADED:-}" ]] && return 0
+_PULSE_TODO_SYNC_WORKSPACE_LOADED=1
+
+_PTSW_OWNER_MARKER=".aidevops-pulse-todo-sync-owner"
+_PTSW_MARKER_VERSION="v1"
+_PTSW_VALIDATION_REASON=""
+_PTSW_OWNER_PID=""
+_PTSW_OWNER_START=""
+_PTSW_OWNER_CREATED=""
+_PTSW_OWNER_STATE=""
+_PULSE_TODO_SYNC_WORKSPACE=""
+_PULSE_TODO_SYNC_WORKSPACE_ROOT=""
+_PULSE_TODO_SYNC_OWNER_PID=""
+_PULSE_TODO_SYNC_OWNER_START=""
+
+_ptsw_process_start_fingerprint() {
+	local process_pid="$1"
+	local process_start=""
+	[[ "$process_pid" =~ ^[1-9][0-9]*$ ]] || return 1
+	process_start=$(LC_ALL=C ps -p "$process_pid" -o lstart= 2>/dev/null) || return 1
+	process_start="${process_start#"${process_start%%[![:space:]]*}"}"
+	process_start="${process_start%"${process_start##*[![:space:]]}"}"
+	[[ -n "$process_start" ]] || return 1
+	printf '%s\n' "$process_start"
+	return 0
+}
+
+_ptsw_resolve_temp_root() {
+	local create_root="${1:-0}"
+	local temp_root="${AIDEVOPS_TEMP_DIR:-${HOME:-}/.aidevops/.agent-workspace/tmp}"
+	[[ -n "$temp_root" && "$temp_root" == /* ]] || return 1
+	if [[ "$create_root" == "1" ]]; then
+		mkdir -p "$temp_root" 2>/dev/null || return 1
+	fi
+	[[ -d "$temp_root" ]] || return 1
+	(cd "$temp_root" 2>/dev/null && pwd -P)
+	return $?
+}
+
+_ptsw_safe_identity() {
+	local candidate="$1"
+	local identity="${candidate%/}"
+	identity="${identity##*/}"
+	printf '%s' "$identity" | LC_ALL=C tr -c 'A-Za-z0-9._-' '_'
+	return 0
+}
+
+_ptsw_validate_workspace_path() {
+	local candidate="$1"
+	local require_marker="${2:-1}"
+	local temp_root=""
+	local candidate_parent=""
+	local resolved_parent=""
+	local resolved_candidate=""
+	local identity=""
+	local marker_path=""
+	_PTSW_VALIDATION_REASON="invalid-path"
+	[[ -n "$candidate" && "$candidate" == /* ]] || return 1
+	candidate="${candidate%/}"
+	identity="${candidate##*/}"
+	if [[ ! "$identity" =~ ^pulse-todo-sync\.[A-Za-z0-9]{6}$ ]]; then
+		_PTSW_VALIDATION_REASON="malformed-name"
+		return 1
+	fi
+	if [[ -L "$candidate" ]]; then
+		_PTSW_VALIDATION_REASON="symlink"
+		return 1
+	fi
+	if [[ ! -d "$candidate" ]]; then
+		_PTSW_VALIDATION_REASON="not-directory"
+		return 1
+	fi
+	temp_root=$(_ptsw_resolve_temp_root 0) || {
+		_PTSW_VALIDATION_REASON="temp-root-unavailable"
+		return 1
+	}
+	candidate_parent="${candidate%/*}"
+	resolved_parent=$(cd "$candidate_parent" 2>/dev/null && pwd -P) || {
+		_PTSW_VALIDATION_REASON="parent-unavailable"
+		return 1
+	}
+	if [[ "$resolved_parent" != "$temp_root" ]]; then
+		_PTSW_VALIDATION_REASON="outside-temp-root"
+		return 1
+	fi
+	resolved_candidate=$(cd "$candidate" 2>/dev/null && pwd -P) || {
+		_PTSW_VALIDATION_REASON="workspace-unavailable"
+		return 1
+	}
+	if [[ "$resolved_candidate" != "${temp_root}/${identity}" ]]; then
+		_PTSW_VALIDATION_REASON="path-mismatch"
+		return 1
+	fi
+	if [[ "$require_marker" == "1" ]]; then
+		marker_path="${candidate}/${_PTSW_OWNER_MARKER}"
+		if [[ -L "$marker_path" ]]; then
+			_PTSW_VALIDATION_REASON="owner-marker-symlink"
+			return 1
+		fi
+		if [[ ! -f "$marker_path" ]]; then
+			_PTSW_VALIDATION_REASON="missing-owner-marker"
+			return 1
+		fi
+	fi
+	_PTSW_VALIDATION_REASON=""
+	return 0
+}
+
+_ptsw_read_owner_marker() {
+	local workspace_root="$1"
+	local marker_path="${workspace_root}/${_PTSW_OWNER_MARKER}"
+	local marker_record=""
+	local marker_version=""
+	local owner_pid=""
+	local owner_created=""
+	local owner_start=""
+	local extra_field=""
+	_PTSW_OWNER_PID=""
+	_PTSW_OWNER_START=""
+	_PTSW_OWNER_CREATED=""
+	[[ -f "$marker_path" && ! -L "$marker_path" ]] || return 1
+	marker_record=$(<"$marker_path") || return 1
+	[[ "$marker_record" != *$'\n'* ]] || return 1
+	IFS=$'\t' read -r marker_version owner_pid owner_created owner_start extra_field <<<"$marker_record"
+	[[ "$marker_version" == "$_PTSW_MARKER_VERSION" ]] || return 1
+	[[ "$owner_pid" =~ ^[1-9][0-9]*$ ]] || return 1
+	[[ "$owner_created" =~ ^[1-9][0-9]*$ ]] || return 1
+	[[ -n "$owner_start" && -z "$extra_field" ]] || return 1
+	_PTSW_OWNER_PID="$owner_pid"
+	_PTSW_OWNER_START="$owner_start"
+	_PTSW_OWNER_CREATED="$owner_created"
+	return 0
+}
+
+_ptsw_create_workspace() {
+	local remote_url="$1"
+	local temp_root=""
+	local workspace_root=""
+	local marker_path=""
+	local marker_tmp=""
+	local owner_pid="${BASHPID:-$$}"
+	local owner_start=""
+	local owner_created=""
+	_PULSE_TODO_SYNC_WORKSPACE=""
+	_PULSE_TODO_SYNC_WORKSPACE_ROOT=""
+	_PULSE_TODO_SYNC_OWNER_PID=""
+	_PULSE_TODO_SYNC_OWNER_START=""
+	[[ -n "$remote_url" ]] || return 1
+	owner_start=$(_ptsw_process_start_fingerprint "$owner_pid") || return 1
+	owner_created=$(date +%s 2>/dev/null) || return 1
+	[[ "$owner_created" =~ ^[1-9][0-9]*$ ]] || return 1
+	temp_root=$(_ptsw_resolve_temp_root 1) || return 1
+	workspace_root=$(mktemp -d "${temp_root}/pulse-todo-sync.XXXXXX") || return 1
+	workspace_root=$(cd "$workspace_root" 2>/dev/null && pwd -P) || return 1
+	if ! _ptsw_validate_workspace_path "$workspace_root" 0; then
+		rmdir "$workspace_root" 2>/dev/null || true
+		return 1
+	fi
+	marker_path="${workspace_root}/${_PTSW_OWNER_MARKER}"
+	marker_tmp="${marker_path}.tmp.${owner_pid}"
+	if ! printf '%s\t%s\t%s\t%s\n' "$_PTSW_MARKER_VERSION" "$owner_pid" \
+		"$owner_created" "$owner_start" >"$marker_tmp" 2>/dev/null; then
+		rm -f "$marker_tmp" 2>/dev/null || true
+		rmdir "$workspace_root" 2>/dev/null || true
+		return 1
+	fi
+	if ! mv "$marker_tmp" "$marker_path" 2>/dev/null; then
+		rm -f "$marker_tmp" 2>/dev/null || true
+		rmdir "$workspace_root" 2>/dev/null || true
+		return 1
+	fi
+	_PULSE_TODO_SYNC_WORKSPACE_ROOT="$workspace_root"
+	_PULSE_TODO_SYNC_WORKSPACE="${workspace_root}/repo"
+	_PULSE_TODO_SYNC_OWNER_PID="$owner_pid"
+	_PULSE_TODO_SYNC_OWNER_START="$owner_start"
+	git clone --quiet --no-tags "$remote_url" "$_PULSE_TODO_SYNC_WORKSPACE" >/dev/null 2>&1 || return 1
+	return 0
+}
+
+_ptsw_remove_owned_workspace() {
+	local workspace_root="$1"
+	local expected_pid="$2"
+	local expected_start="$3"
+	local current_start=""
+	[[ -n "$workspace_root" ]] || return 0
+	[[ -e "$workspace_root" || -L "$workspace_root" ]] || return 0
+	_ptsw_validate_workspace_path "$workspace_root" 1 || return 1
+	_ptsw_read_owner_marker "$workspace_root" || return 1
+	[[ "$_PTSW_OWNER_PID" == "$expected_pid" ]] || return 1
+	[[ "$_PTSW_OWNER_START" == "$expected_start" ]] || return 1
+	current_start=$(_ptsw_process_start_fingerprint "$expected_pid") || return 1
+	[[ "$current_start" == "$expected_start" ]] || return 1
+	rm -rf "$workspace_root" 2>/dev/null || return 1
+	[[ ! -e "$workspace_root" && ! -L "$workspace_root" ]] || return 1
+	return 0
+}
+
+_ptsw_process_visibility_available() {
+	local self_pid="${BASHPID:-$$}"
+	local observed_pid=""
+	observed_pid=$(LC_ALL=C ps -p "$self_pid" -o pid= 2>/dev/null) || return 1
+	observed_pid="${observed_pid//[[:space:]]/}"
+	[[ "$observed_pid" == "$self_pid" ]] || return 1
+	return 0
+}
+
+_ptsw_classify_owner() {
+	local owner_pid="$1"
+	local owner_start="$2"
+	local current_start=""
+	local observed_pid=""
+	local ps_rc=0
+	local kill_error=""
+	_PTSW_OWNER_STATE="unknown"
+	if current_start=$(_ptsw_process_start_fingerprint "$owner_pid"); then
+		if [[ "$current_start" == "$owner_start" ]]; then
+			_PTSW_OWNER_STATE="active"
+		else
+			_PTSW_OWNER_STATE="stale"
+		fi
+		return 0
+	fi
+	_ptsw_process_visibility_available || return 0
+	kill_error=$(LC_ALL=C kill -0 "$owner_pid" 2>&1) || true
+	case "$kill_error" in
+	*"Operation not permitted"* | *"operation not permitted"*) return 0 ;;
+	esac
+	observed_pid=$(LC_ALL=C ps -p "$owner_pid" -o pid= 2>/dev/null) || ps_rc=$?
+	observed_pid="${observed_pid//[[:space:]]/}"
+	if [[ "$ps_rc" -eq 1 && -z "$observed_pid" ]]; then
+		_PTSW_OWNER_STATE="stale"
+	fi
+	return 0
+}
+
+_ptsw_workspace_grace_secs() {
+	local stage_timeout="${PRE_RUN_STAGE_TIMEOUT:-600}"
+	local grace_secs="${PULSE_TODO_SYNC_WORKSPACE_GRACE_SECS:-}"
+	[[ "$stage_timeout" =~ ^[1-9][0-9]*$ ]] || stage_timeout=600
+	if [[ ! "$grace_secs" =~ ^[1-9][0-9]*$ ]]; then
+		grace_secs=$((stage_timeout + 300))
+	fi
+	if [[ "$grace_secs" -le "$stage_timeout" ]]; then
+		grace_secs=$((stage_timeout + 1))
+	fi
+	printf '%s\n' "$grace_secs"
+	return 0
+}
+
+_ptsw_log_sweep_outcome() {
+	local outcome="$1"
+	local reason="$2"
+	local identity="$3"
+	local detail="${4:-}"
+	local log_file="${WRAPPER_LOGFILE:-${LOGFILE:-/dev/null}}"
+	printf '[pulse-wrapper] TODO ref sync stale cleanup outcome=%s reason=%s workspace=%s%s\n' \
+		"$outcome" "$reason" "$identity" "${detail:+ ${detail}}" >>"$log_file" 2>/dev/null || true
+	return 0
+}
+
+_ptsw_move_to_recoverable_trash() {
+	local workspace_root="$1"
+	local identity="$2"
+	local trash_root="${AIDEVOPS_TODO_SYNC_TRASH_ROOT:-${AIDEVOPS_ORPHAN_TRASH_ROOT:-${HOME:-}/.Trash}}"
+	local resolved_trash_root=""
+	local destination=""
+	local move_epoch=""
+	[[ -n "$trash_root" && "$trash_root" == /* ]] || return 1
+	mkdir -p "$trash_root" 2>/dev/null || return 1
+	resolved_trash_root=$(cd "$trash_root" 2>/dev/null && pwd -P) || return 1
+	case "$resolved_trash_root" in
+	"$workspace_root" | "$workspace_root"/*) return 1 ;;
+	esac
+	move_epoch=$(date +%s 2>/dev/null) || return 1
+	destination="${resolved_trash_root}/aidevops-pulse-todo-sync-${identity}-${move_epoch}-${BASHPID:-$$}-${RANDOM}"
+	[[ ! -e "$destination" && ! -L "$destination" ]] || return 1
+	mv "$workspace_root" "$destination" 2>/dev/null || return 1
+	[[ ! -e "$workspace_root" && ! -L "$workspace_root" ]] || return 1
+	return 0
+}
+
+_ptsw_sweep_stale_workspaces() {
+	local temp_root=""
+	local now_epoch=""
+	local grace_secs=""
+	local max_recoveries="${PULSE_TODO_SYNC_MAX_RECOVERIES_PER_RUN:-5}"
+	local workspace_root=""
+	local identity=""
+	local safe_identity=""
+	local age_secs=0
+	local removed=0
+	local owner_pid=""
+	local owner_start=""
+	local owner_created=""
+	[[ "$max_recoveries" =~ ^[1-9][0-9]*$ ]] || max_recoveries=5
+	temp_root=$(_ptsw_resolve_temp_root 0) || {
+		printf '0\n'
+		return 0
+	}
+	now_epoch=$(date +%s 2>/dev/null) || {
+		printf '0\n'
+		return 0
+	}
+	grace_secs=$(_ptsw_workspace_grace_secs) || {
+		printf '0\n'
+		return 0
+	}
+	for workspace_root in "$temp_root"/pulse-todo-sync.*; do
+		[[ -e "$workspace_root" || -L "$workspace_root" ]] || continue
+		safe_identity=$(_ptsw_safe_identity "$workspace_root")
+		if ! _ptsw_validate_workspace_path "$workspace_root" 1; then
+			_ptsw_log_sweep_outcome "skipped" "${_PTSW_VALIDATION_REASON:-invalid-candidate}" "$safe_identity"
+			continue
+		fi
+		identity="${workspace_root##*/}"
+		if ! _ptsw_read_owner_marker "$workspace_root"; then
+			_ptsw_log_sweep_outcome "skipped" "malformed-owner-marker" "$identity"
+			continue
+		fi
+		owner_pid="$_PTSW_OWNER_PID"
+		owner_start="$_PTSW_OWNER_START"
+		owner_created="$_PTSW_OWNER_CREATED"
+		age_secs=$((now_epoch - owner_created))
+		if [[ "$age_secs" -lt 0 ]]; then
+			_ptsw_log_sweep_outcome "skipped" "future-owner-marker" "$identity"
+			continue
+		fi
+		if [[ "$age_secs" -lt "$grace_secs" ]]; then
+			_ptsw_log_sweep_outcome "skipped" "grace-period" "$identity" "age=${age_secs}s grace=${grace_secs}s"
+			continue
+		fi
+		_ptsw_classify_owner "$owner_pid" "$owner_start"
+		case "$_PTSW_OWNER_STATE" in
+		active)
+			_ptsw_log_sweep_outcome "skipped" "active-owner" "$identity" "owner_pid=${owner_pid}"
+			continue
+			;;
+		unknown)
+			_ptsw_log_sweep_outcome "skipped" "owner-visibility-unknown" "$identity" "owner_pid=${owner_pid}"
+			continue
+			;;
+		esac
+		if [[ "$removed" -ge "$max_recoveries" ]]; then
+			_ptsw_log_sweep_outcome "skipped" "recovery-cap" "$identity" "cap=${max_recoveries}"
+			continue
+		fi
+		# Recheck the mutable ownership record immediately before the move.
+		if ! _ptsw_validate_workspace_path "$workspace_root" 1 || \
+			! _ptsw_read_owner_marker "$workspace_root" || \
+			[[ "$_PTSW_OWNER_PID" != "$owner_pid" || "$_PTSW_OWNER_START" != "$owner_start" || \
+				"$_PTSW_OWNER_CREATED" != "$owner_created" ]]; then
+			_ptsw_log_sweep_outcome "skipped" "owner-marker-changed" "$identity"
+			continue
+		fi
+		_ptsw_classify_owner "$owner_pid" "$owner_start"
+		if [[ "$_PTSW_OWNER_STATE" != "stale" ]]; then
+			_ptsw_log_sweep_outcome "skipped" "owner-state-changed" "$identity"
+			continue
+		fi
+		if _ptsw_move_to_recoverable_trash "$workspace_root" "$identity"; then
+			removed=$((removed + 1))
+			_ptsw_log_sweep_outcome "removed" "dead-owner" "$identity" "age=${age_secs}s owner_pid=${owner_pid} mode=trash"
+		else
+			_ptsw_log_sweep_outcome "failure" "trash-move-failed" "$identity" "owner_pid=${owner_pid}"
+		fi
+	done
+	printf '%s\n' "$removed"
+	return 0
+}

--- a/.agents/scripts/pulse-todo-sync-workspace.sh
+++ b/.agents/scripts/pulse-todo-sync-workspace.sh
@@ -23,8 +23,16 @@ _PULSE_TODO_SYNC_OWNER_START=""
 _ptsw_process_start_fingerprint() {
 	local process_pid="$1"
 	local process_start=""
+	local stat_content=""
+	local stat_after_comm=""
 	[[ "$process_pid" =~ ^[1-9][0-9]*$ ]] || return 1
-	process_start=$(LC_ALL=C ps -p "$process_pid" -o lstart= 2>/dev/null) || return 1
+	if [[ -r "/proc/${process_pid}/stat" ]]; then
+		stat_content=$(<"/proc/${process_pid}/stat") || return 1
+		stat_after_comm="${stat_content##*) }"
+		process_start=$(printf '%s\n' "$stat_after_comm" | awk '{print $20}') || return 1
+	else
+		process_start=$(LC_ALL=C ps -p "$process_pid" -o lstart= 2>/dev/null) || return 1
+	fi
 	process_start="${process_start#"${process_start%%[![:space:]]*}"}"
 	process_start="${process_start%"${process_start##*[![:space:]]}"}"
 	[[ -n "$process_start" ]] || return 1
@@ -34,7 +42,11 @@ _ptsw_process_start_fingerprint() {
 
 _ptsw_resolve_temp_root() {
 	local create_root="${1:-0}"
-	local temp_root="${AIDEVOPS_TEMP_DIR:-${HOME:-}/.aidevops/.agent-workspace/tmp}"
+	local temp_root="${AIDEVOPS_TEMP_DIR:-}"
+	if [[ -z "$temp_root" ]]; then
+		[[ -n "${HOME:-}" ]] || return 1
+		temp_root="${HOME}/.aidevops/.agent-workspace/tmp"
+	fi
 	[[ -n "$temp_root" && "$temp_root" == /* ]] || return 1
 	if [[ "$create_root" == "1" ]]; then
 		mkdir -p "$temp_root" 2>/dev/null || return 1
@@ -218,6 +230,7 @@ _ptsw_classify_owner() {
 	local observed_pid=""
 	local ps_rc=0
 	local kill_error=""
+	local kill_rc=0
 	_PTSW_OWNER_STATE="unknown"
 	if current_start=$(_ptsw_process_start_fingerprint "$owner_pid"); then
 		if [[ "$current_start" == "$owner_start" ]]; then
@@ -228,7 +241,11 @@ _ptsw_classify_owner() {
 		return 0
 	fi
 	_ptsw_process_visibility_available || return 0
-	kill_error=$(LC_ALL=C kill -0 "$owner_pid" 2>&1) || true
+	kill_error=$(LC_ALL=C kill -0 "$owner_pid" 2>&1) || kill_rc=$?
+	# A successful signal probe proves the PID is live. If its generation token
+	# cannot be observed, fail closed instead of treating degraded ps output as
+	# evidence that the owner disappeared.
+	[[ "$kill_rc" -eq 0 ]] && return 0
 	case "$kill_error" in
 	*"Operation not permitted"* | *"operation not permitted"*) return 0 ;;
 	esac
@@ -268,10 +285,14 @@ _ptsw_log_sweep_outcome() {
 _ptsw_move_to_recoverable_trash() {
 	local workspace_root="$1"
 	local identity="$2"
-	local trash_root="${AIDEVOPS_TODO_SYNC_TRASH_ROOT:-${AIDEVOPS_ORPHAN_TRASH_ROOT:-${HOME:-}/.Trash}}"
+	local trash_root="${AIDEVOPS_TODO_SYNC_TRASH_ROOT:-${AIDEVOPS_ORPHAN_TRASH_ROOT:-}}"
 	local resolved_trash_root=""
 	local destination=""
 	local move_epoch=""
+	if [[ -z "$trash_root" ]]; then
+		[[ -n "${HOME:-}" ]] || return 1
+		trash_root="${HOME}/.Trash"
+	fi
 	[[ -n "$trash_root" && "$trash_root" == /* ]] || return 1
 	mkdir -p "$trash_root" 2>/dev/null || return 1
 	resolved_trash_root=$(cd "$trash_root" 2>/dev/null && pwd -P) || return 1

--- a/.agents/scripts/pulse-todo-sync-workspace.sh
+++ b/.agents/scripts/pulse-todo-sync-workspace.sh
@@ -354,9 +354,9 @@ _ptsw_sweep_stale_workspaces() {
 			continue
 		fi
 		# Recheck the mutable ownership record immediately before the move.
-		if ! _ptsw_validate_workspace_path "$workspace_root" 1 || \
-			! _ptsw_read_owner_marker "$workspace_root" || \
-			[[ "$_PTSW_OWNER_PID" != "$owner_pid" || "$_PTSW_OWNER_START" != "$owner_start" || \
+		if ! _ptsw_validate_workspace_path "$workspace_root" 1 ||
+			! _ptsw_read_owner_marker "$workspace_root" ||
+			[[ "$_PTSW_OWNER_PID" != "$owner_pid" || "$_PTSW_OWNER_START" != "$owner_start" ||
 				"$_PTSW_OWNER_CREATED" != "$owner_created" ]]; then
 			_ptsw_log_sweep_outcome "$_PTSW_OUTCOME_SKIPPED" "owner-marker-changed" "$identity"
 			continue

--- a/.agents/scripts/pulse-todo-sync-workspace.sh
+++ b/.agents/scripts/pulse-todo-sync-workspace.sh
@@ -157,7 +157,7 @@ _ptsw_create_workspace() {
 	local workspace_root=""
 	local marker_path=""
 	local marker_tmp=""
-	local owner_pid="${BASHPID:-$$}"
+	local owner_pid="${BASHPID:-}"
 	local owner_start=""
 	local owner_created=""
 	_PULSE_TODO_SYNC_WORKSPACE=""
@@ -165,6 +165,13 @@ _ptsw_create_workspace() {
 	_PULSE_TODO_SYNC_OWNER_PID=""
 	_PULSE_TODO_SYNC_OWNER_START=""
 	[[ -n "$remote_url" ]] || return 1
+	if [[ -z "$owner_pid" ]]; then
+		# Bash 3.2 has no BASHPID and $$ remains the ancestor shell PID inside
+		# a subshell. The command-substitution child sees this workspace owner
+		# as its PPID, so exec avoids reporting an intermediate shell instead.
+		owner_pid="$(exec sh -c 'printf "%s" "$PPID"')" || return 1
+	fi
+	[[ "$owner_pid" =~ ^[1-9][0-9]*$ ]] || return 1
 	owner_start=$(_ptsw_process_start_fingerprint "$owner_pid") || return 1
 	owner_created=$(date +%s 2>/dev/null) || return 1
 	[[ "$owner_created" =~ ^[1-9][0-9]*$ ]] || return 1

--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -640,7 +640,7 @@ sync_todo_refs_for_repo() (
 	2) printf '[pulse-wrapper] TODO ref sync status=retryable_conflict repo=%s base=%s\n' \
 		"$repo_slug" "${base_sha:0:12}" >>"$WRAPPER_LOGFILE" ;;
 	*) printf '[pulse-wrapper] TODO ref sync status=retryable_failure stage=publication repo=%s rc=%s\n' \
-			"$repo_slug" "$publication_rc" >>"$WRAPPER_LOGFILE" ;;
+		"$repo_slug" "$publication_rc" >>"$WRAPPER_LOGFILE" ;;
 	esac
 	if [[ "$publication_rc" -eq 0 ]]; then
 		lifecycle_stage="complete"

--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -13,6 +13,7 @@
 #
 # Dependencies:
 #   - shared-constants.sh (logging primitives via worker-lifecycle-common.sh)
+#   - pulse-todo-sync-workspace.sh (owned isolated-clone lifecycle)
 #   - pulse-wrapper-config.sh (LOGFILE, WRAPPER_LOGFILE, PULSE_DIR, PIDFILE,
 #     LOCKDIR, STATE_FILE, HEADLESS_RUNTIME_HELPER, PULSE_MODEL,
 #     PULSE_COLD_START_TIMEOUT[_UNDERFILLED], _PULSE_REFRESHED_THIS_CYCLE
@@ -38,6 +39,11 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	[[ "$_lib_path" == "${BASH_SOURCE[0]}" ]] && _lib_path="."
 	SCRIPT_DIR="$(cd "$_lib_path" && pwd)"
 	unset _lib_path
+fi
+
+if [[ -f "${SCRIPT_DIR}/pulse-todo-sync-workspace.sh" ]]; then
+	# shellcheck source=pulse-todo-sync-workspace.sh
+	source "${SCRIPT_DIR}/pulse-todo-sync-workspace.sh"
 fi
 
 #######################################
@@ -508,19 +514,34 @@ _pulse_reconcile_stale_blocked_if_due() {
 #######################################
 _pulse_create_todo_sync_workspace() {
 	local repo_path="$1"
+	local repo_slug="$2"
 	local remote_url=""
-	local temp_base="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
-	local workspace=""
+	: "$repo_slug"
 	remote_url=$(git -C "$repo_path" remote get-url origin 2>/dev/null) || return 1
 	[[ -n "$remote_url" ]] || return 1
-	mkdir -p "$temp_base" || return 1
-	workspace=$(mktemp -d "${temp_base}/pulse-todo-sync.XXXXXX") || return 1
-	if ! git clone --quiet --no-tags "$remote_url" "${workspace}/repo" >/dev/null 2>&1; then
-		rm -rf "$workspace"
-		return 1
+	declare -F _ptsw_create_workspace >/dev/null 2>&1 || return 1
+	_ptsw_create_workspace "$remote_url"
+	return $?
+}
+
+_pulse_todo_sync_exit_cleanup() {
+	local original_rc="$1"
+	local workspace_root="$2"
+	local repo_slug="$3"
+	local lifecycle_stage="$4"
+	local owner_pid="$5"
+	local owner_start="$6"
+	local workspace_identity=""
+	[[ -n "$workspace_root" ]] || return "$original_rc"
+	workspace_identity=$(_ptsw_safe_identity "$workspace_root")
+	if _ptsw_remove_owned_workspace "$workspace_root" "$owner_pid" "$owner_start"; then
+		printf '[pulse-wrapper] TODO ref sync workspace cleanup outcome=removed stage=%s repo=%s workspace=%s\n' \
+			"$lifecycle_stage" "$repo_slug" "$workspace_identity" >>"$WRAPPER_LOGFILE"
+	else
+		printf '[pulse-wrapper] TODO ref sync workspace cleanup outcome=failure stage=%s repo=%s workspace=%s\n' \
+			"$lifecycle_stage" "$repo_slug" "$workspace_identity" >>"$WRAPPER_LOGFILE"
 	fi
-	printf '%s\n' "${workspace}/repo"
-	return 0
+	return "$original_rc"
 }
 
 _pulse_run_issue_sync_stage() {
@@ -542,31 +563,42 @@ _pulse_run_issue_sync_stage() {
 # are logged and returned so the caller can continue other repositories while
 # preserving retryable evidence.
 #######################################
-sync_todo_refs_for_repo() {
+sync_todo_refs_for_repo() (
 	local repo_slug="$1"
 	local repo_path="$2"
 	local script_dir="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)}"
-	local workspace="" workspace_root="" base_sha="" branch_name="" changed_paths=""
+	local workspace="" base_sha="" branch_name="" changed_paths=""
 	local stage="" sync_failed=0 publication_rc=0
+	local lifecycle_stage="workspace"
+	local _pulse_todo_sync_exit_rc=0
+	_PULSE_TODO_SYNC_WORKSPACE=""
+	_PULSE_TODO_SYNC_WORKSPACE_ROOT=""
+	_PULSE_TODO_SYNC_OWNER_PID=""
+	_PULSE_TODO_SYNC_OWNER_START=""
+	trap '_pulse_todo_sync_exit_cleanup "$?" "$_PULSE_TODO_SYNC_WORKSPACE_ROOT" "$repo_slug" "$lifecycle_stage" "$_PULSE_TODO_SYNC_OWNER_PID" "$_PULSE_TODO_SYNC_OWNER_START"; _pulse_todo_sync_exit_rc=$?; trap - EXIT; exit "$_pulse_todo_sync_exit_rc"' EXIT
+	trap 'exit 143' TERM
+	trap 'exit 130' INT
+	trap 'exit 129' HUP
 
-	workspace=$(_pulse_create_todo_sync_workspace "$repo_path") || {
+	lifecycle_stage="clone"
+	_pulse_create_todo_sync_workspace "$repo_path" "$repo_slug" || {
 		printf '[pulse-wrapper] TODO ref sync status=retryable_failure stage=workspace repo=%s\n' \
 			"$repo_slug" >>"$WRAPPER_LOGFILE"
 		return 1
 	}
-	workspace_root="${workspace%/repo}"
+	workspace="$_PULSE_TODO_SYNC_WORKSPACE"
+	lifecycle_stage="metadata"
 	base_sha=$(git -C "$workspace" rev-parse HEAD 2>/dev/null) || {
-		rm -rf "$workspace_root"
 		return 1
 	}
 	branch_name=$(git -C "$workspace" symbolic-ref --short HEAD 2>/dev/null) || {
-		rm -rf "$workspace_root"
 		return 1
 	}
 
 	printf '[pulse-wrapper] Syncing TODO refs: repo=%s root=automation base=%s\n' \
 		"$repo_slug" "${base_sha:0:12}" >>"$WRAPPER_LOGFILE"
 	for stage in pull close reopen; do
+		lifecycle_stage="$stage"
 		if ! _pulse_run_issue_sync_stage "$script_dir" "$stage" "$repo_slug" "$workspace"; then
 			printf '[pulse-wrapper] TODO ref sync status=retryable_failure stage=%s repo=%s\n' \
 				"$stage" "$repo_slug" >>"$WRAPPER_LOGFILE"
@@ -576,19 +608,18 @@ sync_todo_refs_for_repo() {
 	# Materialize TODO dependency edges before the graph and dispatch stages.
 	# Failures remain retryable and the relationship helper moves affected
 	# available issues to blocked rather than exposing an unverified ordering.
+	lifecycle_stage="relationships"
 	if ! _pulse_run_issue_sync_stage "$script_dir" relationships "$repo_slug" "$workspace"; then
 		printf '[pulse-wrapper] TODO ref sync status=retryable_failure stage=relationships repo=%s\n' \
 			"$repo_slug" >>"$WRAPPER_LOGFILE"
 		sync_failed=1
 	fi
 	if [[ "$sync_failed" -ne 0 ]]; then
-		rm -rf "$workspace_root"
 		return 1
 	fi
 
 	if ! declare -F planning_publish >/dev/null 2>&1; then
 		[[ -f "${script_dir}/planning-publisher.sh" ]] || {
-			rm -rf "$workspace_root"
 			return 1
 		}
 		# shellcheck source=planning-publisher.sh
@@ -598,6 +629,7 @@ sync_todo_refs_for_repo() {
 	PLANNING_PUBLISH_RESULT=""
 	PLANNING_PUBLICATION_ID=""
 	PLANNING_PUBLISHED_COMMIT=""
+	lifecycle_stage="publication"
 	TMPDIR="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}" \
 		AIDEVOPS_PLANNING_BASE_SHA="$base_sha" \
 		planning_publish "$workspace" "chore: sync GitHub issue refs to TODO.md [skip ci]" \
@@ -608,11 +640,13 @@ sync_todo_refs_for_repo() {
 	2) printf '[pulse-wrapper] TODO ref sync status=retryable_conflict repo=%s base=%s\n' \
 		"$repo_slug" "${base_sha:0:12}" >>"$WRAPPER_LOGFILE" ;;
 	*) printf '[pulse-wrapper] TODO ref sync status=retryable_failure stage=publication repo=%s rc=%s\n' \
-		"$repo_slug" "$publication_rc" >>"$WRAPPER_LOGFILE" ;;
+			"$repo_slug" "$publication_rc" >>"$WRAPPER_LOGFILE" ;;
 	esac
-	rm -rf "$workspace_root"
+	if [[ "$publication_rc" -eq 0 ]]; then
+		lifecycle_stage="complete"
+	fi
 	return "$publication_rc"
-}
+)
 
 #######################################
 # sync_todo_refs_all_repos

--- a/.agents/scripts/tests/test-issue-sync-project-root.sh
+++ b/.agents/scripts/tests/test-issue-sync-project-root.sh
@@ -315,6 +315,11 @@ kill_workspace=$(only_todo_sync_workspace) || fail "KILL fixture did not expose 
 _ptsw_read_owner_marker "$kill_workspace" || fail "KILL fixture owner marker was invalid"
 kill_owner_pid="$_PTSW_OWNER_PID"
 kill -0 "$kill_owner_pid" 2>/dev/null || fail "workspace marker did not identify a live sync owner"
+if ! pgrep -P "$kill_sync_pid" 2>/dev/null | grep -qx "$kill_owner_pid"; then
+	_force_kill_tree "$kill_sync_pid"
+	wait "$kill_sync_pid" 2>/dev/null || true
+	fail "workspace marker did not identify the sync process child"
+fi
 kill -9 "$kill_owner_pid" 2>/dev/null || fail "could not KILL sync owner"
 kill_wait_rc=0
 wait "$kill_sync_pid" 2>/dev/null || kill_wait_rc=$?

--- a/.agents/scripts/tests/test-issue-sync-project-root.sh
+++ b/.agents/scripts/tests/test-issue-sync-project-root.sh
@@ -172,6 +172,9 @@ sync_todo_refs_for_repo owner/repo-b "$repo_b"
 [[ $(canonical_snapshot "$repo_a") == "$snapshot_a" ]] || fail "repo B invocation changed repo A"
 [[ $(canonical_snapshot "$repo_b") == "$snapshot_b" ]] || fail "repo B canonical checkout changed"
 git --git-dir="$remote_b" show main:TODO.md | grep -q '^synced:owner/repo-b$' || fail "repo B remote was not synced"
+if only_todo_sync_workspace >/dev/null 2>&1; then
+	fail "successful reconciliation left an automation workspace behind"
+fi
 [[ $(trap -p EXIT) == "$parent_exit_trap_before" ]] || fail "sync scope replaced the caller EXIT trap"
 [[ $(trap -p TERM) == "$parent_term_trap_before" ]] || fail "sync scope replaced the caller TERM trap"
 
@@ -200,6 +203,9 @@ AIDEVOPS_PLANNING_BEFORE_PUSH_HOOK=/usr/bin/false \
 [[ $(git --git-dir="$remote_c" rev-parse main) == "$remote_c_before" ]] || fail "failed publication changed remote"
 grep -q 'status=retryable_failure stage=publication repo=owner/repo-c rc=1' "$WRAPPER_LOGFILE" || \
 	fail "publication failure evidence was not logged"
+if only_todo_sync_workspace >/dev/null 2>&1; then
+	fail "retryable publication failure left an automation workspace behind"
+fi
 
 # Cleanup failure is observable without replacing the reconciliation result.
 # Use a retryable-conflict result (2) so a cleanup helper failure cannot be

--- a/.agents/scripts/tests/test-issue-sync-project-root.sh
+++ b/.agents/scripts/tests/test-issue-sync-project-root.sh
@@ -10,6 +10,15 @@ TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="${TEST_DIR}/.."
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin:${PATH}"
+
+# Fixture repositories are intentionally isolated under TMP. Use native Git so
+# the production canonical-worktree shim does not classify them as service
+# mirrors during local verification.
+git() {
+	/usr/bin/git "$@"
+	return $?
+}
 
 fail() {
 	local message="$1"
@@ -73,6 +82,7 @@ fixture_scripts="${TMP}/scripts"
 mkdir -p "$fixture_scripts"
 cp "$SCRIPTS_DIR/pulse-wrapper-cycle.sh" "$fixture_scripts/pulse-wrapper-cycle.sh"
 cp "$SCRIPTS_DIR/planning-publisher.sh" "$fixture_scripts/planning-publisher.sh"
+cp "$SCRIPTS_DIR/pulse-todo-sync-workspace.sh" "$fixture_scripts/pulse-todo-sync-workspace.sh"
 cat >"${fixture_scripts}/issue-sync-helper.sh" <<'FIXTURE'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -97,6 +107,7 @@ chmod +x "${fixture_scripts}/issue-sync-helper.sh"
 
 export CALL_LOG="${TMP}/calls.log"
 export WRAPPER_LOGFILE="${TMP}/pulse.log"
+export LOGFILE="$WRAPPER_LOGFILE"
 export SCRIPT_DIR="$fixture_scripts"
 export AIDEVOPS_TEMP_DIR="${TMP}/automation"
 export AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true
@@ -106,6 +117,34 @@ export GIT_COMMITTER_NAME=Test
 export GIT_COMMITTER_EMAIL=test@example.com
 # shellcheck source=/dev/null
 source "$fixture_scripts/pulse-wrapper-cycle.sh"
+# Keep publication seams available in the parent test shell. Production loads
+# the same module inside the isolated sync scope when it is not already loaded.
+# shellcheck source=/dev/null
+source "$fixture_scripts/planning-publisher.sh"
+
+wait_for_file() {
+	local file_path="$1"
+	local max_attempts="${2:-100}"
+	local attempt=0
+	while [[ ! -e "$file_path" && "$attempt" -lt "$max_attempts" ]]; do
+		sleep 0.1
+		attempt=$((attempt + 1))
+	done
+	[[ -e "$file_path" ]]
+	return $?
+}
+
+only_todo_sync_workspace() {
+	local workspace_root=""
+	local match_count=0
+	for workspace_root in "$AIDEVOPS_TEMP_DIR"/pulse-todo-sync.*; do
+		[[ -d "$workspace_root" ]] || continue
+		match_count=$((match_count + 1))
+		printf '%s\n' "$workspace_root"
+	done
+	[[ "$match_count" -eq 1 ]]
+	return $?
+}
 
 canonical_snapshot() {
 	local root="$1"
@@ -122,6 +161,8 @@ printf '%s\n' 'human canonical dirt A' >>"$repo_a/TODO.md"
 printf '%s\n' 'human canonical dirt B' >>"$repo_b/TODO.md"
 snapshot_a=$(canonical_snapshot "$repo_a")
 snapshot_b=$(canonical_snapshot "$repo_b")
+parent_exit_trap_before=$(trap -p EXIT)
+parent_term_trap_before=$(trap -p TERM)
 sync_todo_refs_for_repo owner/repo-a "$repo_a"
 [[ $(canonical_snapshot "$repo_a") == "$snapshot_a" ]] || fail "repo A canonical checkout changed"
 [[ $(canonical_snapshot "$repo_b") == "$snapshot_b" ]] || fail "repo A invocation changed repo B"
@@ -131,6 +172,8 @@ sync_todo_refs_for_repo owner/repo-b "$repo_b"
 [[ $(canonical_snapshot "$repo_a") == "$snapshot_a" ]] || fail "repo B invocation changed repo A"
 [[ $(canonical_snapshot "$repo_b") == "$snapshot_b" ]] || fail "repo B canonical checkout changed"
 git --git-dir="$remote_b" show main:TODO.md | grep -q '^synced:owner/repo-b$' || fail "repo B remote was not synced"
+[[ $(trap -p EXIT) == "$parent_exit_trap_before" ]] || fail "sync scope replaced the caller EXIT trap"
+[[ $(trap -p TERM) == "$parent_term_trap_before" ]] || fail "sync scope replaced the caller TERM trap"
 
 [[ $(wc -l <"$CALL_LOG" | tr -d ' ') -eq 8 ]] || fail "pulse did not make four bound calls per repository"
 if grep -Fq "|${repo_a}" "$CALL_LOG" || grep -Fq "|${repo_b}" "$CALL_LOG"; then
@@ -157,5 +200,134 @@ AIDEVOPS_PLANNING_BEFORE_PUSH_HOOK=/usr/bin/false \
 [[ $(git --git-dir="$remote_c" rev-parse main) == "$remote_c_before" ]] || fail "failed publication changed remote"
 grep -q 'status=retryable_failure stage=publication repo=owner/repo-c rc=1' "$WRAPPER_LOGFILE" || \
 	fail "publication failure evidence was not logged"
+
+# Cleanup failure is observable without replacing the reconciliation result.
+# Use a retryable-conflict result (2) so a cleanup helper failure cannot be
+# mistaken for the original status.
+repo_cleanup_failure="${TMP}/repo-cleanup-failure"
+remote_cleanup_failure="${TMP}/remote-cleanup-failure.git"
+setup_sync_repo "$repo_cleanup_failure" "$remote_cleanup_failure"
+remove_owned_workspace_definition=$(declare -f _ptsw_remove_owned_workspace)
+planning_publish_definition=$(declare -f planning_publish)
+_ptsw_remove_owned_workspace() {
+	local workspace_root="$1"
+	local expected_pid="$2"
+	local expected_start="$3"
+	: "$workspace_root" "$expected_pid" "$expected_start"
+	return 73
+}
+planning_publish() {
+	local worktree="$1"
+	local commit_message="$2"
+	local remote_name="$3"
+	local branch_name="$4"
+	local changed_paths="$5"
+	: "$worktree" "$commit_message" "$remote_name" "$branch_name" "$changed_paths"
+	PLANNING_PUBLISH_RESULT="retryable_conflict"
+	return 2
+}
+cleanup_failure_rc=0
+sync_todo_refs_for_repo owner/repo-cleanup-failure "$repo_cleanup_failure" || cleanup_failure_rc=$?
+[[ "$cleanup_failure_rc" -eq 2 ]] || fail "cleanup failure replaced retryable reconciliation status"
+grep -q 'workspace cleanup outcome=failure stage=publication repo=owner/repo-cleanup-failure workspace=pulse-todo-sync\.' \
+	"$WRAPPER_LOGFILE" || fail "cleanup failure was not recorded with stage and workspace identity"
+eval "$remove_owned_workspace_definition"
+eval "$planning_publish_definition"
+for leaked_workspace in "$AIDEVOPS_TEMP_DIR"/pulse-todo-sync.*; do
+	[[ -d "$leaked_workspace" ]] || continue
+	rm -rf "$leaked_workspace"
+done
+
+# A watchdog timeout sends TERM through the process tree. The function-local
+# subshell owns its traps, removes the allocated workspace, and leaves caller
+# trap state unchanged while the watchdog preserves its timeout result.
+repo_timeout="${TMP}/repo-timeout"
+remote_timeout="${TMP}/remote-timeout.git"
+setup_sync_repo "$repo_timeout" "$remote_timeout"
+run_issue_sync_stage_definition=$(declare -f _pulse_run_issue_sync_stage)
+export SYNC_BLOCK_MARKER="${TMP}/sync-blocked"
+export SYNC_BLOCK_RELEASE="${TMP}/sync-release"
+rm -f "$SYNC_BLOCK_MARKER" "$SYNC_BLOCK_RELEASE"
+_pulse_run_issue_sync_stage() {
+	local script_dir="$1"
+	local stage="$2"
+	local repo_slug="$3"
+	local workspace="$4"
+	: "$script_dir" "$repo_slug" "$workspace"
+	printf '%s\n' "$stage" >"$SYNC_BLOCK_MARKER"
+	while [[ ! -e "$SYNC_BLOCK_RELEASE" ]]; do
+		sleep 0.1
+	done
+	return 0
+}
+_kill_tree() {
+	local process_pid="$1"
+	local child_pid=""
+	while IFS= read -r child_pid; do
+		[[ -n "$child_pid" ]] && _kill_tree "$child_pid"
+	done < <(pgrep -P "$process_pid" 2>/dev/null || true)
+	kill "$process_pid" 2>/dev/null || true
+	return 0
+}
+_force_kill_tree() {
+	local process_pid="$1"
+	local child_pid=""
+	while IFS= read -r child_pid; do
+		[[ -n "$child_pid" ]] && _force_kill_tree "$child_pid"
+	done < <(pgrep -P "$process_pid" 2>/dev/null || true)
+	kill -9 "$process_pid" 2>/dev/null || true
+	return 0
+}
+unset _PULSE_WATCHDOG_LOADED 2>/dev/null || true
+# shellcheck source=../pulse-watchdog.sh
+source "$SCRIPTS_DIR/pulse-watchdog.sh"
+export PRE_RUN_STAGE_TIMEOUT=1
+timeout_rc=0
+run_stage_with_timeout "sync_todo_refs_all_repos" 1 \
+	sync_todo_refs_for_repo owner/repo-timeout "$repo_timeout" || timeout_rc=$?
+[[ "$timeout_rc" -eq 124 ]] || fail "watchdog timeout status was not preserved"
+[[ -e "$SYNC_BLOCK_MARKER" ]] || fail "watchdog fixture did not reach the allocated workspace stage"
+if only_todo_sync_workspace >/dev/null 2>&1; then
+	fail "TERM timeout left a TODO-sync workspace behind"
+fi
+grep -q 'workspace cleanup outcome=removed stage=pull repo=owner/repo-timeout workspace=pulse-todo-sync\.' \
+	"$WRAPPER_LOGFILE" || fail "TERM cleanup outcome was not recorded"
+[[ $(trap -p EXIT) == "$parent_exit_trap_before" ]] || fail "timeout scope replaced the caller EXIT trap"
+[[ $(trap -p TERM) == "$parent_term_trap_before" ]] || fail "timeout scope replaced the caller TERM trap"
+
+# SIGKILL cannot run EXIT cleanup. Preserve that orphan, age its immutable
+# owner marker, then prove the next bounded sweep moves it recoverably.
+repo_kill="${TMP}/repo-kill"
+remote_kill="${TMP}/remote-kill.git"
+setup_sync_repo "$repo_kill" "$remote_kill"
+export SYNC_BLOCK_MARKER="${TMP}/sync-kill-blocked"
+rm -f "$SYNC_BLOCK_MARKER" "$SYNC_BLOCK_RELEASE"
+sync_todo_refs_for_repo owner/repo-kill "$repo_kill" >/dev/null 2>&1 &
+kill_sync_pid=$!
+wait_for_file "$SYNC_BLOCK_MARKER" || fail "KILL fixture did not allocate a workspace"
+kill_workspace=$(only_todo_sync_workspace) || fail "KILL fixture did not expose exactly one workspace"
+_ptsw_read_owner_marker "$kill_workspace" || fail "KILL fixture owner marker was invalid"
+kill_owner_pid="$_PTSW_OWNER_PID"
+kill -0 "$kill_owner_pid" 2>/dev/null || fail "workspace marker did not identify a live sync owner"
+kill -9 "$kill_owner_pid" 2>/dev/null || fail "could not KILL sync owner"
+kill_wait_rc=0
+wait "$kill_sync_pid" 2>/dev/null || kill_wait_rc=$?
+[[ "$kill_wait_rc" -eq 137 ]] || fail "KILL fixture returned unexpected status"
+[[ -d "$kill_workspace" ]] || fail "KILL fixture did not preserve the orphan for recovery"
+_ptsw_read_owner_marker "$kill_workspace" || fail "orphan owner marker became invalid"
+old_owner_created=$(($(date +%s) - 10))
+printf '%s\t%s\t%s\t%s\n' "$_PTSW_MARKER_VERSION" "$_PTSW_OWNER_PID" \
+	"$old_owner_created" "$_PTSW_OWNER_START" >"${kill_workspace}/${_PTSW_OWNER_MARKER}"
+export PULSE_TODO_SYNC_WORKSPACE_GRACE_SECS=2
+export PULSE_TODO_SYNC_MAX_RECOVERIES_PER_RUN=1
+export AIDEVOPS_TODO_SYNC_TRASH_ROOT="${TMP}/todo-sync-trash"
+kill_recovered=$(_ptsw_sweep_stale_workspaces)
+[[ "$kill_recovered" == "1" ]] || fail "later sweep did not recover the KILL orphan"
+[[ ! -e "$kill_workspace" ]] || fail "KILL orphan remained in the active temp root"
+grep -q 'stale cleanup outcome=removed reason=dead-owner workspace=pulse-todo-sync\.' \
+	"$WRAPPER_LOGFILE" || fail "KILL orphan recovery was not audited"
+eval "$run_issue_sync_stage_definition"
+unset PULSE_TODO_SYNC_WORKSPACE_GRACE_SECS PULSE_TODO_SYNC_MAX_RECOVERIES_PER_RUN \
+	AIDEVOPS_TODO_SYNC_TRASH_ROOT SYNC_BLOCK_MARKER SYNC_BLOCK_RELEASE
 
 printf 'PASS: issue sync automation-workspace contract\n'

--- a/.agents/scripts/tests/test-pulse-temp-worktree-cleanup.sh
+++ b/.agents/scripts/tests/test-pulse-temp-worktree-cleanup.sh
@@ -61,10 +61,15 @@ setup_subject() {
 	export AIDEVOPS_REPOS_JSON="${HOME}/.config/aidevops/repos.json"
 	export AIDEVOPS_CLEANUP_LOG="${TEST_ROOT}/cleanup.log"
 	export LOGFILE="${TEST_ROOT}/pulse.log"
+	export AIDEVOPS_TEMP_DIR="${TEST_ROOT}/automation"
+	export AIDEVOPS_TODO_SYNC_TRASH_ROOT="${TEST_ROOT}/todo-sync-trash"
 	export TEMP_WORKTREE_GRACE_SECS=3600
 	export TEMP_WORKTREE_MAX_REMOVALS_PER_RUN=10
+	export PRE_RUN_STAGE_TIMEOUT=10
+	export PULSE_TODO_SYNC_WORKSPACE_GRACE_SECS=11
+	export PULSE_TODO_SYNC_MAX_RECOVERIES_PER_RUN=5
 	unset TEMP_WORKTREE_LOCK_STALE_SECS 2>/dev/null || true
-	mkdir -p "$AIDEVOPS_LOG_DIR" "${HOME}/.config/aidevops" || return 1
+	mkdir -p "$AIDEVOPS_LOG_DIR" "${HOME}/.config/aidevops" "$AIDEVOPS_TEMP_DIR" || return 1
 
 	is_registered_canonical() { local wt_path="$1"; : "$wt_path"; return 1; }
 	is_worktree_owned_by_others() { local wt_path="$1"; : "$wt_path"; return 1; }
@@ -75,6 +80,7 @@ setup_subject() {
 
 	unset _PULSE_CLEANUP_LOADED 2>/dev/null || true
 	unset _PULSE_TEMP_WORKTREE_CLEANUP_LOADED 2>/dev/null || true
+	unset _PULSE_TODO_SYNC_WORKSPACE_LOADED 2>/dev/null || true
 	unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
 	# shellcheck source=../portable-stat.sh
 	source "${SCRIPT_DIR}/../portable-stat.sh"
@@ -99,6 +105,30 @@ create_repo_with_remote() {
 	git -C "$remote_path" symbolic-ref HEAD refs/heads/main || return 1
 	printf '{"initialized_repos":[{"path":"%s","slug":"example/repo"}]}\n' \
 		"$repo_path" >"$AIDEVOPS_REPOS_JSON" || return 1
+	return 0
+}
+
+create_todo_sync_candidate() {
+	local identity="$1"
+	local owner_pid="$2"
+	local owner_start="$3"
+	local owner_created="$4"
+	local workspace_root="${AIDEVOPS_TEMP_DIR}/${identity}"
+	mkdir -p "$workspace_root" || return 1
+	printf '%s\t%s\t%s\t%s\n' "$_PTSW_MARKER_VERSION" "$owner_pid" \
+		"$owner_created" "$owner_start" >"${workspace_root}/${_PTSW_OWNER_MARKER}" || return 1
+	printf '%s\n' "$workspace_root"
+	return 0
+}
+
+count_todo_sync_candidates() {
+	local workspace_root=""
+	local candidate_count=0
+	for workspace_root in "$AIDEVOPS_TEMP_DIR"/pulse-todo-sync.*; do
+		[[ -d "$workspace_root" ]] || continue
+		candidate_count=$((candidate_count + 1))
+	done
+	printf '%s\n' "$candidate_count"
 	return 0
 }
 
@@ -372,6 +402,98 @@ test_path_classifier_rejects_normal_linked_worktree() {
 	return 0
 }
 
+test_todo_sync_active_grace_and_visibility_guards() {
+	teardown
+	setup_subject || return 1
+	local now_epoch=0
+	local live_start=""
+	local active_workspace=""
+	local grace_workspace=""
+	local unknown_workspace=""
+	local visibility_definition=""
+	local removed=0
+	local rc=0
+	now_epoch=$(date +%s) || return 1
+	live_start=$(_ptsw_process_start_fingerprint "$$") || return 1
+	active_workspace=$(create_todo_sync_candidate "pulse-todo-sync.ACTIVE" "$$" "$live_start" "$((now_epoch - 20))") || return 1
+	grace_workspace=$(create_todo_sync_candidate "pulse-todo-sync.GRACE1" "99999991" "dead-owner" "$now_epoch") || return 1
+	unknown_workspace=$(create_todo_sync_candidate "pulse-todo-sync.UNKNWN" "99999992" "dead-owner" "$((now_epoch - 20))") || return 1
+	visibility_definition=$(declare -f _ptsw_process_visibility_available)
+	_ptsw_process_visibility_available() { return 1; }
+
+	removed=$(cleanup_stale_temp_worktrees) || rc=1
+	eval "$visibility_definition"
+	[[ "$removed" == "0" ]] || rc=1
+	[[ -d "$active_workspace" && -d "$grace_workspace" && -d "$unknown_workspace" ]] || rc=1
+	grep -q 'reason=active-owner workspace=pulse-todo-sync.ACTIVE' "$LOGFILE" 2>/dev/null || rc=1
+	grep -q 'reason=grace-period workspace=pulse-todo-sync.GRACE1' "$LOGFILE" 2>/dev/null || rc=1
+	grep -q 'reason=owner-visibility-unknown workspace=pulse-todo-sync.UNKNWN' "$LOGFILE" 2>/dev/null || rc=1
+	print_result "TODO-sync cleanup preserves active, fresh, and visibility-unknown owners" "$rc" \
+		"removed=$removed"
+	return 0
+}
+
+test_todo_sync_stale_recovery_name_guard_and_cap() {
+	teardown
+	setup_subject || return 1
+	local now_epoch=0
+	local first_workspace=""
+	local second_workspace=""
+	local malformed_workspace=""
+	local remaining=0
+	local trash_count=0
+	local trash_path=""
+	local removed=0
+	local rc=0
+	now_epoch=$(date +%s) || return 1
+	export PULSE_TODO_SYNC_MAX_RECOVERIES_PER_RUN=1
+	first_workspace=$(create_todo_sync_candidate "pulse-todo-sync.AAAAAA" "99999993" "dead-owner" "$((now_epoch - 20))") || return 1
+	second_workspace=$(create_todo_sync_candidate "pulse-todo-sync.BBBBBB" "99999994" "dead-owner" "$((now_epoch - 20))") || return 1
+	malformed_workspace=$(create_todo_sync_candidate "pulse-todo-sync.bad-name" "99999995" "dead-owner" "$((now_epoch - 20))") || return 1
+
+	removed=$(cleanup_stale_temp_worktrees) || rc=1
+	[[ "$removed" == "1" ]] || rc=1
+	remaining=$(count_todo_sync_candidates)
+	[[ "$remaining" == "2" ]] || rc=1
+	[[ -d "$malformed_workspace" ]] || rc=1
+	if [[ ! -d "$first_workspace" && ! -d "$second_workspace" ]]; then
+		rc=1
+	fi
+	for trash_path in "$AIDEVOPS_TODO_SYNC_TRASH_ROOT"/aidevops-pulse-todo-sync-*; do
+		[[ -d "$trash_path" ]] || continue
+		trash_count=$((trash_count + 1))
+	done
+	[[ "$trash_count" -eq 1 ]] || rc=1
+	grep -q 'outcome=removed reason=dead-owner workspace=pulse-todo-sync\.' "$LOGFILE" 2>/dev/null || rc=1
+	grep -q 'reason=recovery-cap workspace=pulse-todo-sync\.' "$LOGFILE" 2>/dev/null || rc=1
+	grep -q 'reason=malformed-name workspace=pulse-todo-sync.bad-name' "$LOGFILE" 2>/dev/null || rc=1
+	print_result "TODO-sync cleanup trashes only valid stale candidates within its cap" "$rc" \
+		"removed=$removed remaining=$remaining trash_count=$trash_count"
+	return 0
+}
+
+test_todo_sync_trash_failure_is_audited() {
+	teardown
+	setup_subject || return 1
+	local now_epoch=0
+	local workspace_root=""
+	local blocked_trash="${TEST_ROOT}/blocked-trash"
+	local removed=0
+	local rc=0
+	now_epoch=$(date +%s) || return 1
+	workspace_root=$(create_todo_sync_candidate "pulse-todo-sync.FAIL01" "99999996" "dead-owner" "$((now_epoch - 20))") || return 1
+	printf 'not a directory\n' >"$blocked_trash" || return 1
+	export AIDEVOPS_TODO_SYNC_TRASH_ROOT="$blocked_trash"
+
+	removed=$(cleanup_stale_temp_worktrees) || rc=1
+	[[ "$removed" == "0" ]] || rc=1
+	[[ -d "$workspace_root" ]] || rc=1
+	grep -q 'outcome=failure reason=trash-move-failed workspace=pulse-todo-sync.FAIL01' "$LOGFILE" 2>/dev/null || rc=1
+	print_result "TODO-sync trash failures remain recoverable and auditable" "$rc" \
+		"removed=$removed candidate_exists=$([[ -d "$workspace_root" ]] && printf y || printf n)"
+	return 0
+}
+
 run_test() {
 	local test_function="$1"
 	local tests_before="$TESTS_RUN"
@@ -394,6 +516,9 @@ run_test test_degraded_visibility_preserves_temp_candidate
 run_test test_cleanup_lock_race_guards
 run_test test_stale_local_main_uses_remote_default
 run_test test_path_classifier_rejects_normal_linked_worktree
+run_test test_todo_sync_active_grace_and_visibility_guards
+run_test test_todo_sync_stale_recovery_name_guard_and_cap
+run_test test_todo_sync_trash_failure_is_audited
 
 printf '\nResults: %s/%s passed, %s failed.\n' \
 	"$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-pulse-temp-worktree-cleanup.sh
+++ b/.agents/scripts/tests/test-pulse-temp-worktree-cleanup.sh
@@ -433,6 +433,39 @@ test_todo_sync_active_grace_and_visibility_guards() {
 	return 0
 }
 
+test_todo_sync_live_pid_with_hidden_identity_is_preserved() {
+	teardown
+	setup_subject || return 1
+	local now_epoch=0
+	local live_start=""
+	local workspace_root=""
+	local visibility_definition=""
+	local ps_definition=""
+	local removed=0
+	local rc=0
+	now_epoch=$(date +%s) || return 1
+	live_start=$(_ptsw_process_start_fingerprint "$$") || return 1
+	workspace_root=$(create_todo_sync_candidate "pulse-todo-sync.LIVEID" "$$" "$live_start" "$((now_epoch - 20))") || return 1
+	visibility_definition=$(declare -f _ptsw_process_visibility_available)
+	ps_definition=$(declare -f ps 2>/dev/null || true)
+	_ptsw_process_visibility_available() { return 0; }
+	ps() { return 1; }
+
+	removed=$(_ptsw_sweep_stale_workspaces) || rc=1
+	eval "$visibility_definition"
+	if [[ -n "$ps_definition" ]]; then
+		eval "$ps_definition"
+	else
+		unset -f ps
+	fi
+	[[ "$removed" == "0" ]] || rc=1
+	[[ -d "$workspace_root" ]] || rc=1
+	grep -q 'reason=owner-visibility-unknown workspace=pulse-todo-sync.LIVEID' "$LOGFILE" 2>/dev/null || rc=1
+	print_result "TODO-sync cleanup fails closed for a live PID with hidden identity" "$rc" \
+		"removed=$removed"
+	return 0
+}
+
 test_todo_sync_stale_recovery_name_guard_and_cap() {
 	teardown
 	setup_subject || return 1
@@ -517,6 +550,7 @@ run_test test_cleanup_lock_race_guards
 run_test test_stale_local_main_uses_remote_default
 run_test test_path_classifier_rejects_normal_linked_worktree
 run_test test_todo_sync_active_grace_and_visibility_guards
+run_test test_todo_sync_live_pid_with_hidden_identity_is_preserved
 run_test test_todo_sync_stale_recovery_name_guard_and_cap
 run_test test_todo_sync_trash_failure_is_audited
 


### PR DESCRIPTION
## Summary

Add owned lifecycle metadata and stale recovery for isolated TODO-sync workspaces, integrate bounded sweeping into temp cleanup, and cover success, retryable, signal, KILL, active-owner, degraded-visibility, grace, malformed-name, cap, and trash-failure paths.

## Files Changed

.agents/scripts/pulse-temp-worktree-cleanup.sh, .agents/scripts/pulse-todo-sync-workspace.sh, .agents/scripts/pulse-wrapper-cycle.sh, .agents/scripts/tests/test-issue-sync-project-root.sh, .agents/scripts/tests/test-pulse-temp-worktree-cleanup.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — bash .agents/scripts/tests/test-issue-sync-project-root.sh; bash .agents/scripts/tests/test-pulse-temp-worktree-cleanup.sh (11/11); shellcheck on all changed shell files; .agents/scripts/linters-local.sh

Resolves #28752


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 54m and 447,945 tokens on this with the user in an interactive session.