### PR TITLE
GH#28756: clean up synchronous systemd service cgroups

### DIFF
--- a/.agents/scripts/auto-update-helper-scheduler.sh
+++ b/.agents/scripts/auto-update-helper-scheduler.sh
@@ -269,7 +269,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-KillMode=process
+KillMode=control-group
 ExecStart=/bin/bash -lc '${script_path} check'
 WorkingDirectory=${agents_dir}
 TimeoutStartSec=120

--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -969,7 +969,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-KillMode=process
+KillMode=control-group
 ExecStart=/bin/bash -lc '\"${script_path}\" check'
 TimeoutStartSec=120
 Nice=10

--- a/.agents/scripts/deferred-job-scheduler.sh
+++ b/.agents/scripts/deferred-job-scheduler.sh
@@ -101,6 +101,8 @@ After=network.target
 
 [Service]
 Type=oneshot
+# Intentional exception: manual dispatch can hand a worker off beyond run-due.
+# Killing this cgroup when the scheduler exits would terminate that worker.
 KillMode=process
 ExecStart=$(_dj_systemd_quote "/bin/bash") $(_dj_systemd_quote "$helper_path") run-due
 TimeoutStartSec=infinity

--- a/.agents/scripts/repo-aidevops-health-helper.sh
+++ b/.agents/scripts/repo-aidevops-health-helper.sh
@@ -1055,7 +1055,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-KillMode=process
+KillMode=control-group
 ExecStart=/bin/bash -lc '\"${script_path}\" check'
 TimeoutStartSec=300
 Nice=10

--- a/.agents/scripts/repo-sync-helper.sh
+++ b/.agents/scripts/repo-sync-helper.sh
@@ -805,7 +805,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-KillMode=process
+KillMode=control-group
 ExecStart=/bin/bash -lc '\"${script_path}\" check'
 TimeoutStartSec=300
 Nice=10

--- a/.agents/scripts/routine-helper.sh
+++ b/.agents/scripts/routine-helper.sh
@@ -459,7 +459,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-KillMode=process
+KillMode=control-group
 ExecStart=/bin/bash -lc $(_systemd_escape "$command")
 Environment=HOME=${HOME}
 Environment=PATH=${PATH}

--- a/.agents/scripts/setup/modules/schedulers-linux.sh
+++ b/.agents/scripts/setup/modules/schedulers-linux.sh
@@ -171,9 +171,7 @@ _install_scheduler_systemd() {
 	fi
 
 	local _service_extra=""
-	local _kill_mode="process"
 	if [[ "$service_name" == "aidevops-supervisor-pulse" ]]; then
-		_kill_mode="control-group"
 		_service_extra+="TimeoutStopSec=30"$'\n'
 		_service_extra+="SendSIGKILL=yes"$'\n'
 	fi
@@ -188,7 +186,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-KillMode=${_kill_mode}
+KillMode=control-group
 ExecStart=/bin/bash -lc $(_systemd_escape "$exec_command")
 TimeoutStartSec=${timeout_sec}
 ${_service_extra}${_env_lines}StandardOutput=append:${log_file}

--- a/.agents/scripts/tests/test-deferred-job-helper.sh
+++ b/.agents/scripts/tests/test-deferred-job-helper.sh
@@ -348,6 +348,18 @@ test_manual_issue_dispatch_and_scheduler_rendering() {
 	return 0
 }
 
+test_deferred_scheduler_preserves_child_survival_exception() {
+	reset_fixture scheduler-policy
+	local rendered=""
+	rendered=$(run_helper_at "$NOW_EPOCH" render-scheduler systemd)
+	if [[ "$rendered" == *"KillMode=process"* && "$rendered" != *"KillMode=control-group"* ]]; then
+		result "deferred scheduler preserves its explicit child-survival exception" 0
+	else
+		result "deferred scheduler preserves its explicit child-survival exception" 1 "$rendered"
+	fi
+	return 0
+}
+
 test_purge_removes_only_owned_state() {
 	reset_fixture purge
 	local job_id=""
@@ -377,6 +389,7 @@ main() {
 	test_claim_recovery_and_running_fuse
 	test_failed_preflight_is_durable
 	test_manual_issue_dispatch_and_scheduler_rendering
+	test_deferred_scheduler_preserves_child_survival_exception
 	test_purge_removes_only_owned_state
 	printf '\n%s/%s tests passed.\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"
 	[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-routine-systemd-calendar.sh
+++ b/.agents/scripts/tests/test-routine-systemd-calendar.sh
@@ -125,6 +125,30 @@ test_execstart_uses_systemd_quoting() {
 	return 0
 }
 
+test_service_uses_control_group_cleanup() {
+	local tmp_home=""
+	local service_file=""
+	local kill_mode=""
+	tmp_home=$(mktemp -d)
+	service_file="${tmp_home}/.config/systemd/user/sh.aidevops.routine-test.service"
+
+	HOME="$tmp_home" "$ROUTINE_HELPER" install-systemd \
+		--name test \
+		--schedule '0 9 * * *' \
+		--dir "$tmp_home" \
+		--prompt 'test prompt' >/dev/null 2>&1
+	kill_mode=$(grep '^KillMode=' "$service_file" 2>/dev/null || true)
+
+	if [[ "$kill_mode" == "KillMode=control-group" ]]; then
+		print_result "routine service uses control-group cleanup" 0
+	else
+		print_result "routine service uses control-group cleanup" 1 \
+			"Expected KillMode=control-group, got: ${kill_mode:-missing}"
+	fi
+	rm -rf "$tmp_home"
+	return 0
+}
+
 test_daily_expression_supported() {
 	local output=""
 	output=$("${REPO_SCRIPTS_DIR}/routine-schedule-helper.sh" systemd-calendar 'daily(@03:30)')
@@ -172,6 +196,7 @@ main() {
 	test_numeric_weekday_keeps_prefix
 	test_step_minutes_supported
 	test_execstart_uses_systemd_quoting
+	test_service_uses_control_group_cleanup
 	test_daily_expression_supported
 	test_pulse_step_minutes_supported
 	test_empty_schedule_fails_cleanly

--- a/.agents/scripts/tests/test-systemd-unit-generation.sh
+++ b/.agents/scripts/tests/test-systemd-unit-generation.sh
@@ -14,6 +14,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit
+REPO_SCRIPTS_DIR="${REPO_ROOT}/.agents/scripts"
+
+# shellcheck source=../setup/modules/schedulers-linux.sh
+source "${REPO_SCRIPTS_DIR}/setup/modules/schedulers-linux.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -41,10 +46,10 @@ print_result() {
 	return 0
 }
 
-skip_if_no_systemd_analyze() {
+systemd_analyze_available() {
 	if ! command -v systemd-analyze >/dev/null 2>&1; then
-		printf 'SKIP: systemd-analyze not available\n'
-		exit 0
+		printf 'SKIP: systemd-analyze not available; parse checks omitted\n'
+		return 1
 	fi
 	return 0
 }
@@ -60,7 +65,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-KillMode=process
+KillMode=control-group
 ExecStart=/bin/bash -lc 'echo hello'
 TimeoutStartSec=60
 StandardOutput=append:${log_file}
@@ -81,7 +86,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-KillMode=process
+KillMode=control-group
 ExecStart=/bin/bash -lc 'echo check'
 TimeoutStartSec=120
 Nice=10
@@ -104,7 +109,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-KillMode=process
+KillMode=control-group
 ExecStart=/bin/bash -lc 'echo sync'
 TimeoutStartSec=300
 Nice=10
@@ -138,6 +143,65 @@ StandardError=append:${log_file}
 [Install]
 WantedBy=multi-user.target
 " >"$service_file"
+	return 0
+}
+
+test_real_scheduler_unit_uses_control_group() {
+	local tmpdir=""
+	local service_name="aidevops-killmode-test-$$"
+	local service_file=""
+	local kill_mode=""
+	tmpdir=$(mktemp -d)
+	service_file="${tmpdir}/home/.config/systemd/user/${service_name}.service"
+	mkdir -p "${tmpdir}/bin" "${tmpdir}/home"
+	printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"${tmpdir}/bin/systemctl"
+	chmod +x "${tmpdir}/bin/systemctl"
+
+	(
+		export HOME="${tmpdir}/home"
+		export PATH="${tmpdir}/bin:${PATH}"
+		_install_scheduler_systemd "$service_name" "true" "60" \
+			"${tmpdir}/scheduler.log" "" "false" "false" "" "60" >/dev/null 2>&1 || true
+	)
+	kill_mode=$(grep -E '^KillMode=' "$service_file" 2>/dev/null || true)
+	rm -rf "$tmpdir"
+
+	if [[ "$kill_mode" == "KillMode=control-group" ]]; then
+		print_result "real shared scheduler unit uses control-group cleanup" 0
+	else
+		print_result "real shared scheduler unit uses control-group cleanup" 1 \
+			"Expected KillMode=control-group, got: ${kill_mode:-missing}"
+	fi
+	return 0
+}
+
+test_standalone_templates_use_control_group() {
+	local relative_path=""
+	local template_path=""
+	local failures=""
+	local -a templates=(
+		"auto-update-helper.sh"
+		"auto-update-helper-scheduler.sh"
+		"routine-helper.sh"
+		"repo-aidevops-health-helper.sh"
+		"repo-sync-helper.sh"
+		"worker-watchdog-cmd.sh"
+		"setup/modules/schedulers-linux.sh"
+	)
+
+	for relative_path in "${templates[@]}"; do
+		template_path="${REPO_SCRIPTS_DIR}/${relative_path}"
+		if ! grep -q '^KillMode=control-group$' "$template_path" || grep -q '^KillMode=process$' "$template_path"; then
+			failures+="${relative_path} "
+		fi
+	done
+
+	if [[ -z "$failures" ]]; then
+		print_result "synchronous systemd templates use control-group cleanup" 0
+	else
+		print_result "synchronous systemd templates use control-group cleanup" 1 \
+			"Unexpected KillMode policy in: ${failures% }"
+	fi
 	return 0
 }
 
@@ -369,21 +433,23 @@ test_no_literal_quotes_in_reposync_unit() {
 # --- Main ---
 
 main() {
-	skip_if_no_systemd_analyze
-
 	printf 'Running systemd unit generation tests...\n\n'
+	test_real_scheduler_unit_uses_control_group
+	test_standalone_templates_use_control_group
 
-	# Confirm the bug exists with quoted values (regression anchor)
-	test_quoted_stdout_fails_verify
+	if systemd_analyze_available; then
+		# Confirm the bug exists with quoted values (regression anchor)
+		test_quoted_stdout_fails_verify
 
-	# Confirm bare values work
-	test_bare_stdout_passes_verify
+		# Confirm bare values work
+		test_bare_stdout_passes_verify
 
-	# Test each generator produces valid units
-	test_scheduler_unit_passes_verify
-	test_autoupdate_unit_passes_verify
-	test_reposync_unit_passes_verify
-	test_supervisor_pulse_unit_uses_control_group_kill
+		# Test each generator produces valid units
+		test_scheduler_unit_passes_verify
+		test_autoupdate_unit_passes_verify
+		test_reposync_unit_passes_verify
+		test_supervisor_pulse_unit_uses_control_group_kill
+	fi
 
 	# Test no literal quotes appear in generated output
 	test_no_literal_quotes_in_scheduler_unit

--- a/.agents/scripts/worker-watchdog-cmd.sh
+++ b/.agents/scripts/worker-watchdog-cmd.sh
@@ -533,7 +533,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-KillMode=process
+KillMode=control-group
 ExecStart=/bin/bash -lc '${script_path} --check'
 TimeoutStartSec=120
 Nice=10


### PR DESCRIPTION
## Summary

Use control-group cleanup for synchronous systemd one-shot services, preserve and document the deferred-job handoff exception, and add focused policy regression coverage.

## Files Changed

.agents/scripts/auto-update-helper-scheduler.sh, .agents/scripts/auto-update-helper.sh, .agents/scripts/deferred-job-scheduler.sh, .agents/scripts/repo-aidevops-health-helper.sh, .agents/scripts/repo-sync-helper.sh, .agents/scripts/routine-helper.sh, .agents/scripts/setup/modules/schedulers-linux.sh, .agents/scripts/tests/test-deferred-job-helper.sh, .agents/scripts/tests/test-routine-systemd-calendar.sh, .agents/scripts/tests/test-systemd-unit-generation.sh, .agents/scripts/worker-watchdog-cmd.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash -n and ShellCheck passed for all 11 changed shell files; systemd unit tests 5/5, routine tests 8/8, deferred-job tests 13/13; linters-local passed. systemd-analyze and a live Linux user manager were unavailable on macOS.

Resolves #28756


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 30m and 567,523 tokens on this with the user in an interactive session.