### PR TITLE
GH#28669: Add bounded Meta account knowledge ingestion

### DIFF
--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -34,9 +34,9 @@ a claim that the route is enabled.
 | Reddit | **Live** submissions and comments | **Live** saved, votes, and hidden | **Live** mentions, replies, inbox, and sent | **Live** subreddit and account relationships | **Live** multireddits and membership | PRAW 8, bounded one-page reads, independent cursors, and provider-window coverage. |
 | YouTube | **Live** uploads; **Live/Partial** activity | **Live** likes; **No/Export** watch history and Watch Later | **Live/Gate** channel-related comments and replies; **No/Export** complete authored history | **Live** outbound subscriptions | **Live** owned playlists and membership; **No/Export** saved playlists | `youtube.readonly` user OAuth, identity recheck per page, bounded list quota, 30-day refresh/delete boundary, and explicit gap rows. |
 | LinkedIn | **Live/Gate/Export** posts and articles | **Live/Gate/Export** comments, reactions, and saved items | **Live/Gate/Export** messages | **Live/Gate/Export** follows, connections, company follows, and groups | **No** newsletter subscriptions | Ten GET-only Member Snapshot streams for eligible EEA/Swiss members; account download remains an unwired export fallback. |
-| Facebook | **Gate/Export** | **Gate/Export** | **Gate/Export** | **Gate/Export** | **Gate/Export** | Shared Meta authorization needs app-review and product-specific evidence. |
-| Instagram | **Gate/Export** media | **Gate/Export** | **Gate/Export** comments and mentions | **Gate/Export** | **Export/No** | Verify Professional versus personal-account coverage before implementation. |
-| Threads | **API/Gate/Export** | **API/Gate/Export** | **API/Gate/Export** replies | **Gate/Export** | **No** until verified | Keep authorization and gaps distinct from Facebook and Instagram despite shared Meta identity. |
+| Facebook | **Live/Gate/Export** managed Page posts; **No/Export** personal profile | **No/Export** curated activity and per-post comments | **No/Export** | **No/Export** personal relationships | **No** | One managed-Page `/posts` stream; app review and Page authority remain explicit, with all personal-account categories excluded. |
+| Instagram | **Live/Gate/Export** Professional media | **No/Export** comments and saved activity | **No/Export** mentions | **No/Export** followers and following | **No/Export** saved collections | One Page-connected Business/Creator `/media` stream; personal accounts and unimplemented per-media edges remain explicit. |
+| Threads | **Live/Gate/Export** posts | **No/Export** likes and repost history | **Live/Gate/Export** authored replies and mentions; **No** messages | **No/Export** followers and following | **No** custom feeds | Three product-scoped streams with app-scoped identity, independent cursors, and stream-specific permission gates. |
 | Medium | **Export/Gate** | **Export/No** | **Export/No** | **Export/No** | **Export/No** | Archive-first; legacy or restricted integration access is not sufficient evidence for live parity. |
 | Quora | **Export** | **Export/No** | **Export/No** | **Export/No** | **No** | No general live account API is accepted without new official evidence. |
 | Skool | **Gate/Export/Gap** | **Gate/Export/Gap** | **Gate/Export/Gap** | **Gate/Export/Gap** | **Gate/Export/Gap** | Verify member versus community-admin access and provider terms before selecting any route. |
@@ -86,6 +86,17 @@ a claim that the route is enabled.
   `.agents/content/social-linkedin.md` records the official regional/product
   gates, `202312` endpoint version, 28-day changelog boundary, account export,
   storage terms, and explicit newsletter disposition checked on 2026-07-27.
+- **Live Meta products:** `.agents/scripts/knowledge_social_meta.py`,
+  `.agents/scripts/_knowledge_social_meta*.py`, and
+  `.agents/tests/test-knowledge-social-meta.sh` prove separately namespaced
+  Facebook, Instagram, and Threads identities, stream registries, OAuth token
+  filters, checkpoints, coverage gaps, GET-only transport, field allowlists,
+  cursor sanitization, and atomic fenced persistence. Facebook enables managed
+  Page posts, Instagram enables Page-connected Professional media, and Threads
+  enables posts, authored replies, and mentions. `.agents/content/social-meta.md`
+  records the official SDK/sample versions, account/app-review gates, scopes,
+  pagination, retention boundary, export dispositions, and unsupported
+  categories checked on 2026-07-27.
 - **All candidate rows:** the provider child owns current official documentation,
   account/export samples, auth scopes, dependency versions, local exported
   symbols, retention evidence, and explicit unsupported findings.

--- a/.agents/content/social-meta.md
+++ b/.agents/content/social-meta.md
@@ -1,0 +1,176 @@
+---
+description: Bounded Facebook, Instagram, and Threads account knowledge ingestion
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  webfetch: true
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Meta Account Knowledge
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Collector**: `knowledge-social-helper.sh sync-meta`
+- **Products**: `facebook`, `instagram`, or `threads`; select exactly one
+- **Auth**: externally provisioned product token, never a browser session
+- **Live routes**: managed Facebook Page posts, Instagram Professional media,
+  and Threads posts, authored replies, or mentions
+- **Isolation**: one filtered token, stable identity, provider namespace, stream
+  registry, checkpoint, and coverage record per product
+- **Mutation boundary**: collector modules issue only allowlisted `GET` requests
+
+<!-- AI-CONTEXT-END -->
+
+## Evidence boundary
+
+The account-knowledge routes were revalidated on 2026-07-27. The local runtime
+has Python 3.14.3 and standard-library `urllib.request.Request` and `urlopen`
+exports. `facebook-sdk`, `facebook-business`, `requests`, and `urllib3` are not
+installed. The collector therefore maps only HTTP status classes and documented
+response fields; it does not import a third-party Meta client or guess SDK error
+symbols.
+
+The official Python Business SDK release `25.0.3`, published 2026-07-17, is the
+version reference for Facebook and Instagram Graph surfaces:
+https://github.com/facebook/facebook-python-business-sdk/releases/tag/25.0.3.
+Its generated Page object exposes the GET-only `/posts` edge and documented Page
+Post fields:
+https://github.com/facebook/facebook-python-business-sdk/blob/542e10e31c40f7925f9ac03c000922a2fd0a2365/facebook_business/adobjects/page.py.
+Its generated IG User object exposes the GET-only `/media` edge and the selected
+media fields:
+https://github.com/facebook/facebook-python-business-sdk/blob/542e10e31c40f7925f9ac03c000922a2fd0a2365/facebook_business/adobjects/iguser.py.
+
+The official Threads sample is the route and field reference for app-scoped
+identity, `/me/threads`, `/me/replies`, and `/me/mentions`:
+https://github.com/fbsamples/threads_api. The source checkpoint reviewed was
+https://github.com/fbsamples/threads_api/commit/854fc140a37e20f6a7086cf3ee0065f99d41f646.
+The sample source uses `graph.threads.com`; its synchronized Postman collection
+still names `graph.threads.net`. The collector sends reads only to the current
+sample source host and accepts cursor metadata from either official host after
+requiring the exact versioned edge and matching `after` cursor.
+
+## Authorization boundary
+
+Store each token outside git as:
+
+```text
+META_<PROFILE>_<FACEBOOK|INSTAGRAM|THREADS>_ACCESS_TOKEN
+```
+
+Use `aidevops secret set` rather than a project file. The parent process exposes
+only the token for the selected profile and product to the read subprocess.
+Facebook, Instagram, and Threads tokens are not interchangeable merely because
+Meta operates each product.
+
+| Product | Stable identity | Required gate recorded by the collector |
+|---|---|---|
+| Facebook | Selected numeric managed Page ID | Page access token, Page authority, `pages_read_engagement`; `pages_show_list` is relevant to external provisioning; app review applies outside app-role accounts. |
+| Instagram | Selected numeric Page-connected IG User ID | Business or Creator account, connected Facebook Page, `instagram_basic`, `pages_read_engagement`, and applicable review. Personal accounts are not accepted as covered. |
+| Threads | App-scoped numeric `/me` ID | Threads app user token and product-specific reviewed scopes: `threads_basic`, plus `threads_read_replies` or `threads_manage_mentions` for the selected stream. |
+
+Official Facebook Login for Business context:
+https://developers.facebook.com/docs/facebook-login/facebook-login-for-business.
+The official Instagram sample records the Business-account, connected-Page, and
+Page-task gates at https://github.com/fbsamples/original-coast-clothing-ig and
+links the product overview at
+https://developers.facebook.com/docs/instagram-api/overview#pages and
+https://developers.facebook.com/docs/instagram-api/overview#tasks.
+
+The official Threads sample requests `threads_basic`, `threads_read_replies`,
+and `threads_manage_mentions` among its product permissions. See
+https://github.com/fbsamples/threads_api/blob/854fc140a37e20f6a7086cf3ee0065f99d41f646/src/index.js
+and the access-token guide at
+https://developers.facebook.com/docs/threads/get-started/get-access-tokens-and-permissions.
+Token provisioning and long-lived-token refresh remain operator-owned; see
+https://developers.facebook.com/docs/threads/get-started/long-lived-tokens.
+
+## Implemented routes
+
+Every invocation verifies the selected identity before collection and again
+before each page. A page reserves two request units: one rebinding check and one
+list GET. The initial identity check reserves one unit. `--budget` is therefore
+3-1000 and `--page-size` is 1-50.
+
+| Product | Stream | Fixed edge | Allowlisted content |
+|---|---|---|---|
+| Facebook | `posts` | `/{page-id}/posts` | ID, message, created/updated time, parent, permalink, status type |
+| Instagram | `media` | `/{ig-user-id}/media` | ID, caption, media type/product type, metadata URL references, permalink, timestamp, username, documented counts |
+| Threads | `posts` | `/me/threads` | ID, text, media type/URL reference, permalink, timestamp, username |
+| Threads | `replies` | `/me/replies` | Same bounded field set for the selected user's replies |
+| Threads | `mentions` | `/me/mentions` | Same bounded field set; stored as observed evidence without fabricating selected-account authorship |
+
+Threads profile and media route references are
+https://developers.facebook.com/docs/threads/threads-profiles#retrieve-a-threads-user-s-profile-information
+and
+https://developers.facebook.com/docs/threads/threads-media#retrieve-a-list-of-all-a-user-s-threads.
+Reply traversal semantics are documented at
+https://developers.facebook.com/docs/threads/reply-management#replies.
+
+Graph paging URLs are never replayed. The child accepts only an HTTPS URL on an
+official product host whose path exactly matches the requested account edge,
+extracts a matching opaque `after` cursor, and drops the URL and any query token
+before returning data to the parent. Each product/stream cursor is versioned and
+stored independently. A successful page, immutable allowlisted response,
+normalized rows, coverage, and next cursor commit in one fenced transaction.
+
+```bash
+knowledge-social-helper.sh sync-meta --product facebook \
+  --connection-id conn_facebook --account-id PAGE_GRAPH_ID \
+  --stream posts --profile personal --budget 11 --page-size 25
+
+knowledge-social-helper.sh sync-meta --product instagram \
+  --connection-id conn_instagram --account-id IG_GRAPH_ID \
+  --stream media --profile personal --budget 11 --page-size 25
+
+knowledge-social-helper.sh sync-meta --product threads \
+  --connection-id conn_threads --account-id THREADS_GRAPH_ID \
+  --stream posts --profile personal --budget 11 --page-size 25
+```
+
+## Explicit coverage and exports
+
+| Product | Category | Disposition |
+|---|---|---|
+| Facebook | Managed Page-authored posts | Live/Gate |
+| Facebook | Personal-profile content, saved/curated activity, relationships, messages | No; Page API authority is not personal-account authority. |
+| Facebook | Comments | No in this collector; requires a separately bounded per-post traversal and permission review. |
+| Facebook | Account download | Export candidate only; no current private schema was validated and no importer is exposed. |
+| Instagram | Professional-account media | Live/Gate |
+| Instagram | Comments and mentions | No in this collector; each requires a separate edge, permission, and pagination contract. |
+| Instagram | Followers/following and saved collections | No verified Graph list edge. |
+| Instagram | Account download | Export candidate only; no current private schema was validated and no importer is exposed. |
+| Threads | Posts, authored replies, mentions | Live/Gate with stream-specific scopes. |
+| Threads | Like/repost history, follower/following lists, messages, custom feeds | No verified account-list edge. |
+| Threads | Account download | Export candidate only; no current private schema was validated and no importer is exposed. |
+
+`Export` is evidence of a possible operator fallback, not successful collection.
+No archive route is wired until a current private sample establishes stable file
+identity, pagination/replay semantics, credential rejection, and product-local
+coverage. Browser capture remains outside this collector and requires the
+separate approved browser-gap workflow.
+
+## Retention and safety
+
+- The reviewed official sample is Meta Platform Policy licensed; its policy
+  reference is http://developers.facebook.com/policy/. No broader
+  collector-specific long-term storage grant was verified.
+- Every live stream therefore records the conservative retention boundary
+  `delete_when_no_longer_needed_or_authorized_under_meta_platform_terms`.
+  Operators must stop collection and remove affected evidence when authority or
+  lawful purpose ends, or when provider/user deletion obligations require it.
+- Unexpected fields are dropped, but credential-shaped keys anywhere in an
+  identity or page item reject the whole page before raw evidence or cursors are
+  written.
+- HTTP error bodies and exceptions never cross the child boundary. Parent
+  diagnostics contain only status-derived failure class and bounded retry time.
+- The provider module has no mutation endpoint registry and every constructed
+  HTTP request fixes `method="GET"`. It does not import browser or outbound
+  operations modules.

--- a/.agents/scripts/_knowledge_social_meta.py
+++ b/.agents/scripts/_knowledge_social_meta.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Per-product Meta stream manifests and resumable Graph cursors."""
+
+from __future__ import annotations
+
+import base64
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from knowledge_social_import import canonical_json, reject_credentials
+from knowledge_social_store import SocialStoreError
+
+GRAPH_API_VERSION = "v25.0"
+THREADS_API_VERSION = "v1.0"
+CURSOR_PREFIX = "meta-graph-v1"
+MAX_CURSOR_BYTES = 2048
+ACCOUNT_ID = re.compile(r"^[0-9]{1,32}$")
+GRAPH_ID = re.compile(r"^[0-9]{1,32}(?:_[0-9]{1,32})?$")
+RETENTION_LIMIT = "delete_when_no_longer_needed_or_authorized_under_meta_platform_terms"
+
+
+class MetaAdapterError(SocialStoreError):
+    """Raised when guarded Meta collection cannot continue safely."""
+
+
+class MetaProviderUnavailableError(MetaAdapterError):
+    """Raised when the bounded Meta OAuth child cannot complete a read."""
+
+
+ADAPTER_ERROR = MetaAdapterError
+PROVIDER_UNAVAILABLE_ERROR = MetaProviderUnavailableError
+
+
+@dataclass(frozen=True)
+class CapabilityGap:
+    """One explicit non-live product capability."""
+
+    stream: str
+    status: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    """One allowlisted product edge and its normalized meaning."""
+
+    edge: str
+    fields: tuple[str, ...]
+    resource_kind: str
+    activity_type: str
+    evidence_class: str
+    required_scopes: tuple[str, ...]
+    retention_limit: str | None = RETENTION_LIMIT
+    coverage_status: str | None = None
+    unavailable_reason: str | None = None
+    cost_units: int = 2
+
+
+@dataclass(frozen=True)
+class ProductSpec:
+    """Identity, authorization, and capability boundary for one Meta product."""
+
+    product: str
+    api_base: str
+    api_version: str
+    paging_hosts: tuple[str, ...]
+    identity_fields: tuple[str, ...]
+    identity_path: str
+    account_gate: str
+    authorization_scopes: tuple[str, ...]
+    streams: dict[str, StreamSpec]
+    gaps: tuple[CapabilityGap, ...]
+
+
+def _capability_gaps(
+    unavailable: dict[str, str], export_reason: str
+) -> tuple[CapabilityGap, ...]:
+    """Build explicit gap records from compact immutable declarations."""
+    gaps = tuple(
+        CapabilityGap(stream, "unavailable", reason)
+        for stream, reason in unavailable.items()
+    )
+    return gaps + (CapabilityGap("account_export", "export", export_reason),)
+
+
+FACEBOOK_STREAMS = {
+    "posts": StreamSpec(
+        "posts",
+        (
+            "id",
+            "created_time",
+            "message",
+            "parent_id",
+            "permalink_url",
+            "status_type",
+            "updated_time",
+        ),
+        "post",
+        "content_author",
+        "authored",
+        ("pages_read_engagement",),
+    )
+}
+
+INSTAGRAM_STREAMS = {
+    "media": StreamSpec(
+        "media",
+        (
+            "id",
+            "caption",
+            "comments_count",
+            "like_count",
+            "media_product_type",
+            "media_type",
+            "media_url",
+            "permalink",
+            "thumbnail_url",
+            "timestamp",
+            "username",
+        ),
+        "media",
+        "content_author",
+        "authored",
+        ("instagram_basic", "pages_read_engagement"),
+    )
+}
+
+THREADS_FIELDS = (
+    "id",
+    "media_type",
+    "media_url",
+    "permalink",
+    "text",
+    "timestamp",
+    "username",
+)
+THREADS_STREAMS = {
+    "posts": StreamSpec(
+        "threads",
+        THREADS_FIELDS,
+        "post",
+        "content_author",
+        "authored",
+        ("threads_basic",),
+    ),
+    "replies": StreamSpec(
+        "replies",
+        THREADS_FIELDS,
+        "reply",
+        "content_author",
+        "authored",
+        ("threads_basic", "threads_read_replies"),
+    ),
+    "mentions": StreamSpec(
+        "mentions",
+        THREADS_FIELDS,
+        "mention",
+        "account_mentioned",
+        "observed",
+        ("threads_basic", "threads_manage_mentions"),
+    ),
+}
+
+PRODUCTS = {
+    "facebook": ProductSpec(
+        "facebook",
+        f"https://graph.facebook.com/{GRAPH_API_VERSION}",
+        GRAPH_API_VERSION,
+        ("graph.facebook.com",),
+        ("id", "name", "category"),
+        "account",
+        "managed_page_with_page_access_token_and_app_review",
+        ("pages_read_engagement", "pages_show_list"),
+        FACEBOOK_STREAMS,
+        _capability_gaps(
+            {
+                "curated_activity": "facebook_page_api_does_not_expose_personal_saved_or_curated_activity",
+                "comments": "facebook_comments_require_a_separately_bounded_per_post_traversal",
+                "account_relationships": "facebook_page_api_does_not_expose_personal_follow_relationships",
+                "messages": "facebook_messaging_api_is_not_a_general_account_history_route",
+            },
+            "facebook_export_has_no_validated_private_schema_or_importer",
+        ),
+    ),
+    "instagram": ProductSpec(
+        "instagram",
+        f"https://graph.facebook.com/{GRAPH_API_VERSION}",
+        GRAPH_API_VERSION,
+        ("graph.facebook.com",),
+        ("id", "username", "name", "followers_count", "follows_count", "media_count"),
+        "account",
+        "page_connected_instagram_business_or_creator_account_with_app_review",
+        ("instagram_basic", "pages_read_engagement", "pages_show_list"),
+        INSTAGRAM_STREAMS,
+        _capability_gaps(
+            {
+                "comments": "instagram_comments_require_a_separately_bounded_per_media_traversal",
+                "mentions": "instagram_mentions_require_separate_permission_and_edge_validation",
+                "relationships": "instagram_graph_api_does_not_expose_follower_or_following_lists",
+                "saved_collections": "instagram_graph_api_does_not_expose_personal_saved_collections",
+            },
+            "instagram_export_has_no_validated_private_schema_or_importer",
+        ),
+    ),
+    "threads": ProductSpec(
+        "threads",
+        f"https://graph.threads.com/{THREADS_API_VERSION}",
+        THREADS_API_VERSION,
+        ("graph.threads.com", "graph.threads.net"),
+        ("id", "username", "name", "is_verified"),
+        "me",
+        "threads_app_user_token_with_product_specific_reviewed_permissions",
+        (
+            "threads_basic",
+            "threads_manage_mentions",
+            "threads_read_replies",
+        ),
+        THREADS_STREAMS,
+        _capability_gaps(
+            {
+                "interactions": "threads_account_like_and_repost_history_has_no_verified_list_edge",
+                "relationships": "threads_follower_and_following_lists_have_no_verified_account_edge",
+                "messages": "threads_api_has_no_general_private_message_history_route",
+                "custom_feeds": "threads_custom_feed_membership_has_no_verified_account_edge",
+            },
+            "threads_export_has_no_validated_private_schema_or_importer",
+        ),
+    ),
+}
+
+
+@dataclass(frozen=True)
+class PageRequest:
+    """One exact, bounded Graph API list request."""
+
+    product: str
+    stream: str
+    account_id: str
+    edge: str
+    fields: tuple[str, ...]
+    after: str | None
+    limit: int
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "page",
+            "product": self.product,
+            "stream": self.stream,
+            "account_id": self.account_id,
+            "edge": self.edge,
+            "fields": ",".join(self.fields),
+            "after": self.after,
+            "limit": self.limit,
+        }
+
+    def evidence_key(self) -> str:
+        return canonical_json(self.payload())
+
+
+def product_spec(product: Any) -> ProductSpec:
+    """Return one product manifest without accepting aliases."""
+    if not isinstance(product, str) or product not in PRODUCTS:
+        raise MetaAdapterError("Meta product is unsupported")
+    return PRODUCTS[product]
+
+
+def graph_id(value: Any, field: str) -> str:
+    """Validate a stable numeric or documented composite Graph identifier."""
+    if not isinstance(value, str) or GRAPH_ID.fullmatch(value) is None:
+        raise MetaAdapterError(f"Meta {field} must be a stable Graph ID")
+    return value
+
+
+def account_id(value: Any, field: str) -> str:
+    """Validate a stable numeric product account identifier."""
+    if not isinstance(value, str) or ACCOUNT_ID.fullmatch(value) is None:
+        raise MetaAdapterError(f"Meta {field} must be a stable numeric account ID")
+    return value
+
+
+def provider_cursor(value: Any) -> str:
+    """Validate an opaque provider cursor before use or storage."""
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise MetaAdapterError("Meta page cursor is invalid")
+    if len(value.encode("utf-8")) > MAX_CURSOR_BYTES:
+        raise MetaAdapterError("Meta page cursor exceeds the safety limit")
+    return value
+
+
+def _stored_cursor(product: str, cursor: str) -> str:
+    encoded = base64.urlsafe_b64encode(provider_cursor(cursor).encode("utf-8"))
+    return f"{CURSOR_PREFIX}:{product}:{encoded.decode('ascii').rstrip('=')}"
+
+
+def _decoded_cursor(product: str, cursor: str) -> str:
+    prefix = f"{CURSOR_PREFIX}:{product}:"
+    if not cursor.startswith(prefix):
+        raise MetaAdapterError("stored Meta cursor has an unsupported product or version")
+    encoded = cursor.removeprefix(prefix)
+    if not encoded or not encoded.isascii():
+        raise MetaAdapterError("stored Meta cursor is invalid")
+    try:
+        decoded = base64.b64decode(
+            encoded + "=" * (-len(encoded) % 4), altchars=b"-_", validate=True
+        ).decode("utf-8")
+    except (UnicodeDecodeError, ValueError) as error:
+        raise MetaAdapterError("stored Meta cursor is invalid") from error
+    return provider_cursor(decoded)
+
+
+def page_request(
+    product: str,
+    stream: str,
+    account: dict[str, Any],
+    state: CursorState,
+    limit: int,
+) -> PageRequest:
+    """Build one product-scoped request from durable per-stream state."""
+    spec = product_spec(product)
+    if stream not in spec.streams:
+        raise MetaAdapterError("Meta stream is unsupported for the selected product")
+    stream_spec = spec.streams[stream]
+    remote_account_id = account_id(account.get("id"), "account ID")
+    after = _decoded_cursor(product, state.cursor) if state.cursor else None
+    return PageRequest(
+        product,
+        stream,
+        remote_account_id,
+        stream_spec.edge,
+        stream_spec.fields,
+        after,
+        limit,
+    )
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    """Return a validated HTTP-like status from a Meta response."""
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise MetaAdapterError("Meta response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return a validated array of allowlisted Meta records."""
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise MetaAdapterError("Meta page data must be an array of objects")
+    reject_credentials(data)
+    return data
+
+
+def page_checkpoint(
+    product: str,
+    payload: dict[str, Any],
+    state: CursorState,
+    request: PageRequest,
+) -> tuple[PageCheckpoint, bool]:
+    """Calculate the next independent Graph cursor for one product stream."""
+    del state
+    meta = payload.get("meta")
+    if not isinstance(meta, dict):
+        raise MetaAdapterError("Meta page metadata must be an object")
+    reject_credentials(meta)
+    if meta.get("product") != product or meta.get("stream") != request.stream:
+        raise MetaAdapterError("Meta page provenance does not match the request")
+    complete = meta.get("complete")
+    next_cursor = meta.get("next_cursor")
+    if not isinstance(complete, bool):
+        raise MetaAdapterError("Meta page completion metadata is invalid")
+    if next_cursor is not None:
+        next_cursor = provider_cursor(next_cursor)
+    if complete == (next_cursor is not None):
+        raise MetaAdapterError(
+            "complete Meta pages cannot carry a cursor and partial pages require one"
+        )
+    cursor = _stored_cursor(product, next_cursor) if next_cursor is not None else None
+    return PageCheckpoint(cursor, None), complete
+
+
+class MetaProductModule:
+    """Dynamic provider-policy adapter consumed by the shared OAuth collector."""
+
+    ADAPTER_ERROR = MetaAdapterError
+    PROVIDER_UNAVAILABLE_ERROR = MetaProviderUnavailableError
+
+    def __init__(self, product: str) -> None:
+        spec = product_spec(product)
+        self.product = product
+        self.PROVIDER = product
+        self.STREAMS = spec.streams
+
+    def page_request(
+        self,
+        stream: str,
+        account: dict[str, Any],
+        state: CursorState,
+        limit: int,
+    ) -> PageRequest:
+        return page_request(self.product, stream, account, state, limit)
+
+    def page_checkpoint(
+        self,
+        payload: dict[str, Any],
+        state: CursorState,
+        request: PageRequest,
+    ) -> tuple[PageCheckpoint, bool]:
+        return page_checkpoint(self.product, payload, state, request)
+
+    def response_status(self, payload: dict[str, Any]) -> int:
+        return response_status(payload)

--- a/.agents/scripts/_knowledge_social_meta_contract.py
+++ b/.agents/scripts/_knowledge_social_meta_contract.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validation and redaction for the bounded Meta Graph subprocess."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import parse_qs, urlsplit
+
+from _knowledge_social_meta import (
+    MetaAdapterError,
+    ProductSpec,
+    StreamSpec,
+    account_id,
+    graph_id,
+    provider_cursor,
+)
+from knowledge_social_import import canonical_json, reject_credentials
+
+MAX_TEXT_BYTES = 256 * 1024
+MAX_ITEM_BYTES = 512 * 1024
+
+
+class MetaReadProviderError(RuntimeError):
+    """Raised for a privacy-safe local Meta provider failure."""
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    """One bounded HTTP result without provider error-body disclosure."""
+
+    status: int
+    payload: dict[str, Any]
+    retry_after: int | None = None
+
+
+def observed_at() -> str:
+    """Return a stable UTC timestamp for one provider response."""
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def exact_keys(request: dict[str, Any], expected: set[str]) -> None:
+    """Reject parent requests outside the allowlisted read contract."""
+    if set(request) != expected:
+        raise MetaReadProviderError("Meta read request has an invalid action shape")
+
+
+def bounded_text(value: Any, field: str) -> str:
+    """Validate bounded provider text without exposing its content in errors."""
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise MetaReadProviderError(f"Meta {field} is invalid")
+    if len(value.encode("utf-8")) > MAX_TEXT_BYTES:
+        raise MetaReadProviderError(f"Meta {field} exceeds the safety limit")
+    return value
+
+
+def stable_graph_id(value: Any, field: str) -> str:
+    """Translate shared Graph-ID validation into the child error boundary."""
+    try:
+        return graph_id(value, field)
+    except MetaAdapterError as error:
+        raise MetaReadProviderError(str(error)) from error
+
+
+def stable_account_id(value: Any, field: str) -> str:
+    """Translate strict account-ID validation into the child error boundary."""
+    try:
+        return account_id(value, field)
+    except MetaAdapterError as error:
+        raise MetaReadProviderError(str(error)) from error
+
+
+def terminal_payload(result: ApiResult) -> dict[str, Any]:
+    """Build a sanitized terminal response envelope."""
+    payload: dict[str, Any] = {"status": result.status, "observed_at": observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload
+
+
+def _record(value: Any, fields: tuple[str, ...], field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise MetaReadProviderError(f"Meta {field} must be an object")
+    reject_credentials(value)
+    selected = {name: value[name] for name in fields if name in value}
+    if len(canonical_json(selected).encode("utf-8")) > MAX_ITEM_BYTES:
+        raise MetaReadProviderError(f"Meta {field} exceeds the safety limit")
+    stable_graph_id(selected.get("id"), f"{field} ID")
+    return selected
+
+
+def identity_payload(
+    result: ApiResult, spec: ProductSpec, expected_id: str
+) -> dict[str, Any]:
+    """Allowlist and bind one product identity to the configured account."""
+    if result.status != 200:
+        return terminal_payload(result)
+    identity = _record(result.payload, spec.identity_fields, "identity")
+    expected = stable_account_id(expected_id, "account ID")
+    actual = stable_account_id(identity.get("id"), "identity account ID")
+    if actual != expected:
+        raise MetaReadProviderError(
+            f"selected {spec.product} account does not match the configured connection"
+        )
+    identity["product"] = spec.product
+    return {"status": 200, "observed_at": observed_at(), "data": identity}
+
+
+def _next_cursor(
+    paging: Any,
+    spec: ProductSpec,
+    stream: StreamSpec,
+    account_id: str,
+) -> str | None:
+    if paging is None:
+        return None
+    if not isinstance(paging, dict):
+        raise MetaReadProviderError("Meta paging metadata must be an object")
+    next_url = paging.get("next")
+    if next_url is None:
+        return None
+    if not isinstance(next_url, str) or len(next_url.encode("utf-8")) > 8192:
+        raise MetaReadProviderError("Meta next-page URL is invalid")
+    parsed = urlsplit(next_url)
+    base = urlsplit(spec.api_base)
+    expected_leaf = account_id if spec.identity_path == "account" else "me"
+    expected_path = f"{base.path}/{expected_leaf}/{stream.edge}"
+    if parsed.scheme != "https":
+        raise MetaReadProviderError("Meta next-page URL is outside the allowlisted edge")
+    if parsed.hostname not in spec.paging_hosts:
+        raise MetaReadProviderError("Meta next-page URL is outside the allowlisted edge")
+    if parsed.username is not None:
+        raise MetaReadProviderError("Meta next-page URL is outside the allowlisted edge")
+    if parsed.password is not None:
+        raise MetaReadProviderError("Meta next-page URL is outside the allowlisted edge")
+    if parsed.fragment:
+        raise MetaReadProviderError("Meta next-page URL is outside the allowlisted edge")
+    if parsed.path != expected_path:
+        raise MetaReadProviderError("Meta next-page URL is outside the allowlisted edge")
+    query = parse_qs(parsed.query, keep_blank_values=True)
+    cursors = paging.get("cursors")
+    if not isinstance(cursors, dict):
+        raise MetaReadProviderError("Meta paging cursors must be an object")
+    after = cursors.get("after")
+    try:
+        cursor = provider_cursor(after)
+    except MetaAdapterError as error:
+        raise MetaReadProviderError(str(error)) from error
+    if query.get("after") != [cursor]:
+        raise MetaReadProviderError("Meta next-page cursor does not match paging metadata")
+    return cursor
+
+
+def page_payload(
+    result: ApiResult,
+    spec: ProductSpec,
+    stream_name: str,
+    account_id: str,
+    limit: int,
+) -> dict[str, Any]:
+    """Allowlist one Graph page and discard provider paging URLs and tokens."""
+    if result.status != 200:
+        return terminal_payload(result)
+    if stream_name not in spec.streams:
+        raise MetaReadProviderError("Meta read stream is unsupported")
+    stream = spec.streams[stream_name]
+    raw_data = result.payload.get("data")
+    if not isinstance(raw_data, list):
+        raise MetaReadProviderError("Meta page data must be an array")
+    if len(raw_data) > limit:
+        raise MetaReadProviderError("Meta page exceeds the requested item limit")
+    data = [_record(item, stream.fields, "page item") for item in raw_data]
+    cursor = _next_cursor(result.payload.get("paging"), spec, stream, account_id)
+    payload = {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": data,
+        "meta": {
+            "product": spec.product,
+            "stream": stream_name,
+            "next_cursor": cursor,
+            "complete": cursor is None,
+        },
+    }
+    reject_credentials(payload)
+    return payload
+
+
+def decode_response(payload: bytes) -> dict[str, Any]:
+    """Decode one already size-bounded Graph response object."""
+    try:
+        value = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise MetaReadProviderError("Meta HTTP response is not valid JSON") from error
+    if not isinstance(value, dict):
+        raise MetaReadProviderError("Meta HTTP response root must be an object")
+    return value

--- a/.agents/scripts/_knowledge_social_meta_normalize.py
+++ b/.agents/scripts/_knowledge_social_meta_normalize.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize allowlisted Meta product records into the shared social schema."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_meta import (
+    RETENTION_LIMIT,
+    MetaAdapterError,
+    account_id,
+    graph_id,
+    page_data,
+    product_spec,
+)
+from knowledge_social_import import reject_credentials
+
+PROVENANCE = "meta_graph_api"
+
+
+@dataclass(frozen=True)
+class PageContext:
+    """Validated product and connection policy for one Graph page."""
+
+    product: str
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def _observation_time(payload: dict[str, Any]) -> str:
+    value = payload.get("observed_at")
+    if not isinstance(value, str) or not value:
+        raise MetaAdapterError("Meta page observed_at must be text")
+    return value
+
+
+def _optional_text(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _coverage(context: PageContext, observed_at: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "stream": gap.stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": RETENTION_LIMIT,
+            "unavailable_reason": gap.reason,
+            "status": gap.status,
+            "observed_at": observed_at,
+        }
+        for gap in product_spec(context.product).gaps
+    ]
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    """Build provider-neutral rows and explicit product coverage evidence."""
+    reject_credentials(payload)
+    observed_at = _observation_time(payload)
+    remote_account_id = account_id(context.account.get("id"), "account ID")
+    spec = product_spec(context.product)
+    if context.stream not in spec.streams:
+        raise MetaAdapterError("Meta stream is unsupported for the selected product")
+    stream = spec.streams[context.stream]
+    meta = payload.get("meta")
+    if (
+        not isinstance(meta, dict)
+        or meta.get("product") != context.product
+        or meta.get("stream") != context.stream
+    ):
+        raise MetaAdapterError("Meta page provenance is invalid")
+
+    objects: list[dict[str, Any]] = []
+    activities: list[dict[str, Any]] = []
+    for item in page_data(payload):
+        remote_id = graph_id(item.get("id"), "object ID")
+        provider_json = {
+            "source": PROVENANCE,
+            "product": context.product,
+            "stream": context.stream,
+            "item": item,
+        }
+        objects.append(
+            {
+                "object_type": stream.resource_kind,
+                "remote_id": remote_id,
+                "account_remote_id": (
+                    remote_account_id if stream.evidence_class == "authored" else None
+                ),
+                "text": _optional_text(
+                    item.get("message", item.get("caption", item.get("text")))
+                ),
+                "created_at": _optional_text(
+                    item.get("created_time", item.get("timestamp"))
+                ),
+                "observed_at": observed_at,
+                "evidence_class": stream.evidence_class,
+                "provider_json": provider_json,
+            }
+        )
+        if stream.evidence_class == "authored":
+            activities.append(
+                {
+                    "activity_type": stream.activity_type,
+                    "remote_id": f"{remote_account_id}:{context.stream}:{remote_id}",
+                    "actor_remote_id": remote_account_id,
+                    "object_remote_id": remote_id,
+                    "occurred_at": _optional_text(
+                        item.get("created_time", item.get("timestamp"))
+                    ),
+                    "observed_at": observed_at,
+                    "state": "active",
+                    "provider_json": {
+                        "source": PROVENANCE,
+                        "product": context.product,
+                        "stream": context.stream,
+                    },
+                }
+            )
+
+    policy = dict(context.policy)
+    policy.update(
+        {
+            "meta_product": context.product,
+            "meta_api_version": spec.api_version,
+            "meta_account_gate": spec.account_gate,
+            "meta_authorization_scopes": list(spec.authorization_scopes),
+            "meta_stream_scopes": list(stream.required_scopes),
+            "meta_provenance": PROVENANCE,
+        }
+    )
+    account_handle = context.account.get("username")
+    display_name = context.account.get("name")
+    archive = {
+        "provider": context.product,
+        "connection_id": context.connection_id,
+        "remote_account_id": remote_account_id,
+        "exported_at": observed_at,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": policy,
+        "accounts": [
+            {
+                "remote_id": remote_account_id,
+                "handle": account_handle if isinstance(account_handle, str) else None,
+                "display_name": display_name if isinstance(display_name, str) else None,
+                "observed_at": observed_at,
+                "provider_json": {
+                    "source": PROVENANCE,
+                    "product": context.product,
+                },
+            }
+        ],
+        "objects": objects,
+        "activities": activities,
+        "media": [],
+        "coverage": _coverage(context, observed_at),
+    }
+    reject_credentials(archive)
+    return archive

--- a/.agents/scripts/_knowledge_social_meta_provider.py
+++ b/.agents/scripts/_knowledge_social_meta_provider.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded GET-only OAuth subprocess for Meta product reads."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from _knowledge_social_meta import (
+    PRODUCTS,
+    MetaAdapterError,
+    account_id,
+    graph_id,
+    product_spec,
+    provider_cursor,
+)
+from _knowledge_social_meta_contract import (
+    ApiResult,
+    MetaReadProviderError,
+    decode_response,
+    exact_keys,
+    identity_payload,
+    page_payload,
+)
+
+MAX_REQUEST_BYTES = 32 * 1024
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+HTTP_TIMEOUT_SECONDS = 60
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+UrlOpen = Callable[..., Any]
+PageValues = tuple[str, str, str, str | None, int]
+READ_EDGES = {
+    product: frozenset(stream.edge for stream in spec.streams.values())
+    for product, spec in PRODUCTS.items()
+}
+
+
+def _profile_prefix(profile: str, product: str) -> str:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise MetaReadProviderError("Meta OAuth profile name is invalid")
+    if product not in PRODUCTS:
+        raise MetaReadProviderError("Meta product is unsupported")
+    return f"META_{profile.upper()}_{product.upper()}"
+
+
+def _access_token(profile: str, product: str) -> str:
+    token = os.environ.get(f"{_profile_prefix(profile, product)}_ACCESS_TOKEN", "")
+    if not token or "\x00" in token or len(token.encode("utf-8")) > 16 * 1024:
+        raise MetaReadProviderError("Meta OAuth profile access token is missing")
+    return token
+
+
+def _http_exports() -> UrlOpen:
+    if not callable(Request) or not callable(urlopen) or not callable(urlencode):
+        raise MetaReadProviderError("Python urllib HTTP exports are unavailable")
+    return urlopen
+
+
+def _request() -> dict[str, Any]:
+    payload = sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1)
+    if len(payload) > MAX_REQUEST_BYTES:
+        raise MetaReadProviderError("Meta read request exceeds the safety limit")
+    try:
+        request = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise MetaReadProviderError("Meta read request is not valid JSON") from error
+    if not isinstance(request, dict):
+        raise MetaReadProviderError("Meta read request root must be an object")
+    return request
+
+
+def _retry_epoch(error: HTTPError) -> int | None:
+    value = error.headers.get("Retry-After") if error.headers else None
+    if not isinstance(value, str) or not value.isascii() or not value.isdigit():
+        return None
+    seconds = int(value)
+    if seconds < 0 or seconds > 86400:
+        return None
+    return int(time.time()) + seconds
+
+
+def _api(
+    token: str,
+    opener: UrlOpen,
+    api_base: str,
+    path: str,
+    params: dict[str, str],
+) -> ApiResult:
+    url = f"{api_base}/{path}?{urlencode(params)}"
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "aidevops-meta-knowledge/1",
+        },
+        method="GET",
+    )
+    try:
+        with opener(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", 200)
+            if isinstance(status, bool) or not isinstance(status, int):
+                raise MetaReadProviderError("Meta HTTP status is invalid")
+            payload = response.read(MAX_RESPONSE_BYTES + 1)
+            if not isinstance(payload, bytes) or len(payload) > MAX_RESPONSE_BYTES:
+                raise MetaReadProviderError("Meta HTTP response exceeds the safety limit")
+            return ApiResult(status, decode_response(payload))
+    except HTTPError as error:
+        status = error.code
+        if isinstance(status, bool) or not isinstance(status, int) or not 400 <= status <= 599:
+            raise MetaReadProviderError("Meta HTTP status is invalid") from error
+        return ApiResult(status, {}, _retry_epoch(error))
+    except (TimeoutError, URLError, OSError) as error:
+        raise MetaReadProviderError("Meta read provider request failed") from error
+
+
+def _identity(
+    api: Callable[[str, dict[str, str]], ApiResult],
+    product: str,
+    expected_id: str,
+) -> dict[str, Any]:
+    spec = product_spec(product)
+    path = expected_id if spec.identity_path == "account" else "me"
+    result = api(path, {"fields": ",".join(spec.identity_fields)})
+    return identity_payload(result, spec, expected_id)
+
+
+def _page_request(
+    request: dict[str, Any],
+) -> PageValues:
+    exact_keys(
+        request,
+        {"action", "product", "stream", "account_id", "edge", "fields", "after", "limit"},
+    )
+    product = request.get("product")
+    spec = product_spec(product)
+    stream = request.get("stream")
+    if not isinstance(stream, str) or stream not in spec.streams:
+        raise MetaReadProviderError("Meta read stream is unsupported")
+    stream_spec = spec.streams[stream]
+    if request.get("edge") != stream_spec.edge:
+        raise MetaReadProviderError("Meta read edge is not allowlisted")
+    if request.get("fields") != ",".join(stream_spec.fields):
+        raise MetaReadProviderError("Meta read fields are not allowlisted")
+    try:
+        selected_account_id = account_id(request.get("account_id"), "account ID")
+    except Exception as error:
+        raise MetaReadProviderError("Meta account ID is invalid") from error
+    after = request.get("after")
+    if after is not None:
+        try:
+            after = provider_cursor(after)
+        except Exception as error:
+            raise MetaReadProviderError("Meta page cursor is invalid") from error
+    limit = request.get("limit")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 50:
+        raise MetaReadProviderError("Meta read limit must be between 1 and 50")
+    return product, stream, selected_account_id, after, limit
+
+
+def _page(
+    api: Callable[[str, dict[str, str]], ApiResult],
+    values: PageValues,
+) -> dict[str, Any]:
+    product, stream, account_id, after, limit = values
+    spec = product_spec(product)
+    stream_spec = spec.streams[stream]
+    identity = _identity(api, product, account_id)
+    if identity.get("status") != 200:
+        return identity
+    leaf = account_id if spec.identity_path == "account" else "me"
+    params = {"fields": ",".join(stream_spec.fields), "limit": str(limit)}
+    if after is not None:
+        params["after"] = after
+    result = api(f"{leaf}/{stream_spec.edge}", params)
+    return page_payload(result, spec, stream, account_id, limit)
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode("utf-8")) > MAX_RESPONSE_BYTES:
+        raise MetaReadProviderError("Meta read response exceeds the safety limit")
+    print(encoded)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        raw_request = _request()
+        action = raw_request.get("action")
+        if action not in ("identity", "page"):
+            raise MetaReadProviderError("Meta read action is unsupported")
+        product = raw_request.get("product")
+        if not isinstance(product, str) or product not in PRODUCTS:
+            raise MetaReadProviderError("Meta product is unsupported")
+        token = _access_token(args.profile, product)
+        opener = _http_exports()
+        spec = product_spec(product)
+        api = lambda path, params: _api(token, opener, spec.api_base, path, params)
+        if action == "identity":
+            exact_keys(raw_request, {"action", "product", "account_id"})
+            selected_account_id = account_id(
+                raw_request.get("account_id"), "account ID"
+            )
+            payload = _identity(api, product, selected_account_id)
+        else:
+            values = _page_request(raw_request)
+            payload = _page(api, values)
+        _emit(payload)
+        return 0
+    except (MetaReadProviderError, MetaAdapterError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - intentionally redact provider internals
+        print("ERROR: Meta read provider request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_meta_reader.py
+++ b/.agents/scripts/_knowledge_social_meta_reader.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and fixture readers for Meta product data."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+from _knowledge_social_collect_cli import guarded_reader_environment
+from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_meta import (
+    MetaAdapterError,
+    MetaProviderUnavailableError,
+    PageRequest,
+    account_id,
+    product_spec,
+)
+from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
+from knowledge_social_import import reject_credentials
+
+READ_TIMEOUT_SECONDS = 120
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+SAFE_PROVIDER_FAILURES = (
+    "Python urllib HTTP exports are unavailable",
+    "Meta OAuth profile access token is missing",
+    "Meta OAuth profile name is invalid",
+    "Meta product is unsupported",
+)
+
+
+class MetaReader(Protocol):
+    """Minimal GET-only provider surface used by collection."""
+
+    def identity(self, expected_id: str) -> dict[str, Any]: ...
+
+    def page(self, request: PageRequest) -> dict[str, Any]: ...
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    if len(output.encode("utf-8")) > MAX_RESPONSE_BYTES:
+        raise MetaAdapterError("Meta read response exceeds the safety limit")
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise MetaAdapterError("Meta read provider returned no valid JSON") from error
+    if not isinstance(payload, dict):
+        raise MetaAdapterError("Meta read response root must be an object")
+    return payload
+
+
+def _provider_failure(stderr: str) -> MetaProviderUnavailableError:
+    for message in SAFE_PROVIDER_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return MetaProviderUnavailableError(message)
+    return MetaProviderUnavailableError("Meta read provider is unavailable")
+
+
+META_OAUTH_POLICY = GuardedOAuthPolicy(
+    "Meta",
+    "META",
+    "META_READ_LOG",
+    READ_TIMEOUT_SECONDS,
+    _decode_output,
+    _provider_failure,
+    MetaProviderUnavailableError,
+)
+
+
+class GuardedMetaOAuth(GuardedOAuthReader):
+    """Execute only one product identity and its allowlisted Graph GETs."""
+
+    def __init__(self, helper: Path, profile: str, product: str) -> None:
+        product_spec(product)
+        self.product = product
+        super().__init__(helper, profile, META_OAUTH_POLICY)
+
+    def _environment(self) -> dict[str, str]:
+        token_name = f"META_{self.profile.upper()}_{self.product.upper()}_ACCESS_TOKEN"
+        return guarded_reader_environment(token_name, ("META_READ_LOG",))
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        return self.process.run(
+            {"action": "identity", "product": self.product, "account_id": expected_id}
+        )
+
+
+def _fixture_page(entry: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    expectation = entry.get("expect_request", {})
+    if not isinstance(expectation, dict):
+        raise MetaAdapterError("Meta fixture request expectation must be an object")
+    actual = request.payload()
+    if any(actual.get(key) != value for key, value in expectation.items()):
+        raise MetaAdapterError("Meta request did not resume at the expected checkpoint")
+    response = entry.get("response", entry)
+    if not isinstance(response, dict):
+        raise MetaAdapterError("Meta fixture page response must be an object")
+    return response
+
+
+class FixtureMeta:
+    """Deterministic OAuth substitute for product pagination and failures."""
+
+    def __init__(self, path: Path, product: str) -> None:
+        self.product = product
+        self.fixture = FixtureSequence(path, f"Meta {product}", MetaAdapterError)
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        del expected_id
+        return self.fixture.identity()
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        if request.product != self.product:
+            raise MetaAdapterError("Meta fixture product does not match the request")
+        return _fixture_page(self.fixture.next_page(), request)
+
+
+def verified_identity(
+    payload: dict[str, Any], expected_id: str, product: str
+) -> dict[str, Any]:
+    """Validate product identity without allowing credential-shaped fields through."""
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise MetaAdapterError(f"{product} account verification returned no account")
+    remote_id = account_id(data.get("id"), "account ID")
+    if data.get("product") != product or remote_id != expected_id:
+        raise MetaAdapterError(
+            f"selected {product} account does not match the configured connection"
+        )
+    account = {"id": remote_id, "product": product}
+    for field in ("username", "name", "category", "is_verified"):
+        value = data.get(field)
+        if isinstance(value, (str, bool)):
+            account[field] = value
+    return account

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -11,6 +11,7 @@ X_HELPER="${SCRIPT_DIR}/knowledge_social_x.py"
 REDDIT_HELPER="${SCRIPT_DIR}/knowledge_social_reddit.py"
 YOUTUBE_HELPER="${SCRIPT_DIR}/knowledge_social_youtube.py"
 LINKEDIN_HELPER="${SCRIPT_DIR}/knowledge_social_linkedin.py"
+META_HELPER="${SCRIPT_DIR}/knowledge_social_meta.py"
 QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
 SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
 SHARE_HELPER="${SCRIPT_DIR}/knowledge_social_share.py"
@@ -86,11 +87,18 @@ LinkedIn synchronization:
   request costs one unit; every page reserves two units for identity rebinding and
   one GET-only snapshot read. --budget is 3-1000 and --page-size is 1-50.
 
+Meta synchronization:
+  sync-meta selects exactly one facebook, instagram, or threads identity and
+  one product-specific GET-only stream. Facebook supports managed Page posts;
+  Instagram supports Professional-account media; Threads supports posts,
+  authored replies, and mentions. Every page revalidates the selected product
+  identity. --budget is 3-1000 and --page-size is 1-50.
+
 EOF
 	return 0
 }
 
-usage() {
+usage_commands() {
 	cat <<'EOF'
 Usage:
   knowledge-social-helper.sh provision [--base PATH] [--alias ALIAS]
@@ -117,6 +125,10 @@ Usage:
     --connection-id ID --account-id MEMBER_ID --stream STREAM --profile PROFILE \
     [--budget UNITS] [--page-size 1-50] [--collector-id ID] \
     [--lease-seconds SECONDS]
+  knowledge-social-helper.sh sync-meta --product facebook|instagram|threads \
+    [--base PATH] [--alias ALIAS] --connection-id ID --account-id GRAPH_ID \
+    --stream STREAM --profile PROFILE [--budget UNITS] [--page-size 1-50] \
+    [--collector-id ID] [--lease-seconds SECONDS]
   knowledge-social-helper.sh sync-due [--base PATH] [--alias ALIAS] \
     [--now-epoch EPOCH] [--interval-seconds SECONDS]
   knowledge-social-helper.sh reconcile-due [--base PATH] [--alias ALIAS] \
@@ -127,6 +139,11 @@ Usage:
   knowledge-social-helper.sh receipts [--base PATH] [--alias ALIAS] \
     [--connection-id ID] [--limit 1-1000]
 EOF
+	return 0
+}
+
+usage() {
+	usage_commands
 	usage_operations
 	cat <<'EOF'
   knowledge-social-helper.sh identity-export [--base PATH] [--vault-dir DIR] --output FILE
@@ -290,6 +307,14 @@ main() {
 			return 1
 		fi
 		python3 "$LINKEDIN_HELPER" "$@" || return 1
+		;;
+	sync-meta)
+		require_runtime || return 1
+		if [[ ! -r "$META_HELPER" ]]; then
+			printf 'ERROR: Meta social adapter missing: %s\n' "$META_HELPER" >&2
+			return 1
+		fi
+		python3 "$META_HELPER" "$@" || return 1
 		;;
 	query | annotate)
 		require_runtime || return 1

--- a/.agents/scripts/knowledge_social_meta.py
+++ b/.agents/scripts/knowledge_social_meta.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one bounded Facebook, Instagram, or Threads account stream."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from _knowledge_social_meta import PRODUCTS, MetaProductModule, product_spec
+from _knowledge_social_meta_normalize import PageContext, normalize_page
+from _knowledge_social_meta_reader import FixtureMeta, GuardedMetaOAuth, verified_identity
+from _knowledge_social_oauth_collector import OAuthCollectorPolicy, run_oauth_collector
+
+
+def _select_product(argv: list[str]) -> tuple[str, list[str]]:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--product", required=True, choices=tuple(PRODUCTS))
+    args, remaining = parser.parse_known_args(argv)
+    return args.product, remaining
+
+
+def _collector_policy(product: str) -> OAuthCollectorPolicy:
+    spec = product_spec(product)
+    module = MetaProductModule(product)
+    return OAuthCollectorPolicy(
+        display_name=f"Meta {product.title()}",
+        provider_module=module,
+        helper=Path(__file__).with_name("_knowledge_social_meta_provider.py"),
+        fixture_reader=lambda path: FixtureMeta(path, product),
+        live_reader=lambda helper, profile: GuardedMetaOAuth(helper, profile, product),
+        page_context=lambda connection, account, stream, enabled, policy: PageContext(
+            product, connection, account, stream, enabled, policy
+        ),
+        normalize_page=normalize_page,
+        verified_identity=lambda payload, expected: verified_identity(
+            payload, expected, product
+        ),
+        budget_unit="request",
+        default_budget=11,
+        min_budget=3,
+        max_page_size=50,
+    )
+
+
+def main() -> int:
+    product, remaining = _select_product(sys.argv[1:])
+    original = sys.argv
+    sys.argv = [original[0], *remaining]
+    try:
+        description = (
+            f"Collect one GET-only {product} stream. Account gate: "
+            f"{product_spec(product).account_gate}."
+        )
+        return run_oauth_collector(_collector_policy(product), description)
+    finally:
+        sys.argv = original
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/tests/test-knowledge-social-meta.sh
+++ b/.agents/tests/test-knowledge-social-meta.sh
@@ -1,0 +1,598 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-meta.sh — bounded Meta product collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' \
+			"$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c \
+		'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_count() {
+	local product="$1"
+	python3 - "$ROOT/sources/social/raw/$product" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+print(len(list(root.rglob("*.json.gz"))) if root.exists() else 0)
+PY
+	return 0
+}
+
+expect_sync_failure() {
+	local description="$1"
+	local product="$2"
+	local account_id="$3"
+	local stream="$4"
+	local fixture="$5"
+	if "$HELPER" sync-meta --product "$product" --base "$BASE" \
+		--alias personal:default --connection-id "conn_${product}_failure" \
+		--account-id "$account_id" --stream "$stream" --profile fixture \
+		--fixture "$fixture" >/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'Meta social collector tests\n'
+
+help_output=$("$HELPER" help)
+if [[ "$help_output" == *"sync-meta"* && "$help_output" == *"facebook|instagram|threads"* ]]; then
+	assert_eq "Meta help exposes the product-scoped route" advertised advertised
+else
+	assert_eq "Meta help exposes the product-scoped route" missing advertised
+fi
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import ast
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+
+from _knowledge_social_collect import CursorState
+from _knowledge_social_meta import (
+    GRAPH_API_VERSION,
+    PRODUCTS,
+    THREADS_API_VERSION,
+    MetaAdapterError,
+    MetaProductModule,
+    page_checkpoint,
+    page_request,
+)
+from _knowledge_social_meta_contract import ApiResult, page_payload
+from _knowledge_social_meta_provider import READ_EDGES, _http_exports
+
+assert GRAPH_API_VERSION == "v25.0"
+assert THREADS_API_VERSION == "v1.0"
+assert set(PRODUCTS) == {"facebook", "instagram", "threads"}
+assert PRODUCTS["facebook"].api_base == "https://graph.facebook.com/v25.0"
+assert PRODUCTS["instagram"].api_base == "https://graph.facebook.com/v25.0"
+assert PRODUCTS["threads"].api_base == "https://graph.threads.com/v1.0"
+assert set(PRODUCTS["facebook"].streams) == {"posts"}
+assert set(PRODUCTS["instagram"].streams) == {"media"}
+assert set(PRODUCTS["threads"].streams) == {"posts", "replies", "mentions"}
+assert READ_EDGES == {
+    "facebook": frozenset({"posts"}),
+    "instagram": frozenset({"media"}),
+    "threads": frozenset({"threads", "replies", "mentions"}),
+}
+assert callable(_http_exports())
+
+request = page_request(
+    "facebook", "posts", {"id": "1001"}, CursorState(None, None, False), 1
+)
+payload = {
+    "meta": {
+        "product": "facebook",
+        "stream": "posts",
+        "next_cursor": "cursor-one",
+        "complete": False,
+    }
+}
+checkpoint, complete = page_checkpoint(
+    "facebook", payload, CursorState(None, None, False), request
+)
+resumed = page_request(
+    "facebook",
+    "posts",
+    {"id": "1001"},
+    CursorState(checkpoint.next_cursor, None, complete),
+    1,
+)
+assert resumed.after == "cursor-one" and complete is False
+assert MetaProductModule("threads").PROVIDER == "threads"
+
+result = ApiResult(
+    200,
+    {
+        "data": [{"id": "1001_5001", "message": "safe", "unexpected": "drop"}],
+        "paging": {
+            "cursors": {"after": "cursor-two"},
+            "next": "https://graph.facebook.com/v25.0/1001/posts?after=cursor-two",
+        },
+    },
+)
+safe_page = page_payload(result, PRODUCTS["facebook"], "posts", "1001", 1)
+assert safe_page["data"] == [{"id": "1001_5001", "message": "safe"}]
+assert safe_page["meta"]["next_cursor"] == "cursor-two"
+
+threads_page = page_payload(
+    ApiResult(
+        200,
+        {
+            "data": [{"id": "7001", "text": "safe"}],
+            "paging": {
+                "cursors": {"after": "threads-cursor"},
+                "next": "https://graph.threads.net/v1.0/me/threads?after=threads-cursor",
+            },
+        },
+    ),
+    PRODUCTS["threads"],
+    "posts",
+    "3001",
+    1,
+)
+assert threads_page["meta"]["next_cursor"] == "threads-cursor"
+try:
+    page_request(
+        "facebook", "posts", {"id": "1001_5001"}, CursorState(None, None, False), 1
+    )
+except MetaAdapterError:
+    pass
+else:
+    raise AssertionError("composite content ID was accepted as an account identity")
+
+sources = [
+    path.read_text(encoding="utf-8")
+    for path in sorted(scripts.glob("*knowledge_social_meta*.py"))
+]
+assert sources
+assert all("knowledge_social_operations" not in source for source in sources)
+assert all("knowledge_social_browser" not in source for source in sources)
+trees = [ast.parse(source) for source in sources]
+request_calls = [
+    node
+    for tree in trees
+    for node in ast.walk(tree)
+    if isinstance(node, ast.Call)
+    and isinstance(node.func, ast.Name)
+    and node.func.id == "Request"
+]
+assert request_calls
+for node in request_calls:
+    methods = [
+        keyword.value.value
+        for keyword in node.keywords
+        if keyword.arg == "method" and isinstance(keyword.value, ast.Constant)
+    ]
+    assert methods == ["GET"]
+PY
+assert_eq "product manifests, cursor isolation, field allowlists, and GET-only transport are guarded" \
+	verified verified
+
+cat >"$TMP_DIR/facebook-1.json" <<'JSON'
+{
+  "identity":{"data":{"id":"1001","product":"facebook","name":"Fixture Page"}},
+  "pages":[{
+    "expect_request":{"product":"facebook","stream":"posts","after":null,"limit":1},
+    "response":{"status":200,"observed_at":"2026-07-27T10:00:00Z",
+      "data":[{"id":"1001_5001","message":"bounded page post","created_time":"2026-07-01T10:00:00Z"}],
+      "meta":{"product":"facebook","stream":"posts","next_cursor":"cursor-one","complete":false}}
+  }]
+}
+JSON
+first_result=$("$HELPER" sync-meta --product facebook --base "$BASE" \
+	--alias personal:default --connection-id conn_facebook --account-id 1001 \
+	--stream posts --profile fixture --budget 3 --page-size 1 \
+	--fixture "$TMP_DIR/facebook-1.json")
+assert_eq "one Facebook page pauses at the hard request budget" \
+	"$(json_field "$first_result" status)" budget_exhausted
+assert_eq "identity and one Graph page reserve three units" \
+	"$(json_field "$first_result" budget_units)" 3
+assert_eq "Facebook content is stored under its own provider identity" \
+	"$(sql_value "SELECT provider || ':' || text_content FROM objects WHERE remote_id='1001_5001'")" \
+	"facebook:bounded page post"
+assert_eq "Facebook curated activity remains explicit unavailable evidence" \
+	"$(sql_value "SELECT status FROM coverage_records WHERE provider='facebook' AND stream='curated_activity'")" \
+	unavailable
+
+cat >"$TMP_DIR/facebook-2.json" <<'JSON'
+{
+  "identity":{"data":{"id":"1001","product":"facebook","name":"Fixture Page"}},
+  "pages":[{
+    "expect_request":{"product":"facebook","stream":"posts","after":"cursor-one","limit":1},
+    "response":{"status":200,"observed_at":"2026-07-27T10:01:00Z",
+      "data":[{"id":"1001_5002","message":"resumed page post","created_time":"2026-07-02T10:00:00Z"}],
+      "meta":{"product":"facebook","stream":"posts","next_cursor":null,"complete":true}}
+  }]
+}
+JSON
+second_result=$("$HELPER" sync-meta --product facebook --base "$BASE" \
+	--alias personal:default --connection-id conn_facebook --account-id 1001 \
+	--stream posts --profile fixture --page-size 1 \
+	--fixture "$TMP_DIR/facebook-2.json")
+assert_eq "Facebook resumes from its independent opaque cursor" \
+	"$(json_field "$second_result" status)" complete
+assert_eq "Facebook completion clears only its stream cursor" \
+	"$(sql_value "SELECT coalesce(cursor,'done') || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_facebook' AND stream='posts'")" \
+	"done:1"
+
+facebook_batches=$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='facebook'")
+python3 - "$TMP_DIR/facebook-1.json" "$TMP_DIR/facebook-2.json" \
+	"$TMP_DIR/facebook-replay.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    first = json.load(source)
+with open(sys.argv[2], encoding="utf-8") as source:
+    second = json.load(source)
+with open(sys.argv[3], "w", encoding="utf-8") as target:
+    json.dump({"identity": first["identity"], "pages": first["pages"] + second["pages"]}, target)
+PY
+"$HELPER" sync-meta --product facebook --base "$BASE" \
+	--alias personal:default --connection-id conn_facebook --account-id 1001 \
+	--stream posts --profile fixture --budget 5 --page-size 1 \
+	--fixture "$TMP_DIR/facebook-replay.json" >/dev/null
+assert_eq "exact Facebook page replay is content-addressed and idempotent" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='facebook'")" \
+	"$facebook_batches"
+
+cat >"$TMP_DIR/instagram.json" <<'JSON'
+{
+  "identity":{"data":{"id":"2001","product":"instagram","username":"fixture_ig"}},
+  "pages":[{
+    "expect_request":{"product":"instagram","stream":"media","after":null},
+    "response":{"status":200,"observed_at":"2026-07-27T10:02:00Z",
+      "data":[{"id":"6001","caption":"professional media","media_type":"IMAGE","timestamp":"2026-07-03T10:00:00Z"}],
+      "meta":{"product":"instagram","stream":"media","next_cursor":null,"complete":true}}
+  }]
+}
+JSON
+"$HELPER" sync-meta --product instagram --base "$BASE" \
+	--alias personal:default --connection-id conn_instagram --account-id 2001 \
+	--stream media --profile fixture --fixture "$TMP_DIR/instagram.json" >/dev/null
+assert_eq "Instagram media uses a separate provider identity and checkpoint" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='instagram' AND object_type='media' AND remote_id='6001'")" 1
+assert_eq "Instagram relationships remain explicit unavailable evidence" \
+	"$(sql_value "SELECT status FROM coverage_records WHERE provider='instagram' AND stream='relationships'")" \
+	unavailable
+
+object_id=7001
+for stream in posts replies mentions; do
+	cat >"$TMP_DIR/threads-${stream}.json" <<JSON
+{"identity":{"data":{"id":"3001","product":"threads","username":"fixture_threads"}},
+ "pages":[{"expect_request":{"product":"threads","stream":"${stream}","after":null},
+ "response":{"status":200,"observed_at":"2026-07-27T10:03:00Z",
+ "data":[{"id":"${object_id}","text":"threads ${stream}","timestamp":"2026-07-04T10:00:00Z"}],
+ "meta":{"product":"threads","stream":"${stream}","next_cursor":null,"complete":true}}}]}
+JSON
+	"$HELPER" sync-meta --product threads --base "$BASE" \
+		--alias personal:default --connection-id conn_threads --account-id 3001 \
+		--stream "$stream" --profile fixture \
+		--fixture "$TMP_DIR/threads-${stream}.json" >/dev/null
+	object_id=$((object_id + 1))
+done
+assert_eq "Threads posts, replies, and mentions own independent checkpoints" \
+	"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_threads' AND backfill_complete=1")" 3
+assert_eq "observed Threads mentions do not fabricate an authored activity" \
+	"$(sql_value "SELECT count(*) FROM activities WHERE provider='threads' AND activity_type='account_mentioned'")" 0
+assert_eq "observed Threads mentions are not attributed to the selected account" \
+	"$(sql_value "SELECT coalesce(account_remote_id,'none') || ':' || evidence_class FROM objects WHERE provider='threads' AND remote_id='7003'")" \
+	"none:observed"
+assert_eq "Threads relationship coverage remains explicit" \
+	"$(sql_value "SELECT status FROM coverage_records WHERE provider='threads' AND stream='relationships'")" \
+	unavailable
+
+cursor_before=$(sql_value "SELECT backfill_complete FROM sync_cursors WHERE connection_id='conn_facebook' AND stream='posts'")
+cat >"$TMP_DIR/facebook-rate.json" <<'JSON'
+{"identity":{"data":{"id":"1001","product":"facebook"}},
+ "pages":[{"status":429,"observed_at":"2026-07-27T10:04:00Z","retry_after":1785232800}]}
+JSON
+rate_result=$("$HELPER" sync-meta --product facebook --base "$BASE" \
+	--alias personal:default --connection-id conn_facebook --account-id 1001 \
+	--stream posts --profile fixture --fixture "$TMP_DIR/facebook-rate.json")
+assert_eq "terminal Meta rate limits are sanitized" \
+	"$(json_field "$rate_result" failure_class)" rate_limit
+assert_eq "terminal Meta failures preserve the prior checkpoint" \
+	"$(sql_value "SELECT backfill_complete FROM sync_cursors WHERE connection_id='conn_facebook' AND stream='posts'")" \
+	"$cursor_before"
+
+cat >"$TMP_DIR/facebook-credential.json" <<'JSON'
+{"identity":{"data":{"id":"1001","product":"facebook"}},
+ "pages":[{"status":200,"observed_at":"2026-07-27T10:05:00Z",
+ "data":[{"id":"5999","access_token":"must-not-persist"}],
+ "meta":{"product":"facebook","stream":"posts","next_cursor":null,"complete":true}}]}
+JSON
+raw_before_credential=$(raw_count facebook)
+expect_sync_failure "credential-shaped Meta data is rejected" facebook 1001 posts \
+	"$TMP_DIR/facebook-credential.json"
+assert_eq "credential rejection creates no Facebook raw evidence" \
+	"$(raw_count facebook)" "$raw_before_credential"
+
+cat >"$TMP_DIR/facebook-wrong-account.json" <<'JSON'
+{"identity":{"data":{"id":"1999","product":"facebook"}},"pages":[]}
+JSON
+raw_before_mismatch=$(raw_count facebook)
+expect_sync_failure "Meta account rebinding fails before collection" facebook 1001 posts \
+	"$TMP_DIR/facebook-wrong-account.json"
+assert_eq "identity mismatch creates no Facebook raw evidence" \
+	"$(raw_count facebook)" "$raw_before_mismatch"
+
+python3 - "$ROOT" "$SCRIPT_DIR/../scripts" <<'PY'
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[2])
+from _knowledge_social_collect import (
+    CollectionContext, ConnectionConfig, CursorState, PageCheckpoint, SuccessfulPage,
+)
+from _knowledge_social_collect_persist import persist_page
+from _knowledge_social_lease import (
+    RunLeaseRequest, SocialLeaseLostError, acquire_run_lease, release_run_lease,
+)
+from _knowledge_social_meta import PRODUCTS
+
+root = Path(sys.argv[1])
+old = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_meta_fence", "posts", "old_runner", "sync", 1),
+    now_epoch=9000,
+)
+new = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_meta_fence", "posts", "new_runner", "sync", 10),
+    now_epoch=9001,
+)
+context = CollectionContext(
+    root,
+    "conn_meta_fence",
+    {"id": "4001", "product": "facebook"},
+    "posts",
+    "none",
+    ConnectionConfig(("posts",), {"media_hydration": "none"}),
+    CursorState(None, None, False),
+    PRODUCTS["facebook"].streams["posts"],
+    old,
+    "facebook",
+)
+archive = {
+    "provider": "facebook",
+    "connection_id": "conn_meta_fence",
+    "remote_account_id": "4001",
+    "exported_at": "2026-07-27T10:06:00Z",
+    "enabled_streams": ["posts"],
+    "policy": {"media_hydration": "none"},
+    "accounts": [], "objects": [], "activities": [], "media": [], "coverage": [],
+}
+page = SuccessfulPage(
+    {
+        "status": 200,
+        "observed_at": archive["exported_at"],
+        "data": [],
+        "meta": {"product": "facebook", "stream": "posts"},
+    },
+    '{"product":"facebook","stream":"posts"}',
+    archive,
+    PageCheckpoint(None, None),
+    True,
+    2,
+)
+os.environ["AIDEVOPS_SOCIAL_NOW_EPOCH"] = "9001"
+try:
+    persist_page(context, page)
+except SocialLeaseLostError:
+    pass
+else:
+    raise SystemExit("stale Meta collector advanced persistence")
+with sqlite3.connect(root / "index" / "social.db") as database:
+    cursor = database.execute(
+        "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_meta_fence'"
+    ).fetchone()[0]
+assert cursor == 0
+release_run_lease(root, new)
+PY
+assert_eq "stale Meta lease cannot commit evidence or a cursor" verified verified
+
+mkdir -p "$TMP_DIR/fake-meta"
+cat >"$TMP_DIR/fake-meta/sitecustomize.py" <<'PY'
+import json
+import os
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+import urllib.request
+
+
+class Response:
+    status = 200
+
+    def __init__(self, payload):
+        self.payload = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, _limit):
+        return self.payload
+
+
+def fake_urlopen(request, timeout):
+    parsed = urlparse(request.full_url)
+    query = parse_qs(parsed.query)
+    path = parsed.path
+    is_page = path.endswith("/4001/posts")
+    log_path = Path(os.environ["META_READ_LOG"])
+    headers = {key.lower(): value for key, value in request.header_items()}
+    row = {
+        "kind": "page" if is_page else "identity",
+        "host": parsed.hostname,
+        "path": path,
+        "method": request.get_method(),
+        "fields": query.get("fields", [None])[0],
+        "limit": query.get("limit", [None])[0],
+        "bearer": headers.get("authorization", "").startswith("Bearer "),
+        "selected_secret": "META_FIXTURE_FACEBOOK_ACCESS_TOKEN" in os.environ,
+        "instagram_secret": "META_FIXTURE_INSTAGRAM_ACCESS_TOKEN" in os.environ,
+        "threads_secret": "META_FIXTURE_THREADS_ACCESS_TOKEN" in os.environ,
+        "unrelated_secret": "UNRELATED_PROVIDER_TOKEN" in os.environ,
+        "timeout": timeout,
+    }
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row, sort_keys=True) + "\n")
+    if path.endswith("/4001"):
+        calls = sum(
+            json.loads(line)["kind"] == "identity"
+            for line in log_path.read_text(encoding="utf-8").splitlines()
+        )
+        rebound = log_path.name == "meta-rebind.log" and calls > 1
+        return Response({
+            "id": "4999" if rebound else "4001",
+            "name": "Guarded Page",
+            "category": "Fixture",
+        })
+    if is_page:
+        return Response({
+            "data": [{
+                "id": "4001_8001",
+                "message": "guarded live Meta evidence",
+                "created_time": "2026-07-27T10:07:00Z",
+            }]
+        })
+    raise RuntimeError("unexpected endpoint")
+
+
+urllib.request.urlopen = fake_urlopen
+PY
+: >"$TMP_DIR/meta-read.log"
+chmod 0600 "$TMP_DIR/meta-read.log"
+live_result=$(
+	PYTHONPATH="$TMP_DIR/fake-meta" META_READ_LOG="$TMP_DIR/meta-read.log" \
+		META_FIXTURE_FACEBOOK_ACCESS_TOKEN=fixture-token \
+		META_FIXTURE_INSTAGRAM_ACCESS_TOKEN=other-product \
+		META_FIXTURE_THREADS_ACCESS_TOKEN=other-product \
+		UNRELATED_PROVIDER_TOKEN=unrelated \
+		"$HELPER" sync-meta --product facebook --base "$BASE" \
+		--alias personal:default --connection-id conn_meta_live --account-id 4001 \
+		--stream posts --profile fixture --budget 3 --page-size 7
+)
+assert_eq "guarded live Meta boundary persists one Facebook page" \
+	"$(json_field "$live_result" status)" complete
+live_guard=$(
+	python3 - "$TMP_DIR/meta-read.log" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+rows = [json.loads(line) for line in Path(sys.argv[1]).read_text().splitlines()]
+identities = [row for row in rows if row["kind"] == "identity"]
+pages = [row for row in rows if row["kind"] == "page"]
+safe = (
+    len(identities) == 2
+    and len(pages) == 1
+    and pages[0]["limit"] == "7"
+    and all(row["host"] == "graph.facebook.com" for row in rows)
+    and all(row["method"] == "GET" and row["bearer"] for row in rows)
+    and all(row["selected_secret"] for row in rows)
+    and all(not row["instagram_secret"] for row in rows)
+    and all(not row["threads_secret"] for row in rows)
+    and all(not row["unrelated_secret"] for row in rows)
+    and all(row["timeout"] == 60 for row in rows)
+)
+print("bounded-read-only" if safe else "unsafe")
+PY
+)
+assert_eq "live Meta boundary revalidates identity and passes only selected credentials" \
+	"$live_guard" bounded-read-only
+assert_eq "guarded live Meta evidence reaches the provider-neutral corpus" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='facebook' AND remote_id='4001_8001'")" 1
+
+: >"$TMP_DIR/meta-rebind.log"
+chmod 0600 "$TMP_DIR/meta-rebind.log"
+raw_before_rebind=$(raw_count facebook)
+if PYTHONPATH="$TMP_DIR/fake-meta" META_READ_LOG="$TMP_DIR/meta-rebind.log" \
+	META_FIXTURE_FACEBOOK_ACCESS_TOKEN=fixture-token \
+	"$HELPER" sync-meta --product facebook --base "$BASE" \
+	--alias personal:default --connection-id conn_meta_rebind --account-id 4001 \
+	--stream posts --profile fixture --budget 3 --page-size 7 \
+	>/dev/null 2>&1; then
+	rebind_result=accepted
+else
+	rebind_result=rejected
+fi
+assert_eq "live Meta boundary rejects account rebinding before the stream read" \
+	"$rebind_result" rejected
+assert_eq "per-page Meta identity mismatch creates no raw evidence" \
+	"$(raw_count facebook)" "$raw_before_rebind"
+
+assert_eq "each Meta product persists a distinct account identity" \
+	"$(sql_value "SELECT count(DISTINCT provider) FROM accounts WHERE provider IN ('facebook','instagram','threads')")" 3
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -ne 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds isolated, GET-only Facebook, Instagram, and Threads account collectors with per-product identities, allowlisted fields and edges, independent cursors, explicit coverage gaps, and operator evidence.

## Files Changed

- `.agents/scripts/knowledge_social_meta.py` and `_knowledge_social_meta*.py`: product manifests, guarded OAuth reads, response contracts, normalization, cursors, and persistence integration.
- `.agents/scripts/knowledge-social-helper.sh`: `sync-meta` CLI and help wiring.
- `.agents/tests/test-knowledge-social-meta.sh`: fixture, live-boundary, stale-lease, identity, credential, terminal-failure, idempotency, and mutation-exclusion coverage.
- `.agents/content/social-meta.md` and the social capability matrix: verified routes, permission/account gates, retention, exports, and unsupported categories.

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Meta fixture/live-boundary suite passes 28/28; social corpus, sync, X, Reddit, YouTube, LinkedIn, query, sharing, browser-gap, and operations suites pass; ShellCheck, Python compileall, and changed-file lint pass.

## Review

- Independent closeout review: clean.
- Evidence bundle: `969dc36d9b624a0c02f2fb284cf47f1eab343dc4165780bf18bf613fe5a8f3c4`.

## Key Decisions

- Use stdlib `urllib` because no Meta client SDK is installed.
- Isolate credentials, stable identities, streams, and checkpoints by product.
- Expose only verified official read routes; unsupported and export-only capabilities remain explicit coverage evidence.
- Treat Threads mentions as observed third-party content rather than selected-account authorship.

Resolves #28669
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 1h 3m and 730,898 tokens on this as a headless worker.