### PR TITLE
GH#28763: fix: terminate MCP timeout process groups

### DIFF
--- a/.agents/scripts/mcp-config-adapter.sh
+++ b/.agents/scripts/mcp-config-adapter.sh
@@ -55,44 +55,111 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 # shellcheck source=ai-cli-config.sh
 source "${SCRIPT_DIR}/ai-cli-config.sh"
 
-_mcp_adapter_run_with_timeout() {
+_mcp_adapter_kill_timeout_target() {
+	local child_pid="$1"
+	local child_pgid="$2"
+	local kill_after_seconds="$3"
+	local self_pgid=""
+	local signal_target="$child_pid"
+	[[ -n "$child_pid" ]] || return 0
+
+	self_pgid="$(ps -o pgid= -p "$$" 2>/dev/null | tr -d '[:space:]')" || true
+	if [[ -n "$child_pgid" && -n "$self_pgid" && "$child_pgid" != "$self_pgid" ]]; then
+		signal_target="-${child_pgid}"
+	fi
+
+	if ! kill -0 -- "$signal_target" 2>/dev/null; then
+		return 0
+	fi
+
+	kill -TERM -- "$signal_target" 2>/dev/null || true
+	sleep "$kill_after_seconds"
+	if kill -0 -- "$signal_target" 2>/dev/null; then
+		kill -KILL -- "$signal_target" 2>/dev/null || true
+	fi
+	return 0
+}
+
+_mcp_adapter_timeout_watchdog() {
+	local timeout_seconds="$1"
+	local child_pid="$2"
+	local child_pgid="$3"
+	local kill_after_seconds="$4"
+	local timeout_marker="$5"
+
+	sleep "$timeout_seconds"
+	if kill -0 "$child_pid" 2>/dev/null; then
+		printf 'timed-out\n' >"$timeout_marker"
+		_mcp_adapter_kill_timeout_target "$child_pid" "$child_pgid" "$kill_after_seconds"
+	fi
+	return 0
+}
+
+_mcp_adapter_timeout_cleanup() {
+	local watchdog_pid="$1"
+	local child_pid="$2"
+	local child_pgid="$3"
+	local kill_after_seconds="$4"
+	local timeout_marker="$5"
+
+	if [[ -n "$watchdog_pid" ]]; then
+		kill "$watchdog_pid" 2>/dev/null || true
+		wait "$watchdog_pid" 2>/dev/null || true
+	fi
+	_mcp_adapter_kill_timeout_target "$child_pid" "$child_pgid" "$kill_after_seconds"
+	wait "$child_pid" 2>/dev/null || true
+	rm -f "$timeout_marker"
+	return 0
+}
+
+_mcp_adapter_run_with_timeout() (
 	local timeout_seconds="$1"
 	shift
 	local kill_after_seconds="${AIDEVOPS_MCP_TIMEOUT_KILL_AFTER_SECONDS:-2}"
+	local timeout_marker=""
+	local child_pid=""
+	local child_pgid=""
+	local watchdog_pid=""
+	local command_status=0
+	local monitor_was_enabled=false
 
-	if command -v timeout >/dev/null 2>&1; then
-		if _mcp_adapter_timeout_supports_kill_after timeout; then
-			timeout -k "${kill_after_seconds}s" "${timeout_seconds}s" "$@"
-		else
-			timeout "${timeout_seconds}s" "$@"
-		fi
-		return $?
+	timeout_marker="$(mktemp "${TMPDIR:-/tmp}/aidevops-mcp-timeout.XXXXXX")"
+	trap '_mcp_adapter_timeout_cleanup "$watchdog_pid" "$child_pid" "$child_pgid" "$kill_after_seconds" "$timeout_marker"' EXIT
+
+	if command -v setsid >/dev/null 2>&1; then
+		setsid "$@" &
+		child_pid=$!
+		child_pgid="$child_pid"
+	else
+		# Bash job control gives a background command its own process group on
+		# macOS systems where setsid is unavailable. Restore the caller's mode
+		# immediately after launch so sourcing this adapter has no lasting effect.
+		[[ $- == *m* ]] && monitor_was_enabled=true
+		set -m
+		"$@" &
+		child_pid=$!
+		child_pgid="$child_pid"
+		$monitor_was_enabled && set -m || set +m
 	fi
 
-	if command -v gtimeout >/dev/null 2>&1; then
-		if _mcp_adapter_timeout_supports_kill_after gtimeout; then
-			gtimeout -k "${kill_after_seconds}s" "${timeout_seconds}s" "$@"
-		else
-			gtimeout "${timeout_seconds}s" "$@"
-		fi
-		return $?
+	_mcp_adapter_timeout_watchdog "$timeout_seconds" "$child_pid" "$child_pgid" "$kill_after_seconds" "$timeout_marker" &
+	watchdog_pid=$!
+
+	if wait "$child_pid"; then
+		command_status=0
+	else
+		command_status=$?
 	fi
 
-	if command -v perl >/dev/null 2>&1; then
-		perl -e 'alarm shift @ARGV; exec @ARGV' "$timeout_seconds" "$@"
-		return $?
+	if [[ -s "$timeout_marker" ]]; then
+		wait "$watchdog_pid" 2>/dev/null || true
+		return 124
 	fi
 
-	"$@"
-	return $?
-}
-
-_mcp_adapter_timeout_supports_kill_after() {
-	local timeout_cmd="$1"
-
-	"$timeout_cmd" --help 2>&1 | grep -q -- '-k'
-	return $?
-}
+	kill "$watchdog_pid" 2>/dev/null || true
+	wait "$watchdog_pid" 2>/dev/null || true
+	return "$command_status"
+)
 
 _MCP_ADAPTER_CLAUDE_EXISTING_CACHE=""
 _MCP_ADAPTER_CLAUDE_LIST_STATUS_CACHE=""

--- a/.agents/scripts/tests/test-mcp-config-adapter-claude-timeout.sh
+++ b/.agents/scripts/tests/test-mcp-config-adapter-claude-timeout.sh
@@ -69,27 +69,6 @@ EOF
 	return 0
 }
 
-make_stub_timeout_with_kill_after_log() {
-	local temp_dir="$1"
-
-	cat >"${temp_dir}/timeout" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-if [[ "${1:-}" == "--help" ]]; then
-	printf 'Usage: timeout [-k DURATION] DURATION COMMAND\n'
-	exit 0
-fi
-printf '%s\n' "$*" >"${TIMEOUT_STUB_ARGS_FILE:?}"
-if [[ "${1:-}" == "-k" ]]; then
-	shift 2
-fi
-shift
-"$@"
-EOF
-	chmod +x "${temp_dir}/timeout"
-	return 0
-}
-
 run_claude_registration_with_stub() {
 	local mode="$1"
 	local temp_dir
@@ -98,11 +77,14 @@ run_claude_registration_with_stub() {
 
 	make_stub_claude "$temp_dir" "$mode"
 
-	PATH="${temp_dir}:$PATH" AIDEVOPS_MCP_CLAUDE_TIMEOUT_SECONDS=1 bash -c '
+	PATH="${temp_dir}:$PATH" AIDEVOPS_MCP_CLAUDE_TIMEOUT_SECONDS=1 \
+		AIDEVOPS_MCP_TIMEOUT_KILL_AFTER_SECONDS=0.2 bash -c '
 		set -euo pipefail
 		source "$1"
 		_register_mcp_claude "macos-automator" "{\"command\":\"npx\",\"args\":[\"-y\",\"@example/mcp\"]}"
 	' bash "$ADAPTER"
+	trap - RETURN
+	rm -rf "$temp_dir"
 	return 0
 }
 
@@ -127,30 +109,9 @@ run_two_claude_registrations_with_stub() {
 	if [[ -f "$list_count_file" ]]; then
 		read -r list_count <"$list_count_file" || list_count=0
 	fi
+	trap - RETURN
+	rm -rf "$temp_dir"
 	printf '%s\n' "$list_count"
-	return 0
-}
-
-run_timeout_with_stub() {
-	local temp_dir args_file
-	temp_dir="$(mktemp -d)"
-	trap 'rm -rf "$temp_dir"' RETURN
-	args_file="${temp_dir}/timeout-args"
-
-	make_stub_claude "$temp_dir" "ok"
-	make_stub_timeout_with_kill_after_log "$temp_dir"
-
-	PATH="${temp_dir}:$PATH" TIMEOUT_STUB_ARGS_FILE="$args_file" bash -c '
-		set -euo pipefail
-		source "$1"
-		_mcp_adapter_run_with_timeout 1 claude mcp list >/dev/null
-	' bash "$ADAPTER"
-
-	if [[ -f "$args_file" ]]; then
-		local timeout_args
-		read -r timeout_args <"$args_file" || timeout_args=""
-		printf '%s\n' "$timeout_args"
-	fi
 	return 0
 }
 
@@ -199,16 +160,115 @@ test_claude_mcp_list_is_cached_per_registration_pass() {
 	return 0
 }
 
-test_timeout_uses_kill_after_when_available() {
-	local timeout_args
-	timeout_args="$(run_timeout_with_stub)"
+test_timeout_terminates_process_group() {
+	local temp_dir fixture child_pid_file grandchild_pid_file status child_pid grandchild_pid isolation_mode
+	local failure_message=""
+	temp_dir="$(mktemp -d)"
+	trap 'rm -rf "$temp_dir"' RETURN
+	fixture="${temp_dir}/spawn-tree.sh"
+	child_pid_file="${temp_dir}/child.pid"
+	grandchild_pid_file="${temp_dir}/grandchild.pid"
+	cat >"$fixture" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+child_pid_file="$1"
+grandchild_pid_file="$2"
+bash -c 'sleep 30 & printf "%s\n" "$!" >"$1"; wait' bash "$grandchild_pid_file" &
+printf '%s\n' "$!" >"$child_pid_file"
+wait
+EOF
+	chmod +x "$fixture"
 
-	if [[ "$timeout_args" == "-k 2s 1s claude mcp list" ]]; then
-		print_result "timeout uses kill-after when supported" 0
+	for isolation_mode in auto fallback; do
+		rm -f "$child_pid_file" "$grandchild_pid_file"
+		set +e
+		AIDEVOPS_MCP_TIMEOUT_KILL_AFTER_SECONDS=0.2 bash -c '
+			set -euo pipefail
+			source "$1"
+			if [[ "$5" == "fallback" ]]; then
+				command() {
+					local command_flag="${1:-}"
+					local command_name="${2:-}"
+					if [[ "$command_flag" == "-v" && "$command_name" == "setsid" ]]; then
+						return 1
+					fi
+					builtin command "$@"
+					return $?
+				}
+			fi
+			_mcp_adapter_run_with_timeout 1 "$2" "$3" "$4"
+		' bash "$ADAPTER" "$fixture" "$child_pid_file" "$grandchild_pid_file" "$isolation_mode" >/dev/null 2>&1
+		status=$?
+		set -e
+
+		child_pid="$(read_pid_file "$child_pid_file")" || true
+		grandchild_pid="$(read_pid_file "$grandchild_pid_file")" || true
+		if [[ "$status" -ne 124 ]] || pid_is_alive "$child_pid" || pid_is_alive "$grandchild_pid"; then
+			failure_message="mode=${isolation_mode} status=${status} child=${child_pid:-missing} grandchild=${grandchild_pid:-missing}"
+			break
+		fi
+	done
+
+	trap - RETURN
+	rm -rf "$temp_dir"
+	if [[ -z "$failure_message" ]]; then
+		print_result "timeout terminates process group with setsid and portable fallback" 0
 		return 0
 	fi
 
-	print_result "timeout uses kill-after when supported" 1 "timeout_args=${timeout_args}"
+	print_result "timeout terminates child and grandchild process group" 1 \
+		"$failure_message"
+	return 0
+}
+
+read_pid_file() {
+	local pid_file="$1"
+	local pid=""
+	local attempts=20
+
+	while [[ "$attempts" -gt 0 ]]; do
+		if [[ -s "$pid_file" ]]; then
+			read -r pid <"$pid_file" || pid=""
+			printf '%s\n' "$pid"
+			return 0
+		fi
+		sleep 0.1
+		attempts=$((attempts - 1))
+	done
+	return 1
+}
+
+pid_is_alive() {
+	local pid="$1"
+	[[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null
+	return $?
+}
+
+test_success_preserves_output_and_status() {
+	local output status failure_status
+
+	set +e
+	output="$(bash -c '
+		set -euo pipefail
+		source "$1"
+		_mcp_adapter_run_with_timeout 5 bash -c '\''printf "ready\\n"; exit 0'\''
+	' bash "$ADAPTER")"
+	status=$?
+	bash -c '
+		set -euo pipefail
+		source "$1"
+		_mcp_adapter_run_with_timeout 5 bash -c '\''exit 7'\''
+	' bash "$ADAPTER" >/dev/null 2>&1
+	failure_status=$?
+	set -e
+
+	if [[ "$status" -eq 0 && "$output" == "ready" && "$failure_status" -eq 7 ]]; then
+		print_result "successful command preserves output and status" 0
+		return 0
+	fi
+
+	print_result "successful command preserves output and status" 1 \
+		"status=${status} failure_status=${failure_status} output=${output}"
 	return 0
 }
 
@@ -216,7 +276,8 @@ main() {
 	test_claude_mcp_list_timeout_is_non_blocking
 	test_claude_mcp_add_timeout_is_non_blocking
 	test_claude_mcp_list_is_cached_per_registration_pass
-	test_timeout_uses_kill_after_when_available
+	test_timeout_terminates_process_group
+	test_success_preserves_output_and_status
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary

Run bounded MCP CLI commands in isolated process groups, terminate descendants on timeout or wrapper exit, and retain a macOS Bash job-control fallback.

## Files Changed

.agents/scripts/mcp-config-adapter.sh, .agents/scripts/tests/test-mcp-config-adapter-claude-timeout.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash -n and ShellCheck on the adapter and focused test; bash .agents/scripts/tests/test-mcp-config-adapter-claude-timeout.sh

Resolves #28763


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 7m and 103,665 tokens on this as a headless worker.