### PR TITLE
GH#28766: Pin OpenCode 1.18.5 for headless workers

### DIFF
--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -145,10 +145,10 @@ aidevops_ensure_pulse_start_epoch() {
 # Set to "latest" to resume tracking upstream. Grep for the variable name to
 # find all consumers that need updating when unpinning.
 
-# OpenCode unpinned: root cause was SQLite contention (shared DB, busy_timeout=0),
-# not version-specific. Fixed by DB isolation per worker (v3.6.130).
-# Upstream context: https://github.com/anomalyco/opencode/issues/21215
-readonly OPENCODE_PINNED_VERSION="latest"
+# GH#28766: OpenCode 1.18.7 stalls Linux headless workers while bootstrapping
+# location services with an isolated XDG_DATA_HOME. Keep the last verified
+# working release until a newer version passes that same headless smoke test.
+readonly OPENCODE_PINNED_VERSION="1.18.5"
 
 # Minimum GitHub CLI version required for `gh api --paginate --slurp`.
 # Older distro packages can parse `gh` as installed while dispatch paths fail

--- a/.agents/scripts/tests/test-tool-version-check-opencode.sh
+++ b/.agents/scripts/tests/test-tool-version-check-opencode.sh
@@ -10,9 +10,11 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 TOOL_VERSION_CHECK="$REPO_ROOT/.agents/scripts/tool-version-check.sh"
+SHARED_CONSTANTS="$REPO_ROOT/.agents/scripts/shared-constants.sh"
+HEADLESS_RUNTIME_LIB="$REPO_ROOT/.agents/scripts/headless-runtime-lib.sh"
 
-if [[ ! -f "$TOOL_VERSION_CHECK" ]]; then
-	printf 'FAIL: cannot find %s\n' "$TOOL_VERSION_CHECK" >&2
+if [[ ! -f "$TOOL_VERSION_CHECK" || ! -f "$SHARED_CONSTANTS" || ! -f "$HEADLESS_RUNTIME_LIB" ]]; then
+	printf 'FAIL: cannot find OpenCode version policy sources\n' >&2
 	exit 1
 fi
 
@@ -43,8 +45,12 @@ extract_function() {
 	awk '
 		/^_opencode_upgrade_cmd\(\)/, /^}$/ { print; next }
 	' "$TOOL_VERSION_CHECK" >"$SANDBOX/extract.sh"
-	if ! grep -q '^_opencode_upgrade_cmd()' "$SANDBOX/extract.sh"; then
-		printf 'FAIL: extraction did not capture _opencode_upgrade_cmd\n' >&2
+	awk '
+		/^_enforce_opencode_version_pin\(\)/, /^}$/ { print; next }
+	' "$HEADLESS_RUNTIME_LIB" >>"$SANDBOX/extract.sh"
+	if ! grep -q '^_opencode_upgrade_cmd()' "$SANDBOX/extract.sh" ||
+		! grep -q '^_enforce_opencode_version_pin()' "$SANDBOX/extract.sh"; then
+		printf 'FAIL: extraction did not capture OpenCode version functions\n' >&2
 		exit 1
 	fi
 	return 0
@@ -67,6 +73,11 @@ write_executable() {
 }
 
 extract_function
+
+printf 'Test 0: OpenCode remains pinned to the last verified headless release\n'
+# shellcheck source=../shared-constants.sh
+source "$SHARED_CONSTANTS"
+assert_eq "OpenCode headless regression pin" "1.18.5" "$OPENCODE_PINNED_VERSION"
 
 printf 'Test 1: Homebrew OpenCode chooses brew instead of npm\n'
 mkdir -p "$SANDBOX/opt/homebrew/bin" "$SANDBOX/opt/homebrew/Cellar/opencode/1.15.10/bin" "$SANDBOX/opt/homebrew/opt" "$SANDBOX/homebrew-case"
@@ -147,6 +158,22 @@ printf "npm %s\n" "$*" >>"'"$SANDBOX"'/npm-case/calls"'
 	PATH="$SANDBOX/npm-bin:$SANDBOX/npm-case:$SYSTEM_PATH" bash -c "$cmd"
 )
 assert_eq "npm OpenCode upgrade command" "npm install -g opencode-ai@1.15.10" "$(tr '\n' ';' <"$SANDBOX/npm-case/calls" | sed 's/;$//')"
+
+printf 'Test 4: headless version guard restores the pinned release\n'
+mkdir -p "$SANDBOX/version-guard"
+write_executable "$SANDBOX/version-guard/opencode" '#!/usr/bin/env bash
+printf "1.18.7\n"'
+# shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
+write_executable "$SANDBOX/version-guard/npm" '#!/usr/bin/env bash
+printf "%s\n" "$*" >>"'"$SANDBOX"'/version-guard/calls"'
+(
+	source_extracted
+	OPENCODE_BIN_DEFAULT="$SANDBOX/version-guard/opencode"
+	print_warning() { return 0; }
+	print_info() { return 0; }
+	PATH="$SANDBOX/version-guard:$SYSTEM_PATH" _enforce_opencode_version_pin
+)
+assert_eq "headless pin reinstall command" "install -g opencode-ai@1.18.5" "$(tr '\n' ';' <"$SANDBOX/version-guard/calls" | sed 's/;$//')"
 
 printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
 if [[ "$FAIL" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Pin OpenCode to the last verified Linux headless release and add regression coverage for the shared pin and pre-canary drift guard.

## Files Changed

.agents/scripts/shared-constants.sh, .agents/scripts/tests/test-tool-version-check-opencode.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — linters-local.sh; shellcheck; 6 OpenCode version-policy tests; 38 OpenCode install tests

Resolves #28766


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 25m and 307,651 tokens on this with the user in an interactive session.