### PR TITLE
GH#28758: bridge checkout-free planning publication to merge gate

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -34,6 +34,12 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _lib_path
 fi
 
+# Checkout-free planning publication receipts provide the only narrow exception
+# to same-named local-branch head equality. The verifier revalidates all evidence.
+# shellcheck source=./planning-publisher.sh
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/planning-publisher.sh"
+
 # --- Pre-Merge Gate ---
 
 # Pre-merge gate (GH#17541) — deterministic enforcement of review-bot-gate
@@ -230,8 +236,15 @@ _full_loop_verify_pr_readiness() {
 		local local_head=""
 		local_head=$(git rev-parse HEAD 2>/dev/null || true)
 		if [[ -z "$local_head" || "$local_head" != "$verified_head" ]]; then
-			print_error "PR #${pr_number} head drifted from the current worktree; push or refresh review evidence before merge"
-			return 1
+			local repo_root=""
+			repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+			if [[ -n "$repo_root" ]] && planning_verify_publication_receipt \
+				"$repo_root" origin "$pr_head_ref" "$verified_head"; then
+				print_info "Verified checkout-free planning publication receipt at PR head ${verified_head}; local Git state remains untouched"
+			else
+				print_error "PR #${pr_number} head drifted from the current worktree without a valid checkout-free planning publication receipt; push or refresh review evidence before merge"
+				return 1
+			fi
 		fi
 	fi
 	_full_loop_persist_pr_check_evidence "$FULL_LOOP_PR_CHECK_STATUS" "$verified_head" "$FULL_LOOP_REQUIRED_CHECKS_SUCCESS_EVIDENCE" || true

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -501,21 +501,55 @@ _merge_fetch_pinned_commit_objects() {
 	local base_ref="$2"
 	local base_sha="$3"
 	local head_sha="$4"
+	local object_repo="${5:-}"
+	local remote_url="${6:-}"
+	local fetched_sha=""
+	local -a git_context=()
+	[[ -n "$object_repo" ]] && git_context=(-C "$object_repo")
 
-	if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
-		git fetch --quiet --no-tags origin "refs/heads/${base_ref}" || return 1
+	if ! git "${git_context[@]}" cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+		if [[ -n "$object_repo" ]]; then
+			[[ -n "$remote_url" ]] || return 1
+			git -C "$object_repo" fetch --quiet --no-tags "$remote_url" "refs/heads/${base_ref}" || return 1
+			fetched_sha=$(git -C "$object_repo" rev-parse FETCH_HEAD 2>/dev/null) || return 1
+			[[ "$fetched_sha" == "$base_sha" ]] || return 1
+		else
+			git fetch --quiet --no-tags origin "refs/heads/${base_ref}" || return 1
+		fi
 	fi
-	if ! git cat-file -e "${head_sha}^{commit}" 2>/dev/null; then
-		git fetch --quiet --no-tags origin "refs/pull/${pr_number}/head" || return 1
+	if ! git "${git_context[@]}" cat-file -e "${head_sha}^{commit}" 2>/dev/null; then
+		if [[ -n "$object_repo" ]]; then
+			[[ -n "$remote_url" ]] || return 1
+			git -C "$object_repo" fetch --quiet --no-tags "$remote_url" "refs/pull/${pr_number}/head" || return 1
+			fetched_sha=$(git -C "$object_repo" rev-parse FETCH_HEAD 2>/dev/null) || return 1
+			[[ "$fetched_sha" == "$head_sha" ]] || return 1
+		else
+			git fetch --quiet --no-tags origin "refs/pull/${pr_number}/head" || return 1
+		fi
 	fi
-	git cat-file -e "${base_sha}^{commit}" 2>/dev/null || return 1
-	git cat-file -e "${head_sha}^{commit}" 2>/dev/null || return 1
+	git "${git_context[@]}" cat-file -e "${base_sha}^{commit}" 2>/dev/null || return 1
+	git "${git_context[@]}" cat-file -e "${head_sha}^{commit}" 2>/dev/null || return 1
+	return 0
+}
+
+_merge_create_prospective_object_context() {
+	local context_root="$1"
+	local object_repo="${context_root}/repository.git"
+	local source_objects=""
+	local object_format=""
+	source_objects=$(git rev-parse --path-format=absolute --git-path objects 2>/dev/null) || return 1
+	object_format=$(git rev-parse --show-object-format 2>/dev/null || true)
+	[[ -n "$source_objects" && -n "$object_format" ]] || return 1
+	git -C "$context_root" init --bare --quiet --object-format="$object_format" repository.git || return 1
+	[[ -d "${object_repo}/objects/info" ]] || return 1
+	printf '%s\n' "$source_objects" >"${object_repo}/objects/info/alternates" || return 1
+	printf '%s\n' "$object_repo"
 	return 0
 }
 
 # Fail closed unless the exact current PR head can be merged prospectively into
 # the fresh base without introducing duplicate TODO task IDs or issue mappings.
-_merge_guard_prospective_todo() {
+_merge_guard_prospective_todo() (
 	local pr_number="$1"
 	local repo="$2"
 	local refs=""
@@ -525,6 +559,8 @@ _merge_guard_prospective_todo() {
 	local merge_tree_output=""
 	local merge_tree_sha=""
 	local temp_dir=""
+	local object_repo=""
+	local remote_url=""
 	local report=""
 	local report_rc="0"
 
@@ -541,39 +577,43 @@ _merge_guard_prospective_todo() {
 		print_error "Merge blocked: PR head changed before prospective TODO validation"
 		return 1
 	fi
-	_merge_fetch_pinned_commit_objects "$pr_number" "$base_ref" "$base_sha" "$head_sha" || {
+	temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-prospective-todo.XXXXXX") || {
+		print_error "Merge blocked: unable to create isolated prospective Git context"
+		return 1
+	}
+	trap 'rm -rf "$temp_dir"' EXIT HUP INT TERM
+	object_repo=$(_merge_create_prospective_object_context "$temp_dir") || {
+		print_error "Merge blocked: unable to initialize isolated prospective Git context"
+		return 1
+	}
+	remote_url=$(git remote get-url origin 2>/dev/null || true)
+	_merge_fetch_pinned_commit_objects "$pr_number" "$base_ref" "$base_sha" "$head_sha" "$object_repo" "$remote_url" || {
 		print_error "Merge blocked: unable to materialize pinned PR commits for prospective TODO validation"
 		return 1
 	}
 
-	if ! merge_tree_output=$(git merge-tree --write-tree "$base_sha" "$head_sha" 2>&1); then
+	if ! merge_tree_output=$(git -C "$object_repo" merge-tree --write-tree "$base_sha" "$head_sha" 2>&1); then
 		print_error "Merge blocked: prospective merge-tree evidence is indeterminate"
 		printf '%s\n' "$merge_tree_output" >&2
 		return 1
 	fi
 	merge_tree_sha=$(printf '%s\n' "$merge_tree_output" | sed -n '1p')
 	if ! [[ "$merge_tree_sha" =~ ^[0-9a-fA-F]{40,64}$ ]] || \
-		! git cat-file -e "${merge_tree_sha}^{tree}" 2>/dev/null; then
+		! git -C "$object_repo" cat-file -e "${merge_tree_sha}^{tree}" 2>/dev/null; then
 		print_error "Merge blocked: prospective merge-tree did not produce a verifiable tree"
 		return 1
 	fi
 
 	# Repositories without TODO.md have no task mapping surface to validate.
-	if ! git cat-file -e "${merge_tree_sha}:TODO.md" 2>/dev/null; then
+	if ! git -C "$object_repo" cat-file -e "${merge_tree_sha}:TODO.md" 2>/dev/null; then
 		return 0
 	fi
-	temp_dir=$(mktemp -d) || {
-		print_error "Merge blocked: unable to create prospective TODO validation workspace"
-		return 1
-	}
-	if ! git show "${merge_tree_sha}:TODO.md" >"${temp_dir}/merged"; then
-		rm -rf "$temp_dir"
+	if ! git -C "$object_repo" show "${merge_tree_sha}:TODO.md" >"${temp_dir}/merged"; then
 		print_error "Merge blocked: unable to read prospective TODO evidence"
 		return 1
 	fi
-	if git cat-file -e "${base_sha}:TODO.md" 2>/dev/null; then
-		if ! git show "${base_sha}:TODO.md" >"${temp_dir}/base"; then
-			rm -rf "$temp_dir"
+	if git -C "$object_repo" cat-file -e "${base_sha}:TODO.md" 2>/dev/null; then
+		if ! git -C "$object_repo" show "${base_sha}:TODO.md" >"${temp_dir}/base"; then
 			print_error "Merge blocked: unable to read base TODO evidence"
 			return 1
 		fi
@@ -581,7 +621,6 @@ _merge_guard_prospective_todo() {
 		: >"${temp_dir}/base"
 	fi
 	report=$(todo_duplicate_report "${temp_dir}/merged" "${temp_dir}/base") || report_rc=$?
-	rm -rf "$temp_dir"
 	if [[ "$report_rc" -eq 0 ]]; then
 		return 0
 	fi
@@ -592,7 +631,7 @@ _merge_guard_prospective_todo() {
 	fi
 	print_error "Merge blocked: prospective TODO duplicate evidence is indeterminate"
 	return 1
-}
+)
 
 # _merge_rest_fallback — squash/merge/rebase a PR via the REST pull merge endpoint.
 #

--- a/.agents/scripts/planning-commit-helper.sh
+++ b/.agents/scripts/planning-commit-helper.sh
@@ -583,10 +583,26 @@ commit_planning_files() {
 	fi
 	local changed_paths=""
 	changed_paths=$(_planning_publish_changed_paths "$repo_root")
-	if planning_publish "$repo_root" "$commit_msg" origin "$current_branch" "$changed_paths"; then
+	if AIDEVOPS_PLANNING_WRITE_RECEIPT=true \
+		planning_publish "$repo_root" "$commit_msg" origin "$current_branch" "$changed_paths"; then
+		if [[ "$PLANNING_PUBLISHED_COMMIT" != "$PLANNING_PUBLICATION_SOURCE_HEAD" &&
+			(-z "$PLANNING_PUBLICATION_RECEIPT" || -z "$PLANNING_PUBLICATION_HANDOFF_ID") ]]; then
+			log_error "Planning files reached the remote branch, but no verified checkout-free merge handoff receipt is available"
+			return 1
+		fi
 		log_success "Planning files published without changing local Git state"
+		if [[ -n "$PLANNING_PUBLICATION_RECEIPT" ]]; then
+			printf 'AIDEVOPS_PLANNING_PUBLICATION_RECEIPT=%s\n' "$PLANNING_PUBLICATION_RECEIPT"
+			printf 'AIDEVOPS_PLANNING_PUBLISHED_COMMIT=%s\n' "$PLANNING_PUBLISHED_COMMIT"
+			printf 'AIDEVOPS_PLANNING_PUBLICATION_SOURCE_HEAD=%s\n' "$PLANNING_PUBLICATION_SOURCE_HEAD"
+			printf 'AIDEVOPS_PLANNING_PUBLICATION_HANDOFF_ID=%s\n' "$PLANNING_PUBLICATION_HANDOFF_ID"
+		fi
 	else
-		log_error "Planning file publication failed; no successful direct push or planning PR was created"
+		if [[ "$PLANNING_PUBLISH_RESULT" == "published_receipt_failed" ]]; then
+			log_error "Planning files reached the remote branch, but receipt persistence failed; retry to reconstruct the safe handoff"
+		else
+			log_error "Planning file publication failed; no successful direct push or planning PR was created"
+		fi
 		return 1
 	fi
 

--- a/.agents/scripts/planning-publisher.sh
+++ b/.agents/scripts/planning-publisher.sh
@@ -10,7 +10,17 @@ _PLANNING_PUBLISHER_LOADED=1
 PLANNING_PUBLISH_MAX_RETRIES="${PLANNING_PUBLISH_MAX_RETRIES:-3}"
 PLANNING_PUBLISH_RESULT=""
 PLANNING_PUBLICATION_ID=""
+PLANNING_PUBLICATION_HANDOFF_ID=""
 PLANNING_PUBLISHED_COMMIT=""
+PLANNING_PUBLICATION_SOURCE_HEAD=""
+PLANNING_PUBLICATION_RECEIPT=""
+PLANNING_SNAPSHOT_FILE_OPERATION="file"
+PLANNING_BRANCH_REF_PREFIX="refs/heads/"
+_PLANNING_PUBLISH_TEMP_DIR=""
+_PLANNING_PUBLISH_SNAPSHOT_FILE=""
+_PLANNING_PUBLISH_INDEX_FILE=""
+_PLANNING_PUBLISH_CANDIDATE_SHA=""
+_PLANNING_PUBLISH_HANDOFF_ID=""
 
 _planning_git() {
 	local git_bin="${AIDEVOPS_PLANNING_GIT_BIN:-git}"
@@ -40,17 +50,25 @@ _planning_publish_log_retryable_conflict() {
 	return 0
 }
 
-_planning_publish_path_allowed() {
-	local path="$1"
-	local scope="${AIDEVOPS_PLANNING_PUBLISH_SCOPE:-planning}"
+_planning_publish_path_allowed_for_scope() {
+	local scope="$1"
+	local path="$2"
 	case "${scope}:${path}" in
 	planning:TODO.md | planning:todo/*)
-		[[ "$path" != *'..'* && "$path" != *'//'* && "$path" != */ ]]
+		[[ "$path" != *'..'* && "$path" != *'//'* && "$path" != */ && \
+			"$path" != *$'\t'* && "$path" != *$'\n'* && "$path" != *$'\r'* ]]
 		return $?
 		;;
 	simplification-state:.agents/configs/simplification-state.json) return 0 ;;
 	*) return 1 ;;
 	esac
+}
+
+_planning_publish_path_allowed() {
+	local path="$1"
+	local scope="${AIDEVOPS_PLANNING_PUBLISH_SCOPE:-planning}"
+	_planning_publish_path_allowed_for_scope "$scope" "$path"
+	return $?
 }
 
 _planning_publish_changed_paths() {
@@ -82,11 +100,333 @@ _planning_publish_snapshot() {
 		if [[ -f "${repo_path}/${path}" ]]; then
 			local blob_sha=""
 			blob_sha=$(_planning_git -C "$repo_path" hash-object -w -- "${repo_path}/${path}") || return 1
-			printf 'file\t%s\t%s\n' "$blob_sha" "$path" >>"$snapshot_file" || return 1
+			printf '%s\t%s\t%s\n' "$PLANNING_SNAPSHOT_FILE_OPERATION" "$blob_sha" "$path" >>"$snapshot_file" || return 1
 		else
 			printf 'delete\t-\t%s\n' "$path" >>"$snapshot_file" || return 1
 		fi
 	done <<<"$paths"
+	return 0
+}
+
+# Rebuild receipt evidence without writing blobs into the repository object
+# database. Publication needs `hash-object -w`; merge-time verification must not.
+_planning_publish_snapshot_readonly() {
+	local repo_path="$1"
+	local paths="$2"
+	local snapshot_file="$3"
+	local scope="${4:-planning}"
+	local path=""
+	local blob_sha=""
+	: >"$snapshot_file" || return 1
+	while IFS= read -r path; do
+		[[ -n "$path" ]] || continue
+		_planning_publish_path_allowed_for_scope "$scope" "$path" || return 1
+		if [[ -L "${repo_path}/${path}" ]] || [[ -d "${repo_path}/${path}" ]]; then
+			return 1
+		fi
+		if [[ -f "${repo_path}/${path}" ]]; then
+			blob_sha=$(_planning_git -C "$repo_path" hash-object -- "${repo_path}/${path}") || return 1
+			printf '%s\t%s\t%s\n' "$PLANNING_SNAPSHOT_FILE_OPERATION" "$blob_sha" "$path" >>"$snapshot_file" || return 1
+		else
+			printf 'delete\t-\t%s\n' "$path" >>"$snapshot_file" || return 1
+		fi
+	done <<<"$paths"
+	return 0
+}
+
+_planning_publish_repository_id() {
+	local repo_path="$1"
+	local common_dir=""
+	local repository_id=""
+	common_dir=$(_planning_git -C "$repo_path" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+	repository_id=$(printf '%s\n' "$common_dir" | _planning_git -C "$repo_path" hash-object --stdin) || return 1
+	printf '%s\n' "$repository_id"
+	return 0
+}
+
+# Bind every mutable receipt field needed by the merge exception to immutable
+# commit evidence. The snapshot digest already commits to operation/path/blob
+# rows; this envelope additionally commits to where and from what state it was
+# published so editing a local receipt cannot substitute another ancestor HEAD.
+_planning_publish_handoff_id() {
+	local repo_path="$1"
+	local remote_name="$2"
+	local branch_name="$3"
+	local source_head="$4"
+	local published_parent="$5"
+	local publication_id="$6"
+	local scope="${7:-${AIDEVOPS_PLANNING_PUBLISH_SCOPE:-planning}}"
+	local repository_id=""
+	repository_id=$(_planning_publish_repository_id "$repo_path") || return 1
+	printf 'format=aidevops-planning-handoff-v1\nrepository_id=%s\nscope=%s\nremote=%s\nbranch=%s\nsource_head=%s\npublished_parent=%s\npublication_id=%s\n' \
+		"$repository_id" "$scope" "$remote_name" "$branch_name" "$source_head" \
+		"$published_parent" "$publication_id" |
+		_planning_git -C "$repo_path" hash-object --stdin
+	return $?
+}
+
+planning_publication_receipt_path() {
+	local repo_path="$1"
+	local remote_name="$2"
+	local branch_name="$3"
+	local receipt_dir="${AIDEVOPS_PLANNING_RECEIPT_DIR:-}"
+	local repository_id=""
+	local receipt_id=""
+	if [[ -z "$receipt_dir" ]]; then
+		[[ -n "${HOME:-}" ]] || return 1
+		receipt_dir="${HOME}/.aidevops/state/planning-publications"
+	fi
+	repository_id=$(_planning_publish_repository_id "$repo_path") || return 1
+	receipt_id=$(printf '%s\n%s\n%s\n' "$repository_id" "$remote_name" "$branch_name" |
+		_planning_git -C "$repo_path" hash-object --stdin) || return 1
+	printf '%s/%s-%s.receipt\n' "$receipt_dir" "$repository_id" "$receipt_id"
+	return 0
+}
+
+_planning_publish_commit_has_publication_id() {
+	local repo_path="$1"
+	local commit_sha="$2"
+	local publication_id="$3"
+	local body=""
+	local line=""
+	local matches=0
+	body=$(_planning_git -C "$repo_path" show -s --format=%B "$commit_sha" 2>/dev/null) || return 1
+	while IFS= read -r line; do
+		[[ "$line" == "Planning-Publication-ID: ${publication_id}" ]] && matches=$((matches + 1))
+	done <<<"$body"
+	[[ "$matches" -eq 1 ]]
+	return $?
+}
+
+_planning_publish_commit_has_handoff_id() {
+	local repo_path="$1"
+	local commit_sha="$2"
+	local handoff_id="$3"
+	local body=""
+	local line=""
+	local matches=0
+	body=$(_planning_git -C "$repo_path" show -s --format=%B "$commit_sha" 2>/dev/null) || return 1
+	while IFS= read -r line; do
+		[[ "$line" == "Planning-Publication-Handoff-ID: ${handoff_id}" ]] && matches=$((matches + 1))
+	done <<<"$body"
+	[[ "$matches" -eq 1 ]]
+	return $?
+}
+
+_planning_publish_write_receipt() {
+	local repo_path="$1"
+	local remote_name="$2"
+	local branch_name="$3"
+	local source_head="$4"
+	local published_commit="$5"
+	local published_parent="$6"
+	local publication_id="$7"
+	local handoff_id="$8"
+	local snapshot_file="$9"
+	local scope="${AIDEVOPS_PLANNING_PUBLISH_SCOPE:-planning}"
+	local repository_id=""
+	local expected_handoff_id=""
+	local receipt_path=""
+	local receipt_tmp=""
+	local snapshot_line=""
+
+	PLANNING_PUBLICATION_RECEIPT=""
+	[[ "${AIDEVOPS_PLANNING_WRITE_RECEIPT:-false}" == "true" ]] || return 0
+	repository_id=$(_planning_publish_repository_id "$repo_path") || return 1
+	expected_handoff_id=$(_planning_publish_handoff_id "$repo_path" "$remote_name" "$branch_name" \
+		"$source_head" "$published_parent" "$publication_id" "$scope") || return 1
+	[[ "$handoff_id" == "$expected_handoff_id" ]] || return 1
+	receipt_path=$(planning_publication_receipt_path "$repo_path" "$remote_name" "$branch_name") || return 1
+	mkdir -p "${receipt_path%/*}" || return 1
+	receipt_tmp="${receipt_path}.tmp.$$"
+	(
+		umask 077
+		{
+			printf 'format=aidevops-planning-publication-v2\n'
+			printf 'repository_id=%s\n' "$repository_id"
+			printf 'scope=%s\n' "$scope"
+			printf 'remote=%s\n' "$remote_name"
+			printf 'branch=%s\n' "$branch_name"
+			printf 'source_head=%s\n' "$source_head"
+			printf 'published_commit=%s\n' "$published_commit"
+			printf 'published_parent=%s\n' "$published_parent"
+			printf 'publication_id=%s\n' "$publication_id"
+			printf 'handoff_id=%s\n' "$handoff_id"
+			printf '%s\n' 'snapshot_begin'
+			while IFS= read -r snapshot_line || [[ -n "$snapshot_line" ]]; do
+				printf '%s\n' "$snapshot_line"
+			done <"$snapshot_file"
+			printf '%s\n' 'snapshot_end'
+		} >"$receipt_tmp" || exit 1
+		mv "$receipt_tmp" "$receipt_path" || exit 1
+	) || {
+		rm -f "$receipt_tmp"
+		return 1
+	}
+	PLANNING_PUBLICATION_RECEIPT="$receipt_path"
+	return 0
+}
+
+_planning_publish_receipt_value() {
+	local receipt_path="$1"
+	local key="$2"
+	local line=""
+	local value=""
+	local matches=0
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		[[ "$line" == "snapshot_begin" ]] && break
+		if [[ "$line" == "${key}="* ]]; then
+			value="${line#*=}"
+			matches=$((matches + 1))
+		fi
+	done <"$receipt_path"
+	[[ "$matches" -eq 1 ]] || return 1
+	printf '%s\n' "$value"
+	return 0
+}
+
+_planning_publish_extract_receipt_snapshot() {
+	local receipt_path="$1"
+	local snapshot_file="$2"
+	local line=""
+	local in_snapshot=0
+	local ended=0
+	: >"$snapshot_file" || return 1
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		if [[ "$line" == "snapshot_begin" ]]; then
+			[[ "$in_snapshot" -eq 0 && "$ended" -eq 0 ]] || return 1
+			in_snapshot=1
+			continue
+		fi
+		if [[ "$line" == "snapshot_end" ]]; then
+			[[ "$in_snapshot" -eq 1 && "$ended" -eq 0 ]] || return 1
+			in_snapshot=0
+			ended=1
+			continue
+		fi
+		[[ "$ended" -eq 0 ]] || return 1
+		[[ "$in_snapshot" -eq 1 ]] && printf '%s\n' "$line" >>"$snapshot_file"
+	done <"$receipt_path"
+	[[ "$in_snapshot" -eq 0 && "$ended" -eq 1 && -s "$snapshot_file" ]]
+	return $?
+}
+
+_planning_publish_verify_receipt_snapshot() {
+	local repo_path="$1"
+	local snapshot_file="$2"
+	local publication_id="$3"
+	local published_commit="$4"
+	local published_parent="$5"
+	local temp_dir="$6"
+	local paths_file="${temp_dir}/paths"
+	local current_snapshot="${temp_dir}/current-snapshot"
+	local operation=""
+	local blob_sha=""
+	local path=""
+	local current_blob=""
+	local changed_path=""
+	local changed_paths=""
+	local current_changed_paths=""
+	local paths=""
+	local snapshot_digest=""
+	: >"$paths_file" || return 1
+	while IFS=$'\t' read -r operation blob_sha path; do
+		[[ -n "$path" ]] || return 1
+		_planning_publish_path_allowed_for_scope planning "$path" || return 1
+		case "$operation" in
+		"$PLANNING_SNAPSHOT_FILE_OPERATION") [[ "$blob_sha" =~ ^[0-9a-fA-F]{40,64}$ ]] || return 1 ;;
+		delete) [[ "$blob_sha" == "-" ]] || return 1 ;;
+		*) return 1 ;;
+		esac
+		grep -Fqx -- "$path" "$paths_file" 2>/dev/null && return 1
+		printf '%s\n' "$path" >>"$paths_file" || return 1
+	done <"$snapshot_file"
+	snapshot_digest=$(_planning_git -C "$repo_path" hash-object "$snapshot_file") || return 1
+	[[ "$snapshot_digest" == "$publication_id" ]] || return 1
+	paths=$(<"$paths_file")
+	current_changed_paths=$(_planning_publish_changed_paths "$repo_path") || return 1
+	[[ "$current_changed_paths" == "$paths" ]] || return 1
+	_planning_publish_snapshot_readonly "$repo_path" "$paths" "$current_snapshot" planning || return 1
+	cmp -s "$snapshot_file" "$current_snapshot" || return 1
+	while IFS=$'\t' read -r operation blob_sha path; do
+		if [[ "$operation" == "$PLANNING_SNAPSHOT_FILE_OPERATION" ]]; then
+			current_blob=$(_planning_git -C "$repo_path" rev-parse "${published_commit}:${path}" 2>/dev/null) || return 1
+			[[ "$current_blob" == "$blob_sha" ]] || return 1
+		elif _planning_git -C "$repo_path" cat-file -e "${published_commit}:${path}" 2>/dev/null; then
+			return 1
+		fi
+	done <"$snapshot_file"
+	changed_paths=$(_planning_git -C "$repo_path" diff-tree --no-commit-id --name-only -r "$published_parent" "$published_commit") || return 1
+	[[ -n "$changed_paths" ]] || return 1
+	while IFS= read -r changed_path; do
+		[[ -n "$changed_path" ]] || continue
+		_planning_publish_path_allowed_for_scope planning "$changed_path" || return 1
+		grep -Fqx -- "$changed_path" "$paths_file" || return 1
+	done <<<"$changed_paths"
+	return 0
+}
+
+# Verify a receipt against the current local snapshot, immutable commit evidence,
+# the exact remote branch head, and the PR head already pinned by full-loop.
+planning_verify_publication_receipt() {
+	local repo_path="$1"
+	local remote_name="$2"
+	local branch_name="$3"
+	local expected_commit="$4"
+	local receipt_path=""
+	local temp_dir=""
+	local snapshot_file=""
+	local format="" repository_id="" expected_repository_id="" scope="" receipt_remote="" receipt_branch=""
+	local source_head="" published_commit="" published_parent="" publication_id="" handoff_id=""
+	local expected_handoff_id=""
+	local current_branch="" current_head="" parent_line="" remote_line="" remote_sha="" remote_ref=""
+	local branch_ref="${PLANNING_BRANCH_REF_PREFIX}${branch_name}"
+
+	receipt_path=$(planning_publication_receipt_path "$repo_path" "$remote_name" "$branch_name") || return 1
+	[[ -f "$receipt_path" && ! -L "$receipt_path" ]] || return 1
+	format=$(_planning_publish_receipt_value "$receipt_path" format) || return 1
+	repository_id=$(_planning_publish_receipt_value "$receipt_path" repository_id) || return 1
+	scope=$(_planning_publish_receipt_value "$receipt_path" scope) || return 1
+	receipt_remote=$(_planning_publish_receipt_value "$receipt_path" remote) || return 1
+	receipt_branch=$(_planning_publish_receipt_value "$receipt_path" branch) || return 1
+	source_head=$(_planning_publish_receipt_value "$receipt_path" source_head) || return 1
+	published_commit=$(_planning_publish_receipt_value "$receipt_path" published_commit) || return 1
+	published_parent=$(_planning_publish_receipt_value "$receipt_path" published_parent) || return 1
+	publication_id=$(_planning_publish_receipt_value "$receipt_path" publication_id) || return 1
+	handoff_id=$(_planning_publish_receipt_value "$receipt_path" handoff_id) || return 1
+	expected_repository_id=$(_planning_publish_repository_id "$repo_path") || return 1
+	[[ "$format" == "aidevops-planning-publication-v2" && "$repository_id" == "$expected_repository_id" && \
+		"$scope" == "planning" && "$receipt_remote" == "$remote_name" && "$receipt_branch" == "$branch_name" ]] || return 1
+	[[ "$source_head" =~ ^[0-9a-fA-F]{40,64}$ && "$published_commit" =~ ^[0-9a-fA-F]{40,64}$ && \
+		"$published_parent" =~ ^[0-9a-fA-F]{40,64}$ && "$publication_id" =~ ^[0-9a-fA-F]{40,64}$ && \
+		"$handoff_id" =~ ^[0-9a-fA-F]{40,64}$ ]] || return 1
+	[[ "$published_commit" == "$expected_commit" ]] || return 1
+	expected_handoff_id=$(_planning_publish_handoff_id "$repo_path" "$receipt_remote" "$receipt_branch" \
+		"$source_head" "$published_parent" "$publication_id" "$scope") || return 1
+	[[ "$handoff_id" == "$expected_handoff_id" ]] || return 1
+	current_branch=$(_planning_git -C "$repo_path" branch --show-current 2>/dev/null) || return 1
+	current_head=$(_planning_git -C "$repo_path" rev-parse --verify "HEAD^{commit}" 2>/dev/null) || return 1
+	[[ "$current_branch" == "$branch_name" && "$current_head" == "$source_head" ]] || return 1
+	_planning_git -C "$repo_path" merge-base --is-ancestor "$source_head" "$published_commit" 2>/dev/null || return 1
+	parent_line=$(_planning_git -C "$repo_path" rev-list --parents -n 1 "$published_commit" 2>/dev/null) || return 1
+	[[ "$parent_line" == "${published_commit} ${published_parent}" ]] || return 1
+	_planning_publish_commit_has_publication_id "$repo_path" "$published_commit" "$publication_id" || return 1
+	_planning_publish_commit_has_handoff_id "$repo_path" "$published_commit" "$handoff_id" || return 1
+	remote_line=$(_planning_git -C "$repo_path" ls-remote --heads "$remote_name" "$branch_ref" 2>/dev/null) || return 1
+	[[ "$remote_line" != *$'\n'* ]] || return 1
+	IFS=$'\t' read -r remote_sha remote_ref <<<"$remote_line"
+	[[ "$remote_sha" == "$published_commit" && "$remote_ref" == "$branch_ref" ]] || return 1
+	temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/planning-receipt-verify.XXXXXX") || return 1
+	snapshot_file="${temp_dir}/snapshot"
+	if ! _planning_publish_extract_receipt_snapshot "$receipt_path" "$snapshot_file" || \
+		! _planning_publish_verify_receipt_snapshot "$repo_path" "$snapshot_file" "$publication_id" \
+			"$published_commit" "$published_parent" "$temp_dir"; then
+		rm -rf "$temp_dir"
+		return 1
+	fi
+	rm -rf "$temp_dir"
+	PLANNING_PUBLICATION_RECEIPT="$receipt_path"
+	PLANNING_PUBLICATION_HANDOFF_ID="$handoff_id"
 	return 0
 }
 
@@ -100,7 +440,7 @@ _planning_publish_build_index() {
 	GIT_INDEX_FILE="$index_file" _planning_git -C "$repo_path" read-tree "$parent_sha" || return 1
 	while IFS=$'\t' read -r operation blob_sha path; do
 		[[ -n "$path" ]] || continue
-		if [[ "$operation" == "file" ]]; then
+		if [[ "$operation" == "$PLANNING_SNAPSHOT_FILE_OPERATION" ]]; then
 			GIT_INDEX_FILE="$index_file" _planning_git -C "$repo_path" update-index --add --cacheinfo "100644,${blob_sha},${path}" || return 1
 		else
 			GIT_INDEX_FILE="$index_file" _planning_git -C "$repo_path" update-index --force-remove -- "$path" || return 1
@@ -120,7 +460,7 @@ _planning_publish_verify_index() {
 		_planning_publish_path_allowed "$changed_path" || return 1
 	done < <(GIT_INDEX_FILE="$index_file" _planning_git -C "$repo_path" diff --cached --name-only "$parent_sha")
 	while IFS=$'\t' read -r operation expected_sha path; do
-		if [[ "$operation" == "file" ]]; then
+		if [[ "$operation" == "$PLANNING_SNAPSHOT_FILE_OPERATION" ]]; then
 			staged_sha=$(GIT_INDEX_FILE="$index_file" _planning_git -C "$repo_path" rev-parse ":${path}" 2>/dev/null) || return 1
 			[[ "$staged_sha" == "$expected_sha" ]] || return 1
 		elif GIT_INDEX_FILE="$index_file" _planning_git -C "$repo_path" rev-parse ":${path}" >/dev/null 2>&1; then
@@ -197,6 +537,7 @@ _planning_publish_resolve_parent() {
 	local target_check_rc=0
 	local default_branch=""
 	local parent_sha=""
+	local branch_ref="${PLANNING_BRANCH_REF_PREFIX}${branch_name}"
 
 	if _planning_git -C "$repo_path" fetch -q "$remote_name" "$branch_name" 2>/dev/null; then
 		parent_sha=$(_planning_git -C "$repo_path" rev-parse FETCH_HEAD) || return 1
@@ -204,7 +545,7 @@ _planning_publish_resolve_parent() {
 		return 0
 	fi
 
-	if _planning_git -C "$repo_path" ls-remote --exit-code --heads "$remote_name" "refs/heads/${branch_name}" >/dev/null 2>&1; then
+	if _planning_git -C "$repo_path" ls-remote --exit-code --heads "$remote_name" "$branch_ref" >/dev/null 2>&1; then
 		# The branch appeared after the failed fetch. Refetch it and use the
 		# normal update lease rather than misclassifying it as absent.
 		_planning_git -C "$repo_path" fetch -q "$remote_name" "$branch_name" || return 1
@@ -234,16 +575,139 @@ _planning_publish_push() {
 	local branch_name="$3"
 	local expected_sha="$4"
 	local candidate_sha="$5"
+	local branch_ref="${PLANNING_BRANCH_REF_PREFIX}${branch_name}"
 	if [[ -n "${AIDEVOPS_PLANNING_FENCE_REF:-}" && -n "${AIDEVOPS_PLANNING_FENCE_SHA:-}" ]]; then
 		_planning_git -C "$repo_path" push -q --atomic \
-			--force-with-lease="refs/heads/${branch_name}:${expected_sha}" \
+			--force-with-lease="${branch_ref}:${expected_sha}" \
 			--force-with-lease="${AIDEVOPS_PLANNING_FENCE_REF}:${AIDEVOPS_PLANNING_FENCE_SHA}" \
-			"$remote_name" "${candidate_sha}:refs/heads/${branch_name}" \
+			"$remote_name" "${candidate_sha}:${branch_ref}" \
 			"${AIDEVOPS_PLANNING_FENCE_SHA}:${AIDEVOPS_PLANNING_FENCE_REF}"
 		return $?
 	fi
-	_planning_git -C "$repo_path" push -q --force-with-lease="refs/heads/${branch_name}:${expected_sha}" "$remote_name" "${candidate_sha}:refs/heads/${branch_name}"
+	_planning_git -C "$repo_path" push -q --force-with-lease="${branch_ref}:${expected_sha}" "$remote_name" "${candidate_sha}:${branch_ref}"
 	return $?
+}
+
+_planning_publish_reset_result() {
+	PLANNING_PUBLISH_RESULT=""
+	PLANNING_PUBLICATION_ID=""
+	PLANNING_PUBLICATION_HANDOFF_ID=""
+	PLANNING_PUBLISHED_COMMIT=""
+	PLANNING_PUBLICATION_SOURCE_HEAD=""
+	PLANNING_PUBLICATION_RECEIPT=""
+	return 0
+}
+
+_planning_publish_record_noop_receipt() {
+	local repo_path="$1"
+	local remote_name="$2"
+	local branch_name="$3"
+	local source_head="$4"
+	local latest_sha="$5"
+	local publication_id="$6"
+	local snapshot_file="$7"
+	local parent_line=""
+	local parent_sha=""
+	local handoff_id=""
+	PLANNING_PUBLISH_RESULT="noop"
+	PLANNING_PUBLISHED_COMMIT="$latest_sha"
+	[[ "${AIDEVOPS_PLANNING_WRITE_RECEIPT:-false}" == "true" ]] || return 0
+	_planning_publish_commit_has_publication_id "$repo_path" "$latest_sha" "$publication_id" || return 1
+	parent_line=$(_planning_git -C "$repo_path" rev-list --parents -n 1 "$latest_sha" 2>/dev/null) || return 1
+	parent_sha="${parent_line#* }"
+	[[ "$parent_sha" != "$parent_line" && "$parent_sha" != *' '* ]] || return 1
+	handoff_id=$(_planning_publish_handoff_id "$repo_path" "$remote_name" "$branch_name" \
+		"$source_head" "$parent_sha" "$publication_id") || return 1
+	_planning_publish_commit_has_handoff_id "$repo_path" "$latest_sha" "$handoff_id" || return 1
+	PLANNING_PUBLICATION_HANDOFF_ID="$handoff_id"
+	_planning_publish_write_receipt "$repo_path" "$remote_name" "$branch_name" "$source_head" \
+		"$latest_sha" "$parent_sha" "$publication_id" "$handoff_id" "$snapshot_file" || return 1
+	return 0
+}
+
+_planning_publish_record_pushed_receipt() {
+	local repo_path="$1"
+	local remote_name="$2"
+	local branch_name="$3"
+	local source_head="$4"
+	local candidate_sha="$5"
+	local parent_sha="$6"
+	local publication_id="$7"
+	local handoff_id="$8"
+	local snapshot_file="$9"
+	PLANNING_PUBLISH_RESULT="published"
+	PLANNING_PUBLISHED_COMMIT="$candidate_sha"
+	PLANNING_PUBLICATION_HANDOFF_ID="$handoff_id"
+	if ! _planning_publish_write_receipt "$repo_path" "$remote_name" "$branch_name" "$source_head" \
+		"$candidate_sha" "$parent_sha" "$publication_id" "$handoff_id" "$snapshot_file"; then
+		PLANNING_PUBLISH_RESULT="published_receipt_failed"
+		return 1
+	fi
+	return 0
+}
+
+_planning_publish_prepare_snapshot() {
+	local repo_path="$1"
+	local paths="$2"
+	local publication_id=""
+	_PLANNING_PUBLISH_TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/planning-publisher.XXXXXX") || return 1
+	_PLANNING_PUBLISH_SNAPSHOT_FILE="${_PLANNING_PUBLISH_TEMP_DIR}/snapshot"
+	_PLANNING_PUBLISH_INDEX_FILE="${_PLANNING_PUBLISH_TEMP_DIR}/index"
+	_planning_publish_snapshot "$repo_path" "$paths" "$_PLANNING_PUBLISH_SNAPSHOT_FILE" || {
+		rm -rf "$_PLANNING_PUBLISH_TEMP_DIR"
+		return 1
+	}
+	publication_id=$(_planning_git -C "$repo_path" hash-object "$_PLANNING_PUBLISH_SNAPSHOT_FILE") || {
+		rm -rf "$_PLANNING_PUBLISH_TEMP_DIR"
+		return 1
+	}
+	PLANNING_PUBLICATION_ID="$publication_id"
+	return 0
+}
+
+_planning_publish_run_pre_push_guards() {
+	local repo_path="$1"
+	local remote_name="$2"
+	local branch_name="$3"
+	local parent_sha="$4"
+	local candidate_sha="$5"
+	local attempt="$6"
+	if [[ -n "${AIDEVOPS_PLANNING_BEFORE_PUSH_HOOK:-}" ]]; then
+		"$AIDEVOPS_PLANNING_BEFORE_PUSH_HOOK" "$repo_path" "$remote_name" "$branch_name" \
+			"$parent_sha" "$candidate_sha" "$attempt" || return 1
+	fi
+	if [[ -n "${AIDEVOPS_PLANNING_PUSH_GUARD:-}" ]]; then
+		"$AIDEVOPS_PLANNING_PUSH_GUARD" "$repo_path" "$remote_name" "$branch_name" \
+			"$parent_sha" "$candidate_sha" "$attempt" || return 3
+	fi
+	return 0
+}
+
+_planning_publish_build_candidate() {
+	local repo_path="$1"
+	local remote_name="$2"
+	local branch_name="$3"
+	local source_head="$4"
+	local parent_sha="$5"
+	local publication_id="$6"
+	local commit_msg="$7"
+	local tree_sha="$8"
+	local index_file="$9"
+	local handoff_id=""
+	local candidate_sha=""
+	_PLANNING_PUBLISH_CANDIDATE_SHA=""
+	_PLANNING_PUBLISH_HANDOFF_ID=""
+	handoff_id=$(_planning_publish_handoff_id "$repo_path" "$remote_name" "$branch_name" \
+		"$source_head" "$parent_sha" "$publication_id") || return 1
+	candidate_sha=$(printf '%s\n\nPlanning-Publication-ID: %s\nPlanning-Publication-Handoff-ID: %s\n' \
+		"$commit_msg" "$publication_id" "$handoff_id" | _planning_git -C "$repo_path" commit-tree "$tree_sha" -p "$parent_sha") || return 1
+	if ! _planning_publish_validate "$repo_path" "$parent_sha" "$candidate_sha" "$index_file"; then
+		_planning_publish_log error "Planning publication validation failed; nothing pushed"
+		return 1
+	fi
+	_PLANNING_PUBLISH_HANDOFF_ID="$handoff_id"
+	_PLANNING_PUBLISH_CANDIDATE_SHA="$candidate_sha"
+	return 0
 }
 
 planning_publish() {
@@ -253,26 +717,23 @@ planning_publish() {
 	local branch_name="${4:-}"
 	local paths="${5:-}"
 	local temp_dir="" snapshot_file="" index_file="" parent_sha="" tree_sha="" candidate_sha=""
-	local publication_id="" attempt=0 push_rc=0 latest_sha="" expected_sha="" parent_resolution="" base_sha="${AIDEVOPS_PLANNING_BASE_SHA:-}"
+	local publication_id="" handoff_id="" attempt=0 push_rc=0 latest_sha="" expected_sha="" parent_resolution="" base_sha="${AIDEVOPS_PLANNING_BASE_SHA:-}"
+	local guard_rc=0 source_head=""
 
 	[[ -n "$branch_name" ]] || branch_name=$(_planning_git -C "$repo_path" symbolic-ref --short HEAD 2>/dev/null) || return 1
+	_planning_publish_reset_result
+	source_head=$(_planning_git -C "$repo_path" rev-parse --verify "HEAD^{commit}" 2>/dev/null) || return 1
+	PLANNING_PUBLICATION_SOURCE_HEAD="$source_head"
 	[[ -n "$paths" ]] || paths=$(_planning_publish_changed_paths "$repo_path")
 	if [[ -z "$paths" ]]; then
 		PLANNING_PUBLISH_RESULT="noop"
 		return 0
 	fi
-	temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/planning-publisher.XXXXXX") || return 1
-	snapshot_file="${temp_dir}/snapshot"
-	index_file="${temp_dir}/index"
-	_planning_publish_snapshot "$repo_path" "$paths" "$snapshot_file" || {
-		rm -rf "$temp_dir"
-		return 1
-	}
-	publication_id=$(_planning_git -C "$repo_path" hash-object "$snapshot_file") || {
-		rm -rf "$temp_dir"
-		return 1
-	}
-	PLANNING_PUBLICATION_ID="$publication_id"
+	_planning_publish_prepare_snapshot "$repo_path" "$paths" || return 1
+	temp_dir="$_PLANNING_PUBLISH_TEMP_DIR"
+	snapshot_file="$_PLANNING_PUBLISH_SNAPSHOT_FILE"
+	index_file="$_PLANNING_PUBLISH_INDEX_FILE"
+	publication_id="$PLANNING_PUBLICATION_ID"
 
 	while [[ $attempt -lt $PLANNING_PUBLISH_MAX_RETRIES ]]; do
 		attempt=$((attempt + 1))
@@ -295,8 +756,12 @@ planning_publish() {
 			return 1
 		}
 		if [[ "$tree_sha" == "$(_planning_git -C "$repo_path" rev-parse "${latest_sha}^{tree}")" ]]; then
-			PLANNING_PUBLISH_RESULT="noop"
-			PLANNING_PUBLISHED_COMMIT="$latest_sha"
+			_planning_publish_record_noop_receipt "$repo_path" "$remote_name" "$branch_name" "$source_head" \
+				"$latest_sha" "$publication_id" "$snapshot_file" || {
+				_planning_publish_log error "Remote planning state is current, but its publication handoff receipt could not be reconstructed"
+				rm -rf "$temp_dir"
+				return 3
+			}
 			rm -rf "$temp_dir"
 			return 0
 		fi
@@ -312,32 +777,29 @@ planning_publish() {
 			return 2
 		fi
 		parent_sha="$latest_sha"
-		candidate_sha=$(printf '%s\n\nPlanning-Publication-ID: %s\n' "$commit_msg" "$publication_id" | _planning_git -C "$repo_path" commit-tree "$tree_sha" -p "$parent_sha") || {
+		_planning_publish_build_candidate "$repo_path" "$remote_name" "$branch_name" "$source_head" \
+			"$parent_sha" "$publication_id" "$commit_msg" "$tree_sha" "$index_file" || {
 			rm -rf "$temp_dir"
 			return 1
 		}
-		if ! _planning_publish_validate "$repo_path" "$parent_sha" "$candidate_sha" "$index_file"; then
-			_planning_publish_log error "Planning publication validation failed; nothing pushed"
+		handoff_id="$_PLANNING_PUBLISH_HANDOFF_ID"
+		candidate_sha="$_PLANNING_PUBLISH_CANDIDATE_SHA"
+		guard_rc=0
+		_planning_publish_run_pre_push_guards "$repo_path" "$remote_name" "$branch_name" \
+			"$parent_sha" "$candidate_sha" "$attempt" || guard_rc=$?
+		if [[ "$guard_rc" -ne 0 ]]; then
 			rm -rf "$temp_dir"
-			return 1
-		fi
-		if [[ -n "${AIDEVOPS_PLANNING_BEFORE_PUSH_HOOK:-}" ]]; then
-			"$AIDEVOPS_PLANNING_BEFORE_PUSH_HOOK" "$repo_path" "$remote_name" "$branch_name" "$parent_sha" "$candidate_sha" "$attempt" || {
-				rm -rf "$temp_dir"
-				return 1
-			}
-		fi
-		if [[ -n "${AIDEVOPS_PLANNING_PUSH_GUARD:-}" ]]; then
-			"$AIDEVOPS_PLANNING_PUSH_GUARD" "$repo_path" "$remote_name" "$branch_name" "$parent_sha" "$candidate_sha" "$attempt" || {
-				rm -rf "$temp_dir"
-				return 3
-			}
+			return "$guard_rc"
 		fi
 		push_rc=0
 		_planning_publish_push "$repo_path" "$remote_name" "$branch_name" "$expected_sha" "$candidate_sha" || push_rc=$?
 		if [[ $push_rc -eq 0 ]]; then
-			PLANNING_PUBLISH_RESULT="published"
-			PLANNING_PUBLISHED_COMMIT="$candidate_sha"
+			if ! _planning_publish_record_pushed_receipt "$repo_path" "$remote_name" "$branch_name" "$source_head" \
+				"$candidate_sha" "$parent_sha" "$publication_id" "$handoff_id" "$snapshot_file"; then
+				_planning_publish_log error "Remote branch advanced to ${candidate_sha}, but the publication handoff receipt could not be persisted; retry safely to reconstruct it"
+				rm -rf "$temp_dir"
+				return 3
+			fi
 			_planning_publish_log success "Published allowlisted files (${publication_id})"
 			rm -rf "$temp_dir"
 			return 0

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -30,6 +30,12 @@ readonly TEST_RESET='\033[0m'
 TESTS_RUN=0
 TESTS_FAILED=0
 TEST_ROOT=""
+HANDOFF_ROOT=""
+HANDOFF_REPO=""
+HANDOFF_RECEIPT_DIR=""
+HANDOFF_RECEIPT=""
+HANDOFF_SOURCE_HEAD=""
+HANDOFF_PUBLISHED_COMMIT=""
 
 print_result() {
 	local test_name="$1"
@@ -965,12 +971,184 @@ test_non_squash_skips_subject_override() {
 	return 0
 }
 
+handoff_state_digest() {
+	local repo="$1"
+	{
+		/usr/bin/git -C "$repo" rev-parse HEAD
+		/usr/bin/git -C "$repo" ls-files -s
+		/usr/bin/git -C "$repo" diff --binary
+		/usr/bin/git -C "$repo" diff --cached --binary
+		/usr/bin/git -C "$repo" status --porcelain=v1 --untracked-files=all
+	} | /usr/bin/git -C "$repo" hash-object --stdin
+	return $?
+}
+
+create_planning_handoff_fixture() {
+	local fixture_name="$1"
+	local scripts_dir="${SCRIPT_DIR}/.."
+	local publication_output=""
+	HANDOFF_ROOT="${TEST_ROOT}/handoff-${fixture_name}"
+	HANDOFF_REPO="${HANDOFF_ROOT}/work"
+	HANDOFF_RECEIPT_DIR="${HANDOFF_ROOT}/receipts"
+	HANDOFF_RECEIPT=""
+	HANDOFF_SOURCE_HEAD=""
+	HANDOFF_PUBLISHED_COMMIT=""
+	mkdir -p "$HANDOFF_ROOT" || return 1
+	/usr/bin/git init --bare --initial-branch=main "${HANDOFF_ROOT}/remote.git" >/dev/null 2>&1 || return 1
+	/usr/bin/git clone "${HANDOFF_ROOT}/remote.git" "$HANDOFF_REPO" >/dev/null 2>&1 || return 1
+	/usr/bin/git -C "$HANDOFF_REPO" config user.email test@test.local || return 1
+	/usr/bin/git -C "$HANDOFF_REPO" config user.name Test || return 1
+	/usr/bin/git -C "$HANDOFF_REPO" config commit.gpgsign false || return 1
+	printf '# Tasks\n' >"${HANDOFF_REPO}/TODO.md"
+	printf 'base\n' >"${HANDOFF_REPO}/README.md"
+	/usr/bin/git -C "$HANDOFF_REPO" add TODO.md README.md || return 1
+	/usr/bin/git -C "$HANDOFF_REPO" commit -q -m seed || return 1
+	/usr/bin/git -C "$HANDOFF_REPO" push -q origin main || return 1
+	printf '%s\n' '- [ ] t900 checkout-free handoff ref:GH#900' >>"${HANDOFF_REPO}/TODO.md"
+	cp "${HANDOFF_REPO}/TODO.md" "${HANDOFF_ROOT}/expected-TODO.md" || return 1
+	publication_output=$(
+		SCRIPT_DIR="$scripts_dir"
+		# shellcheck source=../planning-publisher.sh
+		source "${scripts_dir}/planning-publisher.sh"
+		AIDEVOPS_PLANNING_GIT_BIN=/usr/bin/git \
+			AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true \
+			AIDEVOPS_PLANNING_RECEIPT_DIR="$HANDOFF_RECEIPT_DIR" \
+			AIDEVOPS_PLANNING_WRITE_RECEIPT=true \
+			planning_publish "$HANDOFF_REPO" "plan: checkout-free handoff" origin main || exit $?
+		printf '%s\t%s\t%s\n' "$PLANNING_PUBLICATION_RECEIPT" "$PLANNING_PUBLICATION_SOURCE_HEAD" "$PLANNING_PUBLISHED_COMMIT"
+	) || return 1
+	IFS=$'\t' read -r HANDOFF_RECEIPT HANDOFF_SOURCE_HEAD HANDOFF_PUBLISHED_COMMIT <<<"$publication_output"
+	[[ -f "$HANDOFF_RECEIPT" && -n "$HANDOFF_SOURCE_HEAD" && -n "$HANDOFF_PUBLISHED_COMMIT" ]]
+	return $?
+}
+
+write_handoff_gh_stub() {
+	cat >"${TEST_ROOT}/bin/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+	if [[ "$*" == *"--json state,isDraft,reviewDecision,headRefOid,headRefName"* ]]; then
+		printf '{"state":"OPEN","isDraft":false,"reviewDecision":"","headRefOid":"%s","headRefName":"main"}\n' "${HANDOFF_EXPECTED_HEAD:?}"
+		exit 0
+	fi
+	if [[ "$*" == *"--json headRefOid"* ]]; then
+		printf '%s\n' "${HANDOFF_EXPECTED_HEAD:?}"
+		exit 0
+	fi
+fi
+exit 1
+GHSTUB
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+run_handoff_readiness() {
+	local repo="$1"
+	local receipt_dir="$2"
+	local expected_head="$3"
+	local scripts_dir="${SCRIPT_DIR}/.."
+	local tmp_runner=""
+	local rc=0
+	write_handoff_gh_stub || return 1
+	tmp_runner=$(mktemp) || return 1
+	cat >"$tmp_runner" <<RUNNER_EOF
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR='${scripts_dir}'
+HEADLESS=true
+source '${scripts_dir}/shared-constants.sh'
+source '${scripts_dir}/full-loop-helper-commit.sh'
+_full_loop_query_required_checks() {
+	local pr_number="\$1"
+	local repo="\$2"
+	local pr_head_ref="\$3"
+	: "\$pr_number" "\$repo" "\$pr_head_ref"
+	FULL_LOOP_REQUIRED_CHECKS_JSON='[]'
+	FULL_LOOP_REQUIRED_CHECKS_SUCCESS_EVIDENCE='no-required-checks'
+	FULL_LOOP_REQUIRED_CHECKS_SUCCESS_SUMMARY='no required checks are configured'
+	return 0
+}
+_full_loop_persist_pr_check_evidence() {
+	local status="\$1"
+	local head_sha="\$2"
+	local evidence="\${3:-}"
+	: "\$status" "\$head_sha" "\$evidence"
+	return 0
+}
+cd '${repo}'
+_full_loop_verify_pr_readiness '42' 'testorg/testrepo'
+RUNNER_EOF
+	chmod +x "$tmp_runner"
+	env PATH="${TEST_ROOT}/bin:/usr/bin:/bin:/opt/homebrew/bin:${PATH}" \
+		HANDOFF_EXPECTED_HEAD="$expected_head" \
+		AIDEVOPS_PLANNING_GIT_BIN=/usr/bin/git \
+		AIDEVOPS_PLANNING_RECEIPT_DIR="$receipt_dir" \
+		bash "$tmp_runner" 2>&1 || rc=$?
+	rm -f "$tmp_runner"
+	return $rc
+}
+
+test_checkout_free_publication_readiness_handoff() {
+	local output="" before="" after="" valid_rc=0 changed_rc=0 added_rc=0 ordinary_rc=0 advanced_rc=0
+	local ordinary_repo="" ordinary_receipts="" ordinary_head=""
+	local advanced_repo="" advanced_receipts="" advanced_root="" advanced_head=""
+	create_planning_handoff_fixture valid || {
+		print_result "planning handoff: fixture setup succeeds" 1
+		return 0
+	}
+	before=$(handoff_state_digest "$HANDOFF_REPO")
+	output=$(run_handoff_readiness "$HANDOFF_REPO" "$HANDOFF_RECEIPT_DIR" "$HANDOFF_PUBLISHED_COMMIT") || valid_rc=$?
+	after=$(handoff_state_digest "$HANDOFF_REPO")
+	print_result "planning handoff: exact checkout-free receipt passes readiness" "$valid_rc" "output=$output"
+	print_result "planning handoff: readiness preserves local HEAD, index, and files" "$([[ "$before" == "$after" ]] && printf '0' || printf '1')"
+	printf '%s\n' '- [ ] t901 post-publication drift ref:GH#901' >>"${HANDOFF_REPO}/TODO.md"
+	run_handoff_readiness "$HANDOFF_REPO" "$HANDOFF_RECEIPT_DIR" "$HANDOFF_PUBLISHED_COMMIT" >/dev/null 2>&1 || changed_rc=$?
+	print_result "planning handoff: changed local planning snapshot is blocked" "$((changed_rc == 0 ? 1 : 0))"
+	cp "${HANDOFF_ROOT}/expected-TODO.md" "${HANDOFF_REPO}/TODO.md" || return 0
+	mkdir -p "${HANDOFF_REPO}/todo" || return 0
+	printf '%s\n' '# Added after publication' >"${HANDOFF_REPO}/todo/t902.md"
+	run_handoff_readiness "$HANDOFF_REPO" "$HANDOFF_RECEIPT_DIR" "$HANDOFF_PUBLISHED_COMMIT" >/dev/null 2>&1 || added_rc=$?
+	print_result "planning handoff: newly added planning path is blocked" "$((added_rc == 0 ? 1 : 0))"
+
+	create_planning_handoff_fixture ordinary || return 0
+	ordinary_repo="$HANDOFF_REPO"
+	ordinary_receipts="$HANDOFF_RECEIPT_DIR"
+	ordinary_head="$HANDOFF_PUBLISHED_COMMIT"
+	printf 'ordinary local commit\n' >>"${ordinary_repo}/README.md"
+	/usr/bin/git -C "$ordinary_repo" add README.md
+	/usr/bin/git -C "$ordinary_repo" commit -q -m 'ordinary local drift'
+	run_handoff_readiness "$ordinary_repo" "$ordinary_receipts" "$ordinary_head" >/dev/null 2>&1 || ordinary_rc=$?
+	print_result "planning handoff: ordinary unpushed local commit remains blocked" "$((ordinary_rc == 0 ? 1 : 0))"
+
+	create_planning_handoff_fixture advanced || return 0
+	advanced_repo="$HANDOFF_REPO"
+	advanced_receipts="$HANDOFF_RECEIPT_DIR"
+	advanced_root="$HANDOFF_ROOT"
+	/usr/bin/git clone "${advanced_root}/remote.git" "${advanced_root}/competitor" >/dev/null 2>&1 || return 0
+	/usr/bin/git -C "${advanced_root}/competitor" config user.email test@test.local
+	/usr/bin/git -C "${advanced_root}/competitor" config user.name Test
+	/usr/bin/git -C "${advanced_root}/competitor" config commit.gpgsign false
+	printf 'remote advancement\n' >>"${advanced_root}/competitor/README.md"
+	/usr/bin/git -C "${advanced_root}/competitor" commit -q -am 'advance remote head'
+	/usr/bin/git -C "${advanced_root}/competitor" push -q origin main
+	advanced_head=$(/usr/bin/git -C "${advanced_root}/competitor" rev-parse HEAD)
+	run_handoff_readiness "$advanced_repo" "$advanced_receipts" "$advanced_head" >/dev/null 2>&1 || advanced_rc=$?
+	print_result "planning handoff: advanced remote PR head makes receipt stale" "$((advanced_rc == 0 ? 1 : 0))"
+	return 0
+}
+
 run_prospective_todo_guard() {
 	local fixture_dir="$1"
 	local base_sha="$2"
 	local head_sha="$3"
+	local fetch_mode="${4:-stub}"
 	local scripts_dir="${SCRIPT_DIR}/.."
 	local tmp_runner=""
+	local verification_tmp="${fixture_dir}/verification-tmp"
+	local fetch_override=""
+	if [[ "$fetch_mode" == "stub" ]]; then
+		fetch_override='_merge_fetch_pinned_commit_objects() { return 0; }'
+	fi
+	mkdir -p "$verification_tmp"
 	tmp_runner=$(mktemp)
 	cat >"$tmp_runner" <<RUNNER_EOF
 #!/usr/bin/env bash
@@ -979,16 +1157,34 @@ SCRIPT_DIR='${scripts_dir}'
 source '${scripts_dir}/shared-constants.sh'
 source '${scripts_dir}/full-loop-helper-merge.sh'
 _merge_fetch_pr_refs_rest() { printf 'main\t%s\t%s\n' '${base_sha}' '${head_sha}'; return 0; }
-_merge_fetch_pinned_commit_objects() { return 0; }
+${fetch_override}
 cd '${fixture_dir}'
 _merge_guard_prospective_todo '42' 'testorg/testrepo'
 RUNNER_EOF
 	chmod +x "$tmp_runner"
 	local rc=0
-	env PATH="${TEST_ROOT}/bin:/usr/bin:/bin:${scripts_dir}:${PATH}" bash "$tmp_runner" 2>&1 || rc=$?
+	env PATH="${TEST_ROOT}/bin:/usr/bin:/bin:${scripts_dir}:${PATH}" TMPDIR="$verification_tmp" \
+		bash "$tmp_runner" 2>&1 || rc=$?
 	rm -f "$tmp_runner"
 	[[ "$rc" -eq 0 ]] && return 0
 	return 1
+}
+
+prospective_contexts_clean() {
+	local fixture_dir="$1"
+	local leftovers=""
+	leftovers=$(compgen -G "${fixture_dir}/verification-tmp/aidevops-prospective-todo.*" || true)
+	[[ -z "$leftovers" ]]
+	return $?
+}
+
+prospective_git_storage_digest() {
+	local fixture_dir="$1"
+	{
+		/usr/bin/git -C "$fixture_dir" count-objects -v
+		/usr/bin/git -C "$fixture_dir" for-each-ref --format='%(refname) %(objectname)'
+	} | /usr/bin/git -C "$fixture_dir" hash-object --stdin
+	return $?
 }
 
 create_prospective_fixture() {
@@ -1000,6 +1196,7 @@ create_prospective_fixture() {
 		/usr/bin/git init -q
 		/usr/bin/git config user.email test@test.local
 		/usr/bin/git config user.name Test
+		/usr/bin/git config commit.gpgsign false
 		printf '## Base tasks\n- [ ] t1 Root ref:GH#1\n\n## Branch tasks\n' >TODO.md
 		/usr/bin/git add TODO.md
 		/usr/bin/git commit -q -m root
@@ -1021,25 +1218,94 @@ create_prospective_fixture() {
 	return 0
 }
 
+create_prospective_fetch_fixture() {
+	local fixture_root="${TEST_ROOT}/prospective-fetch"
+	local remote_repo="${fixture_root}/remote.git"
+	local fixture_dir="${fixture_root}/work"
+	local competitor="${fixture_root}/competitor"
+	local root_sha="" base_sha="" head_sha=""
+	mkdir -p "$fixture_root" || return 1
+	/usr/bin/git init --bare --initial-branch=main "$remote_repo" >/dev/null 2>&1 || return 1
+	/usr/bin/git clone "$remote_repo" "$fixture_dir" >/dev/null 2>&1 || return 1
+	/usr/bin/git -C "$fixture_dir" config user.email test@test.local || return 1
+	/usr/bin/git -C "$fixture_dir" config user.name Test || return 1
+	/usr/bin/git -C "$fixture_dir" config commit.gpgsign false || return 1
+	printf '## Base tasks\n- [ ] t1 Root ref:GH#1\n\n## Branch tasks\n' >"${fixture_dir}/TODO.md"
+	/usr/bin/git -C "$fixture_dir" add TODO.md || return 1
+	/usr/bin/git -C "$fixture_dir" commit -q -m root || return 1
+	root_sha=$(/usr/bin/git -C "$fixture_dir" rev-parse HEAD) || return 1
+	/usr/bin/git -C "$fixture_dir" push -q origin main || return 1
+	printf '## Base tasks\n- [ ] t1 Root ref:GH#1\n- [ ] t2 Base addition ref:GH#2\n\n## Branch tasks\n' >"${fixture_dir}/TODO.md"
+	/usr/bin/git -C "$fixture_dir" commit -q -am base || return 1
+	base_sha=$(/usr/bin/git -C "$fixture_dir" rev-parse HEAD) || return 1
+	/usr/bin/git -C "$fixture_dir" push -q origin main || return 1
+	/usr/bin/git clone "$remote_repo" "$competitor" >/dev/null 2>&1 || return 1
+	/usr/bin/git -C "$competitor" config user.email test@test.local || return 1
+	/usr/bin/git -C "$competitor" config user.name Test || return 1
+	/usr/bin/git -C "$competitor" config commit.gpgsign false || return 1
+	/usr/bin/git -C "$competitor" checkout -q --detach "$root_sha" || return 1
+	printf '## Base tasks\n- [ ] t1 Root ref:GH#1\n\n## Branch tasks\n- [ ] t3 Unique head addition ref:GH#3\n' >"${competitor}/TODO.md"
+	/usr/bin/git -C "$competitor" commit -q -am head || return 1
+	head_sha=$(/usr/bin/git -C "$competitor" rev-parse HEAD) || return 1
+	/usr/bin/git -C "$competitor" push -q origin "${head_sha}:refs/pull/42/head" || return 1
+	printf '%s\n' "$base_sha" >"${fixture_root}/base.sha"
+	printf '%s\n' "$head_sha" >"${fixture_root}/head.sha"
+	printf '%s\n' "$fixture_dir"
+	return 0
+}
+
 test_prospective_todo_merge_guard() {
-	local fixture_dir="" base_sha="" head_sha="" output="" rc=0
+	local fixture_dir="" fixture_root="" base_sha="" head_sha="" output="" rc=0 objects_before="" objects_after=""
+	local cleanup_rc=0 isolation_rc=0 storage_before="" storage_after="" absent_before=0 absent_after=0
 	fixture_dir=$(create_prospective_fixture collision)
 	base_sha=$(<"${fixture_dir}/base.sha")
 	head_sha=$(<"${fixture_dir}/head.sha")
+	objects_before=$(/usr/bin/git -C "$fixture_dir" count-objects -v)
 	output=$(run_prospective_todo_guard "$fixture_dir" "$base_sha" "$head_sha") || rc=$?
+	objects_after=$(/usr/bin/git -C "$fixture_dir" count-objects -v)
+	prospective_contexts_clean "$fixture_dir" || cleanup_rc=$?
+	[[ "$cleanup_rc" -eq 0 && "$objects_before" == "$objects_after" ]] || isolation_rc=1
 	print_result "prospective TODO: merge-only collision is blocked" "$((rc == 0 ? 1 : 0))" "output=$output"
 	print_result "prospective TODO: task and issue duplicates are reported" "$([[ "$output" == *"Duplicate task ID: t2"* && "$output" == *"Duplicate issue mapping: ref:GH#2"* ]] && printf '0' || printf '1')" "output=$output"
+	print_result "prospective TODO: collision writes only to cleaned isolated context" "$isolation_rc"
 
 	rc=0
+	cleanup_rc=0
+	isolation_rc=0
 	fixture_dir=$(create_prospective_fixture unique)
 	base_sha=$(<"${fixture_dir}/base.sha")
 	head_sha=$(<"${fixture_dir}/head.sha")
+	objects_before=$(/usr/bin/git -C "$fixture_dir" count-objects -v)
 	run_prospective_todo_guard "$fixture_dir" "$base_sha" "$head_sha" >/dev/null || rc=$?
+	objects_after=$(/usr/bin/git -C "$fixture_dir" count-objects -v)
+	prospective_contexts_clean "$fixture_dir" || cleanup_rc=$?
+	[[ "$cleanup_rc" -eq 0 && "$objects_before" == "$objects_after" ]] || isolation_rc=1
 	print_result "prospective TODO: unique stale branch passes" "$rc"
+	print_result "prospective TODO: success writes only to cleaned isolated context" "$isolation_rc"
 
 	rc=0
+	cleanup_rc=0
 	output=$(run_prospective_todo_guard "$fixture_dir" deadbeef deadbeef) || rc=$?
 	print_result "prospective TODO: indeterminate merge-tree fails closed" "$((rc == 0 ? 1 : 0))" "output=$output"
+	prospective_contexts_clean "$fixture_dir" || cleanup_rc=$?
+	print_result "prospective TODO: failure cleans isolated context" "$cleanup_rc"
+
+	rc=0
+	cleanup_rc=0
+	isolation_rc=0
+	fixture_dir=$(create_prospective_fetch_fixture) || return 0
+	fixture_root="${fixture_dir%/work}"
+	base_sha=$(<"${fixture_root}/base.sha")
+	head_sha=$(<"${fixture_root}/head.sha")
+	storage_before=$(prospective_git_storage_digest "$fixture_dir")
+	if /usr/bin/git -C "$fixture_dir" cat-file -e "${head_sha}^{commit}" 2>/dev/null; then absent_before=1; fi
+	run_prospective_todo_guard "$fixture_dir" "$base_sha" "$head_sha" live >/dev/null || rc=$?
+	storage_after=$(prospective_git_storage_digest "$fixture_dir")
+	if /usr/bin/git -C "$fixture_dir" cat-file -e "${head_sha}^{commit}" 2>/dev/null; then absent_after=1; fi
+	prospective_contexts_clean "$fixture_dir" || cleanup_rc=$?
+	[[ "$rc" -eq 0 && "$cleanup_rc" -eq 0 && "$absent_before" -eq 0 && "$absent_after" -eq 0 && \
+		"$storage_before" == "$storage_after" ]] || isolation_rc=1
+	print_result "prospective TODO: missing PR objects fetch only into cleaned isolated context" "$isolation_rc"
 	return 0
 }
 
@@ -1072,6 +1338,7 @@ main() {
 	test_wip_draft_takeover_uses_reviewed_pr_title
 	test_invalid_squash_title_blocks_before_merge
 	test_non_squash_skips_subject_override
+	test_checkout_free_publication_readiness_handoff
 	test_prospective_todo_merge_guard
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-planning-publisher.sh
+++ b/.agents/scripts/tests/test-planning-publisher.sh
@@ -66,6 +66,42 @@ run_publish() {
 	return $?
 }
 
+run_publish_with_receipt() {
+	local repo="$1"
+	local receipt_dir="$2"
+	local branch="${3:-main}"
+	(
+		SCRIPT_DIR="$(dirname "$PUBLISHER")"
+		# shellcheck source=../planning-publisher.sh
+		source "$PUBLISHER"
+		AIDEVOPS_PLANNING_GIT_BIN=/usr/bin/git \
+			AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true \
+			AIDEVOPS_PLANNING_RECEIPT_DIR="$receipt_dir" \
+			AIDEVOPS_PLANNING_WRITE_RECEIPT=true \
+			planning_publish "$repo" "plan: test receipt" origin "$branch" || exit $?
+		printf 'receipt=%s\n' "$PLANNING_PUBLICATION_RECEIPT"
+		printf 'commit=%s\n' "$PLANNING_PUBLISHED_COMMIT"
+		printf 'source=%s\n' "$PLANNING_PUBLICATION_SOURCE_HEAD"
+	)
+	return $?
+}
+
+run_receipt_verify() {
+	local repo="$1"
+	local receipt_dir="$2"
+	local branch="$3"
+	local expected_commit="$4"
+	(
+		SCRIPT_DIR="$(dirname "$PUBLISHER")"
+		# shellcheck source=../planning-publisher.sh
+		source "$PUBLISHER"
+		AIDEVOPS_PLANNING_GIT_BIN=/usr/bin/git \
+			AIDEVOPS_PLANNING_RECEIPT_DIR="$receipt_dir" \
+			planning_verify_publication_receipt "$repo" origin "$branch" "$expected_commit"
+	)
+	return $?
+}
+
 run_simplification_publish() {
 	local repo="$1"
 	local hook="${2:-}"
@@ -126,6 +162,122 @@ test_state_allowlist_and_idempotence() {
 	if [[ "$before" == "$after" && "$first_remote" == "$second_remote" && "$count" -eq 1 ]] &&
 		git --git-dir="${root}/remote.git" show main:TODO.md | grep -q t001 &&
 		[[ "$(git --git-dir="${root}/remote.git" show main:README.md)" == "base" ]]; then pass "$name"; else fail "$name" invariant; fi
+	rm -rf "$root"
+	return 0
+}
+
+test_publication_receipt_revalidates_exact_handoff() {
+	local name="persists and revalidates exact checkout-free publication evidence"
+	local root="" repo="" receipt_dir="" output="" replay_output="" receipt="" published_commit="" replayed_commit="" source_head=""
+	local before="" after="" valid_rc=0 replay_rc=0 changed_rc=0 added_rc=0 forged_rc=0 remote_head="" forged_tmp="" line=""
+	root=$(mktemp -d) || return 0
+	setup_repo "$root" || {
+		fail "$name" setup
+		return 0
+	}
+	repo="${root}/work"
+	receipt_dir="${root}/receipts"
+	printf '%s\n' '- [ ] t009 receipt handoff ref:GH#9' >>"${repo}/TODO.md"
+	cp "${repo}/TODO.md" "${root}/expected-TODO.md" || return 0
+	before=$(state_digest "$repo")
+	output=$(run_publish_with_receipt "$repo" "$receipt_dir" main) || {
+		fail "$name" publish
+		rm -rf "$root"
+		return 0
+	}
+	while IFS= read -r line; do
+		case "$line" in
+		receipt=*) receipt="${line#receipt=}" ;;
+		commit=*) published_commit="${line#commit=}" ;;
+		source=*) source_head="${line#source=}" ;;
+		esac
+	done <<<"$output"
+	after=$(state_digest "$repo")
+	remote_head=$(/usr/bin/git --git-dir="${root}/remote.git" rev-parse main)
+	run_receipt_verify "$repo" "$receipt_dir" main "$published_commit" || valid_rc=$?
+	rm -f "$receipt"
+	replay_output=$(run_publish_with_receipt "$repo" "$receipt_dir" main) || replay_rc=$?
+	while IFS= read -r line; do
+		case "$line" in
+		receipt=*) receipt="${line#receipt=}" ;;
+		commit=*) replayed_commit="${line#commit=}" ;;
+		esac
+	done <<<"$replay_output"
+	run_receipt_verify "$repo" "$receipt_dir" main "$published_commit" || replay_rc=$?
+	printf '%s\n' '- [ ] t010 changed after publication ref:GH#10' >>"${repo}/TODO.md"
+	run_receipt_verify "$repo" "$receipt_dir" main "$published_commit" >/dev/null 2>&1 || changed_rc=$?
+	cp "${root}/expected-TODO.md" "${repo}/TODO.md" || return 0
+	printf '%s\n' '# Added after publication' >"${repo}/todo/tasks/t011.md"
+	run_receipt_verify "$repo" "$receipt_dir" main "$published_commit" >/dev/null 2>&1 || added_rc=$?
+	rm -f "${repo}/todo/tasks/t011.md"
+	forged_tmp="${receipt}.forged"
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		if [[ "$line" == source_head=* ]]; then
+			printf 'source_head=0000000000000000000000000000000000000000\n'
+		else
+			printf '%s\n' "$line"
+		fi
+	done <"$receipt" >"$forged_tmp"
+	mv "$forged_tmp" "$receipt"
+	run_receipt_verify "$repo" "$receipt_dir" main "$published_commit" >/dev/null 2>&1 || forged_rc=$?
+	if [[ -f "$receipt" && "$before" == "$after" && "$valid_rc" -eq 0 && "$replay_rc" -eq 0 && \
+		"$changed_rc" -ne 0 && "$added_rc" -ne 0 && "$forged_rc" -ne 0 && "$remote_head" == "$published_commit" && \
+		"$replayed_commit" == "$published_commit" && "$source_head" == "$(/usr/bin/git -C "$repo" rev-parse HEAD)" ]] && \
+		grep -q '^format=aidevops-planning-publication-v2$' "$receipt" &&
+		grep -q '^handoff_id=[0-9a-fA-F]\{40,64\}$' "$receipt"; then
+		pass "$name"
+	else
+		fail "$name" "receipt invariant failed (valid=$valid_rc replay=$replay_rc changed=$changed_rc added=$added_rc forged=$forged_rc)"
+	fi
+	rm -rf "$root"
+	return 0
+}
+
+test_publication_receipt_rejects_ancestor_source_forgery() {
+	local name="rejects a receipt that substitutes another ancestor for the published source HEAD"
+	local root="" repo="" receipt_dir="" output="" receipt="" published_commit="" source_head=""
+	local ancestor_head="" forged_tmp="" line="" forged_rc=0
+	root=$(mktemp -d) || return 0
+	setup_repo "$root" || {
+		fail "$name" setup
+		return 0
+	}
+	repo="${root}/work"
+	receipt_dir="${root}/receipts"
+	/usr/bin/git -C "$repo" commit --allow-empty -q -m 'source anchor' || return 0
+	/usr/bin/git -C "$repo" push -q origin main || return 0
+	ancestor_head=$(/usr/bin/git -C "$repo" rev-parse HEAD^) || return 0
+	printf '%s\n' '- [ ] t012 immutable source handoff ref:GH#12' >>"${repo}/TODO.md"
+	output=$(run_publish_with_receipt "$repo" "$receipt_dir" main) || {
+		fail "$name" publish
+		rm -rf "$root"
+		return 0
+	}
+	while IFS= read -r line; do
+		case "$line" in
+		receipt=*) receipt="${line#receipt=}" ;;
+		commit=*) published_commit="${line#commit=}" ;;
+		source=*) source_head="${line#source=}" ;;
+		esac
+	done <<<"$output"
+	forged_tmp="${receipt}.forged"
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		if [[ "$line" == source_head=* ]]; then
+			printf 'source_head=%s\n' "$ancestor_head"
+		else
+			printf '%s\n' "$line"
+		fi
+	done <"$receipt" >"$forged_tmp"
+	mv "$forged_tmp" "$receipt"
+	/usr/bin/git -C "$repo" update-ref refs/heads/main "$ancestor_head" "$source_head" || return 0
+	run_receipt_verify "$repo" "$receipt_dir" main "$published_commit" >/dev/null 2>&1 || forged_rc=$?
+	if [[ "$forged_rc" -ne 0 && "$(/usr/bin/git -C "$repo" rev-parse HEAD)" == "$ancestor_head" ]] &&
+		/usr/bin/git --git-dir="${root}/remote.git" show -s --format=%B "$published_commit" |
+		grep -q '^Planning-Publication-Handoff-ID: [0-9a-fA-F]\{40,64\}$'; then
+		pass "$name"
+	else
+		fail "$name" "forged ancestor source was accepted (rc=$forged_rc)"
+	fi
 	rm -rf "$root"
 	return 0
 }
@@ -510,7 +662,7 @@ HOOK
 
 test_explicit_git_capability_preserves_guarded_checkout() {
 	local name="explicit Git capability publishes planning paths while canonical guard remains active"
-	local root="" repo="" shim_dir="" before="" after="" guard_rc=0 count="" real_git="" real_true=""
+	local root="" repo="" shim_dir="" before="" after="" guard_rc=0 guard_output="" count="" real_git="" real_true=""
 	real_git=$(command -v git || true)
 	real_true=$(command -v true || true)
 	if [[ -z "$real_git" || -z "$real_true" ]]; then
@@ -530,7 +682,11 @@ test_explicit_git_capability_preserves_guarded_checkout() {
 	}
 	cp "${SCRIPT_DIR_TEST}/../git" \
 		"${SCRIPT_DIR_TEST}/../canonical-git-command-guard.py" \
+		"${SCRIPT_DIR_TEST}/../canonical_git_invocation.py" \
 		"${SCRIPT_DIR_TEST}/../canonical_git_policy.py" \
+		"${SCRIPT_DIR_TEST}/../canonical_git_readonly.py" \
+		"${SCRIPT_DIR_TEST}/../canonical_git_ref_queries.py" \
+		"${SCRIPT_DIR_TEST}/../canonical_git_repository.py" \
 		"${SCRIPT_DIR_TEST}/../canonical_shell_parser.py" \
 		"$shim_dir/" || {
 		fail "$name" guard-copy
@@ -557,13 +713,13 @@ test_explicit_git_capability_preserves_guarded_checkout() {
 		return 0
 	}
 	after=$(state_digest "$repo")
-	PATH="${shim_dir}:${PATH}" git -C "$repo" config user.name blocked-test >/dev/null 2>&1 || guard_rc=$?
+	guard_output=$(PATH="${shim_dir}:${PATH}" git -C "$repo" config user.name blocked-test 2>&1) || guard_rc=$?
 	count=$(git --git-dir="${root}/remote.git" show main:TODO.md | grep -c 'pr:#60 completed:2026-07-14' || true)
 	if [[ "$before" == "$after" && "$guard_rc" -eq 42 && "$count" -eq 1 ]] &&
 		git --git-dir="${root}/remote.git" show main:todo/PLANS.md | grep -q 'Status:\*\* Completed'; then
 		pass "$name"
 	else
-		fail "$name" "state or guard invariant failed (guard_rc=$guard_rc count=$count)"
+		fail "$name" "state or guard invariant failed (guard_rc=$guard_rc count=$count output=$guard_output)"
 	fi
 	rm -rf "$root"
 	return 0
@@ -572,6 +728,8 @@ test_explicit_git_capability_preserves_guarded_checkout() {
 main() {
 	test_git_binary_availability_is_validated
 	test_state_allowlist_and_idempotence
+	test_publication_receipt_revalidates_exact_handoff
+	test_publication_receipt_rejects_ancestor_source_forgery
 	test_simplification_state_scope_preserves_checkout
 	test_simplification_state_defaults_to_main_without_origin_head
 	test_simplification_state_conflict_is_retryable


### PR DESCRIPTION
## Summary

Bridge checkout-free planning publication safely into the full-loop merge gate.

- Persist a versioned receipt containing the publication commit, source HEAD, branch, remote, allowlisted snapshot, and immutable handoff ID.
- Revalidate the receipt against the exact PR/remote head, local branch and snapshot, publication parent, and commit trailers while preserving ordinary drift rejection.
- Run prospective `merge-tree --write-tree` checks in an isolated alternates-backed bare object context with guarded cleanup.
- Preserve current-main squash-subject validation while integrating the recovered implementation.

## Files Changed

- `.agents/scripts/planning-commit-helper.sh`
- `.agents/scripts/planning-publisher.sh`
- `.agents/scripts/full-loop-helper-commit.sh`
- `.agents/scripts/full-loop-helper-merge.sh`
- `.agents/scripts/tests/test-planning-publisher.sh`
- `.agents/scripts/tests/test-full-loop-merge.sh`

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified
- `bash .agents/scripts/tests/test-planning-publisher.sh` — 15 passed
- `bash .agents/scripts/tests/test-full-loop-merge.sh` — 70 passed
- ShellCheck on all six changed shell files — clean
- `.agents/scripts/linters-local.sh --changed` — passed
- Independent high-risk closeout review of exact head `50e33395f77a28f38e5fbeb8596e20acfb5f729f` — clean

Resolves #28758

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 31m and 387,348 tokens on this as a headless worker. Solved in 4h 3m.
