### PR TITLE
t18181: Add release-only upstream watch mode for Native SDK

### DIFF
--- a/.agents/configs/upstream-watch.json
+++ b/.agents/configs/upstream-watch.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Upstream repos to watch for releases and significant changes. Managed by upstream-watch-helper.sh (t1426). Entry schema: {slug, description, relevance, default_branch, added_at}. State (last_release_seen, last_commit_seen, last_checked, updates_pending) stored in ~/.aidevops/cache/upstream-watch-state.json. Non-GitHub upstreams are tracked in the non_github_upstreams array for manual/scheduled checks.",
+  "$comment": "Upstream repos to watch for releases and significant changes. Managed by upstream-watch-helper.sh (t1426). Entry schema: {slug, description, relevance, watch_mode, baseline_release, baseline_commit, affects, default_branch, added_at}. watch_mode defaults to releases-and-commits; releases suppresses commit alerts. State (last_release_seen, last_commit_seen, last_checked, updates_pending) is stored in ~/.aidevops/cache/upstream-watch-state.json. Non-GitHub upstreams are tracked in the non_github_upstreams array for manual/scheduled checks.",
   "repos": [
     {
       "slug": "rtk-ai/rtk",
@@ -56,6 +56,23 @@
       "relevance": "DESIGN.md format spec at version alpha — aidevops design-md agent (.agents/tools/design/design-md.md) and template (.agents/templates/DESIGN.md.template) adopted v0.1.0 in t2807/PR #20749. New releases may change YAML schema, rename sections, add/remove linter rules, or alter component property set. CLI is @google/design.md on npm. Watch for v1 release (signals format stabilisation) and breaking schema changes.",
       "default_branch": "main",
       "added_at": "2026-04-24T17:24:54Z"
+    },
+    {
+      "slug": "vercel-labs/native",
+      "description": "Apache-2.0 toolkit for native desktop applications with declarative UI, Zig or compiled TypeScript logic, WebView shells, and agent-oriented automation",
+      "relevance": "Release-only inspiration source for the aidevops desktop shell and GUI verification. Review React/WebView integration, accessibility automation, record/replay, packaging, signing, updates, platform parity, security boundaries, and toolchain stability against todo/research/native-sdk-assessment.md. Do not import the SDK, bundled skill, eval workspace, platform binaries, or Vercel services automatically.",
+      "watch_mode": "releases",
+      "baseline_release": "v0.6.1",
+      "baseline_commit": "a7509a7fa6c467eaed021250538b482886f1c6bf",
+      "affects": [
+        "docs/gui/adr-0001-product-scope-stack-repo-layout.md",
+        "docs/gui/desktop-packaging.md",
+        "docs/gui/testing-ci-cd.md",
+        "packages/gui-desktop/",
+        "todo/research/native-sdk-assessment.md"
+      ],
+      "default_branch": "main",
+      "added_at": "2026-07-28"
     }
   ],
   "non_github_upstreams": [

--- a/.agents/reference/auto-update.md
+++ b/.agents/reference/auto-update.md
@@ -34,6 +34,8 @@ Check current state: `aidevops auto-update status` shows a `Linger: yes|no` row 
 
 **Upstream watch**: `upstream-watch-helper.sh check` — monitors external repos for new releases. Config: `.agents/configs/upstream-watch.json`. State: `~/.aidevops/cache/upstream-watch-state.json`. Commands: `status`, `check`, `ack <slug>`.
 
+GitHub entries monitor releases and commits by default. Use `upstream-watch-helper.sh add <owner/repo> --releases-only` or set `watch_mode` to `releases` for fast-moving inspiration repos where commit-level alerts would create noise. Optional committed `baseline_release` and `baseline_commit` values seed missing local state at the last reviewed version; later acknowledgements remain in the local state file.
+
 **Update behavior**: Shared agents overwritten on update. Only `custom/` and `draft/` preserved.
 
 ## Related

--- a/.agents/scripts/tests/test-upstream-watch-mode.sh
+++ b/.agents/scripts/tests/test-upstream-watch-mode.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Release-only mode, baseline seeding, and CLI registration coverage.
+
+set -euo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+HELPER="${SCRIPTS_DIR}/upstream-watch-helper.sh"
+
+PASS=0
+FAIL=0
+
+check_equal() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf 'PASS: %s\n' "$name"
+	else
+		FAIL=$((FAIL + 1))
+		printf 'FAIL: %s\n  expected: %s\n  actual:   %s\n' "$name" "$expected" "$actual"
+	fi
+	return 0
+}
+
+log_line_count() {
+	local log_file="$1"
+	wc -l <"$log_file" | tr -d '[:space:]'
+	return 0
+}
+
+TMP="$(mktemp -d -t upstream-watch-mode.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+export SCRIPT_DIR="$SCRIPTS_DIR"
+export RED="" YELLOW="" BLUE="" GREEN="" CYAN="" NC=""
+
+RELEASE_PROBE_LOG="${TMP}/release-probes.log"
+COMMIT_PROBE_LOG="${TMP}/commit-probes.log"
+QUEUE_LOG="${TMP}/queue.log"
+OUTPUT_LOG="${TMP}/output.log"
+
+_log_warn() {
+	return 0
+}
+
+_queue_upstream_update_issue() {
+	local slug="$1"
+	local kind="$2"
+	local old_value="$3"
+	local new_value="$4"
+	local entry_json="$5"
+	local compact_entry
+	compact_entry=$(printf '%s' "$entry_json" | jq -c '.')
+	printf '%s|%s|%s|%s|%s\n' "$slug" "$kind" "$old_value" "$new_value" "$compact_entry" >>"$QUEUE_LOG"
+	return 0
+}
+
+# shellcheck source=../upstream-watch-helper-check.sh
+source "${SCRIPTS_DIR}/upstream-watch-helper-check.sh"
+
+_probe_github_release() {
+	printf 'release\n' >>"$RELEASE_PROBE_LOG"
+	printf '%s' "${TEST_RELEASE_JSON:-}"
+	return "${TEST_RELEASE_RC:-0}"
+}
+
+_probe_github_commit() {
+	printf 'commit\n' >>"$COMMIT_PROBE_LOG"
+	printf '%s' "${TEST_COMMIT_JSON:-}"
+	return "${TEST_COMMIT_RC:-0}"
+}
+
+_show_release_diff() {
+	return 0
+}
+
+_show_commit_diff() {
+	return 0
+}
+
+reset_case() {
+	: >"$RELEASE_PROBE_LOG"
+	: >"$COMMIT_PROBE_LOG"
+	: >"$QUEUE_LOG"
+	: >"$OUTPUT_LOG"
+	_check_updates_found=0
+	_check_had_probe_failure=false
+	TEST_RELEASE_RC=0
+	TEST_COMMIT_RC=0
+	TEST_RELEASE_JSON='{"tag_name":"v1","name":"v1","published_at":"2026-07-27T00:00:00Z"}'
+	TEST_COMMIT_JSON='{"sha":"new0000abcdef","commit":{"committer":{"date":"2026-07-27T00:00:00Z"}}}'
+	return 0
+}
+
+# Default entries retain release-and-commit monitoring.
+reset_case
+default_config='{"repos":[{"slug":"owner/default","relevance":"fixture"}]}'
+_check_state='{"last_check":"","repos":{"owner/default":{"last_release_seen":"v1","last_commit_seen":"old0000","last_checked":"","updates_pending":0}},"non_github":{}}'
+_check_single_github_repo "owner/default" "$default_config" "2026-07-28T00:00:00Z" false >"$OUTPUT_LOG"
+check_equal "default mode probes commits" "1" "$(log_line_count "$COMMIT_PROBE_LOG")"
+check_equal "default mode marks commit update pending" "1" "$(printf '%s' "$_check_state" | jq -r '.repos["owner/default"].updates_pending')"
+check_equal "default mode queues commit review" "commit" "$(cut -d '|' -f 2 "$QUEUE_LOG")"
+
+# Release-only entries ignore commit-only movement and avoid the commit API.
+reset_case
+release_config='{"repos":[{"slug":"owner/releases","watch_mode":"releases","relevance":"fixture"}]}'
+_check_state='{"last_check":"","repos":{"owner/releases":{"last_release_seen":"v1","last_commit_seen":"old0000","last_checked":"","updates_pending":0}},"non_github":{}}'
+_check_single_github_repo "owner/releases" "$release_config" "2026-07-28T00:00:00Z" true >"$OUTPUT_LOG"
+check_equal "release-only mode skips commit probe" "0" "$(log_line_count "$COMMIT_PROBE_LOG")"
+check_equal "release-only mode ignores commit-only movement" "0" "$(printf '%s' "$_check_state" | jq -r '.repos["owner/releases"].updates_pending')"
+check_equal "release-only mode preserves commit state" "old0000" "$(printf '%s' "$_check_state" | jq -r '.repos["owner/releases"].last_commit_seen')"
+check_equal "release-only mode queues nothing without a release" "0" "$(log_line_count "$QUEUE_LOG")"
+
+# A release change still creates review work without a commit probe.
+reset_case
+TEST_RELEASE_JSON='{"tag_name":"v2","name":"v2","published_at":"2026-07-28T00:00:00Z"}'
+_check_state='{"last_check":"","repos":{"owner/releases":{"last_release_seen":"v1","last_commit_seen":"old0000","last_checked":"","updates_pending":0}},"non_github":{}}'
+_check_single_github_repo "owner/releases" "$release_config" "2026-07-28T00:00:00Z" true >"$OUTPUT_LOG"
+check_equal "release-only mode detects a release" "1" "$(printf '%s' "$_check_state" | jq -r '.repos["owner/releases"].updates_pending')"
+check_equal "release-only mode queues release review" "release" "$(cut -d '|' -f 2 "$QUEUE_LOG")"
+check_equal "release detection still skips commit probe" "0" "$(log_line_count "$COMMIT_PROBE_LOG")"
+
+# A committed baseline prevents an alert when runtime state is absent.
+reset_case
+baseline_config='{"repos":[{"slug":"owner/baseline","watch_mode":"releases","baseline_release":"v1","baseline_commit":"a7509a7fa6c467e"}]}'
+_check_state='{"last_check":"","repos":{},"non_github":{}}'
+_check_single_github_repo "owner/baseline" "$baseline_config" "2026-07-28T00:00:00Z" false >"$OUTPUT_LOG"
+check_equal "baseline seeds reviewed release" "v1" "$(printf '%s' "$_check_state" | jq -r '.repos["owner/baseline"].last_release_seen')"
+check_equal "baseline stores compact provenance commit" "a7509a7" "$(printf '%s' "$_check_state" | jq -r '.repos["owner/baseline"].last_commit_seen')"
+check_equal "baseline avoids historical alert" "0" "$(log_line_count "$QUEUE_LOG")"
+
+# Invalid committed modes fail the overall check without probing upstream.
+reset_case
+invalid_config='{"repos":[{"slug":"owner/invalid","watch_mode":"everything"}]}'
+_check_state='{"last_check":"","repos":{},"non_github":{}}'
+_check_single_github_repo "owner/invalid" "$invalid_config" "2026-07-28T00:00:00Z" false >"$OUTPUT_LOG" 2>&1
+check_equal "invalid mode marks probe failure" "true" "$_check_had_probe_failure"
+check_equal "invalid mode avoids release probe" "0" "$(log_line_count "$RELEASE_PROBE_LOG")"
+check_equal "invalid mode avoids commit probe" "0" "$(log_line_count "$COMMIT_PROBE_LOG")"
+
+# Source the public helper and isolate add behaviour from network/filesystem state.
+# shellcheck source=../upstream-watch-helper.sh
+source "$HELPER"
+
+WRITTEN_CONFIG=""
+WRITTEN_STATE=""
+
+_check_prerequisites() {
+	return 0
+}
+
+_read_config() {
+	printf '%s' '{"repos":[],"non_github_upstreams":[]}'
+	return 0
+}
+
+_write_config() {
+	local config_json="$1"
+	WRITTEN_CONFIG="$config_json"
+	return 0
+}
+
+_read_state() {
+	printf '%s' '{"last_check":"","repos":{},"non_github":{}}'
+	return 0
+}
+
+_write_state() {
+	local state_json="$1"
+	WRITTEN_STATE="$state_json"
+	return 0
+}
+
+_now_iso() {
+	printf '%s' '2026-07-28T00:00:00Z'
+	return 0
+}
+
+_log_info() {
+	return 0
+}
+
+gh() {
+	local command="$1"
+	local endpoint="$2"
+	if [[ "$command" != "api" ]]; then
+		return 1
+	fi
+	if [[ "$endpoint" == */releases/latest ]]; then
+		printf '%s\n' '{"tag_name":"v9","published_at":"2026-07-28T00:00:00Z","name":"v9"}'
+	elif [[ "$endpoint" == *'/commits?per_page=1' ]]; then
+		printf '%s\n' 'abcdef0123456789'
+	elif [[ "$endpoint" == repos/* ]]; then
+		printf '%s\n' '{"description":"Fixture repository","stargazers_count":1,"pushed_at":"2026-07-28T00:00:00Z","default_branch":"main"}'
+	else
+		return 1
+	fi
+	return 0
+}
+
+cmd_add owner/cli fixture releases >"${TMP}/cli.out" 2>&1
+check_equal "add stores release-only mode" "releases" "$(printf '%s' "$WRITTEN_CONFIG" | jq -r '.repos[] | select(.slug == "owner/cli") | .watch_mode')"
+check_equal "add stores release baseline" "v9" "$(printf '%s' "$WRITTEN_CONFIG" | jq -r '.repos[] | select(.slug == "owner/cli") | .baseline_release')"
+check_equal "add stores commit baseline" "abcdef0123456789" "$(printf '%s' "$WRITTEN_CONFIG" | jq -r '.repos[] | select(.slug == "owner/cli") | .baseline_commit')"
+check_equal "add seeds runtime release state" "v9" "$(printf '%s' "$WRITTEN_STATE" | jq -r '.repos["owner/cli"].last_release_seen')"
+
+if cmd_add owner/bad "" everything >"${TMP}/invalid.out" 2>&1; then
+	invalid_rc="0"
+else
+	invalid_rc="$?"
+fi
+check_equal "add rejects invalid watch mode" "1" "$invalid_rc"
+
+WRITTEN_CONFIG=""
+WRITTEN_STATE=""
+main add owner/parser --mode releases --relevance "parser fixture" >"${TMP}/parser.out" 2>&1
+check_equal "CLI parser forwards slug" "owner/parser" "$(printf '%s' "$WRITTEN_CONFIG" | jq -r '.repos[0].slug')"
+check_equal "CLI parser forwards relevance" "parser fixture" "$(printf '%s' "$WRITTEN_CONFIG" | jq -r '.repos[0].relevance')"
+check_equal "CLI parser forwards explicit mode" "releases" "$(printf '%s' "$WRITTEN_CONFIG" | jq -r '.repos[0].watch_mode')"
+
+WRITTEN_CONFIG=""
+WRITTEN_STATE=""
+main add owner/shortcut --releases-only >"${TMP}/shortcut.out" 2>&1
+check_equal "CLI releases-only shortcut is supported" "releases" "$(printf '%s' "$WRITTEN_CONFIG" | jq -r '.repos[0].watch_mode')"
+
+if [[ "$FAIL" -gt 0 ]]; then
+	printf '%s test(s) failed, %s passed\n' "$FAIL" "$PASS" >&2
+	exit 1
+fi
+
+printf '%s test(s) passed\n' "$PASS"

--- a/.agents/scripts/upstream-watch-helper-check.sh
+++ b/.agents/scripts/upstream-watch-helper-check.sh
@@ -32,9 +32,55 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _lib_path
 fi
 
+readonly UPSTREAM_WATCH_MODE_RELEASES="releases"
+readonly UPSTREAM_WATCH_MODE_RELEASES_AND_COMMITS="releases-and-commits"
+
 # =============================================================================
 # GitHub API probes
 # =============================================================================
+
+#######################################
+# Validate a GitHub upstream watch mode.
+# Arguments:
+#   $1 - Watch mode
+# Returns: 0 when supported, 1 otherwise
+#######################################
+_upstream_watch_mode_valid() {
+	local watch_mode="$1"
+	if [[ "$watch_mode" == "$UPSTREAM_WATCH_MODE_RELEASES" || "$watch_mode" == "$UPSTREAM_WATCH_MODE_RELEASES_AND_COMMITS" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Seed missing runtime state from a committed review baseline.
+# Existing runtime state always wins so acknowledgements remain local.
+# Arguments:
+#   $1 - Repository slug
+#   $2 - Config entry JSON
+#######################################
+_initialize_github_repo_state() {
+	local slug="$1"
+	local entry_json="$2"
+
+	if printf '%s' "$_check_state" | jq -e --arg slug "$slug" '.repos[$slug] != null' >/dev/null 2>&1; then
+		return 0
+	fi
+
+	local baseline_release baseline_commit
+	baseline_release=$(printf '%s' "$entry_json" | jq -r '.baseline_release // ""')
+	baseline_commit=$(printf '%s' "$entry_json" | jq -r '.baseline_commit // ""')
+	_check_state=$(printf '%s' "$_check_state" | jq --arg slug "$slug" \
+		--arg release "$baseline_release" --arg commit "${baseline_commit:0:7}" \
+		'.repos[$slug] = {
+			last_release_seen: $release,
+			last_commit_seen: $commit,
+			last_checked: "",
+			updates_pending: 0
+		}') || return 1
+	return 0
+}
 
 #######################################
 # Probe GitHub API for the latest release of a repository.
@@ -293,7 +339,7 @@ _show_commit_diff() {
 # =============================================================================
 
 #######################################
-# Check a single GitHub repo for new releases and commits.
+# Check a single GitHub repo according to its configured watch mode.
 # Updates state in-place (passed by reference via global _check_state).
 # Arguments:
 #   $1 - Repository slug (owner/repo)
@@ -310,9 +356,22 @@ _check_single_github_repo() {
 	local now="$3"
 	local verbose="$4"
 
-	# Get relevance from config
-	local relevance
-	relevance=$(echo "$config" | jq -r --arg slug "$slug" '.repos[] | select(.slug == $slug) | .relevance // ""')
+	local entry_json relevance watch_mode
+	entry_json=$(printf '%s' "$config" | jq --arg slug "$slug" '.repos[] | select(.slug == $slug)')
+	relevance=$(printf '%s' "$entry_json" | jq -r '.relevance // ""')
+	watch_mode=$(printf '%s' "$entry_json" | jq -r --arg default_mode "$UPSTREAM_WATCH_MODE_RELEASES_AND_COMMITS" '.watch_mode // $default_mode')
+	if ! _upstream_watch_mode_valid "$watch_mode"; then
+		_log_warn "Invalid watch_mode '${watch_mode}' for ${slug}"
+		echo -e "${RED}Error${NC}: Invalid watch_mode '${watch_mode}' for ${slug}; expected ${UPSTREAM_WATCH_MODE_RELEASES} or ${UPSTREAM_WATCH_MODE_RELEASES_AND_COMMITS}" >&2
+		_check_had_probe_failure=true
+		return 0
+	fi
+
+	if ! _initialize_github_repo_state "$slug" "$entry_json"; then
+		_log_warn "Failed to initialize runtime state for ${slug}"
+		_check_had_probe_failure=true
+		return 0
+	fi
 
 	# Get last-seen state
 	local last_release_seen last_commit_seen updates_pending_before
@@ -337,14 +396,18 @@ _check_single_github_repo() {
 		has_new_release=true
 	fi
 
-	# --- Check commits (even if no new release) ---
+	# --- Check commits when this entry opted into commit monitoring ---
 	local commit_json="" latest_commit="" latest_commit_date=""
-	if ! commit_json=$(_probe_github_commit "$slug"); then
-		probe_failed=true
-	fi
-	if [[ -n "$commit_json" ]]; then
-		latest_commit=$(echo "$commit_json" | jq -r '.sha // ""')
-		latest_commit_date=$(echo "$commit_json" | jq -r '.commit.committer.date // ""')
+	local watch_commits=false
+	if [[ "$watch_mode" == "$UPSTREAM_WATCH_MODE_RELEASES_AND_COMMITS" ]]; then
+		watch_commits=true
+		if ! commit_json=$(_probe_github_commit "$slug"); then
+			probe_failed=true
+		fi
+		if [[ -n "$commit_json" ]]; then
+			latest_commit=$(echo "$commit_json" | jq -r '.sha // ""')
+			latest_commit_date=$(echo "$commit_json" | jq -r '.commit.committer.date // ""')
+		fi
 	fi
 
 	local has_new_commits=false
@@ -353,11 +416,13 @@ _check_single_github_repo() {
 	fi
 
 	# --- Report ---
+	local report_verbose="$verbose"
+	[[ "$watch_commits" == false ]] && report_verbose=false
 	_report_github_repo_update "$slug" "$relevance" \
 		"$has_new_release" "$has_new_commits" \
 		"$last_release_seen" "$last_commit_seen" \
 		"$latest_release_tag" "$latest_release_name" "$latest_release_date" \
-		"$latest_commit" "$latest_commit_date" "$verbose"
+		"$latest_commit" "$latest_commit_date" "$report_verbose"
 
 	# Update last_checked and updates_pending (not last_seen -- requires explicit ack)
 	# Skip state update if probes failed to avoid masking errors as "up to date"
@@ -378,9 +443,7 @@ _check_single_github_repo() {
 				update_old="$last_release_seen"
 				update_new="$latest_release_tag"
 			fi
-			local config_entry
-			config_entry=$(echo "$config" | jq --arg slug "$slug" '.repos[] | select(.slug == $slug)')
-			_queue_upstream_update_issue "$slug" "$update_kind" "$update_old" "$update_new" "$config_entry"
+			_queue_upstream_update_issue "$slug" "$update_kind" "$update_old" "$update_new" "$entry_json"
 		fi
 	else
 		_check_had_probe_failure=true

--- a/.agents/scripts/upstream-watch-helper.sh
+++ b/.agents/scripts/upstream-watch-helper.sh
@@ -13,7 +13,7 @@
 # for improvements relevant to our implementation.
 #
 # Usage:
-#   upstream-watch-helper.sh add <owner/repo> [--relevance "why we care"]
+#   upstream-watch-helper.sh add <owner/repo> [--relevance "why we care"] [--mode releases]
 #   upstream-watch-helper.sh remove <owner/repo>
 #   upstream-watch-helper.sh check [--verbose]     Check all watched repos for updates
 #   upstream-watch-helper.sh check <owner/repo>    Check a specific repo
@@ -62,6 +62,12 @@ CONFIG_FILE="${AGENTS_DIR}/configs/upstream-watch.json"
 STATE_FILE="${HOME}/.aidevops/cache/upstream-watch-state.json"
 LOGFILE="${HOME}/.aidevops/logs/upstream-watch.log"
 UPSTREAM_WATCH_LABEL="${UPSTREAM_WATCH_LABEL:-source:upstream-watch}"
+if [[ -z "${UPSTREAM_WATCH_STATUS_NONE+x}" ]]; then
+	readonly UPSTREAM_WATCH_STATUS_NONE="none"
+fi
+if [[ -z "${UPSTREAM_WATCH_STATUS_NEVER+x}" ]]; then
+	readonly UPSTREAM_WATCH_STATUS_NEVER="never"
+fi
 
 # Logging prefix for shared log_* functions
 # shellcheck disable=SC2034
@@ -88,16 +94,53 @@ source "${SCRIPT_DIR}/upstream-watch-helper-check.sh"
 # =============================================================================
 
 #######################################
+# Build a committed GitHub watch entry with its reviewed baseline.
+# Arguments: slug, description, relevance, mode, release, commit, branch, added-at
+#######################################
+_build_github_watch_entry() {
+	local slug="$1"
+	local description="$2"
+	local relevance="$3"
+	local watch_mode="$4"
+	local baseline_release="$5"
+	local baseline_commit="$6"
+	local default_branch="$7"
+	local added_at="$8"
+	jq -n \
+		--arg slug "$slug" \
+		--arg desc "$description" \
+		--arg relevance "$relevance" \
+		--arg watch_mode "$watch_mode" \
+		--arg baseline_release "$baseline_release" \
+		--arg baseline_commit "$baseline_commit" \
+		--arg branch "$default_branch" \
+		--arg added "$added_at" \
+		'{
+			slug: $slug,
+			description: $desc,
+			relevance: $relevance,
+			watch_mode: $watch_mode,
+			baseline_release: $baseline_release,
+			baseline_commit: $baseline_commit,
+			default_branch: $branch,
+			added_at: $added
+		}' || return 1
+	return 0
+}
+
+#######################################
 # Add a repository to the upstream watchlist
 # Verifies the repo exists, captures initial state (latest release/commit),
 # and stores config + state so the first check doesn't flag everything as new.
 # Arguments:
 #   $1 - Repository slug (owner/repo)
 #   $2 - Optional relevance description
+#   $3 - Watch mode (releases or releases-and-commits)
 #######################################
 cmd_add() {
 	local slug="$1"
 	local relevance="${2:-}"
+	local watch_mode="${3:-$UPSTREAM_WATCH_MODE_RELEASES_AND_COMMITS}"
 
 	if [[ -z "$slug" ]]; then
 		echo -e "${RED}Error: Repository slug required (owner/repo)${NC}" >&2
@@ -107,6 +150,10 @@ cmd_add() {
 	# Validate slug format
 	if [[ ! "$slug" =~ ^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$ ]]; then
 		echo -e "${RED}Error: Invalid slug format. Expected: owner/repo${NC}" >&2
+		return 1
+	fi
+	if ! _upstream_watch_mode_valid "$watch_mode"; then
+		echo -e "${RED}Error: Invalid watch mode '${watch_mode}'. Expected ${UPSTREAM_WATCH_MODE_RELEASES} or ${UPSTREAM_WATCH_MODE_RELEASES_AND_COMMITS}.${NC}" >&2
 		return 1
 	fi
 
@@ -151,19 +198,8 @@ cmd_add() {
 	local now
 	now=$(_now_iso)
 	local new_entry
-	new_entry=$(jq -n \
-		--arg slug "$slug" \
-		--arg desc "$description" \
-		--arg relevance "$relevance" \
-		--arg branch "$default_branch" \
-		--arg added "$now" \
-		'{
-			slug: $slug,
-			description: $desc,
-			relevance: $relevance,
-			default_branch: $branch,
-			added_at: $added
-		}')
+	new_entry=$(_build_github_watch_entry "$slug" "$description" "$relevance" "$watch_mode" \
+		"$latest_tag" "$latest_commit" "$default_branch" "$now") || return 1
 
 	# Add to config
 	config=$(echo "$config" | jq --argjson entry "$new_entry" '.repos += [$entry]')
@@ -190,8 +226,9 @@ cmd_add() {
 	echo "  Description: ${description}"
 	[[ -n "$relevance" ]] && echo "  Relevance:   ${relevance}"
 	[[ -n "$latest_tag" ]] && echo "  Latest release: ${latest_tag}"
+	echo "  Watch mode: ${watch_mode}"
 	echo "  Default branch: ${default_branch}"
-	_log_info "Added watch: ${slug} (relevance: ${relevance:-none})"
+	_log_info "Added watch: ${slug} (mode: ${watch_mode}, relevance: ${relevance:-none})"
 	return 0
 }
 
@@ -341,7 +378,7 @@ cmd_status() {
 	fi
 
 	local last_check
-	last_check=$(echo "$state" | jq -r '.last_check // "never"')
+	last_check=$(echo "$state" | jq -r --arg fallback "$UPSTREAM_WATCH_STATUS_NEVER" '.last_check // $fallback')
 
 	echo -e "${BLUE}Upstream Watch Status${NC}"
 	echo "GitHub repos:          ${repo_count}"
@@ -355,12 +392,13 @@ cmd_status() {
 		echo "$config" | jq -r '.repos[] | .slug' | while IFS= read -r slug; do
 			[[ -z "$slug" ]] && continue
 
-			local relevance
+			local relevance watch_mode
 			relevance=$(echo "$config" | jq -r --arg slug "$slug" '.repos[] | select(.slug == $slug) | .relevance // ""')
+			watch_mode=$(echo "$config" | jq -r --arg slug "$slug" --arg default_mode "$UPSTREAM_WATCH_MODE_RELEASES_AND_COMMITS" '.repos[] | select(.slug == $slug) | .watch_mode // $default_mode')
 			local last_release last_commit last_checked pending
-			last_release=$(echo "$state" | jq -r --arg slug "$slug" '.repos[$slug].last_release_seen // "none"')
-			last_commit=$(echo "$state" | jq -r --arg slug "$slug" '.repos[$slug].last_commit_seen // "none"')
-			last_checked=$(echo "$state" | jq -r --arg slug "$slug" '.repos[$slug].last_checked // "never"')
+			last_release=$(echo "$state" | jq -r --arg slug "$slug" --arg fallback "$UPSTREAM_WATCH_STATUS_NONE" '.repos[$slug].last_release_seen // $fallback')
+			last_commit=$(echo "$state" | jq -r --arg slug "$slug" --arg fallback "$UPSTREAM_WATCH_STATUS_NONE" '.repos[$slug].last_commit_seen // $fallback')
+			last_checked=$(echo "$state" | jq -r --arg slug "$slug" --arg fallback "$UPSTREAM_WATCH_STATUS_NEVER" '.repos[$slug].last_checked // $fallback')
 			pending=$(echo "$state" | jq -r --arg slug "$slug" '.repos[$slug].updates_pending // 0')
 
 			if [[ "$pending" -gt 0 ]]; then
@@ -369,7 +407,12 @@ cmd_status() {
 				echo -e "  ${GREEN}-${NC} ${slug}"
 			fi
 			echo "    Last release seen: ${last_release}"
-			echo "    Last commit seen:  ${last_commit}"
+			if [[ "$watch_mode" == "$UPSTREAM_WATCH_MODE_RELEASES" ]]; then
+				echo "    Last commit seen:  not tracked"
+			else
+				echo "    Last commit seen:  ${last_commit}"
+			fi
+			echo "    Watch mode:        ${watch_mode}"
 			echo "    Last checked:      ${last_checked:0:10}"
 			[[ -n "$relevance" ]] && echo "    Relevance:         ${relevance}"
 			echo ""
@@ -388,8 +431,8 @@ cmd_status() {
 			relevance=$(echo "$config" | jq -r --arg name "$entry_name" '.non_github_upstreams[] | select(.name == $name) | .relevance // ""')
 
 			local last_seen last_checked pending
-			last_seen=$(echo "$state" | jq -r --arg name "$entry_name" '.non_github[$name].last_seen // "none"')
-			last_checked=$(echo "$state" | jq -r --arg name "$entry_name" '.non_github[$name].last_checked // "never"')
+			last_seen=$(echo "$state" | jq -r --arg name "$entry_name" --arg fallback "$UPSTREAM_WATCH_STATUS_NONE" '.non_github[$name].last_seen // $fallback')
+			last_checked=$(echo "$state" | jq -r --arg name "$entry_name" --arg fallback "$UPSTREAM_WATCH_STATUS_NEVER" '.non_github[$name].last_checked // $fallback')
 			pending=$(echo "$state" | jq -r --arg name "$entry_name" '.non_github[$name].updates_pending // 0')
 
 			if [[ "$pending" -gt 0 ]]; then
@@ -419,7 +462,9 @@ USAGE:
     upstream-watch-helper.sh <command> [options]
 
 COMMANDS:
-    add <owner/repo> [--relevance "..."]   Add a repo to the watchlist
+    add <owner/repo> [--relevance "..."] [--mode MODE]
+                                             Add a repo to the watchlist
+    add <owner/repo> --releases-only         Shortcut for --mode releases
     remove <owner/repo>                     Remove a repo from the watchlist
     check [--verbose]                       Check all repos for new releases/commits
     check <owner/repo>                      Check a specific repo
@@ -431,6 +476,10 @@ EXAMPLES:
     # Watch a repo
     upstream-watch-helper.sh add vercel-labs/portless \
       --relevance "Local dev hosting -- compare against localdev-helper.sh"
+
+    # Watch stable releases without reacting to every commit
+    upstream-watch-helper.sh add vercel-labs/native --releases-only \
+      --relevance "Review desktop-shell and agent-native GUI improvements"
 
     # Check for updates
     upstream-watch-helper.sh check
@@ -447,6 +496,11 @@ CONFIG:
     Watchlist: ~/.aidevops/agents/configs/upstream-watch.json
     State:     ~/.aidevops/cache/upstream-watch-state.json
     Log:       ~/.aidevops/logs/upstream-watch.log
+
+    GitHub entries default to "releases-and-commits". Set watch_mode to
+    "releases" (or use --releases-only) for fast-moving inspiration repos.
+    Optional baseline_release and baseline_commit values seed a new install
+    at the last reviewed upstream state without generating a historical alert.
 
 NON-GITHUB UPSTREAMS:
     Repos on Docker Hub, GitLab, Forgejo, etc. are configured in
@@ -478,6 +532,52 @@ EOF
 # =============================================================================
 
 #######################################
+# Parse add-command options and dispatch to cmd_add.
+# Arguments:
+#   $@ - Repository slug and add options
+#######################################
+_dispatch_add() {
+	local slug=""
+	local relevance=""
+	local watch_mode="$UPSTREAM_WATCH_MODE_RELEASES_AND_COMMITS"
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--relevance)
+			local relevance_value="${2:-}"
+			if [[ $# -ge 2 && -n "$relevance_value" && "${relevance_value:0:1}" != "-" ]]; then
+				relevance="$relevance_value"
+				shift 2
+			else
+				echo -e "${RED}Error: --relevance requires a value${NC}" >&2
+				return 1
+			fi
+			;;
+		--mode)
+			local mode_value="${2:-}"
+			if [[ $# -ge 2 && -n "$mode_value" && "${mode_value:0:1}" != "-" ]]; then
+				watch_mode="$mode_value"
+				shift 2
+			else
+				echo -e "${RED}Error: --mode requires a value${NC}" >&2
+				return 1
+			fi
+			;;
+		--releases-only)
+			watch_mode="$UPSTREAM_WATCH_MODE_RELEASES"
+			shift
+			;;
+		*)
+			[[ -n "$slug" ]] || slug="$arg"
+			shift
+			;;
+		esac
+	done
+	cmd_add "$slug" "$relevance" "$watch_mode"
+	return 0
+}
+
+#######################################
 # Main entry point -- parse command and dispatch to handler
 # Arguments:
 #   $1 - Command (add, remove, check, ack, status, help)
@@ -489,43 +589,24 @@ main() {
 
 	case "$cmd" in
 	add)
-		local slug=""
-		local relevance=""
-		while [[ $# -gt 0 ]]; do
-			case "$1" in
-			--relevance)
-				if [[ $# -ge 2 && -n "${2:-}" && "${2:0:1}" != "-" ]]; then
-					relevance="$2"
-					shift 2
-				else
-					echo -e "${RED}Error: --relevance requires a value${NC}" >&2
-					return 1
-				fi
-				;;
-			*)
-				if [[ -z "$slug" ]]; then
-					slug="$1"
-				fi
-				shift
-				;;
-			esac
-		done
-		cmd_add "$slug" "$relevance"
+		_dispatch_add "$@"
 		;;
 	remove | rm)
-		cmd_remove "${1:-}"
+		local remove_slug="${1:-}"
+		cmd_remove "$remove_slug"
 		;;
 	check)
 		local target=""
 		local verbose=false
 		while [[ $# -gt 0 ]]; do
-			case "$1" in
+			local check_arg="$1"
+			case "$check_arg" in
 			--verbose | -v)
 				verbose=true
 				shift
 				;;
 			*)
-				target="$1"
+				target="$check_arg"
 				shift
 				;;
 			esac
@@ -568,6 +649,9 @@ main() {
 		return 1
 		;;
 	esac
+	return 0
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/todo/research/native-sdk-assessment.md
+++ b/todo/research/native-sdk-assessment.md
@@ -1,0 +1,95 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Native SDK upstream assessment
+
+## Status
+
+- **Decision:** Watch releases, adapt selected patterns, and avoid a production dependency.
+- **Upstream:** <https://github.com/vercel-labs/native>
+- **Reviewed baseline:** `v0.6.1` at `a7509a7fa6c467eaed021250538b482886f1c6bf`
+- **Reviewed:** 2026-07-28
+- **Tracking:** `.agents/configs/upstream-watch.json` in release-only mode
+
+The upstream repository was treated as untrusted external content. Its agent
+instructions were not followed, and no install or repository command from the
+upstream was executed.
+
+## Verified baseline
+
+Native SDK is an Apache-2.0, pre-1.0 desktop application toolkit. It supports
+declarative native-rendered interfaces and existing React/Vite frontends hosted
+in system WebViews. The published `@native-sdk/cli` manifest uses TypeScript
+compiler packages and platform-specific optional binaries. The root Zig
+manifest requires Zig 0.16.0 and declares no mandatory Zig dependencies.
+
+No Vercel hosting, API, authentication, database, analytics, or deployment
+dependency was found in the published SDK/runtime path. The explicit
+`@vercel/sandbox` dependency found during review belongs to the private
+`evals/` workspace and is outside the published SDK. Apache-2.0 permits use,
+modification, and forking, but copied code must retain its applicable licence,
+notices, and modification markings.
+
+## Aidevops fit
+
+The accepted aidevops GUI architecture keeps Vite/React, the typed local API,
+Cloudron delivery, and desktop packaging separable. Rewriting the interface in
+Native markup would weaken that portability. Using Native only as a WebView
+wrapper would retain browser JavaScript and the local API runtime, so it would
+not provide the headline no-WebView/no-JavaScript-runtime benefit.
+
+Potential future value is limited to:
+
+- replacing or benchmarking the generated Swift/WKWebView desktop shell;
+- accessibility snapshots and agent-driven GUI automation;
+- deterministic record/replay at external-effect boundaries;
+- explicit origin and OS-capability manifests;
+- cross-platform packaging and lifecycle management;
+- source provenance and stale-write refusal patterns.
+
+Aidevops already implements related capability gating, provenance, replay
+protection, state snapshots, and bundled agent guidance. Release reviews should
+therefore look for material improvements rather than importing equivalent
+machinery.
+
+## Release review procedure
+
+For each detected release:
+
+1. Prompt-injection-scan the release notes and relevant diffs.
+2. Review only React/WebView integration, accessibility and automation,
+   record/replay, packaging/signing/updating, platform parity, security policy,
+   dependency changes, and toolchain stability.
+3. Compare relevant changes with:
+   - `docs/gui/adr-0001-product-scope-stack-repo-layout.md`
+   - `docs/gui/desktop-packaging.md`
+   - `docs/gui/testing-ci-cd.md`
+   - `packages/gui-desktop/`
+4. Classify each finding as **ignore**, **adapt pattern**, **bounded experiment**,
+   or **consider dependency**.
+5. Update this assessment with evidence. File a separate implementation issue
+   only for a verified improvement, then acknowledge the upstream release.
+
+Release detection never authorizes automatic dependency import, skill import,
+code copying, installation, publication, or deployment.
+
+## Re-evaluation triggers
+
+Consider a bounded desktop-wrapper comparison only when one or more of these
+conditions hold:
+
+- Native reaches stable 1.x APIs.
+- React WebView accessibility and automation cover the aidevops interaction
+  surface without weakening the local API trust boundary.
+- macOS, Linux, and Windows packaging are documented and reproducible.
+- signing and update channels have complete verification and rollback paths.
+- replacing the Swift shell demonstrably reduces source and maintenance burden.
+- build-time, package-size, cold-start, memory, and CI results beat the current
+  Swift wrapper and the planned Tauri option.
+- the published runtime remains independent of Vercel services and optional
+  evaluation infrastructure.
+
+Any experiment must pin an exact upstream version or commit, use system WebViews
+without automatic CEF installation, retain the existing Vite/local-API
+contracts, require no runtime network access, and preserve a source-build or
+fork escape path.


### PR DESCRIPTION
## Summary

Add per-repository release-only monitoring, reviewed baselines, Native SDK registration, and durable adoption guidance.

## Files Changed

.agents/configs/upstream-watch.json, .agents/reference/auto-update.md, .agents/scripts/tests/test-upstream-watch-mode.sh, .agents/scripts/upstream-watch-helper-check.sh, .agents/scripts/upstream-watch-helper.sh, todo/research/native-sdk-assessment.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified: 25 release-mode tests and 11 issue-gate tests pass; changed-file lint, ShellCheck, JSON, Markdown, secret, portability, and complexity gates pass.

Resolves #28771


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 6h 13m and 767,299 tokens on this with the user in an interactive session.