### PR TITLE
GH#27777: Eliminate native API attribution unknowns

### DIFF
--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -277,7 +277,7 @@ _mark_reopen_merged_pr_task() {
 _reopen_find_merged_pr() {
 	local repo="$1" tid="$2" ref_num="$3"
 	local owner="${repo%%/*}" name="${repo#*/}"
-	local pr_info="" result=""
+	local pr_info="" result="" reported_cost=""
 
 	pr_info=$(gh_find_merged_pr "$repo" "$tid" 2>/dev/null || true)
 	if [[ -n "$pr_info" ]]; then
@@ -290,7 +290,9 @@ _reopen_find_merged_pr() {
 	# cannot be reopened merely because title-based discovery missed it.
 	[[ "$repo" == */* && -n "$owner" && -n "$name" && "$ref_num" =~ ^[0-9]+$ ]] || return 1
 	# shellcheck disable=SC2016
-	result=$(gh api graphql -f query='
+	result=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="issue-sync-reopen-closing-pr-exact-cost" \
+		gh api graphql -f query='
 query($owner:String!,$name:String!,$number:Int!) {
   repository(owner:$owner,name:$name) {
     nameWithOwner
@@ -301,7 +303,10 @@ query($owner:String!,$name:String!,$number:Int!) {
       }
     }
   }
+	rateLimit { cost }
 }' -F owner="$owner" -F name="$name" -F number="$ref_num" 2>/dev/null) || return 1
+	reported_cost=$(printf '%s' "$result" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
+	[[ "$reported_cost" =~ ^[1-9][0-9]*$ ]] || return 1
 	printf '%s' "$result" | jq -er --arg repo "$repo" '
       .data.repository
       | select(.nameWithOwner == $repo)

--- a/.agents/scripts/issue-sync-lib-ref.sh
+++ b/.agents/scripts/issue-sync-lib-ref.sh
@@ -309,15 +309,70 @@ resolve_gh_node_id() {
 	local repo="$2"
 	local owner="${repo%%/*}"
 	local name="${repo##*/}"
-
-	local node_id
+	local response="" reported_cost="" node_id=""
 	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub, not shell.
-	node_id=$(_gh_with_timeout read gh api graphql \
-		-f query='query($owner:String!,$name:String!,$num:Int!){repository(owner:$owner,name:$name){issue(number:$num){id}}}' \
+	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="issue-sync-node-id-exact-cost" \
+		_gh_with_timeout read gh api graphql \
+		-f query='query($owner:String!,$name:String!,$num:Int!){repository(owner:$owner,name:$name){issue(number:$num){id}}rateLimit{cost}}' \
 		-f owner="$owner" -f name="$name" -F num="$issue_number" \
-		--jq '.data.repository.issue.id' 2>/dev/null || echo "")
-	echo "$node_id"
+		2>/dev/null) || response=""
+	reported_cost=$(printf '%s' "$response" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
+	if [[ "$reported_cost" =~ ^[1-9][0-9]*$ ]]; then
+		node_id=$(printf '%s' "$response" | jq -r '.data.repository.issue.id // empty' 2>/dev/null) || node_id=""
+	fi
+	printf '%s\n' "$node_id"
 	return 0
+}
+
+# Check one bounded native blocked-by connection using response-owned cost.
+# Returns: 0=present, 1=absent, 2=lookup unavailable/incomplete.
+_gh_native_blocked_by_contains() {
+	local blocked_id="$1" blocking_id="$2"
+	local payload="" reported_cost="" has_next="" contains=""
+	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub, not shell.
+	payload=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="issue-sync-blocked-by-read-exact-cost" \
+		_gh_with_timeout read gh api graphql -f query='
+query($blocked:ID!) {
+  node(id:$blocked) { ... on Issue { blockedBy(first:100) { nodes { id } pageInfo { hasNextPage } } } }
+	rateLimit { cost }
+}' -f blocked="$blocked_id" 2>/dev/null) || return 2
+	reported_cost=$(printf '%s' "$payload" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
+	[[ "$reported_cost" =~ ^[1-9][0-9]*$ ]] || return 2
+	contains=$(printf '%s' "$payload" | jq -r --arg id "$blocking_id" \
+		'any(.data.node.blockedBy.nodes[]?; .id == $id)' 2>/dev/null) || return 2
+	[[ "$contains" == "true" ]] && return 0
+	has_next=$(printf '%s' "$payload" | jq -r \
+		'.data.node.blockedBy.pageInfo.hasNextPage | if type == "boolean" then tostring else "unknown" end' \
+		2>/dev/null) || return 2
+	[[ "$has_next" == "false" ]] && return 1
+	return 2
+}
+
+# Check one bounded native sub-issue connection using response-owned cost.
+# Returns: 0=present, 1=absent, 2=lookup unavailable/incomplete.
+_gh_native_sub_issue_contains() {
+	local parent_id="$1" child_id="$2"
+	local payload="" reported_cost="" has_next="" contains=""
+	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub, not shell.
+	payload=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="issue-sync-sub-issue-read-exact-cost" \
+		_gh_with_timeout read gh api graphql -f query='
+query($parent:ID!) {
+  node(id:$parent) { ... on Issue { subIssues(first:100) { nodes { id } pageInfo { hasNextPage } } } }
+	rateLimit { cost }
+}' -f parent="$parent_id" 2>/dev/null) || return 2
+	reported_cost=$(printf '%s' "$payload" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
+	[[ "$reported_cost" =~ ^[1-9][0-9]*$ ]] || return 2
+	contains=$(printf '%s' "$payload" | jq -r --arg id "$child_id" \
+		'any(.data.node.subIssues.nodes[]?; .id == $id)' 2>/dev/null) || return 2
+	[[ "$contains" == "true" ]] && return 0
+	has_next=$(printf '%s' "$payload" | jq -r \
+		'.data.node.subIssues.pageInfo.hasNextPage | if type == "boolean" then tostring else "unknown" end' \
+		2>/dev/null) || return 2
+	[[ "$has_next" == "false" ]] && return 1
+	return 2
 }
 
 # Extract the selected tier from a brief file.

--- a/.agents/scripts/issue-sync-lib-ref.sh
+++ b/.agents/scripts/issue-sync-lib-ref.sh
@@ -34,6 +34,8 @@
 # Include guard
 [[ -n "${_ISSUE_SYNC_LIB_REF_LOADED:-}" ]] && return 0
 _ISSUE_SYNC_LIB_REF_LOADED=1
+_ISLR_GRAPHQL_COST_FILTER='.data.rateLimit.cost // empty'
+_ISLR_JSON_TRUE="true"
 
 # Defensive SCRIPT_DIR fallback
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
@@ -309,7 +311,9 @@ resolve_gh_node_id() {
 	local repo="$2"
 	local owner="${repo%%/*}"
 	local name="${repo##*/}"
-	local response="" reported_cost="" node_id=""
+	local response=""
+	local reported_cost=""
+	local node_id=""
 	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub, not shell.
 	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="issue-sync-node-id-exact-cost" \
@@ -317,7 +321,7 @@ resolve_gh_node_id() {
 		-f query='query($owner:String!,$name:String!,$num:Int!){repository(owner:$owner,name:$name){issue(number:$num){id}}rateLimit{cost}}' \
 		-f owner="$owner" -f name="$name" -F num="$issue_number" \
 		2>/dev/null) || response=""
-	reported_cost=$(printf '%s' "$response" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
+	reported_cost=$(printf '%s' "$response" | jq -r "$_ISLR_GRAPHQL_COST_FILTER" 2>/dev/null) || reported_cost=""
 	if [[ "$reported_cost" =~ ^[1-9][0-9]*$ ]]; then
 		node_id=$(printf '%s' "$response" | jq -r '.data.repository.issue.id // empty' 2>/dev/null) || node_id=""
 	fi
@@ -329,7 +333,10 @@ resolve_gh_node_id() {
 # Returns: 0=present, 1=absent, 2=lookup unavailable/incomplete.
 _gh_native_blocked_by_contains() {
 	local blocked_id="$1" blocking_id="$2"
-	local payload="" reported_cost="" has_next="" contains=""
+	local payload=""
+	local reported_cost=""
+	local has_next=""
+	local contains=""
 	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub, not shell.
 	payload=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="issue-sync-blocked-by-read-exact-cost" \
@@ -338,11 +345,11 @@ query($blocked:ID!) {
   node(id:$blocked) { ... on Issue { blockedBy(first:100) { nodes { id } pageInfo { hasNextPage } } } }
 	rateLimit { cost }
 }' -f blocked="$blocked_id" 2>/dev/null) || return 2
-	reported_cost=$(printf '%s' "$payload" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
+	reported_cost=$(printf '%s' "$payload" | jq -r "$_ISLR_GRAPHQL_COST_FILTER" 2>/dev/null) || reported_cost=""
 	[[ "$reported_cost" =~ ^[1-9][0-9]*$ ]] || return 2
 	contains=$(printf '%s' "$payload" | jq -r --arg id "$blocking_id" \
 		'any(.data.node.blockedBy.nodes[]?; .id == $id)' 2>/dev/null) || return 2
-	[[ "$contains" == "true" ]] && return 0
+	[[ "$contains" == "$_ISLR_JSON_TRUE" ]] && return 0
 	has_next=$(printf '%s' "$payload" | jq -r \
 		'.data.node.blockedBy.pageInfo.hasNextPage | if type == "boolean" then tostring else "unknown" end' \
 		2>/dev/null) || return 2
@@ -354,7 +361,10 @@ query($blocked:ID!) {
 # Returns: 0=present, 1=absent, 2=lookup unavailable/incomplete.
 _gh_native_sub_issue_contains() {
 	local parent_id="$1" child_id="$2"
-	local payload="" reported_cost="" has_next="" contains=""
+	local payload=""
+	local reported_cost=""
+	local has_next=""
+	local contains=""
 	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub, not shell.
 	payload=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="issue-sync-sub-issue-read-exact-cost" \
@@ -363,11 +373,11 @@ query($parent:ID!) {
   node(id:$parent) { ... on Issue { subIssues(first:100) { nodes { id } pageInfo { hasNextPage } } } }
 	rateLimit { cost }
 }' -f parent="$parent_id" 2>/dev/null) || return 2
-	reported_cost=$(printf '%s' "$payload" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
+	reported_cost=$(printf '%s' "$payload" | jq -r "$_ISLR_GRAPHQL_COST_FILTER" 2>/dev/null) || reported_cost=""
 	[[ "$reported_cost" =~ ^[1-9][0-9]*$ ]] || return 2
 	contains=$(printf '%s' "$payload" | jq -r --arg id "$child_id" \
 		'any(.data.node.subIssues.nodes[]?; .id == $id)' 2>/dev/null) || return 2
-	[[ "$contains" == "true" ]] && return 0
+	[[ "$contains" == "$_ISLR_JSON_TRUE" ]] && return 0
 	has_next=$(printf '%s' "$payload" | jq -r \
 		'.data.node.subIssues.pageInfo.hasNextPage | if type == "boolean" then tostring else "unknown" end' \
 		2>/dev/null) || return 2

--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -309,15 +309,32 @@ _cached_node_id() {
 # whether this call created, observed, failed, or deferred the edge.
 _gh_add_blocked_by() {
 	local blocked_id="$1" blocking_id="$2"
-	local result mutation_rc=0
-	result=$(_gh_with_timeout write gh api graphql -f query='
+	local result="" reported_cost="" contains_rc=0 mutation_rc=0
+	_gh_native_blocked_by_contains "$blocked_id" "$blocking_id" || contains_rc=$?
+	case "$contains_rc" in
+		0)
+			log_verbose "  blocked-by relationship already exists"
+			_relationship_record_outcome "$_REL_OUTCOME_ALREADY_PRESENT"
+			return 0
+			;;
+		1) ;;
+		*)
+			_relationship_record_outcome "$_REL_OUTCOME_FAILED_RESOLUTION"
+			return 1
+			;;
+	esac
+	result=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="issue-sync-add-blocked-by-exact-cost" \
+		_gh_with_timeout write gh api graphql -f query='
 mutation($blocked:ID!,$blocking:ID!) {
   addBlockedBy(input: {issueId:$blocked, blockingIssueId:$blocking}) {
     issue { number }
   }
+	rateLimit { cost }
 }' -f blocked="$blocked_id" -f blocking="$blocking_id" 2>&1) || mutation_rc=$?
-
-	if echo "$result" | grep -q '"number"'; then
+	reported_cost=$(printf '%s' "$result" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
+	if [[ "$mutation_rc" -eq 0 && "$reported_cost" =~ ^[1-9][0-9]*$ ]] && \
+		printf '%s' "$result" | grep -q '"number"'; then
 		_relationship_record_outcome "$_REL_OUTCOME_CREATED"
 		return 0
 	fi
@@ -331,48 +348,29 @@ mutation($blocked:ID!,$blocking:ID!) {
 	return 1
 }
 
-# Check whether one native blocked-by edge currently exists. A paginated result
-# that does not contain the target is unknown rather than absent.
-# Returns: 0=present, 1=absent, 2=lookup unavailable/incomplete.
-_gh_native_blocked_by_contains() {
-	local blocked_id="$1"
-	local blocking_id="$2"
-	local payload="" has_next="" contains=""
-	payload=$(_gh_with_timeout read gh api graphql -f query='
-query($blocked:ID!) {
-  node(id:$blocked) {
-    ... on Issue {
-      blockedBy(first:100) { nodes { id } pageInfo { hasNextPage } }
-    }
-  }
-}' -f blocked="$blocked_id" 2>/dev/null) || return 2
-	contains=$(printf '%s' "$payload" | jq -r --arg id "$blocking_id" \
-		'any(.data.node.blockedBy.nodes[]?; .id == $id)' 2>/dev/null) || return 2
-	[[ "$contains" == "true" ]] && return 0
-	has_next=$(printf '%s' "$payload" | jq -r \
-		'.data.node.blockedBy.pageInfo.hasNextPage // true' 2>/dev/null) || return 2
-	[[ "$has_next" == "${REL_FALSE}" ]] && return 1
-	return 2
-}
-
 # Remove a deterministic break edge from an already-materialized native cycle.
 # Absence is idempotent success; lookup or mutation uncertainty remains retryable.
 _gh_remove_blocked_by() {
 	local blocked_id="$1"
 	local blocking_id="$2"
-	local contains_rc=0 result=""
+	local contains_rc=0 mutation_rc=0 result="" reported_cost=""
 	_gh_native_blocked_by_contains "$blocked_id" "$blocking_id" || contains_rc=$?
 	case "$contains_rc" in
 		1) return 0 ;;
 		2) return 1 ;;
 	esac
-	result=$(_gh_with_timeout write gh api graphql -f query='
+	result=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="issue-sync-remove-blocked-by-exact-cost" \
+		_gh_with_timeout write gh api graphql -f query='
 mutation($blocked:ID!,$blocking:ID!) {
   removeBlockedBy(input: {issueId:$blocked, blockingIssueId:$blocking}) {
     issue { number }
   }
-}' -f blocked="$blocked_id" -f blocking="$blocking_id" 2>&1)
-	if printf '%s' "$result" | grep -q '"number"'; then
+	rateLimit { cost }
+}' -f blocked="$blocked_id" -f blocking="$blocking_id" 2>&1) || mutation_rc=$?
+	reported_cost=$(printf '%s' "$result" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
+	if [[ "$mutation_rc" -eq 0 && "$reported_cost" =~ ^[1-9][0-9]*$ ]] && \
+		printf '%s' "$result" | grep -q '"number"'; then
 		return 0
 	fi
 	log_verbose "  removeBlockedBy error: ${result:0:200}"
@@ -549,21 +547,36 @@ _dependency_cycle_should_skip_edge() {
 	return 1
 }
 
-# Arguments:
-#   $1 - parent_node_id
-#   $2 - child_node_id
+# Arguments: $1=parent_node_id, $2=child_node_id
 # Returns: 0=success/already-exists, 1=error
 _gh_add_sub_issue() {
 	local parent_id="$1" child_id="$2"
-	local result mutation_rc=0
-	result=$(_gh_with_timeout write gh api graphql -f query='
+	local result="" reported_cost="" contains_rc=0 mutation_rc=0
+	_gh_native_sub_issue_contains "$parent_id" "$child_id" || contains_rc=$?
+	case "$contains_rc" in
+		0)
+			log_verbose "  sub-issue relationship already exists"
+			_relationship_record_outcome "$_REL_OUTCOME_ALREADY_PRESENT"
+			return 0
+			;;
+		1) ;;
+		*)
+			_relationship_record_outcome "$_REL_OUTCOME_FAILED_RESOLUTION"
+			return 1
+			;;
+	esac
+	result=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="issue-sync-add-sub-issue-exact-cost" \
+		_gh_with_timeout write gh api graphql -f query='
 mutation($parent:ID!,$child:ID!) {
   addSubIssue(input: {issueId:$parent, subIssueId:$child}) {
     issue { number }
   }
+	rateLimit { cost }
 }' -f parent="$parent_id" -f child="$child_id" 2>&1) || mutation_rc=$?
-
-	if echo "$result" | grep -q '"number"'; then
+	reported_cost=$(printf '%s' "$result" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
+	if [[ "$mutation_rc" -eq 0 && "$reported_cost" =~ ^[1-9][0-9]*$ ]] && \
+		printf '%s' "$result" | grep -q '"number"'; then
 		_relationship_record_outcome "$_REL_OUTCOME_CREATED"
 		return 0
 	fi

--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -334,7 +334,7 @@ mutation($blocked:ID!,$blocking:ID!) {
 }' -f blocked="$blocked_id" -f blocking="$blocking_id" 2>&1) || mutation_rc=$?
 	reported_cost=$(printf '%s' "$result" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
 	if [[ "$mutation_rc" -eq 0 && "$reported_cost" =~ ^[1-9][0-9]*$ ]] && \
-		printf '%s' "$result" | grep -q '"number"'; then
+		printf '%s' "$result" | jq -e '.data.addBlockedBy.issue.number | numbers' >/dev/null 2>&1; then
 		_relationship_record_outcome "$_REL_OUTCOME_CREATED"
 		return 0
 	fi
@@ -370,7 +370,7 @@ mutation($blocked:ID!,$blocking:ID!) {
 }' -f blocked="$blocked_id" -f blocking="$blocking_id" 2>&1) || mutation_rc=$?
 	reported_cost=$(printf '%s' "$result" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
 	if [[ "$mutation_rc" -eq 0 && "$reported_cost" =~ ^[1-9][0-9]*$ ]] && \
-		printf '%s' "$result" | grep -q '"number"'; then
+		printf '%s' "$result" | jq -e '.data.removeBlockedBy.issue.number | numbers' >/dev/null 2>&1; then
 		return 0
 	fi
 	log_verbose "  removeBlockedBy error: ${result:0:200}"
@@ -576,7 +576,7 @@ mutation($parent:ID!,$child:ID!) {
 }' -f parent="$parent_id" -f child="$child_id" 2>&1) || mutation_rc=$?
 	reported_cost=$(printf '%s' "$result" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
 	if [[ "$mutation_rc" -eq 0 && "$reported_cost" =~ ^[1-9][0-9]*$ ]] && \
-		printf '%s' "$result" | grep -q '"number"'; then
+		printf '%s' "$result" | jq -e '.data.addSubIssue.issue.number | numbers' >/dev/null 2>&1; then
 		_relationship_record_outcome "$_REL_OUTCOME_CREATED"
 		return 0
 	fi

--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -44,6 +44,7 @@ PR_REVIEW_THREAD_RESPONSE_BOT_RE="${PR_REVIEW_THREAD_RESPONSE_BOT_RE:-coderabbit
 PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN="${PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN:-false}"
 PRRTS_BOOL_TRUE="true"
 PRRTS_BOOL_FALSE="false"
+PRRTS_VALUE_UNKNOWN="unknown"
 PRRTS_TSV_FIELD_SEPARATOR=$'\034'
 # Increment when the worker prompt or launch contract changes so escalated
 # same-fingerprint state receives one fresh bounded remediation pass.
@@ -52,6 +53,7 @@ PRRTS_RC_GRAPHQL_EXHAUSTED=75
 PRRTS_BLOCKED_BY_CODE="code"
 PRRTS_BLOCKED_BY_INFRASTRUCTURE="infrastructure"
 PRRTS_REASON_HEAD_FETCH_FAILED="pr_head_fetch_failed"
+PRRTS_REASON_HEAD_REPOSITORY_UNVERIFIED="pr_head_repository_unverified"
 PRRTS_REASON_WORKTREE_OWNERSHIP_UNVERIFIED="review_worktree_ownership_unverified"
 PRRTS_WORKTREE_FAILURE_BLOCKED_BY="$PRRTS_BLOCKED_BY_INFRASTRUCTURE"
 PRRTS_WORKTREE_FAILURE_REASON="review_worktree_preparation_failed"
@@ -182,8 +184,8 @@ _prrts_graphql_rate_limit_ok() {
 
 _prrts_graphql_remaining() {
 	local remaining=""
-	remaining=$(gh api rate_limit --jq '.resources.graphql.remaining // 0' 2>/dev/null) || remaining="unknown"
-	[[ -n "$remaining" ]] || remaining="unknown"
+	remaining=$(gh api rate_limit --jq '.resources.graphql.remaining // 0' 2>/dev/null) || remaining="$PRRTS_VALUE_UNKNOWN"
+	[[ -n "$remaining" ]] || remaining="$PRRTS_VALUE_UNKNOWN"
 	printf '%s\n' "$remaining"
 	return 0
 }
@@ -228,9 +230,9 @@ _prrts_thread_has_marker() {
 		'[.data.node.comments.nodes[]? | select((.body // "") | contains($marker))] | length' 2>/dev/null) || count=0
 	[[ "$count" =~ ^[0-9]+$ ]] || count=0
 	[[ "$count" -gt 0 ]] && return 0
-	has_next=$(printf '%s' "$response" | jq -r \
-		'.data.node.comments.pageInfo.hasNextPage | if type == "boolean" then tostring else "unknown" end' \
-		2>/dev/null) || has_next="unknown"
+	has_next=$(printf '%s' "$response" | jq -r --arg unknown "$PRRTS_VALUE_UNKNOWN" \
+		'.data.node.comments.pageInfo.hasNextPage | if type == "boolean" then tostring else $unknown end' \
+		2>/dev/null) || has_next="$PRRTS_VALUE_UNKNOWN"
 	[[ "$has_next" == "$PRRTS_BOOL_FALSE" ]] && return 1
 	_prrts_log "write: marker lookup incomplete for thread ${thread_id}"
 	return 2
@@ -1256,7 +1258,7 @@ _prrts_validate_worker_head() {
 		AIDEVOPS_GH_ROUTE_DECISION="review-thread-head-repository-rest" \
 		gh api "repos/${repo_slug}/pulls/${pr_number}" 2>/dev/null) || {
 		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — could not verify PR head repository"
-		PRRTS_WORKTREE_FAILURE_REASON="pr_head_repository_unverified"
+		PRRTS_WORKTREE_FAILURE_REASON="$PRRTS_REASON_HEAD_REPOSITORY_UNVERIFIED"
 		return 1
 	}
 	is_cross_repository=$(printf '%s' "$pr_repo_json" | jq -er '
@@ -1265,7 +1267,7 @@ _prrts_validate_worker_head() {
 		else error("missing PR repository identity")
 		end' 2>/dev/null) || {
 		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — could not verify PR head repository"
-		PRRTS_WORKTREE_FAILURE_REASON="pr_head_repository_unverified"
+		PRRTS_WORKTREE_FAILURE_REASON="$PRRTS_REASON_HEAD_REPOSITORY_UNVERIFIED"
 		return 1
 	}
 	if [[ "$is_cross_repository" == "$PRRTS_BOOL_TRUE" ]]; then
@@ -1276,7 +1278,7 @@ _prrts_validate_worker_head() {
 	fi
 	if [[ "$is_cross_repository" != "$PRRTS_BOOL_FALSE" ]]; then
 		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — PR head repository response was indeterminate"
-		PRRTS_WORKTREE_FAILURE_REASON="pr_head_repository_unverified"
+		PRRTS_WORKTREE_FAILURE_REASON="$PRRTS_REASON_HEAD_REPOSITORY_UNVERIFIED"
 		return 1
 	fi
 	return 0

--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -188,32 +188,52 @@ _prrts_graphql_remaining() {
 	return 0
 }
 
+_prrts_graphql_response_has_positive_cost() {
+	local response="$1"
+	local reported_cost=""
+	reported_cost=$(printf '%s' "$response" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
+	[[ "$reported_cost" =~ ^[1-9][0-9]*$ ]]
+	return $?
+}
+
 _prrts_thread_has_marker() {
 	local thread_id="$1"
 	local marker="$2"
 	[[ -n "$thread_id" && -n "$marker" ]] || return 1
 
-	local response="" count="0" rc=0
+	local response="" count="0" has_next="" rc=0
 	# shellcheck disable=SC2016
-	response=$(gh api graphql \
+	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="review-thread-marker-exact-cost" \
+		gh api graphql \
 		-F thread="$thread_id" -f query='
 			query($thread: ID!) {
 				node(id: $thread) {
 					... on PullRequestReviewThread {
-						comments(first: 100) { nodes { body } }
+						comments(first: 100) { nodes { body } pageInfo { hasNextPage } }
 					}
 				}
+				rateLimit { cost }
 			}
 		' 2>/dev/null) || rc=$?
 	if [[ "$rc" -ne 0 ]]; then
 		_prrts_log "write: marker lookup failed for thread ${thread_id} (rc=${rc})"
-		return 1
+		return 2
+	fi
+	if ! _prrts_graphql_response_has_positive_cost "$response"; then
+		_prrts_log "write: marker lookup returned no exact GraphQL cost for thread ${thread_id}"
+		return 2
 	fi
 	count=$(printf '%s' "$response" | jq -r --arg marker "$marker" \
 		'[.data.node.comments.nodes[]? | select((.body // "") | contains($marker))] | length' 2>/dev/null) || count=0
 	[[ "$count" =~ ^[0-9]+$ ]] || count=0
-	[[ "$count" -gt 0 ]]
-	return $?
+	[[ "$count" -gt 0 ]] && return 0
+	has_next=$(printf '%s' "$response" | jq -r \
+		'.data.node.comments.pageInfo.hasNextPage | if type == "boolean" then tostring else "unknown" end' \
+		2>/dev/null) || has_next="unknown"
+	[[ "$has_next" == "$PRRTS_BOOL_FALSE" ]] && return 1
+	_prrts_log "write: marker lookup incomplete for thread ${thread_id}"
+	return 2
 }
 
 _prrts_thread_author_login() {
@@ -222,7 +242,9 @@ _prrts_thread_author_login() {
 	[[ -n "$thread_id" ]] || return 1
 
 	# shellcheck disable=SC2016
-	response=$(gh api graphql \
+	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="review-thread-author-exact-cost" \
+		gh api graphql \
 		-F thread="$thread_id" -f query='
 			query($thread: ID!) {
 				node(id: $thread) {
@@ -230,11 +252,16 @@ _prrts_thread_author_login() {
 						comments(first: 1) { nodes { author { login } } }
 					}
 				}
+				rateLimit { cost }
 			}
 		' 2>/dev/null) || rc=$?
 	if [[ "$rc" -ne 0 ]]; then
 		_prrts_log "reply: author lookup failed for thread ${thread_id} (rc=${rc})"
-		return 1
+		return 2
+	fi
+	if ! _prrts_graphql_response_has_positive_cost "$response"; then
+		_prrts_log "reply: author lookup returned no exact GraphQL cost for thread ${thread_id}"
+		return 2
 	fi
 	login=$(printf '%s' "$response" | jq -r '.data.node.comments?.nodes[0]?.author?.login // ""') || login=""
 	if [[ -z "$login" ]]; then
@@ -288,7 +315,8 @@ cmd_reply() {
 	local thread_id="$2"
 	local body_file="$3"
 	local marker="${4:-}"
-	local body="" dry_run="${PR_REVIEW_THREAD_RESPONSE_DRY_RUN:-false}" author_login=""
+	local body="" dry_run="${PR_REVIEW_THREAD_RESPONSE_DRY_RUN:-false}" author_login="" response=""
+	local marker_rc=1 author_rc=0
 
 	[[ -n "$repo_slug" && -n "$thread_id" && -n "$body_file" && -f "$body_file" ]] || {
 		_prrts_usage >&2
@@ -297,31 +325,53 @@ cmd_reply() {
 	body=$(<"$body_file") || body=""
 	[[ -n "$body" ]] || return 2
 
-	if [[ -n "$marker" ]] && _prrts_thread_has_marker "$thread_id" "$marker"; then
-		_prrts_log "reply: skipped ${repo_slug} thread ${thread_id} — marker already present"
-		return 0
+	if [[ -n "$marker" ]]; then
+		marker_rc=0
+		_prrts_thread_has_marker "$thread_id" "$marker" || marker_rc=$?
+		case "$marker_rc" in
+			0)
+				_prrts_log "reply: skipped ${repo_slug} thread ${thread_id} — marker already present"
+				return 0
+				;;
+			1) ;;
+			*) return 1 ;;
+		esac
 	fi
 	if [[ "$dry_run" == "$PRRTS_BOOL_TRUE" ]]; then
 		printf 'DRY-RUN would reply to %s thread %s\n' "$repo_slug" "$thread_id"
 		return 0
 	fi
 	_prrts_graphql_rate_limit_ok || return 1
-	if author_login="$(_prrts_thread_author_login "$thread_id")"; then
+	author_login="$(_prrts_thread_author_login "$thread_id")" || author_rc=$?
+	if [[ "$author_rc" -eq 0 ]]; then
 		body="$(_prrts_body_with_author_mention "$body" "$author_login")"
-	else
+	elif [[ "$author_rc" -eq 1 ]]; then
 		_prrts_log "reply: posting without author mention for ${repo_slug} thread ${thread_id}"
+	else
+		return 1
 	fi
 
 	# shellcheck disable=SC2016
-	gh api graphql \
+	if ! response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="review-thread-reply-exact-cost" \
+		gh api graphql \
 		-F thread="$thread_id" -f body="$body" \
 		-f query='
 			mutation($thread: ID!, $body: String!) {
 				addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $thread, body: $body}) {
 					comment { id url }
 				}
+				rateLimit { cost }
 			}
-		' >/dev/null
+		'); then
+		_prrts_log "reply: GraphQL mutation failed for ${repo_slug} thread ${thread_id}"
+		return 1
+	fi
+	if ! _prrts_graphql_response_has_positive_cost "$response" ||
+		! printf '%s' "$response" | jq -e '(.data.addPullRequestReviewThreadReply.comment.id // "") | length > 0' >/dev/null 2>&1; then
+		_prrts_log "reply: GraphQL mutation response was unmetered or malformed for ${repo_slug} thread ${thread_id}"
+		return 1
+	fi
 	_prrts_log "reply: posted in-thread response for ${repo_slug} thread ${thread_id}"
 	return 0
 }
@@ -329,7 +379,7 @@ cmd_reply() {
 cmd_resolve() {
 	local repo_slug="$1"
 	local thread_id="$2"
-	local dry_run="${PR_REVIEW_THREAD_RESPONSE_DRY_RUN:-false}"
+	local dry_run="${PR_REVIEW_THREAD_RESPONSE_DRY_RUN:-false}" response=""
 	[[ -n "$repo_slug" && -n "$thread_id" ]] || {
 		_prrts_usage >&2
 		return 2
@@ -340,13 +390,24 @@ cmd_resolve() {
 	fi
 	_prrts_graphql_rate_limit_ok || return 1
 	# shellcheck disable=SC2016
-	gh api graphql \
+	if ! response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="review-thread-resolve-exact-cost" \
+		gh api graphql \
 		-F thread="$thread_id" \
 		-f query='
 			mutation($thread: ID!) {
 				resolveReviewThread(input: {threadId: $thread}) { thread { id isResolved } }
+				rateLimit { cost }
 			}
-		' >/dev/null
+		'); then
+		_prrts_log "resolve: GraphQL mutation failed for ${repo_slug} thread ${thread_id}"
+		return 1
+	fi
+	if ! _prrts_graphql_response_has_positive_cost "$response" ||
+		! printf '%s' "$response" | jq -e '.data.resolveReviewThread.thread.isResolved == true' >/dev/null 2>&1; then
+		_prrts_log "resolve: GraphQL mutation response was unmetered or malformed for ${repo_slug} thread ${thread_id}"
+		return 1
+	fi
 	_prrts_log "resolve: resolved ${repo_slug} thread ${thread_id}"
 	return 0
 }
@@ -367,7 +428,9 @@ _prrts_fetch_review_threads_json() {
 	local owner="" name="" response="" rc=0
 	_prrts_parse_repo_slug "$repo_slug" owner name
 	# shellcheck disable=SC2016
-	response=$(gh api graphql \
+	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="review-thread-scan-exact-cost" \
+		gh api graphql \
 		-F owner="$owner" -F name="$name" -F pr="$pr_number" \
 		-f query='
 			query($owner: String!, $name: String!, $pr: Int!) {
@@ -390,9 +453,11 @@ _prrts_fetch_review_threads_json() {
 									}
 								}
 							}
+							pageInfo { hasNextPage }
 						}
 					}
 				}
+				rateLimit { cost }
 			}
 		' 2>/dev/null) || rc=$?
 	if [[ "$rc" -ne 0 ]]; then
@@ -405,8 +470,17 @@ _prrts_fetch_review_threads_json() {
 		_prrts_log "fetch: gh graphql failed for ${repo_slug}#${pr_number} (rc=${rc}, graphql_remaining=${remaining})"
 		return 2
 	fi
+	if ! _prrts_graphql_response_has_positive_cost "$response"; then
+		_prrts_log "fetch: GraphQL cost unavailable for ${repo_slug}#${pr_number}"
+		return 2
+	fi
 	if ! printf '%s' "$response" | jq -e '.data.repository.pullRequest.reviewThreads' >/dev/null 2>&1; then
 		_prrts_log "fetch: malformed reviewThreads response for ${repo_slug}#${pr_number}"
+		return 2
+	fi
+	if ! printf '%s' "$response" | jq -e \
+		'.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage == false' >/dev/null 2>&1; then
+		_prrts_log "fetch: reviewThreads response incomplete for ${repo_slug}#${pr_number}"
 		return 2
 	fi
 	printf '%s' "$response"
@@ -1158,7 +1232,7 @@ _prrts_validate_worker_head() {
 	local pr_number="$3"
 	local head_ref="$4"
 	local head_oid="$5"
-	local is_cross_repository=""
+	local is_cross_repository="" pr_repo_json=""
 
 	[[ -n "$head_ref" ]] || {
 		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — PR head branch is unavailable"
@@ -1178,8 +1252,18 @@ _prrts_validate_worker_head() {
 		PRRTS_WORKTREE_FAILURE_REASON="pr_head_sha_invalid"
 		return 1
 	fi
-	is_cross_repository=$(gh pr view "$pr_number" --repo "$repo_slug" --json isCrossRepository \
-		--jq '.isCrossRepository | tostring' 2>/dev/null) || {
+	pr_repo_json=$(AIDEVOPS_GH_QUOTA_COST_ON_SUCCESS=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="review-thread-head-repository-rest" \
+		gh api "repos/${repo_slug}/pulls/${pr_number}" 2>/dev/null) || {
+		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — could not verify PR head repository"
+		PRRTS_WORKTREE_FAILURE_REASON="pr_head_repository_unverified"
+		return 1
+	}
+	is_cross_repository=$(printf '%s' "$pr_repo_json" | jq -er '
+		if ((.head.repo.full_name // "") | length) > 0 and ((.base.repo.full_name // "") | length) > 0
+		then (.head.repo.full_name != .base.repo.full_name) | tostring
+		else error("missing PR repository identity")
+		end' 2>/dev/null) || {
 		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — could not verify PR head repository"
 		PRRTS_WORKTREE_FAILURE_REASON="pr_head_repository_unverified"
 		return 1

--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -411,15 +411,20 @@ _should_defer_auto_unblock() {
 		return 0
 	fi
 
-	# (b) Non-dep BLOCKED markers in recent comments. Single API call per
-	# candidate; unblock candidates are rare (typical cycle: 0-5 across all
-	# repos), so the cost is well-bounded. Silently tolerate fetch failures
-	# (fail-open on API error → behave as before, preserving the t1935
+	# (b) Non-dep BLOCKED markers in recent comments. Use the paginated REST
+	# issue-comments endpoint because only comment bodies are needed; native
+	# `gh issue view --json comments` is GraphQL-only and cannot expose
+	# response-owned cost. Unblock candidates are rare (typical cycle: 0-5
+	# across all repos), so the cost is well-bounded. Silently tolerate fetch
+	# failures (fail-open on API error → behave as before, preserving the t1935
 	# auto-unblock path when network is flaky).
 	local recent_bodies=""
-	recent_bodies=$(gh issue view "$issue_num" --repo "$repo_slug" \
-		--json comments --jq '[.comments[-10:][] | .body] | join("\n---\n")' \
-		2>/dev/null) || recent_bodies=""
+	recent_bodies=$(set -o pipefail; gh api \
+		"repos/${repo_slug}/issues/${issue_num}/comments?per_page=100" --paginate --slurp 2>/dev/null |
+		jq -r '
+			(if (type == "array" and ((.[0]? | type) == "array")) then add else . end)
+			| .[-10:] | map(.body // "") | join("\n---\n")
+		') || recent_bodies=""
 
 	if [[ -n "$recent_bodies" ]]; then
 		if printf '%s' "$recent_bodies" | grep -qE "$_PULSE_DEP_GRAPH_NON_DEP_BLOCK_MARKERS"; then

--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -1115,8 +1115,12 @@ This comment is idempotent; the HTML sentinel prevents duplicates on subsequent 
 
 	# Idempotency guard — only suppresses duplicate comment; labels are still healed
 	local existing_comments
-	existing_comments=$(gh issue view "$issue_num" --repo "$slug" \
-		--json comments --jq '[.comments[].body] | join("\n")' 2>/dev/null || echo "")
+	existing_comments=$(set -o pipefail; gh api \
+		"repos/${slug}/issues/${issue_num}/comments?per_page=100" --paginate --slurp 2>/dev/null |
+		jq -r '
+			(if (type == "array" and ((.[0]? | type) == "array")) then add else . end)
+			| map(.body // "") | join("\n")
+		' || echo "")
 	local comment_already_posted="$_PIR_BOOL_FALSE"
 	[[ "$existing_comments" == *"$check_sentinel"* ]] && comment_already_posted="$_PIR_BOOL_TRUE"
 

--- a/.agents/scripts/pulse-triage-cache.sh
+++ b/.agents/scripts/pulse-triage-cache.sh
@@ -284,22 +284,18 @@ _gh_idempotent_comment() {
 		return 2
 	fi
 
-	# Fetch existing comments and check for marker.
-	# Use the REST API for issues; gh pr view for PRs.
+	# Fetch existing issue comments and check for marker. Pull-request
+	# conversation comments use this same REST endpoint; native `gh pr view
+	# --json comments` is GraphQL-only and cannot expose response-owned cost.
 	local existing_comments=""
-	if [[ "$entity_type" == "pr" ]]; then
-		existing_comments=$(gh pr view "$entity_number" --repo "$repo_slug" \
-			--json comments --jq '.comments[].body')
-	else
-		# t3565: GitHub's issue-comments REST endpoint defaults to the oldest
-		# 30 comments. Long-running issues can have idempotency markers beyond
-		# page 1, so normalize paginated gh output before grepping for markers.
-		existing_comments=$(set -o pipefail; gh api "repos/${repo_slug}/issues/${entity_number}/comments?per_page=100" \
-			--paginate --slurp | jq -r --arg array_type "$_PTC_JSON_ARRAY_TYPE" '
-				(if (type == $array_type and ((.[0]? | type) == $array_type)) then .[] else . end)[]
-				| .body // ""
-			')
-	fi
+	# t3565: GitHub's issue-comments REST endpoint defaults to the oldest
+	# 30 comments. Long-running issues and PRs can have idempotency markers
+	# beyond page 1, so normalize paginated gh output before grepping.
+	existing_comments=$(set -o pipefail; gh api "repos/${repo_slug}/issues/${entity_number}/comments?per_page=100" \
+		--paginate --slurp | jq -r --arg array_type "$_PTC_JSON_ARRAY_TYPE" '
+			(if (type == $array_type and ((.[0]? | type) == $array_type)) then .[] else . end)[]
+			| .body // ""
+		')
 	local api_exit=$?
 
 	if [[ $api_exit -ne 0 ]]; then

--- a/.agents/scripts/pulse-triage-evaluation.sh
+++ b/.agents/scripts/pulse-triage-evaluation.sh
@@ -36,6 +36,7 @@
 # Include guard
 [[ -n "${_PULSE_TRIAGE_EVALUATION_LIB_LOADED:-}" ]] && return 0
 _PULSE_TRIAGE_EVALUATION_LIB_LOADED=1
+_PTE_JSON_ARRAY_TYPE="array"
 
 # Defensive SCRIPT_DIR fallback
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
@@ -184,8 +185,8 @@ _reevaluate_stale_continuations() {
 	local gate_comment
 	gate_comment=$(set -o pipefail; gh api \
 		"repos/${repo_slug}/issues/${issue_number}/comments?per_page=100" --paginate --slurp 2>/dev/null |
-		jq -r '
-			(if (type == "array" and ((.[0]? | type) == "array")) then add else . end)
+		jq -r --arg array_type "$_PTE_JSON_ARRAY_TYPE" '
+			(if (type == $array_type and ((.[0]? | type) == $array_type)) then add else . end)
 			| map(select((.body // "") | contains("## Large File Simplification Gate")))
 			| .[0].body // empty
 		') || gate_comment=""
@@ -437,8 +438,8 @@ _consolidation_dispatch_comment_exists() {
 
 	local marker_count
 	marker_count=$(set -o pipefail; gh api "repos/${repo_slug}/issues/${parent_num}/comments?per_page=100" \
-		--paginate --slurp | jq -r '
-			[ (if (type == "array" and ((.[0]? | type) == "array")) then .[] else . end)[]
+		--paginate --slurp | jq -r --arg array_type "$_PTE_JSON_ARRAY_TYPE" '
+			[ (if (type == $array_type and ((.[0]? | type) == $array_type)) then .[] else . end)[]
 			| select((.body // "") | contains("## Issue Consolidation Dispatched")) ] | length
 	') || return 1
 	[[ "$marker_count" =~ ^[0-9]+$ ]] || marker_count=0

--- a/.agents/scripts/pulse-triage-evaluation.sh
+++ b/.agents/scripts/pulse-triage-evaluation.sh
@@ -178,13 +178,17 @@ _reevaluate_stale_continuations() {
 	local repo_slug="$2"
 	local repo_path="$3"
 
-	# Fetch gate sticky comment. map+.[0] preserves the full multi-line body
+	# Fetch the gate sticky comment through paginated REST because this operation
+	# needs only comment bodies. map+.[0] preserves the full multi-line body
 	# (.[]+head-1 would truncate to the heading line, losing the issue refs).
 	local gate_comment
-	gate_comment=$(gh issue view "$issue_number" --repo "$repo_slug" \
-		--comments --json comments \
-		--jq '.comments | map(select(.body | contains("## Large File Simplification Gate"))) | .[0].body // empty' \
-		2>/dev/null) || gate_comment=""
+	gate_comment=$(set -o pipefail; gh api \
+		"repos/${repo_slug}/issues/${issue_number}/comments?per_page=100" --paginate --slurp 2>/dev/null |
+		jq -r '
+			(if (type == "array" and ((.[0]? | type) == "array")) then add else . end)
+			| map(select((.body // "") | contains("## Large File Simplification Gate")))
+			| .[0].body // empty
+		') || gate_comment=""
 	[[ -n "$gate_comment" ]] || return 1
 
 	# Extract only the "recently-closed — continuation" issue numbers; open

--- a/.agents/scripts/pulse-wrapper-bootstrap.sh
+++ b/.agents/scripts/pulse-wrapper-bootstrap.sh
@@ -432,8 +432,9 @@ _resolve_linked_pr_for_issue() {
 		return 0
 	}
 
-	# GitHub's GraphQL closingIssuesReferences is the authoritative way to
-	# find PRs that will close this issue. The REST search alternative
+	# GitHub's GraphQL closing relationship is the authoritative way to find
+	# PRs that will close this issue. Use a fixed query with response-owned cost;
+	# native `gh issue view` hides GraphQL cost. The REST search alternative
 	# (`gh search prs "linked:$issue_num"`) is rate-limited heavily and
 	# returns false positives via mention.
 	#
@@ -441,11 +442,34 @@ _resolve_linked_pr_for_issue() {
 	# extraction regex in pulse-merge.sh::_extract_linked_issue. Best-effort
 	# everywhere — empty stdout means "skip this record, full merge pass
 	# will catch it on next tick".
-	local pr_num=""
-	pr_num=$(gh issue view "$issue_num" --repo "$slug" \
-		--json closedByPullRequestsReferences \
-		--jq '.closedByPullRequestsReferences // [] | map(select(.state=="OPEN")) | .[0].number // empty' \
-		2>/dev/null) || pr_num=""
+	local owner="${slug%%/*}"
+	local name="${slug#*/}"
+	local pr_num="" response="" reported_cost=""
+	# shellcheck disable=SC2016
+	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="pulse-linked-pr-exact-cost" \
+		gh api graphql -F owner="$owner" -F name="$name" -F number="$issue_num" -f query='
+			query($owner: String!, $name: String!, $number: Int!) {
+				repository(owner: $owner, name: $name) {
+					issue(number: $number) {
+						closedByPullRequestsReferences(first: 100) {
+							nodes { number state }
+							pageInfo { hasNextPage }
+						}
+					}
+				}
+				rateLimit { cost }
+			}
+		' 2>/dev/null) || response=""
+	reported_cost=$(printf '%s' "$response" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
+	if [[ "$reported_cost" =~ ^[0-9]+$ ]]; then
+		pr_num=$(printf '%s' "$response" | jq -r '
+			.data.repository.issue.closedByPullRequestsReferences
+			| select(.pageInfo.hasNextPage == false)
+			| [.nodes[]? | select(.state == "OPEN")]
+			| .[0].number // empty
+		' 2>/dev/null) || pr_num=""
+	fi
 
 	if [[ -z "$pr_num" ]]; then
 		# Fallback: list recent open PRs in the repo and grep for the

--- a/.agents/scripts/pulse-wrapper-bootstrap.sh
+++ b/.agents/scripts/pulse-wrapper-bootstrap.sh
@@ -462,7 +462,7 @@ _resolve_linked_pr_for_issue() {
 			}
 		' 2>/dev/null) || response=""
 	reported_cost=$(printf '%s' "$response" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
-	if [[ "$reported_cost" =~ ^[0-9]+$ ]]; then
+	if [[ "$reported_cost" =~ ^[1-9][0-9]*$ ]]; then
 		pr_num=$(printf '%s' "$response" | jq -r '
 			.data.repository.issue.closedByPullRequestsReferences
 			| select(.pageInfo.hasNextPage == false)

--- a/.agents/scripts/shared-gh-wrappers-rest-read-semantics.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-read-semantics.sh
@@ -19,6 +19,16 @@ _rest_args_have_author() {
 	return 1
 }
 
+_rest_pr_list_requires_search() {
+	local arg=""
+	for arg in "$@"; do
+		case "$arg" in
+		--author|--author=*|-A|--assignee|--assignee=*|-a|--label|--label=*|-l|--search|--search=*|-S|--draft|-d) return 0 ;;
+		esac
+	done
+	return 1
+}
+
 _rest_resolve_actor_filter() {
 	local actor="$1"
 	if [[ "$actor" == "@me" ]]; then
@@ -297,7 +307,7 @@ _rest_pr_list_can_preserve_args() {
 	local fields=""
 	local limit=30
 	local state="$_REST_READ_STATE_OPEN"
-	_rest_args_have_author "$@" && mode="$_REST_READ_MODE_SEARCH"
+	_rest_pr_list_requires_search "$@" && mode="$_REST_READ_MODE_SEARCH"
 	while [[ $# -gt 0 ]]; do
 		local arg="$1"
 		case "$arg" in
@@ -602,18 +612,18 @@ _rest_pr_search() {
 		*) printf '_rest_pr_search: unsupported argument: %s\n' "$arg" >&2; return 2 ;;
 		esac
 	done
-	[[ -n "$repo" && -n "$author" && "$limit" =~ ^[1-9][0-9]*$ && "$limit" -le 1000 ]] &&
+	[[ -n "$repo" && "$limit" =~ ^[1-9][0-9]*$ && "$limit" -le 1000 ]] &&
 		_rest_repo_slug_supported "$repo" || {
-		printf '_rest_pr_search: --repo, --author, and a limit <= 1000 are required\n' >&2
+		printf '_rest_pr_search: --repo and a limit <= 1000 are required\n' >&2
 		return 1
 	}
 	if [[ -n "$json_fields" ]] && ! _rest_pr_list_fields_supported search "$json_fields"; then
 		printf '_rest_pr_search: unsupported JSON field set: %s\n' "$json_fields" >&2
 		return 2
 	fi
-	author="$(_rest_resolve_actor_filter "$author")" || return 1
+	[[ -z "$author" ]] || author="$(_rest_resolve_actor_filter "$author")" || return 1
 	[[ -z "$assignee" ]] || assignee="$(_rest_resolve_actor_filter "$assignee")" || return 1
-	local query="${search}${search:+ }repo:${repo} is:pr author:${author}"
+	local query="${search}${search:+ }repo:${repo} is:pr"
 	case "$state" in
 	open) query="${query} is:open" ;;
 	closed) query="${query} is:closed is:unmerged" ;;
@@ -621,6 +631,7 @@ _rest_pr_search() {
 	all) ;;
 	*) printf '_rest_pr_search: unsupported state: %s\n' "$state" >&2; return 2 ;;
 	esac
+	[[ -z "$author" ]] || query="${query} author:${author}"
 	[[ -z "$assignee" ]] || query="${query} assignee:${assignee}"
 	local qualifier=""
 	if [[ -n "$base_branch" ]]; then
@@ -650,7 +661,7 @@ _rest_pr_search() {
 }
 
 _rest_pr_list_dispatch() {
-	if _rest_args_have_author "$@"; then
+	if _rest_pr_list_requires_search "$@"; then
 		_rest_pr_search "$@"
 	else
 		_rest_pr_list "$@"

--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -627,7 +627,7 @@ gh_issue_view() {
 # Routes directly to REST (`gh api GET /repos/{owner}/{repo}/pulls`) when
 # GraphQL remaining is below the fallback threshold, and still falls back to
 # REST if the primary call fails during an exhaustion window. Direct list reads
-# use /pulls; --author reads use pagination-complete Search API qualifiers.
+# use /pulls; search-only filters use pagination-complete Search API qualifiers.
 # Unsupported argument or JSON-field shapes remain on native GraphQL.
 #
 #   gh_pr_list --repo owner/repo --state open --json number,title
@@ -641,7 +641,7 @@ gh_pr_list() {
 	local _uses_search=0
 	local _pool="rest-core"
 	_rest_pr_list_can_preserve_args "$@" && _rest_capable=1
-	if _rest_args_have_author "$@"; then
+	if _rest_pr_list_requires_search "$@"; then
 		_uses_search=1
 		_pool="rest-search"
 	fi
@@ -654,7 +654,7 @@ gh_pr_list() {
 	local _out="" _rc=0
 	if [[ $_rest_capable -eq 1 ]] && _rest_read_first_enabled; then
 		if [[ $_uses_search -eq 1 ]]; then
-			print_info "[INFO] gh-wrapper: REST-first read mode, routing author-filtered pr list to /search/issues"
+			print_info "[INFO] gh-wrapper: REST-first read mode, routing search-filtered pr list to /search/issues"
 		else
 			print_info "[INFO] gh-wrapper: REST-first read mode, routing pr list to REST"
 		fi
@@ -668,7 +668,7 @@ gh_pr_list() {
 	fi
 	if [[ $_rest_capable -eq 1 ]] && { { command -v github_app_should_route_rest >/dev/null 2>&1 && github_app_should_route_rest "$_pool" gh_pr_list; } || _rest_should_fallback; }; then
 		if [[ $_uses_search -eq 1 ]]; then
-			print_info "[INFO] gh-wrapper: GraphQL budget low, routing author-filtered pr list to /search/issues"
+			print_info "[INFO] gh-wrapper: GraphQL budget low, routing search-filtered pr list to /search/issues"
 		else
 			print_info "[INFO] gh-wrapper: GraphQL budget low, routing pr list to REST"
 		fi
@@ -685,7 +685,7 @@ gh_pr_list() {
 	local rc=$?
 	if [[ $rc -ne 0 && $_rest_capable -eq 1 ]] && _rest_should_fallback; then
 		if [[ $_uses_search -eq 1 ]]; then
-			print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to /search/issues for author-filtered pr list"
+			print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to /search/issues for search-filtered pr list"
 		else
 			print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for pr list"
 		fi

--- a/.agents/scripts/tests/test-approve-kicks-pulse.sh
+++ b/.agents/scripts/tests/test-approve-kicks-pulse.sh
@@ -428,6 +428,53 @@ assert_eq "issue 12345 resolved to PR 99999 by stub" \
 echo ""
 
 # -----------------------------------------------------------------------------
+# Test 7b: issue→PR resolver owns and validates fixed GraphQL operation cost.
+# -----------------------------------------------------------------------------
+echo "Test 7b: resolver reports response-owned GraphQL cost"
+echo "======================================================"
+
+metered_graphql_log="${TMPROOT}/test7b-graphql.log"
+: >"$metered_graphql_log"
+resolver_result=$(
+(
+	# shellcheck disable=SC1091
+	source "${PARENT_DIR}/pulse-wrapper-bootstrap.sh" >/dev/null 2>&1
+
+	gh() {
+		local cmd="${1:-}"
+		local subcmd="${2:-}"
+		if [[ "$cmd" == "api" && "$subcmd" == "graphql" ]]; then
+			printf 'meter=%s route=%s\n' \
+				"${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" \
+				"${AIDEVOPS_GH_ROUTE_DECISION:-}" >>"$metered_graphql_log"
+			printf '%s\n' "$*" >>"$metered_graphql_log"
+			printf '%s\n' '{"data":{"repository":{"issue":{"closedByPullRequestsReferences":{"nodes":[{"number":76543,"state":"OPEN"}],"pageInfo":{"hasNextPage":false}}}},"rateLimit":{"cost":1}}}'
+			return 0
+		fi
+		return 1
+	}
+
+	gh_pr_list() {
+		printf 'unexpected fallback\n' >>"$metered_graphql_log"
+		return 1
+	}
+
+	_resolve_linked_pr_for_issue "marcusquinn/aidevops" "12345"
+)
+)
+assert_eq "resolver returns the open PR from fixed GraphQL" "76543" "$resolver_result"
+if grep -qF 'meter=1 route=pulse-linked-pr-exact-cost' "$metered_graphql_log" &&
+	grep -qF 'rateLimit { cost }' "$metered_graphql_log" &&
+	! grep -qF 'unexpected fallback' "$metered_graphql_log"; then
+	assert_pass "resolver meters GraphQL from the returned rateLimit.cost"
+else
+	assert_fail "resolver meters GraphQL from the returned rateLimit.cost" \
+		"graphql log: $(cat "$metered_graphql_log")"
+fi
+
+echo ""
+
+# -----------------------------------------------------------------------------
 # Test 8: issue→PR fallback resolver uses gh_pr_list wrapper when available.
 # -----------------------------------------------------------------------------
 echo "Test 8: resolver fallback uses gh_pr_list"

--- a/.agents/scripts/tests/test-approve-kicks-pulse.sh
+++ b/.agents/scripts/tests/test-approve-kicks-pulse.sh
@@ -475,6 +475,50 @@ fi
 echo ""
 
 # -----------------------------------------------------------------------------
+# Test 7c: a zero GraphQL cost is not valid operation-owned evidence.
+# -----------------------------------------------------------------------------
+echo "Test 7c: resolver rejects zero GraphQL cost"
+echo "============================================"
+
+zero_cost_graphql_log="${TMPROOT}/test7c-graphql.log"
+: >"$zero_cost_graphql_log"
+resolver_result=$(
+(
+	# shellcheck disable=SC1091
+	source "${PARENT_DIR}/pulse-wrapper-bootstrap.sh" >/dev/null 2>&1
+
+	gh() {
+		local cmd="${1:-}"
+		local subcmd="${2:-}"
+		if [[ "$cmd" == "api" && "$subcmd" == "graphql" ]]; then
+			printf '%s\n' 'graphql-zero-cost' >>"$zero_cost_graphql_log"
+			printf '%s\n' '{"data":{"repository":{"issue":{"closedByPullRequestsReferences":{"nodes":[{"number":76543,"state":"OPEN"}],"pageInfo":{"hasNextPage":false}}}},"rateLimit":{"cost":0}}}'
+			return 0
+		fi
+		return 1
+	}
+
+	gh_pr_list() {
+		printf '%s\n' 'fallback-used' >>"$zero_cost_graphql_log"
+		printf '%s\n' '[{"number":87654,"body":"Fixes #12345"}]'
+		return 0
+	}
+
+	_resolve_linked_pr_for_issue "marcusquinn/aidevops" "12345"
+)
+)
+assert_eq "resolver rejects zero-cost GraphQL and uses its fallback" "87654" "$resolver_result"
+if grep -qF 'graphql-zero-cost' "$zero_cost_graphql_log" &&
+	grep -qF 'fallback-used' "$zero_cost_graphql_log"; then
+	assert_pass "zero GraphQL cost cannot authorize linked-PR resolution"
+else
+	assert_fail "zero GraphQL cost cannot authorize linked-PR resolution" \
+		"graphql log: $(cat "$zero_cost_graphql_log")"
+fi
+
+echo ""
+
+# -----------------------------------------------------------------------------
 # Test 8: issue→PR fallback resolver uses gh_pr_list wrapper when available.
 # -----------------------------------------------------------------------------
 echo "Test 8: resolver fallback uses gh_pr_list"

--- a/.agents/scripts/tests/test-backfill-sub-issues.sh
+++ b/.agents/scripts/tests/test-backfill-sub-issues.sh
@@ -164,19 +164,24 @@ fi
 
 # gh api graphql -f query=...
 if [[ "$cmd1" == "api" && "$cmd2" == "graphql" ]]; then
+	[[ "${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" == "1" && "$*" == *"rateLimit"* ]] || exit 1
 	# Check the mutation name in the query body
 	for arg in "$@"; do
 		if [[ "$arg" == *"addSubIssue"* ]]; then
-			printf '%s\n' '{"data":{"addSubIssue":{"issue":{"number":1}}}}'
+			printf '%s\n' '{"data":{"addSubIssue":{"issue":{"number":1}},"rateLimit":{"cost":1}}}'
+			exit 0
+		fi
+		if [[ "$arg" == *"subIssues(first:100)"* ]]; then
+			printf '%s\n' '{"data":{"node":{"subIssues":{"nodes":[],"pageInfo":{"hasNextPage":false}}},"rateLimit":{"cost":1}}}'
 			exit 0
 		fi
 		if [[ "$arg" == *"issue(number"* ]]; then
 			# resolve_gh_node_id query — fail when _GH_GRAPHQL_NODE_FAIL=1 is set
 			if [[ "${_GH_GRAPHQL_NODE_FAIL:-0}" == "1" ]]; then
-				printf '\n'
+				printf '%s\n' '{"data":{"repository":{"issue":null},"rateLimit":{"cost":1}}}'
 				exit 0
 			fi
-			printf '%s\n' 'NODE_STUB_ID'
+			printf '%s\n' '{"data":{"repository":{"issue":{"id":"NODE_STUB_ID"}},"rateLimit":{"cost":1}}}'
 			exit 0
 		fi
 	done
@@ -642,6 +647,7 @@ resolve_gh_node_id() {
 	local issue_number="$1" repo="$2"
 	local owner="${repo%%/*}" name="${repo##*/}"
 	local node_id
+	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub, not shell.
 	node_id=$(gh api graphql \
 		-f query='query($owner:String!,$name:String!,$num:Int!){repository(owner:$owner,name:$name){issue(number:$num){id}}}' \
 		-f owner="$owner" -f name="$name" -F num="$issue_number" \

--- a/.agents/scripts/tests/test-consolidation-dispatch.sh
+++ b/.agents/scripts/tests/test-consolidation-dispatch.sh
@@ -414,6 +414,29 @@ Duplicate body should not post."
 	return 0
 }
 
+test_idempotent_pr_comment_uses_paginated_rest_comments() {
+	setup_gh_stub
+	GH_API_COMMENTS_JSON=$(jq -n '[[{"body":"older page"}],[{"body":"## PR Gate Marker\n\nA gate comment already exists."}]]')
+	export GH_API_COMMENTS_JSON
+
+	_gh_idempotent_comment 456 "owner/repo" \
+		"## PR Gate Marker" \
+		"## PR Gate Marker
+
+Duplicate body should not post." "pr"
+
+	if grep -qF 'api repos/owner/repo/issues/456/comments?per_page=100 --paginate --slurp' "$GH_LOG" 2>/dev/null &&
+		! grep -qE '^(pr view|pr comment)' "$GH_LOG" 2>/dev/null; then
+		print_result "_gh_idempotent_comment reads PR conversation comments through paginated REST" 0
+	else
+		print_result "_gh_idempotent_comment reads PR conversation comments through paginated REST" 1 \
+			"unexpected gh calls: $(cat "$GH_LOG")"
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
 test_needs_consolidation_skips_with_child() {
 	setup_gh_stub
 	GH_ISSUE_VIEW_LABELS="bug,tier:standard"
@@ -1003,6 +1026,7 @@ main() {
 	test_consolidation_child_exists_detects_parent_dispatch_comment_on_later_page
 	test_consolidation_child_exists_fails_closed_on_search_error
 	test_idempotent_comment_reads_paginated_issue_comments
+	test_idempotent_pr_comment_uses_paginated_rest_comments
 	test_needs_consolidation_skips_with_child
 
 	# t2144 regression suite

--- a/.agents/scripts/tests/test-dependency-readiness-normalization.sh
+++ b/.agents/scripts/tests/test-dependency-readiness-normalization.sh
@@ -173,15 +173,18 @@ _gh_with_timeout() {
 	return 1
 }
 gh() {
-	printf 'GraphQL: Validation failed: already been taken\n'
-	return 1
+	[[ "${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" == "1" && "$*" == *"rateLimit"* ]] || return 1
+	printf '%s\n' '{"data":{"node":{"blockedBy":{"nodes":[{"id":"I_blocker"}],"pageInfo":{"hasNextPage":false}}},"rateLimit":{"cost":1}}}'
+	return 0
 }
 export -f gh log_verbose _gh_with_timeout
 # shellcheck disable=SC1090
 source "${SCRIPTS_DIR}/issue-sync-lib-parse.sh"
 # shellcheck disable=SC1090
+source "${SCRIPTS_DIR}/issue-sync-lib-ref.sh"
+# shellcheck disable=SC1090
 source "${SCRIPTS_DIR}/issue-sync-relationships.sh"
-assert_true "concurrent native relationship write is idempotent" _gh_add_blocked_by "I_blocked" "I_blocker"
+assert_true "existing native relationship pre-read is idempotent" _gh_add_blocked_by "I_blocked" "I_blocker"
 
 dependency_status="status:available,auto-dispatch"
 dependency_status_writes=""
@@ -290,9 +293,9 @@ assert_true "cross-phase sync normalizes the dependent issue" \
 
 gh() {
 	if [[ "$*" == *"query("* ]]; then
-		printf '%s\n' '{"data":{"node":{"blockedBy":{"nodes":[{"id":"I_blocker"}],"pageInfo":{"hasNextPage":false}}}}}'
+		printf '%s\n' '{"data":{"node":{"blockedBy":{"nodes":[{"id":"I_blocker"}],"pageInfo":{"hasNextPage":false}}},"rateLimit":{"cost":1}}}'
 	else
-		printf '%s\n' '{"data":{"removeBlockedBy":{"issue":{"number":10}}}}'
+		printf '%s\n' '{"data":{"removeBlockedBy":{"issue":{"number":10}},"rateLimit":{"cost":1}}}'
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -1156,21 +1156,42 @@ fi
 unset STUB_PRIMARY_FAIL
 
 # =============================================================================
-# Test 24: gh_pr_list keeps --search on GraphQL path when budget is low
+# Test 24: gh_pr_list routes --search through exact Search API semantics
 # =============================================================================
 : >"$GH_CALLS"
 : >"$GH_INFO_OUTPUT"
 export STUB_RATE_LIMIT_REMAINING=0
 
-gh_pr_list --repo "owner/repo" --search "fallback" --state open --json number --jq length >/dev/null 2>&1 || true
+pr_search_count=$(gh_pr_list --repo "owner/repo" --search "fallback" --state open --json number --jq length 2>/dev/null || true)
 
-if grep -qE '^pr list' "$GH_CALLS" 2>/dev/null &&
-	! grep -qE '^api /repos/owner/repo/pulls\?' "$GH_CALLS" 2>/dev/null; then
-	pass "gh_pr_list leaves --search on primary path when REST cannot preserve semantics"
+if [[ "$pr_search_count" == "1" ]] && grep -qE '^api -i /search/issues\?' "$GH_CALLS" 2>/dev/null &&
+	grep -q 'fallback%20repo%3Aowner%2Frepo%20is%3Apr%20is%3Aopen' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^(pr list|api /repos/owner/repo/pulls\?)' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_pr_list preserves --search through Search API qualifiers without requiring --author"
 else
-	fail "gh_pr_list leaves --search on primary path when REST cannot preserve semantics" \
-		"GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
+	fail "gh_pr_list preserves --search through Search API qualifiers without requiring --author" \
+		"count=${pr_search_count} GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
 fi
+
+# Search-only PR filters must select /search/issues even without --search or
+# --author; the direct /pulls endpoint cannot preserve these semantics.
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export AIDEVOPS_GH_PR_LIST_CACHE_DISABLE=1
+gh_pr_list --repo "owner/repo" --assignee bob --state open --json number >/dev/null 2>&1 || true
+gh_pr_list --repo "owner/repo" --label "needs review" --state open --json number >/dev/null 2>&1 || true
+gh_pr_list --repo "owner/repo" --draft --state open --json number >/dev/null 2>&1 || true
+search_only_calls=$(grep -cE '^api -i /search/issues\?' "$GH_CALLS" 2>/dev/null || true)
+if [[ "$search_only_calls" == "3" ]] && grep -q 'assignee%3Abob' "$GH_CALLS" 2>/dev/null &&
+	grep -q 'label%3A%22needs%20review%22' "$GH_CALLS" 2>/dev/null &&
+	grep -q 'draft%3Atrue' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^(pr list|api /repos/owner/repo/pulls\?)' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_pr_list routes assignee, label, and draft filters through Search API"
+else
+	fail "gh_pr_list routes assignee, label, and draft filters through Search API" \
+		"search_calls=${search_only_calls} GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
+fi
+unset AIDEVOPS_GH_PR_LIST_CACHE_DISABLE
 
 # =============================================================================
 # Test 25: gh_pr_view routes directly to REST when GraphQL remaining is low
@@ -1749,25 +1770,29 @@ unset AIDEVOPS_GH_PR_VIEW_CACHE AIDEVOPS_GH_PR_VIEW_CACHE_DIR AIDEVOPS_GH_PR_VIE
 unset AIDEVOPS_GH_REST_FIRST_READS
 
 # =============================================================================
-# Test 28: gh_pr_list --search → no non-equivalent REST fallback
+# Test 28: gh_pr_list combines caller search and exact filter qualifiers
 # =============================================================================
 : >"$GH_CALLS"
 : >"$GH_INFO_OUTPUT"
-export STUB_PRIMARY_FAIL=1
 export STUB_RATE_LIMIT_REMAINING=0
+export STUB_SEARCH_FIXTURE='{"items":[{"number":42,"state":"open","title":"Matching draft PR","html_url":"https://github.com/owner/repo/pull/42","draft":true,"assignees":[{"login":"bob"}],"labels":[{"name":"needs review"}],"pull_request":{"merged_at":null}}]}'
 
-gh_pr_list --repo "owner/repo" --state open --search "Resolves #42 in:body" \
-	--json number --limit 5 >/dev/null 2>&1 || true
+filtered_pr_number=$(gh_pr_list --repo "owner/repo" --state open --search "Resolves #42 in:body" \
+	--assignee bob --label "needs review" --draft --json number --limit 5 --jq '.[0].number' 2>/dev/null || true)
 
-if grep -qE '^pr list' "$GH_CALLS" 2>/dev/null &&
-	! grep -qE '^api /repos/owner/repo/pulls' "$GH_CALLS" 2>/dev/null; then
-	pass "gh_pr_list --search preserves semantics by skipping REST fallback"
+if [[ "$filtered_pr_number" == "42" ]] && grep -qE '^api -i /search/issues\?' "$GH_CALLS" 2>/dev/null &&
+	grep -q 'Resolves%20%2342%20in%3Abody' "$GH_CALLS" 2>/dev/null &&
+	grep -q 'assignee%3Abob' "$GH_CALLS" 2>/dev/null && grep -q 'draft%3Atrue' "$GH_CALLS" 2>/dev/null &&
+	grep -q 'label%3A%22needs%20review%22' "$GH_CALLS" 2>/dev/null &&
+	! grep -q 'author%3A' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^(pr list|api /repos/owner/repo/pulls)' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_pr_list combines caller search and exact filters without an author qualifier"
 else
-	fail "gh_pr_list --search preserves semantics by skipping REST fallback" \
-		"GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
+	fail "gh_pr_list combines caller search and exact filters without an author qualifier" \
+		"number=${filtered_pr_number} GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
 fi
 
-unset STUB_PRIMARY_FAIL
+unset STUB_SEARCH_FIXTURE
 export STUB_RATE_LIMIT_REMAINING=5000
 
 # =============================================================================

--- a/.agents/scripts/tests/test-issue-sync-relationship-deadline.sh
+++ b/.agents/scripts/tests/test-issue-sync-relationship-deadline.sh
@@ -119,18 +119,26 @@ pass "edge loop stops with retryable state after aggregate exhaustion"
 MUTATION_FIXTURE=""
 _gh_with_timeout() {
 	local operation="$1"
-	: "$operation"
+	[[ "${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" == "1" && "$*" == *"rateLimit"* ]] || return 1
 	case "$MUTATION_FIXTURE" in
 	created)
-		printf '{"data":{"issue":{"number":101}}}\n'
+		if [[ "$operation" == "read" ]]; then
+			printf '%s\n' '{"data":{"node":{"blockedBy":{"nodes":[],"pageInfo":{"hasNextPage":false}}},"rateLimit":{"cost":1}}}'
+		else
+			printf '%s\n' '{"data":{"addBlockedBy":{"issue":{"number":101}},"rateLimit":{"cost":1}}}'
+		fi
 		return 0
 		;;
 	already-present)
-		printf 'already been taken\n'
-		return 1
+		printf '%s\n' '{"data":{"node":{"blockedBy":{"nodes":[{"id":"NODE_103"}],"pageInfo":{"hasNextPage":false}}},"rateLimit":{"cost":1}}}'
+		return 0
 		;;
 	failed)
-		printf '{"errors":[{"message":"SECRET_PAYLOAD"}]}\n'
+		if [[ "$operation" == "read" ]]; then
+			printf '%s\n' '{"data":{"node":{"blockedBy":{"nodes":[],"pageInfo":{"hasNextPage":false}}},"rateLimit":{"cost":1}}}'
+			return 0
+		fi
+		printf '%s\n' '{"errors":[{"message":"SECRET_PAYLOAD"}]}'
 		return 1
 		;;
 	esac

--- a/.agents/scripts/tests/test-issue-sync-reopen-churn.sh
+++ b/.agents/scripts/tests/test-issue-sync-reopen-churn.sh
@@ -34,13 +34,18 @@ if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/issues/204/comments" ]]
 	exit 0
 fi
 if [[ "${1:-}" == "api" && "${2:-}" == "graphql" ]]; then
+	[[ "${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" == "1" && "$*" == *"rateLimit"* ]] || exit 1
 	case "$*" in
 	*"number=205"*)
-		printf '%s\n' '{"data":{"repository":{"nameWithOwner":"owner/repo","issue":{"closedByPullRequestsReferences":{"nodes":[{"number":27347,"url":"https://github.com/owner/repo/pull/27347","state":"MERGED","mergedAt":"2026-07-12T14:55:46Z","repository":{"nameWithOwner":"owner/repo"}}],"pageInfo":{"hasNextPage":false}}}}}}'
+		printf '%s\n' '{"data":{"repository":{"nameWithOwner":"owner/repo","issue":{"closedByPullRequestsReferences":{"nodes":[{"number":27347,"url":"https://github.com/owner/repo/pull/27347","state":"MERGED","mergedAt":"2026-07-12T14:55:46Z","repository":{"nameWithOwner":"owner/repo"}}],"pageInfo":{"hasNextPage":false}}}},"rateLimit":{"cost":1}}}'
 		exit 0
 		;;
 	*"number=206"*)
-		printf '%s\n' '{"data":{"repository":{"nameWithOwner":"owner/repo","issue":{"closedByPullRequestsReferences":{"nodes":[],"pageInfo":{"hasNextPage":true}}}}}}'
+		printf '%s\n' '{"data":{"repository":{"nameWithOwner":"owner/repo","issue":{"closedByPullRequestsReferences":{"nodes":[],"pageInfo":{"hasNextPage":true}}}},"rateLimit":{"cost":1}}}'
+		exit 0
+		;;
+	*"number=207"*)
+		printf '%s\n' '{"data":{"repository":{"nameWithOwner":"owner/repo","issue":{"closedByPullRequestsReferences":{"nodes":[],"pageInfo":{"hasNextPage":false}}}}}}'
 		exit 0
 		;;
 	esac
@@ -134,6 +139,7 @@ check_output "structural closing PR prevents false reopen when title omits task 
 	"27347|https://github.com/owner/repo/pull/27347" \
 	_reopen_find_merged_pr "owner/repo" "t18109" "205"
 check_failure "truncated structural closing relationships fail closed" _reopen_find_merged_pr "owner/repo" "t18109" "206"
+check_failure "unmetered structural closing relationships fail closed" _reopen_find_merged_pr "owner/repo" "t18109" "207"
 check_failure "invalid issue coordinates fail closed" _reopen_find_merged_pr "owner/repo" "t18109" "not-a-number"
 
 printf '\nResults: %s passed, %s failed\n' "$PASS" "$FAIL"

--- a/.agents/scripts/tests/test-parent-phase-dep-parser.sh
+++ b/.agents/scripts/tests/test-parent-phase-dep-parser.sh
@@ -188,13 +188,18 @@ fi
 
 # gh api graphql -f query=...
 if [[ "$cmd1" == "api" && "$cmd2" == "graphql" ]]; then
+	[[ "${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" == "1" && "$*" == *"rateLimit"* ]] || exit 1
 	for arg in "$@"; do
 		if [[ "$arg" == *"addBlockedBy"* ]]; then
-			printf '%s\n' '{"data":{"addBlockedBy":{"issue":{"number":99}}}}'
+			printf '%s\n' '{"data":{"addBlockedBy":{"issue":{"number":99}},"rateLimit":{"cost":1}}}'
+			exit 0
+		fi
+		if [[ "$arg" == *"blockedBy(first:100)"* ]]; then
+			printf '%s\n' '{"data":{"node":{"blockedBy":{"nodes":[],"pageInfo":{"hasNextPage":false}}},"rateLimit":{"cost":1}}}'
 			exit 0
 		fi
 		if [[ "$arg" == *"issue(number"* ]]; then
-			printf '%s\n' 'NODE_STUB_ID'
+			printf '%s\n' '{"data":{"repository":{"issue":{"id":"NODE_STUB_ID"}},"rateLimit":{"cost":1}}}'
 			exit 0
 		fi
 	done

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -36,19 +36,29 @@ if [[ "$1" == "api" && "${2:-}" == "rate_limit" ]]; then
 	printf '%s\n' "${STUB_GRAPHQL_REMAINING:-100}"
 	exit 0
 fi
+if [[ "$1" == "api" && "${2:-}" =~ ^repos/owner/repo/pulls/[0-9]+$ ]]; then
+	[[ "${AIDEVOPS_GH_QUOTA_COST_ON_SUCCESS:-}" == "1" ]] || exit 1
+	case "${STUB_PR_REPOSITORY_MODE:-same}" in
+	missing) printf '%s\n' '{"head":{"repo":null},"base":{"repo":{"full_name":"owner/repo"}}}' ;;
+	cross) printf '%s\n' '{"head":{"repo":{"full_name":"contributor/repo"}},"base":{"repo":{"full_name":"owner/repo"}}}' ;;
+	*) printf '%s\n' '{"head":{"repo":{"full_name":"owner/repo"}},"base":{"repo":{"full_name":"owner/repo"}}}' ;;
+	esac
+	exit 0
+fi
 if [[ "$1" == "pr" && "${2:-}" == "list" ]]; then
 	printf '%s\n' "${STUB_PR_LIST:-1	Fix active PR	false	origin:worker	feature/review	${TEST_HEAD_OID_1}	worker-bot}"
 	exit 0
 fi
 if [[ "$1" == "pr" && "${2:-}" == "view" ]]; then
 	if [[ "$*" == *"--json isCrossRepository"* ]]; then
-		printf '%s\n' "${STUB_CROSS_REPOSITORY:-false}"
+		exit 1
 	else
 		printf '%s\n' "${STUB_PR_VIEW:-Fix active PR	feature/review	${TEST_HEAD_OID_1}	worker-bot}"
 	fi
 	exit 0
 fi
 if [[ "$1" == "api" && "${2:-}" == "graphql" ]]; then
+	[[ "${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" == "1" && "$*" == *"rateLimit"* ]] || exit 1
 	for arg in "$@"; do
 		if [[ "$arg" == "owner=" || "$arg" == "name=" ]]; then
 			printf 'empty repo GraphQL field: %s\n' "$arg" >&2
@@ -69,24 +79,28 @@ if [[ "$1" == "api" && "${2:-}" == "graphql" ]]; then
 			previous_arg="$arg"
 		done
 		printf 'reply\n' >>"${GRAPHQL_MUTATIONS_LOG:-/dev/null}"
-		printf '{"data":{"addPullRequestReviewThreadReply":{"comment":{"id":"COMMENT1","url":"https://example.invalid/reply"}}}}\n'
+		printf '{"data":{"addPullRequestReviewThreadReply":{"comment":{"id":"COMMENT1","url":"https://example.invalid/reply"}},"rateLimit":{"cost":1}}}\n'
 		exit 0
 	fi
 	if [[ "$*" == *"resolveReviewThread"* ]]; then
 		printf 'resolve\n' >>"${GRAPHQL_MUTATIONS_LOG:-/dev/null}"
-		printf '{"data":{"resolveReviewThread":{"thread":{"id":"THREAD1","isResolved":true}}}}\n'
+		printf '{"data":{"resolveReviewThread":{"thread":{"id":"THREAD1","isResolved":true}},"rateLimit":{"cost":1}}}\n'
 		exit 0
 	fi
 	if [[ "$*" == *"node(id:"* && "$*" == *"comments(first: 1)"* ]]; then
 		if [[ "${STUB_THREAD_AUTHOR_MODE:-ok}" == "missing" ]]; then
-			printf '{"data":{"node":{"comments":{"nodes":[{"author":null}]}}}}\n'
+			printf '{"data":{"node":{"comments":{"nodes":[{"author":null}]}},"rateLimit":{"cost":1}}}\n'
 		else
-			printf '{"data":{"node":{"comments":{"nodes":[{"author":{"login":"%s"}}]}}}}\n' "${STUB_THREAD_AUTHOR_LOGIN:-reviewer}"
+			printf '{"data":{"node":{"comments":{"nodes":[{"author":{"login":"%s"}}]}},"rateLimit":{"cost":1}}}\n' "${STUB_THREAD_AUTHOR_LOGIN:-reviewer}"
 		fi
 		exit 0
 	fi
 	if [[ "$*" == *"node(id:"* || "$*" == *"comments(first: 100)"* ]]; then
-		printf '{"data":{"node":{"comments":{"nodes":[]}}}}\n'
+		printf '{"data":{"node":{"comments":{"nodes":[],"pageInfo":{"hasNextPage":false}}},"rateLimit":{"cost":1}}}\n'
+		exit 0
+	fi
+	if [[ "${STUB_GRAPHQL_COST_MODE:-exact}" == "missing" ]]; then
+		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false}}}}}}'
 		exit 0
 	fi
 	case "${STUB_THREADS_MODE:-unresolved}" in
@@ -95,16 +109,16 @@ if [[ "$1" == "api" && "${2:-}" == "graphql" ]]; then
 		exit 1
 		;;
 	none)
-		printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}\n'
+		printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false}}}},"rateLimit":{"cost":1}}}\n'
 		;;
 	human)
-		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"THREAD_HUMAN","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"maintainer"},"path":"script.sh","line":12,"url":"https://example.invalid/human","updatedAt":"2026-06-03T00:00:00Z"}]}},{"id":"THREAD_BOT","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"path":"bot.sh","line":3,"url":"https://example.invalid/bot","updatedAt":"2026-06-03T00:00:00Z"}]}}]}}}}}'
+		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"THREAD_HUMAN","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"maintainer"},"path":"script.sh","line":12,"url":"https://example.invalid/human","updatedAt":"2026-06-03T00:00:00Z"}]}},{"id":"THREAD_BOT","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"path":"bot.sh","line":3,"url":"https://example.invalid/bot","updatedAt":"2026-06-03T00:00:00Z"}]} }],"pageInfo":{"hasNextPage":false}}}},"rateLimit":{"cost":1}}}'
 		;;
 	outdated)
-		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"THREAD_OLD","isResolved":false,"isOutdated":true,"comments":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"path":"old.sh","line":7,"url":"https://example.invalid/outdated","updatedAt":"2026-06-03T00:00:00Z"}]}}]}}}}}'
+		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"THREAD_OLD","isResolved":false,"isOutdated":true,"comments":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"path":"old.sh","line":7,"url":"https://example.invalid/outdated","updatedAt":"2026-06-03T00:00:00Z"}]}}],"pageInfo":{"hasNextPage":false}}}},"rateLimit":{"cost":1}}}'
 		;;
 	*)
-		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"THREAD1","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"gemini-code-assist[bot]"},"path":".agents/scripts/example.sh","line":42,"url":"https://example.invalid/thread","updatedAt":"2026-06-03T00:00:00Z"}]}},{"id":"THREAD2","isResolved":true,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"path":"old.sh","line":1,"url":"https://example.invalid/resolved","updatedAt":"2026-06-03T00:00:00Z"}]}}]}}}}}'
+		printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"THREAD1","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"gemini-code-assist[bot]"},"path":".agents/scripts/example.sh","line":42,"url":"https://example.invalid/thread","updatedAt":"2026-06-03T00:00:00Z"}]}},{"id":"THREAD2","isResolved":true,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"path":"old.sh","line":1,"url":"https://example.invalid/resolved","updatedAt":"2026-06-03T00:00:00Z"}]} }],"pageInfo":{"hasNextPage":false}}}},"rateLimit":{"cost":1}}}'
 		;;
 	esac
 	exit 0
@@ -291,7 +305,7 @@ WORKTREE_STUB
 }
 
 setup_test_env() {
-	unset STUB_PR_LIST STUB_PR_VIEW STUB_THREADS_MODE STUB_CROSS_REPOSITORY STUB_REMOTE_HEAD
+	unset STUB_PR_LIST STUB_PR_VIEW STUB_THREADS_MODE STUB_GRAPHQL_COST_MODE STUB_PR_REPOSITORY_MODE STUB_REMOTE_HEAD
 	unset STUB_GIT_INVALID_BRANCH STUB_GIT_FETCH_FAIL STUB_GIT_CANONICAL_FETCH_FAIL
 	unset STUB_REMOTE_HEAD_INITIAL STUB_REMOTE_HEAD_AFTER_FETCH STUB_WORKTREE_ACTUAL_HEAD STUB_WORKTREE_HELPER_FAIL
 	unset STUB_WORKTREE_REGISTER_OWNER STUB_WORKTREE_OWNER_PID STUB_WORKTREE_OWNER_SESSION
@@ -559,7 +573,7 @@ test_dispatch_rejects_reused_unverified_owner() {
 
 test_dispatch_blocks_cross_repository_head() {
 	setup_test_env
-	export STUB_CROSS_REPOSITORY="true"
+	export STUB_PR_REPOSITORY_MODE="cross"
 	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
 	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
 	local old_epoch=""
@@ -702,6 +716,20 @@ test_scan_includes_outdated_unresolved_threads() {
 		print_result "scan includes unresolved outdated bot thread" 0
 	else
 		print_result "scan includes unresolved outdated bot thread" 1 "output=${output}"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_scan_fails_closed_without_graphql_cost() {
+	setup_test_env
+	export STUB_GRAPHQL_COST_MODE="missing"
+	local output=""
+	output="$($SCANNER scan owner/repo "${TEST_ROOT}/repo" || true)"
+	if [[ -z "$output" ]] && grep -q 'GraphQL cost unavailable' "$LOGFILE" 2>/dev/null; then
+		print_result "scan fails closed without response-owned GraphQL cost" 0
+	else
+		print_result "scan fails closed without response-owned GraphQL cost" 1 "output=${output}"
 	fi
 	teardown_test_env
 	return 0
@@ -1554,13 +1582,14 @@ if [[ "$1" == "api" && "${2:-}" == "rate_limit" ]]; then
 	exit 0
 fi
 if [[ "$1" == "api" && "${2:-}" == "graphql" ]]; then
+	[[ "${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" == "1" && "$*" == *"rateLimit"* ]] || exit 1
 	if [[ "$*" == *"comments(first: 100)"* ]]; then
-		printf '{"data":{"node":{"comments":{"nodes":[{"body":"<!-- aidevops:review-thread-response:THREAD1 --> already"}]}}}}\n'
+		printf '{"data":{"node":{"comments":{"nodes":[{"body":"<!-- aidevops:review-thread-response:THREAD1 --> already"}],"pageInfo":{"hasNextPage":false}}},"rateLimit":{"cost":1}}}\n'
 		exit 0
 	fi
 	if [[ "$*" == *"addPullRequestReviewThreadReply"* ]]; then
 		printf 'reply\n' >>"${GRAPHQL_MUTATIONS_LOG:-/dev/null}"
-		printf '{}\n'
+		printf '{"data":{"addPullRequestReviewThreadReply":{"comment":{"id":"COMMENT1"}},"rateLimit":{"cost":1}}}\n'
 		exit 0
 	fi
 fi
@@ -1584,6 +1613,7 @@ main() {
 	test_scan_finds_unresolved_bot_thread
 	test_scan_skips_draft_prs
 	test_scan_includes_outdated_unresolved_threads
+	test_scan_fails_closed_without_graphql_cost
 	test_scan_pr_excludes_human_threads_by_default
 	test_scan_pr_can_include_human_threads_with_opt_in
 	test_dispatch_launches_worker_and_writes_state

--- a/.agents/scripts/tests/test-pulse-dep-graph-non-dep-block.sh
+++ b/.agents/scripts/tests/test-pulse-dep-graph-non-dep-block.sh
@@ -139,7 +139,7 @@ assert_eq 'blocked-by line' 'false' \
 ###############################################################################
 # Part 3: _should_defer_auto_unblock integration via mocked gh
 #
-# Source the helper and stub `gh` on PATH to return controlled comment
+# Source the helper and stub `gh` on PATH to return controlled REST comment
 # JSON. This exercises both signals end-to-end without hitting GitHub.
 ###############################################################################
 
@@ -149,11 +149,10 @@ printf '\n== _should_defer_auto_unblock integration ==\n'
 STUB_DIR=$(mktemp -d)
 trap 'rm -rf "$STUB_DIR"' EXIT
 
-# Stub gh that reads a canned response file. The helper calls
-# `gh issue view $num --repo $slug --json comments --jq '...'` so the
-# stub inspects argv to decide which canned file to serve.
+# Stub gh that reads a canned paginated REST response file.
 cat >"$STUB_DIR/gh" <<'STUB'
 #!/usr/bin/env bash
+printf '%s\n' "$*" >>"${GH_STUB_CALLS:-/dev/null}"
 # Canned response is whatever lives in $GH_STUB_COMMENTS.
 # If unset or file missing, return empty so the helper fail-opens.
 if [[ "${GH_STUB_COMMENTS:-}" && -f "${GH_STUB_COMMENTS}" ]]; then
@@ -164,6 +163,8 @@ fi
 STUB
 chmod +x "$STUB_DIR/gh"
 export PATH="$STUB_DIR:$PATH"
+export GH_STUB_CALLS="$STUB_DIR/gh-calls.log"
+: >"$GH_STUB_CALLS"
 
 # Shim the helper's dependencies: LOGFILE must exist so `echo >>` works.
 export LOGFILE="$STUB_DIR/test.log"
@@ -185,27 +186,30 @@ assert_eq 'clean body and empty comments → unblock' '__no_defer__' "$got"
 
 # Scenario 3: body defer flag false, comment contains **BLOCKED** → defer
 export GH_STUB_COMMENTS="$STUB_DIR/blocked-comment.json"
-printf '**BLOCKED** — cannot proceed autonomously. Evidence: ...' >"$GH_STUB_COMMENTS"
+jq -cn --arg body '**BLOCKED** — cannot proceed autonomously. Evidence: ...' '[{body:$body}]' >"$GH_STUB_COMMENTS"
+: >"$GH_STUB_CALLS"
 got=$(_should_defer_auto_unblock 'owner/repo' '123' 'false' || echo "__no_defer__")
 assert_eq 'worker BLOCKED comment triggers defer' 'comment-marker' "$got"
+rest_comment_calls=$(grep -cF 'api repos/owner/repo/issues/123/comments?per_page=100 --paginate --slurp' "$GH_STUB_CALLS" 2>/dev/null || true)
+assert_eq 'comment marker read uses paginated REST' '1' "$rest_comment_calls"
 
 # Scenario 4: Worker Watchdog Kill comment → defer
-printf '## Worker Watchdog Kill\n\n**Reason:** idle' >"$GH_STUB_COMMENTS"
+jq -cn --arg body $'## Worker Watchdog Kill\n\n**Reason:** idle' '[{body:$body}]' >"$GH_STUB_COMMENTS"
 got=$(_should_defer_auto_unblock 'owner/repo' '123' 'false' || echo "__no_defer__")
 assert_eq 'watchdog kill comment triggers defer' 'comment-marker' "$got"
 
 # Scenario 5: Terminal blocker comment → defer
-printf '**Terminal blocker detected** (GH#5141) — skipping dispatch.' >"$GH_STUB_COMMENTS"
+jq -cn --arg body '**Terminal blocker detected** (GH#5141) — skipping dispatch.' '[{body:$body}]' >"$GH_STUB_COMMENTS"
 got=$(_should_defer_auto_unblock 'owner/repo' '123' 'false' || echo "__no_defer__")
 assert_eq 'terminal blocker comment triggers defer' 'comment-marker' "$got"
 
 # Scenario 6: clean comment (dispatch claim, merge summary) → unblock
-printf 'DISPATCH_CLAIM nonce=abc123 runner=marcusquinn\n---\nPR #1234 merged.' >"$GH_STUB_COMMENTS"
+jq -cn --arg body $'DISPATCH_CLAIM nonce=abc123 runner=maintainer\n---\nPR #1234 merged.' '[{body:$body}]' >"$GH_STUB_COMMENTS"
 got=$(_should_defer_auto_unblock 'owner/repo' '123' 'false' || echo "__no_defer__")
 assert_eq 'clean operational comments → unblock' '__no_defer__' "$got"
 
 # Scenario 7: body defer takes precedence even with clean comments
-printf 'DISPATCH_CLAIM nonce=abc123' >"$GH_STUB_COMMENTS"
+jq -cn --arg body 'DISPATCH_CLAIM nonce=abc123' '[{body:$body}]' >"$GH_STUB_COMMENTS"
 got=$(_should_defer_auto_unblock 'owner/repo' '123' 'true' || echo "__no_defer__")
 assert_eq 'body defer precedence over clean comments' 'body-defer' "$got"
 

--- a/.agents/scripts/tests/test-pulse-dep-graph-stale-label-cleanup.sh
+++ b/.agents/scripts/tests/test-pulse-dep-graph-stale-label-cleanup.sh
@@ -76,6 +76,10 @@ gh() {
 		printf '%s\n' R_example
 		return 0
 	fi
+	if [[ "$top_command" == "api" && "${1:-}" == repos/example/repo/issues/*/comments\?per_page=100 ]]; then
+		printf '%s\n' '[[]]'
+		return 0
+	fi
 	if [[ "$top_command" == "api" && "${1:-}" == repos/example/repo/issues/* ]]; then
 		local issue_num="${1##*/}"
 		printf '%s\tI_%s\n' "$issue_num" "$issue_num"

--- a/.agents/scripts/tests/test-pulse-labelless-reconcile.sh
+++ b/.agents/scripts/tests/test-pulse-labelless-reconcile.sh
@@ -118,7 +118,13 @@ source "$RECONCILE_SRC"
 gh_issue_comment() { gh issue comment "$@" && return 0 || return 1; }
 # shellcheck disable=SC2317
 gh_pr_comment() { gh pr comment "$@" && return 0 || return 1; }
-export -f gh_issue_comment gh_pr_comment
+# Keep the test independent of any live pulse prefetch cache and route the
+# fallback list wrapper through the controlled gh function below.
+# shellcheck disable=SC2317
+_read_cache_issues_for_slug() { return 1; }
+# shellcheck disable=SC2317
+gh_issue_list() { gh issue list "$@"; return $?; }
+export -f gh_issue_comment gh_pr_comment _read_cache_issues_for_slug gh_issue_list
 
 # Override `gh` as a shell function AFTER sourcing.
 # shellcheck disable=SC2317
@@ -133,25 +139,24 @@ gh() {
 		return 0
 	fi
 
-	# gh issue view N --json comments --jq ...
-	if [[ "$cmd" == "issue" && "$sub" == "view" ]]; then
-		# Return empty comments — no sentinel present → backfill proceeds
-		printf '[]'
-		return 0
-	fi
-
-	# gh api repos/test/repo/issues/NNN --jq '.author_association // "NONE"'
+	# gh api repos/test/repo/issues/NNN — return the REST issue object fields
+	# consumed by the reconcile action.
 	# (t2450: reconcile_labelless_aidevops_issues fetches author_association
 	# per candidate because gh issue list --json doesn't expose it.)
 	if [[ "$cmd" == "api" ]]; then
 		case "$sub" in
+			*/issues/*/comments\?per_page=100)
+				# Empty paginated comments — no sentinel present, so backfill proceeds.
+				printf '%s' '[[]]'
+				return 0
+				;;
 			*/issues/*)
 				local num="${sub##*/}"
 				case "$num" in
-					500 | 501 | 502) printf '%s' "MEMBER" ;;
-					503) printf '%s' "CONTRIBUTOR" ;;
-					504) printf '%s' "NONE" ;;
-					*) printf '%s' "NONE" ;;
+					500 | 501 | 502) printf '%s' '{"author_association":"MEMBER"}' ;;
+					503) printf '%s' '{"author_association":"CONTRIBUTOR"}' ;;
+					504) printf '%s' '{"author_association":"NONE"}' ;;
+					*) printf '%s' '{"author_association":"NONE"}' ;;
 				esac
 				return 0
 				;;
@@ -212,6 +217,14 @@ edit_501=$(grep -c '^gh issue edit 501 --repo test/repo' "$TRACE_FILE" || true)
 edit_502=$(grep -c '^gh issue edit 502 --repo test/repo' "$TRACE_FILE" || true)
 comment_500=$(grep -c '^gh issue comment 500 --repo test/repo' "$TRACE_FILE" || true)
 comment_501=$(grep -c '^gh issue comment 501 --repo test/repo' "$TRACE_FILE" || true)
+rest_comment_reads=$(grep -cE '^gh api repos/test/repo/issues/(500|503|504)/comments\?per_page=100 --paginate --slurp$' "$TRACE_FILE" || true)
+native_comment_reads=$(grep -cE '^gh issue view .*--json comments' "$TRACE_FILE" || true)
+
+if [[ "$rest_comment_reads" -ne 3 || "$native_comment_reads" -ne 0 ]]; then
+	printf 'FAIL: expected 3 paginated REST comment reads and 0 native comment views; got REST=%d native=%d\n' \
+		"$rest_comment_reads" "$native_comment_reads"
+	failed=1
+fi
 
 # #500 MUST be edited at least once
 if [[ "$edit_500" -lt 1 ]]; then

--- a/.agents/scripts/tests/test-reeval-stale-continuation.sh
+++ b/.agents/scripts/tests/test-reeval-stale-continuation.sh
@@ -82,7 +82,7 @@ GH_CALLS_LOG="${TMP}/gh_calls.log"
 # Per-test state reset via reset_state()
 GH_LABEL_REMOVED=""
 GH_VIEW_JSON=""     # JSON for plain gh issue view (no --comments)
-GH_COMMENTS_JSON="" # JSON for gh issue view --comments ({"comments":[...]})
+GH_COMMENTS_JSON="" # gh-shaped comment fixture ({"comments":[...]})
 GH_EDIT_RC=0
 GH_EDIT_KEEP_LABEL="false"
 
@@ -177,7 +177,11 @@ gh() {
 	# gh label create — silent no-op
 	[[ "$1" == "label" && "$2" == "create" ]] && return 0
 
-	# gh api — return empty array (idempotent comment check)
+	# gh api issue comments — convert the gh-shaped fixture to paginated REST.
+	if [[ "$1" == "api" && "${2:-}" == repos/*/issues/*/comments\?per_page=100 ]]; then
+		printf '%s\n' "$GH_COMMENTS_JSON" | jq -c '[.comments // []]'
+		return 0
+	fi
 	[[ "$1" == "api" ]] && printf '[]' && return 0
 
 	# gh issue comment — no-op
@@ -357,6 +361,11 @@ assert_eq \
 assert_eq \
 	"no gate comment → label NOT removed" \
 	"" "${GH_LABEL_REMOVED}"
+rest_comment_reads=$(grep -cF 'gh api repos/owner/repo/issues/100/comments?per_page=100 --paginate --slurp' "$GH_CALLS_LOG" 2>/dev/null || true)
+native_comment_reads=$(grep -cE '^gh issue view 100 .*--comments' "$GH_CALLS_LOG" 2>/dev/null || true)
+assert_eq \
+	"gate comment lookup uses paginated REST" \
+	"1:0" "${rest_comment_reads}:${native_comment_reads}"
 
 # ---- Test 8: open continuation → label preserved ----
 reset_state
@@ -472,6 +481,10 @@ gh() {
 		return 0
 	fi
 	[[ "$1" == "label" && "$2" == "create" ]] && return 0
+	if [[ "$1" == "api" && "${2:-}" == repos/*/issues/*/comments\?per_page=100 ]]; then
+		printf '%s\n' "$GH_COMMENTS_JSON" | jq -c '[.comments // []]'
+		return 0
+	fi
 	[[ "$1" == "api" ]] && printf '[]' && return 0
 	[[ "$1" == "issue" && "$2" == "comment" ]] && return 0
 	[[ "$1" == "issue" && "$2" == "list" ]] && printf '%s\n' "$GH_VIEW_JSON" && return 0
@@ -547,6 +560,10 @@ gh() {
 		return 0
 	fi
 	[[ "$1" == "label" && "$2" == "create" ]] && return 0
+	if [[ "$1" == "api" && "${2:-}" == repos/*/issues/*/comments\?per_page=100 ]]; then
+		printf '%s\n' "$GH_COMMENTS_JSON" | jq -c '[.comments // []]'
+		return 0
+	fi
 	[[ "$1" == "api" ]] && printf '[]' && return 0
 	[[ "$1" == "issue" && "$2" == "comment" ]] && return 0
 	return 0


### PR DESCRIPTION
For #27777

## Summary

- route PR-list filters through semantics-preserving REST Search and move issue/PR comment reads to pagination-complete REST endpoints
- make fixed GraphQL reads and mutations return and validate positive operation-owned `rateLimit.cost` values
- pre-read native issue relationships to avoid routine duplicate mutations while preserving fail-closed behavior
- reject missing, zero, malformed, or pagination-incomplete attribution evidence

## Implementation context

- GraphQL attribution: `.agents/scripts/issue-sync-lib-ref.sh`, `.agents/scripts/issue-sync-relationships.sh`, `.agents/scripts/pr-review-thread-response-scanner.sh`, `.agents/scripts/pulse-wrapper-bootstrap.sh`
- REST migrations and routing: `.agents/scripts/pulse-dep-graph.sh`, `.agents/scripts/pulse-issue-reconcile.sh`, `.agents/scripts/pulse-triage-cache.sh`, `.agents/scripts/pulse-triage-evaluation.sh`, `.agents/scripts/shared-gh-wrappers-rest-read-semantics.sh`
- Regression coverage: the corresponding scripts under `.agents/scripts/tests/`

## Verification

- `.agents/scripts/linters-local.sh --full` — passed; existing repository advisories did not regress
- focused attribution, relationship, review-thread, REST-routing, reconciliation, consolidation, and continuation suites — passed
- zero-cost linked-PR resolver regression — 36/36 assertions passed
- ShellCheck, Bash 3.2 compatibility, secret scanning, and `git diff --check` — passed
- independent exact-head closeout review — `CLOSEOUT: PASS`

## Decisions and rollout

- response-owned GraphQL cost is accepted only when it is a positive integer; uncertain requests remain unknown rather than inferred from shared cumulative headers
- bounded relationship and review-thread reads reject incomplete pages instead of treating them as absent
- this PR does not publish a release; representative exact-attribution smoke and controlled webhook/baseline evidence follow the merged local deployment

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.5 spent 10d 20h and 38,009,278 tokens on this with the user in an interactive session. Overall, 12d 21h since this issue was created.
