### PR TITLE
GH#28774: fix: let non-WIP base drift reach normal rebase

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -540,11 +540,6 @@ _finalize_wip_history() {
 		print_error "Cannot snapshot ${base_ref} before WIP history finalization."
 		return 1
 	}
-	if ! git merge-base --is-ancestor "$base_oid" HEAD 2>/dev/null; then
-		print_error "Refusing WIP finalization: current ${base_ref} is not an ancestor of HEAD."
-		print_error "Rebase onto ${base_ref}, resolve any conflicts, then retry commit-and-pr."
-		return 1
-	fi
 	printf -v branch_range '%s..HEAD' "$base_oid"
 	if ! branch_subjects=$(git log --format=%s "$branch_range" 2>/dev/null); then
 		print_error "Cannot inspect branch commit subjects relative to ${base_ref}."
@@ -560,6 +555,15 @@ _finalize_wip_history() {
 	done <<<"$branch_subjects"
 	if [[ "$has_wip" == "0" ]]; then
 		return 0
+	fi
+
+	# The exact-base ancestry proof protects the soft reset below. Non-WIP
+	# history does not need rewriting, so let the normal rebase stage integrate
+	# a concurrently advanced base instead of rejecting safe base drift here.
+	if ! git merge-base --is-ancestor "$base_oid" HEAD 2>/dev/null; then
+		print_error "Refusing WIP finalization: current ${base_ref} is not an ancestor of HEAD."
+		print_error "Rebase onto ${base_ref}, resolve any conflicts, then retry commit-and-pr."
+		return 1
 	fi
 
 	local worktree_status=""

--- a/.agents/scripts/tests/test-full-loop-wip-finalization.sh
+++ b/.agents/scripts/tests/test-full-loop-wip-finalization.sh
@@ -164,6 +164,42 @@ test_no_wip_preserves_history() {
 	return 0
 }
 
+test_non_wip_base_drift_reaches_normal_rebase() {
+	local repo_dir="${TEST_ROOT}/non-wip-base-drift"
+	make_repo "$repo_dir" || return 1
+	commit_change "$repo_dir" 'feature' 'fix: preserve feature change' || return 1
+	local original_head=""
+	original_head=$(git -C "$repo_dir" rev-parse HEAD)
+
+	(
+		cd "$repo_dir" || exit 1
+		git switch -q --detach origin/develop
+		printf 'upstream\n' >upstream.txt
+		git add upstream.txt
+		git commit -qm 'fix: concurrent upstream change'
+		git branch -f develop HEAD
+		git switch -q --detach "$original_head"
+		_finalize_wip_history 'fix: preserve feature change' &&
+			_rebase_for_push 'feature/test' 0
+	) >/dev/null 2>&1
+	local rc=$?
+	local count="" subject="" status="" content=""
+	count=$(git -C "$repo_dir" rev-list --count origin/develop..HEAD)
+	subject=$(git -C "$repo_dir" log -1 --format=%s)
+	status=$(git -C "$repo_dir" status --porcelain)
+	content=$(git -C "$repo_dir" show HEAD:tracked.txt)
+	if [[ "$rc" -eq 0 && "$count" == '1' && "$subject" == 'fix: preserve feature change' &&
+		-z "$status" && "$content" == $'base\nfeature' ]] &&
+		git -C "$repo_dir" merge-base --is-ancestor origin/develop HEAD &&
+		git -C "$repo_dir" show HEAD:upstream.txt >/dev/null 2>&1; then
+		print_result 'non-WIP base drift reaches normal rebase without upstream reversions' 0
+	else
+		print_result 'non-WIP base drift reaches normal rebase without upstream reversions' 1 \
+			"rc=${rc}, count=${count}, subject=${subject}, status=${status}"
+	fi
+	return 0
+}
+
 test_commit_hook_failure_restores_tip() {
 	local repo_dir="${TEST_ROOT}/hook-failure"
 	make_repo "$repo_dir" || return 1
@@ -262,14 +298,15 @@ test_orchestrator_finalizes_before_validation() {
 test_single_wip_is_finalized
 test_buried_wip_squashes_branch_range
 test_no_wip_preserves_history
+test_non_wip_base_drift_reaches_normal_rebase
 test_commit_hook_failure_restores_tip
 test_wip_final_message_is_rejected
 test_base_drift_fails_closed_without_reverting_upstream
 test_orchestrator_finalizes_before_validation
 
 printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
-if [[ "$TESTS_RUN" -ne 7 ]]; then
-	printf '%sFAIL%s expected 7 tests to execute\n' "$TEST_RED" "$TEST_RESET"
+if [[ "$TESTS_RUN" -ne 8 ]]; then
+	printf '%sFAIL%s expected 8 tests to execute\n' "$TEST_RED" "$TEST_RESET"
 	exit 1
 fi
 [[ "$TESTS_FAILED" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Inspect non-WIP branch subjects before enforcing the exact-base ancestry proof, preserving fail-closed WIP rewriting while allowing the normal rebase stage to integrate concurrent upstream changes. Add regression coverage for upstream files, clean state, and one conventional feature commit.

## Files Changed

.agents/scripts/full-loop-helper-commit.sh, .agents/scripts/tests/test-full-loop-wip-finalization.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-full-loop-wip-finalization.sh; shellcheck .agents/scripts/full-loop-helper.sh .agents/scripts/full-loop-helper-commit.sh .agents/scripts/tests/test-full-loop-wip-finalization.sh

Resolves #28774


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 2m and 62,477 tokens on this as a headless worker.