### PR TITLE
GH#28670: feat: add Medium account archive ingestion

### DIFF
--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -37,7 +37,7 @@ a claim that the route is enabled.
 | Facebook | **Live/Gate/Export** managed Page posts; **No/Export** personal profile | **No/Export** curated activity and per-post comments | **No/Export** | **No/Export** personal relationships | **No** | One managed-Page `/posts` stream; app review and Page authority remain explicit, with all personal-account categories excluded. |
 | Instagram | **Live/Gate/Export** Professional media | **No/Export** comments and saved activity | **No/Export** mentions | **No/Export** followers and following | **No/Export** saved collections | One Page-connected Business/Creator `/media` stream; personal accounts and unimplemented per-media edges remain explicit. |
 | Threads | **Live/Gate/Export** posts | **No/Export** likes and repost history | **Live/Gate/Export** authored replies and mentions; **No** messages | **No/Export** followers and following | **No** custom feeds | Three product-scoped streams with app-scoped identity, independent cursors, and stream-specific permission gates. |
-| Medium | **Export/Gate** | **Export/No** | **Export/No** | **Export/No** | **Export/No** | Archive-first; legacy or restricted integration access is not sufficient evidence for live parity. |
+| Medium | **Live/Export** authored posts; **Live/Partial** explicit responses | **Live/Export/No** bookmarks, claps, highlights, and list membership when present | **No** | **Live/Export/No** publication membership and follows when present | **Live/Export/No** owned lists when present | Identity-verified native HTML ZIP import with exact replay, bounded local parsing, and per-archive complete/unavailable coverage; legacy API access is not live parity. |
 | Quora | **Export** | **Export/No** | **Export/No** | **Export/No** | **No** | No general live account API is accepted without new official evidence. |
 | Skool | **Gate/Export/Gap** | **Gate/Export/Gap** | **Gate/Export/Gap** | **Gate/Export/Gap** | **Gate/Export/Gap** | Verify member versus community-admin access and provider terms before selecting any route. |
 | Discourse | **API/Export** | **API/Export** | **API/Gate/Export** | **API/Gate/Export** | **API/Gate/Export** | Scope by installation and user/API-key authority; support hosted and self-hosted instances. |
@@ -97,6 +97,16 @@ a claim that the route is enabled.
   records the official SDK/sample versions, account/app-review gates, scopes,
   pagination, retention boundary, export dispositions, and unsupported
   categories checked on 2026-07-27.
+- **Live Medium export:** `.agents/scripts/knowledge_social_medium.py`,
+  `.agents/scripts/_knowledge_social_medium*.py`, and
+  `.agents/tests/test-knowledge-social-medium.sh` prove selected-account
+  identity, safe ZIP handling, bounded item/byte costs, immutable original-ZIP
+  evidence, content-addressed replay, authored/curated separation, explicit
+  response and absent-category gaps, lease fencing, sanitized credential
+  rejection, and static isolation from network/browser/outbound mutation paths.
+  `.agents/content/social-medium.md` records the official HTML-ZIP export,
+  unsupported legacy API, terms, retention, historical community schema
+  evidence, and unverified categories checked on 2026-07-28.
 - **All candidate rows:** the provider child owns current official documentation,
   account/export samples, auth scopes, dependency versions, local exported
   symbols, retention evidence, and explicit unsupported findings.

--- a/.agents/content/social-medium.md
+++ b/.agents/content/social-medium.md
@@ -1,0 +1,161 @@
+---
+description: Identity-verified Medium account export ingestion
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  webfetch: true
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Medium Account Knowledge
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Importer**: `knowledge-social-helper.sh import-medium-archive`
+- **Input**: a native Medium HTML ZIP requested by the account owner
+- **Identity**: explicit `Medium user ID` from exactly one
+  `profile/profile.html`, matched to `--account-id`; `--username` adds a second
+  check
+- **Implemented evidence**: authored posts, explicit responses, publication
+  membership, bookmarks, lists, highlights, claps, and followed users,
+  publications, or topics only when their validated archive category is present
+- **Isolation**: no provider request, browser, extraction, media hydration, API
+  token, or outbound operation is reachable
+- **Replay**: the original ZIP is content-addressed; normalized rows, coverage,
+  archive checkpoint, and run receipt commit under one final lease fence
+
+<!-- AI-CONTEXT-END -->
+
+## Evidence boundary
+
+The route and documentation were checked on 2026-07-28. The worker runtime has
+Python 3.14.3 with standard-library `zipfile.ZipFile` and
+`html.parser.HTMLParser`. Neither a `medium` nor `medium_api` Python package is
+installed. The importer intentionally has no third-party client and maps no
+provider API responses or error symbols.
+
+Medium's current export help says the owner requests **Download your
+information** under **Settings → Security and apps** and receives an email when
+the export is ready. It documents HTML files in a ZIP, but it does not publish a
+normative directory schema, manifest/version, filename grammar, HTML contract,
+or download-link expiry:
+https://help.medium.com/hc/en-us/articles/115004745787-Export-your-account-data.
+
+The current API/import help says Medium issues no new integration tokens and
+permits no new integrations, while existing tokens may continue to work:
+https://help.medium.com/hc/en-us/articles/213480228-API-Importing. The official
+API documentation is archived and explicitly unsupported:
+https://github.com/Medium/medium-api-docs. Its historical surface covers profile,
+publication listing, publishing, and image upload—not account-history reads for
+posts, responses, bookmarks, lists, highlights, claps, or follows. Legacy
+integration access is therefore not a live collector route.
+
+Medium's API terms constrain automated activity, rate-sensitive access, and
+storage to the reasonable period needed for a service:
+https://help.medium.com/hc/en-us/articles/214151487-Medium-API-Terms-of-Use.
+The Medium Rules prohibit unsupported scraping and scripted copying through
+interfaces other than those Medium publishes:
+https://help.medium.com/hc/en-us/articles/213477928-Medium-Rules. This importer
+uses only the owner-requested export and never contacts Medium.
+
+The published privacy policy says account-associated personal data is generally
+held while an account is active and account data is deleted within 14 days of
+closure, subject to stated legal and operational exceptions:
+https://policy.medium.com/medium-privacy-policy-f03bf92035c9. That policy is not
+an export-email download-link lifetime and the importer does not infer one.
+
+## Validated archive contract
+
+Medium does not publish the ZIP's inner schema. The fail-closed contract is
+documented by `.agents/tests/fixtures/medium-archive-fixture.py` and the focused
+assertions in `.agents/tests/test-knowledge-social-medium.sh`. The sanitized
+fixture reproduces microformat markers observed by the public `valueof/meh`
+parser and fixtures at
+https://github.com/valueof/meh/tree/main/parser and
+https://github.com/valueof/meh/tree/main/testdata. Those sources are community
+observations, not a Medium compatibility guarantee. A current owner export may
+add categories or change HTML; unknown members remain immutable raw evidence and
+receive partial coverage instead of being guessed.
+
+| Archive path | Required markers | Normalized evidence |
+|---|---|---|
+| `profile/profile.html` | Exactly one `Medium user ID`; optional `h-card`, `p-name`, `u-url`, and `@username` cross-check | Verified owner account; email and connected-account fields are not normalized |
+| `posts/*.html` | `data-field="body"` or `e-content`; canonical URL or explicit post ID when available | Authored post object plus `content_author`; an explicit `u-in-reply-to` or response ID records response classification |
+| `bookmarks/*.html` | `h-cite` URL; optional `dt-published` | Curated story reference plus bookmark activity |
+| `claps/*.html` | `u-like-of`/`h-cite` URL; optional bounded `+1`–`+50` count | Curated story reference plus clap activity |
+| `highlights/*.html` | `markup--highlight` selection, with source URL when present | Curated highlight object and activity |
+| `lists/*.html` | `p-name`; `li[data-field="post"]` URLs; canonical list URL when present | Owned curated list, referenced stories, and membership activities |
+| `profile/publications.html` | Publication links | Publication relationship and membership activity; role remains `member` unless an unambiguous supported marker is added |
+| `users-following/*.html` | Profile links | Followed account plus `follow_user` activity |
+| `pubs-following/*.html` | Publication links | Publication reference plus `follow_publication` activity |
+| `topics-following/*.html` | Topic links | Topic reference plus `follow_topic` activity |
+
+Post authoring and curation never share an evidence class. A post without an
+explicit response marker remains `unclassified_authored`; the `responses`
+coverage record stays `partial` because the archive does not guarantee a
+response discriminator. Timezone-free bookmark, clap, and highlight timestamps
+remain in provenance with `timestamp_timezone_known=false`; no UTC instant is
+invented.
+
+Security/session history, blocks, interests, memberships, charges, IPs, Twitter
+suggestions, binaries, and unknown paths are not interpreted as social evidence.
+They remain inside the immutable private ZIP and produce
+`unmapped_archive_members=partial`. Mentions/messages and local media remain
+explicitly unavailable. No remote media URL is fetched.
+
+## Import
+
+Record the export observation time from the owner's request/email context with
+an explicit timezone. Never paste a signed download URL or account data into a
+command, issue, fixture, or log.
+
+```bash
+knowledge-social-helper.sh import-medium-archive \
+  --archive "$HOME/private/medium-export.zip" \
+  --connection-id conn_medium_personal \
+  --account-id MEDIUM_USER_ID \
+  --username MEDIUM_HANDLE \
+  --exported-at 2026-07-28T08:00:00Z \
+  --max-items 50000 \
+  --max-bytes 536870912
+```
+
+`--max-items` bounds both ZIP members and unique normalized records.
+`--max-bytes` bounds compressed and total uncompressed input; each member also
+has a 32 MiB ceiling. Defaults are 50,000 items and 512 MiB, with hard CLI caps
+of 1,000,000 and 1 GiB. The route consumes zero provider-request units.
+
+The parser reads members directly without extracting them. It rejects absolute
+or traversing paths, duplicate case-folded names, symlinks, encrypted members,
+NULs, oversized members, malformed required markers, conflicting canonical IDs,
+account mismatch/rebinding, and credential-shaped HTML attributes or URL query
+fields—including signed-URL credentials—before raw evidence is written. The
+selected connection owns one expiring archive lease; the final transaction
+rechecks its fencing generation before writing.
+
+The raw ZIP is gzip-wrapped by the shared content-addressed evidence store. Its
+`blob_ref` is opaque even though the shared store currently uses a `.json.gz`
+suffix. Decompressing the blob returns the exact original ZIP bytes. Exact replay
+reuses its SHA-256 fetch batch and updates no duplicate normalized identities.
+
+## Coverage and retention
+
+`complete` means every recognized member of that category in this finite ZIP was
+parsed; it does not claim that Medium exported every historical account event.
+An absent category records `unavailable:category_not_present_in_archive` rather
+than an empty success. Unknown HTML and unsupported native categories remain
+`partial` raw evidence.
+
+The ZIP can contain personal data about the owner and third parties. Keep the
+corpus owner-only, preserve a lawful purpose, do not share the raw blob by
+default, and delete it when authority or purpose ends. The importer records the
+conservative boundary
+`private_export_under_operator_control_and_lawful_purpose`; it does not convert
+Medium's server-retention policy into a local indefinite-storage grant.

--- a/.agents/scripts/_knowledge_social_medium.py
+++ b/.agents/scripts/_knowledge_social_medium.py
@@ -1,0 +1,1200 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validate, normalize, and atomically persist a Medium account export."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import io
+import os
+import re
+import sqlite3
+import stat
+import zipfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable
+from urllib.parse import parse_qsl, urlsplit, urlunsplit
+
+from _knowledge_social_lease import (
+    RunLease,
+    RunReceiptUpdate,
+    assert_run_lease,
+    update_run_receipt,
+)
+from _knowledge_social_medium_html import (
+    HtmlNode,
+    classes,
+    descendants,
+    first_descendant,
+    parse_html,
+    text,
+    walk,
+)
+from knowledge_social_import import (
+    FORBIDDEN_CREDENTIAL_KEYS,
+    FORBIDDEN_CREDENTIAL_SUFFIXES,
+    import_accounts,
+    import_activities,
+    import_coverage,
+    import_media,
+    import_objects,
+    reject_credentials,
+    upsert_connection,
+)
+from knowledge_social_store import (
+    SocialStoreError,
+    connect,
+    migrate,
+    validate_opaque,
+    write_raw_batch,
+)
+
+PROVIDER = "medium"
+ARCHIVE_SCHEMA = "medium-html-export-v1"
+PROVENANCE = "medium_account_export"
+RETENTION_LIMIT = "private_export_under_operator_control_and_lawful_purpose"
+MAX_MEMBER_BYTES = 32 * 1024 * 1024
+USER_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{2,127}$")
+USERNAME = re.compile(r"^[A-Za-z0-9_.-]{1,64}$")
+PROFILE_ID = re.compile(r"Medium user ID:\s*([A-Za-z0-9_-]{3,128})", re.I)
+PROFILE_HANDLE = re.compile(r"^@([A-Za-z0-9_.-]{1,64})$", re.I)
+PROFILE_TEXT_HANDLE = re.compile(r"Profile:\s*@([A-Za-z0-9_.-]{1,64})", re.I)
+PROFILE_URL_HANDLE = re.compile(r"(?:^|/)@([A-Za-z0-9_.-]{1,64})(?:/|$)", re.I)
+CLAP_COUNT = re.compile(r"\+(\d{1,3})\s*(?:—|-)")
+FORBIDDEN_URL_QUERY_KEYS = {
+    "awsaccesskeyid",
+    "googleaccessid",
+    "keypairid",
+    "policy",
+    "sig",
+    "signature",
+}
+FORBIDDEN_URL_QUERY_PREFIXES = ("xamz", "xgoog")
+FORBIDDEN_URL_QUERY_SUFFIXES = (
+    "accesskeyid",
+    "credential",
+    "keypairid",
+    "securitytoken",
+    "signature",
+)
+
+CATEGORY_PREFIXES = {
+    "posts": ("posts/",),
+    "bookmarks": ("bookmarks/",),
+    "claps": ("claps/",),
+    "highlights": ("highlights/",),
+    "lists": ("lists/",),
+    "publication_membership": ("profile/publications.html",),
+    "users_following": ("users-following/",),
+    "publications_following": ("pubs-following/",),
+    "topics_following": ("topics-following/",),
+}
+
+
+@dataclass(frozen=True)
+class MediumIdentity:
+    account_id: str
+    username: str | None
+    display_name: str | None
+    profile_url: str | None
+
+
+@dataclass(frozen=True)
+class ParsedMediumArchive:
+    archive: dict[str, Any]
+    raw_sha256: str
+    recognized_members: int
+    unrecognized_members: int
+    normalized_items: int
+
+
+class _Builder:
+    def __init__(
+        self,
+        connection_id: str,
+        identity: MediumIdentity,
+        observed_at: str,
+        raw_sha256: str,
+        max_items: int,
+    ) -> None:
+        self.connection_id = connection_id
+        self.identity = identity
+        self.observed_at = observed_at
+        self.raw_sha256 = raw_sha256
+        self.max_items = max_items
+        self.accounts: dict[str, dict[str, Any]] = {}
+        self.objects: dict[tuple[str, str], dict[str, Any]] = {}
+        self.activities: dict[tuple[str, str], dict[str, Any]] = {}
+        self.coverage: dict[str, dict[str, Any]] = {}
+        self.add_account(
+            identity.account_id,
+            identity.username,
+            identity.display_name,
+            {
+                "source": PROVENANCE,
+                "profile_url": identity.profile_url,
+                "identity_status": "verified",
+            },
+        )
+
+    def _check_budget(self) -> None:
+        count = len(self.accounts) + len(self.objects) + len(self.activities)
+        if count > self.max_items:
+            raise SocialStoreError("Medium archive exceeds the item budget")
+
+    def add_account(
+        self,
+        remote_id: str,
+        handle: str | None,
+        display_name: str | None,
+        provider_json: dict[str, Any],
+    ) -> None:
+        self.accounts[remote_id] = {
+            "remote_id": remote_id,
+            "handle": handle,
+            "display_name": display_name,
+            "observed_at": self.observed_at,
+            "provider_json": provider_json,
+        }
+        self._check_budget()
+
+    def add_object(
+        self,
+        object_type: str,
+        remote_id: str,
+        content: str | None,
+        created_at: str | None,
+        evidence_class: str,
+        provider_json: dict[str, Any],
+        *,
+        owned: bool = False,
+    ) -> None:
+        self.objects[(object_type, remote_id)] = {
+            "object_type": object_type,
+            "remote_id": remote_id,
+            "account_remote_id": self.identity.account_id if owned else None,
+            "text": content,
+            "created_at": created_at,
+            "observed_at": self.observed_at,
+            "evidence_class": evidence_class,
+            "provider_json": provider_json,
+        }
+        self._check_budget()
+
+    def add_activity(
+        self,
+        activity_type: str,
+        remote_id: str,
+        object_remote_id: str | None,
+        occurred_at: str | None,
+        provider_json: dict[str, Any],
+    ) -> None:
+        self.activities[(activity_type, remote_id)] = {
+            "activity_type": activity_type,
+            "remote_id": remote_id,
+            "actor_remote_id": self.identity.account_id,
+            "object_remote_id": object_remote_id,
+            "occurred_at": occurred_at,
+            "observed_at": self.observed_at,
+            "state": "active",
+            "provider_json": provider_json,
+        }
+        self._check_budget()
+
+    def add_coverage(
+        self,
+        stream: str,
+        status: str,
+        reason: str | None,
+        *,
+        exhausted: bool,
+    ) -> None:
+        self.coverage[stream] = {
+            "stream": stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": exhausted,
+            "retention_limit": RETENTION_LIMIT,
+            "unavailable_reason": reason,
+            "status": status,
+            "observed_at": self.observed_at,
+        }
+
+    def finish(
+        self, present: set[str], recognized: int, unrecognized: int
+    ) -> ParsedMediumArchive:
+        enabled = sorted(present)
+        archive = {
+            "provider": PROVIDER,
+            "connection_id": self.connection_id,
+            "remote_account_id": self.identity.account_id,
+            "exported_at": self.observed_at,
+            "enabled_streams": enabled,
+            "policy": {
+                "archive_schema": ARCHIVE_SCHEMA,
+                "archive_sha256": self.raw_sha256,
+                "network_requests": 0,
+                "recognized_members": recognized,
+                "unrecognized_members": unrecognized,
+                "source": PROVENANCE,
+            },
+            "accounts": sorted(self.accounts.values(), key=lambda row: row["remote_id"]),
+            "objects": sorted(
+                self.objects.values(),
+                key=lambda row: (row["object_type"], row["remote_id"]),
+            ),
+            "activities": sorted(
+                self.activities.values(),
+                key=lambda row: (row["activity_type"], row["remote_id"]),
+            ),
+            "media": [],
+            "coverage": sorted(self.coverage.values(), key=lambda row: row["stream"]),
+        }
+        reject_credentials(archive)
+        normalized_items = (
+            len(archive["accounts"])
+            + len(archive["objects"])
+            + len(archive["activities"])
+        )
+        return ParsedMediumArchive(
+            archive, self.raw_sha256, recognized, unrecognized, normalized_items
+        )
+
+
+def _digest_id(prefix: str, *values: str) -> str:
+    material = "\0".join(values).encode("utf-8")
+    return f"{prefix}_{hashlib.sha256(material).hexdigest()[:40]}"
+
+
+def _normalized_url(value: str | None) -> str | None:
+    if not value or "\x00" in value or len(value.encode("utf-8")) > 4096:
+        return None
+    try:
+        parsed = urlsplit(value)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError as error:
+        raise SocialStoreError("Medium archive URL is malformed") from error
+    if parsed.scheme.lower() not in {"http", "https"} or not hostname:
+        return None
+    if parsed.username is not None or parsed.password is not None:
+        raise SocialStoreError("Medium archive URL contains user information")
+    for key, _query_value in parse_qsl(
+        parsed.query, keep_blank_values=True, max_num_fields=1000
+    ):
+        normalized_key = "".join(
+            character for character in key.lower() if character.isalnum()
+        )
+        if (
+            normalized_key in FORBIDDEN_CREDENTIAL_KEYS
+            or normalized_key in FORBIDDEN_URL_QUERY_KEYS
+            or normalized_key.startswith(FORBIDDEN_URL_QUERY_PREFIXES)
+            or normalized_key.endswith(FORBIDDEN_CREDENTIAL_SUFFIXES)
+            or normalized_key.endswith(FORBIDDEN_URL_QUERY_SUFFIXES)
+        ):
+            raise SocialStoreError("Medium archive URL contains credential-shaped data")
+    host = hostname.lower()
+    if ":" in host:
+        host = f"[{host}]"
+    if port is not None:
+        default = (parsed.scheme.lower(), port) in {("http", 80), ("https", 443)}
+        if not default:
+            host = f"{host}:{port}"
+    path = parsed.path or "/"
+    return urlunsplit((parsed.scheme.lower(), host, path, parsed.query, ""))
+
+
+def _timestamp(value: str | None) -> tuple[str | None, str | None, bool]:
+    raw = value.strip() if isinstance(value, str) and value.strip() else None
+    if raw is None:
+        return None, None, False
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None, raw, False
+    if parsed.tzinfo is None:
+        return None, raw, False
+    normalized = parsed.astimezone(UTC).isoformat().replace("+00:00", "Z")
+    return normalized, raw, True
+
+
+def normalize_exported_at(value: str) -> str:
+    normalized, _raw, known = _timestamp(value)
+    if not known or normalized is None:
+        raise SocialStoreError("Medium exported-at must include an explicit timezone")
+    return normalized
+
+
+def _node_href(node: HtmlNode | None) -> str | None:
+    return _normalized_url(node.attrs.get("href")) if node is not None else None
+
+
+def _first_with_classes(node: HtmlNode, names: Iterable[str]) -> HtmlNode | None:
+    expected = set(names)
+    for candidate in walk(node):
+        if expected.intersection(classes(candidate)):
+            return candidate
+    return None
+
+
+def _profile_identity(document: HtmlNode) -> MediumIdentity:
+    content = text(document)
+    identifiers = set(PROFILE_ID.findall(content))
+    if len(identifiers) != 1:
+        raise SocialStoreError(
+            "Medium archive requires exactly one profile Medium user ID"
+        )
+    account_id = next(iter(identifiers))
+    if USER_ID.fullmatch(account_id) is None:
+        raise SocialStoreError("Medium archive profile user ID is invalid")
+
+    profile_links = descendants(document, tag="a", class_name="u-url")
+    profile_urls = {_node_href(node) for node in profile_links}
+    profile_urls.discard(None)
+    if len(profile_urls) > 1:
+        raise SocialStoreError("Medium archive profile URLs conflict")
+    profile_url = next(iter(profile_urls), None)
+
+    handles: set[str] = set()
+    for node in profile_links:
+        label_match = PROFILE_HANDLE.fullmatch(text(node))
+        url_match = PROFILE_URL_HANDLE.search(node.attrs.get("href", ""))
+        if label_match:
+            handles.add(label_match.group(1))
+        if url_match:
+            handles.add(url_match.group(1))
+    profile_match = PROFILE_TEXT_HANDLE.search(content)
+    if profile_match:
+        handles.add(profile_match.group(1))
+    if len({handle.casefold() for handle in handles}) > 1:
+        raise SocialStoreError("Medium archive profile usernames conflict")
+    username = next(iter(handles), None)
+    if username is not None and USERNAME.fullmatch(username) is None:
+        raise SocialStoreError("Medium archive profile username is invalid")
+
+    display = first_descendant(document, class_name="p-name")
+    display_name = text(display) if display is not None else None
+    return MediumIdentity(account_id, username, display_name or None, profile_url)
+
+
+def _validate_expected_identity(
+    identity: MediumIdentity, expected_account_id: str, expected_username: str | None
+) -> None:
+    validate_opaque(expected_account_id, "account_id")
+    if identity.account_id != expected_account_id:
+        raise SocialStoreError("selected Medium account does not match the archive")
+    if expected_username is None:
+        return
+    selected = expected_username.removeprefix("@")
+    if USERNAME.fullmatch(selected) is None:
+        raise SocialStoreError("selected Medium username is invalid")
+    if identity.username is None or identity.username.casefold() != selected.casefold():
+        raise SocialStoreError("selected Medium username does not match the archive")
+
+
+def _member_provenance(name: str, payload: bytes) -> dict[str, Any]:
+    return {
+        "source": PROVENANCE,
+        "archive_member": name,
+        "member_sha256": hashlib.sha256(payload).hexdigest(),
+    }
+
+
+def _post(
+    builder: _Builder, name: str, payload: bytes, document: HtmlNode
+) -> int:
+    body = first_descendant(document, attr_name="data-field", attr_value="body")
+    if body is None:
+        body = first_descendant(document, class_name="e-content")
+    if body is None:
+        raise SocialStoreError("Medium archive post is missing its body marker")
+    title_node = first_descendant(document, class_name="p-name")
+    if title_node is None:
+        title_node = first_descendant(document, tag="title")
+    title = text(title_node) if title_node is not None else ""
+    body_text = text(body)
+    content = "\n\n".join(part for part in (title, body_text) if part) or None
+
+    canonical_nodes = descendants(document, tag="a", class_name="p-canonical")
+    canonical_urls = {_node_href(node) for node in canonical_nodes}
+    canonical_urls.discard(None)
+    if len(canonical_urls) > 1:
+        raise SocialStoreError("Medium archive post canonical URLs conflict")
+    canonical_url = next(iter(canonical_urls), None)
+
+    author_nodes = descendants(document, tag="a", class_name="p-author")
+    author_handles: set[str] = set()
+    for node in author_nodes:
+        label_match = PROFILE_HANDLE.fullmatch(text(node))
+        url_match = PROFILE_URL_HANDLE.search(node.attrs.get("href", ""))
+        if label_match:
+            author_handles.add(label_match.group(1))
+        if url_match:
+            author_handles.add(url_match.group(1))
+    if (
+        builder.identity.username is not None
+        and author_handles
+        and builder.identity.username.casefold()
+        not in {handle.casefold() for handle in author_handles}
+    ):
+        raise SocialStoreError("Medium archive post author conflicts with the profile")
+
+    published = first_descendant(document, tag="time", class_name="dt-published")
+    published_value = (
+        published.attrs.get("datetime") or text(published) if published is not None else None
+    )
+    occurred_at, timestamp_raw, timezone_known = _timestamp(published_value)
+    response_marker = any(
+        "u-in-reply-to" in classes(node) or "data-response-id" in node.attrs
+        for node in walk(document)
+    )
+    explicit_ids = {
+        node.attrs[attribute]
+        for node in walk(document)
+        for attribute in ("data-post-id", "data-response-id")
+        if node.attrs.get(attribute)
+    }
+    if len(explicit_ids) > 1:
+        raise SocialStoreError("Medium archive post IDs conflict")
+    if explicit_ids:
+        remote_id = _digest_id("medium_post", next(iter(explicit_ids)))
+        identity_confidence = "explicit"
+    elif canonical_url is not None:
+        remote_id = _digest_id("medium_post", canonical_url)
+        identity_confidence = "canonical_url"
+    else:
+        remote_id = _digest_id("medium_post", name, hashlib.sha256(payload).hexdigest())
+        identity_confidence = "content_addressed"
+
+    provenance = _member_provenance(name, payload)
+    provenance.update(
+        {
+            "canonical_url": canonical_url,
+            "identity_confidence": identity_confidence,
+            "post_kind": "response" if response_marker else "unclassified_authored",
+            "timestamp_raw": timestamp_raw,
+            "timestamp_timezone_known": timezone_known,
+        }
+    )
+    builder.add_object(
+        "post",
+        remote_id,
+        content,
+        occurred_at,
+        "authored",
+        provenance,
+        owned=True,
+    )
+    builder.add_activity(
+        "content_author",
+        _digest_id("medium_activity", builder.identity.account_id, remote_id),
+        remote_id,
+        occurred_at,
+        {"source": PROVENANCE, "post_kind": provenance["post_kind"]},
+    )
+    return 1
+
+
+def _reference_object(
+    builder: _Builder, url: str, title: str | None, source: str
+) -> str:
+    remote_id = _digest_id("medium_url", url)
+    builder.add_object(
+        "story_reference",
+        remote_id,
+        title,
+        None,
+        "curated",
+        {"source": PROVENANCE, "canonical_url": url, "archive_category": source},
+    )
+    return remote_id
+
+
+def _time_from_item(item: HtmlNode) -> tuple[str | None, str | None, bool]:
+    node = first_descendant(item, tag="time", class_name="dt-published")
+    value = node.attrs.get("datetime") or text(node) if node is not None else None
+    return _timestamp(value)
+
+
+def _bookmarks(builder: _Builder, name: str, document: HtmlNode) -> int:
+    items = descendants(document, tag="li")
+    if not items and first_descendant(document, tag="ul") is None:
+        raise SocialStoreError("Medium bookmark schema is unrecognized")
+    processed = 0
+    for item in items:
+        anchor = first_descendant(item, tag="a", class_name="h-cite")
+        url = _node_href(anchor)
+        if anchor is None or url is None:
+            raise SocialStoreError("Medium bookmark entry is missing a valid URL")
+        object_id = _reference_object(builder, url, text(anchor) or None, "bookmarks")
+        occurred_at, raw, known = _time_from_item(item)
+        builder.add_activity(
+            "bookmark",
+            _digest_id("medium_bookmark", builder.identity.account_id, object_id),
+            object_id,
+            occurred_at,
+            {
+                "source": PROVENANCE,
+                "archive_member": name,
+                "timestamp_raw": raw,
+                "timestamp_timezone_known": known,
+            },
+        )
+        processed += 1
+    return processed
+
+
+def _claps(builder: _Builder, name: str, document: HtmlNode) -> int:
+    items = descendants(document, tag="li")
+    if not items and first_descendant(document, tag="ul") is None:
+        raise SocialStoreError("Medium clap schema is unrecognized")
+    processed = 0
+    for item in items:
+        anchor = _first_with_classes(item, ("u-like-of", "h-cite"))
+        url = _node_href(anchor)
+        if anchor is None or url is None:
+            raise SocialStoreError("Medium clap entry is missing a valid URL")
+        object_id = _reference_object(builder, url, text(anchor) or None, "claps")
+        occurred_at, raw, known = _time_from_item(item)
+        match = CLAP_COUNT.search(text(item))
+        clap_count = int(match.group(1)) if match is not None else None
+        if clap_count is not None and not 1 <= clap_count <= 50:
+            raise SocialStoreError("Medium archive clap count is outside 1-50")
+        builder.add_activity(
+            "clap",
+            _digest_id("medium_clap", builder.identity.account_id, object_id),
+            object_id,
+            occurred_at,
+            {
+                "source": PROVENANCE,
+                "archive_member": name,
+                "clap_count": clap_count,
+                "timestamp_raw": raw,
+                "timestamp_timezone_known": known,
+            },
+        )
+        processed += 1
+    return processed
+
+
+def _highlights(builder: _Builder, name: str, document: HtmlNode) -> int:
+    items = descendants(document, tag="li")
+    if not items and first_descendant(document, tag="ul") is None:
+        raise SocialStoreError("Medium highlight schema is unrecognized")
+    processed = 0
+    for item_index, item in enumerate(items):
+        source = _first_with_classes(item, ("h-cite", "u-highlight-of"))
+        source_url = _node_href(source)
+        if source is not None and source_url is None:
+            raise SocialStoreError("Medium highlight source URL is invalid")
+        marked = descendants(item, class_name="markup--highlight")
+        if not marked:
+            raise SocialStoreError("Medium highlight entry has no selection marker")
+        for selection_index, selection in enumerate(marked):
+            selected_text = text(selection)
+            if not selected_text:
+                raise SocialStoreError("Medium highlight selection is empty")
+            identity = source_url or f"{name}:{item_index}"
+            remote_id = _digest_id(
+                "medium_highlight", identity, str(selection_index), selected_text
+            )
+            occurred_at, raw, known = _time_from_item(item)
+            builder.add_object(
+                "highlight",
+                remote_id,
+                selected_text,
+                occurred_at,
+                "curated",
+                {
+                    "source": PROVENANCE,
+                    "archive_member": name,
+                    "source_url": source_url,
+                    "timestamp_raw": raw,
+                    "timestamp_timezone_known": known,
+                },
+            )
+            builder.add_activity(
+                "highlight",
+                _digest_id("medium_highlight_activity", builder.identity.account_id, remote_id),
+                remote_id,
+                occurred_at,
+                {"source": PROVENANCE},
+            )
+            processed += 1
+    return processed
+
+
+def _lists(builder: _Builder, name: str, payload: bytes, document: HtmlNode) -> int:
+    title_node = first_descendant(document, class_name="p-name")
+    summary_node = first_descendant(document, class_name="p-summary")
+    title = text(title_node) if title_node is not None else None
+    summary = text(summary_node) if summary_node is not None else None
+    canonical = first_descendant(document, tag="a", class_name="p-canonical")
+    list_url = _node_href(canonical)
+    if not title:
+        raise SocialStoreError("Medium archive list is missing its title marker")
+    list_id = (
+        _digest_id("medium_list", list_url)
+        if list_url is not None
+        else _digest_id("medium_list", name, hashlib.sha256(payload).hexdigest())
+    )
+    builder.add_object(
+        "list",
+        list_id,
+        "\n\n".join(value for value in (title, summary) if value) or None,
+        None,
+        "curated",
+        {
+            **_member_provenance(name, payload),
+            "canonical_url": list_url,
+        },
+        owned=True,
+    )
+    processed = 1
+    for item in descendants(document, tag="li", attr_name="data-field", attr_value="post"):
+        anchor = first_descendant(item, tag="a", attr_name="href")
+        url = _node_href(anchor)
+        if anchor is None or url is None:
+            raise SocialStoreError("Medium archive list entry is missing a valid URL")
+        object_id = _reference_object(builder, url, text(anchor) or None, "lists")
+        builder.add_activity(
+            "list_membership",
+            _digest_id("medium_list_member", list_id, object_id),
+            object_id,
+            None,
+            {"source": PROVENANCE, "list_remote_id": list_id},
+        )
+        processed += 1
+    return processed
+
+
+def _profile_publications(builder: _Builder, document: HtmlNode) -> int:
+    if first_descendant(document, tag="ul") is None:
+        raise SocialStoreError("Medium publication membership schema is unrecognized")
+    processed = 0
+    for anchor in descendants(document, tag="a", attr_name="href"):
+        url = _node_href(anchor)
+        label = text(anchor)
+        if url is None or not label:
+            raise SocialStoreError("Medium publication membership URL is invalid")
+        surrounding = text(anchor)
+        role = next(
+            (value for value in ("editor", "writer") if value in surrounding.casefold()),
+            "member",
+        )
+        publication_id = _digest_id("medium_publication", url)
+        builder.add_object(
+            "publication",
+            publication_id,
+            label,
+            None,
+            "relationship",
+            {"source": PROVENANCE, "canonical_url": url},
+        )
+        builder.add_activity(
+            "publication_membership",
+            _digest_id(
+                "medium_publication_membership",
+                builder.identity.account_id,
+                publication_id,
+                role,
+            ),
+            publication_id,
+            None,
+            {"source": PROVENANCE, "role": role},
+        )
+        processed += 1
+    return processed
+
+
+def _following(builder: _Builder, category: str, document: HtmlNode) -> int:
+    target_type = {
+        "users_following": "user",
+        "publications_following": "publication",
+        "topics_following": "topic",
+    }[category]
+    anchors = descendants(document, tag="a", attr_name="href")
+    if not anchors and text(document):
+        raise SocialStoreError("Medium following schema is unrecognized")
+    processed = 0
+    for anchor in anchors:
+        url = _node_href(anchor)
+        label = text(anchor)
+        if url is None or not label:
+            raise SocialStoreError("Medium following entry URL is invalid")
+        target_id = _digest_id(f"medium_{target_type}", url)
+        if target_type == "user":
+            match = PROFILE_HANDLE.search(label)
+            handle = match.group(1) if match is not None else None
+            builder.add_account(
+                target_id,
+                handle,
+                label.removeprefix("@") or None,
+                {"source": PROVENANCE, "profile_url": url, "relationship": "followed"},
+            )
+        else:
+            builder.add_object(
+                target_type,
+                target_id,
+                label,
+                None,
+                "relationship",
+                {"source": PROVENANCE, "canonical_url": url},
+            )
+        builder.add_activity(
+            f"follow_{target_type}",
+            _digest_id(
+                f"medium_follow_{target_type}", builder.identity.account_id, target_id
+            ),
+            target_id,
+            None,
+            {"source": PROVENANCE},
+        )
+        processed += 1
+    return processed
+
+
+def _category(name: str) -> str | None:
+    for category, prefixes in CATEGORY_PREFIXES.items():
+        if any(name == prefix or name.startswith(prefix) for prefix in prefixes):
+            return category
+    return None
+
+
+def _safe_members(
+    archive: zipfile.ZipFile, max_bytes: int, max_items: int
+) -> list[zipfile.ZipInfo]:
+    infos = archive.infolist()
+    if len(infos) > max_items:
+        raise SocialStoreError("Medium archive exceeds the member budget")
+    seen: set[str] = set()
+    folded: set[str] = set()
+    total = 0
+    safe: list[zipfile.ZipInfo] = []
+    for info in infos:
+        name = info.filename
+        path = PurePosixPath(name)
+        if (
+            not name
+            or "\\" in name
+            or "\x00" in name
+            or path.is_absolute()
+            or any(part in {"", ".", ".."} for part in path.parts)
+        ):
+            raise SocialStoreError("Medium archive contains an unsafe member path")
+        if name in seen or name.casefold() in folded:
+            raise SocialStoreError("Medium archive contains duplicate member paths")
+        seen.add(name)
+        folded.add(name.casefold())
+        mode = (info.external_attr >> 16) & 0o170000
+        if mode == stat.S_IFLNK:
+            raise SocialStoreError("Medium archive cannot contain symbolic links")
+        if info.flag_bits & 0x1:
+            raise SocialStoreError("Medium archive cannot contain encrypted members")
+        if info.is_dir():
+            continue
+        if info.file_size > MAX_MEMBER_BYTES:
+            raise SocialStoreError("Medium archive member exceeds the byte budget")
+        total += info.file_size
+        if total > max_bytes:
+            raise SocialStoreError("Medium archive exceeds the uncompressed byte budget")
+        safe.append(info)
+    return sorted(safe, key=lambda info: info.filename)
+
+
+def _read_regular_archive(path: Path, max_bytes: int) -> bytes:
+    """Open once without following symlinks and reject in-place changes."""
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow:
+        flags |= nofollow
+    elif path.is_symlink():
+        raise SocialStoreError("Medium archive must be a regular non-symlink file")
+    descriptor = -1
+    try:
+        descriptor = os.open(path, flags)
+        with os.fdopen(descriptor, "rb") as source:
+            descriptor = -1
+            before = os.fstat(source.fileno())
+            if not stat.S_ISREG(before.st_mode):
+                raise SocialStoreError(
+                    "Medium archive must be a regular non-symlink file"
+                )
+            if before.st_size <= 0 or before.st_size > max_bytes:
+                raise SocialStoreError(
+                    "Medium archive exceeds the compressed byte budget"
+                )
+            payload = source.read(max_bytes + 1)
+            after = os.fstat(source.fileno())
+    except SocialStoreError:
+        raise
+    except OSError as error:
+        raise SocialStoreError("Medium archive could not be opened safely") from error
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    before_identity = (
+        before.st_dev,
+        before.st_ino,
+        before.st_size,
+        before.st_mtime_ns,
+    )
+    after_identity = (
+        after.st_dev,
+        after.st_ino,
+        after.st_size,
+        after.st_mtime_ns,
+    )
+    if (
+        len(payload) > max_bytes
+        or len(payload) != before.st_size
+        or before_identity != after_identity
+    ):
+        raise SocialStoreError("Medium archive changed while it was being read")
+    return payload
+
+
+def _parse_category_member(
+    builder: _Builder,
+    category: str,
+    name: str,
+    payload: bytes,
+    document: HtmlNode,
+) -> int:
+    if category == "posts":
+        return _post(builder, name, payload, document)
+    if category == "bookmarks":
+        return _bookmarks(builder, name, document)
+    if category == "claps":
+        return _claps(builder, name, document)
+    if category == "highlights":
+        return _highlights(builder, name, document)
+    if category == "lists":
+        return _lists(builder, name, payload, document)
+    if category == "publication_membership":
+        return _profile_publications(builder, document)
+    return _following(builder, category, document)
+
+
+def parse_medium_archive(
+    path: Path,
+    connection_id: str,
+    expected_account_id: str,
+    expected_username: str | None,
+    exported_at: str,
+    max_bytes: int,
+    max_items: int,
+) -> tuple[ParsedMediumArchive, bytes]:
+    """Validate a native Medium ZIP and build provider-neutral records in memory."""
+    validate_opaque(connection_id, "connection_id")
+    payload = _read_regular_archive(path, max_bytes)
+    digest = hashlib.sha256(payload).hexdigest()
+    observed_at = normalize_exported_at(exported_at)
+    try:
+        with zipfile.ZipFile(io.BytesIO(payload), "r") as archive:
+            members = _safe_members(archive, max_bytes, max_items)
+            profile_infos = [
+                info for info in members if info.filename == "profile/profile.html"
+            ]
+            if len(profile_infos) != 1:
+                raise SocialStoreError(
+                    "Medium archive requires exactly one profile/profile.html"
+                )
+            documents: dict[str, tuple[bytes, HtmlNode]] = {}
+            for info in members:
+                if not info.filename.lower().endswith(".html"):
+                    continue
+                member_payload = archive.read(info)
+                documents[info.filename] = (member_payload, parse_html(member_payload))
+    except (
+        RecursionError,
+        RuntimeError,
+        zipfile.BadZipFile,
+        zipfile.LargeZipFile,
+    ) as error:
+        raise SocialStoreError("Medium archive is not a supported ZIP file") from error
+
+    identity = _profile_identity(documents["profile/profile.html"][1])
+    _validate_expected_identity(identity, expected_account_id, expected_username)
+    builder = _Builder(
+        connection_id, identity, observed_at, digest, max_items
+    )
+    present: set[str] = set()
+    recognized = 1
+    unrecognized = 0
+    for info in members:
+        name = info.filename
+        if name == "profile/profile.html":
+            continue
+        category = _category(name)
+        if category is None:
+            unrecognized += 1
+            continue
+        if not name.lower().endswith(".html"):
+            raise SocialStoreError("Medium recognized archive members must be HTML")
+        member_payload, document = documents[name]
+        _parse_category_member(builder, category, name, member_payload, document)
+        present.add(category)
+        recognized += 1
+
+    for category in CATEGORY_PREFIXES:
+        status = "complete" if category in present else "unavailable"
+        reason = None if category in present else "category_not_present_in_archive"
+        builder.add_coverage(
+            category, status, reason, exhausted=category in present
+        )
+    builder.add_coverage(
+        "responses",
+        "partial" if "posts" in present else "unavailable",
+        (
+            "archive_posts_do_not_guarantee_a_response_discriminator"
+            if "posts" in present
+            else "posts_category_not_present_in_archive"
+        ),
+        exhausted="posts" in present,
+    )
+    builder.add_coverage(
+        "mentions_messages",
+        "unavailable",
+        "no_documented_medium_export_category",
+        exhausted=False,
+    )
+    builder.add_coverage(
+        "local_media",
+        "unavailable",
+        "local_media_schema_not_validated_and_network_hydration_is_disabled",
+        exhausted=False,
+    )
+    builder.add_coverage(
+        "unmapped_archive_members",
+        "partial" if unrecognized else "complete",
+        "raw_members_preserved_without_normalization" if unrecognized else None,
+        exhausted=unrecognized == 0,
+    )
+    return builder.finish(present, recognized, unrecognized), payload
+
+
+def _assert_connection_binding(
+    database: sqlite3.Connection, connection_id: str, account_id: str
+) -> None:
+    row = database.execute(
+        "SELECT provider,remote_account_id FROM connections WHERE connection_id=?",
+        (connection_id,),
+    ).fetchone()
+    if row is None:
+        return
+    if row["provider"] != PROVIDER or row["remote_account_id"] != account_id:
+        raise SocialStoreError("Medium connection is already bound to another account")
+
+
+def _refresh_fts(database: sqlite3.Connection, archive: dict[str, Any]) -> None:
+    for record in archive["objects"]:
+        identity = (PROVIDER, record["object_type"], record["remote_id"])
+        database.execute(
+            "DELETE FROM objects_fts WHERE provider=? AND object_type=? AND remote_id=?",
+            identity,
+        )
+        database.execute(
+            """INSERT INTO objects_fts(
+               provider,object_type,remote_id,account_remote_id,text_content,evidence_class)
+               SELECT provider,object_type,remote_id,account_remote_id,text_content,evidence_class
+                 FROM objects WHERE provider=? AND object_type=? AND remote_id=?""",
+            identity,
+        )
+
+
+def _raw_path(root: Path, connection_id: str, digest: str) -> Path:
+    return (
+        root
+        / "sources"
+        / "social"
+        / "raw"
+        / PROVIDER
+        / connection_id
+        / f"{digest}.json.gz"
+    )
+
+
+def _gzip_payload_digest(path: Path) -> str:
+    if path.is_symlink() or not path.is_file():
+        raise SocialStoreError("Medium raw evidence is missing or unsafe")
+    digest = hashlib.sha256()
+    try:
+        with gzip.open(path, "rb") as source:
+            while chunk := source.read(1024 * 1024):
+                digest.update(chunk)
+    except OSError as error:
+        raise SocialStoreError("Medium raw evidence could not be verified") from error
+    return digest.hexdigest()
+
+
+def _validate_replay_blob(
+    root: Path, connection_id: str, digest: str, blob_ref: str
+) -> None:
+    path = _raw_path(root, connection_id, digest)
+    expected_ref = path.relative_to(root).as_posix()
+    if blob_ref != expected_ref or _gzip_payload_digest(path) != digest:
+        raise SocialStoreError("Medium raw replay evidence does not match its batch")
+
+
+def _remove_created_raw(path: Path, digest: str) -> None:
+    try:
+        if _gzip_payload_digest(path) == digest:
+            path.unlink()
+    except (OSError, SocialStoreError):
+        return
+
+
+def _result(
+    parsed: ParsedMediumArchive,
+    account_id: str,
+    blob_ref: str,
+    normalized_items: int,
+    *,
+    replayed: bool,
+) -> dict[str, Any]:
+    return {
+        "account_id": account_id,
+        "archive_sha256": parsed.raw_sha256,
+        "blob_ref": blob_ref,
+        "normalized_items": normalized_items,
+        "recognized_members": parsed.recognized_members,
+        "replayed": replayed,
+        "status": "complete",
+        "unrecognized_members": parsed.unrecognized_members,
+    }
+
+
+def persist_medium_archive(
+    root: Path,
+    parsed: ParsedMediumArchive,
+    payload: bytes,
+    lease: RunLease,
+) -> dict[str, Any]:
+    """Commit raw ZIP evidence, normalized rows, coverage, and replay marker atomically."""
+    archive = parsed.archive
+    reject_credentials(archive)
+    if hashlib.sha256(payload).hexdigest() != parsed.raw_sha256:
+        raise SocialStoreError("Medium archive changed after validation")
+    connection_id = archive["connection_id"]
+    account_id = archive["remote_account_id"]
+    raw_path = _raw_path(root, connection_id, parsed.raw_sha256)
+    raw_existed = raw_path.exists() or raw_path.is_symlink()
+    created_raw = False
+    committed = False
+    database = connect(root)
+    try:
+        migrate(database)
+        database.execute("BEGIN IMMEDIATE")
+        assert_run_lease(database, lease)
+        _assert_connection_binding(database, connection_id, account_id)
+        existing = database.execute(
+            "SELECT provider,connection_id,stream,response_hash,blob_ref,"
+            "resource_count,completed_at FROM fetch_batches WHERE batch_id=?",
+            (parsed.raw_sha256,),
+        ).fetchone()
+        if existing is not None:
+            if (
+                existing["provider"] != PROVIDER
+                or existing["connection_id"] != connection_id
+            ):
+                raise SocialStoreError(
+                    "Medium archive digest is already bound to another connection"
+                )
+            if (
+                existing["stream"] != "archive"
+                or existing["response_hash"] != parsed.raw_sha256
+                or existing["completed_at"] != archive["exported_at"]
+            ):
+                raise SocialStoreError(
+                    "Medium archive replay metadata conflicts with the stored batch"
+                )
+            _validate_replay_blob(
+                root,
+                connection_id,
+                parsed.raw_sha256,
+                str(existing["blob_ref"]),
+            )
+            update_run_receipt(
+                database,
+                lease,
+                RunReceiptUpdate("complete", resource_delta=0, terminal=True),
+            )
+            database.execute("COMMIT")
+            committed = True
+            return _result(
+                parsed,
+                account_id,
+                str(existing["blob_ref"]),
+                int(existing["resource_count"]),
+                replayed=True,
+            )
+        batch_id, blob_ref = write_raw_batch(
+            root, PROVIDER, connection_id, payload
+        )
+        created_raw = not raw_existed
+        if batch_id != parsed.raw_sha256:
+            raise SocialStoreError("Medium raw evidence hash changed")
+        upsert_connection(database, archive, PROVIDER, connection_id)
+        import_accounts(database, archive, PROVIDER)
+        import_objects(database, archive, PROVIDER, batch_id)
+        import_activities(database, archive, PROVIDER, batch_id)
+        import_media(database, archive, PROVIDER, batch_id)
+        import_coverage(database, archive, PROVIDER, connection_id, batch_id)
+        _refresh_fts(database, archive)
+        database.execute(
+            """INSERT INTO fetch_batches(
+               batch_id,provider,connection_id,stream,request_hash,response_hash,blob_ref,
+               resource_count,budget_units,started_at,completed_at,terminal_status)
+               VALUES(?,?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(batch_id) DO NOTHING""",
+            (
+                batch_id,
+                PROVIDER,
+                connection_id,
+                "archive",
+                batch_id,
+                batch_id,
+                blob_ref,
+                parsed.normalized_items,
+                0,
+                archive["exported_at"],
+                archive["exported_at"],
+                "success",
+            ),
+        )
+        database.execute(
+            """INSERT INTO sync_cursors(
+               connection_id,stream,cursor,watermark,last_success_at,backfill_complete)
+               VALUES(?,?,?,?,?,1) ON CONFLICT(connection_id,stream) DO UPDATE SET
+               cursor=NULL,watermark=excluded.watermark,
+               last_success_at=excluded.last_success_at,backfill_complete=1""",
+            (connection_id, "archive", None, batch_id, archive["exported_at"]),
+        )
+        update_run_receipt(
+            database,
+            lease,
+            RunReceiptUpdate(
+                "complete", resource_delta=parsed.normalized_items, terminal=True
+            ),
+        )
+        database.execute("COMMIT")
+        committed = True
+        return _result(
+            parsed,
+            account_id,
+            blob_ref,
+            parsed.normalized_items,
+            replayed=False,
+        )
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        if created_raw and not committed:
+            _remove_created_raw(raw_path, parsed.raw_sha256)
+        raise
+    finally:
+        database.close()

--- a/.agents/scripts/_knowledge_social_medium_html.py
+++ b/.agents/scripts/_knowledge_social_medium_html.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Small, non-networking HTML helpers for Medium account exports."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from html.parser import HTMLParser
+from typing import Iterator
+
+from knowledge_social_import import (
+    FORBIDDEN_CREDENTIAL_KEYS,
+    FORBIDDEN_CREDENTIAL_SUFFIXES,
+)
+from knowledge_social_store import SocialStoreError
+
+VOID_ELEMENTS = {
+    "area",
+    "base",
+    "br",
+    "col",
+    "embed",
+    "hr",
+    "img",
+    "input",
+    "link",
+    "meta",
+    "param",
+    "source",
+    "track",
+    "wbr",
+}
+MAX_HTML_DEPTH = 256
+
+
+def _normalized_name(value: str) -> str:
+    return "".join(character for character in value.lower() if character.isalnum())
+
+
+def _credential_attribute(name: str) -> bool:
+    normalized = _normalized_name(name)
+    return normalized in FORBIDDEN_CREDENTIAL_KEYS or normalized.endswith(
+        FORBIDDEN_CREDENTIAL_SUFFIXES
+    )
+
+
+@dataclass
+class HtmlNode:
+    """A minimal HTML node retaining only tags, attributes, and text."""
+
+    tag: str
+    attrs: dict[str, str]
+    children: list[HtmlNode | str] = field(default_factory=list)
+
+
+class _TreeParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.root = HtmlNode("document", {})
+        self.stack = [self.root]
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        normalized_attrs: dict[str, str] = {}
+        for name, value in attrs:
+            lowered = name.lower()
+            if _credential_attribute(lowered):
+                raise SocialStoreError(
+                    "Medium archive contains credential-shaped HTML attributes"
+                )
+            normalized_attrs[lowered] = value or ""
+        node = HtmlNode(tag.lower(), normalized_attrs)
+        self.stack[-1].children.append(node)
+        if node.tag not in VOID_ELEMENTS:
+            if len(self.stack) > MAX_HTML_DEPTH:
+                raise SocialStoreError("Medium archive HTML nesting is too deep")
+            self.stack.append(node)
+
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        self.handle_starttag(tag, attrs)
+        if tag.lower() not in VOID_ELEMENTS:
+            self.stack.pop()
+
+    def handle_endtag(self, tag: str) -> None:
+        lowered = tag.lower()
+        for index in range(len(self.stack) - 1, 0, -1):
+            if self.stack[index].tag == lowered:
+                del self.stack[index:]
+                return
+
+    def handle_data(self, data: str) -> None:
+        self.stack[-1].children.append(data)
+
+
+def parse_html(payload: bytes) -> HtmlNode:
+    """Decode one bounded UTF-8 export member and return its minimal tree."""
+    try:
+        source = payload.decode("utf-8-sig")
+    except UnicodeDecodeError as error:
+        raise SocialStoreError("Medium archive HTML must be valid UTF-8") from error
+    if "\x00" in source:
+        raise SocialStoreError("Medium archive HTML contains a NUL byte")
+    parser = _TreeParser()
+    try:
+        parser.feed(source)
+        parser.close()
+    except (SocialStoreError, ValueError) as error:
+        if isinstance(error, SocialStoreError):
+            raise
+        raise SocialStoreError("Medium archive HTML is malformed") from error
+    return parser.root
+
+
+def walk(node: HtmlNode) -> Iterator[HtmlNode]:
+    """Yield every element below a node in document order."""
+    pending = [
+        child for child in reversed(node.children) if isinstance(child, HtmlNode)
+    ]
+    while pending:
+        current = pending.pop()
+        yield current
+        pending.extend(
+            child
+            for child in reversed(current.children)
+            if isinstance(child, HtmlNode)
+        )
+
+
+def text(node: HtmlNode) -> str:
+    """Return normalized descendant text without retaining HTML markup."""
+    parts: list[str] = []
+    pending: list[HtmlNode | str] = list(reversed(node.children))
+    while pending:
+        current = pending.pop()
+        if isinstance(current, str):
+            parts.append(current)
+        else:
+            pending.extend(reversed(current.children))
+    return re.sub(r"\s+", " ", " ".join(parts)).strip()
+
+
+def classes(node: HtmlNode) -> set[str]:
+    return {value for value in node.attrs.get("class", "").split() if value}
+
+
+def descendants(
+    node: HtmlNode,
+    *,
+    tag: str | None = None,
+    class_name: str | None = None,
+    attr_name: str | None = None,
+    attr_value: str | None = None,
+) -> list[HtmlNode]:
+    """Return descendants matching the small selector subset export parsers use."""
+    matches: list[HtmlNode] = []
+    for candidate in walk(node):
+        if tag is not None and candidate.tag != tag:
+            continue
+        if class_name is not None and class_name not in classes(candidate):
+            continue
+        if attr_name is not None and attr_name not in candidate.attrs:
+            continue
+        if attr_value is not None and candidate.attrs.get(attr_name or "") != attr_value:
+            continue
+        matches.append(candidate)
+    return matches
+
+
+def first_descendant(
+    node: HtmlNode,
+    *,
+    tag: str | None = None,
+    class_name: str | None = None,
+    attr_name: str | None = None,
+    attr_value: str | None = None,
+) -> HtmlNode | None:
+    matches = descendants(
+        node,
+        tag=tag,
+        class_name=class_name,
+        attr_name=attr_name,
+        attr_value=attr_value,
+    )
+    return matches[0] if matches else None

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -12,6 +12,7 @@ REDDIT_HELPER="${SCRIPT_DIR}/knowledge_social_reddit.py"
 YOUTUBE_HELPER="${SCRIPT_DIR}/knowledge_social_youtube.py"
 LINKEDIN_HELPER="${SCRIPT_DIR}/knowledge_social_linkedin.py"
 META_HELPER="${SCRIPT_DIR}/knowledge_social_meta.py"
+MEDIUM_HELPER="${SCRIPT_DIR}/knowledge_social_medium.py"
 QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
 SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
 SHARE_HELPER="${SCRIPT_DIR}/knowledge_social_share.py"
@@ -103,6 +104,10 @@ usage_commands() {
 Usage:
   knowledge-social-helper.sh provision [--base PATH] [--alias ALIAS]
   knowledge-social-helper.sh import-archive [--base PATH] [--alias ALIAS] --archive FILE
+  knowledge-social-helper.sh import-medium-archive [--base PATH] [--alias ALIAS] \
+    --archive FILE --connection-id ID --account-id MEDIUM_USER_ID \
+    --exported-at ISO_TIME [--username HANDLE] [--max-items N] [--max-bytes N] \
+    [--collector-id ID] [--lease-seconds SECONDS]
   knowledge-social-helper.sh rebuild [--base PATH] [--alias ALIAS]
   knowledge-social-helper.sh coverage [--base PATH] [--alias ALIAS]
   knowledge-social-helper.sh query [--base PATH] [--alias ALIAS] \
@@ -180,6 +185,14 @@ Archive format:
   objects, activities, media, and coverage. IDs must be provider-stable IDs;
   connection_id must be an opaque local ID. Unknown provider fields belong in
   provider_json objects. The original canonical payload is stored immutably.
+
+Medium account export:
+  import-medium-archive accepts only a native HTML ZIP export with exactly one
+  profile/profile.html and a matching explicit Medium user ID. It performs no
+  provider requests, extracts no files, rejects unsafe ZIP members and
+  credential-shaped HTML attributes or URL queries, applies item/byte limits,
+  and stores the original ZIP content-addressed before committing normalized
+  rows and coverage.
 
 EOF
 	usage_sync
@@ -266,6 +279,16 @@ require_runtime() {
 	return 0
 }
 
+run_medium_import() {
+	require_runtime || return 1
+	if [[ ! -r "$MEDIUM_HELPER" ]]; then
+		printf 'ERROR: Medium archive adapter missing: %s\n' "$MEDIUM_HELPER" >&2
+		return 1
+	fi
+	python3 "$MEDIUM_HELPER" "$@" || return 1
+	return 0
+}
+
 main() {
 	local subcommand="${1:-help}"
 	if [[ $# -gt 0 ]]; then
@@ -275,6 +298,9 @@ main() {
 	provision | import-archive | rebuild | coverage)
 		require_runtime || return 1
 		python3 "$PYTHON_HELPER" "$subcommand" "$@" || return 1
+		;;
+	import-medium-archive)
+		run_medium_import "$@" || return 1
 		;;
 	sync-x)
 		require_runtime || return 1

--- a/.agents/scripts/knowledge_social_medium.py
+++ b/.agents/scripts/knowledge_social_medium.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Import one bounded, identity-verified Medium account export."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from _knowledge_social_lease import (
+    RunLease,
+    RunLeaseRequest,
+    acquire_run_lease,
+    fail_active_run,
+    release_run_lease,
+)
+from _knowledge_social_medium import parse_medium_archive, persist_medium_archive
+from knowledge_corpus_catalog import DEFAULT_ALIAS, resolve
+from knowledge_corpus_context import CatalogError
+from knowledge_social_store import SocialStoreError, validate_root
+
+DEFAULT_MAX_BYTES = 512 * 1024 * 1024
+DEFAULT_MAX_ITEMS = 50_000
+
+
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be an integer") from error
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be positive")
+    return parsed
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", type=Path)
+    parser.add_argument("--alias", default=DEFAULT_ALIAS)
+    parser.add_argument("--archive", type=Path, required=True)
+    parser.add_argument("--connection-id", required=True)
+    parser.add_argument("--account-id", required=True)
+    parser.add_argument("--username")
+    parser.add_argument(
+        "--exported-at",
+        required=True,
+        help="export observation time with an explicit timezone",
+    )
+    parser.add_argument("--max-bytes", type=_positive_int, default=DEFAULT_MAX_BYTES)
+    parser.add_argument("--max-items", type=_positive_int, default=DEFAULT_MAX_ITEMS)
+    parser.add_argument("--collector-id", default="medium_archive")
+    parser.add_argument("--lease-seconds", type=_positive_int, default=300)
+    args = parser.parse_args()
+    if args.max_bytes > 1024 * 1024 * 1024:
+        parser.error("--max-bytes cannot exceed 1073741824")
+    if args.max_items > 1_000_000:
+        parser.error("--max-items cannot exceed 1000000")
+    if args.lease_seconds > 86_400:
+        parser.error("--lease-seconds cannot exceed 86400")
+    return args
+
+
+def _release_safely(root: Path, lease: RunLease | None) -> None:
+    if lease is None:
+        return
+    try:
+        release_run_lease(root, lease)
+    except SocialStoreError:
+        return
+
+
+def main() -> int:
+    args = parse_args()
+    lease: RunLease | None = None
+    root: Path | None = None
+    try:
+        base = (
+            args.base
+            if args.base is not None
+            else Path.home() / ".aidevops" / ".agent-workspace" / "knowledge"
+        )
+        root = validate_root(resolve(base, args.alias, "knowledge.write"))
+        parsed, payload = parse_medium_archive(
+            args.archive,
+            args.connection_id,
+            args.account_id,
+            args.username,
+            args.exported_at,
+            args.max_bytes,
+            args.max_items,
+        )
+        lease = acquire_run_lease(
+            root,
+            RunLeaseRequest(
+                args.connection_id,
+                "archive",
+                args.collector_id,
+                "sync",
+                args.lease_seconds,
+                parsed.raw_sha256,
+            ),
+        )
+        result = persist_medium_archive(root, parsed, payload, lease)
+        _release_safely(root, lease)
+        lease = None
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    except (CatalogError, OSError, SocialStoreError, ValueError) as error:
+        if root is not None and lease is not None:
+            try:
+                fail_active_run(root, lease, "archive_validation")
+            except SocialStoreError:
+                pass
+            _release_safely(root, lease)
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/tests/fixtures/medium-archive-fixture.py
+++ b/.agents/tests/fixtures/medium-archive-fixture.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Generate sanitized Medium HTML-export ZIP fixtures for focused tests."""
+
+from __future__ import annotations
+
+import stat
+import sys
+import zipfile
+from pathlib import Path
+
+STORY = """<!doctype html><html><head><title>Fixture Story</title></head><body>
+<article class="h-entry" data-post-id="post-fixture-1">
+  <h1 class="p-name">Fixture Story</h1>
+  <section class="e-content" data-field="body"><p class="graf">Authored evidence.</p></section>
+  <footer><a class="p-author h-card" href="https://medium.com/@fixture">@fixture</a>
+    <time class="dt-published" datetime="2026-07-27T10:00:00Z">published</time>
+    <a class="p-canonical" href="https://medium.com/@fixture/fixture-story-11111111">canonical</a>
+  </footer>
+</article></body></html>"""
+RESPONSE = """<!doctype html><html><body>
+<article class="h-entry" data-response-id="response-fixture-2">
+  <h1 class="p-name">Fixture Response</h1>
+  <a class="u-in-reply-to" href="https://medium.com/@source/original-22222222">original</a>
+  <section class="e-content" data-field="body"><p class="graf">Authored response.</p></section>
+  <footer><a class="p-author h-card" href="https://medium.com/@fixture">@fixture</a>
+    <time class="dt-published" datetime="2026-07-27T11:00:00+00:00">published</time>
+    <a class="p-canonical" href="https://medium.com/@fixture/fixture-response-33333333">canonical</a>
+  </footer>
+</article></body></html>"""
+BOOKMARKS = """<html><body><ul><li><a class="h-cite" href="https://medium.com/@source/saved-44444444">Saved story</a>
+<time class="dt-published">2026-07-27 4:50 pm</time></li></ul></body></html>"""
+CLAPS = """<html><body><ul><li class="h-entry">+25 — <a class="h-cite u-like-of" href="https://medium.com/@source/saved-44444444">Clapped story</a>
+<time class="dt-published">2026-07-27 4:55 pm</time></li></ul></body></html>"""
+HIGHLIGHTS = """<html><body><ul><li class="h-entry"><a class="h-cite u-highlight-of" href="https://medium.com/@source/highlighted-55555555">Source</a>
+<p class="graf">Context <span class="markup--highlight" name="selection">Selected words</span></p>
+<time class="dt-published">2026-07-27 5:00 pm</time></li></ul></body></html>"""
+LISTS = """<html><body><h1 class="p-name">Fixture List</h1><h2 class="p-summary">Curated references</h2>
+<ul><li data-field="post"><a href="https://medium.com/@source/listed-66666666">Listed story</a></li></ul>
+<footer><a class="p-canonical" href="https://medium.com/@fixture/list/fixture-list-77777777">list</a></footer></body></html>"""
+
+
+def profile_html(mode: str) -> str:
+    account_id = "medium_other_99" if mode == "other-account" else "medium_user_42"
+    credential = ' data-access-token="must-not-persist"' if mode == "credential" else ""
+    profile = f"""<!doctype html><html><body>
+<section class="h-card"{credential}>
+  <h3 class="p-name">Fixture Author</h3>
+  <h4>Account info</h4><ul>
+    <li>Profile: <a class="u-url" href="https://medium.com/@fixture">@fixture</a></li>
+    <li>Email address: fixture@example.invalid</li>
+    <li>Medium user ID: {account_id}</li>
+  </ul>
+</section></body></html>"""
+    if mode == "deep":
+        return "<div>" * 300 + profile + "</div>" * 300
+    return profile
+
+
+def write_special_members(archive: zipfile.ZipFile, mode: str) -> None:
+    if mode == "traversal":
+        archive.writestr("../escape.html", "unsafe")
+    elif mode == "duplicate":
+        archive.writestr("posts/case.html", STORY)
+        archive.writestr("POSTS/CASE.HTML", STORY)
+    elif mode == "member-symlink":
+        link = zipfile.ZipInfo("posts/link.html")
+        link.create_system = 3
+        link.external_attr = (stat.S_IFLNK | 0o777) << 16
+        archive.writestr(link, "story.html")
+    elif mode == "oversized-member":
+        archive.writestr("sessions/large.bin", b"A" * (32 * 1024 * 1024 + 1))
+
+
+def write_social_members(archive: zipfile.ZipFile, mode: str) -> None:
+    story = (
+        "<html><body><h1>Malformed post</h1></body></html>"
+        if mode == "malformed"
+        else STORY
+    )
+    bookmarks = (
+        "<html><body><ul><li>schema changed</li></ul></body></html>"
+        if mode == "malformed-bookmarks"
+        else BOOKMARKS
+    )
+    highlights = (
+        '<html><body><ul><li><span class="markup--highlight"></span></li></ul></body></html>'
+        if mode == "malformed-highlights"
+        else HIGHLIGHTS
+    )
+    archive.writestr("posts/story.html", story)
+    archive.writestr("posts/response.html", RESPONSE)
+    archive.writestr("bookmarks/bookmarks.html", bookmarks)
+    archive.writestr("claps/claps.html", CLAPS)
+    archive.writestr("highlights/highlights.html", highlights)
+    archive.writestr("lists/list.html", LISTS)
+    archive.writestr(
+        "profile/publications.html",
+        '<html><body><ul><li>Writer <a href="https://medium.com/fixture-publication">Fixture Publication</a></li></ul></body></html>',
+    )
+    archive.writestr(
+        "users-following/users.html",
+        '<html><body><a href="https://medium.com/@followed">@followed</a></body></html>',
+    )
+    archive.writestr(
+        "pubs-following/publications.html",
+        '<html><body><a href="https://medium.com/fixture-publication">Fixture Publication</a></body></html>',
+    )
+    archive.writestr(
+        "topics-following/topics.html",
+        '<html><body><a href="https://medium.com/tag/testing">Testing</a></body></html>',
+    )
+    archive.writestr(
+        "sessions/devices.html", "<html><body>excluded device history</body></html>"
+    )
+    if mode == "expansion":
+        archive.writestr(
+            "sessions/large.html", "<html>" + "A" * 100000 + "</html>"
+        )
+
+
+def mark_encrypted(target: Path) -> None:
+    payload = bytearray(target.read_bytes())
+    for marker, offset in ((b"PK\x03\x04", 6), (b"PK\x01\x02", 8)):
+        cursor = 0
+        while True:
+            index = payload.find(marker, cursor)
+            if index < 0:
+                break
+            flags = int.from_bytes(
+                payload[index + offset : index + offset + 2], "little"
+            ) | 1
+            payload[index + offset : index + offset + 2] = flags.to_bytes(2, "little")
+            cursor = index + len(marker)
+    target.write_bytes(payload)
+
+
+def main() -> int:
+    target = Path(sys.argv[1])
+    mode = sys.argv[2]
+    excluded = {
+        "credential",
+        "deep",
+        "duplicate",
+        "encrypted",
+        "member-symlink",
+        "minimal",
+        "other-account",
+        "oversized-member",
+        "traversal",
+    }
+    with zipfile.ZipFile(target, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("profile/profile.html", profile_html(mode))
+        write_special_members(archive, mode)
+        if mode not in excluded:
+            write_social_members(archive, mode)
+    if mode == "encrypted":
+        mark_encrypted(target)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/tests/test-knowledge-social-medium.sh
+++ b/.agents/tests/test-knowledge-social-medium.sh
@@ -1,0 +1,543 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-medium.sh — Medium native account export importer tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+ARCHIVE="${TMP_DIR}/medium-export.zip"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' \
+			"$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c \
+		'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_count() {
+	local connection_id="$1"
+	python3 - "$ROOT/sources/social/raw/medium/$connection_id" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+print(len(list(root.rglob("*.json.gz"))) if root.exists() else 0)
+PY
+	return 0
+}
+
+expect_import_failure() {
+	local description="$1"
+	local archive="$2"
+	local connection_id="$3"
+	local account_id="$4"
+	shift 4
+	if "$HELPER" import-medium-archive --base "$BASE" --alias personal:default \
+		--archive "$archive" --connection-id "$connection_id" \
+		--account-id "$account_id" --username fixture \
+		--exported-at 2026-07-28T08:00:00Z "$@" >/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+make_archive() {
+	local target="$1"
+	local mode="$2"
+	python3 "${SCRIPT_DIR}/fixtures/medium-archive-fixture.py" "$target" "$mode"
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'Medium account export importer tests\n'
+
+help_output=$("$HELPER" help)
+if [[ "$help_output" == *"import-medium-archive"* && "$help_output" == *"MEDIUM_USER_ID"* ]]; then
+	assert_eq "help exposes the identity-bound Medium archive route" advertised advertised
+else
+	assert_eq "help exposes the identity-bound Medium archive route" missing advertised
+fi
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import ast
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+targets = [
+    scripts / "knowledge_social_medium.py",
+    scripts / "_knowledge_social_medium.py",
+    scripts / "_knowledge_social_medium_html.py",
+]
+for target in targets:
+    source = target.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imports = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imports.update(
+        node.module or "" for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)
+    )
+    assert "urllib.request" not in imports
+    assert "socket" not in imports
+    assert not any(
+        "outbound" in name or "browser" in name or "operations" in name
+        for name in imports
+    )
+    assert "subprocess" not in imports
+    assert "urlopen(" not in source and "requests." not in source
+PY
+assert_eq "Medium importer has no network or outbound mutation reachability" isolated isolated
+
+make_archive "$ARCHIVE" valid
+runtime_isolation=$(
+	python3 - "$ARCHIVE" "$SCRIPT_DIR/../scripts" "$TMP_DIR/runtime-root" <<'PY'
+import importlib.abc
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+
+class MutationImportBlocker(importlib.abc.MetaPathFinder):
+    blocked = (
+        "_knowledge_social_outbound",
+        "knowledge_social_browser",
+        "knowledge_social_operations",
+    )
+
+    def find_spec(self, fullname, _path, _target=None):
+        if fullname.startswith(self.blocked):
+            raise AssertionError(f"mutation module import attempted: {fullname}")
+        return None
+
+
+def blocked_runtime(*_args, **_kwargs):
+    raise AssertionError("network, subprocess, or mutation execution attempted")
+
+
+sys.meta_path.insert(0, MutationImportBlocker())
+socket.socket = blocked_runtime
+subprocess.Popen = blocked_runtime
+subprocess.call = blocked_runtime
+subprocess.check_call = blocked_runtime
+subprocess.check_output = blocked_runtime
+subprocess.run = blocked_runtime
+os.system = blocked_runtime
+os.popen = blocked_runtime
+sys.path.insert(0, sys.argv[2])
+from _knowledge_social_lease import (
+    RunLeaseRequest,
+    acquire_run_lease,
+    release_run_lease,
+)
+from _knowledge_social_medium import (
+    _normalized_url,
+    parse_medium_archive,
+    persist_medium_archive,
+)
+from knowledge_social_store import SocialStoreError
+
+first = _normalized_url("https://example.invalid/story?id=1")
+second = _normalized_url("https://example.invalid/story?id=2")
+assert first != second and first.endswith("?id=1") and second.endswith("?id=2")
+for unsafe_url in (
+    "https://example.invalid/story?access_token=forbidden",
+    "https://example.invalid/story?X-Amz-Signature=forbidden",
+    "https://example.invalid/story?X-Goog-Credential=forbidden",
+    "https://example.invalid/story?sig=forbidden",
+):
+    try:
+        _normalized_url(unsafe_url)
+    except SocialStoreError:
+        pass
+    else:
+        raise AssertionError("credential-shaped URL query was accepted")
+parsed, _payload = parse_medium_archive(
+    Path(sys.argv[1]), "conn_runtime_check", "medium_user_42", "fixture",
+    "2026-07-28T08:00:00Z", 512 * 1024 * 1024, 50_000,
+)
+runtime_root = Path(sys.argv[3])
+runtime_root.mkdir(mode=0o700)
+lease = acquire_run_lease(
+    runtime_root,
+    RunLeaseRequest("conn_runtime_check", "archive", "runtime_check", "sync", 300),
+)
+result = persist_medium_archive(runtime_root, parsed, _payload, lease)
+release_run_lease(runtime_root, lease)
+print("isolated" if result["status"] == "complete" else "failed")
+PY
+)
+assert_eq "runtime import cannot reach network, subprocess, or mutation adapters" \
+	"$runtime_isolation" isolated
+result=$("$HELPER" import-medium-archive --base "$BASE" --alias personal:default \
+	--archive "$ARCHIVE" --connection-id conn_medium --account-id medium_user_42 \
+	--username fixture --exported-at 2026-07-28T08:00:00Z)
+assert_eq "validated Medium archive import completes" "$(json_field "$result" status)" complete
+assert_eq "first import is distinguished from an exact replay" \
+	"$(json_field "$result" replayed)" False
+assert_eq "current sanitized fixture recognizes all social HTML members" \
+	"$(json_field "$result" recognized_members)" 11
+assert_eq "unsupported session metadata remains an explicit unmapped member" \
+	"$(json_field "$result" unrecognized_members)" 1
+assert_eq "profile identity binds the selected Medium user ID and handle" \
+	"$(sql_value "SELECT remote_id || ':' || handle FROM accounts WHERE provider='medium' AND remote_id='medium_user_42'")" \
+	"medium_user_42:fixture"
+assert_eq "authored posts stay distinct from curated objects" \
+	"$(sql_value "SELECT count(*) || ':' || (SELECT count(*) FROM objects WHERE provider='medium' AND evidence_class='curated') FROM objects WHERE provider='medium' AND evidence_class='authored'")" \
+	"2:4"
+assert_eq "an explicit response marker survives normalization" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='medium' AND provider_json LIKE '%\"post_kind\":\"response\"%'")" 1
+assert_eq "publication membership and all three follow directions persist" \
+	"$(sql_value "SELECT count(*) FROM activities WHERE provider='medium' AND activity_type IN ('publication_membership','follow_user','follow_publication','follow_topic')")" 4
+assert_eq "timezone-free curation timestamps are preserved without invented UTC" \
+	"$(sql_value "SELECT count(*) FROM activities WHERE provider='medium' AND activity_type='bookmark' AND occurred_at IS NULL AND provider_json LIKE '%2026-07-27 4:50 pm%'")" 1
+assert_eq "response coverage remains partial instead of claiming archive parity" \
+	"$(sql_value "SELECT status || ':' || cursor_exhausted FROM coverage_records WHERE provider='medium' AND stream='responses'")" partial:1
+assert_eq "missing media and messages remain explicit No coverage" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE provider='medium' AND stream IN ('local_media','mentions_messages') AND status='unavailable'")" 2
+assert_eq "unmapped native export state is retained as partial coverage" \
+	"$(sql_value "SELECT status FROM coverage_records WHERE provider='medium' AND stream='unmapped_archive_members'")" partial
+assert_eq "archive replay marker is an independent exhausted checkpoint" \
+	"$(sql_value "SELECT coalesce(cursor,'done') || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_medium' AND stream='archive'")" done:1
+
+archive_hash=$(
+	python3 - "$ARCHIVE" <<'PY'
+import hashlib
+import sys
+from pathlib import Path
+
+print(hashlib.sha256(Path(sys.argv[1]).read_bytes()).hexdigest())
+PY
+)
+assert_eq "result exposes only the content-addressed archive digest" \
+	"$(json_field "$result" archive_sha256)" "$archive_hash"
+raw_integrity=$(
+	python3 - "$ARCHIVE" "$ROOT" <<'PY'
+import gzip
+import hashlib
+import sqlite3
+import sys
+from pathlib import Path
+
+archive = Path(sys.argv[1]).read_bytes()
+root = Path(sys.argv[2])
+with sqlite3.connect(root / "index" / "social.db") as database:
+    relative = database.execute(
+        "SELECT blob_ref FROM fetch_batches WHERE provider='medium' AND connection_id='conn_medium'"
+    ).fetchone()[0]
+with gzip.open(root / relative, "rb") as source:
+    stored = source.read()
+print("verified" if stored == archive and hashlib.sha256(stored).hexdigest() == hashlib.sha256(archive).hexdigest() else "failed")
+PY
+)
+assert_eq "immutable raw evidence is the exact original ZIP payload" "$raw_integrity" verified
+
+batch_count=$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='medium' AND connection_id='conn_medium'")
+object_count=$(sql_value "SELECT count(*) FROM objects WHERE provider='medium'")
+replay_result=$("$HELPER" import-medium-archive --base "$BASE" --alias personal:default \
+	--archive "$ARCHIVE" --connection-id conn_medium --account-id medium_user_42 \
+	--username fixture --exported-at 2026-07-28T08:00:00Z)
+assert_eq "exact Medium archive replay is content-addressed and idempotent" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='medium' AND connection_id='conn_medium'")" "$batch_count"
+assert_eq "exact replay follows the no-op path" \
+	"$(json_field "$replay_result" replayed)" True
+assert_eq "archive replay preserves normalized object cardinality" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='medium'")" "$object_count"
+
+observed_before=$(sql_value "SELECT observed_at FROM objects WHERE provider='medium' AND evidence_class='authored' LIMIT 1")
+if "$HELPER" import-medium-archive --base "$BASE" --alias personal:default \
+	--archive "$ARCHIVE" --connection-id conn_medium --account-id medium_user_42 \
+	--username fixture --exported-at 2026-07-28T09:00:00Z >/dev/null 2>&1; then
+	replay_metadata=accepted
+else
+	replay_metadata=rejected
+fi
+assert_eq "same bytes with conflicting observation metadata are rejected" \
+	"$replay_metadata" rejected
+assert_eq "conflicting replay metadata cannot rewrite normalized evidence" \
+	"$(sql_value "SELECT observed_at FROM objects WHERE provider='medium' AND evidence_class='authored' LIMIT 1")" \
+	"$observed_before"
+
+expect_import_failure "one content digest cannot bind a second connection" \
+	"$ARCHIVE" conn_duplicate_digest medium_user_42
+assert_eq "cross-connection digest rejection creates no second raw blob" \
+	"$(raw_count conn_duplicate_digest)" 0
+
+wrong_archive="${TMP_DIR}/wrong.zip"
+make_archive "$wrong_archive" minimal
+expect_import_failure "selected account mismatch fails before persistence" \
+	"$wrong_archive" conn_wrong another_user_99
+assert_eq "identity mismatch creates no raw Medium evidence" "$(raw_count conn_wrong)" 0
+
+credential_archive="${TMP_DIR}/credential.zip"
+make_archive "$credential_archive" credential
+credential_error="${TMP_DIR}/credential-error.txt"
+if "$HELPER" import-medium-archive --base "$BASE" --alias personal:default \
+	--archive "$credential_archive" --connection-id conn_credential \
+	--account-id medium_user_42 --username fixture \
+	--exported-at 2026-07-28T08:00:00Z >/dev/null 2>"$credential_error"; then
+	credential_result=accepted
+else
+	credential_result=rejected
+fi
+assert_eq "credential-shaped HTML is rejected before persistence" "$credential_result" rejected
+if [[ $(<"$credential_error") == *"must-not-persist"* ]]; then
+	assert_eq "credential rejection diagnostics are sanitized" leaked sanitized
+else
+	assert_eq "credential rejection diagnostics are sanitized" sanitized sanitized
+fi
+assert_eq "credential rejection creates no raw evidence" "$(raw_count conn_credential)" 0
+
+malformed_archive="${TMP_DIR}/malformed.zip"
+make_archive "$malformed_archive" malformed
+cursor_before=$(sql_value "SELECT watermark FROM sync_cursors WHERE connection_id='conn_medium' AND stream='archive'")
+expect_import_failure "malformed category HTML is terminal before persistence" \
+	"$malformed_archive" conn_malformed medium_user_42
+assert_eq "malformed import preserves the prior successful checkpoint" \
+	"$(sql_value "SELECT watermark FROM sync_cursors WHERE connection_id='conn_medium' AND stream='archive'")" "$cursor_before"
+assert_eq "malformed import creates no raw evidence" "$(raw_count conn_malformed)" 0
+
+malformed_bookmarks="${TMP_DIR}/malformed-bookmarks.zip"
+make_archive "$malformed_bookmarks" malformed-bookmarks
+expect_import_failure "recognized categories cannot claim complete after schema drift" \
+	"$malformed_bookmarks" conn_malformed_bookmarks medium_user_42
+assert_eq "unparseable category markers create no raw evidence" \
+	"$(raw_count conn_malformed_bookmarks)" 0
+
+malformed_highlights="${TMP_DIR}/malformed-highlights.zip"
+make_archive "$malformed_highlights" malformed-highlights
+expect_import_failure "empty highlight markers cannot claim complete coverage" \
+	"$malformed_highlights" conn_malformed_highlights medium_user_42
+assert_eq "empty highlight selections create no raw evidence" \
+	"$(raw_count conn_malformed_highlights)" 0
+
+traversal_archive="${TMP_DIR}/traversal.zip"
+make_archive "$traversal_archive" traversal
+expect_import_failure "ZIP traversal members fail closed" \
+	"$traversal_archive" conn_traversal medium_user_42
+assert_eq "unsafe ZIP members create no raw evidence" "$(raw_count conn_traversal)" 0
+
+symlink_archive="${TMP_DIR}/archive-link.zip"
+ln -s "$ARCHIVE" "$symlink_archive"
+expect_import_failure "input archive symlinks fail closed" \
+	"$symlink_archive" conn_input_symlink medium_user_42
+
+duplicate_archive="${TMP_DIR}/duplicate.zip"
+make_archive "$duplicate_archive" duplicate
+expect_import_failure "case-folded duplicate ZIP paths fail closed" \
+	"$duplicate_archive" conn_duplicate medium_user_42
+
+member_symlink_archive="${TMP_DIR}/member-symlink.zip"
+make_archive "$member_symlink_archive" member-symlink
+expect_import_failure "ZIP member symlinks fail closed" \
+	"$member_symlink_archive" conn_member_symlink medium_user_42
+
+encrypted_archive="${TMP_DIR}/encrypted.zip"
+make_archive "$encrypted_archive" encrypted
+expect_import_failure "encrypted ZIP members fail closed before parsing" \
+	"$encrypted_archive" conn_encrypted medium_user_42
+
+oversized_member_archive="${TMP_DIR}/oversized-member.zip"
+make_archive "$oversized_member_archive" oversized-member
+expect_import_failure "the per-member expansion ceiling fails closed" \
+	"$oversized_member_archive" conn_oversized_member medium_user_42
+assert_eq "encrypted and oversized members create no raw evidence" \
+	"$(($(raw_count conn_encrypted) + $(raw_count conn_oversized_member)))" 0
+
+deep_archive="${TMP_DIR}/deep.zip"
+make_archive "$deep_archive" deep
+deep_error="${TMP_DIR}/deep-error.txt"
+if "$HELPER" import-medium-archive --base "$BASE" --alias personal:default \
+	--archive "$deep_archive" --connection-id conn_deep --account-id medium_user_42 \
+	--username fixture --exported-at 2026-07-28T08:00:00Z \
+	>/dev/null 2>"$deep_error"; then
+	deep_result=accepted
+else
+	deep_result=rejected
+fi
+assert_eq "pathological HTML depth fails as a bounded validation error" \
+	"$deep_result" rejected
+if [[ $(<"$deep_error") == *"Traceback"* ]]; then
+	assert_eq "deep HTML diagnostics contain no traceback or local paths" leaked sanitized
+else
+	assert_eq "deep HTML diagnostics contain no traceback or local paths" sanitized sanitized
+fi
+
+expect_import_failure "member and normalized item budget stops before persistence" \
+	"$ARCHIVE" conn_item_budget medium_user_42 --max-items 3
+expect_import_failure "compressed byte budget stops before persistence" \
+	"$ARCHIVE" conn_byte_budget medium_user_42 --max-bytes 128
+expansion_archive="${TMP_DIR}/expansion.zip"
+make_archive "$expansion_archive" expansion
+expect_import_failure "aggregate uncompressed ZIP growth stops before persistence" \
+	"$expansion_archive" conn_expansion_budget medium_user_42 --max-bytes 4096
+assert_eq "budget stops create no raw evidence" \
+	"$(($(raw_count conn_item_budget) + $(raw_count conn_byte_budget) + $(raw_count conn_expansion_budget)))" 0
+
+other_archive="${TMP_DIR}/other-account.zip"
+make_archive "$other_archive" other-account
+raw_before_rebind=$(raw_count conn_medium)
+fetch_before_rebind=$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='medium' AND connection_id='conn_medium'")
+expect_import_failure "connection rebinding is rejected under the final fence" \
+	"$other_archive" conn_medium medium_other_99 --username fixture
+assert_eq "account rebinding writes no raw evidence or fetch batch" \
+	"$(raw_count conn_medium):$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='medium' AND connection_id='conn_medium'")" \
+	"${raw_before_rebind}:${fetch_before_rebind}"
+
+python3 - "$ROOT" "$ARCHIVE" "$SCRIPT_DIR/../scripts" "$expansion_archive" <<'PY'
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[3])
+import _knowledge_social_medium as medium
+from _knowledge_social_lease import (
+    RunLeaseRequest,
+    SocialLeaseLostError,
+    acquire_run_lease,
+    release_run_lease,
+)
+from _knowledge_social_medium import parse_medium_archive, persist_medium_archive
+
+root = Path(sys.argv[1])
+parsed, payload = parse_medium_archive(
+    Path(sys.argv[2]),
+    "conn_medium_stale",
+    "medium_user_42",
+    "fixture",
+    "2026-07-28T08:00:00Z",
+    512 * 1024 * 1024,
+    50_000,
+)
+old = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_medium_stale", "archive", "old_runner", "sync", 1),
+    now_epoch=9000,
+)
+new = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_medium_stale", "archive", "new_runner", "sync", 10),
+    now_epoch=9001,
+)
+os.environ["AIDEVOPS_SOCIAL_NOW_EPOCH"] = "9001"
+try:
+    persist_medium_archive(root, parsed, payload, old)
+except SocialLeaseLostError:
+    pass
+else:
+    raise SystemExit("stale Medium archive lease advanced persistence")
+with sqlite3.connect(root / "index" / "social.db") as database:
+    count = database.execute(
+        "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_medium_stale'"
+    ).fetchone()[0]
+assert count == 0
+release_run_lease(root, new)
+
+expiring_parsed, expiring_payload = parse_medium_archive(
+    Path(sys.argv[4]),
+    "conn_medium_expiring",
+    "medium_user_42",
+    "fixture",
+    "2026-07-28T08:00:00Z",
+    512 * 1024 * 1024,
+    50_000,
+)
+expiring = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_medium_expiring", "archive", "expiring_runner", "sync", 1),
+    now_epoch=9100,
+)
+os.environ["AIDEVOPS_SOCIAL_NOW_EPOCH"] = "9100"
+original_update = medium.update_run_receipt
+
+
+def expire_before_receipt(database, lease, update):
+    os.environ["AIDEVOPS_SOCIAL_NOW_EPOCH"] = "9101"
+    return original_update(database, lease, update)
+
+
+medium.update_run_receipt = expire_before_receipt
+try:
+    medium.persist_medium_archive(root, expiring_parsed, expiring_payload, expiring)
+except SocialLeaseLostError:
+    pass
+else:
+    raise SystemExit("expired Medium archive lease advanced persistence")
+finally:
+    medium.update_run_receipt = original_update
+with sqlite3.connect(root / "index" / "social.db") as database:
+    count = database.execute(
+        "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_medium_expiring'"
+    ).fetchone()[0]
+assert count == 0
+release_run_lease(root, expiring)
+PY
+assert_eq "stale archive lease cannot commit evidence or a replay checkpoint" \
+	"$(raw_count conn_medium_stale):$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_medium_stale'")" 0:0
+assert_eq "lease expiry after raw staging rolls back the blob and database rows" \
+	"$(raw_count conn_medium_expiring):$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_medium_expiring'")" 0:0
+
+assert_eq "profile email and security state never enter normalized provider rows" \
+	"$(sql_value "SELECT count(*) FROM accounts WHERE provider='medium' AND provider_json LIKE '%example.invalid%'")" 0
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -ne 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add an identity-verified, export-first Medium HTML ZIP importer with bounded safe parsing, immutable content-addressed evidence, fenced replay semantics, explicit coverage gaps, CLI wiring, and operator documentation.

## Files Changed

.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md, .agents/content/social-medium.md, .agents/scripts/_knowledge_social_medium.py, .agents/scripts/_knowledge_social_medium_html.py, .agents/scripts/knowledge-social-helper.sh, .agents/scripts/knowledge_social_medium.py, .agents/tests/fixtures/medium-archive-fixture.py, .agents/tests/test-knowledge-social-medium.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: focused Medium suite passed 56 checks; social store/sync/query/browser/sharing/operations and X/Reddit/YouTube/LinkedIn/Meta regressions passed; Python compileall, ShellCheck, and .agents/scripts/linters-local.sh --changed passed.

Resolves #28670


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 1h 5m and 406,427 tokens on this as a headless worker.