### PR TITLE
GH#28791: eliminate per-line task block grep

### DIFF
--- a/.agents/scripts/issue-sync-lib-parse.sh
+++ b/.agents/scripts/issue-sync-lib-parse.sh
@@ -355,22 +355,28 @@ parse_task_line() {
 extract_task_block() {
 	local task_id="$1"
 	local todo_file="$2"
-	local task_id_ere=""
-	task_id_ere=$(task_identity_escape_ere "$task_id") || return 1
+	local task_line_ere='^[[:space:]]*- \[.\] ([^[:space:]]+) '
+	local list_item_ere='^[[:space:]]*- '
+	local candidate_task_id=""
+	task_identity_validate "$task_id" || return 1
 
 	local in_block=false
 	local block=""
 	local task_indent=-1
 
 	while IFS= read -r line; do
-		# Check if this is the target task line
-		if [[ "$in_block" == "false" ]] && echo "$line" | grep -qE "^[[:space:]]*- \[.\] ${task_id_ere} "; then
-			in_block=true
-			block="$line"
-			# Calculate indent level using pure bash (avoids subshells in loop)
-			local prefix="${line%%[! ]*}"
-			task_indent=${#prefix}
-			continue
+		# Capture the checkbox-position token in pure Bash, then compare the
+		# validated canonical ID literally. Avoid external processes in this hot loop.
+		if [[ "$in_block" == "false" ]] && [[ "$line" =~ $task_line_ere ]]; then
+			candidate_task_id="${BASH_REMATCH[1]}"
+			if [[ "$candidate_task_id" == "$task_id" ]]; then
+				in_block=true
+				block="$line"
+				# Calculate indent level using pure bash (avoids subshells in loop)
+				local prefix="${line%%[! ]*}"
+				task_indent=${#prefix}
+				continue
+			fi
 		fi
 
 		if [[ "$in_block" == "true" ]]; then
@@ -390,7 +396,7 @@ extract_task_block() {
 			fi
 
 			# If indent is <= task indent and it's not a subtask/notes line, we're done
-			if [[ $current_indent -le $task_indent ]] && ! echo "$line" | grep -qE '^\s*- '; then
+			if [[ $current_indent -le $task_indent ]] && [[ ! "$line" =~ $list_item_ere ]]; then
 				break
 			fi
 

--- a/.agents/scripts/test-issue-sync-lib.sh
+++ b/.agents/scripts/test-issue-sync-lib.sh
@@ -434,6 +434,93 @@ else
 	pass "parse_task_line: multiple parent declarations fail closed"
 fi
 
+# -----------------------------------------------------------------------------
+# extract_task_block behavior and large-file process regression (GH#28791)
+# -----------------------------------------------------------------------------
+cat >"$TMP/todo-extract.md" <<EOF
+- [ ] t7 open parent
+  - [x] t7.1 completed child
+    - Notes: nested child evidence
+  - Notes: parent evidence
+- [x] ${NAMESPACED_ID} completed namespaced parent
+  - Notes: namespaced evidence
+- [-] t9 declined task
+## Boundary
+EOF
+
+expected_t7=$(cat <<'EOF'
+- [ ] t7 open parent
+  - [x] t7.1 completed child
+    - Notes: nested child evidence
+  - Notes: parent evidence
+EOF
+)
+actual_t7=$(extract_task_block "t7" "$TMP/todo-extract.md")
+if [[ "$actual_t7" == "$expected_t7" ]]; then
+	pass "extract_task_block: preserves nested subtasks and notes exactly"
+else
+	fail "extract_task_block: changed nested block output"
+fi
+
+expected_namespaced=$(cat <<EOF
+- [x] ${NAMESPACED_ID} completed namespaced parent
+  - Notes: namespaced evidence
+EOF
+)
+actual_namespaced=$(extract_task_block "$NAMESPACED_ID" "$TMP/todo-extract.md")
+if [[ "$actual_namespaced" == "$expected_namespaced" ]]; then
+	pass "extract_task_block: matches completed origin-namespaced IDs literally"
+else
+	fail "extract_task_block: failed origin-namespaced lookup"
+fi
+
+if [[ "$(extract_task_block "t9" "$TMP/todo-extract.md")" == "- [-] t9 declined task" ]]; then
+	pass "extract_task_block: preserves declined task status and heading boundary"
+else
+	fail "extract_task_block: changed declined task or heading boundary behavior"
+fi
+
+if [[ -z "$(extract_task_block "t8" "$TMP/todo-extract.md")" ]]; then
+	pass "extract_task_block: missing canonical ID returns an empty block"
+else
+	fail "extract_task_block: missing canonical ID returned content"
+fi
+
+if extract_task_block "t01" "$TMP/todo-extract.md" >/dev/null 2>&1; then
+	fail "extract_task_block: accepted malformed task ID"
+else
+	pass "extract_task_block: malformed task ID fails closed"
+fi
+
+large_todo="$TMP/todo-extract-large.md"
+{
+	i=1
+	while [[ $i -le 4500 ]]; do
+		printf -- '- [ ] t%d generated task %d\n' "$i" "$i"
+		i=$((i + 1))
+	done
+} >"$large_todo"
+
+GREP_CALL_LOG="$TMP/extract-task-block-grep-calls.log"
+export GREP_CALL_LOG
+grep() {
+	local grep_status=0
+	printf 'grep called\n' >>"$GREP_CALL_LOG"
+	command grep "$@" || grep_status=$?
+	return "$grep_status"
+}
+export -f grep
+extract_started=$SECONDS
+large_result=$(extract_task_block "t4500" "$large_todo")
+extract_elapsed=$((SECONDS - extract_started))
+unset -f grep
+
+if [[ "$large_result" == "- [ ] t4500 generated task 4500" && ! -s "$GREP_CALL_LOG" && $extract_elapsed -lt 5 ]]; then
+	pass "extract_task_block: late lookup avoids per-line grep processes"
+else
+	fail "extract_task_block: late lookup output/process/time regression (elapsed=${extract_elapsed}s)"
+fi
+
 mkdir -p "$TMP/project/todo"
 cat >"$TMP/project/todo/PLANS.md" <<'EOF'
 ### Root plan

--- a/.agents/scripts/test-issue-sync-lib.sh
+++ b/.agents/scripts/test-issue-sync-lib.sh
@@ -448,13 +448,7 @@ cat >"$TMP/todo-extract.md" <<EOF
 ## Boundary
 EOF
 
-expected_t7=$(cat <<'EOF'
-- [ ] t7 open parent
-  - [x] t7.1 completed child
-    - Notes: nested child evidence
-  - Notes: parent evidence
-EOF
-)
+expected_t7=$'- [ ] t7 open parent\n  - [x] t7.1 completed child\n    - Notes: nested child evidence\n  - Notes: parent evidence'
 actual_t7=$(extract_task_block "t7" "$TMP/todo-extract.md")
 if [[ "$actual_t7" == "$expected_t7" ]]; then
 	pass "extract_task_block: preserves nested subtasks and notes exactly"
@@ -462,11 +456,7 @@ else
 	fail "extract_task_block: changed nested block output"
 fi
 
-expected_namespaced=$(cat <<EOF
-- [x] ${NAMESPACED_ID} completed namespaced parent
-  - Notes: namespaced evidence
-EOF
-)
+expected_namespaced="- [x] ${NAMESPACED_ID} completed namespaced parent"$'\n'"  - Notes: namespaced evidence"
 actual_namespaced=$(extract_task_block "$NAMESPACED_ID" "$TMP/todo-extract.md")
 if [[ "$actual_namespaced" == "$expected_namespaced" ]]; then
 	pass "extract_task_block: matches completed origin-namespaced IDs literally"


### PR DESCRIPTION
## Summary

Replace per-line external task lookup with pure-Bash canonical-ID matching and add exact behavior plus large-file regression coverage.

## Files Changed

.agents/scripts/issue-sync-lib-parse.sh, .agents/scripts/test-issue-sync-lib.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 29 issue-sync library tests pass on modern Bash and macOS Bash 3.2; 17 completion-evidence, 27 held-body, 11 close-signature, and 83 task-identity assertions pass; ShellCheck, shfmt, bash32 regression, and linters-local pass.

Resolves #28791


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 19m and 235,784 tokens on this with the user in an interactive session.