### PR TITLE
GH#28777: Isolate prospective merge-tree validation

### DIFF
--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -503,44 +503,79 @@ _merge_fetch_pinned_commit_objects() {
 	local head_sha="$4"
 	local object_repo="${5:-}"
 	local remote_url="${6:-}"
+	local real_git="${7:-}"
 	local fetched_sha=""
-	local -a git_context=()
-	[[ -n "$object_repo" ]] && git_context=(-C "$object_repo")
-
-	if ! git "${git_context[@]}" cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
-		if [[ -n "$object_repo" ]]; then
-			[[ -n "$remote_url" ]] || return 1
-			git -C "$object_repo" fetch --quiet --no-tags "$remote_url" "refs/heads/${base_ref}" || return 1
-			fetched_sha=$(git -C "$object_repo" rev-parse FETCH_HEAD 2>/dev/null) || return 1
-			[[ "$fetched_sha" == "$base_sha" ]] || return 1
-		else
+	if [[ -z "$object_repo" ]]; then
+		git cat-file -e "${base_sha}^{commit}" 2>/dev/null ||
 			git fetch --quiet --no-tags origin "refs/heads/${base_ref}" || return 1
-		fi
-	fi
-	if ! git "${git_context[@]}" cat-file -e "${head_sha}^{commit}" 2>/dev/null; then
-		if [[ -n "$object_repo" ]]; then
-			[[ -n "$remote_url" ]] || return 1
-			git -C "$object_repo" fetch --quiet --no-tags "$remote_url" "refs/pull/${pr_number}/head" || return 1
-			fetched_sha=$(git -C "$object_repo" rev-parse FETCH_HEAD 2>/dev/null) || return 1
-			[[ "$fetched_sha" == "$head_sha" ]] || return 1
-		else
+		git cat-file -e "${head_sha}^{commit}" 2>/dev/null ||
 			git fetch --quiet --no-tags origin "refs/pull/${pr_number}/head" || return 1
-		fi
+		git cat-file -e "${base_sha}^{commit}" 2>/dev/null || return 1
+		git cat-file -e "${head_sha}^{commit}" 2>/dev/null || return 1
+		return 0
 	fi
-	git "${git_context[@]}" cat-file -e "${base_sha}^{commit}" 2>/dev/null || return 1
-	git "${git_context[@]}" cat-file -e "${head_sha}^{commit}" 2>/dev/null || return 1
+
+	[[ -x "$real_git" ]] || return 1
+	if ! _merge_run_repository_isolated_git "$real_git" -C "$object_repo" cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+		[[ -n "$remote_url" ]] || return 1
+		_merge_run_repository_isolated_git "$real_git" -C "$object_repo" \
+			fetch --quiet --no-tags "$remote_url" "refs/heads/${base_ref}" || return 1
+		fetched_sha=$(_merge_run_repository_isolated_git "$real_git" -C "$object_repo" \
+			rev-parse FETCH_HEAD 2>/dev/null) || return 1
+		[[ "$fetched_sha" == "$base_sha" ]] || return 1
+	fi
+	if ! _merge_run_repository_isolated_git "$real_git" -C "$object_repo" cat-file -e "${head_sha}^{commit}" 2>/dev/null; then
+		[[ -n "$remote_url" ]] || return 1
+		_merge_run_repository_isolated_git "$real_git" -C "$object_repo" \
+			fetch --quiet --no-tags "$remote_url" "refs/pull/${pr_number}/head" || return 1
+		fetched_sha=$(_merge_run_repository_isolated_git "$real_git" -C "$object_repo" \
+			rev-parse FETCH_HEAD 2>/dev/null) || return 1
+		[[ "$fetched_sha" == "$head_sha" ]] || return 1
+	fi
+	_merge_run_repository_isolated_git "$real_git" -C "$object_repo" \
+		cat-file -e "${base_sha}^{commit}" 2>/dev/null || return 1
+	_merge_run_repository_isolated_git "$real_git" -C "$object_repo" \
+		cat-file -e "${head_sha}^{commit}" 2>/dev/null || return 1
 	return 0
 }
 
+_merge_run_repository_isolated_git() (
+	local git_bin="$1"
+	shift
+	unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_ATTR_SOURCE GIT_COMMON_DIR GIT_DIR
+	unset GIT_EXEC_PATH GIT_GRAFT_FILE GIT_INDEX_FILE GIT_NAMESPACE
+	unset GIT_OBJECT_DIRECTORY GIT_QUARANTINE_PATH GIT_REPLACE_REF_BASE
+	unset GIT_SHALLOW_FILE GIT_WORK_TREE
+	"$git_bin" "$@"
+	return $?
+)
+
+_merge_run_config_isolated_git() (
+	local real_git="$1"
+	local config_root="$2"
+	shift 2
+	unset GIT_CONFIG GIT_CONFIG_COUNT GIT_CONFIG_GLOBAL GIT_CONFIG_PARAMETERS GIT_CONFIG_SYSTEM
+	export HOME="${config_root}/home" XDG_CONFIG_HOME="${config_root}/xdg"
+	export GIT_CONFIG_NOSYSTEM=1 GIT_ATTR_NOSYSTEM=1
+	_merge_run_repository_isolated_git "$real_git" "$@"
+	return $?
+)
+
 _merge_create_prospective_object_context() {
 	local context_root="$1"
+	local real_git="$2"
 	local object_repo="${context_root}/repository.git"
 	local source_objects=""
 	local object_format=""
-	source_objects=$(git rev-parse --path-format=absolute --git-path objects 2>/dev/null) || return 1
-	object_format=$(git rev-parse --show-object-format 2>/dev/null || true)
+	[[ -x "$real_git" ]] || return 1
+	mkdir -p "${context_root}/home" "${context_root}/xdg" || return 1
+	source_objects=$(_merge_run_config_isolated_git git "$context_root" \
+		rev-parse --path-format=absolute --git-path objects 2>/dev/null) || return 1
+	object_format=$(_merge_run_config_isolated_git git "$context_root" \
+		rev-parse --show-object-format 2>/dev/null || true)
 	[[ -n "$source_objects" && -n "$object_format" ]] || return 1
-	git -C "$context_root" init --bare --quiet --object-format="$object_format" repository.git || return 1
+	_merge_run_config_isolated_git "$real_git" "$context_root" -c init.templateDir= \
+		-C "$context_root" init --bare --quiet --object-format="$object_format" repository.git || return 1
 	[[ -d "${object_repo}/objects/info" ]] || return 1
 	printf '%s\n' "$source_objects" >"${object_repo}/objects/info/alternates" || return 1
 	printf '%s\n' "$object_repo"
@@ -558,9 +593,11 @@ _merge_guard_prospective_todo() (
 	local head_sha=""
 	local merge_tree_output=""
 	local merge_tree_sha=""
+	local temp_root=""
 	local temp_dir=""
 	local object_repo=""
 	local remote_url=""
+	local real_git="${AIDEVOPS_REAL_GIT_BIN:-/usr/bin/git}"
 	local report=""
 	local report_rc="0"
 
@@ -577,43 +614,67 @@ _merge_guard_prospective_todo() (
 		print_error "Merge blocked: PR head changed before prospective TODO validation"
 		return 1
 	fi
-	temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-prospective-todo.XXXXXX") || {
+	if [[ -n "${AIDEVOPS_TEMP_DIR:-}" ]]; then
+		temp_root="$AIDEVOPS_TEMP_DIR"
+	elif [[ -n "${HOME:-}" ]]; then
+		temp_root="${HOME}/.aidevops/.agent-workspace/tmp"
+	else
+		print_error "Merge blocked: no approved temporary root is available"
+		return 1
+	fi
+	[[ -x "$real_git" ]] || {
+		print_error "Merge blocked: native Git executable is unavailable"
+		return 1
+	}
+	mkdir -p "$temp_root" || {
+		print_error "Merge blocked: unable to prepare approved temporary root"
+		return 1
+	}
+	temp_dir=$(mktemp -d "${temp_root%/}/aidevops-prospective-todo.XXXXXX") || {
 		print_error "Merge blocked: unable to create isolated prospective Git context"
 		return 1
 	}
 	trap 'rm -rf "$temp_dir"' EXIT HUP INT TERM
-	object_repo=$(_merge_create_prospective_object_context "$temp_dir") || {
+	object_repo=$(_merge_create_prospective_object_context "$temp_dir" "$real_git") || {
 		print_error "Merge blocked: unable to initialize isolated prospective Git context"
 		return 1
 	}
-	remote_url=$(git remote get-url origin 2>/dev/null || true)
-	_merge_fetch_pinned_commit_objects "$pr_number" "$base_ref" "$base_sha" "$head_sha" "$object_repo" "$remote_url" || {
+	remote_url=$(_merge_run_config_isolated_git git "$temp_dir" remote get-url origin 2>/dev/null || true)
+	_merge_fetch_pinned_commit_objects "$pr_number" "$base_ref" "$base_sha" "$head_sha" \
+		"$object_repo" "$remote_url" "$real_git" || {
 		print_error "Merge blocked: unable to materialize pinned PR commits for prospective TODO validation"
 		return 1
 	}
 
-	if ! merge_tree_output=$(git -C "$object_repo" merge-tree --write-tree "$base_sha" "$head_sha" 2>&1); then
+	if ! merge_tree_output=$(_merge_run_config_isolated_git "$real_git" "$temp_dir" \
+		-C "$object_repo" -c core.attributesFile=/dev/null \
+		merge-tree --write-tree "$base_sha" "$head_sha" 2>&1); then
 		print_error "Merge blocked: prospective merge-tree evidence is indeterminate"
 		printf '%s\n' "$merge_tree_output" >&2
 		return 1
 	fi
 	merge_tree_sha=$(printf '%s\n' "$merge_tree_output" | sed -n '1p')
-	if ! [[ "$merge_tree_sha" =~ ^[0-9a-fA-F]{40,64}$ ]] || \
-		! git -C "$object_repo" cat-file -e "${merge_tree_sha}^{tree}" 2>/dev/null; then
+	if ! [[ "$merge_tree_sha" =~ ^[0-9a-fA-F]{40,64}$ ]] ||
+		! _merge_run_config_isolated_git "$real_git" "$temp_dir" -C "$object_repo" \
+			cat-file -e "${merge_tree_sha}^{tree}" 2>/dev/null; then
 		print_error "Merge blocked: prospective merge-tree did not produce a verifiable tree"
 		return 1
 	fi
 
 	# Repositories without TODO.md have no task mapping surface to validate.
-	if ! git -C "$object_repo" cat-file -e "${merge_tree_sha}:TODO.md" 2>/dev/null; then
+	if ! _merge_run_config_isolated_git "$real_git" "$temp_dir" -C "$object_repo" \
+		cat-file -e "${merge_tree_sha}:TODO.md" 2>/dev/null; then
 		return 0
 	fi
-	if ! git -C "$object_repo" show "${merge_tree_sha}:TODO.md" >"${temp_dir}/merged"; then
+	if ! _merge_run_config_isolated_git "$real_git" "$temp_dir" -C "$object_repo" \
+		show "${merge_tree_sha}:TODO.md" >"${temp_dir}/merged"; then
 		print_error "Merge blocked: unable to read prospective TODO evidence"
 		return 1
 	fi
-	if git -C "$object_repo" cat-file -e "${base_sha}:TODO.md" 2>/dev/null; then
-		if ! git -C "$object_repo" show "${base_sha}:TODO.md" >"${temp_dir}/base"; then
+	if _merge_run_config_isolated_git "$real_git" "$temp_dir" -C "$object_repo" \
+		cat-file -e "${base_sha}:TODO.md" 2>/dev/null; then
+		if ! _merge_run_config_isolated_git "$real_git" "$temp_dir" -C "$object_repo" \
+			show "${base_sha}:TODO.md" >"${temp_dir}/base"; then
 			print_error "Merge blocked: unable to read base TODO evidence"
 			return 1
 		fi

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -1144,11 +1144,23 @@ run_prospective_todo_guard() {
 	local scripts_dir="${SCRIPT_DIR}/.."
 	local tmp_runner=""
 	local verification_tmp="${fixture_dir}/verification-tmp"
+	local attacker_home="${fixture_dir}/attacker-home"
+	local driver_script="${fixture_dir}/merge-driver.sh"
+	local driver_marker="${fixture_dir}/merge-driver-ran"
+	local hostile_objects="${fixture_dir}/hostile-objects"
+	local hostile_alternates="${fixture_dir}/hostile-alternates"
+	local hostile_index="${fixture_dir}/hostile-index"
 	local fetch_override=""
 	if [[ "$fetch_mode" == "stub" ]]; then
 		fetch_override='_merge_fetch_pinned_commit_objects() { return 0; }'
 	fi
-	mkdir -p "$verification_tmp"
+	mkdir -p "$verification_tmp" "$attacker_home" "$hostile_objects" "$hostile_alternates"
+	# shellcheck disable=SC2016  # The generated driver expands this at execution time.
+	printf '%s\n' '#!/usr/bin/env bash' ': >"${AIDEVOPS_TEST_MERGE_DRIVER_MARKER:?}"' 'exit 1' >"$driver_script"
+	chmod +x "$driver_script"
+	HOME="$attacker_home" /usr/bin/git config --global merge.aidevops-test.driver \
+		"${driver_script} %O %A %B"
+	rm -f "$driver_marker"
 	tmp_runner=$(mktemp)
 	cat >"$tmp_runner" <<RUNNER_EOF
 #!/usr/bin/env bash
@@ -1163,7 +1175,12 @@ _merge_guard_prospective_todo '42' 'testorg/testrepo'
 RUNNER_EOF
 	chmod +x "$tmp_runner"
 	local rc=0
-	env PATH="${TEST_ROOT}/bin:/usr/bin:/bin:${scripts_dir}:${PATH}" TMPDIR="$verification_tmp" \
+	env PATH="${TEST_ROOT}/bin:${scripts_dir}:/usr/bin:/bin:${PATH}" \
+		HOME="$attacker_home" AIDEVOPS_TEMP_DIR="$verification_tmp" \
+		AIDEVOPS_REAL_GIT_BIN=/usr/bin/git AIDEVOPS_TEST_MERGE_DRIVER_MARKER="$driver_marker" \
+		GIT_ALTERNATE_OBJECT_DIRECTORIES="$hostile_alternates" \
+		GIT_ATTR_SOURCE=refs/heads/aidevops-hostile GIT_INDEX_FILE="$hostile_index" \
+		GIT_OBJECT_DIRECTORY="$hostile_objects" \
 		bash "$tmp_runner" 2>&1 || rc=$?
 	rm -f "$tmp_runner"
 	[[ "$rc" -eq 0 ]] && return 0
@@ -1176,6 +1193,14 @@ prospective_contexts_clean() {
 	leftovers=$(compgen -G "${fixture_dir}/verification-tmp/aidevops-prospective-todo.*" || true)
 	[[ -z "$leftovers" ]]
 	return $?
+}
+
+prospective_hostile_git_environment_clean() {
+	local fixture_dir="$1"
+	[[ ! -e "${fixture_dir}/hostile-index" ]] || return 1
+	rmdir "${fixture_dir}/hostile-objects" 2>/dev/null || return 1
+	rmdir "${fixture_dir}/hostile-alternates" 2>/dev/null || return 1
+	return 0
 }
 
 prospective_git_storage_digest() {
@@ -1197,8 +1222,9 @@ create_prospective_fixture() {
 		/usr/bin/git config user.email test@test.local
 		/usr/bin/git config user.name Test
 		/usr/bin/git config commit.gpgsign false
+		printf 'TODO.md merge=aidevops-test\n' >.gitattributes
 		printf '## Base tasks\n- [ ] t1 Root ref:GH#1\n\n## Branch tasks\n' >TODO.md
-		/usr/bin/git add TODO.md
+		/usr/bin/git add .gitattributes TODO.md
 		/usr/bin/git commit -q -m root
 		local root_sha=""
 		root_sha=$(/usr/bin/git rev-parse HEAD)
@@ -1256,7 +1282,7 @@ create_prospective_fetch_fixture() {
 
 test_prospective_todo_merge_guard() {
 	local fixture_dir="" fixture_root="" base_sha="" head_sha="" output="" rc=0 objects_before="" objects_after=""
-	local cleanup_rc=0 isolation_rc=0 storage_before="" storage_after="" absent_before=0 absent_after=0
+	local cleanup_rc=0 environment_rc=0 isolation_rc=0 storage_before="" storage_after="" absent_before=0 absent_after=0
 	fixture_dir=$(create_prospective_fixture collision)
 	base_sha=$(<"${fixture_dir}/base.sha")
 	head_sha=$(<"${fixture_dir}/head.sha")
@@ -1264,13 +1290,18 @@ test_prospective_todo_merge_guard() {
 	output=$(run_prospective_todo_guard "$fixture_dir" "$base_sha" "$head_sha") || rc=$?
 	objects_after=$(/usr/bin/git -C "$fixture_dir" count-objects -v)
 	prospective_contexts_clean "$fixture_dir" || cleanup_rc=$?
+	prospective_hostile_git_environment_clean "$fixture_dir" || environment_rc=$?
 	[[ "$cleanup_rc" -eq 0 && "$objects_before" == "$objects_after" ]] || isolation_rc=1
 	print_result "prospective TODO: merge-only collision is blocked" "$((rc == 0 ? 1 : 0))" "output=$output"
 	print_result "prospective TODO: task and issue duplicates are reported" "$([[ "$output" == *"Duplicate task ID: t2"* && "$output" == *"Duplicate issue mapping: ref:GH#2"* ]] && printf '0' || printf '1')" "output=$output"
+	print_result "prospective TODO: configured external merge driver is not executed" \
+		"$([[ ! -e "${fixture_dir}/merge-driver-ran" ]] && printf '0' || printf '1')"
+	print_result "prospective TODO: hostile repository environment writes no external state" "$environment_rc"
 	print_result "prospective TODO: collision writes only to cleaned isolated context" "$isolation_rc"
 
 	rc=0
 	cleanup_rc=0
+	environment_rc=0
 	isolation_rc=0
 	fixture_dir=$(create_prospective_fixture unique)
 	base_sha=$(<"${fixture_dir}/base.sha")
@@ -1279,19 +1310,24 @@ test_prospective_todo_merge_guard() {
 	run_prospective_todo_guard "$fixture_dir" "$base_sha" "$head_sha" >/dev/null || rc=$?
 	objects_after=$(/usr/bin/git -C "$fixture_dir" count-objects -v)
 	prospective_contexts_clean "$fixture_dir" || cleanup_rc=$?
-	[[ "$cleanup_rc" -eq 0 && "$objects_before" == "$objects_after" ]] || isolation_rc=1
+	prospective_hostile_git_environment_clean "$fixture_dir" || environment_rc=$?
+	[[ "$cleanup_rc" -eq 0 && "$environment_rc" -eq 0 && "$objects_before" == "$objects_after" ]] || isolation_rc=1
 	print_result "prospective TODO: unique stale branch passes" "$rc"
 	print_result "prospective TODO: success writes only to cleaned isolated context" "$isolation_rc"
 
 	rc=0
 	cleanup_rc=0
+	environment_rc=0
 	output=$(run_prospective_todo_guard "$fixture_dir" deadbeef deadbeef) || rc=$?
 	print_result "prospective TODO: indeterminate merge-tree fails closed" "$((rc == 0 ? 1 : 0))" "output=$output"
 	prospective_contexts_clean "$fixture_dir" || cleanup_rc=$?
+	prospective_hostile_git_environment_clean "$fixture_dir" || environment_rc=$?
+	[[ "$environment_rc" -eq 0 ]] || cleanup_rc=1
 	print_result "prospective TODO: failure cleans isolated context" "$cleanup_rc"
 
 	rc=0
 	cleanup_rc=0
+	environment_rc=0
 	isolation_rc=0
 	fixture_dir=$(create_prospective_fetch_fixture) || return 0
 	fixture_root="${fixture_dir%/work}"
@@ -1303,7 +1339,9 @@ test_prospective_todo_merge_guard() {
 	storage_after=$(prospective_git_storage_digest "$fixture_dir")
 	if /usr/bin/git -C "$fixture_dir" cat-file -e "${head_sha}^{commit}" 2>/dev/null; then absent_after=1; fi
 	prospective_contexts_clean "$fixture_dir" || cleanup_rc=$?
-	[[ "$rc" -eq 0 && "$cleanup_rc" -eq 0 && "$absent_before" -eq 0 && "$absent_after" -eq 0 && \
+	prospective_hostile_git_environment_clean "$fixture_dir" || environment_rc=$?
+	[[ "$rc" -eq 0 && "$cleanup_rc" -eq 0 && "$environment_rc" -eq 0 && \
+		"$absent_before" -eq 0 && "$absent_after" -eq 0 && \
 		"$storage_before" == "$storage_after" ]] || isolation_rc=1
 	print_result "prospective TODO: missing PR objects fetch only into cleaned isolated context" "$isolation_rc"
 	return 0


### PR DESCRIPTION
## Summary

Run prospective merge-tree validation in a helper-owned bare repository through config- and repository-environment-isolated native Git while retaining the canonical guard for ordinary merge-tree calls.

## Files Changed

.agents/scripts/full-loop-helper-merge.sh, .agents/scripts/tests/test-full-loop-merge.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — test-full-loop-merge.sh: 72/72; test-canonical-git-command-guard.sh: 58/58; linters-local.sh and ShellCheck passed; independent closeout review passed.

Resolves #28777


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.5 spent 10d 22h and 38,636,339 tokens on this with the user in an interactive session.