### PR TITLE
GH#27777: Exclude local credential helper from API telemetry

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -690,6 +690,16 @@ _shim_block_headless_external_write_if_needed() {
 # -----------------------------------------------------------------------------
 _SHIM_READ_REWRITE=""
 case "${1:-}:${2:-}" in
+	auth:git-credential)
+		# The Git credential-helper protocol only reads local auth storage and
+		# exchanges key/value records over stdin/stdout. Counting it as GraphQL
+		# creates false unknown-quota attempts (GH#27777); preserve it byte-for-byte.
+		_real_gh="$(_find_real_gh)" || {
+			printf '[aidevops] gh shim: real gh binary not found on PATH\n' >&2
+			exit 127
+		}
+		exec "$_real_gh" "$@"
+		;;
 	issue:comment | issue:create | issue:edit | issue:close | issue:reopen | issue:lock | issue:pin | issue:delete | \
 	pr:create | pr:comment | pr:edit | pr:review | pr:merge | pr:close | pr:reopen | pr:ready | pr:lock | \
 	label:create | label:edit | label:delete | release:create | release:delete | release:upload) ;;

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -682,6 +682,11 @@ chmod +x "$SHIM_FIXTURE/gh"
 cat >"$NATIVE_FIXTURE/gh" <<'EOF_NATIVE_GH'
 #!/usr/bin/env bash
 printf '%s\n' "$@" >>"$NATIVE_ATTEMPT_LOG"
+if [[ "${1:-}:${2:-}" == "auth:git-credential" ]]; then
+	command cat >"$NATIVE_CREDENTIAL_INPUT"
+	printf 'username=fixture\npassword=fixture\n\n'
+	exit "${NATIVE_CREDENTIAL_STATUS:-0}"
+fi
 page=1
 jq_requested=0
 expect_jq=0
@@ -750,6 +755,43 @@ EOF_NATIVE_GH
 chmod +x "$NATIVE_FIXTURE/gh"
 export AIDEVOPS_GH_API_LOG="$TMPDIR/shim-attempts.log"
 export NATIVE_ATTEMPT_LOG="$TMPDIR/native-attempts.log"
+export NATIVE_CREDENTIAL_INPUT="$TMPDIR/native-credential-input"
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+
+# Git invokes `gh auth git-credential` as a local stdin/stdout credential
+# helper. It must remain byte-compatible without becoming a synthetic GraphQL
+# request or an unknown-quota attempt in transport evidence (GH#27777).
+credential_request="$TMPDIR/credential-request"
+credential_expected_output="$TMPDIR/credential-output.expected"
+credential_actual_output="$TMPDIR/credential-output.actual"
+printf 'protocol=https\nhost=github.com\n\n' >"$credential_request"
+printf 'username=fixture\npassword=fixture\n\n' >"$credential_expected_output"
+PATH="$NATIVE_FIXTURE:/usr/bin:/bin" \
+	"$SHIM_FIXTURE/gh" auth git-credential get \
+	<"$credential_request" >"$credential_actual_output"
+credential_input_status=0
+cmp -s "$credential_request" "$NATIVE_CREDENTIAL_INPUT" || credential_input_status=$?
+assert_eq "local credential helper preserves stdin bytes" "0" "$credential_input_status"
+credential_output_status=0
+cmp -s "$credential_expected_output" "$credential_actual_output" || credential_output_status=$?
+assert_eq "local credential helper preserves stdout bytes" "0" "$credential_output_status"
+assert_eq "local credential helper invokes native gh once" "1" "$(grep -c '^auth$' "$NATIVE_ATTEMPT_LOG")"
+assert_path_absent "local credential helper emits no API telemetry" "$AIDEVOPS_GH_API_LOG"
+credential_failure_status=0
+set +e
+PATH="$NATIVE_FIXTURE:/usr/bin:/bin" NATIVE_CREDENTIAL_STATUS=17 \
+	"$SHIM_FIXTURE/gh" auth git-credential get <"$credential_request" >/dev/null
+credential_failure_status=$?
+set -e
+assert_eq "local credential helper preserves native failure status" "17" "$credential_failure_status"
+
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+PATH="$NATIVE_FIXTURE:/usr/bin:/bin" \
+	"$SHIM_FIXTURE/gh" auth git-credential-extra get >/dev/null
+assert_file_exists "near-match auth command retains API telemetry" "$AIDEVOPS_GH_API_LOG"
+assert_eq "near-match auth command retains one transport attempt" "1" \
+	"$(awk -F'\t' '$9 == "attempt" { count++ } END { print count + 0 }' "$AIDEVOPS_GH_API_LOG")"
+
 rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
 PATH="$NATIVE_FIXTURE:/usr/bin:/bin" AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
 	"$SHIM_FIXTURE/gh" api '/repos/private-owner/private-repo/issues?page=2&token=private-value' >/dev/null


### PR DESCRIPTION
For #27777

## Summary

- bypass API instrumentation only for the exact `gh auth git-credential` local credential-helper command
- preserve arguments, stdin/stdout bytes, native exit status, and signal behavior by executing native `gh` directly
- cover exact success/failure behavior and prove a near-match command remains instrumented

## Implementation context

- `.agents/scripts/gh`: exact local-operation bypass before generic API classification
- `.agents/scripts/tests/test-gh-api-instrument.sh`: byte-preservation, status, invocation-count, no-telemetry, and near-match regressions

## Verification

- `test-gh-api-instrument.sh`: 202 passed, 0 failed
- `test-gh-shim.sh`: 91/91; native resolution: 7/7; REST fallback: 85/85
- repository auth-sync coverage, ShellCheck, `git diff --check`, and `.agents/scripts/linters-local.sh --full`: passed
- final review evidence bundle: `0f85c797cd4135e6a50a78c56459bd94ad5f32fe3accc64296103073e03c25a5`

## Runtime Testing

- Risk: Critical because this path mediates Git credential-helper traffic
- Level: runtime-verified with an isolated native-`gh` fixture that exercises real process execution, exact stdin/stdout bytes, native status 17, and telemetry absence

## Decisions and rollout

- match only the first two arguments; trailing credential protocol operations such as `get` pass through unchanged
- keep #27777 open for the fresh 360-second smoke and matched baseline/canary evidence
- no release is requested; deploy the merged source locally before collecting post-fix evidence

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.5 spent 10d 23h and 39,888,215 tokens on this with the user in an interactive session.