### PR TITLE
GH#28673: Add multi-instance Discourse account knowledge ingestion

### DIFF
--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -40,7 +40,7 @@ a claim that the route is enabled.
 | Medium | **Live/Export** authored posts; **Live/Partial** explicit responses | **Live/Export/No** bookmarks, claps, highlights, and list membership when present | **No** | **Live/Export/No** publication membership and follows when present | **Live/Export/No** owned lists when present | Identity-verified native HTML ZIP import with exact replay, bounded local parsing, and per-archive complete/unavailable coverage; legacy API access is not live parity. |
 | Quora | **Export/No** answers, questions, posts, and comments | **Export/No** bookmarks; **No** upvotes and other curation | **No** | **Export/No** user follows; **No** followed topics or Spaces | **No** | The official export has no published schema. Public content samples lack authoritative owner identity, and the companion account-data schema is unpublished; no adapter or CLI route is enabled. |
 | Skool | **No** posts, comments, and course content | **No** reactions and saved state | **No** notifications and messages | **No** memberships, follows, and groups | **No** courses and calendar feeds | **Export/No** admin membership-question answers only. The official Zapier surface is narrow event automation, the export schema and identity contract are unpublished, and provider policy excludes browser collection. |
-| Discourse | **API/Export** | **API/Export** | **API/Gate/Export** | **API/Gate/Export** | **API/Gate/Export** | Scope by installation and user/API-key authority; support hosted and self-hosted instances. |
+| Discourse | **Live** topics and posts | **Live/Partial** likes, bookmarks, and current reading state | **Live/Gate/Partial** notifications and private-topic metadata; **No** message bodies | **Live/Partial** groups and category preferences; **No** unverified Follow plugin | **No** watched/tracked topic inventories until search behavior is verified | Ten User API `read` streams with per-installation namespaces, repeated identity checks, exact GET routes, redirect rejection, and explicit plugin/export/history gaps. |
 | NodeBB | **API/Gate/Export** | **API/Gate/Export** | **API/Gate/Export** | **API/Gate/Export** | **API/Gate/Export** | Verify core REST routes, enabled plugins, and forum privileges per installation. |
 
 ## Recommended candidates
@@ -107,6 +107,17 @@ a claim that the route is enabled.
   `.agents/content/social-medium.md` records the official HTML-ZIP export,
   unsupported legacy API, terms, retention, historical community schema
   evidence, and unverified categories checked on 2026-07-28.
+- **Live Discourse:** `.agents/scripts/knowledge_social_discourse.py`,
+  `.agents/scripts/_knowledge_social_discourse*.py`, and
+  `.agents/tests/test-knowledge-social-discourse.sh` prove ten independently
+  checkpointed account streams, corpus-local keyed installation fingerprints,
+  current-user rebinding, bounded GET-only routes, redirect and write isolation,
+  credential rejection, scope-gated message metadata, terminal coverage,
+  content-addressed replay, and final lease fencing.
+  `.agents/content/social-discourse.md` records the current User API `read`
+  scope, core routes and pagination, hosted/self-hosted variability, optional
+  Follow plugin, archive mutation/retention boundary, installation terms, and
+  explicit unsupported categories checked on 2026-07-28.
 - **Quora export disposition:** `.agents/content/social-quora.md` records the
   official owner-request route, current public archive observations, absent
   schema and retention guarantees, and the identity-verification gap checked on

--- a/.agents/content/social-discourse.md
+++ b/.agents/content/social-discourse.md
@@ -1,0 +1,138 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Discourse Account Knowledge Collection
+
+`knowledge-social-helper.sh sync-discourse` collects bounded account-visible
+metadata from one hosted or self-hosted Discourse installation. Each profile is
+one installation connection. The collector never treats equal user, topic, post,
+or group IDs on different installations as the same social identity.
+
+## Runtime and authorization contract
+
+The collector uses Python's standard-library `urllib.request.Request`,
+`urllib.request.build_opener`, `urllib.request.HTTPRedirectHandler`,
+`urllib.parse.urlencode`, and `urllib.parse.urlsplit` exports. These exports were
+verified with Python 3.14.3 on 2026-07-28. No `pydiscourse`, `discourse-api`, or
+`discourse_api` client was installed or imported, so there is no third-party
+response or error mapping to drift from the installed runtime.
+
+Configure one profile through secure environment injection:
+
+```text
+DISCOURSE_<PROFILE>_BASE_URL
+DISCOURSE_<PROFILE>_USER_API_KEY
+DISCOURSE_<PROFILE>_ORIGIN_KEY
+DISCOURSE_<PROFILE>_USER_API_SCOPE=read
+```
+
+The API key must be a current-user User API key issued with the exact `read`
+scope. Core currently maps `read` to GET requests only, while `write` permits GET,
+POST, PATCH, PUT, and DELETE. The child rejects any profile that does not declare
+exactly `read`; it does not accept admin API keys or `Api-Username`
+impersonation. Scope declaration is an operator assertion, so the transport also
+enforces an exact path/query allowlist and constructs only `method="GET"`
+requests.
+
+`ORIGIN_KEY` must be a securely stored, random value of at least 32 bytes. The
+base must be HTTPS, contain no credentials, query, fragment, encoded path, or dot
+segment, and may include a fixed installation subpath. Redirects are not
+followed. HMAC-SHA-256 over the canonical base and profile-specific origin key
+produces the 24-character installation namespace. Changing either the origin or
+key breaks connection rebinding, while another corpus/key cannot dictionary-map
+or correlate the persisted namespace. The host, subpath, and origin key never
+enter records, checkpoints, receipts, collector output, or errors.
+
+Use `--account-id user_<NUMERIC_ID>` so even one- or two-digit Discourse IDs meet
+the provider-neutral opaque CLI contract. The child calls
+`GET /session/current.json`, compares its numeric ID with that selector, and
+binds the returned username and installation fingerprint. It repeats the same
+identity read before every page. A changed user, username, profile origin, or
+connection binding fails before that page can persist evidence or advance a
+checkpoint.
+
+## Implemented streams
+
+| Stream | Exact read route | Coverage |
+|---|---|---|
+| `authored_topics` | `GET /user_actions.json`, action filter `4` | Authored topic metadata and excerpts, offset pagination, newest-topic watermark. |
+| `authored_posts` | `GET /user_actions.json`, action filter `5` | Authored reply/post metadata and excerpts, offset pagination, newest-post watermark. |
+| `likes` | `GET /user_actions.json`, action filter `1` | Full paginated current-state snapshot of API-visible likes given by the selected user. |
+| `bookmarks` | `GET /u/{selected_username}/bookmarks.json` | Full paginated current-state snapshot, bounded to 20 per page; provider pagination URLs are treated only as a boolean continuation signal and are never followed. |
+| `notifications` | `GET /notifications.json` | Full paginated current-state snapshot of notification IDs, types, read flags, topic references, and timestamps. Pagination uses the numeric total, never the returned URL; the side-effect-prone `recent` query is unreachable. |
+| `private_messages` | `GET /topics/private-messages/{selected_username}.json` | Full paginated snapshot of received/private topic-list metadata only, permission-gated by the selected account. |
+| `sent_messages` | `GET /topics/private-messages-sent/{selected_username}.json` | Full paginated snapshot of sent private-topic metadata only, permission-gated by the selected account. |
+| `reading_state` | `GET /u/{selected_username}/topic-tracking-state.json` | Bounded current topic tracking snapshot, not a historical reading-event log. |
+| `groups` | allowlisted fields already returned by `GET /session/current.json` | Current selected-user group memberships and owner/message flags. |
+| `category_preferences` | `GET /session/current.json`, then `GET /categories.json` | Watched, tracked, muted, regular, and watched-first-post category IDs resolved against visible category metadata. Unknown private IDs remain explicit unresolved records. |
+
+`--page-size` is 1-20 for routes that accept a client limit. Private-message
+topic lists use the installation's fixed page size and reject responses over 100
+items. Reading-state, group, category, and identity preference snapshots reject
+responses over 1000 items. The 8 MiB response cap remains independent of these
+item limits. The initial identity read reserves one request unit and each page
+reserves two units for identity rebinding plus at most one selected data route.
+The groups stream conservatively reserves the same amount even though its data
+comes from the repeated identity response. `--budget` is a hard 3-1000-unit
+allowance.
+
+Every stream has an independent cursor under its connection. Authored-content
+offsets carry the previous newest-item watermark; mutable likes, bookmarks,
+notifications, messages, reading state, groups, and category preferences rescan
+as snapshots so changed flags/counts are not hidden behind a stable resource ID.
+Successful raw page, normalized rows, coverage, cursor, and receipt commit
+atomically under the final lease fence, and exact replay is content-addressed.
+The boundary serializes only allowlisted IDs, bounded text, timestamps, counts,
+booleans, and preference levels. Provider error bodies, URLs, avatars, email
+fields, secure uploads, and credential-shaped keys never cross into persistence.
+
+## Explicit gaps, exports, retention, and terms
+
+Every successful page records unavailable coverage for:
+
+- `account_archive`: no current private sample has validated the archive schema;
+- `followers` and `following`: the official Follow feature is an optional plugin
+  and its unpaginated installation behavior is not enabled here;
+- `watched_topics` and `tracked_topics`: search-based inventories remain disabled
+  until current-version fixtures prove pagination and side-effect behavior;
+- `private_message_bodies`: thread bodies, attachments, and secure uploads are
+  intentionally outside the metadata collector;
+- `complete_reading_history`: core exposes current tracking state, not a
+  documented complete event history.
+
+Core archive initiation is `POST /export_csv/export_entity`, creates server
+state, consumes a non-admin daily allowance, and can act on another user when
+privileged. Current source retains generated user exports for roughly two days,
+but does not publish a stable archive packaging/schema contract. The collector
+therefore cannot initiate, poll, download, or import an archive. A future manual
+import requires a separately validated, user-initiated private sample.
+
+There is no universal self-hosted retention or plugin contract. Installation
+version, settings, authorization, moderation, and site policy govern what the
+current user can read and how long it remains available. CDCK's privacy policy
+applies to its own processing, not every customer installation. The Meta
+Discourse terms prohibit automated access except their stated exception; those
+terms do not automatically govern another installation. Operators must verify
+authorization and the selected installation's terms before enabling a profile.
+The adapter records `installation_policy_and_current_user_visibility` rather
+than claiming complete history or a universal retention window.
+
+No browser collector, mutation route, archive action, admin path, plugin path,
+or outbound operation is wired for Discourse.
+
+## Official evidence checked 2026-07-28
+
+- [Discourse API Documentation](https://docs.discourse.org/openapi.json)
+- [User API key scopes](https://github.com/discourse/discourse/blob/main/app/models/user_api_key_scope.rb)
+- [Current session controller](https://github.com/discourse/discourse/blob/main/app/controllers/session_controller.rb)
+- [Current-user serializer](https://github.com/discourse/discourse/blob/main/app/serializers/current_user_serializer.rb)
+- [User actions controller](https://github.com/discourse/discourse/blob/main/app/controllers/user_actions_controller.rb)
+- [User action types](https://github.com/discourse/discourse/blob/main/app/models/user_action.rb)
+- [Users controller](https://github.com/discourse/discourse/blob/main/app/controllers/users_controller.rb)
+- [Notifications controller](https://github.com/discourse/discourse/blob/main/app/controllers/notifications_controller.rb)
+- [Core routes](https://raw.githubusercontent.com/discourse/discourse/main/config/routes.rb)
+- [Export CSV controller](https://github.com/discourse/discourse/blob/main/app/controllers/export_csv_controller.rb)
+- [User export retention model](https://github.com/discourse/discourse/blob/main/app/models/user_export.rb)
+- [Official Discourse Follow plugin](https://github.com/discourse/discourse-follow)
+- [Discourse privacy policy](https://www.discourse.org/privacy)
+- [Meta Discourse terms](https://meta.discourse.org/tos)

--- a/.agents/scripts/_knowledge_social_discourse.py
+++ b/.agents/scripts/_knowledge_social_discourse.py
@@ -7,30 +7,25 @@ from __future__ import annotations
 
 import base64
 import json
-import re
 from dataclasses import dataclass
 from typing import Any
 
 from _knowledge_social_collect import CursorState, PageCheckpoint
+from _knowledge_social_discourse_identity import (
+    DiscourseAdapterError,
+    DiscourseProviderUnavailableError,
+    instance_id,
+    namespaced_id,
+    provider_account_id,
+    username,
+)
 from knowledge_social_import import canonical_json, reject_credentials
-from knowledge_social_store import SocialStoreError
 
 PROVIDER = "discourse"
 CURSOR_PREFIX = "discourse-v1:"
 RETENTION_LIMIT = "installation_policy_and_current_user_visibility"
 MAX_MESSAGE_PAGE_ITEMS = 100
 MAX_SNAPSHOT_ITEMS = 1000
-INSTANCE_ID = re.compile(r"^[0-9a-f]{24}$")
-PROVIDER_ACCOUNT_ID = re.compile(r"^[1-9][0-9]{0,19}$")
-USERNAME = re.compile(r"^[A-Za-z0-9_.-]{1,100}$")
-
-
-class DiscourseAdapterError(SocialStoreError):
-    """Raised when guarded Discourse collection cannot continue safely."""
-
-
-class DiscourseProviderUnavailableError(DiscourseAdapterError):
-    """Raised when the bounded Discourse HTTP child cannot complete a read."""
 
 
 ADAPTER_ERROR = DiscourseAdapterError
@@ -107,42 +102,6 @@ STREAMS = {
 }
 
 
-def instance_id(value: Any) -> str:
-    """Validate a privacy-safe stable installation fingerprint."""
-    if not isinstance(value, str) or INSTANCE_ID.fullmatch(value) is None:
-        raise DiscourseAdapterError("Discourse installation identity is invalid")
-    return value
-
-
-def provider_account_id(value: Any) -> str:
-    """Normalize a CLI-safe selector or installation-local numeric user ID."""
-    text = str(value) if isinstance(value, int) and not isinstance(value, bool) else value
-    if isinstance(text, str) and text.startswith("user_"):
-        text = text.removeprefix("user_")
-    if not isinstance(text, str) or PROVIDER_ACCOUNT_ID.fullmatch(text) is None:
-        raise DiscourseAdapterError("Discourse account ID is invalid")
-    return text
-
-
-def username(value: Any) -> str:
-    """Validate a selected Discourse username before path interpolation."""
-    if not isinstance(value, str) or USERNAME.fullmatch(value) is None:
-        raise DiscourseAdapterError("Discourse account username is invalid")
-    return value
-
-
-def namespaced_id(installation: str, kind: str, value: str) -> str:
-    """Namespace an installation-local resource ID for shared storage."""
-    stable_instance = instance_id(installation)
-    if not re.fullmatch(r"[a-z][a-z_]{0,31}", kind):
-        raise DiscourseAdapterError("Discourse resource kind is invalid")
-    if not isinstance(value, str) or not value or not re.fullmatch(
-        r"[A-Za-z0-9_-]{1,128}", value
-    ):
-        raise DiscourseAdapterError("Discourse resource ID is invalid")
-    return f"dsc_{stable_instance}_{kind}_{value}"
-
-
 @dataclass(frozen=True)
 class PageRequest:
     """Allowlisted bounded request passed to the Discourse HTTP subprocess."""
@@ -171,6 +130,19 @@ class PageRequest:
 
     def evidence_key(self) -> str:
         return canonical_json(self.payload())
+
+
+PAGE_REQUEST_KEYS = {
+    "action",
+    "stream",
+    "account_id",
+    "provider_account_id",
+    "username",
+    "instance_id",
+    "position",
+    "stop_at",
+    "limit",
+}
 
 
 def _checkpoint_id(value: Any, field: str, *, optional: bool = False) -> str | None:
@@ -251,39 +223,44 @@ def page_request(
     )
 
 
-def parse_page_request(payload: dict[str, Any]) -> PageRequest:
-    """Validate the exact child-process page request shape."""
-    expected = {
-        "action",
-        "stream",
-        "account_id",
-        "provider_account_id",
-        "username",
-        "instance_id",
-        "position",
-        "stop_at",
-        "limit",
-    }
-    if set(payload) != expected or payload.get("action") != "page":
-        raise DiscourseAdapterError("Discourse read request has an invalid action shape")
+def _request_stream(payload: dict[str, Any]) -> str:
     stream = payload.get("stream")
-    if not isinstance(stream, str) or stream not in STREAMS:
+    if not isinstance(stream, str):
         raise DiscourseAdapterError("Discourse stream is unsupported")
+    if stream not in STREAMS:
+        raise DiscourseAdapterError("Discourse stream is unsupported")
+    return stream
+
+
+def _request_account_id(payload: dict[str, Any]) -> str:
     account_id = _checkpoint_id(payload.get("account_id"), "selected account ID")
     if account_id is None:
         raise DiscourseAdapterError("Discourse selected account ID is required")
+    return account_id
+
+
+def _request_limit(payload: dict[str, Any]) -> int:
     limit = payload.get("limit")
-    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 20:
+    if isinstance(limit, bool) or not isinstance(limit, int):
         raise DiscourseAdapterError("Discourse page size is invalid")
+    if not 1 <= limit <= 20:
+        raise DiscourseAdapterError("Discourse page size is invalid")
+    return limit
+
+
+def parse_page_request(payload: dict[str, Any]) -> PageRequest:
+    """Validate the exact child-process page request shape."""
+    if set(payload) != PAGE_REQUEST_KEYS or payload.get("action") != "page":
+        raise DiscourseAdapterError("Discourse read request has an invalid action shape")
     return PageRequest(
-        stream,
-        account_id,
+        _request_stream(payload),
+        _request_account_id(payload),
         provider_account_id(payload.get("provider_account_id")),
         username(payload.get("username")),
         instance_id(payload.get("instance_id")),
         _position(payload.get("position"), "page position"),
         _checkpoint_id(payload.get("stop_at"), "request watermark", optional=True),
-        limit,
+        _request_limit(payload),
     )
 
 
@@ -303,60 +280,108 @@ def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
     return data
 
 
+@dataclass(frozen=True)
+class PageMetadata:
+    """Validated checkpoint metadata returned by the HTTP child."""
+
+    next_position: int | None
+    newest_id: str | None
+    reached_watermark: bool
+    complete: bool
+    snapshot: bool
+
+
+def _completion_flag(meta: dict[str, Any], field: str) -> bool:
+    value = meta.get(field)
+    if not isinstance(value, bool):
+        raise DiscourseAdapterError("Discourse page completion metadata is invalid")
+    return value
+
+
+def _page_metadata(payload: dict[str, Any], request: PageRequest) -> PageMetadata:
+    meta = payload.get("meta")
+    if not isinstance(meta, dict):
+        raise DiscourseAdapterError("Discourse page metadata must be an object")
+    reject_credentials(meta)
+    if meta.get("stream") != request.stream:
+        raise DiscourseAdapterError("Discourse page provenance is invalid")
+    if instance_id(meta.get("instance_id")) != request.instance_id:
+        raise DiscourseAdapterError("Discourse page provenance is invalid")
+    next_value = meta.get("next_position")
+    next_position = None
+    if next_value is not None:
+        next_position = _position(next_value, "next page position")
+    if next_position is not None and next_position <= request.position:
+        raise DiscourseAdapterError("Discourse next page position did not advance")
+    snapshot = meta.get("snapshot")
+    if not isinstance(snapshot, bool):
+        raise DiscourseAdapterError("Discourse page pagination metadata is invalid")
+    return PageMetadata(
+        next_position,
+        _checkpoint_id(meta.get("newest_id"), "newest ID", optional=True),
+        _completion_flag(meta, "reached_watermark"),
+        _completion_flag(meta, "complete"),
+        snapshot,
+    )
+
+
+def _page_item_limit(request: PageRequest) -> int:
+    if request.stream in ("private_messages", "sent_messages"):
+        return MAX_MESSAGE_PAGE_ITEMS
+    if request.stream in ("reading_state", "groups", "category_preferences"):
+        return MAX_SNAPSHOT_ITEMS
+    return request.limit
+
+
+def _validate_page_items(payload: dict[str, Any], request: PageRequest) -> None:
+    if len(page_data(payload)) > _page_item_limit(request):
+        raise DiscourseAdapterError("Discourse page exceeds the item safety limit")
+
+
+def _validate_page_mode(request: PageRequest, meta: PageMetadata) -> None:
+    spec = STREAMS[request.stream]
+    if not spec.incremental and request.stop_at is not None:
+        raise DiscourseAdapterError("Discourse snapshot cannot use a watermark")
+    if meta.snapshot != (spec.pagination == "snapshot"):
+        raise DiscourseAdapterError("Discourse page pagination metadata is invalid")
+
+
+def _page_complete(meta: PageMetadata) -> bool:
+    complete = meta.complete or meta.reached_watermark
+    if complete and meta.next_position is not None:
+        raise DiscourseAdapterError("complete Discourse page cannot have a next cursor")
+    if not complete and meta.next_position is None:
+        raise DiscourseAdapterError("partial Discourse page requires a next cursor")
+    return complete
+
+
+def _page_watermark(
+    state: CursorState, request: PageRequest, meta: PageMetadata
+) -> str | None:
+    spec = STREAMS[request.stream]
+    if not spec.incremental:
+        return state.watermark
+    if request.position != 0:
+        return state.watermark
+    if meta.newest_id is None:
+        return state.watermark
+    return meta.newest_id
+
+
 def page_checkpoint(
     payload: dict[str, Any],
     state: CursorState,
     request: PageRequest,
 ) -> tuple[PageCheckpoint, bool]:
     """Calculate one atomic per-installation, per-stream checkpoint."""
-    meta = payload.get("meta")
-    if not isinstance(meta, dict):
-        raise DiscourseAdapterError("Discourse page metadata must be an object")
-    reject_credentials(meta)
-    if meta.get("stream") != request.stream or instance_id(
-        meta.get("instance_id")
-    ) != request.instance_id:
-        raise DiscourseAdapterError("Discourse page provenance is invalid")
-    next_value = meta.get("next_position")
-    next_position = (
-        None if next_value is None else _position(next_value, "next page position")
-    )
-    if next_position is not None and next_position <= request.position:
-        raise DiscourseAdapterError("Discourse next page position did not advance")
-    newest = _checkpoint_id(meta.get("newest_id"), "newest ID", optional=True)
-    reached = meta.get("reached_watermark")
-    complete_value = meta.get("complete")
-    snapshot = meta.get("snapshot")
-    if not isinstance(reached, bool) or not isinstance(complete_value, bool):
-        raise DiscourseAdapterError("Discourse page completion metadata is invalid")
-    spec = STREAMS[request.stream]
-    item_limit = (
-        MAX_MESSAGE_PAGE_ITEMS
-        if request.stream in ("private_messages", "sent_messages")
-        else MAX_SNAPSHOT_ITEMS
-        if request.stream in ("reading_state", "groups", "category_preferences")
-        else request.limit
-    )
-    if len(page_data(payload)) > item_limit:
-        raise DiscourseAdapterError("Discourse page exceeds the item safety limit")
-    if not spec.incremental and request.stop_at is not None:
-        raise DiscourseAdapterError("Discourse snapshot cannot use a watermark")
-    if not isinstance(snapshot, bool) or snapshot != (spec.pagination == "snapshot"):
-        raise DiscourseAdapterError("Discourse page pagination metadata is invalid")
-    complete = complete_value or reached
-    if complete == (next_position is not None):
-        message = (
-            "complete Discourse page cannot have a next cursor"
-            if complete
-            else "partial Discourse page requires a next cursor"
-        )
-        raise DiscourseAdapterError(message)
-    watermark = state.watermark
-    if spec.incremental and request.position == 0 and newest is not None:
-        watermark = newest
-    next_cursor = (
-        _encode_cursor(next_position, request.stop_at)
-        if next_position is not None
-        else None
-    )
-    return PageCheckpoint(next_cursor, watermark), complete
+    meta = _page_metadata(payload, request)
+    _validate_page_items(payload, request)
+    _validate_page_mode(request, meta)
+    complete = _page_complete(meta)
+    next_cursor = None
+    if meta.next_position is not None:
+        next_cursor = _encode_cursor(meta.next_position, request.stop_at)
+    return PageCheckpoint(
+        next_cursor,
+        _page_watermark(state, request, meta),
+    ), complete

--- a/.agents/scripts/_knowledge_social_discourse.py
+++ b/.agents/scripts/_knowledge_social_discourse.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Discourse stream policy, instance identity, and durable checkpoints."""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from knowledge_social_import import canonical_json, reject_credentials
+from knowledge_social_store import SocialStoreError
+
+PROVIDER = "discourse"
+CURSOR_PREFIX = "discourse-v1:"
+RETENTION_LIMIT = "installation_policy_and_current_user_visibility"
+MAX_MESSAGE_PAGE_ITEMS = 100
+MAX_SNAPSHOT_ITEMS = 1000
+INSTANCE_ID = re.compile(r"^[0-9a-f]{24}$")
+PROVIDER_ACCOUNT_ID = re.compile(r"^[1-9][0-9]{0,19}$")
+USERNAME = re.compile(r"^[A-Za-z0-9_.-]{1,100}$")
+
+
+class DiscourseAdapterError(SocialStoreError):
+    """Raised when guarded Discourse collection cannot continue safely."""
+
+
+class DiscourseProviderUnavailableError(DiscourseAdapterError):
+    """Raised when the bounded Discourse HTTP child cannot complete a read."""
+
+
+ADAPTER_ERROR = DiscourseAdapterError
+PROVIDER_UNAVAILABLE_ERROR = DiscourseProviderUnavailableError
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    """Static collection and coverage policy for one Discourse stream."""
+
+    resource_kind: str
+    activity_mode: str
+    pagination: str
+    incremental: bool
+    retention_limit: str | None
+    coverage_status: str | None = None
+    unavailable_reason: str | None = None
+    cost_units: int = 2
+
+
+def _listing(
+    resource_kind: str, activity_mode: str, *, incremental: bool = True
+) -> StreamSpec:
+    return StreamSpec(
+        resource_kind,
+        activity_mode,
+        "listing" if incremental else "snapshot",
+        incremental,
+        RETENTION_LIMIT,
+    )
+
+
+STREAMS = {
+    "authored_topics": _listing("topic", "content_author"),
+    "authored_posts": _listing("post", "content_author"),
+    "likes": _listing("post", "selected_account", incremental=False),
+    "bookmarks": _listing("post", "selected_account", incremental=False),
+    "notifications": _listing(
+        "notification", "selected_account", incremental=False
+    ),
+    "private_messages": StreamSpec(
+        "private_message_topic",
+        "selected_account",
+        "snapshot",
+        False,
+        RETENTION_LIMIT,
+        "partial",
+        "private_message_topic_metadata_only",
+    ),
+    "sent_messages": StreamSpec(
+        "private_message_topic",
+        "selected_account",
+        "snapshot",
+        False,
+        RETENTION_LIMIT,
+        "partial",
+        "private_message_topic_metadata_only",
+    ),
+    "reading_state": StreamSpec(
+        "topic_state",
+        "selected_account",
+        "snapshot",
+        False,
+        RETENTION_LIMIT,
+        "partial",
+        "current_topic_state_not_event_history",
+    ),
+    "groups": StreamSpec(
+        "group", "selected_account", "snapshot", False, RETENTION_LIMIT
+    ),
+    "category_preferences": StreamSpec(
+        "category", "selected_account", "snapshot", False, RETENTION_LIMIT
+    ),
+}
+
+
+def instance_id(value: Any) -> str:
+    """Validate a privacy-safe stable installation fingerprint."""
+    if not isinstance(value, str) or INSTANCE_ID.fullmatch(value) is None:
+        raise DiscourseAdapterError("Discourse installation identity is invalid")
+    return value
+
+
+def provider_account_id(value: Any) -> str:
+    """Normalize a CLI-safe selector or installation-local numeric user ID."""
+    text = str(value) if isinstance(value, int) and not isinstance(value, bool) else value
+    if isinstance(text, str) and text.startswith("user_"):
+        text = text.removeprefix("user_")
+    if not isinstance(text, str) or PROVIDER_ACCOUNT_ID.fullmatch(text) is None:
+        raise DiscourseAdapterError("Discourse account ID is invalid")
+    return text
+
+
+def username(value: Any) -> str:
+    """Validate a selected Discourse username before path interpolation."""
+    if not isinstance(value, str) or USERNAME.fullmatch(value) is None:
+        raise DiscourseAdapterError("Discourse account username is invalid")
+    return value
+
+
+def namespaced_id(installation: str, kind: str, value: str) -> str:
+    """Namespace an installation-local resource ID for shared storage."""
+    stable_instance = instance_id(installation)
+    if not re.fullmatch(r"[a-z][a-z_]{0,31}", kind):
+        raise DiscourseAdapterError("Discourse resource kind is invalid")
+    if not isinstance(value, str) or not value or not re.fullmatch(
+        r"[A-Za-z0-9_-]{1,128}", value
+    ):
+        raise DiscourseAdapterError("Discourse resource ID is invalid")
+    return f"dsc_{stable_instance}_{kind}_{value}"
+
+
+@dataclass(frozen=True)
+class PageRequest:
+    """Allowlisted bounded request passed to the Discourse HTTP subprocess."""
+
+    stream: str
+    account_id: str
+    provider_account_id: str
+    username: str
+    instance_id: str
+    position: int
+    stop_at: str | None
+    limit: int
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "page",
+            "stream": self.stream,
+            "account_id": self.account_id,
+            "provider_account_id": self.provider_account_id,
+            "username": self.username,
+            "instance_id": self.instance_id,
+            "position": self.position,
+            "stop_at": self.stop_at,
+            "limit": self.limit,
+        }
+
+    def evidence_key(self) -> str:
+        return canonical_json(self.payload())
+
+
+def _checkpoint_id(value: Any, field: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if (
+        not isinstance(value, str)
+        or not value
+        or "\x00" in value
+        or len(value.encode("utf-8")) > 512
+    ):
+        raise DiscourseAdapterError(f"Discourse {field} is invalid")
+    return value
+
+
+def _position(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise DiscourseAdapterError(f"Discourse {field} must be non-negative")
+    return value
+
+
+def _encode_cursor(position: int, stop_at: str | None) -> str:
+    payload = canonical_json({"position": position, "stop_at": stop_at}).encode(
+        "utf-8"
+    )
+    encoded = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+    return f"{CURSOR_PREFIX}{encoded}"
+
+
+def _decode_cursor(cursor: str) -> tuple[int, str | None]:
+    if not cursor.startswith(CURSOR_PREFIX):
+        raise DiscourseAdapterError("stored Discourse cursor has an unsupported version")
+    encoded = cursor.removeprefix(CURSOR_PREFIX)
+    try:
+        padding = "=" * (-len(encoded) % 4)
+        parsed = json.loads(base64.urlsafe_b64decode(encoded + padding))
+    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+        raise DiscourseAdapterError("stored Discourse cursor is invalid") from error
+    if not isinstance(parsed, dict) or set(parsed) != {"position", "stop_at"}:
+        raise DiscourseAdapterError("stored Discourse cursor has an invalid shape")
+    reject_credentials(parsed)
+    return (
+        _position(parsed["position"], "cursor position"),
+        _checkpoint_id(parsed["stop_at"], "cursor watermark", optional=True),
+    )
+
+
+def page_request(
+    stream: str,
+    account: dict[str, Any],
+    state: CursorState,
+    limit: int,
+) -> PageRequest:
+    """Build one allowlisted request from durable per-stream state."""
+    if stream not in STREAMS:
+        raise DiscourseAdapterError("Discourse stream is unsupported")
+    selected_id = _checkpoint_id(account.get("id"), "selected account ID")
+    if selected_id is None:
+        raise DiscourseAdapterError("verified Discourse identity is incomplete")
+    local_id = provider_account_id(account.get("provider_account_id"))
+    selected_username = username(account.get("username"))
+    installation = instance_id(account.get("instance_id"))
+    position = 0
+    stop_at: str | None = None
+    if state.cursor:
+        position, stop_at = _decode_cursor(state.cursor)
+    elif STREAMS[stream].incremental and state.backfill_complete:
+        stop_at = _checkpoint_id(state.watermark, "watermark", optional=True)
+    return PageRequest(
+        stream,
+        selected_id,
+        local_id,
+        selected_username,
+        installation,
+        position,
+        stop_at,
+        limit,
+    )
+
+
+def parse_page_request(payload: dict[str, Any]) -> PageRequest:
+    """Validate the exact child-process page request shape."""
+    expected = {
+        "action",
+        "stream",
+        "account_id",
+        "provider_account_id",
+        "username",
+        "instance_id",
+        "position",
+        "stop_at",
+        "limit",
+    }
+    if set(payload) != expected or payload.get("action") != "page":
+        raise DiscourseAdapterError("Discourse read request has an invalid action shape")
+    stream = payload.get("stream")
+    if not isinstance(stream, str) or stream not in STREAMS:
+        raise DiscourseAdapterError("Discourse stream is unsupported")
+    account_id = _checkpoint_id(payload.get("account_id"), "selected account ID")
+    if account_id is None:
+        raise DiscourseAdapterError("Discourse selected account ID is required")
+    limit = payload.get("limit")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 20:
+        raise DiscourseAdapterError("Discourse page size is invalid")
+    return PageRequest(
+        stream,
+        account_id,
+        provider_account_id(payload.get("provider_account_id")),
+        username(payload.get("username")),
+        instance_id(payload.get("instance_id")),
+        _position(payload.get("position"), "page position"),
+        _checkpoint_id(payload.get("stop_at"), "request watermark", optional=True),
+        limit,
+    )
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    """Return a validated HTTP-like status from a Discourse response."""
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise DiscourseAdapterError("Discourse response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return a validated, already allowlisted provider data array."""
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise DiscourseAdapterError("Discourse page data must be an array")
+    return data
+
+
+def page_checkpoint(
+    payload: dict[str, Any],
+    state: CursorState,
+    request: PageRequest,
+) -> tuple[PageCheckpoint, bool]:
+    """Calculate one atomic per-installation, per-stream checkpoint."""
+    meta = payload.get("meta")
+    if not isinstance(meta, dict):
+        raise DiscourseAdapterError("Discourse page metadata must be an object")
+    reject_credentials(meta)
+    if meta.get("stream") != request.stream or instance_id(
+        meta.get("instance_id")
+    ) != request.instance_id:
+        raise DiscourseAdapterError("Discourse page provenance is invalid")
+    next_value = meta.get("next_position")
+    next_position = (
+        None if next_value is None else _position(next_value, "next page position")
+    )
+    if next_position is not None and next_position <= request.position:
+        raise DiscourseAdapterError("Discourse next page position did not advance")
+    newest = _checkpoint_id(meta.get("newest_id"), "newest ID", optional=True)
+    reached = meta.get("reached_watermark")
+    complete_value = meta.get("complete")
+    snapshot = meta.get("snapshot")
+    if not isinstance(reached, bool) or not isinstance(complete_value, bool):
+        raise DiscourseAdapterError("Discourse page completion metadata is invalid")
+    spec = STREAMS[request.stream]
+    item_limit = (
+        MAX_MESSAGE_PAGE_ITEMS
+        if request.stream in ("private_messages", "sent_messages")
+        else MAX_SNAPSHOT_ITEMS
+        if request.stream in ("reading_state", "groups", "category_preferences")
+        else request.limit
+    )
+    if len(page_data(payload)) > item_limit:
+        raise DiscourseAdapterError("Discourse page exceeds the item safety limit")
+    if not spec.incremental and request.stop_at is not None:
+        raise DiscourseAdapterError("Discourse snapshot cannot use a watermark")
+    if not isinstance(snapshot, bool) or snapshot != (spec.pagination == "snapshot"):
+        raise DiscourseAdapterError("Discourse page pagination metadata is invalid")
+    complete = complete_value or reached
+    if complete == (next_position is not None):
+        message = (
+            "complete Discourse page cannot have a next cursor"
+            if complete
+            else "partial Discourse page requires a next cursor"
+        )
+        raise DiscourseAdapterError(message)
+    watermark = state.watermark
+    if spec.incremental and request.position == 0 and newest is not None:
+        watermark = newest
+    next_cursor = (
+        _encode_cursor(next_position, request.stop_at)
+        if next_position is not None
+        else None
+    )
+    return PageCheckpoint(next_cursor, watermark), complete

--- a/.agents/scripts/_knowledge_social_discourse_contract.py
+++ b/.agents/scripts/_knowledge_social_discourse_contract.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validation and serialization for the bounded Discourse HTTP child."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_discourse import (
+    DiscourseAdapterError,
+    instance_id,
+    namespaced_id,
+    provider_account_id,
+    username,
+)
+
+MAX_TEXT_BYTES = 256 * 1024
+MAX_IDENTITY_ITEMS = 1000
+
+
+class DiscourseReadProviderError(RuntimeError):
+    """Raised for a privacy-safe local Discourse provider failure."""
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    """One bounded HTTP result without provider error-body disclosure."""
+
+    status: int
+    payload: Any
+    retry_after: int | None = None
+
+
+def observed_at() -> str:
+    """Return a UTC timestamp for one bounded provider response."""
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def exact_keys(request: dict[str, Any], expected: set[str]) -> None:
+    """Reject request shapes outside the allowlisted read contract."""
+    if set(request) != expected:
+        raise DiscourseReadProviderError(
+            "Discourse read request has an invalid action shape"
+        )
+
+
+def object_value(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise DiscourseReadProviderError(f"Discourse {field} must be an object")
+    return value
+
+
+def object_list(
+    value: Any, field: str, *, limit: int | None = None
+) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise DiscourseReadProviderError(
+            f"Discourse {field} must be an array of objects"
+        )
+    if limit is not None and len(value) > limit:
+        raise DiscourseReadProviderError(
+            f"Discourse {field} exceeds the item safety limit"
+        )
+    return value
+
+
+def optional_text(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value:
+        raise DiscourseReadProviderError(f"Discourse {field} must be text")
+    if len(value.encode("utf-8")) > MAX_TEXT_BYTES:
+        raise DiscourseReadProviderError(
+            f"Discourse {field} exceeds the safety limit"
+        )
+    return value
+
+
+def required_text(value: Any, field: str) -> str:
+    text = optional_text(value, field)
+    if not text:
+        raise DiscourseReadProviderError(f"Discourse {field} is required")
+    return text
+
+
+def non_negative_integer(value: Any, field: str, *, optional: bool = False) -> int | None:
+    if value is None and optional:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise DiscourseReadProviderError(
+            f"Discourse {field} must be a non-negative integer"
+        )
+    return value
+
+
+def positive_id(value: Any, field: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    number = non_negative_integer(value, field)
+    if number is None or number < 1:
+        raise DiscourseReadProviderError(f"Discourse {field} must be positive")
+    return str(number)
+
+
+def optional_boolean(value: Any, field: str) -> bool | None:
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise DiscourseReadProviderError(f"Discourse {field} must be boolean")
+    return value
+
+
+def _id_array(value: Any, field: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise DiscourseReadProviderError(f"Discourse {field} must be an array")
+    if len(value) > MAX_IDENTITY_ITEMS:
+        raise DiscourseReadProviderError(
+            f"Discourse {field} exceeds the item safety limit"
+        )
+    return [positive_id(item, field) or "" for item in value]
+
+
+def _groups(value: Any) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    groups = object_list(value, "identity groups", limit=MAX_IDENTITY_ITEMS)
+    return [
+        {
+            "id": positive_id(group.get("id"), "group ID"),
+            "name": required_text(group.get("name"), "group name"),
+            "has_messages": optional_boolean(
+                group.get("has_messages"), "group message flag"
+            ),
+            "owner": optional_boolean(group.get("owner"), "group owner flag"),
+        }
+        for group in groups
+    ]
+
+
+CATEGORY_PREFERENCE_FIELDS = {
+    "muted": "muted_category_ids",
+    "regular": "regular_category_ids",
+    "tracked": "tracked_category_ids",
+    "watched": "watched_category_ids",
+    "watched_first_post": "watched_first_post_category_ids",
+}
+
+
+def identity_value(
+    payload: Any, expected_id: str, installation: str
+) -> dict[str, Any]:
+    """Serialize only the selected current-user identity and preference fields."""
+    root = object_value(payload, "identity response")
+    current = object_value(root.get("current_user"), "current user")
+    local_id = positive_id(current.get("id"), "account ID")
+    if local_id is None or local_id != provider_account_id(expected_id):
+        raise DiscourseReadProviderError(
+            "selected Discourse account does not match the configured connection"
+        )
+    handle = username(current.get("username"))
+    preferences = {
+        label: _id_array(current.get(field), f"{label} category IDs")
+        for label, field in CATEGORY_PREFERENCE_FIELDS.items()
+    }
+    return {
+        "provider_account_id": local_id,
+        "username": handle,
+        "name": optional_text(current.get("name"), "account name") or None,
+        "instance_id": instance_id(installation),
+        "groups": _groups(current.get("groups")),
+        "category_preferences": preferences,
+    }
+
+
+def resource_id(installation: str, kind: str, value: Any, field: str) -> str:
+    local_id = positive_id(value, field)
+    if local_id is None:
+        raise DiscourseReadProviderError(f"Discourse {field} is required")
+    try:
+        return namespaced_id(installation, kind, local_id)
+    except DiscourseAdapterError as error:
+        raise DiscourseReadProviderError(str(error)) from error
+
+
+def terminal_payload(result: ApiResult) -> dict[str, Any]:
+    """Build a sanitized terminal envelope from one HTTP result."""
+    payload: dict[str, Any] = {"status": result.status, "observed_at": observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload

--- a/.agents/scripts/_knowledge_social_discourse_contract.py
+++ b/.agents/scripts/_knowledge_social_discourse_contract.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
@@ -45,6 +46,33 @@ def exact_keys(request: dict[str, Any], expected: set[str]) -> None:
         raise DiscourseReadProviderError(
             "Discourse read request has an invalid action shape"
         )
+
+
+def _bounded_request(payload: bytes, limit: int) -> bytes:
+    if len(payload) > limit:
+        raise DiscourseReadProviderError(
+            "Discourse read request exceeds the safety limit"
+        )
+    return payload
+
+
+def _decoded_request(payload: bytes) -> Any:
+    try:
+        return json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise DiscourseReadProviderError(
+            "Discourse read request is not valid JSON"
+        ) from error
+
+
+def request_object(payload: bytes, limit: int) -> dict[str, Any]:
+    """Decode one bounded provider request without retaining raw input."""
+    request = _decoded_request(_bounded_request(payload, limit))
+    if not isinstance(request, dict):
+        raise DiscourseReadProviderError(
+            "Discourse read request root must be an object"
+        )
+    return request
 
 
 def object_value(value: Any, field: str) -> dict[str, Any]:

--- a/.agents/scripts/_knowledge_social_discourse_http.py
+++ b/.agents/scripts/_knowledge_social_discourse_http.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Exact-origin, redirect-free HTTP transport for Discourse account reads."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import math
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import SplitResult, urlencode, urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from _knowledge_social_discourse_contract import (
+    ApiResult,
+    DiscourseReadProviderError,
+)
+from _knowledge_social_discourse_routes import allowlisted_path
+
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+HTTP_TIMEOUT_SECONDS = 60
+
+
+class Response(Protocol):
+    status: int
+
+    def __enter__(self) -> Response: ...
+
+    def __exit__(self, *args: Any) -> None: ...
+
+    def read(self, size: int = -1) -> bytes: ...
+
+
+class Opener(Protocol):
+    def open(self, request: Request, timeout: int) -> Response: ...
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    """Validated secret profile and privacy-safe installation identity."""
+
+    base_url: str
+    user_api_key: str
+    scope: str
+    instance_id: str
+
+
+class _RejectRedirect(HTTPRedirectHandler):
+    """Convert every redirect into a terminal response without following it."""
+
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def _parsed_url(value: str) -> tuple[SplitResult, int | None]:
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError as error:
+        raise DiscourseReadProviderError(
+            "Discourse profile base URL is invalid"
+        ) from error
+    return parsed, port
+
+
+def _validate_origin(parsed: SplitResult) -> None:
+    if parsed.scheme.lower() != "https":
+        raise DiscourseReadProviderError("Discourse profile base URL must be HTTPS")
+    if parsed.hostname is None:
+        raise DiscourseReadProviderError("Discourse profile base URL must be HTTPS")
+    if parsed.username is not None:
+        raise DiscourseReadProviderError("Discourse profile base URL must be HTTPS")
+    if parsed.password is not None:
+        raise DiscourseReadProviderError("Discourse profile base URL must be HTTPS")
+    if parsed.query:
+        raise DiscourseReadProviderError("Discourse profile base URL must be HTTPS")
+    if parsed.fragment:
+        raise DiscourseReadProviderError("Discourse profile base URL must be HTTPS")
+
+
+def _invalid_path_syntax(path: str) -> bool:
+    return any(marker in path for marker in ("\\", "%", "//"))
+
+
+def _canonical_path(value: str) -> str:
+    path = value.rstrip("/")
+    if _invalid_path_syntax(path):
+        raise DiscourseReadProviderError("Discourse profile base URL is invalid")
+    parts = (part for part in path.split("/") if part)
+    if any(part in (".", "..") for part in parts):
+        raise DiscourseReadProviderError("Discourse profile base URL is invalid")
+    if path.lower().startswith("/admin"):
+        raise DiscourseReadProviderError("Discourse profile base URL is invalid")
+    return path
+
+
+def _canonical_base_url(value: str) -> str:
+    """Canonicalize one HTTPS installation base without leaking it in errors."""
+    parsed, port = _parsed_url(value)
+    _validate_origin(parsed)
+    host = parsed.hostname or ""
+    rendered_host = f"[{host.lower()}]" if ":" in host else host.lower()
+    if port is not None and port != 443:
+        rendered_host = f"{rendered_host}:{port}"
+    return f"https://{rendered_host}{_canonical_path(parsed.path)}"
+
+
+def installation_fingerprint(base_url: str, origin_key: str) -> str:
+    """Return a corpus-local keyed installation namespace."""
+    canonical = _canonical_base_url(base_url)
+    key = origin_key.encode("utf-8")
+    if len(key) < 32:
+        raise DiscourseReadProviderError(
+            "Discourse profile origin key must be at least 32 bytes"
+        )
+    return hmac.new(key, canonical.encode("utf-8"), hashlib.sha256).hexdigest()[:24]
+
+
+def _http_exports() -> Opener:
+    """Verify and return the installed standard-library HTTP surface."""
+    exports = (Request, build_opener, urlencode, urlsplit, HTTPRedirectHandler)
+    if not all(callable(item) for item in exports):
+        raise DiscourseReadProviderError("Python urllib HTTP exports are unavailable")
+    return build_opener(_RejectRedirect())
+
+
+def _retry_epoch(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(seconds):
+        return None
+    if seconds < 0:
+        return None
+    return int(time.time() + math.ceil(seconds))
+
+
+def _decode_response(payload: bytes) -> Any:
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise DiscourseReadProviderError(
+            "Discourse read response exceeds the safety limit"
+        )
+    try:
+        decoded = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise DiscourseReadProviderError(
+            "Discourse read provider returned no valid JSON"
+        ) from error
+    if not isinstance(decoded, (dict, list)):
+        raise DiscourseReadProviderError(
+            "Discourse API response root must be an object or array"
+        )
+    return decoded
+
+
+def _query_keys(path: str) -> frozenset[str]:
+    exact = {
+        "/user_actions.json": frozenset({"username", "filter", "offset", "limit"}),
+        "/notifications.json": frozenset({"username", "offset", "limit"}),
+    }
+    if path in exact:
+        return exact[path]
+    if path.endswith("/bookmarks.json"):
+        return frozenset({"page", "limit"})
+    if path.startswith("/topics/private-messages"):
+        return frozenset({"page"})
+    return frozenset()
+
+
+def _valid_query_item(item: tuple[str, str]) -> bool:
+    key, value = item
+    if not isinstance(key, str) or not isinstance(value, str):
+        return False
+    if "\x00" in key:
+        return False
+    if "\x00" in value:
+        return False
+    return True
+
+
+def _validate_api_request(path: str, params: dict[str, str]) -> None:
+    if not allowlisted_path(path):
+        raise DiscourseReadProviderError("Discourse API route is not allowlisted")
+    if set(params) != _query_keys(path):
+        raise DiscourseReadProviderError("Discourse API route is not allowlisted")
+    if "recent" in params:
+        raise DiscourseReadProviderError("Discourse API query is invalid")
+    if not all(_valid_query_item(item) for item in params.items()):
+        raise DiscourseReadProviderError("Discourse API query is invalid")
+
+
+def _http_status(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise DiscourseReadProviderError("Discourse HTTP status is invalid")
+    return value
+
+
+def _request_for(config: ProfileConfig, path: str, params: dict[str, str]) -> Request:
+    query = f"?{urlencode(params)}" if params else ""
+    return Request(
+        f"{config.base_url}{path}{query}",
+        headers={
+            "Accept": "application/json",
+            "User-Api-Key": config.user_api_key,
+            "User-Agent": "aidevops-discourse-knowledge/1",
+        },
+        method="GET",
+    )
+
+
+def _api(
+    config: ProfileConfig,
+    opener: Opener,
+    path: str,
+    params: dict[str, str],
+) -> ApiResult:
+    """Execute one exact-origin, redirect-free, GET-only JSON request."""
+    _validate_api_request(path, params)
+    request = _request_for(config, path, params)
+    try:
+        with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            status = _http_status(getattr(response, "status", 200))
+            payload = response.read(MAX_RESPONSE_BYTES + 1)
+            if not isinstance(payload, bytes):
+                raise DiscourseReadProviderError("Discourse HTTP response is invalid")
+            return ApiResult(status, _decode_response(payload))
+    except HTTPError as error:
+        status = _http_status(error.code)
+        retry_header = None
+        if error.headers is not None:
+            retry_header = error.headers.get("Retry-After")
+        return ApiResult(status, {}, _retry_epoch(retry_header))
+    except (TimeoutError, URLError, OSError) as error:
+        raise DiscourseReadProviderError(
+            "Discourse read provider request failed"
+        ) from error

--- a/.agents/scripts/_knowledge_social_discourse_identity.py
+++ b/.agents/scripts/_knowledge_social_discourse_identity.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Discourse installation, account, and resource identity validation."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from knowledge_social_store import SocialStoreError
+
+INSTANCE_ID = re.compile(r"^[0-9a-f]{24}$")
+PROVIDER_ACCOUNT_ID = re.compile(r"^[1-9][0-9]{0,19}$")
+USERNAME = re.compile(r"^[A-Za-z0-9_.-]{1,100}$")
+RESOURCE_KIND = re.compile(r"^[a-z][a-z_]{0,31}$")
+RESOURCE_ID = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+
+
+class DiscourseAdapterError(SocialStoreError):
+    """Raised when guarded Discourse collection cannot continue safely."""
+
+
+class DiscourseProviderUnavailableError(DiscourseAdapterError):
+    """Raised when the bounded Discourse HTTP child cannot complete a read."""
+
+
+def instance_id(value: Any) -> str:
+    """Validate a privacy-safe stable installation fingerprint."""
+    if not isinstance(value, str):
+        raise DiscourseAdapterError("Discourse installation identity is invalid")
+    if INSTANCE_ID.fullmatch(value) is None:
+        raise DiscourseAdapterError("Discourse installation identity is invalid")
+    return value
+
+
+def provider_account_id(value: Any) -> str:
+    """Normalize a CLI-safe selector or installation-local numeric user ID."""
+    text = str(value) if isinstance(value, int) and not isinstance(value, bool) else value
+    if isinstance(text, str) and text.startswith("user_"):
+        text = text.removeprefix("user_")
+    if not isinstance(text, str):
+        raise DiscourseAdapterError("Discourse account ID is invalid")
+    if PROVIDER_ACCOUNT_ID.fullmatch(text) is None:
+        raise DiscourseAdapterError("Discourse account ID is invalid")
+    return text
+
+
+def username(value: Any) -> str:
+    """Validate a selected Discourse username before path interpolation."""
+    if not isinstance(value, str):
+        raise DiscourseAdapterError("Discourse account username is invalid")
+    if USERNAME.fullmatch(value) is None:
+        raise DiscourseAdapterError("Discourse account username is invalid")
+    return value
+
+
+def namespaced_id(installation: str, kind: str, value: str) -> str:
+    """Namespace an installation-local resource ID for shared storage."""
+    stable_instance = instance_id(installation)
+    if RESOURCE_KIND.fullmatch(kind) is None:
+        raise DiscourseAdapterError("Discourse resource kind is invalid")
+    if not isinstance(value, str):
+        raise DiscourseAdapterError("Discourse resource ID is invalid")
+    if not value or RESOURCE_ID.fullmatch(value) is None:
+        raise DiscourseAdapterError("Discourse resource ID is invalid")
+    return f"dsc_{stable_instance}_{kind}_{value}"

--- a/.agents/scripts/_knowledge_social_discourse_normalize.py
+++ b/.agents/scripts/_knowledge_social_discourse_normalize.py
@@ -112,73 +112,121 @@ def _coverage(observed_at: str) -> list[dict[str, Any]]:
     ]
 
 
-def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
-    """Build provider-neutral rows and explicit installation-specific gaps."""
-    reject_credentials(payload)
-    observed_at = _observed_at(payload)
-    account_id = _required_text(context.account, "id")
-    installation = instance_id(context.account.get("instance_id"))
+@dataclass(frozen=True)
+class NormalizationState:
+    """Validated values shared by every row from one provider page."""
+
+    observed_at: str
+    account_id: str
+    installation: str
+    activity_type: str
+    authored: bool
+
+
+def _normalization_state(
+    payload: dict[str, Any], context: PageContext
+) -> NormalizationState:
+    return NormalizationState(
+        _observed_at(payload),
+        _required_text(context.account, "id"),
+        instance_id(context.account.get("instance_id")),
+        ACTIVITY_TYPES[context.stream],
+        context.stream in ("authored_topics", "authored_posts"),
+    )
+
+
+def _item_kind(item: dict[str, Any]) -> str:
+    kind = item.get("kind")
+    if not isinstance(kind, str):
+        raise DiscourseAdapterError("Discourse page contains an unsupported item kind")
+    if kind not in OBJECT_TYPES:
+        raise DiscourseAdapterError("Discourse page contains an unsupported item kind")
+    return kind
+
+
+def _created_at(item: dict[str, Any]) -> str | None:
+    return (
+        _optional_text(item, "created_at")
+        or _optional_text(item, "last_posted_at")
+        or _optional_text(item, "last_visited_at")
+    )
+
+
+def _object_row(
+    item: dict[str, Any], context: PageContext, state: NormalizationState
+) -> dict[str, Any]:
+    kind = _item_kind(item)
+    remote_id = _required_text(item, "remote_id")
+    provider_json = {
+        "source": PROVENANCE,
+        "instance_id": state.installation,
+        "stream": context.stream,
+        "record": item,
+    }
+    reject_credentials(provider_json)
+    return {
+        "object_type": kind,
+        "remote_id": remote_id,
+        "account_remote_id": state.account_id if state.authored else None,
+        "text": _text(item),
+        "created_at": _created_at(item),
+        "observed_at": state.observed_at,
+        "evidence_class": "authored" if state.authored else "observed",
+        "provider_json": provider_json,
+    }
+
+
+def _has_activity(item: dict[str, Any], stream: str) -> bool:
+    if stream != "category_preferences":
+        return True
+    levels = item.get("preference_levels")
+    if not isinstance(levels, list):
+        raise DiscourseAdapterError(
+            "Discourse category preference levels are invalid"
+        )
+    if any(not isinstance(level, str) for level in levels):
+        raise DiscourseAdapterError(
+            "Discourse category preference levels are invalid"
+        )
+    return bool(levels)
+
+
+def _activity_row(
+    item: dict[str, Any], context: PageContext, state: NormalizationState
+) -> dict[str, Any] | None:
+    if not _has_activity(item, context.stream):
+        return None
+    remote_id = _required_text(item, "remote_id")
+    return {
+        "activity_type": state.activity_type,
+        "remote_id": f"{state.account_id}_{state.activity_type}_{remote_id}",
+        "actor_remote_id": state.account_id,
+        "object_remote_id": remote_id,
+        "occurred_at": _created_at(item),
+        "observed_at": state.observed_at,
+        "state": "active",
+        "provider_json": {
+            "source": PROVENANCE,
+            "instance_id": state.installation,
+            "stream": context.stream,
+        },
+    }
+
+
+def _normalized_rows(
+    payload: dict[str, Any], context: PageContext, state: NormalizationState
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     objects: list[dict[str, Any]] = []
     activities: list[dict[str, Any]] = []
     for item in page_data(payload):
-        kind = item.get("kind")
-        if not isinstance(kind, str) or kind not in OBJECT_TYPES:
-            raise DiscourseAdapterError(
-                "Discourse page contains an unsupported item kind"
-            )
-        remote_id = _required_text(item, "remote_id")
-        provider_json = {
-            "source": PROVENANCE,
-            "instance_id": installation,
-            "stream": context.stream,
-            "record": item,
-        }
-        reject_credentials(provider_json)
-        authored = context.stream in ("authored_topics", "authored_posts")
-        created_at = (
-            _optional_text(item, "created_at")
-            or _optional_text(item, "last_posted_at")
-            or _optional_text(item, "last_visited_at")
-        )
-        objects.append(
-            {
-                "object_type": kind,
-                "remote_id": remote_id,
-                "account_remote_id": account_id if authored else None,
-                "text": _text(item),
-                "created_at": created_at,
-                "observed_at": observed_at,
-                "evidence_class": "authored" if authored else "observed",
-                "provider_json": provider_json,
-            }
-        )
-        activity_type = ACTIVITY_TYPES[context.stream]
-        if context.stream == "category_preferences":
-            levels = item.get("preference_levels")
-            if not isinstance(levels, list) or any(
-                not isinstance(level, str) for level in levels
-            ):
-                raise DiscourseAdapterError(
-                    "Discourse category preference levels are invalid"
-                )
-            if not levels:
-                continue
-        activities.append(
-            {
-                "activity_type": activity_type,
-                "remote_id": f"{account_id}_{activity_type}_{remote_id}",
-                "actor_remote_id": account_id,
-                "object_remote_id": remote_id,
-                "occurred_at": created_at,
-                "observed_at": observed_at,
-                "state": "active",
-                "provider_json": {
-                    "source": PROVENANCE,
-                    "instance_id": installation,
-                    "stream": context.stream,
-                },
-            }
-        )
+        objects.append(_object_row(item, context, state))
+        activity = _activity_row(item, context, state)
+        if activity is not None:
+            activities.append(activity)
+    return objects, activities
+
+
+def _archive_policy(context: PageContext, installation: str) -> dict[str, Any]:
     policy = dict(context.policy)
     policy.update(
         {
@@ -188,22 +236,30 @@ def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, A
             "discourse_redirects": "rejected",
         }
     )
+    return policy
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    """Build provider-neutral rows and explicit installation-specific gaps."""
+    reject_credentials(payload)
+    state = _normalization_state(payload, context)
+    objects, activities = _normalized_rows(payload, context, state)
     archive = {
         "provider": PROVIDER,
         "connection_id": context.connection_id,
-        "remote_account_id": account_id,
-        "exported_at": observed_at,
+        "remote_account_id": state.account_id,
+        "exported_at": state.observed_at,
         "enabled_streams": list(context.enabled_streams),
-        "policy": policy,
+        "policy": _archive_policy(context, state.installation),
         "accounts": [
             {
-                "remote_id": account_id,
+                "remote_id": state.account_id,
                 "handle": context.account.get("username"),
                 "display_name": context.account.get("name"),
-                "observed_at": observed_at,
+                "observed_at": state.observed_at,
                 "provider_json": {
                     "source": PROVENANCE,
-                    "instance_id": installation,
+                    "instance_id": state.installation,
                     "provider_account_id": context.account.get(
                         "provider_account_id"
                     ),
@@ -213,7 +269,7 @@ def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, A
         "objects": objects,
         "activities": activities,
         "media": [],
-        "coverage": _coverage(observed_at),
+        "coverage": _coverage(state.observed_at),
     }
     reject_credentials(archive)
     return archive

--- a/.agents/scripts/_knowledge_social_discourse_normalize.py
+++ b/.agents/scripts/_knowledge_social_discourse_normalize.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize allowlisted Discourse records into provider-neutral evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_discourse import (
+    PROVIDER,
+    RETENTION_LIMIT,
+    DiscourseAdapterError,
+    instance_id,
+    page_data,
+)
+from knowledge_social_import import reject_credentials
+
+PROVENANCE = "discourse_http_api"
+GAPS = (
+    ("account_archive", "manual_archive_schema_not_validated"),
+    ("followers", "discourse_follow_plugin_not_verified"),
+    ("following", "discourse_follow_plugin_not_verified"),
+    ("watched_topics", "search_side_effects_not_validated"),
+    ("tracked_topics", "search_side_effects_not_validated"),
+    ("private_message_bodies", "message_body_and_attachment_reads_not_enabled"),
+    ("complete_reading_history", "current_topic_state_not_event_history"),
+)
+OBJECT_TYPES = frozenset(
+    {
+        "topic",
+        "post",
+        "bookmark",
+        "notification",
+        "private_message_topic",
+        "topic_state",
+        "group",
+        "category",
+    }
+)
+ACTIVITY_TYPES = {
+    "authored_topics": "authored_topic",
+    "authored_posts": "authored_post",
+    "likes": "like",
+    "bookmarks": "bookmark",
+    "notifications": "notification",
+    "private_messages": "private_message_received",
+    "sent_messages": "private_message_sent",
+    "reading_state": "reading_state",
+    "groups": "group_membership",
+    "category_preferences": "category_preference",
+}
+
+
+@dataclass(frozen=True)
+class PageContext:
+    """Validated connection policy needed to normalize one Discourse page."""
+
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def _required_text(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise DiscourseAdapterError(f"Discourse record requires {key}")
+    return value
+
+
+def _optional_text(record: dict[str, Any], key: str) -> str | None:
+    value = record.get(key)
+    if value is not None and (
+        not isinstance(value, str) or "\x00" in value
+    ):
+        raise DiscourseAdapterError(f"Discourse record {key} must be text")
+    return value
+
+
+def _observed_at(payload: dict[str, Any]) -> str:
+    value = payload.get("observed_at")
+    if not isinstance(value, str) or not value:
+        raise DiscourseAdapterError("Discourse page observed_at must be text")
+    return value
+
+
+def _text(record: dict[str, Any]) -> str | None:
+    values = [
+        value
+        for key in ("title", "excerpt", "name", "description")
+        if (value := _optional_text(record, key))
+    ]
+    return "\n\n".join(values) or None
+
+
+def _coverage(observed_at: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "stream": stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": RETENTION_LIMIT,
+            "unavailable_reason": reason,
+            "status": "unavailable",
+            "observed_at": observed_at,
+        }
+        for stream, reason in GAPS
+    ]
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    """Build provider-neutral rows and explicit installation-specific gaps."""
+    reject_credentials(payload)
+    observed_at = _observed_at(payload)
+    account_id = _required_text(context.account, "id")
+    installation = instance_id(context.account.get("instance_id"))
+    objects: list[dict[str, Any]] = []
+    activities: list[dict[str, Any]] = []
+    for item in page_data(payload):
+        kind = item.get("kind")
+        if not isinstance(kind, str) or kind not in OBJECT_TYPES:
+            raise DiscourseAdapterError(
+                "Discourse page contains an unsupported item kind"
+            )
+        remote_id = _required_text(item, "remote_id")
+        provider_json = {
+            "source": PROVENANCE,
+            "instance_id": installation,
+            "stream": context.stream,
+            "record": item,
+        }
+        reject_credentials(provider_json)
+        authored = context.stream in ("authored_topics", "authored_posts")
+        created_at = (
+            _optional_text(item, "created_at")
+            or _optional_text(item, "last_posted_at")
+            or _optional_text(item, "last_visited_at")
+        )
+        objects.append(
+            {
+                "object_type": kind,
+                "remote_id": remote_id,
+                "account_remote_id": account_id if authored else None,
+                "text": _text(item),
+                "created_at": created_at,
+                "observed_at": observed_at,
+                "evidence_class": "authored" if authored else "observed",
+                "provider_json": provider_json,
+            }
+        )
+        activity_type = ACTIVITY_TYPES[context.stream]
+        if context.stream == "category_preferences":
+            levels = item.get("preference_levels")
+            if not isinstance(levels, list) or any(
+                not isinstance(level, str) for level in levels
+            ):
+                raise DiscourseAdapterError(
+                    "Discourse category preference levels are invalid"
+                )
+            if not levels:
+                continue
+        activities.append(
+            {
+                "activity_type": activity_type,
+                "remote_id": f"{account_id}_{activity_type}_{remote_id}",
+                "actor_remote_id": account_id,
+                "object_remote_id": remote_id,
+                "occurred_at": created_at,
+                "observed_at": observed_at,
+                "state": "active",
+                "provider_json": {
+                    "source": PROVENANCE,
+                    "instance_id": installation,
+                    "stream": context.stream,
+                },
+            }
+        )
+    policy = dict(context.policy)
+    policy.update(
+        {
+            "discourse_auth_scope": "read",
+            "discourse_instance_id": installation,
+            "discourse_transport": "stdlib_urllib_get_only",
+            "discourse_redirects": "rejected",
+        }
+    )
+    archive = {
+        "provider": PROVIDER,
+        "connection_id": context.connection_id,
+        "remote_account_id": account_id,
+        "exported_at": observed_at,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": policy,
+        "accounts": [
+            {
+                "remote_id": account_id,
+                "handle": context.account.get("username"),
+                "display_name": context.account.get("name"),
+                "observed_at": observed_at,
+                "provider_json": {
+                    "source": PROVENANCE,
+                    "instance_id": installation,
+                    "provider_account_id": context.account.get(
+                        "provider_account_id"
+                    ),
+                },
+            }
+        ],
+        "objects": objects,
+        "activities": activities,
+        "media": [],
+        "coverage": _coverage(observed_at),
+    }
+    reject_credentials(archive)
+    return archive

--- a/.agents/scripts/_knowledge_social_discourse_pages.py
+++ b/.agents/scripts/_knowledge_social_discourse_pages.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded pagination and stream dispatch for Discourse account reads."""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import Any, Callable
+
+from _knowledge_social_discourse import (
+    MAX_MESSAGE_PAGE_ITEMS,
+    PageRequest,
+    STREAMS,
+)
+from _knowledge_social_discourse_contract import (
+    ApiResult,
+    DiscourseReadProviderError,
+    non_negative_integer,
+    object_list,
+    object_value,
+    observed_at,
+)
+from _knowledge_social_discourse_routes import (
+    _action_record,
+    _bookmark_record,
+    _category_records,
+    _group_records,
+    _message_path,
+    _message_record,
+    _notification_record,
+    _tracking_records,
+    _user_path,
+)
+
+Api = Callable[[str, dict[str, str]], ApiResult]
+PageResult = ApiResult | dict[str, Any]
+PageHandler = Callable[[Api, PageRequest, dict[str, Any]], PageResult]
+
+
+def _snapshot_mode(request: PageRequest, snapshot: bool | None) -> bool:
+    expected = STREAMS[request.stream].pagination == "snapshot"
+    if snapshot is None:
+        return expected
+    if snapshot != expected:
+        raise DiscourseReadProviderError(
+            "Discourse response snapshot mode is invalid"
+        )
+    return snapshot
+
+
+def _accepted_records(
+    request: PageRequest, records: list[dict[str, Any]]
+) -> tuple[list[dict[str, Any]], bool]:
+    if request.stop_at is None:
+        return records, False
+    for index, record in enumerate(records):
+        if record.get("remote_id") == request.stop_at:
+            return records[:index], True
+    return records, False
+
+
+def _listing_payload(
+    request: PageRequest,
+    records: list[dict[str, Any]],
+    next_position: int | None,
+    *,
+    snapshot: bool | None = None,
+) -> dict[str, Any]:
+    accepted, reached = _accepted_records(request, records)
+    if reached:
+        next_position = None
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": accepted,
+        "meta": {
+            "stream": request.stream,
+            "instance_id": request.instance_id,
+            "next_position": next_position,
+            "newest_id": records[0].get("remote_id") if records else None,
+            "reached_watermark": reached,
+            "complete": reached or next_position is None,
+            "snapshot": _snapshot_mode(request, snapshot),
+        },
+    }
+
+
+def _user_actions(
+    api: Api, request: PageRequest, _identity: dict[str, Any]
+) -> PageResult:
+    action_filter = {
+        "authored_topics": "4",
+        "authored_posts": "5",
+        "likes": "1",
+    }[request.stream]
+    result = api(
+        "/user_actions.json",
+        {
+            "username": request.username,
+            "filter": action_filter,
+            "offset": str(request.position),
+            "limit": str(request.limit),
+        },
+    )
+    if result.status != 200:
+        return result
+    root = object_value(result.payload, "user action response")
+    source = object_list(
+        root.get("user_actions", []), "user actions", limit=request.limit
+    )
+    kind = "topic" if request.stream == "authored_topics" else "post"
+    records = [_action_record(item, request, kind) for item in source]
+    next_position = None
+    if len(source) >= request.limit:
+        next_position = request.position + len(source)
+    return _listing_payload(request, records, next_position)
+
+
+def _more_pages(
+    container: dict[str, Any], field: str, fallback: bool, message: str
+) -> bool:
+    value = container.get(field)
+    if value is not None and not isinstance(value, str):
+        raise DiscourseReadProviderError(message)
+    if field in container:
+        return bool(value)
+    return fallback
+
+
+def _bookmarks(
+    api: Api, request: PageRequest, _identity: dict[str, Any]
+) -> PageResult:
+    result = api(
+        _user_path(request.username, "bookmarks"),
+        {"page": str(request.position), "limit": str(request.limit)},
+    )
+    if result.status != 200:
+        return result
+    root = object_value(result.payload, "bookmark response")
+    listing = object_value(root.get("user_bookmark_list", root), "bookmark list")
+    source = object_list(listing.get("bookmarks", []), "bookmarks", limit=request.limit)
+    records = [_bookmark_record(item, request) for item in source]
+    has_more = _more_pages(
+        listing,
+        "more_bookmarks_url",
+        len(source) >= request.limit,
+        "Discourse bookmark pagination is invalid",
+    )
+    next_position = request.position + 1 if has_more else None
+    return _listing_payload(request, records, next_position)
+
+
+def _notification_next(
+    root: dict[str, Any], request: PageRequest, item_count: int
+) -> int | None:
+    total = non_negative_integer(
+        root.get("total_rows_notifications"),
+        "notification total",
+        optional=False,
+    )
+    consumed = request.position + item_count
+    if total is None or consumed > total:
+        raise DiscourseReadProviderError(
+            "Discourse notification pagination did not advance"
+        )
+    if item_count == 0 and request.position < total:
+        raise DiscourseReadProviderError(
+            "Discourse notification pagination did not advance"
+        )
+    return consumed if consumed < total else None
+
+
+def _notifications(
+    api: Api, request: PageRequest, _identity: dict[str, Any]
+) -> PageResult:
+    result = api(
+        "/notifications.json",
+        {
+            "username": request.username,
+            "offset": str(request.position),
+            "limit": str(request.limit),
+        },
+    )
+    if result.status != 200:
+        return result
+    root = object_value(result.payload, "notification response")
+    source = object_list(
+        root.get("notifications", []), "notifications", limit=request.limit
+    )
+    records = [_notification_record(item, request) for item in source]
+    return _listing_payload(
+        request,
+        records,
+        _notification_next(root, request, len(source)),
+    )
+
+
+def _messages(
+    api: Api,
+    request: PageRequest,
+    _identity: dict[str, Any],
+    *,
+    sent: bool,
+) -> PageResult:
+    result = api(
+        _message_path(request.username, sent), {"page": str(request.position)}
+    )
+    if result.status != 200:
+        return result
+    root = object_value(result.payload, "private-message response")
+    listing = object_value(root.get("topic_list"), "private-message topic list")
+    source = object_list(
+        listing.get("topics", []),
+        "private-message topics",
+        limit=MAX_MESSAGE_PAGE_ITEMS,
+    )
+    records = [_message_record(item, request) for item in source]
+    per_page = non_negative_integer(
+        listing.get("per_page"), "private-message page size", optional=True
+    )
+    has_more = _more_pages(
+        listing,
+        "more_topics_url",
+        len(source) >= (per_page or request.limit),
+        "Discourse private-message pagination is invalid",
+    )
+    next_position = request.position + 1 if has_more else None
+    return _listing_payload(request, records, next_position, snapshot=True)
+
+
+def _reading_state(
+    api: Api, request: PageRequest, _identity: dict[str, Any]
+) -> PageResult:
+    result = api(_user_path(request.username, "topic-tracking-state"), {})
+    if result.status != 200:
+        return result
+    records = _tracking_records(result.payload, request)
+    return _listing_payload(request, records, None, snapshot=True)
+
+
+def _groups(
+    _api: Api, request: PageRequest, identity: dict[str, Any]
+) -> PageResult:
+    records = _group_records(identity, request)
+    return _listing_payload(request, records, None, snapshot=True)
+
+
+def _category_preferences(
+    api: Api, request: PageRequest, identity: dict[str, Any]
+) -> PageResult:
+    result = api("/categories.json", {})
+    if result.status != 200:
+        return result
+    records = _category_records(result.payload, identity, request)
+    return _listing_payload(request, records, None, snapshot=True)
+
+
+PAGE_HANDLERS: dict[str, PageHandler] = {
+    "authored_topics": _user_actions,
+    "authored_posts": _user_actions,
+    "likes": _user_actions,
+    "bookmarks": _bookmarks,
+    "notifications": _notifications,
+    "private_messages": partial(_messages, sent=False),
+    "sent_messages": partial(_messages, sent=True),
+    "reading_state": _reading_state,
+    "groups": _groups,
+    "category_preferences": _category_preferences,
+}
+
+
+def page(
+    api: Api, request: PageRequest, identity: dict[str, Any]
+) -> PageResult:
+    """Execute exactly one reviewed GET route for the selected stream."""
+    handler = PAGE_HANDLERS.get(request.stream)
+    if handler is None:
+        raise DiscourseReadProviderError("Discourse stream is unsupported")
+    return handler(api, request, identity)

--- a/.agents/scripts/_knowledge_social_discourse_provider.py
+++ b/.agents/scripts/_knowledge_social_discourse_provider.py
@@ -6,22 +6,16 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
-import hmac
 import json
-import math
 import os
 import re
 import sys
-import time
-from dataclasses import dataclass
-from typing import Any, Protocol
-from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode, urlsplit
-from urllib.request import HTTPRedirectHandler, Request, build_opener
+from functools import partial
+from typing import Any
 
 from _knowledge_social_discourse import (
     DiscourseAdapterError,
+    PageRequest,
     namespaced_id,
     parse_page_request,
     provider_account_id,
@@ -33,54 +27,23 @@ from _knowledge_social_discourse_contract import (
     identity_value,
     object_value,
     observed_at,
+    request_object,
     terminal_payload,
 )
-from _knowledge_social_discourse_routes import allowlisted_path, page
+from _knowledge_social_discourse_http import (
+    HTTP_TIMEOUT_SECONDS,
+    MAX_RESPONSE_BYTES,
+    Opener,
+    ProfileConfig,
+    _api,
+    _canonical_base_url,
+    _http_exports,
+    installation_fingerprint,
+)
+from _knowledge_social_discourse_routes import page
 
 MAX_REQUEST_BYTES = 32 * 1024
-MAX_RESPONSE_BYTES = 8 * 1024 * 1024
-HTTP_TIMEOUT_SECONDS = 60
 PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
-
-
-class Response(Protocol):
-    status: int
-
-    def __enter__(self) -> Response: ...
-
-    def __exit__(self, *args: Any) -> None: ...
-
-    def read(self, size: int = -1) -> bytes: ...
-
-
-class Opener(Protocol):
-    def open(self, request: Request, timeout: int) -> Response: ...
-
-
-@dataclass(frozen=True)
-class ProfileConfig:
-    """Validated secret profile and privacy-safe installation identity."""
-
-    base_url: str
-    user_api_key: str
-    scope: str
-    instance_id: str
-
-
-class _RejectRedirect(HTTPRedirectHandler):
-    """Convert every redirect into a terminal HTTP response without following it."""
-
-    def redirect_request(
-        self,
-        req: Request,
-        fp: Any,
-        code: int,
-        msg: str,
-        headers: Any,
-        newurl: str,
-    ) -> None:
-        del req, fp, code, msg, headers, newurl
-        return None
 
 
 def _profile_prefix(profile: str) -> str:
@@ -94,51 +57,6 @@ def _profile_value(prefix: str, suffix: str, field: str, limit: int) -> str:
     if not value or "\x00" in value or len(value.encode("utf-8")) > limit:
         raise DiscourseReadProviderError(f"Discourse profile {field} is missing")
     return value
-
-
-def _canonical_base_url(value: str) -> str:
-    """Canonicalize one HTTPS installation base without leaking it in errors."""
-    try:
-        parsed = urlsplit(value)
-        port = parsed.port
-    except ValueError as error:
-        raise DiscourseReadProviderError("Discourse profile base URL is invalid") from error
-    if (
-        parsed.scheme.lower() != "https"
-        or not parsed.hostname
-        or parsed.username is not None
-        or parsed.password is not None
-        or parsed.query
-        or parsed.fragment
-    ):
-        raise DiscourseReadProviderError("Discourse profile base URL must be HTTPS")
-    path = parsed.path.rstrip("/")
-    lowered_path = path.lower()
-    if (
-        "\\" in path
-        or "%" in path
-        or "//" in path
-        or any(part in (".", "..") for part in path.split("/") if part)
-    ):
-        raise DiscourseReadProviderError("Discourse profile base URL is invalid")
-    host = parsed.hostname.lower()
-    rendered_host = f"[{host}]" if ":" in host else host
-    if port is not None and port != 443:
-        rendered_host = f"{rendered_host}:{port}"
-    if lowered_path.startswith("/admin"):
-        raise DiscourseReadProviderError("Discourse profile base URL is invalid")
-    return f"https://{rendered_host}{path}"
-
-
-def installation_fingerprint(base_url: str, origin_key: str) -> str:
-    """Return a corpus-local keyed installation namespace."""
-    canonical = _canonical_base_url(base_url)
-    key = origin_key.encode("utf-8")
-    if len(key) < 32:
-        raise DiscourseReadProviderError(
-            "Discourse profile origin key must be at least 32 bytes"
-        )
-    return hmac.new(key, canonical.encode("utf-8"), hashlib.sha256).hexdigest()[:24]
 
 
 def _profile(profile: str) -> ProfileConfig:
@@ -163,125 +81,9 @@ def _profile(profile: str) -> ProfileConfig:
     )
 
 
-def _http_exports() -> Opener:
-    """Verify and return the installed standard-library HTTP surface."""
-    if not all(
-        callable(item)
-        for item in (Request, build_opener, urlencode, urlsplit, HTTPRedirectHandler)
-    ):
-        raise DiscourseReadProviderError("Python urllib HTTP exports are unavailable")
-    return build_opener(_RejectRedirect())
-
-
 def _request() -> dict[str, Any]:
     payload = sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1)
-    if len(payload) > MAX_REQUEST_BYTES:
-        raise DiscourseReadProviderError(
-            "Discourse read request exceeds the safety limit"
-        )
-    try:
-        request = json.loads(payload.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise DiscourseReadProviderError(
-            "Discourse read request is not valid JSON"
-        ) from error
-    if not isinstance(request, dict):
-        raise DiscourseReadProviderError(
-            "Discourse read request root must be an object"
-        )
-    return request
-
-
-def _retry_epoch(value: str | None) -> int | None:
-    if value is None:
-        return None
-    try:
-        seconds = float(value)
-    except (TypeError, ValueError):
-        return None
-    if not math.isfinite(seconds) or seconds < 0:
-        return None
-    return int(time.time() + math.ceil(seconds))
-
-
-def _decode_response(payload: bytes) -> Any:
-    if len(payload) > MAX_RESPONSE_BYTES:
-        raise DiscourseReadProviderError(
-            "Discourse read response exceeds the safety limit"
-        )
-    try:
-        decoded = json.loads(payload.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise DiscourseReadProviderError(
-            "Discourse read provider returned no valid JSON"
-        ) from error
-    if not isinstance(decoded, (dict, list)):
-        raise DiscourseReadProviderError(
-            "Discourse API response root must be an object or array"
-        )
-    return decoded
-
-
-def _query_keys(path: str) -> frozenset[str]:
-    if path == "/user_actions.json":
-        return frozenset({"username", "filter", "offset", "limit"})
-    if path == "/notifications.json":
-        return frozenset({"username", "offset", "limit"})
-    if path.endswith("/bookmarks.json"):
-        return frozenset({"page", "limit"})
-    if path.startswith("/topics/private-messages"):
-        return frozenset({"page"})
-    return frozenset()
-
-
-def _api(
-    config: ProfileConfig,
-    opener: Opener,
-    path: str,
-    params: dict[str, str],
-) -> ApiResult:
-    """Execute one exact-origin, redirect-free, GET-only JSON request."""
-    if not allowlisted_path(path) or set(params) != _query_keys(path):
-        raise DiscourseReadProviderError("Discourse API route is not allowlisted")
-    if "recent" in params or any(
-        not isinstance(key, str)
-        or not isinstance(value, str)
-        or "\x00" in key
-        or "\x00" in value
-        for key, value in params.items()
-    ):
-        raise DiscourseReadProviderError("Discourse API query is invalid")
-    query = f"?{urlencode(params)}" if params else ""
-    request = Request(
-        f"{config.base_url}{path}{query}",
-        headers={
-            "Accept": "application/json",
-            "User-Api-Key": config.user_api_key,
-            "User-Agent": "aidevops-discourse-knowledge/1",
-        },
-        method="GET",
-    )
-    try:
-        with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
-            status = getattr(response, "status", 200)
-            if isinstance(status, bool) or not isinstance(status, int):
-                raise DiscourseReadProviderError("Discourse HTTP status is invalid")
-            payload = response.read(MAX_RESPONSE_BYTES + 1)
-            if not isinstance(payload, bytes):
-                raise DiscourseReadProviderError("Discourse HTTP response is invalid")
-            return ApiResult(status, _decode_response(payload))
-    except HTTPError as error:
-        status = error.code
-        if isinstance(status, bool) or not isinstance(status, int):
-            raise DiscourseReadProviderError("Discourse HTTP status is invalid") from error
-        retry_header = (
-            error.headers.get("Retry-After") if error.headers is not None else None
-        )
-        return ApiResult(status, {}, _retry_epoch(retry_header))
-    except (TimeoutError, URLError, OSError) as error:
-        raise DiscourseReadProviderError(
-            "Discourse read provider request failed"
-        ) from error
+    return request_object(payload, MAX_REQUEST_BYTES)
 
 
 def _identity(
@@ -312,49 +114,75 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _identity_action(
+    request: dict[str, Any], config: ProfileConfig, opener: Opener
+) -> dict[str, Any]:
+    exact_keys(request, {"action", "account_id"})
+    expected_id = provider_account_id(request.get("account_id"))
+    return _identity(config, opener, expected_id)
+
+
+def _verify_page_account(
+    request: PageRequest, data: dict[str, Any], config: ProfileConfig
+) -> None:
+    expected_namespace = namespaced_id(
+        config.instance_id, "user", request.provider_account_id
+    )
+    if data.get("instance_id") != request.instance_id:
+        raise DiscourseReadProviderError(
+            "selected Discourse account does not match the connection"
+        )
+    if data.get("provider_account_id") != request.provider_account_id:
+        raise DiscourseReadProviderError(
+            "selected Discourse account does not match the connection"
+        )
+    if data.get("username") != request.username:
+        raise DiscourseReadProviderError(
+            "selected Discourse account does not match the connection"
+        )
+    if request.account_id != expected_namespace:
+        raise DiscourseReadProviderError(
+            "selected Discourse account does not match the connection"
+        )
+
+
+def _page_action(
+    raw_request: dict[str, Any], config: ProfileConfig, opener: Opener
+) -> dict[str, Any]:
+    request = parse_page_request(raw_request)
+    if request.instance_id != config.instance_id:
+        raise DiscourseReadProviderError(
+            "selected Discourse installation does not match the connection"
+        )
+    identity = _identity(config, opener, request.provider_account_id)
+    if identity.get("status") != 200:
+        return identity
+    data = object_value(identity.get("data"), "account verification")
+    _verify_page_account(request, data, config)
+    result = page(partial(_api, config, opener), request, data)
+    if isinstance(result, ApiResult):
+        return terminal_payload(result)
+    return result
+
+
+def _dispatch(
+    request: dict[str, Any], config: ProfileConfig, opener: Opener
+) -> dict[str, Any]:
+    action = request.get("action")
+    if action == "identity":
+        return _identity_action(request, config, opener)
+    if action == "page":
+        return _page_action(request, config, opener)
+    raise DiscourseReadProviderError("Discourse read action is unsupported")
+
+
 def main() -> int:
     args = parse_args()
     try:
         raw_request = _request()
-        action = raw_request.get("action")
-        if action not in ("identity", "page"):
-            raise DiscourseReadProviderError("Discourse read action is unsupported")
         config = _profile(args.profile)
         opener = _http_exports()
-        if action == "identity":
-            exact_keys(raw_request, {"action", "account_id"})
-            expected_id = provider_account_id(raw_request.get("account_id"))
-            payload = _identity(config, opener, expected_id)
-        else:
-            request = parse_page_request(raw_request)
-            if request.instance_id != config.instance_id:
-                raise DiscourseReadProviderError(
-                    "selected Discourse installation does not match the connection"
-                )
-            identity = _identity(config, opener, request.provider_account_id)
-            if identity.get("status") != 200:
-                payload = identity
-            else:
-                data = object_value(identity.get("data"), "account verification")
-                expected_namespace = namespaced_id(
-                    config.instance_id, "user", request.provider_account_id
-                )
-                if (
-                    data.get("instance_id") != request.instance_id
-                    or data.get("provider_account_id") != request.provider_account_id
-                    or data.get("username") != request.username
-                    or request.account_id != expected_namespace
-                ):
-                    raise DiscourseReadProviderError(
-                        "selected Discourse account does not match the connection"
-                    )
-                result = page(
-                    lambda path, params: _api(config, opener, path, params),
-                    request,
-                    data,
-                )
-                payload = terminal_payload(result) if isinstance(result, ApiResult) else result
-        _emit(payload)
+        _emit(_dispatch(raw_request, config, opener))
         return 0
     except (DiscourseReadProviderError, DiscourseAdapterError) as error:
         print(f"ERROR: {error}", file=sys.stderr)

--- a/.agents/scripts/_knowledge_social_discourse_provider.py
+++ b/.agents/scripts/_knowledge_social_discourse_provider.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded, redirect-free, GET-only Discourse account reader subprocess."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import math
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode, urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from _knowledge_social_discourse import (
+    DiscourseAdapterError,
+    namespaced_id,
+    parse_page_request,
+    provider_account_id,
+)
+from _knowledge_social_discourse_contract import (
+    ApiResult,
+    DiscourseReadProviderError,
+    exact_keys,
+    identity_value,
+    object_value,
+    observed_at,
+    terminal_payload,
+)
+from _knowledge_social_discourse_routes import allowlisted_path, page
+
+MAX_REQUEST_BYTES = 32 * 1024
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+HTTP_TIMEOUT_SECONDS = 60
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+
+
+class Response(Protocol):
+    status: int
+
+    def __enter__(self) -> Response: ...
+
+    def __exit__(self, *args: Any) -> None: ...
+
+    def read(self, size: int = -1) -> bytes: ...
+
+
+class Opener(Protocol):
+    def open(self, request: Request, timeout: int) -> Response: ...
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    """Validated secret profile and privacy-safe installation identity."""
+
+    base_url: str
+    user_api_key: str
+    scope: str
+    instance_id: str
+
+
+class _RejectRedirect(HTTPRedirectHandler):
+    """Convert every redirect into a terminal HTTP response without following it."""
+
+    def redirect_request(
+        self,
+        req: Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> None:
+        del req, fp, code, msg, headers, newurl
+        return None
+
+
+def _profile_prefix(profile: str) -> str:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise DiscourseReadProviderError("Discourse profile name is invalid")
+    return f"DISCOURSE_{profile.upper()}"
+
+
+def _profile_value(prefix: str, suffix: str, field: str, limit: int) -> str:
+    value = os.environ.get(f"{prefix}_{suffix}", "")
+    if not value or "\x00" in value or len(value.encode("utf-8")) > limit:
+        raise DiscourseReadProviderError(f"Discourse profile {field} is missing")
+    return value
+
+
+def _canonical_base_url(value: str) -> str:
+    """Canonicalize one HTTPS installation base without leaking it in errors."""
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError as error:
+        raise DiscourseReadProviderError("Discourse profile base URL is invalid") from error
+    if (
+        parsed.scheme.lower() != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise DiscourseReadProviderError("Discourse profile base URL must be HTTPS")
+    path = parsed.path.rstrip("/")
+    lowered_path = path.lower()
+    if (
+        "\\" in path
+        or "%" in path
+        or "//" in path
+        or any(part in (".", "..") for part in path.split("/") if part)
+    ):
+        raise DiscourseReadProviderError("Discourse profile base URL is invalid")
+    host = parsed.hostname.lower()
+    rendered_host = f"[{host}]" if ":" in host else host
+    if port is not None and port != 443:
+        rendered_host = f"{rendered_host}:{port}"
+    if lowered_path.startswith("/admin"):
+        raise DiscourseReadProviderError("Discourse profile base URL is invalid")
+    return f"https://{rendered_host}{path}"
+
+
+def installation_fingerprint(base_url: str, origin_key: str) -> str:
+    """Return a corpus-local keyed installation namespace."""
+    canonical = _canonical_base_url(base_url)
+    key = origin_key.encode("utf-8")
+    if len(key) < 32:
+        raise DiscourseReadProviderError(
+            "Discourse profile origin key must be at least 32 bytes"
+        )
+    return hmac.new(key, canonical.encode("utf-8"), hashlib.sha256).hexdigest()[:24]
+
+
+def _profile(profile: str) -> ProfileConfig:
+    prefix = _profile_prefix(profile)
+    base_url = _canonical_base_url(
+        _profile_value(prefix, "BASE_URL", "base URL", 4096)
+    )
+    user_api_key = _profile_value(
+        prefix, "USER_API_KEY", "user API key", 16 * 1024
+    )
+    origin_key = _profile_value(prefix, "ORIGIN_KEY", "origin key", 16 * 1024)
+    scope = _profile_value(prefix, "USER_API_SCOPE", "user API scope", 64)
+    if scope != "read":
+        raise DiscourseReadProviderError(
+            "Discourse user API profile must declare the read scope"
+        )
+    return ProfileConfig(
+        base_url,
+        user_api_key,
+        scope,
+        installation_fingerprint(base_url, origin_key),
+    )
+
+
+def _http_exports() -> Opener:
+    """Verify and return the installed standard-library HTTP surface."""
+    if not all(
+        callable(item)
+        for item in (Request, build_opener, urlencode, urlsplit, HTTPRedirectHandler)
+    ):
+        raise DiscourseReadProviderError("Python urllib HTTP exports are unavailable")
+    return build_opener(_RejectRedirect())
+
+
+def _request() -> dict[str, Any]:
+    payload = sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1)
+    if len(payload) > MAX_REQUEST_BYTES:
+        raise DiscourseReadProviderError(
+            "Discourse read request exceeds the safety limit"
+        )
+    try:
+        request = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise DiscourseReadProviderError(
+            "Discourse read request is not valid JSON"
+        ) from error
+    if not isinstance(request, dict):
+        raise DiscourseReadProviderError(
+            "Discourse read request root must be an object"
+        )
+    return request
+
+
+def _retry_epoch(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    return int(time.time() + math.ceil(seconds))
+
+
+def _decode_response(payload: bytes) -> Any:
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise DiscourseReadProviderError(
+            "Discourse read response exceeds the safety limit"
+        )
+    try:
+        decoded = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise DiscourseReadProviderError(
+            "Discourse read provider returned no valid JSON"
+        ) from error
+    if not isinstance(decoded, (dict, list)):
+        raise DiscourseReadProviderError(
+            "Discourse API response root must be an object or array"
+        )
+    return decoded
+
+
+def _query_keys(path: str) -> frozenset[str]:
+    if path == "/user_actions.json":
+        return frozenset({"username", "filter", "offset", "limit"})
+    if path == "/notifications.json":
+        return frozenset({"username", "offset", "limit"})
+    if path.endswith("/bookmarks.json"):
+        return frozenset({"page", "limit"})
+    if path.startswith("/topics/private-messages"):
+        return frozenset({"page"})
+    return frozenset()
+
+
+def _api(
+    config: ProfileConfig,
+    opener: Opener,
+    path: str,
+    params: dict[str, str],
+) -> ApiResult:
+    """Execute one exact-origin, redirect-free, GET-only JSON request."""
+    if not allowlisted_path(path) or set(params) != _query_keys(path):
+        raise DiscourseReadProviderError("Discourse API route is not allowlisted")
+    if "recent" in params or any(
+        not isinstance(key, str)
+        or not isinstance(value, str)
+        or "\x00" in key
+        or "\x00" in value
+        for key, value in params.items()
+    ):
+        raise DiscourseReadProviderError("Discourse API query is invalid")
+    query = f"?{urlencode(params)}" if params else ""
+    request = Request(
+        f"{config.base_url}{path}{query}",
+        headers={
+            "Accept": "application/json",
+            "User-Api-Key": config.user_api_key,
+            "User-Agent": "aidevops-discourse-knowledge/1",
+        },
+        method="GET",
+    )
+    try:
+        with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", 200)
+            if isinstance(status, bool) or not isinstance(status, int):
+                raise DiscourseReadProviderError("Discourse HTTP status is invalid")
+            payload = response.read(MAX_RESPONSE_BYTES + 1)
+            if not isinstance(payload, bytes):
+                raise DiscourseReadProviderError("Discourse HTTP response is invalid")
+            return ApiResult(status, _decode_response(payload))
+    except HTTPError as error:
+        status = error.code
+        if isinstance(status, bool) or not isinstance(status, int):
+            raise DiscourseReadProviderError("Discourse HTTP status is invalid") from error
+        retry_header = (
+            error.headers.get("Retry-After") if error.headers is not None else None
+        )
+        return ApiResult(status, {}, _retry_epoch(retry_header))
+    except (TimeoutError, URLError, OSError) as error:
+        raise DiscourseReadProviderError(
+            "Discourse read provider request failed"
+        ) from error
+
+
+def _identity(
+    config: ProfileConfig, opener: Opener, expected_id: str
+) -> dict[str, Any]:
+    result = _api(config, opener, "/session/current.json", {})
+    if result.status != 200:
+        return terminal_payload(result)
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": identity_value(result.payload, expected_id, config.instance_id),
+    }
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode("utf-8")) > MAX_RESPONSE_BYTES:
+        raise DiscourseReadProviderError(
+            "Discourse read response exceeds the safety limit"
+        )
+    print(encoded)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        raw_request = _request()
+        action = raw_request.get("action")
+        if action not in ("identity", "page"):
+            raise DiscourseReadProviderError("Discourse read action is unsupported")
+        config = _profile(args.profile)
+        opener = _http_exports()
+        if action == "identity":
+            exact_keys(raw_request, {"action", "account_id"})
+            expected_id = provider_account_id(raw_request.get("account_id"))
+            payload = _identity(config, opener, expected_id)
+        else:
+            request = parse_page_request(raw_request)
+            if request.instance_id != config.instance_id:
+                raise DiscourseReadProviderError(
+                    "selected Discourse installation does not match the connection"
+                )
+            identity = _identity(config, opener, request.provider_account_id)
+            if identity.get("status") != 200:
+                payload = identity
+            else:
+                data = object_value(identity.get("data"), "account verification")
+                expected_namespace = namespaced_id(
+                    config.instance_id, "user", request.provider_account_id
+                )
+                if (
+                    data.get("instance_id") != request.instance_id
+                    or data.get("provider_account_id") != request.provider_account_id
+                    or data.get("username") != request.username
+                    or request.account_id != expected_namespace
+                ):
+                    raise DiscourseReadProviderError(
+                        "selected Discourse account does not match the connection"
+                    )
+                result = page(
+                    lambda path, params: _api(config, opener, path, params),
+                    request,
+                    data,
+                )
+                payload = terminal_payload(result) if isinstance(result, ApiResult) else result
+        _emit(payload)
+        return 0
+    except (DiscourseReadProviderError, DiscourseAdapterError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - intentionally redact provider internals
+        print("ERROR: Discourse read provider request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_discourse_reader.py
+++ b/.agents/scripts/_knowledge_social_discourse_reader.py
@@ -126,23 +126,27 @@ class GuardedDiscourse:
         return self.process.run(request.payload())
 
 
+def _fixture_object(value: Any, message: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise DiscourseAdapterError(message)
+    return value
+
+
 def _fixture_page(entry: dict[str, Any], request: PageRequest) -> dict[str, Any]:
-    expectation = entry.get("expect_request", {})
-    if not isinstance(expectation, dict):
-        raise DiscourseAdapterError(
-            "Discourse fixture request expectation must be an object"
-        )
+    expectation = _fixture_object(
+        entry.get("expect_request", {}),
+        "Discourse fixture request expectation must be an object",
+    )
     actual = request.payload()
-    if any(actual.get(key) != value for key, value in expectation.items()):
-        raise DiscourseAdapterError(
-            "Discourse request did not resume at the expected checkpoint"
-        )
-    response = entry.get("response", entry)
-    if not isinstance(response, dict):
-        raise DiscourseAdapterError(
-            "Discourse fixture page response must be an object"
-        )
-    return response
+    for key, value in expectation.items():
+        if actual.get(key) != value:
+            raise DiscourseAdapterError(
+                "Discourse request did not resume at the expected checkpoint"
+            )
+    return _fixture_object(
+        entry.get("response", entry),
+        "Discourse fixture page response must be an object",
+    )
 
 
 class FixtureDiscourse:
@@ -157,6 +161,20 @@ class FixtureDiscourse:
 
     def page(self, request: PageRequest) -> dict[str, Any]:
         return _fixture_page(self.fixture.next_page(), request)
+
+
+def _display_name(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise DiscourseAdapterError("Discourse account name must be text")
+    if not value:
+        raise DiscourseAdapterError("Discourse account name must be text")
+    if "\x00" in value:
+        raise DiscourseAdapterError("Discourse account name must be text")
+    if len(value.encode("utf-8")) > 256 * 1024:
+        raise DiscourseAdapterError("Discourse account name must be text")
+    return value
 
 
 def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
@@ -174,14 +192,7 @@ def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, An
         raise DiscourseAdapterError(
             "selected Discourse account does not match the configured connection"
         )
-    display_name = data.get("name")
-    if display_name is not None and (
-        not isinstance(display_name, str)
-        or not display_name
-        or "\x00" in display_name
-        or len(display_name.encode("utf-8")) > 256 * 1024
-    ):
-        raise DiscourseAdapterError("Discourse account name must be text")
+    display_name = _display_name(data.get("name"))
     return {
         "id": namespaced_id(installation, "user", local_id),
         "provider_account_id": local_id,

--- a/.agents/scripts/_knowledge_social_discourse_reader.py
+++ b/.agents/scripts/_knowledge_social_discourse_reader.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and deterministic fixture readers for Discourse collection."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Protocol
+
+from _knowledge_social_collect_cli import (
+    READER_ENVIRONMENT_KEYS,
+    GuardedReaderProcess,
+)
+from _knowledge_social_discourse import (
+    PageRequest,
+    DiscourseAdapterError,
+    DiscourseProviderUnavailableError,
+    instance_id,
+    namespaced_id,
+    provider_account_id,
+    username,
+)
+from _knowledge_social_fixture import FixtureSequence
+from knowledge_social_import import reject_credentials
+
+READ_TIMEOUT_SECONDS = 120
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+SAFE_PROVIDER_FAILURES = (
+    "Python urllib HTTP exports are unavailable",
+    "Discourse profile name is invalid",
+    "Discourse profile base URL is missing",
+    "Discourse profile base URL must be HTTPS",
+    "Discourse profile user API key is missing",
+    "Discourse profile origin key is missing",
+    "Discourse profile origin key must be at least 32 bytes",
+    "Discourse profile user API scope is missing",
+    "Discourse user API profile must declare the read scope",
+    "selected Discourse account does not match the configured connection",
+    "selected Discourse installation does not match the connection",
+)
+
+
+class DiscourseReader(Protocol):
+    """Minimal read-only surface consumed by the shared OAuth collector."""
+
+    def identity(self, expected_id: str) -> dict[str, Any]: ...
+
+    def page(self, request: PageRequest) -> dict[str, Any]: ...
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    if len(output.encode("utf-8")) > MAX_RESPONSE_BYTES:
+        raise DiscourseAdapterError("Discourse read response exceeds the safety limit")
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise DiscourseAdapterError(
+            "Discourse read provider returned no valid JSON"
+        ) from error
+    if not isinstance(payload, dict):
+        raise DiscourseAdapterError("Discourse read response root must be an object")
+    return payload
+
+
+def _provider_failure(stderr: str) -> DiscourseProviderUnavailableError:
+    for message in SAFE_PROVIDER_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return DiscourseProviderUnavailableError(message)
+    return DiscourseProviderUnavailableError(
+        "Discourse read provider is unavailable"
+    )
+
+
+class GuardedDiscourse:
+    """Execute only identity and allowlisted page reads in a bounded child."""
+
+    def __init__(self, helper: Path, profile: str) -> None:
+        if PROFILE_NAME.fullmatch(profile) is None:
+            raise DiscourseProviderUnavailableError(
+                "Discourse profile name is invalid"
+            )
+        if helper.is_symlink() or not helper.is_file():
+            raise DiscourseProviderUnavailableError(
+                "Discourse read provider is unavailable"
+            )
+        self.profile = profile
+        self.process = GuardedReaderProcess(
+            helper=helper,
+            profile=profile,
+            environment=self._environment,
+            timeout_seconds=READ_TIMEOUT_SECONDS,
+            decode_output=_decode_output,
+            provider_failure=_provider_failure,
+            unavailable_error=DiscourseProviderUnavailableError,
+            provider_name="Discourse",
+        )
+
+    def _environment(self) -> dict[str, str]:
+        prefix = f"DISCOURSE_{self.profile.upper()}"
+        profile_keys = {
+            f"{prefix}_BASE_URL",
+            f"{prefix}_USER_API_KEY",
+            f"{prefix}_ORIGIN_KEY",
+            f"{prefix}_USER_API_SCOPE",
+        }
+        environment = {
+            key: value
+            for key, value in os.environ.items()
+            if key in READER_ENVIRONMENT_KEYS or key in profile_keys
+        }
+        if os.environ.get("AIDEVOPS_TEST_MODE") == "1":
+            for key in ("AIDEVOPS_TEST_MODE", "PYTHONPATH", "DISCOURSE_READ_LOG"):
+                if key in os.environ:
+                    environment[key] = os.environ[key]
+        return environment
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        return self.process.run({"action": "identity", "account_id": expected_id})
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        return self.process.run(request.payload())
+
+
+def _fixture_page(entry: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    expectation = entry.get("expect_request", {})
+    if not isinstance(expectation, dict):
+        raise DiscourseAdapterError(
+            "Discourse fixture request expectation must be an object"
+        )
+    actual = request.payload()
+    if any(actual.get(key) != value for key, value in expectation.items()):
+        raise DiscourseAdapterError(
+            "Discourse request did not resume at the expected checkpoint"
+        )
+    response = entry.get("response", entry)
+    if not isinstance(response, dict):
+        raise DiscourseAdapterError(
+            "Discourse fixture page response must be an object"
+        )
+    return response
+
+
+class FixtureDiscourse:
+    """Deterministic HTTP substitute for pagination and failure fixtures."""
+
+    def __init__(self, path: Path) -> None:
+        self.fixture = FixtureSequence(path, "Discourse", DiscourseAdapterError)
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        del expected_id
+        return self.fixture.identity()
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        return _fixture_page(self.fixture.next_page(), request)
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    """Bind an installation-local user ID to a privacy-safe global namespace."""
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise DiscourseAdapterError(
+            "Discourse account verification returned no account"
+        )
+    local_id = provider_account_id(data.get("provider_account_id"))
+    installation = instance_id(data.get("instance_id"))
+    handle = username(data.get("username"))
+    if local_id != provider_account_id(expected_id):
+        raise DiscourseAdapterError(
+            "selected Discourse account does not match the configured connection"
+        )
+    display_name = data.get("name")
+    if display_name is not None and (
+        not isinstance(display_name, str)
+        or not display_name
+        or "\x00" in display_name
+        or len(display_name.encode("utf-8")) > 256 * 1024
+    ):
+        raise DiscourseAdapterError("Discourse account name must be text")
+    return {
+        "id": namespaced_id(installation, "user", local_id),
+        "provider_account_id": local_id,
+        "instance_id": installation,
+        "username": handle,
+        "name": display_name,
+    }

--- a/.agents/scripts/_knowledge_social_discourse_routes.py
+++ b/.agents/scripts/_knowledge_social_discourse_routes.py
@@ -266,266 +266,100 @@ def _group_records(identity: dict[str, Any], request: PageRequest) -> list[dict[
     ]
 
 
-def _category_records(
-    payload: Any, identity: dict[str, Any], request: PageRequest
-) -> list[dict[str, Any]]:
+def _category_source(payload: Any) -> list[dict[str, Any]]:
     root = object_value(payload, "category response")
     category_list = object_value(root.get("category_list"), "category list")
-    categories = object_list(
+    return object_list(
         category_list.get("categories", []),
         "categories",
         limit=MAX_SNAPSHOT_ITEMS,
     )
+
+
+def _preference_values(level: Any, values: Any) -> tuple[str, list[str]]:
+    if not isinstance(level, str):
+        raise DiscourseReadProviderError("Discourse category preferences are invalid")
+    if not isinstance(values, list):
+        raise DiscourseReadProviderError("Discourse category preferences are invalid")
+    return level, [required_text(value, "category preference ID") for value in values]
+
+
+def _preference_map(identity: dict[str, Any]) -> dict[str, list[str]]:
     preferences = object_value(
         identity.get("category_preferences", {}), "category preferences"
     )
     by_id: dict[str, list[str]] = {}
     for level, values in preferences.items():
-        if not isinstance(level, str) or not isinstance(values, list):
-            raise DiscourseReadProviderError(
-                "Discourse category preferences are invalid"
-            )
-        for value in values:
-            local_id = required_text(value, "category preference ID")
-            by_id.setdefault(local_id, []).append(level)
-    records: list[dict[str, Any]] = []
-    observed_ids: set[str] = set()
-    for item in categories:
-        local_id = positive_id(item.get("id"), "category ID")
-        if local_id is None:
-            raise DiscourseReadProviderError("Discourse category has no stable ID")
-        observed_ids.add(local_id)
-        records.append(
-            {
-                "kind": "category",
-                "remote_id": resource_id(
-                    request.instance_id,
-                    "category",
-                    int(local_id),
-                    "category ID",
-                ),
-                "category_id": local_id,
-                "name": required_text(item.get("name"), "category name"),
-                "slug": optional_text(item.get("slug"), "category slug"),
-                "description": optional_text(
-                    item.get("description_text"), "category description"
-                ),
-                "preference_levels": sorted(by_id.get(local_id, [])),
-                "resolved": True,
-            }
-        )
-    for local_id, levels in sorted(by_id.items()):
-        if local_id in observed_ids:
-            continue
-        records.append(
-            {
-                "kind": "category",
-                "remote_id": resource_id(
-                    request.instance_id,
-                    "category",
-                    int(local_id),
-                    "category preference ID",
-                ),
-                "category_id": local_id,
-                "name": None,
-                "slug": None,
-                "description": None,
-                "preference_levels": sorted(levels),
-                "resolved": False,
-            }
-        )
-    return records
+        label, local_ids = _preference_values(level, values)
+        for local_id in local_ids:
+            by_id.setdefault(local_id, []).append(label)
+    return by_id
 
 
-def _listing_payload(
-    request: PageRequest,
-    records: list[dict[str, Any]],
-    next_position: int | None,
-    *,
-    snapshot: bool | None = None,
+def _resolved_category(
+    item: dict[str, Any], by_id: dict[str, list[str]], request: PageRequest
 ) -> dict[str, Any]:
-    expected_snapshot = STREAMS[request.stream].pagination == "snapshot"
-    if snapshot is not None and snapshot != expected_snapshot:
-        raise DiscourseReadProviderError(
-            "Discourse response snapshot mode is invalid"
-        )
-    is_snapshot = expected_snapshot if snapshot is None else snapshot
-    newest = records[0].get("remote_id") if records else None
-    accepted: list[dict[str, Any]] = []
-    reached = False
-    for record in records:
-        if request.stop_at is not None and record.get("remote_id") == request.stop_at:
-            reached = True
-            break
-        accepted.append(record)
-    if reached:
-        next_position = None
-    complete = reached or next_position is None
+    local_id = positive_id(item.get("id"), "category ID")
+    if local_id is None:
+        raise DiscourseReadProviderError("Discourse category has no stable ID")
     return {
-        "status": 200,
-        "observed_at": observed_at(),
-        "data": accepted,
-        "meta": {
-            "stream": request.stream,
-            "instance_id": request.instance_id,
-            "next_position": next_position,
-            "newest_id": newest,
-            "reached_watermark": reached,
-            "complete": complete,
-            "snapshot": is_snapshot,
-        },
+        "kind": "category",
+        "remote_id": resource_id(
+            request.instance_id,
+            "category",
+            int(local_id),
+            "category ID",
+        ),
+        "category_id": local_id,
+        "name": required_text(item.get("name"), "category name"),
+        "slug": optional_text(item.get("slug"), "category slug"),
+        "description": optional_text(
+            item.get("description_text"), "category description"
+        ),
+        "preference_levels": sorted(by_id.get(local_id, [])),
+        "resolved": True,
     }
 
 
-def _user_actions(api: Api, request: PageRequest) -> ApiResult | dict[str, Any]:
-    action_filter = {
-        "authored_topics": "4",
-        "authored_posts": "5",
-        "likes": "1",
-    }[request.stream]
-    result = api(
-        "/user_actions.json",
-        {
-            "username": request.username,
-            "filter": action_filter,
-            "offset": str(request.position),
-            "limit": str(request.limit),
-        },
-    )
-    if result.status != 200:
-        return result
-    root = object_value(result.payload, "user action response")
-    source = object_list(
-        root.get("user_actions", []), "user actions", limit=request.limit
-    )
-    kind = "topic" if request.stream == "authored_topics" else "post"
-    records = [_action_record(item, request, kind) for item in source]
-    next_position = (
-        request.position + len(source) if len(source) >= request.limit else None
-    )
-    return _listing_payload(request, records, next_position)
+def _unresolved_category(
+    local_id: str, levels: list[str], request: PageRequest
+) -> dict[str, Any]:
+    return {
+        "kind": "category",
+        "remote_id": resource_id(
+            request.instance_id,
+            "category",
+            int(local_id),
+            "category preference ID",
+        ),
+        "category_id": local_id,
+        "name": None,
+        "slug": None,
+        "description": None,
+        "preference_levels": sorted(levels),
+        "resolved": False,
+    }
 
 
-def _bookmarks(api: Api, request: PageRequest) -> ApiResult | dict[str, Any]:
-    result = api(
-        _user_path(request.username, "bookmarks"),
-        {"page": str(request.position), "limit": str(request.limit)},
+def _category_records(
+    payload: Any, identity: dict[str, Any], request: PageRequest
+) -> list[dict[str, Any]]:
+    by_id = _preference_map(identity)
+    records = [
+        _resolved_category(item, by_id, request) for item in _category_source(payload)
+    ]
+    observed_ids = {record["category_id"] for record in records}
+    records.extend(
+        _unresolved_category(local_id, by_id[local_id], request)
+        for local_id in sorted(set(by_id) - observed_ids)
     )
-    if result.status != 200:
-        return result
-    root = object_value(result.payload, "bookmark response")
-    listing = root.get("user_bookmark_list", root)
-    listing_object = object_value(listing, "bookmark list")
-    source = object_list(
-        listing_object.get("bookmarks", []), "bookmarks", limit=request.limit
-    )
-    records = [_bookmark_record(item, request) for item in source]
-    more = listing_object.get("more_bookmarks_url")
-    if more is not None and not isinstance(more, str):
-        raise DiscourseReadProviderError("Discourse bookmark pagination is invalid")
-    has_more = bool(more) if "more_bookmarks_url" in listing_object else len(source) >= request.limit
-    return _listing_payload(
-        request, records, request.position + 1 if has_more else None
-    )
-
-
-def _notifications(api: Api, request: PageRequest) -> ApiResult | dict[str, Any]:
-    result = api(
-        "/notifications.json",
-        {
-            "username": request.username,
-            "offset": str(request.position),
-            "limit": str(request.limit),
-        },
-    )
-    if result.status != 200:
-        return result
-    root = object_value(result.payload, "notification response")
-    source = object_list(
-        root.get("notifications", []), "notifications", limit=request.limit
-    )
-    records = [_notification_record(item, request) for item in source]
-    total = non_negative_integer(
-        root.get("total_rows_notifications"),
-        "notification total",
-        optional=False,
-    )
-    consumed = request.position + len(source)
-    if total is None or consumed > total or (not source and request.position < total):
-        raise DiscourseReadProviderError(
-            "Discourse notification pagination did not advance"
-        )
-    return _listing_payload(request, records, consumed if consumed < total else None)
-
-
-def _messages(
-    api: Api, request: PageRequest, *, sent: bool
-) -> ApiResult | dict[str, Any]:
-    result = api(
-        _message_path(request.username, sent), {"page": str(request.position)}
-    )
-    if result.status != 200:
-        return result
-    root = object_value(result.payload, "private-message response")
-    listing = object_value(root.get("topic_list"), "private-message topic list")
-    source = object_list(
-        listing.get("topics", []),
-        "private-message topics",
-        limit=MAX_MESSAGE_PAGE_ITEMS,
-    )
-    records = [_message_record(item, request) for item in source]
-    more = listing.get("more_topics_url")
-    if more is not None and not isinstance(more, str):
-        raise DiscourseReadProviderError(
-            "Discourse private-message pagination is invalid"
-        )
-    per_page = non_negative_integer(
-        listing.get("per_page"), "private-message page size", optional=True
-    )
-    has_more = bool(more) if "more_topics_url" in listing else len(source) >= (per_page or request.limit)
-    return _listing_payload(
-        request,
-        records,
-        request.position + 1 if has_more else None,
-        snapshot=True,
-    )
+    return records
 
 
 def page(
     api: Api, request: PageRequest, identity: dict[str, Any]
 ) -> ApiResult | dict[str, Any]:
     """Execute exactly one reviewed GET route for the selected stream."""
-    if request.stream not in STREAMS:
-        raise DiscourseReadProviderError("Discourse stream is unsupported")
-    if request.stream in ("authored_topics", "authored_posts", "likes"):
-        return _user_actions(api, request)
-    if request.stream == "bookmarks":
-        return _bookmarks(api, request)
-    if request.stream == "notifications":
-        return _notifications(api, request)
-    if request.stream == "private_messages":
-        return _messages(api, request, sent=False)
-    if request.stream == "sent_messages":
-        return _messages(api, request, sent=True)
-    if request.stream == "reading_state":
-        result = api(_user_path(request.username, "topic-tracking-state"), {})
-        if result.status != 200:
-            return result
-        return _listing_payload(
-            request, _tracking_records(result.payload, request), None, snapshot=True
-        )
-    if request.stream == "groups":
-        return _listing_payload(
-            request, _group_records(identity, request), None, snapshot=True
-        )
-    if request.stream == "category_preferences":
-        result = api("/categories.json", {})
-        if result.status != 200:
-            return result
-        return _listing_payload(
-            request,
-            _category_records(result.payload, identity, request),
-            None,
-            snapshot=True,
-        )
-    raise DiscourseReadProviderError("Discourse stream is unsupported")
+    from _knowledge_social_discourse_pages import page as execute_page
+
+    return execute_page(api, request, identity)

--- a/.agents/scripts/_knowledge_social_discourse_routes.py
+++ b/.agents/scripts/_knowledge_social_discourse_routes.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Exact GET route allowlist and serializers for Discourse account reads."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable
+from urllib.parse import quote
+
+from _knowledge_social_discourse import (
+    MAX_MESSAGE_PAGE_ITEMS,
+    MAX_SNAPSHOT_ITEMS,
+    PageRequest,
+    STREAMS,
+)
+from _knowledge_social_discourse_contract import (
+    ApiResult,
+    DiscourseReadProviderError,
+    non_negative_integer,
+    object_list,
+    object_value,
+    observed_at,
+    optional_boolean,
+    optional_text,
+    positive_id,
+    required_text,
+    resource_id,
+)
+
+Api = Callable[[str, dict[str, str]], ApiResult]
+
+EXACT_READ_PATHS = frozenset(
+    {
+        "/session/current.json",
+        "/user_actions.json",
+        "/notifications.json",
+        "/categories.json",
+    }
+)
+PARAMETERIZED_READ_PATHS = (
+    re.compile(r"^/u/[A-Za-z0-9_.-]+/bookmarks\.json$"),
+    re.compile(r"^/u/[A-Za-z0-9_.-]+/topic-tracking-state\.json$"),
+    re.compile(r"^/topics/private-messages/[A-Za-z0-9_.-]+\.json$"),
+    re.compile(r"^/topics/private-messages-sent/[A-Za-z0-9_.-]+\.json$"),
+)
+
+
+def allowlisted_path(path: str) -> bool:
+    """Return whether a path is one of the reviewed account-visible GET routes."""
+    return path in EXACT_READ_PATHS or any(
+        pattern.fullmatch(path) for pattern in PARAMETERIZED_READ_PATHS
+    )
+
+
+def _user_path(handle: str, suffix: str) -> str:
+    encoded = quote(handle, safe="")
+    path = f"/u/{encoded}/{suffix}.json"
+    if not allowlisted_path(path):
+        raise DiscourseReadProviderError("Discourse API path is not allowlisted")
+    return path
+
+
+def _message_path(handle: str, sent: bool) -> str:
+    encoded = quote(handle, safe="")
+    direction = "private-messages-sent" if sent else "private-messages"
+    path = f"/topics/{direction}/{encoded}.json"
+    if not allowlisted_path(path):
+        raise DiscourseReadProviderError("Discourse API path is not allowlisted")
+    return path
+
+
+def _action_record(
+    item: dict[str, Any], request: PageRequest, kind: str
+) -> dict[str, Any]:
+    object_field = "topic_id" if kind == "topic" else "post_id"
+    local_id = positive_id(item.get(object_field), f"{kind} ID")
+    if local_id is None:
+        raise DiscourseReadProviderError(f"Discourse {kind} ID is required")
+    action_type = non_negative_integer(item.get("action_type"), "action type")
+    expected_action = 4 if kind == "topic" else 5 if request.stream == "authored_posts" else 1
+    if action_type != expected_action:
+        raise DiscourseReadProviderError(
+            "Discourse user action does not match the selected stream"
+        )
+    return {
+        "kind": kind,
+        "remote_id": resource_id(
+            request.instance_id, kind, item.get(object_field), f"{kind} ID"
+        ),
+        "topic_id": positive_id(item.get("topic_id"), "topic ID", optional=True),
+        "post_id": positive_id(item.get("post_id"), "post ID", optional=True),
+        "action_type": action_type,
+        "title": optional_text(item.get("title"), "action title"),
+        "excerpt": optional_text(item.get("excerpt"), "action excerpt"),
+        "created_at": optional_text(item.get("created_at"), "action timestamp"),
+    }
+
+
+def _bookmark_record(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    bookmark_id = positive_id(item.get("id"), "bookmark ID")
+    post_id = positive_id(item.get("post_id"), "bookmark post ID", optional=True)
+    source_id = post_id or bookmark_id
+    if source_id is None or bookmark_id is None:
+        raise DiscourseReadProviderError("Discourse bookmark has no stable ID")
+    return {
+        "kind": "post" if post_id else "bookmark",
+        "remote_id": resource_id(
+            request.instance_id,
+            "post" if post_id else "bookmark",
+            int(source_id),
+            "bookmark object ID",
+        ),
+        "bookmark_id": bookmark_id,
+        "topic_id": positive_id(item.get("topic_id"), "bookmark topic ID", optional=True),
+        "post_id": post_id,
+        "title": optional_text(item.get("title"), "bookmark title"),
+        "excerpt": optional_text(item.get("excerpt"), "bookmark excerpt"),
+        "created_at": optional_text(item.get("created_at"), "bookmark timestamp"),
+    }
+
+
+def _notification_record(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    notification_id = positive_id(item.get("id"), "notification ID")
+    if notification_id is None:
+        raise DiscourseReadProviderError("Discourse notification has no stable ID")
+    return {
+        "kind": "notification",
+        "remote_id": resource_id(
+            request.instance_id,
+            "notification",
+            int(notification_id),
+            "notification ID",
+        ),
+        "notification_type": non_negative_integer(
+            item.get("notification_type"), "notification type"
+        ),
+        "read": optional_boolean(item.get("read"), "notification read flag"),
+        "topic_id": positive_id(item.get("topic_id"), "notification topic ID", optional=True),
+        "post_number": non_negative_integer(
+            item.get("post_number"), "notification post number", optional=True
+        ),
+        "created_at": optional_text(
+            item.get("created_at"), "notification timestamp"
+        ),
+    }
+
+
+def _message_record(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    topic_id = positive_id(item.get("id"), "private-message topic ID")
+    if topic_id is None:
+        raise DiscourseReadProviderError(
+            "Discourse private-message topic has no stable ID"
+        )
+    archetype = item.get("archetype")
+    if archetype not in (None, "private_message"):
+        raise DiscourseReadProviderError(
+            "Discourse private-message listing returned a public topic"
+        )
+    return {
+        "kind": "private_message_topic",
+        "remote_id": resource_id(
+            request.instance_id,
+            "message",
+            int(topic_id),
+            "private-message topic ID",
+        ),
+        "topic_id": topic_id,
+        "title": optional_text(item.get("title"), "private-message title"),
+        "created_at": optional_text(
+            item.get("created_at"), "private-message timestamp"
+        ),
+        "last_posted_at": optional_text(
+            item.get("last_posted_at"), "private-message last-post timestamp"
+        ),
+        "posts_count": non_negative_integer(
+            item.get("posts_count"), "private-message post count", optional=True
+        ),
+        "reply_count": non_negative_integer(
+            item.get("reply_count"), "private-message reply count", optional=True
+        ),
+        "highest_post_number": non_negative_integer(
+            item.get("highest_post_number"),
+            "private-message highest post number",
+            optional=True,
+        ),
+        "last_read_post_number": non_negative_integer(
+            item.get("last_read_post_number"),
+            "private-message last read post number",
+            optional=True,
+        ),
+        "unread_posts": non_negative_integer(
+            item.get("unread_posts"), "private-message unread count", optional=True
+        ),
+    }
+
+
+def _tracking_records(payload: Any, request: PageRequest) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        source = object_list(
+            payload, "topic tracking state", limit=MAX_SNAPSHOT_ITEMS
+        )
+    else:
+        root = object_value(payload, "topic tracking response")
+        candidate = root.get("topic_tracking_state", root.get("topic_tracking_states", []))
+        source = object_list(
+            candidate, "topic tracking state", limit=MAX_SNAPSHOT_ITEMS
+        )
+    records: list[dict[str, Any]] = []
+    for item in source:
+        topic_id = positive_id(item.get("topic_id"), "tracked topic ID")
+        if topic_id is None:
+            raise DiscourseReadProviderError("Discourse topic state has no stable ID")
+        records.append(
+            {
+                "kind": "topic_state",
+                "remote_id": resource_id(
+                    request.instance_id,
+                    "topic_state",
+                    int(topic_id),
+                    "tracked topic ID",
+                ),
+                "topic_id": topic_id,
+                "highest_post_number": non_negative_integer(
+                    item.get("highest_post_number"),
+                    "highest post number",
+                    optional=True,
+                ),
+                "last_read_post_number": non_negative_integer(
+                    item.get("last_read_post_number"),
+                    "last read post number",
+                    optional=True,
+                ),
+                "notification_level": non_negative_integer(
+                    item.get("notification_level"),
+                    "topic notification level",
+                    optional=True,
+                ),
+                "last_visited_at": optional_text(
+                    item.get("last_visited_at"), "topic visit timestamp"
+                ),
+            }
+        )
+    return records
+
+
+def _group_records(identity: dict[str, Any], request: PageRequest) -> list[dict[str, Any]]:
+    groups = object_list(
+        identity.get("groups", []), "identity groups", limit=MAX_SNAPSHOT_ITEMS
+    )
+    return [
+        {
+            "kind": "group",
+            "remote_id": resource_id(
+                request.instance_id, "group", int(required_text(group.get("id"), "group ID")), "group ID"
+            ),
+            "group_id": required_text(group.get("id"), "group ID"),
+            "name": required_text(group.get("name"), "group name"),
+            "has_messages": optional_boolean(
+                group.get("has_messages"), "group message flag"
+            ),
+            "owner": optional_boolean(group.get("owner"), "group owner flag"),
+        }
+        for group in groups
+    ]
+
+
+def _category_records(
+    payload: Any, identity: dict[str, Any], request: PageRequest
+) -> list[dict[str, Any]]:
+    root = object_value(payload, "category response")
+    category_list = object_value(root.get("category_list"), "category list")
+    categories = object_list(
+        category_list.get("categories", []),
+        "categories",
+        limit=MAX_SNAPSHOT_ITEMS,
+    )
+    preferences = object_value(
+        identity.get("category_preferences", {}), "category preferences"
+    )
+    by_id: dict[str, list[str]] = {}
+    for level, values in preferences.items():
+        if not isinstance(level, str) or not isinstance(values, list):
+            raise DiscourseReadProviderError(
+                "Discourse category preferences are invalid"
+            )
+        for value in values:
+            local_id = required_text(value, "category preference ID")
+            by_id.setdefault(local_id, []).append(level)
+    records: list[dict[str, Any]] = []
+    observed_ids: set[str] = set()
+    for item in categories:
+        local_id = positive_id(item.get("id"), "category ID")
+        if local_id is None:
+            raise DiscourseReadProviderError("Discourse category has no stable ID")
+        observed_ids.add(local_id)
+        records.append(
+            {
+                "kind": "category",
+                "remote_id": resource_id(
+                    request.instance_id,
+                    "category",
+                    int(local_id),
+                    "category ID",
+                ),
+                "category_id": local_id,
+                "name": required_text(item.get("name"), "category name"),
+                "slug": optional_text(item.get("slug"), "category slug"),
+                "description": optional_text(
+                    item.get("description_text"), "category description"
+                ),
+                "preference_levels": sorted(by_id.get(local_id, [])),
+                "resolved": True,
+            }
+        )
+    for local_id, levels in sorted(by_id.items()):
+        if local_id in observed_ids:
+            continue
+        records.append(
+            {
+                "kind": "category",
+                "remote_id": resource_id(
+                    request.instance_id,
+                    "category",
+                    int(local_id),
+                    "category preference ID",
+                ),
+                "category_id": local_id,
+                "name": None,
+                "slug": None,
+                "description": None,
+                "preference_levels": sorted(levels),
+                "resolved": False,
+            }
+        )
+    return records
+
+
+def _listing_payload(
+    request: PageRequest,
+    records: list[dict[str, Any]],
+    next_position: int | None,
+    *,
+    snapshot: bool | None = None,
+) -> dict[str, Any]:
+    expected_snapshot = STREAMS[request.stream].pagination == "snapshot"
+    if snapshot is not None and snapshot != expected_snapshot:
+        raise DiscourseReadProviderError(
+            "Discourse response snapshot mode is invalid"
+        )
+    is_snapshot = expected_snapshot if snapshot is None else snapshot
+    newest = records[0].get("remote_id") if records else None
+    accepted: list[dict[str, Any]] = []
+    reached = False
+    for record in records:
+        if request.stop_at is not None and record.get("remote_id") == request.stop_at:
+            reached = True
+            break
+        accepted.append(record)
+    if reached:
+        next_position = None
+    complete = reached or next_position is None
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": accepted,
+        "meta": {
+            "stream": request.stream,
+            "instance_id": request.instance_id,
+            "next_position": next_position,
+            "newest_id": newest,
+            "reached_watermark": reached,
+            "complete": complete,
+            "snapshot": is_snapshot,
+        },
+    }
+
+
+def _user_actions(api: Api, request: PageRequest) -> ApiResult | dict[str, Any]:
+    action_filter = {
+        "authored_topics": "4",
+        "authored_posts": "5",
+        "likes": "1",
+    }[request.stream]
+    result = api(
+        "/user_actions.json",
+        {
+            "username": request.username,
+            "filter": action_filter,
+            "offset": str(request.position),
+            "limit": str(request.limit),
+        },
+    )
+    if result.status != 200:
+        return result
+    root = object_value(result.payload, "user action response")
+    source = object_list(
+        root.get("user_actions", []), "user actions", limit=request.limit
+    )
+    kind = "topic" if request.stream == "authored_topics" else "post"
+    records = [_action_record(item, request, kind) for item in source]
+    next_position = (
+        request.position + len(source) if len(source) >= request.limit else None
+    )
+    return _listing_payload(request, records, next_position)
+
+
+def _bookmarks(api: Api, request: PageRequest) -> ApiResult | dict[str, Any]:
+    result = api(
+        _user_path(request.username, "bookmarks"),
+        {"page": str(request.position), "limit": str(request.limit)},
+    )
+    if result.status != 200:
+        return result
+    root = object_value(result.payload, "bookmark response")
+    listing = root.get("user_bookmark_list", root)
+    listing_object = object_value(listing, "bookmark list")
+    source = object_list(
+        listing_object.get("bookmarks", []), "bookmarks", limit=request.limit
+    )
+    records = [_bookmark_record(item, request) for item in source]
+    more = listing_object.get("more_bookmarks_url")
+    if more is not None and not isinstance(more, str):
+        raise DiscourseReadProviderError("Discourse bookmark pagination is invalid")
+    has_more = bool(more) if "more_bookmarks_url" in listing_object else len(source) >= request.limit
+    return _listing_payload(
+        request, records, request.position + 1 if has_more else None
+    )
+
+
+def _notifications(api: Api, request: PageRequest) -> ApiResult | dict[str, Any]:
+    result = api(
+        "/notifications.json",
+        {
+            "username": request.username,
+            "offset": str(request.position),
+            "limit": str(request.limit),
+        },
+    )
+    if result.status != 200:
+        return result
+    root = object_value(result.payload, "notification response")
+    source = object_list(
+        root.get("notifications", []), "notifications", limit=request.limit
+    )
+    records = [_notification_record(item, request) for item in source]
+    total = non_negative_integer(
+        root.get("total_rows_notifications"),
+        "notification total",
+        optional=False,
+    )
+    consumed = request.position + len(source)
+    if total is None or consumed > total or (not source and request.position < total):
+        raise DiscourseReadProviderError(
+            "Discourse notification pagination did not advance"
+        )
+    return _listing_payload(request, records, consumed if consumed < total else None)
+
+
+def _messages(
+    api: Api, request: PageRequest, *, sent: bool
+) -> ApiResult | dict[str, Any]:
+    result = api(
+        _message_path(request.username, sent), {"page": str(request.position)}
+    )
+    if result.status != 200:
+        return result
+    root = object_value(result.payload, "private-message response")
+    listing = object_value(root.get("topic_list"), "private-message topic list")
+    source = object_list(
+        listing.get("topics", []),
+        "private-message topics",
+        limit=MAX_MESSAGE_PAGE_ITEMS,
+    )
+    records = [_message_record(item, request) for item in source]
+    more = listing.get("more_topics_url")
+    if more is not None and not isinstance(more, str):
+        raise DiscourseReadProviderError(
+            "Discourse private-message pagination is invalid"
+        )
+    per_page = non_negative_integer(
+        listing.get("per_page"), "private-message page size", optional=True
+    )
+    has_more = bool(more) if "more_topics_url" in listing else len(source) >= (per_page or request.limit)
+    return _listing_payload(
+        request,
+        records,
+        request.position + 1 if has_more else None,
+        snapshot=True,
+    )
+
+
+def page(
+    api: Api, request: PageRequest, identity: dict[str, Any]
+) -> ApiResult | dict[str, Any]:
+    """Execute exactly one reviewed GET route for the selected stream."""
+    if request.stream not in STREAMS:
+        raise DiscourseReadProviderError("Discourse stream is unsupported")
+    if request.stream in ("authored_topics", "authored_posts", "likes"):
+        return _user_actions(api, request)
+    if request.stream == "bookmarks":
+        return _bookmarks(api, request)
+    if request.stream == "notifications":
+        return _notifications(api, request)
+    if request.stream == "private_messages":
+        return _messages(api, request, sent=False)
+    if request.stream == "sent_messages":
+        return _messages(api, request, sent=True)
+    if request.stream == "reading_state":
+        result = api(_user_path(request.username, "topic-tracking-state"), {})
+        if result.status != 200:
+            return result
+        return _listing_payload(
+            request, _tracking_records(result.payload, request), None, snapshot=True
+        )
+    if request.stream == "groups":
+        return _listing_payload(
+            request, _group_records(identity, request), None, snapshot=True
+        )
+    if request.stream == "category_preferences":
+        result = api("/categories.json", {})
+        if result.status != 200:
+            return result
+        return _listing_payload(
+            request,
+            _category_records(result.payload, identity, request),
+            None,
+            snapshot=True,
+        )
+    raise DiscourseReadProviderError("Discourse stream is unsupported")

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -13,6 +13,7 @@ YOUTUBE_HELPER="${SCRIPT_DIR}/knowledge_social_youtube.py"
 LINKEDIN_HELPER="${SCRIPT_DIR}/knowledge_social_linkedin.py"
 META_HELPER="${SCRIPT_DIR}/knowledge_social_meta.py"
 MEDIUM_HELPER="${SCRIPT_DIR}/knowledge_social_medium.py"
+DISCOURSE_HELPER="${SCRIPT_DIR}/knowledge_social_discourse.py"
 QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
 SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
 SHARE_HELPER="${SCRIPT_DIR}/knowledge_social_share.py"
@@ -95,6 +96,12 @@ Meta synchronization:
   authored replies, and mentions. Every page revalidates the selected product
   identity. --budget is 3-1000 and --page-size is 1-50.
 
+Discourse synchronization:
+  sync-discourse verifies the current user and exact HTTPS installation before
+  every allowlisted GET page. Each profile must declare a User API key with the
+  exact read scope. Installation fingerprints namespace account and resource IDs
+  without exposing private hosts. --budget is 3-1000 and --page-size is 1-20.
+
 EOF
 	return 0
 }
@@ -133,6 +140,10 @@ Usage:
   knowledge-social-helper.sh sync-meta --product facebook|instagram|threads \
     [--base PATH] [--alias ALIAS] --connection-id ID --account-id GRAPH_ID \
     --stream STREAM --profile PROFILE [--budget UNITS] [--page-size 1-50] \
+    [--collector-id ID] [--lease-seconds SECONDS]
+  knowledge-social-helper.sh sync-discourse [--base PATH] [--alias ALIAS] \
+    --connection-id ID --account-id USER_NUMERIC_ID --stream STREAM \
+    --profile PROFILE [--budget UNITS] [--page-size 1-20] \
     [--collector-id ID] [--lease-seconds SECONDS]
   knowledge-social-helper.sh sync-due [--base PATH] [--alias ALIAS] \
     [--now-epoch EPOCH] [--interval-seconds SECONDS]
@@ -289,6 +300,19 @@ run_medium_import() {
 	return 0
 }
 
+run_provider_sync() {
+	local provider_name="$1"
+	local provider_helper="$2"
+	shift 2 || return 1
+	require_runtime || return 1
+	if [[ ! -r "$provider_helper" ]]; then
+		printf 'ERROR: %s social adapter missing: %s\n' "$provider_name" "$provider_helper" >&2
+		return 1
+	fi
+	python3 "$provider_helper" "$@" || return 1
+	return 0
+}
+
 main() {
 	local subcommand="${1:-help}"
 	if [[ $# -gt 0 ]]; then
@@ -335,12 +359,10 @@ main() {
 		python3 "$LINKEDIN_HELPER" "$@" || return 1
 		;;
 	sync-meta)
-		require_runtime || return 1
-		if [[ ! -r "$META_HELPER" ]]; then
-			printf 'ERROR: Meta social adapter missing: %s\n' "$META_HELPER" >&2
-			return 1
-		fi
-		python3 "$META_HELPER" "$@" || return 1
+		run_provider_sync Meta "$META_HELPER" "$@" || return 1
+		;;
+	sync-discourse)
+		run_provider_sync Discourse "$DISCOURSE_HELPER" "$@" || return 1
 		;;
 	query | annotate)
 		require_runtime || return 1

--- a/.agents/scripts/knowledge_social_discourse.py
+++ b/.agents/scripts/knowledge_social_discourse.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one bounded, read-only Discourse account stream into a social corpus."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import _knowledge_social_discourse as discourse
+from _knowledge_social_discourse_normalize import PageContext, normalize_page
+from _knowledge_social_discourse_reader import (
+    FixtureDiscourse,
+    GuardedDiscourse,
+    verified_identity,
+)
+from _knowledge_social_oauth_collector import (
+    OAuthCollectorPolicy,
+    run_oauth_collector,
+)
+
+COLLECTOR_POLICY = OAuthCollectorPolicy(
+    display_name="Discourse",
+    provider_module=discourse,
+    helper=Path(__file__).with_name("_knowledge_social_discourse_provider.py"),
+    fixture_reader=FixtureDiscourse,
+    live_reader=GuardedDiscourse,
+    page_context=PageContext,
+    normalize_page=normalize_page,
+    verified_identity=verified_identity,
+    budget_unit="request",
+    max_page_size=20,
+)
+
+
+def main() -> int:
+    return run_oauth_collector(COLLECTOR_POLICY, __doc__ or "")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/tests/test-knowledge-social-discourse.sh
+++ b/.agents/tests/test-knowledge-social-discourse.sh
@@ -1,0 +1,818 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-discourse.sh — Multi-instance Discourse collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+INSTANCE_A="aaaaaaaaaaaaaaaaaaaaaaaa"
+INSTANCE_B="bbbbbbbbbbbbbbbbbbbbbbbb"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' \
+			"$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c \
+		'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_count() {
+	python3 - "$ROOT/sources/social/raw/discourse" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+print(len(list(root.rglob("*.json.gz"))) if root.exists() else 0)
+PY
+	return 0
+}
+
+expect_sync_failure() {
+	local description="$1"
+	local fixture="$2"
+	local connection_id="$3"
+	local account_id="$4"
+	local stream="$5"
+	if "$HELPER" sync-discourse --base "$BASE" --alias personal:default \
+		--connection-id "$connection_id" --account-id "$account_id" \
+		--stream "$stream" --profile fixture --fixture "$fixture" \
+		>/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+run_terminal_fixture() {
+	local name="$1"
+	local status="$2"
+	local expected_failure="$3"
+	local expected_coverage="$4"
+	local fixture="${TMP_DIR}/terminal-${name}.json"
+	python3 - "$fixture" "$INSTANCE_A" "$status" <<'PY'
+import json
+import sys
+
+instance = sys.argv[2]
+status = int(sys.argv[3])
+page = {
+    "status": status,
+    "observed_at": f"2026-07-28T09:{status % 60:02d}:00Z",
+}
+if status == 429:
+    page["retry_after"] = 1785200000
+payload = {
+    "identity": {"data": {
+        "provider_account_id": "42",
+        "username": "selected_user",
+        "instance_id": instance,
+    }},
+    "pages": [page],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+	local result=""
+	result=$("$HELPER" sync-discourse --base "$BASE" --alias personal:default \
+		--connection-id "conn_terminal_${name}" --account-id user_42 \
+		--stream private_messages --profile fixture --fixture "$fixture")
+	assert_eq "${status} Discourse response is terminal" \
+		"$(json_field "$result" failure_class)" "$expected_failure"
+	assert_eq "${status} terminal response records explicit coverage" \
+		"$(sql_value "SELECT status || ':' || unavailable_reason FROM coverage_records WHERE connection_id='conn_terminal_${name}' AND stream='private_messages'")" \
+		"${expected_coverage}:${expected_failure}"
+	assert_eq "${status} terminal response advances no checkpoint" \
+		"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_terminal_${name}'")" 0
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'Discourse social collector tests\n'
+
+help_output=$("$HELPER" help)
+if [[ "$help_output" == *"exact HTTPS installation"* &&
+	"$help_output" == *"--page-size is 1-20"* ]]; then
+	assert_eq "Discourse CLI advertises the executable safety contract" advertised advertised
+else
+	assert_eq "Discourse CLI advertises the executable safety contract" missing advertised
+fi
+matrix_output=$(<"$SCRIPT_DIR/../aidevops/knowledge-plane/06-social-provider-capabilities.md")
+docs_output=$(<"$SCRIPT_DIR/../content/social-discourse.md")
+if [[ "$matrix_output" == *'| Discourse | **Live** topics and posts'* &&
+	"$docs_output" == *'DISCOURSE_<PROFILE>_ORIGIN_KEY'* ]]; then
+	assert_eq "Live capability claim is backed by operator evidence" verified verified
+else
+	assert_eq "Live capability claim is backed by operator evidence" missing verified
+fi
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import ast
+import json
+import os
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+
+from _knowledge_social_discourse import PageRequest, STREAMS, namespaced_id
+from _knowledge_social_discourse_contract import ApiResult
+from _knowledge_social_discourse_provider import (
+    HTTP_TIMEOUT_SECONDS,
+    ProfileConfig,
+    _api,
+    _canonical_base_url,
+    _http_exports,
+    _profile,
+    installation_fingerprint,
+)
+from _knowledge_social_discourse_routes import (
+    EXACT_READ_PATHS,
+    allowlisted_path,
+    page,
+)
+
+expected_streams = {
+    "authored_topics", "authored_posts", "likes", "bookmarks",
+    "notifications", "private_messages", "sent_messages", "reading_state",
+    "groups", "category_preferences",
+}
+assert set(STREAMS) == expected_streams
+assert EXACT_READ_PATHS == {
+    "/session/current.json", "/user_actions.json", "/notifications.json",
+    "/categories.json",
+}
+for rejected in (
+    "/export_csv/latest_user_archive/42.json",
+    "/admin/users/list/active.json",
+    "/post_actions/42.json",
+    "/topics.json",
+):
+    assert not allowlisted_path(rejected)
+
+base_a = _canonical_base_url("https://community-a.example.invalid/forum/")
+base_b = _canonical_base_url("https://community-b.example.invalid/forum")
+origin_key_a = "a" * 32
+origin_key_b = "b" * 32
+instance_a = installation_fingerprint(base_a, origin_key_a)
+instance_b = installation_fingerprint(base_b, origin_key_b)
+assert base_a == "https://community-a.example.invalid/forum"
+assert instance_a != instance_b
+assert installation_fingerprint(base_a, origin_key_b) != instance_a
+assert namespaced_id(instance_a, "user", "42") != namespaced_id(
+    instance_b, "user", "42"
+)
+for invalid in (
+    "http://community.example.invalid",
+    "https://user@example.invalid",
+    "https://community.example.invalid/%2e%2e/admin",
+):
+    try:
+        _canonical_base_url(invalid)
+    except RuntimeError as error:
+        assert "example.invalid" not in str(error)
+    else:
+        raise AssertionError("unsafe Discourse base URL was accepted")
+
+class Response:
+    status = 200
+
+    def __init__(self, payload):
+        self.payload = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def read(self, size=-1):
+        return self.payload[:size]
+
+
+class Opener:
+    def __init__(self, payload):
+        self.payload = payload
+        self.requests = []
+
+    def open(self, request, timeout):
+        assert timeout == HTTP_TIMEOUT_SECONDS
+        assert request.method == "GET"
+        assert "private-key-value" not in request.full_url
+        self.requests.append(request)
+        return Response(self.payload)
+
+
+config = ProfileConfig(base_a, "private-key-value", "read", instance_a)
+opener = Opener({"category_list": {"categories": []}})
+result = _api(config, opener, "/categories.json", {})
+assert result.status == 200
+assert len(opener.requests) == 1
+assert callable(_http_exports().open)
+try:
+    _api(config, opener, "/admin/users.json", {})
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("non-allowlisted Discourse route was reachable")
+try:
+    _api(
+        config,
+        opener,
+        "/notifications.json",
+        {"username": "selected_user", "offset": "0", "limit": "20", "recent": "true"},
+    )
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("notification side-effect query was reachable")
+
+os.environ["DISCOURSE_SCOPE_TEST_BASE_URL"] = base_a
+os.environ["DISCOURSE_SCOPE_TEST_USER_API_KEY"] = "private-key-value"
+os.environ["DISCOURSE_SCOPE_TEST_ORIGIN_KEY"] = origin_key_a
+os.environ["DISCOURSE_SCOPE_TEST_USER_API_SCOPE"] = "write"
+try:
+    _profile("scope_test")
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("Discourse write scope was accepted")
+
+request = PageRequest(
+    "authored_topics",
+    namespaced_id(instance_a, "user", "42"),
+    "42",
+    "selected_user",
+    instance_a,
+    0,
+    None,
+    1,
+)
+seen = []
+
+def action_api(path, params):
+    seen.append((path, params))
+    return ApiResult(
+        200,
+        {"user_actions": [{
+            "action_type": 4, "topic_id": 100, "post_id": 101,
+            "title": "Selected topic", "excerpt": "Bounded body",
+            "created_at": "2026-07-28T09:00:00Z",
+        }]},
+    )
+
+serialized = page(action_api, request, {})
+assert serialized["data"][0]["remote_id"] == namespaced_id(instance_a, "topic", "100")
+assert serialized["meta"]["next_position"] == 1
+assert seen == [(
+    "/user_actions.json",
+    {"username": "selected_user", "filter": "4", "offset": "0", "limit": "1"},
+)]
+
+def request_for(stream, limit=2):
+    return PageRequest(
+        stream,
+        namespaced_id(instance_a, "user", "42"),
+        "42",
+        "selected_user",
+        instance_a,
+        0,
+        None,
+        limit,
+    )
+
+
+def route_result(stream, payload, identity=None, limit=2):
+    calls = []
+
+    def api(path, params):
+        calls.append((path, params))
+        return ApiResult(200, payload)
+
+    return page(api, request_for(stream, limit), identity or {}), calls
+
+
+authored_post, _ = route_result(
+    "authored_posts",
+    {"user_actions": [{"action_type": 5, "topic_id": 7, "post_id": 8}]},
+)
+assert authored_post["data"][0]["kind"] == "post"
+
+likes, _ = route_result(
+    "likes",
+    {"user_actions": [{"action_type": 1, "topic_id": 7, "post_id": 8}]},
+)
+assert likes["meta"]["snapshot"] is True
+
+bookmarks, bookmark_calls = route_result(
+    "bookmarks",
+    {"user_bookmark_list": {"bookmarks": [{"id": 9, "post_id": 8}], "more_bookmarks_url": None}},
+)
+assert bookmarks["meta"]["snapshot"] is True
+assert bookmark_calls[0][0] == "/u/selected_user/bookmarks.json"
+
+notifications, notification_calls = route_result(
+    "notifications",
+    {
+        "notifications": [{"id": 10, "notification_type": 1, "read": False}],
+        "total_rows_notifications": 1,
+        "load_more_notifications": "/notifications?offset=1",
+    },
+    limit=1,
+)
+assert notifications["meta"]["complete"] is True
+assert notifications["meta"]["next_position"] is None
+assert "recent" not in notification_calls[0][1]
+
+empty_notifications, _ = route_result(
+    "notifications",
+    {
+        "notifications": [],
+        "total_rows_notifications": 0,
+        "load_more_notifications": "/notifications?offset=0",
+    },
+    limit=1,
+)
+assert empty_notifications["meta"]["complete"] is True
+
+message_payload = {
+    "topic_list": {
+        "topics": [{"id": 11, "archetype": "private_message", "title": "Subject"}],
+        "per_page": 20,
+        "more_topics_url": None,
+    }
+}
+received, received_calls = route_result("private_messages", message_payload)
+sent, sent_calls = route_result("sent_messages", message_payload)
+assert received["meta"]["snapshot"] is True
+assert sent["meta"]["snapshot"] is True
+assert "/private-messages/" in received_calls[0][0]
+assert "/private-messages-sent/" in sent_calls[0][0]
+
+reading, _ = route_result(
+    "reading_state",
+    [{"topic_id": 12, "highest_post_number": 3, "last_read_post_number": 2}],
+)
+assert reading["data"][0]["kind"] == "topic_state"
+
+identity = {
+    "groups": [{"id": "13", "name": "Members", "has_messages": True, "owner": False}],
+    "category_preferences": {"watched": ["14"]},
+}
+groups, group_calls = route_result("groups", {}, identity)
+assert groups["data"][0]["kind"] == "group"
+assert group_calls == []
+
+categories, category_calls = route_result(
+    "category_preferences",
+    {"category_list": {"categories": [{"id": 14, "name": "Selected"}]}},
+    identity,
+)
+assert categories["data"][0]["preference_levels"] == ["watched"]
+assert category_calls[0][0] == "/categories.json"
+
+def expect_route_rejection(stream, payload, identity=None, limit=20):
+    try:
+        route_result(stream, payload, identity, limit)
+    except RuntimeError:
+        return
+    raise AssertionError(f"oversized or stalled {stream} route was accepted")
+
+
+expect_route_rejection(
+    "notifications",
+    {"notifications": [], "total_rows_notifications": 1},
+    limit=1,
+)
+expect_route_rejection(
+    "private_messages",
+    {"topic_list": {"topics": [{}] * 101, "per_page": 20}},
+)
+expect_route_rejection("reading_state", [{}] * 1001)
+expect_route_rejection("groups", {}, {"groups": [{}] * 1001})
+expect_route_rejection(
+    "category_preferences",
+    {"category_list": {"categories": [{}] * 1001}},
+    {"category_preferences": {}},
+)
+
+sources = [
+    path.read_text(encoding="utf-8")
+    for path in sorted(scripts.glob("_knowledge_social_discourse*.py"))
+]
+trees = [ast.parse(source) for source in sources]
+request_calls = [
+    node
+    for tree in trees
+    for node in ast.walk(tree)
+    if isinstance(node, ast.Call)
+    and isinstance(node.func, ast.Name)
+    and node.func.id == "Request"
+]
+assert request_calls
+for node in request_calls:
+    methods = [
+        keyword.value.value
+        for keyword in node.keywords
+        if keyword.arg == "method" and isinstance(keyword.value, ast.Constant)
+    ]
+    assert methods == ["GET"]
+imports = {
+    alias.name.split(".")[0]
+    for tree in trees
+    for node in ast.walk(tree)
+    if isinstance(node, (ast.Import, ast.ImportFrom))
+    for alias in (node.names if isinstance(node, ast.Import) else [ast.alias(node.module or "")])
+}
+assert "requests" not in imports
+assert "pydiscourse" not in imports
+assert all("_knowledge_social_outbound" not in source for source in sources)
+PY
+assert_eq "stdlib transport, exact routes, namespaces, scope, and GET-only AST are guarded" \
+	verified verified
+
+cat >"$TMP_DIR/minimum-budget.json" <<JSON
+{"identity":{"data":{"provider_account_id":"42","username":"selected_user","instance_id":"${INSTANCE_A}"}},"pages":[]}
+JSON
+for budget in 1 2; do
+	if "$HELPER" sync-discourse --base "$BASE" --alias personal:default \
+		--connection-id "conn_budget_${budget}" --account-id user_42 \
+		--stream authored_topics --profile fixture \
+		--fixture "$TMP_DIR/minimum-budget.json" --budget "$budget" \
+		>/dev/null 2>&1; then
+		assert_eq "Discourse budget ${budget} is rejected" accepted rejected
+	else
+		assert_eq "Discourse budget ${budget} is rejected" rejected rejected
+	fi
+done
+assert_eq "rejected budgets create no run receipts" \
+	"$(sql_value "SELECT count(*) FROM sync_runs WHERE connection_id LIKE 'conn_budget_%'")" 0
+
+cat >"$TMP_DIR/instance-a-first.json" <<JSON
+{
+  "identity":{"data":{"provider_account_id":"42","username":"selected_user","name":"Private A","instance_id":"${INSTANCE_A}"}},
+  "pages":[{
+    "expect_request":{"position":0,"stop_at":null,"limit":1,"instance_id":"${INSTANCE_A}","provider_account_id":"42"},
+    "response":{"status":200,"observed_at":"2026-07-28T10:00:00Z",
+      "data":[{"kind":"topic","remote_id":"dsc_${INSTANCE_A}_topic_100","topic_id":"100","post_id":"101","action_type":4,"title":"Newest bounded topic","excerpt":"Discourse fixture knowledge","created_at":"2026-07-28T09:00:00Z"}],
+      "meta":{"stream":"authored_topics","instance_id":"${INSTANCE_A}","next_position":1,"newest_id":"dsc_${INSTANCE_A}_topic_100","reached_watermark":false,"complete":false,"snapshot":false}}
+  }]
+}
+JSON
+first_result=$("$HELPER" sync-discourse --base "$BASE" --alias personal:default \
+	--connection-id conn_instance_a --account-id user_42 --stream authored_topics \
+	--profile fixture --fixture "$TMP_DIR/instance-a-first.json" \
+	--budget 3 --page-size 1)
+assert_eq "one bounded Discourse page pauses the initial backfill" \
+	"$(json_field "$first_result" status)" budget_exhausted
+assert_eq "identity plus one page reserves three request units" \
+	"$(json_field "$first_result" budget_units)" 3
+assert_eq "partial page commits evidence and its cursor atomically" \
+	"$(sql_value "SELECT (SELECT count(*) FROM fetch_batches WHERE connection_id='conn_instance_a') || ':' || (SELECT backfill_complete FROM sync_cursors WHERE connection_id='conn_instance_a' AND stream='authored_topics')")" \
+	"1:0"
+assert_eq "authored Discourse text reaches the FTS projection" \
+	"$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'bounded'")" 1
+assert_eq "collector output omits private identity metadata" \
+	"$([[ "$first_result" == *Private* || "$first_result" == *selected_user* ]] && printf present || printf absent)" absent
+
+cat >"$TMP_DIR/instance-a-resume.json" <<JSON
+{
+  "identity":{"data":{"provider_account_id":"42","username":"selected_user","instance_id":"${INSTANCE_A}"}},
+  "pages":[{
+    "expect_request":{"position":1,"stop_at":null,"instance_id":"${INSTANCE_A}"},
+    "response":{"status":200,"observed_at":"2026-07-28T10:01:00Z",
+      "data":[{"kind":"topic","remote_id":"dsc_${INSTANCE_A}_topic_90","topic_id":"90","post_id":"91","action_type":4,"title":"Older topic","excerpt":"Resumed page","created_at":"2026-07-27T09:00:00Z"}],
+      "meta":{"stream":"authored_topics","instance_id":"${INSTANCE_A}","next_position":null,"newest_id":"dsc_${INSTANCE_A}_topic_90","reached_watermark":false,"complete":true,"snapshot":false}}
+  }]
+}
+JSON
+second_result=$("$HELPER" sync-discourse --base "$BASE" --alias personal:default \
+	--connection-id conn_instance_a --account-id user_42 --stream authored_topics \
+	--profile fixture --fixture "$TMP_DIR/instance-a-resume.json")
+assert_eq "Discourse backfill resumes from its independent position" \
+	"$(json_field "$second_result" status)" complete
+assert_eq "completed backfill preserves the first-page watermark" \
+	"$(sql_value "SELECT coalesce(cursor,'done') || ':' || watermark || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_instance_a' AND stream='authored_topics'")" \
+	"done:dsc_${INSTANCE_A}_topic_100:1"
+
+cat >"$TMP_DIR/instance-a-delta.json" <<JSON
+{
+  "identity":{"data":{"provider_account_id":"42","username":"selected_user","instance_id":"${INSTANCE_A}"}},
+  "pages":[{
+    "expect_request":{"position":0,"stop_at":"dsc_${INSTANCE_A}_topic_100","instance_id":"${INSTANCE_A}"},
+    "response":{"status":200,"observed_at":"2026-07-28T10:01:30Z",
+      "data":[{"kind":"topic","remote_id":"dsc_${INSTANCE_A}_topic_110","topic_id":"110","post_id":"111","action_type":4,"title":"Incremental topic","created_at":"2026-07-28T10:01:00Z"}],
+      "meta":{"stream":"authored_topics","instance_id":"${INSTANCE_A}","next_position":null,"newest_id":"dsc_${INSTANCE_A}_topic_110","reached_watermark":true,"complete":true,"snapshot":false}}
+  }]
+}
+JSON
+"$HELPER" sync-discourse --base "$BASE" --alias personal:default \
+	--connection-id conn_instance_a --account-id user_42 --stream authored_topics \
+	--profile fixture --fixture "$TMP_DIR/instance-a-delta.json" >/dev/null
+assert_eq "authored-content delta advances its stable watermark" \
+	"$(sql_value "SELECT watermark FROM sync_cursors WHERE connection_id='conn_instance_a' AND stream='authored_topics'")" \
+	"dsc_${INSTANCE_A}_topic_110"
+
+cat >"$TMP_DIR/instance-b.json" <<JSON
+{
+  "identity":{"data":{"provider_account_id":"42","username":"selected_user","instance_id":"${INSTANCE_B}"}},
+  "pages":[{"status":200,"observed_at":"2026-07-28T10:02:00Z",
+    "data":[{"kind":"topic","remote_id":"dsc_${INSTANCE_B}_topic_100","topic_id":"100","post_id":"101","action_type":4,"title":"Same local ID, other installation","created_at":"2026-07-28T08:00:00Z"}],
+    "meta":{"stream":"authored_topics","instance_id":"${INSTANCE_B}","next_position":null,"newest_id":"dsc_${INSTANCE_B}_topic_100","reached_watermark":false,"complete":true,"snapshot":false}}]
+}
+JSON
+"$HELPER" sync-discourse --base "$BASE" --alias personal:default \
+	--connection-id conn_instance_b --account-id user_42 --stream authored_topics \
+	--profile fixture --fixture "$TMP_DIR/instance-b.json" >/dev/null
+assert_eq "two installations cannot collide on account or topic IDs" \
+	"$(sql_value "SELECT (SELECT count(*) FROM accounts WHERE provider='discourse') || ':' || (SELECT count(*) FROM objects WHERE provider='discourse' AND object_type='topic')")" \
+	"2:4"
+assert_eq "installation checkpoints retain distinct stable origins" \
+	"$(sql_value "SELECT count(DISTINCT watermark) FROM sync_cursors WHERE connection_id IN ('conn_instance_a','conn_instance_b') AND stream='authored_topics'")" 2
+
+batches_before_rebind=$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_instance_a'")
+expect_sync_failure "cross-installation connection rebinding is rejected" \
+	"$TMP_DIR/instance-b.json" conn_instance_a user_42 authored_topics
+assert_eq "rebind rejection preserves prior evidence and checkpoints" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_instance_a'")" \
+	"$batches_before_rebind"
+
+cat >"$TMP_DIR/identity-mismatch.json" <<JSON
+{"identity":{"data":{"provider_account_id":"43","username":"other_user","instance_id":"${INSTANCE_A}"}},"pages":[]}
+JSON
+identity_raw_before=$(raw_count)
+expect_sync_failure "selected-account identity mismatch is rejected" \
+	"$TMP_DIR/identity-mismatch.json" conn_identity_mismatch user_42 authored_topics
+assert_eq "identity mismatch creates no raw evidence" "$(raw_count)" "$identity_raw_before"
+
+cat >"$TMP_DIR/credential.json" <<JSON
+{
+  "identity":{"data":{"provider_account_id":"42","username":"selected_user","instance_id":"${INSTANCE_A}"}},
+  "pages":[{"status":200,"observed_at":"2026-07-28T10:03:00Z","api_key":"must-not-persist","data":[],
+    "meta":{"stream":"authored_topics","instance_id":"${INSTANCE_A}","next_position":null,"newest_id":null,"reached_watermark":false,"complete":true,"snapshot":false}}]
+}
+JSON
+credential_raw_before=$(raw_count)
+expect_sync_failure "credential-shaped Discourse pages are rejected" \
+	"$TMP_DIR/credential.json" conn_credential user_42 authored_topics
+assert_eq "credential rejection creates no raw evidence" \
+	"$(raw_count)" "$credential_raw_before"
+
+cat >"$TMP_DIR/malformed.json" <<JSON
+{
+  "identity":{"data":{"provider_account_id":"42","username":"selected_user","instance_id":"${INSTANCE_A}"}},
+  "pages":[{"status":200,"observed_at":"2026-07-28T10:04:00Z","data":{"kind":"topic"},
+    "meta":{"stream":"authored_topics","instance_id":"${INSTANCE_A}","next_position":null,"newest_id":null,"reached_watermark":false,"complete":true,"snapshot":false}}]
+}
+JSON
+expect_sync_failure "malformed Discourse page roots are rejected" \
+	"$TMP_DIR/malformed.json" conn_malformed user_42 authored_topics
+
+python3 - "$TMP_DIR/oversized.json" "$INSTANCE_A" <<'PY'
+import json
+import sys
+
+instance = sys.argv[2]
+data = [
+    {
+        "kind": "topic",
+        "remote_id": f"dsc_{instance}_topic_{200 + offset}",
+        "topic_id": str(200 + offset),
+        "action_type": 4,
+    }
+    for offset in range(21)
+]
+payload = {
+    "identity": {"data": {
+        "provider_account_id": "42",
+        "username": "selected_user",
+        "instance_id": instance,
+    }},
+    "pages": [{
+        "status": 200,
+        "observed_at": "2026-07-28T10:04:30Z",
+        "data": data,
+        "meta": {
+            "stream": "authored_topics",
+            "instance_id": instance,
+            "next_position": None,
+            "newest_id": data[0]["remote_id"],
+            "reached_watermark": False,
+            "complete": True,
+            "snapshot": False,
+        },
+    }],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+oversized_raw_before=$(raw_count)
+expect_sync_failure "oversized Discourse pages are rejected before persistence" \
+	"$TMP_DIR/oversized.json" conn_oversized user_42 authored_topics
+assert_eq "oversized page rejection creates no raw evidence" \
+	"$(raw_count)" "$oversized_raw_before"
+
+run_terminal_fixture forbidden 403 authorization failed
+run_terminal_fixture unavailable 404 unavailable unavailable
+run_terminal_fixture rate 429 rate_limit paused
+run_terminal_fixture provider 500 provider failed
+
+cat >"$TMP_DIR/messages.json" <<JSON
+{
+  "identity":{"data":{"provider_account_id":"42","username":"selected_user","instance_id":"${INSTANCE_A}"}},
+  "pages":[{"status":200,"observed_at":"2026-07-28T10:05:00Z",
+    "data":[{"kind":"private_message_topic","remote_id":"dsc_${INSTANCE_A}_message_500","topic_id":"500","title":"Private scope-gated subject","created_at":"2026-07-28T08:00:00Z","last_posted_at":"2026-07-28T09:00:00Z","posts_count":2,"unread_posts":1}],
+    "meta":{"stream":"private_messages","instance_id":"${INSTANCE_A}","next_position":null,"newest_id":"dsc_${INSTANCE_A}_message_500","reached_watermark":false,"complete":true,"snapshot":true}}]
+}
+JSON
+"$HELPER" sync-discourse --base "$BASE" --alias personal:default \
+	--connection-id conn_messages --account-id user_42 --stream private_messages \
+	--profile fixture --fixture "$TMP_DIR/messages.json" >/dev/null
+assert_eq "authorized messages persist topic metadata without bodies" \
+	"$(sql_value "SELECT object_type || ':' || json_extract(provider_json,'$.record.posts_count') FROM objects WHERE remote_id='dsc_${INSTANCE_A}_message_500'")" \
+	"private_message_topic:2"
+assert_eq "private-message body limits remain explicit partial coverage" \
+	"$(sql_value "SELECT status || ':' || unavailable_reason FROM coverage_records WHERE connection_id='conn_messages' AND stream='private_messages'")" \
+	"partial:private_message_topic_metadata_only"
+assert_eq "unsupported plugin, archive, search, body, and history routes remain gaps" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE connection_id='conn_messages' AND status='unavailable' AND stream IN ('account_archive','followers','following','watched_topics','tracked_topics','private_message_bodies','complete_reading_history')")" 7
+
+cat >"$TMP_DIR/messages-update.json" <<JSON
+{
+  "identity":{"data":{"provider_account_id":"42","username":"selected_user","instance_id":"${INSTANCE_A}"}},
+  "pages":[{
+    "expect_request":{"position":0,"stop_at":null},
+    "response":{"status":200,"observed_at":"2026-07-28T10:05:30Z",
+      "data":[{"kind":"private_message_topic","remote_id":"dsc_${INSTANCE_A}_message_500","topic_id":"500","title":"Private scope-gated subject","created_at":"2026-07-28T08:00:00Z","last_posted_at":"2026-07-28T10:05:00Z","posts_count":3,"unread_posts":2}],
+      "meta":{"stream":"private_messages","instance_id":"${INSTANCE_A}","next_position":null,"newest_id":"dsc_${INSTANCE_A}_message_500","reached_watermark":false,"complete":true,"snapshot":true}}
+  }]
+}
+JSON
+"$HELPER" sync-discourse --base "$BASE" --alias personal:default \
+	--connection-id conn_messages --account-id user_42 --stream private_messages \
+	--profile fixture --fixture "$TMP_DIR/messages-update.json" >/dev/null
+assert_eq "mutable message-topic metadata is refreshed by a full snapshot" \
+	"$(sql_value "SELECT json_extract(provider_json,'$.record.posts_count') || ':' || json_extract(provider_json,'$.record.unread_posts') FROM objects WHERE remote_id='dsc_${INSTANCE_A}_message_500'")" \
+	"3:2"
+assert_eq "message snapshots never persist a stable-ID watermark" \
+	"$(sql_value "SELECT coalesce(watermark,'none') FROM sync_cursors WHERE connection_id='conn_messages' AND stream='private_messages'")" none
+
+cat >"$TMP_DIR/groups.json" <<JSON
+{
+  "identity":{"data":{"provider_account_id":"42","username":"selected_user","instance_id":"${INSTANCE_A}"}},
+  "pages":[{"status":200,"observed_at":"2026-07-28T10:06:00Z",
+    "data":[{"kind":"group","remote_id":"dsc_${INSTANCE_A}_group_7","group_id":"7","name":"Fixture group","has_messages":true,"owner":false}],
+    "meta":{"stream":"groups","instance_id":"${INSTANCE_A}","next_position":null,"newest_id":"dsc_${INSTANCE_A}_group_7","reached_watermark":false,"complete":true,"snapshot":true}}]
+}
+JSON
+"$HELPER" sync-discourse --base "$BASE" --alias personal:default \
+	--connection-id conn_groups --account-id user_42 --stream groups \
+	--profile fixture --fixture "$TMP_DIR/groups.json" >/dev/null
+group_batches=$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_groups'")
+group_raw=$(raw_count)
+"$HELPER" sync-discourse --base "$BASE" --alias personal:default \
+	--connection-id conn_groups --account-id user_42 --stream groups \
+	--profile fixture --fixture "$TMP_DIR/groups.json" >/dev/null
+assert_eq "exact snapshot replay is content-addressed and idempotent" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_groups'"):$(raw_count)" \
+	"${group_batches}:${group_raw}"
+assert_eq "group replay leaves one stable membership" \
+	"$(sql_value "SELECT count(*) FROM activities WHERE provider='discourse' AND activity_type='group_membership' AND object_remote_id='dsc_${INSTANCE_A}_group_7'")" 1
+
+python3 - "$ROOT" "$SCRIPT_DIR/../scripts" <<'PY'
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[2])
+from _knowledge_social_collect import (
+    CollectionContext,
+    ConnectionConfig,
+    CursorState,
+    PageCheckpoint,
+    SuccessfulPage,
+)
+from _knowledge_social_collect_persist import persist_page
+from _knowledge_social_discourse import STREAMS
+from _knowledge_social_lease import (
+    RunLeaseRequest,
+    SocialLeaseLostError,
+    acquire_run_lease,
+    release_run_lease,
+)
+
+root = Path(sys.argv[1])
+old = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_discourse_fence", "groups", "old_runner", "sync", 1),
+    now_epoch=9000,
+)
+new = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_discourse_fence", "groups", "new_runner", "sync", 10),
+    now_epoch=9001,
+)
+account_id = "dsc_aaaaaaaaaaaaaaaaaaaaaaaa_user_42"
+context = CollectionContext(
+    root,
+    "conn_discourse_fence",
+    {"id": account_id},
+    "groups",
+    "none",
+    ConnectionConfig(("groups",), {"media_hydration": "none"}),
+    CursorState(None, None, False),
+    STREAMS["groups"],
+    old,
+    "discourse",
+)
+archive = {
+    "provider": "discourse",
+    "connection_id": "conn_discourse_fence",
+    "remote_account_id": account_id,
+    "exported_at": "2026-07-28T10:07:00Z",
+    "enabled_streams": ["groups"],
+    "policy": {"media_hydration": "none"},
+    "accounts": [],
+    "objects": [],
+    "activities": [],
+    "media": [],
+    "coverage": [],
+}
+page = SuccessfulPage(
+    {"status": 200, "observed_at": archive["exported_at"], "data": [], "meta": {}},
+    '{"stream":"groups"}',
+    archive,
+    PageCheckpoint(None, None),
+    True,
+    2,
+)
+os.environ["AIDEVOPS_SOCIAL_NOW_EPOCH"] = "9001"
+try:
+    persist_page(context, page)
+except SocialLeaseLostError:
+    pass
+else:
+    raise SystemExit("stale Discourse collector advanced persistence")
+with sqlite3.connect(root / "index" / "social.db") as database:
+    cursor = database.execute(
+        "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_discourse_fence'"
+    ).fetchone()[0]
+assert cursor == 0
+release_run_lease(root, new)
+PY
+assert_eq "stale Discourse lease cannot commit evidence or a cursor" verified verified
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add ten bounded Discourse User API read streams with per-installation namespaces, independent checkpoints, immutable evidence, explicit unsupported coverage, and hosted/self-hosted operator guidance.

## Files Changed

.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md, .agents/content/social-discourse.md, .agents/scripts/_knowledge_social_discourse.py, .agents/scripts/_knowledge_social_discourse_contract.py, .agents/scripts/_knowledge_social_discourse_normalize.py, .agents/scripts/_knowledge_social_discourse_provider.py, .agents/scripts/_knowledge_social_discourse_reader.py, .agents/scripts/_knowledge_social_discourse_routes.py, .agents/scripts/knowledge-social-helper.sh, .agents/scripts/knowledge_social_discourse.py, .agents/tests/test-knowledge-social-discourse.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified: test-knowledge-social-discourse.sh passes 45 assertions; Python 3.14.3 compileall, ShellCheck, shfmt, and linters-local.sh --changed pass.

Resolves #28673


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.189 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 50m and 343,878 tokens on this as a headless worker.