### PR TITLE
GH#28801: fix: converge terminal release cleanup receipts

### DIFF
--- a/.agents/scripts/full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/full-loop-cleanup-receipt.sh
@@ -439,11 +439,37 @@ full_loop_update_cleanup_release_status() {
 	local pr_number="$2"
 	local release_status="$3"
 	local receipt_path=""
+	local current_release=""
 	local now=""
 
+	[[ "$release_status" == "$_FULL_LOOP_RECEIPT_RELEASE_PUBLISHED" || "$release_status" == "$_FULL_LOOP_RECEIPT_RELEASE_SUPERSEDED" || "$release_status" == "$_FULL_LOOP_RECEIPT_RELEASE_NOT_REQUESTED" ]] || return 1
 	receipt_path=$(_full_loop_cleanup_receipt_path "$repo" "$pr_number") || return 1
 	[[ -f "$receipt_path" ]] || return 0
 	_full_loop_receipt_lock_acquire || return 1
+	if ! jq -e --arg repo "$repo" --argjson pr "$pr_number" \
+		'.repository == $repo and .pr_number == $pr' "$receipt_path" >/dev/null 2>&1; then
+		_full_loop_receipt_lock_release
+		return 1
+	fi
+	current_release=$(jq -r '.release_status // empty' "$receipt_path" 2>/dev/null || true)
+	case "${current_release}:${release_status}" in
+	"pending:${_FULL_LOOP_RECEIPT_RELEASE_NOT_REQUESTED}" | \
+		"pending:${_FULL_LOOP_RECEIPT_RELEASE_PUBLISHED}" | \
+		"pending:${_FULL_LOOP_RECEIPT_RELEASE_SUPERSEDED}" | \
+		"authorized:${_FULL_LOOP_RECEIPT_RELEASE_PUBLISHED}" | \
+		"authorized:${_FULL_LOOP_RECEIPT_RELEASE_SUPERSEDED}" | \
+		"${_FULL_LOOP_RECEIPT_RELEASE_NOT_REQUESTED}:${_FULL_LOOP_RECEIPT_RELEASE_PUBLISHED}" | \
+		"${_FULL_LOOP_RECEIPT_RELEASE_NOT_REQUESTED}:${_FULL_LOOP_RECEIPT_RELEASE_SUPERSEDED}" | \
+		"${release_status}:${release_status}") ;;
+	*)
+		_full_loop_receipt_lock_release
+		return 1
+		;;
+	esac
+	if [[ "$current_release" == "$release_status" ]]; then
+		_full_loop_receipt_lock_release
+		return 0
+	fi
 	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || {
 		_full_loop_receipt_lock_release
 		return 1

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -1288,6 +1288,9 @@ _full_loop_reconcile_published_release_receipt() {
 	if [[ "$receipt_status" == "$_FULL_LOOP_RELEASE_SUPERSEDED" ]]; then
 		_full_loop_verify_superseded_release_receipt "$repo" "$pr_number" || return 1
 	fi
+	if declare -F full_loop_update_cleanup_release_status >/dev/null 2>&1; then
+		full_loop_update_cleanup_release_status "$repo" "$pr_number" "$receipt_status" || return 1
+	fi
 	RELEASE_STATUS="$receipt_status"
 	if ! save_state "${CURRENT_PHASE:-${PHASE:-complete}}" "$SAVED_PROMPT" "$pr_number" \
 		"${STARTED_AT:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}"; then
@@ -1295,6 +1298,31 @@ _full_loop_reconcile_published_release_receipt() {
 		return 1
 	fi
 	return 0
+}
+
+_full_loop_reconcile_completion_release_receipt() {
+	local repo="$1"
+	local pr_number="$2"
+	local local_status="$3"
+	local receipt_path=""
+	local receipt_status=""
+	receipt_path=$(_full_loop_release_receipt_path "$repo" "$pr_number") || return 1
+	if [[ ! -f "$receipt_path" ]]; then
+		[[ "$local_status" == "$_FULL_LOOP_RELEASE_NOT_REQUESTED" ]]
+		return $?
+	fi
+	IFS= read -r receipt_status <"$receipt_path" || return 1
+	case "$receipt_status" in
+	"$_FULL_LOOP_RELEASE_PUBLISHED" | "$_FULL_LOOP_RELEASE_SUPERSEDED")
+		_full_loop_reconcile_published_release_receipt "$repo" "$pr_number"
+		return $?
+		;;
+	"$_FULL_LOOP_RELEASE_NOT_REQUESTED")
+		[[ "$local_status" == "$_FULL_LOOP_RELEASE_NOT_REQUESTED" ]]
+		return $?
+		;;
+	*) return 1 ;;
+	esac
 }
 
 _full_loop_reconcile_detached_publication_receipt() {
@@ -1326,8 +1354,8 @@ cmd_complete() {
 		print_error "Cannot resolve repository for deferred cleanup handoff"
 		return 1
 	}
-	if [[ "${RELEASE_STATUS:-}" == "authorized" ]]; then
-		_full_loop_reconcile_published_release_receipt "$repo" "$PR_NUMBER" || {
+	if [[ "${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" == "authorized" || "${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" == "$_FULL_LOOP_RELEASE_NOT_REQUESTED" ]]; then
+		_full_loop_reconcile_completion_release_receipt "$repo" "$PR_NUMBER" "${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" || {
 			print_error "Cleanup blocked: release:${RELEASE_STATUS} is not terminal-success"
 			return 1
 		}

--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -185,11 +185,13 @@ _full_loop_release_guard_existing() {
 	fi
 	case "$release_status" in
 	"$_FULL_LOOP_RELEASE_PUBLISHED")
+		full_loop_update_cleanup_release_status "$repo" "$source_pr" "$release_status" || return 1
 		printf 'release:published already recorded for PR #%s; skipping duplicate publication\n' "$source_pr"
 		return 0
 		;;
 	"$_FULL_LOOP_RELEASE_SUPERSEDED")
 		_full_loop_verify_superseded_release_receipt "$repo" "$source_pr" || return 1
+		full_loop_update_cleanup_release_status "$repo" "$source_pr" "$release_status" || return 1
 		printf 'release:superseded already recorded for PR #%s; skipping duplicate publication\n' "$source_pr"
 		return 0
 		;;

--- a/.agents/scripts/tests/test-full-loop-completion-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-completion-evidence.sh
@@ -413,7 +413,8 @@ status="${output##*$'\n'}"
 [[ "$status" == "published" && ! -s "${ROOT}/release-calls.log" ]]
 printf 'PASS published detached-release receipt prevents duplicate publication\n'
 
-rm -f "${receipt_dir}/marcusquinn_aidevops-42.status" "${receipt_dir}/marcusquinn_aidevops-42.aggregate.json"
+rm -f "${receipt_dir}/marcusquinn_aidevops-42.status" "${receipt_dir}/marcusquinn_aidevops-42.aggregate.json" \
+	"${cleanup_receipt_dir}/marcusquinn_aidevops-42.json"
 : >"${ROOT}/release-calls.log"
 output=$(env "${flow_env[@]}" RELEASE_RUNNER_STATUS=superseded bash "$state_runner")
 status="${output##*$'\n'}"
@@ -502,6 +503,33 @@ grep -q '^release_status: published$' "${ROOT}/handoff-state/full-loop.state"
 jq -e '.executor_completion_state == "COMPLETE" and .release_status == "published"' \
 	"${cleanup_receipt_dir}/marcusquinn_aidevops-44.json" >/dev/null
 printf 'PASS matching published receipt atomically promotes stale authorized lifecycle state\n'
+
+printf '%s\n' superseded >"${receipt_dir}/marcusquinn_aidevops-47.status"
+jq -cn '{schema_version:1,status:"superseded",repository:"marcusquinn/aidevops",pr_number:47,
+	source_merge:("1" * 40),aggregate_pr:99,aggregate_merge:("2" * 40),release_tag:"v3.0.0",release_commit:("3" * 40)}' \
+	>"${receipt_dir}/marcusquinn_aidevops-47.aggregate.json"
+superseded_handoff_output=$(AIDEVOPS_FULL_LOOP_REPO=marcusquinn/aidevops \
+	AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	TEST_PR_NUMBER=47 TEST_RELEASE_STATUS=not-requested bash "$handoff_runner")
+printf '%s\n' "$superseded_handoff_output" | grep -q '<promise>FULL_LOOP_CLEANUP_DEFERRED</promise>'
+jq -e '.executor_completion_state == "COMPLETE" and .release_status == "superseded"' \
+	"${cleanup_receipt_dir}/marcusquinn_aidevops-47.json" >/dev/null
+AIDEVOPS_FULL_LOOP_REPO=marcusquinn/aidevops AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" \
+	AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" TEST_PR_NUMBER=47 TEST_RELEASE_STATUS=not-requested \
+	bash "$handoff_runner" >/dev/null
+printf 'PASS stale no-release completion converges verified superseded evidence idempotently\n'
+
+printf '%s\n' superseded >"${receipt_dir}/marcusquinn_aidevops-48.status"
+jq -cn '{schema_version:1,status:"superseded",repository:"wrong/repo",pr_number:48}' \
+	>"${receipt_dir}/marcusquinn_aidevops-48.aggregate.json"
+if AIDEVOPS_FULL_LOOP_REPO=marcusquinn/aidevops AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" \
+	AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" TEST_PR_NUMBER=48 TEST_RELEASE_STATUS=not-requested \
+	bash "$handoff_runner" >/dev/null 2>&1; then
+	printf 'FAIL malformed aggregate evidence allowed stale no-release completion\n'
+	exit 1
+fi
+[[ ! -e "${cleanup_receipt_dir}/marcusquinn_aidevops-48.json" ]]
+printf 'PASS malformed aggregate evidence cannot create converged cleanup state\n'
 
 for invalid_case in missing failed mismatched; do
 	invalid_pr=45

--- a/.agents/scripts/tests/test-full-loop-release-helper.sh
+++ b/.agents/scripts/tests/test-full-loop-release-helper.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit
 ROOT=$(mktemp -d)
 trap 'rm -rf "$ROOT"' EXIT
 mkdir -p "$ROOT/bin" "$ROOT/repo/linked-branch" "$ROOT/repo/.agents/scripts" \
-	"$ROOT/repo/.git" "$ROOT/worktrees"
+	"$ROOT/repo/.git" "$ROOT/worktrees" "$ROOT/cleanup"
 : >"$ROOT/repo/aidevops.sh"
 : >"$ROOT/repo/.agents/scripts/version-manager.sh"
 
@@ -136,6 +136,8 @@ fi
 printf 'PASS detached release runner persists publication receipt after successful gates\n'
 
 cp "$ROOT/vm.log" "$ROOT/vm-after-publication.log"
+printf '%s\n' '{"schema_version":1,"repository":"marcusquinn/aidevops","pr_number":42,"release_status":"not-requested"}' \
+	>"$ROOT/cleanup/marcusquinn_aidevops-42.json"
 worktree_adds_before=$(grep -c 'worktree add --detach .*/aidevops-release-42-' "$ROOT/git.log")
 (
 	cd "$ROOT/repo/linked-branch"
@@ -147,12 +149,14 @@ worktree_adds_before=$(grep -c 'worktree add --detach .*/aidevops-release-42-' "
 		AIDEVOPS_FULL_LOOP_VERSION_MANAGER="../../version-manager.sh" \
 		AIDEVOPS_FULL_LOOP_SOURCE_RESOLVER="$ROOT/source-resolver.sh" \
 		AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$ROOT/receipts" \
+		AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$ROOT/cleanup" \
 		AIDEVOPS_FULL_LOOP_REPO=marcusquinn/aidevops \
 		bash "$SCRIPT_DIR/full-loop-release-helper.sh" minor 42 full
 )
 cmp -s "$ROOT/vm.log" "$ROOT/vm-after-publication.log"
 worktree_adds_after=$(grep -c 'worktree add --detach .*/aidevops-release-42-' "$ROOT/git.log")
 [[ "$worktree_adds_after" -eq "$worktree_adds_before" ]]
+jq -e '.release_status == "published"' "$ROOT/cleanup/marcusquinn_aidevops-42.json" >/dev/null
 printf 'PASS repeated detached release reconciliation skips duplicate publication\n'
 
 pending_rc=0
@@ -259,15 +263,35 @@ grep -qx 'superseded' "$ROOT/receipts/marcusquinn_aidevops-45.status"
 jq -e '.status == "superseded" and .pr_number == 45 and .aggregate_pr == 99 and .release_tag == "v3.0.0"' \
 	"$ROOT/receipts/marcusquinn_aidevops-45.aggregate.json" >/dev/null
 cp "$ROOT/aggregate-vm.log" "$ROOT/aggregate-vm-before-retry.log"
+printf '%s\n' '{"schema_version":1,"repository":"marcusquinn/aidevops","pr_number":45,"release_status":"not-requested"}' \
+	>"$ROOT/cleanup/marcusquinn_aidevops-45.json"
 (
 	cd "$ROOT/repo/linked-branch"
 	PATH="$ROOT/bin:/usr/bin:/bin" \
 		GIT_CALL_LOG="$ROOT/git.log" VM_CALL_LOG="$ROOT/aggregate-vm.log" FAKE_REPO_ROOT="$ROOT/repo" \
 		AIDEVOPS_WORKTREE_BASE_DIR="$ROOT/worktrees" AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$ROOT/receipts" \
+		AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$ROOT/cleanup" \
 		AIDEVOPS_FULL_LOOP_REPO=marcusquinn/aidevops \
 		bash "$SCRIPT_DIR/full-loop-release-helper.sh" patch 45 incremental
 )
 cmp -s "$ROOT/aggregate-vm.log" "$ROOT/aggregate-vm-before-retry.log"
+jq -e '.release_status == "superseded"' "$ROOT/cleanup/marcusquinn_aidevops-45.json" >/dev/null
+
+printf '%s\n' '{"schema_version":1,"repository":"wrong/repo","pr_number":45,"release_status":"not-requested"}' \
+	>"$ROOT/cleanup/marcusquinn_aidevops-45.json"
+if (
+	cd "$ROOT/repo/linked-branch"
+	PATH="$ROOT/bin:/usr/bin:/bin" GIT_CALL_LOG="$ROOT/git.log" VM_CALL_LOG="$ROOT/aggregate-vm.log" \
+		FAKE_REPO_ROOT="$ROOT/repo" AIDEVOPS_WORKTREE_BASE_DIR="$ROOT/worktrees" \
+		AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$ROOT/receipts" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$ROOT/cleanup" \
+		AIDEVOPS_FULL_LOOP_REPO=marcusquinn/aidevops \
+		bash "$SCRIPT_DIR/full-loop-release-helper.sh" patch 45 incremental
+); then
+	printf 'FAIL mismatched cleanup receipt accepted terminal release replay\n'
+	exit 1
+fi
+jq -e '.repository == "wrong/repo" and .release_status == "not-requested"' \
+	"$ROOT/cleanup/marcusquinn_aidevops-45.json" >/dev/null
 printf 'PASS reviewed aggregate source publishes once and truthfully supersedes included receipts\n'
 
 exit 0


### PR DESCRIPTION
## Summary

Reconcile verified published or superseded release evidence into stale cleanup receipts during completion and idempotent release retries while rejecting malformed identities and conflicting terminal states.

## Files Changed

.agents/scripts/full-loop-cleanup-receipt.sh, .agents/scripts/full-loop-helper-state.sh, .agents/scripts/full-loop-release-helper.sh, .agents/scripts/tests/test-full-loop-completion-evidence.sh, .agents/scripts/tests/test-full-loop-release-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — .agents/scripts/tests/test-full-loop-completion-evidence.sh; bash .agents/scripts/tests/test-full-loop-release-helper.sh; .agents/scripts/tests/test-release-provenance-helper.sh; .agents/scripts/linters-local.sh

Resolves #28801


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.189 plugin for [OpenCode](https://opencode.ai) v1.18.7 with gpt-5.6-sol spent 12m and 93,002 tokens on this as a headless worker.