### PR TITLE
GH#28800: fix Linux sensitive-temp stat probing

### DIFF
--- a/.agents/scripts/sensitive-temp-helper.sh
+++ b/.agents/scripts/sensitive-temp-helper.sh
@@ -25,6 +25,31 @@ _aidevops_sensitive_temp_reject() {
 	return 1
 }
 
+_aidevops_sensitive_temp_stat_owner_uid() {
+	local path="$1"
+	local owner_uid=""
+	owner_uid=$(stat -c '%u' "$path" 2>/dev/null || true)
+	if [[ ! "$owner_uid" =~ ^[0-9]+$ ]]; then
+		owner_uid=$(stat -f '%u' "$path" 2>/dev/null || true)
+	fi
+	[[ "$owner_uid" =~ ^[0-9]+$ ]] || return 1
+	printf '%s\n' "$owner_uid"
+	return 0
+}
+
+_aidevops_sensitive_temp_stat_mode() {
+	local path="$1"
+	local bsd_format="$2"
+	local mode=""
+	mode=$(stat -c '%a' "$path" 2>/dev/null || true)
+	if [[ ! "$mode" =~ ^[0-7]{3,6}$ ]]; then
+		mode=$(stat -f "$bsd_format" "$path" 2>/dev/null || true)
+	fi
+	[[ "$mode" =~ ^[0-7]{3,6}$ ]] || return 1
+	printf '%s\n' "$mode"
+	return 0
+}
+
 _aidevops_sensitive_temp_physical_path_is_safe() {
 	local candidate="$1"
 	local remainder="${candidate#/}"
@@ -64,14 +89,14 @@ _aidevops_sensitive_temp_physical_path_is_safe() {
 				"$_AIDEVOPS_SENSITIVE_TEMP_UNKNOWN" "missing_non_directory_or_symlink_component"
 			return 1
 		fi
-		owner_uid=$(stat -f '%u' "$current" 2>/dev/null || stat -c '%u' "$current" 2>/dev/null) || {
+		owner_uid=$(_aidevops_sensitive_temp_stat_owner_uid "$current") || {
 			_aidevops_sensitive_temp_reject "$current" "$_AIDEVOPS_SENSITIVE_TEMP_UNKNOWN" \
 				"$_AIDEVOPS_SENSITIVE_TEMP_UNKNOWN" "owner_stat_failed"
 			return 1
 		}
 		# BSD %Lp omits special bits; %p retains the sticky bit (and file type).
 		# GNU %a returns permission bits only. The masks below work for either.
-		mode=$(stat -f '%p' "$current" 2>/dev/null || stat -c '%a' "$current" 2>/dev/null) || {
+		mode=$(_aidevops_sensitive_temp_stat_mode "$current" '%p') || {
 			_aidevops_sensitive_temp_reject "$current" "$owner_uid" \
 				"$_AIDEVOPS_SENSITIVE_TEMP_UNKNOWN" "mode_stat_failed"
 			return 1
@@ -147,7 +172,7 @@ aidevops_sensitive_temp_root() {
 			"$_AIDEVOPS_SENSITIVE_TEMP_UNKNOWN" "current_uid_unavailable"
 		return 1
 	}
-	owner_uid=$(stat -f '%u' "$temp_root" 2>/dev/null || stat -c '%u' "$temp_root" 2>/dev/null) || {
+	owner_uid=$(_aidevops_sensitive_temp_stat_owner_uid "$temp_root") || {
 		_aidevops_sensitive_temp_reject "$temp_root" "$_AIDEVOPS_SENSITIVE_TEMP_UNKNOWN" \
 			"$_AIDEVOPS_SENSITIVE_TEMP_UNKNOWN" "owner_stat_failed"
 		return 1
@@ -162,7 +187,7 @@ aidevops_sensitive_temp_root() {
 			"$_AIDEVOPS_SENSITIVE_TEMP_UNKNOWN" "sensitive_root_chmod_failed"
 		return 1
 	}
-	mode=$(stat -f '%Lp' "$temp_root" 2>/dev/null || stat -c '%a' "$temp_root" 2>/dev/null) || {
+	mode=$(_aidevops_sensitive_temp_stat_mode "$temp_root" '%Lp') || {
 		_aidevops_sensitive_temp_reject "$temp_root" "$owner_uid" \
 			"$_AIDEVOPS_SENSITIVE_TEMP_UNKNOWN" "mode_stat_failed"
 		return 1

--- a/.agents/scripts/tests/test-sensitive-temp-helper.sh
+++ b/.agents/scripts/tests/test-sensitive-temp-helper.sh
@@ -61,6 +61,59 @@ wait_for_absence() {
 	return 1
 }
 
+stat() {
+	local flag="${1:-}"
+	local format="${2:-}"
+	local path="${3:-}"
+	: "$path"
+	if [[ "$flag" == "-c" && "$format" == "%u" ]]; then
+		printf '4242\n'
+		return 0
+	fi
+	if [[ "$flag" == "-c" && "$format" == "%a" ]]; then
+		printf '1777\n'
+		return 0
+	fi
+	if [[ "$flag" == "-f" ]]; then
+		printf '  File: filesystem statistics\n0\n'
+		return 0
+	fi
+	return 1
+}
+[[ "$(_aidevops_sensitive_temp_stat_owner_uid /fixture)" == "4242" ]] || \
+	fail "GNU owner stat did not win over successful filesystem-mode output"
+[[ "$(_aidevops_sensitive_temp_stat_mode /fixture '%p')" == "1777" ]] || \
+	fail "GNU mode stat did not win over successful filesystem-mode output"
+unset -f stat
+
+stat() {
+	local flag="${1:-}"
+	local format="${2:-}"
+	local path="${3:-}"
+	: "$path"
+	[[ "$flag" == "-c" ]] && return 1
+	if [[ "$flag" == "-f" && "$format" == "%u" ]]; then
+		printf '501\n'
+		return 0
+	fi
+	if [[ "$flag" == "-f" && "$format" == "%p" ]]; then
+		printf '41777\n'
+		return 0
+	fi
+	if [[ "$flag" == "-f" && "$format" == "%Lp" ]]; then
+		printf '700\n'
+		return 0
+	fi
+	return 1
+}
+[[ "$(_aidevops_sensitive_temp_stat_owner_uid /fixture)" == "501" ]] || \
+	fail "BSD owner stat fallback failed"
+[[ "$(_aidevops_sensitive_temp_stat_mode /fixture '%p')" == "41777" ]] || \
+	fail "BSD ancestor mode fallback lost sticky-bit mode"
+[[ "$(_aidevops_sensitive_temp_stat_mode /fixture '%Lp')" == "700" ]] || \
+	fail "BSD final-root mode fallback failed"
+unset -f stat
+
 managed_dir=$(aidevops_sensitive_temp_create_dir "test-private") || \
 	fail "failed to create a managed sensitive directory"
 [[ "${managed_dir%/*}" == "$MANAGED_ROOT" && \


### PR DESCRIPTION
## Summary

Use validated GNU-first stat probes with BSD fallbacks for sensitive temporary path ownership and mode checks.

## Files Changed

.agents/scripts/sensitive-temp-helper.sh, .agents/scripts/tests/test-sensitive-temp-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Sensitive-temp regression suite passes; ShellCheck clean; changed-file local gates pass; review bundle ba84364660c866c92bf76674d07ae2af691c33d50525ee41f2c4127ca883c3 is clean.

Resolves #28800


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.189 plugin for [OpenCode](https://opencode.ai) v1.18.8 with gpt-5.6-sol spent 1h 16m and 402,332 tokens on this with the user in an interactive session.