### PR TITLE
GH#28803: complete cleanup for already-missing worktrees

### DIFF
--- a/.agents/scripts/tests/test-worktree-metadata-prune.sh
+++ b/.agents/scripts/tests/test-worktree-metadata-prune.sh
@@ -12,6 +12,7 @@ REPO="${TEST_ROOT}/repo"
 LINKED="${TEST_ROOT}/linked"
 FAILED_LINKED="${TEST_ROOT}/failed-linked"
 RECOVERABLE_LINKED="${TEST_ROOT}/recoverable-linked"
+RECOVERABLE_MISSING_LINKED="${TEST_ROOT}/recoverable-missing-linked"
 MOVE_FAILED_LINKED="${TEST_ROOT}/move-failed-linked"
 PRUNE_FAILED_LINKED="${TEST_ROOT}/prune-failed-linked"
 DIRTY_LINKED="${TEST_ROOT}/dirty-linked"
@@ -50,6 +51,7 @@ printf 'seed\n' >"${REPO}/README.md"
 /usr/bin/git -C "$REPO" worktree add -q -b feature/prune-test "$LINKED"
 /usr/bin/git -C "$REPO" worktree add -q -b feature/prune-failure "$FAILED_LINKED"
 /usr/bin/git -C "$REPO" worktree add -q -b feature/recoverable-success "$RECOVERABLE_LINKED"
+/usr/bin/git -C "$REPO" worktree add -q -b feature/recoverable-missing "$RECOVERABLE_MISSING_LINKED"
 /usr/bin/git -C "$REPO" worktree add -q -b feature/recoverable-move-failure "$MOVE_FAILED_LINKED"
 /usr/bin/git -C "$REPO" worktree add -q -b feature/recoverable-prune-failure "$PRUNE_FAILED_LINKED"
 /usr/bin/git -C "$REPO" worktree add -q -b feature/recoverable-dirty "$DIRTY_LINKED"
@@ -245,6 +247,31 @@ _branch_exists_on_any_remote() {
 	: "$worktree_branch"
 	return 0
 }
+
+missing_move_target="${TEST_ROOT}/never-created-worktree"
+if ! _clean_move_worktree_recoverably "$missing_move_target" ||
+	[[ "$_WT_CLEAN_RECOVERABLE_FAILURE_DETAIL" != "path-already-gone" ]]; then
+	printf 'FAIL absent recoverable source was not treated as idempotent success\n'
+	exit 1
+fi
+printf 'PASS absent recoverable source is an explicit idempotent success\n'
+
+rm -rf "$RECOVERABLE_MISSING_LINKED"
+missing_recovery_output=$(
+	cd "$REPO" || exit 1
+	AIDEVOPS_WORKTREE_TRASH_ROOT="$RECOVERABLE_TRASH" \
+		_clean_remove_classified_worktree "$RECOVERABLE_MISSING_LINKED" "feature/recoverable-missing" \
+		"false" "false" "visibility=degraded" "$REPO" "$_WT_CLEAN_MODE_RECOVERABLE" "true"
+)
+[[ "$(printf '%s\n' "$missing_recovery_output" | grep -cFx "$_WT_CLEAN_COMPLETED_EVENT")" -eq 1 ]] || {
+	printf 'FAIL absent recoverable source did not complete metadata cleanup: %s\n' "$missing_recovery_output"
+	exit 1
+}
+if /usr/bin/git -C "$REPO" worktree list --porcelain | grep -Fqx "worktree $RECOVERABLE_MISSING_LINKED"; then
+	printf 'FAIL absent recoverable source left exact Git worktree metadata registered\n'
+	exit 1
+fi
+printf 'PASS absent recoverable source continues through verified metadata pruning\n'
 
 recovery_output=$(
 	cd "$REPO" || exit 1

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -1013,7 +1013,10 @@ _clean_move_worktree_recoverably() {
 	_WT_CLEAN_RECOVERABLE_FAILURE_DETAIL=""
 
 	[[ -n "$worktree_path" ]] || return 1
-	[[ -e "$worktree_path" ]] || return 1
+	if [[ ! -e "$worktree_path" && ! -L "$worktree_path" ]]; then
+		_WT_CLEAN_RECOVERABLE_FAILURE_DETAIL="path-already-gone"
+		return 0
+	fi
 	if [[ -n "$trash_root" ]]; then
 		if _clean_move_worktree_to_trash_bucket "$worktree_path" "$trash_root"; then
 			return 0


### PR DESCRIPTION
## Summary

Treat an absent recoverable cleanup source as an explicit idempotent success so verified Git worktree metadata pruning can complete.

## Files Changed

.agents/scripts/tests/test-worktree-metadata-prune.sh, .agents/scripts/worktree-clean-lib.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Worktree metadata-prune suite passes all scenarios; ShellCheck clean; changed-file local gates pass; review bundle 1b4f8f73cd542e0670286639f4631973bcd6716ece7b43869948d79ba106a04c is clean.

Resolves #28803


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.189 plugin for [OpenCode](https://opencode.ai) v1.18.8 with gpt-5.6-sol spent 1h 20m and 423,482 tokens on this with the user in an interactive session.