### PR TITLE
GH#28807: fix: bind dispatch precreation to finite owner

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1016,7 +1016,7 @@ _dlw_claim_unowned_reused_worktree() {
 		return 1
 	fi
 	if ! claim_worktree_ownership "$worktree_path" "$branch" \
-		--task "$issue_number" --session "$session_id" 2>/dev/null; then
+		--task "$issue_number" --session "$session_id" --owner-pid "$$" 2>/dev/null; then
 		echo "[dispatch_with_dedup] Atomic owner claim rejected for reused worktree #${issue_number}: ${worktree_path}" >>"$LOGFILE"
 		return 1
 	fi
@@ -1104,7 +1104,8 @@ _dlw_precreate_worktree() {
 		if declare -F register_worktree >/dev/null 2>&1; then
 			register_worktree "$_DLW_WORKTREE_PATH" "$_DLW_WORKTREE_BRANCH" \
 				--task "$issue_number" \
-				--session "$_precreate_session" 2>/dev/null || true
+				--session "$_precreate_session" \
+				--owner-pid "$$" 2>/dev/null || true
 		fi
 		# Restore gitignored deps (node_modules) that git doesn't track
 		_dlw_restore_worktree_deps "$_DLW_WORKTREE_PATH" "$repo_path"

--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -948,6 +948,38 @@ _wt_owner_live_pid_reused_or_untrusted() {
 	return 1
 }
 
+_wt_legacy_dispatch_precreate_systemd_owner_expired() {
+	local wt_path="$1"
+	local owner_pid="$2"
+	local grace_minutes="${WORKTREE_DISPATCH_PRECREATE_LEGACY_GRACE_MINUTES:-15}"
+	local registered_comm=""
+	local current_comm=""
+	local expired=""
+
+	[[ "$owner_pid" =~ ^[0-9]+$ ]] || return 1
+	if [[ ! "$grace_minutes" =~ ^[0-9]+$ || "$grace_minutes" -lt 1 ]]; then
+		grace_minutes=15
+	fi
+	current_comm=$(_get_proc_comm "$owner_pid")
+	registered_comm=$(_wt_owner_comm_for_path "$wt_path")
+	[[ "$current_comm" == "systemd" && "$registered_comm" == "systemd" ]] || return 1
+
+	expired=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+        SELECT CASE
+            WHEN owner_pid = ${owner_pid}
+             AND COALESCE(task_id, '') != ''
+             AND task_id NOT GLOB '*[^0-9]*'
+             AND owner_session = 'dispatch-precreate-' || task_id
+             AND COALESCE(created_at, '') != ''
+             AND datetime(replace(replace(created_at, 'T', ' '), 'Z', ''), '+${grace_minutes} minutes') <= datetime('now')
+            THEN 1 ELSE 0 END
+        FROM worktree_owners
+        WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
+    " 2>/dev/null || printf '0')
+	[[ "$expired" == "1" ]] || return 1
+	return 0
+}
+
 # Compare a registry owner against an already-resolved caller PID.
 _wt_is_worktree_owned_by_others_for_resolved_pid() {
 	local wt_path="$1"
@@ -977,6 +1009,14 @@ _wt_is_worktree_owned_by_others_for_resolved_pid() {
 			return 1
 		fi
 		return 0
+	fi
+	# Deployed versions before GH#28807 registered dispatch-precreate handoffs
+	# against the immortal systemd --user parent. That identity is never a valid
+	# specialized handoff owner. Preserve a bounded launch grace, then remove only
+	# exact numeric task/session pairs so legacy rows can no longer block cleanup.
+	if _wt_legacy_dispatch_precreate_systemd_owner_expired "$wt_path" "$owner_pid"; then
+		unregister_worktree "$wt_path"
+		return 1
 	fi
 
 	# Owner recovered or PID was reused while still registered; clear any stale

--- a/.agents/scripts/tests/test-precreation-failure-skip.sh
+++ b/.agents/scripts/tests/test-precreation-failure-skip.sh
@@ -174,7 +174,7 @@ register_worktree() {
 	local wt_path="$1"
 	local branch="$2"
 	shift 2
-	local task="" session=""
+	local task="" session="" owner_pid=""
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--task)
@@ -185,10 +185,14 @@ register_worktree() {
 			session="${2:-}"
 			shift 2
 			;;
+		--owner-pid)
+			owner_pid="${2:-}"
+			shift 2
+			;;
 		*) shift ;;
 		esac
 	done
-	REGISTERED_WORKTREE_ARGS="${wt_path}|${branch}|${task}|${session}"
+	REGISTERED_WORKTREE_ARGS="${wt_path}|${branch}|${task}|${session}|${owner_pid}"
 	return 0
 }
 STUB_OWNER_INFO=""
@@ -204,7 +208,7 @@ claim_worktree_ownership() {
 	local wt_path="$1"
 	local branch="$2"
 	shift 2
-	local task="" session=""
+	local task="" session="" owner_pid=""
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--task)
@@ -215,10 +219,14 @@ claim_worktree_ownership() {
 			session="${2:-}"
 			shift 2
 			;;
+		--owner-pid)
+			owner_pid="${2:-}"
+			shift 2
+			;;
 		*) shift ;;
 		esac
 	done
-	CLAIMED_WORKTREE_ARGS="${wt_path}|${branch}|${task}|${session}"
+	CLAIMED_WORKTREE_ARGS="${wt_path}|${branch}|${task}|${session}|${owner_pid}"
 	[[ "$STUB_CLAIM_WORKTREE_RC" -eq 0 ]] || return 1
 	return 0
 }
@@ -333,7 +341,7 @@ else
 	fail "freshly-created worktree is marked non-reused" "got: '${_DLW_WORKTREE_REUSED:-unset}', expected: '0'"
 fi
 
-if [[ "$REGISTERED_WORKTREE_ARGS" == "${STUB_WT_SUCCESS_PATH}|${_DLW_WORKTREE_BRANCH}|88888|dispatch-precreate-88888" ]]; then
+if [[ "$REGISTERED_WORKTREE_ARGS" == "${STUB_WT_SUCCESS_PATH}|${_DLW_WORKTREE_BRANCH}|88888|dispatch-precreate-88888|$$" ]]; then
 	pass "fresh precreated worktree is registered as transferable"
 else
 	fail "fresh precreated worktree is registered as transferable" "got: '$REGISTERED_WORKTREE_ARGS'"
@@ -434,7 +442,7 @@ STUB_CLAIM_WORKTREE_RC=0
 : >"$LOGFILE"
 _dlw_precreate_worktree "66666" "$FAKE_REPO"
 rc=$?
-expected_claim="${STUB_EXISTING_PATH}|${STUB_EXISTING_BRANCH}|66666|dispatch-precreate-66666"
+expected_claim="${STUB_EXISTING_PATH}|${STUB_EXISTING_BRANCH}|66666|dispatch-precreate-66666|$$"
 if [[ "$rc" -eq 0 && "$CLAIMED_WORKTREE_ARGS" == "$expected_claim" && -z "$REGISTERED_WORKTREE_ARGS" ]]; then
 	pass "unowned reused worktree uses an atomic ownership claim"
 else

--- a/.agents/scripts/tests/test-worktree-registry-dead-owner.sh
+++ b/.agents/scripts/tests/test-worktree-registry-dead-owner.sh
@@ -212,6 +212,83 @@ test_recent_live_pid_without_comm_still_blocks() {
 	return 0
 }
 
+test_expired_legacy_dispatch_precreate_systemd_owner_unregisters() {
+	local wt_path
+	wt_path=$(make_worktree_dir "legacy-dispatch-precreate-systemd")
+	local owner_pid
+	owner_pid=$(live_other_pid)
+	register_worktree "$wt_path" "feature/legacy-dispatch-precreate-systemd" \
+		--owner-pid "$owner_pid" --session "dispatch-precreate-28807" --task "28807"
+	local registry_path
+	registry_path=$(_wt_registry_lookup_path "$wt_path")
+	sqlite3 "$WORKTREE_REGISTRY_DB" "
+        UPDATE worktree_owners
+        SET created_at = '2020-01-01T00:00:00Z', owner_comm = 'systemd'
+        WHERE worktree_path = '$(_wt_sql_escape "$registry_path")';
+    "
+	_get_proc_comm() { printf '%s' 'systemd'; return 0; }
+	export WORKTREE_DISPATCH_PRECREATE_LEGACY_GRACE_MINUTES=15
+
+	local rc=0
+	if is_worktree_owned_by_others "$wt_path" >/dev/null 2>&1; then
+		rc=1
+	fi
+	assert_owner_missing "$wt_path" || rc=1
+	print_result "expired legacy systemd precreate owner unregisters" "$rc"
+	return 0
+}
+
+test_recent_legacy_dispatch_precreate_systemd_owner_blocks() {
+	local wt_path
+	wt_path=$(make_worktree_dir "recent-dispatch-precreate-systemd")
+	local owner_pid
+	owner_pid=$(live_other_pid)
+	register_worktree "$wt_path" "feature/recent-dispatch-precreate-systemd" \
+		--owner-pid "$owner_pid" --session "dispatch-precreate-28808" --task "28808"
+	local registry_path
+	registry_path=$(_wt_registry_lookup_path "$wt_path")
+	sqlite3 "$WORKTREE_REGISTRY_DB" "
+        UPDATE worktree_owners SET owner_comm = 'systemd'
+        WHERE worktree_path = '$(_wt_sql_escape "$registry_path")';
+    "
+	_get_proc_comm() { printf '%s' 'systemd'; return 0; }
+	export WORKTREE_DISPATCH_PRECREATE_LEGACY_GRACE_MINUTES=15
+
+	local rc=0
+	if ! is_worktree_owned_by_others "$wt_path" >/dev/null 2>&1; then
+		rc=1
+	fi
+	assert_owner_exists "$wt_path" || rc=1
+	print_result "recent legacy systemd precreate owner keeps launch grace" "$rc"
+	return 0
+}
+
+test_mismatched_legacy_dispatch_precreate_identity_blocks() {
+	local wt_path
+	wt_path=$(make_worktree_dir "mismatched-dispatch-precreate-systemd")
+	local owner_pid
+	owner_pid=$(live_other_pid)
+	register_worktree "$wt_path" "feature/mismatched-dispatch-precreate-systemd" \
+		--owner-pid "$owner_pid" --session "dispatch-precreate-99999" --task "28809"
+	local registry_path
+	registry_path=$(_wt_registry_lookup_path "$wt_path")
+	sqlite3 "$WORKTREE_REGISTRY_DB" "
+        UPDATE worktree_owners
+        SET created_at = '2020-01-01T00:00:00Z', owner_comm = 'systemd'
+        WHERE worktree_path = '$(_wt_sql_escape "$registry_path")';
+    "
+	_get_proc_comm() { printf '%s' 'systemd'; return 0; }
+	export WORKTREE_DISPATCH_PRECREATE_LEGACY_GRACE_MINUTES=15
+
+	local rc=0
+	if ! is_worktree_owned_by_others "$wt_path" >/dev/null 2>&1; then
+		rc=1
+	fi
+	assert_owner_exists "$wt_path" || rc=1
+	print_result "mismatched systemd precreate identity remains protected" "$rc"
+	return 0
+}
+
 test_explicit_cleanup_lease_identity() {
 	local wt_path
 	wt_path=$(make_worktree_dir "explicit-cleanup-lease")
@@ -313,6 +390,9 @@ main() {
 	test_owner_pid_override_rejects_sql_payload
 	test_stale_live_pid_comm_mismatch_unregisters
 	test_recent_live_pid_without_comm_still_blocks
+	test_expired_legacy_dispatch_precreate_systemd_owner_unregisters
+	test_recent_legacy_dispatch_precreate_systemd_owner_blocks
+	test_mismatched_legacy_dispatch_precreate_identity_blocks
 	test_explicit_cleanup_lease_identity
 	test_legacy_registry_schema_migrates_on_owner_check
 	test_should_skip_cleanup_branch_merged_within_grace


### PR DESCRIPTION
## Summary

Bind dispatch-precreated worktrees to the finite pulse owner and reconcile only expired legacy systemd rows with exact numeric task/session identity

## Files Changed

.agents/scripts/pulse-dispatch-worker-launch.sh, .agents/scripts/shared-worktree-registry.sh, .agents/scripts/tests/test-precreation-failure-skip.sh, .agents/scripts/tests/test-worktree-registry-dead-owner.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified with 44 precreation/launch fixture checks, 12 SQLite registry owner-lifecycle checks, ShellCheck, bash syntax validation, and changed-file quality gates

Resolves #28807


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.189 plugin for [OpenCode](https://opencode.ai) v1.18.8 with gpt-5.6-sol spent 1h 32m and 607,540 tokens on this with the user in an interactive session.