### PR TITLE
GH#28816: fix exact API attribution after baseline observation

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -394,6 +394,26 @@ _shim_transport_page() {
 	return 0
 }
 
+_shim_graphql_query_requests_rate_limit_cost() {
+	local -a arguments=("$@")
+	local command_name="${arguments[0]:-}"
+	local subcommand="${arguments[1]:-}"
+	local arg=""
+	local query=""
+	local cost_pattern='rateLimit[[:space:]]*(\([^)]*\)[[:space:]]*)?\{[^}]*cost([[:space:]}(]|$)'
+	[[ "$command_name" == "api" && "$subcommand" == "graphql" ]] || return 1
+	for arg in "${arguments[@]:2}"; do
+		case "$arg" in
+		--include | --paginate | --silent | --slurp | -i | -q | --jq | -t | --template) return 1 ;;
+		--jq=* | --template=* | -q?* | -t?*) return 1 ;;
+		query=*) query="${arg#query=}" ;;
+		-fquery=* | -Fquery=* | --field=query=* | --raw-field=query=*) query="${arg#*=}" ;;
+		esac
+	done
+	[[ -n "$query" && "$query" =~ $cost_pattern ]] || return 1
+	return 0
+}
+
 #######################################
 # Execute one fixed-shape GraphQL query whose response includes
 # data.rateLimit.cost. Capture stdout privately, record the returned operation-
@@ -409,15 +429,22 @@ _shim_run_response_metered_graphql() {
 		local retry="$1"; shift
 		local temp_dir="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
 		local output_file="" start_ms="" end_ms="" elapsed_ms="" quota_cost=""
+		local quota_state_file="" quota_lock_dir=""
 		local rc=0 replay_rc=0 outcome="success"
 
 		[[ "${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-0}" == "1" && "$path" == "graphql" ]] || return 125
+		_shim_graphql_query_requests_rate_limit_cost "$@" || return 125
 		declare -F gh_record_attempt >/dev/null 2>&1 || return 125
 		declare -F _ghqa_prepare_private_dir >/dev/null 2>&1 || return 125
+		declare -F _ghqa_response_meter_lock_acquire >/dev/null 2>&1 || return 125
+		declare -F _ghqa_response_meter_lock_invalidate_release >/dev/null 2>&1 || return 125
 		command -v jq >/dev/null 2>&1 || return 125
+		_ghqa_response_meter_lock_acquire "$executable" "$@" || return 125
+		quota_state_file="$_GHQA_RESPONSE_METER_STATE_FILE"
+		quota_lock_dir="$_GHQA_RESPONSE_METER_LOCK_DIR"
+		trap '_ghqa_response_meter_lock_invalidate_release "$quota_state_file" "$quota_lock_dir"; [[ -z "$output_file" ]] || rm -f -- "$output_file" 2>/dev/null || true' EXIT
 		_ghqa_prepare_private_dir "$temp_dir" || return 125
 		output_file=$(mktemp "${temp_dir}/gh-graphql-cost-response.XXXXXX" 2>/dev/null) || return 125
-		trap 'rm -f -- "$output_file" 2>/dev/null || true' EXIT
 		trap 'exit 129' HUP
 		trap 'exit 130' INT
 		trap 'exit 143' TERM

--- a/.agents/scripts/gh-quota-attribution-lib.sh
+++ b/.agents/scripts/gh-quota-attribution-lib.sh
@@ -21,6 +21,8 @@ _GHQA_METHOD=""
 _GHQA_FIELDS_REQUESTED=0
 _GHQA_INPUT_REQUESTED=0
 _GHQA_AMBIGUOUS=0
+_GHQA_RESPONSE_METER_STATE_FILE=""
+_GHQA_RESPONSE_METER_LOCK_DIR=""
 
 _ghqa_lower() {
 	local value="$1"
@@ -271,6 +273,39 @@ _ghqa_lock_release() {
 	return 0
 }
 
+_ghqa_response_meter_lock_acquire() {
+	local executable="$1"
+	shift
+	local host=""
+	local fingerprint=""
+	local state_dir=""
+	local state_file=""
+	local lock_dir=""
+	_GHQA_RESPONSE_METER_STATE_FILE=""
+	_GHQA_RESPONSE_METER_LOCK_DIR=""
+	[[ "${AIDEVOPS_GH_EXACT_QUOTA_CAPTURE:-0}" == 1 ]] || return 0
+	host=$(_ghqa_target_host "$@" 2>/dev/null || true)
+	[[ "$host" == github.com ]] || return 1
+	fingerprint=$(_ghqa_auth_fingerprint "$executable" "$host" 2>/dev/null || true)
+	[[ "$fingerprint" =~ ^[a-f0-9]{64}$ ]] || return 1
+	state_dir="${AIDEVOPS_GH_QUOTA_STATE_DIR:-${HOME}/.aidevops/state/gh-quota-attribution}"
+	_ghqa_prepare_private_dir "$state_dir" || return 1
+	state_file="${state_dir}/${fingerprint}.state"
+	lock_dir="${state_file}.lock.d"
+	_ghqa_lock_acquire "$lock_dir" || return 1
+	_GHQA_RESPONSE_METER_STATE_FILE="$state_file"
+	_GHQA_RESPONSE_METER_LOCK_DIR="$lock_dir"
+	return 0
+}
+
+_ghqa_response_meter_lock_invalidate_release() {
+	local state_file="$1"
+	local lock_dir="$2"
+	[[ -z "$state_file" ]] || rm -f -- "$state_file" 2>/dev/null || true
+	[[ -z "$lock_dir" ]] || _ghqa_lock_release "$lock_dir"
+	return 0
+}
+
 _ghqa_state_get() {
 	local state_file="$1"
 	local requested_resource="$2"
@@ -500,9 +535,9 @@ _ghqa_capture_cleanup() {
 _ghqa_capture_frames_valid() {
 	local parsed="$1"
 	local expected_frames="$2"
-	local kind frame_index status_count status resource used remaining reset elapsed
+	local kind frame_index status_count status resource used remaining reset elapsed response_cost
 	local rows=0
-	while IFS=$'\t' read -r kind frame_index status_count status resource used remaining reset elapsed; do
+	while IFS=$'\t' read -r kind frame_index status_count status resource used remaining reset elapsed response_cost; do
 		[[ "$kind" == frame ]] || continue
 		rows=$((rows + 1))
 		[[ "$frame_index" =~ ^[1-9][0-9]*$ && "$status_count" == 1 ]] || return 1
@@ -511,6 +546,7 @@ _ghqa_capture_frames_valid() {
 		for value in "$used" "$remaining" "$reset" "$elapsed"; do
 			[[ "$value" =~ ^[0-9]+$ ]] || return 1
 		done
+		[[ -z "$response_cost" || "$response_cost" =~ ^[0-9]+$ ]] || return 1
 	done <<<"$parsed"
 	[[ "$rows" -eq "$expected_frames" && "$rows" -gt 0 ]]
 	return $?
@@ -532,6 +568,7 @@ _ghqa_response_cost() {
 	local resource="$2"
 	local used="$3"
 	local reset="$4"
+	local status="$5"
 	local previous="" previous_used="" previous_reset="" delta=""
 	previous=$(_ghqa_state_get "$state_file" "$resource" 2>/dev/null || true)
 	IFS=$'\t' read -r previous_used previous_reset <<<"$previous"
@@ -545,6 +582,11 @@ _ghqa_response_cost() {
 		printf '1'
 		return 0
 	fi
+	if [[ "$delta" == 0 && "$status" =~ ^[0-9]{3}$ ]] \
+		&& ((status == 304 || status >= 400)); then
+		printf '0'
+		return 0
+	fi
 	return 1
 }
 
@@ -556,14 +598,15 @@ _ghqa_write_complete_frames() {
 	local command_rc="$5"
 	local parsed="$6"
 	shift 6
-	local kind="" frame_index="" status_count="" status="" resource="" used="" remaining="" reset="" elapsed=""
+	local kind="" frame_index="" status_count="" status="" resource="" used="" remaining="" reset="" elapsed="" response_cost=""
 	local frame_total=0 path="" pool="" page="" outcome="" quota_cost="" exact_success_cost="" decision=""
+	local invalidate_state=0
 	local success_quota_cost="${AIDEVOPS_GH_QUOTA_COST_ON_SUCCESS:-}"
 	frame_total=$(printf '%s\n' "$parsed" | awk -F '\t' '$1 == "frame" { count++ } END { print count + 0 }')
 	if [[ "$command_rc" -eq 0 && "$frame_total" -eq 1 ]]; then
 		exact_success_cost=$(_ghqa_exact_success_cost "$original_path" "${@:2}" 2>/dev/null || true)
 	fi
-	while IFS=$'\t' read -r kind frame_index status_count status resource used remaining reset elapsed; do
+	while IFS=$'\t' read -r kind frame_index status_count status resource used remaining reset elapsed response_cost; do
 		[[ "$kind" == frame ]] || continue
 		path=$(_ghqa_path_for_resource "$original_path" "$resource")
 		pool=$(_ghqa_pool_for_resource "$resource")
@@ -580,8 +623,11 @@ _ghqa_write_complete_frames() {
 			quota_cost="$success_quota_cost"
 		elif [[ -n "$exact_success_cost" ]]; then
 			quota_cost="$exact_success_cost"
+		elif [[ "$resource" == graphql && "$response_cost" =~ ^[0-9]+$ ]]; then
+			quota_cost="$response_cost"
+			invalidate_state=1
 		else
-			quota_cost=$(_ghqa_response_cost "$state_file" "$resource" "$used" "$reset" 2>/dev/null || true)
+			quota_cost=$(_ghqa_response_cost "$state_file" "$resource" "$used" "$reset" "$status" 2>/dev/null || true)
 		fi
 		[[ -n "$quota_cost" ]] || quota_cost=x
 		# Always advance the observed counter state, including operation-owned
@@ -592,6 +638,7 @@ _ghqa_write_complete_frames() {
 			"$path" "$page" "$outcome" "$status" "$elapsed" "$quota_cost" \
 			"$pool" "$decision" "$remaining" >>"$result_file"
 	done <<<"$parsed"
+	[[ "$invalidate_state" -eq 0 ]] || rm -f -- "$state_file" 2>/dev/null || true
 	return 0
 }
 
@@ -649,6 +696,11 @@ _ghqa_capture_locked() {
 	if [[ "$version" == v1 && "$frame_count" =~ ^[1-9][0-9]*$ ]] \
 		&& _ghqa_capture_frames_valid "$parsed" "$frame_count"; then
 		_ghqa_write_complete_frames "$result_file" "$state_file" "$path" "$page" "$rc" "$parsed" "$@"
+	elif [[ "$version" == v1 && "$frame_count" == 1 ]]; then
+		# One recognized request frame proves the attempt and caller-owned page,
+		# even when no complete response metadata arrived. Quota remains unknown.
+		_ghqa_write_fallback_attempt "$result_file" "$path" "$page" \
+			"$([[ "$rc" -eq 0 ]] && printf success || printf error)" "$elapsed_ms" ""
 	else
 		_ghqa_write_fallback_attempt "$result_file" "$path" 0 \
 			"$([[ "$rc" -eq 0 ]] && printf success || printf error)" "$elapsed_ms" ""

--- a/.agents/scripts/gh-quota-debug-filter.py
+++ b/.agents/scripts/gh-quota-debug-filter.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 import sys
 from pathlib import Path
@@ -20,6 +21,7 @@ RATE_HEADER = re.compile(
     rb"^< X-Ratelimit-(Resource|Used|Remaining|Reset):\s*([^\s]+)\s*$",
     re.IGNORECASE,
 )
+RATE_FIELDS = frozenset({"resource", "used", "remaining", "reset"})
 
 
 def _frame_ranges(lines: List[bytes]) -> List[Tuple[int, int]]:
@@ -51,22 +53,45 @@ def _duration_ms(frame: List[bytes]) -> Optional[int]:
     return None
 
 
-def _response_metadata(frame: List[bytes]) -> Tuple[int, Dict[str, str]]:
-    responses: List[Dict[str, str]] = []
+def _graphql_rate_cost(body: List[bytes]) -> Optional[int]:
+    try:
+        payload = json.loads(b"\n".join(body))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    data = payload.get("data")
+    rate_limit = data.get("rateLimit") if isinstance(data, dict) else None
+    cost = rate_limit.get("cost") if isinstance(rate_limit, dict) else None
+    if isinstance(cost, bool) or not isinstance(cost, int) or cost < 0:
+        return None
+    return cost
+
+
+def _response_metadata(
+    frame: List[bytes],
+) -> Tuple[int, Dict[str, str], Optional[int]]:
+    responses: List[Tuple[Dict[str, str], List[bytes]]] = []
     current: Optional[Dict[str, str]] = None
+    current_body: Optional[List[bytes]] = None
     in_headers = False
     for line in frame:
         stripped = line.rstrip(b"\r\n")
         status_match = RESPONSE_STATUS.match(stripped)
         if status_match:
             current = {"status": status_match.group(1).decode("ascii")}
-            responses.append(current)
+            current_body = []
+            responses.append((current, current_body))
             in_headers = True
             continue
         if in_headers and stripped == b"":
             in_headers = False
             continue
-        if not in_headers or current is None:
+        if current is not None and current_body is not None and not in_headers:
+            if not REQUEST_END.match(stripped):
+                current_body.append(stripped)
+            continue
+        if current is None:
             continue
         header_match = RATE_HEADER.match(stripped)
         if not header_match:
@@ -74,7 +99,13 @@ def _response_metadata(frame: List[bytes]) -> Tuple[int, Dict[str, str]]:
         name = header_match.group(1).decode("ascii").lower()
         value = header_match.group(2).decode("ascii", errors="ignore")
         current[name] = value
-    return len(responses), responses[-1] if responses else {}
+    rate_responses = [
+        response for response in responses if RATE_FIELDS <= response[0].keys()
+    ]
+    if not rate_responses:
+        return 0, {}, None
+    headers, body = rate_responses[-1]
+    return len(rate_responses), headers, _graphql_rate_cost(body)
 
 
 def _write_sanitized_stderr(
@@ -112,7 +143,7 @@ def main() -> int:
     print(f"v1\t{len(ranges)}")
     for frame_index, (start, end) in enumerate(ranges, start=1):
         frame = lines[start:end]
-        status_count, response = _response_metadata(frame)
+        status_count, response, response_cost = _response_metadata(frame)
         duration = _duration_ms(frame)
         values = [
             "frame",
@@ -124,6 +155,7 @@ def main() -> int:
             response.get("remaining", ""),
             response.get("reset", ""),
             "" if duration is None else str(duration),
+            "" if response_cost is None else str(response_cost),
         ]
         print("\t".join(values))
     return 0

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -131,12 +131,22 @@ fi
 if [[ "${GH_DEBUG:-}" == "api" && "${STUB_GH_DEBUG_RESPONSE:-0}" == "1" ]]; then
 	printf '* Request at 2026-07-24 00:00:00 +0000 UTC\n' >&2
 	printf '> Authorization: token private-fixture-token\n\n' >&2
-	printf '< HTTP/2.0 %s Fixture\n' "${STUB_GH_DEBUG_STATUS:-200}" >&2
-	printf '< X-Ratelimit-Resource: %s\n' "${STUB_GH_DEBUG_RESOURCE:-graphql}" >&2
-	printf '< X-Ratelimit-Used: %s\n' "${STUB_GH_DEBUG_USED:-201}" >&2
-	printf '< X-Ratelimit-Remaining: %s\n' "${STUB_GH_DEBUG_REMAINING:-4799}" >&2
-	printf '< X-Ratelimit-Reset: %s\n\n' "${STUB_GH_DEBUG_RESET:-2000}" >&2
-	printf '{"private":"response-body-fixture"}\n' >&2
+	if [[ "${STUB_GH_DEBUG_REQUEST_ONLY:-0}" != "1" ]]; then
+		printf '< HTTP/2.0 %s Fixture\n' "${STUB_GH_DEBUG_STATUS:-200}" >&2
+		printf '< X-Ratelimit-Resource: %s\n' "${STUB_GH_DEBUG_RESOURCE:-graphql}" >&2
+		printf '< X-Ratelimit-Used: %s\n' "${STUB_GH_DEBUG_USED:-201}" >&2
+		printf '< X-Ratelimit-Remaining: %s\n' "${STUB_GH_DEBUG_REMAINING:-4799}" >&2
+		printf '< X-Ratelimit-Reset: %s\n\n' "${STUB_GH_DEBUG_RESET:-2000}" >&2
+		if [[ -n "${STUB_GH_DEBUG_BODY:-}" ]]; then
+			printf '%s\n' "$STUB_GH_DEBUG_BODY" >&2
+		else
+			printf '{"private":"response-body-fixture"}\n' >&2
+		fi
+		if [[ "${STUB_GH_DEBUG_TRAILING_RESPONSE:-0}" == "1" ]]; then
+			printf '< HTTP/2.0 200 Redirected\n\n' >&2
+			printf '{"private":"redirected-response-fixture"}\n' >&2
+		fi
+	fi
 	printf '* Request took 12.5ms\n' >&2
 	[[ -z "${STUB_GH_DIAGNOSTIC:-}" ]] || printf '%s\n' "$STUB_GH_DIAGNOSTIC" >&2
 elif [[ -n "${STUB_GH_UNFRAMED_PRIVATE_STDERR:-}" ]]; then
@@ -1158,6 +1168,77 @@ else
 	_fail "failed REST exact quota capture" "log: $(cat "$failed_log" 2>/dev/null || true)"
 fi
 
+zero_cost_log="$TMP/exact-zero-cost-rest.log"
+zero_cost_state="$TMP/exact-zero-cost-rest-state"
+: >"$zero_cost_log"
+if GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$zero_cost_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$zero_cost_log" STUB_GH_DEBUG_RESPONSE=1 STUB_GH_EXIT_CODE=1 \
+	STUB_BOOTSTRAP_CORE_USED=100 STUB_GH_DEBUG_RESOURCE=core \
+	STUB_GH_DEBUG_STATUS=403 STUB_GH_DEBUG_USED=100 STUB_GH_DEBUG_REMAINING=4900 \
+	STUB_GH_DEBUG_RESET=2000 "$SHIM_RUN" api /repos/owner/repo >/dev/null 2>/dev/null; then
+	_fail "zero-cost REST response status" "stub failure unexpectedly succeeded"
+fi
+if [[ "$(_read_attempt_quota "$zero_cost_log")" == "0" \
+	&& "$(_read_last_attempt_field "$zero_cost_log" 14)" == "error" \
+	&& "$(_read_last_attempt_field "$zero_cost_log" 15)" == "403" ]]; then
+	_pass "counter-proven zero-cost REST failure records exact zero quota"
+else
+	_fail "zero-cost REST response attribution" "log: $(cat "$zero_cost_log" 2>/dev/null || true)"
+fi
+
+successful_zero_log="$TMP/exact-successful-zero-delta.log"
+successful_zero_state="$TMP/exact-successful-zero-delta-state"
+: >"$successful_zero_log"
+GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$successful_zero_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$successful_zero_log" STUB_GH_DEBUG_RESPONSE=1 \
+	STUB_BOOTSTRAP_GRAPHQL_USED=100 STUB_GH_DEBUG_RESOURCE=graphql \
+	STUB_GH_DEBUG_STATUS=200 STUB_GH_DEBUG_USED=100 STUB_GH_DEBUG_REMAINING=4900 \
+	STUB_GH_DEBUG_RESET=2000 "$SHIM_RUN" pr view 123 --repo owner/repo >/dev/null 2>/dev/null
+if [[ "$(_read_attempt_quota "$successful_zero_log")" == "unknown" \
+	&& "$(_read_last_attempt_field "$successful_zero_log" 15)" == "200" ]]; then
+	_pass "successful zero-delta response remains unknown instead of shifting quota cost"
+else
+	_fail "successful zero-delta fail-closed behavior" "log: $(cat "$successful_zero_log" 2>/dev/null || true)"
+fi
+
+redirect_log="$TMP/exact-redirect-rest.log"
+redirect_state="$TMP/exact-redirect-rest-state"
+: >"$redirect_log"
+GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$redirect_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$redirect_log" STUB_GH_DEBUG_RESPONSE=1 \
+	STUB_GH_DEBUG_TRAILING_RESPONSE=1 STUB_BOOTSTRAP_CORE_USED=100 \
+	STUB_GH_DEBUG_RESOURCE=core STUB_GH_DEBUG_STATUS=302 STUB_GH_DEBUG_USED=101 \
+	STUB_GH_DEBUG_REMAINING=4899 STUB_GH_DEBUG_RESET=2000 \
+	"$SHIM_RUN" api /repos/owner/repo/actions/jobs/1/logs >/dev/null 2>/dev/null
+if [[ "$(_read_attempt_quota "$redirect_log")" == "1" \
+	&& "$(_read_last_attempt_field "$redirect_log" 12)" == "1" \
+	&& "$(_read_last_attempt_field "$redirect_log" 15)" == "302" ]]; then
+	_pass "redirect frames select the single complete GitHub quota response"
+else
+	_fail "redirect response attribution" "log: $(cat "$redirect_log" 2>/dev/null || true)"
+fi
+
+incomplete_log="$TMP/exact-incomplete-rest.log"
+incomplete_state="$TMP/exact-incomplete-rest-state"
+: >"$incomplete_log"
+if GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$incomplete_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$incomplete_log" STUB_GH_DEBUG_RESPONSE=1 \
+	STUB_GH_DEBUG_REQUEST_ONLY=1 STUB_GH_EXIT_CODE=1 \
+	"$SHIM_RUN" api /repos/owner/repo >/dev/null 2>/dev/null; then
+	_fail "incomplete REST response status" "stub failure unexpectedly succeeded"
+fi
+if [[ "$(_read_attempt_quota "$incomplete_log")" == "unknown" \
+	&& "$(_read_last_attempt_field "$incomplete_log" 12)" == "1" \
+	&& "$(_read_last_attempt_field "$incomplete_log" 14)" == "error" ]]; then
+	_pass "one incomplete request frame preserves exact caller-owned page"
+else
+	_fail "incomplete request page attribution" "log: $(cat "$incomplete_log" 2>/dev/null || true)"
+fi
+
 gap_log="$TMP/exact-counter-gap.log"
 gap_state="$TMP/exact-counter-gap-state"
 : >"$gap_log"
@@ -1222,9 +1303,11 @@ echo ""
 echo "Test 24: response-metered GraphQL quota attribution"
 response_cost_log="$TMP/response-cost-graphql.log"
 response_cost_out="$TMP/response-cost-graphql.out"
+response_cost_state="$TMP/response-cost-graphql-state"
 : >"$response_cost_log"
-STUB_GRAPHQL_RESPONSE_JSON='{"data":{"rateLimit":{"cost":2},"viewer":{"login":"fixture"}}}' \
-	AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 AIDEVOPS_TEMP_DIR="$exact_temp" \
+GH_TOKEN=fixture-token STUB_GRAPHQL_RESPONSE_JSON='{"data":{"rateLimit":{"cost":2},"viewer":{"login":"fixture"}}}' \
+	AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$response_cost_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
 	AIDEVOPS_GH_API_LOG="$response_cost_log" "$SHIM_RUN" api graphql \
 	-f 'query={viewer{login} rateLimit{cost}}' >"$response_cost_out"
 if [[ "$(_read_attempt_quota "$response_cost_log")" == "2" \
@@ -1235,16 +1318,72 @@ else
 	_fail "response-metered GraphQL attribution" "log: $(cat "$response_cost_log" 2>/dev/null || true) output: $(cat "$response_cost_out" 2>/dev/null || true)"
 fi
 
-response_missing_log="$TMP/response-cost-missing.log"
-: >"$response_missing_log"
-STUB_GRAPHQL_RESPONSE_JSON='{"data":{"viewer":{"login":"fixture"}}}' \
-	AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 AIDEVOPS_TEMP_DIR="$exact_temp" \
-	AIDEVOPS_GH_API_LOG="$response_missing_log" "$SHIM_RUN" api graphql \
-	-f 'query={viewer{login}}' >/dev/null
-if [[ "$(_read_attempt_quota "$response_missing_log")" == "unknown" ]]; then
-	_pass "missing GraphQL response cost remains unknown"
+response_followup_log="$TMP/response-cost-followup.log"
+: >"$response_followup_log"
+GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$response_cost_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$response_followup_log" STUB_GH_DEBUG_RESPONSE=1 \
+	STUB_BOOTSTRAP_GRAPHQL_USED=300 STUB_GH_DEBUG_RESOURCE=graphql \
+	STUB_GH_DEBUG_USED=301 STUB_GH_DEBUG_REMAINING=4699 STUB_GH_DEBUG_RESET=2000 \
+	"$SHIM_RUN" pr view 123 --repo owner/repo >/dev/null 2>/dev/null
+if [[ "$(_read_attempt_quota "$response_followup_log")" == "1" ]]; then
+	_pass "response-metered GraphQL invalidates cumulative state before exact follow-up"
 else
-	_fail "missing response-cost fail-closed behavior" "log: $(cat "$response_missing_log" 2>/dev/null || true)"
+	_fail "response-metered state invalidation" "log: $(cat "$response_followup_log" 2>/dev/null || true)"
+fi
+
+transformed_cost_log="$TMP/response-cost-transformed.log"
+transformed_cost_state="$TMP/response-cost-transformed-state"
+: >"$transformed_cost_log"
+GH_TOKEN=fixture-token STUB_GRAPHQL_RESPONSE_JSON='{"data":{"rateLimit":{"cost":1}}}' \
+	AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$transformed_cost_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$transformed_cost_log" STUB_GH_DEBUG_RESPONSE=1 \
+	STUB_GH_DEBUG_BODY='{"data":{"rateLimit":{"cost":1}}}' \
+	STUB_BOOTSTRAP_GRAPHQL_USED=200 STUB_GH_DEBUG_RESOURCE=graphql \
+	STUB_GH_DEBUG_USED=200 STUB_GH_DEBUG_REMAINING=4800 STUB_GH_DEBUG_RESET=2000 \
+	"$SHIM_RUN" api graphql -f 'query={rateLimit{cost}}' --jq '.data.rateLimit.cost' >/dev/null 2>/dev/null
+if [[ "$(_read_attempt_quota "$transformed_cost_log")" == "1" \
+	&& "$(_read_last_attempt_field "$transformed_cost_log" 6)" != "graphql-response-metered" ]]; then
+	_pass "output-transformed GraphQL queries use response-owned exact transport cost"
+else
+	_fail "transformed GraphQL response-meter guard" "log: $(cat "$transformed_cost_log" 2>/dev/null || true)"
+fi
+
+response_missing_log="$TMP/response-cost-missing.log"
+response_missing_out="$TMP/response-cost-missing.out"
+response_missing_state="$TMP/response-cost-missing-state"
+: >"$response_missing_log"
+GH_TOKEN=fixture-token STUB_GRAPHQL_RESPONSE_JSON='{"data":{"viewer":{"login":"fixture"}}}' \
+	AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$response_missing_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$response_missing_log" STUB_GH_DEBUG_RESPONSE=1 \
+	STUB_BOOTSTRAP_GRAPHQL_USED=200 STUB_GH_DEBUG_RESOURCE=graphql \
+	STUB_GH_DEBUG_USED=201 STUB_GH_DEBUG_REMAINING=4799 STUB_GH_DEBUG_RESET=2000 \
+	"$SHIM_RUN" api graphql -f 'query={viewer{login}}' >"$response_missing_out" 2>/dev/null
+if [[ "$(_read_attempt_quota "$response_missing_log")" == "1" \
+	&& "$(_read_last_attempt_field "$response_missing_log" 6)" != "graphql-response-metered" \
+	&& "$(jq -r '.data.viewer.login' "$response_missing_out")" == "fixture" ]]; then
+	_pass "GraphQL queries without rateLimit.cost use exact transport capture"
+else
+	_fail "missing response-cost transport fallback" "log: $(cat "$response_missing_log" 2>/dev/null || true) output: $(cat "$response_missing_out" 2>/dev/null || true)"
+fi
+
+native_meter_log="$TMP/response-cost-native-command.log"
+native_meter_state="$TMP/response-cost-native-command-state"
+: >"$native_meter_log"
+GH_TOKEN=fixture-token AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+	AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 AIDEVOPS_GH_QUOTA_STATE_DIR="$native_meter_state" \
+	AIDEVOPS_TEMP_DIR="$exact_temp" AIDEVOPS_GH_API_LOG="$native_meter_log" \
+	STUB_GH_DEBUG_RESPONSE=1 STUB_BOOTSTRAP_GRAPHQL_USED=200 \
+	STUB_GH_DEBUG_RESOURCE=graphql STUB_GH_DEBUG_USED=201 \
+	STUB_GH_DEBUG_REMAINING=4799 STUB_GH_DEBUG_RESET=2000 \
+	"$SHIM_RUN" pr view 123 --repo owner/repo >/dev/null 2>/dev/null
+if [[ "$(_read_attempt_quota "$native_meter_log")" == "1" \
+	&& "$(_read_last_attempt_field "$native_meter_log" 6)" != "graphql-response-metered" ]]; then
+	_pass "global response-meter flag cannot intercept native GraphQL commands"
+else
+	_fail "native GraphQL response-meter guard" "log: $(cat "$native_meter_log" 2>/dev/null || true)"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Restrict GraphQL response metering to eligible direct queries, preserve response-owned cost through transformed output, serialize quota state, and retain exact page evidence. For #27777.

## Files Changed

.agents/scripts/gh, .agents/scripts/gh-quota-attribution-lib.sh, .agents/scripts/gh-quota-debug-filter.py, .agents/scripts/tests/test-gh-shim.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — 98 gh-shim assertions; 202 instrumentation assertions; ShellCheck, bash -n, Python compile, secret scan, local quality gates, and a zero-unknown live GraphQL attribution smoke.

Resolves #28816


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.190 plugin for [OpenCode](https://opencode.ai) v1.18.8 with gpt-5.5 spent 11d 14h and 41,101,604 tokens on this with the user in an interactive session.