### PR TITLE
GH#28820: use high reasoning for Sol thinking tier

### DIFF
--- a/.agents/configs/aidevops.defaults.jsonc
+++ b/.agents/configs/aidevops.defaults.jsonc
@@ -243,7 +243,7 @@
       },
       "thinking": {
         "models": ["openai/gpt-5.6-sol", "anthropic/claude-opus-4-6"],
-        "reasoning": { "openai": "max" }
+        "reasoning": { "openai": "high" }
       }
     },
 

--- a/.agents/configs/model-routing-table.json
+++ b/.agents/configs/model-routing-table.json
@@ -15,7 +15,7 @@
     },
     "thinking": {
       "models": ["openai/gpt-5.6-sol", "anthropic/claude-opus-4-6"],
-      "reasoning": { "openai": "max" }
+      "reasoning": { "openai": "high" }
     }
   },
 

--- a/.agents/scripts/setup/modules/migrations.sh
+++ b/.agents/scripts/setup/modules/migrations.sh
@@ -1692,7 +1692,7 @@ migrate_custom_model_routing_reasoning_defaults() {
 		.tiers.simple.reasoning.openai = "medium" |
 		.tiers.thinking = (.tiers.thinking // {}) |
 		.tiers.thinking.reasoning = (.tiers.thinking.reasoning // {}) |
-		.tiers.thinking.reasoning.openai = "max"
+		.tiers.thinking.reasoning.openai = "high"
 	' "$custom_table" >"$temp_file"; then
 		print_warning "Failed to update custom model routing table structure in $custom_table; t18137 migration will retry"
 		rm -f "$temp_file"

--- a/.agents/scripts/tests/test-headless-runtime-variant.sh
+++ b/.agents/scripts/tests/test-headless-runtime-variant.sh
@@ -61,11 +61,11 @@ assert_equals "medium" "$actual" "GPT-5.6 Terra simple worker uses medium routed
 
 with_clean_variant_env
 actual=$(resolve_headless_variant "worker" "thinking" "openai/gpt-5.6-sol")
-assert_equals "max" "$actual" "GPT-5.6 Sol thinking worker uses max routed effort" || true
+assert_equals "high" "$actual" "GPT-5.6 Sol thinking worker uses high routed effort" || true
 
 with_clean_variant_env
 actual=$(resolve_headless_variant "worker" "thinking" "openai/gpt-5.6-sol-fast")
-assert_equals "max" "$actual" "GPT-5.6 Sol Fast thinking worker uses max provider mapping" || true
+assert_equals "high" "$actual" "GPT-5.6 Sol Fast thinking worker uses high provider mapping" || true
 
 with_clean_variant_env
 actual=$(resolve_headless_variant "worker" "standard" "openai/gpt-5.6-sol")
@@ -77,13 +77,18 @@ actual=$(resolve_headless_variant "worker" "thinking" "openai/gpt-5.6-sol")
 assert_equals "high" "$actual" "explicit GPT-5.6 Sol high variant remains stable" || true
 
 with_clean_variant_env
+AIDEVOPS_HEADLESS_VARIANT_THINKING="max"
+actual=$(resolve_headless_variant "worker" "thinking" "openai/gpt-5.6-sol")
+assert_equals "max" "$actual" "explicit GPT-5.6 Sol max opt-in remains available" || true
+
+with_clean_variant_env
 AIDEVOPS_HEADLESS_VARIANT_THINKING="xhigh"
 actual=$(resolve_headless_variant "worker" "thinking" "openai/gpt-5.6-sol")
 assert_equals "xhigh" "$actual" "explicit GPT-5.6 Sol xhigh opt-in remains available" || true
 
 with_clean_variant_env
 actual=$(resolve_headless_variant "pulse" "thinking" "openai/gpt-5.6-sol")
-assert_equals "max" "$actual" "pulse thinking tier uses the same max runtime mapping" || true
+assert_equals "high" "$actual" "pulse thinking tier uses the same high runtime mapping" || true
 
 with_clean_variant_env
 

--- a/.agents/scripts/tests/test-model-routing-reasoning-migration.sh
+++ b/.agents/scripts/tests/test-model-routing-reasoning-migration.sh
@@ -86,7 +86,7 @@ cat >"$custom_table" <<'JSON'
 JSON
 migrate_custom_model_routing_reasoning_defaults
 assert_eq "medium" "$(jq -r '.tiers.simple.reasoning.openai' "$custom_table")" "simple custom reasoning migrates to medium" || true
-assert_eq "max" "$(jq -r '.tiers.thinking.reasoning.openai' "$custom_table")" "thinking custom reasoning migrates to max" || true
+assert_eq "high" "$(jq -r '.tiers.thinking.reasoning.openai' "$custom_table")" "thinking custom reasoning migrates to high" || true
 assert_eq "custom/simple" "$(jq -r '.tiers.simple.models[0]' "$custom_table")" "custom model order is preserved" || true
 assert_eq "keep" "$(jq -r '.tiers.simple.reasoning.other' "$custom_table")" "unrelated reasoning settings are preserved" || true
 assert_eq "preserve" "$(jq -r '.user_setting' "$custom_table")" "unrelated custom configuration is preserved" || true

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -81,7 +81,8 @@ is always denied because secrets must flow through secret tooling, not prompts.
 - **Workers**: Round-robin across canonical `simple`, `standard`, or `thinking` routes after allowlist filtering and auth checks.
 - **Local switch**: Set `AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=openai` to force both pulse and workers onto the default OpenAI fallbacks. If you want OpenAI primary but Anthropic fallback, reorder `custom/configs/model-routing-table.json` and omit the allowlist.
 - **Current default mapping**: The active routing table currently maps `simple` to OpenAI Terra then Anthropic Haiku, `standard` to OpenAI Sol then Z.AI GLM then Anthropic Sonnet, and `thinking` to OpenAI Sol then Anthropic Opus. Availability and provider policy decide the exact model at execution time.
-- **Reasoning mapping**: The same routing table currently maps OpenAI `simple`, `standard`, and `thinking` to `medium`, `medium`, and `max`. Other providers use their provider/runtime defaults unless configured explicitly.
+- **Reasoning mapping**: The same routing table currently maps OpenAI `simple`, `standard`, and `thinking` to `medium`, `medium`, and `high`. Other providers use their provider/runtime defaults unless configured explicitly.
+- **Thinking-tier balance**: `high` is the shared Sol default for complex work. Explicit `max` and `xhigh` overrides remain available when a task justifies higher effort.
 - **OpenAI tier rationale**: Terra costs $2.50/M input and $15/M output and is competitive with GPT-5.5, making it the conservative choice for prescriptive/simple work. Sol costs $5/M input and $30/M output and is OpenAI's recommended flagship coding model.
 - **OpenAI pro caveat**: `openai/gpt-5.6-sol-pro` passed a live OpenCode ChatGPT OAuth smoke test on 2026-07-10, but OpenAI publishes neither an API price nor comparative Sol Pro benchmarks. It remains excluded from automatic workers pending repository-specific completion-rate evidence. Historical `gpt-5.5-pro` and older `*-pro`/`o3-pro` IDs remain excluded.
 - **GPT-5.5 standard workers**: aidevops omits env-derived standard-tier variants so OpenCode sends no explicit thinking override. Explicit CLI `--variant` still wins.
@@ -115,7 +116,8 @@ Example hard pin:
 export AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST="openai"
 ```
 
-Example reasoning effort override:
+Example reasoning effort override, including an explicit opt-in above the shared
+thinking default:
 
 ```bash
 export AIDEVOPS_HEADLESS_VARIANT_STANDARD="high"


### PR DESCRIPTION
## Summary

- Change the shared OpenAI `thinking` tier from `gpt-5.6-sol` at `max` reasoning to `high`.
- Keep `simple` and `standard` at `medium`, with model ordering unchanged.
- Preserve explicit `max` and `xhigh` overrides for tasks that need higher effort.

## Implementation

- `.agents/configs/model-routing-table.json` and `.agents/configs/aidevops.defaults.jsonc`: align canonical and shipped defaults on `high`.
- `.agents/scripts/setup/modules/migrations.sh`: use `high` for installations whose existing one-time reasoning migration has not yet run; completed migration markers still protect later user edits.
- `.agents/tools/context/model-routing.md`: document the new default and higher-effort opt-ins.
- Routing and migration tests cover worker, Pulse, Sol Fast, custom-table migration, and explicit overrides.

## Verification

- `bash .agents/scripts/tests/test-headless-runtime-variant.sh` (12/12 passed)
- `bash .agents/scripts/tests/test-model-routing-reasoning-migration.sh` (18/18 passed)
- `bash .agents/scripts/tests/test-canonical-tier-routing.sh` (10/10 passed)
- `.agents/scripts/linters-local.sh` (passed)

## Risk

Low. The intended behavior change reduces only the implicit thinking-tier effort. Model/provider order is unchanged, and users can retain or select `max`/`xhigh` through explicit overrides.

Resolves #28820

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.190 plugin for [OpenCode](https://opencode.ai) v1.18.8 with gpt-5.6-sol spent 2h 8m and 1,393,774 tokens on this with the user in an interactive session.