### PR TITLE
GH#28828: Make canonical recovery examples parseable by OpenCode policy

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
@@ -511,6 +511,27 @@ test("rejects ambiguous shell syntax before execution", () => {
   );
 });
 
+test("authorizes documented canonical recovery commands without dynamic expansion", () => {
+  assert.doesNotThrow(() => checkCommandSafetyGate(
+    "canonical-recovery-helper.sh fast-forward-current --repo /path/to/canonical-checkout --branch develop --issue 123 --confirm FAST_FORWARD_CANONICAL_BRANCH",
+    scriptsDir,
+    process.cwd(),
+  ));
+  assert.doesNotThrow(() => checkCommandSafetyGate(
+    "canonical-recovery-helper.sh sync-mirror --repo /path/to/canonical-checkout --issue 123 --confirm SYNCHRONIZE_CANONICAL_MIRROR",
+    scriptsDir,
+    process.cwd(),
+  ));
+  assert.throws(
+    () => checkCommandSafetyGate(
+      "${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/canonical-recovery-helper.sh sync-mirror --repo /path/to/canonical-checkout --issue 123 --confirm SYNCHRONIZE_CANONICAL_MIRROR",
+      scriptsDir,
+      process.cwd(),
+    ),
+    /command\.parse-error.*dynamic shell expansion/,
+  );
+});
+
 test("enforces network policy in OpenCode worker tool adapter", () => {
   assert.throws(
     () => checkCommandSafetyGate(

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -44,7 +44,7 @@ Inside an existing linked worktree, refresh and rebase before editing. From the 
 **Canonical synchronization after a merge (explicit authorization only):** direct `git pull`, `fetch`, reset, clean, and merge remain blocked in canonical checkouts. A full-loop request for a maintained non-aidevops repository authorizes synchronization of the merged PR base; a standalone request to update a canonical checkout has the same narrow scope. For a clean, non-diverged mirror, use:
 
 ```bash
-${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/canonical-recovery-helper.sh fast-forward-current \
+canonical-recovery-helper.sh fast-forward-current \
   --repo /path/to/canonical-checkout --branch develop --issue 123 \
   --confirm FAST_FORWARD_CANONICAL_BRANCH
 ```
@@ -58,7 +58,7 @@ If unexpected tracked, staged, untracked, or local-commit state exists, use the
 lossless route instead of waiting, stashing, resetting, or cleaning:
 
 ```bash
-${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/canonical-recovery-helper.sh sync-mirror \
+canonical-recovery-helper.sh sync-mirror \
   --repo /path/to/canonical-checkout --issue 123 \
   --confirm SYNCHRONIZE_CANONICAL_MIRROR
 ```

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -49,6 +49,9 @@ canonical-recovery-helper.sh fast-forward-current \
   --confirm FAST_FORWARD_CANONICAL_BRANCH
 ```
 
+The runtime adds the deployed framework scripts directory to `PATH`; invoking
+the helper by name keeps the command portable and parseable by command policy.
+
 The asserted branch must equal the branch resolved from registered config,
 committed project config, or `origin/HEAD`. The helper refuses arbitrary branch
 names, linked/detached checkouts, divergence, concurrent recovery, stale refs,


### PR DESCRIPTION
## Summary

- invoke `canonical-recovery-helper.sh` by its runtime-provisioned PATH name in both canonical synchronization examples
- cover both documented operations through OpenCode's production command-policy hook
- retain fail-closed rejection of dynamic executable expansion

## Verification

- `node --test .agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs`
- `.agents/scripts/tests/test-command-policy-helper.sh`
- `.agents/scripts/tests/test-canonical-recovery-helper.sh`
- `.agents/scripts/linters-local.sh --changed`

Resolves #28828

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.192 plugin for [OpenCode](https://opencode.ai) v1.18.8 with gpt-5.6-sol spent 8m and 99,852 tokens on this as a headless worker.