### PR TITLE
GH#28822: Preserve Git-locked worktrees during detached age cleanup

### DIFF
--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -51,6 +51,8 @@ _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED=1
 _WTAR_REMOVED="removed"
 _WTAR_SKIPPED="skipped"
 _WTAR_FIXTURE_REMOVED="fixture-removed"
+_WTAR_MODE_SKIPPED="skipped"
+_WTAR_BOOL_TRUE="true"
 _WT_CWD_VISIBILITY_COMPLETE="complete"
 _WT_CWD_VISIBILITY_DEGRADED="degraded"
 _WT_CWD_VISIBILITY_UNUSABLE="unusable"
@@ -58,6 +60,28 @@ _WT_CWD_CAPTURE_DEGRADED_RC=2
 _WT_CWD_MATCH_UNUSABLE_RC=3
 _WT_CWD_REASON_DEGRADED="cwd-visibility-degraded"
 _WT_CWD_REASON_UNUSABLE="cwd-visibility-unusable"
+_WT_GIT_STATE_CLEAR="clear"
+_WT_GIT_STATE_LOCKED="locked"
+_WT_GIT_STATE_NOT_WORKTREE="not-worktree"
+_WT_GIT_STATE_UNREADABLE="unreadable"
+_WT_GIT_REASON_LOCKED="git-worktree-locked"
+_WT_GIT_REASON_UNREADABLE="git-metadata-unreadable"
+_WT_GIT_REASON_IDENTITY_CHANGED="git-worktree-identity-changed"
+_WT_GIT_REASON_REMOVE_FAILED="git-worktree-remove-failed"
+_WT_GIT_STATUS_FIELD_PREFIX="aidevops-git-status "
+_WT_RECOVERY_FORMAT="aidevops-worktree-recovery-v1"
+_WT_RECOVERY_DIR_NAME=".aidevops-worktree-recovery"
+_WT_RECOVERY_BRANCH_DETACHED="detached"
+WORKTREE_RECOVERABLE_ARCHIVE_PATH=""
+
+_WT_ID_REAL_GIT=""
+_WT_ID_SOURCE_REAL=""
+_WT_ID_SOURCE_INODE=""
+_WT_ID_ADMIN_REAL=""
+_WT_ID_ADMIN_INODE=""
+_WT_ID_COMMON_REAL=""
+_WT_ID_HEAD=""
+_WT_ID_BRANCH=""
 
 # =============================================================================
 # log_worktree_removal_event — write one structured log line per event
@@ -269,6 +293,482 @@ _worktree_has_process_cwd() {
 	esac
 }
 
+# A porcelain block is complete when it describes either one bare repository or
+# one linked worktree with exactly one HEAD and one branch/detached identity.
+_worktree_git_block_is_complete() {
+	local head_count="$1"
+	local branch_count="$2"
+	local detached_count="$3"
+	local bare_count="$4"
+
+	if [[ "$bare_count" -eq 1 ]]; then
+		[[ "$head_count" -eq 0 && "$branch_count" -eq 0 && "$detached_count" -eq 0 ]]
+		return $?
+	fi
+	[[ "$bare_count" -eq 0 && "$head_count" -eq 1 &&
+		$((branch_count + detached_count)) -eq 1 ]]
+	return $?
+}
+
+_worktree_git_head_payload_is_valid() {
+	local head_oid="$1"
+
+	[[ "${#head_oid}" -eq 40 || "${#head_oid}" -eq 64 ]] || return 1
+	case "$head_oid" in
+	*[!0-9a-fA-F]*) return 1 ;;
+	esac
+	return 0
+}
+
+_worktree_git_branch_payload_is_valid() {
+	local branch_ref="$1"
+	local branch_name=""
+	local component=""
+	local remaining=""
+
+	case "$branch_ref" in
+	refs/heads/*) ;;
+	*) return 1 ;;
+	esac
+	branch_name="${branch_ref#refs/heads/}"
+	[[ -n "$branch_name" ]] || return 1
+	case "$branch_name" in
+	*..* | *@\{* | /* | */ | *//* | *[[:space:]]* | *~* | *^* | *:* | *\?* | *\** | *\[* | *\\*) return 1 ;;
+	esac
+	remaining="$branch_name"
+	while :; do
+		component="${remaining%%/*}"
+		[[ -n "$component" && "$component" != .* && "$component" != *. &&
+			"$component" != *.lock ]] || return 1
+		[[ "$remaining" == */* ]] || break
+		remaining="${remaining#*/}"
+	done
+	return 0
+}
+
+_worktree_git_list_lock_state() {
+	local wt_path="$1"
+	local wt_path_real="$2"
+	local candidate_root="$3"
+	local field="" list_status="" listed_path=""
+	local parser_valid=1 in_candidate=0 in_block=0 status_seen=0
+	local candidate_seen=0 candidate_complete=0 candidate_locked=0
+	local head_count=0 branch_count=0 detached_count=0 bare_count=0
+
+	while IFS= read -r -d '' field; do
+		case "$field" in
+		"$_WT_GIT_STATUS_FIELD_PREFIX"*)
+			[[ "$status_seen" -eq 0 && "$in_block" -eq 0 ]] || parser_valid=0
+			list_status="${field#"$_WT_GIT_STATUS_FIELD_PREFIX"}"
+			status_seen=1
+			;;
+		worktree\ *)
+			[[ "$status_seen" -eq 0 && "$in_block" -eq 0 ]] || parser_valid=0
+			listed_path="${field#worktree }"
+			[[ -n "$listed_path" ]] || parser_valid=0
+			in_block=1 in_candidate=0
+			head_count=0 branch_count=0 detached_count=0 bare_count=0
+			if [[ "$listed_path" == "$candidate_root" || "$listed_path" == "$wt_path" ||
+				"$listed_path" == "$wt_path_real" ]]; then
+				[[ "$candidate_seen" -eq 0 ]] || parser_valid=0
+				in_candidate=1 candidate_seen=1
+			fi
+			;;
+		HEAD\ *)
+			head_count=$((head_count + 1))
+			[[ "$in_block" -eq 1 && "$status_seen" -eq 0 && "$head_count" -eq 1 ]] || parser_valid=0
+			_worktree_git_head_payload_is_valid "${field#HEAD }" || parser_valid=0
+			;;
+		branch\ *)
+			branch_count=$((branch_count + 1))
+			[[ "$in_block" -eq 1 && "$status_seen" -eq 0 && "$branch_count" -eq 1 ]] || parser_valid=0
+			_worktree_git_branch_payload_is_valid "${field#branch }" || parser_valid=0
+			;;
+		detached)
+			detached_count=$((detached_count + 1))
+			[[ "$in_block" -eq 1 && "$status_seen" -eq 0 && "$detached_count" -eq 1 ]] || parser_valid=0
+			;;
+		bare)
+			bare_count=$((bare_count + 1))
+			[[ "$in_block" -eq 1 && "$status_seen" -eq 0 && "$bare_count" -eq 1 ]] || parser_valid=0
+			;;
+		locked | locked\ *)
+			[[ "$in_block" -eq 1 && "$status_seen" -eq 0 ]] || parser_valid=0
+			[[ "$in_candidate" -eq 0 ]] || candidate_locked=1
+			;;
+		"")
+			if [[ "$status_seen" -eq 1 || "$in_block" -ne 1 ]]; then
+				parser_valid=0
+			elif _worktree_git_block_is_complete "$head_count" "$branch_count" "$detached_count" "$bare_count"; then
+				[[ "$in_candidate" -eq 0 ]] || candidate_complete=1
+			else
+				parser_valid=0
+			fi
+			in_block=0 in_candidate=0
+			;;
+		*) [[ "$in_block" -eq 1 && "$status_seen" -eq 0 ]] || parser_valid=0 ;;
+		esac
+	done < <(
+		git -C "$wt_path" worktree list --porcelain -z 2>/dev/null
+		printf '%s%s\0' "$_WT_GIT_STATUS_FIELD_PREFIX" "$?"
+	)
+
+	if [[ "$parser_valid" -ne 1 || "$status_seen" -ne 1 || "$in_block" -ne 0 ||
+		"$list_status" != "0" || "$candidate_seen" -ne 1 || "$candidate_complete" -ne 1 ]]; then
+		printf '%s\n' "$_WT_GIT_STATE_UNREADABLE"
+	elif [[ "$candidate_locked" -eq 1 ]]; then
+		printf '%s\n' "$_WT_GIT_STATE_LOCKED"
+	else
+		printf '%s\n' "$_WT_GIT_STATE_CLEAR"
+	fi
+	return 0
+}
+
+# Classify the candidate's exact Git worktree metadata block. Git worktree
+# locks are an explicit operator/session preservation boundary, so callers must
+# not infer "unlocked" from a failed query or an unregistered-looking result.
+# Args: $1=worktree path, $2=resolved worktree path
+_worktree_git_lock_state() {
+	local wt_path="$1"
+	local wt_path_real="$2"
+	local candidate_root=""
+
+	if [[ ! -e "$wt_path" && ! -L "$wt_path" ]]; then
+		printf '%s\n' "$_WT_GIT_STATE_NOT_WORKTREE"
+		return 0
+	fi
+	if [[ ! -d "$wt_path" || ! -r "$wt_path" || ! -x "$wt_path" ]]; then
+		printf '%s\n' "$_WT_GIT_STATE_UNREADABLE"
+		return 0
+	fi
+	if ! candidate_root=$(git -C "$wt_path" rev-parse --show-toplevel 2>/dev/null); then
+		if [[ -e "$wt_path/.git" || -L "$wt_path/.git" ]]; then
+			printf '%s\n' "$_WT_GIT_STATE_UNREADABLE"
+		else
+			printf '%s\n' "$_WT_GIT_STATE_NOT_WORKTREE"
+		fi
+		return 0
+	fi
+	if [[ "$candidate_root" != "$wt_path" && "$candidate_root" != "$wt_path_real" ]]; then
+		printf '%s\n' "$_WT_GIT_STATE_UNREADABLE"
+		return 0
+	fi
+	_worktree_git_list_lock_state "$wt_path" "$wt_path_real" "$candidate_root"
+	return 0
+}
+
+_worktree_git_common_dir() {
+	local real_git="$1"
+	local wt_path="$2"
+	local common_dir=""
+
+	common_dir=$("$real_git" -C "$wt_path" rev-parse --git-common-dir 2>/dev/null) || return 1
+	if [[ "$common_dir" != /* ]]; then
+		common_dir=$(cd "$wt_path/$common_dir" 2>/dev/null && pwd -P) || return 1
+	else
+		common_dir=$(cd "$common_dir" 2>/dev/null && pwd -P) || return 1
+	fi
+	printf '%s\n' "$common_dir"
+	return 0
+}
+
+# Resolve an existing path physically, or reconstruct a missing path from its
+# physical parent. The latter keeps Git's stored path comparable after a
+# recoverable move on systems where /var and /private/var alias each other.
+_worktree_physical_path() {
+	local wt_path="$1"
+	local clean_wt_path="$wt_path"
+	local parent_path=""
+	local parent_real=""
+	local path_basename=""
+
+	while [[ "$clean_wt_path" != "/" && "$clean_wt_path" == */ ]]; do
+		clean_wt_path="${clean_wt_path%/}"
+	done
+	if [[ -d "$clean_wt_path" ]]; then
+		(cd "$clean_wt_path" 2>/dev/null && pwd -P)
+		return $?
+	fi
+	[[ "$clean_wt_path" == /* && "$clean_wt_path" != "/" ]] || return 1
+	parent_path="${clean_wt_path%/*}"
+	path_basename="${clean_wt_path##*/}"
+	[[ -n "$parent_path" ]] || parent_path="/"
+	[[ -n "$path_basename" ]] || return 1
+	parent_real=$(cd "$parent_path" 2>/dev/null && pwd -P) || return 1
+	if [[ "$parent_real" == "/" ]]; then
+		printf '/%s\n' "$path_basename"
+	else
+		printf '%s/%s\n' "$parent_real" "$path_basename"
+	fi
+	return 0
+}
+
+_worktree_log_git_refusal() {
+	local wt_path="$1"
+	local caller="$2"
+	local git_state="$3"
+	local context="${4:-}"
+	local refusal_reason="$_WT_GIT_REASON_UNREADABLE"
+
+	if [[ "$git_state" == "$_WT_GIT_STATE_LOCKED" ]]; then
+		refusal_reason="$_WT_GIT_REASON_LOCKED"
+	elif [[ "$git_state" == "$_WT_GIT_STATE_CLEAR" ]]; then
+		refusal_reason="$_WT_GIT_REASON_REMOVE_FAILED"
+	fi
+	WORKTREE_REMOVAL_GUARD_REASON="$refusal_reason"
+	log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "$refusal_reason" "$_WTAR_MODE_SKIPPED" "$context"
+	return 0
+}
+
+_worktree_log_identity_refusal() {
+	local wt_path="$1"
+	local caller="$2"
+	local context="${3:-}"
+
+	WORKTREE_REMOVAL_GUARD_REASON="$_WT_GIT_REASON_IDENTITY_CHANGED"
+	log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" \
+		"$_WT_GIT_REASON_IDENTITY_CHANGED" "$_WTAR_MODE_SKIPPED" "$context"
+	return 0
+}
+
+_worktree_path_identity() {
+	local target_path="$1"
+	local platform=""
+
+	[[ -e "$target_path" && ! -L "$target_path" ]] || return 1
+	platform=$(uname -s 2>/dev/null) || return 1
+	case "$platform" in
+	Darwin) stat -f '%d:%i' "$target_path" 2>/dev/null || return 1 ;;
+	Linux) stat -c '%d:%i' -- "$target_path" 2>/dev/null || return 1 ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
+# Copy exactly once into a unique destination. In particular, do not retry into
+# a partially populated directory: cp changes semantics when the destination
+# already exists, which could make a partial archive look complete.
+_worktree_copy_directory_once() {
+	local source_path="$1"
+	local destination_path="$2"
+	local platform=""
+
+	[[ -d "$source_path" && ! -e "$destination_path" && ! -L "$destination_path" ]] || return 1
+	platform=$(uname -s 2>/dev/null) || return 1
+	case "$platform" in
+	Darwin) cp -ac "$source_path" "$destination_path" 2>/dev/null || return 1 ;;
+	Linux) cp -a --reflink=auto "$source_path" "$destination_path" 2>/dev/null || return 1 ;;
+	*) cp -Rp "$source_path" "$destination_path" 2>/dev/null || return 1 ;;
+	esac
+	return 0
+}
+
+_worktree_capture_git_identity() {
+	local wt_path="$1"
+	local candidate_root=""
+	local branch_status=0
+
+	_WT_ID_REAL_GIT=""
+	_WT_ID_SOURCE_REAL=""
+	_WT_ID_SOURCE_INODE=""
+	_WT_ID_ADMIN_REAL=""
+	_WT_ID_ADMIN_INODE=""
+	_WT_ID_COMMON_REAL=""
+	_WT_ID_HEAD=""
+	_WT_ID_BRANCH=""
+	[[ -d "$wt_path" && ! -L "$wt_path" ]] || return 1
+	_WT_ID_SOURCE_REAL=$(cd "$wt_path" 2>/dev/null && pwd -P) || return 1
+	_WT_ID_SOURCE_INODE=$(_worktree_path_identity "$wt_path") || return 1
+	_WT_ID_REAL_GIT=$(_worktree_cleanup_real_git) || return 1
+	candidate_root=$("$_WT_ID_REAL_GIT" -C "$wt_path" rev-parse --show-toplevel 2>/dev/null) || return 1
+	candidate_root=$(cd "$candidate_root" 2>/dev/null && pwd -P) || return 1
+	[[ "$candidate_root" == "$_WT_ID_SOURCE_REAL" ]] || return 1
+	_WT_ID_ADMIN_REAL=$("$_WT_ID_REAL_GIT" -C "$wt_path" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+	_WT_ID_ADMIN_REAL=$(cd "$_WT_ID_ADMIN_REAL" 2>/dev/null && pwd -P) || return 1
+	_WT_ID_ADMIN_INODE=$(_worktree_path_identity "$_WT_ID_ADMIN_REAL") || return 1
+	_WT_ID_COMMON_REAL=$(_worktree_git_common_dir "$_WT_ID_REAL_GIT" "$wt_path") || return 1
+	_WT_ID_HEAD=$("$_WT_ID_REAL_GIT" -C "$wt_path" rev-parse --verify HEAD 2>/dev/null) || return 1
+	_worktree_git_head_payload_is_valid "$_WT_ID_HEAD" || return 1
+	if _WT_ID_BRANCH=$("$_WT_ID_REAL_GIT" -C "$wt_path" symbolic-ref -q HEAD 2>/dev/null); then
+		_worktree_git_branch_payload_is_valid "$_WT_ID_BRANCH" || return 1
+	else
+		branch_status=$?
+		[[ "$branch_status" -eq 1 ]] || return 1
+		_WT_ID_BRANCH="$_WT_RECOVERY_BRANCH_DETACHED"
+	fi
+	case "$_WT_ID_SOURCE_REAL$_WT_ID_ADMIN_REAL$_WT_ID_COMMON_REAL" in
+	*$'\n'*) return 1 ;;
+	esac
+	return 0
+}
+
+_worktree_recovery_dir_for_archive() {
+	local archive_path="$1"
+	local archive_parent="${archive_path%/*}"
+
+	[[ -n "$archive_path" && "$archive_parent" != "$archive_path" ]] || return 1
+	printf '%s/%s\n' "$archive_parent" "$_WT_RECOVERY_DIR_NAME"
+	return 0
+}
+
+_worktree_write_recovery_identity() {
+	local recovery_dir="$1"
+
+	printf '%s\n' "$_WT_RECOVERY_FORMAT" >"${recovery_dir}/format" || return 1
+	printf '%s\n' "$_WT_ID_SOURCE_REAL" >"${recovery_dir}/source-real" || return 1
+	printf '%s\n' "$_WT_ID_SOURCE_INODE" >"${recovery_dir}/source-inode" || return 1
+	printf '%s\n' "$_WT_ID_ADMIN_REAL" >"${recovery_dir}/admin-real" || return 1
+	printf '%s\n' "$_WT_ID_ADMIN_INODE" >"${recovery_dir}/admin-inode" || return 1
+	printf '%s\n' "$_WT_ID_COMMON_REAL" >"${recovery_dir}/common-real" || return 1
+	printf '%s\n' "$_WT_ID_HEAD" >"${recovery_dir}/head" || return 1
+	printf '%s\n' "$_WT_ID_BRANCH" >"${recovery_dir}/branch" || return 1
+	return 0
+}
+
+_worktree_recovery_archive_is_valid() {
+	local archive_path="$1"
+	local recovery_dir=""
+	local recovery_admin=""
+	local recovery_admin_real=""
+	local format=""
+	local expected_head=""
+	local expected_branch=""
+	local actual_admin=""
+	local actual_head=""
+	local real_git=""
+
+	recovery_dir=$(_worktree_recovery_dir_for_archive "$archive_path") || return 1
+	recovery_admin="${recovery_dir}/admin"
+	[[ -d "$archive_path" && -f "$archive_path/.git" && ! -L "$archive_path/.git" ]] || return 1
+	[[ -d "$recovery_admin" && -f "$recovery_admin/HEAD" && -f "$recovery_admin/index" ]] || return 1
+	IFS= read -r format <"${recovery_dir}/format" || return 1
+	IFS= read -r expected_head <"${recovery_dir}/head" || return 1
+	IFS= read -r expected_branch <"${recovery_dir}/branch" || return 1
+	[[ "$format" == "$_WT_RECOVERY_FORMAT" ]] || return 1
+	_worktree_git_head_payload_is_valid "$expected_head" || return 1
+	if [[ "$expected_branch" != "$_WT_RECOVERY_BRANCH_DETACHED" ]]; then
+		_worktree_git_branch_payload_is_valid "$expected_branch" || return 1
+	fi
+	real_git=$(_worktree_cleanup_real_git) || return 1
+	recovery_admin_real=$(cd "$recovery_admin" 2>/dev/null && pwd -P) || return 1
+	actual_admin=$("$real_git" -C "$archive_path" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+	actual_admin=$(cd "$actual_admin" 2>/dev/null && pwd -P) || return 1
+	[[ "$actual_admin" == "$recovery_admin_real" ]] || return 1
+	actual_head=$("$real_git" -C "$archive_path" rev-parse --verify HEAD 2>/dev/null) || return 1
+	[[ "$actual_head" == "$expected_head" ]] || return 1
+	"$real_git" -C "$archive_path" status --porcelain=v1 -z --untracked-files=all >/dev/null 2>&1 || return 1
+	return 0
+}
+
+_worktree_archive_source_matches() {
+	local wt_path="$1"
+	local archive_path="$2"
+	local recovery_dir=""
+	local expected_source_real=""
+	local expected_source_inode=""
+	local expected_admin_real=""
+	local expected_admin_inode=""
+	local expected_common_real=""
+	local expected_head=""
+	local expected_branch=""
+
+	recovery_dir=$(_worktree_recovery_dir_for_archive "$archive_path") || return 1
+	IFS= read -r expected_source_real <"${recovery_dir}/source-real" || return 1
+	IFS= read -r expected_source_inode <"${recovery_dir}/source-inode" || return 1
+	IFS= read -r expected_admin_real <"${recovery_dir}/admin-real" || return 1
+	IFS= read -r expected_admin_inode <"${recovery_dir}/admin-inode" || return 1
+	IFS= read -r expected_common_real <"${recovery_dir}/common-real" || return 1
+	IFS= read -r expected_head <"${recovery_dir}/head" || return 1
+	IFS= read -r expected_branch <"${recovery_dir}/branch" || return 1
+	_worktree_capture_git_identity "$wt_path" || return 1
+	[[ "$_WT_ID_SOURCE_REAL" == "$expected_source_real" ]] || return 1
+	[[ "$_WT_ID_SOURCE_INODE" == "$expected_source_inode" ]] || return 1
+	[[ "$_WT_ID_ADMIN_REAL" == "$expected_admin_real" ]] || return 1
+	[[ "$_WT_ID_ADMIN_INODE" == "$expected_admin_inode" ]] || return 1
+	[[ "$_WT_ID_COMMON_REAL" == "$expected_common_real" ]] || return 1
+	[[ "$_WT_ID_HEAD" == "$expected_head" ]] || return 1
+	[[ "$_WT_ID_BRANCH" == "$expected_branch" ]] || return 1
+	return 0
+}
+
+archive_worktree_path_recoverably() {
+	local wt_path="$1"
+	local caller="$2"
+	local context="${3:-}"
+	local wt_path_real="$wt_path"
+	local trash_root="${AIDEVOPS_WORKTREE_TRASH_ROOT:-${AIDEVOPS_ORPHAN_TRASH_ROOT:-}}"
+	local trash_root_real=""
+	local trash_bucket=""
+	local archive_path=""
+	local recovery_dir=""
+	local recovery_admin=""
+	local worktree_basename=""
+	local git_state=""
+
+	WORKTREE_RECOVERABLE_ARCHIVE_PATH=""
+	_worktree_capture_git_identity "$wt_path" || return 1
+	wt_path_real="$_WT_ID_SOURCE_REAL"
+	git_state=$(_worktree_git_lock_state "$wt_path" "$wt_path_real") ||
+		git_state="$_WT_GIT_STATE_UNREADABLE"
+	if [[ "$git_state" != "$_WT_GIT_STATE_CLEAR" ]]; then
+		_worktree_log_git_refusal "$wt_path" "$caller" "$git_state" "$context"
+		return 1
+	fi
+	if [[ -z "$trash_root" ]]; then
+		[[ -n "${HOME:-}" ]] || return 1
+		trash_root="${HOME}/.Trash"
+	fi
+	[[ "$trash_root" == /* ]] || return 1
+	mkdir -p "$trash_root" 2>/dev/null || return 1
+	trash_root_real=$(cd "$trash_root" 2>/dev/null && pwd -P) || return 1
+	case "$trash_root_real" in
+	"$wt_path_real" | "$wt_path_real"/*) return 1 ;;
+	esac
+	worktree_basename="${wt_path%/}"
+	worktree_basename="${worktree_basename##*/}"
+	[[ -n "$worktree_basename" && "$worktree_basename" != "." &&
+		"$worktree_basename" != "$_WT_RECOVERY_DIR_NAME" ]] || return 1
+	trash_bucket="${trash_root_real}/aidevops-worktree-cleanup-$(date -u '+%Y%m%dT%H%M%SZ')-$$-${RANDOM}"
+	archive_path="${trash_bucket}/${worktree_basename}"
+	recovery_dir="${trash_bucket}/${_WT_RECOVERY_DIR_NAME}"
+	recovery_admin="${recovery_dir}/admin"
+	mkdir "$trash_bucket" 2>/dev/null || return 1
+	_worktree_copy_directory_once "$wt_path_real" "$archive_path" || return 1
+	mkdir "$recovery_dir" 2>/dev/null || return 1
+	_worktree_copy_directory_once "$_WT_ID_ADMIN_REAL" "$recovery_admin" || return 1
+	_worktree_write_recovery_identity "$recovery_dir" || return 1
+	printf '%s\n' "$_WT_ID_HEAD" >"${recovery_admin}/HEAD" || return 1
+	printf '%s\n' "$_WT_ID_COMMON_REAL" >"${recovery_admin}/commondir" || return 1
+	printf '%s\n' "${archive_path}/.git" >"${recovery_admin}/gitdir" || return 1
+	printf 'gitdir: %s\n' "$recovery_admin" >"${archive_path}/.git" || return 1
+	_worktree_recovery_archive_is_valid "$archive_path" || return 1
+	_worktree_archive_source_matches "$wt_path" "$archive_path" || return 1
+	git_state=$(_worktree_git_lock_state "$wt_path" "$wt_path_real") ||
+		git_state="$_WT_GIT_STATE_UNREADABLE"
+	if [[ "$git_state" != "$_WT_GIT_STATE_CLEAR" ]]; then
+		_worktree_log_git_refusal "$wt_path" "$caller" "$git_state" "$context"
+		return 1
+	fi
+	WORKTREE_RECOVERABLE_ARCHIVE_PATH="$archive_path"
+	return 0
+}
+
+_worktree_guard_path_is_usable() {
+	local wt_path="$1"
+	local caller="$2"
+
+	if [[ -z "$wt_path" ]]; then
+		WORKTREE_REMOVAL_GUARD_REASON="empty-path"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "empty-path" "$_WTAR_MODE_SKIPPED"
+		return 1
+	fi
+	if [[ -L "$wt_path" ]]; then
+		_worktree_log_identity_refusal "$wt_path" "$caller"
+		return 1
+	fi
+	return 0
+}
+
 # =============================================================================
 # worktree_removal_guard — shared destructive-path guard for production cleanup
 #
@@ -279,10 +779,11 @@ _worktree_has_process_cwd() {
 #   $4  cwd_snapshot — optional newline-separated live-process cwd snapshot
 #   $5  cwd_visibility — complete, degraded, or unusable (default: complete)
 #
-# Refuses registered canonical repos, the caller's current working directory,
-# and worktrees that still have any live process cwd inside them. On refusal,
-# WORKTREE_REMOVAL_GUARD_REASON contains the short audit reason for callers that
-# opt into a user-facing diagnostic. The guard itself remains silent.
+# Refuses registered canonical repos, Git-locked or metadata-unreadable
+# worktrees, the caller's current working directory, and worktrees that still
+# have any live process cwd inside them. On refusal, WORKTREE_REMOVAL_GUARD_REASON
+# contains the short audit reason for callers that opt into a user-facing
+# diagnostic. The guard itself remains silent.
 # Returns 0 for complete no-match, 2 for degraded no-match (recoverable path
 # required), and 1 for every hard refusal or unusable snapshot.
 # =============================================================================
@@ -294,20 +795,17 @@ worktree_removal_guard() {
 	local cwd_visibility="${5:-$_WT_CWD_VISIBILITY_COMPLETE}"
 	local cwd_snapshot_provided=0
 	local cwd_match_status=0
+	local git_lock_state=""
 	WORKTREE_REMOVAL_GUARD_REASON=""
 	WORKTREE_REMOVAL_GUARD_VISIBILITY=""
 	[[ "$#" -ge 4 ]] && cwd_snapshot_provided=1
 
-	if [[ -z "$wt_path" ]]; then
-		WORKTREE_REMOVAL_GUARD_REASON="empty-path"
-		log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "empty-path" "skipped"
-		return 1
-	fi
+	_worktree_guard_path_is_usable "$wt_path" "$caller" || return 1
 
 	if command -v is_registered_canonical >/dev/null 2>&1; then
 		if is_registered_canonical "$wt_path"; then
 			WORKTREE_REMOVAL_GUARD_REASON="canonical-skip"
-			log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "canonical-skip" "skipped"
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "canonical-skip" "$_WTAR_MODE_SKIPPED"
 			return 1
 		fi
 	fi
@@ -323,11 +821,26 @@ worktree_removal_guard() {
 		case "$current_dir" in
 		"$wt_path" | "$wt_path"/* | "$wt_path_real" | "$wt_path_real"/*)
 			WORKTREE_REMOVAL_GUARD_REASON="current-worktree"
-			log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "current-worktree" "skipped"
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "current-worktree" "$_WTAR_MODE_SKIPPED"
 			return 1
 			;;
 		esac
 	fi
+
+	git_lock_state=$(_worktree_git_lock_state "$wt_path" "$wt_path_real") ||
+		git_lock_state="$_WT_GIT_STATE_UNREADABLE"
+	case "$git_lock_state" in
+	"$_WT_GIT_STATE_LOCKED")
+		WORKTREE_REMOVAL_GUARD_REASON="$_WT_GIT_REASON_LOCKED"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "$_WT_GIT_REASON_LOCKED" "$_WTAR_MODE_SKIPPED"
+		return 1
+		;;
+	"$_WT_GIT_STATE_UNREADABLE")
+		WORKTREE_REMOVAL_GUARD_REASON="$_WT_GIT_REASON_UNREADABLE"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "$_WT_GIT_REASON_UNREADABLE" "$_WTAR_MODE_SKIPPED"
+		return 1
+		;;
+	esac
 
 	if [[ "$cwd_snapshot_provided" -eq 1 ]]; then
 		if _worktree_cwd_snapshot_contains_path "$wt_path" "$wt_path_real" "$cwd_snapshot"; then
@@ -348,7 +861,7 @@ worktree_removal_guard() {
 	if [[ "$cwd_match_status" -eq 0 ]]; then
 		WORKTREE_REMOVAL_GUARD_VISIBILITY="$cwd_visibility"
 		WORKTREE_REMOVAL_GUARD_REASON="active-cwd"
-		log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "active-cwd" "skipped"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "active-cwd" "$_WTAR_MODE_SKIPPED"
 		return 1
 	fi
 	if [[ "$cwd_match_status" -eq "$_WT_CWD_CAPTURE_DEGRADED_RC" ]]; then
@@ -360,12 +873,119 @@ worktree_removal_guard() {
 	if [[ "$cwd_match_status" -eq "$_WT_CWD_MATCH_UNUSABLE_RC" ]]; then
 		WORKTREE_REMOVAL_GUARD_VISIBILITY="$_WT_CWD_VISIBILITY_UNUSABLE"
 		WORKTREE_REMOVAL_GUARD_REASON="$_WT_CWD_REASON_UNUSABLE"
-		log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "$_WT_CWD_REASON_UNUSABLE" "skipped"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$caller" "$wt_path" "$_WT_CWD_REASON_UNUSABLE" "$_WTAR_MODE_SKIPPED"
 		return 1
 	fi
 
 	WORKTREE_REMOVAL_GUARD_VISIBILITY="$_WT_CWD_VISIBILITY_COMPLETE"
 	: "$reason"
+	return 0
+}
+
+_worktree_remove_with_native_git() {
+	local wt_path="$1"
+	local caller="$2"
+	local context="$3"
+	local force_remove="$4"
+	local archive_path="${5:-}"
+	local real_git=""
+	local common_dir=""
+	local wt_path_real="$wt_path"
+	local git_state=""
+
+	if [[ -L "$wt_path" ]]; then
+		_worktree_log_identity_refusal "$wt_path" "$caller" "$context"
+		return 1
+	fi
+	if [[ ! -e "$wt_path" ]]; then
+		if [[ -n "$archive_path" ]]; then
+			_worktree_log_identity_refusal "$wt_path" "$caller" "$context"
+			return 1
+		fi
+		return 0
+	fi
+	if [[ -e "$wt_path" ]]; then
+		wt_path_real=$(cd "$wt_path" 2>/dev/null && pwd -P) || wt_path_real="$wt_path"
+	fi
+	git_state=$(_worktree_git_lock_state "$wt_path" "$wt_path_real") ||
+		git_state="$_WT_GIT_STATE_UNREADABLE"
+	if [[ "$git_state" != "$_WT_GIT_STATE_CLEAR" ]]; then
+		_worktree_log_git_refusal "$wt_path" "$caller" "$git_state" "$context"
+		return 1
+	fi
+	if ! real_git=$(_worktree_cleanup_real_git); then
+		_worktree_log_git_refusal "$wt_path" "$caller" "$_WT_GIT_STATE_UNREADABLE" "$context"
+		return 1
+	fi
+	if ! common_dir=$(_worktree_git_common_dir "$real_git" "$wt_path"); then
+		_worktree_log_git_refusal "$wt_path" "$caller" "$_WT_GIT_STATE_UNREADABLE" "$context"
+		return 1
+	fi
+	if [[ -n "$archive_path" ]] && ! _worktree_archive_source_matches "$wt_path" "$archive_path"; then
+		_worktree_log_identity_refusal "$wt_path" "$caller" "$context"
+		return 1
+	fi
+
+	if [[ "$force_remove" == "$_WTAR_BOOL_TRUE" ]]; then
+		# One force can remove dirty state, but Git requires force twice to
+		# override a worktree lock acquired after our final metadata check.
+		"$real_git" --git-dir="$common_dir" worktree remove --force "$wt_path_real" 2>/dev/null || {
+			git_state=$(_worktree_git_lock_state "$wt_path" "$wt_path_real") ||
+				git_state="$_WT_GIT_STATE_UNREADABLE"
+			_worktree_log_git_refusal "$wt_path" "$caller" "$git_state" "$context"
+			return 1
+		}
+	else
+		"$real_git" --git-dir="$common_dir" worktree remove "$wt_path_real" 2>/dev/null || {
+			git_state=$(_worktree_git_lock_state "$wt_path" "$wt_path_real") ||
+				git_state="$_WT_GIT_STATE_UNREADABLE"
+			_worktree_log_git_refusal "$wt_path" "$caller" "$git_state" "$context"
+			return 1
+		}
+	fi
+	[[ ! -e "$wt_path" && ! -e "$wt_path_real" ]] || return 1
+	return 0
+}
+
+# Remove a registered worktree only after a durable copy exists outside it.
+# Native Git remains the final authority, so a lock acquired during the archive
+# copy blocks source removal without any temporary lock-release protocol.
+# Args: $1=worktree, $2=archive, $3=caller, $4=reason, $5=context,
+#       $6=allow degraded CWD evidence, $7=allow one force
+remove_archived_worktree_path() {
+	local wt_path="$1"
+	local archive_path="$2"
+	local caller="$3"
+	local reason="$4"
+	local context="${5:-}"
+	local allow_degraded="${6:-false}"
+	local force_remove="${7:-false}"
+	local archive_path_real=""
+	local wt_path_real="$wt_path"
+	local guard_status=0
+
+	_worktree_recovery_archive_is_valid "$archive_path" || return 1
+	archive_path_real=$(cd "$archive_path" 2>/dev/null && pwd -P) || return 1
+	if [[ -e "$wt_path" ]]; then
+		wt_path_real=$(cd "$wt_path" 2>/dev/null && pwd -P) || return 1
+	fi
+	case "$archive_path_real" in
+	"$wt_path_real" | "$wt_path_real"/*) return 1 ;;
+	esac
+	if ! _worktree_archive_source_matches "$wt_path" "$archive_path"; then
+		_worktree_log_identity_refusal "$wt_path" "$caller" "$context"
+		return 1
+	fi
+	if worktree_removal_guard "$wt_path" "$caller" "$reason"; then
+		guard_status=0
+	else
+		guard_status=$?
+	fi
+	if [[ "$guard_status" -ne 0 ]]; then
+		[[ "$allow_degraded" == "$_WTAR_BOOL_TRUE" && "$guard_status" -eq "$_WT_CWD_CAPTURE_DEGRADED_RC" ]] || return 1
+	fi
+	_worktree_remove_with_native_git "$wt_path" "$caller" "$context" "$force_remove" "$archive_path" || return 1
+	_worktree_recovery_archive_is_valid "$archive_path" || return 1
 	return 0
 }
 
@@ -387,9 +1007,7 @@ remove_worktree_path_permanently() {
 	local context="${4:-}"
 
 	worktree_removal_guard "$wt_path" "$caller" "$reason" || return 1
-	[[ ! -e "$wt_path" ]] && return 0
-
-	if rm -rf "$wt_path" 2>/dev/null; then
+	if _worktree_remove_with_native_git "$wt_path" "$caller" "$context" "false"; then
 		log_worktree_removal_event "$_WTAR_REMOVED" "$caller" "$wt_path" "$reason" "permanent" "$context"
 		return 0
 	fi
@@ -398,8 +1016,8 @@ remove_worktree_path_permanently() {
 }
 
 # Resolve native Git without selecting the canonical mutation-guard shim. This
-# helper is the audited exception for pruning metadata after a guarded removal
-# has already moved a linked worktree directory to trash.
+# helper is the audited exception for an already-guarded linked worktree's
+# lock-aware removal and missing-metadata prune operations.
 _worktree_cleanup_real_git() {
 	local candidate="${AIDEVOPS_REAL_GIT_BIN:-}"
 
@@ -424,20 +1042,68 @@ _worktree_metadata_contains_path() {
 	local repo_context="$2"
 	local wt_path="$3"
 	local clean_wt_path="$wt_path"
-	local list_output=""
-	local listed_path=""
+	local physical_wt_path="$wt_path"
+	local field="" list_status="" listed_path=""
+	local parser_valid=1 in_block=0 status_seen=0 target_seen=0
+	local head_count=0 branch_count=0 detached_count=0 bare_count=0
 
 	while [[ "$clean_wt_path" != "/" && "$clean_wt_path" == */ ]]; do
 		clean_wt_path="${clean_wt_path%/}"
 	done
-	if ! list_output=$("$real_git" -C "$repo_context" worktree list --porcelain); then
+	physical_wt_path=$(_worktree_physical_path "$clean_wt_path") || physical_wt_path="$clean_wt_path"
+	while IFS= read -r -d '' field; do
+		case "$field" in
+		"$_WT_GIT_STATUS_FIELD_PREFIX"*)
+			[[ "$status_seen" -eq 0 && "$in_block" -eq 0 ]] || parser_valid=0
+			list_status="${field#"$_WT_GIT_STATUS_FIELD_PREFIX"}"
+			status_seen=1
+			;;
+		worktree\ *)
+			[[ "$status_seen" -eq 0 && "$in_block" -eq 0 ]] || parser_valid=0
+			listed_path="${field#worktree }"
+			[[ -n "$listed_path" ]] || parser_valid=0
+			in_block=1
+			head_count=0 branch_count=0 detached_count=0 bare_count=0
+			if [[ "$listed_path" == "$clean_wt_path" || "$listed_path" == "$physical_wt_path" ]]; then
+				[[ "$target_seen" -eq 0 ]] || parser_valid=0
+				target_seen=1
+			fi
+			;;
+		HEAD\ *)
+			head_count=$((head_count + 1))
+			[[ "$in_block" -eq 1 && "$status_seen" -eq 0 && "$head_count" -eq 1 ]] || parser_valid=0
+			_worktree_git_head_payload_is_valid "${field#HEAD }" || parser_valid=0
+			;;
+		branch\ *)
+			branch_count=$((branch_count + 1))
+			[[ "$in_block" -eq 1 && "$status_seen" -eq 0 && "$branch_count" -eq 1 ]] || parser_valid=0
+			_worktree_git_branch_payload_is_valid "${field#branch }" || parser_valid=0
+			;;
+		detached)
+			detached_count=$((detached_count + 1))
+			[[ "$in_block" -eq 1 && "$status_seen" -eq 0 && "$detached_count" -eq 1 ]] || parser_valid=0
+			;;
+		bare)
+			bare_count=$((bare_count + 1))
+			[[ "$in_block" -eq 1 && "$status_seen" -eq 0 && "$bare_count" -eq 1 ]] || parser_valid=0
+			;;
+		"")
+			if [[ "$status_seen" -eq 1 || "$in_block" -ne 1 ]] ||
+				! _worktree_git_block_is_complete "$head_count" "$branch_count" "$detached_count" "$bare_count"; then
+				parser_valid=0
+			fi
+			in_block=0
+			;;
+		*) [[ "$in_block" -eq 1 && "$status_seen" -eq 0 ]] || parser_valid=0 ;;
+		esac
+	done < <(
+		"$real_git" -C "$repo_context" worktree list --porcelain -z 2>/dev/null
+		printf '%s%s\0' "$_WT_GIT_STATUS_FIELD_PREFIX" "$?"
+	)
+	if [[ "$parser_valid" -ne 1 || "$status_seen" -ne 1 || "$in_block" -ne 0 || "$list_status" != "0" ]]; then
 		return 2
 	fi
-
-	while IFS= read -r listed_path; do
-		listed_path="${listed_path%$'\r'}"
-		[[ "$listed_path" == "worktree $clean_wt_path" ]] && return 0
-	done <<<"$list_output"
+	[[ "$target_seen" -eq 0 ]] || return 0
 
 	return 1
 }

--- a/.agents/scripts/pulse-cleanup-degraded-orphans.sh
+++ b/.agents/scripts/pulse-cleanup-degraded-orphans.sh
@@ -7,10 +7,11 @@
 
 [[ -n "${_PULSE_CLEANUP_DEGRADED_ORPHANS_LOADED:-}" ]] && return 0
 _PULSE_CLEANUP_DEGRADED_ORPHANS_LOADED=1
+_PCDO_REASON_RECOVERABLE="degraded-cwd-orphan-recoverable"
 
 _PCDO_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [[ -f "${_PCDO_SCRIPT_DIR}/worktree-clean-lib.sh" ]]; then
-	# Reuse the cleanup lease and recoverable-move primitives. Their remaining
+	# Reuse the cleanup lease and recoverable-archive primitives. Their remaining
 	# dependencies are resolved only when the corresponding functions are called.
 	# shellcheck source=worktree-clean-lib.sh
 	source "${_PCDO_SCRIPT_DIR}/worktree-clean-lib.sh"
@@ -85,7 +86,7 @@ _pcdo_fresh_cwd_state_allows_recovery() {
 	local wt_path_age="$1"
 	local guard_status=0
 
-	if worktree_removal_guard "$wt_path_age" "$_WTAR_PC_CALLER" "degraded-cwd-orphan-recoverable"; then
+	if worktree_removal_guard "$wt_path_age" "$_WTAR_PC_CALLER" "$_PCDO_REASON_RECOVERABLE"; then
 		guard_status=0
 	else
 		guard_status=$?
@@ -110,13 +111,14 @@ _pc_remove_degraded_orphan_recoverably() {
 	local wt_age_secs="${11}"
 	local reason="${12}"
 	local audit_context=""
+	local recoverable_archive=""
 
 	[[ "$commits_ahead" -eq 0 && "$dirty_count" -eq 0 ]] || return 1
 	[[ "$reason" == *"crashed worker"* ]] || return 1
 	_pcdo_open_pr_absent_verified "$repo_slug_age" "$wt_branch_age" || return 1
 	if ! _clean_acquire_removal_lease "$wt_path_age" "$wt_branch_age"; then
 		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" \
-			"cleanup-lease-skip" "skipped"
+			"cleanup-lease-skip" "$_WTAR_MODE_SKIPPED"
 		return 1
 	fi
 
@@ -132,10 +134,19 @@ _pc_remove_degraded_orphan_recoverably() {
 		return 1
 	fi
 
-	if ! _clean_move_worktree_recoverably "$wt_path_age"; then
+	if ! _clean_archive_worktree_recoverably "$wt_path_age" "$_WTAR_PC_CALLER"; then
 		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" \
-			"recoverable-move-failed" "skipped" \
+			"recoverable-archive-failed" "$_WTAR_MODE_SKIPPED" \
 			"$audit_context recoverable_backends=${_WT_CLEAN_RECOVERABLE_FAILURE_DETAIL:-unknown}"
+		_pcdo_release_removal_lease "$wt_path_age"
+		return 1
+	fi
+	recoverable_archive="$_WT_CLEAN_RECOVERABLE_ARCHIVE_PATH"
+	if ! remove_archived_worktree_path "$wt_path_age" "$recoverable_archive" \
+		"$_WTAR_PC_CALLER" "$_PCDO_REASON_RECOVERABLE" "$audit_context" \
+		"true" "false"; then
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" \
+			"recoverable-remove-failed" "$_WTAR_MODE_SKIPPED" "$audit_context"
 		_pcdo_release_removal_lease "$wt_path_age"
 		return 1
 	fi
@@ -148,7 +159,7 @@ _pc_remove_degraded_orphan_recoverably() {
 
 	unregister_worktree "$wt_path_age" 2>/dev/null || true
 	log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_PC_CALLER" "$wt_path_age" \
-		"degraded-cwd-orphan-recoverable" "recoverable-trash" "$audit_context"
+		"$_PCDO_REASON_RECOVERABLE" "recoverable-trash" "$audit_context"
 	if declare -F full_loop_mark_cleanup_cleaned_for_worktree >/dev/null 2>&1; then
 		full_loop_mark_cleanup_cleaned_for_worktree "$wt_path_age" || true
 	fi

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -393,10 +393,10 @@ _pc_recent_worker_metric_exists() {
 # see each fallback. Tested by test-pulse-cleanup-config-defaults.sh.
 
 #######################################
-# Move a path to system trash before permanent deletion (GH#19042).
+# Move a path to system trash without a permanent-delete fallback (GH#19042).
 # Mirrors worktree-helper.sh trash_path() so Pass 2 orphan cleanup gets
 # the same recoverability as Pass 1 (which calls worktree-helper.sh clean).
-# Prefers: trash CLI (macOS Homebrew), gio trash (Linux), rm -rf fallback.
+# Prefers: trash CLI (macOS Homebrew), then gio trash (Linux).
 # Args: $1=path to trash
 # Returns 0 on success, 1 on failure.
 #
@@ -424,7 +424,6 @@ _trash_or_remove() {
 	if command -v gio >/dev/null 2>&1; then
 		gio trash "$target" 2>/dev/null && return 0
 	fi
-	rm -rf "$target" 2>/dev/null && return 0
 	return 1
 }
 
@@ -1350,10 +1349,7 @@ _pc_handle_generated_clean_cruft_worktree() {
 		return $?
 	fi
 	echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): removing detached generated worktree — clean auto/review cruft older than ${archive_secs}s" >>"$LOGFILE"
-	if ! remove_worktree_path_permanently "$wt_path_age" "$_WTAR_PC_CALLER" "$removal_reason" "$audit_context"; then
-		git -C "$rp_age" worktree remove --force "$wt_path_age" 2>/dev/null || return 1
-		log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_PC_CALLER" "$wt_path_age" "$removal_reason" "permanent" "$audit_context"
-	fi
+	remove_worktree_path_permanently "$wt_path_age" "$_WTAR_PC_CALLER" "$removal_reason" "$audit_context" || return 1
 	git -C "$rp_age" worktree prune 2>/dev/null || true
 	unregister_worktree "$wt_path_age" 2>/dev/null || true
 	return 0
@@ -1503,14 +1499,7 @@ _pc_permanently_remove_eligible_orphan() {
 	if [[ "$reason" == *"crashed worker"* && -n "$wt_branch_age" && -n "$repo_slug_age" ]]; then
 		_record_orphan_crash_classification "$wt_branch_age" "$dirty_count" "$repo_slug_age"
 	fi
-	if ! remove_worktree_path_permanently "$wt_path_age" "$_WTAR_PC_CALLER" "$_PC_REASON_AGE_ELIGIBLE" "$audit_context"; then
-		if git -C "$rp_age" worktree remove --force "$wt_path_age" 2>/dev/null; then
-			log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_PC_CALLER" "$wt_path_age" \
-				"$_PC_REASON_AGE_ELIGIBLE" "permanent" "$audit_context"
-		else
-			return 1
-		fi
-	fi
+	remove_worktree_path_permanently "$wt_path_age" "$_WTAR_PC_CALLER" "$_PC_REASON_AGE_ELIGIBLE" "$audit_context" || return 1
 	git -C "$rp_age" worktree prune 2>/dev/null || true
 	unregister_worktree "$wt_path_age" 2>/dev/null || true
 	if [[ -n "$wt_branch_age" ]]; then

--- a/.agents/scripts/skill-update-pr-lib.sh
+++ b/.agents/scripts/skill-update-pr-lib.sh
@@ -685,9 +685,8 @@ _cleanup_worktree() {
 		fi
 		log_info "Cleaning up empty worktree: $wt_path"
 		if ! remove_worktree_path_permanently "$wt_path" "$_WTAR_SU_CALLER" "manual"; then
-			if git worktree remove "$wt_path" --force 2>/dev/null; then
-				log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_SU_CALLER" "$wt_path" "manual" "permanent"
-			fi
+			log_warning "Skipping branch cleanup because guarded worktree removal failed: $wt_path"
+			return 0
 		fi
 		git branch -D "$branch" 2>/dev/null || true
 		unregister_worktree "$wt_path"

--- a/.agents/scripts/tests/test-pulse-cleanup-centralize-worktrees.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-centralize-worktrees.sh
@@ -6,10 +6,18 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PULSE_CLEANUP="${SCRIPT_DIR}/../pulse-cleanup.sh"
+GIT_BIN="${AIDEVOPS_TEST_GIT_BIN:-/usr/bin/git}"
 
 TEST_ROOT=""
 TESTS_RUN=0
 TESTS_FAILED=0
+
+# Keep isolated fixture mutations on native Git. The repository-level canonical
+# guard is under separate test and must not classify temporary main worktrees.
+git() {
+	"$GIT_BIN" "$@"
+	return $?
+}
 
 print_result() {
 	local name="$1"

--- a/.agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh
@@ -11,6 +11,14 @@ if [[ -d "$ROOT_DIR/.agents/scripts" ]]; then
 else
 	AGENTS_SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 fi
+GIT_BIN="${AIDEVOPS_TEST_GIT_BIN:-/usr/bin/git}"
+
+# Keep temporary fixture repositories on native Git; canonical mutation-guard
+# behavior is covered by its dedicated tests.
+git() {
+	"$GIT_BIN" "$@"
+	return $?
+}
 
 TEST_ROOT=""
 TESTS_RUN=0

--- a/.agents/scripts/tests/test-pulse-cleanup-preserves-dirty.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-preserves-dirty.sh
@@ -27,6 +27,14 @@ TEST_ROOT=""
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PULSE_CLEANUP="${SCRIPT_DIR}/../pulse-cleanup.sh"
+GIT_BIN="${AIDEVOPS_TEST_GIT_BIN:-/usr/bin/git}"
+
+# Keep temporary fixture repositories on native Git; canonical mutation-guard
+# behavior is covered by its dedicated tests.
+git() {
+	"$GIT_BIN" "$@"
+	return $?
+}
 
 print_result() {
 	local name="$1"

--- a/.agents/scripts/tests/test-pulse-cleanup-unregister.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-unregister.sh
@@ -9,12 +9,21 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GIT_BIN="${AIDEVOPS_TEST_GIT_BIN:-/usr/bin/git}"
 TEST_ROOT=$(mktemp -d)
 trap 'rm -rf "$TEST_ROOT"' EXIT
 
 LOGFILE="${TEST_ROOT}/pulse.log"
 export AIDEVOPS_CLEANUP_LOG="${TEST_ROOT}/cleanup_worktrees.log"
 UNREGISTER_LOG="${TEST_ROOT}/unregister.log"
+
+# Production functions under test invoke `git` by name. Pin fixture operations
+# to native Git so the canonical mutation guard for the real repository cannot
+# misclassify isolated test repositories.
+git() {
+	"$GIT_BIN" "$@"
+	return $?
+}
 
 # shellcheck source=../shared-constants.sh
 source "${SCRIPT_DIR}/shared-constants.sh"
@@ -90,6 +99,68 @@ test_orphan_removal_unregisters() {
 	return 0
 }
 
+test_locked_orphan_is_preserved() {
+	local repo_path="${TEST_ROOT}/repo-locked"
+	local wt_path="${TEST_ROOT}/wt-locked"
+	local wt_root=""
+	local metadata=""
+	make_repo_with_worktree "$repo_path" "$wt_path" "feature/locked"
+	"$GIT_BIN" -C "$repo_path" worktree lock --reason "observation-provenance" "$wt_path"
+
+	if _cleanup_single_worktree "$repo_path" "$wt_path" "feature/locked" "$(date +%s)" "" "main"; then
+		fail "locked orphan was reported as removed"
+	fi
+
+	[[ -d "$wt_path" ]] || fail "locked orphan physical path was removed"
+	wt_root=$("$GIT_BIN" -C "$wt_path" rev-parse --show-toplevel) || fail "locked orphan root became unreadable"
+	metadata=$("$GIT_BIN" -C "$repo_path" worktree list --porcelain) || fail "locked orphan metadata became unreadable"
+	printf '%s\n' "$metadata" | grep -Fqx "worktree $wt_root" || fail "locked orphan registration was removed"
+	printf '%s\n' "$metadata" | grep -Eq '^locked([[:space:]]|$)' || fail "locked orphan lock marker was removed"
+	if [[ -f "$UNREGISTER_LOG" ]] && grep -Fxq "$wt_path" "$UNREGISTER_LOG"; then
+		fail "locked orphan was unregistered"
+	fi
+	grep -q 'git-worktree-locked.*mode=skipped' "$AIDEVOPS_CLEANUP_LOG" || fail "locked orphan skip was not audited"
+	pass "pulse cleanup preserves Git-locked eligible orphan"
+	return 0
+}
+
+test_late_write_before_permanent_remove_is_preserved() {
+	local repo_path="${TEST_ROOT}/repo-late-write"
+	local wt_path="${TEST_ROOT}/wt-late-write"
+	local wrapper_path="${TEST_ROOT}/late-write-git"
+	local marker_path="${TEST_ROOT}/late-write-injected"
+	local metadata=""
+	local wt_root=""
+	make_repo_with_worktree "$repo_path" "$wt_path" "feature/late-write"
+	wt_root=$(/usr/bin/git -C "$wt_path" rev-parse --show-toplevel) || fail "late-write root became unreadable"
+	cat >"$wrapper_path" <<'LATE_WRITE_GIT'
+#!/usr/bin/env bash
+if [[ "$*" == *"worktree remove"* && ! -e "${LATE_WRITE_MARKER:?}" ]]; then
+	printf 'late state\n' >"${LATE_WRITE_WORKTREE:?}/late-write.txt" || exit 1
+	: >"$LATE_WRITE_MARKER"
+fi
+exec "${REAL_GIT:?}" "$@"
+LATE_WRITE_GIT
+	chmod +x "$wrapper_path"
+
+	if REAL_GIT="$GIT_BIN" LATE_WRITE_MARKER="$marker_path" \
+		LATE_WRITE_WORKTREE="$wt_path" AIDEVOPS_REAL_GIT_BIN="$wrapper_path" \
+		_cleanup_single_worktree "$repo_path" "$wt_path" "feature/late-write" \
+		"$(date +%s)" "" "main"; then
+		fail "late-write permanent cleanup was reported as complete"
+	fi
+	[[ -f "$wt_path/late-write.txt" && -e "$marker_path" ]] || fail "late write or source was removed"
+	metadata=$(/usr/bin/git -C "$repo_path" worktree list --porcelain) || fail "late-write metadata became unreadable"
+	printf '%s\n' "$metadata" | grep -Fqx "worktree $wt_root" || fail "late-write registration was removed"
+	printf '%s\n' "$metadata" | grep -Fqx "branch refs/heads/feature/late-write" || fail "late-write branch identity was removed"
+	if [[ -f "$UNREGISTER_LOG" ]] && grep -Fxq "$wt_path" "$UNREGISTER_LOG"; then
+		fail "late-write worktree was unregistered"
+	fi
+	grep -q 'git-worktree-remove-failed.*mode=skipped' "$AIDEVOPS_CLEANUP_LOG" || fail "late-write refusal was not audited"
+	pass "pulse permanent cleanup preserves a write acquired after clean classification"
+	return 0
+}
+
 test_degraded_orphan_removal_is_recoverable() {
 	local repo_path="${TEST_ROOT}/repo-degraded"
 	local wt_path="${TEST_ROOT}/wt-degraded"
@@ -127,6 +198,8 @@ test_degraded_orphan_removal_is_recoverable() {
 		fail "degraded eligible orphan was not removed recoverably"
 
 	[[ ! -e "$wt_path" ]] || fail "degraded orphan source path still exists"
+	compgen -G "${trash_root}/aidevops-worktree-cleanup-*/wt-degraded" >/dev/null ||
+		fail "degraded orphan archive was not retained"
 	if /usr/bin/git -C "$repo_path" worktree list --porcelain | grep -Fqx "worktree $wt_path"; then
 		fail "degraded orphan metadata remains registered"
 	fi
@@ -134,6 +207,85 @@ test_degraded_orphan_removal_is_recoverable() {
 	grep -q 'degraded-cwd-orphan-recoverable.*mode=recoverable-trash' "$AIDEVOPS_CLEANUP_LOG" ||
 		fail "recoverable degraded removal was not audited"
 	pass "pulse cleanup recoverably removes a degraded clean zero-ahead no-PR orphan"
+	return 0
+}
+
+# A foreign Git lock acquired after archive completion but before native source
+# removal must preserve the source, exact metadata, and completed archive.
+test_degraded_orphan_lock_race_is_preserved() {
+	local repo_path="${TEST_ROOT}/repo-degraded-race"
+	local wt_path="${TEST_ROOT}/wt-degraded-race"
+	local trash_root="${TEST_ROOT}/recoverable-race-trash"
+	local wrapper_path="${TEST_ROOT}/degraded-race-git"
+	local marker_path="${TEST_ROOT}/degraded-race-lock-injected"
+	local metadata=""
+	local wt_root=""
+	make_repo_with_worktree "$repo_path" "$wt_path" "feature/degraded-race"
+	wt_root=$(/usr/bin/git -C "$wt_path" rev-parse --show-toplevel) || fail "degraded race root became unreadable"
+	mkdir -p "$trash_root"
+	cat >"$wrapper_path" <<'RACE_GIT'
+#!/usr/bin/env bash
+if [[ "$*" == *"worktree remove"* && ! -e "${RACE_MARKER:?}" ]]; then
+	: >"$RACE_MARKER"
+	"${REAL_GIT:?}" -C "${RACE_REPO:?}" worktree lock --reason "foreign-degraded-race" "${RACE_WORKTREE:?}" || exit 1
+fi
+exec "${REAL_GIT:?}" "$@"
+RACE_GIT
+	chmod +x "$wrapper_path"
+
+	if AIDEVOPS_REAL_GIT_BIN="$wrapper_path" REAL_GIT="$GIT_BIN" \
+		RACE_MARKER="$marker_path" RACE_REPO="$repo_path" RACE_WORKTREE="$wt_path" \
+		AIDEVOPS_WORKTREE_TRASH_ROOT="$trash_root" \
+		_cleanup_single_worktree "$repo_path" "$wt_path" "feature/degraded-race" \
+		"$(date +%s)" "owner/repo" "main"; then
+		fail "degraded lock race was reported as removed"
+	fi
+
+	[[ -e "$marker_path" && -d "$wt_path" ]] || fail "degraded lock race removed the physical path"
+	compgen -G "${trash_root}/aidevops-worktree-cleanup-*/wt-degraded-race" >/dev/null ||
+		fail "degraded lock race lost the completed archive"
+	metadata=$(/usr/bin/git -C "$repo_path" worktree list --porcelain) || fail "degraded race metadata became unreadable"
+	printf '%s\n' "$metadata" | grep -Fqx "worktree $wt_root" || fail "degraded race registration was removed"
+	printf '%s\n' "$metadata" | grep -Fqx "locked foreign-degraded-race" || fail "foreign degraded race lock was not retained"
+	if [[ -f "$UNREGISTER_LOG" ]] && grep -Fxq "$wt_path" "$UNREGISTER_LOG"; then
+		fail "degraded race worktree was unregistered"
+	fi
+	grep -q 'git-worktree-locked.*mode=skipped' "$AIDEVOPS_CLEANUP_LOG" || fail "degraded race lock refusal was not audited"
+	pass "pulse degraded cleanup preserves a lock acquired after its guard"
+	return 0
+}
+
+test_degraded_orphan_remove_failure_preserves_source_and_archive() {
+	local repo_path="${TEST_ROOT}/repo-degraded-remove-failure"
+	local wt_path="${TEST_ROOT}/wt-degraded-remove-failure"
+	local trash_root="${TEST_ROOT}/recoverable-remove-failure-trash"
+	local metadata=""
+	local wt_root=""
+	make_repo_with_worktree "$repo_path" "$wt_path" "feature/degraded-remove-failure"
+	wt_root=$(/usr/bin/git -C "$wt_path" rev-parse --show-toplevel) || fail "remove failure root became unreadable"
+	mkdir -p "$trash_root"
+
+	if (
+		remove_archived_worktree_path() {
+			return 1
+		}
+		AIDEVOPS_WORKTREE_TRASH_ROOT="$trash_root" \
+			_cleanup_single_worktree "$repo_path" "$wt_path" \
+			"feature/degraded-remove-failure" "$(date +%s)" "owner/repo" "main"
+	); then
+		fail "degraded native removal failure was reported as complete"
+	fi
+
+	[[ -d "$wt_path" ]] || fail "native removal failure lost the registered source"
+	compgen -G "${trash_root}/aidevops-worktree-cleanup-*/wt-degraded-remove-failure" >/dev/null ||
+		fail "native removal failure lost the completed archive"
+	metadata=$(/usr/bin/git -C "$repo_path" worktree list --porcelain) || fail "remove failure metadata became unreadable"
+	printf '%s\n' "$metadata" | grep -Fqx "worktree $wt_root" || fail "remove failure pruned exact metadata"
+	if [[ -f "$UNREGISTER_LOG" ]] && grep -Fxq "$wt_path" "$UNREGISTER_LOG"; then
+		fail "native removal failure unregistered partial cleanup"
+	fi
+	grep -q 'recoverable-remove-failed.*mode=skipped' "$AIDEVOPS_CLEANUP_LOG" || fail "remove failure was not audited as skipped"
+	pass "pulse degraded cleanup preserves source and archive when native removal fails"
 	return 0
 }
 
@@ -405,14 +557,52 @@ test_zombie_reaper_fails_closed_on_stale_or_indeterminate_evidence() {
 	return 0
 }
 
+test_permanent_removal_failure_has_no_git_fallback() {
+	local repo_path="${TEST_ROOT}/repo-no-fallback"
+	local wt_path="${TEST_ROOT}/wt-no-fallback"
+	local fallback_log="${TEST_ROOT}/git-remove-fallback.log"
+	make_repo_with_worktree "$repo_path" "$wt_path" "feature/no-fallback"
+
+	if ! (
+		remove_worktree_path_permanently() {
+			return 1
+		}
+		git() {
+			local all_args="$*"
+			if [[ "$all_args" == *"worktree remove"* ]]; then
+				printf '%s\n' "$all_args" >>"$fallback_log"
+				return 0
+			fi
+			"$GIT_BIN" "$@"
+			return $?
+		}
+		if _pc_permanently_remove_eligible_orphan "$repo_path" "$wt_path" \
+			"feature/no-fallback" "verified stale orphan" 0 "" "repo-no-fallback" "test=context"; then
+			exit 1
+		fi
+		exit 0
+	); then
+		fail "permanent helper refusal triggered a Git removal fallback"
+	fi
+	[[ -d "$wt_path" ]] || fail "failed permanent helper did not preserve the worktree"
+	[[ ! -s "$fallback_log" ]] || fail "failed permanent helper invoked git worktree remove"
+	pass "pulse cleanup never bypasses a failed permanent removal helper"
+	return 0
+}
+
 test_current_cwd_skip
 test_orphan_removal_unregisters
+test_locked_orphan_is_preserved
+test_late_write_before_permanent_remove_is_preserved
 test_orphan_crash_skips_closed_issue_comment
 test_orphan_crash_keeps_open_issue_recovery
 test_zombie_reaper_requires_ledger_repo
 test_zombie_reaper_uses_ledger_repo_and_pid
 test_zombie_reaper_rejects_unverified_completion
 test_zombie_reaper_fails_closed_on_stale_or_indeterminate_evidence
+test_permanent_removal_failure_has_no_git_fallback
 test_degraded_orphan_removal_is_recoverable
+test_degraded_orphan_lock_race_is_preserved
+test_degraded_orphan_remove_failure_preserves_source_and_archive
 
 exit 0

--- a/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
@@ -11,6 +11,14 @@ set -uo pipefail
 TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 CLEAN_LIB_PATH="${TEST_SCRIPTS_DIR}/worktree-clean-lib.sh"
 AUDIT_HELPER_PATH="${TEST_SCRIPTS_DIR}/audit-worktree-removal-helper.sh"
+GIT_BIN="${AIDEVOPS_TEST_GIT_BIN:-/usr/bin/git}"
+
+# Keep isolated fixture mutations on native Git. The repository-level canonical
+# guard is tested separately and must not classify temporary main worktrees.
+git() {
+	"$GIT_BIN" "$@"
+	return $?
+}
 
 TEST_ROOT=$(mktemp -d)
 trap 'rm -rf "$TEST_ROOT"' EXIT
@@ -301,6 +309,36 @@ test_cleanup_lease_released_when_removal_guard_blocks() {
 	[[ -f "$release_marker" ]] || rc=1
 	print_result "cleanup lease releases when removal guard blocks" "$rc" \
 		"Expected guarded skip to conditionally release cleanup PID ownership"
+	return 0
+}
+
+test_remove_merged_reports_metadata_verification_failure() {
+	local repo_path="${TEST_ROOT}/repo-removal-failure-status"
+	local wt_path="${TEST_ROOT}/wt-removal-failure-status"
+	local log_file="${TEST_ROOT}/removal-failure-status.log"
+	local branch="feature/gh-99037-removal-failure-status"
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+	setup_repo "$repo_path" || rc=1
+	git -C "$repo_path" checkout -q -b "$branch" || rc=1
+	printf 'removal failure status\n' >"$repo_path/removal-failure-status.txt" || rc=1
+	git -C "$repo_path" add removal-failure-status.txt || rc=1
+	git -C "$repo_path" commit -q -m "removal failure status branch" || rc=1
+	git -C "$repo_path" checkout -q main || rc=1
+	git -C "$repo_path" worktree add -q "$wt_path" "$branch" || rc=1
+
+	if (
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		prune_missing_worktree_metadata() { return 1; }
+		_clean_remove_merged "main" "$repo_path" "false" "$branch" "" "true" "" >/dev/null
+	); then
+		rc=1
+	fi
+	[[ ! -d "$wt_path" ]] || rc=1
+	assert_file_contains "$log_file" "worktree-skipped.*metadata-prune-failed.*mode=partial-cleanup" || rc=1
+	print_result "remove merged reports metadata verification failure" "$rc" \
+		"Expected aggregate cleanup status to retain a destructive-path failure"
 	return 0
 }
 
@@ -703,6 +741,101 @@ test_closed_issue_dirty_unproven_branch_stashes_and_preserves_branch() {
 	return 0
 }
 
+test_closed_issue_dirty_lock_race_preserves_files() {
+	local repo_path="${TEST_ROOT}/repo-closed-issue-dirty-race"
+	local wt_path="${TEST_ROOT}/wt-closed-issue-dirty-race"
+	local log_file="${TEST_ROOT}/closed-issue-dirty-race-cleanup.log"
+	local wrapper_path="${TEST_ROOT}/closed-issue-dirty-race-git"
+	local concurrent_stash_marker="${TEST_ROOT}/closed-issue-dirty-race-concurrent-stash"
+	local final_race_marker="${TEST_ROOT}/closed-issue-dirty-race-final"
+	local branch="feature/auto-20260520-gh99033"
+	local foreign_branch="feature/foreign-concurrent-stash"
+	local foreign_wt_path="${TEST_ROOT}/wt-foreign-concurrent-stash"
+	local expected_status=""
+	local actual_status=""
+	local expected_tracked=""
+	local expected_untracked=""
+	local metadata=""
+	local wt_root=""
+	local stash_count=0
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+	setup_repo "$repo_path" || rc=1
+	git -C "$repo_path" checkout -q -b "$branch" || rc=1
+	printf 'closed issue dirty race\n' >"$repo_path/closed-issue-dirty-race.txt" || rc=1
+	git -C "$repo_path" add closed-issue-dirty-race.txt || rc=1
+	git -C "$repo_path" commit -q -m "closed issue dirty race branch" || rc=1
+	git -C "$repo_path" checkout -q main || rc=1
+	git -C "$repo_path" worktree add -q "$wt_path" "$branch" || rc=1
+	git -C "$repo_path" worktree add -q -b "$foreign_branch" "$foreign_wt_path" main || rc=1
+	wt_root=$(git -C "$wt_path" rev-parse --show-toplevel) || rc=1
+	printf 'dirty tracked state\n' >>"$wt_path/closed-issue-dirty-race.txt" || rc=1
+	printf 'dirty untracked state\n' >"$wt_path/untracked-race.txt" || rc=1
+	printf 'foreign concurrent state\n' >"$foreign_wt_path/foreign-stash.txt" || rc=1
+	expected_status=$(git -C "$wt_path" status --porcelain --untracked-files=all) || rc=1
+	expected_tracked=$(<"$wt_path/closed-issue-dirty-race.txt")
+	expected_untracked=$(<"$wt_path/untracked-race.txt")
+	cat >"$wrapper_path" <<'RACE_GIT'
+#!/usr/bin/env bash
+if [[ "$*" == *"worktree remove"* && ! -e "${RACE_MARKER:?}" ]]; then
+	: >"$RACE_MARKER"
+	"${REAL_GIT:?}" -C "${RACE_REPO:?}" worktree lock --reason \
+		"foreign-after-stash-archive" "${RACE_WORKTREE:?}" || exit 1
+fi
+exec "${REAL_GIT:?}" "$@"
+RACE_GIT
+	chmod +x "$wrapper_path" || rc=1
+
+	if (
+		cd "$repo_path" || exit 1
+		export AIDEVOPS_REAL_GIT_BIN="$wrapper_path"
+		export REAL_GIT="$GIT_BIN"
+		export RACE_MARKER="$final_race_marker"
+		export RACE_REPO="$repo_path"
+		export RACE_WORKTREE="$wt_path"
+		source_clean_lib_with_stubs || exit 1
+		capture_worktree_process_cwds() {
+			printf '/unrelated-cwd\n'
+			return 0
+		}
+		worktree_has_changes() {
+			local candidate_path="$1"
+			git -C "$candidate_path" status --porcelain 2>/dev/null | grep -q .
+			return $?
+		}
+		git() {
+			local all_args="$*"
+			if [[ "$all_args" == *"-C $wt_path stash push"* && ! -e "$concurrent_stash_marker" ]]; then
+				"$GIT_BIN" "$@" || return $?
+				: >"$concurrent_stash_marker"
+				"$GIT_BIN" -C "$foreign_wt_path" stash push -u \
+					-m "foreign concurrent stash" >/dev/null 2>&1 || return 1
+				return 0
+			fi
+			"$GIT_BIN" "$@"
+			return $?
+		}
+		_clean_remove_classified_worktree "$wt_path" "$branch" "true" "true" \
+			"test=dirty-lock-race" "$repo_path"
+	); then
+		rc=1
+	fi
+
+	actual_status=$(git -C "$wt_path" status --porcelain --untracked-files=all 2>/dev/null) || rc=1
+	metadata=$(git -C "$repo_path" worktree list --porcelain 2>/dev/null) || rc=1
+	stash_count=$(git -C "$repo_path" stash list 2>/dev/null | wc -l | tr -d ' ') || stash_count=0
+	[[ -e "$concurrent_stash_marker" && -e "$final_race_marker" && -d "$wt_path" ]] || rc=1
+	[[ "$(<"$wt_path/closed-issue-dirty-race.txt")" == "$expected_tracked" ]] || rc=1
+	[[ "$(<"$wt_path/untracked-race.txt")" == "$expected_untracked" ]] || rc=1
+	[[ "$actual_status" == "$expected_status" ]] || rc=1
+	printf '%s\n' "$metadata" | grep -Fqx "worktree $wt_root" || rc=1
+	printf '%s\n' "$metadata" | grep -Fqx "locked foreign-after-stash-archive" || rc=1
+	[[ "$stash_count" -ge 2 ]] || rc=1
+	print_result "closed issue dirty lock race preserves files" "$rc" \
+		"Expected exact concurrent stash recovery, restored dirty files, and foreign lock authority"
+	return 0
+}
+
 echo "=== test-worktree-cleanup-branch-merged-owned-skip.sh ==="
 test_protected_pass_set_blocks_branch_merged_removal
 test_terminal_pr_proof_bypasses_protected_pass_skip
@@ -710,6 +843,7 @@ test_terminal_pr_cleanup_waits_for_deferred_parent_exit
 test_dead_marker_preserves_replacement_owner
 test_terminal_cleanup_requires_removal_lease
 test_cleanup_lease_released_when_removal_guard_blocks
+test_remove_merged_reports_metadata_verification_failure
 test_squash_merged_pr_without_ancestor_proof_classifies
 test_prefetched_merged_pr_metadata_skips_exact_head_lookup
 test_merged_pr_list_passes_explicit_repo_slug
@@ -721,6 +855,7 @@ test_remote_deleted_without_ancestor_proof_skips
 test_closed_issue_unproven_branch_removes_worktree_preserves_branch
 test_fix_numeric_closed_issue_branch_removes_worktree_preserves_branch
 test_closed_issue_dirty_unproven_branch_stashes_and_preserves_branch
+test_closed_issue_dirty_lock_race_preserves_files
 
 printf '\nResults: %d/%d passed, %d failed.\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN" "$TESTS_FAILED"
 if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-worktree-cleanup-claim-guard.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-claim-guard.sh
@@ -36,6 +36,14 @@ TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 HELPER_PATH="${TEST_SCRIPTS_DIR}/interactive-session-helper.sh"
 STAMP_LIB_PATH="${TEST_SCRIPTS_DIR}/interactive-session-helper-stamp.sh"
 CLEAN_LIB_PATH="${TEST_SCRIPTS_DIR}/worktree-clean-lib.sh"
+GIT_BIN="${AIDEVOPS_TEST_GIT_BIN:-/usr/bin/git}"
+
+# Keep isolated fixture mutations on native Git. Canonical mutation-guard
+# behavior is covered independently and is not part of this claim test.
+git() {
+	"$GIT_BIN" "$@"
+	return $?
+}
 
 # NOT readonly — shared-constants.sh declares readonly RED/GREEN/RESET
 # and the collision under `set -e` silently kills the test shell.

--- a/.agents/scripts/tests/test-worktree-helper-nested-path-guard.sh
+++ b/.agents/scripts/tests/test-worktree-helper-nested-path-guard.sh
@@ -48,9 +48,17 @@
 set -uo pipefail
 
 TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+GIT_BIN="${AIDEVOPS_TEST_GIT_BIN:-/usr/bin/git}"
 TEST_RED=$'\033[0;31m'
 TEST_GREEN=$'\033[0;32m'
 TEST_RESET=$'\033[0m'
+
+# Keep the temporary repository fixture on native Git. The helper's own
+# canonical guard is outside this path-validation regression's scope.
+git() {
+	"$GIT_BIN" "$@"
+	return $?
+}
 
 TESTS_RUN=0
 TESTS_FAILED=0

--- a/.agents/scripts/tests/test-worktree-metadata-prune.sh
+++ b/.agents/scripts/tests/test-worktree-metadata-prune.sh
@@ -15,6 +15,7 @@ RECOVERABLE_LINKED="${TEST_ROOT}/recoverable-linked"
 RECOVERABLE_MISSING_LINKED="${TEST_ROOT}/recoverable-missing-linked"
 MOVE_FAILED_LINKED="${TEST_ROOT}/move-failed-linked"
 PRUNE_FAILED_LINKED="${TEST_ROOT}/prune-failed-linked"
+REMOVE_FAILED_LINKED="${TEST_ROOT}/remove-failed-linked"
 DIRTY_LINKED="${TEST_ROOT}/dirty-linked"
 OWNERSHIP_LINKED="${TEST_ROOT}/ownership-linked"
 INTEGRATION_LINKED="${TEST_ROOT}/integration-linked"
@@ -26,8 +27,11 @@ SHIM_BIN="${TEST_ROOT}/bin"
 TEST_PATH="${SHIM_BIN}:/usr/bin:/bin:/usr/sbin:/sbin"
 FAILING_GIT="${TEST_ROOT}/failing-git"
 QUERY_FAILING_GIT="${TEST_ROOT}/query-failing-git"
+MALFORMED_QUERY_GIT="${TEST_ROOT}/malformed-query-git"
+ALIAS_QUERY_GIT="${TEST_ROOT}/alias-query-git"
 POST_PRUNE_QUERY_FAILING_GIT="${TEST_ROOT}/post-prune-query-failing-git"
 POST_PRUNE_QUERY_STATE="${TEST_ROOT}/post-prune-query-state"
+POST_PRUNE_MARKER="${TEST_ROOT}/post-prune-invoked"
 RUNTIME_PID=""
 
 teardown() {
@@ -54,9 +58,11 @@ printf 'seed\n' >"${REPO}/README.md"
 /usr/bin/git -C "$REPO" worktree add -q -b feature/recoverable-missing "$RECOVERABLE_MISSING_LINKED"
 /usr/bin/git -C "$REPO" worktree add -q -b feature/recoverable-move-failure "$MOVE_FAILED_LINKED"
 /usr/bin/git -C "$REPO" worktree add -q -b feature/recoverable-prune-failure "$PRUNE_FAILED_LINKED"
+/usr/bin/git -C "$REPO" worktree add -q -b feature/recoverable-remove-failure "$REMOVE_FAILED_LINKED"
 /usr/bin/git -C "$REPO" worktree add -q -b feature/recoverable-dirty "$DIRTY_LINKED"
 /usr/bin/git -C "$REPO" worktree add -q -b feature/recoverable-ownership "$OWNERSHIP_LINKED"
 /usr/bin/git -C "$REPO" worktree add -q -b feature/recoverable-integration "$INTEGRATION_LINKED"
+/usr/bin/git -C "$REPO" worktree add -q -b feature/recoverable-home-archive "$RECOVERABLE_FALLBACK_SOURCE"
 ln -s "$GIT_SHIM" "${SHIM_BIN}/git"
 
 if PATH="$TEST_PATH" git -C "$REPO" worktree prune >/dev/null 2>&1; then
@@ -86,7 +92,7 @@ cat >"$FAILING_GIT" <<'EOF'
 if [[ "$*" == *"worktree prune"* ]]; then
 	exit 1
 fi
-if [[ "$*" == *"worktree list --porcelain"* ]]; then
+if [[ "$*" == *"worktree list --porcelain -z"* ]]; then
 	/usr/bin/git "$@" || exit 1
 	printf 'worktree %s\n\n' "${FAILED_LINKED_FOR_TEST:?}"
 	exit 0
@@ -127,6 +133,61 @@ if AIDEVOPS_REAL_GIT_BIN="$QUERY_FAILING_GIT" \
 fi
 printf 'PASS metadata query failure cannot report cleanup success\n'
 
+cat >"$MALFORMED_QUERY_GIT" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"worktree list --porcelain -z"* ]]; then
+	case "${MALFORMED_QUERY_MODE:?}" in
+	missing-identity) printf 'worktree %s\0\0' "${MALFORMED_QUERY_OTHER:?}" ;;
+	empty-head) printf 'worktree %s\0HEAD \0branch refs/heads/test\0\0' "${MALFORMED_QUERY_OTHER:?}" ;;
+	empty-branch) printf 'worktree %s\0HEAD 0123456789abcdef0123456789abcdef01234567\0branch \0\0' "${MALFORMED_QUERY_OTHER:?}" ;;
+	whitespace-head) printf 'worktree %s\0HEAD \t\0branch refs/heads/test\0\0' "${MALFORMED_QUERY_OTHER:?}" ;;
+	invalid-head) printf 'worktree %s\0HEAD deadbeef\0branch refs/heads/test\0\0' "${MALFORMED_QUERY_OTHER:?}" ;;
+	whitespace-branch) printf 'worktree %s\0HEAD 0123456789abcdef0123456789abcdef01234567\0branch \t\0\0' "${MALFORMED_QUERY_OTHER:?}" ;;
+	invalid-branch) printf 'worktree %s\0HEAD 0123456789abcdef0123456789abcdef01234567\0branch refs/heads/bad..name\0\0' "${MALFORMED_QUERY_OTHER:?}" ;;
+	invalid-namespace) printf 'worktree %s\0HEAD 0123456789abcdef0123456789abcdef01234567\0branch refs/tags/test\0\0' "${MALFORMED_QUERY_OTHER:?}" ;;
+	*) exit 1 ;;
+	esac
+	exit 0
+fi
+exec /usr/bin/git "$@"
+EOF
+chmod +x "$MALFORMED_QUERY_GIT"
+for malformed_query_mode in missing-identity empty-head empty-branch whitespace-head invalid-head \
+	whitespace-branch invalid-branch invalid-namespace; do
+	if AIDEVOPS_REAL_GIT_BIN="$MALFORMED_QUERY_GIT" \
+		MALFORMED_QUERY_MODE="$malformed_query_mode" \
+		MALFORMED_QUERY_OTHER="${TEST_ROOT}/different-malformed-target" \
+		prune_missing_worktree_metadata "$REPO" "${TEST_ROOT}/missing-malformed-query-target"; then
+		printf 'FAIL malformed status-zero metadata mode %s was treated as authoritative absence\n' \
+			"$malformed_query_mode"
+		exit 1
+	fi
+done
+printf 'PASS malformed status-zero metadata cannot prove exact target absence\n'
+
+alias_physical_parent="${TEST_ROOT}/metadata-physical-parent"
+alias_logical_parent="${TEST_ROOT}/metadata-logical-parent"
+alias_target="${alias_logical_parent}/missing-alias-target"
+mkdir -p "$alias_physical_parent"
+ln -s "$alias_physical_parent" "$alias_logical_parent"
+alias_physical_target="$(cd "$alias_physical_parent" && pwd -P)/missing-alias-target"
+cat >"$ALIAS_QUERY_GIT" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"worktree list --porcelain -z"* ]]; then
+	printf 'worktree %s\0HEAD 0123456789abcdef0123456789abcdef01234567\0branch refs/heads/test\0\0' \
+		"${ALIAS_QUERY_PHYSICAL:?}"
+	exit 0
+fi
+exec /usr/bin/git "$@"
+EOF
+chmod +x "$ALIAS_QUERY_GIT"
+if ! ALIAS_QUERY_PHYSICAL="$alias_physical_target" \
+	_worktree_metadata_contains_path "$ALIAS_QUERY_GIT" "$REPO" "$alias_target"; then
+	printf 'FAIL physical parent alias did not match exact Git metadata\n'
+	exit 1
+fi
+printf 'PASS physical parent alias matches exact missing-worktree metadata\n'
+
 if (
 	_worktree_cleanup_real_git() {
 		return 0
@@ -148,12 +209,14 @@ if [[ "$*" == *"worktree list --porcelain"* ]]; then
 	query_count=$((query_count + 1))
 	printf '%s\n' "$query_count" >"$POST_PRUNE_QUERY_STATE_FOR_TEST"
 	if [[ "$query_count" -eq 1 ]]; then
-		printf 'worktree %s\n\n' "${POST_PRUNE_TARGET_FOR_TEST:?}"
+		printf 'worktree %s\0HEAD 0123456789abcdef0123456789abcdef01234567\0branch refs/heads/test\0\0' \
+			"${POST_PRUNE_TARGET_FOR_TEST:?}"
 		exit 0
 	fi
 	exit 1
 fi
 if [[ "$*" == *"worktree prune"* ]]; then
+	: >"${POST_PRUNE_MARKER_FOR_TEST:?}"
 	exit 0
 fi
 exec /usr/bin/git "$@"
@@ -161,9 +224,16 @@ EOF
 chmod +x "$POST_PRUNE_QUERY_FAILING_GIT"
 if AIDEVOPS_REAL_GIT_BIN="$POST_PRUNE_QUERY_FAILING_GIT" \
 	POST_PRUNE_QUERY_STATE_FOR_TEST="$POST_PRUNE_QUERY_STATE" \
+	POST_PRUNE_MARKER_FOR_TEST="$POST_PRUNE_MARKER" \
 	POST_PRUNE_TARGET_FOR_TEST="${TEST_ROOT}/missing-post-prune-query-target" \
 	prune_missing_worktree_metadata "$REPO" "${TEST_ROOT}/missing-post-prune-query-target"; then
 	printf 'FAIL post-prune metadata query failure was treated as successful cleanup\n'
+	exit 1
+fi
+post_prune_query_count=""
+IFS= read -r post_prune_query_count <"$POST_PRUNE_QUERY_STATE" || post_prune_query_count=""
+if [[ "$post_prune_query_count" != "2" || ! -e "$POST_PRUNE_MARKER" ]]; then
+	printf 'FAIL post-prune query fixture did not reach prune and the second metadata query\n'
 	exit 1
 fi
 printf 'PASS post-prune metadata query failure cannot report cleanup success\n'
@@ -249,7 +319,7 @@ _branch_exists_on_any_remote() {
 }
 
 missing_move_target="${TEST_ROOT}/never-created-worktree"
-if ! _clean_move_worktree_recoverably "$missing_move_target" ||
+if ! _clean_archive_worktree_recoverably "$missing_move_target" ||
 	[[ "$_WT_CLEAN_RECOVERABLE_FAILURE_DETAIL" != "path-already-gone" ]]; then
 	printf 'FAIL absent recoverable source was not treated as idempotent success\n'
 	exit 1
@@ -295,37 +365,29 @@ compgen -G "${RECOVERABLE_TRASH}/*/recoverable-linked" >/dev/null || {
 	printf 'FAIL recoverable cleanup did not preserve candidate files in trash\n'
 	exit 1
 }
-printf 'PASS degraded cleanup emits completion only after recoverable move and exact metadata absence\n'
+printf 'PASS degraded cleanup emits completion only after archive retention and exact metadata absence\n'
 
-mkdir -p "$RECOVERABLE_FALLBACK_SOURCE" "$RECOVERABLE_FALLBACK_HOME" "$RECOVERABLE_FALLBACK_BIN"
-printf 'recoverable fixture\n' >"${RECOVERABLE_FALLBACK_SOURCE}/fixture.txt"
-for backend in trash gio; do
-	cat >"${RECOVERABLE_FALLBACK_BIN}/${backend}" <<'EOF'
-#!/usr/bin/env bash
-exit 1
-EOF
-	chmod +x "${RECOVERABLE_FALLBACK_BIN}/${backend}"
-done
+mkdir -p "$RECOVERABLE_FALLBACK_HOME" "$RECOVERABLE_FALLBACK_BIN"
 if ! HOME="$RECOVERABLE_FALLBACK_HOME" PATH="$RECOVERABLE_FALLBACK_BIN:/usr/bin:/bin" \
-	_clean_move_worktree_recoverably "$RECOVERABLE_FALLBACK_SOURCE"; then
-	printf 'FAIL recoverable cleanup stopped after trash and gio backend failures: %s\n' \
+	_clean_archive_worktree_recoverably "$RECOVERABLE_FALLBACK_SOURCE"; then
+	printf 'FAIL recoverable cleanup could not create its home trash archive: %s\n' \
 		"${_WT_CLEAN_RECOVERABLE_FAILURE_DETAIL:-unknown}"
 	exit 1
 fi
-[[ ! -e "$RECOVERABLE_FALLBACK_SOURCE" ]] || {
-	printf 'FAIL recoverable cleanup fallback left the source path in place\n'
+[[ -d "$RECOVERABLE_FALLBACK_SOURCE" ]] || {
+	printf 'FAIL recoverable archive preparation removed the registered source\n'
 	exit 1
 }
-compgen -G "${RECOVERABLE_FALLBACK_HOME}/.Trash/aidevops-worktree-cleanup-*/recoverable-fallback-source" >/dev/null || {
-	printf 'FAIL recoverable cleanup did not fall through to the home trash bucket\n'
+[[ -d "$_WT_CLEAN_RECOVERABLE_ARCHIVE_PATH" && -e "$_WT_CLEAN_RECOVERABLE_ARCHIVE_PATH/.git" ]] || {
+	printf 'FAIL recoverable cleanup did not create a complete home trash archive\n'
 	exit 1
 }
-printf 'PASS failed trash and gio backends fall through to the home trash bucket\n'
+printf 'PASS archive preparation retains the source and creates a home trash copy\n'
 
 move_failure_output=""
 if move_failure_output=$(
 	cd "$REPO" || exit 1
-	_clean_move_worktree_recoverably() {
+	_clean_archive_worktree_recoverably() {
 		local worktree_path="$1"
 		: "$worktree_path"
 		return 1
@@ -333,14 +395,14 @@ if move_failure_output=$(
 	_clean_remove_classified_worktree "$MOVE_FAILED_LINKED" "feature/recoverable-move-failure" \
 		"false" "false" "visibility=degraded" "$REPO" "$_WT_CLEAN_MODE_RECOVERABLE" "true"
 ); then
-	printf 'FAIL recoverable move failure reported cleanup success\n'
+	printf 'FAIL recoverable archive failure reported cleanup success\n'
 	exit 1
 fi
 [[ -d "$MOVE_FAILED_LINKED" && "$move_failure_output" != *"$_WT_CLEAN_COMPLETED_EVENT"* ]] || {
-	printf 'FAIL recoverable move failure removed candidate or emitted completion\n'
+	printf 'FAIL recoverable archive failure removed candidate or emitted completion\n'
 	exit 1
 }
-printf 'PASS recoverable move failure remains fail-closed with zero completion events\n'
+printf 'PASS recoverable archive failure remains fail-closed with zero completion events\n'
 
 prune_failure_output=""
 if prune_failure_output=$(
@@ -362,11 +424,43 @@ fi
 	printf 'FAIL metadata prune failure emitted completion or left an irreversible state\n'
 	exit 1
 }
-/usr/bin/git -C "$REPO" worktree list --porcelain | grep -Fqx "worktree $PRUNE_FAILED_LINKED" || {
-	printf 'FAIL metadata prune failure fixture did not preserve stale metadata for recovery\n'
+if /usr/bin/git -C "$REPO" worktree list --porcelain | grep -Fqx "worktree $PRUNE_FAILED_LINKED"; then
+	printf 'FAIL native Git removal left stale metadata before verification failed\n'
+	exit 1
+fi
+compgen -G "${RECOVERABLE_TRASH}/aidevops-worktree-cleanup-*/prune-failed-linked" >/dev/null || {
+	printf 'FAIL metadata verification failure lost the recoverable archive\n'
 	exit 1
 }
-printf 'PASS metadata prune failure remains recoverable and emits zero completion events\n'
+printf 'PASS metadata verification failure retains its archive and emits zero completion events\n'
+
+remove_failure_output=""
+if remove_failure_output=$(
+	cd "$REPO" || exit 1
+	remove_archived_worktree_path() {
+		return 1
+	}
+	AIDEVOPS_WORKTREE_TRASH_ROOT="$RECOVERABLE_TRASH" \
+		_clean_remove_classified_worktree "$REMOVE_FAILED_LINKED" "feature/recoverable-remove-failure" \
+		"false" "false" "visibility=degraded" "$REPO" "$_WT_CLEAN_MODE_RECOVERABLE" "true"
+); then
+	printf 'FAIL native removal failure reported cleanup success\n'
+	exit 1
+fi
+[[ -d "$REMOVE_FAILED_LINKED" && "$remove_failure_output" != *"$_WT_CLEAN_COMPLETED_EVENT"* ]] || {
+	printf 'FAIL native removal failure lost its source or emitted completion\n'
+	exit 1
+}
+remove_failure_metadata=$(/usr/bin/git -C "$REPO" worktree list --porcelain) || exit 1
+printf '%s\n' "$remove_failure_metadata" | grep -Fqx "worktree $REMOVE_FAILED_LINKED" || {
+	printf 'FAIL native removal failure pruned exact metadata\n'
+	exit 1
+}
+compgen -G "${RECOVERABLE_TRASH}/aidevops-worktree-cleanup-*/remove-failed-linked" >/dev/null || {
+	printf 'FAIL native removal failure lost its completed archive\n'
+	exit 1
+}
+printf 'PASS native removal failure preserves source, metadata, archive, and zero completion events\n'
 
 printf 'dirty state\n' >"${DIRTY_LINKED}/dirty.txt"
 dirty_output=""

--- a/.agents/scripts/tests/test-worktree-removal-audit.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit.sh
@@ -32,6 +32,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 AUDIT_HELPER="${SCRIPT_DIR}/../audit-worktree-removal-helper.sh"
 COMMANDS_HELPER="${SCRIPT_DIR}/../worktree-helper-cmds.sh"
+CLEAN_HELPER="${SCRIPT_DIR}/../worktree-clean-lib.sh"
+SKILL_PR_HELPER="${SCRIPT_DIR}/../skill-update-pr-lib.sh"
+GIT_BIN="${AIDEVOPS_TEST_GIT_BIN:-/usr/bin/git}"
 
 TESTS_RUN=0
 TESTS_PASSED=0
@@ -90,6 +93,21 @@ assert_line_count() {
 	fi
 	echo "  expected $expected lines, got $actual"
 	return 1
+}
+
+create_git_worktree_fixture() {
+	local repo_path="$1"
+	local wt_path="$2"
+	local branch_name="$3"
+
+	"$GIT_BIN" init -q -b main "$repo_path" || return 1
+	"$GIT_BIN" -C "$repo_path" config user.email test@example.invalid || return 1
+	"$GIT_BIN" -C "$repo_path" config user.name 'Aidevops Test' || return 1
+	printf 'base\n' >"${repo_path}/README.md" || return 1
+	"$GIT_BIN" -C "$repo_path" add README.md || return 1
+	"$GIT_BIN" -C "$repo_path" commit -q -m init || return 1
+	"$GIT_BIN" -C "$repo_path" worktree add -q -b "$branch_name" "$wt_path" main || return 1
+	return 0
 }
 
 # =============================================================================
@@ -342,10 +360,11 @@ test_guard_refuses_other_process_cwd() {
 # =============================================================================
 test_permanent_helper_removes_and_logs() {
 	local log_file="${TEST_DIR}/t9-cleanup.log"
+	local repo_path="${TEST_DIR}/old-repo"
 	export AIDEVOPS_CLEANUP_LOG="$log_file"
 
 	local wt_path="${TEST_DIR}/old-wt"
-	mkdir -p "$wt_path"
+	create_git_worktree_fixture "$repo_path" "$wt_path" "feature/old" || return 1
 
 	unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
 	# shellcheck source=../audit-worktree-removal-helper.sh
@@ -363,6 +382,728 @@ test_permanent_helper_removes_and_logs() {
 	assert_file_contains "$log_file" "worktree-removed.*age-eligible.*mode=permanent" || rc=1
 	print_result "permanent_helper_removes_and_logs" "$rc" \
 		"Expected permanent removal audit. Log: $(cat "$log_file" 2>/dev/null)"
+	return 0
+}
+
+# =============================================================================
+# An inaccessible candidate must not be inferred to be a non-Git directory.
+# =============================================================================
+test_guard_fails_closed_on_inaccessible_candidate() {
+	local log_file="${TEST_DIR}/inaccessible-cleanup.log"
+	local repo_path="${TEST_DIR}/inaccessible-repo"
+	local wt_path="${TEST_DIR}/inaccessible-worktree"
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+
+	create_git_worktree_fixture "$repo_path" "$wt_path" "feature/inaccessible" || rc=1
+	chmod 000 "$wt_path" || rc=1
+	if (
+		unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+		# shellcheck source=../audit-worktree-removal-helper.sh
+		source "$AUDIT_HELPER"
+		worktree_removal_guard "$wt_path" "test.sh" "manual" ""
+	); then
+		rc=1
+	fi
+	chmod 700 "$wt_path" || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	assert_file_contains "$log_file" "worktree-skipped.*git-metadata-unreadable.*mode=skipped" || rc=1
+	print_result "guard_fails_closed_on_inaccessible_candidate" "$rc" \
+		"Expected inaccessible candidate to remain and report unreadable metadata"
+	return 0
+}
+
+# =============================================================================
+# NUL-delimited porcelain parsing preserves unusual paths and exact block
+# ownership: a lock in the adjacent block must not taint an unlocked candidate.
+# =============================================================================
+test_git_lock_parser_handles_unusual_paths_and_adjacent_blocks() {
+	local repo_path="${TEST_DIR}/parser-repo"
+	local wt_path="${TEST_DIR}/parser-worktree"$'\n'"with-newline"
+	local adjacent_path="${TEST_DIR}/parser-adjacent"
+	local wt_path_real=""
+	local git_state=""
+	local rc=0
+
+	create_git_worktree_fixture "$repo_path" "$wt_path" "feature/parser" || rc=1
+	"$GIT_BIN" -C "$repo_path" worktree add -q -b "feature/parser-adjacent" "$adjacent_path" main || rc=1
+	"$GIT_BIN" -C "$repo_path" worktree lock --reason "adjacent-preservation" "$adjacent_path" || rc=1
+	wt_path_real=$(cd "$wt_path" && pwd -P) || rc=1
+	git_state=$(_worktree_git_lock_state "$wt_path" "$wt_path_real") || rc=1
+	[[ "$git_state" == "$_WT_GIT_STATE_CLEAR" ]] || rc=1
+	"$GIT_BIN" -C "$repo_path" worktree lock --reason "candidate-preservation" "$wt_path" || rc=1
+	git_state=$(_worktree_git_lock_state "$wt_path" "$wt_path_real") || rc=1
+	[[ "$git_state" == "$_WT_GIT_STATE_LOCKED" ]] || rc=1
+	print_result "git_lock_parser_handles_unusual_paths_and_adjacent_blocks" "$rc" \
+		"Expected exact NUL-safe lock ownership for unusual worktree paths"
+	return 0
+}
+
+# =============================================================================
+# A status-zero list is not authoritative unless every block is structurally
+# complete. Missing, duplicate, contradictory, or nested fields fail closed.
+# =============================================================================
+test_git_lock_parser_rejects_malformed_blocks() {
+	local wt_path="${TEST_DIR}/malformed-parser-worktree"
+	local other_path="${TEST_DIR}/malformed-parser-other"
+	local valid_head="0123456789abcdef0123456789abcdef01234567"
+	local other_head="89abcdef0123456789abcdef0123456789abcdef"
+	local malformed_mode=""
+	local git_state=""
+	local rc=0
+	mkdir -p "$wt_path"
+
+	git() {
+		local all_args="$*"
+		case "$all_args" in
+		*"rev-parse --show-toplevel"*) printf '%s\n' "$wt_path" ;;
+		*"worktree list --porcelain -z"*)
+			case "$malformed_mode" in
+			unterminated) printf 'worktree %s\0HEAD %s\0branch refs/heads/test\0' "$wt_path" "$valid_head" ;;
+			duplicate-start) printf 'worktree %s\0HEAD %s\0worktree %s\0HEAD %s\0branch refs/heads/other\0\0' "$wt_path" "$valid_head" "$other_path" "$other_head" ;;
+			missing-head) printf 'worktree %s\0branch refs/heads/test\0\0' "$wt_path" ;;
+			missing-identity) printf 'worktree %s\0HEAD %s\0\0' "$wt_path" "$valid_head" ;;
+			contradictory) printf 'worktree %s\0HEAD %s\0branch refs/heads/test\0detached\0\0' "$wt_path" "$valid_head" ;;
+			duplicate-head) printf 'worktree %s\0HEAD %s\0HEAD %s\0branch refs/heads/test\0\0' "$wt_path" "$valid_head" "$other_head" ;;
+			empty-head) printf 'worktree %s\0HEAD \0branch refs/heads/test\0\0' "$wt_path" ;;
+			empty-branch) printf 'worktree %s\0HEAD %s\0branch \0\0' "$wt_path" "$valid_head" ;;
+			whitespace-head) printf 'worktree %s\0HEAD \t\0branch refs/heads/test\0\0' "$wt_path" ;;
+			invalid-head) printf 'worktree %s\0HEAD deadbeef\0branch refs/heads/test\0\0' "$wt_path" ;;
+			whitespace-branch) printf 'worktree %s\0HEAD %s\0branch \t\0\0' "$wt_path" "$valid_head" ;;
+			invalid-branch) printf 'worktree %s\0HEAD %s\0branch refs/heads/bad..name\0\0' "$wt_path" "$valid_head" ;;
+			invalid-namespace) printf 'worktree %s\0HEAD %s\0branch refs/tags/test\0\0' "$wt_path" "$valid_head" ;;
+			esac
+			;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
+	for malformed_mode in unterminated duplicate-start missing-head missing-identity contradictory duplicate-head \
+		empty-head empty-branch whitespace-head invalid-head whitespace-branch invalid-branch invalid-namespace; do
+		git_state=$(_worktree_git_lock_state "$wt_path" "$wt_path") || rc=1
+		[[ "$git_state" == "$_WT_GIT_STATE_UNREADABLE" ]] || rc=1
+	done
+	unset -f git
+	print_result "git_lock_parser_rejects_malformed_blocks" "$rc" \
+		"Expected malformed structure, object IDs, and branch refs to remain unreadable"
+	return 0
+}
+
+# =============================================================================
+# Missing paths are normalized through their physical parent so aliases such as
+# macOS /var and /private/var compare to the same Git metadata path.
+# =============================================================================
+test_missing_worktree_physical_parent_alias() {
+	local physical_parent="${TEST_DIR}/physical-parent"
+	local alias_parent="${TEST_DIR}/alias-parent"
+	local expected_parent=""
+	local resolved_path=""
+	local rc=0
+	mkdir -p "$physical_parent"
+	ln -s "$physical_parent" "$alias_parent" || rc=1
+	expected_parent=$(cd "$physical_parent" && pwd -P) || rc=1
+	resolved_path=$(_worktree_physical_path "${alias_parent}/missing-worktree") || rc=1
+	[[ "$resolved_path" == "${expected_parent}/missing-worktree" ]] || rc=1
+	print_result "missing_worktree_physical_parent_alias" "$rc" \
+		"Expected a missing aliased path to resolve through its physical parent"
+	return 0
+}
+
+# =============================================================================
+# Git remains the final permanent-removal authority. A foreign lock acquired
+# after the initial guard but before `git worktree remove` must preserve the
+# physical path and metadata.
+# =============================================================================
+test_permanent_helper_preserves_lock_acquired_after_guard() {
+	local log_file="${TEST_DIR}/race-cleanup.log"
+	local repo_path="${TEST_DIR}/race-repo"
+	local wt_path="${TEST_DIR}/race-worktree"
+	local wrapper_path="${TEST_DIR}/race-git"
+	local marker_path="${TEST_DIR}/race-lock-injected"
+	local metadata=""
+	local wt_root=""
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+
+	create_git_worktree_fixture "$repo_path" "$wt_path" "feature/race" || rc=1
+	cat >"$wrapper_path" <<'RACE_GIT'
+#!/usr/bin/env bash
+if [[ "$*" == *"worktree remove"* && ! -e "${RACE_MARKER:?}" ]]; then
+	: >"$RACE_MARKER"
+	"${REAL_GIT:?}" -C "${RACE_REPO:?}" worktree lock --reason "foreign-race-lock" "${RACE_WORKTREE:?}" || exit 1
+fi
+exec "${REAL_GIT:?}" "$@"
+RACE_GIT
+	chmod +x "$wrapper_path" || rc=1
+	if (
+		export AIDEVOPS_REAL_GIT_BIN="$wrapper_path"
+		export REAL_GIT="$GIT_BIN"
+		export RACE_MARKER="$marker_path"
+		export RACE_REPO="$repo_path"
+		export RACE_WORKTREE="$wt_path"
+		unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+		# shellcheck source=../audit-worktree-removal-helper.sh
+		source "$AUDIT_HELPER"
+		remove_worktree_path_permanently "$wt_path" "test.sh" "age-eligible"
+	); then
+		rc=1
+	fi
+	[[ -d "$wt_path" && -e "$marker_path" ]] || rc=1
+	wt_root=$("$GIT_BIN" -C "$wt_path" rev-parse --show-toplevel 2>/dev/null) || rc=1
+	metadata=$("$GIT_BIN" -C "$repo_path" worktree list --porcelain) || rc=1
+	printf '%s\n' "$metadata" | grep -Fqx "worktree $wt_root" || rc=1
+	printf '%s\n' "$metadata" | grep -Eq '^locked([[:space:]]|$)' || rc=1
+	assert_file_contains "$log_file" "worktree-skipped.*git-worktree-locked.*mode=skipped" || rc=1
+	print_result "permanent_helper_preserves_lock_acquired_after_guard" "$rc" \
+		"Expected a lock acquired after guard evaluation to block final deletion"
+	return 0
+}
+
+# =============================================================================
+# Recoverable cleanup creates a complete archive while the registered source is
+# still intact, then lets native Git remove the source and exact metadata.
+# =============================================================================
+test_recoverable_archive_then_native_remove() {
+	local repo_path="${TEST_DIR}/archive-repo"
+	local wt_path="${TEST_DIR}/archive-worktree"
+	local trash_root="${TEST_DIR}/archive-trash"
+	local archive_path=""
+	local wt_root=""
+	local metadata=""
+	local rc=0
+	local AIDEVOPS_WORKTREE_TRASH_ROOT="$trash_root"
+
+	create_git_worktree_fixture "$repo_path" "$wt_path" "feature/archive" || rc=1
+	wt_root=$("$GIT_BIN" -C "$wt_path" rev-parse --show-toplevel 2>/dev/null) || rc=1
+	AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" archive_worktree_path_recoverably \
+		"$wt_path" "test.sh" "archive-test" || rc=1
+	archive_path="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
+	[[ -d "$wt_path" && -d "$archive_path" && -e "$archive_path/.git" ]] || rc=1
+	metadata=$("$GIT_BIN" -C "$repo_path" worktree list --porcelain) || rc=1
+	printf '%s\n' "$metadata" | grep -Fqx "worktree $wt_root" || rc=1
+	AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" remove_archived_worktree_path \
+		"$wt_path" "$archive_path" "test.sh" "recoverable-test" \
+		"recovery_path=archive-first" "false" "false" || rc=1
+	AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" prune_missing_worktree_metadata "$repo_path" "$wt_path" || rc=1
+	if "$GIT_BIN" -C "$repo_path" worktree list --porcelain | grep -Fqx "worktree $wt_root"; then
+		rc=1
+	fi
+	[[ ! -e "$wt_path" && -d "$archive_path" && -e "$archive_path/.git" ]] || rc=1
+	print_result "recoverable_archive_then_native_remove" "$rc" \
+		"Expected archive retention after native source and metadata removal"
+	return 0
+}
+
+# =============================================================================
+# A foreign lock acquired after archive completion but before native Git removal
+# must preserve the registered source while the completed archive also remains.
+# =============================================================================
+test_recoverable_archive_preserves_late_lock() {
+	local repo_path="${TEST_DIR}/archive-race-repo"
+	local wt_path="${TEST_DIR}/archive-race-worktree"
+	local trash_root="${TEST_DIR}/archive-race-trash"
+	local wrapper_path="${TEST_DIR}/archive-race-git"
+	local marker_path="${TEST_DIR}/archive-race-lock-injected"
+	local archive_path=""
+	local metadata=""
+	local wt_root=""
+	local rc=0
+	local AIDEVOPS_WORKTREE_TRASH_ROOT="$trash_root"
+
+	create_git_worktree_fixture "$repo_path" "$wt_path" "feature/archive-race" || rc=1
+	AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" archive_worktree_path_recoverably \
+		"$wt_path" "test.sh" "archive-race" || rc=1
+	archive_path="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
+	cat >"$wrapper_path" <<'RACE_GIT'
+#!/usr/bin/env bash
+if [[ "$*" == *"worktree remove"* && ! -e "${RACE_MARKER:?}" ]]; then
+	: >"$RACE_MARKER"
+	"${REAL_GIT:?}" -C "${RACE_REPO:?}" worktree lock \
+		--reason "foreign-after-archive" "${RACE_WORKTREE:?}" || exit 1
+fi
+exec "${REAL_GIT:?}" "$@"
+RACE_GIT
+	chmod +x "$wrapper_path" || rc=1
+	wt_root=$("$GIT_BIN" -C "$wt_path" rev-parse --show-toplevel 2>/dev/null) || rc=1
+	if REAL_GIT="$GIT_BIN" RACE_MARKER="$marker_path" RACE_REPO="$repo_path" \
+		RACE_WORKTREE="$wt_path" AIDEVOPS_REAL_GIT_BIN="$wrapper_path" \
+		remove_archived_worktree_path "$wt_path" "$archive_path" "test.sh" \
+		"recoverable-test" "recovery_path=archive-first" "false" "false"; then
+		rc=1
+	fi
+	metadata=$("$GIT_BIN" -C "$repo_path" worktree list --porcelain) || rc=1
+	[[ -d "$wt_path" && -d "$archive_path" && -e "$archive_path/.git" && -e "$marker_path" ]] || rc=1
+	printf '%s\n' "$metadata" | grep -Fqx "worktree $wt_root" || rc=1
+	printf '%s\n' "$metadata" | grep -Fxq "locked foreign-after-archive" || rc=1
+	print_result "recoverable_archive_preserves_late_lock" "$rc" \
+		"Expected a late lock to preserve source, metadata, and completed archive"
+	return 0
+}
+
+# =============================================================================
+# Forced recovery keeps a usable detached admin snapshot with the exact staged,
+# unstaged, and untracked state that existed before native source removal.
+# =============================================================================
+test_recovery_archive_preserves_index_and_dirty_files() {
+	local repo_path="${TEST_DIR}/archive-dirty-repo"
+	local wt_path="${TEST_DIR}/archive-dirty-worktree"
+	local trash_root="${TEST_DIR}/archive-dirty-trash"
+	local archive_path=""
+	local recovery_dir=""
+	local expected_status=""
+	local actual_status=""
+	local expected_head=""
+	local actual_head=""
+	local recorded_branch=""
+	local rc=0
+	local AIDEVOPS_WORKTREE_TRASH_ROOT="$trash_root"
+
+	create_git_worktree_fixture "$repo_path" "$wt_path" "feature/archive-dirty" || rc=1
+	printf 'staged state\n' >>"$wt_path/README.md" || rc=1
+	"$GIT_BIN" -C "$wt_path" add README.md || rc=1
+	printf 'unstaged state\n' >>"$wt_path/README.md" || rc=1
+	printf 'untracked state\n' >"$wt_path/untracked.txt" || rc=1
+	expected_status=$("$GIT_BIN" -C "$wt_path" status --porcelain=v1 --untracked-files=all) || rc=1
+	expected_head=$("$GIT_BIN" -C "$wt_path" rev-parse --verify HEAD) || rc=1
+	AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" archive_worktree_path_recoverably \
+		"$wt_path" "test.sh" "dirty-archive" || rc=1
+	archive_path="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
+	recovery_dir=$(_worktree_recovery_dir_for_archive "$archive_path") || rc=1
+	AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" remove_archived_worktree_path \
+		"$wt_path" "$archive_path" "test.sh" "dirty-archive" \
+		"recovery_path=archive-first" "false" "true" || rc=1
+	actual_status=$("$GIT_BIN" -C "$archive_path" status --porcelain=v1 --untracked-files=all) || rc=1
+	actual_head=$("$GIT_BIN" -C "$archive_path" rev-parse --verify HEAD) || rc=1
+	IFS= read -r recorded_branch <"${recovery_dir}/branch" || rc=1
+	[[ ! -e "$wt_path" && "$actual_status" == "$expected_status" ]] || rc=1
+	[[ "$actual_head" == "$expected_head" ]] || rc=1
+	[[ "$recorded_branch" == "refs/heads/feature/archive-dirty" ]] || rc=1
+	if "$GIT_BIN" -C "$archive_path" symbolic-ref -q HEAD >/dev/null 2>&1; then
+		rc=1
+	fi
+	print_result "recovery_archive_preserves_index_and_dirty_files" "$rc" \
+		"Expected a usable detached archive with exact index and file state"
+	return 0
+}
+
+test_recovery_archive_preserves_detached_head_identity() {
+	local repo_path="${TEST_DIR}/archive-detached-repo"
+	local wt_path="${TEST_DIR}/archive-detached-worktree"
+	local trash_root="${TEST_DIR}/archive-detached-trash"
+	local archive_path=""
+	local recovery_dir=""
+	local expected_head=""
+	local actual_head=""
+	local recorded_branch=""
+	local rc=0
+	local AIDEVOPS_WORKTREE_TRASH_ROOT="$trash_root"
+
+	create_git_worktree_fixture "$repo_path" "$wt_path" "feature/archive-detached" || rc=1
+	"$GIT_BIN" -C "$wt_path" checkout -q --detach || rc=1
+	expected_head=$("$GIT_BIN" -C "$wt_path" rev-parse --verify HEAD) || rc=1
+	AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" archive_worktree_path_recoverably \
+		"$wt_path" "test.sh" "detached-archive" || rc=1
+	archive_path="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
+	recovery_dir=$(_worktree_recovery_dir_for_archive "$archive_path") || rc=1
+	AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" remove_archived_worktree_path \
+		"$wt_path" "$archive_path" "test.sh" "detached-archive" \
+		"recovery_path=archive-first" "false" "false" || rc=1
+	actual_head=$("$GIT_BIN" -C "$archive_path" rev-parse --verify HEAD) || rc=1
+	IFS= read -r recorded_branch <"${recovery_dir}/branch" || rc=1
+	[[ "$actual_head" == "$expected_head" && "$recorded_branch" == "detached" ]] || rc=1
+	if "$GIT_BIN" -C "$archive_path" symbolic-ref -q HEAD >/dev/null 2>&1; then
+		rc=1
+	fi
+	print_result "recovery_archive_preserves_detached_head_identity" "$rc" \
+		"Expected detached identity and HEAD to survive native removal"
+	return 0
+}
+
+# =============================================================================
+# The archive and final removal must refer to the same source/admin identity.
+# Replacing the registered worktree at the same pathname must fail closed.
+# =============================================================================
+test_recoverable_archive_refuses_replacement_worktree() {
+	local log_file="${TEST_DIR}/archive-replacement.log"
+	local repo_path="${TEST_DIR}/archive-replacement-repo"
+	local wt_path="${TEST_DIR}/archive-replacement-worktree"
+	local trash_root="${TEST_DIR}/archive-replacement-trash"
+	local archive_path=""
+	local metadata=""
+	local rc=0
+	local AIDEVOPS_WORKTREE_TRASH_ROOT="$trash_root"
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+
+	create_git_worktree_fixture "$repo_path" "$wt_path" "feature/archive-original" || rc=1
+	AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" archive_worktree_path_recoverably \
+		"$wt_path" "test.sh" "replacement-test" || rc=1
+	archive_path="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
+	"$GIT_BIN" -C "$repo_path" worktree remove "$wt_path" || rc=1
+	"$GIT_BIN" -C "$repo_path" worktree add -q -b "feature/archive-replacement" "$wt_path" main || rc=1
+	if AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" remove_archived_worktree_path \
+		"$wt_path" "$archive_path" "test.sh" "replacement-test" \
+		"recovery_path=archive-first" "false" "false"; then
+		rc=1
+	fi
+	metadata=$("$GIT_BIN" -C "$repo_path" worktree list --porcelain) || rc=1
+	[[ -d "$wt_path" && -d "$archive_path" ]] || rc=1
+	printf '%s\n' "$metadata" | grep -Fqx "branch refs/heads/feature/archive-replacement" || rc=1
+	assert_file_contains "$log_file" "git-worktree-identity-changed.*mode=skipped" || rc=1
+	print_result "recoverable_archive_refuses_replacement_worktree" "$rc" \
+		"Expected replacement identity to preserve both replacement and archive"
+	return 0
+}
+
+test_recoverable_archive_refuses_late_unarchived_write_without_force() {
+	local log_file="${TEST_DIR}/archive-late-write.log"
+	local repo_path="${TEST_DIR}/archive-late-write-repo"
+	local wt_path="${TEST_DIR}/archive-late-write-worktree"
+	local trash_root="${TEST_DIR}/archive-late-write-trash"
+	local wrapper_path="${TEST_DIR}/archive-late-write-git"
+	local marker_path="${TEST_DIR}/archive-late-write-injected"
+	local archive_path=""
+	local rc=0
+	local AIDEVOPS_WORKTREE_TRASH_ROOT="$trash_root"
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+
+	create_git_worktree_fixture "$repo_path" "$wt_path" "feature/archive-late-write" || rc=1
+	AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" archive_worktree_path_recoverably \
+		"$wt_path" "test.sh" "late-write-test" || rc=1
+	archive_path="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
+	cat >"$wrapper_path" <<'LATE_WRITE_GIT'
+#!/usr/bin/env bash
+if [[ "$*" == *"worktree remove"* && ! -e "${LATE_WRITE_MARKER:?}" ]]; then
+	printf 'late state\n' >"${LATE_WRITE_WORKTREE:?}/late-write.txt" || exit 1
+	: >"$LATE_WRITE_MARKER"
+fi
+exec "${REAL_GIT:?}" "$@"
+LATE_WRITE_GIT
+	chmod +x "$wrapper_path" || rc=1
+	if REAL_GIT="$GIT_BIN" LATE_WRITE_MARKER="$marker_path" \
+		LATE_WRITE_WORKTREE="$wt_path" AIDEVOPS_REAL_GIT_BIN="$wrapper_path" \
+		remove_archived_worktree_path "$wt_path" "$archive_path" "test.sh" \
+		"late-write-test" "recovery_path=archive-first" "false" "false"; then
+		rc=1
+	fi
+	[[ -f "$wt_path/late-write.txt" && ! -e "$archive_path/late-write.txt" ]] || rc=1
+	assert_file_contains "$log_file" "git-worktree-remove-failed.*mode=skipped" || rc=1
+	print_result "recoverable_archive_refuses_late_unarchived_write_without_force" "$rc" \
+		"Expected an unforced native removal to preserve a late write"
+	return 0
+}
+
+test_removal_helpers_refuse_direct_symlink_alias() {
+	local log_file="${TEST_DIR}/symlink-alias.log"
+	local repo_path="${TEST_DIR}/symlink-alias-repo"
+	local wt_path="${TEST_DIR}/symlink-alias-worktree"
+	local alias_path="${TEST_DIR}/symlink-alias"
+	local trash_root="${TEST_DIR}/symlink-alias-trash"
+	local rc=0
+	local AIDEVOPS_WORKTREE_TRASH_ROOT="$trash_root"
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+
+	create_git_worktree_fixture "$repo_path" "$wt_path" "feature/symlink-alias" || rc=1
+	ln -s "$wt_path" "$alias_path" || rc=1
+	if remove_worktree_path_permanently "$alias_path" "test.sh" "alias-test"; then
+		rc=1
+	fi
+	if archive_worktree_path_recoverably "$alias_path" "test.sh" "alias-test"; then
+		rc=1
+	fi
+	[[ -L "$alias_path" && -d "$wt_path" ]] || rc=1
+	assert_file_contains "$log_file" "git-worktree-identity-changed.*mode=skipped" || rc=1
+	print_result "removal_helpers_refuse_direct_symlink_alias" "$rc" \
+		"Expected direct symlink aliases to fail before source removal"
+	return 0
+}
+
+# =============================================================================
+# Manual cleanup archives first, removes through native Git, and verifies exact
+# metadata absence before ownership is unregistered.
+# =============================================================================
+test_manual_cleanup_archives_removes_and_prunes() {
+	local log_file="${TEST_DIR}/manual-archive-cleanup.log"
+	local repo_path="${TEST_DIR}/manual-archive-repo"
+	local wt_path="${TEST_DIR}/manual-archive-worktree"
+	local trash_destination="${TEST_DIR}/manual-archive-trash"
+	local unregister_log="${TEST_DIR}/manual-archive-unregister.log"
+	local wt_root=""
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+
+	create_git_worktree_fixture "$repo_path" "$wt_path" "feature/manual-archive" || rc=1
+	wt_root=$("$GIT_BIN" -C "$wt_path" rev-parse --show-toplevel 2>/dev/null) || rc=1
+	if ! (
+		unset _WORKTREE_CMDS_LIB_LOADED 2>/dev/null || true
+		SCRIPT_DIR="${COMMANDS_HELPER%/*}"
+		SCRIPT_NAME="worktree-helper.sh"
+		_WTAR_WH_CALLER="worktree-helper.sh"
+		RED="" GREEN="" YELLOW="" BLUE="" NC=""
+		export AIDEVOPS_REAL_GIT_BIN="$GIT_BIN"
+		export AIDEVOPS_WORKTREE_TRASH_ROOT="$trash_destination"
+		# shellcheck source=../worktree-helper-cmds.sh
+		source "$COMMANDS_HELPER"
+		get_repo_root() {
+			printf '%s\n' "$repo_path"
+			return 0
+		}
+		capture_worktree_process_cwds() {
+			printf '/\n'
+			return 0
+		}
+		is_registered_canonical() { return 1; }
+		unregister_worktree() {
+			local removed_path="$1"
+			printf '%s\n' "$removed_path" >>"$unregister_log"
+			return 0
+		}
+		localdev_auto_branch_rm() { return 0; }
+		preview_proxy_auto_free() { return 0; }
+		_remove_cleanup_and_execute "$wt_path"
+	); then
+		rc=1
+	fi
+	[[ ! -e "$wt_path" && -d "$trash_destination" ]] || rc=1
+	compgen -G "${trash_destination}/aidevops-worktree-cleanup-*/manual-archive-worktree" >/dev/null || rc=1
+	if "$GIT_BIN" -C "$repo_path" worktree list --porcelain | grep -Fqx "worktree $wt_root"; then
+		rc=1
+	fi
+	grep -Fxq "$wt_path" "$unregister_log" 2>/dev/null || rc=1
+	assert_file_contains "$log_file" "worktree-removed.*manual.*mode=trash" || rc=1
+	print_result "manual_cleanup_archives_removes_and_prunes" "$rc" \
+		"Expected archive-first manual cleanup to verify metadata and unregister"
+	return 0
+}
+
+# =============================================================================
+# A recoverable caller cannot rely on stale guard evidence. If a foreign lock
+# exists when archive preparation starts, source removal must not start.
+# =============================================================================
+test_recoverable_cleanup_preserves_lock_acquired_after_guard() {
+	local log_file="${TEST_DIR}/recoverable-race-cleanup.log"
+	local repo_path="${TEST_DIR}/recoverable-race-repo"
+	local wt_path="${TEST_DIR}/recoverable-race-worktree"
+	local wt_root=""
+	local metadata=""
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+
+	create_git_worktree_fixture "$repo_path" "$wt_path" "feature/recoverable-race" || rc=1
+	"$GIT_BIN" -C "$repo_path" worktree lock --reason "foreign-race-lock" "$wt_path" || rc=1
+	if (
+		unset _WORKTREE_CLEAN_LIB_LOADED 2>/dev/null || true
+		SCRIPT_DIR="${CLEAN_HELPER%/*}"
+		RED="" GREEN="" YELLOW="" BLUE="" NC=""
+		_WTAR_WH_CALLER="test.sh"
+		# shellcheck source=../worktree-clean-lib.sh
+		source "$CLEAN_HELPER"
+		worktree_removal_guard() {
+			WORKTREE_REMOVAL_GUARD_REASON="cwd-visibility-degraded"
+			return 2
+		}
+		worktree_has_changes() { return 1; }
+		_branch_has_active_interactive_claim() { return 1; }
+		_clean_removal_lease_owned_by_others() { return 1; }
+		_clean_remove_classified_worktree "$wt_path" "feature/recoverable-race" \
+			"false" "false" "test=context" "$repo_path" \
+			"$_WT_CLEAN_MODE_RECOVERABLE" "true"
+	); then
+		rc=1
+	fi
+	[[ -d "$wt_path" ]] || rc=1
+	wt_root=$("$GIT_BIN" -C "$wt_path" rev-parse --show-toplevel 2>/dev/null) || rc=1
+	metadata=$("$GIT_BIN" -C "$repo_path" worktree list --porcelain) || rc=1
+	printf '%s\n' "$metadata" | grep -Fqx "worktree $wt_root" || rc=1
+	printf '%s\n' "$metadata" | grep -Eq '^locked([[:space:]]|$)' || rc=1
+	assert_file_contains "$log_file" "worktree-skipped.*git-worktree-locked.*mode=skipped" || rc=1
+	print_result "recoverable_cleanup_preserves_lock_acquired_after_guard" "$rc" \
+		"Expected archive preparation to preserve a lock after a stale guard"
+	return 0
+}
+
+# =============================================================================
+# Skill-update cleanup must not delete the branch or unregister ownership when
+# the guarded permanent-removal primitive refuses the worktree.
+# =============================================================================
+test_skill_cleanup_has_no_removal_failure_fallback() {
+	local wt_path="${TEST_DIR}/skill-fallback-worktree"
+	local side_effect_log="${TEST_DIR}/skill-fallback-effects.log"
+	local rc=0
+	mkdir -p "$wt_path"
+
+	if ! (
+		unset _SKILL_UPDATE_PR_LIB_LOADED 2>/dev/null || true
+		SCRIPT_DIR="${SKILL_PR_HELPER%/*}"
+		_WTAR_SU_CALLER="skill-update-helper.sh"
+		# shellcheck source=../skill-update-pr-lib.sh
+		source "$SKILL_PR_HELPER"
+		get_default_branch() {
+			printf '%s\n' "main"
+			return 0
+		}
+		git() {
+			local all_args="$*"
+			case "$all_args" in
+			*"rev-list --count main..HEAD"*) printf '%s\n' "0" ;;
+			*"worktree remove"* | *"branch -D"*) printf '%s\n' "$all_args" >>"$side_effect_log" ;;
+			*) "$GIT_BIN" "$@" || return $? ;;
+			esac
+			return 0
+		}
+		is_worktree_owned_by_others() { return 1; }
+		worktree_removal_guard() { return 0; }
+		remove_worktree_path_permanently() { return 1; }
+		log_info() { return 0; }
+		log_warning() { return 0; }
+		unregister_worktree() {
+			printf '%s\n' "unregister:$1" >>"$side_effect_log"
+			return 0
+		}
+		_cleanup_worktree "$wt_path" "feature/skill-fallback"
+	); then
+		rc=1
+	fi
+	[[ -d "$wt_path" ]] || rc=1
+	[[ ! -s "$side_effect_log" ]] || rc=1
+	print_result "skill_cleanup_has_no_removal_failure_fallback" "$rc" \
+		"Expected failed guarded removal to preserve the path, branch, and registry"
+	return 0
+}
+
+# =============================================================================
+# Shared removal guard treats Git worktree locks as a non-overridable safety
+# boundary. Direct permanent deletion must not bypass the lock.
+# =============================================================================
+test_permanent_helper_preserves_git_locked_worktree() {
+	local log_file="${TEST_DIR}/locked-cleanup.log"
+	local repo_path="${TEST_DIR}/locked-repo"
+	local wt_path="${TEST_DIR}/locked-worktree"
+	local wt_root=""
+	local metadata=""
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+
+	create_git_worktree_fixture "$repo_path" "$wt_path" "feature/locked" || rc=1
+	"$GIT_BIN" -C "$repo_path" worktree lock --reason "observation-provenance" "$wt_path" || rc=1
+	if (
+		unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+		# shellcheck source=../audit-worktree-removal-helper.sh
+		source "$AUDIT_HELPER"
+		capture_worktree_process_cwds() {
+			printf '/\n'
+			return 0
+		}
+		remove_worktree_path_permanently "$wt_path" "test.sh" "age-eligible"
+	); then
+		rc=1
+	fi
+	[[ -d "$wt_path" ]] || rc=1
+	wt_root=$("$GIT_BIN" -C "$wt_path" rev-parse --show-toplevel 2>/dev/null) || rc=1
+	metadata=$("$GIT_BIN" -C "$repo_path" worktree list --porcelain 2>/dev/null) || rc=1
+	printf '%s\n' "$metadata" | grep -Fqx "worktree $wt_root" || rc=1
+	printf '%s\n' "$metadata" | grep -Eq '^locked([[:space:]]|$)' || rc=1
+	assert_file_contains "$log_file" "worktree-skipped.*git-worktree-locked.*mode=skipped" || rc=1
+	print_result "permanent_helper_preserves_git_locked_worktree" "$rc" \
+		"Expected locked worktree path and metadata to remain. Log: $(cat "$log_file" 2>/dev/null)"
+	return 0
+}
+
+# =============================================================================
+# Git metadata failures are not evidence that a worktree is unlocked.
+# =============================================================================
+test_permanent_helper_fails_closed_on_unreadable_git_metadata() {
+	local log_file="${TEST_DIR}/unreadable-cleanup.log"
+	local wt_path="${TEST_DIR}/unreadable-worktree"
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+	mkdir -p "$wt_path"
+	printf 'gitdir: unavailable\n' >"${wt_path}/.git"
+
+	if (
+		unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+		# shellcheck source=../audit-worktree-removal-helper.sh
+		source "$AUDIT_HELPER"
+		git() {
+			return 1
+		}
+		capture_worktree_process_cwds() {
+			printf '/\n'
+			return 0
+		}
+		remove_worktree_path_permanently "$wt_path" "test.sh" "age-eligible"
+	); then
+		rc=1
+	fi
+	[[ -d "$wt_path" ]] || rc=1
+	assert_file_contains "$log_file" "worktree-skipped.*git-metadata-unreadable.*mode=skipped" || rc=1
+	print_result "permanent_helper_fails_closed_on_unreadable_git_metadata" "$rc" \
+		"Expected unreadable Git metadata to block permanent removal. Log: $(cat "$log_file" 2>/dev/null)"
+	return 0
+}
+
+# =============================================================================
+# A successful metadata query that omits the exact candidate is ambiguous and
+# must not be treated as proof that the candidate is unlocked.
+# =============================================================================
+test_permanent_helper_fails_closed_on_ambiguous_git_metadata() {
+	local log_file="${TEST_DIR}/ambiguous-cleanup.log"
+	local wt_path="${TEST_DIR}/ambiguous-worktree"
+	local rc=0
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+	mkdir -p "$wt_path"
+	printf 'gitdir: ambiguous\n' >"${wt_path}/.git"
+
+	if (
+		unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+		# shellcheck source=../audit-worktree-removal-helper.sh
+		source "$AUDIT_HELPER"
+		git() {
+			local all_args="$*"
+			case "$all_args" in
+			*"rev-parse --show-toplevel"*) printf '%s\n' "$wt_path" ;;
+			*"worktree list --porcelain -z"*)
+				printf 'worktree %s\0HEAD 0123456789abcdef0123456789abcdef01234567\0detached\0\0' \
+					"${TEST_DIR}/different-worktree"
+				;;
+			*) return 1 ;;
+			esac
+			return 0
+		}
+		capture_worktree_process_cwds() {
+			printf '/\n'
+			return 0
+		}
+		remove_worktree_path_permanently "$wt_path" "test.sh" "age-eligible"
+	); then
+		rc=1
+	fi
+	[[ -d "$wt_path" ]] || rc=1
+	assert_file_contains "$log_file" "worktree-skipped.*git-metadata-unreadable.*mode=skipped" || rc=1
+	print_result "permanent_helper_fails_closed_on_ambiguous_git_metadata" "$rc" \
+		"Expected ambiguous Git metadata to block permanent removal. Log: $(cat "$log_file" 2>/dev/null)"
+	return 0
+}
+
+# =============================================================================
+# Verified unlocked worktrees remain eligible for the caller's existing policy.
+# =============================================================================
+test_guard_allows_verified_unlocked_worktree() {
+	local repo_path="${TEST_DIR}/unlocked-repo"
+	local wt_path="${TEST_DIR}/unlocked-worktree"
+	local rc=0
+
+	create_git_worktree_fixture "$repo_path" "$wt_path" "feature/unlocked" || rc=1
+	if ! (
+		unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+		# shellcheck source=../audit-worktree-removal-helper.sh
+		source "$AUDIT_HELPER"
+		worktree_removal_guard "$wt_path" "test.sh" "manual" ""
+	); then
+		rc=1
+	fi
+	[[ -d "$wt_path" ]] || rc=1
+	print_result "guard_allows_verified_unlocked_worktree" "$rc" \
+		"Expected verified unlocked worktree to pass the shared guard"
 	return 0
 }
 
@@ -767,7 +1508,7 @@ test_manual_guard_refusal_diagnostics() {
 		: "$removal_mode"
 		return 1
 	}
-	for reason in active-cwd current-worktree canonical-skip; do
+	for reason in active-cwd current-worktree canonical-skip git-worktree-locked git-metadata-unreadable; do
 		guard_reason_to_test="$reason"
 		if _remove_validate_path "/safe/example-worktree" 2>>"$output_file"; then
 			rc=1
@@ -776,8 +1517,10 @@ test_manual_guard_refusal_diagnostics() {
 	assert_file_contains "$output_file" "Reason: active-cwd.*live process" || rc=1
 	assert_file_contains "$output_file" "Reason: current-worktree.*inside the target" || rc=1
 	assert_file_contains "$output_file" "Reason: canonical-skip.*canonical checkout" || rc=1
+	assert_file_contains "$output_file" "Reason: git-worktree-locked.*explicitly locked" || rc=1
+	assert_file_contains "$output_file" "Reason: git-metadata-unreadable.*could not prove" || rc=1
 	assert_file_contains "$output_file" "cannot bypass this protection" || rc=1
-	assert_line_count "$log_file" 3 || rc=1
+	assert_line_count "$log_file" 5 || rc=1
 	print_result "manual_guard_refusal_diagnostics" "$rc" \
 		"Expected safe diagnostics and exactly one audit row per refusal"
 	return 0
@@ -800,6 +1543,25 @@ test_idempotent_sourcing
 test_guard_refuses_current_cwd
 test_guard_refuses_other_process_cwd
 test_permanent_helper_removes_and_logs
+test_guard_fails_closed_on_inaccessible_candidate
+test_git_lock_parser_handles_unusual_paths_and_adjacent_blocks
+test_git_lock_parser_rejects_malformed_blocks
+test_missing_worktree_physical_parent_alias
+test_permanent_helper_preserves_lock_acquired_after_guard
+test_recoverable_archive_then_native_remove
+test_recoverable_archive_preserves_late_lock
+test_recovery_archive_preserves_index_and_dirty_files
+test_recovery_archive_preserves_detached_head_identity
+test_recoverable_archive_refuses_replacement_worktree
+test_recoverable_archive_refuses_late_unarchived_write_without_force
+test_removal_helpers_refuse_direct_symlink_alias
+test_manual_cleanup_archives_removes_and_prunes
+test_recoverable_cleanup_preserves_lock_acquired_after_guard
+test_skill_cleanup_has_no_removal_failure_fallback
+test_permanent_helper_preserves_git_locked_worktree
+test_permanent_helper_fails_closed_on_unreadable_git_metadata
+test_permanent_helper_fails_closed_on_ambiguous_git_metadata
+test_guard_allows_verified_unlocked_worktree
 test_optional_guard_context_logged
 test_process_cwd_guard_refuses_empty_paths
 test_process_cwd_snapshot_failure_is_fail_closed

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -18,7 +18,7 @@
 #   - audit-worktree-removal-helper.sh (log_worktree_removal_event, _WTAR_*)
 #     Must be sourced by the orchestrator before this library is loaded.
 #   - worktree-helper.sh helper functions (resolved at call time):
-#       worktree_has_changes, trash_path, branch_was_pushed,
+#       worktree_has_changes, branch_was_pushed,
 #       _branch_exists_on_any_remote, get_default_branch,
 #       localdev_auto_branch_rm, assert_git_available,
 #       assert_main_worktree_sane
@@ -654,9 +654,15 @@ _WT_CLEAN_MODE_SKIPPED="skipped"
 _WT_CLEAN_MODE_BRANCH_PRESERVED="branch-preserved"
 _WT_CLEAN_MODE_PERMANENT="permanent"
 _WT_CLEAN_MODE_RECOVERABLE="recoverable-trash"
+_WT_CLEAN_MODE_PARTIAL="partial-cleanup"
 _WT_CLEAN_COMPLETED_EVENT="AIDEVOPS_WORKTREE_REMOVAL_COMPLETED=1"
 _WT_CLEAN_BOOL_TRUE=true
 _WT_CLEAN_BOOL_FALSE=false
+_WT_CLEAN_OUTCOME_SKIPPED="skipped"
+_WT_CLEAN_OUTCOME_FAILED="failed"
+_WT_CLEAN_OUTCOME_REMOVED="removed"
+_WT_CLEAN_LAST_REMOVAL_OUTCOME="$_WT_CLEAN_OUTCOME_SKIPPED"
+_WT_CLEAN_STASH_ARCHIVE_SEQUENCE=0
 _WT_CLEAN_LAST_PRESERVE_BRANCH="${_WT_CLEAN_LAST_PRESERVE_BRANCH:-$_WT_CLEAN_BOOL_FALSE}"
 
 _clean_protected_mark() {
@@ -727,11 +733,48 @@ _clean_issue_is_closed() {
 _clean_archive_dirty_worktree_stash() {
 	local wt_path="$1"
 	local wt_branch="$2"
+	local archive_token=""
+	local candidate_oid=""
+	local candidate_subject=""
+	local match_count=0
+	local stash_entries=""
+	local stash_oid=""
 	if ! worktree_has_changes "$wt_path"; then
 		return 0
 	fi
-	git -C "$wt_path" stash push -u -m "aidevops worktree cleanup archive: ${wt_branch:-detached}" >/dev/null 2>&1
-	return $?
+	_WT_CLEAN_STASH_ARCHIVE_SEQUENCE=$((_WT_CLEAN_STASH_ARCHIVE_SEQUENCE + 1))
+	archive_token="aidevops-stash-archive:$$:${_WT_CLEAN_STASH_ARCHIVE_SEQUENCE}:${RANDOM}"
+	git -C "$wt_path" stash push -u \
+		-m "aidevops worktree cleanup archive [${archive_token}]: ${wt_branch:-detached}" \
+		>/dev/null 2>&1 || return 1
+	stash_entries=$(git -C "$wt_path" stash list --format='%H%x09%gs' 2>/dev/null) || return 1
+	while IFS=$'\t' read -r candidate_oid candidate_subject; do
+		case "$candidate_subject" in
+		*"$archive_token"*)
+			stash_oid="$candidate_oid"
+			match_count=$((match_count + 1))
+			;;
+		esac
+	done <<<"$stash_entries"
+	[[ "$match_count" -eq 1 && -n "$stash_oid" ]] || return 1
+	git -C "$wt_path" cat-file -e "${stash_oid}^{commit}" 2>/dev/null || return 1
+	# Keep the immutable stash while restoring the exact dirty worktree before
+	# final native Git removal. If a preservation lock wins, the surviving
+	# worktree retains its tracked, staged, and untracked files.
+	git -C "$wt_path" stash apply --index "$stash_oid" >/dev/null 2>&1 || return 1
+	return 0
+}
+
+_clean_remove_preserving_branch() {
+	local wt_path="$1"
+	local wt_branch="$2"
+	local audit_context="$3"
+
+	_clean_archive_dirty_worktree_stash "$wt_path" "$wt_branch" || return 1
+	worktree_removal_guard "$wt_path" "$_WTAR_WH_CALLER" \
+		"$_WT_CLEAN_REASON_CLOSED_ISSUE_ARCHIVE" || return 1
+	_worktree_remove_with_native_git "$wt_path" "$_WTAR_WH_CALLER" "$audit_context" "true" || return 1
+	return 0
 }
 
 _clean_closed_issue_archive_allowed() {
@@ -988,63 +1031,27 @@ _clean_scan_merged() {
 	return 1
 }
 
-_clean_move_worktree_to_trash_bucket() {
+# Copy a worktree to recoverable trash before any source removal. This is the
+# only physical-removal preparation permitted when process-CWD visibility is
+# degraded, so interruption or a late lock always leaves a recoverable copy.
+_clean_archive_worktree_recoverably() {
 	local worktree_path="$1"
-	local trash_root="$2"
-	local trash_bucket=""
-	local worktree_basename=""
-
-	worktree_basename=$(basename "$worktree_path") || return 1
-	[[ -n "$worktree_basename" && "$worktree_basename" != "." && "$worktree_basename" != "/" ]] || return 1
-	trash_bucket="${trash_root}/aidevops-worktree-cleanup-$(date -u '+%Y%m%dT%H%M%SZ')-$$"
-	mkdir -p "$trash_bucket" 2>/dev/null || return 1
-	mv "$worktree_path" "$trash_bucket/$worktree_basename" 2>/dev/null || return 1
-	[[ ! -e "$worktree_path" ]] || return 1
-	return 0
-}
-
-# Move a worktree to recoverable trash without any rm -rf fallback. This is the
-# only physical-removal primitive permitted when process-CWD visibility is
-# degraded, so a false absence inference remains recoverable.
-_clean_move_worktree_recoverably() {
-	local worktree_path="$1"
-	local trash_root="${AIDEVOPS_WORKTREE_TRASH_ROOT:-${AIDEVOPS_ORPHAN_TRASH_ROOT:-}}"
-	local backend_failures=""
+	local caller="${2:-${_WTAR_WH_CALLER:-worktree-helper.sh}}"
 	_WT_CLEAN_RECOVERABLE_FAILURE_DETAIL=""
+	_WT_CLEAN_RECOVERABLE_ARCHIVE_PATH=""
 
 	[[ -n "$worktree_path" ]] || return 1
 	if [[ ! -e "$worktree_path" && ! -L "$worktree_path" ]]; then
 		_WT_CLEAN_RECOVERABLE_FAILURE_DETAIL="path-already-gone"
 		return 0
 	fi
-	if [[ -n "$trash_root" ]]; then
-		if _clean_move_worktree_to_trash_bucket "$worktree_path" "$trash_root"; then
-			return 0
-		fi
-		_WT_CLEAN_RECOVERABLE_FAILURE_DETAIL="configured-trash-root-failed"
+	if ! archive_worktree_path_recoverably "$worktree_path" "$caller" \
+		"recoverable-cleanup"; then
+		_WT_CLEAN_RECOVERABLE_FAILURE_DETAIL="archive-copy-failed"
 		return 1
 	fi
-	if command -v trash >/dev/null 2>&1; then
-		if trash "$worktree_path" 2>/dev/null && [[ ! -e "$worktree_path" ]]; then
-			return 0
-		fi
-		backend_failures="trash-failed"
-	else
-		backend_failures="trash-unavailable"
-	fi
-	if command -v gio >/dev/null 2>&1; then
-		if gio trash "$worktree_path" 2>/dev/null && [[ ! -e "$worktree_path" ]]; then
-			return 0
-		fi
-		backend_failures="${backend_failures},gio-failed"
-	else
-		backend_failures="${backend_failures},gio-unavailable"
-	fi
-	if _clean_move_worktree_to_trash_bucket "$worktree_path" "${HOME}/.Trash"; then
-		return 0
-	fi
-	_WT_CLEAN_RECOVERABLE_FAILURE_DETAIL="${backend_failures},home-trash-bucket-failed"
-	return 1
+	_WT_CLEAN_RECOVERABLE_ARCHIVE_PATH="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
+	return 0
 }
 
 _clean_merge_type_has_terminal_pr_state() {
@@ -1109,6 +1116,8 @@ _clean_remove_classified_worktree() {
 	local guard_status=0
 	local audit_reason="$_WT_CLEAN_REASON_BRANCH_MERGED"
 	local completed_mode="$_WT_CLEAN_MODE_PERMANENT"
+	local recoverable_archive=""
+	_WT_CLEAN_LAST_REMOVAL_OUTCOME="$_WT_CLEAN_OUTCOME_SKIPPED"
 
 	if worktree_removal_guard "$worktree_path" "$_WTAR_WH_CALLER" "$_WT_CLEAN_REASON_BRANCH_MERGED"; then
 		guard_status=0
@@ -1131,38 +1140,53 @@ _clean_remove_classified_worktree() {
 		use_force="$_WT_CLEAN_BOOL_TRUE"
 	fi
 	if [[ "$removal_mode" == "$_WT_CLEAN_MODE_RECOVERABLE" ]]; then
-		if _clean_move_worktree_recoverably "$worktree_path"; then
-			removed="$_WT_CLEAN_BOOL_TRUE"
+		if _clean_archive_worktree_recoverably "$worktree_path"; then
+			recoverable_archive="$_WT_CLEAN_RECOVERABLE_ARCHIVE_PATH"
+			if [[ -z "$recoverable_archive" && ! -e "$worktree_path" && ! -L "$worktree_path" ]]; then
+				removed="$_WT_CLEAN_BOOL_TRUE"
+			elif ! remove_archived_worktree_path "$worktree_path" "$recoverable_archive" \
+				"$_WTAR_WH_CALLER" "$_WT_CLEAN_REASON_BRANCH_MERGED" "$audit_context" \
+				"true" "false"; then
+				log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" \
+					"recoverable-remove-failed" "$_WT_CLEAN_MODE_SKIPPED" "$audit_context"
+				_WT_CLEAN_LAST_REMOVAL_OUTCOME="$_WT_CLEAN_OUTCOME_FAILED"
+				return 1
+			else
+				removed="$_WT_CLEAN_BOOL_TRUE"
+			fi
 			completed_mode="$_WT_CLEAN_MODE_RECOVERABLE"
 		else
-			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "recoverable-move-failed" "$_WT_CLEAN_MODE_SKIPPED" "$audit_context recoverable_backends=${_WT_CLEAN_RECOVERABLE_FAILURE_DETAIL:-unknown}"
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "recoverable-archive-failed" "$_WT_CLEAN_MODE_SKIPPED" "$audit_context recoverable_backends=${_WT_CLEAN_RECOVERABLE_FAILURE_DETAIL:-unknown}"
+			_WT_CLEAN_LAST_REMOVAL_OUTCOME="$_WT_CLEAN_OUTCOME_FAILED"
 			return 1
 		fi
 	elif [[ "$preserve_branch" == "$_WT_CLEAN_BOOL_TRUE" ]]; then
-		_clean_archive_dirty_worktree_stash "$worktree_path" "$worktree_branch" || return 1
-		if git worktree remove --force "$worktree_path" 2>/dev/null; then
+		if _clean_remove_preserving_branch "$worktree_path" "$worktree_branch" "$audit_context"; then
 			removed="$_WT_CLEAN_BOOL_TRUE"
 			audit_reason="$_WT_CLEAN_REASON_CLOSED_ISSUE_ARCHIVE"
 			completed_mode="$_WT_CLEAN_MODE_BRANCH_PRESERVED"
 		fi
-	elif rm -rf "$worktree_path" 2>/dev/null; then
-		removed="$_WT_CLEAN_BOOL_TRUE"
 	else
-		local remove_flag
+		local remove_flag=""
 		if [[ "$use_force" == "$_WT_CLEAN_BOOL_TRUE" ]]; then
 			remove_flag="--force"
 		fi
+		# Git is the final physical-removal authority. A concurrent lock makes
+		# this command fail; cleanup never falls back to direct rm.
 		# shellcheck disable=SC2086
 		if git worktree remove $remove_flag "$worktree_path" 2>/dev/null; then
 			removed="$_WT_CLEAN_BOOL_TRUE"
 		fi
 	fi
 	if [[ "$removed" != "$_WT_CLEAN_BOOL_TRUE" ]]; then
+		_WT_CLEAN_LAST_REMOVAL_OUTCOME="$_WT_CLEAN_OUTCOME_FAILED"
 		echo -e "${RED}Failed to remove $worktree_branch - may have uncommitted changes${NC}" >&2
 		return 1
 	fi
 	if ! prune_missing_worktree_metadata "$repo_context" "$worktree_path"; then
-		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" "metadata-prune-failed" "partial-cleanup" "$audit_context"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$worktree_path" \
+			"metadata-prune-failed" "$_WT_CLEAN_MODE_PARTIAL" "$audit_context"
+		_WT_CLEAN_LAST_REMOVAL_OUTCOME="$_WT_CLEAN_OUTCOME_FAILED"
 		return 1
 	fi
 	unregister_worktree "$worktree_path"
@@ -1175,6 +1199,7 @@ _clean_remove_classified_worktree() {
 		full_loop_mark_cleanup_cleaned_for_worktree "$worktree_path" || true
 	fi
 	printf '%s\n' "$_WT_CLEAN_COMPLETED_EVENT"
+	_WT_CLEAN_LAST_REMOVAL_OUTCOME="$_WT_CLEAN_OUTCOME_REMOVED"
 	return 0
 }
 
@@ -1193,6 +1218,7 @@ _clean_remove_candidate_after_lease() {
 	local removal_status=0
 	local removal_mode="$_WT_CLEAN_MODE_PERMANENT"
 	local recovery_authorized="$_WT_CLEAN_BOOL_FALSE"
+	_WT_CLEAN_LAST_REMOVAL_OUTCOME="$_WT_CLEAN_OUTCOME_SKIPPED"
 
 	if worktree_removal_guard "$worktree_path" "$_WTAR_WH_CALLER" "$_WT_CLEAN_REASON_BRANCH_MERGED"; then
 		guard_status=0
@@ -1238,6 +1264,7 @@ _clean_remove_merged() {
 
 	local worktree_path=""
 	local worktree_branch=""
+	local removal_failures=0
 
 	while IFS= read -r line; do
 		if [[ "$line" =~ ^worktree\ (.+)$ ]]; then
@@ -1285,8 +1312,12 @@ _clean_remove_merged() {
 						worktree_branch=""
 						continue
 					fi
-					_clean_remove_candidate_after_lease "$worktree_path" "$worktree_branch" "$force_merged" "$preserve_branch" \
-						"$audit_context" "$main_wt_path" "$merge_type" "$merged_prs" "$closed_prs" "$open_prs" || true
+					if ! _clean_remove_candidate_after_lease "$worktree_path" "$worktree_branch" "$force_merged" "$preserve_branch" \
+						"$audit_context" "$main_wt_path" "$merge_type" "$merged_prs" "$closed_prs" "$open_prs"; then
+						if [[ "$_WT_CLEAN_LAST_REMOVAL_OUTCOME" == "$_WT_CLEAN_OUTCOME_FAILED" ]]; then
+							removal_failures=$((removal_failures + 1))
+						fi
+					fi
 				fi
 			fi
 			worktree_path=""
@@ -1297,6 +1328,7 @@ _clean_remove_merged() {
 		echo ""
 	)
 
+	[[ "$removal_failures" -eq 0 ]] || return 1
 	return 0
 }
 
@@ -1433,9 +1465,14 @@ cmd_clean() {
 
 	if [[ "$response" =~ ^[Yy]$ ]]; then
 		# Second pass: remove merged worktrees
-		_clean_remove_merged "$default_branch" "$main_worktree_path" "$remote_state_unknown" "$merged_pr_branches" "$open_pr_branches" "$force_merged" "$closed_pr_branches"
+		local cleanup_status=0
+		_clean_remove_merged "$default_branch" "$main_worktree_path" "$remote_state_unknown" "$merged_pr_branches" "$open_pr_branches" "$force_merged" "$closed_pr_branches" || cleanup_status=$?
 		if declare -F full_loop_reconcile_cleanup_receipts >/dev/null 2>&1; then
 			full_loop_reconcile_cleanup_receipts
+		fi
+		if [[ "$cleanup_status" -ne 0 ]]; then
+			echo -e "${YELLOW}Cleanup completed with one or more removal failures${NC}" >&2
+			return 1
 		fi
 		echo -e "${GREEN}Cleanup complete${NC}" >&2
 	else

--- a/.agents/scripts/worktree-helper-cmds.sh
+++ b/.agents/scripts/worktree-helper-cmds.sh
@@ -122,6 +122,14 @@ _remove_show_guard_error() {
 		printf '%s\n' "Reason: canonical-skip — the target is a registered canonical checkout." >&2
 		printf '%s\n' "Recovery: preserve the canonical checkout and remove only an eligible linked worktree. --force cannot bypass this protection." >&2
 		;;
+	git-worktree-locked)
+		printf '%s\n' "Reason: git-worktree-locked — Git metadata marks this worktree as explicitly locked." >&2
+		printf '%s\n' "Recovery: preserve the worktree, or unlock it only after its owning observation or session has ended. --force cannot bypass this protection." >&2
+		;;
+	git-metadata-unreadable)
+		printf '%s\n' "Reason: git-metadata-unreadable — the guard could not prove the exact worktree registration is readable and unlocked." >&2
+		printf '%s\n' "Recovery: repair Git metadata access and verify the exact worktree block is unlocked before retrying. --force cannot bypass this protection." >&2
+		;;
 	*)
 		printf '%s\n' "Reason: ${guard_reason:-guard-refused} — the shared safety guard did not authorize removal." >&2
 		printf '%s\n' "Recovery: inspect the cleanup audit log, resolve the safety condition, then retry." >&2
@@ -138,9 +146,10 @@ _remove_validate_path() {
 	local path_to_remove="$1"
 	local guard_caller="${SCRIPT_NAME:-worktree-helper.sh}"
 
-	# The shared guard blocks canonical repos, this shell's cwd, and every live
-	# process whose cwd is inside the target. --force may override ownership or
-	# dirty-state policy, but it must never override a live process cwd.
+	# The shared guard blocks canonical repos, Git-locked or metadata-unreadable
+	# worktrees, this shell's cwd, and every live process whose cwd is inside the
+	# target. --force may override ownership or dirty-state policy, but it must
+	# never override these preservation boundaries.
 	if ! worktree_removal_guard "$path_to_remove" "$guard_caller" "$_WT_REMOVE_MODE_MANUAL"; then
 		_remove_show_guard_error "$path_to_remove" "${WORKTREE_REMOVAL_GUARD_REASON:-}"
 		return 1
@@ -187,14 +196,11 @@ _remove_validate_path() {
 _remove_cleanup_and_execute() {
 	local path_to_remove="$1"
 	local repo_context=""
+	local completed_mode="trash"
+	local recoverable_archive=""
+	local force_remove="false"
 	repo_context=$(get_repo_root) || return 1
-
-	# Clean up aidevops runtime files before removal (prevents "contains untracked files" error)
-	# Use trash_path for recoverable deletion; fall back to rm -rf if trash unavailable.
-	trash_path "$path_to_remove/.agents/loop-state" || true
-	trash_path "$path_to_remove/.agents/tmp" || true
-	rm -f "$path_to_remove/.agents/.DS_Store" 2>/dev/null || true
-	rmdir "$path_to_remove/.agent" 2>/dev/null || true # Only removes if empty
+	[[ "${WORKTREE_FORCE_REMOVE:-}" == "1" ]] && force_remove="true"
 
 	# Capture branch name before removal for localdev cleanup (t1224.8)
 	local removed_branch=""
@@ -206,21 +212,28 @@ _remove_cleanup_and_execute() {
 		_remove_show_guard_error "$path_to_remove" "${WORKTREE_REMOVAL_GUARD_REASON:-}"
 		return 1
 	fi
+	if ! archive_worktree_path_recoverably "$path_to_remove" "${SCRIPT_NAME:-worktree-helper.sh}" \
+		"manual-cleanup"; then
+		_remove_show_guard_error "$path_to_remove" "${WORKTREE_REMOVAL_GUARD_REASON:-}"
+		return 1
+	fi
+	recoverable_archive="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
 
 	echo -e "${BLUE}Removing worktree: $path_to_remove${NC}"
-	# Move the worktree directory to trash BEFORE git deregisters it.
-	# This makes accidental removal recoverable — the directory survives in trash.
-	# git worktree prune then cleans up the now-missing entry from .git/worktrees/.
-	if ! trash_path "$path_to_remove"; then
-		# trash unavailable or failed — fall back to git worktree remove
-		git worktree remove "$path_to_remove" || return 1
-	else
-		if ! prune_missing_worktree_metadata "$repo_context" "$path_to_remove"; then
-			printf '%b\n' "${YELLOW}Partial cleanup: worktree files moved to trash, but Git metadata remains.${NC}"
-			printf '%s\n' "Recovery: resolve Git metadata permissions or locks, then prune the missing worktree from a linked worktree and verify it is absent from 'git worktree list --porcelain'."
-			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$path_to_remove" "metadata-prune-failed" "partial-cleanup"
-			return 1
-		fi
+	# Copy first, then let native Git perform the final source removal. A lock
+	# acquired at any point before that command keeps the registered source
+	# intact, while an interruption after it still leaves the archive.
+	if ! remove_archived_worktree_path "$path_to_remove" "$recoverable_archive" \
+		"${SCRIPT_NAME:-worktree-helper.sh}" "$_WT_REMOVE_MODE_MANUAL" \
+		"recovery_path=archive-first" "false" "$force_remove"; then
+		printf '%b\n' "${YELLOW}Cleanup stopped: the source remains protected and its recoverable archive was retained.${NC}"
+		return 1
+	fi
+	if ! prune_missing_worktree_metadata "$repo_context" "$path_to_remove"; then
+		printf '%b\n' "${YELLOW}Partial cleanup: the worktree archive is retained, but Git metadata verification failed.${NC}"
+		printf '%s\n' "Recovery: preserve the archive, resolve Git metadata permissions, then verify the exact worktree is absent from 'git worktree list --porcelain'."
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$path_to_remove" "metadata-prune-failed" "partial-cleanup"
+		return 1
 	fi
 
 	# Unregister ownership (t189)
@@ -229,7 +242,7 @@ _remove_cleanup_and_execute() {
 	echo -e "${GREEN}Worktree removed successfully${NC}"
 
 	# t2976: audit log — manual removal completed
-	log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_WH_CALLER" "$path_to_remove" "$_WT_REMOVE_MODE_MANUAL" "trash"
+	log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_WH_CALLER" "$path_to_remove" "$_WT_REMOVE_MODE_MANUAL" "$completed_mode"
 
 	# Localdev integration (t1224.8): auto-remove branch subdomain route
 	if [[ -n "$removed_branch" ]]; then


### PR DESCRIPTION
## Summary

Make every destructive worktree cleanup path fail closed on Git/process locks and retain an identity-bound recovery archive before native removal.

## Files Changed

.agents/scripts/audit-worktree-removal-helper.sh, .agents/scripts/pulse-cleanup-degraded-orphans.sh, .agents/scripts/pulse-cleanup.sh, .agents/scripts/skill-update-pr-lib.sh, .agents/scripts/tests/test-pulse-cleanup-centralize-worktrees.sh, .agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh, .agents/scripts/tests/test-pulse-cleanup-preserves-dirty.sh, .agents/scripts/tests/test-pulse-cleanup-unregister.sh, .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh, .agents/scripts/tests/test-worktree-cleanup-claim-guard.sh, .agents/scripts/tests/test-worktree-helper-nested-path-guard.sh, .agents/scripts/tests/test-worktree-metadata-prune.sh, .agents/scripts/tests/test-worktree-removal-audit.sh, .agents/scripts/worktree-clean-lib.sh, .agents/scripts/worktree-helper-cmds.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified: nine focused cleanup suites pass; worktree audit passes 41/41 on modern Bash and Bash 3.2; metadata-prune passes on both; changed-file lint, ShellCheck for all 15 changed shell files, secretlint, portability, complexity, and git diff checks pass.

Resolves #28822


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.192 plugin for [OpenCode](https://opencode.ai) v1.18.8 with gpt-5.5 spent 11d 19h and 45,011,115 tokens on this with the user in an interactive session.