### PR TITLE
GH#28823: Eliminate native multi-frame and issue-view quota unknowns

### DIFF
--- a/.agents/scripts/gh-quota-attribution-lib.sh
+++ b/.agents/scripts/gh-quota-attribution-lib.sh
@@ -623,6 +623,13 @@ _ghqa_write_complete_frames() {
 			quota_cost="$success_quota_cost"
 		elif [[ -n "$exact_success_cost" ]]; then
 			quota_cost="$exact_success_cost"
+		# Native non-api commands can fan out into multiple complete REST
+		# responses. Each successful core/search frame is one exact primary-rate
+		# request. Keep direct `gh api` calls on the endpoint-aware parser above so
+		# GET /rate_limit and ambiguous API argument shapes remain fail-closed.
+		elif [[ "$frame_total" -gt 1 && "$outcome" == success && "${2:-}" != api &&
+			"$resource" =~ ^(core|search)$ ]]; then
+			quota_cost=1
 		elif [[ "$resource" == graphql && "$response_cost" =~ ^[0-9]+$ ]]; then
 			quota_cost="$response_cost"
 			invalidate_state=1

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -944,8 +944,9 @@ _rest_pr_create() {
 # The --json FIELDS flag maps common gh field names onto REST fields so
 # proactive REST-first routing can preserve compact gh-shaped output. Field
 # names align with `gh issue view --json` for common fields (state, title,
-# body, labels, assignees, createdAt).
-# Fields without an exact projection, including GraphQL `id`, remain native.
+# body, labels, assignees, createdAt). GitHub's REST `node_id` is the exact
+# global node identifier returned by the GraphQL-backed gh `id` field.
+# Fields without an exact projection remain native.
 #
 # Returns the underlying gh api exit code.
 #######################################
@@ -1014,6 +1015,7 @@ _rest_issue_object_json_jq() {
 	local user_jq="$2"
 	local projection=""
 	local field=""
+	local id_projection='id: (if (.node_id | type) == "string" and .node_id != "" then .node_id else error("REST issue node_id must be a non-empty string") end)'
 	local actor_projection=""
 	local assignees_projection=""
 	local labels_projection=""
@@ -1023,6 +1025,7 @@ _rest_issue_object_json_jq() {
 	while IFS= read -r field; do
 		[[ -z "$field" ]] && continue
 		case "$field" in
+		id) projection="${projection}${projection:+,}${id_projection}" ;;
 		number) projection="${projection}${projection:+,}number: .number" ;;
 		state) projection="${projection}${projection:+,}state: (.state | ascii_upcase)" ;;
 		url) projection="${projection}${projection:+,}url: .html_url" ;;

--- a/.agents/scripts/shared-gh-wrappers-rest-read-semantics.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-read-semantics.sh
@@ -177,7 +177,7 @@ _rest_issue_view_fields_supported() {
 	local field=""
 	while IFS= read -r field; do
 		case "$field" in
-		number|state|url|title|body|createdAt|updatedAt|closedAt|labels|assignees|author|stateReason|closed|locked) ;;
+		id|number|state|url|title|body|createdAt|updatedAt|closedAt|labels|assignees|author|stateReason|closed|locked) ;;
 		*) return 1 ;;
 		esac
 	done < <(_rest_split_csv "$fields")

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -477,6 +477,38 @@ assert_eq "exact successful frame records inferred quota" "1" \
 assert_eq "exact failed frame leaves inferred quota unknown" "x" \
 	"$(awk -F '\t' 'NR == 1 { print $7 }' "$exact_failure_result")"
 
+# --- Test 11d: successful native multi-frame REST costs are exact -----------
+native_multi_result="$TMPDIR/native-multi.result"
+native_multi_state="$TMPDIR/native-multi.state"
+native_multi_frames=$'frame\t1\t1\t200\tcore\t500\t4500\t1800000000\t10\nframe\t2\t1\t200\tcore\t501\t4499\t1800000000\t11\nframe\t3\t1\t200\tcore\t502\t4498\t1800000000\t12'
+: >"$native_multi_result"
+_ghqa_state_write_all "$native_multi_state" 500 1800000000 20 1800000000 0 1800000000
+_ghqa_write_complete_frames "$native_multi_result" "$native_multi_state" graphql 1 0 \
+	"$native_multi_frames" gh run view 123 --log
+assert_eq "native multi-frame REST pages retain separate exact attempts" \
+	"rest:1:success:1,rest:2:success:1,rest:3:success:1" \
+	"$(awk -F '\t' '{ value = value (value ? "," : "") $2 ":" $3 ":" $4 ":" $7 } END { print value }' "$native_multi_result")"
+
+native_mixed_result="$TMPDIR/native-mixed.result"
+native_mixed_state="$TMPDIR/native-mixed.state"
+native_mixed_frames=$'frame\t1\t1\t200\tcore\t10\t4990\t1800000000\t10\nframe\t2\t1\t200\tgraphql\t20\t4980\t1800000000\t11'
+: >"$native_mixed_result"
+_ghqa_state_write_all "$native_mixed_state" 10 1800000000 20 1800000000 0 1800000000
+_ghqa_write_complete_frames "$native_mixed_result" "$native_mixed_state" graphql 1 0 \
+	"$native_mixed_frames" gh run view 123
+assert_eq "native multi-frame inference leaves GraphQL without proof unknown" "1,x" \
+	"$(awk -F '\t' '{ value = value (value ? "," : "") $7 } END { print value }' "$native_mixed_result")"
+
+native_failed_result="$TMPDIR/native-failed.result"
+native_failed_state="$TMPDIR/native-failed.state"
+native_failed_frames=$'frame\t1\t1\t200\tcore\t10\t4990\t1800000000\t10\nframe\t2\t1\t500\tcore\t12\t4988\t1800000000\t11'
+: >"$native_failed_result"
+_ghqa_state_write_all "$native_failed_state" 10 1800000000 20 1800000000 0 1800000000
+_ghqa_write_complete_frames "$native_failed_result" "$native_failed_state" graphql 1 1 \
+	"$native_failed_frames" gh run view 123
+assert_eq "failed native REST frame remains unknown without counter proof" "1,x" \
+	"$(awk -F '\t' '{ value = value (value ? "," : "") $7 } END { print value }' "$native_failed_result")"
+
 # --- Test 12: effective window comes from retained attempt timestamps -----
 gh_clear_log
 first_ts=$((now - 30))

--- a/.agents/scripts/tests/test-gh-issue-read-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-issue-read-rest-fallback.sh
@@ -165,9 +165,12 @@ gh() {
 			fi
 			_i=$((_i + 1))
 		done
-		local _result="${STUB_REST_VIEW_RESULT:-{\"state\":\"OPEN\",\"number\":42,\"title\":\"Test issue\",\"body\":\"body text\",\"labels\":[{\"name\":\"bug\"}],\"assignees\":[]}}"
+		local _result="${STUB_REST_VIEW_RESULT:-}"
+		if [[ -z "$_result" ]]; then
+			_result='{"state":"OPEN","number":42,"title":"Test issue","body":"body text","labels":[{"name":"bug"}],"assignees":[]}'
+		fi
 		if [[ -n "$_jq_expr" ]]; then
-			printf '%s\n' "$_result" | jq -r "$_jq_expr" 2>/dev/null
+			printf '%s\n' "$_result" | jq -r "$_jq_expr" 2>/dev/null || return 1
 		else
 			printf '%s\n' "$_result"
 		fi
@@ -268,9 +271,10 @@ fi
 unset STUB_REST_VIEW_RESULT
 
 # =============================================================================
-# Test 3: _rest_issue_view accepts --json flag without error (compat, ignored)
+# Test 3: _rest_issue_view projects supported --json fields exactly
 # =============================================================================
 : >"$GH_CALLS"
+export STUB_REST_VIEW_RESULT='{"state":"open"}'
 
 _result=$(_rest_issue_view 42 --repo "owner/repo" --json state 2>&1)
 _rc=$?
@@ -281,6 +285,32 @@ else
 	fail "_rest_issue_view accepts --json flag without error" \
 		"rc=${_rc} output=${_result}"
 fi
+
+export STUB_REST_VIEW_RESULT='{"node_id":"I_kwDOFixture42","number":42,"state":"open","updated_at":"2026-07-28T19:38:58Z"}'
+_result=$(_rest_issue_view 42 --repo "owner/repo" --json id,number,state,updatedAt 2>/dev/null)
+if jq -e '.id == "I_kwDOFixture42" and .number == 42 and .state == "OPEN" and .updatedAt == "2026-07-28T19:38:58Z"' \
+	>/dev/null 2>&1 <<<"$_result"; then
+	pass "_rest_issue_view maps GraphQL id exactly from REST node_id"
+else
+	fail "_rest_issue_view maps GraphQL id exactly from REST node_id" "output=${_result}"
+fi
+
+_result=$(_rest_issue_view 42 --repo "owner/repo" --json id --jq '.id' 2>/dev/null)
+if [[ "$_result" == "I_kwDOFixture42" ]]; then
+	pass "_rest_issue_view preserves scalar jq output for id"
+else
+	fail "_rest_issue_view preserves scalar jq output for id" "output=${_result}"
+fi
+
+export STUB_REST_VIEW_RESULT='{"node_id":null,"number":42,"state":"open"}'
+_result=$(_rest_issue_view 42 --repo "owner/repo" --json id,number 2>&1)
+_rc=$?
+if [[ "$_rc" -ne 0 ]]; then
+	pass "_rest_issue_view rejects a missing REST node_id"
+else
+	fail "_rest_issue_view rejects a missing REST node_id" "output=${_result}"
+fi
+unset STUB_REST_VIEW_RESULT
 
 # =============================================================================
 # Test 4: _rest_issue_view returns error when issue number or repo missing

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -129,25 +129,37 @@ if [[ "$1" == "api" && "$2" == "rate_limit" ]]; then
 	exit 0
 fi
 if [[ "${GH_DEBUG:-}" == "api" && "${STUB_GH_DEBUG_RESPONSE:-0}" == "1" ]]; then
-	printf '* Request at 2026-07-24 00:00:00 +0000 UTC\n' >&2
-	printf '> Authorization: token private-fixture-token\n\n' >&2
-	if [[ "${STUB_GH_DEBUG_REQUEST_ONLY:-0}" != "1" ]]; then
-		printf '< HTTP/2.0 %s Fixture\n' "${STUB_GH_DEBUG_STATUS:-200}" >&2
-		printf '< X-Ratelimit-Resource: %s\n' "${STUB_GH_DEBUG_RESOURCE:-graphql}" >&2
-		printf '< X-Ratelimit-Used: %s\n' "${STUB_GH_DEBUG_USED:-201}" >&2
-		printf '< X-Ratelimit-Remaining: %s\n' "${STUB_GH_DEBUG_REMAINING:-4799}" >&2
-		printf '< X-Ratelimit-Reset: %s\n\n' "${STUB_GH_DEBUG_RESET:-2000}" >&2
-		if [[ -n "${STUB_GH_DEBUG_BODY:-}" ]]; then
-			printf '%s\n' "$STUB_GH_DEBUG_BODY" >&2
-		else
-			printf '{"private":"response-body-fixture"}\n' >&2
+	_stub_frame=1
+	_stub_frame_total=1
+	[[ "${STUB_GH_DEBUG_MULTI_FRAME:-0}" == "1" ]] && _stub_frame_total=3
+	while [[ "$_stub_frame" -le "$_stub_frame_total" ]]; do
+		_stub_used="${STUB_GH_DEBUG_USED:-201}"
+		_stub_remaining="${STUB_GH_DEBUG_REMAINING:-4799}"
+		if [[ "$_stub_frame_total" -gt 1 ]]; then
+			_stub_used=$((${STUB_GH_DEBUG_MULTI_USED_BASE:-100} + _stub_frame - 1))
+			_stub_remaining=$((${STUB_GH_DEBUG_MULTI_REMAINING_BASE:-4900} - _stub_frame + 1))
 		fi
-		if [[ "${STUB_GH_DEBUG_TRAILING_RESPONSE:-0}" == "1" ]]; then
-			printf '< HTTP/2.0 200 Redirected\n\n' >&2
-			printf '{"private":"redirected-response-fixture"}\n' >&2
+		printf '* Request at 2026-07-24 00:00:00 +0000 UTC\n' >&2
+		printf '> Authorization: token private-fixture-token\n\n' >&2
+		if [[ "${STUB_GH_DEBUG_REQUEST_ONLY:-0}" != "1" ]]; then
+			printf '< HTTP/2.0 %s Fixture\n' "${STUB_GH_DEBUG_STATUS:-200}" >&2
+			printf '< X-Ratelimit-Resource: %s\n' "${STUB_GH_DEBUG_RESOURCE:-graphql}" >&2
+			printf '< X-Ratelimit-Used: %s\n' "$_stub_used" >&2
+			printf '< X-Ratelimit-Remaining: %s\n' "$_stub_remaining" >&2
+			printf '< X-Ratelimit-Reset: %s\n\n' "${STUB_GH_DEBUG_RESET:-2000}" >&2
+			if [[ -n "${STUB_GH_DEBUG_BODY:-}" ]]; then
+				printf '%s\n' "$STUB_GH_DEBUG_BODY" >&2
+			else
+				printf '{"private":"response-body-fixture"}\n' >&2
+			fi
+			if [[ "${STUB_GH_DEBUG_TRAILING_RESPONSE:-0}" == "1" ]]; then
+				printf '< HTTP/2.0 200 Redirected\n\n' >&2
+				printf '{"private":"redirected-response-fixture"}\n' >&2
+			fi
 		fi
-	fi
-	printf '* Request took 12.5ms\n' >&2
+		printf '* Request took 12.5ms\n' >&2
+		_stub_frame=$((_stub_frame + 1))
+	done
 	[[ -z "${STUB_GH_DIAGNOSTIC:-}" ]] || printf '%s\n' "$STUB_GH_DIAGNOSTIC" >&2
 elif [[ -n "${STUB_GH_UNFRAMED_PRIVATE_STDERR:-}" ]]; then
 	printf '%s\n' "$STUB_GH_UNFRAMED_PRIVATE_STDERR" >&2
@@ -203,6 +215,32 @@ if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+/issues\? ]]; then
 	else
 		printf '%s\n' "$fixture"
 	fi
+	exit 0
+fi
+if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+/issues/[0-9]+$ ]]; then
+	jq_filter=""
+	i=3
+	while [[ $i -le $# ]]; do
+		if [[ "${!i}" == "--jq" ]]; then
+			next=$((i + 1))
+			jq_filter="${!next:-}"
+			break
+		fi
+		i=$((i + 1))
+	done
+	fixture="${STUB_REST_ISSUE_VIEW_JSON:-}"
+	if [[ -z "$fixture" ]]; then
+		fixture='{"node_id":"I_kwDOFixture42","number":42,"state":"open","updated_at":"2026-07-28T19:38:58Z"}'
+	fi
+	if [[ -n "$jq_filter" ]]; then
+		printf '%s\n' "$fixture" | jq -r -c "$jq_filter" || exit 1
+	else
+		printf '%s\n' "$fixture"
+	fi
+	exit 0
+fi
+if [[ "$1" == "issue" && "$2" == "view" && -n "${STUB_NATIVE_ISSUE_VIEW_JSON:-}" ]]; then
+	printf '%s\n' "$STUB_NATIVE_ISSUE_VIEW_JSON"
 	exit 0
 fi
 EOF
@@ -777,6 +815,51 @@ else
 	_fail "unsupported issue view GraphQL preservation" "argv: $argv log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
 fi
 
+echo ""
+echo "Test 15e: issue view node IDs preserve exact REST output"
+_reset_log
+export AIDEVOPS_GH_API_LOG="$TMP/gh-api-calls-issue-view-id.log"
+rm -f "$AIDEVOPS_GH_API_LOG"
+output=$(AIDEVOPS_GH_FORCE_REST_READS=1 "$SHIM_RUN" issue view 42 --repo owner/repo \
+	--json id,number,state,updatedAt 2>/dev/null || true)
+argv=$(_read_argv)
+if jq -e '.id == "I_kwDOFixture42" and .number == 42 and .state == "OPEN" and .updatedAt == "2026-07-28T19:38:58Z"' \
+	>/dev/null 2>&1 <<<"$output" &&
+	[[ "$argv" == *$'api\n/repos/owner/repo/issues/42'* ]] &&
+	grep -q $'\tgh_issue_view\trest' "$AIDEVOPS_GH_API_LOG" &&
+	! grep -q $'\tgh_issue_view\tgraphql' "$AIDEVOPS_GH_API_LOG"; then
+	_pass "issue view id maps exactly from REST node_id"
+else
+	_fail "issue view id REST projection" "output: $output argv: $argv log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
+fi
+
+_reset_log
+export AIDEVOPS_GH_API_LOG="$TMP/gh-api-calls-issue-view-id-scalar.log"
+rm -f "$AIDEVOPS_GH_API_LOG"
+output=$(AIDEVOPS_GH_FORCE_REST_READS=1 "$SHIM_RUN" issue view 42 --repo owner/repo \
+	--json id --jq '.id' 2>/dev/null || true)
+if [[ "$output" == "I_kwDOFixture42" ]] && grep -q $'\tgh_issue_view\trest' "$AIDEVOPS_GH_API_LOG"; then
+	_pass "issue view id preserves scalar jq output"
+else
+	_fail "issue view id scalar REST projection" "output: $output log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
+fi
+
+_reset_log
+export AIDEVOPS_GH_API_LOG="$TMP/gh-api-calls-issue-view-id-malformed.log"
+rm -f "$AIDEVOPS_GH_API_LOG"
+output=$(STUB_REST_ISSUE_VIEW_JSON='{"node_id":null,"number":42,"state":"open"}' \
+	STUB_NATIVE_ISSUE_VIEW_JSON='{"id":"I_nativeFallback","number":42,"state":"OPEN"}' \
+	AIDEVOPS_GH_FORCE_REST_READS=1 "$SHIM_RUN" issue view 42 --repo owner/repo \
+	--json id,number,state 2>/dev/null || true)
+argv=$(_read_argv)
+if [[ "$output" == '{"id":"I_nativeFallback","number":42,"state":"OPEN"}' ]] &&
+	[[ "$argv" == $'issue\nview\n42\n--repo\nowner/repo\n--json\nid,number,state' ]] &&
+	grep -q $'\tgh_issue_view\tgraphql' "$AIDEVOPS_GH_API_LOG"; then
+	_pass "malformed REST node_id fails open to unchanged native issue view"
+else
+	_fail "malformed issue node_id native fallback" "output: $output argv: $argv log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
+fi
+
 # =============================================================================
 # Test 16: raw interactive aidevops tracking issue creation is normalized
 # =============================================================================
@@ -1220,6 +1303,24 @@ if [[ "$(_read_attempt_quota "$redirect_log")" == "1" \
 	_pass "redirect frames select the single complete GitHub quota response"
 else
 	_fail "redirect response attribution" "log: $(cat "$redirect_log" 2>/dev/null || true)"
+fi
+
+native_multi_log="$TMP/exact-native-multi-rest.log"
+native_multi_state="$TMP/exact-native-multi-rest-state"
+: >"$native_multi_log"
+GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$native_multi_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$native_multi_log" STUB_GH_DEBUG_RESPONSE=1 \
+	STUB_GH_DEBUG_MULTI_FRAME=1 STUB_BOOTSTRAP_CORE_USED=100 \
+	STUB_GH_DEBUG_RESOURCE=core STUB_GH_DEBUG_RESET=2000 \
+	"$SHIM_RUN" run view 123 --log >/dev/null 2>/dev/null
+native_multi_summary=$(awk -F '\t' '$2 == "gh_run_view" && $9 == "attempt" {
+	value = value (value ? "," : "") $3 ":" $12 ":" $14 ":" $17
+} END { print value }' "$native_multi_log")
+if [[ "$native_multi_summary" == "rest:1:success:1,rest:2:success:1,rest:3:success:1" ]]; then
+	_pass "native multi-frame REST responses record exact per-frame costs"
+else
+	_fail "native multi-frame REST quota attribution" "summary: $native_multi_summary log: $(cat "$native_multi_log" 2>/dev/null || true)"
 fi
 
 incomplete_log="$TMP/exact-incomplete-rest.log"


### PR DESCRIPTION
## Summary

- Attribute each successful complete `core` or `search` response frame from a native non-`api` multi-frame command as one exact primary-rate request.
- Preserve fail-closed attribution for direct `gh api`, GraphQL, failed, incomplete, and ambiguous frames.
- Project `gh issue view --json id` exactly from a validated non-empty REST `node_id`, falling back to the unchanged native command when REST cannot provide that identity.
- Add unit, shim, scalar-output, malformed-identity, and native-fallback regressions.

## Files

- `.agents/scripts/gh-quota-attribution-lib.sh`: native multi-frame exact-cost inference.
- `.agents/scripts/shared-gh-wrappers-rest-read-semantics.sh`: exact issue-view `id` support.
- `.agents/scripts/shared-gh-wrappers-rest-fallback.sh`: validated `node_id` projection.
- `.agents/scripts/tests/test-gh-api-instrument.sh`: frame-level exactness and fail-closed tests.
- `.agents/scripts/tests/test-gh-shim.sh`: end-to-end native multi-frame and issue-view routing tests.
- `.agents/scripts/tests/test-gh-issue-read-rest-fallback.sh`: lower-level projection and malformed-response tests.

## Verification

- `bash .agents/scripts/tests/test-gh-api-instrument.sh` — 205 passed.
- `bash .agents/scripts/tests/test-gh-shim.sh` — 102 passed.
- `bash .agents/scripts/tests/test-gh-issue-read-rest-fallback.sh` — 30 passed.
- macOS Bash 3.2: `test-gh-shim.sh` and `test-gh-issue-read-rest-fallback.sh` passed; all six changed files passed syntax validation.
- `shellcheck` passed for all six changed files.
- `.agents/scripts/linters-local.sh` passed.
- Forced local REST issue-view verification returned exact `id`, number, state, and timestamp with exit 0.

## Residual risk

- Exact frame attribution remains intentionally dependent on complete GitHub `GH_DEBUG=api` response framing.
- Missing or malformed REST `node_id` values intentionally fall back to native GraphQL routing rather than fabricating identity.

Resolves #28823
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.192 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.5 spent 11d 20h and 45,625,286 tokens on this with the user in an interactive session.