### PR TITLE
GH#28827: Exclude pulse stage subshells from runtime audit

### DIFF
--- a/.agents/scripts/runtime-audit-rules/process-count-anomaly.sh
+++ b/.agents/scripts/runtime-audit-rules/process-count-anomaly.sh
@@ -39,6 +39,19 @@ runtime_audit_check() {
 	# Count lines that contain the pattern but exclude greps of itself
 	local matches
 	matches=$(printf '%s\n' "$ps_out" | grep -F "$pattern" | grep -vE 'grep|runtime-audit|runtime-health-audit')
+	if [[ -z "${PS_OUTPUT_OVERRIDE:-}" && -n "$matches" ]]; then
+		local filtered_matches="" match_line pid ppid ppid_cmd
+		while IFS= read -r match_line; do
+			read -r pid _ <<<"$match_line"
+			ppid=$(ps -p "$pid" -o ppid= 2>/dev/null | tr -d ' ')
+			if [[ -n "$ppid" ]]; then
+				ppid_cmd=$(ps -p "$ppid" -o command= 2>/dev/null)
+				[[ "$ppid_cmd" == *"$pattern"* ]] && continue
+			fi
+			filtered_matches+="${filtered_matches:+$'\n'}${match_line}"
+		done <<<"$matches"
+		matches="$filtered_matches"
+	fi
 	local count
 	count=$(printf '%s\n' "$matches" | grep -cE '\S' 2>/dev/null || true)
 	[[ "$count" =~ ^[0-9]+$ ]] || count=0

--- a/.agents/scripts/tests/test-runtime-audit-detectors.sh
+++ b/.agents/scripts/tests/test-runtime-audit-detectors.sh
@@ -198,6 +198,49 @@ out=$(_run_detector "$RULES_DIR/process-count-anomaly.sh" \
 assert_rc "2.5 below-threshold fixture returns 0" "0" "$rc"
 assert_empty "2.6 below-threshold emits no output" "$out"
 
+# Live mode: background stage subshells inherit the pulse-wrapper argv but
+# have the root pulse process as their parent, so they must not count as
+# duplicate top-level instances.
+FAKE_PS_DIR="$TMPDIR_TEST/fake-ps-bin"
+mkdir -p "$FAKE_PS_DIR"
+cat >"$FAKE_PS_DIR/ps" <<'FAKE_PS'
+#!/usr/bin/env bash
+if [[ "$*" == "-ax -o pid=,command=" ]]; then
+	printf '%s\n' \
+		"  101 /bin/bash /Users/x/.aidevops/agents/scripts/pulse-wrapper.sh" \
+		"  102 /bin/bash /Users/x/.aidevops/agents/scripts/pulse-wrapper.sh" \
+		"  103 /bin/bash /Users/x/.aidevops/agents/scripts/pulse-wrapper.sh" \
+		"  104 /bin/bash /Users/x/.aidevops/agents/scripts/pulse-wrapper.sh" \
+		"  105 /bin/bash /Users/x/.aidevops/agents/scripts/pulse-wrapper.sh" \
+		"  106 /bin/bash /Users/x/.aidevops/agents/scripts/pulse-wrapper.sh"
+	exit 0
+fi
+if [[ "$4" == "ppid=" ]]; then
+	if [[ "$2" == "101" ]]; then
+		printf '1\n'
+	else
+		printf '101\n'
+	fi
+	exit 0
+fi
+if [[ "$4" == "command=" ]]; then
+	if [[ "$2" == "101" ]]; then
+		printf '/bin/bash /Users/x/.aidevops/agents/scripts/pulse-wrapper.sh\n'
+	else
+		printf '/sbin/init\n'
+	fi
+	exit 0
+fi
+exit 1
+FAKE_PS
+chmod +x "$FAKE_PS_DIR/ps"
+out=$(_run_detector "$RULES_DIR/process-count-anomaly.sh" \
+	"PATH=$FAKE_PS_DIR:/usr/bin:/bin" \
+	"LEAK_THRESHOLD=3" \
+	"PROC_PATTERN=pulse-wrapper.sh") && rc=0 || rc=$?
+assert_rc "2.7 live mode excludes pulse-wrapper child subshells" "0" "$rc"
+assert_empty "2.8 filtered live mode emits no output" "$out"
+
 # ---------------------------------------------------------------------------
 # Test 3: deployed-vs-source-mtime-drift
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Filter pulse-wrapper child subshells by their parent process before evaluating live process-count anomalies, while preserving fixture behavior.

## Files Changed

.agents/scripts/runtime-audit-rules/process-count-anomaly.sh, .agents/scripts/tests/test-runtime-audit-detectors.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — bash .agents/scripts/tests/test-runtime-audit-detectors.sh (55 passed); shellcheck on changed scripts; git diff --check

Resolves #28827


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.192 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 4m and 78,180 tokens on this as a headless worker.