### PR TITLE
GH#28830: fix: correlate terminal dispatch evidence

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -1402,11 +1402,12 @@ cmd_transition() {
 	if [[ ("$phase" == "$LEASE_PHASE_PRELAUNCH" || "$phase" == "ready") && "$current_phase" != "$LEASE_PHASE_PRELAUNCH" ]]; then
 		return 1
 	fi
-	local expires_at="0" now_epoch="" body=""
+	local expires_at="0" now_epoch="" body="" attempt_id="${AIDEVOPS_ATTEMPT_ID:-unknown}"
+	[[ "$attempt_id" =~ ^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$ ]] || attempt_id="unknown"
 	now_epoch=$(_now_epoch)
 	[[ "$phase" == "terminal" ]] || expires_at="$((now_epoch + ttl))"
 	body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
-DISPATCH_LEASE phase=${phase} lease_token=${lease_token} device=$(_resolve_device_id) session=${session_key:-issue-${issue_number}} expires_at=${expires_at} ts=$(_now_utc)
+DISPATCH_LEASE phase=${phase} lease_token=${lease_token} device=$(_resolve_device_id) session=${session_key:-issue-${issue_number}} expires_at=${expires_at} ts=$(_now_utc) attempt_id=${attempt_id}
 <!-- ops:end -->"
 	gh api "$(_issue_comments_endpoint "$repo_slug" "$issue_number")" --method POST --field body="$body" >/dev/null 2>&1 || return 1
 	return 0

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -2310,6 +2310,7 @@ _dd_has_matching_terminal_lease() {
 			.lease_token == $marker.lease_token and
 			.device == $marker.device and
 			.session == $marker.session and
+			.lease_terminal_attempt_id == $marker.attempt_id and
 			((.id // 0) | tostring) == $marker.claim_id
 		)' >/dev/null 2>&1; then
 		return 0

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -2266,11 +2266,12 @@ _dd_fetch_trusted_issue_comments() {
 #######################################
 # Check for a cryptographically-unpredictable lease token whose terminal
 # transition matches the trusted dispatch author, original claim author,
-# device, and session. Both the claim and transition ordering must surround the
-# deterministic dispatch comment, so unrelated or forged terminal text cannot
-# retire its dedup lock.
+# device, and session. Correlated markers bind directly to the exact claim and
+# may be retired by terminal state on either side of the delayed audit write.
+# Legacy markers retain strict claim-before/terminal-after ordering.
 #
-# Args: comments JSON, dispatch timestamp, dispatch comment ID, dispatch author
+# Args: comments JSON, dispatch timestamp, dispatch comment ID, dispatch author,
+#       dispatch comment body
 # Returns: 0 when a matching terminal lease supersedes dispatch; 1 otherwise
 #######################################
 _dd_has_matching_terminal_lease() {
@@ -2278,6 +2279,7 @@ _dd_has_matching_terminal_lease() {
 	local dispatch_created_at="$2"
 	local dispatch_id="$3"
 	local dispatch_author="$4"
+	local dispatch_body="${5:-}"
 	local lease_filter="${SCRIPT_DIR}/dispatch-lease-claims.jq"
 	local claims_json="[]"
 	local parsed_claims="[]"
@@ -2294,6 +2296,24 @@ _dd_has_matching_terminal_lease() {
 		--argjson now "$now_epoch" --argjson max_age 2147483647 \
 		--argjson include_terminal true \
 		-f "$lease_filter" 2>/dev/null) || return 1
+
+	local marker_json=""
+	marker_json=$(printf '%s' "$dispatch_body" | jq -Rrc '
+		try capture("aidevops:dispatch lease_token=(?<lease_token>[^ ]+) device=(?<device>[^ ]+) session=(?<session>[^ ]+) attempt_id=(?<attempt_id>[^ ]+) claim_id=(?<claim_id>[0-9]+)")
+		catch empty
+	' 2>/dev/null) || marker_json=""
+	if [[ -n "$marker_json" ]] && printf '%s' "$parsed_claims" | jq -e \
+		--argjson marker "$marker_json" --arg dispatch_author "$dispatch_author" '
+		any(.[];
+			.lease_phase == "terminal" and
+			.claim_author == $dispatch_author and
+			.lease_token == $marker.lease_token and
+			.device == $marker.device and
+			.session == $marker.session and
+			((.id // 0) | tostring) == $marker.claim_id
+		)' >/dev/null 2>&1; then
+		return 0
+	fi
 
 	if printf '%s' "$parsed_claims" | jq -e \
 		--arg dispatch_ts "$dispatch_created_at" --argjson dispatch_id "$dispatch_id" \
@@ -2389,10 +2409,11 @@ has_dispatch_comment() {
 		return 1
 	fi
 
-	local dispatch_created_at dispatch_author dispatch_id
+	local dispatch_created_at dispatch_author dispatch_id dispatch_body
 	dispatch_created_at=$(printf '%s' "$last_dispatch_json" | jq -r '.created_at // ""' 2>/dev/null) || dispatch_created_at=""
 	dispatch_author=$(printf '%s' "$last_dispatch_json" | jq -r '.author // ""' 2>/dev/null) || dispatch_author=""
 	dispatch_id=$(printf '%s' "$last_dispatch_json" | jq -r '.id // 0' 2>/dev/null) || dispatch_id=0
+	dispatch_body=$(printf '%s' "$last_dispatch_json" | jq -r '.body // ""' 2>/dev/null) || dispatch_body=""
 	[[ "$dispatch_id" =~ ^[0-9]+$ ]] || dispatch_id=0
 
 	# Check if the dispatch comment is within TTL
@@ -2403,7 +2424,7 @@ has_dispatch_comment() {
 	# A CLAIM_RELEASED write can fail after the worker has already emitted its
 	# structured terminal lease transition. Reconcile that authenticated
 	# transition as equivalent durable completion evidence (GH#28437).
-	if _dd_has_matching_terminal_lease "$comments_json" "$dispatch_created_at" "$dispatch_id" "$dispatch_author"; then
+	if _dd_has_matching_terminal_lease "$comments_json" "$dispatch_created_at" "$dispatch_id" "$dispatch_author" "$dispatch_body"; then
 		return 1
 	fi
 

--- a/.agents/scripts/dispatch-lease-claims.jq
+++ b/.agents/scripts/dispatch-lease-claims.jq
@@ -25,24 +25,27 @@ map(. as $claim |
        | select((.body // "") | contains("DISPATCH_LEASE"))
        | select(($claim.claim_author != "") and ((.author // .user.login // "") == $claim.claim_author))
        | . + ((.body | capture("phase=(?<phase>[^ ]+) lease_token=[^ ]+ device=(?<device>[^ ]+) session=(?<session>[^ ]+) expires_at=(?<expires>[0-9]+)")) as $t
+               | ((.body | [capture("attempt_id=(?<attempt_id>\\S+)")?][0] // {})) as $attempt
                | {transition_phase:$t.phase, transition_device:$t.device, transition_session:$t.session,
                   transition_expires:($t.expires|tonumber), transition_epoch:(.created_at | fromdateiso8601? // 0),
-                  transition_at:(.created_at // ""), transition_id:(.id | tonumber? // 0)})
+                  transition_at:(.created_at // ""), transition_id:(.id | tonumber? // 0),
+                  transition_attempt_id:($attempt.attempt_id // "unknown")})
        | select(.transition_device == $claim.device and .transition_session == $claim.session)
        | select([.transition_epoch, .transition_id] >= [$claim.created_epoch, ($claim.id | tonumber? // 0)])
       ] | sort_by(.created_at, .id)) as $transitions |
     (reduce $transitions[] as $event
-      ({phase:"prelaunch", expires:$claim.lease_expires_at, terminal_at:"", terminal_id:0};
+      ({phase:"prelaunch", expires:$claim.lease_expires_at, terminal_at:"", terminal_id:0, terminal_attempt_id:""};
        if .phase == "terminal" or .expires < $event.transition_epoch then .
        elif $event.transition_phase == "prelaunch" and .phase == "prelaunch" and $event.transition_expires >= $event.transition_epoch
          then .phase="prelaunch" | .expires=$event.transition_expires
        elif $event.transition_phase == "ready" and .phase == "prelaunch" and $event.transition_expires >= $event.transition_epoch
          then .phase="ready" | .expires=$event.transition_expires
        elif $event.transition_phase == "terminal" and (.phase == "prelaunch" or .phase == "ready")
-         then .phase="terminal" | .expires=0 | .terminal_at=$event.transition_at | .terminal_id=$event.transition_id
+         then .phase="terminal" | .expires=0 | .terminal_at=$event.transition_at | .terminal_id=$event.transition_id | .terminal_attempt_id=$event.transition_attempt_id
        else . end)) as $state |
     $claim + {lease_phase:$state.phase, lease_expires_at:$state.expires,
-              lease_terminal_at:$state.terminal_at, lease_terminal_id:$state.terminal_id}) |
+              lease_terminal_at:$state.terminal_at, lease_terminal_id:$state.terminal_id,
+              lease_terminal_attempt_id:$state.terminal_attempt_id}) |
 map(select(.age_seconds >= 0 and (.age_seconds <= $max_age or (.lease_phase == "ready" and .lease_expires_at >= $now)))) |
 (if $include_terminal then . else
     map(select(.lease_phase != "terminal" and ((.lease_expires_at // 0) == 0 or .lease_expires_at >= $now)))

--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -87,6 +87,15 @@ _lease_latest_entry() {
 	return $?
 }
 
+_lease_latest_entry_for_token() {
+	local session_key="$1"
+	local lease_token="$2"
+	jq -sc --arg sk "$session_key" --arg token "$lease_token" \
+		'[.[] | select(.session_key == $sk and (.lease_token // "") == $token)] | last // empty' \
+		"$LEDGER_FILE" 2>/dev/null
+	return $?
+}
+
 _lease_entry_is_active() {
 	local entry="$1"
 	local now_epoch="" expires_at="" phase="" status=""
@@ -330,7 +339,11 @@ _lease_registration_exists() {
 	local lease_token="$2"
 	[[ -s "$LEDGER_FILE" ]] || return 1
 	local existing="" existing_token="" existing_status=""
-	existing=$(_lease_latest_entry "$session_key") || return 1
+	if [[ -n "$lease_token" ]]; then
+		existing=$(_lease_latest_entry_for_token "$session_key" "$lease_token") || return 1
+	else
+		existing=$(_lease_latest_entry "$session_key") || return 1
+	fi
 	existing_token=$(printf '%s' "$existing" | jq -r '.lease_token // ""' 2>/dev/null) || return 1
 	existing_status=$(printf '%s' "$existing" | jq -r '.status // ""' 2>/dev/null) || return 1
 	if [[ -n "$lease_token" ]]; then
@@ -346,7 +359,7 @@ _lease_terminal_registration_exists() {
 	local lease_token="$2"
 	[[ -n "$lease_token" && -s "$LEDGER_FILE" ]] || return 1
 	local existing="" existing_token=""
-	existing=$(_lease_latest_entry "$session_key") || return 1
+	existing=$(_lease_latest_entry_for_token "$session_key" "$lease_token") || return 1
 	existing_token=$(printf '%s' "$existing" | jq -r '.lease_token // ""' 2>/dev/null) || return 1
 	[[ "$existing_token" == "$lease_token" ]] || return 1
 	if _lease_entry_is_active "$existing"; then
@@ -495,7 +508,7 @@ _lease_append_transition() {
 	_ensure_ledger
 	_acquire_lock || return 1
 	local current=""
-	current=$(_lease_latest_entry "$session_key") || current=""
+	current=$(_lease_latest_entry_for_token "$session_key" "$lease_token") || current=""
 	if [[ -z "$current" || "$(printf '%s' "$current" | jq -r '.lease_token // ""')" != "$lease_token" ]]; then
 		_release_lock
 		return 1

--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -334,11 +334,25 @@ _lease_registration_exists() {
 	existing_token=$(printf '%s' "$existing" | jq -r '.lease_token // ""' 2>/dev/null) || return 1
 	existing_status=$(printf '%s' "$existing" | jq -r '.status // ""' 2>/dev/null) || return 1
 	if [[ -n "$lease_token" ]]; then
-		[[ -n "$existing" && "$existing_token" == "$lease_token" ]]
+		[[ -n "$existing" && "$existing_token" == "$lease_token" ]] && _lease_entry_is_active "$existing"
 		return $?
 	fi
 	[[ -n "$existing" && -z "$existing_token" && "$existing_status" == "$LEDGER_STATUS_ACTIVE" ]]
 	return $?
+}
+
+_lease_terminal_registration_exists() {
+	local session_key="$1"
+	local lease_token="$2"
+	[[ -n "$lease_token" && -s "$LEDGER_FILE" ]] || return 1
+	local existing="" existing_token=""
+	existing=$(_lease_latest_entry "$session_key") || return 1
+	existing_token=$(printf '%s' "$existing" | jq -r '.lease_token // ""' 2>/dev/null) || return 1
+	[[ "$existing_token" == "$lease_token" ]] || return 1
+	if _lease_entry_is_active "$existing"; then
+		return 1
+	fi
+	return 0
 }
 
 #######################################
@@ -419,6 +433,11 @@ cmd_register() {
 		return 1
 	fi
 	if _lease_registration_exists "$session_key" "$lease_token"; then _release_lock; return 0; fi
+	if _lease_terminal_registration_exists "$session_key" "$lease_token"; then
+		_release_lock
+		echo "Error: register refused terminal dispatch lease" >&2
+		return 1
+	fi
 	local now
 	now=$(_now_utc)
 	owner_process_start=$(_process_start_token "$dispatch_pid" 2>/dev/null || true)
@@ -1335,7 +1354,13 @@ cmd_count() {
 	# pid. On a 1200-entry synthetic ledger that made `count` take ~2.4s.
 	# A single jq pass emits just the PIDs; bash keeps the kill -0 liveness
 	# checks because jq cannot query process state.
-	inflight_pids=$(jq -r --arg active "$LEDGER_STATUS_ACTIVE" 'select(.status == $active) | (.pid // 0)' "$LEDGER_FILE" 2>/dev/null) || inflight_pids=""
+	inflight_pids=$(jq -sr --arg active "$LEDGER_STATUS_ACTIVE" '
+		group_by([.session_key, (.lease_token // ""), (.attempt_id // "")])
+		| map(last)
+		| .[]
+		| select(.status == $active and (.lease_phase // "prelaunch") != "terminal")
+		| (.pid // 0)
+	' "$LEDGER_FILE" 2>/dev/null) || inflight_pids=""
 
 	if [[ -z "$inflight_pids" ]]; then
 		printf '%s\n' "0"

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -2027,8 +2027,9 @@ _dlw_mark_worker_in_progress() {
 # Stagger (GH#17549): reduces SQLite write contention on opencode.db
 # (busy_timeout=0). Without it, batches of 8+ workers all hit the DB
 # simultaneously, causing SQLITE_BUSY → silent mid-turn death. The stagger
-# happens after the dispatch comment is posted so a fast worker failure cannot
-# publish CLAIM_RELEASED before the public "Dispatching worker" audit event.
+# happens after the dispatch comment is posted. A fast worker can publish its
+# terminal lease before this parent reaches the audit write, so the marker
+# carries the exact dispatch identity for order-independent reconciliation.
 #
 # Dispatch comment (GH#15317): posted from the dispatcher, NOT from the
 # worker LLM session. Previously, the worker was responsible for posting
@@ -2094,6 +2095,7 @@ _dlw_post_launch_hooks() {
 	fi
 	dispatch_comment_body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
 Dispatching worker (deterministic).
+<!-- aidevops:dispatch lease_token=${_claim_lease_token:-legacy} device=${_claim_lease_device:-legacy} session=${session_key} attempt_id=${attempt_id:-unknown} claim_id=${_claim_comment_id:-0} -->
 - **Worker PID**: ${worker_pid}
 - **Model**: ${display_model}
 - **Tier**: ${dispatch_tier}

--- a/.agents/scripts/tests/test-dispatch-atomic-lease.sh
+++ b/.agents/scripts/tests/test-dispatch-atomic-lease.sh
@@ -325,6 +325,38 @@ test_untrusted_dispatch_identity_cannot_replace_active_lock() {
 	return 0
 }
 
+test_correlated_terminal_before_dispatch_releases_exact_attempt() {
+	local root="${TMP_DIR}/terminal-before-dispatch" expires_at="" terminal_body=""
+	local claim_a="" claim_b=""
+	create_mock_gh "$root"
+	expires_at=$(($(date -u '+%s') + 600))
+	claim_a="DISPATCH_CLAIM nonce=token-a runner=shared-login ts=$(date -u +%Y-%m-%dT%H:%M:%SZ) max_age_s=600 version=test lease_token=token-a device=device-a session=issue-50 phase=prelaunch expires_at=${expires_at}"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" \
+		gh api repos/owner/repo/issues/50/comments --method POST --field body="$claim_a" >/dev/null
+	terminal_body="DISPATCH_LEASE phase=terminal lease_token=token-a device=device-a session=issue-50 expires_at=0 ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" \
+		gh api repos/owner/repo/issues/50/comments --method POST --field body="$terminal_body" >/dev/null
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" \
+		gh api repos/owner/repo/issues/50/comments --method POST \
+		--field body=$'Dispatching worker (deterministic).\n<!-- aidevops:dispatch lease_token=token-a device=device-a session=issue-50 attempt_id=attempt-a claim_id=1 -->' >/dev/null
+	if PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" DISPATCH_COMMENT_MAX_AGE=600 \
+		"$DEDUP" has-dispatch-comment 50 owner/repo shared-login >/dev/null 2>&1; then
+		fail "correlated terminal-before-dispatch evidence retained the exact attempt lock"
+	fi
+
+	claim_b="DISPATCH_CLAIM nonce=token-b runner=shared-login ts=$(date -u +%Y-%m-%dT%H:%M:%SZ) max_age_s=600 version=test lease_token=token-b device=device-b session=issue-50 phase=prelaunch expires_at=${expires_at}"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" \
+		gh api repos/owner/repo/issues/50/comments --method POST --field body="$claim_b" >/dev/null
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" \
+		gh api repos/owner/repo/issues/50/comments --method POST \
+		--field body=$'Dispatching worker (deterministic).\n<!-- aidevops:dispatch lease_token=token-b device=device-b session=issue-50 attempt_id=attempt-b claim_id=4 -->' >/dev/null
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" DISPATCH_COMMENT_MAX_AGE=600 \
+		"$DEDUP" has-dispatch-comment 50 owner/repo shared-login >/dev/null \
+		|| fail "older terminal attempt released a newer correlated dispatch marker"
+	pass "correlated terminal-before-dispatch only releases its exact attempt"
+	return 0
+}
+
 test_large_comment_history_avoids_argv_limits() {
 	local root="${TMP_DIR}/large-history" output="" exit_code=0 dispatch_ts=""
 	create_mock_gh "$root"
@@ -413,6 +445,7 @@ test_local_ledger_guards
 test_concurrent_same_login_devices
 test_launch_crash_ready_terminal_race
 test_untrusted_dispatch_identity_cannot_replace_active_lock
+test_correlated_terminal_before_dispatch_releases_exact_attempt
 test_large_comment_history_avoids_argv_limits
 test_prelaunch_renewal_covers_slow_startup
 test_invalid_device_not_public

--- a/.agents/scripts/tests/test-dispatch-atomic-lease.sh
+++ b/.agents/scripts/tests/test-dispatch-atomic-lease.sh
@@ -326,19 +326,27 @@ test_untrusted_dispatch_identity_cannot_replace_active_lock() {
 }
 
 test_correlated_terminal_before_dispatch_releases_exact_attempt() {
-	local root="${TMP_DIR}/terminal-before-dispatch" expires_at="" terminal_body=""
-	local claim_a="" claim_b=""
+	local root="${TMP_DIR}/terminal-before-dispatch" expires_at=""
+	local claim_a="" claim_b="" claim_a_id="" claim_b_id=""
 	create_mock_gh "$root"
 	expires_at=$(($(date -u '+%s') + 600))
 	claim_a="DISPATCH_CLAIM nonce=token-a runner=shared-login ts=$(date -u +%Y-%m-%dT%H:%M:%SZ) max_age_s=600 version=test lease_token=token-a device=device-a session=issue-50 phase=prelaunch expires_at=${expires_at}"
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" \
 		gh api repos/owner/repo/issues/50/comments --method POST --field body="$claim_a" >/dev/null
-	terminal_body="DISPATCH_LEASE phase=terminal lease_token=token-a device=device-a session=issue-50 expires_at=0 ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" \
-		gh api repos/owner/repo/issues/50/comments --method POST --field body="$terminal_body" >/dev/null
+	claim_a_id=$(jq -sr 'last.id' "$root/state/comments.jsonl")
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a AIDEVOPS_ATTEMPT_ID=attempt-a \
+		"$CLAIM" transition terminal 50 owner/repo token-a issue-50 0 >/dev/null
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" \
 		gh api repos/owner/repo/issues/50/comments --method POST \
-		--field body=$'Dispatching worker (deterministic).\n<!-- aidevops:dispatch lease_token=token-a device=device-a session=issue-50 attempt_id=attempt-a claim_id=1 -->' >/dev/null
+		--field body="Dispatching worker (deterministic).
+<!-- aidevops:dispatch lease_token=token-a device=device-a session=issue-50 attempt_id=attempt-wrong claim_id=${claim_a_id} -->" >/dev/null
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" DISPATCH_COMMENT_MAX_AGE=600 \
+		"$DEDUP" has-dispatch-comment 50 owner/repo shared-login >/dev/null \
+		|| fail "wrong attempt ID released a correlated dispatch marker"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" \
+		gh api repos/owner/repo/issues/50/comments --method POST \
+		--field body="Dispatching worker (deterministic).
+<!-- aidevops:dispatch lease_token=token-a device=device-a session=issue-50 attempt_id=attempt-a claim_id=${claim_a_id} -->" >/dev/null
 	if PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" DISPATCH_COMMENT_MAX_AGE=600 \
 		"$DEDUP" has-dispatch-comment 50 owner/repo shared-login >/dev/null 2>&1; then
 		fail "correlated terminal-before-dispatch evidence retained the exact attempt lock"
@@ -347,9 +355,11 @@ test_correlated_terminal_before_dispatch_releases_exact_attempt() {
 	claim_b="DISPATCH_CLAIM nonce=token-b runner=shared-login ts=$(date -u +%Y-%m-%dT%H:%M:%SZ) max_age_s=600 version=test lease_token=token-b device=device-b session=issue-50 phase=prelaunch expires_at=${expires_at}"
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" \
 		gh api repos/owner/repo/issues/50/comments --method POST --field body="$claim_b" >/dev/null
+	claim_b_id=$(jq -sr 'last.id' "$root/state/comments.jsonl")
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" \
 		gh api repos/owner/repo/issues/50/comments --method POST \
-		--field body=$'Dispatching worker (deterministic).\n<!-- aidevops:dispatch lease_token=token-b device=device-b session=issue-50 attempt_id=attempt-b claim_id=4 -->' >/dev/null
+		--field body="Dispatching worker (deterministic).
+<!-- aidevops:dispatch lease_token=token-b device=device-b session=issue-50 attempt_id=attempt-b claim_id=${claim_b_id} -->" >/dev/null
 	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" DISPATCH_COMMENT_MAX_AGE=600 \
 		"$DEDUP" has-dispatch-comment 50 owner/repo shared-login >/dev/null \
 		|| fail "older terminal attempt released a newer correlated dispatch marker"

--- a/.agents/scripts/tests/test-dispatch-ledger-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-ledger-helper.sh
@@ -133,14 +133,18 @@ test_register_refuses_terminal_lease_resurrection() {
 	run_helper "$LEDGER_HELPER" complete --session-key "issue-42" --lease-token "lease-terminal" \
 		--attempt-id "attempt-terminal"
 	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 \
+		--repo "owner/repo" --pid $$ --lease-token "lease-new" --attempt-id "attempt-new"
+	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 \
 		--repo "owner/repo" --pid $$ --lease-token "lease-terminal" --attempt-id "attempt-terminal"
 
-	local result=0 active_count="" entry_count=""
+	local result=0 active_count="" entry_count="" terminal_count=""
 	active_count=$("$LEDGER_HELPER" count)
 	entry_count=$(wc -l <"${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" | tr -d ' ')
-	[[ "$LAST_EXIT" -ne 0 && "$active_count" -eq 0 && "$entry_count" -eq 2 ]] || result=1
+	terminal_count=$(jq -s '[.[] | select(.lease_token == "lease-terminal")] | length' \
+		"${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl")
+	[[ "$LAST_EXIT" -ne 0 && "$active_count" -eq 1 && "$entry_count" -eq 3 && "$terminal_count" -eq 2 ]] || result=1
 	print_result "register cannot resurrect a terminal dispatch lease" "$result" \
-		"register_exit=${LAST_EXIT}, active=${active_count}, entries=${entry_count}"
+		"register_exit=${LAST_EXIT}, active=${active_count}, entries=${entry_count}, terminal_entries=${terminal_count}"
 	teardown_test_env
 	return 0
 }

--- a/.agents/scripts/tests/test-dispatch-ledger-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-ledger-helper.sh
@@ -126,6 +126,25 @@ test_register_separates_attempt_identity_from_lease() {
 	return 0
 }
 
+test_register_refuses_terminal_lease_resurrection() {
+	setup_test_env
+	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 \
+		--repo "owner/repo" --pid $$ --lease-token "lease-terminal" --attempt-id "attempt-terminal"
+	run_helper "$LEDGER_HELPER" complete --session-key "issue-42" --lease-token "lease-terminal" \
+		--attempt-id "attempt-terminal"
+	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 \
+		--repo "owner/repo" --pid $$ --lease-token "lease-terminal" --attempt-id "attempt-terminal"
+
+	local result=0 active_count="" entry_count=""
+	active_count=$("$LEDGER_HELPER" count)
+	entry_count=$(wc -l <"${AIDEVOPS_DISPATCH_LEDGER_DIR}/dispatch-ledger.jsonl" | tr -d ' ')
+	[[ "$LAST_EXIT" -ne 0 && "$active_count" -eq 0 && "$entry_count" -eq 2 ]] || result=1
+	print_result "register cannot resurrect a terminal dispatch lease" "$result" \
+		"register_exit=${LAST_EXIT}, active=${active_count}, entries=${entry_count}"
+	teardown_test_env
+	return 0
+}
+
 test_terminal_updates_target_exact_attempt() {
 	setup_test_env
 	run_helper "$LEDGER_HELPER" register --session-key "issue-42" --issue 42 \
@@ -933,6 +952,7 @@ main() {
 
 	test_register_creates_entry
 	test_register_separates_attempt_identity_from_lease
+	test_register_refuses_terminal_lease_resurrection
 	test_terminal_updates_target_exact_attempt
 	test_record_recovery_is_idempotent
 	test_record_recovery_rejects_missing_option_values

--- a/.agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh
@@ -148,13 +148,18 @@ set_issue_status() {
 
 original_script_dir="$SCRIPT_DIR"
 SCRIPT_DIR="$TEST_TMP"
-_claim_comment_id=""
+_claim_comment_id="77"
+_claim_lease_token="lease-123"
+_claim_lease_device="device-a"
 PULSE_DISPATCH_STAGGER_SECONDS=0
 export TEST_LEDGER_RC=0
 LOGFILE="${TEST_TMP}/pulse.log" _dlw_post_launch_hooks \
 	"123" "owner/repo" "runner-a" "$$" "issue-123" "standard" "test-model" "${TEST_TMP}/worktree" "attempt-123"
 if [[ "$STATUS_MUTATIONS" != "123|owner/repo|in-progress|--add-assignee runner-a" ]]; then
 	fail "successful worker registration did not transition queued issue to in-progress: ${STATUS_MUTATIONS:-none}"
+fi
+if ! grep -Fq 'aidevops:dispatch lease_token=lease-123 device=device-a session=issue-123 attempt_id=attempt-123 claim_id=77' "$GH_CALLS_FILE"; then
+	fail "dispatch comment did not publish its exact lease and attempt identity"
 fi
 
 STATUS_MUTATIONS=""


### PR DESCRIPTION
## Summary

Bind deterministic dispatch markers to the exact claim lease, device, session, attempt, and claim comment so authenticated terminal transitions retire only their own marker regardless of GitHub comment ordering. Refuse ledger registration from resurrecting any older terminal lease after a newer session generation exists.

The corrective review also makes terminal transitions publish their validated attempt identity and parses that identity as a whitespace-delimited token inside wrapped audit comments.

## Files Changed

- `.agents/scripts/dispatch-claim-helper.sh`
- `.agents/scripts/dispatch-dedup-helper.sh`
- `.agents/scripts/dispatch-lease-claims.jq`
- `.agents/scripts/dispatch-ledger-helper.sh`
- `.agents/scripts/pulse-dispatch-worker-launch.sh`
- `.agents/scripts/tests/test-dispatch-atomic-lease.sh`
- `.agents/scripts/tests/test-dispatch-ledger-helper.sh`
- `.agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh`

## Runtime Testing

- **Risk level:** Critical
- `bash .agents/scripts/tests/test-dispatch-atomic-lease.sh` — passed
- `bash .agents/scripts/tests/test-dispatch-ledger-helper.sh` — 31 passed
- `bash .agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh` — passed
- ShellCheck and `bash -n` on all changed shell files — passed
- `git diff --check` — passed

Resolves #28830
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.192 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 56m and 1,119,447 tokens on this with the user in an interactive session.