### PR TITLE
GH#28837: Close single-frame REST quota gaps

### DIFF
--- a/.agents/scripts/gh-quota-attribution-lib.sh
+++ b/.agents/scripts/gh-quota-attribution-lib.sh
@@ -623,13 +623,18 @@ _ghqa_write_complete_frames() {
 			quota_cost="$success_quota_cost"
 		elif [[ -n "$exact_success_cost" ]]; then
 			quota_cost="$exact_success_cost"
-		# Native non-api commands can fan out into multiple complete REST
-		# responses. Each successful core/search frame is one exact primary-rate
-		# request. Keep direct `gh api` calls on the endpoint-aware parser above so
+		# Native non-api commands can emit one complete REST response or fan out
+		# into several. Each successful core/search frame owns one exact primary-
+		# rate unit, except an authenticated conditional 304 response, which owns
+		# zero. Keep direct `gh api` calls on the endpoint-aware parser above so
 		# GET /rate_limit and ambiguous API argument shapes remain fail-closed.
-		elif [[ "$frame_total" -gt 1 && "$outcome" == success && "${2:-}" != api &&
+		elif [[ "$frame_total" -gt 0 && "$outcome" == success && "${2:-}" != api &&
 			"$resource" =~ ^(core|search)$ ]]; then
-			quota_cost=1
+			if [[ "$status" == 304 ]]; then
+				quota_cost=0
+			else
+				quota_cost=1
+			fi
 		elif [[ "$resource" == graphql && "$response_cost" =~ ^[0-9]+$ ]]; then
 			quota_cost="$response_cost"
 			invalidate_state=1

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -787,7 +787,7 @@ Key framework file paths (use these directly, do NOT search for them):
 - Aidevops source repo only: the same files are edited at .agents/scripts/commands/full-loop.md and under .agents/scripts/
 
 Implementation approach:
-1. Read the issue body FIRST (gh issue view $WORKER_ISSUE_NUMBER). Look for a "Worker Guidance" or "How" section -- it contains the files to modify, reference patterns, and verification commands. Follow these directly when present.
+1. Read the issue body FIRST (gh issue view "$WORKER_ISSUE_NUMBER" --repo "$WORKER_REPO_SLUG" --json body --jq '.body // ""'). Look for a "Worker Guidance" or "How" section -- it contains the files to modify, reference patterns, and verification commands. Follow these directly when present.
 2. If Worker Guidance/How is missing or incomplete, do bounded discovery instead of stopping: use the issue title/body, exact error text, nearby helper names, tests, and git history to identify likely target files. Proceed when expected behavior, target area, and safe verification are clear.
 3. Auto-generated "Unactioned Review Feedback" / quality-debt issues are not missing context solely because they lack file paths. Treat Source PR + captured review text as reproduction context; first verify whether the review is actionable, already fixed, or positive-only scanner noise, then implement a scanner/test fix or record a no-code resolution with evidence as the repo policy allows.
 4. Budget discipline: spend at most 25% of your effort on reading/exploring. After reading the issue body + 2-3 likely reference files, start writing code. Do not read entire helper scripts -- read only the sections you will modify.

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -595,7 +595,7 @@ You are assigned to work on issue #${issue_number} in ${repo_slug}.
 Previous dispatch attempts for this issue launched a worker but produced zero session output. Do not rely on embedded issue content from the dispatcher.
 
 First actions:
-1. Read the issue directly with: gh issue view ${issue_number} --repo ${repo_slug}
+1. Read the issue body directly with: gh issue view ${issue_number} --repo ${repo_slug} --json body --jq '.body // ""'
 ${snapshot_instruction}
 3. Ignore ops/provenance/audit comments as implementation context.
 4. Summarize the actionable task, files, and verification before editing.

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -489,6 +489,39 @@ assert_eq "native multi-frame REST pages retain separate exact attempts" \
 	"rest:1:success:1,rest:2:success:1,rest:3:success:1" \
 	"$(awk -F '\t' '{ value = value (value ? "," : "") $2 ":" $3 ":" $4 ":" $7 } END { print value }' "$native_multi_result")"
 
+native_single_result="$TMPDIR/native-single.result"
+native_single_state="$TMPDIR/native-single.state"
+native_single_frame=$'frame\t1\t1\t200\tcore\t507\t4493\t1800000000\t10'
+: >"$native_single_result"
+_ghqa_state_write_all "$native_single_state" 500 1800000000 20 1800000000 0 1800000000
+_ghqa_write_complete_frames "$native_single_result" "$native_single_state" graphql 1 0 \
+	"$native_single_frame" gh auth status
+assert_eq "native single-frame REST response has response-owned exact cost" \
+	"rest:1:success:1" \
+	"$(awk -F '\t' '{ print $2 ":" $3 ":" $4 ":" $7 }' "$native_single_result")"
+
+native_search_result="$TMPDIR/native-search.result"
+native_search_state="$TMPDIR/native-search.state"
+native_search_frame=$'frame\t1\t1\t200\tsearch\t17\t13\t1800000000\t10'
+: >"$native_search_result"
+_ghqa_state_write_all "$native_search_state" 500 1800000000 20 1800000000 10 1800000000
+_ghqa_write_complete_frames "$native_search_result" "$native_search_state" graphql 1 0 \
+	"$native_search_frame" gh search issues attribution
+assert_eq "native single-frame search response has response-owned exact cost" \
+	"search-rest:1:success:1" \
+	"$(awk -F '\t' '{ print $2 ":" $3 ":" $4 ":" $7 }' "$native_search_result")"
+
+native_conditional_result="$TMPDIR/native-conditional.result"
+native_conditional_state="$TMPDIR/native-conditional.state"
+native_conditional_frames=$'frame\t1\t1\t304\tcore\t500\t4500\t1800000000\t10\nframe\t2\t1\t200\tcore\t501\t4499\t1800000000\t11'
+: >"$native_conditional_result"
+_ghqa_state_write_all "$native_conditional_state" 500 1800000000 20 1800000000 0 1800000000
+_ghqa_write_complete_frames "$native_conditional_result" "$native_conditional_state" graphql 1 0 \
+	"$native_conditional_frames" gh run view 123 --log
+assert_eq "native conditional REST response preserves exact zero cost" \
+	"rest:1:success:0,rest:2:success:1" \
+	"$(awk -F '\t' '{ value = value (value ? "," : "") $2 ":" $3 ":" $4 ":" $7 } END { print value }' "$native_conditional_result")"
+
 native_mixed_result="$TMPDIR/native-mixed.result"
 native_mixed_state="$TMPDIR/native-mixed.state"
 native_mixed_frames=$'frame\t1\t1\t200\tcore\t10\t4990\t1800000000\t10\nframe\t2\t1\t200\tgraphql\t20\t4980\t1800000000\t11'

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -1323,6 +1323,24 @@ else
 	_fail "native multi-frame REST quota attribution" "summary: $native_multi_summary log: $(cat "$native_multi_log" 2>/dev/null || true)"
 fi
 
+native_single_log="$TMP/exact-native-single-rest.log"
+native_single_state="$TMP/exact-native-single-rest-state"
+: >"$native_single_log"
+GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$native_single_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$native_single_log" STUB_GH_DEBUG_RESPONSE=1 \
+	STUB_BOOTSTRAP_CORE_USED=100 STUB_GH_DEBUG_RESOURCE=core \
+	STUB_GH_DEBUG_STATUS=200 STUB_GH_DEBUG_USED=107 STUB_GH_DEBUG_REMAINING=4893 \
+	STUB_GH_DEBUG_RESET=2000 "$SHIM_RUN" auth status >/dev/null 2>/dev/null
+if [[ "$(_read_last_attempt_field "$native_single_log" 2)" == "gh_auth_status" \
+	&& "$(_read_last_attempt_field "$native_single_log" 3)" == "rest" \
+	&& "$(_read_last_attempt_field "$native_single_log" 15)" == "200" \
+	&& "$(_read_attempt_quota "$native_single_log")" == "1" ]]; then
+	_pass "native single-frame auth REST response records exact cost"
+else
+	_fail "native single-frame auth REST quota attribution" "log: $(cat "$native_single_log" 2>/dev/null || true)"
+fi
+
 incomplete_log="$TMP/exact-incomplete-rest.log"
 incomplete_state="$TMP/exact-incomplete-rest-state"
 : >"$incomplete_log"

--- a/.agents/scripts/tests/test-headless-runtime-contract-tests.sh
+++ b/.agents/scripts/tests/test-headless-runtime-contract-tests.sh
@@ -15,6 +15,7 @@ test_appends_escalation_contract() {
 
 	if [[ "$output" == *'HEADLESS_CONTINUATION_CONTRACT_V9'* ]] &&
 		[[ "$output" == *'Read the issue body FIRST'* ]] &&
+		[[ "$output" == *"gh issue view \"\$WORKER_ISSUE_NUMBER\" --repo \"\$WORKER_REPO_SLUG\" --json body --jq"* ]] &&
 		[[ "$output" == *'Look for a "Worker Guidance" or "How" section'* ]] &&
 		[[ "$output" == *'do bounded discovery instead of stopping'* ]] &&
 		[[ "$output" == *'Auto-generated "Unactioned Review Feedback" / quality-debt issues are not missing context solely because they lack file paths'* ]] &&

--- a/.agents/scripts/tests/test-zero-output-url-fallback.sh
+++ b/.agents/scripts/tests/test-zero-output-url-fallback.sh
@@ -75,7 +75,7 @@ GH_COMMENT_METRICS=""
 ISSUE_BODY_SNAPSHOT_HELPER="/usr/bin/true"
 export ISSUE_BODY_SNAPSHOT_HELPER
 fallback_prompt=$(_dlw_prepare_prompt_for_launch 123 owner/repo "Test issue" "FULL EMBEDDED BRIEF")
-if printf '%s' "$fallback_prompt" | grep -q 'gh issue view 123 --repo owner/repo' \
+if printf '%s' "$fallback_prompt" | grep -q 'gh issue view 123 --repo owner/repo --json body --jq' \
 	&& printf '%s' "$fallback_prompt" | grep -q 'issue-body-snapshot-helper.sh fetch owner/repo 123' \
 	&& ! printf '%s' "$fallback_prompt" | grep -q 'FULL EMBEDDED BRIEF'; then
 	pass "repeated zero-output launches switch to URL-only bootstrap prompt"
@@ -111,7 +111,7 @@ write_state 1
 GH_COMMENT_ZERO_COUNT=2
 GH_COMMENT_METRICS=$'0\t0\t2\t0'
 comment_fallback_prompt=$(_dlw_prepare_prompt_for_launch 123 owner/repo "Test issue" "FULL EMBEDDED BRIEF")
-if printf '%s' "$comment_fallback_prompt" | grep -q 'gh issue view 123 --repo owner/repo' \
+if printf '%s' "$comment_fallback_prompt" | grep -q 'gh issue view 123 --repo owner/repo --json body --jq' \
 	&& ! printf '%s' "$comment_fallback_prompt" | grep -q 'FULL EMBEDDED BRIEF'; then
 	pass "comment evidence triggers URL-only fallback when state count is low"
 else
@@ -124,7 +124,7 @@ GH_COMMENT_ZERO_COUNT=0
 GH_COMMENT_METRICS=$'50\t0\t2\t1000'
 shared_metrics_prompt=$(_dlw_prepare_prompt_for_launch 123 owner/repo "Test issue" "FULL EMBEDDED BRIEF")
 prepare_api_calls=$(wc -l <"${TMP}/gh-api-calls.log" | tr -d '[:space:]')
-if printf '%s' "$shared_metrics_prompt" | grep -q 'gh issue view 123 --repo owner/repo' \
+if printf '%s' "$shared_metrics_prompt" | grep -q 'gh issue view 123 --repo owner/repo --json body --jq' \
 	&& [[ "$prepare_api_calls" == "1" ]]; then
 	pass "prepare prompt reuses comment bloat metrics for zero-output evidence"
 else


### PR DESCRIPTION
## Summary

Attribute complete single-frame native core/search responses exactly, preserve conditional 304 zero cost, and make worker issue-body bootstrap reads REST-preservable.

## Files Changed

.agents/scripts/gh-quota-attribution-lib.sh, .agents/scripts/headless-runtime-lib.sh, .agents/scripts/pulse-dispatch-worker-launch.sh, .agents/scripts/tests/test-gh-api-instrument.sh, .agents/scripts/tests/test-gh-shim.sh, .agents/scripts/tests/test-headless-runtime-contract-tests.sh, .agents/scripts/tests/test-zero-output-url-fallback.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 208 quota instrumentation tests, 103 gh shim tests, 206 headless runtime tests, 12 zero-output fallback tests, ShellCheck, and changed-file local lint passed.

Resolves #28837


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.192 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.5 spent 11d 21h and 46,408,564 tokens on this with the user in an interactive session.