### PR TITLE
docs: prepare release notes for dispatch fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- exclude Pulse stage subshells from runtime audit false positives (#28827)
+- bind terminal dispatch evidence to exact worker attempts (#28830)
+- share authoritative required-check configuration across full-loop and Pulse (#28831)
+
 ## [3.32.192] - 2026-07-28
 
 ### Changed


### PR DESCRIPTION
## Summary

Add explicit Unreleased changelog entries for the three merged fixes requested for immediate publication:

- Pulse runtime-audit false positives from stage subshells.
- Terminal dispatch evidence correlated to exact worker attempts.
- Shared required-check configuration across full-loop and Pulse.

This reviewed checkpoint becomes the direct release source because the original PRs already carry terminal `release:not-requested` receipts; those immutable receipts cannot be rewritten after the later publication request.

## Verification

- Confirmed the branch starts at the current `origin/main` tip.
- `git diff --check` passed.
- Changelog structure follows the existing Keep a Changelog format.

Ref #28827
Ref #28830
Ref #28831

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.192 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-sol spent 1h 59m and 1,417,052 tokens on this with the user in an interactive session.