### PR TITLE
GH#28844: Fix guarded workflow rollout preparation

### DIFF
--- a/.agents/scripts/sync-workflows-helper.sh
+++ b/.agents/scripts/sync-workflows-helper.sh
@@ -191,6 +191,53 @@ _worktree_for_branch() {
 	return 1
 }
 
+# Refresh a canonical repository's remote-tracking branch from linked-worktree
+# context so the canonical Git guard remains intact. Bootstrap a short-lived
+# detached worktree when the repository has no linked worktree yet.
+_refresh_origin_from_linked_context() {
+	local _repo_path="$1"
+	local _default_branch="$2"
+	local _base_dir="$3"
+	local _slug="$4"
+	local _fetch_path=""
+	local _line _candidate
+	while IFS= read -r _line; do
+		case "$_line" in
+		worktree\ *)
+			_candidate="${_line#worktree }"
+			if [[ -d "$_candidate" ]] && _is_linked_worktree "$_candidate"; then
+				_fetch_path="$_candidate"
+				break
+			fi
+			;;
+		esac
+	done < <(git -C "$_repo_path" worktree list --porcelain 2>/dev/null)
+
+	local _bootstrap_path=""
+	if [[ -z "$_fetch_path" ]]; then
+		local _safe_slug
+		_safe_slug=$(printf '%s' "$_slug" | sed 's|[^A-Za-z0-9._-]|-|g')
+		mkdir -p "$_base_dir" || return 1
+		_bootstrap_path="${_base_dir}/.${_safe_slug}-workflow-sync-fetch-$$"
+		[[ ! -e "$_bootstrap_path" ]] || return 1
+		git -C "$_repo_path" worktree add -q --detach \
+			"$_bootstrap_path" HEAD >/dev/null 2>&1 || return 1
+		_fetch_path="$_bootstrap_path"
+	fi
+
+	local _fetch_rc=0
+	local _cleanup_rc=0
+	git -C "$_fetch_path" fetch --no-tags --quiet origin \
+		"+refs/heads/${_default_branch}:refs/remotes/origin/${_default_branch}" \
+		>/dev/null 2>&1 || _fetch_rc=$?
+	if [[ -n "$_bootstrap_path" ]]; then
+		git -C "$_fetch_path" worktree remove --force "$_bootstrap_path" \
+			>/dev/null 2>&1 || _cleanup_rc=$?
+	fi
+	[[ "$_fetch_rc" -eq 0 && "$_cleanup_rc" -eq 0 ]] || return 1
+	return 0
+}
+
 # _prepare_apply_worktree <slug> <classified-path> <branch>
 # Emits the safe linked worktree path used for mutation.
 _prepare_apply_worktree() {
@@ -210,7 +257,6 @@ _prepare_apply_worktree() {
 	local _default_branch
 	_default_branch=$(git -C "$_classified_path" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
 	[[ -z "$_default_branch" ]] && _default_branch="$_BRANCH_DEFAULT_NAME"
-	git -C "$_classified_path" fetch -q origin "$_default_branch" >/dev/null 2>&1 || return 1
 
 	local _existing
 	_existing=$(_worktree_for_branch "$_classified_path" "$_branch") || _existing=""
@@ -233,6 +279,8 @@ _prepare_apply_worktree() {
 	_default_ref=$(_remote_default_ref "$_default_branch")
 	mkdir -p "$_base_dir" || return 1
 	[[ ! -e "$_worktree_path" ]] || return 1
+	_refresh_origin_from_linked_context \
+		"$_classified_path" "$_default_branch" "$_base_dir" "$_slug" || return 1
 	git -C "$_classified_path" worktree add -q -B "$_branch" \
 		"$_worktree_path" "$_default_ref" >/dev/null 2>&1 || return 1
 	if command -v register_worktree >/dev/null 2>&1; then

--- a/.agents/scripts/tests/test-sync-workflows-install-missing.sh
+++ b/.agents/scripts/tests/test-sync-workflows-install-missing.sh
@@ -203,10 +203,37 @@ cat >"$test_root/.config/aidevops/repos.json" <<EOF
 {"initialized_repos":[{"path":"$apply_repo","slug":"fake/apply"}]}
 EOF
 : >"$test_root/gh.log"
-safe_path="$test_root/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+mkdir -p "$test_root/guard-bin"
+cat >"$test_root/guard-bin/git" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+real_git="${AIDEVOPS_TEST_GIT_BIN:?}"
+canonical_repo="${CANONICAL_GIT_REPO:?}"
+guard_log="${CANONICAL_GIT_GUARD_LOG:?}"
+args=("$@")
+git_cwd="$PWD"
+command_index=0
+if [[ "${args[0]:-}" == "-C" ]]; then
+	git_cwd="${args[1]:-}"
+	command_index=2
+fi
+if [[ "${args[$command_index]:-}" == "fetch" ]]; then
+	if [[ "$git_cwd" == "$canonical_repo" ]]; then
+		printf 'blocked-canonical-fetch\n' >>"$guard_log"
+		exit 97
+	fi
+	printf 'linked-fetch\n' >>"$guard_log"
+fi
+exec "$real_git" "$@"
+EOF
+chmod +x "$test_root/guard-bin/git"
+: >"$test_root/canonical-git-guard.log"
+safe_path="$test_root/guard-bin:$test_root/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 apply_output=$(HOME="$test_root" PATH="$safe_path" \
 	GH_CALL_LOG="$test_root/gh.log" AIDEVOPS_TEMP_DIR="$test_root/agent-tmp" \
-	AIDEVOPS_WORKTREE_BASE_DIR="$test_root/worktrees" bash "$HELPER" \
+	AIDEVOPS_WORKTREE_BASE_DIR="$test_root/worktrees" \
+	AIDEVOPS_TEST_GIT_BIN="$real_git" CANONICAL_GIT_REPO="$apply_repo" \
+	CANONICAL_GIT_GUARD_LOG="$test_root/canonical-git-guard.log" bash "$HELPER" \
 	--apply --repo fake/apply --workflow linked-issue-check --install-missing \
 	--issue 28844 --branch chore/test-issue-first 2>&1)
 apply_rc=$?
@@ -224,13 +251,19 @@ assert_contains "apply-mode preserves repository guidance" "$applied_contributin
 assert_contains "apply-mode installs managed policy block" "$applied_contributing" \
 	'<!-- aidevops:issue-first-pr:start -->'
 
+guard_calls=$(<"$test_root/canonical-git-guard.log")
+assert_contains "apply refreshes from linked-worktree context" "$guard_calls" 'linked-fetch'
+assert_not_contains "apply avoids canonical fetch" "$guard_calls" 'blocked-canonical-fetch'
+
 apply_gh_calls=$(<"$test_root/gh.log")
 assert_contains "PR creation uses body-file discipline" "$apply_gh_calls" '--body-file'
 assert_not_contains "PR creation does not use inline body" "$apply_gh_calls" '--body '
 
 second_apply=$(HOME="$test_root" PATH="$safe_path" \
 	GH_CALL_LOG="$test_root/gh.log" AIDEVOPS_TEMP_DIR="$test_root/agent-tmp" \
-	AIDEVOPS_WORKTREE_BASE_DIR="$test_root/worktrees" bash "$HELPER" \
+	AIDEVOPS_WORKTREE_BASE_DIR="$test_root/worktrees" \
+	AIDEVOPS_TEST_GIT_BIN="$real_git" CANONICAL_GIT_REPO="$apply_repo" \
+	CANONICAL_GIT_GUARD_LOG="$test_root/canonical-git-guard.log" bash "$HELPER" \
 	--apply --repo fake/apply --workflow linked-issue-check --install-missing \
 	--issue 28844 --branch chore/test-issue-first 2>&1)
 second_rc=$?


### PR DESCRIPTION
## Summary

- refresh canonical repositories from linked-worktree context before creating
  isolated workflow-rollout worktrees
- bootstrap and remove a short-lived detached worktree when no linked context
  exists yet
- preserve the canonical Git guard instead of bypassing it
- add a regression harness that rejects canonical fetches and proves apply-mode
  uses linked-worktree fetches

## Failure evidence

The first post-merge rollout attempted all 42 eligible repositories. Every
eligible row failed safely during linked-worktree preparation, before any
commit, push, or downstream PR. The common cause was a direct fetch from each
canonical checkout, which the canonical Git guard correctly rejects.

The 17 intentional eligibility skips remained unchanged: 8 local-only entries
and 9 external-upstream entries.

## Verification

- `bash .agents/scripts/tests/test-sync-workflows-install-missing.sh` — 31 tests
- `bash .agents/scripts/tests/test-sync-workflows-helper.sh` — 48 tests
- `bash .agents/scripts/tests/test-check-workflows-helper.sh` — 22 tests
- ShellCheck on both changed shell files
- `.agents/scripts/linters-local.sh`
- `git diff --check`

For #28844

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.193 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol
