### PR TITLE
GH#28868: Fix invalid rate-limit selections in native relationship mutations

### DIFF
--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -309,7 +309,7 @@ _cached_node_id() {
 # whether this call created, observed, failed, or deferred the edge.
 _gh_add_blocked_by() {
 	local blocked_id="$1" blocking_id="$2"
-	local result="" reported_cost="" contains_rc=0 mutation_rc=0
+	local result="" contains_rc=0 mutation_rc=0
 	_gh_native_blocked_by_contains "$blocked_id" "$blocking_id" || contains_rc=$?
 	case "$contains_rc" in
 		0)
@@ -323,18 +323,20 @@ _gh_add_blocked_by() {
 			return 1
 			;;
 	esac
-	result=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+	# GitHub exposes rateLimit on Query, not Mutation. This fixed mutation has
+	# no connections and consumes one GraphQL point, accounted at transport.
+	result=$(AIDEVOPS_GH_QUOTA_COST=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="issue-sync-add-blocked-by-exact-cost" \
 		_gh_with_timeout write gh api graphql -f query='
 mutation($blocked:ID!,$blocking:ID!) {
   addBlockedBy(input: {issueId:$blocked, blockingIssueId:$blocking}) {
     issue { number }
   }
-	rateLimit { cost }
 }' -f blocked="$blocked_id" -f blocking="$blocking_id" 2>&1) || mutation_rc=$?
-	reported_cost=$(printf '%s' "$result" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
-	if [[ "$mutation_rc" -eq 0 && "$reported_cost" =~ ^[1-9][0-9]*$ ]] && \
-		printf '%s' "$result" | jq -e '.data.addBlockedBy.issue.number | numbers' >/dev/null 2>&1; then
+	if [[ "$mutation_rc" -eq 0 ]] && \
+		printf '%s' "$result" | jq -e \
+		'((.errors // []) | length) == 0 and (.data.addBlockedBy.issue.number | type == "number")' \
+		>/dev/null 2>&1; then
 		_relationship_record_outcome "$_REL_OUTCOME_CREATED"
 		return 0
 	fi
@@ -353,24 +355,24 @@ mutation($blocked:ID!,$blocking:ID!) {
 _gh_remove_blocked_by() {
 	local blocked_id="$1"
 	local blocking_id="$2"
-	local contains_rc=0 mutation_rc=0 result="" reported_cost=""
+	local contains_rc=0 mutation_rc=0 result=""
 	_gh_native_blocked_by_contains "$blocked_id" "$blocking_id" || contains_rc=$?
 	case "$contains_rc" in
 		1) return 0 ;;
 		2) return 1 ;;
 	esac
-	result=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+	result=$(AIDEVOPS_GH_QUOTA_COST=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="issue-sync-remove-blocked-by-exact-cost" \
 		_gh_with_timeout write gh api graphql -f query='
 mutation($blocked:ID!,$blocking:ID!) {
   removeBlockedBy(input: {issueId:$blocked, blockingIssueId:$blocking}) {
     issue { number }
   }
-	rateLimit { cost }
 }' -f blocked="$blocked_id" -f blocking="$blocking_id" 2>&1) || mutation_rc=$?
-	reported_cost=$(printf '%s' "$result" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
-	if [[ "$mutation_rc" -eq 0 && "$reported_cost" =~ ^[1-9][0-9]*$ ]] && \
-		printf '%s' "$result" | jq -e '.data.removeBlockedBy.issue.number | numbers' >/dev/null 2>&1; then
+	if [[ "$mutation_rc" -eq 0 ]] && \
+		printf '%s' "$result" | jq -e \
+		'((.errors // []) | length) == 0 and (.data.removeBlockedBy.issue.number | type == "number")' \
+		>/dev/null 2>&1; then
 		return 0
 	fi
 	log_verbose "  removeBlockedBy error: ${result:0:200}"
@@ -551,7 +553,7 @@ _dependency_cycle_should_skip_edge() {
 # Returns: 0=success/already-exists, 1=error
 _gh_add_sub_issue() {
 	local parent_id="$1" child_id="$2"
-	local result="" reported_cost="" contains_rc=0 mutation_rc=0
+	local result="" contains_rc=0 mutation_rc=0
 	_gh_native_sub_issue_contains "$parent_id" "$child_id" || contains_rc=$?
 	case "$contains_rc" in
 		0)
@@ -565,18 +567,18 @@ _gh_add_sub_issue() {
 			return 1
 			;;
 	esac
-	result=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+	result=$(AIDEVOPS_GH_QUOTA_COST=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="issue-sync-add-sub-issue-exact-cost" \
 		_gh_with_timeout write gh api graphql -f query='
 mutation($parent:ID!,$child:ID!) {
   addSubIssue(input: {issueId:$parent, subIssueId:$child}) {
     issue { number }
   }
-	rateLimit { cost }
 }' -f parent="$parent_id" -f child="$child_id" 2>&1) || mutation_rc=$?
-	reported_cost=$(printf '%s' "$result" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || reported_cost=""
-	if [[ "$mutation_rc" -eq 0 && "$reported_cost" =~ ^[1-9][0-9]*$ ]] && \
-		printf '%s' "$result" | jq -e '.data.addSubIssue.issue.number | numbers' >/dev/null 2>&1; then
+	if [[ "$mutation_rc" -eq 0 ]] && \
+		printf '%s' "$result" | jq -e \
+		'((.errors // []) | length) == 0 and (.data.addSubIssue.issue.number | type == "number")' \
+		>/dev/null 2>&1; then
 		_relationship_record_outcome "$_REL_OUTCOME_CREATED"
 		return 0
 	fi

--- a/.agents/scripts/tests/test-backfill-sub-issues.sh
+++ b/.agents/scripts/tests/test-backfill-sub-issues.sh
@@ -164,11 +164,15 @@ fi
 
 # gh api graphql -f query=...
 if [[ "$cmd1" == "api" && "$cmd2" == "graphql" ]]; then
-	[[ "${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" == "1" && "$*" == *"rateLimit"* ]] || exit 1
 	# Check the mutation name in the query body
+	if [[ "$*" == *"addSubIssue"* ]]; then
+		[[ "${AIDEVOPS_GH_QUOTA_COST:-}" == "1" && "$*" != *"rateLimit"* ]] || exit 1
+	else
+		[[ "${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" == "1" && "$*" == *"rateLimit"* ]] || exit 1
+	fi
 	for arg in "$@"; do
 		if [[ "$arg" == *"addSubIssue"* ]]; then
-			printf '%s\n' '{"data":{"addSubIssue":{"issue":{"number":1}},"rateLimit":{"cost":1}}}'
+			printf '%s\n' '{"data":{"addSubIssue":{"issue":{"number":1}}}}'
 			exit 0
 		fi
 		if [[ "$arg" == *"subIssues(first:100)"* ]]; then

--- a/.agents/scripts/tests/test-dependency-readiness-normalization.sh
+++ b/.agents/scripts/tests/test-dependency-readiness-normalization.sh
@@ -295,7 +295,8 @@ gh() {
 	if [[ "$*" == *"query("* ]]; then
 		printf '%s\n' '{"data":{"node":{"blockedBy":{"nodes":[{"id":"I_blocker"}],"pageInfo":{"hasNextPage":false}}},"rateLimit":{"cost":1}}}'
 	else
-		printf '%s\n' '{"data":{"removeBlockedBy":{"issue":{"number":10}},"rateLimit":{"cost":1}}}'
+		[[ "${AIDEVOPS_GH_QUOTA_COST:-}" == "1" && "$*" != *"rateLimit"* ]] || return 1
+		printf '%s\n' '{"data":{"removeBlockedBy":{"issue":{"number":10}}}}'
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-issue-sync-relationship-deadline.sh
+++ b/.agents/scripts/tests/test-issue-sync-relationship-deadline.sh
@@ -119,13 +119,17 @@ pass "edge loop stops with retryable state after aggregate exhaustion"
 MUTATION_FIXTURE=""
 _gh_with_timeout() {
 	local operation="$1"
-	[[ "${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" == "1" && "$*" == *"rateLimit"* ]] || return 1
+	if [[ "$operation" == "read" ]]; then
+		[[ "${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" == "1" && "$*" == *"rateLimit"* ]] || return 1
+	else
+		[[ "${AIDEVOPS_GH_QUOTA_COST:-}" == "1" && "$*" != *"rateLimit"* ]] || return 1
+	fi
 	case "$MUTATION_FIXTURE" in
 	created)
 		if [[ "$operation" == "read" ]]; then
 			printf '%s\n' '{"data":{"node":{"blockedBy":{"nodes":[],"pageInfo":{"hasNextPage":false}}},"rateLimit":{"cost":1}}}'
 		else
-			printf '%s\n' '{"data":{"addBlockedBy":{"issue":{"number":101}},"rateLimit":{"cost":1}}}'
+			printf '%s\n' '{"data":{"addBlockedBy":{"issue":{"number":101}}}}'
 		fi
 		return 0
 		;;
@@ -141,6 +145,14 @@ _gh_with_timeout() {
 		printf '%s\n' '{"errors":[{"message":"SECRET_PAYLOAD"}]}'
 		return 1
 		;;
+	partial-error)
+		if [[ "$operation" == "read" ]]; then
+			printf '%s\n' '{"data":{"node":{"blockedBy":{"nodes":[],"pageInfo":{"hasNextPage":false}}},"rateLimit":{"cost":1}}}'
+		else
+			printf '%s\n' '{"data":{"addBlockedBy":{"issue":{"number":101}}},"errors":[{"message":"UNCERTAIN_WRITE"}]}'
+		fi
+		return 0
+		;;
 	esac
 	return 1
 }
@@ -153,12 +165,17 @@ MUTATION_FIXTURE="failed"
 mutation_rc=0
 _gh_add_blocked_by NODE_101 NODE_104 || mutation_rc=$?
 [[ "$mutation_rc" -eq 1 ]] || fail "failed mutation fixture did not fail"
+MUTATION_FIXTURE="partial-error"
+mutation_rc=0
+_gh_add_blocked_by NODE_101 NODE_105 || mutation_rc=$?
+[[ "$mutation_rc" -eq 1 ]] || fail "partial GraphQL error was treated as mutation success"
 _relationship_record_outcome "deferred:deadline"
 mixed_summary=$(_relationship_print_summary 1 0 1 2 true)
-[[ "$mixed_summary" == *"Edges: created=1 already-present=1 failed=1 deferred=1"* ]] || fail "mixed outcomes were not distinguished: $mixed_summary"
+[[ "$mixed_summary" == *"Edges: created=1 already-present=1 failed=2 deferred=1"* ]] || fail "mixed outcomes were not distinguished: $mixed_summary"
 [[ "$mixed_summary" == *"Tasks: attempted=1 complete=0/1"* ]] || fail "partial task was presented as complete: $mixed_summary"
 [[ "$mixed_summary" == *"Failure: failed:graphql"* ]] || fail "sanitized failure class was not retained: $mixed_summary"
 [[ "$mixed_summary" != *"SECRET_PAYLOAD"* ]] || fail "raw GraphQL payload leaked into summary"
+[[ "$mixed_summary" != *"UNCERTAIN_WRITE"* ]] || fail "partial GraphQL error leaked into summary"
 [[ "$mixed_summary" == *"Recovery: rerun"* ]] || fail "partial summary omitted recovery command"
 pass "mixed relationship outcomes remain actionable and sanitized"
 

--- a/.agents/scripts/tests/test-parent-phase-dep-parser.sh
+++ b/.agents/scripts/tests/test-parent-phase-dep-parser.sh
@@ -188,10 +188,14 @@ fi
 
 # gh api graphql -f query=...
 if [[ "$cmd1" == "api" && "$cmd2" == "graphql" ]]; then
-	[[ "${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" == "1" && "$*" == *"rateLimit"* ]] || exit 1
+	if [[ "$*" == *"addBlockedBy"* ]]; then
+		[[ "${AIDEVOPS_GH_QUOTA_COST:-}" == "1" && "$*" != *"rateLimit"* ]] || exit 1
+	else
+		[[ "${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" == "1" && "$*" == *"rateLimit"* ]] || exit 1
+	fi
 	for arg in "$@"; do
 		if [[ "$arg" == *"addBlockedBy"* ]]; then
-			printf '%s\n' '{"data":{"addBlockedBy":{"issue":{"number":99}},"rateLimit":{"cost":1}}}'
+			printf '%s\n' '{"data":{"addBlockedBy":{"issue":{"number":99}}}}'
 			exit 0
 		fi
 		if [[ "$arg" == *"blockedBy(first:100)"* ]]; then


### PR DESCRIPTION
## Summary

Remove the Query-only rateLimit selection from native relationship mutations and account their fixed one-point GraphQL cost at transport; update fixtures to reject invalid mutation response shapes.

## Files Changed

.agents/scripts/issue-sync-relationships.sh, .agents/scripts/tests/test-backfill-sub-issues.sh, .agents/scripts/tests/test-dependency-readiness-normalization.sh, .agents/scripts/tests/test-issue-sync-relationship-deadline.sh, .agents/scripts/tests/test-parent-phase-dep-parser.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused relationship, dependency-normalization, parent-phase, and sub-issue backfill suites pass; targeted ShellCheck passes.

Resolves #28868


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.195 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 10m and 98,240 tokens on this as a headless worker.