### PR TITLE
GH#28862: Gate dormant repository automation

### DIFF
--- a/.agents/custom/scripts/r-stub-title-scan.sh
+++ b/.agents/custom/scripts/r-stub-title-scan.sh
@@ -167,7 +167,7 @@ _mark_seen() {
 _get_pulse_repos() {
     [[ -n "${STUB_SCAN_REPOS:-}" ]] && { echo "$STUB_SCAN_REPOS" | tr ',' '\n'; return 0; }
     [[ -f "$REPOS_JSON" ]] || { _log "ERROR" "repos.json not found at ${REPOS_JSON}"; return 1; }
-    jq -r '.initialized_repos[]? | select(.pulse == true) | select(.local_only != true) | .slug' \
+    jq -r '.initialized_repos[]? | select(.maintenance != false and .pulse == true) | select(.local_only != true) | .slug' \
         "$REPOS_JSON" || true
     return 0
 }

--- a/.agents/reference/repos-json-fields.md
+++ b/.agents/reference/repos-json-fields.md
@@ -10,6 +10,7 @@ Config file: `~/.config/aidevops/repos.json`. Structure: `{"initialized_repos": 
 |-------|------|-------------|
 | `slug` | string | `owner/repo` — ALWAYS use this for `gh` commands, never guess org names |
 | `pulse` | bool | `true` = active development, tasks, issues. `false` = no task management |
+| `maintenance` | bool | Missing/`true` = include in recurring cross-repo maintenance. `false` = keep registered but omit from routine API scans, workflow/badge rollout, and Pulse. |
 | `local_only` | bool | No remote; skip all `gh` operations |
 | `priority` | string | `"tooling"` (infrastructure), `"product"` (user-facing), `"profile"` (docs-only) |
 | `maintainer` | string | GitHub username. Auto-detected from `gh api user`; falls back to slug owner |
@@ -55,6 +56,28 @@ Agent-source repos receive non-destructive template management:
 - Public TODO entries, issue text, logs, and comments must not include private repo slugs; use generic wording such as "a managed private agent source repo".
 
 ## Scheduling and Lifecycle Fields
+
+Registration, maintenance, and Pulse are separate scopes:
+
+- Registration retains canonical path resolution, history, privacy guards, and
+  explicit one-repository commands.
+- `maintenance: false` marks a repository dormant. Recurring all-repository
+  scans omit it, while an explicit `--repo owner/repo` check or repair may still
+  target it without bypassing `local_only`, contributor, or permission gates.
+- `pulse: true` additionally enables active task/issue automation. Dormant
+  repositories are never Pulse-eligible; the CLI disables Pulse when pausing
+  maintenance and does not silently re-enable it on resume.
+- Safety hygiene remains registration-scoped: privacy inventory, stale claim and
+  dispatch-label cleanup, dirty-PR recovery, and local worktree cleanup continue
+  to see dormant repositories but never use dormancy to authorize new work.
+- Missing `maintenance` defaults to `true` for backward compatibility.
+
+Manage the state without hand-editing JSON:
+
+```bash
+aidevops repos maintenance off owner/repo
+aidevops repos maintenance on owner/repo
+```
 
 | Field | Type | Example | Description |
 |-------|------|---------|-------------|

--- a/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
@@ -601,6 +601,81 @@ get_registered_repos() {
 	return 0
 }
 
+# Set whether a registered repository participates in recurring maintenance.
+# Usage: set_repo_maintenance <slug-or-path> <true|false>
+# Disabling maintenance also disables Pulse so all existing pulse selectors
+# converge even before they learn the maintenance field directly.
+set_repo_maintenance() {
+	local selector="$1"
+	local desired="$2"
+	init_repos_file
+
+	if ! command -v jq &>/dev/null; then
+		print_error "jq required for repo management"
+		return 1
+	fi
+	case "$desired" in
+	true | false) ;;
+	*)
+		print_error "Maintenance state must be 'true' or 'false'"
+		return 2
+		;;
+	esac
+
+	if [[ -d "$selector" ]]; then
+		selector=$(cd "$selector" 2>/dev/null && pwd -P) || return 1
+		selector=$(resolve_canonical_repo_path "$selector")
+	fi
+
+	local matches
+	matches=$(jq -r --arg selector "$selector" \
+		'[.initialized_repos[]? | select(.slug == $selector or .path == $selector)] | length' \
+		"$REPOS_FILE" 2>/dev/null) || return 1
+	if [[ "$matches" != "1" ]]; then
+		print_error "Expected one registered repo matching '$selector'; found $matches"
+		return 1
+	fi
+
+	local temp_file
+	temp_file=$(mktemp "${REPOS_FILE}.tmp.XXXXXX") || return 1
+	if ! jq --arg selector "$selector" --argjson desired "$desired" '
+		(.initialized_repos[] | select(.slug == $selector or .path == $selector)) |=
+			(if $desired then .maintenance = true
+			 else .maintenance = false | .pulse = false
+			 end)
+	' "$REPOS_FILE" >"$temp_file"; then
+		rm -f "$temp_file"
+		return 1
+	fi
+	if ! jq -e '.initialized_repos | type == "array"' "$temp_file" >/dev/null 2>&1; then
+		rm -f "$temp_file"
+		print_error "Refusing to write an invalid repos.json"
+		return 1
+	fi
+	if ! mv "$temp_file" "$REPOS_FILE"; then
+		rm -f "$temp_file"
+		return 1
+	fi
+	return 0
+}
+
+# Print effective maintenance state for a registered repository.
+# Output: maintenance<TAB>pulse<TAB>slug<TAB>path
+get_repo_maintenance_state() {
+	local selector="$1"
+	if [[ -d "$selector" ]]; then
+		selector=$(cd "$selector" 2>/dev/null && pwd -P) || return 1
+		selector=$(resolve_canonical_repo_path "$selector")
+	fi
+	jq -r --arg selector "$selector" '
+		.initialized_repos[]?
+		| select(.slug == $selector or .path == $selector)
+		| [(if .maintenance == false then false else true end), (.pulse // false), (.slug // ""), (.path // "")]
+		| @tsv
+	' "$REPOS_FILE" 2>/dev/null
+	return 0
+}
+
 # Get the maintainer GitHub username for a repo
 # Fallback chain: maintainer field > slug owner > empty string
 # Usage: get_repo_maintainer <slug>

--- a/.agents/scripts/badges-check-helper.sh
+++ b/.agents/scripts/badges-check-helper.sh
@@ -17,7 +17,8 @@
 #   LOCAL-ONLY  — repo has `local_only: true`, skip
 #   EXTERNAL    — repo is in a non-owned org or contributed: true (read-only info)
 #
-# Check (drift detection) enumerates ALL non-local-only repos for visibility.
+# Check (drift detection) enumerates maintained non-local-only repos by default.
+# An explicit --repo check may inspect a dormant registration.
 # The owned-org filter applies only to sync/install (write) operations.
 #
 # Usage:
@@ -142,7 +143,7 @@ _usage() {
 
 # ─── Repo iteration ─────────────────────────────────────────────────────────
 
-# Emit one "path|local_only|contributed|slug" TSV line per registered repo.
+# Emit one "path|local_only|contributed|role|maintenance|slug" TSV line per registered repo.
 _iterate_repos() {
 	if [[ ! -f "$REPOS_JSON" ]]; then
 		_die "repos.json not found at $REPOS_JSON — aidevops may not be initialised"
@@ -157,6 +158,8 @@ _iterate_repos() {
 			(.path // ""),
 			(.local_only // false | tostring),
 			(.contributed // false | tostring),
+			(.role // "maintainer"),
+			((if .maintenance == false then false else true end) | tostring),
 			(.slug // "")
 		]
 		| @tsv
@@ -166,14 +169,15 @@ _iterate_repos() {
 
 # ─── Classification ─────────────────────────────────────────────────────────
 
-# _classify_badges_repo <path> <local_only> <contributed> <slug> <badges_helper>
+# _classify_badges_repo <path> <local_only> <contributed> <role> <slug> <badges_helper>
 # Emits: class\tnote
 _classify_badges_repo() {
 	local _path="$1"
 	local _local_only="$2"
 	local _contributed="$3"
-	local _slug="$4"
-	local _badges_helper="$5"
+	local _role="$4"
+	local _slug="$5"
+	local _badges_helper="$6"
 
 	if [[ "$_local_only" == "true" ]]; then
 		printf 'LOCAL-ONLY\t\n'
@@ -183,7 +187,7 @@ _classify_badges_repo() {
 	# Classify scope: EXTERNAL if contributed or org not in owned list
 	local _org="${_slug%%/*}"
 	local _is_external=0
-	if [[ "$_contributed" == "true" ]]; then
+	if [[ "$_contributed" == "true" || "$_role" == "contributor" ]]; then
 		_is_external=1
 	elif [[ -n "$_org" ]] && ! _is_owned_org "$_org"; then
 		_is_external=1
@@ -348,18 +352,19 @@ _process_repos() {
 	local _rows
 	_rows=$(_iterate_repos) || exit $?
 
-	local _path _local_only_flag _contributed_flag _slug
-	while IFS=$'\t' read -r _path _local_only_flag _contributed_flag _slug; do
+	local _path _local_only_flag _contributed_flag _role _maintenance_flag _slug
+	while IFS=$'\t' read -r _path _local_only_flag _contributed_flag _role _maintenance_flag _slug; do
 		[[ -z "$_slug" && -z "$_path" ]] && continue
 		local _label="${_slug:-$(basename "$_path")}"
 		[[ -n "$_filter_slug" && "$_slug" != "$_filter_slug" ]] && continue
+		[[ -z "$_filter_slug" && "$_maintenance_flag" == "false" ]] && continue
 
 		_total=$((_total + 1))
 		_path="${_path/#\~/$HOME}"
 
 		local _class _note
 		IFS=$'\t' read -r _class _note < <(_classify_badges_repo \
-			"$_path" "$_local_only_flag" "$_contributed_flag" "$_slug" "$_badges_helper")
+			"$_path" "$_local_only_flag" "$_contributed_flag" "$_role" "$_slug" "$_badges_helper")
 
 		case "$_class" in
 		LOCAL-ONLY) _local_only=$((_local_only + 1)) ;;

--- a/.agents/scripts/badges-sync-helper.sh
+++ b/.agents/scripts/badges-sync-helper.sh
@@ -13,7 +13,8 @@
 #
 # Sync/install operations are restricted to owned-org repos
 # (marcusquinn, essentials-com, wpallstars, or ~/.config/aidevops/badge-orgs.conf).
-# contributed:true repos and non-owned orgs are skipped with a SKIPPED/EXTERNAL note.
+# contributor-role/contributed repos and non-owned orgs are skipped with a
+# SKIPPED/EXTERNAL note.
 #
 # Default mode is --dry-run. Pass --apply to actually write, commit, push,
 # and open a PR per repo.
@@ -441,6 +442,15 @@ _open_pr() {
 
 # ─── Iteration ──────────────────────────────────────────────────────────────
 
+_repo_is_contributor() {
+	local _slug="$1"
+	[[ -f "$REPOS_JSON" ]] || return 1
+	jq -e --arg slug "$_slug" \
+		'first(.initialized_repos[]? | select(.slug == $slug)) | .role == "contributor"' \
+		"$REPOS_JSON" >/dev/null 2>&1
+	return $?
+}
+
 # _list_actionable_repos <filter_slug>
 # Emits TSV: slug\tpath\tstatus for repos needing sync.
 _list_actionable_repos() {
@@ -476,6 +486,12 @@ _process_rows() {
 		[[ -z "$_slug" ]] && continue
 		# Never touch aidevops itself
 		[[ "$_slug" == "marcusquinn/aidevops" ]] && continue
+		if _repo_is_contributor "$_slug"; then
+			local _result="${_slug}	${_STATUS_SKIPPED}	contributor role — sync is read-only"
+			_print_result_row "$_json_out" "$_result"
+			_COUNT_SKIPPED=$((_COUNT_SKIPPED + 1))
+			continue
+		fi
 
 		# Enforce owned-org filter at write time
 		local _org="${_slug%%/*}"

--- a/.agents/scripts/check-workflows-helper.sh
+++ b/.agents/scripts/check-workflows-helper.sh
@@ -534,7 +534,7 @@ _resolve_caller_worktree_root() {
 	return 0
 }
 
-# _iterate_repos — emit one "slug|path|local_only" line per registered repo
+# _iterate_repos — emit one "path|local_only|maintenance|slug" line per registered repo
 _iterate_repos() {
 	if [[ ! -f "$REPOS_JSON" ]]; then
 		_die "repos.json not found at $REPOS_JSON — aidevops may not be initialised"
@@ -543,7 +543,7 @@ _iterate_repos() {
 		_die "jq required — install via Homebrew/apt or equivalent"
 	fi
 
-	# Order: path, local_only, slug — path is never empty, so it occupies the
+	# Order: path, local_only, maintenance, slug — path is never empty, so it occupies the
 	# leading field. Slug (which CAN be empty for local_only repos) goes last
 	# so bash's `read` with IFS=$'\t' doesn't collapse the empty-slug case
 	# (tab is treated as whitespace IFS; leading empties collapse, trailing
@@ -553,6 +553,7 @@ _iterate_repos() {
 		| [
 			(.path // ""),
 			(.local_only // false | tostring),
+			((if .maintenance == false then false else true end) | tostring),
 			(.slug // "")
 		]
 		| @tsv
@@ -951,11 +952,11 @@ _process_rows() {
 		# each slug, so it cannot be safely hoisted per workflow type.
 		local _canon_norm=""
 
-		local _path _local_only_flag _slug
-		while IFS=$'\t' read -r _path _local_only_flag _slug; do
+		local _path _local_only_flag _maintenance_flag _slug
+		while IFS=$'\t' read -r _path _local_only_flag _maintenance_flag _slug; do
 			[[ -z "$_slug" && -z "$_path" ]] && continue
 			local _label="${_slug:-$(basename "$_path")}"
-			[[ -n "$_filter_slug" && "$_slug" != "$_filter_slug" ]] && continue
+			[[ (-n "$_filter_slug" && "$_slug" != "$_filter_slug") || (-z "$_filter_slug" && "$_maintenance_flag" == "false") ]] && continue
 
 			_total=$((_total + 1))
 			local _row_evidence_source

--- a/.agents/scripts/cloudron-package-monitor-helper.sh
+++ b/.agents/scripts/cloudron-package-monitor-helper.sh
@@ -235,7 +235,7 @@ _cloudron_monitor_run() {
 		else
 			_cloudron_monitor_compatibility_entry "$entry" "$apply" || failures=$((failures + 1))
 		fi
-	done < <(jq -c '.initialized_repos[] | select(.app_type == "cloudron-package")' "$REPOS_FILE")
+	done < <(jq -c '.initialized_repos[] | select(.maintenance != false and .app_type == "cloudron-package")' "$REPOS_FILE")
 	[[ "$failures" -eq 0 ]] || return 1
 	return 0
 }

--- a/.agents/scripts/contribution-watch-helper.sh
+++ b/.agents/scripts/contribution-watch-helper.sh
@@ -247,7 +247,7 @@ _get_managed_repo_slugs() {
 		return 0
 	fi
 
-	jq -r '.initialized_repos[] | select(.pulse == true and .slug != null and .slug != "") | .slug' "$REPOS_JSON" 2>/dev/null || true
+	jq -r '.initialized_repos[] | select(.slug != null and .slug != "") | .slug' "$REPOS_JSON" 2>/dev/null || true
 	return 0
 }
 
@@ -519,10 +519,10 @@ cmd_seed() {
 	echo -e "${BLUE}Discovering external contributions for @${username}...${NC}"
 	_log_info "Seed started for @${username} (dry_run=${dry_run})"
 
-	# Get list of our own repos to exclude
+	# Get all registered repos to exclude, including dormant safety scope.
 	local own_repos=""
 	if [[ -f "$REPOS_JSON" ]]; then
-		own_repos=$(jq -r '.initialized_repos[] | select(.pulse == true) | .slug' "$REPOS_JSON" 2>/dev/null | tr '\n' '|')
+		own_repos=$(jq -r '.initialized_repos[] | .slug // empty' "$REPOS_JSON" 2>/dev/null | tr '\n' '|')
 	fi
 
 	local state

--- a/.agents/scripts/dashboard-freshness-check.sh
+++ b/.agents/scripts/dashboard-freshness-check.sh
@@ -285,7 +285,7 @@ _repo_slugs_for_dashboard_scan() {
 	fi
 	jq -r '
 		.initialized_repos[]?
-		| select(.pulse == true and (.local_only // false) == false and .slug != null and .slug != "")
+		| select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != null and .slug != "")
 		| .slug
 	' "$REPOS_JSON" || true
 	return 0

--- a/.agents/scripts/dependabot-alert-monitor.sh
+++ b/.agents/scripts/dependabot-alert-monitor.sh
@@ -64,6 +64,7 @@ _dam_list_repos() {
   [[ -f "$repos_json" ]] || return 1
   jq -r '
     .initialized_repos[]?
+    | select(.maintenance != false)
     | select((.pulse // false) == true)
     | select((.local_only // false) == false)
     | select(.dependabot_alert_monitor != false)

--- a/.agents/scripts/foss-contribution-helper.sh
+++ b/.agents/scripts/foss-contribution-helper.sh
@@ -222,7 +222,7 @@ _get_daily_tokens_used() {
 # =============================================================================
 
 _get_foss_repos() {
-	jq -r '.initialized_repos[] | select(.foss == true) | .slug' "$REPOS_JSON" 2>/dev/null || true
+	jq -r '.initialized_repos[] | select(.maintenance != false and (.local_only // false) == false and .foss == true) | .slug' "$REPOS_JSON" 2>/dev/null || true
 	return 0
 }
 

--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -342,7 +342,7 @@ load_pulse_repo_allowlist() {
 		printf '%s' ""
 		return 0
 	fi
-	jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and (.slug // "") != "") | .slug' "$repos_json_path" 2>/dev/null | paste -sd ',' -
+	jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and (.slug // "") != "") | .slug' "$repos_json_path" 2>/dev/null | paste -sd ',' -
 	return 0
 }
 

--- a/.agents/scripts/inbox-digest-routine.sh
+++ b/.agents/scripts/inbox-digest-routine.sh
@@ -264,7 +264,7 @@ main() {
 			_process_inbox "$slug" "$repo_path" "$age_days" "$dry_run" || true
 			processed=$(( processed + 1 ))
 		done < <(jq -r \
-			'.initialized_repos[]? | select(.pulse == true and .local_only != true) | "\(.path)|\(.slug)"' \
+			'.initialized_repos[]? | select(.maintenance != false and .pulse == true and .local_only != true) | "\(.path)|\(.slug)"' \
 			"$REPOS_JSON" 2>/dev/null)
 	else
 		print_warning "repos.json not found at ${REPOS_JSON}. Skipping repo scan."

--- a/.agents/scripts/interactive-session-helper-scan.sh
+++ b/.agents/scripts/interactive-session-helper-scan.sh
@@ -144,7 +144,7 @@ _isc_print_orphan_pr_entry() {
 # -----------------------------------------------------------------------------
 # Internal: scan closed-not-merged PRs whose linked issue is still open
 # -----------------------------------------------------------------------------
-# For each pulse-enabled repo in repos.json:
+# For each registered non-local repo, including dormant safety scope:
 #   1. List PRs closed (not merged) in the last 14 days via gh pr list.
 #   2. Extract linked issue numbers from the PR body keywords:
 #      Resolves/Closes/Fixes/For #N.
@@ -217,7 +217,7 @@ _isc_scan_closed_pr_orphans() {
 
 		done <<<"$pr_entries"
 
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug' \
+	done < <(jq -r '.initialized_repos[] | select((.local_only // false) == false and .slug != "") | .slug' \
 		"$repos_json" 2>/dev/null || true)
 
 	printf '%d' "$orphan_count"
@@ -307,7 +307,7 @@ _isc_cmd_release_if_dead() {
 
 # scan-stale Phase 1a helper (t2148) — stampless interactive claims.
 # -----------------------------------------------------------------------------
-# Iterates pulse-enabled repos from repos.json, calls
+# Iterates registered non-local repos from repos.json, calls
 # _isc_list_stampless_interactive_claims per slug, prints findings to stdout.
 # Extracted from _isc_cmd_scan_stale to keep the coordinator under the
 # 100-line function cap enforced by the Complexity Analysis CI gate.
@@ -353,7 +353,7 @@ _isc_scan_stampless_phase() {
 			printf '\n'
 			stampless_count=$((stampless_count + 1))
 		done < <(_isc_list_stampless_interactive_claims "$runner_user_1a" "$slug_1a" 2>/dev/null || true)
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug' \
+	done < <(jq -r '.initialized_repos[] | select((.local_only // false) == false and .slug != "") | .slug' \
 		"$repos_json_1a" 2>/dev/null || true)
 
 	if [[ $stampless_count -eq 0 ]]; then

--- a/.agents/scripts/mission-dashboard-helper.sh
+++ b/.agents/scripts/mission-dashboard-helper.sh
@@ -484,7 +484,7 @@ _status_print_blockers() {
 				echo -e "  ${YELLOW}${slug}:${NC}"
 				echo "$blocked_issues"
 			fi
-		done < <(jq -r '.[] | select(.pulse == true) | .slug // empty' "$repos_json" 2>/dev/null)
+		done < <(jq -r '.initialized_repos[]? | select(.maintenance != false and .pulse == true) | .slug // empty' "$repos_json" 2>/dev/null)
 		if [[ "$found_blockers" == "false" ]]; then
 			echo "  None"
 		fi

--- a/.agents/scripts/orchestration-efficiency-collector.sh
+++ b/.agents/scripts/orchestration-efficiency-collector.sh
@@ -662,7 +662,7 @@ collect_audit_trails() {
 		repos_json="${HOME}/.config/aidevops/repos.json"
 		if [[ -f "$repos_json" ]] && command -v jq &>/dev/null; then
 			local pulse_repos
-			pulse_repos=$(jq -r '.[] | select(.pulse == true and .local_only != true) | .slug' "$repos_json" 2>/dev/null || echo "")
+			pulse_repos=$(jq -r '.initialized_repos[]? | select(.maintenance != false and .pulse == true and .local_only != true) | .slug' "$repos_json" 2>/dev/null || echo "")
 			while IFS= read -r repo_slug; do
 				[[ -z "$repo_slug" ]] && continue
 				# Issues closed today

--- a/.agents/scripts/peer-productivity-monitor.sh
+++ b/.agents/scripts/peer-productivity-monitor.sh
@@ -132,6 +132,7 @@ _list_pulse_repos() {
 		return 0
 	fi
 	jq -r '.initialized_repos[]
+		| select(.maintenance != false)
 		| select(.pulse == true)
 		| select(.local_only != true)
 		| select(.slug != null and .slug != "")

--- a/.agents/scripts/pr-salvage-helper.sh
+++ b/.agents/scripts/pr-salvage-helper.sh
@@ -468,7 +468,7 @@ scan_all_repos() {
 	fi
 
 	local repo_slugs
-	repo_slugs=$(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$REPOS_JSON")
+	repo_slugs=$(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$REPOS_JSON")
 
 	while IFS= read -r slug; do
 		[[ -z "$slug" ]] && continue

--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -2647,7 +2647,7 @@ dispatch_routine_comment_responses() {
 			bash "$responder" dispatch "$slug" "$repo_path" "$issue_number" "$comment_id" 2>>"$LOGFILE" || true
 			dispatched=$((dispatched + 1))
 		done <<<"$scan_output"
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true) | select(.local_only != true) | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null)
+	done < <(jq -r '.initialized_repos[] | select(.maintenance != false) | select(.pulse == true) | select(.local_only != true) | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null)
 
 	if [[ "$dispatched" -gt 0 ]]; then
 		echo "[pulse-wrapper] Routine comment responses: dispatched ${dispatched} workers" >>"$LOGFILE"
@@ -2744,7 +2744,7 @@ dispatch_foss_workers() {
 		foss_count=$((foss_count + 1))
 		available=$((available - 1))
 	done < <(jq -r '.initialized_repos[]
-		| select(.foss == true and (.foss_config.blocklist // false) == false)
+		| select(.maintenance != false and (.local_only // false) == false and .foss == true and (.foss_config.blocklist // false) == false)
 		| [
 			.slug,
 			.path,

--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -465,7 +465,7 @@ _group_repos_by_owner() {
 
 	jq -r '
 		[.initialized_repos[] |
-			select(.pulse == true and (.local_only // false) == false and .slug != "") |
+			select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") |
 			.slug
 		] |
 		group_by(split("/")[0]) |

--- a/.agents/scripts/pulse-canonical-maintenance.sh
+++ b/.agents/scripts/pulse-canonical-maintenance.sh
@@ -259,7 +259,8 @@ _canonical_ff_single_repo() {
 # ---------------------------------------------------------------------------
 # _canonical_fast_forward
 #
-# For each pulse-enabled, non-local_only repo in repos.json, run pre-flight
+# For each maintained repository, run the remote diagnostic pass. Safety
+# worktree cleanup below deliberately keeps a broader all-registered scope.
 # checks and fast-forward if behind origin.
 # Arguments: $1 - dry_run ("1" for dry run, "0" for real)
 # Returns: 0 always (fail-open per repo)
@@ -270,7 +271,7 @@ _canonical_fast_forward() {
 	[[ -f "$repos_json" ]] && command -v jq &>/dev/null || return 0
 
 	local -a _repo_list=()
-	mapfile -t _repo_list < <(jq -r '.initialized_repos[] | select((.pulse // false) == true) | select((.local_only // false) == false) | .path // ""' "$repos_json" 2>/dev/null)
+	mapfile -t _repo_list < <(jq -r '.initialized_repos[] | select(.maintenance != false) | select((.pulse // false) == true) | select((.local_only // false) == false) | .path // ""' "$repos_json" 2>/dev/null)
 
 	local repo_path ff_count=0 skip_count=0
 	for repo_path in "${_repo_list[@]}"; do
@@ -361,7 +362,7 @@ _stale_worktree_sweep_single_repo() {
 # ---------------------------------------------------------------------------
 # _stale_worktree_sweep
 #
-# For each pulse-enabled, non-local_only repo: invoke worktree-helper.sh
+# For each registered, non-local_only repo: invoke worktree-helper.sh
 # clean --auto --force-merged with a per-repo hard timeout.
 # Arguments: $1 - dry_run ("1" for dry run, "0" for real)
 # Returns: 0 always (fail-open per repo)
@@ -390,7 +391,7 @@ _stale_worktree_sweep() {
 	fi
 
 	local -a _repo_list=()
-	mapfile -t _repo_list < <(jq -r '.initialized_repos[] | select((.pulse // false) == true) | select((.local_only // false) == false) | .path // ""' "$repos_json" 2>/dev/null)
+	mapfile -t _repo_list < <(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path // ""' "$repos_json" 2>/dev/null)
 
 	local repo_path sweep_count=0
 	for repo_path in "${_repo_list[@]}"; do

--- a/.agents/scripts/pulse-capacity-alloc.sh
+++ b/.agents/scripts/pulse-capacity-alloc.sh
@@ -214,7 +214,7 @@ _scan_pr_salvage() {
 			salvage_found=true
 			echo "$salvage_output"
 		fi
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null)
+	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null)
 
 	if [[ "$salvage_found" == "false" ]]; then
 		echo "- No salvageable closed-unmerged PRs detected"
@@ -386,7 +386,7 @@ _count_priority_repos() {
 
 	read -r product_repos tooling_repos < <(jq -r '
 		.initialized_repos |
-		map(select(.pulse == true and (.local_only // false) == false and .slug != "")) |
+		map(select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "")) |
 		[
 			(map(select(.priority == "product")) | length),
 			(map(select(.priority == "tooling")) | length)
@@ -437,7 +437,7 @@ _count_dispatchable_product_repos() {
 			if [[ "$daily_pr_count" -lt "$DAILY_PR_CAP" ]]; then
 				dispatchable=$((dispatchable + 1))
 			fi
-		done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "" and .priority == "product") | .slug' "$repos_json" 2>/dev/null)
+		done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "" and .priority == "product") | .slug' "$repos_json" 2>/dev/null)
 	else
 		dispatchable="$product_repos"
 	fi

--- a/.agents/scripts/pulse-capacity.sh
+++ b/.agents/scripts/pulse-capacity.sh
@@ -408,7 +408,7 @@ count_runnable_candidates() {
 		pulse_count_debug_log "count_runnable_candidates repo=${slug} issues=${issue_count} prs=${pr_count} total=$((issue_count + pr_count))"
 
 		total=$((total + issue_count + pr_count))
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null)
+	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null)
 
 	echo "$total"
 	return 0
@@ -467,7 +467,7 @@ count_queued_without_worker() {
 				pulse_count_debug_log "count_queued_without_worker repo=${slug} issue=${issue_num} missing_worker=true"
 			fi
 		done < <(echo "$queued_json" | jq -r --arg self "$self_login" '.[] | .number as $n | ((.assignees | length) > 0 and (([.assignees[].login] | index($self)) == null)) as $assigned_other | "\($n)|\($assigned_other)"' 2>/dev/null)
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null)
+	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null)
 
 	echo "$total"
 	return 0

--- a/.agents/scripts/pulse-check-queue-scan.py
+++ b/.agents/scripts/pulse-check-queue-scan.py
@@ -109,7 +109,12 @@ def _load_repos(repos_json: pathlib.Path) -> tuple[list[dict[str, Any]], str]:
     for repo in initialized:
         if not isinstance(repo, dict):
             continue
-        if repo.get("pulse") is True and not repo.get("local_only") and repo.get("slug"):
+        if (
+            repo.get("maintenance", True) is not False
+            and repo.get("pulse") is True
+            and not repo.get("local_only")
+            and repo.get("slug")
+        ):
             repos.append(repo)
     return repos, ""
 

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -2612,7 +2612,7 @@ cleanup_stalled_workers() {
 		[[ -n "$issue_num" ]] || continue
 
 		local log_file="" log_size=""
-		# Check all pulse-enabled repos for matching log
+		# Check all registered repos for matching logs, including dormant scope.
 		local found_log=""
 		local repo_slug=""
 		while IFS= read -r repo_slug; do
@@ -2622,7 +2622,7 @@ cleanup_stalled_workers() {
 				found_log="$log_file"
 				break
 			fi
-		done < <(jq -r '.initialized_repos[] | select(.pulse == true) | .slug // ""' "$REPOS_JSON")
+		done < <(jq -r '.initialized_repos[] | .slug // ""' "$REPOS_JSON")
 		# Fallback log path
 		if [[ -z "$found_log" ]]; then
 			log_file=$(aidevops_pulse_worker_log_fallback_path "$issue_num" 2>/dev/null || true)

--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -298,7 +298,7 @@ build_dependency_graph_cache() {
 	build_start=$(date +%s)
 
 	local repos_json
-	repos_json=$(jq -c '.initialized_repos[] | select(.pulse == true and (.local_only != true))' \
+	repos_json=$(jq -c '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only != true))' \
 		"${HOME}/.config/aidevops/repos.json" 2>/dev/null) || repos_json=""
 	if [[ -z "$repos_json" ]]; then
 		echo "[pulse-wrapper] dep-graph-cache: no pulse repos found, skipping" >>"$LOGFILE"

--- a/.agents/scripts/pulse-dirty-pr-sweep.sh
+++ b/.agents/scripts/pulse-dirty-pr-sweep.sh
@@ -1248,8 +1248,8 @@ _dirty_pr_sweep_for_repo() {
 # Public entry points
 # -----------------------------------------------------------------------------
 
-# Sweep all pulse-enabled repos. Respects the interval gate — early-returns
-# 0 when not due. Safe to call every pulse cycle.
+# Sweep all registered non-local repos, including dormant dirty-state recovery.
+# Respects the interval gate — early-returns 0 when not due.
 dirty_pr_sweep_all_repos() {
 	# Honour pulse stop flag when running as module.
 	if [[ -n "${STOP_FLAG:-}" && -f "$STOP_FLAG" ]]; then
@@ -1291,7 +1291,7 @@ dirty_pr_sweep_all_repos() {
 			_dps_log "stop flag appeared mid-run — breaking"
 			break
 		fi
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | [.slug, .path] | join("|")' "$repos_json" 2>/dev/null)
+	done < <(jq -r '.initialized_repos[] | select((.local_only // false) == false and .slug != "") | [.slug, .path] | join("|")' "$repos_json" 2>/dev/null)
 
 	_dirty_pr_sweep_mark_run
 	_dps_log "sweep complete: rebased=${total_rebased} closed=${total_closed} notified=${total_notified}"

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -417,7 +417,7 @@ build_ranked_dispatch_candidates_json() {
 			else .pulse_hours.end
 			end;
 		.initialized_repos[] |
-		select(.pulse == true and (.local_only // false) == false and .slug != "" and .path != "") |
+		select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "" and .path != "") |
 		[
 			.slug,
 			.path,
@@ -773,7 +773,7 @@ _should_run_llm_supervisor() {
 		[[ "$pc" =~ ^[0-9]+$ ]] || pc=0
 		current_issues=$((current_issues + ic))
 		current_prs=$((current_prs + pc))
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | [.slug, .path] | join("|")' "$REPOS_JSON" 2>/dev/null)
+	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | [.slug, .path] | join("|")' "$REPOS_JSON" 2>/dev/null)
 
 	local snap_age=$((now_epoch - snap_epoch))
 	local total_before=$((snap_issues + snap_prs))

--- a/.agents/scripts/pulse-fix-the-fixer-detector.sh
+++ b/.agents/scripts/pulse-fix-the-fixer-detector.sh
@@ -546,7 +546,7 @@ cmd_run() {
 	elif [[ -f "$REPOS_JSON" ]]; then
 		# Iterate pulse-enabled, non-local-only repos.
 		local repos_str
-		repos_str=$(jq -r '.initialized_repos[]? | select(.pulse == true) | select((.local_only // false) == false) | .slug' "$REPOS_JSON" 2>/dev/null) || repos_str=""
+		repos_str=$(jq -r '.initialized_repos[]? | select(.maintenance != false) | select(.pulse == true) | select((.local_only // false) == false) | .slug' "$REPOS_JSON" 2>/dev/null) || repos_str=""
 		while IFS= read -r r; do
 			[[ -n "$r" ]] && target_repos+=("$r")
 		done <<<"$repos_str"

--- a/.agents/scripts/pulse-issue-reconcile-close.sh
+++ b/.agents/scripts/pulse-issue-reconcile-close.sh
@@ -56,7 +56,7 @@ fi
 # Module-level slug iteration filter (string-literal ratchet: avoids repeating
 # the jq filter 3x across close_issues_with_merged_prs, reconcile_stale_done_issues,
 # and reconcile_open_issues_with_merged_prs).
-_pir_close_slug_filter='.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""'
+_pir_close_slug_filter='.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""'
 
 #######################################
 # Close open issues whose work is already done — a merged PR exists

--- a/.agents/scripts/pulse-issue-reconcile-normalize.sh
+++ b/.agents/scripts/pulse-issue-reconcile-normalize.sh
@@ -319,7 +319,7 @@ _normalize_label_invariants() {
 	while IFS= read -r slug; do
 		[[ -n "$slug" ]] || continue
 		_normalize_label_invariants_for_repo "$slug" "$triage_cutoff"
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
+	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
 
 	echo "[pulse-wrapper] label_invariants: checked=${_LI_CHECKED} status_fixed=${_LI_STATUS_FIXED} tier_fixed=${_LI_TIER_FIXED} triage_missing=${_LI_TRIAGE_MISSING}" >>"$LOGFILE"
 

--- a/.agents/scripts/pulse-issue-reconcile-parent.sh
+++ b/.agents/scripts/pulse-issue-reconcile-parent.sh
@@ -392,7 +392,7 @@ reconcile_completed_parent_tasks() {
 			[[ "$_SP_CPT_ESCALATED" -eq 1 ]] && total_escalated=$((total_escalated + 1))
 			[[ "$_SP_CPT_REOPENED" -eq 1 ]] && total_reopened=$((total_reopened + 1))
 		done
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
+	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
 
 	if [[ "$total_closed" -gt 0 || "$total_nudged" -gt 0 || "$total_escalated" -gt 0 || "$total_reopened" -gt 0 ]]; then
 		echo "[pulse-wrapper] Reconcile completed parent tasks: closed=${total_closed} reopened=${total_reopened} nudged=${total_nudged} escalated=${total_escalated}" >>"$LOGFILE"

--- a/.agents/scripts/pulse-issue-reconcile-stale.sh
+++ b/.agents/scripts/pulse-issue-reconcile-stale.sh
@@ -278,6 +278,10 @@ _normalize_unassign_stale() {
 
 	while IFS= read -r slug; do
 		[[ -n "$slug" ]] || continue
+		if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
+			|| ! repo_allows_pulse_write_actions "$slug"; then
+			continue
+		fi
 
 		# Find issues assigned to runner_user with active-dispatch labels
 		local stale_json
@@ -309,7 +313,7 @@ _normalize_unassign_stale() {
 			_normalize_clear_status_labels "$stale_num" "$slug" "$runner_user" || true
 			total_reset=$((total_reset + 1))
 		done <<<"$stale_issues"
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
+	done < <(jq -r '.initialized_repos[] | select((.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
 
 	# t2372: always log scan summary so silent runs are visible in pulse log
 	# and operators can confirm the sweep is firing per-cycle.

--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -657,7 +657,7 @@ _normalize_reassign_self() {
 				total_assigned=$((total_assigned + 1))
 			fi
 		done <<<"$all_rows"
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
+	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
 
 	if [[ "$total_checked" -gt 0 ]]; then
 		echo "[pulse-wrapper] Assignment normalization: assigned ${total_assigned}/${total_checked} active unassigned issues to ${runner_user} (skipped_claimed=${total_skipped_claimed})" >>"$LOGFILE"
@@ -749,6 +749,10 @@ _normalize_unassign_stampless_interactive() {
 
 	while IFS= read -r slug; do
 		[[ -n "$slug" ]] || continue
+		if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
+			|| ! repo_allows_pulse_write_actions "$slug"; then
+			continue
+		fi
 
 		# t2773: route through gh_issue_list wrapper (REST fallback on rate-limit exhaustion).
 		# This fetch is assignee-filtered, so it cannot use the prefetch cache
@@ -812,7 +816,7 @@ _normalize_unassign_stampless_interactive() {
 				total_released=$((total_released + 1))
 			fi
 		done <<<"$rows"
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" 2>/dev/null || true)
+	done < <(jq -r '.initialized_repos[] | select((.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" 2>/dev/null || true)
 
 	if [[ "$total_released" -gt 0 ]]; then
 		echo "[pulse-wrapper] Stampless interactive cleanup: released ${total_released} issues for dispatch" >>"$LOGFILE"
@@ -1038,7 +1042,7 @@ This comment is idempotent; the HTML sentinel prevents duplicates on subsequent 
 				total_fixed=$((total_fixed + 1))
 			fi
 		done
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
+	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
 
 	if [[ "$((total_fixed + total_skipped))" -gt 0 ]]; then
 		echo "[pulse-wrapper] Labelless backfill: fixed=${total_fixed}, skipped=${total_skipped}" >>"$LOGFILE"
@@ -1545,7 +1549,7 @@ reconcile_issues_single_pass() {
 		# Slash in slug would break log parsing; replace with underscore.
 		local _slug_safe="${slug//\//_}"
 		_log_substage_timing "substage:reconcile_sp/repo:${_slug_safe}" "$_slug_start" 0
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
+	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
 
 	# t2838: persist last-run epoch when backfill actually ran this cycle.
 	# Skip on dry runs (pbf_total_run == 0) so we retry next cycle.

--- a/.agents/scripts/pulse-merge-pass.sh
+++ b/.agents/scripts/pulse-merge-pass.sh
@@ -737,7 +737,7 @@ merge_ready_prs_all_repos() {
 		echo "[pulse-wrapper] Same-pass merge outcome cache unavailable; zero-progress aggregate will fail closed" >>"$_mr_logfile"
 	fi
 
-	_mr_repo_rows=$(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | [.slug, .path] | join("|")' "$_mr_repos_json" 2>/dev/null) || _mr_repo_rows=""
+	_mr_repo_rows=$(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | [.slug, .path] | join("|")' "$_mr_repos_json" 2>/dev/null) || _mr_repo_rows=""
 	_pmp_prepare_merge_checkpoint_resume "$_mr_repo_rows" "$_mr_checkpoint_file" "$_mr_logfile" \
 		_mr_checkpoint _mr_resume_pending _mr_resumed_from_checkpoint || true
 

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -1752,7 +1752,7 @@ Auto-approved: ${approval_reason}. Stale recovery tick reset." \
 				fi
 			fi
 		done
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.maintainer // (.slug | split("/")[0]))"' "$repos_json" 2>/dev/null)
+	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.maintainer // (.slug | split("/")[0]))"' "$repos_json" 2>/dev/null)
 
 	if [[ "$total_approved" -gt 0 ]]; then
 		echo "[pulse-wrapper] Auto-approve maintainer issues: approved ${total_approved} issue(s)" >>"$LOGFILE"

--- a/.agents/scripts/pulse-prefetch-workers.sh
+++ b/.agents/scripts/pulse-prefetch-workers.sh
@@ -186,7 +186,7 @@ prefetch_foss_scan() {
 	local foss_repo_count=0
 	local repos_json_path="${REPOS_JSON:-}"
 	if [[ -n "$repos_json_path" && -f "$repos_json_path" ]] && command -v jq &>/dev/null; then
-		foss_repo_count=$(jq '[.initialized_repos[] | select(.foss == true)] | length' "$repos_json_path" || echo 0)
+		foss_repo_count=$(jq '[.initialized_repos[] | select(.maintenance != false and (.local_only // false) == false and .foss == true)] | length' "$repos_json_path" || echo 0)
 	fi
 	if [[ "${foss_repo_count:-0}" -eq 0 ]]; then
 		return 0

--- a/.agents/scripts/pulse-prefetch.sh
+++ b/.agents/scripts/pulse-prefetch.sh
@@ -68,7 +68,7 @@ prefetch_state() {
 			else .pulse_hours.end
 			end;
 		.initialized_repos[] |
-		select(.pulse == true and (.local_only // false) == false and .slug != "") |
+		select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") |
 		[
 			.slug,
 			.path,

--- a/.agents/scripts/pulse-queue-governor.sh
+++ b/.agents/scripts/pulse-queue-governor.sh
@@ -108,7 +108,7 @@ _fetch_queue_metrics() {
 		total_issues=$((total_issues + repo_issue_total))
 		ready_prs=$((ready_prs + repo_ready))
 		failing_prs=$((failing_prs + repo_failing))
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.path)"' "$REPOS_JSON" 2>/dev/null)
+	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.path)"' "$REPOS_JSON" 2>/dev/null)
 
 	echo "$total_prs"
 	echo "$total_issues"

--- a/.agents/scripts/pulse-repo-meta.sh
+++ b/.agents/scripts/pulse-repo-meta.sh
@@ -180,6 +180,9 @@ get_repo_role_by_slug() {
 #######################################
 repo_allows_pulse_write_actions() {
 	local repo_slug="$1"
+	local repo_role=""
+	repo_role=$(get_repo_role_by_slug "$repo_slug") || return 1
+	[[ "$repo_role" == "$_PULSE_REPO_ROLE_MAINTAINER" ]] || return 1
 
 	# #aidevops:trust-boundary — never rely on repos.json role or successful
 	# public comments as authority. Require the authenticated runner to be an

--- a/.agents/scripts/pulse-repo-tier.sh
+++ b/.agents/scripts/pulse-repo-tier.sh
@@ -268,7 +268,7 @@ cmd_classify() {
 
 	local slugs
 	slugs=$(jq -r '.initialized_repos[] |
-		select(.pulse == true and (.local_only // false) == false and .slug != "") |
+		select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") |
 		.slug
 	' "$REPOS_JSON" 2>/dev/null) || slugs=""
 

--- a/.agents/scripts/pulse-routines.sh
+++ b/.agents/scripts/pulse-routines.sh
@@ -530,7 +530,7 @@ evaluate_routines() {
 			fi
 		done <<<"$routine_section"
 
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false) | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null || true)
+	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false) | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null || true)
 
 	if [[ "$routines_dispatched" -gt 0 ]]; then
 		echo "[pulse-wrapper] evaluate_routines: dispatched ${routines_dispatched} routine(s)" >>"$LOGFILE"

--- a/.agents/scripts/pulse-session-helper.sh
+++ b/.agents/scripts/pulse-session-helper.sh
@@ -148,7 +148,7 @@ is_config_consent_enabled() {
 #######################################
 get_pulse_repo_count() {
 	if [[ -f "$REPOS_JSON" ]] && command -v jq &>/dev/null; then
-		jq '[.initialized_repos[] | select(.pulse == true)] | length' "$REPOS_JSON" || echo "0"
+		jq '[.initialized_repos[] | select(.maintenance != false and .pulse == true)] | length' "$REPOS_JSON" || echo "0"
 	else
 		echo "?"
 	fi

--- a/.agents/scripts/pulse-simplification-scan.sh
+++ b/.agents/scripts/pulse-simplification-scan.sh
@@ -60,7 +60,7 @@ _complexity_scan_check_interval() {
 _pulse_enabled_repo_slugs() {
 	local repos_json="$1"
 	[[ -f "$repos_json" ]] || return 0
-	jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null || true
+	jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null || true
 	return 0
 }
 

--- a/.agents/scripts/pulse-triage-dispatch.sh
+++ b/.agents/scripts/pulse-triage-dispatch.sh
@@ -610,8 +610,13 @@ _backfill_stale_consolidation_labels() {
 	local total_backfilled=0
 	local total_cleared_stale=0
 	local total_locks_expired=0
-	while IFS='|' read -r slug rpath; do
+	local maintenance_flag="" pulse_flag=""
+	while IFS='|' read -r slug rpath maintenance_flag pulse_flag; do
 		[[ -n "$slug" ]] || continue
+		if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
+			|| ! repo_allows_pulse_write_actions "$slug"; then
+			continue
+		fi
 
 		# t2151: TTL sweep for stuck `consolidation-in-progress` labels.
 		# Separate query from needs-consolidation because a lock can be held
@@ -629,6 +634,7 @@ _backfill_stale_consolidation_labels() {
 				total_locks_expired=$((total_locks_expired + 1))
 			fi
 		done < <(printf '%s' "$locked_issues_json" | jq -r '.[]?.number // ""' 2>/dev/null)
+		[[ "$maintenance_flag" == "false" || "$pulse_flag" != "true" ]] && continue
 
 		local issues_json
 		issues_json=$(gh_issue_list --repo "$slug" --state open \
@@ -669,7 +675,7 @@ _backfill_stale_consolidation_labels() {
 				total_backfilled=$((total_backfilled + 1))
 			fi
 		done < <(printf '%s' "$issues_json" | jq -r '.[] | "\(.number)|\([.labels[].name] | join(","))"' 2>/dev/null)
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.path // "")"' "$repos_json" 2>/dev/null)
+	done < <(jq -r '.initialized_repos[] | select((.local_only // false) == false and .slug != "") | "\(.slug)|\(.path // "")|\(if .maintenance == false then false else true end)|\(.pulse // false)"' "$repos_json" 2>/dev/null)
 
 	if [[ "$total_backfilled" -gt 0 ]]; then
 		echo "[pulse-wrapper] Consolidation backfill: dispatched ${total_backfilled} stale consolidation child issue(s)" >>"$LOGFILE"

--- a/.agents/scripts/pulse-triage-evaluation.sh
+++ b/.agents/scripts/pulse-triage-evaluation.sh
@@ -92,7 +92,7 @@ _reevaluate_consolidation_labels() {
 				total_cleared=$((total_cleared + 1))
 			fi
 		done < <(printf '%s' "$issues_json" | jq -r '.[]?.number // ""')
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null)
+	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null)
 
 	if [[ "$total_cleared" -gt 0 ]]; then
 		echo "[pulse-wrapper] Consolidation re-evaluation: cleared ${total_cleared} stale needs-consolidation label(s)" >>"$LOGFILE"
@@ -383,7 +383,7 @@ _reevaluate_simplification_labels() {
 				fi
 			fi
 		done < <(printf '%s' "$issues_json" | jq -r '.[]?.number // ""')
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "" and .path != "") | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null)
+	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "" and .path != "") | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null)
 
 	if [[ "$total_cleared" -gt 0 ]]; then
 		echo "[pulse-wrapper] Simplification re-evaluation: cleared ${total_cleared} stale needs-simplification label(s)" >>"$LOGFILE"

--- a/.agents/scripts/pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/pulse-wrapper-cycle-gates.sh
@@ -184,7 +184,7 @@ _pulse_scope_repos_for_available_work_gate() {
 		read -r _scope <"${SCOPE_FILE:-}" || [[ -n "$_scope" ]] || _scope=""
 	fi
 	if [[ -z "$_scope" && -f "${REPOS_JSON:-}" ]]; then
-		_scope=$(jq -r '[.initialized_repos[]? | select(.pulse == true and (.local_only // false) == false and (.slug // "") != "") | .slug] | join(",")' "${REPOS_JSON:-}") || _scope=""
+		_scope=$(jq -r '[.initialized_repos[]? | select(.maintenance != false and .pulse == true and (.local_only // false) == false and (.slug // "") != "") | .slug] | join(",")' "${REPOS_JSON:-}") || _scope=""
 	fi
 	local _slug=""
 	while IFS= read -r _slug; do

--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -500,7 +500,7 @@ _pulse_reconcile_stale_blocked_if_due() {
 	while IFS= read -r repo_slug; do
 		[[ -n "$repo_slug" ]] || continue
 		reconcile_stale_blocked_issues "$repo_slug" 2>>"$LOGFILE" || failures=$((failures + 1))
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null || true)
+	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null || true)
 	touch "$sentinel" 2>/dev/null || true
 	echo "[pulse-wrapper] stale-blocked reconciliation completed failures=${failures} cadence=${interval}s" >>"$LOGFILE"
 	return 0
@@ -715,7 +715,7 @@ sync_todo_refs_all_repos() {
 			[[ "$job_rc" -eq 0 ]] || sync_failures=$((sync_failures + 1))
 			active_pids=("${active_pids[@]:1}")
 		fi
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "" and .path != "") | [.slug, .path] | join("|")' "$repos_json" 2>/dev/null || true)
+	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "" and .path != "") | [.slug, .path] | join("|")' "$repos_json" 2>/dev/null || true)
 	for pid in "${active_pids[@]}"; do
 		job_rc=0
 		wait "$pid" || job_rc=$?

--- a/.agents/scripts/repo-aidevops-health-helper.sh
+++ b/.agents/scripts/repo-aidevops-health-helper.sh
@@ -776,6 +776,7 @@ _check_version_bumps() {
 	local entries_raw
 	entries_raw=$(jq -r '
 		.initialized_repos[]? |
+		select(.maintenance != false) |
 		[.slug, (.path // ""), (.local_only // false)] |
 		@tsv
 	' "$CONFIG_FILE" 2>/dev/null || true)

--- a/.agents/scripts/session-miner-pulse.sh
+++ b/.agents/scripts/session-miner-pulse.sh
@@ -929,7 +929,7 @@ file_contributor_insights() {
 			# shellcheck disable=SC2086
 			"$insight_helper" file $dr_flag "${scoped_compressed_file}" "$slug" 2>&1 || true
 		fi
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null)
+	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null)
 
 	return 0
 }

--- a/.agents/scripts/setup/modules/migrations.sh
+++ b/.agents/scripts/setup/modules/migrations.sh
@@ -1794,7 +1794,7 @@ backfill_issue_relationships() {
 			print_warning "  $(basename "$expanded_path"): relationships sync had errors"
 			failed_repos=$((failed_repos + 1))
 		fi
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true) | [.path, .slug, (.local_only // false | tostring)] | @tsv' "$repos_file" 2>/dev/null)
+	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true) | [.path, .slug, (.local_only // false | tostring)] | @tsv' "$repos_file" 2>/dev/null)
 
 	# Create marker directory and file
 	mkdir -p "$marker_dir"

--- a/.agents/scripts/shared-dispatch-label-cleanup.sh
+++ b/.agents/scripts/shared-dispatch-label-cleanup.sh
@@ -163,7 +163,6 @@ _dispatch_label_sweep_repos() {
 	[[ -f "$repos_json" ]] || return 1
 	jq -r '
 		.initialized_repos[]? |
-		select((.pulse // false) == true) |
 		select((.local_only // false) == false) |
 		.slug // empty
 	' "$repos_json" 2>/dev/null
@@ -184,6 +183,10 @@ sweep_closed_auto_dispatch_issues() {
 	local repo_slug issue_number issue_rows snapshot state state_reason labels_csv reason
 	while IFS= read -r repo_slug; do
 		[[ -n "$repo_slug" ]] || continue
+		if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
+			|| ! repo_allows_pulse_write_actions "$repo_slug"; then
+			continue
+		fi
 		issue_rows=$(_dispatch_blocker_active_issue_candidates "$repo_slug" "$limit") || {
 			logger_failed=$((logger_failed + 1))
 			continue

--- a/.agents/scripts/stats-health-dashboard-data.sh
+++ b/.agents/scripts/stats-health-dashboard-data.sh
@@ -496,7 +496,7 @@ _compute_worker_success_rates() {
 				--jq '[.[] | select(.mergedAt == null)] | length' \
 				--limit 500 2>/dev/null || echo "0")
 			closed_unmerged_count=$(( closed_unmerged_count + ${cu:-0} ))
-		done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only != true)) | .slug' "$repos_file" 2>/dev/null)
+		done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only != true)) | .slug' "$repos_file" 2>/dev/null)
 	fi
 	local metrics_file="${HOME}/.aidevops/logs/headless-runtime-metrics.jsonl"
 	if [[ -f "$metrics_file" ]]; then
@@ -904,7 +904,7 @@ _refresh_person_stats_cache() {
 	search_remaining=$(_stats_health_person_stats_search_remaining)
 
 	local repo_entries
-	repo_entries=$(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null || echo "")
+	repo_entries=$(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null || echo "")
 
 	local repo_count=0
 	local search_api_cost_per_contributor=4
@@ -946,7 +946,7 @@ _refresh_person_stats_cache() {
 	# Cross-repo person-stats
 	search_remaining=$(_stats_health_person_stats_search_remaining)
 	local all_repo_paths
-	all_repo_paths=$(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false) | .path' "$repos_json" 2>/dev/null || echo "")
+	all_repo_paths=$(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false) | .path' "$repos_json" 2>/dev/null || echo "")
 	if [[ -n "$all_repo_paths" && "$search_remaining" -ge "$search_api_cost_per_contributor" ]]; then
 		local -a cross_args=()
 		while IFS= read -r rp; do

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -360,7 +360,7 @@ update_health_issues() {
 	fi
 
 	local repo_entries
-	repo_entries=$(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null || echo "")
+	repo_entries=$(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null || echo "")
 
 	if [[ -z "$repo_entries" ]]; then
 		return 0

--- a/.agents/scripts/stats-quality-sweep.sh
+++ b/.agents/scripts/stats-quality-sweep.sh
@@ -145,7 +145,7 @@ run_daily_quality_sweep() {
 	fi
 
 	local repo_entries
-	repo_entries=$(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null || echo "")
+	repo_entries=$(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null || echo "")
 
 	if [[ -z "$repo_entries" ]]; then
 		return 0

--- a/.agents/scripts/tests/test-consolidation-dispatch.sh
+++ b/.agents/scripts/tests/test-consolidation-dispatch.sh
@@ -176,6 +176,13 @@ _setup_gh_stub_globals() {
 		gh pr list "$@"
 		return $?
 	}
+	repo_allows_pulse_write_actions() {
+		local repo_slug="$1"
+		case "$repo_slug" in
+		owner/repo | marcusquinn/aidevops) return 0 ;;
+		*) return 1 ;;
+		esac
+	}
 	return 0
 }
 

--- a/.agents/scripts/tests/test-dispatch-label-cleanup.sh
+++ b/.agents/scripts/tests/test-dispatch-label-cleanup.sh
@@ -42,7 +42,7 @@ setup_env() {
 	: >"$LOGFILE"
 	: >"${TEST_ROOT}/gh.log"
 	cat >"$REPOS_JSON" <<'JSON'
-{"initialized_repos":[{"slug":"owner/repo","pulse":true,"local_only":false},{"slug":"owner/local","pulse":true,"local_only":true},{"slug":"owner/off","pulse":false,"local_only":false}]}
+{"initialized_repos":[{"slug":"owner/repo","pulse":true,"local_only":false},{"slug":"owner/local","pulse":true,"local_only":true},{"slug":"owner/off","pulse":false,"local_only":false},{"slug":"owner/contributor","pulse":false,"local_only":false,"role":"contributor"}]}
 JSON
 	return 0
 }
@@ -82,6 +82,14 @@ install_gh_stub() {
 		return 0
 	}
 	return 0
+}
+
+repo_allows_pulse_write_actions() {
+	local repo_slug="$1"
+	case "$repo_slug" in
+	owner/repo | owner/off) return 0 ;;
+	*) return 1 ;;
+	esac
 }
 
 append_blocker() {
@@ -188,10 +196,13 @@ test_sweep_preserves_blockers_on_logger_failure() {
 	append_blocker 101 issue-101 request-logger-failure
 	local failing_logger="${TEST_ROOT}/failing-worker-blocker-log.mjs"
 	cat >"$failing_logger" <<'JS'
-if (process.argv[2] === "list-active-issues") {
+const slugIndex = process.argv.indexOf("--repo-slug");
+const slug = slugIndex >= 0 ? process.argv[slugIndex + 1] : "";
+if (process.argv[2] === "list-active-issues" && slug === "owner/repo") {
   process.stdout.write("101\n");
   process.exit(0);
 }
+if (process.argv[2] === "list-active-issues") process.exit(0);
 process.exit(1);
 JS
 	DISPATCH_LABEL_CLEANUP_BLOCKER_LOGGER="$failing_logger"

--- a/.agents/scripts/tests/test-issue-reconcile.sh
+++ b/.agents/scripts/tests/test-issue-reconcile.sh
@@ -107,6 +107,11 @@ gh_issue_list() {
 	gh issue list "$@"
 	return $?
 }
+repo_allows_pulse_write_actions() {
+	local repo_slug="$1"
+	[[ "$repo_slug" == "owner/testrepo" ]]
+	return $?
+}
 
 # =============================================================================
 # Part 1 — _normalize_reassign_self: self-assigns orphaned active issues
@@ -258,6 +263,10 @@ chmod +x "${STUB_DIR}/gh"
 STAMP_DIR="${HOME}/.aidevops/.agent-workspace/interactive-claims"
 mkdir -p "$STAMP_DIR"
 rm -f "${STAMP_DIR}/owner-testrepo-555.json"
+
+# The pause operation sets both fields false; cleanup must remain registered-scope.
+jq '(.initialized_repos[0].maintenance, .initialized_repos[0].pulse) = (false, false)' \
+	"$REPOS_JSON" >"${REPOS_JSON}.tmp" && mv "${REPOS_JSON}.tmp" "$REPOS_JSON"
 
 rm -f "$GH_EDIT_ARGS_FILE"
 NOW_EPOCH_P5=$(date +%s)

--- a/.agents/scripts/tests/test-maintenance-repo-selection.sh
+++ b/.agents/scripts/tests/test-maintenance-repo-selection.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/aidevops-maintenance-selection.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+export HOME="${TEST_ROOT}/home"
+CONFIG_DIR="${HOME}/.config/aidevops"
+DEPLOYED_SCRIPTS_DIR="${HOME}/.aidevops/agents/scripts"
+mkdir -p "$CONFIG_DIR" "$DEPLOYED_SCRIPTS_DIR"
+cp "$REPO_ROOT/.agents/scripts/readme-badges-helper.sh" \
+	"${DEPLOYED_SCRIPTS_DIR}/readme-badges-helper.sh"
+chmod +x "${DEPLOYED_SCRIPTS_DIR}/readme-badges-helper.sh"
+
+legacy_path="${TEST_ROOT}/legacy"
+maintained_path="${TEST_ROOT}/maintained"
+dormant_path="${TEST_ROOT}/dormant"
+local_path="${TEST_ROOT}/local"
+contributed_path="${TEST_ROOT}/contributed"
+contributor_path="${TEST_ROOT}/contributor"
+mkdir -p "$legacy_path" "$maintained_path" "$dormant_path" "$local_path" "$contributed_path" "$contributor_path"
+jq -n \
+	--arg legacy "$legacy_path" \
+	--arg maintained "$maintained_path" \
+	--arg dormant "$dormant_path" \
+	--arg local_path "$local_path" \
+	--arg contributed "$contributed_path" \
+	--arg contributor "$contributor_path" '{initialized_repos: [
+		{slug: "owner/legacy", path: $legacy, pulse: true},
+		{slug: "owner/maintained", path: $maintained, pulse: true, maintenance: true},
+		{slug: "owner/dormant", path: $dormant, pulse: true, maintenance: false},
+		{slug: "owner/local", path: $local_path, pulse: true, maintenance: false, local_only: true},
+		{slug: "marcusquinn/contributed", path: $contributed, pulse: true, maintenance: false, contributed: true},
+		{slug: "marcusquinn/contributor", path: $contributor, pulse: true, maintenance: false, role: "contributor"}
+	]}' >"${CONFIG_DIR}/repos.json"
+
+check_all=$(bash "$REPO_ROOT/.agents/scripts/check-workflows-helper.sh" \
+	--json --workflow issue-sync 2>/dev/null || true)
+[[ "$(printf '%s\n' "$check_all" | jq -s 'length')" == "2" ]]
+[[ "$(printf '%s\n' "$check_all" | jq -s 'any(.[]; .slug == "owner/dormant")')" == "false" ]]
+
+check_explicit=$(bash "$REPO_ROOT/.agents/scripts/check-workflows-helper.sh" \
+	--json --repo owner/dormant --workflow issue-sync 2>/dev/null || true)
+[[ "$(printf '%s\n' "$check_explicit" | jq -r '.slug')" == "owner/dormant" ]]
+
+check_local=$(bash "$REPO_ROOT/.agents/scripts/check-workflows-helper.sh" \
+	--json --repo owner/local --workflow issue-sync 2>/dev/null || true)
+[[ "$(printf '%s\n' "$check_local" | jq -r '.classification')" == "LOCAL-ONLY" ]]
+
+badges_all=$(bash "$REPO_ROOT/.agents/scripts/badges-check-helper.sh" --json 2>/dev/null || true)
+[[ "$(printf '%s\n' "$badges_all" | jq -s 'length')" == "2" ]]
+[[ "$(printf '%s\n' "$badges_all" | jq -s 'any(.[]; .slug == "owner/dormant")')" == "false" ]]
+
+badges_explicit=$(bash "$REPO_ROOT/.agents/scripts/badges-check-helper.sh" \
+	--json --repo owner/dormant 2>/dev/null || true)
+[[ "$(printf '%s\n' "$badges_explicit" | jq -r '.slug')" == "owner/dormant" ]]
+
+badges_contributed=$(bash "$REPO_ROOT/.agents/scripts/badges-check-helper.sh" \
+	--json --repo marcusquinn/contributed 2>/dev/null || true)
+[[ "$(printf '%s\n' "$badges_contributed" | jq -r '.classification')" == "EXTERNAL" ]]
+
+badges_contributor=$(bash "$REPO_ROOT/.agents/scripts/badges-check-helper.sh" \
+	--json --repo marcusquinn/contributor 2>/dev/null || true)
+[[ "$(printf '%s\n' "$badges_contributor" | jq -r '.classification')" == "EXTERNAL" ]]
+
+python3 - "$REPO_ROOT" "${CONFIG_DIR}/repos.json" <<'PYEOF'
+import importlib.util
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+repos_json = pathlib.Path(sys.argv[2])
+module_path = root / ".agents" / "scripts" / "pulse-check-queue-scan.py"
+spec = importlib.util.spec_from_file_location("pulse_check_queue_scan", module_path)
+if spec is None or spec.loader is None:
+    raise SystemExit("FAIL: could not load Pulse queue scanner")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+repos, error = module._load_repos(repos_json)
+assert error == "", error
+assert [repo["slug"] for repo in repos] == ["owner/legacy", "owner/maintained"]
+PYEOF
+
+# The batched owner prefetch must use the same maintenance boundary.
+export SCRIPT_DIR="$REPO_ROOT/.agents/scripts"
+# shellcheck source=../pulse-batch-prefetch-helper.sh
+source "$REPO_ROOT/.agents/scripts/pulse-batch-prefetch-helper.sh" help >/dev/null
+owner_group=$(_group_repos_by_owner "${CONFIG_DIR}/repos.json")
+[[ "$owner_group" == "owner|owner/legacy,owner/maintained" ]]
+
+printf 'PASS recurring repo selectors skip dormant entries and explicit checks retain access\n'

--- a/.agents/scripts/tests/test-maintenance-selector-contract.sh
+++ b/.agents/scripts/tests/test-maintenance-selector-contract.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+
+python3 - "$REPO_ROOT" <<'PYEOF'
+import pathlib
+import re
+import sys
+
+root = pathlib.Path(sys.argv[1])
+
+required_functions = {
+    ".agents/custom/scripts/r-stub-title-scan.sh": ["_get_pulse_repos"],
+    ".agents/scripts/cloudron-package-monitor-helper.sh": ["_cloudron_monitor_run"],
+    ".agents/scripts/dashboard-freshness-check.sh": ["_repo_slugs_for_dashboard_scan"],
+    ".agents/scripts/dependabot-alert-monitor.sh": ["_dam_list_repos"],
+    ".agents/scripts/gh-failure-miner-helper.sh": ["load_pulse_repo_allowlist"],
+    ".agents/scripts/inbox-digest-routine.sh": ["main"],
+    ".agents/scripts/mission-dashboard-helper.sh": ["_status_print_blockers"],
+    ".agents/scripts/orchestration-efficiency-collector.sh": ["collect_audit_trails"],
+    ".agents/scripts/peer-productivity-monitor.sh": ["_list_pulse_repos"],
+    ".agents/scripts/pr-salvage-helper.sh": ["scan_all_repos"],
+    ".agents/scripts/foss-contribution-helper.sh": ["_get_foss_repos"],
+    ".agents/scripts/pulse-ancillary-dispatch.sh": [
+        "dispatch_foss_workers",
+        "dispatch_routine_comment_responses",
+    ],
+    ".agents/scripts/pulse-batch-prefetch-helper.sh": ["_group_repos_by_owner"],
+    ".agents/scripts/pulse-capacity-alloc.sh": [
+        "_count_dispatchable_product_repos",
+        "_count_priority_repos",
+        "_scan_pr_salvage",
+    ],
+    ".agents/scripts/pulse-capacity.sh": [
+        "count_queued_without_worker",
+        "count_runnable_candidates",
+    ],
+    ".agents/scripts/pulse-canonical-maintenance.sh": ["_canonical_fast_forward"],
+    ".agents/scripts/pulse-dep-graph.sh": ["build_dependency_graph_cache"],
+    ".agents/scripts/pulse-dispatch-engine.sh": [
+        "_should_run_llm_supervisor",
+        "build_ranked_dispatch_candidates_json",
+    ],
+    ".agents/scripts/pulse-fix-the-fixer-detector.sh": ["cmd_run"],
+    ".agents/scripts/pulse-issue-reconcile-normalize.sh": ["_normalize_label_invariants"],
+    ".agents/scripts/pulse-issue-reconcile-parent.sh": ["reconcile_completed_parent_tasks"],
+    ".agents/scripts/pulse-issue-reconcile.sh": [
+        "_normalize_reassign_self",
+        "reconcile_issues_single_pass",
+        "reconcile_labelless_aidevops_issues",
+    ],
+    ".agents/scripts/pulse-merge-pass.sh": ["merge_ready_prs_all_repos"],
+    ".agents/scripts/pulse-nmr-approval.sh": ["auto_approve_maintainer_issues"],
+    ".agents/scripts/pulse-prefetch.sh": ["prefetch_state"],
+    ".agents/scripts/pulse-prefetch-workers.sh": ["prefetch_foss_scan"],
+    ".agents/scripts/pulse-queue-governor.sh": ["_fetch_queue_metrics"],
+    ".agents/scripts/pulse-repo-tier.sh": ["cmd_classify"],
+    ".agents/scripts/pulse-routines.sh": ["evaluate_routines"],
+    ".agents/scripts/pulse-session-helper.sh": ["get_pulse_repo_count"],
+    ".agents/scripts/pulse-simplification-scan.sh": ["_pulse_enabled_repo_slugs"],
+    ".agents/scripts/pulse-triage-evaluation.sh": [
+        "_reevaluate_consolidation_labels",
+        "_reevaluate_simplification_labels",
+    ],
+    ".agents/scripts/pulse-wrapper-cycle-gates.sh": ["_pulse_scope_repos_for_available_work_gate"],
+    ".agents/scripts/pulse-wrapper-cycle.sh": [
+        "_pulse_reconcile_stale_blocked_if_due",
+        "sync_todo_refs_all_repos",
+    ],
+    ".agents/scripts/session-miner-pulse.sh": ["file_contributor_insights"],
+    ".agents/scripts/setup/modules/migrations.sh": ["backfill_issue_relationships"],
+    ".agents/scripts/stats-health-dashboard-data.sh": [
+        "_compute_worker_success_rates",
+        "_refresh_person_stats_cache",
+    ],
+    ".agents/scripts/stats-health-dashboard.sh": ["update_health_issues"],
+    ".agents/scripts/stats-quality-sweep.sh": ["run_daily_quality_sweep"],
+    ".agents/scripts/repo-aidevops-health-helper.sh": ["_check_version_bumps"],
+}
+
+
+def function_body(path: pathlib.Path, name: str) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start_pattern = re.compile(rf"^{re.escape(name)}\(\) \{{$")
+    for index, line in enumerate(lines):
+        if not start_pattern.match(line):
+            continue
+        for end in range(index + 1, len(lines)):
+            if lines[end] == "}":
+                return "\n".join(lines[index : end + 1])
+        raise AssertionError(f"{path}: unterminated function {name}")
+    raise AssertionError(f"{path}: function {name} not found")
+
+
+errors = []
+for relative_path, function_names in required_functions.items():
+    path = root / relative_path
+    for function_name in function_names:
+        try:
+            body = function_body(path, function_name)
+        except AssertionError as exc:
+            errors.append(str(exc))
+            continue
+        if ".maintenance != false" not in body:
+            errors.append(
+                f"{relative_path}:{function_name} lacks the recurring maintenance predicate"
+            )
+
+remote_recurring_functions = {
+    ".agents/scripts/foss-contribution-helper.sh": ["_get_foss_repos"],
+    ".agents/scripts/pulse-ancillary-dispatch.sh": ["dispatch_foss_workers"],
+    ".agents/scripts/pulse-prefetch-workers.sh": ["prefetch_foss_scan"],
+}
+for relative_path, function_names in remote_recurring_functions.items():
+    path = root / relative_path
+    for function_name in function_names:
+        body = function_body(path, function_name)
+        if "(.local_only // false) == false" not in body:
+            errors.append(
+                f"{relative_path}:{function_name} lacks the local-only exclusion"
+            )
+
+safety_functions = {
+    ".agents/scripts/aidevops-update-check.sh": ["_detect_stuck_index_conflict"],
+    ".agents/scripts/contribution-watch-helper.sh": [
+        "_get_managed_repo_slugs",
+        "cmd_seed",
+    ],
+    ".agents/scripts/contributor-insight-helper.sh": ["_load_private_slugs"],
+    ".agents/scripts/interactive-session-helper-scan.sh": [
+        "_isc_scan_closed_pr_orphans",
+        "_isc_scan_stampless_phase",
+    ],
+    ".agents/scripts/pulse-canonical-maintenance.sh": ["_stale_worktree_sweep"],
+    ".agents/scripts/pulse-cleanup.sh": [
+        "_cleanup_merged_prs_for_all_repos",
+        "cleanup_stalled_workers",
+        "cleanup_stashes",
+        "cleanup_worktrees",
+    ],
+    ".agents/scripts/pulse-dirty-pr-sweep.sh": ["dirty_pr_sweep_all_repos"],
+    ".agents/scripts/pulse-issue-reconcile.sh": [
+        "_normalize_unassign_stampless_interactive"
+    ],
+    ".agents/scripts/pulse-issue-reconcile-stale.sh": ["_normalize_unassign_stale"],
+    ".agents/scripts/repo-aidevops-health-helper.sh": [
+        "_check_missing_folders",
+        "_check_no_init_repos",
+    ],
+    ".agents/scripts/shared-dispatch-label-cleanup.sh": [
+        "_dispatch_label_sweep_repos"
+    ],
+}
+for relative_path, function_names in safety_functions.items():
+    path = root / relative_path
+    for function_name in function_names:
+        try:
+            body = function_body(path, function_name)
+        except AssertionError as exc:
+            errors.append(str(exc))
+            continue
+        if ".maintenance" in body or ".pulse" in body:
+            errors.append(
+                f"{relative_path}:{function_name} safety scope must ignore maintenance and Pulse state"
+            )
+
+guarded_safety_writes = {
+    ".agents/scripts/pulse-issue-reconcile.sh": [
+        "_normalize_unassign_stampless_interactive"
+    ],
+    ".agents/scripts/pulse-issue-reconcile-stale.sh": ["_normalize_unassign_stale"],
+    ".agents/scripts/pulse-triage-dispatch.sh": [
+        "_backfill_stale_consolidation_labels"
+    ],
+    ".agents/scripts/shared-dispatch-label-cleanup.sh": [
+        "sweep_closed_auto_dispatch_issues"
+    ],
+}
+for relative_path, function_names in guarded_safety_writes.items():
+    path = root / relative_path
+    for function_name in function_names:
+        body = function_body(path, function_name)
+        if "repo_allows_pulse_write_actions" not in body:
+            errors.append(
+                f"{relative_path}:{function_name} lacks contributor/write-authority guard"
+            )
+
+close_source = (root / ".agents/scripts/pulse-issue-reconcile-close.sh").read_text(
+    encoding="utf-8"
+)
+if "_pir_close_slug_filter='.initialized_repos[] | select(.maintenance != false" not in close_source:
+    errors.append("pulse-issue-reconcile-close.sh shared selector lacks maintenance predicate")
+
+triage_body = function_body(
+    root / ".agents/scripts/pulse-triage-dispatch.sh",
+    "_backfill_stale_consolidation_labels",
+)
+if "if .maintenance == false then false else true end" not in triage_body:
+    errors.append("triage consolidation scan does not expose effective maintenance state")
+if "(.pulse // false)" not in triage_body:
+    errors.append("triage consolidation scan does not expose Pulse state")
+if '[[ "$maintenance_flag" == "false" || "$pulse_flag" != "true" ]] && continue' not in triage_body:
+    errors.append("triage consolidation scan does not gate dispatch work for dormant repos")
+
+hygiene_body = function_body(
+    root / ".agents/scripts/pulse-prefetch-secondary.sh", "prefetch_hygiene"
+)
+if ".maintenance" in hygiene_body or ".pulse" in hygiene_body:
+    errors.append("safety hygiene prefetch must ignore maintenance and Pulse state")
+
+if errors:
+    raise SystemExit("FAIL\n- " + "\n- ".join(errors))
+
+print("PASS recurring selectors enforce maintenance while safety hygiene retains visibility")
+PYEOF

--- a/.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh
@@ -55,6 +55,13 @@ write_repos_json() {
         "labels_filter": ["help wanted", "needs, triage", "bug"],
         "disclosure": false
       }
+    },
+    {
+      "slug": "owner/local-project",
+      "path": "~/Git/local-project",
+      "maintenance": true,
+      "local_only": true,
+      "foss": true
     }
   ]
 }
@@ -262,4 +269,5 @@ printf 'PASS: FOSS recent local runtime failures are backed off\n'
 printf 'PASS: FOSS duplicate session keys are deduplicated per cycle\n'
 printf 'PASS: FOSS dispatch falls back across configured labels\n'
 printf 'PASS: FOSS repo paths expand leading tilde before worker launch\n'
+printf 'PASS: FOSS dispatch excludes local-only repositories\n'
 exit 0

--- a/.agents/scripts/tests/test-repo-maintenance-state.sh
+++ b/.agents/scripts/tests/test-repo-maintenance-state.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/aidevops-repo-maintenance.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+export HOME="${TEST_ROOT}/home"
+INSTALL_DIR="$REPO_ROOT"
+AGENTS_DIR="$REPO_ROOT/.agents"
+CONFIG_DIR="${HOME}/.config/aidevops"
+REPOS_FILE="${CONFIG_DIR}/repos.json"
+export INSTALL_DIR AGENTS_DIR CONFIG_DIR REPOS_FILE
+
+mkdir -p "$CONFIG_DIR" "${TEST_ROOT}/repo-a" "${TEST_ROOT}/repo-b"
+repo_a="$(cd "${TEST_ROOT}/repo-a" && pwd -P)"
+repo_b="$(cd "${TEST_ROOT}/repo-b" && pwd -P)"
+jq -n --arg repo_a "$repo_a" --arg repo_b "$repo_b" '{
+  initialized_repos: [
+    {slug: "owner/repo-a", path: $repo_a, pulse: true, marker: "preserve"},
+    {slug: "owner/repo-b", path: $repo_b, pulse: true}
+  ],
+  git_parent_dirs: []
+}' >"$REPOS_FILE"
+
+print_error() {
+	return 0
+}
+
+# shellcheck source=../aidevops-cli/aidevops-repos-lib.sh
+source "$REPO_ROOT/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh"
+
+initial_state=$(get_repo_maintenance_state "owner/repo-b")
+[[ "$initial_state" == $'true\ttrue\towner/repo-b\t'"$repo_b" ]]
+
+set_repo_maintenance "owner/repo-a" false
+[[ "$(jq -r '.initialized_repos[0].maintenance' "$REPOS_FILE")" == "false" ]]
+[[ "$(jq -r '.initialized_repos[0].pulse' "$REPOS_FILE")" == "false" ]]
+[[ "$(jq -r '.initialized_repos[0].marker' "$REPOS_FILE")" == "preserve" ]]
+paused_state=$(get_repo_maintenance_state "owner/repo-a")
+[[ "$paused_state" == $'false\tfalse\towner/repo-a\t'"$repo_a" ]]
+
+# Safety cleanup must still enumerate a repo after the public pause operation
+# sets both maintenance:false and pulse:false.
+REPOS_JSON="$REPOS_FILE"
+export REPOS_JSON
+# shellcheck source=../shared-dispatch-label-cleanup.sh
+source "$REPO_ROOT/.agents/scripts/shared-dispatch-label-cleanup.sh"
+safety_slugs=$(_dispatch_label_sweep_repos "$REPOS_FILE")
+[[ $'\n'"$safety_slugs"$'\n' == *$'\nowner/repo-a\n'* ]]
+
+set_repo_maintenance "$repo_a" true
+[[ "$(jq -r '.initialized_repos[0].maintenance' "$REPOS_FILE")" == "true" ]]
+[[ "$(jq -r '.initialized_repos[0].pulse' "$REPOS_FILE")" == "false" ]]
+
+cli_output=$(bash "$REPO_ROOT/aidevops.sh" repos maintenance off owner/repo-a)
+[[ "$cli_output" == *"Maintenance paused for owner/repo-a"* ]]
+list_output=$(bash "$REPO_ROOT/aidevops.sh" repos list)
+[[ "$list_output" == *"Automation: dormant (Pulse: off)"* ]]
+cli_output=$(bash "$REPO_ROOT/aidevops.sh" repos maintenance on owner/repo-a)
+[[ "$cli_output" == *"Maintenance enabled for owner/repo-a (Pulse remains false)"* ]]
+list_output=$(bash "$REPO_ROOT/aidevops.sh" repos list)
+[[ "$list_output" == *"Automation: maintained (Pulse: false)"* ]]
+
+before=$(shasum -a 256 "$REPOS_FILE" | cut -d' ' -f1)
+if set_repo_maintenance "owner/missing" false; then
+	printf 'FAIL unknown repository was accepted\n' >&2
+	exit 1
+fi
+after=$(shasum -a 256 "$REPOS_FILE" | cut -d' ' -f1)
+[[ "$before" == "$after" ]]
+
+if set_repo_maintenance "owner/repo-a" invalid; then
+	printf 'FAIL invalid maintenance state was accepted\n' >&2
+	exit 1
+fi
+if compgen -G "${REPOS_FILE}.tmp.*" >/dev/null; then
+	printf 'FAIL temporary repos.json files were not cleaned up\n' >&2
+	exit 1
+fi
+
+printf 'PASS repository maintenance state uses atomic replacement, remains backward compatible, and preserves safety scope\n'

--- a/.agents/scripts/tests/test-repo-role-guard.sh
+++ b/.agents/scripts/tests/test-repo-role-guard.sh
@@ -52,6 +52,11 @@ cat >"$TEST_REPOS_JSON" <<'JSON'
       "role": "contributor"
     },
     {
+      "slug": "bob/write-capable-contributor",
+      "pulse": true,
+      "role": "contributor"
+    },
+    {
       "slug": "alice/auto-detect-repo",
       "pulse": true
     },
@@ -92,7 +97,7 @@ _CACHED_GH_USER="alice"
 _gh_current_user_allows_repo_write() {
 	local repo_slug="$1"
 	case "$repo_slug" in
-	alice/owned-repo | alice/auto-detect-repo | alice/unknown-repo)
+	alice/owned-repo | alice/auto-detect-repo | alice/unknown-repo | bob/write-capable-contributor)
 		return 0
 		;;
 	*)
@@ -157,8 +162,16 @@ else
 fi
 assert_eq "write actions blocked without repo write permission" "no" "$write_allowed"
 
+# Test 9b: Explicit contributor role remains blocked even with live write permission.
+if repo_allows_pulse_write_actions "bob/write-capable-contributor"; then
+	write_allowed="yes"
+else
+	write_allowed="no"
+fi
+assert_eq "write actions blocked for explicit contributor role" "no" "$write_allowed"
+
 # Test 10: Deterministic merge pass uses the write-action role guard.
-if grep -q "repo_allows_pulse_write_actions \"\$repo_slug\"" "${PARENT_DIR}/pulse-merge-process.sh"; then
+if grep -q "repo_allows_pulse_write_actions \"\$repo_slug\"" "${PARENT_DIR}/pulse-merge-pass.sh"; then
 	guard_present="yes"
 else
 	guard_present="no"
@@ -182,8 +195,8 @@ fi
 assert_eq "dirty PR sweep loads repo-role guard for standalone execution" "yes" "$guard_present"
 
 # Test 13: Write sweeps fail closed when the guard helper is unavailable.
-if grep -q '! declare -F repo_allows_pulse_write_actions' "${PARENT_DIR}/pulse-merge-process.sh" \
-	&& grep -q "|| ! repo_allows_pulse_write_actions \"\$repo_slug\"" "${PARENT_DIR}/pulse-merge-process.sh" \
+if grep -q '! declare -F repo_allows_pulse_write_actions' "${PARENT_DIR}/pulse-merge-pass.sh" \
+	&& grep -q "|| ! repo_allows_pulse_write_actions \"\$repo_slug\"" "${PARENT_DIR}/pulse-merge-pass.sh" \
 	&& grep -q '! declare -F repo_allows_pulse_write_actions' "${PARENT_DIR}/pulse-dirty-pr-sweep.sh" \
 	&& grep -q "|| ! repo_allows_pulse_write_actions \"\$repo_slug\"" "${PARENT_DIR}/pulse-dirty-pr-sweep.sh"; then
 	guard_present="yes"

--- a/.agents/scripts/tests/test-reusable-workflow-permission-contracts.sh
+++ b/.agents/scripts/tests/test-reusable-workflow-permission-contracts.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Verify every canonical reusable-workflow caller grants its exact permission union.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+
+python3 - "$REPO_ROOT" <<'PYEOF'
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+import tempfile
+
+try:
+    import yaml
+except ImportError as exc:
+    raise SystemExit("FAIL: PyYAML is required for workflow permission contract tests") from exc
+
+
+ROOT = pathlib.Path(sys.argv[1])
+CALLER_DIR = ROOT / ".agents" / "templates" / "workflows"
+REUSABLE_DIR = ROOT / ".github" / "workflows"
+REMOTE_USES_PATTERN = re.compile(
+    r"^marcusquinn/aidevops/\.github/workflows/([^/@]+\.ya?ml)@"
+)
+LOCAL_USES_PATTERN = re.compile(r"^\./\.github/workflows/([^/]+\.ya?ml)$")
+LEVELS = {"none": 0, "read": 1, "write": 2}
+
+
+def load_mapping(path: pathlib.Path) -> dict:
+    with path.open(encoding="utf-8") as handle:
+        value = yaml.safe_load(handle)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: workflow root must be a mapping")
+    return value
+
+
+def explicit_permissions(value: object, context: str) -> dict[str, str]:
+    if value is None:
+        raise ValueError(f"{context}: permissions must be an explicit mapping")
+    if not isinstance(value, dict):
+        raise ValueError(f"{context}: permissions must be an explicit mapping")
+    normalized: dict[str, str] = {}
+    for permission, level in value.items():
+        if not isinstance(permission, str) or level not in LEVELS:
+            raise ValueError(f"{context}: unsupported permission {permission}={level}")
+        if level != "none":
+            normalized[permission] = level
+    return normalized
+
+
+def reusable_path_for_uses(
+    uses: str, reusable_dir: pathlib.Path = REUSABLE_DIR
+) -> pathlib.Path | None:
+    local_match = LOCAL_USES_PATTERN.match(uses)
+    if local_match:
+        return reusable_dir / local_match.group(1)
+    remote_match = REMOTE_USES_PATTERN.match(uses)
+    if remote_match:
+        return reusable_dir / remote_match.group(1)
+    return None
+
+
+def merge_permission_union(
+    target: dict[str, str], additions: dict[str, str]
+) -> None:
+    for permission, level in additions.items():
+        if LEVELS[level] > LEVELS.get(target.get(permission, "none"), 0):
+            target[permission] = level
+
+
+def reusable_permission_union(
+    workflow_path: pathlib.Path,
+    reusable_dir: pathlib.Path = REUSABLE_DIR,
+    active: set[pathlib.Path] | None = None,
+) -> dict[str, str]:
+    resolved_path = workflow_path.resolve()
+    active = set() if active is None else active
+    if resolved_path in active:
+        raise ValueError(f"{workflow_path}: recursive reusable-workflow cycle")
+    active.add(resolved_path)
+    workflow = load_mapping(workflow_path)
+    context = str(workflow_path)
+    top = (
+        explicit_permissions(workflow["permissions"], f"{context}: top level")
+        if "permissions" in workflow
+        else None
+    )
+    required: dict[str, str] = {}
+    jobs = workflow.get("jobs", {}) or {}
+    if not isinstance(jobs, dict) or not jobs:
+        raise ValueError(f"{context}: jobs must be a non-empty mapping")
+    try:
+        for job_name, job in jobs.items():
+            if not isinstance(job, dict):
+                raise ValueError(f"{context}: job {job_name} must be a mapping")
+            permissions = explicit_permissions(
+                job.get("permissions") if "permissions" in job else top,
+                f"{context}: job {job_name}",
+            )
+            merge_permission_union(required, permissions)
+            uses = job.get("uses")
+            if isinstance(uses, str):
+                nested_path = reusable_path_for_uses(uses, reusable_dir)
+                if nested_path is not None:
+                    nested_required = reusable_permission_union(
+                        nested_path, reusable_dir, active
+                    )
+                    if permissions != nested_required:
+                        raise ValueError(
+                            f"{context}: job {job_name} permissions={permissions}; "
+                            f"nested_union={nested_required} from {nested_path.name}"
+                        )
+                    merge_permission_union(required, nested_required)
+        return required
+    finally:
+        active.remove(resolved_path)
+
+
+def discover_caller_paths(
+    caller_dir: pathlib.Path, workflow_dir: pathlib.Path
+) -> list[pathlib.Path]:
+    return sorted(
+        set(caller_dir.glob("*-caller.yml"))
+        | set(caller_dir.glob("*-caller.yaml"))
+        | set(workflow_dir.glob("*.yml"))
+        | set(workflow_dir.glob("*.yaml"))
+    )
+
+
+def assert_discovery_contract() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = pathlib.Path(temp_dir)
+        caller_dir = root / "callers"
+        workflow_dir = root / "workflows"
+        caller_dir.mkdir()
+        workflow_dir.mkdir()
+        yaml_caller = caller_dir / "fixture-caller.yaml"
+        nested_reusable = workflow_dir / "outer-reusable.yaml"
+        inner_reusable = workflow_dir / "inner-reusable.yaml"
+        yaml_caller.write_text("jobs: {}\n", encoding="utf-8")
+        nested_reusable.write_text(
+            "jobs:\n  nested:\n    permissions:\n      issues: read\n"
+            "    uses: ./.github/workflows/inner-reusable.yaml\n",
+            encoding="utf-8",
+        )
+        inner_reusable.write_text(
+            "jobs:\n  leaf:\n    permissions:\n      issues: read\n    runs-on: ubuntu-latest\n    steps: []\n",
+            encoding="utf-8",
+        )
+        discovered = set(discover_caller_paths(caller_dir, workflow_dir))
+        if yaml_caller not in discovered or nested_reusable not in discovered:
+            raise AssertionError(
+                "caller discovery must include .yaml and reusable-to-reusable workflows"
+            )
+        nested_union = reusable_permission_union(nested_reusable, workflow_dir)
+        if nested_union != {"issues": "read"}:
+            raise AssertionError(
+                f"nested reusable permission union was not propagated: {nested_union}"
+            )
+        implicit_reusable = workflow_dir / "implicit-reusable.yml"
+        implicit_reusable.write_text(
+            "jobs:\n  leaf:\n    runs-on: ubuntu-latest\n    steps: []\n",
+            encoding="utf-8",
+        )
+        try:
+            reusable_permission_union(implicit_reusable, workflow_dir)
+        except ValueError as exc:
+            if "permissions must be an explicit mapping" not in str(exc):
+                raise
+        else:
+            raise AssertionError("implicit repository-default permissions were accepted")
+        nested_reusable.write_text(
+            "jobs:\n  nested:\n    permissions:\n      contents: read\n"
+            "    uses: ./.github/workflows/inner-reusable.yaml\n",
+            encoding="utf-8",
+        )
+        try:
+            reusable_permission_union(nested_reusable, workflow_dir)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("insufficient intermediate permissions were accepted")
+
+
+def main() -> int:
+    checked = 0
+    failures: list[str] = []
+    assert_discovery_contract()
+    caller_paths = discover_caller_paths(CALLER_DIR, REUSABLE_DIR)
+    for caller_path in caller_paths:
+        try:
+            caller = load_mapping(caller_path)
+            caller_top = (
+                explicit_permissions(
+                    caller["permissions"], f"{caller_path}: top level"
+                )
+                if "permissions" in caller
+                else None
+            )
+            jobs = caller.get("jobs", {}) or {}
+            if not isinstance(jobs, dict):
+                raise ValueError(f"{caller_path}: jobs must be a mapping")
+            for job_name, job in jobs.items():
+                if not isinstance(job, dict):
+                    continue
+                uses = job.get("uses")
+                if not isinstance(uses, str):
+                    continue
+                reusable_path = reusable_path_for_uses(uses)
+                if reusable_path is None:
+                    continue
+                required = reusable_permission_union(reusable_path)
+                granted = explicit_permissions(
+                    job.get("permissions") if "permissions" in job else caller_top,
+                    f"{caller_path}: calling job {job_name}",
+                )
+                checked += 1
+                if granted != required:
+                    failures.append(
+                        f"{caller_path.name}:{job_name}: caller={granted}; "
+                        f"required_union={required} from {reusable_path.name}"
+                    )
+                else:
+                    print(f"PASS {caller_path.name} -> {reusable_path.name}")
+        except (OSError, ValueError, yaml.YAMLError) as exc:
+            failures.append(str(exc))
+
+    if checked == 0:
+        failures.append("no canonical reusable-workflow caller pairs were found")
+    if failures:
+        for failure in failures:
+            print(f"FAIL {failure}", file=sys.stderr)
+        return 1
+    print(f"PASS all {checked} reusable-workflow permission contract(s)")
+    return 0
+
+
+raise SystemExit(main())
+PYEOF

--- a/.agents/scripts/tests/test-stampless-non-task-filter.sh
+++ b/.agents/scripts/tests/test-stampless-non-task-filter.sh
@@ -278,6 +278,11 @@ chmod +x "${STUB_BIN}/gh"
 
 # Set required globals for _normalize_unassign_stampless_interactive
 export PULSE_QUEUED_SCAN_LIMIT=200
+repo_allows_pulse_write_actions() {
+	local repo_slug="$1"
+	[[ "$repo_slug" == "owner/repo" ]]
+	return $?
+}
 
 # Source pulse-issue-reconcile.sh (sub-library of pulse-wrapper.sh)
 # shellcheck source=/dev/null

--- a/.agents/templates/workflows/linked-issue-check-caller.yml
+++ b/.agents/templates/workflows/linked-issue-check-caller.yml
@@ -13,6 +13,7 @@ name: Linked Issue Check
 # a repository ruleset.
 
 permissions:
+  issues: read
   pull-requests: read
   statuses: write
 

--- a/.agents/templates/workflows/loc-badge-caller.yml
+++ b/.agents/templates/workflows/loc-badge-caller.yml
@@ -14,6 +14,11 @@ name: Repository Metrics — generate local README data and badges
 # It runs weekly and after default-branch pushes, but skips if metrics are
 # already fresh (24h by default). It does not run on pull_request events.
 
+# Permissions ceiling for downstream repos with default_workflow_permissions: read.
+# Reusable workflow job-level permissions cannot exceed the caller's ceiling.
+permissions:
+  contents: write
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -342,6 +342,16 @@ jobs:
         echo ""
         echo "All shell scripts passed ShellCheck"
 
+    - name: Reusable Workflow and Maintenance Scope Contracts (GH#28862)
+      run: |
+        python3 -m pip install --disable-pip-version-check --no-input PyYAML==6.0.3
+        bash .agents/scripts/tests/test-loc-badge-reusable-install.sh
+        bash .agents/scripts/tests/test-reusable-workflow-caller.sh
+        bash .agents/scripts/tests/test-reusable-workflow-permission-contracts.sh
+        bash .agents/scripts/tests/test-repo-maintenance-state.sh
+        bash .agents/scripts/tests/test-maintenance-repo-selection.sh
+        bash .agents/scripts/tests/test-maintenance-selector-contract.sh
+
     - name: MCP Inspector Health Identity Regression (GH#27967)
       run: |
         echo "Running MCP inspector health identity regression test..."

--- a/.github/workflows/linked-issue-check.yml
+++ b/.github/workflows/linked-issue-check.yml
@@ -11,6 +11,7 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
+  issues: read
   pull-requests: read
   statuses: write
 

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -690,7 +690,7 @@ _repos_list() {
 	fi
 	local current_ver
 	current_ver=$(get_version)
-	jq -r '.initialized_repos[] | "\(.path)|\(.version)|\(.features | join(","))"' "$REPOS_FILE" 2>/dev/null | while IFS='|' read -r path version features; do
+	jq -r '.initialized_repos[] | "\(.path)|\(.version)|\((.features // []) | join(","))|\(if .maintenance == false then false else true end)|\(.pulse // false)"' "$REPOS_FILE" 2>/dev/null | while IFS='|' read -r path version features maintenance pulse; do
 		local name
 		name=$(basename "$path")
 		local status="✓" status_color="$GREEN"
@@ -706,6 +706,11 @@ _repos_list() {
 		echo "    Path: $path"
 		echo "    Version: $version"
 		echo "    Features: $features"
+		if [[ "$maintenance" == "true" ]]; then
+			echo "    Automation: maintained (Pulse: $pulse)"
+		else
+			echo "    Automation: dormant (Pulse: off)"
+		fi
 		echo ""
 	done
 	echo "Legend: ✓ up-to-date  ↑ update available  ✗ not found"
@@ -775,6 +780,40 @@ _repos_clean() {
 	return 0
 }
 
+_repos_maintenance() {
+	local state="${1:-}"
+	local selector="${2:-}"
+	case "$state" in
+	on | true | maintained) state="true" ;;
+	off | false | dormant | paused) state="false" ;;
+	*)
+		print_error "Usage: aidevops repos maintenance <on|off> [slug-or-path]"
+		return 2
+		;;
+	esac
+
+	if [[ -z "$selector" ]]; then
+		if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+			print_error "Specify a repo slug/path or run from within a registered repo"
+			return 1
+		fi
+		selector=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+	fi
+
+	set_repo_maintenance "$selector" "$state" || return $?
+	local result
+	result=$(get_repo_maintenance_state "$selector") || return 1
+	local maintenance pulse slug path
+	IFS=$'\t' read -r maintenance pulse slug path <<<"$result"
+	local label="${slug:-$path}"
+	if [[ "$maintenance" == "true" ]]; then
+		print_success "Maintenance enabled for $label (Pulse remains $pulse)"
+	else
+		print_success "Maintenance paused for $label (registration retained; Pulse disabled)"
+	fi
+	return 0
+}
+
 # Repos management command
 cmd_repos() {
 	local action="${1:-list}"
@@ -783,6 +822,10 @@ cmd_repos() {
 	add) _repos_add ;;
 	remove | rm) _repos_remove "${2:-}" ;;
 	clean) _repos_clean ;;
+	maintenance | maintain)
+		shift
+		_repos_maintenance "$@"
+		;;
 	*)
 		echo "Usage: aidevops repos <command>"
 		echo ""
@@ -791,6 +834,8 @@ cmd_repos() {
 		echo "  add      Register current project"
 		echo "  remove   Remove project from registry"
 		echo "  clean    Remove entries for non-existent projects"
+		echo "  maintenance <on|off> [repo]"
+		echo "           Include/exclude a registered repo from recurring automation"
 		;;
 	esac
 }


### PR DESCRIPTION
## Summary

Fix reusable-workflow token ceilings, add maintained/dormant repository state, exclude dormant and local-only repositories from recurring automation, and preserve guarded registration-scoped safety cleanup.

## Files Changed

.agents/custom/scripts/r-stub-title-scan.sh, .agents/reference/repos-json-fields.md, .agents/scripts/aidevops-cli/aidevops-repos-lib.sh, .agents/scripts/badges-check-helper.sh, .agents/scripts/badges-sync-helper.sh, .agents/scripts/check-workflows-helper.sh, .agents/scripts/cloudron-package-monitor-helper.sh, .agents/scripts/contribution-watch-helper.sh, .agents/scripts/dashboard-freshness-check.sh, .agents/scripts/dependabot-alert-monitor.sh, .agents/scripts/foss-contribution-helper.sh, .agents/scripts/gh-failure-miner-helper.sh, .agents/scripts/inbox-digest-routine.sh, .agents/scripts/interactive-session-helper-scan.sh, .agents/scripts/mission-dashboard-helper.sh, .agents/scripts/orchestration-efficiency-collector.sh, .agents/scripts/peer-productivity-monitor.sh, .agents/scripts/pr-salvage-helper.sh, .agents/scripts/pulse-ancillary-dispatch.sh, .agents/scripts/pulse-batch-prefetch-helper.sh, .agents/scripts/pulse-canonical-maintenance.sh, .agents/scripts/pulse-capacity-alloc.sh, .agents/scripts/pulse-capacity.sh, .agents/scripts/pulse-check-queue-scan.py, .agents/scripts/pulse-cleanup.sh, .agents/scripts/pulse-dep-graph.sh, .agents/scripts/pulse-dirty-pr-sweep.sh, .agents/scripts/pulse-dispatch-engine.sh, .agents/scripts/pulse-fix-the-fixer-detector.sh, .agents/scripts/pulse-issue-reconcile-close.sh, .agents/scripts/pulse-issue-reconcile-normalize.sh, .agents/scripts/pulse-issue-reconcile-parent.sh, .agents/scripts/pulse-issue-reconcile-stale.sh, .agents/scripts/pulse-issue-reconcile.sh, .agents/scripts/pulse-merge-pass.sh, .agents/scripts/pulse-nmr-approval.sh, .agents/scripts/pulse-prefetch-workers.sh, .agents/scripts/pulse-prefetch.sh, .agents/scripts/pulse-queue-governor.sh, .agents/scripts/pulse-repo-meta.sh, .agents/scripts/pulse-repo-tier.sh, .agents/scripts/pulse-routines.sh, .agents/scripts/pulse-session-helper.sh, .agents/scripts/pulse-simplification-scan.sh, .agents/scripts/pulse-triage-dispatch.sh, .agents/scripts/pulse-triage-evaluation.sh, .agents/scripts/pulse-wrapper-cycle-gates.sh, .agents/scripts/pulse-wrapper-cycle.sh, .agents/scripts/repo-aidevops-health-helper.sh, .agents/scripts/session-miner-pulse.sh, .agents/scripts/setup/modules/migrations.sh, .agents/scripts/shared-dispatch-label-cleanup.sh, .agents/scripts/stats-health-dashboard-data.sh, .agents/scripts/stats-health-dashboard.sh, .agents/scripts/stats-quality-sweep.sh, .agents/scripts/tests/test-consolidation-dispatch.sh, .agents/scripts/tests/test-dispatch-label-cleanup.sh, .agents/scripts/tests/test-issue-reconcile.sh, .agents/scripts/tests/test-maintenance-repo-selection.sh, .agents/scripts/tests/test-maintenance-selector-contract.sh, .agents/scripts/tests/test-pulse-ancillary-foss-dispatch.sh, .agents/scripts/tests/test-repo-maintenance-state.sh, .agents/scripts/tests/test-repo-role-guard.sh, .agents/scripts/tests/test-reusable-workflow-permission-contracts.sh, .agents/scripts/tests/test-stampless-non-task-filter.sh, .agents/templates/workflows/linked-issue-check-caller.yml, .agents/templates/workflows/loc-badge-caller.yml, .github/workflows/code-quality.yml, .github/workflows/linked-issue-check.yml, aidevops.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Changed-file lint, ShellCheck, Actionlint, permission-contract tests, maintenance selector/state tests, FOSS dispatch tests, cleanup/reconciliation tests, and independent closeout reviews passed.

Resolves #28862


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.195 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h 52m and 1,419,151 tokens on this with the user in an interactive session.