### PR TITLE
chore: re-aggregate authorized repository-maintenance release

### DIFF
--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -91,7 +91,7 @@ Aggregation PR #28875 reviews authorized PR #28871 at
 `4b1ef7ef1d0e5fdd27b4961b47e278063c47ae55` because deterministic task-state
 updates and PR #28870 advanced `main` before publication.
 
-A follow-up aggregation reviews authorized PR #28871 at
+Aggregation PR #28879 reviews authorized PR #28871 at
 `4b1ef7ef1d0e5fdd27b4961b47e278063c47ae55` and prior aggregation PR #28875 at
 `a039ed430bc97bd0327ddfc1d0d2a1b4f790277d` because PR #28876 advanced `main`
 before publication.

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -91,6 +91,11 @@ Aggregation PR #28875 reviews authorized PR #28871 at
 `4b1ef7ef1d0e5fdd27b4961b47e278063c47ae55` because deterministic task-state
 updates and PR #28870 advanced `main` before publication.
 
+A follow-up aggregation reviews authorized PR #28871 at
+`4b1ef7ef1d0e5fdd27b4961b47e278063c47ae55` and prior aggregation PR #28875 at
+`a039ed430bc97bd0327ddfc1d0d2a1b4f790277d` because PR #28876 advanced `main`
+before publication.
+
 Manual arbitrary-version package publication is intentionally unsupported. A
 recovery operation must use an existing tag that passes the same verifier.
 


### PR DESCRIPTION
## Summary

Create the reviewed exact-tip aggregation record required after PR #28876
advanced `main` beyond the first aggregation PR #28875.

## Release provenance

- Authorized source: PR #28871 at merge
  `4b1ef7ef1d0e5fdd27b4961b47e278063c47ae55`.
- Prior aggregation: PR #28875 at merge
  `a039ed430bc97bd0327ddfc1d0d2a1b4f790277d`.
- Exact branch base: `4ce6835eead411990acc13e77eebee31e8fb038b`.
- Sequence: this draft was created from the initial documentation commit;
  follow-up commit `b3ec969f5` binds PR #28879 and the immutable source manifest
  without rewriting published history.

## Verification

- Branch starts at the exact current `origin/main` tip.
- Changed-file lint and `git diff --check` passed.
- The initial branch commit has no recognized aggregation trailer; only the
  final commit carries one contiguous trailer block.

Ref #28871
Ref #28875

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.195 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol
