### PR TITLE
GH#28878: fix: preserve colon-qualified TODO labels

### DIFF
--- a/.agents/scripts/issue-sync-lib-parse.sh
+++ b/.agents/scripts/issue-sync-lib-parse.sh
@@ -278,7 +278,7 @@ parse_task_line() {
 
 	# Extract tags
 	local tags
-	tags=$(echo "$line" | grep -oE '#[a-z][a-z0-9-]*' | tr '\n' ',' | sed 's/,$//' || echo "")
+	tags=$(echo "$line" | grep -oE '#[a-z][a-z0-9-]*(:[a-z0-9][a-z0-9-]*)?' | tr '\n' ',' | sed 's/,$//' || echo "")
 
 	# Extract estimate (with optional breakdown)
 	local estimate

--- a/.agents/scripts/test-issue-sync-lib.sh
+++ b/.agents/scripts/test-issue-sync-lib.sh
@@ -434,6 +434,31 @@ else
 	pass "parse_task_line: multiple parent declarations fail closed"
 fi
 
+parsed_tags=$(parse_task_line '- [ ] t7 preserve labels #bug #release-blocker #priority:high tier:standard')
+if printf '%s\n' "$parsed_tags" | grep -qx 'tags=#bug,#release-blocker,#priority:high'; then
+	pass "parse_task_line: preserves simple, hyphenated, and colon-qualified tags"
+else
+	fail "parse_task_line: truncated a colon-qualified tag or changed existing tags"
+fi
+
+mapped_labels=$(map_tags_to_labels "$(printf '%s\n' "$parsed_tags" | sed -n 's/^tags=//p')")
+if [[ "$mapped_labels" == "bug,priority:high,release-blocker" ]] &&
+	! printf '%s\n' "$mapped_labels" | tr ',' '\n' | grep -qx 'priority'; then
+	pass "map_tags_to_labels: preserves priority:high without a bare priority label"
+else
+	fail "map_tags_to_labels: changed or truncated priority:high"
+fi
+
+for priority in critical high medium low; do
+	parsed_priority=$(parse_task_line "- [ ] t7 preserve priority #priority:${priority} tier:standard")
+	if printf '%s\n' "$parsed_priority" | grep -qx "tags=#priority:${priority}" &&
+		[[ "$(map_tags_to_labels "#priority:${priority}")" == "priority:${priority}" ]]; then
+		pass "priority tags: preserves priority:${priority} exactly"
+	else
+		fail "priority tags: changed or truncated priority:${priority}"
+	fi
+done
+
 # -----------------------------------------------------------------------------
 # extract_task_block behavior and large-file process regression (GH#28791)
 # -----------------------------------------------------------------------------

--- a/.agents/scripts/tests/test-issue-sync-tier-extraction.sh
+++ b/.agents/scripts/tests/test-issue-sync-tier-extraction.sh
@@ -66,8 +66,8 @@ fail() {
 	return 0
 }
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
-SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)" || exit 1
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)" || exit 1
 REPO_ROOT="$(cd "${SCRIPTS_DIR}/../.." && pwd)" || exit 1
 LIB="${SCRIPTS_DIR}/issue-sync-lib.sh"
 HELPER="${SCRIPTS_DIR}/issue-sync-helper.sh"


### PR DESCRIPTION
## Summary

Preserve one bounded colon-qualified segment in TODO tag parsing and cover exact priority label mapping.

## Files Changed

.agents/scripts/issue-sync-lib-parse.sh, .agents/scripts/test-issue-sync-lib.sh, .claude-plugin/marketplace.json, CHANGELOG.md, README.md, VERSION, aidevops.sh, package.json, setup.sh, sonar-project.properties

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/test-issue-sync-lib.sh; shellcheck .agents/scripts/issue-sync-lib-parse.sh .agents/scripts/test-issue-sync-lib.sh

Resolves #28878


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.195 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 2m and 49,501 tokens on this as a headless worker.