### PR TITLE
GH#28880: fix: dispatch before label maintenance

### DIFF
--- a/.agents/scripts/pulse-cache-prime.sh
+++ b/.agents/scripts/pulse-cache-prime.sh
@@ -4,14 +4,14 @@
 #
 # pulse-cache-prime.sh (t2992) — pre-warm pulse caches before restart.
 #
-# When `aidevops update` deploys new code, the pulse restarts and its
-# first cycle pays the full cold-cache cost: ~210s prefetch_state +
-# ~144s preflight_capacity_and_labels + ~50s preflight_cleanup_and_ledger
-# ≈ 8-10 minutes before any productive work. This script pre-warms the
-# L3 per-owner JSON caches via pulse-batch-prefetch-helper.sh refresh,
-# so the next pulse cycle's prefetch_state finds warm state and runs
-# the delta path (t1975 architecture — only fetches items with
-# updatedAt > last_prefetch).
+# When `aidevops update` deploys new code, the pulse restarts and its first
+# cycle pays the full cold-cache cost, including ~210s prefetch_state. Before
+# GH#28880, cross-repository label maintenance also held the first worker fill
+# for ~144s; the initial fill now runs before that maintenance. This script
+# still pre-warms the L3 per-owner JSON caches via
+# pulse-batch-prefetch-helper.sh refresh, so the remaining cycle's
+# prefetch_state finds warm state and runs the delta path (t1975 architecture —
+# only fetches items with updatedAt > last_prefetch).
 #
 # Wired into pulse-lifecycle-helper.sh::_start so every restart path
 # (aidevops update, setup.sh, manual restart, t2914 ensure-running)

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -1405,11 +1405,11 @@ _run_preflight_stages() {
 	_preflight_start_merge_first || true
 	run_stage_with_timeout "preflight_cleanup_and_ledger" "$_pflt_timeout" \
 		_preflight_cleanup_and_ledger || true
-	run_stage_with_timeout "preflight_capacity_and_labels" "$_pflt_timeout" \
-		_preflight_capacity_and_labels || true
-	# t3054: preflight_early_dispatch does NOT use run_stage_with_timeout.
-	# Unlike other preflight stages (single-step operations), this stage
-	# wraps apply_dispatch_max which iterates N candidates, each
+	run_stage_with_timeout "preflight_capacity" "$_pflt_timeout" \
+		_preflight_capacity || true
+	# t3054: dispatch passes do NOT use run_stage_with_timeout. Unlike other
+	# preflight stages (single-step operations), each wraps apply_dispatch_max,
+	# which iterates N candidates that are each
 	# independently protected by run_stage_with_timeout "dispatch_candidate_*"
 	# (600s per candidate). A 600s GROUP timeout killed in-progress candidates
 	# that were still within their individual budgets (92 timeouts in 1079 runs =
@@ -1419,6 +1419,15 @@ _run_preflight_stages() {
 	local _pflt_ed_rc=0
 	_preflight_early_dispatch || _pflt_ed_rc=$?
 	_log_substage_timing "preflight_early_dispatch" "$_pflt_ed_start" "$_pflt_ed_rc"
+	# GH#28880: cross-repository label maintenance can take 3-5 minutes. Run it
+	# after the initial fill so already-eligible workers boot in parallel, then
+	# refill once so newly unblocked candidates remain dispatchable this cycle.
+	run_stage_with_timeout "preflight_label_maintenance" "$_pflt_timeout" \
+		_preflight_label_maintenance || true
+	local _pflt_refill_start=$SECONDS
+	local _pflt_refill_rc=0
+	_preflight_post_label_refill || _pflt_refill_rc=$?
+	_log_substage_timing "preflight_post_label_refill" "$_pflt_refill_start" "$_pflt_refill_rc"
 	# t3055: Post-dispatch housekeeping runs under a separate async lock by
 	# default. These stages do not protect the immediate worker claim/ledger
 	# safety boundary, so blocking the dispatch lock on them lets a 24-worker

--- a/.agents/scripts/pulse-dispatch-preflight-lib.sh
+++ b/.agents/scripts/pulse-dispatch-preflight-lib.sh
@@ -244,13 +244,18 @@ _preflight_early_dispatch() {
 
 #######################################
 # Refill after label maintenance without repeating routine-comment responses.
-# apply_dispatch_max re-enumerates candidates and preserves the existing claim,
+# Invalidate the cycle-scoped candidate snapshot first so apply_dispatch_max
+# sees labels changed by maintenance while preserving the existing claim,
 # ledger, trust, and per-candidate timeout gates across multiple fill passes.
 #######################################
 _preflight_post_label_refill() {
 	if [[ -f "$STOP_FLAG" ]]; then
 		echo "[pulse-wrapper] Stop flag present — skipping post-label dispatch_max" >>"$LOGFILE"
 	else
+		if ! _dispatch_invalidate_candidate_snapshot "label_maintenance_complete"; then
+			echo "[pulse-wrapper] Post-label dispatch_max skipped: unable to invalidate candidate snapshot" >>"$LOGFILE"
+			return 0
+		fi
 		echo "[pulse-wrapper] Post-label dispatch_max: refilling after label maintenance" >>"$LOGFILE"
 		apply_dispatch_max
 	fi

--- a/.agents/scripts/pulse-dispatch-preflight-lib.sh
+++ b/.agents/scripts/pulse-dispatch-preflight-lib.sh
@@ -11,8 +11,8 @@
 # re-register as a new function-complexity violation if moved).
 #
 # Each helper groups one phase of preflight work: asynchronous merge-first,
-# cleanup/reap, capacity/labels, early dispatch, ownership reconcile, and
-# prefetch+scope.
+# cleanup/reap, capacity, early dispatch, label maintenance/refill, ownership
+# reconcile, and prefetch+scope.
 #
 # Usage: source "${SCRIPT_DIR}/pulse-dispatch-preflight-lib.sh"
 #
@@ -36,9 +36,9 @@ _PULSE_DISPATCH_PREFLIGHT_LIB_LOADED=1
 # Helpers for _run_preflight_stages (GH#18656)
 # -----------------------------------------------------------------------------
 # The helpers below group related preflight work so _run_preflight_stages
-# stays under 100 lines and each group (merge-first, cleanup/reap,
-# capacity/labels, early dispatch, daily scans, ownership reconcile, and
-# prefetch/scope) can be read independently.
+# stays under 100 lines and each group (merge-first, cleanup/reap, capacity,
+# early dispatch, label maintenance/refill, daily scans, ownership reconcile,
+# and prefetch/scope) can be read independently.
 
 #######################################
 # Give the existing standalone merge routine a non-blocking head start before
@@ -154,21 +154,20 @@ _preflight_cleanup_and_ledger() {
 }
 
 #######################################
-# Capacity calculation + session count warning + needs-* label
-# re-evaluation. Must run before the early dispatch pass so max workers
-# and priority allocations are current.
+# Capacity calculation + session count warning. Must run before the first
+# dispatch pass so max workers and priority allocations are current.
 #######################################
-_preflight_capacity_and_labels() {
+_preflight_capacity() {
 	# GH#21470: per-substage timing so slow callers are identifiable in
 	# pulse-stage-timings.log. Each _log_substage_timing call writes one TSV
 	# record with the same format as run_stage_with_timeout outer records.
 	local _ss0=$SECONDS
 	calculate_max_workers
-	_log_substage_timing "substage:cap_labels/calculate_max_workers" "$_ss0" 0
+	_log_substage_timing "substage:capacity/calculate_max_workers" "$_ss0" 0
 
 	local _ss1=$SECONDS
 	calculate_priority_allocations
-	_log_substage_timing "substage:cap_labels/calculate_priority_allocations" "$_ss1" 0
+	_log_substage_timing "substage:capacity/calculate_priority_allocations" "$_ss1" 0
 
 	local _ss2=$SECONDS
 	local _session_ct
@@ -176,28 +175,40 @@ _preflight_capacity_and_labels() {
 	if [[ "${_session_ct:-0}" -gt "$SESSION_COUNT_WARN" ]]; then
 		echo "[pulse-wrapper] Session warning: $_session_ct interactive sessions open (threshold: $SESSION_COUNT_WARN). Each consumes 100-440MB + language servers. Consider closing unused tabs." >>"$LOGFILE"
 	fi
-	_log_substage_timing "substage:cap_labels/check_session_count" "$_ss2" 0
+	_log_substage_timing "substage:capacity/check_session_count" "$_ss2" 0
 
-	# Re-evaluate needs-consolidation labels before dispatch. Issues labeled
+	return 0
+}
+
+#######################################
+# Cross-repository needs-* label maintenance. Runs after the first dispatch so
+# already-eligible work can boot while these idempotent sweeps expose additional
+# candidates for the post-maintenance refill.
+#######################################
+_preflight_label_maintenance() {
+	# GH#21470: preserve per-substage timing while separating these potentially
+	# slow GitHub/repository sweeps from the capacity-critical dispatch path.
+
+	# Re-evaluate needs-consolidation labels before the refill. Issues labeled
 	# by an earlier (less precise) filter may no longer trigger under the
-	# current filter. Auto-clearing here makes them dispatchable immediately
+	# current filter. Auto-clearing here makes them dispatchable in this cycle
 	# instead of stuck forever behind a label that list_dispatchable_issue_candidates_json
 	# filters out (needs-* exclusion at line 6703).
-	local _ss3=$SECONDS
+	local _ss0=$SECONDS
 	_reevaluate_consolidation_labels
-	_log_substage_timing "substage:cap_labels/reevaluate_consolidation_labels" "$_ss3" 0
+	_log_substage_timing "substage:label_maintenance/reevaluate_consolidation_labels" "$_ss0" 0
 
 	# t1982: Backfill pass for stuck needs-consolidation issues that never
 	# got a consolidation-task child created (pre-t1982 dispatches just
 	# labelled and returned). Dispatches a child retroactively so the
 	# parent can actually be consolidated instead of sitting forever.
-	local _ss4=$SECONDS
+	local _ss1=$SECONDS
 	_backfill_stale_consolidation_labels
-	_log_substage_timing "substage:cap_labels/backfill_consolidation_labels" "$_ss4" 0
+	_log_substage_timing "substage:label_maintenance/backfill_consolidation_labels" "$_ss1" 0
 
-	local _ss5=$SECONDS
+	local _ss2=$SECONDS
 	_reevaluate_simplification_labels
-	_log_substage_timing "substage:cap_labels/reevaluate_simplification_labels" "$_ss5" 0
+	_log_substage_timing "substage:label_maintenance/reevaluate_simplification_labels" "$_ss2" 0
 
 	return 0
 }
@@ -228,6 +239,21 @@ _preflight_early_dispatch() {
 	# user comments and dispatch lightweight Haiku workers to respond.
 	# Runs before heavy housekeeping so responses are fast.
 	dispatch_routine_comment_responses || true
+	return 0
+}
+
+#######################################
+# Refill after label maintenance without repeating routine-comment responses.
+# apply_dispatch_max re-enumerates candidates and preserves the existing claim,
+# ledger, trust, and per-candidate timeout gates across multiple fill passes.
+#######################################
+_preflight_post_label_refill() {
+	if [[ -f "$STOP_FLAG" ]]; then
+		echo "[pulse-wrapper] Stop flag present — skipping post-label dispatch_max" >>"$LOGFILE"
+	else
+		echo "[pulse-wrapper] Post-label dispatch_max: refilling after label maintenance" >>"$LOGFILE"
+		apply_dispatch_max
+	fi
 	return 0
 }
 

--- a/.agents/scripts/pulse-triage-evaluation.sh
+++ b/.agents/scripts/pulse-triage-evaluation.sh
@@ -69,8 +69,9 @@ _clear_needs_consolidation_label() {
 # exclusion) never reach dispatch_with_dedup, so the auto-clear logic in
 # _issue_needs_consolidation can't fire. This pass runs them through the
 # current filter and removes the label if they no longer trigger.
-# Lightweight: one gh issue list per repo + one _issue_needs_consolidation
-# call per labeled issue. Runs every cycle before the early fill floor.
+# One gh issue list per repo + one _issue_needs_consolidation call per labeled
+# issue. Runs between the initial fill and the post-maintenance refill so this
+# cross-repository sweep cannot delay already-eligible work (GH#28880).
 #######################################
 _reevaluate_consolidation_labels() {
 	local repos_json="$REPOS_JSON"

--- a/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
@@ -94,6 +94,53 @@ assert_match_count() {
 	return 0
 }
 
+assert_refill_runtime_contract() {
+	local label="$1"
+	local actual_events="" expected_events="dispatch;routine;invalidate:label_maintenance_complete;dispatch;"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	actual_events=$(
+		(
+			unset _PULSE_DISPATCH_PREFLIGHT_LIB_LOADED
+			# shellcheck source=../pulse-dispatch-preflight-lib.sh
+			source "$PREFLIGHT_LIB"
+			REFILL_EVENTS=""
+			STOP_FLAG=""
+			LOGFILE="/dev/null"
+
+			_dispatch_invalidate_candidate_snapshot() {
+				local reason="$1"
+				REFILL_EVENTS="${REFILL_EVENTS}invalidate:${reason};"
+				return 0
+			}
+
+			apply_dispatch_max() {
+				REFILL_EVENTS="${REFILL_EVENTS}dispatch;"
+				return 0
+			}
+
+			dispatch_routine_comment_responses() {
+				REFILL_EVENTS="${REFILL_EVENTS}routine;"
+				return 0
+			}
+
+			_preflight_early_dispatch
+			_preflight_post_label_refill
+			STOP_FLAG="$PREFLIGHT_LIB"
+			_preflight_post_label_refill
+			printf '%s\n' "$REFILL_EVENTS"
+		)
+	)
+	if [[ "$actual_events" == "$expected_events" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected events: $expected_events"
+		echo "  actual events:   ${actual_events:-none}"
+	fi
+	return 0
+}
+
 # Resolve paths relative to this test file
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ENGINE="$SCRIPT_DIR/pulse-dispatch-engine.sh"
@@ -249,6 +296,8 @@ assert_match_count \
 	'^[[:space:]]*dispatch_routine_comment_responses[[:space:]]*\|\|[[:space:]]*true' \
 	1 \
 	"$PREFLIGHT_LIB"
+assert_refill_runtime_contract \
+	"9l: refill invalidates candidates before dispatch and does not repeat routine responses"
 
 # --- Benign expected dispatch blocks must not be surfaced as generic stage failures ---
 

--- a/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
@@ -4,7 +4,7 @@
 #
 # shellcheck disable=SC2016  # single-quoted regex patterns are literal by design
 #
-# test-pulse-dispatch-engine-stage-wiring.sh — regression guard for t2443
+# test-pulse-dispatch-engine-stage-wiring.sh — regression guard for t2443/GH#28880
 #
 # Verifies that post-dispatch housekeeping stages remain independently timed
 # and are wired through the async housekeeping launcher, not wrapped in a
@@ -15,7 +15,9 @@
 # before auto_decomposer_scanner could run. t2443 promoted each scanner to
 # an independent stage so each gets its own timeout budget; t3055 then moved
 # those independent stages behind an async post-dispatch lock so housekeeping
-# cannot hold the dispatch cycle open while worker slots drain.
+# cannot hold the dispatch cycle open while worker slots drain. GH#28880 also
+# keeps cross-repository label maintenance between two unwrapped fill passes so
+# already-eligible work launches before those sweeps.
 
 set -u
 
@@ -58,11 +60,46 @@ assert_not_grep() {
 	return 0
 }
 
+assert_order() {
+	local label="$1" first_pattern="$2" second_pattern="$3" file="$4"
+	local first_line="" second_line=""
+	TESTS_RUN=$((TESTS_RUN + 1))
+	first_line=$(grep -nEm1 "$first_pattern" "$file" 2>/dev/null | cut -d: -f1 || true)
+	second_line=$(grep -nEm1 "$second_pattern" "$file" 2>/dev/null | cut -d: -f1 || true)
+	if [[ "$first_line" =~ ^[0-9]+$ && "$second_line" =~ ^[0-9]+$ && "$first_line" -lt "$second_line" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  first pattern/line:  $first_pattern / ${first_line:-missing}"
+		echo "  second pattern/line: $second_pattern / ${second_line:-missing}"
+	fi
+	return 0
+}
+
+assert_match_count() {
+	local label="$1" pattern="$2" expected_count="$3" file="$4"
+	local actual_count=0
+	TESTS_RUN=$((TESTS_RUN + 1))
+	actual_count=$(grep -cE "$pattern" "$file" 2>/dev/null || true)
+	[[ "$actual_count" =~ ^[0-9]+$ ]] || actual_count=0
+	if [[ "$actual_count" -eq "$expected_count" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected/actual count: $expected_count / $actual_count"
+		echo "  pattern:               $pattern"
+	fi
+	return 0
+}
+
 # Resolve paths relative to this test file
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ENGINE="$SCRIPT_DIR/pulse-dispatch-engine.sh"
 CORE="$SCRIPT_DIR/pulse-dispatch-core.sh"
 DISPATCH_LIB="$SCRIPT_DIR/pulse-dispatch-lib.sh"
+PREFLIGHT_LIB="$SCRIPT_DIR/pulse-dispatch-preflight-lib.sh"
 
 echo "=== t2443 + t2903: pulse-dispatch-engine stage wiring regression tests ==="
 echo "Engine: $ENGINE"
@@ -160,6 +197,58 @@ assert_grep \
 	"9: async post-dispatch housekeeping uses _pflt_timeout" \
 	'_pulse_start_post_dispatch_housekeeping "\$_pflt_timeout"' \
 	"$ENGINE"
+
+# --- Already-eligible work launches before cross-repository label maintenance ---
+
+assert_grep \
+	"9a: capacity calculation is an independently timed preflight stage" \
+	'run_stage_with_timeout "preflight_capacity"' \
+	"$ENGINE"
+assert_grep \
+	"9b: label maintenance is an independently timed preflight stage" \
+	'run_stage_with_timeout "preflight_label_maintenance"' \
+	"$ENGINE"
+assert_grep \
+	"9c: capacity and label maintenance use separate helper functions" \
+	'^_preflight_label_maintenance\(\)' \
+	"$PREFLIGHT_LIB"
+assert_grep \
+	"9d: post-label refill has a dedicated helper" \
+	'^_preflight_post_label_refill\(\)' \
+	"$PREFLIGHT_LIB"
+assert_order \
+	"9e: capacity completes before the initial fill" \
+	'^[[:space:]]*run_stage_with_timeout "preflight_capacity"' \
+	'^[[:space:]]*_preflight_early_dispatch([[:space:]]|$)' \
+	"$ENGINE"
+assert_order \
+	"9f: initial fill precedes label maintenance" \
+	'^[[:space:]]*_preflight_early_dispatch([[:space:]]|$)' \
+	'^[[:space:]]*run_stage_with_timeout "preflight_label_maintenance"' \
+	"$ENGINE"
+assert_order \
+	"9g: label maintenance precedes the same-cycle refill" \
+	'^[[:space:]]*run_stage_with_timeout "preflight_label_maintenance"' \
+	'^[[:space:]]*_preflight_post_label_refill([[:space:]]|$)' \
+	"$ENGINE"
+assert_order \
+	"9h: post-label refill precedes async housekeeping" \
+	'^[[:space:]]*_preflight_post_label_refill([[:space:]]|$)' \
+	'^[[:space:]]*_pulse_start_post_dispatch_housekeeping([[:space:]]|$)' \
+	"$ENGINE"
+assert_not_grep \
+	"9i: initial fill is not wrapped by the group timeout" \
+	'run_stage_with_timeout "preflight_early_dispatch"' \
+	"$ENGINE"
+assert_not_grep \
+	"9j: post-label refill is not wrapped by the group timeout" \
+	'run_stage_with_timeout "preflight_post_label_refill"' \
+	"$ENGINE"
+assert_match_count \
+	"9k: routine comment responses run only during the initial fill" \
+	'^[[:space:]]*dispatch_routine_comment_responses[[:space:]]*\|\|[[:space:]]*true' \
+	1 \
+	"$PREFLIGHT_LIB"
 
 # --- Benign expected dispatch blocks must not be surfaced as generic stage failures ---
 


### PR DESCRIPTION
## Summary

Dispatch already-eligible Pulse work before slow cross-repository label maintenance, then invalidate the candidate snapshot and refill once for newly unblocked work.

## Files Changed

.agents/scripts/pulse-cache-prime.sh, .agents/scripts/pulse-dispatch-engine.sh, .agents/scripts/pulse-dispatch-preflight-lib.sh, .agents/scripts/pulse-triage-evaluation.sh, .agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified locally by executing the actual Bash preflight and candidate-snapshot paths: 38 stage-wiring assertions; snapshot rebuild/bypass, merge-first, sync/async housekeeping, cycle-health, and 42 wrapper characterization tests; local linters and ShellCheck; independent exact-head CLEAN review.

Resolves #28880


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.196 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 20h 4m and 6,170,466 tokens on this with the user in an interactive session.