### PR TITLE
GH#28877: Harden review prompts and Pulse label provisioning

### DIFF
--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -1164,7 +1164,7 @@ Thread preview: ${safe_preview}
    Review-thread read/reply/resolve operations are GraphQL-only in this helper;
    use the scanner commands above or 'gh api graphql'. The resolveReviewThread
    mutation has no REST endpoint, so do not try 'gh api repos/...' for resolve.
-4. For each unresolved bot finding, classify it as actionable or praise-only:
+4. For each unresolved review thread, classify it as actionable or praise-only:
    - Actionable means the thread requests a code, documentation, configuration,
      or follow-up change. Verify the premise in the cited file and context.
    - Praise-only means positive feedback or an observation with no requested

--- a/.agents/scripts/pulse-check-helper.sh
+++ b/.agents/scripts/pulse-check-helper.sh
@@ -40,6 +40,7 @@ FAILURE_FAMILY_THRESHOLD="${PULSE_CHECK_FAILURE_FAMILY_THRESHOLD:-3}"
 FAILURE_FAMILY_RECOVERY_SECONDS="${PULSE_CHECK_FAILURE_FAMILY_RECOVERY_SECONDS:-86400}"
 FAILURE_FAMILY_STATE_FILE="${PULSE_CHECK_FAILURE_FAMILY_STATE_FILE:-${HOME}/.aidevops/cache/failure-family-remediation.json}"
 FAILURE_FAMILY_STATUS_RECURRING="recurring"
+PULSE_CHECK_LABELS_ENSURED=""
 
 _usage() {
 	cat <<EOF
@@ -374,6 +375,69 @@ _record_failure_family_state() {
 	return 0
 }
 
+_pulse_check_label_contract() {
+	printf '%s\n' \
+		'auto-dispatch|0E8A16|Eligible for autonomous worker dispatch' \
+		'tier:standard|1D76DB|Standard-tier implementation requiring contextual judgment' \
+		'bug|D73A4A|Something is not working' \
+		'framework|5319E7|AI DevOps framework maintenance' \
+		'pulse|0052CC|Pulse dispatch and worker automation' \
+		'self-improvement|7057FF|Automated framework self-improvement' \
+		'source:pulse-check|C2E0C6|Auto-created by the Pulse check routine'
+	return 0
+}
+
+_pulse_check_label_present() {
+	local labels_json="$1"
+	local label_name="$2"
+	if printf '%s' "$labels_json" | jq -e --arg label "$label_name" \
+		'any(.[]?; .name == $label)' >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
+_ensure_pulse_check_labels() {
+	local repo_slug="$1"
+	[[ -n "$repo_slug" ]] || return 1
+	case ",${PULSE_CHECK_LABELS_ENSURED}," in
+	*",${repo_slug},"*) return 0 ;;
+	esac
+
+	local existing_labels_json=""
+	if ! existing_labels_json=$(gh label list --repo "$repo_slug" --limit 1000 --json name 2>/dev/null) ||
+		! printf '%s' "$existing_labels_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
+		print_error "pulse-check: failed to list labels for ${repo_slug}"
+		return 1
+	fi
+
+	while IFS='|' read -r label_name color description; do
+		[[ -n "$label_name" ]] || continue
+		if _pulse_check_label_present "$existing_labels_json" "$label_name"; then
+			continue
+		fi
+
+		local create_output=""
+		if create_output=$(gh label create "$label_name" --repo "$repo_slug" \
+			--color "$color" --description "$description" 2>&1); then
+			continue
+		fi
+
+		# Treat a concurrent creator as success, but fail closed when the
+		# required label still cannot be verified after the write attempt.
+		local refreshed_labels_json=""
+		refreshed_labels_json=$(gh label list --repo "$repo_slug" --limit 1000 --json name 2>/dev/null) || refreshed_labels_json="[]"
+		if _pulse_check_label_present "$refreshed_labels_json" "$label_name"; then
+			continue
+		fi
+		print_error "pulse-check: failed to ensure label ${label_name} on ${repo_slug}: ${create_output}"
+		return 1
+	done < <(_pulse_check_label_contract)
+
+	PULSE_CHECK_LABELS_ENSURED="${PULSE_CHECK_LABELS_ENSURED:+${PULSE_CHECK_LABELS_ENSURED},}${repo_slug}"
+	return 0
+}
+
 _apply_finding() {
 	local slug="$1"
 	local finding_json="$2"
@@ -401,6 +465,7 @@ _apply_finding() {
 	fi
 
 	_load_gh_wrappers || return 1
+	_ensure_pulse_check_labels "$slug" || return 1
 
 	local body_file=""
 	body_file=$(mktemp "${TMPDIR:-/tmp}/pulse-check-issue.XXXXXX") || return 1

--- a/.agents/scripts/pulse-check-helper.sh
+++ b/.agents/scripts/pulse-check-helper.sh
@@ -397,6 +397,17 @@ _pulse_check_label_present() {
 	return 1
 }
 
+_list_pulse_check_labels() {
+	local repo_slug="$1"
+	local labels_json=""
+	if ! labels_json=$(gh api --paginate "repos/${repo_slug}/labels?per_page=100" 2>/dev/null |
+		jq -s '[.[][]? | {name: .name}]'); then
+		return 1
+	fi
+	printf '%s\n' "$labels_json"
+	return 0
+}
+
 _ensure_pulse_check_labels() {
 	local repo_slug="$1"
 	[[ -n "$repo_slug" ]] || return 1
@@ -405,7 +416,7 @@ _ensure_pulse_check_labels() {
 	esac
 
 	local existing_labels_json=""
-	if ! existing_labels_json=$(gh label list --repo "$repo_slug" --limit 1000 --json name 2>/dev/null) ||
+	if ! existing_labels_json=$(_list_pulse_check_labels "$repo_slug") ||
 		! printf '%s' "$existing_labels_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
 		print_error "pulse-check: failed to list labels for ${repo_slug}"
 		return 1
@@ -426,7 +437,7 @@ _ensure_pulse_check_labels() {
 		# Treat a concurrent creator as success, but fail closed when the
 		# required label still cannot be verified after the write attempt.
 		local refreshed_labels_json=""
-		refreshed_labels_json=$(gh label list --repo "$repo_slug" --limit 1000 --json name 2>/dev/null) || refreshed_labels_json="[]"
+		refreshed_labels_json=$(_list_pulse_check_labels "$repo_slug") || refreshed_labels_json="[]"
 		if _pulse_check_label_present "$refreshed_labels_json" "$label_name"; then
 			continue
 		fi

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -978,7 +978,10 @@ test_dispatch_pr_launches_targeted_worker_with_human_opt_in() {
 	PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN=true $SCANNER dispatch-pr owner/repo "${TEST_ROOT}/repo" 1
 	wait_for_headless_log || true
 	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
-	if [[ -s "$HEADLESS_LOG" && -f "$state_file" ]] && grep -q 'Target: PR #1 in owner/repo' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null; then
+	if [[ -s "$HEADLESS_LOG" && -f "$state_file" ]] &&
+		grep -q 'Target: PR #1 in owner/repo' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
+		grep -q 'For each unresolved review thread' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null &&
+		! grep -q 'For each unresolved bot finding' "$HEADLESS_PROMPT_CAPTURE" 2>/dev/null; then
 		print_result "dispatch-pr launches bounded targeted worker with human opt-in" 0
 	else
 		print_result "dispatch-pr launches bounded targeted worker with human opt-in" 1 "headless=$(wc -c <"$HEADLESS_LOG" 2>/dev/null || printf 0), state=${state_file}"

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -180,7 +180,7 @@ if [[ " $* " == *" api graphql "* ]]; then
   printf '%s\n' '{"data":{"repository":{"issue":{"blockedBy":{"nodes":[],"pageInfo":{"hasNextPage":false}}}}}}'
   exit 0
 fi
-if [[ " $* " == *" label list "* ]]; then
+if [[ " $* " == *" api "*"/labels?per_page=100"* ]]; then
   printf '%s\n' "${PULSE_CHECK_EXISTING_LABELS_JSON:-[]}"
   exit "${PULSE_CHECK_LABEL_LIST_EXIT:-0}"
 fi

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -63,6 +63,22 @@ assert_eq() {
 	return 0
 }
 
+assert_precedes() {
+	local label="$1"
+	local first="$2"
+	local second="$3"
+	local haystack="$4"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$haystack" == *"$first"*"$second"* ]]; then
+		printf '%sPASS%s: %s\n' "$TEST_GREEN" "$TEST_NC" "$label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf '%sFAIL%s: %s\n' "$TEST_RED" "$TEST_NC" "$label"
+		printf '  expected %s before %s\n' "$first" "$second"
+	fi
+	return 0
+}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HELPER="${SCRIPT_DIR}/pulse-check-helper.sh"
 CORE_ROUTINES="${SCRIPT_DIR}/routines/core-routines.sh"
@@ -162,6 +178,19 @@ if [[ " $* " == *" repo view "* ]]; then
 fi
 if [[ " $* " == *" api graphql "* ]]; then
   printf '%s\n' '{"data":{"repository":{"issue":{"blockedBy":{"nodes":[],"pageInfo":{"hasNextPage":false}}}}}}'
+  exit 0
+fi
+if [[ " $* " == *" label list "* ]]; then
+  printf '%s\n' "${PULSE_CHECK_EXISTING_LABELS_JSON:-[]}"
+  exit "${PULSE_CHECK_LABEL_LIST_EXIT:-0}"
+fi
+if [[ " $* " == *" label create "* ]]; then
+  label_name="${3:-}"
+  printf 'label-create=%s\n' "$label_name" >>"${PULSE_CHECK_CAPTURE}"
+  if [[ "$label_name" == "${PULSE_CHECK_FAIL_LABEL:-}" ]]; then
+    printf 'simulated label creation failure\n' >&2
+    exit 1
+  fi
   exit 0
 fi
 if [[ " $* " == *" --search "* ]]; then
@@ -290,11 +319,30 @@ assert_eq "classified launch failures suppress launch accounting gap" "auto-disp
 
 APPLY_OUT=$(env "${COMMON_ENV[@]}" "$HELPER" apply --repo owner/aidevops 2>&1)
 assert_contains "apply reports issue filing" "pulse-check: filed" "$APPLY_OUT"
-BODY=$(cat "${TEST_ROOT}/capture.txt.body")
+CAPTURE=$(<"${TEST_ROOT}/capture.txt")
+for required_label in auto-dispatch tier:standard bug framework pulse self-improvement source:pulse-check; do
+	assert_contains "apply provisions ${required_label}" "label-create=${required_label}" "$CAPTURE"
+done
+assert_precedes "apply provisions labels before issue creation" "label-create=source:pulse-check" "repo=owner/aidevops" "$CAPTURE"
+assert_contains "apply passes complete label contract" "labels=auto-dispatch,tier:standard,bug,framework,pulse,self-improvement,source:pulse-check" "$CAPTURE"
+BODY=$(<"${TEST_ROOT}/capture.txt.body")
 assert_contains "apply body carries marker" "aidevops:generator=pulse-check finding=" "$BODY"
 assert_contains "apply body carries verification" ".agents/scripts/tests/test-pulse-check-helper.sh" "$BODY"
 assert_not_contains "apply body omits private slug" "private/repo-one" "$BODY"
 assert_not_contains "apply body omits issue title" "secret one" "$BODY"
+
+rm -f "${TEST_ROOT}/capture.txt" "${TEST_ROOT}/capture.txt.body"
+EXISTING_LABELS='[{"name":"auto-dispatch"},{"name":"tier:standard"},{"name":"bug"},{"name":"framework"},{"name":"pulse"},{"name":"self-improvement"},{"name":"source:pulse-check"}]'
+EXISTING_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_EXISTING_LABELS_JSON=${EXISTING_LABELS}" "$HELPER" apply --repo owner/aidevops 2>&1)
+EXISTING_CAPTURE=$(<"${TEST_ROOT}/capture.txt")
+assert_contains "existing labels still allow issue filing" "pulse-check: filed" "$EXISTING_OUT"
+assert_not_contains "existing label metadata is not overwritten" "label-create=" "$EXISTING_CAPTURE"
+
+rm -f "${TEST_ROOT}/capture.txt" "${TEST_ROOT}/capture.txt.body"
+FAILED_LABEL_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_FAIL_LABEL=source:pulse-check" "$HELPER" apply --repo owner/aidevops 2>&1)
+FAILED_LABEL_CAPTURE=$(<"${TEST_ROOT}/capture.txt")
+assert_contains "required label failure is reported" "failed to ensure label source:pulse-check" "$FAILED_LABEL_OUT"
+assert_not_contains "required label failure prevents issue creation" "repo=owner/aidevops" "$FAILED_LABEL_CAPTURE"
 
 # shellcheck source=../routines/core-routines.sh
 CORE_OUTPUT=$(source "$CORE_ROUTINES" && get_core_routine_entries)


### PR DESCRIPTION
## Summary

Make review-thread worker prompts author-neutral and provision the complete Pulse-check label contract before issue creation.

Resolves #28883

## Files Changed

.agents/scripts/pr-review-thread-response-scanner.sh, .agents/scripts/pulse-check-helper.sh, .agents/scripts/tests/test-pr-review-thread-response-scanner.sh, .agents/scripts/tests/test-pulse-check-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 35 Pulse-check tests, 58 review-thread scanner tests, ShellCheck, and local quality gates passed

Resolves #28877


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.196 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 31m and 558,158 tokens on this with the user in an interactive session.