### PR TITLE
GH#28887: Disambiguate Pulse timing executor PIDs

### DIFF
--- a/.agents/scripts/pulse-diagnose-cycle-health.sh
+++ b/.agents/scripts/pulse-diagnose-cycle-health.sh
@@ -118,6 +118,8 @@ _ch_stage_stats() {
 	{
 		nf=split($0, f, "\t")
 		if (nf < 5 || f[1] < cutoff) next
+		# Fields 1-5 are the legacy schema. Field 6 optionally identifies the
+		# executor, but field 5 remains the cycle-owner aggregation key.
 		ts=f[1]; stage=f[2]; dur=f[3]+0; rc=f[4]+0
 		cnt[stage]++
 		if (rc==124) to[stage]++
@@ -153,20 +155,20 @@ _ch_cycle_stats() {
 	{
 		nf=split($0, f, "\t")
 		if (nf < 5 || f[1] < cutoff) next
-		ts=f[1]; stage=f[2]; rc=f[4]+0; pid=f[5]
-		pids[pid]=1
-		if (!pid_first[pid] || ts < pid_first[pid]) pid_first[pid]=ts
+		ts=f[1]; stage=f[2]; rc=f[4]+0; owner_pid=f[5]
+		owners[owner_pid]=1
+		if (!owner_first[owner_pid] || ts < owner_first[owner_pid]) owner_first[owner_pid]=ts
 		if (stage=="preflight_early_dispatch" && rc==0) {
-			ff[pid]=1
-			if (ts > last_ff_ts) { last_ff_ts=ts; last_ff_pid=pid }
+			ff[owner_pid]=1
+			if (ts > last_ff_ts) { last_ff_ts=ts; last_ff_owner=owner_pid }
 		}
 	}
 	END {
 		total=0; ff_count=0; since_ff=0
-		for (pid in pids) total++
-		for (pid in ff) ff_count++
+		for (owner_pid in owners) total++
+		for (owner_pid in ff) ff_count++
 		if (last_ff_ts) {
-			for (pid in pids) if (!(pid in ff) && pid_first[pid]>last_ff_ts) since_ff++
+			for (owner_pid in owners) if (!(owner_pid in ff) && owner_first[owner_pid]>last_ff_ts) since_ff++
 		} else since_ff=total
 		printf "cycles_started=%d\nfill_floor_cycles=%d\ncycles_since_ff=%d\nlast_ff_ts=%s\n", total, ff_count, since_ff, last_ff_ts
 	}' "$timings_file" 2>/dev/null

--- a/.agents/scripts/pulse-watchdog.sh
+++ b/.agents/scripts/pulse-watchdog.sh
@@ -241,12 +241,13 @@ run_stage_with_timeout() {
 			wait "$stage_pid" 2>/dev/null || true
 			# GH#20025: Log timeout to structured timing log
 			if [[ -n "${PULSE_STAGE_TIMINGS_LOG:-}" ]]; then
-				printf '%s\t%s\t%d\t%d\t%d\n' \
+				printf '%s\t%s\t%d\t%d\t%d\t%d\n' \
 					"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
 					"$stage_name" \
 					"$elapsed" \
 					124 \
-					"$$" >>"$PULSE_STAGE_TIMINGS_LOG" 2>/dev/null || true
+					"$$" \
+					"$stage_pid" >>"$PULSE_STAGE_TIMINGS_LOG" 2>/dev/null || true
 			fi
 			return 124
 		fi
@@ -260,14 +261,16 @@ run_stage_with_timeout() {
 	local stage_duration=$((stage_end - stage_start))
 
 	# GH#20025: Append structured timing record to dedicated log for analysis.
-	# Format: ISO-timestamp \t stage_name \t duration_seconds \t exit_code \t pid
+	# Format: ISO-timestamp \t stage_name \t duration_seconds \t exit_code
+	#         \t cycle_owner_pid \t executor_pid
 	if [[ -n "${PULSE_STAGE_TIMINGS_LOG:-}" ]]; then
-		printf '%s\t%s\t%d\t%d\t%d\n' \
+		printf '%s\t%s\t%d\t%d\t%d\t%d\n' \
 			"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
 			"$stage_name" \
 			"$stage_duration" \
 			"$stage_status" \
-			"$$" >>"$PULSE_STAGE_TIMINGS_LOG" 2>/dev/null || true
+			"$$" \
+			"$stage_pid" >>"$PULSE_STAGE_TIMINGS_LOG" 2>/dev/null || true
 	fi
 
 	if [[ "$stage_status" -ne 0 ]]; then
@@ -293,24 +296,40 @@ run_stage_with_timeout() {
 #
 # Writes the same TSV format as run_stage_with_timeout so both outer stage
 # and substage records land in one log and can be analysed uniformly:
-#   ISO-timestamp <TAB> stage_name <TAB> duration_s <TAB> exit_code <TAB> pid
+#   ISO-timestamp <TAB> stage_name <TAB> duration_s <TAB> exit_code
+#     <TAB> cycle_owner_pid <TAB> executor_pid
 #
 # Returns: 0 (always — never fails the caller)
 #######################################
+_pulse_executor_pid() {
+	local executor_pid="${BASHPID:-}"
+	if [[ -z "$executor_pid" ]]; then
+		# Bash 3.2 has no BASHPID and $$ remains the cycle-owner PID inside a
+		# subshell. The command-substitution child sees the caller as its PPID.
+		executor_pid="$(exec sh -c 'printf "%s" "$PPID"')" || return 1
+	fi
+	[[ "$executor_pid" =~ ^[1-9][0-9]*$ ]] || return 1
+	printf '%s' "$executor_pid"
+	return 0
+}
+
 _log_substage_timing() {
 	local substage_name="$1"
 	local start_secs="${2:-0}"
 	local exit_code="${3:-0}"
 	local duration=$(( SECONDS - start_secs ))
+	local executor_pid=""
 	[[ "$duration" =~ ^[0-9]+$ ]] || duration=0
 	echo "[pulse-wrapper] Substage: ${substage_name} (${exit_code}, ${duration}s)" >>"${LOGFILE:-/dev/null}"
 	if [[ -n "${PULSE_STAGE_TIMINGS_LOG:-}" ]]; then
-		printf '%s\t%s\t%d\t%d\t%d\n' \
+		executor_pid=$(_pulse_executor_pid) || executor_pid="unavailable"
+		printf '%s\t%s\t%d\t%d\t%d\t%s\n' \
 			"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
 			"$substage_name" \
 			"$duration" \
 			"$exit_code" \
-			"$$" >>"$PULSE_STAGE_TIMINGS_LOG" 2>/dev/null || true
+			"$$" \
+			"$executor_pid" >>"$PULSE_STAGE_TIMINGS_LOG" 2>/dev/null || true
 	fi
 	return 0
 }

--- a/.agents/scripts/pulse-watchdog.sh
+++ b/.agents/scripts/pulse-watchdog.sh
@@ -301,15 +301,15 @@ run_stage_with_timeout() {
 #
 # Returns: 0 (always — never fails the caller)
 #######################################
-_pulse_executor_pid() {
-	local executor_pid="${BASHPID:-}"
+_pulse_resolve_executor_pid() {
+	local executor_pid="$1"
 	if [[ -z "$executor_pid" ]]; then
 		# Bash 3.2 has no BASHPID and $$ remains the cycle-owner PID inside a
 		# subshell. The command-substitution child sees the caller as its PPID.
 		executor_pid="$(exec sh -c 'printf "%s" "$PPID"')" || return 1
 	fi
 	[[ "$executor_pid" =~ ^[1-9][0-9]*$ ]] || return 1
-	printf '%s' "$executor_pid"
+	_PULSE_EXECUTOR_PID="$executor_pid"
 	return 0
 }
 
@@ -322,7 +322,11 @@ _log_substage_timing() {
 	[[ "$duration" =~ ^[0-9]+$ ]] || duration=0
 	echo "[pulse-wrapper] Substage: ${substage_name} (${exit_code}, ${duration}s)" >>"${LOGFILE:-/dev/null}"
 	if [[ -n "${PULSE_STAGE_TIMINGS_LOG:-}" ]]; then
-		executor_pid=$(_pulse_executor_pid) || executor_pid="unavailable"
+		if _pulse_resolve_executor_pid "${BASHPID:-}"; then
+			executor_pid="$_PULSE_EXECUTOR_PID"
+		else
+			executor_pid="unavailable"
+		fi
 		printf '%s\t%s\t%d\t%d\t%d\t%s\n' \
 			"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
 			"$substage_name" \

--- a/.agents/scripts/tests/test-pulse-diagnose-cycle-health.sh
+++ b/.agents/scripts/tests/test-pulse-diagnose-cycle-health.sh
@@ -332,14 +332,43 @@ output=$(
 assert_exit_code "mixed legacy and extended timing rows exit 0" 0 "$rc"
 assert_contains "multiple executors under one owner still produce four cycles" "cycles_started=4" "$output"
 
-# --- Test 17: executor lookup failure does not suppress a timing row ---
-printf '\nTest 17: executor lookup failure remains non-blocking\n'
+# --- Test 17: substage timing records the background executor ---
+printf '\nTest 17: substage timing records its background executor\n'
+EXECUTOR_TIMINGS="${TMPDIR_TEST}/executor-timings.log"
+(
+	# shellcheck source=../pulse-watchdog.sh
+	source "$WATCHDOG_LIB"
+	LOGFILE="${TMPDIR_TEST}/executor-wrapper.log"
+	PULSE_STAGE_TIMINGS_LOG="$EXECUTOR_TIMINGS"
+	_log_substage_timing "substage:test/executor" "$SECONDS" 0
+) &
+executor_pid=$!
+wait "$executor_pid"
+output=$(<"$EXECUTOR_TIMINGS")
+assert_contains "sixth field identifies the background executor" $'\t'"${executor_pid}" "$output"
+
+# --- Test 18: Bash 3.2 fallback resolves the calling background process ---
+printf '\nTest 18: executor fallback resolves its background caller\n'
+FALLBACK_EXECUTOR="${TMPDIR_TEST}/fallback-executor-pid"
+(
+	# shellcheck source=../pulse-watchdog.sh
+	source "$WATCHDOG_LIB"
+	_pulse_resolve_executor_pid ""
+	printf '%s' "$_PULSE_EXECUTOR_PID" >"$FALLBACK_EXECUTOR"
+) &
+executor_pid=$!
+wait "$executor_pid"
+output=$(<"$FALLBACK_EXECUTOR")
+assert_contains "PPID fallback identifies the background caller" "$executor_pid" "$output"
+
+# --- Test 19: executor lookup failure does not suppress a timing row ---
+printf '\nTest 19: executor lookup failure remains non-blocking\n'
 FAILURE_TIMINGS="${TMPDIR_TEST}/executor-failure-timings.log"
 rc=0
 (
 	# shellcheck source=../pulse-watchdog.sh
 	source "$WATCHDOG_LIB"
-	_pulse_executor_pid() { return 1; }
+	_pulse_resolve_executor_pid() { return 1; }
 	LOGFILE="${TMPDIR_TEST}/executor-failure-wrapper.log"
 	PULSE_STAGE_TIMINGS_LOG="$FAILURE_TIMINGS"
 	_log_substage_timing "substage:test/fallback" "$SECONDS" 0

--- a/.agents/scripts/tests/test-pulse-diagnose-cycle-health.sh
+++ b/.agents/scripts/tests/test-pulse-diagnose-cycle-health.sh
@@ -4,13 +4,15 @@
 # Regression tests for pulse-diagnose-helper.sh cycle-health subcommand (t2752)
 #
 # Uses fixture log files — no live network or real pulse logs required.
-# Log format: timestamp \t stage_name \t duration_secs \t exit_code \t pid
+# Log format: timestamp \t stage_name \t duration_secs \t exit_code
+#             \t cycle_owner_pid [\t executor_pid]
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HELPER="${SCRIPT_DIR}/../pulse-diagnose-helper.sh"
 CYCLE_HEALTH_LIB="${SCRIPT_DIR}/../pulse-diagnose-cycle-health.sh"
+WATCHDOG_LIB="${SCRIPT_DIR}/../pulse-watchdog.sh"
 PASS=0
 FAIL=0
 TOTAL=0
@@ -73,7 +75,7 @@ export PULSE_DIAGNOSE_NOW_EPOCH="$TEST_NOW_EPOCH"
 
 # Build a fixture with two complete and two incomplete cycles.
 #
-# Cycle 1 (PID 11111) — complete: reaches preflight_early_dispatch exit 0
+# Cycle 1 (owner PID 11111, executor PIDs 51111/51112) — complete
 # Cycle 2 (PID 22222) — degraded: cleanup_worktrees exits 124 (timeout), stops early
 # Cycle 3 (PID 33333) — complete: reaches preflight_early_dispatch exit 0
 # Cycle 4 (PID 44444) — incomplete: cleanup_worktrees exits 124, stops (after last dispatch)
@@ -81,8 +83,8 @@ export PULSE_DIAGNOSE_NOW_EPOCH="$TEST_NOW_EPOCH"
 # The test-only clock override makes the fixed fixture recent in the 24h window.
 
 cat > "$FIXTURE_TIMINGS" <<'TIMINGS'
-2026-06-24T00:00:01Z	cleanup_orphans	2	0	11111
-2026-06-24T00:00:03Z	cleanup_stale_opencode	2	0	11111
+2026-06-24T00:00:01Z	cleanup_orphans	2	0	11111	51111
+2026-06-24T00:00:03Z	cleanup_stale_opencode	2	0	11111	51112
 2026-06-24T00:00:05Z	cleanup_stalled_workers	2	0	11111
 2026-06-24T00:01:10Z	cleanup_worktrees	5	0	11111
 2026-06-24T00:01:20Z	cleanup_stashes	3	0	11111
@@ -317,6 +319,34 @@ output=$(
 ) || rc=$?
 assert_exit_code "leading-dash wrapper filename exits 0" 0 "$rc"
 assert_contains "leading-dash wrapper filename is counted" "acquired=4" "$output"
+
+# --- Test 16: extended rows preserve owner aggregation across executors ---
+printf '\nTest 16: multiple executors remain one owner cycle\n'
+rc=0
+output=$(
+	unset SCRIPT_DIR
+	# shellcheck source=../pulse-diagnose-cycle-health.sh
+	source "$CYCLE_HEALTH_LIB"
+	_ch_cycle_stats "$FIXTURE_TIMINGS" "2026-06-24T00:00:00Z"
+) || rc=$?
+assert_exit_code "mixed legacy and extended timing rows exit 0" 0 "$rc"
+assert_contains "multiple executors under one owner still produce four cycles" "cycles_started=4" "$output"
+
+# --- Test 17: executor lookup failure does not suppress a timing row ---
+printf '\nTest 17: executor lookup failure remains non-blocking\n'
+FAILURE_TIMINGS="${TMPDIR_TEST}/executor-failure-timings.log"
+rc=0
+(
+	# shellcheck source=../pulse-watchdog.sh
+	source "$WATCHDOG_LIB"
+	_pulse_executor_pid() { return 1; }
+	LOGFILE="${TMPDIR_TEST}/executor-failure-wrapper.log"
+	PULSE_STAGE_TIMINGS_LOG="$FAILURE_TIMINGS"
+	_log_substage_timing "substage:test/fallback" "$SECONDS" 0
+) || rc=$?
+assert_exit_code "failed executor lookup does not fail the caller" 0 "$rc"
+output=$(<"$FAILURE_TIMINGS")
+assert_contains "failed executor lookup writes explicit unavailable identity" $'\tunavailable' "$output"
 
 # =============================================================================
 # Summary


### PR DESCRIPTION
## Summary

- Preserve field 5 as the Pulse cycle-owner PID while adding executor PID as field 6.
- Resolve background executor identity with `BASHPID` and a Bash 3.2-safe PPID fallback.
- Keep legacy five-field rows and mixed logs aggregated by cycle owner.
- Keep executor lookup failures non-blocking with an explicit `unavailable` value.

## Verification

- `bash .agents/scripts/tests/test-pulse-diagnose-cycle-health.sh` — 42 passed
- `.agents/scripts/shellcheck-wrapper.sh .agents/scripts/pulse-watchdog.sh .agents/scripts/pulse-diagnose-cycle-health.sh .agents/scripts/tests/test-pulse-diagnose-cycle-health.sh`
- `git diff --check`

Resolves #28887

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.197 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol
