### PR TITLE
GH#28892: Advance OpenCode headless pin safely

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1522,7 +1522,8 @@ _find_alternative_opencode_binary() {
 # Something outside our control (unknown process, worker side-effect)
 # periodically upgrades opencode to @latest. This guard runs on every
 # canary check and reinstalls the pinned version if it drifted.
-# Cheap: one `opencode --version` + optional npm install and verification.
+# Cheap: one `opencode --version` + optional package-managed repair and
+# verification.
 # Returns non-zero when repair fails or the installed runtime remains drifted,
 # allowing every headless launch path to fail closed before starting a worker.
 #######################################
@@ -1546,7 +1547,12 @@ _enforce_opencode_version_pin() {
 	fi
 
 	print_warning "OpenCode version drift: installed=$installed, pin=$pin -- reinstalling"
-	if ! npm install -g "opencode-ai@${pin}" >/dev/null 2>&1; then
+	local repair_cmd=""
+	if ! repair_cmd=$(aidevops_opencode_upgrade_command "$pin"); then
+		print_error "Cannot build OpenCode ${pin} repair command -- refusing headless launch"
+		return 1
+	fi
+	if ! AIDEVOPS_OPENCODE_BIN="$OPENCODE_BIN_DEFAULT" bash -c "$repair_cmd" >/dev/null 2>&1; then
 		print_error "Failed to restore OpenCode to ${pin} -- refusing headless launch"
 		return 1
 	fi

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -145,10 +145,39 @@ aidevops_ensure_pulse_start_epoch() {
 # Set to "latest" to resume tracking upstream. Grep for the variable name to
 # find all consumers that need updating when unpinning.
 
-# GH#28766: OpenCode 1.18.7 stalls Linux headless workers while bootstrapping
-# location services with an isolated XDG_DATA_HOME. Keep the last verified
-# working release until a newer version passes that same headless smoke test.
-readonly OPENCODE_PINNED_VERSION="1.18.5"
+# GH#28766: OpenCode 1.18.7 stalled Linux headless workers while bootstrapping
+# location services with an isolated XDG_DATA_HOME. GH#28892 advances the pin
+# after 1.18.9 passed the current isolated headless canary.
+readonly OPENCODE_PINNED_VERSION="1.18.9"
+
+# Build the package-manager-aware OpenCode repair command used by both routine
+# tool updates and the fail-closed headless version guard. The optional
+# AIDEVOPS_OPENCODE_BIN environment variable lets callers preserve an already
+# resolved binary path that is not present on PATH.
+aidevops_opencode_upgrade_command() {
+	local pkg_version="$1"
+
+	# shellcheck disable=SC2016  # Single quotes intentional: bash -c payload
+	printf '%s' \
+		'r="${AIDEVOPS_OPENCODE_BIN:-}"; [[ -n "$r" ]] || r=$(command -v opencode 2>/dev/null || printf ""); ' \
+		'if [[ -n "$r" ]]; then ' \
+		'if command -v brew >/dev/null 2>&1; then ' \
+		'r_dir=$(cd "$(dirname "$r")" 2>/dev/null && pwd -P || printf ""); ' \
+		'r_link=$(readlink "$r" 2>/dev/null || printf ""); r_real="$r"; ' \
+		'if [[ -n "$r_link" ]]; then case "$r_link" in /*) r_real="$r_link" ;; *) r_real="$r_dir/$r_link" ;; esac; fi; ' \
+		'r_real_dir=$(cd "$(dirname "$r_real")" 2>/dev/null && pwd -P || printf ""); ' \
+		'brew_formula_real=""; ' \
+		'if brew list --versions opencode >/dev/null 2>&1; then ' \
+		'brew_formula=$(brew --prefix opencode 2>/dev/null || printf ""); ' \
+		'[[ -d "$brew_formula" ]] && brew_formula_real=$(cd "$brew_formula" && pwd -P || printf ""); ' \
+		'fi; ' \
+		'if [[ -n "$brew_formula_real" ]] && { [[ "$r_dir" == "$brew_formula_real"/* ]] || [[ "$r_real_dir" == "$brew_formula_real"/* ]]; }; then ' \
+		'brew upgrade opencode || brew reinstall opencode; exit $?; ' \
+		'fi; fi; ' \
+		'if [[ "$r" == *bun* ]]; then bun install -g opencode-ai@'"${pkg_version}"'; else npm install -g opencode-ai@'"${pkg_version}"'; fi; ' \
+		'else printf "OpenCode binary not found for repair\\n" >&2; exit 1; fi'
+	return 0
+}
 
 # Minimum GitHub CLI version required for `gh api --paginate --slurp`.
 # Older distro packages can parse `gh` as installed while dispatch paths fail

--- a/.agents/scripts/tests/test-tool-version-check-opencode.sh
+++ b/.agents/scripts/tests/test-tool-version-check-opencode.sh
@@ -79,7 +79,7 @@ extract_function
 printf 'Test 0: OpenCode remains pinned to the last verified headless release\n'
 # shellcheck source=../shared-constants.sh
 source "$SHARED_CONSTANTS"
-assert_eq "OpenCode headless regression pin" "1.18.5" "$OPENCODE_PINNED_VERSION"
+assert_eq "OpenCode headless regression pin" "1.18.9" "$OPENCODE_PINNED_VERSION"
 
 printf 'Test 1: Homebrew OpenCode chooses brew instead of npm\n'
 mkdir -p "$SANDBOX/opt/homebrew/bin" "$SANDBOX/opt/homebrew/Cellar/opencode/1.15.10/bin" "$SANDBOX/opt/homebrew/opt" "$SANDBOX/homebrew-case"
@@ -162,27 +162,28 @@ printf "npm %s\n" "$*" >>"'"$SANDBOX"'/npm-case/calls"'
 assert_eq "npm OpenCode upgrade command" "npm install -g opencode-ai@1.15.10" "$(tr '\n' ';' <"$SANDBOX/npm-case/calls" | sed 's/;$//')"
 
 printf 'Test 4: headless version guard restores the pinned release\n'
-mkdir -p "$SANDBOX/version-guard"
+mkdir -p "$SANDBOX/version-guard/runtime" "$SANDBOX/version-guard/bin"
 # shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
-write_executable "$SANDBOX/version-guard/opencode" '#!/usr/bin/env bash
+write_executable "$SANDBOX/version-guard/runtime/opencode" '#!/usr/bin/env bash
 version=$(<"'"$SANDBOX"'/version-guard/version")
 printf "%s\n" "$version"'
 # shellcheck disable=SC2016 # Literal stub body; quoted SANDBOX segments are expanded by the outer script.
-write_executable "$SANDBOX/version-guard/npm" '#!/usr/bin/env bash
+write_executable "$SANDBOX/version-guard/bin/npm" '#!/usr/bin/env bash
 printf "%s\n" "$*" >>"'"$SANDBOX"'/version-guard/calls"
-printf "1.18.5\n" >"'"$SANDBOX"'/version-guard/version"'
+printf "1.18.9\n" >"'"$SANDBOX"'/version-guard/version"'
 printf '1.18.7\n' >"$SANDBOX/version-guard/version"
 guard_rc=0
 (
 	source_extracted
-	OPENCODE_BIN_DEFAULT="$SANDBOX/version-guard/opencode"
+	OPENCODE_BIN_DEFAULT="$SANDBOX/version-guard/runtime/opencode"
 	print_warning() { return 0; }
 	print_info() { return 0; }
 	print_error() { return 0; }
-	PATH="$SANDBOX/version-guard:$SYSTEM_PATH" _enforce_opencode_version_pin
+	PATH="$SANDBOX/version-guard/bin:$SYSTEM_PATH" _enforce_opencode_version_pin
 ) || guard_rc=$?
 assert_eq "headless pin repair status" "0" "$guard_rc"
-assert_eq "headless pin reinstall command" "install -g opencode-ai@1.18.5" "$(tr '\n' ';' <"$SANDBOX/version-guard/calls" | sed 's/;$//')"
+assert_eq "headless repair uses resolved binary outside PATH" "1.18.9" "$("$SANDBOX/version-guard/runtime/opencode")"
+assert_eq "headless pin reinstall command" "install -g opencode-ai@1.18.9" "$(tr '\n' ';' <"$SANDBOX/version-guard/calls" | sed 's/;$//')"
 
 printf 'Test 5: headless version guard fails closed when reinstall fails\n'
 mkdir -p "$SANDBOX/version-install-failure"
@@ -221,7 +222,7 @@ assert_eq "headless post-repair mismatch status" "1" "$guard_rc"
 printf 'Test 7: headless version guard rejects a failed version probe\n'
 mkdir -p "$SANDBOX/version-probe-failure"
 write_executable "$SANDBOX/version-probe-failure/opencode" '#!/usr/bin/env bash
-printf "1.18.5\n"
+printf "1.18.9\n"
 exit 3'
 write_executable "$SANDBOX/version-probe-failure/npm" '#!/usr/bin/env bash
 exit 0'

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -78,25 +78,9 @@ done
 # $1 = OpenCode package version to install with bun/npm when not Homebrew-owned.
 _opencode_upgrade_cmd() {
 	local pkg_version="$1"
-
-	# shellcheck disable=SC2016  # Single quotes intentional: bash -c payload
-	printf '%s' \
-		'if r=$(command -v opencode 2>/dev/null); then ' \
-		'if command -v brew >/dev/null 2>&1; then ' \
-		'r_dir=$(cd "$(dirname "$r")" 2>/dev/null && pwd -P || printf ""); ' \
-		'r_link=$(readlink "$r" 2>/dev/null || printf ""); r_real="$r"; ' \
-		'if [[ -n "$r_link" ]]; then case "$r_link" in /*) r_real="$r_link" ;; *) r_real="$r_dir/$r_link" ;; esac; fi; ' \
-		'r_real_dir=$(cd "$(dirname "$r_real")" 2>/dev/null && pwd -P || printf ""); ' \
-		'brew_formula_real=""; ' \
-		'if brew list --versions opencode >/dev/null 2>&1; then ' \
-		'brew_formula=$(brew --prefix opencode 2>/dev/null || printf ""); ' \
-		'[[ -d "$brew_formula" ]] && brew_formula_real=$(cd "$brew_formula" && pwd -P || printf ""); ' \
-		'fi; ' \
-		'if [[ -n "$brew_formula_real" ]] && { [[ "$r_dir" == "$brew_formula_real"/* ]] || [[ "$r_real_dir" == "$brew_formula_real"/* ]]; }; then ' \
-		'brew upgrade opencode || brew reinstall opencode; exit $?; ' \
-		'fi; fi; ' \
-		'if [[ "$r" == *bun* ]]; then bun install -g opencode-ai@'"${pkg_version}"'; else npm install -g opencode-ai@'"${pkg_version}"'; fi; ' \
-		'fi'
+	if ! aidevops_opencode_upgrade_command "$pkg_version"; then
+		return 1
+	fi
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Advance the verified OpenCode pin to 1.18.9 and share package-manager-aware repair logic between routine updates and the fail-closed headless guard.

## Files Changed

.agents/scripts/headless-runtime-lib.sh, .agents/scripts/shared-constants.sh, .agents/scripts/tests/test-tool-version-check-opencode.sh, .agents/scripts/tool-version-check.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Forced isolated OpenCode 1.18.9 canary; 11 version-policy tests; 38 installer tests; targeted ShellCheck; linters-local.sh. A pre-existing test-setup-opencode-cli.sh ephemeral-fixture failure reproduces on origin/main and is tracked separately.

Resolves #28892


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.197 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 35m and 289,884 tokens on this with the user in an interactive session.