### PR TITLE
GH#28893: Preserve ownership contract in manual dispatch

### DIFF
--- a/.agents/automate.md
+++ b/.agents/automate.md
@@ -32,7 +32,7 @@ You dispatch workers, merge PRs, coordinate scheduled tasks, and monitor backgro
 
 ## Quick Reference
 
-- Dispatch: `headless-runtime-helper.sh run --role worker --session-key KEY --dir PATH --title TITLE --prompt PROMPT &`
+- Issue dispatch: `dispatch-single-issue-helper.sh dispatch NUMBER OWNER/REPO`
 - Merge: `gh pr merge NUMBER --repo SLUG --squash`
 - Issue: `gh issue edit NUMBER --repo SLUG --add-label LABEL`
 - Config: `config.jsonc` (authoritative via `config_get()`), NOT `settings.json`
@@ -48,19 +48,19 @@ You dispatch workers, merge PRs, coordinate scheduled tasks, and monitor backgro
 
 ## Dispatch Protocol
 
-Never use raw `opencode run` or `claude` CLI — always use the headless runtime helper:
+Never use raw `opencode run`, `claude`, or the low-level headless runtime helper
+for issue-backed work. Use the single-issue dispatcher so ownership ceremony,
+deduplication, worktree creation, and runner identity transport stay coupled:
 
 ```bash
-~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
-  --role worker \
-  --session-key "issue-NUMBER" \
-  --dir PATH \
-  --title "Issue #NUMBER: TITLE" \
-  --prompt "/full-loop Implement issue #NUMBER (URL) -- DESCRIPTION" &
+~/.aidevops/agents/scripts/dispatch-single-issue-helper.sh dispatch NUMBER OWNER/REPO
 sleep 2  # between dispatches
-# --model only for escalation after 2+ failures: --model anthropic/claude-opus-4-6
-# Helper handles round-robin, backoff, session persistence; validate launch, re-dispatch on failure
+# Add --model only for an exact compatibility override after repeated failures.
+# The dispatcher launches detached and reports its worktree, log, and session key.
 ```
+
+For non-issue headless jobs only, invoke `headless-runtime-helper.sh run`
+directly; it handles provider rotation, backoff, and session persistence.
 
 ## Agent Routing
 

--- a/.agents/reference/agent-routing.md
+++ b/.agents/reference/agent-routing.md
@@ -5,7 +5,7 @@
 
 ## Core rule
 
-Dispatch workers with `headless-runtime-helper.sh run`, not bare runtime CLIs. The helper provides provider rotation, session persistence, backoff, and lifecycle reinforcement. Bare `claude run`, `claude`, `claude -p`, or similar commands can skip lifecycle reinforcement and stop after PR creation (GH#5096).
+Dispatch issue-backed workers with `dispatch-single-issue-helper.sh dispatch NUMBER OWNER/REPO`. It performs deduplication and ownership ceremony, creates the worktree, and forwards the verified runner identity to `headless-runtime-helper.sh`. Use `headless-runtime-helper.sh run` directly only for non-issue headless jobs. Never use bare runtime CLIs: they skip lifecycle reinforcement and can stop after PR creation (GH#5096).
 
 Capability cataloguing is not evidence of live usability. Before routing work that depends on an external tool or service, run `scripts/capability-readiness-helper.py route <capability> --runtime <opencode|claude-code>`. Mandatory dimensions that are false **or unknown** force the declared fallback; the structured response reports the reason and coverage impact. The canonical contract is `configs/capability-registry.json`; generated inventory: `reference/capability-registry.md`.
 

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -1125,8 +1125,8 @@ _dsi_parse_dispatch_args() {
 			shift
 			;;
 		--no-ceremony)
-			# Skip the pre-launch dispatch ceremony (status:queued + origin:worker
-			# + assignee normalize). Default: ceremony is ON. Use only when
+			# Skip the pre-launch dispatch ceremony (status:queued + assignee
+			# normalization). Default: ceremony is ON. Use only when
 			# you intentionally want to bypass dedup-visibility — e.g., when
 			# debugging a stuck worker by re-launching without disturbing
 			# the existing label/assignee state.
@@ -1201,7 +1201,7 @@ _dsi_print_dryrun() {
 	if [[ "$_DSI_ARG_NO_CEREMONY" -eq 1 ]]; then
 		_dsi_info "  Ceremony:     SKIPPED (--no-ceremony) — labels and assignee unchanged"
 	else
-		_dsi_info "  Ceremony:     would set status:queued + origin:worker + assignee=self (pulse-parity)"
+		_dsi_info "  Ceremony:     would set status:queued + assignee=self (pulse-parity)"
 	fi
 	case "$dedup_state" in
 	blocked) _dsi_warn "  Dedup:        WOULD BLOCK — ${dedup_result}" ;;
@@ -1692,8 +1692,8 @@ Options:
   --base <ref>    Worktree base branch/ref. Default: repo dispatch/PR base
                   policy from config, falling back to origin/HEAD.
   --dry-run       Print planned dispatch without launching.
-  --no-ceremony   Skip the pre-launch ceremony (status:queued + origin:worker
-                  + assignee normalize). Default: ceremony is ON. Use only
+  --no-ceremony   Skip the pre-launch ceremony (status:queued + assignee
+                  normalization). Default: ceremony is ON. Use only
                   when you intentionally want to bypass dedup-visibility.
   -h, --help      Show this help.
 

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -563,14 +563,15 @@ _dsi_repo_path_for_slug() {
 # one. This was the canonical failure mode observed during the 2026-04-27
 # GitHub-search degradation incident on #21406/#21407/#21408.
 #
-# Best-effort — non-fatal if the gh edit fails. The worker still launches;
-# the operator can manually fix labels via `set_issue_status` after the
-# fact. The race-window risk is preferred over refusing to launch.
+# Required for normal issue-backed dispatch. If the ownership mutation fails,
+# dispatch stops before worktree creation or worker launch and releases its
+# consensus claim. Launching without a verifiable owner would make the worker's
+# fail-closed ownership fence reject the same dispatch later.
 #
 # Args:
 #   $1 - issue_number, $2 - repo_slug, $3 - self_login (runner GH login),
 #   $4 - issue_meta_json (.assignees[].login parsed for normalization)
-# Returns: 0 success, 1 gh edit failed (warning emitted)
+# Returns: 0 success, 1 gh edit failed (error emitted)
 #######################################
 _dsi_apply_dispatch_ceremony() {
 	local issue_number="$1"
@@ -593,7 +594,7 @@ _dsi_apply_dispatch_ceremony() {
 	done < <(printf '%s' "$issue_meta_json" | jq -r '.assignees[].login // ""')
 
 	if ! set_issue_status "$issue_number" "$repo_slug" "queued" "${_extra_flags[@]}" >/dev/null 2>&1; then
-		_dsi_warn "Dispatch ceremony failed (non-fatal — worker will still launch; fix labels manually if needed)"
+		_dsi_err "Dispatch ceremony failed — refusing to launch without a verified issue owner"
 		return 1
 	fi
 
@@ -1533,7 +1534,10 @@ _dsi_dispatch_after_dedup_clear() {
 	local self_login="$3"
 	local session_key="$4"
 
-	_dsi_apply_prelaunch_ceremony_if_enabled "$issue_number" "$repo_slug" "$self_login"
+	if ! _dsi_apply_prelaunch_ceremony_if_enabled "$issue_number" "$repo_slug" "$self_login"; then
+		_dsi_reset_after_prelaunch_failure "$issue_number" "$repo_slug" "$self_login" "dispatch_ceremony_failed"
+		return 1
+	fi
 
 	# Step 7: pre-create worktree
 	if ! _dsi_create_worktree "$issue_number" "$repo_slug"; then
@@ -1565,11 +1569,14 @@ _dsi_apply_prelaunch_ceremony_if_enabled() {
 
 	# Step 5.5: pre-launch dispatch ceremony (t3000) — pulse-parity ownership
 	# claim. Closes the race window between worker launch and the next pulse
-	# cycle by transitioning status:queued + origin:worker + assignee=self
-	# atomically before the worker spawns. Bypassed via --no-ceremony.
-	if [[ "$_DSI_ARG_NO_CEREMONY" -ne 1 ]]; then
-		_dsi_apply_dispatch_ceremony "$issue_number" "$repo_slug" \
-			"$self_login" "$_DSI_ISSUE_META_JSON" || true
+	# cycle by transitioning status:queued + assignee=self atomically before
+	# the worker spawns. Bypassed only via explicit --no-ceremony.
+	if [[ "$_DSI_ARG_NO_CEREMONY" -eq 1 ]]; then
+		return 0
+	fi
+	if ! _dsi_apply_dispatch_ceremony "$issue_number" "$repo_slug" \
+		"$self_login" "$_DSI_ISSUE_META_JSON"; then
+		return 1
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
 # Tests for dispatch-single-issue-helper.sh — focused on the t3000
-# `_dsi_apply_dispatch_ceremony` function which mirrors the canonical pulse
+# fail-closed dispatch ceremony which mirrors the canonical pulse
 # `_dlw_assign_and_label` ownership-claim sequence.
 #
 # Background: the manual single-issue dispatch CLI was previously launching
@@ -446,12 +446,56 @@ test_ceremony_handles_set_issue_status_failure() {
 	local rc=0
 	_dsi_apply_dispatch_ceremony 1 owner/repo runner-self "$issue_meta" >/dev/null 2>&1 || rc=$?
 
-	# When set_issue_status fails (e.g. gh API error), ceremony returns 1
-	# but does NOT propagate set -e — caller treats it as best-effort.
+	# When set_issue_status fails (e.g. gh API error), ceremony returns 1 so
+	# the caller can stop before creating a worktree or launching a worker.
 	local rc_check=1
 	[[ "$rc" -eq 1 ]] && rc_check=0
 	print_result "ceremony returns 1 when set_issue_status fails" "$rc_check"
 
+	return 0
+}
+
+test_ceremony_failure_blocks_launch_and_releases_claim() {
+	reset_test_state
+	_install_mock_set_issue_status success
+	local test_dir=""
+	test_dir=$(mktemp -d)
+	local release_log="${test_dir}/release.log"
+	local worktree_log="${test_dir}/worktree.log"
+	local launch_log="${test_dir}/launch.log"
+	local rc=0
+
+	(
+		_DSI_ARG_NO_CEREMONY=0
+		_DSI_ISSUE_META_JSON='{"assignees":[]}'
+		_dsi_apply_dispatch_ceremony() { return 1; }
+		_dsi_release_consensus_claim() {
+			printf 'released\n' >"$release_log"
+			return 0
+		}
+		_dsi_create_worktree() {
+			printf 'created\n' >"$worktree_log"
+			return 0
+		}
+		_dsi_launch_and_report() {
+			printf 'launched\n' >"$launch_log"
+			return 0
+		}
+		_dsi_dispatch_after_dedup_clear 1 owner/repo runner-self session-key >/dev/null 2>&1
+	) || rc=$?
+
+	local blocked=1
+	[[ "$rc" -eq 1 && -f "$release_log" && ! -e "$worktree_log" && ! -e "$launch_log" ]] && blocked=0
+	print_result "ceremony failure releases claim before worktree creation or worker launch" "$blocked" \
+		"rc=$rc release=$([[ -f "$release_log" ]] && printf yes || printf no) worktree=$([[ -e "$worktree_log" ]] && printf yes || printf no) launch=$([[ -e "$launch_log" ]] && printf yes || printf no)"
+
+	local reset_logged=""
+	reset_logged=$(<"$SET_ISSUE_STATUS_LOG")
+	local reset_ok=1
+	[[ "$reset_logged" == *"set_issue_status 1 owner/repo available --remove-assignee runner-self"* ]] && reset_ok=0
+	print_result "ceremony failure restores available status and removes dispatcher assignee" "$reset_ok" "$reset_logged"
+
+	rm -rf "$test_dir"
 	return 0
 }
 
@@ -1379,6 +1423,7 @@ _run_tests() {
 	test_ceremony_handles_empty_assignees
 	test_ceremony_handles_empty_self_login
 	test_ceremony_handles_set_issue_status_failure
+	test_ceremony_failure_blocks_launch_and_releases_claim
 	test_no_ceremony_flag_parses_correctly
 	test_model_override_guidance_is_provider_neutral
 	test_load_issue_meta_accepts_lowercase_open

--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -33,7 +33,7 @@ tools:
 **Draft agents**: Share domain instructions across workers via `~/.aidevops/agents/draft/`. See `tools/build-agent/build-agent.md`.
 **Remote dispatch**: `tools/containers/remote-dispatch.md` (SSH/Tailscale with credential forwarding).
 
-> **Never use bare `opencode run` for dispatch** — skips lifecycle reinforcement, workers stop after PR creation (GH#5096). Always use `headless-runtime-helper.sh run`.
+> **Issue-backed workers:** use `dispatch-single-issue-helper.sh dispatch NUMBER OWNER/REPO`. It keeps ownership ceremony and runner identity transport coupled. Use `headless-runtime-helper.sh run` directly only for non-issue jobs; never use bare `opencode run` for managed dispatch (GH#5096).
 
 <!-- AI-CONTEXT-END -->
 
@@ -67,10 +67,9 @@ opencode run -c "Continue" | -s ses_abc123 "Add handling"   # resume session
 **Stagger manual launches by 30-60s** to avoid thundering herd (RAM exhaustion, API rate limiting, MCP cold boot storms). Pulse supervisor handles staggering automatically (`RAM_PER_WORKER_MB`, `RAM_RESERVE_MB`, `MAX_WORKERS_CAP`).
 
 ```bash
-HELPER="$(aidevops config get paths.agents_dir | sed "s|^~|$HOME|")/scripts/headless-runtime-helper.sh"
+HELPER="$(aidevops config get paths.agents_dir | sed "s|^~|$HOME|")/scripts/dispatch-single-issue-helper.sh"
 for issue in 42 43 44; do
-  $HELPER run --role worker --session-key "issue-${issue}" --dir ~/Git/myproject \
-    --title "Issue #${issue}" --prompt "/full-loop Implement issue #${issue}" &
+	$HELPER dispatch "$issue" owner/repo
   sleep 30
 done
 ```


### PR DESCRIPTION
## Summary

Route documented issue-backed launches through the single-issue dispatcher and stop before worktree creation or spawn when ownership ceremony fails.

## Files Changed

.agents/automate.md, .agents/reference/agent-routing.md, .agents/scripts/dispatch-single-issue-helper.sh, .agents/scripts/tests/test-dispatch-single-issue-helper.sh, .agents/tools/ai-assistants/headless-dispatch.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 76 dispatch-helper tests passed; headless-runtime worktree contract tests passed; targeted ShellCheck and linters-local passed.

Resolves #28893


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.197 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 55m and 523,241 tokens on this with the user in an interactive session.