### PR TITLE
GH#28896: fix: accept explicit no-required-check evidence

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -77,11 +77,15 @@ _full_loop_persist_pr_check_evidence() {
 _full_loop_query_required_checks() {
 	local pr_number="$1"
 	local repo="$2"
+	local pr_head_ref="$3"
 	local required_contexts=""
+	local required_contexts_rc=0
 	local required_checks=""
 	local required_rc=0
 	local required_checks_stderr=""
 	local required_checks_stderr_file=""
+	local minimum_check_count=1
+	local expected_no_required_checks="no required checks reported on the '${pr_head_ref}' branch"
 
 	FULL_LOOP_REQUIRED_CHECKS_JSON=""
 	FULL_LOOP_REQUIRED_CHECKS_ERROR_EVIDENCE="unavailable"
@@ -89,8 +93,8 @@ _full_loop_query_required_checks() {
 	FULL_LOOP_REQUIRED_CHECKS_SUCCESS_EVIDENCE="required-checks-pass"
 	FULL_LOOP_REQUIRED_CHECKS_SUCCESS_SUMMARY="required checks are terminal-success"
 
-	required_contexts=$(_required_contexts_for_default_branch "$repo") || return 1
-	if [[ -z "$required_contexts" ]]; then
+	required_contexts=$(_required_contexts_for_default_branch "$repo") || required_contexts_rc=$?
+	if [[ "$required_contexts_rc" -eq 0 && -z "$required_contexts" ]]; then
 		FULL_LOOP_REQUIRED_CHECKS_JSON="[]"
 		FULL_LOOP_REQUIRED_CHECKS_SUCCESS_EVIDENCE="no-required-checks"
 		FULL_LOOP_REQUIRED_CHECKS_SUCCESS_SUMMARY="no required checks are configured"
@@ -108,11 +112,16 @@ _full_loop_query_required_checks() {
 	rm -f "$required_checks_stderr_file"
 	FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="gh exit ${required_rc}"
 
-	if [[ -n "$required_checks_stderr" || ("$required_rc" -ne 0 && "$required_rc" -ne 1 && "$required_rc" -ne 8) ]]; then
+	if [[ "$required_rc" -eq 1 && -z "$required_checks" && -n "$pr_head_ref" && "$required_checks_stderr" == "$expected_no_required_checks" ]]; then
+		required_checks="[]"
+		minimum_check_count=0
+		FULL_LOOP_REQUIRED_CHECKS_SUCCESS_EVIDENCE="no-required-checks"
+		FULL_LOOP_REQUIRED_CHECKS_SUCCESS_SUMMARY="no required checks are configured"
+	elif [[ -n "$required_checks_stderr" || ("$required_rc" -ne 0 && "$required_rc" -ne 1 && "$required_rc" -ne 8) ]]; then
 		return 1
 	fi
-	if [[ -z "$required_checks" ]] || ! printf '%s' "$required_checks" | jq -e \
-		'type == "array" and length > 0' >/dev/null 2>&1; then
+	if [[ -z "$required_checks" ]] || ! printf '%s' "$required_checks" | jq -e --argjson minimum "$minimum_check_count" \
+		'type == "array" and length >= $minimum' >/dev/null 2>&1; then
 		return 1
 	fi
 	FULL_LOOP_REQUIRED_CHECKS_JSON="$required_checks"
@@ -194,7 +203,7 @@ _full_loop_verify_pr_readiness() {
 	pr_head_ref=$(printf '%s' "$pr_json" | jq -r '.headRefName // empty')
 
 	local required_checks=""
-	_full_loop_query_required_checks "$pr_number" "$repo" || {
+	_full_loop_query_required_checks "$pr_number" "$repo" "$pr_head_ref" || {
 		FULL_LOOP_PR_CHECK_STATUS="$_FULL_LOOP_CHECK_INDETERMINATE"
 		export FULL_LOOP_PR_CHECK_STATUS
 		_full_loop_persist_pr_check_evidence "$FULL_LOOP_PR_CHECK_STATUS" "$verified_head" "$FULL_LOOP_REQUIRED_CHECKS_ERROR_EVIDENCE" || true

--- a/.agents/scripts/gh-checks-wait-helper.sh
+++ b/.agents/scripts/gh-checks-wait-helper.sh
@@ -98,8 +98,22 @@ PY
 		args+=(--required)
 	fi
 	local rc=0
-	gh "${args[@]}" 2>/dev/null || rc=$?
+	local checks=""
+	local checks_stderr=""
+	local checks_stderr_file=""
+	checks_stderr_file=$(mktemp "${TMPDIR:-/tmp}/aidevops-gh-checks-wait.XXXXXX") || return 1
+	checks=$(gh "${args[@]}" 2>"$checks_stderr_file") || rc=$?
+	checks_stderr=$(<"$checks_stderr_file")
+	rm -f "$checks_stderr_file"
+	if [[ "$required_only" -eq 1 && "$rc" -eq 1 && -z "$checks" && "$checks_stderr" =~ ^no\ required\ checks\ reported\ on\ the\ \'[^\']+\'\ branch$ ]]; then
+		printf '[]\n'
+		return 0
+	fi
+	if [[ -n "$checks_stderr" ]]; then
+		return 1
+	fi
 	if [[ "$rc" -eq 0 || "$rc" -eq 1 || "$rc" -eq 8 ]]; then
+		printf '%s' "$checks"
 		return 0
 	fi
 	return "$rc"

--- a/.agents/scripts/tests/test-full-loop-remote-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-remote-evidence.sh
@@ -28,6 +28,10 @@ if [[ "${1:-}" == "api" && "${2:-}" == "repos/testorg/testrepo" ]]; then
 	exit 0
 fi
 if [[ "${1:-}" == "api" && "${2:-}" == *"/protection/required_status_checks" ]]; then
+	if [[ "${GH_TEST_MODE:-pass}" == "cli-no-required" ]]; then
+		printf '%s\n' 'gh: HTTP 403: branch protection unavailable' >&2
+		exit 1
+	fi
 	if [[ "${GH_TEST_MODE:-pass}" == "no-required" ]]; then
 		printf '%s\n' 'gh: HTTP 404: Not Found' >&2
 		exit 1
@@ -48,6 +52,10 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "checks" ]]; then
 		no-required)
 			printf '%s\n' 'required-check CLI must not run when configuration has no contexts' >&2
 			exit 99
+			;;
+		cli-no-required)
+			printf "%s\n" "no required checks reported on the 'remote-branch' branch" >&2
+			exit 1
 			;;
 		api-error)
 			printf '%s\n' 'HTTP 503: service unavailable' >&2
@@ -129,6 +137,12 @@ run_gate no-required || {
 	exit 1
 }
 printf 'PASS explicit no-required-checks evidence reaches the review-bot gate\n'
+
+run_gate cli-no-required || {
+	printf 'FAIL canonical CLI no-required-checks evidence was rejected after API failure\n'
+	exit 1
+}
+printf 'PASS canonical CLI no-required-checks evidence survives unavailable branch protection\n'
 
 for mode in draft pending changes closed api-error changed-wording malformed empty-array; do
 	if run_gate "$mode"; then

--- a/.agents/scripts/tests/test-gh-checks-wait-helper.sh
+++ b/.agents/scripts/tests/test-gh-checks-wait-helper.sh
@@ -75,6 +75,38 @@ write_fixture "$empty_dir" 1 '[]'
 empty_output=$(run_fixture_wait "$empty_dir")
 assert_contains "no required checks is terminal success" "PASS: required checks completed" "$empty_output"
 
+live_bin="${TMPDIR_TEST}/live-bin"
+mkdir -p "$live_bin"
+cat >"${live_bin}/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "pr" && "${2:-}" == "checks" ]]; then
+	if [[ "${GH_TEST_MODE:-no-required}" == "api-error" ]]; then
+		printf '%s\n' 'HTTP 503: service unavailable' >&2
+		exit 1
+	fi
+	printf "%s\n" "no required checks reported on the 'feature/test' branch" >&2
+	exit 1
+fi
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+	printf '%s\n' 'live-head'
+	exit 0
+fi
+exit 1
+STUB
+chmod +x "${live_bin}/gh"
+
+live_no_required_output=$(PATH="${live_bin}:$PATH" AIDEVOPS_GH_CHECKS_TEST_NO_SLEEP=1 \
+	"$HELPER" wait 123 --repo example/repo --timeout 0 2>&1)
+assert_contains "canonical CLI no-required message is terminal success" "PASS: required checks completed" "$live_no_required_output"
+
+set +e
+live_api_error_output=$(PATH="${live_bin}:$PATH" GH_TEST_MODE=api-error AIDEVOPS_GH_CHECKS_TEST_NO_SLEEP=1 \
+	"$HELPER" wait 123 --repo example/repo --timeout 0 2>&1)
+live_api_error_rc=$?
+set -e
+[[ "$live_api_error_rc" -eq 2 ]] && pass "CLI API error remains indeterminate" || fail "CLI API error remains indeterminate" "got ${live_api_error_rc}"
+assert_contains "CLI API error is diagnosed" "state unavailable" "$live_api_error_output"
+
 mixed_skipping_dir="${TMPDIR_TEST}/mixed-skipping"
 write_fixture "$mixed_skipping_dir" 1 '[{"name":"Required","workflow":"CI","state":"SUCCESS","bucket":"pass","link":""},{"name":"Optional","workflow":"CI","state":"SKIPPED","bucket":"skipping","link":""}]'
 mixed_skipping_output=$(run_fixture_wait "$mixed_skipping_dir")


### PR DESCRIPTION
## Summary

Accept GitHub CLI's canonical no-required-check response when branch-protection lookup is unavailable, while preserving fail-closed handling for arbitrary empty output and API failures.

## Files Changed

.agents/scripts/full-loop-helper-commit.sh, .agents/scripts/gh-checks-wait-helper.sh, .agents/scripts/tests/test-full-loop-remote-evidence.sh, .agents/scripts/tests/test-gh-checks-wait-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-full-loop-remote-evidence.sh; bash .agents/scripts/tests/test-gh-checks-wait-helper.sh; shellcheck .agents/scripts/full-loop-helper-commit.sh .agents/scripts/gh-checks-wait-helper.sh .agents/scripts/tests/test-full-loop-remote-evidence.sh .agents/scripts/tests/test-gh-checks-wait-helper.sh

Resolves #28896


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.197 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 4m and 67,657 tokens on this as a headless worker.