### PR TITLE
GH#28888: fix(sync-workflows): isolate PR output from diagnostics

### DIFF
--- a/.agents/scripts/sync-workflows-helper.sh
+++ b/.agents/scripts/sync-workflows-helper.sh
@@ -1182,18 +1182,42 @@ _sync_open_pr() {
 			"$_slug" "$_status" "$_STATUS_FAILED"
 		return 1
 	}
-	local _pr_url
+	local _stderr_file
+	_stderr_file=$(mktemp "${_body_file%/*}/sync-workflows-pr-stderr.XXXXXX") || {
+		rm -f "$_body_file"
+		printf '%s\t%s\t%s\tPR diagnostic-file creation failed\n' \
+			"$_slug" "$_status" "$_STATUS_FAILED"
+		return 1
+	}
+	local _pr_url _pr_stderr _failure_detail
 	if ! _pr_url=$(gh_create_pr \
 		--repo "$_slug" \
 		--title "$_pr_title" \
 		--body-file "$_body_file" \
 		--head "$_branch_name" \
-		--base "$_default_branch" 2>&1); then
-		rm -f "$_body_file"
-		printf '%s\t%s\t%s\tgh_create_pr failed: %s\n' "$_slug" "$_status" "$_STATUS_FAILED" "$_pr_url"
+		--base "$_default_branch" 2>"$_stderr_file"); then
+		_pr_stderr=$(<"$_stderr_file")
+		[[ -s "$_stderr_file" ]] && command cat "$_stderr_file" >&2
+		_failure_detail=$(printf '%s %s' "$_pr_url" "$_pr_stderr" |
+			tr '\t\r\n' '   ' |
+			sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//' |
+			cut -c1-500)
+		[[ -n "$_failure_detail" ]] || _failure_detail="no diagnostic output"
+		rm -f "$_body_file" "$_stderr_file"
+		printf '%s\t%s\t%s\tgh_create_pr failed: %s\n' \
+			"$_slug" "$_status" "$_STATUS_FAILED" "$_failure_detail"
 		return 1
 	fi
-	rm -f "$_body_file"
+	[[ -s "$_stderr_file" ]] && command cat "$_stderr_file" >&2
+	_pr_url=$(printf '%s' "$_pr_url" |
+		tr '\t\r\n' '   ' |
+		sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')
+	rm -f "$_body_file" "$_stderr_file"
+	if [[ -z "$_pr_url" ]]; then
+		printf '%s\t%s\t%s\tgh_create_pr returned empty stdout\n' \
+			"$_slug" "$_status" "$_STATUS_FAILED"
+		return 1
+	fi
 	printf '%s\t%s\t%s\tPR: %s\n' "$_slug" "$_status" "$_STATUS_APPLIED" "$_pr_url"
 	return 0
 }

--- a/.agents/scripts/tests/test-sync-workflows-install-missing.sh
+++ b/.agents/scripts/tests/test-sync-workflows-install-missing.sh
@@ -86,6 +86,7 @@ if [[ "${1:-} ${2:-}" == "pr list" ]]; then
 fi
 if [[ "${1:-} ${2:-}" == "pr create" ]]; then
 	printf 'mock-pr\n'
+	printf 'mock benign PR diagnostic\n' >&2
 	exit 0
 fi
 if [[ "${1:-}" != "api" ]]; then
@@ -241,6 +242,10 @@ apply_output=$(HOME="$test_root" PATH="$safe_path" \
 apply_rc=$?
 assert_exit "apply-mode missing install succeeds" 0 "$apply_rc"
 assert_contains "apply-mode reports repository PR" "$apply_output" 'PR: mock-pr'
+assert_contains "apply-mode retains benign PR diagnostics" "$apply_output" \
+	'mock benign PR diagnostic'
+assert_not_contains "apply-mode keeps diagnostics out of PR detail" "$apply_output" \
+	$'PR: mock-pr\nmock benign PR diagnostic'
 
 applied_workflow=$("$real_git" --git-dir="$apply_bare" show \
 	'chore/test-issue-first:.github/workflows/linked-issue-check.yml')


### PR DESCRIPTION
## Summary

Capture gh_create_pr stdout separately from bounded stderr diagnostics, preserve operator warnings, reject empty successful stdout, and keep result rows single-line.

## Files Changed

.agents/scripts/sync-workflows-helper.sh, .agents/scripts/tests/test-sync-workflows-install-missing.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-sync-workflows-install-missing.sh; shellcheck target helper and regression test; .agents/scripts/linters-local.sh --changed

Resolves #28888


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.197 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 8m and 88,217 tokens on this as a headless worker.