### PR TITLE
GH#28897: fix: recover stale worker draft checkpoints

### DIFF
--- a/.agents/scripts/dispatch-dedup-pr.sh
+++ b/.agents/scripts/dispatch-dedup-pr.sh
@@ -89,10 +89,14 @@ _has_open_pr_check_healthy_sibling() {
 	local issue_number="$1"
 	local repo_slug="$2"
 
-	local pr_json match_pr draft_pr
+	local pr_json match_pr draft_pr draft_pr_number draft_pr_kind
 	pr_json=$(gh pr list --repo "$repo_slug" --state open \
 		--search "#${issue_number}" --limit 20 \
-		--json number,title,body,isDraft,reviewDecision,mergeStateStatus,mergeable,changedFiles,files 2>/dev/null) || pr_json="[]"
+		--json number,title,body,isDraft,reviewDecision,mergeStateStatus,mergeable,changedFiles,files,labels 2>/dev/null) || {
+		printf 'PR_LOOKUP_UNCERTAIN: open PR lookup failed for issue #%s in %s; dispatch is blocked\n' \
+			"$issue_number" "$repo_slug"
+		return 0
+	}
 
 	local issue_ref_pattern healthy_state_pattern blocked_state_pattern
 	issue_ref_pattern="([^[:alnum:]_]|^)((close[sd]?|fix(e[sd])?|resolve[sd]?|for|refs?):?[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}|GH#${issue_number}|#${issue_number})([^[:alnum:]_]|$)"
@@ -101,14 +105,30 @@ _has_open_pr_check_healthy_sibling() {
 
 	draft_pr=$(printf '%s' "$pr_json" | jq -r \
 		--arg issue_pattern "$issue_ref_pattern" '
+		def names: [.labels[]?.name];
+		def protected: names | any(
+			. == "origin:interactive" or . == "hold-for-review" or
+			. == "no-auto-dispatch" or . == "needs-maintainer-review"
+		);
+		def worker_owned: names | any(. == "origin:worker" or . == "origin:worker-takeover");
 		[
 			.[] | select(
 				(.isDraft == true) and
 				([.title?, .body?] | map(strings) | any(test($issue_pattern; "i")))
 			)
-		] | .[0].number // empty' 2>/dev/null) || draft_pr=""
+		] | .[0] |
+		if . then "\(.number)|\(if worker_owned and (protected | not) then "worker" else "protected" end)"
+		else "" end' 2>/dev/null) || draft_pr=""
 	if [[ -n "$draft_pr" ]]; then
-		printf 'draft PR #%s is a durable checkpoint for issue #%s; ordinary redispatch is blocked\n' "$draft_pr" "$issue_number"
+		draft_pr_number="${draft_pr%%|*}"
+		draft_pr_kind="${draft_pr#*|}"
+		if [[ "$draft_pr_kind" == "worker" ]]; then
+			printf 'WORKER_DRAFT_CHECKPOINT: draft PR #%s is a durable checkpoint for issue #%s; ordinary redispatch is blocked\n' \
+				"$draft_pr_number" "$issue_number"
+			return 0
+		fi
+		printf 'draft PR #%s is a durable checkpoint for issue #%s; ordinary redispatch is blocked\n' \
+			"$draft_pr_number" "$issue_number"
 		return 0
 	fi
 

--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -960,7 +960,6 @@ _is_stale_assignment() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local blocking_assignees="$3"
-
 	local now_epoch
 	now_epoch=$(date +%s)
 

--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -204,7 +204,7 @@ _stale_recovery_find_open_pr() {
 	local _open_pr _open_pr_json
 	_open_pr_json=$(gh pr list --repo "$repo_slug" --state open \
 		--search "#${issue_number} in:body" --limit 20 \
-		--json number,isDraft,labels,statusCheckRollup 2>/dev/null) || _open_pr_json="[]"
+		--json number,isDraft,labels,statusCheckRollup 2>/dev/null) || return 1
 	_open_pr=$(printf '%s' "$_open_pr_json" | jq -r \
 		--arg ready_failed "$_DDS_KIND_READY_FAILED" \
 		--arg ready "$_DDS_KIND_READY" \
@@ -240,7 +240,7 @@ _stale_recovery_find_open_pr() {
 				elif .lifecycle_kind == $ready then 1
 				elif .lifecycle_kind == $draft then 2 else 3 end) |
 			.[0] | if . then "\(.number)|\(.lifecycle_kind)" else "" end' \
-		2>/dev/null) || _open_pr=""
+		2>/dev/null) || return 1
 	printf '%s' "$_open_pr"
 	return 0
 }
@@ -652,7 +652,11 @@ _recover_stale_assignment() {
 	_comments_pages=$(_stale_recovery_fetch_comments_pages "$issue_number" "$repo_slug")
 	_prior_ticks=$(_stale_recovery_count_ticks_from_pages "$_comments_pages")
 	_latest_dispatch_ts=$(_stale_recovery_latest_dispatch_ts_from_pages "$_comments_pages")
-	_open_pr=$(_stale_recovery_find_open_pr "$issue_number" "$repo_slug")
+	if ! _open_pr=$(_stale_recovery_find_open_pr "$issue_number" "$repo_slug"); then
+		printf 'STALE_RECOVERY_UNCERTAIN: issue #%s in %s — open PR lookup failed; preserving assignment\n' \
+			"$issue_number" "$repo_slug"
+		return 1
+	fi
 	if [[ -n "$_open_pr" ]]; then
 		_open_pr_number="${_open_pr%%|*}"
 		_open_pr_kind="${_open_pr#*|}"
@@ -1015,7 +1019,8 @@ _is_stale_assignment() {
 			return 1
 		fi
 		# No dispatch comment AND no recent activity — stale
-		_recover_stale_assignment "$issue_number" "$repo_slug" "$blocking_assignees" "no dispatch claim comment found, no recent activity (threshold=${effective_threshold}s, interactive=${is_interactive})"
+		_recover_stale_assignment "$issue_number" "$repo_slug" "$blocking_assignees" \
+			"no dispatch claim comment found, no recent activity (threshold=${effective_threshold}s, interactive=${is_interactive})" || return 1
 		return 0
 	fi
 
@@ -1050,6 +1055,6 @@ _is_stale_assignment() {
 
 	# Both dispatch claim and last activity are older than threshold — stale
 	_recover_stale_assignment "$issue_number" "$repo_slug" "$blocking_assignees" \
-		"dispatch claim ${dispatch_age}s old, last activity ${activity_age_msg} old (threshold=${effective_threshold}s, interactive=${is_interactive})"
+		"dispatch claim ${dispatch_age}s old, last activity ${activity_age_msg} old (threshold=${effective_threshold}s, interactive=${is_interactive})" || return 1
 	return 0
 }

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -190,7 +190,8 @@ has_worker_for_repo_issue() {
 #######################################
 # Thin orchestrator — runs read-only dedup layers in order.
 # Byte-for-byte behavioural equivalent of the pre-GH#18654 single-function
-# implementation. Each layer returns 0 to block dispatch or 1 to continue.
+# implementation. Layers return 0 to block or 1 to continue; Layer 4 returns 2
+# only for a worker draft that must reach stale-assignment recovery first.
 # The optimistic GitHub claim lock runs after the worker canary preflight in
 # _dispatch_launch_worker so a broken local runtime does not publish noisy
 # DISPATCH_CLAIM comments when no worker can start.
@@ -205,7 +206,17 @@ check_dispatch_dedup() {
 	_dedup_layer1_ledger_check "$issue_number" "$repo_slug" && return 0
 	_dedup_layer2_process_match "$issue_number" "$repo_slug" && return 0
 	_dedup_layer3_title_match "$title" && return 0
-	_dedup_layer4_pr_evidence "$issue_number" "$repo_slug" "$issue_title" && return 0
+	local _pr_evidence_rc=0
+	_dedup_layer4_pr_evidence "$issue_number" "$repo_slug" "$issue_title" || _pr_evidence_rc=$?
+	if [[ "$_pr_evidence_rc" -eq 0 ]]; then
+		return 0
+	fi
+	# A verified worker-owned draft is still a hard duplicate-dispatch block,
+	# but its assignment may need the existing stale-checkpoint transition.
+	# Unknown Layer 4 outcomes fail closed rather than weakening PR protection.
+	if [[ "$_pr_evidence_rc" -ne 1 && "$_pr_evidence_rc" -ne 2 ]]; then
+		return 0
+	fi
 	# Active dispatch comments and assignment/claim guards are expected
 	# cross-runner locks, not launch failures. Preserve the block while giving
 	# dispatch_max a distinct benign rc so the stage wrapper suppresses generic
@@ -213,6 +224,7 @@ check_dispatch_dedup() {
 	# current pulse cycle (GH#23541).
 	_dedup_layer5_dispatch_comment "$issue_number" "$repo_slug" "$self_login" && return 3
 	_dedup_layer6_assignee_and_stale "$issue_number" "$repo_slug" "$self_login" && return 3
+	[[ "$_pr_evidence_rc" -eq 2 ]] && return 0
 
 	return 1
 }

--- a/.agents/scripts/pulse-dispatch-dedup-layers.sh
+++ b/.agents/scripts/pulse-dispatch-dedup-layers.sh
@@ -202,7 +202,7 @@ _dedup_layer3_title_match() {
 # If a worker already produced a PR (open or merged), do not dispatch another.
 # Previously only checked --state merged, missing open PRs entirely.
 # Arguments: issue_number, repo_slug, issue_title
-# Exit: 0 = blocked, 1 = continue
+# Exit: 0 = blocked, 1 = continue, 2 = worker draft needs stale-assignment routing
 #######################################
 _dedup_layer4_pr_evidence() {
 	local issue_number="$1"
@@ -216,6 +216,9 @@ _dedup_layer4_pr_evidence() {
 				echo "[pulse-wrapper] Dedup: ${dedup_helper_output}" >>"$LOGFILE"
 			else
 				echo "[pulse-wrapper] Dedup: PR evidence already exists for #${issue_number} in ${repo_slug}" >>"$LOGFILE"
+			fi
+			if [[ "$dedup_helper_output" == WORKER_DRAFT_CHECKPOINT:* ]]; then
+				return 2
 			fi
 			return 0
 		fi

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
@@ -48,6 +48,9 @@ set -euo pipefail
 
 # gh pr list — returns fixture JSON for (repo, state, search) lookup.
 if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
+	if [[ "${GH_PR_LIST_FAIL:-0}" == "1" ]]; then
+		exit 1
+	fi
 	local_repo=""
 	local_state=""
 	local_search=""
@@ -304,6 +307,59 @@ marcusquinn/aidevops|open|#18779 in:body|[{"number":18906,"body":"Resolves #1877
 
 	print_result "has-open-pr blocks competing dispatch for draft checkpoint" 1 \
 		"Expected durable draft checkpoint to block ordinary redispatch"
+	return 0
+}
+
+test_has_open_pr_marks_worker_draft_for_stale_routing() {
+	set_gh_fixtures 'marcusquinn/aidevops|open|#18780|[{"number":18907,"title":"Worker checkpoint for #18780","body":"Resolves #18780. Incomplete worker checkpoint.","isDraft":true,"reviewDecision":"REVIEW_REQUIRED","mergeStateStatus":"UNKNOWN","labels":[{"name":"origin:worker"}]}]'
+
+	local output=""
+	if output=$("$HELPER_SCRIPT" has-open-pr 18780 marcusquinn/aidevops 'worker draft checkpoint'); then
+		if [[ "$output" == WORKER_DRAFT_CHECKPOINT:* ]]; then
+			print_result "has-open-pr marks worker draft for stale routing" 0
+			return 0
+		fi
+		print_result "has-open-pr marks worker draft for stale routing" 1 "Unexpected output: ${output}"
+		return 0
+	fi
+
+	print_result "has-open-pr marks worker draft for stale routing" 1 \
+		"Expected worker draft checkpoint to block ordinary redispatch"
+	return 0
+}
+
+test_has_open_pr_keeps_protected_draft_unroutable() {
+	set_gh_fixtures 'marcusquinn/aidevops|open|#18781|[{"number":18908,"title":"Interactive checkpoint for #18781","body":"Resolves #18781. Held for review.","isDraft":true,"reviewDecision":"REVIEW_REQUIRED","mergeStateStatus":"UNKNOWN","labels":[{"name":"origin:interactive"}]}]'
+
+	local output=""
+	if output=$("$HELPER_SCRIPT" has-open-pr 18781 marcusquinn/aidevops 'protected draft checkpoint'); then
+		if [[ "$output" == *"draft PR #18908 is a durable checkpoint"* && "$output" != WORKER_DRAFT_CHECKPOINT:* ]]; then
+			print_result "has-open-pr keeps protected draft out of stale routing" 0
+			return 0
+		fi
+		print_result "has-open-pr keeps protected draft out of stale routing" 1 "Unexpected output: ${output}"
+		return 0
+	fi
+
+	print_result "has-open-pr keeps protected draft out of stale routing" 1 \
+		"Expected protected draft checkpoint to block ordinary redispatch"
+	return 0
+}
+
+test_has_open_pr_fails_closed_when_sibling_lookup_fails() {
+	export GH_PR_LIST_FAIL=1
+	local output=""
+	local rc=0
+	output=$("$HELPER_SCRIPT" has-open-pr 18782 marcusquinn/aidevops 'lookup uncertainty') || rc=$?
+	unset GH_PR_LIST_FAIL
+
+	if [[ "$rc" -eq 0 && "$output" == PR_LOOKUP_UNCERTAIN:* ]]; then
+		print_result "has-open-pr fails closed when sibling lookup is uncertain" 0
+		return 0
+	fi
+
+	print_result "has-open-pr fails closed when sibling lookup is uncertain" 1 \
+		"rc=${rc} output=${output}"
 	return 0
 }
 
@@ -708,6 +764,9 @@ main() {
 	test_has_open_pr_allows_dispatch_on_task_id_collision
 	test_has_open_pr_detects_open_body_closing_keyword
 	test_has_open_pr_blocks_draft_body_closing_keyword
+	test_has_open_pr_marks_worker_draft_for_stale_routing
+	test_has_open_pr_keeps_protected_draft_unroutable
+	test_has_open_pr_fails_closed_when_sibling_lookup_fails
 	test_has_open_pr_ignores_open_body_planning_for_reference
 	test_has_open_pr_requires_open_close_keyword_for_our_issue
 	test_has_open_pr_blocks_approved_mergeable_sibling

--- a/.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh
@@ -94,6 +94,11 @@ chmod +x "$HELPER_PATH"
 
 # shellcheck source=../pulse-dispatch-dedup-layers.sh
 source "${SCRIPTS_DIR}/pulse-dispatch-dedup-layers.sh"
+# shellcheck source=../pulse-dispatch-core.sh
+source "${SCRIPTS_DIR}/pulse-dispatch-core.sh"
+# Sourced modules use SCRIPT_DIR for their own bootstrap; restore the fixture
+# helper directory used by the Layer 6 tests below.
+SCRIPT_DIR="$TMP_DIR"
 
 FAST_FAIL_CALLS=0
 LAST_FAST_FAIL=""
@@ -279,12 +284,66 @@ test_terminal_pr_checkpoint_routes_existing_consolidation_guard() {
 	return 0
 }
 
+test_worker_draft_checkpoint_reaches_stale_guard_and_stays_blocked() {
+	local result=""
+	result=$(
+		(
+			local calls=""
+			_dedup_layer1_ledger_check() { return 1; }
+			_dedup_layer2_process_match() { return 1; }
+			_dedup_layer3_title_match() { return 1; }
+			_dedup_layer4_pr_evidence() { calls="${calls}4,"; return 2; }
+			_dedup_layer5_dispatch_comment() { calls="${calls}5,"; return 1; }
+			_dedup_layer6_assignee_and_stale() { calls="${calls}6,"; return 1; }
+
+			local rc=0
+			check_dispatch_dedup "2905" "exampleorg/examplerepo" "Issue #2905" "stale draft" "runner" || rc=$?
+			printf '%s|%s' "$rc" "$calls"
+		)
+	)
+
+	if [[ "$result" == "0|4,5,6," ]]; then
+		pass "worker draft checkpoint reaches stale guard and cannot redispatch"
+	else
+		fail "worker draft checkpoint reaches stale guard and cannot redispatch" "result=${result}"
+	fi
+	return 0
+}
+
+test_protected_draft_remains_immediate_pr_block() {
+	local result=""
+	result=$(
+		(
+			local calls=""
+			_dedup_layer1_ledger_check() { return 1; }
+			_dedup_layer2_process_match() { return 1; }
+			_dedup_layer3_title_match() { return 1; }
+			_dedup_layer4_pr_evidence() { calls="${calls}4,"; return 0; }
+			_dedup_layer5_dispatch_comment() { calls="${calls}5,"; return 1; }
+			_dedup_layer6_assignee_and_stale() { calls="${calls}6,"; return 1; }
+
+			local rc=0
+			check_dispatch_dedup "2905" "exampleorg/examplerepo" "Issue #2905" "protected draft" "runner" || rc=$?
+			printf '%s|%s' "$rc" "$calls"
+		)
+	)
+
+	if [[ "$result" == "0|4," ]]; then
+		pass "protected draft remains an immediate PR evidence block"
+	else
+		fail "protected draft remains an immediate PR evidence block" "result=${result}"
+	fi
+	return 0
+}
+
 test_stale_recovery_without_claim_skips_fast_fail
 test_prelaunch_canary_stale_recovery_skips_fast_fail
 test_stale_recovery_with_dispatch_claim_records_fast_fail
 test_stale_recovery_blocked_by_dependency_blocks_redispatch
 test_terminal_stale_recovery_routes_consolidation_and_blocks
 test_terminal_pr_checkpoint_routes_existing_consolidation_guard
+test_worker_draft_checkpoint_reaches_stale_guard_and_stays_blocked
+test_protected_draft_remains_immediate_pr_block
 
 printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]] || exit 1

--- a/.agents/scripts/tests/test-dispatch-dedup-stale-terminal-evidence.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-stale-terminal-evidence.sh
@@ -47,6 +47,7 @@ COMMENTS_JSON='[]'
 ESCALATED=0
 RECOVERED=0
 OPEN_PR_STATE=""
+OPEN_PR_LOOKUP_FAIL=0
 ESCALATION_REASON=""
 COMMENT_BODIES="${TMP_HOME}/comments.log"
 : >"$COMMENT_BODIES"
@@ -85,6 +86,9 @@ set_issue_status() {
 }
 
 _stale_recovery_find_open_pr() {
+	if [[ "$OPEN_PR_LOOKUP_FAIL" -eq 1 ]]; then
+		return 1
+	fi
 	printf '%s' "$OPEN_PR_STATE"
 	return 0
 }
@@ -157,6 +161,24 @@ else
 	fail "stale draft checkpoint escalates without competing redispatch" \
 		"ESCALATED=${ESCALATED} RECOVERED=${RECOVERED} REASON=${ESCALATION_REASON}"
 fi
+
+ESCALATED=0
+RECOVERED=0
+OPEN_PR_STATE=""
+OPEN_PR_LOOKUP_FAIL=1
+
+lookup_output=""
+lookup_rc=0
+lookup_output=$(_recover_stale_assignment 3978 owner/repo runner "worker lease expired") || lookup_rc=$?
+
+if [[ "$lookup_rc" -ne 0 && "$ESCALATED" -eq 0 && "$RECOVERED" -eq 0 && "$lookup_output" == *"STALE_RECOVERY_UNCERTAIN"* ]]; then
+	pass "open PR lookup uncertainty retains stale checkpoint ownership"
+else
+	fail "open PR lookup uncertainty retains stale checkpoint ownership" \
+		"rc=${lookup_rc} ESCALATED=${ESCALATED} RECOVERED=${RECOVERED} output=${lookup_output}"
+fi
+
+OPEN_PR_LOOKUP_FAIL=0
 
 ESCALATED=0
 RECOVERED=0


### PR DESCRIPTION
## Summary

Route verified worker-owned draft PRs through the existing assignee stale-recovery path while preserving duplicate-dispatch protection and failing closed on PR lookup uncertainty.

## Files Changed

.agents/scripts/dispatch-dedup-pr.sh, .agents/scripts/dispatch-dedup-stale.sh, .agents/scripts/pulse-dispatch-core.sh, .agents/scripts/pulse-dispatch-dedup-layers.sh, .agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh, .agents/scripts/tests/test-dispatch-dedup-stale-no-worker.sh, .agents/scripts/tests/test-dispatch-dedup-stale-terminal-evidence.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused has-open-pr, stale terminal evidence, stale no-worker tests, and ShellCheck pass.

Resolves #28897


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.197 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 15m and 165,133 tokens on this as a headless worker.