### PR TITLE
GH#28889: fix(canonical-git): allow read-only diff-tree queries

### DIFF
--- a/.agents/scripts/canonical_git_policy.py
+++ b/.agents/scripts/canonical_git_policy.py
@@ -21,6 +21,7 @@ READ_ONLY = frozenset(
         "status",
         "diff",
         "diff-files",
+        "diff-tree",
         "log",
         "show",
         "rev-parse",

--- a/.agents/scripts/tests/test-canonical-git-command-guard.sh
+++ b/.agents/scripts/tests/test-canonical-git-command-guard.sh
@@ -135,6 +135,8 @@ fi
 
 assert_allowed "allows canonical status" "$REPO" "git status --short"
 assert_allowed "allows canonical diff-files query" "$REPO" "git diff-files --name-only"
+assert_allowed "allows canonical diff-tree query" "$REPO" \
+	"git diff-tree --root --no-commit-id --name-only -r '$INITIAL_HEAD'"
 assert_allowed "allows canonical branch listing" "$REPO" "git branch -vv --no-abbrev"
 assert_allowed "allows canonical branch pattern listing" "$REPO" "git branch --list 'feature/*'"
 assert_allowed "allows canonical branch containment query" "$REPO" "git branch --contains main"


### PR DESCRIPTION
## Summary

Add diff-tree to the canonical Git read-only allowlist and cover the behavior with a focused guard regression assertion.

## Files Changed

.agents/scripts/canonical_git_policy.py, .agents/scripts/tests/test-canonical-git-command-guard.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-canonical-git-command-guard.sh; python3 -m py_compile .agents/scripts/canonical_git_policy.py; .agents/scripts/linters-local.sh --changed

Resolves #28889


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.197 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 2m and 29,808 tokens on this as a headless worker.