### PR TITLE
GH#28894: Improve pulse diagnostic correlation

### DIFF
--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -549,7 +549,7 @@ _render_pr_text() {
 		return 0
 	fi
 
-	local last_rule_id=""
+	local last_rule_id="" unclassified_count=0
 	local entry
 	for entry in "$@"; do
 		if [[ "$entry" == "  RAW: "* ]]; then
@@ -559,7 +559,7 @@ _render_pr_text() {
 
 		local ts rule_id script line_range description
 		IFS='|' read -r ts rule_id script line_range description <<< "$entry"
-
+		[[ "$rule_id" == "unclassified" && "$_CMD_PR_VERBOSE" -ne 1 ]] && { unclassified_count=$((unclassified_count + 1)); continue; }
 		printf '  %s  %b%-30s%b  %s\n' \
 			"$ts" "$YELLOW" "${script:-unknown}" "$NC" "${rule_id:-unclassified}"
 		printf '              %s\n' "$description"
@@ -569,7 +569,7 @@ _render_pr_text() {
 		printf '\n'
 		last_rule_id="$rule_id"
 	done
-
+	[[ "$unclassified_count" -gt 0 ]] && printf '  Unclassified pulse events: %d (use --verbose for raw evidence)\n\n' "$unclassified_count"
 	printf 'Summary:\n'
 	printf '  Total pulse events: %d\n' "$event_count"
 
@@ -998,7 +998,6 @@ _cmd_issue_parse_args() {
 _fetch_issue_metadata() {
 	local issue_number="$1"
 	local repo_slug="$2"
-
 	if [[ "${PULSE_DIAGNOSE_GH_OFFLINE:-0}" == "1" ]]; then
 		echo "{}"
 		return 0
@@ -1040,7 +1039,7 @@ _fetch_issue_comments() {
 }
 
 # Fetch linked PR numbers for an issue via timeline cross-references and
-# worker branch pattern search.
+# bounded open-PR metadata filtering.
 # Args: $1 = issue number, $2 = repo slug
 # Outputs newline-separated PR numbers to stdout.
 _fetch_issue_linked_prs() {
@@ -1056,7 +1055,6 @@ _fetch_issue_linked_prs() {
 	local owner="" repo=""
 	owner="${repo_slug%%/*}"
 	repo="${repo_slug##*/}"
-
 	# Strategy 1: timeline cross-references from PRs that reference this issue
 	# (pipe through jq so the gh stub in tests sees raw JSON)
 	local xref_nums=""
@@ -1064,13 +1062,13 @@ _fetch_issue_linked_prs() {
 		--paginate 2>/dev/null \
 		| jq -r '[.[] | select(.event == "cross-referenced") | select(.source.issue.pull_request != null) | .source.issue.number] | unique | .[]' \
 		2>/dev/null) || xref_nums=""
-
-	# Strategy 2: worker branch naming pattern (feature/auto-*-gh<N>)
+	# Strategy 2: locally filter one bounded open-PR snapshot (including drafts).
 	local branch_prs=""
-	branch_prs=$(gh pr list --repo "$repo_slug" --state all \
-		--search "gh${issue_number} in:head" \
-		--json number --limit 10 2>/dev/null \
-		| jq -r '.[].number' 2>/dev/null) || branch_prs=""
+	branch_prs=$(gh pr list --repo "$repo_slug" --state open \
+		--json number,headRefName --limit 100 2>/dev/null \
+		| jq -r --arg token "gh${issue_number}" \
+			'.[] | select((.headRefName // "") | test("(^|[^[:alnum:]])" + $token + "([^0-9]|$)")) | .number' \
+			2>/dev/null) || branch_prs=""
 
 	{ printf '%s\n' "$xref_nums"; printf '%s\n' "$branch_prs"; } \
 		| grep -E '^[0-9]+$' 2>/dev/null | sort -n | uniq
@@ -1155,7 +1153,7 @@ _render_issue_linked_prs() {
 		printf '  PR #%s  %s  %s\n' "$pr_num" "$pr_state" "${pr_title:-(no title)}"
 		[[ -n "$pr_head" ]] && printf '    Branch: %s\n' "$pr_head"
 		[[ -n "$pr_merged_at" ]] && printf '    Merged: %s\n' "$pr_merged_at"
-		local pr_log_lines="" event_count=0
+		local pr_log_lines="" event_count=0 unclassified_count=0
 		pr_log_lines=$(_collect_pr_log_lines "$pr_num" "$logfile" "$logdir")
 		event_count=0
 		if [[ -n "$pr_log_lines" ]]; then
@@ -1166,10 +1164,12 @@ _render_issue_linked_prs() {
 				ts=$(_extract_timestamp "$log_line")
 				classification=$(_classify_log_line "$log_line")
 				IFS='|' read -r rule_id script_name line_range description <<< "$classification"
+				[[ "$rule_id" == "unclassified" && "$verbose" -ne 1 ]] && { unclassified_count=$((unclassified_count + 1)); continue; }
 				printf '    %s  %b%-25s%b  %s\n' \
 					"$ts" "$CYAN" "${rule_id:-unclassified}" "$NC" "$description"
 				[[ "$verbose" -eq 1 ]] && printf '      RAW: %s\n' "$log_line"
 			done <<< "$pr_log_lines"
+			[[ "$unclassified_count" -gt 0 ]] && printf '    Unclassified pulse events: %d (use --verbose for raw evidence)\n' "$unclassified_count"
 			printf '    (%d pulse events)\n' "$event_count"
 		else
 			printf '    (no pulse log entries for this PR)\n'

--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -53,7 +53,7 @@ readonly DEFAULT_GH_API_LOG="${HOME}/.aidevops/logs/gh-api-calls.log"
 readonly DEFAULT_BLOCKER_LOG="${HOME}/.aidevops/logs/worker-progress-blockers.jsonl"
 readonly DEFAULT_SYSTEMD_TIMER_FILE="${HOME}/.config/systemd/user/aidevops-supervisor-pulse.timer"
 readonly _UNKNOWN="unknown"
-
+readonly _UNCLASSIFIED="unclassified"
 # =============================================================================
 # Rule Inventory (Phase A)
 #
@@ -347,7 +347,7 @@ _classify_log_line() {
 		fi
 	done <<< "$inventory"
 
-	echo "unclassified|||Unclassified pulse log entry"
+	printf '%s|||Unclassified pulse log entry\n' "$_UNCLASSIFIED"
 	return 0
 }
 
@@ -559,9 +559,9 @@ _render_pr_text() {
 
 		local ts rule_id script line_range description
 		IFS='|' read -r ts rule_id script line_range description <<< "$entry"
-		[[ "$rule_id" == "unclassified" && "$_CMD_PR_VERBOSE" -ne 1 ]] && { unclassified_count=$((unclassified_count + 1)); continue; }
+		[[ "$rule_id" == "$_UNCLASSIFIED" && "$_CMD_PR_VERBOSE" -ne 1 ]] && { unclassified_count=$((unclassified_count + 1)); continue; }
 		printf '  %s  %b%-30s%b  %s\n' \
-			"$ts" "$YELLOW" "${script:-unknown}" "$NC" "${rule_id:-unclassified}"
+			"$ts" "$YELLOW" "${script:-unknown}" "$NC" "${rule_id:-$_UNCLASSIFIED}"
 		printf '              %s\n' "$description"
 		if [[ -n "$line_range" ]]; then
 			printf '              source: %s:%s\n' "${script}" "${line_range}"
@@ -573,7 +573,7 @@ _render_pr_text() {
 	printf 'Summary:\n'
 	printf '  Total pulse events: %d\n' "$event_count"
 
-	if [[ -n "$last_rule_id" && "$last_rule_id" != "unclassified" ]]; then
+	if [[ -n "$last_rule_id" && "$last_rule_id" != "$_UNCLASSIFIED" ]]; then
 		printf '  Last pulse decision: %s\n' "$last_rule_id"
 	fi
 
@@ -1164,9 +1164,9 @@ _render_issue_linked_prs() {
 				ts=$(_extract_timestamp "$log_line")
 				classification=$(_classify_log_line "$log_line")
 				IFS='|' read -r rule_id script_name line_range description <<< "$classification"
-				[[ "$rule_id" == "unclassified" && "$verbose" -ne 1 ]] && { unclassified_count=$((unclassified_count + 1)); continue; }
+				[[ "$rule_id" == "$_UNCLASSIFIED" && "$verbose" -ne 1 ]] && { unclassified_count=$((unclassified_count + 1)); continue; }
 				printf '    %s  %b%-25s%b  %s\n' \
-					"$ts" "$CYAN" "${rule_id:-unclassified}" "$NC" "$description"
+					"$ts" "$CYAN" "${rule_id:-$_UNCLASSIFIED}" "$NC" "$description"
 				[[ "$verbose" -eq 1 ]] && printf '      RAW: %s\n' "$log_line"
 			done <<< "$pr_log_lines"
 			[[ "$unclassified_count" -gt 0 ]] && printf '    Unclassified pulse events: %d (use --verbose for raw evidence)\n' "$unclassified_count"

--- a/.agents/scripts/tests/test-pulse-diagnose-helper.sh
+++ b/.agents/scripts/tests/test-pulse-diagnose-helper.sh
@@ -87,6 +87,7 @@ FIXTURE_GH_COOLDOWN="${TMPDIR_TEST}/gh-secondary-cooldown.json"
 FIXTURE_GH_COOLDOWN_EVENTS="${TMPDIR_TEST}/gh-cooldown-events.jsonl"
 FIXTURE_BLOCKERS="${TMPDIR_TEST}/worker-progress-blockers.jsonl"
 export PULSE_DIAGNOSE_BLOCKER_LOG="$FIXTURE_BLOCKERS"
+unset AIDEVOPS_GH_PR_VIEW_CACHE_DIR
 
 # Create fixture pulse.log with 3+ distinct rule outcomes:
 # 1. PR #20329: escalated by dirty-pr-sweep (notify), then admin-bypass merge
@@ -109,6 +110,9 @@ cat > "$FIXTURE_LOGFILE" <<'FIXTURE'
 2026-04-21T19:10:05Z [pulse-wrapper] Per-cycle PR view cache enabled for duplicate repo#PR reads ttl=3600s (GH#23433/GH#23604)
 2026-04-21T19:30:00Z [pulse-dirty-pr-sweep] sweep complete: rebased=1 closed=0 notified=2
 2026-04-21T20:00:00Z [pulse-wrapper] Deterministic merge pass complete: merged=3, closed_conflicting=0, failed=0
+2026-04-21T20:01:00Z [pulse-wrapper] Review bot gate: PASS for PR #28869 in marcusquinn/aidevops
+2026-04-21T20:01:01Z [pulse-mystery] first unknown observation for PR #28869
+2026-04-21T20:01:02Z [pulse-mystery] second unknown observation for PR #28869
 FIXTURE
 
 cat >"$FIXTURE_BLOCKERS" <<'BLOCKERS'
@@ -206,6 +210,12 @@ if [[ "$*" == *"pr view"*"21876"* ]]; then
 JSON
   exit 0
 fi
+if [[ "$*" == *"pr view"*"28869"* ]]; then
+  cat <<'JSON'
+{"number":28869,"title":"fix pulse diagnostics","state":"OPEN","author":{"login":"worker"},"mergedAt":null,"closedAt":null,"createdAt":"2026-07-29T19:21:19Z","labels":[{"name":"origin:worker"}],"reviewDecision":"","mergeStateStatus":"BLOCKED","headRefName":"feature/auto-20260729-192119-gh28780","baseRefName":"main","isDraft":true}
+JSON
+  exit 0
+fi
 if [[ "$*" == *"issue view"*"21860"* ]]; then
   cat <<'JSON'
 {"number":21860,"title":"t3206: worker re-dispatch loops on same branch","state":"OPEN","author":{"login":"marcusquinn"},"createdAt":"2026-04-26T08:00:00Z","closedAt":null,"labels":[{"name":"auto-dispatch"},{"name":"status:queued"}],"assignees":[]}
@@ -216,6 +226,14 @@ if [[ "$*" == *"issue view"*"99998"* ]]; then
   cat <<'JSON'
 {"number":99998,"title":"ghost issue","state":"CLOSED","author":{"login":"marcusquinn"},"createdAt":"2026-04-01T00:00:00Z","closedAt":"2026-04-02T00:00:00Z","labels":[],"assignees":[]}
 JSON
+  exit 0
+fi
+if [[ "$*" == *"issue view"*"28780"* ]]; then
+  echo '{"number":28780,"title":"draft discovery fixture","state":"OPEN","author":{"login":"marcusquinn"},"createdAt":"2026-07-29T00:00:00Z","closedAt":null,"labels":[],"assignees":[]}'
+  exit 0
+fi
+if [[ "$*" == *"issue view"*"2878"* ]]; then
+  echo '{"number":2878,"title":"near match fixture","state":"OPEN","author":{"login":"marcusquinn"},"createdAt":"2026-07-29T00:00:00Z","closedAt":null,"labels":[],"assignees":[]}'
   exit 0
 fi
 if [[ "$*" == *"api"*"issues/21860/timeline"* ]]; then
@@ -246,12 +264,8 @@ if [[ "$*" == *"api"*"comments"* ]]; then
   echo '[]'
   exit 0
 fi
-if [[ "$*" == *"pr list"*"gh21860"* ]]; then
-  echo '[]'
-  exit 0
-fi
 if [[ "$*" == *"pr list"* ]]; then
-  echo '[]'
+  echo '[{"number":28869,"headRefName":"feature/auto-20260729-192119-gh28780"},{"number":28870,"headRefName":"feature/auto-20260729-192120-gh287800"}]'
   exit 0
 fi
 echo '{}' >&2
@@ -364,6 +378,24 @@ output=$(PULSE_DIAGNOSE_LOGFILE="$FIXTURE_LOGFILE" \
 
 assert_contains "verbose shows RAW:" "RAW:" "$output"
 
+# --- Test 8b: default PR output compacts unclassified events ---
+printf '\nTest 8b: default PR output compacts unclassified events\n'
+output=$(PULSE_DIAGNOSE_LOGFILE="$FIXTURE_LOGFILE" \
+	PULSE_DIAGNOSE_LOGDIR="$TMPDIR_TEST" \
+	PATH="${TMPDIR_TEST}:${PATH}" \
+	"$HELPER" pr 28869 --repo marcusquinn/aidevops 2>&1) || true
+assert_contains "default output summarizes unclassified events" "Unclassified pulse events: 2" "$output"
+unclassified_rows=$(printf '%s' "$output" | grep -c 'Unclassified pulse log entry' 2>/dev/null || true)
+assert_eq "default output omits repeated unclassified rows" "0" "$unclassified_rows"
+
+output=$(PULSE_DIAGNOSE_LOGFILE="$FIXTURE_LOGFILE" \
+	PULSE_DIAGNOSE_LOGDIR="$TMPDIR_TEST" \
+	PATH="${TMPDIR_TEST}:${PATH}" \
+	"$HELPER" pr 28869 --repo marcusquinn/aidevops --verbose 2>&1) || true
+unclassified_rows=$(printf '%s' "$output" | grep -c 'Unclassified pulse log entry' 2>/dev/null || true)
+assert_eq "verbose output retains every unclassified event" "2" "$unclassified_rows"
+assert_contains "verbose output retains unknown raw evidence" "second unknown observation" "$output"
+
 # --- Test 9: --json output ---
 printf '\nTest 9: --json output for PR\n'
 output=$(PULSE_DIAGNOSE_LOGFILE="$FIXTURE_LOGFILE" \
@@ -376,6 +408,12 @@ if command -v jq >/dev/null 2>&1; then
 	assert_eq "JSON event_count for PR #20336" "4" "$json_event_count"
 	json_merged=$(echo "$output" | jq '.merged' 2>/dev/null || echo "false")
 	assert_eq "JSON merged=true for PR #20336" "true" "$json_merged"
+	output=$(PULSE_DIAGNOSE_LOGFILE="$FIXTURE_LOGFILE" \
+		PULSE_DIAGNOSE_LOGDIR="$TMPDIR_TEST" \
+		PATH="${TMPDIR_TEST}:${PATH}" \
+		"$HELPER" pr 28869 --repo marcusquinn/aidevops --json 2>&1) || true
+	assert_eq "JSON preserves total event count" "3" "$(printf '%s' "$output" | jq '.event_count')"
+	assert_eq "JSON preserves both unclassified events" "2" "$(printf '%s' "$output" | jq '[.events[] | select(.rule_id == "unclassified")] | length')"
 fi
 
 # --- Test 10: missing pulse.log ---
@@ -531,6 +569,28 @@ output=$(PULSE_DIAGNOSE_LOGFILE="$FIXTURE_LOGFILE" \
 	"$HELPER" issue 21860 --repo marcusquinn/aidevops --verbose 2>&1) || true
 
 assert_contains "verbose shows RAW: lines" "RAW:" "$output"
+
+# --- Test 17b: empty timeline discovers exact draft branch and rejects near matches ---
+printf '\nTest 17b: linked draft branch discovery and near-match rejection\n'
+output=$(PULSE_DIAGNOSE_LOGFILE="$FIXTURE_LOGFILE" \
+	PULSE_DIAGNOSE_LOGDIR="$TMPDIR_TEST" \
+	PATH="${TMPDIR_TEST}:${PATH}" \
+	"$HELPER" issue 28780 --repo marcusquinn/aidevops 2>&1) || true
+assert_contains "matching draft branch is linked" "PR #28869" "$output"
+assert_contains "issue output compacts unclassified events" "Unclassified pulse events: 2" "$output"
+
+output=$(PULSE_DIAGNOSE_LOGFILE="$FIXTURE_LOGFILE" \
+	PULSE_DIAGNOSE_LOGDIR="$TMPDIR_TEST" \
+	PATH="${TMPDIR_TEST}:${PATH}" \
+	"$HELPER" issue 2878 --repo marcusquinn/aidevops 2>&1) || true
+assert_contains "near-match issue has no linked PR" "no linked or worker PRs found" "$output"
+
+output=$(PULSE_DIAGNOSE_LOGFILE="$FIXTURE_LOGFILE" \
+	PULSE_DIAGNOSE_LOGDIR="$TMPDIR_TEST" \
+	PATH="${TMPDIR_TEST}:${PATH}" \
+	"$HELPER" issue 28780 --repo marcusquinn/aidevops --json 2>&1) || true
+assert_eq "JSON includes branch-discovered draft PR" "28869" "$(printf '%s' "$output" | jq '.linked_prs[0].number')"
+assert_eq "issue JSON preserves pulse event count" "3" "$(printf '%s' "$output" | jq '.linked_prs[0].pulse_event_count')"
 
 # --- Test 18: issue gh offline mode ---
 printf '\nTest 18: issue gh offline mode graceful degradation\n'


### PR DESCRIPTION
## Summary

Discover exact issue-token worker branches from bounded open PR metadata and compact repeated unclassified events in default text reports while retaining verbose and JSON evidence.

## Files Changed

.agents/scripts/pulse-diagnose-helper.sh, .agents/scripts/tests/test-pulse-diagnose-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused pulse diagnostics regression suite: 106 passed; ShellCheck clean.

Resolves #28894


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.197 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 4m and 76,256 tokens on this as a headless worker.