### PR TITLE
t18182: Preserve clean checkouts during simplification publication

### DIFF
--- a/.agents/scripts/planning-publisher.sh
+++ b/.agents/scripts/planning-publisher.sh
@@ -81,11 +81,38 @@ _planning_publish_changed_paths() {
 	return 0
 }
 
+_planning_publish_source_file() {
+	local repo_path="$1"
+	local path="$2"
+	local external_source="$3"
+	local scope="${AIDEVOPS_PLANNING_PUBLISH_SCOPE:-planning}"
+	if [[ -z "$external_source" ]]; then
+		printf '%s\n' "${repo_path}/${path}"
+		return 0
+	fi
+	if [[ "$scope" != "simplification-state" || "$path" != ".agents/configs/simplification-state.json" ]]; then
+		_planning_publish_log error "External publication sources are not allowed for scope/path: ${scope}:${path}"
+		return 1
+	fi
+	if [[ ! -f "$external_source" || -L "$external_source" ]]; then
+		_planning_publish_log error "External publication source must be a regular non-symlink file"
+		return 1
+	fi
+	if ! jq -e 'type == "object" and (.files | type == "object")' "$external_source" >/dev/null 2>&1; then
+		_planning_publish_log error "External simplification-state source is malformed"
+		return 1
+	fi
+	printf '%s\n' "$external_source"
+	return 0
+}
+
 _planning_publish_snapshot() {
 	local repo_path="$1"
 	local paths="$2"
 	local snapshot_file="$3"
+	local external_source="${4:-}"
 	local path=""
+	local source_file=""
 	: >"$snapshot_file" || return 1
 	while IFS= read -r path; do
 		[[ -n "$path" ]] || continue
@@ -93,13 +120,14 @@ _planning_publish_snapshot() {
 			_planning_publish_log error "Unauthorized publication path: $path"
 			return 1
 		}
-		if [[ -L "${repo_path}/${path}" ]] || [[ -d "${repo_path}/${path}" ]]; then
+		source_file=$(_planning_publish_source_file "$repo_path" "$path" "$external_source") || return 1
+		if [[ -L "$source_file" ]] || [[ -d "$source_file" ]]; then
 			_planning_publish_log error "Publication paths must be regular files: $path"
 			return 1
 		fi
-		if [[ -f "${repo_path}/${path}" ]]; then
+		if [[ -f "$source_file" ]]; then
 			local blob_sha=""
-			blob_sha=$(_planning_git -C "$repo_path" hash-object -w -- "${repo_path}/${path}") || return 1
+			blob_sha=$(_planning_git -C "$repo_path" hash-object -w -- "$source_file") || return 1
 			printf '%s\t%s\t%s\n' "$PLANNING_SNAPSHOT_FILE_OPERATION" "$blob_sha" "$path" >>"$snapshot_file" || return 1
 		else
 			printf 'delete\t-\t%s\n' "$path" >>"$snapshot_file" || return 1
@@ -649,11 +677,12 @@ _planning_publish_record_pushed_receipt() {
 _planning_publish_prepare_snapshot() {
 	local repo_path="$1"
 	local paths="$2"
+	local external_source="${3:-}"
 	local publication_id=""
 	_PLANNING_PUBLISH_TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/planning-publisher.XXXXXX") || return 1
 	_PLANNING_PUBLISH_SNAPSHOT_FILE="${_PLANNING_PUBLISH_TEMP_DIR}/snapshot"
 	_PLANNING_PUBLISH_INDEX_FILE="${_PLANNING_PUBLISH_TEMP_DIR}/index"
-	_planning_publish_snapshot "$repo_path" "$paths" "$_PLANNING_PUBLISH_SNAPSHOT_FILE" || {
+	_planning_publish_snapshot "$repo_path" "$paths" "$_PLANNING_PUBLISH_SNAPSHOT_FILE" "$external_source" || {
 		rm -rf "$_PLANNING_PUBLISH_TEMP_DIR"
 		return 1
 	}
@@ -716,6 +745,7 @@ planning_publish() {
 	local remote_name="${3:-origin}"
 	local branch_name="${4:-}"
 	local paths="${5:-}"
+	local external_source="${6:-}"
 	local temp_dir="" snapshot_file="" index_file="" parent_sha="" tree_sha="" candidate_sha=""
 	local publication_id="" handoff_id="" attempt=0 push_rc=0 latest_sha="" expected_sha="" parent_resolution="" base_sha="${AIDEVOPS_PLANNING_BASE_SHA:-}"
 	local guard_rc=0 source_head=""
@@ -729,7 +759,7 @@ planning_publish() {
 		PLANNING_PUBLISH_RESULT="noop"
 		return 0
 	fi
-	_planning_publish_prepare_snapshot "$repo_path" "$paths" || return 1
+	_planning_publish_prepare_snapshot "$repo_path" "$paths" "$external_source" || return 1
 	temp_dir="$_PLANNING_PUBLISH_TEMP_DIR"
 	snapshot_file="$_PLANNING_PUBLISH_SNAPSHOT_FILE"
 	index_file="$_PLANNING_PUBLISH_INDEX_FILE"

--- a/.agents/scripts/pulse-simplification-orchestration.sh
+++ b/.agents/scripts/pulse-simplification-orchestration.sh
@@ -330,9 +330,52 @@ _complexity_scan_state_refresh() {
 
 	# Publish state without staging or committing in the canonical checkout.
 	if [[ "$state_updated" == true ]]; then
-		_simplification_state_push "$aidevops_path"
+		_simplification_state_push "$aidevops_path" "$state_file"
 	fi
 	return 0
+}
+
+# Create one private registry snapshot for refresh, publication, and same-cycle scans.
+_complexity_scan_state_snapshot_create() {
+	local aidevops_path="$1"
+	local source_file="${aidevops_path}/.agents/configs/simplification-state.json"
+	local temp_root="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+	local temp_dir=""
+	[[ -f "$source_file" && ! -L "$source_file" ]] || return 1
+	mkdir -p "$temp_root" || return 1
+	temp_dir=$(umask 077 && mktemp -d "${temp_root%/}/simplification-state.XXXXXX") || return 1
+	cp "$source_file" "${temp_dir}/simplification-state.json" || {
+		rmdir "$temp_dir" 2>/dev/null || true
+		return 1
+	}
+	printf '%s\n' "${temp_dir}/simplification-state.json"
+	return 0
+}
+
+_complexity_scan_state_snapshot_cleanup() {
+	local state_file="$1"
+	local state_dir="${state_file%/*}"
+	[[ "${state_file##*/}" == "simplification-state.json" ]] || return 1
+	rm -f "$state_file" || return 1
+	rmdir "$state_dir" 2>/dev/null || return 1
+	return 0
+}
+
+_complexity_scan_run_isolated_state_cycle() {
+	local scan_helper="$1"
+	local aidevops_path="$2"
+	local repos_json="$3"
+	local aidevops_slug="$4"
+	local state_file=""
+	local cycle_rc=0
+	state_file=$(_complexity_scan_state_snapshot_create "$aidevops_path") || return 1
+	_complexity_scan_state_refresh "$aidevops_path" "$state_file" "$aidevops_slug" || cycle_rc=$?
+	if [[ -x "$scan_helper" ]]; then
+		_complexity_scan_lang_shell "$scan_helper" "$aidevops_path" "$state_file" "$repos_json" "$aidevops_slug" || cycle_rc=$?
+		_complexity_scan_lang_md "$scan_helper" "$aidevops_path" "$state_file" "$repos_json" "$aidevops_slug" || cycle_rc=$?
+	fi
+	_complexity_scan_state_snapshot_cleanup "$state_file" || cycle_rc=1
+	return "$cycle_rc"
 }
 
 # _complexity_scan_lang_shell — shell-file complexity scan via helper (Phase 2, t2001)
@@ -527,13 +570,9 @@ run_weekly_complexity_scan() {
 	gh label create "recheck-simplicity" --repo "$aidevops_slug" --color "D4C5F9" \
 		--description "File changed since last simplification and needs recheck" --force 2>/dev/null || true
 
-	local state_file="${aidevops_path}/.agents/configs/simplification-state.json"
-	_complexity_scan_state_refresh "$aidevops_path" "$state_file" "$aidevops_slug"
-
 	local scan_helper="${SCRIPT_DIR}/complexity-scan-helper.sh"
+	_complexity_scan_run_isolated_state_cycle "$scan_helper" "$aidevops_path" "$repos_json" "$aidevops_slug" || true
 	if [[ -x "$scan_helper" ]]; then
-		_complexity_scan_lang_shell "$scan_helper" "$aidevops_path" "$state_file" "$repos_json" "$aidevops_slug"
-		_complexity_scan_lang_md "$scan_helper" "$aidevops_path" "$state_file" "$repos_json" "$aidevops_slug"
 		_complexity_scan_sweep_check "$scan_helper" "$aidevops_slug"
 		_complexity_scan_ratchet_check "$scan_helper" "$aidevops_path" "$aidevops_slug"
 	else

--- a/.agents/scripts/pulse-simplification-state.sh
+++ b/.agents/scripts/pulse-simplification-state.sh
@@ -321,9 +321,10 @@ _simplification_state_prune() {
 }
 
 # Publish simplification state without mutating the source checkout.
-# Arguments: $1 - repo_path
+# Arguments: $1 - repo_path, $2 - optional isolated state source
 _simplification_state_push() {
 	local repo_path="$1"
+	local state_source="${2:-}"
 	local state_rel=".agents/configs/simplification-state.json"
 	local module_dir="${BASH_SOURCE[0]%/*}"
 	local main_branch="" base_sha="" publication_rc=0
@@ -342,7 +343,7 @@ _simplification_state_push() {
 	AIDEVOPS_PLANNING_BASE_SHA="$base_sha" \
 		AIDEVOPS_PLANNING_PUBLISH_SCOPE="simplification-state" \
 		planning_publish "$repo_path" "chore: update simplification state registry" \
-			origin "$main_branch" "$state_rel" || publication_rc=$?
+			origin "$main_branch" "$state_rel" "$state_source" || publication_rc=$?
 	case "$publication_rc" in
 	0) echo "[pulse-wrapper] simplification-state: ${PLANNING_PUBLISH_RESULT:-published} on $main_branch" >>"${LOGFILE:-/dev/null}" ;;
 	2) echo "[pulse-wrapper] simplification-state: retryable publication conflict on $main_branch" >>"${LOGFILE:-/dev/null}" ;;

--- a/.agents/scripts/tests/test-planning-publisher.sh
+++ b/.agents/scripts/tests/test-planning-publisher.sh
@@ -105,13 +105,15 @@ run_receipt_verify() {
 run_simplification_publish() {
 	local repo="$1"
 	local hook="${2:-}"
+	local source_file="${3:-}"
+	local validator="${4:-/usr/bin/true}"
 	(
 		LOGFILE="/dev/null"
 		# shellcheck source=../pulse-simplification-state.sh
 		source "$STATE_SCRIPT"
-		AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true \
+		AIDEVOPS_PLANNING_VALIDATOR="$validator" \
 			AIDEVOPS_PLANNING_BEFORE_PUSH_HOOK="$hook" \
-			_simplification_state_push "$repo"
+			_simplification_state_push "$repo" "$source_file"
 	)
 	return $?
 }
@@ -327,6 +329,99 @@ test_simplification_state_scope_preserves_checkout() {
 	return 0
 }
 
+test_external_simplification_source_contract() {
+	local name="accepts only valid isolated simplification-state sources"
+	local root="" repo="" source_file="" before="" after="" first_remote="" second_remote=""
+	local receipt_dir="" receipt="" invalid="" source_path_leaked=0 validator_rc=0 reject_rc=0
+	root=$(mktemp -d) || return 0
+	setup_repo "$root" || {
+		fail "$name" setup
+		return 0
+	}
+	repo="${root}/work"
+	mkdir -p "${repo}/.agents/configs" || return 0
+	printf '%s\n' '{"files":{}}' >"${repo}/.agents/configs/simplification-state.json"
+	git -C "$repo" add .agents/configs/simplification-state.json
+	GIT_AUTHOR_NAME=Test GIT_AUTHOR_EMAIL=test@example.invalid GIT_COMMITTER_NAME=Test GIT_COMMITTER_EMAIL=test@example.invalid \
+		git -C "$repo" commit -qm "seed simplification state"
+	git -C "$repo" push -q origin main
+	source_file="${root}/isolated-state.json"
+	printf '%s\n' '{"files":{"external.sh":{"passes":3}}}' >"$source_file"
+	receipt_dir="${root}/receipts"
+	before=$(state_digest "$repo")
+	AIDEVOPS_PLANNING_RECEIPT_DIR="$receipt_dir" AIDEVOPS_PLANNING_WRITE_RECEIPT=true \
+		run_simplification_publish "$repo" "" "$source_file" || {
+		fail "$name" publish
+		rm -rf "$root"
+		return 0
+	}
+	after=$(state_digest "$repo")
+	first_remote=$(git --git-dir="${root}/remote.git" rev-parse main)
+	AIDEVOPS_PLANNING_RECEIPT_DIR="$receipt_dir" AIDEVOPS_PLANNING_WRITE_RECEIPT=true \
+		run_simplification_publish "$repo" "" "$source_file" || reject_rc=$?
+	second_remote=$(git --git-dir="${root}/remote.git" rev-parse main)
+	receipt=$(printf '%s\n' "$receipt_dir"/*.receipt)
+	grep -Fq "$source_file" "$receipt" 2>/dev/null && source_path_leaked=1
+	invalid="${root}/invalid.json"
+	printf '%s\n' '{not-json' >"$invalid"
+	run_simplification_publish "$repo" "" "$invalid" || validator_rc=$?
+	if [[ "$before" == "$after" && "$first_remote" == "$second_remote" && "$reject_rc" -eq 0 && \
+		"$validator_rc" -ne 0 && "$source_path_leaked" -eq 0 ]] &&
+		git --git-dir="${root}/remote.git" show main:.agents/configs/simplification-state.json | grep -q 'external.sh'; then
+		pass "$name"
+	else
+		fail "$name" "external source invariant failed (replay=$reject_rc invalid=$validator_rc leaked=$source_path_leaked)"
+	fi
+	rm -rf "$root"
+	return 0
+}
+
+test_external_simplification_source_rejections() {
+	local name="rejects symlink directory unauthorized and validation-failing external sources"
+	local root="" repo="" valid="" invalid="" source_dir="" source_link="" remote_before="" before="" after=""
+	local symlink_rc=0 directory_rc=0 scope_rc=0 validation_rc=0
+	root=$(mktemp -d) || return 0
+	setup_repo "$root" || {
+		fail "$name" setup
+		return 0
+	}
+	repo="${root}/work"
+	mkdir -p "${repo}/.agents/configs" || return 0
+	printf '%s\n' '{"files":{}}' >"${repo}/.agents/configs/simplification-state.json"
+	git -C "$repo" add .agents/configs/simplification-state.json
+	GIT_AUTHOR_NAME=Test GIT_AUTHOR_EMAIL=test@example.invalid GIT_COMMITTER_NAME=Test GIT_COMMITTER_EMAIL=test@example.invalid \
+		git -C "$repo" commit -qm "seed simplification state"
+	git -C "$repo" push -q origin main
+	valid="${root}/valid.json"
+	invalid="${root}/invalid-shape.json"
+	source_dir="${root}/source-dir"
+	source_link="${root}/source-link.json"
+	printf '%s\n' '{"files":{"valid.sh":{"passes":1}}}' >"$valid"
+	printf '%s\n' '{"entries":{}}' >"$invalid"
+	mkdir -p "$source_dir"
+	ln -s "$valid" "$source_link"
+	remote_before=$(git --git-dir="${root}/remote.git" rev-parse main)
+	before=$(state_digest "$repo")
+	run_simplification_publish "$repo" "" "$source_link" || symlink_rc=$?
+	run_simplification_publish "$repo" "" "$source_dir" || directory_rc=$?
+	(
+		# shellcheck source=../planning-publisher.sh
+		source "$PUBLISHER"
+		AIDEVOPS_PLANNING_PUBLISH_SCOPE=planning AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true \
+			planning_publish "$repo" "reject external planning source" origin main TODO.md "$valid"
+	) >/dev/null 2>&1 || scope_rc=$?
+	run_simplification_publish "$repo" "" "$valid" /usr/bin/false || validation_rc=$?
+	after=$(state_digest "$repo")
+	if [[ "$symlink_rc" -ne 0 && "$directory_rc" -ne 0 && "$scope_rc" -ne 0 && "$validation_rc" -ne 0 && \
+		"$before" == "$after" && "$remote_before" == "$(git --git-dir="${root}/remote.git" rev-parse main)" ]]; then
+		pass "$name"
+	else
+		fail "$name" "rejection invariant failed (symlink=$symlink_rc dir=$directory_rc scope=$scope_rc validation=$validation_rc)"
+	fi
+	rm -rf "$root"
+	return 0
+}
+
 test_simplification_state_defaults_to_main_without_origin_head() {
 	local name="defaults simplification-state publication to main when origin/HEAD is unavailable"
 	local root="" repo="" remote_state="" publish_rc=0
@@ -360,7 +455,7 @@ test_simplification_state_defaults_to_main_without_origin_head() {
 
 test_simplification_state_conflict_is_retryable() {
 	local name="simplification-state contention fails retryably without overwriting remote state"
-	local root="" repo="" hook="" before="" after="" rc=0 remote_state=""
+	local root="" repo="" hook="" source_file="" before="" after="" rc=0 remote_state=""
 	root=$(mktemp -d) || return 0
 	setup_repo "$root" || {
 		fail "$name" setup
@@ -368,7 +463,13 @@ test_simplification_state_conflict_is_retryable() {
 	}
 	repo="${root}/work"
 	mkdir -p "${repo}/.agents/configs" || return 0
-	printf '%s\n' '{"files":{"local.sh":{"passes":1}}}' >"${repo}/.agents/configs/simplification-state.json"
+	printf '%s\n' '{"files":{}}' >"${repo}/.agents/configs/simplification-state.json"
+	git -C "$repo" add .agents/configs/simplification-state.json
+	GIT_AUTHOR_NAME=Test GIT_AUTHOR_EMAIL=test@example.invalid GIT_COMMITTER_NAME=Test GIT_COMMITTER_EMAIL=test@example.invalid \
+		git -C "$repo" commit -qm "seed simplification state"
+	git -C "$repo" push -q origin main
+	source_file="${root}/isolated-state.json"
+	printf '%s\n' '{"files":{"local.sh":{"passes":1}}}' >"$source_file"
 	hook="${root}/state-rival.sh"
 	cat >"$hook" <<'HOOK'
 #!/usr/bin/env bash
@@ -386,7 +487,7 @@ exit 0
 HOOK
 	chmod +x "$hook"
 	before=$(state_digest "$repo")
-	run_simplification_publish "$repo" "$hook" || rc=$?
+	run_simplification_publish "$repo" "$hook" "$source_file" || rc=$?
 	after=$(state_digest "$repo")
 	remote_state=$(git --git-dir="${root}/remote.git" show main:.agents/configs/simplification-state.json)
 	if [[ "$rc" -eq 2 && "$before" == "$after" && "$remote_state" == *"rival.sh"* && "$remote_state" != *"local.sh"* ]]; then
@@ -731,6 +832,8 @@ main() {
 	test_publication_receipt_revalidates_exact_handoff
 	test_publication_receipt_rejects_ancestor_source_forgery
 	test_simplification_state_scope_preserves_checkout
+	test_external_simplification_source_contract
+	test_external_simplification_source_rejections
 	test_simplification_state_defaults_to_main_without_origin_head
 	test_simplification_state_conflict_is_retryable
 	test_validation_failure_pushes_nothing

--- a/.agents/scripts/tests/test-simplification-state-publication-isolation.sh
+++ b/.agents/scripts/tests/test-simplification-state-publication-isolation.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression guard for GH#28872: refresh and publication use an isolated state snapshot.
+
+set -euo pipefail
+# Fixture repositories are disposable; bypass interactive canonical-repo guards.
+PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPT_DIR="${SCRIPT_DIR_TEST}/.."
+STATE_SCRIPT="${SCRIPT_DIR}/pulse-simplification-state.sh"
+ORCHESTRATION_SCRIPT="${SCRIPT_DIR}/pulse-simplification-orchestration.sh"
+TEST_ROOT="$(mktemp -d)"
+REMOTE="${TEST_ROOT}/remote.git"
+REPO="${TEST_ROOT}/canonical"
+OBSERVED="${TEST_ROOT}/observed-state"
+LOGFILE="${TEST_ROOT}/pulse.log"
+AIDEVOPS_TEMP_DIR="${TEST_ROOT}/managed-temp"
+export AIDEVOPS_TEMP_DIR LOGFILE OBSERVED
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+state_digest() {
+	local repo_path="$1"
+	{
+		git -C "$repo_path" rev-parse HEAD
+		git -C "$repo_path" ls-files -s
+		git -C "$repo_path" diff --binary
+		git -C "$repo_path" diff --cached --binary
+		git -C "$repo_path" status --porcelain=v1 --untracked-files=all
+	} | git hash-object --stdin
+	return 0
+}
+
+git init --bare --initial-branch=main "$REMOTE" >/dev/null
+git clone -q "$REMOTE" "$REPO"
+git -C "$REPO" config user.name Test
+git -C "$REPO" config user.email test@example.invalid
+git -C "$REPO" config commit.gpgsign false
+mkdir -p "${REPO}/.agents/configs"
+printf '%s\n' '#!/usr/bin/env bash' 'printf refreshed' >"${REPO}/tracked.sh"
+printf '%s\n' '{"files":{"tracked.sh":{"hash":"0000000000000000000000000000000000000000","passes":1}}}' \
+	>"${REPO}/.agents/configs/simplification-state.json"
+git -C "$REPO" add .
+git -C "$REPO" commit -qm seed
+git -C "$REPO" push -q origin main
+git -C "$REPO" remote set-head origin main
+
+SCAN_HELPER="${TEST_ROOT}/scan-helper.sh"
+cat >"$SCAN_HELPER" <<'SCAN'
+#!/usr/bin/env bash
+set -euo pipefail
+scan_type=""
+state_file=""
+shift 2
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--type) scan_type="$2"; shift 2 ;;
+	--state-file) state_file="$2"; shift 2 ;;
+	*) shift ;;
+	esac
+done
+hash=$(jq -r '.files["tracked.sh"].hash' "$state_file")
+printf '%s|%s|%s\n' "$scan_type" "$state_file" "$hash" >>"$OBSERVED"
+exit 0
+SCAN
+chmod +x "$SCAN_HELPER"
+
+# shellcheck source=../pulse-simplification-state.sh
+source "$STATE_SCRIPT"
+# shellcheck source=../pulse-simplification-orchestration.sh
+source "$ORCHESTRATION_SCRIPT"
+
+_simplification_state_backfill_closed() {
+	local _repo_path="$1"
+	local _state_file="$2"
+	local _repo_slug="$3"
+	printf '0\n'
+	return 0
+}
+
+_simplification_close_spurious_requeue_issues() {
+	local _repo_path="$1"
+	local _repo_slug="$2"
+	printf '0\n'
+	return 0
+}
+
+_complexity_scan_create_issues() {
+	local _results="$1"
+	local _repos_json="$2"
+	local _repo_slug="$3"
+	return 0
+}
+
+_complexity_scan_create_md_issues() {
+	local _results="$1"
+	local _repos_json="$2"
+	local _repo_slug="$3"
+	return 0
+}
+
+before=$(state_digest "$REPO")
+expected_hash=$(git -C "$REPO" hash-object tracked.sh)
+AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true \
+	_complexity_scan_run_isolated_state_cycle "$SCAN_HELPER" "$REPO" "${TEST_ROOT}/repos.json" test/aidevops
+after=$(state_digest "$REPO")
+first_remote=$(git --git-dir="$REMOTE" rev-parse main)
+
+[[ "$before" == "$after" ]]
+[[ "$(git --git-dir="$REMOTE" show main:.agents/configs/simplification-state.json | jq -r '.files["tracked.sh"].hash')" == "$expected_hash" ]]
+[[ "$(wc -l <"$OBSERVED" | tr -d ' ')" == "2" ]]
+[[ "$(cut -d'|' -f3 "$OBSERVED" | sort -u)" == "$expected_hash" ]]
+observed_state=$(cut -d'|' -f2 "$OBSERVED" | sort -u)
+[[ "$observed_state" != "${REPO}/.agents/configs/simplification-state.json" ]]
+[[ ! -e "$observed_state" ]]
+
+: >"$OBSERVED"
+AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true \
+	_complexity_scan_run_isolated_state_cycle "$SCAN_HELPER" "$REPO" "${TEST_ROOT}/repos.json" test/aidevops
+[[ "$before" == "$(state_digest "$REPO")" ]]
+[[ "$first_remote" == "$(git --git-dir="$REMOTE" rev-parse main)" ]]
+[[ "$(wc -l <"$OBSERVED" | tr -d ' ')" == "2" ]]
+
+printf 'PASS simplification-state refresh publication remains checkout-isolated\n'
+exit 0


### PR DESCRIPTION
## Summary

Refresh, publish, and scan simplification state through one private snapshot while allowing only a validated external source for the fixed registry destination.

## Files Changed

.agents/scripts/planning-publisher.sh, .agents/scripts/pulse-simplification-orchestration.sh, .agents/scripts/pulse-simplification-state.sh, .agents/scripts/tests/test-planning-publisher.sh, .agents/scripts/tests/test-simplification-state-publication-isolation.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-simplification-state-publication-isolation.sh; bash .agents/scripts/tests/test-planning-publisher.sh; bash .agents/scripts/tests/test-simplification-state-preserve.sh; bash .agents/scripts/tests/test-full-loop-merge.sh; shellcheck targeted files; .agents/scripts/linters-local.sh --changed

Resolves #28872


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.197 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 8m and 128,991 tokens on this as a headless worker.