### PR TITLE
GH#28906: fix: isolate OpenCode setup fixture candidates

### DIFF
--- a/.agents/scripts/tests/test-setup-opencode-cli.sh
+++ b/.agents/scripts/tests/test-setup-opencode-cli.sh
@@ -270,6 +270,18 @@ cp "$SANDBOX/bin/opencode-qwen" "$HOME/.local/bin/opencode"
 cp "$SANDBOX/bin/opencode-real" "$HOME/.bun/bin/opencode"
 (
 	source_lib
+	# Test 5d covers invalid-shim healing; temporary-path classification has
+	# dedicated coverage in tests/test-opencode-stable-shim.sh.
+	# shellcheck disable=SC2329  # Called through setup_opencode_cli from the sourced library.
+	_setup_opencode_binary_is_ephemeral() {
+		local bin="$1"
+
+		if [[ "$bin" == "$HOME/.bun/bin/opencode" ]]; then
+			return 1
+		fi
+
+		return 0
+	}
 	export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH"
 	export OPENCODE_BIN=""
 	rc=0
@@ -291,9 +303,14 @@ fi
 echo "Test 6: setup_opencode_cli fail-open when no bun/npm + invalid current"
 # Wipe persisted file from previous test so we can confirm it stays absent.
 rm -f "$HOME/.aidevops/.opencode-bin-resolved"
-rm -f "$HOME/.bun/bin/opencode"
+rm -f "$HOME/.bun/bin/opencode" "$HOME/.local/bin/opencode"
 (
 	source_lib
+	# Keep the fail-open fixture independent of host-level OpenCode installs.
+	# shellcheck disable=SC2329  # Called through setup_opencode_cli from the sourced library.
+	_setup_opencode_binary_is_ephemeral() {
+		return 0
+	}
 	# Force minimal PATH so neither bun nor npm resolves; supply only the
 	# claude shim under the name 'opencode'.
 	rm -f "$SANDBOX/bin/opencode"


### PR DESCRIPTION
## Summary

Isolate Test 5d's synthetic Bun candidate from temporary-path classification and prevent Test 6 from selecting host OpenCode installs.

## Files Changed

.agents/scripts/tests/test-setup-opencode-cli.sh

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — bash .agents/scripts/tests/test-setup-opencode-cli.sh; bash tests/test-opencode-stable-shim.sh; shellcheck .agents/scripts/tests/test-setup-opencode-cli.sh tests/test-opencode-stable-shim.sh; git diff --check; .agents/scripts/linters-local.sh --changed

Resolves #28906


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.197 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 6m and 74,358 tokens on this as a headless worker.