### PR TITLE
t18183: Preserve framed GH attempts and REST rewrite failures

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -852,8 +852,9 @@ fi
 # workers to source shared-gh-wrappers.sh.
 #
 # Bypass: AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1
-# Fail-open: any error in sourcing, budget check, or REST call falls
-# through to the real gh binary.
+# Fail-open before REST dispatch and after local projection failures. An HTTP
+# failure from an attempted REST transport remains authoritative so the shim
+# does not duplicate it through GraphQL.
 # -----------------------------------------------------------------------------
 if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 	# Bypass — explicit override.
@@ -916,7 +917,20 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		return 1
 	}
 
+	_SHIM_REST_REWRITE_ATTEMPTED=0
+	_shim_rest_rewrite_has_http_failure() {
+		local log_file="${AIDEVOPS_GH_API_LOG:-${GH_API_LOG:-}}"
+		[[ -n "$log_file" && -r "$log_file" ]] || return 1
+		awk -F '\t' -v logical_id="$AIDEVOPS_GH_LOGICAL_ID" '
+			$8 == "v2" && $9 == "attempt" && $10 == logical_id &&
+			$15 ~ /^[45][0-9][0-9]$/ { found = 1 }
+			END { exit found ? 0 : 1 }
+		' "$log_file"
+		return $?
+	}
+
 	_shim_rest_rewrite_read() {
+		_SHIM_REST_REWRITE_ATTEMPTED=0
 		# Source the REST fallback helper (contains _rest_should_fallback
 		# and the _rest_* translator functions).
 		local _rest_helper=""
@@ -974,6 +988,7 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		gh_record_call "$_route_path" "$(_shim_caller_label "${1:-}" "${2:-}")" 2>/dev/null || true
 
 		# Dispatch to the appropriate REST translator.
+		_SHIM_REST_REWRITE_ATTEMPTED=1
 		case "$_SHIM_READ_REWRITE" in
 		pr:view)    _rest_pr_view "${_SHIM_REST_ARGS[@]}" --repo "$_SHIM_REPO" ;;
 		issue:view) _rest_issue_view "${_SHIM_REST_ARGS[@]}" --repo "$_SHIM_REPO" ;;
@@ -984,26 +999,27 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		return $?
 	}
 
-	# Attempt REST rewrite. On success, exit with the translator's status.
-	# On failure (helper missing, budget OK, REST error), fall through to
-	# the real gh binary — fail-open.
+	# Attempt REST rewrite. A response-backed HTTP failure is authoritative:
+	# retrying through GraphQL duplicates traffic and can turn a clear REST error
+	# into an ambiguous second failure. Local projection failures retain native
+	# fallback because the REST response may not reproduce the requested output.
 	if _shim_rest_rewrite_read "$@"; then
 		exit 0
 	else
 		_rest_rc=$?
-		# If the REST translator ran but returned non-zero (actual API error
-		# vs. budget-OK/missing-helper), propagate the error rather than
-		# retrying via GraphQL (which would also fail if budget is exhausted).
-		# Budget-OK returns rc=1 from _rest_should_fallback; we only
-		# get here when rc=1 from the function wrapper. The translator errors
-		# are already printed to stderr by the _rest_* functions.
-		# Conservative: always fall through to real gh.
-		# GH#21857/t3448: record the graphql call — the real gh will use GraphQL.
+		if [[ "$_SHIM_REST_REWRITE_ATTEMPTED" -eq 1 ]] && _shim_rest_rewrite_has_http_failure; then
+			exit "$_rest_rc"
+		fi
+		# Preserve native fallback for projection/local failures because REST may
+		# have returned data that cannot safely reproduce gh output. Routes that
+		# never attempted REST are plain GraphQL selection.
 		_transport_caller=$(_shim_caller_label "${1:-}" "${2:-}")
 		_transport_retry=$(gh_attempt_count_for_logical "$AIDEVOPS_GH_LOGICAL_ID")
 		[[ "$_transport_retry" =~ ^[0-9]+$ ]] || _transport_retry=0
-		gh_record_call graphql "$_transport_caller" "" "" rest-fallback-graphql 2>/dev/null || true
-		AIDEVOPS_GH_ROUTE_DECISION=rest-fallback-graphql \
+		_transport_decision=graphql-selected
+		[[ "$_SHIM_REST_REWRITE_ATTEMPTED" -eq 0 ]] || _transport_decision=rest-fallback-graphql
+		gh_record_call graphql "$_transport_caller" "" "" "$_transport_decision" 2>/dev/null || true
+		AIDEVOPS_GH_ROUTE_DECISION="$_transport_decision" \
 			_shim_run_transport "$REAL_GH" graphql "$_transport_caller" "$_transport_retry" "$@"
 		exit $?
 	fi

--- a/.agents/scripts/gh-quota-attribution-lib.sh
+++ b/.agents/scripts/gh-quota-attribution-lib.sh
@@ -590,6 +590,19 @@ _ghqa_response_cost() {
 	return 1
 }
 
+_ghqa_frame_page() {
+	local original_page="$1"
+	local frame_index="$2"
+	local frame_total="$3"
+	[[ "$frame_index" =~ ^[1-9][0-9]*$ ]] || return 1
+	if [[ ! "$original_page" =~ ^[1-9][0-9]*$ || "$frame_total" -gt 1 ]]; then
+		printf '%s' "$frame_index"
+		return 0
+	fi
+	printf '%s' "$original_page"
+	return 0
+}
+
 _ghqa_write_complete_frames() {
 	local result_file="$1"
 	local state_file="$2"
@@ -610,8 +623,7 @@ _ghqa_write_complete_frames() {
 		[[ "$kind" == frame ]] || continue
 		path=$(_ghqa_path_for_resource "$original_path" "$resource")
 		pool=$(_ghqa_pool_for_resource "$resource")
-		page="$original_page"
-		[[ "$frame_total" -eq 1 ]] || page="$frame_index"
+		page=$(_ghqa_frame_page "$original_page" "$frame_index" "$frame_total") || page=0
 		outcome=success
 		if [[ "$status" -ge 400 || ( "$frame_index" -eq "$frame_total" && "$command_rc" -ne 0 ) ]]; then
 			outcome=error
@@ -652,6 +664,32 @@ _ghqa_write_complete_frames() {
 	done <<<"$parsed"
 	[[ "$invalidate_state" -eq 0 ]] || rm -f -- "$state_file" 2>/dev/null || true
 	return 0
+}
+
+_ghqa_write_incomplete_frames() {
+	local result_file="$1"
+	local original_path="$2"
+	local original_page="$3"
+	local command_rc="$4"
+	local parsed="$5"
+	local elapsed_ms="$6"
+	local kind="" frame_index="" ignored="" page="" frame_elapsed=""
+	local frame_total=0 rows=0 outcome=success
+	[[ "$command_rc" -eq 0 ]] || outcome=error
+	frame_total=$(printf '%s\n' "$parsed" | awk -F '\t' '$1 == "frame" { count++ } END { print count + 0 }')
+	while IFS=$'\t' read -r kind frame_index ignored; do
+		[[ "$kind" == frame && "$frame_index" =~ ^[1-9][0-9]*$ ]] || continue
+		page=$(_ghqa_frame_page "$original_page" "$frame_index" "$frame_total") || continue
+		# Only aggregate process latency is available for incomplete frames. Own it
+		# on the final frame and use zero for preceding frames so totals stay exact.
+		frame_elapsed=0
+		[[ "$frame_index" -ne "$frame_total" ]] || frame_elapsed="$elapsed_ms"
+		_ghqa_write_fallback_attempt "$result_file" "$original_path" "$page" \
+			"$outcome" "$frame_elapsed" ""
+		rows=$((rows + 1))
+	done <<<"$parsed"
+	[[ "$rows" -gt 0 ]]
+	return $?
 }
 
 _ghqa_capture_locked() {
@@ -708,11 +746,14 @@ _ghqa_capture_locked() {
 	if [[ "$version" == v1 && "$frame_count" =~ ^[1-9][0-9]*$ ]] \
 		&& _ghqa_capture_frames_valid "$parsed" "$frame_count"; then
 		_ghqa_write_complete_frames "$result_file" "$state_file" "$path" "$page" "$rc" "$parsed" "$@"
-	elif [[ "$version" == v1 && "$frame_count" == 1 ]]; then
-		# One recognized request frame proves the attempt and caller-owned page,
-		# even when no complete response metadata arrived. Quota remains unknown.
-		_ghqa_write_fallback_attempt "$result_file" "$path" "$page" \
-			"$([[ "$rc" -eq 0 ]] && printf success || printf error)" "$elapsed_ms" ""
+	elif [[ "$version" == v1 && "$frame_count" =~ ^[1-9][0-9]*$ ]]; then
+		# Every parser-emitted request frame proves one attempt even when response
+		# metadata is incomplete. Frame indexes make native pagination page-exact;
+		# quota remains unknown until response-owned evidence exists.
+		_ghqa_write_incomplete_frames "$result_file" "$path" "$page" "$rc" \
+			"$parsed" "$elapsed_ms" || \
+			_ghqa_write_fallback_attempt "$result_file" "$path" 0 \
+				"$([[ "$rc" -eq 0 ]] && printf success || printf error)" "$elapsed_ms" ""
 	else
 		_ghqa_write_fallback_attempt "$result_file" "$path" 0 \
 			"$([[ "$rc" -eq 0 ]] && printf success || printf error)" "$elapsed_ms" ""

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -85,6 +85,9 @@ if [[ "$1" == "auth" && "$2" == "token" ]]; then
 	printf '%s\n' 'fixture-token'
 	exit 0
 fi
+if [[ -n "${STUB_GH_CALL_LOG:-}" ]]; then
+	printf '%s\t%s\n' "${1:-}" "${2:-}" >>"$STUB_GH_CALL_LOG"
+fi
 : >"$STUB_GH_LOG"
 for arg in "$@"; do
 	printf '%s\n' "$arg" >>"$STUB_GH_LOG"
@@ -175,6 +178,10 @@ if [[ "$1" == "api" && "$2" == "-i" && "$3" =~ ^/search/issues\? ]]; then
 	fixture='{"items":[{"number":22350,"state":"open","title":"Authored PR","html_url":"https://github.com/owner/repo/pull/22350","user":{"login":"managed"},"pull_request":{"merged_at":null}}]}'
 	printf 'HTTP/2 200\r\nX-RateLimit-Resource: search\r\n\r\n%s\n' "$fixture"
 	exit 0
+fi
+if [[ "${STUB_REST_READ_FAIL:-0}" == "1" && "$1" == "api" && \
+	"$2" =~ ^/repos/[^/]+/[^/]+/(issues|pulls)(\?|/|$) ]]; then
+	exit "${STUB_REST_READ_EXIT_CODE:-42}"
 fi
 if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+/pulls\? ]]; then
 	jq_filter=""
@@ -285,6 +292,7 @@ export STUB_SIG_LOG="$TMP/sig-argv.log"
 export STUB_GH_BODY_LOG="$TMP/gh-body.log"
 export STUB_GH_BODY_PATH_LOG="$TMP/gh-body-path.log"
 export STUB_GH_MAIN_CALL_LOG="$TMP/gh-main-call.log"
+export STUB_GH_CALL_LOG="$TMP/gh-call.log"
 
 SHIM_RUN="$TMP/scripts/gh"
 
@@ -304,6 +312,7 @@ _reset_log() {
 	: >"$STUB_GH_BODY_LOG"
 	: >"$STUB_GH_BODY_PATH_LOG"
 	: >"$STUB_GH_MAIN_CALL_LOG"
+	: >"$STUB_GH_CALL_LOG"
 	return 0
 }
 
@@ -749,10 +758,40 @@ AIDEVOPS_GH_REST_FIRST_READS=1 "$SHIM_RUN" pr list --repo owner/repo \
 	--state open --json number,reviewDecision,headRefOid 2>/dev/null || true
 argv=$(_read_argv)
 if [[ "$argv" == $'pr\nlist\n--repo\nowner/repo\n--state\nopen\n--json\nnumber,reviewDecision,headRefOid' ]] &&
-	grep -q $'\tgh_pr_list\tgraphql' "$AIDEVOPS_GH_API_LOG"; then
+	awk -F '\t' '$2 == "gh_pr_list" && $3 == "graphql" && $6 == "graphql-selected" { found = 1 } END { exit found ? 0 : 1 }' \
+		"$AIDEVOPS_GH_API_LOG"; then
 	_pass "REST-first leaves GraphQL-only pr list fields on GraphQL"
 else
 	_fail "REST-first GraphQL-only pr list preservation" "argv: $argv log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
+fi
+
+echo ""
+echo "Test 15f: failed REST rewrite uses default telemetry and does not retry through GraphQL"
+_reset_log
+default_log_home="$TMP/default-log-home"
+default_api_log="$default_log_home/.aidevops/logs/gh-api-calls.log"
+mkdir -p "$default_log_home/.aidevops/logs"
+rm -f "$default_api_log"
+rest_failure_rc=0
+env -u AIDEVOPS_GH_API_LOG HOME="$default_log_home" GH_TOKEN=fixture-token \
+	AIDEVOPS_GH_REST_FIRST_READS=1 AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$TMP/rest-rewrite-failure-state" AIDEVOPS_TEMP_DIR="$TMP" \
+	STUB_REST_READ_FAIL=1 STUB_REST_READ_EXIT_CODE=42 STUB_GH_DEBUG_RESPONSE=1 \
+	STUB_BOOTSTRAP_CORE_USED=100 STUB_GH_DEBUG_RESOURCE=core STUB_GH_DEBUG_STATUS=403 \
+	STUB_GH_DEBUG_USED=101 STUB_GH_DEBUG_REMAINING=4899 STUB_GH_DEBUG_RESET=2000 \
+	"$SHIM_RUN" issue list --repo owner/repo --state open --json number,title \
+	>/dev/null 2>/dev/null || rest_failure_rc=$?
+rest_api_calls=$(awk -F '\t' '$1 == "api" && $2 ~ /^\/repos\// { count++ } END { print count + 0 }' "$STUB_GH_CALL_LOG")
+native_issue_calls=$(awk -F '\t' '$1 == "issue" && $2 == "list" { count++ } END { print count + 0 }' "$STUB_GH_CALL_LOG")
+if [[ "$rest_failure_rc" -ne 0 && "$rest_api_calls" -eq 1 && "$native_issue_calls" -eq 0 ]] &&
+	awk -F '\t' '$9 == "attempt" && $15 == "403" { found = 1 } END { exit found ? 0 : 1 }' \
+		"$default_api_log" &&
+	! awk -F '\t' '$2 == "gh_issue_list" && $3 == "graphql" { found = 1 } END { exit found ? 0 : 1 }' \
+		"$default_api_log"; then
+	_pass "attempted REST failure propagates without duplicate GraphQL request"
+else
+	_fail "failed REST rewrite propagation" \
+		"rc: $rest_failure_rc REST calls: $rest_api_calls native calls: $native_issue_calls log: $(cat "$default_api_log" 2>/dev/null || true)"
 fi
 
 echo ""
@@ -1341,6 +1380,23 @@ else
 	_fail "native single-frame auth REST quota attribution" "log: $(cat "$native_single_log" 2>/dev/null || true)"
 fi
 
+opaque_single_log="$TMP/exact-native-opaque-single-rest.log"
+opaque_single_state="$TMP/exact-native-opaque-single-rest-state"
+: >"$opaque_single_log"
+GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_EXPLICIT_PAGINATION_DISABLE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$opaque_single_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$opaque_single_log" STUB_GH_DEBUG_RESPONSE=1 \
+	STUB_BOOTSTRAP_CORE_USED=100 STUB_GH_DEBUG_RESOURCE=core \
+	STUB_GH_DEBUG_STATUS=200 STUB_GH_DEBUG_USED=101 STUB_GH_DEBUG_REMAINING=4899 \
+	STUB_GH_DEBUG_RESET=2000 "$SHIM_RUN" api /repos/owner/repo --paginate >/dev/null 2>/dev/null
+if [[ "$(_read_last_attempt_field "$opaque_single_log" 12)" == "1" \
+	&& "$(_read_attempt_quota "$opaque_single_log")" == "1" ]]; then
+	_pass "single complete native-pagination frame resolves to page one"
+else
+	_fail "single complete native-pagination page attribution" "log: $(cat "$opaque_single_log" 2>/dev/null || true)"
+fi
+
 incomplete_log="$TMP/exact-incomplete-rest.log"
 incomplete_state="$TMP/exact-incomplete-rest-state"
 : >"$incomplete_log"
@@ -1357,6 +1413,30 @@ if [[ "$(_read_attempt_quota "$incomplete_log")" == "unknown" \
 	_pass "one incomplete request frame preserves exact caller-owned page"
 else
 	_fail "incomplete request page attribution" "log: $(cat "$incomplete_log" 2>/dev/null || true)"
+fi
+
+incomplete_multi_log="$TMP/exact-incomplete-multi-rest.log"
+incomplete_multi_state="$TMP/exact-incomplete-multi-rest-state"
+: >"$incomplete_multi_log"
+if GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_EXPLICIT_PAGINATION_DISABLE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$incomplete_multi_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$incomplete_multi_log" STUB_GH_DEBUG_RESPONSE=1 \
+	STUB_GH_DEBUG_MULTI_FRAME=1 STUB_GH_DEBUG_REQUEST_ONLY=1 STUB_GH_EXIT_CODE=1 \
+	"$SHIM_RUN" api /repos/owner/repo --paginate >/dev/null 2>/dev/null; then
+	_fail "incomplete multi-frame response status" "stub failure unexpectedly succeeded"
+fi
+incomplete_multi_summary=$(awk -F '\t' '$2 == "gh_api_rest" && $9 == "attempt" {
+	count++
+	pages = pages (pages ? "," : "") $12
+	unknown_quota += ($17 == "")
+	known_elapsed += ($16 ~ /^[0-9]+$/)
+} END { print count "|" pages "|" unknown_quota "|" known_elapsed }' "$incomplete_multi_log")
+if [[ "$incomplete_multi_summary" == "3|1,2,3|3|3" ]]; then
+	_pass "incomplete native pagination preserves every recognized frame and page"
+else
+	_fail "incomplete multi-frame page attribution" \
+		"summary: $incomplete_multi_summary log: $(cat "$incomplete_multi_log" 2>/dev/null || true)"
 fi
 
 gap_log="$TMP/exact-counter-gap.log"


### PR DESCRIPTION
## Summary

Preserve one exact attempt per recognized GH debug frame, assign positive native-pagination pages, distinguish native GraphQL selection from REST fallback, and prevent HTTP-backed REST failures from issuing a duplicate GraphQL request.

## Files Changed

.agents/scripts/gh, .agents/scripts/gh-quota-attribution-lib.sh, .agents/scripts/tests/test-gh-shim.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — runtime-verified: executed bash .agents/scripts/tests/test-gh-shim.sh against the real shim with stubbed transports (106 passed); direct ShellCheck, git diff --check, Bash 3.2 compatibility, portability, secret scans, and scoped linters-local passed.

Resolves #28907


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.197 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.5 spent 12d 22h and 47,780,727 tokens on this with the user in an interactive session.