### PR TITLE
GH#28781: Add deterministic filtered mailbox ingestion

### DIFF
--- a/.agents/aidevops/knowledge-plane/02-email-sources.md
+++ b/.agents/aidevops/knowledge-plane/02-email-sources.md
@@ -226,58 +226,99 @@ aidevops email thread  <message-id> [knowledge-root]     # Look up thread by mes
 Helper: `.agents/scripts/email-thread-helper.sh`.
 Python module: `.agents/scripts/email_thread.py`.
 
-## Email Filter → Case-Attach (t2856)
+## Filtered Mailbox Collection and Case Routing
 
-Sieve-style rules in `_config/email-filters.json` auto-attach matched email
-sources to cases when the filter tick runs (routine `r045`, every 15 min).
+Version 2 rules in `_config/email-filters.json` are shared by mailbox collection
+and post-ingest case routing. Copy the sanitized template from
+`.agents/templates/email-filters-config.json`; keep real addresses, domains,
+references, and phrases in the private working configuration.
 
-**Filter config:** `<repo>/_config/email-filters.json` (template at `.agents/templates/email-filters-config.json`):
+### Deterministic match grammar
 
-```json
-{
-  "rules": [
-    {
-      "name": "Dispute counsel correspondence",
-      "match": {
-        "from_contains": "counsel@example.com",
-        "subject_contains_any": ["Re: Dispute"]
-      },
-      "actions": [
-        { "attach_to_case": "case-2026-0001-dispute-acme", "role": "evidence" },
-        { "set_sensitivity": "privileged" }
-      ]
-    }
-  ]
-}
-```
+Each rule has a stable `id`, optional `mailboxes` and `folders` selectors, and a
+`match` object containing `all` and/or `any` condition arrays. Every `all`
+condition must match and at least one `any` condition must match when `any` is
+present.
 
-**Match predicates (AND semantics — all must match):**
+| Field | Operators | Behavior |
+|-------|-----------|----------|
+| `from`, `to`, `cc`, available `bcc` | `exact_address`, `exact_domain` | Parsed addr-spec or complete IDNA-normalized domain equality; never suffix matching |
+| `direction` | `equals` | `sent`, `received`, or `either`, relative to verified mailbox identities |
+| `subject`, `body`, `header`, `attachment_name` | `exact`, `phrase`, `keyword`, `reference` | NFKC Unicode normalization; configurable case sensitivity; deterministic whitespace |
+| `reference`, `keyword`, `phrase` | same text operators | Shorthand fields with `target` set to `subject`, `body`, `attachment_name`, or the default subject+body corpus |
 
-| Predicate | Type | Description |
-|-----------|------|-------------|
-| `from_contains` | string | Partial match on From/Sender (case-insensitive) |
-| `from_equals` | string | Exact match on From/Sender |
-| `subject_contains_any` | string[] | Any element present in Subject (case-insensitive) |
-| `subject_matches_regex` | string | Python regex matched against Subject |
-| `body_contains` | string | Partial match on body_preview/body |
-| `has_attachment_kind` | string | Attachment kind present in `attachments[]` |
+`keyword` uses Unicode word boundaries. `reference` additionally treats hyphens
+as identifier characters, so `CASE-12` cannot match `CASE-123`. A missing BCC
+field is a coverage gap, not a successful negative assertion.
 
-**Actions:**
+### Collection authority and privacy
 
-| Action | Description |
-|--------|-------------|
-| `attach_to_case` + `role` | Calls `case-helper.sh attach <case-id> <source-id> --role <role>` |
-| `set_sensitivity` | Updates `sensitivity` field in meta.json |
+- IMAP selects folders read-only and fetches with `BODY.PEEK[]`; JMAP uses read
+  methods. Filtered collection never marks, moves, labels, flags, deletes,
+  replies to, or sends mail.
+- Server search predicates are optional candidate optimizations only.
+  `email_match_rules.py` always performs the final local check.
+- Only locally confirmed matches enter `_knowledge/inbox/`. Unmatched content
+  is not written; state records only counts, field names, timestamps, and rule
+  IDs/digests.
+- A mailbox keeps legacy unfiltered polling until a collection rule targets it.
+  Once targeted, collection is fail-closed across that mailbox: folders without
+  a selected rule persist nothing, and disabling every selected rule pauses
+  collection rather than reverting to unfiltered reads. Rules with
+  `collection: false` remain routing-only and do not enable this gate.
+- An unreadable or explicitly unsupported filter-config version stops polling;
+  it never silently falls back to unfiltered persistence. Versionless legacy
+  routing configs remain post-ingest-only before collection migration. After
+  filtered lineage state exists, a missing or versionless config also stops
+  polling; an explicit v2 config is required to opt back into unfiltered reads.
+- Each mailbox/folder/transport/rule digest has an independent checkpoint in
+  `_knowledge/.imap-state.json`. A rule edit creates a new lineage and runs the
+  configured bounded `backfill.limit` (default 500, maximum 5000). IMAP and JMAP
+  checkpoints record content-free candidate totals, continuation state, and a
+  `backfill_truncated` marker when more history existed than the configured bound.
+- Overlapping rules write one deterministic staging file plus an adjacent,
+  content-free `.collection.json` receipt containing transport, mailbox, folder,
+  opaque message key, and matching rule IDs/digests. Canonical ingest merges
+  those receipts into `meta.json.collection_refs`, including when the message
+  already exists, while preserving one message/attachment graph.
 
-**Filter state:** `_knowledge/.email-filter-state.json` — last-processed source ID, prevents double-processing.
+For JMAP provider accounts, `email-mailbox-helper.sh sync <account> --folder
+<folder>` auto-detects `_config/email-filters.json`. It gives the provider
+account slug to the rule's `mailboxes` selector, downloads raw RFC-822 blobs only
+after local matches, and stages those blobs in `_knowledge/inbox/`. The JMAP
+collector uses only `Mailbox/get`, `Email/query`, `Email/queryChanges`,
+`Email/get`, and authenticated blob downloads; terminal failures retain the
+prior checkpoint and remove incomplete staging. Malformed downloaded MIME is a
+terminal failure and never enters the inbox.
 
-**Audit log:** `_cases/<case-id>/comms/email-attach.jsonl` — one line per attachment action.
+JMAP callers can also pass `--filter-config`, `--rule-id`, and repeatable
+`--account-identity` to `email_jmap_adapter.py fetch_body`. A non-match returns
+only a content-free explanation and exit status 3, so callers cannot persist an
+unconfirmed body accidentally.
+
+### Case actions and compatibility
+
+`email-filter-helper.sh` uses the same v2 matcher for already-ingested messages.
+`attach_to_case` creates a source reference; `set_sensitivity` updates source
+metadata. Interactive `filter add` rules default to `collection: false` so a
+new routing rule cannot unexpectedly suppress mailbox ingestion. Existing
+versionless legacy predicates remain post-ingest compatible but never become
+collection authorities. An explicit `collection: true` rule runs actions only
+when canonical metadata contains its exact rule ID/digest receipt; routing-only
+rules remain global. Routing state includes an enabled-ruleset digest and
+per-source collection-reference digests. Match/action edits replay canonical
+sources, and a receipt merged into pre-existing evidence replays that source
+without reprocessing unchanged evidence.
 
 ```bash
-aidevops email filter tick   [knowledge-root]             # Run filter pass (called by r045)
-aidevops email filter list   [knowledge-root]             # List rules with match summaries
-aidevops email filter add    [knowledge-root]             # Interactive rule builder
-aidevops email filter test   <rule-name> [knowledge-root] # Dry-run against last 50 sources
+aidevops email filter tick   [knowledge-root]
+aidevops email filter list   [knowledge-root]
+aidevops email filter add    [knowledge-root]
+aidevops email filter test   <rule-name> [knowledge-root]
 ```
 
-Helper: `.agents/scripts/email-filter-helper.sh`.
+Dry-run explanations include only the rule ID, matched field names, and missing
+field names. Helpers: `.agents/scripts/email_match_rules.py`,
+`.agents/scripts/email-poll-helper.sh`, `.agents/scripts/email_jmap_collection.py`,
+`.agents/scripts/email-mailbox-helper.sh`, and
+`.agents/scripts/email-filter-helper.sh`.

--- a/.agents/scripts/email-filter-helper.sh
+++ b/.agents/scripts/email-filter-helper.sh
@@ -33,8 +33,12 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 init_log_file
 
 readonly CASE_HELPER="${SCRIPT_DIR}/case-helper.sh"
+readonly MATCH_RULES_PY="${SCRIPT_DIR}/email_match_rules.py"
+readonly COLLECTION_RECEIPTS_PY="${SCRIPT_DIR}/email_collection_receipts.py"
 readonly DEFAULT_FILTER_CONFIG_NAME="_config/email-filters.json"
 readonly FILTER_STATE_FILENAME=".email-filter-state.json"
+readonly _RULE_OPERATOR_KEY="operator"
+readonly _RULE_VALUE_KEY="value"
 
 # =============================================================================
 # Root resolution
@@ -82,6 +86,36 @@ _resolve_filter_state() {
 	echo "${knowledge_root}/${FILTER_STATE_FILENAME}"
 }
 
+_resolve_mailbox_config() {
+	local knowledge_root="$1"
+	local repo_config
+	repo_config="$(dirname "$knowledge_root")/_config/mailboxes.json"
+	if [[ -f "$repo_config" ]]; then
+		printf '%s\n' "$repo_config"
+		return 0
+	fi
+	local global_config="${HOME}/.config/aidevops/mailboxes.json"
+	[[ -f "$global_config" ]] && printf '%s\n' "$global_config"
+	return 0
+}
+
+_rule_account_identities() {
+	local rule_json="$1" knowledge_root="$2"
+	local mailbox_config
+	mailbox_config="$(_resolve_mailbox_config "$knowledge_root")"
+	[[ -n "$mailbox_config" ]] || return 0
+	local mailbox_ids
+	mailbox_ids="$(_jq_c "$rule_json" '.mailboxes // []')"
+	jq -r --argjson ids "$mailbox_ids" '
+        [.mailboxes[]
+         | .id as $id
+         | select(($ids | length) == 0 or ($ids | index($id)) != null)
+         | ((.identities // []) + [(.user // empty)])[]]
+        | unique[]
+    ' "$mailbox_config" 2>/dev/null || true
+	return 0
+}
+
 _resolve_cases_dir() {
 	local knowledge_root="$1"
 	local parent
@@ -101,6 +135,14 @@ _check_deps() {
 	fi
 	if ! command -v python3 &>/dev/null; then
 		print_error "python3 is required for regex matching."
+		ok=0
+	fi
+	if [[ ! -f "$MATCH_RULES_PY" ]]; then
+		print_error "email_match_rules.py is required for version 2 filters."
+		ok=0
+	fi
+	if [[ ! -f "$COLLECTION_RECEIPTS_PY" ]]; then
+		print_error "email_collection_receipts.py is required for collection rules."
 		ok=0
 	fi
 	[[ "$ok" -eq 1 ]] && return 0 || return 1
@@ -155,12 +197,49 @@ _load_filter_state() {
 	fi
 }
 
+_load_filter_state_digest() {
+	local state_file="$1"
+	if [[ -f "$state_file" ]]; then
+		jq -r '.rules_digest // ""' "$state_file" 2>/dev/null || true
+	else
+		echo ""
+	fi
+	return 0
+}
+
+_load_filter_source_digests() {
+	local state_file="$1"
+	if [[ -f "$state_file" ]]; then
+		jq -c '.source_collection_digests // {}' "$state_file" 2>/dev/null || echo '{}'
+	else
+		echo '{}'
+	fi
+	return 0
+}
+
+_filter_rules_digest() {
+	local filter_json="$1"
+	printf '%s' "$filter_json" |
+		jq -cS '[.rules[] | select(if has("enabled") then .enabled else true end)]' |
+		python3 -c 'import hashlib, sys; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest()[:16])'
+	return 0
+}
+
+_source_collection_digest() {
+	local meta_path="$1"
+	jq -cS '.collection_refs // []' "$meta_path" |
+		python3 -c 'import hashlib, sys; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest()[:16])'
+	return 0
+}
+
 _save_filter_state() {
-	local state_file="$1" last_id="$2"
+	local state_file="$1" last_id="$2" rules_digest="$3" source_digests="$4"
 	local ts
 	ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date +%Y-%m-%dT%H:%M:%SZ)"
-	printf '{"last_processed_source_id": "%s", "updated_at": "%s"}\n' \
-		"$last_id" "$ts" >"$state_file"
+	jq -n --arg last_id "$last_id" --arg ts "$ts" --arg digest "$rules_digest" \
+		--argjson source_digests "$source_digests" \
+		'{last_processed_source_id: $last_id, updated_at: $ts, rules_digest: $digest, source_collection_digests: $source_digests}' >"$state_file"
+	return 0
 }
 
 # =============================================================================
@@ -188,6 +267,25 @@ _list_email_sources() {
 _get_meta_field() {
 	local meta_path="$1" field="$2"
 	jq -r --arg f "$field" '.[$f] // ""' "$meta_path" 2>/dev/null || true
+}
+
+_rule_is_eligible_for_source() {
+	local rule_json="$1"
+	local meta_path="$2"
+	printf '%s' "$rule_json" |
+		python3 "$COLLECTION_RECEIPTS_PY" eligible --meta "$meta_path" >/dev/null
+	return $?
+}
+
+_rule_collection_mode() {
+	local rule_json="$1"
+	_jq_r "$rule_json" '
+        if has("collection") then .collection
+        elif ((.match // {}) | (has("all") or has("any"))) then true
+        else false
+        end
+    '
+	return 0
 }
 
 # =============================================================================
@@ -262,7 +360,21 @@ _read_two_fields() {
 
 # Returns 0 (match) or 1 (no match)
 _evaluate_rule_match() {
-	local match_json="$1" meta_path="$2"
+	local match_json="$1" meta_path="$2" identities="${3:-}" collection="${4:-false}"
+	local schema_v2
+	schema_v2="$(_jq_r "$match_json" 'if (has("all") or has("any")) then "1" else "0" end')"
+	if [[ "$schema_v2" == "1" ]]; then
+		local identity_args=() identity rule_payload
+		while IFS= read -r identity; do
+			[[ -n "$identity" ]] && identity_args+=(--account-identity "$identity")
+		done <<<"$identities"
+		rule_payload="$(jq -cn --argjson match "$match_json" --argjson collection "$collection" \
+			'{"id":"post-ingest-rule","collection":$collection,"match":$match}')"
+		if printf '%s' "$rule_payload" | python3 "$MATCH_RULES_PY" match-meta --meta "$meta_path" "${identity_args[@]}" >/dev/null; then
+			return 0
+		fi
+		return 1
+	fi
 
 	local from subject body
 	from="$(_read_two_fields "$meta_path" "from" "sender")"
@@ -312,6 +424,21 @@ _evaluate_rule_match() {
 	fi
 
 	return 0
+}
+
+_rule_matches_source() {
+	local collection="$1"
+	local match_json="$2"
+	local meta_path="$3"
+	local identities="$4"
+	# Exact collection provenance already certifies the private transport match.
+	if [[ "$collection" == "true" ]]; then
+		return 0
+	fi
+	if _evaluate_rule_match "$match_json" "$meta_path" "$identities" "$collection"; then
+		return 0
+	fi
+	return 1
 }
 
 # =============================================================================
@@ -391,6 +518,40 @@ _execute_rule_actions() {
 	return 0
 }
 
+_process_source_rules() {
+	local source_id="$1"
+	local meta_path="$2"
+	local filter_json="$3"
+	local rule_count="$4"
+	local knowledge_root="$5"
+	local cases_dir="$6"
+	local dry_run="$7"
+	local matched=1 i=0
+	while [[ "$i" -lt "$rule_count" ]]; do
+		local rule enabled collection
+		rule="$(_jq_c "$filter_json" ".rules[$i]")"
+		enabled="$(_jq_r "$rule" 'if has("enabled") then .enabled else true end')"
+		collection="$(_rule_collection_mode "$rule")"
+		if [[ "$enabled" != "true" ]] || ! _rule_is_eligible_for_source "$rule" "$meta_path"; then
+			i=$((i + 1))
+			continue
+		fi
+		local rule_name match_json actions_json identities
+		rule_name="$(_jq_r "$rule" '.name // "unnamed"')"
+		match_json="$(_jq_c "$rule" '.match // {}')"
+		actions_json="$(_jq_c "$rule" '.actions // []')"
+		identities="$(_rule_account_identities "$rule" "$knowledge_root")"
+		if _rule_matches_source "$collection" "$match_json" "$meta_path" "$identities"; then
+			print_info "Match: ${rule_name} → ${source_id}"
+			_execute_rule_actions "$actions_json" "$source_id" "$meta_path" \
+				"$cases_dir" "$rule_name" "$dry_run"
+			matched=0
+		fi
+		i=$((i + 1))
+	done
+	return "$matched"
+}
+
 # =============================================================================
 # tick: main pulse routine — evaluate all rules against unprocessed sources
 # =============================================================================
@@ -401,7 +562,10 @@ cmd_tick() {
 		local _cur="${1:-}"
 		case "$_cur" in
 		--dry-run) dry_run=1 ;;
-		-*) print_error "Unknown option: ${_cur}"; return 1 ;;
+		-*)
+			print_error "Unknown option: ${_cur}"
+			return 1
+			;;
 		*) knowledge_root="$_cur" ;;
 		esac
 		shift
@@ -428,13 +592,30 @@ cmd_tick() {
 	fi
 
 	# Load state: last processed source_id
-	local last_id
+	local last_id saved_digest rules_digest saved_source_digests
 	last_id="$(_load_filter_state "$state_file")"
+	saved_digest="$(_load_filter_state_digest "$state_file")"
+	saved_source_digests="$(_load_filter_source_digests "$state_file")"
+	rules_digest="$(_filter_rules_digest "$filter_json")"
+	if [[ -n "$last_id" && "$saved_digest" != "$rules_digest" ]]; then
+		last_id=""
+		saved_source_digests='{}'
+	fi
 
 	# Enumerate email sources, filter to those after last_id
-	local sources_list matched_any=0 saw_last=0 last_seen_id=""
+	local matched_any=0 saw_last=0 last_seen_id="" current_source_digests='{}'
 	while IFS=$'\t' read -r source_id meta_path _ingested_at; do
 		[[ -z "$source_id" || -z "$meta_path" ]] && continue
+		local current_source_digest saved_source_digest source_changed=0
+		current_source_digest="$(_source_collection_digest "$meta_path")"
+		saved_source_digest=$(printf '%s' "$saved_source_digests" |
+			jq -r --arg source_id "$source_id" '.[$source_id] // ""')
+		current_source_digests=$(printf '%s' "$current_source_digests" |
+			jq -c --arg source_id "$source_id" --arg digest "$current_source_digest" \
+				'. + {($source_id): $digest}')
+		if [[ -n "$saved_source_digest" && "$saved_source_digest" != "$current_source_digest" ]]; then
+			source_changed=1
+		fi
 
 		# State gate: skip until we've passed last_id
 		if [[ -n "$last_id" && "$saw_last" -eq 0 ]]; then
@@ -442,35 +623,22 @@ cmd_tick() {
 				saw_last=1
 			fi
 			last_seen_id="$source_id"
-			continue
+			if [[ "$source_changed" -eq 0 ]]; then
+				continue
+			fi
 		fi
 
 		last_seen_id="$source_id"
 
-		# Evaluate each rule
-		local i=0
-		while [[ "$i" -lt "$rule_count" ]]; do
-			local rule
-			rule="$(_jq_c "$filter_json" ".rules[$i]")"
-			local rule_name match_json actions_json
-			rule_name="$(_jq_r "$rule" '.name // "unnamed"')"
-			match_json="$(_jq_c "$rule" '.match // {}')"
-			actions_json="$(_jq_c "$rule" '.actions // []')"
-
-			if _evaluate_rule_match "$match_json" "$meta_path"; then
-				print_info "Match: ${rule_name} → ${source_id}"
-				_execute_rule_actions "$actions_json" "$source_id" "$meta_path" \
-					"$cases_dir" "$rule_name" "$dry_run"
-				matched_any=1
-			fi
-
-			i=$((i + 1))
-		done
+		if _process_source_rules "$source_id" "$meta_path" "$filter_json" "$rule_count" \
+			"$knowledge_root" "$cases_dir" "$dry_run"; then
+			matched_any=1
+		fi
 	done < <(_list_email_sources "$sources_dir")
 
 	# Persist state: record last processed source_id
 	if [[ "$dry_run" -eq 0 && -n "$last_seen_id" ]]; then
-		_save_filter_state "$state_file" "$last_seen_id"
+		_save_filter_state "$state_file" "$last_seen_id" "$rules_digest" "$current_source_digests"
 	fi
 
 	if [[ "$matched_any" -eq 0 ]]; then
@@ -485,7 +653,11 @@ cmd_tick() {
 
 cmd_add() {
 	local knowledge_root=""
-	if [[ $# -gt 0 ]]; then local _kr="${1:-}"; knowledge_root="$_kr"; shift; fi
+	if [[ $# -gt 0 ]]; then
+		local _kr="${1:-}"
+		knowledge_root="$_kr"
+		shift
+	fi
 	knowledge_root="$(_resolve_root "$knowledge_root")" || return 1
 	_check_deps || return 1
 
@@ -507,10 +679,11 @@ cmd_add() {
 	[[ -z "$role" ]] && role="evidence"
 	printf 'set_sensitivity (public|internal|confidential|restricted|privileged, leave blank to skip): ' && read -r set_sensitivity
 
-	# Build match object
-	local match_json="{}"
-	[[ -n "$from_contains" ]] && match_json="$(echo "$match_json" | jq --arg v "$from_contains" '.from_contains = $v')"
-	[[ -n "$from_equals" ]] && match_json="$(echo "$match_json" | jq --arg v "$from_equals" '.from_equals = $v')"
+	# Build a version 2 shared matcher block. Interactive rules remain
+	# post-ingest routing rules unless collection selectors are added manually.
+	local match_json='{"all":[],"any":[]}'
+	[[ -n "$from_contains" ]] && match_json="$(echo "$match_json" | jq --arg v "$from_contains" --arg op "$_RULE_OPERATOR_KEY" --arg val "$_RULE_VALUE_KEY" '.all += [{"field":"from",($op):"contains",($val):$v}]')"
+	[[ -n "$from_equals" ]] && match_json="$(echo "$match_json" | jq --arg v "$from_equals" --arg op "$_RULE_OPERATOR_KEY" --arg val "$_RULE_VALUE_KEY" '.all += [{"field":"from",($op):"exact_address",($val):$v}]')"
 	if [[ -n "$subject_contains_any" ]]; then
 		local phrases_json
 		phrases_json="$(echo "$subject_contains_any" | python3 -c "
@@ -519,7 +692,11 @@ raw = sys.stdin.read().strip()
 parts = [p.strip() for p in raw.split(',') if p.strip()]
 print(json.dumps(parts))
 " 2>/dev/null || echo '[]')"
-		match_json="$(echo "$match_json" | jq --argjson a "$phrases_json" '.subject_contains_any = $a')"
+		match_json="$(echo "$match_json" | jq --argjson a "$phrases_json" --arg op "$_RULE_OPERATOR_KEY" --arg val "$_RULE_VALUE_KEY" '.any += [$a[] | {"field":"subject",($op):"phrase",($val):.}]')"
+	fi
+	if [[ "$(echo "$match_json" | jq '[.all[], .any[]] | length')" -eq 0 ]]; then
+		print_error "At least one match condition is required."
+		return 1
 	fi
 
 	# Build actions array
@@ -534,15 +711,16 @@ print(json.dumps(parts))
 	fi
 
 	# Build new rule
-	local new_rule
-	new_rule="$(jq -n --arg n "$rule_name" --argjson m "$match_json" --argjson a "$actions_json" \
-		'{"name": $n, "match": $m, "actions": $a}')"
+	local new_rule rule_id
+	rule_id="$(printf '%s' "$rule_name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g; s/--*/-/g; s/^-//; s/-$//')"
+	new_rule="$(jq -n --arg id "$rule_id" --arg n "$rule_name" --argjson m "$match_json" --argjson a "$actions_json" \
+		'{"id": $id, "name": $n, "collection": false, "match": $m, "actions": $a}')"
 
 	# Load existing config and append
 	local existing_config
 	existing_config="$(_load_filter_config "$config_file")"
 	local updated
-	updated="$(echo "$existing_config" | jq --argjson r "$new_rule" '.rules += [$r]')"
+	updated="$(echo "$existing_config" | jq --argjson r "$new_rule" '.version = 2 | .rules += [$r]')"
 	echo "$updated" >"$config_file"
 
 	print_success "Rule '${rule_name}' added to ${config_file}"
@@ -559,8 +737,14 @@ cmd_test() {
 		print_error "Usage: email-filter-helper.sh test <rule-name> [knowledge-root]"
 		return 1
 	fi
-	local _rn="${1:-}"; rule_name="$_rn"; shift
-	if [[ $# -gt 0 ]]; then local _kr="${1:-}"; knowledge_root="$_kr"; shift; fi
+	local _rn="${1:-}"
+	rule_name="$_rn"
+	shift
+	if [[ $# -gt 0 ]]; then
+		local _kr="${1:-}"
+		knowledge_root="$_kr"
+		shift
+	fi
 	knowledge_root="$(_resolve_root "$knowledge_root")" || return 1
 	_check_deps || return 1
 
@@ -580,9 +764,11 @@ cmd_test() {
 		return 1
 	fi
 
-	local match_json actions_json
+	local match_json actions_json identities collection
 	match_json="$(_jq_c "$rule" '.match // {}')"
 	actions_json="$(_jq_c "$rule" '.actions // []')"
+	identities="$(_rule_account_identities "$rule" "$knowledge_root")"
+	collection="$(_rule_collection_mode "$rule")"
 
 	print_info "Testing rule '${rule_name}' against last 50 email sources (dry-run)…"
 
@@ -598,7 +784,10 @@ cmd_test() {
 	while IFS=$'\t' read -r source_id meta_path _ingested_at; do
 		[[ -z "$source_id" || -z "$meta_path" ]] && continue
 		tested=$((tested + 1))
-		if _evaluate_rule_match "$match_json" "$meta_path"; then
+		if ! _rule_is_eligible_for_source "$rule" "$meta_path"; then
+			continue
+		fi
+		if _rule_matches_source "$collection" "$match_json" "$meta_path" "$identities"; then
 			matched=$((matched + 1))
 			print_info "  WOULD MATCH: ${source_id}"
 			_execute_rule_actions "$actions_json" "$source_id" "$meta_path" "" "$rule_name" 1
@@ -615,7 +804,11 @@ cmd_test() {
 
 cmd_list() {
 	local knowledge_root=""
-	if [[ $# -gt 0 ]]; then local _kr="${1:-}"; knowledge_root="$_kr"; shift; fi
+	if [[ $# -gt 0 ]]; then
+		local _kr="${1:-}"
+		knowledge_root="$_kr"
+		shift
+	fi
 	knowledge_root="$(_resolve_root "$knowledge_root")" || return 1
 	_check_deps || return 1
 

--- a/.agents/scripts/email-ingest-helper.sh
+++ b/.agents/scripts/email-ingest-helper.sh
@@ -23,20 +23,37 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 [[ -z "${NC+x}" ]] && NC='\033[0m'
 
 if ! declare -f print_info >/dev/null 2>&1; then
-	print_info() { local _m="$1"; printf "${BLUE}[INFO]${NC} %s\n" "$_m"; }
+	print_info() {
+		local _m="$1"
+		printf "${BLUE}[INFO]${NC} %s\n" "$_m"
+		return 0
+	}
 fi
 if ! declare -f print_success >/dev/null 2>&1; then
-	print_success() { local _m="$1"; printf "${GREEN}[OK]${NC} %s\n" "$_m"; }
+	print_success() {
+		local _m="$1"
+		printf "${GREEN}[OK]${NC} %s\n" "$_m"
+		return 0
+	}
 fi
 if ! declare -f print_warning >/dev/null 2>&1; then
-	print_warning() { local _m="$1"; printf "${YELLOW}[WARN]${NC} %s\n" "$_m"; }
+	print_warning() {
+		local _m="$1"
+		printf "${YELLOW}[WARN]${NC} %s\n" "$_m"
+		return 0
+	}
 fi
 if ! declare -f print_error >/dev/null 2>&1; then
-	print_error() { local _m="$1"; printf "${RED}[ERROR]${NC} %s\n" "$_m"; }
+	print_error() {
+		local _m="$1"
+		printf "${RED}[ERROR]${NC} %s\n" "$_m"
+		return 0
+	}
 fi
 
 KNOWLEDGE_HELPER="${SCRIPT_DIR}/knowledge-helper.sh"
 EMAIL_PARSER="${SCRIPT_DIR}/email_parse.py"
+COLLECTION_RECEIPTS="${SCRIPT_DIR}/email_collection_receipts.py"
 SENSITIVITY_DETECTOR="${SCRIPT_DIR}/sensitivity-detector-helper.sh"
 DOC_EXTRACTOR="${SCRIPT_DIR}/document-extraction-helper.sh"
 META_DEFAULT_SENSITIVITY="internal"
@@ -97,6 +114,26 @@ _allocate_source_id() {
 	return 0
 }
 
+_existing_email_source() {
+	local sources_dir="$1"
+	local content_sha="$2"
+	local message_id="$3"
+	local meta_path existing_sha existing_message_id existing_kind
+	for meta_path in "${sources_dir}"/*/meta.json; do
+		[[ -f "$meta_path" ]] || continue
+		existing_kind=$(jq -r '.kind // ""' "$meta_path" 2>/dev/null || true)
+		[[ "$existing_kind" == "email" ]] || continue
+		existing_sha=$(jq -r '.sha256 // ""' "$meta_path" 2>/dev/null || true)
+		existing_message_id=$(jq -r '.message_id // ""' "$meta_path" 2>/dev/null || true)
+		if [[ -n "$content_sha" && "$content_sha" != "$_UNKNOWN_STR" && "$existing_sha" == "$content_sha" ]] ||
+			[[ -n "$message_id" && "$existing_message_id" == "$message_id" ]]; then
+			jq -r '.id // ""' "$meta_path" 2>/dev/null
+			return 0
+		fi
+	done
+	return 1
+}
+
 # _sanitise_html: strip tracking pixels and remote beacon images
 # Args: <html-content>  (reads from stdin if no arg)
 _sanitise_html() {
@@ -118,6 +155,7 @@ _sanitise_html() {
 # _write_email_meta: write meta.json with email-specific fields
 # Args: <meta_path> <source_id> <source_uri> <sha256> <size_bytes>
 #        <parsed_json_file> <body_text_sha> <body_html_sha> <child_ids_json>
+#        <collection_receipt_file>
 _write_email_meta() {
 	local meta_path="$1"
 	local source_id="$2"
@@ -128,6 +166,7 @@ _write_email_meta() {
 	local body_text_sha="$7"
 	local body_html_sha="$8"
 	local child_ids_json="$9"
+	local collection_receipt_file="${10}"
 	_require_jq || return 1
 	local ts actor
 	ts=$(date -u +"$_TS_FMT" 2>/dev/null || date +"$_TS_FMT")
@@ -146,6 +185,7 @@ _write_email_meta() {
 		--arg bh_sha "${body_html_sha:-$_NULL_STR}" \
 		--arg nil "$_NULL_STR" \
 		--argjson children "$child_ids_json" \
+		--argjson collection "$(cat "$collection_receipt_file")" \
 		'{
 			version: 1,
 			id: $id,
@@ -169,7 +209,8 @@ _write_email_meta() {
 			references: ($parsed.references // ""),
 			body_text_sha: (if $bt_sha == $nil then null else $bt_sha end),
 			body_html_sha: (if $bh_sha == $nil then null else $bh_sha end),
-			attachments: $children
+			attachments: $children,
+			collection_refs: $collection
 		}' >"$meta_path"
 	return 0
 }
@@ -310,9 +351,20 @@ cmd_ingest() {
 		local _key="$1"
 		shift
 		case "$_key" in
-		--repo-path) local _rp="$1"; repo_path="$_rp"; shift ;;
-		--sensitivity) local _s="$1"; sensitivity_override="$_s"; shift ;;
-		-*) print_error "Unknown option: $_key"; return 1 ;;
+		--repo-path)
+			local _rp="$1"
+			repo_path="$_rp"
+			shift
+			;;
+		--sensitivity)
+			local _s="$1"
+			sensitivity_override="$_s"
+			shift
+			;;
+		-*)
+			print_error "Unknown option: $_key"
+			return 1
+			;;
 		*) [[ -z "$eml_path" ]] && eml_path="$_key" ;;
 		esac
 	done
@@ -329,8 +381,8 @@ cmd_ingest() {
 	repo_path="$(cd "$repo_path" && pwd)"
 	# Resolve knowledge root via knowledge-helper.sh
 	local knowledge_root
-	knowledge_root=$(bash "$KNOWLEDGE_HELPER" status "$repo_path" 2>/dev/null \
-		| grep -oE '/[^ ]*_knowledge' | head -1 || true)
+	knowledge_root=$(bash "$KNOWLEDGE_HELPER" status "$repo_path" 2>/dev/null |
+		grep -oE '/[^ ]*_knowledge' | head -1 || true)
 	if [[ -z "$knowledge_root" ]]; then
 		# Fallback: construct from repo_path
 		knowledge_root="${repo_path}/_knowledge"
@@ -360,6 +412,27 @@ _do_ingest() {
 		rm -rf "$parse_dir"
 		return 1
 	fi
+	local collection_receipt_file="${parse_dir}/collection-receipt.json"
+	if ! python3 "$COLLECTION_RECEIPTS" extract --eml "$eml_path" >"$collection_receipt_file"; then
+		print_error "Invalid email collection receipt: $eml_path"
+		rm -rf "$parse_dir"
+		return 1
+	fi
+	local eml_sha256 parsed_message_id existing_source_id
+	eml_sha256=$(_sha256_file "$eml_path") || eml_sha256="$_UNKNOWN_STR"
+	parsed_message_id=$(jq -r '.message_id // ""' "$parsed_json_file")
+	if existing_source_id=$(_existing_email_source "$sources_dir" "$eml_sha256" "$parsed_message_id"); then
+		if ! python3 "$COLLECTION_RECEIPTS" merge-meta \
+			--eml "$eml_path" \
+			--meta "${sources_dir}/${existing_source_id}/meta.json"; then
+			print_error "Failed to merge collection references: $existing_source_id"
+			rm -rf "$parse_dir"
+			return 1
+		fi
+		rm -rf "$parse_dir"
+		print_success "Ingested email (existing canonical): $existing_source_id"
+		return 0
+	fi
 	# Allocate parent source ID
 	local basename_no_ext
 	basename_no_ext="$(basename "$eml_path")"
@@ -371,8 +444,7 @@ _do_ingest() {
 	# Store body files
 	_store_body_files "$parsed_json_file" "$source_dir" "$parse_dir"
 	# Compute hashes
-	local eml_sha256 eml_size body_text_sha body_html_sha
-	eml_sha256=$(_sha256_file "$eml_path") || eml_sha256="$_UNKNOWN_STR"
+	local eml_size body_text_sha body_html_sha
 	eml_size=$(wc -c <"$eml_path" | tr -d ' ')
 	body_text_sha=$(_compute_body_sha "${source_dir}/text.txt")
 	body_html_sha=$(_compute_body_sha "${source_dir}/body.html")
@@ -386,7 +458,8 @@ _do_ingest() {
 	source_uri="file://${abs_path}"
 	_write_email_meta "${source_dir}/meta.json" "$source_id" "$source_uri" \
 		"$eml_sha256" "$eml_size" "$parsed_json_file" \
-		"$body_text_sha" "$body_html_sha" "$children_json"
+		"$body_text_sha" "$body_html_sha" "$children_json" \
+		"$collection_receipt_file"
 	# Run sensitivity on parent
 	_run_sensitivity "$source_id" "$knowledge_root"
 	# Apply sensitivity override if provided
@@ -484,7 +557,7 @@ main() {
 	local subcommand="${1:-help}"
 	shift || true
 	case "$subcommand" in
-	ingest)  cmd_ingest "$@" ;;
+	ingest) cmd_ingest "$@" ;;
 	help | -h | --help) cmd_help ;;
 	*)
 		print_error "Unknown subcommand: $subcommand"

--- a/.agents/scripts/email-mailbox-helper.sh
+++ b/.agents/scripts/email-mailbox-helper.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 #   email-mailbox-helper.sh flag [account] --email-id ID --flag NAME [--clear]  (JMAP)
 #   email-mailbox-helper.sh search [account] --query "SEARCH" [--folder FOLDER] [--limit N]
 #   email-mailbox-helper.sh smart-mailbox [account] --name NAME --criteria "SEARCH"
-#   email-mailbox-helper.sh sync [account] [--folder FOLDER] [--full]
+#   email-mailbox-helper.sh sync [account] [--folder FOLDER] [--full] [--dry-run]
 #   email-mailbox-helper.sh push [account] [--types mail] [--timeout 300]  (JMAP only)
 #   email-mailbox-helper.sh help
 #
@@ -46,6 +46,7 @@ readonly PROVIDERS_CONFIG="${CONFIG_DIR}/email-providers.json"
 readonly IMAP_ADAPTER="${SCRIPT_DIR}/email_imap_adapter.py"
 readonly JMAP_ADAPTER="${SCRIPT_DIR}/email_jmap_adapter.py"
 readonly MAILBOX_WORKSPACE="${HOME}/.aidevops/.agent-workspace/email-mailbox"
+readonly COLLECTION_LINEAGE_FILTERED="filtered"
 
 # ============================================================================
 # Dependency checks
@@ -355,6 +356,58 @@ get_preferred_protocol() {
 	else
 		echo "imap"
 	fi
+	return 0
+}
+
+_collection_state_lineage_status() {
+	local state_path="$1"
+	local lineage_marker="$2"
+	if [[ ! -f "$state_path" ]]; then
+		printf '%s\n' "none"
+		return 0
+	fi
+	if ! jq -e 'type == "object"' "$state_path" >/dev/null 2>&1; then
+		print_error "Invalid ${state_path}; refusing unfiltered JMAP collection"
+		return 1
+	fi
+	if jq -e --arg marker "$lineage_marker" '[keys[] | select(contains($marker))] | length > 0' "$state_path" >/dev/null 2>&1; then
+		printf '%s\n' "$COLLECTION_LINEAGE_FILTERED"
+	else
+		printf '%s\n' "none"
+	fi
+	return 0
+}
+
+_resolve_auto_collection_filter_config() {
+	local config_path="$1"
+	local state_path="$2"
+	local lineage_status
+	lineage_status=$(_collection_state_lineage_status "$state_path" "/jmap/filter/") || return 1
+	if [[ ! -f "$config_path" ]]; then
+		if [[ "$lineage_status" == "$COLLECTION_LINEAGE_FILTERED" ]]; then
+			print_error "Missing ${config_path} after filtered collection; refusing unfiltered JMAP collection"
+			return 1
+		fi
+		return 0
+	fi
+	if ! jq -e 'type == "object"' "$config_path" >/dev/null 2>&1; then
+		print_error "Invalid ${config_path}; refusing unfiltered JMAP collection"
+		return 1
+	fi
+	local version
+	version=$(jq -r 'if has("version") then (.version | tostring) else "" end' "$config_path")
+	if [[ -z "$version" ]]; then
+		if [[ "$lineage_status" == "$COLLECTION_LINEAGE_FILTERED" ]]; then
+			print_error "Versionless ${config_path} cannot replace prior filtered collection; use an explicit version 2 config"
+			return 1
+		fi
+		return 0
+	fi
+	if [[ "$version" != "2" ]]; then
+		print_error "Unsupported email filter version ${version}; refusing unfiltered JMAP collection"
+		return 1
+	fi
+	printf '%s\n' "$config_path"
 	return 0
 }
 
@@ -953,7 +1006,8 @@ cmd_smart_mailbox() {
 }
 
 cmd_sync() {
-	local account="${1:-}"
+	local account_arg="${1:-}"
+	local account="$account_arg"
 	shift || true
 
 	if [[ -z "$account" ]]; then
@@ -961,20 +1015,55 @@ cmd_sync() {
 		return 1
 	fi
 
-	local folder="INBOX" full_sync=false
+	local folder="INBOX" full_sync=false dry_run=false
+	local filter_config="" filter_config_explicit=false
+	local state_path="_knowledge/.imap-state.json"
+	local inbox_dir="_knowledge/inbox"
 	while [[ $# -gt 0 ]]; do
-		case "$1" in
+		local flag="${1:-}"
+		case "$flag" in
 		--folder)
-			folder="$2"
+			local folder_arg="${2:-}"
+			folder="$folder_arg"
 			shift 2
 			;;
 		--full)
 			full_sync=true
 			shift
 			;;
-		*) shift ;;
+		--filter-config)
+			if [[ $# -lt 2 || -z "${2:-}" ]]; then
+				print_error "--filter-config requires a non-empty path"
+				return 1
+			fi
+			local filter_arg="$2"
+			filter_config="$filter_arg"
+			filter_config_explicit=true
+			shift 2
+			;;
+		--state)
+			local state_arg="${2:-}"
+			state_path="$state_arg"
+			shift 2
+			;;
+		--inbox)
+			local inbox_arg="${2:-}"
+			inbox_dir="$inbox_arg"
+			shift 2
+			;;
+		--dry-run)
+			dry_run=true
+			shift
+			;;
+		*)
+			print_error "Unknown sync option: $flag"
+			return 1
+			;;
 		esac
 	done
+	if [[ "$filter_config_explicit" == "false" ]]; then
+		filter_config=$(_resolve_auto_collection_filter_config "_config/email-filters.json" "$state_path") || return 1
+	fi
 
 	local extra_args=(--folder "$folder")
 	if [[ "$full_sync" == "true" ]]; then
@@ -988,6 +1077,17 @@ cmd_sync() {
 		local jmap_args=(--mailbox "$folder")
 		if [[ "$full_sync" == "true" ]]; then
 			jmap_args+=(--full)
+		fi
+		if [[ -n "$filter_config" ]]; then
+			jmap_args+=(
+				--filter-config "$filter_config"
+				--collection-mailbox-id "$account"
+				--state "$state_path"
+				--inbox "$inbox_dir"
+			)
+		fi
+		if [[ "$dry_run" == "true" ]]; then
+			jmap_args+=(--dry-run)
 		fi
 		run_jmap_adapter "$account" "index_sync" "${jmap_args[@]}"
 	else
@@ -1057,7 +1157,7 @@ Commands:
   flag <account> --email-id --flag  Set/clear a keyword (JMAP)
   search <account> --query       Search messages
   smart-mailbox <account> --name --criteria  Create a saved search
-  sync <account> [--folder] [--full]  Sync folder headers to local index
+  sync <account> [--folder] [--full]  Sync headers or collect matched JMAP mail
   push <account> [--types] [--timeout]  Push notifications (JMAP only)
   help                           Show this help
 
@@ -1072,6 +1172,10 @@ Options:
   --clear         Clear a flag instead of setting it
   --query SEARCH  Search criteria (IMAP SEARCH string or JMAP filter JSON)
   --full          Full sync (not incremental)
+  --filter-config Version 2 private rules (auto-detected in _config/)
+  --state PATH    Content-free JMAP collection state
+  --inbox PATH    Knowledge inbox for matched JMAP .eml files
+  --dry-run       Match JMAP candidates without evidence or state writes
   --test          Test connectivity when listing accounts
   --types TYPES   Push event types, comma-separated (default: mail)
   --timeout SECS  Push listen timeout in seconds (default: 300)

--- a/.agents/scripts/email-poll-helper.sh
+++ b/.agents/scripts/email-poll-helper.sh
@@ -37,10 +37,12 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 
 readonly POLL_PY="${SCRIPT_DIR}/email_poll.py"
 readonly _ERR_NO_CONFIG="No mailboxes.json config found"
+readonly COLLECTION_LINEAGE_FILTERED="filtered"
 
 # Config resolution order (first-found wins)
 _REPO_CONFIG="_config/mailboxes.json"
 _GLOBAL_CONFIG="${HOME}/.config/aidevops/mailboxes.json"
+_FILTER_CONFIG="_config/email-filters.json"
 
 # State and inbox paths (relative to CWD = repo root)
 _STATE_FILE="_knowledge/.imap-state.json"
@@ -83,6 +85,67 @@ _require_poll_py() {
 	return 0
 }
 
+_collection_state_lineage_status() {
+	local state_path="$1"
+	local lineage_marker="$2"
+	if [[ ! -f "$state_path" ]]; then
+		printf '%s\n' "none"
+		return 0
+	fi
+	if ! command -v jq >/dev/null 2>&1; then
+		log_error "jq is required to inspect ${state_path}; refusing unfiltered mailbox collection"
+		return 1
+	fi
+	if ! jq -e 'type == "object"' "$state_path" >/dev/null 2>&1; then
+		log_error "Invalid ${state_path}; refusing unfiltered mailbox collection"
+		return 1
+	fi
+	if jq -e --arg marker "$lineage_marker" '[keys[] | select(contains($marker))] | length > 0' "$state_path" >/dev/null 2>&1; then
+		printf '%s\n' "$COLLECTION_LINEAGE_FILTERED"
+	else
+		printf '%s\n' "none"
+	fi
+	return 0
+}
+
+_resolve_collection_filter_config() {
+	# Versionless legacy filters remain post-ingest-only until a mailbox has
+	# filtered lineage state. After migration, only an explicit v2 ruleset may
+	# restore unfiltered reads (for example, collection:false on every rule).
+	local lineage_status
+	lineage_status=$(_collection_state_lineage_status "$_STATE_FILE" "/imap/filter/") || return 1
+	if [[ ! -f "$_FILTER_CONFIG" ]]; then
+		if [[ "$lineage_status" == "$COLLECTION_LINEAGE_FILTERED" ]]; then
+			log_error "Missing ${_FILTER_CONFIG} after filtered collection; refusing unfiltered mailbox collection"
+			return 1
+		fi
+		return 0
+	fi
+	if ! command -v jq >/dev/null 2>&1; then
+		log_error "jq is required to validate ${_FILTER_CONFIG}; refusing unfiltered mailbox collection"
+		return 1
+	fi
+	if ! jq -e 'type == "object"' "$_FILTER_CONFIG" >/dev/null 2>&1; then
+		log_error "Invalid ${_FILTER_CONFIG}; refusing unfiltered mailbox collection"
+		return 1
+	fi
+	local version
+	version=$(jq -r 'if has("version") then (.version | tostring) else "" end' "$_FILTER_CONFIG")
+	if [[ -z "$version" ]]; then
+		if [[ "$lineage_status" == "$COLLECTION_LINEAGE_FILTERED" ]]; then
+			log_error "Versionless ${_FILTER_CONFIG} cannot replace prior filtered collection; use an explicit version 2 config"
+			return 1
+		fi
+		return 0
+	fi
+	if [[ "$version" != "2" ]]; then
+		log_error "Unsupported email filter version ${version}; refusing unfiltered mailbox collection"
+		return 1
+	fi
+	printf '%s\n' "$_FILTER_CONFIG"
+	return 0
+}
+
 _acquire_lock() {
 	mkdir -p "$_LOCK_DIR"
 	if ! mkdir "${_LOCK_FILE}" 2>/dev/null; then
@@ -119,6 +182,8 @@ cmd_tick() {
 
 	_require_python3 || return 1
 	_require_poll_py || return 1
+	local filter_config
+	filter_config=$(_resolve_collection_filter_config) || return 1
 
 	if ! _acquire_lock; then
 		return 0
@@ -131,11 +196,14 @@ cmd_tick() {
 	local result
 	local py_exit=0
 	local _stderr_tmp
+	local filter_args=()
+	[[ -n "$filter_config" ]] && filter_args=(--filters "$filter_config")
 	_stderr_tmp=$(mktemp)
 	result=$(python3 "$POLL_PY" tick \
 		--config "$config_path" \
 		--state "$_STATE_FILE" \
-		--inbox "$_INBOX_DIR" 2>"$_stderr_tmp") || py_exit=$?
+		--inbox "$_INBOX_DIR" \
+		"${filter_args[@]}" 2>"$_stderr_tmp") || py_exit=$?
 	local _py_stderr
 	_py_stderr=$(cat "$_stderr_tmp" 2>/dev/null || true)
 	rm -f "$_stderr_tmp"
@@ -159,17 +227,21 @@ total = sum(r.get('fetched_count', 0) for r in d.get('results', []))
 print(total)
 " 2>/dev/null || echo "0")
 
+	local command_rc=0
 	if [[ "$overall_status" == "ok" ]]; then
 		log_info "Tick complete: $fetched_count new message(s)"
 	else
 		log_warn "Tick complete with errors: $fetched_count message(s) fetched"
-		# Log full result for debugging but don't crash pulse
+		# Preserve legacy pulse behavior; filtered collection fails below.
 		echo "$result" >&2
+		if [[ -n "$filter_config" ]]; then
+			command_rc=1
+		fi
 	fi
 
 	_release_lock
 	trap - EXIT
-	return 0
+	return "$command_rc"
 }
 
 cmd_backfill() {
@@ -186,8 +258,14 @@ cmd_backfill() {
 		local flag="$1"
 		local val="${2:-}"
 		case "$flag" in
-		--since) since="$val"; shift 2 ;;
-		--rate-limit) rate_limit="$val"; shift 2 ;;
+		--since)
+			since="$val"
+			shift 2
+			;;
+		--rate-limit)
+			rate_limit="$val"
+			shift 2
+			;;
 		*) shift ;;
 		esac
 	done
@@ -205,17 +283,22 @@ cmd_backfill() {
 
 	_require_python3 || return 1
 	_require_poll_py || return 1
+	local filter_config
+	filter_config=$(_resolve_collection_filter_config) || return 1
 
 	mkdir -p "$_INBOX_DIR"
 
 	log_info "Backfilling mailbox '$mailbox_id' from $since (rate: ${rate_limit}/min)"
+	local filter_args=()
+	[[ -n "$filter_config" ]] && filter_args=(--filters "$filter_config")
 	python3 "$POLL_PY" backfill \
 		--config "$config_path" \
 		--state "$_STATE_FILE" \
 		--inbox "$_INBOX_DIR" \
 		--mailbox-id "$mailbox_id" \
 		--since "$since" \
-		--rate-limit "$rate_limit"
+		--rate-limit "$rate_limit" \
+		"${filter_args[@]}"
 
 	return 0
 }
@@ -297,6 +380,10 @@ Config locations (first-found wins):
   _config/mailboxes.json                       Per-repo (git-trackable)
   ~/.config/aidevops/mailboxes.json            Personal / global
 
+Version 2 rules in _config/email-filters.json are applied before persistence.
+Only locally confirmed matches enter _knowledge/inbox; unmatched candidates
+leave content-free per-rule coverage in _knowledge/.imap-state.json.
+
 State:  _knowledge/.imap-state.json
 Inbox:  _knowledge/inbox/
 
@@ -322,10 +409,10 @@ main() {
 	shift || true
 
 	case "$cmd" in
-	tick)        cmd_tick "$@" ;;
-	backfill)    cmd_backfill "$@" ;;
-	test)        cmd_test "$@" ;;
-	list)        cmd_list "$@" ;;
+	tick) cmd_tick "$@" ;;
+	backfill) cmd_backfill "$@" ;;
+	test) cmd_test "$@" ;;
+	list) cmd_list "$@" ;;
 	help | -h | --help) cmd_help ;;
 	*)
 		log_error "Unknown command: $cmd"

--- a/.agents/scripts/email_collection_receipts.py
+++ b/.agents/scripts/email_collection_receipts.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Content-free collection receipts linking staged mail to canonical evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from email_match_rules import rule_digest
+from email_match_validation import validate_rule
+
+
+_RECEIPT_SUFFIX = ".collection.json"
+_RULE_TOKEN = re.compile(r"[A-Za-z0-9_.-]{1,64}")
+
+
+@dataclass(frozen=True)
+class ReceiptContext:
+    """Provider identity for one content-free collection reference."""
+
+    transport: str
+    mailbox_id: str
+    folder: str
+    message_key: str
+
+
+def sidecar_path(eml_path: str | Path) -> Path:
+    """Return the collection sidecar path adjacent to one staged message."""
+    path = Path(eml_path)
+    return path.with_name(path.name + _RECEIPT_SUFFIX)
+
+
+def _rule_references(rules: Iterable[Mapping[str, Any]]) -> list[dict[str, str]]:
+    references = {
+        (str(rule.get("id") or rule.get("name")), rule_digest(rule))
+        for rule in rules
+    }
+    return [
+        {"id": rule_id, "digest": digest}
+        for rule_id, digest in sorted(references)
+    ]
+
+
+def build_receipt(
+    context: ReceiptContext, rules: Iterable[Mapping[str, Any]]
+) -> dict[str, Any]:
+    """Build a private receipt containing selectors and rule IDs, never literals."""
+    payload = {
+        "version": 1,
+        "transport": context.transport,
+        "mailbox_id": context.mailbox_id,
+        "folder": context.folder,
+        "message_key": context.message_key,
+        "rules": _rule_references(rules),
+    }
+    return _validate_receipt(payload)
+
+
+def _validate_receipt(receipt: object) -> dict[str, Any]:
+    if not isinstance(receipt, dict) or set(receipt) != {
+        "version", "transport", "mailbox_id", "folder", "message_key", "rules"
+    }:
+        raise ValueError("invalid collection receipt shape")
+    if receipt.get("version") != 1 or receipt.get("transport") not in {"imap", "jmap"}:
+        raise ValueError("invalid collection receipt version or transport")
+    for field_name in ("mailbox_id", "folder", "message_key"):
+        if not isinstance(receipt.get(field_name), str) or not receipt[field_name]:
+            raise ValueError("invalid collection receipt identity")
+    rules = receipt.get("rules")
+    if not isinstance(rules, list) or not rules:
+        raise ValueError("invalid collection receipt rules")
+    for rule in rules:
+        if not isinstance(rule, dict) or set(rule) != {"id", "digest"}:
+            raise ValueError("invalid collection rule reference")
+        if not _RULE_TOKEN.fullmatch(str(rule.get("id") or "")):
+            raise ValueError("invalid collection rule id")
+        if not re.fullmatch(r"[0-9a-f]{16}", str(rule.get("digest") or "")):
+            raise ValueError("invalid collection rule digest")
+    return receipt
+
+
+def _load_sidecar(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    with path.open(encoding="utf-8") as handle:
+        return _validate_receipt(json.load(handle))
+
+
+def _identity(receipt: Mapping[str, Any]) -> tuple[str, str, str, str]:
+    return tuple(
+        str(receipt[name])
+        for name in ("transport", "mailbox_id", "folder", "message_key")
+    )  # type: ignore[return-value]
+
+
+def _merge_receipts(
+    existing: dict[str, Any] | None, current: dict[str, Any]
+) -> dict[str, Any]:
+    if existing is None:
+        return current
+    if _identity(existing) != _identity(current):
+        raise ValueError("collection receipt identity changed")
+    merged = dict(current)
+    merged["rules"] = sorted(
+        {json.dumps(rule, sort_keys=True) for rule in existing["rules"] + current["rules"]}
+    )
+    merged["rules"] = [json.loads(rule) for rule in merged["rules"]]
+    return merged
+
+
+def _write_json_atomic(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        with temporary.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        temporary.replace(path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def write_collection_receipt(
+    eml_path: str | Path,
+    context: ReceiptContext,
+    rules: Iterable[Mapping[str, Any]],
+) -> Path:
+    """Atomically write or extend a sidecar for an already staged message."""
+    path = sidecar_path(eml_path)
+    payload = _merge_receipts(_load_sidecar(path), build_receipt(context, rules))
+    _write_json_atomic(path, payload)
+    return path
+
+
+def stage_collection_receipt(
+    staged_eml: str | Path,
+    destination_eml: str | Path,
+    context: ReceiptContext,
+    rules: Iterable[Mapping[str, Any]],
+) -> tuple[Path, Path]:
+    """Stage a merged sidecar and return its atomic publish pair."""
+    staged_path = sidecar_path(staged_eml)
+    destination = sidecar_path(destination_eml)
+    payload = _merge_receipts(
+        _load_sidecar(destination), build_receipt(context, rules)
+    )
+    with staged_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    return staged_path, destination
+
+
+def collection_refs_for_eml(eml_path: str | Path) -> list[dict[str, Any]]:
+    """Return a validated canonical-meta reference list for one staged message."""
+    receipt = _load_sidecar(sidecar_path(eml_path))
+    return [receipt] if receipt is not None else []
+
+
+def merge_receipt_into_meta(eml_path: str | Path, meta_path: str | Path) -> None:
+    """Merge one staged receipt into an existing canonical email metadata file."""
+    incoming = collection_refs_for_eml(eml_path)
+    if not incoming:
+        return
+    path = Path(meta_path)
+    with path.open(encoding="utf-8") as handle:
+        meta = json.load(handle)
+    if not isinstance(meta, dict):
+        raise ValueError("canonical email metadata must be an object")
+    raw_references = meta.get("collection_refs") or []
+    if not isinstance(raw_references, list):
+        raise ValueError("invalid canonical collection references")
+    references = [_validate_receipt(reference) for reference in raw_references]
+    incoming_receipt = incoming[0]
+    for index, reference in enumerate(references):
+        if _identity(reference) == _identity(incoming_receipt):
+            references[index] = _merge_receipts(reference, incoming_receipt)
+            break
+    else:
+        references.append(incoming_receipt)
+    meta["collection_refs"] = sorted(references, key=_identity)
+    _write_json_atomic(path, meta)
+
+
+def rule_is_eligible(meta_path: str | Path, rule: Mapping[str, Any]) -> bool:
+    """Require exact collection provenance only for explicit collection rules."""
+    block = rule.get("match")
+    uses_v2_match = isinstance(block, Mapping) and (
+        "all" in block or "any" in block
+    )
+    if uses_v2_match:
+        validate_rule(rule)
+    collection = rule.get("collection", uses_v2_match)
+    if collection is not True:
+        return True
+    rule_id = str(rule.get("id") or rule.get("name") or "")
+    if not _RULE_TOKEN.fullmatch(rule_id):
+        raise ValueError("invalid collection rule id")
+    expected = {"id": rule_id, "digest": rule_digest(rule)}
+    with Path(meta_path).open(encoding="utf-8") as handle:
+        meta = json.load(handle)
+    references = meta.get("collection_refs") if isinstance(meta, dict) else None
+    if references is None:
+        return False
+    if not isinstance(references, list):
+        raise ValueError("invalid canonical collection references")
+    validated = [_validate_receipt(reference) for reference in references]
+    return any(expected in reference["rules"] for reference in validated)
+
+
+def _cmd_extract(args: argparse.Namespace) -> int:
+    print(json.dumps(collection_refs_for_eml(args.eml), sort_keys=True))
+    return 0
+
+
+def _cmd_merge(args: argparse.Namespace) -> int:
+    merge_receipt_into_meta(args.eml, args.meta)
+    return 0
+
+
+def _cmd_eligible(args: argparse.Namespace) -> int:
+    rule = json.load(sys.stdin)
+    if not isinstance(rule, dict):
+        raise ValueError("collection rule must be an object")
+    return 0 if rule_is_eligible(args.meta, rule) else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Canonical email collection receipts")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    extract = subparsers.add_parser("extract")
+    extract.add_argument("--eml", required=True)
+    merge = subparsers.add_parser("merge-meta")
+    merge.add_argument("--eml", required=True)
+    merge.add_argument("--meta", required=True)
+    eligible = subparsers.add_parser("eligible")
+    eligible.add_argument("--meta", required=True)
+    args = parser.parse_args()
+    try:
+        handlers = {
+            "extract": _cmd_extract,
+            "merge-meta": _cmd_merge,
+            "eligible": _cmd_eligible,
+        }
+        return handlers[args.command](args)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"ERROR: collection receipt {type(exc).__name__}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/email_jmap_adapter.py
+++ b/.agents/scripts/email_jmap_adapter.py
@@ -125,6 +125,9 @@ def build_parser():
     # fetch_body
     fb = subparsers.add_parser("fetch_body", help="Fetch an email body by ID")
     fb.add_argument("--email-id", required=True, help="JMAP email ID")
+    fb.add_argument("--filter-config", help="Version 2 rules checked locally before output")
+    fb.add_argument("--rule-id", help="Rule ID required with --filter-config")
+    fb.add_argument("--account-identity", action="append", default=[])
 
     # search
     sr = subparsers.add_parser("search", help="Search emails")
@@ -179,6 +182,22 @@ def build_parser():
     )
     ix.add_argument(
         "--full", action="store_true", help="Full sync (not incremental)"
+    )
+    ix.add_argument(
+        "--filter-config",
+        help="Version 2 rules for locally-authoritative knowledge collection",
+    )
+    ix.add_argument(
+        "--collection-mailbox-id",
+        help="Private rule mailbox selector (defaults to --user)",
+    )
+    ix.add_argument("--state", help="Content-free collection checkpoint file")
+    ix.add_argument("--inbox", help="Knowledge inbox for matched .eml files")
+    ix.add_argument("--account-identity", action="append", default=[])
+    ix.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Match candidates without writing evidence or checkpoints",
     )
 
     # push

--- a/.agents/scripts/email_jmap_collection.py
+++ b/.agents/scripts/email_jmap_collection.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Read-only, locally-authoritative JMAP collection for the knowledge inbox."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from email_jmap_collection_transport import (
+    CollectionContext,
+    RuleQuery,
+    candidate_fields,
+    commit_matches,
+    fetch_bodies,
+    query_rule,
+    requested_headers,
+    stage_matches,
+)
+from email_match_rules import (
+    load_rule_config,
+    match_rule,
+    select_rules,
+)
+
+
+def _load_state(path_value: str) -> dict[str, Any]:
+    path = Path(path_value)
+    if not path.is_file():
+        return {}
+    with path.open(encoding="utf-8") as handle:
+        state = json.load(handle)
+    if not isinstance(state, dict):
+        raise ValueError("collection state must be an object")
+    return state
+
+
+def _save_state(path_value: str, state: dict[str, Any]) -> None:
+    path = Path(path_value)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        with temporary.open("w", encoding="utf-8") as handle:
+            json.dump(state, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        temporary.replace(path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _filtering_enabled(rules: list[dict[str, Any]], mailbox_id: str) -> bool:
+    return any(
+        rule.get("collection", True) is not False
+        and (not rule.get("mailboxes") or mailbox_id in rule["mailboxes"])
+        for rule in rules
+    )
+
+
+def _evaluate_queries(
+    queries: list[RuleQuery],
+    emails: dict[str, dict[str, Any]],
+    state: dict[str, Any],
+    account_identities: tuple[str, ...],
+) -> tuple[dict[str, list[dict[str, Any]]], dict[str, int], set[str]]:
+    headers = requested_headers([query.rule for query in queries])
+    field_cache = {
+        email_id: candidate_fields(email, headers) for email_id, email in emails.items()
+    }
+    matched_rules_by_email: dict[str, list[dict[str, Any]]] = {}
+    matched_rules: dict[str, int] = {}
+    coverage_gaps: set[str] = set()
+    now = datetime.now(timezone.utc).isoformat()
+    for query in queries:
+        prior = state.get(query.key, {})
+        query_matches = 0
+        query_gaps: set[str] = set()
+        for email_id in query.ids:
+            fields = field_cache.get(email_id)
+            if fields is None:
+                query_gaps.add("message")
+                continue
+            match = match_rule(query.rule, fields, account_identities)
+            query_gaps.update(match.unavailable_fields)
+            if match.matched:
+                matched_rules_by_email.setdefault(email_id, []).append(query.rule)
+                query_matches += 1
+        rule_id = str(query.rule["id"])
+        matched_rules[rule_id] = query_matches
+        coverage_gaps.update(query_gaps)
+        state[query.key] = {
+            "transport": "jmap",
+            "query_state": query.query_state,
+            "last_polled_at": now,
+            "scanned": int(prior.get("scanned", 0)) + len(query.ids),
+            "matched": int(prior.get("matched", 0)) + query_matches,
+            "coverage_gaps": sorted(set(prior.get("coverage_gaps", [])) | query_gaps),
+            "candidate_total": query.total,
+            "has_more": query.has_more,
+            "backfill_truncated": bool(prior.get("backfill_truncated"))
+            or (query.mode == "full" and query.has_more),
+            "mode": query.mode,
+        }
+    return matched_rules_by_email, matched_rules, coverage_gaps
+
+
+def collect_filtered(context: CollectionContext) -> dict[str, Any]:
+    """Collect one JMAP folder with independent, bounded, content-free lineages."""
+    state = _load_state(context.state_path)
+    active_rules = select_rules(
+        {"rules": context.rules}, context.collection_mailbox_id, context.folder_name
+    )
+    enabled = _filtering_enabled(context.rules, context.collection_mailbox_id)
+    result: dict[str, Any] = {
+        "status": "ok",
+        "transport": "jmap",
+        "mode": "filtered",
+        "collection_state": (
+            "active" if active_rules else ("paused" if enabled else "not_targeted")
+        ),
+        "lineages": len(active_rules),
+        "scanned": 0,
+        "candidate_total": 0,
+        "unmatched_evaluations": 0,
+        "fetched_count": 0,
+        "matched_rules": {},
+        "coverage_gaps": [],
+        "has_more": False,
+        "backfill_truncated": False,
+    }
+    if not active_rules:
+        return result
+
+    queries = [query_rule(context, state, rule) for rule in active_rules]
+    candidate_ids = list(
+        dict.fromkeys(email_id for query in queries for email_id in query.ids)
+    )
+    emails = fetch_bodies(context, candidate_ids, active_rules)
+    matched_rules_by_email, matched_rules, coverage_gaps = _evaluate_queries(
+        queries, emails, state, context.account_identities
+    )
+
+    result.update({
+        "scanned": sum(len(query.ids) for query in queries),
+        "candidate_total": sum(query.total for query in queries),
+        "unmatched_evaluations": sum(len(query.ids) for query in queries)
+        - sum(matched_rules.values()),
+        "fetched_count": len(matched_rules_by_email),
+        "matched_rules": matched_rules,
+        "coverage_gaps": sorted(coverage_gaps),
+        "has_more": any(query.has_more for query in queries),
+        "backfill_truncated": any(
+            query.mode == "full" and query.has_more for query in queries
+        ),
+    })
+    if context.dry_run:
+        return result
+
+    stage: Path | None = None
+    try:
+        stage, pending = stage_matches(context, matched_rules_by_email, emails)
+        commit_matches(pending)
+        _save_state(context.state_path, state)
+    finally:
+        if stage is not None:
+            shutil.rmtree(stage, ignore_errors=True)
+    return result
+
+
+def run_filtered_sync(
+    args: Any,
+    session_context: tuple[dict[str, Any], str, str],
+    mailbox_context: tuple[str, str],
+) -> int | None:
+    """Validate CLI inputs and run locally-authoritative JMAP collection."""
+    session, account_id, api_url = session_context
+    mailbox_name, mailbox_id = mailbox_context
+    try:
+        rules = load_rule_config(args.filter_config).get("rules", [])
+        collection_mailbox_id = (
+            getattr(args, "collection_mailbox_id", "") or args.user
+        )
+        if not _filtering_enabled(rules, collection_mailbox_id):
+            return None
+        if not getattr(args, "state", "") or not getattr(args, "inbox", ""):
+            print(
+                "ERROR: filtered JMAP sync requires --state and --inbox",
+                file=sys.stderr,
+            )
+            return 2
+        identities = tuple(
+            dict.fromkeys(
+                (getattr(args, "account_identity", []) or []) + [args.user]
+            )
+        )
+        context = CollectionContext(
+            session=session,
+            api_url=api_url,
+            user=args.user,
+            account_id=account_id,
+            collection_mailbox_id=collection_mailbox_id,
+            folder_name=mailbox_name,
+            folder_id=mailbox_id,
+            rules=rules,
+            state_path=args.state,
+            inbox_dir=args.inbox,
+            account_identities=identities,
+            force_full=bool(args.full),
+            dry_run=bool(getattr(args, "dry_run", False)),
+        )
+        result = collect_filtered(context)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(
+            json.dumps({"error": type(exc).__name__, "mode": "filtered"}),
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(result, indent=2))
+    return 0

--- a/.agents/scripts/email_jmap_collection_transport.py
+++ b/.agents/scripts/email_jmap_collection_transport.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""JMAP query, body-fetch, and raw-message staging for filtered collection."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import shutil
+import urllib.request
+import uuid
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote, urlsplit
+
+from email_collection_receipts import (
+    ReceiptContext,
+    stage_collection_receipt,
+)
+from email_jmap_commands import (
+    BODY_PROPERTIES,
+    _extract_html_body,
+    _extract_text_body,
+)
+from email_jmap_helpers import _find_response
+from email_jmap_transport import _get_auth, _jmap_request, _make_auth_header
+from email_match_rules import (
+    MessageFields,
+    fields_from_bytes,
+    fields_from_mapping,
+    rule_digest,
+)
+
+
+_BATCH_SIZE = 100
+_MAX_BODY_BYTES = 1048576
+
+
+@dataclass(frozen=True)
+class CollectionContext:
+    """Immutable authority and storage context for one JMAP folder scan."""
+
+    session: dict[str, Any]
+    api_url: str
+    user: str
+    account_id: str
+    collection_mailbox_id: str
+    folder_name: str
+    folder_id: str
+    rules: list[dict[str, Any]]
+    state_path: str
+    inbox_dir: str
+    account_identities: tuple[str, ...]
+    force_full: bool = False
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class RuleQuery:
+    """One bounded rule lineage query and its uncommitted next state."""
+
+    key: str
+    rule: dict[str, Any]
+    ids: tuple[str, ...]
+    query_state: str
+    total: int
+    has_more: bool
+    mode: str
+
+
+@dataclass(frozen=True)
+class StagedMatch:
+    """One staged raw message and its content-free collection receipt."""
+
+    raw_path: Path | None
+    destination: Path
+    receipt_path: Path
+    receipt_destination: Path
+
+
+def _safe_component(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", value)
+
+
+def _lineage_key(context: CollectionContext, rule: dict[str, Any]) -> str:
+    rule_id = _safe_component(str(rule.get("id") or rule.get("name")))
+    folder = _safe_component(context.folder_name)
+    return (
+        f"{context.collection_mailbox_id}/{folder}/jmap/filter/"
+        f"{rule_id}/{rule_digest(rule)}"
+    )
+
+
+def _query_filter(context: CollectionContext, rule: dict[str, Any]) -> dict[str, Any]:
+    query_filter: dict[str, Any] = {"inMailbox": context.folder_id}
+    since_date = str((rule.get("backfill") or {}).get("since") or "")
+    if since_date:
+        query_filter["after"] = f"{since_date}T00:00:00Z"
+    return query_filter
+
+
+def _query_initial(
+    context: CollectionContext, rule: dict[str, Any], key: str, limit: int
+) -> RuleQuery:
+    method_calls = [[
+        "Email/query",
+        {
+            "accountId": context.account_id,
+            "filter": _query_filter(context, rule),
+            "sort": [{"property": "receivedAt", "isAscending": False}],
+            "position": 0,
+            "limit": limit,
+        },
+        "q0",
+    ]]
+    response = _jmap_request(context.api_url, context.user, method_calls)
+    result = _find_response(response.get("methodResponses", []), "Email/query", "q0")
+    if not result or not result.get("queryState"):
+        raise ValueError("JMAP query did not return a checkpoint")
+    ids = tuple(str(item) for item in result.get("ids", []))
+    total = int(result.get("total", len(ids)))
+    return RuleQuery(
+        key, rule, ids, str(result["queryState"]), total, total > len(ids), "full"
+    )
+
+
+def _query_changes(
+    context: CollectionContext,
+    rule: dict[str, Any],
+    key: str,
+    saved_state: str,
+    limit: int,
+) -> RuleQuery:
+    method_calls = [[
+        "Email/queryChanges",
+        {
+            "accountId": context.account_id,
+            "filter": _query_filter(context, rule),
+            "sort": [{"property": "receivedAt", "isAscending": False}],
+            "sinceQueryState": saved_state,
+            "maxChanges": limit,
+        },
+        "qc0",
+    ]]
+    response = _jmap_request(context.api_url, context.user, method_calls)
+    result = _find_response(
+        response.get("methodResponses", []), "Email/queryChanges", "qc0"
+    )
+    if not result or not result.get("newQueryState"):
+        raise ValueError("JMAP queryChanges did not return a checkpoint")
+    ids = tuple(
+        str(item["id"])
+        for item in result.get("added", [])
+        if isinstance(item, dict) and item.get("id")
+    )
+    return RuleQuery(
+        key,
+        rule,
+        ids,
+        str(result["newQueryState"]),
+        len(ids),
+        bool(result.get("hasMoreChanges")),
+        "delta",
+    )
+
+
+def query_rule(
+    context: CollectionContext, state: dict[str, Any], rule: dict[str, Any]
+) -> RuleQuery:
+    """Return one initial or incremental bounded candidate page."""
+    key = _lineage_key(context, rule)
+    limit = int((rule.get("backfill") or {}).get("limit", 500))
+    saved_state = str(state.get(key, {}).get("query_state") or "")
+    if saved_state and not context.force_full:
+        return _query_changes(context, rule, key, saved_state, limit)
+    return _query_initial(context, rule, key, limit)
+
+
+def requested_headers(rules: list[dict[str, Any]]) -> tuple[str, ...]:
+    """Return unique custom headers required by the active rules."""
+    names: list[str] = []
+    for rule in rules:
+        block = rule.get("match") or {}
+        for group in ("all", "any"):
+            for condition in block.get(group) or []:
+                if condition.get("field") == "header" and condition.get("header"):
+                    names.append(str(condition["header"]))
+    return tuple(dict.fromkeys(names))
+
+
+def _body_properties(rules: list[dict[str, Any]]) -> list[str]:
+    properties = list(BODY_PROPERTIES)
+    properties.extend(f"header:{name}:asText" for name in requested_headers(rules))
+    return list(dict.fromkeys(properties))
+
+
+def fetch_bodies(
+    context: CollectionContext, email_ids: list[str], rules: list[dict[str, Any]]
+) -> dict[str, dict[str, Any]]:
+    """Fetch complete local-match fields for a bounded candidate union."""
+    fetched: dict[str, dict[str, Any]] = {}
+    properties = _body_properties(rules)
+    for start in range(0, len(email_ids), _BATCH_SIZE):
+        batch = email_ids[start:start + _BATCH_SIZE]
+        method_calls = [[
+            "Email/get",
+            {
+                "accountId": context.account_id,
+                "ids": batch,
+                "properties": properties,
+                "fetchTextBodyValues": True,
+                "fetchHTMLBodyValues": True,
+                "maxBodyValueBytes": _MAX_BODY_BYTES,
+            },
+            "g0",
+        ]]
+        response = _jmap_request(context.api_url, context.user, method_calls)
+        result = _find_response(response.get("methodResponses", []), "Email/get", "g0")
+        if result is None:
+            raise ValueError("JMAP Email/get did not return candidate bodies")
+        for email in result.get("list", []):
+            email_id = str(email.get("id") or "")
+            if email_id:
+                fetched[email_id] = email
+    return fetched
+
+
+def candidate_fields(
+    email: dict[str, Any], headers: tuple[str, ...]
+) -> MessageFields:
+    """Map a JMAP Email/get object into shared deterministic match fields."""
+    body_values = email.get("bodyValues") or {}
+    candidate = dict(email)
+    candidate["text_body"] = _extract_text_body(email, body_values)
+    candidate["html_body"] = _extract_html_body(email, body_values)
+    candidate["headers"] = {
+        name: email.get(f"header:{name}:asText", "") for name in headers
+    }
+    fields = fields_from_mapping(candidate)
+    unavailable = set(fields.unavailable_fields)
+    if any(value.get("isTruncated") for value in body_values.values()):
+        unavailable.add("body")
+    if any(f"header:{name}:asText" not in email for name in headers):
+        unavailable.add("header")
+    return replace(fields, unavailable_fields=tuple(sorted(unavailable)))
+
+
+def _download_url(template: str, account_id: str, email: dict[str, Any]) -> str:
+    values = {
+        "accountId": account_id,
+        "blobId": str(email.get("blobId") or ""),
+        "name": f"{email.get('id', 'message')}.eml",
+        "type": "message/rfc822",
+    }
+    if not template or not values["blobId"]:
+        raise ValueError("JMAP raw-message download is unavailable")
+    url = template
+    for key, value in values.items():
+        url = url.replace("{" + key + "}", quote(value, safe=""))
+    parsed = urlsplit(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("JMAP raw-message download URL must use HTTP(S)")
+    return url
+
+
+def _download_raw_email(context: CollectionContext, email: dict[str, Any]) -> bytes:
+    url = _download_url(
+        str(context.session.get("downloadUrl") or ""), context.account_id, email
+    )
+    auth_type, credential = _get_auth()
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": _make_auth_header(context.user, auth_type, credential),
+            "Accept": "message/rfc822",
+        },
+        method="GET",
+    )
+    # The scheme and authority are validated by _download_url above.
+    with urllib.request.urlopen(request, timeout=30) as response:  # nosec B310
+        raw_message = response.read()
+    if not raw_message:
+        raise ValueError("JMAP raw-message download was empty")
+    fields_from_bytes(raw_message)
+    return raw_message
+
+
+def _output_path(context: CollectionContext, email_id: str) -> Path:
+    mailbox = _safe_component(context.collection_mailbox_id)
+    folder = _safe_component(context.folder_name)
+    opaque_id = hashlib.sha256(email_id.encode("utf-8")).hexdigest()[:20]
+    return Path(context.inbox_dir) / f"email-{mailbox}-{folder}-jmap-{opaque_id}.eml"
+
+
+def stage_matches(
+    context: CollectionContext,
+    matched_rules_by_email: dict[str, list[dict[str, Any]]],
+    emails: dict[str, dict[str, Any]],
+) -> tuple[Path, list[StagedMatch]]:
+    """Download matched raw messages to an incomplete private staging folder."""
+    inbox = Path(context.inbox_dir)
+    inbox.mkdir(parents=True, exist_ok=True)
+    stage = inbox / f".jmap-stage-{uuid.uuid4().hex}"
+    stage.mkdir()
+    pending: list[StagedMatch] = []
+    try:
+        for email_id in sorted(matched_rules_by_email):
+            destination = _output_path(context, email_id)
+            raw_path: Path | None = None
+            receipt_base = stage / destination.name
+            if not destination.is_file():
+                raw_path = receipt_base
+                raw_path.write_bytes(_download_raw_email(context, emails[email_id]))
+            receipt_path, receipt_destination = stage_collection_receipt(
+                receipt_base,
+                destination,
+                ReceiptContext(
+                    "jmap",
+                    context.collection_mailbox_id,
+                    context.folder_name,
+                    email_id,
+                ),
+                matched_rules_by_email[email_id],
+            )
+            pending.append(
+                StagedMatch(
+                    raw_path,
+                    destination,
+                    receipt_path,
+                    receipt_destination,
+                )
+            )
+    except Exception:
+        shutil.rmtree(stage, ignore_errors=True)
+        raise
+    return stage, pending
+
+
+def commit_matches(pending: list[StagedMatch]) -> None:
+    """Publish fully downloaded raw messages using atomic same-volume renames."""
+    for match in pending:
+        match.receipt_path.replace(match.receipt_destination)
+        if match.raw_path is not None:
+            match.raw_path.replace(match.destination)

--- a/.agents/scripts/email_jmap_commands.py
+++ b/.agents/scripts/email_jmap_commands.py
@@ -13,6 +13,7 @@ import sys
 
 from email_jmap_index import _init_index_db, _upsert_jmap_email, _first_or_empty
 from email_jmap_transport import _jmap_request, _session_context
+from email_match_rules import fields_from_mapping, load_rule_config, match_rule
 from email_jmap_helpers import (
     _find_response,
     _resolve_mailbox_id,
@@ -180,14 +181,14 @@ def _extract_text_body(em, body_values):
     return text_body
 
 
-def _extract_html_body_length(em, body_values):
-    """Return total byte length of HTML body parts."""
-    length = 0
+def _extract_html_body(em, body_values):
+    """Extract concatenated HTML body from email parts."""
+    html_body = ""
     for part in em.get("htmlBody") or []:
         part_id = part.get("partId", "")
         if part_id in body_values:
-            length += len(body_values[part_id].get("value", ""))
-    return length
+            html_body += body_values[part_id].get("value", "")
+    return html_body
 
 
 def _extract_attachments(em):
@@ -249,10 +250,12 @@ def cmd_fetch_body(args):
 
     em = emails[0]
     body_values = em.get("bodyValues", {})
+    html_body = _extract_html_body(em, body_values)
 
     from_addrs = em.get("from") or []
     to_addrs = em.get("to") or []
     cc_addrs = em.get("cc") or []
+    bcc_addrs = em.get("bcc") or []
 
     result = {
         "email_id": em.get("id", ""),
@@ -265,16 +268,35 @@ def cmd_fetch_body(args):
         "from": _format_addresses(from_addrs),
         "to": _format_addresses(to_addrs),
         "cc": _format_addresses(cc_addrs),
+        "bcc": _format_addresses(bcc_addrs),
         "subject": em.get("subject", ""),
         "in_reply_to": _first_or_empty(em.get("inReplyTo")),
         "references": em.get("references") or [],
         "keywords": list((em.get("keywords") or {}).keys()),
         "text_body": _extract_text_body(em, body_values),
-        "html_body_length": _extract_html_body_length(em, body_values),
+        "html_body_length": len(html_body),
         "has_attachment": em.get("hasAttachment", False),
         "attachments": _extract_attachments(em),
         "preview": em.get("preview", ""),
     }
+    if args.filter_config:
+        config = load_rule_config(args.filter_config)
+        selected = [
+            rule for rule in config["rules"]
+            if str(rule.get("id") or rule.get("name")) == args.rule_id
+        ]
+        if not selected:
+            print(json.dumps({"error": "rule_not_found", "rule_id": args.rule_id}), file=sys.stderr)
+            return 2
+        identities = args.account_identity or [args.user]
+        match_candidate = dict(em)
+        match_candidate["text_body"] = result["text_body"]
+        match_candidate["html_body"] = html_body
+        local_match = match_rule(selected[0], fields_from_mapping(match_candidate), identities)
+        if not local_match.matched:
+            print(json.dumps(local_match.explanation(), sort_keys=True))
+            return 3
+        result["local_match"] = local_match.explanation()
     print(json.dumps(result, indent=2))
     return 0
 

--- a/.agents/scripts/email_jmap_sync.py
+++ b/.agents/scripts/email_jmap_sync.py
@@ -16,6 +16,7 @@ import urllib.request
 from collections import namedtuple
 from datetime import datetime, timezone
 
+from email_jmap_collection import run_filtered_sync
 from email_jmap_index import (
     _SYNC_STATE_UPSERT,
     _init_index_db,
@@ -247,7 +248,7 @@ def cmd_index_sync(args):
 
     Uses JMAP state strings for efficient delta sync when available.
     """
-    _, account_id, api_url = _session_context(args)
+    session, account_id, api_url = _session_context(args)
 
     mailbox_name = args.mailbox or "INBOX"
     mailbox_id = _resolve_mailbox_id(
@@ -259,6 +260,21 @@ def cmd_index_sync(args):
             file=sys.stderr,
         )
         return 1
+
+    if getattr(args, "filter_config", ""):
+        filtered_result = run_filtered_sync(
+            args,
+            (session, account_id, api_url),
+            (mailbox_name, mailbox_id),
+        )
+        if filtered_result is not None:
+            return filtered_result
+    if getattr(args, "dry_run", False):
+        print(
+            "ERROR: --dry-run requires --filter-config for JMAP sync",
+            file=sys.stderr,
+        )
+        return 2
 
     account_key = f"{args.user}@jmap"
     db_conn = _init_index_db()

--- a/.agents/scripts/email_match_evaluator.py
+++ b/.agents/scripts/email_match_evaluator.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Low-level condition evaluation for deterministic email matching."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Any, Mapping
+
+from email_match_validation import ADDRESS_FIELDS, normalize_address, normalize_domain
+
+
+def condition_dependencies(condition: Mapping[str, Any]) -> set[str]:
+    """Return normalized message fields needed to evaluate a condition."""
+    field_name = str(condition["field"])
+    if field_name not in {"reference", "keyword", "phrase"}:
+        return {field_name}
+    targets = {
+        "subject": {"subject"},
+        "body": {"body"},
+        "attachment_name": {"attachment_name"},
+        "subject_body": {"subject", "body"},
+    }
+    return targets[str(condition.get("target", "subject_body"))]
+
+
+def groups_match(all_results: list[bool], any_results: list[bool]) -> bool:
+    """Combine deterministic ``all`` and ``any`` condition groups."""
+    return all(all_results) and (any(any_results) if any_results else True)
+
+
+def normalize_text(value: object, *, case_sensitive: bool = False) -> str:
+    """Apply deterministic Unicode and whitespace normalization."""
+    normalized = unicodedata.normalize("NFKC", str(value or ""))
+    normalized = " ".join(normalized.split())
+    return normalized if case_sensitive else normalized.casefold()
+
+
+def _field_values(condition: Mapping[str, Any], fields: Any) -> tuple[str, ...]:
+    field_name = str(condition["field"])
+    if field_name in ADDRESS_FIELDS:
+        values = fields.addresses.get(field_name, ())
+    elif field_name == "subject":
+        values = (fields.subject,)
+    elif field_name == "body":
+        values = (fields.body,)
+    elif field_name == "attachment_name":
+        values = fields.attachment_names
+    elif field_name == "header":
+        header_name = str(condition.get("header", "")).casefold()
+        values = (fields.headers.get(header_name, ""),)
+    else:
+        target = str(condition.get("target", "subject_body"))
+        targets = {
+            "subject": (fields.subject,),
+            "body": (fields.body,),
+            "attachment_name": fields.attachment_names,
+            "subject_body": (fields.subject, fields.body),
+        }
+        values = targets[target]
+    return values
+
+
+def _text_match(value: str, literal: str, operator: str, case_sensitive: bool) -> bool:
+    haystack = normalize_text(value, case_sensitive=case_sensitive)
+    needle = normalize_text(literal, case_sensitive=case_sensitive)
+    if operator in {"exact", "equals"}:
+        return haystack == needle
+    if operator in {"contains", "phrase"}:
+        return needle in haystack
+    boundary = r"\w" if operator == "keyword" else r"\w-"
+    return re.search(rf"(?<![{boundary}]){re.escape(needle)}(?![{boundary}])", haystack) is not None
+
+
+def _direction_matches(literal: str, fields: Any, account_identities: tuple[str, ...]) -> bool:
+    senders = set(fields.addresses.get("from", ()))
+    recipients = set().union(*(set(fields.addresses.get(name, ())) for name in ("to", "cc", "bcc")))
+    identities = set(account_identities)
+    sent = literal in {"sent", "either"} and bool(senders & identities)
+    received = literal in {"received", "either"} and bool(recipients & identities)
+    return sent or received
+
+
+def _exact_address_match(operator: str, literal: str, values: tuple[str, ...]) -> bool | None:
+    if operator == "exact_address":
+        needle = normalize_address(literal)
+        return bool(needle) and needle in values
+    if operator == "exact_domain":
+        domain = normalize_domain(literal)
+        return bool(domain) and any(value.rsplit("@", 1)[-1] == domain for value in values)
+    return None
+
+
+def condition_matches(
+    condition: Mapping[str, Any], fields: Any, account_identities: tuple[str, ...]
+) -> bool:
+    """Evaluate one already-validated condition against normalized fields."""
+    field_name = str(condition["field"])
+    operator = str(condition.get("operator", condition.get("mode")))
+    literal = str(condition["value"])
+    if field_name == "direction":
+        return _direction_matches(literal, fields, account_identities)
+    values = _field_values(condition, fields)
+    exact_match = _exact_address_match(operator, literal, values)
+    if exact_match is not None:
+        return exact_match
+    case_sensitive = bool(condition.get("case_sensitive", False))
+    return any(_text_match(value, literal, operator, case_sensitive) for value in values)

--- a/.agents/scripts/email_match_header_validation.py
+++ b/.agents/scripts/email_match_header_validation.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Small RFC header-name validator shared by strict email rule parsing."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+
+_HEADER_NAME_PATTERN = re.compile(r"[A-Za-z0-9!#$%&'*+.^_`|~-]+")
+
+
+def header_option_is_valid(
+    condition: Mapping[str, Any], field_name: object
+) -> bool:
+    """Return whether a header condition has a safe RFC field name."""
+    if field_name != "header":
+        return True
+    header_name = condition.get("header")
+    return isinstance(header_name, str) and bool(
+        _HEADER_NAME_PATTERN.fullmatch(header_name)
+    )

--- a/.agents/scripts/email_match_rules.py
+++ b/.agents/scripts/email_match_rules.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Deterministic, transport-neutral matching for filtered email collection.
+
+Server-side IMAP/JMAP predicates may reduce candidate reads, but this module is
+the final authority before a message is written to the knowledge inbox.
+Diagnostics intentionally expose rule IDs and field names, never rule literals
+or message content.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from email import policy
+from email.message import Message
+from email.parser import BytesParser
+from email.utils import getaddresses
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from email_match_evaluator import condition_dependencies, condition_matches, groups_match
+from email_match_validation import (
+    ADDRESS_FIELDS,
+    RULESET_VERSION,
+    RuleValidationError,
+    conditions,
+    match_block,
+    normalize_address,
+    validate_rule,
+)
+
+
+@dataclass(frozen=True)
+class MessageFields:
+    """Normalized fields used by both IMAP and JMAP candidates."""
+
+    addresses: dict[str, tuple[str, ...]]
+    subject: str = ""
+    body: str = ""
+    headers: dict[str, str] = field(default_factory=dict)
+    attachment_names: tuple[str, ...] = ()
+    unavailable_fields: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class MatchResult:
+    """Content-free result suitable for logs and checkpoint coverage."""
+
+    matched: bool
+    rule_id: str
+    matched_fields: tuple[str, ...] = ()
+    unavailable_fields: tuple[str, ...] = ()
+
+    def explanation(self) -> dict[str, Any]:
+        """Return a diagnostic that cannot disclose private match literals."""
+        return {
+            "matched": self.matched,
+            "rule_id": self.rule_id,
+            "matched_fields": list(self.matched_fields),
+            "unavailable_fields": list(self.unavailable_fields),
+        }
+
+
+def _parsed_addresses(values: list[str]) -> list[str]:
+    return [address for _name, address in getaddresses(values)]
+
+
+def _list_address_candidates(values: list[object]) -> list[object]:
+    mapped: list[object] = []
+    header_values: list[str] = []
+    for item in values:
+        if isinstance(item, Mapping):
+            mapped.append(item.get("email", ""))
+        else:
+            header_values.append(str(item))
+    return mapped + _parsed_addresses(header_values)
+
+
+def _address_candidates(value: object) -> list[object]:
+    if isinstance(value, list):
+        return _list_address_candidates(value)
+    return _parsed_addresses([str(value or "")])
+
+
+def _addresses(value: object) -> tuple[str, ...]:
+    candidates = _address_candidates(value)
+    normalized = (normalize_address(candidate) for candidate in candidates)
+    return tuple(dict.fromkeys(address for address in normalized if address))
+
+
+def _decode_part(part: Message) -> str:
+    try:
+        content = part.get_content()
+    except (LookupError, UnicodeError):
+        payload = part.get_payload(decode=True) or b""
+        content = payload.decode(part.get_content_charset() or "utf-8", errors="replace")
+    return content if isinstance(content, str) else ""
+
+
+def _message_content(message: Message) -> tuple[str, tuple[str, ...]]:
+    body_parts: list[str] = []
+    attachment_names: list[str] = []
+    parts: Iterable[Message] = message.walk() if message.is_multipart() else (message,)
+    for part in parts:
+        filename = part.get_filename()
+        if filename:
+            attachment_names.append(filename)
+            continue
+        if part.get_content_type() in {"text/plain", "text/html"}:
+            text = _decode_part(part)
+            if part.get_content_type() == "text/html":
+                text = html.unescape(re.sub(r"<[^>]+>", " ", text))
+            body_parts.append(text)
+    return "\n".join(body_parts), tuple(attachment_names)
+
+
+def fields_from_bytes(raw_message: bytes) -> MessageFields:
+    """Decode an RFC-822 candidate without making any provider mutation."""
+    message = BytesParser(policy=policy.default).parsebytes(raw_message)
+    if any(part.defects for part in message.walk()):
+        raise ValueError("malformed RFC-822 message")
+    addresses = {name: _addresses(message.get_all(name, [])) for name in ADDRESS_FIELDS}
+    unavailable = ("bcc",) if "bcc" not in message else ()
+    body, attachment_names = _message_content(message)
+    headers = {name.casefold(): "\n".join(message.get_all(name, [])) for name in message.keys()}
+    return MessageFields(
+        addresses=addresses,
+        subject=str(message.get("subject", "")),
+        body=body,
+        headers=headers,
+        attachment_names=attachment_names,
+        unavailable_fields=unavailable,
+    )
+
+
+def _attachment_names(message: Mapping[str, Any]) -> tuple[str, ...]:
+    attachments = message.get("attachments") or []
+    return tuple(
+        str(item.get("name") or item.get("filename") or item.get("attachment_filename") or "")
+        for item in attachments
+        if isinstance(item, Mapping)
+    )
+
+
+def _mapping_headers(message: Mapping[str, Any]) -> dict[str, str]:
+    raw_headers = message.get("headers") or {}
+    if not isinstance(raw_headers, Mapping):
+        return {}
+    return {str(name).casefold(): str(value) for name, value in raw_headers.items()}
+
+
+def _mapping_body(message: Mapping[str, Any]) -> str:
+    body = next(filter(None, map(message.get, ("body", "text_body"))), "")
+    html_body = html.unescape(
+        re.sub(r"<[^>]+>", " ", str(message.get("html_body") or ""))
+    )
+    preview = next(filter(None, map(message.get, ("body_preview", "preview"))), "")
+    return str(next(filter(None, (body, html_body, preview)), ""))
+
+
+def fields_from_mapping(message: Mapping[str, Any]) -> MessageFields:
+    """Build fields from JMAP data or an ingested ``meta.json`` mapping."""
+    unavailable = tuple(name for name in ADDRESS_FIELDS if name not in message)
+    addresses = {name: _addresses(message.get(name, "")) for name in ADDRESS_FIELDS}
+    return MessageFields(
+        addresses=addresses,
+        subject=str(message.get("subject") or message.get("title") or ""),
+        body=_mapping_body(message),
+        headers=_mapping_headers(message),
+        attachment_names=_attachment_names(message),
+        unavailable_fields=unavailable,
+    )
+
+
+def load_rule_config(source: str | Path | Mapping[str, Any]) -> dict[str, Any]:
+    """Load and strictly validate a version 2 private filter configuration."""
+    if isinstance(source, Mapping):
+        config = dict(source)
+    else:
+        with Path(source).open(encoding="utf-8") as handle:
+            config = json.load(handle)
+    if set(config) - {"version", "rules", "_comment", "_doc"}:
+        raise RuleValidationError("ruleset has unsupported keys")
+    if config.get("version") != RULESET_VERSION:
+        raise RuleValidationError(f"filtered collection requires ruleset version {RULESET_VERSION}")
+    rules = config.get("rules")
+    if not isinstance(rules, list):
+        raise RuleValidationError("rules must be an array")
+    seen: set[str] = set()
+    for rule in rules:
+        if not isinstance(rule, Mapping):
+            raise RuleValidationError("each rule must be an object")
+        validate_rule(rule)
+        rule_id = str(rule["id"])
+        if rule_id in seen:
+            raise RuleValidationError(f"duplicate rule id '{rule_id}'")
+        seen.add(rule_id)
+    return config
+
+
+def rule_digest(rule: Mapping[str, Any]) -> str:
+    """Return a stable lineage digest without exposing private literals."""
+    material = {
+        "match": match_block(rule),
+        "mailboxes": rule.get("mailboxes", []),
+        "folders": rule.get("folders", []),
+        "backfill": rule.get("backfill", {}),
+    }
+    encoded = json.dumps(material, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+def select_rules(config: Mapping[str, Any], mailbox_id: str, folder: str) -> list[dict[str, Any]]:
+    """Select enabled collection rules for a mailbox/folder pair."""
+    selected = []
+    for raw_rule in config.get("rules", []):
+        rule = dict(raw_rule)
+        if rule.get("enabled", True) is False or rule.get("collection", True) is False:
+            continue
+        if rule.get("mailboxes") and mailbox_id not in rule["mailboxes"]:
+            continue
+        if rule.get("folders") and folder not in rule["folders"]:
+            continue
+        selected.append(rule)
+    return selected
+
+
+def _normalized_identities(account_identities: Iterable[str]) -> tuple[str, ...]:
+    normalized = (normalize_address(value) for value in account_identities)
+    return tuple(address for address in normalized if address)
+
+
+def _evaluate_conditions(
+    rule_conditions: list[Mapping[str, Any]],
+    fields: MessageFields,
+    identities: tuple[str, ...],
+) -> list[bool]:
+    return [condition_matches(item, fields, identities) for item in rule_conditions]
+
+
+def _match_details(
+    evaluated: list[tuple[Mapping[str, Any], bool]], unavailable_fields: tuple[str, ...]
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    matched_fields = tuple(dict.fromkeys(str(condition["field"]) for condition, result in evaluated if result))
+    condition_fields = set().union(*(condition_dependencies(condition) for condition, _ in evaluated))
+    unavailable = tuple(sorted(set(unavailable_fields) & condition_fields))
+    return matched_fields, unavailable
+
+
+def match_rule(
+    rule: Mapping[str, Any],
+    fields: MessageFields,
+    account_identities: Iterable[str] = (),
+) -> MatchResult:
+    """Evaluate ``all`` and ``any`` groups and return a redacted result."""
+    validate_rule(rule)
+    rule_id = str(rule["id"])
+    identities = _normalized_identities(account_identities)
+    block = match_block(rule)
+    all_conditions = conditions(block, "all")
+    any_conditions = conditions(block, "any")
+    all_results = _evaluate_conditions(all_conditions, fields, identities)
+    any_results = _evaluate_conditions(any_conditions, fields, identities)
+    matched = groups_match(all_results, any_results)
+    evaluated = list(zip(all_conditions + any_conditions, all_results + any_results))
+    matched_fields, unavailable = _match_details(evaluated, fields.unavailable_fields)
+    return MatchResult(matched, rule_id, matched_fields, unavailable)
+
+
+def _load_meta_fields(meta_path: Path) -> MessageFields:
+    with meta_path.open(encoding="utf-8") as handle:
+        meta = json.load(handle)
+    text_path = meta_path.parent / "text.txt"
+    if text_path.is_file():
+        meta["body"] = text_path.read_text(encoding="utf-8", errors="replace")
+    return fields_from_mapping(meta)
+
+
+def _cmd_match_meta(args: argparse.Namespace) -> int:
+    try:
+        rule_input = json.load(sys.stdin)
+        rule = rule_input if "id" in rule_input or "name" in rule_input else {"id": "private-rule", "match": rule_input}
+        result = match_rule(rule, _load_meta_fields(Path(args.meta)), args.account_identity)
+    except (OSError, json.JSONDecodeError, RuleValidationError) as exc:
+        print(json.dumps({"error": type(exc).__name__}), file=sys.stderr)
+        return 2
+    print(json.dumps(result.explanation(), sort_keys=True))
+    return 0 if result.matched else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Deterministic private email-rule matcher")
+    sub = parser.add_subparsers(dest="command", required=True)
+    match_meta = sub.add_parser("match-meta", help="Match stdin rule JSON against an ingested email")
+    match_meta.add_argument("--meta", required=True)
+    match_meta.add_argument("--account-identity", action="append", default=[])
+    args = parser.parse_args()
+    if args.command == "match-meta":
+        return _cmd_match_meta(args)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/email_match_validation.py
+++ b/.agents/scripts/email_match_validation.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Strict schema validation and identity normalization for email match rules."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from datetime import date
+from email.utils import getaddresses
+from typing import Any, Mapping
+
+from email_match_header_validation import header_option_is_valid
+
+
+RULESET_VERSION = 2
+ADDRESS_FIELDS = {"from", "to", "cc", "bcc"}
+TEXT_FIELDS = {"subject", "body", "header", "attachment_name", "reference", "keyword", "phrase"}
+OPERATORS = {"exact", "exact_address", "exact_domain", "phrase", "keyword", "reference", "contains"}
+
+RULE_KEYS = {
+    "id", "name", "enabled", "collection", "mailboxes", "folders",
+    "match", "actions", "backfill", "_comment",
+}
+CONDITION_KEYS = {"field", "operator", "mode", "value", "case_sensitive", "target", "header"}
+TARGETS = {"subject_body", "subject", "body", "attachment_name"}
+
+
+class RuleValidationError(ValueError):
+    """Raised when a collection rule is ambiguous or unsafe."""
+
+
+def normalize_address(value: object) -> str:
+    """Normalize an addr-spec while preserving exact local/domain boundaries."""
+    parsed = getaddresses([str(value or "")])
+    address = parsed[0][1].strip() if parsed else ""
+    if address.count("@") != 1:
+        return ""
+    local, domain = address.rsplit("@", 1)
+    if not local or not domain:
+        return ""
+    try:
+        normalized_domain = domain.rstrip(".").encode("idna").decode("ascii").casefold()
+    except UnicodeError:
+        return ""
+    return f"{unicodedata.normalize('NFKC', local).casefold()}@{normalized_domain}"
+
+
+def normalize_domain(value: object) -> str:
+    """Normalize a standalone domain without allowing suffix matches."""
+    domain = str(value or "").strip().lstrip("@").rstrip(".")
+    try:
+        return domain.encode("idna").decode("ascii").casefold()
+    except UnicodeError:
+        return ""
+
+
+def match_block(rule: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return the explicit match block, including legacy direct blocks."""
+    block = rule.get("match", rule)
+    if not isinstance(block, Mapping):
+        raise RuleValidationError("rule match must be an object")
+    return block
+
+
+def conditions(block: Mapping[str, Any], group: str) -> list[Mapping[str, Any]]:
+    """Return and type-check one condition group."""
+    raw = block.get(group, [])
+    if raw is None:
+        return []
+    if not isinstance(raw, list) or any(not isinstance(item, Mapping) for item in raw):
+        raise RuleValidationError(f"match.{group} must be an array of conditions")
+    return list(raw)
+
+
+def _validated_rule_id(rule: Mapping[str, Any]) -> str:
+    if set(rule) - RULE_KEYS:
+        raise RuleValidationError("rule has unsupported keys")
+    rule_id = rule.get("id")
+    if not isinstance(rule_id, str) or not re.fullmatch(r"[A-Za-z0-9_.-]{1,64}", rule_id):
+        raise RuleValidationError("rule requires a non-empty id")
+    return rule_id
+
+
+def _validate_rule_flags(rule: Mapping[str, Any], rule_id: str) -> None:
+    if "name" in rule and not isinstance(rule["name"], str):
+        raise RuleValidationError(f"rule '{rule_id}' name must be a string")
+    for flag_name in ("enabled", "collection"):
+        if flag_name in rule and not isinstance(rule[flag_name], bool):
+            raise RuleValidationError(f"rule '{rule_id}' {flag_name} must be boolean")
+
+
+def _validate_rule_selectors(rule: Mapping[str, Any], rule_id: str) -> None:
+    for selector in ("mailboxes", "folders"):
+        values = rule.get(selector, [])
+        if not isinstance(values, list) or any(not isinstance(value, str) or not value for value in values):
+            raise RuleValidationError(f"rule '{rule_id}' {selector} must contain strings")
+
+
+def _validate_rule_metadata(rule: Mapping[str, Any]) -> str:
+    rule_id = _validated_rule_id(rule)
+    _validate_rule_flags(rule, rule_id)
+    _validate_rule_selectors(rule, rule_id)
+    return rule_id
+
+
+def _validate_backfill(rule: Mapping[str, Any], rule_id: str) -> None:
+    backfill = rule.get("backfill", {})
+    if not isinstance(backfill, Mapping) or set(backfill) - {"since", "limit"}:
+        raise RuleValidationError(f"rule '{rule_id}' has invalid backfill")
+    limit = backfill.get("limit", 500)
+    if not isinstance(limit, int) or isinstance(limit, bool) or not 1 <= limit <= 5000:
+        raise RuleValidationError(f"rule '{rule_id}' backfill limit must be 1..5000")
+    if "since" not in backfill:
+        return
+    try:
+        date.fromisoformat(str(backfill["since"]))
+    except ValueError as exc:
+        raise RuleValidationError(f"rule '{rule_id}' backfill since must be an ISO date") from exc
+
+
+def _validate_actions(rule: Mapping[str, Any], rule_id: str) -> None:
+    actions = rule.get("actions", [])
+    if not isinstance(actions, list) or any(not isinstance(action, Mapping) for action in actions):
+        raise RuleValidationError(f"rule '{rule_id}' actions must be objects")
+    for action in actions:
+        if set(action) - {"attach_to_case", "role", "set_sensitivity"}:
+            raise RuleValidationError(f"rule '{rule_id}' action has unsupported keys")
+
+
+def _validate_condition_shape(condition: Mapping[str, Any], rule_id: str) -> tuple[object, object]:
+    if set(condition) - CONDITION_KEYS:
+        raise RuleValidationError(f"rule '{rule_id}' condition has unsupported keys")
+    field_name = condition.get("field")
+    operator = condition.get("operator", condition.get("mode"))
+    if field_name not in ADDRESS_FIELDS | TEXT_FIELDS | {"direction"}:
+        raise RuleValidationError(f"rule '{rule_id}' has unsupported field")
+    if operator not in OPERATORS | {"equals"}:
+        raise RuleValidationError(f"rule '{rule_id}' has unsupported operator")
+    value = condition.get("value")
+    if not isinstance(value, str) or not " ".join(unicodedata.normalize("NFKC", value).split()):
+        raise RuleValidationError(f"rule '{rule_id}' condition requires a value")
+    return field_name, operator
+
+
+def _validate_direction(field_name: object, operator: object, value: object) -> None:
+    if field_name == "direction" and value not in {"sent", "received", "either"}:
+        raise RuleValidationError("direction has an invalid value")
+    if field_name == "direction" and operator not in {"exact", "equals"}:
+        raise RuleValidationError("direction requires the equals operator")
+
+
+def _validate_exact_address_operator(field_name: object, operator: object, value: object) -> None:
+    if operator == "exact_address" and field_name not in ADDRESS_FIELDS:
+        raise RuleValidationError("exact_address requires an address field")
+    if operator == "exact_address" and not normalize_address(value):
+        raise RuleValidationError("exact_address requires a valid addr-spec")
+
+
+def _validate_exact_domain_operator(field_name: object, operator: object, value: object) -> None:
+    if operator == "exact_domain" and field_name not in ADDRESS_FIELDS:
+        raise RuleValidationError("exact_domain requires an address field")
+    if operator == "exact_domain" and not normalize_domain(value):
+        raise RuleValidationError("exact_domain requires a valid domain")
+
+
+def _validate_condition_operator(
+    condition: Mapping[str, Any], field_name: object, operator: object, collection: bool
+) -> None:
+    value = condition["value"]
+    _validate_direction(field_name, operator, value)
+    _validate_exact_address_operator(field_name, operator, value)
+    _validate_exact_domain_operator(field_name, operator, value)
+    if collection and field_name in ADDRESS_FIELDS and operator not in {"exact_address", "exact_domain"}:
+        raise RuleValidationError("collection address fields require exact_address or exact_domain")
+
+
+def _validate_condition_options(condition: Mapping[str, Any], field_name: object) -> None:
+    if "case_sensitive" in condition and not isinstance(condition["case_sensitive"], bool):
+        raise RuleValidationError("case_sensitive must be boolean")
+    if condition.get("target", "subject_body") not in TARGETS:
+        raise RuleValidationError("condition has unsupported target")
+    if not header_option_is_valid(condition, field_name):
+        raise RuleValidationError("header field requires an RFC header name")
+
+
+def _validate_condition(condition: Mapping[str, Any], rule_id: str, collection: bool) -> None:
+    field_name, operator = _validate_condition_shape(condition, rule_id)
+    _validate_condition_operator(condition, field_name, operator, collection)
+    _validate_condition_options(condition, field_name)
+
+
+def validate_rule(rule: Mapping[str, Any]) -> None:
+    """Validate one v2 rule without interpreting provider capabilities."""
+    rule_id = _validate_rule_metadata(rule)
+    _validate_backfill(rule, rule_id)
+    _validate_actions(rule, rule_id)
+    block = match_block(rule)
+    if set(block) - {"all", "any"}:
+        raise RuleValidationError(f"rule '{rule_id}' match has unsupported keys")
+    all_conditions = conditions(block, "all")
+    any_conditions = conditions(block, "any")
+    if not all_conditions and not any_conditions:
+        raise RuleValidationError(f"rule '{rule_id}' requires all and/or any conditions")
+    for condition in all_conditions + any_conditions:
+        _validate_condition(condition, rule_id, rule.get("collection", True) is not False)

--- a/.agents/scripts/email_poll.py
+++ b/.agents/scripts/email_poll.py
@@ -32,9 +32,19 @@ import os
 import re
 import subprocess
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
+
+from email_collection_receipts import ReceiptContext, write_collection_receipt
+from email_match_rules import (
+    MatchResult,
+    fields_from_bytes,
+    load_rule_config,
+    match_rule,
+    rule_digest,
+    select_rules,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -53,6 +63,58 @@ class PollConfig:
     dry_run: bool = False
     rate_limit_per_min: int = 0
     max_messages: int = 0
+    rules: list[dict] = field(default_factory=list)
+    account_identities: tuple[str, ...] = ()
+
+
+@dataclass
+class BackfillConfig:
+    """Options for one bounded mailbox backfill."""
+
+    inbox_dir: str
+    since_date: str
+    rate_limit_per_min: int = 100
+    rules: list[dict] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class EmlWriteTarget:
+    """Private inbox destination for one staged IMAP message."""
+
+    inbox_dir: str
+    mailbox_id: str
+    folder: str
+    uid: int
+
+
+@dataclass
+class RuleScanContext:
+    """Prepared rule state for one folder poll."""
+
+    rule_keys: dict[str, dict]
+    rule_cursors: dict[str, int]
+    pending_states: dict[str, dict]
+    account_identities: tuple[str, ...]
+    filtering_enabled: bool = False
+    candidate_uids: dict[str, set[int]] = field(default_factory=dict)
+    candidate_evidence: dict[str, dict[str, object]] = field(default_factory=dict)
+    matched_rules_by_uid: dict[int, list[dict]] = field(default_factory=dict)
+
+
+@dataclass
+class BackfillContext:
+    """Mailbox and rule state shared while scanning one backfill folder."""
+
+    mailbox_id: str
+    folder: str
+    state: dict
+    config: BackfillConfig
+    active_rules: list[dict]
+    account_identities: tuple[str, ...]
+    filtering_enabled: bool = False
+    candidate_uids: dict[str, set[int]] = field(default_factory=dict)
+    candidate_evidence: dict[str, dict[str, object]] = field(default_factory=dict)
+    matched_rules_by_uid: dict[int, list[dict]] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -153,6 +215,29 @@ def _state_key(mailbox_id: str, folder: str) -> str:
     return f"{mailbox_id}/{safe_folder}"
 
 
+def _filter_state_key(mailbox_id: str, folder: str, rule: dict) -> str:
+    """Content-free checkpoint key for one mailbox/folder/rule lineage."""
+    rule_id = re.sub(r"[^a-zA-Z0-9_.-]", "_", str(rule.get("id") or rule.get("name")))
+    return f"{_state_key(mailbox_id, folder)}/imap/filter/{rule_id}/{rule_digest(rule)}"
+
+
+def _mailbox_filtering_enabled(rules: list[dict], mailbox_id: str) -> bool:
+    """Return whether collection-rule configuration makes a mailbox fail closed."""
+    return any(
+        rule.get("collection", True) is not False
+        and (not rule.get("mailboxes") or mailbox_id in rule["mailboxes"])
+        for rule in rules
+    )
+
+
+def _backfill_state_key(
+    mailbox_id: str, folder: str, rule: dict, since_date: str = ""
+) -> str:
+    """Keep bounded replay receipts separate from the live high watermark."""
+    lineage_date = since_date or str((rule.get("backfill") or {}).get("since") or "all")
+    return f"{_filter_state_key(mailbox_id, folder, rule)}/backfill/{lineage_date}"
+
+
 # ---------------------------------------------------------------------------
 # IMAP connection helpers
 # ---------------------------------------------------------------------------
@@ -165,38 +250,62 @@ def _connect_imap(host: str, port: int, user: str, password: str) -> imaplib.IMA
 
 
 def _search_uids_since(
-    conn: imaplib.IMAP4_SSL, folder: str, last_uid: int, max_uids: int = 0
-) -> list[int]:
+    conn: imaplib.IMAP4_SSL,
+    folder: str,
+    last_uid: int,
+    max_uids: int = 0,
+    since_date: str = "",
+) -> tuple[list[int], dict[str, object]]:
     """SELECT folder and return UIDs > last_uid, optionally capped at max_uids.
 
-    Returns a plain list[int]. Raises RuntimeError on IMAP errors.
+    Returns selected UIDs and content-free scan evidence. Raises RuntimeError on
+    IMAP errors.
     """
     status, _ = conn.select(f'"{folder}"', readonly=True)
     if status != "OK":
         raise RuntimeError(f"SELECT '{folder}' failed: {status}")
 
     start_uid = last_uid + 1
-    status, data = conn.uid("SEARCH", None, f"UID {start_uid}:*")  # type: ignore[arg-type]
+    criteria = f"UID {start_uid}:*"
+    if since_date:
+        imap_date = datetime.strptime(since_date, "%Y-%m-%d").strftime("%d-%b-%Y")
+        criteria = f"{criteria} SINCE {imap_date}"
+    status, data = conn.uid("SEARCH", None, criteria)  # type: ignore[arg-type]
     if status != "OK":
         raise RuntimeError(f"UID SEARCH failed: {status}")
 
-    uid_list_raw = data[0]
-    if not uid_list_raw:
-        return []
-
-    uid_strings = uid_list_raw.decode().split()
-    if not uid_strings:
-        return []
-
+    uid_list_raw = data[0] if data else b""
+    uid_strings = uid_list_raw.decode().split() if uid_list_raw else []
     # Filter: server may return * = UIDNEXT-1 when the range is empty
     valid_uids = [int(u) for u in uid_strings if int(u) > last_uid]
-    if not valid_uids:
-        return []
+    candidate_total = len(valid_uids)
+    has_more = max_uids > 0 and candidate_total > max_uids
+    evidence: dict[str, object] = {
+        "candidate_total": candidate_total,
+        "has_more": has_more,
+        "backfill_truncated": last_uid == 0 and has_more,
+        "mode": "initial" if last_uid == 0 else "incremental",
+    }
 
     if max_uids > 0:
-        valid_uids = valid_uids[:max_uids]
+        # A new rule lineage performs one bounded recent-history replay, then
+        # checkpoints the high UID so later ticks collect only new mail.
+        valid_uids = valid_uids[-max_uids:] if last_uid == 0 else valid_uids[:max_uids]
 
-    return valid_uids
+    return valid_uids, evidence
+
+
+def _uid_fetch_selected(
+    conn: imaplib.IMAP4_SSL, valid_uids: list[int]
+) -> list[tuple[int, bytes]]:
+    """Fetch one sorted union of already-selected candidate UIDs."""
+    if not valid_uids:
+        return []
+    uid_set = ",".join(str(uid) for uid in valid_uids)
+    status, fetch_data = conn.uid("FETCH", uid_set, "(BODY.PEEK[])")  # type: ignore[arg-type]
+    if status != "OK":
+        raise RuntimeError(f"UID FETCH failed: {status}")
+    return _parse_fetch_response(fetch_data, valid_uids)
 
 
 def _parse_fetch_response(
@@ -239,20 +348,15 @@ def _uid_fetch_since(
 
     Returns a list of (uid, raw_rfc822_bytes) tuples sorted by UID ascending.
     """
-    valid_uids = _search_uids_since(conn, folder, last_uid, max_uids)
+    valid_uids, _evidence = _search_uids_since(conn, folder, last_uid, max_uids)
     if not valid_uids:
         return []
 
-    uid_set = ",".join(str(u) for u in valid_uids)
-    status, fetch_data = conn.uid("FETCH", uid_set, "(RFC822)")  # type: ignore[arg-type]
-    if status != "OK":
-        raise RuntimeError(f"UID FETCH failed: {status}")
-
-    return _parse_fetch_response(fetch_data, valid_uids, last_uid)
+    return _uid_fetch_selected(conn, valid_uids)
 
 
 def _uid_fetch_since_date(
-    conn: imaplib.IMAP4_SSL, folder: str, since_date: str
+    conn: imaplib.IMAP4_SSL, folder: str, since_date: str, max_uids: int = 0
 ) -> list[tuple[int, bytes]]:
     """Fetch all messages in folder with INTERNALDATE >= since_date.
 
@@ -282,9 +386,11 @@ def _uid_fetch_since_date(
     valid_uids = [int(u) for u in uid_strings]
     if not valid_uids:
         return []
+    if max_uids > 0:
+        valid_uids = valid_uids[-max_uids:]
 
     uid_set = ",".join(str(u) for u in valid_uids)
-    status, fetch_data = conn.uid("FETCH", uid_set, "(RFC822)")  # type: ignore[arg-type]
+    status, fetch_data = conn.uid("FETCH", uid_set, "(BODY.PEEK[])")  # type: ignore[arg-type]
     if status != "OK":
         raise RuntimeError(f"UID FETCH failed: {status}")
 
@@ -296,24 +402,150 @@ def _uid_fetch_since_date(
 # .eml file output
 # ---------------------------------------------------------------------------
 
-def _write_eml(inbox_dir: str, mailbox_id: str, folder: str, uid: int, raw_msg: bytes) -> Path:
+def _write_eml(
+    target: EmlWriteTarget,
+    raw_msg: bytes,
+    receipt: tuple[ReceiptContext, list[dict]] | None = None,
+) -> Path:
     """Write raw RFC-822 bytes to inbox_dir/email-<mailbox_id>-<folder>-<uid>.eml.
 
     Folder is included to prevent UID collisions across folders (UIDs are
     per-folder on IMAP servers, so the same UID can exist in multiple folders).
     """
-    Path(inbox_dir).mkdir(parents=True, exist_ok=True)
-    safe_id = re.sub(r"[^a-zA-Z0-9_-]", "_", mailbox_id)
-    safe_folder = re.sub(r"[^a-zA-Z0-9_-]", "_", folder)
-    filename = f"email-{safe_id}-{safe_folder}-{uid}.eml"
-    out_path = Path(inbox_dir) / filename
-    out_path.write_bytes(raw_msg)
+    Path(target.inbox_dir).mkdir(parents=True, exist_ok=True)
+    safe_id = re.sub(r"[^a-zA-Z0-9_-]", "_", target.mailbox_id)
+    safe_folder = re.sub(r"[^a-zA-Z0-9_-]", "_", target.folder)
+    filename = f"email-{safe_id}-{safe_folder}-{target.uid}.eml"
+    out_path = Path(target.inbox_dir) / filename
+    staging_path = out_path.with_suffix(".eml.tmp")
+    try:
+        staging_path.write_bytes(raw_msg)
+        if receipt is not None:
+            context, rules = receipt
+            write_collection_receipt(out_path, context, rules)
+        staging_path.replace(out_path)
+    finally:
+        staging_path.unlink(missing_ok=True)
     return out_path
 
 
 # ---------------------------------------------------------------------------
 # Folder-level polling helper
 # ---------------------------------------------------------------------------
+
+def _prepare_rule_scan(
+    mb_id: str, folder: str, state: dict, config: PollConfig
+) -> tuple[RuleScanContext, int]:
+    """Prepare independent rule cursors and the bounded fetch window."""
+    rules = select_rules({"rules": config.rules}, mb_id, folder) if config.rules else []
+    rule_keys = {_filter_state_key(mb_id, folder, rule): rule for rule in rules}
+    rule_cursors = {
+        rule_key: state.get(rule_key, {}).get("last_uid_seen", 0)
+        for rule_key in rule_keys
+    }
+    last_uid = min(rule_cursors.values()) if rule_cursors else state.get(_state_key(mb_id, folder), {}).get("last_uid_seen", 0)
+    context = RuleScanContext(
+        rule_keys=rule_keys,
+        rule_cursors=rule_cursors,
+        pending_states={rule_key: dict(state.get(rule_key, {})) for rule_key in rule_keys},
+        account_identities=config.account_identities,
+        filtering_enabled=_mailbox_filtering_enabled(config.rules, mb_id),
+    )
+    return context, last_uid
+
+
+def _rule_candidate_uids(
+    conn: imaplib.IMAP4_SSL,
+    folder: str,
+    entries: dict[str, tuple[dict, int]],
+    minimum_since: str = "",
+    max_uids: int = 0,
+) -> tuple[dict[str, set[int]], dict[str, dict[str, object]]]:
+    """Select a bounded candidate window independently for each rule lineage."""
+    selected: dict[str, set[int]] = {}
+    evidence: dict[str, dict[str, object]] = {}
+    for rule_key, (rule, cursor) in entries.items():
+        backfill = rule.get("backfill") or {}
+        limit = int(backfill.get("limit", 500))
+        if max_uids > 0:
+            limit = min(limit, max_uids)
+        since_date = max(minimum_since, str(backfill.get("since") or ""))
+        candidate_uids, evidence[rule_key] = _search_uids_since(
+            conn,
+            folder,
+            cursor,
+            max_uids=limit,
+            since_date=since_date,
+        )
+        selected[rule_key] = set(candidate_uids)
+    return selected, evidence
+
+
+def _fetch_poll_candidates(
+    conn: imaplib.IMAP4_SSL,
+    folder: str,
+    context: RuleScanContext,
+    last_uid: int,
+    max_uids: int,
+) -> list[tuple[int, bytes]]:
+    if not context.rule_keys:
+        if context.filtering_enabled:
+            return []
+        return _uid_fetch_since(conn, folder, last_uid, max_uids=max_uids)
+    entries = {
+        rule_key: (rule, context.rule_cursors[rule_key])
+        for rule_key, rule in context.rule_keys.items()
+    }
+    context.candidate_uids, context.candidate_evidence = _rule_candidate_uids(
+        conn,
+        folder,
+        entries,
+        max_uids=max_uids,
+    )
+    union = sorted(set().union(*context.candidate_uids.values()))
+    return _uid_fetch_selected(conn, union)
+
+
+def _scan_poll_message(
+    uid: int, raw_msg: bytes, context: RuleScanContext, folder_result: dict
+) -> bool:
+    """Apply each unseen rule and update only content-free pending receipts."""
+    if not context.rule_keys:
+        if context.filtering_enabled:
+            return False
+        folder_result["scanned"] += 1
+        return True
+    fields = fields_from_bytes(raw_msg)
+    should_write = False
+    for rule_key, rule in context.rule_keys.items():
+        if uid not in context.candidate_uids[rule_key]:
+            continue
+        match = match_rule(rule, fields, context.account_identities)
+        folder_result["scanned"] += 1
+        folder_result["coverage_gaps"].extend(match.unavailable_fields)
+        if match.matched:
+            should_write = True
+            context.matched_rules_by_uid.setdefault(uid, []).append(rule)
+            current = folder_result["matched_rules"].get(match.rule_id, 0)
+            folder_result["matched_rules"][match.rule_id] = current + 1
+        prior = context.pending_states[rule_key]
+        candidate_evidence = context.candidate_evidence.get(rule_key, {})
+        context.pending_states[rule_key] = {
+            "last_uid_seen": uid,
+            "last_polled_at": folder_result["last_polled_at"],
+            "scanned": prior.get("scanned", 0) + 1,
+            "matched": prior.get("matched", 0) + int(match.matched),
+            "coverage_gaps": sorted(
+                set(prior.get("coverage_gaps", [])) | set(match.unavailable_fields)
+            ),
+            "candidate_total": candidate_evidence.get("candidate_total", 0),
+            "has_more": bool(candidate_evidence.get("has_more")),
+            "backfill_truncated": bool(prior.get("backfill_truncated"))
+            or bool(candidate_evidence.get("backfill_truncated")),
+            "mode": candidate_evidence.get("mode", "incremental"),
+        }
+    return should_write
+
 
 def _poll_folder(
     conn: imaplib.IMAP4_SSL,
@@ -330,12 +562,33 @@ def _poll_folder(
     import time  # noqa: PLC0415
 
     key = _state_key(mb_id, folder)
-    last_uid = state.get(key, {}).get("last_uid_seen", 0)
+    scan_context, last_uid = _prepare_rule_scan(mb_id, folder, state, config)
     now_iso = datetime.now(timezone.utc).isoformat()
-    folder_result: dict = {"folder": folder, "fetched": 0, "error": None}
+    folder_result: dict = {
+        "folder": folder,
+        "fetched": 0,
+        "scanned": 0,
+        "matched_rules": {},
+        "coverage_gaps": [],
+        "candidate_total": 0,
+        "has_more": False,
+        "backfill_truncated": False,
+        "error": None,
+        "last_polled_at": now_iso,
+    }
 
     try:
-        messages = _uid_fetch_since(conn, folder, last_uid, max_uids=config.max_messages)
+        messages = _fetch_poll_candidates(
+            conn, folder, scan_context, last_uid, config.max_messages
+        )
+        evidence = list(scan_context.candidate_evidence.values())
+        folder_result["candidate_total"] = sum(
+            int(item.get("candidate_total", 0)) for item in evidence
+        )
+        folder_result["has_more"] = any(item.get("has_more") for item in evidence)
+        folder_result["backfill_truncated"] = any(
+            item.get("backfill_truncated") for item in evidence
+        )
     except Exception as exc:
         folder_result["error"] = str(exc)
         folder_result["new_high_uid"] = last_uid
@@ -343,19 +596,41 @@ def _poll_folder(
 
     new_high_uid = last_uid
     delay = (60.0 / config.rate_limit_per_min) if config.rate_limit_per_min > 0 else 0
+    pending_writes: list[tuple[int, bytes]] = []
 
-    for uid, raw_msg in messages:
+    try:
+        for uid, raw_msg in messages:
+            should_write = _scan_poll_message(uid, raw_msg, scan_context, folder_result)
+            if should_write:
+                pending_writes.append((uid, raw_msg))
+            new_high_uid = max(new_high_uid, uid)
+            folder_result["fetched"] += int(should_write)
+            if delay > 0:
+                time.sleep(delay)
+
         if not config.dry_run:
-            _write_eml(config.inbox_dir, mb_id, folder, uid, raw_msg)
-        if uid > new_high_uid:
-            new_high_uid = uid
-        folder_result["fetched"] += 1
-        if delay > 0:
-            time.sleep(delay)
+            for uid, raw_msg in pending_writes:
+                rules = scan_context.matched_rules_by_uid.get(uid, [])
+                collection_receipt = None
+                if rules:
+                    receipt_context = ReceiptContext("imap", mb_id, folder, str(uid))
+                    collection_receipt = (receipt_context, rules)
+                _write_eml(
+                    EmlWriteTarget(config.inbox_dir, mb_id, folder, uid),
+                    raw_msg,
+                    collection_receipt,
+                )
+            if scan_context.rule_keys:
+                state.update(scan_context.pending_states)
+            elif new_high_uid > last_uid:
+                state[key] = {"last_uid_seen": new_high_uid, "last_polled_at": now_iso}
+    except Exception as exc:
+        folder_result["error"] = type(exc).__name__
+        folder_result["new_high_uid"] = last_uid
+        return folder_result
 
-    if not config.dry_run and new_high_uid > last_uid:
-        state[key] = {"last_uid_seen": new_high_uid, "last_polled_at": now_iso}
-
+    folder_result["coverage_gaps"] = sorted(set(folder_result["coverage_gaps"]))
+    folder_result.pop("last_polled_at")
     folder_result["new_high_uid"] = new_high_uid
     return folder_result
 
@@ -414,9 +689,11 @@ def poll_mailbox(mb_config: dict, state: dict, config: "PollConfig | None" = Non
         return result
 
     total_fetched = 0
+    identities = tuple(mb_config.get("identities") or ()) + (user,)
+    folder_config = replace(config, account_identities=identities)
     try:
         for folder in folders:
-            folder_result = _poll_folder(conn, mb_id, folder, state, config)
+            folder_result = _poll_folder(conn, mb_id, folder, state, folder_config)
             if folder_result.get("error"):
                 result["status"] = "partial_error"
             total_fetched += folder_result["fetched"]
@@ -435,32 +712,189 @@ def poll_mailbox(mb_config: dict, state: dict, config: "PollConfig | None" = Non
     return result
 
 
-def backfill_mailbox(
+def _record_backfill_match(
+    context: BackfillContext, rule: dict, uid: int, match: MatchResult
+) -> None:
+    """Record one sanitized rule receipt without persisting message content."""
+    receipt_key = _backfill_receipt_key(context, rule)
+    prior = context.state.get(receipt_key, {})
+    candidate_evidence = context.candidate_evidence.get(receipt_key, {})
+    context.state[receipt_key] = {
+        "last_uid_seen": uid,
+        "last_scanned_at": datetime.now(timezone.utc).isoformat(),
+        "since": context.config.since_date,
+        "scanned": prior.get("scanned", 0) + 1,
+        "matched": prior.get("matched", 0) + int(match.matched),
+        "coverage_gaps": sorted(
+            set(prior.get("coverage_gaps", [])) | set(match.unavailable_fields)
+        ),
+        "candidate_total": candidate_evidence.get("candidate_total", 0),
+        "has_more": bool(candidate_evidence.get("has_more")),
+        "backfill_truncated": bool(prior.get("backfill_truncated"))
+        or bool(candidate_evidence.get("backfill_truncated")),
+        "mode": candidate_evidence.get("mode", "initial"),
+    }
+    if match.matched:
+        context.matched_rules_by_uid.setdefault(uid, []).append(rule)
+
+
+def _backfill_receipt_key(context: BackfillContext, rule: dict) -> str:
+    rule_since = str((rule.get("backfill") or {}).get("since") or "")
+    effective_since = max(context.config.since_date, rule_since)
+    return _backfill_state_key(
+        context.mailbox_id, context.folder, rule, effective_since
+    )
+
+
+def _scan_backfill_message(context: BackfillContext, uid: int, raw_msg: bytes) -> bool:
+    if not context.active_rules:
+        return not context.filtering_enabled
+    fields = fields_from_bytes(raw_msg)
+    should_write = False
+    for rule in context.active_rules:
+        receipt_key = _backfill_receipt_key(context, rule)
+        if uid not in context.candidate_uids[receipt_key]:
+            continue
+        match = match_rule(rule, fields, context.account_identities)
+        _record_backfill_match(context, rule, uid, match)
+        should_write = should_write or match.matched
+    return should_write
+
+
+def _backfill_messages(
+    conn: imaplib.IMAP4_SSL, context: BackfillContext
+) -> list[tuple[int, bytes]]:
+    if not context.active_rules:
+        if context.filtering_enabled:
+            return []
+        return _uid_fetch_since_date(conn, context.folder, context.config.since_date)
+    entries = {
+        key: (rule, context.state.get(key, {}).get("last_uid_seen", 0))
+        for rule in context.active_rules
+        for key in [_backfill_receipt_key(context, rule)]
+    }
+    context.candidate_uids, context.candidate_evidence = _rule_candidate_uids(
+        conn,
+        context.folder,
+        entries,
+        minimum_since=context.config.since_date,
+    )
+    union = sorted(set().union(*context.candidate_uids.values()))
+    return _uid_fetch_selected(conn, union)
+
+
+def _process_backfill_messages(
+    context: BackfillContext, messages: list[tuple[int, bytes]], result: dict
+) -> None:
+    import time  # noqa: PLC0415
+
+    delay = 60.0 / context.config.rate_limit_per_min if context.config.rate_limit_per_min > 0 else 0
+    for uid, raw_msg in messages:
+        should_write = _scan_backfill_message(context, uid, raw_msg)
+        if should_write:
+            rules = context.matched_rules_by_uid.get(uid, [])
+            collection_receipt = None
+            if rules:
+                receipt_context = ReceiptContext(
+                    "imap", context.mailbox_id, context.folder, str(uid)
+                )
+                collection_receipt = (receipt_context, rules)
+            _write_eml(
+                EmlWriteTarget(
+                    context.config.inbox_dir,
+                    context.mailbox_id,
+                    context.folder,
+                    uid,
+                ),
+                raw_msg,
+                collection_receipt,
+            )
+            result["fetched"] += 1
+        result["scanned"] += 1
+        if delay > 0:
+            time.sleep(delay)
+    result["message_count"] = len(messages)
+
+
+def _backfill_folder(conn: imaplib.IMAP4_SSL, context: BackfillContext) -> dict:
+    result = {
+        "folder": context.folder,
+        "fetched": 0,
+        "scanned": 0,
+        "candidate_total": 0,
+        "has_more": False,
+        "backfill_truncated": False,
+        "error": None,
+    }
+    try:
+        messages = _backfill_messages(conn, context)
+    except Exception as exc:
+        result["error"] = str(exc)
+        return result
+    evidence = list(context.candidate_evidence.values())
+    result["candidate_total"] = sum(
+        int(item.get("candidate_total", 0)) for item in evidence
+    )
+    result["has_more"] = any(item.get("has_more") for item in evidence)
+    result["backfill_truncated"] = any(
+        item.get("backfill_truncated") for item in evidence
+    )
+    _process_backfill_messages(context, messages, result)
+    return result
+
+
+def _backfill_mailbox_folders(
+    conn: imaplib.IMAP4_SSL,
     mb_config: dict,
     state: dict,
-    inbox_dir: str,
-    since_date: str,
-    rate_limit_per_min: int = 100,
-) -> dict:
+    config: BackfillConfig,
+    result: dict,
+) -> int:
+    mailbox_id = mb_config["id"]
+    identities = tuple(mb_config.get("identities") or ()) + (mb_config["user"],)
+    total_fetched = 0
+    for folder in mb_config.get("folders", ["INBOX"]):
+        active_rules = select_rules({"rules": config.rules}, mailbox_id, folder) if config.rules else []
+        context = BackfillContext(
+            mailbox_id,
+            folder,
+            state,
+            config,
+            active_rules,
+            identities,
+            _mailbox_filtering_enabled(config.rules, mailbox_id),
+        )
+        folder_result = _backfill_folder(conn, context)
+        if folder_result["error"]:
+            result["status"] = "partial_error"
+        total_fetched += folder_result["fetched"]
+        result["folders"][folder] = folder_result
+    return total_fetched
+
+
+def _safe_logout(conn: imaplib.IMAP4_SSL) -> None:
+    try:
+        conn.logout()
+    except Exception:
+        pass
+
+
+def backfill_mailbox(mb_config: dict, state: dict, config: BackfillConfig) -> dict:
     """Back-fill a single mailbox from since_date (bypasses last-seen UID).
 
     Rate-limited to avoid IMAP-server abuse (default: 100 msgs/min).
     Does NOT update the high-watermark UID (backfill is additive, not a tick).
     """
-    import time  # noqa: PLC0415
-
     mb_id = mb_config["id"]
     host = mb_config["host"]
     port = int(mb_config.get("port", 993))
     user = mb_config["user"]
     password_ref = mb_config.get("password_ref", "")
-    folders = mb_config.get("folders", ["INBOX"])
-
     result: dict = {
         "mailbox_id": mb_id,
         "status": "ok",
         "fetched_count": 0,
-        "since_date": since_date,
+        "since_date": config.since_date,
         "folders": {},
     }
 
@@ -478,34 +912,10 @@ def backfill_mailbox(
         result["error"] = str(exc)
         return result
 
-    total_fetched = 0
-    delay = (60.0 / rate_limit_per_min) if rate_limit_per_min > 0 else 0
-
     try:
-        for folder in folders:
-            folder_result = {"folder": folder, "fetched": 0, "error": None}
-            try:
-                messages = _uid_fetch_since_date(conn, folder, since_date)
-            except Exception as exc:
-                folder_result["error"] = str(exc)
-                result["folders"][folder] = folder_result
-                result["status"] = "partial_error"
-                continue
-
-            for uid, raw_msg in messages:
-                _write_eml(inbox_dir, mb_id, folder, uid, raw_msg)
-                total_fetched += 1
-                folder_result["fetched"] += 1
-                if delay > 0:
-                    time.sleep(delay)
-
-            folder_result["message_count"] = len(messages)
-            result["folders"][folder] = folder_result
+        total_fetched = _backfill_mailbox_folders(conn, mb_config, state, config, result)
     finally:
-        try:
-            conn.logout()
-        except Exception:
-            pass
+        _safe_logout(conn)
 
     result["fetched_count"] = total_fetched
     return result
@@ -519,7 +929,8 @@ def cmd_tick(args: argparse.Namespace) -> int:
     """Tick: poll all mailboxes, write new messages to inbox."""
     config = load_mailboxes_config(args.config)
     state = load_state(args.state)
-    poll_cfg = PollConfig(inbox_dir=args.inbox)
+    rules = load_rule_config(args.filters).get("rules", []) if args.filters else []
+    poll_cfg = PollConfig(inbox_dir=args.inbox, rules=rules)
     results = []
     overall_ok = True
 
@@ -553,14 +964,16 @@ def cmd_backfill(args: argparse.Namespace) -> int:
     config = load_mailboxes_config(args.config)
     mb_config = get_mailbox_config(config, args.mailbox_id)
     state = load_state(args.state)
+    rules = load_rule_config(args.filters).get("rules", []) if args.filters else []
 
-    res = backfill_mailbox(
-        mb_config,
-        state,
-        args.inbox,
-        args.since,
+    backfill_config = BackfillConfig(
+        inbox_dir=args.inbox,
+        since_date=args.since,
         rate_limit_per_min=args.rate_limit,
+        rules=rules,
     )
+    res = backfill_mailbox(mb_config, state, backfill_config)
+    save_state(args.state, state)
     print(json.dumps(res, indent=2))
     return 0 if res["status"] == "ok" else 1
 
@@ -627,6 +1040,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_tick.add_argument("--config", required=True, help="Path to mailboxes.json")
     p_tick.add_argument("--state", required=True, help="Path to .imap-state.json")
     p_tick.add_argument("--inbox", required=True, help="Directory to write .eml files")
+    p_tick.add_argument("--filters", help="Optional version 2 email filter config")
 
     # backfill
     p_bf = sub.add_parser("backfill", help="Backfill a mailbox from a given date")
@@ -634,6 +1048,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_bf.add_argument("--state", required=True)
     p_bf.add_argument("--inbox", required=True)
     p_bf.add_argument("--mailbox-id", required=True, help="Mailbox ID to backfill")
+    p_bf.add_argument("--filters", help="Optional version 2 email filter config")
     p_bf.add_argument("--since", required=True, help="ISO date, e.g. 2026-01-01")
     p_bf.add_argument(
         "--rate-limit", type=int, default=100,

--- a/.agents/templates/email-filters-config.json
+++ b/.agents/templates/email-filters-config.json
@@ -1,29 +1,56 @@
 {
-  "_comment": "Email filter ruleset template. Copy to <repo>/_config/email-filters.json and customise.",
-  "_doc": "Rules are evaluated in order with AND semantics (all match predicates must match). First match wins per source per tick run.",
+  "version": 2,
+  "_comment": "Private email filter rules. Copy to <repo>/_config/email-filters.json; never commit real addresses, references, or phrases.",
+  "_doc": "The transport may narrow candidates, but these all/any conditions are always checked locally before persistence.",
   "rules": [
     {
-      "name": "Dispute counsel correspondence",
-      "_comment": "Example: attach emails from dispute counsel to the dispute case as privileged evidence",
+      "id": "case-correspondence",
+      "name": "Selected case correspondence",
+      "enabled": true,
+      "collection": true,
+      "mailboxes": ["work-mailbox"],
+      "folders": ["INBOX", "Sent"],
+      "backfill": {
+        "since": "2026-01-01",
+        "limit": 500
+      },
       "match": {
-        "from_contains": "dispute-counsel@example.com",
-        "subject_contains_any": ["Re: Dispute", "Dispute Notice"]
+        "all": [
+          {
+            "field": "from",
+            "operator": "exact_domain",
+            "value": "example.com"
+          },
+          {
+            "field": "direction",
+            "operator": "equals",
+            "value": "received"
+          }
+        ],
+        "any": [
+          {
+            "field": "subject",
+            "operator": "reference",
+            "value": "CASE-123"
+          },
+          {
+            "field": "body",
+            "operator": "phrase",
+            "value": "signed agreement",
+            "case_sensitive": false
+          },
+          {
+            "field": "attachment_name",
+            "operator": "keyword",
+            "value": "contract"
+          }
+        ]
       },
       "actions": [
-        { "attach_to_case": "case-2026-0001-dispute-acme", "role": "evidence" },
-        { "set_sensitivity": "privileged" }
-      ]
-    },
-    {
-      "name": "Contract review emails",
-      "_comment": "Example: emails with 'contract' in subject from legal team → attach to contract case",
-      "match": {
-        "from_contains": "legal@example.com",
-        "subject_matches_regex": "contract|agreement|NDA"
-      },
-      "actions": [
-        { "attach_to_case": "case-2026-0002-contract-review", "role": "reference" },
-        { "set_sensitivity": "confidential" }
+        {
+          "attach_to_case": "case-example",
+          "role": "reference"
+        }
       ]
     }
   ]

--- a/.agents/tests/test-email-filter.sh
+++ b/.agents/tests/test-email-filter.sh
@@ -14,6 +14,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 FILTER_HELPER="${SCRIPT_DIR}/../scripts/email-filter-helper.sh"
+MAILBOX_HELPER="${SCRIPT_DIR}/../scripts/email-mailbox-helper.sh"
+MATCH_RULES="${SCRIPT_DIR}/../scripts/email_match_rules.py"
 
 # =============================================================================
 # Test framework
@@ -182,6 +184,32 @@ _make_email_source() {
   "sensitivity": "internal"
 }
 EOF
+	return 0
+}
+
+_add_collection_ref() {
+	local meta_path="$1"
+	local config_path="$2"
+	local rule_id="$3"
+	python3 - "$SCRIPT_DIR/../scripts" "$meta_path" "$config_path" "$rule_id" <<'PYEOF'
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[1])
+from email_collection_receipts import ReceiptContext, build_receipt  # noqa: E402
+
+meta_path = Path(sys.argv[2])
+with Path(sys.argv[3]).open(encoding="utf-8") as handle:
+    config = json.load(handle)
+rule = next(item for item in config["rules"] if item["id"] == sys.argv[4])
+with meta_path.open(encoding="utf-8") as handle:
+    meta = json.load(handle)
+meta["collection_refs"] = [
+    build_receipt(ReceiptContext("imap", "work", "INBOX", "fixture-1"), [rule])
+]
+meta_path.write_text(json.dumps(meta, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PYEOF
 	return 0
 }
 
@@ -423,6 +451,640 @@ test_tick_no_match_exits_zero() {
 	return 0
 }
 
+test_v2_deterministic_match_semantics() {
+	echo "==> v2 matcher: exact boundaries, direction, Unicode, and coverage"
+	if python3 - "$MATCH_RULES" <<'PYEOF'; then
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+sys.path.insert(0, str(Path(sys.argv[1]).parent))
+from email_match_rules import (  # noqa: E402
+    RuleValidationError,
+    fields_from_bytes,
+    fields_from_mapping,
+    load_rule_config,
+    match_rule,
+)
+
+raw = (
+    b"From: Counsel <legal@example.com>\r\n"
+    b"To: Observer <observer@client.test>, Case Worker <worker@client.test>\r\n"
+    b"Subject: Re: CASE-123 signed agreement\r\n\r\n"
+    b"Please review the signed   agreement."
+)
+fields = fields_from_bytes(raw)
+rule = {
+    "id": "case-rule",
+    "match": {
+        "all": [
+            {"field": "from", "operator": "exact_domain", "value": "example.com"},
+            {"field": "to", "operator": "exact_address", "value": "worker@client.test"},
+            {"field": "direction", "operator": "equals", "value": "received"},
+        ],
+        "any": [
+            {"field": "subject", "operator": "reference", "value": "CASE-123"},
+            {"field": "body", "operator": "phrase", "value": "SIGNED AGREEMENT"},
+        ],
+    },
+}
+assert match_rule(rule, fields, ["worker@client.test"]).matched
+
+evil = {"id": "evil", "match": {"all": [
+    {"field": "from", "operator": "exact_domain", "value": "evil-example.com"}
+]}}
+assert not match_rule(evil, fields).matched
+short = {"id": "short", "match": {"all": [
+    {"field": "subject", "operator": "reference", "value": "CASE-12"}
+]}}
+assert not match_rule(short, fields).matched
+
+unicode_fields = fields_from_mapping({"subject": "ＣＡＳＥ café\u0301   signed\n agreement"})
+unicode_rule = {"id": "unicode", "match": {"all": [
+    {"field": "subject", "operator": "phrase", "value": "case café́ signed agreement"}
+]}}
+assert match_rule(unicode_rule, unicode_fields).matched
+
+bcc_rule = {"id": "bcc", "match": {"all": [
+    {"field": "bcc", "operator": "exact_address", "value": "hidden@example.com"}
+]}}
+bcc_result = match_rule(bcc_rule, fields)
+assert not bcc_result.matched and bcc_result.unavailable_fields == ("bcc",)
+
+truncated = replace(
+    fields_from_mapping({"subject": "CASE-123"}),
+    unavailable_fields=("body",),
+)
+shorthand = {"id": "shorthand", "match": {"all": [
+    {"field": "reference", "operator": "reference", "value": "CASE-123"}
+]}}
+shorthand_result = match_rule(shorthand, truncated)
+assert shorthand_result.matched and shorthand_result.unavailable_fields == ("body",)
+
+try:
+    fields_from_bytes(b"Content-Type: multipart/mixed\r\n\r\nbroken")
+except ValueError:
+    pass
+else:
+    raise AssertionError("malformed MIME accepted")
+
+try:
+    load_rule_config({"version": 2, "rules": [{"id": "unsafe", "match": {"all": []}}]})
+except RuleValidationError:
+    pass
+else:
+    raise AssertionError("empty rule accepted")
+
+for bad_backfill in ({"limit": 0}, {"limit": 5001}, {"limit": True}, {"since": "not-a-date"}):
+    invalid = {"version": 2, "rules": [{
+        "id": "invalid-backfill",
+        "backfill": bad_backfill,
+        "match": {"all": [{"field": "subject", "operator": "contains", "value": "x"}]},
+    }]}
+    try:
+        load_rule_config(invalid)
+    except RuleValidationError:
+        pass
+    else:
+        raise AssertionError(f"invalid backfill accepted: {bad_backfill}")
+
+invalid_action = {"version": 2, "rules": [{
+    "id": "invalid-action",
+    "actions": [{"delete": True}],
+    "match": {"all": [{"field": "subject", "operator": "contains", "value": "x"}]},
+}]}
+try:
+    load_rule_config(invalid_action)
+except RuleValidationError:
+    pass
+else:
+    raise AssertionError("unsupported action accepted")
+
+for condition in (
+    {"field": "from", "operator": "contains", "value": "example.com"},
+    {"field": "subject", "operator": "phrase", "value": " \t\n "},
+    {"field": "header", "operator": "phrase", "header": "Bad:Header", "value": "x"},
+):
+    invalid = {"version": 2, "rules": [{
+        "id": "overbroad",
+        "match": {"all": [condition]},
+    }]}
+    try:
+        load_rule_config(invalid)
+    except RuleValidationError:
+        pass
+    else:
+        raise AssertionError(f"overbroad collection condition accepted: {condition}")
+
+load_rule_config({"version": 2, "rules": [{
+    "id": "legacy-routing",
+    "collection": False,
+    "match": {"all": [{"field": "from", "operator": "contains", "value": "example.com"}]},
+}]})
+PYEOF
+		_pass "v2 deterministic match semantics"
+	else
+		_fail "v2 deterministic match semantics" "matcher assertions failed"
+	fi
+	return 0
+}
+
+test_v2_direction_action_routing() {
+	echo "==> v2 matcher: late collection provenance replays post-ingest actions"
+	_setup
+	local base="${TEST_TMPDIR}/repo"
+	_make_knowledge_root "$base"
+	_make_email_source "${base}/_knowledge/sources" "src-direction" \
+		"sender@example.com" "Direction Test" "2026-07-01T08:00:00Z"
+	_make_email_source "${base}/_knowledge/sources" "src-uncollected" \
+		"sender@example.com" "Direction Test" "2026-07-01T08:01:00Z"
+	local source_name
+	for source_name in src-direction src-uncollected; do
+		jq '.to = "Observer <observer@example.com>, Worker <worker@example.com>"' \
+			"${base}/_knowledge/sources/${source_name}/meta.json" >"${base}/meta.next.json"
+		mv "${base}/meta.next.json" "${base}/_knowledge/sources/${source_name}/meta.json"
+	done
+	cat >"${base}/_config/mailboxes.json" <<'EOF'
+{"mailboxes":[{"id":"work","user":"worker@example.com","identities":["alias@example.com"]}]}
+EOF
+	cat >"${base}/_config/email-filters.json" <<'EOF'
+{"version":2,"rules":[{"id":"direction-action","name":"Direction action","mailboxes":["work"],"match":{"all":[{"field":"direction","operator":"equals","value":"received"},{"field":"subject","operator":"contains","value":"Direction Test"},{"field":"header","header":"X-Case","operator":"phrase","value":"accepted"}]},"actions":[{"set_sensitivity":"confidential"}]}]}
+EOF
+	KNOWLEDGE_ROOT="${base}/_knowledge" bash "$FILTER_HELPER" tick >/dev/null
+	local before_sensitivity
+	before_sensitivity=$(jq -r '.sensitivity' "${base}/_knowledge/sources/src-direction/meta.json")
+	_add_collection_ref \
+		"${base}/_knowledge/sources/src-direction/meta.json" \
+		"${base}/_config/email-filters.json" \
+		"direction-action"
+	KNOWLEDGE_ROOT="${base}/_knowledge" bash "$FILTER_HELPER" tick >/dev/null
+	local collected_sensitivity uncollected_sensitivity
+	collected_sensitivity=$(jq -r '.sensitivity' "${base}/_knowledge/sources/src-direction/meta.json")
+	uncollected_sensitivity=$(jq -r '.sensitivity' "${base}/_knowledge/sources/src-uncollected/meta.json")
+	if [[ "$before_sensitivity" == "internal" && "$collected_sensitivity" == "confidential" && "$uncollected_sensitivity" == "internal" ]]; then
+		_pass "late collection provenance replays only the newly eligible canonical source"
+	else
+		_fail "late collection provenance replays only the newly eligible canonical source" \
+			"before=$before_sensitivity collected=$collected_sensitivity uncollected=$uncollected_sensitivity"
+	fi
+	_teardown
+	return 0
+}
+
+test_v2_rule_change_replays_actions() {
+	echo "==> v2 routing: disabled rules stay inert and changes replay canonical sources"
+	_setup
+	local base="${TEST_TMPDIR}/repo"
+	_make_knowledge_root "$base"
+	_make_email_source "${base}/_knowledge/sources" "src-replay" \
+		"sender@example.com" "Replay action" "2026-07-01T08:00:00Z"
+	cat >"${base}/_config/email-filters.json" <<'EOF'
+{"version":2,"rules":[{"id":"routing-replay","enabled":false,"collection":false,"match":{"all":[{"field":"subject","operator":"phrase","value":"Replay action"}]},"actions":[{"set_sensitivity":"confidential"}]}]}
+EOF
+	KNOWLEDGE_ROOT="${base}/_knowledge" bash "$FILTER_HELPER" tick >/dev/null
+	local first_sensitivity first_digest
+	first_sensitivity=$(jq -r '.sensitivity' "${base}/_knowledge/sources/src-replay/meta.json")
+	first_digest=$(jq -r '.rules_digest' "${base}/_knowledge/.email-filter-state.json")
+	jq '.rules[0].enabled = true' "${base}/_config/email-filters.json" >"${base}/filters.next.json"
+	mv "${base}/filters.next.json" "${base}/_config/email-filters.json"
+	KNOWLEDGE_ROOT="${base}/_knowledge" bash "$FILTER_HELPER" tick >/dev/null
+	local second_sensitivity second_digest
+	second_sensitivity=$(jq -r '.sensitivity' "${base}/_knowledge/sources/src-replay/meta.json")
+	second_digest=$(jq -r '.rules_digest' "${base}/_knowledge/.email-filter-state.json")
+	if [[ "$first_sensitivity" == "internal" && "$second_sensitivity" == "confidential" &&
+		-n "$first_digest" && "$first_digest" != "$second_digest" ]]; then
+		_pass "disabled routing rule replays after its ruleset changes"
+	else
+		_fail "disabled routing rule replays after its ruleset changes" \
+			"first=$first_sensitivity second=$second_sensitivity"
+	fi
+	_teardown
+	return 0
+}
+
+test_jmap_filter_gate_read_isolation() {
+	echo "==> JMAP filter gate: read-only local authority and missing-field coverage"
+	if python3 - "$SCRIPT_DIR/../scripts" <<'PYEOF'; then
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+from argparse import Namespace
+from pathlib import Path
+
+sys.path.insert(0, str(Path(sys.argv[1])))
+import email_jmap_commands as commands  # noqa: E402
+
+calls = []
+email = {
+    "id": "email-1",
+    "blobId": "blob-1",
+    "threadId": "thread-1",
+    "mailboxIds": {"mailbox-1": True},
+    "messageId": ["<email-1@example.test>"],
+    "receivedAt": "2026-07-31T10:00:00Z",
+    "from": [{"email": "sender@example.test"}],
+    "to": [{"email": "worker@example.test"}],
+    "subject": "Private message",
+    "textBody": [],
+    "htmlBody": [{"partId": "part-1"}],
+    "bodyValues": {"part-1": {"value": "<p>Private unmatched JMAP body: signed <strong>agreement</strong></p>"}},
+    "preview": "A teaser without the matching phrase",
+    "attachments": [],
+    "keywords": {},
+}
+
+
+def fake_request(_api_url, _user, method_calls):
+    calls.extend(method_calls)
+    return {"methodResponses": [["Email/get", {"list": [email]}, "g0"]]}
+
+
+commands._session_context = lambda _args: ({}, "account-1", "unused-api-endpoint")
+commands._jmap_request = fake_request
+with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+    json.dump({
+        "version": 2,
+        "rules": [{
+            "id": "bcc-rule",
+            "match": {"all": [{
+                "field": "bcc",
+                "operator": "exact_address",
+                "value": "hidden@example.test",
+            }]},
+        }, {
+            "id": "html-rule",
+            "match": {"all": [{
+                "field": "body",
+                "operator": "phrase",
+                "value": "signed agreement",
+            }]},
+        }],
+    }, handle)
+    config_path = handle.name
+
+args = Namespace(
+    email_id="email-1",
+    filter_config=config_path,
+    rule_id="bcc-rule",
+    account_identity=["worker@example.test"],
+    user="worker@example.test",
+)
+output = io.StringIO()
+try:
+    with contextlib.redirect_stdout(output):
+        result = commands.cmd_fetch_body(args)
+    explanation = json.loads(output.getvalue())
+    assert result == 3
+    assert explanation == {
+        "matched": False,
+        "matched_fields": [],
+        "rule_id": "bcc-rule",
+        "unavailable_fields": ["bcc"],
+    }
+    assert "Private unmatched JMAP body" not in output.getvalue()
+    args.rule_id = "html-rule"
+    matched_output = io.StringIO()
+    with contextlib.redirect_stdout(matched_output):
+        matched_result = commands.cmd_fetch_body(args)
+    matched = json.loads(matched_output.getvalue())
+    assert matched_result == 0
+    assert matched["local_match"]["matched"] is True
+    assert matched["local_match"]["matched_fields"] == ["body"]
+    assert [call[0] for call in calls] == ["Email/get", "Email/get"]
+finally:
+    os.unlink(config_path)
+PYEOF
+		_pass "JMAP filter gate is read-only and redacts non-matches"
+	else
+		_fail "JMAP filter gate is read-only and redacts non-matches" "JMAP assertions failed"
+	fi
+	return 0
+}
+
+test_jmap_filter_config_auto_detection() {
+	echo "==> JMAP collection config: legacy compatibility and invalid-config isolation"
+	_setup
+	local root="${TEST_TMPDIR}/repo"
+	local fake_bin="${TEST_TMPDIR}/bin"
+	local adapter_args="${TEST_TMPDIR}/adapter-args"
+	mkdir -p "${root}/_config" "${root}/_knowledge" "$fake_bin"
+	cat >"${fake_bin}/gopass" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+*" user") printf '%s\n' 'worker@example.test' ;;
+*) printf '%s\n' 'fixture-token' ;;
+esac
+EOF
+	cat >"${fake_bin}/python3" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >"$FAKE_JMAP_ARGS"
+EOF
+	chmod +x "${fake_bin}/gopass" "${fake_bin}/python3"
+
+	printf '%s\n' '{"rules":[]}' >"${root}/_config/email-filters.json"
+	local legacy_rc=0
+	(cd "$root" && PATH="${fake_bin}:$PATH" FAKE_JMAP_ARGS="$adapter_args" \
+		bash "$MAILBOX_HELPER" sync fastmail >/dev/null 2>&1) || legacy_rc=$?
+	local legacy_args=""
+	[[ -f "$adapter_args" ]] && legacy_args=$(<"$adapter_args")
+
+	printf '%s\n' '{"version":2,"rules":[]}' >"${root}/_config/email-filters.json"
+	rm -f "$adapter_args"
+	local v2_rc=0
+	(cd "$root" && PATH="${fake_bin}:$PATH" FAKE_JMAP_ARGS="$adapter_args" \
+		bash "$MAILBOX_HELPER" sync fastmail >/dev/null 2>&1) || v2_rc=$?
+	local v2_args=""
+	[[ -f "$adapter_args" ]] && v2_args=$(<"$adapter_args")
+
+	printf '%s\n' '{invalid-json' >"${root}/_config/email-filters.json"
+	rm -f "$adapter_args"
+	local invalid_rc=0
+	(cd "$root" && PATH="${fake_bin}:$PATH" FAKE_JMAP_ARGS="$adapter_args" \
+		bash "$MAILBOX_HELPER" sync fastmail >/dev/null 2>&1) || invalid_rc=$?
+
+	printf '%s\n' '{"fastmail/INBOX/jmap/filter/case-rule/digest":{"last_received_at":"2026-07-31T00:00:00Z"}}' \
+		>"${root}/_knowledge/.imap-state.json"
+	rm -f "${root}/_config/email-filters.json" "$adapter_args"
+	local missing_rc=0
+	(cd "$root" && PATH="${fake_bin}:$PATH" FAKE_JMAP_ARGS="$adapter_args" \
+		bash "$MAILBOX_HELPER" sync fastmail >/dev/null 2>&1) || missing_rc=$?
+
+	printf '%s\n' '{"rules":[]}' >"${root}/_config/email-filters.json"
+	local downgrade_rc=0
+	(cd "$root" && PATH="${fake_bin}:$PATH" FAKE_JMAP_ARGS="$adapter_args" \
+		bash "$MAILBOX_HELPER" sync fastmail >/dev/null 2>&1) || downgrade_rc=$?
+	local empty_explicit_rc=0
+	(cd "$root" && PATH="${fake_bin}:$PATH" FAKE_JMAP_ARGS="$adapter_args" \
+		bash "$MAILBOX_HELPER" sync fastmail --filter-config "" >/dev/null 2>&1) || empty_explicit_rc=$?
+
+	if [[ "$legacy_rc" -eq 0 && "$legacy_args" != *"--filter-config"* &&
+		"$v2_rc" -eq 0 && "$v2_args" == *"--filter-config _config/email-filters.json"* &&
+		"$invalid_rc" -ne 0 && "$missing_rc" -ne 0 && "$downgrade_rc" -ne 0 &&
+		"$empty_explicit_rc" -ne 0 && ! -f "$adapter_args" ]]; then
+		_pass "JMAP auto-detection preserves pre-migration legacy sync and fails closed after migration"
+	else
+		_fail "JMAP auto-detection preserves pre-migration legacy sync and fails closed after migration" \
+			"legacy_rc=$legacy_rc v2_rc=$v2_rc invalid_rc=$invalid_rc missing_rc=$missing_rc downgrade_rc=$downgrade_rc empty_explicit_rc=$empty_explicit_rc"
+	fi
+	_teardown
+	return 0
+}
+
+test_jmap_routing_only_config_preserves_index_sync() {
+	echo "==> JMAP collection config: routing-only rules preserve legacy index sync"
+	if python3 - "$SCRIPT_DIR/../scripts" <<'PYEOF'; then
+import contextlib
+import io
+import json
+import sys
+import tempfile
+from argparse import Namespace
+from pathlib import Path
+
+sys.path.insert(0, str(Path(sys.argv[1])))
+import email_jmap_sync as sync  # noqa: E402
+
+
+class FakeDatabase:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    config_path = Path(tmp) / "filters.json"
+    config_path.write_text(json.dumps({
+        "version": 2,
+        "rules": [{
+            "id": "route-only",
+            "collection": False,
+            "match": {"all": [{
+                "field": "subject", "operator": "phrase", "value": "route",
+            }]},
+            "actions": [],
+        }],
+    }), encoding="utf-8")
+    database = FakeDatabase()
+    full_sync_calls = []
+    sync._session_context = lambda _args: ({}, "account-1", "unused-api-endpoint")
+    sync._resolve_mailbox_id = lambda *_args: "mailbox-1"
+    sync._init_index_db = lambda: database
+    sync._full_sync = lambda context: (full_sync_calls.append(context) or (0, "legacy-state"))
+    args = Namespace(
+        mailbox="INBOX",
+        user="worker@example.test",
+        filter_config=str(config_path),
+        collection_mailbox_id="work-jmap",
+        state="",
+        inbox="",
+        account_identity=[],
+        full=True,
+        dry_run=False,
+    )
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        result = sync.cmd_index_sync(args)
+    payload = json.loads(output.getvalue())
+    assert result == 0
+    assert len(full_sync_calls) == 1
+    assert database.closed is True
+    assert payload["mode"] == "full" and payload["state"] == "legacy-state"
+PYEOF
+		_pass "routing-only JMAP config preserves legacy index sync"
+	else
+		_fail "routing-only JMAP config preserves legacy index sync" "fallback assertions failed"
+	fi
+	return 0
+}
+
+test_jmap_filtered_collection() {
+	echo "==> JMAP collection: bounded lineages, local authority, and atomic receipts"
+	if python3 - "$SCRIPT_DIR/../scripts" <<'PYEOF'; then
+import json
+import sys
+import tempfile
+from dataclasses import replace
+from pathlib import Path
+
+sys.path.insert(0, str(Path(sys.argv[1])))
+import email_jmap_collection as collection  # noqa: E402
+import email_jmap_collection_transport as transport  # noqa: E402
+
+rules = [{
+    "id": "sender-rule",
+    "collection": True,
+    "mailboxes": ["work-jmap"],
+    "folders": ["INBOX"],
+    "backfill": {"since": "2026-01-01", "limit": 2},
+    "match": {"all": [{
+        "field": "from", "operator": "exact_address", "value": "sender@example.test",
+    }]},
+}, {
+    "id": "reference-rule",
+    "collection": True,
+    "mailboxes": ["work-jmap"],
+    "folders": ["INBOX"],
+    "backfill": {"limit": 2},
+    "match": {"all": [{
+        "field": "subject", "operator": "reference", "value": "CASE-123",
+    }]},
+}]
+
+emails = {
+    "match": {
+        "id": "match",
+        "blobId": "blob-match",
+        "from": [{"email": "sender@example.test"}],
+        "to": [{"email": "worker@example.test"}],
+        "subject": "Re: CASE-123",
+        "textBody": [{"partId": "text-1"}],
+        "htmlBody": [],
+        "bodyValues": {"text-1": {"value": "Matched canonical body"}},
+        "attachments": [{"name": "contract.pdf", "blobId": "attachment-1"}],
+    },
+    "miss": {
+        "id": "miss",
+        "blobId": "blob-miss",
+        "from": [{"email": "other@example.test"}],
+        "to": [{"email": "worker@example.test"}],
+        "subject": "Newsletter",
+        "textBody": [{"partId": "text-2"}],
+        "htmlBody": [],
+        "bodyValues": {"text-2": {"value": "Unmatched private body"}},
+        "attachments": [],
+    },
+}
+safe_download = transport._download_url(
+    "https://files.example.test/{accountId}/{blobId}/{name}?type={type}",
+    "account-1",
+    emails["match"],
+)
+assert safe_download.startswith("https://files.example.test/account-1/blob-match/")
+for unsafe_download in (
+    "file:///private/{blobId}",
+    "ftp://files.example.test/{blobId}",
+    "https:///missing-authority/{blobId}",
+):
+    try:
+        transport._download_url(unsafe_download, "account-1", emails["match"])
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("unsafe JMAP download URL was accepted")
+calls = []
+query_count = 0
+
+
+def fake_request(_api_url, _user, method_calls):
+    global query_count
+    method, arguments, call_id = method_calls[0]
+    calls.append(method)
+    if method == "Email/query":
+        query_count += 1
+        return {"methodResponses": [[method, {
+            "ids": ["match", "miss"],
+            "queryState": f"query-{query_count}",
+            "total": 3,
+        }, call_id]]}
+    if method == "Email/queryChanges":
+        return {"methodResponses": [[method, {
+            "added": [],
+            "removed": [],
+            "newQueryState": arguments["sinceQueryState"] + "-next",
+            "hasMoreChanges": False,
+        }, call_id]]}
+    if method == "Email/get":
+        return {"methodResponses": [[method, {
+            "list": [emails[email_id] for email_id in arguments["ids"]],
+            "notFound": [],
+        }, call_id]]}
+    raise AssertionError(f"mutation route reached: {method}")
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    root = Path(tmp)
+    state_path = root / "state.json"
+    inbox = root / "inbox"
+    context = collection.CollectionContext(
+        session={"downloadUrl": "unused-download-template"},
+        api_url="unused-api-endpoint",
+        user="worker@example.test",
+        account_id="account-1",
+        collection_mailbox_id="work-jmap",
+        folder_name="INBOX",
+        folder_id="mailbox-1",
+        rules=rules,
+        state_path=str(state_path),
+        inbox_dir=str(inbox),
+        account_identities=("worker@example.test",),
+    )
+    downloads = []
+    transport._jmap_request = fake_request
+    transport._download_raw_email = lambda _context, email: (
+        downloads.append(email["id"]) or
+        b"From: sender@example.test\r\nSubject: CASE-123\r\n\r\nMatched canonical body"
+    )
+
+    first = collection.collect_filtered(context)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    evidence = list(inbox.glob("*.eml"))
+    receipts = list(inbox.glob("*.eml.collection.json"))
+    assert first["scanned"] == 4 and first["fetched_count"] == 1
+    assert first["matched_rules"] == {"sender-rule": 1, "reference-rule": 1}
+    assert first["has_more"] is True
+    assert first["backfill_truncated"] is True
+    assert len(state) == 2 and all(value["transport"] == "jmap" for value in state.values())
+    assert all(value["backfill_truncated"] is True for value in state.values())
+    assert len(evidence) == 1 and downloads == ["match"]
+    assert len(receipts) == 1
+    receipt = json.loads(receipts[0].read_text(encoding="utf-8"))
+    assert receipt["transport"] == "jmap" and receipt["message_key"] == "match"
+    assert [item["id"] for item in receipt["rules"]] == [
+        "reference-rule", "sender-rule"
+    ]
+    assert "sender@example.test" not in receipts[0].read_text(encoding="utf-8")
+    assert b"Matched canonical body" in evidence[0].read_bytes()
+    assert b"Unmatched private body" not in evidence[0].read_bytes()
+
+    second = collection.collect_filtered(context)
+    assert second["scanned"] == 0 and second["fetched_count"] == 0
+    assert downloads == ["match"]
+
+    changed_rules = json.loads(json.dumps(rules))
+    changed_rules[1]["match"]["all"][0]["value"] = "CASE-999"
+    changed = collection.collect_filtered(replace(context, rules=changed_rules))
+    changed_state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert changed["scanned"] == 2 and len(changed_state) == 3
+
+    evidence[0].unlink()
+    state_before_failure = state_path.read_bytes()
+
+    def fail_download(_context, _email):
+        raise RuntimeError("fixture download failure")
+
+    transport._download_raw_email = fail_download
+    try:
+        collection.collect_filtered(replace(context, force_full=True))
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("terminal download failure did not fail closed")
+    assert state_path.read_bytes() == state_before_failure
+    assert not list(inbox.glob(".jmap-stage-*"))
+    assert set(calls) <= {"Email/query", "Email/queryChanges", "Email/get"}
+PYEOF
+		_pass "JMAP collection is bounded, read-only, deduplicated, and atomic"
+	else
+		_fail "JMAP collection is bounded, read-only, deduplicated, and atomic" "JMAP collection assertions failed"
+	fi
+	return 0
+}
+
 # =============================================================================
 # Run all tests
 # =============================================================================
@@ -452,6 +1114,13 @@ test_tick_dry_run_no_state_written
 test_filter_test_dry_run_no_actions
 test_filter_test_nonexistent_rule
 test_tick_no_match_exits_zero
+test_v2_deterministic_match_semantics
+test_v2_direction_action_routing
+test_v2_rule_change_replays_actions
+test_jmap_filter_gate_read_isolation
+test_jmap_filter_config_auto_detection
+test_jmap_routing_only_config_preserves_index_sync
+test_jmap_filtered_collection
 
 echo ""
 echo "Results: ${TESTS_PASSED} passed, ${TESTS_FAILED} failed"

--- a/.agents/tests/test-email-ingest.sh
+++ b/.agents/tests/test-email-ingest.sh
@@ -163,6 +163,40 @@ _find_source_last() {
 	return 0
 }
 
+_write_collection_sidecar() {
+	local eml_path="$1"
+	local transport="$2"
+	local message_key="$3"
+	python3 - "$SCRIPT_DIR/../scripts" "$eml_path" "$transport" "$message_key" <<'PYEOF'
+import sys
+
+sys.path.insert(0, sys.argv[1])
+from email_collection_receipts import ReceiptContext, write_collection_receipt  # noqa: E402
+
+rules = [{
+    "id": "case-rule",
+    "collection": True,
+    "match": {"all": [{
+        "field": "subject", "operator": "reference", "value": "PRIVATE-123",
+    }]},
+}]
+if sys.argv[3] == "imap":
+    rules.append({
+        "id": "overlap-rule",
+        "collection": True,
+        "match": {"all": [{
+            "field": "from", "operator": "exact_address", "value": "private@example.test",
+        }]},
+    })
+write_collection_receipt(
+    sys.argv[2],
+    ReceiptContext(sys.argv[3], "work", "INBOX", sys.argv[4]),
+    rules,
+)
+PYEOF
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Section 1: Python parser tests (email_parse.py)
 # ---------------------------------------------------------------------------
@@ -346,17 +380,18 @@ echo ""
 echo "=== Section 3: Sanitisation tests ==="
 echo ""
 
-# Test 9: Sanitisation idempotency — re-ingesting should produce same sanitised result
+# Test 9: Sanitisation idempotency and canonical message deduplication
 if [[ -n "${SRC_HTML:-}" ]]; then
 	first_html=$(cat "${SOURCES}/${SRC_HTML}/body.html")
-	# Re-ingest same file to a new path (will get deduped ID)
+	# Re-ingest the same message; canonical identity must be reused.
 	bash "$HELPER" ingest "$FIXTURES/html-only.eml" --repo-path "$REPO_PATH" >/dev/null 2>&1
 	SRC_HTML2=$(_find_source_last "html")
-	if [[ -n "$SRC_HTML2" && "$SRC_HTML2" != "$SRC_HTML" ]]; then
+	if [[ -n "$SRC_HTML2" && "$SRC_HTML2" == "$SRC_HTML" ]]; then
 		second_html=$(cat "${SOURCES}/${SRC_HTML2}/body.html")
-		assert_eq "sanitisation:idempotent: same output" "$first_html" "$second_html"
+		assert_eq "sanitisation:idempotent: same canonical output" "$first_html" "$second_html"
+		_pass "ingest:duplicate: reuses canonical email source"
 	else
-		_pass "sanitisation:idempotent: dedup ID different (acceptable)"
+		_fail "ingest:duplicate: reuses canonical email source" "first=$SRC_HTML second=$SRC_HTML2"
 	fi
 else
 	_pass "sanitisation:idempotent: skipped (no html source)"
@@ -365,6 +400,45 @@ fi
 # Test 10: Verify meta.json version field
 if [[ -n "${SRC_PLAIN:-}" ]]; then
 	assert_json_field "meta:version: version=1" "${SOURCES}/${SRC_PLAIN}/meta.json" '.version' "1"
+fi
+
+# Test 11: Duplicate transports merge collection provenance into one canonical source
+if [[ -n "${SRC_PLAIN:-}" ]]; then
+	COLLECTED_IMAP="${TMP_DIR}/collected-imap.eml"
+	cp "$FIXTURES/plaintext.eml" "$COLLECTED_IMAP"
+	_write_collection_sidecar "$COLLECTED_IMAP" "imap" "uid-101"
+	imap_ingest=$(bash "$HELPER" ingest "$COLLECTED_IMAP" --repo-path "$REPO_PATH" 2>&1)
+	assert_contains "ingest:collection: pre-existing canonical reused" "$imap_ingest" "existing canonical"
+	assert_json_field "ingest:collection: first transport reference merged" \
+		"${SOURCES}/${SRC_PLAIN}/meta.json" '.collection_refs | length' "1"
+	assert_json_field "ingest:collection: overlapping rules preserved" \
+		"${SOURCES}/${SRC_PLAIN}/meta.json" '.collection_refs[0].rules | length' "2"
+
+	COLLECTED_JMAP="${TMP_DIR}/collected-jmap.eml"
+	cp "$FIXTURES/plaintext.eml" "$COLLECTED_JMAP"
+	_write_collection_sidecar "$COLLECTED_JMAP" "jmap" "email-101"
+	jmap_ingest=$(bash "$HELPER" ingest "$COLLECTED_JMAP" --repo-path "$REPO_PATH" 2>&1)
+	assert_contains "ingest:collection: second duplicate reused" "$jmap_ingest" "existing canonical"
+	assert_json_field "ingest:collection: multiple transport references merged" \
+		"${SOURCES}/${SRC_PLAIN}/meta.json" '.collection_refs | length' "2"
+	collection_refs=$(jq -c '.collection_refs' "${SOURCES}/${SRC_PLAIN}/meta.json")
+	assert_not_contains "ingest:collection: references redact filter literals" \
+		"$collection_refs" "PRIVATE-123"
+
+	MALFORMED_EML="${TMP_DIR}/malformed-receipt.eml"
+	cp "$FIXTURES/plaintext.eml" "$MALFORMED_EML"
+	cat >"${MALFORMED_EML}.collection.json" <<'EOF'
+{"version":1,"transport":"imap","mailbox_id":"work","folder":"INBOX","message_key":"uid-102","rules":[{"id":"case-rule","digest":"0000000000000000","literal":"PRIVATE-123"}]}
+EOF
+	if bash "$HELPER" ingest "$MALFORMED_EML" --repo-path "$REPO_PATH" >/dev/null 2>&1; then
+		_fail "ingest:collection: malformed receipt fails closed" "ingestion unexpectedly succeeded"
+	else
+		_pass "ingest:collection: malformed receipt fails closed"
+	fi
+	assert_json_field "ingest:collection: malformed receipt leaves canonical references unchanged" \
+		"${SOURCES}/${SRC_PLAIN}/meta.json" '.collection_refs | length' "2"
+else
+	_fail "ingest:collection: provenance fixtures" "plaintext canonical source unavailable"
 fi
 
 # ---------------------------------------------------------------------------

--- a/.agents/tests/test-email-poll.sh
+++ b/.agents/tests/test-email-poll.sh
@@ -133,6 +133,40 @@ PYEOF
 	return 0
 }
 
+create_mock_imap_filtered() {
+	local mock_dir="$1"
+	python3 - "$mock_dir" <<'PYEOF'
+import sys
+
+mock_dir = sys.argv[1]
+code = '''class IMAP4_SSL:
+    def __init__(self, host, port=993):
+        pass
+    def login(self, user, password):
+        return ("OK", [b"Logged in"])
+    def select(self, folder, readonly=False):
+        assert readonly is True
+        return ("OK", [b"2"])
+    def uid(self, command, *args):
+        if command == "SEARCH":
+            return ("OK", [b"4001 4002"])
+        if command == "FETCH":
+            assert any("BODY.PEEK[]" in str(arg) for arg in args)
+            matching = b"From: counsel@example.com\\r\\nTo: user@filtered-mb.example\\r\\nSubject: CASE-123\\r\\n\\r\\nPrivate matching content"
+            unrelated = b"From: news@unrelated.test\\r\\nTo: user@filtered-mb.example\\r\\nSubject: Newsletter\\r\\n\\r\\nPrivate unmatched content"
+            h1 = b"4001 (BODY[] {%d} UID 4001)" % len(matching)
+            h2 = b"4002 (BODY[] {%d} UID 4002)" % len(unrelated)
+            return ("OK", [(h1, matching), b")", (h2, unrelated), b")"])
+        return ("OK", [b""])
+    def logout(self):
+        return ("BYE", [b"x"])
+'''
+with open(f"{mock_dir}/imaplib.py", "w") as handle:
+    handle.write(code)
+PYEOF
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Shared config factory
 # ---------------------------------------------------------------------------
@@ -169,6 +203,79 @@ test_tick_missing_config_skips() {
 		pass "$name"
 	else
 		fail "$name" "exit=$exit_rc output=$output"
+	fi
+	return 0
+}
+
+test_filter_config_validation_fails_closed() {
+	local name="tick: collection config fails closed after filtered migration"
+	local tmpdir="${TEST_TMPDIR}/filter-config-validation"
+	mkdir -p "${tmpdir}/mock" "${tmpdir}/_config" "${tmpdir}/_knowledge/inbox"
+	create_mock_imap_happy "${tmpdir}/mock" "9001"
+	make_mailbox_config "${tmpdir}/_config/mailboxes.json" "validation-mb" "TEST_EMAIL_PASSWORD"
+	printf '%s\n' '{invalid-json' >"${tmpdir}/_config/email-filters.json"
+
+	local invalid_output invalid_rc=0
+	invalid_output=$(cd "$tmpdir" && TEST_EMAIL_PASSWORD="testpass" \
+		PYTHONPATH="${tmpdir}/mock" bash "$POLL_HELPER" tick 2>&1) || invalid_rc=$?
+	local invalid_count
+	invalid_count=$(find "${tmpdir}/_knowledge/inbox" -name "*.eml" 2>/dev/null | wc -l | tr -d ' ')
+
+	printf '%s\n' '{"rules":[]}' >"${tmpdir}/_config/email-filters.json"
+	local legacy_rc=0
+	(cd "$tmpdir" && TEST_EMAIL_PASSWORD="testpass" \
+		PYTHONPATH="${tmpdir}/mock" bash "$POLL_HELPER" tick >/dev/null 2>&1) || legacy_rc=$?
+	local legacy_count
+	legacy_count=$(find "${tmpdir}/_knowledge/inbox" -name "*.eml" 2>/dev/null | wc -l | tr -d ' ')
+
+	printf '%s\n' '{"validation-mb/INBOX/imap/filter/case-rule/digest":{"last_uid_seen":1}}' >"${tmpdir}/_knowledge/.imap-state.json"
+	rm -f "${tmpdir}/_knowledge/inbox/"*.eml "${tmpdir}/_config/email-filters.json"
+	local missing_output missing_rc=0
+	missing_output=$(cd "$tmpdir" && TEST_EMAIL_PASSWORD="testpass" \
+		PYTHONPATH="${tmpdir}/mock" bash "$POLL_HELPER" tick 2>&1) || missing_rc=$?
+
+	printf '%s\n' '{"rules":[]}' >"${tmpdir}/_config/email-filters.json"
+	local downgrade_rc=0
+	(cd "$tmpdir" && TEST_EMAIL_PASSWORD="testpass" \
+		PYTHONPATH="${tmpdir}/mock" bash "$POLL_HELPER" tick >/dev/null 2>&1) || downgrade_rc=$?
+	local post_migration_count
+	post_migration_count=$(find "${tmpdir}/_knowledge/inbox" -name "*.eml" 2>/dev/null | wc -l | tr -d ' ')
+
+	if [[ "$invalid_rc" -ne 0 && "$invalid_count" -eq 0 && "$invalid_output" == *"refusing unfiltered"* &&
+		"$legacy_rc" -eq 0 && "$legacy_count" -eq 1 && "$missing_rc" -ne 0 &&
+		"$missing_output" == *"refusing unfiltered"* && "$downgrade_rc" -ne 0 && "$post_migration_count" -eq 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "invalid_rc=$invalid_rc invalid_count=$invalid_count legacy_rc=$legacy_rc legacy_count=$legacy_count missing_rc=$missing_rc downgrade_rc=$downgrade_rc post_migration_count=$post_migration_count"
+	fi
+	return 0
+}
+
+test_filtered_helper_surfaces_poll_failure() {
+	local name="filtered tick: provider failure is nonzero and preserves its checkpoint"
+	local tmpdir="${TEST_TMPDIR}/filtered-provider-failure"
+	mkdir -p "${tmpdir}/mock" "${tmpdir}/_config" "${tmpdir}/_knowledge/inbox"
+	create_mock_imap_connfail "${tmpdir}/mock"
+	make_mailbox_config "${tmpdir}/_config/mailboxes.json" "failure-mb" "TEST_EMAIL_PASSWORD"
+	cat >"${tmpdir}/_config/email-filters.json" <<'EOF'
+{"version":2,"rules":[{"id":"failure-rule","mailboxes":["failure-mb"],"match":{"all":[{"field":"subject","operator":"phrase","value":"case"}]}}]}
+EOF
+	printf '%s\n' '{"failure-mb/INBOX/imap/filter/failure-rule/prior":{"last_uid_seen":77}}' \
+		>"${tmpdir}/_knowledge/.imap-state.json"
+
+	local exit_rc=0
+	(cd "$tmpdir" && TEST_EMAIL_PASSWORD="testpass" \
+		PYTHONPATH="${tmpdir}/mock" bash "$POLL_HELPER" tick >/dev/null 2>&1) || exit_rc=$?
+	local prior_cursor
+	prior_cursor=$(jq -r '.["failure-mb/INBOX/imap/filter/failure-rule/prior"].last_uid_seen' \
+		"${tmpdir}/_knowledge/.imap-state.json")
+	local eml_count
+	eml_count=$(find "${tmpdir}/_knowledge/inbox" -name "*.eml" 2>/dev/null | wc -l | tr -d ' ')
+
+	if [[ "$exit_rc" -ne 0 && "$prior_cursor" -eq 77 && "$eml_count" -eq 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "exit=$exit_rc prior_cursor=$prior_cursor eml_count=$eml_count"
 	fi
 	return 0
 }
@@ -430,6 +537,221 @@ print(ids[0] if ids else '')
 	return 0
 }
 
+test_filtered_collection() {
+	local name="filtered tick: persists matches only with content-free lineage state"
+	local tmpdir="${TEST_TMPDIR}/filtered"
+	mkdir -p "${tmpdir}/mock" "${tmpdir}/inbox"
+	create_mock_imap_filtered "${tmpdir}/mock"
+	make_mailbox_config "${tmpdir}/mailboxes.json" "filtered-mb" "TEST_EMAIL_PASSWORD"
+	jq '.mailboxes[0].folders = ["INBOX", "Archive"]' "${tmpdir}/mailboxes.json" \
+		>"${tmpdir}/mailboxes.next.json"
+	mv "${tmpdir}/mailboxes.next.json" "${tmpdir}/mailboxes.json"
+	cat >"${tmpdir}/filters.json" <<'EOF'
+{
+  "version": 2,
+  "rules": [
+    {
+      "id": "case-rule",
+      "mailboxes": ["filtered-mb"],
+      "folders": ["INBOX"],
+      "backfill": {"limit": 25},
+      "match": {"all": [
+        {"field": "from", "operator": "exact_domain", "value": "example.com"},
+        {"field": "direction", "operator": "equals", "value": "received"},
+        {"field": "subject", "operator": "reference", "value": "CASE-123"}
+      ]}
+    },
+    {
+      "id": "overlap-rule",
+      "mailboxes": ["filtered-mb"],
+      "folders": ["INBOX"],
+      "backfill": {"limit": 25},
+      "match": {"all": [
+        {"field": "from", "operator": "exact_address", "value": "counsel@example.com"},
+        {"field": "subject", "operator": "reference", "value": "CASE-123"}
+      ]}
+    }
+  ]
+}
+EOF
+
+	local exit_rc=0
+	TEST_EMAIL_PASSWORD="testpass" PYTHONPATH="${tmpdir}/mock" \
+		python3 "$POLL_PY" tick \
+		--config "${tmpdir}/mailboxes.json" \
+		--state "${tmpdir}/state.json" \
+		--inbox "${tmpdir}/inbox" \
+		--filters "${tmpdir}/filters.json" >"${tmpdir}/result.json" 2>&1 || exit_rc=$?
+
+	local eml_count state_safe=0 result_safe=0 receipt_safe=0 receipt_path=""
+	eml_count=$(find "${tmpdir}/inbox" -name "*.eml" 2>/dev/null | wc -l | tr -d ' ')
+	local candidate
+	for candidate in "${tmpdir}/inbox/"*.eml.collection.json; do
+		[[ -f "$candidate" ]] && receipt_path="$candidate"
+	done
+	if [[ -n "$receipt_path" ]] &&
+		jq -e '.transport == "imap" and .mailbox_id == "filtered-mb" and .folder == "INBOX" and (.rules | length) == 2' "$receipt_path" >/dev/null &&
+		! grep -q 'example.com\|CASE-123\|Private' "$receipt_path"; then
+		receipt_safe=1
+	fi
+	if [[ -f "${tmpdir}/state.json" ]] && grep -q '/imap/filter/case-rule/' "${tmpdir}/state.json" &&
+		grep -q '/imap/filter/overlap-rule/' "${tmpdir}/state.json" &&
+		! grep -q 'example.com\|CASE-123\|Private' "${tmpdir}/state.json"; then
+		state_safe=1
+	fi
+	if [[ -f "${tmpdir}/result.json" ]] && grep -q '"scanned": 4' "${tmpdir}/result.json" &&
+		grep -q '"fetched_count": 1' "${tmpdir}/result.json"; then
+		result_safe=1
+	fi
+
+	jq '.rules[1].match.all[1].value = "CASE-999"' "${tmpdir}/filters.json" >"${tmpdir}/filters.next.json"
+	mv "${tmpdir}/filters.next.json" "${tmpdir}/filters.json"
+	TEST_EMAIL_PASSWORD="testpass" PYTHONPATH="${tmpdir}/mock" \
+		python3 "$POLL_PY" tick \
+		--config "${tmpdir}/mailboxes.json" \
+		--state "${tmpdir}/state.json" \
+		--inbox "${tmpdir}/inbox" \
+		--filters "${tmpdir}/filters.json" >"${tmpdir}/result-second.json" 2>&1 || exit_rc=$?
+	jq '(.rules[].enabled) = false' "${tmpdir}/filters.json" >"${tmpdir}/filters.disabled.json"
+	mv "${tmpdir}/filters.disabled.json" "${tmpdir}/filters.json"
+	TEST_EMAIL_PASSWORD="testpass" PYTHONPATH="${tmpdir}/mock" \
+		python3 "$POLL_PY" tick \
+		--config "${tmpdir}/mailboxes.json" \
+		--state "${tmpdir}/state.json" \
+		--inbox "${tmpdir}/inbox" \
+		--filters "${tmpdir}/filters.json" >"${tmpdir}/result-disabled.json" 2>&1 || exit_rc=$?
+	local lineage_count
+	lineage_count=$(jq '[keys[] | select(contains("/filter/"))] | length' "${tmpdir}/state.json")
+	local final_eml_count
+	final_eml_count=$(find "${tmpdir}/inbox" -name "*.eml" 2>/dev/null | wc -l | tr -d ' ')
+	if [[ "$exit_rc" -eq 0 && "$eml_count" -eq 1 && "$state_safe" -eq 1 && "$result_safe" -eq 1 && "$receipt_safe" -eq 1 ]] &&
+		[[ "$lineage_count" -eq 3 ]] && grep -q '"fetched_count": 0' "${tmpdir}/result-second.json" &&
+		grep -q '"fetched_count": 0' "${tmpdir}/result-disabled.json" && [[ "$final_eml_count" -eq 1 ]] &&
+		grep -q 'Private matching content' "${tmpdir}/inbox/"*.eml &&
+		! grep -q 'Private unmatched content' "${tmpdir}/inbox/"*.eml &&
+		[[ ! -e "${tmpdir}/inbox/email-filtered-mb-Archive-4001.eml" ]]; then
+		pass "$name"
+	else
+		fail "$name" "exit=$exit_rc eml=$eml_count state_safe=$state_safe result_safe=$result_safe receipt_safe=$receipt_safe lineages=$lineage_count"
+	fi
+	return 0
+}
+
+test_per_rule_candidate_windows() {
+	local name="filtered tick: preserves independent rule limits, dates, and cursors"
+	if python3 - "$SCRIPTS_DIR" <<'PYEOF'; then
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(sys.argv[1])))
+from email_poll import (  # noqa: E402
+    BackfillConfig,
+    BackfillContext,
+    RuleScanContext,
+    _backfill_messages,
+    _backfill_state_key,
+    _filter_state_key,
+    _rule_candidate_uids,
+    _scan_poll_message,
+)
+
+
+class FakeConnection:
+    def __init__(self):
+        self.criteria = []
+
+    def select(self, _folder, readonly=False):
+        assert readonly is True
+        return "OK", [b"1000"]
+
+    def uid(self, command, *_args):
+        assert command == "SEARCH"
+        criteria = str(_args[-1])
+        self.criteria.append(criteria)
+        start = 101 if "UID 101:*" in criteria else 1
+        return "OK", [" ".join(str(uid) for uid in range(start, 1001)).encode()]
+
+
+conn = FakeConnection()
+entries = {
+    "existing": ({"id": "existing", "backfill": {"limit": 500}}, 100),
+    "new": ({"id": "new", "backfill": {"limit": 25, "since": "2026-07-01"}}, 0),
+}
+selected, evidence = _rule_candidate_uids(conn, "INBOX", entries)
+assert selected["existing"] == set(range(101, 601))
+assert selected["new"] == set(range(976, 1001))
+assert evidence["existing"] == {
+    "candidate_total": 900,
+    "has_more": True,
+    "backfill_truncated": False,
+    "mode": "incremental",
+}
+assert evidence["new"] == {
+    "candidate_total": 1000,
+    "has_more": True,
+    "backfill_truncated": True,
+    "mode": "initial",
+}
+assert any("SINCE 01-Jul-2026" in item for item in conn.criteria)
+rule = entries["new"][0]
+assert _backfill_state_key("mb", "INBOX", rule, "2026-07-01") != _backfill_state_key(
+    "mb", "INBOX", rule, "2026-01-01"
+)
+backfill_context = BackfillContext(
+    mailbox_id="mb",
+    folder="INBOX",
+    state={},
+    config=BackfillConfig(inbox_dir="unused", since_date="2026-01-01"),
+    active_rules=[rule],
+    account_identities=(),
+    filtering_enabled=True,
+)
+with patch("email_poll._uid_fetch_selected", return_value=[]):
+    assert _backfill_messages(conn, backfill_context) == []
+backfill_key = _backfill_state_key("mb", "INBOX", rule, "2026-07-01")
+assert backfill_context.candidate_uids[backfill_key] == set(range(976, 1001))
+assert backfill_context.candidate_evidence[backfill_key]["candidate_total"] == 1000
+
+coverage_rule = {"id": "coverage", "match": {"all": [
+    {"field": "bcc", "operator": "exact_address", "value": "hidden@example.test"}
+]}}
+coverage_key = _filter_state_key("mb", "INBOX", coverage_rule)
+assert "/imap/filter/" in coverage_key
+scan_context = RuleScanContext(
+    rule_keys={coverage_key: coverage_rule},
+    rule_cursors={coverage_key: 0},
+    pending_states={coverage_key: {
+        "last_uid_seen": 0,
+        "scanned": 1,
+        "matched": 0,
+        "coverage_gaps": ["body"],
+    }},
+    account_identities=(),
+    filtering_enabled=True,
+    candidate_uids={coverage_key: {1}},
+)
+folder_result = {
+    "scanned": 0,
+    "matched_rules": {},
+    "coverage_gaps": [],
+    "last_polled_at": "2026-07-31T00:00:00Z",
+}
+assert not _scan_poll_message(
+    1,
+    b"From: sender@example.test\r\nSubject: no bcc\r\n\r\nbody",
+    scan_context,
+    folder_result,
+)
+assert scan_context.pending_states[coverage_key]["coverage_gaps"] == ["bcc", "body"]
+PYEOF
+		pass "$name"
+	else
+		fail "$name" "candidate planning assertions failed"
+	fi
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Test: shellcheck
 # ---------------------------------------------------------------------------
@@ -455,6 +777,8 @@ main() {
 
 	test_python_syntax
 	test_tick_missing_config_skips
+	test_filter_config_validation_fails_closed
+	test_filtered_helper_surfaces_poll_failure
 	test_tick_happy_path
 	test_missing_credentials
 	test_connection_failure
@@ -462,6 +786,8 @@ main() {
 	test_backfill_date_filter
 	test_dry_run
 	test_list_command
+	test_filtered_collection
+	test_per_rule_candidate_windows
 	test_shellcheck
 
 	teardown


### PR DESCRIPTION
## Summary

- Add transport-neutral, deterministic version 2 email matching for IMAP and JMAP candidates.
- Persist only locally matched messages and retain independent bounded checkpoints for each rule lineage.
- Add canonical, content-free collection receipts so deduplicated sources preserve exact rule provenance.
- Route post-ingest actions from verified collection provenance without re-evaluating fields unavailable in canonical metadata.
- Restrict JMAP raw-message downloads to validated HTTP(S) URLs with an explicit authority.

## Privacy and Failure Semantics

- Server-side queries only bound candidate reads; the local matcher remains authoritative before persistence.
- Invalid rulesets, malformed MIME, provider failures, and missing or downgraded configuration after filtered migration fail closed.
- Raw messages and checkpoint state are committed only after successful matching and staging; unmatched message content is not written.
- Receipts contain transport identity plus rule ID/digest, not private rule literals or message content.
- JMAP session responses cannot select local-file, FTP, custom-scheme, or authority-less download handlers.
- Legacy pre-migration behavior remains compatible, including routing-only JMAP index sync.

## Runtime Testing

- **Risk:** high
- **Testing level:** runtime-verified
- `python3 -m compileall -q .agents/scripts`
- `bash .agents/tests/test-email-filter.sh` — 23 passed
- `bash .agents/tests/test-email-poll.sh` — 14 passed
- `bash .agents/tests/test-email-ingest.sh` — 58 passed
- `bash .agents/tests/test-email-thread.sh` — 17 passed

## Quality and Review

- `.agents/scripts/linters-local.sh` — passed
- Qlty regression gate at `041bf43f5`: 47 base smells, 47 head smells, delta 0
- Qlty new-file gate: seven new source files scanned, zero smells
- Closeout evidence bundle: `625fa2f3524294ed52134caf0c7c5bb419d66dc62d9c34a067fe4db128449d04`
- Closeout review found and fixed stale filtered-backfill evidence plumbing; the regression now exercises the filtered backfill path directly.
- CodeFactor identified an unsafe-scheme boundary at the JMAP download call; URL validation and HTTP(S)/invalid-scheme regressions now close B310 explicitly.

## Key Decisions

- Use strict local semantics for exact addresses/domains, Unicode-normalized text, keyword boundaries, direction, custom headers, and missing-field coverage.
- Keep rule checkpoints isolated by transport, mailbox, folder, rule ID, digest, and backfill date.
- Preserve late collection provenance across canonical deduplication so newly eligible routing actions replay safely.
- Record bounded candidate totals, continuation state, and initial-backfill truncation without exposing mailbox content.

Resolves #28781
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.200 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 3h and 2,957,572 tokens on this with the user in an interactive session.