### PR TITLE
GH#28911: Adopt externally merged PR cleanup receipts

### DIFF
--- a/.agents/scripts/full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/full-loop-cleanup-receipt.sh
@@ -145,6 +145,39 @@ _full_loop_receipt_lock_release() {
 	return 0
 }
 
+_full_loop_cleanup_deferred_matches() {
+	local receipt_path="$1"
+	local repo="$2"
+	local pr_number="$3"
+	local worktree="$4"
+	local branch="$5"
+	local owner_pid="$6"
+	local owner_identity="$7"
+	local owner_session="$8"
+	local release_status="$9"
+	local executor_completion_state="${10}"
+
+	jq -e \
+		--arg repo "$repo" --argjson pr_number "$pr_number" \
+		--arg worktree "$worktree" --arg branch "$branch" \
+		--argjson owner_pid "$owner_pid" --arg owner_identity "$owner_identity" \
+		--arg owner_session "$owner_session" --arg release_status "$release_status" \
+		--arg executor_completion_state "$executor_completion_state" \
+		--arg cleanup_deferred "$_FULL_LOOP_CLEANUP_DEFERRED" '
+		.schema_version == 1
+		and .repository == $repo and .pr_number == $pr_number
+		and .worktree == $worktree and .branch == $branch
+		and .executor_completion_state == $executor_completion_state
+		and .resource_cleanup_state == $cleanup_deferred
+		and .release_status == $release_status
+		and .owner.pid == $owner_pid
+		and .owner.process_identity == $owner_identity
+		and .owner.session == $owner_session
+		and .cleanup_lease == {state:"pending",pid:null,acquired_at:null}
+	' "$receipt_path" >/dev/null 2>&1
+	return $?
+}
+
 full_loop_write_cleanup_deferred() {
 	local repo="$1"
 	local pr_number="$2"
@@ -157,14 +190,36 @@ full_loop_write_cleanup_deferred() {
 	local receipt_path=""
 	local owner_identity=""
 	local now=""
+	local temp_path=""
 
 	[[ -n "$worktree" && -n "$branch" && "$owner_pid" =~ ^[0-9]+$ ]] || return 1
 	[[ "$executor_completion_state" == "FINALIZATION_PENDING" || "$executor_completion_state" == "$_FULL_LOOP_EXECUTOR_COMPLETE" ]] || return 1
 	command -v jq >/dev/null 2>&1 || return 1
 	receipt_path=$(_full_loop_cleanup_receipt_path "$repo" "$pr_number") || return 1
-	owner_identity=$(_full_loop_process_identity "$owner_pid") || return 1
-	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
-	mkdir -p "${receipt_path%/*}" || return 1
+	_full_loop_receipt_lock_acquire || return 1
+	kill -0 "$owner_pid" 2>/dev/null || {
+		_full_loop_receipt_lock_release
+		return 1
+	}
+	owner_identity=$(_full_loop_process_identity "$owner_pid") || {
+		_full_loop_receipt_lock_release
+		return 1
+	}
+	if [[ -f "$receipt_path" ]]; then
+		if _full_loop_cleanup_deferred_matches "$receipt_path" "$repo" "$pr_number" "$worktree" "$branch" \
+			"$owner_pid" "$owner_identity" "$owner_session" "$release_status" "$executor_completion_state"; then
+			_full_loop_receipt_lock_release
+			printf '%s\n' "$receipt_path"
+			return 0
+		fi
+		_full_loop_receipt_lock_release
+		return 1
+	fi
+	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || {
+		_full_loop_receipt_lock_release
+		return 1
+	}
+	temp_path="${receipt_path}.tmp.$$"
 	jq -cn \
 		--arg repo "$repo" --argjson pr_number "$pr_number" \
 		--arg worktree "$worktree" --arg branch "$branch" \
@@ -176,8 +231,16 @@ full_loop_write_cleanup_deferred() {
 		  executor_completion_state:$executor_completion_state,resource_cleanup_state:$state,release_status:$release_status,
 		  owner:{pid:$owner_pid,process_identity:$owner_identity,session:$owner_session},
 		  cleanup_lease:{state:"pending",pid:null,acquired_at:null},created_at:$now,updated_at:$now,cleaned_at:null}' \
-		>"${receipt_path}.tmp.$$" || return 1
-	mv "${receipt_path}.tmp.$$" "$receipt_path" || return 1
+		>"$temp_path" || {
+		_full_loop_receipt_lock_release
+		return 1
+	}
+	mv "$temp_path" "$receipt_path" || {
+		rm -f "$temp_path"
+		_full_loop_receipt_lock_release
+		return 1
+	}
+	_full_loop_receipt_lock_release
 	printf '%s\n' "$receipt_path"
 	return 0
 }

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -1187,6 +1187,41 @@ _merge_fresh_worktree_cleanup_plan() {
 	return 0
 }
 
+_merge_fresh_adopted_worktree_cleanup_plan() {
+	local pr_number="$1"
+	local repo="$2"
+	local pr_json=""
+	local pr_head_ref=""
+	local pr_head_oid=""
+	local pr_head_repo=""
+	local cleanup_plan=""
+	local worktree_path=""
+	local branch_name=""
+	local current_repo=""
+
+	pr_json=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh pr view "$pr_number" --repo "$repo" \
+		--json state,mergedAt,mergeCommit,headRefName,headRefOid,headRepository,isCrossRepository 2>/dev/null) || return 1
+	printf '%s' "$pr_json" | jq -e --arg repo "$repo" '
+		.state == "MERGED"
+		and (.mergedAt | strings | length > 0)
+		and (.mergeCommit.oid | strings | length > 0)
+		and (.headRefName | strings | length > 0)
+		and (.headRefOid | strings | length > 0)
+		and .headRepository.nameWithOwner == $repo
+		and (.isCrossRepository == true or .isCrossRepository == false)
+	' >/dev/null 2>&1 || return 1
+	IFS=$'\t' read -r pr_head_ref pr_head_oid pr_head_repo < <(
+		printf '%s' "$pr_json" | jq -r '[.headRefName, .headRefOid, .headRepository.nameWithOwner] | @tsv'
+	)
+	cleanup_plan=$(_merge_current_worktree_cleanup_plan "$pr_head_ref" "$pr_head_oid" "$pr_head_repo" "$repo") || return 1
+	IFS=$'\t' read -r worktree_path branch_name _ <<<"$cleanup_plan"
+	[[ "$branch_name" == "$pr_head_ref" ]] || return 1
+	current_repo=$(_merge_current_github_repo_identity "$worktree_path" 2>/dev/null || true)
+	[[ -n "$current_repo" && "$current_repo" == "$repo" ]] || return 1
+	printf '%s\n' "$cleanup_plan"
+	return 0
+}
+
 _merge_default_branch_for_cleanup() {
 	local canonical_dir="$1"
 	local default_ref=""
@@ -1300,6 +1335,8 @@ _merge_record_deferred_cleanup_owner() {
 	local pr_number="$1"
 	local repo="$2"
 	local cleanup_plan="$3"
+	local release_status="${4:-pending}"
+	local executor_completion_state="${5:-FINALIZATION_PENDING}"
 	local worktree_path="" branch_name="" canonical_dir="" delete_remote_branch=""
 	IFS=$'\t' read -r worktree_path branch_name canonical_dir delete_remote_branch <<<"$cleanup_plan"
 	: "$canonical_dir" "$delete_remote_branch"
@@ -1313,20 +1350,21 @@ _merge_record_deferred_cleanup_owner() {
 	[[ "$owner_pid" =~ ^[0-9]+$ ]] || owner_pid="$PPID"
 	[[ "$owner_pid" =~ ^[0-9]+$ ]] || return 1
 
-	local marker_dir="${worktree_path}/.agents"
-	local marker_path="${marker_dir}/.full-loop-cleanup-deferred"
-	mkdir -p "$marker_dir" || return 1
-	# Keep the legacy marker during rollout so an older deployed cleanup
-	# supervisor still preserves the live owner. The external receipt below is
-	# the durable source of lifecycle truth and survives worktree removal.
-	printf '%s\n' "$owner_pid" >"${marker_path}.tmp.$$" || return 1
-	mv "${marker_path}.tmp.$$" "$marker_path" || return 1
 	local owner_session="${AIDEVOPS_SESSION_ID:-${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-full-loop-merge}}}"
 	if ! declare -F full_loop_write_cleanup_deferred >/dev/null 2>&1; then
 		return 1
 	fi
 	full_loop_write_cleanup_deferred "$repo" "$pr_number" "$worktree_path" "$branch_name" \
-		"$owner_pid" "$owner_session" "pending" "FINALIZATION_PENDING" >/dev/null || return 1
+		"$owner_pid" "$owner_session" "$release_status" "$executor_completion_state" >/dev/null || return 1
+
+	local marker_dir="${worktree_path}/.agents"
+	local marker_path="${marker_dir}/.full-loop-cleanup-deferred"
+	mkdir -p "$marker_dir" || return 1
+	# Keep the legacy marker during rollout so an older deployed cleanup
+	# supervisor still preserves the live owner. The external receipt above is
+	# the durable source of lifecycle truth and survives worktree removal.
+	printf '%s\n' "$owner_pid" >"${marker_path}.tmp.$$" || return 1
+	mv "${marker_path}.tmp.$$" "$marker_path" || return 1
 
 	if declare -F claim_worktree_ownership >/dev/null 2>&1; then
 		claim_worktree_ownership "$worktree_path" "$branch_name" \
@@ -1334,6 +1372,41 @@ _merge_record_deferred_cleanup_owner() {
 			--session "${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-full-loop-merge}}" \
 			--task "post-merge-cleanup" >/dev/null 2>&1 || true
 	fi
+	return 0
+}
+
+cmd_adopt_merged_receipt() {
+	local pr_number="${1:-}"
+	local repo=""
+	local cleanup_plan=""
+	local release_status=""
+
+	if [[ $# -lt 1 || $# -gt 2 || ! "$pr_number" =~ ^[0-9]+$ ]]; then
+		print_error "Usage: full-loop-helper.sh adopt-merged-receipt <PR> [REPO]"
+		return 1
+	fi
+	repo=$(_merge_resolve_repo "${2:-}") || {
+		print_error "Adoption blocked: repository identity is unavailable"
+		return 1
+	}
+	cleanup_plan=$(_merge_fresh_adopted_worktree_cleanup_plan "$pr_number" "$repo") || {
+		print_error "Adoption blocked: merged PR head does not match this registered linked worktree and repository"
+		return 1
+	}
+	if ! declare -F _full_loop_terminal_release_status >/dev/null 2>&1; then
+		print_error "Adoption blocked: terminal release verifier is unavailable"
+		return 1
+	fi
+	release_status=$(_full_loop_terminal_release_status "$repo" "$pr_number") || {
+		print_error "Adoption blocked: terminal release evidence is missing or invalid"
+		return 1
+	}
+	_merge_record_deferred_cleanup_owner "$pr_number" "$repo" "$cleanup_plan" \
+		"$release_status" "FINALIZATION_PENDING" || {
+		print_error "Adoption blocked: cleanup receipt conflicts with existing owner, lease, or lifecycle evidence"
+		return 1
+	}
+	print_success "Adopted merged PR #${pr_number} into deferred cleanup (release:${release_status})"
 	return 0
 }
 

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -245,6 +245,8 @@ Commands:
                                  gh CLI level; if both are given, --admin wins and
                                   --auto is dropped (GH#19310).
   record-no-release <PR> [REPO]  Verify merged evidence and record release:not-requested.
+  adopt-merged-receipt <PR> [REPO]
+                                 Adopt an externally merged exact-head worktree into cleanup.
   finalize-receipt <PR> [REPO]   Finalize a direct-merge cleanup receipt without local state.
   migrate-repository-receipt <PR> <OLD_REPO> <NEW_REPO>
                                  Migrate cleanup and release identity after a repo rename.
@@ -282,6 +284,7 @@ main() {
 	wait-checks) cmd_wait_checks "$@" ;;
 	merge) cmd_merge "$@" ;;
 	record-no-release) cmd_record_no_release "$@" ;;
+	adopt-merged-receipt) cmd_adopt_merged_receipt "$@" ;;
 	finalize-receipt) cmd_finalize_receipt "$@" ;;
 	migrate-repository-receipt) cmd_migrate_repository_receipt "$@" ;;
 	complete) cmd_complete "$@" ;;

--- a/.agents/scripts/tests/test-full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/tests/test-full-loop-cleanup-receipt.sh
@@ -47,6 +47,13 @@ jq -e --argjson owner_pid "$OWNER_PID" '
 full_loop_cleanup_owner_alive "$receipt_one"
 printf 'PASS deferred receipt persists external owner identity and pending lease\n'
 
+cp "$receipt_one" "${TEST_ROOT}/receipt-idempotent.json"
+replayed_receipt=$(full_loop_write_cleanup_deferred example/repo 101 "${TEST_ROOT}/worktree-one" feature/one \
+	"$OWNER_PID" session-one not-requested)
+[[ "$replayed_receipt" == "$receipt_one" ]]
+cmp -s "$receipt_one" "${TEST_ROOT}/receipt-idempotent.json"
+printf 'PASS identical deferred receipt replay is idempotent\n'
+
 _WTAR_SKIPPED="skipped"
 _WTAR_WH_CALLER="test"
 _WT_CLEAN_MODE_SKIPPED="skipped"
@@ -70,6 +77,16 @@ _clean_deferred_parent_alive "${TEST_ROOT}/worktree-one" || deferred_state=$?
 [[ "$deferred_state" -eq 2 ]]
 printf 'PASS guarded cleanup treats PID reuse as an expired owner generation\n'
 
+cp "$receipt_one" "${TEST_ROOT}/receipt-conflict.json"
+if full_loop_write_cleanup_deferred example/repo 101 "${TEST_ROOT}/worktree-one" feature/one \
+	"$OWNER_PID" session-one not-requested >/dev/null; then
+	printf 'FAIL conflicting owner generation was overwritten by receipt replay\n'
+	exit 1
+fi
+cmp -s "$receipt_one" "${TEST_ROOT}/receipt-conflict.json"
+printf 'PASS conflicting owner generation fails closed without mutation\n'
+
+rm -f "$receipt_one"
 receipt_one=$(full_loop_write_cleanup_deferred example/repo 101 "${TEST_ROOT}/worktree-one" feature/one \
 	"$OWNER_PID" session-one not-requested)
 export OPENCODE_PID="$OWNER_PID"
@@ -111,6 +128,14 @@ printf 'PASS reused worktree paths select the newest lifecycle receipt\n'
 receipt_two=$(full_loop_write_cleanup_deferred example/repo 102 "${TEST_ROOT}/worktree-two" feature/two \
 	"$OWNER_PID" session-two not-requested)
 full_loop_transition_cleanup_receipt "$receipt_two" "$_FULL_LOOP_CLEANUP_LEASED" "$$"
+cp "$receipt_two" "${TEST_ROOT}/receipt-leased.json"
+if full_loop_write_cleanup_deferred example/repo 102 "${TEST_ROOT}/worktree-two" feature/two \
+	"$OWNER_PID" session-two not-requested >/dev/null; then
+	printf 'FAIL leased receipt was overwritten by receipt replay\n'
+	exit 1
+fi
+cmp -s "$receipt_two" "${TEST_ROOT}/receipt-leased.json"
+printf 'PASS leased receipt rejects replay without mutation\n'
 printf '[2026-07-21T00:00:01Z] [test] worktree-removed: %s — branch-merged — mode=permanent\n' \
 	"${TEST_ROOT}/worktree-two" >>"$AIDEVOPS_CLEANUP_LOG"
 rm -rf "${TEST_ROOT}/worktree-two"

--- a/.agents/scripts/tests/test-full-loop-completion-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-completion-evidence.sh
@@ -14,6 +14,15 @@ cleanup_receipt_dir="${ROOT}/cleanup-receipts"
 
 cat >"${ROOT}/bin/gh" <<'STUB'
 #!/usr/bin/env bash
+if [[ "$*" == *"state,mergedAt,mergeCommit,headRefName,headRefOid,headRepository,isCrossRepository"* ]]; then
+	jq -cn \
+		--arg head_ref "${COMPLETION_PR_HEAD_REF:-}" \
+		--arg head_oid "${COMPLETION_PR_HEAD_OID:-}" \
+		--arg head_repo "${COMPLETION_PR_HEAD_REPO:-}" \
+		'{state:"MERGED",mergedAt:"2026-07-11T00:00:00Z",mergeCommit:{oid:"merge123"},
+		  headRefName:$head_ref,headRefOid:$head_oid,headRepository:{nameWithOwner:$head_repo},isCrossRepository:false}'
+	exit 0
+fi
 if [[ "$*" == *"headRefName,headRefOid,headRepository,isCrossRepository"* ]]; then
 	jq -cn \
 		--arg head_ref "${COMPLETION_PR_HEAD_REF:-}" \
@@ -190,7 +199,7 @@ printf 'PASS superseded source receipts finalize truthfully and cannot be downgr
 alias_canonical="${ROOT}/alias-canonical"
 alias_worktree="${ROOT}/alias-worktree"
 alias_branch="bugfix/repair-pr-head"
-alias_pr_head="feature/original-pr-head"
+alias_pr_head="$alias_branch"
 alias_repo="marcusquinn/aidevops"
 fixture_git="${AIDEVOPS_TEST_GIT_BIN:-$(command -p -v git)}"
 mkdir -p "$alias_canonical"
@@ -205,35 +214,46 @@ printf 'alias fixture\n' >"${alias_canonical}/README.md"
 alias_head=$("$fixture_git" -C "$alias_worktree" rev-parse HEAD)
 "$fixture_git" -C "$alias_worktree" remote add pr-head "https://github.com/${alias_repo}.git"
 
-alias_receipt_runner="${ROOT}/alias-receipt-runner.sh"
-cat >"$alias_receipt_runner" <<RUNNER
+adopt_receipt_runner="${ROOT}/adopt-receipt-runner.sh"
+cat >"$adopt_receipt_runner" <<RUNNER
 #!/usr/bin/env bash
 set -euo pipefail
 SCRIPT_DIR='${SCRIPTS_DIR}'
 source '${SCRIPTS_DIR}/shared-constants.sh'
+source '${SCRIPTS_DIR}/full-loop-helper-state.sh'
 source '${SCRIPTS_DIR}/full-loop-helper-merge.sh'
 cd "\$1"
-cleanup_plan=\$(_merge_fresh_worktree_cleanup_plan "\$2" "\$3")
-[[ -n "\$cleanup_plan" ]]
-_merge_record_deferred_cleanup_owner "\$2" "\$3" "\$cleanup_plan"
+cmd_adopt_merged_receipt "\$2" "\$3"
 RUNNER
-chmod +x "$alias_receipt_runner"
+chmod +x "$adopt_receipt_runner"
 
 COMPLETION_PR_HEAD_REF="$alias_pr_head" \
 	COMPLETION_PR_HEAD_OID="$alias_head" \
 	COMPLETION_PR_HEAD_REPO="$alias_repo" \
+	AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$record_runner" 43 "$alias_repo" >/dev/null
+COMPLETION_PR_HEAD_REF="$alias_pr_head" \
+	COMPLETION_PR_HEAD_OID="$alias_head" \
+	COMPLETION_PR_HEAD_REPO="$alias_repo" \
 	AIDEVOPS_SESSION_ID=completion-alias \
+	AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" \
 	AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
 	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
-	bash "$alias_receipt_runner" "$alias_worktree" 43 "$alias_repo" >/dev/null
+	bash "$adopt_receipt_runner" "$alias_worktree" 43 "$alias_repo" >/dev/null
 alias_receipt="${cleanup_receipt_dir}/marcusquinn_aidevops-43.json"
 jq -e --arg branch "$alias_branch" '
 	.executor_completion_state == "FINALIZATION_PENDING"
 	and .resource_cleanup_state == "CLEANUP_DEFERRED"
+	and .release_status == "not-requested"
 	and .branch == $branch
 ' "$alias_receipt" >/dev/null
-AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
-	bash "$record_runner" 43 "$alias_repo" >/dev/null
+cp "$alias_receipt" "${ROOT}/adopted-receipt-before.json"
+COMPLETION_PR_HEAD_REF="$alias_pr_head" COMPLETION_PR_HEAD_OID="$alias_head" COMPLETION_PR_HEAD_REPO="$alias_repo" \
+	AIDEVOPS_SESSION_ID=completion-alias AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" \
+	AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$adopt_receipt_runner" "$alias_worktree" 43 "$alias_repo" >/dev/null
+cmp -s "$alias_receipt" "${ROOT}/adopted-receipt-before.json"
 AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
 	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
 	bash "$finalize_runner" 43 "$alias_repo" >/dev/null
@@ -243,7 +263,7 @@ jq -e --arg branch "$alias_branch" '
 	and .release_status == "not-requested"
 	and .branch == $branch
 ' "$alias_receipt" >/dev/null
-printf 'PASS exact-head alias receipt flows through record-no-release and finalize-receipt without reconstruction\n'
+printf 'PASS public merged-receipt adoption is idempotent and flows through finalization\n'
 
 cp "$direct_receipt" "${ROOT}/direct-receipt-before.json"
 if COMPLETION_PR_STATE=OPEN AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" \

--- a/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
@@ -12,6 +12,7 @@ FIXTURE_GIT_BIN=""
 GH_PR_HEAD_REF=""
 GH_PR_HEAD_OID=""
 GH_PR_HEAD_REPO=""
+GH_RELEASE_STATUS="not-requested"
 TESTS_RUN=0
 TESTS_FAILED=0
 
@@ -57,6 +58,13 @@ gh() {
 	local subcommand="${2:-}"
 	local args="$*"
 	if [[ "$command" == "pr" && "$subcommand" == "view" ]]; then
+		if [[ "$args" == *"state,mergedAt,mergeCommit,headRefName,headRefOid,headRepository,isCrossRepository"* ]]; then
+			jq -cn --arg head_ref "$GH_PR_HEAD_REF" --arg head_oid "$GH_PR_HEAD_OID" \
+				--arg head_repo "$GH_PR_HEAD_REPO" \
+				'{state:"MERGED",mergedAt:"2026-07-11T00:00:00Z",mergeCommit:{oid:"merge123"},
+				  headRefName:$head_ref,headRefOid:$head_oid,headRepository:{nameWithOwner:$head_repo},isCrossRepository:false}'
+			return 0
+		fi
 		if [[ "$args" == *"state,mergedAt,mergeCommit"* ]]; then
 			printf '%s\n' '{"state":"MERGED","mergedAt":"2026-07-11T00:00:00Z","mergeCommit":{"oid":"merge123"}}'
 			return 0
@@ -72,6 +80,17 @@ gh() {
 			return 0
 		fi
 	fi
+	return 0
+}
+
+_full_loop_terminal_release_status() {
+	local repo="$1"
+	local pr_number="$2"
+	[[ -n "$repo" && "$pr_number" =~ ^[0-9]+$ ]] || return 1
+	case "$GH_RELEASE_STATUS" in
+	published | superseded | not-requested) printf '%s\n' "$GH_RELEASE_STATUS" ;;
+	*) return 1 ;;
+	esac
 	return 0
 }
 
@@ -217,6 +236,7 @@ TRASH
 	GH_PR_HEAD_REF="feature/full-loop-cleanup"
 	GH_PR_HEAD_OID=$(git -C "$worktree_path" rev-parse HEAD)
 	GH_PR_HEAD_REPO="example/repo"
+	GH_RELEASE_STATUS="not-requested"
 	git -C "$canonical_repo" checkout -q -b feature/active
 	git clone -q "$origin_repo" "$updater_repo"
 	git -C "$updater_repo" config user.email test@example.invalid
@@ -241,6 +261,12 @@ configure_alias_repo_identity() {
 	local alias_branch="$1"
 	git -C "$worktree_path" branch -m "$alias_branch"
 	git -C "$worktree_path" remote add pr-head "https://github.com/${GH_PR_HEAD_REPO}.git"
+	return 0
+}
+
+configure_managed_repo_identity() {
+	local worktree_path="${TEST_ROOT}/worktrees/repo-feature-full-loop-cleanup"
+	git -C "$worktree_path" remote add managed "https://github.com/${GH_PR_HEAD_REPO}.git"
 	return 0
 }
 
@@ -313,6 +339,106 @@ test_cmd_merge_defers_exact_head_alias_worktree() {
 		and .worktree == $worktree and .branch == $branch
 	' "$receipt_path" >/dev/null || rc=1
 	print_result "exact-head repair alias persists its actual local cleanup target" "$rc"
+	return 0
+}
+
+test_cmd_adopt_merged_receipt_is_idempotent() {
+	setup_subject
+	configure_managed_repo_identity
+	local receipt_path="${AIDEVOPS_FULL_LOOP_CLEANUP_DIR}/example_repo-123.json"
+	local worktree_path="${TEST_ROOT}/worktrees/repo-feature-full-loop-cleanup"
+	local receipt_worktree=""
+	local rc=0
+	receipt_worktree=$(git -C "$worktree_path" rev-parse --show-toplevel)
+
+	cmd_adopt_merged_receipt "123" "example/repo" || rc=1
+	[[ -f "$receipt_path" ]] || rc=1
+	jq -e --arg worktree "$receipt_worktree" '
+		.repository == "example/repo" and .pr_number == 123
+		and .worktree == $worktree and .branch == "feature/full-loop-cleanup"
+		and .executor_completion_state == "FINALIZATION_PENDING"
+		and .resource_cleanup_state == "CLEANUP_DEFERRED"
+		and .release_status == "not-requested"
+		and .cleanup_lease.state == "pending"
+		and (.owner.pid | type == "number") and (.owner.process_identity | length > 0)
+	' "$receipt_path" >/dev/null || rc=1
+	cp "$receipt_path" "${TEST_ROOT}/adopted-before.json"
+	cmd_adopt_merged_receipt "123" "example/repo" || rc=1
+	cmp -s "$receipt_path" "${TEST_ROOT}/adopted-before.json" || rc=1
+	print_result "externally merged PR adoption is exact-head and idempotent" "$rc"
+	return 0
+}
+
+test_cmd_adopt_merged_receipt_rejects_unsafe_evidence() {
+	local rc=0
+	local receipt_path=""
+
+	setup_subject
+	configure_managed_repo_identity
+	receipt_path="${AIDEVOPS_FULL_LOOP_CLEANUP_DIR}/example_repo-123.json"
+	GH_RELEASE_STATUS="pending"
+	if cmd_adopt_merged_receipt "123" "example/repo" >/dev/null 2>&1; then rc=1; fi
+	[[ ! -e "$receipt_path" ]] || rc=1
+
+	setup_subject
+	configure_managed_repo_identity
+	receipt_path="${AIDEVOPS_FULL_LOOP_CLEANUP_DIR}/example_repo-123.json"
+	GH_PR_HEAD_OID="0000000000000000000000000000000000000000"
+	if cmd_adopt_merged_receipt "123" "example/repo" >/dev/null 2>&1; then rc=1; fi
+	[[ ! -e "$receipt_path" ]] || rc=1
+
+	setup_subject
+	configure_managed_repo_identity
+	receipt_path="${AIDEVOPS_FULL_LOOP_CLEANUP_DIR}/example_repo-123.json"
+	git branch -m "feature/different-branch"
+	if cmd_adopt_merged_receipt "123" "example/repo" >/dev/null 2>&1; then rc=1; fi
+	[[ ! -e "$receipt_path" ]] || rc=1
+
+	setup_subject
+	configure_managed_repo_identity
+	receipt_path="${AIDEVOPS_FULL_LOOP_CLEANUP_DIR}/example_repo-123.json"
+	if cmd_adopt_merged_receipt "123" "wrong/repo" >/dev/null 2>&1; then rc=1; fi
+	[[ ! -e "$receipt_path" ]] || rc=1
+
+	setup_subject
+	configure_managed_repo_identity
+	receipt_path="${AIDEVOPS_FULL_LOOP_CLEANUP_DIR}/example_repo-123.json"
+	_resolve_worktree_owner_pid() {
+		printf '%s\n' 99999999
+		return 0
+	}
+	if cmd_adopt_merged_receipt "123" "example/repo" >/dev/null 2>&1; then rc=1; fi
+	[[ ! -e "$receipt_path" ]] || rc=1
+	unset -f _resolve_worktree_owner_pid
+
+	print_result "merged-receipt adoption rejects nonterminal, head, branch, repository, and dead-owner evidence" "$rc"
+	return 0
+}
+
+test_cmd_adopt_merged_receipt_rejects_receipt_conflicts() {
+	local rc=0
+	local receipt_path=""
+
+	setup_subject
+	configure_managed_repo_identity
+	receipt_path="${AIDEVOPS_FULL_LOOP_CLEANUP_DIR}/example_repo-123.json"
+	cmd_adopt_merged_receipt "123" "example/repo" >/dev/null || rc=1
+	jq '.owner.process_identity = "reused process generation"' "$receipt_path" >"${receipt_path}.tmp"
+	mv "${receipt_path}.tmp" "$receipt_path"
+	cp "$receipt_path" "${TEST_ROOT}/conflict-before.json"
+	if cmd_adopt_merged_receipt "123" "example/repo" >/dev/null 2>&1; then rc=1; fi
+	cmp -s "$receipt_path" "${TEST_ROOT}/conflict-before.json" || rc=1
+
+	setup_subject
+	configure_managed_repo_identity
+	receipt_path="${AIDEVOPS_FULL_LOOP_CLEANUP_DIR}/example_repo-123.json"
+	cmd_adopt_merged_receipt "123" "example/repo" >/dev/null || rc=1
+	full_loop_transition_cleanup_receipt "$receipt_path" "$_FULL_LOOP_CLEANUP_LEASED" "$$" || rc=1
+	cp "$receipt_path" "${TEST_ROOT}/leased-before.json"
+	if cmd_adopt_merged_receipt "123" "example/repo" >/dev/null 2>&1; then rc=1; fi
+	cmp -s "$receipt_path" "${TEST_ROOT}/leased-before.json" || rc=1
+
+	print_result "merged-receipt adoption preserves conflicting and leased receipts" "$rc"
 	return 0
 }
 
@@ -462,6 +588,9 @@ main() {
 	test_cmd_merge_defers_current_linked_worktree
 	test_cmd_merge_defers_cleanup_for_live_process_cwd
 	test_cmd_merge_defers_exact_head_alias_worktree
+	test_cmd_adopt_merged_receipt_is_idempotent
+	test_cmd_adopt_merged_receipt_rejects_unsafe_evidence
+	test_cmd_adopt_merged_receipt_rejects_receipt_conflicts
 	test_cleanup_plan_rejects_head_drift
 	test_cleanup_plan_rejects_detached_checkout
 	test_cleanup_plan_rejects_canonical_checkout

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -247,6 +247,18 @@ receipt's executor finalization fields. After an explicit repository rename, use
 new identity and migrates cleanup plus release receipts while preserving owner,
 lease, worktree, branch, creation time, and irreversible cleanup state.
 
+If a maintainer or merge queue merges the PR before the merge wrapper records its
+cleanup receipt, first establish terminal release evidence, then run
+`full-loop-helper.sh adopt-merged-receipt <PR> [REPO]` from the still-registered
+linked worktree, followed by `finalize-receipt`. Adoption performs a fresh merged
+PR read, requires the current local `HEAD` and managed GitHub repository identity
+plus branch to match the immutable PR head, binds a live PID and process-generation identity,
+and atomically creates only the missing `CLEANUP_DEFERRED` receipt. An identical
+replay is idempotent; conflicting, leased, cleaned, dead-owner, nonterminal-release,
+canonical-checkout, detached-checkout, or mismatched repository/head evidence
+fails closed without replacing the existing receipt. Adoption never calls the
+merge API and never infers publication intent.
+
 **4.7 Maintained-App Local Base Synchronization (MANDATORY):** After a maintained non-aidevops merge, read the merged PR's verified `baseRefName`, resolve the registered canonical checkout, and use the clean `fast-forward-current` or lossless `sync-mirror` operation documented in `workflows/git-workflow.md`. Full-loop consent authorizes this guarded synchronization. Verify local `HEAD` equals `origin/<baseRefName>` before recording `LOCAL_BASE_SYNCED`.
 
 **4.8 Closing Comments:** Managed repos receive structured issue and PR closing comments with the normal pre-close verification. External sessions do not close the upstream issue; follow upstream conventions and leave at most one concise issue comment linking the PR when useful.


### PR DESCRIPTION
## Summary

- Add `adopt-merged-receipt` for the maintainer-wins-merge race.
- Require fresh merged PR, exact head/branch/repository, live process-generation owner, and terminal release evidence.
- Make deferred receipt creation atomic and idempotent while rejecting conflicting or leased receipts without mutation.
- Document the public recovery sequence and preserve existing direct-wrapper cleanup behavior.

## Verification

- `bash .agents/scripts/tests/test-full-loop-completion-evidence.sh`
- `bash .agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh`
- `bash .agents/scripts/tests/test-full-loop-cleanup-receipt.sh`
- `shellcheck .agents/scripts/full-loop-helper.sh .agents/scripts/full-loop-helper-state.sh .agents/scripts/full-loop-helper-merge.sh .agents/scripts/full-loop-cleanup-receipt.sh`
- `.agents/scripts/linters-local.sh`

## Risk and testing

- Runtime risk: Critical
- Testing level: Runtime-verified

Resolves #28911
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.197 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 22m and 241,421 tokens on this as a headless worker.