### PR TITLE
GH#28917: Preserve aggregate release provenance

### DIFF
--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -45,6 +45,17 @@ against GitHub, requires their exact merge SHAs to be ancestors of the aggregate
 tip, and copies the complete manifest into the signed tag. An intervening direct
 commit without this reviewed attestation remains blocked.
 
+The source resolver classifies an exact-tip aggregation PR as aggregate even
+when the caller names that aggregation PR rather than one of its included
+sources. This prevents the direct-source fast path from omitting the tag copy.
+For an already-signed tag whose redundant aggregate entries are wholly absent,
+recovery may reconstruct them only from the signed `Aidevops-Source-Merge` SHA
+after validating the aggregator identity, complete commit manifest, and every
+included PR. Any explicit partial, duplicate, malformed, or conflicting tag
+manifest remains fail-closed. A recovery workflow executes this verifier from
+its exact reviewed `main` workflow commit while all release artifacts remain
+pinned to the immutable tag checkout.
+
 After all publication and deployment gates succeed, the aggregation PR receives
 `release:published`; each included PR receives `release:superseded` plus a JSON
 receipt linking its merge SHA to the aggregation PR, release tag, and release
@@ -99,6 +110,12 @@ before publication.
 Aggregation PR #28916 reviews authorized PR #28914 at
 `d522f4df38fc17dddc1cc1feed72e7dfa9279088` because the deterministic t18185
 completion commit advanced `main` before publication.
+
+Release `v3.32.198` exposed the exact-tip classification gap when publication
+named aggregation PR #28916: the signed tag bound its reviewed merge SHA but
+omitted the redundant `Aidevops-Aggregated-Source` copy. Publication correctly
+failed before side effects. Issue #28917 records the no-retag recovery and the
+resolver regression coverage.
 
 Manual arbitrary-version package publication is intentionally unsupported. A
 recovery operation must use an existing tag that passes the same verifier.

--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -15,6 +15,7 @@ _FULL_LOOP_RELEASE_EVENT_RECOVERY="workflow_dispatch"
 _FULL_LOOP_RELEASE_JSON_ARRAY_TYPE="array"
 _FULL_LOOP_RELEASE_JSON_STRING_TYPE="string"
 _FULL_LOOP_RELEASE_PROVENANCE_PREDICATE="https://slsa.dev/provenance/v1"
+_FULL_LOOP_RELEASE_TRUE="true"
 
 _full_loop_release_tag_body() {
 	local tag_name="$1"
@@ -42,23 +43,34 @@ _full_loop_release_find_tag_for_pr() {
 	local candidate_tag=""
 	local tag_body=""
 	local trailer=""
-	local matched=0
+	local source_json=""
+	local requested_present="false"
+	local textually_matched=0
 
 	_FULL_LOOP_RELEASE_FOUND_TAG=""
 	git -C "$REPO_ROOT" fetch origin --tags --quiet || return 1
 	while IFS= read -r candidate_tag; do
 		[[ -n "$candidate_tag" ]] || continue
 		tag_body=$(_full_loop_release_tag_body "$candidate_tag") || return 1
-		matched=0
+		textually_matched=0
 		while IFS= read -r trailer; do
 			case "$trailer" in
 			"Aidevops-Source-PR: ${requested_pr}" | "Aidevops-Aggregated-Source: ${requested_pr}@"*)
-				matched=1
+				textually_matched=1
 				break
 				;;
 			esac
 		done <<<"$tag_body"
-		[[ "$matched" -eq 1 ]] || continue
+		if ! source_json=$(_full_loop_release_source_json_from_tag "$candidate_tag"); then
+			[[ "$textually_matched" -eq 0 ]] || return 1
+			continue
+		fi
+		requested_present=$(jq -r --argjson requested "$requested_pr" \
+			'([.source_pr] + [.aggregated_sources[].pr]) | any(. == $requested)' <<<"$source_json") || return 1
+		if [[ "$textually_matched" -eq 1 && "$requested_present" != "$_FULL_LOOP_RELEASE_TRUE" ]]; then
+			return 1
+		fi
+		[[ "$requested_present" == "$_FULL_LOOP_RELEASE_TRUE" ]] || continue
 		_full_loop_release_verify_tag_provenance "$repo" "$candidate_tag" || return 1
 		_FULL_LOOP_RELEASE_FOUND_TAG="$candidate_tag"
 		return 0
@@ -74,6 +86,55 @@ _full_loop_release_latest_tag() {
 		return 0
 	done < <(git -C "$REPO_ROOT" tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname)
 	return 1
+}
+
+_full_loop_release_source_merge_trailer_values() {
+	local source_merge="$1"
+	local trailer_key="$2"
+	local commit_message=""
+	local parsed_trailers=""
+
+	commit_message=$(git -C "$REPO_ROOT" log -1 --format='%B' "$source_merge" 2>/dev/null) || return 1
+	parsed_trailers=$(git -C "$REPO_ROOT" interpret-trailers --parse <<<"$commit_message") || return 1
+	awk -v prefix="${trailer_key}: " \
+		'index($0, prefix) == 1 { print substr($0, length(prefix) + 1) }' \
+		<<<"$parsed_trailers"
+	return $?
+}
+
+_full_loop_release_manifest_json_from_source_merge() {
+	local source_pr="$1"
+	local source_merge="$2"
+	local manifest_pr=""
+	local manifest_entries=""
+	local aggregate_payload=""
+	local aggregate_pr=""
+	local aggregate_merge=""
+	local aggregates_json="[]"
+
+	manifest_pr=$(_full_loop_release_source_merge_trailer_values \
+		"$source_merge" "Aidevops-Release-Aggregator-PR") || return 1
+	manifest_entries=$(_full_loop_release_source_merge_trailer_values \
+		"$source_merge" "Aidevops-Release-Aggregates") || return 1
+	if [[ -z "$manifest_pr" && -z "$manifest_entries" ]]; then
+		printf '[]\n'
+		return 0
+	fi
+	[[ "$manifest_pr" == "$source_pr" && -n "$manifest_entries" ]] || return 1
+	while IFS= read -r aggregate_payload; do
+		[[ -n "$aggregate_payload" ]] || continue
+		aggregate_pr="${aggregate_payload%%@*}"
+		aggregate_merge="${aggregate_payload#*@}"
+		[[ "$aggregate_payload" == *@* && "$aggregate_pr" =~ ^[0-9]+$ && "$aggregate_merge" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+		[[ "$aggregate_pr" != "$source_pr" ]] || return 1
+		if jq -e --argjson pr "$aggregate_pr" 'any(.[]; .pr == $pr)' <<<"$aggregates_json" >/dev/null; then
+			return 1
+		fi
+		aggregates_json=$(jq -cn --argjson pr "$aggregate_pr" --arg merge "$aggregate_merge" \
+			--argjson existing "$aggregates_json" '$existing + [{pr:$pr,merge:$merge}]') || return 1
+	done <<<"$manifest_entries"
+	printf '%s\n' "$aggregates_json"
+	return 0
 }
 
 _full_loop_release_source_json_from_tag() {
@@ -97,12 +158,22 @@ _full_loop_release_source_json_from_tag() {
 			aggregate_pr="${aggregate_payload%%@*}"
 			aggregate_merge="${aggregate_payload#*@}"
 			[[ "$aggregate_pr" =~ ^[0-9]+$ && "$aggregate_merge" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+			if jq -e --argjson pr "$aggregate_pr" 'any(.[]; .pr == $pr)' <<<"$aggregates_json" >/dev/null; then
+				return 1
+			fi
 			aggregates_json=$(jq -cn --argjson pr "$aggregate_pr" --arg merge "$aggregate_merge" \
 				--argjson existing "$aggregates_json" '$existing + [{pr:$pr,merge:$merge}]') || return 1
 			;;
 		esac
 	done <<<"$tag_body"
 	[[ "$source_pr" =~ ^[0-9]+$ && "$source_merge" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+	if jq -e --argjson source_pr "$source_pr" 'any(.[]; .pr == $source_pr)' <<<"$aggregates_json" >/dev/null; then
+		return 1
+	fi
+	if [[ "$aggregates_json" == "[]" ]]; then
+		aggregates_json=$(_full_loop_release_manifest_json_from_source_merge \
+			"$source_pr" "$source_merge") || return 1
+	fi
 	jq -cn --argjson source_pr "$source_pr" --arg source_merge "$source_merge" \
 		--argjson aggregated_sources "$aggregates_json" \
 		'{source_pr:$source_pr,source_merge:$source_merge,aggregated_sources:$aggregated_sources}'
@@ -443,7 +514,7 @@ _full_loop_release_finalize_reconciliation() {
 	source_merge=$(jq -er '.source_merge' <<<"$source_json") || return 1
 	requested_present=$(jq -r --argjson requested "$requested_pr" \
 		'([.source_pr] + [.aggregated_sources[].pr]) | any(. == $requested)' <<<"$source_json") || return 1
-	[[ "$requested_present" == "true" ]] || return 1
+	[[ "$requested_present" == "$_FULL_LOOP_RELEASE_TRUE" ]] || return 1
 	_full_loop_validate_release_candidates "$repo" "$source_json" || return 1
 	_full_loop_release_prepare_tag_worktree "$tag_name" || return 1
 	version_manager="${SCRIPT_DIR}/version-manager.sh"

--- a/.agents/scripts/release-provenance-helper.sh
+++ b/.agents/scripts/release-provenance-helper.sh
@@ -119,23 +119,29 @@ _release_provenance_resolve_source() {
 	requested_merge=$(jq -er '.mergeCommit.oid // empty' <<<"$requested_json" 2>/dev/null) || return 1
 	_release_provenance_verify_pr_record "$repo_slug" "$branch_name" "$requested_pr" "$requested_merge" "$release_head" || return 1
 
-	if [[ "$requested_merge" == "$release_head" ]]; then
-		jq -cn --argjson requested_pr "$requested_pr" --arg source_merge "$requested_merge" \
-			'{mode:"direct",requested_pr:$requested_pr,source_pr:$requested_pr,source_merge:$source_merge,aggregated_sources:[]}'
-		return 0
-	fi
-
 	aggregate_pr=$(_release_provenance_trailer_values_at_commit "$release_head" "Aidevops-Release-Aggregator-PR") || return 1
-	[[ "$aggregate_pr" =~ ^[0-9]+$ ]] || {
+	aggregate_entries=$(_release_provenance_trailer_values_at_commit "$release_head" "Aidevops-Release-Aggregates") || return 1
+	if [[ -z "$aggregate_pr" && -z "$aggregate_entries" ]]; then
+		if [[ "$requested_merge" == "$release_head" ]]; then
+			jq -cn --argjson requested_pr "$requested_pr" --arg source_merge "$requested_merge" \
+				'{mode:"direct",requested_pr:$requested_pr,source_pr:$requested_pr,source_merge:$source_merge,aggregated_sources:[]}'
+			return 0
+		fi
 		_release_provenance_error "current main tip is not an explicit release-aggregation PR"
 		return 1
+	fi
+	[[ "$aggregate_pr" =~ ^[0-9]+$ ]] || {
+		_release_provenance_error "release-aggregation PR has no immutable aggregator identity"
+		return 1
 	}
-	_release_provenance_verify_pr_record "$repo_slug" "$branch_name" "$aggregate_pr" "$release_head" "$release_head" || return 1
-	aggregate_entries=$(_release_provenance_trailer_values_at_commit "$release_head" "Aidevops-Release-Aggregates") || return 1
 	[[ -n "$aggregate_entries" ]] || {
 		_release_provenance_error "release-aggregation PR has no immutable source manifest"
 		return 1
 	}
+	_release_provenance_verify_pr_record "$repo_slug" "$branch_name" "$aggregate_pr" "$release_head" "$release_head" || return 1
+	if [[ "$requested_pr" == "$aggregate_pr" && "$requested_merge" == "$release_head" ]]; then
+		found_requested=true
+	fi
 	while IFS= read -r entry; do
 		[[ -n "$entry" ]] || continue
 		entry_pr="${entry%%@*}"
@@ -414,6 +420,13 @@ _release_provenance_verify_aggregate_manifest() {
 		_release_provenance_verify_pr_record "$repo_slug" "$branch_name" "$entry_pr" "$entry_merge" "$source_merge" || return 1
 		manifest_json=$(jq -c --argjson pr "$entry_pr" --arg merge "$entry_merge" '. + [{pr:$pr,merge:$merge}]' <<<"$manifest_json") || return 1
 	done <<<"$manifest_entries"
+	if [[ "$_RELEASE_PROVENANCE_AGGREGATED_SOURCES" == '[]' ]]; then
+		# A signed source-merge SHA transitively binds this reviewed manifest.
+		# Recover only a completely omitted redundant tag list; any explicit
+		# partial or conflicting list remains a hard failure below.
+		_RELEASE_PROVENANCE_AGGREGATED_SOURCES="$manifest_json"
+		return 0
+	fi
 	if [[ "$(jq -cS . <<<"$manifest_json")" != "$(jq -cS . <<<"$_RELEASE_PROVENANCE_AGGREGATED_SOURCES")" ]]; then
 		_release_provenance_error "tag aggregated sources differ from the reviewed aggregation manifest"
 		return 1

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -43,6 +43,91 @@ if ! jq -e '.source_pr == 90
 fi
 printf 'PASS signed tag trailers reconstruct release provenance\n'
 
+legacy_source_json=$(
+	(
+		_full_loop_release_tag_body() {
+			local tag_name="$1"
+			[[ "$tag_name" == "v1.2.4" ]] || return 1
+			cat <<'BODY'
+Release v1.2.4
+
+Aidevops-Version: 1.2.4
+Aidevops-Source-PR: 90
+Aidevops-Source-Merge: 1111111111111111111111111111111111111111
+BODY
+			return 0
+		}
+		_full_loop_release_source_merge_trailer_values() {
+			local source_merge="$1"
+			local trailer_key="$2"
+			[[ "$source_merge" == "1111111111111111111111111111111111111111" ]] || return 1
+			case "$trailer_key" in
+			Aidevops-Release-Aggregator-PR) printf '90\n' ;;
+			Aidevops-Release-Aggregates) printf '89@2222222222222222222222222222222222222222\n' ;;
+			*) return 1 ;;
+			esac
+			return 0
+		}
+		_full_loop_release_source_json_from_tag v1.2.4
+	)
+)
+if ! jq -e '.source_pr == 90
+	and .source_merge == "1111111111111111111111111111111111111111"
+	and .aggregated_sources == [{"pr":89,"merge":"2222222222222222222222222222222222222222"}]' \
+	<<<"$legacy_source_json" >/dev/null; then
+	printf 'FAIL signed source merge did not reconstruct an omitted aggregate list\n'
+	exit 1
+fi
+printf 'PASS signed source merge reconstructs an omitted redundant tag manifest\n'
+
+legacy_found_tag=$(
+	(
+		git() {
+			local args="$*"
+			case "$args" in
+			*" fetch origin --tags --quiet"*) return 0 ;;
+			*" tag --list "*) printf 'v1.2.4\n' ;;
+			*) return 1 ;;
+			esac
+			return 0
+		}
+		_full_loop_release_tag_body() {
+			local tag_name="$1"
+			[[ "$tag_name" == "v1.2.4" ]] || return 1
+			printf '%s\n' \
+				'Release v1.2.4' \
+				'Aidevops-Version: 1.2.4' \
+				'Aidevops-Source-PR: 90' \
+				'Aidevops-Source-Merge: 1111111111111111111111111111111111111111'
+			return 0
+		}
+		_full_loop_release_source_merge_trailer_values() {
+			local source_merge="$1"
+			local trailer_key="$2"
+			[[ "$source_merge" == "1111111111111111111111111111111111111111" ]] || return 1
+			case "$trailer_key" in
+			Aidevops-Release-Aggregator-PR) printf '90\n' ;;
+			Aidevops-Release-Aggregates) printf '89@2222222222222222222222222222222222222222\n' ;;
+			*) return 1 ;;
+			esac
+			return 0
+		}
+		_full_loop_release_verify_tag_provenance() {
+			local repo="$1"
+			local tag_name="$2"
+			[[ "$repo" == "test/repo" && "$tag_name" == "v1.2.4" ]]
+			return $?
+		}
+		_full_loop_release_find_tag_for_pr test/repo 89 || exit 1
+		printf '%s\n' "$_FULL_LOOP_RELEASE_FOUND_TAG"
+	)
+)
+if [[ "$legacy_found_tag" != "v1.2.4" ]]; then
+	printf 'FAIL included source PR could not discover its transitively bound tag\n'
+	exit 1
+fi
+printf 'PASS included source PR discovers its transitively bound release tag\n'
+
 mkdir -p "${TEST_ROOT}/worktrees" "${TEST_ROOT}/tag-checkout" \
 	"${TEST_ROOT}/runtime" "${TEST_ROOT}/tag-checkout/.agents/scripts"
 export AIDEVOPS_WORKTREE_BASE_DIR="${TEST_ROOT}/worktrees"

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -43,34 +43,33 @@ if ! jq -e '.source_pr == 90
 fi
 printf 'PASS signed tag trailers reconstruct release provenance\n'
 
-legacy_source_json=$(
-	(
-		_full_loop_release_tag_body() {
-			local tag_name="$1"
-			[[ "$tag_name" == "v1.2.4" ]] || return 1
-			cat <<'BODY'
-Release v1.2.4
-
-Aidevops-Version: 1.2.4
-Aidevops-Source-PR: 90
-Aidevops-Source-Merge: 1111111111111111111111111111111111111111
-BODY
-			return 0
-		}
-		_full_loop_release_source_merge_trailer_values() {
-			local source_merge="$1"
-			local trailer_key="$2"
-			[[ "$source_merge" == "1111111111111111111111111111111111111111" ]] || return 1
-			case "$trailer_key" in
-			Aidevops-Release-Aggregator-PR) printf '90\n' ;;
-			Aidevops-Release-Aggregates) printf '89@2222222222222222222222222222222222222222\n' ;;
-			*) return 1 ;;
-			esac
-			return 0
-		}
-		_full_loop_release_source_json_from_tag v1.2.4
-	)
-)
+legacy_source_json_file="${TEST_ROOT}/legacy-source.json"
+(
+	_full_loop_release_tag_body() {
+		local tag_name="$1"
+		[[ "$tag_name" == "v1.2.4" ]] || return 1
+		printf '%s\n' \
+			'Release v1.2.4' \
+			'' \
+			'Aidevops-Version: 1.2.4' \
+			'Aidevops-Source-PR: 90' \
+			'Aidevops-Source-Merge: 1111111111111111111111111111111111111111'
+		return 0
+	}
+	_full_loop_release_source_merge_trailer_values() {
+		local source_merge="$1"
+		local trailer_key="$2"
+		[[ "$source_merge" == "1111111111111111111111111111111111111111" ]] || return 1
+		case "$trailer_key" in
+		Aidevops-Release-Aggregator-PR) printf '90\n' ;;
+		Aidevops-Release-Aggregates) printf '89@2222222222222222222222222222222222222222\n' ;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
+	_full_loop_release_source_json_from_tag v1.2.4
+) >"$legacy_source_json_file"
+legacy_source_json=$(<"$legacy_source_json_file")
 if ! jq -e '.source_pr == 90
 	and .source_merge == "1111111111111111111111111111111111111111"
 	and .aggregated_sources == [{"pr":89,"merge":"2222222222222222222222222222222222222222"}]' \
@@ -80,48 +79,48 @@ if ! jq -e '.source_pr == 90
 fi
 printf 'PASS signed source merge reconstructs an omitted redundant tag manifest\n'
 
-legacy_found_tag=$(
-	(
-		git() {
-			local args="$*"
-			case "$args" in
-			*" fetch origin --tags --quiet"*) return 0 ;;
-			*" tag --list "*) printf 'v1.2.4\n' ;;
-			*) return 1 ;;
-			esac
-			return 0
-		}
-		_full_loop_release_tag_body() {
-			local tag_name="$1"
-			[[ "$tag_name" == "v1.2.4" ]] || return 1
-			printf '%s\n' \
-				'Release v1.2.4' \
-				'Aidevops-Version: 1.2.4' \
-				'Aidevops-Source-PR: 90' \
-				'Aidevops-Source-Merge: 1111111111111111111111111111111111111111'
-			return 0
-		}
-		_full_loop_release_source_merge_trailer_values() {
-			local source_merge="$1"
-			local trailer_key="$2"
-			[[ "$source_merge" == "1111111111111111111111111111111111111111" ]] || return 1
-			case "$trailer_key" in
-			Aidevops-Release-Aggregator-PR) printf '90\n' ;;
-			Aidevops-Release-Aggregates) printf '89@2222222222222222222222222222222222222222\n' ;;
-			*) return 1 ;;
-			esac
-			return 0
-		}
-		_full_loop_release_verify_tag_provenance() {
-			local repo="$1"
-			local tag_name="$2"
-			[[ "$repo" == "test/repo" && "$tag_name" == "v1.2.4" ]]
-			return $?
-		}
-		_full_loop_release_find_tag_for_pr test/repo 89 || exit 1
-		printf '%s\n' "$_FULL_LOOP_RELEASE_FOUND_TAG"
-	)
-)
+legacy_found_tag_file="${TEST_ROOT}/legacy-found-tag.txt"
+(
+	git() {
+		local args="$*"
+		case "$args" in
+		*" fetch origin --tags --quiet"*) return 0 ;;
+		*" tag --list "*) printf 'v1.2.4\n' ;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
+	_full_loop_release_tag_body() {
+		local tag_name="$1"
+		[[ "$tag_name" == "v1.2.4" ]] || return 1
+		printf '%s\n' \
+			'Release v1.2.4' \
+			'Aidevops-Version: 1.2.4' \
+			'Aidevops-Source-PR: 90' \
+			'Aidevops-Source-Merge: 1111111111111111111111111111111111111111'
+		return 0
+	}
+	_full_loop_release_source_merge_trailer_values() {
+		local source_merge="$1"
+		local trailer_key="$2"
+		[[ "$source_merge" == "1111111111111111111111111111111111111111" ]] || return 1
+		case "$trailer_key" in
+		Aidevops-Release-Aggregator-PR) printf '90\n' ;;
+		Aidevops-Release-Aggregates) printf '89@2222222222222222222222222222222222222222\n' ;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
+	_full_loop_release_verify_tag_provenance() {
+		local repo="$1"
+		local tag_name="$2"
+		[[ "$repo" == "test/repo" && "$tag_name" == "v1.2.4" ]]
+		return $?
+	}
+	_full_loop_release_find_tag_for_pr test/repo 89 || exit 1
+	printf '%s\n' "$_FULL_LOOP_RELEASE_FOUND_TAG"
+) >"$legacy_found_tag_file"
+legacy_found_tag=$(<"$legacy_found_tag_file")
 if [[ "$legacy_found_tag" != "v1.2.4" ]]; then
 	printf 'FAIL included source PR could not discover its transitively bound tag\n'
 	exit 1

--- a/.agents/scripts/tests/test-release-provenance-helper.sh
+++ b/.agents/scripts/tests/test-release-provenance-helper.sh
@@ -191,6 +191,18 @@ jq -e --arg merge "$AGGREGATE_MERGE" --arg original "$AGG_ORIGINAL" '
 ' <<<"$aggregate_json" >/dev/null
 printf 'PASS reviewed aggregation manifest recovers an authorized historical source\n'
 
+aggregate_self_json=$(
+	cd "$AGG_REPO" || exit 1
+	PATH="${AGG_BIN}:/opt/homebrew/bin:/usr/bin:/bin" \
+		bash "$HELPER" resolve-source --source-pr 99 --repo test/aggregate
+)
+jq -e --arg merge "$AGGREGATE_MERGE" --arg original "$AGG_ORIGINAL" '
+	.mode == "aggregate" and .requested_pr == 99 and .source_pr == 99
+	and .source_merge == $merge
+	and .aggregated_sources == [{pr:42,merge:$original}]
+' <<<"$aggregate_self_json" >/dev/null
+printf 'PASS exact-tip aggregation PR preserves its reviewed source manifest\n'
+
 git -C "$AGG_REPO" switch -q --detach "$AGG_ORIGINAL"
 git -C "$AGG_REPO" commit -q --allow-empty -m 'unreviewed direct commit'
 if (
@@ -230,14 +242,29 @@ git -C "$AGG_REPO" tag -a v2.0.0 -m "Release v2.0.0 - tampered aggregate fixture
 Aidevops-Version: 2.0.0
 Aidevops-Source-PR: 99
 Aidevops-Source-Merge: ${AGGREGATE_MERGE}"
+
+(
+	cd "$AGG_REPO" || exit 1
+	PATH="${AGG_BIN}:/opt/homebrew/bin:/usr/bin:/bin" \
+		bash "$HELPER" verify --tag v2.0.0 --repo test/aggregate >/dev/null
+)
+printf 'PASS signed source merge recovers a completely omitted redundant tag manifest\n'
+
+git -C "$AGG_REPO" tag -d v2.0.0 >/dev/null
+git -C "$AGG_REPO" tag -a v2.0.0 -m "Release v2.0.0 - conflicting aggregate fixture
+
+Aidevops-Version: 2.0.0
+Aidevops-Source-PR: 99
+Aidevops-Source-Merge: ${AGGREGATE_MERGE}
+Aidevops-Aggregated-Source: 42@0000000000000000000000000000000000000000"
 if (
 	cd "$AGG_REPO" || exit 1
 	PATH="${AGG_BIN}:/opt/homebrew/bin:/usr/bin:/bin" \
 		bash "$HELPER" verify --tag v2.0.0 --repo test/aggregate
 ) >/dev/null 2>&1; then
-	printf 'FAIL tag omitted the reviewed aggregate sources\n'
+	printf 'FAIL tag with an explicit conflicting aggregate source was accepted\n'
 	exit 1
 fi
-printf 'PASS tag tampering cannot omit reviewed aggregate sources\n'
+printf 'PASS explicit aggregate-source conflicts remain fail-closed\n'
 
 exit 0

--- a/.agents/scripts/tests/test-release-publication-workflows.sh
+++ b/.agents/scripts/tests/test-release-publication-workflows.sh
@@ -63,10 +63,16 @@ assert_contains "recovery requires exact commit correlation" \
 	"Exact verified tag commit; run identity appends the workflow commit" "$PACKAGE_WORKFLOW"
 assert_absent "suppressed release-event chaining is removed" "types: [published]" "$PACKAGE_WORKFLOW"
 assert_absent "package metadata is not rewritten before publish" "--no-git-tag-version" "$PACKAGE_WORKFLOW"
-assert_contains "unified workflow verifies provenance" "release-provenance-helper.sh verify" "$PACKAGE_WORKFLOW"
+# shellcheck disable=SC2016 # Match literal workflow shell variables.
+assert_contains "unified workflow verifies provenance" 'bash "$VERIFIER" verify' "$PACKAGE_WORKFLOW"
 assert_contains "recovery executes only from reviewed main" 'refs/heads/main' "$PACKAGE_WORKFLOW"
 assert_contains "recovery binds the exact tag commit" \
 	"Recovery correlation does not bind the exact tag commit" "$PACKAGE_WORKFLOW"
+# shellcheck disable=SC2016 # Match literal workflow shell variables.
+assert_contains "recovery verifier is pinned to the reviewed workflow commit" \
+	'git worktree add --detach "$VERIFIER_WORKTREE" "$GITHUB_SHA"' "$PACKAGE_WORKFLOW"
+assert_contains "tag pushes retain the immutable tag verifier" \
+	'VERIFIER=".agents/scripts/release-provenance-helper.sh"' "$PACKAGE_WORKFLOW"
 # shellcheck disable=SC2016 # Match the literal workflow expression.
 assert_contains "recovery run identity records the actual workflow commit" \
 	'${{ inputs.correlation || github.sha }}.${{ github.sha }}' "$PACKAGE_WORKFLOW"
@@ -111,12 +117,14 @@ assert_contains "Homebrew verification keeps its executable test selector" \
 assert_contains "Homebrew convergence compares the complete generated formula" \
 	"cmp -s homebrew/aidevops.rb" "$PACKAGE_WORKFLOW"
 assert_absent "Homebrew publication failures are not masked" "continue-on-error: true" "$PACKAGE_WORKFLOW"
+# shellcheck disable=SC2016 # Match the literal verifier command.
 assert_order "release provenance precedes release creation" \
-	"release-provenance-helper.sh verify" "github-release-helper.sh create" "$PACKAGE_WORKFLOW"
+	'bash "$VERIFIER" verify' "github-release-helper.sh create" "$PACKAGE_WORKFLOW"
 assert_order "GitHub release precedes npm publication" \
 	"github-release-helper.sh create" "npm publish --provenance" "$PACKAGE_WORKFLOW"
+# shellcheck disable=SC2016 # Match the literal verifier command.
 assert_order "package provenance precedes npm publication" \
-	"release-provenance-helper.sh verify" "npm publish --provenance" "$PACKAGE_WORKFLOW"
+	'bash "$VERIFIER" verify' "npm publish --provenance" "$PACKAGE_WORKFLOW"
 
 package_environment_count=$(grep -cE \
 	'^[[:space:]]*environment:[[:space:]]*release[[:space:]]*$' "$PACKAGE_WORKFLOW" || true)
@@ -126,7 +134,8 @@ if [[ "$package_environment_count" -ne 1 ]]; then
 fi
 printf 'PASS unified publication uses one release environment job\n'
 
-verification_count=$(grep -cF 'release-provenance-helper.sh verify' "$PACKAGE_WORKFLOW" || true)
+# shellcheck disable=SC2016 # Match the literal verifier command.
+verification_count=$(grep -cF 'bash "$VERIFIER" verify' "$PACKAGE_WORKFLOW" || true)
 if [[ "$verification_count" -ne 1 ]]; then
 	printf 'FAIL unified publication must verify provenance exactly once before side effects\n'
 	exit 1

--- a/.agents/workflows/release.md
+++ b/.agents/workflows/release.md
@@ -45,11 +45,21 @@ contract.
 If `main` advanced after authorization, create and review a dedicated aggregation
 PR whose squash-merge commit contains `Aidevops-Release-Aggregator-PR` and one
 `Aidevops-Release-Aggregates: PR@MERGE_SHA` trailer per included source. Then
-rerun the original command. The helper accepts only an exact aggregate `main`
-tip, preserves the manifest in the signed tag, marks the aggregate PR published,
-and marks included source receipts superseded with immutable release links.
-Arbitrary descendants and unreviewed direct commits remain blocked. Full contract:
-`reference/release-publication-controls.md` "Intervening-main recovery".
+rerun the original source-PR command. If recovery instead names the aggregation
+PR itself, the resolver must still classify that exact tip as an aggregate and
+copy every reviewed source into the signed tag; it cannot fall through to direct
+mode. The helper accepts only an exact aggregate `main` tip, marks the aggregate
+PR published, and marks included source receipts superseded with immutable
+release links. Arbitrary descendants and unreviewed direct commits remain
+blocked.
+
+An already-signed tag whose aggregate list was completely omitted may recover
+the redundant list only from its signed `Aidevops-Source-Merge` commit after the
+same reviewed manifest and every included PR verify. Any explicit partial or
+conflicting tag list remains a hard failure. Recovery runs the verifier from the
+exact reviewed `main` workflow commit while package contents stay pinned to the
+immutable tag. Full contract: `reference/release-publication-controls.md`
+"Intervening-main recovery".
 
 **DO NOT** run separate bump/tag/push commands. **Prerequisites**: terminal-success PR checks/reviews, observed merged state/SHA, authenticated `gh`, an accessible aidevops repository, and unreleased changelog content (or changelog-only `--force`). The helper fetches `origin/main` and creates its own detached release worktree; it does not require or mutate a clean canonical checkout.
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -47,6 +47,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          VERIFIER=".agents/scripts/release-provenance-helper.sh"
           [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
             echo "::error::Invalid release tag: $RELEASE_TAG"
             exit 1
@@ -65,6 +66,17 @@ jobs:
               echo "::error::Recovery correlation is malformed"
               exit 1
             }
+            [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+              echo "::error::Recovery workflow commit is malformed"
+              exit 1
+            }
+            VERIFIER_WORKTREE="$RUNNER_TEMP/release-provenance-verifier"
+            git cat-file -e "${GITHUB_SHA}^{commit}" || {
+              echo "::error::Recovery workflow commit is unavailable"
+              exit 1
+            }
+            git worktree add --detach "$VERIFIER_WORKTREE" "$GITHUB_SHA"
+            VERIFIER="$VERIFIER_WORKTREE/.agents/scripts/release-provenance-helper.sh"
           else
             echo "::error::Unsupported publication event: $RELEASE_EVENT"
             exit 1
@@ -91,7 +103,7 @@ jobs:
             echo "::error::Refusing stale release $RELEASE_TAG; newest tag is ${LATEST_TAG:-unknown}"
             exit 1
           }
-          bash .agents/scripts/release-provenance-helper.sh verify \
+          bash "$VERIFIER" verify \
             --tag "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY"
 


### PR DESCRIPTION
## Summary

Preserve exact-tip aggregation manifests across immutable tags, reconstruct only fully omitted redundant tag entries from the signed source merge, discover included-source tags transitively, and run recovery verification from the exact dispatched main commit.

## Files Changed

.agents/reference/release-publication-controls.md, .agents/scripts/full-loop-release-reconcile.sh, .agents/scripts/release-provenance-helper.sh, .agents/scripts/tests/test-full-loop-release-reconcile.sh, .agents/scripts/tests/test-release-provenance-helper.sh, .agents/scripts/tests/test-release-publication-workflows.sh, .agents/workflows/release.md, .github/workflows/publish-packages.yml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused provenance, reconcile, release-helper, command, and workflow tests pass; actionlint passes; linters-local --changed passes all 12 gates; immutable v3.32.198 verifies with the corrected helper.

Resolves #28917


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.197 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h 56m and 1,228,442 tokens on this with the user in an interactive session.