### PR TITLE
GH#28919: Bind postflight to recovery publication runs

### DIFF
--- a/.agents/scripts/jq/release-owned-check-runs.jq
+++ b/.agents/scripts/jq/release-owned-check-runs.jq
@@ -8,10 +8,50 @@ def latest_by_key:
   | group_by(run_key)
   | map(max_by([run_time, (.id // 0)]));
 
-($release_run_documents
- | flatten
- | map(.workflow_runs // [])
- | add
+def workflow_runs($documents):
+  (($documents
+    | flatten
+    | map(.workflow_runs // [])
+    | add) // []);
+
+def correlated_recovery_run:
+  ($release_tag | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))
+  and (.event == "workflow_dispatch")
+  and (.path == ".github/workflows/publish-packages.yml")
+  and ((.head_sha // "") | test("^[0-9a-f]{40}$"))
+  and ((.id // null) | type == "number")
+  and ((.check_suite_id // null) | type == "number")
+  and (
+    (.name // "")
+    == ("Publish " + $release_tag + " [" + $release_sha + "." + (.head_sha // "") + "]")
+  );
+
+def recovery_check:
+  {
+    id,
+    name: "Publish GitHub, npm, and Homebrew",
+    status,
+    conclusion,
+    completed_at: (
+      if .status == "completed"
+      then (.updated_at // .run_started_at // .created_at)
+      else null
+      end
+    ),
+    started_at: .run_started_at,
+    created_at,
+    updated_at,
+    check_suite: {id: .check_suite_id},
+    app: {slug: "github-actions"},
+    recovery_workflow_run_id: .id
+  };
+
+(workflow_runs($release_run_documents)) as $release_workflow_runs
+|
+(workflow_runs($recovery_run_documents)
+ | map(select(correlated_recovery_run))) as $correlated_recovery_runs
+|
+($release_workflow_runs
  | map(
      select(.head_sha == $release_sha)
      | select(.event == "push" or .event == "release" or .event == "workflow_dispatch")
@@ -20,10 +60,7 @@ def latest_by_key:
  | map(select(. != null))
  | unique) as $release_suite_ids
 |
-($release_run_documents
- | flatten
- | map(.workflow_runs // [])
- | add
+($release_workflow_runs
  | map(
      select(.head_sha == $release_sha)
      | select((.event == "push" or .event == "release" or .event == "workflow_dispatch") | not)
@@ -34,11 +71,14 @@ def latest_by_key:
 |
 {
   check_runs: (
-    [
-      .check_runs[]?
-      | select(.name != $self_name)
-      | select(.check_suite.id as $suite_id | $release_suite_ids | index($suite_id))
-    ]
+    (
+      [
+        .check_runs[]?
+        | select(.name != $self_name)
+        | select(.check_suite.id as $suite_id | $release_suite_ids | index($suite_id))
+      ]
+      + ($correlated_recovery_runs | map(recovery_check))
+    )
     | latest_by_key
   ),
   advisory_check_runs: (
@@ -50,5 +90,9 @@ def latest_by_key:
     ]
     | latest_by_key
   ),
-  unrelated_workflow_runs: $unrelated_workflow_runs
+  unrelated_workflow_runs: $unrelated_workflow_runs,
+  recovery_workflow_runs: (
+    $correlated_recovery_runs
+    | map({id, name, event, head_sha, status, conclusion, check_suite_id})
+  )
 }

--- a/.agents/scripts/postflight-check.sh
+++ b/.agents/scripts/postflight-check.sh
@@ -134,16 +134,26 @@ get_repo_info() {
 load_release_owned_checks() {
 	local repo="$1"
 	local release_sha="$2"
-	local check_runs_response release_runs_response
+	local release_tag="${POSTFLIGHT_RELEASE_TAG:-}"
+	local check_runs_response release_runs_response recovery_runs_response
 	check_runs_response=$(gh api --paginate --slurp \
 		"repos/${repo}/commits/${release_sha}/check-runs?per_page=100" 2>/dev/null |
 		jq -c -f "$SCRIPT_DIR/jq/flatten-check-run-pages.jq") || return 1
 	release_runs_response=$(gh api --paginate --slurp \
 		"repos/${repo}/actions/runs?head_sha=${release_sha}&per_page=100" 2>/dev/null) || return 1
+	if [[ -n "$release_tag" ]]; then
+		recovery_runs_response=$(gh api --paginate --slurp \
+			"repos/${repo}/actions/workflows/publish-packages.yml/runs?event=workflow_dispatch&per_page=100" \
+			2>/dev/null) || return 1
+	else
+		recovery_runs_response='{"workflow_runs":[]}'
+	fi
 	jq -c \
 		--arg release_sha "$release_sha" \
+		--arg release_tag "$release_tag" \
 		--arg self_name "Verify Release Health" \
 		--slurpfile release_run_documents <(printf '%s\n' "$release_runs_response") \
+		--slurpfile recovery_run_documents <(printf '%s\n' "$recovery_runs_response") \
 		-f "$SCRIPT_DIR/jq/release-owned-check-runs.jq" \
 		<<<"$check_runs_response"
 	return $?

--- a/.agents/scripts/tests/fixtures/postflight-recovery-workflow-runs.json
+++ b/.agents/scripts/tests/fixtures/postflight-recovery-workflow-runs.json
@@ -1,0 +1,50 @@
+{
+  "workflow_runs": [
+    {
+      "id": 1101,
+      "name": "Publish v1.2.3 [release-sha.1111111111111111111111111111111111111111]",
+      "event": "workflow_dispatch",
+      "path": ".github/workflows/publish-packages.yml",
+      "head_sha": "1111111111111111111111111111111111111111",
+      "check_suite_id": 601,
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-07-13T20:04:00Z",
+      "run_started_at": "2026-07-13T20:04:10Z",
+      "updated_at": "2026-07-13T20:05:00Z"
+    },
+    {
+      "id": 1102,
+      "name": "Publish v9.9.9 [release-sha.2222222222222222222222222222222222222222]",
+      "event": "workflow_dispatch",
+      "path": ".github/workflows/publish-packages.yml",
+      "head_sha": "2222222222222222222222222222222222222222",
+      "check_suite_id": 602,
+      "status": "completed",
+      "conclusion": "failure",
+      "updated_at": "2026-07-13T20:06:00Z"
+    },
+    {
+      "id": 1103,
+      "name": "Publish v1.2.3 [release-sha.3333333333333333333333333333333333333333]",
+      "event": "workflow_dispatch",
+      "path": ".github/workflows/publish-packages.yml",
+      "head_sha": "4444444444444444444444444444444444444444",
+      "check_suite_id": 603,
+      "status": "completed",
+      "conclusion": "failure",
+      "updated_at": "2026-07-13T20:07:00Z"
+    },
+    {
+      "id": 1104,
+      "name": "Publish v1.2.3 [release-sha.5555555555555555555555555555555555555555]",
+      "event": "workflow_dispatch",
+      "path": ".github/workflows/untrusted.yml",
+      "head_sha": "5555555555555555555555555555555555555555",
+      "check_suite_id": 604,
+      "status": "completed",
+      "conclusion": "failure",
+      "updated_at": "2026-07-13T20:08:00Z"
+    }
+  ]
+}

--- a/.agents/scripts/tests/fixtures/postflight-release-owned-check-runs.json
+++ b/.agents/scripts/tests/fixtures/postflight-release-owned-check-runs.json
@@ -11,9 +11,9 @@
     },
     {
       "id": 2002,
-      "name": "Publish npm package",
+      "name": "Publish GitHub, npm, and Homebrew",
       "status": "completed",
-      "conclusion": "success",
+      "conclusion": "failure",
       "completed_at": "2026-07-13T20:01:00Z",
       "check_suite": { "id": 502 },
       "app": { "slug": "github-actions" }

--- a/.agents/scripts/tests/test-postflight-release-owned-checks.sh
+++ b/.agents/scripts/tests/test-postflight-release-owned-checks.sh
@@ -7,12 +7,16 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 FILTER="${REPO_ROOT}/.agents/scripts/jq/release-owned-check-runs.jq"
 WORKFLOW_FIXTURE="${SCRIPT_DIR}/fixtures/postflight-release-workflow-runs.json"
 CHECK_FIXTURE="${SCRIPT_DIR}/fixtures/postflight-release-owned-check-runs.json"
+RECOVERY_FIXTURE="${SCRIPT_DIR}/fixtures/postflight-recovery-workflow-runs.json"
+RECOVERY_RUNS=$(jq -c . "$RECOVERY_FIXTURE")
 
 scope_checks() {
 	jq -c \
 		--arg release_sha "release-sha" \
+		--arg release_tag "v1.2.3" \
 		--arg self_name "Verify Release Health" \
 		--slurpfile release_run_documents "$WORKFLOW_FIXTURE" \
+		--slurpfile recovery_run_documents <(printf '%s\n' "$RECOVERY_RUNS") \
 		-f "$FILTER"
 	return 0
 }
@@ -21,29 +25,52 @@ SCOPED=$(scope_checks <"$CHECK_FIXTURE")
 
 jq -e '
   (.check_runs | length) == 2 and
-  all(.check_runs[]; .check_suite.id == 501 or .check_suite.id == 502) and
+  any(.check_runs[]; .name == "Framework Validation" and .check_suite.id == 501) and
+  any(.check_runs[]; .name == "Publish GitHub, npm, and Homebrew" and .recovery_workflow_run_id == 1101) and
   all(.check_runs[]; .status == "completed" and .conclusion == "success") and
   (.advisory_check_runs | length) == 1 and
   .advisory_check_runs[0].name == "Socket Security: Project Report" and
   .advisory_check_runs[0].status == "in_progress" and
   (all((.check_runs + .advisory_check_runs)[]; .name != "Verify Release Health")) and
   (.unrelated_workflow_runs | length) == 2 and
-  [.unrelated_workflow_runs[].event] == ["issues", "issue_comment"]
+  [.unrelated_workflow_runs[].event] == ["issues", "issue_comment"] and
+  (.recovery_workflow_runs | length) == 1 and
+  .recovery_workflow_runs[0].id == 1101
 ' <<<"$SCOPED" >/dev/null
 
 printf 'PASS: superseded, self, and unrelated checks do not delay successful release checks\n'
 printf 'PASS: pending external checks are classified as non-required advisories\n'
 printf 'PASS: newer unrelated issue and comment runs are reported separately\n'
+printf 'PASS: exact-tag recovery success supersedes only its earlier publication failure\n'
+printf 'PASS: malformed, other-tag, and wrong-workflow recovery identities are ignored\n'
 
 PAGINATED_SCOPED=$(jq -c \
 	--arg release_sha "release-sha" \
+	--arg release_tag "v1.2.3" \
 	--arg self_name "Verify Release Health" \
 	--slurpfile release_run_documents <(jq -s '.' "$WORKFLOW_FIXTURE") \
+	--slurpfile recovery_run_documents <(jq -s '.' "$RECOVERY_FIXTURE") \
 	-f "$FILTER" \
 	"$CHECK_FIXTURE")
 jq -e '(.check_runs | length) == 2' <<<"$PAGINATED_SCOPED" >/dev/null
 
 printf 'PASS: paginated workflow-run response retains release-owned suites\n'
+
+RECOVERY_RUNS=$(jq -c '(.workflow_runs[] | select(.id == 1101)) |= (.status = "in_progress" | .conclusion = null)' "$RECOVERY_FIXTURE")
+PENDING_RECOVERY=$(scope_checks <"$CHECK_FIXTURE")
+jq -e 'any(.check_runs[]; .name == "Publish GitHub, npm, and Homebrew" and .status == "in_progress" and .conclusion == null)' \
+	<<<"$PENDING_RECOVERY" >/dev/null
+
+printf 'PASS: matching pending recovery publication remains pending\n'
+
+RECOVERY_RUNS=$(jq -c '(.workflow_runs[] | select(.id == 1101)) |= (.conclusion = "failure")' "$RECOVERY_FIXTURE")
+FAILED_RECOVERY=$(scope_checks <"$CHECK_FIXTURE")
+jq -e 'any(.check_runs[]; .name == "Publish GitHub, npm, and Homebrew" and .status == "completed" and .conclusion == "failure")' \
+	<<<"$FAILED_RECOVERY" >/dev/null
+
+printf 'PASS: matching failed recovery publication remains blocking\n'
+
+RECOVERY_RUNS=$(jq -c . "$RECOVERY_FIXTURE")
 
 PENDING_INPUT=$(jq '(.check_runs[] | select(.id == 2001)) |= (.status = "in_progress" | .conclusion = null)' "$CHECK_FIXTURE")
 PENDING=$(scope_checks <<<"$PENDING_INPUT")
@@ -58,8 +85,12 @@ jq -e '([.check_runs[] | select(.status == "completed" and (.conclusion == "fail
 printf 'PASS: terminal release-quality failures such as Qlty remain named and blocking\n'
 
 grep -Fq "actions/runs?head_sha=\${COMMIT_SHA}&per_page=100" "${REPO_ROOT}/.github/workflows/postflight.yml"
+grep -Fq 'actions/workflows/publish-packages.yml/runs?event=workflow_dispatch&branch=main&per_page=100' "${REPO_ROOT}/.github/workflows/postflight.yml"
 grep -Fq 'release-owned-check-runs.jq' "${REPO_ROOT}/.github/workflows/postflight.yml"
 grep -Fq -- '--slurpfile release_run_documents' "${REPO_ROOT}/.github/workflows/postflight.yml"
+grep -Fq -- '--slurpfile recovery_run_documents' "${REPO_ROOT}/.github/workflows/postflight.yml"
+grep -Fq -- '--arg release_tag "$RELEASE_TAG"' "${REPO_ROOT}/.github/workflows/postflight.yml"
+grep -Fq 'RELEASE_TAG: ${{ github.event.inputs.tag || github.event.release.tag_name || github.ref_name }}' "${REPO_ROOT}/.github/workflows/postflight.yml"
 grep -Fq 'non-required advisory check(s) remain non-terminal' "${REPO_ROOT}/.github/workflows/postflight.yml"
 grep -Fq 'load_release_owned_checks' "${REPO_ROOT}/.agents/scripts/postflight-check.sh"
 grep -Fq 'unrelated issue/comment workflow run(s) excluded' "${REPO_ROOT}/.agents/scripts/postflight-check.sh"

--- a/.github/workflows/postflight.yml
+++ b/.github/workflows/postflight.yml
@@ -43,6 +43,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         REPO: ${{ github.repository }}
         COMMIT_SHA: ${{ steps.release_commit.outputs.sha }}
+        RELEASE_TAG: ${{ github.event.inputs.tag || '' }}
       run: |
         echo "Waiting for release-owned check runs to complete..."
         echo "Note: Excluding issue/comment workflows and this workflow to avoid unrelated waits"
@@ -56,10 +57,14 @@ jobs:
             | jq -c -f .agents/scripts/jq/flatten-check-run-pages.jq)
           RELEASE_RUNS_RESPONSE=$(gh api --paginate --slurp \
             "repos/${REPO}/actions/runs?head_sha=${COMMIT_SHA}&per_page=100")
+          RECOVERY_RUNS_RESPONSE=$(gh api --paginate --slurp \
+            "repos/${REPO}/actions/workflows/publish-packages.yml/runs?event=workflow_dispatch&branch=main&per_page=100")
           RELEASE_CHECK_RUNS=$(jq -c \
             --arg release_sha "$COMMIT_SHA" \
+            --arg release_tag "$RELEASE_TAG" \
             --arg self_name "$SELF_NAME" \
             --slurpfile release_run_documents <(printf '%s\n' "$RELEASE_RUNS_RESPONSE") \
+            --slurpfile recovery_run_documents <(printf '%s\n' "$RECOVERY_RUNS_RESPONSE") \
             -f .agents/scripts/jq/release-owned-check-runs.jq \
             <<<"$CHECK_RUNS_RESPONSE")
           PENDING=$(jq --arg self_name "$SELF_NAME" \
@@ -84,10 +89,14 @@ jobs:
           | jq -c -f .agents/scripts/jq/flatten-check-run-pages.jq)
         RELEASE_RUNS_RESPONSE=$(gh api --paginate --slurp \
           "repos/${REPO}/actions/runs?head_sha=${COMMIT_SHA}&per_page=100")
+        RECOVERY_RUNS_RESPONSE=$(gh api --paginate --slurp \
+          "repos/${REPO}/actions/workflows/publish-packages.yml/runs?event=workflow_dispatch&branch=main&per_page=100")
         RELEASE_CHECK_RUNS=$(jq -c \
           --arg release_sha "$COMMIT_SHA" \
+          --arg release_tag "$RELEASE_TAG" \
           --arg self_name "$SELF_NAME" \
           --slurpfile release_run_documents <(printf '%s\n' "$RELEASE_RUNS_RESPONSE") \
+          --slurpfile recovery_run_documents <(printf '%s\n' "$RECOVERY_RUNS_RESPONSE") \
           -f .agents/scripts/jq/release-owned-check-runs.jq \
           <<<"$CHECK_RUNS_RESPONSE")
         REMAINING=$(jq '[.check_runs[] | select(.status != "completed")] | length' \
@@ -112,6 +121,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         REPO: ${{ github.repository }}
         COMMIT_SHA: ${{ steps.release_commit.outputs.sha }}
+        RELEASE_TAG: ${{ github.event.inputs.tag || '' }}
       run: |
         echo "## CI/CD Pipeline Status" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
@@ -125,10 +135,14 @@ jobs:
           | jq -c -f .agents/scripts/jq/flatten-check-run-pages.jq)
         RELEASE_RUNS_RESPONSE=$(gh api --paginate --slurp \
           "repos/${REPO}/actions/runs?head_sha=${COMMIT_SHA}&per_page=100")
+        RECOVERY_RUNS_RESPONSE=$(gh api --paginate --slurp \
+          "repos/${REPO}/actions/workflows/publish-packages.yml/runs?event=workflow_dispatch&branch=main&per_page=100")
         RELEASE_CHECK_RUNS=$(jq -c \
           --arg release_sha "$COMMIT_SHA" \
+          --arg release_tag "$RELEASE_TAG" \
           --arg self_name "$SELF_NAME" \
           --slurpfile release_run_documents <(printf '%s\n' "$RELEASE_RUNS_RESPONSE") \
+          --slurpfile recovery_run_documents <(printf '%s\n' "$RECOVERY_RUNS_RESPONSE") \
           -f .agents/scripts/jq/release-owned-check-runs.jq \
           <<<"$CHECK_RUNS_RESPONSE")
         EFFECTIVE_CHECK_RUNS=$(echo "$RELEASE_CHECK_RUNS" \
@@ -258,7 +272,7 @@ jobs:
       env:
         CICD_STATUS: ${{ steps.cicd.outputs.cicd_status }}
         SONAR_STATUS: ${{ steps.sonarcloud.outputs.sonar_status }}
-        RELEASE_TAG: ${{ github.event.release.tag_name || github.ref_name }}
+        RELEASE_TAG: ${{ github.event.inputs.tag || github.event.release.tag_name || github.ref_name }}
         COMMIT_SHA: ${{ steps.release_commit.outputs.sha }}
       run: |
         echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Teach exact-tag postflight to include only correlation-bound recovery publication runs, synthesize them into the existing latest check identity, retain pending and failed recovery states, and report the explicit dispatch tag.

## Files Changed

.agents/scripts/jq/release-owned-check-runs.jq, .agents/scripts/postflight-check.sh, .agents/scripts/tests/fixtures/postflight-recovery-workflow-runs.json, .agents/scripts/tests/fixtures/postflight-release-owned-check-runs.json, .agents/scripts/tests/test-postflight-release-owned-checks.sh, .github/workflows/postflight.yml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused postflight and release workflow tests pass; actionlint, ShellCheck, Bash 3.2 parsing, and linters-local --changed pass; live read-only postflight against v3.32.198 now reports 18 required checks passed.

Resolves #28919


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 2h 43m and 1,415,585 tokens on this with the user in an interactive session.