### PR TITLE
GH#28860: Prevent TODO-sync workspace disk exhaustion

### DIFF
--- a/.agents/scripts/pulse-temp-helper.sh
+++ b/.agents/scripts/pulse-temp-helper.sh
@@ -57,6 +57,8 @@ aidevops_pulse_worker_log_candidates() {
 aidevops_pulse_tmp_cleanup() {
 	local max_age_minutes="${1:-2880}"
 	local root=""
+	local helper=""
+	local temp_root=""
 	[[ "$max_age_minutes" =~ ^[0-9]+$ ]] || max_age_minutes=2880
 	root=$(aidevops_pulse_tmp_root) || return 0
 	# Best-effort cleanup with exact minutes on macOS/Linux. Files currently open
@@ -85,6 +87,15 @@ for name in os.listdir(root):
     except OSError:
         pass
 PY
+	fi
+	helper="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/pulse-todo-sync-workspace.sh"
+	if [[ -f "$helper" ]]; then
+		# shellcheck source=pulse-todo-sync-workspace.sh
+		source "$helper"
+		temp_root="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+		AIDEVOPS_TEMP_DIR="$temp_root" \
+			PULSE_TODO_SYNC_STALE_CLEANUP_MODE="${PULSE_TODO_SYNC_STALE_CLEANUP_MODE:-delete}" \
+			_ptsw_sweep_stale_workspaces >/dev/null || true
 	fi
 	return 0
 }

--- a/.agents/scripts/pulse-todo-sync-workspace.sh
+++ b/.agents/scripts/pulse-todo-sync-workspace.sh
@@ -28,6 +28,12 @@ _PULSE_TODO_SYNC_WORKSPACE=""
 _PULSE_TODO_SYNC_WORKSPACE_ROOT=""
 _PULSE_TODO_SYNC_OWNER_PID=""
 _PULSE_TODO_SYNC_OWNER_START=""
+_PTSW_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || _PTSW_SCRIPT_DIR=""
+
+if ! declare -F _file_mtime_epoch >/dev/null 2>&1 && [[ -f "${_PTSW_SCRIPT_DIR}/portable-stat.sh" ]]; then
+	# shellcheck source=portable-stat.sh
+	source "${_PTSW_SCRIPT_DIR}/portable-stat.sh"
+fi
 
 _ptsw_process_start_fingerprint() {
 	local process_pid="$1"
@@ -323,15 +329,78 @@ _ptsw_move_to_recoverable_trash() {
 	return 0
 }
 
+_ptsw_remove_stale_workspace() {
+	local workspace_root="$1"
+	local identity="$2"
+	local mode="${PULSE_TODO_SYNC_STALE_CLEANUP_MODE:-delete}"
+	case "$mode" in
+	delete | direct)
+		_ptsw_validate_workspace_path "$workspace_root" 1 || return 1
+		rm -rf "$workspace_root" 2>/dev/null || return 1
+		[[ ! -e "$workspace_root" && ! -L "$workspace_root" ]] || return 1
+		_PTSW_REMOVE_MODE="delete"
+		return 0
+		;;
+	trash | recoverable)
+		_ptsw_move_to_recoverable_trash "$workspace_root" "$identity" || return 1
+		_PTSW_REMOVE_MODE="trash"
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+_ptsw_count_workspace_candidates() {
+	local temp_root="$1"
+	local count=0
+	local workspace_root=""
+	for workspace_root in "$temp_root"/pulse-todo-sync.*; do
+		[[ -e "$workspace_root" || -L "$workspace_root" ]] || continue
+		count=$((count + 1))
+	done
+	printf '%s\n' "$count"
+	return 0
+}
+
+_ptsw_temp_root_usage_kib() {
+	local temp_root="$1"
+	local usage=""
+	usage=$(du -sk "$temp_root" 2>/dev/null | awk '{print $1}') || return 1
+	[[ "$usage" =~ ^[0-9]+$ ]] || return 1
+	printf '%s\n' "$usage"
+	return 0
+}
+
+_ptsw_effective_recovery_cap() {
+	local temp_root="$1"
+	local configured_cap="$2"
+	local count_threshold="${PULSE_TODO_SYNC_PRESSURE_COUNT_THRESHOLD:-50}"
+	local size_threshold_mib="${PULSE_TODO_SYNC_PRESSURE_MIB_THRESHOLD:-10240}"
+	local candidate_count=0
+	local usage_kib=0
+	local size_threshold_kib=0
+	[[ "$configured_cap" =~ ^[1-9][0-9]*$ ]] || configured_cap=50
+	[[ "$count_threshold" =~ ^[1-9][0-9]*$ ]] || count_threshold=50
+	[[ "$size_threshold_mib" =~ ^[1-9][0-9]*$ ]] || size_threshold_mib=10240
+	candidate_count=$(_ptsw_count_workspace_candidates "$temp_root") || candidate_count=0
+	usage_kib=$(_ptsw_temp_root_usage_kib "$temp_root") || usage_kib=0
+	size_threshold_kib=$((size_threshold_mib * 1024))
+	if [[ "$candidate_count" -gt "$configured_cap" && "$candidate_count" -ge "$count_threshold" ]]; then
+		configured_cap="$candidate_count"
+	elif [[ "$usage_kib" -ge "$size_threshold_kib" && "$candidate_count" -gt "$configured_cap" ]]; then
+		configured_cap="$candidate_count"
+	fi
+	printf '%s\n' "$configured_cap"
+	return 0
+}
+
 _ptsw_workspace_mtime_epoch() {
 	local workspace_root="$1"
 	local mtime_epoch=""
-	if declare -F _file_mtime_epoch >/dev/null 2>&1; then
-		mtime_epoch=$(_file_mtime_epoch "$workspace_root" 2>/dev/null) || mtime_epoch=""
-	else
-		mtime_epoch=$(stat -f '%m' "$workspace_root" 2>/dev/null \
-			|| stat -c '%Y' "$workspace_root" 2>/dev/null) || mtime_epoch=""
-	fi
+	declare -F _file_mtime_epoch >/dev/null 2>&1 || return 1
+	mtime_epoch=$(_file_mtime_epoch "$workspace_root" 2>/dev/null) || mtime_epoch=""
 	[[ "$mtime_epoch" =~ ^[1-9][0-9]*$ ]] || return 1
 	printf '%s\n' "$mtime_epoch"
 	return 0
@@ -420,8 +489,8 @@ _ptsw_classify_legacy_workspace_activity() {
 	local workspace_root="$1"
 	_PTSW_LEGACY_ACTIVITY_STATE="$_PTSW_STATE_UNKNOWN"
 	[[ "$_PTSW_LEGACY_SNAPSHOTS_READY" == "1" ]] || _ptsw_capture_legacy_process_snapshots
-	if _ptsw_cwd_snapshot_contains_workspace "$workspace_root" \
-		|| _ptsw_command_snapshot_contains_workspace "$workspace_root"; then
+	if _ptsw_cwd_snapshot_contains_workspace "$workspace_root" ||
+		_ptsw_command_snapshot_contains_workspace "$workspace_root"; then
 		_PTSW_LEGACY_ACTIVITY_STATE="active"
 		return 0
 	fi
@@ -492,11 +561,47 @@ _ptsw_migrate_legacy_workspace() {
 	return 1
 }
 
+_ptsw_sweep_zero() {
+	printf '0\n'
+	return 0
+}
+
+_ptsw_remove_dead_owner_workspace() {
+	local workspace_root="$1"
+	local identity="$2"
+	local age_secs="$3"
+	local owner_pid="$4"
+	local owner_start="$5"
+	local owner_created="$6"
+	local owner_detail="owner_pid=${owner_pid}"
+	local remove_mode=""
+	# Recheck the mutable ownership record immediately before removal.
+	if ! _ptsw_validate_workspace_path "$workspace_root" 1 ||
+		! _ptsw_read_owner_marker "$workspace_root" ||
+		[[ "$_PTSW_OWNER_PID" != "$owner_pid" || "$_PTSW_OWNER_START" != "$owner_start" ||
+			"$_PTSW_OWNER_CREATED" != "$owner_created" ]]; then
+		_ptsw_log_sweep_outcome "$_PTSW_OUTCOME_SKIPPED" "owner-marker-changed" "$identity"
+		return 1
+	fi
+	_ptsw_classify_owner "$owner_pid" "$owner_start"
+	if [[ "$_PTSW_OWNER_STATE" != "$_PTSW_OWNER_STALE" ]]; then
+		_ptsw_log_sweep_outcome "$_PTSW_OUTCOME_SKIPPED" "owner-state-changed" "$identity"
+		return 1
+	fi
+	if _ptsw_remove_stale_workspace "$workspace_root" "$identity"; then
+		remove_mode="${_PTSW_REMOVE_MODE:-unknown}"
+		_ptsw_log_sweep_outcome "removed" "dead-owner" "$identity" "age=${age_secs}s owner_pid=${owner_pid} mode=${remove_mode}"
+		return 0
+	fi
+	_ptsw_log_sweep_outcome "failure" "stale-remove-failed" "$identity" "$owner_detail"
+	return 1
+}
+
 _ptsw_sweep_stale_workspaces() {
 	local temp_root=""
 	local now_epoch=""
 	local grace_secs=""
-	local max_recoveries="${PULSE_TODO_SYNC_MAX_RECOVERIES_PER_RUN:-5}"
+	local max_recoveries="${PULSE_TODO_SYNC_MAX_RECOVERIES_PER_RUN:-50}"
 	local workspace_root=""
 	local identity=""
 	local safe_identity=""
@@ -506,17 +611,19 @@ _ptsw_sweep_stale_workspaces() {
 	local owner_start=""
 	local owner_created=""
 	local owner_detail=""
-	[[ "$max_recoveries" =~ ^[1-9][0-9]*$ ]] || max_recoveries=5
+	_PTSW_REMOVE_MODE=""
+	[[ "$max_recoveries" =~ ^[1-9][0-9]*$ ]] || max_recoveries=50
 	temp_root=$(_ptsw_resolve_temp_root 0) || {
-		printf '0\n'
+		_ptsw_sweep_zero
 		return 0
 	}
+	max_recoveries=$(_ptsw_effective_recovery_cap "$temp_root" "$max_recoveries") || max_recoveries=50
 	now_epoch=$(date +%s 2>/dev/null) || {
-		printf '0\n'
+		_ptsw_sweep_zero
 		return 0
 	}
 	grace_secs=$(_ptsw_workspace_grace_secs) || {
-		printf '0\n'
+		_ptsw_sweep_zero
 		return 0
 	}
 	_PTSW_LEGACY_SNAPSHOTS_READY=0
@@ -525,8 +632,8 @@ _ptsw_sweep_stale_workspaces() {
 		[[ -e "$workspace_root" || -L "$workspace_root" ]] || continue
 		safe_identity=$(_ptsw_safe_identity "$workspace_root")
 		if ! _ptsw_validate_workspace_path "$workspace_root" 1; then
-			if [[ "$_PTSW_VALIDATION_REASON" == "$_PTSW_REASON_MISSING_OWNER_MARKER" ]] \
-				&& _ptsw_migrate_legacy_workspace "$workspace_root" "$safe_identity" "$now_epoch" "$legacy_migrated"; then
+			if [[ "$_PTSW_VALIDATION_REASON" == "$_PTSW_REASON_MISSING_OWNER_MARKER" ]] &&
+				_ptsw_migrate_legacy_workspace "$workspace_root" "$safe_identity" "$now_epoch" "$legacy_migrated"; then
 				legacy_migrated=$((legacy_migrated + 1))
 				removed=$((removed + 1))
 				continue
@@ -568,25 +675,9 @@ _ptsw_sweep_stale_workspaces() {
 			_ptsw_log_sweep_outcome "$_PTSW_OUTCOME_SKIPPED" "recovery-cap" "$identity" "cap=${max_recoveries}"
 			continue
 		fi
-		# Recheck the mutable ownership record immediately before the move.
-		if ! _ptsw_validate_workspace_path "$workspace_root" 1 ||
-			! _ptsw_read_owner_marker "$workspace_root" ||
-			[[ "$_PTSW_OWNER_PID" != "$owner_pid" || "$_PTSW_OWNER_START" != "$owner_start" ||
-				"$_PTSW_OWNER_CREATED" != "$owner_created" ]]; then
-			_ptsw_log_sweep_outcome "$_PTSW_OUTCOME_SKIPPED" "owner-marker-changed" "$identity"
-			continue
-		fi
-		_ptsw_classify_owner "$owner_pid" "$owner_start"
-		if [[ "$_PTSW_OWNER_STATE" != "$_PTSW_OWNER_STALE" ]]; then
-			_ptsw_log_sweep_outcome "$_PTSW_OUTCOME_SKIPPED" "owner-state-changed" "$identity"
-			continue
-		fi
-		if _ptsw_move_to_recoverable_trash "$workspace_root" "$identity"; then
+		if _ptsw_remove_dead_owner_workspace "$workspace_root" "$identity" "$age_secs" "$owner_pid" "$owner_start" "$owner_created"; then
 			marked_removed=$((marked_removed + 1))
 			removed=$((removed + 1))
-			_ptsw_log_sweep_outcome "removed" "dead-owner" "$identity" "age=${age_secs}s owner_pid=${owner_pid} mode=trash"
-		else
-			_ptsw_log_sweep_outcome "failure" "trash-move-failed" "$identity" "$owner_detail"
 		fi
 	done
 	printf '%s\n' "$removed"

--- a/.agents/scripts/tests/test-pulse-todo-sync-stale-cleanup.sh
+++ b/.agents/scripts/tests/test-pulse-todo-sync-stale-cleanup.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${TEST_DIR}/.."
+TEST_ROOT="$(mktemp -d)"
+
+cleanup() {
+	rm -rf "$TEST_ROOT" 2>/dev/null || true
+	return 0
+}
+trap cleanup EXIT
+
+export HOME="${TEST_ROOT}/home"
+export AIDEVOPS_TEMP_DIR="${TEST_ROOT}/tmp"
+export WRAPPER_LOGFILE="${TEST_ROOT}/pulse-wrapper.log"
+export LOGFILE="$WRAPPER_LOGFILE"
+mkdir -p "$HOME" "$AIDEVOPS_TEMP_DIR"
+: >"$WRAPPER_LOGFILE"
+
+# shellcheck source=../pulse-todo-sync-workspace.sh
+source "${SCRIPTS_DIR}/pulse-todo-sync-workspace.sh"
+
+make_workspace() {
+	local name="$1"
+	local owner_pid="$2"
+	local owner_start="$3"
+	local owner_created="$4"
+	local workspace="${AIDEVOPS_TEMP_DIR}/${name}"
+	mkdir -p "${workspace}/repo/.git"
+	printf '%s\t%s\t%s\t%s\n' "$_PTSW_MARKER_VERSION" "$owner_pid" "$owner_created" "$owner_start" >"${workspace}/${_PTSW_OWNER_MARKER}"
+	printf '%s\n' "$workspace"
+	return 0
+}
+
+old_epoch=$(($(date +%s) - 7200))
+active_start=$(_ptsw_process_start_fingerprint "$$")
+
+for index in 1 2 3 4 5 6 7; do
+	make_workspace "pulse-todo-sync.AAAA${index}${index}" "999999" "dead-${index}" "$old_epoch" >/dev/null
+done
+make_workspace "pulse-todo-sync.ZZZZZZ" "$$" "$active_start" "$old_epoch" >/dev/null
+mkdir -p "${AIDEVOPS_TEMP_DIR}/pulse-todo-sync.BADBAD/repo/.git"
+
+export PULSE_TODO_SYNC_MAX_RECOVERIES_PER_RUN=5
+export PULSE_TODO_SYNC_PRESSURE_COUNT_THRESHOLD=6
+export PULSE_TODO_SYNC_STALE_CLEANUP_MODE=delete
+removed=$(_ptsw_sweep_stale_workspaces)
+
+[[ "$removed" -eq 7 ]] || {
+	printf 'FAIL expected dynamic cleanup to remove 7 stale workspaces, got %s\n' "$removed" >&2
+	exit 1
+}
+[[ -d "${AIDEVOPS_TEMP_DIR}/pulse-todo-sync.ZZZZZZ" ]] || {
+	printf 'FAIL active owner workspace was removed\n' >&2
+	exit 1
+}
+[[ -d "${AIDEVOPS_TEMP_DIR}/pulse-todo-sync.BADBAD" ]] || {
+	printf 'FAIL markerless legacy workspace should not be direct-deleted\n' >&2
+	exit 1
+}
+if compgen -G "${AIDEVOPS_TEMP_DIR}/pulse-todo-sync.AAAA*" >/dev/null; then
+	printf 'FAIL stale dead-owner workspaces remain\n' >&2
+	exit 1
+fi
+grep -q 'mode=delete' "$WRAPPER_LOGFILE" || {
+	printf 'FAIL cleanup log did not record direct delete mode\n' >&2
+	exit 1
+}
+
+printf 'PASS TODO-sync stale cleanup scales under pressure and preserves active/legacy workspaces\n'

--- a/.agents/scripts/tests/test-pulse-worker-temp-dir.sh
+++ b/.agents/scripts/tests/test-pulse-worker-temp-dir.sh
@@ -105,6 +105,18 @@ PY
 	return 0
 }
 
+test_cleanup_sweeps_stale_todo_sync_workspace() {
+	local workspace="${HOME}/.aidevops/.agent-workspace/tmp/pulse-todo-sync.STALE1"
+	local marker="${workspace}/.aidevops-pulse-todo-sync-owner"
+	local old_epoch=0
+	old_epoch=$(($(date +%s) - 7200))
+	mkdir -p "${workspace}/repo/.git"
+	printf '%s\t%s\t%s\t%s\n' "v1" "999999" "$old_epoch" "dead-owner" >"$marker"
+	aidevops_pulse_tmp_cleanup 60
+	[[ ! -e "$workspace" && ! -L "$workspace" ]] || return 1
+	return 0
+}
+
 main() {
 	setup
 	if test_fallback_home_workspace; then record "fallback home pulse tmp" 0; else record "fallback home pulse tmp" 1; fi
@@ -112,6 +124,7 @@ main() {
 	if test_override_wins; then record "override wins" 0; else record "override wins" 1; fi
 	if test_worker_log_setup_uses_per_user_dir; then record "worker log setup avoids global tmp" 0; else record "worker log setup avoids global tmp" 1; fi
 	if test_cleanup_removes_only_old_pulse_logs; then record "cleanup removes old pulse logs" 0; else record "cleanup removes old pulse logs" 1; fi
+	if test_cleanup_sweeps_stale_todo_sync_workspace; then record "cleanup sweeps stale TODO-sync workspaces" 0; else record "cleanup sweeps stale TODO-sync workspaces" 1; fi
 	teardown
 	printf '\nPassed: %s, Failed: %s\n' "$PASS" "$FAIL"
 	[[ "$FAIL" -eq 0 ]] || return 1


### PR DESCRIPTION
## Summary
- Adds safe direct-delete cleanup for stale marker-owned pulse TODO-sync workspaces after owner/process revalidation.
- Dynamically raises the stale recovery cap when workspace count or temp-root size indicates disk pressure.
- Wires recurring pulse temp cleanup to sweep stale TODO-sync clone workspaces in the aidevops user temp root.
- Adds regression coverage for scaled cleanup, active-owner preservation, markerless legacy preservation, and recurring cleanup wiring.

## Testing
- .agents/scripts/tests/test-pulse-todo-sync-stale-cleanup.sh
- bash .agents/scripts/tests/test-pulse-todo-sync-parallel.sh
- .agents/scripts/tests/test-pulse-worker-temp-dir.sh
- .agents/scripts/tests/test-config-helper-tmp-home.sh
- shellcheck .agents/scripts/pulse-todo-sync-workspace.sh .agents/scripts/pulse-temp-helper.sh .agents/scripts/tests/test-pulse-todo-sync-stale-cleanup.sh .agents/scripts/tests/test-pulse-worker-temp-dir.sh
- .agents/scripts/linters-local.sh
- bun run typecheck

Resolves #28860

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.5 spent 16m and 180,384 tokens on this with the user in an interactive session.