### PR TITLE
t18184: Fix status-label reconciliation and REST issue edit array safety

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -594,6 +594,207 @@ _rest_pr_comment() {
 }
 
 #######################################
+# Return success when one exact value occurs in a newline-separated set.
+_rest_lines_contain() {
+	local values="$1"
+	local expected="$2"
+	local value=""
+	while IFS= read -r value; do
+		[[ -n "$value" && "$value" == "$expected" ]] && return 0
+	done <<<"$values"
+	return 1
+}
+
+#######################################
+# Filter requested issue-edit deltas against a validated current set. Adds emit
+# only absent values. Removes emit only present values and exclude requested
+# adds so add wins, matching the existing full-array computation.
+_rest_filter_issue_deltas() {
+	local current="$1"
+	local candidates="$2"
+	local excluded="$3"
+	local mode="$4"
+	local candidate=""
+	local emitted=""
+	while IFS= read -r candidate; do
+		[[ -n "$candidate" ]] || continue
+		_rest_lines_contain "$emitted" "$candidate" && continue
+		if [[ "$mode" == "add" ]]; then
+			_rest_lines_contain "$current" "$candidate" && continue
+		else
+			_rest_lines_contain "$current" "$candidate" || continue
+			_rest_lines_contain "$excluded" "$candidate" && continue
+		fi
+		printf '%s\n' "$candidate"
+		emitted="${emitted}${emitted:+$'\n'}${candidate}"
+	done <<<"$candidates"
+	return 0
+}
+
+#######################################
+# Return success only when the issue snapshot has structurally valid label and
+# assignee arrays. Delta mutations must never start from unknown current state.
+_REST_ISSUE_JSON_STRING_TYPE=string
+_rest_issue_delta_snapshot_valid() {
+	local current_json="$1"
+	local array_type="array"
+	local object_type="object"
+	printf '%s' "$current_json" | jq -e \
+		--arg array_type "$array_type" --arg object_type "$object_type" \
+		--arg string_type "$_REST_ISSUE_JSON_STRING_TYPE" '
+		((.labels | type) == $array_type) and
+		(all(.labels[]; (type == $object_type) and ((.name | type) == $string_type) and ((.name | length) > 0))) and
+		((.assignees | type) == $array_type) and
+		(all(.assignees[]; (type == $object_type) and ((.login | type) == $string_type) and ((.login | length) > 0)))
+	' >/dev/null 2>&1
+	return $?
+}
+
+#######################################
+# Apply one add/remove array operation through a targeted GitHub REST endpoint.
+_rest_issue_apply_array_delta() {
+	local method="$1"
+	local path="$2"
+	local field="$3"
+	local values="$4"
+	[[ -n "$values" ]] || return 0
+	local -a api_args=(-X "$method" "$path")
+	local value=""
+	while IFS= read -r value; do
+		[[ -n "$value" ]] && api_args+=(-f "${field}[]=${value}")
+	done <<<"$values"
+	_rest_api_call write gh api "${api_args[@]}" >/dev/null 2>&1
+	local rc=$?
+	[[ $rc -eq 0 ]] && _REST_ISSUE_DELTA_MUTATED=1
+	return $rc
+}
+
+#######################################
+# Remove exact labels through per-label REST endpoints so concurrent unrelated
+# additions are never submitted in a stale replacement array.
+_rest_issue_remove_label_deltas() {
+	local issue_path="$1"
+	local label_values="$2"
+	local label=""
+	local encoded=""
+	while IFS= read -r label; do
+		[[ -n "$label" ]] || continue
+		encoded=$(printf '%s' "$label" | jq -sRr '@uri') || return 1
+		_rest_api_call write gh api -X DELETE "${issue_path}/labels/${encoded}" >/dev/null 2>&1 || return 1
+		_REST_ISSUE_DELTA_MUTATED=1
+	done <<<"$label_values"
+	return 0
+}
+
+#######################################
+# Apply filtered deltas in the phase-specific safe order. Passthrough metadata
+# adds first so a rejected replacement leaves existing values intact. Managed
+# status transitions remove first so a failed target add cannot create a dual
+# status state.
+_rest_issue_apply_delta_plan() {
+	local issue_path="$1"
+	local adds_l="$2"
+	local rms_l="$3"
+	local adds_a="$4"
+	local rms_a="$5"
+	local delta_order="$6"
+	if [[ "$delta_order" == "remove-first" ]]; then
+		_rest_issue_remove_label_deltas "$issue_path" "$rms_l" || return 1
+		_rest_issue_apply_array_delta DELETE "${issue_path}/assignees" assignees "$rms_a" || return 1
+		_rest_issue_apply_array_delta POST "${issue_path}/labels" labels "$adds_l" || return 1
+		_rest_issue_apply_array_delta POST "${issue_path}/assignees" assignees "$adds_a" || return 1
+		return 0
+	fi
+	_rest_issue_apply_array_delta POST "${issue_path}/labels" labels "$adds_l" || return 1
+	_rest_issue_apply_array_delta POST "${issue_path}/assignees" assignees "$adds_a" || return 1
+	_rest_issue_remove_label_deltas "$issue_path" "$rms_l" || return 1
+	_rest_issue_apply_array_delta DELETE "${issue_path}/assignees" assignees "$rms_a" || return 1
+	return 0
+}
+
+#######################################
+# Apply label and assignee deltas without full-array replacement. One validated
+# GET filters no-op requests; targeted subresource writes then preserve any
+# unrelated value added concurrently after that snapshot.
+_rest_issue_edit_preserving_deltas() {
+	gh_record_call rest _rest_issue_edit_preserving_deltas 2>/dev/null || true
+	_REST_ISSUE_DELTA_FAILURE_STAGE="parse"
+	_REST_ISSUE_DELTA_MUTATED=0
+	local num_or_url="${1:-}"
+	shift || true
+	local repo=""
+	local delta_order="add-first"
+	local -a delta_add_labels=() delta_rm_labels=() delta_add_assignees=() delta_rm_assignees=()
+	local arg="" value="" token=""
+	while [[ $# -gt 0 ]]; do
+		arg="$1"
+		[[ "$arg" == *=* ]] && { value="${arg#*=}"; arg="${arg%%=*}"; shift; } || { value="${2:-}"; shift 2; }
+		case "$arg" in
+		--repo) repo="$value" ;;
+		--delta-order)
+			[[ "$value" == "add-first" || "$value" == "remove-first" ]] || return 1
+			delta_order="$value"
+			;;
+		--add-label) while IFS= read -r token; do [[ -n "$token" ]] && delta_add_labels+=("$token"); done < <(_rest_split_csv "$value") ;;
+		--remove-label) while IFS= read -r token; do [[ -n "$token" ]] && delta_rm_labels+=("$token"); done < <(_rest_split_csv "$value") ;;
+		--add-assignee) while IFS= read -r token; do [[ -n "$token" ]] && delta_add_assignees+=("$token"); done < <(_rest_split_csv "$value") ;;
+		--remove-assignee) while IFS= read -r token; do [[ -n "$token" ]] && delta_rm_assignees+=("$token"); done < <(_rest_split_csv "$value") ;;
+		*) return 1 ;;
+		esac
+	done
+	local num=""
+	{ read -r repo; read -r num; } < <(_rest_normalize_issue_ref "$num_or_url" "$repo")
+	[[ -n "$repo" && "$num" =~ ^[0-9]+$ ]] || return 1
+
+	_REST_ISSUE_DELTA_FAILURE_STAGE="snapshot"
+	local issue_path="/repos/${repo}/issues"
+	issue_path="${issue_path}/${num}"
+	local current_json="" current_labels="" current_assignees=""
+	current_json=$(_rest_api_call read gh api "$issue_path" 2>/dev/null) || return 1
+	_rest_issue_delta_snapshot_valid "$current_json" || return 1
+	current_labels=$(printf '%s' "$current_json" | jq -r '.labels[].name') || return 1
+	current_assignees=$(printf '%s' "$current_json" | jq -r '.assignees[].login') || return 1
+
+	local adds_l="" rms_l="" adds_a="" rms_a=""
+	adds_l=$(_rest_filter_issue_deltas "$current_labels" "$(printf '%s\n' "${delta_add_labels[@]}")" "" add) || return 1
+	rms_l=$(_rest_filter_issue_deltas "$current_labels" "$(printf '%s\n' "${delta_rm_labels[@]}")" "$(printf '%s\n' "${delta_add_labels[@]}")" remove) || return 1
+	adds_a=$(_rest_filter_issue_deltas "$current_assignees" "$(printf '%s\n' "${delta_add_assignees[@]}")" "" add) || return 1
+	rms_a=$(_rest_filter_issue_deltas "$current_assignees" "$(printf '%s\n' "${delta_rm_assignees[@]}")" "$(printf '%s\n' "${delta_add_assignees[@]}")" remove) || return 1
+
+	_REST_ISSUE_DELTA_FAILURE_STAGE="mutation"
+	_rest_issue_apply_delta_plan "$issue_path" "$adds_l" "$rms_l" "$adds_a" "$rms_a" "$delta_order" || return 1
+	_REST_ISSUE_DELTA_FAILURE_STAGE=""
+	return 0
+}
+
+#######################################
+# Build full-array PATCH flags from one validated current-issue snapshot.
+# Args: $1=issue_path, then newline-separated add/remove sets for labels and
+# assignees. Prints tab-separated flag/value pairs.
+_rest_issue_edit_array_flags() {
+	local issue_path="$1"
+	local add_labels="$2"
+	local rm_labels="$3"
+	local add_assignees="$4"
+	local rm_assignees="$5"
+	local current_json=""
+	current_json=$(_rest_api_call read gh api "$issue_path" 2>/dev/null) || return 1
+
+	local flags=""
+	if [[ -n "${add_labels}${rm_labels}" ]]; then
+		flags=$(_rest_print_patch_array_flags "$current_json" "labels" "name" \
+			"$add_labels" "$rm_labels") || return 1
+		printf '%s\n' "$flags"
+	fi
+	if [[ -n "${add_assignees}${rm_assignees}" ]]; then
+		flags=$(_rest_print_patch_array_flags "$current_json" "assignees" "login" \
+			"$add_assignees" "$rm_assignees") || return 1
+		printf '%s\n' "$flags"
+	fi
+	return 0
+}
+
+#######################################
 # _rest_issue_edit: PATCH /repos/{owner}/{repo}/issues/{N}.
 # Handles --title, --body, --body-file, --add-label, --remove-label,
 # --add-assignee, --remove-assignee, --milestone, --state. REST PATCH
@@ -621,7 +822,6 @@ _rest_issue_edit() {
 	rm_labels=()
 	add_assignees=()
 	rm_assignees=()
-
 	local _first="${1:-}"
 	if [[ $# -gt 0 && "$_first" != --* ]]; then
 		num_or_url="$_first"
@@ -645,7 +845,6 @@ _rest_issue_edit() {
 		*) : ;;
 		esac
 	done
-
 	local num=""
 	{ read -r repo; read -r num; } < <(_rest_normalize_issue_ref "$num_or_url" "$repo")
 
@@ -664,6 +863,27 @@ _rest_issue_edit() {
 	[[ $has_milestone -eq 1 ]] && api_args+=(-F "milestone=${milestone:-null}")
 	[[ $has_state -eq 1 ]] && api_args+=(-f "state=${state}")
 
+	# Labels and assignees: fetch current issue state once, validate both arrays,
+	# and translate deltas into the complete arrays REST PATCH requires.
+	local _array_flags=""
+	if [[ ${#add_labels[@]} -gt 0 || ${#rm_labels[@]} -gt 0 ]]; then
+		_array_flags="labels"
+	fi
+	if [[ ${#add_assignees[@]} -gt 0 || ${#rm_assignees[@]} -gt 0 ]]; then
+		_array_flags="${_array_flags}assignees"
+	fi
+	if [[ -n "$_array_flags" ]]; then
+		_array_flags=$(_rest_issue_edit_array_flags "$_issue_path" \
+			"$(printf '%s\n' "${add_labels[@]}")" "$(printf '%s\n' "${rm_labels[@]}")" \
+			"$(printf '%s\n' "${add_assignees[@]}")" "$(printf '%s\n' "${rm_assignees[@]}")") || return 1
+		local _flag=""
+		local _val=""
+		while IFS=$'\t' read -r _flag _val; do
+			[[ -n "$_flag" && -n "$_val" ]] || return 1
+			api_args+=("$_flag" "$_val")
+		done <<<"$_array_flags"
+	fi
+
 	local tmp_body=""
 	local tmp_body_owned=0
 	if [[ $has_body -eq 1 ]]; then
@@ -677,24 +897,7 @@ _rest_issue_edit() {
 		api_args+=(-F "$(_rest_body_file_arg "$tmp_body")")
 	fi
 
-	# Labels and assignees: REST requires full arrays. Delegated to
-	# _rest_print_patch_array_flags; see that helper for the state-fetch
-	# and delta-application logic.
-	local _flag _val
-	if [[ ${#add_labels[@]} -gt 0 || ${#rm_labels[@]} -gt 0 ]]; then
-		while IFS=$'\t' read -r _flag _val; do
-			api_args+=("$_flag" "$_val")
-		done < <(_rest_print_patch_array_flags "$_issue_path" "labels" ".labels[].name" \
-			"$(printf '%s\n' "${add_labels[@]}")" "$(printf '%s\n' "${rm_labels[@]}")")
-	fi
-	if [[ ${#add_assignees[@]} -gt 0 || ${#rm_assignees[@]} -gt 0 ]]; then
-		while IFS=$'\t' read -r _flag _val; do
-			api_args+=("$_flag" "$_val")
-		done < <(_rest_print_patch_array_flags "$_issue_path" "assignees" ".assignees[].login" \
-			"$(printf '%s\n' "${add_assignees[@]}")" "$(printf '%s\n' "${rm_assignees[@]}")")
-	fi
-
-	gh api "${api_args[@]}" >/dev/null 2>&1
+	_rest_api_call write gh api "${api_args[@]}" >/dev/null 2>&1
 	local rc=$?
 
 	[[ $tmp_body_owned -eq 1 && -f "$tmp_body" ]] && rm -f "$tmp_body"
@@ -703,24 +906,38 @@ _rest_issue_edit() {
 }
 
 #######################################
-# Print -f flags for a PATCH array field (labels or assignees) given the
-# current state (fetched via REST) and add/remove deltas. Output is one
-# tab-separated `-f\tfield[]=value` pair per line; caller reads with
-# `IFS=$'\t' read -r k v` and appends both to the api_args array.
+# Print flags for a PATCH array field (labels or assignees) given validated
+# current issue JSON and add/remove deltas. Output is one tab-separated
+# flag/value pair per line. An empty target emits `-F\tfield[]`, which gh 2.96+
+# serializes as an explicit empty array.
 # Factored out of _rest_issue_edit so that function stays under the
 # 100-line complexity gate.
 #
-# Args: $1=issue_path  $2=field_name  $3=jq_expr  $4=adds_nl  $5=rms_nl
+# Args: $1=current_json $2=field_name $3=value_key $4=adds_nl $5=rms_nl
 #######################################
 _rest_print_patch_array_flags() {
-	local issue_path="$1"
+	local current_json="$1"
 	local field="$2"
-	local jq_expr="$3"
+	local value_key="$3"
 	local adds="$4"
 	local rms="$5"
-	local _current _target _elem
-	_current=$(gh api "$issue_path" --jq "$jq_expr" 2>/dev/null) || _current=""
-	_target=$(_rest_compute_target_set "$_current" "$adds" "$rms")
+	local _current=""
+	local _target=""
+	local _elem=""
+	if ! printf '%s' "$current_json" | jq -e --arg field "$field" --arg key "$value_key" \
+		--arg string_type "$_REST_ISSUE_JSON_STRING_TYPE" '
+		if (.[$field] | type) != "array" then false
+		else all(.[$field][]; (type == "object") and ((.[$key] | type) == $string_type) and ((.[$key] | length) > 0))
+		end' >/dev/null 2>&1; then
+		return 1
+	fi
+	_current=$(printf '%s' "$current_json" | jq -r --arg field "$field" --arg key "$value_key" \
+		'.[$field][] | .[$key]' 2>/dev/null) || return 1
+	_target=$(_rest_compute_target_set "$_current" "$adds" "$rms") || return 1
+	if [[ -z "$_target" ]]; then
+		printf -- '-F\t%s[]\n' "$field"
+		return 0
+	fi
 	while IFS= read -r _elem; do
 		[[ -n "$_elem" ]] && printf -- '-f\t%s[]=%s\n' "$field" "$_elem"
 	done <<<"$_target"

--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -459,11 +459,87 @@ _gh_pr_view_try_mixed_split() {
 	return 0
 }
 
+# Print the managed status-label contract as name/color/description TSV rows.
+_status_label_contract() {
+	printf '%s\t%s\t%s\n' \
+		"status:available" "0e8a16" "Task is available for claiming" \
+		"status:queued" "fbca04" "Worker dispatched, not yet started" \
+		"status:claimed" "f9d0c4" "Interactive session claimed this task" \
+		"status:in-progress" "1d76db" "Worker actively running" \
+		"status:in-review" "5319e7" "PR open, awaiting review/merge" \
+		"status:done" "6f42c1" "Task is complete" \
+		"status:blocked" "d93f0b" "Waiting on blocker task"
+	return 0
+}
+
+# Fetch every repository label once so steady-state verification is read-only.
+_status_labels_snapshot() {
+	local repo="$1"
+	AIDEVOPS_GH_ROUTE_DECISION="status-label-contract-list-rest" \
+		_gh_with_timeout read gh api "/repos/${repo}/labels?per_page=100" --paginate \
+		--jq '.[] | [.name, ((.color // "") | ascii_downcase), (.description // "")] | @tsv'
+	return $?
+}
+
+# Print color/description for one exact label name from a snapshot.
+_status_label_snapshot_definition() {
+	local snapshot="$1"
+	local expected_name="$2"
+	local name=""
+	local color=""
+	local description=""
+	while IFS=$'\t' read -r name color description; do
+		if [[ "$name" == "$expected_name" ]]; then
+			printf '%s\t%s' "$color" "$description"
+			return 0
+		fi
+	done <<<"$snapshot"
+	return 1
+}
+
+# Return success only when a snapshot exactly satisfies the full contract.
+_status_label_snapshot_matches_contract() {
+	local snapshot="$1"
+	local name=""
+	local color=""
+	local description=""
+	local actual=""
+	while IFS=$'\t' read -r name color description; do
+		actual=$(_status_label_snapshot_definition "$snapshot" "$name") || return 1
+		[[ "$actual" == "${color}"$'\t'"${description}" ]] || return 1
+	done < <(_status_label_contract)
+	return 0
+}
+
+# Create a missing definition or reconcile a concurrent create deterministically.
+_status_label_create_or_reconcile() {
+	local repo="$1"
+	local name="$2"
+	local color="$3"
+	local description="$4"
+	if AIDEVOPS_GH_ROUTE_DECISION="status-label-contract-create-rest" \
+		_gh_with_timeout write gh label create "$name" --repo "$repo" \
+		--description "$description" --color "$color" 2>/dev/null; then
+		return 0
+	fi
+
+	local refreshed=""
+	local actual=""
+	refreshed=$(_status_labels_snapshot "$repo") || return 1
+	actual=$(_status_label_snapshot_definition "$refreshed" "$name") || return 1
+	if [[ "$actual" == "${color}"$'\t'"${description}" ]]; then
+		return 0
+	fi
+	AIDEVOPS_GH_ROUTE_DECISION="status-label-contract-edit-rest" \
+		_gh_with_timeout write gh label edit "$name" --repo "$repo" \
+		--description "$description" --color "$color"
+	return $?
+}
+
 # Ensure all core status:* labels exist on a repo (idempotent, cached per-process).
-# The helper relies on --remove-label being idempotent for *unset* labels (gh
-# returns exit 0 when a label exists in the repo but isn't applied to the issue),
-# but fails hard when a label doesn't exist in the repo at all. Pre-creating
-# them once per repo per process closes that gap.
+# A converged repository costs one paginated read and zero writes. Missing or
+# drifted definitions are reconciled, then the complete contract is re-verified
+# before the process-local cache is populated.
 #
 # Usage: ensure_status_labels_exist "owner/repo"
 _STATUS_LABELS_ENSURED=""
@@ -475,33 +551,41 @@ ensure_status_labels_exist() {
 	*",${repo},"*) return 0 ;;
 	esac
 
-	# Colors roughly follow GitHub's default palette for lifecycle states.
-	gh label create "status:available" --repo "$repo" \
-		--description "Task is available for claiming" --color "0E8A16" --force 2>/dev/null || true
-	gh label create "status:queued" --repo "$repo" \
-		--description "Worker dispatched, not yet started" --color "FBCA04" --force 2>/dev/null || true
-	gh label create "status:claimed" --repo "$repo" \
-		--description "Interactive session claimed this task" --color "F9D0C4" --force 2>/dev/null || true
-	gh label create "status:in-progress" --repo "$repo" \
-		--description "Worker actively running" --color "1D76DB" --force 2>/dev/null || true
-	gh label create "status:in-review" --repo "$repo" \
-		--description "PR open, awaiting review/merge" --color "5319E7" --force 2>/dev/null || true
-	gh label create "status:done" --repo "$repo" \
-		--description "Task is complete" --color "6F42C1" --force 2>/dev/null || true
-	gh label create "status:blocked" --repo "$repo" \
-		--description "Waiting on blocker task" --color "D93F0B" --force 2>/dev/null || true
+	local snapshot=""
+	snapshot=$(_status_labels_snapshot "$repo") || return 1
+	if ! _status_label_snapshot_matches_contract "$snapshot"; then
+		local name=""
+		local color=""
+		local description=""
+		local actual=""
+		while IFS=$'\t' read -r name color description; do
+			actual=$(_status_label_snapshot_definition "$snapshot" "$name") || actual=""
+			[[ "$actual" == "${color}"$'\t'"${description}" ]] && continue
+			if [[ -n "$actual" ]]; then
+				AIDEVOPS_GH_ROUTE_DECISION="status-label-contract-edit-rest" \
+					_gh_with_timeout write gh label edit "$name" --repo "$repo" \
+					--description "$description" --color "$color" || return 1
+			else
+				_status_label_create_or_reconcile "$repo" "$name" "$color" "$description" || return 1
+			fi
+		done < <(_status_label_contract)
+		snapshot=$(_status_labels_snapshot "$repo") || return 1
+		_status_label_snapshot_matches_contract "$snapshot" || return 1
+	fi
 
 	_STATUS_LABELS_ENSURED="${_STATUS_LABELS_ENSURED:+${_STATUS_LABELS_ENSURED},}${repo}"
 	return 0
 }
 
 #######################################
-# Transition an issue to a status:* label atomically (t2033).
+# Transition an issue to one status:* label (t2033).
 #
-# Removes every sibling core status:* label in a single `gh issue edit` call,
-# then adds the target. This is the ONLY sanctioned way to change an issue's
-# status label — ad-hoc --add-label/--remove-label calls must go through
-# this helper so the status state machine is enforced centrally.
+# The REST-first path uses targeted label and assignee subresource mutations so
+# a stale read cannot replace concurrent unrelated values. Passthrough deltas
+# complete before status reconciliation, so an invalid assignee or unrelated
+# label cannot strand a partially applied status transition. Each phase retains
+# native `gh issue edit` as a compatibility fallback. This is the ONLY sanctioned
+# way to change an issue's status label so the state machine remains central.
 #
 # Args:
 #   $1 — issue number
@@ -528,7 +612,7 @@ ensure_status_labels_exist() {
 #       --add-label "needs-maintainer-review"
 #######################################
 set_issue_status() {
-	gh_record_call graphql set_issue_status 2>/dev/null || true
+	gh_record_call rest set_issue_status 2>/dev/null || true
 	local issue_num="$1"
 	local repo_slug="$2"
 	local new_status="$3"
@@ -557,28 +641,61 @@ set_issue_status() {
 		fi
 	fi
 
-	# Ensure labels exist (cached per-process per-repo so this is cheap)
-	ensure_status_labels_exist "$repo_slug" || true
+	# Ensure labels exist (cached per-process per-repo so this is cheap).
+	# Fail closed: an unknown repository-label contract makes sibling removals
+	# unsafe and must not proceed to either edit path.
+	if ! ensure_status_labels_exist "$repo_slug"; then
+		print_warning "gh-wrapper: unable to verify status-label contract for ${repo_slug}"
+		return 1
+	fi
 
-	# Build flag list: remove all core status labels, add target if non-empty.
-	local -a _flags=()
+	# Build status-only flags: remove all core labels, add target if non-empty.
+	local -a _status_flags=()
 	local _label
 	for _label in "${ISSUE_STATUS_LABELS[@]}"; do
 		if [[ "$_label" == "$new_status" ]]; then
-			_flags+=(--add-label "status:${_label}")
+			_status_flags+=(--add-label "status:${_label}")
 		else
-			_flags+=(--remove-label "status:${_label}")
+			_status_flags+=(--remove-label "status:${_label}")
 		fi
 	done
 
-	# Pass through any extra flags the caller wants to apply in the same edit
-	_flags+=("$@")
+	# Complete passthrough deltas before touching status labels. If both REST and
+	# native handling reject an extra (for example, an invalid assignee), the
+	# existing status remains unchanged rather than becoming a dual-label state.
+	local -a _extra_flags=("$@")
+	local _rc=0
+	if [[ ${#_extra_flags[@]} -gt 0 ]]; then
+		AIDEVOPS_GH_ROUTE_DECISION="status-extra-edit-rest-deltas" \
+			_rest_issue_edit_preserving_deltas "$issue_num" --repo "$repo_slug" "${_extra_flags[@]}"
+		_rc=$?
+		if [[ $_rc -ne 0 ]]; then
+			if [[ "${_REST_ISSUE_DELTA_FAILURE_STAGE:-}" != "mutation" ]]; then
+				print_info "[INFO] gh-wrapper: REST status preflight unavailable, using combined native edit"
+				gh_record_call graphql set_issue_status_combined_native_fallback 2>/dev/null || true
+				AIDEVOPS_GH_ROUTE_DECISION="status-combined-native-fallback" \
+					_gh_with_timeout write gh issue edit "$issue_num" --repo "$repo_slug" \
+					"${_status_flags[@]}" "${_extra_flags[@]}" 2>/dev/null
+				return $?
+			fi
+			print_info "[INFO] gh-wrapper: REST status extras failed, falling back to native gh issue edit"
+			gh_record_call graphql set_issue_status_extra_native_fallback 2>/dev/null || true
+			AIDEVOPS_GH_ROUTE_DECISION="status-extra-edit-native-fallback" \
+				_gh_with_timeout write gh issue edit "$issue_num" --repo "$repo_slug" "${_extra_flags[@]}" 2>/dev/null
+			_rc=$?
+		fi
+		[[ $_rc -eq 0 ]] || return $_rc
+	fi
 
-	_gh_with_timeout write gh issue edit "$issue_num" --repo "$repo_slug" "${_flags[@]}" 2>/dev/null
-	local _rc=$?
-	if [[ $_rc -ne 0 ]] && _rest_should_fallback; then
-		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for set_issue_status"
-		_rest_issue_edit "$issue_num" --repo "$repo_slug" "${_flags[@]}"
+	AIDEVOPS_GH_ROUTE_DECISION="status-issue-edit-rest-deltas" \
+		_rest_issue_edit_preserving_deltas "$issue_num" --repo "$repo_slug" \
+		--delta-order remove-first "${_status_flags[@]}"
+	_rc=$?
+	if [[ $_rc -ne 0 ]]; then
+		print_info "[INFO] gh-wrapper: REST status delta edit failed, falling back to native gh issue edit"
+		gh_record_call graphql set_issue_status_native_fallback 2>/dev/null || true
+		AIDEVOPS_GH_ROUTE_DECISION="status-issue-edit-native-fallback" \
+			_gh_with_timeout write gh issue edit "$issue_num" --repo "$repo_slug" "${_status_flags[@]}" 2>/dev/null
 		_rc=$?
 	fi
 	return $_rc

--- a/.agents/scripts/tests/test-cost-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-cost-circuit-breaker.sh
@@ -86,6 +86,22 @@ if [[ "\$1" == "api" ]]; then
 		echo '{"login":"test-runner"}'
 		exit 0
 	fi
+	if [[ "\$2" == "/repos/"*"/labels?per_page=100" ]]; then
+		printf '%s\n' \\
+			\$'status:available\t0e8a16\tTask is available for claiming' \\
+			\$'status:queued\tfbca04\tWorker dispatched, not yet started' \\
+			\$'status:claimed\tf9d0c4\tInteractive session claimed this task' \\
+			\$'status:in-progress\t1d76db\tWorker actively running' \\
+			\$'status:in-review\t5319e7\tPR open, awaiting review/merge' \\
+			\$'status:done\t6f42c1\tTask is complete' \\
+			\$'status:blocked\td93f0b\tWaiting on blocker task'
+		exit 0
+	fi
+	# Keep this circuit-breaker test focused on its historical native mutation
+	# assertions; dedicated REST wrapper tests cover the REST-first path.
+	if [[ "\$2" == "/repos/"*"/issues/"* ]]; then
+		exit 1
+	fi
 	echo '{}'
 	exit 0
 fi

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -249,14 +249,13 @@ _stub_gh_api() {
 		return $?
 	fi
 	if [[ "$subcommand" =~ ^/repos/.+/issues/[0-9]+$ ]]; then
-		if [[ -n "${STUB_ISSUE_VIEW_FIXTURE:-}" ]]; then
-			local jq_filter=""
-			jq_filter="$(_stub_jq_filter_arg 3 api "$@")"
-			_stub_print_fixture_with_jq "$STUB_ISSUE_VIEW_FIXTURE" "$jq_filter" -r
-			return $?
-		fi
-		printf '%s\n' "${STUB_CURRENT_LABELS:-bug}"
-		return 0
+		[[ "${STUB_ISSUE_GET_FAIL:-0}" == "1" ]] && return 1
+		local jq_filter=""
+		local fixture='{"number":42,"state":"open","locked":false,"labels":[{"name":"bug"}],"assignees":[]}'
+		fixture="${STUB_ISSUE_VIEW_FIXTURE:-$fixture}"
+		jq_filter="$(_stub_jq_filter_arg 3 api "$@")"
+		_stub_print_fixture_with_jq "$fixture" "$jq_filter" -r
+		return $?
 	fi
 	if [[ "$subcommand" =~ ^/repos/[^/]+/[^/]+/issues\? ]]; then
 		_stub_gh_api_issues_list api "$@"
@@ -490,11 +489,11 @@ fi
 
 # =============================================================================
 # Test 8: _rest_issue_edit computes full labels array from add/remove deltas
-# Current labels stub returns "bug" (single label). We add "auto-dispatch",
+# Current issue stub returns "bug" (single label). We add "auto-dispatch",
 # remove "bug" — target set should be ["auto-dispatch"] only.
 # =============================================================================
 : >"$GH_CALLS"
-export STUB_CURRENT_LABELS="bug"
+export STUB_ISSUE_VIEW_FIXTURE='{"labels":[{"name":"bug"}],"assignees":[]}'
 _rest_issue_edit 42 \
 	--repo "owner/repo" \
 	--add-label "auto-dispatch" \
@@ -508,7 +507,74 @@ else
 		"GH_CALLS=$(cat "$GH_CALLS")"
 fi
 
-unset STUB_CURRENT_LABELS
+unset STUB_ISSUE_VIEW_FIXTURE
+
+# =============================================================================
+# Test 8a: current-state GET failure is fail-closed and emits no PATCH.
+# =============================================================================
+: >"$GH_CALLS"
+export STUB_ISSUE_GET_FAIL=1
+_rest_issue_edit 43 --repo "owner/repo" --remove-label "bug" >/dev/null 2>&1
+rest_edit_rc=$?
+if [[ "$rest_edit_rc" -ne 0 ]] &&
+	! grep -qE '^api -X PATCH.*/repos/owner/repo/issues/43' "$GH_CALLS" 2>/dev/null; then
+	pass "_rest_issue_edit fails closed when current-state GET fails"
+else
+	fail "_rest_issue_edit fails closed when current-state GET fails" \
+		"rc=${rest_edit_rc}; GH_CALLS=$(cat "$GH_CALLS")"
+fi
+unset STUB_ISSUE_GET_FAIL
+
+# =============================================================================
+# Test 8b: malformed full-array state is fail-closed and emits no PATCH.
+# =============================================================================
+: >"$GH_CALLS"
+export STUB_ISSUE_VIEW_FIXTURE='{"labels":"malformed","assignees":[]}'
+_rest_issue_edit 44 --repo "owner/repo" --remove-label "bug" >/dev/null 2>&1
+rest_edit_rc=$?
+if [[ "$rest_edit_rc" -ne 0 ]] &&
+	! grep -qE '^api -X PATCH.*/repos/owner/repo/issues/44' "$GH_CALLS" 2>/dev/null; then
+	pass "_rest_issue_edit fails closed on malformed current arrays"
+else
+	fail "_rest_issue_edit fails closed on malformed current arrays" \
+		"rc=${rest_edit_rc}; GH_CALLS=$(cat "$GH_CALLS")"
+fi
+unset STUB_ISSUE_VIEW_FIXTURE
+
+# =============================================================================
+# Test 8c: removing the final value emits an explicit empty array field.
+# =============================================================================
+: >"$GH_CALLS"
+export STUB_ISSUE_VIEW_FIXTURE='{"labels":[{"name":"bug"}],"assignees":[]}'
+_rest_issue_edit 45 --repo "owner/repo" --remove-label "bug" >/dev/null 2>&1
+rest_edit_rc=$?
+if [[ "$rest_edit_rc" -eq 0 ]] &&
+	grep -qE '^api -X PATCH.*/repos/owner/repo/issues/45.*-F labels\[\]' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE 'labels\[\]=bug' "$GH_CALLS" 2>/dev/null; then
+	pass "_rest_issue_edit encodes an explicit empty final labels array"
+else
+	fail "_rest_issue_edit encodes an explicit empty final labels array" \
+		"rc=${rest_edit_rc}; GH_CALLS=$(cat "$GH_CALLS")"
+fi
+unset STUB_ISSUE_VIEW_FIXTURE
+
+# =============================================================================
+# Test 8d: label and assignee deltas share one current-state GET.
+# =============================================================================
+: >"$GH_CALLS"
+export STUB_ISSUE_VIEW_FIXTURE='{"labels":[{"name":"bug"}],"assignees":[{"login":"old-worker"}]}'
+_rest_issue_edit 46 --repo "owner/repo" \
+	--add-label "auto-dispatch" --remove-assignee "old-worker" >/dev/null 2>&1
+rest_edit_rc=$?
+issue_get_count=$(grep -c '^api /repos/owner/repo/issues/46$' "$GH_CALLS" 2>/dev/null || true)
+if [[ "$rest_edit_rc" -eq 0 && "$issue_get_count" -eq 1 ]] &&
+	grep -qE '^api -X PATCH.*/repos/owner/repo/issues/46.*labels\[\]=bug.*labels\[\]=auto-dispatch.*-F assignees\[\]' "$GH_CALLS" 2>/dev/null; then
+	pass "_rest_issue_edit shares one validated GET across label and assignee arrays"
+else
+	fail "_rest_issue_edit shares one validated GET across label and assignee arrays" \
+		"rc=${rest_edit_rc}; gets=${issue_get_count}; GH_CALLS=$(cat "$GH_CALLS")"
+fi
+unset STUB_ISSUE_VIEW_FIXTURE
 
 # =============================================================================
 # Test 9: gh_issue_comment → falls back to REST when primary fails AND exhausted

--- a/.agents/scripts/tests/test-gh-write-timeout-coverage.sh
+++ b/.agents/scripts/tests/test-gh-write-timeout-coverage.sh
@@ -19,7 +19,7 @@ expected_calls=(
 	'_gh_with_timeout write gh label create "solved:worker"'
 	'_gh_with_timeout write gh label create "solved:interactive"'
 	'_gh_with_timeout write gh api graphql -f query='
-	'_gh_with_timeout write gh issue comment "$@"'
+	'_gh_with_timeout write "$gh_command" issue comment "$@"'
 	'_gh_with_timeout write gh pr comment "$@"'
 	'_gh_with_timeout write gh label create "origin:worker"'
 	'_gh_with_timeout write gh label create "origin:interactive"'

--- a/.agents/scripts/tests/test-label-invariants.sh
+++ b/.agents/scripts/tests/test-label-invariants.sh
@@ -193,6 +193,20 @@ case "$1" in
 			echo '{"login":"test-user"}'
 			exit 0
 		fi
+		if [[ "$2" == /repos/*/labels\?per_page=100 ]]; then
+			printf '%s\t%s\t%s\n' \
+				"status:available" "0e8a16" "Task is available for claiming" \
+				"status:queued" "fbca04" "Worker dispatched, not yet started" \
+				"status:claimed" "f9d0c4" "Interactive session claimed this task" \
+				"status:in-progress" "1d76db" "Worker actively running" \
+				"status:in-review" "5319e7" "PR open, awaiting review/merge" \
+				"status:done" "6f42c1" "Task is complete" \
+				"status:blocked" "d93f0b" "Waiting on blocker task"
+			exit 0
+		fi
+		# Force the compatibility path; REST-first behavior has a dedicated
+		# production-wrapper test in test-status-label-state-machine.sh.
+		[[ "$2" == /repos/*/issues/[0-9]* ]] && exit 1
 		;;
 	label)
 		# gh label create (used by ensure_status_labels_exist)
@@ -323,6 +337,18 @@ case "$1" in
 			echo "test-user"
 			exit 0
 		fi
+		if [[ "$2" == /repos/*/labels\?per_page=100 ]]; then
+			printf '%s\t%s\t%s\n' \
+				"status:available" "0e8a16" "Task is available for claiming" \
+				"status:queued" "fbca04" "Worker dispatched, not yet started" \
+				"status:claimed" "f9d0c4" "Interactive session claimed this task" \
+				"status:in-progress" "1d76db" "Worker actively running" \
+				"status:in-review" "5319e7" "PR open, awaiting review/merge" \
+				"status:done" "6f42c1" "Task is complete" \
+				"status:blocked" "d93f0b" "Waiting on blocker task"
+			exit 0
+		fi
+		[[ "$2" == /repos/*/issues/[0-9]* ]] && exit 1
 		;;
 	issue)
 		case "$2" in

--- a/.agents/scripts/tests/test-status-label-state-machine.sh
+++ b/.agents/scripts/tests/test-status-label-state-machine.sh
@@ -53,6 +53,9 @@ mkdir -p "$STUB_DIR"
 # Exported so the gh stub subprocess can reach it at runtime — the heredoc
 # below is quoted ('STUBEOF') to avoid substitution at stub-write time.
 export GH_CALLS_FILE="${TEST_ROOT}/gh_calls.log"
+export STATUS_LABEL_STATE_FILE="${TEST_ROOT}/status-labels-converged"
+export ISSUE_STATE_FILE="${TEST_ROOT}/issue-state.json"
+export ISSUE_CONCURRENT_MARKER="${TEST_ROOT}/issue-concurrent-injected"
 
 #######################################
 # Write a gh stub that records every invocation's argv to GH_CALLS_FILE,
@@ -62,15 +65,148 @@ export GH_CALLS_FILE="${TEST_ROOT}/gh_calls.log"
 # The stub always exits 0 so the helper's "$?" reflects argument validation
 # and label-set construction logic, not simulated gh failures.
 #######################################
+append_stub_gh_mutations() {
+	cat >>"${STUB_DIR}/gh" <<'STUBEOF'
+if [[ "${1:-}" == "api" && "${2:-}" == "-X" ]]; then
+	[[ "${STUB_REST_MUTATION_FAIL:-0}" == "1" ]] && exit 1
+	[[ -n "${STUB_REST_MUTATION_FAIL_METHOD:-}" && "${3:-}" == "${STUB_REST_MUTATION_FAIL_METHOD}" ]] && exit 1
+	if [[ "${STUB_STATEFUL_ISSUE:-0}" == "1" && "${3:-}" == "POST" && "${4:-}" == */labels ]]; then
+		for arg in "$@"; do
+			case "$arg" in
+			labels\[\]=*)
+				label="${arg#labels[]=}"
+				jq --arg label "$label" \
+					'if any(.labels[]; .name == $label) then . else .labels += [{"name": $label}] end' \
+					"${ISSUE_STATE_FILE}" >"${ISSUE_STATE_FILE}.next" || exit 1
+				mv "${ISSUE_STATE_FILE}.next" "${ISSUE_STATE_FILE}"
+				;;
+			esac
+		done
+	elif [[ "${STUB_STATEFUL_ISSUE:-0}" == "1" && "${3:-}" == "DELETE" && "${4:-}" == */labels/* ]]; then
+		encoded_label="${4##*/}"
+		label="${encoded_label//%3A/:}"
+		jq --arg label "$label" '.labels |= map(select(.name != $label))' \
+			"${ISSUE_STATE_FILE}" >"${ISSUE_STATE_FILE}.next" || exit 1
+		mv "${ISSUE_STATE_FILE}.next" "${ISSUE_STATE_FILE}"
+	elif [[ "${STUB_STATEFUL_ISSUE:-0}" == "1" && ( "${3:-}" == "POST" || "${3:-}" == "DELETE" ) && "${4:-}" == */assignees ]]; then
+		for arg in "$@"; do
+			case "$arg" in
+			assignees\[\]=*)
+				login="${arg#assignees[]=}"
+				if [[ "${3:-}" == "POST" ]]; then
+					jq --arg login "$login" \
+						'if any(.assignees[]; .login == $login) then . else .assignees += [{"login": $login}] end' \
+						"${ISSUE_STATE_FILE}" >"${ISSUE_STATE_FILE}.next" || exit 1
+				else
+					jq --arg login "$login" '.assignees |= map(select(.login != $login))' \
+						"${ISSUE_STATE_FILE}" >"${ISSUE_STATE_FILE}.next" || exit 1
+				fi
+				mv "${ISSUE_STATE_FILE}.next" "${ISSUE_STATE_FILE}"
+				;;
+			esac
+		done
+	fi
+	exit 0
+fi
+STUBEOF
+	return 0
+}
+
 write_stub_gh() {
 	: >"$GH_CALLS_FILE"
 	cat >"${STUB_DIR}/gh" <<'STUBEOF'
 #!/usr/bin/env bash
 # Stub gh for test-status-label-state-machine.sh — records all calls.
 printf '%s\n' "$*" >>"${GH_CALLS_FILE}"
+
+if [[ "${1:-}" == "api" && "${2:-}" == /repos/*/labels\?per_page=100 ]]; then
+	[[ "${STUB_LABEL_LIST_FAIL:-0}" == "1" ]] && exit 1
+	printf '%s\t%s\t%s\n' \
+		"status:available" "0e8a16" "Task is available for claiming" \
+		"status:queued" "fbca04" "Worker dispatched, not yet started" \
+		"status:claimed" "f9d0c4" "Interactive session claimed this task" \
+		"status:in-progress" "1d76db" "Worker actively running" \
+		"status:in-review" "5319e7" "PR open, awaiting review/merge" \
+		"status:done" "6f42c1" "Task is complete"
+	if [[ -f "${STATUS_LABEL_STATE_FILE}" || "${STUB_LABEL_MODE:-exact}" == "exact" ]]; then
+		printf '%s\t%s\t%s\n' "status:blocked" "d93f0b" "Waiting on blocker task"
+	elif [[ "${STUB_LABEL_MODE:-exact}" == "drifted" ]]; then
+		printf '%s\t%s\t%s\n' "status:blocked" "ffffff" "Drifted definition"
+	fi
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == /repos/*/issues/[0-9]* ]]; then
+	[[ "${STUB_ISSUE_GET_FAIL:-0}" == "1" ]] && exit 1
+	if [[ "${STUB_STATEFUL_ISSUE:-0}" == "1" && -f "${ISSUE_STATE_FILE}" ]]; then
+		cat "${ISSUE_STATE_FILE}"
+		if [[ ( -n "${STUB_CONCURRENT_LABEL_AFTER_GET:-}" || -n "${STUB_CONCURRENT_ASSIGNEE_AFTER_GET:-}" ) && ! -f "${ISSUE_CONCURRENT_MARKER}" ]]; then
+			if [[ -n "${STUB_CONCURRENT_LABEL_AFTER_GET:-}" ]]; then
+				jq --arg label "${STUB_CONCURRENT_LABEL_AFTER_GET}" \
+					'if any(.labels[]; .name == $label) then . else .labels += [{"name": $label}] end' \
+					"${ISSUE_STATE_FILE}" >"${ISSUE_STATE_FILE}.next" || exit 1
+				mv "${ISSUE_STATE_FILE}.next" "${ISSUE_STATE_FILE}"
+			fi
+			if [[ -n "${STUB_CONCURRENT_ASSIGNEE_AFTER_GET:-}" ]]; then
+				jq --arg login "${STUB_CONCURRENT_ASSIGNEE_AFTER_GET}" \
+					'if any(.assignees[]; .login == $login) then . else .assignees += [{"login": $login}] end' \
+					"${ISSUE_STATE_FILE}" >"${ISSUE_STATE_FILE}.next" || exit 1
+				mv "${ISSUE_STATE_FILE}.next" "${ISSUE_STATE_FILE}"
+			fi
+			: >"${ISSUE_CONCURRENT_MARKER}"
+		fi
+	elif [[ -n "${STUB_ISSUE_JSON:-}" ]]; then
+		printf '%s\n' "$STUB_ISSUE_JSON"
+	else
+		exit 1
+	fi
+	exit 0
+fi
+STUBEOF
+	append_stub_gh_mutations
+	cat >>"${STUB_DIR}/gh" <<'STUBEOF'
+
+if [[ "${1:-}" == "label" ]]; then
+	if [[ "${2:-}" == "create" && "${STUB_LABEL_CREATE_CONFLICT:-0}" == "1" ]]; then
+		: >"${STATUS_LABEL_STATE_FILE}"
+		exit 1
+	fi
+	[[ "${STUB_LABEL_WRITE_FAIL:-0}" == "1" ]] && exit 1
+	: >"${STATUS_LABEL_STATE_FILE}"
+	exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "edit" ]]; then
+	[[ "${STUB_NATIVE_EDIT_FAIL:-0}" == "1" ]] && exit 1
+	if [[ "${STUB_STATEFUL_ISSUE:-0}" == "1" ]]; then
+		shift 2
+		while [[ $# -gt 0 ]]; do
+			case "$1" in
+			--add-label)
+				label="${2:-}"
+				jq --arg label "$label" \
+					'if any(.labels[]; .name == $label) then . else .labels += [{"name": $label}] end' \
+					"${ISSUE_STATE_FILE}" >"${ISSUE_STATE_FILE}.next" || exit 1
+				mv "${ISSUE_STATE_FILE}.next" "${ISSUE_STATE_FILE}"
+				shift 2
+				;;
+			--remove-label)
+				label="${2:-}"
+				jq --arg label "$label" '.labels |= map(select(.name != $label))' \
+					"${ISSUE_STATE_FILE}" >"${ISSUE_STATE_FILE}.next" || exit 1
+				mv "${ISSUE_STATE_FILE}.next" "${ISSUE_STATE_FILE}"
+				shift 2
+				;;
+			*) shift ;;
+			esac
+		done
+	fi
+	exit 0
+fi
 exit 0
 STUBEOF
 	chmod +x "${STUB_DIR}/gh"
+	return 0
 }
 
 # Source the helper. Prepending STUB_DIR to PATH ensures the stub is picked up.
@@ -84,6 +220,12 @@ source "${TEST_SCRIPTS_DIR}/shared-constants.sh"
 _reset_state() {
 	_STATUS_LABELS_ENSURED=""
 	: >"$GH_CALLS_FILE"
+	rm -f "$STATUS_LABEL_STATE_FILE" "$ISSUE_STATE_FILE" "$ISSUE_STATE_FILE.next" "$ISSUE_CONCURRENT_MARKER"
+	unset STUB_ISSUE_JSON STUB_ISSUE_GET_FAIL STUB_REST_MUTATION_FAIL STUB_REST_MUTATION_FAIL_METHOD
+	unset STUB_NATIVE_EDIT_FAIL
+	unset STUB_STATEFUL_ISSUE STUB_CONCURRENT_LABEL_AFTER_GET STUB_CONCURRENT_ASSIGNEE_AFTER_GET
+	unset STUB_LABEL_LIST_FAIL STUB_LABEL_MODE STUB_LABEL_CREATE_CONFLICT STUB_LABEL_WRITE_FAIL
+	return 0
 }
 
 #######################################
@@ -145,6 +287,29 @@ assert_last_edit_lacks() {
 }
 
 #######################################
+# Verify at least one native edit phase contains every required substring.
+#######################################
+assert_any_edit_has() {
+	local name="$1"
+	shift
+	local edit_calls=""
+	edit_calls=$(grep 'issue edit' "$GH_CALLS_FILE" || true)
+	local needle=""
+	local missing=()
+	for needle in "$@"; do
+		if ! printf '%s' "$edit_calls" | grep -qF -- "$needle"; then
+			missing+=("$needle")
+		fi
+	done
+	if [[ ${#missing[@]} -eq 0 ]]; then
+		print_result "$name" 0
+	else
+		print_result "$name" 1 "(missing: ${missing[*]} | got: ${edit_calls})"
+	fi
+	return 0
+}
+
+#######################################
 # TEST 1: Transition to status:queued produces 1 add + 6 removes
 #######################################
 test_queued_transition() {
@@ -180,7 +345,7 @@ test_available_with_extra_flags() {
 	print_result "available+extra returns 0" 0
 	assert_last_edit_has "available+extra: adds status:available" \
 		"--add-label status:available"
-	assert_last_edit_has "available+extra: passes through --remove-assignee" \
+	assert_any_edit_has "available+extra: passes through --remove-assignee" \
 		"--remove-assignee stale-worker"
 	assert_last_edit_has "available+extra: removes sibling status:queued" \
 		"--remove-label status:queued"
@@ -198,7 +363,7 @@ test_empty_status_clear_only() {
 		return 0
 	}
 	print_result "empty status returns 0" 0
-	assert_last_edit_has "clear-only: passes through --add-label" \
+	assert_any_edit_has "clear-only: passes through --add-label" \
 		"--add-label needs-maintainer-review"
 	assert_last_edit_has "clear-only: removes status:available" \
 		"--remove-label status:available"
@@ -316,12 +481,313 @@ test_dispatch_realistic_pattern() {
 		"--add-label status:queued"
 	assert_last_edit_has "dispatch: removes status:available (the t2033 bug fix)" \
 		"--remove-label status:available"
-	assert_last_edit_has "dispatch: passes through --add-assignee" \
+	assert_any_edit_has "dispatch: passes through --add-assignee" \
 		"--add-assignee runner-a"
-	assert_last_edit_has "dispatch: passes through --add-label origin:worker" \
+	assert_any_edit_has "dispatch: passes through --add-label origin:worker" \
 		"--add-label origin:worker"
-	assert_last_edit_has "dispatch: passes through --remove-assignee" \
+	assert_any_edit_has "dispatch: passes through --remove-assignee" \
 		"--remove-assignee runner-b"
+	return 0
+}
+
+#######################################
+# TEST 9: A normal transition uses targeted REST delta endpoints, preserving
+# unrelated labels instead of submitting a stale full-array replacement.
+#######################################
+test_rest_first_transition() {
+	_reset_state
+	export STUB_ISSUE_JSON='{"labels":[{"name":"bug"},{"name":"status:available"}],"assignees":[{"login":"stale-worker"}]}'
+	set_issue_status 314 "owner/repo" "queued" --remove-assignee "stale-worker"
+	local rc=$?
+	if [[ "$rc" -eq 0 ]] &&
+		grep -q '^api -X POST /repos/owner/repo/issues/314/labels -f labels\[\]=status:queued$' "$GH_CALLS_FILE" &&
+		grep -q '^api -X DELETE /repos/owner/repo/issues/314/labels/status%3Aavailable$' "$GH_CALLS_FILE" &&
+		grep -q '^api -X DELETE /repos/owner/repo/issues/314/assignees -f assignees\[\]=stale-worker$' "$GH_CALLS_FILE" &&
+		! grep -qE '^(api -X PATCH /repos/owner/repo/issues/314|issue edit 314)' "$GH_CALLS_FILE"; then
+		print_result "REST-first transition uses targeted delta endpoints" 0
+	else
+		print_result "REST-first transition uses targeted delta endpoints" 1 \
+			"(rc=${rc}; calls=$(cat "$GH_CALLS_FILE"))"
+	fi
+	if ! grep -q 'labels\[\]=bug' "$GH_CALLS_FILE"; then
+		print_result "REST-first transition never replaces unrelated labels" 0
+	else
+		print_result "REST-first transition never replaces unrelated labels" 1 \
+			"(calls=$(cat "$GH_CALLS_FILE"))"
+	fi
+	return 0
+}
+
+#######################################
+# TEST 10: An unrelated label added after the snapshot survives the transition.
+#######################################
+test_concurrent_unrelated_label_is_preserved() {
+	_reset_state
+	printf '%s\n' '{"labels":[{"name":"bug"},{"name":"status:available"}],"assignees":[]}' >"$ISSUE_STATE_FILE"
+	export STUB_STATEFUL_ISSUE=1
+	export STUB_CONCURRENT_LABEL_AFTER_GET="external-update"
+	set_issue_status 315 "owner/repo" "queued"
+	local rc=$?
+	local final_labels=""
+	final_labels=$(jq -r '.labels[].name' "$ISSUE_STATE_FILE" | sort)
+	if [[ "$rc" -eq 0 && "$final_labels" == $'bug\nexternal-update\nstatus:queued' ]]; then
+		print_result "concurrent unrelated label survives REST status transition" 0
+	else
+		print_result "concurrent unrelated label survives REST status transition" 1 \
+			"(rc=${rc}; labels=${final_labels}; calls=$(cat "$GH_CALLS_FILE"))"
+	fi
+	return 0
+}
+
+#######################################
+# TEST 11: An unrelated assignee added after the snapshot also survives.
+#######################################
+test_concurrent_unrelated_assignee_is_preserved() {
+	_reset_state
+	printf '%s\n' '{"labels":[{"name":"bug"},{"name":"status:queued"}],"assignees":[{"login":"old-worker"}]}' >"$ISSUE_STATE_FILE"
+	export STUB_STATEFUL_ISSUE=1
+	export STUB_CONCURRENT_ASSIGNEE_AFTER_GET="observer"
+	set_issue_status 316 "owner/repo" "queued" \
+		--add-assignee "new-worker" --remove-assignee "old-worker"
+	local rc=$?
+	local final_assignees=""
+	final_assignees=$(jq -r '.assignees[].login' "$ISSUE_STATE_FILE" | sort)
+	if [[ "$rc" -eq 0 && "$final_assignees" == $'new-worker\nobserver' ]]; then
+		print_result "concurrent unrelated assignee survives REST status transition" 0
+	else
+		print_result "concurrent unrelated assignee survives REST status transition" 1 \
+			"(rc=${rc}; assignees=${final_assignees}; calls=$(cat "$GH_CALLS_FILE"))"
+	fi
+	return 0
+}
+
+#######################################
+# TEST 10: A converged status-label contract is one read and zero writes.
+#######################################
+test_converged_label_contract_is_read_only() {
+	_reset_state
+	ensure_status_labels_exist "owner/repo"
+	local rc=$?
+	local reads=0
+	local writes=0
+	reads=$(grep -c '^api /repos/owner/repo/labels?per_page=100 ' "$GH_CALLS_FILE" 2>/dev/null || true)
+	writes=$(grep -Ec '^label (create|edit) ' "$GH_CALLS_FILE" 2>/dev/null || true)
+	if [[ "$rc" -eq 0 && "$reads" -eq 1 && "$writes" -eq 0 ]]; then
+		print_result "converged label contract uses one read and zero writes" 0
+	else
+		print_result "converged label contract uses one read and zero writes" 1 \
+			"(rc=${rc}; reads=${reads}; writes=${writes}; calls=$(cat "$GH_CALLS_FILE"))"
+	fi
+	return 0
+}
+
+#######################################
+# TEST 11: Missing and drifted definitions use create/edit respectively, then
+# re-read the full contract before populating the process cache.
+#######################################
+test_label_contract_reconciliation() {
+	_reset_state
+	export STUB_LABEL_MODE="missing"
+	ensure_status_labels_exist "owner/repo"
+	local missing_rc=$?
+	if [[ "$missing_rc" -eq 0 ]] &&
+		grep -q '^label create status:blocked ' "$GH_CALLS_FILE" &&
+		! grep -q -- '--force' "$GH_CALLS_FILE"; then
+		print_result "missing status label is created without --force" 0
+	else
+		print_result "missing status label is created without --force" 1 \
+			"(rc=${missing_rc}; calls=$(cat "$GH_CALLS_FILE"))"
+	fi
+
+	_reset_state
+	export STUB_LABEL_MODE="drifted"
+	ensure_status_labels_exist "owner/repo"
+	local drifted_rc=$?
+	if [[ "$drifted_rc" -eq 0 ]] &&
+		grep -q '^label edit status:blocked ' "$GH_CALLS_FILE" &&
+		! grep -q '^label create status:blocked ' "$GH_CALLS_FILE"; then
+		print_result "drifted status label is edited without create churn" 0
+	else
+		print_result "drifted status label is edited without create churn" 1 \
+			"(rc=${drifted_rc}; calls=$(cat "$GH_CALLS_FILE"))"
+	fi
+	return 0
+}
+
+#######################################
+# TEST 12: A concurrent create conflict is re-read and accepted only after the
+# resulting repository definition exactly matches the contract.
+#######################################
+test_label_create_conflict_is_verified() {
+	_reset_state
+	export STUB_LABEL_MODE="missing"
+	export STUB_LABEL_CREATE_CONFLICT=1
+	ensure_status_labels_exist "owner/repo"
+	local rc=$?
+	local reads=0
+	reads=$(grep -c '^api /repos/owner/repo/labels?per_page=100 ' "$GH_CALLS_FILE" 2>/dev/null || true)
+	if [[ "$rc" -eq 0 && "$reads" -ge 3 ]] &&
+		grep -q '^label create status:blocked ' "$GH_CALLS_FILE"; then
+		print_result "concurrent label create conflict is re-read and verified" 0
+	else
+		print_result "concurrent label create conflict is re-read and verified" 1 \
+			"(rc=${rc}; reads=${reads}; calls=$(cat "$GH_CALLS_FILE"))"
+	fi
+	return 0
+}
+
+#######################################
+# TEST 13: Unknown label state blocks every issue mutation.
+#######################################
+test_label_contract_read_failure_is_fail_closed() {
+	_reset_state
+	export STUB_LABEL_LIST_FAIL=1
+	set_issue_status 2718 "owner/repo" "queued" >/dev/null 2>&1
+	local rc=$?
+	if [[ "$rc" -ne 0 ]] &&
+		! grep -qE '^(api -X (PATCH|POST|DELETE)|issue edit|label (create|edit))' "$GH_CALLS_FILE"; then
+		print_result "failed label-contract read performs no mutation" 0
+	else
+		print_result "failed label-contract read performs no mutation" 1 \
+			"(rc=${rc}; calls=$(cat "$GH_CALLS_FILE"))"
+	fi
+	return 0
+}
+
+#######################################
+# TEST 15: Extras that fail in both routes leave status labels untouched.
+#######################################
+test_failed_extra_does_not_start_status_transition() {
+	_reset_state
+	printf '%s\n' '{"labels":[{"name":"bug"},{"name":"status:available"}],"assignees":[]}' >"$ISSUE_STATE_FILE"
+	export STUB_STATEFUL_ISSUE=1
+	export STUB_REST_MUTATION_FAIL=1
+	export STUB_NATIVE_EDIT_FAIL=1
+	set_issue_status 1618 "owner/repo" "in-review" --add-assignee "invalid-worker" >/dev/null 2>&1
+	local rc=$?
+	local final_statuses=""
+	final_statuses=$(jq -r '.labels[].name | select(startswith("status:"))' "$ISSUE_STATE_FILE")
+	if [[ "$rc" -ne 0 && "$final_statuses" == "status:available" ]] &&
+		! grep -qE 'labels\[\]=status:in-review|/labels/status%3Aavailable|--add-label status:in-review' "$GH_CALLS_FILE"; then
+		print_result "failed passthrough extra leaves existing status untouched" 0
+	else
+		print_result "failed passthrough extra leaves existing status untouched" 1 \
+			"(rc=${rc}; statuses=${final_statuses}; calls=$(cat "$GH_CALLS_FILE"))"
+	fi
+	return 0
+}
+
+#######################################
+# TEST 16: A failed REST status phase falls back with status-only flags and
+# converges without replaying unrelated extras.
+#######################################
+test_rest_status_failure_uses_status_only_native_fallback() {
+	_reset_state
+	printf '%s\n' '{"labels":[{"name":"bug"},{"name":"status:available"}],"assignees":[]}' >"$ISSUE_STATE_FILE"
+	export STUB_STATEFUL_ISSUE=1
+	export STUB_REST_MUTATION_FAIL=1
+	set_issue_status 1619 "owner/repo" "in-review" >/dev/null 2>&1
+	local rc=$?
+	local final_labels=""
+	final_labels=$(jq -r '.labels[].name' "$ISSUE_STATE_FILE" | sort)
+	local native_call=""
+	native_call=$(grep '^issue edit 1619 ' "$GH_CALLS_FILE" | tail -1 || true)
+	if [[ "$rc" -eq 0 && "$final_labels" == $'bug\nstatus:in-review' &&
+		"$native_call" == *"--add-label status:in-review"* && "$native_call" != *"assignee"* ]]; then
+		print_result "failed REST status phase uses status-only native fallback" 0
+	else
+		print_result "failed REST status phase uses status-only native fallback" 1 \
+			"(rc=${rc}; labels=${final_labels}; native=${native_call}; calls=$(cat "$GH_CALLS_FILE"))"
+	fi
+	return 0
+}
+
+#######################################
+# TEST 17: If the target-label add and native fallback both fail, the REST
+# phase has already removed the old status and therefore cannot strand a dual
+# status-label state.
+#######################################
+test_failed_target_add_never_strands_dual_statuses() {
+	_reset_state
+	printf '%s\n' '{"labels":[{"name":"bug"},{"name":"status:available"}],"assignees":[]}' >"$ISSUE_STATE_FILE"
+	export STUB_STATEFUL_ISSUE=1
+	export STUB_REST_MUTATION_FAIL_METHOD=POST
+	export STUB_NATIVE_EDIT_FAIL=1
+	set_issue_status 1620 "owner/repo" "queued" >/dev/null 2>&1
+	local rc=$?
+	local final_statuses=""
+	final_statuses=$(jq -r '.labels[].name | select(startswith("status:"))' "$ISSUE_STATE_FILE")
+	local remove_line=""
+	local add_line=""
+	remove_line=$(grep -n '^api -X DELETE /repos/owner/repo/issues/1620/labels/status%3Aavailable$' \
+		"$GH_CALLS_FILE" | cut -d: -f1 || true)
+	add_line=$(grep -n '^api -X POST /repos/owner/repo/issues/1620/labels -f labels\[\]=status:queued$' \
+		"$GH_CALLS_FILE" | cut -d: -f1 || true)
+	if [[ "$rc" -ne 0 && -z "$final_statuses" && -n "$remove_line" && -n "$add_line" && "$remove_line" -lt "$add_line" ]]; then
+		print_result "failed target add cannot strand dual statuses" 0
+	else
+		print_result "failed target add cannot strand dual statuses" 1 \
+			"(rc=${rc}; statuses=${final_statuses}; remove=${remove_line}; add=${add_line}; calls=$(cat "$GH_CALLS_FILE"))"
+	fi
+	return 0
+}
+
+#######################################
+# TEST 18: Passthrough assignee replacements add first. A rejected replacement
+# and failed native fallback therefore leave the existing assignee intact and
+# never begin the status phase.
+#######################################
+test_failed_extra_add_preserves_existing_assignee() {
+	_reset_state
+	local existing_assignee="old-worker"
+	jq -n --arg login "$existing_assignee" \
+		'{labels:[{name:"status:available"}],assignees:[{login:$login}]}' >"$ISSUE_STATE_FILE"
+	export STUB_STATEFUL_ISSUE=1
+	export STUB_REST_MUTATION_FAIL_METHOD=POST
+	export STUB_NATIVE_EDIT_FAIL=1
+	set_issue_status 1621 "owner/repo" "in-review" \
+		--add-assignee "invalid-worker" --remove-assignee "$existing_assignee" >/dev/null 2>&1
+	local rc=$?
+	local final_assignees=""
+	local final_statuses=""
+	final_assignees=$(jq -r '.assignees[].login' "$ISSUE_STATE_FILE")
+	final_statuses=$(jq -r '.labels[].name | select(startswith("status:"))' "$ISSUE_STATE_FILE")
+	if [[ "$rc" -ne 0 && "$final_assignees" == "$existing_assignee" && "$final_statuses" == "status:available" ]] &&
+		! grep -q '^api -X DELETE /repos/owner/repo/issues/1621/assignees ' "$GH_CALLS_FILE"; then
+		print_result "failed extra add preserves existing assignee" 0
+	else
+		print_result "failed extra add preserves existing assignee" 1 \
+			"(rc=${rc}; assignees=${final_assignees}; statuses=${final_statuses}; calls=$(cat "$GH_CALLS_FILE"))"
+	fi
+	return 0
+}
+
+#######################################
+# TEST 19: The same add-first protection applies to passthrough label
+# replacements, including labels unrelated to the managed status state.
+#######################################
+test_failed_extra_add_preserves_existing_label() {
+	_reset_state
+	local existing_label="origin:legacy"
+	jq -n --arg label "$existing_label" \
+		'{labels:[{name:"status:available"},{name:$label}],assignees:[]}' >"$ISSUE_STATE_FILE"
+	export STUB_STATEFUL_ISSUE=1
+	export STUB_REST_MUTATION_FAIL_METHOD=POST
+	export STUB_NATIVE_EDIT_FAIL=1
+	set_issue_status 1622 "owner/repo" "in-review" \
+		--add-label "missing-label" --remove-label "$existing_label" >/dev/null 2>&1
+	local rc=$?
+	local final_statuses=""
+	final_statuses=$(jq -r '.labels[].name | select(startswith("status:"))' "$ISSUE_STATE_FILE")
+	if [[ "$rc" -ne 0 && "$final_statuses" == "status:available" ]] &&
+		jq -e --arg label "$existing_label" 'any(.labels[]; .name == $label)' "$ISSUE_STATE_FILE" >/dev/null &&
+		! grep -q '^api -X DELETE /repos/owner/repo/issues/1622/labels/' "$GH_CALLS_FILE"; then
+		print_result "failed extra add preserves existing label" 0
+	else
+		print_result "failed extra add preserves existing label" 1 \
+			"(rc=${rc}; statuses=${final_statuses}; calls=$(cat "$GH_CALLS_FILE"))"
+	fi
+	return 0
 }
 
 # =============================================================================
@@ -336,6 +802,18 @@ main() {
 	test_missing_args_rejected
 	test_canonical_label_list
 	test_dispatch_realistic_pattern
+	test_rest_first_transition
+	test_concurrent_unrelated_label_is_preserved
+	test_concurrent_unrelated_assignee_is_preserved
+	test_converged_label_contract_is_read_only
+	test_label_contract_reconciliation
+	test_label_create_conflict_is_verified
+	test_label_contract_read_failure_is_fail_closed
+	test_failed_extra_does_not_start_status_transition
+	test_rest_status_failure_uses_status_only_native_fallback
+	test_failed_target_add_never_strands_dual_statuses
+	test_failed_extra_add_preserves_existing_assignee
+	test_failed_extra_add_preserves_existing_label
 
 	printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/TODO.md
+++ b/TODO.md
@@ -1210,6 +1210,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18185 Strengthen OpenCode compaction continuation state #documentation #full-loop #no-auto-dispatch #opencode-plugin #testing #type:enhancement ref:GH#28913 pr:#28914 completed:2026-07-30
 
+- [ ] t18184 Fix status-label reconciliation and REST issue edit array safety #bug #efficiency #framework #github-api #no-auto-dispatch ref:GH#28912
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22
@@ -4732,5 +4734,3 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 - [x] t18181 Add release-only upstream watch mode for Native SDK #enhancement #framework #monitoring ref:GH#28771 pr:#28773 completed:2026-07-28
 
 - [x] t18183 Preserve framed GH attempts and REST rewrite failures #auto-dispatch #bug ref:GH#28907 pr:#28909 completed:2026-07-30
-
-- [ ] t18184 Fix status-label reconciliation and REST issue edit array safety #bug #efficiency #framework #github-api ref:GH#28912


### PR DESCRIPTION
## Summary

Reconcile the status-label contract with bounded REST reads and targeted label and assignee deltas while preserving fail-closed native fallbacks.

## Files Changed

.agents/scripts/shared-gh-wrappers-rest-fallback.sh, .agents/scripts/shared-gh-wrappers-status.sh, .agents/scripts/tests/test-cost-circuit-breaker.sh, .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh, .agents/scripts/tests/test-gh-write-timeout-coverage.sh, .agents/scripts/tests/test-label-invariants.sh, .agents/scripts/tests/test-status-label-state-machine.sh, TODO.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Local linters; ShellCheck and bash -n; state machine 41/41; REST fallback 89/89; label invariants 44/44; bash and zsh compatibility suites; live converged transition on issue 28912.

Resolves #28912


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.5 spent 13d 15h and 49,527,162 tokens on this with the user in an interactive session.