### PR TITLE
GH#28924: fix: abort merge pass when GitHub auth is unavailable

### DIFF
--- a/.agents/scripts/pulse-merge-routine.sh
+++ b/.agents/scripts/pulse-merge-routine.sh
@@ -252,6 +252,17 @@ _pmr_graphql_budget_allows_run() {
 	return 0
 }
 
+_pmr_require_gh_auth() {
+	local token=""
+	if ! token=$(gh auth token 2>/dev/null) || [[ -z "$token" ]]; then
+		_pmr_log ERROR "GitHub authentication unavailable; aborting merge routine before API access to prevent unauthenticated requests"
+		printf '%s\n' 'pulse-merge-routine: GitHub authentication unavailable; refusing unauthenticated API access' >&2
+		return 1
+	fi
+	unset token
+	return 0
+}
+
 # =============================================================================
 # File-based lock (mkdir-based for bash 3.2 + macOS portability)
 # =============================================================================
@@ -415,6 +426,9 @@ cmd_run() {
 	if ! _pmr_acquire_lock; then
 		exit 0
 	fi
+	if ! _pmr_require_gh_auth; then
+		return 1
+	fi
 	if ! _pmr_graphql_budget_allows_run; then
 		date +%s >"$PULSE_MERGE_ROUTINE_LAST_RUN" 2>/dev/null || true
 		return 0
@@ -481,6 +495,9 @@ cmd_dry_run() {
 	_pmr_log INFO "DRY-RUN mode: merge routine (pid=$$, timeout=${PULSE_MERGE_ROUTINE_TIMEOUT_SECONDS}s)"
 	if ! _pmr_acquire_lock; then
 		exit 0
+	fi
+	if ! _pmr_require_gh_auth; then
+		return 1
 	fi
 	if ! _pmr_graphql_budget_allows_run; then
 		return 0

--- a/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
+++ b/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
@@ -56,6 +56,7 @@
 #   18. linked-issue closure invokes dependency reconciliation
 #   19. stuck escalation invokes the idempotent comment provider
 #   20. both paths run without missing-function diagnostics
+#   21. missing gh authentication aborts before the first API request
 
 set -uo pipefail
 
@@ -198,6 +199,23 @@ if grep -qF "export PATH=\"\${SCRIPT_DIR}:\${PATH}\"" "$ROUTINE_FILE"; then
 else
 	fail "6b: routine re-prioritises framework scripts in PATH" \
 		"missing SCRIPT_DIR PATH prepend after script-dir resolution"
+fi
+
+# =============================================================================
+# Test 6c: merge runs fail closed when gh has no authentication context
+# =============================================================================
+auth_test_home=$(mktemp -d)
+auth_output=""
+auth_exit=0
+auth_output=$(HOME="$auth_test_home" GH_TOKEN="" GITHUB_TOKEN="" \
+	LC_ALL=C timeout 30 "$ROUTINE_FILE" --repo example/repo 2>&1) || auth_exit=$?
+rm -rf "$auth_test_home"
+
+if [[ "$auth_exit" -ne 0 ]] && printf '%s\n' "$auth_output" | grep -qF 'refusing unauthenticated API access'; then
+	pass "6c: missing gh authentication aborts before API access"
+else
+	fail "6c: missing gh authentication aborts before API access" \
+		"exit=$auth_exit, output=$auth_output"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Fail the standalone merge routine closed before quota probes or PR processing when gh auth token is missing or unreadable, and cover the unauthenticated path with a standalone regression test.

## Files Changed

.agents/scripts/pulse-merge-routine.sh, .agents/scripts/tests/test-pulse-merge-routine-standalone.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — .agents/scripts/tests/test-pulse-merge-routine-standalone.sh exercised the missing-auth runtime path and passed 21/21; shellcheck .agents/scripts/pulse-merge-routine.sh .agents/scripts/tests/test-pulse-merge-routine-standalone.sh; git diff --check

Resolves #28924


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 7m and 93,415 tokens on this as a headless worker.