### PR TITLE
GH#28929: Permit managed OpenCode skill paths

### DIFF
--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -52,6 +52,8 @@ const MANAGED_EXTERNAL_DIRECTORIES = [
   "~/.config/aidevops/**",
   "~/.config/opencode/command",
   "~/.config/opencode/command/**",
+  "~/.config/opencode/skills",
+  "~/.config/opencode/skills/**",
   "~/Git/_worktrees",
   "~/Git/_worktrees/**",
   ...[...tempDirectories].sort().flatMap((path) => [path, `${path}/**`]),

--- a/.agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs
@@ -27,6 +27,8 @@ const managedRules = {
   "~/.config/aidevops/**": "allow",
   "~/.config/opencode/command": "allow",
   "~/.config/opencode/command/**": "allow",
+  "~/.config/opencode/skills": "allow",
+  "~/.config/opencode/skills/**": "allow",
   "~/Git/_worktrees": "allow",
   "~/Git/_worktrees/**": "allow",
   ...Object.fromEntries([...tempDirectories].sort().flatMap((path) => [
@@ -52,6 +54,8 @@ test("adds narrow managed-directory exceptions after a broad ask rule", () => {
     "~/Documents/**": "deny",
     ...managedRules,
   });
+  assert.equal(config.permission.external_directory["~/.config/opencode/agent"], undefined);
+  assert.equal(config.permission.external_directory["~/.config/opencode/agent/**"], undefined);
 });
 
 test("converts a top-level default without allowing unrelated directories", () => {


### PR DESCRIPTION
## Summary

Allow the aidevops-managed OpenCode skills directory and descendants while keeping sibling config directories under the existing permission policy.

## Files Changed

.agents/plugins/opencode-aidevops/config-hook.mjs, .agents/plugins/opencode-aidevops/tests/test-managed-directory-permissions.mjs

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Managed-directory Node test 5/5; node syntax checks; local linter suite; git diff --check.

Resolves #28929


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 1h 13m and 509,410 tokens on this with the user in an interactive session.