### PR TITLE
GH#28931: Hand off consolidated specs for dispatch

### DIFF
--- a/.agents/scripts/pulse-triage-dispatch.sh
+++ b/.agents/scripts/pulse-triage-dispatch.sh
@@ -92,11 +92,13 @@ _compose_consolidation_worker_instructions() {
 \`\`\`bash
 gh issue create --repo "${repo_slug}" \\
   --title "consolidated: <concise description derived from the merged spec>" \\
-  --label "consolidated,origin:worker,<copy relevant labels from parent, excluding needs-consolidation, consolidation-task, and origin:interactive>" \\
+  --label "consolidated,origin:worker,auto-dispatch,<copy relevant labels from parent, excluding needs-consolidation, consolidation-task, and origin:interactive>" \\
   --body "<merged body from step 2>"
 \`\`\`
 
 **Note (GH#18670):** \`origin:worker\` is mandatory on this label list — consolidated issues are pulse-generated artifacts, not interactive maintainer work. Without it, the issue is born \`origin:interactive\` (raw \`gh issue create\` has no origin auto-detection), which triggers the GH#18352 dispatch-dedup block and drains the queue.
+
+**Dispatch handoff:** \`auto-dispatch\` is also mandatory. The consolidated successor marker and this explicit handoff must both be present before \`_has_consolidated_label\` permits implementation dispatch.
 
    Capture the new issue number as \$NEW_NUM.
 

--- a/.agents/scripts/tests/test-consolidation-dispatch.sh
+++ b/.agents/scripts/tests/test-consolidation-dispatch.sh
@@ -296,6 +296,10 @@ test_child_body_contains_parent_content_and_authors() {
 		failures=$((failures + 1))
 		failmsg="${failmsg} | missing self-contained warning"
 	fi
+	if ! printf '%s' "$body" | grep -qF -- '--label "consolidated,origin:worker,auto-dispatch,<copy relevant labels from parent, excluding needs-consolidation, consolidation-task, and origin:interactive>"'; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | consolidated successor instructions omit auto-dispatch handoff"
+	fi
 	if printf '%s' "$body" | grep -q 'github-actions'; then
 		failures=$((failures + 1))
 		failmsg="${failmsg} | bot comment leaked into child body"


### PR DESCRIPTION
## Summary

Include auto-dispatch in generated consolidated successor instructions so the producer satisfies the existing canonical-marker consumer gate.

## Files Changed

.agents/scripts/pulse-triage-dispatch.sh, .agents/scripts/tests/test-consolidation-dispatch.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Consolidation dispatch suite 34/34; consolidated-label suite 10/10; ShellCheck; local linter suite; git diff --check.

Resolves #28931


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 1h 22m and 561,120 tokens on this with the user in an interactive session.