### PR TITLE
GH#28925: Bound standalone merge scans

### DIFF
--- a/.agents/scripts/pulse-merge-routine.sh
+++ b/.agents/scripts/pulse-merge-routine.sh
@@ -151,9 +151,30 @@ source "${SCRIPT_DIR}/pulse-merge-stuck.sh"
 # Env-var defaults (belt-and-suspenders — also guarded inside the function)
 # =============================================================================
 
-# PULSE_MERGE_BATCH_LIMIT is normally set by pulse-wrapper.sh:727. Set a
-# safe default here so standalone invocation doesn't hit an unbound variable.
+# PULSE_MERGE_BATCH_LIMIT is normally set by pulse-wrapper.sh:727. Keep the
+# standalone routine's per-repository enrichment set bounded even when an
+# inherited environment requests a full-repository scan.
 PULSE_MERGE_BATCH_LIMIT="${PULSE_MERGE_BATCH_LIMIT:-50}"
+PULSE_MERGE_ROUTINE_BATCH_LIMIT_MAX="${PULSE_MERGE_ROUTINE_BATCH_LIMIT_MAX:-50}"
+[[ "$PULSE_MERGE_ROUTINE_BATCH_LIMIT_MAX" =~ ^[1-9][0-9]*$ ]] || PULSE_MERGE_ROUTINE_BATCH_LIMIT_MAX=50
+[[ "$PULSE_MERGE_BATCH_LIMIT" =~ ^[1-9][0-9]*$ ]] || PULSE_MERGE_BATCH_LIMIT="$PULSE_MERGE_ROUTINE_BATCH_LIMIT_MAX"
+if [[ "$PULSE_MERGE_BATCH_LIMIT" -gt "$PULSE_MERGE_ROUTINE_BATCH_LIMIT_MAX" ]]; then
+	PULSE_MERGE_BATCH_LIMIT="$PULSE_MERGE_ROUTINE_BATCH_LIMIT_MAX"
+fi
+export PULSE_MERGE_BATCH_LIMIT PULSE_MERGE_ROUTINE_BATCH_LIMIT_MAX
+
+# Match the normal pulse bootstrap's durable REST PR-view cache. Standalone
+# scheduler launches are separate processes, so the wrapper's PID-scoped
+# fallback would otherwise start cold on every cycle. Mutation-sensitive reads
+# continue to bypass this cache at their existing call sites.
+AIDEVOPS_GH_PR_VIEW_CACHE="${AIDEVOPS_GH_PR_VIEW_CACHE:-1}"
+AIDEVOPS_GH_PR_VIEW_CACHE_DIR="${AIDEVOPS_GH_PR_VIEW_CACHE_DIR:-${AIDEVOPS_PULSE_PR_VIEW_CACHE_DIR:-${HOME}/.aidevops/cache/pulse-pr-view-cache}}"
+AIDEVOPS_GH_PR_VIEW_CACHE_TTL="${AIDEVOPS_GH_PR_VIEW_CACHE_TTL:-${AIDEVOPS_PULSE_PR_VIEW_CACHE_TTL:-3600}}"
+if [[ "$AIDEVOPS_GH_PR_VIEW_CACHE" == "1" ]] && ! mkdir -p "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR"; then
+	printf 'pulse-merge-routine: failed to create persistent PR view cache: %s\n' "$AIDEVOPS_GH_PR_VIEW_CACHE_DIR" >&2
+	AIDEVOPS_GH_PR_VIEW_CACHE=0
+fi
+export AIDEVOPS_GH_PR_VIEW_CACHE AIDEVOPS_GH_PR_VIEW_CACHE_DIR AIDEVOPS_GH_PR_VIEW_CACHE_TTL
 
 # PULSE_START_EPOCH is normally set by pulse-wrapper.sh. Shared bootstrap keeps
 # standalone runners safe under `set -u` and exports the value for helpers that
@@ -479,7 +500,10 @@ pulse-enabled repos from REPOS_JSON (${REPOS_JSON}). The in-cycle merge call
 in pulse-wrapper.sh short-circuits when this routine ran within the last 60s.
 
 Env overrides:
-  PULSE_MERGE_BATCH_LIMIT=50              Max PRs fetched per repo per run.
+  PULSE_MERGE_BATCH_LIMIT=${PULSE_MERGE_BATCH_LIMIT}              Max PRs fetched per repo per run.
+  PULSE_MERGE_ROUTINE_BATCH_LIMIT_MAX=${PULSE_MERGE_ROUTINE_BATCH_LIMIT_MAX}  Standalone hard ceiling.
+  AIDEVOPS_GH_PR_VIEW_CACHE=1             Reuse non-mutation PR views across runs.
+  AIDEVOPS_GH_PR_VIEW_CACHE_TTL=3600      Persistent PR-view cache TTL in seconds.
   PULSE_MERGE_ROUTINE_TIMEOUT_SECONDS=600 Hard ceiling on routine runtime (t3041).
                                           Process tree killed on overrun. Min 1s.
   DRY_RUN=1                               Same as --dry-run.

--- a/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
+++ b/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
@@ -57,6 +57,8 @@
 #   19. stuck escalation invokes the idempotent comment provider
 #   20. both paths run without missing-function diagnostics
 #   21. missing gh authentication aborts before the first API request
+#   22. standalone runs initialise a durable cross-process PR-view cache
+#   23. inherited oversized PR batches are clamped for standalone runs
 
 set -uo pipefail
 
@@ -216,6 +218,35 @@ if [[ "$auth_exit" -ne 0 ]] && printf '%s\n' "$auth_output" | grep -qF 'refusing
 else
 	fail "6c: missing gh authentication aborts before API access" \
 		"exit=$auth_exit, output=$auth_output"
+fi
+
+# =============================================================================
+# Test 6d: standalone bootstrap creates the persistent PR-view cache
+# =============================================================================
+cache_test_home=$(mktemp -d)
+cache_output=""
+cache_exit=0
+cache_output=$(HOME="$cache_test_home" "$ROUTINE_FILE" help 2>&1) || cache_exit=$?
+if [[ "$cache_exit" -eq 0 && -d "$cache_test_home/.aidevops/cache/pulse-pr-view-cache" ]]; then
+	pass "6d: standalone bootstrap initialises persistent PR-view cache"
+else
+	fail "6d: standalone bootstrap initialises persistent PR-view cache" \
+		"exit=$cache_exit, output=$cache_output"
+fi
+rm -rf "$cache_test_home"
+
+# =============================================================================
+# Test 6e: standalone bootstrap clamps inherited oversized PR batches
+# =============================================================================
+bounded_output=""
+bounded_exit=0
+bounded_output=$(PULSE_MERGE_BATCH_LIMIT=310 PULSE_MERGE_ROUTINE_BATCH_LIMIT_MAX=50 \
+	"$ROUTINE_FILE" help 2>&1) || bounded_exit=$?
+if [[ "$bounded_exit" -eq 0 ]] && printf '%s\n' "$bounded_output" | grep -qF 'PULSE_MERGE_BATCH_LIMIT=50'; then
+	pass "6e: standalone bootstrap clamps oversized PR batches"
+else
+	fail "6e: standalone bootstrap clamps oversized PR batches" \
+		"exit=$bounded_exit, output=$bounded_output"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Give standalone merge cycles the same stable cross-process PR-view cache as normal Pulse and clamp inherited per-repository candidate batches before enrichment.

## Files Changed

.agents/scripts/pulse-merge-routine.sh, .agents/scripts/tests/test-pulse-merge-routine-standalone.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Standalone merge routine suite 23/23; REST fallback suite 89/89; ShellCheck; local linter suite; git diff --check.

Resolves #28925


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 1h 29m and 642,338 tokens on this with the user in an interactive session.