### PR TITLE
GH#28947: Restore collaborator-authored debt dispatch

### DIFF
--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -1045,12 +1045,12 @@ _nmr_evaluate_reason_metadata() {
 
 #######################################
 # Check if the needs-maintainer-review label was most recently applied
-# by the maintainer themselves (indicating a manual hold), OR by a
+# by a write-authorized maintainer (indicating a manual hold), OR by a
 # circuit breaker trip (which must be treated as a hold even though
 # the token actor is the maintainer).
 #
-# GH#18671 / t2386: the pulse runs as the maintainer's GitHub token,
-# so `actor.login == maintainer` matches all three cases:
+# GH#18671 / t2386: the pulse runs as a write-authorized GitHub token,
+# so a maintainer-equivalent label actor matches all three cases:
 #   1. Human maintainer clicks the label (manual hold)
 #   2. Pulse scanner applies default NMR at creation (auto-clear OK)
 #   3. Circuit breaker trips (t2007 cost / t2008 stale) — MUST preserve
@@ -1150,17 +1150,29 @@ _nmr_applied_by_maintainer() {
 		return 0
 	fi
 
-	if [[ "$nmr_actor" != "$maintainer" ]]; then
+	if [[ -z "$nmr_actor" ]]; then
 		return 1
 	fi
+	local nmr_actor_authority_rc=0
+	#aidevops:trust-boundary -- a transient authority lookup must preserve an
+	# identified actor's NMR hold rather than silently treating it as automation.
+	_gh_actor_has_repo_write_authority "$slug" "$nmr_actor" "COLLABORATOR" || nmr_actor_authority_rc=$?
+	case "$nmr_actor_authority_rc" in
+	0) ;;
+	1) return 1 ;;
+	*)
+		echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — authority lookup failed for actor=${nmr_actor}; preserving NMR" >>"$LOGFILE"
+		return 0
+		;;
+	esac
 
-	# Actor matches the maintainer. Two remaining possibilities:
+	# Actor has maintainer-equivalent write authority. Two possibilities remain:
 	#   1. Creation-default signature (scanner applied NMR at creation
 	#      time) → auto-approve OK, return 1.
 	#   2. No signature → genuine manual hold, return 0.
 	if [[ -n "$nmr_at" ]]; then
 		if _nmr_application_has_automation_signature "$issue_num" "$slug" "$nmr_at"; then
-			echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — actor=${maintainer} but creation-default signature detected — classifying as automation-applied (GH#18671)" >>"$LOGFILE"
+			echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — write-authorized actor=${nmr_actor} but creation-default signature detected — classifying as automation-applied (GH#18671)" >>"$LOGFILE"
 			return 1
 		fi
 	fi
@@ -1267,12 +1279,13 @@ notify_ever_nmr_without_approval() {
 # Before automation posts `aidevops-signed-approval` or says "maintainer is
 # author", self-validate against GitHub: the current token actor must have
 # write/maintain/admin permission on the target repo, and the issue author must
-# be an upstream OWNER/MEMBER with the expected maintainer login.
+# independently have write/maintain/admin authority. This includes account-pool
+# collaborators that create trusted scanner issues in a user-owned repository.
 #
 # Arguments:
 #   $1 - issue number
 #   $2 - repo slug (owner/repo)
-#   $3 - expected maintainer login from repos.json
+#   $3 - configured maintainer login from repos.json
 #   $4 - issue author login from the list response
 # Returns: 0 when approval comments may be posted, 1 otherwise.
 #######################################
@@ -1283,7 +1296,6 @@ _nmr_current_actor_can_post_maintainer_approval() {
 	local listed_author="$4"
 
 	[[ -n "$issue_num" && -n "$slug" && -n "$maintainer" && -n "$listed_author" ]] || return 1
-	[[ "$listed_author" == "$maintainer" ]] || return 1
 
 	local issue_meta
 	local issue_api_path
@@ -1295,11 +1307,11 @@ _nmr_current_actor_can_post_maintainer_approval() {
 	local issue_assoc
 	issue_author=$(printf '%s' "$issue_meta" | jq -r '.user.login // empty' 2>/dev/null) || issue_author=""
 	issue_assoc=$(printf '%s' "$issue_meta" | jq -r '.author_association // "NONE"' 2>/dev/null) || issue_assoc="NONE"
-	[[ "$issue_author" == "$maintainer" ]] || return 1
-	case "$issue_assoc" in
-	OWNER | MEMBER) ;;
-	*) return 1 ;;
-	esac
+	[[ "$issue_author" == "$listed_author" ]] || return 1
+
+	# #aidevops:trust-boundary — never infer author authority from the mutable
+	# configured maintainer field or author_association alone.
+	_gh_actor_has_repo_write_authority "$slug" "$issue_author" "$issue_assoc" || return 1
 
 	local actor
 	actor=$(gh api user --jq '.login // empty' 2>/dev/null) || actor=""
@@ -1658,9 +1670,9 @@ _nmr_restore_dispatchable_state() {
 # issue <number>`. This ensures only a human with the system password
 # (and root access to the approval signing key) can approve issues.
 #
-# Fallback: maintainer-authored issues are still auto-approved (the
-# maintainer wouldn't gate their own issues), UNLESS the maintainer
-# manually applied NMR themselves — that signals an intentional hold
+# Fallback: maintainer-equivalent authored issues are still auto-approved (a
+# trusted scanner account should not gate its own issues), UNLESS a write-
+# authorized maintainer manually applied NMR — that signals an intentional hold
 # and must be preserved. Comment-based approval is removed — workers
 # share the same GitHub account so any comment from the account is
 # indistinguishable from a human comment.
@@ -1697,16 +1709,14 @@ auto_approve_maintainer_issues() {
 			local approval_reason=""
 			_NMR_AUTO_APPROVAL_REASON_OVERRIDE=""
 
-			# Case 1: maintainer created the issue — auto-approve unless NMR
-			# was manually applied by the maintainer (intentional hold).
-			if [[ "$issue_author" == "$maintainer" ]]; then
-				if ! _nmr_current_actor_can_post_maintainer_approval "$issue_num" "$slug" "$maintainer" "$issue_author"; then
-					echo "[pulse-wrapper] Skipping auto-approve for #${issue_num} in ${slug} — maintainer-authority trust-boundary check failed" >>"$LOGFILE"
-				elif _nmr_applied_by_maintainer "$issue_num" "$slug" "$maintainer"; then
+			# Case 1: a maintainer-equivalent actor created the issue — auto-approve
+			# unless a write-authorized maintainer applied an intentional hold.
+			if _nmr_current_actor_can_post_maintainer_approval "$issue_num" "$slug" "$maintainer" "$issue_author"; then
+				if _nmr_applied_by_maintainer "$issue_num" "$slug" "$maintainer"; then
 					echo "[pulse-wrapper] Skipping auto-approve for #${issue_num} in ${slug} — NMR manually applied by maintainer" >>"$LOGFILE"
 				else
 					should_approve=true
-					approval_reason="${_NMR_AUTO_APPROVAL_REASON_OVERRIDE:-maintainer is author, NMR applied by automation}"
+					approval_reason="${_NMR_AUTO_APPROVAL_REASON_OVERRIDE:-write-authorized maintainer is author, NMR applied by automation}"
 				fi
 			fi
 

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -1044,6 +1044,50 @@ _nmr_evaluate_reason_metadata() {
 }
 
 #######################################
+# Classify the latest NMR label event as a manual maintainer hold.
+#
+# Arguments:
+#   $1 - issue_num : GitHub issue number
+#   $2 - slug      : repo slug (owner/repo)
+#   $3 - nmr_actor : actor from the latest NMR label event
+#   $4 - nmr_at    : timestamp of the latest NMR label event
+#
+# Returns 0 when NMR must be preserved, 1 when auto-clear is allowed.
+#######################################
+_nmr_actor_event_is_manual_hold() {
+	local issue_num="$1"
+	local slug="$2"
+	local nmr_actor="$3"
+	local nmr_at="$4"
+
+	[[ -n "$nmr_actor" ]] || return 1
+
+	local nmr_actor_authority_rc=0
+	#aidevops:trust-boundary -- a transient authority lookup must preserve an
+	# identified actor's NMR hold rather than silently treating it as automation.
+	_gh_actor_has_repo_write_authority "$slug" "$nmr_actor" "COLLABORATOR" || nmr_actor_authority_rc=$?
+	case "$nmr_actor_authority_rc" in
+	0) ;;
+	1) return 1 ;;
+	*)
+		echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — authority lookup failed for actor=${nmr_actor}; preserving NMR" >>"$LOGFILE"
+		return 0
+		;;
+	esac
+
+	if [[ -n "$nmr_at" ]] && _nmr_application_has_automation_signature "$issue_num" "$slug" "$nmr_at"; then
+		echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — write-authorized actor=${nmr_actor} but creation-default signature detected — classifying as automation-applied (GH#18671)" >>"$LOGFILE"
+		return 1
+	fi
+
+	local authority_metadata=""
+	authority_metadata=$(_nmr_metadata_json "$NMR_REASON_AUTHORITY" "$NMR_CLASS_GENUINE_AUTHORITY" "manual-hold" true)
+	_nmr_record_revalidation_state "$issue_num" "$slug" "$authority_metadata" "$nmr_at" "$NMR_STATUS_HUMAN_AUTHORITY" || true
+	_nmr_emit_decision_packet "$issue_num" "$slug" "$NMR_REASON_AUTHORITY" || true
+	return 0
+}
+
+#######################################
 # Check if the needs-maintainer-review label was most recently applied
 # by a write-authorized maintainer (indicating a manual hold), OR by a
 # circuit breaker trip (which must be treated as a hold even though
@@ -1150,38 +1194,10 @@ _nmr_applied_by_maintainer() {
 		return 0
 	fi
 
-	if [[ -z "$nmr_actor" ]]; then
-		return 1
-	fi
-	local nmr_actor_authority_rc=0
-	#aidevops:trust-boundary -- a transient authority lookup must preserve an
-	# identified actor's NMR hold rather than silently treating it as automation.
-	_gh_actor_has_repo_write_authority "$slug" "$nmr_actor" "COLLABORATOR" || nmr_actor_authority_rc=$?
-	case "$nmr_actor_authority_rc" in
-	0) ;;
-	1) return 1 ;;
-	*)
-		echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — authority lookup failed for actor=${nmr_actor}; preserving NMR" >>"$LOGFILE"
+	if _nmr_actor_event_is_manual_hold "$issue_num" "$slug" "$nmr_actor" "$nmr_at"; then
 		return 0
-		;;
-	esac
-
-	# Actor has maintainer-equivalent write authority. Two possibilities remain:
-	#   1. Creation-default signature (scanner applied NMR at creation
-	#      time) → auto-approve OK, return 1.
-	#   2. No signature → genuine manual hold, return 0.
-	if [[ -n "$nmr_at" ]]; then
-		if _nmr_application_has_automation_signature "$issue_num" "$slug" "$nmr_at"; then
-			echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — write-authorized actor=${nmr_actor} but creation-default signature detected — classifying as automation-applied (GH#18671)" >>"$LOGFILE"
-			return 1
-		fi
 	fi
-
-	local authority_metadata=""
-	authority_metadata=$(_nmr_metadata_json "$NMR_REASON_AUTHORITY" "$NMR_CLASS_GENUINE_AUTHORITY" "manual-hold" true)
-	_nmr_record_revalidation_state "$issue_num" "$slug" "$authority_metadata" "$nmr_at" "$NMR_STATUS_HUMAN_AUTHORITY" || true
-	_nmr_emit_decision_packet "$issue_num" "$slug" "$NMR_REASON_AUTHORITY" || true
-	return 0
+	return 1
 }
 
 #######################################

--- a/.agents/scripts/shared-gh-collaborator-permission.sh
+++ b/.agents/scripts/shared-gh-collaborator-permission.sh
@@ -204,7 +204,10 @@ _gh_collaborator_permission_lookup() {
 	local line=""
 	local body=""
 	local in_body=0
-	local permission_value=""
+	# Keep the internal value distinct from caller-selected output names. Bash
+	# uses dynamic scope, so a local named permission_value would shadow the
+	# common caller output variable and silently return an empty permission.
+	local resolved_permission=""
 
 	AIDEVOPS_GH_COLLAB_PERMISSION_HTTP="$_AIDEVOPS_GH_PERMISSION_UNKNOWN_VALUE"
 	AIDEVOPS_GH_COLLAB_PERMISSION_REASON="$_AIDEVOPS_GH_PERMISSION_UNKNOWN_VALUE"
@@ -268,18 +271,18 @@ _gh_collaborator_permission_lookup() {
 		return 2
 	fi
 
-	permission_value=$(printf '%s' "$body" | jq -r '.permission // .role_name // ""' 2>/dev/null) || permission_value=""
-	if [[ -z "$permission_value" ]]; then
-		permission_value=$(printf '%s' "$api_response" | sed -nE 's/^[[:space:]]*\{?[[:space:]]*"(permission|role_name)"[[:space:]]*:[[:space:]]*"(admin|maintain|write|triage|read|none)".*/\2/p' | tail -1) || permission_value=""
+	resolved_permission=$(printf '%s' "$body" | jq -r '.permission // .role_name // ""' 2>/dev/null) || resolved_permission=""
+	if [[ -z "$resolved_permission" ]]; then
+		resolved_permission=$(printf '%s' "$api_response" | sed -nE 's/^[[:space:]]*\{?[[:space:]]*"(permission|role_name)"[[:space:]]*:[[:space:]]*"(admin|maintain|write|triage|read|none)".*/\2/p' | tail -1) || resolved_permission=""
 	fi
-	case "$permission_value" in
+	case "$resolved_permission" in
 	admin | maintain | write | triage | read | none)
 		AIDEVOPS_GH_COLLAB_PERMISSION_REASON="ok"
 		export AIDEVOPS_GH_COLLAB_PERMISSION_REASON
 		if [[ -n "$out_var" ]]; then
-			printf -v "$out_var" '%s' "$permission_value"
+			printf -v "$out_var" '%s' "$resolved_permission"
 		else
-			printf '%s\n' "$permission_value"
+			printf '%s\n' "$resolved_permission"
 		fi
 		return 0
 		;;

--- a/.agents/scripts/tests/test-pulse-nmr-maintainer-authority.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-maintainer-authority.sh
@@ -40,6 +40,8 @@ setup_test_env() {
 	export ISSUE_API_AUTHOR="maintainer"
 	export ISSUE_LIST_AUTHOR="maintainer"
 	export ACTOR_PERMISSION="write"
+	export AUTHOR_PERMISSION="write"
+	export NMR_TIMELINE_JSON='[]'
 	: >"$LOGFILE"
 	: >"$POSTED_COMMENT"
 	: >"$STATUS_CALLS_FILE"
@@ -53,6 +55,10 @@ if [[ "${1:-}" == "api" ]]; then
 		path="${3:-}"
 		if [[ "$path" == */collaborators/runner/permission ]]; then
 			printf 'HTTP/2.0 200 OK\n\n{"permission":"%s"}\n' "${ACTOR_PERMISSION:-none}"
+			exit 0
+		fi
+		if [[ "$path" == */collaborators/trusted-author/permission ]]; then
+			printf 'HTTP/2.0 200 OK\n\n{"permission":"%s"}\n' "${AUTHOR_PERMISSION:-none}"
 			exit 0
 		fi
 	fi
@@ -73,12 +79,16 @@ if [[ "${1:-}" == "api" ]]; then
 		printf '{"permission":"%s"}\n' "${ACTOR_PERMISSION:-none}" | jq -r "${jq_filter:-.}"
 		exit 0
 	fi
+	if [[ "$path" == */collaborators/trusted-author/permission ]]; then
+		printf '{"permission":"%s"}\n' "${AUTHOR_PERMISSION:-none}" | jq -r "${jq_filter:-.}"
+		exit 0
+	fi
 	if [[ "$path" == */issues/24479 ]]; then
 		printf '{"user":{"login":"%s"},"author_association":"%s","labels":[]}\n' "${ISSUE_API_AUTHOR:-maintainer}" "${ISSUE_ASSOC:-NONE}"
 		exit 0
 	fi
 	if [[ "$path" == */timeline ]]; then
-		printf '[]\n'
+		printf '%s\n' "${NMR_TIMELINE_JSON:-[]}"
 		exit 0
 	fi
 	if [[ "$path" == */comments ]]; then
@@ -137,6 +147,10 @@ export -f set_issue_status
 run_auto_approve() {
 	# shellcheck disable=SC1090
 	source "$NMR_SCRIPT"
+	# Keep reason-classification tests from writing the user's persistent cache.
+	_nmr_record_revalidation_state() {
+		return 0
+	}
 	auto_approve_maintainer_issues
 	return 0
 }
@@ -202,11 +216,63 @@ test_allows_owner_author_with_write_permission() {
 	return 0
 }
 
+test_allows_write_authorized_collaborator() {
+	setup_test_env
+	export ISSUE_LIST_AUTHOR="trusted-author"
+	export ISSUE_API_AUTHOR="trusted-author"
+	export ISSUE_ASSOC="COLLABORATOR"
+	export AUTHOR_PERMISSION="write"
+	run_auto_approve
+	if grep -q 'aidevops-signed-approval' "$POSTED_COMMENT" 2>/dev/null; then
+		print_result "auto-approval allows write-authorized collaborator issues" 0
+	else
+		print_result "auto-approval allows write-authorized collaborator issues" 1 "approval comment missing"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_blocks_read_only_collaborator() {
+	setup_test_env
+	export ISSUE_LIST_AUTHOR="trusted-author"
+	export ISSUE_API_AUTHOR="trusted-author"
+	export ISSUE_ASSOC="COLLABORATOR"
+	export AUTHOR_PERMISSION="read"
+	run_auto_approve
+	if [[ ! -s "$POSTED_COMMENT" ]]; then
+		print_result "auto-approval blocks read-only collaborator issues" 0
+	else
+		print_result "auto-approval blocks read-only collaborator issues" 1 "unexpected approval comment"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_preserves_peer_maintainer_manual_hold() {
+	setup_test_env
+	export ISSUE_LIST_AUTHOR="trusted-author"
+	export ISSUE_API_AUTHOR="trusted-author"
+	export ISSUE_ASSOC="COLLABORATOR"
+	export AUTHOR_PERMISSION="write"
+	export NMR_TIMELINE_JSON='[{"event":"labeled","label":{"name":"needs-maintainer-review"},"actor":{"login":"trusted-author"},"created_at":"2026-07-30T20:00:00Z"}]'
+	run_auto_approve
+	if ! grep -q 'aidevops-signed-approval' "$POSTED_COMMENT" 2>/dev/null && [[ ! -s "$STATUS_CALLS_FILE" ]]; then
+		print_result "auto-approval preserves peer maintainer manual NMR hold" 0
+	else
+		print_result "auto-approval preserves peer maintainer manual NMR hold" 1 "unexpected approval or status transition"
+	fi
+	teardown_test_env
+	return 0
+}
+
 main() {
 	test_blocks_none_author_association
 	test_blocks_external_author_even_with_nmr_automation
 	test_blocks_actor_without_write_permission
 	test_allows_owner_author_with_write_permission
+	test_allows_write_authorized_collaborator
+	test_blocks_read_only_collaborator
+	test_preserves_peer_maintainer_manual_hold
 	printf '\nTests run: %d\n' "$TESTS_RUN"
 	printf 'Tests failed: %d\n' "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Preserve collaborator permission outputs, recognize write-authorized scanner authors for NMR auto-approval, and keep manual peer-maintainer holds fail-closed.

## Files Changed

.agents/scripts/pulse-nmr-approval.sh, .agents/scripts/shared-gh-collaborator-permission.sh, .agents/scripts/tests/test-pulse-nmr-maintainer-authority.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused NMR, collaborator-authority, collaborator current-user, and complexity sweep tests pass; ShellCheck clean.

Resolves #28947


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 16m and 260,223 tokens on this as a headless worker.