### PR TITLE
GH#28942: Preserve worker ownership during status handoff

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-gates.sh
+++ b/.agents/scripts/pulse-dispatch-worker-gates.sh
@@ -39,12 +39,12 @@ _dlw_mark_worker_in_progress() {
 		echo "[dispatch_with_dedup] Worker registration for #${issue_number} has non-live PID ${worker_pid}; retaining status:queued for recovery" >>"$LOGFILE"
 		return 1
 	fi
-	if ! declare -F set_issue_status >/dev/null 2>&1; then
-		echo "[dispatch_with_dedup] Cannot transition #${issue_number} to status:in-progress: status helper unavailable" >>"$LOGFILE"
+	if ! declare -F transition_owned_issue_status >/dev/null 2>&1; then
+		echo "[dispatch_with_dedup] Cannot transition #${issue_number} to status:in-progress: ownership-transition helper unavailable" >>"$LOGFILE"
 		return 1
 	fi
-	if ! set_issue_status "$issue_number" "$repo_slug" "in-progress" \
-		--add-assignee "$self_login" >/dev/null 2>&1; then
+	if ! transition_owned_issue_status "$issue_number" "$repo_slug" "$self_login" \
+		"queued" "in-progress" >/dev/null 2>&1; then
 		echo "[dispatch_with_dedup] Failed to transition registered worker #${issue_number} to status:in-progress; retaining queued recovery signal" >>"$LOGFILE"
 		return 1
 	fi

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -688,9 +688,10 @@ _rest_issue_remove_label_deltas() {
 
 #######################################
 # Apply filtered deltas in the phase-specific safe order. Passthrough metadata
-# adds first so a rejected replacement leaves existing values intact. Managed
+# adds first so a rejected replacement leaves existing values intact. General
 # status transitions remove first so a failed target add cannot create a dual
-# status state.
+# status state. Ownership handoffs may explicitly use add-first when continuous
+# acceptance is more important than avoiding a temporary dual-status overlap.
 _rest_issue_apply_delta_plan() {
 	local issue_path="$1"
 	local adds_l="$2"
@@ -724,6 +725,8 @@ _rest_issue_edit_preserving_deltas() {
 	shift || true
 	local repo=""
 	local delta_order="add-first"
+	local required_label=""
+	local required_assignee=""
 	local -a delta_add_labels=() delta_rm_labels=() delta_add_assignees=() delta_rm_assignees=()
 	local arg="" value="" token=""
 	while [[ $# -gt 0 ]]; do
@@ -731,6 +734,8 @@ _rest_issue_edit_preserving_deltas() {
 		[[ "$arg" == *=* ]] && { value="${arg#*=}"; arg="${arg%%=*}"; shift; } || { value="${2:-}"; shift 2; }
 		case "$arg" in
 		--repo) repo="$value" ;;
+		--require-label) required_label="$value" ;;
+		--require-assignee) required_assignee="$value" ;;
 		--delta-order)
 			[[ "$value" == "add-first" || "$value" == "remove-first" ]] || return 1
 			delta_order="$value"
@@ -754,6 +759,13 @@ _rest_issue_edit_preserving_deltas() {
 	_rest_issue_delta_snapshot_valid "$current_json" || return 1
 	current_labels=$(printf '%s' "$current_json" | jq -r '.labels[].name') || return 1
 	current_assignees=$(printf '%s' "$current_json" | jq -r '.assignees[].login') || return 1
+	_REST_ISSUE_DELTA_FAILURE_STAGE="precondition"
+	if [[ -n "$required_label" ]] && ! _rest_lines_contain "$current_labels" "$required_label"; then
+		return 1
+	fi
+	if [[ -n "$required_assignee" ]] && ! _rest_lines_contain "$current_assignees" "$required_assignee"; then
+		return 1
+	fi
 
 	local adds_l="" rms_l="" adds_a="" rms_a=""
 	adds_l=$(_rest_filter_issue_deltas "$current_labels" "$(printf '%s\n' "${delta_add_labels[@]}")" "" add) || return 1

--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -702,6 +702,84 @@ set_issue_status() {
 }
 
 #######################################
+# Transition an owned issue between accepted worker states without ever
+# removing the source state before the target state has been accepted.
+#
+# The source label and owner are checked against the same REST snapshot used to
+# plan targeted mutations. The target is added before sibling statuses are
+# removed. There is deliberately no native fallback: if REST preflight or a
+# mutation fails, retaining the source label (or a temporary source+target
+# overlap) is safer than creating an unowned gap or overwriting a takeover.
+#
+# Args:
+#   $1 — issue number
+#   $2 — repo slug (owner/repo)
+#   $3 — required assignee login
+#   $4 — required source status
+#   $5 — target status
+# Returns: 0 on complete transition, 1 on precondition/mutation failure,
+#          2 on invalid arguments
+#######################################
+transition_owned_issue_status() {
+	gh_record_call rest transition_owned_issue_status 2>/dev/null || true
+	local issue_num="$1"
+	local repo_slug="$2"
+	local owner_login="$3"
+	local source_status="$4"
+	local target_status="$5"
+
+	if [[ -z "$issue_num" || -z "$repo_slug" || -z "$owner_login" || -z "$source_status" || -z "$target_status" ]]; then
+		printf 'transition_owned_issue_status: all arguments are required\n' >&2
+		return 2
+	fi
+	if [[ "$source_status" == "$target_status" ]]; then
+		printf 'transition_owned_issue_status: source and target statuses must differ\n' >&2
+		return 2
+	fi
+
+	local _candidate=""
+	local _status=""
+	local _valid=0
+	for _candidate in "$source_status" "$target_status"; do
+		_valid=0
+		for _status in "${ISSUE_STATUS_LABELS[@]}"; do
+			if [[ "$_status" == "$_candidate" ]]; then
+				_valid=1
+				break
+			fi
+		done
+		if [[ "$_valid" -eq 0 ]]; then
+			printf 'transition_owned_issue_status: invalid status "%s" (valid: %s)\n' \
+				"$_candidate" "${ISSUE_STATUS_LABELS[*]}" >&2
+			return 2
+		fi
+	done
+
+	if ! ensure_status_labels_exist "$repo_slug"; then
+		print_warning "gh-wrapper: unable to verify status-label contract for ${repo_slug}"
+		return 1
+	fi
+
+	local -a _status_flags=()
+	local _label=""
+	local _status_label=""
+	for _label in "${ISSUE_STATUS_LABELS[@]}"; do
+		printf -v _status_label 'status:%s' "$_label"
+		if [[ "$_label" == "$target_status" ]]; then
+			_status_flags+=(--add-label "$_status_label")
+		else
+			_status_flags+=(--remove-label "$_status_label")
+		fi
+	done
+
+	AIDEVOPS_GH_ROUTE_DECISION="owned-status-transition-rest-deltas" \
+		_rest_issue_edit_preserving_deltas "$issue_num" --repo "$repo_slug" \
+		--require-label "status:${source_status}" --require-assignee "$owner_login" \
+		--delta-order add-first "${_status_flags[@]}"
+	return $?
+}
+
+#######################################
 # gh_issue_view — drop-in replacement for gh issue view.  (t2689)
 # Routes directly to REST (`gh api GET /repos/{owner}/{repo}/issues/{N}`) when
 # GraphQL remaining is below the fallback threshold, and still falls back to

--- a/.agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh
@@ -146,6 +146,16 @@ set_issue_status() {
 	return 0
 }
 
+transition_owned_issue_status() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local owner_login="$3"
+	local source_status="$4"
+	local target_status="$5"
+	STATUS_MUTATIONS="${issue_number}|${repo_slug}|${owner_login}|${source_status}|${target_status}"
+	return 0
+}
+
 original_script_dir="$SCRIPT_DIR"
 SCRIPT_DIR="$TEST_TMP"
 _claim_comment_id="77"
@@ -155,7 +165,7 @@ PULSE_DISPATCH_STAGGER_SECONDS=0
 export TEST_LEDGER_RC=0
 LOGFILE="${TEST_TMP}/pulse.log" _dlw_post_launch_hooks \
 	"123" "owner/repo" "runner-a" "$$" "issue-123" "standard" "test-model" "${TEST_TMP}/worktree" "attempt-123"
-if [[ "$STATUS_MUTATIONS" != "123|owner/repo|in-progress|--add-assignee runner-a" ]]; then
+if [[ "$STATUS_MUTATIONS" != "123|owner/repo|runner-a|queued|in-progress" ]]; then
 	fail "successful worker registration did not transition queued issue to in-progress: ${STATUS_MUTATIONS:-none}"
 fi
 if ! grep -Fq 'aidevops:dispatch lease_token=lease-123 device=device-a session=issue-123 attempt_id=attempt-123 claim_id=77' "$GH_CALLS_FILE"; then

--- a/.agents/scripts/tests/test-status-label-state-machine.sh
+++ b/.agents/scripts/tests/test-status-label-state-machine.sh
@@ -790,6 +790,109 @@ test_failed_extra_add_preserves_existing_label() {
 	return 0
 }
 
+#######################################
+# TEST 20: Owned worker transitions add the accepted target before removing the
+# queued recovery signal, then converge to one status.
+#######################################
+test_owned_transition_adds_target_before_source_removal() {
+	_reset_state
+	printf '%s\n' '{"labels":[{"name":"status:queued"}],"assignees":[{"login":"runner-a"}]}' >"$ISSUE_STATE_FILE"
+	export STUB_STATEFUL_ISSUE=1
+	transition_owned_issue_status 1623 "owner/repo" "runner-a" "queued" "in-progress"
+	local rc=$?
+	local final_statuses=""
+	local add_line=""
+	local remove_line=""
+	final_statuses=$(jq -r '.labels[].name | select(startswith("status:"))' "$ISSUE_STATE_FILE")
+	add_line=$(grep -n '^api -X POST /repos/owner/repo/issues/1623/labels -f labels\[\]=status:in-progress$' \
+		"$GH_CALLS_FILE" | cut -d: -f1 || true)
+	remove_line=$(grep -n '^api -X DELETE /repos/owner/repo/issues/1623/labels/status%3Aqueued$' \
+		"$GH_CALLS_FILE" | cut -d: -f1 || true)
+	if [[ "$rc" -eq 0 && "$final_statuses" == "status:in-progress" && -n "$add_line" && -n "$remove_line" && "$add_line" -lt "$remove_line" ]]; then
+		print_result "owned transition adds target before removing source" 0
+	else
+		print_result "owned transition adds target before removing source" 1 \
+			"(rc=${rc}; statuses=${final_statuses}; add=${add_line}; remove=${remove_line}; calls=$(cat "$GH_CALLS_FILE"))"
+	fi
+	return 0
+}
+
+#######################################
+# TEST 21: A rejected target add leaves the queued recovery signal intact and
+# never falls back to an ordering-unknown native mutation.
+#######################################
+test_owned_transition_failed_add_preserves_source() {
+	_reset_state
+	printf '%s\n' '{"labels":[{"name":"status:queued"}],"assignees":[{"login":"runner-a"}]}' >"$ISSUE_STATE_FILE"
+	export STUB_STATEFUL_ISSUE=1
+	export STUB_REST_MUTATION_FAIL_METHOD=POST
+	transition_owned_issue_status 1624 "owner/repo" "runner-a" "queued" "in-progress" >/dev/null 2>&1
+	local rc=$?
+	local final_statuses=""
+	final_statuses=$(jq -r '.labels[].name | select(startswith("status:"))' "$ISSUE_STATE_FILE")
+	if [[ "$rc" -ne 0 && "$final_statuses" == "status:queued" ]] &&
+		! grep -q '^issue edit 1624 ' "$GH_CALLS_FILE"; then
+		print_result "failed owned target add preserves queued source" 0
+	else
+		print_result "failed owned target add preserves queued source" 1 \
+			"(rc=${rc}; statuses=${final_statuses}; calls=$(cat "$GH_CALLS_FILE"))"
+	fi
+	return 0
+}
+
+#######################################
+# TEST 22: A failed source removal leaves an accepted overlap rather than a
+# zero-status ownership gap.
+#######################################
+test_owned_transition_failed_remove_preserves_overlap() {
+	_reset_state
+	printf '%s\n' '{"labels":[{"name":"status:queued"}],"assignees":[{"login":"runner-a"}]}' >"$ISSUE_STATE_FILE"
+	export STUB_STATEFUL_ISSUE=1
+	export STUB_REST_MUTATION_FAIL_METHOD=DELETE
+	transition_owned_issue_status 1625 "owner/repo" "runner-a" "queued" "in-progress" >/dev/null 2>&1
+	local rc=$?
+	local accepted_count=0
+	accepted_count=$(jq '[.labels[].name | select(. == "status:queued" or . == "status:in-progress")] | length' "$ISSUE_STATE_FILE")
+	if [[ "$rc" -ne 0 && "$accepted_count" -eq 2 ]] &&
+		! grep -q '^issue edit 1625 ' "$GH_CALLS_FILE"; then
+		print_result "failed owned source removal preserves accepted overlap" 0
+	else
+		print_result "failed owned source removal preserves accepted overlap" 1 \
+			"(rc=${rc}; accepted=${accepted_count}; calls=$(cat "$GH_CALLS_FILE"))"
+	fi
+	return 0
+}
+
+#######################################
+# TEST 23: The transition snapshot must still contain both the expected source
+# status and expected owner before any mutation starts.
+#######################################
+test_owned_transition_preconditions_fail_closed() {
+	_reset_state
+	printf '%s\n' '{"labels":[{"name":"status:in-review"}],"assignees":[{"login":"runner-a"}]}' >"$ISSUE_STATE_FILE"
+	export STUB_STATEFUL_ISSUE=1
+	transition_owned_issue_status 1626 "owner/repo" "runner-a" "queued" "in-progress" >/dev/null 2>&1
+	local source_rc=$?
+	local source_writes=0
+	source_writes=$(grep -Ec '^api -X (POST|DELETE) /repos/owner/repo/issues/1626/' "$GH_CALLS_FILE" || true)
+
+	_reset_state
+	printf '%s\n' '{"labels":[{"name":"status:queued"}],"assignees":[{"login":"runner-b"}]}' >"$ISSUE_STATE_FILE"
+	export STUB_STATEFUL_ISSUE=1
+	transition_owned_issue_status 1627 "owner/repo" "runner-a" "queued" "in-progress" >/dev/null 2>&1
+	local owner_rc=$?
+	local owner_writes=0
+	owner_writes=$(grep -Ec '^api -X (POST|DELETE) /repos/owner/repo/issues/1627/' "$GH_CALLS_FILE" || true)
+
+	if [[ "$source_rc" -ne 0 && "$owner_rc" -ne 0 && "$source_writes" -eq 0 && "$owner_writes" -eq 0 ]]; then
+		print_result "owned transition preconditions fail closed" 0
+	else
+		print_result "owned transition preconditions fail closed" 1 \
+			"(source_rc=${source_rc}; owner_rc=${owner_rc}; source_writes=${source_writes}; owner_writes=${owner_writes}; calls=$(cat "$GH_CALLS_FILE"))"
+	fi
+	return 0
+}
+
 # =============================================================================
 # Run tests
 # =============================================================================
@@ -814,6 +917,10 @@ main() {
 	test_failed_target_add_never_strands_dual_statuses
 	test_failed_extra_add_preserves_existing_assignee
 	test_failed_extra_add_preserves_existing_label
+	test_owned_transition_adds_target_before_source_removal
+	test_owned_transition_failed_add_preserves_source
+	test_owned_transition_failed_remove_preserves_overlap
+	test_owned_transition_preconditions_fail_closed
 
 	printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Add a preconditioned, add-first queued-to-in-progress handoff that keeps an accepted worker status present throughout mutation and refuses unsafe native fallback.

## Files Changed

.agents/scripts/pulse-dispatch-worker-gates.sh, .agents/scripts/shared-gh-wrappers-rest-fallback.sh, .agents/scripts/shared-gh-wrappers-status.sh, .agents/scripts/tests/test-pulse-dispatch-worker-launch-comment-metrics.sh, .agents/scripts/tests/test-status-label-state-machine.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — 45/45 status-state tests; 89/89 REST-wrapper tests; dispatch launch metrics tests; 16/16 lifecycle communication tests; changed-file and full local lint suites.

Resolves #28942


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 43m and 496,216 tokens on this with the user in an interactive session.