### PR TITLE
GH#28944: Make issue-sync first-match lookups pipe-safe

### DIFF
--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -348,11 +348,12 @@ _reopen_mark_if_completed() {
 _do_close() {
 	local task_id="$1" issue_number="$2" todo_file="$3" repo="$4"
 	require_task_issue_mapping "$task_id" "$todo_file" "$repo" "$issue_number" || return 1
-	local task_id_ere
-	task_id_ere=$(_escape_ere "$task_id")
 	local task_with_notes task_line pr_info pr_num="" pr_url=""
 	task_with_notes=$(extract_task_block "$task_id" "$todo_file")
-	task_line=$(strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${task_id_ere} " | head -1 || echo "")
+	if ! task_line=$(find_todo_task_line "$task_id" "$todo_file"); then
+		print_error "Failed to read TODO.md while looking up $task_id"
+		return 1
+	fi
 	[[ -z "$task_with_notes" ]] && task_with_notes="$task_line"
 
 	# GH#20828: probe parent-task label before closing. The workflow path's
@@ -379,7 +380,10 @@ _do_close() {
 		pr_num="${pr_info%%|*}"
 		pr_url="${pr_info#*|}"
 		[[ "$DRY_RUN" != "true" && -n "$pr_num" ]] && add_pr_ref_to_todo "$task_id" "$pr_num" "$todo_file"
-		task_line=$(strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${task_id_ere} " | head -1 || echo "")
+		if ! task_line=$(find_todo_task_line "$task_id" "$todo_file"); then
+			print_error "Failed to read TODO.md while refreshing $task_id"
+			return 1
+		fi
 		task_with_notes=$(extract_task_block "$task_id" "$todo_file")
 		[[ -z "$task_with_notes" ]] && task_with_notes="$task_line"
 	fi
@@ -432,10 +436,11 @@ cmd_close() {
 
 	# Single-task mode
 	if [[ -n "$target_task" ]]; then
-		local target_ere
-		target_ere=$(_escape_ere "$target_task")
 		local task_line
-		task_line=$(strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${target_ere} " | head -1 || echo "")
+		if ! task_line=$(find_todo_task_line "$target_task" "$todo_file"); then
+			print_error "Failed to read TODO.md while looking up $target_task"
+			return 1
+		fi
 		local num
 		num=$(echo "$task_line" | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || echo "")
 		if [[ -z "$num" ]]; then

--- a/.agents/scripts/issue-sync-helper-commands.sh
+++ b/.agents/scripts/issue-sync-helper-commands.sh
@@ -104,7 +104,7 @@ cmd_pull() {
 			login=$(echo "$issue_line" | jq -r '.assignees[0].login // empty' 2>/dev/null || echo "")
 			[[ -z "$login" ]] && continue
 			local tl
-			tl=$(strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${tid_ere} " | head -1 || echo "")
+			tl=$(find_todo_task_line "$tid" "$todo_file") || return 1
 			[[ -z "$tl" ]] && continue
 			echo "$tl" | grep -qE 'assignee:[A-Za-z0-9._@-]+' && continue
 			if [[ "$DRY_RUN" == "true" ]]; then

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -231,9 +231,6 @@ _push_finalize_task_creation() {
 _push_process_task() {
 	local task_id="$1" repo="$2" todo_file="$3" project_root="$4"
 	log_verbose "Processing $task_id..."
-	local task_id_ere
-	task_id_ere=$(_escape_ere "$task_id")
-
 	# Skip if issue already exists
 	local existing
 	existing=$(gh_find_issue_by_title "$repo" "${task_id}:" "all" 500)
@@ -244,7 +241,10 @@ _push_process_task() {
 	fi
 
 	local task_line
-	task_line=$(strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${task_id_ere} " | head -1 || echo "")
+	if ! task_line=$(find_todo_task_line "$task_id" "$todo_file"); then
+		print_error "Failed to read TODO.md while looking up $task_id"
+		return 1
+	fi
 	[[ -z "$task_line" ]] && {
 		print_warning "Task $task_id not found in TODO.md"
 		return 0
@@ -319,9 +319,10 @@ _push_process_task() {
 _enrich_process_task() {
 	local task_id="$1" repo="$2" todo_file="$3" project_root="$4" task_line="${5:-}"
 	if [[ -z "$task_line" ]]; then
-		local task_id_ere
-		task_id_ere=$(_escape_ere "$task_id")
-		task_line=$(strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${task_id_ere} " | head -1 || echo "")
+		if ! task_line=$(find_todo_task_line "$task_id" "$todo_file"); then
+			print_error "Failed to read TODO.md while looking up $task_id"
+			return 1
+		fi
 	fi
 	local num
 	num=$(echo "$task_line" | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || echo "")

--- a/.agents/scripts/issue-sync-lib-parse.sh
+++ b/.agents/scripts/issue-sync-lib-parse.sh
@@ -65,6 +65,29 @@ strip_code_fences() {
 	return 0
 }
 
+# Return the first live TODO task line for TASK_ID without closing the parser's
+# output early. The final awk consumes the complete stripped stream and delays
+# its single output until EOF, so an early match cannot SIGPIPE
+# strip_code_fences. Parser and input failures remain non-zero.
+find_todo_task_line() {
+	local task_id="$1"
+	local todo_file="$2"
+	local pipeline_status=()
+	strip_code_fences <"$todo_file" | awk -v task_id="$task_id" '
+		!found && /^[[:space:]]*- \[.\] / {
+			candidate = $0
+			sub(/^[[:space:]]*- \[.\] /, "", candidate)
+			if (index(candidate, task_id " ") == 1) { first = $0; found = 1 }
+		}
+		END { if (found) print first }
+	'
+	pipeline_status=("${PIPESTATUS[@]}")
+	if [[ "${pipeline_status[0]}" -ne 0 || "${pipeline_status[1]}" -ne 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
 # Strip only HTML comment regions (<!-- ... -->) from stdin, including
 # multi-line comments. Leaves code fences and everything else untouched.
 # Useful for callers that need comment stripping without fence removal.

--- a/.agents/scripts/issue-sync-lib-ref.sh
+++ b/.agents/scripts/issue-sync-lib-ref.sh
@@ -256,11 +256,9 @@ resolve_task_gh_number() {
 			return 0
 		fi
 	fi
-	local task_id_ere
-	task_id_ere=$(_escape_ere "$task_id")
-
-	local ref="" issue_json="" issue_id="" issue_number="" issue_state="" issue_cursor=""
-	ref=$(strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${task_id_ere} " | head -1 |
+	local ref="" issue_json="" issue_id="" issue_number="" issue_state="" issue_cursor="" task_line=""
+	task_line=$(find_todo_task_line "$task_id" "$todo_file") || return 1
+	ref=$(printf '%s\n' "$task_line" |
 		grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || echo "")
 	[[ "$ref" =~ ^[1-9][0-9]*$ ]] || return 1
 	issue_json=$(_gh_with_timeout read gh issue view "$ref" --repo "$repo" --json id,number,state,updatedAt 2>/dev/null || true)

--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -392,10 +392,9 @@ _dependency_sync_has_active_status() {
 }
 
 _relationship_task_line() {
-	local task_id="$1" todo_file="$2" task_id_ere=""
-	task_id_ere=$(_escape_ere "$task_id")
-	strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${task_id_ere} " | head -1 || true
-	return 0
+	local task_id="$1" todo_file="$2"
+	find_todo_task_line "$task_id" "$todo_file"
+	return $?
 }
 
 # Move an inactive dependency-bearing issue out of the available queue. This is

--- a/.agents/scripts/test-issue-sync-lib.sh
+++ b/.agents/scripts/test-issue-sync-lib.sh
@@ -27,6 +27,10 @@
 #   13. strip_code_fences: strips multi-line HTML comments and example tasks
 #   14. strip_html_comments: standalone helper strips comments only
 #   15. add_gh_ref_to_todo: replaces placeholder ref:none instead of appending
+#   16. find_todo_task_line: large early match is pipefail-safe
+#   17. find_todo_task_line: no match is successful and empty
+#   18. find_todo_task_line: input failure remains detectable
+#   19. issue-sync first-match task lookups use the bounded helper
 #
 # Exit 0 = all tests pass, 1 = at least one failure.
 
@@ -550,6 +554,55 @@ if printf '%s\n' "$plan_result" | grep -q 'Root plan'; then
 	pass "find_plan_by_task_id: walks every ancestor to the root"
 else
 	fail "find_plan_by_task_id: failed deep hierarchy root lookup"
+fi
+
+# -----------------------------------------------------------------------------
+# Tests 16-19: bounded first-match task lookup (GH#28944)
+# -----------------------------------------------------------------------------
+first_match_todo="$TMP/todo-first-match-large.md"
+{
+	printf '%s\n' '- [ ] t1 early task ref:GH#1'
+	i=2
+	while [[ $i -le 100000 ]]; do
+		printf -- '- [ ] t%d generated filler ref:GH#%d\n' "$i" "$i"
+		i=$((i + 1))
+	done
+} >"$first_match_todo"
+
+first_match_stderr="$TMP/first-match.stderr"
+first_match_result=""
+first_match_status=0
+first_match_result=$(find_todo_task_line "t1" "$first_match_todo" 2>"$first_match_stderr") || first_match_status=$?
+first_match_stderr_bytes=$(wc -c <"$first_match_stderr")
+if [[ $first_match_status -eq 0 && "$first_match_result" == '- [ ] t1 early task ref:GH#1' && ! -s "$first_match_stderr" ]]; then
+	pass "find_todo_task_line: large early match is pipefail-safe"
+else
+	fail "find_todo_task_line: large early match failed or emitted diagnostics (status=${first_match_status}, result=${first_match_result:-<empty>}, stderr-bytes=${first_match_stderr_bytes})"
+fi
+
+no_match_result="sentinel"
+no_match_status=0
+no_match_result=$(find_todo_task_line "t100001" "$first_match_todo") || no_match_status=$?
+if [[ $no_match_status -eq 0 && -z "$no_match_result" ]]; then
+	pass "find_todo_task_line: no match is successful and empty"
+else
+	fail "find_todo_task_line: no-match contract changed"
+fi
+
+read_failure_status=0
+find_todo_task_line "t1" "$TMP/missing-todo.md" >/dev/null 2>&1 || read_failure_status=$?
+if [[ $read_failure_status -ne 0 ]]; then
+	pass "find_todo_task_line: input failure remains detectable"
+else
+	fail "find_todo_task_line: input failure was hidden"
+fi
+
+helper_lookup_count=$(grep -c 'find_todo_task_line' "$SCRIPT_DIR/issue-sync-helper.sh")
+close_lookup_count=$(grep -c 'find_todo_task_line' "$SCRIPT_DIR/issue-sync-helper-close.sh")
+if [[ "$helper_lookup_count" -eq 2 && "$close_lookup_count" -eq 3 ]]; then
+	pass "issue-sync first-match task lookups use the bounded helper"
+else
+	fail "issue-sync first-match task lookups are not fully migrated"
 fi
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Added a bounded TODO task-line selector that consumes parser output through EOF, migrated issue-sync first-match lookups, and preserved parser/read failures.

## Files Changed

.agents/scripts/issue-sync-helper-close.sh, .agents/scripts/issue-sync-helper-commands.sh, .agents/scripts/issue-sync-helper.sh, .agents/scripts/issue-sync-lib-parse.sh, .agents/scripts/issue-sync-lib-ref.sh, .agents/scripts/issue-sync-relationships.sh, .agents/scripts/test-issue-sync-lib.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/test-issue-sync-lib.sh; ShellCheck on all changed shell files

Resolves #28944


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 7m and 97,622 tokens on this as a headless worker.