### PR TITLE
GH#28950: fix: guard quota capture cleanup under nounset

### DIFF
--- a/.agents/scripts/gh-quota-attribution-lib.sh
+++ b/.agents/scripts/gh-quota-attribution-lib.sh
@@ -701,9 +701,9 @@ _ghqa_capture_locked() {
 	local path="$6"
 	local page="$7"
 	shift 7
-	local debug_file parsed header version frame_count
+	local debug_file="" parsed="" header="" version="" frame_count=""
 	local started_ms finished_ms elapsed_ms rc=0
-	trap '_ghqa_capture_cleanup "$debug_file" "$lock_dir"' EXIT HUP INT TERM
+	trap '_ghqa_capture_cleanup "${debug_file:-}" "${lock_dir:-}"' EXIT HUP INT TERM
 	if ! _ghqa_lock_acquire "$lock_dir"; then
 		lock_dir=""
 		_ghqa_run_uncaptured_to_result "$result_file" "$path" "$page" "$@"

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -1496,6 +1496,28 @@ else
 	_fail "local-only exact-capture bypass" "log: $(cat "$local_log" 2>/dev/null || true)"
 fi
 
+# Successful managed writes with debug output unset still run capture cleanup.
+# Keep this path nounset-safe and preserve the wrapped commands' success status.
+write_success_state="$TMP/exact-write-success-state"
+write_success_log="$TMP/exact-write-success.log"
+write_success_err="$TMP/exact-write-success.err"
+: >"$write_success_log"
+: >"$write_success_err"
+if GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$write_success_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$write_success_log" "$SHIM_RUN" pr reopen 123 --repo owner/repo \
+	>/dev/null 2>"$write_success_err" && \
+	GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$write_success_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$write_success_log" "$SHIM_RUN" issue edit 123 --repo owner/repo \
+	>/dev/null 2>>"$write_success_err" && \
+	! grep -q 'debug_file: unbound variable' "$write_success_err"; then
+	_pass "successful PR and issue writes with unset debug output preserve status without nounset diagnostics"
+else
+	_fail "successful write cleanup with unset debug output" \
+		"stderr: $(cat "$write_success_err" 2>/dev/null || true)"
+fi
+
 # =============================================================================
 # Test 24: response-owned GraphQL cost is recorded after reading the response
 # =============================================================================


### PR DESCRIPTION
## Summary

Initialize and nounset-guard quota debug cleanup, with regression coverage for successful managed PR and issue writes when debug output is unset.

## Files Changed

.agents/scripts/gh-quota-attribution-lib.sh, .agents/scripts/tests/test-gh-shim.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — shellcheck .agents/scripts/gh-quota-attribution-lib.sh .agents/scripts/tests/test-gh-shim.sh; Test 23 regression passed; full test harness has 9 pre-existing Test 22 direct REST attribution failures

Resolves #28950


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-terra spent 10m and 92,251 tokens on this as a headless worker.