### PR TITLE
GH#28956: Prevent pre-edit auto-creation from reusing stale task branches

### DIFF
--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -443,9 +443,9 @@ _handle_loop_mode_on_protected() {
 	# Derive branch name from --task description or fall back to generic
 	local _wt_branch_name=""
 	local _wt_task_desc="${TASK_DESC:-}"
+	local _wt_issue_num=""
 	if [[ -n "$_wt_task_desc" ]]; then
 		# Extract issue number if present (e.g., "Implement issue #17642")
-		local _wt_issue_num=""
 		_wt_issue_num=$(printf '%s' "$_wt_task_desc" | grep -oE '#[0-9]+|issue[/ ]*([0-9]+)' | grep -oE '[0-9]+' | head -1) || _wt_issue_num=""
 		if [[ -n "$_wt_issue_num" ]]; then
 			# Slugify the task title for the branch name
@@ -462,27 +462,48 @@ _handle_loop_mode_on_protected() {
 	# Try to create the worktree using the helper
 	local _wt_helper="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/worktree-helper.sh"
 	local _wt_path=""
+	local _wt_actual_branch=""
+	local _wt_provenance=""
+	local _wt_target=""
+	local _wt_ahead=""
+	local _wt_behind=""
+	local _wt_helper_rc=1
 	if [[ -x "$_wt_helper" ]]; then
 		local _wt_output=""
-		_wt_output=$("$_wt_helper" add "$_wt_branch_name" 2>&1) || true
+		local -a _wt_args=(add "$_wt_branch_name" --fresh-on-collision)
+		if [[ -n "$_wt_issue_num" ]]; then
+			_wt_args+=(--issue "$_wt_issue_num")
+		fi
+		if _wt_output=$("$_wt_helper" "${_wt_args[@]}" 2>&1); then
+			_wt_helper_rc=0
+		fi
 		local _wt_clean_output=""
 		_wt_clean_output=$(printf '%s' "$_wt_output" | perl -pe 's/\e\[[0-9;]*[[:alpha:]]//g') || _wt_clean_output="$_wt_output"
-		# Extract the worktree path from helper output
-		_wt_path=$(printf '%s' "$_wt_clean_output" | grep -oE '/[^ ]*Git/[^ ]*' | head -1) || _wt_path=""
-		if [[ -z "$_wt_path" ]]; then
-			# Fallback: construct expected path from repo name + branch
-			local _wt_repo_name=""
-			_wt_repo_name=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
-			local _wt_safe_branch=""
-			_wt_safe_branch=$(printf '%s' "$_wt_branch_name" | tr '/' '-')
-			_wt_path="$(dirname "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")/${_wt_repo_name}-${_wt_safe_branch}"
+		_wt_path=$(printf '%s\n' "$_wt_clean_output" | awk -F= '/^WORKTREE_PATH=/{print substr($0, index($0, "=") + 1); exit}') || _wt_path=""
+		_wt_actual_branch=$(printf '%s\n' "$_wt_clean_output" | awk -F= '/^WORKTREE_BRANCH=/{print substr($0, index($0, "=") + 1); exit}') || _wt_actual_branch=""
+		_wt_provenance=$(printf '%s\n' "$_wt_clean_output" | awk -F= '/^WORKTREE_PROVENANCE=/{print $2; exit}') || _wt_provenance=""
+		_wt_target=$(printf '%s\n' "$_wt_clean_output" | awk -F= '/^WORKTREE_TARGET=/{print $2; exit}') || _wt_target=""
+		_wt_ahead=$(printf '%s\n' "$_wt_clean_output" | awk -F= '/^WORKTREE_AHEAD=/{print $2; exit}') || _wt_ahead=""
+		_wt_behind=$(printf '%s\n' "$_wt_clean_output" | awk -F= '/^WORKTREE_BEHIND=/{print $2; exit}') || _wt_behind=""
+		if [[ "$_wt_helper_rc" -ne 0 ]]; then
+			printf '%s\n' "$_wt_clean_output"
 		fi
 	fi
 
+	local _wt_checked_branch=""
 	if [[ -n "$_wt_path" && -d "$_wt_path" ]]; then
+		_wt_checked_branch=$(git -C "$_wt_path" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+	fi
+	if [[ "$_wt_helper_rc" -eq 0 && -n "$_wt_path" && -d "$_wt_path" &&
+		-n "$_wt_actual_branch" && "$_wt_checked_branch" == "$_wt_actual_branch" &&
+		-n "$_wt_provenance" && -n "$_wt_target" ]]; then
 		echo "LOOP_DECISION=worktree_created"
 		echo "WORKTREE_PATH=$_wt_path"
-		echo "WORKTREE_BRANCH=$_wt_branch_name"
+		echo "WORKTREE_BRANCH=$_wt_actual_branch"
+		echo "WORKTREE_PROVENANCE=$_wt_provenance"
+		echo "WORKTREE_TARGET=$_wt_target"
+		echo "WORKTREE_AHEAD=${_wt_ahead:-0}"
+		echo "WORKTREE_BEHIND=${_wt_behind:-0}"
 		echo -e "${GREEN}LOOP-AUTO${NC}: Worktree created at $_wt_path"
 		echo ""
 		echo "NEXT_STEP: cd to the worktree path and continue implementation there."
@@ -493,7 +514,8 @@ _handle_loop_mode_on_protected() {
 		echo -e "${RED}LOOP-AUTO${NC}: Failed to auto-create worktree '$_wt_branch_name'"
 		echo "LOOP_DECISION=worktree"
 		echo "WORKTREE_BRANCH=$_wt_branch_name"
-		echo "NEXT_STEP: Run worktree-helper.sh add '$_wt_branch_name' manually, then cd to the new path."
+		echo "ACTION_REQUIRED=inspect_existing_task_branch"
+		echo "NEXT_STEP: Inspect the reported branch collision, then choose an explicit continuation or a new branch."
 		exit 2 # Special exit code for "create worktree"
 	fi
 }

--- a/.agents/scripts/tests/test-pre-edit-check.sh
+++ b/.agents/scripts/tests/test-pre-edit-check.sh
@@ -17,6 +17,7 @@ TESTS_FAILED=0
 TEST_ROOT=""
 TEST_REGISTRY_DIR=""
 TEST_REGISTRY_DB=""
+TEST_WORKTREE_BASE=""
 
 print_result() {
 	local test_name="$1"
@@ -39,6 +40,7 @@ print_result() {
 
 setup_test_repo() {
 	TEST_ROOT=$(mktemp -d)
+	TEST_WORKTREE_BASE="$(dirname "$TEST_ROOT")/$(basename "$TEST_ROOT")-worktrees"
 	TEST_REGISTRY_DIR="${TEST_ROOT}/.registry"
 	TEST_REGISTRY_DB="${TEST_REGISTRY_DIR}/worktree-registry.db"
 	"$GIT_BIN" -C "$TEST_ROOT" init -b main >/dev/null 2>&1 || {
@@ -58,6 +60,9 @@ setup_test_repo() {
 teardown_test_repo() {
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
 		rm -rf "$TEST_ROOT"
+	fi
+	if [[ -n "$TEST_WORKTREE_BASE" && -d "$TEST_WORKTREE_BASE" ]]; then
+		rm -rf "$TEST_WORKTREE_BASE"
 	fi
 	return 0
 }
@@ -491,6 +496,119 @@ test_auto_creates_git_path_worktree_from_ansi_helper_output() {
 	return 0
 }
 
+test_task_branch_collisions_are_lossless_and_fresh() {
+	local remote_path="${TEST_ROOT}/fixture-remote.git"
+	local worktree_base="$TEST_WORKTREE_BASE"
+	"$GIT_BIN" init -q --bare "$remote_path"
+	"$GIT_BIN" -C "$TEST_ROOT" remote add origin "$remote_path"
+	"$GIT_BIN" -C "$TEST_ROOT" push -q -u origin main
+	"$GIT_BIN" -C "$TEST_ROOT" remote set-head origin main
+
+	local task="Implement issue #28956 stale collision"
+	local output=""
+	local exit_code=0
+	output=$(AIDEVOPS_WORKTREE_BASE_DIR="$worktree_base" FULL_LOOP_HEADLESS=true \
+		run_helper "$TEST_ROOT" --loop-mode --task "$task" 2>&1) || exit_code=$?
+	local original_branch=""
+	local original_path=""
+	original_branch=$(printf '%s\n' "$output" | awk -F= '/^WORKTREE_BRANCH=/{print $2; exit}')
+	original_path=$(printf '%s\n' "$output" | awk -F= '/^WORKTREE_PATH=/{print substr($0, index($0, "=") + 1); exit}')
+	local original_sha=""
+	original_sha=$("$GIT_BIN" -C "$original_path" rev-parse HEAD 2>/dev/null || true)
+	if [[ "$exit_code" -ne 0 || "$output" != *"WORKTREE_PROVENANCE=fresh"* || -z "$original_sha" ]]; then
+		print_result "creates first task worktree with fresh provenance" 1 "exit=${exit_code} output=${output}"
+		return 0
+	fi
+	print_result "creates first task worktree with fresh provenance" 0
+
+	"$GIT_BIN" -C "$TEST_ROOT" worktree remove --force "$original_path"
+	ensure_registry_schema
+	sqlite3 "$TEST_REGISTRY_DB" "DELETE FROM worktree_owners WHERE worktree_path = '$original_path';"
+
+	local target_tree=""
+	local advanced_sha=""
+	target_tree=$("$GIT_BIN" -C "$TEST_ROOT" rev-parse "${original_sha}^{tree}")
+	advanced_sha=$(printf 'remote advance\n' | "$GIT_BIN" -C "$TEST_ROOT" commit-tree "$target_tree" -p "$original_sha")
+	"$GIT_BIN" -C "$TEST_ROOT" push -q origin "${advanced_sha}:refs/heads/main"
+
+	output=""
+	exit_code=0
+	output=$(AIDEVOPS_WORKTREE_BASE_DIR="$worktree_base" FULL_LOOP_HEADLESS=true \
+		run_helper "$TEST_ROOT" --loop-mode --task "$task" 2>&1) || exit_code=$?
+	local fresh_branch=""
+	local fresh_path=""
+	fresh_branch=$(printf '%s\n' "$output" | awk -F= '/^WORKTREE_BRANCH=/{print $2; exit}')
+	fresh_path=$(printf '%s\n' "$output" | awk -F= '/^WORKTREE_PATH=/{print substr($0, index($0, "=") + 1); exit}')
+	local fresh_sha=""
+	fresh_sha=$("$GIT_BIN" -C "$fresh_path" rev-parse HEAD 2>/dev/null || true)
+	local preserved_sha=""
+	preserved_sha=$("$GIT_BIN" -C "$TEST_ROOT" rev-parse "refs/heads/${original_branch}" 2>/dev/null || true)
+	if [[ "$exit_code" -eq 0 && "$fresh_branch" == "${original_branch}-fresh" &&
+		"$fresh_sha" == "$advanced_sha" && "$preserved_sha" == "$original_sha" &&
+		"$output" == *"WORKTREE_PROVENANCE=fresh_collision"* ]]; then
+		print_result "stale inactive task branch creates one fresh collision branch" 0
+	else
+		print_result "stale inactive task branch creates one fresh collision branch" 1 \
+			"exit=${exit_code} original=${preserved_sha} fresh=${fresh_sha} target=${advanced_sha} output=${output}"
+	fi
+
+	output=""
+	exit_code=0
+	output=$(AIDEVOPS_WORKTREE_BASE_DIR="$worktree_base" FULL_LOOP_HEADLESS=true \
+		run_helper "$TEST_ROOT" --loop-mode --task "$task" 2>&1) || exit_code=$?
+	local repeated_path=""
+	repeated_path=$(printf '%s\n' "$output" | awk -F= '/^WORKTREE_PATH=/{print substr($0, index($0, "=") + 1); exit}')
+	local fresh_root=""
+	local repeated_root=""
+	fresh_root=$("$GIT_BIN" -C "$fresh_path" rev-parse --show-toplevel 2>/dev/null || true)
+	repeated_root=$("$GIT_BIN" -C "$repeated_path" rev-parse --show-toplevel 2>/dev/null || true)
+	if [[ "$exit_code" -eq 0 && "$repeated_root" == "$fresh_root" &&
+		"$output" == *"WORKTREE_PROVENANCE=continuation_active"* ]]; then
+		print_result "repeated task resumes its correctly owned active worktree" 0
+	else
+		print_result "repeated task resumes its correctly owned active worktree" 1 "exit=${exit_code} output=${output}"
+	fi
+
+	local unique_task="Issue #29999 unique collision"
+	local unique_branch="bugfix/gh29999-issue-29999-unique-collision"
+	local unique_sha=""
+	unique_sha=$(printf 'unique task commit\n' | "$GIT_BIN" -C "$TEST_ROOT" commit-tree "$target_tree" -p "$advanced_sha")
+	"$GIT_BIN" -C "$TEST_ROOT" branch "$unique_branch" "$unique_sha"
+	output=""
+	exit_code=0
+	output=$(AIDEVOPS_WORKTREE_BASE_DIR="$worktree_base" FULL_LOOP_HEADLESS=true \
+		run_helper "$TEST_ROOT" --loop-mode --task "$unique_task" 2>&1) || exit_code=$?
+	local unique_after=""
+	unique_after=$("$GIT_BIN" -C "$TEST_ROOT" rev-parse "refs/heads/${unique_branch}")
+	if [[ "$exit_code" -eq 2 && "$unique_after" == "$unique_sha" &&
+		"$output" == *"WORKTREE_COLLISION=unique_commits"* &&
+		"$output" == *"ACTION_REQUIRED=inspect_existing_task_branch"* ]]; then
+		print_result "inactive task branch with unique commits fails closed unchanged" 0
+	else
+		print_result "inactive task branch with unique commits fails closed unchanged" 1 "exit=${exit_code} output=${output}"
+	fi
+
+	local origin_url=""
+	origin_url=$("$GIT_BIN" -C "$TEST_ROOT" remote get-url origin)
+	"$GIT_BIN" -C "$TEST_ROOT" remote set-url origin "${TEST_ROOT}/missing-remote.git"
+	output=""
+	exit_code=0
+	output=$(AIDEVOPS_WORKTREE_BASE_DIR="$worktree_base" FULL_LOOP_HEADLESS=true \
+		run_helper "$TEST_ROOT" --loop-mode --task "Issue #30000 refresh failure" 2>&1) || exit_code=$?
+	"$GIT_BIN" -C "$TEST_ROOT" remote set-url origin "$origin_url"
+	local refresh_branch_created=0
+	if "$GIT_BIN" -C "$TEST_ROOT" show-ref --verify --quiet refs/heads/bugfix/gh30000-issue-30000-refresh-failure; then
+		refresh_branch_created=1
+	fi
+	if [[ "$exit_code" -eq 2 && "$output" == *"could not refresh origin/main"* &&
+		"$refresh_branch_created" -eq 0 ]]; then
+		print_result "remote refresh failure does not create a task branch" 0
+	else
+		print_result "remote refresh failure does not create a task branch" 1 "exit=${exit_code} output=${output}"
+	fi
+	return 0
+}
+
 main() {
 	trap teardown_test_repo EXIT
 	setup_test_repo
@@ -512,6 +630,7 @@ main() {
 	test_absolute_path_outside_repo_blocked_on_main
 	test_todo_subdir_path_requires_worktree
 	test_auto_creates_git_path_worktree_from_ansi_helper_output
+	test_task_branch_collisions_are_lossless_and_fresh
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -618,7 +618,8 @@ _cmd_add_assert_path_outside_repo() {
 }
 
 # Parse cmd_add arguments: positional (branch, path) + optional flags.
-# Sets global _ADD_BRANCH, _ADD_PATH, _ADD_ISSUE, _ADD_BASE. Returns 1 on parse error.
+# Sets global _ADD_BRANCH, _ADD_PATH, _ADD_ISSUE, _ADD_BASE, and
+# _ADD_FRESH_ON_COLLISION. Returns 1 on parse error.
 # Extracted from cmd_add (t2260) to keep function bodies under 100 lines.
 # --base <ref> (t2802): explicit base for new branch creation. Default is
 # origin/<default_branch> — prevents scope-leak PRs when canonical HEAD is stale.
@@ -627,6 +628,7 @@ _parse_cmd_add_args() {
 	_ADD_PATH=""
 	_ADD_ISSUE=""
 	_ADD_BASE=""
+	_ADD_FRESH_ON_COLLISION=0
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
 		case "$_arg" in
@@ -656,9 +658,13 @@ _parse_cmd_add_args() {
 				_ADD_BASE="${_arg#--base=}"
 				shift
 				;;
+			--fresh-on-collision)
+				_ADD_FRESH_ON_COLLISION=1
+				shift
+				;;
 			-*)
 				echo -e "${RED}Error: Unknown option: $_arg${NC}"
-				echo "Usage: worktree-helper.sh add <branch> [path] [--issue NNN] [--base REF]"
+				echo "Usage: worktree-helper.sh add <branch> [path] [--issue NNN] [--base REF] [--fresh-on-collision]"
 				return 1
 				;;
 			*)
@@ -673,10 +679,132 @@ _parse_cmd_add_args() {
 	done
 	if [[ -z "$_ADD_BRANCH" ]]; then
 		echo -e "${RED}Error: Branch name required${NC}"
-		echo "Usage: worktree-helper.sh add <branch> [path] [--issue NNN] [--base REF]"
+		echo "Usage: worktree-helper.sh add <branch> [path] [--issue NNN] [--base REF] [--fresh-on-collision]"
 		return 1
 	fi
 	return 0
+}
+
+# Emit additive machine-readable provenance for callers that opt into safe
+# task-branch collision handling.
+_cmd_add_print_collision_provenance() {
+	[[ "${_ADD_FRESH_ON_COLLISION:-0}" -eq 1 ]] || return 0
+	printf 'WORKTREE_PATH=%s\n' "${_ADD_COLLISION_PATH:-}"
+	printf 'WORKTREE_BRANCH=%s\n' "${_ADD_COLLISION_BRANCH:-}"
+	printf 'WORKTREE_PROVENANCE=%s\n' "${_ADD_COLLISION_PROVENANCE:-unknown}"
+	printf 'WORKTREE_TARGET=%s\n' "${_ADD_COLLISION_TARGET_SHA:-}"
+	printf 'WORKTREE_AHEAD=%s\n' "${_ADD_COLLISION_AHEAD:-0}"
+	printf 'WORKTREE_BEHIND=%s\n' "${_ADD_COLLISION_BEHIND:-0}"
+	return 0
+}
+
+# Classify an existing task-derived branch against a freshly resolved target.
+# The opt-in policy is lossless: unique commits are never rewritten, and one
+# deterministic "-fresh" branch bounds retries after a stale empty collision.
+_cmd_add_classify_collision_branch() {
+	local requested_branch="$1"
+	local explicit_base="$2"
+	local explicit_issue="$3"
+	local target_ref=""
+	target_ref=$(_resolve_worktree_base_ref "$explicit_base") || return 1
+	[[ -n "$target_ref" ]] || {
+		echo "WORKTREE_COLLISION=target_unresolved" >&2
+		return 1
+	}
+
+	_ADD_COLLISION_TARGET_SHA=$(git rev-parse --verify "${target_ref}^{commit}" 2>/dev/null) || return 1
+	_ADD_COLLISION_BRANCH="$requested_branch"
+	_ADD_COLLISION_PROVENANCE="fresh"
+	_ADD_COLLISION_AHEAD=0
+	_ADD_COLLISION_BEHIND=0
+	_ADD_COLLISION_PATH=""
+	_ADD_COLLISION_REUSED_ACTIVE=0
+
+	branch_exists "$requested_branch" || return 0
+
+	local candidate_branch="$requested_branch"
+	local candidate_path=""
+	local ahead=0
+	local behind=0
+	ahead=$(git rev-list --count "${_ADD_COLLISION_TARGET_SHA}..refs/heads/${candidate_branch}" 2>/dev/null) || return 1
+	behind=$(git rev-list --count "refs/heads/${candidate_branch}..${_ADD_COLLISION_TARGET_SHA}" 2>/dev/null) || return 1
+
+	if candidate_path=$(get_worktree_path_for_branch "$candidate_branch"); then
+		local owner_info=""
+		local owner_pid="" owner_session="" owner_batch="" owner_task="" owner_created=""
+		owner_info=$(check_worktree_owner "$candidate_path" 2>/dev/null || true)
+		IFS='|' read -r owner_pid owner_session owner_batch owner_task owner_created <<<"$owner_info"
+		if [[ -z "$explicit_issue" || "$owner_task" != "$explicit_issue" ]]; then
+			printf 'WORKTREE_COLLISION=active_ownership_unverified\n' >&2
+			printf 'WORKTREE_BRANCH=%s\n' "$candidate_branch" >&2
+			printf 'WORKTREE_PATH=%s\n' "$candidate_path" >&2
+			printf 'ACTION_REQUIRED=inspect_existing_task_worktree\n' >&2
+			return 1
+		fi
+		_ADD_COLLISION_PATH="$candidate_path"
+		_ADD_COLLISION_PROVENANCE="continuation_active"
+		_ADD_COLLISION_AHEAD="$ahead"
+		_ADD_COLLISION_BEHIND="$behind"
+		_ADD_COLLISION_REUSED_ACTIVE=1
+		return 0
+	fi
+
+	if [[ "$ahead" -gt 0 ]]; then
+		printf 'WORKTREE_COLLISION=unique_commits\n' >&2
+		printf 'WORKTREE_BRANCH=%s\n' "$candidate_branch" >&2
+		printf 'WORKTREE_TARGET=%s\n' "$_ADD_COLLISION_TARGET_SHA" >&2
+		printf 'WORKTREE_AHEAD=%s\n' "$ahead" >&2
+		printf 'WORKTREE_BEHIND=%s\n' "$behind" >&2
+		printf 'ACTION_REQUIRED=inspect_existing_task_branch\n' >&2
+		return 1
+	fi
+
+	if [[ "$behind" -eq 0 ]]; then
+		_ADD_COLLISION_PROVENANCE="fresh_existing"
+		return 0
+	fi
+
+	candidate_branch="${requested_branch}-fresh"
+	_ADD_COLLISION_BRANCH="$candidate_branch"
+	_ADD_COLLISION_PROVENANCE="fresh_collision"
+	_ADD_COLLISION_AHEAD=0
+	_ADD_COLLISION_BEHIND=0
+	branch_exists "$candidate_branch" || return 0
+
+	ahead=$(git rev-list --count "${_ADD_COLLISION_TARGET_SHA}..refs/heads/${candidate_branch}" 2>/dev/null) || return 1
+	behind=$(git rev-list --count "refs/heads/${candidate_branch}..${_ADD_COLLISION_TARGET_SHA}" 2>/dev/null) || return 1
+	if candidate_path=$(get_worktree_path_for_branch "$candidate_branch"); then
+		local fresh_owner_info=""
+		local fresh_owner_pid="" fresh_owner_session="" fresh_owner_batch="" fresh_owner_task="" fresh_owner_created=""
+		fresh_owner_info=$(check_worktree_owner "$candidate_path" 2>/dev/null || true)
+		IFS='|' read -r fresh_owner_pid fresh_owner_session fresh_owner_batch fresh_owner_task fresh_owner_created <<<"$fresh_owner_info"
+		if [[ -z "$explicit_issue" || "$fresh_owner_task" != "$explicit_issue" ]]; then
+			printf 'WORKTREE_COLLISION=active_ownership_unverified\n' >&2
+			printf 'WORKTREE_BRANCH=%s\n' "$candidate_branch" >&2
+			printf 'WORKTREE_PATH=%s\n' "$candidate_path" >&2
+			printf 'ACTION_REQUIRED=inspect_existing_task_worktree\n' >&2
+			return 1
+		fi
+		_ADD_COLLISION_PATH="$candidate_path"
+		_ADD_COLLISION_PROVENANCE="continuation_active"
+		_ADD_COLLISION_AHEAD="$ahead"
+		_ADD_COLLISION_BEHIND="$behind"
+		_ADD_COLLISION_REUSED_ACTIVE=1
+		return 0
+	fi
+
+	if [[ "$ahead" -eq 0 && "$behind" -eq 0 ]]; then
+		_ADD_COLLISION_PROVENANCE="fresh_existing"
+		return 0
+	fi
+
+	printf 'WORKTREE_COLLISION=fresh_branch_changed\n' >&2
+	printf 'WORKTREE_BRANCH=%s\n' "$candidate_branch" >&2
+	printf 'WORKTREE_TARGET=%s\n' "$_ADD_COLLISION_TARGET_SHA" >&2
+	printf 'WORKTREE_AHEAD=%s\n' "$ahead" >&2
+	printf 'WORKTREE_BEHIND=%s\n' "$behind" >&2
+	printf 'ACTION_REQUIRED=inspect_existing_task_branch\n' >&2
+	return 1
 }
 
 # Refresh an origin branch from linked-worktree context so the canonical Git
@@ -848,6 +976,7 @@ cmd_add() {
 	local path="$_ADD_PATH"
 	local explicit_issue="$_ADD_ISSUE"  # t2260: --issue NNN for unambiguous claim
 	local explicit_base="$_ADD_BASE"    # t2802: --base REF for explicit base
+	local fresh_on_collision="$_ADD_FRESH_ON_COLLISION"
 
 	# t2235: Detect self-invented task ID variants (e.g. t2213b, t2213-2, t2213.fix)
 	# Task IDs come ONLY from claim-task-id.sh. For follow-ups, claim a fresh ID.
@@ -867,6 +996,16 @@ cmd_add() {
 		return 1
 	fi
 
+	if [[ "$fresh_on_collision" -eq 1 ]]; then
+		_cmd_add_classify_collision_branch "$branch" "$explicit_base" "$explicit_issue" || return 1
+		branch="$_ADD_COLLISION_BRANCH"
+		explicit_base="$_ADD_COLLISION_TARGET_SHA"
+		if [[ "$_ADD_COLLISION_REUSED_ACTIVE" -eq 1 ]]; then
+			_cmd_add_print_collision_provenance
+			return 0
+		fi
+	fi
+
 	# Check if worktree already exists for this branch
 	local existing_path
 	if existing_path=$(get_worktree_path_for_branch "$branch"); then
@@ -875,6 +1014,8 @@ cmd_add() {
 		echo ""
 		echo "To use it:"
 		echo "  cd $existing_path" || exit
+		_ADD_COLLISION_PATH="$existing_path"
+		_cmd_add_print_collision_provenance
 		return 0
 	fi
 
@@ -932,6 +1073,8 @@ cmd_add() {
 	_interactive_session_auto_claim "$branch" "$path" "$explicit_issue" || true
 
 	_print_worktree_add_success "$path" "$branch"
+	_ADD_COLLISION_PATH="$path"
+	_cmd_add_print_collision_provenance
 
 	# Localdev integration (t1224.8): auto-create branch subdomain route
 	localdev_auto_branch "$branch"

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -14,7 +14,8 @@
 #   worktree-helper.sh <command> [options]
 #
 # Commands:
-#   add <branch> [path] [--issue NNN] [--base REF]  Create worktree for branch (auto-names path)
+#   add <branch> [path] [--issue NNN] [--base REF] [--fresh-on-collision]
+#                          Create worktree for branch (auto-names path)
 #   list                   List all worktrees with status
 #   remove <path|branch>   Remove a worktree
 #   status                 Show current worktree info


### PR DESCRIPTION
## Summary

Classify repeated task-branch collisions against a refreshed target, preserve ambiguous commits, and emit additive provenance for fresh and owned continuation paths.

## Files Changed

.agents/scripts/pre-edit-check.sh, .agents/scripts/tests/test-pre-edit-check.sh, .agents/scripts/worktree-helper-add.sh, .agents/scripts/worktree-helper.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Runtime fixture covers stale inactive branches, owned active continuation, unique-commit preservation, and refresh failure; focused shell tests and ShellCheck pass.

Resolves #28956


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 16m and 124,870 tokens on this as a headless worker.