### PR TITLE
GH#28944: Avoid issue-sync first-match SIGPIPE

### DIFF
--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -348,11 +348,9 @@ _reopen_mark_if_completed() {
 _do_close() {
 	local task_id="$1" issue_number="$2" todo_file="$3" repo="$4"
 	require_task_issue_mapping "$task_id" "$todo_file" "$repo" "$issue_number" || return 1
-	local task_id_ere
-	task_id_ere=$(_escape_ere "$task_id")
 	local task_with_notes task_line pr_info pr_num="" pr_url=""
 	task_with_notes=$(extract_task_block "$task_id" "$todo_file")
-	task_line=$(strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${task_id_ere} " | head -1 || echo "")
+	task_line=$(_first_todo_task_line_or_empty "$task_id" "$todo_file") || return 1
 	[[ -z "$task_with_notes" ]] && task_with_notes="$task_line"
 
 	# GH#20828: probe parent-task label before closing. The workflow path's
@@ -379,7 +377,7 @@ _do_close() {
 		pr_num="${pr_info%%|*}"
 		pr_url="${pr_info#*|}"
 		[[ "$DRY_RUN" != "true" && -n "$pr_num" ]] && add_pr_ref_to_todo "$task_id" "$pr_num" "$todo_file"
-		task_line=$(strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${task_id_ere} " | head -1 || echo "")
+		task_line=$(_first_todo_task_line_or_empty "$task_id" "$todo_file") || return 1
 		task_with_notes=$(extract_task_block "$task_id" "$todo_file")
 		[[ -z "$task_with_notes" ]] && task_with_notes="$task_line"
 	fi
@@ -432,10 +430,8 @@ cmd_close() {
 
 	# Single-task mode
 	if [[ -n "$target_task" ]]; then
-		local target_ere
-		target_ere=$(_escape_ere "$target_task")
 		local task_line
-		task_line=$(strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${target_ere} " | head -1 || echo "")
+		task_line=$(_first_todo_task_line_or_empty "$target_task" "$todo_file") || return 1
 		local num
 		num=$(echo "$task_line" | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || echo "")
 		if [[ -z "$num" ]]; then

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -231,8 +231,6 @@ _push_finalize_task_creation() {
 _push_process_task() {
 	local task_id="$1" repo="$2" todo_file="$3" project_root="$4"
 	log_verbose "Processing $task_id..."
-	local task_id_ere
-	task_id_ere=$(_escape_ere "$task_id")
 
 	# Skip if issue already exists
 	local existing
@@ -244,7 +242,7 @@ _push_process_task() {
 	fi
 
 	local task_line
-	task_line=$(strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${task_id_ere} " | head -1 || echo "")
+	task_line=$(_first_todo_task_line_or_empty "$task_id" "$todo_file") || return 1
 	[[ -z "$task_line" ]] && {
 		print_warning "Task $task_id not found in TODO.md"
 		return 0
@@ -319,9 +317,7 @@ _push_process_task() {
 _enrich_process_task() {
 	local task_id="$1" repo="$2" todo_file="$3" project_root="$4" task_line="${5:-}"
 	if [[ -z "$task_line" ]]; then
-		local task_id_ere
-		task_id_ere=$(_escape_ere "$task_id")
-		task_line=$(strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${task_id_ere} " | head -1 || echo "")
+		task_line=$(_first_todo_task_line_or_empty "$task_id" "$todo_file") || return 1
 	fi
 	local num
 	num=$(echo "$task_line" | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || echo "")

--- a/.agents/scripts/issue-sync-lib-parse.sh
+++ b/.agents/scripts/issue-sync-lib-parse.sh
@@ -65,6 +65,52 @@ strip_code_fences() {
 	return 0
 }
 
+# Select the first live TODO task row without asking a downstream consumer to
+# terminate strip_code_fences early. The selector consumes the complete parser
+# stream, so an expected first match cannot surface as an upstream SIGPIPE.
+# Returns: 0=match, 1=no match, 2=input/parser/selector failure.
+_first_todo_task_line() {
+	local task_id="$1"
+	local todo_file="$2"
+	local pipeline_status=()
+
+	strip_code_fences <"$todo_file" | awk -v wanted="$task_id" '
+		!found && match($0, /^[[:space:]]*-[[:space:]]+\[.\][[:space:]]+/) {
+			remaining = substr($0, RLENGTH + 1)
+			split(remaining, fields, /[[:space:]]+/)
+			if (fields[1] == wanted) {
+				print
+				found = 1
+			}
+		}
+		END { if (!found) { exit 1 } }
+	'
+	pipeline_status=("${PIPESTATUS[@]}")
+	[[ "${pipeline_status[0]}" -eq 0 ]] || return 2
+	case "${pipeline_status[1]}" in
+	0) return 0 ;;
+	1) return 1 ;;
+	*) return 2 ;;
+	esac
+}
+
+# Preserve existing empty-on-no-match caller semantics while surfacing genuine
+# input/parser failures as a nonzero command result.
+_first_todo_task_line_or_empty() {
+	local task_id="$1"
+	local todo_file="$2"
+	local task_line=""
+	local selector_status=0
+
+	task_line=$(_first_todo_task_line "$task_id" "$todo_file") || selector_status=$?
+	if [[ "$selector_status" -gt 1 ]]; then
+		print_error "Failed to parse TODO.md while selecting $task_id"
+		return 1
+	fi
+	[[ "$selector_status" -eq 0 ]] && printf '%s\n' "$task_line"
+	return 0
+}
+
 # Strip only HTML comment regions (<!-- ... -->) from stdin, including
 # multi-line comments. Leaves code fences and everything else untouched.
 # Useful for callers that need comment stripping without fence removal.

--- a/.agents/scripts/test-issue-sync-lib.sh
+++ b/.agents/scripts/test-issue-sync-lib.sh
@@ -553,6 +553,62 @@ else
 fi
 
 # -----------------------------------------------------------------------------
+# GH#28944: first-match task selection must consume the complete parser stream.
+# -----------------------------------------------------------------------------
+selector_todo="$TMP/todo-first-selector.md"
+{
+	printf '%s\n' '- [ ] t1 early selector target ref:GH#1'
+	selector_i=2
+	while [[ "$selector_i" -le 12000 ]]; do
+		printf -- '- [ ] t%s selector filler ref:GH#%s\n' "$selector_i" "$selector_i"
+		selector_i=$((selector_i + 1))
+	done
+} >"$selector_todo"
+
+selector_status=0
+selector_output=$(_first_todo_task_line "t1" "$selector_todo" 2>"$TMP/selector-early.err") || selector_status=$?
+if [[ "$selector_status" -eq 0 && "$selector_output" == '- [ ] t1 early selector target ref:GH#1' && ! -s "$TMP/selector-early.err" ]]; then
+	pass "first TODO task selector: large early match avoids SIGPIPE diagnostics"
+else
+	fail "first TODO task selector: large early match failed (status=$selector_status output=$selector_output)"
+fi
+
+selector_status=0
+selector_output=$(_first_todo_task_line "t99999" "$selector_todo" 2>"$TMP/selector-missing.err") || selector_status=$?
+if [[ "$selector_status" -eq 1 && -z "$selector_output" && ! -s "$TMP/selector-missing.err" ]]; then
+	pass "first TODO task selector: no match remains distinct and quiet"
+else
+	fail "first TODO task selector: no-match contract failed (status=$selector_status output=$selector_output)"
+fi
+
+selector_status=0
+selector_output=$(_first_todo_task_line "t1" "$TMP/missing-selector.md" 2>"$TMP/selector-read.err") || selector_status=$?
+if [[ "$selector_status" -eq 2 && -z "$selector_output" && -s "$TMP/selector-read.err" ]]; then
+	pass "first TODO task selector: read failure remains detectable"
+else
+	fail "first TODO task selector: read failure contract failed (status=$selector_status output=$selector_output)"
+fi
+
+selector_status=0
+selector_output=$(_first_todo_task_line_or_empty "t1" "$TMP/missing-selector.md" 2>"$TMP/selector-wrapper.err") || selector_status=$?
+if [[ "$selector_status" -eq 1 && -z "$selector_output" && -s "$TMP/selector-wrapper.err" ]]; then
+	pass "first TODO task selector: caller wrapper propagates parser failure"
+else
+	fail "first TODO task selector: caller wrapper hid parser failure (status=$selector_status output=$selector_output)"
+fi
+
+selector_calls=$(grep -c '_first_todo_task_line' \
+	"$SCRIPT_DIR/issue-sync-helper.sh" "$SCRIPT_DIR/issue-sync-helper-close.sh" | \
+	awk -F: '{ total += $2 } END { print total + 0 }')
+if [[ "$selector_calls" -eq 5 ]] &&
+	! grep -E 'strip_code_fences .*head -1' \
+		"$SCRIPT_DIR/issue-sync-helper.sh" "$SCRIPT_DIR/issue-sync-helper-close.sh" >/dev/null; then
+	pass "first TODO task selector: all enumerated issue-sync call sites migrated"
+else
+	fail "first TODO task selector: enumerated call-site migration incomplete (calls=$selector_calls)"
+fi
+
+# -----------------------------------------------------------------------------
 # Summary
 # -----------------------------------------------------------------------------
 printf '\n'


### PR DESCRIPTION
## Summary

Move first-task selection into the issue-sync parser so the selector consumes the complete filtered stream, avoiding expected upstream SIGPIPE while preserving no-match and parser-failure semantics.

## Files Changed

.agents/scripts/issue-sync-helper-close.sh, .agents/scripts/issue-sync-helper.sh, .agents/scripts/issue-sync-lib-parse.sh, .agents/scripts/test-issue-sync-lib.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified: bash .agents/scripts/test-issue-sync-lib.sh (40 tests, 0 failures); test-issue-sync completion-evidence, close-signature, reopen-churn, push-failures, and enrich-bounds suites; .agents/scripts/linters-local.sh

Resolves #28944


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 2h 34m and 1,317,495 tokens on this with the user in an interactive session.