### PR TITLE
GH#28956: Prevent pre-edit auto-creation from reusing stale task branches

### DIFF
--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -418,6 +418,60 @@ _is_explicit_headless_flow() {
 	esac
 }
 
+_loop_worktree_output_value() {
+	local output="$1"
+	local key="$2"
+	printf '%s\n' "$output" | awk -F= -v key="$key" '$1 == key {print substr($0, index($0, "=") + 1); exit}'
+	return 0
+}
+
+_create_loop_task_worktree() {
+	local requested_branch="$1"
+	local issue_num="$2"
+	local helper="${SCRIPT_DIR}/worktree-helper.sh"
+	_LOOP_WT_PATH=""
+	_LOOP_WT_BRANCH=""
+	_LOOP_WT_PROVENANCE=""
+	_LOOP_WT_TARGET=""
+	_LOOP_WT_AHEAD=""
+	_LOOP_WT_BEHIND=""
+	_LOOP_WT_COLLISION=""
+	_LOOP_WT_ACTION=""
+	_LOOP_WT_RC=1
+	[[ -x "$helper" ]] || return 1
+
+	local output=""
+	local -a args=(add "$requested_branch" --fresh-on-collision)
+	[[ -z "$issue_num" ]] || args+=(--issue "$issue_num")
+	if output=$("$helper" "${args[@]}" 2>&1); then
+		_LOOP_WT_RC=0
+	fi
+	output=$(printf '%s' "$output" | perl -pe 's/\e\[[0-9;]*[[:alpha:]]//g') || true
+	_LOOP_WT_PATH=$(_loop_worktree_output_value "$output" WORKTREE_PATH)
+	_LOOP_WT_BRANCH=$(_loop_worktree_output_value "$output" WORKTREE_BRANCH)
+	_LOOP_WT_PROVENANCE=$(_loop_worktree_output_value "$output" WORKTREE_PROVENANCE)
+	_LOOP_WT_TARGET=$(_loop_worktree_output_value "$output" WORKTREE_TARGET)
+	_LOOP_WT_AHEAD=$(_loop_worktree_output_value "$output" WORKTREE_AHEAD)
+	_LOOP_WT_BEHIND=$(_loop_worktree_output_value "$output" WORKTREE_BEHIND)
+	_LOOP_WT_COLLISION=$(_loop_worktree_output_value "$output" WORKTREE_COLLISION)
+	_LOOP_WT_ACTION=$(_loop_worktree_output_value "$output" ACTION_REQUIRED)
+	if [[ "$_LOOP_WT_RC" -ne 0 ]]; then
+		printf '%s\n' "$output" | awk '!/^[A-Z_]+=/'
+		return 1
+	fi
+	return 0
+}
+
+_print_loop_worktree_failure_next_step() {
+	local action="$1"
+	if [[ "$action" == "refresh_target" ]]; then
+		echo "NEXT_STEP: Restore remote access, refresh the target branch, and retry without changing local task branches."
+		return 0
+	fi
+	echo "NEXT_STEP: Inspect the reported branch collision, then choose an explicit continuation or a new branch."
+	return 0
+}
+
 _handle_loop_mode_on_protected() {
 	local branch="$1"
 
@@ -443,9 +497,9 @@ _handle_loop_mode_on_protected() {
 	# Derive branch name from --task description or fall back to generic
 	local _wt_branch_name=""
 	local _wt_task_desc="${TASK_DESC:-}"
+	local _wt_issue_num=""
 	if [[ -n "$_wt_task_desc" ]]; then
 		# Extract issue number if present (e.g., "Implement issue #17642")
-		local _wt_issue_num=""
 		_wt_issue_num=$(printf '%s' "$_wt_task_desc" | grep -oE '#[0-9]+|issue[/ ]*([0-9]+)' | grep -oE '[0-9]+' | head -1) || _wt_issue_num=""
 		if [[ -n "$_wt_issue_num" ]]; then
 			# Slugify the task title for the branch name
@@ -459,30 +513,31 @@ _handle_loop_mode_on_protected() {
 		_wt_branch_name="feature/auto-$(date +%Y%m%d-%H%M%S)"
 	fi
 
-	# Try to create the worktree using the helper
-	local _wt_helper="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/worktree-helper.sh"
-	local _wt_path=""
-	if [[ -x "$_wt_helper" ]]; then
-		local _wt_output=""
-		_wt_output=$("$_wt_helper" add "$_wt_branch_name" 2>&1) || true
-		local _wt_clean_output=""
-		_wt_clean_output=$(printf '%s' "$_wt_output" | perl -pe 's/\e\[[0-9;]*[[:alpha:]]//g') || _wt_clean_output="$_wt_output"
-		# Extract the worktree path from helper output
-		_wt_path=$(printf '%s' "$_wt_clean_output" | grep -oE '/[^ ]*Git/[^ ]*' | head -1) || _wt_path=""
-		if [[ -z "$_wt_path" ]]; then
-			# Fallback: construct expected path from repo name + branch
-			local _wt_repo_name=""
-			_wt_repo_name=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
-			local _wt_safe_branch=""
-			_wt_safe_branch=$(printf '%s' "$_wt_branch_name" | tr '/' '-')
-			_wt_path="$(dirname "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")/${_wt_repo_name}-${_wt_safe_branch}"
-		fi
-	fi
+	_create_loop_task_worktree "$_wt_branch_name" "$_wt_issue_num" || true
+	local _wt_path="$_LOOP_WT_PATH"
+	local _wt_actual_branch="$_LOOP_WT_BRANCH"
+	local _wt_provenance="$_LOOP_WT_PROVENANCE"
+	local _wt_target="$_LOOP_WT_TARGET"
+	local _wt_ahead="$_LOOP_WT_AHEAD"
+	local _wt_behind="$_LOOP_WT_BEHIND"
+	local _wt_collision="$_LOOP_WT_COLLISION"
+	local _wt_failure_action="$_LOOP_WT_ACTION"
+	local _wt_helper_rc="$_LOOP_WT_RC"
 
+	local _wt_checked_branch=""
 	if [[ -n "$_wt_path" && -d "$_wt_path" ]]; then
+		_wt_checked_branch=$(git -C "$_wt_path" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+	fi
+	if [[ "$_wt_helper_rc" -eq 0 && -n "$_wt_path" && -d "$_wt_path" &&
+		-n "$_wt_actual_branch" && "$_wt_checked_branch" == "$_wt_actual_branch" &&
+		-n "$_wt_provenance" && -n "$_wt_target" ]]; then
 		echo "LOOP_DECISION=worktree_created"
 		echo "WORKTREE_PATH=$_wt_path"
-		echo "WORKTREE_BRANCH=$_wt_branch_name"
+		echo "WORKTREE_BRANCH=$_wt_actual_branch"
+		echo "WORKTREE_PROVENANCE=$_wt_provenance"
+		echo "WORKTREE_TARGET=$_wt_target"
+		echo "WORKTREE_AHEAD=${_wt_ahead:-0}"
+		echo "WORKTREE_BEHIND=${_wt_behind:-0}"
 		echo -e "${GREEN}LOOP-AUTO${NC}: Worktree created at $_wt_path"
 		echo ""
 		echo "NEXT_STEP: cd to the worktree path and continue implementation there."
@@ -492,8 +547,14 @@ _handle_loop_mode_on_protected() {
 		# Worktree creation failed — fall back to signalling exit 2
 		echo -e "${RED}LOOP-AUTO${NC}: Failed to auto-create worktree '$_wt_branch_name'"
 		echo "LOOP_DECISION=worktree"
-		echo "WORKTREE_BRANCH=$_wt_branch_name"
-		echo "NEXT_STEP: Run worktree-helper.sh add '$_wt_branch_name' manually, then cd to the new path."
+		echo "WORKTREE_BRANCH=${_wt_actual_branch:-$_wt_branch_name}"
+		[[ -z "$_wt_path" ]] || echo "WORKTREE_PATH=$_wt_path"
+		echo "WORKTREE_COLLISION=${_wt_collision:-creation_failed}"
+		[[ -z "$_wt_target" ]] || echo "WORKTREE_TARGET=$_wt_target"
+		[[ -z "$_wt_ahead" ]] || echo "WORKTREE_AHEAD=$_wt_ahead"
+		[[ -z "$_wt_behind" ]] || echo "WORKTREE_BEHIND=$_wt_behind"
+		echo "ACTION_REQUIRED=${_wt_failure_action:-inspect_existing_task_branch}"
+		_print_loop_worktree_failure_next_step "$_wt_failure_action"
 		exit 2 # Special exit code for "create worktree"
 	fi
 }

--- a/.agents/scripts/tests/test-pre-edit-check.sh
+++ b/.agents/scripts/tests/test-pre-edit-check.sh
@@ -17,6 +17,13 @@ TESTS_FAILED=0
 TEST_ROOT=""
 TEST_REGISTRY_DIR=""
 TEST_REGISTRY_DB=""
+TEST_WORKTREE_BASE=""
+COLLISION_TASK=""
+COLLISION_ORIGINAL_BRANCH=""
+COLLISION_ORIGINAL_SHA=""
+COLLISION_ADVANCED_SHA=""
+COLLISION_TARGET_TREE=""
+COLLISION_FRESH_PATH=""
 
 print_result() {
 	local test_name="$1"
@@ -39,6 +46,7 @@ print_result() {
 
 setup_test_repo() {
 	TEST_ROOT=$(mktemp -d)
+	TEST_WORKTREE_BASE="$(dirname "$TEST_ROOT")/$(basename "$TEST_ROOT")-worktrees"
 	TEST_REGISTRY_DIR="${TEST_ROOT}/.registry"
 	TEST_REGISTRY_DB="${TEST_REGISTRY_DIR}/worktree-registry.db"
 	"$GIT_BIN" -C "$TEST_ROOT" init -b main >/dev/null 2>&1 || {
@@ -58,6 +66,9 @@ setup_test_repo() {
 teardown_test_repo() {
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
 		rm -rf "$TEST_ROOT"
+	fi
+	if [[ -n "$TEST_WORKTREE_BASE" && -d "$TEST_WORKTREE_BASE" ]]; then
+		rm -rf "$TEST_WORKTREE_BASE"
 	fi
 	return 0
 }
@@ -491,6 +502,138 @@ test_auto_creates_git_path_worktree_from_ansi_helper_output() {
 	return 0
 }
 
+setup_task_branch_collision_fixture() {
+	local remote_path="${TEST_ROOT}/fixture-remote.git"
+	"$GIT_BIN" init -q --bare "$remote_path"
+	"$GIT_BIN" -C "$TEST_ROOT" remote add origin "$remote_path"
+	"$GIT_BIN" -C "$TEST_ROOT" push -q -u origin main
+	"$GIT_BIN" -C "$TEST_ROOT" remote set-head origin main
+
+	COLLISION_TASK="Implement issue #28956 stale collision"
+	local output=""
+	local exit_code=0
+	output=$(OPENCODE_SESSION_ID=collision-session AIDEVOPS_WORKTREE_BASE_DIR="$TEST_WORKTREE_BASE" \
+		FULL_LOOP_HEADLESS=true run_helper "$TEST_ROOT" --loop-mode --task "$COLLISION_TASK" 2>&1) || exit_code=$?
+	local original_path=""
+	COLLISION_ORIGINAL_BRANCH=$(printf '%s\n' "$output" | awk -F= '/^WORKTREE_BRANCH=/{print $2; exit}')
+	original_path=$(printf '%s\n' "$output" | awk -F= '/^WORKTREE_PATH=/{print substr($0, index($0, "=") + 1); exit}')
+	COLLISION_ORIGINAL_SHA=$("$GIT_BIN" -C "$original_path" rev-parse HEAD 2>/dev/null || true)
+	if [[ "$exit_code" -ne 0 || "$output" != *"WORKTREE_PROVENANCE=fresh"* || -z "$COLLISION_ORIGINAL_SHA" ]]; then
+		print_result "creates first task worktree with fresh provenance" 1 "exit=${exit_code} output=${output}"
+		return 1
+	fi
+	print_result "creates first task worktree with fresh provenance" 0
+
+	"$GIT_BIN" -C "$TEST_ROOT" worktree remove --force "$original_path"
+	ensure_registry_schema
+	sqlite3 "$TEST_REGISTRY_DB" "DELETE FROM worktree_owners WHERE worktree_path = '$original_path';"
+	COLLISION_TARGET_TREE=$("$GIT_BIN" -C "$TEST_ROOT" rev-parse "${COLLISION_ORIGINAL_SHA}^{tree}")
+	COLLISION_ADVANCED_SHA=$(printf 'remote advance\n' | "$GIT_BIN" -C "$TEST_ROOT" commit-tree \
+		"$COLLISION_TARGET_TREE" -p "$COLLISION_ORIGINAL_SHA")
+	"$GIT_BIN" -C "$TEST_ROOT" push -q origin "${COLLISION_ADVANCED_SHA}:refs/heads/main"
+	return 0
+}
+
+test_stale_task_branch_is_replaced_and_owned_continuation_resumes() {
+	local output=""
+	local exit_code=0
+	output=$(OPENCODE_SESSION_ID=collision-session AIDEVOPS_WORKTREE_BASE_DIR="$TEST_WORKTREE_BASE" \
+		FULL_LOOP_HEADLESS=true run_helper "$TEST_ROOT" --loop-mode --task "$COLLISION_TASK" 2>&1) || exit_code=$?
+	local fresh_branch=""
+	fresh_branch=$(printf '%s\n' "$output" | awk -F= '/^WORKTREE_BRANCH=/{print $2; exit}')
+	COLLISION_FRESH_PATH=$(printf '%s\n' "$output" | awk -F= '/^WORKTREE_PATH=/{print substr($0, index($0, "=") + 1); exit}')
+	local fresh_sha=""
+	fresh_sha=$("$GIT_BIN" -C "$COLLISION_FRESH_PATH" rev-parse HEAD 2>/dev/null || true)
+	local preserved_sha=""
+	preserved_sha=$("$GIT_BIN" -C "$TEST_ROOT" rev-parse "refs/heads/${COLLISION_ORIGINAL_BRANCH}" 2>/dev/null || true)
+	if [[ "$exit_code" -eq 0 && "$fresh_branch" == "${COLLISION_ORIGINAL_BRANCH}-fresh" &&
+		"$fresh_sha" == "$COLLISION_ADVANCED_SHA" && "$preserved_sha" == "$COLLISION_ORIGINAL_SHA" &&
+		"$output" == *"WORKTREE_PROVENANCE=fresh_collision"* ]]; then
+		print_result "stale inactive task branch creates one fresh collision branch" 0
+	else
+		print_result "stale inactive task branch creates one fresh collision branch" 1 \
+			"exit=${exit_code} original=${preserved_sha} fresh=${fresh_sha} target=${COLLISION_ADVANCED_SHA} output=${output}"
+	fi
+
+	output=""
+	exit_code=0
+	output=$(OPENCODE_SESSION_ID=foreign-session AIDEVOPS_WORKTREE_BASE_DIR="$TEST_WORKTREE_BASE" \
+		FULL_LOOP_HEADLESS=true run_helper "$TEST_ROOT" --loop-mode --task "$COLLISION_TASK" 2>&1) || exit_code=$?
+	local branch_key_count=0
+	branch_key_count=$(printf '%s\n' "$output" | grep -c '^WORKTREE_BRANCH=' || true)
+	if [[ "$exit_code" -eq 2 && "$branch_key_count" -eq 1 &&
+		"$output" == *"WORKTREE_COLLISION=active_ownership_unverified"* ]]; then
+		print_result "foreign session cannot reuse an active task worktree" 0
+	else
+		print_result "foreign session cannot reuse an active task worktree" 1 "exit=${exit_code} output=${output}"
+	fi
+
+	output=""
+	exit_code=0
+	output=$(OPENCODE_SESSION_ID=collision-session AIDEVOPS_WORKTREE_BASE_DIR="$TEST_WORKTREE_BASE" \
+		FULL_LOOP_HEADLESS=true run_helper "$TEST_ROOT" --loop-mode --task "$COLLISION_TASK" 2>&1) || exit_code=$?
+	local repeated_path=""
+	repeated_path=$(printf '%s\n' "$output" | awk -F= '/^WORKTREE_PATH=/{print substr($0, index($0, "=") + 1); exit}')
+	local fresh_root=""
+	local repeated_root=""
+	fresh_root=$("$GIT_BIN" -C "$COLLISION_FRESH_PATH" rev-parse --show-toplevel 2>/dev/null || true)
+	repeated_root=$("$GIT_BIN" -C "$repeated_path" rev-parse --show-toplevel 2>/dev/null || true)
+	if [[ "$exit_code" -eq 0 && "$repeated_root" == "$fresh_root" &&
+		"$output" == *"WORKTREE_PROVENANCE=continuation_active"* ]]; then
+		print_result "repeated task resumes its correctly owned active worktree" 0
+	else
+		print_result "repeated task resumes its correctly owned active worktree" 1 "exit=${exit_code} output=${output}"
+	fi
+	return 0
+}
+
+test_unique_task_branch_fails_closed() {
+	local unique_task="Issue #29999 unique collision"
+	local unique_branch="bugfix/gh29999-issue-29999-unique-collision"
+	local unique_sha=""
+	unique_sha=$(printf 'unique task commit\n' | "$GIT_BIN" -C "$TEST_ROOT" commit-tree \
+		"$COLLISION_TARGET_TREE" -p "$COLLISION_ADVANCED_SHA")
+	"$GIT_BIN" -C "$TEST_ROOT" branch "$unique_branch" "$unique_sha"
+	local output=""
+	local exit_code=0
+	output=$(OPENCODE_SESSION_ID=collision-session AIDEVOPS_WORKTREE_BASE_DIR="$TEST_WORKTREE_BASE" \
+		FULL_LOOP_HEADLESS=true run_helper "$TEST_ROOT" --loop-mode --task "$unique_task" 2>&1) || exit_code=$?
+	local unique_after=""
+	unique_after=$("$GIT_BIN" -C "$TEST_ROOT" rev-parse "refs/heads/${unique_branch}")
+	if [[ "$exit_code" -eq 2 && "$unique_after" == "$unique_sha" &&
+		"$output" == *"WORKTREE_COLLISION=unique_commits"* &&
+		"$output" == *"ACTION_REQUIRED=inspect_existing_task_branch"* ]]; then
+		print_result "inactive task branch with unique commits fails closed unchanged" 0
+	else
+		print_result "inactive task branch with unique commits fails closed unchanged" 1 "exit=${exit_code} output=${output}"
+	fi
+	return 0
+}
+
+test_task_branch_remote_refresh_failure_fails_closed() {
+	local origin_url=""
+	origin_url=$("$GIT_BIN" -C "$TEST_ROOT" remote get-url origin)
+	"$GIT_BIN" -C "$TEST_ROOT" remote set-url origin "${TEST_ROOT}/missing-remote.git"
+	local output=""
+	local exit_code=0
+	output=$(OPENCODE_SESSION_ID=collision-session AIDEVOPS_WORKTREE_BASE_DIR="$TEST_WORKTREE_BASE" \
+		FULL_LOOP_HEADLESS=true run_helper "$TEST_ROOT" --loop-mode --task "Issue #30000 refresh failure" 2>&1) || exit_code=$?
+	"$GIT_BIN" -C "$TEST_ROOT" remote set-url origin "$origin_url"
+	local refresh_branch_created=0
+	if "$GIT_BIN" -C "$TEST_ROOT" show-ref --verify --quiet refs/heads/bugfix/gh30000-issue-30000-refresh-failure; then
+		refresh_branch_created=1
+	fi
+	if [[ "$exit_code" -eq 2 && "$output" == *"WORKTREE_COLLISION=target_refresh_failed"* &&
+		"$output" == *"ACTION_REQUIRED=refresh_target"* &&
+		"$output" == *"NEXT_STEP: Restore remote access, refresh the target branch"* &&
+		"$refresh_branch_created" -eq 0 ]]; then
+		print_result "remote refresh failure does not create a task branch" 0
+	else
+		print_result "remote refresh failure does not create a task branch" 1 "exit=${exit_code} output=${output}"
+	fi
+	return 0
+}
+
 main() {
 	trap teardown_test_repo EXIT
 	setup_test_repo
@@ -512,6 +655,10 @@ main() {
 	test_absolute_path_outside_repo_blocked_on_main
 	test_todo_subdir_path_requires_worktree
 	test_auto_creates_git_path_worktree_from_ansi_helper_output
+	setup_task_branch_collision_fixture
+	test_stale_task_branch_is_replaced_and_owned_continuation_resumes
+	test_unique_task_branch_fails_closed
+	test_task_branch_remote_refresh_failure_fails_closed
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then

--- a/.agents/scripts/tests/test-worktree-fresh-base.sh
+++ b/.agents/scripts/tests/test-worktree-fresh-base.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 HELPER="${SCRIPT_DIR}/../worktree-helper.sh"
+ADD_HELPER="${SCRIPT_DIR}/../worktree-helper-add.sh"
 REAL_GIT=$(command -v git)
 ROOT=$(mktemp -d)
 trap 'rm -rf "$ROOT"' EXIT
@@ -99,5 +100,72 @@ ISSUE_OWNER=$(sqlite3 -separator '|' "$REGISTRY_DB" \
 	exit 1
 }
 printf 'PASS explicit --issue propagates into the registry task ID\n'
+
+git -C "$CANONICAL" branch test/race-guard "$PINNED_SHA"
+RACE_OUTPUT=""
+RACE_RC=0
+RACE_OUTPUT=$(
+	cd "$CANONICAL" || exit 1
+	SCRIPT_DIR="$(cd "$(dirname "$ADD_HELPER")" && pwd)"
+	# shellcheck source=../worktree-helper-add.sh
+	source "$ADD_HELPER"
+	_ADD_FRESH_ON_COLLISION=1
+	_ADD_COLLISION_EXPECTED_SHA="$REMOTE_SHA"
+	_ADD_COLLISION_TARGET_SHA="$REMOTE_SHA"
+	_ADD_COLLISION_AHEAD=0
+	_ADD_COLLISION_BEHIND=1
+	_cmd_add_assert_collision_ref_unchanged test/race-guard 2>&1
+) || RACE_RC=$?
+if [[ "$RACE_RC" -eq 1 && "$RACE_OUTPUT" == *"WORKTREE_COLLISION=branch_changed_during_creation"* ]]; then
+	printf 'PASS collision ref changes are rejected at mutation time\n'
+else
+	printf 'FAIL collision ref change was not rejected: rc=%s output=%s\n' "$RACE_RC" "$RACE_OUTPUT"
+	exit 1
+fi
+
+RACE_BRANCH=test/race-e2e
+RACE_PATH="${WORKTREES}/canonical-test-race-e2e"
+RACE_MUTATED_SHA=$(printf 'race mutation\n' | git -C "$CANONICAL" commit-tree \
+	"$(git -C "$CANONICAL" rev-parse "${REMOTE_SHA}^{tree}")" -p "$REMOTE_SHA")
+git -C "$CANONICAL" branch "$RACE_BRANCH" "$REMOTE_SHA"
+RACE_OUTPUT=""
+RACE_RC=0
+RACE_OUTPUT=$(
+	cd "$CANONICAL" || exit 1
+	SCRIPT_DIR="$(cd "$(dirname "$ADD_HELPER")" && pwd)"
+	# shellcheck source=../worktree-helper-add.sh
+	source "$ADD_HELPER"
+	RED=""
+	NC=""
+	BLUE=""
+	GREEN=""
+	YELLOW=""
+	BOLD=""
+	get_repo_root() {
+		git rev-parse --show-toplevel 2>/dev/null
+		return $?
+	}
+	aidevops_worktree_capacity_check() { return 0; }
+	eval "$(declare -f _cmd_add_create_worktree | sed '1s/_cmd_add_create_worktree/_cmd_add_create_worktree_original/')"
+	_cmd_add_create_worktree() {
+		local branch="$1"
+		local path="$2"
+		local explicit_base="$3"
+		git update-ref "refs/heads/${branch}" "$RACE_MUTATED_SHA" || return 1
+		_cmd_add_create_worktree_original "$branch" "$path" "$explicit_base"
+		return $?
+	}
+	AIDEVOPS_SKIP_AUTO_CLAIM=1 cmd_add "$RACE_BRANCH" "$RACE_PATH" \
+		--issue 456 --base "$REMOTE_SHA" --fresh-on-collision 2>&1
+) || RACE_RC=$?
+RACE_BRANCH_AFTER=$(git -C "$CANONICAL" rev-parse "refs/heads/${RACE_BRANCH}")
+if [[ "$RACE_RC" -eq 1 && "$RACE_BRANCH_AFTER" == "$RACE_MUTATED_SHA" && ! -d "$RACE_PATH" &&
+	"$RACE_OUTPUT" == *"WORKTREE_COLLISION=branch_changed_during_creation"* ]]; then
+	printf 'PASS post-creation race guard preserves ref and removes wrong-tip worktree\n'
+else
+	printf 'FAIL post-creation race guard: rc=%s branch=%s path=%s output=%s\n' \
+		"$RACE_RC" "$RACE_BRANCH_AFTER" "$RACE_PATH" "$RACE_OUTPUT"
+	exit 1
+fi
 
 exit 0

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -237,7 +237,7 @@ _remove_show_owner_error() {
 _interactive_session_auto_claim() {
 	local branch="$1"
 	local worktree_path="$2"
-	local explicit_issue="${3:-}"  # t2260: --issue NNN takes highest precedence
+	local explicit_issue="${3:-}" # t2260: --issue NNN takes highest precedence
 
 	# Only engage for interactive sessions — workers handle their own
 	# claim flow via dispatch-dedup-helper.sh at dispatch time.
@@ -286,10 +286,10 @@ _interactive_session_auto_claim() {
 				# Match ONLY the structured ref:GH#NNN field on the task's TODO line
 				local task_id_ere=""
 				task_id_ere=$(task_identity_escape_ere "$task_id") || return 0
-				issue_num=$(grep -E "^- \[.\] ${task_id_ere}([[:space:]]|$)" "$repo_root/TODO.md" \
-					| grep -oE 'ref:GH#[0-9]+' \
-					| grep -oE '[0-9]+' \
-					| head -1 || true)
+				issue_num=$(grep -E "^- \[.\] ${task_id_ere}([[:space:]]|$)" "$repo_root/TODO.md" |
+					grep -oE 'ref:GH#[0-9]+' |
+					grep -oE '[0-9]+' |
+					head -1 || true)
 			fi
 		fi
 	fi
@@ -470,8 +470,8 @@ _worktree_resolve_abs_path() {
 	else
 		# Parent does not exist — naive join (best-effort absolute form)
 		case "$input" in
-			/*) printf '%s\n' "$input" ;;
-			*)  printf '%s/%s\n' "$(pwd -P)" "$input" ;;
+		/*) printf '%s\n' "$input" ;;
+		*) printf '%s/%s\n' "$(pwd -P)" "$input" ;;
 		esac
 	fi
 	return 0
@@ -618,7 +618,8 @@ _cmd_add_assert_path_outside_repo() {
 }
 
 # Parse cmd_add arguments: positional (branch, path) + optional flags.
-# Sets global _ADD_BRANCH, _ADD_PATH, _ADD_ISSUE, _ADD_BASE. Returns 1 on parse error.
+# Sets global _ADD_BRANCH, _ADD_PATH, _ADD_ISSUE, _ADD_BASE, and
+# _ADD_FRESH_ON_COLLISION. Returns 1 on parse error.
 # Extracted from cmd_add (t2260) to keep function bodies under 100 lines.
 # --base <ref> (t2802): explicit base for new branch creation. Default is
 # origin/<default_branch> — prevents scope-leak PRs when canonical HEAD is stale.
@@ -627,56 +628,182 @@ _parse_cmd_add_args() {
 	_ADD_PATH=""
 	_ADD_ISSUE=""
 	_ADD_BASE=""
+	_ADD_FRESH_ON_COLLISION=0
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
 		case "$_arg" in
-			--issue)
-				local _next="${2:-}"
-				if [[ -z "$_next" ]]; then
-					echo -e "${RED}Error: --issue requires a number${NC}"
-					return 1
-				fi
-				_ADD_ISSUE="$_next"
-				shift 2
-				;;
-			--issue=*)
-				_ADD_ISSUE="${_arg#--issue=}"
-				shift
-				;;
-			--base)
-				local _next_base="${2:-}"
-				if [[ -z "$_next_base" ]]; then
-					echo -e "${RED}Error: --base requires a ref (e.g. origin/main, develop, <sha>)${NC}"
-					return 1
-				fi
-				_ADD_BASE="$_next_base"
-				shift 2
-				;;
-			--base=*)
-				_ADD_BASE="${_arg#--base=}"
-				shift
-				;;
-			-*)
-				echo -e "${RED}Error: Unknown option: $_arg${NC}"
-				echo "Usage: worktree-helper.sh add <branch> [path] [--issue NNN] [--base REF]"
+		--issue)
+			local _next="${2:-}"
+			if [[ -z "$_next" ]]; then
+				echo -e "${RED}Error: --issue requires a number${NC}"
 				return 1
-				;;
-			*)
-				if [[ -z "$_ADD_BRANCH" ]]; then
-					_ADD_BRANCH="$_arg"
-				elif [[ -z "$_ADD_PATH" ]]; then
-					_ADD_PATH="$_arg"
-				fi
-				shift
-				;;
+			fi
+			_ADD_ISSUE="$_next"
+			shift 2
+			;;
+		--issue=*)
+			_ADD_ISSUE="${_arg#--issue=}"
+			shift
+			;;
+		--base)
+			local _next_base="${2:-}"
+			if [[ -z "$_next_base" ]]; then
+				echo -e "${RED}Error: --base requires a ref (e.g. origin/main, develop, <sha>)${NC}"
+				return 1
+			fi
+			_ADD_BASE="$_next_base"
+			shift 2
+			;;
+		--base=*)
+			_ADD_BASE="${_arg#--base=}"
+			shift
+			;;
+		--fresh-on-collision)
+			_ADD_FRESH_ON_COLLISION=1
+			shift
+			;;
+		-*)
+			echo -e "${RED}Error: Unknown option: $_arg${NC}"
+			echo "Usage: worktree-helper.sh add <branch> [path] [--issue NNN] [--base REF] [--fresh-on-collision]"
+			return 1
+			;;
+		*)
+			if [[ -z "$_ADD_BRANCH" ]]; then
+				_ADD_BRANCH="$_arg"
+			elif [[ -z "$_ADD_PATH" ]]; then
+				_ADD_PATH="$_arg"
+			fi
+			shift
+			;;
 		esac
 	done
 	if [[ -z "$_ADD_BRANCH" ]]; then
 		echo -e "${RED}Error: Branch name required${NC}"
-		echo "Usage: worktree-helper.sh add <branch> [path] [--issue NNN] [--base REF]"
+		echo "Usage: worktree-helper.sh add <branch> [path] [--issue NNN] [--base REF] [--fresh-on-collision]"
 		return 1
 	fi
 	return 0
+}
+
+# Emit additive machine-readable provenance for callers that opt into safe
+# task-branch collision handling.
+_cmd_add_print_collision_provenance() {
+	[[ "${_ADD_FRESH_ON_COLLISION:-0}" -eq 1 ]] || return 0
+	printf 'WORKTREE_PATH=%s\n' "${_ADD_COLLISION_PATH:-}"
+	printf 'WORKTREE_BRANCH=%s\n' "${_ADD_COLLISION_BRANCH:-}"
+	printf 'WORKTREE_PROVENANCE=%s\n' "${_ADD_COLLISION_PROVENANCE:-unknown}"
+	printf 'WORKTREE_TARGET=%s\n' "${_ADD_COLLISION_TARGET_SHA:-}"
+	printf 'WORKTREE_AHEAD=%s\n' "${_ADD_COLLISION_AHEAD:-0}"
+	printf 'WORKTREE_BEHIND=%s\n' "${_ADD_COLLISION_BEHIND:-0}"
+	return 0
+}
+
+_cmd_add_emit_collision() {
+	local collision="$1"
+	local branch="$2"
+	local action="$3"
+	local path="${4:-}"
+	printf 'WORKTREE_COLLISION=%s\n' "$collision" >&2
+	printf 'WORKTREE_BRANCH=%s\n' "$branch" >&2
+	[[ -z "$path" ]] || printf 'WORKTREE_PATH=%s\n' "$path" >&2
+	printf 'WORKTREE_TARGET=%s\n' "${_ADD_COLLISION_TARGET_SHA:-}" >&2
+	printf 'WORKTREE_AHEAD=%s\n' "${_ADD_COLLISION_AHEAD:-0}" >&2
+	printf 'WORKTREE_BEHIND=%s\n' "${_ADD_COLLISION_BEHIND:-0}" >&2
+	printf 'ACTION_REQUIRED=%s\n' "$action" >&2
+	return 1
+}
+
+_cmd_add_measure_collision_branch() {
+	local branch="$1"
+	_ADD_COLLISION_AHEAD=$(git rev-list --count "${_ADD_COLLISION_TARGET_SHA}..refs/heads/${branch}" 2>/dev/null) || return 1
+	_ADD_COLLISION_BEHIND=$(git rev-list --count "refs/heads/${branch}..${_ADD_COLLISION_TARGET_SHA}" 2>/dev/null) || return 1
+	_ADD_COLLISION_PATH=$(get_worktree_path_for_branch "$branch" 2>/dev/null || true)
+	return 0
+}
+
+_cmd_add_accept_owned_active_collision() {
+	local branch="$1"
+	local explicit_issue="$2"
+	local owner_info=""
+	local owner_pid="" owner_session="" owner_batch="" owner_task="" owner_created=""
+	local current_session="${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
+	owner_info=$(check_worktree_owner "$_ADD_COLLISION_PATH" 2>/dev/null || true)
+	IFS='|' read -r owner_pid owner_session owner_batch owner_task owner_created <<<"$owner_info"
+	if [[ -z "$explicit_issue" || -z "$current_session" ||
+		"$owner_task" != "$explicit_issue" || "$owner_session" != "$current_session" ]]; then
+		_cmd_add_emit_collision active_ownership_unverified "$branch" \
+			inspect_existing_task_worktree "$_ADD_COLLISION_PATH"
+		return 1
+	fi
+	_ADD_COLLISION_PROVENANCE="continuation_active"
+	_ADD_COLLISION_REUSED_ACTIVE=1
+	return 0
+}
+
+_cmd_add_classify_fresh_collision_branch() {
+	local branch="$1"
+	local explicit_issue="$2"
+	_ADD_COLLISION_BRANCH="$branch"
+	_ADD_COLLISION_PROVENANCE="fresh_collision"
+	_ADD_COLLISION_AHEAD=0
+	_ADD_COLLISION_BEHIND=0
+	_ADD_COLLISION_PATH=""
+	branch_exists "$branch" || return 0
+	_cmd_add_measure_collision_branch "$branch" || return 1
+	if [[ -n "$_ADD_COLLISION_PATH" ]]; then
+		_cmd_add_accept_owned_active_collision "$branch" "$explicit_issue"
+		return $?
+	fi
+	if [[ "$_ADD_COLLISION_AHEAD" -eq 0 && "$_ADD_COLLISION_BEHIND" -eq 0 ]]; then
+		_ADD_COLLISION_PROVENANCE="fresh_existing"
+		return 0
+	fi
+	_cmd_add_emit_collision fresh_branch_changed "$branch" inspect_existing_task_branch
+	return 1
+}
+
+# Classify an existing task-derived branch against a freshly resolved target.
+# The opt-in policy is lossless: unique commits are never rewritten, and one
+# deterministic "-fresh" branch bounds retries after a stale empty collision.
+_cmd_add_classify_collision_branch() {
+	local requested_branch="$1"
+	local explicit_base="$2"
+	local explicit_issue="$3"
+	local target_ref=""
+	if ! target_ref=$(_resolve_worktree_base_ref "$explicit_base"); then
+		_cmd_add_emit_collision target_refresh_failed "$requested_branch" refresh_target
+		return 1
+	fi
+	[[ -n "$target_ref" ]] || {
+		_cmd_add_emit_collision target_unresolved "$requested_branch" refresh_target
+		return 1
+	}
+
+	_ADD_COLLISION_TARGET_SHA=$(git rev-parse --verify "${target_ref}^{commit}" 2>/dev/null) || return 1
+	_ADD_COLLISION_EXPECTED_SHA="$_ADD_COLLISION_TARGET_SHA"
+	_ADD_COLLISION_BRANCH="$requested_branch"
+	_ADD_COLLISION_PROVENANCE="fresh"
+	_ADD_COLLISION_AHEAD=0
+	_ADD_COLLISION_BEHIND=0
+	_ADD_COLLISION_PATH=""
+	_ADD_COLLISION_REUSED_ACTIVE=0
+	branch_exists "$requested_branch" || return 0
+
+	_cmd_add_measure_collision_branch "$requested_branch" || return 1
+	if [[ -n "$_ADD_COLLISION_PATH" ]]; then
+		_cmd_add_accept_owned_active_collision "$requested_branch" "$explicit_issue"
+		return $?
+	fi
+	if [[ "$_ADD_COLLISION_AHEAD" -gt 0 ]]; then
+		_cmd_add_emit_collision unique_commits "$requested_branch" inspect_existing_task_branch
+		return 1
+	fi
+	if [[ "$_ADD_COLLISION_BEHIND" -eq 0 ]]; then
+		_ADD_COLLISION_PROVENANCE="fresh_existing"
+		return 0
+	fi
+	_cmd_add_classify_fresh_collision_branch "${requested_branch}-fresh" "$explicit_issue"
+	return $?
 }
 
 # Refresh an origin branch from linked-worktree context so the canonical Git
@@ -840,26 +967,89 @@ _cmd_add_create_worktree() {
 	return 1
 }
 
+_cmd_add_warn_task_id_variant() {
+	local branch="$1"
+	if [[ ! "$branch" =~ t[0-9]+[a-z]($|[-_/]) && ! "$branch" =~ t[0-9]+[-._][0-9]+($|[-_/]) ]]; then
+		return 0
+	fi
+	print_warning "Branch name contains a non-claimed task ID variant ($branch)."
+	print_warning "Task IDs come ONLY from claim-task-id.sh. For follow-ups, claim a fresh ID."
+	if [[ -t 0 ]]; then
+		local confirm=""
+		read -rp "Continue with this branch name anyway? [y/N] " confirm
+		[[ "$confirm" =~ ^[Yy]$ ]] || return 1
+	fi
+	return 0
+}
+
+_cmd_add_use_existing_worktree() {
+	local branch="$1"
+	local existing_path=""
+	existing_path=$(get_worktree_path_for_branch "$branch") || return 1
+	if [[ "${_ADD_FRESH_ON_COLLISION:-0}" -eq 1 ]]; then
+		_ADD_COLLISION_PATH="$existing_path"
+		_cmd_add_emit_collision concurrent_worktree "$branch" inspect_existing_task_worktree "$existing_path"
+		return 2
+	fi
+	echo -e "${YELLOW}Worktree already exists for branch '$branch'${NC}"
+	echo -e "Path: ${BOLD}$existing_path${NC}"
+	echo ""
+	echo "To use it:"
+	echo "  cd $existing_path" || exit
+	return 0
+}
+
+_cmd_add_assert_collision_ref_unchanged() {
+	local branch="$1"
+	[[ "${_ADD_FRESH_ON_COLLISION:-0}" -eq 1 ]] || return 0
+	branch_exists "$branch" || return 0
+	local current_sha=""
+	current_sha=$(git rev-parse --verify "refs/heads/${branch}^{commit}" 2>/dev/null) || return 1
+	if [[ "$current_sha" != "$_ADD_COLLISION_EXPECTED_SHA" ]]; then
+		_cmd_add_emit_collision branch_changed_during_creation "$branch" inspect_existing_task_branch
+		return 1
+	fi
+	return 0
+}
+
+_cmd_add_verify_collision_tip() {
+	local branch="$1"
+	local path="$2"
+	[[ "${_ADD_FRESH_ON_COLLISION:-0}" -eq 1 ]] || return 0
+	local actual_sha=""
+	actual_sha=$(git -C "$path" rev-parse HEAD 2>/dev/null || true)
+	if [[ "$actual_sha" == "$_ADD_COLLISION_EXPECTED_SHA" ]]; then
+		return 0
+	fi
+	git worktree remove --force "$path" >/dev/null 2>&1 || true
+	_ADD_COLLISION_PATH=""
+	_cmd_add_emit_collision branch_changed_during_creation "$branch" inspect_existing_task_branch
+	return 1
+}
+
+_cmd_add_prepare_collision_mode() {
+	local branch="$1"
+	local explicit_base="$2"
+	local explicit_issue="$3"
+	_cmd_add_classify_collision_branch "$branch" "$explicit_base" "$explicit_issue" || return 1
+	if [[ "$_ADD_COLLISION_REUSED_ACTIVE" -eq 1 ]]; then
+		_cmd_add_print_collision_provenance
+		return 2
+	fi
+	return 0
+}
+
 # --- cmd_add ---
 
 cmd_add() {
 	_parse_cmd_add_args "$@" || return 1
 	local branch="$_ADD_BRANCH"
 	local path="$_ADD_PATH"
-	local explicit_issue="$_ADD_ISSUE"  # t2260: --issue NNN for unambiguous claim
-	local explicit_base="$_ADD_BASE"    # t2802: --base REF for explicit base
+	local explicit_issue="$_ADD_ISSUE" # t2260: --issue NNN for unambiguous claim
+	local explicit_base="$_ADD_BASE"   # t2802: --base REF for explicit base
 
-	# t2235: Detect self-invented task ID variants (e.g. t2213b, t2213-2, t2213.fix)
-	# Task IDs come ONLY from claim-task-id.sh. For follow-ups, claim a fresh ID.
-	if [[ "$branch" =~ t[0-9]+[a-z]($|[-_/]) ]] || [[ "$branch" =~ t[0-9]+[-._][0-9]+($|[-_/]) ]]; then
-		print_warning "Branch name contains a non-claimed task ID variant ($branch)."
-		print_warning "Task IDs come ONLY from claim-task-id.sh. For follow-ups, claim a fresh ID."
-		if [[ -t 0 ]]; then # interactive
-			read -rp "Continue with this branch name anyway? [y/N] " confirm
-			[[ "$confirm" =~ ^[Yy]$ ]] || return 1
-		fi
-		# headless: warn only, don't block (could be legitimate in rare cases)
-	fi
+	# t2235: warn about self-invented task ID variants; headless callers continue.
+	_cmd_add_warn_task_id_variant "$branch" || return 1
 
 	# Check if we're in a git repo
 	if [[ -z "$(get_repo_root)" ]]; then
@@ -867,15 +1057,23 @@ cmd_add() {
 		return 1
 	fi
 
-	# Check if worktree already exists for this branch
-	local existing_path
-	if existing_path=$(get_worktree_path_for_branch "$branch"); then
-		echo -e "${YELLOW}Worktree already exists for branch '$branch'${NC}"
-		echo -e "Path: ${BOLD}$existing_path${NC}"
-		echo ""
-		echo "To use it:"
-		echo "  cd $existing_path" || exit
+	if [[ "$_ADD_FRESH_ON_COLLISION" -eq 1 ]]; then
+		local collision_rc=0
+		_cmd_add_prepare_collision_mode "$branch" "$explicit_base" "$explicit_issue" || collision_rc=$?
+		[[ "$collision_rc" -eq 1 ]] && return 1
+		[[ "$collision_rc" -eq 2 ]] && return 0
+		branch="$_ADD_COLLISION_BRANCH"
+		explicit_base="$_ADD_COLLISION_TARGET_SHA"
+	fi
+
+	# Recheck both the ref and active-worktree state at mutation time.
+	_cmd_add_assert_collision_ref_unchanged "$branch" || return 1
+	local existing_rc=0
+	_cmd_add_use_existing_worktree "$branch" || existing_rc=$?
+	if [[ "$existing_rc" -eq 0 ]]; then
 		return 0
+	elif [[ "$existing_rc" -eq 2 ]]; then
+		return 1
 	fi
 
 	# Generate path if not provided
@@ -906,6 +1104,7 @@ cmd_add() {
 
 	# Create worktree (existing branch → simple checkout; new branch → base-ref dance).
 	_cmd_add_create_worktree "$branch" "$path" "$explicit_base" || return 1
+	_cmd_add_verify_collision_tip "$branch" "$path" || return 1
 
 	# Register ownership (t189). Preserve the explicit issue identity so a
 	# same-task headless continuation can safely reclaim this worktree.
@@ -932,6 +1131,8 @@ cmd_add() {
 	_interactive_session_auto_claim "$branch" "$path" "$explicit_issue" || true
 
 	_print_worktree_add_success "$path" "$branch"
+	_ADD_COLLISION_PATH="$path"
+	_cmd_add_print_collision_provenance
 
 	# Localdev integration (t1224.8): auto-create branch subdomain route
 	localdev_auto_branch "$branch"

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -14,7 +14,8 @@
 #   worktree-helper.sh <command> [options]
 #
 # Commands:
-#   add <branch> [path] [--issue NNN] [--base REF]  Create worktree for branch (auto-names path)
+#   add <branch> [path] [--issue NNN] [--base REF] [--fresh-on-collision]
+#                          Create worktree for branch (auto-names path)
 #   list                   List all worktrees with status
 #   remove <path|branch>   Remove a worktree
 #   status                 Show current worktree info


### PR DESCRIPTION
## Summary

Classify repeated task branches against a refreshed target, create one bounded fresh branch for stale no-unique-commit collisions, require same-session ownership for active continuation, and fail closed on ambiguous or raced state.

## Files Changed

.agents/scripts/pre-edit-check.sh, .agents/scripts/tests/test-pre-edit-check.sh, .agents/scripts/tests/test-worktree-fresh-base.sh, .agents/scripts/worktree-helper-add.sh, .agents/scripts/worktree-helper.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime fixtures cover stale inactive branches, same-session and foreign-session active worktrees, unique-commit preservation, remote refresh failure, and pre/post-creation ref races; focused shell tests, ShellCheck, shfmt, complexity gates, and changed-file lint pass.

Resolves #28956


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 58m and 266,611 tokens on this as a headless worker.