### PR TITLE
GH#28966: fix: preserve task completion guard compatibility

### DIFF
--- a/.agents/scripts/task-complete-helper.sh
+++ b/.agents/scripts/task-complete-helper.sh
@@ -791,10 +791,9 @@ sync_plans_status() {
 
 # Commit and push TODO.md (and PLANS.md if changed)
 commit_and_push() {
-	local task_id="$1"
-	local proof_log="$2"
-	local repo_path="$3"
-	local no_push="$4"
+	local repo_path="$1"
+	local no_push="$2"
+	local issue_number="$3"
 
 	cd "$repo_path" || {
 		log_error "Failed to cd to $repo_path"
@@ -819,14 +818,16 @@ commit_and_push() {
 		return 0
 	fi
 
-	# Commit
-	local commit_msg="chore: mark $task_id complete ($proof_log)"
-	if ! git commit -m "$commit_msg"; then
+	# Keep task IDs and proof metadata in TODO.md rather than the commit message:
+	# task-id-collision-guard validates every tNNN-like token in the message.
+	local commit_subject="chore: mark task complete"
+	local commit_footer="For #${issue_number}"
+	if ! git commit -m "$commit_subject" -m "$commit_footer"; then
 		log_error "Failed to commit TODO.md"
 		return 1
 	fi
 
-	log_success "Committed: $commit_msg"
+	log_success "Committed: $commit_subject ($commit_footer)"
 
 	# Push (unless --no-push)
 	if [[ "$no_push" == "false" ]]; then
@@ -840,6 +841,36 @@ commit_and_push() {
 		log_info "Skipped push (--no-push flag)"
 	fi
 
+	return 0
+}
+
+# Resolve the mapped GitHub issue from the task before modifying TODO.md.
+# A task-completion commit must retain a guard-compatible issue footer, so fail
+# before mutation when the task has no canonical ref:GH#NNN mapping.
+task_issue_number() {
+	local task_id="$1"
+	local todo_file="$2"
+	local task_line=""
+	local issue_number=""
+
+	task_line=$(grep -E "^- \[[ x]\] ${task_id}${TASK_COMPLETE_ID_BOUNDARY}" "$todo_file" | head -1 || true)
+	if [[ -z "$task_line" ]]; then
+		log_error "Task $task_id not found in an open TODO.md entry"
+		return 1
+	fi
+	# An already-completed task is an idempotent no-op, so it does not need a
+	# footer for a commit that will not be created.
+	if [[ "$task_line" == "- [x]"* ]]; then
+		return 0
+	fi
+
+	issue_number=$(printf '%s\n' "$task_line" | grep -oE 'ref:GH#[0-9]+' | head -1 | tr -cd '0-9')
+	if [[ -z "$issue_number" ]]; then
+		log_error "Task $task_id has no ref:GH#NNN mapping; refusing to mutate TODO.md without a compliant commit footer"
+		return 1
+	fi
+
+	printf '%s\n' "$issue_number"
 	return 0
 }
 
@@ -902,6 +933,14 @@ main() {
 		log_info "Testing level: ${TESTING_LEVEL}"
 	fi
 
+	# Derive the guard-compatible commit footer before changing task state. This
+	# prevents a staged-but-uncommittable TODO.md mutation when task metadata is
+	# incomplete.
+	local issue_number=""
+	if ! issue_number=$(task_issue_number "$TASK_ID" "${REPO_PATH}/TODO.md"); then
+		return 1
+	fi
+
 	# Mark task complete
 	if ! complete_task "$TASK_ID" "$proof_log" "$REPO_PATH"; then
 		return 1
@@ -911,7 +950,7 @@ main() {
 	sync_plans_status "$TASK_ID" "$proof_log" "$REPO_PATH" || true
 
 	# Commit and push (includes PLANS.md if modified)
-	if ! commit_and_push "$TASK_ID" "$proof_log" "$REPO_PATH" "$NO_PUSH"; then
+	if ! commit_and_push "$REPO_PATH" "$NO_PUSH" "$issue_number"; then
 		return 1
 	fi
 

--- a/.agents/scripts/tests/test-task-complete-move.sh
+++ b/.agents/scripts/tests/test-task-complete-move.sh
@@ -7,7 +7,7 @@
 # Verifies that complete_task() in task-complete-helper.sh moves completed entries
 # to the ## Done section instead of doing in-place [x] marking.
 #
-# Tests (7 edge cases):
+# Tests (8 edge cases):
 #   1. Single-line task (no subtasks) moves from Ready to Done
 #   2. Task with explicit subtask IDs (t123.1) — guard prevents completion
 #   3. Task with indented subtasks (all complete) — block moves to Done
@@ -15,6 +15,7 @@
 #   5. Task in ## In Progress — also moved to Done
 #   6. ## Done header missing — errors out clearly, no data loss
 #   7. Multiple consecutive tasks — block boundary doesn't bleed into next entry
+#   8. Completion commit keeps task proof in TODO.md and uses a guard-safe footer
 #
 # Strategy:
 #   - Create a real git repo in a temp dir (script does git add/commit).
@@ -23,6 +24,11 @@
 #   - Assert section membership and proof-log presence.
 
 set -u
+
+# Fixture repositories are disposable; use native Git rather than the runtime
+# canonical-worktree guard shim that protects the actual source checkout.
+PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH
 
 if [[ -t 1 ]]; then
 	TEST_GREEN=$'\033[0;32m'
@@ -77,9 +83,30 @@ setup_repo() {
 	git -C "$repo_dir" init -q
 	git -C "$repo_dir" config user.email "test@test.com"
 	git -C "$repo_dir" config user.name "Test"
+	git -C "$repo_dir" config commit.gpgsign false
+	git -C "$repo_dir" config tag.gpgsign false
 	git -C "$repo_dir" add TODO.md
 	git -C "$repo_dir" commit -q -m "initial"
 	REPO_PATH="$repo_dir"
+	return 0
+}
+
+# Install a minimal commit-msg guard matching the production constraint: task
+# IDs in generated completion messages must be rejected unless explicitly
+# mapped. The helper must succeed without --no-verify.
+install_task_id_guard_stub() {
+	local repo_path="$1"
+	local hooks_dir="$repo_path/test-hooks"
+	mkdir -p "$hooks_dir"
+	cat >"$hooks_dir/commit-msg" <<'HOOK'
+#!/usr/bin/env bash
+if grep -qE 't[0-9]+' "$1"; then
+	exit 1
+fi
+exit 0
+HOOK
+	chmod +x "$hooks_dir/commit-msg"
+	git -C "$repo_path" config core.hooksPath "$hooks_dir"
 	return 0
 }
 
@@ -369,6 +396,44 @@ if ! task_in_done "t701" "$REPO_PATH/TODO.md"; then
 	pass "t701 NOT in Done"
 else
 	fail "t701 NOT in Done" "t701 was incorrectly moved to Done"
+fi
+
+# =============================================================================
+# Test 8: Completion commits use a guard-safe subject and mapped issue footer
+# =============================================================================
+printf '\nTest 8: completion commit uses mapped issue footer\n'
+
+FIXTURE="${FIXTURE_HEADER}- [ ] t800 completion commit metadata #tag ~1h ref:GH#800 logged:2026-01-01
+${FIXTURE_SECTIONS}"
+
+setup_repo "$FIXTURE" "repo8"
+install_task_id_guard_stub "$REPO_PATH"
+
+if "$HELPER" t800 --verified 2026-01-15 --testing-level runtime-verified --no-push --skip-merge-check \
+	--repo-path "$REPO_PATH" >/dev/null 2>&1; then
+	pass "helper completes task with task-ID guard enabled"
+else
+	fail "helper completes task with task-ID guard enabled" "helper unexpectedly failed"
+fi
+
+commit_subject=$(git -C "$REPO_PATH" log -1 --format=%s)
+commit_body=$(git -C "$REPO_PATH" log -1 --format=%b)
+if [[ "$commit_subject" == "chore: mark task complete" ]]; then
+	pass "completion commit subject contains no task ID"
+else
+	fail "completion commit subject contains no task ID" "got: $commit_subject"
+fi
+
+if [[ "$commit_body" == "For #800" ]]; then
+	pass "completion commit has mapped issue footer"
+else
+	fail "completion commit has mapped issue footer" "got: $commit_body"
+fi
+
+if grep -qE "verified:2026-01-15 testing:runtime-verified" "$REPO_PATH/TODO.md"; then
+	pass "proof metadata remains in TODO.md"
+else
+	fail "proof metadata remains in TODO.md" "proof metadata missing from TODO.md"
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-task-complete-pr-verify.sh
+++ b/.agents/scripts/tests/test-task-complete-pr-verify.sh
@@ -30,6 +30,11 @@
 
 set -u
 
+# Fixture repositories are disposable; use native Git rather than the runtime
+# canonical-worktree guard shim that protects the actual source checkout.
+PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH
+
 if [[ -t 1 ]]; then
 	TEST_GREEN=$'\033[0;32m'
 	TEST_RED=$'\033[0;31m'
@@ -106,6 +111,8 @@ setup_repo() {
 	git -C "$repo_dir" init -q
 	git -C "$repo_dir" config user.email "test@test.com"
 	git -C "$repo_dir" config user.name "Test"
+	git -C "$repo_dir" config commit.gpgsign false
+	git -C "$repo_dir" config tag.gpgsign false
 	git -C "$repo_dir" add TODO.md
 	git -C "$repo_dir" commit -q -m "initial"
 	REPO_PATH="$repo_dir"


### PR DESCRIPTION
## Summary

Use a task-free completion commit subject and mapped For footer, preserving proof metadata in TODO.md and rejecting unmapped tasks before mutation.

## Files Changed

.agents/scripts/task-complete-helper.sh, .agents/scripts/tests/test-task-complete-move.sh, .agents/scripts/tests/test-task-complete-pr-verify.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-task-complete-move.sh; bash .agents/scripts/tests/test-task-complete-pr-verify.sh; .agents/scripts/linters-local.sh

Resolves #28966


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-terra spent 6m and 119,741 tokens on this as a headless worker.