### PR TITLE
GH#28968: Stabilize approval timeline snapshots

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -1462,7 +1462,7 @@ _approval_classify_signed_comment() {
 	local body="$5"
 	local pub_key="$6"
 	local expected_head_sha="${7:-}"
-	local payload="" snapshot_json="" current_digest="" signed_digest="" normalized_slug=""
+	local payload="" snapshot_json="" current_digest="" signed_digest="" normalized_slug="" issued_at=""
 	normalized_slug=$(printf '%s' "$slug" | tr '[:upper:]' '[:lower:]')
 
 	payload=$(_extract_fenced_block "$body" 1)
@@ -1505,7 +1505,11 @@ _approval_classify_signed_comment() {
 		fi
 	fi
 
-	snapshot_json=$(approval_snapshot_v2_build "$target_type" "$target_number" "$slug" "$comment_id") || {
+	issued_at=$(jq -r '.issued_at' <<<"$payload") || {
+		printf 'MALFORMED_APPROVAL\n'
+		return 0
+	}
+	snapshot_json=$(approval_snapshot_v2_build "$target_type" "$target_number" "$slug" "$comment_id" "$issued_at") || {
 		printf 'API_ERROR\n'
 		return 0
 	}

--- a/.agents/scripts/approval-snapshot-v2.sh
+++ b/.agents/scripts/approval-snapshot-v2.sh
@@ -92,14 +92,29 @@ _approval_snapshot_v2_comments_json() {
 
 _approval_snapshot_v2_linked_references_json() {
 	local pages_json="$1"
+	local issued_at_cutoff="${2:-}"
 	local empty_string=""
+	local timestamp_pattern='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'
+	[[ -z "$issued_at_cutoff" || "$issued_at_cutoff" =~ $timestamp_pattern ]] || return 1
 
 	# GitHub timeline cross-reference events are the authoritative read-only
 	# projection of issue/PR links. Keep external text and URLs as opaque bytes;
 	# this helper never follows or executes them.
-	jq -cS --arg empty "$empty_string" '
+	# #aidevops:trust-boundary — approval authority covers references visible at
+	# signing time. A later reference cannot extend that signed authority and must
+	# not revoke it when GitHub exposes the timeline event asynchronously.
+	jq -cS --arg empty "$empty_string" --arg cutoff "$issued_at_cutoff" --arg timestamp_pattern "$timestamp_pattern" '
+		def is_linked_reference:
+			(.event // $empty) == "cross-referenced"
+			or (.event // $empty) == "connected"
+			or (.event // $empty) == "disconnected"
+			or (.event // $empty) == "referenced";
+		if $cutoff != $empty and any(.[][]?; is_linked_reference and (((.created_at // $empty) | test($timestamp_pattern)) | not)) then
+			error("linked reference has no authoritative created_at")
+		else
 		[.[][]?
-		| select((.event // $empty) == "cross-referenced" or (.event // $empty) == "connected" or (.event // $empty) == "disconnected" or (.event // $empty) == "referenced")
+		| select(is_linked_reference)
+		| select($cutoff == $empty or .created_at <= $cutoff)
 		| {
 			event: (.event // $empty),
 			id: (.id // null),
@@ -133,6 +148,7 @@ _approval_snapshot_v2_linked_references_json() {
 			} end)
 		}
 		] | sort_by(.created_at, .event, .id)
+		end
 	' <<<"$pages_json"
 	return $?
 }
@@ -169,6 +185,7 @@ approval_snapshot_v2_build() (
 	local target_number="$2"
 	local slug="$3"
 	local excluded_comment_id="${4:-}"
+	local issued_at_cutoff="${5:-}"
 	local issue_json="" comments_pages="" comments_json="" timeline_pages="" linked_references_json="" normalized_slug=""
 	local empty_string=""
 	local temp_dir=""
@@ -188,7 +205,7 @@ approval_snapshot_v2_build() (
 	comments_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/issues/${target_number}/comments?per_page=100") || return 1
 	comments_json=$(_approval_snapshot_v2_comments_json "$comments_pages" "$excluded_comment_id" "conversation") || return 1
 	timeline_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/issues/${target_number}/timeline?per_page=100") || return 1
-	linked_references_json=$(_approval_snapshot_v2_linked_references_json "$timeline_pages") || return 1
+	linked_references_json=$(_approval_snapshot_v2_linked_references_json "$timeline_pages" "$issued_at_cutoff") || return 1
 	temp_dir=$(_approval_snapshot_v2_create_temp_dir) || return 1
 	trap 'rm -rf "$temp_dir"' EXIT
 	_approval_snapshot_v2_write_json_file "$temp_dir/issue.json" "$issue_json" || return 1
@@ -287,7 +304,7 @@ approval_snapshot_v2_payload() (
 	local snapshot_json="" digest="" normalized_slug=""
 	local temp_dir=""
 
-	snapshot_json=$(approval_snapshot_v2_build "$target_type" "$target_number" "$slug" "$excluded_comment_id") || return 1
+	snapshot_json=$(approval_snapshot_v2_build "$target_type" "$target_number" "$slug" "$excluded_comment_id" "$issued_at") || return 1
 	digest=$(approval_snapshot_v2_digest "$snapshot_json") || return 1
 	normalized_slug=$(printf '%s' "$slug" | tr '[:upper:]' '[:lower:]')
 	temp_dir=$(_approval_snapshot_v2_create_temp_dir) || return 1

--- a/.agents/scripts/approval-snapshot-v2.sh
+++ b/.agents/scripts/approval-snapshot-v2.sh
@@ -95,7 +95,6 @@ _approval_snapshot_v2_linked_references_json() {
 	local issued_at_cutoff="${2:-}"
 	local empty_string=""
 	local timestamp_pattern='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'
-	[[ -z "$issued_at_cutoff" || "$issued_at_cutoff" =~ $timestamp_pattern ]] || return 1
 
 	# GitHub timeline cross-reference events are the authoritative read-only
 	# projection of issue/PR links. Keep external text and URLs as opaque bytes;
@@ -109,7 +108,14 @@ _approval_snapshot_v2_linked_references_json() {
 			or (.event // $empty) == "connected"
 			or (.event // $empty) == "disconnected"
 			or (.event // $empty) == "referenced";
-		if $cutoff != $empty and any(.[][]?; is_linked_reference and (((.created_at // $empty) | test($timestamp_pattern)) | not)) then
+		def is_valid_timestamp:
+			. as $timestamp
+			| ($timestamp | type) == "string"
+			and ($timestamp | test($timestamp_pattern))
+			and ((try ($timestamp | fromdateiso8601 | todateiso8601) catch $empty) == $timestamp);
+		if $cutoff != $empty and (($cutoff | is_valid_timestamp) | not) then
+			error("approval cutoff has no authoritative issued_at")
+		elif $cutoff != $empty and any(.[][]?; is_linked_reference and (((.created_at // $empty) | is_valid_timestamp) | not)) then
 			error("linked reference has no authoritative created_at")
 		else
 		[.[][]?

--- a/.agents/scripts/tests/test-approval-helper-content-binding.sh
+++ b/.agents/scripts/tests/test-approval-helper-content-binding.sh
@@ -373,6 +373,24 @@ extra trusted commentary" '.[0] += [{id:4305,node_id:"IC_4305",user:{id:1,node_i
 	return 0
 }
 
+test_post_approval_linked_references() {
+	reset_and_sign issue 41
+	jq '.[0] += [(.[0][0] | .id = 420 | .node_id = "EV_420" | .created_at = "2026-01-01T00:06:00Z" | .source.issue.number = 10)]' \
+		"${FIXTURES}/timeline-41.json" >"${FIXTURES}/timeline.tmp" && mv "${FIXTURES}/timeline.tmp" "${FIXTURES}/timeline-41.json"
+	assert_verify "post-approval issue reference does not extend signed scope" issue 41 VERIFIED 0
+
+	reset_and_sign pr 42
+	jq '.[0] += [(.[0][0] | .id = 421 | .node_id = "EV_421" | .created_at = "2026-01-01T00:06:00Z" | .source.issue.number = 11)]' \
+		"${FIXTURES}/timeline-42.json" >"${FIXTURES}/timeline.tmp" && mv "${FIXTURES}/timeline.tmp" "${FIXTURES}/timeline-42.json"
+	assert_verify "post-approval PR reference does not extend signed scope" pr 42 VERIFIED 0 "$PR_HEAD"
+
+	reset_and_sign issue 41
+	jq '.[0] += [(.[0][0] | .id = 422 | .node_id = "EV_422" | .created_at = null | .source.issue.number = 12)]' \
+		"${FIXTURES}/timeline-41.json" >"${FIXTURES}/timeline.tmp" && mv "${FIXTURES}/timeline.tmp" "${FIXTURES}/timeline-41.json"
+	assert_verify "missing linked-reference timestamp fails closed" issue 41 API_ERROR 6
+	return 0
+}
+
 main() {
 	install_gh_stub
 	write_baseline_fixtures
@@ -404,6 +422,7 @@ main() {
 	append_signed_comment pr 42 "2026-01-01T00:06:00Z" 4300
 	assert_verify "repeat approval verifies against the newest exact snapshot" pr 42 VERIFIED 0 "$PR_HEAD"
 	test_trusted_lifecycle_comments
+	test_post_approval_linked_references
 
 	reset_and_sign pr 42
 	local marker_drift="<!-- aidevops-signed-approval --> unsigned external drift"

--- a/.agents/scripts/tests/test-approval-helper-content-binding.sh
+++ b/.agents/scripts/tests/test-approval-helper-content-binding.sh
@@ -388,6 +388,17 @@ test_post_approval_linked_references() {
 	jq '.[0] += [(.[0][0] | .id = 422 | .node_id = "EV_422" | .created_at = null | .source.issue.number = 12)]' \
 		"${FIXTURES}/timeline-41.json" >"${FIXTURES}/timeline.tmp" && mv "${FIXTURES}/timeline.tmp" "${FIXTURES}/timeline-41.json"
 	assert_verify "missing linked-reference timestamp fails closed" issue 41 API_ERROR 6
+
+	reset_and_sign issue 41
+	jq '.[0] += [(.[0][0] | .id = 423 | .node_id = "EV_423" | .created_at = "2026-02-30T00:06:00Z" | .source.issue.number = 13)]' \
+		"${FIXTURES}/timeline-41.json" >"${FIXTURES}/timeline.tmp" && mv "${FIXTURES}/timeline.tmp" "${FIXTURES}/timeline-41.json"
+	assert_verify "calendar-invalid linked-reference timestamp fails closed" issue 41 API_ERROR 6
+
+	if PATH="${TEST_ROOT}/bin:$PATH" FIXTURES="$FIXTURES" approval_snapshot_v2_build issue 41 owner/repo "" "2026-02-30T00:06:00Z" >/dev/null 2>&1; then
+		print_result "calendar-invalid approval cutoff fails closed" 1
+	else
+		print_result "calendar-invalid approval cutoff fails closed" 0
+	fi
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- Bind approval snapshot reconstruction to the signed `issued_at` timestamp.
- Ignore linked-reference lifecycle events created after approval authority was signed.
- Fail closed when cutoff-scoped linked references lack valid authoritative timestamps.
- Preserve backward compatibility for direct snapshot callers without a cutoff.

## Runtime Testing

- **Risk:** critical (cryptographic approval verification path)
- **Evidence:** runtime-verified against production issue #28943; the modified helper changed the observed result from `STALE_APPROVAL` to `VERIFIED`.
- `bash .agents/scripts/tests/test-approval-helper-content-binding.sh` — 35 passed, 0 failed, including calendar-invalid cutoff and linked-reference timestamps.
- `bash .agents/scripts/tests/test-approval-helper-verify-state.sh` — 2 passed, 0 failed.
- `.agents/scripts/linters-local.sh` — all local checks passed, including ShellCheck, secret scanning, Bash 3.2 compatibility, portability, and complexity ratchets.

## Security decision

References visible before approval remain content-bound. A later reference cannot extend signed authority and therefore cannot revoke approval solely because GitHub exposes its timeline event asynchronously. Missing or malformed relevant timestamps fail closed as `API_ERROR`.

Resolves #28968
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 3h 59m and 2,160,569 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Approval verification now uses the approval’s original issuance time when validating linked references.
  * References added after approval are excluded from verification snapshots.
  * Invalid or missing timestamps now cause verification to fail safely.

* **Tests**
  * Added regression coverage for post-approval references and invalid timestamp scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->