### PR TITLE
GH#28866: fix: keep check-workflows help side-effect-free

### DIFF
--- a/.agents/scripts/check-workflows-helper.sh
+++ b/.agents/scripts/check-workflows-helper.sh
@@ -1021,6 +1021,19 @@ _process_rows() {
 }
 
 main() {
+	# Handle help before validating dependencies or touching repos.json. Argument
+	# parsing normally runs in a process substitution below, where `exit 0` only
+	# exits the subshell and would otherwise allow inventory processing to begin.
+	local _arg
+	for _arg in "$@"; do
+		case "$_arg" in
+		-h | --help)
+			_usage
+			return 0
+			;;
+		esac
+	done
+
 	# Fail fast on missing repos.json — _die inside command substitution only
 	# exits the subshell, not the parent.
 	if [[ ! -f "$REPOS_JSON" ]]; then

--- a/.agents/scripts/tests/test-aidevops-check-workflows-command.sh
+++ b/.agents/scripts/tests/test-aidevops-check-workflows-command.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Root CLI delegation regression tests for GH#28866.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+AIDEVOPS_SH="${REPO_ROOT}/aidevops.sh"
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+mkdir -p "${TEST_ROOT}/home/.config/aidevops" "${TEST_ROOT}/bin"
+
+# A help request must not invoke jq or parse this deliberately invalid registry.
+printf 'registry sentinel: must not be read\n' >"${TEST_ROOT}/home/.config/aidevops/repos.json"
+cat >"${TEST_ROOT}/bin/jq" <<'STUB'
+#!/usr/bin/env bash
+printf 'registry sentinel was read\n' >>"$SENTINEL_LOG"
+exit 97
+STUB
+chmod +x "${TEST_ROOT}/bin/jq"
+
+run_help() {
+	local flag="$1"
+	local output rc=0
+	output=$(HOME="${TEST_ROOT}/home" \
+		PATH="${TEST_ROOT}/bin:${PATH}" \
+		SENTINEL_LOG="${TEST_ROOT}/sentinel.log" \
+		AIDEVOPS_REPO_PATH="$REPO_ROOT" \
+		bash "$AIDEVOPS_SH" check-workflows "$flag" 2>&1) || rc=$?
+
+	if [[ "$rc" -ne 0 ]]; then
+		printf 'FAIL check-workflows %s exited %d\n%s\n' "$flag" "$rc" "$output" >&2
+		return 1
+	fi
+	if [[ "$output" != *"check-workflows-helper.sh [--repo OWNER/REPO]"* ]] ||
+		[[ "$output" == *"Summary:"* ]] || [[ "$output" == *"local evidence"* ]]; then
+		printf 'FAIL check-workflows %s did not print bounded usage only\n%s\n' "$flag" "$output" >&2
+		return 1
+	fi
+	if [[ -e "${TEST_ROOT}/sentinel.log" ]]; then
+		printf 'FAIL check-workflows %s read the repository registry\n' "$flag" >&2
+		return 1
+	fi
+	printf 'PASS check-workflows %s prints usage without registry access\n' "$flag"
+	return 0
+}
+
+run_help --help
+run_help -h
+
+exit 0

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1680,6 +1680,23 @@ _cmd_client_format() {
 # Main entry point
 main() {
 	local command="${1:-help}"
+	local check_workflows_helper="check-workflows-helper.sh"
+	shift || true
+
+	# Help for inventory commands must bypass repository auto-detection and
+	# version checks. Those startup checks may read the repository registry,
+	# while help must remain bounded and side-effect-free.
+	if [[ "$command" == "check-workflows" || "$command" == "workflows" ]]; then
+		local arg
+		for arg in "$@"; do
+			case "$arg" in
+			-h | --help)
+				_dispatch_helper "$check_workflows_helper" "$check_workflows_helper" "$@"
+				return $?
+				;;
+			esac
+		done
+	fi
 
 	# Auto-detect unregistered repo on any command (silent check)
 	_main_check_unregistered "$command"
@@ -1689,7 +1706,6 @@ main() {
 		_main_check_version
 	fi
 
-	shift || true
 	case "$command" in
 	init | i) cmd_init "$@" ;;
 	setup) cmd_setup "$@" ;;
@@ -1711,7 +1727,7 @@ main() {
 	pulse) _dispatch_helper "pulse-session-helper.sh" "pulse-session-helper.sh" "$@" ;;
 	schedule) _dispatch_helper "deferred-job-helper.sh" "deferred-job-helper.sh" "$@" ;;
 	launch-worker | launch_worker) cmd_launch_worker "$@" ;;
-	check-workflows | workflows) _dispatch_helper "check-workflows-helper.sh" "check-workflows-helper.sh" "$@" ;;
+	check-workflows | workflows) _dispatch_helper "$check_workflows_helper" "$check_workflows_helper" "$@" ;;
 	sync-workflows) _dispatch_helper "sync-workflows-helper.sh" "sync-workflows-helper.sh" "$@" ;;
 	metrics) _dispatch_helper "repo-metrics-helper.sh" "repo-metrics-helper.sh" "$@" ;;
 	badges)


### PR DESCRIPTION
## Summary

Forward check-workflows help before startup registry checks, make helper help exit before dependency validation, and add a sentinel regression test for both help aliases.

## Files Changed

.agents/scripts/check-workflows-helper.sh, .agents/scripts/tests/test-aidevops-check-workflows-command.sh, aidevops.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — .agents/scripts/tests/test-aidevops-check-workflows-command.sh; .agents/scripts/tests/test-aidevops-sh-portability.sh; shellcheck modified files; .agents/scripts/linters-local.sh

Resolves #28866


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 7m and 80,662 tokens on this as a headless worker.