### PR TITLE
GH#28971: Keep dependency normalization off initial dispatch

### DIFF
--- a/.agents/scripts/pulse-campaign-shadow.sh
+++ b/.agents/scripts/pulse-campaign-shadow.sh
@@ -124,10 +124,11 @@ pulse_campaign_shadow_candidates_json() {
 	local repo_slug="$1"
 	local repo_path="$2"
 	local source_limit="${3:-1000}"
+	local dependency_normalization_mode="${4:-normalize}"
 	local candidates_json="[]"
 
 	if ! _pulse_campaign_shadow_enabled; then
-		candidates_json=$(list_dispatchable_issue_candidates_json "$repo_slug" "$source_limit") || candidates_json='[]'
+		candidates_json=$(list_dispatchable_issue_candidates_json "$repo_slug" "$source_limit" "" "" "$dependency_normalization_mode") || candidates_json='[]'
 		_dispatch_filter_repo_pr_backlog_candidates "$repo_slug" "$candidates_json"
 		return 0
 	fi
@@ -140,12 +141,12 @@ pulse_campaign_shadow_candidates_json() {
 	if [[ -z "$raw_snapshot_file" || -z "$ready_file" || -z "$plan_file" || -z "$snapshot_status_file" ]]; then
 		rm -f "$raw_snapshot_file" "$ready_file" "$plan_file" "$snapshot_status_file"
 		_pulse_campaign_log "temporary workspace unavailable repo=${repo_slug}; legacy candidates retained"
-		candidates_json=$(list_dispatchable_issue_candidates_json "$repo_slug" "$source_limit") || candidates_json='[]'
+		candidates_json=$(list_dispatchable_issue_candidates_json "$repo_slug" "$source_limit" "" "" "$dependency_normalization_mode") || candidates_json='[]'
 		_dispatch_filter_repo_pr_backlog_candidates "$repo_slug" "$candidates_json"
 		return 0
 	fi
 
-	candidates_json=$(list_dispatchable_issue_candidates_json "$repo_slug" "$source_limit" "$raw_snapshot_file" "$snapshot_status_file") || candidates_json='[]'
+	candidates_json=$(list_dispatchable_issue_candidates_json "$repo_slug" "$source_limit" "$raw_snapshot_file" "$snapshot_status_file" "$dependency_normalization_mode") || candidates_json='[]'
 	candidates_json=$(_dispatch_filter_repo_pr_backlog_candidates "$repo_slug" "$candidates_json")
 	(
 		umask 077

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -148,9 +148,10 @@ else
 		local repo_slug="$1"
 		local repo_path="$2"
 		local source_limit="${3:-1000}"
+		local dependency_normalization_mode="${4:-normalize}"
 		local candidates_json="[]"
 		: "$repo_path"
-		candidates_json=$(list_dispatchable_issue_candidates_json "$repo_slug" "$source_limit") || candidates_json='[]'
+		candidates_json=$(list_dispatchable_issue_candidates_json "$repo_slug" "$source_limit" "" "" "$dependency_normalization_mode") || candidates_json='[]'
 		_dispatch_filter_repo_pr_backlog_candidates "$repo_slug" "$candidates_json"
 		return 0
 	}
@@ -366,10 +367,12 @@ _append_ranked_repo_candidates() {
 # Build ranked deterministic dispatch candidates across all pulse repos.
 # Arguments:
 #   $1 - max issues to fetch per repo (optional)
+#   $2 - dependency normalization mode (optional: normalize or skip)
 # Returns: JSON array sorted by score desc, createdAt asc, updatedAt asc
 #######################################
 build_ranked_dispatch_candidates_json() {
 	local per_repo_limit="${1:-$PULSE_RUNNABLE_ISSUE_LIMIT}"
+	local dependency_normalization_mode="${2:-normalize}"
 	[[ "$per_repo_limit" =~ ^[0-9]+$ ]] || per_repo_limit="$PULSE_RUNNABLE_ISSUE_LIMIT"
 	local age_bonus_per_day="${PULSE_DISPATCH_AGE_BONUS_PER_DAY:-25}"
 	local age_bonus_cap="${PULSE_DISPATCH_AGE_BONUS_CAP:-900}"
@@ -400,7 +403,7 @@ build_ranked_dispatch_candidates_json() {
 		# Record that we are polling this repo now (atomic write, non-fatal)
 		update_repo_pulse_timestamp "$repo_slug"
 		local repo_candidates_json
-		repo_candidates_json=$(pulse_campaign_shadow_candidates_json "$repo_slug" "$repo_path" "$per_repo_limit") || repo_candidates_json='[]'
+		repo_candidates_json=$(pulse_campaign_shadow_candidates_json "$repo_slug" "$repo_path" "$per_repo_limit" "$dependency_normalization_mode") || repo_candidates_json='[]'
 		if [[ -z "$repo_candidates_json" || "$repo_candidates_json" == "[]" ]]; then
 			continue
 		fi
@@ -492,9 +495,13 @@ _dispatch_order_idle_borrowing_candidates() {
 # round) to preserve the existing "test the waters" recovery semantics;
 # otherwise parallel is preferred so the 24-slot pool fills in 1 cycle.
 #
+# Arguments:
+#   $1 - dependency normalization mode (optional: normalize or skip)
+#
 # Returns: dispatched worker count via stdout
 #######################################
 dispatch_max() {
+	local dependency_normalization_mode="${1:-normalize}"
 	local capacity_line
 	capacity_line=$(_dispatch_compute_capacity) || {
 		echo 0
@@ -524,7 +531,7 @@ dispatch_max() {
 	fi
 
 	local candidates_json candidate_count
-	candidates_json=$(_dispatch_ranked_candidates_json "$PULSE_RUNNABLE_ISSUE_LIMIT") || candidates_json='[]'
+	candidates_json=$(_dispatch_ranked_candidates_json "$PULSE_RUNNABLE_ISSUE_LIMIT" "$dependency_normalization_mode") || candidates_json='[]'
 	candidate_count=$(printf '%s' "$candidates_json" | jq 'length' 2>/dev/null) || candidate_count=0
 	[[ "$candidate_count" =~ ^[0-9]+$ ]] || candidate_count=0
 	if [[ "$candidate_count" -eq 0 ]]; then
@@ -991,8 +998,12 @@ _pulse_start_post_dispatch_housekeeping() {
 # Phase 2 re-enumerates and dispatches it in the same cycle. Without
 # Phase 2, the child waits a minimum of one additional pulse cycle
 # (3–7 min stable; 10–20 min when wrapper cycles are unstable).
+#
+# Arguments:
+#   $1 - dependency normalization mode (optional: normalize or skip)
 #######################################
 apply_dispatch_max() {
+	local dependency_normalization_mode="${1:-normalize}"
 	if [[ -f "$STOP_FLAG" ]]; then
 		echo "[pulse-wrapper] Dispatch_max skipped: stop flag present" >>"$LOGFILE"
 		return 0
@@ -1007,11 +1018,11 @@ apply_dispatch_max() {
 	[[ "$apply_max_workers" =~ ^[0-9]+$ ]] || apply_max_workers=1
 
 	local fill_dispatched
-	fill_dispatched=$(dispatch_max) || fill_dispatched=0
+	fill_dispatched=$(dispatch_max "$dependency_normalization_mode") || fill_dispatched=0
 	[[ "$fill_dispatched" =~ ^[0-9]+$ ]] || fill_dispatched=0
 
 	_adaptive_launch_settle_wait "$fill_dispatched" "dispatch_max"
-	_dispatch_min_worker_floor_refill "$apply_max_workers" "$((apply_active_workers + fill_dispatched))"
+	_dispatch_min_worker_floor_refill "$apply_max_workers" "$((apply_active_workers + fill_dispatched))" "$dependency_normalization_mode"
 
 	# t2749: Phase 2 — re-enumerate when consolidation created a child during
 	# Phase 1. The sentinel is written by _dispatch_issue_consolidation in
@@ -1031,10 +1042,10 @@ apply_dispatch_max() {
 			echo "[pulse-wrapper] Dispatch_max Phase 2: consolidation child created during Phase 1 (active=${_p2_active}, max=${_p2_max}) — re-enumerating candidates (t2749)" >>"$LOGFILE"
 			_dispatch_invalidate_candidate_snapshot "consolidation_child_created" || true
 			local fill_dispatched_p2
-			fill_dispatched_p2=$(dispatch_max) || fill_dispatched_p2=0
+			fill_dispatched_p2=$(dispatch_max "$dependency_normalization_mode") || fill_dispatched_p2=0
 			[[ "$fill_dispatched_p2" =~ ^[0-9]+$ ]] || fill_dispatched_p2=0
 			_adaptive_launch_settle_wait "$fill_dispatched_p2" "dispatch_max phase 2"
-			_dispatch_min_worker_floor_refill "$_p2_max" "$((_p2_active + fill_dispatched_p2))"
+			_dispatch_min_worker_floor_refill "$_p2_max" "$((_p2_active + fill_dispatched_p2))" "$dependency_normalization_mode"
 		else
 			echo "[pulse-wrapper] Dispatch_max Phase 2: consolidation child created but slots full (active=${_p2_active}, max=${_p2_max}) — skipping (t2749)" >>"$LOGFILE"
 		fi
@@ -1058,8 +1069,10 @@ apply_dispatch_max() {
 # Args:
 #   $1 - optional capped max-worker target
 #   $2 - optional capped active-worker count
+#   $3 - dependency normalization mode (optional: normalize or skip)
 #######################################
 _dispatch_min_worker_floor_refill() {
+	local dependency_normalization_mode="${3:-normalize}"
 	local min_worker_floor="${AIDEVOPS_MIN_WORKER_CONCURRENCY:-}"
 	if [[ -z "$min_worker_floor" ]] && declare -F config_get >/dev/null 2>&1; then
 		min_worker_floor=$(config_get "orchestration.min_worker_concurrency" "6")
@@ -1121,7 +1134,7 @@ _dispatch_min_worker_floor_refill() {
 
 		refill_attempt=$((refill_attempt + 1))
 		echo "[pulse-wrapper] Minimum worker floor refill: active=${active_workers}/${min_worker_floor}, attempt=${refill_attempt}/${max_refill_attempts} — re-enumerating candidates" >>"$LOGFILE"
-		fill_dispatched=$(dispatch_max) || fill_dispatched=0
+		fill_dispatched=$(dispatch_max "$dependency_normalization_mode") || fill_dispatched=0
 		[[ "$fill_dispatched" =~ ^[0-9]+$ ]] || fill_dispatched=0
 		if ((fill_dispatched <= 0)); then
 			echo "[pulse-wrapper] Minimum worker floor refill stopped: dispatch_max returned ${fill_dispatched} (no eligible candidates or hard gate exhausted)" >>"$LOGFILE"

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -65,6 +65,7 @@ _DISPATCH_BENIGN_BLOCKS_FILE_OWNED="0"
 _DISPATCH_BENIGN_BLOCKS_SCRATCH_DIR=""
 _DISPATCH_BENIGN_BLOCKS_LEGACY_MIN_AGE_SECONDS="${AIDEVOPS_PULSE_BENIGN_BLOCKS_LEGACY_MIN_AGE_SECONDS:-3600}"
 [[ "$_DISPATCH_BENIGN_BLOCKS_LEGACY_MIN_AGE_SECONDS" =~ ^[0-9]+$ ]] || _DISPATCH_BENIGN_BLOCKS_LEGACY_MIN_AGE_SECONDS=3600
+_DISPATCH_DEPENDENCY_NORMALIZATION_SKIP="skip"
 # Out-parameter set by _dispatch_process_candidate when a successful launch clears
 # the throttle file. The orchestrator loop reads this and restores
 # _effective_slots to the unthrottled available_slots value.
@@ -89,17 +90,22 @@ _dispatch_cycle_cache_path() {
 
 _dispatch_candidate_snapshot_path() {
 	local per_repo_limit="${1:-${PULSE_RUNNABLE_ISSUE_LIMIT:-1000}}"
+	local dependency_normalization_mode="${2:-normalize}"
+	local mode_suffix=""
 	[[ "$per_repo_limit" =~ ^[0-9]+$ ]] || per_repo_limit=1000
-	_dispatch_cycle_cache_path "pulse-dispatch-candidates" ".${per_repo_limit}.json"
+	[[ "$dependency_normalization_mode" == "$_DISPATCH_DEPENDENCY_NORMALIZATION_SKIP" ]] || dependency_normalization_mode="normalize"
+	[[ "$dependency_normalization_mode" == "$_DISPATCH_DEPENDENCY_NORMALIZATION_SKIP" ]] && mode_suffix=".skip"
+	_dispatch_cycle_cache_path "pulse-dispatch-candidates" ".${per_repo_limit}${mode_suffix}.json"
 	return $?
 }
 
 _dispatch_cleanup_cycle_cache() {
 	local per_repo_limit="${1:-${PULSE_RUNNABLE_ISSUE_LIMIT:-1000}}"
-	local candidate_file="" triage_file="" cache_file=""
+	local candidate_file="" skip_candidate_file="" triage_file="" cache_file=""
 	candidate_file=$(_dispatch_candidate_snapshot_path "$per_repo_limit" 2>/dev/null || true)
+	skip_candidate_file=$(_dispatch_candidate_snapshot_path "$per_repo_limit" "$_DISPATCH_DEPENDENCY_NORMALIZATION_SKIP" 2>/dev/null || true)
 	triage_file=$(_dispatch_cycle_cache_path "pulse-triage-prepass" ".done" 2>/dev/null || true)
-	for cache_file in "$candidate_file" "$triage_file"; do
+	for cache_file in "$candidate_file" "$skip_candidate_file" "$triage_file"; do
 		[[ -n "$cache_file" && ( -f "$cache_file" || -L "$cache_file" ) ]] || continue
 		rm -f "$cache_file" 2>/dev/null || true
 	done
@@ -109,10 +115,15 @@ _dispatch_cleanup_cycle_cache() {
 _dispatch_invalidate_candidate_snapshot() {
 	local reason="${1:-state_mutation}"
 	local per_repo_limit="${2:-${PULSE_RUNNABLE_ISSUE_LIMIT:-1000}}"
-	local snapshot_file=""
-	snapshot_file=$(_dispatch_candidate_snapshot_path "$per_repo_limit") || return 0
-	if [[ -f "$snapshot_file" && ! -L "$snapshot_file" ]]; then
-		rm -f "$snapshot_file" 2>/dev/null || return 1
+	local snapshot_file="" dependency_normalization_mode="" removed_snapshot=0
+	for dependency_normalization_mode in normalize "$_DISPATCH_DEPENDENCY_NORMALIZATION_SKIP"; do
+		snapshot_file=$(_dispatch_candidate_snapshot_path "$per_repo_limit" "$dependency_normalization_mode") || continue
+		if [[ -f "$snapshot_file" && ! -L "$snapshot_file" ]]; then
+			rm -f "$snapshot_file" 2>/dev/null || return 1
+			removed_snapshot=1
+		fi
+	done
+	if [[ "$removed_snapshot" -eq 1 ]]; then
 		echo "[pulse-wrapper] Dispatch candidate snapshot invalidated: reason=${reason}" >>"$LOGFILE"
 	fi
 	return 0
@@ -120,14 +131,16 @@ _dispatch_invalidate_candidate_snapshot() {
 
 _dispatch_ranked_candidates_json() {
 	local per_repo_limit="${1:-${PULSE_RUNNABLE_ISSUE_LIMIT:-1000}}"
+	local dependency_normalization_mode="${2:-normalize}"
 	local snapshot_file="" snapshot_tmp="" candidates_json="[]"
 	[[ "$per_repo_limit" =~ ^[0-9]+$ ]] || per_repo_limit=1000
+	[[ "$dependency_normalization_mode" == "$_DISPATCH_DEPENDENCY_NORMALIZATION_SKIP" ]] || dependency_normalization_mode="normalize"
 	if [[ "${PULSE_DISPATCH_CANDIDATE_SNAPSHOT_ENABLED:-1}" == "0" ]]; then
-		build_ranked_dispatch_candidates_json "$per_repo_limit"
+		build_ranked_dispatch_candidates_json "$per_repo_limit" "$dependency_normalization_mode"
 		return $?
 	fi
-	snapshot_file=$(_dispatch_candidate_snapshot_path "$per_repo_limit") || {
-		build_ranked_dispatch_candidates_json "$per_repo_limit"
+	snapshot_file=$(_dispatch_candidate_snapshot_path "$per_repo_limit" "$dependency_normalization_mode") || {
+		build_ranked_dispatch_candidates_json "$per_repo_limit" "$dependency_normalization_mode"
 		return $?
 	}
 	if [[ -f "$snapshot_file" && ! -L "$snapshot_file" ]] && jq -e 'type == "array"' "$snapshot_file" >/dev/null 2>&1; then
@@ -137,11 +150,11 @@ _dispatch_ranked_candidates_json() {
 	fi
 	if [[ -L "$snapshot_file" ]]; then
 		rm -f "$snapshot_file" 2>/dev/null || {
-			build_ranked_dispatch_candidates_json "$per_repo_limit"
+			build_ranked_dispatch_candidates_json "$per_repo_limit" "$dependency_normalization_mode"
 			return $?
 		}
 	fi
-	candidates_json=$(build_ranked_dispatch_candidates_json "$per_repo_limit") || candidates_json='[]'
+	candidates_json=$(build_ranked_dispatch_candidates_json "$per_repo_limit" "$dependency_normalization_mode") || candidates_json='[]'
 	if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$candidates_json"; then
 		candidates_json='[]'
 	fi

--- a/.agents/scripts/pulse-dispatch-preflight-lib.sh
+++ b/.agents/scripts/pulse-dispatch-preflight-lib.sh
@@ -232,7 +232,11 @@ _preflight_early_dispatch() {
 		# worker launch. Keep that trust-boundary check in the dispatch path rather
 		# than depending on the asynchronous issue-triage GitHub Actions workflow.
 		echo "[pulse-wrapper] Early dispatch_max: dispatching workers before housekeeping" >>"$LOGFILE"
-		apply_dispatch_max
+		# GH#28971: the first fill is a latency-sensitive fast path. Keep blocked
+		# children filtered from its fetched snapshot, but defer dependency graph
+		# normalization/refetch to the post-label refill below. Pass the mode as an
+		# internal argument so it cannot leak into launched worker environments.
+		apply_dispatch_max "skip"
 	fi
 
 	# Routine comment responses: scan routine-tracking issues for unanswered

--- a/.agents/scripts/pulse-repo-meta.sh
+++ b/.agents/scripts/pulse-repo-meta.sh
@@ -236,6 +236,7 @@ repo_allows_pulse_write_actions() {
 #   $2 - max issues to fetch (optional, default 100)
 #   $3 - optional private file for the exact raw open-issue snapshot
 #   $4 - optional private file receiving 1 when the snapshot fetch succeeded
+#   $5 - dependency normalization mode (optional: normalize or skip; default normalize)
 # Returns: JSON array of issue objects (number, title, url, createdAt, updatedAt, labels, assignees)
 #######################################
 _pulse_issue_snapshot_is_valid() {
@@ -262,6 +263,7 @@ list_dispatchable_issue_candidates_json() {
 	local limit="${2:-100}"
 	local raw_snapshot_file="${3:-}"
 	local snapshot_status_file="${4:-}"
+	local dependency_normalization_mode="${5:-normalize}"
 	local snapshot_succeeded=1
 
 	if [[ -z "$repo_slug" ]]; then
@@ -296,7 +298,8 @@ list_dispatchable_issue_candidates_json() {
 	# reach the dispatch-time readiness guard. Normalize once per bounded TTL
 	# whenever the fetched snapshot contains blocked work; this also covers a
 	# roadmap alongside unrelated runnable candidates.
-	if printf '%s' "$issue_json" | jq -e 'any(.[]; any(.labels[]?; .name == "status:blocked"))' >/dev/null 2>&1 &&
+	if [[ "$dependency_normalization_mode" != "skip" ]] &&
+		printf '%s' "$issue_json" | jq -e 'any(.[]; any(.labels[]?; .name == "status:blocked"))' >/dev/null 2>&1 &&
 		declare -F normalize_repo_dependency_readiness_if_due >/dev/null 2>&1; then
 		normalize_repo_dependency_readiness_if_due "$repo_slug" >/dev/null 2>&1 || true
 		local refreshed_issue_json=""

--- a/.agents/scripts/tests/test-dependency-readiness-normalization.sh
+++ b/.agents/scripts/tests/test-dependency-readiness-normalization.sh
@@ -387,7 +387,16 @@ normalize_repo_dependency_readiness_if_due() {
 	return 0
 }
 export -f gh_issue_list normalize_repo_dependency_readiness_if_due
+fast_candidates=$(list_dispatchable_issue_candidates_json "owner/repo" 100 "" "" "skip")
+assert_eq "fast candidate mode fetches once" "1" "$(<"$candidate_fetch_file")"
+assert_eq "fast candidate mode skips dependency normalization" "0" "$(<"$normalization_file")"
+assert_eq "fast candidate mode keeps blocked child out" "0" \
+	"$(printf '%s' "$fast_candidates" | jq 'map(select(.number == 20)) | length')"
+
+printf '0\n' >"$candidate_fetch_file"
+printf '0\n' >"$normalization_file"
 recovered_candidates=$(list_dispatchable_issue_candidates_json "owner/repo" 100)
+assert_eq "default candidate mode fetches again after normalization" "2" "$(<"$candidate_fetch_file")"
 assert_eq "all-blocked roadmap triggers dependency normalization" "1" "$(<"$normalization_file")"
 assert_eq "next dependency-ready child reaches shared candidate stream" "20" \
 	"$(printf '%s' "$recovered_candidates" | jq -r 'map(select(.number == 20))[0].number')"

--- a/.agents/scripts/tests/test-pulse-campaign-shadow.sh
+++ b/.agents/scripts/tests/test-pulse-campaign-shadow.sh
@@ -33,7 +33,8 @@ list_dispatchable_issue_candidates_json() {
 	local source_limit="$2"
 	local raw_snapshot_file="${3:-}"
 	local snapshot_status_file="${4:-}"
-	printf '%s|%s\n' "$repo_slug" "$source_limit" >>"$FETCH_LOG"
+	local dependency_normalization_mode="${5:-normalize}"
+	printf '%s|%s|%s\n' "$repo_slug" "$source_limit" "$dependency_normalization_mode" >>"$FETCH_LOG"
 	if [[ -n "$raw_snapshot_file" ]]; then
 		printf '%s\n' "$LEGACY_JSON" >"$raw_snapshot_file"
 	fi
@@ -84,9 +85,10 @@ assert_equal() {
 }
 
 export AIDEVOPS_PULSE_CAMPAIGN_SHADOW_ENABLED=0
-disabled_output=$(pulse_campaign_shadow_candidates_json "example/repository" "$TEST_ROOT" 100)
+disabled_output=$(pulse_campaign_shadow_candidates_json "example/repository" "$TEST_ROOT" 100 "skip")
 assert_equal "$FILTERED_JSON" "$disabled_output" "disabled shadow preserves legacy output"
 assert_equal "1" "$(wc -l <"$FETCH_LOG" | tr -d ' ')" "disabled shadow performs one issue fetch"
+assert_equal "example/repository|100|skip" "$(<"$FETCH_LOG")" "disabled shadow forwards normalization mode"
 if [[ -e "$CAPTURE_RAW" || -e "$CAPTURE_READY" || -e "$CAPTURE_SUCCEEDED" ]]; then
 	printf 'FAIL: disabled shadow invoked the campaign planner\n' >&2
 	exit 1
@@ -97,6 +99,7 @@ export AIDEVOPS_PULSE_CAMPAIGN_SHADOW_ENABLED=1
 enabled_output=$(pulse_campaign_shadow_candidates_json "example/repository" "$TEST_ROOT" 100)
 assert_equal "$FILTERED_JSON" "$enabled_output" "enabled shadow preserves legacy output"
 assert_equal "1" "$(wc -l <"$FETCH_LOG" | tr -d ' ')" "enabled shadow reuses one issue fetch"
+assert_equal "example/repository|100|normalize" "$(<"$FETCH_LOG")" "enabled shadow defaults normalization mode"
 assert_equal "$LEGACY_JSON" "$(<"$CAPTURE_RAW")" "planner receives the exact raw snapshot"
 assert_equal "$FILTERED_JSON" "$(<"$CAPTURE_READY")" "planner receives the exact filtered-ready set"
 assert_equal "1" "$(<"$CAPTURE_SUCCEEDED")" "planner receives successful snapshot provenance"

--- a/.agents/scripts/tests/test-pulse-dispatch-candidate-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-candidate-snapshot.sh
@@ -23,33 +23,49 @@ mkdir -p "$AIDEVOPS_TEMP_DIR" "${HOME}/.aidevops/logs"
 source "${SCRIPT_DIR}/pulse-dispatch-engine.sh"
 
 BUILD_COUNT_FILE="${TEST_ROOT}/build-count"
+BUILD_MODE_FILE="${TEST_ROOT}/build-mode"
 : >"$BUILD_COUNT_FILE"
+: >"$BUILD_MODE_FILE"
 _PULSE_CYCLE_ID="test-cycle-candidate-snapshot"
 
 build_ranked_dispatch_candidates_json() {
 	local per_repo_limit="$1"
+	local dependency_normalization_mode="${2:-normalize}"
 	local call_count=0
 	: "$per_repo_limit"
 	call_count=$(wc -l <"$BUILD_COUNT_FILE" 2>/dev/null || printf '0')
 	printf 'call\n' >>"$BUILD_COUNT_FILE"
+	printf '%s\n' "$dependency_normalization_mode" >>"$BUILD_MODE_FILE"
 	printf '[{"number":%s}]\n' "$((call_count + 1))"
 	return 0
 }
 
-first=$(_dispatch_ranked_candidates_json 50)
-second=$(_dispatch_ranked_candidates_json 50)
+first=$(_dispatch_ranked_candidates_json 50 "skip")
+second=$(_dispatch_ranked_candidates_json 50 "skip")
 [[ "$first" == '[{"number":1}]' && "$second" == "$first" ]] || {
 	printf 'FAIL candidate snapshot was not reused: first=%s second=%s\n' "$first" "$second" >&2
 	exit 1
 }
-[[ "$(wc -l <"$BUILD_COUNT_FILE" | tr -d ' ')" == "1" ]] || {
-	printf 'FAIL candidate builder ran more than once before invalidation\n' >&2
+normalized_before_invalidation=$(_dispatch_ranked_candidates_json 50)
+skip_after_normalize=$(_dispatch_ranked_candidates_json 50 "skip")
+[[ "$normalized_before_invalidation" == '[{"number":2}]' && "$skip_after_normalize" == "$first" ]] || {
+	printf 'FAIL candidate snapshots collided across normalization modes\n' >&2
+	exit 1
+}
+[[ "$(wc -l <"$BUILD_COUNT_FILE" | tr -d ' ')" == "2" ]] || {
+	printf 'FAIL candidate builder did not build once per normalization mode\n' >&2
+	exit 1
+}
+normalize_snapshot_file=$(_dispatch_candidate_snapshot_path 50)
+skip_snapshot_file=$(_dispatch_candidate_snapshot_path 50 "skip")
+[[ "$normalize_snapshot_file" != "$skip_snapshot_file" && -f "$normalize_snapshot_file" && -f "$skip_snapshot_file" ]] || {
+	printf 'FAIL candidate snapshot paths are not mode-specific\n' >&2
 	exit 1
 }
 
 _dispatch_invalidate_candidate_snapshot "test_state_mutation" 50
 third=$(_dispatch_ranked_candidates_json 50)
-[[ "$third" == '[{"number":2}]' ]] || {
+[[ "$third" == '[{"number":3}]' ]] || {
 	printf 'FAIL candidate snapshot did not rebuild after invalidation: %s\n' "$third" >&2
 	exit 1
 }
@@ -58,18 +74,21 @@ PULSE_RUNNABLE_ISSUE_LIMIT=50
 triage_marker=$(_dispatch_cycle_cache_path "pulse-triage-prepass" ".done")
 printf 'done\n' >"$triage_marker"
 _dispatch_cleanup_cycle_cache
-snapshot_file=$(_dispatch_candidate_snapshot_path 50)
-[[ ! -e "$snapshot_file" && ! -e "$triage_marker" ]] || {
+[[ ! -e "$normalize_snapshot_file" && ! -e "$skip_snapshot_file" && ! -e "$triage_marker" ]] || {
 	printf 'FAIL cycle cache cleanup left candidate or triage artifacts behind\n' >&2
 	exit 1
 }
 
 export PULSE_DISPATCH_CANDIDATE_SNAPSHOT_ENABLED=0
-fourth=$(_dispatch_ranked_candidates_json 50)
+fourth=$(_dispatch_ranked_candidates_json 50 "skip")
 fifth=$(_dispatch_ranked_candidates_json 50)
-[[ "$fourth" == '[{"number":3}]' && "$fifth" == '[{"number":4}]' ]] || {
+[[ "$fourth" == '[{"number":4}]' && "$fifth" == '[{"number":5}]' ]] || {
 	printf 'FAIL candidate snapshot escape hatch did not bypass cache\n' >&2
 	exit 1
 }
+[[ "$(<"$BUILD_MODE_FILE")" == $'skip\nnormalize\nnormalize\nskip\nnormalize' ]] || {
+	printf 'FAIL candidate builder did not receive normalization modes: %s\n' "$(<"$BUILD_MODE_FILE")" >&2
+	exit 1
+}
 
-printf 'PASS dispatch candidate snapshots reuse enumeration and invalidate on state mutation\n'
+printf 'PASS dispatch candidate snapshots reuse enumeration, preserve modes, and invalidate on state mutation\n'

--- a/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
@@ -96,7 +96,7 @@ assert_match_count() {
 
 assert_refill_runtime_contract() {
 	local label="$1"
-	local actual_events="" expected_events="dispatch;routine;invalidate:label_maintenance_complete;dispatch;"
+	local actual_events="" expected_events="dispatch:skip;routine;invalidate:label_maintenance_complete;dispatch:normalize;"
 	TESTS_RUN=$((TESTS_RUN + 1))
 	actual_events=$(
 		(
@@ -114,7 +114,8 @@ assert_refill_runtime_contract() {
 			}
 
 			apply_dispatch_max() {
-				REFILL_EVENTS="${REFILL_EVENTS}dispatch;"
+				local dependency_normalization_mode="${1:-normalize}"
+				REFILL_EVENTS="${REFILL_EVENTS}dispatch:${dependency_normalization_mode};"
 				return 0
 			}
 
@@ -297,7 +298,7 @@ assert_match_count \
 	1 \
 	"$PREFLIGHT_LIB"
 assert_refill_runtime_contract \
-	"9l: refill invalidates candidates before dispatch and does not repeat routine responses"
+	"9l: initial fill skips dependency normalization and refill restores the default"
 
 # --- Benign expected dispatch blocks must not be surfaced as generic stage failures ---
 


### PR DESCRIPTION
## Summary

Thread an explicit dependency-normalization mode through Pulse dispatch so the initial fill avoids synchronous normalization while post-label refill retains normalized readiness. Keep candidate snapshots mode-specific and invalidate both variants after state mutation.

## Files Changed

.agents/scripts/pulse-campaign-shadow.sh, .agents/scripts/pulse-dispatch-engine.sh, .agents/scripts/pulse-dispatch-lib.sh, .agents/scripts/pulse-dispatch-preflight-lib.sh, .agents/scripts/pulse-repo-meta.sh, .agents/scripts/tests/test-dependency-readiness-normalization.sh, .agents/scripts/tests/test-pulse-campaign-shadow.sh, .agents/scripts/tests/test-pulse-dispatch-candidate-snapshot.sh, .agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — runtime-verified: .agents/scripts/linters-local.sh --changed --no-cache; dependency readiness, dispatch stage wiring, candidate snapshot, campaign shadow, minimum concurrency, current-state guardrail, phase-two consolidation, and wrapper characterization test suites; two independent final reviews found no P0-P2 defects.

Resolves #28971


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 53m and 1,318,685 tokens on this with the user in an interactive session.