### PR TITLE
GH#28935: fix: isolate routines publication from canonical guard

### DIFF
--- a/.agents/scripts/canonical_git_policy.py
+++ b/.agents/scripts/canonical_git_policy.py
@@ -96,6 +96,43 @@ def _is_isolated_prospective_merge_tree(
     return os.path.dirname(context_dir) == os.path.realpath(tempfile.gettempdir())
 
 
+def _is_isolated_routines_publisher(
+    real_git_path: str,
+    effective_cwd: str,
+    prefix: list[str],
+    subcommand: str,
+) -> bool:
+    """Allow bounded mutations only in the routines publisher's private clone."""
+    if subcommand not in {"add", "commit", "fetch", "push"}:
+        return False
+    git_dir = _git_output(
+        real_git_path,
+        effective_cwd,
+        *prefix,
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-dir",
+    )
+    repo_dir = _git_output(
+        real_git_path,
+        effective_cwd,
+        *prefix,
+        "rev-parse",
+        "--path-format=absolute",
+        "--show-toplevel",
+    )
+    if not git_dir or not repo_dir:
+        return False
+    repo_dir = os.path.realpath(repo_dir)
+    context_dir = os.path.dirname(repo_dir)
+    return bool(
+        os.path.basename(repo_dir) == "repo"
+        and re.fullmatch(r"routines-publisher\.[A-Za-z0-9]+", os.path.basename(context_dir))
+        and os.path.dirname(context_dir) == os.path.realpath(tempfile.gettempdir())
+        and os.path.realpath(git_dir) == os.path.join(repo_dir, ".git")
+    )
+
+
 def classify_git_argv(
     argv: list[str], cwd: str, real_git_path: str, check_unresolved: bool = False
 ) -> tuple[bool, str]:
@@ -120,6 +157,10 @@ def classify_git_argv(
             real_git_path, effective_cwd, prefix, subcommand, args
         ):
             result = True, "isolated prospective merge-tree probe"
+        elif _is_isolated_routines_publisher(
+            real_git_path, effective_cwd, prefix, subcommand
+        ):
+            result = True, "isolated routines publisher mutation"
         elif _is_allowed_canonical(subcommand, args):
             result = True, "read-only canonical operation or linked-worktree creation"
         else:

--- a/.agents/scripts/init-routines-helper.sh
+++ b/.agents/scripts/init-routines-helper.sh
@@ -560,7 +560,7 @@ _publish_routines_scaffold() {
 		local changed_paths=""
 		temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/routines-publisher.XXXXXX") || return 1
 		staging_repo="${temp_dir}/repo"
-		if ! git clone -q --single-branch --branch "$branch" "$origin_url" "$staging_repo"; then
+		if ! git -C "$temp_dir" clone -q --single-branch --branch "$branch" "$origin_url" "$staging_repo"; then
 			rm -rf "$temp_dir"
 			return 1
 		fi

--- a/.agents/scripts/tests/test-init-routines-readonly-guard.sh
+++ b/.agents/scripts/tests/test-init-routines-readonly-guard.sh
@@ -206,6 +206,41 @@ test_isolated_publication_preserves_canonical_checkout() {
 	return 0
 }
 
+test_isolated_publication_uses_guard_aware_clone_context() {
+	local tmp_dir=""
+	tmp_dir=$(mktemp -d)
+	local remote_repo="${tmp_dir}/remote.git"
+	local canonical_repo="${tmp_dir}/mirror"
+	create_remote_fixture "$remote_repo" "$canonical_repo"
+	# shellcheck disable=SC1090
+	source "$INIT_ROUTINES"
+	local before=""
+	before=$(canonical_fingerprint "$canonical_repo")
+
+	# Keep the production Git shim active and enter a canonical checkout. The
+	# publisher must move clone execution into its disposable directory rather
+	# than bypassing the guard.
+	local rc=0
+	local output=""
+	output=$(
+		cd "$canonical_repo" || exit 1
+		PATH="${REPO_SCRIPTS}:/usr/bin:/bin:/usr/sbin:/sbin" _publish_routines_scaffold "$canonical_repo"
+	) 2>&1 || rc=$?
+	local after=""
+	after=$(canonical_fingerprint "$canonical_repo")
+	local remote_todo=""
+	remote_todo=$(git --git-dir="$remote_repo" show main:TODO.md 2>/dev/null || true)
+	rm -rf "$tmp_dir"
+
+	if [[ "$rc" -eq 0 && "$before" == "$after" && "$remote_todo" == "# Routines"* ]]; then
+		print_result "isolated publication succeeds through canonical Git guard (GH#28935)" 0
+		return 0
+	fi
+	print_result "isolated publication succeeds through canonical Git guard (GH#28935)" 1 \
+		"rc=${rc} canonical_unchanged=$([[ "$before" == "$after" ]] && printf yes || printf no) remote_todo_present=$([[ -n "$remote_todo" ]] && printf yes || printf no) output=${output}"
+	return 0
+}
+
 test_isolated_publication_uses_remote_ahead_tip() {
 	local tmp_dir=""
 	tmp_dir=$(mktemp -d)
@@ -402,6 +437,7 @@ main() {
 	test_common_tolerates_readonly_colors
 	test_routines_loader_isolates_errors
 	test_isolated_publication_preserves_canonical_checkout
+	test_isolated_publication_uses_guard_aware_clone_context
 	test_isolated_publication_uses_remote_ahead_tip
 	test_isolated_publication_fails_closed_on_validation
 	test_isolated_publication_retries_nonconflicting_race


### PR DESCRIPTION
## Summary

Run the disposable routines clone from its temporary parent, permit only add/commit/fetch/push inside the exact routines-publisher temporary clone, and cover the real canonical Git shim path while preserving canonical checkout fingerprints.

## Files Changed

.agents/scripts/canonical_git_policy.py, .agents/scripts/init-routines-helper.sh, .agents/scripts/tests/test-init-routines-readonly-guard.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-init-routines-readonly-guard.sh; bash .agents/scripts/tests/test-canonical-git-command-guard.sh; shellcheck .agents/scripts/init-routines-helper.sh .agents/scripts/tests/test-init-routines-readonly-guard.sh; python3 -m py_compile .agents/scripts/canonical_git_policy.py; .agents/scripts/linters-local.sh; bounded setup reached routine issue refresh without the prior canonical guard rejection

Resolves #28935


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 21m and 145,243 tokens on this as a headless worker.