### PR TITLE
GH#28851: fix: resolve Reddit ingestion review findings

### DIFF
--- a/.agents/scripts/_knowledge_social_collect_persist.py
+++ b/.agents/scripts/_knowledge_social_collect_persist.py
@@ -45,6 +45,7 @@ class RawBatch:
     batch_id: str
     blob_ref: str
     request_hash: str
+    response_hash: str
     observed_at: str
 
 
@@ -103,6 +104,7 @@ def _raw_batch(
     provider = _provider(context)
     response = canonical_json(payload).encode("utf-8")
     request_hash = hashlib.sha256(request.encode("utf-8")).hexdigest()
+    response_hash = hashlib.sha256(response).hexdigest()
     envelope = canonical_json(
         {
             "provider": provider,
@@ -110,14 +112,14 @@ def _raw_batch(
             "stream": context.stream,
             "observed_at": observed_at,
             "request_hash": request_hash,
-            "response_sha256": hashlib.sha256(response).hexdigest(),
+            "response_sha256": response_hash,
             "response": payload,
         }
     ).encode("utf-8")
     batch_id, blob_ref = write_raw_batch(
         context.root, provider, context.connection_id, envelope
     )
-    return RawBatch(batch_id, blob_ref, request_hash, observed_at)
+    return RawBatch(batch_id, blob_ref, request_hash, response_hash, observed_at)
 
 
 def _insert_fetch_batch(
@@ -131,7 +133,7 @@ def _insert_fetch_batch(
            resource_count,budget_units,started_at,completed_at,terminal_status)
            VALUES(?,?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(batch_id) DO NOTHING""",
         (
-            record.raw.batch_id,
+            record.raw.response_hash,
             _provider(context),
             context.connection_id,
             context.stream,
@@ -178,7 +180,8 @@ def _update_cursor(
            VALUES(?,?,?,?,?,?) ON CONFLICT(connection_id,stream) DO UPDATE SET
            cursor=excluded.cursor,watermark=excluded.watermark,
            last_success_at=excluded.last_success_at,
-           backfill_complete=excluded.backfill_complete""",
+           backfill_complete=MAX(
+             sync_cursors.backfill_complete,excluded.backfill_complete)""",
         (
             context.connection_id,
             context.stream,

--- a/.agents/scripts/_knowledge_social_reddit.py
+++ b/.agents/scripts/_knowledge_social_reddit.py
@@ -81,8 +81,8 @@ STREAMS = {
     "subscribed_subreddits": _listing(
         "subreddit", "selected_account", incremental=False
     ),
-    "moderated_subreddits": _listing(
-        "subreddit", "selected_account", incremental=False
+    "moderated_subreddits": StreamSpec(
+        "subreddit", "selected_account", "snapshot", False, None
     ),
     "contributor_subreddits": _listing(
         "subreddit", "selected_account", incremental=False

--- a/.agents/scripts/_knowledge_social_reddit_read_routes.py
+++ b/.agents/scripts/_knowledge_social_reddit_read_routes.py
@@ -33,10 +33,15 @@ LISTING_STREAMS = {
     "downvoted",
     "hidden",
     "subscribed_subreddits",
-    "moderated_subreddits",
     "contributor_subreddits",
 }
-SNAPSHOT_STREAMS = {"multireddits", "friends", "blocked", "trusted"}
+SNAPSHOT_STREAMS = {
+    "multireddits",
+    "friends",
+    "blocked",
+    "trusted",
+    "moderated_subreddits",
+}
 
 
 @dataclass(frozen=True)
@@ -135,12 +140,6 @@ def _subscribed_subreddits(
     return client.user.subreddits(**kwargs)
 
 
-def _moderated_subreddits(
-    client: Any, _selected_user: Any, kwargs: dict[str, Any]
-) -> Iterable[Any]:
-    return client.user.moderator_subreddits(**kwargs)
-
-
 def _contributor_subreddits(
     client: Any, _selected_user: Any, kwargs: dict[str, Any]
 ) -> Iterable[Any]:
@@ -160,7 +159,6 @@ LISTING_ROUTES: dict[str, ListingRoute] = {
     "downvoted": _downvoted,
     "hidden": _hidden,
     "subscribed_subreddits": _subscribed_subreddits,
-    "moderated_subreddits": _moderated_subreddits,
     "contributor_subreddits": _contributor_subreddits,
 }
 
@@ -261,11 +259,16 @@ def _trusted(client: Any) -> list[Any]:
     return client.user.trusted()
 
 
+def _moderated_subreddits(client: Any) -> list[Any]:
+    return client.user.me().moderated()
+
+
 SNAPSHOT_ROUTES: dict[str, SnapshotRoute] = {
     "multireddits": _multireddits,
     "friends": _friends,
     "blocked": _blocked,
     "trusted": _trusted,
+    "moderated_subreddits": _moderated_subreddits,
 }
 
 

--- a/.agents/scripts/knowledge_social_reddit.py
+++ b/.agents/scripts/knowledge_social_reddit.py
@@ -145,8 +145,7 @@ def collect_pages(
                 progress,
                 run_id=context.lease.run_id if context.lease else None,
             )
-    if progress.pages:
-        record_bounded_stop(context, "paused", "budget")
+    record_bounded_stop(context, "paused", "budget")
     return collection_result(
         "budget_exhausted",
         progress,

--- a/.agents/scripts/knowledge_social_reddit.py
+++ b/.agents/scripts/knowledge_social_reddit.py
@@ -145,7 +145,8 @@ def collect_pages(
                 progress,
                 run_id=context.lease.run_id if context.lease else None,
             )
-    record_bounded_stop(context, "paused", "budget")
+    if progress.pages:
+        record_bounded_stop(context, "paused", "budget")
     return collection_result(
         "budget_exhausted",
         progress,

--- a/.agents/tests/test-knowledge-social-reddit.sh
+++ b/.agents/tests/test-knowledge-social-reddit.sh
@@ -190,7 +190,6 @@ expected_listing_routes = {
     "downvoted": "selected.downvoted",
     "hidden": "selected.hidden",
     "subscribed_subreddits": "client.user.subreddits",
-    "moderated_subreddits": "client.user.moderator_subreddits",
     "contributor_subreddits": "client.user.contributor_subreddits",
 }
 expected_snapshot_routes = {
@@ -213,6 +212,25 @@ for stream, expected_route in expected_snapshot_routes.items():
     client = RecordingNode("client", route_calls)
     assert _snapshot_values(client, stream) == []
     assert route_calls == [(expected_route, {})]
+
+
+class ModeratedIdentity:
+    def moderated(self):
+        return []
+
+
+class ModeratedUser:
+    def me(self):
+        return ModeratedIdentity()
+
+
+class ModeratedClient:
+    user = ModeratedUser()
+
+
+assert _snapshot_values(ModeratedClient(), "moderated_subreddits") == []
+assert STREAMS["moderated_subreddits"].pagination == "snapshot"
+assert STREAMS["moderated_subreddits"].retention_limit is None
 
 missing = "PRAW is unavailable; install it outside the agent session"
 assert str(_provider_failure(f"ERROR: {missing}")) == missing
@@ -288,6 +306,8 @@ assert_eq "backfill exhaustion preserves the first page watermark" \
 	"done:t3_new:1"
 assert_eq "both immutable backfill pages remain durable" \
 	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_authored' AND stream='authored_submissions' AND terminal_status='success'")" 2
+assert_eq "fetch batches store response-body hashes rather than envelope IDs" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_authored' AND response_hash != batch_id")" 2
 
 cat >"$TMP_DIR/incremental.json" <<'JSON'
 {
@@ -349,6 +369,8 @@ JSON
 	--connection-id conn_authored --account-id reddit42 \
 	--stream authored_comments --profile fixture --budget 1 \
 	--fixture "$TMP_DIR/comments-partial.json" >/dev/null
+assert_eq "partial incremental pages preserve completed backfill state" \
+	"$(sql_value "SELECT backfill_complete FROM sync_cursors WHERE connection_id='conn_authored' AND stream='authored_comments'")" 1
 
 cat >"$TMP_DIR/comments-resume.json" <<'JSON'
 {

--- a/.agents/tests/test-knowledge-social-reddit.sh
+++ b/.agents/tests/test-knowledge-social-reddit.sh
@@ -546,6 +546,7 @@ python3 - "$ROOT" "$SCRIPT_DIR/../scripts" <<'PY'
 import os
 import sqlite3
 import sys
+from dataclasses import replace
 from pathlib import Path
 
 sys.path.insert(0, sys.argv[2])
@@ -556,6 +557,7 @@ from _knowledge_social_collect import (
     PageCheckpoint,
     SuccessfulPage,
 )
+import _knowledge_social_collect_persist as persist_module
 from _knowledge_social_collect_persist import persist_page
 from _knowledge_social_lease import (
     RunLeaseRequest,
@@ -609,6 +611,31 @@ page = SuccessfulPage(
     True,
     1,
 )
+expiring = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_reddit_expiry", "friends", "same_runner", "sync", 1),
+    now_epoch=9000,
+)
+expiry_archive = dict(archive, connection_id="conn_reddit_expiry")
+expiry_context = replace(context, connection_id="conn_reddit_expiry", lease=expiring)
+expiry_page = replace(page, archive=expiry_archive)
+clock = iter((9000, 9001))
+original_social_now = persist_module.social_now
+persist_module.social_now = lambda: next(clock)
+try:
+    persist_page(expiry_context, expiry_page)
+except SocialLeaseLostError:
+    pass
+else:
+    raise SystemExit("Reddit collector committed after its lease expired")
+finally:
+    persist_module.social_now = original_social_now
+with sqlite3.connect(root / "index" / "social.db") as database:
+    expiry_cursor = database.execute(
+        "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_reddit_expiry'"
+    ).fetchone()[0]
+assert expiry_cursor == 0
+release_run_lease(root, expiring)
 os.environ["AIDEVOPS_SOCIAL_NOW_EPOCH"] = "9001"
 try:
     persist_page(context, page)


### PR DESCRIPTION
## Summary

Store response-body hashes, latch completed backfills, route moderated subreddit reads through the PRAW 8 snapshot API, and cover fresh-clock lease fencing. The unused imports were already removed; the zero-page budget premise is unreachable because Reddit budgets are at least 1 and every stream costs 1.

## Files Changed

.agents/scripts/_knowledge_social_collect_persist.py, .agents/scripts/_knowledge_social_reddit.py, .agents/scripts/_knowledge_social_reddit_read_routes.py, .agents/tests/test-knowledge-social-reddit.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — .agents/tests/test-knowledge-social-reddit.sh (45 passed); ShellCheck; Python py_compile; git diff --check. Ruff unavailable in the worker image.

Resolves #28851


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 4m and 82,754 tokens on this as a headless worker.