### PR TITLE
GH#28859: reduce OAuth callback module complexity

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool-callback-server.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-callback-server.mjs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/**
+ * OAuth Pool — Local Callback Server
+ *
+ * Captures OAuth authorization responses on the loopback callback endpoint.
+ *
+ * @module oauth-pool-callback-server
+ */
+
+import { createServer } from "http";
+import { OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_TIMEOUT_MS } from "./oauth-pool-constants.mjs";
+
+export function startOAuthCallbackServer(expectedState) {
+  let resolveCode, rejectCode, server, timeoutId, resolveReady;
+  const promise = new Promise((resolve, reject) => { resolveCode = resolve; rejectCode = reject; });
+  const ready = new Promise((resolve) => { resolveReady = resolve; });
+  const escapeHtml = (s) =>
+    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;").replace(/'/g, "&#039;");
+
+  function cleanup() {
+    if (timeoutId) clearTimeout(timeoutId);
+    if (server) { try { server.close(); } catch { /* ignore */ } }
+  }
+
+  server = createServer((req, res) => {
+    let reqUrl;
+    try { reqUrl = new URL(req.url, `http://localhost:${OAUTH_CALLBACK_PORT}`); }
+    catch { res.writeHead(400, { "Content-Type": "text/plain" }); res.end("Bad request"); return; }
+
+    if (reqUrl.pathname !== "/auth/callback") {
+      res.writeHead(404, { "Content-Type": "text/plain" }); res.end("Not found"); return;
+    }
+
+    const code = reqUrl.searchParams.get("code");
+    const error = reqUrl.searchParams.get("error");
+
+    // Validate OAuth state to prevent CSRF / account-mixup attacks.
+    if (expectedState) {
+      const returnedState = reqUrl.searchParams.get("state");
+      if (returnedState !== expectedState) {
+        console.error("[aidevops] OAuth pool: state mismatch in callback — possible CSRF");
+        res.writeHead(400, { "Content-Type": "text/plain" });
+        res.end("State mismatch — authorization rejected");
+        cleanup();
+        rejectCode(new Error("OAuth state mismatch"));
+        return;
+      }
+    }
+
+    if (error) {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(`<!DOCTYPE html><html><body><h2>Authorization Failed</h2><p>${escapeHtml(error)}</p><p>${escapeHtml(reqUrl.searchParams.get("error_description") || "")}</p><p>You can close this tab.</p></body></html>`);
+      cleanup();
+      rejectCode(new Error(`OAuth error: ${error}`));
+    } else if (code) {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(`<!DOCTYPE html><html><body><h2>Authorization Successful</h2><p>The authorization code has been captured. Return to OpenCode.</p><p>You can close this tab.</p></body></html>`);
+      cleanup();
+      resolveCode(code);
+    } else {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end("Waiting for OAuth callback...");
+    }
+  });
+
+  server.on("error", (err) => {
+    cleanup();
+    if (err.code === "EADDRINUSE") {
+      console.error(`[aidevops] OAuth pool: port ${OAUTH_CALLBACK_PORT} in use`);
+      resolveReady(false);
+      return;
+    }
+    console.error(`[aidevops] OAuth pool: callback server error: ${err.message}`);
+    resolveReady(false);
+    rejectCode(err);
+  });
+
+  server.listen(OAUTH_CALLBACK_PORT, "127.0.0.1", () => {
+    console.error(`[aidevops] OAuth pool: callback server listening on port ${OAUTH_CALLBACK_PORT}`);
+    resolveReady(true);
+  });
+
+  timeoutId = setTimeout(() => { cleanup(); rejectCode(new Error("OAuth callback timeout")); }, OAUTH_CALLBACK_TIMEOUT_MS);
+  return { promise, ready, close: cleanup };
+}

--- a/.agents/plugins/opencode-aidevops/oauth-pool-callback.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-callback.mjs
@@ -10,11 +10,12 @@
  */
 
 import { createHash, randomBytes } from "crypto";
-import { createServer } from "http";
-import { OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_TIMEOUT_MS } from "./oauth-pool-constants.mjs";
 import {
   getAccounts, upsertAccount, savePendingToken,
 } from "./oauth-pool-storage.mjs";
+import { startOAuthCallbackServer } from "./oauth-pool-callback-server.mjs";
+
+export { startOAuthCallbackServer };
 
 // ---------------------------------------------------------------------------
 // PKCE helpers
@@ -37,85 +38,6 @@ export function generatePKCE() {
  */
 export function generateState() {
   return randomBytes(32).toString("base64url");
-}
-
-// ---------------------------------------------------------------------------
-// OAuth callback server
-// ---------------------------------------------------------------------------
-
-export function startOAuthCallbackServer(expectedState) {
-  let resolveCode, rejectCode, server, timeoutId, resolveReady;
-  const promise = new Promise((resolve, reject) => { resolveCode = resolve; rejectCode = reject; });
-  const ready = new Promise((resolve) => { resolveReady = resolve; });
-  const escapeHtml = (s) =>
-    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;").replace(/'/g, "&#039;");
-
-  function cleanup() {
-    if (timeoutId) clearTimeout(timeoutId);
-    if (server) { try { server.close(); } catch { /* ignore */ } }
-  }
-
-  server = createServer((req, res) => {
-    let reqUrl;
-    try { reqUrl = new URL(req.url, `http://localhost:${OAUTH_CALLBACK_PORT}`); }
-    catch { res.writeHead(400, { "Content-Type": "text/plain" }); res.end("Bad request"); return; }
-
-    if (reqUrl.pathname !== "/auth/callback") {
-      res.writeHead(404, { "Content-Type": "text/plain" }); res.end("Not found"); return;
-    }
-
-    const code = reqUrl.searchParams.get("code");
-    const error = reqUrl.searchParams.get("error");
-
-    // Validate OAuth state to prevent CSRF / account-mixup attacks.
-    if (expectedState) {
-      const returnedState = reqUrl.searchParams.get("state");
-      if (returnedState !== expectedState) {
-        console.error("[aidevops] OAuth pool: state mismatch in callback — possible CSRF");
-        res.writeHead(400, { "Content-Type": "text/plain" });
-        res.end("State mismatch — authorization rejected");
-        cleanup();
-        rejectCode(new Error("OAuth state mismatch"));
-        return;
-      }
-    }
-
-    if (error) {
-      res.writeHead(200, { "Content-Type": "text/html" });
-      res.end(`<!DOCTYPE html><html><body><h2>Authorization Failed</h2><p>${escapeHtml(error)}</p><p>${escapeHtml(reqUrl.searchParams.get("error_description") || "")}</p><p>You can close this tab.</p></body></html>`);
-      cleanup();
-      rejectCode(new Error(`OAuth error: ${error}`));
-    } else if (code) {
-      res.writeHead(200, { "Content-Type": "text/html" });
-      res.end(`<!DOCTYPE html><html><body><h2>Authorization Successful</h2><p>The authorization code has been captured. Return to OpenCode.</p><p>You can close this tab.</p></body></html>`);
-      cleanup();
-      resolveCode(code);
-    } else {
-      res.writeHead(200, { "Content-Type": "text/plain" });
-      res.end("Waiting for OAuth callback...");
-    }
-  });
-
-  server.on("error", (err) => {
-    cleanup();
-    if (err.code === "EADDRINUSE") {
-      console.error(`[aidevops] OAuth pool: port ${OAUTH_CALLBACK_PORT} in use`);
-      resolveReady(false);
-      return;
-    }
-    console.error(`[aidevops] OAuth pool: callback server error: ${err.message}`);
-    resolveReady(false);
-    rejectCode(err);
-  });
-
-  server.listen(OAUTH_CALLBACK_PORT, "127.0.0.1", () => {
-    console.error(`[aidevops] OAuth pool: callback server listening on port ${OAUTH_CALLBACK_PORT}`);
-    resolveReady(true);
-  });
-
-  timeoutId = setTimeout(() => { cleanup(); rejectCode(new Error("OAuth callback timeout")); }, OAUTH_CALLBACK_TIMEOUT_MS);
-  return { promise, ready, close: cleanup };
 }
 
 // ---------------------------------------------------------------------------

--- a/.agents/plugins/opencode-aidevops/tests/test-oauth-pool-callback-server.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-oauth-pool-callback-server.mjs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { startOAuthCallbackServer } from "../oauth-pool-callback.mjs";
+
+test("callback server preserves the public re-export and captures valid codes", async () => {
+  const server = startOAuthCallbackServer("expected-state");
+
+  try {
+    assert.equal(await server.ready, true);
+    const response = await fetch(
+      "http://127.0.0.1:1455/auth/callback?code=test-code&state=expected-state",
+    );
+
+    assert.equal(response.status, 200);
+    assert.match(await response.text(), /Authorization Successful/);
+    assert.equal(await server.promise, "test-code");
+  } finally {
+    server.close();
+  }
+});
+
+test("callback server rejects mismatched OAuth state", async () => {
+  const server = startOAuthCallbackServer("expected-state");
+  const rejection = assert.rejects(server.promise, /OAuth state mismatch/);
+
+  try {
+    assert.equal(await server.ready, true);
+    const response = await fetch(
+      "http://127.0.0.1:1455/auth/callback?code=test-code&state=wrong-state",
+    );
+
+    assert.equal(response.status, 400);
+    await rejection;
+  } finally {
+    server.close();
+  }
+});
+
+test("callback server escapes OAuth errors and rejects the pending code", async () => {
+  const server = startOAuthCallbackServer("expected-state");
+  const unsafeError = "<img src=x onerror=alert(1)>";
+  const rejection = assert.rejects(server.promise, /OAuth error: <img src=x onerror=alert\(1\)>/);
+
+  try {
+    assert.equal(await server.ready, true);
+    const description = encodeURIComponent('<script>"not allowed"</script>');
+    const error = encodeURIComponent(unsafeError);
+    const response = await fetch(
+      `http://127.0.0.1:1455/auth/callback?error=${error}&error_description=${description}&state=expected-state`,
+    );
+    const body = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.match(body, /&lt;img src=x onerror=alert\(1\)&gt;/);
+    assert.match(body, /&lt;script&gt;&quot;not allowed&quot;&lt;\/script&gt;/);
+    assert.equal(body.includes(unsafeError), false);
+    assert.doesNotMatch(body, /<script>/);
+    await rejection;
+
+    const rebound = startOAuthCallbackServer("rebound-state");
+    try {
+      assert.equal(await rebound.ready, true);
+    } finally {
+      rebound.close();
+    }
+  } finally {
+    server.close();
+  }
+});
+
+test("closing the callback server releases the loopback port", async () => {
+  const first = startOAuthCallbackServer("first-state");
+  assert.equal(await first.ready, true);
+  first.close();
+
+  const second = startOAuthCallbackServer("second-state");
+  try {
+    assert.equal(await second.ready, true);
+  } finally {
+    second.close();
+  }
+});


### PR DESCRIPTION
## Summary

- extract the local OAuth callback server into a focused module
- preserve `oauth-pool-callback.mjs` exports and internal bindings
- add runtime coverage for successful callbacks and OAuth state rejection

## Testing

- `node --check .agents/plugins/opencode-aidevops/oauth-pool-callback.mjs`
- `node --check .agents/plugins/opencode-aidevops/oauth-pool-callback-server.mjs`
- `node --test .agents/plugins/opencode-aidevops/tests/test-oauth-pool-callback-server.mjs .agents/plugins/opencode-aidevops/tests/test-reexport-local-binding.mjs`
- `~/.qlty/bin/qlty smells` reports no smells for the modified source, extracted module, or new test

## Runtime Testing

- `runtime-verified`: exercised the loopback HTTP callback server for successful code capture and CSRF state mismatch rejection

## Complexity Bump Justification

This behavior-preserving split moves `startOAuthCallbackServer` from `.agents/plugins/opencode-aidevops/oauth-pool-callback.mjs:46` into a focused sibling module. Qlty measurement: base target file=1 smell; head target file=0, new source file=0, new test file=0; net=-1. The split reduces the cited file complexity without introducing a new-file smell.

Resolves #28859

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.199 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 9m and 107,491 tokens on this as a headless worker.
