### PR TITLE
GH#28864: Fix cross-repository full-loop merge evidence resolution

### DIFF
--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -427,7 +427,7 @@ _merge_guard_admin_merge_maintainer_review() {
 		print_error "Merge blocked: unable to verify live repository permission for PR author ${pr_author}"
 		return 1
 	fi
-	if [[ "$labels_padded" == *",external-contributor,"* ]] || \
+	if [[ "$labels_padded" == *",external-contributor,"* ]] ||
 		[[ "$is_fork" == "true" ]] || [[ "$author_rc" -ne 0 ]]; then
 		treat_as_external=1
 	fi
@@ -448,7 +448,7 @@ _merge_guard_admin_merge_maintainer_review() {
 			print_error "Merge blocked: unable to verify maintainer-review labels on issue #${issue_number}"
 			return 1
 		fi
-		if [[ "$treat_as_external" -eq 1 ]] && \
+		if [[ "$treat_as_external" -eq 1 ]] &&
 			! _merge_target_crypto_approved issue "$issue_number" "$repo"; then
 			print_error "Merge blocked: external/fork PR linked issue #${issue_number} lacks current cryptographic development authority"
 			return 1
@@ -482,17 +482,34 @@ _merge_fetch_head_sha_rest() {
 	return 0
 }
 
-# Return the fresh base ref, base SHA, and head SHA that GitHub currently binds
-# to the PR. The three fields form the pinned evidence boundary for a local
-# prospective merge-tree check.
+# Return the fresh base ref, base SHA, head SHA, base repository, and clone URL
+# that GitHub currently binds to the PR. These fields form the pinned evidence
+# boundary for a local prospective merge-tree check and keep explicit-repository
+# merges independent of the caller's current Git remote.
 _merge_fetch_pr_refs_rest() {
 	local pr_number="$1"
 	local repo="$2"
 	local refs=""
 	refs=$(gh api "repos/${repo}/pulls/${pr_number}" \
-		--jq '[.base.ref // empty, .base.sha // empty, .head.sha // empty] | @tsv' 2>/dev/null) || return 1
-	[[ "$refs" == *$'\t'*$'\t'* ]] || return 1
+		--jq '[.base.ref // empty, .base.sha // empty, .head.sha // empty, .base.repo.full_name // empty, .base.repo.clone_url // empty] | @tsv' 2>/dev/null) || return 1
+	[[ "$refs" == *$'\t'*$'\t'*$'\t'*$'\t'* ]] || return 1
 	printf '%s\n' "$refs"
+	return 0
+}
+
+_merge_validate_target_remote_url() {
+	local target_repo="$1"
+	local remote_url="$2"
+	local git_host="${GH_HOST:-github.com}"
+	local expected_url=""
+	local normalized_remote_url=""
+	local normalized_expected_url=""
+	[[ "$git_host" =~ ^[A-Za-z0-9.-]+$ ]] || return 1
+	[[ "$target_repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || return 1
+	expected_url="https://${git_host}/${target_repo}.git"
+	normalized_remote_url=$(printf '%s' "$remote_url" | tr '[:upper:]' '[:lower:]')
+	normalized_expected_url=$(printf '%s' "$expected_url" | tr '[:upper:]' '[:lower:]')
+	[[ "$normalized_remote_url" == "$normalized_expected_url" ]] || return 1
 	return 0
 }
 
@@ -519,7 +536,7 @@ _merge_fetch_pinned_commit_objects() {
 	if ! _merge_run_repository_isolated_git "$real_git" -C "$object_repo" cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
 		[[ -n "$remote_url" ]] || return 1
 		_merge_run_repository_isolated_git "$real_git" -C "$object_repo" \
-			fetch --quiet --no-tags "$remote_url" "refs/heads/${base_ref}" || return 1
+			fetch --quiet --no-tags -- "$remote_url" "refs/heads/${base_ref}" || return 1
 		fetched_sha=$(_merge_run_repository_isolated_git "$real_git" -C "$object_repo" \
 			rev-parse FETCH_HEAD 2>/dev/null) || return 1
 		[[ "$fetched_sha" == "$base_sha" ]] || return 1
@@ -527,7 +544,7 @@ _merge_fetch_pinned_commit_objects() {
 	if ! _merge_run_repository_isolated_git "$real_git" -C "$object_repo" cat-file -e "${head_sha}^{commit}" 2>/dev/null; then
 		[[ -n "$remote_url" ]] || return 1
 		_merge_run_repository_isolated_git "$real_git" -C "$object_repo" \
-			fetch --quiet --no-tags "$remote_url" "refs/pull/${pr_number}/head" || return 1
+			fetch --quiet --no-tags -- "$remote_url" "refs/pull/${pr_number}/head" || return 1
 		fetched_sha=$(_merge_run_repository_isolated_git "$real_git" -C "$object_repo" \
 			rev-parse FETCH_HEAD 2>/dev/null) || return 1
 		[[ "$fetched_sha" == "$head_sha" ]] || return 1
@@ -591,6 +608,9 @@ _merge_guard_prospective_todo() (
 	local base_ref=""
 	local base_sha=""
 	local head_sha=""
+	local target_repo=""
+	local normalized_repo=""
+	local normalized_target_repo=""
 	local merge_tree_output=""
 	local merge_tree_sha=""
 	local temp_root=""
@@ -605,9 +625,19 @@ _merge_guard_prospective_todo() (
 		print_error "Merge blocked: unable to pin fresh PR base/head evidence for prospective TODO validation"
 		return 1
 	}
-	IFS=$'\t' read -r base_ref base_sha head_sha <<<"$refs"
-	if [[ -z "$base_ref" || -z "$base_sha" || -z "$head_sha" ]]; then
+	IFS=$'\t' read -r base_ref base_sha head_sha target_repo remote_url <<<"$refs"
+	if [[ -z "$base_ref" || -z "$base_sha" || -z "$head_sha" || -z "$target_repo" || -z "$remote_url" ]]; then
 		print_error "Merge blocked: incomplete PR base/head evidence for prospective TODO validation"
+		return 1
+	fi
+	normalized_repo=$(printf '%s' "$repo" | tr '[:upper:]' '[:lower:]')
+	normalized_target_repo=$(printf '%s' "$target_repo" | tr '[:upper:]' '[:lower:]')
+	if [[ "$normalized_repo" != "$normalized_target_repo" ]]; then
+		print_error "Merge blocked: prospective TODO repository evidence does not match the explicit target"
+		return 1
+	fi
+	if ! _merge_validate_target_remote_url "$target_repo" "$remote_url"; then
+		print_error "Merge blocked: prospective TODO remote URL does not match the explicit target"
 		return 1
 	fi
 	if [[ -n "${FULL_LOOP_VERIFIED_PR_HEAD_SHA:-}" && "$head_sha" != "$FULL_LOOP_VERIFIED_PR_HEAD_SHA" ]]; then
@@ -639,7 +669,6 @@ _merge_guard_prospective_todo() (
 		print_error "Merge blocked: unable to initialize isolated prospective Git context"
 		return 1
 	}
-	remote_url=$(_merge_run_config_isolated_git git "$temp_dir" remote get-url origin 2>/dev/null || true)
 	_merge_fetch_pinned_commit_objects "$pr_number" "$base_ref" "$base_sha" "$head_sha" \
 		"$object_repo" "$remote_url" "$real_git" || {
 		print_error "Merge blocked: unable to materialize pinned PR commits for prospective TODO validation"

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -10,6 +10,15 @@ PMRC_CHECK_SUCCESS="success"
 PMRC_CHECK_FAILURE="failure"
 PMRC_BOOL_TRUE="true"
 PMRC_JSON_ARRAY="array"
+PMRC_JSON_NUMBER="number"
+PMRC_JSON_OBJECT="object"
+PMRC_JSON_STRING="string"
+PMRC_RULESET_ACTIVE="active"
+PMRC_RULESET_BRANCH="branch"
+PMRC_RULESET_DISABLED="disabled"
+PMRC_RULESET_EVALUATE="evaluate"
+PMRC_RULESET_PUSH="push"
+PMRC_RULESET_TAG="tag"
 PMRC_MAINTAINER_GATE="maintainer-gate"
 PMRC_MAINTAINER_GATE_DISPLAY="Maintainer Review & Assignee Gate"
 PMRC_MAINTAINER_GATE_WORKFLOW="gate / Maintainer Review & Assignee Gate"
@@ -46,6 +55,73 @@ _pmrc_cache_key() {
 	[[ -n "$safe_key" ]] || safe_key="empty"
 	printf '%s\n' "$safe_key"
 	return 0
+}
+
+_pmrc_classic_protection_unavailable_for_private_repo() {
+	local response="$1"
+	[[ "$response" == *"Upgrade to GitHub Pro or make this repository public to enable this feature."* ]] || return 1
+	[[ "$response" == *"HTTP 403"* ]] || return 1
+	return 0
+}
+
+_pmrc_rulesets_list_schema_valid() {
+	local rulesets_json="$1"
+	printf '%s' "$rulesets_json" | jq -e \
+		--arg active "$PMRC_RULESET_ACTIVE" \
+		--arg array "$PMRC_JSON_ARRAY" \
+		--arg branch "$PMRC_RULESET_BRANCH" \
+		--arg disabled "$PMRC_RULESET_DISABLED" \
+		--arg evaluate "$PMRC_RULESET_EVALUATE" \
+		--arg number "$PMRC_JSON_NUMBER" \
+		--arg obj "$PMRC_JSON_OBJECT" \
+		--arg push "$PMRC_RULESET_PUSH" \
+		--arg string "$PMRC_JSON_STRING" \
+		--arg tag "$PMRC_RULESET_TAG" '
+		type == $array and
+		all(.[];
+			type == $obj and
+			(.id | type == $number and . > 0) and
+			(.enforcement as $value |
+				($value | type == $string) and
+				([$active, $disabled, $evaluate] | index($value) != null)) and
+			(.target as $value |
+				($value | type == $string) and
+				([$branch, $push, $tag] | index($value) != null)))
+	' >/dev/null 2>&1
+	return $?
+}
+
+_pmrc_branch_ruleset_detail_schema_valid() {
+	local detail="$1"
+	local expected_id="$2"
+	printf '%s' "$detail" | jq -e \
+		--arg active "$PMRC_RULESET_ACTIVE" \
+		--arg array "$PMRC_JSON_ARRAY" \
+		--arg branch "$PMRC_RULESET_BRANCH" \
+		--argjson expected_id "$expected_id" \
+		--arg obj "$PMRC_JSON_OBJECT" \
+		--arg number "$PMRC_JSON_NUMBER" \
+		--arg required_status_checks "required_status_checks" \
+		--arg string "$PMRC_JSON_STRING" '
+		type == $obj and
+		(.id | type == $number and . == $expected_id) and
+		.enforcement == $active and
+		.target == $branch and
+		(.conditions.ref_name.include | type == $array) and
+		all(.conditions.ref_name.include[]; type == $string) and
+		((.conditions.ref_name.exclude // []) | type == $array) and
+		all((.conditions.ref_name.exclude // [])[]; type == $string) and
+		(.rules | type == $array) and
+		all(.rules[];
+			type == $obj and (.type | type == $string) and
+			(if .type == $required_status_checks then
+				(.parameters.required_status_checks | type == $array) and
+				all(.parameters.required_status_checks[];
+					type == $obj and
+					((.context // .name // "") | type == $string and length > 0))
+			else true end))
+	' >/dev/null 2>&1
+	return $?
 }
 
 #######################################
@@ -110,10 +186,16 @@ _required_contexts_from_rulesets_for_default_branch() {
 		echo "[pulse-merge] _required_contexts_from_rulesets_for_default_branch: rulesets list failed for ${repo_slug} — caller will fail closed (GH#23019)" >>"$log_target"
 		return 1
 	}
-	[[ -n "$rulesets_json" && "$rulesets_json" != "[]" && "$rulesets_json" != "null" ]] || return 0
+	if ! _pmrc_rulesets_list_schema_valid "$rulesets_json"; then
+		echo "[pulse-merge] _required_contexts_from_rulesets_for_default_branch: rulesets list parse failed for ${repo_slug} — caller will fail closed (GH#23019, GH#28864)" >>"$log_target"
+		return 1
+	fi
+	[[ "$rulesets_json" != "[]" ]] || return 0
 
 	local active_ids=""
-	active_ids=$(printf '%s' "$rulesets_json" | jq -r '.[]? | select(.enforcement == "active") | .id // empty' 2>/dev/null) || {
+	active_ids=$(printf '%s' "$rulesets_json" | jq -r \
+		--arg active "$PMRC_RULESET_ACTIVE" --arg branch "$PMRC_RULESET_BRANCH" \
+		'.[] | select(.enforcement == $active and .target == $branch) | .id' 2>/dev/null) || {
 		echo "[pulse-merge] _required_contexts_from_rulesets_for_default_branch: rulesets list parse failed for ${repo_slug} — caller will fail closed (GH#23019)" >>"$log_target"
 		return 1
 	}
@@ -134,6 +216,11 @@ _required_contexts_from_rulesets_for_default_branch() {
 			rm -f "$contexts_tmp"
 			return 1
 		}
+		if ! _pmrc_branch_ruleset_detail_schema_valid "$detail" "$id"; then
+			echo "[pulse-merge] _required_contexts_from_rulesets_for_default_branch: ruleset detail ${id} parse failed for ${repo_slug} — caller will fail closed (GH#23019, GH#28864)" >>"$log_target"
+			rm -f "$contexts_tmp"
+			return 1
+		fi
 
 		include_patterns=$(printf '%s' "$detail" | jq -r '.conditions.ref_name.include // [] | .[]' 2>/dev/null) || {
 			echo "[pulse-merge] _required_contexts_from_rulesets_for_default_branch: ruleset detail ${id} parse failed for ${repo_slug} — caller will fail closed (GH#23019)" >>"$log_target"
@@ -206,15 +293,21 @@ _required_contexts_for_default_branch_uncached() {
 		"repos/${repo_slug}/branches/${default_branch}/protection/required_status_checks" \
 		2>&1) || protection_rc=$?
 	if [[ "$protection_rc" -ne 0 ]]; then
+		local classic_unavailable_reason=""
 		if grep -qi 'HTTP 404\|Not Found' <<<"$protection_resp"; then
-			local ruleset_contexts_404=""
-			ruleset_contexts_404=$(_required_contexts_from_rulesets_for_default_branch "$repo_slug" "$default_branch") || return 1
-			if [[ -n "$ruleset_contexts_404" ]]; then
-				echo "[pulse-merge] _required_contexts_for_default_branch: no classic branch protection on ${repo_slug} (HTTP 404), but active rulesets require contexts (GH#23019)" >>"$log_target"
-				printf '%s\n' "$ruleset_contexts_404"
+			classic_unavailable_reason="HTTP 404"
+		elif _pmrc_classic_protection_unavailable_for_private_repo "$protection_resp"; then
+			classic_unavailable_reason="private-plan unavailable (HTTP 403)"
+		fi
+		if [[ -n "$classic_unavailable_reason" ]]; then
+			local ruleset_contexts_unavailable=""
+			ruleset_contexts_unavailable=$(_required_contexts_from_rulesets_for_default_branch "$repo_slug" "$default_branch") || return 1
+			if [[ -n "$ruleset_contexts_unavailable" ]]; then
+				echo "[pulse-merge] _required_contexts_for_default_branch: no classic branch protection on ${repo_slug} (${classic_unavailable_reason}), but active rulesets require contexts (GH#23019, GH#28864)" >>"$log_target"
+				printf '%s\n' "$ruleset_contexts_unavailable"
 				return 0
 			fi
-			echo "[pulse-merge] _required_contexts_for_default_branch: no classic branch protection or required ruleset contexts on ${repo_slug} default branch (HTTP 404) — empty contexts (t3193, GH#23019)" >>"$log_target"
+			echo "[pulse-merge] _required_contexts_for_default_branch: no classic branch protection or required ruleset contexts on ${repo_slug} default branch (${classic_unavailable_reason}) — empty contexts (t3193, GH#23019, GH#28864)" >>"$log_target"
 			return 0
 		fi
 		echo "[pulse-merge] _required_contexts_for_default_branch: branch protection API failed for ${repo_slug} (exit ${protection_rc}) — caller will fail closed (t2922)" >>"$log_target"
@@ -312,11 +405,11 @@ _pmrc_normalize_snapshot_checks_json() {
 
 	checks_json=$(jq -s \
 		--arg completed "$PMRC_CHECK_COMPLETED" --arg success "$PMRC_CHECK_SUCCESS" --arg failure "$PMRC_CHECK_FAILURE" \
-		--arg array_type "$PMRC_JSON_ARRAY" \
+		--arg array_type "$PMRC_JSON_ARRAY" --arg object_type "$PMRC_JSON_OBJECT" \
 		--arg skipped "skipped" --arg maintainer "$PMRC_MAINTAINER_GATE" --arg maintainer_display "$PMRC_MAINTAINER_GATE_DISPLAY" \
 		--arg maintainer_workflow "$PMRC_MAINTAINER_GATE_WORKFLOW" \
 		--arg review_gate "$PMRC_REVIEW_BOT_GATE" --arg review_gate_workflow "$PMRC_REVIEW_BOT_GATE_WORKFLOW" '
-		if length != 2 or (.[0] | type) != $array_type or (.[1] | type) != "object"
+		if length != 2 or (.[0] | type) != $array_type or (.[1] | type) != $object_type
 		then error("invalid check-runs or commit-status response")
 		else . end |
 		.[0] as $pages | .[1] as $statuses |
@@ -1156,8 +1249,9 @@ _check_ruleset_required_reviews_passing() {
 		echo "[pulse-merge] _check_ruleset_required_reviews_passing: review fetch failed for PR #${pr_number} in ${repo_slug} with ruleset requiring ${required_count} approval(s) — failing closed (GH#24577)" >>"$LOGFILE"
 		return 1
 	fi
-	approved_count=$(jq -er --arg author "$pr_author" --arg empty "$empty_string" --arg array_type "$PMRC_JSON_ARRAY" '
-		if type != $array_type or any(.[]; type != $array_type) or any(.[][]?; type != "object") then
+	approved_count=$(jq -er --arg author "$pr_author" --arg empty "$empty_string" \
+		--arg array_type "$PMRC_JSON_ARRAY" --arg object_type "$PMRC_JSON_OBJECT" '
+		if type != $array_type or any(.[]; type != $array_type) or any(.[][]?; type != $object_type) then
 			error("invalid paginated reviews response")
 		else
 			[.[][]? | {

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -747,16 +747,16 @@ CACHE
 	print_result "stale gh cache 401: gh pr merge called exactly twice" "$((merge_count == 2 ? 0 : 1))" "merge_count=${merge_count}"
 
 	local stale_quarantined=0
-	if [[ ! -f "${TEST_ROOT}/home/.cache/gh/graphql-401.cache" ]] && \
+	if [[ ! -f "${TEST_ROOT}/home/.cache/gh/graphql-401.cache" ]] &&
 		find "${TEST_ROOT}/home/.cache/gh" -path '*/aidevops-quarantine-*/graphql-401.cache' -type f | grep -q .; then
 		stale_quarantined=1
 	fi
 	print_result "stale gh cache 401: top-level 401 cache quarantined" "$((1 - stale_quarantined))"
 
 	local collision_paths_preserved=0
-	if [[ ! -f "${TEST_ROOT}/home/.cache/gh/api/shared.cache" ]] && \
-		[[ ! -f "${TEST_ROOT}/home/.cache/gh/graphql/shared.cache" ]] && \
-		find "${TEST_ROOT}/home/.cache/gh" -path '*/aidevops-quarantine-*/api/shared.cache' -type f | grep -q . && \
+	if [[ ! -f "${TEST_ROOT}/home/.cache/gh/api/shared.cache" ]] &&
+		[[ ! -f "${TEST_ROOT}/home/.cache/gh/graphql/shared.cache" ]] &&
+		find "${TEST_ROOT}/home/.cache/gh" -path '*/aidevops-quarantine-*/api/shared.cache' -type f | grep -q . &&
 		find "${TEST_ROOT}/home/.cache/gh" -path '*/aidevops-quarantine-*/graphql/shared.cache' -type f | grep -q .; then
 		collision_paths_preserved=1
 	fi
@@ -1141,6 +1141,8 @@ run_prospective_todo_guard() {
 	local base_sha="$2"
 	local head_sha="$3"
 	local fetch_mode="${4:-stub}"
+	local remote_url="${5:-https://github.com/testorg/testrepo.git}"
+	local reported_repo="${6:-testorg/testrepo}"
 	local scripts_dir="${SCRIPT_DIR}/.."
 	local tmp_runner=""
 	local verification_tmp="${fixture_dir}/verification-tmp"
@@ -1151,8 +1153,11 @@ run_prospective_todo_guard() {
 	local hostile_alternates="${fixture_dir}/hostile-alternates"
 	local hostile_index="${fixture_dir}/hostile-index"
 	local fetch_override=""
+	local validation_override=""
 	if [[ "$fetch_mode" == "stub" ]]; then
 		fetch_override='_merge_fetch_pinned_commit_objects() { return 0; }'
+	else
+		validation_override='_merge_validate_target_remote_url() { return 0; }'
 	fi
 	mkdir -p "$verification_tmp" "$attacker_home" "$hostile_objects" "$hostile_alternates"
 	# shellcheck disable=SC2016  # The generated driver expands this at execution time.
@@ -1168,8 +1173,9 @@ set -euo pipefail
 SCRIPT_DIR='${scripts_dir}'
 source '${scripts_dir}/shared-constants.sh'
 source '${scripts_dir}/full-loop-helper-merge.sh'
-_merge_fetch_pr_refs_rest() { printf 'main\t%s\t%s\n' '${base_sha}' '${head_sha}'; return 0; }
+_merge_fetch_pr_refs_rest() { printf 'main\t%s\t%s\t%s\t%s\n' '${base_sha}' '${head_sha}' '${reported_repo}' '${remote_url}'; return 0; }
 ${fetch_override}
+${validation_override}
 cd '${fixture_dir}'
 _merge_guard_prospective_todo '42' 'testorg/testrepo'
 RUNNER_EOF
@@ -1249,6 +1255,8 @@ create_prospective_fetch_fixture() {
 	local remote_repo="${fixture_root}/remote.git"
 	local fixture_dir="${fixture_root}/work"
 	local competitor="${fixture_root}/competitor"
+	local caller_remote="${fixture_root}/caller-remote.git"
+	local caller="${fixture_root}/caller"
 	local root_sha="" base_sha="" head_sha=""
 	mkdir -p "$fixture_root" || return 1
 	/usr/bin/git init --bare --initial-branch=main "$remote_repo" >/dev/null 2>&1 || return 1
@@ -1274,14 +1282,24 @@ create_prospective_fetch_fixture() {
 	/usr/bin/git -C "$competitor" commit -q -am head || return 1
 	head_sha=$(/usr/bin/git -C "$competitor" rev-parse HEAD) || return 1
 	/usr/bin/git -C "$competitor" push -q origin "${head_sha}:refs/pull/42/head" || return 1
+	/usr/bin/git init --bare --initial-branch=main "$caller_remote" >/dev/null 2>&1 || return 1
+	/usr/bin/git clone "$caller_remote" "$caller" >/dev/null 2>&1 || return 1
+	/usr/bin/git -C "$caller" config user.email test@test.local || return 1
+	/usr/bin/git -C "$caller" config user.name Test || return 1
+	/usr/bin/git -C "$caller" config commit.gpgsign false || return 1
+	printf 'unrelated caller repository\n' >"${caller}/README.md"
+	/usr/bin/git -C "$caller" add README.md || return 1
+	/usr/bin/git -C "$caller" commit -q -m root || return 1
+	/usr/bin/git -C "$caller" push -q origin main || return 1
 	printf '%s\n' "$base_sha" >"${fixture_root}/base.sha"
 	printf '%s\n' "$head_sha" >"${fixture_root}/head.sha"
-	printf '%s\n' "$fixture_dir"
+	printf '%s\n' "$remote_repo" >"${fixture_root}/remote.url"
+	printf '%s\n' "$caller"
 	return 0
 }
 
 test_prospective_todo_merge_guard() {
-	local fixture_dir="" fixture_root="" base_sha="" head_sha="" output="" rc=0 objects_before="" objects_after=""
+	local fixture_dir="" fixture_root="" base_sha="" head_sha="" remote_url="" output="" rc=0 objects_before="" objects_after=""
 	local cleanup_rc=0 environment_rc=0 isolation_rc=0 storage_before="" storage_after="" absent_before=0 absent_after=0
 	fixture_dir=$(create_prospective_fixture collision)
 	base_sha=$(<"${fixture_dir}/base.sha")
@@ -1330,20 +1348,33 @@ test_prospective_todo_merge_guard() {
 	environment_rc=0
 	isolation_rc=0
 	fixture_dir=$(create_prospective_fetch_fixture) || return 0
-	fixture_root="${fixture_dir%/work}"
+	fixture_root="${fixture_dir%/caller}"
 	base_sha=$(<"${fixture_root}/base.sha")
 	head_sha=$(<"${fixture_root}/head.sha")
+	remote_url=$(<"${fixture_root}/remote.url")
 	storage_before=$(prospective_git_storage_digest "$fixture_dir")
 	if /usr/bin/git -C "$fixture_dir" cat-file -e "${head_sha}^{commit}" 2>/dev/null; then absent_before=1; fi
-	run_prospective_todo_guard "$fixture_dir" "$base_sha" "$head_sha" live >/dev/null || rc=$?
+	run_prospective_todo_guard "$fixture_dir" "$base_sha" "$head_sha" live "$remote_url" >/dev/null || rc=$?
 	storage_after=$(prospective_git_storage_digest "$fixture_dir")
 	if /usr/bin/git -C "$fixture_dir" cat-file -e "${head_sha}^{commit}" 2>/dev/null; then absent_after=1; fi
 	prospective_contexts_clean "$fixture_dir" || cleanup_rc=$?
 	prospective_hostile_git_environment_clean "$fixture_dir" || environment_rc=$?
-	[[ "$rc" -eq 0 && "$cleanup_rc" -eq 0 && "$environment_rc" -eq 0 && \
-		"$absent_before" -eq 0 && "$absent_after" -eq 0 && \
+	[[ "$rc" -eq 0 && "$cleanup_rc" -eq 0 && "$environment_rc" -eq 0 &&
+		"$absent_before" -eq 0 && "$absent_after" -eq 0 &&
 		"$storage_before" == "$storage_after" ]] || isolation_rc=1
-	print_result "prospective TODO: missing PR objects fetch only into cleaned isolated context" "$isolation_rc"
+	print_result "prospective TODO: explicit target objects fetch from an unrelated caller repository" "$isolation_rc"
+
+	rc=0
+	output=$(run_prospective_todo_guard "$fixture_dir" "$base_sha" "$head_sha" live "$remote_url" 'otherorg/otherrepo') || rc=$?
+	print_result "prospective TODO: target repository mismatch fails closed" \
+		"$([[ "$rc" -ne 0 && "$output" == *"does not match the explicit target"* ]] && printf '0' || printf '1')" \
+		"output=$output"
+
+	rc=0
+	output=$(run_prospective_todo_guard "$fixture_dir" "$base_sha" "$head_sha" stub 'https://attacker.invalid/testorg/testrepo.git') || rc=$?
+	print_result "prospective TODO: target remote URL mismatch fails closed" \
+		"$([[ "$rc" -ne 0 && "$output" == *"remote URL does not match the explicit target"* ]] && printf '0' || printf '1')" \
+		"output=$output"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh
+++ b/.agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh
@@ -30,7 +30,10 @@
 #   11. rulesets_non_matching_branch — non-default ruleset ignored → return 0
 #   12. default_branch_api_error — can't get default branch → return 1 (fail-closed)
 #   13. branch_protection_api_error — can't get branch protection → return 1 (fail-closed)
-#   14. checks_api_error — can't get REST check-runs → return 1 (fail-closed)
+#   14. private_plan_unavailable — known private-plan response plus no active
+#       required rulesets resolves to no configured checks
+#   15. private_plan_ruleset_error — ruleset lookup still fails closed
+#   16. checks_api_error — can't get REST check-runs → return 1 (fail-closed)
 #
 # Strategy: source shared-gh-wrappers-checks.sh for `gh_pr_check_runs_rest`,
 # extract _check_required_checks_passing from pulse-merge-process.sh, eval it,
@@ -114,7 +117,8 @@ setup_test_env() {
 #
 # Mode env vars:
 #   MOCK_REPO_MODE     — ok | error
-#   MOCK_BP_MODE       — three_required | no_required | not_found | error
+#   MOCK_BP_MODE       — three_required | no_required | not_found |
+#                        private_plan_unavailable | error
 #   MOCK_RULESETS_MODE — none | active_required | active_required_star |
 #                        active_required_plain_branch |
 #                        active_required_excluded_default |
@@ -146,33 +150,42 @@ apply_jq() {
 
 # Match: gh api repos/SLUG/rulesets/ID (repository ruleset detail)
 if [[ "$1" == "api" && "$2" == repos/* && "$*" == *"/rulesets/"* ]]; then
+	branch_identity='"id":101,"target":"branch","enforcement":"active"'
 	case "${MOCK_RULESETS_MODE:-none}" in
 	active_required)
-		apply_jq '{"conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"]}},"rules":[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"review-bot-gate"}]}}]}' "$@"
+		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":{\"include\":[\"~DEFAULT_BRANCH\"]}},\"rules\":[{\"type\":\"required_status_checks\",\"parameters\":{\"required_status_checks\":[{\"context\":\"review-bot-gate\"}]}}]}" "$@"
 		exit 0
 		;;
 	active_required_star)
-		apply_jq '{"conditions":{"ref_name":{"include":["*"]}},"rules":[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"review-bot-gate"}]}}]}' "$@"
+		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":{\"include\":[\"*\"]}},\"rules\":[{\"type\":\"required_status_checks\",\"parameters\":{\"required_status_checks\":[{\"context\":\"review-bot-gate\"}]}}]}" "$@"
 		exit 0
 		;;
 	active_required_plain_branch)
-		apply_jq '{"conditions":{"ref_name":{"include":["main"]}},"rules":[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"review-bot-gate"}]}}]}' "$@"
+		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":{\"include\":[\"main\"]}},\"rules\":[{\"type\":\"required_status_checks\",\"parameters\":{\"required_status_checks\":[{\"context\":\"review-bot-gate\"}]}}]}" "$@"
 		exit 0
 		;;
 	active_required_excluded_default)
-		apply_jq '{"conditions":{"ref_name":{"include":["*"],"exclude":["main"]}},"rules":[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"review-bot-gate"}]}}]}' "$@"
+		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":{\"include\":[\"*\"],\"exclude\":[\"main\"]}},\"rules\":[{\"type\":\"required_status_checks\",\"parameters\":{\"required_status_checks\":[{\"context\":\"review-bot-gate\"}]}}]}" "$@"
 		exit 0
 		;;
 	active_required_other_branch)
-		apply_jq '{"conditions":{"ref_name":{"include":["refs/heads/release"]}},"rules":[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"review-bot-gate"}]}}]}' "$@"
+		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":{\"include\":[\"refs/heads/release\"]}},\"rules\":[{\"type\":\"required_status_checks\",\"parameters\":{\"required_status_checks\":[{\"context\":\"review-bot-gate\"}]}}]}" "$@"
 		exit 0
 		;;
 	detail_error)
 		printf 'gh: mock ruleset detail API error\n' >&2
 		exit 1
 		;;
+	detail_malformed)
+		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":null},\"rules\":\"invalid\"}" "$@"
+		exit 0
+		;;
+	detail_mismatch)
+		apply_jq '{"id":202,"target":"tag","enforcement":"active","conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"]}},"rules":[]}' "$@"
+		exit 0
+		;;
 	*)
-		apply_jq '{"conditions":{"ref_name":{"include":[]}},"rules":[]}' "$@"
+		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":{\"include\":[]}},\"rules\":[]}" "$@"
 		exit 0
 		;;
 	esac
@@ -186,8 +199,20 @@ if [[ "$1" == "api" && "$2" == repos/* && "$*" == *"/rulesets"* ]]; then
 		exit 0
 		;;
 	active_required | active_required_star | active_required_plain_branch | \
-		active_required_excluded_default | active_required_other_branch | detail_error)
-		apply_jq '[{"id":101,"enforcement":"active"}]' "$@"
+	active_required_excluded_default | active_required_other_branch | detail_error | detail_malformed | detail_mismatch)
+		apply_jq '[{"id":101,"enforcement":"active","target":"branch"}]' "$@"
+		exit 0
+		;;
+	malformed)
+		apply_jq 'null' "$@"
+		exit 0
+		;;
+	malformed_entry)
+		apply_jq '[{"id":"","enforcement":"active","target":"branch"}]' "$@"
+		exit 0
+		;;
+	active_tag)
+		apply_jq '[{"id":101,"enforcement":"active","target":"tag"}]' "$@"
 		exit 0
 		;;
 	error)
@@ -230,6 +255,10 @@ if [[ "$1" == "api" && "$*" == *"protection/required_status_checks"* ]]; then
 		;;
 	not_found)
 		printf 'gh: HTTP 404: Not Found\n' >&2
+		exit 1
+		;;
+	private_plan_unavailable)
+		printf 'gh: Upgrade to GitHub Pro or make this repository public to enable this feature. (HTTP 403)\n' >&2
 		exit 1
 		;;
 	error)
@@ -574,6 +603,55 @@ test_branch_protection_api_error() {
 	return 0
 }
 
+test_private_plan_unavailable_without_required_rulesets() {
+	reset_logs
+	export MOCK_BP_MODE="private_plan_unavailable"
+	export MOCK_RULESETS_MODE="none"
+	assert_returns 0 "private-plan classic protection unavailable + no required rulesets → allowed"
+	assert_log_contains "private-plan unavailable (HTTP 403)" \
+		"private-plan unavailable: classified narrowly"
+	assert_log_contains "empty contexts" \
+		"private-plan unavailable: successful ruleset lookup proves no configured checks"
+	return 0
+}
+
+test_private_plan_unavailable_ruleset_error() {
+	reset_logs
+	export MOCK_BP_MODE="private_plan_unavailable"
+	export MOCK_RULESETS_MODE="error"
+	assert_returns 1 "private-plan classic protection unavailable + ruleset API error → blocked"
+	assert_log_contains "rulesets list failed" \
+		"private-plan unavailable: ruleset API error remains fail-closed"
+	return 0
+}
+
+test_private_plan_unavailable_malformed_rulesets() {
+	local mode=""
+	for mode in malformed malformed_entry detail_malformed detail_mismatch; do
+		reset_logs
+		export MOCK_BP_MODE="private_plan_unavailable"
+		export MOCK_RULESETS_MODE="$mode"
+		assert_returns 1 "private-plan classic protection unavailable + ${mode} rulesets → blocked"
+		assert_log_contains "parse failed" \
+			"private-plan unavailable: ${mode} ruleset response remains fail-closed"
+	done
+	return 0
+}
+
+test_private_plan_unavailable_ignores_non_branch_rulesets() {
+	reset_logs
+	export MOCK_BP_MODE="private_plan_unavailable"
+	export MOCK_RULESETS_MODE="active_tag"
+	assert_returns 0 "private-plan classic protection unavailable + active tag ruleset → allowed"
+	if grep -Fq '/rulesets/101' "$GH_CALL_LOG"; then
+		print_result "private-plan unavailable: non-branch ruleset detail is not queried" 1 \
+			"gh calls: $(cat "$GH_CALL_LOG")"
+	else
+		print_result "private-plan unavailable: non-branch ruleset detail is not queried" 0
+	fi
+	return 0
+}
+
 test_rollup_api_error() {
 	reset_logs
 	export MOCK_REPO_MODE="ok"
@@ -609,6 +687,10 @@ main() {
 	test_rulesets_non_matching_branch_ignored
 	test_default_branch_api_error
 	test_branch_protection_api_error
+	test_private_plan_unavailable_without_required_rulesets
+	test_private_plan_unavailable_ruleset_error
+	test_private_plan_unavailable_malformed_rulesets
+	test_private_plan_unavailable_ignores_non_branch_rulesets
 	test_rollup_api_error
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -124,21 +124,22 @@ apply_jq() {
 }
 
 if [[ "$1" == "api" && "$2" == repos/* && "$*" == *"/rulesets/"* ]]; then
+	branch_identity='"id":101,"target":"branch","enforcement":"active"'
 	case "${MOCK_GH_MODE:-all_pass}" in
 	ruleset_review_only_missing | ruleset_review_only_approved | ruleset_review_latest_changes_requested | ruleset_review_paginated_approved | ruleset_review_author_only | ruleset_review_malformed_response | ruleset_review_malformed_element | ruleset_review_fetch_error)
-		apply_jq '{"conditions":{"ref_name":{"include":["refs/heads/main"]}},"rules":[{"type":"pull_request","parameters":{"required_approving_review_count":1}}]}' "$@"
+		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":{\"include\":[\"refs/heads/main\"]}},\"rules\":[{\"type\":\"pull_request\",\"parameters\":{\"required_approving_review_count\":1}}]}" "$@"
 		;;
 	ruleset_mixed_review_status)
-		apply_jq '{"conditions":{"ref_name":{"include":["refs/heads/main"]}},"rules":[{"type":"pull_request","parameters":{"required_approving_review_count":1}},{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"required-a"}]}}]}' "$@"
+		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":{\"include\":[\"refs/heads/main\"]}},\"rules\":[{\"type\":\"pull_request\",\"parameters\":{\"required_approving_review_count\":1}},{\"type\":\"required_status_checks\",\"parameters\":{\"required_status_checks\":[{\"context\":\"required-a\"}]}}]}" "$@"
 		;;
 	ruleset_review_zero)
-		apply_jq '{"conditions":{"ref_name":{"include":["refs/heads/main"]}},"rules":[{"type":"pull_request","parameters":{"required_approving_review_count":0}}]}' "$@"
+		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":{\"include\":[\"refs/heads/main\"]}},\"rules\":[{\"type\":\"pull_request\",\"parameters\":{\"required_approving_review_count\":0}}]}" "$@"
 		;;
 	ruleset_review_malformed_optional)
-		apply_jq '{"conditions":{"ref_name":"unexpected"},"rules":[{"type":"pull_request","parameters":"unexpected"}]}' "$@"
+		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":\"unexpected\"},\"rules\":[{\"type\":\"pull_request\",\"parameters\":\"unexpected\"}]}" "$@"
 		;;
 	*)
-		apply_jq '{"conditions":{"ref_name":{"include":[]}},"rules":[]}' "$@"
+		apply_jq "{${branch_identity},\"conditions\":{\"ref_name\":{\"include\":[]}},\"rules\":[]}" "$@"
 		;;
 	esac
 	exit 0
@@ -147,7 +148,7 @@ fi
 if [[ "$1" == "api" && "$2" == repos/* && "$*" == *"/rulesets"* ]]; then
 	case "${MOCK_GH_MODE:-all_pass}" in
 	ruleset_review_only_missing | ruleset_review_only_approved | ruleset_mixed_review_status | ruleset_review_zero | ruleset_review_malformed_optional | ruleset_review_latest_changes_requested | ruleset_review_paginated_approved | ruleset_review_author_only | ruleset_review_malformed_response | ruleset_review_malformed_element | ruleset_review_fetch_error)
-		apply_jq '[{"id":101,"enforcement":"active"}]' "$@"
+		apply_jq '[{"id":101,"enforcement":"active","target":"branch"}]' "$@"
 		;;
 	*)
 		apply_jq '[]' "$@"
@@ -719,7 +720,7 @@ test_ruleset_review_count_accepts_prefetched_rulesets_json() {
 	export MOCK_GH_MODE="ruleset_review_only_missing"
 	assert_ruleset_review_count_output "1" \
 		"pre-fetched rulesets JSON skips rulesets list fetch" \
-		'[{"id":101,"enforcement":"active"}]'
+		'[{"id":101,"enforcement":"active","target":"branch"}]'
 	assert_gh_call_absent "api repos/marcusquinn/aidevops/rulesets" \
 		"pre-fetched rulesets JSON avoids redundant rulesets list API call"
 	return 0


### PR DESCRIPTION
## Summary

- bind prospective merge object fetches to the explicit PR target repository instead of the caller worktree remote
- classify GitHub private-plan classic protection unavailability only after successful ruleset evidence
- preserve fail-closed behavior for repository mismatches and ruleset/API failures

## Verification

- `.agents/scripts/tests/test-full-loop-merge.sh`
- `bash .agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh`
- `.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh`
- ShellCheck on changed shell files

## Runtime Testing

Runtime-verified with isolated Git repositories and mocked GitHub API responses.

Resolves #28864

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.199 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 13m and 157,196 tokens on this as a headless worker.