### PR TITLE
GH#28997: Filter expected approval audit transitions

### DIFF
--- a/.agents/reference/gh-audit-log.md
+++ b/.agents/reference/gh-audit-log.md
@@ -227,7 +227,9 @@ The daily routine `r-gh-audit-scan` runs `gh-audit-anomaly-helper.sh scan`:
 
 The scanner:
 1. Reads entries since the last scan (tracked in `~/.aidevops/logs/gh-audit-scanner.state`)
-2. Filters entries with `suspicious[] | length > 0`
+2. Filters entries with `suspicious[] | length > 0`, excluding the exact
+   `approval-helper.sh` transition that removes `needs-maintainer-review` after
+   signed approval (the original audit entry remains unchanged)
 3. Files a GitHub issue on `marcusquinn/aidevops` with a summary table when anomalies are found
 
 To run the scanner manually:

--- a/.agents/scripts/gh-audit-anomaly-helper.sh
+++ b/.agents/scripts/gh-audit-anomaly-helper.sh
@@ -180,13 +180,29 @@ _cmd_scan_collect_anomalies() {
 	_sc_anomaly_entries=()
 
 	if command -v jq &>/dev/null; then
-		# Single jq pass: skip counted lines, emit only lines whose .suspicious array is non-empty.
+		# Single jq pass: skip counted lines, emit only actionable anomalies.
 		# Gemini feedback (GH#20145 PR #20153): avoid one-jq-per-line in while read loops.
+		# The approval helper intentionally removes needs-maintainer-review only after
+		# its signed approval checks pass. Keep that transition in the immutable log,
+		# but do not file a daily alert when its complete provenance and delta match.
 		local line
 		while IFS= read -r line; do
 			_sc_anomaly_entries+=("$line")
 		done < <(tail -n +"$((skip_count + 1))" "$log_file" \
-			| jq -c 'select(.suspicious | length > 0)' 2>/dev/null || true)
+			| jq -c '
+				select(.suspicious | length > 0)
+				# aidevops:trust-boundary — fail closed unless every approval transition field matches.
+				| select((
+					.op == "issue_edit"
+					and .caller_function == "_approval_apply_issue_lifecycle_updates"
+					and ((.caller_script // "") | endswith("/agents/scripts/approval-helper.sh")
+						or endswith("/.agents/scripts/approval-helper.sh"))
+					and .suspicious == ["protected_label_removed:needs-maintainer-review"]
+					and (.delta.labels_removed // []) == ["needs-maintainer-review"]
+					and (((.delta.labels_added // []) - ["auto-dispatch"]) | length == 0)
+					and ((.before.labels // []) | index("needs-maintainer-review") != null)
+					and ((.after.labels // []) | index("needs-maintainer-review") == null)
+				) | not)' 2>/dev/null || true)
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
+++ b/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for GH#28997: expected signed approval transitions remain
+# audited without generating daily anomaly issues.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/../gh-audit-anomaly-helper.sh"
+TEST_ROOT=""
+
+cleanup() {
+	[[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT" 2>/dev/null || true
+	return 0
+}
+trap cleanup EXIT
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+TEST_ROOT="$(mktemp -d -t aidevops-gh-anomaly-XXXXXX)"
+LOG_FILE="${TEST_ROOT}/gh-audit.log"
+
+cat >"$LOG_FILE" <<'EOF'
+{"ts":"2026-07-31T00:00:00Z","op":"issue_edit","repo":"example/repo","number":1,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","before":{"labels":["needs-maintainer-review"]},"after":{"labels":["auto-dispatch"]},"delta":{"labels_removed":["needs-maintainer-review"],"labels_added":["auto-dispatch"]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
+{"ts":"2026-07-31T00:01:00Z","op":"issue_edit","repo":"example/repo","number":2,"caller_script":"/workspace/.agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","before":{"labels":["needs-maintainer-review"]},"after":{"labels":[]},"delta":{"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
+{"ts":"2026-07-31T00:02:00Z","op":"issue_edit","repo":"example/repo","number":3,"caller_script":"/tmp/close-issue.sh","caller_function":"main","before":{"labels":["status:in-review"]},"after":{"labels":["status:done"]},"delta":{"labels_removed":["status:in-review"],"labels_added":["status:done"]},"suspicious":["protected_label_removed:status:in-review"]}
+{"ts":"2026-07-31T00:03:00Z","op":"issue_edit","repo":"example/repo","number":4,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","before":{"labels":["needs-maintainer-review"]},"after":{"labels":["auto-dispatch"]},"delta":{"labels_removed":["needs-maintainer-review"],"labels_added":["auto-dispatch"]},"suspicious":["protected_label_removed:needs-maintainer-review","body_delta_pct=-100"]}
+EOF
+
+output=$(GH_AUDIT_LOG_FILE="$LOG_FILE" GH_ANOMALY_STATE_FILE="${TEST_ROOT}/state.json" \
+	GH_AUDIT_QUIET=true "$HELPER" scan --all --dry-run)
+
+[[ "$output" == *"**Anomalies found:** 2"* ]] || fail "expected transitions were not excluded exactly"
+[[ "$output" == *"| #3 |"* ]] || fail "unexpected lifecycle transition was hidden"
+[[ "$output" == *"| #4 |"* ]] || fail "approval transition with an additional signal was hidden"
+[[ "$output" != *"| #1 |"* && "$output" != *"| #2 |"* ]] || fail "expected approval transition remained actionable"
+
+printf 'PASS: expected approval transitions are retained in the log but excluded from alerts\n'


### PR DESCRIPTION
## Summary

Keep signed approval label removals in the immutable audit log while excluding only exact expected transitions from daily anomaly alerts; add fail-closed regression coverage and document the behavior.

## Files Changed

.agents/reference/gh-audit-log.md, .agents/scripts/gh-audit-anomaly-helper.sh, .agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — shellcheck; targeted anomaly scanner regression; production-log replay reduced the reported window from 25 findings to the one non-approval transition

Resolves #28997


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.199 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 4m and 105,015 tokens on this as a headless worker.