### PR TITLE
GH#28855: scope canonical Git guard to managed repositories

### DIFF
--- a/.agents/scripts/canonical_git_repository.py
+++ b/.agents/scripts/canonical_git_repository.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -47,6 +48,82 @@ def git_output(real_git_path: str, cwd: str, *args: str) -> str:
     return result.stdout.strip() if result.returncode == 0 else ""
 
 
+def _repos_file() -> Path:
+    configured = os.environ.get("AIDEVOPS_REPOS_FILE") or os.environ.get(
+        "AIDEVOPS_REPOS_JSON"
+    )
+    return Path(configured or "~/.config/aidevops/repos.json").expanduser()
+
+
+def _registered_roots() -> list[Path]:
+    try:
+        payload = json.loads(_repos_file().read_text(encoding="utf-8"))
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    entries = payload.get("initialized_repos", [])
+    if not isinstance(entries, list):
+        return []
+    roots: list[Path] = []
+    for entry in entries:
+        if not isinstance(entry, dict) or not entry.get("path"):
+            continue
+        try:
+            roots.append(Path(str(entry["path"])).expanduser().resolve())
+        except (OSError, RuntimeError, ValueError):
+            continue
+    return roots
+
+
+def _is_managed_root(repo_root: str) -> bool:
+    root = Path(repo_root).resolve()
+    return (root / ".aidevops.json").is_file() or root in _registered_roots()
+
+
+def _is_registered_common_dir(common_dir: str) -> bool:
+    common = Path(common_dir).resolve()
+    for root in _registered_roots():
+        dot_git = root / ".git"
+        if dot_git.is_dir() and dot_git.resolve() == common:
+            return True
+        if not dot_git.is_file():
+            continue
+        try:
+            marker = dot_git.read_text(encoding="utf-8").strip()
+            if not marker.startswith("gitdir:"):
+                continue
+            target = Path(marker.split(":", 1)[1].strip()).expanduser()
+            if not target.is_absolute():
+                target = root / target
+            if target.resolve() == common:
+                return True
+        except (OSError, RuntimeError, ValueError):
+            continue
+    return False
+
+
+def _has_worktree_override(git_prefix: list[str]) -> bool:
+    return bool(
+        os.environ.get("GIT_WORK_TREE")
+        or "--work-tree" in git_prefix
+        or any(value.startswith("--work-tree=") for value in git_prefix)
+    )
+
+
+def _linked_worktree_root(git_dir: str) -> Path | None:
+    metadata_dir = Path(git_dir).resolve()
+    try:
+        marker = (metadata_dir / "gitdir").read_text(encoding="utf-8").strip()
+        marker_path = Path(marker).expanduser()
+        if not marker_path.is_absolute():
+            marker_path = metadata_dir / marker_path
+        marker_path = marker_path.resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return marker_path.parent if marker_path.name == ".git" else None
+
+
 def is_canonical(real_git_path: str, cwd: str, git_prefix: list[str]) -> bool:
     git_dir = git_output(
         real_git_path,
@@ -64,8 +141,44 @@ def is_canonical(real_git_path: str, cwd: str, git_prefix: list[str]) -> bool:
         "--path-format=absolute",
         "--git-common-dir",
     )
-    return bool(
-        git_dir
-        and common_dir
-        and os.path.realpath(git_dir) == os.path.realpath(common_dir)
+    repo_root = git_output(
+        real_git_path,
+        cwd,
+        *git_prefix,
+        "rev-parse",
+        "--path-format=absolute",
+        "--show-toplevel",
     )
+    canonical_common_dir = os.path.realpath(common_dir) if common_dir else ""
+    canonical_git_dir = os.path.realpath(git_dir) if git_dir else ""
+    configured_worktree = git_output(
+        real_git_path,
+        cwd,
+        *git_prefix,
+        "config",
+        "--path",
+        "--get",
+        "core.worktree",
+    )
+    if _has_worktree_override(git_prefix):
+        pass
+    elif configured_worktree:
+        worktree_path = Path(configured_worktree).expanduser()
+        if not worktree_path.is_absolute():
+            worktree_path = Path(canonical_common_dir) / worktree_path
+        repo_root = str(worktree_path.resolve())
+    elif (
+        canonical_git_dir == canonical_common_dir
+        and os.path.basename(canonical_common_dir) == ".git"
+    ):
+        repo_root = os.path.dirname(canonical_common_dir)
+    if not git_dir or not common_dir or not repo_root:
+        return False
+    if canonical_git_dir == canonical_common_dir:
+        return _is_managed_root(repo_root) or _is_registered_common_dir(
+            canonical_common_dir
+        )
+    linked_root = _linked_worktree_root(canonical_git_dir)
+    if linked_root and linked_root == Path(repo_root).resolve():
+        return False
+    return _is_managed_root(repo_root)

--- a/.agents/scripts/secret-helper.sh
+++ b/.agents/scripts/secret-helper.sh
@@ -335,7 +335,10 @@ cmd_set() {
 	if has_gopass; then
 		local gopass_output
 		if ! gopass_output=$(printf '%s' "$value" | gopass insert --force "${GOPASS_PREFIX}/${name}" 2>&1); then
-			if [[ "$gopass_output" == *"GPG"* || "$gopass_output" == *"gpg"* ]]; then
+			if [[ "$gopass_output" == *"BLOCKED by canonical Git guard"* ]]; then
+				print_error "Failed to store $name in gopass because the canonical Git guard blocked the password-store update"
+				printf '  %s\n' "$gopass_output" >&2
+			elif [[ "$gopass_output" == *"GPG"* || "$gopass_output" == *"gpg"* ]]; then
 				print_error "Failed to store $name in gopass (GPG error)"
 			elif [[ "$gopass_output" == *"not initialized"* ]]; then
 				print_error "Failed to store $name in gopass (store not initialized)"

--- a/.agents/scripts/tests/test-canonical-git-command-guard.sh
+++ b/.agents/scripts/tests/test-canonical-git-command-guard.sh
@@ -11,6 +11,10 @@ TEST_ROOT=$(mktemp -d)
 trap 'rm -rf "$TEST_ROOT"' EXIT
 REPO="${TEST_ROOT}/repo"
 LINKED="${TEST_ROOT}/linked"
+PASSWORD_REPO="${TEST_ROOT}/password-store"
+MARKED_REPO="${TEST_ROOT}/marked-repo"
+SEPARATE_REPO="${TEST_ROOT}/separate-repo"
+SEPARATE_GIT_DIR="${TEST_ROOT}/separate-repo-git"
 TESTS=0
 FAILURES=0
 
@@ -42,6 +46,23 @@ printf 'seed\n' >"${REPO}/README.md"
 git -C "$REPO" add README.md
 git -C "$REPO" commit -q -m seed
 INITIAL_HEAD=$(git -C "$REPO" rev-parse HEAD)
+REPOS_FILE="${TEST_ROOT}/repos.json"
+printf '{"initialized_repos":[{"path":"%s"},{"path":"%s"}]}\n' \
+	"$REPO" "$SEPARATE_REPO" >"$REPOS_FILE"
+export AIDEVOPS_REPOS_FILE="$REPOS_FILE"
+
+mkdir -p "$PASSWORD_REPO"
+git -C "$PASSWORD_REPO" init -q -b main
+printf 'encrypted fixture\n' >"${PASSWORD_REPO}/test-secret.gpg"
+
+mkdir -p "$MARKED_REPO"
+git -C "$MARKED_REPO" init -q -b main
+printf '{}\n' >"${MARKED_REPO}/.aidevops.json"
+printf 'managed fixture\n' >"${MARKED_REPO}/managed.txt"
+
+mkdir -p "$SEPARATE_REPO"
+git init -q -b main --separate-git-dir "$SEPARATE_GIT_DIR" "$SEPARATE_REPO"
+printf '{}\n' >"${SEPARATE_REPO}/.aidevops.json"
 
 assert_blocked() {
 	local name="$1"
@@ -124,6 +145,33 @@ assert_blocked "blocks canonical symbolic-ref unknown options" "git symbolic-ref
 assert_blocked "blocks canonical symbolic-ref without a ref" "git symbolic-ref --short"
 assert_blocked "blocks canonical symbolic-ref option terminator" "git symbolic-ref -- refs/remotes/origin/HEAD"
 assert_blocked "blocks canonical symbolic-ref second ref after option terminator" "git symbolic-ref -- HEAD refs/heads/safety/example"
+assert_blocked "blocks mutation in a repository with an aidevops project marker" \
+	"git -C '$MARKED_REPO' add managed.txt"
+assert_blocked "blocks git-dir-only mutation targeting a managed canonical repository" \
+	"git -C '$PASSWORD_REPO' --git-dir='$REPO/.git' update-ref refs/heads/blocked '$INITIAL_HEAD'"
+assert_blocked "blocks git-dir-only mutation targeting a registered separate Git directory" \
+	"git -C '$PASSWORD_REPO' --git-dir='$SEPARATE_GIT_DIR' update-ref refs/heads/blocked '$INITIAL_HEAD'"
+assert_blocked "blocks an unrelated Git directory from mutating a managed worktree" \
+	"git --git-dir='$PASSWORD_REPO/.git' --work-tree='$MARKED_REPO' reset --hard"
+assert_allowed "allows gopass-style Git mutation in an unrelated password store" "$REPO" \
+	"git -C '$PASSWORD_REPO' add test-secret.gpg"
+if (cd "$REPO" && env PATH="${SCRIPT_DIR}:/usr/bin:/bin" "$SHIM" -C "$PASSWORD_REPO" add test-secret.gpg); then
+	if git -C "$PASSWORD_REPO" diff --cached --quiet -- test-secret.gpg; then
+		fail "PATH shim permits unrelated password-store mutation"
+	else
+		pass "PATH shim permits unrelated password-store mutation"
+	fi
+else
+	fail "PATH shim permits unrelated password-store mutation"
+fi
+printf '{"initialized_repos":null}\n' >"$REPOS_FILE"
+assert_allowed "malformed managed-repository registry does not intercept unrelated Git" "$REPO" \
+	"git -C '$PASSWORD_REPO' add test-secret.gpg"
+printf '{"initialized_repos":[{"path":"~aidevops-user-that-does-not-exist/repo"}]}\n' >"$REPOS_FILE"
+assert_allowed "invalid managed-repository path does not intercept unrelated Git" "$REPO" \
+	"git -C '$PASSWORD_REPO' add test-secret.gpg"
+printf '{"initialized_repos":[{"path":"%s"},{"path":"%s"}]}\n' \
+	"$REPO" "$SEPARATE_REPO" >"$REPOS_FILE"
 
 if [[ "$(git -C "$REPO" symbolic-ref --short HEAD)" == "main" ]] &&
 	[[ "$(git -C "$REPO" rev-parse HEAD)" == "$INITIAL_HEAD" ]] &&
@@ -156,12 +204,15 @@ PROSPECTIVE_REPO="${PROSPECTIVE_CONTEXT}/repository.git"
 git -C "$PROSPECTIVE_CONTEXT" init --bare -q repository.git
 assert_allowed_with_temp_root "allows the pinned merge-tree probe in its isolated bare temp repo" \
 	"$PROSPECTIVE_REPO" "git merge-tree --write-tree '$INITIAL_HEAD' '$INITIAL_HEAD'"
-assert_blocked "blocks unrelated writes in the isolated bare temp repo" \
-	"git -C '$PROSPECTIVE_REPO' update-ref refs/heads/main '$INITIAL_HEAD'"
+assert_allowed "allows unrelated writes in an unmanaged isolated bare temp repo" \
+	"$REPO" "git -C '$PROSPECTIVE_REPO' update-ref refs/heads/main '$INITIAL_HEAD'"
 
 git -C "$REPO" worktree add -q -b feature/example "$LINKED"
 assert_allowed "allows normal Git mutation in linked worktree" "$LINKED" "git switch -c feature/linked-child"
 assert_allowed "allows rev-list query in linked worktree" "$LINKED" "git rev-list --count HEAD"
+LINKED_GIT_DIR=$(git -C "$LINKED" rev-parse --path-format=absolute --git-dir)
+assert_blocked "blocks linked-worktree metadata from mutating the canonical worktree" \
+	"git --git-dir='$LINKED_GIT_DIR' --work-tree='$REPO' reset --hard"
 
 git -C "$REPO" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/develop
 DEFAULT_BRANCH=$(

--- a/.agents/scripts/tests/test-git-safety-guard.sh
+++ b/.agents/scripts/tests/test-git-safety-guard.sh
@@ -74,6 +74,7 @@ setup_test_repo() {
 	printf '# TODO\n' >"${TEST_ROOT}/TODO.md"
 	printf 'tasks\n' >"${TEST_ROOT}/todo/tasks.md"
 	printf 'code\n' >"${TEST_ROOT}/src/foo.ts"
+	printf '{}\n' >"${TEST_ROOT}/.aidevops.json"
 	git -C "$TEST_ROOT" add .
 	git -C "$TEST_ROOT" commit -m "test: seed repo" >/dev/null 2>&1
 	return 0


### PR DESCRIPTION
## Summary

Resolve each Git invocation's target and apply canonical mutation policy only to repositories registered with aidevops or carrying .aidevops.json; add password-store regression coverage

## Files Changed

.agents/scripts/canonical_git_repository.py, .agents/scripts/tests/test-canonical-git-command-guard.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — python compile, canonical Git guard regression suite, and ShellCheck pass

Resolves #28855


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.199 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 5m and 95,956 tokens on this as a headless worker.