### PR TITLE
GH#28997: Harden verified audit anomaly exemptions

### DIFF
--- a/.agents/reference/gh-audit-log.md
+++ b/.agents/reference/gh-audit-log.md
@@ -221,7 +221,7 @@ gh-audit-log-helper.sh status
 
 The daily routine `r-gh-audit-scan` runs `gh-audit-anomaly-helper.sh scan`:
 
-```
+```text
 - [x] r-gh-audit-scan Scan gh-audit.log for anomalies repeat:daily(@09:00) run:scripts/gh-audit-anomaly-helper.sh scan
 ```
 
@@ -229,7 +229,8 @@ The scanner:
 1. Reads entries since the last scan (tracked in `~/.aidevops/logs/gh-audit-scanner.state`)
 2. Filters entries with `suspicious[] | length > 0`, excluding the exact
    `approval-helper.sh` transition that removes `needs-maintainer-review` after
-   signed approval (the original audit entry remains unchanged)
+   current-state V2 approval verification (the original audit entry remains
+   unchanged)
 3. Files a GitHub issue on `marcusquinn/aidevops` with a summary table when anomalies are found
 
 To run the scanner manually:

--- a/.agents/scripts/gh-audit-anomaly-helper.sh
+++ b/.agents/scripts/gh-audit-anomaly-helper.sh
@@ -38,6 +38,7 @@ readonly GH_ANOMALY_STATE_FILE_DEFAULT="${HOME}/.aidevops/logs/gh-audit-scanner.
 readonly GH_ANOMALY_LOG_DIR_DEFAULT="${HOME}/.aidevops/logs"
 readonly GH_ANOMALY_LOG_FILENAME="gh-audit.log"
 readonly GH_ANOMALY_DEFAULT_REPO="marcusquinn/aidevops"
+readonly GH_ANOMALY_NMR_LABEL="needs-maintainer-review"
 # Maximum anomaly entries to include in an issue (prevents overly large issues)
 readonly GH_ANOMALY_MAX_ISSUE_ENTRIES=20
 
@@ -156,8 +157,14 @@ _cmd_scan_parse_args() {
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
 		case "$_arg" in
-		--all) _sc_scan_all=1; shift ;;
-		--dry-run) _sc_dry_run=1; shift ;;
+		--all)
+			_sc_scan_all=1
+			shift
+			;;
+		--dry-run)
+			_sc_dry_run=1
+			shift
+			;;
 		--repo)
 			_sc_issue_repo="${2:-${GH_ANOMALY_DEFAULT_REPO}}"
 			shift 2
@@ -174,7 +181,7 @@ _cmd_scan_parse_args() {
 # Collect NDJSON entries with non-empty suspicious[] arrays into the
 # caller-scoped array _sc_anomaly_entries.
 # Args: log_file skip_count
-# Returns 0 always.
+# Returns 1 when jq cannot parse the scan window so the checkpoint is preserved.
 _cmd_scan_collect_anomalies() {
 	local log_file="$1" skip_count="$2"
 	_sc_anomaly_entries=()
@@ -185,31 +192,42 @@ _cmd_scan_collect_anomalies() {
 		# The approval helper intentionally removes needs-maintainer-review only after
 		# its signed approval checks pass. Keep that transition in the immutable log,
 		# but do not file a daily alert when its complete provenance and delta match.
-		local line
-		while IFS= read -r line; do
-			_sc_anomaly_entries+=("$line")
-		done < <(tail -n +"$((skip_count + 1))" "$log_file" \
-			| jq -c '
-				select(.suspicious | length > 0)
+		local line filtered_file
+		filtered_file="$(mktemp -t gh-audit-anomaly-filter.XXXXXX)" || {
+			_ga_warn "Could not create anomaly scan buffer"
+			return 1
+		}
+		if ! tail -n +"$((skip_count + 1))" "$log_file" |
+			jq -c --arg nmr "$GH_ANOMALY_NMR_LABEL" '
+				select(try ((.suspicious | length) > 0) catch true)
 				# aidevops:trust-boundary — fail closed unless every approval transition field matches.
-				| select((
+				| select((try (
 					.op == "issue_edit"
 					and .caller_function == "_approval_apply_issue_lifecycle_updates"
 					and ((.caller_script // "") | endswith("/agents/scripts/approval-helper.sh")
 						or endswith("/.agents/scripts/approval-helper.sh"))
-					and .suspicious == ["protected_label_removed:needs-maintainer-review"]
-					and (.delta.labels_removed // []) == ["needs-maintainer-review"]
+					and .flags.approval_verified == "v2-current-state"
+					and .suspicious == [("protected_label_removed:" + $nmr)]
+					and (.delta.labels_removed // []) == [$nmr]
 					and (((.delta.labels_added // []) - ["auto-dispatch"]) | length == 0)
-					and ((.before.labels // []) | index("needs-maintainer-review") != null)
-					and ((.after.labels // []) | index("needs-maintainer-review") == null)
-				) | not)' 2>/dev/null || true)
+					and ((.before.labels // []) | index($nmr) != null)
+					and ((.after.labels // []) | index($nmr) == null)
+				) catch false) | not)' >"$filtered_file" 2>/dev/null; then
+			rm -f "$filtered_file"
+			_ga_warn "Malformed audit NDJSON detected — checkpoint not advanced"
+			return 1
+		fi
+		while IFS= read -r line; do
+			_sc_anomaly_entries+=("$line")
+		done <"$filtered_file"
+		rm -f "$filtered_file"
 		return 0
 	fi
 
 	# Fallback without jq: substring-match the suspicious field.
 	local line line_num=0
 	while IFS= read -r line; do
-		line_num=$(( line_num + 1 ))
+		line_num=$((line_num + 1))
 		[[ -z "$line" ]] && continue
 		[[ "$line_num" -le "$skip_count" ]] && continue
 		if [[ "$line" == *'"suspicious":['* ]] && [[ "$line" != *'"suspicious":[]'* ]]; then
@@ -248,7 +266,7 @@ BODY
 			break
 		fi
 		_ga_format_anomaly_row "$entry"
-		included=$(( included + 1 ))
+		included=$((included + 1))
 	done
 
 	cat <<FOOTER
@@ -341,7 +359,7 @@ cmd_scan() {
 	start_line=0
 	[[ "$_sc_scan_all" -eq 0 ]] && start_line="$(_ga_read_last_line)"
 	skip_count="$start_line"
-	lines_to_scan=$(( total_lines - skip_count ))
+	lines_to_scan=$((total_lines - skip_count))
 
 	if [[ "$lines_to_scan" -le 0 ]]; then
 		_ga_info "No new entries since last scan (last_line=${start_line}, total=${total_lines})"
@@ -351,7 +369,10 @@ cmd_scan() {
 	_ga_info "Scanning ${lines_to_scan} entries (lines ${start_line}+1..${total_lines})"
 
 	local -a _sc_anomaly_entries=()
-	_cmd_scan_collect_anomalies "$log_file" "$skip_count"
+	if ! _cmd_scan_collect_anomalies "$log_file" "$skip_count"; then
+		_ga_warn "Audit scan aborted without updating state"
+		return 1
+	fi
 
 	local anomaly_count="${#_sc_anomaly_entries[@]}"
 	_ga_info "Found ${anomaly_count} anomalous entries"

--- a/.agents/scripts/gh-audit-log-helper.sh
+++ b/.agents/scripts/gh-audit-log-helper.sh
@@ -60,8 +60,8 @@ readonly GH_AUDIT_MAX_SIZE_MB_DEFAULT=10
 readonly GH_AUDIT_MAX_ROTATIONS_DEFAULT=10
 
 # Anomaly thresholds
-readonly GH_AUDIT_TITLE_SHRINK_PCT_THRESHOLD=50  # flag if title shrinks >50%
-readonly GH_AUDIT_BODY_WIPE_THRESHOLD=100          # flag if body goes to 0
+readonly GH_AUDIT_TITLE_SHRINK_PCT_THRESHOLD=50 # flag if title shrinks >50%
+readonly GH_AUDIT_BODY_WIPE_THRESHOLD=100       # flag if body goes to 0
 
 # Labels whose removal is always suspicious
 readonly GH_AUDIT_PROTECTED_LABELS=(
@@ -222,7 +222,7 @@ _gh_audit_delta_pct() {
 		echo "0"
 		return 0
 	fi
-	local delta=$(( (after - before) * 100 / before ))
+	local delta=$(((after - before) * 100 / before))
 	echo "$delta"
 	return 0
 }
@@ -369,9 +369,9 @@ _gh_audit_prune_rotations() {
 		return 0
 	fi
 
-	local to_delete=$(( count - max_rotations ))
+	local to_delete=$((count - max_rotations))
 	local i
-	for (( i = 0; i < to_delete; i++ )); do
+	for ((i = 0; i < to_delete; i++)); do
 		rm -f "${rotation_files[i]}" 2>/dev/null || true
 	done
 
@@ -395,15 +395,42 @@ _cmd_record_parse_args() {
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
 		case "$_arg" in
-		--op) _rr_op="${2:-}"; shift 2 ;;
-		--repo) _rr_repo="${2:-}"; shift 2 ;;
-		--number) _rr_number="${2:-}"; shift 2 ;;
-		--before-json) _rr_before_json="${2:-}"; shift 2 ;;
-		--after-json) _rr_after_json="${2:-}"; shift 2 ;;
-		--caller-script) _rr_caller_script="${2:-}"; shift 2 ;;
-		--caller-function) _rr_caller_function="${2:-}"; shift 2 ;;
-		--caller-line) _rr_caller_line="${2:-0}"; shift 2 ;;
-		--flags-json) _rr_flags_json="${2:-{}}"; shift 2 ;;
+		--op)
+			_rr_op="${2:-}"
+			shift 2
+			;;
+		--repo)
+			_rr_repo="${2:-}"
+			shift 2
+			;;
+		--number)
+			_rr_number="${2:-}"
+			shift 2
+			;;
+		--before-json)
+			_rr_before_json="${2:-}"
+			shift 2
+			;;
+		--after-json)
+			_rr_after_json="${2:-}"
+			shift 2
+			;;
+		--caller-script)
+			_rr_caller_script="${2:-}"
+			shift 2
+			;;
+		--caller-function)
+			_rr_caller_function="${2:-}"
+			shift 2
+			;;
+		--caller-line)
+			_rr_caller_line="${2:-0}"
+			shift 2
+			;;
+		--flags-json)
+			_rr_flags_json="${2:-}"
+			shift 2
+			;;
 		*)
 			_gh_audit_warn "Unknown argument to record: ${_arg} (ignored)"
 			shift
@@ -645,7 +672,7 @@ cmd_rotate() {
 
 	local size_bytes
 	size_bytes="$(_gh_audit_byte_count "$log_file")"
-	local max_size_bytes=$(( max_size_mb * 1048576 ))
+	local max_size_bytes=$((max_size_mb * 1048576))
 
 	if [[ "$size_bytes" -lt "$max_size_bytes" ]]; then
 		return 0

--- a/.agents/scripts/shared-gh-wrappers-safe-edit.sh
+++ b/.agents/scripts/shared-gh-wrappers-safe-edit.sh
@@ -146,11 +146,17 @@ _gh_audit_fetch_issue_state_json() {
 
 	[[ -z "$issue_num" || -z "$repo" ]] && echo "$empty" && return 0
 	[[ ! "$issue_num" =~ ^[0-9]+$ ]] && echo "$empty" && return 0
-	command -v jq &>/dev/null || { echo "$empty"; return 0; }
+	command -v jq &>/dev/null || {
+		echo "$empty"
+		return 0
+	}
 
 	local data
 	data=$(gh issue view "$issue_num" --repo "$repo" \
-		--json title,body,labels 2>/dev/null) || { echo "$empty"; return 0; }
+		--json title,body,labels 2>/dev/null) || {
+		echo "$empty"
+		return 0
+	}
 
 	jq -c '{
 		title_len: ((.title // "") | length),
@@ -173,11 +179,17 @@ _gh_audit_fetch_pr_state_json() {
 
 	[[ -z "$pr_num" || -z "$repo" ]] && echo "$empty" && return 0
 	[[ ! "$pr_num" =~ ^[0-9]+$ ]] && echo "$empty" && return 0
-	command -v jq &>/dev/null || { echo "$empty"; return 0; }
+	command -v jq &>/dev/null || {
+		echo "$empty"
+		return 0
+	}
 
 	local data
 	data=$(gh pr view "$pr_num" --repo "$repo" \
-		--json title,body,labels 2>/dev/null) || { echo "$empty"; return 0; }
+		--json title,body,labels 2>/dev/null) || {
+		echo "$empty"
+		return 0
+	}
 
 	jq -c '{
 		title_len: ((.title // "") | length),
@@ -204,6 +216,7 @@ _gh_audit_record_op() {
 	local op="$1" repo="$2" number="$3"
 	local before_json="$4" after_json="$5"
 	local caller_script="$6" caller_function="$7" caller_line="$8"
+	local flags_json="{}"
 
 	# Skip audit when number is unavailable or not an integer
 	[[ -z "$number" || ! "$number" =~ ^[0-9]+$ ]] && return 0
@@ -212,6 +225,17 @@ _gh_audit_record_op() {
 	local audit_helper
 	audit_helper="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/gh-audit-log-helper.sh"
 	[[ ! -x "$audit_helper" ]] && return 0
+	# aidevops:trust-boundary — caller provenance alone is spoofable. Record the
+	# exemption proof only after independently re-verifying the signed approval
+	# and authenticated actor authority against current GitHub state.
+	if [[ "$op" == "issue_edit" && "$caller_function" == "_approval_apply_issue_lifecycle_updates" ]] &&
+		command -v cmd_verify &>/dev/null; then
+		local approval_verification=""
+		approval_verification=$(cmd_verify issue "$number" "$repo" --require-authority 2>/dev/null) || approval_verification=""
+		if [[ "$approval_verification" == "VERIFIED" ]]; then
+			flags_json='{"approval_verified":"v2-current-state"}'
+		fi
+	fi
 
 	GH_AUDIT_QUIET=true "$audit_helper" record \
 		--op "$op" \
@@ -222,6 +246,7 @@ _gh_audit_record_op() {
 		--caller-script "${caller_script:-unknown}" \
 		--caller-function "${caller_function:-unknown}" \
 		--caller-line "${caller_line:-0}" \
+		--flags-json "$flags_json" \
 		2>/dev/null || true
 
 	return 0

--- a/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
+++ b/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 HELPER="${SCRIPT_DIR}/../gh-audit-anomaly-helper.sh"
+SAFE_EDIT_HELPER="${SCRIPT_DIR}/../shared-gh-wrappers-safe-edit.sh"
 TEST_ROOT=""
 
 cleanup() {
@@ -26,18 +27,65 @@ TEST_ROOT="$(mktemp -d -t aidevops-gh-anomaly-XXXXXX)"
 LOG_FILE="${TEST_ROOT}/gh-audit.log"
 
 cat >"$LOG_FILE" <<'EOF'
-{"ts":"2026-07-31T00:00:00Z","op":"issue_edit","repo":"example/repo","number":1,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","before":{"labels":["needs-maintainer-review"]},"after":{"labels":["auto-dispatch"]},"delta":{"labels_removed":["needs-maintainer-review"],"labels_added":["auto-dispatch"]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
-{"ts":"2026-07-31T00:01:00Z","op":"issue_edit","repo":"example/repo","number":2,"caller_script":"/workspace/.agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","before":{"labels":["needs-maintainer-review"]},"after":{"labels":[]},"delta":{"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
+{"ts":"2026-07-31T00:00:00Z","op":"issue_edit","repo":"example/repo","number":1,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"labels":["needs-maintainer-review"]},"after":{"labels":["auto-dispatch"]},"delta":{"labels_removed":["needs-maintainer-review"],"labels_added":["auto-dispatch"]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
+{"ts":"2026-07-31T00:01:00Z","op":"issue_edit","repo":"example/repo","number":2,"caller_script":"/workspace/.agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"labels":["needs-maintainer-review"]},"after":{"labels":[]},"delta":{"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
 {"ts":"2026-07-31T00:02:00Z","op":"issue_edit","repo":"example/repo","number":3,"caller_script":"/tmp/close-issue.sh","caller_function":"main","before":{"labels":["status:in-review"]},"after":{"labels":["status:done"]},"delta":{"labels_removed":["status:in-review"],"labels_added":["status:done"]},"suspicious":["protected_label_removed:status:in-review"]}
-{"ts":"2026-07-31T00:03:00Z","op":"issue_edit","repo":"example/repo","number":4,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","before":{"labels":["needs-maintainer-review"]},"after":{"labels":["auto-dispatch"]},"delta":{"labels_removed":["needs-maintainer-review"],"labels_added":["auto-dispatch"]},"suspicious":["protected_label_removed:needs-maintainer-review","body_delta_pct=-100"]}
+{"ts":"2026-07-31T00:03:00Z","op":"issue_edit","repo":"example/repo","number":4,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"labels":["needs-maintainer-review"]},"after":{"labels":["auto-dispatch"]},"delta":{"labels_removed":["needs-maintainer-review"],"labels_added":["auto-dispatch"]},"suspicious":["protected_label_removed:needs-maintainer-review","body_delta_pct=-100"]}
+{"ts":"2026-07-31T00:04:00Z","op":"issue_edit","repo":"example/repo","number":5,"caller_script":42,"caller_function":"_approval_apply_issue_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"labels":["needs-maintainer-review"]},"after":{"labels":[]},"delta":{"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
+{"ts":"2026-07-31T00:05:00Z","op":"issue_edit","repo":"example/repo","number":6,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","flags":{},"before":{"labels":["needs-maintainer-review"]},"after":{"labels":[]},"delta":{"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
 EOF
 
 output=$(GH_AUDIT_LOG_FILE="$LOG_FILE" GH_ANOMALY_STATE_FILE="${TEST_ROOT}/state.json" \
 	GH_AUDIT_QUIET=true "$HELPER" scan --all --dry-run)
 
-[[ "$output" == *"**Anomalies found:** 2"* ]] || fail "expected transitions were not excluded exactly"
+[[ "$output" == *"**Anomalies found:** 4"* ]] || fail "expected transitions were not excluded exactly"
 [[ "$output" == *"| #3 |"* ]] || fail "unexpected lifecycle transition was hidden"
 [[ "$output" == *"| #4 |"* ]] || fail "approval transition with an additional signal was hidden"
+[[ "$output" == *"| #5 |"* ]] || fail "malformed provenance was dropped instead of retained"
+[[ "$output" == *"| #6 |"* ]] || fail "unverified approval provenance was trusted"
 [[ "$output" != *"| #1 |"* && "$output" != *"| #2 |"* ]] || fail "expected approval transition remained actionable"
+
+MALFORMED_LOG="${TEST_ROOT}/malformed-audit.log"
+cat >"$MALFORMED_LOG" <<'EOF'
+{"suspicious":[]}
+not-json
+{"ts":"2026-07-31T00:06:00Z","op":"issue_edit","repo":"example/repo","number":9,"caller_function":"main","suspicious":["body_delta_pct=-100"]}
+EOF
+malformed_rc=0
+GH_AUDIT_LOG_FILE="$MALFORMED_LOG" GH_ANOMALY_STATE_FILE="${TEST_ROOT}/malformed-state.json" \
+	GH_AUDIT_QUIET=true "$HELPER" scan --all --dry-run >/dev/null 2>&1 || malformed_rc=$?
+[[ "$malformed_rc" -ne 0 ]] || fail "malformed NDJSON did not fail the scan closed"
+[[ ! -e "${TEST_ROOT}/malformed-state.json" ]] || fail "malformed NDJSON advanced the scan checkpoint"
+
+# shellcheck source=../shared-gh-wrappers-safe-edit.sh
+source "$SAFE_EDIT_HELPER"
+PROOF_LOG="${TEST_ROOT}/proof-audit.log"
+export GH_AUDIT_LOG_FILE="$PROOF_LOG"
+cmd_verify() {
+	printf 'VERIFIED\n'
+	return 0
+}
+_gh_audit_record_op \
+	"issue_edit" "example/repo" "7" \
+	'{"title_len":1,"body_len":1,"labels":["needs-maintainer-review"]}' \
+	'{"title_len":1,"body_len":1,"labels":[]}' \
+	"/runtime/agents/scripts/approval-helper.sh" \
+	"_approval_apply_issue_lifecycle_updates" "1"
+jq -e '.flags.approval_verified == "v2-current-state"' "$PROOF_LOG" >/dev/null ||
+	fail "successful current-state verification did not produce audit proof"
+
+cmd_verify() {
+	printf 'STALE_APPROVAL\n'
+	return 4
+}
+_gh_audit_record_op \
+	"issue_edit" "example/repo" "8" \
+	'{"title_len":1,"body_len":1,"labels":["needs-maintainer-review"]}' \
+	'{"title_len":1,"body_len":1,"labels":[]}' \
+	"/runtime/agents/scripts/approval-helper.sh" \
+	"_approval_apply_issue_lifecycle_updates" "1"
+jq -e -s '.[1].flags == {}' "$PROOF_LOG" >/dev/null ||
+	fail "failed approval verification produced trusted audit proof"
+unset GH_AUDIT_LOG_FILE
 
 printf 'PASS: expected approval transitions are retained in the log but excluded from alerts\n'


### PR DESCRIPTION
## Summary

Hardens the anomaly exemption merged in #28998 after exact-head review found fail-open trust and parser paths.

- records exemption proof only after fresh V2 signature and actor-authority verification
- repairs `--flags-json` parsing so proof reaches immutable audit entries
- requires exact proof, provenance, signal, and label deltas before suppressing an alert
- aborts malformed NDJSON scans without advancing their checkpoint
- adds regression coverage for malformed fields, malformed JSON, missing proof, and failed verification

## Verification

- targeted anomaly scanner regression
- 50 approval lifecycle tests
- ShellCheck and shfmt
- scoped `linters-local.sh`
- exact review-evidence bundle plus two independent security reviews

For #28997

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.199 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 25m and 274,801 tokens on this as a headless worker. Overall, 47m since this issue was created.
