### PR TITLE
GH#28995: clean terminal ci-repair worktrees safely

### DIFF
--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -1923,7 +1923,7 @@ _pc_cleanup_orphan_sibling_dirs() {
 	local repo_records_orphan
 	repo_records_orphan=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | [(.path // ""), (.slug // "")] | @tsv' "$repos_json" 2>/dev/null || printf '')
 
-	local rp_orphan repo_slug_orphan
+	local rp_orphan="" repo_slug_orphan=""
 	while IFS=$'\t' read -r rp_orphan repo_slug_orphan; do
 		[[ -z "$rp_orphan" ]] && continue
 		[[ -d "$rp_orphan/.git" || -f "$rp_orphan/.git" ]] || continue

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -238,6 +238,9 @@ _pc_terminal_pr_state_for_branch() {
 		return 0
 		;;
 	esac
+	# A directly associated OPEN PR outranks any numeric token embedded in the
+	# branch name. Only fall back when the local-only branch has no head PR.
+	[[ -z "$pr_state" ]] || return 1
 
 	pr_state=$(_pc_pr_state_for_branch_reference "$repo_slug" "$branch_name" 2>/dev/null) || return 1
 	case "$pr_state" in

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -141,6 +141,39 @@ _pc_pr_from_branch() {
 }
 
 #######################################
+# Resolve the state of a PR number embedded in a local repair/review branch.
+#
+# CI-repair workers commit on a local `repair/<hash>-pr-<N>-...` branch but
+# push back to the contributor's original PR branch. A head-branch lookup for
+# the local repair branch therefore cannot find that PR; the embedded number
+# is the durable lookup key.
+#
+# Args:
+#   $1 - repo slug (owner/repo)
+#   $2 - local branch name
+# Outputs: PR state (OPEN|CLOSED|MERGED)
+# Returns: 0 when a referenced PR state was verified, 1 otherwise
+#######################################
+_pc_pr_state_for_branch_reference() {
+	local repo_slug="$1"
+	local branch_name="$2"
+	local pr_number=""
+	local pr_state=""
+
+	[[ -n "$repo_slug" && -n "$branch_name" ]] || return 1
+	pr_number=$(_pc_pr_from_branch "$branch_name" 2>/dev/null) || return 1
+	[[ "$pr_number" =~ ^[0-9]+$ ]] || return 1
+	pr_state=$(gh pr view "$pr_number" --repo "$repo_slug" --json state --jq '.state // ""' 2>/dev/null) || return 1
+	case "$pr_state" in
+	OPEN | CLOSED | MERGED)
+		printf '%s\n' "$pr_state"
+		return 0
+		;;
+	esac
+	return 1
+}
+
+#######################################
 # Check whether a branch has at least one matching PR.
 #
 # `gh_pr_list` intentionally emits cached/output text with `printf '%s'`, so
@@ -160,6 +193,7 @@ _pc_branch_has_pr() {
 	local branch_name="$2"
 	local pr_state="$3"
 	local pr_number=""
+	local referenced_pr_state=""
 
 	if [[ -z "$repo_slug" || -z "$branch_name" || -z "$pr_state" ]]; then
 		return 1
@@ -169,6 +203,16 @@ _pc_branch_has_pr() {
 	if [[ -n "$pr_number" ]]; then
 		return 0
 	fi
+
+	# CI-repair branches are deliberately local-only, so their actual PR cannot
+	# be found by `--head`. Preserve open repairs and recognize terminal ones by
+	# the immutable PR number embedded in the branch name.
+	referenced_pr_state=$(_pc_pr_state_for_branch_reference "$repo_slug" "$branch_name" 2>/dev/null) || return 1
+	case "${pr_state}:${referenced_pr_state}" in
+	open:OPEN | closed:CLOSED | closed:MERGED | merged:MERGED | all:OPEN | all:CLOSED | all:MERGED)
+		return 0
+		;;
+	esac
 	return 1
 }
 
@@ -188,6 +232,14 @@ _pc_terminal_pr_state_for_branch() {
 
 	[[ -n "$repo_slug" && -n "$branch_name" ]] || return 1
 	pr_state=$(gh_pr_list --repo "$repo_slug" --head "$branch_name" --state all --limit 1 --json state --jq '.[0].state // empty' 2>/dev/null) || return 1
+	case "$pr_state" in
+	CLOSED | MERGED)
+		printf '%s\n' "$pr_state"
+		return 0
+		;;
+	esac
+
+	pr_state=$(_pc_pr_state_for_branch_reference "$repo_slug" "$branch_name" 2>/dev/null) || return 1
 	case "$pr_state" in
 	CLOSED | MERGED)
 		printf '%s\n' "$pr_state"
@@ -1438,6 +1490,8 @@ _pc_handle_terminal_worktree_archive() {
 	local repo_slug_age="${9:-}"
 	local audit_context
 	local terminal_pr_state=""
+	local terminal_pr_number=""
+	local terminal_recovery_path="branch-preserved-terminal-pr"
 	local guard_ok
 	guard_ok=$(printf 'cle%s' 'ar')
 
@@ -1449,8 +1503,12 @@ _pc_handle_terminal_worktree_archive() {
 	fi
 
 	if terminal_pr_state=$(_pc_terminal_pr_state_for_branch "$repo_slug_age" "$wt_branch_age"); then
-		audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "pr-${terminal_pr_state}" "$guard_ok" "$guard_ok" "$guard_ok" "branch-preserved-terminal-pr")
-		echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): removing ${wt_branch_age:-detached} — branch PR is ${terminal_pr_state}; state archived and branch preserved" >>"$LOGFILE"
+		terminal_pr_number=$(_pc_pr_from_branch "$wt_branch_age" 2>/dev/null || true)
+		if [[ -n "$terminal_pr_number" ]]; then
+			terminal_recovery_path="branch-preserved-terminal-pr-${terminal_pr_number}"
+		fi
+		audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "pr-${terminal_pr_state}" "$guard_ok" "$guard_ok" "$guard_ok" "$terminal_recovery_path")
+		echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): removing ${wt_branch_age:-detached} — branch PR ${terminal_pr_number:+#${terminal_pr_number} }is ${terminal_pr_state}; state archived and branch preserved" >>"$LOGFILE"
 		_pc_archive_and_remove_worktree_preserving_branch "$rp_age" "$wt_path_age" "$wt_branch_age" "$audit_context"
 		return $?
 	fi
@@ -1682,6 +1740,72 @@ _pc_is_registered_worktree_path() {
 }
 
 #######################################
+# Extract the PR number from the exact ci-repair sibling grammar emitted by
+# `_ci_repair_create_worktree` in pulse-merge-feedback.sh.
+#
+# Args:
+#   $1 - repo_name: canonical repo basename
+#   $2 - candidate_name: sibling basename
+# Outputs: embedded PR number
+# Returns: 0 only for a producer-compatible ci-repair name, 1 otherwise
+#######################################
+_pc_ci_repair_pr_from_sibling_name() {
+	local repo_name="$1"
+	local candidate_name="$2"
+	local generated_suffix=""
+	[[ -n "$repo_name" && -n "$candidate_name" ]] || return 1
+	case "$candidate_name" in
+	"${repo_name}-"*) generated_suffix="${candidate_name#"${repo_name}-"}" ;;
+	*) return 1 ;;
+	esac
+	if [[ "$generated_suffix" =~ ^[0-9a-f]{64}-ci-repair-pr([1-9][0-9]*)-[0-9a-f]{12}-[0-9a-f]{12}-a[1-9][0-9]*$ ]]; then
+		printf '%s\n' "${BASH_REMATCH[1]}"
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Validate an exact ci-repair sibling name without emitting its PR number.
+#
+# Args mirror _pc_ci_repair_pr_from_sibling_name.
+# Returns: 0 only for a producer-compatible ci-repair name, 1 otherwise
+#######################################
+_pc_ci_repair_sibling_name_allowed() {
+	local repo_name="$1"
+	local candidate_name="$2"
+	if _pc_ci_repair_pr_from_sibling_name "$repo_name" "$candidate_name" >/dev/null; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Preserve unregistered ci-repair siblings until their embedded PR is terminal.
+#
+# Non-ci-repair sibling families pass through unchanged. API failures and
+# OPEN/unknown PR states fail closed so Pass 4 cannot trash a live repair.
+#
+# Args:
+#   $1 - repo slug (owner/repo)
+#   $2 - canonical repo basename
+#   $3 - candidate sibling basename
+# Returns: 0 when generic or terminal ci-repair cleanup is allowed, 1 otherwise
+#######################################
+_pc_orphan_sibling_pr_state_allowed() {
+	local repo_slug="$1"
+	local repo_name="$2"
+	local candidate_name="$3"
+	local pr_number=""
+	pr_number=$(_pc_ci_repair_pr_from_sibling_name "$repo_name" "$candidate_name" 2>/dev/null) || return 0
+	[[ -n "$repo_slug" ]] || return 1
+	if _pc_pr_terminal_for_branch_archive "$pr_number" "$repo_slug" >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
 # Determine whether a sibling name is a worker/worktree-derived outlier.
 #
 # Args:
@@ -1693,6 +1817,9 @@ _pc_orphan_sibling_name_allowed() {
 	local repo_name="$1"
 	local candidate_name="$2"
 	[[ -n "$repo_name" && -n "$candidate_name" ]] || return 1
+	if _pc_ci_repair_sibling_name_allowed "$repo_name" "$candidate_name"; then
+		return 0
+	fi
 	case "$candidate_name" in
 	"${repo_name}-feature-"* | "${repo_name}-fix-"* | "${repo_name}-chore-"* | "${repo_name}-docs-"* | "${repo_name}-refactor-"* | "${repo_name}-bugfix-"* | "${repo_name}-issue-"* | "${repo_name}-gh"* | "${repo_name}-pr"* | "${repo_name}-t"[0-9]* | "${repo_name}-repair-"* | "${repo_name}-review-"* | "${repo_name}-release-"* | "${repo_name}-release-clone-"* | "${repo_name}.fix-"* | "${repo_name}.bugfix-"* | "${repo_name}.refactor-"*)
 		return 0
@@ -1790,11 +1917,11 @@ _pc_cleanup_orphan_sibling_dirs() {
 	local moved_count=0
 	[[ -f "$repos_json" ]] && command -v jq >/dev/null 2>&1 || { echo 0; return 0; }
 
-	local repo_paths_orphan
-	repo_paths_orphan=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path // ""' "$repos_json" 2>/dev/null || printf '')
+	local repo_records_orphan
+	repo_records_orphan=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | [(.path // ""), (.slug // "")] | @tsv' "$repos_json" 2>/dev/null || printf '')
 
-	local rp_orphan
-	while IFS= read -r rp_orphan; do
+	local rp_orphan repo_slug_orphan
+	while IFS=$'\t' read -r rp_orphan repo_slug_orphan; do
 		[[ -z "$rp_orphan" ]] && continue
 		[[ -d "$rp_orphan/.git" || -f "$rp_orphan/.git" ]] || continue
 		local repo_parent repo_name candidate_path candidate_name reason central_base
@@ -1809,6 +1936,7 @@ _pc_cleanup_orphan_sibling_dirs() {
 			[[ -d "$candidate_path" ]] || continue
 			candidate_name=$(basename "$candidate_path")
 			_pc_orphan_sibling_name_allowed "$repo_name" "$candidate_name" || continue
+			_pc_orphan_sibling_pr_state_allowed "$repo_slug_orphan" "$repo_name" "$candidate_name" || continue
 			if reason=$(_pc_classify_orphan_sibling_dir "$rp_orphan" "$candidate_path" "$now_epoch"); then
 				echo "[pulse-wrapper] Orphan dir cleanup ($repo_name): moving $candidate_path to trash — $reason" >>"$LOGFILE"
 				if _pc_trash_orphan_dir "$candidate_path"; then
@@ -1824,6 +1952,7 @@ _pc_cleanup_orphan_sibling_dirs() {
 				[[ -d "$candidate_path" ]] || continue
 				candidate_name=$(basename "$candidate_path")
 				_pc_orphan_sibling_name_allowed "$repo_name" "$candidate_name" || continue
+				_pc_orphan_sibling_pr_state_allowed "$repo_slug_orphan" "$repo_name" "$candidate_name" || continue
 				if reason=$(_pc_classify_orphan_sibling_dir "$rp_orphan" "$candidate_path" "$now_epoch"); then
 					echo "[pulse-wrapper] Orphan dir cleanup ($repo_name): moving $candidate_path to trash — $reason" >>"$LOGFILE"
 					if _pc_trash_orphan_dir "$candidate_path"; then
@@ -1835,7 +1964,7 @@ _pc_cleanup_orphan_sibling_dirs() {
 				fi
 			done
 		fi
-	done <<<"$repo_paths_orphan"
+	done <<<"$repo_records_orphan"
 
 	echo "$moved_count"
 	return 0

--- a/.agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh
@@ -132,8 +132,14 @@ load_subject() {
 	gh() {
 		if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
 			case "${3:-}" in
-			28995) printf 'CLOSED\n'; return 0 ;;
-			28996) printf 'OPEN\n'; return 0 ;;
+			28995)
+				printf 'CLOSED\n'
+				return 0
+				;;
+			28996)
+				printf 'OPEN\n'
+				return 0
+				;;
 			esac
 		fi
 		return 1
@@ -201,8 +207,8 @@ test_orphan_sibling_dirs_move_to_trash_only() {
 	fi
 
 	local malformed_preserved=0
-	if [[ -d "$TEST_ROOT/Git/_worktrees/$CI_REPAIR_BAD_HASH_NAME" && \
-		-d "$TEST_ROOT/Git/_worktrees/$CI_REPAIR_BAD_PR_NAME" && \
+	if [[ -d "$TEST_ROOT/Git/_worktrees/$CI_REPAIR_BAD_HASH_NAME" &&
+		-d "$TEST_ROOT/Git/_worktrees/$CI_REPAIR_BAD_PR_NAME" &&
 		-d "$TEST_ROOT/Git/_worktrees/$CI_REPAIR_BAD_ATTEMPT_NAME" ]]; then
 		malformed_preserved=1
 	fi

--- a/.agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh
@@ -24,6 +24,14 @@ TEST_ROOT=""
 TESTS_RUN=0
 TESTS_PASSED=0
 TESTS_FAILED=0
+CI_REPAIR_REPO_HASH="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+CI_REPAIR_HEAD_PREFIX="bbbbbbbbbbbb"
+CI_REPAIR_FINGERPRINT_PREFIX="cccccccccccc"
+CI_REPAIR_VALID_NAME="aidevops-${CI_REPAIR_REPO_HASH}-ci-repair-pr28995-${CI_REPAIR_HEAD_PREFIX}-${CI_REPAIR_FINGERPRINT_PREFIX}-a1"
+CI_REPAIR_OPEN_NAME="aidevops-${CI_REPAIR_REPO_HASH}-ci-repair-pr28996-${CI_REPAIR_HEAD_PREFIX}-${CI_REPAIR_FINGERPRINT_PREFIX}-a1"
+CI_REPAIR_BAD_HASH_NAME="aidevops-${CI_REPAIR_REPO_HASH%?}-ci-repair-pr28995-${CI_REPAIR_HEAD_PREFIX}-${CI_REPAIR_FINGERPRINT_PREFIX}-a1"
+CI_REPAIR_BAD_PR_NAME="aidevops-${CI_REPAIR_REPO_HASH}-ci-repair-pr0-${CI_REPAIR_HEAD_PREFIX}-${CI_REPAIR_FINGERPRINT_PREFIX}-a1"
+CI_REPAIR_BAD_ATTEMPT_NAME="aidevops-${CI_REPAIR_REPO_HASH}-ci-repair-pr28995-${CI_REPAIR_HEAD_PREFIX}-${CI_REPAIR_FINGERPRINT_PREFIX}-a0"
 
 print_result() {
 	local test_name="$1"
@@ -91,6 +99,15 @@ JSON
 	mkdir -p "$TEST_ROOT/Git/_worktrees/aidevops.bugfix-central-leftover"
 	printf 'central legacy\n' >"$TEST_ROOT/Git/_worktrees/aidevops.bugfix-central-leftover/NOTE.txt"
 
+	# Exact current ci-repair grammar is eligible; near-matches are preserved.
+	mkdir -p "$TEST_ROOT/Git/_worktrees/$CI_REPAIR_VALID_NAME"
+	printf 'ci repair leftover\n' >"$TEST_ROOT/Git/_worktrees/$CI_REPAIR_VALID_NAME/NOTE.txt"
+	mkdir -p "$TEST_ROOT/Git/_worktrees/$CI_REPAIR_OPEN_NAME"
+	printf 'open ci repair\n' >"$TEST_ROOT/Git/_worktrees/$CI_REPAIR_OPEN_NAME/NOTE.txt"
+	mkdir -p "$TEST_ROOT/Git/_worktrees/$CI_REPAIR_BAD_HASH_NAME"
+	mkdir -p "$TEST_ROOT/Git/_worktrees/$CI_REPAIR_BAD_PR_NAME"
+	mkdir -p "$TEST_ROOT/Git/_worktrees/$CI_REPAIR_BAD_ATTEMPT_NAME"
+
 	# Standalone repo: must not be trashed automatically.
 	mkdir -p "$TEST_ROOT/Git/aidevops-cloudron-app"
 	git -C "$TEST_ROOT/Git/aidevops-cloudron-app" init -q
@@ -112,6 +129,36 @@ load_subject() {
 	source "$AGENTS_SCRIPTS_DIR/shared-constants.sh"
 	# shellcheck source=../pulse-cleanup.sh
 	source "$AGENTS_SCRIPTS_DIR/pulse-cleanup.sh"
+	gh() {
+		if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+			case "${3:-}" in
+			28995) printf 'CLOSED\n'; return 0 ;;
+			28996) printf 'OPEN\n'; return 0 ;;
+			esac
+		fi
+		return 1
+	}
+	return 0
+}
+
+test_ci_repair_sibling_name_validation() {
+	local rc=0
+	_pc_orphan_sibling_name_allowed "aidevops" "$CI_REPAIR_VALID_NAME" || rc=1
+	_pc_orphan_sibling_name_allowed "aidevops" "$CI_REPAIR_OPEN_NAME" || rc=1
+	_pc_orphan_sibling_pr_state_allowed "example/aidevops" "aidevops" "$CI_REPAIR_VALID_NAME" || rc=1
+	if _pc_orphan_sibling_pr_state_allowed "example/aidevops" "aidevops" "$CI_REPAIR_OPEN_NAME"; then
+		rc=1
+	fi
+	if _pc_orphan_sibling_name_allowed "aidevops" "$CI_REPAIR_BAD_HASH_NAME"; then
+		rc=1
+	fi
+	if _pc_orphan_sibling_name_allowed "aidevops" "$CI_REPAIR_BAD_PR_NAME"; then
+		rc=1
+	fi
+	if _pc_orphan_sibling_name_allowed "aidevops" "$CI_REPAIR_BAD_ATTEMPT_NAME"; then
+		rc=1
+	fi
+	print_result "ci-repair sibling allowlist accepts only producer-compatible names" "$rc"
 	return 0
 }
 
@@ -120,8 +167,8 @@ test_orphan_sibling_dirs_move_to_trash_only() {
 	local moved_count
 	moved_count=$(_pc_cleanup_orphan_sibling_dirs "$repo_json" "$(date +%s)")
 
-	if [[ "$moved_count" -ne 7 ]]; then
-		print_result "orphan sibling cleanup moves eligible sibling and centralized outliers" 1 "expected 7 moved, got $moved_count"
+	if [[ "$moved_count" -ne 8 ]]; then
+		print_result "orphan sibling cleanup moves eligible sibling and centralized outliers" 1 "expected 8 moved, got $moved_count"
 		return 0
 	fi
 
@@ -147,10 +194,27 @@ test_orphan_sibling_dirs_move_to_trash_only() {
 			trashed_count=$((trashed_count + 1))
 		done
 	done
-	if [[ "$trashed_count" -eq 7 ]]; then
+	if [[ "$trashed_count" -eq 8 ]]; then
 		print_result "eligible outliers are recoverable in trash bucket" 0
 	else
-		print_result "eligible outliers are recoverable in trash bucket" 1 "expected 7 trashed dirs, got $trashed_count"
+		print_result "eligible outliers are recoverable in trash bucket" 1 "expected 8 trashed dirs, got $trashed_count"
+	fi
+
+	local malformed_preserved=0
+	if [[ -d "$TEST_ROOT/Git/_worktrees/$CI_REPAIR_BAD_HASH_NAME" && \
+		-d "$TEST_ROOT/Git/_worktrees/$CI_REPAIR_BAD_PR_NAME" && \
+		-d "$TEST_ROOT/Git/_worktrees/$CI_REPAIR_BAD_ATTEMPT_NAME" ]]; then
+		malformed_preserved=1
+	fi
+	if [[ "$malformed_preserved" -eq 1 ]]; then
+		print_result "malformed ci-repair sibling names are preserved" 0
+	else
+		print_result "malformed ci-repair sibling names are preserved" 1
+	fi
+	if [[ -d "$TEST_ROOT/Git/_worktrees/$CI_REPAIR_OPEN_NAME" ]]; then
+		print_result "open ci-repair sibling is preserved" 0
+	else
+		print_result "open ci-repair sibling is preserved" 1
 	fi
 	return 0
 }
@@ -206,6 +270,7 @@ main() {
 	fi
 	setup_fixture
 	load_subject
+	test_ci_repair_sibling_name_validation
 	test_orphan_sibling_dirs_move_to_trash_only
 	test_standalone_clean_check_requires_successful_status
 	printf '\n%d/%d tests passed\n' "$TESTS_PASSED" "$TESTS_RUN"

--- a/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
@@ -240,6 +240,31 @@ test_open_ci_repair_dirty_worktree_is_preserved() {
 	return 0
 }
 
+test_open_head_pr_outranks_embedded_terminal_reference() {
+	source_pulse_cleanup_with_stubs || return 1
+	gh_pr_list() {
+		printf '%s\n' "OPEN"
+		return 0
+	}
+	gh() {
+		if [[ "${1:-}" == "pr" && "${2:-}" == "view" && "${3:-}" == "23085" ]]; then
+			printf '%s\n' "CLOSED"
+			return 0
+		fi
+		return 1
+	}
+
+	local terminal_state=""
+	terminal_state=$(_pc_terminal_pr_state_for_branch "testowner/testrepo" "repair/pr-23085-followup" 2>/dev/null)
+	local lookup_rc=$?
+	local rc=0
+	[[ "$lookup_rc" -eq 1 ]] || rc=1
+	[[ -z "$terminal_state" ]] || rc=1
+	print_result "open head PR outranks embedded terminal PR reference" "$rc" \
+		"lookup_rc=$lookup_rc terminal_state=$terminal_state"
+	return 0
+}
+
 test_merged_branch_pr_removes_before_age_threshold() {
 	local repo_dir="${TEST_ROOT}/repo-merged-branch-pr"
 	local wt_path="${TEST_ROOT}/worker-wt-merged-branch-pr"
@@ -718,6 +743,7 @@ test_local_only_repo_worktree_logs_explicit_skip
 test_closed_issue_local_commit_no_pr_removes_before_age_threshold
 test_closed_pr_reference_local_commit_no_pr_removes_before_age_threshold
 test_open_ci_repair_dirty_worktree_is_preserved
+test_open_head_pr_outranks_embedded_terminal_reference
 test_merged_branch_pr_removes_before_age_threshold
 test_closed_issue_dirty_worktree_stashes_and_preserves_branch
 test_terminal_worktree_respects_live_owner_signal

--- a/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
@@ -170,9 +170,11 @@ test_closed_issue_local_commit_no_pr_removes_before_age_threshold() {
 
 test_closed_pr_reference_local_commit_no_pr_removes_before_age_threshold() {
 	local repo_dir="${TEST_ROOT}/repo-closed-pr-ref"
-	local wt_path="${TEST_ROOT}/worker-wt-closed-pr-ref"
-	local branch_name="repair/pr-23078-followup"
+	local repo_hash="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	local wt_path="${TEST_ROOT}/aidevops-${repo_hash}-ci-repair-pr23078-bbbbbbbbbbbb-cccccccccccc-a1"
+	local branch_name="repair/${repo_hash}-pr-23078-bbbbbbbbbbbb-cccccccccccc-a1"
 	setup_repo_with_worker_worktree "$repo_dir" "$wt_path" "$branch_name" || return 1
+	touch "$wt_path/.git"
 	source_pulse_cleanup_with_stubs || return 1
 	gh() {
 		if [[ "${1:-}" == "pr" && "${2:-}" == "view" && "${3:-}" == "23078" ]]; then
@@ -199,9 +201,42 @@ test_closed_pr_reference_local_commit_no_pr_removes_before_age_threshold() {
 	[[ "$branch_exists" -eq 0 ]] || rc=1
 	grep -q 'worktree-removed.*local-commits-branch-preserved.*mode=branch-preserved' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	grep -q 'pr_state=pr-CLOSED' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
-	grep -q 'recovery_path=branch-preserved-closed-pr-23078' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	grep -q 'recovery_path=branch-preserved-terminal-pr-23078' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	print_result "closed PR reference local commits/no PR archives before age threshold" "$rc" \
 		"cleanup_rc=$cleanup_rc branch_exists=$branch_exists log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
+	return 0
+}
+
+test_open_ci_repair_dirty_worktree_is_preserved() {
+	local repo_dir="${TEST_ROOT}/repo-open-ci-repair"
+	local repo_hash="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	local wt_path="${TEST_ROOT}/aidevops-${repo_hash}-ci-repair-pr23084-bbbbbbbbbbbb-cccccccccccc-a1"
+	local branch_name="repair/${repo_hash}-pr-23084-bbbbbbbbbbbb-cccccccccccc-a1"
+	setup_repo_with_worker_worktree "$repo_dir" "$wt_path" "$branch_name" "8 days ago" || return 1
+	printf 'dirty repair state\n' >"$wt_path/dirty-repair.txt"
+	source_pulse_cleanup_with_stubs || return 1
+	gh() {
+		if [[ "${1:-}" == "pr" && "${2:-}" == "view" && "${3:-}" == "23084" ]]; then
+			printf '%s\n' "OPEN"
+			return 0
+		fi
+		return 1
+	}
+
+	local now_epoch
+	now_epoch=$(date +%s)
+	AIDEVOPS_HEADLESS_METRICS_FILE="${TEST_ROOT}/missing-open-ci-repair-metrics.jsonl"
+	export AIDEVOPS_HEADLESS_METRICS_FILE
+
+	_cleanup_single_worktree "$repo_dir" "$wt_path" "$branch_name" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
+	local cleanup_rc=$?
+
+	local rc=0
+	[[ "$cleanup_rc" -eq 1 ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	[[ -f "$wt_path/dirty-repair.txt" ]] || rc=1
+	print_result "open ci-repair PR preserves stale dirty worktree" "$rc" \
+		"cleanup_rc=$cleanup_rc log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
 	return 0
 }
 
@@ -280,8 +315,9 @@ test_closed_issue_dirty_worktree_stashes_and_preserves_branch() {
 
 test_terminal_worktree_respects_live_owner_signal() {
 	local repo_dir="${TEST_ROOT}/repo-terminal-owner"
-	local wt_path="${TEST_ROOT}/worker-wt-terminal-owner"
-	local branch_name="feature/auto-20260507-190808-gh23083"
+	local repo_hash="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	local wt_path="${TEST_ROOT}/aidevops-${repo_hash}-ci-repair-pr23083-bbbbbbbbbbbb-cccccccccccc-a1"
+	local branch_name="repair/${repo_hash}-pr-23083-bbbbbbbbbbbb-cccccccccccc-a1"
 	setup_repo_with_worker_worktree "$repo_dir" "$wt_path" "$branch_name" || return 1
 	source_pulse_cleanup_with_stubs || return 1
 	is_worktree_owned_by_others() { return 0; }
@@ -289,8 +325,8 @@ test_terminal_worktree_respects_live_owner_signal() {
 		local command_name="${1:-}"
 		local subcommand_name="${2:-}"
 		local target_number="${3:-}"
-		if [[ "$command_name" == "issue" && "$subcommand_name" == "view" && "$target_number" == "23083" ]]; then
-			printf '%s\n' "CLOSED"
+		if [[ "$command_name" == "pr" && "$subcommand_name" == "view" && "$target_number" == "23083" ]]; then
+			printf '%s\n' "MERGED"
 			return 0
 		fi
 		return 1
@@ -681,6 +717,7 @@ test_young_local_commit_logs_not_age_eligible
 test_local_only_repo_worktree_logs_explicit_skip
 test_closed_issue_local_commit_no_pr_removes_before_age_threshold
 test_closed_pr_reference_local_commit_no_pr_removes_before_age_threshold
+test_open_ci_repair_dirty_worktree_is_preserved
 test_merged_branch_pr_removes_before_age_threshold
 test_closed_issue_dirty_worktree_stashes_and_preserves_branch
 test_terminal_worktree_respects_live_owner_signal


### PR DESCRIPTION
## Summary

Recognize exact ci-repair worktree names, verify embedded PR state, clean terminal repairs centrally, and preserve open or live worktrees

## Files Changed

.agents/scripts/pulse-cleanup.sh, .agents/scripts/tests/test-pulse-cleanup-orphan-sibling-dirs.sh, .agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — ShellCheck; orphan sibling cleanup 7/7; worker-owned cleanup 21/21; CI repair routing 28/28; local and full repository quality gates

Resolves #28995


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.199 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 2h 20m and 617,937 tokens on this with the user in an interactive session.