### PR TITLE
GH#29002: prevent OpenCode self-updates past version pin

### DIFF
--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -151,6 +151,9 @@ try:
 except Exception:
     sys.exit(1)
 
+if config.get("autoupdate") is not False:
+    sys.exit(1)
+
 configured = config.get("agent", {})
 if not isinstance(configured, dict):
     sys.exit(1)

--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -123,6 +123,25 @@ compute_runtime_source_hash() {
 	return 0
 }
 
+_opencode_managed_config_matches_source() {
+	python3 - <<'PY'
+import json
+import os
+import sys
+
+config_path = os.path.expanduser("~/.config/opencode/opencode.json")
+
+try:
+    with open(config_path, "r", encoding="utf-8") as handle:
+        config = json.load(handle)
+except Exception:
+    sys.exit(1)
+
+sys.exit(0 if config.get("autoupdate") is False else 1)
+PY
+	return $?
+}
+
 _opencode_agent_output_matches_source() {
 	python3 - <<'PY'
 import json
@@ -149,9 +168,6 @@ try:
     with open(config_path, "r", encoding="utf-8") as handle:
         config = json.load(handle)
 except Exception:
-    sys.exit(1)
-
-if config.get("autoupdate") is not False:
     sys.exit(1)
 
 configured = config.get("agent", {})
@@ -202,6 +218,7 @@ _runtime_output_matches_source() {
 	local runtime_id="$1"
 	case "$runtime_id" in
 	opencode)
+		_opencode_managed_config_matches_source || return 1
 		if [[ "$(rt_feature_agents "$runtime_id" 2>/dev/null || echo yes)" == "yes" ]]; then
 			_opencode_agent_output_matches_source || return 1
 		fi

--- a/.agents/scripts/opencode-agent-discovery.py
+++ b/.agents/scripts/opencode-agent-discovery.py
@@ -29,6 +29,10 @@ except (OSError, json.JSONDecodeError) as e:
     print(f"Error: Failed to load {config_path}: {e}", file=sys.stderr)
     sys.exit(1)
 
+# Prevent OpenCode's built-in updater from bypassing the framework-controlled
+# runtime version pin and breaking fail-closed headless launches.
+config['autoupdate'] = False
+
 # =============================================================================
 # DISCOVER PRIMARY AGENTS
 # =============================================================================

--- a/.agents/scripts/tests/test-runtime-command-reconciliation.sh
+++ b/.agents/scripts/tests/test-runtime-command-reconciliation.sh
@@ -28,19 +28,19 @@ HOME="$TEST_HOME"
 source "$REPO_ROOT/.agents/scripts/generate-runtime-config.sh"
 
 printf '%s\n' '{"autoupdate":false,"agent":{}}' >"$TEST_HOME/.config/opencode/opencode.json"
-if ! _opencode_agent_output_matches_source; then
+if ! _opencode_managed_config_matches_source || ! _opencode_agent_output_matches_source; then
 	printf '%s\n' 'FAIL: managed autoupdate=false failed parity verification' >&2
 	exit 1
 fi
 
 printf '%s\n' '{"agent":{}}' >"$TEST_HOME/.config/opencode/opencode.json"
-if _opencode_agent_output_matches_source; then
+if _opencode_managed_config_matches_source; then
 	printf '%s\n' 'FAIL: missing managed autoupdate setting passed parity verification' >&2
 	exit 1
 fi
 
 printf '%s\n' '{"autoupdate":true,"agent":{},"custom":"preserve"}' >"$TEST_HOME/.config/opencode/opencode.json"
-if _opencode_agent_output_matches_source; then
+if _opencode_managed_config_matches_source; then
 	printf '%s\n' 'FAIL: enabled OpenCode autoupdate passed parity verification' >&2
 	exit 1
 fi

--- a/.agents/scripts/tests/test-runtime-command-reconciliation.sh
+++ b/.agents/scripts/tests/test-runtime-command-reconciliation.sh
@@ -19,12 +19,42 @@ mkdir -p \
 	"$TEST_HOME/.aidevops/agents/commands" \
 	"$TEST_HOME/.aidevops/agents/scripts/commands" \
 	"$TEST_HOME/.config/opencode/command"
+ln -s "$REPO_ROOT/.agents/scripts/lib" "$TEST_HOME/.aidevops/agents/scripts/lib"
 printf '%s\n' '# build command' >"$TEST_HOME/.aidevops/agents/commands/aidevops-build-plus.md"
 printf '%s\n' '# session command' >"$TEST_HOME/.aidevops/agents/scripts/commands/session-analysis.md"
 
 HOME="$TEST_HOME"
 # shellcheck source=../generate-runtime-config.sh
 source "$REPO_ROOT/.agents/scripts/generate-runtime-config.sh"
+
+printf '%s\n' '{"autoupdate":false,"agent":{}}' >"$TEST_HOME/.config/opencode/opencode.json"
+if ! _opencode_agent_output_matches_source; then
+	printf '%s\n' 'FAIL: managed autoupdate=false failed parity verification' >&2
+	exit 1
+fi
+
+printf '%s\n' '{"agent":{}}' >"$TEST_HOME/.config/opencode/opencode.json"
+if _opencode_agent_output_matches_source; then
+	printf '%s\n' 'FAIL: missing managed autoupdate setting passed parity verification' >&2
+	exit 1
+fi
+
+printf '%s\n' '{"autoupdate":true,"agent":{},"custom":"preserve"}' >"$TEST_HOME/.config/opencode/opencode.json"
+if _opencode_agent_output_matches_source; then
+	printf '%s\n' 'FAIL: enabled OpenCode autoupdate passed parity verification' >&2
+	exit 1
+fi
+
+HOME="$TEST_HOME" python3 "$REPO_ROOT/.agents/scripts/opencode-agent-discovery.py" >/dev/null
+if ! jq -e '.autoupdate == false and .custom == "preserve"' "$TEST_HOME/.config/opencode/opencode.json" >/dev/null; then
+	printf '%s\n' 'FAIL: OpenCode config generation did not disable autoupdate while preserving unrelated keys' >&2
+	exit 1
+fi
+HOME="$TEST_HOME" python3 "$REPO_ROOT/.agents/scripts/opencode-agent-discovery.py" >/dev/null
+if ! jq -e '.autoupdate == false and .custom == "preserve"' "$TEST_HOME/.config/opencode/opencode.json" >/dev/null; then
+	printf '%s\n' 'FAIL: repeated OpenCode config generation did not preserve managed autoupdate state' >&2
+	exit 1
+fi
 
 if _opencode_command_output_matches_source; then
 	printf '%s\n' 'FAIL: missing generated commands passed parity verification' >&2


### PR DESCRIPTION
## Summary

Manage autoupdate=false in the canonical OpenCode config writer and make runtime convergence reject missing or enabled values independently of agent generation.

## Files Changed

.agents/scripts/generate-runtime-config.sh, .agents/scripts/opencode-agent-discovery.py, .agents/scripts/tests/test-runtime-command-reconciliation.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified with isolated config generation and reconciliation; runtime command reconciliation passed; 11 OpenCode version-policy tests passed; incremental deployment test passed; ShellCheck, Python compile, git diff check, and linters-local passed.

Resolves #29002


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.199 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 1h 4m and 353,395 tokens on this with the user in an interactive session.