### PR TITLE
GH#29003: Auto-approve isolated OpenCode tool-output reads

### DIFF
--- a/.agents/plugins/opencode-aidevops/permission-broker-tool-output.mjs
+++ b/.agents/plugins/opencode-aidevops/permission-broker-tool-output.mjs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { lstatSync, realpathSync } from "fs";
+import { basename, dirname, resolve } from "path";
+
+function normalizePathPattern(value) {
+  return typeof value === "string" ? value.replaceAll("\\", "/") : "";
+}
+
+function pathHasSymlinkComponent(target) {
+  let current = resolve(target);
+  try {
+    while (true) {
+      if (lstatSync(current).isSymbolicLink()) return true;
+      const parent = dirname(current);
+      if (parent === current) return false;
+      current = parent;
+    }
+  } catch {
+    return true;
+  }
+}
+
+function hasExactToolOutputPattern(raw, directory) {
+  const expected = `${normalizePathPattern(directory)}/*`;
+  const input = raw?.patterns ?? raw?.pattern;
+  const patterns = Array.isArray(input) ? input : input == null ? [] : [input];
+  return patterns.length === 1 && normalizePathPattern(patterns[0]) === expected;
+}
+
+function managedToolOutputPath(raw, directory) {
+  const filepath = raw?.metadata?.filepath || "";
+  const parentDir = raw?.metadata?.parentDir || "";
+  if (!filepath || !parentDir || resolve(parentDir) !== directory || dirname(resolve(filepath)) !== directory) return "";
+  return basename(filepath).startsWith("tool_") ? filepath : "";
+}
+
+function isSafeManagedToolOutputFile(filepath, directory) {
+  try {
+    const info = lstatSync(filepath);
+    return info.isFile()
+      && !info.isSymbolicLink()
+      && !pathHasSymlinkComponent(directory)
+      && dirname(realpathSync(filepath)) === realpathSync(directory);
+  } catch {
+    return false;
+  }
+}
+
+export function isManagedToolOutputRead(toolCalls, raw, dataHome) {
+  const permission = raw?.permission || raw?.type || "";
+  const callID = raw?.tool?.callID || raw?.callID || "";
+  if (permission !== "external_directory" || toolCalls.get(callID)?.tool !== "read") return false;
+
+  const directory = resolve(dataHome, "opencode", "tool-output");
+  if (!hasExactToolOutputPattern(raw, directory)) return false;
+  const filepath = managedToolOutputPath(raw, directory);
+  return Boolean(filepath) && isSafeManagedToolOutputFile(filepath, directory);
+}

--- a/.agents/plugins/opencode-aidevops/permission-broker.mjs
+++ b/.agents/plugins/opencode-aidevops/permission-broker.mjs
@@ -121,22 +121,21 @@ function pathHasSymlinkComponent(target) {
   }
 }
 
-function isManagedToolOutputRead(toolCalls, raw, dataHome) {
-  const permission = raw?.permission || raw?.type || "";
-  const callID = raw?.tool?.callID || raw?.callID || "";
-  if (permission !== "external_directory" || toolCalls.get(callID)?.tool !== "read") return false;
+function hasExactToolOutputPattern(raw, directory) {
+  const expected = `${normalizePathPattern(directory)}/*`;
+  const input = raw?.patterns ?? raw?.pattern;
+  const patterns = Array.isArray(input) ? input : input == null ? [] : [input];
+  return patterns.length === 1 && normalizePathPattern(patterns[0]) === expected;
+}
 
-  const directory = resolve(dataHome, "opencode", "tool-output");
-  const expectedPattern = `${normalizePathPattern(directory)}/*`;
-  const patternInput = raw?.patterns ?? raw?.pattern;
-  const patterns = Array.isArray(patternInput) ? patternInput : patternInput == null ? [] : [patternInput];
-  if (patterns.length !== 1 || normalizePathPattern(patterns[0]) !== expectedPattern) return false;
-
+function managedToolOutputPath(raw, directory) {
   const filepath = raw?.metadata?.filepath || "";
   const parentDir = raw?.metadata?.parentDir || "";
-  if (!filepath || !parentDir || resolve(parentDir) !== directory || dirname(resolve(filepath)) !== directory) return false;
-  if (!basename(filepath).startsWith("tool_")) return false;
+  if (!filepath || !parentDir || resolve(parentDir) !== directory || dirname(resolve(filepath)) !== directory) return "";
+  return basename(filepath).startsWith("tool_") ? filepath : "";
+}
 
+function isSafeManagedToolOutputFile(filepath, directory) {
   try {
     const info = lstatSync(filepath);
     return info.isFile()
@@ -146,6 +145,17 @@ function isManagedToolOutputRead(toolCalls, raw, dataHome) {
   } catch {
     return false;
   }
+}
+
+function isManagedToolOutputRead(toolCalls, raw, dataHome) {
+  const permission = raw?.permission || raw?.type || "";
+  const callID = raw?.tool?.callID || raw?.callID || "";
+  if (permission !== "external_directory" || toolCalls.get(callID)?.tool !== "read") return false;
+
+  const directory = resolve(dataHome, "opencode", "tool-output");
+  if (!hasExactToolOutputPattern(raw, directory)) return false;
+  const filepath = managedToolOutputPath(raw, directory);
+  return Boolean(filepath) && isSafeManagedToolOutputFile(filepath, directory);
 }
 
 function recordPermissionToolCall(toolCalls, isHeadless, home, input, output) {

--- a/.agents/plugins/opencode-aidevops/permission-broker.mjs
+++ b/.agents/plugins/opencode-aidevops/permission-broker.mjs
@@ -2,10 +2,11 @@
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
 import { createHash } from "crypto";
-import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "fs";
-import { basename, dirname, join, resolve } from "path";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
 import { homedir } from "os";
 import { appendWorkerBlockerEvent } from "../../scripts/worker-blocker-log.mjs";
+import { isManagedToolOutputRead } from "./permission-broker-tool-output.mjs";
 
 const REQUEST_SCHEMA = "aidevops-permission-capture/v1";
 const MAX_PATTERN_LENGTH = 500;
@@ -101,61 +102,6 @@ function normalizePatterns(input, options) {
   return [...new Set(source
     .map((value) => sanitizePermissionText(String(value), options))
     .filter(Boolean))].slice(0, 20);
-}
-
-function normalizePathPattern(value) {
-  return typeof value === "string" ? value.replaceAll("\\", "/") : "";
-}
-
-function pathHasSymlinkComponent(target) {
-  let current = resolve(target);
-  try {
-    while (true) {
-      if (lstatSync(current).isSymbolicLink()) return true;
-      const parent = dirname(current);
-      if (parent === current) return false;
-      current = parent;
-    }
-  } catch {
-    return true;
-  }
-}
-
-function hasExactToolOutputPattern(raw, directory) {
-  const expected = `${normalizePathPattern(directory)}/*`;
-  const input = raw?.patterns ?? raw?.pattern;
-  const patterns = Array.isArray(input) ? input : input == null ? [] : [input];
-  return patterns.length === 1 && normalizePathPattern(patterns[0]) === expected;
-}
-
-function managedToolOutputPath(raw, directory) {
-  const filepath = raw?.metadata?.filepath || "";
-  const parentDir = raw?.metadata?.parentDir || "";
-  if (!filepath || !parentDir || resolve(parentDir) !== directory || dirname(resolve(filepath)) !== directory) return "";
-  return basename(filepath).startsWith("tool_") ? filepath : "";
-}
-
-function isSafeManagedToolOutputFile(filepath, directory) {
-  try {
-    const info = lstatSync(filepath);
-    return info.isFile()
-      && !info.isSymbolicLink()
-      && !pathHasSymlinkComponent(directory)
-      && dirname(realpathSync(filepath)) === realpathSync(directory);
-  } catch {
-    return false;
-  }
-}
-
-function isManagedToolOutputRead(toolCalls, raw, dataHome) {
-  const permission = raw?.permission || raw?.type || "";
-  const callID = raw?.tool?.callID || raw?.callID || "";
-  if (permission !== "external_directory" || toolCalls.get(callID)?.tool !== "read") return false;
-
-  const directory = resolve(dataHome, "opencode", "tool-output");
-  if (!hasExactToolOutputPattern(raw, directory)) return false;
-  const filepath = managedToolOutputPath(raw, directory);
-  return Boolean(filepath) && isSafeManagedToolOutputFile(filepath, directory);
 }
 
 function recordPermissionToolCall(toolCalls, isHeadless, home, input, output) {

--- a/.agents/plugins/opencode-aidevops/permission-broker.mjs
+++ b/.agents/plugins/opencode-aidevops/permission-broker.mjs
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
 import { createHash } from "crypto";
-import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "fs";
-import { dirname } from "path";
+import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "fs";
+import { basename, dirname, join, resolve } from "path";
 import { homedir } from "os";
 import { appendWorkerBlockerEvent } from "../../scripts/worker-blocker-log.mjs";
 
@@ -103,6 +103,51 @@ function normalizePatterns(input, options) {
     .filter(Boolean))].slice(0, 20);
 }
 
+function normalizePathPattern(value) {
+  return typeof value === "string" ? value.replaceAll("\\", "/") : "";
+}
+
+function pathHasSymlinkComponent(target) {
+  let current = resolve(target);
+  try {
+    while (true) {
+      if (lstatSync(current).isSymbolicLink()) return true;
+      const parent = dirname(current);
+      if (parent === current) return false;
+      current = parent;
+    }
+  } catch {
+    return true;
+  }
+}
+
+function isManagedToolOutputRead(toolCalls, raw, dataHome) {
+  const permission = raw?.permission || raw?.type || "";
+  const callID = raw?.tool?.callID || raw?.callID || "";
+  if (permission !== "external_directory" || toolCalls.get(callID)?.tool !== "read") return false;
+
+  const directory = resolve(dataHome, "opencode", "tool-output");
+  const expectedPattern = `${normalizePathPattern(directory)}/*`;
+  const patternInput = raw?.patterns ?? raw?.pattern;
+  const patterns = Array.isArray(patternInput) ? patternInput : patternInput == null ? [] : [patternInput];
+  if (patterns.length !== 1 || normalizePathPattern(patterns[0]) !== expectedPattern) return false;
+
+  const filepath = raw?.metadata?.filepath || "";
+  const parentDir = raw?.metadata?.parentDir || "";
+  if (!filepath || !parentDir || resolve(parentDir) !== directory || dirname(resolve(filepath)) !== directory) return false;
+  if (!basename(filepath).startsWith("tool_")) return false;
+
+  try {
+    const info = lstatSync(filepath);
+    return info.isFile()
+      && !info.isSymbolicLink()
+      && !pathHasSymlinkComponent(directory)
+      && dirname(realpathSync(filepath)) === realpathSync(directory);
+  } catch {
+    return false;
+  }
+}
+
 function recordPermissionToolCall(toolCalls, isHeadless, home, input, output) {
   if (!isHeadless()) return;
   const callID = input?.callID || input?.callId;
@@ -200,38 +245,60 @@ function capturePermissionRequest(toolCalls, loggedEvents, home, blockerLogPath,
   return request;
 }
 
-async function rejectPermissionRequest(client, request) {
-  if (!request?.id || !request?.sessionID) return;
+async function replyPermissionRequest(client, request, response) {
+  if (!request?.id || !request?.sessionID || !client?.postSessionIdPermissionsPermissionId) return false;
   try {
-    await client.postSessionIdPermissionsPermissionId({
+    const result = await client.postSessionIdPermissionsPermissionId({
       path: { id: request.sessionID, permissionID: request.id },
-      body: { response: "reject" },
+      body: { response },
+      throwOnError: true,
     });
+    return !result?.error && (!result?.response || result.response.ok !== false);
   } catch {
-    // `opencode run` may have already rejected the same request.
+    return false;
   }
 }
 
 async function handlePermissionEvent(context, input) {
-  const { client, isHeadless, toolCalls, loggedEvents, home, blockerLogPath } = context;
+  const { client, isHeadless, toolCalls, loggedEvents, home, dataHome, blockerLogPath } = context;
   const event = input?.event;
   if (!isHeadless() || event?.type !== "permission.asked") return;
   const request = event.properties || {};
+  if (isManagedToolOutputRead(toolCalls, request, dataHome)
+    && await replyPermissionRequest(client, request, "once")) return;
   capturePermissionRequest(toolCalls, loggedEvents, home, blockerLogPath, request);
-  await rejectPermissionRequest(client, request);
+  await replyPermissionRequest(client, request, "reject");
 }
 
 function handlePermissionAsk(context, input, output) {
-  const { isHeadless, toolCalls, loggedEvents, home, blockerLogPath } = context;
+  const { isHeadless, toolCalls, loggedEvents, home, dataHome, blockerLogPath } = context;
   if (!isHeadless()) return;
+  if (isManagedToolOutputRead(toolCalls, input, dataHome)) {
+    output.status = "allow";
+    return;
+  }
   capturePermissionRequest(toolCalls, loggedEvents, home, blockerLogPath, input || {});
   output.status = "deny";
 }
 
-export function createPermissionBroker({ client, isHeadless, home = homedir(), blockerLogPath = undefined }) {
+export function createPermissionBroker({
+  client,
+  isHeadless,
+  home = homedir(),
+  dataHome = process.env.XDG_DATA_HOME || "",
+  blockerLogPath = undefined,
+}) {
   const toolCalls = new Map();
   const loggedEvents = new Set();
-  const context = { client, isHeadless, toolCalls, loggedEvents, home, blockerLogPath };
+  const context = {
+    client,
+    isHeadless,
+    toolCalls,
+    loggedEvents,
+    home,
+    dataHome: dataHome || join(home, ".local", "share"),
+    blockerLogPath,
+  };
   return {
     recordToolCall: (input, output) => recordPermissionToolCall(toolCalls, isHeadless, home, input, output),
     handleEvent: (input) => handlePermissionEvent(context, input),

--- a/.agents/plugins/opencode-aidevops/tests/test-permission-broker.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-permission-broker.mjs
@@ -3,7 +3,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -26,6 +26,151 @@ function restoreWorkerEnvironment(previous) {
     else process.env[key] = previous[key];
   }
 }
+
+function toolOutputPermissionEvent({ id, callID, outputDir, outputPath }) {
+  return { event: { type: "permission.asked", properties: {
+    id,
+    sessionID: "session-output",
+    permission: "external_directory",
+    patterns: [`${outputDir}/*`],
+    metadata: { filepath: outputPath, parentDir: outputDir },
+    tool: { callID, messageID: `message-${id}` },
+  } } };
+}
+
+test("headless workers auto-approve only regular OpenCode tool-output reads", async () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "aidevops-permission-broker-")));
+  const dataHome = join(root, "xdg-data");
+  const outputDir = join(dataHome, "opencode", "tool-output");
+  const outputPath = join(outputDir, "tool_01TESTOUTPUT");
+  const requestFile = join(root, "request.json");
+  const blockerLog = join(root, "blockers.jsonl");
+  const previous = preserveWorkerEnvironment();
+  process.env.AIDEVOPS_PERMISSION_REQUEST_FILE = requestFile;
+  mkdirSync(outputDir, { recursive: true });
+  writeFileSync(outputPath, "bounded output\n");
+  const replies = [];
+  const broker = createPermissionBroker({
+    client: { postSessionIdPermissionsPermissionId: async (value) => replies.push(value) },
+    isHeadless: () => true,
+    home: root,
+    dataHome,
+    blockerLogPath: blockerLog,
+  });
+  broker.recordToolCall({ tool: "read", callID: "call-output" }, { args: {} });
+
+  await broker.handleEvent(toolOutputPermissionEvent({
+    id: "permission-output",
+    callID: "call-output",
+    outputDir,
+    outputPath,
+  }));
+
+  assert.equal(replies[0].body.response, "once");
+  assert.equal(existsSync(requestFile), false);
+  assert.equal(existsSync(blockerLog), false);
+
+  broker.recordToolCall({ tool: "read", callID: "call-output-legacy" }, { args: {} });
+  const legacyOutput = { status: "ask" };
+  await broker.permissionAsk({
+    id: "permission-output-legacy",
+    type: "external_directory",
+    pattern: `${outputDir}/*`,
+    callID: "call-output-legacy",
+    metadata: { filepath: outputPath, parentDir: outputDir },
+  }, legacyOutput);
+  assert.equal(legacyOutput.status, "allow");
+  restoreWorkerEnvironment(previous);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("tool-output read approval failure falls back to capture and rejection", async () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "aidevops-permission-broker-")));
+  const dataHome = join(root, "xdg-data");
+  const outputDir = join(dataHome, "opencode", "tool-output");
+  const outputPath = join(outputDir, "tool_01FAILEDAPPROVAL");
+  const requestFile = join(root, "request.json");
+  const blockerLog = join(root, "blockers.jsonl");
+  const previous = preserveWorkerEnvironment();
+  process.env.AIDEVOPS_PERMISSION_REQUEST_FILE = requestFile;
+  mkdirSync(outputDir, { recursive: true });
+  writeFileSync(outputPath, "bounded output\n");
+  const replies = [];
+  const broker = createPermissionBroker({
+    client: { postSessionIdPermissionsPermissionId: async (value) => {
+      replies.push(value);
+      if (value.body.response === "once") return { error: { message: "approval failed" }, response: { ok: false } };
+      return { data: {}, response: { ok: true } };
+    } },
+    isHeadless: () => true,
+    home: root,
+    dataHome,
+    blockerLogPath: blockerLog,
+  });
+  broker.recordToolCall({ tool: "read", callID: "call-output-failed" }, { args: {} });
+
+  await broker.handleEvent(toolOutputPermissionEvent({
+    id: "permission-output-failed",
+    callID: "call-output-failed",
+    outputDir,
+    outputPath,
+  }));
+
+  assert.deepEqual(replies.map((reply) => reply.body.response), ["once", "reject"]);
+  assert.equal(JSON.parse(readFileSync(requestFile, "utf8")).requests[0].tool, "read");
+  assert.equal(JSON.parse(readFileSync(blockerLog, "utf8")).reason, "permission_required");
+  restoreWorkerEnvironment(previous);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("tool-output exception rejects mutation tools and symlink escapes", async () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "aidevops-permission-broker-")));
+  const physicalDataHome = join(root, "physical-xdg-data");
+  const dataHome = join(root, "linked-xdg-data");
+  const physicalOutputDir = join(physicalDataHome, "opencode", "tool-output");
+  const outputDir = join(dataHome, "opencode", "tool-output");
+  const outsidePath = join(root, "outside.txt");
+  const linkedOutput = join(outputDir, "tool_01LINKEDOUTPUT");
+  const regularOutput = join(outputDir, "tool_01REGULAROUTPUT");
+  const requestFile = join(root, "request.json");
+  const previous = preserveWorkerEnvironment();
+  process.env.AIDEVOPS_PERMISSION_REQUEST_FILE = requestFile;
+  mkdirSync(physicalOutputDir, { recursive: true });
+  symlinkSync(physicalDataHome, dataHome, "dir");
+  writeFileSync(outsidePath, "outside\n");
+  writeFileSync(regularOutput, "regular\n");
+  symlinkSync(outsidePath, linkedOutput);
+  const replies = [];
+  const broker = createPermissionBroker({
+    client: { postSessionIdPermissionsPermissionId: async (value) => replies.push(value) },
+    isHeadless: () => true,
+    home: root,
+    dataHome,
+    blockerLogPath: join(root, "blockers.jsonl"),
+  });
+  broker.recordToolCall({ tool: "edit", callID: "call-edit" }, { args: {} });
+  broker.recordToolCall({ tool: "read", callID: "call-symlink" }, { args: {} });
+  broker.recordToolCall({ tool: "read", callID: "call-symlink-directory" }, { args: {} });
+
+  for (const [id, callID, outputPath] of [
+    ["permission-edit", "call-edit", regularOutput],
+    ["permission-symlink", "call-symlink", linkedOutput],
+    ["permission-symlink-directory", "call-symlink-directory", regularOutput],
+  ]) {
+    await broker.handleEvent(toolOutputPermissionEvent({
+      id,
+      callID,
+      outputDir,
+      outputPath,
+    }));
+  }
+
+  assert.deepEqual(replies.map((reply) => reply.body.response), ["reject", "reject", "reject"]);
+  const capture = JSON.parse(readFileSync(requestFile, "utf8"));
+  assert.deepEqual(capture.requests.map((request) => request.tool), ["edit", "read"]);
+  restoreWorkerEnvironment(previous);
+  rmSync(root, { recursive: true, force: true });
+});
 
 test("headless permission event is sanitized, persisted, and rejected", async () => {
   const root = mkdtempSync(join(tmpdir(), "aidevops-permission-broker-"));


### PR DESCRIPTION
## Summary

Auto-approve only validated read-tool access to isolated OpenCode tool-output artifacts while preserving capture-and-reject for all other external-directory requests. For #28659.

## Files Changed

.agents/plugins/opencode-aidevops/permission-broker.mjs, .agents/plugins/opencode-aidevops/tests/test-permission-broker.mjs

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: headless OpenCode 1.18.9 loaded the worktree plugin with deployed plugin dependencies, spilled a 70,000-character Bash result, read the exact isolated XDG tool_* artifact without a permission hold, and returned RUNTIME_TOOL_OUTPUT_READ_OK. Permission-broker tests 10/10, combined focused tests 15/15, Biome and linters-local passed; unrelated baseline failures are tracked by #29004.

Resolves #29003


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.199 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 3h 6m and 1,185,180 tokens on this with the user in an interactive session.