### PR TITLE
GH#29009: Stabilize reciprocal approval snapshots

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -1463,6 +1463,7 @@ _approval_classify_signed_comment() {
 	local pub_key="$6"
 	local expected_head_sha="${7:-}"
 	local payload="" snapshot_json="" current_digest="" signed_digest="" normalized_slug="" issued_at=""
+	local legacy_snapshot_json="" legacy_digest=""
 	normalized_slug=$(printf '%s' "$slug" | tr '[:upper:]' '[:lower:]')
 
 	payload=$(_extract_fenced_block "$body" 1)
@@ -1519,8 +1520,23 @@ _approval_classify_signed_comment() {
 	}
 	signed_digest=$(jq -r '.snapshot_sha256' <<<"$payload") || signed_digest=""
 	if [[ "$current_digest" != "$signed_digest" ]]; then
-		printf 'STALE_APPROVAL\n'
-		return 0
+		# #aidevops:trust-boundary — V2 approvals issued before GH#29009
+		# included mutable linked-source updated_at metadata. Accept that profile
+		# only when its complete current digest still matches the signed digest;
+		# new approvals always use the stable profile above.
+		legacy_snapshot_json=$(approval_snapshot_v2_build "$target_type" "$target_number" "$slug" "$comment_id" "$issued_at" "legacy") || {
+			printf 'API_ERROR\n'
+			return 0
+		}
+		legacy_digest=$(approval_snapshot_v2_digest "$legacy_snapshot_json") || {
+			printf 'API_ERROR\n'
+			return 0
+		}
+		if [[ "$legacy_digest" != "$signed_digest" ]]; then
+			printf 'STALE_APPROVAL\n'
+			return 0
+		fi
+		snapshot_json="$legacy_snapshot_json"
 	fi
 
 	if [[ "$target_type" == "pr" ]]; then

--- a/.agents/scripts/approval-snapshot-v2.sh
+++ b/.agents/scripts/approval-snapshot-v2.sh
@@ -93,8 +93,10 @@ _approval_snapshot_v2_comments_json() {
 _approval_snapshot_v2_linked_references_json() {
 	local pages_json="$1"
 	local issued_at_cutoff="${2:-}"
+	local source_timestamp_profile="${3:-stable}"
 	local empty_string=""
 	local timestamp_pattern='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'
+	[[ "$source_timestamp_profile" == "stable" || "$source_timestamp_profile" == "legacy" ]] || return 1
 
 	# GitHub timeline cross-reference events are the authoritative read-only
 	# projection of issue/PR links. Keep external text and URLs as opaque bytes;
@@ -102,7 +104,12 @@ _approval_snapshot_v2_linked_references_json() {
 	# #aidevops:trust-boundary — approval authority covers references visible at
 	# signing time. A later reference cannot extend that signed authority and must
 	# not revoke it when GitHub exposes the timeline event asynchronously.
-	jq -cS --arg empty "$empty_string" --arg cutoff "$issued_at_cutoff" --arg timestamp_pattern "$timestamp_pattern" '
+	# Linked-source updated_at is intentionally excluded: any source comment
+	# mutates it, so reciprocal issue/PR approval comments would make the two
+	# signatures mutually stale. Source identity and scope-bearing content remain
+	# bound below.
+	jq -cS --arg empty "$empty_string" --arg cutoff "$issued_at_cutoff" --arg timestamp_pattern "$timestamp_pattern" \
+		--arg source_timestamp_profile "$source_timestamp_profile" '
 		def is_linked_reference:
 			(.event // $empty) == "cross-referenced"
 			or (.event // $empty) == "connected"
@@ -135,7 +142,7 @@ _approval_snapshot_v2_linked_references_json() {
 			},
 			commit_id: (.commit_id // $empty),
 			commit_url: (.commit_url // $empty),
-			source: (if (.source.issue // null) == null then null else {
+			source: (if (.source.issue // null) == null then null else ({
 				kind: (if (.source.issue.pull_request // null) == null then "issue" else "pr" end),
 				repository: ((.source.issue.repository.full_name // $empty) | ascii_downcase),
 				number: (.source.issue.number // null),
@@ -144,14 +151,15 @@ _approval_snapshot_v2_linked_references_json() {
 				title: (.source.issue.title // $empty),
 				body: (.source.issue.body // $empty),
 				state: (.source.issue.state // $empty),
-				updated_at: (.source.issue.updated_at // $empty),
 				author: {
 					id: (.source.issue.user.id // null),
 					node_id: (.source.issue.user.node_id // $empty),
 					login: (.source.issue.user.login // $empty),
 					type: (.source.issue.user.type // $empty)
 				}
-			} end)
+			} + (if $source_timestamp_profile == "legacy" then {
+				updated_at: (.source.issue.updated_at // $empty)
+			} else {} end)) end)
 		}
 		] | sort_by(.created_at, .event, .id)
 		end
@@ -192,6 +200,7 @@ approval_snapshot_v2_build() (
 	local slug="$3"
 	local excluded_comment_id="${4:-}"
 	local issued_at_cutoff="${5:-}"
+	local source_timestamp_profile="${6:-stable}"
 	local issue_json="" comments_pages="" comments_json="" timeline_pages="" linked_references_json="" normalized_slug=""
 	local empty_string=""
 	local temp_dir=""
@@ -211,7 +220,7 @@ approval_snapshot_v2_build() (
 	comments_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/issues/${target_number}/comments?per_page=100") || return 1
 	comments_json=$(_approval_snapshot_v2_comments_json "$comments_pages" "$excluded_comment_id" "conversation") || return 1
 	timeline_pages=$(_approval_snapshot_v2_fetch_pages "repos/${slug}/issues/${target_number}/timeline?per_page=100") || return 1
-	linked_references_json=$(_approval_snapshot_v2_linked_references_json "$timeline_pages" "$issued_at_cutoff") || return 1
+	linked_references_json=$(_approval_snapshot_v2_linked_references_json "$timeline_pages" "$issued_at_cutoff" "$source_timestamp_profile") || return 1
 	temp_dir=$(_approval_snapshot_v2_create_temp_dir) || return 1
 	trap 'rm -rf "$temp_dir"' EXIT
 	_approval_snapshot_v2_write_json_file "$temp_dir/issue.json" "$issue_json" || return 1
@@ -307,10 +316,11 @@ approval_snapshot_v2_payload() (
 	local slug="$3"
 	local issued_at="$4"
 	local excluded_comment_id="${5:-}"
+	local source_timestamp_profile="${6:-stable}"
 	local snapshot_json="" digest="" normalized_slug=""
 	local temp_dir=""
 
-	snapshot_json=$(approval_snapshot_v2_build "$target_type" "$target_number" "$slug" "$excluded_comment_id" "$issued_at") || return 1
+	snapshot_json=$(approval_snapshot_v2_build "$target_type" "$target_number" "$slug" "$excluded_comment_id" "$issued_at" "$source_timestamp_profile") || return 1
 	digest=$(approval_snapshot_v2_digest "$snapshot_json") || return 1
 	normalized_slug=$(printf '%s' "$slug" | tr '[:upper:]' '[:lower:]')
 	temp_dir=$(_approval_snapshot_v2_create_temp_dir) || return 1

--- a/.agents/scripts/tests/test-approval-helper-content-binding.sh
+++ b/.agents/scripts/tests/test-approval-helper-content-binding.sh
@@ -108,9 +108,10 @@ append_signed_comment() {
 	local number="$2"
 	local issued_at="$3"
 	local comment_id="${4:-$((number * 100 + 99))}"
+	local source_timestamp_profile="${5:-stable}"
 	local comments_file="${FIXTURES}/comments-${number}.json"
 	local payload="" signature_file="" signature="" body="" updated=""
-	payload=$(PATH="${TEST_ROOT}/bin:$PATH" FIXTURES="$FIXTURES" approval_snapshot_v2_payload "$kind" "$number" owner/repo "$issued_at") || return 1
+	payload=$(PATH="${TEST_ROOT}/bin:$PATH" FIXTURES="$FIXTURES" approval_snapshot_v2_payload "$kind" "$number" owner/repo "$issued_at" "" "$source_timestamp_profile") || return 1
 	signature_file="${TEST_ROOT}/signature-${number}.txt"
 	sign_payload "$payload" "$signature_file" || return 1
 	signature=$(<"$signature_file")
@@ -402,6 +403,23 @@ test_post_approval_linked_references() {
 	return 0
 }
 
+test_linked_source_timestamp_profiles() {
+	write_baseline_fixtures
+	append_signed_comment pr 42 "2026-01-01T00:05:00Z" 4298 legacy
+	assert_verify "legacy linked-source V2 snapshot remains verifiable" pr 42 VERIFIED 0 "$PR_HEAD"
+	jq '.[0][0].source.issue.updated_at = "2026-01-01T00:07:00Z"' "${FIXTURES}/timeline-42.json" >"${FIXTURES}/timeline.tmp" && mv "${FIXTURES}/timeline.tmp" "${FIXTURES}/timeline-42.json"
+	assert_verify "legacy linked-source timestamp drift remains stale" pr 42 STALE_APPROVAL 4 "$PR_HEAD"
+
+	reset_and_sign issue 41
+	jq '.[0][0].source.issue.updated_at = "2026-01-01T00:07:00Z"' "${FIXTURES}/timeline-41.json" >"${FIXTURES}/timeline.tmp" && mv "${FIXTURES}/timeline.tmp" "${FIXTURES}/timeline-41.json"
+	assert_verify "linked-source timestamp drift does not stale issue approval" issue 41 VERIFIED 0
+
+	reset_and_sign pr 42
+	jq '.[0][0].source.issue.updated_at = "2026-01-01T00:07:00Z"' "${FIXTURES}/timeline-42.json" >"${FIXTURES}/timeline.tmp" && mv "${FIXTURES}/timeline.tmp" "${FIXTURES}/timeline-42.json"
+	assert_verify "linked-source timestamp drift does not stale PR approval" pr 42 VERIFIED 0 "$PR_HEAD"
+	return 0
+}
+
 main() {
 	install_gh_stub
 	write_baseline_fixtures
@@ -421,6 +439,7 @@ main() {
 
 	reset_and_sign pr 42
 	assert_verify "unchanged PR V2 snapshot verifies exact head" pr 42 VERIFIED 0 "$PR_HEAD"
+	test_linked_source_timestamp_profiles
 	local original_digest="" repeated_payload="" repeated_digest=""
 	original_digest=$(jq -r '.snapshot_sha256' "${TEST_ROOT}/payload-42.json")
 	repeated_payload=$(PATH="${TEST_ROOT}/bin:$PATH" FIXTURES="$FIXTURES" approval_snapshot_v2_payload pr 42 owner/repo "2026-01-01T00:06:00Z")


### PR DESCRIPTION
## Summary

Prevent reciprocal issue and PR approval comments from invalidating each other by omitting mutable linked-source timestamps from new V2 snapshots, while retaining exact-digest verification for legacy V2 signatures.

## Files Changed

.agents/scripts/approval-helper.sh, .agents/scripts/approval-snapshot-v2.sh, .agents/scripts/tests/test-approval-helper-content-binding.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Runtime-verified production-path fixtures: approval content binding 39/39, full-loop merge authority guard 20/20, approval verify-state 2/2; ShellCheck passed; linters-local.sh and linters-local.sh --full completed successfully.

Resolves #29009


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.199 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 3h 22m and 948,517 tokens on this with the user in an interactive session.