### PR TITLE
GH#29022: Apply OpenCode autoupdate pin in unified generator

### DIFF
--- a/.agents/scripts/agent-discovery.py
+++ b/.agents/scripts/agent-discovery.py
@@ -124,6 +124,8 @@ def output_opencode_json():
         print(f"Error: Failed to load {config_path}: {e}", file=sys.stderr)
         sys.exit(1)
 
+    # Keep OpenCode updates behind the framework-controlled runtime pin.
+    config['autoupdate'] = False
     _update_opencode_agents(config, sorted_agents, primary_agents)
     _merge_instructions(config)
     _ensure_plugin_registered(config)

--- a/.agents/scripts/tests/test-runtime-command-reconciliation.sh
+++ b/.agents/scripts/tests/test-runtime-command-reconciliation.sh
@@ -45,14 +45,14 @@ if _opencode_managed_config_matches_source; then
 	exit 1
 fi
 
-HOME="$TEST_HOME" python3 "$REPO_ROOT/.agents/scripts/opencode-agent-discovery.py" >/dev/null
+_generate_for_runtime opencode agents >/dev/null
 if ! jq -e '.autoupdate == false and .custom == "preserve"' "$TEST_HOME/.config/opencode/opencode.json" >/dev/null; then
-	printf '%s\n' 'FAIL: OpenCode config generation did not disable autoupdate while preserving unrelated keys' >&2
+	printf '%s\n' 'FAIL: unified OpenCode config generation did not disable autoupdate while preserving unrelated keys' >&2
 	exit 1
 fi
-HOME="$TEST_HOME" python3 "$REPO_ROOT/.agents/scripts/opencode-agent-discovery.py" >/dev/null
+_generate_for_runtime opencode agents >/dev/null
 if ! jq -e '.autoupdate == false and .custom == "preserve"' "$TEST_HOME/.config/opencode/opencode.json" >/dev/null; then
-	printf '%s\n' 'FAIL: repeated OpenCode config generation did not preserve managed autoupdate state' >&2
+	printf '%s\n' 'FAIL: repeated unified OpenCode config generation did not preserve managed autoupdate state' >&2
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary

Persist autoupdate=false through the active unified OpenCode agent generator and move regression coverage from the legacy generator to the real unified path.

## Files Changed

.agents/scripts/agent-discovery.py, .agents/scripts/tests/test-runtime-command-reconciliation.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — runtime-verified: the isolated-HOME reconciliation test executed the actual unified generator twice, changed autoupdate=true to false, preserved an unrelated custom key, and passed; ShellCheck, Python compilation, git diff --check, changed-file linters, Qlty regression 47→47, and the zero-new-file gate also passed.

Resolves #29022


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.200 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 4h 26m and 2,422,925 tokens on this with the user in an interactive session.