### PR TITLE
GH#29022: re-aggregate corrective OpenCode release

### DIFF
--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -129,6 +129,10 @@ Aggregation PR #29026 reviews corrective OpenCode unified-generator PR #29023
 at `623e6aeedd77dbf4b1b69b6f411ae71ceb66515d` because the simplification-state
 update advanced `main` before publication.
 
+A pending aggregation re-reviews authorized aggregation PR #29026 at
+`351c820f5db214ddf7a069d57f3db9b74e2b6321` because PR #28910 advanced `main`
+before publication.
+
 Manual arbitrary-version package publication is intentionally unsupported. A
 recovery operation must use an existing tag that passes the same verifier.
 

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -129,7 +129,7 @@ Aggregation PR #29026 reviews corrective OpenCode unified-generator PR #29023
 at `623e6aeedd77dbf4b1b69b6f411ae71ceb66515d` because the simplification-state
 update advanced `main` before publication.
 
-A pending aggregation re-reviews authorized aggregation PR #29026 at
+Aggregation PR #29031 re-reviews authorized aggregation PR #29026 at
 `351c820f5db214ddf7a069d57f3db9b74e2b6321` because PR #28910 advanced `main`
 before publication.
 


### PR DESCRIPTION
## Summary

Re-aggregate authorized exact-tip PR #29026 after PR #28910 advanced `main` before publication could start.

## Release provenance

- Authorized source: PR #29026 at merge `351c820f5db214ddf7a069d57f3db9b74e2b6321`.
- PR #29026 already reviews corrective unified-generator PR #29023 at `623e6aeedd77dbf4b1b69b6f411ae71ceb66515d`.
- Exact branch base: `2d7ab05efc2b5e098f0f31b232cacb6ed63f6484`.
- Sequence: this draft was created from initial documentation commit `9ccf24f4f`; a follow-up commit will bind the allocated PR and immutable source manifest without rewriting published history.

## Verification

- The corrective runtime reconciliation test and live `autoupdate: false` convergence already passed.
- Local changed-file lint, Markdown lint, secret scanning, file-size regression, and `git diff --check` passed.
- The earlier release attempt stopped before publication because current `main` was no longer an explicit aggregation tip.

## Risk and release

- Documentation-only provenance attestation; this PR performs no publication.
- Publication remains constrained to the canonical `aidevops release` entry point after this exact tip is reviewed and merged.

Ref #29002
Ref #29022
Ref #29023
Ref #29026

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.200 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 3h 33m and 586,651 tokens on this with the user in an interactive session. Overall, 1h 13m since this issue was created.
