### PR TITLE
GH#28980: feat: add bounded Pulse queue observability

### DIFF
--- a/.agents/scripts/pulse-check-helper.sh
+++ b/.agents/scripts/pulse-check-helper.sh
@@ -36,6 +36,7 @@ APPLY_MODE=0
 MAX_ISSUES_PER_REPO="${PULSE_CHECK_MAX_ISSUES_PER_REPO:-100}"
 AVAILABLE_THRESHOLD="${PULSE_CHECK_AVAILABLE_THRESHOLD:-3}"
 OLD_AVAILABLE_MINUTES="${PULSE_CHECK_OLD_AVAILABLE_MINUTES:-30}"
+NMR_INACTIVE_MINUTES="${PULSE_CHECK_NMR_INACTIVE_MINUTES:-10080}"
 FAILURE_FAMILY_THRESHOLD="${PULSE_CHECK_FAILURE_FAMILY_THRESHOLD:-3}"
 FAILURE_FAMILY_RECOVERY_SECONDS="${PULSE_CHECK_FAILURE_FAMILY_RECOVERY_SECONDS:-86400}"
 FAILURE_FAMILY_STATE_FILE="${PULSE_CHECK_FAILURE_FAMILY_STATE_FILE:-${HOME}/.aidevops/cache/failure-family-remediation.json}"
@@ -54,6 +55,7 @@ Options:
   --max-issues <N>           Per-repo auto-dispatch issue scan limit (default: ${MAX_ISSUES_PER_REPO})
   --available-threshold <N>  Queue depth threshold for underfill findings (default: ${AVAILABLE_THRESHOLD})
   --old-available-minutes <N> Age threshold for stale available queue counts (default: ${OLD_AVAILABLE_MINUTES})
+  --nmr-inactive-minutes <N> Issue inactivity threshold for aggregate NMR advisories (default: ${NMR_INACTIVE_MINUTES})
   --failure-family-threshold <N> Distinct recurrent family threshold (default: ${FAILURE_FAMILY_THRESHOLD})
   --json                     Emit JSON report
   --apply                    File deduplicated self-improvement issues for autofile findings
@@ -82,6 +84,7 @@ _parse_args() {
 		--max-issues) MAX_ISSUES_PER_REPO="$next"; shift 2 ;;
 		--available-threshold) AVAILABLE_THRESHOLD="$next"; shift 2 ;;
 		--old-available-minutes) OLD_AVAILABLE_MINUTES="$next"; shift 2 ;;
+		--nmr-inactive-minutes) NMR_INACTIVE_MINUTES="$next"; shift 2 ;;
 		--failure-family-threshold) FAILURE_FAMILY_THRESHOLD="$next"; shift 2 ;;
 		--json) JSON_OUTPUT=1; shift ;;
 		--apply) APPLY_MODE=1; shift ;;
@@ -96,6 +99,7 @@ _validate_numeric_options() {
 	[[ "$MAX_ISSUES_PER_REPO" =~ ^[0-9]+$ ]] || MAX_ISSUES_PER_REPO=100
 	[[ "$AVAILABLE_THRESHOLD" =~ ^[0-9]+$ ]] || AVAILABLE_THRESHOLD=3
 	[[ "$OLD_AVAILABLE_MINUTES" =~ ^[0-9]+$ ]] || OLD_AVAILABLE_MINUTES=30
+	[[ "$NMR_INACTIVE_MINUTES" =~ ^[0-9]+$ ]] || NMR_INACTIVE_MINUTES=10080
 	[[ "$FAILURE_FAMILY_THRESHOLD" =~ ^[0-9]+$ ]] || FAILURE_FAMILY_THRESHOLD=3
 	[[ "$FAILURE_FAMILY_RECOVERY_SECONDS" =~ ^[0-9]+$ ]] || FAILURE_FAMILY_RECOVERY_SECONDS=86400
 	return 0
@@ -119,13 +123,14 @@ _run_json_helper() {
 _scan_auto_dispatch_queue() {
 	if [[ ! -f "$QUEUE_SCANNER" ]]; then
 		print_error "pulse-check: queue scanner not found: ${QUEUE_SCANNER}"
-		printf '{"aggregate":{"repos":0,"auto_dispatch_open":0,"available_unassigned":0,"available_old":0,"oldest_available_age_min":0,"repos_with_available":0,"queued":0,"assigned":0,"blocked_labels":0,"dependency_inconsistent_available":0,"needs_tier":0,"needs_status":0,"parent_task":0,"nmr":0,"no_auto_dispatch":0,"gh_errors":0},"error":"queue_scanner_missing"}\n'
+		printf '{"aggregate":{"repos":0,"auto_dispatch_open":0,"available_unassigned":0,"eligible_available_unassigned":0,"available_old":0,"oldest_available_age_min":0,"repos_with_available":0,"queued":0,"assigned":0,"assigned_in_flight":0,"blocked_labels":0,"blocked_explicit_hold":0,"dependency_inconsistent_available":0,"needs_tier":0,"needs_status":0,"malformed_metadata":0,"parent_task":0,"nmr":0,"nmr_inactive":0,"oldest_nmr_inactivity_age_min":0,"nmr_inactivity_threshold_min":0,"no_auto_dispatch":0,"gh_errors":0},"error":"queue_scanner_missing"}\n'
 		return 0
 	fi
 
 	PULSE_CHECK_REPOS_JSON="$REPOS_JSON" \
 		PULSE_CHECK_MAX_ISSUES_PER_REPO="$MAX_ISSUES_PER_REPO" \
 		PULSE_CHECK_OLD_AVAILABLE_MINUTES="$OLD_AVAILABLE_MINUTES" \
+		PULSE_CHECK_NMR_INACTIVE_MINUTES="$NMR_INACTIVE_MINUTES" \
 		python3 "$QUEUE_SCANNER"
 	return 0
 }
@@ -185,7 +190,7 @@ _render_text_report() {
 		"",
 		"## Current utilisation",
 		"- Active workers: " + (.summary.active_workers | tostring) + " / " + (.summary.max_workers | tostring) + " (available slots: " + (.summary.available_slots | tostring) + ")",
-		"- Auto-dispatch queue: " + (.summary.auto_dispatch_available_unassigned | tostring) + " available / " + (.summary.auto_dispatch_open | tostring) + " open across " + (.queue.repos | tostring) + " pulse repos",
+		"- Auto-dispatch queue: " + (.summary.auto_dispatch_available_unassigned | tostring) + " available (" + (.summary.auto_dispatch_eligible_available_unassigned | tostring) + " eligible) / " + (.summary.auto_dispatch_open | tostring) + " open across " + (.queue.repos | tostring) + " pulse repos",
 		"- Queue scan state: " + (.summary.auto_dispatch_scan_state // "scanned"),
 		"- Current window launches: " + (.summary.worker_launches_in_window | tostring) + "; terminal worker events: " + (.summary.worker_terminal_events_in_window | tostring),
 		"- Recent worker metric events: " + (.summary.recent_worker_events | tostring) + "; " + .inputs.historical_window + " runtime handoff rate: " + (.summary.historical_runtime_handoff_rate | percent_text) + "; delivered success rate: " + (.summary.historical_delivery_success_rate | percent_text),
@@ -261,7 +266,7 @@ ${recommendation}
 
 ## Implementation context
 
-- Primary files: \`.agents/scripts/pulse-check-helper.sh\`, \`.agents/scripts/pulse-current-state-helper.sh\`, \`.agents/scripts/worker-activity-helper.sh\`, \`.agents/scripts/pulse-diagnose-helper.sh\`, \`.agents/scripts/pulse-dispatch-worker-launch.sh\`, \`.agents/scripts/headless-runtime-helper.sh\`.
+- Primary files: \`.agents/scripts/pulse-check-queue-scan.py\`, \`.agents/scripts/pulse-check-report.jq\`, \`.agents/scripts/pulse-check-helper.sh\`, and \`.agents/scripts/tests/test-pulse-check-helper.sh\`; follow related diagnostics into current-state or worker helpers only when evidence requires it.
 - Reference patterns: \`.agents/reference/diagnostics-discipline.md\` and \`.agents/reference/worker-diagnostics.md\`.
 - If the exact broken path differs, keep the fix in the pulse/worker diagnostics layer and update this issue with the verified file path before implementation.
 

--- a/.agents/scripts/pulse-check-queue-scan.py
+++ b/.agents/scripts/pulse-check-queue-scan.py
@@ -49,17 +49,24 @@ def _empty_aggregate() -> dict[str, int]:
         "repos": 0,
         "auto_dispatch_open": 0,
         "available_unassigned": 0,
+        "eligible_available_unassigned": 0,
         "available_old": 0,
         "oldest_available_age_min": 0,
         "repos_with_available": 0,
         "queued": 0,
         "assigned": 0,
+        "assigned_in_flight": 0,
         "blocked_labels": 0,
+        "blocked_explicit_hold": 0,
         "dependency_inconsistent_available": 0,
         "needs_tier": 0,
         "needs_status": 0,
+        "malformed_metadata": 0,
         "parent_task": 0,
         "nmr": 0,
+        "nmr_inactive": 0,
+        "oldest_nmr_inactivity_age_min": 0,
+        "nmr_inactivity_threshold_min": 0,
         "no_auto_dispatch": 0,
         "infrastructure": 0,
         GH_ERRORS_KEY: 0,
@@ -104,7 +111,7 @@ def _load_repos(repos_json: pathlib.Path) -> tuple[list[dict[str, Any]], str]:
         return [], "repos_json_unreadable:TypeError"
     initialized = data.get("initialized_repos", [])
     if not isinstance(initialized, list):
-        return [], ""
+        return [], "repos_json_invalid:initialized_repos_type"
     repos = []
     for repo in initialized:
         if not isinstance(repo, dict):
@@ -126,7 +133,7 @@ def _fetch_repo_issues(slug: str, max_issues: int) -> Optional[list[dict[str, An
         "--repo", slug,
         "--state", "open",
         "--label", "auto-dispatch",
-        "--limit", str(max_issues),
+        "--limit", str(max_issues + 1),
         "--json", "number,title,body,labels,assignees,updatedAt",
     ]
     if _valid_repo_slug(slug):
@@ -177,21 +184,35 @@ def _count_issue(
     assigned = bool(issue.get("assignees"))
     blocked = bool(labels & BLOCKING_LABELS)
     dependency_inconsistent = bool(issue.get("dependency_inconsistent"))
+    has_tier = any(label.startswith("tier:") for label in labels)
+    has_status = any(label.startswith("status:") for label in labels)
+    age_min = _issue_age_minutes(issue, now)
+    is_nmr = "needs-maintainer-review" in labels
     aggregate["auto_dispatch_open"] += 1
     aggregate["assigned"] += int(assigned)
+    aggregate["assigned_in_flight"] += int(assigned)
     aggregate["queued"] += int("status:queued" in labels)
-    aggregate["needs_tier"] += int(not any(label.startswith("tier:") for label in labels))
-    aggregate["needs_status"] += int(not any(label.startswith("status:") for label in labels))
+    aggregate["needs_tier"] += int(not has_tier)
+    aggregate["needs_status"] += int(not has_status)
+    aggregate["malformed_metadata"] += int(not has_tier or not has_status)
     aggregate["blocked_labels"] += int(blocked)
+    aggregate["blocked_explicit_hold"] += int(blocked)
     aggregate["dependency_inconsistent_available"] += int(dependency_inconsistent)
     aggregate["parent_task"] += int("parent-task" in labels)
-    aggregate["nmr"] += int("needs-maintainer-review" in labels)
+    aggregate["nmr"] += int(is_nmr)
+    if is_nmr:
+        aggregate["nmr_inactive"] += int(
+            age_min >= aggregate["nmr_inactivity_threshold_min"]
+        )
+        aggregate["oldest_nmr_inactivity_age_min"] = max(
+            aggregate["oldest_nmr_inactivity_age_min"], age_min
+        )
     aggregate["no_auto_dispatch"] += int("no-auto-dispatch" in labels)
     aggregate["infrastructure"] += int("infrastructure" in labels)
     available = "status:available" in labels and not assigned and not blocked and not dependency_inconsistent
     if available:
         aggregate["available_unassigned"] += 1
-        age_min = _issue_age_minutes(issue, now)
+        aggregate["eligible_available_unassigned"] += int(has_tier and has_status)
         aggregate["available_old"] += int(age_min >= old_minutes)
         aggregate["oldest_available_age_min"] = max(aggregate["oldest_available_age_min"], age_min)
     return available
@@ -209,11 +230,17 @@ def _scan_repo(
     if issues is None:
         aggregate[GH_ERRORS_KEY] += 1
         return
+    if len(issues) > max_issues:
+        aggregate[GH_ERRORS_KEY] += 1
+        issues = issues[:max_issues]
     for issue in issues:
         inconsistent, scan_error = _dependency_diagnostic(slug, issue)
         issue["dependency_inconsistent"] = inconsistent
         aggregate[GH_ERRORS_KEY] += int(scan_error)
-    repo_available = sum(int(_count_issue(aggregate, issue, now, old_minutes)) for issue in issues)
+    repo_available = sum(
+        int(_count_issue(aggregate, issue, now, old_minutes))
+        for issue in issues
+    )
     aggregate["repos_with_available"] += int(repo_available > 0)
 
 
@@ -222,7 +249,9 @@ def main() -> int:
     skip_gh = os.environ.get("PULSE_CHECK_SKIP_GH", "") in {"1", "true", "TRUE", "yes", "YES"}
     max_issues = _int_from_env("PULSE_CHECK_MAX_ISSUES_PER_REPO", 100)
     old_minutes = _int_from_env("PULSE_CHECK_OLD_AVAILABLE_MINUTES", 30)
+    nmr_inactive_minutes = _int_from_env("PULSE_CHECK_NMR_INACTIVE_MINUTES", 10080)
     aggregate = _empty_aggregate()
+    aggregate["nmr_inactivity_threshold_min"] = nmr_inactive_minutes
 
     repos, load_error = _load_repos(repos_json)
     if load_error:

--- a/.agents/scripts/pulse-check-report.jq
+++ b/.agents/scripts/pulse-check-report.jq
@@ -16,11 +16,17 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
 (if $active_worker_processes == null then $inferred_active_workers else $active_worker_processes end) as $active_workers |
 (if $active_worker_processes == null then $available_slots else ([$max_workers - $active_worker_processes, 0] | max) end) as $effective_available_slots |
 ($queue.aggregate.available_unassigned // 0 | number_or_zero) as $available_issues |
+($queue.aggregate.eligible_available_unassigned // $queue.aggregate.available_unassigned // 0 | number_or_zero) as $eligible_issues |
 ($queue.aggregate.available_old // 0 | number_or_zero) as $old_available |
 ($queue.aggregate.dependency_inconsistent_available // 0 | number_or_zero) as $dependency_inconsistent |
 ($queue.aggregate.needs_tier // 0 | number_or_zero) as $needs_tier |
+($queue.aggregate.needs_status // 0 | number_or_zero) as $needs_status |
+($queue.aggregate.nmr_inactive // 0 | number_or_zero) as $nmr_inactive |
+($queue.aggregate.oldest_nmr_inactivity_age_min // 0 | number_or_zero) as $oldest_nmr_inactivity_age_min |
+($queue.aggregate.nmr_inactivity_threshold_min // 0 | number_or_zero) as $nmr_inactivity_threshold_min |
 ($queue.aggregate.gh_errors // 0 | number_or_zero) as $gh_errors |
 ($queue.error // "") as $queue_error |
+($queue_error == "" and $gh_errors == 0) as $queue_scan_complete |
 ($current.worker_outcomes.spawned // 0 | number_or_zero) as $spawned |
 ($current.worker_outcomes.launch_validation_failed // $current.pulse_counter_hits.dispatch_worker_launch_failed // 0 | number_or_zero) as $launch_validation_failed |
 ($current.worker_terminal_events // 0 | number_or_zero) as $current_terminal_events |
@@ -57,6 +63,7 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
     historical_success_rate: (if $hist_terminal_total > 0 and $hist_delivered != null then (($hist_delivered / $hist_terminal_total) * 100 | floor) else null end),
     auto_dispatch_open: ($queue.aggregate.auto_dispatch_open // 0),
     auto_dispatch_available_unassigned: $available_issues,
+    auto_dispatch_eligible_available_unassigned: $eligible_issues,
     auto_dispatch_available_old: $old_available,
     auto_dispatch_dependency_inconsistent_available: $dependency_inconsistent,
     auto_dispatch_repos_with_available: ($queue.aggregate.repos_with_available // 0),
@@ -122,18 +129,54 @@ def finding($id; $severity; $title; $evidence; $recommendation; $autofile): {
         true
       )
     else empty end,
-    if ($available_issues >= $threshold and $active_workers == 0) then
+    if ($queue_scan_complete and $eligible_issues >= $threshold and $active_workers == 0) then
       finding(
         "pulse-underfilled-auto-dispatch-queue";
         "high";
         "Auto-dispatch queue is visible while worker capacity is empty";
         [
           ("active_workers=" + ($active_workers | tostring) + "/" + ($max_workers | tostring)),
-          ("available_unassigned_auto_dispatch=" + ($available_issues | tostring)),
+          ("eligible_available_unassigned_auto_dispatch=" + ($eligible_issues | tostring)),
           ("available_older_than_threshold=" + ($old_available | tostring)),
           ("dispatch_stage_events=" + (($current.dispatch_stage_events // 0) | tostring))
         ];
         "Inspect why the pulse did not retain active workers for visible status:available auto-dispatch issues; start with pulse-current-state-helper, worker-activity-helper, and pulse-diagnose-helper cycle-health.";
+        true
+      )
+    else empty end,
+    if ($queue_scan_complete and $effective_available_slots >= $threshold and $eligible_issues < $threshold) then
+      finding(
+        "pulse-eligible-queue-under-target";
+        "high";
+        "Dispatch-eligible queue depth is below the bounded capacity target";
+        [
+          ("available_slots=" + ($effective_available_slots | tostring)),
+          ("eligible_available_unassigned=" + ($eligible_issues | tostring)),
+          ("eligible_depth_target=" + ($threshold | tostring)),
+          ("auto_dispatch_open=" + (($queue.aggregate.auto_dispatch_open // 0) | tostring)),
+          ("assigned_in_flight=" + (($queue.aggregate.assigned_in_flight // $queue.aggregate.assigned // 0) | tostring)),
+          ("blocked_explicit_hold=" + (($queue.aggregate.blocked_explicit_hold // $queue.aggregate.blocked_labels // 0) | tostring)),
+          ("needs_maintainer_review=" + (($queue.aggregate.nmr // 0) | tostring)),
+          ("missing_tier=" + ($needs_tier | tostring)),
+          ("missing_status=" + ($needs_status | tostring))
+        ];
+        "Run existing task generators and metadata normalisers for already-authorized work; if no eligible issues remain, request maintainer authorization decisions. Do not add auto-dispatch, clear needs-maintainer-review, or infer dispatch consent from status/origin labels.";
+        true
+      )
+    else empty end,
+    if ($queue_scan_complete and $nmr_inactive > 0) then
+      finding(
+        "pulse-inactive-nmr-holds";
+        "medium";
+        "Needs-maintainer-review holds have aged aggregate inactivity";
+        [
+          ("needs_maintainer_review=" + (($queue.aggregate.nmr // 0) | tostring)),
+          ("nmr_inactive_at_threshold=" + ($nmr_inactive | tostring)),
+          ("nmr_inactivity_threshold_minutes=" + ($nmr_inactivity_threshold_min | tostring)),
+          ("oldest_nmr_inactivity_minutes=" + ($oldest_nmr_inactivity_age_min | tostring)),
+          "nmr_inactivity_basis=issue_updatedAt_not_label_application_time"
+        ];
+        "Request authority-aware maintainer review of inactive NMR holds without removing needs-maintainer-review, adding auto-dispatch, posting approval markers, or commenting on individual held issues.";
         true
       )
     else empty end,

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -61,6 +61,7 @@ _PULSE_DISPATCH_CORE_LOADED=1
 _PULSE_DISPATCH_FALSE="false"
 _PULSE_DISPATCH_ELIGIBILITY_STAGE="eligibility_gate"
 _PULSE_DISPATCH_NMR_LABEL="needs-maintainer-review"
+_PULSE_DISPATCH_COLLABORATOR_ASSOCIATION="COLLABORATOR"
 
 # t2863: Module-level variable defaults (set -u guards).
 # Ensures LOGFILE is safe to dereference in all functions when this module
@@ -622,12 +623,13 @@ _issue_thread_is_trusted_maintainer_only() {
 	[[ -n "$comments_json" && "$comments_json" != "null" ]] || comments_json="[]"
 
 	local untrusted_comment_count
-	untrusted_comment_count=$(printf '%s' "$comments_json" | jq -r --arg array_type "array" '
+	untrusted_comment_count=$(printf '%s' "$comments_json" | jq -r --arg array_type "array" \
+		--arg collaborator_association "$_PULSE_DISPATCH_COLLABORATOR_ASSOCIATION" '
 		(if type == $array_type and (.[0]? | type) == $array_type then [.[][]]
 		elif type == $array_type then .
 		else [] end)
 		| [ .[] | select(
-			((.author_association // "NONE") as $a | ($a != "OWNER" and $a != "MEMBER" and $a != "COLLABORATOR"))
+			((.author_association // "NONE") as $a | ($a != "OWNER" and $a != "MEMBER" and $a != $collaborator_association))
 			and (((.user.login // .author.login // "") as $login
 				| ((($login == "github-actions[bot]") or ($login == "github-actions"))
 					and ((.body // "") | test("^<!-- (nmr-hold-guidance|ever-nmr-remediation) -->")))) | not)
@@ -637,12 +639,28 @@ _issue_thread_is_trusted_maintainer_only() {
 	[[ "$untrusted_comment_count" =~ ^[0-9]+$ ]] || return 1
 	[[ "$untrusted_comment_count" -eq 0 ]] || return 1
 
-	local collaborator_comment_logins
-	collaborator_comment_logins=$(printf '%s' "$comments_json" | jq -r --arg array_type "array" '
+	local missing_collaborator_login_count
+	missing_collaborator_login_count=$(printf '%s' "$comments_json" | jq -r --arg array_type "array" \
+		--arg collaborator_association "$_PULSE_DISPATCH_COLLABORATOR_ASSOCIATION" '
 		(if type == $array_type and (.[0]? | type) == $array_type then [.[][]]
 		elif type == $array_type then .
 		else [] end)
-		| [ .[] | select((.author_association // "NONE") == "COLLABORATOR") | (.user.login // .author.login // "") ]
+		| [ .[] | select(
+			(.author_association // "NONE") == $collaborator_association
+			and ((.user.login // .author.login // "") == "")
+		) ]
+		| length
+	') || return 1
+	[[ "$missing_collaborator_login_count" =~ ^[0-9]+$ ]] || return 1
+	[[ "$missing_collaborator_login_count" -eq 0 ]] || return 1
+
+	local collaborator_comment_logins
+	collaborator_comment_logins=$(printf '%s' "$comments_json" | jq -r --arg array_type "array" \
+		--arg collaborator_association "$_PULSE_DISPATCH_COLLABORATOR_ASSOCIATION" '
+		(if type == $array_type and (.[0]? | type) == $array_type then [.[][]]
+		elif type == $array_type then .
+		else [] end)
+		| [ .[] | select((.author_association // "NONE") == $collaborator_association) | (.user.login // .author.login // "") ]
 		| unique | .[]
 	') || return 1
 	local comment_login
@@ -662,7 +680,7 @@ _issue_actor_has_repo_write_permission() {
 	# #aidevops:trust-boundary — never trust bare COLLABORATOR association for
 	# ever-NMR bypass. GitHub can use COLLABORATOR for ambiguous private-org
 	# events; require an authenticated per-repo permission lookup.
-	_gh_actor_has_repo_write_authority "$repo_slug" "$login" "COLLABORATOR"
+	_gh_actor_has_repo_write_authority "$repo_slug" "$login" "$_PULSE_DISPATCH_COLLABORATOR_ASSOCIATION"
 	return $?
 }
 

--- a/.agents/scripts/tests/test-pulse-check-helper.sh
+++ b/.agents/scripts/tests/test-pulse-check-helper.sh
@@ -197,6 +197,39 @@ if [[ " $* " == *" --search "* ]]; then
   printf '[]\n'
   exit 0
 fi
+if [[ "${PULSE_CHECK_QUEUE_FIXTURE:-}" == "scan-error" && " $* " == *"public/repo-two"* ]]; then
+  printf 'simulated queue scan failure\n' >&2
+  exit 1
+fi
+if [[ "${PULSE_CHECK_QUEUE_FIXTURE:-}" == "malformed" ]]; then
+  if [[ " $* " == *"private/repo-one"* ]]; then
+    cat <<'JSON'
+[
+  {"number":21,"title":"private malformed one","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"}]},
+  {"number":22,"title":"private malformed two","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"}]},
+  {"number":23,"title":"private malformed three","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"}]}
+]
+JSON
+  else
+    printf '[]\n'
+  fi
+  exit 0
+fi
+if [[ "${PULSE_CHECK_QUEUE_FIXTURE:-}" == "shortfall" || "${PULSE_CHECK_QUEUE_FIXTURE:-}" == "scan-error" || "${PULSE_CHECK_QUEUE_FIXTURE:-}" == "truncation" ]]; then
+  if [[ " $* " == *"private/repo-one"* ]]; then
+    cat <<'JSON'
+[
+  {"number":11,"title":"private eligible","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"tier:standard"}]},
+  {"number":12,"title":"private assigned","updatedAt":"2000-01-01T00:00:00Z","assignees":[{"login":"worker"}],"labels":[{"name":"auto-dispatch"},{"name":"status:queued"},{"name":"tier:standard"}]},
+  {"number":13,"title":"private nmr","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"tier:thinking"},{"name":"needs-maintainer-review"}]},
+  {"number":14,"title":"private malformed","updatedAt":"2000-01-01T00:00:00Z","assignees":[],"labels":[{"name":"auto-dispatch"},{"name":"status:available"}]}
+]
+JSON
+  else
+    printf '[]\n'
+  fi
+  exit 0
+fi
 if [[ " $* " == *"private/repo-one"* ]]; then
   cat <<'JSON'
 [
@@ -256,7 +289,7 @@ printf '%s=== pulse-check-helper.sh tests ===%s\n' "$TEST_BLUE" "$TEST_NC"
 
 OUT=$(env "${COMMON_ENV[@]}" "$HELPER" report 2>&1)
 assert_contains "text report shows empty active capacity" "Active workers: 0 / 6" "$OUT"
-assert_contains "text report excludes infrastructure advisories from available work" "Auto-dispatch queue: 5 available / 6 open" "$OUT"
+assert_contains "text report distinguishes eligible work" "Auto-dispatch queue: 5 available (4 eligible) / 6 open" "$OUT"
 assert_contains "underfilled finding appears" "pulse-underfilled-auto-dispatch-queue" "$OUT"
 assert_contains "launch accounting finding appears" "pulse-launch-accounting-gap" "$OUT"
 assert_not_contains "text report omits private slug" "private/repo-one" "$OUT"
@@ -273,6 +306,11 @@ HANDOFF_RATE=$(printf '%s' "$JSON_OUT" | jq -r '.summary.historical_runtime_hand
 assert_eq "json runtime handoff rate uses terminal session denominator" "90" "$HANDOFF_RATE"
 SUCCESS_RATE=$(printf '%s' "$JSON_OUT" | jq -r '.summary.historical_success_rate')
 assert_eq "json delivered success rate is unknown without GitHub delivery check" "null" "$SUCCESS_RATE"
+
+MALFORMED_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_QUEUE_FIXTURE=malformed" "$HELPER" json 2>&1)
+assert_contains "malformed queue emits normalization shortfall" "pulse-eligible-queue-under-target" "$MALFORMED_OUT"
+assert_contains "malformed queue reports missing tiers" "auto-dispatch-missing-tier-labels" "$MALFORMED_OUT"
+assert_not_contains "malformed queue cannot trigger worker-retention underfill" "pulse-underfilled-auto-dispatch-queue" "$MALFORMED_OUT"
 
 cat >"${TEST_ROOT}/current-state-active.sh" <<'SH'
 #!/usr/bin/env bash
@@ -297,6 +335,54 @@ ACTIVE_IDS=$(printf '%s' "$JSON_ACTIVE_OUT" | jq -r '[.findings[].id] | sort | j
 assert_eq "json reports process-scan active workers" "2" "$ACTIVE_COUNT"
 assert_eq "json recomputes available slots from process count" "4" "$ACTIVE_AVAILABLE"
 assert_eq "process-scan active workers suppress underfill finding" "auto-dispatch-missing-tier-labels" "$ACTIVE_IDS"
+
+cat >"${TEST_ROOT}/current-state-shortfall.sh" <<'SH'
+#!/usr/bin/env bash
+cat <<'JSON'
+{
+  "dispatch_alive": true,
+  "dispatch_stage_events": 2,
+  "active_worker_processes": 2,
+  "current_state_guardrails": {"available_slots_last": 22},
+  "pulse_gauges": {"dispatch_capacity_final_max_workers": 24},
+  "worker_outcomes": {"spawned": 0},
+  "worker_terminal_events": 0,
+  "graphql_budget_status": "OK fixture"
+}
+JSON
+SH
+chmod +x "${TEST_ROOT}/current-state-shortfall.sh"
+SHORTFALL_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_QUEUE_FIXTURE=shortfall" \
+	"PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_ROOT}/current-state-shortfall.sh" "$HELPER" json 2>&1)
+SHORTFALL_IDS=$(printf '%s' "$SHORTFALL_OUT" | jq -r '[.findings[].id] | sort | join(",")')
+assert_eq "active workers do not hide eligible queue shortfall" "auto-dispatch-missing-tier-labels,pulse-eligible-queue-under-target,pulse-inactive-nmr-holds" "$SHORTFALL_IDS"
+assert_eq "shortfall fixture has one eligible issue" "1" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.queue.eligible_available_unassigned')"
+assert_eq "shortfall fixture distinguishes assigned work" "1" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.queue.assigned_in_flight')"
+assert_eq "shortfall fixture distinguishes held work" "1" "$(printf '%s' "$SHORTFALL_OUT" | jq -r '.queue.blocked_explicit_hold')"
+assert_contains "NMR advisory names updatedAt inactivity basis" "issue_updatedAt_not_label_application_time" "$SHORTFALL_OUT"
+assert_not_contains "shortfall JSON omits private issue title" "private nmr" "$SHORTFALL_OUT"
+
+SCAN_ERROR_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_QUEUE_FIXTURE=scan-error" \
+	"PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_ROOT}/current-state-shortfall.sh" "$HELPER" json 2>&1)
+assert_contains "partial scan reports GitHub error" "pulse-check-gh-scan-errors" "$SCAN_ERROR_OUT"
+assert_not_contains "partial scan suppresses queue shortfall" "pulse-eligible-queue-under-target" "$SCAN_ERROR_OUT"
+assert_not_contains "partial scan suppresses NMR inactivity" "pulse-inactive-nmr-holds" "$SCAN_ERROR_OUT"
+
+TRUNCATED_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_QUEUE_FIXTURE=truncation" \
+	"PULSE_CHECK_MAX_ISSUES_PER_REPO=3" \
+	"PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_ROOT}/current-state-shortfall.sh" "$HELPER" json 2>&1)
+assert_contains "saturated scan reports bounded incompleteness" "pulse-check-gh-scan-errors" "$TRUNCATED_OUT"
+assert_not_contains "saturated scan suppresses queue shortfall" "pulse-eligible-queue-under-target" "$TRUNCATED_OUT"
+assert_not_contains "saturated scan suppresses NMR inactivity" "pulse-inactive-nmr-holds" "$TRUNCATED_OUT"
+
+cat >"${TEST_ROOT}/repos-invalid.json" <<'JSON'
+{"initialized_repos":"not-an-array"}
+JSON
+INVALID_REPOS_OUT=$(env "${COMMON_ENV[@]}" "PULSE_CHECK_REPOS_JSON=${TEST_ROOT}/repos-invalid.json" \
+	"PULSE_CHECK_CURRENT_STATE_HELPER=${TEST_ROOT}/current-state-shortfall.sh" "$HELPER" json 2>&1)
+assert_contains "malformed repos schema reports incomplete scan" "pulse-check-queue-scan-skipped" "$INVALID_REPOS_OUT"
+assert_not_contains "malformed repos schema suppresses queue shortfall" "pulse-eligible-queue-under-target" "$INVALID_REPOS_OUT"
+assert_not_contains "malformed repos schema suppresses NMR inactivity" "pulse-inactive-nmr-holds" "$INVALID_REPOS_OUT"
 
 cat >"${TEST_ROOT}/current-state.sh" <<'SH'
 #!/usr/bin/env bash

--- a/.agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 CORE_SCRIPT="${SCRIPT_DIR}/../pulse-dispatch-core.sh"
+AUTHORITY_SCRIPT="${SCRIPT_DIR}/../shared-gh-collaborator-permission.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -21,6 +22,7 @@ ISSUE_LOGIN="maintainer"
 COMMENTS_JSON="[]"
 APPROVAL_KNOWN_STATUS=""
 COLLAB_PERMISSION="write"
+_AIDEVOPS_GH_PERMISSION_UNKNOWN_VALUE="unknown"
 
 print_result() {
 	local test_name="$1"
@@ -44,10 +46,12 @@ print_result() {
 define_helpers_under_test() {
 	local helper_src
 	helper_src=$(awk '
+		/^_PULSE_DISPATCH_COLLABORATOR_ASSOCIATION=/ { print }
 		/^_issue_thread_is_trusted_maintainer_only\(\) \{/,/^}$/ { print }
 		/^_issue_actor_has_repo_write_permission\(\) \{/,/^}$/ { print }
 		/^_check_nmr_approval_gate\(\) \{/,/^}$/ { print }
-	' "$CORE_SCRIPT")
+		/^_gh_actor_has_repo_write_authority\(\) \{/,/^}$/ { print }
+	' "$CORE_SCRIPT" "$AUTHORITY_SCRIPT")
 	if [[ -z "$helper_src" ]]; then
 		printf 'ERROR: could not extract helpers from %s\n' "$CORE_SCRIPT" >&2
 		return 1
@@ -282,6 +286,39 @@ test_write_collaborator_comments_bypass_historical_nmr() {
 	return 0
 }
 
+test_collaborator_comment_without_login_preserves_historical_nmr() {
+	setup_case "OWNER" '[{"author_association":"COLLABORATOR","body":"missing identity"}]'
+	if _check_nmr_approval_gate 110 "owner/repo" '{"labels":[{"name":"auto-dispatch"}]}'; then
+		if [[ "$APPROVAL_KNOWN_STATUS" == "unknown" ]]; then
+			print_result "COLLABORATOR comment without login preserves historical NMR" 0
+		else
+			print_result "COLLABORATOR comment without login preserves historical NMR" 1 "expected known_status=unknown, got ${APPROVAL_KNOWN_STATUS}"
+		fi
+		cleanup_case
+		return 0
+	fi
+	print_result "COLLABORATOR comment without login preserves historical NMR" 1 "gate unexpectedly allowed dispatch"
+	cleanup_case
+	return 0
+}
+
+test_collaborator_permission_failure_preserves_historical_nmr() {
+	setup_case "OWNER" '[{"author_association":"COLLABORATOR","user":{"login":"coadmin"},"body":"lookup fails"}]'
+	COLLAB_PERMISSION="fail"
+	if _check_nmr_approval_gate 111 "owner/repo" '{"labels":[{"name":"auto-dispatch"}]}'; then
+		if [[ "$APPROVAL_KNOWN_STATUS" == "unknown" ]]; then
+			print_result "COLLABORATOR permission failure preserves historical NMR" 0
+		else
+			print_result "COLLABORATOR permission failure preserves historical NMR" 1 "expected known_status=unknown, got ${APPROVAL_KNOWN_STATUS}"
+		fi
+		cleanup_case
+		return 0
+	fi
+	print_result "COLLABORATOR permission failure preserves historical NMR" 1 "gate unexpectedly allowed dispatch"
+	cleanup_case
+	return 0
+}
+
 test_comment_jq_parse_errors_remain_visible() {
 	setup_case "OWNER" '{not-json'
 	local stderr_file="${TEST_ROOT}/jq-stderr.log"
@@ -338,6 +375,8 @@ main() {
 	test_active_nmr_label_preserves_gate
 	test_collaborator_author_does_not_bypass_historical_nmr
 	test_write_collaborator_comments_bypass_historical_nmr
+	test_collaborator_comment_without_login_preserves_historical_nmr
+	test_collaborator_permission_failure_preserves_historical_nmr
 	test_comment_jq_parse_errors_remain_visible
 	test_comment_jq_error_matcher_handles_jq_versions
 


### PR DESCRIPTION
## Summary

Distinguish eligible, assigned, held, and malformed Pulse queue work; report capacity shortfalls and aggregate updatedAt-based NMR inactivity without widening dispatch authority; fix the prior Qlty function-parameters regression.

## Files Changed

.agents/scripts/pulse-check-helper.sh, .agents/scripts/pulse-check-queue-scan.py, .agents/scripts/pulse-check-report.jq, .agents/scripts/pulse-dispatch-core.sh, .agents/scripts/tests/test-pulse-check-helper.sh, .agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified through deterministic helper/scanner/report fixtures: bash .agents/scripts/tests/test-pulse-check-helper.sh; bash .agents/scripts/tests/test-pulse-nmr-approval.sh; bash .agents/scripts/tests/test-pulse-nmr-maintainer-authority.sh; bash .agents/scripts/tests/test-pulse-dispatch-core-nmr-trusted-thread.sh. Quality: QLTY_CLI_VERSION=0.636.0 .agents/scripts/qlty-regression-helper.sh --base origin/main --head HEAD; .agents/scripts/linters-local.sh --changed --no-cache.

Resolves #28980


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.200 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 19m and 103,373 tokens on this as a headless worker.