### PR TITLE
GH#29036: add commit history charts to profile READMEs

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -651,6 +651,48 @@ _build_readme_connect() {
 	return 0
 }
 
+# --- Build the commit-history chart for a user ---
+# Usage: _build_commit_history_chart <gh_user>
+# Outputs a centered light/dark picture without a clickable provider backlink.
+_build_commit_history_chart() {
+	local gh_user="$1"
+	gh_user="${gh_user//[^a-zA-Z0-9-]/}"
+	if [[ -z "$gh_user" ]]; then
+		return 0
+	fi
+
+	cat <<EOF
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://commit-history.com/embed/${gh_user}?theme=dark" />
+    <img alt="${gh_user}'s commit history" src="https://commit-history.com/embed/${gh_user}" />
+  </picture>
+</div>
+EOF
+	return 0
+}
+
+# --- Append the commit-history chart to an older aidevops-generated README ---
+# Usage: _ensure_commit_history_chart <readme_path> <gh_user>
+_ensure_commit_history_chart() {
+	local readme_path="$1"
+	local gh_user="$2"
+	if ! grep -Fq '> Stats auto-updated by [aidevops]' "$readme_path" 2>/dev/null; then
+		return 0
+	fi
+	if grep -Fq 'https://commit-history.com/embed/' "$readme_path" 2>/dev/null; then
+		return 0
+	fi
+
+	local commit_history_chart
+	commit_history_chart=$(_build_commit_history_chart "$gh_user")
+	if [[ -z "$commit_history_chart" ]]; then
+		return 0
+	fi
+	printf '\n%s\n' "$commit_history_chart" >>"$readme_path"
+	return 0
+}
+
 # --- Generate rich profile README from GitHub data ---
 _generate_rich_readme() {
 	local gh_user="$1"
@@ -700,6 +742,8 @@ _generate_rich_readme() {
 	# Build connect section
 	local connect
 	connect=$(_build_readme_connect "$gh_user" "$blog" "$twitter")
+	local commit_history_chart
+	commit_history_chart=$(_build_commit_history_chart "$gh_user")
 
 	# Compose the README
 	{
@@ -745,6 +789,8 @@ _generate_rich_readme() {
 		echo ""
 		echo "<!-- UPDATED-START -->"
 		echo "<!-- UPDATED-END -->"
+		echo ""
+		printf '%s\n' "$commit_history_chart"
 	} >"$readme_path"
 
 	return 0
@@ -1163,6 +1209,9 @@ cmd_update() {
 		}
 		!skip { print }
 	' "$readme_path" >"$tmp_file"
+	local gh_user
+	gh_user=$(_resolve_profile_user "$profile_repo")
+	_ensure_commit_history_chart "$tmp_file" "$gh_user"
 
 	# Check if content changed, ignoring UPDATED marker block
 	local old_normalized new_normalized

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -216,6 +216,47 @@ test_update_preserves_manual_sections() {
 	return 0
 }
 
+test_update_migrates_generated_readme_with_commit_history_chart() {
+	local test_name="profile update adds commit-history chart to older generated README"
+
+	TEST_DIR=$(mktemp -d)
+	local fixture_home="${TEST_DIR}/home"
+	local fixture_repo="${TEST_DIR}/profile-repo"
+	local fixture_remote="${TEST_DIR}/profile-remote.git"
+	local helper_dir="${TEST_DIR}/helper"
+	local helper_path="${helper_dir}/profile-readme-helper.sh"
+
+	mkdir -p "${helper_dir}" "${fixture_home}"
+	install_helper_with_libs "${helper_dir}"
+	write_stub_dependencies "${helper_dir}"
+	create_profile_repo_fixture "${fixture_home}" "${fixture_repo}" "${fixture_remote}"
+	printf '\n> Stats auto-updated by [aidevops](https://aidevops.sh).\n' >>"${fixture_repo}/README.md"
+	git -C "${fixture_repo}" add README.md
+	git -C "${fixture_repo}" commit -m "test: mark fixture as generated" >/dev/null
+	git -C "${fixture_repo}" push >/dev/null
+
+	if ! HOME="${fixture_home}" bash "${helper_path}" update >/dev/null 2>&1 ||
+		! HOME="${fixture_home}" bash "${helper_path}" update >/dev/null 2>&1; then
+		print_result "${test_name}" 1 "helper update command failed"
+		return 0
+	fi
+
+	local readme="${fixture_repo}/README.md"
+	if [[ "$(grep -c '<picture>' "$readme")" -ne 1 ]] ||
+		! grep -Fq 'srcset="https://commit-history.com/embed/profile-repo?theme=dark"' "$readme" ||
+		! grep -Fq 'src="https://commit-history.com/embed/profile-repo"' "$readme"; then
+		print_result "${test_name}" 1 "migration did not add one username-specific chart"
+		return 0
+	fi
+	if grep -Fq '<a href="https://commit-history.com/' "$readme"; then
+		print_result "${test_name}" 1 "migrated chart contains an unnecessary provider backlink"
+		return 0
+	fi
+
+	print_result "${test_name}" 0
+	return 0
+}
+
 teardown() {
 	if [[ -n "${TEST_DIR}" && -d "${TEST_DIR}" ]]; then
 		rm -rf "${TEST_DIR}"
@@ -477,6 +518,21 @@ EOF
 	# Verify it's a rich README (has the aidevops tagline)
 	if ! grep -q 'aidevops' "$readme"; then
 		print_result "${test_name}" 1 "aidevops reference not found — not a rich README"
+		return 0
+	fi
+
+	# Verify the final generated block is theme-aware and has no provider backlink.
+	if ! grep -Fq 'srcset="https://commit-history.com/embed/profile-repo?theme=dark"' "$readme" ||
+		! grep -Fq 'src="https://commit-history.com/embed/profile-repo"' "$readme"; then
+		print_result "${test_name}" 1 "commit-history light/dark image URLs missing"
+		return 0
+	fi
+	if grep -Fq '<a href="https://commit-history.com/' "$readme"; then
+		print_result "${test_name}" 1 "commit-history chart contains an unnecessary provider backlink"
+		return 0
+	fi
+	if [[ "$(tail -n 1 "$readme")" != "</div>" ]]; then
+		print_result "${test_name}" 1 "commit-history chart is not the final README block"
 		return 0
 	fi
 
@@ -1063,6 +1119,8 @@ main() {
 
 	if [[ "$mode" != "--unit-only" ]]; then
 		test_update_preserves_manual_sections
+		teardown
+		test_update_migrates_generated_readme_with_commit_history_chart
 		teardown
 		test_inject_markers_into_existing_readme
 		teardown


### PR DESCRIPTION
## Summary

Generate a centered light/dark commit-history chart without a clickable provider backlink, and migrate older aidevops-generated profile READMEs during their next stats update.

## Files Changed

.agents/scripts/profile-readme-helper.sh, .agents/scripts/tests/test-profile-readme-boundary.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 17 profile README boundary tests passed; ShellCheck passed; full local linter suite passed; review evidence digest 214c467f4efa240df108e43193eb7f62771a39f16fb8bddaf64bf64aa6c5a0e0.

Resolves #29036


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.200 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 17m and 222,418 tokens on this with the user in an interactive session.