### PR TITLE
GH#29027: aggregate remaining Pulse triage release sources

### DIFF
--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -155,7 +155,7 @@ Aggregation PR #29044 reviews authorized profile README PR #29038 at
 `dfb6bc4a5b76af8697a299b3a17fc74b7c7fecdb` because aggregation PR #29042
 advanced `main` before publication.
 
-An exact-tip re-aggregation is pending for authorized Pulse triage PR #29033 at
+Aggregation PR #29052 re-reviews authorized Pulse triage PR #29033 at
 `fb4feba9216c643d7a61838877eedeb99bcef6e1` and prior aggregation PR #29037 at
 `11f3a9fa04af659b69b94cd19b86b642bf8303f7` because release `v3.32.201`
 terminalized PR #29042 without recursively terminalizing those sources, then

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -148,13 +148,18 @@ before publication.
 
 Aggregation PR #29045 reviews corrective OpenCode aggregation
 PR #29039 at `dd22bd011b2ff0970ff240ab832b1147370320ff` and Pulse aggregation
-PR #29042 at `998eeef0885e7db14ff753992d1f2cfe208de481`, plus profile aggregation
-PR #29044 at `4831ff72d24c9c524b939a8622447c0db0d3a411`, so one exact tip preserves
-all authorized release chains.
+PR #29042 at `998eeef0885e7db14ff753992d1f2cfe208de481`, so one exact tip preserves
+those authorized release chains.
 
 Aggregation PR #29044 reviews authorized profile README PR #29038 at
 `dfb6bc4a5b76af8697a299b3a17fc74b7c7fecdb` because aggregation PR #29042
 advanced `main` before publication.
+
+An exact-tip re-aggregation is pending for authorized Pulse triage PR #29033 at
+`fb4feba9216c643d7a61838877eedeb99bcef6e1` and prior aggregation PR #29037 at
+`11f3a9fa04af659b69b94cd19b86b642bf8303f7` because release `v3.32.201`
+terminalized PR #29042 without recursively terminalizing those sources, then
+the release and simplification-state commits advanced `main`.
 
 Manual arbitrary-version package publication is intentionally unsupported. A
 recovery operation must use an existing tag that passes the same verifier.


### PR DESCRIPTION
## Summary

Create a reviewed exact-tip aggregation for the remaining authorized Pulse triage release sources after `v3.32.201` terminalized PR #29042 but not its nested PR #29033/#29037 sources.

## Release provenance

- Original authorized source: PR #29033 at merge `fb4feba9216c643d7a61838877eedeb99bcef6e1`.
- Prior reviewed aggregation: PR #29037 at merge `11f3a9fa04af659b69b94cd19b86b642bf8303f7`.
- PR #29042 is intentionally excluded because `v3.32.201` reconciliation recorded it as terminally `superseded` by PR #29045.
- Exact branch base: `a83c110db916432fd3233645a24907cd42430d62`.
- Sequence: this draft was created from initial documentation commit `3a962c325`; a follow-up commit will bind the allocated aggregation PR and both unresolved immutable sources without rewriting published history.
- The same documentation change corrects PR #29045's release-control record to match the signed `v3.32.201` tag, whose immutable trailers include PRs #29039 and #29042 but not PR #29044.

## Verification

- PR #29033 required checks and independent P0/P1 closeout review passed at exact head `34740615aff0f22da28ba3fcb91fb7b4b6e02f47`.
- PR #29037 required checks and independent provenance closeout review passed at exact head `64c45e77b5d0cd20d5e48a454f93b3788df93f20`.
- The protected `v3.32.201` GitHub/npm/Homebrew publication workflow passed, and reconciliation records PR #29042 as `superseded`.
- Changed-file lint, Markdown lint, secret scanning, file-size regression, and `git diff --check` pass for this aggregation record.

## Risk and release

- Documentation-only provenance attestation; this PR performs no publication.
- Publication remains constrained to `aidevops release patch 29033 incremental` after this exact tip is reviewed and merged.

Ref #29027
Ref #29033
Ref #29037
Ref #29042
Ref #29045

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.201 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 3h 13m and 2,104,691 tokens on this with the user in an interactive session.