### PR TITLE
GH#29051: fix: restore Medium credential imports

### DIFF
--- a/.agents/scripts/_knowledge_social_medium_common.py
+++ b/.agents/scripts/_knowledge_social_medium_common.py
@@ -21,7 +21,7 @@ from _knowledge_social_medium_html import (
     walk,
 )
 from _knowledge_social_medium_types import MediumIdentity, PROVENANCE
-from knowledge_social_import import (
+from knowledge_source_contract import (
     FORBIDDEN_CREDENTIAL_KEYS,
     FORBIDDEN_CREDENTIAL_SUFFIXES,
 )

--- a/.agents/scripts/_knowledge_social_medium_html.py
+++ b/.agents/scripts/_knowledge_social_medium_html.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from html.parser import HTMLParser
 from typing import Iterator
 
-from knowledge_social_import import (
+from knowledge_source_contract import (
     FORBIDDEN_CREDENTIAL_KEYS,
     FORBIDDEN_CREDENTIAL_SUFFIXES,
 )


### PR DESCRIPTION
## Summary

Restored both Medium parser modules to import shared credential-rejection constants from knowledge_source_contract.

## Files Changed

.agents/scripts/_knowledge_social_medium_common.py, .agents/scripts/_knowledge_social_medium_html.py

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: bash .agents/tests/test-knowledge-social-medium.sh completed 56 passed, 0 failed; python3 -m py_compile .agents/scripts/_knowledge_social_medium_html.py .agents/scripts/_knowledge_social_medium_common.py passed; .agents/scripts/linters-local.sh --changed passed.

Resolves #29051


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.201 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 9m and 53,070 tokens on this as a headless worker.