### PR TITLE
GH#28954: add read-only Bluesky account knowledge ingestion

### DIFF
--- a/.agents/content/social-bluesky.md
+++ b/.agents/content/social-bluesky.md
@@ -1,0 +1,90 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Bluesky and AT Protocol Account Knowledge Collection
+
+`knowledge_social_bluesky.py` collects one bounded account stream at a time.
+The stable account key is the DID. Handles and PDS locations are mutable aliases;
+changing either does not create another account. Every page repeats DID and
+service-fingerprint checks before the shared atomic evidence/checkpoint commit.
+
+## Runtime and authorization
+
+No AT Protocol client dependency is installed. The collector uses Python's
+standard-library `urllib` exports and the lexicons at official atproto commit
+`5782f195e834b5af80e5bcc163c4247893b95e0a` (checked 2026-07-31). This avoids
+inventing SDK methods while preserving exact XRPC NSIDs.
+
+Inject one private profile through the secure credential environment:
+
+```text
+BLUESKY_<PROFILE>_ACCESS_TOKEN
+BLUESKY_<PROFILE>_HANDLE
+BLUESKY_<PROFILE>_PDS_URL
+BLUESKY_<PROFILE>_APPVIEW_SERVICE
+BLUESKY_<PROFILE>_AUTH_MODE=app_password_session
+BLUESKY_<PROFILE>_CHAT_ENABLED=0
+BLUESKY_<PROFILE>_CHAT_SERVICE
+```
+
+Set `CHAT_ENABLED=1` only for a separately authorized chat service. AppView and
+chat service values are DID URL identities with service fragments; their reads
+are proxied through the independently verified PDS with `Atproto-Proxy`. The
+access JWT is therefore never sent to an operator-configured AppView/chat
+origin. The isolated child can construct only HTTPS `GET` requests to an exact
+query allowlist. XRPC procedures—including record writes,
+follow/like/repost/list/feed/moderation/preference/notification mutations and
+chat sends/reactions/deletes—are unreachable. Redirects, URL credentials,
+queries, fragments, non-root service paths, unsafe profile names, and missing
+tokens fail closed. `AUTH_MODE=oauth` is rejected because this stdlib boundary
+does not implement mandatory DPoP proofs and nonce rotation. A short-lived
+access JWT from an app-password session is accepted; the write-capable session
+does not widen the local GET-only route boundary.
+
+Use the DID, not the handle, as `--account-id`. `resolveHandle` verifies the
+configured alias. The live adapter independently resolves `did:plc` through the
+PLC directory, requires its `#atproto_pds` service to equal the configured PDS,
+then uses `describeRepo` as a second fence. PDS and AppView/chat service
+identities are stored only as 24-character SHA-256 fingerprints. A legitimate
+PDS migration restarts a stale service-fenced cursor
+for the same DID and converges by AT URI/CID rather than rebinding the account.
+
+## Authority and stream map
+
+| Authority | Streams | Source contract |
+|---|---|---|
+| PDS repository | `profile`, `posts`, `reposts`, `likes`, `follows`, `blocks`, `lists`, `list_items`, `feed_generators`, `starter_packs`, `labeler_services` | `com.atproto.repo.listRecords`; preserves AT URI, CID, collection/rkey content, and current record revision evidence. |
+| PDS sync | `repo_status`, `blobs` | `com.atproto.sync.getRepoStatus` and `listBlobs`; blob metadata only. |
+| AppView | `author_feed`, `notifications`, `preferences`, `bookmarks`, `mutes`, `appview_lists`, `appview_starter_packs`, `labels` | Derived/current account views with independent cursors and explicit AppView provenance. Notifications cover retained mentions/replies/quotes; preferences carry saved/custom feeds and moderation choices when returned. |
+| Chat | `chat_conversations`, `chat_log` | Separately gated `chat.bsky.convo.listConvos` and `getLog`; messages, reactions, and deletions remain chat events, never repository truth. |
+| Export | `repository_export` | Explicit unavailable coverage until a private CAR sample validates bounded binary import. No export procedure is invoked. |
+
+Each stream has an independent cursor and a hard request budget. `--page-size`
+is 1-100 and `--budget` is 7-1000 request units. Three units are reserved for
+independent PLC, repository, and handle identity checks; each page costs four
+units for repeated identity fences plus its data query. Provider cursors are wrapped
+with DID, stream, and service identity. A changed service safely restarts that
+stream; a changed DID or cross-stream cursor fails closed. Repository/AppView/
+chat overlap converges through DID plus AT URI/CID or a content-derived fallback,
+without treating missing AppView state as a repository deletion.
+
+Complete historical tombstones, CAR bytes, blob bytes, PDS migration history,
+and chat export remain explicit unavailable coverage. Fixture evidence can
+normalize provider-supplied tombstones and revisions, but the snapshot APIs do
+not claim a complete deletion history. Rate limits, denied private/chat access,
+malformed JSON, service rebinding, and cursor errors preserve prior evidence and
+do not advance checkpoints.
+
+## Official evidence checked 2026-07-31
+
+- [Official atproto source](https://github.com/bluesky-social/atproto)
+- [Verified lexicon commit](https://github.com/bluesky-social/atproto/commit/5782f195e834b5af80e5bcc163c4247893b95e0a)
+- [AT Protocol DID contract](https://atproto.com/specs/did)
+- [AT Protocol OAuth contract](https://atproto.com/specs/oauth)
+- Repository and sync lexicons under `lexicons/com/atproto/repo` and `lexicons/com/atproto/sync`
+- Bluesky actor, feed, graph, bookmark, notification, and labeler lexicons under `lexicons/app/bsky`
+- Separately authorized chat lexicons under `lexicons/chat/bsky`
+
+The local dependency check found neither Python `atproto` nor npm
+`@atproto/api`; runtime mappings therefore use only the verified official
+lexicon symbols above.

--- a/.agents/scripts/_knowledge_social_bluesky.py
+++ b/.agents/scripts/_knowledge_social_bluesky.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bluesky stream policy, DID identity, and service-fenced cursors."""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from knowledge_social_import import canonical_json, reject_credentials
+
+PROVIDER = "bluesky"
+CURSOR_PREFIX = "bluesky-v1:"
+RETENTION_LIMIT = "current_repository_and_authorized_service_visibility"
+DID_PATTERN = re.compile(r"^did:(?:plc|web):[A-Za-z0-9._:%-]{3,512}$")
+SERVICE_ID_PATTERN = re.compile(r"^[0-9a-f]{24}$")
+
+
+class BlueskyAdapterError(RuntimeError):
+    """Bluesky fixture, validation, or normalization failure."""
+
+
+class BlueskyProviderUnavailableError(BlueskyAdapterError):
+    """Live Bluesky provider boundary is unavailable."""
+
+
+ADAPTER_ERROR = BlueskyAdapterError
+PROVIDER_UNAVAILABLE_ERROR = BlueskyProviderUnavailableError
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    """Authority, route, normalization, and budget policy for one stream."""
+
+    resource_kind: str
+    activity_mode: str
+    pagination: str
+    incremental: bool
+    retention_limit: str | None
+    coverage_status: str | None = None
+    unavailable_reason: str | None = None
+    cost_units: int = 4
+    authority: str = "pds"
+    endpoint: str = "com.atproto.repo.listRecords"
+    collection: str | None = None
+
+
+def _repo(kind: str, activity: str, collection: str) -> StreamSpec:
+    return StreamSpec(kind, activity, "cursor", False, RETENTION_LIMIT, collection=collection)
+
+
+def _query(kind: str, activity: str, authority: str, endpoint: str) -> StreamSpec:
+    return StreamSpec(
+        kind,
+        activity,
+        "cursor",
+        False,
+        RETENTION_LIMIT,
+        authority=authority,
+        endpoint=endpoint,
+    )
+
+
+STREAMS = {
+    "profile": _repo("profile", "authored_profile", "app.bsky.actor.profile"),
+    "posts": _repo("post", "authored_post", "app.bsky.feed.post"),
+    "reposts": _repo("post", "repost", "app.bsky.feed.repost"),
+    "likes": _repo("post", "like", "app.bsky.feed.like"),
+    "follows": _repo("profile", "follow", "app.bsky.graph.follow"),
+    "blocks": _repo("profile", "block", "app.bsky.graph.block"),
+    "lists": _repo("list", "owned_list", "app.bsky.graph.list"),
+    "list_items": _repo("profile", "list_membership", "app.bsky.graph.listitem"),
+    "feed_generators": _repo("feed", "owned_feed", "app.bsky.feed.generator"),
+    "starter_packs": _repo("starter_pack", "owned_starter_pack", "app.bsky.graph.starterpack"),
+    "labeler_services": _repo("labeler_service", "owned_labeler_service", "app.bsky.labeler.service"),
+    "repo_status": _query("repository", "repository_status", "sync", "com.atproto.sync.getRepoStatus"),
+    "blobs": _query("blob", "repository_blob", "sync", "com.atproto.sync.listBlobs"),
+    "author_feed": _query("post", "appview_author_feed", "appview", "app.bsky.feed.getAuthorFeed"),
+    "notifications": _query("notification", "notification", "appview", "app.bsky.notification.listNotifications"),
+    "preferences": _query("preference", "account_preference", "appview", "app.bsky.actor.getPreferences"),
+    "bookmarks": _query("post", "bookmark", "appview", "app.bsky.bookmark.getBookmarks"),
+    "mutes": _query("profile", "mute", "appview", "app.bsky.graph.getMutes"),
+    "appview_lists": _query("list", "subscribed_list", "appview", "app.bsky.graph.getLists"),
+    "appview_starter_packs": _query("starter_pack", "joined_starter_pack", "appview", "app.bsky.graph.getActorStarterPacks"),
+    "labels": _query("label", "moderation_label", "appview", "com.atproto.label.queryLabels"),
+    "chat_conversations": _query("conversation", "chat_participation", "chat", "chat.bsky.convo.listConvos"),
+    "chat_log": _query("chat_event", "chat_event", "chat", "chat.bsky.convo.getLog"),
+    "repository_export": StreamSpec(
+        "repository_export",
+        "repository_export",
+        "none",
+        False,
+        RETENTION_LIMIT,
+        "unavailable",
+        "binary_car_import_requires_separately_validated_private_export",
+        authority="pds",
+        endpoint="unavailable",
+    ),
+}
+
+
+def did(value: Any, field: str = "DID") -> str:
+    if not isinstance(value, str) or DID_PATTERN.fullmatch(value) is None:
+        raise BlueskyAdapterError(f"Bluesky {field} is invalid")
+    return value
+
+
+def service_id(value: Any, field: str = "service identity") -> str:
+    if not isinstance(value, str) or SERVICE_ID_PATTERN.fullmatch(value) is None:
+        raise BlueskyAdapterError(f"Bluesky {field} is invalid")
+    return value
+
+
+def text(value: Any, field: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or not value or "\x00" in value or len(value.encode()) > 4096:
+        raise BlueskyAdapterError(f"Bluesky {field} is invalid")
+    return value
+
+
+@dataclass(frozen=True)
+class PageRequest:
+    stream: str
+    account_id: str
+    handle: str
+    service_id: str
+    authority: str
+    endpoint: str
+    collection: str | None
+    cursor: str | None
+    limit: int
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "page",
+            "stream": self.stream,
+            "account_id": self.account_id,
+            "handle": self.handle,
+            "service_id": self.service_id,
+            "authority": self.authority,
+            "endpoint": self.endpoint,
+            "collection": self.collection,
+            "cursor": self.cursor,
+            "limit": self.limit,
+        }
+
+    def evidence_key(self) -> str:
+        return canonical_json(self.payload())
+
+
+PAGE_REQUEST_KEYS = set(PageRequest("", "", "", "", "", "", None, None, 1).payload())
+
+
+def _encode_cursor(stream: str, account_did: str, service: str, remote: str) -> str:
+    payload = canonical_json(
+        {"stream": stream, "did": account_did, "service": service, "remote": remote}
+    ).encode()
+    encoded = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+    return f"{CURSOR_PREFIX}{encoded}"
+
+
+def _decode_cursor(cursor: str) -> dict[str, str]:
+    if not cursor.startswith(CURSOR_PREFIX):
+        raise BlueskyAdapterError("stored Bluesky cursor has an unsupported version")
+    try:
+        value = cursor.removeprefix(CURSOR_PREFIX)
+        payload = json.loads(base64.urlsafe_b64decode(value + "=" * (-len(value) % 4)))
+    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+        raise BlueskyAdapterError("stored Bluesky cursor is invalid") from error
+    if not isinstance(payload, dict) or set(payload) != {"stream", "did", "service", "remote"}:
+        raise BlueskyAdapterError("stored Bluesky cursor has an invalid shape")
+    reject_credentials(payload)
+    return {key: text(payload[key], f"cursor {key}") or "" for key in payload}
+
+
+def _stream_service(account: dict[str, Any], authority: str) -> str:
+    field = {"pds": "pds_id", "sync": "pds_id", "appview": "appview_id", "chat": "chat_id"}[authority]
+    return service_id(account.get(field), field)
+
+
+def page_request(stream: str, account: dict[str, Any], state: CursorState, limit: int) -> PageRequest:
+    spec = STREAMS.get(stream)
+    if spec is None:
+        raise BlueskyAdapterError("Bluesky stream is unsupported")
+    account_did = did(account.get("id"), "selected account DID")
+    selected_service = _stream_service(account, spec.authority)
+    remote_cursor = None
+    if state.cursor:
+        stored = _decode_cursor(state.cursor)
+        if stored["stream"] != stream or stored["did"] != account_did:
+            raise BlueskyAdapterError("stored Bluesky cursor belongs to another stream or DID")
+        if stored["service"] == selected_service:
+            remote_cursor = stored["remote"]
+    return PageRequest(
+        stream,
+        account_did,
+        text(account.get("handle"), "handle") or "",
+        selected_service,
+        spec.authority,
+        spec.endpoint,
+        spec.collection,
+        remote_cursor,
+        limit,
+    )
+
+
+def parse_page_request(payload: dict[str, Any]) -> PageRequest:
+    if set(payload) != PAGE_REQUEST_KEYS or payload.get("action") != "page":
+        raise BlueskyAdapterError("Bluesky read request has an invalid action shape")
+    stream = payload.get("stream")
+    if not isinstance(stream, str) or stream not in STREAMS:
+        raise BlueskyAdapterError("Bluesky stream is unsupported")
+    spec = STREAMS[stream]
+    if (payload.get("authority"), payload.get("endpoint"), payload.get("collection")) != (
+        spec.authority,
+        spec.endpoint,
+        spec.collection,
+    ):
+        raise BlueskyAdapterError("Bluesky read route is not allowlisted")
+    limit = payload.get("limit")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 100:
+        raise BlueskyAdapterError("Bluesky page size is invalid")
+    cursor = text(payload.get("cursor"), "page cursor", optional=True)
+    return PageRequest(
+        stream,
+        did(payload.get("account_id"), "account DID"),
+        text(payload.get("handle"), "handle") or "",
+        service_id(payload.get("service_id")),
+        spec.authority,
+        spec.endpoint,
+        spec.collection,
+        cursor,
+        limit,
+    )
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise BlueskyAdapterError("Bluesky response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise BlueskyAdapterError("Bluesky page data must be an array")
+    return data
+
+
+def page_checkpoint(payload: dict[str, Any], state: CursorState, request: PageRequest) -> tuple[PageCheckpoint, bool]:
+    del state
+    meta = payload.get("meta")
+    if not isinstance(meta, dict):
+        raise BlueskyAdapterError("Bluesky page metadata must be an object")
+    reject_credentials(meta)
+    if meta.get("stream") != request.stream or did(meta.get("did")) != request.account_id:
+        raise BlueskyAdapterError("Bluesky page provenance is invalid")
+    if service_id(meta.get("service_id")) != request.service_id:
+        raise BlueskyAdapterError("Bluesky service changed during collection")
+    complete = meta.get("complete")
+    if not isinstance(complete, bool):
+        raise BlueskyAdapterError("Bluesky page completion metadata is invalid")
+    remote = text(meta.get("next_cursor"), "next cursor", optional=True)
+    if complete != (remote is None):
+        raise BlueskyAdapterError("Bluesky cursor and completion state disagree")
+    next_cursor = None if remote is None else _encode_cursor(request.stream, request.account_id, request.service_id, remote)
+    watermark = text(meta.get("watermark"), "watermark", optional=True)
+    return PageCheckpoint(next_cursor, watermark), complete

--- a/.agents/scripts/_knowledge_social_bluesky_http.py
+++ b/.agents/scripts/_knowledge_social_bluesky_http.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Credential isolation, HTTPS validation, and GET-only Bluesky XRPC transport."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode, urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from _knowledge_social_bluesky import STREAMS, BlueskyAdapterError
+
+MAX_REQUEST_BYTES = 32 * 1024
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+HTTP_TIMEOUT_SECONDS = 60
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+SERVICE_IDENTITY = re.compile(
+    r"^did:[a-z0-9]+:[A-Za-z0-9._:%-]+#[A-Za-z0-9._-]+$"
+)
+IDENTITY_ENDPOINTS = frozenset(
+    {"com.atproto.identity.resolveHandle", "com.atproto.repo.describeRepo"}
+)
+READ_ENDPOINTS = frozenset(
+    spec.endpoint for spec in STREAMS.values() if spec.endpoint != "unavailable"
+) | IDENTITY_ENDPOINTS
+
+
+class _RejectRedirect(HTTPRedirectHandler):
+    def redirect_request(self, *args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+        return None
+
+
+@dataclass(frozen=True)
+class Profile:
+    token: str
+    handle: str
+    pds: str
+    appview: str
+    chat: str | None
+    chat_enabled: bool
+    auth_mode: str
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    status: int
+    payload: dict[str, Any]
+    retry_after: int | None = None
+
+
+def observed_at() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _prefix(profile: str) -> str:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise BlueskyAdapterError("Bluesky profile name is invalid")
+    return f"BLUESKY_{profile.upper()}"
+
+
+def _unsafe_service(parsed: Any) -> bool:
+    unsafe_authority = (
+        not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+    )
+    unsafe_suffix = bool(parsed.query or parsed.fragment or parsed.path not in ("", "/"))
+    return parsed.scheme != "https" or unsafe_authority or unsafe_suffix
+
+
+def service_url(value: str) -> str:
+    parsed = urlsplit(value)
+    if _unsafe_service(parsed):
+        raise BlueskyAdapterError("Bluesky service URL is missing or unsafe")
+    port = f":{parsed.port}" if parsed.port else ""
+    return f"https://{parsed.hostname.lower()}{port}"
+
+
+def service_identity(value: str, message: str) -> str:
+    if SERVICE_IDENTITY.fullmatch(value) is None:
+        raise BlueskyAdapterError(message)
+    return value
+
+
+def _bounded_secret(value: str, message: str, limit: int) -> str:
+    if not value or "\x00" in value or len(value.encode()) > limit:
+        raise BlueskyAdapterError(message)
+    return value
+
+
+def profile_from_environment(name: str) -> Profile:
+    prefix = _prefix(name)
+    token = _bounded_secret(
+        os.environ.get(f"{prefix}_ACCESS_TOKEN", ""),
+        "Bluesky profile access token is missing",
+        16 * 1024,
+    )
+    handle = _bounded_secret(
+        os.environ.get(f"{prefix}_HANDLE", ""),
+        "Bluesky profile handle is missing",
+        512,
+    )
+    auth_mode = os.environ.get(f"{prefix}_AUTH_MODE", "")
+    if auth_mode == "oauth":
+        raise BlueskyAdapterError("Bluesky OAuth profile requires DPoP support")
+    if auth_mode != "app_password_session":
+        raise BlueskyAdapterError("Bluesky profile auth mode is invalid")
+    chat_setting = os.environ.get(f"{prefix}_CHAT_ENABLED", "0")
+    if chat_setting not in ("0", "1"):
+        raise BlueskyAdapterError("Bluesky chat authorization setting is invalid")
+    chat_enabled = chat_setting == "1"
+    appview = service_identity(
+        os.environ.get(f"{prefix}_APPVIEW_SERVICE", ""),
+        "Bluesky AppView service identity is invalid",
+    )
+    chat_value = os.environ.get(f"{prefix}_CHAT_SERVICE", "")
+    return Profile(
+        token,
+        handle,
+        service_url(os.environ.get(f"{prefix}_PDS_URL", "")),
+        appview,
+        service_identity(chat_value, "Bluesky chat service identity is invalid")
+        if chat_enabled
+        else None,
+        chat_enabled,
+        auth_mode,
+    )
+
+
+def service_id(value: str | None) -> str:
+    material = value if value is not None else "chat-disabled"
+    return hashlib.sha256(material.encode()).hexdigest()[:24]
+
+
+def connection_id(account_did: str, profile: Profile) -> str:
+    identities = (service_id(profile.pds), service_id(profile.appview), service_id(profile.chat))
+    return hashlib.sha256("|".join((account_did, *identities)).encode()).hexdigest()[:24]
+
+
+def _retry_epoch(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    return int(time.time() + math.ceil(seconds))
+
+
+def _decoded(payload: bytes) -> dict[str, Any]:
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise BlueskyAdapterError("Bluesky read response exceeds the safety limit")
+    try:
+        value = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise BlueskyAdapterError("Bluesky read provider returned no valid JSON") from error
+    if not isinstance(value, dict):
+        raise BlueskyAdapterError("Bluesky API response root must be an object")
+    return value
+
+
+def _response(result: Any) -> ApiResult:
+    status = getattr(result, "status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise BlueskyAdapterError("Bluesky HTTP status is invalid")
+    body = result.read(MAX_RESPONSE_BYTES + 1)
+    if not isinstance(body, bytes):
+        raise BlueskyAdapterError("Bluesky HTTP response is invalid")
+    return ApiResult(status, _decoded(body))
+
+
+def public_json(url: str) -> dict[str, Any]:
+    """Read one fixed-authority public identity document without credentials."""
+    request = Request(
+        url,
+        headers={"Accept": "application/json", "User-Agent": "aidevops-bluesky-knowledge/1"},
+        method="GET",
+    )
+    try:
+        with build_opener(_RejectRedirect).open(request, timeout=HTTP_TIMEOUT_SECONDS) as result:
+            return _response(result).payload
+    except (HTTPError, TimeoutError, URLError, OSError) as error:
+        raise BlueskyAdapterError("Bluesky DID document resolution failed") from error
+
+
+def api(
+    profile: Profile,
+    base: str,
+    endpoint: str,
+    params: dict[str, str],
+    proxy: str | None = None,
+) -> ApiResult:
+    """Execute one allowlisted XRPC query with redirect rejection."""
+    if endpoint not in READ_ENDPOINTS:
+        raise BlueskyAdapterError("Bluesky XRPC query is not allowlisted")
+    query = f"?{urlencode(params)}" if params else ""
+    headers = {
+        "Accept": "application/json",
+        "Authorization": f"Bearer {profile.token}",
+        "User-Agent": "aidevops-bluesky-knowledge/1",
+    }
+    if proxy is not None:
+        headers["Atproto-Proxy"] = proxy
+    request = Request(
+        f"{base}/xrpc/{endpoint}{query}",
+        headers=headers,
+        method="GET",
+    )
+    try:
+        with build_opener(_RejectRedirect).open(request, timeout=HTTP_TIMEOUT_SECONDS) as result:
+            return _response(result)
+    except HTTPError as error:
+        if 300 <= error.code < 400:
+            raise BlueskyAdapterError("Bluesky service redirects are rejected") from error
+        return ApiResult(error.code, {}, _retry_epoch(error.headers.get("Retry-After")))
+    except (TimeoutError, URLError, OSError) as error:
+        raise BlueskyAdapterError("Bluesky read provider request failed") from error
+
+
+def terminal_payload(result: ApiResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": result.status, "observed_at": observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload

--- a/.agents/scripts/_knowledge_social_bluesky_identity.py
+++ b/.agents/scripts/_knowledge_social_bluesky_identity.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Independent did:plc document resolution and PDS service verification."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from urllib.parse import quote
+
+from _knowledge_social_bluesky import BlueskyAdapterError
+from _knowledge_social_bluesky_http import public_json, service_url
+
+PLC_DID = re.compile(r"^did:plc:[a-z2-7]{24}$")
+PLC_DIRECTORY = "https://plc.directory"
+
+
+def _service_entries(document: dict[str, Any]) -> list[dict[str, Any]]:
+    services = document.get("service")
+    if not isinstance(services, list) or any(
+        not isinstance(entry, dict) for entry in services
+    ):
+        raise BlueskyAdapterError("Bluesky DID document has no valid services")
+    return services
+
+
+def pds_endpoint(document: dict[str, Any], account_did: str) -> str:
+    """Return the exact #atproto_pds endpoint from a verified DID document."""
+    if document.get("id") != account_did:
+        raise BlueskyAdapterError("Bluesky DID document identity is invalid")
+    service_ids = {"#atproto_pds", f"{account_did}#atproto_pds"}
+    for entry in _service_entries(document):
+        if (
+            entry.get("id") in service_ids
+            and entry.get("type") == "AtprotoPersonalDataServer"
+        ):
+            endpoint = entry.get("serviceEndpoint")
+            if isinstance(endpoint, str):
+                return service_url(endpoint)
+    raise BlueskyAdapterError("Bluesky DID document has no authoritative PDS")
+
+
+def resolve_pds(account_did: str) -> str:
+    if PLC_DID.fullmatch(account_did) is None:
+        raise BlueskyAdapterError("live Bluesky identity requires a did:plc account")
+    encoded = quote(account_did, safe=":")
+    return pds_endpoint(public_json(f"{PLC_DIRECTORY}/{encoded}"), account_did)

--- a/.agents/scripts/_knowledge_social_bluesky_normalize.py
+++ b/.agents/scripts/_knowledge_social_bluesky_normalize.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize repository, AppView, sync, and chat evidence without merging authority."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_bluesky import (
+    PROVIDER,
+    RETENTION_LIMIT,
+    STREAMS,
+    BlueskyAdapterError,
+    did,
+    page_data,
+    service_id,
+)
+from knowledge_social_import import canonical_json, reject_credentials
+
+GAPS = (
+    ("repository_car_export", "binary_car_import_requires_separately_validated_private_export"),
+    ("historical_tombstones", "snapshot_queries_do_not_expose_complete_deletion_history"),
+    ("blob_bytes", "blob_metadata_only_binary_download_not_enabled"),
+    ("pds_migration_history", "current_verified_service_alias_only"),
+    ("chat_export", "separate_chat_export_procedure_not_enabled"),
+)
+ACTIVITY_ONLY_STREAMS = frozenset(
+    {"likes", "reposts", "follows", "blocks", "list_items"}
+)
+
+
+@dataclass(frozen=True)
+class PageContext:
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def _observed_at(payload: dict[str, Any]) -> str:
+    value = payload.get("observed_at")
+    if not isinstance(value, str) or not value:
+        raise BlueskyAdapterError("Bluesky page observed_at must be text")
+    return value
+
+
+def _optional_text(item: dict[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = item.get(key)
+        if isinstance(value, str) and value and "\x00" not in value:
+            return value[:262144]
+    return None
+
+
+def _record_value(item: dict[str, Any]) -> dict[str, Any]:
+    value = item.get("value")
+    return value if isinstance(value, dict) else item
+
+
+def _object(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _subject_id(item: dict[str, Any]) -> str | None:
+    value = _record_value(item)
+    subject = value.get("subject")
+    if isinstance(subject, str):
+        return subject
+    return _optional_text(_object(subject), "uri", "did", "cid")
+
+
+def _stable_hash(namespace: str, value: Any) -> str:
+    return f"bluesky:{namespace}:" + hashlib.sha256(canonical_json(value).encode()).hexdigest()
+
+
+def _preference_id(item: dict[str, Any]) -> str | None:
+    record_type = _optional_text(item, "$type")
+    if record_type is None:
+        return None
+    discriminators = {
+        key: item.get(key)
+        for key in ("labelerDid", "label", "feed", "tag", "actor", "did")
+        if item.get(key) is not None
+    }
+    return (
+        _stable_hash("preference", {"type": record_type, **discriminators})
+        if discriminators
+        else record_type
+    )
+
+
+def _remote_id(item: dict[str, Any], stream: str) -> str:
+    value = _record_value(item)
+    if stream == "chat_log":
+        remote = _optional_text(item, "rev")
+    elif stream == "author_feed":
+        remote = _optional_text(_object(item.get("post")), "uri")
+    elif stream == "bookmarks":
+        remote = _optional_text(_object(item.get("subject")), "uri")
+    elif stream == "mutes":
+        remote = _optional_text(item, "did")
+    elif stream == "labels":
+        identity = {
+            key: item.get(key) for key in ("src", "uri", "val", "cts", "neg")
+        }
+        remote = _stable_hash("label", identity)
+    elif stream in {"likes", "reposts", "follows", "blocks", "list_items"}:
+        remote = _subject_id(item)
+    elif stream == "preferences":
+        remote = _preference_id(item)
+    else:
+        remote = _optional_text(
+            item, "uri", "cid", "did", "id", "convoId", "messageId"
+        )
+        remote = remote or _optional_text(
+            value, "uri", "cid", "did", "id", "subject"
+        )
+    if remote:
+        return remote
+    return _stable_hash(stream, item)
+
+
+def _text_sources(item: dict[str, Any], stream: str) -> list[dict[str, Any]]:
+    value = _record_value(item)
+    sources = [value, item]
+    if stream == "author_feed":
+        post = _object(item.get("post"))
+        sources = [_object(post.get("record")), post, *sources]
+    elif stream == "bookmarks":
+        bookmarked = _object(item.get("item"))
+        sources = [_object(bookmarked.get("record")), bookmarked, *sources]
+    elif stream == "chat_log":
+        sources = [_object(item.get("message")), *sources]
+    return sources
+
+
+def _text(item: dict[str, Any], stream: str) -> str | None:
+    parts = [
+        text
+        for source in _text_sources(item, stream)
+        for key in ("displayName", "name", "title", "text", "description")
+        if isinstance((text := source.get(key)), str) and text
+    ]
+    return "\n\n".join(dict.fromkeys(parts))[:262144] or None
+
+
+def _created_at(item: dict[str, Any], stream: str) -> str | None:
+    for source in _text_sources(item, stream):
+        created = _optional_text(
+            source, "createdAt", "indexedAt", "sentAt", "updatedAt"
+        )
+        if created:
+            return created
+    return None
+
+
+def _activity_remote_id(
+    item: dict[str, Any], stream: str, account_did: str, target_id: str
+) -> str:
+    if stream == "chat_log":
+        return _optional_text(item, "rev") or _stable_hash("chat-event", item)
+    if stream in {"likes", "reposts", "follows", "blocks", "list_items"}:
+        return _optional_text(item, "uri") or _stable_hash(stream, item)
+    if stream == "labels":
+        return target_id
+    return f"{account_did}:{STREAMS[stream].activity_mode}:{target_id}"
+
+
+def _actor_id(item: dict[str, Any], stream: str, account_did: str) -> str:
+    if stream == "chat_log":
+        sender = _object(_object(item.get("message")).get("sender"))
+        return _optional_text(sender, "did") or account_did
+    return account_did
+
+
+def _deleted(item: dict[str, Any], stream: str) -> bool:
+    record_type = _optional_text(item, "$type") or ""
+    return bool(
+        item.get("deleted")
+        or _record_value(item).get("deleted")
+        or (stream == "chat_log" and "logDeleteMessage" in record_type)
+    )
+
+
+def _coverage(observed_at: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "stream": stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": RETENTION_LIMIT,
+            "unavailable_reason": reason,
+            "status": "unavailable",
+            "observed_at": observed_at,
+        }
+        for stream, reason in GAPS
+    ]
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    """Build canonical rows while retaining each service as explicit provenance."""
+    reject_credentials(payload)
+    observed_at = _observed_at(payload)
+    spec = STREAMS[context.stream]
+    account_did = did(context.account.get("id"), "account DID")
+    authority_id = service_id(
+        context.account.get("pds_id" if spec.authority in ("pds", "sync") else f"{spec.authority}_id")
+    )
+    objects = []
+    activities = []
+    media = []
+    for item in page_data(payload):
+        remote_id = _remote_id(item, context.stream)
+        value = _record_value(item)
+        deleted = _deleted(item, context.stream)
+        provider_json = {
+            "authority": spec.authority,
+            "service_id": authority_id,
+            "stream": context.stream,
+            "at_uri": _optional_text(item, "uri") or _optional_text(value, "uri"),
+            "cid": _optional_text(item, "cid") or _optional_text(value, "cid"),
+            "revision": _optional_text(item, "rev") or _optional_text(value, "rev"),
+            "action_at_uri": _optional_text(item, "uri"),
+            "target_remote_id": remote_id,
+            "tombstone": deleted,
+            "record": item,
+        }
+        reject_credentials(provider_json)
+        if context.stream not in ACTIVITY_ONLY_STREAMS:
+            objects.append(
+                {
+                    "object_type": spec.resource_kind,
+                    "remote_id": remote_id,
+                    "account_remote_id": account_did
+                    if context.stream in {"profile", "posts"}
+                    else None,
+                    "text": _text(item, context.stream),
+                    "created_at": _created_at(item, context.stream),
+                    "observed_at": observed_at,
+                    "evidence_class": "authored"
+                    if context.stream in {"profile", "posts"}
+                    else "observed",
+                    "provider_json": provider_json,
+                }
+            )
+        activities.append(
+            {
+                "activity_type": spec.activity_mode,
+                "remote_id": _activity_remote_id(
+                    item, context.stream, account_did, remote_id
+                ),
+                "actor_remote_id": _actor_id(item, context.stream, account_did),
+                "object_remote_id": remote_id,
+                "occurred_at": _created_at(item, context.stream),
+                "observed_at": observed_at,
+                "state": "deleted" if deleted else "active",
+                "provider_json": {
+                    "authority": spec.authority,
+                    "service_id": authority_id,
+                    "stream": context.stream,
+                },
+            }
+        )
+        if context.stream == "blobs":
+            media.append(
+                {
+                    "remote_id": remote_id,
+                    "object_remote_id": remote_id,
+                    "content_sha256": None,
+                    "mime_type": None,
+                    "byte_size": None,
+                    "blob_ref": remote_id,
+                    "hydration_state": "metadata_only",
+                }
+            )
+    policy = dict(context.policy)
+    policy.update(
+        {
+            "bluesky_identity": "stable_did",
+            "bluesky_authority": spec.authority,
+            "bluesky_service_id": authority_id,
+            "bluesky_transport": "stdlib_urllib_get_only_xrpc_queries",
+            "bluesky_procedures": "unreachable",
+        }
+    )
+    archive = {
+        "provider": PROVIDER,
+        "connection_id": context.connection_id,
+        "remote_account_id": account_did,
+        "exported_at": observed_at,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": policy,
+        "accounts": [
+            {
+                "remote_id": account_did,
+                "handle": context.account.get("handle"),
+                "display_name": context.account.get("name"),
+                "observed_at": observed_at,
+                "provider_json": {
+                    "identity": "did",
+                    "pds_id": context.account.get("pds_id"),
+                    "appview_id": context.account.get("appview_id"),
+                    "chat_id": context.account.get("chat_id"),
+                },
+            }
+        ],
+        "objects": objects,
+        "activities": activities,
+        "media": media,
+        "coverage": _coverage(observed_at),
+    }
+    reject_credentials(archive)
+    return archive

--- a/.agents/scripts/_knowledge_social_bluesky_provider.py
+++ b/.agents/scripts/_knowledge_social_bluesky_provider.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded GET-only XRPC subprocess for Bluesky account collection."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+from _knowledge_social_bluesky import BlueskyAdapterError, PageRequest, did, parse_page_request
+from _knowledge_social_bluesky_http import (
+    MAX_REQUEST_BYTES,
+    MAX_RESPONSE_BYTES,
+    Profile,
+    api,
+    connection_id,
+    observed_at,
+    profile_from_environment,
+    service_id,
+    terminal_payload,
+)
+from _knowledge_social_bluesky_identity import resolve_pds
+from _knowledge_social_bluesky_routes import page
+
+
+def identity(profile: Profile, expected_id: str) -> dict[str, Any]:
+    """Verify handle resolution and current PDS ownership for one stable DID."""
+    account_did = did(expected_id, "configured account DID")
+    if resolve_pds(account_did) != profile.pds:
+        raise BlueskyAdapterError(
+            "selected Bluesky PDS does not match the authoritative DID document"
+        )
+    describe = api(
+        profile,
+        profile.pds,
+        "com.atproto.repo.describeRepo",
+        {"repo": account_did},
+    )
+    if describe.status != 200:
+        return terminal_payload(describe)
+    resolved = api(
+        profile,
+        profile.pds,
+        "com.atproto.identity.resolveHandle",
+        {"handle": profile.handle},
+    )
+    if resolved.status != 200:
+        return terminal_payload(resolved)
+    if describe.payload.get("did") != account_did:
+        raise BlueskyAdapterError("selected Bluesky PDS does not serve the configured DID")
+    if resolved.payload.get("did") != account_did:
+        raise BlueskyAdapterError("selected Bluesky handle does not resolve to the configured DID")
+    current_handle = describe.payload.get("handle")
+    if not isinstance(current_handle, str) or not current_handle:
+        current_handle = profile.handle
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": {
+            "did": account_did,
+            "handle": current_handle,
+            "pds_id": service_id(profile.pds),
+            "appview_id": service_id(profile.appview),
+            "chat_id": service_id(profile.chat),
+            "instance_id": connection_id(account_did, profile),
+            "auth_mode": profile.auth_mode,
+        },
+    }
+
+
+def _read_request() -> dict[str, Any]:
+    payload = sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1)
+    if len(payload) > MAX_REQUEST_BYTES:
+        raise BlueskyAdapterError("Bluesky read request exceeds the safety limit")
+    try:
+        value = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise BlueskyAdapterError("Bluesky read request is not valid JSON") from error
+    if not isinstance(value, dict):
+        raise BlueskyAdapterError("Bluesky read request root must be an object")
+    return value
+
+
+def _expected_service(data: dict[str, Any], request: PageRequest) -> Any:
+    field = "pds_id" if request.authority == "sync" else f"{request.authority}_id"
+    return data.get(field)
+
+
+def _verified_page(profile: Profile, request: PageRequest) -> dict[str, Any]:
+    verified = identity(profile, request.account_id)
+    if verified.get("status") != 200:
+        return verified
+    data = verified.get("data")
+    if not isinstance(data, dict) or _expected_service(data, request) != request.service_id:
+        raise BlueskyAdapterError("Bluesky service changed during collection")
+    return page(profile, request)
+
+
+def handle_request(profile: Profile, raw: dict[str, Any]) -> dict[str, Any]:
+    """Dispatch only the two exact child-process actions."""
+    action = raw.get("action")
+    if action == "identity" and set(raw) == {"action", "account_id"}:
+        return identity(profile, did(raw.get("account_id"), "account DID"))
+    if action == "page":
+        return _verified_page(profile, parse_page_request(raw))
+    raise BlueskyAdapterError("Bluesky read action is unsupported")
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode()) > MAX_RESPONSE_BYTES:
+        raise BlueskyAdapterError("Bluesky read response exceeds the safety limit")
+    print(encoded)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    return parser.parse_args()
+
+
+def run(profile_name: str) -> int:
+    """Run one redacted child invocation."""
+    try:
+        _emit(handle_request(profile_from_environment(profile_name), _read_request()))
+        return 0
+    except BlueskyAdapterError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - redact transport and credential internals
+        print("ERROR: Bluesky read provider request failed", file=sys.stderr)
+        return 1
+
+
+def main() -> int:
+    return run(parse_args().profile)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_bluesky_reader.py
+++ b/.agents/scripts/_knowledge_social_bluesky_reader.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and deterministic fixture readers for Bluesky."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from _knowledge_social_bluesky import (
+    BlueskyAdapterError,
+    BlueskyProviderUnavailableError,
+    PageRequest,
+    did,
+    service_id,
+    text,
+)
+from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
+from knowledge_social_import import reject_credentials
+
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+SAFE_FAILURES = (
+    "Python urllib HTTP exports are unavailable",
+    "Bluesky profile name is invalid",
+    "Bluesky profile access token is missing",
+    "Bluesky profile handle is missing",
+    "Bluesky OAuth profile requires DPoP support",
+    "Bluesky AppView service identity is invalid",
+    "Bluesky chat service identity is invalid",
+    "Bluesky service URL is missing or unsafe",
+    "selected Bluesky DID does not match the configured connection",
+    "selected Bluesky handle does not resolve to the configured DID",
+    "selected Bluesky PDS does not serve the configured DID",
+    "selected Bluesky PDS does not match the authoritative DID document",
+    "Bluesky service changed during collection",
+)
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    if len(output.encode()) > MAX_RESPONSE_BYTES:
+        raise BlueskyAdapterError("Bluesky read response exceeds the safety limit")
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise BlueskyAdapterError("Bluesky read provider returned no valid JSON") from error
+    if not isinstance(payload, dict):
+        raise BlueskyAdapterError("Bluesky read response root must be an object")
+    return payload
+
+
+def _provider_failure(stderr: str) -> BlueskyProviderUnavailableError:
+    for message in SAFE_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return BlueskyProviderUnavailableError(message)
+    return BlueskyProviderUnavailableError("Bluesky read provider is unavailable")
+
+
+BLUESKY_READER_POLICY = GuardedOAuthPolicy(
+    "Bluesky",
+    "BLUESKY",
+    "BLUESKY_READ_LOG",
+    120,
+    _decode_output,
+    _provider_failure,
+    BlueskyProviderUnavailableError,
+    (
+        "ACCESS_TOKEN",
+        "HANDLE",
+        "PDS_URL",
+        "APPVIEW_SERVICE",
+        "CHAT_SERVICE",
+        "CHAT_ENABLED",
+        "AUTH_MODE",
+    ),
+    "",
+)
+
+
+class GuardedBluesky(GuardedOAuthReader):
+    """Run only identity and allowlisted XRPC query requests in a child."""
+
+    def __init__(self, helper: Path, profile: str) -> None:
+        super().__init__(helper, profile, BLUESKY_READER_POLICY)
+
+
+class FixtureBluesky:
+    """Deterministic substitute for service, cursor, and migration fixtures."""
+
+    def __init__(self, path: Path) -> None:
+        self.fixture = FixtureSequence(path, "Bluesky", BlueskyAdapterError)
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        del expected_id
+        return self.fixture.identity()
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        entry = self.fixture.next_page()
+        expected = entry.get("expect_request", {})
+        if not isinstance(expected, dict):
+            raise BlueskyAdapterError("Bluesky fixture request expectation must be an object")
+        actual = request.payload()
+        if any(actual.get(key) != value for key, value in expected.items()):
+            raise BlueskyAdapterError("Bluesky request did not resume at the expected checkpoint")
+        response = entry.get("response", entry)
+        if not isinstance(response, dict):
+            raise BlueskyAdapterError("Bluesky fixture page response must be an object")
+        return response
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    """Bind mutable handle/service aliases to one stable account DID."""
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise BlueskyAdapterError("Bluesky account verification returned no account")
+    account_did = did(data.get("did"), "account DID")
+    if account_did != did(expected_id, "configured account DID"):
+        raise BlueskyAdapterError("selected Bluesky DID does not match the configured connection")
+    return {
+        "id": account_did,
+        "provider_account_id": account_did,
+        "handle": text(data.get("handle"), "handle"),
+        "pds_id": service_id(data.get("pds_id"), "PDS identity"),
+        "appview_id": service_id(data.get("appview_id"), "AppView identity"),
+        "chat_id": service_id(data.get("chat_id"), "chat identity"),
+        "instance_id": service_id(data.get("instance_id"), "connection identity"),
+        "name": text(data.get("display_name"), "display name", optional=True),
+    }

--- a/.agents/scripts/_knowledge_social_bluesky_routes.py
+++ b/.agents/scripts/_knowledge_social_bluesky_routes.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Exact Bluesky XRPC query parameters and bounded response projection."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from _knowledge_social_bluesky import BlueskyAdapterError, PageRequest
+from _knowledge_social_bluesky_http import (
+    ApiResult,
+    Profile,
+    api,
+    observed_at,
+    service_id,
+    terminal_payload,
+)
+
+RESULT_KEYS = {
+    "com.atproto.repo.listRecords": "records",
+    "com.atproto.sync.listBlobs": "cids",
+    "app.bsky.feed.getAuthorFeed": "feed",
+    "app.bsky.notification.listNotifications": "notifications",
+    "app.bsky.actor.getPreferences": "preferences",
+    "app.bsky.bookmark.getBookmarks": "bookmarks",
+    "app.bsky.graph.getMutes": "mutes",
+    "app.bsky.graph.getLists": "lists",
+    "app.bsky.graph.getActorStarterPacks": "starterPacks",
+    "com.atproto.label.queryLabels": "labels",
+    "chat.bsky.convo.listConvos": "convos",
+    "chat.bsky.convo.getLog": "logs",
+}
+
+
+def _base_params(request: PageRequest) -> dict[str, str]:
+    endpoint = request.endpoint
+    if endpoint == "com.atproto.repo.listRecords":
+        params = {
+            "repo": request.account_id,
+            "collection": request.collection or "",
+            "limit": str(request.limit),
+        }
+    elif endpoint in ("com.atproto.sync.getRepoStatus", "com.atproto.sync.listBlobs"):
+        params = {"did": request.account_id}
+    elif endpoint == "app.bsky.feed.getAuthorFeed":
+        params = {
+            "actor": request.account_id,
+            "filter": "posts_with_replies",
+            "limit": str(request.limit),
+        }
+    elif endpoint in ("app.bsky.graph.getLists", "app.bsky.graph.getActorStarterPacks"):
+        params = {"actor": request.account_id, "limit": str(request.limit)}
+    elif endpoint == "com.atproto.label.queryLabels":
+        params = {"uriPatterns": f"at://{request.account_id}/*", "limit": str(request.limit)}
+    elif endpoint == "app.bsky.actor.getPreferences":
+        params = {}
+    elif endpoint == "chat.bsky.convo.getLog":
+        params = {}
+    else:
+        params = {"limit": str(request.limit)}
+    return params
+
+
+def params_for(request: PageRequest) -> dict[str, str]:
+    params = _base_params(request)
+    if request.endpoint == "com.atproto.sync.listBlobs":
+        params["limit"] = str(request.limit)
+    if request.cursor:
+        params["cursor"] = request.cursor
+    return params
+
+
+def items_from(payload: dict[str, Any], request: PageRequest) -> list[dict[str, Any]]:
+    if request.endpoint == "com.atproto.sync.getRepoStatus":
+        return [payload]
+    key = RESULT_KEYS.get(request.endpoint)
+    value = payload.get(key, []) if key else []
+    if not isinstance(value, list):
+        raise BlueskyAdapterError("Bluesky query result is not an array")
+    if request.endpoint == "com.atproto.sync.listBlobs":
+        return [{"cid": item} for item in value if isinstance(item, str)]
+    if any(not isinstance(item, dict) for item in value):
+        raise BlueskyAdapterError("Bluesky query result contains an invalid item")
+    return value
+
+
+def _proxy_service(profile: Profile, request: PageRequest) -> str | None:
+    if request.authority == "chat":
+        return profile.chat if profile.chat_enabled else None
+    return profile.appview if request.authority == "appview" else ""
+
+
+def _query(profile: Profile, request: PageRequest) -> tuple[ApiResult, list[dict[str, Any]]] | None:
+    proxy = _proxy_service(profile, request)
+    if proxy is None:
+        return None
+    identity = profile.pds if proxy == "" else proxy
+    if service_id(identity) != request.service_id:
+        raise BlueskyAdapterError("Bluesky service changed during collection")
+    result = api(
+        profile,
+        profile.pds,
+        request.endpoint,
+        params_for(request),
+        proxy or None,
+    )
+    return result, items_from(result.payload, request) if result.status == 200 else []
+
+
+def _first_text(values: list[dict[str, Any]], keys: tuple[str, ...]) -> str | None:
+    if not values:
+        return None
+    for key in keys:
+        candidate = values[0].get(key)
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return None
+
+
+def _watermark(result: ApiResult, items: list[dict[str, Any]]) -> str | None:
+    direct = _first_text([result.payload], ("rev", "cid", "uri", "id"))
+    return direct or _first_text(items, ("uri", "cid", "id", "convoId", "messageId"))
+
+
+def _success(request: PageRequest, result: ApiResult, items: list[dict[str, Any]]) -> dict[str, Any]:
+    cursor = result.payload.get("cursor")
+    if cursor is not None and (not isinstance(cursor, str) or not cursor):
+        raise BlueskyAdapterError("Bluesky query cursor is invalid")
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": items,
+        "meta": {
+            "stream": request.stream,
+            "did": request.account_id,
+            "service_id": request.service_id,
+            "next_cursor": cursor,
+            "complete": cursor is None,
+            "watermark": _watermark(result, items),
+        },
+    }
+
+
+def page(profile: Profile, request: PageRequest) -> dict[str, Any]:
+    """Read and project one service-fenced page."""
+    if request.endpoint == "unavailable":
+        return _success(request, ApiResult(200, {}), [])
+    queried = _query(profile, request)
+    if queried is None:
+        return {"status": 403, "observed_at": observed_at()}
+    result, items = queried
+    if result.status != 200:
+        return terminal_payload(result)
+    return _success(request, result, items)

--- a/.agents/scripts/knowledge_social_bluesky.py
+++ b/.agents/scripts/knowledge_social_bluesky.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one bounded, read-only Bluesky/AT Protocol account stream."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import _knowledge_social_bluesky as bluesky
+from _knowledge_social_collect import ContextRequest
+from _knowledge_social_collect_cli import CollectorCliPolicy, parse_collector_args, run_collector
+from _knowledge_social_collect_state import load_context
+from _knowledge_social_lease import (
+    RunLeaseRequest,
+    SocialLeaseLostError,
+    acquire_run_lease,
+    fail_active_run,
+    release_run_lease,
+)
+from _knowledge_social_bluesky_normalize import PageContext, normalize_page
+from _knowledge_social_bluesky_reader import FixtureBluesky, GuardedBluesky, verified_identity
+from _knowledge_social_oauth_collector import OAuthCollector, OAuthCollectorPolicy
+from knowledge_social_store import validate_opaque
+
+COLLECTOR_POLICY = OAuthCollectorPolicy(
+    display_name="Bluesky",
+    provider_module=bluesky,
+    helper=Path(__file__).with_name("_knowledge_social_bluesky_provider.py"),
+    fixture_reader=FixtureBluesky,
+    live_reader=GuardedBluesky,
+    page_context=PageContext,
+    normalize_page=normalize_page,
+    verified_identity=verified_identity,
+    budget_unit="request",
+    default_budget=19,
+    min_budget=7,
+    max_page_size=100,
+)
+
+
+class BlueskyCollector(OAuthCollector):
+    """Use a stable DID selector instead of the generic opaque account ID."""
+
+    @staticmethod
+    def _identity_cost(result: dict[str, Any]) -> dict[str, Any]:
+        units = result.get("budget_units")
+        if isinstance(units, int) and not isinstance(units, bool):
+            result["budget_units"] = units + 2
+        return result
+
+    def _budgeted_pages(self, runner: Any, context: Any) -> dict[str, Any]:
+        declared_budget = self.args.budget
+        self.args.budget = declared_budget - 2
+        try:
+            return self._identity_cost(self._collect_pages(runner, context))
+        finally:
+            self.args.budget = declared_budget
+
+    def collect(self, args: Any, root: Path, collector_id: str) -> dict[str, Any]:
+        del args
+        connection_id = validate_opaque(self.args.connection_id, "connection_id")
+        account_id = bluesky.did(self.args.account_id, "configured account DID")
+        lease = acquire_run_lease(
+            root,
+            RunLeaseRequest(
+                connection_id,
+                self.args.stream,
+                collector_id,
+                "sync",
+                self.args.lease_seconds,
+            ),
+        )
+        try:
+            runner = self._runner()
+            identity = runner.identity(account_id)
+            terminal = self._identity_terminal_result(root, lease, identity)
+            if terminal is not None:
+                return self._identity_cost(terminal)
+            account = self.policy.verified_identity(identity, account_id)
+            context = replace(
+                load_context(
+                    root,
+                    ContextRequest(
+                        bluesky.PROVIDER,
+                        connection_id,
+                        account,
+                        self.args.stream,
+                        "none",
+                    ),
+                    bluesky.STREAMS,
+                ),
+                lease=lease,
+            )
+            return self._budgeted_pages(runner, context)
+        except Exception as error:
+            try:
+                fail_active_run(root, lease, self._failure_class(error))
+            except SocialLeaseLostError:
+                pass
+            raise
+        finally:
+            release_run_lease(root, lease)
+
+
+def main() -> int:
+    cli_policy = CollectorCliPolicy(
+        description=__doc__ or "",
+        streams=tuple(bluesky.STREAMS),
+        default_budget=COLLECTOR_POLICY.default_budget,
+        min_budget=COLLECTOR_POLICY.min_budget,
+        max_page_size=COLLECTOR_POLICY.max_page_size,
+        budget_unit=COLLECTOR_POLICY.budget_unit,
+    )
+    args = parse_collector_args(cli_policy)
+    return run_collector(args, BlueskyCollector(COLLECTOR_POLICY, args).collect)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/tests/fixtures/knowledge-social-bluesky/profile.json
+++ b/.agents/tests/fixtures/knowledge-social-bluesky/profile.json
@@ -1,0 +1,48 @@
+{
+  "identity": {
+    "status": 200,
+    "observed_at": "2026-07-31T12:00:00Z",
+    "data": {
+      "did": "did:plc:fixtureaccountaaaaaaaa",
+      "handle": "fixture.example.invalid",
+      "pds_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+      "appview_id": "bbbbbbbbbbbbbbbbbbbbbbbb",
+      "chat_id": "cccccccccccccccccccccccc",
+      "instance_id": "dddddddddddddddddddddddd",
+      "display_name": "Fixture Account"
+    }
+  },
+  "pages": [
+    {
+      "expect_request": {
+        "stream": "profile",
+        "account_id": "did:plc:fixtureaccountaaaaaaaa",
+        "service_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+        "cursor": null
+      },
+      "response": {
+        "status": 200,
+        "observed_at": "2026-07-31T12:00:01Z",
+        "data": [
+          {
+            "uri": "at://did:plc:fixtureaccountaaaaaaaa/app.bsky.actor.profile/self",
+            "cid": "bafyfixtureprofilecid",
+            "value": {
+              "$type": "app.bsky.actor.profile",
+              "displayName": "Fixture Account",
+              "description": "Synthetic fixture only"
+            }
+          }
+        ],
+        "meta": {
+          "stream": "profile",
+          "did": "did:plc:fixtureaccountaaaaaaaa",
+          "service_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+          "next_cursor": null,
+          "complete": true,
+          "watermark": "bafyfixtureprofilecid"
+        }
+      }
+    }
+  ]
+}

--- a/.agents/tests/test-knowledge-social-bluesky.sh
+++ b/.agents/tests/test-knowledge-social-bluesky.sh
@@ -1,0 +1,392 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-bluesky.sh — Bluesky authority and no-write tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="${SCRIPT_DIR}/../scripts"
+FIXTURE="${SCRIPT_DIR}/fixtures/knowledge-social-bluesky/profile.json"
+CORPUS_HELPER="${SCRIPTS}/knowledge-corpus-helper.sh"
+SOCIAL_HELPER="${SCRIPTS}/knowledge-social-helper.sh"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+ACCOUNT_DID="did:plc:fixtureaccountaaaaaaaa"
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		printf '  PASS  %s\n' "$description"
+	else
+		printf '  FAIL  %s (expected=%s actual=%s)\n' "$description" "$expected" "$actual"
+		return 1
+	fi
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+printf 'Bluesky social collector tests\n'
+
+python3 - "$SCRIPTS" <<'PY'
+import ast
+import os
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+
+from _knowledge_social_bluesky import (
+    STREAMS,
+    BlueskyAdapterError,
+    PageRequest,
+    page_checkpoint,
+    page_request,
+    parse_page_request,
+)
+from _knowledge_social_bluesky_http import (
+    Profile,
+    profile_from_environment,
+    service_id,
+    service_url,
+)
+from _knowledge_social_bluesky_identity import pds_endpoint
+from _knowledge_social_bluesky_routes import items_from, page, params_for
+from _knowledge_social_collect import CursorState
+
+expected = {
+    "profile", "posts", "reposts", "likes", "follows", "blocks",
+    "lists", "list_items", "feed_generators", "starter_packs",
+    "labeler_services", "repo_status", "blobs", "author_feed",
+    "notifications", "preferences", "bookmarks", "mutes", "appview_lists",
+    "appview_starter_packs", "labels", "chat_conversations", "chat_log",
+    "repository_export",
+}
+assert set(STREAMS) == expected
+assert STREAMS["posts"].collection == "app.bsky.feed.post"
+assert STREAMS["notifications"].authority == "appview"
+assert STREAMS["chat_log"].authority == "chat"
+assert STREAMS["repository_export"].coverage_status == "unavailable"
+assert all(spec.cost_units == 4 for spec in STREAMS.values())
+
+request = PageRequest(
+    "posts", "did:plc:fixtureaccountaaaaaaaa", "fixture.example.invalid",
+    "a" * 24, "pds", "com.atproto.repo.listRecords",
+    "app.bsky.feed.post", None, 50,
+)
+assert parse_page_request(request.payload()) == request
+for endpoint in (
+    "com.atproto.repo.createRecord", "com.atproto.repo.putRecord",
+    "com.atproto.repo.deleteRecord", "com.atproto.repo.applyWrites",
+    "app.bsky.graph.muteActor", "app.bsky.notification.updateSeen",
+    "chat.bsky.convo.sendMessage", "chat.bsky.convo.deleteMessageForSelf",
+):
+    assert endpoint not in {spec.endpoint for spec in STREAMS.values()}
+
+provider = ast.parse((scripts / "_knowledge_social_bluesky_http.py").read_text())
+methods = {
+    node.value.value
+    for node in ast.walk(provider)
+    if isinstance(node, ast.keyword)
+    and node.arg == "method"
+    and isinstance(node.value, ast.Constant)
+}
+assert methods == {"GET"}
+
+try:
+    altered = request.payload()
+    altered["endpoint"] = "com.atproto.repo.applyWrites"
+    parse_page_request(altered)
+except BlueskyAdapterError:
+    pass
+else:
+    raise AssertionError("write-capable XRPC route was accepted")
+
+account = {
+    "id": request.account_id,
+    "handle": request.handle,
+    "pds_id": "a" * 24,
+    "appview_id": "b" * 24,
+    "chat_id": "c" * 24,
+}
+checkpoint, complete = page_checkpoint(
+    {
+        "meta": {
+            "stream": "posts", "did": request.account_id,
+            "service_id": "a" * 24, "next_cursor": "opaque-page-2",
+            "complete": False, "watermark": "bafyfixturewatermark",
+        }
+    },
+    CursorState(None, None, False),
+    request,
+)
+assert complete is False
+resumed = page_request(
+    "posts", account, CursorState(checkpoint.next_cursor, checkpoint.watermark, False), 50
+)
+assert resumed.cursor == "opaque-page-2"
+migrated = dict(account, pds_id="e" * 24)
+assert page_request(
+    "posts", migrated, CursorState(checkpoint.next_cursor, checkpoint.watermark, False), 50
+).cursor is None
+try:
+    rebound = dict(account, id="did:plc:anotherfixtureaccount")
+    page_request(
+        "posts", rebound, CursorState(checkpoint.next_cursor, checkpoint.watermark, False), 50
+    )
+except BlueskyAdapterError:
+    pass
+else:
+    raise AssertionError("DID-rebound cursor was accepted")
+
+profile = Profile(
+    "x", request.handle, "https://pds.example.invalid",
+    "https://appview.example.invalid", None, False, "oauth",
+)
+chat_request = PageRequest(
+    "chat_log", request.account_id, request.handle, service_id(None),
+    "chat", "chat.bsky.convo.getLog", None, None, 50,
+)
+assert page(profile, chat_request)["status"] == 403
+assert params_for(chat_request) == {}
+assert params_for(request) == {
+    "repo": request.account_id,
+    "collection": "app.bsky.feed.post",
+    "limit": "50",
+}
+try:
+    items_from({"records": ["malformed"]}, request)
+except BlueskyAdapterError:
+    pass
+else:
+    raise AssertionError("malformed repository records were accepted")
+for unsafe in (
+    "http://pds.example.invalid", "https://user@pds.example.invalid",
+    "https://pds.example.invalid/path", "https://pds.example.invalid?query=1",
+):
+    try:
+        service_url(unsafe)
+    except BlueskyAdapterError:
+        pass
+    else:
+        raise AssertionError("unsafe service URL was accepted")
+
+document = {
+    "id": request.account_id,
+    "service": [{
+        "id": "#atproto_pds",
+        "type": "AtprotoPersonalDataServer",
+        "serviceEndpoint": "https://pds.example.invalid",
+    }],
+}
+assert pds_endpoint(document, request.account_id) == "https://pds.example.invalid"
+try:
+    pds_endpoint(document, "did:plc:anotherfixtureaccount")
+except BlueskyAdapterError:
+    pass
+else:
+    raise AssertionError("mismatched DID document was accepted")
+
+os.environ.update({
+    "BLUESKY_TEST_ACCESS_TOKEN": "x",
+    "BLUESKY_TEST_HANDLE": request.handle,
+    "BLUESKY_TEST_PDS_URL": "https://pds.example.invalid",
+    "BLUESKY_TEST_APPVIEW_SERVICE": "did:web:appview.example.invalid#bsky_appview",
+    "BLUESKY_TEST_AUTH_MODE": "oauth",
+})
+try:
+    profile_from_environment("test")
+except BlueskyAdapterError as error:
+    assert "DPoP" in str(error)
+else:
+    raise AssertionError("bearer-only OAuth profile was accepted")
+PY
+assert_eq "routes, migration, cursors, and private gates are bounded" verified verified
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$SOCIAL_HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+result=$(python3 "$SCRIPTS/knowledge_social_bluesky.py" \
+	--base "$BASE" --alias personal:default \
+	--connection-id conn_bluesky_fixture --account-id "$ACCOUNT_DID" \
+	--stream profile --profile fixture --fixture "$FIXTURE")
+assert_eq "fixture collection completes" \
+	"$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["status"])' "$result")" complete
+assert_eq "reported budget includes all identity requests" \
+	"$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["budget_units"])' "$result")" 7
+assert_eq "stable DID is canonical account identity" \
+	"$(sql_value "SELECT remote_id FROM accounts WHERE provider='bluesky'")" "$ACCOUNT_DID"
+assert_eq "repository profile evidence persists once" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='bluesky' AND object_type='profile'")" 1
+assert_eq "service authority is retained" \
+	"$(sql_value "SELECT json_extract(provider_json, '$.authority') FROM objects WHERE provider='bluesky'")" pds
+assert_eq "binary export remains explicit unavailable coverage" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE connection_id='conn_bluesky_fixture' AND stream='repository_car_export' AND status='unavailable'")" 1
+
+python3 - "$SCRIPTS" <<'PY'
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[1])
+from _knowledge_social_bluesky import PageRequest
+from _knowledge_social_bluesky_normalize import PageContext, normalize_page
+
+did = "did:plc:fixtureaccountaaaaaaaa"
+account = {
+    "id": did,
+    "handle": "fixture.example.invalid",
+    "pds_id": "a" * 24,
+    "appview_id": "b" * 24,
+    "chat_id": "c" * 24,
+}
+payload = {
+    "observed_at": "2026-07-31T12:00:00Z",
+    "data": [{
+        "uri": f"at://{did}/app.bsky.feed.post/deleted",
+        "cid": "bafyfixturedeleted",
+        "deleted": True,
+        "value": {"text": "Synthetic tombstone"},
+    }],
+}
+archive = normalize_page(payload, PageContext("conn", account, "posts", ("posts",), {}))
+assert archive["activities"][0]["state"] == "deleted"
+assert archive["objects"][0]["provider_json"]["tombstone"] is True
+assert archive["objects"][0]["provider_json"]["at_uri"].startswith("at://")
+assert archive["objects"][0]["provider_json"]["cid"] == "bafyfixturedeleted"
+blob_archive = normalize_page(
+    {"observed_at": payload["observed_at"], "data": [{"cid": "bafyfixtureblob"}]},
+    PageContext("conn", account, "blobs", ("blobs",), {}),
+)
+assert blob_archive["media"][0] == {
+    "remote_id": "bafyfixtureblob",
+    "object_remote_id": "bafyfixtureblob",
+    "content_sha256": None,
+    "mime_type": None,
+    "byte_size": None,
+    "blob_ref": "bafyfixtureblob",
+    "hydration_state": "metadata_only",
+}
+
+like_uri = f"at://{did}/app.bsky.feed.like/action"
+target_uri = "at://did:plc:targetfixtureaccount/app.bsky.feed.post/post"
+like_archive = normalize_page(
+    {
+        "observed_at": payload["observed_at"],
+        "data": [{
+            "uri": like_uri,
+            "cid": "bafyfixturelike",
+            "value": {"subject": {"uri": target_uri, "cid": "bafyfixturepost"}},
+        }],
+    },
+    PageContext("conn", account, "likes", ("likes",), {}),
+)
+assert like_archive["objects"] == []
+assert like_archive["activities"][0]["remote_id"] == like_uri
+assert like_archive["activities"][0]["object_remote_id"] == target_uri
+
+preference_type = "app.bsky.actor.defs#labelersPref"
+preference_a = {"$type": preference_type, "labelerDid": "did:plc:labelerfixturea"}
+preference_b = {"$type": preference_type, "labelerDid": "did:plc:labelerfixtureb"}
+preference_archive = normalize_page(
+    {"observed_at": payload["observed_at"], "data": [preference_a, preference_b]},
+    PageContext("conn", account, "preferences", ("preferences",), {}),
+)
+preference_ids = [row["remote_id"] for row in preference_archive["objects"]]
+assert len(set(preference_ids)) == 2
+preference_a["visibility"] = "hide"
+updated_preference = normalize_page(
+    {"observed_at": payload["observed_at"], "data": [preference_a]},
+    PageContext("conn", account, "preferences", ("preferences",), {}),
+)
+assert updated_preference["objects"][0]["remote_id"] == preference_ids[0]
+
+bookmark = {
+    "subject": {"uri": target_uri, "cid": "bafyfixturepost"},
+    "createdAt": payload["observed_at"],
+    "item": {
+        "uri": target_uri,
+        "likeCount": 1,
+        "record": {"text": "Bookmarked fixture post"},
+    },
+}
+bookmark_archive = normalize_page(
+    {"observed_at": payload["observed_at"], "data": [bookmark]},
+    PageContext("conn", account, "bookmarks", ("bookmarks",), {}),
+)
+bookmark["item"]["likeCount"] = 2
+updated_bookmark = normalize_page(
+    {"observed_at": payload["observed_at"], "data": [bookmark]},
+    PageContext("conn", account, "bookmarks", ("bookmarks",), {}),
+)
+assert bookmark_archive["objects"][0]["remote_id"] == target_uri
+assert updated_bookmark["objects"][0]["remote_id"] == target_uri
+assert bookmark_archive["objects"][0]["text"] == "Bookmarked fixture post"
+
+chat_items = [
+    {
+        "$type": "chat.bsky.convo.defs#logCreateMessage",
+        "rev": "chat-rev-1",
+        "convoId": "convo-fixture",
+        "message": {
+            "id": "message-1", "rev": "message-rev-1",
+            "text": "First fixture message",
+            "sender": {"did": "did:plc:senderfixtureaccount"},
+            "sentAt": "2026-07-31T11:00:00Z",
+        },
+    },
+    {
+        "$type": "chat.bsky.convo.defs#logDeleteMessage",
+        "rev": "chat-rev-2",
+        "convoId": "convo-fixture",
+        "message": {
+            "id": "message-1", "rev": "message-rev-2",
+            "sender": {"did": "did:plc:senderfixtureaccount"},
+            "sentAt": "2026-07-31T11:01:00Z",
+        },
+    },
+]
+chat_archive = normalize_page(
+    {"observed_at": payload["observed_at"], "data": chat_items},
+    PageContext("conn", account, "chat_log", ("chat_log",), {}),
+)
+assert [row["remote_id"] for row in chat_archive["objects"]] == [
+    "chat-rev-1", "chat-rev-2"
+]
+assert chat_archive["objects"][0]["text"] == "First fixture message"
+assert chat_archive["activities"][0]["actor_remote_id"] == "did:plc:senderfixtureaccount"
+assert chat_archive["activities"][1]["state"] == "deleted"
+PY
+assert_eq "normalization identities and sparse relationships converge" verified verified
+
+if rg -n --glob '*bluesky*' 'method="(POST|PUT|PATCH|DELETE)"' \
+	"$SCRIPTS" "$SCRIPT_DIR/fixtures/knowledge-social-bluesky" >/dev/null; then
+	assert_eq "credentials and provider writes remain unreachable" exposed isolated
+else
+	assert_eq "credentials and provider writes remain unreachable" isolated isolated
+fi
+
+printf 'Bluesky social collector tests passed\n'


### PR DESCRIPTION
## Summary

Add bounded, read-only Bluesky/AT Protocol ingestion with stable DID identity,
independently verified PDS/AppView/chat authority, GET-only XRPC routes,
deterministic normalization, and explicit unavailable coverage.

## Files Changed

- `.agents/content/social-bluesky.md`
- `.agents/scripts/_knowledge_social_bluesky.py`
- `.agents/scripts/_knowledge_social_bluesky_http.py`
- `.agents/scripts/_knowledge_social_bluesky_identity.py`
- `.agents/scripts/_knowledge_social_bluesky_normalize.py`
- `.agents/scripts/_knowledge_social_bluesky_provider.py`
- `.agents/scripts/_knowledge_social_bluesky_reader.py`
- `.agents/scripts/_knowledge_social_bluesky_routes.py`
- `.agents/scripts/knowledge_social_bluesky.py`
- `.agents/tests/fixtures/knowledge-social-bluesky/profile.json`
- `.agents/tests/test-knowledge-social-bluesky.sh`

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — fixture integration, static no-write
  assertions, ShellCheck, Python compileall, qlty new-file gate (0 smells), qlty
  regression (47 → 47), and smell threshold (47 ≤ 49) pass.

## Key Decisions

- Preserve the DID as canonical identity while treating handle and PDS as
  mutable aliases.
- Route AppView and chat reads through the DID-verified PDS and fail OAuth
  closed without DPoP support.
- Emit relationship activities without sparse target-object upserts that could
  overwrite richer evidence.
- Keep CAR/blob bytes, complete tombstone history, PDS migration history, and
  chat export as explicit unavailable coverage.

Resolves #28954

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.201 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h 28m and 663,548 tokens on this as a headless worker.
