### PR TITLE
GH#28787: add bounded Gumroad seller ingestion

### DIFF
--- a/.agents/content/social-gumroad.md
+++ b/.agents/content/social-gumroad.md
@@ -1,0 +1,93 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Gumroad Seller Knowledge Collection
+
+`knowledge_social_gumroad.py` collects bounded seller evidence from four exact
+Gumroad API v2 GET routes. It is intentionally provider-specific until #28867
+registers all commerce collectors in the shared helper.
+
+## Connection and protected-data contract
+
+Configure one private profile through secure environment injection:
+
+```text
+GUMROAD_<PROFILE>_ACCESS_TOKEN
+GUMROAD_<PROFILE>_PII_KEY
+```
+
+`PII_KEY` is an operator-generated random value of at least 32 bytes and must be
+stable for one profile. The child uses it only to produce deterministic HMAC
+aliases for customer and affiliate email addresses. Direct email, customer name,
+address, postal code, custom fields, license value, card visual/type, bank visual,
+PayPal address, tracking URL, and processor transaction ID are discarded before
+raw evidence crosses the child boundary. Tokens and the HMAC key never enter
+requests, logs, status, checkpoints, or evidence.
+
+Use `gumroad_<USER_ID_WITH_TRAILING_EQUALS_REMOVED>` as `--account-id`. This
+canonical account namespace converts Gumroad's padded `user_id` into the shared
+corpus identifier grammar without persisting a second account identity. Use a
+dedicated token with only the streams' required grants; sales require
+`view_sales`, and payouts require `view_payouts`.
+Identity is checked before collection and before every page. The isolated child
+constructs only `method="GET"` requests to a fixed API origin, rejects redirects,
+and accepts only `/user`, `/products`, `/sales`, and `/payouts`.
+
+## Implemented streams
+
+| Stream | Official route | Normalized coverage |
+|---|---|---|
+| `profile` | `GET /v2/user` | Stable seller ID and bounded display metadata; email is omitted. |
+| `products` | `GET /v2/products` | Product state, prices/currency, variants/options, tags, publication/deletion flags, shipping/subscription state, and only a file-metadata-presence flag. |
+| `sales` | `GET /v2/sales` | Orders, product/customer aliases, quantities, variants, price/fee/tax/shipping amounts, refunds, chargebacks/disputes, shipping state, subscriptions, license presence, and affiliate aliases/amounts. |
+| `payouts` | `GET /v2/payouts` | Current/upcoming payout amount, currency, status, dates, and processor; bank/PayPal identifiers are omitted. |
+
+Sales and payouts are `protected_business` evidence. Corpus isolation remains the
+authorization boundary: do not share the containing corpus without an explicit
+grant appropriate for customer and financial evidence. Product-scoped active
+subscriber and offer-code fan-out remain explicit gaps rather than hidden empty
+streams. Subscription and license state available on sales is retained without
+license secrets.
+
+Every listing uses the documented opaque `next_page_key`; returned next-page URLs
+are never followed. Each stream owns an independent cursor and first-page
+watermark. API responses may contain up to the configured 100-item safety cap.
+The provider does not document a read-rate limit or retention guarantee, so the
+collector uses a 3-1000 request-unit budget and records both limitations.
+
+## Exports, webhooks, and unavailable categories
+
+The dashboard has sales, audience, affiliate, and payout export workflows, but
+current official source does not publish one stable seller export schema and
+generation creates server state. No export generation, polling, download, or CSV
+import is wired.
+
+Resource subscriptions support sale, refund, dispute, dispute-won, cancellation,
+subscription-updated, subscription-ended, and subscription-restarted events.
+Creating one is a `PUT`; current documentation does not define a receiver
+signature. Events are therefore neither registered nor trusted as evidence. API
+reads remain the reconciliation authority.
+
+No verified seller read route was found for a complete affiliate directory,
+balance, posts/updates, workflows/emails, community/messages, or downloadable
+digital-file contents. Deleted resources and history are limited to records the
+current API still returns. These categories are persisted as unavailable coverage,
+not successful empty streams. Browser/storefront automation is prohibited.
+
+The following documented mutation families are unreachable: product create,
+update, delete, enable/disable and file/variant/offer edits; sale refunds, shipping
+updates, receipt resend; license changes; resource-subscription create/delete;
+and profile/content/email changes. Collector source contains no POST, PUT, PATCH,
+or DELETE request constructor.
+
+## Official evidence checked 2026-07-31
+
+- [Gumroad API documentation](https://gumroad.com/api)
+- [Current open-source Gumroad release](https://github.com/antiwork/gumroad/releases/tag/v2026.07.31.32)
+- [Seller API setup and OAuth help](https://github.com/antiwork/gumroad/blob/main/app/views/help_center/articles/contents/_280-create-application-api.html.erb)
+- [User endpoint source](https://github.com/antiwork/gumroad/blob/main/app/javascript/components/ApiDocumentation/Endpoints/User.tsx)
+- [Product endpoint source](https://github.com/antiwork/gumroad/blob/main/app/javascript/components/ApiDocumentation/Endpoints/Products.tsx)
+- [Sales endpoint source](https://github.com/antiwork/gumroad/blob/main/app/javascript/components/ApiDocumentation/Endpoints/Sales.tsx)
+- [Subscriber endpoint source](https://github.com/antiwork/gumroad/blob/main/app/javascript/components/ApiDocumentation/Endpoints/Subscribers.tsx)
+- [Payout endpoint source](https://github.com/antiwork/gumroad/blob/main/app/javascript/components/ApiDocumentation/Endpoints/Payouts.tsx)
+- [Resource-subscription endpoint source](https://github.com/antiwork/gumroad/blob/main/app/javascript/components/ApiDocumentation/Endpoints/ResourceSubscriptions.tsx)

--- a/.agents/scripts/_knowledge_social_gumroad.py
+++ b/.agents/scripts/_knowledge_social_gumroad.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Gumroad stream policy, identity binding, and durable checkpoints."""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from knowledge_social_import import canonical_json, reject_credentials
+
+PROVIDER = "gumroad"
+CURSOR_PREFIX = "gumroad-v1:"
+RETENTION_LIMIT = "current_api_visibility_and_undocumented_provider_retention"
+PROVIDER_ID = re.compile(r"^[A-Za-z0-9_=-]{6,160}$")
+
+
+class GumroadAdapterError(RuntimeError):
+    """Raised when Gumroad evidence violates the local collector contract."""
+
+
+class GumroadProviderUnavailableError(GumroadAdapterError):
+    """Raised when the isolated Gumroad reader cannot run safely."""
+
+
+ADAPTER_ERROR = GumroadAdapterError
+PROVIDER_UNAVAILABLE_ERROR = GumroadProviderUnavailableError
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    """Static collection and coverage policy for one Gumroad stream."""
+
+    resource_kind: str
+    activity_mode: str
+    pagination: str
+    incremental: bool
+    retention_limit: str | None
+    coverage_status: str | None = None
+    unavailable_reason: str | None = None
+    cost_units: int = 2
+
+
+STREAMS = {
+    "profile": StreamSpec("seller_profile", "selected_account", "snapshot", False, RETENTION_LIMIT),
+    "products": StreamSpec("product", "seller_inventory", "snapshot", False, RETENTION_LIMIT),
+    "sales": StreamSpec("sale", "seller_transaction", "listing", True, RETENTION_LIMIT),
+    "payouts": StreamSpec("payout", "seller_payout", "listing", True, RETENTION_LIMIT),
+}
+
+
+def provider_id(value: Any, field: str = "ID") -> str:
+    """Validate one opaque Gumroad identifier without exposing it in errors."""
+    if not isinstance(value, str) or PROVIDER_ID.fullmatch(value) is None:
+        raise GumroadAdapterError(f"Gumroad {field} is invalid")
+    return value
+
+
+def seller_id(value: Any, field: str = "seller ID") -> str:
+    """Map Gumroad's padded user ID to the corpus-safe account namespace."""
+    raw = provider_id(value, field)
+    if raw.startswith("gumroad_"):
+        return raw
+    return provider_id(f"gumroad_{raw.rstrip('=')}", field)
+
+
+def _optional_cursor(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value or "\x00" in value or len(value.encode()) > 1024:
+        raise GumroadAdapterError(f"Gumroad {field} is invalid")
+    return value
+
+
+def _encode_cursor(page_key: str) -> str:
+    encoded = base64.urlsafe_b64encode(canonical_json({"page_key": page_key}).encode()).decode().rstrip("=")
+    return f"{CURSOR_PREFIX}{encoded}"
+
+
+def _decode_cursor(cursor: str) -> str:
+    if not cursor.startswith(CURSOR_PREFIX):
+        raise GumroadAdapterError("stored Gumroad cursor has an unsupported version")
+    encoded = cursor.removeprefix(CURSOR_PREFIX)
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4)))
+    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+        raise GumroadAdapterError("stored Gumroad cursor is invalid") from error
+    if not isinstance(payload, dict) or set(payload) != {"page_key"}:
+        raise GumroadAdapterError("stored Gumroad cursor has an invalid shape")
+    reject_credentials(payload)
+    page_key = _optional_cursor(payload["page_key"], "page key")
+    if page_key is None:
+        raise GumroadAdapterError("stored Gumroad page key is missing")
+    return page_key
+
+
+@dataclass(frozen=True)
+class PageRequest:
+    """Allowlisted request passed to the isolated Gumroad HTTP child."""
+
+    stream: str
+    account_id: str
+    provider_account_id: str
+    page_key: str | None
+    stop_at: str | None
+    limit: int
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "page",
+            "stream": self.stream,
+            "account_id": self.account_id,
+            "provider_account_id": self.provider_account_id,
+            "page_key": self.page_key,
+            "stop_at": self.stop_at,
+            "limit": self.limit,
+        }
+
+    def evidence_key(self) -> str:
+        return canonical_json(self.payload())
+
+
+def page_request(stream: str, account: dict[str, Any], state: CursorState, limit: int) -> PageRequest:
+    """Build one request from an independent per-stream checkpoint."""
+    if stream not in STREAMS:
+        raise GumroadAdapterError("Gumroad stream is unsupported")
+    account_id = seller_id(account.get("id"), "selected account ID")
+    remote_id = seller_id(account.get("provider_account_id"), "provider account ID")
+    if account_id != remote_id:
+        raise GumroadAdapterError("selected Gumroad account does not match the configured connection")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 100:
+        raise GumroadAdapterError("Gumroad page safety limit is invalid")
+    page_key = _decode_cursor(state.cursor) if state.cursor else None
+    stop_at = state.watermark if STREAMS[stream].incremental and state.backfill_complete else None
+    return PageRequest(stream, account_id, remote_id, page_key, stop_at, limit)
+
+
+def parse_page_request(payload: dict[str, Any]) -> PageRequest:
+    """Validate the exact child-process page request shape."""
+    expected = {"action", "stream", "account_id", "provider_account_id", "page_key", "stop_at", "limit"}
+    if set(payload) != expected or payload.get("action") != "page":
+        raise GumroadAdapterError("Gumroad read request has an invalid action shape")
+    stream = payload.get("stream")
+    if not isinstance(stream, str) or stream not in STREAMS:
+        raise GumroadAdapterError("Gumroad stream is unsupported")
+    account_id = seller_id(payload.get("account_id"), "selected account ID")
+    provider_account = seller_id(payload.get("provider_account_id"), "provider account ID")
+    if account_id != provider_account:
+        raise GumroadAdapterError("selected Gumroad account does not match the configured connection")
+    limit = payload.get("limit")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 100:
+        raise GumroadAdapterError("Gumroad page safety limit is invalid")
+    return PageRequest(
+        stream,
+        account_id,
+        provider_account,
+        _optional_cursor(payload.get("page_key"), "page key"),
+        _optional_cursor(payload.get("stop_at"), "watermark"),
+        limit,
+    )
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise GumroadAdapterError("Gumroad response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise GumroadAdapterError("Gumroad page data must be an array")
+    return data
+
+
+def page_checkpoint(payload: dict[str, Any], state: CursorState, request: PageRequest) -> tuple[PageCheckpoint, bool]:
+    """Calculate one atomic page-key checkpoint and stable watermark."""
+    data = page_data(payload)
+    if len(data) > request.limit:
+        raise GumroadAdapterError("Gumroad page exceeds the item safety limit")
+    meta = payload.get("meta")
+    if not isinstance(meta, dict) or meta.get("stream") != request.stream:
+        raise GumroadAdapterError("Gumroad page provenance is invalid")
+    reject_credentials(meta)
+    next_key = _optional_cursor(meta.get("next_page_key"), "next page key")
+    newest_id = _optional_cursor(meta.get("newest_id"), "newest ID")
+    reached = meta.get("reached_watermark")
+    complete_flag = meta.get("complete")
+    if not isinstance(reached, bool) or not isinstance(complete_flag, bool):
+        raise GumroadAdapterError("Gumroad page completion metadata is invalid")
+    complete = reached or complete_flag
+    if complete == (next_key is not None):
+        raise GumroadAdapterError("Gumroad page completion cursor is invalid")
+    if next_key is not None and next_key == request.page_key:
+        raise GumroadAdapterError("Gumroad next page key did not advance")
+    next_cursor = _encode_cursor(next_key) if next_key else None
+    watermark = state.watermark
+    if STREAMS[request.stream].incremental and request.page_key is None:
+        watermark = newest_id or watermark
+    return PageCheckpoint(next_cursor, watermark), complete

--- a/.agents/scripts/_knowledge_social_gumroad_normalize.py
+++ b/.agents/scripts/_knowledge_social_gumroad_normalize.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize minimized Gumroad seller records into canonical evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_gumroad import PROVIDER, RETENTION_LIMIT, GumroadAdapterError, page_data
+from knowledge_social_import import reject_credentials
+
+PROVENANCE = "gumroad_v2_get_api"
+PROTECTED_STREAMS = frozenset({"sales", "payouts"})
+GAPS = (
+    ("offers", "product_scoped_offer_code_fanout_not_enabled"),
+    ("complete_subscribers", "product_scoped_subscriber_fanout_not_enabled"),
+    ("license_secrets", "license_values_are_intentionally_not_persisted"),
+    ("affiliate_directory", "no_verified_seller_read_route"),
+    ("balance", "no_verified_balance_read_route"),
+    ("posts_updates", "no_verified_seller_read_route"),
+    ("workflows_emails", "no_verified_seller_read_route"),
+    ("community_messages", "no_verified_seller_read_route"),
+    ("digital_files", "signed_file_downloads_and_contents_not_collected"),
+    ("seller_exports", "dashboard_generation_and_unpublished_schema_not_enabled"),
+    ("webhook_events", "subscription_mutation_and_no_documented_signature"),
+    ("deleted_resources", "only_records_retained_by_current_api_are_visible"),
+    ("provider_retention", "no_documented_api_retention_guarantee"),
+    ("rate_limit", "no_documented_read_rate_limit_contract"),
+)
+ACTIVITY_TYPES = {"profile": "seller_profile", "products": "product_state", "sales": "sale", "payouts": "payout_state"}
+
+
+@dataclass(frozen=True)
+class PageContext:
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def _required_text(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise GumroadAdapterError(f"Gumroad record requires {field}")
+    return value
+
+
+def _optional_text(value: Any, field: str) -> str | None:
+    if value is not None and (not isinstance(value, str) or "\x00" in value):
+        raise GumroadAdapterError(f"Gumroad record {field} must be text")
+    return value
+
+
+def _observed_at(payload: dict[str, Any]) -> str:
+    return _required_text(payload.get("observed_at"), "observed_at")
+
+
+def _coverage(observed_at: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "stream": stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": RETENTION_LIMIT,
+            "unavailable_reason": reason,
+            "status": "unavailable",
+            "observed_at": observed_at,
+        }
+        for stream, reason in GAPS
+    ]
+
+
+def _text(item: dict[str, Any], stream: str) -> str | None:
+    if stream == "products":
+        values = [_optional_text(item.get("name"), "name"), _optional_text(item.get("description"), "description")]
+    elif stream == "profile":
+        values = [_optional_text(item.get("name"), "name")]
+    else:
+        values = [_optional_text(item.get("product_name"), "product name")]
+    return "\n\n".join(value for value in values if value) or None
+
+
+def _object(item: dict[str, Any], context: PageContext, observed_at: str) -> dict[str, Any]:
+    kind = _required_text(item.get("kind"), "kind")
+    expected_kind = context.stream.removesuffix("s") if context.stream != "profile" else "seller_profile"
+    if kind != expected_kind:
+        raise GumroadAdapterError("Gumroad page contains an unsupported item kind")
+    remote_id = _required_text(item.get("remote_id"), "remote_id")
+    protected = context.stream in PROTECTED_STREAMS
+    provider_json = {
+        "source": PROVENANCE,
+        "stream": context.stream,
+        "classification": "protected_business" if protected else "business",
+        "record": item,
+    }
+    reject_credentials(provider_json)
+    return {
+        "object_type": kind,
+        "remote_id": remote_id,
+        "account_remote_id": context.account.get("id"),
+        "text": _text(item, context.stream),
+        "created_at": _optional_text(item.get("created_at"), "created_at"),
+        "observed_at": observed_at,
+        "evidence_class": "protected_business" if protected else "authored",
+        "provider_json": provider_json,
+    }
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    """Build corpus rows while keeping direct customer/payment identifiers out."""
+    reject_credentials(payload)
+    observed_at = _observed_at(payload)
+    account_id = _required_text(context.account.get("id"), "selected account ID")
+    objects = [_object(item, context, observed_at) for item in page_data(payload)]
+    activities = [
+        {
+            "activity_type": ACTIVITY_TYPES[context.stream],
+            "remote_id": f"{account_id}_{ACTIVITY_TYPES[context.stream]}_{item['remote_id']}",
+            "actor_remote_id": account_id,
+            "object_remote_id": item["remote_id"],
+            "occurred_at": _optional_text(item.get("created_at"), "activity time"),
+            "observed_at": observed_at,
+            "state": "active",
+            "provider_json": {"source": PROVENANCE, "stream": context.stream},
+        }
+        for item in page_data(payload)
+    ]
+    policy = dict(context.policy)
+    policy.update({
+        "gumroad_transport": "stdlib_urllib_get_only",
+        "gumroad_api_version": "v2",
+        "gumroad_direct_pii": "discarded",
+        "gumroad_customer_aliases": "profile_keyed_hmac_sha256",
+        "gumroad_financial_classification": "protected_business",
+        "gumroad_exports": "disabled",
+        "gumroad_events": "untrusted_and_disabled",
+    })
+    archive = {
+        "provider": PROVIDER,
+        "connection_id": context.connection_id,
+        "remote_account_id": account_id,
+        "exported_at": observed_at,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": policy,
+        "accounts": [{
+            "remote_id": account_id,
+            "handle": context.account.get("username"),
+            "display_name": context.account.get("name"),
+            "observed_at": observed_at,
+            "provider_json": {"source": PROVENANCE},
+        }],
+        "objects": objects,
+        "activities": activities,
+        "media": [],
+        "coverage": _coverage(observed_at),
+    }
+    reject_credentials(archive)
+    return archive

--- a/.agents/scripts/_knowledge_social_gumroad_provider.py
+++ b/.agents/scripts/_knowledge_social_gumroad_provider.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded, redirect-free, GET-only Gumroad seller reader subprocess."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from _knowledge_social_gumroad import (
+    GumroadAdapterError,
+    PageRequest,
+    parse_page_request,
+    seller_id,
+)
+from _knowledge_social_gumroad_records import (
+    object_list,
+    object_value,
+    payout_record,
+    product_record,
+    sale_record,
+    text_value,
+)
+
+API_ROOT = "https://api.gumroad.com/v2"
+MAX_REQUEST_BYTES = 32 * 1024
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+ROUTES = {"profile": "/user", "products": "/products", "sales": "/sales", "payouts": "/payouts"}
+COLLECTION_KEYS = {"products": "products", "sales": "sales", "payouts": "payouts"}
+
+
+class GumroadReadProviderError(RuntimeError):
+    """Raised for a privacy-safe local provider failure."""
+
+
+class RejectRedirects(HTTPRedirectHandler):
+    """Reject redirects so bearer credentials never cross origins."""
+
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+@dataclass(frozen=True)
+class Profile:
+    access_token: str
+    pii_key: bytes
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    status: int
+    payload: Any
+    retry_after: int | None = None
+
+
+def _observed_at() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _profile(profile: str) -> Profile:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise GumroadReadProviderError("Gumroad profile name is invalid")
+    prefix = f"GUMROAD_{profile.upper()}"
+    token = os.environ.get(f"{prefix}_ACCESS_TOKEN", "")
+    pii_key = os.environ.get(f"{prefix}_PII_KEY", "")
+    if not token or "\x00" in token or len(token.encode()) > 16 * 1024:
+        raise GumroadReadProviderError("Gumroad profile access token is missing")
+    if not pii_key or "\x00" in pii_key or len(pii_key.encode()) > 16 * 1024:
+        raise GumroadReadProviderError("Gumroad profile PII key is missing")
+    if len(pii_key.encode()) < 32:
+        raise GumroadReadProviderError("Gumroad profile PII key must be at least 32 bytes")
+    return Profile(token, pii_key.encode())
+
+
+def _request(profile: Profile, path: str, params: dict[str, str]) -> ApiResult:
+    if path not in ROUTES.values():
+        raise GumroadReadProviderError("Gumroad read route is unsupported")
+    query = f"?{urlencode(params)}" if params else ""
+    request = Request(
+        f"{API_ROOT}{path}{query}",
+        headers={"Accept": "application/json", "Authorization": f"Bearer {profile.access_token}"},
+        method="GET",
+    )
+    try:
+        with build_opener(RejectRedirects).open(request, timeout=60) as response:
+            payload = response.read(MAX_RESPONSE_BYTES + 1)
+            status = int(response.status)
+            retry_after = response.headers.get("Retry-After")
+    except HTTPError as error:
+        status = int(error.code)
+        payload = b"{}"
+        retry_after = error.headers.get("Retry-After") if error.headers else None
+    except (OSError, URLError) as error:
+        raise GumroadReadProviderError("Gumroad API request failed") from error
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise GumroadReadProviderError("Gumroad API response exceeds the byte safety limit")
+    try:
+        decoded = json.loads(payload.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise GumroadReadProviderError("Gumroad API returned no valid JSON") from error
+    retry = int(retry_after) if isinstance(retry_after, str) and retry_after.isdigit() else None
+    return ApiResult(status, decoded, retry)
+
+
+def _terminal(result: ApiResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": result.status, "observed_at": _observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload
+
+
+def _identity(profile: Profile, expected_id: str) -> dict[str, Any]:
+    result = _request(profile, "/user", {})
+    if result.status != 200:
+        return _terminal(result)
+    root = object_value(result.payload, "identity response")
+    if root.get("success") is not True:
+        return {"status": 502, "observed_at": _observed_at()}
+    user = object_value(root.get("user"), "identity user")
+    remote_id = seller_id(user.get("user_id"), "account ID")
+    if remote_id != seller_id(expected_id, "selected account ID"):
+        raise GumroadReadProviderError("selected Gumroad account does not match the configured connection")
+    return {
+        "status": 200,
+        "observed_at": _observed_at(),
+        "data": {
+            "provider_account_id": remote_id,
+            "username": text_value(user.get("url"), "account URL"),
+            "display_name": text_value(user.get("name"), "account name"),
+        },
+    }
+
+
+def _page(profile: Profile, request: PageRequest, identity: dict[str, Any]) -> dict[str, Any]:
+    if identity.get("provider_account_id") != request.provider_account_id:
+        raise GumroadReadProviderError("selected Gumroad account does not match the configured connection")
+    if request.stream == "profile":
+        return {
+            "status": 200,
+            "observed_at": _observed_at(),
+            "data": [{"kind": "seller_profile", "remote_id": request.account_id, "name": identity.get("display_name")}],
+            "meta": {"stream": "profile", "next_page_key": None, "newest_id": request.account_id, "reached_watermark": False, "complete": True},
+        }
+    params = {"page_key": request.page_key} if request.page_key else {}
+    result = _request(profile, ROUTES[request.stream], params)
+    if result.status != 200:
+        return _terminal(result)
+    root = object_value(result.payload, f"{request.stream} response")
+    if root.get("success") is not True:
+        return {"status": 502, "observed_at": _observed_at()}
+    values = object_list(root.get(COLLECTION_KEYS[request.stream]), request.stream, 100)
+    converters = {
+        "products": product_record,
+        "sales": lambda item: sale_record(profile.pii_key, item),
+        "payouts": payout_record,
+    }
+    converted = [converters[request.stream](item) for item in values]
+    reached = False
+    if request.stop_at:
+        retained = []
+        for item in converted:
+            if item["remote_id"] == request.stop_at:
+                reached = True
+                break
+            retained.append(item)
+        converted = retained
+    if len(converted) > request.limit:
+        raise GumroadReadProviderError("Gumroad page exceeds the configured item safety limit")
+    next_key = text_value(root.get("next_page_key"), "next page key")
+    complete = reached or next_key is None
+    return {
+        "status": 200,
+        "observed_at": _observed_at(),
+        "data": converted,
+        "meta": {
+            "stream": request.stream,
+            "next_page_key": None if complete else next_key,
+            "newest_id": converted[0]["remote_id"] if converted else None,
+            "reached_watermark": reached,
+            "complete": complete,
+        },
+    }
+
+
+def _request_object(payload: bytes) -> dict[str, Any]:
+    if len(payload) > MAX_REQUEST_BYTES:
+        raise GumroadReadProviderError("Gumroad read request exceeds the safety limit")
+    try:
+        request = json.loads(payload.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise GumroadReadProviderError("Gumroad read request is not valid JSON") from error
+    return object_value(request, "read request")
+
+
+def _dispatch(request: dict[str, Any], profile: Profile) -> dict[str, Any]:
+    action = request.get("action")
+    if action == "identity":
+        if set(request) != {"action", "account_id"}:
+            raise GumroadReadProviderError("Gumroad read request has an invalid action shape")
+        return _identity(profile, seller_id(request.get("account_id"), "selected account ID"))
+    if action != "page":
+        raise GumroadReadProviderError("Gumroad read action is unsupported")
+    page_request = parse_page_request(request)
+    identity_result = _identity(profile, page_request.provider_account_id)
+    if identity_result.get("status") != 200:
+        return identity_result
+    identity = object_value(identity_result.get("data"), "verified identity")
+    return _page(profile, page_request, identity)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    args = parser.parse_args()
+    try:
+        payload = _dispatch(_request_object(sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1)), _profile(args.profile))
+        encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+        if len(encoded.encode()) > MAX_RESPONSE_BYTES:
+            raise GumroadReadProviderError("Gumroad read response exceeds the safety limit")
+        print(encoded)
+        return 0
+    except (GumroadReadProviderError, GumroadAdapterError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - redact provider and customer internals
+        print("ERROR: Gumroad read provider request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_gumroad_reader.py
+++ b/.agents/scripts/_knowledge_social_gumroad_reader.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and deterministic fixture readers for Gumroad collection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_gumroad import (
+    GumroadAdapterError,
+    GumroadProviderUnavailableError,
+    PageRequest,
+    seller_id,
+)
+from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
+from knowledge_social_import import reject_credentials
+
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+SAFE_FAILURES = (
+    "Gumroad profile name is invalid",
+    "Gumroad profile access token is missing",
+    "Gumroad profile PII key is missing",
+    "Gumroad profile PII key must be at least 32 bytes",
+    "selected Gumroad account does not match the configured connection",
+)
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    if len(output.encode()) > MAX_RESPONSE_BYTES:
+        raise GumroadAdapterError("Gumroad read response exceeds the safety limit")
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise GumroadAdapterError("Gumroad read provider returned no valid JSON") from error
+    if not isinstance(payload, dict):
+        raise GumroadAdapterError("Gumroad read response root must be an object")
+    return payload
+
+
+def _provider_failure(stderr: str) -> GumroadProviderUnavailableError:
+    for message in SAFE_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return GumroadProviderUnavailableError(message)
+    return GumroadProviderUnavailableError("Gumroad read provider is unavailable")
+
+
+READER_POLICY = GuardedOAuthPolicy(
+    "Gumroad",
+    "GUMROAD",
+    "GUMROAD_READ_LOG",
+    120,
+    _decode_output,
+    _provider_failure,
+    GumroadProviderUnavailableError,
+    ("ACCESS_TOKEN", "PII_KEY"),
+)
+
+
+class GuardedGumroad(GuardedOAuthReader):
+    """Execute only identity and allowlisted GET reads in a bounded child."""
+
+    def __init__(self, helper: Path, profile: str) -> None:
+        super().__init__(helper, profile, READER_POLICY)
+
+
+class FixtureGumroad:
+    """Deterministic HTTP substitute for pagination and failure fixtures."""
+
+    def __init__(self, path: Path) -> None:
+        self.fixture = FixtureSequence(path, "Gumroad", GumroadAdapterError)
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        del expected_id
+        return self.fixture.identity()
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        entry = self.fixture.next_page()
+        expectation = entry.get("expect_request", {})
+        if not isinstance(expectation, dict):
+            raise GumroadAdapterError("Gumroad fixture expectation must be an object")
+        actual = request.payload()
+        if any(actual.get(key) != value for key, value in expectation.items()):
+            raise GumroadAdapterError("Gumroad request did not resume at the expected checkpoint")
+        response = entry.get("response", entry)
+        if not isinstance(response, dict):
+            raise GumroadAdapterError("Gumroad fixture page response must be an object")
+        return response
+
+
+def _optional_text(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value or len(value.encode()) > 4096:
+        raise GumroadAdapterError(f"Gumroad account {field} must be bounded text")
+    return value
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    """Bind every run to the exact seller returned by GET /v2/user."""
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise GumroadAdapterError("Gumroad account verification returned no account")
+    remote_id = seller_id(data.get("provider_account_id"), "account ID")
+    if remote_id != seller_id(expected_id, "selected account ID"):
+        raise GumroadAdapterError("selected Gumroad account does not match the configured connection")
+    return {
+        "id": remote_id,
+        "provider_account_id": remote_id,
+        "username": _optional_text(data.get("username"), "username"),
+        "name": _optional_text(data.get("display_name"), "display name"),
+    }

--- a/.agents/scripts/_knowledge_social_gumroad_records.py
+++ b/.agents/scripts/_knowledge_social_gumroad_records.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Minimize Gumroad product, sale, and payout API records."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from typing import Any
+
+from _knowledge_social_gumroad import GumroadAdapterError, provider_id, seller_id
+
+MAX_TEXT_BYTES = 128 * 1024
+
+
+def object_value(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise GumroadAdapterError(f"Gumroad {field} must be an object")
+    return value
+
+
+def object_list(value: Any, field: str, limit: int) -> list[dict[str, Any]]:
+    if (
+        not isinstance(value, list)
+        or any(not isinstance(item, dict) for item in value)
+        or len(value) > limit
+    ):
+        raise GumroadAdapterError(f"Gumroad {field} exceeds the item safety limit")
+    return value
+
+
+def text_value(value: Any, field: str, *, optional: bool = True) -> str | None:
+    if value is None and optional:
+        return None
+    if (
+        not isinstance(value, str)
+        or not value
+        or "\x00" in value
+        or len(value.encode()) > MAX_TEXT_BYTES
+    ):
+        raise GumroadAdapterError(f"Gumroad {field} is invalid")
+    return value
+
+
+def _number(value: Any, field: str) -> int | float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise GumroadAdapterError(f"Gumroad {field} is invalid")
+    return value
+
+
+def _boolean(value: Any, field: str) -> bool | None:
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise GumroadAdapterError(f"Gumroad {field} is invalid")
+    return value
+
+
+def _private_ref(pii_key: bytes, kind: str, value: Any) -> str | None:
+    text = text_value(value, kind)
+    if text is None:
+        return None
+    digest = hmac.new(
+        pii_key,
+        f"{kind}\0{text.casefold()}".encode(),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{kind}_{digest[:32]}"
+
+
+def _recurrence_prices(value: Any) -> dict[str, dict[str, int | float | None]] | None:
+    if value is None:
+        return None
+    root = object_value(value, "variant recurrence prices")
+    if len(root) > 10:
+        raise GumroadAdapterError("Gumroad variant recurrence prices exceed the safety limit")
+    result = {}
+    for recurrence, price in root.items():
+        name = text_value(recurrence, "variant recurrence", optional=False)
+        details = object_value(price, "variant recurrence price")
+        result[name] = {
+            "price_cents": _number(details.get("price_cents"), "recurrence price"),
+            "suggested_price_cents": _number(
+                details.get("suggested_price_cents"), "suggested recurrence price"
+            ),
+        }
+    return result
+
+
+def _variants(value: Any) -> list[dict[str, Any]]:
+    result = []
+    for group in object_list(value or [], "product variants", 100):
+        options = []
+        for option in object_list(
+            group.get("options", []), "product variant options", 100
+        ):
+            options.append(
+                {
+                    "name": text_value(
+                        option.get("name"), "variant option name", optional=False
+                    ),
+                    "price_difference": _number(
+                        option.get("price_difference"), "variant price difference"
+                    ),
+                    "is_pay_what_you_want": _boolean(
+                        option.get("is_pay_what_you_want"), "variant price mode"
+                    ),
+                    "recurrence_prices": _recurrence_prices(
+                        option.get("recurrence_prices")
+                    ),
+                }
+            )
+        result.append(
+            {
+                "title": text_value(
+                    group.get("title"), "variant title", optional=False
+                ),
+                "options": options,
+            }
+        )
+    return result
+
+
+def product_record(item: dict[str, Any]) -> dict[str, Any]:
+    """Keep bounded product metadata and exclude signed file details."""
+    tags = item.get("tags", [])
+    if (
+        not isinstance(tags, list)
+        or any(not isinstance(tag, str) or "\x00" in tag for tag in tags)
+        or len(tags) > 100
+    ):
+        raise GumroadAdapterError("Gumroad product tags are invalid")
+    return {
+        "kind": "product",
+        "remote_id": provider_id(item.get("id"), "product ID"),
+        "name": text_value(item.get("name"), "product name", optional=False),
+        "description": text_value(item.get("description"), "product description"),
+        "price_cents": _number(item.get("price"), "product price"),
+        "currency": text_value(item.get("currency"), "product currency"),
+        "published": _boolean(item.get("published"), "product published state"),
+        "deleted": _boolean(item.get("deleted"), "product deleted state"),
+        "requires_shipping": _boolean(
+            item.get("require_shipping"), "product shipping state"
+        ),
+        "subscription_duration": text_value(
+            item.get("subscription_duration"), "subscription duration"
+        ),
+        "tags": tags,
+        "variants": _variants(item.get("variants")),
+        "file_metadata_present": bool(item.get("file_info")),
+    }
+
+
+def sale_record(pii_key: bytes, item: dict[str, Any]) -> dict[str, Any]:
+    """Replace customer identifiers and discard payment, address, and license values."""
+    affiliate = item.get("affiliate")
+    affiliate_data = affiliate if isinstance(affiliate, dict) else {}
+    variants = item.get("variants", {})
+    if not isinstance(variants, dict) or len(variants) > 100:
+        raise GumroadAdapterError("Gumroad sale variants are invalid")
+    return {
+        "kind": "sale",
+        "remote_id": provider_id(item.get("id"), "sale ID"),
+        "seller_id": seller_id(item.get("seller_id"), "sale seller ID"),
+        "product_id": provider_id(item.get("product_id"), "sale product ID"),
+        "product_name": text_value(item.get("product_name"), "sale product name"),
+        "customer_ref": _private_ref(
+            pii_key, "customer", item.get("purchase_email") or item.get("email")
+        ),
+        "affiliate_ref": _private_ref(
+            pii_key, "affiliate", affiliate_data.get("email")
+        ),
+        "affiliate_amount": text_value(
+            affiliate_data.get("amount"), "affiliate amount"
+        ),
+        "created_at": text_value(item.get("created_at"), "sale creation time"),
+        "order_id": (
+            str(item.get("order_id"))
+            if isinstance(item.get("order_id"), int)
+            and not isinstance(item.get("order_id"), bool)
+            else None
+        ),
+        "price_cents": _number(item.get("price"), "sale price"),
+        "fee_cents": _number(item.get("gumroad_fee"), "sale fee"),
+        "tax_cents": _number(item.get("tax_cents"), "sale tax"),
+        "shipping_cents": _number(item.get("shipping_cents"), "sale shipping"),
+        "quantity": _number(item.get("quantity"), "sale quantity"),
+        "variants": variants,
+        "refunded": _boolean(item.get("refunded"), "sale refund state"),
+        "partially_refunded": _boolean(
+            item.get("partially_refunded"), "sale partial refund state"
+        ),
+        "chargedback": _boolean(item.get("chargedback"), "sale chargeback state"),
+        "disputed": _boolean(item.get("disputed"), "sale dispute state"),
+        "dispute_won": _boolean(item.get("dispute_won"), "sale dispute outcome"),
+        "shipped": _boolean(item.get("shipped"), "sale shipping state"),
+        "subscription_id": (
+            provider_id(item.get("subscription_id"), "subscription ID")
+            if item.get("subscription_id")
+            else None
+        ),
+        "subscription_duration": text_value(
+            item.get("subscription_duration"), "sale subscription duration"
+        ),
+        "subscription_cancelled": _boolean(
+            item.get("cancelled"), "subscription cancellation state"
+        ),
+        "subscription_ended": _boolean(
+            item.get("ended"), "subscription ended state"
+        ),
+        "has_license": bool(item.get("license_key") or item.get("license_id")),
+    }
+
+
+def payout_record(item: dict[str, Any]) -> dict[str, Any]:
+    """Keep payout totals and state while excluding destination identifiers."""
+    amount = text_value(item.get("amount"), "payout amount", optional=False)
+    currency = text_value(item.get("currency"), "payout currency", optional=False)
+    created = text_value(item.get("created_at"), "payout creation time", optional=False)
+    payout_id = item.get("id")
+    remote_id = (
+        provider_id(payout_id, "payout ID")
+        if payout_id
+        else "upcoming_"
+        + hashlib.sha256(f"{created}|{currency}|{amount}".encode()).hexdigest()[:32]
+    )
+    return {
+        "kind": "payout",
+        "remote_id": remote_id,
+        "amount": amount,
+        "currency": currency,
+        "status_label": text_value(item.get("status"), "payout status"),
+        "created_at": created,
+        "processed_at": text_value(
+            item.get("processed_at"), "payout processing time"
+        ),
+        "payment_processor": text_value(
+            item.get("payment_processor"), "payout processor"
+        ),
+    }

--- a/.agents/scripts/knowledge_social_gumroad.py
+++ b/.agents/scripts/knowledge_social_gumroad.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one bounded, read-only Gumroad seller stream into a social corpus."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import _knowledge_social_gumroad as gumroad
+from _knowledge_social_gumroad_normalize import PageContext, normalize_page
+from _knowledge_social_gumroad_reader import FixtureGumroad, GuardedGumroad, verified_identity
+from _knowledge_social_oauth_collector import OAuthCollectorPolicy, run_oauth_collector
+
+COLLECTOR_OPTIONS = {
+    "display_name": "Gumroad",
+    "provider_module": gumroad,
+    "helper": Path(__file__).with_name("_knowledge_social_gumroad_provider.py"),
+    "fixture_reader": FixtureGumroad,
+    "live_reader": GuardedGumroad,
+    "page_context": PageContext,
+    "normalize_page": normalize_page,
+    "verified_identity": verified_identity,
+    "budget_unit": "request",
+    "default_budget": 11,
+    "min_budget": 3,
+    "max_page_size": 100,
+}
+
+
+def main() -> int:
+    return run_oauth_collector(OAuthCollectorPolicy(**COLLECTOR_OPTIONS), __doc__ or "")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/tests/test-knowledge-social-gumroad.sh
+++ b/.agents/tests/test-knowledge-social-gumroad.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-gumroad.sh — protected Gumroad seller collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="${SCRIPT_DIR}/../scripts"
+COLLECTOR="${SCRIPTS}/knowledge_social_gumroad.py"
+CORPUS_HELPER="${SCRIPTS}/knowledge-corpus-helper.sh"
+SOCIAL_HELPER="${SCRIPTS}/knowledge-social-helper.sh"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+ACCOUNT_ID="gumroad_G_-mnBf9b1j9A7a4ub4nFQ"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' "$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c 'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' "$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_text() {
+	python3 - "$ROOT/sources/social/raw/gumroad" <<'PY'
+import gzip
+import sys
+from pathlib import Path
+root = Path(sys.argv[1])
+print("\n".join(gzip.open(path, "rt", encoding="utf-8").read() for path in root.rglob("*.json.gz")))
+PY
+	return 0
+}
+
+run_fixture() {
+	local fixture="$1"
+	local connection="$2"
+	local stream="$3"
+	shift 3
+	if python3 "$COLLECTOR" --base "$BASE" --alias personal:default \
+		--connection-id "$connection" --account-id "$ACCOUNT_ID" \
+		--stream "$stream" --profile fixture --fixture "$fixture" "$@"; then
+		return 0
+	fi
+	return 1
+}
+
+run_terminal_case() {
+	local name="$1"
+	local status="$2"
+	local expected_failure="$3"
+	local fixture="${TMP_DIR}/terminal-${name}.json"
+	python3 - "$fixture" "$ACCOUNT_ID" "$status" <<'PY'
+import json
+import sys
+
+payload = {
+    "identity": {"data": {"provider_account_id": sys.argv[2]}},
+    "pages": [{"status": int(sys.argv[3]), "observed_at": "2026-07-31T12:03:00Z"}],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+	local result=""
+	result=$(run_fixture "$fixture" "conn_terminal_${name}" sales)
+	assert_eq "${status} response is terminal without a checkpoint" \
+		"$(json_field "$result" failure_class):$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_terminal_${name}'")" \
+		"${expected_failure}:0"
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$SOCIAL_HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'Gumroad social collector tests\n'
+
+python3 - "$SCRIPTS" <<'PY'
+import ast
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+from _knowledge_social_gumroad import PageRequest, STREAMS, page_checkpoint
+from _knowledge_social_gumroad_records import product_record, sale_record
+from _knowledge_social_collect import CursorState
+
+assert set(STREAMS) == {"profile", "products", "sales", "payouts"}
+product = product_record({
+    "id": "product_123", "name": "Guide", "price": 1200, "currency": "usd",
+    "published": True, "deleted": False, "require_shipping": False,
+    "tags": ["guide"], "variants": [], "file_info": {"guide.pdf": {"size": 10}},
+})
+assert product["file_metadata_present"] is True and "file_info" not in product
+sale = sale_record(b"p" * 32, {
+    "id": "sale_12345", "seller_id": "seller_123", "product_id": "product_123",
+    "purchase_email": "buyer@example.invalid", "product_name": "Guide", "price": 1200,
+    "gumroad_fee": 120, "tax_cents": 20, "shipping_cents": 0, "quantity": 1,
+    "variants": {}, "license_key": "never-store", "card": {"visual": "4242"},
+})
+assert sale["customer_ref"].startswith("customer_")
+assert sale["has_license"] is True
+assert "email" not in str(sale).lower() and "never-store" not in str(sale) and "4242" not in str(sale)
+
+request = PageRequest("sales", "seller_123", "seller_123", None, None, 100)
+checkpoint, complete = page_checkpoint({
+    "data": [{"remote_id": "sale_1"}],
+    "meta": {"stream": "sales", "next_page_key": "next_1", "newest_id": "sale_1", "reached_watermark": False, "complete": False},
+}, CursorState(None, None, False), request)
+assert not complete and checkpoint.next_cursor and checkpoint.watermark == "sale_1"
+
+sources = [path.read_text(encoding="utf-8") for path in scripts.glob("*knowledge_social_gumroad*.py")]
+trees = [ast.parse(source) for source in sources]
+request_calls = [
+    node for tree in trees for node in ast.walk(tree)
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "Request"
+]
+assert len(request_calls) == 1
+methods = [kw.value.value for kw in request_calls[0].keywords if kw.arg == "method" and isinstance(kw.value, ast.Constant)]
+assert methods == ["GET"]
+for forbidden in ('method="POST"', 'method="PUT"', 'method="PATCH"', 'method="DELETE"', "playwright", "selenium", "_knowledge_social_outbound"):
+    assert all(forbidden not in source for source in sources)
+PY
+assert_eq "official routes, protected minimization, cursors, and GET-only AST are guarded" verified verified
+
+cat >"$TMP_DIR/products-first.json" <<JSON
+{"identity":{"data":{"provider_account_id":"${ACCOUNT_ID}","display_name":"Seller"}},"pages":[{
+  "expect_request":{"page_key":null,"stop_at":null,"limit":100},
+  "response":{"status":200,"observed_at":"2026-07-31T12:00:00Z","data":[
+    {"kind":"product","remote_id":"product_123","name":"Private Guide","description":"Bounded commerce knowledge","price_cents":1200,"currency":"usd","published":true,"deleted":false,"requires_shipping":false,"tags":[],"variants":[],"file_metadata_present":true}],
+  "meta":{"stream":"products","next_page_key":"page_2","newest_id":"product_123","reached_watermark":false,"complete":false}}}]}
+JSON
+first=$(run_fixture "$TMP_DIR/products-first.json" conn_products products --budget 3 --page-size 100)
+assert_eq "one bounded product page pauses with a durable cursor" "$(json_field "$first" status)" budget_exhausted
+assert_eq "product evidence reaches corpus search" "$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'commerce'")" 1
+
+cat >"$TMP_DIR/products-resume.json" <<JSON
+{"identity":{"data":{"provider_account_id":"${ACCOUNT_ID}"}},"pages":[{
+  "expect_request":{"page_key":"page_2"},
+  "response":{"status":200,"observed_at":"2026-07-31T12:01:00Z","data":[],
+  "meta":{"stream":"products","next_page_key":null,"newest_id":null,"reached_watermark":false,"complete":true}}}]}
+JSON
+second=$(run_fixture "$TMP_DIR/products-resume.json" conn_products products)
+assert_eq "opaque product page key resumes and completes" "$(json_field "$second" status)" complete
+assert_eq "product checkpoint is independently complete" "$(sql_value "SELECT backfill_complete FROM sync_cursors WHERE connection_id='conn_products' AND stream='products'")" 1
+
+cat >"$TMP_DIR/sales.json" <<JSON
+{"identity":{"data":{"provider_account_id":"${ACCOUNT_ID}"}},"pages":[{
+  "response":{"status":200,"observed_at":"2026-07-31T12:02:00Z","data":[
+    {"kind":"sale","remote_id":"sale_12345","seller_id":"${ACCOUNT_ID}","product_id":"product_123","product_name":"Private Guide","customer_ref":"customer_0123456789abcdef0123456789abcdef","affiliate_ref":null,"affiliate_amount":null,"created_at":"2026-07-31T11:00:00Z","order_id":"42","price_cents":1200,"fee_cents":120,"tax_cents":20,"shipping_cents":0,"quantity":1,"variants":{},"refunded":false,"partially_refunded":false,"chargedback":false,"disputed":false,"dispute_won":false,"shipped":false,"subscription_id":null,"subscription_duration":null,"subscription_cancelled":null,"subscription_ended":null,"has_license":true}],
+  "meta":{"stream":"sales","next_page_key":null,"newest_id":"sale_12345","reached_watermark":false,"complete":true}}}]}
+JSON
+run_fixture "$TMP_DIR/sales.json" conn_sales sales >/dev/null
+assert_eq "sale financial evidence is classified as protected business data" \
+	"$(sql_value "SELECT evidence_class FROM objects WHERE provider='gumroad' AND remote_id='sale_12345'")" protected_business
+persisted=$(raw_text)
+if [[ "$persisted" == *"buyer@example"* || "$persisted" == *"license_key"* || "$persisted" == *"card"* || "$persisted" == *"bank"* ]]; then
+	assert_eq "raw evidence excludes direct customer/payment secrets" leaked excluded
+else
+	assert_eq "raw evidence excludes direct customer/payment secrets" excluded excluded
+fi
+assert_eq "API/export/event and retention gaps stay explicit" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE connection_id='conn_sales' AND status='unavailable'")" 14
+
+cat >"$TMP_DIR/mismatch.json" <<'JSON'
+{"identity":{"data":{"provider_account_id":"other_seller_123"}},"pages":[]}
+JSON
+if run_fixture "$TMP_DIR/mismatch.json" conn_mismatch sales >/dev/null 2>&1; then
+	assert_eq "seller identity mismatch is rejected before persistence" accepted rejected
+else
+	assert_eq "seller identity mismatch is rejected before persistence" rejected rejected
+fi
+assert_eq "identity mismatch creates no connection" "$(sql_value "SELECT count(*) FROM connections WHERE connection_id='conn_mismatch'")" 0
+
+cat >"$TMP_DIR/rate.json" <<JSON
+{"identity":{"data":{"provider_account_id":"${ACCOUNT_ID}"}},"pages":[{"status":429,"observed_at":"2026-07-31T12:03:00Z","retry_after":60}]}
+JSON
+rate=$(run_fixture "$TMP_DIR/rate.json" conn_rate payouts)
+assert_eq "rate limits pause without checkpoint advancement" "$(json_field "$rate" failure_class):$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_rate'")" rate_limit:0
+run_terminal_case forbidden 403 authorization
+run_terminal_case unavailable 404 unavailable
+run_terminal_case provider 500 provider
+
+docs=$(<"$SCRIPT_DIR/../content/social-gumroad.md")
+if [[ "$docs" == *"Official evidence checked 2026-07-31"* && "$docs" == *"No export generation"* && "$docs" == *"no POST, PUT, PATCH"* ]]; then
+	assert_eq "dated capability matrix documents explicit safe gaps" documented documented
+else
+	assert_eq "dated capability matrix documents explicit safe gaps" missing documented
+fi
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add identity-bound GET-only Gumroad seller profile, product, sales, and payout ingestion with protected customer aliases and explicit export, webhook, retention, and unsupported-route gaps.

## Files Changed

.agents/content/social-gumroad.md, .agents/scripts/_knowledge_social_gumroad.py, .agents/scripts/_knowledge_social_gumroad_normalize.py, .agents/scripts/_knowledge_social_gumroad_provider.py, .agents/scripts/_knowledge_social_gumroad_reader.py, .agents/scripts/knowledge_social_gumroad.py, .agents/tests/test-knowledge-social-gumroad.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — bash .agents/tests/test-knowledge-social-gumroad.sh; python3 -m compileall -q .agents/scripts; shellcheck .agents/tests/test-knowledge-social-gumroad.sh

Resolves #28787


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.201 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 25m and 245,677 tokens on this as a headless worker.