### PR TITLE
GH#28955: Add safe Binance Square ingestion disposition

### DIFF
--- a/.agents/content/social-binance-square.md
+++ b/.agents/content/social-binance-square.md
@@ -1,0 +1,159 @@
+---
+description: Binance Square read-ingestion evidence and fail-closed no-route disposition
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  webfetch: true
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Binance Square Account Knowledge
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Importer**: none; no Binance Square provider module or social-helper
+  command exists
+- **Official surface**: Binance publishes a Square OpenAPI skill for creating
+  posts and uploading media; it explicitly excludes reading and account
+  management
+- **Current disposition**: **No** for every requested read, export, event, and
+  private-account category
+- **Credential boundary**: Square publishing keys and Binance exchange,
+  trading, wallet, Pay, Merchant, and account-security credentials are rejected
+  as ingestion authority
+- **Browser route**: disabled; public pages do not prove account identity or
+  authenticated completeness, and cookie/session scraping is not permitted
+- **Activation rule**: enable only after Binance documents a Square-specific,
+  read-only route with stable creator identity, scopes, schemas, pagination,
+  retention, and replay behavior
+
+No importer, API reader, export parser, event receiver, or browser route is
+enabled.
+
+<!-- AI-CONTEXT-END -->
+
+## Evidence boundary
+
+The official surfaces and local runtime were checked on 2026-07-31. The worker
+runtime has Python 3.14.3, and no `binance`, `binance_connector`,
+`binance_sdk_spot`, or `binance_square` Python module is installed. No
+third-party client symbols, response fields, scopes, pagination contract, or
+error codes are mapped.
+
+Binance's official Skills Hub repository describes itself as an agent skills
+marketplace. Its pinned Square Post skill says that the skill only creates new
+posts and must not be used for reading, searching, commenting, liking, editing,
+deleting, scheduling, or managing existing Square posts:
+https://github.com/binance/binance-skills-hub/blob/3bf89edb7eea313c36688d21cd4512f9f501b57d/skills/binance/square-post/SKILL.md.
+
+The same official skill documents a `BINANCE_SQUARE_OPENAPI_KEY`, points creators
+to https://www.binance.com/square/creator-center/home, and supports text, image,
+article, and video publication. Its scope section explicitly excludes reading,
+listing, searching, editing, deleting, interactions, profiles, account
+management, scheduling, and drafts. This is current evidence of a mutation-only
+publishing surface, not permission to repurpose that key for ingestion.
+
+The pinned repository state is dated 2026-07-23:
+https://github.com/binance/binance-skills-hub/commit/3bf89edb7eea313c36688d21cd4512f9f501b57d.
+The Square skill first appears in the official history on 2026-03-06:
+https://github.com/binance/binance-skills-hub/commit/a59c603ff29451122ae219cbc11be651fe606c5a.
+
+Current file trees for Binance's official Postman collection, Python and
+JavaScript public API connectors, Spot API documentation, public API Swagger,
+and CLI contain no Square-specific path. Their documented exchange/public API
+scope is not evidence of Square social-read support. No current official
+Square-specific account export, data-download schema, webhook, event stream, or
+authenticated read API was verified in the reviewed official sources.
+
+This disposition records only what the dated official evidence proves. It does
+not infer that an absent route can never be introduced.
+
+## Requested coverage
+
+| Requested category | Current official evidence | Disposition |
+|---|---|---|
+| Account and creator profile | The official skill excludes profiles and account management | **No** |
+| Authored posts and articles | Official OpenAPI creates new content but does not read, list, search, edit, or delete existing content | **No** |
+| Revisions, deletion history, and drafts | Editing, deleting, scheduling, and drafts are explicitly excluded | **No** |
+| Comments, replies, and mentions | Commenting is excluded; no read route or export schema was verified | **No** |
+| Likes and reactions | Liking and other interactions are excluded; no read route was verified | **No** |
+| Bookmarks and saved state | No supported read, export, or event route was verified | **No** |
+| Follows, subscriptions, lists, topics, and feeds | No supported account-state route or export schema was verified | **No** |
+| Notifications and messages | No supported read, export, or event route was verified | **No** |
+| Media, live, and audio metadata | The publishing skill uploads new image/video media only; it does not read existing media or live/audio history | **No** |
+| Campaigns, rewards, and monetization | No read-only Square route was verified; financial or creator-payment data remains protected | **No** |
+| Private state and account history | No authenticated read route or documented account archive was verified | **No** |
+| Public Square pages | Public pages are not authenticated owner evidence and cannot establish private completeness or deletion history | **No** |
+
+An absent route is not evidence that the account has no records. Every category
+remains unavailable rather than becoming successful empty coverage. No current
+official export generation limit, delivery time, schema version, download
+expiry, or retention period was verified.
+
+## Financial and mutation isolation
+
+Binance Square is treated only as a social-content provider candidate. Generic
+Binance spot, margin, futures, wallet, transfer, withdrawal, deposit, Pay,
+Merchant, KYC, account, device, and security APIs are different authority
+surfaces and are never fallbacks for Square. API-key presence, a Binance login,
+or access to a public Square page cannot establish a read route.
+
+The known Square OpenAPI key authorizes publishing. Because it is
+mutation-capable and the official skill documents no read operation, an
+ingestion command must not accept, store, inspect, validate, or exercise it.
+Likewise, exchange or financial credentials must fail before any network
+request. No collected text may become a trading instruction or input to order,
+transfer, wallet, payment, outreach, publishing, commenting, liking, following,
+or messaging tools.
+
+No public-page, browser-cookie, session-token, undocumented endpoint, or
+reverse-engineered mobile route is an approved fallback. Public evidence can be
+referenced manually as public evidence, but it cannot be persisted as selected
+account coverage.
+
+The negative contract is enforced by
+`.agents/tests/test-knowledge-social-binance-square.sh`.
+
+## Activation checklist
+
+Before enabling Binance Square ingestion:
+
+1. Obtain a current official Square-specific read API, owner export, or event
+   contract. A publishing API, generic exchange API, public page, or privacy
+   request without a stable documented artifact is insufficient.
+2. Verify the exact Binance account and Square creator/profile identity from
+   provider-controlled fields before any raw or normalized persistence. Never
+   persist login, KYC, balance, order, position, wallet, transfer, payment, or
+   account-security data.
+3. Record the narrow read scopes, authentication type, endpoint or export
+   version, response schema, pagination, deletion/revision semantics, rate
+   limits, replay behavior, generation limits, expiry, and retention.
+4. Reject credentials that permit trading, orders, transfers, withdrawals,
+   deposits, wallets, payments, account/security changes, publishing, comments,
+   likes, follows, or messages before network access.
+5. Add independent bounded streams and checkpoints only for categories proven
+   by official fixtures. Unknown and absent categories remain explicit gaps.
+6. Test identity mismatch, rebinding, scope rejection, malformed and terminal
+   responses, pagination or export replay, protected-data scrubbing, stale
+   leases, final identity fences, and zero financial or social side effects.
+7. Keep Square evidence, credentials, receipts, and checkpoints separate from
+   every Binance exchange, wallet, payment, and account-operation store.
+8. Update the dated capability evidence only after the official route and
+   synthetic fixtures agree; never infer fields or errors from another Binance
+   product.
+
+## Retention and privacy
+
+No retention grant follows from the public publishing skill. Future Square
+evidence may contain third-party personal data, financial discussion, private
+relationships, messages, customer identity, or monetization details. Keep live
+credentials, account and creator identifiers, exports, signed links, private
+content, and collected evidence out of git, issues, fixtures, command output,
+and shared workspaces.

--- a/.agents/tests/test-knowledge-social-binance-square.sh
+++ b/.agents/tests/test-knowledge-social-binance-square.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-binance-square.sh — Binance Square no-route isolation contract
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SCRIPTS_DIR="${REPO_ROOT}/.agents/scripts"
+HELPER="${SCRIPTS_DIR}/knowledge-social-helper.sh"
+BROWSER="${SCRIPTS_DIR}/knowledge_social_browser.py"
+DOC="${REPO_ROOT}/.agents/content/social-binance-square.md"
+PASS=0
+FAIL=0
+
+record_pass() {
+	local description="$1"
+	PASS=$((PASS + 1))
+	printf '  PASS  %s\n' "$description"
+	return 0
+}
+
+record_fail() {
+	local description="$1"
+	FAIL=$((FAIL + 1))
+	printf '  FAIL  %s\n' "$description"
+	return 0
+}
+
+assert_contains() {
+	local file="$1"
+	local expected="$2"
+	local description="$3"
+	if grep -Fq -- "$expected" "$file"; then
+		record_pass "$description"
+	else
+		record_fail "$description"
+	fi
+	return 0
+}
+
+printf 'Binance Square read-ingestion no-route contract\n'
+
+assert_contains "$DOC" \
+	'https://github.com/binance/binance-skills-hub/blob/3bf89edb7eea313c36688d21cd4512f9f501b57d/skills/binance/square-post/SKILL.md' \
+	'official pinned Square scope evidence is recorded'
+assert_contains "$DOC" \
+	'The official surfaces and local runtime were checked on 2026-07-31.' \
+	'disposition has a dated evidence boundary'
+assert_contains "$DOC" \
+	'No importer, API reader, export parser, event receiver, or browser route is' \
+	'documentation states every disabled route explicitly'
+assert_contains "$DOC" \
+	'current evidence of a mutation-only' \
+	'publishing authority is not treated as read authority'
+assert_contains "$DOC" \
+	'exchange or financial credentials must fail before any network' \
+	'financial credentials fail closed before network access'
+assert_contains "$DOC" \
+	'official export generation limit, delivery time, schema version' \
+	'unknown export and retention contracts are explicit'
+
+for category in \
+	'Account and creator profile' \
+	'Authored posts and articles' \
+	'Revisions, deletion history, and drafts' \
+	'Comments, replies, and mentions' \
+	'Likes and reactions' \
+	'Bookmarks and saved state' \
+	'Follows, subscriptions, lists, topics, and feeds' \
+	'Notifications and messages' \
+	'Media, live, and audio metadata' \
+	'Campaigns, rewards, and monetization' \
+	'Private state and account history' \
+	'Public Square pages'; do
+	if grep -F "| ${category} |" "$DOC" | grep -Fq '| **No** |'; then
+		record_pass "${category} remains an explicit no-route gap"
+	else
+		record_fail "${category} remains an explicit no-route gap"
+	fi
+done
+
+if [[ -e "${SCRIPTS_DIR}/knowledge_social_binance_square.py" ]]; then
+	record_fail 'no Binance Square provider entry point exists'
+else
+	record_pass 'no Binance Square provider entry point exists'
+fi
+shopt -s nullglob
+square_modules=("${SCRIPTS_DIR}"/_knowledge_social_binance_square*.py)
+shopt -u nullglob
+if [[ "${#square_modules[@]}" -eq 0 ]]; then
+	record_pass 'no placeholder Binance Square support modules exist'
+else
+	record_fail 'no placeholder Binance Square support modules exist'
+fi
+
+if grep -Eiq 'BINANCE_SQUARE|import-binance-square|sync-binance-square|collect-binance-square|publish-binance-square' "$HELPER"; then
+	record_fail 'social helper exposes no Binance Square or publishing route'
+else
+	record_pass 'social helper exposes no Binance Square or publishing route'
+fi
+if grep -Eiq 'binance([_-]square|[[:space:]]+square)' "$BROWSER"; then
+	record_fail 'browser collector exposes no Binance Square selector'
+else
+	record_pass 'browser collector exposes no Binance Square selector'
+fi
+
+if BINANCE_SQUARE_OPENAPI_KEY='synthetic_not_a_secret' \
+	BINANCE_API_KEY='synthetic_not_a_secret' \
+	"$HELPER" sync-binance-square \
+	--connection-id conn_binance_square_test \
+	--account-id account_binance_square_test >/dev/null 2>&1; then
+	record_fail 'mutation-capable credentials cannot activate Square ingestion'
+else
+	record_pass 'mutation-capable credentials cannot activate Square ingestion'
+fi
+
+if "$HELPER" import-binance-square-export \
+	--export "${SCRIPT_DIR}/fixtures/untrusted-binance-square-export.zip" \
+	--connection-id conn_binance_square_test \
+	--account-id account_binance_square_test >/dev/null 2>&1; then
+	record_fail 'export-shaped input cannot reach persistence'
+else
+	record_pass 'export-shaped input cannot reach persistence'
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -ne 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Documented the dated official no-safe-read-route outcome and added a fixture-free contract proving no provider, helper, browser, export, publishing, or financial credential path can activate ingestion.

## Files Changed

.agents/content/social-binance-square.md, .agents/tests/test-knowledge-social-binance-square.sh

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — bash .agents/tests/test-knowledge-social-binance-square.sh (24 passed); shellcheck; git diff --check; changed-file lint gates passed through Markdown, secrets, portability, and complexity checks; pre-push quality hook passed.

Resolves #28955


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.201 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 30m and 151,312 tokens on this as a headless worker.