### PR TITLE
GH#28786: add multi-instance Nextcloud Talk knowledge ingestion

### DIFF
--- a/.agents/content/social-nextcloud-talk.md
+++ b/.agents/content/social-nextcloud-talk.md
@@ -1,0 +1,123 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Nextcloud Talk Knowledge Collection
+
+`knowledge_social_nextcloud_talk.py` collects bounded, account-visible evidence
+from explicitly allowlisted rooms on one Nextcloud installation. The provider is
+not registered in `knowledge-social-helper.sh` yet; shared registration and the
+aggregate capability matrix belong to #28867.
+
+## Runtime and private profile
+
+The adapter was validated with Python 3.14 standard-library `urllib.request` and
+`urllib.parse` exports. It imports no Nextcloud client package. Configure each
+installation through secure environment injection:
+
+```text
+NEXTCLOUD_TALK_<PROFILE>_BASE_URL=https://cloud.example.invalid
+NEXTCLOUD_TALK_<PROFILE>_USERNAME=selected-account
+NEXTCLOUD_TALK_<PROFILE>_APP_PASSWORD=<secure-value>
+NEXTCLOUD_TALK_<PROFILE>_ORIGIN_KEY=<random-value-at-least-32-bytes>
+NEXTCLOUD_TALK_<PROFILE>_ALLOWED_ROOMS=<comma-separated-room-tokens>
+NEXTCLOUD_TALK_<PROFILE>_EXPECTED_SERVER_MAJOR=32
+NEXTCLOUD_TALK_<PROFILE>_EXPECTED_TALK_MAJOR=22
+```
+
+Store values with `aidevops secret set NAME` or another mode-0600 secret store.
+Never put URLs, usernames, tokens, room names, app passwords, origin keys,
+webhook headers, files, or messages in repository configuration. An app password
+is a revocable account credential, not an endpoint-scoped grant. Use a dedicated
+account with membership only in intended rooms, then apply the room-token
+allowlist as a second boundary.
+
+The base URL must be exact HTTPS with no credentials, query, fragment, encoded
+path, or redirect. HMAC-SHA-256 over the canonical base URL and private origin
+key creates an installation namespace. Account, room, participant, message, and
+attachment IDs are opaque and installation-scoped; equal native IDs on separate
+servers cannot collide.
+
+## Identity and capability fence
+
+Before collection and before every page, the isolated child performs only GET
+requests and verifies:
+
+1. `/ocs/v2.php/cloud/capabilities` reports the configured Nextcloud and Talk
+   major versions and includes `chat-v2` plus `conversation-v4`.
+2. `/ocs/v2.php/cloud/user` is the configured account.
+3. `/ocs/v2.php/apps/spreed/api/v4/room` contains every configured room token as
+   a current membership.
+4. The selected opaque room identity still maps to the same allowlist position.
+
+Version, account, installation, room, or membership drift stops before raw
+evidence or checkpoints advance. Responses are capped at 16 MiB. Room lists are
+capped at 100 configured rooms, participants at 500 per room, and chat pages at
+200 messages. `--budget` is a hard bounded-read allowance.
+
+## Streams and persistence
+
+| Stream | Official GET surface | Behavior |
+|---|---|---|
+| `capabilities` | cloud capabilities, current user, Talk rooms | Records exact tested versions and an allowlist of knowledge-relevant features. |
+| `rooms` | Talk API v4 `/room` | Stores allowlisted room type, name, current membership role, read-only state, expiration, activity, unread count, call state, and federation observation. |
+| `participants` | Talk API v4 `/room/{token}/participants` | Stores bounded user, guest, email, and federated participant snapshots independently per room. |
+| `messages` | Talk API v1 `/chat/{token}` | Reads history with `lookIntoFuture=0`, `setReadMarker=0`, `noStatusUpdate=1`, and `markNotificationsAsRead=0`; follows only `X-Chat-Last-Given`. |
+
+Each top-level stream has its own lease and database checkpoint. The messages
+cursor additionally carries a separate opaque watermark and current history
+position for every allowlisted room. Initial history and later refreshes converge
+on the same object IDs. A final lease fence atomically commits raw OCS evidence,
+normalized rows, coverage, receipt, and the next cursor.
+
+Messages preserve replies, edit timestamps, deletion observations, aggregated
+reactions, mentions, system events, call summaries, poll/object-share signals,
+and message-linked attachment metadata when returned by the tested version and
+account. Attachment URLs and paths are discarded. `_files.py` validates already
+authorized bytes against MIME, size, digest, and hard byte budgets, but live
+WebDAV hydration stays disabled until file identity and authorization can be
+revalidated without broadening Files access.
+
+## Webhooks and honest gaps
+
+OCS history is the recovery authority. The optional webhook module verifies the
+exact backend plus `HMAC-SHA256(random-header || raw-body)`, rejects non-allowlisted
+rooms, produces replay-stable event IDs, and marks every event for OCS
+reconciliation. It is not wired as a standalone persistence or recovery route.
+
+Coverage remains unavailable rather than complete for content removed before
+observation, history outside retention/membership/expiration, encrypted or
+otherwise unreadable content, complete reaction actor history, separately fetched
+poll details, call recording content, attachment bytes, and webhook-only history.
+Authorization loss, malformed OCS envelopes, unsupported versions, 401/403/404,
+429, 5xx, maintenance, and federation failures preserve the prior cursor.
+
+No send-message, reaction mutation, moderation, participant, room, call, poll,
+file-share, read-marker, or bot write route is accepted. Existing Talk dispatch
+credentials and outbound code remain separate.
+
+## Verification
+
+```bash
+bash .agents/tests/test-knowledge-social-nextcloud-talk.sh
+bash .agents/tests/test-knowledge-social-sync.sh
+bash .agents/tests/test-knowledge-social.sh
+python3 -m compileall -q .agents/scripts
+.agents/scripts/linters-local.sh --changed
+```
+
+Synthetic Talk 21 and Talk 22 fixtures cover multi-instance identity, room and
+message pagination, independent room resume, replay-stable IDs, edits/deletions,
+reactions, replies, mentions, guests/federation, call and poll observations,
+attachment budgets, webhook signatures, terminal authorization, credentials,
+and a static GET-only reachability check.
+
+## Official evidence checked 2026-07-31
+
+- [Talk capabilities](https://nextcloud-talk.readthedocs.io/en/latest/capabilities/)
+- [Global API status](https://nextcloud-talk.readthedocs.io/en/latest/global/)
+- [Conversation API v4](https://nextcloud-talk.readthedocs.io/en/latest/conversation/)
+- [Participant API v4](https://nextcloud-talk.readthedocs.io/en/latest/participant/)
+- [Chat API v1](https://nextcloud-talk.readthedocs.io/en/latest/chat/)
+- [Reaction API](https://nextcloud-talk.readthedocs.io/en/latest/reaction/)
+- [Poll API](https://nextcloud-talk.readthedocs.io/en/latest/poll/)
+- [Bots and webhooks](https://nextcloud-talk.readthedocs.io/en/latest/bots/)

--- a/.agents/scripts/_knowledge_social_nextcloud_talk.py
+++ b/.agents/scripts/_knowledge_social_nextcloud_talk.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Nextcloud Talk stream policy, private instance identity, and checkpoints."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from knowledge_social_import import canonical_json, reject_credentials
+
+PROVIDER = "nextcloud_talk"
+CURSOR_PREFIX = "nextcloud-talk-v1:"
+RETENTION_LIMIT = "room_retention_membership_and_message_expiration"
+INSTANCE = re.compile(r"^[0-9a-f]{24}$")
+OPAQUE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,191}$")
+
+
+class NextcloudTalkAdapterError(RuntimeError):
+    """Raised when provider evidence violates the Talk collector contract."""
+
+
+class NextcloudTalkProviderUnavailableError(NextcloudTalkAdapterError):
+    """Raised when the isolated Talk reader cannot be used safely."""
+
+
+ADAPTER_ERROR = NextcloudTalkAdapterError
+PROVIDER_UNAVAILABLE_ERROR = NextcloudTalkProviderUnavailableError
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    """Collection and coverage policy for one Talk stream."""
+
+    resource_kind: str
+    activity_mode: str
+    pagination: str
+    incremental: bool
+    retention_limit: str | None
+    coverage_status: str | None = None
+    unavailable_reason: str | None = None
+    cost_units: int = 3
+
+
+STREAMS = {
+    "capabilities": StreamSpec(
+        "installation_capability", "selected_account", "snapshot", False, None, cost_units=3
+    ),
+    "rooms": StreamSpec("conversation", "membership", "snapshot", False, RETENTION_LIMIT),
+    "participants": StreamSpec(
+        "participant", "room_membership", "room_snapshot", False, RETENTION_LIMIT
+    ),
+    "messages": StreamSpec(
+        "message", "room_history", "room_history", True, RETENTION_LIMIT
+    ),
+}
+
+
+def _text(value: Any, field: str, *, limit: int = 512) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or "\x00" in value
+        or len(value.encode("utf-8")) > limit
+    ):
+        raise NextcloudTalkAdapterError(f"Nextcloud Talk {field} is invalid")
+    return value
+
+
+def instance_id(value: Any) -> str:
+    """Validate one privacy-safe installation fingerprint."""
+    text = _text(value, "instance identity", limit=24)
+    if INSTANCE.fullmatch(text) is None:
+        raise NextcloudTalkAdapterError("Nextcloud Talk instance identity is invalid")
+    return text
+
+
+def provider_account_id(value: Any) -> str:
+    """Validate the selected account selector without accepting a global ID."""
+    text = _text(value, "account ID")
+    local = text.removeprefix("user_")
+    if not local or OPAQUE.fullmatch(local) is None:
+        raise NextcloudTalkAdapterError("Nextcloud Talk account ID is invalid")
+    return local
+
+
+def private_fingerprint(key: str, *parts: str) -> str:
+    """Create an opaque stable identifier without persisting native identifiers."""
+    encoded = key.encode("utf-8")
+    if len(encoded) < 32:
+        raise NextcloudTalkAdapterError(
+            "Nextcloud Talk profile origin key must be at least 32 bytes"
+        )
+    message = "\x00".join(parts).encode("utf-8")
+    return hmac.new(encoded, message, hashlib.sha256).hexdigest()[:24]
+
+
+def namespaced_id(installation: str, kind: str, native_id: Any) -> str:
+    """Namespace a provider object while hiding its native identifier."""
+    installation = instance_id(installation)
+    kind = _text(kind, "object kind", limit=32)
+    native = _text(str(native_id), "native object ID", limit=2048)
+    digest = hashlib.sha256(f"{installation}\x00{kind}\x00{native}".encode()).hexdigest()[:24]
+    return f"nct_{installation}_{kind}_{digest}"
+
+
+def _non_negative(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise NextcloudTalkAdapterError(f"Nextcloud Talk {field} must be non-negative")
+    return value
+
+
+def _watermarks(value: Any, field: str) -> dict[str, str]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict) or len(value) > 100:
+        raise NextcloudTalkAdapterError(f"Nextcloud Talk {field} is invalid")
+    result: dict[str, str] = {}
+    for room_id, message_id in value.items():
+        room = _text(room_id, f"{field} room")
+        message = _text(message_id, f"{field} message")
+        result[room] = message
+    return result
+
+
+def _encode_state(
+    room_index: int,
+    position: int,
+    stop_map: dict[str, str],
+    newest_map: dict[str, str],
+) -> str:
+    payload = canonical_json(
+        {
+            "newest": newest_map,
+            "position": position,
+            "room_index": room_index,
+            "stop": stop_map,
+        }
+    ).encode()
+    return CURSOR_PREFIX + base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+
+
+def _decode_state(cursor: str) -> tuple[int, int, dict[str, str], dict[str, str]]:
+    if not cursor.startswith(CURSOR_PREFIX):
+        raise NextcloudTalkAdapterError("stored Nextcloud Talk cursor is unsupported")
+    encoded = cursor.removeprefix(CURSOR_PREFIX)
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4)))
+    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+        raise NextcloudTalkAdapterError("stored Nextcloud Talk cursor is invalid") from error
+    if not isinstance(payload, dict) or set(payload) != {
+        "newest", "position", "room_index", "stop"
+    }:
+        raise NextcloudTalkAdapterError("stored Nextcloud Talk cursor shape is invalid")
+    reject_credentials(payload)
+    return (
+        _non_negative(payload["room_index"], "cursor room index"),
+        _non_negative(payload["position"], "cursor message position"),
+        _watermarks(payload["stop"], "cursor stop map"),
+        _watermarks(payload["newest"], "cursor newest map"),
+    )
+
+
+def _encode_watermark(value: dict[str, str]) -> str | None:
+    if not value:
+        return None
+    payload = canonical_json(value).encode()
+    return base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+
+
+def _decode_watermark(value: str | None) -> dict[str, str]:
+    if value is None:
+        return {}
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(value + "=" * (-len(value) % 4)))
+    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+        raise NextcloudTalkAdapterError("stored Nextcloud Talk watermark is invalid") from error
+    return _watermarks(payload, "watermark")
+
+
+@dataclass(frozen=True)
+class PageRequest:
+    """Exact request envelope passed to the isolated GET-only child."""
+
+    stream: str
+    account_id: str
+    provider_account_id: str
+    instance_id: str
+    room_index: int
+    room_id: str | None
+    position: int
+    stop_at: str | None
+    limit: int
+    stop_map: dict[str, str]
+    newest_map: dict[str, str]
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "page",
+            "stream": self.stream,
+            "account_id": self.account_id,
+            "provider_account_id": self.provider_account_id,
+            "instance_id": self.instance_id,
+            "room_index": self.room_index,
+            "room_id": self.room_id,
+            "position": self.position,
+            "stop_at": self.stop_at,
+            "limit": self.limit,
+            "stop_map": self.stop_map,
+            "newest_map": self.newest_map,
+        }
+
+    def evidence_key(self) -> str:
+        return canonical_json(self.payload())
+
+
+PAGE_REQUEST_KEYS = set(PageRequest.__dataclass_fields__) | {"action"}
+
+
+def _room_ids(account: dict[str, Any]) -> tuple[str, ...]:
+    values = account.get("room_ids")
+    if not isinstance(values, list) or not values or len(values) > 100:
+        raise NextcloudTalkAdapterError("verified Nextcloud Talk room allowlist is invalid")
+    rooms = tuple(_text(value, "room identity") for value in values)
+    if len(set(rooms)) != len(rooms):
+        raise NextcloudTalkAdapterError("verified Nextcloud Talk room allowlist is invalid")
+    return rooms
+
+
+def page_request(
+    stream: str, account: dict[str, Any], state: CursorState, limit: int
+) -> PageRequest:
+    """Build one request from independent stream and per-room history state."""
+    if stream not in STREAMS:
+        raise NextcloudTalkAdapterError("Nextcloud Talk stream is unsupported")
+    rooms = _room_ids(account)
+    room_index = 0
+    position = 0
+    stop_map = _decode_watermark(state.watermark) if state.backfill_complete else {}
+    newest_map = dict(stop_map)
+    if state.cursor:
+        room_index, position, stop_map, newest_map = _decode_state(state.cursor)
+    if stream in ("capabilities", "rooms"):
+        room_index = 0
+        position = 0
+        room_id = None
+    else:
+        if room_index >= len(rooms):
+            raise NextcloudTalkAdapterError("Nextcloud Talk cursor room is out of range")
+        room_id = rooms[room_index]
+    return PageRequest(
+        stream,
+        _text(account.get("id"), "selected account identity"),
+        provider_account_id(account.get("provider_account_id")),
+        instance_id(account.get("instance_id")),
+        room_index,
+        room_id,
+        position,
+        stop_map.get(room_id) if room_id else None,
+        limit,
+        stop_map,
+        newest_map,
+    )
+
+
+def parse_page_request(payload: dict[str, Any]) -> PageRequest:
+    """Validate an exact child-process page request."""
+    if set(payload) != PAGE_REQUEST_KEYS or payload.get("action") != "page":
+        raise NextcloudTalkAdapterError("Nextcloud Talk read request shape is invalid")
+    stream = payload.get("stream")
+    if not isinstance(stream, str) or stream not in STREAMS:
+        raise NextcloudTalkAdapterError("Nextcloud Talk stream is unsupported")
+    limit = payload.get("limit")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 200:
+        raise NextcloudTalkAdapterError("Nextcloud Talk page size is invalid")
+    room = payload.get("room_id")
+    if room is not None:
+        room = _text(room, "room identity")
+    return PageRequest(
+        stream,
+        _text(payload.get("account_id"), "selected account identity"),
+        provider_account_id(payload.get("provider_account_id")),
+        instance_id(payload.get("instance_id")),
+        _non_negative(payload.get("room_index"), "room index"),
+        room,
+        _non_negative(payload.get("position"), "message position"),
+        None if payload.get("stop_at") is None else _text(payload.get("stop_at"), "watermark"),
+        limit,
+        _watermarks(payload.get("stop_map"), "stop map"),
+        _watermarks(payload.get("newest_map"), "newest map"),
+    )
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise NextcloudTalkAdapterError("Nextcloud Talk response status is invalid")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise NextcloudTalkAdapterError("Nextcloud Talk page data must be an array")
+    return data
+
+
+def page_checkpoint(
+    payload: dict[str, Any], state: CursorState, request: PageRequest
+) -> tuple[PageCheckpoint, bool]:
+    """Calculate one atomic stream checkpoint with independent room watermarks."""
+    del state
+    meta = payload.get("meta")
+    if not isinstance(meta, dict):
+        raise NextcloudTalkAdapterError("Nextcloud Talk page metadata is missing")
+    reject_credentials(meta)
+    if meta.get("stream") != request.stream or meta.get("instance_id") != request.instance_id:
+        raise NextcloudTalkAdapterError("Nextcloud Talk page provenance is invalid")
+    if meta.get("room_id") != request.room_id:
+        raise NextcloudTalkAdapterError("Nextcloud Talk room identity was rebound")
+    limits = {
+        "capabilities": 1,
+        "rooms": 100,
+        "participants": 500,
+        "messages": request.limit,
+    }
+    if len(page_data(payload)) > limits[request.stream]:
+        raise NextcloudTalkAdapterError("Nextcloud Talk page exceeds the item safety limit")
+    complete = meta.get("complete")
+    if not isinstance(complete, bool):
+        raise NextcloudTalkAdapterError("Nextcloud Talk completion metadata is invalid")
+    newest_map = dict(request.newest_map)
+    newest = meta.get("newest_id")
+    if newest is not None and request.room_id and request.position == 0:
+        newest_map[request.room_id] = _text(newest, "newest message identity")
+    if complete:
+        return PageCheckpoint(None, _encode_watermark(newest_map)), True
+    next_room = _non_negative(meta.get("next_room_index"), "next room index")
+    next_position = _non_negative(meta.get("next_position"), "next message position")
+    if next_room < request.room_index or (
+        next_room == request.room_index and next_position <= request.position
+    ):
+        raise NextcloudTalkAdapterError("Nextcloud Talk pagination did not advance")
+    cursor = _encode_state(next_room, next_position, request.stop_map, newest_map)
+    return PageCheckpoint(cursor, _encode_watermark(newest_map)), False

--- a/.agents/scripts/_knowledge_social_nextcloud_talk_contract.py
+++ b/.agents/scripts/_knowledge_social_nextcloud_talk_contract.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validation primitives for bounded Nextcloud Talk OCS reads."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Mapping
+
+from _knowledge_social_nextcloud_talk import NextcloudTalkAdapterError
+
+MAX_TEXT_BYTES = 256 * 1024
+
+
+class NextcloudTalkReadProviderError(NextcloudTalkAdapterError):
+    """Raised for a privacy-safe local Talk provider failure."""
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    status: int
+    payload: Any
+    headers: Mapping[str, str]
+    retry_after: int | None = None
+
+
+def observed_at() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def request_object(payload: bytes, limit: int) -> dict[str, Any]:
+    if len(payload) > limit:
+        raise NextcloudTalkReadProviderError("Nextcloud Talk request exceeds the safety limit")
+    try:
+        request = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise NextcloudTalkReadProviderError("Nextcloud Talk request is not valid JSON") from error
+    if not isinstance(request, dict):
+        raise NextcloudTalkReadProviderError("Nextcloud Talk request root must be an object")
+    return request
+
+
+def object_value(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise NextcloudTalkReadProviderError(f"Nextcloud Talk {field} must be an object")
+    return value
+
+
+def object_list(value: Any, field: str, *, limit: int) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise NextcloudTalkReadProviderError(
+            f"Nextcloud Talk {field} must be an array of objects"
+        )
+    if len(value) > limit:
+        raise NextcloudTalkReadProviderError(f"Nextcloud Talk {field} exceeds the item limit")
+    return value
+
+
+def optional_text(value: Any, field: str, *, limit: int = MAX_TEXT_BYTES) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value or len(value.encode()) > limit:
+        raise NextcloudTalkReadProviderError(f"Nextcloud Talk {field} must be bounded text")
+    return value
+
+
+def required_text(value: Any, field: str, *, limit: int = MAX_TEXT_BYTES) -> str:
+    text = optional_text(value, field, limit=limit)
+    if not text:
+        raise NextcloudTalkReadProviderError(f"Nextcloud Talk {field} is required")
+    return text
+
+
+def integer(value: Any, field: str, *, optional: bool = False) -> int | None:
+    if value is None and optional:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise NextcloudTalkReadProviderError(f"Nextcloud Talk {field} must be an integer")
+    return value
+
+
+def non_negative(value: Any, field: str, *, optional: bool = False) -> int | None:
+    number = integer(value, field, optional=optional)
+    if number is not None and number < 0:
+        raise NextcloudTalkReadProviderError(
+            f"Nextcloud Talk {field} must be non-negative"
+        )
+    return number
+
+
+def boolean(value: Any, field: str, *, optional: bool = False) -> bool | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, bool):
+        raise NextcloudTalkReadProviderError(f"Nextcloud Talk {field} must be boolean")
+    return value
+
+
+def ocs_data(payload: Any, field: str) -> Any:
+    """Return data from a successful JSON OCS envelope."""
+    root = object_value(payload, f"{field} response")
+    ocs = object_value(root.get("ocs"), f"{field} OCS envelope")
+    meta = object_value(ocs.get("meta"), f"{field} OCS metadata")
+    status_code = integer(meta.get("statuscode"), f"{field} OCS status")
+    if status_code not in (100, 200):
+        raise NextcloudTalkReadProviderError(f"Nextcloud Talk {field} OCS request failed")
+    return ocs.get("data")
+
+
+def terminal_payload(result: ApiResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": result.status, "observed_at": observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload

--- a/.agents/scripts/_knowledge_social_nextcloud_talk_files.py
+++ b/.agents/scripts/_knowledge_social_nextcloud_talk_files.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validate already-authorized message-linked Nextcloud Talk attachment bytes."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+
+from _knowledge_social_nextcloud_talk import NextcloudTalkAdapterError
+
+DIGEST = re.compile(r"^[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True)
+class VerifiedAttachment:
+    content_sha256: str
+    byte_size: int
+    mime_type: str
+
+
+def validate_attachment_bytes(
+    content: bytes,
+    *,
+    expected_sha256: str,
+    expected_size: int,
+    mime_type: str,
+    max_bytes: int,
+    allowed_mime_types: frozenset[str],
+) -> VerifiedAttachment:
+    """Fail closed before bytes can be handed to canonical blob persistence."""
+    if not isinstance(content, bytes) or len(content) > max_bytes or max_bytes < 1:
+        raise NextcloudTalkAdapterError("Nextcloud Talk attachment exceeds the byte budget")
+    if isinstance(expected_size, bool) or expected_size < 0 or len(content) != expected_size:
+        raise NextcloudTalkAdapterError("Nextcloud Talk attachment size identity changed")
+    if mime_type not in allowed_mime_types or "\x00" in mime_type:
+        raise NextcloudTalkAdapterError("Nextcloud Talk attachment MIME type is denied")
+    digest = hashlib.sha256(content).hexdigest()
+    if DIGEST.fullmatch(expected_sha256) is None or not hmac_compare(digest, expected_sha256):
+        raise NextcloudTalkAdapterError("Nextcloud Talk attachment digest identity changed")
+    return VerifiedAttachment(digest, len(content), mime_type)
+
+
+def hmac_compare(actual: str, expected: str) -> bool:
+    """Compare public content digests without data-dependent early exit."""
+    if len(actual) != len(expected):
+        return False
+    difference = 0
+    for actual_byte, expected_byte in zip(actual.encode(), expected.encode(), strict=True):
+        difference |= actual_byte ^ expected_byte
+    return difference == 0

--- a/.agents/scripts/_knowledge_social_nextcloud_talk_http.py
+++ b/.agents/scripts/_knowledge_social_nextcloud_talk_http.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Exact-origin, redirect-free, GET-only transport for Nextcloud Talk OCS."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import math
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import SplitResult, urlencode, urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from _knowledge_social_nextcloud_talk_contract import (
+    ApiResult,
+    NextcloudTalkReadProviderError,
+)
+
+MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+HTTP_TIMEOUT_SECONDS = 60
+
+
+class Response(Protocol):
+    status: int
+    headers: Any
+
+    def __enter__(self) -> Response: ...
+
+    def __exit__(self, *args: Any) -> None: ...
+
+    def read(self, size: int = -1) -> bytes: ...
+
+
+class Opener(Protocol):
+    def open(self, request: Request, timeout: int) -> Response: ...
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    """Validated private profile for one exact Nextcloud installation."""
+
+    base_url: str
+    username: str
+    app_password: str
+    origin_key: str
+    instance_id: str
+    allowed_rooms: tuple[str, ...]
+    expected_server_major: int
+    expected_talk_major: int
+
+
+class _RejectRedirect(HTTPRedirectHandler):
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def _parsed_url(value: str) -> tuple[SplitResult, int | None]:
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError as error:
+        raise NextcloudTalkReadProviderError(
+            "Nextcloud Talk profile base URL is invalid"
+        ) from error
+    return parsed, port
+
+
+def _canonical_path(path: str) -> str:
+    result = path.rstrip("/")
+    if any(marker in result for marker in ("\\", "%", "//")):
+        raise NextcloudTalkReadProviderError("Nextcloud Talk profile base URL is invalid")
+    if any(part in (".", "..") for part in result.split("/") if part):
+        raise NextcloudTalkReadProviderError("Nextcloud Talk profile base URL is invalid")
+    return result
+
+
+def canonical_base_url(value: str) -> str:
+    """Canonicalize one HTTPS installation without exposing it in errors."""
+    parsed, port = _parsed_url(value)
+    if (
+        parsed.scheme.lower() != "https"
+        or parsed.hostname is None
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise NextcloudTalkReadProviderError(
+            "Nextcloud Talk profile base URL must be exact HTTPS"
+        )
+    host = parsed.hostname.lower()
+    rendered = f"[{host}]" if ":" in host else host
+    if port is not None and port != 443:
+        rendered = f"{rendered}:{port}"
+    return f"https://{rendered}{_canonical_path(parsed.path)}"
+
+
+def installation_fingerprint(base_url: str, origin_key: str) -> str:
+    key = origin_key.encode("utf-8")
+    if len(key) < 32:
+        raise NextcloudTalkReadProviderError(
+            "Nextcloud Talk profile origin key must be at least 32 bytes"
+        )
+    canonical = canonical_base_url(base_url)
+    return hmac.new(key, canonical.encode(), hashlib.sha256).hexdigest()[:24]
+
+
+def http_opener() -> Opener:
+    exports = (Request, build_opener, urlencode, urlsplit, HTTPRedirectHandler)
+    if not all(callable(item) for item in exports):
+        raise NextcloudTalkReadProviderError("Python urllib HTTP exports are unavailable")
+    return build_opener(_RejectRedirect())
+
+
+def _retry_epoch(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    return int(time.time() + math.ceil(seconds))
+
+
+def _headers(value: Any) -> dict[str, str]:
+    if value is None or not hasattr(value, "items"):
+        return {}
+    return {str(key).lower(): str(item) for key, item in value.items()}
+
+
+def _decode(payload: bytes, status: int) -> Any:
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise NextcloudTalkReadProviderError("Nextcloud Talk response exceeds the safety limit")
+    if status == 304 and not payload:
+        return {}
+    try:
+        decoded = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise NextcloudTalkReadProviderError(
+            "Nextcloud Talk provider returned no valid JSON"
+        ) from error
+    if not isinstance(decoded, dict):
+        raise NextcloudTalkReadProviderError("Nextcloud Talk OCS root must be an object")
+    return decoded
+
+
+def _allowed_path(config: ProfileConfig, path: str) -> bool:
+    exact = {
+        "/ocs/v2.php/cloud/capabilities",
+        "/ocs/v2.php/cloud/user",
+        "/ocs/v2.php/apps/spreed/api/v4/room",
+    }
+    if path in exact:
+        return True
+    return any(
+        path
+        in {
+            f"/ocs/v2.php/apps/spreed/api/v4/room/{token}",
+            f"/ocs/v2.php/apps/spreed/api/v4/room/{token}/participants",
+            f"/ocs/v2.php/apps/spreed/api/v1/chat/{token}",
+        }
+        for token in config.allowed_rooms
+    )
+
+
+def _query_keys(path: str) -> frozenset[str]:
+    if path == "/ocs/v2.php/apps/spreed/api/v4/room":
+        return frozenset({"includeStatus", "noStatusUpdate"})
+    if "/api/v1/chat/" in path:
+        return frozenset(
+            {
+                "includeLastKnown",
+                "lastKnownMessageId",
+                "limit",
+                "lookIntoFuture",
+                "markNotificationsAsRead",
+                "noStatusUpdate",
+                "setReadMarker",
+            }
+        )
+    return frozenset()
+
+
+def _request(config: ProfileConfig, path: str, params: dict[str, str]) -> Request:
+    if not _allowed_path(config, path) or set(params) != _query_keys(path):
+        raise NextcloudTalkReadProviderError("Nextcloud Talk OCS route is not allowlisted")
+    if any(
+        not isinstance(key, str)
+        or not isinstance(value, str)
+        or "\x00" in key
+        or "\x00" in value
+        for key, value in params.items()
+    ):
+        raise NextcloudTalkReadProviderError("Nextcloud Talk OCS query is invalid")
+    query = {**params, "format": "json"}
+    encoded = base64.b64encode(
+        f"{config.username}:{config.app_password}".encode("utf-8")
+    ).decode("ascii")
+    return Request(
+        f"{config.base_url}{path}?{urlencode(query)}",
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Basic {encoded}",
+            "OCS-APIRequest": "true",
+            "User-Agent": "aidevops-nextcloud-talk-knowledge/1",
+        },
+        method="GET",
+    )
+
+
+def api(
+    config: ProfileConfig,
+    opener: Opener,
+    path: str,
+    params: dict[str, str],
+) -> ApiResult:
+    """Execute one exact-origin, redirect-free, GET-only OCS request."""
+    request = _request(config, path, params)
+    try:
+        with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", 200)
+            if isinstance(status, bool) or not isinstance(status, int):
+                raise NextcloudTalkReadProviderError("Nextcloud Talk HTTP status is invalid")
+            payload = response.read(MAX_RESPONSE_BYTES + 1)
+            if not isinstance(payload, bytes):
+                raise NextcloudTalkReadProviderError("Nextcloud Talk HTTP response is invalid")
+            return ApiResult(status, _decode(payload, status), _headers(response.headers))
+    except HTTPError as error:
+        headers = _headers(error.headers)
+        return ApiResult(error.code, {}, headers, _retry_epoch(headers.get("retry-after")))
+    except (TimeoutError, URLError, OSError) as error:
+        raise NextcloudTalkReadProviderError(
+            "Nextcloud Talk provider request failed"
+        ) from error

--- a/.agents/scripts/_knowledge_social_nextcloud_talk_normalize.py
+++ b/.agents/scripts/_knowledge_social_nextcloud_talk_normalize.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize allowlisted Nextcloud Talk records into canonical social evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_nextcloud_talk import (
+    PROVIDER,
+    RETENTION_LIMIT,
+    NextcloudTalkAdapterError,
+    instance_id,
+    page_data,
+)
+from knowledge_social_import import reject_credentials
+
+PROVENANCE = "nextcloud_talk_official_ocs"
+GAPS = (
+    ("history_before_retention", "server_retention_membership_or_expiration_boundary"),
+    ("deleted_before_observation", "not_recoverable_through_current_ocs_history"),
+    ("encrypted_or_unreadable", "content_not_returned_to_selected_account"),
+    ("reaction_actor_history", "message_pages_expose_counts_not_complete_actor_history"),
+    ("poll_details", "poll_objects_require_separate_capability_and_object_reads"),
+    ("call_recording_content", "call_system_summaries_only"),
+    ("attachment_bytes", "message_linked_metadata_only_until_webdav_identity_is_verified"),
+    ("webhook_recovery", "webhooks_are_optional_freshness_not_history_authority"),
+)
+
+
+@dataclass(frozen=True)
+class PageContext:
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def _required_text(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise NextcloudTalkAdapterError(f"Nextcloud Talk record requires {field}")
+    return value
+
+
+def _optional_text(value: Any, field: str) -> str | None:
+    if value is not None and (not isinstance(value, str) or "\x00" in value):
+        raise NextcloudTalkAdapterError(f"Nextcloud Talk record {field} must be text")
+    return value
+
+
+def _observed_at(payload: dict[str, Any]) -> str:
+    return _required_text(payload.get("observed_at"), "observed_at")
+
+
+def _coverage(observed_at: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "stream": stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": RETENTION_LIMIT,
+            "unavailable_reason": reason,
+            "status": "unavailable",
+            "observed_at": observed_at,
+        }
+        for stream, reason in GAPS
+    ]
+
+
+def _text(item: dict[str, Any]) -> str | None:
+    values = [
+        text
+        for key in ("name", "text", "system_message")
+        if (text := _optional_text(item.get(key), key))
+    ]
+    return "\n\n".join(values) or None
+
+
+def _object(
+    item: dict[str, Any], context: PageContext, observed_at: str, installation: str
+) -> dict[str, Any]:
+    kind = _required_text(item.get("kind"), "kind")
+    if kind not in {"installation_capability", "conversation", "participant", "message"}:
+        raise NextcloudTalkAdapterError("Nextcloud Talk item kind is unsupported")
+    remote_id = _required_text(item.get("remote_id"), "remote_id")
+    provider_json = {
+        "source": PROVENANCE,
+        "instance_id": installation,
+        "stream": context.stream,
+        "record": item,
+    }
+    reject_credentials(provider_json)
+    authored = kind == "message" and item.get("actor_id") == context.account.get("id")
+    return {
+        "object_type": kind,
+        "remote_id": remote_id,
+        "account_remote_id": context.account.get("id") if authored else None,
+        "text": _text(item),
+        "created_at": _optional_text(item.get("created_at"), "created_at"),
+        "observed_at": observed_at,
+        "evidence_class": "authored" if authored else "observed",
+        "provider_json": provider_json,
+    }
+
+
+def _base_activity(
+    activity_type: str,
+    suffix: str,
+    item: dict[str, Any],
+    context: PageContext,
+    observed_at: str,
+    installation: str,
+) -> dict[str, Any]:
+    remote_id = _required_text(item.get("remote_id"), "remote_id")
+    actor = item.get("actor_id") or context.account.get("id")
+    return {
+        "activity_type": activity_type,
+        "remote_id": f"{remote_id}_{suffix}",
+        "actor_remote_id": _required_text(actor, "activity actor"),
+        "object_remote_id": remote_id,
+        "occurred_at": _optional_text(item.get("created_at"), "created_at"),
+        "observed_at": observed_at,
+        "state": "deleted" if item.get("deleted") else "active",
+        "provider_json": {
+            "source": PROVENANCE,
+            "instance_id": installation,
+            "stream": context.stream,
+            "room_id": item.get("room_id"),
+        },
+    }
+
+
+def _activities(
+    item: dict[str, Any], context: PageContext, observed_at: str, installation: str
+) -> list[dict[str, Any]]:
+    kind = _required_text(item.get("kind"), "kind")
+    base_type = {
+        "installation_capability": "capability_observed",
+        "conversation": "room_membership",
+        "participant": "participant_membership",
+        "message": "message_observed",
+    }[kind]
+    activities = [_base_activity(base_type, base_type, item, context, observed_at, installation)]
+    if item.get("edited_at"):
+        activities.append(
+            _base_activity("message_edited", "edited", item, context, observed_at, installation)
+        )
+    if item.get("deleted"):
+        activities.append(
+            _base_activity("message_deleted", "deleted", item, context, observed_at, installation)
+        )
+    reactions = item.get("reactions", {})
+    if isinstance(reactions, dict):
+        for index, (reaction, count) in enumerate(sorted(reactions.items())):
+            activity = _base_activity(
+                "reaction_summary", f"reaction_{index}", item, context, observed_at, installation
+            )
+            activity["provider_json"]["reaction"] = reaction
+            activity["provider_json"]["count"] = count
+            activities.append(activity)
+    return activities
+
+
+def _media(item: dict[str, Any]) -> list[dict[str, Any]]:
+    attachments = item.get("attachments", [])
+    if not isinstance(attachments, list):
+        raise NextcloudTalkAdapterError("Nextcloud Talk attachments must be an array")
+    result: list[dict[str, Any]] = []
+    for attachment in attachments:
+        if not isinstance(attachment, dict):
+            raise NextcloudTalkAdapterError("Nextcloud Talk attachment must be an object")
+        result.append(
+            {
+                "remote_id": _required_text(attachment.get("remote_id"), "attachment ID"),
+                "object_remote_id": _required_text(item.get("remote_id"), "message ID"),
+                "content_sha256": None,
+                "mime_type": _optional_text(attachment.get("mime_type"), "attachment MIME type"),
+                "byte_size": attachment.get("byte_size"),
+                "blob_ref": None,
+                "hydration_state": "metadata",
+            }
+        )
+    return result
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    """Build canonical rows and explicit capability/authority dispositions."""
+    reject_credentials(payload)
+    observed_at = _observed_at(payload)
+    installation = instance_id(context.account.get("instance_id"))
+    items = page_data(payload)
+    objects = [_object(item, context, observed_at, installation) for item in items]
+    activities = [
+        activity
+        for item in items
+        for activity in _activities(item, context, observed_at, installation)
+    ]
+    media = [entry for item in items for entry in _media(item)]
+    policy = dict(context.policy)
+    policy.update(
+        {
+            "nextcloud_talk_instance_id": installation,
+            "nextcloud_talk_transport": "stdlib_urllib_get_only",
+            "nextcloud_talk_room_allowlist": "private_profile",
+            "nextcloud_talk_history_authority": "ocs",
+            "nextcloud_talk_webhooks": "optional_not_enabled",
+            "media_hydration": "metadata",
+        }
+    )
+    archive = {
+        "provider": PROVIDER,
+        "connection_id": context.connection_id,
+        "remote_account_id": context.account.get("id"),
+        "exported_at": observed_at,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": policy,
+        "accounts": [
+            {
+                "remote_id": context.account.get("id"),
+                "handle": None,
+                "display_name": context.account.get("name"),
+                "observed_at": observed_at,
+                "provider_json": {
+                    "source": PROVENANCE,
+                    "instance_id": installation,
+                    "server_version": context.account.get("server_version"),
+                    "talk_version": context.account.get("talk_version"),
+                },
+            }
+        ],
+        "objects": objects,
+        "activities": activities,
+        "media": media,
+        "coverage": _coverage(observed_at),
+    }
+    reject_credentials(archive)
+    return archive

--- a/.agents/scripts/_knowledge_social_nextcloud_talk_provider.py
+++ b/.agents/scripts/_knowledge_social_nextcloud_talk_provider.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded, redirect-free, GET-only Nextcloud Talk OCS reader subprocess."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from functools import partial
+from typing import Any
+
+from _knowledge_social_nextcloud_talk import (
+    NextcloudTalkAdapterError,
+    PageRequest,
+    parse_page_request,
+)
+from _knowledge_social_nextcloud_talk_contract import (
+    ApiResult,
+    NextcloudTalkReadProviderError,
+    request_object,
+    terminal_payload,
+)
+from _knowledge_social_nextcloud_talk_http import (
+    MAX_RESPONSE_BYTES,
+    Opener,
+    ProfileConfig,
+    api,
+    canonical_base_url,
+    http_opener,
+    installation_fingerprint,
+)
+from _knowledge_social_nextcloud_talk_routes import identity, page
+
+MAX_REQUEST_BYTES = 64 * 1024
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+ROOM_TOKEN = re.compile(r"^[A-Za-z0-9]{4,64}$")
+
+
+def _profile_prefix(profile: str) -> str:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise NextcloudTalkReadProviderError("Nextcloud Talk profile name is invalid")
+    return f"NEXTCLOUD_TALK_{profile.upper()}"
+
+
+def _profile_value(prefix: str, suffix: str, field: str, limit: int) -> str:
+    value = os.environ.get(f"{prefix}_{suffix}", "")
+    if not value or "\x00" in value or len(value.encode()) > limit:
+        raise NextcloudTalkReadProviderError(f"Nextcloud Talk profile {field} is missing")
+    return value
+
+
+def _positive_major(value: str, field: str) -> int:
+    try:
+        result = int(value)
+    except ValueError as error:
+        raise NextcloudTalkReadProviderError(
+            f"Nextcloud Talk profile {field} is invalid"
+        ) from error
+    if result < 1 or result > 999:
+        raise NextcloudTalkReadProviderError(f"Nextcloud Talk profile {field} is invalid")
+    return result
+
+
+def _allowed_rooms(value: str) -> tuple[str, ...]:
+    rooms = tuple(part.strip() for part in value.split(",") if part.strip())
+    if (
+        not rooms
+        or len(rooms) > 100
+        or len(set(rooms)) != len(rooms)
+        or any(ROOM_TOKEN.fullmatch(room) is None for room in rooms)
+    ):
+        raise NextcloudTalkReadProviderError(
+            "Nextcloud Talk profile room allowlist is invalid"
+        )
+    return rooms
+
+
+def _profile(profile: str) -> ProfileConfig:
+    prefix = _profile_prefix(profile)
+    base_url = canonical_base_url(
+        _profile_value(prefix, "BASE_URL", "base URL", 4096)
+    )
+    username = _profile_value(prefix, "USERNAME", "username", 512)
+    app_password = _profile_value(prefix, "APP_PASSWORD", "app password", 16 * 1024)
+    origin_key = _profile_value(prefix, "ORIGIN_KEY", "origin key", 16 * 1024)
+    rooms = _allowed_rooms(
+        _profile_value(prefix, "ALLOWED_ROOMS", "room allowlist", 16 * 1024)
+    )
+    server_major = _positive_major(
+        _profile_value(prefix, "EXPECTED_SERVER_MAJOR", "server major", 8),
+        "server major",
+    )
+    talk_major = _positive_major(
+        _profile_value(prefix, "EXPECTED_TALK_MAJOR", "Talk major", 8),
+        "Talk major",
+    )
+    return ProfileConfig(
+        base_url,
+        username,
+        app_password,
+        origin_key,
+        installation_fingerprint(base_url, origin_key),
+        rooms,
+        server_major,
+        talk_major,
+    )
+
+
+def _identity(
+    config: ProfileConfig, opener: Opener, expected_selector: str
+) -> dict[str, Any]:
+    result = identity(partial(api, config, opener), config, expected_selector)
+    if isinstance(result, ApiResult):
+        return terminal_payload(result)
+    return {"status": 200, "data": result, "observed_at": result.get("observed_at")}
+
+
+def _verify_page(request: PageRequest, data: dict[str, Any], config: ProfileConfig) -> None:
+    rooms = data.get("room_ids")
+    if not isinstance(rooms, list):
+        raise NextcloudTalkReadProviderError("Nextcloud Talk verified rooms are invalid")
+    if request.stream not in ("capabilities", "rooms") and request.room_index >= len(rooms):
+        raise NextcloudTalkReadProviderError("Nextcloud Talk room index is invalid")
+    expected_room = (
+        None
+        if request.stream in ("capabilities", "rooms")
+        else rooms[request.room_index]
+    )
+    if (
+        request.instance_id != config.instance_id
+        or request.instance_id != data.get("instance_id")
+        or request.account_id != data.get("id")
+        or request.provider_account_id != data.get("provider_account_id")
+        or request.room_id != expected_room
+    ):
+        raise NextcloudTalkReadProviderError(
+            "selected Nextcloud Talk account or room does not match the profile"
+        )
+
+
+def _dispatch(
+    request: dict[str, Any], config: ProfileConfig, opener: Opener
+) -> dict[str, Any]:
+    action = request.get("action")
+    if action == "identity":
+        if set(request) != {"action", "account_id"}:
+            raise NextcloudTalkReadProviderError("Nextcloud Talk identity request is invalid")
+        expected = request.get("account_id")
+        if not isinstance(expected, str):
+            raise NextcloudTalkReadProviderError("Nextcloud Talk account selector is invalid")
+        return _identity(config, opener, expected)
+    page_request = parse_page_request(request)
+    verified = _identity(config, opener, f"user_{config.username}")
+    if verified.get("status") != 200:
+        return verified
+    data = verified.get("data")
+    if not isinstance(data, dict):
+        raise NextcloudTalkReadProviderError("Nextcloud Talk identity response is invalid")
+    _verify_page(page_request, data, config)
+    result = page(partial(api, config, opener), config, page_request, data)
+    return terminal_payload(result) if isinstance(result, ApiResult) else result
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode()) > MAX_RESPONSE_BYTES:
+        raise NextcloudTalkReadProviderError("Nextcloud Talk response exceeds the safety limit")
+    print(encoded)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        request = request_object(sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1), MAX_REQUEST_BYTES)
+        _emit(_dispatch(request, _profile(args.profile), http_opener()))
+        return 0
+    except (NextcloudTalkReadProviderError, NextcloudTalkAdapterError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - redact provider and credential internals
+        print("ERROR: Nextcloud Talk read provider request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_nextcloud_talk_reader.py
+++ b/.agents/scripts/_knowledge_social_nextcloud_talk_reader.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and deterministic fixture readers for Nextcloud Talk."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_nextcloud_talk import (
+    NextcloudTalkAdapterError,
+    NextcloudTalkProviderUnavailableError,
+    PageRequest,
+    instance_id,
+)
+from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
+from knowledge_social_import import reject_credentials
+
+READ_TIMEOUT_SECONDS = 180
+MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+SAFE_PROVIDER_FAILURES = (
+    "Python urllib HTTP exports are unavailable",
+    "Nextcloud Talk profile name is invalid",
+    "Nextcloud Talk profile base URL is missing",
+    "Nextcloud Talk profile base URL must be exact HTTPS",
+    "Nextcloud Talk profile username is missing",
+    "Nextcloud Talk profile app password is missing",
+    "Nextcloud Talk profile origin key is missing",
+    "Nextcloud Talk profile origin key must be at least 32 bytes",
+    "Nextcloud Talk profile room allowlist is invalid",
+    "Nextcloud Talk profile server major is invalid",
+    "Nextcloud Talk profile Talk major is invalid",
+    "selected Nextcloud Talk account does not match the profile",
+    "selected Nextcloud Talk account or room does not match the profile",
+    "configured Nextcloud Talk room is unavailable to the selected account",
+    "Nextcloud Talk server or app version changed from the configured profile",
+    "Nextcloud Talk required read APIs are unavailable",
+)
+
+
+class NextcloudTalkReader(Protocol):
+    def identity(self, expected_id: str) -> dict[str, Any]: ...
+
+    def page(self, request: PageRequest) -> dict[str, Any]: ...
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    if len(output.encode()) > MAX_RESPONSE_BYTES:
+        raise NextcloudTalkAdapterError("Nextcloud Talk response exceeds the safety limit")
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise NextcloudTalkAdapterError(
+            "Nextcloud Talk provider returned no valid JSON"
+        ) from error
+    if not isinstance(payload, dict):
+        raise NextcloudTalkAdapterError("Nextcloud Talk response root must be an object")
+    return payload
+
+
+def _provider_failure(stderr: str) -> NextcloudTalkProviderUnavailableError:
+    for message in SAFE_PROVIDER_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return NextcloudTalkProviderUnavailableError(message)
+    return NextcloudTalkProviderUnavailableError("Nextcloud Talk read provider is unavailable")
+
+
+NEXTCLOUD_TALK_READER_POLICY = GuardedOAuthPolicy(
+    "Nextcloud Talk",
+    "NEXTCLOUD_TALK",
+    "NEXTCLOUD_TALK_READ_LOG",
+    READ_TIMEOUT_SECONDS,
+    _decode_output,
+    _provider_failure,
+    NextcloudTalkProviderUnavailableError,
+    (
+        "BASE_URL",
+        "USERNAME",
+        "APP_PASSWORD",
+        "ORIGIN_KEY",
+        "ALLOWED_ROOMS",
+        "EXPECTED_SERVER_MAJOR",
+        "EXPECTED_TALK_MAJOR",
+    ),
+    "",
+)
+
+
+class GuardedNextcloudTalk(GuardedOAuthReader):
+    """Execute only identity and allowlisted Talk page reads in a child."""
+
+    def __init__(self, helper: Path, profile: str) -> None:
+        super().__init__(helper, profile, NEXTCLOUD_TALK_READER_POLICY)
+
+
+class FixtureNextcloudTalk:
+    """Deterministic OCS substitute for version, pagination, and failure fixtures."""
+
+    def __init__(self, path: Path) -> None:
+        self.fixture = FixtureSequence(path, "Nextcloud Talk", NextcloudTalkAdapterError)
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        del expected_id
+        return self.fixture.identity()
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        entry = self.fixture.next_page()
+        expectation = entry.get("expect_request", {})
+        if not isinstance(expectation, dict):
+            raise NextcloudTalkAdapterError(
+                "Nextcloud Talk fixture request expectation must be an object"
+            )
+        actual = request.payload()
+        if any(actual.get(key) != value for key, value in expectation.items()):
+            raise NextcloudTalkAdapterError(
+                "Nextcloud Talk request did not resume at the expected checkpoint"
+            )
+        response = entry.get("response", entry)
+        if not isinstance(response, dict):
+            raise NextcloudTalkAdapterError(
+                "Nextcloud Talk fixture page response must be an object"
+            )
+        return response
+
+
+def _bounded_text(value: Any, field: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or not value or "\x00" in value or len(value.encode()) > 512:
+        raise NextcloudTalkAdapterError(f"Nextcloud Talk account {field} is invalid")
+    return value
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    """Bind the child-verified user to one installation and room allowlist."""
+    del expected_id
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise NextcloudTalkAdapterError("Nextcloud Talk verification returned no account")
+    rooms = data.get("room_ids")
+    if not isinstance(rooms, list) or not rooms or len(rooms) > 100:
+        raise NextcloudTalkAdapterError("Nextcloud Talk room allowlist is invalid")
+    room_ids = [_bounded_text(room, "room identity") for room in rooms]
+    if len(set(room_ids)) != len(room_ids):
+        raise NextcloudTalkAdapterError("Nextcloud Talk room allowlist is invalid")
+    features = data.get("features")
+    if not isinstance(features, list) or any(not isinstance(value, str) for value in features):
+        raise NextcloudTalkAdapterError("Nextcloud Talk features are invalid")
+    return {
+        "id": _bounded_text(data.get("id"), "identity"),
+        "provider_account_id": _bounded_text(data.get("provider_account_id"), "account ID"),
+        "instance_id": instance_id(data.get("instance_id")),
+        "room_ids": room_ids,
+        "name": _bounded_text(data.get("display_name"), "display name", optional=True),
+        "server_version": _bounded_text(data.get("server_version"), "server version"),
+        "talk_version": _bounded_text(data.get("talk_version"), "Talk version"),
+        "features": features,
+    }

--- a/.agents/scripts/_knowledge_social_nextcloud_talk_routes.py
+++ b/.agents/scripts/_knowledge_social_nextcloud_talk_routes.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Identity checks and allowlisted serializers for Nextcloud Talk OCS reads."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Callable
+
+from _knowledge_social_nextcloud_talk import (
+    PageRequest,
+    namespaced_id,
+    private_fingerprint,
+)
+from _knowledge_social_nextcloud_talk_contract import (
+    ApiResult,
+    NextcloudTalkReadProviderError,
+    boolean,
+    non_negative,
+    object_list,
+    object_value,
+    observed_at,
+    ocs_data,
+    optional_text,
+    required_text,
+)
+from _knowledge_social_nextcloud_talk_http import ProfileConfig
+
+Api = Callable[[str, dict[str, str]], ApiResult]
+PageResult = ApiResult | dict[str, Any]
+REQUIRED_FEATURES = frozenset({"chat-v2", "conversation-v4"})
+
+
+def _timestamp(value: Any, field: str) -> str | None:
+    seconds = non_negative(value, field, optional=True)
+    if seconds is None:
+        return None
+    return datetime.fromtimestamp(seconds, UTC).isoformat().replace("+00:00", "Z")
+
+
+def room_id(config: ProfileConfig, token: str) -> str:
+    digest = private_fingerprint(config.origin_key, config.instance_id, "room", token)
+    return f"nct_{config.instance_id}_room_{digest}"
+
+
+def _account_id(config: ProfileConfig, username: str) -> str:
+    digest = private_fingerprint(config.origin_key, config.instance_id, "user", username)
+    return f"nct_{config.instance_id}_user_{digest}"
+
+
+def _version_major(value: Any, field: str) -> tuple[int, str]:
+    if isinstance(value, dict):
+        major = non_negative(value.get("major"), f"{field} major")
+        rendered = optional_text(value.get("string"), f"{field} version", limit=64)
+        if major is None:
+            raise NextcloudTalkReadProviderError(f"Nextcloud Talk {field} version is missing")
+        return major, rendered or str(major)
+    rendered = required_text(value, f"{field} version", limit=64)
+    try:
+        major = int(rendered.split(".", 1)[0])
+    except ValueError as error:
+        raise NextcloudTalkReadProviderError(
+            f"Nextcloud Talk {field} version is invalid"
+        ) from error
+    return major, rendered
+
+
+def _capabilities(api: Api, config: ProfileConfig) -> dict[str, Any] | ApiResult:
+    result = api("/ocs/v2.php/cloud/capabilities", {})
+    if result.status != 200:
+        return result
+    data = object_value(ocs_data(result.payload, "capabilities"), "capabilities data")
+    server_major, server_version = _version_major(data.get("version"), "server")
+    capabilities = object_value(data.get("capabilities"), "capabilities map")
+    talk = object_value(capabilities.get("spreed"), "Talk capabilities")
+    talk_major, talk_version = _version_major(talk.get("version"), "app")
+    features_value = talk.get("features")
+    if not isinstance(features_value, list) or any(
+        not isinstance(feature, str) for feature in features_value
+    ):
+        raise NextcloudTalkReadProviderError("Nextcloud Talk features are invalid")
+    features = frozenset(features_value)
+    if server_major != config.expected_server_major or talk_major != config.expected_talk_major:
+        raise NextcloudTalkReadProviderError(
+            "Nextcloud Talk server or app version changed from the configured profile"
+        )
+    if not REQUIRED_FEATURES.issubset(features):
+        raise NextcloudTalkReadProviderError("Nextcloud Talk required read APIs are unavailable")
+    allowed_features = sorted(
+        features
+        & {
+            "bots-v1",
+            "chat-get-context",
+            "chat-keep-notifications",
+            "chat-replies",
+            "conversation-v4",
+            "edit-messages",
+            "federation-v1",
+            "markdown-messages",
+            "message-expiration",
+            "reactions",
+            "rich-object-list-media",
+            "system-messages",
+            "talk-polls",
+            "threads",
+        }
+    )
+    return {
+        "server_major": server_major,
+        "server_version": server_version,
+        "talk_major": talk_major,
+        "talk_version": talk_version,
+        "features": allowed_features,
+    }
+
+
+def _selected_user(api: Api, config: ProfileConfig, expected_selector: str) -> dict[str, Any] | ApiResult:
+    result = api("/ocs/v2.php/cloud/user", {})
+    if result.status != 200:
+        return result
+    data = object_value(ocs_data(result.payload, "current user"), "current user data")
+    username = required_text(data.get("id"), "current user ID", limit=191)
+    if expected_selector.removeprefix("user_") != username:
+        raise NextcloudTalkReadProviderError(
+            "selected Nextcloud Talk account does not match the profile"
+        )
+    return {
+        "id": _account_id(config, username),
+        "provider_account_id": private_fingerprint(
+            config.origin_key, config.instance_id, "account", username
+        ),
+        "display_name": optional_text(data.get("display-name"), "display name"),
+    }
+
+
+def _room_record(config: ProfileConfig, value: dict[str, Any]) -> dict[str, Any]:
+    token = required_text(value.get("token"), "room token", limit=64)
+    if token not in config.allowed_rooms:
+        raise NextcloudTalkReadProviderError("Nextcloud Talk returned a non-allowlisted room")
+    return {
+        "kind": "conversation",
+        "remote_id": room_id(config, token),
+        "name": optional_text(
+            value.get("displayName", value.get("name")), "room name", limit=512
+        ),
+        "room_type": non_negative(value.get("type"), "room type", optional=True),
+        "participant_type": non_negative(
+            value.get("participantType"), "participant type", optional=True
+        ),
+        "read_only": non_negative(value.get("readOnly"), "room read-only", optional=True),
+        "message_expiration": non_negative(
+            value.get("messageExpiration"), "message expiration", optional=True
+        ),
+        "last_activity": _timestamp(value.get("lastActivity"), "room last activity"),
+        "has_call": boolean(value.get("hasCall"), "room call state", optional=True),
+        "unread_messages": non_negative(
+            value.get("unreadMessages"), "unread message count", optional=True
+        ),
+        "federated": value.get("remoteServer") is not None,
+    }
+
+
+def _rooms(api: Api, config: ProfileConfig) -> list[dict[str, Any]] | ApiResult:
+    result = api(
+        "/ocs/v2.php/apps/spreed/api/v4/room",
+        {"includeStatus": "false", "noStatusUpdate": "1"},
+    )
+    if result.status != 200:
+        return result
+    source = object_list(ocs_data(result.payload, "room list"), "room list", limit=500)
+    by_token = {
+        required_text(item.get("token"), "room token", limit=64): item for item in source
+    }
+    if any(token not in by_token for token in config.allowed_rooms):
+        raise NextcloudTalkReadProviderError(
+            "configured Nextcloud Talk room is unavailable to the selected account"
+        )
+    return [_room_record(config, by_token[token]) for token in config.allowed_rooms]
+
+
+def identity(api: Api, config: ProfileConfig, expected_selector: str) -> dict[str, Any] | ApiResult:
+    """Verify versions, account, and complete room allowlist before collection."""
+    capabilities = _capabilities(api, config)
+    if isinstance(capabilities, ApiResult):
+        return capabilities
+    account = _selected_user(api, config, expected_selector)
+    if isinstance(account, ApiResult):
+        return account
+    rooms = _rooms(api, config)
+    if isinstance(rooms, ApiResult):
+        return rooms
+    return {
+        **account,
+        "instance_id": config.instance_id,
+        "room_ids": [room["remote_id"] for room in rooms],
+        "rooms": rooms,
+        **capabilities,
+    }
+
+
+def _meta(
+    request: PageRequest,
+    records: list[dict[str, Any]],
+    *,
+    next_room_index: int,
+    next_position: int,
+    complete: bool,
+    final_room: bool = False,
+) -> dict[str, Any]:
+    accepted = records
+    reached = False
+    if request.stop_at is not None:
+        for index, record in enumerate(records):
+            if record.get("remote_id") == request.stop_at:
+                accepted = records[:index]
+                reached = True
+                break
+    if reached:
+        next_room_index = request.room_index + 1
+        next_position = 0
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": accepted,
+        "meta": {
+            "stream": request.stream,
+            "instance_id": request.instance_id,
+            "room_id": request.room_id,
+            "next_room_index": next_room_index,
+            "next_position": next_position,
+            "newest_id": records[0].get("remote_id") if records else None,
+            "reached_watermark": reached,
+            "complete": complete or (reached and final_room),
+        },
+    }
+
+
+def _room_token(config: ProfileConfig, request: PageRequest) -> str:
+    if request.room_index >= len(config.allowed_rooms):
+        raise NextcloudTalkReadProviderError("Nextcloud Talk room index is invalid")
+    token = config.allowed_rooms[request.room_index]
+    if request.room_id != room_id(config, token):
+        raise NextcloudTalkReadProviderError("Nextcloud Talk room identity was rebound")
+    return token
+
+
+def _participant(value: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    actor_type = required_text(value.get("actorType"), "participant actor type", limit=64)
+    actor_id = required_text(value.get("actorId"), "participant actor ID", limit=512)
+    remote_id = namespaced_id(request.instance_id, "participant", f"{actor_type}:{actor_id}")
+    return {
+        "kind": "participant",
+        "remote_id": remote_id,
+        "room_id": request.room_id,
+        "actor_type": actor_type,
+        "participant_type": non_negative(
+            value.get("participantType"), "participant type", optional=True
+        ),
+        "permissions": non_negative(value.get("permissions"), "participant permissions", optional=True),
+        "in_call": non_negative(value.get("inCall"), "participant call state", optional=True),
+        "federated": actor_type in {"federated_users", "federated_user"},
+        "guest": actor_type in {"guests", "emails"},
+    }
+
+
+def _participants(api: Api, config: ProfileConfig, request: PageRequest) -> PageResult:
+    token = _room_token(config, request)
+    result = api(f"/ocs/v2.php/apps/spreed/api/v4/room/{token}/participants", {})
+    if result.status != 200:
+        return result
+    source = object_list(ocs_data(result.payload, "participants"), "participants", limit=500)
+    records = [_participant(value, request) for value in source]
+    next_room = request.room_index + 1
+    complete = next_room >= len(config.allowed_rooms)
+    return _meta(
+        request,
+        records,
+        next_room_index=next_room,
+        next_position=0,
+        complete=complete,
+        final_room=complete,
+    )
+
+
+def _parameter_records(parameters: Any, request: PageRequest) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    if parameters is None:
+        return [], []
+    values = object_value(parameters, "message parameters")
+    if len(values) > 100:
+        raise NextcloudTalkReadProviderError("Nextcloud Talk message parameters exceed the limit")
+    mentions: list[dict[str, Any]] = []
+    attachments: list[dict[str, Any]] = []
+    for value in values.values():
+        item = object_value(value, "message parameter")
+        kind = optional_text(item.get("type"), "parameter type", limit=64)
+        native_id = optional_text(item.get("id"), "parameter ID", limit=2048)
+        if not kind or not native_id:
+            continue
+        if kind in {"user", "guest", "federated_user", "call"}:
+            mentions.append(
+                {
+                    "kind": kind,
+                    "remote_id": namespaced_id(request.instance_id, kind, native_id),
+                }
+            )
+        if kind in {"file", "deck-card", "voice-message"}:
+            size = non_negative(item.get("size"), "attachment size", optional=True)
+            attachments.append(
+                {
+                    "remote_id": namespaced_id(request.instance_id, "attachment", native_id),
+                    "mime_type": optional_text(item.get("mimetype"), "attachment MIME type", limit=255),
+                    "byte_size": size,
+                    "hydration_state": "metadata",
+                }
+            )
+    return mentions, attachments
+
+
+def _message(value: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    message_id = non_negative(value.get("id"), "message ID")
+    if message_id is None:
+        raise NextcloudTalkReadProviderError("Nextcloud Talk message ID is missing")
+    remote_id = namespaced_id(request.instance_id, "message", f"{request.room_id}:{message_id}")
+    parent_value = value.get("parent")
+    parent_id = None
+    if isinstance(parent_value, dict) and parent_value.get("id") is not None:
+        parent_id = namespaced_id(
+            request.instance_id,
+            "message",
+            f"{request.room_id}:{non_negative(parent_value.get('id'), 'parent message ID')}",
+        )
+    mentions, attachments = _parameter_records(value.get("messageParameters"), request)
+    reactions = value.get("reactions", {})
+    if not isinstance(reactions, dict) or any(
+        not isinstance(key, str)
+        or isinstance(count, bool)
+        or not isinstance(count, int)
+        or count < 0
+        for key, count in reactions.items()
+    ):
+        raise NextcloudTalkReadProviderError("Nextcloud Talk reaction summary is invalid")
+    return {
+        "kind": "message",
+        "remote_id": remote_id,
+        "room_id": request.room_id,
+        "actor_id": namespaced_id(
+            request.instance_id,
+            optional_text(value.get("actorType"), "message actor type", limit=64) or "unknown",
+            optional_text(value.get("actorId"), "message actor ID", limit=512) or "unknown",
+        ),
+        "text": optional_text(value.get("message"), "message text"),
+        "created_at": _timestamp(value.get("timestamp"), "message timestamp"),
+        "message_type": optional_text(value.get("messageType"), "message type", limit=64),
+        "system_message": optional_text(value.get("systemMessage"), "system message", limit=128),
+        "parent_id": parent_id,
+        "deleted": value.get("messageType") == "comment_deleted",
+        "edited_at": _timestamp(value.get("lastEditTimestamp"), "message edit timestamp"),
+        "expiration_at": _timestamp(value.get("expirationTimestamp"), "message expiration"),
+        "reactions": dict(sorted(reactions.items())),
+        "mentions": mentions,
+        "attachments": attachments,
+        "markdown": boolean(value.get("markdown"), "markdown flag", optional=True),
+    }
+
+
+def _messages(api: Api, config: ProfileConfig, request: PageRequest) -> PageResult:
+    token = _room_token(config, request)
+    params = {
+        "includeLastKnown": "0",
+        "lastKnownMessageId": str(request.position),
+        "limit": str(request.limit),
+        "lookIntoFuture": "0",
+        "markNotificationsAsRead": "0",
+        "noStatusUpdate": "1",
+        "setReadMarker": "0",
+    }
+    result = api(f"/ocs/v2.php/apps/spreed/api/v1/chat/{token}", params)
+    if result.status == 304:
+        records: list[dict[str, Any]] = []
+    elif result.status != 200:
+        return result
+    else:
+        source = object_list(ocs_data(result.payload, "chat history"), "chat history", limit=request.limit)
+        records = [_message(value, request) for value in source]
+    next_header = result.headers.get("x-chat-last-given")
+    if not records or next_header is None:
+        next_room = request.room_index + 1
+        complete = next_room >= len(config.allowed_rooms)
+        return _meta(
+            request,
+            records,
+            next_room_index=next_room,
+            next_position=0,
+            complete=complete,
+            final_room=complete,
+        )
+    try:
+        next_position = int(next_header)
+    except ValueError as error:
+        raise NextcloudTalkReadProviderError("Nextcloud Talk chat cursor is invalid") from error
+    if next_position <= 0 or next_position == request.position:
+        raise NextcloudTalkReadProviderError("Nextcloud Talk chat cursor did not advance")
+    return _meta(
+        request,
+        records,
+        next_room_index=request.room_index,
+        next_position=next_position,
+        complete=False,
+        final_room=request.room_index + 1 >= len(config.allowed_rooms),
+    )
+
+
+def page(
+    api: Api,
+    config: ProfileConfig,
+    request: PageRequest,
+    verified: dict[str, Any],
+) -> PageResult:
+    """Execute one reviewed Talk GET route after identity and room revalidation."""
+    if request.stream == "capabilities":
+        record = {
+            "kind": "installation_capability",
+            "remote_id": namespaced_id(request.instance_id, "capability", "talk"),
+            "server_major": verified["server_major"],
+            "server_version": verified["server_version"],
+            "talk_major": verified["talk_major"],
+            "talk_version": verified["talk_version"],
+            "features": verified["features"],
+        }
+        return _meta(request, [record], next_room_index=0, next_position=0, complete=True)
+    if request.stream == "rooms":
+        return _meta(
+            request,
+            list(verified["rooms"]),
+            next_room_index=0,
+            next_position=0,
+            complete=True,
+        )
+    if request.stream == "participants":
+        return _participants(api, config, request)
+    return _messages(api, config, request)

--- a/.agents/scripts/_knowledge_social_nextcloud_talk_webhook.py
+++ b/.agents/scripts/_knowledge_social_nextcloud_talk_webhook.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Verify and sanitize optional Nextcloud Talk webhook freshness evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import re
+from typing import Any, Mapping
+
+from _knowledge_social_nextcloud_talk import (
+    NextcloudTalkAdapterError,
+    instance_id,
+    namespaced_id,
+    private_fingerprint,
+)
+from _knowledge_social_nextcloud_talk_http import canonical_base_url
+
+SIGNATURE = re.compile(r"^[0-9a-f]{64}$")
+RANDOM = re.compile(r"^[A-Za-z0-9+/=_-]{32,128}$")
+MAX_WEBHOOK_BYTES = 2 * 1024 * 1024
+
+
+def _header(headers: Mapping[str, str], name: str) -> str:
+    values = {str(key).lower(): str(value) for key, value in headers.items()}
+    value = values.get(name.lower(), "")
+    if not value or "\x00" in value:
+        raise NextcloudTalkAdapterError("Nextcloud Talk webhook header is missing")
+    return value
+
+
+def verify_webhook(
+    body: bytes,
+    headers: Mapping[str, str],
+    *,
+    secret: str,
+    expected_backend: str,
+) -> None:
+    """Verify backend identity and HMAC(random || body) before parsing content."""
+    if not isinstance(body, bytes) or len(body) > MAX_WEBHOOK_BYTES:
+        raise NextcloudTalkAdapterError("Nextcloud Talk webhook body exceeds the limit")
+    if len(secret.encode("utf-8")) < 32:
+        raise NextcloudTalkAdapterError("Nextcloud Talk webhook secret is invalid")
+    random_value = _header(headers, "X-Nextcloud-Talk-Random")
+    signature = _header(headers, "X-Nextcloud-Talk-Signature").lower()
+    backend = _header(headers, "X-Nextcloud-Talk-Backend")
+    if RANDOM.fullmatch(random_value) is None or SIGNATURE.fullmatch(signature) is None:
+        raise NextcloudTalkAdapterError("Nextcloud Talk webhook signature is malformed")
+    if canonical_base_url(backend) != canonical_base_url(expected_backend):
+        raise NextcloudTalkAdapterError("Nextcloud Talk webhook backend identity changed")
+    expected = hmac.new(
+        secret.encode("utf-8"), random_value.encode("ascii") + body, hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(expected, signature):
+        raise NextcloudTalkAdapterError("Nextcloud Talk webhook signature is invalid")
+
+
+def _object(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise NextcloudTalkAdapterError(f"Nextcloud Talk webhook {field} is invalid")
+    return value
+
+
+def _text(value: Any, field: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if (
+        not isinstance(value, str)
+        or not value
+        or "\x00" in value
+        or len(value.encode("utf-8")) > 256 * 1024
+    ):
+        raise NextcloudTalkAdapterError(f"Nextcloud Talk webhook {field} is invalid")
+    return value
+
+
+def normalize_webhook(
+    body: bytes,
+    *,
+    origin_key: str,
+    installation: str,
+    allowed_rooms: Mapping[str, str],
+) -> dict[str, Any]:
+    """Return replay-stable opaque metadata for later OCS reconciliation."""
+    installation = instance_id(installation)
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise NextcloudTalkAdapterError("Nextcloud Talk webhook is not valid JSON") from error
+    root = _object(payload, "root")
+    event_type = _text(root.get("type"), "event type")
+    if event_type not in {"Create", "Like", "Undo", "Join", "Leave"}:
+        raise NextcloudTalkAdapterError("Nextcloud Talk webhook event is unsupported")
+    target = _object(root.get("target", root.get("object")), "target")
+    token = _text(target.get("id"), "room token")
+    expected_room = allowed_rooms.get(str(token))
+    derived = (
+        f"nct_{installation}_room_"
+        f"{private_fingerprint(origin_key, installation, 'room', str(token))}"
+    )
+    if expected_room != derived:
+        raise NextcloudTalkAdapterError("Nextcloud Talk webhook room is not allowlisted")
+    event_object = root.get("object")
+    while isinstance(event_object, dict) and event_object.get("type") == "Like":
+        event_object = event_object.get("object")
+    note = event_object if isinstance(event_object, dict) else {}
+    native_message = _text(note.get("id"), "message ID", optional=True)
+    message_id = (
+        namespaced_id(installation, "message", f"{derived}:{native_message}")
+        if native_message
+        else None
+    )
+    digest = hashlib.sha256(body).hexdigest()
+    return {
+        "event_id": namespaced_id(installation, "webhook", digest),
+        "event_type": event_type,
+        "room_id": derived,
+        "message_id": message_id,
+        "content_sha256": digest,
+        "requires_ocs_reconciliation": True,
+    }
+
+
+def verify_and_normalize_webhook(
+    body: bytes,
+    headers: Mapping[str, str],
+    *,
+    secret: str,
+    expected_backend: str,
+    origin_key: str,
+    installation: str,
+    allowed_rooms: Mapping[str, str],
+) -> dict[str, Any]:
+    verify_webhook(body, headers, secret=secret, expected_backend=expected_backend)
+    return normalize_webhook(
+        body,
+        origin_key=origin_key,
+        installation=installation,
+        allowed_rooms=allowed_rooms,
+    )

--- a/.agents/scripts/knowledge_social_nextcloud_talk.py
+++ b/.agents/scripts/knowledge_social_nextcloud_talk.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one bounded, read-only Nextcloud Talk stream into a social corpus."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import _knowledge_social_nextcloud_talk as nextcloud_talk
+from _knowledge_social_nextcloud_talk_normalize import PageContext, normalize_page
+from _knowledge_social_nextcloud_talk_reader import (
+    FixtureNextcloudTalk,
+    GuardedNextcloudTalk,
+    verified_identity,
+)
+from _knowledge_social_oauth_collector import OAuthCollectorPolicy, run_oauth_collector
+
+COLLECTOR_OPTIONS = {
+    "display_name": "Nextcloud Talk",
+    "provider_module": nextcloud_talk,
+    "helper": Path(__file__).with_name("_knowledge_social_nextcloud_talk_provider.py"),
+    "fixture_reader": FixtureNextcloudTalk,
+    "live_reader": GuardedNextcloudTalk,
+    "page_context": PageContext,
+    "normalize_page": normalize_page,
+    "verified_identity": verified_identity,
+    "budget_unit": "bounded read",
+    "default_budget": 10,
+    "min_budget": 4,
+    "max_page_size": 200,
+}
+
+
+def main() -> int:
+    return run_oauth_collector(OAuthCollectorPolicy(**COLLECTOR_OPTIONS), __doc__ or "")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/services/communications/nextcloud-talk.md
+++ b/.agents/services/communications/nextcloud-talk.md
@@ -29,7 +29,7 @@ tools:
 | Script | `nextcloud-talk-dispatch-helper.sh [setup\|start\|stop\|status\|map\|unmap\|mappings\|test\|logs]` |
 | Config | `~/.config/aidevops/nextcloud-talk-bot.json` (600 permissions) |
 | Data | `~/.aidevops/.agent-workspace/nextcloud-talk-bot/` |
-| Docs | [Talk docs](https://nextcloud-talk.readthedocs.io/) · [Bot API](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/bots.html) |
+| Docs | [Talk docs](https://nextcloud-talk.readthedocs.io/) · [Bots and webhooks](https://nextcloud-talk.readthedocs.io/en/latest/bots/) |
 
 **Key differentiator**: You own server, database, encryption keys, and backups. No third party (including Nextcloud GmbH) has access. Unlike Slack/Teams/Discord: zero external data access. Unlike SimpleX/Signal: full collaboration suite (files, calendar, office, contacts).
 
@@ -43,7 +43,7 @@ nextcloud-talk-dispatch-helper.sh start --daemon
 
 ## Architecture
 
-**Stack**: Talk Room → webhook POST (HMAC-SHA256) → Bot Endpoint (Bun/Node) → `runner-helper.sh` → AI session → OCS API reply → Talk Room.
+**Stack**: Talk Room → webhook POST (HMAC-SHA256 over random header + body) → Bot Endpoint (Bun/Node) → `runner-helper.sh` → AI session → OCS API reply → Talk Room.
 
 **Message flow**: signature verify → access control → entity resolution (`entity-helper.sh`) → Layer 0 log → context load → dispatch → headless AI session → OCS API reply + reaction emoji (⏳/✅/❌).
 
@@ -99,8 +99,8 @@ const ALLOWED_USERS = new Set(["admin", "developer1", "developer2"]);
 const app = express();
 app.use(express.raw({ type: "application/json" }));
 
-function verifySignature(body: Buffer, signature: string): boolean {
-  const expected = createHmac("sha256", WEBHOOK_SECRET).update(body).digest("hex");
+function verifySignature(body: Buffer, random: string, signature: string): boolean {
+  const expected = createHmac("sha256", WEBHOOK_SECRET).update(random).update(body).digest("hex");
   if (expected.length !== signature.length) return false;
   let result = 0;
   for (let i = 0; i < expected.length; i++) result |= expected.charCodeAt(i) ^ signature.charCodeAt(i);
@@ -117,7 +117,8 @@ async function ocsPost(path: string, body: object): Promise<void> {
 
 app.post("/webhook", async (req, res) => {
   const sig = req.headers["x-nextcloud-talk-signature"] as string;
-  if (!sig || !verifySignature(req.body, sig)) { res.status(401).send("Invalid signature"); return; }
+  const random = req.headers["x-nextcloud-talk-random"] as string;
+  if (!sig || !random || !verifySignature(req.body, random, sig)) { res.status(401).send("Invalid signature"); return; }
   res.status(200).send("OK");
 
   const p = JSON.parse(req.body.toString());
@@ -146,7 +147,7 @@ Base: `https://cloud.example.com/ocs/v2.php/apps/spreed/api/` · Auth: `Basic bo
 |--------|--------|------|
 | List conversations | GET | `v4/room` |
 | Send message | POST | `v1/chat/TOKEN` · body: `{"message":"..."}` |
-| Get messages | GET | `v1/chat/TOKEN?lookIntoFuture=0&limit=50` |
+| Get messages without read/status side effects | GET | `v1/chat/TOKEN?lookIntoFuture=0&limit=50&setReadMarker=0&noStatusUpdate=1&markNotificationsAsRead=0` |
 | Send reaction | POST | `v1/reaction/TOKEN/MESSAGE_ID` · body: `{"reaction":"👍"}` |
 
 Talk supports markdown: `**bold**`, `` `code` ``, headings, lists.
@@ -167,7 +168,7 @@ Better theoretical privacy: SimpleX (no user identifiers) and Signal (E2E everyt
 
 **Compliance**: GDPR (full control), HIPAA/SOC2/ISO 27001 configurable. Jurisdiction = where you host — no CLOUD Act/FISA 702 unless US-hosted. AGPL-3.0 — fully auditable.
 
-**Bot security**: webhook can be localhost/LAN/tunneled (no public internet required) · HMAC-SHA256 prevents forged deliveries · app password is scoped/revocable · handler+logs never leave your infrastructure.
+**Bot security**: webhook can be localhost/LAN/tunneled (no public internet required) · verify the backend header and HMAC-SHA256 over the random header plus raw body · app passwords are revocable account credentials, not endpoint-scoped API grants · room membership and explicit allowlists provide the collector boundary.
 
 ## aidevops Integration
 

--- a/.agents/tests/fixtures/knowledge-social-nextcloud-talk/messages-first.json
+++ b/.agents/tests/fixtures/knowledge-social-nextcloud-talk/messages-first.json
@@ -1,0 +1,63 @@
+{
+  "identity": {
+    "data": {
+      "id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_user_111111111111111111111111",
+      "provider_account_id": "111111111111111111111111",
+      "display_name": "Fixture Account",
+      "instance_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+      "room_ids": [
+        "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_222222222222222222222222",
+        "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_333333333333333333333333"
+      ],
+      "server_version": "32.0.8",
+      "talk_version": "22.0.4",
+      "features": ["chat-v2", "conversation-v4", "edit-messages", "federation-v1", "reactions", "talk-polls"]
+    }
+  },
+  "pages": [
+    {
+      "expect_request": {
+        "stream": "messages",
+        "room_index": 0,
+        "room_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_222222222222222222222222",
+        "position": 0,
+        "stop_at": null,
+        "limit": 2
+      },
+      "response": {
+        "status": 200,
+        "observed_at": "2026-07-31T12:00:00Z",
+        "data": [
+          {
+            "kind": "message",
+            "remote_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_message_444444444444444444444444",
+            "room_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_222222222222222222222222",
+            "actor_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_user_111111111111111111111111",
+            "text": "Bounded fixture knowledge",
+            "created_at": "2026-07-31T11:59:00Z",
+            "message_type": "comment",
+            "system_message": "",
+            "parent_id": null,
+            "deleted": false,
+            "edited_at": "2026-07-31T11:59:30Z",
+            "expiration_at": null,
+            "reactions": {"ack": 2},
+            "mentions": [{"kind": "user", "remote_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_user_555555555555555555555555"}],
+            "attachments": [{"remote_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_attachment_666666666666666666666666", "mime_type": "text/plain", "byte_size": 12, "hydration_state": "metadata"}],
+            "markdown": true
+          }
+        ],
+        "meta": {
+          "stream": "messages",
+          "instance_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+          "room_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_222222222222222222222222",
+          "next_room_index": 0,
+          "next_position": 90,
+          "newest_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_message_444444444444444444444444",
+          "reached_watermark": false,
+          "complete": false
+        }
+      }
+    }
+  ]
+}

--- a/.agents/tests/fixtures/knowledge-social-nextcloud-talk/messages-resume.json
+++ b/.agents/tests/fixtures/knowledge-social-nextcloud-talk/messages-resume.json
@@ -1,0 +1,121 @@
+{
+  "identity": {
+    "data": {
+      "id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_user_111111111111111111111111",
+      "provider_account_id": "111111111111111111111111",
+      "instance_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+      "room_ids": [
+        "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_222222222222222222222222",
+        "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_333333333333333333333333"
+      ],
+      "server_version": "32.0.8",
+      "talk_version": "22.0.4",
+      "features": ["chat-v2", "conversation-v4", "edit-messages", "federation-v1", "reactions", "talk-polls"]
+    }
+  },
+  "pages": [
+    {
+      "expect_request": {
+        "stream": "messages",
+        "room_index": 0,
+        "position": 90,
+        "stop_at": null
+      },
+      "response": {
+        "status": 200,
+        "observed_at": "2026-07-31T12:01:00Z",
+        "data": [
+          {
+            "kind": "message",
+            "remote_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_message_777777777777777777777777",
+            "room_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_222222222222222222222222",
+            "actor_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_user_888888888888888888888888",
+            "text": "Message deleted before the next observation",
+            "created_at": "2026-07-30T11:00:00Z",
+            "message_type": "comment_deleted",
+            "system_message": "message_deleted",
+            "parent_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_message_999999999999999999999999",
+            "deleted": true,
+            "edited_at": null,
+            "expiration_at": null,
+            "reactions": {},
+            "mentions": [],
+            "attachments": [],
+            "markdown": false
+          }
+        ],
+        "meta": {
+          "stream": "messages",
+          "instance_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+          "room_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_222222222222222222222222",
+          "next_room_index": 1,
+          "next_position": 0,
+          "newest_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_message_777777777777777777777777",
+          "reached_watermark": false,
+          "complete": false
+        }
+      }
+    },
+    {
+      "expect_request": {
+        "stream": "messages",
+        "room_index": 1,
+        "room_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_333333333333333333333333",
+        "position": 0,
+        "stop_at": null
+      },
+      "response": {
+        "status": 200,
+        "observed_at": "2026-07-31T12:02:00Z",
+        "data": [
+          {
+            "kind": "message",
+            "remote_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_message_aaaaaaaaaaaaaaaaaaaaaaab",
+            "room_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_333333333333333333333333",
+            "actor_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_federated_user_bbbbbbbbbbbbbbbbbbbbbbbb",
+            "text": "Call ended with a retained summary",
+            "created_at": "2026-07-31T11:00:00Z",
+            "message_type": "system",
+            "system_message": "call_ended",
+            "parent_id": null,
+            "deleted": false,
+            "edited_at": null,
+            "expiration_at": null,
+            "reactions": {},
+            "mentions": [],
+            "attachments": [],
+            "markdown": false
+          },
+          {
+            "kind": "message",
+            "remote_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_message_cccccccccccccccccccccccc",
+            "room_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_333333333333333333333333",
+            "actor_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_guest_dddddddddddddddddddddddd",
+            "text": "Poll object shared",
+            "created_at": "2026-07-31T10:00:00Z",
+            "message_type": "system",
+            "system_message": "object_shared",
+            "parent_id": null,
+            "deleted": false,
+            "edited_at": null,
+            "expiration_at": null,
+            "reactions": {},
+            "mentions": [{"kind": "call", "remote_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_call_eeeeeeeeeeeeeeeeeeeeeeee"}],
+            "attachments": [],
+            "markdown": false
+          }
+        ],
+        "meta": {
+          "stream": "messages",
+          "instance_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+          "room_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_333333333333333333333333",
+          "next_room_index": 2,
+          "next_position": 0,
+          "newest_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_message_aaaaaaaaaaaaaaaaaaaaaaab",
+          "reached_watermark": false,
+          "complete": true
+        }
+      }
+    }
+  ]
+}

--- a/.agents/tests/fixtures/knowledge-social-nextcloud-talk/participants.json
+++ b/.agents/tests/fixtures/knowledge-social-nextcloud-talk/participants.json
@@ -1,0 +1,89 @@
+{
+  "identity": {
+    "data": {
+      "id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_user_111111111111111111111111",
+      "provider_account_id": "111111111111111111111111",
+      "instance_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+      "room_ids": [
+        "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_222222222222222222222222",
+        "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_333333333333333333333333"
+      ],
+      "server_version": "32.0.8",
+      "talk_version": "22.0.4",
+      "features": ["chat-v2", "conversation-v4", "federation-v1"]
+    }
+  },
+  "pages": [
+    {
+      "expect_request": {"stream": "participants", "room_index": 0, "position": 0},
+      "response": {
+        "status": 200,
+        "observed_at": "2026-07-31T12:03:30Z",
+        "data": [
+          {
+            "kind": "participant",
+            "remote_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_participant_111111111111111111111111",
+            "room_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_222222222222222222222222",
+            "actor_type": "users",
+            "participant_type": 3,
+            "permissions": 254,
+            "in_call": 0,
+            "federated": false,
+            "guest": false
+          },
+          {
+            "kind": "participant",
+            "remote_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_participant_222222222222222222222222",
+            "room_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_222222222222222222222222",
+            "actor_type": "guests",
+            "participant_type": 4,
+            "permissions": 118,
+            "in_call": 0,
+            "federated": false,
+            "guest": true
+          }
+        ],
+        "meta": {
+          "stream": "participants",
+          "instance_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+          "room_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_222222222222222222222222",
+          "next_room_index": 1,
+          "next_position": 0,
+          "newest_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_participant_111111111111111111111111",
+          "reached_watermark": false,
+          "complete": false
+        }
+      }
+    },
+    {
+      "expect_request": {"stream": "participants", "room_index": 1, "position": 0},
+      "response": {
+        "status": 200,
+        "observed_at": "2026-07-31T12:03:31Z",
+        "data": [
+          {
+            "kind": "participant",
+            "remote_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_participant_333333333333333333333333",
+            "room_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_333333333333333333333333",
+            "actor_type": "federated_users",
+            "participant_type": 3,
+            "permissions": 118,
+            "in_call": 0,
+            "federated": true,
+            "guest": false
+          }
+        ],
+        "meta": {
+          "stream": "participants",
+          "instance_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+          "room_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_333333333333333333333333",
+          "next_room_index": 2,
+          "next_position": 0,
+          "newest_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_participant_333333333333333333333333",
+          "reached_watermark": false,
+          "complete": true
+        }
+      }
+    }
+  ]
+}

--- a/.agents/tests/fixtures/knowledge-social-nextcloud-talk/rooms-talk21.json
+++ b/.agents/tests/fixtures/knowledge-social-nextcloud-talk/rooms-talk21.json
@@ -1,0 +1,47 @@
+{
+  "identity": {
+    "data": {
+      "id": "nct_bbbbbbbbbbbbbbbbbbbbbbbb_user_111111111111111111111111",
+      "provider_account_id": "111111111111111111111111",
+      "instance_id": "bbbbbbbbbbbbbbbbbbbbbbbb",
+      "room_ids": ["nct_bbbbbbbbbbbbbbbbbbbbbbbb_room_222222222222222222222222"],
+      "server_version": "31.0.9",
+      "talk_version": "21.1.2",
+      "features": ["chat-v2", "conversation-v4", "federation-v1", "reactions"]
+    }
+  },
+  "pages": [
+    {
+      "expect_request": {"stream": "rooms", "room_id": null, "position": 0},
+      "response": {
+        "status": 200,
+        "observed_at": "2026-07-31T12:03:00Z",
+        "data": [
+          {
+            "kind": "conversation",
+            "remote_id": "nct_bbbbbbbbbbbbbbbbbbbbbbbb_room_222222222222222222222222",
+            "name": "Synthetic room",
+            "room_type": 2,
+            "participant_type": 3,
+            "read_only": 0,
+            "message_expiration": 0,
+            "last_activity": "2026-07-31T12:00:00Z",
+            "has_call": false,
+            "unread_messages": 0,
+            "federated": false
+          }
+        ],
+        "meta": {
+          "stream": "rooms",
+          "instance_id": "bbbbbbbbbbbbbbbbbbbbbbbb",
+          "room_id": null,
+          "next_room_index": 0,
+          "next_position": 0,
+          "newest_id": "nct_bbbbbbbbbbbbbbbbbbbbbbbb_room_222222222222222222222222",
+          "reached_watermark": false,
+          "complete": true
+        }
+      }
+    }
+  ]
+}

--- a/.agents/tests/test-knowledge-social-nextcloud-talk.sh
+++ b/.agents/tests/test-knowledge-social-nextcloud-talk.sh
@@ -1,0 +1,409 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-nextcloud-talk.sh — Nextcloud Talk collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="${SCRIPT_DIR}/../scripts"
+COLLECTOR="${SCRIPTS}/knowledge_social_nextcloud_talk.py"
+CORPUS_HELPER="${SCRIPTS}/knowledge-corpus-helper.sh"
+SOCIAL_HELPER="${SCRIPTS}/knowledge-social-helper.sh"
+FIXTURES="${SCRIPT_DIR}/fixtures/knowledge-social-nextcloud-talk"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' \
+			"$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c \
+		'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+collect() {
+	local connection_id="$1"
+	local stream="$2"
+	local fixture="$3"
+	local result=0
+	shift 3
+	python3 "$COLLECTOR" --base "$BASE" --alias personal:default \
+		--connection-id "$connection_id" --account-id user_fixture \
+		--stream "$stream" --profile fixture --fixture "$fixture" "$@" || result=$?
+	return "$result"
+}
+
+expect_failure() {
+	local description="$1"
+	local connection_id="$2"
+	local stream="$3"
+	local fixture="$4"
+	if collect "$connection_id" "$stream" "$fixture" >/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$SOCIAL_HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'Nextcloud Talk social collector tests\n'
+
+help_output=$(python3 "$COLLECTOR" --help)
+if [[ "$help_output" == *"{capabilities,rooms,participants,messages}"* &&
+	"$help_output" == *"--page-size PAGE_SIZE"* ]]; then
+	assert_eq "provider CLI exposes only reviewed streams" reviewed reviewed
+else
+	assert_eq "provider CLI exposes only reviewed streams" missing reviewed
+fi
+
+python3 - "$SCRIPTS" <<'PY'
+import ast
+import hashlib
+import hmac
+import json
+import os
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+
+from _knowledge_social_nextcloud_talk import (
+    CursorState,
+    STREAMS,
+    namespaced_id,
+    page_request,
+    private_fingerprint,
+)
+from _knowledge_social_nextcloud_talk_files import validate_attachment_bytes
+from _knowledge_social_nextcloud_talk_http import (
+    HTTP_TIMEOUT_SECONDS,
+    ProfileConfig,
+    api,
+    canonical_base_url,
+    installation_fingerprint,
+)
+from _knowledge_social_nextcloud_talk_provider import _profile
+from _knowledge_social_nextcloud_talk_webhook import verify_and_normalize_webhook
+
+assert set(STREAMS) == {"capabilities", "rooms", "participants", "messages"}
+origin = "o" * 32
+base_a = canonical_base_url("https://cloud-a.example.invalid/nextcloud/")
+base_b = canonical_base_url("https://cloud-b.example.invalid/nextcloud")
+instance_a = installation_fingerprint(base_a, origin)
+instance_b = installation_fingerprint(base_b, origin)
+assert instance_a != instance_b
+assert namespaced_id(instance_a, "message", "42") != namespaced_id(
+    instance_b, "message", "42"
+)
+for invalid in (
+    "http://cloud.example.invalid",
+    "https://user@cloud.example.invalid",
+    "https://cloud.example.invalid/%2e%2e/admin",
+):
+    try:
+        canonical_base_url(invalid)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("unsafe Nextcloud base URL was accepted")
+
+os.environ.update(
+    {
+        "NEXTCLOUD_TALK_SCOPE_BASE_URL": base_a,
+        "NEXTCLOUD_TALK_SCOPE_USERNAME": "fixture-user",
+        "NEXTCLOUD_TALK_SCOPE_APP_PASSWORD": "TEST_ONLY_NOT_A_SECRET",
+        "NEXTCLOUD_TALK_SCOPE_ORIGIN_KEY": origin,
+        "NEXTCLOUD_TALK_SCOPE_ALLOWED_ROOMS": "abcd1234,efgh5678",
+        "NEXTCLOUD_TALK_SCOPE_EXPECTED_SERVER_MAJOR": "32",
+        "NEXTCLOUD_TALK_SCOPE_EXPECTED_TALK_MAJOR": "22",
+    }
+)
+profile = _profile("scope")
+assert profile.allowed_rooms == ("abcd1234", "efgh5678")
+
+
+class Response:
+    status = 200
+    headers = {}
+
+    def __init__(self, payload):
+        self.payload = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def read(self, size=-1):
+        return self.payload[:size]
+
+
+class Opener:
+    def __init__(self):
+        self.requests = []
+
+    def open(self, request, timeout):
+        assert timeout == HTTP_TIMEOUT_SECONDS
+        assert request.method == "GET"
+        assert "TEST_ONLY_NOT_A_SECRET" not in request.full_url
+        self.requests.append(request)
+        return Response({"ocs": {"meta": {"statuscode": 100}, "data": {"id": "fixture-user"}}})
+
+
+opener = Opener()
+assert api(profile, opener, "/ocs/v2.php/cloud/user", {}).status == 200
+try:
+    api(profile, opener, "/ocs/v2.php/apps/spreed/api/v1/bot/abcd1234/message", {})
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("Nextcloud Talk bot mutation route was reachable")
+
+account = {
+    "id": namespaced_id(instance_a, "user", "selected"),
+    "provider_account_id": "1" * 24,
+    "instance_id": instance_a,
+    "room_ids": [namespaced_id(instance_a, "room", "one"), namespaced_id(instance_a, "room", "two")],
+}
+request = page_request("messages", account, CursorState(None, None, False), 50)
+assert request.room_index == 0 and request.position == 0
+
+content = b"fixture bytes"
+digest = hashlib.sha256(content).hexdigest()
+verified = validate_attachment_bytes(
+    content,
+    expected_sha256=digest,
+    expected_size=len(content),
+    mime_type="text/plain",
+    max_bytes=1024,
+    allowed_mime_types=frozenset({"text/plain"}),
+)
+assert verified.content_sha256 == digest
+
+token = "abcd1234"
+room = (
+    f"nct_{instance_a}_room_"
+    f"{private_fingerprint(origin, instance_a, 'room', token)}"
+)
+body = json.dumps(
+    {
+        "type": "Create",
+        "actor": {"type": "Person", "id": "users/fixture-user"},
+        "object": {"type": "Note", "id": "42", "name": "message"},
+        "target": {"type": "Collection", "id": token},
+    },
+    separators=(",", ":"),
+).encode()
+random_value = "R" * 64
+secret = "s" * 32
+signature = hmac.new(secret.encode(), random_value.encode() + body, hashlib.sha256).hexdigest()
+event = verify_and_normalize_webhook(
+    body,
+    {
+        "X-Nextcloud-Talk-Random": random_value,
+        "X-Nextcloud-Talk-Signature": signature,
+        "X-Nextcloud-Talk-Backend": base_a,
+    },
+    secret=secret,
+    expected_backend=base_a,
+    origin_key=origin,
+    installation=instance_a,
+    allowed_rooms={token: room},
+)
+assert event["room_id"] == room and event["requires_ocs_reconciliation"] is True
+try:
+    verify_and_normalize_webhook(
+        body,
+        {
+            "X-Nextcloud-Talk-Random": random_value,
+            "X-Nextcloud-Talk-Signature": "0" * 64,
+            "X-Nextcloud-Talk-Backend": base_a,
+        },
+        secret=secret,
+        expected_backend=base_a,
+        origin_key=origin,
+        installation=instance_a,
+        allowed_rooms={token: room},
+    )
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("invalid Talk webhook signature was accepted")
+
+sources = [
+    path.read_text(encoding="utf-8")
+    for path in sorted(scripts.glob("_knowledge_social_nextcloud_talk*.py"))
+]
+trees = [ast.parse(source) for source in sources]
+request_calls = [
+    node
+    for tree in trees
+    for node in ast.walk(tree)
+    if isinstance(node, ast.Call)
+    and isinstance(node.func, ast.Name)
+    and node.func.id == "Request"
+]
+assert request_calls
+for node in request_calls:
+    methods = [
+        keyword.value.value
+        for keyword in node.keywords
+        if keyword.arg == "method" and isinstance(keyword.value, ast.Constant)
+    ]
+    assert methods == ["GET"]
+assert all("_knowledge_social_outbound" not in source for source in sources)
+PY
+assert_eq "versions, origins, GET-only routes, webhooks, and file budgets are guarded" \
+	verified verified
+
+first_result=$(collect conn_a messages "$FIXTURES/messages-first.json" --budget 4 --page-size 2)
+assert_eq "one bounded OCS page pauses the initial history backfill" \
+	"$(json_field "$first_result" status)" budget_exhausted
+assert_eq "page evidence and room cursor commit atomically" \
+	"$(sql_value "SELECT count(*) || ':' || (SELECT backfill_complete FROM sync_cursors WHERE connection_id='conn_a' AND stream='messages') FROM fetch_batches WHERE connection_id='conn_a'")" \
+	"1:0"
+assert_eq "message text reaches canonical full-text search" \
+	"$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'bounded'")" 1
+assert_eq "edit and reaction observations become canonical activities" \
+	"$(sql_value "SELECT count(*) FROM activities WHERE provider='nextcloud_talk' AND activity_type IN ('message_edited','reaction_summary')")" 2
+assert_eq "message-linked attachment metadata is bounded and non-hydrated" \
+	"$(sql_value "SELECT count(*) || ':' || min(hydration_state) FROM media WHERE provider='nextcloud_talk'")" \
+	"1:metadata"
+
+resume_result=$(collect conn_a messages "$FIXTURES/messages-resume.json" --budget 7 --page-size 2)
+assert_eq "history resumes at the exact room cursor and completes both rooms" \
+	"$(json_field "$resume_result" status)" complete
+assert_eq "completed history keeps one independent watermark per room" \
+	"$(sql_value "SELECT backfill_complete || ':' || (watermark IS NOT NULL) FROM sync_cursors WHERE connection_id='conn_a' AND stream='messages'")" \
+	"1:1"
+assert_eq "replies, call summaries, poll observations, and federated actors persist" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='nextcloud_talk' AND object_type='message'")" 4
+assert_eq "message deletion observations remain explicit canonical activities" \
+	"$(sql_value "SELECT count(*) FROM activities WHERE provider='nextcloud_talk' AND activity_type='message_deleted'")" 1
+assert_eq "retention, encryption, reaction, poll, call, file, and webhook gaps remain explicit" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE connection_id='conn_a' AND status='unavailable'")" 8
+
+collect conn_b rooms "$FIXTURES/rooms-talk21.json" --budget 4 --page-size 50 >/dev/null
+assert_eq "Talk 21 and Talk 22 fixture connections coexist without ID collision" \
+	"$(sql_value "SELECT count(DISTINCT remote_id) FROM accounts WHERE provider='nextcloud_talk'")" 2
+assert_eq "allowlisted room metadata remains instance scoped" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='nextcloud_talk' AND object_type='conversation'")" 1
+collect conn_participants participants "$FIXTURES/participants.json" --budget 7 --page-size 50 >/dev/null
+assert_eq "user, guest, and federated participant snapshots import per room" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='nextcloud_talk' AND object_type='participant'")" 3
+expect_failure "cross-instance connection rebinding is rejected" \
+	conn_a rooms "$FIXTURES/rooms-talk21.json"
+
+python3 - "$TMP_DIR/terminal.json" <<'PY'
+import json
+import sys
+
+payload = {
+    "identity": {"data": {
+        "id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_user_111111111111111111111111",
+        "provider_account_id": "111111111111111111111111",
+        "instance_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+        "room_ids": ["nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_222222222222222222222222"],
+        "server_version": "32.0.8",
+        "talk_version": "22.0.4",
+        "features": ["chat-v2", "conversation-v4"],
+    }},
+    "pages": [{"status": 403, "observed_at": "2026-07-31T12:04:00Z"}],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+terminal_result=$(collect conn_terminal participants "$TMP_DIR/terminal.json")
+assert_eq "lost room authority is a terminal authorization result" \
+	"$(json_field "$terminal_result" failure_class)" authorization
+assert_eq "terminal authority failure advances no checkpoint" \
+	"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_terminal'")" 0
+
+python3 - "$TMP_DIR/credential.json" <<'PY'
+import json
+import sys
+
+payload = {
+    "identity": {"data": {
+        "id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_user_111111111111111111111111",
+        "provider_account_id": "111111111111111111111111",
+        "instance_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+        "room_ids": ["nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_222222222222222222222222"],
+        "server_version": "32.0.8",
+        "talk_version": "22.0.4",
+        "features": ["chat-v2", "conversation-v4"],
+    }},
+    "pages": [{
+        "status": 200,
+        "observed_at": "2026-07-31T12:05:00Z",
+        "app_password": "MUST_NOT_PERSIST",
+        "data": [],
+        "meta": {
+            "stream": "participants",
+            "instance_id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+            "room_id": "nct_aaaaaaaaaaaaaaaaaaaaaaaa_room_222222222222222222222222",
+            "next_room_index": 1,
+            "next_position": 0,
+            "newest_id": None,
+            "reached_watermark": False,
+            "complete": True,
+        },
+    }],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+expect_failure "credential-shaped OCS evidence is rejected before persistence" \
+	conn_credential participants "$TMP_DIR/credential.json"
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add provider-specific multi-instance Nextcloud Talk ingestion with version, account, and room identity fences; bounded OCS history and participant collection; optional verified webhooks; attachment budgets; canonical normalization; fixtures; and honest coverage gaps.

## Files Changed

.agents/content/social-nextcloud-talk.md, .agents/scripts/_knowledge_social_nextcloud_talk.py, .agents/scripts/_knowledge_social_nextcloud_talk_contract.py, .agents/scripts/_knowledge_social_nextcloud_talk_files.py, .agents/scripts/_knowledge_social_nextcloud_talk_http.py, .agents/scripts/_knowledge_social_nextcloud_talk_normalize.py, .agents/scripts/_knowledge_social_nextcloud_talk_provider.py, .agents/scripts/_knowledge_social_nextcloud_talk_reader.py, .agents/scripts/_knowledge_social_nextcloud_talk_routes.py, .agents/scripts/_knowledge_social_nextcloud_talk_webhook.py, .agents/scripts/knowledge_social_nextcloud_talk.py, .agents/services/communications/nextcloud-talk.md, .agents/tests/fixtures/knowledge-social-nextcloud-talk/messages-first.json, .agents/tests/fixtures/knowledge-social-nextcloud-talk/messages-resume.json, .agents/tests/fixtures/knowledge-social-nextcloud-talk/participants.json, .agents/tests/fixtures/knowledge-social-nextcloud-talk/rooms-talk21.json, .agents/tests/test-knowledge-social-nextcloud-talk.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified with bash .agents/tests/test-knowledge-social-nextcloud-talk.sh (19 assertions), python3 -m compileall -q .agents/scripts, and shellcheck .agents/tests/test-knowledge-social-nextcloud-talk.sh.

Resolves #28786


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.201 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 34m and 260,968 tokens on this as a headless worker.