### PR TITLE
GH#29060: Optimize release tag discovery

### DIFF
--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -37,10 +37,50 @@ _full_loop_release_verify_tag_provenance() {
 	return $?
 }
 
+_full_loop_release_candidate_tags_for_pr() {
+	local requested_pr="$1"
+	local ref_format='%(refname:short)%1f'
+	local trailer_index=""
+	local legacy_source_merges=""
+	local legacy_source_lookup=""
+	local candidate_tag=""
+	local source_prs=""
+	local source_merge=""
+	local aggregated_sources=""
+	local direct_marker=",${requested_pr},"
+	local aggregate_marker=",${requested_pr}@"
+	local legacy_source_marker=""
+
+	[[ "$requested_pr" =~ ^[0-9]+$ ]] || return 1
+	ref_format+='%(trailers:key=Aidevops-Source-PR,valueonly,separator=%x2C)%1f'
+	ref_format+='%(trailers:key=Aidevops-Source-Merge,valueonly,separator=%x2C)%1f'
+	ref_format+='%(trailers:key=Aidevops-Aggregated-Source,valueonly,separator=%x2C)'
+	trailer_index=$(git -C "$REPO_ROOT" for-each-ref --sort=-version:refname \
+		--format="$ref_format" 'refs/tags/v[0-9]*.[0-9]*.[0-9]*') || return 1
+	legacy_source_merges=$(git -C "$REPO_ROOT" log --all --fixed-strings \
+		--grep="Aidevops-Release-Aggregates: ${requested_pr}@" --format='%H') || return 1
+	legacy_source_lookup=",${legacy_source_merges//$'\n'/,},"
+
+	while IFS=$'\x1f' read -r candidate_tag source_prs source_merge aggregated_sources; do
+		[[ -n "$candidate_tag" ]] || continue
+		if [[ ",${source_prs}," == *"$direct_marker"* ]] ||
+			[[ ",${aggregated_sources}," == *"$aggregate_marker"* ]]; then
+			printf '%s\n' "$candidate_tag"
+			continue
+		fi
+		legacy_source_marker=",${source_merge},"
+		if [[ -n "$source_merge" && "$legacy_source_lookup" == *"$legacy_source_marker"* ]]; then
+			printf '%s\n' "$candidate_tag"
+		fi
+	done <<<"$trailer_index"
+	return 0
+}
+
 _full_loop_release_find_tag_for_pr() {
 	local repo="$1"
 	local requested_pr="$2"
 	local candidate_tag=""
+	local candidate_tags=""
 	local tag_body=""
 	local trailer=""
 	local source_json=""
@@ -49,6 +89,7 @@ _full_loop_release_find_tag_for_pr() {
 
 	_FULL_LOOP_RELEASE_FOUND_TAG=""
 	git -C "$REPO_ROOT" fetch origin --tags --quiet || return 1
+	candidate_tags=$(_full_loop_release_candidate_tags_for_pr "$requested_pr") || return 1
 	while IFS= read -r candidate_tag; do
 		[[ -n "$candidate_tag" ]] || continue
 		tag_body=$(_full_loop_release_tag_body "$candidate_tag") || return 1
@@ -74,7 +115,7 @@ _full_loop_release_find_tag_for_pr() {
 		_full_loop_release_verify_tag_provenance "$repo" "$candidate_tag" || return 1
 		_FULL_LOOP_RELEASE_FOUND_TAG="$candidate_tag"
 		return 0
-	done < <(git -C "$REPO_ROOT" tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname)
+	done <<<"$candidate_tags"
 	return 2
 }
 
@@ -287,7 +328,8 @@ _full_loop_release_verify_npm_provenance() {
 
 	audit_dir=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-npm-provenance.XXXXXX") || return 1
 	if ! (
-		trap 'command rm -rf -- "$audit_dir"' EXIT
+		_FULL_LOOP_RELEASE_AUDIT_DIR="$audit_dir"
+		trap 'command rm -rf -- "$_FULL_LOOP_RELEASE_AUDIT_DIR"' EXIT
 		npm install --prefix "$audit_dir" --ignore-scripts --no-audit --no-fund --save-exact \
 			"aidevops@${version}" >/dev/null 2>&1 || exit 1
 		audit_json=$(npm --prefix "$audit_dir" audit signatures \

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -85,7 +85,12 @@ legacy_found_tag_file="${TEST_ROOT}/legacy-found-tag.txt"
 		local args="$*"
 		case "$args" in
 		*" fetch origin --tags --quiet"*) return 0 ;;
-		*" tag --list "*) printf 'v1.2.4\n' ;;
+		*" for-each-ref "*)
+			printf 'v1.2.4\x1f90\x1f1111111111111111111111111111111111111111\x1f\n'
+			;;
+		*" log --all --fixed-strings "*)
+			printf '1111111111111111111111111111111111111111\n'
+			;;
 		*) return 1 ;;
 		esac
 		return 0
@@ -126,6 +131,80 @@ if [[ "$legacy_found_tag" != "v1.2.4" ]]; then
 	exit 1
 fi
 printf 'PASS included source PR discovers its transitively bound release tag\n'
+
+candidate_tags_file="${TEST_ROOT}/candidate-tags.txt"
+(
+	git() {
+		local args="$*"
+		case "$args" in
+		*" for-each-ref "*)
+			printf '%b\n' \
+				'v2.0.0\x1f890\x1faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\x1f' \
+				'v1.9.0\x1f89\x1fbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\x1f' \
+				'v1.8.0\x1f90\x1fcccccccccccccccccccccccccccccccccccccccc\x1f890@dddddddddddddddddddddddddddddddddddddddd' \
+				'v1.7.0\x1f90\x1feeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\x1f89@ffffffffffffffffffffffffffffffffffffffff'
+			;;
+		*" log --all --fixed-strings "*) return 0 ;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
+	_full_loop_release_candidate_tags_for_pr 89
+) >"$candidate_tags_file"
+candidate_tags=$(<"$candidate_tags_file")
+if [[ "$candidate_tags" != $'v1.9.0\nv1.7.0' ]]; then
+	printf 'FAIL one-pass trailer index did not preserve exact newest-first candidates\n'
+	exit 1
+fi
+printf 'PASS one-pass trailer index preserves exact newest-first candidates\n'
+
+if (
+	git() {
+		local args="$*"
+		case "$args" in
+		*" for-each-ref "*) return 1 ;;
+		*" log --all --fixed-strings "*) return 0 ;;
+		esac
+		return 1
+	}
+	_full_loop_release_candidate_tags_for_pr 89
+); then
+	printf 'FAIL tag enumeration failure was treated as an empty candidate set\n'
+	exit 1
+fi
+printf 'PASS tag enumeration failure remains fail closed\n'
+
+if (
+	git() {
+		local args="$*"
+		case "$args" in
+		*" fetch origin --tags --quiet"*) return 0 ;;
+		*" for-each-ref "*)
+			printf 'v1.2.5\x1f90\x1f1111111111111111111111111111111111111111\x1f89@2222222222222222222222222222222222222222\n'
+			;;
+		*" log --all --fixed-strings "*) return 0 ;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
+	_full_loop_release_tag_body() {
+		local tag_name="$1"
+		[[ "$tag_name" == "v1.2.5" ]] || return 1
+		printf '%s\n' 'Aidevops-Aggregated-Source: 89@2222222222222222222222222222222222222222'
+		return 0
+	}
+	_full_loop_release_source_json_from_tag() {
+		local tag_name="$1"
+		[[ "$tag_name" == "v1.2.5" ]] || return 1
+		printf '%s\n' '{"source_pr":90,"source_merge":"1111111111111111111111111111111111111111","aggregated_sources":[]}'
+		return 0
+	}
+	_full_loop_release_find_tag_for_pr test/repo 89
+); then
+	printf 'FAIL textual and reconstructed provenance disagreement was accepted\n'
+	exit 1
+fi
+printf 'PASS textual and reconstructed provenance disagreement remains fail closed\n'
 
 mkdir -p "${TEST_ROOT}/worktrees" "${TEST_ROOT}/tag-checkout" \
 	"${TEST_ROOT}/runtime" "${TEST_ROOT}/tag-checkout/.agents/scripts"
@@ -463,10 +542,15 @@ set_fake_provenance_payload "https://github.com/test/repo" "refs/heads/main"
 printf 'PASS npm package integrity and signed workflow provenance are bound exactly\n'
 printf 'PASS recovery accepts immutable npm provenance from tag or main publication\n'
 
-channel_output=$(_full_loop_release_verify_channels test/repo v1.2.3) || {
+channel_error_file="${TEST_ROOT}/channel-errors.txt"
+channel_output=$(_full_loop_release_verify_channels test/repo v1.2.3 2>"$channel_error_file") || {
 	printf 'FAIL exact published channels did not converge\n'
 	exit 1
 }
+if [[ -s "$channel_error_file" ]]; then
+	printf 'FAIL published channel verification emitted cleanup errors\n'
+	exit 1
+fi
 if [[ "$channel_output" != *"HOMEBREW_SHA256=${FAKE_FORMULA_SHA}"* ]]; then
 	printf 'FAIL channel verification omitted the exact Homebrew digest\n'
 	exit 1


### PR DESCRIPTION
## Summary

Replace the 3,050-tag subprocess loop with a newest-first one-pass trailer index while preserving legacy source-manifest recovery and fail-closed provenance verification. Harden npm audit cleanup for Bash 3.2 after the required compatibility run exposed an unbound EXIT-trap variable.

## Files Changed

.agents/scripts/full-loop-release-reconcile.sh, .agents/scripts/tests/test-full-loop-release-reconcile.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — /bin/bash .agents/scripts/tests/test-full-loop-release-reconcile.sh; shellcheck .agents/scripts/full-loop-release-reconcile.sh .agents/scripts/tests/test-full-loop-release-reconcile.sh; .agents/scripts/linters-local.sh --changed; real 3,050-tag for-each-ref index completed in 0.25s

Resolves #29060


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.201 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 4h 10m and 2,500,709 tokens on this with the user in an interactive session.