### PR TITLE
t18189: Route standard tier through Luna max reasoning

### DIFF
--- a/.agents/configs/aidevops.defaults.jsonc
+++ b/.agents/configs/aidevops.defaults.jsonc
@@ -249,8 +249,8 @@
         "reasoning": { "openai": "medium" }
       },
       "standard": {
-        "models": ["openai/gpt-5.6-sol", "anthropic/claude-sonnet-4-6"],
-        "reasoning": { "openai": "medium" }
+        "models": ["openai/gpt-5.6-luna", "anthropic/claude-sonnet-4-6"],
+        "reasoning": { "openai": "max" }
       },
       "thinking": {
         "models": ["openai/gpt-5.6-sol", "anthropic/claude-opus-4-6"],
@@ -280,9 +280,9 @@
     // Fallback chain configuration for model-level failover.
     "fallback_chains": {
       "simple":   ["openai/gpt-5.6-terra", "anthropic/claude-haiku-4-5"],
-      "standard": ["openai/gpt-5.6-sol", "anthropic/claude-sonnet-4-6"],
+      "standard": ["openai/gpt-5.6-luna", "anthropic/claude-sonnet-4-6"],
       "thinking": ["openai/gpt-5.6-sol", "anthropic/claude-opus-4-6"],
-      "default":  ["openai/gpt-5.6-sol", "anthropic/claude-sonnet-4-6"]
+      "default":  ["openai/gpt-5.6-luna", "anthropic/claude-sonnet-4-6"]
     },
 
     // Fallback trigger configuration.

--- a/.agents/configs/model-routing-table.json
+++ b/.agents/configs/model-routing-table.json
@@ -10,8 +10,8 @@
       "reasoning": { "openai": "medium" }
     },
     "standard": {
-      "models": ["openai/gpt-5.6-sol", "zai-coding-plan/glm-5.2", "anthropic/claude-sonnet-4-6"],
-      "reasoning": { "openai": "medium" }
+      "models": ["openai/gpt-5.6-luna", "zai-coding-plan/glm-5.2", "anthropic/claude-sonnet-4-6"],
+      "reasoning": { "openai": "max" }
     },
     "thinking": {
       "models": ["openai/gpt-5.6-sol", "anthropic/claude-opus-4-6"],

--- a/.agents/scripts/ai-research-helper.sh
+++ b/.agents/scripts/ai-research-helper.sh
@@ -44,9 +44,21 @@ resolve_opencode_model_id() {
 	case "$name" in
 	simple) echo "openai/gpt-5.6-terra" ;;
 	local) echo "openai/gpt-5.4-mini" ;;
-	standard | thinking) echo "openai/gpt-5.6-sol" ;;
+	standard) echo "openai/gpt-5.6-luna" ;;
+	thinking) echo "openai/gpt-5.6-sol" ;;
 	openai/* | anthropic/* | google/*) echo "$name" ;;
 	*) echo "$name" ;;
+	esac
+	return 0
+}
+
+resolve_opencode_variant() {
+	local name="${1:-simple}"
+	case "$name" in
+	simple) echo "medium" ;;
+	standard) echo "max" ;;
+	thinking) echo "high" ;;
+	*) echo "" ;;
 	esac
 	return 0
 }
@@ -281,11 +293,16 @@ call_opencode() {
 		return 2
 	fi
 
-	local model_id raw text timeout_cmd wrapped_prompt
+	local model_id variant_id raw text timeout_cmd wrapped_prompt
+	local -a variant_args=()
 	local run_dir="${AIDEVOPS_AI_RESEARCH_OPENCODE_DIR:-/tmp/opencode}"
 	model_id="${AIDEVOPS_AI_RESEARCH_OPENCODE_MODEL:-}"
 	if [[ -z "$model_id" ]]; then
 		model_id=$(resolve_opencode_model_id "$model_name")
+	fi
+	variant_id=$(resolve_opencode_variant "$model_name")
+	if [[ -n "$variant_id" ]]; then
+		variant_args=(--variant "$variant_id")
 	fi
 	timeout_cmd=""
 	if command -v timeout &>/dev/null; then
@@ -297,12 +314,12 @@ call_opencode() {
 	wrapped_prompt="You are a non-interactive AI research helper. Do not use tools. Do not ask follow-up questions. Do not greet. Return only the requested answer text, with no preamble or markdown. Task:\n${prompt}"
 
 	if [[ -n "$timeout_cmd" ]]; then
-		raw=$(cd "$run_dir" && AIDEVOPS_HEADLESS=1 $timeout_cmd opencode run --format json -m "$model_id" "$wrapped_prompt" 2>&1) || {
+		raw=$(cd "$run_dir" && AIDEVOPS_HEADLESS=1 $timeout_cmd opencode run --format json -m "$model_id" "${variant_args[@]}" "$wrapped_prompt" 2>&1) || {
 			log_error "OpenCode AI research call failed"
 			return 1
 		}
 	else
-		raw=$(cd "$run_dir" && AIDEVOPS_HEADLESS=1 opencode run --format json -m "$model_id" "$wrapped_prompt" 2>&1) || {
+		raw=$(cd "$run_dir" && AIDEVOPS_HEADLESS=1 opencode run --format json -m "$model_id" "${variant_args[@]}" "$wrapped_prompt" 2>&1) || {
 			log_error "OpenCode AI research call failed"
 			return 1
 		}

--- a/.agents/scripts/fallback-chain-helper.sh
+++ b/.agents/scripts/fallback-chain-helper.sh
@@ -60,7 +60,7 @@ get_tier_models_from_table() {
 		# Hardcoded minimal fallback for missing tier definitions.
 		case "$tier" in
 		simple) echo '["openai/gpt-5.6-terra","anthropic/claude-haiku-4-5"]' ;;
-		standard) echo '["openai/gpt-5.6-sol","zai-coding-plan/glm-5.2","anthropic/claude-sonnet-4-6"]' ;;
+		standard) echo '["openai/gpt-5.6-luna","zai-coding-plan/glm-5.2","anthropic/claude-sonnet-4-6"]' ;;
 		thinking) echo '["openai/gpt-5.6-sol","anthropic/claude-opus-4-6"]' ;;
 		*)
 			print_error "Unknown tier: $tier"

--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -183,7 +183,7 @@ get_tier_models() {
 	# deliberately fails closed rather than sending local-only work to cloud.
 	case "$tier" in
 	simple) current_model=$'openai/gpt-5.6-terra\nanthropic/claude-haiku-4-5' ;;
-	standard) current_model=$'openai/gpt-5.6-sol\nzai-coding-plan/glm-5.2\nanthropic/claude-sonnet-4-6' ;;
+	standard) current_model=$'openai/gpt-5.6-luna\nzai-coding-plan/glm-5.2\nanthropic/claude-sonnet-4-6' ;;
 	thinking) current_model=$'openai/gpt-5.6-sol\nanthropic/claude-opus-4-6' ;;
 	*) return 1 ;;
 	esac
@@ -545,7 +545,6 @@ invalidate_cache() {
 	fi
 	return 0
 }
-
 
 # =============================================================================
 # Sub-libraries

--- a/.agents/scripts/model-registry-helper.sh
+++ b/.agents/scripts/model-registry-helper.sh
@@ -1289,7 +1289,7 @@ _route_lookup_models() {
 		fallback_model="${fallback_model:-anthropic/claude-haiku-4-5}"
 		;;
 	standard)
-		primary_model="${primary_model:-openai/gpt-5.6-sol}"
+		primary_model="${primary_model:-openai/gpt-5.6-luna}"
 		fallback_model="${fallback_model:-anthropic/claude-sonnet-4-6}"
 		;;
 	thinking)

--- a/.agents/scripts/shared-model-tier.sh
+++ b/.agents/scripts/shared-model-tier.sh
@@ -112,7 +112,10 @@ resolve_model_tier() {
 
 	# Static fallback: map tier names to concrete models
 	case "$tier" in
-	standard | thinking)
+	standard)
+		echo "openai/gpt-5.6-luna"
+		;;
+	thinking)
 		echo "openai/gpt-5.6-sol"
 		;;
 	simple)

--- a/.agents/scripts/tests/test-ai-research-helper-oauth-pool.sh
+++ b/.agents/scripts/tests/test-ai-research-helper-oauth-pool.sh
@@ -169,6 +169,24 @@ STUB
 	return 0
 }
 
+test_opencode_tier_models() {
+	local standard_model=""
+	local standard_variant=""
+	local thinking_model=""
+	# shellcheck source=/dev/null
+	source "${REPO_ROOT}/.agents/scripts/ai-research-helper.sh"
+	standard_model=$(resolve_opencode_model_id standard)
+	standard_variant=$(resolve_opencode_variant standard)
+	thinking_model=$(resolve_opencode_model_id thinking)
+	if [[ "$standard_model" == "openai/gpt-5.6-luna" && "$standard_variant" == "max" && "$thinking_model" == "openai/gpt-5.6-sol" ]]; then
+		record_result "OpenCode research tiers follow canonical Luna and Sol defaults" 0
+		return 0
+	fi
+	record_result "OpenCode research tiers follow canonical Luna and Sol defaults" 1 \
+		"standard=${standard_model:-<empty>} variant=${standard_variant:-<empty>} thinking=${thinking_model:-<empty>}"
+	return 0
+}
+
 write_detector_stubs() {
 	cat >"${TEST_ROOT}/bin/gh" <<'STUB'
 #!/usr/bin/env bash
@@ -223,6 +241,7 @@ main() {
 	trap teardown_sandbox EXIT
 	test_oauth_pool_fallbacks
 	test_auto_provider_prefers_opencode
+	test_opencode_tier_models
 	test_detector_rc2_records_cooldown
 	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-canonical-tier-routing.sh
+++ b/.agents/scripts/tests/test-canonical-tier-routing.sh
@@ -50,7 +50,8 @@ if [[ "${1:-}" != "resolve" ]]; then
 fi
 case "${2:-}" in
 simple) printf '%s' "openai/gpt-5.6-terra" ;;
-standard | thinking) printf '%s' "openai/gpt-5.6-sol" ;;
+standard) printf '%s' "openai/gpt-5.6-luna" ;;
+thinking) printf '%s' "openai/gpt-5.6-sol" ;;
 *) exit 1 ;;
 esac
 exit 0
@@ -65,7 +66,7 @@ source "$AGENTS_SCRIPTS/pulse-model-routing.sh"
 assert_equals "openai/gpt-5.6-terra" \
 	"$(resolve_dispatch_model_for_labels 'tier:simple')" \
 	"simple tier resolves through runtime mapping"
-assert_equals "openai/gpt-5.6-sol" \
+assert_equals "openai/gpt-5.6-luna" \
 	"$(resolve_dispatch_model_for_labels 'tier:standard')" \
 	"standard tier resolves through runtime mapping"
 assert_equals "openai/gpt-5.6-sol" \

--- a/.agents/scripts/tests/test-headless-openai-routing.sh
+++ b/.agents/scripts/tests/test-headless-openai-routing.sh
@@ -65,11 +65,11 @@ select_model() {
 test_openai_allowlist_selects_standard_tier_model() {
 	local selected=""
 	selected=$(select_model standard)
-	if [[ "$selected" == "openai/gpt-5.6-sol" ]]; then
+	if [[ "$selected" == "openai/gpt-5.6-luna" ]]; then
 		print_result "OpenAI allowlist selects standard tier from routing table" 0
 		return 0
 	fi
-	print_result "OpenAI allowlist selects standard tier from routing table" 1 "Expected openai/gpt-5.6-sol, got ${selected:-<empty>}"
+	print_result "OpenAI allowlist selects standard tier from routing table" 1 "Expected openai/gpt-5.6-luna, got ${selected:-<empty>}"
 	return 0
 }
 
@@ -111,7 +111,7 @@ test_standard_alternatives_are_scoped() {
 	local routing_table="${SCRIPT_DIR}/../../configs/model-routing-table.json"
 	local models=""
 	models=$(jq -r '.tiers.standard.models[]' "$routing_table")
-	if printf '%s\n' "$models" | grep -qx 'zai-coding-plan/glm-5.2' && \
+	if printf '%s\n' "$models" | grep -qx 'zai-coding-plan/glm-5.2' &&
 		! printf '%s\n' "$models" | grep -qx 'zai/glm-5.2'; then
 		print_result "Standard tier includes coding-plan GLM-5.2 but excludes direct Z.AI" 0
 		return 0

--- a/.agents/scripts/tests/test-headless-runtime-variant.sh
+++ b/.agents/scripts/tests/test-headless-runtime-variant.sh
@@ -68,8 +68,8 @@ actual=$(resolve_headless_variant "worker" "thinking" "openai/gpt-5.6-sol-fast")
 assert_equals "high" "$actual" "GPT-5.6 Sol Fast thinking worker uses high provider mapping" || true
 
 with_clean_variant_env
-actual=$(resolve_headless_variant "worker" "standard" "openai/gpt-5.6-sol")
-assert_equals "medium" "$actual" "GPT-5.6 Sol standard worker uses routed effort" || true
+actual=$(resolve_headless_variant "worker" "standard" "openai/gpt-5.6-luna")
+assert_equals "max" "$actual" "GPT-5.6 Luna standard worker uses max routed effort" || true
 
 with_clean_variant_env
 AIDEVOPS_HEADLESS_VARIANT_THINKING="high"

--- a/.agents/scripts/tests/test-tier3-simplified.sh
+++ b/.agents/scripts/tests/test-tier3-simplified.sh
@@ -250,10 +250,10 @@ test_fallback_chain_helper() {
 
 	# Test: resolve standard tier
 	output=$("$helper" resolve standard --quiet 2>&1) || true
-	if echo "$output" | grep -q "gpt-5.6-sol"; then
-		print_result "fallback: resolve standard -> gpt-5.6-sol" 0
+	if echo "$output" | grep -q "gpt-5.6-luna"; then
+		print_result "fallback: resolve standard -> gpt-5.6-luna" 0
 	else
-		print_result "fallback: resolve standard -> gpt-5.6-sol" 1 "Got: $output"
+		print_result "fallback: resolve standard -> gpt-5.6-luna" 1 "Got: $output"
 	fi
 
 	# Test: resolve thinking tier

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -32,7 +32,7 @@ model: simple
 | Tier | Current ordered mapping | Use When |
 |------|-------|----------|
 | `simple` | openai/gpt-5.6-terra → anthropic/claude-haiku-4-5 | Classification, search, triage, formatting, and bounded transforms |
-| `standard` | openai/gpt-5.6-sol → zai-coding-plan/glm-5.2 → anthropic/claude-sonnet-4-6 | Code, review, debugging, docs, and most development tasks |
+| `standard` | openai/gpt-5.6-luna → zai-coding-plan/glm-5.2 → anthropic/claude-sonnet-4-6 | Code, review, debugging, docs, and most development tasks |
 | `thinking` | openai/gpt-5.6-sol → anthropic/claude-opus-4-6 | Architecture, novel problems, security audits, and complex trade-offs |
 
 **Model IDs**: Always fully-qualified (`claude-sonnet-4-6`, not `claude-sonnet-4`). Short-form → `ProviderModelNotFoundError`. CLI prefix: `anthropic/`, `google/`, `openai/`.
@@ -80,10 +80,10 @@ is always denied because secrets must flow through secret tooling, not prompts.
 - **Pulse**: Resolves `standard` through `model-availability-helper.sh resolve standard`, so it follows routing-table order, health checks, local routing-table overrides, and `AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST`.
 - **Workers**: Round-robin across canonical `simple`, `standard`, or `thinking` routes after allowlist filtering and auth checks.
 - **Local switch**: Set `AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=openai` to force both pulse and workers onto the default OpenAI fallbacks. If you want OpenAI primary but Anthropic fallback, reorder `custom/configs/model-routing-table.json` and omit the allowlist.
-- **Current default mapping**: The active routing table currently maps `simple` to OpenAI Terra then Anthropic Haiku, `standard` to OpenAI Sol then Z.AI GLM then Anthropic Sonnet, and `thinking` to OpenAI Sol then Anthropic Opus. Availability and provider policy decide the exact model at execution time.
-- **Reasoning mapping**: The same routing table currently maps OpenAI `simple`, `standard`, and `thinking` to `medium`, `medium`, and `high`. Other providers use their provider/runtime defaults unless configured explicitly.
+- **Current default mapping**: The active routing table currently maps `simple` to OpenAI Terra then Anthropic Haiku, `standard` to OpenAI Luna then Z.AI GLM then Anthropic Sonnet, and `thinking` to OpenAI Sol then Anthropic Opus. Availability and provider policy decide the exact model at execution time.
+- **Reasoning mapping**: The same routing table currently maps OpenAI `simple`, `standard`, and `thinking` to `medium`, `max`, and `high`. Other providers use their provider/runtime defaults unless configured explicitly.
 - **Thinking-tier balance**: `high` is the shared Sol default for complex work. Explicit `max` and `xhigh` overrides remain available when a task justifies higher effort.
-- **OpenAI tier rationale**: Terra costs $2.50/M input and $15/M output and is competitive with GPT-5.5, making it the conservative choice for prescriptive/simple work. Sol costs $5/M input and $30/M output and is OpenAI's recommended flagship coding model.
+- **OpenAI tier rationale**: Terra costs $2.50/M input and $15/M output and remains the conservative choice for prescriptive/simple work. Luna costs $1/M input and $6/M output and supports `max` reasoning, making it the cost-efficient default for standard work. Sol remains the flagship thinking model at $5/M input and $30/M output.
 - **OpenAI pro caveat**: `openai/gpt-5.6-sol-pro` passed a live OpenCode ChatGPT OAuth smoke test on 2026-07-10, but OpenAI publishes neither an API price nor comparative Sol Pro benchmarks. It remains excluded from automatic workers pending repository-specific completion-rate evidence. Historical `gpt-5.5-pro` and older `*-pro`/`o3-pro` IDs remain excluded.
 - **GPT-5.5 standard workers**: aidevops omits env-derived standard-tier variants so OpenCode sends no explicit thinking override. Explicit CLI `--variant` still wins.
 - **GLM-5.2 option**: Standard routing may use `zai-coding-plan/glm-5.2` when that OpenCode provider is authenticated. Direct `zai/glm-5.2` is intentionally excluded.
@@ -104,7 +104,7 @@ Example custom override for OpenAI-capable headless routing:
 ```json
 {
   "tiers": {
-    "standard": { "models": ["openai/gpt-5.6-sol", "anthropic/claude-sonnet-4-6"] },
+    "standard": { "models": ["openai/gpt-5.6-luna", "anthropic/claude-sonnet-4-6"] },
     "thinking": { "models": ["openai/gpt-5.6-sol", "anthropic/claude-opus-4-6"] }
   }
 }

--- a/TODO.md
+++ b/TODO.md
@@ -1213,6 +1213,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18184 Fix status-label reconciliation and REST issue edit array safety #bug #efficiency #framework #github-api #no-auto-dispatch ref:GH#28912 pr:#28933 completed:2026-07-30
 
+- [ ] t18189 Route standard workload tier through OpenAI Luna max reasoning #type:enhancement ref:GH#29070
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Make GPT-5.6 Luna with max reasoning the OpenAI default for standard workloads across canonical config, documented defaults, fail-safe routing, and AI research.

## Files Changed

.agents/configs/aidevops.defaults.jsonc, .agents/configs/model-routing-table.json, .agents/scripts/ai-research-helper.sh, .agents/scripts/fallback-chain-helper.sh, .agents/scripts/model-availability-helper.sh, .agents/scripts/model-registry-helper.sh, .agents/scripts/shared-model-tier.sh, .agents/scripts/tests/test-ai-research-helper-oauth-pool.sh, .agents/scripts/tests/test-canonical-tier-routing.sh, .agents/scripts/tests/test-headless-openai-routing.sh, .agents/scripts/tests/test-headless-runtime-variant.sh, .agents/scripts/tests/test-tier3-simplified.sh, .agents/tools/context/model-routing.md, TODO.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Focused routing/reasoning/pricing/OAuth tests pass; ShellCheck and shfmt pass; linters-local.sh passes; live Luna/max OpenCode and AI-research smoke tests pass.

Resolves #29070


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.201 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 14m and 171,460 tokens on this with the user in an interactive session.