### PR TITLE
GH#29027: re-aggregate remaining Pulse triage release sources

### DIFF
--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -161,6 +161,12 @@ Aggregation PR #29052 re-reviews authorized Pulse triage PR #29033 at
 terminalized PR #29042 without recursively terminalizing those sources, then
 the release and simplification-state commits advanced `main`.
 
+A pending exact-tip aggregation re-reviews the same unresolved PR #29033 and
+PR #29037 sources because subsequent merges through PR #29071 advanced `main`
+before publication from PR #29052 could complete. Its branch is based at
+`9ee52e20b8c5ffecd4672f8784e78993acb7f70f`; the allocated aggregation PR and
+immutable source manifest are bound only by the follow-up commit.
+
 Manual arbitrary-version package publication is intentionally unsupported. A
 recovery operation must use an existing tag that passes the same verifier.
 

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -161,11 +161,10 @@ Aggregation PR #29052 re-reviews authorized Pulse triage PR #29033 at
 terminalized PR #29042 without recursively terminalizing those sources, then
 the release and simplification-state commits advanced `main`.
 
-A pending exact-tip aggregation re-reviews the same unresolved PR #29033 and
-PR #29037 sources because subsequent merges through PR #29071 advanced `main`
-before publication from PR #29052 could complete. Its branch is based at
-`9ee52e20b8c5ffecd4672f8784e78993acb7f70f`; the allocated aggregation PR and
-immutable source manifest are bound only by the follow-up commit.
+Aggregation PR #29075 re-reviews the same unresolved PR #29033 and PR #29037
+sources because subsequent merges through PR #29071 advanced `main` before
+publication from PR #29052 could complete. Its exact branch base is
+`9ee52e20b8c5ffecd4672f8784e78993acb7f70f`.
 
 Manual arbitrary-version package publication is intentionally unsupported. A
 recovery operation must use an existing tag that passes the same verifier.


### PR DESCRIPTION
## Summary

Create a reviewed exact-tip aggregation for the still-unreleased Pulse triage sources after later merges invalidated PR #29052's exact-tip release position.

## Release provenance

- Original authorized source: PR #29033 at merge `fb4feba9216c643d7a61838877eedeb99bcef6e1`.
- Prior reviewed aggregation: PR #29037 at merge `11f3a9fa04af659b69b94cd19b86b642bf8303f7`.
- PR #29042 remains excluded because release `v3.32.201` terminally superseded it without recursively settling PR #29033 or PR #29037.
- PR #29052 carried the correct unresolved manifest, but publication failed before side effects after `main` advanced.
- Exact branch base: `9ee52e20b8c5ffecd4672f8784e78993acb7f70f`.
- Sequence: this draft was created from initial documentation commit `cfc3fe99d`; follow-up commit `d0a2c2653` binds aggregation PR #29075 and both immutable sources without rewriting published history.

## Verification

- Local receipts remain `failed` for PR #29033 and absent for PR #29037; neither PR has a matching signed release tag.
- PR #29071 merged the release tag-scan optimization at exact base tip `9ee52e20b8c5ffecd4672f8784e78993acb7f70f`; its local, Bash 3.2, independent-review, and required CI gates passed.
- The complete 3,050-tag trailer index now runs in one Git process in approximately 0.25 seconds while preserving full signed-provenance verification.
- Changed-file lint, Markdown lint, secret scanning, file-size regression, and `git diff --check` pass for this documentation-only attestation.

## Risk and release

- Documentation-only provenance attestation; this PR performs no publication.
- Publication remains constrained to `.agents/scripts/full-loop-release-helper.sh patch 29033 incremental` after this exact tip is reviewed and merged.

Ref #29027
Ref #29033
Ref #29037
Ref #29052
Ref #29060
Ref #29071

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.201 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 4h 39m and 2,625,152 tokens on this with the user in an interactive session.
