### PR TITLE
GH#28783: Add bounded read-only Discord account knowledge ingestion

### DIFF
--- a/.agents/content/social-discord.md
+++ b/.agents/content/social-discord.md
@@ -1,0 +1,138 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Discord Knowledge Collection
+
+`knowledge_social_discord.py` is a provider-specific, read-only collector for an
+explicitly configured Discord bot installation. Shared registration is owned by
+issue #28867; until that integration lands, invoke the Python entry point directly.
+The existing Discord bot guide remains a separate, write-capable integration.
+
+## Runtime and authority contract
+
+The live child uses Python's standard-library `urllib.request.Request`,
+`urllib.request.urlopen`, and `urllib.parse.urlencode` against Discord REST API
+v10. No Discord SDK is installed or imported. Every network request is a `GET`
+to a path matched by a fixed read-route expression. Message sends, reactions,
+moderation, channel/thread changes, role changes, and webhook operations have no
+route or action in the collector.
+
+Configure one private profile through the secret execution context:
+
+```text
+DISCORD_<PROFILE>_BOT_TOKEN
+DISCORD_<PROFILE>_APPLICATION_ID
+DISCORD_<PROFILE>_GUILD_ID
+DISCORD_<PROFILE>_CHANNEL_IDS
+DISCORD_<PROFILE>_THREAD_IDS
+DISCORD_<PROFILE>_DM_CHANNEL_IDS
+DISCORD_<PROFILE>_MESSAGE_CONTENT_INTENT
+DISCORD_<PROFILE>_GUILD_MEMBERS_INTENT
+DISCORD_<PROFILE>_EXPORT_USER_ID
+DISCORD_<PROFILE>_EXPORT_PATH
+DISCORD_<PROFILE>_GATEWAY_EVENTS_PATH
+```
+
+IDs are comma-separated snowflakes. At least one channel, thread, or bot-visible
+DM channel is required. Paths and identifiers stay in private configuration;
+only sanitized identity and coverage policy enter the corpus. Store the bot
+credential with `aidevops secret set`, never in a profile file or command line.
+
+Before binding a connection, the child reads the current bot user, current
+application, and configured guild. It compares all three identities with the
+profile and parent request. The same checks run before every page. A changed
+bot, application, guild, allowlist, intent declaration, or export-user identity
+fails before persistence. Existing connection policy is checked again during
+normalization and the final social-store lease fence remains authoritative.
+
+Example before shared command registration:
+
+```bash
+python3 ~/.aidevops/agents/scripts/knowledge_social_discord.py \
+  --alias personal:default --connection-id DISCORD_CONNECTION_ID \
+  --account-id EXPECTED_BOT_USER_ID --stream messages \
+  --profile personal --budget 11 --page-size 100
+```
+
+## Permissions and intents
+
+Use the smallest bot installation possible:
+
+- `View Channel` and `Read Message History` on every allowlisted guild channel
+  and thread;
+- `Guilds` Gateway intent for guild/channel/thread lifecycle events;
+- `Guild Messages` for guild message and reaction events;
+- `Direct Messages` only for DMs in which the bot participates and which are
+  explicitly allowlisted;
+- `Message Content` when message text, embeds, attachments, and components are
+  required outside the documented privileged-intent exceptions;
+- `Guild Members` only when complete member snapshots or member events are
+  required.
+
+Do not grant Send Messages, Add Reactions, Manage Messages, Manage Threads,
+Manage Channels, Manage Roles, moderation, or webhook permissions to the
+collector bot. A separately deployed interactive bot must use a different
+credential and process boundary.
+
+## Implemented streams
+
+| Stream | Official or operator-authorized route | Coverage |
+|---|---|---|
+| `messages` | `GET /channels/{channel.id}/messages` for explicit channel, thread, and bot-visible DM IDs | Independent composite snowflake cursor and per-channel newest watermark. Deleted messages and prior revisions require prospective events. |
+| `metadata` | Guild channels and roles plus explicit thread lookups | Guild, text, announcement, forum, active-thread, and archived-thread metadata that the bot can currently view. Thread messages require explicit thread allowlisting. |
+| `members` | Paginated guild-member list | Current snapshot only and explicitly partial when the Guild Members intent or authority is absent. |
+| `gateway_events` | Validated local JSONL spool of official Gateway dispatches | Prospective create/update/delete, reaction, channel, thread, member, and role observations. The collector does not open a WebSocket or send Gateway commands. |
+| `account_export` | Operator-supplied official Discord account export ZIP | Idempotent message replay for explicitly allowlisted channels and a configured export user. Export shape and selected categories remain partial coverage. |
+
+REST, Gateway, and export evidence converge on Discord message snowflakes. A
+Gateway event is also retained as revision/deletion observation evidence; it
+never deletes an earlier raw batch or canonical message. Export replay does not
+authorize a user session and is never treated as a credential.
+
+Discord's account-export layout is not a developer API contract. The parser
+accepts only safe ZIP paths, bounded entries, channel metadata, and message CSV
+files. A changed or malformed package fails closed without advancing the export
+cursor. Validate a current private export before relying on category coverage.
+
+## Rate limits, media, and explicit gaps
+
+The HTTP child reads `X-RateLimit-*` and `Retry-After` response headers rather
+than hard-coding route limits. A 429 pauses the invocation, records a sanitized
+retry epoch, and leaves the last successful cursor unchanged. Authorization,
+unavailable-resource, and provider failures are terminal for that invocation.
+
+Attachment snowflakes are canonical media identity. Filenames, MIME types, and
+sizes may be retained; signed or expiring CDN URLs are transport data and are
+not stored as identity or logged. Hydration remains `remote_only` until a
+separate approved media workflow supplies immutable bytes and a digest.
+
+Every successful page keeps these limits visible:
+
+- arbitrary user DM history is unavailable to a bot; only bot-participating,
+  explicitly allowlisted DM channels are eligible;
+- REST cannot reconstruct deleted messages or prior revisions;
+- reaction summaries are collected without unbounded reacting-user hydration;
+- Message Content and Guild Members intent gaps remain partial, never complete;
+- inaccessible, deleted, archived, or permission-revoked channels remain gaps;
+- Gateway spools are prospective and their local retention/resume gaps remain
+  explicit;
+- exports are snapshots with operator-selected categories and an unstable
+  package shape.
+
+Discord Developer Policy prohibits scraping and using API message content to
+train machine-learning or AI models without Discord's express permission. This
+collector is for authorized private evidence retrieval and does not grant model
+training rights. Apply corpus isolation, retention, deletion, and user-consent
+rules independently of technical API visibility.
+
+## Official evidence checked 2026-07-31
+
+- [Discord Developer Platform](https://docs.discord.com/developers/intro.md)
+- [Application resource and current application](https://docs.discord.com/developers/resources/application.md)
+- [Guild resource](https://docs.discord.com/developers/resources/guild.md)
+- [Channel, message-history, thread, and archived-thread routes](https://docs.discord.com/developers/resources/channel.md)
+- [Gateway](https://docs.discord.com/developers/events/gateway.md)
+- [Gateway events](https://docs.discord.com/developers/events/gateway-events.md)
+- [Permissions](https://docs.discord.com/developers/topics/permissions.md)
+- [Rate limits](https://docs.discord.com/developers/topics/rate-limits.md)
+- [Discord Developer Policy](https://docs.discord.com/developers/policies/developer-policy.md)

--- a/.agents/scripts/_knowledge_social_discord.py
+++ b/.agents/scripts/_knowledge_social_discord.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Discord stream policy, allowlisted requests, and durable checkpoints."""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from knowledge_social_import import canonical_json, reject_credentials
+from knowledge_social_store import SocialStoreError
+
+PROVIDER = "discord"
+CURSOR_PREFIX = "discord-v1:"
+SNOWFLAKE = re.compile(r"^[0-9]{5,24}$")
+
+
+class DiscordAdapterError(SocialStoreError):
+    """Raised when bounded Discord collection cannot continue safely."""
+
+
+class DiscordProviderUnavailableError(DiscordAdapterError):
+    """Raised when the guarded Discord child cannot complete a read."""
+
+
+ADAPTER_ERROR = DiscordAdapterError
+PROVIDER_UNAVAILABLE_ERROR = DiscordProviderUnavailableError
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    """Static collection and coverage policy for one Discord stream."""
+
+    resource_kind: str
+    incremental: bool
+    retention_limit: str | None
+    coverage_status: str | None = None
+    unavailable_reason: str | None = None
+    cost_units: int = 2
+
+
+STREAMS = {
+    "messages": StreamSpec(
+        "message",
+        True,
+        "provider_retention_and_channel_visibility",
+        "partial",
+        "rest_history_excludes_deleted_messages_and_prior_revisions",
+    ),
+    "metadata": StreamSpec("guild_metadata", False, None),
+    "members": StreamSpec(
+        "member",
+        False,
+        None,
+        "partial",
+        "guild_members_intent_and_current_membership_required",
+    ),
+    "gateway_events": StreamSpec(
+        "event",
+        True,
+        "local_gateway_spool_retention",
+        "partial",
+        "prospective_events_only_with_resume_and_spool_gaps_visible",
+    ),
+    "account_export": StreamSpec(
+        "export_message",
+        False,
+        "operator_supplied_official_export_snapshot",
+        "partial",
+        "export_shape_and_requested_categories_are_not_api_contracts",
+    ),
+}
+
+
+def snowflake(value: Any, field: str, *, optional: bool = False) -> str | None:
+    """Validate one Discord snowflake without coercing numeric JSON values."""
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or SNOWFLAKE.fullmatch(value) is None:
+        raise DiscordAdapterError(f"Discord {field} must be a snowflake")
+    return value
+
+
+def _snowflakes(value: Any, field: str) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise DiscordAdapterError(f"Discord {field} must be an array")
+    result = tuple(snowflake(item, field) or "" for item in value)
+    if len(result) != len(set(result)):
+        raise DiscordAdapterError(f"Discord {field} must not contain duplicates")
+    return result
+
+
+def _encode_state(value: dict[str, Any]) -> str:
+    reject_credentials(value)
+    payload = canonical_json(value).encode("utf-8")
+    if len(payload) > 16384:
+        raise DiscordAdapterError("Discord checkpoint exceeds the safety limit")
+    encoded = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+    return f"{CURSOR_PREFIX}{encoded}"
+
+
+def _decode_state(value: str | None, field: str) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not value.startswith(CURSOR_PREFIX):
+        raise DiscordAdapterError(f"stored Discord {field} has an unsupported version")
+    try:
+        encoded = value.removeprefix(CURSOR_PREFIX)
+        parsed = json.loads(base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4)))
+    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+        raise DiscordAdapterError(f"stored Discord {field} is invalid") from error
+    if not isinstance(parsed, dict):
+        raise DiscordAdapterError(f"stored Discord {field} has an invalid shape")
+    reject_credentials(parsed)
+    return parsed
+
+
+@dataclass(frozen=True)
+class PageRequest:
+    """Complete identity and authority fence for one provider page."""
+
+    stream: str
+    bot_id: str
+    application_id: str
+    guild_id: str
+    channel_ids: tuple[str, ...]
+    thread_ids: tuple[str, ...]
+    dm_channel_ids: tuple[str, ...]
+    message_content_intent: bool
+    guild_members_intent: bool
+    export_user_id: str | None
+    cursor: dict[str, Any] | None
+    watermark: dict[str, Any] | None
+    limit: int
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "page",
+            "stream": self.stream,
+            "bot_id": self.bot_id,
+            "application_id": self.application_id,
+            "guild_id": self.guild_id,
+            "channel_ids": list(self.channel_ids),
+            "thread_ids": list(self.thread_ids),
+            "dm_channel_ids": list(self.dm_channel_ids),
+            "message_content_intent": self.message_content_intent,
+            "guild_members_intent": self.guild_members_intent,
+            "export_user_id": self.export_user_id,
+            "cursor": self.cursor,
+            "watermark": self.watermark,
+            "limit": self.limit,
+        }
+
+    def evidence_key(self) -> str:
+        return canonical_json(self.payload())
+
+
+def page_request(
+    stream: str, account: dict[str, Any], state: CursorState, limit: int
+) -> PageRequest:
+    """Build one child request from verified identity and durable state."""
+    if stream not in STREAMS:
+        raise DiscordAdapterError("Discord stream is not allowlisted")
+    application_id = snowflake(account.get("application_id"), "application ID")
+    guild_id = snowflake(account.get("guild_id"), "guild ID")
+    bot_id = snowflake(account.get("id"), "bot user ID")
+    if application_id is None or guild_id is None or bot_id is None:
+        raise DiscordAdapterError("verified Discord identity is incomplete")
+    return PageRequest(
+        stream,
+        bot_id,
+        application_id,
+        guild_id,
+        _snowflakes(account.get("channel_ids"), "channel allowlist"),
+        _snowflakes(account.get("thread_ids"), "thread allowlist"),
+        _snowflakes(account.get("dm_channel_ids"), "DM allowlist"),
+        bool(account.get("message_content_intent")),
+        bool(account.get("guild_members_intent")),
+        snowflake(account.get("export_user_id"), "export user ID", optional=True),
+        _decode_state(state.cursor, "cursor"),
+        _decode_state(state.watermark, "watermark"),
+        limit,
+    )
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise DiscordAdapterError("Discord response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise DiscordAdapterError("Discord page data must be an array")
+    return data
+
+
+def _optional_mapping(meta: dict[str, Any], field: str) -> dict[str, Any] | None:
+    value = meta.get(field)
+    if value is not None and not isinstance(value, dict):
+        raise DiscordAdapterError(f"Discord {field.replace('_', ' ')} must be an object")
+    return value
+
+
+def _checkpoint_meta(
+    payload: dict[str, Any], request: PageRequest
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None, bool]:
+    meta = payload.get("meta")
+    if not isinstance(meta, dict):
+        raise DiscordAdapterError("Discord page meta must be an object")
+    reject_credentials(meta)
+    next_cursor = _optional_mapping(meta, "next_cursor")
+    watermark = _optional_mapping(meta, "watermark")
+    complete = meta.get("complete")
+    snapshot = meta.get("snapshot")
+    if not isinstance(complete, bool) or not isinstance(snapshot, bool):
+        raise DiscordAdapterError("Discord completion metadata is invalid")
+    if snapshot != (not STREAMS[request.stream].incremental):
+        raise DiscordAdapterError("Discord snapshot metadata is invalid")
+    if complete == (next_cursor is not None):
+        raise DiscordAdapterError("Discord page cursor conflicts with completion")
+    return next_cursor, watermark, complete
+
+
+def page_checkpoint(
+    payload: dict[str, Any], state: CursorState, request: PageRequest
+) -> tuple[PageCheckpoint, bool]:
+    """Validate provider pagination and encode independent stream state."""
+    next_cursor, watermark, complete = _checkpoint_meta(payload, request)
+    next_value = _encode_state(next_cursor) if next_cursor is not None else None
+    watermark_value = (
+        _encode_state(watermark) if watermark is not None else state.watermark
+    )
+    return PageCheckpoint(next_value, watermark_value), complete

--- a/.agents/scripts/_knowledge_social_discord_contract.py
+++ b/.agents/scripts/_knowledge_social_discord_contract.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validation and serialization for bounded Discord provider reads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+MAX_TEXT_BYTES = 256 * 1024
+
+
+class DiscordReadProviderError(RuntimeError):
+    """Raised for a privacy-safe local Discord provider failure."""
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    """One bounded HTTP result without provider error-body disclosure."""
+
+    status: int
+    payload: Any
+    retry_after: int | None = None
+    rate_limit: dict[str, str] | None = None
+
+
+def observed_at() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def exact_keys(request: dict[str, Any], expected: set[str]) -> None:
+    if set(request) != expected:
+        raise DiscordReadProviderError("Discord read request has an invalid shape")
+
+
+def object_value(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise DiscordReadProviderError(f"Discord {field} must be an object")
+    return value
+
+
+def array_value(value: Any, field: str) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise DiscordReadProviderError(f"Discord {field} must be an array")
+    return value
+
+
+def text(value: Any, field: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or "\x00" in value:
+        raise DiscordReadProviderError(f"Discord {field} must be text")
+    if len(value.encode("utf-8")) > MAX_TEXT_BYTES:
+        raise DiscordReadProviderError(f"Discord {field} exceeds the safety limit")
+    return value
+
+
+def snowflake(value: Any, field: str, *, optional: bool = False) -> str | None:
+    value = text(value, field, optional=optional)
+    if value is None:
+        return None
+    if not value.isascii() or not value.isdigit() or not 5 <= len(value) <= 24:
+        raise DiscordReadProviderError(f"Discord {field} must be a snowflake")
+    return value
+
+
+def boolean(value: Any, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise DiscordReadProviderError(f"Discord {field} must be boolean")
+    return value
+
+
+def integer(value: Any, field: str, *, minimum: int = 0) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise DiscordReadProviderError(f"Discord {field} must be an integer")
+    return value
+
+
+def terminal_payload(result: ApiResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": result.status, "observed_at": observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload
+
+
+def _application_flags(payload: dict[str, Any]) -> int:
+    value = payload.get("flags_new", payload.get("flags", 0))
+    if isinstance(value, str) and value.isascii() and value.isdigit():
+        value = int(value)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise DiscordReadProviderError("Discord application flags are invalid")
+    return value
+
+
+def _verify_intent_flags(application_payload: dict[str, Any], config: dict[str, Any]) -> None:
+    flags = _application_flags(application_payload)
+    intent_bits = {
+        "message_content_intent": (1 << 18) | (1 << 19),
+        "guild_members_intent": (1 << 14) | (1 << 15),
+    }
+    missing = [field for field, bits in intent_bits.items() if config[field] and not flags & bits]
+    if missing:
+        raise DiscordReadProviderError(
+            "Discord identity does not match the configured connection"
+        )
+
+
+def identity_value(
+    user_payload: dict[str, Any],
+    application_payload: dict[str, Any],
+    guild_payload: dict[str, Any],
+    config: dict[str, Any],
+    expected_bot_id: str,
+) -> dict[str, Any]:
+    """Verify bot, application, and guild before exposing sanitized identity."""
+    bot_id = snowflake(user_payload.get("id"), "bot user ID")
+    application_id = snowflake(application_payload.get("id"), "application ID")
+    guild_id = snowflake(guild_payload.get("id"), "guild ID")
+    app_bot = application_payload.get("bot")
+    if bot_id != expected_bot_id:
+        raise DiscordReadProviderError(
+            "Discord identity does not match the configured connection"
+        )
+    if application_id != config["application_id"] or guild_id != config["guild_id"]:
+        raise DiscordReadProviderError(
+            "Discord identity does not match the configured connection"
+        )
+    if isinstance(app_bot, dict) and app_bot.get("id") != bot_id:
+        raise DiscordReadProviderError(
+            "Discord identity does not match the configured connection"
+        )
+    _verify_intent_flags(application_payload, config)
+    return {
+        "id": bot_id,
+        "application_id": application_id,
+        "guild_id": guild_id,
+        "channel_ids": list(config["channel_ids"]),
+        "thread_ids": list(config["thread_ids"]),
+        "dm_channel_ids": list(config["dm_channel_ids"]),
+        "message_content_intent": config["message_content_intent"],
+        "guild_members_intent": config["guild_members_intent"],
+        "export_user_id": config["export_user_id"],
+    }
+
+
+def _user(value: Any, field: str) -> dict[str, Any]:
+    user = object_value(value, field)
+    return {
+        "id": snowflake(user.get("id"), f"{field} ID"),
+        "username": text(user.get("username"), f"{field} username", optional=True),
+        "global_name": text(
+            user.get("global_name"), f"{field} global name", optional=True
+        ),
+        "bot": bool(user.get("bot", False)),
+    }
+
+
+def serialize_message(item: dict[str, Any], expected_channel: str) -> dict[str, Any]:
+    """Reduce a Discord message to stable evidence and transport-safe metadata."""
+    message_id = snowflake(item.get("id"), "message ID")
+    channel_id = snowflake(item.get("channel_id"), "message channel ID")
+    if channel_id != expected_channel:
+        raise DiscordReadProviderError("Discord message crossed the channel fence")
+    author = _user(item.get("author"), "message author")
+    mentions = [_user(value, "mention") for value in item.get("mentions", [])]
+    attachments = []
+    for value in item.get("attachments", []):
+        attachment = object_value(value, "attachment")
+        attachments.append(
+            {
+                "id": snowflake(attachment.get("id"), "attachment ID"),
+                "filename": text(attachment.get("filename"), "attachment filename"),
+                "content_type": text(
+                    attachment.get("content_type"), "attachment content type", optional=True
+                ),
+                "size": integer(attachment.get("size", 0), "attachment size"),
+                "ephemeral": bool(attachment.get("ephemeral", False)),
+            }
+        )
+    reactions = []
+    for value in item.get("reactions", []):
+        reaction = object_value(value, "reaction")
+        emoji = object_value(reaction.get("emoji"), "reaction emoji")
+        reactions.append(
+            {
+                "emoji_id": snowflake(emoji.get("id"), "emoji ID", optional=True),
+                "emoji_name": text(emoji.get("name"), "emoji name", optional=True),
+                "count": integer(reaction.get("count", 0), "reaction count"),
+            }
+        )
+    return {
+        "kind": "message",
+        "remote_id": message_id,
+        "channel_id": channel_id,
+        "guild_id": snowflake(item.get("guild_id"), "message guild ID", optional=True),
+        "author": author,
+        "content": text(item.get("content", ""), "message content"),
+        "timestamp": text(item.get("timestamp"), "message timestamp"),
+        "edited_timestamp": text(
+            item.get("edited_timestamp"), "message edit timestamp", optional=True
+        ),
+        "type": integer(item.get("type", 0), "message type"),
+        "mentions": mentions,
+        "attachments": attachments,
+        "embeds": item.get("embeds", []),
+        "reactions": reactions,
+        "reference_message_id": snowflake(
+            object_value(item.get("message_reference", {}), "message reference").get(
+                "message_id"
+            ),
+            "referenced message ID",
+            optional=True,
+        ),
+    }
+
+
+def serialize_channel(item: dict[str, Any], guild_id: str) -> dict[str, Any]:
+    item_guild = snowflake(item.get("guild_id", guild_id), "channel guild ID")
+    if item_guild != guild_id:
+        raise DiscordReadProviderError("Discord channel crossed the guild fence")
+    return {
+        "kind": "channel",
+        "remote_id": snowflake(item.get("id"), "channel ID"),
+        "guild_id": item_guild,
+        "channel_type": integer(item.get("type"), "channel type"),
+        "name": text(item.get("name"), "channel name", optional=True),
+        "topic": text(item.get("topic"), "channel topic", optional=True),
+        "parent_id": snowflake(item.get("parent_id"), "parent channel ID", optional=True),
+        "archived": bool(object_value(item.get("thread_metadata", {}), "thread metadata").get("archived", False)),
+        "applied_tags": [snowflake(value, "forum tag ID") for value in item.get("applied_tags", [])],
+    }
+
+
+def serialize_role(item: dict[str, Any], guild_id: str) -> dict[str, Any]:
+    return {
+        "kind": "role",
+        "remote_id": snowflake(item.get("id"), "role ID"),
+        "guild_id": guild_id,
+        "name": text(item.get("name"), "role name"),
+        "permissions": text(item.get("permissions", "0"), "role permissions"),
+        "managed": bool(item.get("managed", False)),
+    }
+
+
+def serialize_member(item: dict[str, Any], guild_id: str) -> dict[str, Any]:
+    user = _user(item.get("user"), "member user")
+    return {
+        "kind": "member",
+        "remote_id": user["id"],
+        "guild_id": guild_id,
+        "user": user,
+        "nick": text(item.get("nick"), "member nickname", optional=True),
+        "roles": [snowflake(value, "member role ID") for value in item.get("roles", [])],
+        "joined_at": text(item.get("joined_at"), "member joined timestamp", optional=True),
+    }

--- a/.agents/scripts/_knowledge_social_discord_export.py
+++ b/.agents/scripts/_knowledge_social_discord_export.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded parser for operator-supplied official Discord account exports."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import re
+import zipfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from _knowledge_social_discord_contract import DiscordReadProviderError, snowflake, text
+
+MAX_EXPORT_BYTES = 2 * 1024 * 1024 * 1024
+MAX_ENTRY_BYTES = 64 * 1024 * 1024
+MAX_ENTRIES = 100_000
+MESSAGE_CSV = re.compile(r"^messages/[^/]+/messages\.csv$")
+
+
+def _safe_names(archive: zipfile.ZipFile) -> list[str]:
+    infos = archive.infolist()
+    total_size = sum(info.file_size for info in infos)
+    if len(infos) > MAX_ENTRIES or total_size > MAX_EXPORT_BYTES:
+        raise DiscordReadProviderError("Discord account export exceeds the safety limit")
+    names = []
+    for info in infos:
+        path = PurePosixPath(info.filename)
+        if path.is_absolute() or ".." in path.parts or info.file_size > MAX_ENTRY_BYTES:
+            raise DiscordReadProviderError("Discord account export contains an unsafe entry")
+        names.append(info.filename)
+    return names
+
+
+def _verify_export_user(
+    archive: zipfile.ZipFile, names: list[str], expected_user_id: str
+) -> None:
+    candidates = ("account/user.json", "account/account.json", "user.json")
+    name = next((candidate for candidate in candidates if candidate in names), None)
+    if name is None:
+        raise DiscordReadProviderError("Discord account export user identity is missing")
+    try:
+        payload = json.loads(archive.read(name).decode("utf-8"))
+    except (KeyError, UnicodeError, json.JSONDecodeError) as error:
+        raise DiscordReadProviderError("Discord account export user is invalid") from error
+    if not isinstance(payload, dict):
+        raise DiscordReadProviderError("Discord account export user is invalid")
+    exported_user_id = snowflake(
+        payload.get("id") or payload.get("user_id"), "export user ID"
+    )
+    if exported_user_id != expected_user_id:
+        raise DiscordReadProviderError("Discord account export user identity mismatched")
+
+
+def _channel_ids(archive: zipfile.ZipFile, names: list[str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for name in names:
+        if not name.startswith("messages/") or not name.endswith("/channel.json"):
+            continue
+        try:
+            payload = json.loads(archive.read(name).decode("utf-8"))
+        except (KeyError, UnicodeError, json.JSONDecodeError) as error:
+            raise DiscordReadProviderError("Discord account export channel is invalid") from error
+        if not isinstance(payload, dict):
+            raise DiscordReadProviderError("Discord account export channel is invalid")
+        channel_id = snowflake(payload.get("id"), "export channel ID")
+        result[str(PurePosixPath(name).parent / "messages.csv")] = channel_id or ""
+    return result
+
+
+def _message_row(
+    row: dict[str, str | None], channel_id: str, author_id: str
+) -> dict[str, Any]:
+    return {
+        "kind": "export_message",
+        "remote_id": snowflake(row.get("ID") or row.get("id"), "export message ID"),
+        "channel_id": channel_id,
+        "author_id": author_id,
+        "timestamp": text(
+            row.get("Timestamp") or row.get("timestamp"),
+            "export message timestamp",
+        ),
+        "content": text(
+            row.get("Contents") or row.get("content") or "",
+            "export message content",
+        ),
+        "attachments": text(
+            row.get("Attachments") or row.get("attachments"),
+            "export attachment references",
+            optional=True,
+        ),
+    }
+
+
+def _csv_rows(
+    archive: zipfile.ZipFile, name: str, channel_id: str, author_id: str
+) -> list[dict[str, Any]]:
+    try:
+        source = io.StringIO(archive.read(name).decode("utf-8-sig"), newline="")
+        return [_message_row(row, channel_id, author_id) for row in csv.DictReader(source)]
+    except (KeyError, OSError, UnicodeError, csv.Error) as error:
+        raise DiscordReadProviderError("Discord account export messages are invalid") from error
+
+
+def _rows(archive: zipfile.ZipFile, config: dict[str, Any]) -> list[dict[str, Any]]:
+    names = _safe_names(archive)
+    _verify_export_user(archive, names, config["export_user_id"])
+    channels = _channel_ids(archive, names)
+    allowed = {
+        *config["channel_ids"],
+        *config["thread_ids"],
+        *config["dm_channel_ids"],
+    }
+    records: list[dict[str, Any]] = []
+    for name in sorted(value for value in names if MESSAGE_CSV.fullmatch(value)):
+        channel_id = channels.get(name)
+        if channel_id not in allowed:
+            continue
+        records.extend(_csv_rows(archive, name, channel_id, config["export_user_id"]))
+    return records
+
+
+def _export_path(path_value: str | None) -> Path:
+    if not path_value:
+        raise DiscordReadProviderError("Discord account export is unavailable")
+    path = Path(path_value).expanduser()
+    valid = (
+        not path.is_symlink()
+        and path.is_file()
+        and path.stat().st_size <= MAX_EXPORT_BYTES
+        and zipfile.is_zipfile(path)
+    )
+    if not valid:
+        raise DiscordReadProviderError("Discord account export is unavailable")
+    return path
+
+
+def _export_offset(cursor: dict[str, Any] | None) -> int:
+    if cursor is None:
+        return 0
+    offset = cursor.get("offset")
+    if set(cursor) != {"offset"} or isinstance(offset, bool) or not isinstance(offset, int):
+        raise DiscordReadProviderError("Discord export cursor is invalid")
+    if offset < 0:
+        raise DiscordReadProviderError("Discord export cursor is invalid")
+    return offset
+
+
+def page_account_export(
+    path_value: str | None,
+    config: dict[str, Any],
+    cursor: dict[str, Any] | None,
+    limit: int,
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    """Page a validated export without treating it as a user-session credential."""
+    if config.get("export_user_id") is None:
+        raise DiscordReadProviderError("Discord account export is unavailable")
+    path = _export_path(path_value)
+    offset = _export_offset(cursor)
+    try:
+        with zipfile.ZipFile(path) as archive:
+            rows = _rows(archive, config)
+    except (OSError, zipfile.BadZipFile) as error:
+        raise DiscordReadProviderError("Discord account export is invalid") from error
+    page = rows[offset : offset + limit]
+    next_offset = offset + len(page)
+    next_cursor = {"offset": next_offset} if next_offset < len(rows) else None
+    return page, next_cursor

--- a/.agents/scripts/_knowledge_social_discord_gateway.py
+++ b/.agents/scripts/_knowledge_social_discord_gateway.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validate and page a local spool of official Discord Gateway dispatches."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from _knowledge_social_discord_contract import (
+    DiscordReadProviderError,
+    integer,
+    object_value,
+    snowflake,
+    text,
+)
+from knowledge_social_import import reject_credentials
+
+MAX_SPOOL_BYTES = 32 * 1024 * 1024
+EVENTS = {
+    "MESSAGE_CREATE",
+    "MESSAGE_UPDATE",
+    "MESSAGE_DELETE",
+    "MESSAGE_DELETE_BULK",
+    "MESSAGE_REACTION_ADD",
+    "MESSAGE_REACTION_REMOVE",
+    "MESSAGE_REACTION_REMOVE_ALL",
+    "MESSAGE_REACTION_REMOVE_EMOJI",
+    "CHANNEL_CREATE",
+    "CHANNEL_UPDATE",
+    "CHANNEL_DELETE",
+    "THREAD_CREATE",
+    "THREAD_UPDATE",
+    "THREAD_DELETE",
+    "THREAD_LIST_SYNC",
+    "THREAD_MEMBERS_UPDATE",
+    "GUILD_MEMBER_ADD",
+    "GUILD_MEMBER_UPDATE",
+    "GUILD_MEMBER_REMOVE",
+    "GUILD_ROLE_CREATE",
+    "GUILD_ROLE_UPDATE",
+    "GUILD_ROLE_DELETE",
+}
+
+
+def _allowed_dispatch(data: dict[str, Any], config: dict[str, Any]) -> bool:
+    guild_id = data.get("guild_id")
+    channel_id = data.get("channel_id") or data.get("id")
+    if guild_id is not None and guild_id != config["guild_id"]:
+        return False
+    if channel_id is None:
+        return guild_id == config["guild_id"]
+    allowed = {
+        *config["channel_ids"],
+        *config["thread_ids"],
+        *config["dm_channel_ids"],
+    }
+    return channel_id in allowed
+
+
+def _spool_path(path_value: str | None) -> Path:
+    if not path_value:
+        raise DiscordReadProviderError("Discord gateway event spool is unavailable")
+    path = Path(path_value).expanduser()
+    valid = not path.is_symlink() and path.is_file()
+    if valid:
+        valid = path.stat().st_size <= MAX_SPOOL_BYTES
+    if not valid:
+        raise DiscordReadProviderError("Discord gateway event spool is unavailable")
+    return path
+
+
+def _after_sequence(cursor: dict[str, Any] | None) -> int:
+    if cursor is None:
+        return 0
+    if set(cursor) != {"sequence"}:
+        raise DiscordReadProviderError("Discord gateway cursor is invalid")
+    return integer(cursor.get("sequence"), "gateway sequence")
+
+
+def _decode_dispatch(line: str) -> tuple[int, str, dict[str, Any]] | None:
+    if not line.strip():
+        return None
+    event = object_value(json.loads(line), "gateway event")
+    reject_credentials(event)
+    if event.get("op") != 0:
+        return None
+    return (
+        integer(event.get("s"), "gateway sequence"),
+        text(event.get("t"), "gateway event name") or "",
+        object_value(event.get("d"), "gateway event data"),
+    )
+
+
+def _event_record(
+    sequence: int, event_name: str, data: dict[str, Any], guild_id: str
+) -> dict[str, Any]:
+    return {
+        "kind": "gateway_event",
+        "remote_id": f"{guild_id}:{sequence}",
+        "sequence": sequence,
+        "event_name": event_name,
+        "data": data,
+    }
+
+
+def page_gateway_events(
+    path_value: str | None,
+    config: dict[str, Any],
+    cursor: dict[str, Any] | None,
+    limit: int,
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None, dict[str, Any]]:
+    """Return dispatches after the durable sequence without opening a Gateway."""
+    path = _spool_path(path_value)
+    after = _after_sequence(cursor)
+    accepted: list[dict[str, Any]] = []
+    last_sequence = after
+    try:
+        with path.open(encoding="utf-8") as source:
+            for line in source:
+                dispatch = _decode_dispatch(line)
+                if dispatch is None:
+                    continue
+                sequence, event_name, data = dispatch
+                if sequence <= after or event_name not in EVENTS:
+                    continue
+                last_sequence = max(last_sequence, sequence)
+                if not _allowed_dispatch(data, config):
+                    continue
+                accepted.append(_event_record(sequence, event_name, data, config["guild_id"]))
+                if len(accepted) >= limit:
+                    return accepted, {"sequence": last_sequence}, {"sequence": last_sequence}
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise DiscordReadProviderError("Discord gateway event spool is invalid") from error
+    watermark = {"sequence": last_sequence}
+    return accepted, None, watermark

--- a/.agents/scripts/_knowledge_social_discord_normalize.py
+++ b/.agents/scripts/_knowledge_social_discord_normalize.py
@@ -36,6 +36,30 @@ class Rows:
     media: dict[str, dict[str, Any]]
 
 
+@dataclass(frozen=True)
+class AccountDetails:
+    handle: str | None = None
+    display_name: str | None = None
+    provider_json: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class ObjectDetails:
+    account_id: str | None = None
+    text: str | None = None
+    created_at: str | None = None
+    evidence_class: str = "observed"
+    provider_json: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class ActivityDetails:
+    object_id: str | None = None
+    occurred_at: str | None = None
+    state: str = "active"
+    provider_json: dict[str, Any] | None = None
+
+
 def _required(record: dict[str, Any], field: str) -> str:
     value = record.get(field)
     if not isinstance(value, str) or not value:
@@ -53,17 +77,15 @@ def _optional(record: dict[str, Any], field: str) -> str | None:
 def _account(
     remote_id: str,
     observed_at: str,
-    *,
-    handle: str | None = None,
-    display_name: str | None = None,
-    provider_json: dict[str, Any] | None = None,
+    details: AccountDetails | None = None,
 ) -> dict[str, Any]:
+    details = details or AccountDetails()
     return {
         "remote_id": remote_id,
-        "handle": handle,
-        "display_name": display_name,
+        "handle": details.handle,
+        "display_name": details.display_name,
         "observed_at": observed_at,
-        "provider_json": provider_json or {},
+        "provider_json": details.provider_json or {},
     }
 
 
@@ -71,23 +93,19 @@ def _object(
     kind: str,
     remote_id: str,
     observed_at: str,
-    *,
-    account_id: str | None = None,
-    text: str | None = None,
-    created_at: str | None = None,
-    evidence_class: str = "observed",
-    provider_json: dict[str, Any] | None = None,
+    details: ObjectDetails | None = None,
 ) -> dict[str, Any]:
-    metadata = provider_json or {}
+    details = details or ObjectDetails()
+    metadata = details.provider_json or {}
     reject_credentials(metadata)
     return {
         "object_type": kind,
         "remote_id": remote_id,
-        "account_remote_id": account_id,
-        "text": text,
-        "created_at": created_at,
+        "account_remote_id": details.account_id,
+        "text": details.text,
+        "created_at": details.created_at,
         "observed_at": observed_at,
-        "evidence_class": evidence_class,
+        "evidence_class": details.evidence_class,
         "provider_json": metadata,
     }
 
@@ -97,21 +115,18 @@ def _activity(
     remote_id: str,
     actor_id: str,
     observed_at: str,
-    *,
-    object_id: str | None = None,
-    occurred_at: str | None = None,
-    state: str = "active",
-    provider_json: dict[str, Any] | None = None,
+    details: ActivityDetails | None = None,
 ) -> dict[str, Any]:
+    details = details or ActivityDetails()
     return {
         "activity_type": kind,
         "remote_id": remote_id,
         "actor_remote_id": actor_id,
-        "object_remote_id": object_id,
-        "occurred_at": occurred_at,
+        "object_remote_id": details.object_id,
+        "occurred_at": details.occurred_at,
         "observed_at": observed_at,
-        "state": state,
-        "provider_json": provider_json or {},
+        "state": details.state,
+        "provider_json": details.provider_json or {},
     }
 
 
@@ -120,9 +135,11 @@ def _user(user: dict[str, Any], observed_at: str, rows: Rows) -> str:
     rows.accounts[remote_id] = _account(
         remote_id,
         observed_at,
-        handle=_optional(user, "username"),
-        display_name=_optional(user, "global_name"),
-        provider_json={"bot": bool(user.get("bot", False))},
+        AccountDetails(
+            handle=_optional(user, "username"),
+            display_name=_optional(user, "global_name"),
+            provider_json={"bot": bool(user.get("bot", False))},
+        ),
     )
     return remote_id
 
@@ -176,19 +193,23 @@ def _message(record: dict[str, Any], observed_at: str, rows: Rows) -> None:
         "message",
         remote_id,
         observed_at,
-        account_id=author_id,
-        text=_optional(record, "content"),
-        created_at=_optional(record, "timestamp"),
-        evidence_class="authored" if author.get("bot") else "observed",
-        provider_json=metadata,
+        ObjectDetails(
+            account_id=author_id,
+            text=_optional(record, "content"),
+            created_at=_optional(record, "timestamp"),
+            evidence_class="authored" if author.get("bot") else "observed",
+            provider_json=metadata,
+        ),
     )
     rows.activities[("message_authored", remote_id)] = _activity(
         "message_authored",
         remote_id,
         author_id,
         observed_at,
-        object_id=remote_id,
-        occurred_at=_optional(record, "timestamp"),
+        ActivityDetails(
+            object_id=remote_id,
+            occurred_at=_optional(record, "timestamp"),
+        ),
     )
     for attachment in record.get("attachments", []):
         _attachment(attachment, remote_id, rows)
@@ -199,7 +220,10 @@ def _metadata(record: dict[str, Any], observed_at: str, rows: Rows) -> None:
     remote_id = _required(record, "remote_id")
     if kind == "guild":
         rows.objects[(kind, remote_id)] = _object(
-            kind, remote_id, observed_at, provider_json={"identity_verified": True}
+            kind,
+            remote_id,
+            observed_at,
+            ObjectDetails(provider_json={"identity_verified": True}),
         )
         return
     if kind == "member":
@@ -211,25 +235,29 @@ def _metadata(record: dict[str, Any], observed_at: str, rows: Rows) -> None:
             kind,
             f"{record['guild_id']}:{user_id}",
             observed_at,
-            account_id=user_id,
-            created_at=_optional(record, "joined_at"),
-            provider_json={
-                "guild_id": record["guild_id"],
-                "roles": record.get("roles", []),
-                "nick": record.get("nick"),
-            },
+            ObjectDetails(
+                account_id=user_id,
+                created_at=_optional(record, "joined_at"),
+                provider_json={
+                    "guild_id": record["guild_id"],
+                    "roles": record.get("roles", []),
+                    "nick": record.get("nick"),
+                },
+            ),
         )
         return
     rows.objects[(kind, remote_id)] = _object(
         kind,
         remote_id,
         observed_at,
-        text=_optional(record, "topic") or _optional(record, "name"),
-        provider_json={
-            key: value
-            for key, value in record.items()
-            if key not in {"kind", "remote_id", "name", "topic"}
-        },
+        ObjectDetails(
+            text=_optional(record, "topic") or _optional(record, "name"),
+            provider_json={
+                key: value
+                for key, value in record.items()
+                if key not in {"kind", "remote_id", "name", "topic"}
+            },
+        ),
     )
 
 
@@ -249,16 +277,24 @@ def _gateway(
         "gateway_event",
         remote_id,
         observed_at,
-        provider_json={"event_name": event_name, "sequence": record.get("sequence"), "data": data},
+        ObjectDetails(
+            provider_json={
+                "event_name": event_name,
+                "sequence": record.get("sequence"),
+                "data": data,
+            }
+        ),
     )
     rows.activities[(event_name.lower(), remote_id)] = _activity(
         event_name.lower(),
         remote_id,
         context.account["id"],
         observed_at,
-        object_id=object_id,
-        state="deleted" if "DELETE" in event_name else "active",
-        provider_json={"observation": True},
+        ActivityDetails(
+            object_id=object_id,
+            state="deleted" if "DELETE" in event_name else "active",
+            provider_json={"observation": True},
+        ),
     )
 
 
@@ -270,15 +306,17 @@ def _export_message(record: dict[str, Any], observed_at: str, rows: Rows) -> Non
         "message",
         remote_id,
         observed_at,
-        account_id=author_id,
-        text=_optional(record, "content"),
-        created_at=_optional(record, "timestamp"),
-        evidence_class="authored",
-        provider_json={
-            "channel_id": _required(record, "channel_id"),
-            "source": "official_account_export",
-            "attachment_references": _optional(record, "attachments"),
-        },
+        ObjectDetails(
+            account_id=author_id,
+            text=_optional(record, "content"),
+            created_at=_optional(record, "timestamp"),
+            evidence_class="authored",
+            provider_json={
+                "channel_id": _required(record, "channel_id"),
+                "source": "official_account_export",
+                "attachment_references": _optional(record, "attachments"),
+            },
+        ),
     )
 
 
@@ -364,10 +402,12 @@ def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, A
     rows.accounts[context.account["id"]] = _account(
         context.account["id"],
         observed_at,
-        provider_json={
-            "application_id": context.account["application_id"],
-            "bot": True,
-        },
+        AccountDetails(
+            provider_json={
+                "application_id": context.account["application_id"],
+                "bot": True,
+            }
+        ),
     )
     for record in page_data(payload):
         _normalize_record(record, context, observed_at, rows)

--- a/.agents/scripts/_knowledge_social_discord_normalize.py
+++ b/.agents/scripts/_knowledge_social_discord_normalize.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize sanitized Discord pages into provider-neutral social records."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_discord import (
+    PROVIDER,
+    DiscordAdapterError,
+    page_data,
+)
+from knowledge_social_import import canonical_json, reject_credentials
+
+
+@dataclass(frozen=True)
+class PageContext:
+    """Verified connection policy needed to normalize one Discord page."""
+
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+@dataclass
+class Rows:
+    accounts: dict[str, dict[str, Any]]
+    objects: dict[tuple[str, str], dict[str, Any]]
+    activities: dict[tuple[str, str], dict[str, Any]]
+    media: dict[str, dict[str, Any]]
+
+
+def _required(record: dict[str, Any], field: str) -> str:
+    value = record.get(field)
+    if not isinstance(value, str) or not value:
+        raise DiscordAdapterError(f"Discord record requires {field}")
+    return value
+
+
+def _optional(record: dict[str, Any], field: str) -> str | None:
+    value = record.get(field)
+    if value is not None and not isinstance(value, str):
+        raise DiscordAdapterError(f"Discord record {field} must be text")
+    return value
+
+
+def _account(
+    remote_id: str,
+    observed_at: str,
+    *,
+    handle: str | None = None,
+    display_name: str | None = None,
+    provider_json: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "remote_id": remote_id,
+        "handle": handle,
+        "display_name": display_name,
+        "observed_at": observed_at,
+        "provider_json": provider_json or {},
+    }
+
+
+def _object(
+    kind: str,
+    remote_id: str,
+    observed_at: str,
+    *,
+    account_id: str | None = None,
+    text: str | None = None,
+    created_at: str | None = None,
+    evidence_class: str = "observed",
+    provider_json: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    metadata = provider_json or {}
+    reject_credentials(metadata)
+    return {
+        "object_type": kind,
+        "remote_id": remote_id,
+        "account_remote_id": account_id,
+        "text": text,
+        "created_at": created_at,
+        "observed_at": observed_at,
+        "evidence_class": evidence_class,
+        "provider_json": metadata,
+    }
+
+
+def _activity(
+    kind: str,
+    remote_id: str,
+    actor_id: str,
+    observed_at: str,
+    *,
+    object_id: str | None = None,
+    occurred_at: str | None = None,
+    state: str = "active",
+    provider_json: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "activity_type": kind,
+        "remote_id": remote_id,
+        "actor_remote_id": actor_id,
+        "object_remote_id": object_id,
+        "occurred_at": occurred_at,
+        "observed_at": observed_at,
+        "state": state,
+        "provider_json": provider_json or {},
+    }
+
+
+def _user(user: dict[str, Any], observed_at: str, rows: Rows) -> str:
+    remote_id = _required(user, "id")
+    rows.accounts[remote_id] = _account(
+        remote_id,
+        observed_at,
+        handle=_optional(user, "username"),
+        display_name=_optional(user, "global_name"),
+        provider_json={"bot": bool(user.get("bot", False))},
+    )
+    return remote_id
+
+
+def _mentions(record: dict[str, Any], observed_at: str, rows: Rows) -> list[str]:
+    result = []
+    for mention in record.get("mentions", []):
+        if not isinstance(mention, dict):
+            raise DiscordAdapterError("Discord mention must be an object")
+        result.append(_user(mention, observed_at, rows))
+    return result
+
+
+def _attachment(
+    attachment: Any, message_id: str, rows: Rows
+) -> None:
+    if not isinstance(attachment, dict):
+        raise DiscordAdapterError("Discord attachment must be an object")
+    attachment_id = _required(attachment, "id")
+    byte_size = attachment.get("size")
+    if isinstance(byte_size, bool) or not isinstance(byte_size, int):
+        raise DiscordAdapterError("Discord attachment size must be an integer")
+    rows.media[attachment_id] = {
+        "remote_id": attachment_id,
+        "object_remote_id": message_id,
+        "content_sha256": None,
+        "mime_type": _optional(attachment, "content_type"),
+        "byte_size": byte_size,
+        "blob_ref": None,
+        "hydration_state": "remote_only",
+    }
+
+
+def _message(record: dict[str, Any], observed_at: str, rows: Rows) -> None:
+    remote_id = _required(record, "remote_id")
+    author = record.get("author")
+    if not isinstance(author, dict):
+        raise DiscordAdapterError("Discord message author must be an object")
+    author_id = _user(author, observed_at, rows)
+    metadata = {
+        "channel_id": _required(record, "channel_id"),
+        "guild_id": _optional(record, "guild_id"),
+        "edited_at": _optional(record, "edited_timestamp"),
+        "message_type": record.get("type", 0),
+        "mentions": _mentions(record, observed_at, rows),
+        "embeds": record.get("embeds", []),
+        "reactions": record.get("reactions", []),
+        "reference_message_id": _optional(record, "reference_message_id"),
+    }
+    rows.objects[("message", remote_id)] = _object(
+        "message",
+        remote_id,
+        observed_at,
+        account_id=author_id,
+        text=_optional(record, "content"),
+        created_at=_optional(record, "timestamp"),
+        evidence_class="authored" if author.get("bot") else "observed",
+        provider_json=metadata,
+    )
+    rows.activities[("message_authored", remote_id)] = _activity(
+        "message_authored",
+        remote_id,
+        author_id,
+        observed_at,
+        object_id=remote_id,
+        occurred_at=_optional(record, "timestamp"),
+    )
+    for attachment in record.get("attachments", []):
+        _attachment(attachment, remote_id, rows)
+
+
+def _metadata(record: dict[str, Any], observed_at: str, rows: Rows) -> None:
+    kind = _required(record, "kind")
+    remote_id = _required(record, "remote_id")
+    if kind == "guild":
+        rows.objects[(kind, remote_id)] = _object(
+            kind, remote_id, observed_at, provider_json={"identity_verified": True}
+        )
+        return
+    if kind == "member":
+        user = record.get("user")
+        if not isinstance(user, dict):
+            raise DiscordAdapterError("Discord member user must be an object")
+        user_id = _user(user, observed_at, rows)
+        rows.objects[(kind, f"{record['guild_id']}:{user_id}")] = _object(
+            kind,
+            f"{record['guild_id']}:{user_id}",
+            observed_at,
+            account_id=user_id,
+            created_at=_optional(record, "joined_at"),
+            provider_json={
+                "guild_id": record["guild_id"],
+                "roles": record.get("roles", []),
+                "nick": record.get("nick"),
+            },
+        )
+        return
+    rows.objects[(kind, remote_id)] = _object(
+        kind,
+        remote_id,
+        observed_at,
+        text=_optional(record, "topic") or _optional(record, "name"),
+        provider_json={
+            key: value
+            for key, value in record.items()
+            if key not in {"kind", "remote_id", "name", "topic"}
+        },
+    )
+
+
+def _gateway(
+    record: dict[str, Any], context: PageContext, observed_at: str, rows: Rows
+) -> None:
+    remote_id = _required(record, "remote_id")
+    event_name = _required(record, "event_name")
+    data = record.get("data")
+    if not isinstance(data, dict):
+        raise DiscordAdapterError("Discord gateway event data must be an object")
+    reject_credentials(data)
+    object_id = data.get("id") or data.get("message_id")
+    if object_id is not None and not isinstance(object_id, str):
+        raise DiscordAdapterError("Discord gateway resource ID must be text")
+    rows.objects[("gateway_event", remote_id)] = _object(
+        "gateway_event",
+        remote_id,
+        observed_at,
+        provider_json={"event_name": event_name, "sequence": record.get("sequence"), "data": data},
+    )
+    rows.activities[(event_name.lower(), remote_id)] = _activity(
+        event_name.lower(),
+        remote_id,
+        context.account["id"],
+        observed_at,
+        object_id=object_id,
+        state="deleted" if "DELETE" in event_name else "active",
+        provider_json={"observation": True},
+    )
+
+
+def _export_message(record: dict[str, Any], observed_at: str, rows: Rows) -> None:
+    remote_id = _required(record, "remote_id")
+    author_id = _required(record, "author_id")
+    rows.accounts[author_id] = _account(author_id, observed_at)
+    rows.objects[("message", remote_id)] = _object(
+        "message",
+        remote_id,
+        observed_at,
+        account_id=author_id,
+        text=_optional(record, "content"),
+        created_at=_optional(record, "timestamp"),
+        evidence_class="authored",
+        provider_json={
+            "channel_id": _required(record, "channel_id"),
+            "source": "official_account_export",
+            "attachment_references": _optional(record, "attachments"),
+        },
+    )
+
+
+def _identity_policy(account: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: account[key]
+        for key in (
+            "application_id",
+            "guild_id",
+            "channel_ids",
+            "thread_ids",
+            "dm_channel_ids",
+            "message_content_intent",
+            "guild_members_intent",
+            "export_user_id",
+        )
+    }
+
+
+def _coverage(context: PageContext, payload: dict[str, Any], observed_at: str) -> list[dict[str, Any]]:
+    reasons = {
+        "arbitrary_user_dms": "bot_api_cannot_read_user_dm_history_outside_bot_visible_allowlist",
+        "deleted_message_history": "rest_api_does_not_reconstruct_deleted_messages_or_prior_revisions",
+        "reaction_users": "reaction_summaries_collected_without_unbounded_user_hydration",
+        "attachments": "expiring_cdn_urls_are_transport_data_and_are_not_canonical_identity",
+    }
+    if not context.account["message_content_intent"]:
+        reasons["message_content"] = "message_content_intent_not_enabled_or_approved"
+    if not context.account["guild_members_intent"]:
+        reasons["guild_members"] = "guild_members_intent_not_enabled_or_approved"
+    meta = payload.get("meta", {})
+    if isinstance(meta, dict):
+        for reason in meta.get("gaps", []):
+            if isinstance(reason, str):
+                digest = hashlib.sha256(reason.encode()).hexdigest()[:12]
+                reasons[f"stream_gap_{digest}"] = reason
+    return [
+        {
+            "stream": stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": None,
+            "unavailable_reason": reason,
+            "status": "unavailable" if stream == "arbitrary_user_dms" else "partial",
+            "observed_at": observed_at,
+        }
+        for stream, reason in reasons.items()
+    ]
+
+
+def _normalize_record(
+    record: dict[str, Any], context: PageContext, observed_at: str, rows: Rows
+) -> None:
+    reject_credentials(record)
+    kind = record.get("kind")
+    if kind == "message":
+        _message(record, observed_at, rows)
+    elif kind in {"guild", "channel", "role", "member"}:
+        _metadata(record, observed_at, rows)
+    elif kind == "gateway_event":
+        _gateway(record, context, observed_at, rows)
+    elif kind == "export_message":
+        _export_message(record, observed_at, rows)
+    else:
+        raise DiscordAdapterError("Discord page contains an unsupported item kind")
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    """Validate a successful page and converge API, Gateway, and export evidence."""
+    reject_credentials(payload)
+    observed_at = payload.get("observed_at")
+    if not isinstance(observed_at, str) or not observed_at:
+        raise DiscordAdapterError("Discord page observed_at must be text")
+    identity = _identity_policy(context.account)
+    existing = context.policy.get("discord_identity")
+    if existing is not None and existing != identity:
+        raise DiscordAdapterError("stored Discord authority does not match verified identity")
+    policy = dict(context.policy)
+    policy["discord_identity"] = identity
+    reject_credentials(policy)
+    rows = Rows({}, {}, {}, {})
+    rows.accounts[context.account["id"]] = _account(
+        context.account["id"],
+        observed_at,
+        provider_json={
+            "application_id": context.account["application_id"],
+            "bot": True,
+        },
+    )
+    for record in page_data(payload):
+        _normalize_record(record, context, observed_at, rows)
+    archive = {
+        "provider": PROVIDER,
+        "connection_id": context.connection_id,
+        "remote_account_id": context.account["id"],
+        "exported_at": observed_at,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": policy,
+        "accounts": list(rows.accounts.values()),
+        "objects": list(rows.objects.values()),
+        "activities": list(rows.activities.values()),
+        "media": list(rows.media.values()),
+        "coverage": _coverage(context, payload, observed_at),
+    }
+    reject_credentials(archive)
+    canonical_json(archive)
+    return archive

--- a/.agents/scripts/_knowledge_social_discord_provider.py
+++ b/.agents/scripts/_knowledge_social_discord_provider.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded read-only Discord REST and local replay subprocess."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import sys
+import time
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from _knowledge_social_discord_contract import (
+    ApiResult,
+    DiscordReadProviderError,
+    exact_keys,
+    identity_value,
+    object_value,
+    snowflake,
+    terminal_payload,
+)
+from _knowledge_social_discord_routes import page, page_request
+
+API_BASE = "https://discord.com/api/v10"
+MAX_REQUEST_BYTES = 64 * 1024
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+HTTP_TIMEOUT_SECONDS = 60
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+READ_PATH = re.compile(
+    r"^/(users/@me|applications/@me|guilds/[0-9]+(?:/(?:channels|roles|members))?|channels/[0-9]+(?:/messages)?)$"
+)
+UrlOpen = Callable[..., Any]
+
+
+def _prefix(profile: str) -> str:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise DiscordReadProviderError("Discord bot profile configuration is invalid")
+    return f"DISCORD_{profile.upper()}"
+
+
+def _env(prefix: str, suffix: str, *, required: bool = False) -> str | None:
+    value = os.environ.get(f"{prefix}_{suffix}")
+    if required and not value:
+        message = (
+            "Discord bot profile token is missing"
+            if suffix == "BOT_TOKEN"
+            else "Discord bot profile configuration is invalid"
+        )
+        raise DiscordReadProviderError(message)
+    if value is not None and ("\x00" in value or len(value.encode("utf-8")) > 65536):
+        raise DiscordReadProviderError("Discord bot profile configuration is invalid")
+    return value
+
+
+def _ids(value: str | None, field: str) -> tuple[str, ...]:
+    if not value:
+        return ()
+    values = tuple(part.strip() for part in value.split(",") if part.strip())
+    result = tuple(snowflake(part, field) or "" for part in values)
+    if len(result) != len(set(result)):
+        raise DiscordReadProviderError("Discord bot profile configuration is invalid")
+    return result
+
+
+def _flag(value: str | None) -> bool:
+    if value is None:
+        return False
+    if value.lower() not in ("true", "false"):
+        raise DiscordReadProviderError("Discord bot profile configuration is invalid")
+    return value.lower() == "true"
+
+
+def _config(profile: str) -> tuple[str, dict[str, Any], str | None, str | None]:
+    prefix = _prefix(profile)
+    token = _env(prefix, "BOT_TOKEN", required=True) or ""
+    config = {
+        "application_id": snowflake(
+            _env(prefix, "APPLICATION_ID", required=True), "application ID"
+        ),
+        "guild_id": snowflake(_env(prefix, "GUILD_ID", required=True), "guild ID"),
+        "channel_ids": _ids(_env(prefix, "CHANNEL_IDS"), "channel ID"),
+        "thread_ids": _ids(_env(prefix, "THREAD_IDS"), "thread ID"),
+        "dm_channel_ids": _ids(_env(prefix, "DM_CHANNEL_IDS"), "DM channel ID"),
+        "message_content_intent": _flag(_env(prefix, "MESSAGE_CONTENT_INTENT")),
+        "guild_members_intent": _flag(_env(prefix, "GUILD_MEMBERS_INTENT")),
+        "export_user_id": snowflake(
+            _env(prefix, "EXPORT_USER_ID"), "export user ID", optional=True
+        ),
+    }
+    if not any(
+        (config["channel_ids"], config["thread_ids"], config["dm_channel_ids"])
+    ):
+        raise DiscordReadProviderError("Discord bot profile configuration is invalid")
+    all_surfaces = (
+        *config["channel_ids"],
+        *config["thread_ids"],
+        *config["dm_channel_ids"],
+    )
+    if len(all_surfaces) != len(set(all_surfaces)):
+        raise DiscordReadProviderError("Discord bot profile configuration is invalid")
+    return (
+        token,
+        config,
+        _env(prefix, "EXPORT_PATH"),
+        _env(prefix, "GATEWAY_EVENTS_PATH"),
+    )
+
+
+def _request_payload() -> dict[str, Any]:
+    payload = sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1)
+    if len(payload) > MAX_REQUEST_BYTES:
+        raise DiscordReadProviderError("Discord read request exceeds the safety limit")
+    try:
+        request = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise DiscordReadProviderError("Discord read request is not valid JSON") from error
+    if not isinstance(request, dict):
+        raise DiscordReadProviderError("Discord read request root must be an object")
+    return request
+
+
+def _decode_response(payload: bytes) -> Any:
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise DiscordReadProviderError("Discord read response exceeds the safety limit")
+    try:
+        return json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise DiscordReadProviderError("Discord API returned no valid JSON") from error
+
+
+def _retry_epoch(value: str | None) -> int | None:
+    try:
+        seconds = float(value) if value is not None else None
+    except ValueError:
+        return None
+    if seconds is None or not math.isfinite(seconds) or seconds < 0:
+        return None
+    return int(time.time() + math.ceil(seconds))
+
+
+def _rate_headers(headers: Any) -> dict[str, str]:
+    names = (
+        "X-RateLimit-Limit",
+        "X-RateLimit-Remaining",
+        "X-RateLimit-Reset",
+        "X-RateLimit-Reset-After",
+        "X-RateLimit-Bucket",
+        "X-RateLimit-Scope",
+    )
+    return {name: value for name in names if (value := headers.get(name)) is not None}
+
+
+def _api(
+    token: str, opener: UrlOpen, endpoint: str, params: dict[str, str]
+) -> ApiResult:
+    if READ_PATH.fullmatch(endpoint) is None:
+        raise DiscordReadProviderError("Discord API endpoint is not allowlisted")
+    url = f"{API_BASE}{endpoint}"
+    if params:
+        url = f"{url}?{urlencode(params)}"
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bot {token}",
+            "User-Agent": "aidevops-discord-knowledge/1",
+        },
+        method="GET",
+    )
+    try:
+        with opener(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", 200)
+            if isinstance(status, bool) or not isinstance(status, int):
+                raise DiscordReadProviderError("Discord HTTP status is invalid")
+            payload = response.read(MAX_RESPONSE_BYTES + 1)
+            if not isinstance(payload, bytes):
+                raise DiscordReadProviderError("Discord HTTP response is invalid")
+            return ApiResult(status, _decode_response(payload), rate_limit=_rate_headers(response.headers))
+    except HTTPError as error:
+        return ApiResult(
+            error.code,
+            {},
+            _retry_epoch(error.headers.get("Retry-After")),
+            _rate_headers(error.headers),
+        )
+    except (TimeoutError, URLError, OSError) as error:
+        raise DiscordReadProviderError("Discord read provider request failed") from error
+
+
+def _identity(
+    api: Callable[[str, dict[str, str]], ApiResult],
+    config: dict[str, Any],
+    expected_bot_id: str,
+) -> dict[str, Any]:
+    user = api("/users/@me", {})
+    if user.status != 200:
+        return terminal_payload(user)
+    application = api("/applications/@me", {})
+    if application.status != 200:
+        return terminal_payload(application)
+    guild = api(f"/guilds/{config['guild_id']}", {})
+    if guild.status != 200:
+        return terminal_payload(guild)
+    return {
+        "status": 200,
+        "observed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "data": identity_value(
+            object_value(user.payload, "current user"),
+            object_value(application.payload, "current application"),
+            object_value(guild.payload, "guild"),
+            config,
+            expected_bot_id,
+        ),
+    }
+
+
+def _verify_surfaces(
+    api: Callable[[str, dict[str, str]], ApiResult], config: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Prove every allowlisted channel belongs to its declared authority."""
+    groups = (
+        (config["channel_ids"], {0, 5, 15, 16}, True),
+        (config["thread_ids"], {10, 11, 12}, True),
+        (config["dm_channel_ids"], {1}, False),
+    )
+    for channel_ids, allowed_types, guild_surface in groups:
+        failure = _verify_surface_group(
+            api, channel_ids, allowed_types, config["guild_id"], guild_surface
+        )
+        if failure is not None:
+            return failure
+    return None
+
+
+def _verify_surface_group(
+    api: Callable[[str, dict[str, str]], ApiResult],
+    channel_ids: tuple[str, ...],
+    allowed_types: set[int],
+    guild_id: str,
+    guild_surface: bool,
+) -> dict[str, Any] | None:
+    for channel_id in channel_ids:
+        result = api(f"/channels/{channel_id}", {})
+        if result.status != 200:
+            return terminal_payload(result)
+        channel = object_value(result.payload, "allowlisted channel")
+        channel_type = channel.get("type")
+        expected_guild = guild_id if guild_surface else None
+        if channel_type not in allowed_types or channel.get("guild_id") != expected_guild:
+            raise DiscordReadProviderError(
+                "Discord identity does not match the configured connection"
+            )
+    return None
+
+
+def _execute(
+    raw_request: dict[str, Any],
+    api: Callable[[str, dict[str, str]], ApiResult],
+    config: dict[str, Any],
+    export_path: str | None,
+    gateway_path: str | None,
+) -> dict[str, Any]:
+    action = raw_request.get("action")
+    if action == "identity":
+        exact_keys(raw_request, {"action", "account_id"})
+        account_id = snowflake(raw_request.get("account_id"), "bot user ID")
+        return _identity(api, config, account_id or "")
+    if action != "page":
+        raise DiscordReadProviderError("Discord read action is unsupported")
+    request = page_request(raw_request)
+    identity = _identity(api, config, request.config["bot_id"])
+    if identity.get("status") != 200:
+        return identity
+    expected_identity = dict(request.config)
+    expected_identity["id"] = expected_identity.pop("bot_id")
+    for field in ("channel_ids", "thread_ids", "dm_channel_ids"):
+        expected_identity[field] = list(expected_identity[field])
+    if identity.get("data") != expected_identity:
+        raise DiscordReadProviderError(
+            "Discord identity does not match the configured connection"
+        )
+    surface_failure = _verify_surfaces(api, config)
+    return surface_failure or page(
+        api, request, export_path=export_path, gateway_path=gateway_path
+    )
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode("utf-8")) > MAX_RESPONSE_BYTES:
+        raise DiscordReadProviderError("Discord read response exceeds the safety limit")
+    print(encoded)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        raw_request = _request_payload()
+        token, config, export_path, gateway_path = _config(args.profile)
+        api = lambda endpoint, params: _api(token, urlopen, endpoint, params)
+        payload = _execute(raw_request, api, config, export_path, gateway_path)
+        _emit(payload)
+        return 0
+    except DiscordReadProviderError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - intentionally redact provider internals
+        print("ERROR: Discord read provider request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_discord_reader.py
+++ b/.agents/scripts/_knowledge_social_discord_reader.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and fixture readers for the read-only Discord adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from _knowledge_social_discord import (
+    DiscordAdapterError,
+    DiscordProviderUnavailableError,
+    PageRequest,
+    snowflake,
+)
+from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
+from knowledge_social_import import reject_credentials
+
+READ_TIMEOUT_SECONDS = 120
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+SAFE_PROVIDER_FAILURES = (
+    "Discord bot profile token is missing",
+    "Discord bot profile configuration is invalid",
+    "Discord identity does not match the configured connection",
+    "Discord account export is unavailable",
+    "Discord gateway event spool is unavailable",
+)
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    if len(output.encode("utf-8")) > MAX_RESPONSE_BYTES:
+        raise DiscordAdapterError("Discord read response exceeds the safety limit")
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise DiscordAdapterError("Discord read provider returned no valid JSON") from error
+    if not isinstance(payload, dict):
+        raise DiscordAdapterError("Discord read response root must be an object")
+    return payload
+
+
+def _provider_failure(stderr: str) -> DiscordProviderUnavailableError:
+    for message in SAFE_PROVIDER_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return DiscordProviderUnavailableError(message)
+    return DiscordProviderUnavailableError("Discord read provider is unavailable")
+
+
+DISCORD_BOT_POLICY = GuardedOAuthPolicy(
+    "Discord",
+    "DISCORD",
+    "DISCORD_READ_LOG",
+    READ_TIMEOUT_SECONDS,
+    _decode_output,
+    _provider_failure,
+    DiscordProviderUnavailableError,
+    (
+        "BOT_TOKEN",
+        "APPLICATION_ID",
+        "GUILD_ID",
+        "CHANNEL_IDS",
+        "THREAD_IDS",
+        "DM_CHANNEL_IDS",
+        "MESSAGE_CONTENT_INTENT",
+        "GUILD_MEMBERS_INTENT",
+        "EXPORT_USER_ID",
+        "EXPORT_PATH",
+        "GATEWAY_EVENTS_PATH",
+    ),
+    "bot",
+)
+
+
+class GuardedDiscordBot(GuardedOAuthReader):
+    """Execute only identity and allowlisted GET/local-replay reads."""
+
+    def __init__(self, helper: Path, profile: str) -> None:
+        super().__init__(helper, profile, DISCORD_BOT_POLICY)
+
+
+def _fixture_page(entry: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    expectation = entry.get("expect_request", {})
+    if not isinstance(expectation, dict):
+        raise DiscordAdapterError("Discord fixture expectation must be an object")
+    actual = request.payload()
+    if any(actual.get(key) != value for key, value in expectation.items()):
+        raise DiscordAdapterError("Discord request did not resume at the checkpoint")
+    response = entry.get("response", entry)
+    if not isinstance(response, dict):
+        raise DiscordAdapterError("Discord fixture page must be an object")
+    return response
+
+
+class FixtureDiscord:
+    """Deterministic provider substitute for Discord collection fixtures."""
+
+    def __init__(self, path: Path) -> None:
+        self.fixture = FixtureSequence(path, "Discord", DiscordAdapterError)
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        del expected_id
+        return self.fixture.identity()
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        return _fixture_page(self.fixture.next_page(), request)
+
+
+def _bool(value: Any, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise DiscordAdapterError(f"Discord {field} must be boolean")
+    return value
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    """Validate application, bot, guild, allowlists, and export user binding."""
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise DiscordAdapterError("Discord identity returned no account")
+    bot_id = snowflake(data.get("id"), "bot user ID")
+    if bot_id != expected_id:
+        raise DiscordAdapterError("Discord identity does not match the configured connection")
+    result = {
+        "id": bot_id,
+        "application_id": snowflake(data.get("application_id"), "application ID"),
+        "guild_id": snowflake(data.get("guild_id"), "guild ID"),
+        "channel_ids": data.get("channel_ids"),
+        "thread_ids": data.get("thread_ids"),
+        "dm_channel_ids": data.get("dm_channel_ids"),
+        "message_content_intent": _bool(
+            data.get("message_content_intent"), "message-content intent"
+        ),
+        "guild_members_intent": _bool(
+            data.get("guild_members_intent"), "guild-members intent"
+        ),
+        "export_user_id": data.get("export_user_id"),
+    }
+    for field in ("channel_ids", "thread_ids", "dm_channel_ids"):
+        values = result[field]
+        if not isinstance(values, list):
+            raise DiscordAdapterError(f"Discord {field} must be an array")
+        result[field] = [snowflake(value, field) for value in values]
+    if result["export_user_id"] is not None:
+        result["export_user_id"] = snowflake(result["export_user_id"], "export user ID")
+    return result

--- a/.agents/scripts/_knowledge_social_discord_routes.py
+++ b/.agents/scripts/_knowledge_social_discord_routes.py
@@ -42,6 +42,13 @@ class ProviderPageRequest:
     limit: int
 
 
+@dataclass(frozen=True)
+class SuccessMeta:
+    watermark: dict[str, Any] | None
+    snapshot: bool
+    gaps: list[str] | None = None
+
+
 def page_request(request: dict[str, Any]) -> ProviderPageRequest:
     exact_keys(
         request,
@@ -107,10 +114,7 @@ def page_request(request: dict[str, Any]) -> ProviderPageRequest:
 def _success(
     data: list[dict[str, Any]],
     next_cursor: dict[str, Any] | None,
-    watermark: dict[str, Any] | None,
-    *,
-    snapshot: bool,
-    gaps: list[str] | None = None,
+    meta: SuccessMeta,
 ) -> dict[str, Any]:
     return {
         "status": 200,
@@ -118,10 +122,10 @@ def _success(
         "data": data,
         "meta": {
             "next_cursor": next_cursor,
-            "watermark": watermark,
+            "watermark": meta.watermark,
             "complete": next_cursor is None,
-            "snapshot": snapshot,
-            "gaps": gaps or [],
+            "snapshot": meta.snapshot,
+            "gaps": meta.gaps or [],
         },
     }
 
@@ -214,7 +218,7 @@ def _messages(api: ApiCall, request: ProviderPageRequest) -> dict[str, Any]:
     channels = _message_channels(request)
     index, before, newest, prior = _message_state(request, channels)
     if index >= len(channels):
-        return _success([], None, {**prior, **newest}, snapshot=False)
+        return _success([], None, SuccessMeta({**prior, **newest}, False))
     channel_id = channels[index]
     failure, items, records = _message_response(
         api, channel_id, request.limit, before
@@ -230,8 +234,10 @@ def _messages(api: ApiCall, request: ProviderPageRequest) -> dict[str, Any]:
     return _success(
         accepted,
         next_cursor,
-        {**prior, **newest} if next_cursor is None else None,
-        snapshot=False,
+        SuccessMeta(
+            {**prior, **newest} if next_cursor is None else None,
+            False,
+        ),
     )
 
 
@@ -280,7 +286,7 @@ def _metadata(api: ApiCall, request: ProviderPageRequest) -> dict[str, Any]:
         for item in array_value(roles.payload, "guild roles")
     )
     data.append({"kind": "guild", "remote_id": guild_id})
-    return _success(data, None, None, snapshot=True)
+    return _success(data, None, SuccessMeta(None, True))
 
 
 def _members(api: ApiCall, request: ProviderPageRequest) -> dict[str, Any]:
@@ -288,9 +294,7 @@ def _members(api: ApiCall, request: ProviderPageRequest) -> dict[str, Any]:
         return _success(
             [],
             None,
-            None,
-            snapshot=True,
-            gaps=["guild_members_intent_not_enabled"],
+            SuccessMeta(None, True, ["guild_members_intent_not_enabled"]),
         )
     cursor = request.cursor or {"after": None}
     if set(cursor) != {"after"}:
@@ -305,7 +309,7 @@ def _members(api: ApiCall, request: ProviderPageRequest) -> dict[str, Any]:
     items = array_value(result.payload, "guild members")
     data = [serialize_member(item, request.config["guild_id"]) for item in items]
     next_cursor = {"after": data[-1]["remote_id"]} if len(items) == request.limit else None
-    return _success(data, next_cursor, None, snapshot=True)
+    return _success(data, next_cursor, SuccessMeta(None, True))
 
 
 def page(
@@ -316,23 +320,29 @@ def page(
     gateway_path: str | None,
 ) -> dict[str, Any]:
     """Dispatch one request through an explicit read-only route."""
-    if request.stream == "messages":
-        return _messages(api, request)
-    if request.stream == "metadata":
-        return _metadata(api, request)
-    if request.stream == "members":
-        return _members(api, request)
-    if request.stream == "gateway_events":
+    def gateway_events() -> dict[str, Any]:
         data, next_cursor, watermark = page_gateway_events(
             gateway_path,
             request.config,
             request.cursor or request.watermark,
             request.limit,
         )
-        return _success(data, next_cursor, watermark, snapshot=False)
-    if request.stream == "account_export":
+        return _success(data, next_cursor, SuccessMeta(watermark, False))
+
+    def account_export() -> dict[str, Any]:
         data, next_cursor = page_account_export(
             export_path, request.config, request.cursor, request.limit
         )
-        return _success(data, next_cursor, None, snapshot=True)
-    raise DiscordReadProviderError("Discord read stream is unsupported")
+        return _success(data, next_cursor, SuccessMeta(None, True))
+
+    handlers: dict[str, Callable[[], dict[str, Any]]] = {
+        "messages": lambda: _messages(api, request),
+        "metadata": lambda: _metadata(api, request),
+        "members": lambda: _members(api, request),
+        "gateway_events": gateway_events,
+        "account_export": account_export,
+    }
+    handler = handlers.get(request.stream)
+    if handler is None:
+        raise DiscordReadProviderError("Discord read stream is unsupported")
+    return handler()

--- a/.agents/scripts/_knowledge_social_discord_routes.py
+++ b/.agents/scripts/_knowledge_social_discord_routes.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Allowlisted Discord REST and local replay routes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from _knowledge_social_discord_contract import (
+    ApiResult,
+    DiscordReadProviderError,
+    array_value,
+    boolean,
+    exact_keys,
+    integer,
+    object_value,
+    observed_at,
+    serialize_channel,
+    serialize_member,
+    serialize_message,
+    serialize_role,
+    snowflake,
+    terminal_payload,
+)
+from _knowledge_social_discord_export import page_account_export
+from _knowledge_social_discord_gateway import page_gateway_events
+
+ApiCall = Callable[[str, dict[str, str]], ApiResult]
+STREAMS = {"messages", "metadata", "members", "gateway_events", "account_export"}
+
+
+@dataclass(frozen=True)
+class ProviderPageRequest:
+    """Validated parent-to-child page request."""
+
+    stream: str
+    config: dict[str, Any]
+    cursor: dict[str, Any] | None
+    watermark: dict[str, Any] | None
+    limit: int
+
+
+def page_request(request: dict[str, Any]) -> ProviderPageRequest:
+    exact_keys(
+        request,
+        {
+            "action",
+            "stream",
+            "bot_id",
+            "application_id",
+            "guild_id",
+            "channel_ids",
+            "thread_ids",
+            "dm_channel_ids",
+            "message_content_intent",
+            "guild_members_intent",
+            "export_user_id",
+            "cursor",
+            "watermark",
+            "limit",
+        },
+    )
+    stream = request.get("stream")
+    if not isinstance(stream, str) or stream not in STREAMS:
+        raise DiscordReadProviderError("Discord read stream is unsupported")
+    cursor = request.get("cursor")
+    watermark = request.get("watermark")
+    if cursor is not None and not isinstance(cursor, dict):
+        raise DiscordReadProviderError("Discord read cursor must be an object")
+    if watermark is not None and not isinstance(watermark, dict):
+        raise DiscordReadProviderError("Discord read watermark must be an object")
+    limit = integer(request.get("limit"), "read limit", minimum=1)
+    if limit > 100:
+        raise DiscordReadProviderError("Discord read limit exceeds 100")
+
+    def ids(field: str) -> tuple[str, ...]:
+        value = request.get(field)
+        if not isinstance(value, list):
+            raise DiscordReadProviderError(f"Discord {field} must be an array")
+        result = tuple(snowflake(item, field) or "" for item in value)
+        if len(result) != len(set(result)):
+            raise DiscordReadProviderError(f"Discord {field} contains duplicates")
+        return result
+
+    config = {
+        "bot_id": snowflake(request.get("bot_id"), "bot user ID"),
+        "application_id": snowflake(request.get("application_id"), "application ID"),
+        "guild_id": snowflake(request.get("guild_id"), "guild ID"),
+        "channel_ids": ids("channel_ids"),
+        "thread_ids": ids("thread_ids"),
+        "dm_channel_ids": ids("dm_channel_ids"),
+        "message_content_intent": boolean(
+            request.get("message_content_intent"), "message-content intent"
+        ),
+        "guild_members_intent": boolean(
+            request.get("guild_members_intent"), "guild-members intent"
+        ),
+        "export_user_id": snowflake(
+            request.get("export_user_id"), "export user ID", optional=True
+        ),
+    }
+    return ProviderPageRequest(stream, config, cursor, watermark, limit)
+
+
+def _success(
+    data: list[dict[str, Any]],
+    next_cursor: dict[str, Any] | None,
+    watermark: dict[str, Any] | None,
+    *,
+    snapshot: bool,
+    gaps: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": data,
+        "meta": {
+            "next_cursor": next_cursor,
+            "watermark": watermark,
+            "complete": next_cursor is None,
+            "snapshot": snapshot,
+            "gaps": gaps or [],
+        },
+    }
+
+
+def _message_channels(request: ProviderPageRequest) -> tuple[str, ...]:
+    return (
+        *request.config["channel_ids"],
+        *request.config["thread_ids"],
+        *request.config["dm_channel_ids"],
+    )
+
+
+def _message_state(
+    request: ProviderPageRequest, channels: tuple[str, ...]
+) -> tuple[int, str | None, dict[str, str], dict[str, str]]:
+    cursor = request.cursor or {"index": 0, "before": None, "newest": {}}
+    if set(cursor) != {"index", "before", "newest"}:
+        raise DiscordReadProviderError("Discord message cursor is invalid")
+    index = integer(cursor.get("index"), "message channel index")
+    before = snowflake(cursor.get("before"), "message before cursor", optional=True)
+    newest = cursor.get("newest")
+    if not isinstance(newest, dict):
+        raise DiscordReadProviderError("Discord message watermark is invalid")
+    return index, before, newest, _message_watermark(request, channels)
+
+
+def _message_watermark(
+    request: ProviderPageRequest, channels: tuple[str, ...]
+) -> dict[str, str]:
+    prior = request.watermark or {}
+    for key, value in prior.items():
+        if key not in channels or not isinstance(value, str) or not value.isdigit():
+            raise DiscordReadProviderError("Discord message watermark is invalid")
+    return prior
+
+
+def _bounded_messages(
+    records: list[dict[str, Any]], stop_at: str | None
+) -> tuple[list[dict[str, Any]], bool]:
+    if stop_at is None:
+        return records, False
+    for index, record in enumerate(records):
+        if record["remote_id"] == stop_at:
+            return records[:index], True
+    return records, False
+
+
+def _next_message_cursor(
+    index: int,
+    channels: tuple[str, ...],
+    records: list[dict[str, Any]],
+    newest: dict[str, str],
+    channel_complete: bool,
+) -> dict[str, Any] | None:
+    if channel_complete:
+        next_index = index + 1
+        if next_index >= len(channels):
+            return None
+        return {"index": next_index, "before": None, "newest": newest}
+    if not records:
+        raise DiscordReadProviderError("Discord message page cannot advance")
+    return {"index": index, "before": records[-1]["remote_id"], "newest": newest}
+
+
+def _message_response(
+    api: ApiCall, channel_id: str, limit: int, before: str | None
+) -> tuple[dict[str, Any] | None, list[Any], list[dict[str, Any]]]:
+    params = {"limit": str(limit)}
+    if before is not None:
+        params["before"] = before
+    result = api(f"/channels/{channel_id}/messages", params)
+    if result.status != 200:
+        return terminal_payload(result), [], []
+    items = array_value(result.payload, "message response")
+    records = [serialize_message(item, channel_id) for item in items]
+    return None, items, records
+
+
+def _update_newest(
+    newest: dict[str, str],
+    channel_id: str,
+    before: str | None,
+    records: list[dict[str, Any]],
+) -> None:
+    if before is None and records:
+        newest[channel_id] = records[0]["remote_id"]
+
+
+def _messages(api: ApiCall, request: ProviderPageRequest) -> dict[str, Any]:
+    channels = _message_channels(request)
+    index, before, newest, prior = _message_state(request, channels)
+    if index >= len(channels):
+        return _success([], None, {**prior, **newest}, snapshot=False)
+    channel_id = channels[index]
+    failure, items, records = _message_response(
+        api, channel_id, request.limit, before
+    )
+    if failure is not None:
+        return failure
+    _update_newest(newest, channel_id, before, records)
+    accepted, reached = _bounded_messages(records, prior.get(channel_id))
+    channel_complete = reached or len(items) < request.limit
+    next_cursor = _next_message_cursor(
+        index, channels, records, newest, channel_complete
+    )
+    return _success(
+        accepted,
+        next_cursor,
+        {**prior, **newest} if next_cursor is None else None,
+        snapshot=False,
+    )
+
+
+def _append_missing_threads(
+    api: ApiCall,
+    thread_ids: tuple[str, ...],
+    listed: set[str],
+    guild_id: str,
+    data: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    for thread_id in thread_ids:
+        if thread_id in listed:
+            continue
+        thread = api(f"/channels/{thread_id}", {})
+        if thread.status != 200:
+            return terminal_payload(thread)
+        data.append(serialize_channel(object_value(thread.payload, "thread"), guild_id))
+    return None
+
+
+def _metadata(api: ApiCall, request: ProviderPageRequest) -> dict[str, Any]:
+    guild_id = request.config["guild_id"]
+    channels = api(f"/guilds/{guild_id}/channels", {})
+    if channels.status != 200:
+        return terminal_payload(channels)
+    roles = api(f"/guilds/{guild_id}/roles", {})
+    if roles.status != 200:
+        return terminal_payload(roles)
+    allowed_channels = {
+        *request.config["channel_ids"],
+        *request.config["thread_ids"],
+    }
+    data = [
+        serialize_channel(item, guild_id)
+        for item in array_value(channels.payload, "guild channels")
+        if item.get("id") in allowed_channels
+    ]
+    listed = {item["remote_id"] for item in data}
+    thread_failure = _append_missing_threads(
+        api, request.config["thread_ids"], listed, guild_id, data
+    )
+    if thread_failure is not None:
+        return thread_failure
+    data.extend(
+        serialize_role(item, guild_id)
+        for item in array_value(roles.payload, "guild roles")
+    )
+    data.append({"kind": "guild", "remote_id": guild_id})
+    return _success(data, None, None, snapshot=True)
+
+
+def _members(api: ApiCall, request: ProviderPageRequest) -> dict[str, Any]:
+    if not request.config["guild_members_intent"]:
+        return _success(
+            [],
+            None,
+            None,
+            snapshot=True,
+            gaps=["guild_members_intent_not_enabled"],
+        )
+    cursor = request.cursor or {"after": None}
+    if set(cursor) != {"after"}:
+        raise DiscordReadProviderError("Discord member cursor is invalid")
+    after = snowflake(cursor.get("after"), "member cursor", optional=True)
+    params = {"limit": str(request.limit)}
+    if after is not None:
+        params["after"] = after
+    result = api(f"/guilds/{request.config['guild_id']}/members", params)
+    if result.status != 200:
+        return terminal_payload(result)
+    items = array_value(result.payload, "guild members")
+    data = [serialize_member(item, request.config["guild_id"]) for item in items]
+    next_cursor = {"after": data[-1]["remote_id"]} if len(items) == request.limit else None
+    return _success(data, next_cursor, None, snapshot=True)
+
+
+def page(
+    api: ApiCall,
+    request: ProviderPageRequest,
+    *,
+    export_path: str | None,
+    gateway_path: str | None,
+) -> dict[str, Any]:
+    """Dispatch one request through an explicit read-only route."""
+    if request.stream == "messages":
+        return _messages(api, request)
+    if request.stream == "metadata":
+        return _metadata(api, request)
+    if request.stream == "members":
+        return _members(api, request)
+    if request.stream == "gateway_events":
+        data, next_cursor, watermark = page_gateway_events(
+            gateway_path,
+            request.config,
+            request.cursor or request.watermark,
+            request.limit,
+        )
+        return _success(data, next_cursor, watermark, snapshot=False)
+    if request.stream == "account_export":
+        data, next_cursor = page_account_export(
+            export_path, request.config, request.cursor, request.limit
+        )
+        return _success(data, next_cursor, None, snapshot=True)
+    raise DiscordReadProviderError("Discord read stream is unsupported")

--- a/.agents/scripts/knowledge_social_discord.py
+++ b/.agents/scripts/knowledge_social_discord.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one identity-bound, read-only Discord stream into a social corpus."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import _knowledge_social_discord as discord
+from _knowledge_social_discord_normalize import PageContext, normalize_page
+from _knowledge_social_discord_reader import (
+    FixtureDiscord,
+    GuardedDiscordBot,
+    verified_identity,
+)
+from _knowledge_social_oauth_collector import OAuthCollectorPolicy, run_oauth_collector
+
+COLLECTOR_POLICY = OAuthCollectorPolicy(
+    display_name="Discord",
+    provider_module=discord,
+    helper=Path(__file__).with_name("_knowledge_social_discord_provider.py"),
+    fixture_reader=FixtureDiscord,
+    live_reader=GuardedDiscordBot,
+    page_context=PageContext,
+    normalize_page=normalize_page,
+    verified_identity=verified_identity,
+    budget_unit="request",
+    default_budget=11,
+    min_budget=3,
+    max_page_size=100,
+)
+
+
+def main() -> int:
+    return run_oauth_collector(COLLECTOR_POLICY, __doc__ or "")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/services/communications/discord.md
+++ b/.agents/services/communications/discord.md
@@ -29,23 +29,29 @@ tools: { read: true, write: false, edit: false, bash: true, glob: false, grep: f
 
 1. [discord.com/developers/applications](https://discord.com/developers/applications) → "New Application" → note **Application ID**
 2. **Bot** tab → "Add Bot" → copy token: `aidevops secret set DISCORD_BOT_TOKEN`
-3. Settings: **Public Bot**: Off | **Message Content Intent**: On (if reading non-slash messages)
+3. Settings: **Public Bot**: Off | **Message Content Intent**: On only when the bot must receive message fields outside Discord's documented privileged-intent exceptions
 
 ### 2. Gateway Intents
 
 | Intent | Privileged | Required for |
 |--------|-----------|--------------|
 | `Guilds` | No | Guild/channel structure, roles |
-| `GuildMessages` | No | Message events in guild channels |
+| `GuildMessages` | No | Message and reaction Gateway events in guild channels |
 | `GuildMembers` | Yes | Member join/leave, role changes |
 | `MessageContent` | Yes | Reading message text (non-slash) |
-| `DirectMessages` | No | DM events |
+| `DirectMessages` | No | Events for DMs in which the bot participates; not arbitrary user DM history |
 
 Privileged intents require manual approval for bots in 100+ guilds (Developer Portal > Bot > Privileged Gateway Intents). **Recommendation**: Use slash commands as primary interaction — avoids `MessageContent` privileged intent.
 
 ### 3. OAuth2 Bot Invite
 
 **OAuth2** > **URL Generator** → scopes: `bot`, `applications.commands` → permissions: Send Messages, Send Messages in Threads, Embed Links, Attach Files, Read Message History, Use Slash Commands, Add Reactions, Manage Threads.
+
+Those permissions are for the interactive bot described in this guide. A
+read-only knowledge collector should use a separate application/credential with
+only View Channel and Read Message History on explicit allowlisted surfaces. See
+`content/social-discord.md`; never reuse its credential for sends, reactions,
+moderation, role changes, webhooks, or channel/thread management.
 
 ```text
 https://discord.com/oauth2/authorize?client_id=YOUR_APP_ID&permissions=326417591296&scope=bot+applications.commands

--- a/.agents/tests/test-knowledge-social-discord.sh
+++ b/.agents/tests/test-knowledge-social-discord.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-discord.sh — Bounded Discord collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COLLECTOR="${SCRIPT_DIR}/../scripts/knowledge_social_discord.py"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+BOT_ID="100000000000000001"
+APP_ID="100000000000000002"
+GUILD_ID="100000000000000003"
+CHANNEL_ID="100000000000000004"
+THREAD_ID="100000000000000005"
+DM_ID="100000000000000006"
+EXPORT_USER_ID="100000000000000007"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' \
+			"$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c 'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+run_fixture() {
+	local connection_id="$1"
+	local stream="$2"
+	local fixture="$3"
+	python3 "$COLLECTOR" --base "$BASE" --alias personal:default \
+		--connection-id "$connection_id" --account-id "$BOT_ID" \
+		--stream "$stream" --profile fixture --budget 3 --page-size 100 \
+		--fixture "$fixture" || return 1
+	return 0
+}
+
+identity_json() {
+	printf '{"data":{"id":"%s","application_id":"%s","guild_id":"%s","channel_ids":["%s"],"thread_ids":["%s"],"dm_channel_ids":["%s"],"message_content_intent":true,"guild_members_intent":true,"export_user_id":"%s"}}' \
+		"$BOT_ID" "$APP_ID" "$GUILD_ID" "$CHANNEL_ID" "$THREAD_ID" "$DM_ID" "$EXPORT_USER_ID"
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+python3 "${SCRIPT_DIR}/../scripts/knowledge_social_import.py" provision \
+	--base "$BASE" --alias personal:default >/dev/null
+
+printf 'Discord social collector tests\n'
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import ast
+import sys
+from pathlib import Path
+from urllib.request import Request
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+from _knowledge_social_discord_contract import ApiResult
+from _knowledge_social_discord_provider import (
+    API_BASE,
+    READ_PATH,
+    _api,
+    _identity,
+    _verify_surfaces,
+)
+from _knowledge_social_discord_routes import STREAMS
+
+assert API_BASE == "https://discord.com/api/v10"
+assert STREAMS == {"messages", "metadata", "members", "gateway_events", "account_export"}
+for forbidden in ("/messages", "/reactions/x/@me", "/webhooks", "/moderation"):
+    if forbidden == "/messages":
+        continue
+    assert READ_PATH.fullmatch(forbidden) is None
+
+
+class Response:
+    status = 200
+    headers = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, _limit):
+        return b"[]"
+
+
+seen = []
+
+
+def opener(request: Request, timeout: int):
+    seen.append((request.get_method(), request.full_url, timeout))
+    return Response()
+
+
+result = _api("fixture", opener, "/channels/100000000000000004/messages", {"limit": "1"})
+assert isinstance(result, ApiResult) and result.status == 200
+assert seen == [("GET", "https://discord.com/api/v10/channels/100000000000000004/messages?limit=1", 60)]
+try:
+    _api("fixture", opener, "/channels/100000000000000004/messages/100000000000000009", {})
+except Exception:
+    pass
+else:
+    raise SystemExit("Discord mutation-shaped route was accepted")
+
+provider_tree = ast.parse(
+    (scripts / "_knowledge_social_discord_provider.py").read_text(encoding="utf-8")
+)
+methods = [
+    keyword.value.value
+    for node in ast.walk(provider_tree)
+    if isinstance(node, ast.Call)
+    and isinstance(node.func, ast.Name)
+    and node.func.id == "Request"
+    for keyword in node.keywords
+    if keyword.arg == "method" and isinstance(keyword.value, ast.Constant)
+]
+assert methods == ["GET"]
+
+bot_id = "100000000000000001"
+app_id = "100000000000000002"
+guild_id = "100000000000000003"
+channel_id = "100000000000000004"
+thread_id = "100000000000000005"
+dm_id = "100000000000000006"
+config = {
+    "application_id": app_id,
+    "guild_id": guild_id,
+    "channel_ids": (channel_id,),
+    "thread_ids": (thread_id,),
+    "dm_channel_ids": (dm_id,),
+    "message_content_intent": True,
+    "guild_members_intent": True,
+    "export_user_id": "100000000000000007",
+}
+responses = {
+    "/users/@me": {"id": bot_id},
+    "/applications/@me": {
+        "id": app_id,
+        "bot": {"id": bot_id},
+        "flags_new": str((1 << 18) | (1 << 14)),
+    },
+    f"/guilds/{guild_id}": {"id": guild_id},
+    f"/channels/{channel_id}": {"id": channel_id, "guild_id": guild_id, "type": 0},
+    f"/channels/{thread_id}": {"id": thread_id, "guild_id": guild_id, "type": 11},
+    f"/channels/{dm_id}": {"id": dm_id, "type": 1},
+}
+
+
+def fake_api(endpoint, _params):
+    return ApiResult(200, responses[endpoint])
+
+
+identity = _identity(fake_api, config, bot_id)
+assert identity["data"]["application_id"] == app_id
+assert _verify_surfaces(fake_api, config) is None
+PY
+assert_eq "Discord provider exposes only GET/local replay reads" verified verified
+
+cat >"$TMP_DIR/messages.json" <<JSON
+{
+  "identity":$(identity_json),
+  "pages":[{
+    "expect_request":{"stream":"messages","guild_id":"$GUILD_ID","channel_ids":["$CHANNEL_ID"]},
+    "response":{"status":200,"observed_at":"2026-07-31T10:00:00Z","data":[{
+      "kind":"message","remote_id":"100000000000000010","channel_id":"$CHANNEL_ID","guild_id":"$GUILD_ID",
+      "author":{"id":"100000000000000011","username":"author","global_name":"Author","bot":false},
+      "content":"Knowledge message","timestamp":"2026-07-31T09:59:00Z","edited_timestamp":"2026-07-31T10:00:00Z","type":0,
+      "mentions":[{"id":"100000000000000012","username":"mentioned","global_name":null,"bot":false}],
+      "attachments":[{"id":"100000000000000013","filename":"report.txt","content_type":"text/plain","size":12,"ephemeral":false}],
+      "embeds":[{"type":"rich","title":"Reference"}],
+      "reactions":[{"emoji_id":null,"emoji_name":"ok","count":2}],"reference_message_id":null
+    }],"meta":{"next_cursor":null,"watermark":{"$CHANNEL_ID":"100000000000000010"},"complete":true,"snapshot":false,"gaps":[]}}}
+  ]
+}
+JSON
+messages_result=$(run_fixture conn_discord messages "$TMP_DIR/messages.json")
+assert_eq "message collection completes" "$(json_field "$messages_result" status)" complete
+assert_eq "message and attachment evidence persist" \
+	"$(sql_value "SELECT (SELECT count(*) FROM objects WHERE provider='discord' AND object_type='message') || ':' || (SELECT count(*) FROM media WHERE provider='discord')")" "1:1"
+assert_eq "reaction summaries and edit observations remain canonical metadata" \
+	"$(sql_value "SELECT json_extract(provider_json,'$.reactions[0].count') || ':' || json_extract(provider_json,'$.edited_at') FROM objects WHERE provider='discord' AND object_type='message'")" \
+	"2:2026-07-31T10:00:00Z"
+assert_eq "arbitrary user DM history remains an explicit unavailable gap" \
+	"$(sql_value "SELECT status FROM coverage_records WHERE provider='discord' AND stream='arbitrary_user_dms'")" unavailable
+assert_eq "attachment transport URLs never become blob identity" \
+	"$(sql_value "SELECT hydration_state || ':' || coalesce(blob_ref,'none') FROM media WHERE provider='discord'")" remote_only:none
+
+cat >"$TMP_DIR/replay.json" <<JSON
+{
+  "identity":$(identity_json),
+  "pages":[{
+    "expect_request":{"watermark":{"$CHANNEL_ID":"100000000000000010"}},
+    "response":{"status":200,"observed_at":"2026-07-31T10:01:00Z","data":[],"meta":{"next_cursor":null,"watermark":{"$CHANNEL_ID":"100000000000000010"},"complete":true,"snapshot":false,"gaps":[]}}}
+  ]
+}
+JSON
+run_fixture conn_discord messages "$TMP_DIR/replay.json" >/dev/null
+assert_eq "REST replay converges without duplicate message truth" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='discord' AND object_type='message'")" 1
+
+cat >"$TMP_DIR/gateway.json" <<JSON
+{
+  "identity":$(identity_json),
+  "pages":[{"status":200,"observed_at":"2026-07-31T10:02:00Z","data":[{
+    "kind":"gateway_event","remote_id":"$GUILD_ID:42","sequence":42,"event_name":"MESSAGE_DELETE",
+    "data":{"id":"100000000000000010","channel_id":"$CHANNEL_ID","guild_id":"$GUILD_ID"}
+  }],"meta":{"next_cursor":null,"watermark":{"sequence":42},"complete":true,"snapshot":false,"gaps":[]}}]
+}
+JSON
+run_fixture conn_gateway gateway_events "$TMP_DIR/gateway.json" >/dev/null
+assert_eq "Gateway deletion observations persist without deleting prior evidence" \
+	"$(sql_value "SELECT state FROM activities WHERE provider='discord' AND activity_type='message_delete'")" deleted
+assert_eq "Gateway overlap preserves the canonical REST message" \
+	"$(sql_value "SELECT text_content FROM objects WHERE provider='discord' AND object_type='message' AND remote_id='100000000000000010'")" "Knowledge message"
+
+cat >"$TMP_DIR/metadata.json" <<JSON
+{
+  "identity":$(identity_json),
+  "pages":[{"status":200,"observed_at":"2026-07-31T10:03:00Z","data":[
+    {"kind":"guild","remote_id":"$GUILD_ID"},
+    {"kind":"channel","remote_id":"$THREAD_ID","guild_id":"$GUILD_ID","channel_type":11,"name":"allowed-thread","topic":null,"parent_id":"$CHANNEL_ID","archived":true,"applied_tags":[]},
+    {"kind":"role","remote_id":"100000000000000014","guild_id":"$GUILD_ID","name":"reader","permissions":"65536","managed":false},
+    {"kind":"member","remote_id":"100000000000000011","guild_id":"$GUILD_ID","user":{"id":"100000000000000011","username":"author","global_name":"Author","bot":false},"nick":null,"roles":["100000000000000014"],"joined_at":"2026-01-01T00:00:00Z"}
+  ],"meta":{"next_cursor":null,"watermark":null,"complete":true,"snapshot":true,"gaps":[]}}]
+}
+JSON
+run_fixture conn_metadata metadata "$TMP_DIR/metadata.json" >/dev/null
+assert_eq "archived thread, role, and member metadata normalize" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='discord' AND object_type IN ('channel','role','member')")" 3
+
+cat >"$TMP_DIR/rate-limit.json" <<JSON
+{"identity":$(identity_json),"pages":[{"status":429,"observed_at":"2026-07-31T10:04:00Z","retry_after":1785500000}]}
+JSON
+rate_result=$(run_fixture conn_rate messages "$TMP_DIR/rate-limit.json")
+assert_eq "rate limits pause one invocation" "$(json_field "$rate_result" status)" rate_limited
+assert_eq "rate limits bind no successful checkpoint" \
+	"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_rate'")" 0
+
+cat >"$TMP_DIR/wrong-identity.json" <<JSON
+{"identity":{"data":{"id":"100000000000000099","application_id":"$APP_ID","guild_id":"$GUILD_ID","channel_ids":["$CHANNEL_ID"],"thread_ids":[],"dm_channel_ids":[],"message_content_intent":true,"guild_members_intent":true,"export_user_id":null}},"pages":[]}
+JSON
+if run_fixture conn_wrong messages "$TMP_DIR/wrong-identity.json" >/dev/null 2>&1; then
+	assert_eq "bot identity mismatch fails closed" accepted rejected
+else
+	assert_eq "bot identity mismatch fails closed" rejected rejected
+fi
+assert_eq "identity mismatch persists no connection" \
+	"$(sql_value "SELECT count(*) FROM connections WHERE connection_id='conn_wrong'")" 0
+
+python3 - "$SCRIPT_DIR/../scripts" "$TMP_DIR" "$GUILD_ID" "$CHANNEL_ID" "$EXPORT_USER_ID" <<'PY'
+import json
+import sys
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[1])
+from _knowledge_social_discord_export import page_account_export
+from _knowledge_social_discord_gateway import page_gateway_events
+
+tmp = Path(sys.argv[2])
+guild_id, channel_id, user_id = sys.argv[3:]
+config = {
+    "guild_id": guild_id,
+    "channel_ids": (channel_id,),
+    "thread_ids": (),
+    "dm_channel_ids": (),
+    "export_user_id": user_id,
+}
+export = tmp / "discord-export.zip"
+with zipfile.ZipFile(export, "w") as archive:
+    archive.writestr("account/user.json", json.dumps({"id": user_id}))
+    archive.writestr("messages/c1/channel.json", json.dumps({"id": channel_id}))
+    archive.writestr(
+        "messages/c1/messages.csv",
+        "ID,Timestamp,Contents,Attachments\n"
+        "100000000000000021,2026-07-31T08:00:00Z,Exported knowledge,\n",
+    )
+rows, cursor = page_account_export(str(export), config, None, 100)
+assert cursor is None and rows[0]["remote_id"] == "100000000000000021"
+
+spool = tmp / "gateway.jsonl"
+spool.write_text(
+    json.dumps({
+        "op": 0,
+        "s": 7,
+        "t": "MESSAGE_UPDATE",
+        "d": {"id": "100000000000000021", "guild_id": guild_id, "channel_id": channel_id},
+    }) + "\n",
+    encoding="utf-8",
+)
+rows, cursor, watermark = page_gateway_events(str(spool), config, None, 100)
+assert cursor is None and watermark == {"sequence": 7}
+assert rows[0]["event_name"] == "MESSAGE_UPDATE"
+PY
+assert_eq "official export and Gateway spool parsers are bounded and replayable" verified verified
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -ne 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add bounded provider-neutral Discord ingestion for allowlisted messages, metadata, members, local Gateway event spools, and official account exports with identity, authority, pagination, checkpoint, and archive safety checks.

## Files Changed

.agents/content/social-discord.md, .agents/scripts/_knowledge_social_discord.py, .agents/scripts/_knowledge_social_discord_contract.py, .agents/scripts/_knowledge_social_discord_export.py, .agents/scripts/_knowledge_social_discord_gateway.py, .agents/scripts/_knowledge_social_discord_normalize.py, .agents/scripts/_knowledge_social_discord_provider.py, .agents/scripts/_knowledge_social_discord_reader.py, .agents/scripts/_knowledge_social_discord_routes.py, .agents/scripts/knowledge_social_discord.py, .agents/services/communications/discord.md, .agents/tests/test-knowledge-social-discord.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: bash .agents/tests/test-knowledge-social-discord.sh passed 15/15 after rebasing onto origin/main; bash .agents/tests/test-knowledge-social.sh passed 33/33; Python compileall, ShellCheck, lizard CCN threshold, and .agents/scripts/linters-local.sh --changed all passed. Tests execute the collector against deterministic Discord API fixtures and bounded local Gateway/export inputs; no live Discord credentials were used.

Resolves #28783


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.201 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h 7m and 530,735 tokens on this as a headless worker.