### PR TITLE
GH#29053: Harden pulse failure handling

### DIFF
--- a/.agents/scripts/fast-fail-release-policy.sh
+++ b/.agents/scripts/fast-fail-release-policy.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+[[ -n "${_FAST_FAIL_RELEASE_POLICY_LOADED:-}" ]] && return 0
+_FAST_FAIL_RELEASE_POLICY_LOADED=1
+
+# Classify whether installing newer aidevops code can plausibly repair a failure.
+# Unknown and source-state failures fail closed so new reason strings cannot
+# silently acquire release-reset eligibility.
+_fast_fail_release_reset_policy() {
+	local reason="$1"
+	local crash_type="${2:-}"
+	if [[ "$crash_type" == "no_work" ]]; then
+		printf '%s\n' "source-state-required"
+		return 0
+	fi
+	case "$reason" in
+	worker_launch_failed | no_worker_process | cli_usage_output | local_error | runtime | runtime_* | canary_failed | prelaunch_contract_failure)
+		printf '%s\n' "release-sensitive"
+		;;
+	*)
+		printf '%s\n' "source-state-required"
+		;;
+	esac
+	return 0
+}

--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -42,6 +42,8 @@ if [[ -r "${_HRFF_SCRIPT_DIR}/shared-repo-state-guard.sh" ]]; then
 	# shellcheck source=shared-repo-state-guard.sh
 	source "${_HRFF_SCRIPT_DIR}/shared-repo-state-guard.sh"
 fi
+# shellcheck source=fast-fail-release-policy.sh
+source "${_HRFF_SCRIPT_DIR}/fast-fail-release-policy.sh"
 unset _HRFF_SCRIPT_DIR
 : "${AIDEVOPS_UNKNOWN_VERSION:=unknown}"
 
@@ -1141,9 +1143,11 @@ _fast_fail_write_state() {
 	local new_backoff="$8"
 	local crash_type="$9"
 	local aidevops_version="${AIDEVOPS_UNKNOWN_VERSION:-unknown}"
+	local release_reset_policy=""
 	if declare -F aidevops_find_version >/dev/null 2>&1; then
 		aidevops_version=$(aidevops_find_version 2>/dev/null || printf '%s' "${AIDEVOPS_UNKNOWN_VERSION:-unknown}")
 	fi
+	release_reset_policy=$(_fast_fail_release_reset_policy "$reason" "${crash_type:-}")
 	local updated_state=""
 	if [[ -f "$state_file" ]]; then
 		updated_state=$(jq --arg k "$key" \
@@ -1154,7 +1158,8 @@ _fast_fail_write_state() {
 			--argjson backoff_secs "$new_backoff" \
 			--arg crash_type "${crash_type:-}" \
 			--arg aidevops_version "$aidevops_version" \
-			'.[$k] = ((.[$k] // {}) + {"count": $count, "ts": $ts, "reason": $reason, "retry_after": $retry_after, "backoff_secs": $backoff_secs, "crash_type": $crash_type, "aidevops_version": $aidevops_version})' \
+			--arg release_reset_policy "$release_reset_policy" \
+			'.[$k] = ((.[$k] // {}) + {"count": $count, "ts": $ts, "reason": $reason, "retry_after": $retry_after, "backoff_secs": $backoff_secs, "crash_type": $crash_type, "aidevops_version": $aidevops_version, "release_reset_policy": $release_reset_policy})' \
 			"$state_file") || {
 			echo "Error: Failed to update $state_file" >&2
 			updated_state=""
@@ -1168,7 +1173,8 @@ _fast_fail_write_state() {
 			--argjson backoff_secs "$new_backoff" \
 			--arg crash_type "${crash_type:-}" \
 			--arg aidevops_version "$aidevops_version" \
-			'.[$k] = ((.[$k] // {}) + {"count": $count, "ts": $ts, "reason": $reason, "retry_after": $retry_after, "backoff_secs": $backoff_secs, "crash_type": $crash_type, "aidevops_version": $aidevops_version})' \
+			--arg release_reset_policy "$release_reset_policy" \
+			'.[$k] = ((.[$k] // {}) + {"count": $count, "ts": $ts, "reason": $reason, "retry_after": $retry_after, "backoff_secs": $backoff_secs, "crash_type": $crash_type, "aidevops_version": $aidevops_version, "release_reset_policy": $release_reset_policy})' \
 			2>/dev/null) || updated_state=""
 	fi
 	if [[ -z "$updated_state" ]]; then

--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -554,6 +554,61 @@ _triage_mark_infrastructure_retry() {
 	return 0
 }
 
+_triage_terminal_snapshot_fingerprint() {
+	local issue_json="$1"
+	printf '%s' "$issue_json" | jq -cS \
+		'{number,title,body,updatedAt,labels:([.labels[].name] | sort)}' 2>/dev/null | \
+		python3 -c 'import hashlib,sys; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest())'
+	local statuses=("${PIPESTATUS[@]}")
+	[[ "${statuses[0]}" -eq 0 && "${statuses[1]}" -eq 0 ]] || return 1
+	return 0
+}
+
+_triage_terminal_snapshot_file() {
+	local issue_num="$1"
+	local repo_slug="$2"
+	local reason="$3"
+	local slug_safe="${repo_slug//\//_}"
+	printf '%s/%s-%s.%s.terminal\n' \
+		"${TRIAGE_CACHE_DIR:-${HOME}/.aidevops/.agent-workspace/tmp/triage-cache}" \
+		"$slug_safe" "$issue_num" "$reason"
+	return 0
+}
+
+_triage_terminal_snapshot_active() {
+	local issue_num="$1"
+	local repo_slug="$2"
+	local reason="$3"
+	local issue_json="$4"
+	local state_file="" fingerprint="" recorded=""
+	state_file=$(_triage_terminal_snapshot_file "$issue_num" "$repo_slug" "$reason") || return 1
+	[[ -f "$state_file" ]] || return 1
+	fingerprint=$(_triage_terminal_snapshot_fingerprint "$issue_json") || return 1
+	recorded=$(<"$state_file")
+	[[ "$recorded" == "$fingerprint" ]] || return 1
+	return 0
+}
+
+_triage_mark_terminal_snapshot() {
+	local issue_num="$1"
+	local repo_slug="$2"
+	local reason="$3"
+	local issue_json="$4"
+	local state_file="" state_dir="" fingerprint="" tmp_file=""
+	state_file=$(_triage_terminal_snapshot_file "$issue_num" "$repo_slug" "$reason") || return 1
+	state_dir="${state_file%/*}"
+	fingerprint=$(_triage_terminal_snapshot_fingerprint "$issue_json") || return 1
+	mkdir -p "$state_dir" || return 1
+	tmp_file=$(mktemp "${state_file}.XXXXXX") || return 1
+	if ! printf '%s\n' "$fingerprint" >"$tmp_file" || ! mv "$tmp_file" "$state_file"; then
+		rm -f "$tmp_file"
+		return 1
+	fi
+	printf '[pulse-wrapper] Triage prefetch terminal for #%s in %s (reason=%s) — unchanged snapshot requires manual review\n' \
+		"$issue_num" "$repo_slug" "$reason" >>"$LOGFILE"
+	return 0
+}
+
 #######################################
 # Create a private managed directory for untrusted triage artifacts and start
 # a detached cleanup guardian. Normal paths remove the directory immediately;
@@ -805,6 +860,10 @@ _triage_prefetch_issue() {
 			"$issue_num" "$repo_slug" "github-issue-read-malformed"
 		return 1
 	fi
+	if _triage_terminal_snapshot_active "$issue_num" "$repo_slug" \
+		"$_PAD_GITHUB_COMMENTS_SNAPSHOT_TOO_LARGE_REASON" "$issue_json"; then
+		return 1
+	fi
 
 	local issue_comment_pages=""
 	if ! issue_comment_pages=$(gh api \
@@ -831,8 +890,8 @@ _triage_prefetch_issue() {
 		return 1
 	fi
 	if [[ "$issue_comment_count" -gt "$_PAD_TRIAGE_MAX_COMMENTS" ]]; then
-		_triage_mark_infrastructure_retry \
-			"$issue_num" "$repo_slug" "$_PAD_GITHUB_COMMENTS_SNAPSHOT_TOO_LARGE_REASON"
+		_triage_mark_terminal_snapshot "$issue_num" "$repo_slug" \
+			"$_PAD_GITHUB_COMMENTS_SNAPSHOT_TOO_LARGE_REASON" "$issue_json" || true
 		return 1
 	fi
 
@@ -861,8 +920,8 @@ _triage_prefetch_issue() {
 	local issue_comment_bytes=""
 	issue_comment_bytes=$(_triage_text_byte_count "$issue_comments") || return 1
 	if [[ "$issue_comment_bytes" -gt "$_PAD_TRIAGE_MAX_COMMENT_BYTES" ]]; then
-		_triage_mark_infrastructure_retry \
-			"$issue_num" "$repo_slug" "$_PAD_GITHUB_COMMENTS_SNAPSHOT_TOO_LARGE_REASON"
+		_triage_mark_terminal_snapshot "$issue_num" "$repo_slug" \
+			"$_PAD_GITHUB_COMMENTS_SNAPSHOT_TOO_LARGE_REASON" "$issue_json" || true
 		return 1
 	fi
 

--- a/.agents/scripts/pulse-dirty-worktree-marker.py
+++ b/.agents/scripts/pulse-dirty-worktree-marker.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Evaluate dirty-worktree marker state from a GitHub comments JSON stream."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import sys
+
+
+CLEAR_STATE = "clear"
+RESOLUTION_TOKENS = (
+    "worker-dirty-worktree:resolved",
+    "WORKER_DIRTY_WORKTREE_RESOLVED",
+    "DIRTY_WORKTREE_RECOVERED",
+    "worker_dirty_worktree_recovered",
+)
+
+
+def parse_timestamp(value: object) -> float | None:
+    if not value:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(
+            str(value).replace("Z", "+00:00")
+        ).timestamp()
+    except ValueError:
+        return None
+
+
+def main() -> int:
+    hold_seconds = int(sys.argv[1])
+    now_override = sys.argv[2] if len(sys.argv) > 2 else ""
+    try:
+        comments = json.load(sys.stdin)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        print(CLEAR_STATE)
+        return 0
+
+    try:
+        now_epoch = (
+            float(now_override)
+            if now_override
+            else datetime.datetime.now(datetime.timezone.utc).timestamp()
+        )
+    except ValueError:
+        now_epoch = datetime.datetime.now(datetime.timezone.utc).timestamp()
+
+    latest_marker_ts = None
+    latest_resolution_ts = None
+    latest_marker_body = ""
+    for comment in comments:
+        body = str(comment.get("body") or "")
+        created = parse_timestamp(comment.get("created_at") or comment.get("createdAt"))
+        if created is None:
+            continue
+        if any(token in body for token in RESOLUTION_TOKENS):
+            latest_resolution_ts = created
+        elif "WORKER_DIRTY_WORKTREE" in body:
+            latest_marker_ts = created
+            latest_marker_body = body
+
+    if latest_marker_ts is None or (
+        latest_resolution_ts is not None and latest_resolution_ts >= latest_marker_ts
+    ):
+        print(CLEAR_STATE)
+        return 0
+
+    age = max(0, int(now_epoch - latest_marker_ts))
+    runner_key = ""
+    for token in latest_marker_body.split():
+        if token.startswith("runner_key="):
+            runner_key = token.split("=", 1)[1]
+            break
+    state = "block" if age <= hold_seconds else "expired"
+    print(f"{state}:age={age}:runner_key={runner_key}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -405,75 +405,9 @@ _dispatch_recent_dirty_worktree_marker_active() {
 	[[ -n "$comments_json" ]] || return 1
 
 	local marker_state=""
-	marker_state=$(AIDEVOPS_DIRTY_WORKTREE_COMMENTS_JSON="$comments_json" python3 - "$hold_seconds" "${AIDEVOPS_DIRTY_WORKTREE_NOW_EPOCH:-}" <<'PY'
-import datetime
-import json
-import os
-import sys
-
-hold_seconds = int(sys.argv[1])
-now_override = sys.argv[2] if len(sys.argv) > 2 else ""
-clear_state = "clear"
-
-try:
-    comments = json.loads(os.environ.get("AIDEVOPS_DIRTY_WORKTREE_COMMENTS_JSON", ""))
-except json.JSONDecodeError:
-    print(clear_state)
-    sys.exit(0)
-
-def parse_ts(value):
-    if not value:
-        return None
-    try:
-        return datetime.datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
-    except ValueError:
-        return None
-
-try:
-    now_epoch = float(now_override) if now_override else datetime.datetime.now(datetime.timezone.utc).timestamp()
-except ValueError:
-    now_epoch = datetime.datetime.now(datetime.timezone.utc).timestamp()
-
-latest_marker_ts = None
-latest_resolution_ts = None
-latest_marker_body = ""
-resolution_tokens = (
-    "worker-dirty-worktree:resolved",
-    "WORKER_DIRTY_WORKTREE_RESOLVED",
-    "DIRTY_WORKTREE_RECOVERED",
-    "worker_dirty_worktree_recovered",
-)
-
-for comment in comments:
-    body = str(comment.get("body") or "")
-    created = parse_ts(comment.get("created_at") or comment.get("createdAt"))
-    if created is None:
-        continue
-    if any(token in body for token in resolution_tokens):
-        latest_resolution_ts = created
-    elif "WORKER_DIRTY_WORKTREE" in body:
-        latest_marker_ts = created
-        latest_marker_body = body
-
-if latest_marker_ts is None:
-    print(clear_state)
-    sys.exit(0)
-if latest_resolution_ts is not None and latest_resolution_ts >= latest_marker_ts:
-    print(clear_state)
-    sys.exit(0)
-
-age = max(0, int(now_epoch - latest_marker_ts))
-runner_key = ""
-for token in latest_marker_body.split():
-    if token.startswith("runner_key="):
-        runner_key = token.split("=", 1)[1]
-        break
-if age <= hold_seconds:
-    print(f"block:age={age}:runner_key={runner_key}")
-else:
-    print(f"expired:age={age}:runner_key={runner_key}")
-PY
-) || marker_state=""
+	marker_state=$(printf '%s' "$comments_json" | \
+		python3 "${_PULSE_DISPATCH_LIB_DIR}/pulse-dirty-worktree-marker.py" \
+			"$hold_seconds" "${AIDEVOPS_DIRTY_WORKTREE_NOW_EPOCH:-}") || marker_state=""
 	_DISPATCH_DIRTY_MARKER_STATE="${marker_state:-clear}"
 
 	[[ "$marker_state" == block:* ]] || return 1

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -827,6 +827,7 @@ _dlw_renew_prelaunch_lease() {
 	local worker_log="$4"
 	local prewarm_timeout="${OPENCODE_PREWARM_TIMEOUT_SECONDS:-90}"
 	local lease_ttl="${AIDEVOPS_DISPATCH_PREWARM_LEASE_TTL:-}"
+	local claim_rc=0
 
 	if [[ -z "${_claim_lease_token:-}" ]]; then
 		return 0
@@ -836,12 +837,15 @@ _dlw_renew_prelaunch_lease() {
 
 	printf '[lifecycle] dispatcher_prelaunch_lease_renew_start session=%s pid=%s\n' \
 		"$session_key" "$$" >>"$worker_log"
-	if ! AIDEVOPS_DEVICE_ID="${_claim_lease_device:-${AIDEVOPS_DEVICE_ID:-}}" \
+	AIDEVOPS_DEVICE_ID="${_claim_lease_device:-${AIDEVOPS_DEVICE_ID:-}}" \
 		"${SCRIPT_DIR}/dispatch-claim-helper.sh" transition prelaunch "$issue_number" \
 		"$repo_slug" "$_claim_lease_token" "$session_key" "$lease_ttl" \
-		>/dev/null 2>&1; then
-		printf '[lifecycle] WARN dispatcher prelaunch lease renewal failed before OpenCode warm-up session=%s pid=%s\n' \
-			"$session_key" "$$" >>"$worker_log"
+		>/dev/null 2>&1 || claim_rc=$?
+	if [[ "$claim_rc" -ne 0 ]]; then
+		printf '[lifecycle] WARN dispatcher prelaunch lease renewal failed before OpenCode warm-up issue=%s repo=%s session=%s helper_rc=%s pid=%s\n' \
+			"$issue_number" "$repo_slug" "$session_key" "$claim_rc" "$$" >>"$worker_log"
+		printf '[dispatch_worker_launch] WARN prelaunch lease renewal failed issue=%s repo=%s session=%s helper_rc=%s\n' \
+			"$issue_number" "$repo_slug" "$session_key" "$claim_rc" >>"${LOGFILE:-/dev/stderr}"
 		return 1
 	fi
 	printf '[lifecycle] dispatcher_prelaunch_lease_renew_done session=%s pid=%s\n' \

--- a/.agents/scripts/pulse-fast-fail.sh
+++ b/.agents/scripts/pulse-fast-fail.sh
@@ -42,6 +42,12 @@
 # Originally a pure move from pulse-wrapper.sh (byte-identical to pre-extraction
 # form). GH#18692 decomposed _fast_fail_record_locked (115 lines) into focused
 # helpers to satisfy the 100-line complexity gate.
+
+_PFF_SCRIPT_DIR="${BASH_SOURCE[0]%/*}"
+[[ "$_PFF_SCRIPT_DIR" == "${BASH_SOURCE[0]}" ]] && _PFF_SCRIPT_DIR="."
+# shellcheck source=fast-fail-release-policy.sh
+source "${_PFF_SCRIPT_DIR}/fast-fail-release-policy.sh"
+unset _PFF_SCRIPT_DIR
 #
 # Configurable environment variables (all optional):
 #   FAST_FAIL_LOCK_ORPHAN_AGE_SECONDS — seconds before an empty lockdir (no owner.pid
@@ -54,6 +60,7 @@
 [[ -n "${_PULSE_FAST_FAIL_LOADED:-}" ]] && return 0
 _PULSE_FAST_FAIL_LOADED=1
 _FF_BOOL_FALSE="false"
+_FF_RELEASE_RESET_POLICY_SOURCE_STATE_REQUIRED="source-state-required"
 
 #######################################
 # Return the fast-fail state key for an issue.
@@ -487,14 +494,18 @@ _ff_release_retry_reset_if_newer() {
 	[[ -n "$repo_slug" ]] || return 1
 
 	if [[ -n "$precomputed_state" ]]; then
-		local precheck_key="" precheck_current_version="" precheck_failure_version="" precheck_reset_version=""
+		local precheck_key="" precheck_current_version="" precheck_failure_version="" precheck_reset_version="" precheck_policy="" precheck_reset_count=""
 		precheck_key=$(_ff_key "$issue_number" "$repo_slug")
 		precheck_current_version="$precomputed_current_version"
 		[[ -n "$precheck_current_version" ]] || precheck_current_version=$(_ff_current_aidevops_version)
 		precheck_failure_version=$(printf '%s' "$precomputed_state" | jq -r --arg k "$precheck_key" '.[$k].aidevops_version // ""' 2>/dev/null) || precheck_failure_version=""
 		precheck_reset_version=$(printf '%s' "$precomputed_state" | jq -r --arg k "$precheck_key" '.[$k].release_retry_reset_version // ""' 2>/dev/null) || precheck_reset_version=""
+		precheck_policy=$(printf '%s' "$precomputed_state" | jq -r --arg k "$precheck_key" --arg default_policy "$_FF_RELEASE_RESET_POLICY_SOURCE_STATE_REQUIRED" '.[$k].release_reset_policy // $default_policy' 2>/dev/null) || precheck_policy="$_FF_RELEASE_RESET_POLICY_SOURCE_STATE_REQUIRED"
+		precheck_reset_count=$(printf '%s' "$precomputed_state" | jq -r --arg k "$precheck_key" '.[$k].release_retry_reset_count // 0' 2>/dev/null) || precheck_reset_count=0
 		[[ -n "$precheck_failure_version" ]] || precheck_failure_version="0.0.0"
 		[[ -n "$precheck_current_version" ]] || return 1
+		[[ "$precheck_policy" == "release-sensitive" ]] || return 1
+		[[ "$precheck_reset_count" -lt "${FAST_FAIL_RELEASE_RETRY_MAX_RESETS:-1}" ]] || return 1
 		[[ "$precheck_reset_version" != "$precheck_current_version" ]] || return 1
 		_ff_version_gt "$precheck_current_version" "$precheck_failure_version" || return 1
 	fi
@@ -508,16 +519,20 @@ _ff_release_retry_reset_if_newer_locked() {
 	local repo_slug="$2"
 	local precomputed_current_version="${3:-}"
 
-	local key="" state="" current_version="" failure_version="" reset_version=""
+	local key="" state="" current_version="" failure_version="" reset_version="" reset_policy="" reset_count=""
 	key=$(_ff_key "$issue_number" "$repo_slug")
 	state=$(_ff_load)
 	current_version="$precomputed_current_version"
 	[[ -n "$current_version" ]] || current_version=$(_ff_current_aidevops_version)
 	failure_version=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].aidevops_version // ""' 2>/dev/null) || failure_version=""
 	reset_version=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].release_retry_reset_version // ""' 2>/dev/null) || reset_version=""
+	reset_policy=$(printf '%s' "$state" | jq -r --arg k "$key" --arg default_policy "$_FF_RELEASE_RESET_POLICY_SOURCE_STATE_REQUIRED" '.[$k].release_reset_policy // $default_policy' 2>/dev/null) || reset_policy="$_FF_RELEASE_RESET_POLICY_SOURCE_STATE_REQUIRED"
+	reset_count=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].release_retry_reset_count // 0' 2>/dev/null) || reset_count=0
 
 	[[ -n "$failure_version" ]] || failure_version="0.0.0"
 	[[ -n "$current_version" ]] || return 1
+	[[ "$reset_policy" == "release-sensitive" ]] || return 1
+	[[ "$reset_count" -lt "${FAST_FAIL_RELEASE_RETRY_MAX_RESETS:-1}" ]] || return 1
 	[[ "$reset_version" != "$current_version" ]] || return 1
 	_ff_version_gt "$current_version" "$failure_version" || return 1
 
@@ -528,7 +543,7 @@ _ff_release_retry_reset_if_newer_locked() {
 		--arg current "$current_version" \
 		--arg previous "$failure_version" \
 		--argjson ts "$now" \
-		'.[$k].count = 0 | .[$k].retry_after = 0 | .[$k].release_retry_reset_version = $current | .[$k].release_retry_reset_from = $previous | .[$k].release_retry_reset_ts = $ts' \
+		'.[$k].count = 0 | .[$k].retry_after = 0 | .[$k].release_retry_reset_version = $current | .[$k].release_retry_reset_from = $previous | .[$k].release_retry_reset_ts = $ts | .[$k].release_retry_reset_count = ((.[$k].release_retry_reset_count // 0) + 1)' \
 		2>/dev/null) || return 1
 	_ff_save "$updated_state"
 	echo "[pulse-wrapper] fast_fail_release_retry_reset: #${issue_number} (${repo_slug}) reset stale failure from aidevops ${failure_version} under current ${current_version}" >>"$LOGFILE"
@@ -632,8 +647,9 @@ _fast_fail_record_locked() {
 	fi
 
 	# Write updated state (include crash_type for diagnostics).
-	local updated_state="" aidevops_version=""
+	local updated_state="" aidevops_version="" release_reset_policy=""
 	aidevops_version=$(_ff_current_aidevops_version)
+	release_reset_policy=$(_fast_fail_release_reset_policy "$reason" "${crash_type:-}")
 	updated_state=$(printf '%s' "$state" | jq \
 		--arg k "$key" \
 		--argjson count "$new_count" \
@@ -643,7 +659,8 @@ _fast_fail_record_locked() {
 		--argjson backoff_secs "$new_backoff" \
 		--arg crash_type "${crash_type:-}" \
 		--arg aidevops_version "$aidevops_version" \
-		'.[$k] = ((.[$k] // {}) + {"count": $count, "ts": $ts, "reason": $reason, "retry_after": $retry_after, "backoff_secs": $backoff_secs, "crash_type": $crash_type, "aidevops_version": $aidevops_version})' 2>/dev/null) || return 0
+		--arg release_reset_policy "$release_reset_policy" \
+		'.[$k] = ((.[$k] // {}) + {"count": $count, "ts": $ts, "reason": $reason, "retry_after": $retry_after, "backoff_secs": $backoff_secs, "crash_type": $crash_type, "aidevops_version": $aidevops_version, "release_reset_policy": $release_reset_policy})' 2>/dev/null) || return 0
 
 	# Flag for enrichment on first non-rate-limit failure: a thinking-tier worker
 	# will analyze the issue and add implementation guidance before re-dispatch.

--- a/.agents/scripts/tests/test-fast-fail-release-retry-reset.sh
+++ b/.agents/scripts/tests/test-fast-fail-release-retry-reset.sh
@@ -80,7 +80,7 @@ write_entry() {
 	local count="$2"
 	local retry_after="$3"
 	local version="$4"
-	printf '{"owner/repo/%s":{"count":%s,"ts":1,"reason":"rate_limit","retry_after":%s,"backoff_secs":600,"crash_type":"","aidevops_version":"%s"}}\n' \
+	printf '{"owner/repo/%s":{"count":%s,"ts":1,"reason":"worker_launch_failed","retry_after":%s,"backoff_secs":600,"crash_type":"","aidevops_version":"%s","release_reset_policy":"release-sensitive"}}\n' \
 		"$issue" "$count" "$retry_after" "$version" >"$FAST_FAIL_STATE_FILE"
 	return 0
 }
@@ -102,6 +102,22 @@ else
 	fail "watchdog loads version metadata when sourced through PATH"
 fi
 
+printf '{"owner/repo/129":{"count":1,"ts":1,"reason":"permission_grant_unverified","retry_after":%s,"backoff_secs":600,"crash_type":"","aidevops_version":"3.14.63","release_reset_policy":"source-state-required"}}\n' \
+	"$future" >"$FAST_FAIL_STATE_FILE"
+if fast_fail_is_skipped 129 owner/repo && [[ "$(jq -r '."owner/repo/129".count' "$FAST_FAIL_STATE_FILE")" == "1" ]]; then
+	pass "source-state failure survives aidevops version upgrades"
+else
+	fail "source-state failure survives aidevops version upgrades"
+fi
+
+printf '{"owner/repo/130":{"count":1,"ts":1,"reason":"unknown","retry_after":%s,"backoff_secs":600,"crash_type":"","aidevops_version":"3.14.63"}}\n' \
+	"$future" >"$FAST_FAIL_STATE_FILE"
+if fast_fail_is_skipped 130 owner/repo && [[ "$(jq -r '."owner/repo/130".count' "$FAST_FAIL_STATE_FILE")" == "1" ]]; then
+	pass "legacy entries without reset policy fail closed"
+else
+	fail "legacy entries without reset policy fail closed"
+fi
+
 if _ff_version_gt "v3.14.64" "3.14.63" && ! _ff_version_gt "3.14.64" "3.14.64" && ! _ff_version_gt "3.14.63" "v3.14.64"; then
 	pass "pure bash version comparison handles prefixed aidevops versions"
 else
@@ -114,11 +130,19 @@ fast_fail_is_skipped 123 owner/repo || reset_rc=$?
 reset_count=$(jq -r '."owner/repo/123".count' "$FAST_FAIL_STATE_FILE")
 reset_retry=$(jq -r '."owner/repo/123".retry_after' "$FAST_FAIL_STATE_FILE")
 reset_version=$(jq -r '."owner/repo/123".release_retry_reset_version' "$FAST_FAIL_STATE_FILE")
-if [[ "$reset_rc" -eq 1 && "$reset_count" == "0" && "$reset_retry" == "0" && "$reset_version" == "3.14.64" && ! -d "${FAST_FAIL_STATE_FILE}.lockdir" ]]; then
+release_reset_count=$(jq -r '."owner/repo/123".release_retry_reset_count' "$FAST_FAIL_STATE_FILE")
+if [[ "$reset_rc" -eq 1 && "$reset_count" == "0" && "$reset_retry" == "0" && "$reset_version" == "3.14.64" && "$release_reset_count" == "1" && ! -d "${FAST_FAIL_STATE_FILE}.lockdir" ]]; then
 	pass "new aidevops version clears old-version backoff once"
 else
 	fail "new aidevops version clears old-version backoff once" \
 		"rc=${reset_rc}; count=${reset_count}; retry=${reset_retry}; reset_version=${reset_version}; lockdir=$([[ -d "${FAST_FAIL_STATE_FILE}.lockdir" ]] && printf present || printf absent)"
+fi
+
+if ! _ff_release_retry_reset_if_newer 123 owner/repo "$(<"$FAST_FAIL_STATE_FILE")" "3.14.65" && \
+	[[ "$(jq -r '."owner/repo/123".release_retry_reset_count' "$FAST_FAIL_STATE_FILE")" == "1" ]]; then
+	pass "cumulative release reset ceiling survives later versions"
+else
+	fail "cumulative release reset ceiling survives later versions"
 fi
 
 skip_rc=0
@@ -140,10 +164,12 @@ fi
 
 fast_fail_record 125 owner/repo worker_noop_zero_output anthropic no_work
 recorded_version=$(jq -r '."owner/repo/125".aidevops_version' "$FAST_FAIL_STATE_FILE")
-if [[ "$recorded_version" == "3.14.64" ]]; then
-	pass "fast_fail_record stores aidevops version metadata"
+recorded_policy=$(jq -r '."owner/repo/125".release_reset_policy' "$FAST_FAIL_STATE_FILE")
+if [[ "$recorded_version" == "3.14.64" && "$recorded_policy" == "source-state-required" ]]; then
+	pass "fast_fail_record stores version and explicit reset policy"
 else
-	fail "fast_fail_record stores aidevops version metadata" "version=${recorded_version}"
+	fail "fast_fail_record stores version and explicit reset policy" \
+		"version=${recorded_version}; policy=${recorded_policy}"
 fi
 
 now=$(date +%s)
@@ -161,7 +187,7 @@ fi
 worker_state="${TMP}/worker-fast-fail.json"
 printf '{"owner/repo/127":{"count":1,"ts":1,"reason":"old","retry_after":0,"backoff_secs":600,"crash_type":"","aidevops_version":"3.14.63","release_retry_reset_version":"3.14.64","release_retry_reset_from":"3.14.63","custom_field":"keep"}}\n' >"$worker_state"
 _fast_fail_write_state "$worker_state" "$TMP" "owner/repo/127" 2 "$now" worker_failed "$future" 1200 no_work
-if jq -e '."owner/repo/127" | .count == 2 and .crash_type == "no_work" and .aidevops_version == "3.14.64" and .release_retry_reset_version == "3.14.64" and .release_retry_reset_from == "3.14.63" and .custom_field == "keep"' \
+if jq -e '."owner/repo/127" | .count == 2 and .crash_type == "no_work" and .release_reset_policy == "source-state-required" and .aidevops_version == "3.14.64" and .release_retry_reset_version == "3.14.64" and .release_retry_reset_from == "3.14.63" and .custom_field == "keep"' \
 	"$worker_state" >/dev/null 2>&1; then
 	pass "worker fast-fail writer preserves version and reset metadata"
 else
@@ -177,7 +203,7 @@ watchdog_json=$(<"$watchdog_state")
 _ff_write_state_entry "$watchdog_json" "$watchdog_state" "$TMP" "$watchdog_lock" \
 	"owner/repo/128" 2 "$now" stall "$future" 1200 overwhelmed
 rmdir "$watchdog_lock"
-if jq -e '."owner/repo/128" | .count == 2 and .crash_type == "overwhelmed" and .aidevops_version == "3.14.64" and .release_retry_reset_version == "3.14.64" and .release_retry_reset_ts == 84 and .custom_field == "keep"' \
+if jq -e '."owner/repo/128" | .count == 2 and .crash_type == "overwhelmed" and .release_reset_policy == "source-state-required" and .aidevops_version == "3.14.64" and .release_retry_reset_version == "3.14.64" and .release_retry_reset_ts == 84 and .custom_field == "keep"' \
 	"$watchdog_state" >/dev/null 2>&1; then
 	pass "watchdog fast-fail writer preserves version and reset metadata"
 else

--- a/.agents/scripts/tests/test-pulse-dispatch-dirty-worktree-marker.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-dirty-worktree-marker.sh
@@ -206,6 +206,65 @@ test_expired_marker_does_not_block() {
 	return 0
 }
 
+test_large_comment_payload_uses_stream_transport() {
+	local padding=""
+	padding=$(python3 -c 'print("x" * 150000)')
+	TEST_GH_COMMENTS_JSON="[{\"created_at\":\"2026-07-05T22:22:12Z\",\"body\":\"WORKER_DIRTY_WORKTREE runner_key=runner-large ${padding}\"}]"
+	set +e
+	AIDEVOPS_DIRTY_WORKTREE_NOW_EPOCH="1783291032" \
+		DISPATCH_DIRTY_WORKTREE_HOLD_SECONDS="21600" \
+		_dispatch_recent_dirty_worktree_marker_active "26635" "marcusquinn/aidevops"
+	local rc=$?
+	set -e
+	TEST_GH_COMMENTS_JSON="[]"
+	if [[ "$rc" -eq 0 && "$_DISPATCH_DIRTY_MARKER_STATE" == *"runner_key=runner-large" ]]; then
+		print_result "large comment payload avoids exec environment limits" 0
+		return 0
+	fi
+	print_result "large comment payload avoids exec environment limits" 1 \
+		"state=${_DISPATCH_DIRTY_MARKER_STATE} rc=${rc}"
+	return 0
+}
+
+test_prelaunch_lease_failure_logs_durable_reason() {
+	local fixture_dir=""
+	fixture_dir=$(mktemp -d)
+	local worker_log="${fixture_dir}/worker.log"
+	local pulse_log="${fixture_dir}/pulse.log"
+	local original_logfile="$LOGFILE"
+	cat >"${fixture_dir}/dispatch-claim-helper.sh" <<'STUB'
+#!/usr/bin/env bash
+exit 7
+STUB
+	chmod +x "${fixture_dir}/dispatch-claim-helper.sh"
+	local original_script_dir="$SCRIPT_DIR"
+	SCRIPT_DIR="$fixture_dir"
+	LOGFILE="$pulse_log"
+	_claim_lease_token="secret-token-must-not-appear"
+	_claim_lease_device="test-device"
+	set +e
+	_dlw_renew_prelaunch_lease "26635" "marcusquinn/aidevops" \
+		"session-test" "$worker_log"
+	local rc=$?
+	set -e
+	SCRIPT_DIR="$original_script_dir"
+	LOGFILE="$original_logfile"
+	unset _claim_lease_token _claim_lease_device
+	local result=0
+	[[ "$rc" -eq 1 ]] || result=1
+	grep -q 'issue=26635 repo=marcusquinn/aidevops session=session-test helper_rc=7' \
+		"$worker_log" || result=1
+	grep -q 'issue=26635 repo=marcusquinn/aidevops session=session-test helper_rc=7' \
+		"$pulse_log" || result=1
+	if grep -q 'secret-token-must-not-appear' "$worker_log" "$pulse_log"; then
+		result=1
+	fi
+	print_result "prelaunch lease failure is durable without token disclosure" \
+		"$result" "rc=${rc}"
+	rm -rf "$fixture_dir"
+	return 0
+}
+
 test_expired_marker_clears_once_with_audit() {
 	local marker='{"created_at":"2026-07-05T22:22:12Z","body":"WORKER_DIRTY_WORKTREE branch=feature/auto-20260706-000537-gh26635 runner_key=runner-other"}'
 	TEST_GH_POST_COUNT=0
@@ -240,6 +299,8 @@ main() {
 	test_dirty_worktree_reuse_preserves_edits
 	test_later_resolution_clears_marker
 	test_expired_marker_does_not_block
+	test_large_comment_payload_uses_stream_transport
+	test_prelaunch_lease_failure_logs_durable_reason
 	test_expired_marker_clears_once_with_audit
 	test_marker_without_runner_key_stays_blocked
 

--- a/.agents/scripts/tests/test-triage-output-shape.sh
+++ b/.agents/scripts/tests/test-triage-output-shape.sh
@@ -240,17 +240,23 @@ load_helpers_under_test() {
 		printf 'ERROR: cannot locate pulse-ancillary-dispatch.sh (tried %s)\n' "$src" >&2
 		exit 2
 	fi
-	# Extract from _ensure_triage_failed_label down to (but not
-	# including) dispatch_triage_reviews — this includes every helper
-	# we need plus _dispatch_triage_review_worker itself.
+	# Extract the pre-post snapshot fence, then the posting/dispatch helper block.
+	# The fence now lives before _ensure_triage_failed_label in production, so the
+	# historical single-range extraction silently omitted it.
 	local tmp
 	tmp=$(mktemp)
+	awk '
+	/^_triage_post_snapshot_failure_reason\(\) \{/{flag=1}
+	flag{print}
+	/^_triage_fetch_pr_snapshot\(\) \{/{flag=0}
+	' "$src" |
+		sed '/^_triage_fetch_pr_snapshot()/,$d' >"$tmp"
 	awk '
 	/^_ensure_triage_failed_label\(\) \{/{flag=1}
 	flag{print}
 	/^dispatch_triage_reviews\(\) \{/{flag=0}
 	' "$src" |
-		sed '/^dispatch_triage_reviews()/,$d' >"$tmp"
+		sed '/^dispatch_triage_reviews()/,$d' >>"$tmp"
 	# shellcheck source=../sensitive-temp-helper.sh
 	source "${here}/../sensitive-temp-helper.sh"
 	# shellcheck disable=SC1090
@@ -258,6 +264,23 @@ load_helpers_under_test() {
 	rm -f "$tmp"
 	_triage_current_text_snapshot_hash() {
 		printf '%s\n' "$MOCK_CURRENT_TEXT_SNAPSHOT_HASH"
+		return 0
+	}
+	_triage_prefetch_issue() {
+		local issue_json_var="$3"
+		local issue_comments_var="$4"
+		local issue_body_var="$5"
+		printf -v "$issue_json_var" '%s' '{}'
+		printf -v "$issue_comments_var" '%s' '[]'
+		printf -v "$issue_body_var" '%s' ''
+		return 0
+	}
+	_triage_default_branch_revision_rest() {
+		printf '%s\n' "$MOCK_CURRENT_PUBLIC_REVISION"
+		return 0
+	}
+	_triage_pr_revision_pair_rest() {
+		printf '%s\n' "$MOCK_PR_REVISION_PAIR"
 		return 0
 	}
 	return 0

--- a/.agents/scripts/tests/test-triage-security-gate.sh
+++ b/.agents/scripts/tests/test-triage-security-gate.sh
@@ -809,6 +809,23 @@ test_missing_scanner_or_guard_retries_as_infrastructure() {
 	return 0
 }
 
+test_terminal_oversize_snapshot_invalidates_on_change() {
+	reset_case
+	set_mock_item "safe body" "safe comment" "safe title"
+	local reason="github-comments-snapshot-too-large"
+	local result=0
+	_triage_mark_terminal_snapshot 42 owner/repo "$reason" "$MOCK_ISSUE_JSON" || result=1
+	_triage_terminal_snapshot_active 42 owner/repo "$reason" "$MOCK_ISSUE_JSON" || result=1
+	local changed_json=""
+	changed_json=$(printf '%s' "$MOCK_ISSUE_JSON" | jq -c '.updatedAt = "2026-07-27T00:02:00Z"')
+	if _triage_terminal_snapshot_active 42 owner/repo "$reason" "$changed_json"; then
+		result=1
+	fi
+	print_result "terminal oversize snapshot skips unchanged input and invalidates on change" \
+		"$result"
+	return 0
+}
+
 main() {
 	test_clean_current_and_history_content_reach_model
 	test_paginated_comments_reach_scanner_and_prompt
@@ -824,6 +841,7 @@ main() {
 	test_retrieval_failures_are_infrastructure
 	test_warning_is_security_and_scanner_error_is_infrastructure
 	test_missing_scanner_or_guard_retries_as_infrastructure
+	test_terminal_oversize_snapshot_invalidates_on_change
 
 	printf '\nResults: %d tests, %d passed, %d failed\n' \
 		"$TESTS_RUN" "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_FAILED"

--- a/.agents/scripts/worker-watchdog-ff.sh
+++ b/.agents/scripts/worker-watchdog-ff.sh
@@ -45,6 +45,8 @@ if [[ -r "${_WWFF_SCRIPT_DIR}/lib/version.sh" ]]; then
 	# shellcheck source=lib/version.sh
 	source "${_WWFF_SCRIPT_DIR}/lib/version.sh"
 fi
+# shellcheck source=fast-fail-release-policy.sh
+source "${_WWFF_SCRIPT_DIR}/fast-fail-release-policy.sh"
 unset _WWFF_SCRIPT_DIR
 
 # =============================================================================
@@ -194,9 +196,11 @@ _ff_write_state_entry() {
 	local new_backoff="${10}"
 	local crash_type="${11:-}"
 	local aidevops_version="${AIDEVOPS_UNKNOWN_VERSION:-unknown}"
+	local release_reset_policy=""
 	if declare -F aidevops_find_version >/dev/null 2>&1; then
 		aidevops_version=$(aidevops_find_version 2>/dev/null || printf '%s' "${AIDEVOPS_UNKNOWN_VERSION:-unknown}")
 	fi
+	release_reset_policy=$(_fast_fail_release_reset_policy "$reason" "$crash_type")
 
 	local updated_state
 	updated_state=$(printf '%s' "$state" | jq \
@@ -208,7 +212,8 @@ _ff_write_state_entry() {
 		--argjson backoff_secs "$new_backoff" \
 		--arg crash_type "$crash_type" \
 		--arg aidevops_version "$aidevops_version" \
-		'.[$k] = ((.[$k] // {}) + {"count": $count, "ts": $ts, "reason": $reason, "retry_after": $retry_after, "backoff_secs": $backoff_secs, "crash_type": $crash_type, "aidevops_version": $aidevops_version})' 2>/dev/null) || {
+		--arg release_reset_policy "$release_reset_policy" \
+		'.[$k] = ((.[$k] // {}) + {"count": $count, "ts": $ts, "reason": $reason, "retry_after": $retry_after, "backoff_secs": $backoff_secs, "crash_type": $crash_type, "aidevops_version": $aidevops_version, "release_reset_policy": $release_reset_policy})' 2>/dev/null) || {
 		rmdir "$lock_dir" 2>/dev/null || true
 		return 1
 	}


### PR DESCRIPTION
## Summary

Harden Pulse diagnostics, dirty-worktree comment transport, oversized triage snapshot handling, and release-aware fast-fail resets.

Resolves #29057
Resolves #29058
Resolves #29046

## Files Changed

.agents/scripts/fast-fail-release-policy.sh, .agents/scripts/headless-runtime-failure.sh, .agents/scripts/pulse-ancillary-dispatch.sh, .agents/scripts/pulse-dirty-worktree-marker.py, .agents/scripts/pulse-dispatch-lib.sh, .agents/scripts/pulse-dispatch-worker-launch.sh, .agents/scripts/pulse-fast-fail.sh, .agents/scripts/tests/test-fast-fail-release-retry-reset.sh, .agents/scripts/tests/test-pulse-dispatch-dirty-worktree-marker.sh, .agents/scripts/tests/test-triage-output-shape.sh, .agents/scripts/tests/test-triage-security-gate.sh, .agents/scripts/worker-watchdog-ff.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified with executable integration fixtures: triage output shape 34/34, dirty-worktree marker 10/10, fast-fail reset 12/12, triage security gate 33/33, worker warm-start 19/19, and fast-fail age-out 13/13; ShellCheck, syntax checks, py_compile, git diff check, and local quality gates passed.

Resolves #29053


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.201 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 39m and 500,225 tokens on this with the user in an interactive session.