### PR TITLE
t18189: Aggregate Luna routing release provenance

### DIFF
--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -166,6 +166,10 @@ sources because subsequent merges through PR #29071 advanced `main` before
 publication from PR #29052 could complete. Its exact branch base is
 `9ee52e20b8c5ffecd4672f8784e78993acb7f70f`.
 
+A pending aggregation reviews authorized Luna standard-routing PR #29072 at
+`d222f326dbdfb705352087e6695ce8bda0d4d0a0` because subsequent merges advanced
+`main` before its explicitly authorized patch release could begin.
+
 Manual arbitrary-version package publication is intentionally unsupported. A
 recovery operation must use an existing tag that passes the same verifier.
 

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -166,7 +166,7 @@ sources because subsequent merges through PR #29071 advanced `main` before
 publication from PR #29052 could complete. Its exact branch base is
 `9ee52e20b8c5ffecd4672f8784e78993acb7f70f`.
 
-A pending aggregation reviews authorized Luna standard-routing PR #29072 at
+Aggregation PR #29082 reviews authorized Luna standard-routing PR #29072 at
 `d222f326dbdfb705352087e6695ce8bda0d4d0a0` because subsequent merges advanced
 `main` before its explicitly authorized patch release could begin.
 


### PR DESCRIPTION
## Summary

Create a reviewed exact-tip aggregation for authorized Luna standard-routing PR #29072 after later merges invalidated its direct release position.

## Release provenance

- Authorized source: PR #29072 at merge `d222f326dbdfb705352087e6695ce8bda0d4d0a0`.
- Exact branch base: `cd652e89fbbe7fc7af037ede09eb70de941d679c`.
- Initial documentation commit: `962cb55ae`.
- Follow-up commit `caf5f963d` binds aggregation PR #29082 and the immutable source without rewriting published history.

## Verification

- Markdown lint and `git diff --check` pass.
- PR #29072 merged after required Complexity Analysis, macOS ShellCheck, and review-bot gates passed.
- This documentation-only attestation performs no publication.

Ref #29070
Ref #29072

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.202 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h 25m and 251,783 tokens on this with the user in an interactive session.
