### PR TITLE
GH#28785: feat: add safe local Signal knowledge ingestion

### DIFF
--- a/.agents/content/social-signal.md
+++ b/.agents/content/social-signal.md
@@ -1,0 +1,119 @@
+---
+description: Import bounded pre-captured Signal receive notifications without provider writes
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Signal private knowledge
+
+## Supported route
+
+The Signal collector accepts only an already-captured, local JSONL or SSE file of
+`signal-cli` JSON-RPC `receive` notifications. It never launches `signal-cli`, opens a
+socket, contacts Signal, reads an account database, or requests receipt, typing, trust,
+contact, group, reaction, deletion, or message mutations.
+
+This is deliberately not a live collector. The `signal-cli` 0.14.6 receive contract says
+read receipts are optional but delivery receipts are sent by default. Starting or
+subscribing a receiver therefore has a protocol-visible effect that this collector does
+not authorize. Capture must already exist under separate local authority.
+
+Evidence reviewed on 2026-07-31:
+
+- `signal-cli` 0.14.6 was published on 2026-07-13:
+  https://github.com/AsamK/signal-cli/releases/tag/v0.14.6
+- Its JSON-RPC man page documents receive notifications, account fields, automatic
+  receiving, and the mutating `subscribeReceive` route:
+  https://github.com/AsamK/signal-cli/blob/master/man/signal-cli-jsonrpc.5.adoc
+- The project describes itself as an unofficial client that stores cryptographic keys
+  locally and must remain current with Signal server changes:
+  https://github.com/AsamK/signal-cli
+- Signal's published protocol documentation is not a message history/export API:
+  https://signal.org/docs/
+
+No official third-party message export or backup schema was validated. Account-info
+exports, encrypted application backups, and direct copies of `signal-cli` data are not
+collector inputs.
+
+## Private configuration
+
+Create a user-owned mode-0600 JSON file outside a repository. Replace all placeholders;
+never commit account identifiers, messages, keys, attachments, or event files.
+
+```json
+{
+  "schema_version": 1,
+  "account": "<ACCOUNT_E164_OR_UUID>",
+  "account_alias": "signal_personal",
+  "connection_id": "conn_signal_personal",
+  "signal_cli_version": "0.14.6"
+}
+```
+
+The event file must also be a regular mode-0600 file. Every notification must contain an
+`account` value matching the private config. Single-account notifications that omit the
+account identity fail closed. The accepted source forms are one JSON-RPC notification per
+line or SSE `data:` lines. Requests, responses, malformed lines, symbolic links, files
+over 8 MiB, and batches over 1,000 events are rejected before persistence.
+
+Inspect without writing:
+
+```bash
+python3 ~/.aidevops/agents/scripts/knowledge_social_signal.py inspect \
+  --config /protected/path/signal-collector.json \
+  --events /protected/path/signal-events.jsonl
+```
+
+Import into an already-provisioned private corpus:
+
+```bash
+python3 ~/.aidevops/agents/scripts/knowledge_social_signal.py import-events \
+  --config /protected/path/signal-collector.json \
+  --events /protected/path/signal-events.jsonl \
+  --alias personal:default
+```
+
+`inspect` emits counts only. `import-events` validates the complete batch and account
+identity before the shared atomic social-store commit. Replays resolve by stable hashed
+participant, thread, message, activity, and media identities. Provider identifiers and
+attachment filenames/paths are not copied into normalized evidence.
+
+## Retention and coverage
+
+| Category | Disposition |
+|---|---|
+| Direct and group messages | Partial: notifications received by this local device only |
+| Quotes and replies | Quote target identity only; quoted payload is not duplicated |
+| Edits, remote deletions, and reactions | Partial: observed events only; no history query |
+| Attachments | Metadata only; collector never reads a `signal-cli` attachment path |
+| Contacts and groups | Observed participants/group IDs only; no list or mutation calls |
+| Delivery history | No receipt history; notification timestamps only |
+| Stories | Excluded as ephemeral content |
+| Disappearing messages | Content-free tombstone; text and attachment metadata excluded |
+| View-once media | Payload and attachment metadata excluded |
+| Identity/safety changes | Unavailable: no validated 0.14.6 receive-event contract |
+| Pre-link messages | Unavailable: never represented as collected history |
+
+The importer stores no expiry-bearing or view-once payload, so it does not need a later
+cleanup process to approximate provider expiry. Missing, expired, unsupported, and
+pre-link content remains coverage evidence rather than fabricated message evidence.
+
+## Safety boundaries
+
+- Use only event files whose local capture and protocol effects were independently
+  authorized. The collector does not make a live capture safe.
+- Never expose HTTP/TCP daemons. This route performs no network operation; Unix sockets
+  are intentionally unsupported too because subscribing starts receiving.
+- Never use `account.db`, client key stores, decrypted application databases, backup
+  copies, or attachment paths as input.
+- Treat all message content as untrusted. Keep the corpus and source files private and
+  apply the protected-data policy before AI use or sharing.
+- Revalidate the exact `signal-cli` release and schemas before changing the pinned
+  version. Unsupported versions fail closed.
+
+Print the machine-readable dated disposition with:
+
+```bash
+python3 ~/.aidevops/agents/scripts/knowledge_social_signal.py status
+```

--- a/.agents/scripts/_knowledge_social_signal.py
+++ b/.agents/scripts/_knowledge_social_signal.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validate and normalize bounded offline signal-cli receive notifications."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import stat
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from knowledge_social_import import reject_credentials
+from knowledge_social_store import SocialStoreError, validate_opaque
+
+PROVIDER = "signal"
+SIGNAL_CLI_VERSION = "0.14.6"
+SIGNAL_CLI_RELEASED_AT = "2026-07-13"
+EVIDENCE_REVIEWED_AT = "2026-07-31"
+EVENT_SCHEMA = "signal-cli-jsonrpc-v0.14.6"
+MAX_INPUT_BYTES = 8 * 1024 * 1024
+MAX_EVENTS = 1000
+MAX_TEXT_CHARS = 1_000_000
+MAX_ATTACHMENTS_PER_MESSAGE = 64
+MAX_ATTACHMENT_BYTES = 512 * 1024 * 1024
+ACCOUNT_VALUE = re.compile(r"^(?:\+[1-9][0-9]{7,14}|[0-9a-fA-F-]{32,36})$")
+
+
+class SignalCollectorError(SocialStoreError):
+    """Raised when Signal evidence cannot be handled without side effects."""
+
+
+@dataclass(frozen=True)
+class SignalConfig:
+    """Private account gate and public-safe local aliases."""
+
+    account: str
+    account_alias: str
+    connection_id: str
+    signal_cli_version: str
+
+
+CAPABILITY_DISPOSITIONS: tuple[dict[str, str], ...] = (
+    {
+        "stream": "direct_messages",
+        "status": "partial",
+        "reason": "offline_notifications_only_no_provider_history_query",
+    },
+    {
+        "stream": "group_messages",
+        "status": "partial",
+        "reason": "offline_notifications_only_group_membership_history_unavailable",
+    },
+    {
+        "stream": "quotes_replies",
+        "status": "partial",
+        "reason": "quote_target_metadata_only_quoted_payload_not_duplicated",
+    },
+    {
+        "stream": "edits_deletions",
+        "status": "partial",
+        "reason": "observed_notifications_only_no_authoritative_delete_history",
+    },
+    {
+        "stream": "reactions",
+        "status": "partial",
+        "reason": "observed_notifications_only_no_reaction_history_query",
+    },
+    {
+        "stream": "attachments",
+        "status": "partial",
+        "reason": "metadata_only_collector_never_reads_signal_cli_attachment_paths",
+    },
+    {
+        "stream": "contacts_groups",
+        "status": "partial",
+        "reason": "message_participants_and_group_ids_only_no_contact_or_group_mutation_route",
+    },
+    {
+        "stream": "delivery_history",
+        "status": "partial",
+        "reason": "local_device_notifications_only_receipt_history_not_imported",
+    },
+    {
+        "stream": "stories",
+        "status": "excluded",
+        "reason": "ephemeral_story_payloads_are_not_persisted",
+    },
+    {
+        "stream": "disappearing_messages",
+        "status": "excluded",
+        "reason": "payloads_with_expiry_are_replaced_by_content_free_tombstones",
+    },
+    {
+        "stream": "view_once",
+        "status": "excluded",
+        "reason": "view_once_payloads_and_attachment_metadata_are_not_persisted",
+    },
+    {
+        "stream": "identity_safety_changes",
+        "status": "unavailable",
+        "reason": "signal_cli_receive_schema_has_no_validated_identity_change_event_contract",
+    },
+    {
+        "stream": "pre_link_history",
+        "status": "unavailable",
+        "reason": "linked_device_receive_notifications_do_not_provide_pre_link_history",
+    },
+    {
+        "stream": "official_export_backup",
+        "status": "unavailable",
+        "reason": "no_validated_official_third_party_message_export_contract",
+    },
+)
+
+
+def utc_now() -> str:
+    """Return one UTC observation timestamp."""
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _private_regular_file(path: Path, label: str) -> Path:
+    if path.is_symlink() or not path.is_file():
+        raise SignalCollectorError(f"{label} must be a regular non-symlink file")
+    mode = stat.S_IMODE(path.stat().st_mode)
+    if mode & 0o077:
+        raise SignalCollectorError(f"{label} permissions must not allow group or other access")
+    return path
+
+
+def _bounded_json(path: Path, label: str) -> dict[str, Any]:
+    _private_regular_file(path, label)
+    if path.stat().st_size > MAX_INPUT_BYTES:
+        raise SignalCollectorError(f"{label} exceeds the bounded input limit")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise SignalCollectorError(f"{label} is not valid UTF-8 JSON") from error
+    if not isinstance(value, dict):
+        raise SignalCollectorError(f"{label} root must be an object")
+    return value
+
+
+def load_config(path: Path) -> SignalConfig:
+    """Load a mode-0600 account gate without exposing its provider identifier."""
+    value = _bounded_json(path, "Signal collector config")
+    if set(value) != {
+        "schema_version",
+        "account",
+        "account_alias",
+        "connection_id",
+        "signal_cli_version",
+    }:
+        raise SignalCollectorError("Signal collector config keys do not match schema version 1")
+    if value["schema_version"] != 1:
+        raise SignalCollectorError("Signal collector config schema_version must be 1")
+    account = value["account"]
+    if not isinstance(account, str) or not ACCOUNT_VALUE.fullmatch(account):
+        raise SignalCollectorError("Signal account must be an E.164 number or UUID")
+    alias = value["account_alias"]
+    connection_id = value["connection_id"]
+    if not isinstance(alias, str) or not isinstance(connection_id, str):
+        raise SignalCollectorError("Signal account_alias and connection_id must be text")
+    validate_opaque(alias, "Signal account alias")
+    validate_opaque(connection_id, "Signal connection ID")
+    version = value["signal_cli_version"]
+    if version != SIGNAL_CLI_VERSION:
+        raise SignalCollectorError(
+            f"Signal event schema is pinned to signal-cli {SIGNAL_CLI_VERSION}"
+        )
+    return SignalConfig(account, alias, connection_id, version)
+
+
+def _event_lines(path: Path) -> list[str]:
+    _private_regular_file(path, "Signal event input")
+    if path.stat().st_size > MAX_INPUT_BYTES:
+        raise SignalCollectorError("Signal event input exceeds the bounded input limit")
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError) as error:
+        raise SignalCollectorError("Signal event input is not valid UTF-8") from error
+    events = [line[5:].strip() if line.startswith("data:") else line.strip() for line in lines]
+    events = [line for line in events if line and not line.startswith(":")]
+    if len(events) > MAX_EVENTS:
+        raise SignalCollectorError("Signal event input exceeds the event limit")
+    return events
+
+
+def _receive_payload(value: dict[str, Any], expected_account: str) -> dict[str, Any]:
+    if value.get("jsonrpc") != "2.0" or value.get("method") != "receive":
+        raise SignalCollectorError("Signal input may contain receive notifications only")
+    if "id" in value or "result" in value or "error" in value:
+        raise SignalCollectorError("Signal input contains a request or response")
+    params = value.get("params")
+    if not isinstance(params, dict):
+        raise SignalCollectorError("Signal receive notification params must be an object")
+    wrapped = params.get("result")
+    payload = wrapped if isinstance(wrapped, dict) else params
+    account = payload.get("account")
+    if account != expected_account:
+        raise SignalCollectorError("Signal notification account identity does not match config")
+    envelope = payload.get("envelope")
+    if not isinstance(envelope, dict):
+        raise SignalCollectorError("Signal receive notification has no envelope")
+    reject_credentials(envelope)
+    return envelope
+
+
+def load_events(path: Path, config: SignalConfig) -> list[dict[str, Any]]:
+    """Read bounded JSONL or SSE data lines and complete the final identity fence."""
+    envelopes: list[dict[str, Any]] = []
+    for line_number, line in enumerate(_event_lines(path), 1):
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise SignalCollectorError(
+                f"Signal event line {line_number} is not valid JSON"
+            ) from error
+        if not isinstance(value, dict):
+            raise SignalCollectorError(f"Signal event line {line_number} must be an object")
+        envelopes.append(_receive_payload(value, config.account))
+    return envelopes
+
+
+def _digest(*parts: object) -> str:
+    payload = json.dumps(parts, ensure_ascii=False, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:40]
+
+
+def _identity(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value or len(value) > 256:
+        raise SignalCollectorError(f"Signal {field} is missing or invalid")
+    return f"id_{_digest(field, value)}"
+
+
+def _timestamp(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise SignalCollectorError(f"Signal {field} must be a positive integer")
+    return value
+
+
+def _iso_millis(value: int) -> str:
+    try:
+        return datetime.fromtimestamp(value / 1000, timezone.utc).isoformat().replace(
+            "+00:00", "Z"
+        )
+    except (OSError, OverflowError, ValueError) as error:
+        raise SignalCollectorError("Signal timestamp is outside the supported range") from error
+
+
+def _text(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or len(value) > MAX_TEXT_CHARS:
+        raise SignalCollectorError(f"Signal {field} is invalid or too large")
+    return value
+
+
+def route_status() -> dict[str, Any]:
+    """Return the dated no-live-route and offline-event disposition."""
+    return {
+        "provider": PROVIDER,
+        "route": "offline_pre_captured_jsonrpc_receive_notifications_only",
+        "live_collector": "unavailable_due_to_unavoidable_default_delivery_receipts",
+        "official_export_backup": "no_validated_third_party_message_export_contract",
+        "signal_cli": {
+            "supported_version": SIGNAL_CLI_VERSION,
+            "released_at": SIGNAL_CLI_RELEASED_AT,
+            "schema": EVENT_SCHEMA,
+            "installed_dependency_required": False,
+        },
+        "reviewed_at": EVIDENCE_REVIEWED_AT,
+        "dispositions": list(CAPABILITY_DISPOSITIONS),
+        "forbidden_actions": [
+            "send",
+            "sendReceipt",
+            "sendTyping",
+            "sendReaction",
+            "trust",
+            "updateContact",
+            "updateGroup",
+            "remoteDelete",
+            "subscribeReceive",
+        ],
+    }

--- a/.agents/scripts/_knowledge_social_signal_normalize.py
+++ b/.agents/scripts/_knowledge_social_signal_normalize.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize validated offline signal-cli notifications into social archives."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_signal import (
+    CAPABILITY_DISPOSITIONS,
+    EVIDENCE_REVIEWED_AT,
+    EVENT_SCHEMA,
+    MAX_ATTACHMENT_BYTES,
+    MAX_ATTACHMENTS_PER_MESSAGE,
+    PROVIDER,
+    SIGNAL_CLI_RELEASED_AT,
+    SignalCollectorError,
+    SignalConfig,
+    _digest,
+    _identity,
+    _iso_millis,
+    _text,
+    _timestamp,
+)
+from knowledge_social_import import reject_credentials
+
+
+@dataclass(frozen=True)
+class MessageContext:
+    """Identity and policy context shared by one normalized message event."""
+
+    archive: dict[str, Any]
+    account_id: str
+    author_id: str
+    participant_id: str
+    observed_at: str
+    direction: str
+
+
+@dataclass(frozen=True)
+class MessageState:
+    """Validated identifiers and expiry state for one message event."""
+
+    timestamp: int
+    thread_id: str
+    message_id: str
+    group_id: str | None
+    expires: int
+    view_once: bool
+    ephemeral: bool
+
+
+def _source(envelope: dict[str, Any]) -> str:
+    source = next(
+        (
+            envelope.get(key)
+            for key in ("sourceUuid", "sourceNumber", "source")
+            if isinstance(envelope.get(key), str) and envelope.get(key)
+        ),
+        None,
+    )
+    return _identity(source, "participant")
+
+
+def _group(data: dict[str, Any]) -> str | None:
+    group = data.get("groupInfo")
+    if group is None:
+        return None
+    if not isinstance(group, dict):
+        raise SignalCollectorError("Signal groupInfo must be an object")
+    return _identity(group.get("groupId"), "group")
+
+
+def _thread(account_id: str, participant_id: str, group_id: str | None) -> str:
+    if group_id is not None:
+        return f"thread_{_digest('group', group_id)}"
+    return f"thread_{_digest('direct', *sorted((account_id, participant_id)))}"
+
+
+def _message_id(thread_id: str, author_id: str, timestamp: int) -> str:
+    return f"msg_{_digest(thread_id, author_id, timestamp)}"
+
+
+def _base_archive(config: SignalConfig, observed_at: str) -> dict[str, Any]:
+    account_id = _identity(config.account, "account")
+    return {
+        "provider": PROVIDER,
+        "connection_id": config.connection_id,
+        "remote_account_id": account_id,
+        "exported_at": observed_at,
+        "enabled_streams": ["offline_receive_notifications"],
+        "policy": {
+            "account_alias": config.account_alias,
+            "account_gate": "every_notification_must_include_matching_account",
+            "attachment_policy": "metadata_only_no_path_or_payload_reads",
+            "collector_network_access": "none",
+            "collector_provider_mutations": "none",
+            "disappearing_message_policy": "content_free_tombstone",
+            "event_schema": EVENT_SCHEMA,
+            "evidence_reviewed_at": EVIDENCE_REVIEWED_AT,
+            "official_export_route": "not_validated",
+            "signal_cli_released_at": SIGNAL_CLI_RELEASED_AT,
+            "signal_cli_version": config.signal_cli_version,
+            "source": "offline_jsonrpc_receive_notifications",
+            "view_once_policy": "exclude_payload_and_attachment_metadata",
+        },
+        "accounts": [
+            {
+                "remote_id": account_id,
+                "handle": config.account_alias,
+                "display_name": None,
+                "observed_at": observed_at,
+                "provider_json": {"source": "local_account_gate"},
+            }
+        ],
+        "objects": [],
+        "activities": [],
+        "media": [],
+        "coverage": [],
+    }
+
+
+def _retention_limit(stream: str) -> str:
+    ephemeral_streams = {"disappearing_messages", "view_once", "stories"}
+    if stream in ephemeral_streams:
+        return "provider_expiry_preserved_no_view_once_payload"
+    return "local_protected_corpus_policy"
+
+
+def _coverage(
+    observed_at: str, earliest: str | None, latest: str | None
+) -> list[dict[str, Any]]:
+    return [
+        {
+            **disposition,
+            "earliest_at": earliest,
+            "latest_at": latest,
+            "cursor_exhausted": False,
+            "retention_limit": _retention_limit(disposition["stream"]),
+            "observed_at": observed_at,
+            "unavailable_reason": disposition["reason"],
+        }
+        for disposition in CAPABILITY_DISPOSITIONS
+    ]
+
+
+def _validate_attachment_size(size: Any) -> int | None:
+    if size is None:
+        return None
+    if isinstance(size, bool) or not isinstance(size, int):
+        raise SignalCollectorError("Signal attachment size is invalid or too large")
+    if size < 0 or size > MAX_ATTACHMENT_BYTES:
+        raise SignalCollectorError("Signal attachment size is invalid or too large")
+    return size
+
+
+def _attachment_row(
+    attachment: Any, message_id: str, index: int
+) -> dict[str, Any]:
+    if not isinstance(attachment, dict):
+        raise SignalCollectorError("Signal attachment must be an object")
+    size = _validate_attachment_size(attachment.get("size"))
+    return {
+        "remote_id": f"media_{_digest(message_id, attachment.get('id'), index)}",
+        "object_remote_id": message_id,
+        "content_sha256": None,
+        "mime_type": _text(
+            attachment.get("contentType"), "attachment content type"
+        ),
+        "byte_size": size,
+        "blob_ref": None,
+        "hydration_state": "metadata_only",
+    }
+
+
+def _attachment_rows(
+    attachments: Any, message_id: str, ephemeral: bool
+) -> list[dict[str, Any]]:
+    if attachments is None or ephemeral:
+        return []
+    if not isinstance(attachments, list):
+        raise SignalCollectorError("Signal attachments must be a bounded array")
+    if len(attachments) > MAX_ATTACHMENTS_PER_MESSAGE:
+        raise SignalCollectorError("Signal attachments must be a bounded array")
+    return [
+        _attachment_row(attachment, message_id, index)
+        for index, attachment in enumerate(attachments)
+    ]
+
+
+def _message_state(context: MessageContext, data: dict[str, Any]) -> MessageState:
+    timestamp = _timestamp(data.get("timestamp"), "message timestamp")
+    group_id = _group(data)
+    thread_id = _thread(context.account_id, context.participant_id, group_id)
+    expires = data.get("expiresInSeconds", 0)
+    if isinstance(expires, bool) or not isinstance(expires, int):
+        raise SignalCollectorError(
+            "Signal expiresInSeconds must be a non-negative integer"
+        )
+    if expires < 0:
+        raise SignalCollectorError(
+            "Signal expiresInSeconds must be a non-negative integer"
+        )
+    view_once = data.get("viewOnce") is True
+    return MessageState(
+        timestamp=timestamp,
+        thread_id=thread_id,
+        message_id=_message_id(thread_id, context.author_id, timestamp),
+        group_id=group_id,
+        expires=expires,
+        view_once=view_once,
+        ephemeral=view_once or expires > 0,
+    )
+
+
+def _reaction_author(reaction: dict[str, Any]) -> Any:
+    return (
+        reaction.get("targetAuthorUuid")
+        or reaction.get("targetAuthorNumber")
+        or reaction.get("targetAuthor")
+    )
+
+
+def _append_reaction(
+    context: MessageContext, state: MessageState, reaction: Any
+) -> None:
+    if not isinstance(reaction, dict):
+        raise SignalCollectorError("Signal reaction must be an object")
+    target_id = _message_id(
+        state.thread_id,
+        _identity(_reaction_author(reaction), "reaction author"),
+        _timestamp(reaction.get("targetSentTimestamp"), "reaction target timestamp"),
+    )
+    context.archive["activities"].append(
+        {
+            "activity_type": "message_reaction",
+            "remote_id": (
+                f"reaction_{_digest(state.message_id, target_id, reaction.get('emoji'))}"
+            ),
+            "actor_remote_id": context.author_id,
+            "object_remote_id": target_id,
+            "occurred_at": _iso_millis(state.timestamp),
+            "observed_at": context.observed_at,
+            "state": "removed" if reaction.get("isRemove") is True else "active",
+            "provider_json": {
+                "emoji": _text(reaction.get("emoji"), "reaction emoji"),
+                "source": "signal_cli_notification",
+                "thread_remote_id": state.thread_id,
+            },
+        }
+    )
+
+
+def _append_delete(
+    context: MessageContext, state: MessageState, remote_delete: Any
+) -> None:
+    if not isinstance(remote_delete, dict):
+        raise SignalCollectorError("Signal remoteDelete must be an object")
+    target_id = _message_id(
+        state.thread_id,
+        context.author_id,
+        _timestamp(remote_delete.get("timestamp"), "delete target timestamp"),
+    )
+    context.archive["activities"].append(
+        {
+            "activity_type": "message_deleted",
+            "remote_id": f"delete_{_digest(state.message_id, target_id)}",
+            "actor_remote_id": context.author_id,
+            "object_remote_id": target_id,
+            "occurred_at": _iso_millis(state.timestamp),
+            "observed_at": context.observed_at,
+            "state": "deleted",
+            "provider_json": {
+                "source": "signal_cli_notification",
+                "thread_remote_id": state.thread_id,
+            },
+        }
+    )
+
+
+def _quote_target(data: dict[str, Any], thread_id: str) -> str | None:
+    quote = data.get("quote")
+    if quote is None:
+        return None
+    if not isinstance(quote, dict):
+        raise SignalCollectorError("Signal quote must be an object")
+    author = quote.get("authorUuid") or quote.get("authorNumber") or quote.get("author")
+    return _message_id(
+        thread_id,
+        _identity(author, "quote author"),
+        _timestamp(quote.get("id"), "quote timestamp"),
+    )
+
+
+def _provider_json(
+    context: MessageContext,
+    data: dict[str, Any],
+    state: MessageState,
+    edit_target: int | None,
+) -> dict[str, Any]:
+    provider_json: dict[str, Any] = {
+        "direction": context.direction,
+        "ephemeral": state.ephemeral,
+        "expires_in_seconds": state.expires,
+        "group_remote_id": state.group_id,
+        "source": "signal_cli_notification",
+        "thread_remote_id": state.thread_id,
+        "view_once": state.view_once,
+    }
+    quote_target = _quote_target(data, state.thread_id)
+    if quote_target is not None:
+        provider_json["quote_target_remote_id"] = quote_target
+    if edit_target is not None:
+        provider_json["edit_target_remote_id"] = _message_id(
+            state.thread_id, context.author_id, edit_target
+        )
+    return provider_json
+
+
+def _object_type(state: MessageState, edit_target: int | None) -> str:
+    if state.ephemeral:
+        return "message_tombstone"
+    if edit_target is not None:
+        return "message_edit"
+    return "message"
+
+
+def _append_content(
+    context: MessageContext,
+    data: dict[str, Any],
+    state: MessageState,
+    edit_target: int | None,
+) -> None:
+    context.archive["objects"].append(
+        {
+            "object_type": _object_type(state, edit_target),
+            "remote_id": state.message_id,
+            "account_remote_id": (
+                context.account_id if context.direction == "outbound" else None
+            ),
+            "text": (
+                None
+                if state.ephemeral
+                else _text(data.get("message"), "message text")
+            ),
+            "created_at": _iso_millis(state.timestamp),
+            "observed_at": context.observed_at,
+            "evidence_class": (
+                "authored" if context.direction == "outbound" else "observed"
+            ),
+            "provider_json": _provider_json(context, data, state, edit_target),
+        }
+    )
+    action = "edit" if edit_target is not None else "sent"
+    context.archive["activities"].append(
+        {
+            "activity_type": (
+                "message_edited" if edit_target is not None else "message_sent"
+            ),
+            "remote_id": f"activity_{_digest(state.message_id, action)}",
+            "actor_remote_id": context.author_id,
+            "object_remote_id": state.message_id,
+            "occurred_at": _iso_millis(state.timestamp),
+            "observed_at": context.observed_at,
+            "state": "tombstone" if state.ephemeral else "active",
+            "provider_json": {
+                "source": "signal_cli_notification",
+                "thread_remote_id": state.thread_id,
+            },
+        }
+    )
+    context.archive["media"].extend(
+        _attachment_rows(data.get("attachments"), state.message_id, state.ephemeral)
+    )
+
+
+def _message_rows(
+    context: MessageContext, data: dict[str, Any], edit_target: int | None = None
+) -> tuple[str, int]:
+    state = _message_state(context, data)
+    kind = "message"
+    if data.get("reaction") is not None:
+        _append_reaction(context, state, data["reaction"])
+        kind = "reaction"
+    elif data.get("remoteDelete") is not None:
+        _append_delete(context, state, data["remoteDelete"])
+        kind = "delete"
+    else:
+        _append_content(context, data, state, edit_target)
+    return kind, state.timestamp
+
+
+def _edit_payload(edit: Any, label: str) -> tuple[dict[str, Any], int]:
+    if not isinstance(edit, dict):
+        raise SignalCollectorError(f"Signal {label} editMessage is invalid")
+    data = edit.get("dataMessage")
+    if not isinstance(data, dict):
+        raise SignalCollectorError(f"Signal {label} editMessage is invalid")
+    target = _timestamp(edit.get("targetSentTimestamp"), "edit target timestamp")
+    return data, target
+
+
+def _message_context(
+    archive: dict[str, Any],
+    observed_at: str,
+    author_id: str,
+    participant_id: str,
+    direction: str,
+) -> MessageContext:
+    return MessageContext(
+        archive=archive,
+        account_id=archive["remote_account_id"],
+        author_id=author_id,
+        participant_id=participant_id,
+        observed_at=observed_at,
+        direction=direction,
+    )
+
+
+def _destination(sent: dict[str, Any]) -> str:
+    value = (
+        sent.get("destinationUuid")
+        or sent.get("destinationNumber")
+        or sent.get("destination")
+    )
+    return _identity(value, "destination")
+
+
+def _normalize_sync(
+    archive: dict[str, Any],
+    envelope: dict[str, Any],
+    sync: Any,
+    observed_at: str,
+) -> tuple[str, int]:
+    if not isinstance(sync, dict):
+        raise SignalCollectorError("Signal syncMessage must be an object")
+    sent = sync.get("sentMessage")
+    if not isinstance(sent, dict):
+        timestamp = _timestamp(envelope.get("timestamp"), "envelope timestamp")
+        return "sync_metadata", timestamp
+    account_id = archive["remote_account_id"]
+    context = _message_context(
+        archive, observed_at, account_id, _destination(sent), "outbound"
+    )
+    edit = sent.get("editMessage")
+    if edit is None:
+        return _message_rows(context, sent)
+    data, target = _edit_payload(edit, "sync")
+    return _message_rows(context, data, target)
+
+
+def _normalize_inbound(
+    archive: dict[str, Any],
+    envelope: dict[str, Any],
+    source_id: str,
+    observed_at: str,
+) -> tuple[str, int]:
+    context = _message_context(
+        archive, observed_at, source_id, source_id, "inbound"
+    )
+    edit = envelope.get("editMessage")
+    data = envelope.get("dataMessage")
+    if edit is not None:
+        edit_data, target = _edit_payload(edit, "inbound")
+        result = _message_rows(context, edit_data, target)
+    elif isinstance(data, dict):
+        result = _message_rows(context, data)
+    else:
+        result = (
+            "unsupported",
+            _timestamp(envelope.get("timestamp"), "envelope timestamp"),
+        )
+    return result
+
+
+def _normalize_envelope(
+    archive: dict[str, Any], envelope: dict[str, Any], observed_at: str
+) -> tuple[str, int]:
+    source_id = _source(envelope)
+    sync = envelope.get("syncMessage")
+    if sync is not None:
+        result = _normalize_sync(archive, envelope, sync, observed_at)
+    else:
+        result = _normalize_inbound(archive, envelope, source_id, observed_at)
+    return result
+
+
+def _dedupe_rows(rows: list[dict[str, Any]], label: str) -> list[dict[str, Any]]:
+    seen: dict[str, str] = {}
+    unique: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        remote_id = row["remote_id"]
+        payload = json.dumps(row, sort_keys=True, ensure_ascii=False)
+        if remote_id in seen and seen[remote_id] != payload:
+            raise SignalCollectorError(f"Signal {label} stable identity collision")
+        seen[remote_id] = payload
+        unique[remote_id] = row
+    return list(unique.values())
+
+
+def _event_bounds(timestamps: list[int]) -> tuple[str | None, str | None]:
+    if not timestamps:
+        return None, None
+    return _iso_millis(min(timestamps)), _iso_millis(max(timestamps))
+
+
+def normalize_events(
+    config: SignalConfig, envelopes: list[dict[str, Any]], observed_at: str
+) -> tuple[dict[str, Any], dict[str, int]]:
+    """Build one canonical archive after validating every event and collision."""
+    archive = _base_archive(config, observed_at)
+    counts: dict[str, int] = {}
+    timestamps: list[int] = []
+    for envelope in envelopes:
+        kind, timestamp = _normalize_envelope(archive, envelope, observed_at)
+        counts[kind] = counts.get(kind, 0) + 1
+        timestamps.append(timestamp)
+    for key in ("objects", "activities", "media"):
+        archive[key] = _dedupe_rows(archive[key], key)
+    earliest, latest = _event_bounds(timestamps)
+    archive["coverage"] = _coverage(observed_at, earliest, latest)
+    reject_credentials(archive)
+    return archive, counts

--- a/.agents/scripts/knowledge_social_signal.py
+++ b/.agents/scripts/knowledge_social_signal.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Inspect or import bounded offline signal-cli receive notifications."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from _knowledge_social_signal import (
+    SignalCollectorError,
+    load_config,
+    load_events,
+    route_status,
+    utc_now,
+)
+from _knowledge_social_signal_normalize import normalize_events
+from knowledge_corpus_catalog import CatalogError, DEFAULT_ALIAS, resolve
+from knowledge_social_import import canonical_json, import_archive_payload
+from knowledge_social_store import SocialStoreError, validate_root
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("status", "inspect", "import-events"))
+    parser.add_argument("--config", type=Path)
+    parser.add_argument("--events", type=Path)
+    parser.add_argument("--base", type=Path)
+    parser.add_argument("--alias", default=DEFAULT_ALIAS)
+    parser.add_argument("--observed-at", help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    needs_input = args.command in {"inspect", "import-events"}
+    if needs_input and (args.config is None or args.events is None):
+        parser.error(f"{args.command} requires --config and --events")
+    if not needs_input and (args.config is not None or args.events is not None):
+        parser.error("--config and --events are valid only for inspect or import-events")
+    if args.command != "import-events" and (args.base is not None or args.alias != DEFAULT_ALIAS):
+        parser.error("--base and --alias are valid only for import-events")
+    return args
+
+
+def _summary(archive: dict[str, Any], counts: dict[str, int]) -> dict[str, Any]:
+    return {
+        "account_alias": archive["policy"]["account_alias"],
+        "activities": len(archive["activities"]),
+        "counts": counts,
+        "media": len(archive["media"]),
+        "objects": len(archive["objects"]),
+        "provider": archive["provider"],
+        "route": archive["policy"]["source"],
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.command == "status":
+            result: Any = route_status()
+        else:
+            config = load_config(args.config)
+            events = load_events(args.events, config)
+            archive, counts = normalize_events(config, events, args.observed_at or utc_now())
+            result = _summary(archive, counts)
+            if args.command == "import-events":
+                base = args.base or Path.home() / ".aidevops" / ".agent-workspace" / "knowledge"
+                root = validate_root(resolve(base, args.alias, "knowledge.write"))
+                imported = import_archive_payload(
+                    root, archive, canonical_json(archive).encode("utf-8")
+                )
+                result["import"] = imported
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    except (CatalogError, OSError, SignalCollectorError, SocialStoreError, ValueError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/services/communications/signal.md
+++ b/.agents/services/communications/signal.md
@@ -24,9 +24,10 @@ tools:
 - **Type**: E2E encrypted messaging — phone number required, minimal metadata, sealed sender
 - **Bot tool**: [signal-cli](https://github.com/AsamK/signal-cli) (Java/GraalVM native) — GPL-3.0
 - **Daemon API**: JSON-RPC 2.0 over HTTP (`:8080`), TCP (`:7583`), Unix socket, stdin/stdout, D-Bus; SSE: `GET /api/v1/events`
-- **Data**: `~/.local/share/signal-cli/data/` (SQLite: `account.db`)
+- **Bot data**: `~/.local/share/signal-cli/data/` (SQLite: `account.db`); never a knowledge-collector input
 - **Registration**: SMS/voice + CAPTCHA, or QR code link to existing account
 - **Docs**: https://github.com/AsamK/signal-cli/wiki
+- **Private knowledge**: offline pre-captured receive notifications only; see `content/social-signal.md`
 
 | Criterion | Signal | SimpleX | Matrix | Telegram |
 |-----------|--------|---------|--------|----------|
@@ -45,6 +46,22 @@ tools:
 **Bot security**: (1) treat all inbound as untrusted — sanitize before AI/shell; (2) allowlist by E.164/UUID; (3) sandbox commands; (4) isolate credentials; (5) scan with `prompt-guard-helper.sh` before AI dispatch.
 
 Cross-reference: `tools/security/opsec.md`, `tools/credentials/gopass.md`, `tools/security/prompt-injection-defender.md`
+
+### Knowledge collector boundary
+
+Bot operations in this reference are not knowledge-ingestion instructions. The collector
+in `scripts/knowledge_social_signal.py` accepts only a bounded, mode-0600 file containing
+pre-captured `receive` notifications whose account identity is present and matches a
+private config. It has no process, network, socket, account-database, key, send, receipt,
+typing, reaction, trust, contact/group, remote-delete, registration, or link route.
+
+As reviewed on 2026-07-31, the supported schema is pinned to unofficial `signal-cli`
+0.14.6. Live collection is not exposed because `receive` sends default delivery receipts
+even when optional read receipts are disabled. No official third-party message
+export/backup contract was validated. Stories and view-once payloads are excluded;
+disappearing messages become content-free tombstones; pre-link and identity-change
+history remain explicit unavailable coverage. See `content/social-signal.md` for the full
+capability and retention table.
 
 **Access control** — no built-in allowlists; filter on sender at the application layer. Identifier types: E.164 (`+XXXXXXXXXXX`), ACI UUID (`a1b2c3d4-...`), PNI (`PNI:a1b2c3d4-...`), username (`u:username.NNN`).
 
@@ -208,7 +225,7 @@ signal-cli -a +1234567890 updateGroup -g GROUP_ID -m +NEW -r +OLD --admin +ADMIN
 ```bash
 signal-cli --config /custom/path ...                                   # custom data dir
 signal-cli --log-file /var/log/signal-cli.log --scrub-log ...          # logging (scrubs sensitive data)
-cp ~/.local/share/signal-cli/data/+1234567890/account.db{,.bak.$(date +%Y%m%d)}  # backup before upgrade
+cp ~/.local/share/signal-cli/data/+1234567890/account.db{,.bak.$(date +%Y%m%d)}  # bot maintenance only; never collector input
 ```
 
 Options: `--service-environment live` (production, default), `--trust-new-identities on-first-use|always|never`, `--disable-send-log`.

--- a/.agents/tests/test-knowledge-social-signal.sh
+++ b/.agents/tests/test-knowledge-social-signal.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-signal.sh — side-effect-free Signal event ingestion tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SIGNAL_HELPER="${SCRIPT_DIR}/../scripts/knowledge_social_signal.py"
+SOCIAL_HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+CONFIG="${TMP_DIR}/signal-config.json"
+EVENTS="${TMP_DIR}/signal-events.jsonl"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' \
+			"$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c \
+		'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+expect_failure() {
+	local description="$1"
+	local config="$2"
+	local events="$3"
+	if python3 "$SIGNAL_HELPER" inspect --config "$config" --events "$events" \
+		--observed-at 2026-07-31T12:00:00Z >/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$SOCIAL_HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+cat >"$CONFIG" <<'JSON'
+{"schema_version":1,"account":"+15550001000","account_alias":"signal_personal","connection_id":"conn_signal_personal","signal_cli_version":"0.14.6"}
+JSON
+chmod 0600 "$CONFIG"
+
+cat >"$EVENTS" <<'JSONL'
+{"jsonrpc":"2.0","method":"receive","params":{"account":"+15550001000","envelope":{"sourceNumber":"+15550001001","sourceUuid":"11111111-1111-4111-8111-111111111111","sourceName":"Fixture Contact","timestamp":1785492000000,"dataMessage":{"timestamp":1785492000000,"message":"fixture direct message","expiresInSeconds":0,"viewOnce":false,"quote":{"id":1785491000000,"authorUuid":"22222222-2222-4222-8222-222222222222","text":"not duplicated"},"attachments":[{"contentType":"image/png","filename":"private-name.png","id":"fixture-attachment","size":2048}]}}}}
+{"jsonrpc":"2.0","method":"receive","params":{"account":"+15550001000","envelope":{"sourceUuid":"11111111-1111-4111-8111-111111111111","timestamp":1785492100000,"dataMessage":{"timestamp":1785492100000,"message":"must not persist","expiresInSeconds":60,"viewOnce":false,"groupInfo":{"groupId":"fixture-group"},"attachments":[]}}}}
+{"jsonrpc":"2.0","method":"receive","params":{"account":"+15550001000","envelope":{"sourceUuid":"11111111-1111-4111-8111-111111111111","timestamp":1785492200000,"dataMessage":{"timestamp":1785492200000,"message":"view once secret","expiresInSeconds":0,"viewOnce":true,"attachments":[{"contentType":"image/jpeg","filename":"secret.jpg","id":"view-once","size":4096}]}}}}
+{"jsonrpc":"2.0","method":"receive","params":{"account":"+15550001000","envelope":{"sourceUuid":"11111111-1111-4111-8111-111111111111","timestamp":1785492300000,"dataMessage":{"timestamp":1785492300000,"expiresInSeconds":0,"viewOnce":false,"reaction":{"emoji":"+1","targetAuthorUuid":"22222222-2222-4222-8222-222222222222","targetSentTimestamp":1785491000000,"isRemove":false}}}}}
+{"jsonrpc":"2.0","method":"receive","params":{"account":"+15550001000","envelope":{"sourceUuid":"11111111-1111-4111-8111-111111111111","timestamp":1785492400000,"editMessage":{"targetSentTimestamp":1785492000000,"dataMessage":{"timestamp":1785492400000,"message":"fixture corrected","expiresInSeconds":0,"viewOnce":false,"attachments":[]}}}}}
+{"jsonrpc":"2.0","method":"receive","params":{"account":"+15550001000","envelope":{"sourceUuid":"11111111-1111-4111-8111-111111111111","timestamp":1785492500000,"dataMessage":{"timestamp":1785492500000,"expiresInSeconds":0,"viewOnce":false,"remoteDelete":{"timestamp":1785492000000}}}}}
+{"jsonrpc":"2.0","method":"receive","params":{"account":"+15550001000","envelope":{"sourceUuid":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","timestamp":1785492600000,"syncMessage":{"sentMessage":{"destinationUuid":"22222222-2222-4222-8222-222222222222","timestamp":1785492600000,"message":"fixture outbound transcript","expiresInSeconds":0,"viewOnce":false,"attachments":[]}}}}}
+{"jsonrpc":"2.0","method":"receive","params":{"account":"+15550001000","envelope":{"sourceUuid":"11111111-1111-4111-8111-111111111111","timestamp":1785492700000,"storyMessage":{"allowsReplies":true,"textAttachment":{"text":"ephemeral story"}}}}}
+JSONL
+chmod 0600 "$EVENTS"
+
+printf 'Signal social collector tests\n'
+
+status=$(python3 "$SIGNAL_HELPER" status)
+assert_eq "status pins the reviewed signal-cli schema" \
+	"$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["signal_cli"]["supported_version"])' "$status")" \
+	0.14.6
+assert_eq "live collection is explicitly unavailable because receive sends delivery receipts" \
+	"$(json_field "$status" live_collector)" \
+	unavailable_due_to_unavoidable_default_delivery_receipts
+
+inspection=$(python3 "$SIGNAL_HELPER" inspect --config "$CONFIG" --events "$EVENTS" \
+	--observed-at 2026-07-31T12:00:00Z)
+assert_eq "bounded fixture inspection sees every notification" \
+	"$(python3 -c 'import json,sys; print(sum(json.loads(sys.argv[1])["counts"].values()))' "$inspection")" 8
+assert_eq "inspection exposes no message content" \
+	"$(python3 -c 'import json,sys; print("fixture direct message" in sys.argv[1])' "$inspection")" False
+
+result=$(python3 "$SIGNAL_HELPER" import-events --config "$CONFIG" --events "$EVENTS" \
+	--base "$BASE" --alias personal:default --observed-at 2026-07-31T12:00:00Z)
+assert_eq "offline notifications import into the protected social corpus" \
+	"$(json_field "$result" objects)" 5
+assert_eq "normal messages and edits preserve authorized text" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='signal' AND text_content LIKE 'fixture%'")" 3
+assert_eq "disappearing and view-once payloads become content-free tombstones" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='signal' AND object_type='message_tombstone' AND text_content IS NULL")" 2
+assert_eq "view-once attachment metadata is excluded" \
+	"$(sql_value "SELECT count(*) FROM media WHERE provider='signal'")" 1
+assert_eq "ordinary attachment paths and filenames never reach canonical evidence" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider_json LIKE '%private-name%' OR provider_json LIKE '%secret.jpg%'")" 0
+assert_eq "reactions and deletion observations are normalized as activities" \
+	"$(sql_value "SELECT count(*) FROM activities WHERE provider='signal' AND activity_type IN ('message_reaction','message_deleted')")" 2
+assert_eq "pre-link history remains explicit unavailable coverage" \
+	"$(sql_value "SELECT status FROM coverage_records WHERE provider='signal' AND stream='pre_link_history'")" unavailable
+assert_eq "view-once retention remains explicit excluded coverage" \
+	"$(sql_value "SELECT status FROM coverage_records WHERE provider='signal' AND stream='view_once'")" excluded
+assert_eq "raw evidence stores normalized archives rather than source event files" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='signal' AND resource_count=14")" 1
+
+python3 "$SIGNAL_HELPER" import-events --config "$CONFIG" --events "$EVENTS" \
+	--base "$BASE" --alias personal:default --observed-at 2026-07-31T12:00:00Z >/dev/null
+assert_eq "exact event replay is idempotent" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='signal'")" 5
+
+BAD_CONFIG="${TMP_DIR}/bad-config.json"
+cat >"$BAD_CONFIG" <<'JSON'
+{"schema_version":1,"account":"+15550009999","account_alias":"signal_personal","connection_id":"conn_signal_personal","signal_cli_version":"0.14.6"}
+JSON
+chmod 0600 "$BAD_CONFIG"
+expect_failure "account rebinding fails before persistence" "$BAD_CONFIG" "$EVENTS"
+
+REQUEST_EVENTS="${TMP_DIR}/request-events.jsonl"
+cat >"$REQUEST_EVENTS" <<'JSONL'
+{"jsonrpc":"2.0","id":"unsafe","method":"send","params":{"account":"+15550001000","message":"must reject"}}
+JSONL
+chmod 0600 "$REQUEST_EVENTS"
+expect_failure "outbound JSON-RPC requests are unreachable" "$CONFIG" "$REQUEST_EVENTS"
+
+PERMISSIVE_CONFIG="${TMP_DIR}/permissive-config.json"
+cp "$CONFIG" "$PERMISSIVE_CONFIG"
+chmod 0644 "$PERMISSIVE_CONFIG"
+expect_failure "config with permissive local permissions fails closed" "$PERMISSIVE_CONFIG" "$EVENTS"
+
+MALFORMED_EVENTS="${TMP_DIR}/malformed-events.jsonl"
+cat >"$MALFORMED_EVENTS" <<'JSONL'
+{"jsonrpc":"2.0","method":"receive","params":{"account":"+15550001000","envelope":{"sourceUuid":"11111111-1111-4111-8111-111111111111","timestamp":1785492800000,"dataMessage":{"timestamp":1785492800000,"message":"partial must not commit","expiresInSeconds":0,"viewOnce":false}}}}
+not-json
+JSONL
+chmod 0600 "$MALFORMED_EVENTS"
+before=$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='signal'")
+expect_failure "malformed batches fail before any atomic commit" "$CONFIG" "$MALFORMED_EVENTS"
+assert_eq "malformed batches preserve the prior checkpoint" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='signal'")" "$before"
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import ast
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+sources = sorted(scripts.glob("_knowledge_social_signal*.py"))
+sources.append(scripts / "knowledge_social_signal.py")
+for source in sources:
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+    imported = {
+        alias.name.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    assert not imported.intersection({"http", "requests", "socket", "subprocess", "urllib"})
+
+core = "\n".join(source.read_text(encoding="utf-8") for source in sources)
+assert "account.db" not in core
+assert "subscribeReceive(" not in core
+assert "Popen(" not in core and "run(" not in core
+PY
+assert_eq "collector code has no network, process, account database, or subscription route" \
+	guarded guarded
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -ne 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add a bounded offline signal-cli receive-event importer with strict account fencing, ephemeral-content exclusion, explicit capability dispositions, tests, safety documentation, and complexity-free normalization modules.

## Files Changed

.agents/content/social-signal.md, .agents/scripts/_knowledge_social_signal.py, .agents/scripts/_knowledge_social_signal_normalize.py, .agents/scripts/knowledge_social_signal.py, .agents/services/communications/signal.md, .agents/tests/test-knowledge-social-signal.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — bash .agents/tests/test-knowledge-social-signal.sh; python3 -m py_compile .agents/scripts/_knowledge_social_signal.py .agents/scripts/_knowledge_social_signal_normalize.py .agents/scripts/knowledge_social_signal.py; shellcheck .agents/tests/test-knowledge-social-signal.sh; radon cc/mi on Signal collector modules

Resolves #28785


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.203 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 12m and 123,823 tokens on this as a headless worker.