### PR TITLE
GH#29079: prevent false NMR billing classifications

### DIFF
--- a/.agents/scripts/pulse-nmr-reason.jq
+++ b/.agents/scripts/pulse-nmr-reason.jq
@@ -5,16 +5,23 @@ def metadata($code; $class; $source): {
   revalidate_after_seconds: (if $class == "temporary" then $revalidate else null end),
   requires_crypto: ($class == "genuine-authority")
 };
+def explicit_metadata:
+  try capture("<!--\\s*nmr-reason\\s+code=(?<code>[a-z_-]+)\\s+class=(?<class>genuine-authority|temporary)\\s*-->")
+  catch null;
+def legacy_metadata:
+  ascii_downcase as $text
+  | if ($text | test("<!--\\s*(cost-circuit-breaker:(fired|no_work_loop)|billing-approval-required)\\b")) then metadata("billing"; "genuine-authority"; "legacy-marker")
+    elif ($text | test("<!--\\s*(secret-required|credential-access-required)\\b")) then metadata("secret"; "genuine-authority"; "legacy-marker")
+    elif ($text | test("<!--\\s*(destructive-approval-required|irreversible-operation)\\b")) then metadata("destructive"; "genuine-authority"; "legacy-marker")
+    elif ($text | test("<!--\\s*(security-sensitive|auth-boundary-approval-required)\\b")) then metadata("security"; "genuine-authority"; "legacy-marker")
+    elif ($text | test("<!--\\s*(dispatch-backoff:rate_limit_nmr|dispatch-infrastructure-failure|transient-infrastructure)\\b")) then metadata("transient_infrastructure"; "temporary"; "legacy-marker")
+    elif ($text | test("<!--\\s*(missing-implementation-context|missing-context)\\b")) then metadata("missing_context"; "temporary"; "legacy-marker")
+    elif ($text | test("<!--\\s*(stale-recovery-tick:escalated|dispatch-circuit-breaker:worker_recovery_loop|diagnostic-ambiguity)\\b")) then metadata("diagnostic_ambiguity"; "temporary"; "legacy-marker")
+    else null end;
 (if type == "array" and (.[0]? | type) == "array" then [.[][]]
  else if type == "array" then . else [] end end) as $comments
-| ([$comments[].body // "" | try capture("nmr-reason code=(?<code>[a-z_-]+) class=(?<class>genuine-authority|temporary)") catch empty] | last) as $explicit
-| ($comments | map(.body // "") | join("\n") | ascii_downcase) as $text
+| ([$comments[].body // "" | explicit_metadata | select(. != null)] | last) as $explicit
+| ([$comments[].body // "" | legacy_metadata | select(. != null)] | last) as $legacy
 | if $explicit != null then metadata($explicit.code; $explicit.class; "structured-marker")
-  elif ($text | test("secret|required credential|credential access")) then metadata("secret"; "genuine-authority"; "legacy-marker")
-  elif ($text | test("destructive|data deletion|irreversible")) then metadata("destructive"; "genuine-authority"; "legacy-marker")
-  elif ($text | test("billing|cost-circuit-breaker|spend approval")) then metadata("billing"; "genuine-authority"; "legacy-marker")
-  elif ($text | test("security-sensitive|supply.chain|auth boundary")) then metadata("security"; "genuine-authority"; "legacy-marker")
-  elif ($text | test("rate_limit_nmr|dispatch-infrastructure-failure|local runtime|launch failure")) then metadata("transient_infrastructure"; "temporary"; "legacy-marker")
-  elif ($text | test("missing implementation context|missing context")) then metadata("missing_context"; "temporary"; "legacy-marker")
-  elif ($text | test("stale-recovery|worker_recovery_loop|diagnostic ambiguity")) then metadata("diagnostic_ambiguity"; "temporary"; "legacy-marker")
+  elif $legacy != null then $legacy
   else metadata("authority"; "genuine-authority"; "default") end

--- a/.agents/scripts/tests/test-pulse-nmr-reason.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-reason.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+FILTER="${SCRIPT_DIR}/../pulse-nmr-reason.jq"
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_reason() {
+	local name="$1"
+	local comments_json="$2"
+	local expected="$3"
+	local actual=""
+	TESTS_RUN=$((TESTS_RUN + 1))
+	actual=$(printf '%s' "$comments_json" | jq -c --argjson revalidate 3600 -f "$FILTER")
+	if [[ "$actual" == "$expected" ]]; then
+		printf 'PASS %s\n' "$name"
+		return 0
+	fi
+	printf 'FAIL %s\n  expected: %s\n  actual:   %s\n' "$name" "$expected" "$actual" >&2
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+authority='{"code":"authority","class":"genuine-authority","source":"default","revalidate_after_seconds":null,"requires_crypto":true}'
+billing='{"code":"billing","class":"genuine-authority","source":"legacy-marker","revalidate_after_seconds":null,"requires_crypto":true}'
+diagnostic='{"code":"diagnostic_ambiguity","class":"temporary","source":"legacy-marker","revalidate_after_seconds":3600,"requires_crypto":false}'
+structured='{"code":"billing","class":"genuine-authority","source":"structured-marker","revalidate_after_seconds":null,"requires_crypto":true}'
+
+# shellcheck disable=SC2016 # Backticks are literal Markdown fixture content.
+assert_reason "ops prose does not impersonate breaker marker" \
+	'[[{"body":"<!-- ops:start -->\nBelow threshold mentions `cost-circuit-breaker:no_work_loop` as documentation.\n<!-- ops:end -->"}],[{"body":"<!-- ops:start -->\n<!-- stale-recovery-tick:escalated (threshold=2) -->\n<!-- ops:end -->"}]]' \
+	"$diagnostic"
+
+assert_reason "latest exact marker determines legacy reason" \
+	'[{"body":"<!-- cost-circuit-breaker:fired tier=standard -->"},{"body":"<!-- stale-recovery-tick:escalated -->"}]' \
+	"$diagnostic"
+
+assert_reason "generated decision packet is not classifier evidence" \
+	'[{"body":"<!-- nmr-decision-packet reason=billing -->\nReason: billing"},{"body":"<!-- stale-recovery-tick:escalated -->"}]' \
+	"$diagnostic"
+
+assert_reason "unrelated billing prose remains fail-closed authority" \
+	'[{"body":"Documentation discusses billing and spend approval without an NMR marker."}]' \
+	"$authority"
+
+assert_reason "exact cost breaker remains genuine authority" \
+	'[{"body":"<!-- cost-circuit-breaker:no_work_loop count=3 -->"}]' \
+	"$billing"
+
+assert_reason "structured marker overrides later legacy marker" \
+	'[{"body":"<!-- nmr-reason code=billing class=genuine-authority -->"},{"body":"<!-- stale-recovery-tick:escalated -->"}]' \
+	"$structured"
+
+printf '\n%d tests run, %d failures\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-worker-reliability-self-heal.sh
+++ b/.agents/scripts/tests/test-worker-reliability-self-heal.sh
@@ -447,21 +447,26 @@ test_no_work_circuit_breaker_threshold_guard() {
 }
 
 test_no_work_circuit_breaker_marker_posted() {
-	# The NMR path must post a comment containing the
-	# cost-circuit-breaker:no_work_loop marker so that
-	# _nmr_application_is_circuit_breaker_trip can detect it.
+	# The actual NMR path must post the machine marker, while the below-threshold
+	# explanatory prose must not quote it and contaminate reason classification.
 
-	local fn_src
-	fn_src=$(awk '/^_log_no_work_skip_escalation\(\) \{/,/^\}/' "$LIFECYCLE_SCRIPT" 2>/dev/null)
-	if [[ -z "$fn_src" ]]; then
+	local breaker_src="" skip_src=""
+	breaker_src=$(awk '/^_apply_no_work_nmr_breaker\(\) \{/,/^\}/' "$LIFECYCLE_SCRIPT" 2>/dev/null)
+	skip_src=$(awk '/^_log_no_work_skip_escalation\(\) \{/,/^\}/' "$LIFECYCLE_SCRIPT" 2>/dev/null)
+	if [[ -z "$breaker_src" || -z "$skip_src" ]]; then
 		print_result "t2769: no_work circuit breaker marker posted" 1 \
-			"_log_no_work_skip_escalation not found"
+			"no_work breaker or below-threshold diagnostic function not found"
 		return 0
 	fi
 
-	if ! printf '%s\n' "$fn_src" | grep -q 'cost-circuit-breaker:no_work_loop'; then
+	if ! printf '%s\n' "$breaker_src" | grep -q 'cost-circuit-breaker:no_work_loop'; then
 		print_result "t2769: no_work circuit breaker marker posted" 1 \
-			"marker 'cost-circuit-breaker:no_work_loop' not found in function body"
+			"marker 'cost-circuit-breaker:no_work_loop' not found in breaker function"
+		return 0
+	fi
+	if printf '%s\n' "$skip_src" | grep -q 'cost-circuit-breaker:no_work_loop'; then
+		print_result "t2769: no_work circuit breaker marker posted" 1 \
+			"below-threshold diagnostic prose quotes the breaker marker"
 		return 0
 	fi
 

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -1363,7 +1363,7 @@ ${marker}
 
 **Why no cascade:** \`no_work\` means the worker never produced reliable implementation evidence — it crashed during runtime setup (FD exhaustion, plugin init failure, branch naming race, auth refresh race) or stale-recovery falsely concluded no progress. A more expensive model cannot fix an infrastructure problem it never reached. Cascading to \`tier:thinking\` would waste capacity on a problem the mapped standard or simple model can handle once the infrastructure clears.
 
-After ${nmr_threshold} consecutive \`no_work\` failures the per-issue no_work circuit breaker (t2769) applies \`needs-maintainer-review\` with a \`cost-circuit-breaker:no_work_loop\` marker that \`_nmr_application_is_circuit_breaker_trip\` (t2386) recognises, so auto-approval correctly preserves NMR.
+After ${nmr_threshold} consecutive \`no_work\` failures the per-issue no_work circuit breaker (t2769) applies \`needs-maintainer-review\` with a dedicated machine marker, so auto-approval correctly preserves NMR.
 
 _Automated by \`escalate_issue_tier()\` no_work skip (t2387) in worker-lifecycle-common.sh_
 <!-- ops:end -->"


### PR DESCRIPTION
## Summary

Classify NMR reasons from exact chronological markers, prevent audit prose and decision packets from feeding back into reason selection, and add focused regression coverage.

## Files Changed

.agents/scripts/pulse-nmr-reason.jq, .agents/scripts/tests/test-pulse-nmr-reason.sh, .agents/scripts/tests/test-worker-reliability-self-heal.sh, .agents/scripts/worker-lifecycle-common.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — linters-local.sh; ShellCheck; runtime-verified production JQ filter with 6 focused fixtures; 21 NMR approval tests; 16 worker reliability tests

Resolves #29079


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.203 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 55m and 393,621 tokens on this with the user in an interactive session.