### PR TITLE
GH#27777: Classify native gh cache frames

### DIFF
--- a/.agents/scripts/gh-quota-debug-filter.py
+++ b/.agents/scripts/gh-quota-debug-filter.py
@@ -7,16 +7,41 @@ from __future__ import annotations
 
 import re
 import sys
+from datetime import datetime
+from email.utils import parsedate_to_datetime
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from gh_quota_debug_response import REQUEST_END, response_metadata
 
 
-REQUEST_START = re.compile(rb"^\* Request at ")
+REQUEST_START = re.compile(
+    rb"^\* Request at (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)? [+-]\d{4})"
+)
+GO_DURATION_COMPONENT = re.compile(
+    rb"([0-9]+(?:\.[0-9]+)?)(ns|(?:\xc2\xb5|\xce\xbc|u)s|ms|s|m|h)"
+)
+DURATION_MS_FACTORS = {
+    b"ns": 0.000001,
+    b"us": 0.001,
+    b"\xc2\xb5s": 0.001,
+    b"\xce\xbcs": 0.001,
+    b"ms": 1.0,
+    b"s": 1000.0,
+}
+DURATION_SECONDS_FACTORS = {
+    **{unit: factor / 1000 for unit, factor in DURATION_MS_FACTORS.items()},
+    b"m": 60.0,
+    b"h": 3600.0,
+}
+CACHE_HOST = b"api.github.com"
+CACHE_MIN_AGE_SECONDS = 2.0
+CACHE_TTL_GRACE_SECONDS = 5.0
+CACHE_RESET_GRACE_SECONDS = 5.0
+CacheRequest = Tuple[datetime, float]
 
 
-def _frame_ranges(lines: List[bytes]) -> List[Tuple[int, int]]:
+def _request_ranges(lines: List[bytes]) -> List[Tuple[int, int]]:
     starts = [index for index, line in enumerate(lines) if REQUEST_START.match(line)]
     ranges: List[Tuple[int, int]] = []
     for position, start in enumerate(starts):
@@ -33,16 +58,120 @@ def _frame_ranges(lines: List[bytes]) -> List[Tuple[int, int]]:
     return ranges
 
 
-def _duration_ms(frame: List[bytes]) -> Optional[int]:
+def _completion_ranges(lines: List[bytes]) -> List[Tuple[int, int]]:
+    ranges: List[Tuple[int, int]] = []
+    start = 0
+    for index, line in enumerate(lines):
+        if REQUEST_END.match(line.rstrip(b"\r\n")):
+            ranges.append((start, index + 1))
+            start = index + 1
+    return ranges
+
+
+def _duration(frame: List[bytes]) -> Optional[Tuple[float, bytes]]:
     for line in reversed(frame):
         match = REQUEST_END.match(line.rstrip(b"\r\n"))
         if not match:
             continue
-        value = float(match.group(1))
-        if match.group(2) == b"s":
-            value *= 1000
-        return max(0, round(value))
+        return float(match.group(1)), match.group(2)
     return None
+
+
+def _duration_ms(frame: List[bytes]) -> Optional[int]:
+    duration = _duration(frame)
+    if duration is None:
+        return None
+    value, unit = duration
+    factor = DURATION_MS_FACTORS.get(unit)
+    if factor is None:
+        return None
+    return max(0, round(value * factor))
+
+
+def _request_header(frame: List[bytes], name: bytes) -> Optional[bytes]:
+    prefix = b"> " + name.lower() + b":"
+    for line in frame:
+        stripped = line.rstrip(b"\r\n")
+        if stripped.lower().startswith(prefix):
+            return stripped.split(b":", 1)[1].strip()
+    return None
+
+
+def _go_duration_seconds(value: bytes) -> Optional[float]:
+    offset = 0
+    total = 0.0
+    for match in GO_DURATION_COMPONENT.finditer(value):
+        if match.start() != offset:
+            return None
+        factor = DURATION_SECONDS_FACTORS.get(match.group(2))
+        if factor is None:
+            return None
+        total += float(match.group(1)) * factor
+        offset = match.end()
+    return total if offset == len(value) and offset > 0 else None
+
+
+def _request_time(frame: List[bytes]) -> Optional[datetime]:
+    if not frame:
+        return None
+    match = REQUEST_START.match(frame[0].rstrip(b"\r\n"))
+    if match is None:
+        return None
+    value = match.group(1).decode("ascii", errors="ignore")
+    time_format = (
+        "%Y-%m-%d %H:%M:%S.%f %z" if "." in value else "%Y-%m-%d %H:%M:%S %z"
+    )
+    try:
+        return datetime.strptime(value, time_format)
+    except ValueError:
+        return None
+
+
+def _cache_request(frame: List[bytes]) -> Optional[CacheRequest]:
+    if _request_header(frame, b"host") != CACHE_HOST:
+        return None
+    ttl_value = _request_header(frame, b"x-gh-cache-ttl")
+    ttl_seconds = _go_duration_seconds(ttl_value) if ttl_value is not None else None
+    request_time = _request_time(frame)
+    if ttl_seconds is None or ttl_seconds <= 0 or request_time is None:
+        return None
+    return request_time, ttl_seconds
+
+
+def _consume_proven_cache_hit(
+    response: Dict[str, str], cache_requests: List[CacheRequest]
+) -> bool:
+    # go-gh's HTTP logger wraps its local cache RoundTripper, so cache hits emit
+    # normal request/response blocks. Exclude one only when four independent
+    # properties agree: github.com host, positive cache TTL, a persisted response
+    # Date that is still inside that TTL, and a retained rate-window reset that
+    # expired before this request. The expired reset is response-owned proof of
+    # stale metadata and stays reliable when local cache work takes milliseconds
+    # under load. Request and completion streams are matched by evidence count
+    # because concurrent gh queries may interleave their starts before either
+    # response is logged.
+    try:
+        reset_epoch = int(response.get("reset", ""))
+    except ValueError:
+        return False
+    try:
+        response_time = parsedate_to_datetime(response.get("date", ""))
+        if response_time.tzinfo is None or response_time.utcoffset() is None:
+            return False
+    except (TypeError, ValueError):
+        return False
+    for index, (request_time, ttl_seconds) in enumerate(cache_requests):
+        age_seconds = (request_time - response_time).total_seconds()
+        reset_expired = (
+            reset_epoch + CACHE_RESET_GRACE_SECONDS < request_time.timestamp()
+        )
+        if (
+            CACHE_MIN_AGE_SECONDS < age_seconds <= ttl_seconds + CACHE_TTL_GRACE_SECONDS
+            and reset_expired
+        ):
+            del cache_requests[index]
+            return True
+    return False
 
 
 def _write_sanitized_stderr(
@@ -69,19 +198,35 @@ def main() -> int:
     except OSError:
         return 1
     lines = data.splitlines(keepends=True)
-    ranges = _frame_ranges(lines)
-    _write_sanitized_stderr(lines, ranges)
-    if data and not ranges:
+    request_ranges = _request_ranges(lines)
+    _write_sanitized_stderr(lines, request_ranges)
+    if data and not request_ranges:
         # Non-empty stderr without a recognized request frame may be a changed
         # GH_DEBUG format containing private request or response data. Keep it
         # suppressed and mark capture invalid rather than claiming no request.
         print("v1\tinvalid")
         return 0
-    print(f"v1\t{len(ranges)}")
-    for frame_index, (start, end) in enumerate(ranges, start=1):
+    cache_requests = []
+    for start, end in request_ranges:
+        request = _cache_request(lines[start:end])
+        if request is not None:
+            cache_requests.append(request)
+    transport_frames = []
+    completion_ranges = _completion_ranges(lines)
+    for start, end in completion_ranges:
         frame = lines[start:end]
         status_count, response, response_cost = response_metadata(frame)
         duration = _duration_ms(frame)
+        if status_count == 1 and duration is not None and _consume_proven_cache_hit(
+            response, cache_requests
+        ):
+            continue
+        transport_frames.append((status_count, response, response_cost, duration))
+    for _ in range(max(0, len(request_ranges) - len(completion_ranges))):
+        transport_frames.append((0, {}, None, None))
+    print(f"v1\t{len(transport_frames)}")
+    for frame_index, record in enumerate(transport_frames, start=1):
+        status_count, response, response_cost, duration = record
         values = [
             "frame",
             str(frame_index),

--- a/.agents/scripts/gh_quota_debug_response.py
+++ b/.agents/scripts/gh_quota_debug_response.py
@@ -11,17 +11,25 @@ from typing import Dict, List, Optional, Tuple
 
 
 REQUEST_END = re.compile(
-    rb"^\* Request took ([0-9]+(?:\.[0-9]+)?)(ms|s)\s*$"
+    rb"^\* Request took ([0-9]+(?:\.[0-9]+)?)(ns|(?:\xc2\xb5|\xce\xbc|u)s|ms|s)\s*$"
 )
 RESPONSE_STATUS = re.compile(
     rb"^< HTTP/\S+\s+([0-9]{3})(?:\s+.*)?$", re.IGNORECASE
 )
+DATE_HEADER = re.compile(rb"^< Date:\s*(.+?)\s*$", re.IGNORECASE)
 RATE_HEADER = re.compile(
     rb"^< X-Ratelimit-(Resource|Used|Remaining|Reset):\s*([^\s]+)\s*$",
     re.IGNORECASE,
 )
 RATE_FIELDS = frozenset({"resource", "used", "remaining", "reset"})
 Response = Tuple[Dict[str, str], List[bytes]]
+
+
+def _decode_ascii(value: bytes) -> Optional[str]:
+    try:
+        return value.decode("ascii")
+    except UnicodeDecodeError:
+        return None
 
 
 def _response_start(line: bytes) -> Optional[Response]:
@@ -31,12 +39,21 @@ def _response_start(line: bytes) -> Optional[Response]:
     return {"status": match.group(1).decode("ascii")}, []
 
 
-def _capture_rate_header(headers: Dict[str, str], line: bytes) -> None:
+def _capture_response_header(headers: Dict[str, str], line: bytes) -> None:
+    date_match = DATE_HEADER.match(line)
+    if date_match is not None:
+        date_value = _decode_ascii(date_match.group(1))
+        if date_value is not None:
+            headers["date"] = date_value
+        return
     match = RATE_HEADER.match(line)
     if match is None:
         return
-    name = match.group(1).decode("ascii").lower()
-    headers[name] = match.group(2).decode("ascii", errors="ignore")
+    name = _decode_ascii(match.group(1))
+    value = _decode_ascii(match.group(2))
+    if name is None or value is None:
+        return
+    headers[name.lower()] = value
 
 
 def _graphql_rate_cost(body: List[bytes]) -> Optional[int]:
@@ -72,7 +89,7 @@ def response_metadata(
         headers, body = responses[-1]
         if in_headers:
             in_headers = stripped != b""
-            _capture_rate_header(headers, stripped)
+            _capture_response_header(headers, stripped)
         elif not REQUEST_END.match(stripped):
             body.append(stripped)
     rate_responses = [

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -143,9 +143,12 @@ if [[ "${GH_DEBUG:-}" == "api" && "${STUB_GH_DEBUG_RESPONSE:-0}" == "1" ]]; then
 			_stub_remaining=$((${STUB_GH_DEBUG_MULTI_REMAINING_BASE:-4900} - _stub_frame + 1))
 		fi
 		printf '* Request at 2026-07-24 00:00:00 +0000 UTC\n' >&2
+		[[ -z "${STUB_GH_DEBUG_HOST:-}" ]] || printf '> Host: %s\n' "$STUB_GH_DEBUG_HOST" >&2
+		[[ -z "${STUB_GH_DEBUG_CACHE_TTL:-}" ]] || printf '> X-Gh-Cache-Ttl: %s\n' "$STUB_GH_DEBUG_CACHE_TTL" >&2
 		printf '> Authorization: token private-fixture-token\n\n' >&2
 		if [[ "${STUB_GH_DEBUG_REQUEST_ONLY:-0}" != "1" ]]; then
 			printf '< HTTP/2.0 %s Fixture\n' "${STUB_GH_DEBUG_STATUS:-200}" >&2
+			[[ -z "${STUB_GH_DEBUG_DATE:-}" ]] || printf '< Date: %s\n' "$STUB_GH_DEBUG_DATE" >&2
 			printf '< X-Ratelimit-Resource: %s\n' "${STUB_GH_DEBUG_RESOURCE:-graphql}" >&2
 			printf '< X-Ratelimit-Used: %s\n' "$_stub_used" >&2
 			printf '< X-Ratelimit-Remaining: %s\n' "$_stub_remaining" >&2
@@ -160,7 +163,7 @@ if [[ "${GH_DEBUG:-}" == "api" && "${STUB_GH_DEBUG_RESPONSE:-0}" == "1" ]]; then
 				printf '{"private":"redirected-response-fixture"}\n' >&2
 			fi
 		fi
-		printf '* Request took 12.5ms\n' >&2
+		printf '* Request took %s\n' "${STUB_GH_DEBUG_DURATION:-12.5ms}" >&2
 		_stub_frame=$((_stub_frame + 1))
 	done
 	[[ -z "${STUB_GH_DIAGNOSTIC:-}" ]] || printf '%s\n' "$STUB_GH_DIAGNOSTIC" >&2
@@ -1482,6 +1485,125 @@ if [[ "$(grep -c $'\tgh-quota-bootstrap\t.*\tattempt\t' "$zero_frame_log" || tru
 	_pass "valid zero-response capture adds no synthetic transport attempt"
 else
 	_fail "zero-response exact capture" "log: $(cat "$zero_frame_log" 2>/dev/null || true)"
+fi
+
+cache_hit_log="$TMP/exact-native-cache-hit.log"
+cache_hit_state="$TMP/exact-native-cache-hit-state"
+: >"$cache_hit_log"
+GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$cache_hit_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$cache_hit_log" STUB_GH_DEBUG_RESPONSE=1 \
+	STUB_BOOTSTRAP_GRAPHQL_USED=200 STUB_GH_DEBUG_RESOURCE=graphql \
+	STUB_GH_DEBUG_USED=200 STUB_GH_DEBUG_REMAINING=4800 STUB_GH_DEBUG_RESET=2000 \
+	STUB_GH_DEBUG_HOST=api.github.com STUB_GH_DEBUG_CACHE_TTL=24h0m0s \
+	STUB_GH_DEBUG_DATE='Thu, 23 Jul 2026 23:00:00 GMT' \
+	STUB_GH_DEBUG_DURATION=2ms "$SHIM_RUN" pr checks 123 --repo owner/repo >/dev/null 2>/dev/null
+if [[ "$(grep -c $'\tgh-quota-bootstrap\t.*\tattempt\t' "$cache_hit_log" || true)" == "1" \
+	&& "$(grep -c $'\tgh_pr_checks\t.*\tattempt\t' "$cache_hit_log" || true)" == "0" ]]; then
+	_pass "proven GitHub CLI cache hits add no synthetic transport attempt"
+else
+	_fail "native cache-hit attribution" "log: $(cat "$cache_hit_log" 2>/dev/null || true)"
+fi
+
+cache_miss_log="$TMP/exact-native-cache-miss.log"
+cache_miss_state="$TMP/exact-native-cache-miss-state"
+: >"$cache_miss_log"
+GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$cache_miss_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$cache_miss_log" STUB_GH_DEBUG_RESPONSE=1 \
+	STUB_BOOTSTRAP_GRAPHQL_USED=200 STUB_BOOTSTRAP_GRAPHQL_RESET=2000000000 \
+	STUB_GH_DEBUG_RESOURCE=graphql STUB_GH_DEBUG_USED=201 STUB_GH_DEBUG_REMAINING=4799 \
+	STUB_GH_DEBUG_RESET=2000000000 \
+	STUB_GH_DEBUG_HOST=api.github.com STUB_GH_DEBUG_CACHE_TTL=24h0m0s \
+	STUB_GH_DEBUG_DATE='Thu, 23 Jul 2026 23:00:00 GMT' \
+	STUB_GH_DEBUG_DURATION='500µs' "$SHIM_RUN" pr checks 123 --repo owner/repo >/dev/null 2>/dev/null
+if [[ "$(grep -c $'\tgh_pr_checks\t.*\tattempt\t' "$cache_miss_log" || true)" == "1" \
+	&& "$(_read_attempt_quota "$cache_miss_log")" == "1" ]]; then
+	_pass "cache-enabled network responses remain transport attempts"
+else
+	_fail "cache-miss fail-closed attribution" "log: $(cat "$cache_miss_log" 2>/dev/null || true)"
+fi
+
+malformed_date_log="$TMP/exact-native-cache-malformed-date.log"
+malformed_date_state="$TMP/exact-native-cache-malformed-date-state"
+: >"$malformed_date_log"
+GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$malformed_date_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$malformed_date_log" STUB_GH_DEBUG_RESPONSE=1 \
+	STUB_BOOTSTRAP_GRAPHQL_USED=200 STUB_GH_DEBUG_RESOURCE=graphql \
+	STUB_GH_DEBUG_USED=201 STUB_GH_DEBUG_REMAINING=4799 STUB_GH_DEBUG_RESET=2000 \
+	STUB_GH_DEBUG_HOST=api.github.com STUB_GH_DEBUG_CACHE_TTL=24h0m0s \
+	STUB_GH_DEBUG_DATE=$'Thu, 23 Jul 2026 23:00:00 GMT\377' \
+	STUB_GH_DEBUG_DURATION='500µs' "$SHIM_RUN" pr checks 123 --repo owner/repo >/dev/null 2>/dev/null
+if [[ "$(grep -c $'\tgh_pr_checks\t.*\tattempt\t' "$malformed_date_log" || true)" == "1" \
+	&& "$(_read_attempt_quota "$malformed_date_log")" == "1" ]]; then
+	_pass "malformed cache response dates cannot prove synthetic zero-attempt hits"
+else
+	_fail "malformed cache-date attribution" "log: $(cat "$malformed_date_log" 2>/dev/null || true)"
+fi
+
+naive_date_log="$TMP/exact-native-cache-naive-date.log"
+naive_date_state="$TMP/exact-native-cache-naive-date-state"
+naive_date_err="$TMP/exact-native-cache-naive-date.err"
+: >"$naive_date_log"
+: >"$naive_date_err"
+GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$naive_date_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$naive_date_log" STUB_GH_DEBUG_RESPONSE=1 \
+	STUB_BOOTSTRAP_GRAPHQL_USED=200 STUB_GH_DEBUG_RESOURCE=graphql \
+	STUB_GH_DEBUG_USED=201 STUB_GH_DEBUG_REMAINING=4799 STUB_GH_DEBUG_RESET=2000 \
+	STUB_GH_DEBUG_HOST=api.github.com STUB_GH_DEBUG_CACHE_TTL=24h0m0s \
+	STUB_GH_DEBUG_DATE='Thu, 23 Jul 2026 23:00:00' \
+	STUB_GH_DEBUG_DURATION='500µs' "$SHIM_RUN" pr checks 123 --repo owner/repo \
+	>/dev/null 2>"$naive_date_err"
+if [[ "$(grep -c $'\tgh_pr_checks\t.*\tattempt\t' "$naive_date_log" || true)" == "1" \
+	&& "$(_read_attempt_quota "$naive_date_log")" == "1" \
+	&& ! -s "$naive_date_err" ]]; then
+	_pass "timezone-free cache response dates fail closed without parser diagnostics"
+else
+	_fail "timezone-free cache-date attribution" \
+		"log: $(cat "$naive_date_log" 2>/dev/null || true) stderr: $(cat "$naive_date_err" 2>/dev/null || true)"
+fi
+
+interleaved_debug="$TMP/exact-interleaved-cache.debug"
+interleaved_err="$TMP/exact-interleaved-cache.err"
+cat >"$interleaved_debug" <<'EOF'
+* Request at 2026-07-24 00:00:00 +0000 UTC
+> Host: api.github.com
+> X-Gh-Cache-Ttl: 24h0m0s
+> Authorization: token private-fixture-token
+
+* Request at 2026-07-24 00:00:00 +0000 UTC
+> Host: api.github.com
+> Authorization: token private-fixture-token
+
+< HTTP/2.0 200 Fixture
+< Date: Thu, 23 Jul 2026 23:00:00 GMT
+< X-Ratelimit-Resource: graphql
+< X-Ratelimit-Used: 200
+< X-Ratelimit-Remaining: 4800
+< X-Ratelimit-Reset: 2000
+
+{"private":"cached-response-fixture"}
+* Request took 500µs
+< HTTP/2.0 200 Fixture
+< Date: Fri, 24 Jul 2026 00:00:00 GMT
+< X-Ratelimit-Resource: graphql
+< X-Ratelimit-Used: 201
+< X-Ratelimit-Remaining: 4799
+< X-Ratelimit-Reset: 2000000000
+
+{"private":"network-response-fixture"}
+* Request took 12.5ms
+EOF
+interleaved_parsed=$(python3 "$TMP/scripts/gh-quota-debug-filter.py" \
+	"$interleaved_debug" 2>"$interleaved_err")
+if [[ "$(printf '%s\n' "$interleaved_parsed" | grep -c $'^v1\t1$')" == "1" \
+	&& "$(printf '%s\n' "$interleaved_parsed" | grep -c $'^frame\t1\t1\t200\tgraphql\t201\t')" == "1" \
+	&& ! -s "$interleaved_err" ]]; then
+	_pass "interleaved cache completions do not hide the concurrent network response"
+else
+	_fail "interleaved cache attribution" "parsed: $interleaved_parsed"
 fi
 
 local_log="$TMP/exact-local-command.log"


### PR DESCRIPTION
## Summary

Recognize native gh cache frames across microsecond and millisecond completion times, separate interleaved request/completion streams, and exclude only cache hits proven by GitHub host, positive TTL, stale response Date, and an expired retained rate-window reset.

## Files Changed

.agents/scripts/gh-quota-debug-filter.py, .agents/scripts/gh_quota_debug_response.py, .agents/scripts/tests/test-gh-shim.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 112 gh-shim tests; ShellCheck; Python AST parsing; changed and full linters-local gates; focused Pulse canary 5/5; live exact probes reduced representative unknown attempts from 15/30 to 7/27.

Resolves #27777


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.203 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.5 spent 14d 20h and 51,710,136 tokens on this with the user in an interactive session.