### PR TITLE
GH#29074: make aidevops init fail closed

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-init-lib.sh
@@ -149,6 +149,73 @@ _init_configure_repo_verify() {
 	return 0
 }
 
+_init_finalize_repo_verify() {
+	local project_root="$1"
+	local config_file="${project_root}/.aidevops.json"
+	[[ -f "$config_file" ]] || return 0
+	[[ "$(jq -r '.features.code_quality == true and .verify.enabled != false' "$config_file" 2>/dev/null)" == "true" ]] || return 0
+	if ! _init_load_repo_verify_lib; then
+		print_error "Repo verify configuration helper unavailable during final hook verification"
+		return 1
+	fi
+
+	local hook_status=""
+	hook_status=$(repo_verify_hook_status "$project_root") || hook_status="unavailable"
+	if [[ "$hook_status" != "installed" ]] || ! _init_repo_verify_hook_integrity "$project_root"; then
+		repo_verify_install_hook "$project_root" >/dev/null 2>&1 || {
+			print_error "Required repo-verify pre-push hook was replaced during initialization"
+			return 1
+		}
+		hook_status=$(repo_verify_hook_status "$project_root") || hook_status="unavailable"
+	fi
+	if [[ "$hook_status" != "installed" ]] || ! _init_repo_verify_hook_integrity "$project_root"; then
+		print_error "Required repo-verify pre-push hook failed its final integrity check (status: ${hook_status})"
+		return 1
+	fi
+	print_success "Verified final repo-verify pre-push hook integrity"
+	return 0
+}
+
+_init_repo_verify_hook_integrity() {
+	local project_root="$1"
+	local common_dir="" hook_file=""
+	common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null) || return 1
+	[[ "$common_dir" == /* ]] || common_dir="${project_root}/${common_dir}"
+	hook_file="${common_dir}/hooks/pre-push"
+	[[ -x "$hook_file" ]] || return 1
+	bash -n "$hook_file" >/dev/null 2>&1 || return 1
+	# shellcheck disable=SC2016 # Match literal dispatcher expressions.
+	grep -Fq '_stdin_data=$(cat)' "$hook_file" || return 1
+	grep -Fq '_repo_verify_hook=""' "$hook_file" || return 1
+	# shellcheck disable=SC2016 # Match literal dispatcher expressions.
+	grep -Fq '"$_repo_verify_hook" "$@" || _exit_code=$?' "$hook_file" || return 1
+	# shellcheck disable=SC2016 # Match literal dispatcher expressions.
+	grep -Fq 'exit "$_exit_code"' "$hook_file" || return 1
+	return 0
+}
+
+_init_run_beads_init() {
+	local project_root="$1"
+	if bd init --help 2>&1 | grep -q -- '--skip-hooks'; then
+		(cd "$project_root" && bd init --skip-hooks 2>/dev/null)
+		return $?
+	fi
+
+	local common_dir="" hook_file="" hook_backup="" beads_status=0
+	common_dir=$(git -C "$project_root" rev-parse --git-common-dir 2>/dev/null) || return 1
+	[[ "$common_dir" == /* ]] || common_dir="${project_root}/${common_dir}"
+	hook_file="${common_dir}/hooks/pre-push"
+	if [[ -f "$hook_file" ]]; then
+		hook_backup=$(mktemp "${hook_file}.aidevops-init.XXXXXX") || return 1
+		cp -p "$hook_file" "$hook_backup" || return 1
+	fi
+	(cd "$project_root" && bd init 2>/dev/null) || beads_status=$?
+	if [[ -n "$hook_backup" ]]; then
+		mv "$hook_backup" "$hook_file" || return 1
+	fi
+	return "$beads_status"
+}
+
 _agent_source_template_dir() {
 	printf '%s\n' "${AGENTS_DIR}/templates/agent-source-repo"
 	return 0
@@ -962,6 +1029,7 @@ _init_run_workflow() {
 	local enable_time_tracking=false enable_database=false enable_beads=false
 	local enable_sops=false enable_security=false enable_deployment_context=false
 	local enable_wordpress_context=false
+	local init_security_posture="not-requested"
 	local _f
 	for _f in $parsed; do
 		case "$_f" in
@@ -1306,7 +1374,7 @@ EOF
 			# Initialize Beads in the project
 			if [[ ! -d "$project_root/.beads" ]]; then
 				print_info "Initializing Beads database..."
-				if (cd "$project_root" && bd init 2>/dev/null); then
+				if _init_run_beads_init "$project_root"; then
 					print_success "Beads initialized"
 				else
 					print_warning "Beads init failed - run manually: bd init"
@@ -1629,24 +1697,36 @@ _init_scaffold_cloudron_release_workflow() {
 	return 0
 }
 
-_init_security_and_registration() {
-
-	# Run security posture assessment if enabled (t1412.11)
+_init_assess_security_posture() {
 	if [[ "$enable_security" == "true" && "${config_migration_deferred:-false}" != "true" ]]; then
 		local security_posture_script="$AGENTS_DIR/scripts/security-posture-helper.sh"
 		if [[ -f "$security_posture_script" ]]; then
 			print_info "Running security posture assessment..."
-			if bash "$security_posture_script" store "$project_root"; then
+			local security_status=0
+			bash "$security_posture_script" store "$project_root" || security_status=$?
+			init_security_posture=$(jq -r '.security_posture.status // "warning"' "$project_root/.aidevops.json" 2>/dev/null || printf 'warning')
+			if [[ "$security_status" -eq 0 && "$init_security_posture" == "good" ]]; then
 				print_success "Security posture assessed and stored in .aidevops.json"
-			else
+			elif [[ "$security_status" -le 1 ]]; then
 				print_warning "Security posture assessment found issues (review with: aidevops security audit)"
+			else
+				print_error "Security posture assessment failed before completion"
+				return 1
 			fi
 		else
+			init_security_posture="skipped"
 			print_info "Security posture check skipped (security-posture-helper.sh not available)"
 		fi
 	elif [[ "$enable_security" == "true" ]]; then
+		init_security_posture="deferred"
 		print_info "Security posture storage deferred until .aidevops.json migration is committed"
 	fi
+	return 0
+}
+
+_init_security_and_registration() {
+	_init_finalize_repo_verify "$project_root" || return 1
+	_init_assess_security_posture || return 1
 
 	# Build features string for registration
 	local features_list=""
@@ -1735,7 +1815,17 @@ _init_commit_files() {
 _init_print_summary() {
 
 	echo ""
-	print_success "AI DevOps initialized! (scope: $init_scope)"
+	case "$init_security_posture" in
+	critical)
+		print_warning "AI DevOps local scaffolding initialized (scope: $init_scope); security and remote hardening remain CRITICAL"
+		;;
+	warning | partial | deferred | skipped | unknown)
+		print_warning "AI DevOps local scaffolding initialized (scope: $init_scope); security or remote hardening remains incomplete"
+		;;
+	*)
+		print_success "AI DevOps initialized! (scope: $init_scope)"
+		;;
+	esac
 	echo ""
 	echo "Enabled features:"
 	[[ "$enable_planning" == "true" ]] && echo "  ✓ Planning (TODO.md, PLANS.md)"

--- a/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
@@ -805,6 +805,80 @@ detect_unregistered_repo() {
 	return 0
 }
 
+# Refresh the configured upstream for a protected branch and record its state.
+# A branch without a configured remote upstream remains valid for local-only use.
+_protected_branch_refresh_upstream() {
+	local current_branch="$1"
+	_PROTECTED_BRANCH_UPSTREAM=""
+	_PROTECTED_BRANCH_AHEAD=0
+	_PROTECTED_BRANCH_BEHIND=0
+
+	local remote="" merge_ref="" remote_branch="" remote_tracking_ref=""
+	remote=$(git config --get "branch.${current_branch}.remote" 2>/dev/null || true)
+	merge_ref=$(git config --get "branch.${current_branch}.merge" 2>/dev/null || true)
+	[[ -n "$remote" && "$remote" != "." && "$merge_ref" == refs/heads/* ]] || return 0
+
+	remote_branch="${merge_ref#refs/heads/}"
+	remote_tracking_ref="refs/remotes/${remote}/${remote_branch}"
+	if ! git fetch --quiet "$remote" "+${merge_ref}:${remote_tracking_ref}"; then
+		print_error "Could not refresh ${remote}/${remote_branch}; refusing protected-branch initialization"
+		return 1
+	fi
+
+	_PROTECTED_BRANCH_UPSTREAM="${remote}/${remote_branch}"
+	local counts=""
+	counts=$(git rev-list --left-right --count "HEAD...${_PROTECTED_BRANCH_UPSTREAM}" 2>/dev/null) || {
+		print_error "Could not compare ${current_branch} with ${_PROTECTED_BRANCH_UPSTREAM}"
+		return 1
+	}
+	read -r _PROTECTED_BRANCH_AHEAD _PROTECTED_BRANCH_BEHIND <<<"$counts"
+	return 0
+}
+
+_protected_branch_worktree_path() {
+	local branch_name="$1"
+	git worktree list --porcelain | awk -v branch_ref="refs/heads/${branch_name}" '
+		/^worktree / { path = substr($0, 10) }
+		$0 == "branch " branch_ref { print path; exit }
+	'
+	return 0
+}
+
+_protected_branch_create_worktree() {
+	local suggested_branch="$1"
+	local upstream="$2"
+	local fallback_dir="$3"
+	local worktree_dir="$fallback_dir"
+
+	if [[ -f "$AGENTS_DIR/scripts/worktree-helper.sh" ]]; then
+		local -a worktree_args=(add "$suggested_branch")
+		[[ -n "$upstream" ]] && worktree_args+=(--base "$upstream")
+		bash "$AGENTS_DIR/scripts/worktree-helper.sh" "${worktree_args[@]}" || {
+			print_error "Failed to create worktree via worktree-helper.sh"
+			return 1
+		}
+		worktree_dir=$(_protected_branch_worktree_path "$suggested_branch")
+		if [[ -z "$worktree_dir" || ! -d "$worktree_dir" ]]; then
+			print_error "Could not resolve the worktree created for $suggested_branch"
+			return 1
+		fi
+	else
+		local worktree_base="${upstream:-HEAD}"
+		git worktree add -b "$suggested_branch" "$worktree_dir" "$worktree_base" || {
+			print_error "Failed to create worktree"
+			return 1
+		}
+	fi
+
+	export WORKTREE_PATH="$worktree_dir"
+	echo ""
+	print_success "Worktree created at: $worktree_dir"
+	print_info "Switching to: $worktree_dir"
+	echo ""
+	cd "$worktree_dir" || return 1
+	return 0
+}
+
 # Check if on protected branch and offer worktree creation
 # Returns 0 if safe to proceed, 1 if user cancelled
 # Sets WORKTREE_PATH if worktree was created
@@ -830,18 +904,28 @@ check_protected_branch() {
 	local repo_name
 	repo_name=$(basename "$project_root")
 	local suggested_branch="$branch_type/$branch_suffix"
+	local _PROTECTED_BRANCH_UPSTREAM=""
+	local _PROTECTED_BRANCH_AHEAD=0
+	local _PROTECTED_BRANCH_BEHIND=0
+	_protected_branch_refresh_upstream "$current_branch" || return 1
 
 	local choice
 	# In non-interactive (non-TTY) contexts, auto-select option 1 (create worktree)
 	# without prompting. This prevents read from blocking or getting EOF in CI/AI
 	# assistant environments, which could cause silent script termination with set -e.
-	if [[ -t 0 ]]; then
+	if [[ -n "${AIDEVOPS_PROTECTED_BRANCH_CHOICE:-}" ]]; then
+		choice="$AIDEVOPS_PROTECTED_BRANCH_CHOICE"
+	elif [[ -t 0 ]]; then
 		echo ""
 		print_warning "On protected branch '$current_branch'"
 		echo ""
 		echo "Options:"
 		echo "  1. Create worktree: $suggested_branch (recommended)"
-		echo "  2. Continue on $current_branch (commits directly to main)"
+		if [[ "$_PROTECTED_BRANCH_BEHIND" -gt 0 ]]; then
+			echo "  2. Continue on $current_branch (unavailable: behind ${_PROTECTED_BRANCH_UPSTREAM} by ${_PROTECTED_BRANCH_BEHIND})"
+		else
+			echo "  2. Continue on $current_branch (commits directly to main)"
+		fi
 		echo "  3. Cancel"
 		echo ""
 		read -r -p "Choice [1]: " choice
@@ -854,42 +938,22 @@ check_protected_branch() {
 
 	case "$choice" in
 	1)
-		# Create worktree
 		local worktree_dir
 		worktree_dir="$(dirname "$project_root")/${repo_name}-${branch_type}-${branch_suffix}"
-
 		print_info "Creating worktree at $worktree_dir..."
-
-		local worktree_created=false
-		if [[ -f "$AGENTS_DIR/scripts/worktree-helper.sh" ]]; then
-			if bash "$AGENTS_DIR/scripts/worktree-helper.sh" add "$suggested_branch"; then
-				worktree_created=true
-			else
-				print_error "Failed to create worktree via worktree-helper.sh"
-				return 1
-			fi
-		else
-			# Fallback without helper script
-			if git worktree add -b "$suggested_branch" "$worktree_dir"; then
-				worktree_created=true
-			else
-				print_error "Failed to create worktree"
-				return 1
-			fi
-		fi
-
-		if [[ "$worktree_created" == "true" ]]; then
-			export WORKTREE_PATH="$worktree_dir"
-			echo ""
-			print_success "Worktree created at: $worktree_dir"
-			print_info "Switching to: $worktree_dir"
-			echo ""
-			# Change to worktree directory for the remainder of this process
-			cd "$worktree_dir" || return 1
-			return 0
-		fi
+		_protected_branch_create_worktree "$suggested_branch" "$_PROTECTED_BRANCH_UPSTREAM" "$worktree_dir" || return 1
+		return 0
 		;;
 	2)
+		if [[ "$_PROTECTED_BRANCH_BEHIND" -gt 0 ]]; then
+			if [[ "$_PROTECTED_BRANCH_AHEAD" -gt 0 ]]; then
+				print_error "Cannot initialize directly on diverged $current_branch (${_PROTECTED_BRANCH_AHEAD} ahead, ${_PROTECTED_BRANCH_BEHIND} behind ${_PROTECTED_BRANCH_UPSTREAM})"
+			else
+				print_error "Cannot initialize directly on stale $current_branch (${_PROTECTED_BRANCH_BEHIND} behind ${_PROTECTED_BRANCH_UPSTREAM})"
+			fi
+			print_info "Choose the recommended worktree option; it starts from the refreshed remote tip"
+			return 1
+		fi
 		print_warning "Continuing on $current_branch - changes will commit directly"
 		return 0
 		;;

--- a/.agents/scripts/tests/test-init-protected-branch-freshness.sh
+++ b/.agents/scripts/tests/test-init-protected-branch-freshness.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+INSTALL_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+AGENTS_DIR="${INSTALL_DIR}/.agents"
+CONFIG_DIR="${HOME}/.config/aidevops"
+REPOS_FILE="${CONFIG_DIR}/repos.json"
+
+print_info() {
+	printf 'INFO %s\n' "$*"
+	return 0
+}
+print_success() {
+	printf 'SUCCESS %s\n' "$*"
+	return 0
+}
+print_warning() {
+	printf 'WARNING %s\n' "$*"
+	return 0
+}
+print_error() {
+	printf 'ERROR %s\n' "$*"
+	return 0
+}
+
+# shellcheck source=../aidevops-cli/aidevops-repos-lib.sh
+source "${INSTALL_DIR}/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh"
+
+TEST_ROOT=""
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_equal() {
+	local expected="$1"
+	local actual="$2"
+	local name="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$expected" == "$actual" ]]; then
+		printf 'PASS %s\n' "$name"
+		return 0
+	fi
+	printf 'FAIL %s (expected=%s actual=%s)\n' "$name" "$expected" "$actual" >&2
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+commit_file() {
+	local repo="$1"
+	local content="$2"
+	printf '%s\n' "$content" >"${repo}/state.txt"
+	git -C "$repo" add state.txt
+	git -C "$repo" commit -q -m "test: ${content}"
+	return 0
+}
+
+run_freshness_checks() {
+	local remote="$1"
+	local seed="$2"
+	local victim="$3"
+	local fresh="$4"
+	commit_file "$seed" "remote-ahead"
+	git -C "$seed" push -q
+	local remote_tip=""
+	remote_tip=$(git -C "$seed" rev-parse HEAD)
+
+	local stale_status=0 stale_output=""
+	stale_output=$(cd "$victim" && AIDEVOPS_PROTECTED_BRANCH_CHOICE=2 check_protected_branch chore aidevops-init) || stale_status=$?
+	assert_equal "1" "$stale_status" "direct protected-branch init rejects a behind branch"
+	assert_equal "true" "$([[ "$stale_output" == *"Cannot initialize directly on stale main"* ]] && printf true || printf false)" "stale rejection explains the upstream mismatch"
+	assert_equal "1" "$(git -C "$victim" rev-list --count HEAD..origin/main)" "preflight fetch refreshes the remote-tracking ref"
+
+	commit_file "$victim" "local-divergence"
+	local diverged_status=0 diverged_output=""
+	diverged_output=$(cd "$victim" && AIDEVOPS_PROTECTED_BRANCH_CHOICE=2 check_protected_branch chore aidevops-init) || diverged_status=$?
+	assert_equal "1" "$diverged_status" "direct protected-branch init rejects a diverged branch"
+	assert_equal "true" "$([[ "$diverged_output" == *"diverged"* ]] && printf true || printf false)" "diverged rejection reports both local and remote history"
+
+	git clone -q "$remote" "$fresh"
+	local fresh_status=0
+	(cd "$fresh" && AIDEVOPS_PROTECTED_BRANCH_CHOICE=2 check_protected_branch chore aidevops-init >/dev/null) || fresh_status=$?
+	assert_equal "0" "$fresh_status" "direct protected-branch init remains available when synchronized"
+
+	local helper_agents="${TEST_ROOT}/helper-agents"
+	local helper_worktree="${TEST_ROOT}/centralized/helper-worktree"
+	mkdir -p "${helper_agents}/scripts" "$(dirname "$helper_worktree")"
+	cat >"${helper_agents}/scripts/worktree-helper.sh" <<'HELPEREOF'
+#!/usr/bin/env bash
+set -euo pipefail
+branch_name="$2"
+base_ref="HEAD"
+[[ "${3:-}" != "--base" ]] || base_ref="$4"
+git worktree add -b "$branch_name" "$HELPER_WORKTREE_PATH" "$base_ref"
+HELPEREOF
+	local helper_status=0
+	(cd "$victim" && AGENTS_DIR="$helper_agents" HELPER_WORKTREE_PATH="$helper_worktree" AIDEVOPS_PROTECTED_BRANCH_CHOICE=1 check_protected_branch chore helper-init >/dev/null) || helper_status=$?
+	assert_equal "0" "$helper_status" "helper-created worktree resolves its configured centralized path"
+	assert_equal "$remote_tip" "$(git -C "$helper_worktree" rev-parse HEAD)" "helper-created worktree starts at the refreshed remote tip"
+
+	local fallback_agents="${TEST_ROOT}/no-helper"
+	mkdir -p "$fallback_agents"
+	local worktree_status=0
+	(cd "$victim" && AGENTS_DIR="$fallback_agents" AIDEVOPS_PROTECTED_BRANCH_CHOICE=1 check_protected_branch chore fallback-init >/dev/null) || worktree_status=$?
+	assert_equal "0" "$worktree_status" "stale protected branch can select the safe worktree path"
+	assert_equal "$remote_tip" "$(git -C "${TEST_ROOT}/victim-chore-fallback-init" rev-parse HEAD)" "fallback worktree starts at the refreshed remote tip"
+	return 0
+}
+
+main() {
+	TEST_ROOT=$(mktemp -d)
+	trap 'rm -rf "$TEST_ROOT"' EXIT
+	local remote="${TEST_ROOT}/remote.git" seed="${TEST_ROOT}/seed"
+	local victim="${TEST_ROOT}/victim" fresh="${TEST_ROOT}/fresh"
+	git init -q --bare "$remote"
+	git init -q -b main "$seed"
+	git -C "$seed" config user.name "Test User"
+	git -C "$seed" config user.email "test@example.invalid"
+	commit_file "$seed" "base"
+	git -C "$seed" remote add origin "$remote"
+	git -C "$seed" push -q -u origin main
+	git --git-dir="$remote" symbolic-ref HEAD refs/heads/main
+	git clone -q "$remote" "$victim"
+	git -C "$victim" config user.name "Test User"
+	git -C "$victim" config user.email "test@example.invalid"
+	run_freshness_checks "$remote" "$seed" "$victim" "$fresh"
+
+	printf '\n%d tests run, %d failures\n' "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]]
+	return $?
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-init-repo-verify.sh
+++ b/.agents/scripts/tests/test-init-repo-verify.sh
@@ -32,6 +32,102 @@ assert_equal() {
 	return 0
 }
 
+test_beads_hook_integrity() {
+	local repo_root="$1"
+	local common_dir="$2"
+	local hook_file="${repo_root}/${common_dir}/hooks/pre-push"
+	local stub_bin="${TEST_TMP_DIR}/bin"
+	local beads_args="${TEST_TMP_DIR}/beads-args"
+	mkdir -p "$stub_bin"
+	cat >"${stub_bin}/bd" <<'BDEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "init" && "${2:-}" == "--help" ]]; then
+	[[ "${BEADS_LEGACY:-false}" == "true" ]] || printf '%s\n' '      --skip-hooks   Skip git hooks installation'
+	exit 0
+fi
+printf '%s\n' "$*" >"$BEADS_ARGS"
+if [[ "${BEADS_LEGACY:-false}" == "true" ]]; then
+	printf '%s\n' '#!/usr/bin/env bash' '# replaced by legacy Beads' 'exit 0' >"$BEADS_HOOK"
+	chmod +x "$BEADS_HOOK"
+fi
+mkdir -p .beads
+exit 0
+BDEOF
+	chmod +x "${stub_bin}/bd"
+	local original_path="$PATH" original_agents_dir="$AGENTS_DIR"
+	PATH="${stub_bin}:${PATH}"
+	AGENTS_DIR="${TEST_TMP_DIR}/empty-agents"
+	mkdir -p "$AGENTS_DIR"
+	export BEADS_ARGS="$beads_args" BEADS_HOOK="$hook_file"
+	local enable_database=false enable_beads=true enable_sops=false
+	local project_root="$repo_root"
+	_init_sops_support() { return 0; }
+	_init_database_and_beads
+	assert_equal "init --skip-hooks" "$(<"$beads_args")" "init prevents modern Beads from replacing the managed hook"
+	assert_equal "0" "$(
+		_init_finalize_repo_verify "$repo_root" >/dev/null 2>&1
+		printf '%s' "$?"
+	)" "final hook integrity passes after modern Beads setup"
+
+	rm -rf "${repo_root}/.beads"
+	BEADS_LEGACY=true _init_database_and_beads
+	assert_equal "init" "$(<"$beads_args")" "legacy Beads initializes without unsupported flags"
+	assert_equal "true" "$(_init_repo_verify_hook_integrity "$repo_root" && printf true || printf false)" "legacy Beads hook replacement is restored"
+
+	printf '%s\n' '#!/usr/bin/env bash' '# aidevops-pre-push-guards' '# guard:repo-verify' 'exit 0' >"$hook_file"
+	chmod +x "$hook_file"
+	_init_finalize_repo_verify "$repo_root"
+	assert_equal "true" "$(_init_repo_verify_hook_integrity "$repo_root" && printf true || printf false)" "final verification repairs a marker-only no-op hook"
+
+	printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"$hook_file"
+	chmod +x "$hook_file"
+	local final_status=0
+	_init_finalize_repo_verify "$repo_root" >/dev/null 2>&1 || final_status=$?
+	assert_equal "1" "$final_status" "init fails when an unmanaged final hook postcondition is lost"
+	AGENTS_DIR="$original_agents_dir"
+	PATH="$original_path"
+	return 0
+}
+
+test_security_completion_status() {
+	local repo_root="$1"
+	local security_agents="${TEST_TMP_DIR}/security-agents"
+	mkdir -p "${security_agents}/scripts"
+	cat >"${security_agents}/scripts/security-posture-helper.sh" <<'SECURITYEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+config_file="${2}/.aidevops.json"
+jq '.security_posture.status = "partial"' "$config_file" >"${config_file}.tmp"
+mv "${config_file}.tmp" "$config_file"
+exit 0
+SECURITYEOF
+	local original_agents_dir="$AGENTS_DIR"
+	AGENTS_DIR="$security_agents"
+	local project_root="$repo_root" enable_security=true config_migration_deferred=false init_security_posture=unknown
+	_init_assess_security_posture
+	assert_equal "partial" "$init_security_posture" "successful security helper preserves a stored partial posture"
+	AGENTS_DIR="$original_agents_dir"
+
+	print_warning() {
+		printf 'WARNING %s\n' "$*"
+		return 0
+	}
+	print_success() {
+		printf 'SUCCESS %s\n' "$*"
+		return 0
+	}
+	local init_scope=standard committed=true
+	local enable_planning=false enable_git_workflow=false enable_code_quality=false enable_time_tracking=false
+	local enable_database=false enable_beads=false enable_sops=false
+	local enable_deployment_context=false enable_wordpress_context=false WORKTREE_PATH=""
+	local summary_output=""
+	summary_output=$(_init_print_summary)
+	assert_equal "true" "$([[ "$summary_output" == *"hardening remains incomplete"* ]] && printf true || printf false)" "partial security posture qualifies the init completion message"
+	assert_equal "false" "$([[ "$summary_output" == *"SUCCESS AI DevOps initialized!"* ]] && printf true || printf false)" "partial security posture suppresses unconditional success"
+	return 0
+}
+
 main() {
 	TEST_TMP_DIR=$(mktemp -d)
 	trap 'rm -rf "$TEST_TMP_DIR"' EXIT
@@ -54,6 +150,8 @@ main() {
 	common_dir=$(/usr/bin/git -C "$repo_root" rev-parse --git-common-dir)
 	assert_equal "1" "$(grep -c '# guard:repo-verify' "${repo_root}/${common_dir}/hooks/pre-push" 2>/dev/null || printf 0)" "init immediately installs repo-verify hook"
 
+	test_beads_hook_integrity "$repo_root" "$common_dir"
+
 	local invalid_config="${TEST_TMP_DIR}/invalid.json"
 	printf '{invalid\n' >"$invalid_config"
 	local invalid_before invalid_after invalid_status=0
@@ -70,12 +168,15 @@ main() {
 	printf '%s\n' '{"scripts":{"lint":"eslint ."}}' >"$opted_out/package.json"
 	/usr/bin/git -C "$opted_out" add package.json
 	_init_configure_repo_verify "$opted_out"
+	_init_finalize_repo_verify "$opted_out"
 	common_dir=$(/usr/bin/git -C "$opted_out" rev-parse --git-common-dir)
 	if [[ -f "${opted_out}/${common_dir}/hooks/pre-push" ]]; then
 		assert_equal "0" "$(grep -c '# guard:repo-verify' "${opted_out}/${common_dir}/hooks/pre-push" 2>/dev/null || printf 0)" "init does not install hook for verify opt-out"
 	else
 		assert_equal "0" "0" "init does not install hook for verify opt-out"
 	fi
+
+	test_security_completion_status "$repo_root"
 
 	printf '\nRan %d tests, %d failed.\n' "$((passed + failed))" "$failed"
 	[[ "$failed" -eq 0 ]] || return 1


### PR DESCRIPTION
## Summary

Refresh protected-branch upstream state, preserve and verify repo hooks across Beads initialization, and report incomplete security posture honestly.

## Files Changed

.agents/scripts/aidevops-cli/aidevops-init-lib.sh, .agents/scripts/aidevops-cli/aidevops-repos-lib.sh, .agents/scripts/tests/test-init-protected-branch-freshness.sh, .agents/scripts/tests/test-init-repo-verify.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — runtime-verified: all six init test scripts passed, including stale/diverged branches, centralized and fallback worktrees, modern/legacy Beads hooks, marker-only hook repair, and partial security posture; linters-local.sh passed.

Resolves #29074


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.203 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h 25m and 674,543 tokens on this with the user in an interactive session.