### PR TITLE
GH#28782: Add bounded read-only Slack account knowledge ingestion

### DIFF
--- a/.agents/content/social-slack.md
+++ b/.agents/content/social-slack.md
@@ -1,0 +1,239 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Slack Workspace Knowledge Collection
+
+`knowledge_social_slack.py` collects bounded, allowlisted Slack Web API evidence
+or imports one administrator-approved Slack JSON export. Both routes use the
+same workspace-scoped account, conversation, message, reaction, file, and
+activity identities. A native Slack ID from another workspace therefore cannot
+collide, while an API record and export record for the same workspace resource
+converge on one canonical identity.
+
+Provider-neutral dispatcher registration is a separate integration phase. Until
+that registration is present, invoke the dedicated Python entry point directly.
+
+## Runtime, profile, and identity contract
+
+The live collector uses Python standard-library `urllib.request.Request`,
+`urllib.request.build_opener`, `urllib.request.HTTPRedirectHandler`, and
+`urllib.parse.urlencode`. No Slack SDK is imported. Redirects are rejected, the
+credential is sent only in the `Authorization` header, response bodies are
+capped at 8 MiB, each invocation is capped at 17 request units, and only the
+exact method-and-HTTP-verb pairs documented below are reachable.
+
+Configure one profile through secure environment injection:
+
+```text
+SLACK_<PROFILE>_ACCESS_TOKEN
+SLACK_<PROFILE>_WORKSPACE_ID
+SLACK_<PROFILE>_ENTERPRISE_ID
+SLACK_<PROFILE>_TOKEN_TYPE=bot|user
+SLACK_<PROFILE>_CONVERSATIONS={"engineering":{"id":"CWORKSPACE123","kind":"public_channel"}}
+```
+
+`ENTERPRISE_ID` is optional unless the selected workspace identity has one.
+`CONVERSATIONS` is a JSON object with at most 500 safe aliases. Every entry must
+contain exactly `id` and `kind`; duplicate native IDs are rejected. Supported
+kinds and required ID prefixes are `public_channel` (`C`), `private_channel`
+(`G`), `im` (`D`), and `mpim` (`G`). Changing a configured workspace,
+enterprise, account, token type, alias, conversation ID, or conversation kind
+fails closed. The collector persists a SHA-256 binding over the complete
+allowlist. Use a new connection ID when intentionally changing that identity or
+allowlist; an old stream cursor can never be silently reused for a new target.
+
+Use the stable account selector:
+
+```text
+slack_<WORKSPACE_ID>_user_<AUTH_TEST_USER_ID>
+```
+
+For example, a workspace `TWORKSPACE123` and selected account `UACCOUNT123`
+become `slack_TWORKSPACE123_user_UACCOUNT123`. The child calls `auth.test` before
+collection and before every page. It compares the returned workspace, optional
+enterprise, user, and bot/user token type with the non-secret profile binding.
+The access token never enters a request URL, provider output, evidence,
+checkpoint, receipt, or error.
+
+Every successful Slack response must include `X-OAuth-Scopes`. The complete
+attested set must contain only these reviewed read scopes:
+
+```text
+team:read
+users:read
+channels:read
+groups:read
+im:read
+mpim:read
+channels:history
+groups:history
+im:history
+mpim:history
+reactions:read
+files:read
+pins:read
+bookmarks:read
+```
+
+Grant only scopes needed by enabled streams. A missing scope attestation, an
+unknown scope, or any write scope rejects the response. Each stream also checks
+its exact required scope, and a changed attested scope set during collection
+fails before persistence.
+
+## Implemented Web API streams
+
+| Stream | Exact Slack method and HTTP verb | Coverage |
+|---|---|---|
+| `workspace` | `GET team.info` | Selected workspace metadata. |
+| `users` | `GET users.list` | Token-visible observed workspace-member snapshot; removals are not reconciled. |
+| `reactions` | `GET reactions.list` | Selected-account reaction results; messages require an allowlisted channel and files require explicit intersection with an allowlisted channel, group, or DM. Removed reactions are not reconciled. |
+| `conversation/<alias>/info` | `GET conversations.info` | Metadata for one exact allowlisted conversation. |
+| `conversation/<alias>/members` | `GET conversations.members` | Token-visible observed membership snapshot; removals are not reconciled. |
+| `conversation/<alias>/history` | `GET conversations.history` | Retained, token-visible messages with incremental refresh. |
+| `conversation/<alias>/thread/<timestamp>` | `GET conversations.replies` | One exact retained thread with incremental refresh. |
+| `conversation/<alias>/pins` | `GET pins.list` | Observed pins snapshot; removals are not reconciled. |
+| `conversation/<alias>/bookmarks` | `POST bookmarks.list` | Observed bookmarks snapshot; Slack defines this read method as POST and removals are not reconciled. |
+| `conversation/<alias>/files` | `GET files.list` | File metadata only; binaries and private URLs are omitted, tombstones are explicit, and absent-file removal is not inferred. |
+
+`POST auth.test` is the only other reachable call. No endpoint string or verb
+comes from provider data. Mutation methods, app/admin routes, search, browser
+automation, export initiation, file download, and outbound operations are not
+wired.
+
+`--page-size` is 1-15. The initial identity check consumes one request unit and
+each page reserves two units for identity rebinding plus its selected data
+method. `--budget` is a hard 3-17 request-unit allowance, so one invocation can
+read at most eight data pages and 17 individually 8 MiB-capped provider
+responses. Cursor pagination resumes across invocations; pins and bookmarks are
+capped snapshots, and file pages use a validated numeric page cursor. Every
+logical stream has an independent durable cursor.
+
+Completed message-history and thread backfills refresh from seven days before
+their newest watermark so recent edits and deletions can update a stable message
+identity. This overlap is not a complete historical-edit guarantee. Raw page,
+normalized rows, coverage, cursor, and run receipt commit atomically under a
+final lease fence. Rate limits pause the run without advancing its cursor.
+
+Example direct API collection:
+
+```bash
+python3 "$HOME/.aidevops/agents/scripts/knowledge_social_slack.py" api \
+  --connection-id conn_slack_personal \
+  --account-id slack_TWORKSPACE123_user_UACCOUNT123 \
+  --profile personal \
+  --stream conversation/engineering/history \
+  --budget 11 \
+  --page-size 15
+```
+
+## Administrator-approved JSON exports
+
+Obtain the ZIP through an authorized Slack export workflow. Never paste a
+download URL, token, or exported private content into a command, issue, fixture,
+or log. The importer never contacts Slack, initiates an export, follows a link,
+extracts members to disk, or reads `SLACK_<PROFILE>_ACCESS_TOKEN`. It uses only
+the profile's non-secret identity and conversation binding.
+
+The implemented parser accepts Slack's flat, workspace-scoped JSON layout.
+Nested whole-organization exports and single-user JSON or TXT layouts are
+explicitly unavailable and fail closed rather than being guessed.
+
+The fail-closed parser recognizes:
+
+| Export member | Interpretation |
+|---|---|
+| exactly one `users.json` or `org_users.json` | Selected account plus only users referenced by selected evidence |
+| optional `team_info.json` | Workspace and enterprise cross-check plus bounded workspace metadata |
+| `channels.json` | Allowlisted public-channel references |
+| `groups.json` | Allowlisted private-channel references |
+| `dms.json` | Allowlisted direct-message references |
+| `mpims.json` | Allowlisted multi-person direct-message references |
+| `<conversation-folder>/YYYY-MM-DD.json` | Messages, threads, edits/deletions, embedded reactions, and file metadata for an allowlisted conversation |
+
+An allowlist entry must resolve to exactly one reference record and its exact
+conversation folder. The importer verifies the selected account, workspace, and
+optional enterprise before normalization. API and export messages use the same
+workspace, conversation ID, and Slack timestamp identity.
+
+Example direct import:
+
+```bash
+python3 "$HOME/.aidevops/agents/scripts/knowledge_social_slack.py" archive \
+  --archive "$HOME/private/slack-export.zip" \
+  --connection-id conn_slack_personal \
+  --account-id slack_TWORKSPACE123_user_UACCOUNT123 \
+  --profile personal \
+  --exported-at 2026-07-31T19:00:00Z \
+  --max-items 25000 \
+  --max-bytes 67108864
+```
+
+`--exported-at` is the operator-observed export time, requires an explicit
+timezone, and cannot exceed the trusted local clock by more than five minutes.
+`--max-items` bounds ZIP members and normalized records. `--max-bytes` bounds
+both the compressed archive and total uncompressed members. Defaults are 25,000
+items and 64 MiB; hard CLI caps are 100,000 items and 128 MiB. Each ZIP member
+also has a 16 MiB ceiling. These limits bound the in-memory ZIP index, selected
+JSON members, normalized records, and filtered evidence construction.
+
+The archive path must be one unchanged regular non-symlink file. The parser
+rejects absolute, traversing, backslash, NUL, duplicate case-folded, symbolic-link,
+encrypted, malformed JSON, oversized, identity-conflicting, and unexpected
+reference structures before persistence. Credential-shaped keys, Slack token
+formats, Slack webhook URLs, and any exact active access token reflected by an
+API response are also rejected; ordinary discussion of credential handling is
+not treated as a secret.
+
+The private raw evidence blob is deliberately **not** the original ZIP. It is
+canonical filtered JSON containing only sanitized records from allowlisted
+conversations, the non-secret immutable connection binding, SHA-256 hashes of
+selected source members, and the full source ZIP digest. Unselected conversation
+bodies and unreferenced user profiles are not persisted. User email fields, file
+private URLs, binary content, and unknown provider fields are omitted. This
+preserves replay/audit linkage without copying unselected workspace content into
+the corpus. Exact filtered-evidence replay is content-addressed and creates no
+duplicate canonical identities. Older API or export evidence can be retained as
+a separate immutable batch, but timestamp-ordered account, object, activity,
+media, coverage, cursor, and connection-policy writes cannot overwrite newer
+canonical state. Within one connection, conflicting evidence with an identical
+observation timestamp fails closed, while byte-equivalent replay remains
+idempotent. Equal-time canonical records shared by separate connections resolve
+deterministically by complete account values or content-addressed batch ID.
+
+## Coverage and retention boundaries
+
+API success records explicit partial or unavailable coverage for unallowlisted
+conversations, plan/membership/token-bounded retention, deleted or purged
+content, disabled file binaries, potentially truncated reaction actors, omitted
+blocks/attachments/canvases/huddles, unreconciled reaction/pin/bookmark/member/
+file removals, and the seven-day historical-edit window.
+At most 100 returned reaction actors per message are accepted; larger nested
+expansions fail closed before normalization, while Slack's reported count still
+records upstream truncation.
+
+An export proves only what its authorized ZIP contains. Each allowlisted
+conversation receives finite archive coverage, while the importer separately
+records that:
+
+- unallowlisted conversations are excluded;
+- channel bookmarks are not documented export members;
+- JSON exports contain file metadata/links rather than imported binaries;
+- edit and deletion records depend on workspace retention;
+- thread timestamps are preserved without a separate complete thread order.
+
+Public channels, private channels, DMs, and MPDMs remain distinct allowlist
+kinds. Message bodies, threads, edits/deletions, reactions, files, users,
+workspace metadata, pins, bookmarks, retention, exports, and inaccessible
+history therefore each have an implemented route or an explicit coverage gap.
+Neither API completion nor archive completion claims all historical workspace
+content. Local retention must remain owner-controlled and authorized for the
+operator's purpose.
+
+## Official evidence checked 2026-07-31
+
+- [Slack `auth.test`](https://docs.slack.dev/reference/methods/auth.test.md)
+- [Slack `conversations.history`](https://docs.slack.dev/reference/methods/conversations.history.md)
+- [Slack `conversations.replies`](https://docs.slack.dev/reference/methods/conversations.replies.md)
+- [Slack `bookmarks.list`](https://docs.slack.dev/reference/methods/bookmarks.list.md)
+- [Slack Web API rate limits](https://docs.slack.dev/apis/web-api/rate-limits.md)
+- [How to read Slack data exports](https://slack.com/help/articles/220556107-How-to-read-Slack-data-exports)

--- a/.agents/scripts/_knowledge_social_slack.py
+++ b/.agents/scripts/_knowledge_social_slack.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Slack stream policy, workspace identity, selectors, and checkpoints."""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+from collections.abc import Iterator, Mapping
+from dataclasses import asdict, dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from _knowledge_social_slack_identity import (
+    ALIAS as ALIAS,
+    CONVERSATION_KINDS as CONVERSATION_KINDS,
+    TOKEN_TYPES as TOKEN_TYPES,
+    SlackAdapterError as SlackAdapterError,
+    SlackProviderUnavailableError as SlackProviderUnavailableError,
+    account_id as account_id,
+    conversation_binding_sha256 as conversation_binding_sha256,
+    conversation_id as conversation_id,
+    enterprise_id as enterprise_id,
+    namespaced_id as namespaced_id,
+    parse_account_id as parse_account_id,
+    slack_timestamp as slack_timestamp,
+    team_id as team_id,
+    token_type as token_type,
+    user_id as user_id,
+)
+from _knowledge_social_slack_evidence_guard import reject_slack_credentials
+from knowledge_social_import import canonical_json
+
+PROVIDER = "slack"
+CURSOR_PREFIX = "slack-v1:"
+RETENTION_LIMIT = "workspace_plan_retention_membership_and_token_visibility"
+HISTORY_OVERLAP_SECONDS = Decimal(7 * 24 * 60 * 60)
+MAX_CURSOR_BYTES = 4096
+MAX_SNAPSHOT_ITEMS = 100
+MAX_EXPANDED_RECORDS_PER_ITEM = 101
+CONVERSATION_STREAM = re.compile(
+    r"^conversation/([a-z0-9][a-z0-9_-]{0,31})/"
+    r"(info|members|history|pins|bookmarks|files)$"
+)
+THREAD_STREAM = re.compile(
+    r"^conversation/([a-z0-9][a-z0-9_-]{0,31})/thread/"
+    r"([0-9]{1,16}\.[0-9]{6})$"
+)
+
+
+ADAPTER_ERROR = SlackAdapterError
+PROVIDER_UNAVAILABLE_ERROR = SlackProviderUnavailableError
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    """Static collection and coverage policy for one logical Slack stream."""
+
+    resource_kind: str
+    activity_mode: str
+    pagination: str
+    incremental: bool
+    retention_limit: str | None = RETENTION_LIMIT
+    coverage_status: str | None = None
+    unavailable_reason: str | None = None
+    cost_units: int = 2
+
+
+@dataclass(frozen=True)
+class StreamSelector:
+    """Validated provider selector encoded by one durable stream key."""
+
+    kind: str
+    alias: str | None = None
+    thread_ts: str | None = None
+
+
+STATIC_SPECS = {
+    "workspace": StreamSpec("workspace", "workspace_metadata", "snapshot", False),
+    "users": StreamSpec(
+        "user", "workspace_member", "cursor", False, coverage_status="partial",
+        unavailable_reason="profile_fields_and_guests_depend_on_token_visibility",
+    ),
+    "reactions": StreamSpec(
+        "reaction", "selected_account", "cursor", False,
+        coverage_status="partial",
+        unavailable_reason=(
+            "selected_account_reactions_truncated_actor_lists_and_unreconciled_removals_only"
+        ),
+    ),
+}
+
+DYNAMIC_SPECS = {
+    "info": StreamSpec("conversation", "conversation_metadata", "snapshot", False),
+    "members": StreamSpec(
+        "membership", "conversation_member", "cursor", False,
+        coverage_status="partial",
+        unavailable_reason=(
+            "membership_is_token_visible_and_removed_members_are_not_reconciled"
+        ),
+    ),
+    "history": StreamSpec(
+        "message", "message", "cursor", True, coverage_status="partial",
+        unavailable_reason="retention_and_seven_day_edit_overlap_bound_history",
+    ),
+    "thread": StreamSpec(
+        "message", "thread_reply", "cursor", True, coverage_status="partial",
+        unavailable_reason="retention_token_type_and_edit_overlap_bound_replies",
+    ),
+    "pins": StreamSpec(
+        "pin", "pin", "snapshot", False, coverage_status="partial",
+        unavailable_reason="snapshot_is_capped_at_100_items_and_removals_are_not_reconciled",
+    ),
+    "bookmarks": StreamSpec(
+        "bookmark", "bookmark", "snapshot", False, coverage_status="partial",
+        unavailable_reason="snapshot_is_capped_at_100_items_and_removals_are_not_reconciled",
+    ),
+    "files": StreamSpec(
+        "file", "file_share", "page", False, coverage_status="partial",
+        unavailable_reason=(
+            "file_metadata_only_binary_hydration_disabled_and_removals_are_not_reconciled"
+        ),
+    ),
+}
+
+
+def parse_stream(value: Any) -> StreamSelector:
+    """Parse one static or allowlisted conversation-scoped stream key."""
+    if value in STATIC_SPECS:
+        return StreamSelector(str(value))
+    if not isinstance(value, str) or len(value) > 127 or "\x00" in value:
+        raise SlackAdapterError("Slack stream is unsupported")
+    match = CONVERSATION_STREAM.fullmatch(value)
+    if match is not None:
+        return StreamSelector(match.group(2), match.group(1))
+    match = THREAD_STREAM.fullmatch(value)
+    if match is not None:
+        return StreamSelector("thread", match.group(1), match.group(2))
+    raise SlackAdapterError("Slack stream is unsupported")
+
+
+class SlackStreamRegistry(Mapping[str, StreamSpec]):
+    """Resolve dynamic conversation selectors without widening shared contracts."""
+
+    def __getitem__(self, key: str) -> StreamSpec:
+        selector = parse_stream(key)
+        if selector.kind in STATIC_SPECS:
+            return STATIC_SPECS[selector.kind]
+        return DYNAMIC_SPECS[selector.kind]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(STATIC_SPECS)
+
+    def __len__(self) -> int:
+        return len(STATIC_SPECS)
+
+    def __contains__(self, key: object) -> bool:
+        try:
+            parse_stream(key)
+        except SlackAdapterError:
+            return False
+        return True
+
+
+STREAMS: Mapping[str, StreamSpec] = SlackStreamRegistry()
+
+
+def _cursor_text(value: Any, field: str, *, optional: bool = True) -> str | None:
+    if value is None and optional:
+        return None
+    if (
+        not isinstance(value, str)
+        or not value
+        or "\x00" in value
+        or len(value.encode("utf-8")) > MAX_CURSOR_BYTES
+    ):
+        raise SlackAdapterError(f"Slack {field} is invalid")
+    return value
+
+
+def _encode_cursor(cursor: str, oldest: str | None) -> str:
+    payload = canonical_json({"cursor": cursor, "oldest": oldest}).encode("utf-8")
+    encoded = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+    return f"{CURSOR_PREFIX}{encoded}"
+
+
+def _decode_cursor(value: str) -> tuple[str, str | None]:
+    if not value.startswith(CURSOR_PREFIX):
+        raise SlackAdapterError("stored Slack cursor has an unsupported version")
+    encoded = value.removeprefix(CURSOR_PREFIX)
+    try:
+        parsed = json.loads(
+            base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4))
+        )
+    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+        raise SlackAdapterError("stored Slack cursor is invalid") from error
+    if not isinstance(parsed, dict) or set(parsed) != {"cursor", "oldest"}:
+        raise SlackAdapterError("stored Slack cursor has an invalid shape")
+    reject_slack_credentials(parsed)
+    return (
+        _cursor_text(parsed["cursor"], "cursor", optional=False) or "",
+        (
+            slack_timestamp(parsed["oldest"], "cursor oldest timestamp")
+            if parsed["oldest"] is not None
+            else None
+        ),
+    )
+
+
+def _overlap_oldest(watermark: str | None) -> str | None:
+    if watermark is None:
+        return None
+    timestamp = slack_timestamp(watermark, "watermark")
+    try:
+        value = max(Decimal(timestamp) - HISTORY_OVERLAP_SECONDS, Decimal(0))
+    except InvalidOperation as error:
+        raise SlackAdapterError("stored Slack watermark is invalid") from error
+    return f"{value:.6f}"
+
+
+@dataclass(frozen=True)
+class PageRequest:
+    """One allowlisted request passed to the isolated Slack reader."""
+
+    stream: str
+    account_id: str
+    provider_account_id: str
+    workspace_id: str
+    enterprise_id: str | None
+    selector: str
+    conversation_alias: str | None
+    thread_ts: str | None
+    cursor: str | None
+    oldest: str | None
+    limit: int
+
+    def payload(self) -> dict[str, Any]:
+        return {"action": "page", **asdict(self)}
+
+    def evidence_key(self) -> str:
+        return canonical_json(self.payload())
+
+
+PAGE_REQUEST_KEYS = set(PageRequest.__dataclass_fields__) | {"action"}
+
+
+def page_request(
+    stream: str, account: dict[str, Any], state: CursorState, limit: int
+) -> PageRequest:
+    """Build one request from a durable workspace/conversation stream state."""
+    selector = parse_stream(stream)
+    selected_id = account.get("id")
+    if not isinstance(selected_id, str):
+        raise SlackAdapterError("verified Slack identity is incomplete")
+    workspace, selected_user = parse_account_id(selected_id)
+    if workspace != team_id(account.get("workspace_id")):
+        raise SlackAdapterError("verified Slack workspace identity is inconsistent")
+    if selected_user != user_id(account.get("provider_account_id")):
+        raise SlackAdapterError("verified Slack account identity is inconsistent")
+    cursor: str | None = None
+    oldest: str | None = None
+    if state.cursor:
+        cursor, oldest = _decode_cursor(state.cursor)
+    elif STREAMS[stream].incremental and state.backfill_complete:
+        oldest = _overlap_oldest(state.watermark)
+    return PageRequest(
+        stream,
+        selected_id,
+        selected_user,
+        workspace,
+        enterprise_id(account.get("enterprise_id")),
+        selector.kind,
+        selector.alias,
+        selector.thread_ts,
+        cursor,
+        oldest,
+        limit,
+    )
+
+
+def parse_page_request(payload: dict[str, Any]) -> PageRequest:
+    """Validate the exact child-process page request shape."""
+    if set(payload) != PAGE_REQUEST_KEYS or payload.get("action") != "page":
+        raise SlackAdapterError("Slack read request has an invalid action shape")
+    stream = payload.get("stream")
+    selector = parse_stream(stream)
+    if payload.get("selector") != selector.kind:
+        raise SlackAdapterError("Slack stream selector is inconsistent")
+    if payload.get("conversation_alias") != selector.alias:
+        raise SlackAdapterError("Slack conversation selector is inconsistent")
+    if payload.get("thread_ts") != selector.thread_ts:
+        raise SlackAdapterError("Slack thread selector is inconsistent")
+    limit = payload.get("limit")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 15:
+        raise SlackAdapterError("Slack page size must be between 1 and 15")
+    selected = payload.get("account_id")
+    workspace, selected_user = parse_account_id(selected)
+    if team_id(payload.get("workspace_id")) != workspace:
+        raise SlackAdapterError("Slack request workspace identity is inconsistent")
+    if user_id(payload.get("provider_account_id")) != selected_user:
+        raise SlackAdapterError("Slack request account identity is inconsistent")
+    cursor = _cursor_text(payload.get("cursor"), "cursor")
+    oldest = payload.get("oldest")
+    if oldest is not None:
+        oldest = slack_timestamp(oldest, "oldest timestamp")
+    return PageRequest(
+        str(stream),
+        str(selected),
+        selected_user,
+        workspace,
+        enterprise_id(payload.get("enterprise_id")),
+        selector.kind,
+        selector.alias,
+        selector.thread_ts,
+        cursor,
+        oldest,
+        limit,
+    )
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise SlackAdapterError("Slack response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise SlackAdapterError("Slack page data must be an array of objects")
+    reject_slack_credentials(data)
+    return data
+
+
+def _metadata(payload: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    meta = payload.get("meta")
+    if not isinstance(meta, dict):
+        raise SlackAdapterError("Slack page metadata must be an object")
+    reject_slack_credentials(meta)
+    expected = {
+        "stream",
+        "selector",
+        "workspace_id",
+        "next_cursor",
+        "newest_ts",
+        "complete",
+        "source",
+    }
+    if set(meta) != expected:
+        raise SlackAdapterError("Slack page metadata has an invalid shape")
+    if (
+        meta.get("stream") != request.stream
+        or meta.get("selector") != request.selector
+        or team_id(meta.get("workspace_id")) != request.workspace_id
+        or meta.get("source") != "slack_web_api"
+    ):
+        raise SlackAdapterError("Slack page provenance is invalid")
+    return meta
+
+
+def page_checkpoint(
+    payload: dict[str, Any], state: CursorState, request: PageRequest
+) -> tuple[PageCheckpoint, bool]:
+    """Calculate one atomic per-workspace, per-conversation stream checkpoint."""
+    meta = _metadata(payload, request)
+    next_cursor = _cursor_text(meta.get("next_cursor"), "next cursor")
+    complete = meta.get("complete")
+    if not isinstance(complete, bool) or complete != (next_cursor is None):
+        raise SlackAdapterError("Slack page completion cursor is invalid")
+    if next_cursor is not None and next_cursor == request.cursor:
+        raise SlackAdapterError("Slack page cursor did not advance")
+    item_limit = request.limit
+    if request.selector in {"pins", "bookmarks"}:
+        item_limit = MAX_SNAPSHOT_ITEMS
+    elif request.selector in {"workspace", "info"}:
+        item_limit = 1
+    elif request.selector in {"history", "thread", "reactions"}:
+        item_limit = request.limit * MAX_EXPANDED_RECORDS_PER_ITEM
+    if len(page_data(payload)) > item_limit:
+        raise SlackAdapterError("Slack page exceeds the item safety limit")
+    newest = meta.get("newest_ts")
+    if newest is not None:
+        newest = slack_timestamp(newest, "newest timestamp")
+    watermark = state.watermark
+    if newest is not None and (watermark is None or Decimal(newest) > Decimal(watermark)):
+        watermark = newest
+    encoded = _encode_cursor(next_cursor, request.oldest) if next_cursor else None
+    return PageCheckpoint(encoded, watermark), complete

--- a/.agents/scripts/_knowledge_social_slack.py
+++ b/.agents/scripts/_knowledge_social_slack.py
@@ -14,7 +14,8 @@ from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from _knowledge_social_collect import CursorState, PageCheckpoint
-from _knowledge_social_slack_identity import (
+# Same-name imports define the stable Slack policy facade for provider modules.
+from _knowledge_social_slack_identity import (  # pylint: disable=unused-import
     ALIAS as ALIAS,
     CONVERSATION_KINDS as CONVERSATION_KINDS,
     TOKEN_TYPES as TOKEN_TYPES,

--- a/.agents/scripts/_knowledge_social_slack_activities.py
+++ b/.agents/scripts/_knowledge_social_slack_activities.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize sanitized Slack records into canonical activities."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_slack import SlackAdapterError
+from _knowledge_social_slack_evidence_guard import reject_slack_credentials
+from _knowledge_social_slack_fields import optional, required
+from knowledge_social_import import canonical_json
+
+
+@dataclass(frozen=True)
+class ActivitySpec:
+    activity_type: str
+    remote_id: str
+    actor: str
+    target: str | None
+    occurred_at: str | None
+    state: str
+    extra: dict[str, Any] | None = None
+
+
+def _activity_id(*values: str) -> str:
+    digest = hashlib.sha256(canonical_json(values).encode("utf-8")).hexdigest()
+    return f"slack_activity_{digest}"
+
+
+def _base_activity(
+    spec: ActivitySpec, observed_at: str, source: str
+) -> dict[str, Any]:
+    provider_json = {"source": source, **(spec.extra or {})}
+    reject_slack_credentials(provider_json)
+    return {
+        "activity_type": spec.activity_type,
+        "remote_id": spec.remote_id,
+        "actor_remote_id": spec.actor,
+        "object_remote_id": spec.target,
+        "occurred_at": spec.occurred_at,
+        "observed_at": observed_at,
+        "state": spec.state,
+        "provider_json": provider_json,
+    }
+
+
+def _message_activities(
+    record: dict[str, Any], observed_at: str, source: str
+) -> list[dict[str, Any]]:
+    remote_id = required(record, "remote_id")
+    actor = required(record, "actor_remote_id")
+    state = required(record, "state")
+    thread = optional(record, "thread_remote_id")
+    activity_type = "thread_reply" if thread and thread != remote_id else "message"
+    initial = ActivitySpec(
+        activity_type,
+        _activity_id(activity_type, remote_id),
+        actor,
+        remote_id,
+        optional(record, "created_at"),
+        state,
+        {"conversation_remote_id": record.get("conversation_remote_id")},
+    )
+    activities = [_base_activity(initial, observed_at, source)]
+    if state in {"edited", "deleted"}:
+        change_type = "message_edit" if state == "edited" else "message_delete"
+        changed_at = optional(record, "edited_at")
+        change = ActivitySpec(
+            change_type,
+            _activity_id(change_type, remote_id, changed_at or observed_at),
+            optional(record, "editor_remote_id") or actor,
+            remote_id,
+            changed_at,
+            state,
+        )
+        activities.append(_base_activity(change, observed_at, source))
+    reactions = record.get("reactions", [])
+    if not isinstance(reactions, list):
+        raise SlackAdapterError("Slack message reactions must be an array")
+    for reaction in reactions:
+        activities.extend(_reaction_activities(reaction, remote_id, observed_at, source))
+    if record.get("is_starred") is True:
+        saved = ActivitySpec(
+            "saved_message",
+            _activity_id("saved_message", remote_id, actor),
+            actor,
+            remote_id,
+            None,
+            "active",
+        )
+        activities.append(_base_activity(saved, observed_at, source))
+    return activities
+
+
+def _reaction_activities(
+    reaction: Any, message_id: str, observed_at: str, source: str
+) -> list[dict[str, Any]]:
+    if not isinstance(reaction, dict):
+        raise SlackAdapterError("Slack message reaction must be an object")
+    name = required(reaction, "name")
+    actors = reaction.get("actor_remote_ids", [])
+    if not isinstance(actors, list) or any(not isinstance(value, str) for value in actors):
+        raise SlackAdapterError("Slack reaction actors must be an array")
+    extra = {
+        "name": name,
+        "reported_count": reaction.get("count"),
+        "actors_truncated": reaction.get("actors_truncated"),
+    }
+    return [
+        _base_activity(
+            ActivitySpec(
+                "reaction",
+                _activity_id("reaction", message_id, name, actor),
+                actor,
+                message_id,
+                None,
+                "active",
+                extra,
+            ),
+            observed_at,
+            source,
+        )
+        for actor in actors
+    ]
+
+
+def record_activities(
+    record: dict[str, Any], selected_id: str, observed_at: str, source: str
+) -> list[dict[str, Any]]:
+    """Expand one sanitized provider record into canonical activities."""
+    kind = required(record, "kind")
+    if kind == "message":
+        return _message_activities(record, observed_at, source)
+    if kind == "membership":
+        spec = ActivitySpec(
+            "conversation_membership",
+            required(record, "remote_id"),
+            required(record, "actor_remote_id"),
+            required(record, "conversation_remote_id"),
+            None,
+            "active",
+        )
+        return [_base_activity(spec, observed_at, source)]
+    if kind in {"bookmark", "pin", "file"}:
+        target = required(record, "remote_id")
+        actor = optional(record, "actor_remote_id") or selected_id
+        state = (
+            "deleted"
+            if kind == "file" and record.get("is_tombstoned") is True
+            else "active"
+        )
+        activity_type = {
+            "bookmark": "bookmark",
+            "pin": "pin",
+            "file": "file_share",
+        }[kind]
+        spec = ActivitySpec(
+            activity_type,
+            _activity_id(activity_type, target, actor),
+            actor,
+            target,
+            optional(record, "created_at"),
+            state,
+        )
+        return [_base_activity(spec, observed_at, source)]
+    if kind == "user":
+        actor = required(record, "remote_id")
+        state = "deleted" if record.get("deleted") is True else "active"
+        spec = ActivitySpec(
+            "workspace_member",
+            _activity_id("workspace_member", actor),
+            actor,
+            None,
+            None,
+            state,
+        )
+        return [_base_activity(spec, observed_at, source)]
+    return []

--- a/.agents/scripts/_knowledge_social_slack_archive.py
+++ b/.agents/scripts/_knowledge_social_slack_archive.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validate and normalize one administrator-approved Slack JSON export."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_lease import social_now
+from _knowledge_social_slack import PROVIDER
+from _knowledge_social_slack_archive_select import select_archive_records
+from _knowledge_social_slack_archive_types import (
+    ParsedSlackArchive as ParsedSlackArchive,
+    SlackArchiveRequest as SlackArchiveRequest,
+)
+from _knowledge_social_slack_evidence_guard import reject_slack_credentials
+from _knowledge_social_slack_normalize import (
+    EXPORT_SOURCE,
+    NormalizationBatch,
+    PageContext,
+    canonical_observed_at,
+    normalize_records,
+)
+from _knowledge_social_slack_route_types import ConversationTarget
+from _knowledge_social_slack_zip import index_archive, read_regular_archive
+from knowledge_social_import import canonical_json
+from knowledge_social_store import SocialStoreError, validate_opaque
+
+MAX_FUTURE_EXPORT_SECONDS = 5 * 60
+
+
+def _timestamp(value: str) -> str:
+    observed_at = canonical_observed_at(value, "export observation time")
+    parsed = datetime.fromisoformat(observed_at.replace("Z", "+00:00"))
+    latest = datetime.fromtimestamp(
+        social_now() + MAX_FUTURE_EXPORT_SECONDS, UTC
+    )
+    if parsed > latest:
+        raise SocialStoreError("Slack export observation time is in the future")
+    return observed_at
+
+
+def _coverage(
+    targets: dict[str, ConversationTarget],
+    present: dict[str, int],
+    observed_at: str,
+) -> list[dict[str, Any]]:
+    rows = [
+        {
+            "stream": "archive",
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": True,
+            "retention_limit": "approved_export_date_range_and_workspace_retention",
+            "unavailable_reason": "export_date_range_and_retention_bound_history",
+            "status": "partial",
+            "observed_at": observed_at,
+        }
+    ]
+    for alias in sorted(targets):
+        count = present.get(alias, 0)
+        rows.append(
+            {
+                "stream": f"conversation/{alias}/archive",
+                "earliest_at": None,
+                "latest_at": None,
+                "cursor_exhausted": True,
+                "retention_limit": "approved_export_date_range_and_workspace_retention",
+                "unavailable_reason": (
+                    "export_date_range_and_retention_bound_history"
+                    if count
+                    else "allowlisted_conversation_has_no_message_files_in_export"
+                ),
+                "status": "partial" if count else "unavailable",
+                "observed_at": observed_at,
+            }
+        )
+    gaps = (
+        ("archive_unallowlisted_conversations", "conversation_allowlist_excludes_other_export_content", "partial"),
+        ("archive_bookmarks", "channel_bookmarks_are_not_documented_export_members", "unavailable"),
+        ("archive_files", "json_exports_contain_file_links_not_file_binaries", "partial"),
+        ("archive_edits_deletions", "edit_and_deletion_records_depend_on_retention_policy", "partial"),
+        ("archive_threads", "json_exports_preserve_thread_timestamps_without_separate_thread_order", "partial"),
+        ("archive_layouts", "nested_org_and_single_user_export_layouts_are_not_supported", "unavailable"),
+        ("archive_rich_message_surfaces", "blocks_attachments_canvases_and_huddles_are_not_normalized", "partial"),
+    )
+    rows.extend(
+        {
+            "stream": stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": "approved_export_date_range_and_workspace_retention",
+            "unavailable_reason": reason,
+            "status": status,
+            "observed_at": observed_at,
+        }
+        for stream, reason, status in gaps
+    )
+    return rows
+
+
+def build_slack_archive(request: SlackArchiveRequest) -> ParsedSlackArchive:
+    """Build filtered immutable evidence and normalized rows from one JSON ZIP."""
+    validate_opaque(request.connection_id, "connection_id")
+    if not request.profile.conversations:
+        raise SocialStoreError("Slack export requires a non-empty conversation allowlist")
+    observed_at = _timestamp(request.exported_at)
+    payload = read_regular_archive(request.path, request.max_bytes)
+    source_sha256 = hashlib.sha256(payload).hexdigest()
+    with index_archive(payload, request.max_bytes, request.max_items) as index:
+        selection = select_archive_records(request, index)
+        account = selection.account
+        records = selection.records
+        streams = tuple(
+            ["archive"]
+            + [
+                f"conversation/{alias}/archive"
+                for alias in sorted(request.profile.conversations)
+            ]
+        )
+        context = PageContext(
+            request.connection_id,
+            account,
+            "archive",
+            streams,
+            {
+                "media_hydration": "none",
+                "slack_export_sha256": source_sha256,
+                "slack_export_filtered": True,
+            },
+        )
+        archive = normalize_records(
+            records,
+            context,
+            NormalizationBatch(
+                observed_at,
+                EXPORT_SOURCE,
+                tuple(
+                    _coverage(
+                        request.profile.conversations, selection.present, observed_at
+                    )
+                ),
+            ),
+        )
+        evidence_value = {
+            "schema": 1,
+            "provider": PROVIDER,
+            "source": EXPORT_SOURCE,
+            "source_sha256": source_sha256,
+            "connection_id": request.connection_id,
+            "workspace_id": account["workspace_id"],
+            "enterprise_id": account["enterprise_id"],
+            "account_id": account["id"],
+            "token_type": account["token_type"],
+            "conversation_binding_sha256": account[
+                "conversation_binding_sha256"
+            ],
+            "selected_member_sha256": {
+                name: hashlib.sha256(index.member_bytes(name)).hexdigest()
+                for name in sorted(selection.selected_members)
+            },
+            "records": records,
+        }
+    reject_slack_credentials(evidence_value)
+    evidence = canonical_json(evidence_value).encode("utf-8")
+    evidence_sha256 = hashlib.sha256(evidence).hexdigest()
+    normalized_items = sum(
+        len(archive[key]) for key in ("accounts", "objects", "activities", "media")
+    )
+    if normalized_items > request.max_items:
+        raise SocialStoreError("Slack export exceeds the normalized item budget")
+    return ParsedSlackArchive(
+        archive,
+        evidence,
+        source_sha256,
+        evidence_sha256,
+        streams[1:],
+        len(selection.selected_members),
+        normalized_items,
+    )

--- a/.agents/scripts/_knowledge_social_slack_archive_count.py
+++ b/.agents/scripts/_knowledge_social_slack_archive_count.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Count bounded canonical row expansion for Slack export records."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from _knowledge_social_slack import namespaced_id
+
+OBJECT_KINDS = frozenset(
+    {"workspace", "conversation", "message", "bookmark", "pin", "file"}
+)
+ACTIVITY_KINDS = frozenset({"membership", "bookmark", "pin", "file", "user"})
+
+
+def _reaction_actors(record: dict[str, Any]) -> list[str]:
+    values: list[str] = []
+    reactions = record.get("reactions", [])
+    if not isinstance(reactions, list):
+        return values
+    for reaction in reactions:
+        if not isinstance(reaction, dict):
+            continue
+        actors = reaction.get("actor_remote_ids", [])
+        if isinstance(actors, list):
+            values.extend(actor for actor in actors if isinstance(actor, str))
+    return values
+
+
+def _account_ids(record: dict[str, Any]) -> set[str]:
+    values = {
+        value
+        for value in (
+            record.get("actor_remote_id"),
+            record.get("editor_remote_id"),
+        )
+        if isinstance(value, str)
+    }
+    if record.get("kind") == "user" and isinstance(record.get("remote_id"), str):
+        values.add(record["remote_id"])
+    values.update(_reaction_actors(record))
+    return values
+
+
+def _activity_count(record: dict[str, Any]) -> int:
+    kind = record.get("kind")
+    if kind in ACTIVITY_KINDS:
+        return 1
+    if kind != "message":
+        return 0
+    count = 1 + len(_reaction_actors(record))
+    if record.get("state") in {"edited", "deleted"}:
+        count += 1
+    if record.get("is_starred") is True:
+        count += 1
+    return count
+
+
+def normalized_item_count(
+    records: list[dict[str, Any]], account: dict[str, Any]
+) -> int:
+    """Count canonical row expansion before allocating normalized collections."""
+    workspace = account["workspace_id"]
+    accounts = {
+        account["id"],
+        namespaced_id(workspace, "workspace_actor", workspace),
+    }
+    objects = 0
+    activities = 0
+    media = 0
+    for record in records:
+        kind = record.get("kind")
+        accounts.update(_account_ids(record))
+        objects += int(kind in OBJECT_KINDS)
+        activities += _activity_count(record)
+        media += int(kind == "file")
+    return len(accounts) + objects + activities + media

--- a/.agents/scripts/_knowledge_social_slack_archive_identity.py
+++ b/.agents/scripts/_knowledge_social_slack_archive_identity.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Resolve Slack export identities and allowlisted reference members."""
+
+from __future__ import annotations
+
+import re
+from pathlib import PurePosixPath
+from typing import Any
+
+from _knowledge_social_slack import account_id, enterprise_id, parse_account_id, team_id
+from _knowledge_social_slack_archive_types import SlackArchiveRequest
+from _knowledge_social_slack_evidence_guard import reject_slack_credentials
+from _knowledge_social_slack_route_types import ConversationTarget
+from _knowledge_social_slack_zip import SlackArchiveIndex
+from knowledge_social_store import SocialStoreError
+
+DATE_MEMBER = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}\.json$")
+REFERENCE_FILES = {
+    "public_channel": "channels.json",
+    "private_channel": "groups.json",
+    "im": "dms.json",
+    "mpim": "mpims.json",
+}
+
+
+def object_list(value: Any, field: str, limit: int) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise SocialStoreError(f"Slack export {field} must be an array of objects")
+    if len(value) > limit:
+        raise SocialStoreError(f"Slack export {field} exceeds the item budget")
+    return value
+
+
+def _single_member(index: SlackArchiveIndex, names: tuple[str, ...]) -> str:
+    present = [name for name in names if name in index.members]
+    if len(present) != 1:
+        raise SocialStoreError("Slack export requires exactly one user reference file")
+    return present[0]
+
+
+def users(
+    index: SlackArchiveIndex, max_items: int
+) -> tuple[list[dict[str, Any]], str]:
+    member = _single_member(index, ("users.json", "org_users.json"))
+    return object_list(index.json_value(member), "users", max_items), member
+
+
+def _selected_user(
+    values: list[dict[str, Any]], selected_user_id: str
+) -> dict[str, Any]:
+    matches = [item for item in values if item.get("id") == selected_user_id]
+    if len(matches) != 1:
+        raise SocialStoreError("Slack export does not contain the selected account")
+    return matches[0]
+
+
+def _team_metadata(index: SlackArchiveIndex) -> dict[str, Any] | None:
+    if "team_info.json" not in index.members:
+        return None
+    value = index.json_value("team_info.json")
+    if not isinstance(value, dict):
+        raise SocialStoreError("Slack export team_info.json must be an object")
+    team = value.get("team", value)
+    if not isinstance(team, dict):
+        raise SocialStoreError("Slack export workspace metadata must be an object")
+    return team
+
+
+def identity(
+    request: SlackArchiveRequest,
+    index: SlackArchiveIndex,
+    user_records: list[dict[str, Any]],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    expected_workspace, expected_user = parse_account_id(request.expected_account_id)
+    binding = request.profile.binding
+    if expected_workspace != binding.workspace_id:
+        raise SocialStoreError("Slack export workspace does not match the profile")
+    selected = _selected_user(user_records, expected_user)
+    team = _team_metadata(index)
+    reject_slack_credentials(selected)
+    if team is not None:
+        reject_slack_credentials(team)
+    selected_workspace = selected.get("team_id")
+    team_workspace = team.get("id") if team is not None else None
+    if selected_workspace is not None and team_workspace is not None:
+        if team_id(selected_workspace) != team_id(team_workspace):
+            raise SocialStoreError("Slack export workspace identity conflicts")
+    observed_workspace = team_workspace or selected_workspace
+    if team_id(observed_workspace) != expected_workspace:
+        raise SocialStoreError("Slack export workspace identity does not match")
+    selected_enterprise = enterprise_id(selected.get("enterprise_id"))
+    team_enterprise = enterprise_id(
+        team.get("enterprise_id") if team is not None else None
+    )
+    if selected_enterprise is not None and team_enterprise is not None:
+        if selected_enterprise != team_enterprise:
+            raise SocialStoreError("Slack export enterprise identity conflicts")
+    observed_enterprise = team_enterprise or selected_enterprise
+    if enterprise_id(observed_enterprise) != binding.enterprise_id:
+        raise SocialStoreError("Slack export enterprise identity does not match")
+    account = {
+        "id": account_id(expected_workspace, expected_user),
+        "provider_account_id": expected_user,
+        "workspace_id": expected_workspace,
+        "enterprise_id": binding.enterprise_id,
+        "token_type": binding.token_type,
+        "scopes": [],
+        "conversation_binding_sha256": request.profile.conversation_binding_sha256,
+        "username": selected.get("name"),
+        "workspace_name": team.get("name") if team else None,
+    }
+    return account, team or {"id": expected_workspace}
+
+
+def _folder_name(record: dict[str, Any], target: ConversationTarget) -> str:
+    folder = record.get("name") or target.conversation_id
+    if not isinstance(folder, str) or not folder:
+        raise SocialStoreError("Slack export conversation folder is invalid")
+    if folder in {".", ".."} or "\\" in folder or "\x00" in folder:
+        raise SocialStoreError("Slack export conversation folder is invalid")
+    if PurePosixPath(folder).name != folder:
+        raise SocialStoreError("Slack export conversation folder is invalid")
+    return folder
+
+
+def reference_record(
+    index: SlackArchiveIndex, target: ConversationTarget, max_items: int
+) -> tuple[dict[str, Any], str, int]:
+    reference_name = REFERENCE_FILES[target.kind]
+    if reference_name not in index.members:
+        raise SocialStoreError("Slack export lacks an allowlisted conversation class")
+    values = object_list(index.json_value(reference_name), reference_name, max_items)
+    matches = [item for item in values if item.get("id") == target.conversation_id]
+    if len(matches) != 1:
+        raise SocialStoreError("Slack export lacks an allowlisted conversation")
+    record = matches[0]
+    reject_slack_credentials(record)
+    members = record.get("members", [])
+    if not isinstance(members, list):
+        raise SocialStoreError("Slack export conversation members must be an array")
+    return record, _folder_name(record, target), len(members)
+
+
+def _is_message_member(name: str, prefix: str) -> bool:
+    if not name.startswith(prefix):
+        return False
+    path = PurePosixPath(name)
+    if len(path.parts) != 2:
+        return False
+    return DATE_MEMBER.fullmatch(path.name) is not None
+
+
+def conversation_member_names(index: SlackArchiveIndex, folder: str) -> list[str]:
+    prefix = f"{folder}/"
+    return sorted(name for name in index.members if _is_message_member(name, prefix))

--- a/.agents/scripts/_knowledge_social_slack_archive_select.py
+++ b/.agents/scripts/_knowledge_social_slack_archive_select.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Select and sanitize allowlisted evidence from one Slack export index."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_slack import parse_account_id
+from _knowledge_social_slack_archive_identity import (
+    REFERENCE_FILES,
+    conversation_member_names as _conversation_member_names,
+    identity as _identity,
+    object_list as _object_list,
+    reference_record as _reference_record,
+    users as _users,
+)
+from _knowledge_social_slack_archive_count import normalized_item_count
+from _knowledge_social_slack_archive_types import SlackArchiveRequest
+from _knowledge_social_slack_evidence_guard import reject_slack_credentials
+from _knowledge_social_slack_records import (
+    conversation_record,
+    membership_records,
+    message_record,
+    user_record,
+    workspace_record,
+)
+from _knowledge_social_slack_route_types import ConversationTarget
+from _knowledge_social_slack_zip import SlackArchiveIndex
+from knowledge_social_store import SocialStoreError
+
+@dataclass(frozen=True)
+class ArchiveSelection:
+    account: dict[str, Any]
+    records: list[dict[str, Any]]
+    selected_members: frozenset[str]
+    present: dict[str, int]
+
+
+@dataclass(frozen=True)
+class SelectionContext:
+    index: SlackArchiveIndex
+    workspace: str
+    max_items: int
+
+
+def _message_file_records(
+    context: SelectionContext,
+    name: str,
+    target: ConversationTarget,
+    remaining: int,
+) -> list[dict[str, Any]]:
+    messages = _object_list(
+        context.index.json_value(name), "conversation messages", context.max_items
+    )
+    records: list[dict[str, Any]] = []
+    for message in messages:
+        reject_slack_credentials(message)
+        expanded = message_record(message, context.workspace, target.conversation_id)
+        if len(records) + len(expanded) > remaining:
+            raise SocialStoreError("Slack export exceeds the normalized item budget")
+        records.extend(expanded)
+    return records
+
+
+def _conversation_records(
+    context: SelectionContext, target: ConversationTarget, remaining: int
+) -> tuple[list[dict[str, Any]], set[str], int, str]:
+    reference, folder, member_count = _reference_record(
+        context.index, target, context.max_items
+    )
+    records = [
+        conversation_record(
+            reference, context.workspace, target.conversation_id, target.kind
+        )
+    ]
+    records.extend(
+        membership_records(
+            reference.get("members", []),
+            context.workspace,
+            target.conversation_id,
+            min(context.max_items, max(member_count, 1)),
+        )
+    )
+    if len(records) > remaining:
+        raise SocialStoreError("Slack export exceeds the normalized item budget")
+    names = _conversation_member_names(context.index, folder)
+    for name in names:
+        records.extend(
+            _message_file_records(context, name, target, remaining - len(records))
+        )
+    return records, set(names), len(names), folder
+
+
+def _bind_folder(
+    bindings: dict[str, str], folder: str, conversation: str
+) -> None:
+    key = folder.casefold()
+    previous = bindings.get(key)
+    if previous is not None and previous != conversation:
+        raise SocialStoreError(
+            "Slack export conversation folder is bound to multiple IDs"
+        )
+    bindings[key] = conversation
+
+
+def _collect_conversations(
+    request: SlackArchiveRequest,
+    context: SelectionContext,
+    initial_count: int,
+) -> tuple[list[dict[str, Any]], set[str], dict[str, int]]:
+    records: list[dict[str, Any]] = []
+    members: set[str] = set()
+    present: dict[str, int] = {}
+    folders: dict[str, str] = {}
+    for alias, target in sorted(request.profile.conversations.items()):
+        remaining = request.max_items - initial_count - len(records)
+        selected, names, count, folder = _conversation_records(
+            context, target, remaining
+        )
+        _bind_folder(folders, folder, target.conversation_id)
+        records.extend(selected)
+        members.add(REFERENCE_FILES[target.kind])
+        members.update(names)
+        present[alias] = count
+    return records, members, present
+
+
+def _raw_user_ids(records: list[dict[str, Any]], selected: str) -> set[str]:
+    ids = {selected}
+    for record in records:
+        values = [record.get("actor_remote_id"), record.get("editor_remote_id")]
+        reactions = record.get("reactions", [])
+        if isinstance(reactions, list):
+            values.extend(
+                actor
+                for reaction in reactions
+                if isinstance(reaction, dict)
+                for actor in reaction.get("actor_remote_ids", [])
+                if isinstance(actor, str)
+            )
+        for value in values:
+            if not isinstance(value, str):
+                continue
+            try:
+                _workspace, native_user = parse_account_id(value)
+            except SocialStoreError:
+                continue
+            ids.add(native_user)
+    return ids
+
+
+def _append_selected_users(
+    records: list[dict[str, Any]],
+    users: list[dict[str, Any]],
+    account: dict[str, Any],
+    max_items: int,
+) -> None:
+    _workspace, selected_user = parse_account_id(account["id"])
+    wanted = _raw_user_ids(records, selected_user)
+    for item in users:
+        if item.get("id") not in wanted:
+            continue
+        reject_slack_credentials(item)
+        if len(records) >= max_items:
+            raise SocialStoreError("Slack export exceeds the normalized item budget")
+        records.append(user_record(item, account["workspace_id"]))
+
+
+def select_archive_records(
+    request: SlackArchiveRequest, index: SlackArchiveIndex
+) -> ArchiveSelection:
+    """Select allowlisted records while enforcing raw and normalized row budgets."""
+    users, users_member = _users(index, request.max_items)
+    account, workspace_value = _identity(request, index, users)
+    records = [workspace_record(workspace_value, account["workspace_id"])]
+    selected_members = {users_member}
+    if "team_info.json" in index.members:
+        selected_members.add("team_info.json")
+    context = SelectionContext(index, account["workspace_id"], request.max_items)
+    conversation_rows, conversation_members, present = _collect_conversations(
+        request, context, len(records)
+    )
+    records.extend(conversation_rows)
+    selected_members.update(conversation_members)
+    _append_selected_users(records, users, account, request.max_items)
+    if normalized_item_count(records, account) > request.max_items:
+        raise SocialStoreError("Slack export exceeds the normalized item budget")
+    return ArchiveSelection(account, records, frozenset(selected_members), present)

--- a/.agents/scripts/_knowledge_social_slack_archive_types.py
+++ b/.agents/scripts/_knowledge_social_slack_archive_types.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Data contracts for one bounded Slack administrator export import."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from _knowledge_social_slack_provider import ProfileConfig
+
+
+@dataclass(frozen=True)
+class SlackArchiveRequest:
+    """Operator-approved archive and bounded import policy."""
+
+    path: Path
+    connection_id: str
+    expected_account_id: str
+    exported_at: str
+    profile: ProfileConfig
+    max_bytes: int
+    max_items: int
+
+
+@dataclass(frozen=True)
+class ParsedSlackArchive:
+    """Validated filtered evidence plus one canonical Slack archive."""
+
+    archive: dict[str, Any]
+    evidence: bytes
+    source_sha256: str
+    evidence_sha256: str
+    conversation_streams: tuple[str, ...]
+    selected_members: int
+    normalized_items: int

--- a/.agents/scripts/_knowledge_social_slack_contract.py
+++ b/.agents/scripts/_knowledge_social_slack_contract.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validation primitives for the isolated Slack HTTP and export readers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_slack import (
+    SlackAdapterError,
+    account_id,
+    enterprise_id,
+    team_id,
+    token_type,
+    user_id,
+)
+
+MAX_TEXT_BYTES = 256 * 1024
+
+
+class SlackReadProviderError(SlackAdapterError):
+    """Raised for a privacy-safe local Slack provider failure."""
+
+
+class SlackAuthorizationError(SlackReadProviderError):
+    """Raised when a verified token lacks one required read capability."""
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    """One bounded Slack Web API result plus verified response metadata."""
+
+    status: int
+    payload: Any
+    scopes: frozenset[str]
+    retry_after: str | None = None
+
+
+@dataclass(frozen=True)
+class IdentityBinding:
+    """Non-secret profile authority that every live request must revalidate."""
+
+    workspace_id: str
+    enterprise_id: str | None
+    token_type: str
+
+
+def observed_at() -> str:
+    return (
+        datetime.now(UTC)
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def exact_keys(request: dict[str, Any], expected: set[str]) -> None:
+    if set(request) != expected:
+        raise SlackReadProviderError("Slack read request has an invalid action shape")
+
+
+def request_object(payload: bytes, limit: int) -> dict[str, Any]:
+    if len(payload) > limit:
+        raise SlackReadProviderError("Slack read request exceeds the safety limit")
+    try:
+        request = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise SlackReadProviderError("Slack read request is not valid JSON") from error
+    if not isinstance(request, dict):
+        raise SlackReadProviderError("Slack read request root must be an object")
+    return request
+
+
+def object_value(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise SlackReadProviderError(f"Slack {field} must be an object")
+    return value
+
+
+def object_list(value: Any, field: str, *, limit: int) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise SlackReadProviderError(f"Slack {field} must be an array of objects")
+    if len(value) > limit:
+        raise SlackReadProviderError(f"Slack {field} exceeds the item safety limit")
+    return value
+
+
+def optional_text(value: Any, field: str, *, limit: int = MAX_TEXT_BYTES) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value:
+        raise SlackReadProviderError(f"Slack {field} must be text")
+    if len(value.encode("utf-8")) > limit:
+        raise SlackReadProviderError(f"Slack {field} exceeds the safety limit")
+    return value
+
+
+def required_text(value: Any, field: str, *, limit: int = MAX_TEXT_BYTES) -> str:
+    text = optional_text(value, field, limit=limit)
+    if not text:
+        raise SlackReadProviderError(f"Slack {field} is required")
+    return text
+
+
+def optional_boolean(value: Any, field: str) -> bool | None:
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise SlackReadProviderError(f"Slack {field} must be boolean")
+    return value
+
+
+def non_negative_integer(
+    value: Any, field: str, *, optional: bool = False
+) -> int | None:
+    if value is None and optional:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise SlackReadProviderError(
+            f"Slack {field} must be a non-negative integer"
+        )
+    return value
+
+
+def _identity_token_type(payload: dict[str, Any]) -> str:
+    bot = payload.get("bot_id")
+    if bot is not None:
+        required_text(bot, "bot ID", limit=64)
+        return "bot"
+    return "user"
+
+
+def identity_value(
+    payload: Any,
+    expected_id: str,
+    binding: IdentityBinding,
+    scopes: frozenset[str],
+) -> dict[str, Any]:
+    """Serialize stable auth.test identity and fail closed on profile rebinding."""
+    root = object_value(payload, "identity response")
+    if root.get("ok") is not True:
+        raise SlackReadProviderError("Slack identity response is unsuccessful")
+    workspace = team_id(root.get("team_id"))
+    selected_user = user_id(root.get("user_id"))
+    enterprise = enterprise_id(root.get("enterprise_id"))
+    actual_type = _identity_token_type(root)
+    expected_workspace, expected_user = _expected_account(expected_id)
+    observed = (workspace, workspace, selected_user, enterprise, actual_type)
+    expected = (
+        binding.workspace_id,
+        expected_workspace,
+        expected_user,
+        binding.enterprise_id,
+        binding.token_type,
+    )
+    if observed != expected:
+        raise SlackReadProviderError(
+            "selected Slack workspace or account does not match the configured connection"
+        )
+    return {
+        "id": account_id(workspace, selected_user),
+        "provider_account_id": selected_user,
+        "workspace_id": workspace,
+        "enterprise_id": enterprise,
+        "token_type": token_type(actual_type),
+        "scopes": sorted(scopes),
+        "username": optional_text(root.get("user"), "account name"),
+        "workspace_name": optional_text(root.get("team"), "workspace name"),
+    }
+
+
+def _expected_account(value: Any) -> tuple[str, str]:
+    from _knowledge_social_slack import parse_account_id
+
+    return parse_account_id(value)
+
+
+def terminal_payload(result: ApiResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": result.status, "observed_at": observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload

--- a/.agents/scripts/_knowledge_social_slack_conversation_routes.py
+++ b/.agents/scripts/_knowledge_social_slack_conversation_routes.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Allowlisted conversation-specific Slack API routes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from _knowledge_social_slack import PageRequest, slack_timestamp
+from _knowledge_social_slack_contract import (
+    SlackReadProviderError,
+    non_negative_integer,
+    object_list,
+    object_value,
+)
+from _knowledge_social_slack_records import (
+    bookmark_record,
+    conversation_record,
+    file_records_for_conversation,
+    membership_records,
+    message_record,
+    newest_message_ts,
+    pin_record,
+)
+from _knowledge_social_slack_route_types import (
+    Api,
+    ConversationTarget,
+    PageResult,
+    next_cursor,
+    page_payload,
+    require_scope,
+    verified_result,
+)
+
+KIND_READ_SCOPE = {
+    "public_channel": "channels:read",
+    "private_channel": "groups:read",
+    "im": "im:read",
+    "mpim": "mpim:read",
+}
+KIND_HISTORY_SCOPE = {
+    "public_channel": "channels:history",
+    "private_channel": "groups:history",
+    "im": "im:history",
+    "mpim": "mpim:history",
+}
+SnapshotRecord = Callable[[dict[str, Any], str, str], dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class SnapshotRoute:
+    scope: str
+    endpoint: str
+    channel_key: str
+    response_key: str
+    label: str
+    record: SnapshotRecord
+
+
+SNAPSHOT_ROUTES = {
+    "pins": SnapshotRoute("pins:read", "pins.list", "channel", "items", "pins", pin_record),
+    "bookmarks": SnapshotRoute(
+        "bookmarks:read",
+        "bookmarks.list",
+        "channel_id",
+        "bookmarks",
+        "bookmarks",
+        bookmark_record,
+    ),
+}
+
+
+def _target(
+    request: PageRequest, conversations: dict[str, ConversationTarget]
+) -> ConversationTarget:
+    alias = request.conversation_alias
+    if alias is None or alias not in conversations:
+        raise SlackReadProviderError("Slack conversation is not allowlisted")
+    target = conversations[alias]
+    if target.alias != alias:
+        raise SlackReadProviderError("Slack conversation alias was rebound")
+    return target
+
+
+def _conversation_info(
+    api: Api, request: PageRequest, identity: dict[str, Any], target: ConversationTarget
+) -> PageResult:
+    require_scope(identity, KIND_READ_SCOPE[target.kind])
+    result = verified_result(
+        api("conversations.info", {"channel": target.conversation_id}), identity
+    )
+    if result.status != 200:
+        return result
+    root = object_value(result.payload, "conversation response")
+    record = conversation_record(
+        root.get("channel"), request.workspace_id, target.conversation_id, target.kind
+    )
+    return page_payload(request, [record], None)
+
+
+def _members(
+    api: Api, request: PageRequest, identity: dict[str, Any], target: ConversationTarget
+) -> PageResult:
+    require_scope(identity, KIND_READ_SCOPE[target.kind])
+    params = {"channel": target.conversation_id, "limit": str(request.limit)}
+    if request.cursor:
+        params["cursor"] = request.cursor
+    result = verified_result(api("conversations.members", params), identity)
+    if result.status != 200:
+        return result
+    root = object_value(result.payload, "conversation members response")
+    records = membership_records(
+        root.get("members"), request.workspace_id, target.conversation_id, request.limit
+    )
+    return page_payload(request, records, next_cursor(root))
+
+
+def _message_request(
+    request: PageRequest, target: ConversationTarget
+) -> tuple[str, dict[str, str]]:
+    endpoint = "conversations.history"
+    params = {"channel": target.conversation_id, "limit": str(request.limit)}
+    if request.selector == "thread":
+        endpoint = "conversations.replies"
+        if request.thread_ts is None:
+            raise SlackReadProviderError("Slack thread timestamp is missing")
+        params["ts"] = request.thread_ts
+    if request.cursor:
+        params["cursor"] = request.cursor
+    if request.oldest:
+        params.update({"oldest": request.oldest, "inclusive": "true"})
+    return endpoint, params
+
+
+def _validate_thread_message(message: dict[str, Any], expected: str) -> None:
+    message_ts = slack_timestamp(message.get("ts"), "thread message timestamp")
+    thread_value = message.get("thread_ts")
+    if message_ts == expected:
+        if thread_value is None:
+            return
+        if slack_timestamp(thread_value, "thread timestamp") != expected:
+            raise SlackReadProviderError(
+                "Slack thread response contains a rebound root"
+            )
+        return
+    if thread_value is None:
+        raise SlackReadProviderError(
+            "Slack thread response contains an unrelated message"
+        )
+    if slack_timestamp(thread_value, "thread timestamp") != expected:
+        raise SlackReadProviderError(
+            "Slack thread response contains an unrelated message"
+        )
+
+
+def _validate_thread_response(
+    request: PageRequest, messages: list[dict[str, Any]]
+) -> None:
+    if request.selector != "thread":
+        return
+    expected = slack_timestamp(request.thread_ts, "requested thread timestamp")
+    for message in messages:
+        _validate_thread_message(message, expected)
+
+
+def _messages(
+    api: Api, request: PageRequest, identity: dict[str, Any], target: ConversationTarget
+) -> PageResult:
+    require_scope(identity, KIND_HISTORY_SCOPE[target.kind])
+    endpoint, params = _message_request(request, target)
+    result = verified_result(api(endpoint, params), identity)
+    if result.status != 200:
+        return result
+    root = object_value(result.payload, "conversation messages response")
+    messages = object_list(root.get("messages"), "messages", limit=request.limit)
+    _validate_thread_response(request, messages)
+    records = [
+        record
+        for message in messages
+        for record in message_record(message, request.workspace_id, target.conversation_id)
+    ]
+    return page_payload(request, records, next_cursor(root), newest_message_ts(records))
+
+
+def _snapshot(
+    api: Api,
+    request: PageRequest,
+    identity: dict[str, Any],
+    target: ConversationTarget,
+    route: SnapshotRoute,
+) -> PageResult:
+    require_scope(identity, route.scope)
+    params = {route.channel_key: target.conversation_id}
+    result = verified_result(api(route.endpoint, params), identity)
+    if result.status != 200:
+        return result
+    root = object_value(result.payload, f"{route.label} response")
+    items = object_list(root.get(route.response_key), route.label, limit=100)
+    records = [
+        route.record(item, request.workspace_id, target.conversation_id)
+        for item in items
+    ]
+    return page_payload(request, records, None)
+
+
+def _file_page(cursor: str | None) -> int:
+    if cursor is None:
+        return 1
+    if not cursor.startswith("page:") or not cursor[5:].isdigit():
+        raise SlackReadProviderError("Slack file page cursor is invalid")
+    page_number = int(cursor[5:])
+    if not 1 <= page_number <= 1_000_000:
+        raise SlackReadProviderError("Slack file page cursor is outside the safety limit")
+    return page_number
+
+
+def _next_file_cursor(root: dict[str, Any], page_number: int) -> str | None:
+    paging = object_value(root.get("paging", {}), "file paging")
+    pages = non_negative_integer(paging.get("pages", 1), "file page count") or 1
+    current = non_negative_integer(paging.get("page", page_number), "file page") or 1
+    if current != page_number or pages > 1_000_000:
+        raise SlackReadProviderError("Slack file paging metadata is invalid")
+    return f"page:{current + 1}" if current < pages else None
+
+
+def _files(
+    api: Api, request: PageRequest, identity: dict[str, Any], target: ConversationTarget
+) -> PageResult:
+    require_scope(identity, "files:read")
+    page_number = _file_page(request.cursor)
+    result = verified_result(
+        api(
+            "files.list",
+            {
+                "channel": target.conversation_id,
+                "count": str(request.limit),
+                "page": str(page_number),
+                "show_files_hidden_by_limit": "false",
+            },
+        ),
+        identity,
+    )
+    if result.status != 200:
+        return result
+    root = object_value(result.payload, "files response")
+    records = file_records_for_conversation(
+        root.get("files"),
+        request.workspace_id,
+        request.limit,
+        target.conversation_id,
+    )
+    return page_payload(request, records, _next_file_cursor(root, page_number))
+
+
+TargetRoute = Callable[[Api, PageRequest, dict[str, Any], ConversationTarget], PageResult]
+TARGET_ROUTES: dict[str, TargetRoute] = {
+    "info": _conversation_info,
+    "members": _members,
+    "history": _messages,
+    "thread": _messages,
+    "files": _files,
+}
+
+
+def conversation_page(
+    api: Api,
+    request: PageRequest,
+    identity: dict[str, Any],
+    conversations: dict[str, ConversationTarget],
+) -> PageResult:
+    """Execute one route scoped to a profile-approved conversation."""
+    target = _target(request, conversations)
+    snapshot = SNAPSHOT_ROUTES.get(request.selector)
+    if snapshot is not None:
+        return _snapshot(api, request, identity, target, snapshot)
+    handler = TARGET_ROUTES.get(request.selector)
+    if handler is None:
+        raise SlackReadProviderError("Slack stream is unsupported")
+    return handler(api, request, identity, target)

--- a/.agents/scripts/_knowledge_social_slack_evidence_guard.py
+++ b/.agents/scripts/_knowledge_social_slack_evidence_guard.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Reject high-confidence Slack secrets before evidence persistence."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from _knowledge_social_slack_identity import SlackAdapterError
+from knowledge_source_contract import (
+    SourceContractError,
+    reject_credentials as reject_credential_keys,
+)
+
+SLACK_TOKEN = re.compile(
+    r"(?<![A-Za-z0-9])(?:xox[a-z]|xapp)-"
+    r"(?=[A-Za-z0-9-]{24,200}(?![A-Za-z0-9-]))"
+    r"(?=[A-Za-z0-9-]*[A-Za-z])(?=[A-Za-z0-9-]*[0-9])"
+    r"[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+(?![A-Za-z0-9])",
+    re.IGNORECASE,
+)
+SLACK_WEBHOOK = re.compile(
+    r"https://hooks\.slack\.com/(?:services|triggers|workflows)/"
+    r"[A-Za-z0-9/_-]{20,}",
+    re.IGNORECASE,
+)
+MIN_TOKEN_SYMBOLS = 8
+
+
+def _contains_slack_token(value: str) -> bool:
+    for match in SLACK_TOKEN.finditer(value):
+        token_body = match.group().split("-", 1)[1]
+        symbols = {character.lower() for character in token_body if character.isalnum()}
+        if len(symbols) >= MIN_TOKEN_SYMBOLS:
+            return True
+    return False
+
+
+def _contains_credential(value: Any, exact_secret: str | None) -> bool:
+    if isinstance(value, str):
+        exact_match = (
+            exact_secret is not None
+            and len(exact_secret) >= 16
+            and exact_secret in value
+        )
+        return exact_match or _contains_slack_token(value) or bool(
+            SLACK_WEBHOOK.search(value)
+        )
+    if isinstance(value, dict):
+        return any(
+            _contains_credential(child, exact_secret) for child in value.values()
+        )
+    if isinstance(value, list):
+        return any(_contains_credential(child, exact_secret) for child in value)
+    return False
+
+
+def reject_slack_credentials(
+    value: Any, *, exact_secret: str | None = None
+) -> None:
+    """Reject credential keys and high-confidence Slack secret scalar values."""
+    try:
+        reject_credential_keys(value)
+    except SourceContractError as error:
+        raise SlackAdapterError(
+            "Slack evidence contains forbidden credential material"
+        ) from error
+    if _contains_credential(value, exact_secret):
+        raise SlackAdapterError(
+            "Slack evidence contains forbidden credential material"
+        )

--- a/.agents/scripts/_knowledge_social_slack_fields.py
+++ b/.agents/scripts/_knowledge_social_slack_fields.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validate primitive fields in sanitized Slack provider records."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from _knowledge_social_slack import SlackAdapterError
+
+
+def required(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise SlackAdapterError(f"Slack record requires {key}")
+    return value
+
+
+def optional(record: dict[str, Any], key: str) -> str | None:
+    value = record.get(key)
+    if value is not None and (not isinstance(value, str) or "\x00" in value):
+        raise SlackAdapterError(f"Slack record {key} must be text")
+    return value

--- a/.agents/scripts/_knowledge_social_slack_http.py
+++ b/.agents/scripts/_knowledge_social_slack_http.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Exact-route, redirect-free, standard-library Slack Web API transport."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from _knowledge_social_slack_contract import ApiResult, SlackReadProviderError
+
+API_BASE = "https://slack.com/api"
+HTTP_TIMEOUT_SECONDS = 60
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+MAX_RETRY_SECONDS = 31 * 24 * 60 * 60
+READ_METHODS = {
+    "auth.test": "POST",
+    "team.info": "GET",
+    "users.list": "GET",
+    "conversations.info": "GET",
+    "conversations.members": "GET",
+    "conversations.history": "GET",
+    "conversations.replies": "GET",
+    "pins.list": "GET",
+    "bookmarks.list": "POST",
+    "files.list": "GET",
+    "reactions.list": "GET",
+}
+READ_SCOPES = frozenset(
+    {
+        "team:read",
+        "users:read",
+        "channels:read",
+        "groups:read",
+        "im:read",
+        "mpim:read",
+        "channels:history",
+        "groups:history",
+        "im:history",
+        "mpim:history",
+        "reactions:read",
+        "files:read",
+        "pins:read",
+        "bookmarks:read",
+    }
+)
+
+AUTH_ERRORS = frozenset(
+    {"invalid_auth", "not_authed", "token_expired", "token_revoked", "account_inactive"}
+)
+AUTHORIZATION_ERRORS = frozenset(
+    {
+        "access_denied",
+        "missing_scope",
+        "no_permission",
+        "not_allowed_token_type",
+        "not_in_channel",
+        "team_access_not_granted",
+        "enterprise_is_restricted",
+        "ekm_access_denied",
+    }
+)
+UNAVAILABLE_ERRORS = frozenset(
+    {
+        "channel_not_found",
+        "file_not_found",
+        "thread_not_found",
+        "method_not_supported_for_channel_type",
+        "not_implemented",
+    }
+)
+PROVIDER_ERRORS = frozenset(
+    {"fatal_error", "internal_error", "service_unavailable", "request_timeout"}
+)
+
+
+class ResponseHeaders(Protocol):
+    def get(self, name: str, default: Any = None) -> Any: ...
+
+
+class Opener(Protocol):
+    def open(self, request: Request, timeout: int) -> Any: ...
+
+
+class _RejectRedirects(HTTPRedirectHandler):
+    def redirect_request(
+        self, *_args: Any, **_kwargs: Any
+    ) -> None:
+        return None
+
+
+def _http_exports() -> Opener:
+    if not all(callable(value) for value in (Request, build_opener, urlencode)):
+        raise SlackReadProviderError("Python urllib HTTP exports are unavailable")
+    return build_opener(_RejectRedirects())
+
+
+def _decode(payload: bytes) -> dict[str, Any]:
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise SlackReadProviderError("Slack HTTP response exceeds the safety limit")
+    try:
+        parsed = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise SlackReadProviderError("Slack HTTP response is not valid JSON") from error
+    if not isinstance(parsed, dict):
+        raise SlackReadProviderError("Slack HTTP response root must be an object")
+    return parsed
+
+
+def _response_bytes(response: Any) -> bytes:
+    payload = response.read(MAX_RESPONSE_BYTES + 1)
+    if not isinstance(payload, bytes):
+        raise SlackReadProviderError("Slack HTTP response is invalid")
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise SlackReadProviderError("Slack HTTP response exceeds the safety limit")
+    return payload
+
+
+def _scopes(headers: ResponseHeaders, *, required: bool) -> frozenset[str]:
+    value = headers.get("X-OAuth-Scopes")
+    if value is None:
+        if required:
+            raise SlackReadProviderError("Slack response did not attest token scopes")
+        return frozenset()
+    if not isinstance(value, str) or "\x00" in value:
+        raise SlackReadProviderError("Slack response scope attestation is invalid")
+    scopes = frozenset(part.strip() for part in value.split(",") if part.strip())
+    if not scopes or any(scope not in READ_SCOPES for scope in scopes):
+        raise SlackReadProviderError("Slack token includes an unsupported or write scope")
+    return scopes
+
+
+def _retry_after(headers: ResponseHeaders) -> str | None:
+    value = headers.get("Retry-After")
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.isascii() or not value.isdigit():
+        raise SlackReadProviderError("Slack Retry-After header is invalid")
+    seconds = int(value)
+    if not 1 <= seconds <= MAX_RETRY_SECONDS:
+        raise SlackReadProviderError("Slack Retry-After header is outside the safety limit")
+    return value
+
+
+def _error_status(payload: dict[str, Any], http_status: int) -> int:
+    error = payload.get("error")
+    status = 400
+    if error == "ratelimited" or http_status == 429:
+        status = 429
+    elif error in AUTH_ERRORS or http_status == 401:
+        status = 401
+    elif error in AUTHORIZATION_ERRORS or http_status == 403:
+        status = 403
+    elif error in UNAVAILABLE_ERRORS or http_status == 404:
+        status = 404
+    elif error in PROVIDER_ERRORS or http_status >= 500:
+        status = 500
+    return status
+
+
+def _result(payload: dict[str, Any], status: int, headers: ResponseHeaders) -> ApiResult:
+    successful = status == 200 and payload.get("ok") is True
+    scopes = _scopes(headers, required=successful)
+    retry_after = _retry_after(headers)
+    if successful:
+        return ApiResult(200, payload, scopes, retry_after)
+    return ApiResult(_error_status(payload, status), {}, scopes, retry_after)
+
+
+def api(
+    token: str,
+    opener: Opener,
+    endpoint: str,
+    params: dict[str, str],
+) -> ApiResult:
+    """Execute one reviewed Slack read method without redirects or token URLs."""
+    method = READ_METHODS.get(endpoint)
+    if method is None:
+        raise SlackReadProviderError("Slack API endpoint is not allowlisted")
+    encoded = urlencode(params).encode("utf-8")
+    url = f"{API_BASE}/{endpoint}"
+    data: bytes | None = None
+    if method == "GET":
+        if encoded:
+            url = f"{url}?{encoded.decode('ascii')}"
+    else:
+        data = encoded
+    request = Request(
+        url,
+        data=data,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+            "User-Agent": "aidevops-slack-knowledge/1",
+        },
+        method=method,
+    )
+    try:
+        with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", 200)
+            if isinstance(status, bool) or not isinstance(status, int):
+                raise SlackReadProviderError("Slack HTTP status is invalid")
+            return _result(_decode(_response_bytes(response)), status, response.headers)
+    except HTTPError as error:
+        try:
+            payload = _decode(_response_bytes(error))
+        except SlackReadProviderError:
+            payload = {}
+        return _result(payload, int(error.code), error.headers)
+    except (TimeoutError, URLError, OSError) as error:
+        raise SlackReadProviderError("Slack read provider request failed") from error

--- a/.agents/scripts/_knowledge_social_slack_identity.py
+++ b/.agents/scripts/_knowledge_social_slack_identity.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validate and namespace immutable Slack workspace identities."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+from typing import Any
+
+from knowledge_social_import import canonical_json
+from knowledge_social_store import SocialStoreError
+
+TOKEN_TYPES = frozenset({"bot", "user"})
+CONVERSATION_KINDS = frozenset(
+    {"public_channel", "private_channel", "im", "mpim"}
+)
+ALIAS = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
+SLACK_TEAM_ID = re.compile(r"^T[A-Z0-9]{2,31}$")
+SLACK_ENTERPRISE_ID = re.compile(r"^E[A-Z0-9]{2,31}$")
+SLACK_USER_ID = re.compile(r"^[UW][A-Z0-9]{2,31}$")
+SLACK_CONVERSATION_ID = re.compile(r"^[CDG][A-Z0-9]{2,31}$")
+SLACK_TIMESTAMP = re.compile(r"^[0-9]{1,16}\.[0-9]{6}$")
+ACCOUNT_ID = re.compile(r"^slack_(T[A-Z0-9]{2,31})_user_([UW][A-Z0-9]{2,31})$")
+
+
+class SlackAdapterError(SocialStoreError):
+    """Raised when bounded Slack collection cannot continue safely."""
+
+
+class SlackProviderUnavailableError(SlackAdapterError):
+    """Raised when the isolated Slack reader cannot complete a read."""
+
+
+def _slack_id(value: Any, field: str, pattern: re.Pattern[str]) -> str:
+    if not isinstance(value, str) or pattern.fullmatch(value) is None:
+        raise SlackAdapterError(f"Slack {field} is invalid")
+    return value
+
+
+def team_id(value: Any) -> str:
+    return _slack_id(value, "workspace ID", SLACK_TEAM_ID)
+
+
+def enterprise_id(value: Any, *, optional: bool = True) -> str | None:
+    if value is None and optional:
+        return None
+    return _slack_id(value, "enterprise ID", SLACK_ENTERPRISE_ID)
+
+
+def user_id(value: Any) -> str:
+    return _slack_id(value, "user ID", SLACK_USER_ID)
+
+
+def conversation_id(value: Any) -> str:
+    return _slack_id(value, "conversation ID", SLACK_CONVERSATION_ID)
+
+
+def slack_timestamp(value: Any, field: str = "timestamp") -> str:
+    return _slack_id(value, field, SLACK_TIMESTAMP)
+
+
+def token_type(value: Any) -> str:
+    if value not in TOKEN_TYPES:
+        raise SlackAdapterError("Slack token type must be bot or user")
+    return str(value)
+
+
+def account_id(workspace: str, user: str) -> str:
+    return f"slack_{team_id(workspace)}_user_{user_id(user)}"
+
+
+def parse_account_id(value: Any) -> tuple[str, str]:
+    if not isinstance(value, str):
+        raise SlackAdapterError("Slack account ID is invalid")
+    match = ACCOUNT_ID.fullmatch(value)
+    if match is None:
+        raise SlackAdapterError("Slack account ID is invalid")
+    return match.group(1), match.group(2)
+
+
+def conversation_binding_sha256(value: Any) -> str:
+    """Hash one exact alias-to-conversation policy after full validation."""
+    if not isinstance(value, dict) or len(value) > 500:
+        raise SlackAdapterError("Slack conversation binding is invalid")
+    prefixes = {
+        "public_channel": "C",
+        "private_channel": "G",
+        "im": "D",
+        "mpim": "G",
+    }
+    normalized: dict[str, dict[str, str]] = {}
+    for alias, target in value.items():
+        if not isinstance(alias, str) or ALIAS.fullmatch(alias) is None:
+            raise SlackAdapterError("Slack conversation alias is invalid")
+        if not isinstance(target, dict) or set(target) != {"id", "kind"}:
+            raise SlackAdapterError("Slack conversation binding is invalid")
+        native_id = conversation_id(target.get("id"))
+        kind = target.get("kind")
+        prefix = prefixes.get(str(kind))
+        if prefix is None or not native_id.startswith(prefix):
+            raise SlackAdapterError("Slack conversation ID and kind conflict")
+        normalized[alias] = {"id": native_id, "kind": str(kind)}
+    native_ids = {target["id"] for target in normalized.values()}
+    if len(native_ids) != len(normalized):
+        raise SlackAdapterError("Slack conversation binding contains duplicate IDs")
+    payload = canonical_json(normalized).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def namespaced_id(workspace: str, kind: str, native_id: Any) -> str:
+    """Build one API/export-stable identity from reviewed Slack native IDs."""
+    workspace = team_id(workspace)
+    if not isinstance(kind, str) or not re.fullmatch(r"[a-z][a-z_]{1,31}", kind):
+        raise SlackAdapterError("Slack identity kind is invalid")
+    if not isinstance(native_id, str) or not native_id or "\x00" in native_id:
+        raise SlackAdapterError("Slack native identity is invalid")
+    if len(native_id.encode("utf-8")) > 256:
+        raise SlackAdapterError("Slack native identity exceeds the safety limit")
+    encoded = base64.urlsafe_b64encode(native_id.encode("utf-8")).decode("ascii")
+    return f"slack_{workspace}_{kind}_{encoded.rstrip('=')}"

--- a/.agents/scripts/_knowledge_social_slack_message_records.py
+++ b/.agents/scripts/_knowledge_social_slack_message_records.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Sanitize Slack messages, reactions, and file metadata."""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+from typing import Any
+
+from _knowledge_social_slack import conversation_id, namespaced_id, slack_timestamp
+from _knowledge_social_slack_contract import (
+    SlackReadProviderError,
+    non_negative_integer,
+    object_list,
+    object_value,
+    optional_boolean,
+    optional_text,
+    required_text,
+)
+from _knowledge_social_slack_record_contract import (
+    ACTOR_ID,
+    FILE_ID,
+    actor_id,
+    epoch_iso,
+    stable_id,
+    timestamp_iso,
+)
+
+REACTION_NAME = re.compile(r"^[A-Za-z0-9_+\-]{1,128}$")
+MAX_REACTIONS = 100
+MAX_REACTION_USERS = 1000
+MAX_REACTION_ACTORS_PER_MESSAGE = 100
+MAX_FILES_PER_MESSAGE = 100
+MAX_FILE_CONVERSATIONS = 1000
+
+
+def _file_record(
+    payload: Any, workspace: str, object_remote_id: str | None = None
+) -> dict[str, Any]:
+    item = object_value(payload, "file")
+    native_id = stable_id(item.get("id"), "file ID", FILE_ID)
+    return {
+        "kind": "file",
+        "remote_id": namespaced_id(workspace, "file", native_id),
+        "file_id": native_id,
+        "object_remote_id": object_remote_id,
+        "actor_remote_id": actor_id(item.get("user"), workspace),
+        "name": optional_text(item.get("name"), "file name", limit=4096),
+        "title": optional_text(item.get("title"), "file title", limit=4096),
+        "mimetype": optional_text(item.get("mimetype"), "file MIME type", limit=255),
+        "size": non_negative_integer(item.get("size"), "file size", optional=True),
+        "created_at": epoch_iso(item.get("timestamp"), "file timestamp"),
+        "is_tombstoned": optional_boolean(
+            item.get("is_tombstoned"), "file tombstone flag"
+        ) or False,
+    }
+
+
+def file_records(
+    values: Any, workspace: str, limit: int, object_remote_id: str | None = None
+) -> list[dict[str, Any]]:
+    return [
+        _file_record(item, workspace, object_remote_id)
+        for item in object_list(values, "files", limit=limit)
+    ]
+
+
+def _file_conversation_ids(payload: dict[str, Any]) -> frozenset[str]:
+    visible_in: set[str] = set()
+    for field in ("channels", "groups", "ims"):
+        values = payload.get(field, [])
+        if not isinstance(values, list) or len(values) > MAX_FILE_CONVERSATIONS:
+            raise SlackReadProviderError(
+                "Slack file conversations exceed the item limit"
+            )
+        visible_in.update(conversation_id(value) for value in values)
+    return frozenset(visible_in)
+
+
+def file_records_for_conversation(
+    values: Any, workspace: str, limit: int, expected_conversation: str
+) -> list[dict[str, Any]]:
+    """Keep only files that explicitly attest the requested conversation."""
+    expected = conversation_id(expected_conversation)
+    return [
+        _file_record(value, workspace)
+        for value in object_list(values, "files", limit=limit)
+        if expected in _file_conversation_ids(value)
+    ]
+
+
+def _reactions(values: Any, workspace: str) -> list[dict[str, Any]]:
+    if values is None:
+        return []
+    source = object_list(values, "message reactions", limit=MAX_REACTIONS)
+    records: list[dict[str, Any]] = []
+    actor_count = 0
+    seen_names: set[str] = set()
+    for reaction in source:
+        name = stable_id(reaction.get("name"), "reaction name", REACTION_NAME)
+        if name in seen_names:
+            raise SlackReadProviderError("Slack message reaction names are duplicated")
+        seen_names.add(name)
+        count = non_negative_integer(reaction.get("count"), "reaction count")
+        users = reaction.get("users", [])
+        if not isinstance(users, list) or len(users) > MAX_REACTION_USERS:
+            raise SlackReadProviderError("Slack reaction users exceed the item limit")
+        actor_count += len(users)
+        if actor_count > MAX_REACTION_ACTORS_PER_MESSAGE:
+            raise SlackReadProviderError(
+                "Slack message reaction actors exceed the item limit"
+            )
+        actors = [
+            actor_id(stable_id(value, "reaction user ID", ACTOR_ID), workspace)
+            for value in users
+        ]
+        if len(set(actors)) != len(actors):
+            raise SlackReadProviderError("Slack message reaction actors are inconsistent")
+        if count is not None and count < len(actors):
+            raise SlackReadProviderError("Slack message reaction actors are inconsistent")
+        records.append(
+            {
+                "name": name,
+                "count": count,
+                "actor_remote_ids": actors,
+                "actors_truncated": count is not None and count > len(actors),
+            }
+        )
+    return records
+
+
+def _message_source(payload: dict[str, Any]) -> tuple[dict[str, Any], str, str]:
+    subtype = optional_text(payload.get("subtype"), "message subtype", limit=128)
+    subtype = subtype or "message"
+    if subtype == "message_changed" and isinstance(payload.get("message"), dict):
+        source = object_value(payload["message"], "changed message")
+        native_ts = slack_timestamp(source.get("ts"), "changed message timestamp")
+        return source, native_ts, "edited"
+    if subtype in {"message_changed", "message_deleted"}:
+        original = payload.get("original_ts", payload.get("deleted_ts"))
+        native_ts = slack_timestamp(original, "original message timestamp")
+        state = "deleted" if subtype == "message_deleted" else "edited"
+        return payload, native_ts, state
+    native_ts = slack_timestamp(payload.get("ts"), "message timestamp")
+    state = "edited" if isinstance(payload.get("edited"), dict) else "active"
+    return payload, native_ts, state
+
+
+def message_record(
+    payload: Any, workspace: str, native_conversation: str
+) -> list[dict[str, Any]]:
+    outer = object_value(payload, "message")
+    source, native_ts, state = _message_source(outer)
+    conversation = conversation_id(native_conversation)
+    remote_id = namespaced_id(workspace, "message", f"{conversation}:{native_ts}")
+    subtype = optional_text(outer.get("subtype"), "message subtype", limit=128)
+    text = None if state == "deleted" else optional_text(source.get("text"), "message text")
+    thread_ts = source.get("thread_ts", outer.get("thread_ts"))
+    thread_remote_id = None
+    if thread_ts is not None:
+        thread_remote_id = namespaced_id(
+            workspace,
+            "message",
+            f"{conversation}:{slack_timestamp(thread_ts, 'thread timestamp')}",
+        )
+    edited = source.get("edited")
+    edited_ts = None
+    editor_value = None
+    if isinstance(edited, dict):
+        edited_ts = timestamp_iso(edited.get("ts"), "edited timestamp")
+        editor_value = edited.get("user")
+    elif state in {"edited", "deleted"}:
+        edited_ts = timestamp_iso(outer.get("ts"), "change timestamp")
+        editor_value = outer.get("editor_id", outer.get("user"))
+    actor_value = source.get(
+        "user", outer.get("user", outer.get("editor_id", source.get("bot_id")))
+    )
+    message = {
+        "kind": "message",
+        "remote_id": remote_id,
+        "conversation_remote_id": namespaced_id(
+            workspace, "conversation", conversation
+        ),
+        "message_ts": native_ts,
+        "thread_remote_id": thread_remote_id,
+        "actor_remote_id": actor_id(actor_value, workspace),
+        "editor_remote_id": (
+            actor_id(editor_value, workspace) if editor_value is not None else None
+        ),
+        "text": text,
+        "subtype": subtype,
+        "state": state,
+        "created_at": timestamp_iso(native_ts, "message timestamp"),
+        "edited_at": edited_ts,
+        "reactions": _reactions(source.get("reactions"), workspace),
+        "is_starred": optional_boolean(source.get("is_starred"), "starred flag")
+        or False,
+    }
+    files = file_records(
+        source.get("files", []), workspace, MAX_FILES_PER_MESSAGE, remote_id
+    )
+    return [message, *files]
+
+
+def reaction_item_records(
+    payload: Any, workspace: str, allowed_conversations: frozenset[str]
+) -> list[dict[str, Any]]:
+    item = object_value(payload, "reaction item")
+    item_type = required_text(item.get("type"), "reaction item type", limit=64)
+    channel = item.get("channel")
+    if item_type == "message":
+        native_channel = conversation_id(channel)
+        if native_channel not in allowed_conversations:
+            return []
+        return message_record(item.get("message"), workspace, native_channel)
+    if item_type == "file":
+        file_value = object_value(item.get("file"), "reaction file")
+        if allowed_conversations.isdisjoint(_file_conversation_ids(file_value)):
+            return []
+        return [_file_record(file_value, workspace)]
+    return []
+
+
+def newest_message_ts(records: list[dict[str, Any]]) -> str | None:
+    timestamps = [
+        item["message_ts"]
+        for item in records
+        if item.get("kind") == "message" and isinstance(item.get("message_ts"), str)
+    ]
+    return max(timestamps, key=Decimal) if timestamps else None

--- a/.agents/scripts/_knowledge_social_slack_normalize.py
+++ b/.agents/scripts/_knowledge_social_slack_normalize.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize allowlisted Slack API/export records into canonical evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_slack import PROVIDER, RETENTION_LIMIT, SlackAdapterError, namespaced_id
+from _knowledge_social_slack_activities import record_activities as _record_activities
+from _knowledge_social_slack_evidence_guard import reject_slack_credentials
+from _knowledge_social_slack_fields import optional as _optional
+from _knowledge_social_slack_fields import required as _required
+from _knowledge_social_slack_records import validate_record
+
+API_SOURCE = "slack_web_api"
+EXPORT_SOURCE = "slack_admin_json_export"
+OBJECT_KINDS = frozenset({"workspace", "conversation", "message", "bookmark", "pin", "file"})
+API_GAPS = (
+    ("api_unallowlisted_conversations", "conversation_allowlist_excludes_other_workspace_content"),
+    ("api_retention_history", "workspace_plan_retention_and_membership_bound_results"),
+    ("api_deleted_content", "deleted_or_purged_content_is_not_guaranteed"),
+    ("api_file_binaries", "file_binary_hydration_is_disabled"),
+    ("api_reaction_actors", "reaction_actor_lists_may_be_truncated"),
+    ("api_historical_edits", "incremental_refresh_uses_a_seven_day_overlap"),
+    (
+        "api_snapshot_removals",
+        "removed_reactions_pins_bookmarks_memberships_and_files_are_not_reconciled",
+    ),
+    ("api_rich_message_surfaces", "blocks_attachments_canvases_and_huddles_are_not_normalized"),
+)
+IMMUTABLE_POLICY_FIELDS = (
+    "slack_workspace_id",
+    "slack_enterprise_id",
+    "slack_token_type",
+    "slack_conversation_binding_sha256",
+)
+
+
+@dataclass(frozen=True)
+class PageContext:
+    """Validated connection policy needed to normalize one Slack page."""
+
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class NormalizationBatch:
+    """Observation metadata applied to one bounded record batch."""
+
+    observed_at: str
+    source: str
+    coverage: tuple[dict[str, Any], ...] = ()
+
+
+def canonical_observed_at(value: Any, field: str = "page observed_at") -> str:
+    """Normalize one zoned observation time for sortable durable comparisons."""
+    if (
+        not isinstance(value, str)
+        or not value
+        or "\x00" in value
+        or len(value) > 64
+    ):
+        raise SlackAdapterError(f"Slack {field} must be ISO-8601 text")
+    text = f"{value[:-1]}+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as error:
+        raise SlackAdapterError(f"Slack {field} must be ISO-8601 text") from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise SlackAdapterError(f"Slack {field} requires a timezone")
+    return (
+        parsed.astimezone(UTC)
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _observed_at(payload: dict[str, Any]) -> str:
+    return canonical_observed_at(payload.get("observed_at"))
+
+
+def _source(payload: dict[str, Any]) -> str:
+    meta = payload.get("meta")
+    if not isinstance(meta, dict) or meta.get("source") not in {API_SOURCE, EXPORT_SOURCE}:
+        raise SlackAdapterError("Slack page provenance is invalid")
+    return str(meta["source"])
+
+
+def _text(record: dict[str, Any]) -> str | None:
+    values = [
+        value
+        for key in ("text", "title", "name", "topic", "purpose")
+        if (value := _optional(record, key))
+    ]
+    return "\n\n".join(values) or None
+
+
+def _provider_json(record: dict[str, Any], source: str) -> dict[str, Any]:
+    value = {"source": source, "record": record}
+    reject_slack_credentials(value)
+    return value
+
+
+def _object_row(
+    record: dict[str, Any], selected_id: str, observed_at: str, source: str
+) -> dict[str, Any] | None:
+    kind = _required(record, "kind")
+    if kind not in OBJECT_KINDS:
+        return None
+    actor = _optional(record, "actor_remote_id")
+    evidence_class = "authored" if actor == selected_id and kind == "message" else "observed"
+    return {
+        "object_type": kind,
+        "remote_id": _required(record, "remote_id"),
+        "account_remote_id": actor,
+        "text": _text(record),
+        "created_at": _optional(record, "created_at"),
+        "observed_at": observed_at,
+        "evidence_class": evidence_class,
+        "provider_json": _provider_json(record, source),
+    }
+
+
+def _account_rows(
+    records: list[dict[str, Any]], context: PageContext, observed_at: str, source: str
+) -> list[dict[str, Any]]:
+    selected_id = _required(context.account, "id")
+    workspace = _required(context.account, "workspace_id")
+    rows: dict[str, dict[str, Any]] = {
+        selected_id: {
+            "remote_id": selected_id,
+            "handle": context.account.get("username"),
+            "display_name": context.account.get("username"),
+            "observed_at": observed_at,
+            "provider_json": {"source": source, "selected": True},
+        },
+        namespaced_id(workspace, "workspace_actor", workspace): {
+            "remote_id": namespaced_id(workspace, "workspace_actor", workspace),
+            "handle": None,
+            "display_name": context.account.get("workspace_name"),
+            "observed_at": observed_at,
+            "provider_json": {"source": source, "workspace_actor": True},
+        },
+    }
+    for record in records:
+        if record.get("kind") == "user":
+            remote_id = _required(record, "remote_id")
+            rows[remote_id] = {
+                "remote_id": remote_id,
+                "handle": record.get("handle"),
+                "display_name": record.get("display_name"),
+                "observed_at": observed_at,
+                "provider_json": _provider_json(record, source),
+            }
+        actors = [record.get("actor_remote_id"), record.get("editor_remote_id")]
+        reactions = record.get("reactions", [])
+        if isinstance(reactions, list):
+            actors.extend(
+                actor
+                for reaction in reactions
+                if isinstance(reaction, dict)
+                for actor in reaction.get("actor_remote_ids", [])
+                if isinstance(actor, str)
+            )
+        for actor in actors:
+            if isinstance(actor, str) and actor not in rows:
+                rows[actor] = {
+                    "remote_id": actor,
+                    "handle": None,
+                    "display_name": None,
+                    "observed_at": observed_at,
+                    "provider_json": {"source": source, "stub": True},
+                }
+    return list(rows.values())
+
+
+def _media_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "remote_id": _required(record, "remote_id"),
+            "object_remote_id": record.get("object_remote_id") or record.get("remote_id"),
+            "content_sha256": None,
+            "mime_type": record.get("mimetype"),
+            "byte_size": record.get("size"),
+            "blob_ref": None,
+            "hydration_state": "metadata_only",
+        }
+        for record in records
+        if record.get("kind") == "file"
+    ]
+
+
+def _connection_policy(context: PageContext, source: str) -> dict[str, Any]:
+    incoming = {
+        "slack_workspace_id": _required(context.account, "workspace_id"),
+        "slack_enterprise_id": context.account.get("enterprise_id"),
+        "slack_token_type": _required(context.account, "token_type"),
+        "slack_conversation_binding_sha256": _required(
+            context.account, "conversation_binding_sha256"
+        ),
+    }
+    policy = dict(context.policy)
+    present = [field for field in IMMUTABLE_POLICY_FIELDS if field in policy]
+    if present and len(present) != len(IMMUTABLE_POLICY_FIELDS):
+        raise SlackAdapterError("stored Slack identity policy is incomplete")
+    if any(policy.get(field) != incoming[field] for field in present):
+        raise SlackAdapterError("stored Slack identity policy was rebound")
+    policy.update(incoming)
+    policy.update(
+        {
+            "slack_read_scopes": context.account.get("scopes", []),
+            "slack_provenance": source,
+            "slack_file_hydration": "disabled",
+        }
+    )
+    return policy
+
+
+def _api_gap_coverage(observed_at: str, source: str) -> list[dict[str, Any]]:
+    if source != API_SOURCE:
+        return []
+    return [
+        {
+            "stream": stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": RETENTION_LIMIT,
+            "unavailable_reason": reason,
+            "status": "unavailable" if stream == "api_file_binaries" else "partial",
+            "observed_at": observed_at,
+        }
+        for stream, reason in API_GAPS
+    ]
+
+
+def normalize_records(
+    records: list[dict[str, Any]],
+    context: PageContext,
+    batch: NormalizationBatch,
+) -> dict[str, Any]:
+    """Build one canonical Slack archive from shared API/export records."""
+    source = batch.source
+    if source not in {API_SOURCE, EXPORT_SOURCE}:
+        raise SlackAdapterError("Slack normalization source is unsupported")
+    observed_at = canonical_observed_at(batch.observed_at)
+    records = [validate_record(record) for record in records]
+    selected_id = _required(context.account, "id")
+    objects = [
+        row
+        for record in records
+        if (row := _object_row(record, selected_id, observed_at, source)) is not None
+    ]
+    activities = [
+        activity
+        for record in records
+        for activity in _record_activities(record, selected_id, observed_at, source)
+    ]
+    policy = _connection_policy(context, source)
+    archive = {
+        "provider": PROVIDER,
+        "connection_id": context.connection_id,
+        "remote_account_id": selected_id,
+        "exported_at": observed_at,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": policy,
+        "accounts": _account_rows(records, context, observed_at, source),
+        "objects": objects,
+        "activities": activities,
+        "media": _media_rows(records),
+        "coverage": [*_api_gap_coverage(observed_at, source), *batch.coverage],
+    }
+    reject_slack_credentials(archive)
+    return archive
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    """Normalize one successful isolated Slack API page."""
+    reject_slack_credentials(payload)
+    records = payload.get("data")
+    if not isinstance(records, list) or any(not isinstance(item, dict) for item in records):
+        raise SlackAdapterError("Slack page data must be an array of objects")
+    batch = NormalizationBatch(_observed_at(payload), _source(payload))
+    return normalize_records(records, context, batch)

--- a/.agents/scripts/_knowledge_social_slack_persist.py
+++ b/.agents/scripts/_knowledge_social_slack_persist.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Atomically persist timestamp-ordered Slack API and export evidence."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import os
+import sqlite3
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from _knowledge_social_collect import CollectionContext, SuccessfulPage
+from _knowledge_social_collect_persist import (
+    FetchRecord,
+    _assert_connection_binding,
+    _insert_fetch_batch,
+    _raw_batch,
+    _run_lease,
+)
+from _knowledge_social_lease import (
+    RunLease,
+    RunReceiptUpdate,
+    _assert_run_lease_at,
+    _update_run_receipt_at,
+    assert_run_lease,
+    social_now,
+    update_run_receipt,
+)
+from _knowledge_social_slack import PROVIDER
+from _knowledge_social_slack_archive import ParsedSlackArchive
+from _knowledge_social_slack_evidence_guard import reject_slack_credentials
+from _knowledge_social_slack_store import (
+    merge_connection_state,
+    store_ordered_records,
+    update_page_state,
+)
+from knowledge_social_import import canonical_json
+from knowledge_social_store import SocialStoreError, connect, migrate, write_raw_batch
+
+
+@dataclass(frozen=True)
+class ObservationSlot:
+    """Metadata that must uniquely identify one Slack observation timestamp."""
+
+    connection_id: str
+    stream: str
+    request_hash: str
+    response_hash: str
+    completed_at: str
+    batch_id: str
+
+
+def _assert_observation_slot(
+    database: sqlite3.Connection, expected: ObservationSlot
+) -> None:
+    rows = database.execute(
+        "SELECT stream,request_hash,response_hash FROM fetch_batches "
+        "WHERE provider=? AND connection_id=? AND completed_at=?",
+        (PROVIDER, expected.connection_id, expected.completed_at),
+    ).fetchall()
+    identity = (expected.stream, expected.request_hash, expected.response_hash)
+    if any(tuple(row) != identity for row in rows):
+        raise SocialStoreError(
+            "Slack evidence timestamp conflicts with an existing batch"
+        )
+
+
+def _page_observation(
+    context: CollectionContext, page: SuccessfulPage, observed_at: str
+) -> ObservationSlot:
+    request_hash = hashlib.sha256(page.request.encode("utf-8")).hexdigest()
+    response = canonical_json(page.payload).encode("utf-8")
+    response_hash = hashlib.sha256(response).hexdigest()
+    envelope = canonical_json(
+        {
+            "provider": PROVIDER,
+            "connection_id": context.connection_id,
+            "stream": context.stream,
+            "observed_at": observed_at,
+            "request_hash": request_hash,
+            "response_sha256": response_hash,
+            "response": page.payload,
+        }
+    ).encode("utf-8")
+    return ObservationSlot(
+        context.connection_id,
+        context.stream,
+        request_hash,
+        response_hash,
+        observed_at,
+        hashlib.sha256(envelope).hexdigest(),
+    )
+
+
+def _raw_path(root: Path, connection_id: str, digest: str) -> Path:
+    return (
+        root
+        / "sources"
+        / "social"
+        / "raw"
+        / PROVIDER
+        / connection_id
+        / f"{digest}.json.gz"
+    )
+
+
+def _gzip_payload_digest(path: Path) -> str:
+    descriptor = -1
+    digest = hashlib.sha256()
+    try:
+        before = path.lstat()
+        if stat.S_ISLNK(before.st_mode) or not stat.S_ISREG(before.st_mode):
+            raise SocialStoreError("Slack raw evidence is missing or unsafe")
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path, flags)
+        with os.fdopen(descriptor, "rb") as raw:
+            descriptor = -1
+            opened = os.fstat(raw.fileno())
+            if (
+                not stat.S_ISREG(opened.st_mode)
+                or (before.st_dev, before.st_ino) != (opened.st_dev, opened.st_ino)
+            ):
+                raise SocialStoreError("Slack raw evidence changed while opening")
+            with gzip.GzipFile(fileobj=raw, mode="rb") as source:
+                while chunk := source.read(1024 * 1024):
+                    digest.update(chunk)
+    except SocialStoreError:
+        raise
+    except (EOFError, OSError) as error:
+        raise SocialStoreError("Slack raw evidence could not be verified") from error
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    return digest.hexdigest()
+
+
+def _validate_replay_blob(
+    root: Path, connection_id: str, digest: str, blob_ref: str
+) -> None:
+    path = _raw_path(root, connection_id, digest)
+    if blob_ref != path.relative_to(root).as_posix() or _gzip_payload_digest(path) != digest:
+        raise SocialStoreError("Slack raw replay evidence does not match its batch")
+
+
+def _remove_created_raw(path: Path, digest: str) -> None:
+    try:
+        if _gzip_payload_digest(path) == digest:
+            path.unlink()
+    except (OSError, SocialStoreError):
+        return
+
+
+def _result(
+    parsed: ParsedSlackArchive, blob_ref: str, replayed: bool
+) -> dict[str, Any]:
+    return {
+        "status": "complete",
+        "source_sha256": parsed.source_sha256,
+        "evidence_sha256": parsed.evidence_sha256,
+        "blob_ref": blob_ref,
+        "normalized_items": parsed.normalized_items,
+        "selected_members": parsed.selected_members,
+        "conversation_streams": len(parsed.conversation_streams),
+        "replayed": replayed,
+    }
+
+
+def _insert_cursors(
+    database: sqlite3.Connection,
+    parsed: ParsedSlackArchive,
+    connection_id: str,
+    completed_at: str,
+) -> None:
+    streams = ("archive", *parsed.conversation_streams)
+    database.executemany(
+        """INSERT INTO sync_cursors(
+           connection_id,stream,cursor,watermark,last_success_at,backfill_complete)
+           VALUES(?,?,NULL,?,?,1) ON CONFLICT(connection_id,stream) DO UPDATE SET
+           cursor=NULL,watermark=excluded.watermark,
+           last_success_at=excluded.last_success_at,backfill_complete=1
+           WHERE excluded.last_success_at >= sync_cursors.last_success_at""",
+        [
+            (connection_id, stream, parsed.source_sha256, completed_at)
+            for stream in streams
+        ],
+    )
+
+
+def persist_slack_page(
+    context: CollectionContext, page: SuccessfulPage
+) -> int:
+    """Persist one API page without letting older evidence regress Slack state."""
+    if context.provider != PROVIDER:
+        raise SocialStoreError("Slack page persistence requires the Slack provider")
+    reject_slack_credentials(page.payload)
+    reject_slack_credentials(page.archive)
+    raw_path: Path | None = None
+    created_raw = False
+    database = connect(context.root)
+    try:
+        migrate(database)
+        database.execute("BEGIN IMMEDIATE")
+        lease = _run_lease(context)
+        _assert_run_lease_at(database, lease, social_now())
+        _assert_connection_binding(database, context)
+        archive = merge_connection_state(database, page.archive)
+        observation = _page_observation(context, page, archive["exported_at"])
+        _assert_observation_slot(database, observation)
+        raw_path = _raw_path(
+            context.root, context.connection_id, observation.batch_id
+        )
+        raw_existed = raw_path.exists() or raw_path.is_symlink()
+        raw = _raw_batch(
+            context, page.payload, page.request, archive["exported_at"]
+        )
+        created_raw = not raw_existed
+        if raw.batch_id != observation.batch_id:
+            raise SocialStoreError("Slack API evidence hash changed")
+        resource_count = sum(
+            len(archive[key])
+            for key in ("accounts", "objects", "activities", "media")
+        )
+        batch_id = _insert_fetch_batch(
+            database,
+            context,
+            FetchRecord(raw, "success", resource_count, page.budget_units),
+        )
+        store_ordered_records(
+            database, archive, batch_id, context.connection_id
+        )
+        update_page_state(database, context, page, archive, batch_id)
+        _update_run_receipt_at(
+            database,
+            lease,
+            RunReceiptUpdate(
+                "complete" if page.complete else "running",
+                resource_delta=resource_count,
+                terminal=page.complete,
+            ),
+            social_now(),
+        )
+        database.execute("COMMIT")
+        return resource_count
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        if created_raw and raw_path is not None:
+            _remove_created_raw(raw_path, observation.batch_id)
+        raise
+    finally:
+        database.close()
+
+
+def persist_slack_archive(
+    root: Path, parsed: ParsedSlackArchive, lease: RunLease
+) -> dict[str, Any]:
+    """Commit filtered raw evidence, rows, coverage, cursors, and receipt atomically."""
+    archive = parsed.archive
+    reject_slack_credentials(archive)
+    if hashlib.sha256(parsed.evidence).hexdigest() != parsed.evidence_sha256:
+        raise SocialStoreError("Slack filtered evidence changed after validation")
+    connection_id = archive["connection_id"]
+    raw_path = _raw_path(root, connection_id, parsed.evidence_sha256)
+    raw_existed = raw_path.exists() or raw_path.is_symlink()
+    created_raw = False
+    committed = False
+    database = connect(root)
+    try:
+        migrate(database)
+        database.execute("BEGIN IMMEDIATE")
+        assert_run_lease(database, lease)
+        _assert_observation_slot(
+            database,
+            ObservationSlot(
+                connection_id,
+                "archive",
+                parsed.evidence_sha256,
+                parsed.source_sha256,
+                archive["exported_at"],
+                parsed.evidence_sha256,
+            ),
+        )
+        archive = merge_connection_state(database, archive)
+        existing = database.execute(
+            "SELECT provider,connection_id,stream,request_hash,response_hash,blob_ref,"
+            "resource_count,budget_units,started_at,completed_at,terminal_status "
+            "FROM fetch_batches WHERE batch_id=?",
+            (parsed.evidence_sha256,),
+        ).fetchone()
+        if existing is not None:
+            observed = (
+                existing["provider"],
+                existing["connection_id"],
+                existing["stream"],
+                existing["request_hash"],
+                existing["response_hash"],
+                existing["resource_count"],
+                existing["budget_units"],
+                existing["started_at"],
+                existing["completed_at"],
+                existing["terminal_status"],
+            )
+            expected = (
+                PROVIDER,
+                connection_id,
+                "archive",
+                parsed.evidence_sha256,
+                parsed.source_sha256,
+                parsed.normalized_items,
+                0,
+                archive["exported_at"],
+                archive["exported_at"],
+                "success",
+            )
+            if observed != expected:
+                raise SocialStoreError("Slack export replay metadata conflicts")
+            _validate_replay_blob(
+                root,
+                connection_id,
+                parsed.evidence_sha256,
+                str(existing["blob_ref"]),
+            )
+            update_run_receipt(
+                database,
+                lease,
+                RunReceiptUpdate("complete", resource_delta=0, terminal=True),
+            )
+            database.execute("COMMIT")
+            committed = True
+            return _result(parsed, str(existing["blob_ref"]), True)
+        batch_id, blob_ref = write_raw_batch(
+            root, PROVIDER, connection_id, parsed.evidence
+        )
+        created_raw = not raw_existed
+        if batch_id != parsed.evidence_sha256:
+            raise SocialStoreError("Slack filtered evidence hash changed")
+        store_ordered_records(database, archive, batch_id, connection_id)
+        database.execute(
+            """INSERT INTO fetch_batches(
+               batch_id,provider,connection_id,stream,request_hash,response_hash,blob_ref,
+               resource_count,budget_units,started_at,completed_at,terminal_status)
+               VALUES(?,?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                batch_id,
+                PROVIDER,
+                connection_id,
+                "archive",
+                parsed.evidence_sha256,
+                parsed.source_sha256,
+                blob_ref,
+                parsed.normalized_items,
+                0,
+                archive["exported_at"],
+                archive["exported_at"],
+                "success",
+            ),
+        )
+        _insert_cursors(database, parsed, connection_id, archive["exported_at"])
+        update_run_receipt(
+            database,
+            lease,
+            RunReceiptUpdate(
+                "complete", resource_delta=parsed.normalized_items, terminal=True
+            ),
+        )
+        database.execute("COMMIT")
+        committed = True
+        return _result(parsed, blob_ref, False)
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        if created_raw and not committed:
+            _remove_created_raw(raw_path, parsed.evidence_sha256)
+        raise
+    finally:
+        database.close()

--- a/.agents/scripts/_knowledge_social_slack_provider.py
+++ b/.agents/scripts/_knowledge_social_slack_provider.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded read-only Slack Web API subprocess with exact method allowlisting."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from functools import partial
+from typing import Any
+
+from _knowledge_social_slack import (
+    ALIAS,
+    CONVERSATION_KINDS,
+    PageRequest,
+    SlackAdapterError,
+    conversation_binding_sha256,
+    conversation_id,
+    parse_page_request,
+    team_id,
+    token_type,
+)
+from _knowledge_social_slack_contract import (
+    ApiResult,
+    IdentityBinding,
+    SlackAuthorizationError,
+    SlackReadProviderError,
+    exact_keys,
+    identity_value,
+    object_value,
+    observed_at,
+    request_object,
+    terminal_payload,
+)
+from _knowledge_social_slack_evidence_guard import reject_slack_credentials
+from _knowledge_social_slack_http import MAX_RESPONSE_BYTES, Opener, _http_exports, api
+from _knowledge_social_slack_routes import ConversationTarget, page
+
+MAX_REQUEST_BYTES = 32 * 1024
+MAX_CONVERSATION_CONFIG_BYTES = 64 * 1024
+MAX_CONVERSATIONS = 500
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    """Validated non-secret binding plus one isolated live credential."""
+
+    token: str | None
+    binding: IdentityBinding
+    conversations: dict[str, ConversationTarget]
+    conversation_binding_sha256: str
+
+
+def _profile_prefix(profile: str) -> str:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise SlackReadProviderError("Slack profile name is invalid")
+    return f"SLACK_{profile.upper()}"
+
+
+def _required_profile_value(prefix: str, suffix: str, field: str, limit: int) -> str:
+    value = os.environ.get(f"{prefix}_{suffix}", "")
+    if not value or "\x00" in value or len(value.encode("utf-8")) > limit:
+        raise SlackReadProviderError(f"Slack profile {field} is missing")
+    return value
+
+
+def _optional_profile_value(prefix: str, suffix: str, field: str, limit: int) -> str | None:
+    value = os.environ.get(f"{prefix}_{suffix}")
+    if value in (None, ""):
+        return None
+    if "\x00" in value or len(value.encode("utf-8")) > limit:
+        raise SlackReadProviderError(f"Slack profile {field} is invalid")
+    return value
+
+
+def _conversation_target(alias: Any, value: Any) -> ConversationTarget:
+    if not isinstance(alias, str) or ALIAS.fullmatch(alias) is None:
+        raise SlackReadProviderError("Slack conversation alias is invalid")
+    if not isinstance(value, dict) or set(value) != {"id", "kind"}:
+        raise SlackReadProviderError("Slack conversation allowlist entry is invalid")
+    native_id = conversation_id(value.get("id"))
+    kind = value.get("kind")
+    if kind not in CONVERSATION_KINDS:
+        raise SlackReadProviderError("Slack conversation kind is unsupported")
+    prefixes = {
+        "public_channel": "C",
+        "private_channel": "G",
+        "im": "D",
+        "mpim": "G",
+    }
+    if not native_id.startswith(prefixes[str(kind)]):
+        raise SlackReadProviderError("Slack conversation ID and kind conflict")
+    return ConversationTarget(alias, native_id, str(kind))
+
+
+def _conversations(prefix: str) -> dict[str, ConversationTarget]:
+    raw = _required_profile_value(
+        prefix,
+        "CONVERSATIONS",
+        "conversation allowlist",
+        MAX_CONVERSATION_CONFIG_BYTES,
+    )
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise SlackReadProviderError(
+            "Slack profile conversation allowlist is invalid"
+        ) from error
+    if not isinstance(parsed, dict) or len(parsed) > MAX_CONVERSATIONS:
+        raise SlackReadProviderError("Slack profile conversation allowlist is invalid")
+    targets = {
+        str(alias): _conversation_target(alias, value)
+        for alias, value in parsed.items()
+    }
+    if len({target.conversation_id for target in targets.values()}) != len(targets):
+        raise SlackReadProviderError("Slack conversation allowlist contains duplicate IDs")
+    return targets
+
+
+def load_profile(
+    profile: str, *, require_token: bool = True, include_token: bool = True
+) -> ProfileConfig:
+    """Load one exact workspace binding for API or approved-export collection."""
+    prefix = _profile_prefix(profile)
+    token = (
+        _optional_profile_value(prefix, "ACCESS_TOKEN", "access token", 16 * 1024)
+        if include_token
+        else None
+    )
+    if require_token and token is None:
+        raise SlackReadProviderError("Slack profile access token is missing")
+    workspace = team_id(
+        _required_profile_value(prefix, "WORKSPACE_ID", "workspace ID", 64)
+    )
+    enterprise_value = _optional_profile_value(
+        prefix, "ENTERPRISE_ID", "enterprise ID", 64
+    )
+    from _knowledge_social_slack import enterprise_id
+
+    enterprise = enterprise_id(enterprise_value)
+    profile_token_type = token_type(
+        _required_profile_value(prefix, "TOKEN_TYPE", "token type", 16)
+    )
+    conversations = _conversations(prefix)
+    binding_value = {
+        alias: {"id": target.conversation_id, "kind": target.kind}
+        for alias, target in conversations.items()
+    }
+    return ProfileConfig(
+        token,
+        IdentityBinding(workspace, enterprise, profile_token_type),
+        conversations,
+        conversation_binding_sha256(binding_value),
+    )
+
+
+def _identity(
+    config: ProfileConfig, opener: Opener, expected_id: str
+) -> dict[str, Any]:
+    if config.token is None:
+        raise SlackReadProviderError("Slack profile access token is missing")
+    result = api(config.token, opener, "auth.test", {})
+    if result.status != 200:
+        return terminal_payload(result)
+    identity = identity_value(
+        result.payload, expected_id, config.binding, result.scopes
+    )
+    identity["conversation_binding_sha256"] = config.conversation_binding_sha256
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": identity,
+    }
+
+
+def _verify_page_identity(
+    request: PageRequest, identity: dict[str, Any], config: ProfileConfig
+) -> None:
+    observed = (
+        identity.get("id"),
+        identity.get("provider_account_id"),
+        identity.get("workspace_id"),
+        identity.get("enterprise_id"),
+        request.workspace_id,
+        request.enterprise_id,
+        identity.get("token_type"),
+    )
+    expected = (
+        request.account_id,
+        request.provider_account_id,
+        request.workspace_id,
+        request.enterprise_id,
+        config.binding.workspace_id,
+        config.binding.enterprise_id,
+        config.binding.token_type,
+    )
+    if observed != expected:
+        raise SlackReadProviderError(
+            "selected Slack workspace or account does not match the configured connection"
+        )
+
+
+def _dispatch(
+    request: dict[str, Any], config: ProfileConfig, opener: Opener
+) -> dict[str, Any]:
+    action = request.get("action")
+    if action == "identity":
+        exact_keys(request, {"action", "account_id"})
+        expected_id = request.get("account_id")
+        if not isinstance(expected_id, str):
+            raise SlackReadProviderError("Slack account ID is invalid")
+        return _identity(config, opener, expected_id)
+    if action != "page":
+        raise SlackReadProviderError("Slack read action is unsupported")
+    page_request = parse_page_request(request)
+    identity_payload = _identity(config, opener, page_request.account_id)
+    if identity_payload.get("status") != 200:
+        return identity_payload
+    identity = object_value(identity_payload.get("data"), "account verification")
+    _verify_page_identity(page_request, identity, config)
+    if config.token is None:
+        raise SlackReadProviderError("Slack profile access token is missing")
+    caller = partial(api, config.token, opener)
+    try:
+        result = page(caller, page_request, identity, config.conversations)
+    except SlackAuthorizationError:
+        return terminal_payload(ApiResult(403, {}, frozenset()))
+    return terminal_payload(result) if isinstance(result, ApiResult) else result
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode("utf-8")) > MAX_RESPONSE_BYTES:
+        raise SlackReadProviderError("Slack read response exceeds the safety limit")
+    print(encoded)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        config = load_profile(args.profile)
+        request = request_object(
+            sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1), MAX_REQUEST_BYTES
+        )
+        response = _dispatch(request, config, _http_exports())
+        reject_slack_credentials(response, exact_secret=config.token)
+        _emit(response)
+        return 0
+    except (SlackReadProviderError, SlackAdapterError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - intentionally redact provider internals
+        print("ERROR: Slack read provider request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_slack_reader.py
+++ b/.agents/scripts/_knowledge_social_slack_reader.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and deterministic fixture readers for Slack collection."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Protocol
+
+from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
+from _knowledge_social_slack import (
+    PageRequest,
+    SlackAdapterError,
+    SlackProviderUnavailableError,
+    enterprise_id,
+    parse_account_id,
+    team_id,
+    token_type,
+    user_id,
+)
+from _knowledge_social_slack_evidence_guard import reject_slack_credentials
+from _knowledge_social_slack_http import READ_SCOPES
+
+READ_TIMEOUT_SECONDS = 120
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+SHA256 = re.compile(r"^[a-f0-9]{64}$")
+SAFE_PROVIDER_FAILURES = (
+    "Python urllib HTTP exports are unavailable",
+    "Slack profile name is invalid",
+    "Slack profile access token is missing",
+    "Slack profile workspace ID is missing",
+    "Slack profile enterprise ID is invalid",
+    "Slack profile token type is missing",
+    "Slack profile conversation allowlist is missing",
+    "Slack profile conversation allowlist is invalid",
+    "Slack token includes an unsupported or write scope",
+    "Slack response did not attest token scopes",
+    "selected Slack workspace or account does not match the configured connection",
+)
+
+
+class SlackReader(Protocol):
+    def identity(self, expected_id: str) -> dict[str, Any]: ...
+
+    def page(self, request: PageRequest) -> dict[str, Any]: ...
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    if len(output.encode("utf-8")) > MAX_RESPONSE_BYTES:
+        raise SlackAdapterError("Slack read response exceeds the safety limit")
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise SlackAdapterError("Slack read provider returned no valid JSON") from error
+    if not isinstance(payload, dict):
+        raise SlackAdapterError("Slack read response root must be an object")
+    return payload
+
+
+def _provider_failure(stderr: str) -> SlackProviderUnavailableError:
+    for message in SAFE_PROVIDER_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return SlackProviderUnavailableError(message)
+    return SlackProviderUnavailableError("Slack read provider is unavailable")
+
+
+SLACK_READER_POLICY = GuardedOAuthPolicy(
+    "Slack",
+    "SLACK",
+    "SLACK_READ_LOG",
+    READ_TIMEOUT_SECONDS,
+    _decode_output,
+    _provider_failure,
+    SlackProviderUnavailableError,
+    (
+        "ACCESS_TOKEN",
+        "WORKSPACE_ID",
+        "ENTERPRISE_ID",
+        "TOKEN_TYPE",
+        "CONVERSATIONS",
+    ),
+    "",
+)
+
+
+class GuardedSlack(GuardedOAuthReader):
+    """Execute only identity and exact allowlisted Slack reads in a child."""
+
+    def __init__(self, helper: Path, profile: str) -> None:
+        super().__init__(helper, profile, SLACK_READER_POLICY)
+
+
+def _fixture_object(value: Any, message: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise SlackAdapterError(message)
+    return value
+
+
+class FixtureSlack:
+    """Deterministic Slack substitute for pagination and failure fixtures."""
+
+    def __init__(self, path: Path) -> None:
+        self.sequence = FixtureSequence(path, "Slack", SlackAdapterError)
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        del expected_id
+        return self.sequence.identity()
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        entry = self.sequence.next_page()
+        expectation = _fixture_object(
+            entry.get("expect_request", {}),
+            "Slack fixture request expectation must be an object",
+        )
+        actual = request.payload()
+        mismatch = any(
+            actual.get(key) != expected for key, expected in expectation.items()
+        )
+        if mismatch:
+            raise SlackAdapterError(
+                "Slack request did not resume at the expected checkpoint"
+            )
+        response = entry.get("response", entry)
+        return _fixture_object(
+            response, "Slack fixture page response must be an object"
+        )
+
+
+def _optional_display(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise SlackAdapterError(f"Slack account {field} must be text")
+    if len(value.encode("utf-8")) > 256 * 1024:
+        raise SlackAdapterError(f"Slack account {field} exceeds the safety limit")
+    return value
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    """Bind one user or bot identity to an exact Slack workspace installation."""
+    reject_slack_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise SlackAdapterError("Slack account verification returned no account")
+    expected_workspace, expected_user = parse_account_id(expected_id)
+    workspace = team_id(data.get("workspace_id"))
+    selected_user = user_id(data.get("provider_account_id"))
+    identity = data.get("id")
+    if (
+        identity != expected_id
+        or workspace != expected_workspace
+        or selected_user != expected_user
+    ):
+        raise SlackAdapterError(
+            "selected Slack workspace or account does not match the configured connection"
+        )
+    scopes = data.get("scopes")
+    if (
+        not isinstance(scopes, list)
+        or not scopes
+        or any(not isinstance(scope, str) or scope not in READ_SCOPES for scope in scopes)
+        or len(set(scopes)) != len(scopes)
+    ):
+        raise SlackAdapterError("Slack identity scopes are invalid")
+    conversation_binding = data.get("conversation_binding_sha256")
+    if (
+        not isinstance(conversation_binding, str)
+        or SHA256.fullmatch(conversation_binding) is None
+    ):
+        raise SlackAdapterError("Slack conversation binding is invalid")
+    return {
+        "id": identity,
+        "provider_account_id": selected_user,
+        "workspace_id": workspace,
+        "enterprise_id": enterprise_id(data.get("enterprise_id")),
+        "token_type": token_type(data.get("token_type")),
+        "scopes": sorted(scopes),
+        "conversation_binding_sha256": conversation_binding,
+        "username": _optional_display(data.get("username"), "name"),
+        "workspace_name": _optional_display(
+            data.get("workspace_name"), "workspace name"
+        ),
+    }

--- a/.agents/scripts/_knowledge_social_slack_record_contract.py
+++ b/.agents/scripts/_knowledge_social_slack_record_contract.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Primitive identity and timestamp contracts for Slack records."""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from _knowledge_social_slack import (
+    account_id,
+    namespaced_id,
+    slack_timestamp,
+    team_id,
+)
+from _knowledge_social_slack_contract import (
+    SlackReadProviderError,
+    non_negative_integer,
+)
+
+ACTOR_ID = re.compile(r"^[BUW][A-Z0-9]{2,31}$")
+FILE_ID = re.compile(r"^F[A-Z0-9]{2,31}$")
+
+
+def stable_id(value: Any, field: str, pattern: re.Pattern[str]) -> str:
+    if not isinstance(value, str) or pattern.fullmatch(value) is None:
+        raise SlackReadProviderError(f"Slack {field} is invalid")
+    return value
+
+
+def timestamp_iso(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    timestamp = slack_timestamp(value, field)
+    try:
+        epoch = Decimal(timestamp)
+        seconds = int(epoch)
+        micros = int((epoch - seconds) * 1_000_000)
+        return (
+            datetime.fromtimestamp(seconds, UTC)
+            .replace(microsecond=micros)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+    except (InvalidOperation, OverflowError, OSError, ValueError) as error:
+        raise SlackReadProviderError(f"Slack {field} is invalid") from error
+
+
+def epoch_iso(value: Any, field: str) -> str | None:
+    if value in (None, 0):
+        return None
+    number = non_negative_integer(value, field)
+    if number is None:
+        return None
+    try:
+        return datetime.fromtimestamp(number, UTC).isoformat().replace("+00:00", "Z")
+    except (OverflowError, OSError, ValueError) as error:
+        raise SlackReadProviderError(f"Slack {field} is invalid") from error
+
+
+def actor_id(value: Any, workspace: str) -> str:
+    if isinstance(value, str) and ACTOR_ID.fullmatch(value) is not None:
+        if value.startswith("B"):
+            return namespaced_id(workspace, "bot", value)
+        return account_id(workspace, value)
+    return namespaced_id(workspace, "workspace_actor", team_id(workspace))

--- a/.agents/scripts/_knowledge_social_slack_records.py
+++ b/.agents/scripts/_knowledge_social_slack_records.py
@@ -21,7 +21,8 @@ from _knowledge_social_slack_contract import (
     optional_boolean,
     optional_text,
 )
-from _knowledge_social_slack_message_records import (
+# Same-name imports define the stable record facade used by route modules.
+from _knowledge_social_slack_message_records import (  # pylint: disable=unused-import
     file_records as file_records,
     file_records_for_conversation as file_records_for_conversation,
     message_record as message_record,
@@ -29,7 +30,7 @@ from _knowledge_social_slack_message_records import (
     reaction_item_records as reaction_item_records,
 )
 from _knowledge_social_slack_record_contract import ACTOR_ID, epoch_iso, stable_id
-from _knowledge_social_slack_snapshot_records import (
+from _knowledge_social_slack_snapshot_records import (  # pylint: disable=unused-import
     bookmark_record as bookmark_record,
     pin_record as pin_record,
 )

--- a/.agents/scripts/_knowledge_social_slack_records.py
+++ b/.agents/scripts/_knowledge_social_slack_records.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Sanitize Slack API and export records into one convergent provider shape."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from _knowledge_social_slack import (
+    CONVERSATION_KINDS,
+    SlackAdapterError,
+    account_id,
+    conversation_id,
+    namespaced_id,
+    team_id,
+)
+from _knowledge_social_slack_contract import (
+    SlackReadProviderError,
+    object_value,
+    optional_boolean,
+    optional_text,
+)
+from _knowledge_social_slack_message_records import (
+    file_records as file_records,
+    file_records_for_conversation as file_records_for_conversation,
+    message_record as message_record,
+    newest_message_ts as newest_message_ts,
+    reaction_item_records as reaction_item_records,
+)
+from _knowledge_social_slack_record_contract import ACTOR_ID, epoch_iso, stable_id
+from _knowledge_social_slack_snapshot_records import (
+    bookmark_record as bookmark_record,
+    pin_record as pin_record,
+)
+
+
+def workspace_record(payload: Any, workspace: str) -> dict[str, Any]:
+    team = object_value(payload, "workspace")
+    native_id = team_id(team.get("id"))
+    if native_id != team_id(workspace):
+        raise SlackReadProviderError("Slack workspace metadata was rebound")
+    return {
+        "kind": "workspace",
+        "remote_id": namespaced_id(workspace, "workspace", native_id),
+        "workspace_id": native_id,
+        "name": optional_text(team.get("name"), "workspace name"),
+        "domain": optional_text(team.get("domain"), "workspace domain", limit=255),
+        "email_domain": optional_text(
+            team.get("email_domain"), "workspace email domain", limit=255
+        ),
+    }
+
+
+def user_record(payload: Any, workspace: str) -> dict[str, Any]:
+    user = object_value(payload, "user")
+    native_id = stable_id(user.get("id"), "user ID", ACTOR_ID)
+    if native_id.startswith("B"):
+        raise SlackReadProviderError("Slack workspace member cannot use a bot ID")
+    profile_value = user.get("profile", {})
+    profile = object_value(profile_value, "user profile")
+    display = optional_text(profile.get("display_name"), "display name")
+    real = optional_text(profile.get("real_name"), "real name")
+    return {
+        "kind": "user",
+        "remote_id": account_id(workspace, native_id),
+        "user_id": native_id,
+        "handle": optional_text(user.get("name"), "user handle", limit=255),
+        "display_name": display or real,
+        "deleted": optional_boolean(user.get("deleted"), "deleted flag") or False,
+        "is_bot": optional_boolean(user.get("is_bot"), "bot flag") or False,
+        "is_restricted": optional_boolean(
+            user.get("is_restricted"), "restricted flag"
+        ) or False,
+    }
+
+
+def _conversation_flags(kind: str) -> dict[str, bool]:
+    if kind not in CONVERSATION_KINDS:
+        raise SlackReadProviderError("Slack conversation kind is unsupported")
+    return {
+        "is_channel": kind == "public_channel",
+        "is_group": kind == "private_channel",
+        "is_im": kind == "im",
+        "is_mpim": kind == "mpim",
+    }
+
+
+def _topic_value(payload: dict[str, Any], field: str) -> str | None:
+    value = payload.get(field)
+    if value is None:
+        return None
+    detail = object_value(value, f"conversation {field}")
+    return optional_text(detail.get("value"), f"conversation {field}")
+
+
+def conversation_record(
+    payload: Any, workspace: str, expected_id: str, kind: str
+) -> dict[str, Any]:
+    conversation = object_value(payload, "conversation")
+    native_id = conversation_id(conversation.get("id"))
+    if native_id != conversation_id(expected_id):
+        raise SlackReadProviderError("Slack conversation metadata was rebound")
+    expected_flags = _conversation_flags(kind)
+    for field, expected in expected_flags.items():
+        value = conversation.get(field)
+        if value is not None and optional_boolean(value, field) is not expected:
+            raise SlackReadProviderError("Slack conversation kind was rebound")
+    created = conversation.get("created")
+    return {
+        "kind": "conversation",
+        "remote_id": namespaced_id(workspace, "conversation", native_id),
+        "conversation_id": native_id,
+        "conversation_kind": kind,
+        "name": optional_text(conversation.get("name"), "conversation name"),
+        "topic": _topic_value(conversation, "topic"),
+        "purpose": _topic_value(conversation, "purpose"),
+        "created_at": epoch_iso(created, "conversation created time"),
+        "is_archived": optional_boolean(
+            conversation.get("is_archived"), "conversation archived flag"
+        ) or False,
+        "is_member": optional_boolean(
+            conversation.get("is_member"), "conversation membership flag"
+        ),
+    }
+
+
+def membership_records(
+    values: Any, workspace: str, native_conversation: str, limit: int
+) -> list[dict[str, Any]]:
+    if not isinstance(values, list) or len(values) > limit:
+        raise SlackReadProviderError("Slack conversation members exceed the item limit")
+    records: list[dict[str, Any]] = []
+    target = namespaced_id(workspace, "conversation", conversation_id(native_conversation))
+    for value in values:
+        native_user = stable_id(value, "member user ID", ACTOR_ID)
+        if native_user.startswith("B"):
+            actor = namespaced_id(workspace, "bot", native_user)
+        else:
+            actor = account_id(workspace, native_user)
+        records.append(
+            {
+                "kind": "membership",
+                "remote_id": namespaced_id(
+                    workspace, "membership", f"{native_conversation}:{native_user}"
+                ),
+                "conversation_remote_id": target,
+                "actor_remote_id": actor,
+            }
+        )
+    return records
+
+
+def validate_record(record: dict[str, Any]) -> dict[str, Any]:
+    """Fail closed if a shared API/export record lacks canonical identity."""
+    if not isinstance(record.get("kind"), str) or not isinstance(
+        record.get("remote_id"), str
+    ):
+        raise SlackAdapterError("Slack normalized record identity is incomplete")
+    return record

--- a/.agents/scripts/_knowledge_social_slack_route_types.py
+++ b/.agents/scripts/_knowledge_social_slack_route_types.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Shared contracts for allowlisted Slack read routes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from _knowledge_social_slack import PageRequest
+from _knowledge_social_slack_contract import (
+    ApiResult,
+    SlackAuthorizationError,
+    SlackReadProviderError,
+    object_value,
+    observed_at,
+    optional_text,
+)
+
+Api = Callable[[str, dict[str, str]], ApiResult]
+PageResult = ApiResult | dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ConversationTarget:
+    """One profile-approved Slack conversation alias."""
+
+    alias: str
+    conversation_id: str
+    kind: str
+
+
+def identity_scopes(identity: dict[str, Any]) -> frozenset[str]:
+    values = identity.get("scopes")
+    if not isinstance(values, list) or any(
+        not isinstance(value, str) for value in values
+    ):
+        raise SlackReadProviderError("Slack identity scopes are invalid")
+    return frozenset(values)
+
+
+def require_scope(identity: dict[str, Any], scope: str) -> None:
+    if scope not in identity_scopes(identity):
+        raise SlackAuthorizationError("Slack profile lacks the required read scope")
+
+
+def verified_result(result: ApiResult, identity: dict[str, Any]) -> ApiResult:
+    if result.status == 200 and result.scopes != identity_scopes(identity):
+        raise SlackReadProviderError("Slack token scopes changed during collection")
+    return result
+
+
+def next_cursor(payload: dict[str, Any]) -> str | None:
+    metadata = payload.get("response_metadata", {})
+    if metadata is None:
+        return None
+    root = object_value(metadata, "response metadata")
+    value = optional_text(root.get("next_cursor"), "next cursor", limit=4096)
+    return value or None
+
+
+def page_payload(
+    request: PageRequest,
+    records: list[dict[str, Any]],
+    cursor: str | None,
+    newest_ts: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": records,
+        "meta": {
+            "stream": request.stream,
+            "selector": request.selector,
+            "workspace_id": request.workspace_id,
+            "next_cursor": cursor,
+            "newest_ts": newest_ts,
+            "complete": cursor is None,
+            "source": "slack_web_api",
+        },
+    }

--- a/.agents/scripts/_knowledge_social_slack_routes.py
+++ b/.agents/scripts/_knowledge_social_slack_routes.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Allowlisted Slack read routes, pagination, and response serialization."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from _knowledge_social_slack import PageRequest
+from _knowledge_social_slack_conversation_routes import conversation_page
+from _knowledge_social_slack_contract import (
+    object_list,
+    object_value,
+)
+from _knowledge_social_slack_records import (
+    newest_message_ts,
+    reaction_item_records,
+    user_record,
+    workspace_record,
+)
+from _knowledge_social_slack_route_types import (
+    Api,
+    ConversationTarget,
+    PageResult,
+    next_cursor,
+    page_payload,
+    require_scope,
+    verified_result,
+)
+
+
+def _workspace(api: Api, request: PageRequest, identity: dict[str, Any]) -> PageResult:
+    require_scope(identity, "team:read")
+    result = verified_result(api("team.info", {}), identity)
+    if result.status != 200:
+        return result
+    root = object_value(result.payload, "workspace response")
+    return page_payload(
+        request, [workspace_record(root.get("team"), request.workspace_id)], None
+    )
+
+
+def _users(api: Api, request: PageRequest, identity: dict[str, Any]) -> PageResult:
+    require_scope(identity, "users:read")
+    params = {"limit": str(request.limit)}
+    if request.cursor:
+        params["cursor"] = request.cursor
+    result = verified_result(api("users.list", params), identity)
+    if result.status != 200:
+        return result
+    root = object_value(result.payload, "users response")
+    members = object_list(root.get("members"), "workspace members", limit=request.limit)
+    records = [user_record(member, request.workspace_id) for member in members]
+    return page_payload(request, records, next_cursor(root))
+
+
+def _reactions(
+    api: Api,
+    request: PageRequest,
+    identity: dict[str, Any],
+    conversations: dict[str, ConversationTarget],
+) -> PageResult:
+    require_scope(identity, "reactions:read")
+    params = {"limit": str(request.limit), "full": "true"}
+    if request.cursor:
+        params["cursor"] = request.cursor
+    result = verified_result(api("reactions.list", params), identity)
+    if result.status != 200:
+        return result
+    root = object_value(result.payload, "reactions response")
+    items = object_list(root.get("items"), "reaction items", limit=request.limit)
+    allowed = frozenset(target.conversation_id for target in conversations.values())
+    records = [
+        record
+        for item in items
+        for record in reaction_item_records(item, request.workspace_id, allowed)
+    ]
+    return page_payload(
+        request, records, next_cursor(root), newest_message_ts(records)
+    )
+
+
+def page(
+    api: Api,
+    request: PageRequest,
+    identity: dict[str, Any],
+    conversations: dict[str, ConversationTarget],
+) -> PageResult:
+    """Execute one reviewed read for an identity-bound Slack stream."""
+    if request.selector == "workspace":
+        result = _workspace(api, request, identity)
+    elif request.selector == "users":
+        result = _users(api, request, identity)
+    elif request.selector == "reactions":
+        result = _reactions(api, request, identity, conversations)
+    else:
+        result = conversation_page(api, request, identity, conversations)
+    return result

--- a/.agents/scripts/_knowledge_social_slack_snapshot_records.py
+++ b/.agents/scripts/_knowledge_social_slack_snapshot_records.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Sanitize Slack bookmark and pin snapshots."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any
+
+from _knowledge_social_slack import conversation_id, namespaced_id, slack_timestamp
+from _knowledge_social_slack_contract import (
+    SlackReadProviderError,
+    non_negative_integer,
+    object_value,
+    optional_text,
+    required_text,
+)
+from _knowledge_social_slack_record_contract import (
+    FILE_ID,
+    actor_id,
+    epoch_iso,
+    stable_id,
+)
+from knowledge_social_import import canonical_json
+
+BOOKMARK_ID = re.compile(r"^Bk[A-Za-z0-9]{2,62}$")
+
+
+def bookmark_record(
+    payload: Any, workspace: str, expected_channel: str
+) -> dict[str, Any]:
+    bookmark = object_value(payload, "bookmark")
+    native_id = stable_id(bookmark.get("id"), "bookmark ID", BOOKMARK_ID)
+    channel = conversation_id(bookmark.get("channel_id"))
+    if channel != conversation_id(expected_channel):
+        raise SlackReadProviderError("Slack bookmark conversation was rebound")
+    return {
+        "kind": "bookmark",
+        "remote_id": namespaced_id(workspace, "bookmark", native_id),
+        "conversation_remote_id": namespaced_id(workspace, "conversation", channel),
+        "actor_remote_id": actor_id(
+            bookmark.get("last_updated_by_user_id"), workspace
+        ),
+        "title": optional_text(bookmark.get("title"), "bookmark title"),
+        "bookmark_type": optional_text(
+            bookmark.get("type"), "bookmark type", limit=128
+        ),
+        "entity_id": optional_text(bookmark.get("entity_id"), "bookmark entity ID"),
+        "created_at": epoch_iso(bookmark.get("date_created"), "bookmark created time"),
+        "updated_at": epoch_iso(bookmark.get("date_updated"), "bookmark updated time"),
+    }
+
+
+def pin_record(payload: Any, workspace: str, expected_channel: str) -> dict[str, Any]:
+    pin = object_value(payload, "pin")
+    channel = conversation_id(pin.get("channel", expected_channel))
+    if channel != conversation_id(expected_channel):
+        raise SlackReadProviderError("Slack pin conversation was rebound")
+    item_type = required_text(pin.get("type"), "pin type", limit=64)
+    target: str
+    text: str | None = None
+    if item_type == "message":
+        message = object_value(pin.get("message"), "pinned message")
+        timestamp = slack_timestamp(message.get("ts"), "pinned message timestamp")
+        target = namespaced_id(workspace, "message", f"{channel}:{timestamp}")
+        text = optional_text(message.get("text"), "pinned message text")
+    elif item_type == "file":
+        file_value = object_value(pin.get("file"), "pinned file")
+        native_file = stable_id(file_value.get("id"), "pinned file ID", FILE_ID)
+        target = namespaced_id(workspace, "file", native_file)
+        text = optional_text(file_value.get("title"), "pinned file title")
+    else:
+        raise SlackReadProviderError("Slack pin type is unsupported")
+    created = non_negative_integer(pin.get("created"), "pin created time", optional=True)
+    material = canonical_json([channel, item_type, target, created])
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()
+    return {
+        "kind": "pin",
+        "remote_id": namespaced_id(workspace, "pin", digest),
+        "conversation_remote_id": namespaced_id(workspace, "conversation", channel),
+        "target_remote_id": target,
+        "actor_remote_id": actor_id(pin.get("created_by"), workspace),
+        "text": text,
+        "created_at": epoch_iso(created, "pin created time"),
+    }

--- a/.agents/scripts/_knowledge_social_slack_store.py
+++ b/.agents/scripts/_knowledge_social_slack_store.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Store timestamp-ordered Slack records without regressing newer state."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+from _knowledge_social_collect import CollectionContext, SuccessfulPage
+from _knowledge_social_slack import PROVIDER
+from _knowledge_social_slack_evidence_guard import reject_slack_credentials
+from _knowledge_social_slack_normalize import IMMUTABLE_POLICY_FIELDS
+from knowledge_social_import import (
+    ACTIVITY_UPSERT,
+    OBJECT_UPSERT,
+    canonical_json,
+    import_media,
+    optional_text,
+    record_list,
+    required_text,
+    upsert_connection,
+)
+from knowledge_social_store import SocialStoreError
+
+ORDERED_ACCOUNT_UPSERT = (
+    "INSERT INTO accounts(provider,remote_id,handle,display_name,observed_at,provider_json) "
+    "VALUES(?,?,?,?,?,?) ON CONFLICT(provider,remote_id) DO UPDATE SET "
+    "handle=excluded.handle,display_name=excluded.display_name,"
+    "observed_at=excluded.observed_at,provider_json=excluded.provider_json "
+    "WHERE excluded.observed_at > accounts.observed_at OR "
+    "(excluded.observed_at = accounts.observed_at AND "
+    "(excluded.handle IS NOT NULL,COALESCE(excluded.handle,''),"
+    "excluded.display_name IS NOT NULL,COALESCE(excluded.display_name,''),"
+    "excluded.provider_json) > "
+    "(accounts.handle IS NOT NULL,COALESCE(accounts.handle,''),"
+    "accounts.display_name IS NOT NULL,COALESCE(accounts.display_name,''),"
+    "accounts.provider_json))"
+)
+ORDERED_OBJECT_UPSERT = (
+    f"{OBJECT_UPSERT} WHERE excluded.observed_at > objects.observed_at OR "
+    "(excluded.observed_at = objects.observed_at "
+    "AND excluded.batch_id > objects.batch_id)"
+)
+ORDERED_ACTIVITY_UPSERT = (
+    f"{ACTIVITY_UPSERT} WHERE excluded.observed_at > activities.observed_at OR "
+    "(excluded.observed_at = activities.observed_at "
+    "AND excluded.batch_id > activities.batch_id)"
+)
+ORDERED_COVERAGE_UPSERT = (
+    "INSERT INTO coverage_records(provider,connection_id,stream,earliest_at,latest_at,"
+    "cursor_exhausted,retention_limit,unavailable_reason,status,batch_id,observed_at) "
+    "VALUES(?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(provider,connection_id,stream) DO UPDATE SET "
+    "earliest_at=excluded.earliest_at,latest_at=excluded.latest_at,"
+    "cursor_exhausted=excluded.cursor_exhausted,retention_limit=excluded.retention_limit,"
+    "unavailable_reason=excluded.unavailable_reason,status=excluded.status,"
+    "batch_id=excluded.batch_id,observed_at=excluded.observed_at "
+    "WHERE excluded.observed_at > coverage_records.observed_at OR "
+    "(excluded.observed_at = coverage_records.observed_at "
+    "AND excluded.batch_id > coverage_records.batch_id)"
+)
+
+
+def _stored_json(value: str, expected: type[Any], field: str) -> Any:
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as error:
+        raise SocialStoreError(f"stored Slack {field} is invalid") from error
+    if not isinstance(parsed, expected):
+        raise SocialStoreError(f"stored Slack {field} is invalid")
+    reject_slack_credentials(parsed)
+    return parsed
+
+
+def merge_connection_state(
+    database: sqlite3.Connection, archive: dict[str, Any]
+) -> dict[str, Any]:
+    """Merge mutable connection metadata while enforcing immutable identity fields."""
+    connection_id = archive["connection_id"]
+    row = database.execute(
+        "SELECT provider,remote_account_id,enabled_streams,policy_json "
+        "FROM connections WHERE connection_id=?",
+        (connection_id,),
+    ).fetchone()
+    if row is None:
+        return archive
+    binding = (row["provider"], row["remote_account_id"])
+    expected_binding = (PROVIDER, archive["remote_account_id"])
+    if binding != expected_binding:
+        raise SocialStoreError("Slack connection is already bound to another account")
+    policy = _stored_json(row["policy_json"], dict, "connection policy")
+    streams = _stored_json(row["enabled_streams"], list, "enabled streams")
+    if any(not isinstance(stream, str) for stream in streams):
+        raise SocialStoreError("stored Slack enabled streams are invalid")
+    incoming_policy = archive.get("policy")
+    if not isinstance(incoming_policy, dict):
+        raise SocialStoreError("Slack connection policy is invalid")
+    if any(field not in policy for field in IMMUTABLE_POLICY_FIELDS):
+        raise SocialStoreError("stored Slack identity policy is incomplete")
+    changed_identity = any(
+        policy[field] != incoming_policy.get(field)
+        for field in IMMUTABLE_POLICY_FIELDS
+    )
+    if changed_identity:
+        raise SocialStoreError("Slack connection identity policy was rebound")
+    latest_row = database.execute(
+        "SELECT max(completed_at) FROM fetch_batches "
+        "WHERE provider=? AND connection_id=?",
+        (PROVIDER, connection_id),
+    ).fetchone()
+    latest = latest_row[0] if latest_row is not None else None
+    merged_policy = dict(policy)
+    if latest is None or archive["exported_at"] > latest:
+        previous_scopes = policy.get("slack_read_scopes")
+        merged_policy.update(incoming_policy)
+        if not incoming_policy.get("slack_read_scopes") and previous_scopes:
+            merged_policy["slack_read_scopes"] = previous_scopes
+    merged_streams = list(streams)
+    for stream in archive.get("enabled_streams", []):
+        if not isinstance(stream, str):
+            raise SocialStoreError("Slack enabled stream is invalid")
+        if stream not in merged_streams:
+            merged_streams.append(stream)
+    return {**archive, "enabled_streams": merged_streams, "policy": merged_policy}
+
+
+def _account_values(record: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        PROVIDER,
+        required_text(record, "remote_id"),
+        optional_text(record, "handle"),
+        optional_text(record, "display_name"),
+        required_text(record, "observed_at"),
+        canonical_json(record.get("provider_json", {})),
+    )
+
+
+def _object_values(record: dict[str, Any], batch_id: str) -> tuple[Any, ...]:
+    return (
+        PROVIDER,
+        required_text(record, "object_type"),
+        required_text(record, "remote_id"),
+        optional_text(record, "account_remote_id"),
+        optional_text(record, "text"),
+        optional_text(record, "created_at"),
+        required_text(record, "observed_at"),
+        required_text(record, "evidence_class"),
+        canonical_json(record.get("provider_json", {})),
+        batch_id,
+    )
+
+
+def _activity_values(record: dict[str, Any], batch_id: str) -> tuple[Any, ...]:
+    return (
+        PROVIDER,
+        required_text(record, "activity_type"),
+        required_text(record, "remote_id"),
+        required_text(record, "actor_remote_id"),
+        optional_text(record, "object_remote_id"),
+        optional_text(record, "occurred_at"),
+        required_text(record, "observed_at"),
+        required_text(record, "state"),
+        canonical_json(record.get("provider_json", {})),
+        batch_id,
+    )
+
+
+def _coverage_values(
+    record: dict[str, Any], connection_id: str, batch_id: str
+) -> tuple[Any, ...]:
+    exhausted = record.get("cursor_exhausted", False)
+    if not isinstance(exhausted, bool):
+        raise SocialStoreError("coverage cursor_exhausted must be boolean")
+    return (
+        PROVIDER,
+        connection_id,
+        required_text(record, "stream"),
+        optional_text(record, "earliest_at"),
+        optional_text(record, "latest_at"),
+        int(exhausted),
+        optional_text(record, "retention_limit"),
+        optional_text(record, "unavailable_reason"),
+        required_text(record, "status"),
+        batch_id,
+        required_text(record, "observed_at"),
+    )
+
+
+def _import_media_ordered(
+    database: sqlite3.Connection, archive: dict[str, Any], batch_id: str
+) -> None:
+    observed_at = required_text(archive, "exported_at")
+    accepted: list[dict[str, Any]] = []
+    for record in record_list(archive, "media"):
+        remote_id = required_text(record, "remote_id")
+        row = database.execute(
+            "SELECT observed_at,batch_id FROM objects "
+            "WHERE provider=? AND object_type='file' AND remote_id=?",
+            (PROVIDER, remote_id),
+        ).fetchone()
+        if row is None or (row["observed_at"], row["batch_id"]) <= (
+            observed_at,
+            batch_id,
+        ):
+            accepted.append(record)
+    import_media(database, {**archive, "media": accepted}, PROVIDER, batch_id)
+
+
+def _refresh_fts(database: sqlite3.Connection, archive: dict[str, Any]) -> None:
+    for record in archive["objects"]:
+        identity = (PROVIDER, record["object_type"], record["remote_id"])
+        database.execute(
+            "DELETE FROM objects_fts WHERE provider=? AND object_type=? AND remote_id=?",
+            identity,
+        )
+        database.execute(
+            """INSERT INTO objects_fts(
+               provider,object_type,remote_id,account_remote_id,text_content,evidence_class)
+               SELECT provider,object_type,remote_id,account_remote_id,text_content,evidence_class
+                 FROM objects WHERE provider=? AND object_type=? AND remote_id=?""",
+            identity,
+        )
+
+
+def store_ordered_records(
+    database: sqlite3.Connection,
+    archive: dict[str, Any],
+    batch_id: str,
+    connection_id: str,
+) -> None:
+    """Upsert one normalized Slack archive in evidence timestamp order."""
+    upsert_connection(database, archive, PROVIDER, connection_id)
+    accounts = (_account_values(row) for row in record_list(archive, "accounts"))
+    objects = (
+        _object_values(row, batch_id) for row in record_list(archive, "objects")
+    )
+    activities = (
+        _activity_values(row, batch_id) for row in record_list(archive, "activities")
+    )
+    coverage = (
+        _coverage_values(row, connection_id, batch_id)
+        for row in record_list(archive, "coverage")
+    )
+    database.executemany(ORDERED_ACCOUNT_UPSERT, accounts)
+    database.executemany(ORDERED_OBJECT_UPSERT, objects)
+    database.executemany(ORDERED_ACTIVITY_UPSERT, activities)
+    _import_media_ordered(database, archive, batch_id)
+    database.executemany(ORDERED_COVERAGE_UPSERT, coverage)
+    _refresh_fts(database, archive)
+
+
+def _page_time_bounds(archive: dict[str, Any]) -> tuple[str | None, str | None]:
+    timestamps = [
+        value
+        for rows, key in (
+            (archive["objects"], "created_at"),
+            (archive["activities"], "occurred_at"),
+        )
+        for record in rows
+        if isinstance((value := record.get(key)), str) and value
+    ]
+    if not timestamps:
+        return None, None
+    return min(timestamps), max(timestamps)
+
+
+def _update_page_cursor(
+    database: sqlite3.Connection,
+    context: CollectionContext,
+    page: SuccessfulPage,
+    observed_at: str,
+) -> None:
+    database.execute(
+        """INSERT INTO sync_cursors(
+           connection_id,stream,cursor,watermark,last_success_at,backfill_complete)
+           VALUES(?,?,?,?,?,?) ON CONFLICT(connection_id,stream) DO UPDATE SET
+           cursor=excluded.cursor,watermark=excluded.watermark,
+           last_success_at=excluded.last_success_at,
+           backfill_complete=MAX(sync_cursors.backfill_complete,excluded.backfill_complete)
+           WHERE excluded.last_success_at >= sync_cursors.last_success_at""",
+        (
+            context.connection_id,
+            context.stream,
+            page.checkpoint.next_cursor,
+            page.checkpoint.watermark,
+            observed_at,
+            int(page.complete),
+        ),
+    )
+
+
+def _upsert_page_coverage(
+    database: sqlite3.Connection,
+    context: CollectionContext,
+    page: SuccessfulPage,
+    archive: dict[str, Any],
+    batch_id: str,
+) -> None:
+    earliest, latest = _page_time_bounds(archive)
+    status = page.coverage_status or ("complete" if page.complete else "partial")
+    database.execute(
+        """INSERT INTO coverage_records(
+           provider,connection_id,stream,earliest_at,latest_at,cursor_exhausted,
+           retention_limit,unavailable_reason,status,batch_id,observed_at)
+           VALUES(?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(provider,connection_id,stream)
+           DO UPDATE SET earliest_at=CASE
+             WHEN coverage_records.earliest_at IS NULL THEN excluded.earliest_at
+             WHEN excluded.earliest_at IS NULL THEN coverage_records.earliest_at
+             WHEN excluded.earliest_at < coverage_records.earliest_at
+               THEN excluded.earliest_at ELSE coverage_records.earliest_at END,
+           latest_at=CASE
+             WHEN coverage_records.latest_at IS NULL THEN excluded.latest_at
+             WHEN excluded.latest_at IS NULL THEN coverage_records.latest_at
+             WHEN excluded.latest_at > coverage_records.latest_at
+               THEN excluded.latest_at ELSE coverage_records.latest_at END,
+           cursor_exhausted=excluded.cursor_exhausted,
+           retention_limit=excluded.retention_limit,
+           unavailable_reason=excluded.unavailable_reason,status=excluded.status,
+           batch_id=excluded.batch_id,observed_at=excluded.observed_at
+           WHERE excluded.observed_at >= coverage_records.observed_at""",
+        (
+            PROVIDER,
+            context.connection_id,
+            context.stream,
+            earliest,
+            latest,
+            int(page.complete),
+            page.retention_limit,
+            page.unavailable_reason,
+            status,
+            batch_id,
+            archive["exported_at"],
+        ),
+    )
+
+
+def update_page_state(
+    database: sqlite3.Connection,
+    context: CollectionContext,
+    page: SuccessfulPage,
+    archive: dict[str, Any],
+    batch_id: str,
+) -> None:
+    """Advance one Slack stream cursor and its aggregate coverage monotonically."""
+    _update_page_cursor(database, context, page, archive["exported_at"])
+    _upsert_page_coverage(database, context, page, archive, batch_id)

--- a/.agents/scripts/_knowledge_social_slack_zip.py
+++ b/.agents/scripts/_knowledge_social_slack_zip.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded regular-file and ZIP handling for Slack JSON exports."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import stat
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from knowledge_social_store import SocialStoreError
+
+MAX_MEMBER_BYTES = 16 * 1024 * 1024
+
+
+def _unsafe_member_path(name: str, path: PurePosixPath) -> bool:
+    return any(
+        (
+            not name,
+            "\\" in name,
+            "\x00" in name,
+            path.is_absolute(),
+            any(part in {"", ".", ".."} for part in path.parts),
+        )
+    )
+
+
+def _validate_member_path(
+    info: zipfile.ZipInfo, seen: set[str], folded: set[str]
+) -> None:
+    name = info.filename
+    if _unsafe_member_path(name, PurePosixPath(name)):
+        raise SocialStoreError("Slack export contains an unsafe member path")
+    if name in seen or name.casefold() in folded:
+        raise SocialStoreError("Slack export contains duplicate member paths")
+    seen.add(name)
+    folded.add(name.casefold())
+
+
+def _validate_member_metadata(info: zipfile.ZipInfo) -> None:
+    mode = (info.external_attr >> 16) & 0o170000
+    if mode == stat.S_IFLNK:
+        raise SocialStoreError("Slack export cannot contain symbolic links")
+    if info.flag_bits & 0x1:
+        raise SocialStoreError("Slack export cannot contain encrypted members")
+    if info.file_size > MAX_MEMBER_BYTES:
+        raise SocialStoreError("Slack export member exceeds the byte budget")
+
+
+def _archive_open_flags(path: Path) -> int:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow:
+        flags |= nofollow
+    elif path.is_symlink():
+        raise SocialStoreError("Slack export must be a regular non-symlink file")
+    return flags
+
+
+def _validate_archive_metadata(metadata: os.stat_result, max_bytes: int) -> None:
+    if not stat.S_ISREG(metadata.st_mode):
+        raise SocialStoreError("Slack export must be a regular non-symlink file")
+    if metadata.st_size <= 0 or metadata.st_size > max_bytes:
+        raise SocialStoreError("Slack export exceeds the compressed byte budget")
+
+
+def _read_archive_descriptor(
+    path: Path, max_bytes: int
+) -> tuple[bytes, os.stat_result, os.stat_result]:
+    descriptor = os.open(path, _archive_open_flags(path))
+    try:
+        before = os.fstat(descriptor)
+        _validate_archive_metadata(before, max_bytes)
+        with os.fdopen(os.dup(descriptor), "rb") as source:
+            payload = source.read(max_bytes + 1)
+        after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    return payload, before, after
+
+
+def _file_identity(metadata: os.stat_result) -> tuple[int, int, int, int]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+    )
+
+
+def read_regular_archive(path: Path, max_bytes: int) -> bytes:
+    """Open one archive without following symlinks and reject in-place changes."""
+    try:
+        payload, before, after = _read_archive_descriptor(path, max_bytes)
+    except SocialStoreError:
+        raise
+    except OSError as error:
+        raise SocialStoreError("Slack export could not be opened safely") from error
+    if len(payload) > max_bytes:
+        raise SocialStoreError("Slack export changed while it was being read")
+    observed = (len(payload), _file_identity(after))
+    expected = (before.st_size, _file_identity(before))
+    if observed != expected:
+        raise SocialStoreError("Slack export changed while it was being read")
+    return payload
+
+
+@dataclass(frozen=True)
+class SlackArchiveIndex:
+    """Validated ZIP metadata with bounded exact-member readers."""
+
+    archive: zipfile.ZipFile
+    members: dict[str, zipfile.ZipInfo]
+
+    def __enter__(self) -> SlackArchiveIndex:
+        return self
+
+    def __exit__(self, *_error: object) -> None:
+        self.archive.close()
+
+    def member_bytes(self, name: str) -> bytes:
+        info = self.members.get(name)
+        if info is None:
+            raise SocialStoreError("Slack export is missing a required JSON member")
+        try:
+            value = self.archive.read(info)
+        except (
+            NotImplementedError,
+            OSError,
+            RuntimeError,
+            zipfile.BadZipFile,
+            zipfile.LargeZipFile,
+        ) as error:
+            raise SocialStoreError("Slack export member could not be read") from error
+        if len(value) != info.file_size or len(value) > MAX_MEMBER_BYTES:
+            raise SocialStoreError("Slack export member changed or exceeded its budget")
+        return value
+
+    def json_value(self, name: str) -> Any:
+        payload = self.member_bytes(name)
+        try:
+            return json.loads(payload.decode("utf-8"))
+        except (RecursionError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise SocialStoreError("Slack export member is not valid UTF-8 JSON") from error
+
+
+def index_archive(
+    payload: bytes, max_uncompressed_bytes: int, max_items: int
+) -> SlackArchiveIndex:
+    """Validate all ZIP metadata before any selected member is interpreted."""
+    try:
+        with zipfile.ZipFile(io.BytesIO(payload), "r") as archive:
+            infos = archive.infolist()
+    except (RuntimeError, zipfile.BadZipFile, zipfile.LargeZipFile) as error:
+        raise SocialStoreError("Slack export is not a supported ZIP file") from error
+    if len(infos) > max_items:
+        raise SocialStoreError("Slack export exceeds the member budget")
+    seen: set[str] = set()
+    folded: set[str] = set()
+    total = 0
+    members: dict[str, zipfile.ZipInfo] = {}
+    for info in infos:
+        _validate_member_path(info, seen, folded)
+        _validate_member_metadata(info)
+        if info.is_dir():
+            continue
+        total += info.file_size
+        if total > max_uncompressed_bytes:
+            raise SocialStoreError("Slack export exceeds the uncompressed byte budget")
+        members[info.filename] = info
+    try:
+        archive = zipfile.ZipFile(io.BytesIO(payload), "r")
+    except (RuntimeError, zipfile.BadZipFile, zipfile.LargeZipFile) as error:
+        raise SocialStoreError("Slack export is not a supported ZIP file") from error
+    return SlackArchiveIndex(archive, members)

--- a/.agents/scripts/knowledge_social_slack.py
+++ b/.agents/scripts/knowledge_social_slack.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect bounded read-only Slack API or approved-export evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import _knowledge_social_slack as slack
+from _knowledge_social_collect import CollectionContext, CursorState, SuccessfulPage
+from _knowledge_social_collect_cli import run_collector
+from _knowledge_social_lease import (
+    RunLease,
+    RunLeaseRequest,
+    acquire_run_lease,
+    fail_active_run,
+    release_run_lease,
+)
+from _knowledge_social_oauth_collector import OAuthCollector, OAuthCollectorPolicy
+from _knowledge_social_slack_archive import SlackArchiveRequest, build_slack_archive
+from _knowledge_social_slack_normalize import PageContext, normalize_page
+from _knowledge_social_slack_persist import persist_slack_archive, persist_slack_page
+from _knowledge_social_slack_provider import load_profile
+from _knowledge_social_slack_reader import FixtureSlack, GuardedSlack, verified_identity
+from knowledge_corpus_catalog import DEFAULT_ALIAS, resolve
+from knowledge_corpus_context import CatalogError
+from knowledge_social_store import SocialStoreError, validate_root
+
+DEFAULT_MAX_ARCHIVE_BYTES = 64 * 1024 * 1024
+DEFAULT_MAX_ARCHIVE_ITEMS = 25_000
+MAX_API_BUDGET = 17
+MAX_ARCHIVE_BYTES = 128 * 1024 * 1024
+MAX_ARCHIVE_ITEMS = 100_000
+
+API_POLICY = OAuthCollectorPolicy(
+    display_name="Slack",
+    provider_module=slack,
+    helper=Path(__file__).with_name("_knowledge_social_slack_provider.py"),
+    fixture_reader=FixtureSlack,
+    live_reader=GuardedSlack,
+    page_context=PageContext,
+    normalize_page=normalize_page,
+    verified_identity=verified_identity,
+    budget_unit="request",
+    default_budget=11,
+    min_budget=3,
+    max_page_size=15,
+)
+
+
+class SlackCollector(OAuthCollector):
+    """Use timestamp-ordered persistence for overlapping API/export evidence."""
+
+    def _persist_success(
+        self,
+        context: CollectionContext,
+        payload: dict[str, Any],
+        request: Any,
+    ) -> tuple[CollectionContext, int, bool]:
+        checkpoint, complete = slack.page_checkpoint(
+            payload, context.state, request
+        )
+        archive = normalize_page(payload, self._page_context(context))
+        page = SuccessfulPage(
+            payload,
+            request.evidence_key(),
+            archive,
+            checkpoint,
+            complete,
+            context.spec.cost_units,
+            retention_limit=context.spec.retention_limit,
+            unavailable_reason=context.spec.unavailable_reason,
+            coverage_status=context.spec.coverage_status,
+        )
+        resources = persist_slack_page(context, page)
+        state = CursorState(checkpoint.next_cursor, checkpoint.watermark, complete)
+        return replace(context, state=state), resources, complete
+
+
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be an integer") from error
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be positive")
+    return parsed
+
+
+def _add_api_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--base", type=Path)
+    parser.add_argument("--alias", default=DEFAULT_ALIAS)
+    parser.add_argument("--connection-id", required=True)
+    parser.add_argument("--account-id", required=True)
+    parser.add_argument("--stream", required=True)
+    parser.add_argument("--profile", required=True)
+    parser.add_argument("--budget", type=_positive_int, default=API_POLICY.default_budget)
+    parser.add_argument("--page-size", type=_positive_int, default=API_POLICY.max_page_size)
+    parser.add_argument("--collector-id")
+    parser.add_argument("--lease-seconds", type=_positive_int, default=300)
+    parser.add_argument("--fixture", type=Path, help=argparse.SUPPRESS)
+
+
+def _add_archive_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--base", type=Path)
+    parser.add_argument("--alias", default=DEFAULT_ALIAS)
+    parser.add_argument("--archive", type=Path, required=True)
+    parser.add_argument("--connection-id", required=True)
+    parser.add_argument("--account-id", required=True)
+    parser.add_argument("--profile", required=True)
+    parser.add_argument("--exported-at", required=True)
+    parser.add_argument(
+        "--max-bytes", type=_positive_int, default=DEFAULT_MAX_ARCHIVE_BYTES
+    )
+    parser.add_argument(
+        "--max-items", type=_positive_int, default=DEFAULT_MAX_ARCHIVE_ITEMS
+    )
+    parser.add_argument("--collector-id", default="slack_archive")
+    parser.add_argument("--lease-seconds", type=_positive_int, default=300)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    api_parser = subparsers.add_parser(
+        "api", help="collect one identity-bound Slack Web API stream"
+    )
+    _add_api_arguments(api_parser)
+    archive_parser = subparsers.add_parser(
+        "archive", help="import one approved Slack JSON export"
+    )
+    _add_archive_arguments(archive_parser)
+    args = parser.parse_args()
+    if args.command == "api":
+        try:
+            slack.parse_stream(args.stream)
+        except slack.SlackAdapterError as error:
+            parser.error(str(error))
+        if not 3 <= args.budget <= MAX_API_BUDGET:
+            parser.error(
+                f"--budget must be between 3 and {MAX_API_BUDGET} request units"
+            )
+        if not 1 <= args.page_size <= 15:
+            parser.error("--page-size must be between 1 and 15 items")
+        if args.lease_seconds > 86_400:
+            parser.error("--lease-seconds cannot exceed 86400")
+    elif args.command == "archive":
+        if args.max_bytes > MAX_ARCHIVE_BYTES:
+            parser.error(f"--max-bytes cannot exceed {MAX_ARCHIVE_BYTES}")
+        if args.max_items > MAX_ARCHIVE_ITEMS:
+            parser.error(f"--max-items cannot exceed {MAX_ARCHIVE_ITEMS}")
+        if args.lease_seconds > 86_400:
+            parser.error("--lease-seconds cannot exceed 86400")
+    return args
+
+
+def _run_api(args: argparse.Namespace) -> int:
+    collector = SlackCollector(API_POLICY, args)
+    return run_collector(args, collector.collect)
+
+
+def _release_safely(root: Path, lease: RunLease | None) -> None:
+    if lease is None:
+        return
+    try:
+        release_run_lease(root, lease)
+    except SocialStoreError:
+        return
+
+
+def _run_archive(args: argparse.Namespace) -> int:
+    root: Path | None = None
+    lease: RunLease | None = None
+    try:
+        base = (
+            args.base
+            if args.base is not None
+            else Path.home() / ".aidevops" / ".agent-workspace" / "knowledge"
+        )
+        root = validate_root(resolve(base, args.alias, "knowledge.write"))
+        profile = load_profile(
+            args.profile, require_token=False, include_token=False
+        )
+        parsed = build_slack_archive(
+            SlackArchiveRequest(
+                args.archive,
+                args.connection_id,
+                args.account_id,
+                args.exported_at,
+                profile,
+                args.max_bytes,
+                args.max_items,
+            )
+        )
+        lease = acquire_run_lease(
+            root,
+            RunLeaseRequest(
+                args.connection_id,
+                "archive",
+                args.collector_id,
+                "sync",
+                args.lease_seconds,
+                parsed.source_sha256,
+            ),
+        )
+        result = persist_slack_archive(root, parsed, lease)
+        _release_safely(root, lease)
+        lease = None
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    except (CatalogError, OSError, SocialStoreError, ValueError) as error:
+        if root is not None and lease is not None:
+            try:
+                fail_active_run(root, lease, "archive_validation")
+            except SocialStoreError:
+                pass
+            _release_safely(root, lease)
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+def main() -> int:
+    args = parse_args()
+    if args.command == "api":
+        return _run_api(args)
+    if args.command == "archive":
+        return _run_archive(args)
+    raise AssertionError("unsupported Slack command")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/tests/fixtures/knowledge-social-slack/api-history-incremental.json
+++ b/.agents/tests/fixtures/knowledge-social-slack/api-history-incremental.json
@@ -1,0 +1,54 @@
+{
+  "identity": {
+    "data": {
+      "id": "slack_T123ABC456_user_U123ABC456",
+      "provider_account_id": "U123ABC456",
+      "workspace_id": "T123ABC456",
+      "enterprise_id": null,
+      "token_type": "bot",
+      "scopes": ["channels:history"],
+      "conversation_binding_sha256": "3fcc8f8db59e6e3e71c06f82804df4a43cc456c1283010b6b809874c47136b4c"
+    }
+  },
+  "pages": [
+    {
+      "expect_request": {
+        "selector": "history",
+        "conversation_alias": "engineering",
+        "cursor": null,
+        "oldest": "1709395200.000001",
+        "limit": 1
+      },
+      "response": {
+        "status": 200,
+        "observed_at": "2026-07-31T19:02:00Z",
+        "data": [
+          {
+            "kind": "message",
+            "remote_id": "slack_T123ABC456_message_QzEyM0FCQzQ1NjoxNzEwMDAwMDAwLjAwMDAwMQ",
+            "conversation_remote_id": "slack_T123ABC456_conversation_QzEyM0FCQzQ1Ng",
+            "message_ts": "1710000000.000001",
+            "thread_remote_id": null,
+            "actor_remote_id": "slack_T123ABC456_user_U123ABC456",
+            "text": "edited Slack fixture knowledge",
+            "subtype": "message_changed",
+            "state": "edited",
+            "created_at": "2024-03-09T16:00:00.000001Z",
+            "edited_at": "2026-07-31T19:02:00Z",
+            "reactions": [],
+            "is_starred": false
+          }
+        ],
+        "meta": {
+          "stream": "conversation/engineering/history",
+          "selector": "history",
+          "workspace_id": "T123ABC456",
+          "next_cursor": null,
+          "newest_ts": "1710000000.000001",
+          "complete": true,
+          "source": "slack_web_api"
+        }
+      }
+    }
+  ]
+}

--- a/.agents/tests/fixtures/knowledge-social-slack/api-history-page-one.json
+++ b/.agents/tests/fixtures/knowledge-social-slack/api-history-page-one.json
@@ -1,0 +1,54 @@
+{
+  "identity": {
+    "data": {
+      "id": "slack_T123ABC456_user_U123ABC456",
+      "provider_account_id": "U123ABC456",
+      "workspace_id": "T123ABC456",
+      "enterprise_id": null,
+      "token_type": "bot",
+      "scopes": ["channels:history"],
+      "conversation_binding_sha256": "3fcc8f8db59e6e3e71c06f82804df4a43cc456c1283010b6b809874c47136b4c"
+    }
+  },
+  "pages": [
+    {
+      "expect_request": {
+        "selector": "history",
+        "conversation_alias": "engineering",
+        "cursor": null,
+        "oldest": null,
+        "limit": 1
+      },
+      "response": {
+        "status": 200,
+        "observed_at": "2026-07-31T19:00:00Z",
+        "data": [
+          {
+            "kind": "message",
+            "remote_id": "slack_T123ABC456_message_QzEyM0FCQzQ1NjoxNzEwMDAwMDAwLjAwMDAwMQ",
+            "conversation_remote_id": "slack_T123ABC456_conversation_QzEyM0FCQzQ1Ng",
+            "message_ts": "1710000000.000001",
+            "thread_remote_id": null,
+            "actor_remote_id": "slack_T123ABC456_user_U123ABC456",
+            "text": "bounded Slack fixture knowledge",
+            "subtype": null,
+            "state": "active",
+            "created_at": "2024-03-09T16:00:00.000001Z",
+            "edited_at": null,
+            "reactions": [],
+            "is_starred": false
+          }
+        ],
+        "meta": {
+          "stream": "conversation/engineering/history",
+          "selector": "history",
+          "workspace_id": "T123ABC456",
+          "next_cursor": "cursor-one",
+          "newest_ts": "1710000000.000001",
+          "complete": false,
+          "source": "slack_web_api"
+        }
+      }
+    }
+  ]
+}

--- a/.agents/tests/fixtures/knowledge-social-slack/api-history-page-two.json
+++ b/.agents/tests/fixtures/knowledge-social-slack/api-history-page-two.json
@@ -1,0 +1,54 @@
+{
+  "identity": {
+    "data": {
+      "id": "slack_T123ABC456_user_U123ABC456",
+      "provider_account_id": "U123ABC456",
+      "workspace_id": "T123ABC456",
+      "enterprise_id": null,
+      "token_type": "bot",
+      "scopes": ["channels:history"],
+      "conversation_binding_sha256": "3fcc8f8db59e6e3e71c06f82804df4a43cc456c1283010b6b809874c47136b4c"
+    }
+  },
+  "pages": [
+    {
+      "expect_request": {
+        "selector": "history",
+        "conversation_alias": "engineering",
+        "cursor": "cursor-one",
+        "oldest": null,
+        "limit": 1
+      },
+      "response": {
+        "status": 200,
+        "observed_at": "2026-07-31T19:01:00Z",
+        "data": [
+          {
+            "kind": "message",
+            "remote_id": "slack_T123ABC456_message_QzEyM0FCQzQ1NjoxNzA5MDAwMDAwLjAwMDAwMQ",
+            "conversation_remote_id": "slack_T123ABC456_conversation_QzEyM0FCQzQ1Ng",
+            "message_ts": "1709000000.000001",
+            "thread_remote_id": null,
+            "actor_remote_id": "slack_T123ABC456_user_U123ABC456",
+            "text": "older Slack fixture knowledge",
+            "subtype": null,
+            "state": "active",
+            "created_at": "2024-02-27T02:13:20.000001Z",
+            "edited_at": null,
+            "reactions": [],
+            "is_starred": false
+          }
+        ],
+        "meta": {
+          "stream": "conversation/engineering/history",
+          "selector": "history",
+          "workspace_id": "T123ABC456",
+          "next_cursor": null,
+          "newest_ts": "1709000000.000001",
+          "complete": true,
+          "source": "slack_web_api"
+        }
+      }
+    }
+  ]
+}

--- a/.agents/tests/fixtures/knowledge-social-slack/api-history.json
+++ b/.agents/tests/fixtures/knowledge-social-slack/api-history.json
@@ -1,0 +1,56 @@
+{
+  "identity": {
+    "data": {
+      "id": "slack_T123ABC456_user_U123ABC456",
+      "provider_account_id": "U123ABC456",
+      "workspace_id": "T123ABC456",
+      "enterprise_id": null,
+      "token_type": "bot",
+      "scopes": ["channels:history"],
+      "conversation_binding_sha256": "3fcc8f8db59e6e3e71c06f82804df4a43cc456c1283010b6b809874c47136b4c",
+      "username": "fixture-user",
+      "workspace_name": "Fixture Workspace"
+    }
+  },
+  "pages": [
+    {
+      "expect_request": {
+        "selector": "history",
+        "conversation_alias": "engineering",
+        "cursor": null,
+        "oldest": null,
+        "limit": 1
+      },
+      "response": {
+        "status": 200,
+        "observed_at": "2026-07-31T19:00:00Z",
+        "data": [
+          {
+            "kind": "message",
+            "remote_id": "slack_T123ABC456_message_QzEyM0FCQzQ1NjoxNzEwMDAwMDAwLjAwMDAwMQ",
+            "conversation_remote_id": "slack_T123ABC456_conversation_QzEyM0FCQzQ1Ng",
+            "message_ts": "1710000000.000001",
+            "thread_remote_id": null,
+            "actor_remote_id": "slack_T123ABC456_user_U123ABC456",
+            "text": "bounded Slack fixture knowledge",
+            "subtype": null,
+            "state": "active",
+            "created_at": "2024-03-09T16:00:00.000001Z",
+            "edited_at": null,
+            "reactions": [],
+            "is_starred": false
+          }
+        ],
+        "meta": {
+          "stream": "conversation/engineering/history",
+          "selector": "history",
+          "workspace_id": "T123ABC456",
+          "next_cursor": null,
+          "newest_ts": "1710000000.000001",
+          "complete": true,
+          "source": "slack_web_api"
+        }
+      }
+    }
+  ]
+}

--- a/.agents/tests/fixtures/slack-archive-fixture.py
+++ b/.agents/tests/fixtures/slack-archive-fixture.py
@@ -84,7 +84,8 @@ def _base_members(mode: str) -> dict[str, Any]:
     elif mode == "stale":
         messages[0]["text"] = "stale archive fixture knowledge"
     elif mode == "credential":
-        messages[0]["access_token"] = "fixture-redacted-value"
+        # Synthetic non-secret value exercises credential-key rejection.
+        messages[0]["access_token"] = "fixture-redacted-value"  # nosec B105
     elif mode == "credential-scalar":
         messages[0]["text"] = SYNTHETIC_TOKEN
     return {

--- a/.agents/tests/fixtures/slack-archive-fixture.py
+++ b/.agents/tests/fixtures/slack-archive-fixture.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Build private-free Slack JSON export fixtures for collector tests."""
+
+from __future__ import annotations
+
+import json
+import stat
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any
+
+WORKSPACE = "T123ABC456"
+SELECTED_USER = "U123ABC456"
+OTHER_USER = "U999ABC456"
+CHANNEL = "C123ABC456"
+OTHER_CHANNEL = "C999ABC456"
+TOKEN_PREFIX = "xo" + "xb" + "-"
+SYNTHETIC_TOKEN = TOKEN_PREFIX + "123456789012-" + "A1b2C3d4E5f6G7h8" * 2
+
+
+def _json(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True).encode("utf-8")
+
+
+def _write(archive: zipfile.ZipFile, name: str, value: Any) -> None:
+    info = zipfile.ZipInfo(name, (2026, 7, 31, 19, 0, 0))
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.external_attr = (stat.S_IFREG | 0o600) << 16
+    archive.writestr(info, _json(value))
+
+
+def _base_members(mode: str) -> dict[str, Any]:
+    selected = SELECTED_USER if mode != "wrong-account" else "U888ABC456"
+    workspace = WORKSPACE if mode != "wrong-workspace" else "T888ABC456"
+    selected_workspace = (
+        "T777ABC456" if mode == "conflicting-workspace" else workspace
+    )
+    messages = [
+        {
+            "type": "message",
+            "user": selected,
+            "text": "bounded Slack fixture knowledge",
+            "ts": "1710000000.000001",
+            "reactions": [{"name": "eyes", "count": 1, "users": [selected]}],
+            "files": [
+                {
+                    "id": "F123ABC456",
+                    "user": selected,
+                    "name": "fixture.txt",
+                    "title": "Fixture attachment",
+                    "mimetype": "text/plain",
+                    "size": 42,
+                    "timestamp": 1710000000,
+                    "url_private": "https://files.example.invalid/credential-bearing-link",
+                }
+            ],
+        },
+        {
+            "type": "message",
+            "subtype": "message_changed",
+            "user": selected,
+            "editor_id": selected,
+            "text": "edited fixture knowledge",
+            "previous": {"text": "old fixture knowledge"},
+            "original_ts": "1710000001.000001",
+            "ts": "1710000010.000001",
+        },
+        {
+            "type": "message",
+            "subtype": "message_deleted",
+            "user": selected,
+            "editor_id": selected,
+            "text": "",
+            "previous": {"text": "deleted fixture knowledge"},
+            "original_ts": "1710000002.000001",
+            "ts": "1710000011.000001",
+        },
+    ]
+    if mode == "changed":
+        messages[0]["text"] = "updated archive fixture knowledge"
+    elif mode == "stale":
+        messages[0]["text"] = "stale archive fixture knowledge"
+    elif mode == "credential":
+        messages[0]["access_token"] = "fixture-redacted-value"
+    elif mode == "credential-scalar":
+        messages[0]["text"] = SYNTHETIC_TOKEN
+    return {
+        "team_info.json": {"id": workspace, "name": "Fixture Workspace"},
+        "users.json": [
+            {
+                "id": selected,
+                "team_id": selected_workspace,
+                "name": "fixture-user",
+                "deleted": False,
+                "is_bot": False,
+                "is_restricted": False,
+                "profile": {
+                    "display_name": "Fixture User",
+                    "real_name": "Fixture User",
+                    "email": "not-collected@example.invalid",
+                },
+            },
+            {
+                "id": OTHER_USER,
+                "team_id": workspace,
+                "name": "other-user",
+                "profile": {"display_name": "Other User"},
+            },
+        ],
+        "channels.json": [
+            {
+                "id": CHANNEL,
+                "name": ".." if mode == "unsafe-folder" else "engineering",
+                "created": 1710000000,
+                "members": [selected],
+                "topic": {"value": "Bounded topic"},
+                "purpose": {"value": "Fixture purpose"},
+            },
+            {
+                "id": OTHER_CHANNEL,
+                "name": "unselected",
+                "members": [OTHER_USER],
+            },
+        ],
+        "engineering/2026-07-31.json": messages,
+        "unselected/2026-07-31.json": [
+            {
+                "type": "message",
+                "user": OTHER_USER,
+                "text": "must-not-persist-from-unselected-conversation",
+                "ts": "1710000999.000001",
+            }
+        ],
+    }
+
+
+def build(path: Path, mode: str) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        members = _base_members(mode)
+        if mode in {"duplicate-folder", "casefold-folder"}:
+            members["channels.json"].append(
+                {
+                    "id": "C777ABC456",
+                    "name": (
+                        "Engineering" if mode == "casefold-folder" else "engineering"
+                    ),
+                    "members": [SELECTED_USER],
+                }
+            )
+        for name, value in members.items():
+            _write(archive, name, value)
+        if mode == "traversal":
+            _write(archive, "../escape.json", {})
+        elif mode == "duplicate":
+            _write(archive, "USERS.json", [])
+        elif mode == "member-symlink":
+            info = zipfile.ZipInfo("unsafe-link", (2026, 7, 31, 19, 0, 0))
+            info.external_attr = (stat.S_IFLNK | 0o777) << 16
+            archive.writestr(info, b"users.json")
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: slack-archive-fixture.py PATH MODE")
+    build(Path(sys.argv[1]), sys.argv[2])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/tests/test-knowledge-social-slack.sh
+++ b/.agents/tests/test-knowledge-social-slack.sh
@@ -1,0 +1,1584 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-slack.sh — Slack API and approved-export collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+export AIDEVOPS_SOCIAL_NOW_EPOCH=1785524400
+export SLACK_FIXTURE_WORKSPACE_ID=T123ABC456
+export SLACK_FIXTURE_TOKEN_TYPE=bot
+export SLACK_FIXTURE_CONVERSATIONS='{"engineering":{"id":"C123ABC456","kind":"public_channel"}}'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SLACK_ENTRY="${SCRIPT_DIR}/../scripts/knowledge_social_slack.py"
+SOCIAL_HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+FIXTURES="${SCRIPT_DIR}/fixtures/knowledge-social-slack"
+ARCHIVE_BUILDER="${SCRIPT_DIR}/fixtures/slack-archive-fixture.py"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+ACCOUNT_ID="slack_T123ABC456_user_U123ABC456"
+MESSAGE_ID="slack_T123ABC456_message_QzEyM0FCQzQ1NjoxNzEwMDAwMDAwLjAwMDAwMQ"
+BINDING_HASH="3fcc8f8db59e6e3e71c06f82804df4a43cc456c1283010b6b809874c47136b4c"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' \
+			"$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c \
+		'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_count() {
+	python3 - "$ROOT/sources/social/raw/slack" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+print(len(list(root.rglob("*.json.gz"))) if root.exists() else 0)
+PY
+	return 0
+}
+
+raw_archive_contains() {
+	local connection_id="$1"
+	local needle="$2"
+	python3 - "$ROOT/sources/social/raw/slack/$connection_id" "$needle" <<'PY'
+import gzip
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+needle = sys.argv[2]
+present = False
+for path in root.glob("*.json.gz") if root.exists() else ():
+    with gzip.open(path, "rt", encoding="utf-8") as source:
+        present = present or needle in source.read()
+print("present" if present else "absent")
+PY
+	return 0
+}
+
+api_sync() {
+	local fixture="$1"
+	local connection_id="$2"
+	local budget="$3"
+	if python3 "$SLACK_ENTRY" api --base "$BASE" --alias personal:default \
+		--connection-id "$connection_id" --account-id "$ACCOUNT_ID" \
+		--stream conversation/engineering/history --profile fixture \
+		--fixture "$fixture" --budget "$budget" --page-size 1; then
+		return 0
+	fi
+	return 1
+}
+
+archive_import() {
+	local archive="$1"
+	local connection_id="$2"
+	local exported_at="${3:-2026-07-31T19:04:00Z}"
+	if python3 "$SLACK_ENTRY" archive --base "$BASE" --alias personal:default \
+		--archive "$archive" --connection-id "$connection_id" \
+		--account-id "$ACCOUNT_ID" --profile fixture \
+		--exported-at "$exported_at"; then
+		return 0
+	fi
+	return 1
+}
+
+expect_archive_failure() {
+	local description="$1"
+	local archive="$2"
+	local connection_id="$3"
+	if archive_import "$archive" "$connection_id" >/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$SOCIAL_HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'Slack social collector tests\n'
+
+docs_output=$(<"$SCRIPT_DIR/../content/social-slack.md")
+if [[ "$docs_output" == *'SLACK_<PROFILE>_CONVERSATIONS='* &&
+	"$docs_output" == *'POST bookmarks.list'* ]]; then
+	assert_eq "Slack operator guide records profile and read-scope evidence" \
+		verified verified
+else
+	assert_eq "Slack operator guide records profile and read-scope evidence" \
+		missing verified
+fi
+
+python3 - "$SCRIPT_DIR/../scripts" "$ROOT" <<'PY'
+import ast
+import io
+import json
+import os
+import sqlite3
+import sys
+import zipfile
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+root = Path(sys.argv[2])
+sys.path.insert(0, str(scripts))
+
+from _knowledge_social_collect import (
+    CollectionContext,
+    ConnectionConfig,
+    CursorState,
+    PageCheckpoint,
+    SuccessfulPage,
+)
+from _knowledge_social_collect_persist import persist_page
+from _knowledge_social_lease import (
+    RunLeaseRequest,
+    acquire_run_lease,
+    release_run_lease,
+    renew_run_lease,
+)
+from _knowledge_social_slack import (
+    STREAMS,
+    SlackAdapterError,
+    page_request,
+    parse_stream,
+)
+from _knowledge_social_slack_contract import (
+    ApiResult,
+    IdentityBinding,
+    SlackReadProviderError,
+    identity_value,
+)
+from _knowledge_social_slack_evidence_guard import reject_slack_credentials
+from _knowledge_social_slack_http import (
+    HTTP_TIMEOUT_SECONDS,
+    READ_METHODS,
+    _RejectRedirects,
+    api,
+)
+from _knowledge_social_slack_normalize import (
+    API_SOURCE,
+    NormalizationBatch,
+    PageContext,
+    canonical_observed_at,
+    normalize_records,
+)
+from _knowledge_social_slack_provider import load_profile
+from _knowledge_social_slack_persist import persist_slack_page
+from _knowledge_social_slack_records import message_record, reaction_item_records
+from _knowledge_social_slack_routes import page
+from _knowledge_social_slack_store import store_ordered_records
+import _knowledge_social_slack_zip as slack_zip
+from knowledge_social_store import connect, migrate
+
+
+def must_reject(callback):
+    try:
+        callback()
+    except (SlackAdapterError, SlackReadProviderError):
+        return
+    raise AssertionError("unsafe Slack operation was accepted")
+
+
+expected_methods = {
+    "auth.test": "POST",
+    "team.info": "GET",
+    "users.list": "GET",
+    "conversations.info": "GET",
+    "conversations.members": "GET",
+    "conversations.history": "GET",
+    "conversations.replies": "GET",
+    "pins.list": "GET",
+    "bookmarks.list": "POST",
+    "files.list": "GET",
+    "reactions.list": "GET",
+}
+assert READ_METHODS == expected_methods
+assert set(STREAMS) == {"workspace", "users", "reactions"}
+assert "conversation/engineering/history" in STREAMS
+assert "conversation/engineering/thread/1710000000.000001" in STREAMS
+assert parse_stream("conversation/engineering/files").kind == "files"
+assert STREAMS["conversation/engineering/pins"].coverage_status == "partial"
+assert STREAMS["conversation/engineering/bookmarks"].coverage_status == "partial"
+must_reject(lambda: parse_stream("conversation/engineering/admin"))
+assert canonical_observed_at("2026-07-31T19:00:00Z") == (
+    "2026-07-31T19:00:00.000000Z"
+)
+assert canonical_observed_at("2026-07-31T19:00:00Z") < canonical_observed_at(
+    "2026-07-31T19:00:00.000001Z"
+)
+must_reject(lambda: canonical_observed_at("2026-07-31T19:00:00"))
+reject_slack_credentials({"text": "discussion of token rotation is allowed"})
+token_prefix = "xo" + "xb" + "-"
+reject_slack_credentials({"text": token_prefix + "1" * 40})
+reject_slack_credentials({"text": token_prefix + "example-placeholder"})
+reject_slack_credentials({"text": token_prefix + "1" * 12 + "-" + "a" * 32})
+synthetic_token = token_prefix + "123456789012-" + "A1b2C3d4E5f6G7h8" * 2
+must_reject(
+    lambda: reject_slack_credentials({"text": synthetic_token})
+)
+must_reject(
+    lambda: reject_slack_credentials(
+        {
+            "text": "https://hooks.slack.com/triggers/"
+            + "A" * 12
+            + "/"
+            + "b" * 32
+        }
+    )
+)
+active_token = "fixture-active-secret-" + "1" * 20
+must_reject(
+    lambda: reject_slack_credentials(
+        {"text": f"reflected {active_token}"}, exact_secret=active_token
+    )
+)
+
+zip_payload = io.BytesIO()
+with zipfile.ZipFile(zip_payload, "w") as fixture_zip:
+    fixture_zip.writestr("fixture.json", b"{}")
+real_zip_file = slack_zip.zipfile.ZipFile
+zip_opens = [0]
+
+
+def counting_zip_file(*args, **kwargs):
+    zip_opens[0] += 1
+    return real_zip_file(*args, **kwargs)
+
+
+slack_zip.zipfile.ZipFile = counting_zip_file
+try:
+    with slack_zip.index_archive(zip_payload.getvalue(), 1024, 2) as zip_index:
+        assert zip_index.member_bytes("fixture.json") == b"{}"
+        assert zip_index.member_bytes("fixture.json") == b"{}"
+finally:
+    slack_zip.zipfile.ZipFile = real_zip_file
+assert zip_opens == [2]
+assert zip_index.archive.fp is None
+
+
+def ordered_archive(connection_id, label):
+    observed_at = "2026-07-31T19:00:20.000000Z"
+    account_id = "slack_T123ABC456_user_U123ABC456"
+    return {
+        "provider": "slack",
+        "connection_id": connection_id,
+        "remote_account_id": account_id,
+        "exported_at": observed_at,
+        "enabled_streams": ["workspace"],
+        "policy": {},
+        "accounts": [
+            {
+                "remote_id": account_id,
+                "handle": label,
+                "display_name": label,
+                "observed_at": observed_at,
+                "provider_json": {"label": label},
+            }
+        ],
+        "objects": [
+            {
+                "object_type": object_type,
+                "remote_id": remote_id,
+                "account_remote_id": account_id,
+                "text": label,
+                "created_at": observed_at,
+                "observed_at": observed_at,
+                "evidence_class": "observed",
+                "provider_json": {"label": label},
+            }
+            for object_type, remote_id in (
+                ("message", "shared-message"),
+                ("file", "shared-file"),
+            )
+        ],
+        "activities": [
+            {
+                "activity_type": "message",
+                "remote_id": "shared-activity",
+                "actor_remote_id": account_id,
+                "object_remote_id": "shared-message",
+                "occurred_at": observed_at,
+                "observed_at": observed_at,
+                "state": "active",
+                "provider_json": {"label": label},
+            }
+        ],
+        "media": [
+            {
+                "remote_id": "shared-file",
+                "object_remote_id": "shared-file",
+                "content_sha256": None,
+                "mime_type": f"text/{label}",
+                "byte_size": 1,
+                "blob_ref": None,
+                "hydration_state": "metadata_only",
+            }
+        ],
+        "coverage": [],
+    }
+
+
+def tie_result(directory, observations):
+    directory.mkdir(mode=0o700)
+    database = connect(directory)
+    try:
+        migrate(database)
+        for connection_id, label, batch_id in observations:
+            store_ordered_records(
+                database,
+                ordered_archive(connection_id, label),
+                batch_id,
+                connection_id,
+            )
+        return (
+            database.execute(
+                "SELECT handle FROM accounts WHERE provider='slack'"
+            ).fetchone()[0],
+            tuple(
+                database.execute(
+                    "SELECT text_content,batch_id FROM objects "
+                    "WHERE provider='slack' AND object_type='message'"
+                ).fetchone()
+            ),
+            tuple(
+                database.execute(
+                    "SELECT json_extract(provider_json,'$.label'),batch_id "
+                    "FROM activities WHERE provider='slack'"
+                ).fetchone()
+            ),
+            tuple(
+                database.execute(
+                    "SELECT mime_type,batch_id FROM media WHERE provider='slack'"
+                ).fetchone()
+            ),
+        )
+    finally:
+        database.close()
+
+
+alpha = ("conn_tie_alpha", "alpha", "a" * 64)
+beta = ("conn_tie_beta", "beta", "b" * 64)
+forward_tie = tie_result(root.parent / "tie-forward", (alpha, beta))
+reverse_tie = tie_result(root.parent / "tie-reverse", (beta, alpha))
+assert forward_tie == reverse_tie
+assert forward_tie == (
+    "beta",
+    ("beta", "b" * 64),
+    ("beta", "b" * 64),
+    ("text/beta", "b" * 64),
+)
+
+profile = load_profile("fixture", require_token=False)
+assert profile.token is None
+assert profile.binding == IdentityBinding("T123ABC456", None, "bot")
+assert profile.conversations["engineering"].conversation_id == "C123ABC456"
+assert profile.conversation_binding_sha256 == (
+    "3fcc8f8db59e6e3e71c06f82804df4a43cc456c1283010b6b809874c47136b4c"
+)
+os.environ["SLACK_FIXTURE_ACCESS_TOKEN"] = "fixture-archive-token"
+assert load_profile(
+    "fixture", require_token=False, include_token=False
+).token is None
+os.environ.pop("SLACK_FIXTURE_ACCESS_TOKEN")
+
+direct_account = {
+    "id": "slack_T123ABC456_user_U123ABC456",
+    "provider_account_id": "U123ABC456",
+    "workspace_id": "T123ABC456",
+    "enterprise_id": None,
+    "token_type": "bot",
+    "scopes": ["team:read"],
+    "conversation_binding_sha256": profile.conversation_binding_sha256,
+    "username": "fixture-user",
+    "workspace_name": "Fixture Workspace",
+}
+direct_config = ConnectionConfig(("workspace",), {"media_hydration": "none"})
+
+
+def direct_context(connection_id, lease):
+    return CollectionContext(
+        root,
+        connection_id,
+        direct_account,
+        "workspace",
+        "none",
+        direct_config,
+        CursorState(None, None, False),
+        STREAMS["workspace"],
+        lease=lease,
+        provider="slack",
+    )
+
+
+def direct_archive(connection_id, observed_at):
+    return normalize_records(
+        [],
+        PageContext(
+            connection_id,
+            direct_account,
+            "workspace",
+            direct_config.enabled_streams,
+            direct_config.policy,
+        ),
+        NormalizationBatch(observed_at, API_SOURCE),
+    )
+
+
+credential_connection = "conn_direct_credential"
+credential_lease = acquire_run_lease(
+    root,
+    RunLeaseRequest(
+        credential_connection, "workspace", "direct_credential", "sync", 300
+    ),
+)
+credential_time = "2026-07-31T19:00:30.000000Z"
+try:
+    must_reject(
+        lambda: persist_slack_page(
+            direct_context(credential_connection, credential_lease),
+            SuccessfulPage(
+                {
+                    "status": 200,
+                    "observed_at": credential_time,
+                    "data": [{"text": synthetic_token}],
+                },
+                "direct-credential-boundary",
+                direct_archive(credential_connection, credential_time),
+                PageCheckpoint(None, None),
+                True,
+                2,
+            ),
+        )
+    )
+finally:
+    assert release_run_lease(root, credential_lease)
+
+rollback_connection = "conn_direct_rollback"
+rollback_lease = acquire_run_lease(
+    root,
+    RunLeaseRequest(
+        rollback_connection, "workspace", "direct_rollback", "sync", 300
+    ),
+)
+rollback_time = "2026-07-31T19:00:31.000000Z"
+malformed_archive = direct_archive(rollback_connection, rollback_time)
+del malformed_archive["objects"]
+try:
+    persist_slack_page(
+        direct_context(rollback_connection, rollback_lease),
+        SuccessfulPage(
+            {"status": 200, "observed_at": rollback_time, "data": []},
+            "direct-rollback-boundary",
+            malformed_archive,
+            PageCheckpoint(None, None),
+            True,
+            2,
+        ),
+    )
+except KeyError:
+    pass
+else:
+    raise AssertionError("malformed Slack page unexpectedly persisted")
+finally:
+    assert release_run_lease(root, rollback_lease)
+
+for connection_id in (credential_connection, rollback_connection):
+    raw_root = root / "sources" / "social" / "raw" / "slack" / connection_id
+    assert not list(raw_root.glob("*.json.gz")) if raw_root.exists() else True
+with sqlite3.connect(root / "index" / "social.db") as database:
+    assert database.execute(
+        "SELECT count(*) FROM fetch_batches WHERE connection_id IN (?,?)",
+        (credential_connection, rollback_connection),
+    ).fetchone()[0] == 0
+
+reaction_file = {
+    "type": "file",
+    "file": {
+        "id": "F123ABC456",
+        "user": "U123ABC456",
+        "channels": ["C999ABC456"],
+        "groups": [],
+        "ims": [],
+    },
+}
+assert reaction_item_records(
+    reaction_file, "T123ABC456", frozenset({"C123ABC456"})
+) == []
+reaction_file["file"]["channels"] = ["C123ABC456"]
+assert len(
+    reaction_item_records(
+        reaction_file, "T123ABC456", frozenset({"C123ABC456"})
+    )
+) == 1
+reaction_file["file"]["channels"] = "C123ABC456"
+must_reject(
+    lambda: reaction_item_records(
+        reaction_file, "T123ABC456", frozenset({"C123ABC456"})
+    )
+)
+must_reject(
+    lambda: reaction_item_records(
+        {
+            "type": "message",
+            "channel": "C123ABC456",
+            "message": {
+                "type": "message",
+                "user": "U123ABC456",
+                "text": "bounded reactions",
+                "ts": "1710000000.000001",
+                "reactions": [
+                    {
+                        "name": "eyes",
+                        "count": 101,
+                        "users": ["U123ABC456"] * 101,
+                    }
+                ],
+            },
+        },
+        "T123ABC456",
+        frozenset({"C123ABC456"}),
+    )
+)
+edited_message = message_record(
+    {
+        "type": "message",
+        "user": "U123ABC456",
+        "text": "edited message",
+        "ts": "1710000000.000001",
+        "edited": {"user": "U999ABC456", "ts": "1710000001.000001"},
+    },
+    "T123ABC456",
+    "C123ABC456",
+)[0]
+assert edited_message["state"] == "edited"
+assert edited_message["editor_remote_id"] == (
+    "slack_T123ABC456_user_U999ABC456"
+)
+
+account = {
+    "id": "slack_T123ABC456_user_U123ABC456",
+    "provider_account_id": "U123ABC456",
+    "workspace_id": "T123ABC456",
+    "enterprise_id": None,
+    "token_type": "bot",
+    "scopes": ["files:read"],
+    "conversation_binding_sha256": profile.conversation_binding_sha256,
+}
+tombstoned = normalize_records(
+    [
+        {
+            "kind": "file",
+            "remote_id": "slack_T123ABC456_file_RjEyM0FCQzQ1Ng",
+            "actor_remote_id": account["id"],
+            "is_tombstoned": True,
+        }
+    ],
+    PageContext(
+        "conn_tombstone",
+        account,
+        "conversation/engineering/files",
+        ("conversation/engineering/files",),
+        {},
+    ),
+    NormalizationBatch("2026-07-31T19:00:00Z", API_SOURCE),
+)
+assert tombstoned["activities"][0]["state"] == "deleted"
+incremental = page_request(
+    "conversation/engineering/history",
+    account,
+    CursorState(None, "1710000000.000001", True),
+    1,
+)
+assert incremental.oldest == "1709395200.000001"
+thread = page_request(
+    "conversation/engineering/thread/1710000000.000001",
+    account,
+    CursorState(None, None, False),
+    1,
+)
+assert thread.selector == "thread" and thread.thread_ts == "1710000000.000001"
+
+
+class Response:
+    def __init__(self, payload, scopes=None, status=200, retry_after=None):
+        self.payload = json.dumps(payload).encode("utf-8")
+        self.status = status
+        self.headers = {}
+        if scopes is not None:
+            self.headers["X-OAuth-Scopes"] = scopes
+        if retry_after is not None:
+            self.headers["Retry-After"] = retry_after
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def read(self, size=-1):
+        return self.payload[:size] if size >= 0 else self.payload
+
+
+class Opener:
+    def __init__(self, response):
+        self.response = response
+        self.requests = []
+
+    def open(self, request, timeout):
+        assert timeout == HTTP_TIMEOUT_SECONDS
+        assert "fixture-read-token" not in request.full_url
+        self.requests.append(request)
+        return self.response
+
+
+team_opener = Opener(Response({"ok": True, "team": {}}, "team:read"))
+team_result = api("fixture-read-token", team_opener, "team.info", {})
+assert team_result.status == 200
+assert team_opener.requests[0].method == "GET"
+assert team_opener.requests[0].data is None
+assert team_opener.requests[0].headers["Authorization"] == "Bearer fixture-read-token"
+
+bookmark_opener = Opener(Response({"ok": True, "bookmarks": []}, "bookmarks:read"))
+api(
+    "fixture-read-token",
+    bookmark_opener,
+    "bookmarks.list",
+    {"channel_id": "C123ABC456"},
+)
+assert bookmark_opener.requests[0].method == "POST"
+assert bookmark_opener.requests[0].data == b"channel_id=C123ABC456"
+
+must_reject(
+    lambda: api(
+        "fixture-read-token",
+        Opener(Response({"ok": True}, "chat:write")),
+        "auth.test",
+        {},
+    )
+)
+must_reject(
+    lambda: api(
+        "fixture-read-token",
+        Opener(Response({"ok": True})),
+        "auth.test",
+        {},
+    )
+)
+must_reject(
+    lambda: api(
+        "fixture-read-token",
+        Opener(Response({"ok": True}, "team:read")),
+        "chat.postMessage",
+        {},
+    )
+)
+rate = api(
+    "fixture-read-token",
+    Opener(Response({"ok": False, "error": "ratelimited"}, status=429, retry_after="30")),
+    "team.info",
+    {},
+)
+assert rate.status == 429 and rate.retry_after == "30"
+assert (
+    _RejectRedirects().redirect_request(None, None, 302, "moved", {}, "https://example.invalid")
+    is None
+)
+
+identity = identity_value(
+    {
+        "ok": True,
+        "team_id": "T123ABC456",
+        "user_id": "U123ABC456",
+        "bot_id": "B123ABC456",
+    },
+    account["id"],
+    profile.binding,
+    frozenset({"channels:history"}),
+)
+assert identity["id"] == account["id"]
+must_reject(
+    lambda: identity_value(
+        {
+            "ok": True,
+            "team_id": "T123ABC456",
+            "user_id": "U999ABC456",
+            "bot_id": "B123ABC456",
+        },
+        account["id"],
+        profile.binding,
+        frozenset({"channels:history"}),
+    )
+)
+
+
+def history_api(endpoint, params):
+    assert endpoint == "conversations.history"
+    assert params == {
+        "channel": "C123ABC456",
+        "limit": "1",
+        "oldest": "1709395200.000001",
+        "inclusive": "true",
+    }
+    return ApiResult(
+        200,
+        {
+            "ok": True,
+            "messages": [
+                {
+                    "type": "message",
+                    "user": "U123ABC456",
+                    "text": "bounded route fixture",
+                    "ts": "1710000000.000001",
+                }
+            ],
+            "response_metadata": {"next_cursor": ""},
+        },
+        frozenset({"channels:history"}),
+    )
+
+
+routed = page(
+    history_api,
+    incremental,
+    {**identity, "scopes": ["channels:history"]},
+    profile.conversations,
+)
+assert routed["data"][0]["remote_id"] == (
+    "slack_T123ABC456_message_QzEyM0FCQzQ1NjoxNzEwMDAwMDAwLjAwMDAwMQ"
+)
+must_reject(
+    lambda: page(
+        history_api,
+        incremental,
+        {**identity, "scopes": ["channels:history"]},
+        {},
+    )
+)
+
+
+def run_route(stream, scope, endpoint, payload):
+    request = page_request(stream, account, CursorState(None, None, False), 1)
+    calls = []
+
+    def route_api(actual_endpoint, params):
+        calls.append((actual_endpoint, params))
+        return ApiResult(200, payload, frozenset({scope}))
+
+    result = page(
+        route_api,
+        request,
+        {**identity, "scopes": [scope]},
+        profile.conversations,
+    )
+    assert calls and calls[0][0] == endpoint
+    return result
+
+
+workspace = run_route(
+    "workspace",
+    "team:read",
+    "team.info",
+    {"ok": True, "team": {"id": "T123ABC456", "name": "Fixture"}},
+)
+assert workspace["data"][0]["kind"] == "workspace"
+users = run_route(
+    "users",
+    "users:read",
+    "users.list",
+    {
+        "ok": True,
+        "members": [
+            {
+                "id": "U123ABC456",
+                "name": "fixture-user",
+                "profile": {"display_name": "Fixture User"},
+            }
+        ],
+        "response_metadata": {"next_cursor": ""},
+    },
+)
+assert users["data"][0]["kind"] == "user"
+reactions = run_route(
+    "reactions",
+    "reactions:read",
+    "reactions.list",
+    {
+        "ok": True,
+        "items": [
+            {
+                "type": "message",
+                "channel": "C123ABC456",
+                "message": {
+                    "user": "U123ABC456",
+                    "text": "Reaction fixture",
+                    "ts": "1710000000.000001",
+                },
+            }
+        ],
+        "response_metadata": {"next_cursor": ""},
+    },
+)
+assert reactions["data"][0]["kind"] == "message"
+info = run_route(
+    "conversation/engineering/info",
+    "channels:read",
+    "conversations.info",
+    {
+        "ok": True,
+        "channel": {
+            "id": "C123ABC456",
+            "name": "engineering",
+            "is_channel": True,
+        },
+    },
+)
+assert info["data"][0]["kind"] == "conversation"
+members = run_route(
+    "conversation/engineering/members",
+    "channels:read",
+    "conversations.members",
+    {
+        "ok": True,
+        "members": ["U123ABC456"],
+        "response_metadata": {"next_cursor": ""},
+    },
+)
+assert members["data"][0]["kind"] == "membership"
+thread_result = run_route(
+    "conversation/engineering/thread/1710000000.000001",
+    "channels:history",
+    "conversations.replies",
+    {
+        "ok": True,
+        "messages": [
+            {
+                "user": "U123ABC456",
+                "text": "Thread fixture",
+                "ts": "1710000001.000001",
+                "thread_ts": "1710000000.000001",
+            }
+        ],
+        "response_metadata": {"next_cursor": ""},
+    },
+)
+assert thread_result["data"][0]["thread_remote_id"] is not None
+must_reject(
+    lambda: run_route(
+        "conversation/engineering/thread/1710000000.000001",
+        "channels:history",
+        "conversations.replies",
+        {
+            "ok": True,
+            "messages": [
+                {
+                    "user": "U123ABC456",
+                    "text": "Unrelated thread fixture",
+                    "ts": "1710000002.000001",
+                    "thread_ts": "1710000009.000001",
+                }
+            ],
+            "response_metadata": {"next_cursor": ""},
+        },
+    )
+)
+pins = run_route(
+    "conversation/engineering/pins",
+    "pins:read",
+    "pins.list",
+    {
+        "ok": True,
+        "items": [
+            {
+                "type": "message",
+                "channel": "C123ABC456",
+                "message": {
+                    "ts": "1710000000.000001",
+                    "text": "Pinned fixture",
+                },
+                "created": 1710000000,
+                "created_by": "U123ABC456",
+            }
+        ],
+    },
+)
+assert pins["data"][0]["kind"] == "pin"
+bookmarks = run_route(
+    "conversation/engineering/bookmarks",
+    "bookmarks:read",
+    "bookmarks.list",
+    {
+        "ok": True,
+        "bookmarks": [
+            {
+                "id": "Bk123ABC456",
+                "channel_id": "C123ABC456",
+                "title": "Bookmark fixture",
+                "type": "link",
+                "last_updated_by_user_id": "U123ABC456",
+            }
+        ],
+    },
+)
+assert bookmarks["data"][0]["kind"] == "bookmark"
+files = run_route(
+    "conversation/engineering/files",
+    "files:read",
+    "files.list",
+    {
+        "ok": True,
+        "files": [
+            {
+                "id": "F123ABC456",
+                "user": "U123ABC456",
+                "channels": ["C123ABC456"],
+                "groups": [],
+                "ims": [],
+            }
+        ],
+        "paging": {"page": 1, "pages": 1},
+    },
+)
+assert files["data"][0]["kind"] == "file"
+unallowlisted_files = run_route(
+    "conversation/engineering/files",
+    "files:read",
+    "files.list",
+    {
+        "ok": True,
+        "files": [
+            {
+                "id": "F999ABC456",
+                "user": "U123ABC456",
+                "channels": ["C999ABC456"],
+                "groups": [],
+                "ims": [],
+            }
+        ],
+        "paging": {"page": 1, "pages": 1},
+    },
+)
+assert unallowlisted_files["data"] == []
+must_reject(
+    lambda: page(
+        lambda *_args: (_ for _ in ()).throw(AssertionError("unexpected API call")),
+        page_request(
+            "conversation/engineering/info",
+            account,
+            CursorState(None, None, False),
+            1,
+        ),
+        {**identity, "scopes": []},
+        profile.conversations,
+    )
+)
+
+public_entry = scripts / "knowledge_social_slack.py"
+assert public_entry.is_file()
+source_paths = [
+    public_entry,
+    *sorted(scripts.glob("_knowledge_social_slack*.py")),
+]
+sources = [path.read_text(encoding="utf-8") for path in source_paths]
+trees = [ast.parse(source) for source in sources]
+imports = {
+    alias.name.split(".")[0]
+    for tree in trees
+    for node in ast.walk(tree)
+    if isinstance(node, (ast.Import, ast.ImportFrom))
+    for alias in (
+        node.names
+        if isinstance(node, ast.Import)
+        else [ast.alias(node.module or "")]
+    )
+}
+forbidden_imports = {
+    "_knowledge_social_outbound",
+    "httpx",
+    "knowledge_social_browser",
+    "knowledge_social_operations",
+    "playwright",
+    "requests",
+    "selenium",
+    "subprocess",
+}
+assert imports.isdisjoint(forbidden_imports)
+forbidden_references = (
+    "_knowledge_social_outbound",
+    "knowledge_social_browser",
+    "knowledge_social_operations",
+)
+assert all(
+    forbidden not in source
+    for source in sources
+    for forbidden in forbidden_references
+)
+
+clock_environment = {
+    key: os.environ.pop(key, None)
+    for key in ("AIDEVOPS_TEST_MODE", "AIDEVOPS_SOCIAL_NOW_EPOCH")
+}
+try:
+    lease = acquire_run_lease(
+        root,
+        RunLeaseRequest(
+            "conn_real_clock", "archive", "real_clock", "sync", 300
+        ),
+    )
+    lease = renew_run_lease(root, lease, 300)
+    real_account = {
+        "id": "slack_T123ABC456_user_U123ABC456",
+        "provider_account_id": "U123ABC456",
+        "workspace_id": "T123ABC456",
+        "enterprise_id": None,
+        "token_type": "bot",
+        "scopes": ["team:read"],
+        "conversation_binding_sha256": profile.conversation_binding_sha256,
+        "username": "fixture-user",
+        "workspace_name": "Fixture Workspace",
+    }
+    observed_at = "2026-07-31T19:00:00Z"
+    config = ConnectionConfig(("workspace",), {"media_hydration": "none"})
+    archive = normalize_records(
+        [],
+        PageContext(
+            "conn_real_clock",
+            real_account,
+            "workspace",
+            config.enabled_streams,
+            config.policy,
+        ),
+        NormalizationBatch(observed_at, API_SOURCE),
+    )
+    persist_page(
+        CollectionContext(
+            root,
+            "conn_real_clock",
+            real_account,
+            "workspace",
+            "none",
+            config,
+            CursorState(None, None, False),
+            STREAMS["workspace"],
+            lease=lease,
+            provider="slack",
+        ),
+        SuccessfulPage(
+            {"status": 200, "observed_at": observed_at, "data": []},
+            "real-clock-regression",
+            archive,
+            PageCheckpoint(None, None),
+            True,
+            2,
+        ),
+    )
+    assert release_run_lease(root, lease)
+finally:
+    for key, value in clock_environment.items():
+        if value is not None:
+            os.environ[key] = value
+PY
+assert_eq "methods, scopes, identities, streams, and production clocks are guarded" \
+	verified verified
+
+first_result=$(api_sync "$FIXTURES/api-history-page-one.json" conn_history 3)
+assert_eq "bounded first history page pauses for its durable cursor" \
+	"$(json_field "$first_result" status)" budget_exhausted
+assert_eq "identity plus one Slack page consumes three request units" \
+	"$(json_field "$first_result" budget_units)" 3
+assert_eq "first history page persists an independent cursor and watermark" \
+	"$(sql_value "SELECT (cursor IS NOT NULL) || ':' || watermark || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_history' AND stream='conversation/engineering/history'")" \
+	"1:1710000000.000001:0"
+
+second_result=$(api_sync "$FIXTURES/api-history-page-two.json" conn_history 3)
+assert_eq "second history invocation resumes the exact Slack cursor" \
+	"$(json_field "$second_result" status)" complete
+assert_eq "completed history preserves its newest high-water mark" \
+	"$(sql_value "SELECT coalesce(cursor,'done') || ':' || watermark || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_history' AND stream='conversation/engineering/history'")" \
+	"done:1710000000.000001:1"
+
+incremental_result=$(api_sync "$FIXTURES/api-history-incremental.json" conn_history 3)
+assert_eq "completed backfill starts a seven-day overlapping refresh" \
+	"$(json_field "$incremental_result" status)" complete
+assert_eq "overlap refresh updates a stable message rather than duplicating it" \
+	"$(sql_value "SELECT count(*) || ':' || text_content FROM objects WHERE provider='slack' AND remote_id='$MESSAGE_ID'")" \
+	"1:edited Slack fixture knowledge"
+assert_eq "edited Slack evidence emits an explicit edit activity" \
+	"$(sql_value "SELECT count(*) FROM activities WHERE provider='slack' AND activity_type='message_edit' AND object_remote_id='$MESSAGE_ID'")" 1
+assert_eq "API limitations remain explicit coverage records" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE provider='slack' AND connection_id='conn_history' AND stream LIKE 'api_%'")" 8
+
+python3 - "$FIXTURES/api-history-incremental.json" "$TMP_DIR" <<'PY'
+import copy
+import json
+import sys
+from pathlib import Path
+
+with Path(sys.argv[1]).open(encoding="utf-8") as source:
+    template = json.load(source)
+target = Path(sys.argv[2])
+token_prefix = "xo" + "xb" + "-"
+synthetic_token = token_prefix + "123456789012-" + "A1b2C3d4E5f6G7h8" * 2
+cases = {
+    "binding": ("conversation_binding_sha256", "0" * 64),
+    "enterprise": ("enterprise_id", "E123ABC456"),
+    "token-type": ("token_type", "user"),
+}
+for name, (field, value) in cases.items():
+    payload = copy.deepcopy(template)
+    payload["identity"]["data"][field] = value
+    with (target / f"api-policy-{name}.json").open("w", encoding="utf-8") as output:
+        json.dump(payload, output)
+equal_time = copy.deepcopy(template)
+equal_time["pages"][0]["response"]["data"][0]["text"] = (
+    "conflicting equal-time API fixture knowledge"
+)
+with (target / "api-equal-time-conflict.json").open("w", encoding="utf-8") as output:
+    json.dump(equal_time, output)
+credential = copy.deepcopy(template)
+credential["pages"][0]["response"]["data"][0]["access_token"] = (
+    "fixture-redacted-value"
+)
+with (target / "api-policy-credential.json").open("w", encoding="utf-8") as output:
+    json.dump(credential, output)
+scalar_credential = copy.deepcopy(template)
+scalar_page = scalar_credential["pages"][0]
+scalar_page["expect_request"]["oldest"] = None
+scalar_page["response"]["data"][0]["text"] = synthetic_token
+with (target / "api-scalar-credential.json").open("w", encoding="utf-8") as output:
+    json.dump(scalar_credential, output)
+PY
+equal_api_raw=$(raw_count)
+equal_api_batches=$(sql_value \
+	"SELECT count(*) FROM fetch_batches WHERE provider='slack' AND connection_id='conn_history'")
+if api_sync "$TMP_DIR/api-equal-time-conflict.json" conn_history 3 \
+	>/dev/null 2>&1; then
+	assert_eq "conflicting API evidence at one observation timestamp is rejected" \
+		accepted rejected
+else
+	assert_eq "conflicting API evidence at one observation timestamp is rejected" \
+		rejected rejected
+fi
+assert_eq "equal-timestamp API rejection preserves canonical state" \
+	"$(sql_value "SELECT text_content FROM objects WHERE provider='slack' AND remote_id='$MESSAGE_ID'")" \
+	"edited Slack fixture knowledge"
+assert_eq "equal-timestamp API rejection persists no provider evidence" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='slack' AND connection_id='conn_history'"):$(raw_count)" \
+	"${equal_api_batches}:${equal_api_raw}"
+
+scalar_api_raw=$(raw_count)
+if api_sync "$TMP_DIR/api-scalar-credential.json" conn_scalar_credential 3 \
+	>/dev/null 2>&1; then
+	assert_eq "Slack token-shaped scalar API evidence is rejected" accepted rejected
+else
+	assert_eq "Slack token-shaped scalar API evidence is rejected" rejected rejected
+fi
+assert_eq "scalar API credential rejection persists no provider evidence" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='slack' AND connection_id='conn_scalar_credential'"):$(raw_count)" \
+	"0:${scalar_api_raw}"
+
+for policy_case in binding enterprise token-type credential; do
+	raw_before=$(raw_count)
+	if api_sync "$TMP_DIR/api-policy-${policy_case}.json" conn_history 3 \
+		>/dev/null 2>&1; then
+		assert_eq "${policy_case} Slack policy change is rejected" accepted rejected
+	else
+		assert_eq "${policy_case} Slack policy change is rejected" rejected rejected
+	fi
+	assert_eq "${policy_case} rejection persists no provider evidence" \
+		"$(raw_count)" "$raw_before"
+done
+assert_eq "rejected policy changes preserve the history checkpoint" \
+	"$(sql_value "SELECT coalesce(cursor,'done') || ':' || watermark || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_history' AND stream='conversation/engineering/history'")" \
+	"done:1710000000.000001:1"
+
+cat >"$TMP_DIR/api-identity-mismatch.json" <<'JSON'
+{
+  "identity": {
+    "data": {
+      "id": "slack_T123ABC456_user_U999ABC456",
+      "provider_account_id": "U999ABC456",
+      "workspace_id": "T123ABC456",
+      "enterprise_id": null,
+      "token_type": "bot",
+      "scopes": ["channels:history"],
+      "conversation_binding_sha256": "3fcc8f8db59e6e3e71c06f82804df4a43cc456c1283010b6b809874c47136b4c"
+    }
+  },
+  "pages": []
+}
+JSON
+raw_before=$(raw_count)
+if api_sync "$TMP_DIR/api-identity-mismatch.json" conn_identity 3 \
+	>/dev/null 2>&1; then
+	assert_eq "API identity rebinding is rejected" accepted rejected
+else
+	assert_eq "API identity rebinding is rejected" rejected rejected
+fi
+assert_eq "identity rejection persists no provider evidence" \
+	"$(raw_count)" "$raw_before"
+
+cat >"$TMP_DIR/api-rate-limit.json" <<'JSON'
+{
+  "identity": {
+    "data": {
+      "id": "slack_T123ABC456_user_U123ABC456",
+      "provider_account_id": "U123ABC456",
+      "workspace_id": "T123ABC456",
+      "enterprise_id": null,
+      "token_type": "bot",
+      "scopes": ["channels:history"],
+      "conversation_binding_sha256": "3fcc8f8db59e6e3e71c06f82804df4a43cc456c1283010b6b809874c47136b4c"
+    }
+  },
+  "pages": [
+    {
+      "response": {
+        "status": 429,
+        "observed_at": "2026-07-31T19:03:00Z",
+        "retry_after": "30"
+      }
+    }
+  ]
+}
+JSON
+rate_result=$(api_sync "$TMP_DIR/api-rate-limit.json" conn_rate 3)
+assert_eq "Slack rate limits produce a paused terminal result" \
+	"$(json_field "$rate_result" status):$(json_field "$rate_result" failure_class)" \
+	"rate_limited:rate_limit"
+assert_eq "rate-limited streams advance no checkpoint" \
+	"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_rate'")" 0
+
+VALID_ARCHIVE="$TMP_DIR/slack-valid.zip"
+CHANGED_ARCHIVE="$TMP_DIR/slack-changed.zip"
+STALE_ARCHIVE="$TMP_DIR/slack-stale.zip"
+python3 "$ARCHIVE_BUILDER" "$VALID_ARCHIVE" valid
+python3 "$ARCHIVE_BUILDER" "$CHANGED_ARCHIVE" changed
+python3 "$ARCHIVE_BUILDER" "$STALE_ARCHIVE" stale
+
+raw_before=$(raw_count)
+if archive_import "$VALID_ARCHIVE" conn_future 2026-07-31T19:05:01Z \
+	>/dev/null 2>&1; then
+	assert_eq "future-dated Slack exports are rejected" accepted rejected
+else
+	assert_eq "future-dated Slack exports are rejected" rejected rejected
+fi
+assert_eq "future export rejection persists no provider evidence" \
+	"$(raw_count)" "$raw_before"
+
+archive_result=$(archive_import "$VALID_ARCHIVE" conn_archive)
+assert_eq "approved export persists normalized filtered Slack evidence" \
+	"$(json_field "$archive_result" status):$(json_field "$archive_result" normalized_items)" \
+	"complete:18"
+assert_eq "approved export hashes only four selected source members" \
+	"$(json_field "$archive_result" selected_members)" 4
+assert_eq "archive persists an immutable token and conversation binding" \
+	"$(sql_value "SELECT json_extract(policy_json,'$.slack_token_type') || ':' || json_extract(policy_json,'$.slack_conversation_binding_sha256') FROM connections WHERE connection_id='conn_archive'")" \
+	"bot:${BINDING_HASH}"
+assert_eq "filtered archive evidence carries its immutable binding" \
+	"$(raw_archive_contains conn_archive "$BINDING_HASH")" present
+assert_eq "API and export use one canonical message identity" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='slack' AND remote_id='$MESSAGE_ID'")" 1
+assert_eq "export source wins through the shared canonical projection" \
+	"$(sql_value "SELECT json_extract(provider_json,'$.source') FROM objects WHERE provider='slack' AND remote_id='$MESSAGE_ID'")" \
+	slack_admin_json_export
+assert_eq "selected archive text reaches full-text search" \
+	"$(sql_value "SELECT count(*) FROM objects_fts WHERE provider='slack' AND remote_id='$MESSAGE_ID' AND objects_fts MATCH 'bounded'")" 1
+assert_eq "archive edits and deletions remain explicit activities" \
+	"$(sql_value "SELECT count(*) FROM activities WHERE provider='slack' AND activity_type IN ('message_edit','message_delete') AND json_extract(provider_json,'$.source')='slack_admin_json_export'")" 2
+assert_eq "archive reaction actors remain explicit activities" \
+	"$(sql_value "SELECT count(*) FROM activities WHERE provider='slack' AND activity_type='reaction' AND object_remote_id='$MESSAGE_ID'")" 1
+assert_eq "file binaries remain disabled metadata-only evidence" \
+	"$(sql_value "SELECT hydration_state || ':' || coalesce(blob_ref,'none') FROM media WHERE provider='slack'")" \
+	"metadata_only:none"
+assert_eq "archive scope and retention limits remain explicit" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE provider='slack' AND connection_id='conn_archive'")" 9
+assert_eq "unallowlisted conversation content is absent from filtered evidence" \
+	"$(raw_archive_contains conn_archive must-not-persist-from-unselected-conversation)" absent
+assert_eq "unselected user email is absent from filtered evidence" \
+	"$(raw_archive_contains conn_archive not-collected@example.invalid)" absent
+assert_eq "file credential-bearing links are absent from filtered evidence" \
+	"$(raw_archive_contains conn_archive credential-bearing-link)" absent
+
+archive_batches=$(sql_value \
+	"SELECT count(*) FROM fetch_batches WHERE provider='slack' AND connection_id='conn_archive' AND stream='archive'")
+archive_raw=$(raw_count)
+replay_result=$(archive_import "$VALID_ARCHIVE" conn_archive)
+assert_eq "exact approved-export replay is idempotent" \
+	"$(json_field "$replay_result" replayed)" True
+assert_eq "archive replay creates no second batch or raw blob" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='slack' AND connection_id='conn_archive' AND stream='archive'"):$(raw_count)" \
+	"${archive_batches}:${archive_raw}"
+
+archive_batch=$(json_field "$archive_result" evidence_sha256)
+python3 - "$ROOT/index/social.db" "$archive_batch" 19 <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as database:
+    database.execute(
+        "UPDATE fetch_batches SET resource_count=? WHERE batch_id=?",
+        (int(sys.argv[3]), sys.argv[2]),
+    )
+PY
+replay_metadata_raw=$(raw_count)
+if archive_import "$VALID_ARCHIVE" conn_archive >/dev/null 2>&1; then
+	assert_eq "archive replay rejects conflicting result metadata" accepted rejected
+else
+	assert_eq "archive replay rejects conflicting result metadata" rejected rejected
+fi
+assert_eq "conflicting replay metadata creates no raw evidence" \
+	"$(raw_count)" "$replay_metadata_raw"
+python3 - "$ROOT/index/social.db" "$archive_batch" 18 <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as database:
+    database.execute(
+        "UPDATE fetch_batches SET resource_count=? WHERE batch_id=?",
+        (int(sys.argv[3]), sys.argv[2]),
+    )
+PY
+
+renamed_result=$(env SLACK_FIXTURE_CONVERSATIONS='{"renamed":{"id":"C123ABC456","kind":"public_channel"}}' \
+	python3 "$SLACK_ENTRY" archive --base "$BASE" --alias personal:default \
+	--archive "$VALID_ARCHIVE" --connection-id conn_archive_renamed \
+	--account-id "$ACCOUNT_ID" --profile fixture \
+	--exported-at 2026-07-31T19:04:00Z)
+assert_eq "a newly bound connection does not collide with prior raw evidence" \
+	"$(json_field "$renamed_result" status):$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='slack' AND connection_id='conn_archive_renamed'")" \
+	"complete:1"
+
+python3 - "$FIXTURES/api-history.json" "$TMP_DIR/api-convergence.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+with Path(sys.argv[1]).open(encoding="utf-8") as source:
+    payload = json.load(source)
+payload["pages"][0]["response"]["observed_at"] = "2026-07-31T19:04:00Z"
+with Path(sys.argv[2]).with_name("api-cross-stream-equal.json").open(
+    "w", encoding="utf-8"
+) as target:
+    json.dump(payload, target)
+payload["pages"][0]["response"]["observed_at"] = "2026-07-31T19:04:30Z"
+with Path(sys.argv[2]).open("w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+cross_stream_raw=$(raw_count)
+cross_stream_batches=$(sql_value \
+	"SELECT count(*) FROM fetch_batches WHERE provider='slack' AND connection_id='conn_archive'")
+if api_sync "$TMP_DIR/api-cross-stream-equal.json" conn_archive 3 \
+	>/dev/null 2>&1; then
+	assert_eq "equal-timestamp evidence across Slack streams is rejected" \
+		accepted rejected
+else
+	assert_eq "equal-timestamp evidence across Slack streams is rejected" \
+		rejected rejected
+fi
+assert_eq "cross-stream equal-timestamp rejection persists no evidence" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='slack' AND connection_id='conn_archive'"):$(raw_count)" \
+	"${cross_stream_batches}:${cross_stream_raw}"
+convergence_result=$(api_sync "$TMP_DIR/api-convergence.json" conn_archive 3)
+assert_eq "archive and API modes converge on one live connection" \
+	"$(json_field "$convergence_result" status)" complete
+assert_eq "API transition preserves archive and history stream registration" \
+	"$(sql_value "SELECT count(*) FROM json_each((SELECT enabled_streams FROM connections WHERE connection_id='conn_archive')) WHERE value IN ('archive','conversation/engineering/history')")" 2
+assert_eq "API transition preserves immutable binding and attested scopes" \
+	"$(sql_value "SELECT json_extract(policy_json,'$.slack_token_type') || ':' || json_extract(policy_json,'$.slack_conversation_binding_sha256') || ':' || json_extract(policy_json,'$.slack_read_scopes[0]') FROM connections WHERE connection_id='conn_archive'")" \
+	"bot:${BINDING_HASH}:channels:history"
+archive_raw=$(raw_count)
+
+changed_result=$(archive_import \
+	"$CHANGED_ARCHIVE" conn_archive 2026-07-31T19:05:00Z)
+changed_source=$(json_field "$changed_result" source_sha256)
+assert_eq "changed approved evidence updates the canonical object" \
+	"$(sql_value "SELECT text_content FROM objects WHERE provider='slack' AND remote_id='$MESSAGE_ID'")" \
+	"updated archive fixture knowledge"
+assert_eq "changed approved evidence creates one new immutable batch" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='slack' AND connection_id='conn_archive' AND stream='archive'")" \
+	$((archive_batches + 1))
+
+equal_time_raw=$(raw_count)
+equal_time_batches=$(sql_value \
+	"SELECT count(*) FROM fetch_batches WHERE provider='slack' AND connection_id='conn_archive'")
+if archive_import \
+	"$STALE_ARCHIVE" conn_archive 2026-07-31T19:05:00Z >/dev/null 2>&1; then
+	assert_eq "conflicting evidence at one observation timestamp is rejected" \
+		accepted rejected
+else
+	assert_eq "conflicting evidence at one observation timestamp is rejected" \
+		rejected rejected
+fi
+assert_eq "equal-timestamp rejection preserves canonical state" \
+	"$(sql_value "SELECT text_content FROM objects WHERE provider='slack' AND remote_id='$MESSAGE_ID'")" \
+	"updated archive fixture knowledge"
+assert_eq "equal-timestamp rejection persists no provider evidence" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE provider='slack' AND connection_id='conn_archive'"):$(raw_count)" \
+	"${equal_time_batches}:${equal_time_raw}"
+
+python3 - "$TMP_DIR/api-convergence.json" "$TMP_DIR/api-stale-after-export.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+with Path(sys.argv[1]).open(encoding="utf-8") as source:
+    payload = json.load(source)
+page = payload["pages"][0]
+page["expect_request"]["oldest"] = "1709395200.000001"
+page["response"]["observed_at"] = "2026-07-31T19:04:15Z"
+page["response"]["data"][0]["text"] = "stale API fixture knowledge"
+with Path(sys.argv[2]).open("w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+stale_api_result=$(api_sync "$TMP_DIR/api-stale-after-export.json" conn_archive 3)
+assert_eq "older API evidence completes without regressing canonical state" \
+	"$(json_field "$stale_api_result" status):$(sql_value "SELECT text_content FROM objects WHERE provider='slack' AND remote_id='$MESSAGE_ID'")" \
+	"complete:updated archive fixture knowledge"
+assert_eq "older API evidence cannot regress its durable cursor" \
+	"$(sql_value "SELECT last_success_at FROM sync_cursors WHERE connection_id='conn_archive' AND stream='conversation/engineering/history'")" \
+	"2026-07-31T19:04:30.000000Z"
+
+archive_import "$STALE_ARCHIVE" conn_archive 2026-07-31T19:03:00Z >/dev/null
+assert_eq "older archive evidence cannot overwrite a newer canonical object" \
+	"$(sql_value "SELECT text_content FROM objects WHERE provider='slack' AND remote_id='$MESSAGE_ID'")" \
+	"updated archive fixture knowledge"
+assert_eq "older archive evidence cannot regress its cursor" \
+	"$(sql_value "SELECT last_success_at FROM sync_cursors WHERE connection_id='conn_archive' AND stream='archive'")" \
+	"2026-07-31T19:05:00.000000Z"
+assert_eq "older archive evidence cannot regress current connection policy" \
+	"$(sql_value "SELECT json_extract(policy_json,'$.slack_export_sha256') FROM connections WHERE connection_id='conn_archive'")" \
+	"$changed_source"
+newest_replay=$(archive_import \
+	"$CHANGED_ARCHIVE" conn_archive 2026-07-31T19:05:00Z)
+assert_eq "newest replay remains idempotent after an older import" \
+	"$(json_field "$newest_replay" replayed):$(sql_value "SELECT text_content FROM objects WHERE provider='slack' AND remote_id='$MESSAGE_ID'")" \
+	"True:updated archive fixture knowledge"
+
+raw_before=$(raw_count)
+if env SLACK_FIXTURE_CONVERSATIONS='{"engineering":{"id":"C999ABC456","kind":"public_channel"}}' \
+	python3 "$SLACK_ENTRY" archive --base "$BASE" --alias personal:default \
+	--archive "$VALID_ARCHIVE" --connection-id conn_archive \
+	--account-id "$ACCOUNT_ID" --profile fixture \
+	--exported-at 2026-07-31T19:05:00Z >/dev/null 2>&1; then
+	assert_eq "archive conversation rebinding is rejected" accepted rejected
+else
+	assert_eq "archive conversation rebinding is rejected" rejected rejected
+fi
+if env SLACK_FIXTURE_TOKEN_TYPE=user \
+	python3 "$SLACK_ENTRY" archive --base "$BASE" --alias personal:default \
+	--archive "$VALID_ARCHIVE" --connection-id conn_archive \
+	--account-id "$ACCOUNT_ID" --profile fixture \
+	--exported-at 2026-07-31T19:05:00Z >/dev/null 2>&1; then
+	assert_eq "archive token-type rebinding is rejected" accepted rejected
+else
+	assert_eq "archive token-type rebinding is rejected" rejected rejected
+fi
+assert_eq "archive binding rejection persists no provider evidence" \
+	"$(raw_count)" "$raw_before"
+
+for mode in wrong-account wrong-workspace conflicting-workspace unsafe-folder traversal duplicate member-symlink credential credential-scalar; do
+	unsafe_archive="$TMP_DIR/slack-${mode}.zip"
+	python3 "$ARCHIVE_BUILDER" "$unsafe_archive" "$mode"
+	expect_archive_failure "${mode} Slack export is rejected" \
+		"$unsafe_archive" "conn_${mode//-/_}"
+done
+
+for mode in duplicate-folder casefold-folder; do
+	duplicate_folder="$TMP_DIR/slack-${mode}.zip"
+	python3 "$ARCHIVE_BUILDER" "$duplicate_folder" "$mode"
+	if env SLACK_FIXTURE_CONVERSATIONS='{"engineering":{"id":"C123ABC456","kind":"public_channel"},"engineering-copy":{"id":"C777ABC456","kind":"public_channel"}}' \
+		python3 "$SLACK_ENTRY" archive --base "$BASE" --alias personal:default \
+		--archive "$duplicate_folder" --connection-id "conn_${mode//-/_}" \
+		--account-id "$ACCOUNT_ID" --profile fixture \
+		--exported-at 2026-07-31T19:04:00Z >/dev/null 2>&1; then
+		assert_eq "${mode} export conversation folders are rejected" accepted rejected
+	else
+		assert_eq "${mode} export conversation folders are rejected" rejected rejected
+	fi
+done
+assert_eq "rejected exports create no raw evidence" "$(raw_count)" \
+	$((archive_raw + 3))
+
+ln -s "$VALID_ARCHIVE" "$TMP_DIR/slack-link.zip"
+expect_archive_failure "archive path symlinks are rejected" \
+	"$TMP_DIR/slack-link.zip" conn_symlink
+if python3 "$SLACK_ENTRY" archive --base "$BASE" --alias personal:default \
+	--archive "$VALID_ARCHIVE" --connection-id conn_bytes \
+	--account-id "$ACCOUNT_ID" --profile fixture \
+	--exported-at 2026-07-31T19:00:00Z --max-bytes 1 \
+	>/dev/null 2>&1; then
+	assert_eq "compressed archive byte budgets fail closed" accepted rejected
+else
+	assert_eq "compressed archive byte budgets fail closed" rejected rejected
+fi
+if python3 "$SLACK_ENTRY" archive --base "$BASE" --alias personal:default \
+	--archive "$VALID_ARCHIVE" --connection-id conn_items \
+	--account-id "$ACCOUNT_ID" --profile fixture \
+	--exported-at 2026-07-31T19:00:00Z --max-items 1 \
+	>/dev/null 2>&1; then
+	assert_eq "archive member budgets fail closed" accepted rejected
+else
+	assert_eq "archive member budgets fail closed" rejected rejected
+fi
+if python3 "$SLACK_ENTRY" archive --base "$BASE" --alias personal:default \
+	--archive "$VALID_ARCHIVE" --connection-id conn_normalized_items \
+	--account-id "$ACCOUNT_ID" --profile fixture \
+	--exported-at 2026-07-31T19:00:00Z --max-items 10 \
+	>/dev/null 2>&1; then
+	assert_eq "archive normalized item budgets fail closed" accepted rejected
+else
+	assert_eq "archive normalized item budgets fail closed" rejected rejected
+fi
+
+assert_eq "completed Slack collectors release every live lease" \
+	"$(sql_value "SELECT count(*) FROM collector_leases")" 0
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add provider-only Slack API and approved-export ingestion with bounded reads, deterministic canonical persistence, immutable evidence, replay safety, checkpointing, lease cleanup, and credential-aware filtering.

## Files Changed

.agents/content/social-slack.md, .agents/scripts/_knowledge_social_slack.py, .agents/scripts/_knowledge_social_slack_activities.py, .agents/scripts/_knowledge_social_slack_archive.py, .agents/scripts/_knowledge_social_slack_archive_count.py, .agents/scripts/_knowledge_social_slack_archive_identity.py, .agents/scripts/_knowledge_social_slack_archive_select.py, .agents/scripts/_knowledge_social_slack_archive_types.py, .agents/scripts/_knowledge_social_slack_contract.py, .agents/scripts/_knowledge_social_slack_conversation_routes.py, .agents/scripts/_knowledge_social_slack_evidence_guard.py, .agents/scripts/_knowledge_social_slack_fields.py, .agents/scripts/_knowledge_social_slack_http.py, .agents/scripts/_knowledge_social_slack_identity.py, .agents/scripts/_knowledge_social_slack_message_records.py, .agents/scripts/_knowledge_social_slack_normalize.py, .agents/scripts/_knowledge_social_slack_persist.py, .agents/scripts/_knowledge_social_slack_provider.py, .agents/scripts/_knowledge_social_slack_reader.py, .agents/scripts/_knowledge_social_slack_record_contract.py, .agents/scripts/_knowledge_social_slack_records.py, .agents/scripts/_knowledge_social_slack_route_types.py, .agents/scripts/_knowledge_social_slack_routes.py, .agents/scripts/_knowledge_social_slack_snapshot_records.py, .agents/scripts/_knowledge_social_slack_store.py, .agents/scripts/_knowledge_social_slack_zip.py, .agents/scripts/knowledge_social_slack.py, .agents/tests/fixtures/knowledge-social-slack/api-history-incremental.json, .agents/tests/fixtures/knowledge-social-slack/api-history-page-one.json, .agents/tests/fixtures/knowledge-social-slack/api-history-page-two.json, .agents/tests/fixtures/knowledge-social-slack/api-history.json, .agents/tests/fixtures/slack-archive-fixture.py, .agents/tests/test-knowledge-social-slack.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: Slack collector suite 86/0; social sync 35/0; social corpus 33/0; source contract 2/0; changed-file local lint, Secretlint, ShellCheck, shfmt, compilation, diff checks, and Qlty all pass.

Resolves #28782


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.203 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 11h 51m and 7,720,825 tokens on this with the user in an interactive session.