### PR TITLE
GH#29106: Route internal PR check reads through exact-cost GraphQL

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -106,11 +106,11 @@ _full_loop_query_required_checks() {
 		FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="cannot capture gh stderr"
 		return 1
 	}
-	required_checks=$(gh pr checks "$pr_number" --repo "$repo" \
-		--required --json name,state,bucket 2>"$required_checks_stderr_file") || required_rc=$?
+	required_checks=$(gh_pr_checks_exact_json "$repo" "$pr_number" required \
+		2>"$required_checks_stderr_file") || required_rc=$?
 	required_checks_stderr=$(<"$required_checks_stderr_file")
 	rm -f "$required_checks_stderr_file"
-	FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="gh exit ${required_rc}"
+	FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="exact check read exit ${required_rc}"
 
 	if [[ "$required_rc" -eq 1 && -z "$required_checks" && -n "$pr_head_ref" && "$required_checks_stderr" == "$expected_no_required_checks" ]]; then
 		required_checks="[]"

--- a/.agents/scripts/gh-checks-wait-helper.sh
+++ b/.agents/scripts/gh-checks-wait-helper.sh
@@ -93,16 +93,17 @@ with open(sys.argv[1], encoding="utf-8") as source:
 PY
 		return 0
 	fi
-	local args=(pr checks "$pr_number" --repo "$repo" --json "name,state,bucket,link,workflow")
+	local selection_mode="all"
 	if [[ "$required_only" -eq 1 ]]; then
-		args+=(--required)
+		selection_mode="required"
 	fi
 	local rc=0
 	local checks=""
 	local checks_stderr=""
 	local checks_stderr_file=""
 	checks_stderr_file=$(mktemp "${TMPDIR:-/tmp}/aidevops-gh-checks-wait.XXXXXX") || return 1
-	checks=$(gh "${args[@]}" 2>"$checks_stderr_file") || rc=$?
+	checks=$(gh_pr_checks_exact_json "$repo" "$pr_number" "$selection_mode" \
+		2>"$checks_stderr_file") || rc=$?
 	checks_stderr=$(<"$checks_stderr_file")
 	rm -f "$checks_stderr_file"
 	if [[ "$required_only" -eq 1 && "$rc" -eq 1 && -z "$checks" && "$checks_stderr" =~ ^no\ required\ checks\ reported\ on\ the\ \'[^\']+\'\ branch$ ]]; then

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -388,7 +388,7 @@ _ci_actionable_failed_checks_markdown() {
 # Return terminal failed check details and names from one jq pass.
 #
 # Args:
-#   $1 - checks_json (array from gh pr checks --json name,bucket,state,link)
+#   $1 - checks_json (normalized exact-read array with name,bucket,state,link)
 #   $2 - terminal_failed_check_filter (jq select expression)
 #
 # Output: first line is filtered checks JSON, followed by a marker and one
@@ -411,6 +411,29 @@ _ci_merge_check_sets() {
 	local primary_checks="$1"
 	local all_checks="$2"
 	printf '%s\n%s\n' "$primary_checks" "$all_checks" | jq -sc 'add | unique_by([.name, .link])' 2>/dev/null || printf '%s' "${primary_checks:-[]}"
+	return 0
+}
+
+#######################################
+# Normalize exact required-check output for CI repair evidence collection.
+# Args: $1=repo slug, $2=PR number, $3=optional supplied checks JSON
+# Stdout: checks JSON, defaulting to an empty array on indeterminate reads
+#######################################
+_ci_repair_required_checks_json() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local supplied_checks_json="${3:-}"
+	local checks_json="$supplied_checks_json"
+	local checks_exit=0
+
+	if [[ -z "$checks_json" ]]; then
+		checks_json=$(gh_pr_checks_exact_json "$repo_slug" "$pr_number" required 2>/dev/null) || checks_exit=$?
+		case "$checks_exit" in
+		0 | 1 | 8) [[ -n "$checks_json" ]] || checks_json="[]" ;;
+		*) checks_json="[]" ;;
+		esac
+	fi
+	printf '%s\n' "$checks_json"
 	return 0
 }
 
@@ -454,13 +477,9 @@ _dispatch_ci_fix_worker() {
 	# failures. Advisory failures do not justify branch ownership or repair work.
 	local terminal_failed_check_filter
 	terminal_failed_check_filter='(.bucket == "fail" or .bucket == "cancel") and (((.conclusion // .state // "") | ascii_downcase) | test("^(failure|action_required)$")) and ((.link // "") != "")'
-	local checks_json="$supplied_checks_json" result_marker=$'\n__AIDEVOPS_CHECK_NAMES__'
+	local checks_json="" result_marker=$'\n__AIDEVOPS_CHECK_NAMES__'
 	local check_results="" failing_checks_json="" failing_checks="" failing_names="" classification_output=""
-	if [[ -z "$checks_json" ]]; then
-		checks_json=$(gh pr checks "$pr_number" --repo "$repo_slug" --required \
-			--json name,bucket,state,link \
-			2>/dev/null) || checks_json="[]"
-	fi
+	checks_json=$(_ci_repair_required_checks_json "$repo_slug" "$pr_number" "$supplied_checks_json")
 	check_results=$(_ci_terminal_failed_check_results "$checks_json" "$terminal_failed_check_filter")
 	failing_checks_json="${check_results%%"$result_marker"*}"
 	failing_names="${check_results#*"$result_marker"}"

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -1038,6 +1038,42 @@ _pulse_merge_preflight_snapshot_gate() {
 }
 
 #######################################
+# Normalize the exact required-check read used by the PR-level fallback.
+# Args: $1=repo_slug, $2=pr_number
+# Stdout: checks JSON
+# Returns: 0=usable JSON or canonical no-required result, 2=API/parse error
+#######################################
+_pmrc_exact_required_checks_json() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local checks_json="" checks_exit=0
+	local checks_stderr="" checks_stderr_file=""
+
+	checks_stderr_file=$(mktemp "${TMPDIR:-/tmp}/aidevops-pulse-required-checks.XXXXXX") || return 2
+	checks_json=$(gh_pr_checks_exact_json "$repo_slug" "$pr_number" required \
+		2>"$checks_stderr_file") || checks_exit=$?
+	checks_stderr=$(<"$checks_stderr_file")
+	rm -f "$checks_stderr_file"
+	if [[ "$checks_exit" -eq 1 && -z "$checks_json" && "$checks_stderr" =~ ^no\ required\ checks\ reported\ on\ the\ \'[^\']+\'\ branch$ ]]; then
+		printf '[]\n'
+		return 0
+	fi
+	if [[ "$checks_exit" -ne 0 && -z "$checks_json" ]]; then
+		return 2
+	fi
+	[[ -z "$checks_stderr" ]] || return 2
+	if [[ -z "$checks_json" || "$checks_json" == "null" || "$checks_json" == "[]" ]]; then
+		if [[ "$checks_exit" -ne 0 ]]; then
+			return 2
+		fi
+		printf '[]\n'
+		return 0
+	fi
+	printf '%s\n' "$checks_json"
+	return 0
+}
+
+#######################################
 # Fallback required-check verification for repositories where the classic branch
 # protection endpoint and repository-rulesets endpoint expose no contexts, but
 # GitHub still reports PR-level required checks (for example org-level rulesets).
@@ -1052,16 +1088,8 @@ _check_required_pr_checks_passing_fallback() {
 	local pr_number="$2"
 
 	local checks_json=""
-	local checks_exit=0
-	checks_json=$(_pmrc_gh_read gh pr checks "$pr_number" --repo "$repo_slug" --required --json name,state,bucket 2>/dev/null)
-	checks_exit=$?
-	if [[ $checks_exit -ne 0 && -z "$checks_json" ]]; then
-		return 2
-	fi
-	if [[ -z "$checks_json" || "$checks_json" == "null" || "$checks_json" == "[]" ]]; then
-		if [[ $checks_exit -ne 0 ]]; then
-			return 2
-		fi
+	checks_json=$(_pmrc_exact_required_checks_json "$repo_slug" "$pr_number") || return 2
+	if [[ "$checks_json" == "[]" ]]; then
 		printf '[]\n'
 		return 0
 	fi

--- a/.agents/scripts/shared-gh-wrappers-checks.sh
+++ b/.agents/scripts/shared-gh-wrappers-checks.sh
@@ -37,6 +37,10 @@
 #       PR list (with .number and .headRefOid) and need each PR's
 #       aggregated status.
 #
+#   gh_pr_checks_exact_json <slug> <pr_number> <required|all>
+#     → echoes the internal `gh pr checks --json` field superset while every
+#       GraphQL page reports its own operation-owned rateLimit.cost.
+#
 # Usage: source "${SCRIPT_DIR}/shared-gh-wrappers-checks.sh"
 #
 # Dependencies:
@@ -480,6 +484,381 @@ _gh_checks_api_read() {
 
 	gh api "$endpoint" "$@"
 	return $?
+}
+
+#######################################
+# Emit a stable diagnostic for an indeterminate exact PR-check read.
+# Args: $1=detail
+#######################################
+_gh_pr_checks_exact_error() {
+	local detail="$1"
+	printf 'gh_pr_checks_exact_json: %s\n' "$detail" >&2
+	return 0
+}
+
+#######################################
+# Normalize and deduplicate collected status-rollup pages like gh CLI 2.96.0.
+# The newest StatusContext wins by context name. The newest CheckRun wins by
+# name/workflow/event. Deduplication happens before required-only filtering.
+#
+# Args: $1=required|all, $2=JSON-lines file containing one nodes array per page
+# Stdout: normalized JSON array
+# Returns: 0=valid, 1=invalid response shape
+#######################################
+_gh_pr_checks_exact_aggregate() {
+	local mode="$1"
+	local pages_file="$2"
+	local array_type='array'
+	local required_mode='required'
+
+	jq -cs --arg mode "$mode" --arg array_type "$array_type" \
+		--arg required_mode "$required_mode" '
+		def bucket_for($state):
+			if $state == "SUCCESS" then "pass"
+			elif ($state == "SKIPPED" or $state == "NEUTRAL") then "skipping"
+			elif ($state == "ERROR" or $state == "FAILURE" or $state == "TIMED_OUT" or $state == "ACTION_REQUIRED") then "fail"
+			elif $state == "CANCELLED" then "cancel"
+			else "pending" end;
+		if all(.[]; type == $array_type) then add else error("invalid page collection") end
+		| map(
+			if .__typename == "StatusContext" then
+				(.state // "") as $state
+				| {
+					_dedup_key: ("status\u0000" + .context),
+					_sort_at: (.createdAt // ""),
+					isRequired: .isRequired,
+					name: .context,
+					state: $state,
+					startedAt: (.createdAt // ""),
+					completedAt: "",
+					link: (.targetUrl // ""),
+					bucket: bucket_for($state),
+					event: "",
+					workflow: "",
+					description: (.description // "")
+				}
+			elif .__typename == "CheckRun" then
+				(.checkSuite.workflowRun.workflow.name // "") as $workflow
+				| (.checkSuite.workflowRun.event // "") as $event
+				| (if .status == "COMPLETED" then (.conclusion // "") else (.status // "") end) as $state
+				| {
+					_dedup_key: ("check\u0000" + .name + "\u0000" + $workflow + "\u0000" + $event),
+					_sort_at: (.startedAt // ""),
+					isRequired: .isRequired,
+					name: .name,
+					state: $state,
+					startedAt: (.startedAt // ""),
+					completedAt: (.completedAt // ""),
+					link: (.detailsUrl // ""),
+					bucket: bucket_for($state),
+					event: $event,
+					workflow: $workflow,
+					description: ""
+				}
+			else error("unsupported check context") end
+		)
+		| sort_by(._sort_at) | reverse
+		| reduce .[] as $item (
+			{seen: {}, items: []};
+			if .seen[$item._dedup_key] then .
+			else .seen[$item._dedup_key] = true | .items += [$item] end
+		)
+		| .items
+		| if $mode == $required_mode then map(select(.isRequired == true)) else . end
+		| map(del(._dedup_key, ._sort_at, .isRequired))
+	' "$pages_file" 2>/dev/null
+	return $?
+}
+
+#######################################
+# Resolve and validate the immutable identity needed for an exact PR-check read.
+# Args: $1=repo slug, $2=numeric PR
+# Stdout: PR node ID, head ref, and head SHA as TSV
+# Returns: 0=valid identity, 2=API/parse failure
+#######################################
+_gh_pr_checks_exact_identity() {
+	local slug="$1"
+	local pr_number="$2"
+	local identity_json="" identity=""
+	local object_type='object'
+	local string_type='string'
+
+	identity_json=$(AIDEVOPS_GH_QUOTA_COST=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="gh-pr-checks-identity-rest" \
+		_gh_checks_api_read "repos/${slug}/pulls/${pr_number}" 2>/dev/null) || {
+		_gh_pr_checks_exact_error "pull-request identity read failed"
+		return 2
+	}
+	identity=$(printf '%s' "$identity_json" | jq -er --argjson expected "$pr_number" \
+		--arg object_type "$object_type" --arg string_type "$string_type" '
+		select(type == $object_type and .number == $expected)
+		| select((.node_id | type) == $string_type and (.node_id | length) > 0)
+		| select((.head.ref | type) == $string_type and (.head.ref | length) > 0)
+		| select((.head.sha | type) == $string_type and (.head.sha | test("^[0-9A-Fa-f]{40}$|^[0-9A-Fa-f]{64}$")))
+		| [.node_id, .head.ref, .head.sha] | @tsv
+	' 2>/dev/null) || identity=""
+	if [[ -z "$identity" ]]; then
+		_gh_pr_checks_exact_error "pull-request identity response was malformed"
+		return 2
+	fi
+	printf '%s\n' "$identity"
+	return 0
+}
+
+#######################################
+# Emit the bounded status-rollup query used by exact PR-check reads.
+# Stdout: GraphQL query
+#######################################
+_gh_pr_checks_exact_query() {
+	# CheckRun.event is part of GitHub CLI's duplicate identity on hosts that
+	# support it. A host returning a field error fails closed rather than silently
+	# collapsing distinct workflow events into one check.
+	# shellcheck disable=SC2016
+	printf '%s\n' 'query PullRequestStatusChecks($id: ID!, $endCursor: String) {
+		node(id: $id) {
+			__typename
+			... on PullRequest {
+				statusCheckRollup: commits(last: 1) {
+					nodes {
+						commit {
+							statusCheckRollup {
+								contexts(first: 100, after: $endCursor) {
+									nodes {
+										__typename
+										... on StatusContext {
+											context state targetUrl createdAt description
+											isRequired(pullRequestId: $id)
+										}
+										... on CheckRun {
+											name status conclusion startedAt completedAt detailsUrl
+											checkSuite { workflowRun { event workflow { name } } }
+											isRequired(pullRequestId: $id)
+										}
+									}
+									pageInfo { hasNextPage endCursor }
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		rateLimit { cost }
+	}'
+	return 0
+}
+
+#######################################
+# Validate one status-rollup page and return its pagination metadata.
+# Args: $1=GraphQL response JSON
+# Stdout: hasNextPage and endCursor as TSV
+# Returns: 0=valid page, 1=partial or malformed page
+#######################################
+_gh_pr_checks_exact_page_meta() {
+	local response="$1"
+	local object_type='object'
+	local array_type='array'
+	local string_type='string'
+	local boolean_type='boolean'
+
+	printf '%s' "$response" | jq -er --arg object_type "$object_type" \
+		--arg array_type "$array_type" --arg string_type "$string_type" \
+		--arg boolean_type "$boolean_type" '
+		select(type == $object_type)
+		| select(((.errors // []) | type) == $array_type and ((.errors // []) | length) == 0)
+		| select((.data.rateLimit.cost | type) == "number" and .data.rateLimit.cost > 0 and (.data.rateLimit.cost | floor) == .data.rateLimit.cost)
+		| select(.data.node.__typename == "PullRequest")
+		| .data.node.statusCheckRollup.nodes as $commits
+		| select(($commits | type) == $array_type and ($commits | length) == 1)
+		| $commits[0].commit.statusCheckRollup.contexts as $contexts
+		| select(($contexts | type) == $object_type)
+		| select(($contexts.nodes | type) == $array_type)
+		| select(all($contexts.nodes[];
+			(.__typename == "StatusContext" and (.context | type) == $string_type and (.context | length) > 0 and (.state | type) == $string_type and (.isRequired | type) == $boolean_type)
+			or
+			(.__typename == "CheckRun" and (.name | type) == $string_type and (.name | length) > 0 and (.status | type) == $string_type and (.isRequired | type) == $boolean_type)
+		))
+		| select(($contexts.pageInfo.hasNextPage | type) == $boolean_type)
+		| select(($contexts.pageInfo.hasNextPage == false) or (($contexts.pageInfo.endCursor | type) == $string_type and ($contexts.pageInfo.endCursor | length) > 0))
+		| [$contexts.pageInfo.hasNextPage, ($contexts.pageInfo.endCursor // "")] | @tsv
+	' 2>/dev/null
+	return $?
+}
+
+#######################################
+# Collect every bounded status-rollup page into a JSON-lines file.
+# Args: $1=PR node ID, $2=GraphQL query, $3=page file, $4=max pages
+# Returns: 0=complete collection, 2=API/parse/pagination failure
+#######################################
+_gh_pr_checks_exact_collect_pages() {
+	local node_id="$1"
+	local query="$2"
+	local pages_file="$3"
+	local max_pages="$4"
+	local page_number=0 cursor="" next_cursor="" has_next="" page_meta=""
+	local response="" nodes_json="" seen_cursors=$'\n' cursor_flag="" cursor_field=""
+	local false_text='false'
+
+	while true; do
+		page_number=$((page_number + 1))
+		if [[ "$page_number" -gt "$max_pages" ]]; then
+			rm -f "$pages_file"
+			_gh_pr_checks_exact_error "status-rollup pagination exceeded ${max_pages} pages"
+			return 2
+		fi
+		if [[ -n "$cursor" ]]; then
+			cursor_flag="-f"
+			cursor_field="endCursor=${cursor}"
+		else
+			cursor_flag="-F"
+			cursor_field="endCursor=null"
+		fi
+		response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+			AIDEVOPS_GH_ROUTE_DECISION="gh-pr-checks-status-rollup-exact-cost" \
+			_gh_checks_api_read graphql -f id="$node_id" "$cursor_flag" "$cursor_field" -f query="$query" 2>/dev/null) || {
+			rm -f "$pages_file"
+			_gh_pr_checks_exact_error "status-rollup page ${page_number} read failed"
+			return 2
+		}
+		page_meta=$(_gh_pr_checks_exact_page_meta "$response") || page_meta=""
+		if [[ -z "$page_meta" ]]; then
+			_gh_pr_checks_exact_error "status-rollup page ${page_number} response was partial or malformed"
+			return 2
+		fi
+		IFS=$'\t' read -r has_next next_cursor <<<"$page_meta"
+		nodes_json=$(printf '%s' "$response" | jq -c '.data.node.statusCheckRollup.nodes[0].commit.statusCheckRollup.contexts.nodes' 2>/dev/null) || nodes_json=""
+		if [[ -z "$nodes_json" ]]; then
+			_gh_pr_checks_exact_error "status-rollup page ${page_number} contexts were unavailable"
+			return 2
+		fi
+		printf '%s\n' "$nodes_json" >>"$pages_file" || {
+			_gh_pr_checks_exact_error "status-rollup page collection failed"
+			return 2
+		}
+		if [[ "$has_next" == "$false_text" ]]; then
+			return 0
+		fi
+		if [[ -z "$next_cursor" || "$seen_cursors" == *$'\n'"$next_cursor"$'\n'* ]]; then
+			_gh_pr_checks_exact_error "status-rollup pagination cursor was incomplete or repeated"
+			return 2
+		fi
+		seen_cursors="${seen_cursors}${next_cursor}"$'\n'
+		cursor="$next_cursor"
+	done
+	return 0
+}
+
+#######################################
+# Aggregate collected pages, emit JSON, and map check buckets to CLI exits.
+# Args: $1=required|all, $2=head ref, $3=JSON-lines page file
+# Returns: 0=pass, 1=terminal failure/no checks, 8=pending, 2=parse failure
+#######################################
+_gh_pr_checks_exact_emit_result() {
+	local mode="$1"
+	local head_ref="$2"
+	local pages_file="$3"
+	local checks_json="" check_count="" result_flags="" has_failure="" has_pending=""
+	local required_mode='required'
+	local fail_bucket='fail'
+	local pending_bucket='pending'
+	local true_text='true'
+	local false_text='false'
+
+	checks_json=$(_gh_pr_checks_exact_aggregate "$mode" "$pages_file") || checks_json=""
+	if [[ -z "$checks_json" ]]; then
+		_gh_pr_checks_exact_error "status-rollup aggregation failed"
+		return 2
+	fi
+	check_count=$(printf '%s' "$checks_json" | jq -r 'length' 2>/dev/null) || check_count=""
+	if [[ ! "$check_count" =~ ^[0-9]+$ ]]; then
+		_gh_pr_checks_exact_error "status-rollup aggregate was malformed"
+		return 2
+	fi
+	if [[ "$check_count" -eq 0 ]]; then
+		if [[ "$mode" == "$required_mode" ]]; then
+			printf "no required checks reported on the '%s' branch\n" "$head_ref" >&2
+		else
+			printf "no checks reported on the '%s' branch\n" "$head_ref" >&2
+		fi
+		return 1
+	fi
+
+	result_flags=$(printf '%s' "$checks_json" | jq -r --arg fail_bucket "$fail_bucket" \
+		--arg pending_bucket "$pending_bucket" \
+		'[any(.[]; .bucket == $fail_bucket), any(.[]; .bucket == $pending_bucket)] | @tsv' 2>/dev/null) || result_flags=""
+	IFS=$'\t' read -r has_failure has_pending <<<"$result_flags"
+	if [[ "$has_failure" != "$true_text" && "$has_failure" != "$false_text" ]] || \
+		[[ "$has_pending" != "$true_text" && "$has_pending" != "$false_text" ]]; then
+		_gh_pr_checks_exact_error "status-rollup outcome was malformed"
+		return 2
+	fi
+	printf '%s\n' "$checks_json"
+	if [[ "$has_failure" == "$true_text" ]]; then
+		return 1
+	fi
+	if [[ "$has_pending" == "$true_text" ]]; then
+		return 8
+	fi
+	return 0
+}
+
+#######################################
+# Read one PR's checks through a bounded status-rollup GraphQL query whose every
+# page carries its own rateLimit.cost. This intentionally covers only the JSON
+# surface used by framework internals; it is not a replacement for interactive
+# `gh pr checks` modes such as --watch, --web, or templates.
+#
+# Args: $1=repo slug, $2=numeric PR, $3=required|all
+# Stdout: JSON array with name/state/bucket/link/workflow plus CLI-compatible
+#         event, description, startedAt, and completedAt fields
+# Returns: 0=no failing or pending checks, 1=terminal failure/no matching checks,
+#          8=pending checks, 2=API/parse/partial-page failure
+#######################################
+gh_pr_checks_exact_json() {
+	local slug="$1"
+	local pr_number="$2"
+	local mode="$3"
+	local max_pages="${AIDEVOPS_GH_PR_CHECKS_MAX_PAGES:-20}"
+	local identity="" identity_exit=0 node_id="" head_ref="" head_sha=""
+	local pages_file="" temp_root="${AIDEVOPS_TEMP_DIR:-${TMPDIR:-/tmp}}"
+	local query="" collect_exit=0 result_exit=0
+	local required_mode='required'
+	local all_mode='all'
+
+	if [[ ! "$slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ || ! "$pr_number" =~ ^[1-9][0-9]*$ ]]; then
+		_gh_pr_checks_exact_error "repository and numeric PR are required"
+		return 2
+	fi
+	if [[ "$mode" != "$required_mode" && "$mode" != "$all_mode" ]]; then
+		_gh_pr_checks_exact_error "mode must be required or all"
+		return 2
+	fi
+	if [[ ! "$max_pages" =~ ^[1-9][0-9]*$ || "$max_pages" -gt 100 ]]; then
+		max_pages=20
+	fi
+
+	identity=$(_gh_pr_checks_exact_identity "$slug" "$pr_number") || identity_exit=$?
+	[[ "$identity_exit" -eq 0 ]] || return "$identity_exit"
+	IFS=$'\t' read -r node_id head_ref head_sha <<<"$identity"
+	if [[ -z "$node_id" || -z "$head_ref" || -z "$head_sha" ]]; then
+		_gh_pr_checks_exact_error "pull-request identity response was incomplete"
+		return 2
+	fi
+
+	pages_file=$(mktemp "${temp_root}/aidevops-gh-pr-checks.XXXXXX" 2>/dev/null) || {
+		_gh_pr_checks_exact_error "temporary page collection unavailable"
+		return 2
+	}
+	query=$(_gh_pr_checks_exact_query)
+	_gh_pr_checks_exact_collect_pages "$node_id" "$query" "$pages_file" "$max_pages" || collect_exit=$?
+	if [[ "$collect_exit" -ne 0 ]]; then
+		rm -f "$pages_file"
+		return "$collect_exit"
+	fi
+
+	_gh_pr_checks_exact_emit_result "$mode" "$head_ref" "$pages_file" || result_exit=$?
+	rm -f "$pages_file"
+	return "$result_exit"
 }
 
 #######################################

--- a/.agents/scripts/tests/test-full-loop-efficient-orchestration.sh
+++ b/.agents/scripts/tests/test-full-loop-efficient-orchestration.sh
@@ -173,6 +173,48 @@ gh() {
 	return 1
 }
 
+gh_pr_checks_exact_json() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local selection_mode="$3"
+	: "$repo_slug" "$pr_number" "$selection_mode"
+	case "$CHECK_MODE" in
+	pending)
+		printf '[{"name":"required","state":"IN_PROGRESS","bucket":"pending"}]\n'
+		return 8
+		;;
+	failure)
+		printf '[{"name":"required","state":"FAILURE","bucket":"fail"}]\n'
+		return 1
+		;;
+	success)
+		printf '[{"name":"required","state":"SUCCESS","bucket":"pass"}]\n'
+		return 0
+		;;
+	no-required)
+		printf 'exact check helper must not run when configuration has no contexts\n' >&2
+		return 99
+		;;
+	api-error)
+		printf 'exact check read unavailable\n' >&2
+		return 2
+		;;
+	changed-wording)
+		printf "no required checks configured for the 'fixture-remote' branch\n" >&2
+		return 1
+		;;
+	malformed)
+		printf 'not-json\n'
+		return 0
+		;;
+	empty-array)
+		printf '[]\n'
+		return 0
+		;;
+	*) return 2 ;;
+	esac
+}
+
 FULL_LOOP_PR_CHECK_STATUS=""
 _full_loop_verify_pr_readiness 42 owner/repo && fail "pending checks passed readiness"
 [[ "$FULL_LOOP_PR_CHECK_STATUS" == "pending" ]] || fail "pending checks were not classified as pending"

--- a/.agents/scripts/tests/test-full-loop-helper-coderabbit-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-helper-coderabbit-reconcile.sh
@@ -227,10 +227,18 @@ test_full_loop_readiness_integration() {
 	print_warning() { return 0; }
 	# shellcheck source=../full-loop-helper-commit.sh
 	source "${SCRIPTS_DIR}/full-loop-helper-commit.sh"
+	gh_pr_checks_exact_json() {
+		local repo_slug="$1"
+		local pr_number="$2"
+		local selection_mode="$3"
+		printf 'exact-checks %s %s %s\n' "$repo_slug" "$pr_number" "$selection_mode" >>"$GH_LOG"
+		printf '%s\n' '[{"name":"required-ci","state":"SUCCESS","bucket":"pass"}]'
+		return 0
+	}
 	local rc=0
 	_full_loop_verify_pr_readiness 42 owner/repo >/dev/null 2>&1 || rc=$?
 	if [[ "$rc" -eq 0 ]] && grep -q "dismissals" "$GH_LOG" \
-		&& grep -q "pr checks 42" "$GH_LOG"; then
+		&& grep -q "exact-checks owner/repo 42 required" "$GH_LOG"; then
 		record_result "full-loop readiness reconciles before required checks" 0
 	else
 		record_result "full-loop readiness reconciles before required checks" 1

--- a/.agents/scripts/tests/test-full-loop-remote-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-remote-evidence.sh
@@ -106,6 +106,46 @@ print_info() { return 0; }
 print_warning() { return 0; }
 print_success() { return 0; }
 source '${SCRIPTS_DIR}/full-loop-helper-commit.sh'
+gh_pr_checks_exact_json() {
+	local repo_slug="\$1"
+	local pr_number="\$2"
+	local selection_mode="\$3"
+	: "\$repo_slug" "\$pr_number" "\$selection_mode"
+	case "\${GH_TEST_MODE:-pass}" in
+		pending)
+			printf '%s\n' '[{"name":"required-ci","state":"IN_PROGRESS","bucket":"pending"}]'
+			return 8
+			;;
+		no-required)
+			printf '%s\n' 'exact check helper must not run when configuration has no contexts' >&2
+			return 99
+			;;
+		cli-no-required)
+			printf "%s\n" "no required checks reported on the 'remote-branch' branch" >&2
+			return 1
+			;;
+		api-error)
+			printf '%s\n' 'exact check read unavailable' >&2
+			return 2
+			;;
+		changed-wording)
+			printf "%s\n" "no required checks configured for the 'remote-branch' branch" >&2
+			return 1
+			;;
+		malformed)
+			printf '%s\n' 'not-json'
+			return 0
+			;;
+		empty-array)
+			printf '%s\n' '[]'
+			return 0
+			;;
+		*)
+			printf '%s\n' '[{"name":"required-ci","state":"SUCCESS","bucket":"pass"}]'
+			return 0
+			;;
+	esac
+}
 cmd_pre_merge_gate 42 testorg/testrepo
 RUNNER
 	chmod +x "$runner"

--- a/.agents/scripts/tests/test-gh-checks-wait-helper.sh
+++ b/.agents/scripts/tests/test-gh-checks-wait-helper.sh
@@ -79,16 +79,20 @@ live_bin="${TMPDIR_TEST}/live-bin"
 mkdir -p "$live_bin"
 cat >"${live_bin}/gh" <<'STUB'
 #!/usr/bin/env bash
-if [[ "${1:-}" == "pr" && "${2:-}" == "checks" ]]; then
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+	printf '%s\n' 'live-head'
+	exit 0
+fi
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/example/repo/pulls/123" ]]; then
+	printf '%s\n' '{"number":123,"node_id":"PR_fixture","head":{"ref":"feature/test","sha":"0123456789abcdef0123456789abcdef01234567"}}'
+	exit 0
+fi
+if [[ "${1:-}" == "api" && "${2:-}" == "graphql" ]]; then
 	if [[ "${GH_TEST_MODE:-no-required}" == "api-error" ]]; then
 		printf '%s\n' 'HTTP 503: service unavailable' >&2
 		exit 1
 	fi
-	printf "%s\n" "no required checks reported on the 'feature/test' branch" >&2
-	exit 1
-fi
-if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
-	printf '%s\n' 'live-head'
+	printf '%s\n' '{"data":{"node":{"__typename":"PullRequest","statusCheckRollup":{"nodes":[{"commit":{"statusCheckRollup":{"contexts":{"nodes":[{"__typename":"StatusContext","context":"optional","state":"SUCCESS","targetUrl":"","createdAt":"2026-08-01T00:00:00Z","description":"","isRequired":false}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}]}},"rateLimit":{"cost":1}}}'
 	exit 0
 fi
 exit 1
@@ -97,15 +101,15 @@ chmod +x "${live_bin}/gh"
 
 live_no_required_output=$(PATH="${live_bin}:$PATH" AIDEVOPS_GH_CHECKS_TEST_NO_SLEEP=1 \
 	"$HELPER" wait 123 --repo example/repo --timeout 0 2>&1)
-assert_contains "canonical CLI no-required message is terminal success" "PASS: required checks completed" "$live_no_required_output"
+assert_contains "canonical no-required message is terminal success" "PASS: required checks completed" "$live_no_required_output"
 
 set +e
 live_api_error_output=$(PATH="${live_bin}:$PATH" GH_TEST_MODE=api-error AIDEVOPS_GH_CHECKS_TEST_NO_SLEEP=1 \
 	"$HELPER" wait 123 --repo example/repo --timeout 0 2>&1)
 live_api_error_rc=$?
 set -e
-[[ "$live_api_error_rc" -eq 2 ]] && pass "CLI API error remains indeterminate" || fail "CLI API error remains indeterminate" "got ${live_api_error_rc}"
-assert_contains "CLI API error is diagnosed" "state unavailable" "$live_api_error_output"
+[[ "$live_api_error_rc" -eq 2 ]] && pass "exact-read API error remains indeterminate" || fail "exact-read API error remains indeterminate" "got ${live_api_error_rc}"
+assert_contains "exact-read API error is diagnosed" "state unavailable" "$live_api_error_output"
 
 mixed_skipping_dir="${TMPDIR_TEST}/mixed-skipping"
 write_fixture "$mixed_skipping_dir" 1 '[{"name":"Required","workflow":"CI","state":"SUCCESS","bucket":"pass","link":""},{"name":"Optional","workflow":"CI","state":"SKIPPED","bucket":"skipping","link":""}]'

--- a/.agents/scripts/tests/test-gh-pr-checks-exact-json.sh
+++ b/.agents/scripts/tests/test-gh-pr-checks-exact-json.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+LIB="${TEST_DIR}/../shared-gh-wrappers-checks.sh"
+TEST_ROOT="$(mktemp -d)"
+CALL_LOG="${TEST_ROOT}/gh-calls.log"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+mkdir -p "${TEST_ROOT}/bin"
+: >"$CALL_LOG"
+
+cat >"${TEST_ROOT}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" != "api" ]]; then
+	printf 'unexpected command: %s\n' "$*" >&2
+	exit 90
+fi
+
+endpoint="${2:-}"
+if [[ "$endpoint" == "repos/owner/repo/pulls/42" ]]; then
+	printf 'rest|%s|%s|%s\n' "${AIDEVOPS_GH_QUOTA_COST:-}" \
+		"${AIDEVOPS_GH_ROUTE_DECISION:-}" "$*" >>"$CALL_LOG"
+	if [[ "${GH_TEST_MODE:-multipage}" == "identity-error" ]]; then
+		exit 1
+	fi
+	if [[ "${GH_TEST_MODE:-multipage}" == "identity-malformed" ]]; then
+		printf '%s\n' '{"number":42,"node_id":"","head":{"ref":"feature/test","sha":"bad"}}'
+		exit 0
+	fi
+	printf '%s\n' '{"number":42,"node_id":"PR_fixture","head":{"ref":"feature/test","sha":"0123456789abcdef0123456789abcdef01234567"}}'
+	exit 0
+fi
+
+if [[ "$endpoint" != "graphql" ]]; then
+	printf 'unexpected endpoint: %s\n' "$endpoint" >&2
+	exit 91
+fi
+
+printf 'graphql|%s|%s|%s\n' "${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" \
+	"${AIDEVOPS_GH_ROUTE_DECISION:-}" "$*" >>"$CALL_LOG"
+
+mode="${GH_TEST_MODE:-multipage}"
+args="$*"
+page=1
+[[ "$args" == *"endCursor=CURSOR1"* ]] && page=2
+
+if [[ "$mode" == "graphql-error" ]]; then
+	printf '%s\n' '{"data":{"node":null,"rateLimit":{"cost":2}},"errors":[{"message":"field unavailable"}]}'
+	exit 0
+fi
+if [[ "$mode" == "missing-rollup" ]]; then
+	printf '%s\n' '{"data":{"node":{"__typename":"PullRequest","statusCheckRollup":{"nodes":[]}},"rateLimit":{"cost":1}}}'
+	exit 0
+fi
+
+nodes='[]'
+has_next=false
+end_cursor=''
+cost=1
+case "$mode" in
+multipage)
+	if [[ "$page" -eq 1 ]]; then
+		nodes='[
+			{"__typename":"CheckRun","name":"build","status":"COMPLETED","conclusion":"SUCCESS","startedAt":"2026-08-01T00:00:00Z","completedAt":"2026-08-01T00:01:00Z","detailsUrl":"https://example.invalid/old","isRequired":true,"checkSuite":{"workflowRun":{"event":"push","workflow":{"name":"CI"}}}},
+			{"__typename":"CheckRun","name":"shadowed","status":"COMPLETED","conclusion":"SUCCESS","startedAt":"2026-08-01T00:05:00Z","completedAt":"2026-08-01T00:06:00Z","detailsUrl":"","isRequired":true,"checkSuite":{"workflowRun":{"event":"push","workflow":{"name":"CI"}}}},
+			{"__typename":"StatusContext","context":"legacy","state":"PENDING","targetUrl":"","createdAt":"2026-08-01T00:00:00Z","description":"old status","isRequired":true}
+		]'
+		has_next=true
+		end_cursor='CURSOR1'
+		cost=2
+	else
+		nodes='[
+			{"__typename":"CheckRun","name":"build","status":"COMPLETED","conclusion":"FAILURE","startedAt":"2026-08-01T01:00:00Z","completedAt":"2026-08-01T01:01:00Z","detailsUrl":"https://example.invalid/new","isRequired":true,"checkSuite":{"workflowRun":{"event":"push","workflow":{"name":"CI"}}}},
+			{"__typename":"CheckRun","name":"shadowed","status":"COMPLETED","conclusion":"SUCCESS","startedAt":"2026-08-01T01:05:00Z","completedAt":"2026-08-01T01:06:00Z","detailsUrl":"","isRequired":false,"checkSuite":{"workflowRun":{"event":"push","workflow":{"name":"CI"}}}},
+			{"__typename":"CheckRun","name":"deploy","status":"COMPLETED","conclusion":"SKIPPED","startedAt":"2026-08-01T00:30:00Z","completedAt":"2026-08-01T00:31:00Z","detailsUrl":"","isRequired":true,"checkSuite":{"workflowRun":{"event":"workflow_dispatch","workflow":{"name":"Release"}}}},
+			{"__typename":"CheckRun","name":"optional","status":"COMPLETED","conclusion":"SUCCESS","startedAt":"2026-08-01T00:20:00Z","completedAt":"2026-08-01T00:21:00Z","detailsUrl":"","isRequired":false,"checkSuite":{"workflowRun":{"event":"pull_request","workflow":{"name":"Advisory"}}}},
+			{"__typename":"StatusContext","context":"legacy","state":"SUCCESS","targetUrl":"https://example.invalid/status","createdAt":"2026-08-01T02:00:00Z","description":"new status","isRequired":true}
+		]'
+		cost=3
+	fi
+	;;
+pending)
+	nodes='[{"__typename":"CheckRun","name":"pending","status":"IN_PROGRESS","conclusion":null,"startedAt":"2026-08-01T00:00:00Z","completedAt":null,"detailsUrl":"","isRequired":true,"checkSuite":{"workflowRun":{"event":"push","workflow":{"name":"CI"}}}}]'
+	;;
+cancel)
+	nodes='[{"__typename":"CheckRun","name":"cancelled","status":"COMPLETED","conclusion":"CANCELLED","startedAt":"2026-08-01T00:00:00Z","completedAt":"2026-08-01T00:01:00Z","detailsUrl":"","isRequired":true,"checkSuite":{"workflowRun":{"event":"push","workflow":{"name":"CI"}}}}]'
+	;;
+no-required)
+	nodes='[{"__typename":"StatusContext","context":"optional","state":"SUCCESS","targetUrl":"","createdAt":"2026-08-01T00:00:00Z","description":"","isRequired":false}]'
+	;;
+empty)
+	nodes='[]'
+	;;
+missing-cost)
+	nodes='[{"__typename":"StatusContext","context":"required","state":"SUCCESS","targetUrl":"","createdAt":"2026-08-01T00:00:00Z","description":"","isRequired":true}]'
+	;;
+zero-cost)
+	nodes='[{"__typename":"StatusContext","context":"required","state":"SUCCESS","targetUrl":"","createdAt":"2026-08-01T00:00:00Z","description":"","isRequired":true}]'
+	cost=0
+	;;
+repeated-cursor)
+	nodes='[{"__typename":"StatusContext","context":"required","state":"SUCCESS","targetUrl":"","createdAt":"2026-08-01T00:00:00Z","description":"","isRequired":true}]'
+	has_next=true
+	end_cursor='CURSOR1'
+	;;
+*)
+	printf 'unknown fixture mode: %s\n' "$mode" >&2
+	exit 92
+	;;
+esac
+
+if [[ "$mode" == "missing-cost" ]]; then
+	jq -nc --argjson nodes "$nodes" --argjson has_next "$has_next" --arg end_cursor "$end_cursor" '
+		{data:{node:{__typename:"PullRequest",statusCheckRollup:{nodes:[{commit:{statusCheckRollup:{contexts:{nodes:$nodes,pageInfo:{hasNextPage:$has_next,endCursor:(if $end_cursor == "" then null else $end_cursor end)}}}}}]}}}}
+	'
+	exit 0
+fi
+
+jq -nc --argjson nodes "$nodes" --argjson has_next "$has_next" --arg end_cursor "$end_cursor" --argjson cost "$cost" '
+	{data:{
+		node:{__typename:"PullRequest",statusCheckRollup:{nodes:[{commit:{statusCheckRollup:{contexts:{nodes:$nodes,pageInfo:{hasNextPage:$has_next,endCursor:(if $end_cursor == "" then null else $end_cursor end)}}}}}]}},
+		rateLimit:{cost:$cost}
+	}}
+'
+exit 0
+STUB
+chmod +x "${TEST_ROOT}/bin/gh"
+
+export CALL_LOG
+export PATH="${TEST_ROOT}/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+# shellcheck source=../shared-gh-wrappers-checks.sh
+source "$LIB"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+CASE_RC=0
+CASE_OUT=""
+CASE_ERR=""
+
+pass() {
+	local description="$1"
+	printf 'PASS: %s\n' "$description"
+	PASS_COUNT=$((PASS_COUNT + 1))
+	return 0
+}
+
+fail() {
+	local description="$1"
+	local detail="${2:-}"
+	printf 'FAIL: %s%s\n' "$description" "${detail:+ — $detail}"
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	return 0
+}
+
+assert_eq() {
+	local description="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		pass "$description"
+	else
+		fail "$description" "expected ${expected}, got ${actual}"
+	fi
+	return 0
+}
+
+assert_contains() {
+	local description="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$actual" == *"$expected"* ]]; then
+		pass "$description"
+	else
+		fail "$description" "missing ${expected}"
+	fi
+	return 0
+}
+
+assert_json() {
+	local description="$1"
+	local filter="$2"
+	local payload="$3"
+	if printf '%s' "$payload" | jq -e "$filter" >/dev/null 2>&1; then
+		pass "$description"
+	else
+		fail "$description" "payload did not satisfy ${filter}"
+	fi
+	return 0
+}
+
+run_case() {
+	local fixture_mode="$1"
+	local selection_mode="$2"
+	local max_pages="${3:-20}"
+	local out_file="${TEST_ROOT}/case.out"
+	local err_file="${TEST_ROOT}/case.err"
+	: >"$out_file"
+	: >"$err_file"
+	set +e
+	GH_TEST_MODE="$fixture_mode" AIDEVOPS_GH_PR_CHECKS_MAX_PAGES="$max_pages" \
+		gh_pr_checks_exact_json owner/repo 42 "$selection_mode" >"$out_file" 2>"$err_file"
+	CASE_RC=$?
+	set -e
+	CASE_OUT=$(<"$out_file")
+	CASE_ERR=$(<"$err_file")
+	return 0
+}
+
+: >"$CALL_LOG"
+run_case multipage required
+assert_eq "terminal failures return one" "1" "$CASE_RC"
+assert_json "multipage results deduplicate before required filtering" \
+	'length == 3 and ([.[].name] | sort) == ["build","deploy","legacy"]' "$CASE_OUT"
+assert_json "newest duplicate and bucket mapping match gh CLI" \
+	'first(.[] | select(.name == "build")) | .state == "FAILURE" and .bucket == "fail" and .link == "https://example.invalid/new" and .workflow == "CI" and .event == "push"' "$CASE_OUT"
+assert_json "status contexts and skipped checks retain projected fields" \
+	'(first(.[] | select(.name == "legacy")) | .state == "SUCCESS" and .bucket == "pass" and .description == "new status") and (first(.[] | select(.name == "deploy")) | .bucket == "skipping")' "$CASE_OUT"
+assert_eq "identity REST read is fixed-cost attributed" "1" \
+	"$(grep -c '^rest|1|gh-pr-checks-identity-rest|' "$CALL_LOG" || true)"
+assert_eq "every GraphQL page uses response-owned cost attribution" "2" \
+	"$(grep -c '^graphql|1|gh-pr-checks-status-rollup-exact-cost|' "$CALL_LOG" || true)"
+assert_contains "GraphQL query requests operation-owned cost" "rateLimit { cost }" "$(<"$CALL_LOG")"
+assert_contains "second page uses the returned cursor" "endCursor=CURSOR1" "$(<"$CALL_LOG")"
+
+run_case multipage all
+assert_json "all mode retains optional checks and only the newest duplicate" \
+	'length == 5 and any(.[]; .name == "optional") and ([.[] | select(.name == "shadowed")] | length) == 1' "$CASE_OUT"
+
+run_case pending required
+assert_eq "pending checks return eight" "8" "$CASE_RC"
+assert_json "in-progress CheckRun maps to pending" 'length == 1 and .[0].state == "IN_PROGRESS" and .[0].bucket == "pending"' "$CASE_OUT"
+
+run_case cancel required
+assert_eq "cancel-only output preserves native zero exit" "0" "$CASE_RC"
+assert_json "cancelled CheckRun maps to cancel" 'length == 1 and .[0].state == "CANCELLED" and .[0].bucket == "cancel"' "$CASE_OUT"
+
+run_case no-required required
+assert_eq "no required checks returns one" "1" "$CASE_RC"
+assert_eq "no required checks emits no JSON" "" "$CASE_OUT"
+assert_eq "no required diagnostic matches native CLI" "no required checks reported on the 'feature/test' branch" "$CASE_ERR"
+
+run_case empty all
+assert_eq "no checks returns one" "1" "$CASE_RC"
+assert_eq "no checks never becomes empty-array success" "" "$CASE_OUT"
+assert_eq "no checks diagnostic names the immutable identity branch" "no checks reported on the 'feature/test' branch" "$CASE_ERR"
+
+for failure_mode in identity-error identity-malformed missing-cost zero-cost graphql-error missing-rollup repeated-cursor; do
+	run_case "$failure_mode" required
+	assert_eq "${failure_mode} fails indeterminate" "2" "$CASE_RC"
+	assert_eq "${failure_mode} emits no JSON" "" "$CASE_OUT"
+done
+
+run_case multipage required 1
+assert_eq "page bound fails closed" "2" "$CASE_RC"
+assert_contains "page bound is diagnosed" "pagination exceeded 1 pages" "$CASE_ERR"
+
+printf '%s passed, %s failed\n' "$PASS_COUNT" "$FAIL_COUNT"
+if [[ "$FAIL_COUNT" -ne 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -330,6 +330,7 @@ define_feedback_helpers() {
 		_ci_actionable_failed_checks_markdown
 		_ci_terminal_failed_check_results
 		_ci_merge_check_sets
+		_ci_repair_required_checks_json
 		_append_feedback_to_issue
 		_transition_issue_for_redispatch
 		_close_and_label_feedback_pr
@@ -380,6 +381,30 @@ EOF
 	_pulse_merge_repo_path_for_slug() { local repo_slug="$1"; [[ -n "$repo_slug" ]]; printf '%s\n' "${TEST_ROOT}/repo"; return 0; }
 	_is_process_alive_and_matches() { local process_pid="$1"; local process_pattern="$2"; local stored_hash="$3"; [[ -n "$process_pattern" || -n "$stored_hash" ]]; kill -0 "$process_pid" 2>/dev/null; return $?; }
 	_file_mtime_epoch() { local file_path="$1"; [[ -e "$file_path" ]] || return 1; date +%s; return 0; }
+	gh_pr_checks_exact_json() {
+		local repo_slug="$1"
+		local pr_number="$2"
+		local selection_mode="$3"
+		printf 'exact-checks %s %s %s\n' "$repo_slug" "$pr_number" "$selection_mode" >>"$GH_LOG"
+		case "${TEST_CHECK_SCENARIO:-terminal_failure}" in
+		pending_only)
+			printf '%s\n' '[{"name":"Lint","bucket":"pending","state":"IN_PROGRESS","link":""}]'
+			return 8
+			;;
+		mixed_pending_pass)
+			printf '%s\n' '[{"name":"Lint","bucket":"pending","state":"QUEUED","link":""},{"name":"Unit","bucket":"pass","state":"SUCCESS","link":""}]'
+			return 8
+			;;
+		advisory_failure)
+			printf "%s\n" "no required checks reported on the 'feature/repair' branch" >&2
+			return 1
+			;;
+		*)
+			printf '%s\n' '[{"name":"Lint","bucket":"fail","state":"FAILURE","link":"https://github.com/owner/repo/actions/runs/123/job/456"}]'
+			return 1
+			;;
+		esac
+	}
 	for fn in "${fns[@]}"; do
 		fn_src=$(extract_function "$fn" "$FEEDBACK_SCRIPT")
 		[[ -n "$fn_src" ]] || return 1

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -233,6 +233,14 @@ teardown_test_env() {
 define_helpers_under_test() {
 	local fn fn_src
 	gh_issue_edit_safe() { gh issue edit "$@"; return $?; }
+	gh_pr_checks_exact_json() {
+		local repo_slug="$1"
+		local pr_number="$2"
+		local selection_mode="$3"
+		printf 'exact-checks %s %s %s\n' "$repo_slug" "$pr_number" "$selection_mode" >>"$GH_LOG"
+		printf '%s\n' '[{"name":"Lint","bucket":"fail","state":"FAILURE","link":"https://github.com/owner/repo/actions/runs/123/job/456"}]'
+		return 1
+	}
 	# Functions to extract, in source order. _build_review_feedback_section
 	# is used by the "build section" tests; the three shared helpers are
 	# required by the refactored _dispatch_pr_fix_worker body.
@@ -245,6 +253,7 @@ define_helpers_under_test() {
 		_ci_actionable_failed_checks_markdown
 		_ci_terminal_failed_check_results
 		_build_ci_feedback_section
+		_ci_repair_required_checks_json
 		_route_ci_repair_fallback
 		_ci_repair_hash_text
 		_dispatch_ci_fix_worker
@@ -589,6 +598,8 @@ test_ci_dispatch_dedupes_by_pr_head_marker() {
 	_dispatch_ci_fix_worker "100" "owner/repo" "42"
 	_route_ci_repair_fallback "100" "owner/repo" "42" "abc123repairsha" "feature/worker" \
 		"changed-fingerprint" "retry budget exhausted" "## CI Failure Feedback" "- **Unit**: failure"
+	_route_ci_repair_fallback "100" "owner/repo" "42" "abc123repairsha" "feature/worker" \
+		"another-fingerprint" "retry budget exhausted" "## CI Failure Feedback" "- **Unit**: failure"
 
 	local body_edit_count pr_close_count
 	body_edit_count=$(grep -cE 'gh issue edit 42 --repo owner/repo --body' "$GH_LOG" 2>/dev/null || true)

--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -73,9 +73,9 @@ print_result() {
 #   expected_only   — required status context is expected/not reported yet
 #   skipping_only   — required check-run concludes skipped
 #   empty_required_pending_fallback — branch/ruleset APIs expose no contexts,
-#      but `gh pr checks --required` reports a pending required check
+#      but the exact PR-check read reports a pending required check
 #   empty_required_stale_maintainer_gate_fallback — branch/ruleset APIs expose
-#      no contexts, `gh pr checks --required` has a stale pending maintainer-gate
+#      no contexts, the exact PR-check read has a stale pending maintainer-gate
 #      status, and the current head's maintainer-gate CheckRun is successful
 #   pr_checks_empty_failure — PR-level required checks exits non-zero with no JSON
 #   ruleset_review_malformed_optional — ruleset detail has unexpected shapes
@@ -214,32 +214,6 @@ fi
 if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"headRefOid"* ]]; then
 	apply_jq '{"headRefOid":"abc123def456789000000000000000000000abcd"}' "$@"
 	exit 0
-fi
-
-if [[ "$1" == "pr" && "$2" == "checks" && "$*" == *"--required"* ]]; then
-	case "${MOCK_GH_MODE:-all_pass}" in
-	empty_required_pending_fallback)
-		apply_jq '[
-			{"name":"ShellCheck (macos-latest)","state":"PENDING","bucket":"pending"},
-			{"name":"maintainer-gate","state":"SUCCESS","bucket":"pass"}
-		]' "$@"
-		exit 2
-		;;
-	empty_required_stale_maintainer_gate_fallback | empty_required_current_pending_maintainer_gate_fallback)
-		apply_jq '[
-			{"name":"Complexity Analysis","state":"SUCCESS","bucket":"pass"},
-			{"name":"maintainer-gate","state":"PENDING","bucket":"pending"}
-		]' "$@"
-		exit 1
-		;;
-	pr_checks_empty_failure)
-		exit 1
-		;;
-	*)
-		apply_jq '[]' "$@"
-		exit 0
-		;;
-	esac
 fi
 
 if [[ "$1" == "api" && "$*" == *"/check-runs"* ]]; then
@@ -386,6 +360,36 @@ define_function_under_test() {
 	# functions in isolation; extracted functions reference the PMRC_* contract.
 	# shellcheck disable=SC1090  # dynamic source from sibling lib
 	source "$REQUIRED_CHECKS_SCRIPT"
+	gh_pr_checks_exact_json() {
+		local repo_slug="$1"
+		local pr_number="$2"
+		local selection_mode="$3"
+		: "$repo_slug" "$pr_number" "$selection_mode"
+		case "${MOCK_GH_MODE:-all_pass}" in
+		empty_required_pending_fallback)
+			printf '%s\n' '[
+				{"name":"ShellCheck (macos-latest)","state":"PENDING","bucket":"pending"},
+				{"name":"maintainer-gate","state":"SUCCESS","bucket":"pass"}
+			]'
+			return 8
+			;;
+		empty_required_stale_maintainer_gate_fallback | empty_required_current_pending_maintainer_gate_fallback)
+			printf '%s\n' '[
+				{"name":"Complexity Analysis","state":"SUCCESS","bucket":"pass"},
+				{"name":"maintainer-gate","state":"PENDING","bucket":"pending"}
+			]'
+			return 8
+			;;
+		pr_checks_empty_failure)
+			printf '%s\n' 'exact check read unavailable' >&2
+			return 2
+			;;
+		*)
+			printf "%s\n" "no required checks reported on the 'fixture-branch' branch" >&2
+			return 1
+			;;
+		esac
+	}
 	gh_pr_view() {
 		if gh pr view "$@"; then
 			return 0


### PR DESCRIPTION
## Summary

Added a bounded exact-cost GraphQL PR-check reader and routed the four internal consumers away from native gh pr checks.

## Files Changed

.agents/scripts/full-loop-helper-commit.sh, .agents/scripts/gh-checks-wait-helper.sh, .agents/scripts/pulse-merge-feedback.sh, .agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/shared-gh-wrappers-checks.sh, .agents/scripts/tests/test-full-loop-efficient-orchestration.sh, .agents/scripts/tests/test-full-loop-helper-coderabbit-reconcile.sh, .agents/scripts/tests/test-full-loop-remote-evidence.sh, .agents/scripts/tests/test-gh-checks-wait-helper.sh, .agents/scripts/tests/test-gh-pr-checks-exact-json.sh, .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh, .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh, .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Full local linter passed; dedicated exact-check suite passed 35/35; affected consumer suites passed; live required-check read returned four passing required checks.

Resolves #29106


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.206 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.5 spent 14d 21h and 53,723,442 tokens on this with the user in an interactive session.