### PR TITLE
GH#29109: Teach release workflows keyless artifact provenance

### DIFF
--- a/.agents/reference/release-artifact-provenance.md
+++ b/.agents/reference/release-artifact-provenance.md
@@ -1,0 +1,121 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Release Artifact Provenance
+
+Use this pattern when a repository publishes installable artifacts, container
+images, update manifests, package indexes, checksums, or release catalogs from
+GitHub Actions. The goal is unattended, independently verifiable publisher
+provenance without a long-lived signing key.
+
+## Default Pattern
+
+1. Restrict publication to a reviewed protected branch or an expected release
+   tag. Validate the exact ref before requesting an OIDC identity.
+2. Build immutable artifacts from the reviewed source revision. Container
+   references must use the resolved digest, never only a mutable tag.
+3. Grant the signing job only the permissions it needs:
+   `id-token: write`, `attestations: write`, and the narrowest required
+   `contents`/`packages` permissions.
+4. Pin `actions/attest-build-provenance` by full commit SHA. Attest the exact
+   file bytes with `subject-path`, or the exact OCI subject name and digest with
+   `subject-name` plus `subject-digest`.
+5. Verify the emitted bundle before publication continues. Constrain
+   verification to the repository, exact signer workflow, and already-validated
+   source ref; do not accept repository ownership alone as sufficient identity.
+6. Publish or promote only the verified artifact. Keep versions append-only and
+   preserve digest-to-release evidence.
+7. Verify the public artifact or registry digest again after publication. Record
+   the verification command in the repository publishing runbook.
+
+GitHub Actions obtains a short-lived signing certificate from its OIDC identity
+and records Sigstore transparency evidence. Routine releases therefore require
+no signing-key secret or operator attendance. Human authority remains necessary
+for initial workflow/branch-policy review, consequential publication consent,
+and trust-policy or keyless-identity changes.
+
+## File Artifact Example
+
+```yaml
+permissions:
+  attestations: write
+  contents: read
+  id-token: write
+
+steps:
+  - name: Attest release artifact
+    id: attest-artifact
+    uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+    with:
+      subject-path: path/to/release-artifact
+
+  - name: Verify exact attestation bundle
+    env:
+      GH_TOKEN: ${{ github.token }}
+    run: |
+      gh attestation verify path/to/release-artifact \
+        --bundle "${{ steps.attest-artifact.outputs.bundle-path }}" \
+        --repo "${GITHUB_REPOSITORY}" \
+        --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/release.yml" \
+        --source-ref refs/heads/main
+```
+
+Replace the workflow path and expected ref with repository-owned constants. For
+tag publication, first validate the exact allowed tag pattern and then verify
+the same `GITHUB_REF`; never let untrusted inputs choose the signer identity or
+expected ref.
+
+## OCI Image Example
+
+```yaml
+- name: Attest immutable image
+  id: attest-image
+  uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+  with:
+    subject-name: ${{ env.IMAGE_REPOSITORY }}
+    subject-digest: ${{ steps.build.outputs.digest }}
+    push-to-registry: true
+
+- name: Verify exact image attestation
+  env:
+    GH_TOKEN: ${{ github.token }}
+    IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+  run: |
+    gh attestation verify "oci://${IMAGE_REPOSITORY}@${IMAGE_DIGEST}" \
+      --bundle "${{ steps.attest-image.outputs.bundle-path }}" \
+      --repo "${GITHUB_REPOSITORY}" \
+      --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/release.yml" \
+      --source-ref refs/heads/main
+```
+
+Authenticate to the registry when verification requires it. Verify the digest
+subject, not the release tag. Keep `push-to-registry: true` when operators need
+to retrieve the attestation with the OCI artifact.
+
+## Existing Releases and Other Ecosystems
+
+- Add a no-version-bump path that attests the current public catalog or artifact
+  once, so adopting provenance does not require fabricating a release.
+- Prefer native trusted publication in addition to artifact attestations, such
+  as npm OIDC provenance. Do not replace an ecosystem's stronger consumer-side
+  verification with a detached attestation that clients ignore.
+- For multiple artifacts, attest a deterministic archive or each independently
+  consumed file. Do not attest a mutable directory whose packaged bytes differ
+  from the public download.
+- Preserve platform signing requirements (for example notarization or package
+  signing). Sigstore provenance identifies the build; it does not replace
+  executable trust mechanisms enforced by an operating system.
+
+## Security Boundary
+
+An attestation makes tampering detectable only when somebody verifies it against
+the expected identity. It does not make a compromised release workflow honest,
+prevent a trusted workflow from building malicious input, or force downstream
+clients to reject an unsigned update. Protect the workflow and branch, pin all
+third-party actions, minimize token permissions, and state whether consumers
+enforce the attestation or it currently provides audit evidence only.
+
+Checksums published beside an artifact are not a substitute: compromise of the
+same host can replace both. Update systems that need rollback/freeze protection
+also require trusted version/expiry policy (for example a TUF-style design), not
+only a signature over the latest manifest.

--- a/.agents/services/hosting/cloudron.md
+++ b/.agents/services/hosting/cloudron.md
@@ -237,7 +237,7 @@ cloudron-helper.sh add-user production newuser@domain.com
 Source: [forum.cloudron.io/topic/14976](https://forum.cloudron.io/topic/14976/what-s-coming-in-9-1) (released to unstable 2026-03-01)
 
 - **Custom app build/deploy**: `cloudron install` uploads source, builds on-server. Source backed up and rebuilt on restore.
-- **Community packages**: Third-party apps via `CloudronVersions.json` URL in dashboard. See `cloudron-app-publishing-skill.md`.
+- **Community packages**: Third-party apps via `CloudronVersions.json` URL in dashboard. Aidevops-packaged apps use keyless image/catalog provenance, while Cloudron currently does not enforce it client-side. See `cloudron-app-publishing-skill.md` and `reference/release-artifact-provenance.md`.
 - **Passkey auth**: FIDO2/WebAuthn. Tested: Bitwarden, YubiKey 5, Nitrokey, native browser/OS.
 - **OIDC CLI login**: Browser-based OIDC for CLI. Pre-obtained API tokens still work for CI/CD.
 - **Addon upgrades**: MongoDB 8, Redis 8.4, Node.js 24.x

--- a/.agents/tests/comprehension/workflows--git-workflow.yaml
+++ b/.agents/tests/comprehension/workflows--git-workflow.yaml
@@ -1,4 +1,4 @@
-# Test: .agents/workflows/git-workflow.md (158 lines — complex workflow doc)
+# Test: .agents/workflows/git-workflow.md (complex workflow doc)
 file: .agents/workflows/git-workflow.md
 tier_minimum: standard
 
@@ -55,3 +55,25 @@ scenarios:
     fast_fail_triggers:
       - refusal
       - structural_violation
+
+  - name: "routes release artifacts to keyless provenance"
+    prompt: "A repository publishes images and an update manifest from GitHub Actions. What provenance pattern should be assessed before changing its release workflow?"
+    expected:
+      contains:
+        - "OIDC"
+        - "exact"
+        - "signer workflow"
+        - "validated ref"
+      not_contains:
+        - "checksum is sufficient"
+      min_length: 60
+      max_length: 700
+    reference_answer: |
+      Assess unattended GitHub Actions OIDC/Sigstore provenance. Attest the exact
+      artifact bytes or immutable image digest, then verify the repository, exact
+      signer workflow, and already validated release ref before publication.
+      Keep any native platform signing or consumer-enforced mechanism. Load
+      reference/release-artifact-provenance.md for the full pattern.
+    fast_fail_triggers:
+      - refusal
+      - security_violation

--- a/.agents/tools/deployment/cloudron-app-packaging-skill.md
+++ b/.agents/tools/deployment/cloudron-app-packaging-skill.md
@@ -25,7 +25,7 @@ Cloudron apps are Docker images plus `CloudronManifest.json`. The platform provi
 
 - **Upstream**: [git.cloudron.io/docs/skills](https://git.cloudron.io/docs/skills) (`cloudron-app-packaging`) | [docs.cloudron.io/packaging](https://docs.cloudron.io/packaging/)
 - **Reference files**: `cloudron-app-packaging-skill/manifest-ref.md`, `cloudron-app-packaging-skill/addons-ref.md`
-- **Also see**: `cloudron-app-packaging.md` (native aidevops guide: helpers, local dev, Dockerfile/start.sh patterns, pre-packaging checks) and `cloudron-app-publishing-skill.md` (required version catalog, public metadata, visual assets, and publication lifecycle)
+- **Also see**: `cloudron-app-packaging.md` (native aidevops guide: helpers, local dev, Dockerfile/start.sh patterns, pre-packaging checks) and `cloudron-app-publishing-skill.md` (required version catalog, public metadata, keyless image/catalog provenance, visual assets, and publication lifecycle)
 - **Last upstream review**: `fcea39616e6e` ("Update the skill for cloudron sync"); no local import changes required beyond keeping the native guide and skill pointers aligned.
 
 ```bash
@@ -35,7 +35,8 @@ cloudron init                    # creates CloudronManifest.json and Dockerfile
 cloudron install                 # uploads source, builds on server, installs app
 cloudron update                  # re-uploads, rebuilds, updates running app
 # For any independently distributed package, initialize and maintain
-# CloudronVersions.json using cloudron-app-publishing-skill.md.
+# CloudronVersions.json and keyless release provenance using
+# cloudron-app-publishing-skill.md.
 ```
 
 <!-- AI-CONTEXT-END -->

--- a/.agents/tools/deployment/cloudron-app-packaging.md
+++ b/.agents/tools/deployment/cloudron-app-packaging.md
@@ -37,7 +37,7 @@ tools:
 6. Read env vars fresh on every start (values change across restarts) — never cache at startup
 7. Health check path must return HTTP 200 unauthenticated
 
-**File Structure**: `CloudronManifest.json`, `Dockerfile`, `start.sh`, `logo.png` (256×256). Independently distributed packages also keep `CloudronVersions.json`, a Cloudron-format changelog, a publishing runbook, and at least one privacy-reviewed screenshot or 3:1 hero; follow `cloudron-app-publishing-skill.md`.
+**File Structure**: `CloudronManifest.json`, `Dockerfile`, `start.sh`, `logo.png` (256×256). Independently distributed packages also keep `CloudronVersions.json`, a Cloudron-format changelog, a publishing runbook, keyless image/catalog provenance, and at least one privacy-reviewed screenshot or 3:1 hero; follow `cloudron-app-publishing-skill.md`.
 
 **CLI Workflow**:
 

--- a/.agents/tools/deployment/cloudron-app-publishing-skill.md
+++ b/.agents/tools/deployment/cloudron-app-publishing-skill.md
@@ -48,6 +48,7 @@ Commit these before the first registry build:
 - A local square 256×256 PNG icon (`icon` normally points to it) and at least one privacy-reviewed product screenshot or hero. `mediaLinks` must use public HTTPS URLs; Cloudron recommends 3:1 images such as 1200×400.
 - A Cloudron-format changelog file when using `file://`: each release heading must be exactly `[X.Y.Z]`, because `cloudron versions add` does not parse Keep a Changelog headings such as `## [X.Y.Z]`.
 - A short publishing runbook that records the canonical catalog URL, registry/repository ownership, asset provenance, test install, rollback, and Community Apps listing steps without storing credentials.
+- A managed GitHub Actions release workflow that creates and verifies keyless provenance for the immutable image digest and exact generated `CloudronVersions.json`; use `reference/release-artifact-provenance.md` before the first publication.
 
 `packageUrl` controls the package-source link in Community Apps and should point to the package repository. It requires `minBoxVersion` 10.0.0. Keep `packagerUrl` pointed at the package maintainer; do not repurpose it as the repository link. Packages that need Cloudron 9.1 compatibility should omit `packageUrl`, while packages that require a repository link should raise the minimum explicitly. `author` and `contactEmail` are deprecated in the manifest reference but are still required by the current CLI version-catalog validator.
 
@@ -106,6 +107,22 @@ git add CloudronVersions.json && git commit -m "release 1.1.0" && git push
 ```
 
 Before promotion, verify fresh install, upgrade from the previous published version, restart, backup/restore, health checks, and the public icon/media URLs. Image push, catalog promotion, catalog hosting, and Community Apps submission are publication actions and require explicit authorization.
+
+## Keyless Publication Provenance
+
+For aidevops-packaged community apps, GitHub Actions OIDC/Sigstore provenance is
+the default release design. Pin the package image by digest; attest both that OCI
+digest and the exact generated catalog bytes; verify each emitted bundle against
+the package repository, exact catalog workflow, and protected source ref before
+committing or promoting the catalog. Add a no-version-bump path that attests the
+existing catalog when this control is first adopted.
+
+Cloudron does not currently verify external Sigstore attestations when importing
+`CloudronVersions.json` or applying automatic updates. Describe the result as
+tamper evidence and publisher provenance, not client-enforced signing. A checksum
+beside the catalog does not close this gap because the same compromised host can
+replace both. Full workflow and verification pattern:
+`reference/release-artifact-provenance.md`.
 
 ## Distribution
 

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -159,6 +159,13 @@ Management: `install-hooks-helper.sh [status|install|test|uninstall]`. Files: `~
 
 After file changes: run preflight automatically. Pass → auto-commit with suggested message (confirm or override). Fail → show issues, offer fixes. After commit → auto-push, offer: create PR, continue working, or done.
 
+**Release-bearing repositories:** when a repository publishes artifacts, images,
+update manifests, or catalogs through GitHub Actions, assess unattended
+OIDC/Sigstore keyless provenance before changing its release workflow. Attest
+exact bytes/digests and verify repository + signer workflow + validated ref
+before publication; retain native platform signing. Pattern:
+`reference/release-artifact-provenance.md`.
+
 **PR Title (MANDATORY)**: `{task-id}: {description}`. Task ID is `tNNN` (from TODO.md) or `GH#NNN` (GitHub issue number, for quality-debt/simplification-debt/issue-only work). Examples: `t318: Update PR workflow documentation`, `GH#12455: tighten hashline-edit-format.md`. NEVER use `qd-`, bare numbers, or invented prefixes. NEVER invent suffixes or variants either — `t2213b`, `t2213-2`, `t2213.fix`, `t2213-followup` are all forbidden. Task IDs come EXCLUSIVELY from `claim-task-id.sh` output; for follow-up work, claim a FRESH ID. For unplanned work: create TODO entry first.
 
 **If changes include `.agents/` files**: Offer to run `./setup.sh` to deploy to `~/.aidevops/agents/`.
@@ -193,6 +200,7 @@ See `workflows/sql-migrations.md`. **Critical rules**: Never modify pushed/deplo
 | `postflight.md` | Verification after release |
 | `version-bump.md` | Version management, release branches |
 | `release.md` | Full release process |
+| `reference/release-artifact-provenance.md` | GitHub OIDC/Sigstore release signing and verification |
 | `sql-migrations.md` | Database schema version control |
 | `tools/git/lumen.md` | AI-powered diffs, commit messages |
 | `tools/security/opsec.md` | CI/CD AI agent security |

--- a/.agents/workflows/release.md
+++ b/.agents/workflows/release.md
@@ -63,7 +63,7 @@ immutable tag. Full contract: `reference/release-publication-controls.md`
 
 **DO NOT** run separate bump/tag/push commands. **Prerequisites**: terminal-success PR checks/reviews, observed merged state/SHA, authenticated `gh`, an accessible aidevops repository, and unreleased changelog content (or changelog-only `--force`). The helper fetches `origin/main` and creates its own detached release worktree; it does not require or mutate a clean canonical checkout.
 
-**Related**: `workflows/version-bump.md` · `workflows/changelog.md` · `workflows/postflight.md` · `.agents/scripts/validate-version-consistency.sh`
+**Related**: `workflows/version-bump.md` · `workflows/changelog.md` · `workflows/postflight.md` · `reference/release-artifact-provenance.md` · `.agents/scripts/validate-version-consistency.sh`
 
 ## Manual Release (Non-aidevops Repos)
 
@@ -72,6 +72,14 @@ repeat a full source scan merely because release follows every merge. Run the
 repository's broad gate only when no trustworthy SHA-matched evidence exists or
 the release changes shared/root contracts that were not covered by affected
 checks.
+
+When a repository publishes installable artifacts, images, update manifests, or
+catalogs from GitHub Actions, default to unattended OIDC/Sigstore provenance:
+attest the exact file or immutable digest, verify the emitted bundle against the
+repository, exact signer workflow, and validated release ref, then publish.
+Preserve native ecosystem signing and state clearly whether consumers enforce
+the attestation. Full design and examples:
+`reference/release-artifact-provenance.md`.
 
 ```bash
 # Conditional only: ./.agents/scripts/linters-local.sh --full


### PR DESCRIPTION
## Summary

Add a reusable OIDC/Sigstore release-provenance reference and route Cloudron packaging plus general release workflows to it.

## Files Changed

.agents/reference/release-artifact-provenance.md, .agents/services/hosting/cloudron.md, .agents/tests/comprehension/workflows--git-workflow.yaml, .agents/tools/deployment/cloudron-app-packaging-skill.md, .agents/tools/deployment/cloudron-app-packaging.md, .agents/tools/deployment/cloudron-app-publishing-skill.md, .agents/workflows/git-workflow.md, .agents/workflows/release.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Changed-file linters, comprehension helper unit tests, and the git-workflow comprehension benchmark pass.

Resolves #29109


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.206 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h 29m and 379,369 tokens on this with the user in an interactive session.