### PR TITLE
GH#29111: Make Cloudron monitoring tag-aware and UTC-scheduled

### DIFF
--- a/.agents/reference/repos-json-fields.md
+++ b/.agents/reference/repos-json-fields.md
@@ -121,7 +121,7 @@ explicit values. Package slugs and paths remain local to `repos.json`.
 | `manifest` | `CloudronManifest.json` | Manifest path relative to the registered repository root. Absolute paths and `..` are rejected by monitors. |
 | `release_workflow` | `.github/workflows/cloudron-package-release.yml` | Thin tag-triggered caller scaffolded by `aidevops init`; existing files are never overwritten. |
 | `upstream_slug` | unset | Upstream GitHub `owner/repo` used for stable-release comparison. Monitoring stays disabled until this is explicitly configured. |
-| `upstream_tag_prefixes` | `["v", ""]` | Non-empty array of tag-stream prefixes. Each value must be a string; the empty string allows bare semantic tags. Only tags whose configured prefix leaves a semantic version are candidates. |
+| `upstream_tag_prefixes` | `["v", ""]` | Non-empty array of tag-stream prefixes. Each value must be a string; ASCII control characters are rejected, while the empty string allows bare semantic tags. Only tags whose configured prefix leaves a semantic version are candidates. |
 | `monitor_upstream` | `true` when `upstream_slug` is set; otherwise `false` | Include the package in the daily upstream-release routine. |
 | `monitor_compatibility` | `true` | Include the package in the weekly manifest and pinned-base audit. |
 

--- a/.agents/reference/repos-json-fields.md
+++ b/.agents/reference/repos-json-fields.md
@@ -121,6 +121,7 @@ explicit values. Package slugs and paths remain local to `repos.json`.
 | `manifest` | `CloudronManifest.json` | Manifest path relative to the registered repository root. Absolute paths and `..` are rejected by monitors. |
 | `release_workflow` | `.github/workflows/cloudron-package-release.yml` | Thin tag-triggered caller scaffolded by `aidevops init`; existing files are never overwritten. |
 | `upstream_slug` | unset | Upstream GitHub `owner/repo` used for stable-release comparison. Monitoring stays disabled until this is explicitly configured. |
+| `upstream_tag_prefixes` | `["v", ""]` | Non-empty array of tag-stream prefixes. Each value must be a string; the empty string allows bare semantic tags. Only tags whose configured prefix leaves a semantic version are candidates. |
 | `monitor_upstream` | `true` when `upstream_slug` is set; otherwise `false` | Include the package in the daily upstream-release routine. |
 | `monitor_compatibility` | `true` | Include the package in the weekly manifest and pinned-base audit. |
 
@@ -130,11 +131,31 @@ explicit values. Package slugs and paths remain local to `repos.json`.
   "cloudron_package": {
     "manifest": "CloudronManifest.json",
     "upstream_slug": "exampleorg/example-upstream",
+    "upstream_tag_prefixes": ["v", ""],
     "monitor_upstream": true,
     "monitor_compatibility": true
   }
 }
 ```
+
+Use a package-specific stream when one upstream repository publishes releases
+for multiple products. For example, this accepts `desktop-v0.5.3` while
+rejecting unrelated `v...` tags:
+
+```json
+{
+  "cloudron_package": {
+    "upstream_slug": "exampleorg/multi-product-upstream",
+    "upstream_tag_prefixes": ["desktop-v"],
+    "monitor_upstream": true
+  }
+}
+```
+
+The upstream monitor paginates all GitHub releases, excludes drafts and
+prereleases, and chooses the numerically highest stable semantic version from
+the configured streams. Invalid prefix configuration or no matching stable tag
+fails closed with a diagnostic rather than falling back to another stream.
 
 The monitors file deduplicated findings only in the package repository and only
 with `ADMIN` or `MAINTAIN` authority. They never build, tag, publish, deploy, or

--- a/.agents/reference/routines.md
+++ b/.agents/reference/routines.md
@@ -25,7 +25,7 @@ material, dispatch paths, and logs remain private with restrictive modes.
 ## Routines
 
 - [x] r001 Weekly SEO rankings export repeat:weekly(mon@09:00) ~30m run:custom/scripts/seo-export.sh
-- [x] r002 Daily health check repeat:daily(@06:00) ~2m run:custom/scripts/health-check.sh
+- [x] r002 Daily health check repeat:daily(@06:00) timezone:UTC ~2m run:custom/scripts/health-check.sh
 - [ ] r003 Monthly content calendar review repeat:monthly(1@09:00) ~15m agent:Content
 - [x] r004 Nightly repo triage repeat:cron(15 2 * * *) ~20m agent:Build+
 ```
@@ -44,6 +44,7 @@ diagnostic.
 | `[x]` / `[ ]` | Enabled / disabled (keep disabled entries for auditability) |
 | `r001` / `r-name` | Stable `r`-prefixed ID — never reuse |
 | `repeat:` | Recurrence expression (see below) |
+| `timezone:` | Optional per-routine IANA timezone token, such as `UTC`, `Europe/Jersey`, or `Etc/GMT+1` |
 | `~30m` | Expected runtime estimate |
 | `run:` | Script path relative to `~/.aidevops/agents/` — deterministic, no LLM tokens |
 | `agent:` | Agent name dispatched via `headless-runtime-helper.sh` |
@@ -57,10 +58,19 @@ diagnostic.
 | `monthly(N@HH:MM)` | `monthly(1@09:00)` | Day N of each month |
 | `cron(expr)` | `cron(15 2 * * *)` | Complex schedules only |
 
-Calendar expressions use the host-local timezone by default. Set
-`AIDEVOPS_SCHEDULE_TIMEZONE` to an IANA timezone when a fleet needs an explicit
-shared contract. `is-due` and `next-run` use the same local-calendar boundaries:
-a run is due when its last successful/terminal run predates the latest boundary.
+Calendar expressions use this precedence: the routine's optional `timezone:`
+field, global `AIDEVOPS_SCHEDULE_TIMEZONE`, the inherited `TZ`, then the host
+timezone. A per-routine field therefore provides a version-controlled exception
+without changing unrelated routines. For example:
+
+```markdown
+- [x] r005 UTC report repeat:daily(@00:30) timezone:UTC run:custom/scripts/report.sh
+```
+
+Timezone values are single IANA-style tokens; malformed fields fail closed
+instead of falling back to the global or host timezone. `is-due` and `next-run`
+use the same local-calendar boundaries: a run is due when its last
+successful/terminal run predates the latest boundary.
 This catches up missed slots and prevents an off-slot bootstrap or manual run from
 suppressing the next boundary. Repeated fall-back hours belong to their first
 occurrence; nonexistent spring-forward local times fail closed with a diagnostic.

--- a/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
@@ -549,7 +549,7 @@ register_repo() {
 	local cloudron_defaults='{}'
 	if [[ -f "${repo_path}/CloudronManifest.json" ]]; then
 		app_type_default="$cloudron_app_type"
-		cloudron_defaults='{"manifest":"CloudronManifest.json","release_workflow":".github/workflows/cloudron-package-release.yml","monitor_compatibility":true}'
+		cloudron_defaults='{"manifest":"CloudronManifest.json","release_workflow":".github/workflows/cloudron-package-release.yml","monitor_compatibility":true,"upstream_tag_prefixes":["v",""]}'
 	fi
 
 	if jq -e --arg path "$repo_path" '.initialized_repos[] | select(.path == $path)' "$REPOS_FILE" &>/dev/null; then

--- a/.agents/scripts/cloudron-package-monitor-helper.sh
+++ b/.agents/scripts/cloudron-package-monitor-helper.sh
@@ -27,6 +27,17 @@ _cloudron_monitor_require_tools() {
 	return 0
 }
 
+_cloudron_monitor_component_newer() {
+	local candidate="$1"
+	local current="$2"
+	if [[ "${#candidate}" -ne "${#current}" ]]; then
+		[[ "${#candidate}" -gt "${#current}" ]]
+		return $?
+	fi
+	[[ "$candidate" > "$current" ]]
+	return $?
+}
+
 _cloudron_monitor_version_newer() {
 	local candidate="${1#v}"
 	local current="${2#v}"
@@ -38,22 +49,73 @@ _cloudron_monitor_version_newer() {
 	local current_major=0 current_minor=0 current_patch=0
 	IFS=. read -r candidate_major candidate_minor candidate_patch <<<"$candidate_core"
 	IFS=. read -r current_major current_minor current_patch <<<"$current_core"
-	if ((candidate_major != current_major)); then
-		((candidate_major > current_major))
+	if [[ "$candidate_major" != "$current_major" ]]; then
+		_cloudron_monitor_component_newer "$candidate_major" "$current_major"
 		return $?
 	fi
-	if ((candidate_minor != current_minor)); then
-		((candidate_minor > current_minor))
+	if [[ "$candidate_minor" != "$current_minor" ]]; then
+		_cloudron_monitor_component_newer "$candidate_minor" "$current_minor"
 		return $?
 	fi
-	if ((candidate_patch != current_patch)); then
-		((candidate_patch > current_patch))
+	if [[ "$candidate_patch" != "$current_patch" ]]; then
+		_cloudron_monitor_component_newer "$candidate_patch" "$current_patch"
 		return $?
 	fi
 	if [[ "$candidate" != *-* && "$current" == *-* ]]; then
 		return 0
 	fi
 	return 1
+}
+
+_cloudron_monitor_tag_version() {
+	local tag="$1"
+	local prefixes_json="$2"
+	local prefix=""
+	local version=""
+	while IFS= read -r prefix; do
+		[[ "$tag" == "$prefix"* ]] || continue
+		version="${tag#"$prefix"}"
+		cloudron_package_is_semver "$version" || continue
+		[[ "${version%%+*}" != *-* ]] || continue
+		printf '%s\n' "$version"
+		return 0
+	done < <(jq -r '.[]' <<<"$prefixes_json")
+	return 1
+}
+
+_cloudron_monitor_latest_release_version() {
+	local releases_json="$1"
+	local prefixes_json="$2"
+	local upstream_slug="$3"
+	local stable_tags=""
+	local tag=""
+	local version=""
+	local latest_version=""
+
+	[[ -n "$releases_json" ]] || _cloudron_monitor_error "GitHub returned an empty releases response for $upstream_slug." || return 1
+	if ! stable_tags=$(jq -r '
+		if type != "array" then
+			error("expected a release array")
+		else
+			.[]
+			| select(type == "object" and .draft != true and .prerelease != true and (.tag_name | type == "string"))
+			| .tag_name
+		end
+	' <<<"$releases_json"); then
+		_cloudron_monitor_error "GitHub releases response for $upstream_slug was not a valid release array." || return 1
+	fi
+
+	while IFS= read -r tag; do
+		[[ -n "$tag" ]] || continue
+		version=$(_cloudron_monitor_tag_version "$tag" "$prefixes_json") || continue
+		if [[ -z "$latest_version" ]] || _cloudron_monitor_version_newer "$version" "$latest_version"; then
+			latest_version="$version"
+		fi
+	done <<<"$stable_tags"
+
+	[[ -n "$latest_version" ]] || _cloudron_monitor_error "No stable semantic release tag for $upstream_slug matches cloudron_package.upstream_tag_prefixes ${prefixes_json}; configure the tag streams or publish a matching stable release." || return 1
+	printf '%s\n' "$latest_version"
+	return 0
 }
 
 _cloudron_monitor_has_authority() {
@@ -156,6 +218,7 @@ _cloudron_monitor_upstream_entry() {
 	local manifest_rel=""
 	local upstream_slug=""
 	local monitor_enabled=""
+	local tag_prefixes=""
 	slug=$(jq -r '.slug // empty' <<<"$entry")
 	repo_path=$(jq -r '.path // empty' <<<"$entry")
 	manifest_rel=$(jq -r '.cloudron_package.manifest // "CloudronManifest.json"' <<<"$entry")
@@ -171,10 +234,15 @@ _cloudron_monitor_upstream_entry() {
 	if ! package_title=$(jq -er '.title | select(type == "string" and test("\\S"))' "$manifest_path"); then
 		_cloudron_monitor_error "Manifest title is missing or blank for registered Cloudron package $slug." || return 1
 	fi
-	local latest_tag=""
-	latest_tag=$(gh api "repos/${upstream_slug}/releases/latest" --jq '.tag_name') || return 1
-	local latest_version="${latest_tag#v}"
-	cloudron_package_is_semver "$latest_version" || _cloudron_monitor_error "Latest release tag for $upstream_slug is not semantic versioning: $latest_tag" || return 1
+	tag_prefixes=$(jq -c '.cloudron_package.upstream_tag_prefixes as $prefixes | if $prefixes == null then ["v", ""] else $prefixes end' <<<"$entry") || return 1
+	jq -e 'type == "array" and length > 0 and all(.[]; type == "string")' <<<"$tag_prefixes" >/dev/null 2>&1 ||
+		_cloudron_monitor_error "cloudron_package.upstream_tag_prefixes for $slug must be a non-empty array of strings." || return 1
+	local releases_json=""
+	if ! releases_json=$(gh api "repos/${upstream_slug}/releases?per_page=100" --paginate); then
+		_cloudron_monitor_error "Could not fetch paginated GitHub releases for $upstream_slug." || return 1
+	fi
+	local latest_version=""
+	latest_version=$(_cloudron_monitor_latest_release_version "$releases_json" "$tag_prefixes" "$upstream_slug") || return 1
 	local current_version=""
 	current_version=$(jq -r '.upstreamVersion // empty' "$manifest_path") || return 1
 	if [[ -n "$current_version" ]] && ! _cloudron_monitor_version_newer "$latest_version" "$current_version"; then

--- a/.agents/scripts/cloudron-package-monitor-helper.sh
+++ b/.agents/scripts/cloudron-package-monitor-helper.sh
@@ -12,6 +12,8 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 source "${SCRIPT_DIR}/cloudron-package-release-lib.sh"
 
 REPOS_FILE="${AIDEVOPS_REPOS_FILE:-${HOME}/.config/aidevops/repos.json}"
+_CLOUDRON_MONITOR_JSON_TYPE_ARRAY=array
+_CLOUDRON_MONITOR_JSON_TYPE_STRING=string
 
 _cloudron_monitor_error() {
 	local message="$1"
@@ -23,7 +25,8 @@ _cloudron_monitor_require_tools() {
 	command -v jq >/dev/null 2>&1 || _cloudron_monitor_error "jq is required." || return 1
 	command -v gh >/dev/null 2>&1 || _cloudron_monitor_error "GitHub CLI is required." || return 1
 	[[ -f "$REPOS_FILE" ]] || _cloudron_monitor_error "repos.json not found: $REPOS_FILE" || return 1
-	jq -e '.initialized_repos | type == "array"' "$REPOS_FILE" >/dev/null 2>&1 || _cloudron_monitor_error "repos.json has no initialized_repos array." || return 1
+	jq -e --arg array_type "$_CLOUDRON_MONITOR_JSON_TYPE_ARRAY" \
+		'.initialized_repos | type == $array_type' "$REPOS_FILE" >/dev/null 2>&1 || _cloudron_monitor_error "repos.json has no initialized_repos array." || return 1
 	return 0
 }
 
@@ -93,12 +96,14 @@ _cloudron_monitor_latest_release_version() {
 	local latest_version=""
 
 	[[ -n "$releases_json" ]] || _cloudron_monitor_error "GitHub returned an empty releases response for $upstream_slug." || return 1
-	if ! stable_tags=$(jq -r '
-		if type != "array" then
+	if ! stable_tags=$(jq -r \
+		--arg array_type "$_CLOUDRON_MONITOR_JSON_TYPE_ARRAY" \
+		--arg string_type "$_CLOUDRON_MONITOR_JSON_TYPE_STRING" '
+		if type != $array_type then
 			error("expected a release array")
 		else
 			.[]
-			| select(type == "object" and .draft != true and .prerelease != true and (.tag_name | type == "string"))
+			| select(type == "object" and .draft != true and .prerelease != true and (.tag_name | type == $string_type))
 			| .tag_name
 		end
 	' <<<"$releases_json"); then
@@ -231,11 +236,13 @@ _cloudron_monitor_upstream_entry() {
 	local manifest_path="${repo_path}/${manifest_rel}"
 	[[ -f "$manifest_path" ]] || _cloudron_monitor_error "Manifest missing for registered Cloudron package $slug." || return 1
 	local package_title=""
-	if ! package_title=$(jq -er '.title | select(type == "string" and test("\\S"))' "$manifest_path"); then
+	if ! package_title=$(jq -er --arg string_type "$_CLOUDRON_MONITOR_JSON_TYPE_STRING" \
+		'.title | select(type == $string_type and test("\\S"))' "$manifest_path"); then
 		_cloudron_monitor_error "Manifest title is missing or blank for registered Cloudron package $slug." || return 1
 	fi
 	tag_prefixes=$(jq -c '.cloudron_package.upstream_tag_prefixes as $prefixes | if $prefixes == null then ["v", ""] else $prefixes end' <<<"$entry") || return 1
-	jq -e 'type == "array" and length > 0 and all(.[]; type == "string")' <<<"$tag_prefixes" >/dev/null 2>&1 ||
+	jq -e --arg array_type "$_CLOUDRON_MONITOR_JSON_TYPE_ARRAY" --arg string_type "$_CLOUDRON_MONITOR_JSON_TYPE_STRING" \
+		'type == $array_type and length > 0 and all(.[]; type == $string_type)' <<<"$tag_prefixes" >/dev/null 2>&1 ||
 		_cloudron_monitor_error "cloudron_package.upstream_tag_prefixes for $slug must be a non-empty array of strings." || return 1
 	local releases_json=""
 	if ! releases_json=$(gh api "repos/${upstream_slug}/releases?per_page=100" --paginate); then

--- a/.agents/scripts/cloudron-package-monitor-helper.sh
+++ b/.agents/scripts/cloudron-package-monitor-helper.sh
@@ -242,8 +242,8 @@ _cloudron_monitor_upstream_entry() {
 	fi
 	tag_prefixes=$(jq -c '.cloudron_package.upstream_tag_prefixes as $prefixes | if $prefixes == null then ["v", ""] else $prefixes end' <<<"$entry") || return 1
 	jq -e --arg array_type "$_CLOUDRON_MONITOR_JSON_TYPE_ARRAY" --arg string_type "$_CLOUDRON_MONITOR_JSON_TYPE_STRING" \
-		'type == $array_type and length > 0 and all(.[]; type == $string_type)' <<<"$tag_prefixes" >/dev/null 2>&1 ||
-		_cloudron_monitor_error "cloudron_package.upstream_tag_prefixes for $slug must be a non-empty array of strings." || return 1
+		'type == $array_type and length > 0 and all(.[]; type == $string_type and all(explode[]; . >= 32 and . != 127))' <<<"$tag_prefixes" >/dev/null 2>&1 ||
+		_cloudron_monitor_error "cloudron_package.upstream_tag_prefixes for $slug must be a non-empty array of strings; control characters are forbidden." || return 1
 	local releases_json=""
 	if ! releases_json=$(gh api "repos/${upstream_slug}/releases?per_page=100" --paginate); then
 		_cloudron_monitor_error "Could not fetch paginated GitHub releases for $upstream_slug." || return 1

--- a/.agents/scripts/init-routines-helper.sh
+++ b/.agents/scripts/init-routines-helper.sh
@@ -64,6 +64,7 @@ Fields:
   repeat: -- schedule: daily(@HH:MM), weekly(day@HH:MM), monthly(N@HH:MM), cron(expr)
   run:    -- deterministic script relative to ~/.aidevops/agents/
   agent:  -- LLM agent dispatched via headless-runtime-helper.sh
+  timezone: -- optional per-routine IANA timezone override
   [x] enabled, [ ] disabled/paused
 
 ## Core Routines (framework-managed)
@@ -79,10 +80,12 @@ TODOEOF
 	if [[ -f "${SCRIPT_DIR}/routines/core-routines.sh" ]]; then
 		# shellcheck disable=SC1091  # sourced file path is dynamic but verified above
 		source "${SCRIPT_DIR}/routines/core-routines.sh"
-		local line
-		while IFS='|' read -r rid enabled title schedule estimate script rtype; do
+		local rid enabled title schedule estimate script rtype timezone
+		local timezone_field=""
+		while IFS='|' read -r rid enabled title schedule estimate script rtype timezone; do
 			[[ -z "$rid" ]] && continue
-			echo "- [${enabled}] ${rid} ${title} ${schedule} ${estimate} run:${script}" >>"${repo_path}/TODO.md"
+			timezone_field="${timezone:+ timezone:${timezone}}"
+			printf '%s\n' "- [${enabled}] ${rid} ${title} ${schedule}${timezone_field} ${estimate} run:${script}" >>"${repo_path}/TODO.md"
 		done < <(get_core_routine_entries)
 	fi
 
@@ -162,7 +165,7 @@ CUSTOMEOF
 <!-- To fix: edit describe_rNNN() in core-routines.sh, not this file -->
 
 "
-	while IFS='|' read -r rid _ _ _ _ _ _; do
+	while IFS='|' read -r rid _ _ _ _ _ _ _; do
 		[[ -z "$rid" ]] && continue
 		local describe_fn="describe_${rid}"
 		if declare -f "$describe_fn" &>/dev/null; then
@@ -881,8 +884,8 @@ _create_core_routine_issues() {
 	local tz_name
 	tz_name=$(_detect_timezone)
 
-	local rid enabled title schedule estimate script rtype
-	while IFS='|' read -r rid enabled title schedule estimate script rtype; do
+	local rid enabled title schedule estimate script rtype timezone
+	while IFS='|' read -r rid enabled title schedule estimate script rtype timezone; do
 		[[ -z "$rid" ]] && continue
 		# Extract short title (before the em dash if present)
 		local short_title
@@ -890,7 +893,9 @@ _create_core_routine_issues() {
 
 		# Generate human-readable schedule
 		local human_schedule
-		human_schedule=$(_humanise_schedule "$schedule" "$tz_name")
+		local schedule_timezone=""
+		schedule_timezone="${timezone:-$tz_name}"
+		human_schedule=$(_humanise_schedule "$schedule" "$schedule_timezone")
 
 		# Detect whether this routine already has a tracking state file. If it
 		# does, we must NOT fire the initial `update --status success` body-

--- a/.agents/scripts/pulse-routines.sh
+++ b/.agents/scripts/pulse-routines.sh
@@ -19,6 +19,7 @@
 #   - _routine_execute
 #   - _routine_extract_section
 #   - _routine_parse_line
+#   - _routine_schedule_is_due
 #   - evaluate_routines
 #
 # Keep behavioral changes in this module covered by the focused selector and
@@ -252,6 +253,7 @@ _RPL_REPEAT=""
 _RPL_RUN=""
 _RPL_AGENT=""
 _RPL_DESC=""
+_RPL_TIMEZONE=""
 
 #######################################
 # Normalize one Markdown line before registry parsing.
@@ -436,8 +438,9 @@ _routine_targets_supervisor() {
 # Parse a single routine TODO line into its component fields.
 #
 # Extracts routine_id, repeat expression, run script, agent name, and
-# description from a TODO.md routine line. Sets module-scope variables
-# (_RPL_ID, _RPL_REPEAT, _RPL_RUN, _RPL_AGENT, _RPL_DESC) on success.
+# optional timezone from a TODO.md routine line. Sets module-scope variables
+# (_RPL_ID, _RPL_REPEAT, _RPL_RUN, _RPL_AGENT, _RPL_DESC, _RPL_TIMEZONE) on
+# success.
 #
 # Arguments: $1 - a TODO.md line matching the routine pattern
 # Returns: 0 if the line was successfully parsed, 1 if it should be skipped
@@ -449,6 +452,7 @@ _routine_parse_line() {
 	_RPL_RUN=""
 	_RPL_AGENT=""
 	_RPL_DESC=""
+	_RPL_TIMEZONE=""
 
 	# Live routine definitions are top-level Markdown list items. Four-space
 	# indentation is a code block and must not become scheduler input.
@@ -486,7 +490,7 @@ _routine_parse_line() {
 
 	# Extract optional run: field — captures script path and any trailing
 	# space-separated argument tokens. Field keywords (agent:, repeat:,
-	# started:, blocked-by:) always contain a colon, so we stop as soon as
+	# timezone:, started:, blocked-by:) always contain a colon, so we stop when
 	# we encounter a token with a colon embedded.
 	if [[ "$line" =~ run:([^[:space:]]+) ]]; then
 		_RPL_RUN="${BASH_REMATCH[1]}"
@@ -507,11 +511,41 @@ _routine_parse_line() {
 		_RPL_AGENT="${BASH_REMATCH[1]}"
 	fi
 
+	# Per-routine timezone tokens are intentionally data-only. The scheduler
+	# receives the value through one environment assignment, never interpolation.
+	local _re_timezone='(^|[[:space:]])timezone:([^[:space:]]*)'
+	local _re_timezone_token='^[A-Za-z0-9][A-Za-z0-9._+-]*(/[A-Za-z0-9][A-Za-z0-9._+-]*)*$'
+	if [[ "$line" =~ $_re_timezone ]]; then
+		_RPL_TIMEZONE="${BASH_REMATCH[2]}"
+		if [[ -z "$_RPL_TIMEZONE" ]] || ! [[ "$_RPL_TIMEZONE" =~ $_re_timezone_token ]]; then
+			printf 'ERROR: routine %s has malformed timezone field\n' "$_RPL_ID" >&2
+			_RPL_TIMEZONE=""
+			return 1
+		fi
+	fi
+
 	# Extract description (text between ID and first field tag).
 	local description_tail="${line#*"${_RPL_ID}"}"
-	_RPL_DESC=$(printf '%s' "$description_tail" | sed -E 's/^[[:space:]]*//' | sed -E 's/[[:space:]]*(repeat:|run:|agent:|#|~|@|started:|blocked-by:).*//')
+	_RPL_DESC=$(printf '%s' "$description_tail" | sed -E 's/^[[:space:]]*//' | sed -E 's/[[:space:]]*(repeat:|run:|agent:|timezone:|#|~|@|started:|blocked-by:).*//')
 
 	return 0
+}
+
+#######################################
+# Check one routine schedule with an optional timezone override.
+# Arguments: $1 - expression, $2 - last-run epoch, $3 - timezone or empty
+# Returns: schedule helper status
+#######################################
+_routine_schedule_is_due() {
+	local expression="$1"
+	local last_run_epoch="$2"
+	local timezone="$3"
+	if [[ -n "$timezone" ]]; then
+		AIDEVOPS_SCHEDULE_TIMEZONE="$timezone" "$ROUTINE_SCHEDULE_HELPER" is-due "$expression" "$last_run_epoch"
+		return $?
+	fi
+	"$ROUTINE_SCHEDULE_HELPER" is-due "$expression" "$last_run_epoch"
+	return $?
 }
 
 #######################################
@@ -575,10 +609,12 @@ evaluate_routines() {
 
 			# Check if due
 			local last_epoch
+			local timezone_context=""
 			last_epoch=$(_routine_last_run_epoch "$_RPL_ID")
+			timezone_context="${_RPL_TIMEZONE:-inherited}"
 
-			if "$ROUTINE_SCHEDULE_HELPER" is-due "$_RPL_REPEAT" "$last_epoch"; then
-				echo "[pulse-wrapper] routine ${_RPL_ID} is due (expr=${_RPL_REPEAT}, last_run_epoch=${last_epoch})" >>"$LOGFILE"
+			if _routine_schedule_is_due "$_RPL_REPEAT" "$last_epoch" "$_RPL_TIMEZONE"; then
+				echo "[pulse-wrapper] routine ${_RPL_ID} is due (expr=${_RPL_REPEAT}, timezone=${timezone_context}, last_run_epoch=${last_epoch})" >>"$LOGFILE"
 				_routine_execute "$_RPL_ID" "$_RPL_DESC" "$_RPL_RUN" "$_RPL_AGENT" "$repo_path"
 				routines_dispatched=$((routines_dispatched + 1))
 			fi

--- a/.agents/scripts/routines/core-routines.sh
+++ b/.agents/scripts/routines/core-routines.sh
@@ -12,7 +12,7 @@
 # ---------------------------------------------------------------------------
 # get_core_routine_entries
 # Outputs one line per core routine in pipe-delimited format:
-#   id|enabled|title|schedule|estimate|script|type
+#   id|enabled|title|schedule|estimate|script|type|timezone (optional)
 # ---------------------------------------------------------------------------
 get_core_routine_entries() {
 	cat <<'ENTRIES'
@@ -31,7 +31,7 @@ r912| |Dashboard server|repeat:persistent|~0s|server/index.ts|service
 r913|x|Weekly opencode DB maintenance|repeat:weekly(sun@04:00)|~2m|scripts/opencode-db-maintenance-helper.sh auto|script
 r914|x|Repo aidevops health — bump stale .aidevops.json, detect drift|repeat:daily(@03:30)|~2m|scripts/repo-aidevops-health-helper.sh run|script
 r915|x|Pulse check — worker utilisation and self-improvement recommendations|repeat:daily(@06:20)|~5m|scripts/pulse-check-helper.sh apply|script
-r916|x|Cloudron packages — check upstream releases|repeat:daily(@07:10)|~2m|scripts/cloudron-package-monitor-helper.sh upstream --apply|script
+r916|x|Cloudron packages — check upstream releases|repeat:daily(@00:30)|~2m|scripts/cloudron-package-monitor-helper.sh upstream --apply|script|UTC
 r917|x|Cloudron packages — audit compatibility|repeat:weekly(sun@07:40)|~5m|scripts/cloudron-package-monitor-helper.sh compatibility --apply|script
 ENTRIES
 	return 0
@@ -924,21 +924,22 @@ describe_r916() {
 
 ## Overview
 
-Daily read-only comparison of registered Cloudron package upstream versions.
+Daily read-only comparison of registered Cloudron package upstream versions at 00:30 UTC.
 New releases become deduplicated, worker-ready issues in the package repository.
 
 ## Schedule
 
 | Field | Value |
 |-------|-------|
-| Frequency | Daily at 07:10 |
+| Frequency | Daily at 00:30 UTC |
 | Type | script |
 | Expected duration | ~2 minutes |
 | Script | \`scripts/cloudron-package-monitor-helper.sh upstream --apply\` |
-$(_scheduler_row_pulse "repeat:daily(@07:10)")
+$(_scheduler_row_pulse "repeat:daily(@00:30) timezone:UTC")
 
 Pulse reads the enabled routine from registered \`TODO.md\` files and evaluates
-the version-controlled \`repeat:\` expression; r916 has no dedicated platform unit.
+the version-controlled \`repeat:daily(@00:30) timezone:UTC\` contract; r916 has no
+dedicated platform unit.
 
 ## Safety rails
 

--- a/.agents/scripts/tests/test-cloudron-package-init.sh
+++ b/.agents/scripts/tests/test-cloudron-package-init.sh
@@ -94,11 +94,13 @@ GITCONFIG
 	assert_equal cloudron-package "$(jq -r '.initialized_repos[0].app_type' "$REPOS_FILE")" "registration records Cloudron app_type"
 	assert_equal CloudronManifest.json "$(jq -r '.initialized_repos[0].cloudron_package.manifest' "$REPOS_FILE")" "registration records manifest path"
 	assert_equal true "$(jq -r '.initialized_repos[0].cloudron_package.monitor_compatibility' "$REPOS_FILE")" "compatibility monitoring defaults on"
-	jq '.initialized_repos[0].cloudron_package += {"upstream_slug":"exampleorg/upstream","monitor_compatibility":false}' "$REPOS_FILE" >"${REPOS_FILE}.tmp"
+	assert_equal '["v",""]' "$(jq -c '.initialized_repos[0].cloudron_package.upstream_tag_prefixes' "$REPOS_FILE")" "registration defaults to v-prefixed and bare upstream tags"
+	jq '.initialized_repos[0].cloudron_package += {"upstream_slug":"exampleorg/upstream","monitor_compatibility":false,"upstream_tag_prefixes":["desktop-v"]}' "$REPOS_FILE" >"${REPOS_FILE}.tmp"
 	mv "${REPOS_FILE}.tmp" "$REPOS_FILE"
 	register_repo "$repo_dir" 9.9.10 planning
 	assert_equal exampleorg/upstream "$(jq -r '.initialized_repos[0].cloudron_package.upstream_slug' "$REPOS_FILE")" "explicit upstream metadata preserved"
 	assert_equal false "$(jq -r '.initialized_repos[0].cloudron_package.monitor_compatibility' "$REPOS_FILE")" "explicit monitoring preference preserved"
+	assert_equal '["desktop-v"]' "$(jq -c '.initialized_repos[0].cloudron_package.upstream_tag_prefixes' "$REPOS_FILE")" "explicit upstream tag stream preserved"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-cloudron-package-monitor.sh
+++ b/.agents/scripts/tests/test-cloudron-package-monitor.sh
@@ -36,8 +36,26 @@ write_fake_commands() {
 	cat >"${bin_dir}/gh" <<'GH'
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ "${1:-}" == "api" && "${2:-}" == repos/*/releases/latest ]]; then
-    printf '%s\n' 'v2.0.0'
+if [[ "${1:-}" == "api" && "${2:-}" == repos/*/releases\?per_page=100 && "${3:-}" == "--paginate" ]]; then
+    [[ "${MONITOR_API_FAIL:-false}" != true ]] || exit 1
+    if [[ -n "${MONITOR_RELEASES_FILE:-}" ]]; then
+        while IFS= read -r line || [[ -n "$line" ]]; do
+            printf '%s\n' "$line"
+        done <"${MONITOR_RELEASES_FILE}"
+    else
+        cat <<'JSON'
+[
+  {"tag_name":"v1.10.0","draft":false,"prerelease":false},
+  {"tag_name":"v9.0.0","draft":true,"prerelease":false},
+  {"tag_name":"desktop-v99.0.0","draft":false,"prerelease":false}
+]
+[
+  {"tag_name":"v8.0.0","draft":false,"prerelease":true},
+  {"tag_name":"2.0.0","draft":false,"prerelease":false},
+  {"tag_name":99,"draft":false,"prerelease":false}
+]
+JSON
+    fi
     exit 0
 fi
 if [[ "${1:-}" == "repo" && "${2:-}" == "view" ]]; then
@@ -150,6 +168,91 @@ test_monitor_deduplicates_and_preserves_source() {
 	return 0
 }
 
+test_monitor_selects_configured_stream() {
+	local home_dir="${TEST_ROOT}/stream-home"
+	local repo_dir="${TEST_ROOT}/stream-package"
+	local bin_dir="${TEST_ROOT}/stream-bin"
+	local log_file="${TEST_ROOT}/stream-issues.log"
+	local releases_file="${TEST_ROOT}/stream-releases.json"
+	local config_tmp="${TEST_ROOT}/stream-repos.json"
+	local manifest_tmp="${TEST_ROOT}/stream-manifest.json"
+	write_fake_commands "$bin_dir"
+	write_fixture "$home_dir" "$repo_dir"
+	jq '.initialized_repos[0].cloudron_package.upstream_tag_prefixes = ["desktop-v"]' \
+		"${home_dir}/.config/aidevops/repos.json" >"$config_tmp"
+	mv "$config_tmp" "${home_dir}/.config/aidevops/repos.json"
+	jq '.upstreamVersion = "0.5.0"' "${repo_dir}/CloudronManifest.json" >"$manifest_tmp"
+	mv "$manifest_tmp" "${repo_dir}/CloudronManifest.json"
+	cat >"$releases_file" <<'JSON'
+[
+  {"tag_name":"desktop-v0.5.2","draft":false,"prerelease":false},
+  {"tag_name":"v99.0.0","draft":false,"prerelease":false},
+  {"tag_name":"desktop-v0.5.3","draft":false,"prerelease":false},
+  {"tag_name":"desktop-v9.0.0","draft":true,"prerelease":false},
+  {"tag_name":"desktop-v8.0.0","draft":false,"prerelease":true}
+]
+JSON
+
+	HOME="$home_dir" PATH="${bin_dir}:$PATH" MONITOR_TEST_LOG="$log_file" \
+		MONITOR_RELEASES_FILE="$releases_file" CLOUDRON_PACKAGE_ISSUE_WRAPPER="${bin_dir}/gh_create_issue" \
+		bash "$HELPER" upstream --apply >/dev/null
+	assert_equal 1 "$(grep -c '^CALL exampleorg/example-package$' "$log_file")" "configured stream creates one issue"
+	assert_equal 1 "$(grep -c '^TITLE Example Package upstream v0.5.3 is available$' "$log_file")" "configured prefix selects highest matching stable tag"
+	assert_equal 0 "$(grep -c '^TITLE Example Package upstream v99.0.0 is available$' "$log_file" || true)" "configured prefix rejects numerically larger unrelated stream"
+	return 0
+}
+
+test_monitor_rejects_malformed_prefixes() {
+	local home_dir="${TEST_ROOT}/prefix-home"
+	local repo_dir="${TEST_ROOT}/prefix-package"
+	local bin_dir="${TEST_ROOT}/prefix-bin"
+	local log_file="${TEST_ROOT}/prefix-issues.log"
+	local config_tmp="${TEST_ROOT}/prefix-repos.json"
+	local output=""
+	local rc=0
+	write_fake_commands "$bin_dir"
+	write_fixture "$home_dir" "$repo_dir"
+	jq '.initialized_repos[0].cloudron_package.upstream_tag_prefixes = []' \
+		"${home_dir}/.config/aidevops/repos.json" >"$config_tmp"
+	mv "$config_tmp" "${home_dir}/.config/aidevops/repos.json"
+
+	if output=$(HOME="$home_dir" PATH="${bin_dir}:$PATH" MONITOR_TEST_LOG="$log_file" \
+		CLOUDRON_PACKAGE_ISSUE_WRAPPER="${bin_dir}/gh_create_issue" bash "$HELPER" upstream --apply 2>&1); then
+		rc=0
+	else
+		rc=$?
+	fi
+	assert_equal 1 "$rc" "empty upstream tag-prefix array fails closed"
+	[[ "$output" == *"upstream_tag_prefixes for exampleorg/example-package must be a non-empty array of strings"* ]] &&
+		assert_equal true true "malformed tag prefixes report actionable error" ||
+		assert_equal true false "malformed tag prefixes report actionable error"
+	[[ ! -f "$log_file" ]] && assert_equal true true "malformed tag prefixes create no issue" || assert_equal true false "malformed tag prefixes create no issue"
+	return 0
+}
+
+test_monitor_fails_closed_on_release_api_error() {
+	local home_dir="${TEST_ROOT}/api-home"
+	local repo_dir="${TEST_ROOT}/api-package"
+	local bin_dir="${TEST_ROOT}/api-bin"
+	local log_file="${TEST_ROOT}/api-issues.log"
+	local output=""
+	local rc=0
+	write_fake_commands "$bin_dir"
+	write_fixture "$home_dir" "$repo_dir"
+	if output=$(HOME="$home_dir" PATH="${bin_dir}:$PATH" MONITOR_TEST_LOG="$log_file" MONITOR_API_FAIL=true \
+		CLOUDRON_PACKAGE_ISSUE_WRAPPER="${bin_dir}/gh_create_issue" bash "$HELPER" upstream --apply 2>&1); then
+		rc=0
+	else
+		rc=$?
+	fi
+	assert_equal 1 "$rc" "paginated release API failure fails closed"
+	[[ "$output" == *"Could not fetch paginated GitHub releases for exampleorg/upstream"* ]] &&
+		assert_equal true true "release API failure reports actionable error" ||
+		assert_equal true false "release API failure reports actionable error"
+	[[ ! -f "$log_file" ]] && assert_equal true true "release API failure creates no issue" || assert_equal true false "release API failure creates no issue"
+	return 0
+}
+
 test_monitor_rejects_blank_package_title() {
 	local home_dir="${TEST_ROOT}/blank-title-home"
 	local repo_dir="${TEST_ROOT}/blank-title-package"
@@ -177,6 +280,9 @@ main() {
 	TEST_ROOT=$(mktemp -d)
 	trap cleanup EXIT
 	test_monitor_deduplicates_and_preserves_source
+	test_monitor_selects_configured_stream
+	test_monitor_rejects_malformed_prefixes
+	test_monitor_fails_closed_on_release_api_error
 	test_monitor_rejects_blank_package_title
 	printf '\nRan %d tests, %d failed.\n' "$((PASSED + FAILED))" "$FAILED"
 	[[ "$FAILED" -eq 0 ]] || return 1

--- a/.agents/scripts/tests/test-cloudron-package-monitor.sh
+++ b/.agents/scripts/tests/test-cloudron-package-monitor.sh
@@ -230,6 +230,34 @@ test_monitor_rejects_malformed_prefixes() {
 	return 0
 }
 
+test_monitor_rejects_control_characters_in_prefixes() {
+	local home_dir="${TEST_ROOT}/control-prefix-home"
+	local repo_dir="${TEST_ROOT}/control-prefix-package"
+	local bin_dir="${TEST_ROOT}/control-prefix-bin"
+	local log_file="${TEST_ROOT}/control-prefix-issues.log"
+	local config_tmp="${TEST_ROOT}/control-prefix-repos.json"
+	local output=""
+	local rc=0
+	write_fake_commands "$bin_dir"
+	write_fixture "$home_dir" "$repo_dir"
+	jq '.initialized_repos[0].cloudron_package.upstream_tag_prefixes = ["desktop-v\nv"]' \
+		"${home_dir}/.config/aidevops/repos.json" >"$config_tmp"
+	mv "$config_tmp" "${home_dir}/.config/aidevops/repos.json"
+
+	if output=$(HOME="$home_dir" PATH="${bin_dir}:$PATH" MONITOR_TEST_LOG="$log_file" \
+		CLOUDRON_PACKAGE_ISSUE_WRAPPER="${bin_dir}/gh_create_issue" bash "$HELPER" upstream --apply 2>&1); then
+		rc=0
+	else
+		rc=$?
+	fi
+	assert_equal 1 "$rc" "control character in upstream tag prefix fails closed"
+	[[ "$output" == *"upstream_tag_prefixes for exampleorg/example-package must be a non-empty array of strings; control characters are forbidden"* ]] &&
+		assert_equal true true "control character prefix reports actionable error" ||
+		assert_equal true false "control character prefix reports actionable error"
+	[[ ! -f "$log_file" ]] && assert_equal true true "control character prefix creates no issue" || assert_equal true false "control character prefix creates no issue"
+	return 0
+}
+
 test_monitor_fails_closed_on_release_api_error() {
 	local home_dir="${TEST_ROOT}/api-home"
 	local repo_dir="${TEST_ROOT}/api-package"
@@ -282,6 +310,7 @@ main() {
 	test_monitor_deduplicates_and_preserves_source
 	test_monitor_selects_configured_stream
 	test_monitor_rejects_malformed_prefixes
+	test_monitor_rejects_control_characters_in_prefixes
 	test_monitor_fails_closed_on_release_api_error
 	test_monitor_rejects_blank_package_title
 	printf '\nRan %d tests, %d failed.\n' "$((PASSED + FAILED))" "$FAILED"

--- a/.agents/scripts/tests/test-cloudron-package-routines.sh
+++ b/.agents/scripts/tests/test-cloudron-package-routines.sh
@@ -6,8 +6,15 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 CORE_ROUTINES="${SCRIPT_DIR}/../routines/core-routines.sh"
+INIT_ROUTINES="${SCRIPT_DIR}/../init-routines-helper.sh"
+TEST_ROOT=""
 PASSED=0
 FAILED=0
+
+cleanup() {
+	[[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT"
+	return 0
+}
 
 assert_contains() {
 	local haystack="$1"
@@ -38,11 +45,13 @@ assert_not_contains() {
 }
 
 main() {
+	TEST_ROOT=$(mktemp -d)
+	trap cleanup EXIT
 	# shellcheck source=../routines/core-routines.sh
 	source "$CORE_ROUTINES"
 	local entries=""
 	entries=$(get_core_routine_entries)
-	assert_contains "$entries" 'r916|x|Cloudron packages — check upstream releases|repeat:daily(@07:10)|~2m|scripts/cloudron-package-monitor-helper.sh upstream --apply|script' "daily upstream routine registered"
+	assert_contains "$entries" 'r916|x|Cloudron packages — check upstream releases|repeat:daily(@00:30)|~2m|scripts/cloudron-package-monitor-helper.sh upstream --apply|script|UTC' "daily UTC upstream routine registered"
 	assert_contains "$entries" 'r917|x|Cloudron packages — audit compatibility|repeat:weekly(sun@07:40)|~5m|scripts/cloudron-package-monitor-helper.sh compatibility --apply|script' "weekly compatibility routine registered"
 	local r916_description=""
 	local r917_description=""
@@ -51,12 +60,27 @@ main() {
 	assert_contains "$r916_description" 'cloudron-package-monitor-helper.sh upstream --apply' "r916 description exposes exact command"
 	assert_contains "$r917_description" 'cloudron-package-monitor-helper.sh compatibility --apply' "r917 description exposes exact command"
 	# shellcheck disable=SC2016  # Markdown backticks are literal expected output.
-	assert_contains "$r916_description" 'Supervisor Pulse evaluates version-controlled `repeat:daily(@07:10)`' "r916 names Pulse as scheduler"
+	assert_contains "$r916_description" 'Supervisor Pulse evaluates version-controlled `repeat:daily(@00:30) timezone:UTC`' "r916 exposes full UTC scheduling contract"
+	assert_contains "$r916_description" 'Daily at 00:30 UTC' "r916 describes its fixed UTC schedule"
 	# shellcheck disable=SC2016  # Markdown backticks are literal expected output.
 	assert_contains "$r917_description" 'Supervisor Pulse evaluates version-controlled `repeat:weekly(sun@07:40)`' "r917 names Pulse as scheduler"
 	assert_contains "$r916_description" 'systemctl --user status sh.aidevops.pulse' "r916 exposes shared Pulse diagnostics"
 	assert_not_contains "$r916_description" 'sh.aidevops.cloudron-package-upstream' "r916 omits fictional dedicated service"
 	assert_not_contains "$r917_description" 'sh.aidevops.cloudron-package-compatibility' "r917 omits fictional dedicated service"
+
+	(
+		# shellcheck source=../init-routines-helper.sh
+		source "$INIT_ROUTINES"
+		DRY_RUN=false
+		_write_todo_md "$TEST_ROOT"
+	)
+	local generated_todo=""
+	local r917_line=""
+	generated_todo=$(<"${TEST_ROOT}/TODO.md")
+	r917_line=$(printf '%s\n' "$generated_todo" | grep '^- \[x\] r917 ')
+	assert_contains "$generated_todo" '- [x] r916 Cloudron packages — check upstream releases repeat:daily(@00:30) timezone:UTC ~2m run:scripts/cloudron-package-monitor-helper.sh upstream --apply' "generated r916 TODO line places UTC after repeat expression"
+	assert_not_contains "$r917_line" 'timezone:' "generated routines without overrides remain timezone-free"
+	assert_contains "$generated_todo" 'timezone: -- optional per-routine IANA timezone override' "generated TODO header documents timezone field"
 	printf '\nRan %d tests, %d failed.\n' "$((PASSED + FAILED))" "$FAILED"
 	[[ "$FAILED" -eq 0 ]] || return 1
 	return 0

--- a/.agents/scripts/tests/test-routine-calendar-scheduling.sh
+++ b/.agents/scripts/tests/test-routine-calendar-scheduling.sh
@@ -75,6 +75,53 @@ assert_next_run() {
 	return 0
 }
 
+assert_pulse_timezone_policy() {
+	ROUTINE_SCHEDULE_HELPER="$HELPER"
+	unset _PULSE_ROUTINES_LOADED
+	# shellcheck source=../pulse-routines.sh
+	source "$PULSE_ROUTINES"
+
+	local parse_rc=0
+	if _routine_parse_line '- [x] r-zone Parsed zone repeat:daily(@00:30) ~1m run:scripts/example.sh timezone:Etc/GMT+1'; then
+		parse_rc=0
+	else
+		parse_rc=$?
+	fi
+	record_result "routine parser accepts IANA timezone token" "$parse_rc" 0
+	record_result "routine parser retains timezone override" "$_RPL_TIMEZONE" 'Etc/GMT+1'
+	record_result "timezone field terminates routine description" "$_RPL_DESC" 'Parsed zone'
+
+	local malformed_rc=0
+	_routine_parse_line '- [x] r-bad-zone Bad zone repeat:daily(@00:30) timezone:Europe/Jersey;' >/dev/null 2>&1 || malformed_rc=$?
+	record_result "malformed timezone field fails closed" "$malformed_rc" 1
+
+	local inherited_timezone="not-empty"
+	if _routine_parse_line '- [x] r-local-zone Local zone repeat:daily(@00:30) run:scripts/example.sh'; then
+		inherited_timezone="$_RPL_TIMEZONE"
+	fi
+	record_result "routine without override retains inherited timezone mode" "$inherited_timezone" ''
+
+	local now_epoch=""
+	local last_epoch=""
+	local override_rc=0
+	local inherited_rc=0
+	now_epoch=$(iso_epoch 2026-07-23T00:45:00Z) || return 1
+	last_epoch=$(iso_epoch 2026-07-23T00:00:00Z) || return 1
+	(
+		export AIDEVOPS_SCHEDULE_TIMEZONE=Europe/Jersey
+		export AIDEVOPS_SCHEDULE_NOW_EPOCH="$now_epoch"
+		_routine_schedule_is_due 'daily(@00:30)' "$last_epoch" UTC
+	) >/dev/null 2>&1 || override_rc=$?
+	(
+		export AIDEVOPS_SCHEDULE_TIMEZONE=Europe/Jersey
+		export AIDEVOPS_SCHEDULE_NOW_EPOCH="$now_epoch"
+		_routine_schedule_is_due 'daily(@00:30)' "$last_epoch" "$inherited_timezone"
+	) >/dev/null 2>&1 || inherited_rc=$?
+	record_result "explicit UTC routine overrides global Europe/Jersey timezone" "$override_rc" 0
+	record_result "routine without override inherits global Europe/Jersey timezone" "$inherited_rc" 1
+	return 0
+}
+
 assert_pulse_state_policy() {
 	ROUTINE_STATE_FILE="${TEST_ROOT}/routine-state.json"
 	LOGFILE="${TEST_ROOT}/pulse.log"
@@ -128,6 +175,7 @@ main() {
 		Europe/Jersey 2026-10-24T12:00:00Z 'daily(@01:30)' 2026-10-25T00:30:00Z
 	assert_next_run "spring-forward nonexistent local time fails closed" \
 		Europe/Jersey 2026-03-28T12:00:00Z 'daily(@01:30)' 'rc:2'
+	assert_pulse_timezone_policy
 	assert_pulse_state_policy
 
 	printf '\nRan %d tests, %d failed.\n' "$((PASSED + FAILED))" "$FAILED"

--- a/.agents/tools/deployment/cloudron-app-packaging.md
+++ b/.agents/tools/deployment/cloudron-app-packaging.md
@@ -262,8 +262,15 @@ Track version in `/app/data/.app_version`; compare on start to run per-version m
 `aidevops init` detects `CloudronManifest.json`, records
 `app_type: cloudron-package` in local `repos.json`, and installs the thin
 `.github/workflows/cloudron-package-release.yml` caller when no file already
-exists. Configure `cloudron_package.upstream_slug` locally to enable daily
-stable-release comparison; compatibility monitoring is enabled by default.
+exists. Configure `cloudron_package.upstream_slug` locally to enable stable-release
+comparison. `cloudron_package.upstream_tag_prefixes` defaults to `["v", ""]`,
+covering `v1.2.3` and bare `1.2.3` tags. Set a product stream such as
+`["desktop-v"]` when a shared upstream publishes tags like `desktop-v0.5.3`;
+unrelated `v...` releases are then ignored. The monitor paginates the GitHub
+releases API, excludes drafts and prereleases, validates the version remaining
+after a configured prefix, and selects the numerically highest matching stable
+semantic release. Invalid prefix configuration and repositories with no matching
+stable tag fail closed. Compatibility monitoring is enabled by default.
 The generated caller pins both the reusable workflow and checked-out validator
 to the same full framework commit. Updating that revision is an explicit,
 reviewed package change; repeated init never overwrites an existing caller.
@@ -283,7 +290,8 @@ changelog entry, and the exact pinned final Cloudron base image.
 
 Core routines provide ongoing reporting:
 
-- `r916` runs `cloudron-package-monitor-helper.sh upstream --apply` daily.
+- `r916` runs `cloudron-package-monitor-helper.sh upstream --apply` daily at
+  `00:30 UTC` using its version-controlled per-routine timezone override.
 - `r917` runs `cloudron-package-monitor-helper.sh compatibility --apply` weekly.
 
 Both routines deduplicate package-local issues, require maintainer-equivalent


### PR DESCRIPTION
## Summary

- Paginate upstream GitHub releases, exclude drafts/prereleases, validate package-specific `cloudron_package.upstream_tag_prefixes` with control characters failing closed, and select the highest matching stable semantic version.
- Add optional per-routine `timezone:` support and schedule r916 at `repeat:daily(@00:30) timezone:UTC` without changing unrelated routines.
- Add registration defaults, generated routine support, focused regression tests, and Cloudron/routine configuration guidance.

## Files

- `.agents/scripts/cloudron-package-monitor-helper.sh` — release-stream selection and fail-closed validation.
- `.agents/scripts/pulse-routines.sh`, `.agents/scripts/routines/core-routines.sh`, `.agents/scripts/init-routines-helper.sh` — timezone parsing/evaluation and r916 generation.
- `.agents/scripts/aidevops-cli/aidevops-repos-lib.sh` — default `["v", ""]` tag prefixes while preserving explicit values.
- Focused tests under `.agents/scripts/tests/` and guidance under `.agents/reference/` plus `.agents/tools/deployment/cloudron-app-packaging.md`.

## Verification

- `bash .agents/scripts/tests/test-cloudron-package-monitor.sh` — 22 passed.
- `bash .agents/scripts/tests/test-cloudron-package-routines.sh` — 13 passed.
- `bash .agents/scripts/tests/test-routine-calendar-scheduling.sh` — 26 passed.
- `bash .agents/scripts/tests/test-cloudron-package-init.sh` — 19 passed.
- `bash .agents/scripts/tests/test-pulse-routines-selector.sh` — 14 passed.
- `.agents/scripts/linters-local.sh` — all local checks passed.

## Runtime Testing

- **Level**: `runtime-verified`.
- Executed the modified monitor in read-only mode against all current Cloudron package registrations; real GitHub pagination completed without API errors and reported newer NetBird/aidevops candidates without mutating package source or release state.
- Deterministic scheduler tests proved `timezone:UTC` overrides a Europe/Jersey global timezone at the 00:30 boundary while routines without an override retain inherited behavior.
- Buzz stream activation remains an explicit local `desktop-v` registration migration after deployment.

Resolves #29111

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.207 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 28s and 1,452 tokens on this with the user in an interactive session.
