### PR TITLE
GH#28784: Add safe WhatsApp knowledge ingestion

### DIFF
--- a/.agents/content/social-whatsapp.md
+++ b/.agents/content/social-whatsapp.md
@@ -1,0 +1,129 @@
+---
+description: Safe WhatsApp knowledge ingestion from explicit chat exports or verified official business webhooks
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# WhatsApp Knowledge Ingestion
+
+WhatsApp evidence has two isolated, read-only routes:
+
+1. a chat export created deliberately by the user; or
+2. a WhatsApp Business Platform `messages` webhook whose raw body, app-secret
+   signature, WABA ID, and receiving phone-number ID all verify.
+
+There is no fallback to WhatsApp Web, Baileys, browser automation, personal
+sessions, local database extraction, cloud-backup access, or backup decryption.
+If neither safe route supplies a category, coverage records it as unavailable.
+
+## User chat exports
+
+WhatsApp's help pages describe exporting one individual or group chat, with or
+without media. As revalidated on 2026-07-31, the documented limits are the latest
+40,000 messages without media or 10,000 with media. WhatsApp does not publish a
+stable machine-readable transcript schema. The collector therefore requires an
+explicit format and fixed UTC offset instead of guessing locale or timezone.
+One fixed offset is only user-asserted provenance; split exports at daylight-saving
+transitions or accept partial timestamp coverage rather than inventing offsets.
+
+Supported parser profiles:
+
+| Profile | Timestamp shape |
+|---------|-----------------|
+| `android-us-12h` | `M/D/YY, H:MM AM - Sender: text` |
+| `android-dmy-24h` | `D/M/YYYY, HH:MM - Sender: text` |
+| `ios-us-12h` | `[M/D/YY, H:MM:SS AM] Sender: text` |
+| `ios-dmy-24h` | `[D/M/YYYY, HH:MM:SS] Sender: text` |
+
+First run a no-write plan:
+
+```bash
+python3 ~/.aidevops/agents/scripts/knowledge_social_whatsapp.py export \
+  --archive /path/to/whatsapp-export.zip \
+  --connection-id private_connection_alias \
+  --conversation-id private_conversation_alias \
+  --format android-dmy-24h \
+  --timezone +01:00 \
+  --observed-at 2026-07-31T12:00:00Z \
+  --dry-run
+```
+
+Remove `--dry-run` only after the counts and selected format are correct. The
+ZIP must contain exactly one UTF-8 transcript. Archive members are bounded and
+checked for traversal, duplicate paths, encryption, links, compressed and actual
+size, compression ratio, item count, and elapsed time. Archive input defaults to
+128 MiB and cannot exceed 512 MiB; `--max-seconds` defaults to 30 and cannot
+exceed 300. Media is streamed for hashing rather than retained in parser memory.
+Media links require an exact unique basename. Missing media remains explicit
+partial coverage.
+
+Exports preserve multiline text, participant display aliases, normalized times,
+duplicate occurrence ordinals, system notices, and embedded media hashes. They
+do not claim structured reply, reaction, edit, deletion, or complete-history
+coverage because WhatsApp does not document those fields in its export format.
+
+## Official business webhooks
+
+The Business Platform path is prospective. It is not a personal-account route
+and it has no general `GET messages` history endpoint. The collector accepts
+only `whatsapp_business_account` `messages` changes after all of these checks:
+
+- `X-Hub-Signature-256` is HMAC-SHA-256 of the exact raw body using the app secret;
+- `entry.id` equals the configured WABA ID;
+- `metadata.phone_number_id` equals the configured receiving phone ID; and
+- every accepted message, status, media, reaction, and reply reference has a
+  bounded provider identity and timestamp. Provider-supplied media digests are
+  validated as 32-byte base64 values but remain unverified until bytes hydrate.
+
+Store the app secret securely, never in repository files or command history:
+
+```bash
+aidevops secret set WHATSAPP_APP_SECRET
+```
+
+The offline adapter reads the secret from `WHATSAPP_APP_SECRET` and the signature
+from `WHATSAPP_WEBHOOK_SIGNATURE` by default, keeping both out of process
+arguments. A
+production HTTP receiver should pass the unmodified request body and signature
+header directly to `parse_business_webhook`, persist before acknowledging, and
+never log payloads, phone numbers, WABA IDs, signatures, or message text.
+
+Inbound text, reply context, reactions, media metadata, and delivery statuses
+are normalized when present. Media download is intentionally unreachable in
+this collector; a later authorized hydrator must enforce official URL expiry,
+MIME, hash, byte, and retention limits. Template lifecycle, missed events,
+personal groups, history before subscription, and a complete retrospective
+edit/delete audit remain explicit gaps.
+
+## Replay, privacy, and retention
+
+- Raw exports and webhook bodies are SHA-256 addressed in the private corpus.
+- Replaying identical bytes with an identical normalized manifest creates no
+  duplicate batch, message, media, activity, or checkpoint. A parser, format,
+  timezone, identity, or normalized-output change creates a separate manifest
+  revision over the same immutable raw blob so prior evidence remains readable.
+- Export and business-event streams use separate fenced leases and checkpoints.
+- Stable normalized participant keys are hashed. Display aliases and any raw
+  provider identifiers remain private inside the access-controlled corpus.
+- Parser or Graph API changes require explicit versioned evidence revisions; they
+  never silently rewrite or delete prior raw evidence.
+- A source deletion, disappearing message, or missing attachment never causes
+  automatic canonical deletion.
+
+## Official evidence reviewed 2026-07-31
+
+- [Android chat export](https://faq.whatsapp.com/1180414079177245/?cms_platform=android)
+- [iPhone chat export](https://faq.whatsapp.com/196737011380816/?cms_platform=iphone)
+- [Cloud API overview](https://developers.facebook.com/docs/whatsapp/cloud-api/overview)
+- [Webhook components](https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/components)
+- [Graph API webhook verification](https://developers.facebook.com/docs/graph-api/webhooks/getting-started)
+- [Cloud API data privacy and security](https://developers.facebook.com/docs/whatsapp/cloud-api/overview/data-privacy-and-security)
+- [Media reference](https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media)
+- [WhatsApp Terms of Service](https://www.whatsapp.com/legal/terms-of-service)
+- [WhatsApp Business Terms](https://www.whatsapp.com/legal/business-terms)
+
+Meta and WhatsApp documentation is version- and account-sensitive. Revalidate
+the pinned Graph API payload fields, retention, group eligibility, and terms
+before enabling a live receiver. An undocumented field is preserved only as raw
+evidence or reported as a gap; it is never treated as stable authority.

--- a/.agents/scripts/_knowledge_social_whatsapp.py
+++ b/.agents/scripts/_knowledge_social_whatsapp.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Atomically persist validated WhatsApp export or webhook evidence."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from _knowledge_social_lease import RunLease, RunReceiptUpdate, assert_run_lease, update_run_receipt
+from _knowledge_social_whatsapp_contract import PROVIDER, ParsedWhatsAppBatch
+from knowledge_social_import import import_accounts, import_activities, import_coverage, import_media, import_objects, reject_credentials, upsert_connection
+from knowledge_social_store import SocialStoreError, connect, migrate, write_raw_batch
+
+
+def _assert_binding(database: sqlite3.Connection, connection_id: str, account_id: str) -> None:
+    row = database.execute(
+        "SELECT provider,remote_account_id FROM connections WHERE connection_id=?",
+        (connection_id,),
+    ).fetchone()
+    if row is not None and (row["provider"] != PROVIDER or row["remote_account_id"] != account_id):
+        raise SocialStoreError("WhatsApp connection is already bound to another source")
+
+
+def _raw_path(root: Path, connection_id: str, digest: str) -> Path:
+    return root / "sources" / "social" / "raw" / PROVIDER / connection_id / f"{digest}.json.gz"
+
+
+def _raw_digest(path: Path) -> str:
+    if path.is_symlink() or not path.is_file():
+        raise SocialStoreError("WhatsApp raw evidence is missing or unsafe")
+    digest = hashlib.sha256()
+    try:
+        with gzip.open(path, "rb") as source:
+            while chunk := source.read(1024 * 1024):
+                digest.update(chunk)
+    except OSError as error:
+        raise SocialStoreError("WhatsApp raw evidence could not be verified") from error
+    return digest.hexdigest()
+
+
+def _refresh_fts(database: sqlite3.Connection, archive: dict[str, Any]) -> None:
+    for record in archive["objects"]:
+        identity = (PROVIDER, record["object_type"], record["remote_id"])
+        database.execute("DELETE FROM objects_fts WHERE provider=? AND object_type=? AND remote_id=?", identity)
+        database.execute(
+            """INSERT INTO objects_fts(provider,object_type,remote_id,account_remote_id,text_content,evidence_class)
+               SELECT provider,object_type,remote_id,account_remote_id,text_content,evidence_class
+                 FROM objects WHERE provider=? AND object_type=? AND remote_id=?""",
+            identity,
+        )
+
+
+def _replay_result(parsed: ParsedWhatsAppBatch, blob_ref: str) -> dict[str, Any]:
+    return {
+        "batch_id": parsed.manifest_sha256,
+        "blob_ref": blob_ref,
+        "normalized_items": parsed.normalized_items,
+        "replayed": True,
+        "status": "complete",
+        "stream": parsed.stream,
+    }
+
+
+def _replay_metadata_matches(
+    existing: sqlite3.Row,
+    parsed: ParsedWhatsAppBatch,
+    connection_id: str,
+    expected_ref: str,
+) -> bool:
+    return all((
+        existing["provider"] == PROVIDER,
+        existing["connection_id"] == connection_id,
+        existing["stream"] == parsed.stream,
+        existing["request_hash"] == parsed.manifest_sha256,
+        existing["response_hash"] == parsed.manifest_sha256,
+        existing["blob_ref"] == expected_ref,
+    ))
+
+
+def _existing_replay(
+    database: sqlite3.Connection,
+    root: Path,
+    parsed: ParsedWhatsAppBatch,
+    connection_id: str,
+    raw_path: Path,
+) -> str | None:
+    existing = database.execute(
+        "SELECT provider,connection_id,stream,request_hash,response_hash,blob_ref,resource_count FROM fetch_batches WHERE batch_id=?",
+        (parsed.manifest_sha256,),
+    ).fetchone()
+    if existing is None:
+        return None
+    expected_ref = raw_path.relative_to(root).as_posix()
+    if not _replay_metadata_matches(existing, parsed, connection_id, expected_ref):
+        raise SocialStoreError("WhatsApp replay metadata conflicts with stored evidence")
+    if _raw_digest(raw_path) != parsed.raw_sha256:
+        raise SocialStoreError("WhatsApp replay metadata conflicts with stored evidence")
+    return str(existing["blob_ref"])
+
+
+def _import_new_batch(
+    database: sqlite3.Connection,
+    archive: dict[str, Any],
+    parsed: ParsedWhatsAppBatch,
+    connection_id: str,
+    blob_ref: str,
+) -> None:
+    batch_id = parsed.manifest_sha256
+    upsert_connection(database, archive, PROVIDER, connection_id)
+    import_accounts(database, archive, PROVIDER)
+    import_objects(database, archive, PROVIDER, batch_id)
+    import_activities(database, archive, PROVIDER, batch_id)
+    import_media(database, archive, PROVIDER, batch_id)
+    import_coverage(database, archive, PROVIDER, connection_id, batch_id)
+    _refresh_fts(database, archive)
+    database.execute(
+        """INSERT INTO fetch_batches(batch_id,provider,connection_id,stream,request_hash,response_hash,blob_ref,
+           resource_count,budget_units,started_at,completed_at,terminal_status) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (batch_id, PROVIDER, connection_id, parsed.stream, batch_id, batch_id, blob_ref,
+         parsed.normalized_items, 0, archive["exported_at"], archive["exported_at"], "success"),
+    )
+    database.execute(
+        """INSERT INTO sync_cursors(connection_id,stream,cursor,watermark,last_success_at,backfill_complete)
+           VALUES(?,?,?,?,?,?) ON CONFLICT(connection_id,stream) DO UPDATE SET
+           cursor=NULL,watermark=excluded.watermark,last_success_at=excluded.last_success_at,
+           backfill_complete=excluded.backfill_complete""",
+        (connection_id, parsed.stream, None, batch_id, archive["exported_at"], int(parsed.stream == "export")),
+    )
+
+
+def _remove_uncommitted_raw(raw_path: Path, parsed: ParsedWhatsAppBatch) -> None:
+    try:
+        if _raw_digest(raw_path) == parsed.raw_sha256:
+            raw_path.unlink()
+    except (OSError, SocialStoreError):
+        return
+
+
+@dataclass
+class _PersistState:
+    raw_path: Path
+    raw_existed: bool
+    created_raw: bool = False
+    committed: bool = False
+
+
+@dataclass(frozen=True)
+class _PersistRequest:
+    root: Path
+    archive: dict[str, Any]
+    parsed: ParsedWhatsAppBatch
+    payload: bytes
+    lease: RunLease
+
+
+def _validate_persist_request(
+    parsed: ParsedWhatsAppBatch, payload: bytes, lease: RunLease
+) -> tuple[dict[str, Any], str]:
+    archive = parsed.archive
+    reject_credentials(archive)
+    if hashlib.sha256(payload).hexdigest() != parsed.raw_sha256:
+        raise SocialStoreError("WhatsApp evidence changed after validation")
+    connection_id = archive["connection_id"]
+    if lease.connection_id != connection_id or lease.stream != parsed.stream:
+        raise SocialStoreError("WhatsApp lease does not authorize this source stream")
+    return archive, connection_id
+
+
+def _commit_batch(
+    database: sqlite3.Connection,
+    request: _PersistRequest,
+    state: _PersistState,
+) -> dict[str, Any]:
+    archive = request.archive
+    parsed = request.parsed
+    connection_id = archive["connection_id"]
+    migrate(database)
+    database.execute("BEGIN IMMEDIATE")
+    assert_run_lease(database, request.lease)
+    _assert_binding(database, connection_id, archive["remote_account_id"])
+    existing_ref = _existing_replay(database, request.root, parsed, connection_id, state.raw_path)
+    if existing_ref is not None:
+        update_run_receipt(database, request.lease, RunReceiptUpdate("complete", terminal=True))
+        database.execute("COMMIT")
+        state.committed = True
+        return _replay_result(parsed, existing_ref)
+    raw_digest, blob_ref = write_raw_batch(request.root, PROVIDER, connection_id, request.payload)
+    state.created_raw = not state.raw_existed
+    if raw_digest != parsed.raw_sha256:
+        raise SocialStoreError("WhatsApp raw evidence hash changed")
+    _import_new_batch(database, archive, parsed, connection_id, blob_ref)
+    update_run_receipt(
+        database,
+        request.lease,
+        RunReceiptUpdate("complete", resource_delta=parsed.normalized_items, terminal=True),
+    )
+    database.execute("COMMIT")
+    state.committed = True
+    return {**_replay_result(parsed, blob_ref), "replayed": False}
+
+
+def persist_batch(root: Path, parsed: ParsedWhatsAppBatch, payload: bytes, lease: RunLease) -> dict[str, Any]:
+    archive, connection_id = _validate_persist_request(parsed, payload, lease)
+    raw_path = _raw_path(root, connection_id, parsed.raw_sha256)
+    state = _PersistState(raw_path, raw_path.exists() or raw_path.is_symlink())
+    request = _PersistRequest(root, archive, parsed, payload, lease)
+    database = connect(root)
+    try:
+        return _commit_batch(database, request, state)
+    except Exception:
+        if database.in_transaction:
+            database.execute("ROLLBACK")
+        if state.created_raw and not state.committed:
+            _remove_uncommitted_raw(state.raw_path, parsed)
+        raise
+    finally:
+        database.close()

--- a/.agents/scripts/_knowledge_social_whatsapp_contract.py
+++ b/.agents/scripts/_knowledge_social_whatsapp_contract.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Provider contract and deterministic identities for WhatsApp evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta, timezone
+from typing import Any
+
+from knowledge_social_import import canonical_json, reject_credentials
+from knowledge_social_store import SocialStoreError, validate_opaque
+
+PROVIDER = "whatsapp"
+EXPORT_SCHEMA = "whatsapp-chat-export-v1"
+WEBHOOK_SCHEMA = "whatsapp-business-webhook-v1"
+EXPORT_RETENTION = "manual_export_may_contain_only_the_latest_40000_messages_or_10000_with_media"
+WEBHOOK_RETENTION = "prospective_events_only_no_general_message_history_endpoint"
+TIMEZONE_OFFSET = re.compile(r"^(?P<sign>[+-])(?P<hours>\d{2}):(?P<minutes>\d{2})$")
+
+
+@dataclass(frozen=True)
+class ParsedWhatsAppBatch:
+    """One fully validated source batch and its immutable original bytes."""
+
+    archive: dict[str, Any]
+    raw_sha256: str
+    manifest_sha256: str
+    stream: str
+    normalized_items: int
+
+
+def digest_id(prefix: str, *values: str) -> str:
+    material = "\0".join((prefix, *values)).encode("utf-8")
+    return f"{prefix}:{hashlib.sha256(material).hexdigest()}"
+
+
+def alias_id(value: str, conversation_id: str) -> str:
+    normalized = " ".join(value.split()).casefold()
+    if not normalized:
+        raise SocialStoreError("WhatsApp participant alias cannot be empty")
+    return digest_id("alias", conversation_id, normalized)
+
+
+def normalized_observed_at(value: str) -> str:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise SocialStoreError("WhatsApp observation time must be ISO-8601") from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise SocialStoreError("WhatsApp observation time requires a timezone")
+    return parsed.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def fixed_timezone(value: str) -> timezone:
+    if value in {"UTC", "Z", "+00:00", "-00:00"}:
+        return timezone.utc
+    match = TIMEZONE_OFFSET.fullmatch(value)
+    if match is None:
+        raise SocialStoreError("WhatsApp timezone must be UTC or an explicit +/-HH:MM offset")
+    hours = int(match["hours"])
+    minutes = int(match["minutes"])
+    offset_minutes = hours * 60 + minutes
+    if minutes > 59 or offset_minutes > 14 * 60:
+        raise SocialStoreError("WhatsApp timezone offset is out of range")
+    delta = timedelta(minutes=offset_minutes)
+    return timezone(delta if match["sign"] == "+" else -delta)
+
+
+def account_record(remote_id: str, alias: str | None, observed_at: str, role: str) -> dict[str, Any]:
+    return {
+        "remote_id": remote_id,
+        "handle": None,
+        "display_name": alias,
+        "observed_at": observed_at,
+        "provider_json": {"identity_kind": "private_alias", "role": role},
+    }
+
+
+def coverage_record(
+    stream: str,
+    observed_at: str,
+    retention: str,
+    status: str,
+    **details: Any,
+) -> dict[str, Any]:
+    unexpected = set(details) - {"reason", "exhausted", "earliest_at", "latest_at"}
+    if unexpected or not isinstance(details.get("exhausted"), bool):
+        raise SocialStoreError("WhatsApp coverage details are invalid")
+    return {
+        "stream": stream,
+        "earliest_at": details.get("earliest_at"),
+        "latest_at": details.get("latest_at"),
+        "cursor_exhausted": details["exhausted"],
+        "retention_limit": retention,
+        "unavailable_reason": details.get("reason"),
+        "status": status,
+        "observed_at": observed_at,
+    }
+
+
+def _manifest_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _manifest_value(item)
+            for key, item in value.items()
+            if key not in {"exported_at", "observed_at"}
+        }
+    if isinstance(value, list):
+        return [_manifest_value(item) for item in value]
+    return value
+
+
+def finish_batch(**parts: Any) -> ParsedWhatsAppBatch:
+    required = {
+        "connection_id", "remote_account_id", "observed_at", "raw_sha256",
+        "stream", "schema", "accounts", "objects", "activities", "media",
+        "coverage", "policy",
+    }
+    if set(parts) != required:
+        raise SocialStoreError("WhatsApp normalized batch fields are invalid")
+    connection_id = parts["connection_id"]
+    remote_account_id = parts["remote_account_id"]
+    validate_opaque(connection_id, "connection_id")
+    if not remote_account_id or len(remote_account_id) > 255:
+        raise SocialStoreError("WhatsApp remote account identity is invalid")
+    archive = {
+        "provider": PROVIDER,
+        "connection_id": connection_id,
+        "remote_account_id": remote_account_id,
+        "exported_at": normalized_observed_at(parts["observed_at"]),
+        "enabled_streams": sorted({record["stream"] for record in parts["coverage"]}),
+        "policy": {
+            "schema": parts["schema"],
+            "raw_sha256": parts["raw_sha256"],
+            "network_requests": 0,
+            "read_only": True,
+            **parts["policy"],
+        },
+        "accounts": sorted(parts["accounts"], key=lambda row: row["remote_id"]),
+        "objects": sorted(parts["objects"], key=lambda row: (row["object_type"], row["remote_id"])),
+        "activities": sorted(parts["activities"], key=lambda row: (row["activity_type"], row["remote_id"])),
+        "media": sorted(parts["media"], key=lambda row: row["remote_id"]),
+        "coverage": sorted(parts["coverage"], key=lambda row: row["stream"]),
+    }
+    reject_credentials(archive)
+    manifest = canonical_json(_manifest_value(archive)).encode("utf-8")
+    manifest_sha256 = hashlib.sha256(manifest).hexdigest()
+    normalized_items = sum(len(archive[key]) for key in ("accounts", "objects", "activities", "media"))
+    return ParsedWhatsAppBatch(
+        archive, parts["raw_sha256"], manifest_sha256, parts["stream"], normalized_items
+    )

--- a/.agents/scripts/_knowledge_social_whatsapp_export.py
+++ b/.agents/scripts/_knowledge_social_whatsapp_export.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Strict parser for bounded, user-authorized WhatsApp chat exports."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import mimetypes
+import re
+import time
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from _knowledge_social_whatsapp_contract import (
+    EXPORT_RETENTION,
+    EXPORT_SCHEMA,
+    ParsedWhatsAppBatch,
+    account_record,
+    alias_id,
+    coverage_record,
+    digest_id,
+    finish_batch,
+    fixed_timezone,
+    normalized_observed_at,
+)
+from _knowledge_social_whatsapp_export_archive import (
+    ExportContents,
+    _check_deadline,
+    _read_contents,
+)
+from knowledge_social_store import SocialStoreError
+
+MAX_LINE_CHARS = 1024 * 1024
+FORMAT_SPECS = {
+    "android-us-12h": (re.compile(r"^(?P<date>\d{1,2}/\d{1,2}/\d{2,4}), (?P<time>\d{1,2}:\d{2}(?::\d{2})? [AP]M) - (?P<body>.*)$"), "%m/%d/%y %I:%M %p", "%m/%d/%Y %I:%M %p"),
+    "android-dmy-24h": (re.compile(r"^(?P<date>\d{1,2}/\d{1,2}/\d{2,4}), (?P<time>\d{1,2}:\d{2}(?::\d{2})?) - (?P<body>.*)$"), "%d/%m/%y %H:%M", "%d/%m/%Y %H:%M"),
+    "ios-us-12h": (re.compile(r"^\[(?P<date>\d{1,2}/\d{1,2}/\d{2,4}), (?P<time>\d{1,2}:\d{2}(?::\d{2})? [AP]M)\] (?P<body>.*)$"), "%m/%d/%y %I:%M %p", "%m/%d/%Y %I:%M %p"),
+    "ios-dmy-24h": (re.compile(r"^\[(?P<date>\d{1,2}/\d{1,2}/\d{2,4}), (?P<time>\d{1,2}:\d{2}(?::\d{2})?)\] (?P<body>.*)$"), "%d/%m/%y %H:%M", "%d/%m/%Y %H:%M"),
+}
+ATTACHMENT_PATTERNS = (
+    re.compile(r"^<attached: (?P<name>[^<>]+)>$", re.IGNORECASE),
+    re.compile(r"^(?P<name>.+?) \(file attached\)$", re.IGNORECASE),
+)
+TIMESTAMP_LIKE = re.compile(r"^\[?\d{1,2}/\d{1,2}/\d{2,4}, ")
+
+
+@dataclass(frozen=True)
+class ExportRequest:
+    path: Path
+    connection_id: str
+    conversation_id: str
+    format_name: str
+    timezone_name: str
+    exported_at: str
+    max_bytes: int
+    max_items: int
+    max_seconds: int
+
+
+def _timestamp(date_value: str, time_value: str, format_name: str, zone: Any) -> str:
+    _pattern, short_format, long_format = FORMAT_SPECS[format_name]
+    parse_format = long_format if len(date_value.rsplit("/", 1)[-1]) == 4 else short_format
+    if time_value.count(":") == 2:
+        parse_format = parse_format.replace("%M", "%M:%S", 1)
+    try:
+        parsed = datetime.strptime(f"{date_value} {time_value}", parse_format)
+    except ValueError as error:
+        raise SocialStoreError("WhatsApp transcript timestamp does not match the selected format") from error
+    if parsed.year < 2000:
+        raise SocialStoreError("WhatsApp transcript contains an ambiguous two-digit year")
+    return parsed.replace(tzinfo=zone).isoformat()
+
+
+def _decode_transcript(transcript: bytes) -> str:
+    try:
+        return transcript.decode("utf-8-sig")
+    except UnicodeDecodeError as error:
+        raise SocialStoreError("WhatsApp transcript must be UTF-8") from error
+
+
+def _new_message(
+    raw_line: str, pattern: re.Pattern[str], format_name: str, zone: Any
+) -> tuple[str, str] | None:
+    if len(raw_line) > MAX_LINE_CHARS:
+        raise SocialStoreError("WhatsApp transcript line exceeds the character budget")
+    normalized = raw_line.replace("\u202f", " ").replace("\u00a0", " ").lstrip("\u200e")
+    match = pattern.match(normalized)
+    if match:
+        return _timestamp(match["date"], match["time"], format_name, zone), match["body"]
+    if TIMESTAMP_LIKE.match(normalized):
+        raise SocialStoreError("WhatsApp transcript mixes timestamp or locale formats")
+    return None
+
+
+def _append_continuation(current: tuple[str, str] | None, raw_line: str) -> tuple[str, str] | None:
+    if current is not None:
+        return current[0], f"{current[1]}\n{raw_line}"
+    if raw_line.strip():
+        raise SocialStoreError("WhatsApp transcript starts with an unrecognized line")
+    return None
+
+
+def _message_rows(
+    transcript: bytes,
+    format_name: str,
+    zone: Any,
+    max_items: int,
+    deadline: float,
+) -> list[tuple[str, str]]:
+    pattern = FORMAT_SPECS[format_name][0]
+    rows: list[tuple[str, str]] = []
+    current: tuple[str, str] | None = None
+    for raw_line in io.StringIO(_decode_transcript(transcript)):
+        _check_deadline(deadline)
+        raw_line = raw_line.rstrip("\r\n")
+        candidate = _new_message(raw_line, pattern, format_name, zone)
+        if candidate is not None:
+            if current is not None:
+                rows.append(current)
+            current = candidate
+        else:
+            current = _append_continuation(current, raw_line)
+        if len(rows) >= max_items:
+            raise SocialStoreError("WhatsApp transcript exceeds the item budget")
+    if current is not None:
+        rows.append(current)
+    if not rows:
+        raise SocialStoreError("WhatsApp transcript contains no recognized records")
+    return rows
+
+
+def _attachment_name(content: str) -> str | None:
+    for pattern in ATTACHMENT_PATTERNS:
+        match = pattern.match(content.strip())
+        if match:
+            name = PurePosixPath(match["name"]).name
+            return name if name == match["name"] else None
+    return None
+
+
+@dataclass
+class _NormalizedExport:
+    request: ExportRequest
+    observed_at: str
+    contents: ExportContents
+    occurrences: Counter[tuple[str, str, str]] = field(default_factory=Counter)
+    accounts: dict[str, dict[str, Any]] = field(default_factory=dict)
+    objects: list[dict[str, Any]] = field(default_factory=list)
+    media: list[dict[str, Any]] = field(default_factory=list)
+    missing_media: int = 0
+
+    def add(self, timestamp: str, body: str) -> None:
+        sender, separator, content = body.partition(": ")
+        actor_id = alias_id(sender, self.request.conversation_id) if separator else digest_id("system", self.request.conversation_id)
+        if separator:
+            self.accounts[actor_id] = account_record(actor_id, sender, self.observed_at, "unverified_export_alias")
+        text = content if separator else body
+        key = (timestamp, actor_id, text)
+        ordinal = self.occurrences[key]
+        self.occurrences[key] += 1
+        content_digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+        remote_id = digest_id("export-message", self.request.conversation_id, timestamp, actor_id, str(ordinal), content_digest)
+        provider_json: dict[str, Any] = {
+            "conversation_id": self.request.conversation_id,
+            "identity_basis": "conversation_timestamp_sender_ordinal_content_digest",
+            "occurrence_ordinal": ordinal,
+            "parser_schema": EXPORT_SCHEMA,
+            "attribution_status": "syntactic_alias_unverified" if separator else "unattributed",
+            "record_kind": "message_like_record" if separator else "system_notice",
+        }
+        self._add_attachment(_attachment_name(text), remote_id, provider_json)
+        self.objects.append({
+            "object_type": "chat_message", "remote_id": remote_id,
+            "account_remote_id": actor_id, "text": text, "created_at": timestamp,
+            "observed_at": self.observed_at, "evidence_class": "observed",
+            "provider_json": provider_json,
+        })
+
+    def _add_attachment(
+        self, attachment: str | None, remote_id: str, provider_json: dict[str, Any]
+    ) -> None:
+        if not attachment:
+            return
+        matched = self.contents.media.get(attachment.casefold())
+        if matched is None:
+            self.missing_media += 1
+            provider_json["attachment_state"] = "missing_from_archive"
+            return
+        member_name, media_digest, media_size = matched
+        media_id = digest_id("export-media", self.request.conversation_id, remote_id, media_digest)
+        provider_json["attachment_remote_id"] = media_id
+        self.media.append({
+            "remote_id": media_id, "object_remote_id": remote_id,
+            "content_sha256": media_digest,
+            "mime_type": mimetypes.guess_type(attachment)[0] or "application/octet-stream",
+            "byte_size": media_size,
+            "blob_ref": f"archive:{self.contents.raw_sha256}#{member_name}",
+            "hydration_state": "embedded_in_raw_archive",
+        })
+
+
+def _export_coverage(
+    observed_at: str, earliest: str, latest: str, missing_media: int
+) -> list[dict[str, Any]]:
+    coverage = [
+        coverage_record("export_text", observed_at, EXPORT_RETENTION, "complete", reason=None, exhausted=True, earliest_at=earliest, latest_at=latest),
+        coverage_record("participants", observed_at, EXPORT_RETENTION, "partial", reason="exports_expose_display_aliases_not_stable_provider_identity", exhausted=True),
+        coverage_record("timestamps", observed_at, EXPORT_RETENTION, "partial", reason="fixed_offset_is_user_asserted_and_exports_spanning_dst_require_separate_imports", exhausted=True, earliest_at=earliest, latest_at=latest),
+        coverage_record("attachments", observed_at, EXPORT_RETENTION, "partial" if missing_media else "complete", reason="referenced_media_missing_from_archive" if missing_media else None, exhausted=missing_media == 0),
+    ]
+    unavailable = (
+        ("replies_quotes", "export_has_no_documented_structured_reply_schema"),
+        ("edits_deletions", "export_has_no_documented_complete_edit_or_delete_history"),
+        ("reactions", "export_has_no_documented_structured_reaction_schema"),
+        ("history_before_export_window", "manual_export_limits_do_not_guarantee_complete_history"),
+    )
+    coverage.extend(
+        coverage_record(stream, observed_at, EXPORT_RETENTION, "unavailable", reason=reason, exhausted=False)
+        for stream, reason in unavailable
+    )
+    return coverage
+
+
+def parse_export(request: ExportRequest) -> tuple[ParsedWhatsAppBatch, bytes]:
+    if request.format_name not in FORMAT_SPECS:
+        raise SocialStoreError("WhatsApp transcript format must be selected explicitly")
+    if request.max_seconds < 1:
+        raise SocialStoreError("WhatsApp elapsed-time budget must be positive")
+    deadline = time.monotonic() + request.max_seconds
+    observed_at = normalized_observed_at(request.exported_at)
+    contents = _read_contents(
+        request.path, request.max_bytes, request.max_items, deadline
+    )
+    rows = _message_rows(
+        contents.transcript,
+        request.format_name,
+        fixed_timezone(request.timezone_name),
+        request.max_items,
+        deadline,
+    )
+    earliest = min(timestamp for timestamp, _body in rows)
+    latest = max(timestamp for timestamp, _body in rows)
+    normalized = _NormalizedExport(request, observed_at, contents)
+    for timestamp, body in rows:
+        _check_deadline(deadline)
+        normalized.add(timestamp, body)
+    parsed = finish_batch(
+        connection_id=request.connection_id,
+        remote_account_id=request.conversation_id,
+        observed_at=observed_at,
+        raw_sha256=contents.raw_sha256,
+        stream="export",
+        schema=EXPORT_SCHEMA,
+        accounts=list(normalized.accounts.values()),
+        objects=normalized.objects,
+        activities=[],
+        media=normalized.media,
+        coverage=_export_coverage(observed_at, earliest, latest, normalized.missing_media),
+        policy={"format": request.format_name, "timezone": request.timezone_name, "source": "user_authorized_chat_export"},
+    )
+    return parsed, contents.raw

--- a/.agents/scripts/_knowledge_social_whatsapp_export_archive.py
+++ b/.agents/scripts/_knowledge_social_whatsapp_export_archive.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded file and ZIP handling for user-authorized WhatsApp exports."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import stat
+import zipfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import BinaryIO, Iterator
+from pathlib import Path, PurePosixPath
+
+from _knowledge_social_whatsapp_zip_guard import (
+    MAX_MEMBER_BYTES,
+    READ_CHUNK_BYTES,
+    check_deadline as _check_deadline,
+    preflight_zip as _preflight_zip,
+    safe_zip_members as _safe_zip_members,
+)
+from knowledge_social_store import SocialStoreError
+
+MAX_TRANSCRIPT_BYTES = 32 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class ExportContents:
+    transcript: bytes
+    media: dict[str, tuple[str, str, int]]
+    raw: bytes
+    raw_sha256: str
+
+
+@contextmanager
+def _opened_regular(path: Path) -> Iterator[BinaryIO]:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = -1
+    try:
+        if not getattr(os, "O_NOFOLLOW", 0) and path.is_symlink():
+            raise SocialStoreError("WhatsApp export must be a regular non-symlink file")
+        descriptor = os.open(path, flags)
+        with os.fdopen(descriptor, "rb") as source:
+            descriptor = -1
+            yield source
+    except SocialStoreError:
+        raise
+    except OSError as error:
+        raise SocialStoreError("WhatsApp export could not be opened safely") from error
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _read_regular_stream(
+    source: BinaryIO, max_bytes: int, deadline: float | None
+) -> tuple[bytes, str]:
+    digest = hashlib.sha256()
+    chunks: list[bytes] = []
+    total = 0
+    while chunk := source.read(READ_CHUNK_BYTES):
+        if deadline is not None:
+            _check_deadline(deadline)
+        total += len(chunk)
+        if total > max_bytes:
+            raise SocialStoreError("WhatsApp export exceeds the byte budget")
+        digest.update(chunk)
+        chunks.append(chunk)
+    return b"".join(chunks), digest.hexdigest()
+
+
+def _validate_unchanged(before: os.stat_result, after: os.stat_result, payload_size: int) -> None:
+    before_identity = (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns)
+    after_identity = (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns)
+    if payload_size != before.st_size or before_identity != after_identity:
+        raise SocialStoreError("WhatsApp export changed while it was being read")
+
+
+def _read_regular_digest(
+    path: Path, max_bytes: int, deadline: float | None = None
+) -> tuple[bytes, str]:
+    with _opened_regular(path) as source:
+        before = os.fstat(source.fileno())
+        if not stat.S_ISREG(before.st_mode) or not 0 < before.st_size <= max_bytes:
+            raise SocialStoreError("WhatsApp export exceeds the byte budget")
+        payload, digest = _read_regular_stream(source, max_bytes, deadline)
+        after = os.fstat(source.fileno())
+    _validate_unchanged(before, after, len(payload))
+    return payload, digest
+
+
+def _read_regular(path: Path, max_bytes: int) -> bytes:
+    payload, _digest = _read_regular_digest(path, max_bytes)
+    return payload
+
+
+def _read_zip_member(
+    archive: zipfile.ZipFile,
+    info: zipfile.ZipInfo,
+    deadline: float,
+    *,
+    capture: bool,
+) -> tuple[bytes | None, str, int]:
+    digest = hashlib.sha256()
+    chunks: list[bytes] = []
+    total = 0
+    with archive.open(info, "r") as source:
+        while chunk := source.read(READ_CHUNK_BYTES):
+            _check_deadline(deadline)
+            total += len(chunk)
+            if total > info.file_size or total > MAX_MEMBER_BYTES:
+                raise SocialStoreError("WhatsApp export member exceeded its declared size")
+            digest.update(chunk)
+            if capture:
+                chunks.append(chunk)
+    if total != info.file_size:
+        raise SocialStoreError("WhatsApp export member size does not match its metadata")
+    return (b"".join(chunks) if capture else None), digest.hexdigest(), total
+
+
+def _transcript_member(members: list[zipfile.ZipInfo]) -> zipfile.ZipInfo:
+    transcripts = [info for info in members if info.filename.casefold().endswith(".txt")]
+    if len(transcripts) != 1:
+        raise SocialStoreError("WhatsApp ZIP export requires exactly one transcript")
+    transcript = transcripts[0]
+    if transcript.file_size > MAX_TRANSCRIPT_BYTES:
+        raise SocialStoreError("WhatsApp transcript exceeds the byte budget")
+    return transcript
+
+
+def _media_manifest(
+    archive: zipfile.ZipFile,
+    members: list[zipfile.ZipInfo],
+    transcript: zipfile.ZipInfo,
+    deadline: float,
+) -> dict[str, tuple[str, str, int]]:
+    media: dict[str, tuple[str, str, int]] = {}
+    for info in members:
+        _check_deadline(deadline)
+        if info == transcript:
+            continue
+        key = PurePosixPath(info.filename).name.casefold()
+        if key in media:
+            raise SocialStoreError("WhatsApp media basenames must be unique")
+        _unused, media_digest, media_size = _read_zip_member(
+            archive, info, deadline, capture=False
+        )
+        media[key] = (info.filename, media_digest, media_size)
+    return media
+
+
+def _read_zip_contents(
+    raw: bytes, raw_sha256: str, max_bytes: int, max_items: int, deadline: float
+) -> ExportContents:
+    _preflight_zip(raw, max_items)
+    with zipfile.ZipFile(io.BytesIO(raw), "r") as archive:
+        members = _safe_zip_members(archive, max_bytes, max_items, deadline)
+        transcript_info = _transcript_member(members)
+        transcript, _digest, _size = _read_zip_member(
+            archive, transcript_info, deadline, capture=True
+        )
+        if transcript is None:
+            raise SocialStoreError("WhatsApp transcript could not be retained")
+        media = _media_manifest(archive, members, transcript_info, deadline)
+    return ExportContents(transcript, media, raw, raw_sha256)
+
+
+def _read_contents(
+    path: Path, max_bytes: int, max_items: int, deadline: float
+) -> ExportContents:
+    raw, raw_sha256 = _read_regular_digest(path, max_bytes, deadline)
+    if path.suffix.casefold() == ".txt":
+        if len(raw) > MAX_TRANSCRIPT_BYTES:
+            raise SocialStoreError("WhatsApp transcript exceeds the byte budget")
+        return ExportContents(raw, {}, raw, raw_sha256)
+    try:
+        return _read_zip_contents(raw, raw_sha256, max_bytes, max_items, deadline)
+    except SocialStoreError:
+        raise
+    except (RuntimeError, zipfile.BadZipFile, zipfile.LargeZipFile) as error:
+        raise SocialStoreError("WhatsApp export is not a supported ZIP file") from error

--- a/.agents/scripts/_knowledge_social_whatsapp_webhook.py
+++ b/.agents/scripts/_knowledge_social_whatsapp_webhook.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Verify and normalize official WhatsApp Business Platform webhook evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_whatsapp_contract import (
+    WEBHOOK_RETENTION,
+    WEBHOOK_SCHEMA,
+    ParsedWhatsAppBatch,
+    account_record,
+    coverage_record,
+    digest_id,
+    finish_batch,
+    normalized_observed_at,
+)
+from _knowledge_social_whatsapp_webhook_records import (
+    WebhookRecords,
+    identity,
+    message_records,
+    status_records,
+)
+from knowledge_social_store import SocialStoreError
+
+MAX_WEBHOOK_BYTES = 2 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class WebhookRequest:
+    payload: bytes
+    signature: str
+    app_secret: bytes
+    connection_id: str
+    expected_waba_id: str
+    expected_phone_number_id: str
+    observed_at: str
+
+
+def _verify_signature(payload: bytes, signature: str, app_secret: bytes) -> None:
+    if not app_secret:
+        raise SocialStoreError("WhatsApp webhook app secret is unavailable")
+    if not signature.startswith("sha256=") or len(signature) != 71:
+        raise SocialStoreError("WhatsApp webhook signature is malformed")
+    expected = "sha256=" + hmac.new(app_secret, payload, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, signature.casefold()):
+        raise SocialStoreError("WhatsApp webhook signature verification failed")
+
+
+def _records(value: Any, field_name: str) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise SocialStoreError(f"WhatsApp webhook {field_name} must be an array of objects")
+    return value
+
+
+def _verify_change_value(change: dict[str, Any], expected_phone: str) -> dict[str, Any]:
+    if change.get("field") != "messages" or not isinstance(change.get("value"), dict):
+        raise SocialStoreError("WhatsApp webhook contains an unsupported change field")
+    value = change["value"]
+    if value.get("messaging_product") != "whatsapp":
+        raise SocialStoreError("WhatsApp webhook messaging product is invalid")
+    metadata = value.get("metadata")
+    if not isinstance(metadata, dict):
+        raise SocialStoreError("WhatsApp webhook phone identity does not match the connection")
+    phone_id = identity(metadata.get("phone_number_id"), "phone identity")
+    if phone_id != expected_phone:
+        raise SocialStoreError("WhatsApp webhook phone identity does not match the connection")
+    return value
+
+
+def _verified_values(
+    root: dict[str, Any], expected_waba: str, expected_phone: str
+) -> list[dict[str, Any]]:
+    values: list[dict[str, Any]] = []
+    for entry in _records(root.get("entry"), "entry"):
+        if identity(entry.get("id"), "WABA identity") != expected_waba:
+            raise SocialStoreError("WhatsApp webhook WABA identity does not match the connection")
+        for change in _records(entry.get("changes"), "changes"):
+            values.append(_verify_change_value(change, expected_phone))
+    if not values:
+        raise SocialStoreError("WhatsApp webhook contains no authorized message changes")
+    return values
+
+
+def _webhook_coverage(observed_at: str) -> list[dict[str, Any]]:
+    states = (
+        ("business_messages", "partial", "prospective_events_received_after_subscription_only"),
+        ("message_statuses", "partial", "only_status_events_delivered_to_this_subscription"),
+        ("history_before_connection", "unavailable", "no_general_business_message_history_endpoint"),
+        ("template_lifecycle", "unavailable", "this_collector_accepts_only_identity_bound_messages_webhooks"),
+        ("personal_and_existing_group_history", "unavailable", "business_webhooks_do_not_authorize_personal_or_preexisting_group_history"),
+        ("edits_and_deletions", "unavailable", "no_complete_retrospective_edit_or_delete_audit_is_documented"),
+    )
+    return [
+        coverage_record(stream, observed_at, WEBHOOK_RETENTION, status, reason=reason, exhausted=False)
+        for stream, status, reason in states
+    ]
+
+
+def parse_business_webhook(request: WebhookRequest) -> ParsedWhatsAppBatch:
+    if not 0 < len(request.payload) <= MAX_WEBHOOK_BYTES:
+        raise SocialStoreError("WhatsApp webhook exceeds the byte budget")
+    _verify_signature(request.payload, request.signature, request.app_secret)
+    try:
+        root = json.loads(request.payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise SocialStoreError("WhatsApp webhook is not valid UTF-8 JSON") from error
+    if not isinstance(root, dict) or root.get("object") != "whatsapp_business_account":
+        raise SocialStoreError("WhatsApp webhook object type is invalid")
+    observed = normalized_observed_at(request.observed_at)
+    expected_waba = identity(request.expected_waba_id, "configured WABA identity")
+    expected_phone = identity(request.expected_phone_number_id, "configured phone identity")
+    business_id = digest_id("business", expected_waba, expected_phone)
+    records = WebhookRecords(
+        accounts={business_id: account_record(business_id, None, observed, "business_phone")}
+    )
+    for value in _verified_values(root, expected_waba, expected_phone):
+        records.extend(message_records(_records(value.get("messages"), "messages"), observed))
+        records.activities.extend(
+            status_records(_records(value.get("statuses"), "statuses"), observed, business_id)
+        )
+    return finish_batch(
+        connection_id=request.connection_id,
+        remote_account_id=business_id,
+        observed_at=observed,
+        raw_sha256=hashlib.sha256(request.payload).hexdigest(),
+        stream="business_webhook",
+        schema=WEBHOOK_SCHEMA,
+        accounts=list(records.accounts.values()),
+        objects=records.objects,
+        activities=records.activities,
+        media=records.media,
+        coverage=_webhook_coverage(observed),
+        policy={"identity_verified": True, "signature": "hmac_sha256_raw_body", "source": "official_business_platform_webhook"},
+    )

--- a/.agents/scripts/_knowledge_social_whatsapp_webhook_records.py
+++ b/.agents/scripts/_knowledge_social_whatsapp_webhook_records.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize typed records from verified WhatsApp Business webhooks."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_whatsapp_contract import account_record, digest_id
+from knowledge_social_store import SocialStoreError
+
+MEDIA_TYPES = {"image", "audio", "video", "document", "sticker"}
+
+
+@dataclass
+class WebhookRecords:
+    objects: list[dict[str, Any]] = field(default_factory=list)
+    activities: list[dict[str, Any]] = field(default_factory=list)
+    media: list[dict[str, Any]] = field(default_factory=list)
+    accounts: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    def extend(self, other: "WebhookRecords") -> None:
+        self.objects.extend(other.objects)
+        self.activities.extend(other.activities)
+        self.media.extend(other.media)
+        self.accounts.update(other.accounts)
+
+
+def identity(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or not value or len(value) > 255:
+        raise SocialStoreError(f"WhatsApp webhook {field_name} is invalid")
+    return value
+
+
+def _text(record: dict[str, Any], message_type: str) -> str | None:
+    value = record.get(message_type)
+    if not isinstance(value, dict):
+        return None
+    for key in ("body", "caption", "emoji", "name"):
+        candidate = value.get(key)
+        if isinstance(candidate, str):
+            return candidate
+    return None
+
+
+def _event_time(value: Any) -> str:
+    if not isinstance(value, str) or not value.isdigit():
+        raise SocialStoreError("WhatsApp webhook event timestamp is invalid")
+    try:
+        return datetime.fromtimestamp(int(value), UTC).isoformat().replace("+00:00", "Z")
+    except (OverflowError, OSError, ValueError) as error:
+        raise SocialStoreError("WhatsApp webhook event timestamp is invalid") from error
+
+
+def _provider_digest(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise SocialStoreError("WhatsApp webhook media digest is invalid")
+    try:
+        decoded = base64.b64decode(value, validate=True)
+    except (binascii.Error, ValueError) as error:
+        raise SocialStoreError("WhatsApp webhook media digest is invalid") from error
+    if len(decoded) != hashlib.sha256().digest_size:
+        raise SocialStoreError("WhatsApp webhook media digest is invalid")
+    return value
+
+
+def _context_id(message: dict[str, Any]) -> str | None:
+    value = message.get("context")
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise SocialStoreError("WhatsApp webhook reply context is invalid")
+    candidate = value.get("id", value.get("message_id"))
+    return identity(candidate, "reply context") if candidate is not None else None
+
+
+def _typed_body(message: dict[str, Any], message_type: str) -> dict[str, Any] | None:
+    typed = message.get(message_type)
+    if message_type in MEDIA_TYPES and not isinstance(typed, dict):
+        raise SocialStoreError("WhatsApp webhook media body is invalid")
+    if message_type == "reaction" and not isinstance(typed, dict):
+        raise SocialStoreError("WhatsApp webhook reaction body is invalid")
+    return typed if isinstance(typed, dict) else None
+
+
+def _media_record(
+    typed: dict[str, Any], message_id: str, provider_json: dict[str, Any]
+) -> dict[str, Any]:
+    media_id = identity(typed.get("id"), "media id")
+    provider_json["media_remote_id"] = media_id
+    provider_digest = _provider_digest(typed.get("sha256"))
+    if provider_digest is not None:
+        provider_json["provider_media_sha256_b64"] = provider_digest
+    mime_type = typed.get("mime_type")
+    if mime_type is not None and not isinstance(mime_type, str):
+        raise SocialStoreError("WhatsApp webhook media MIME type is invalid")
+    return {
+        "remote_id": media_id, "object_remote_id": message_id,
+        "content_sha256": None, "mime_type": mime_type, "byte_size": None,
+        "blob_ref": None, "hydration_state": "metadata_only_provider_digest_unverified",
+    }
+
+
+def _reaction_record(
+    typed: dict[str, Any], message_id: str, sender: str, occurred_at: str, observed_at: str
+) -> dict[str, Any]:
+    target = identity(typed.get("message_id"), "reaction target")
+    emoji = typed.get("emoji")
+    if not isinstance(emoji, str):
+        raise SocialStoreError("WhatsApp webhook reaction emoji is invalid")
+    return {
+        "activity_type": "reaction",
+        "remote_id": digest_id("reaction", message_id, target, emoji),
+        "actor_remote_id": sender, "object_remote_id": target,
+        "occurred_at": occurred_at, "observed_at": observed_at,
+        "state": "removed" if emoji == "" else "active",
+        "provider_json": {"source_message_id": message_id},
+    }
+
+
+def message_records(messages: list[dict[str, Any]], observed_at: str) -> WebhookRecords:
+    records = WebhookRecords()
+    for message in messages:
+        message_id = identity(message.get("id"), "message id")
+        sender = digest_id("business-contact", identity(message.get("from"), "sender identity"))
+        records.accounts[sender] = account_record(sender, None, observed_at, "business_contact")
+        message_type = identity(message.get("type"), "message type")
+        occurred_at = _event_time(message.get("timestamp"))
+        context_id = _context_id(message)
+        provider_json: dict[str, Any] = {"message_type": message_type, "source": "verified_business_webhook"}
+        if context_id:
+            provider_json["reply_to_message_id"] = context_id
+        typed = _typed_body(message, message_type)
+        if message_type in MEDIA_TYPES and typed is not None:
+            records.media.append(_media_record(typed, message_id, provider_json))
+        records.objects.append({
+            "object_type": "business_message", "remote_id": message_id,
+            "account_remote_id": sender, "text": _text(message, message_type),
+            "created_at": occurred_at, "observed_at": observed_at,
+            "evidence_class": "authored", "provider_json": provider_json,
+        })
+        if message_type == "reaction" and typed is not None:
+            records.activities.append(_reaction_record(typed, message_id, sender, occurred_at, observed_at))
+    return records
+
+
+def status_records(
+    statuses: list[dict[str, Any]], observed_at: str, actor_id: str
+) -> list[dict[str, Any]]:
+    activities: list[dict[str, Any]] = []
+    for status in statuses:
+        message_id = identity(status.get("id"), "status message id")
+        state = identity(status.get("status"), "message status")
+        occurred_at = _event_time(status.get("timestamp"))
+        activities.append({
+            "activity_type": "message_status",
+            "remote_id": digest_id("message-status", message_id, state, occurred_at),
+            "actor_remote_id": actor_id, "object_remote_id": message_id,
+            "occurred_at": occurred_at, "observed_at": observed_at, "state": state,
+            "provider_json": {"source": "verified_business_webhook"},
+        })
+    return activities

--- a/.agents/scripts/_knowledge_social_whatsapp_zip_guard.py
+++ b/.agents/scripts/_knowledge_social_whatsapp_zip_guard.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Reject unsafe or over-budget members before WhatsApp ZIP extraction."""
+
+from __future__ import annotations
+
+import stat
+import struct
+import time
+import zipfile
+from pathlib import PurePosixPath
+
+from knowledge_social_store import SocialStoreError
+
+MAX_MEMBER_BYTES = 256 * 1024 * 1024
+MAX_COMPRESSION_RATIO = 200
+READ_CHUNK_BYTES = 1024 * 1024
+
+
+def check_deadline(deadline: float) -> None:
+    if time.monotonic() > deadline:
+        raise SocialStoreError("WhatsApp export exceeded the elapsed-time budget")
+
+
+def _validate_member_path(info: zipfile.ZipInfo, seen: set[str]) -> None:
+    name = info.filename
+    path = PurePosixPath(name)
+    folded = name.casefold()
+    unsafe = not name or "\\" in name or "\x00" in name or path.is_absolute()
+    unsafe = unsafe or any(part in {"", ".", ".."} for part in path.parts)
+    if unsafe or folded in seen:
+        raise SocialStoreError("WhatsApp export contains an unsafe or duplicate member path")
+    seen.add(folded)
+
+
+def _validate_member_type(info: zipfile.ZipInfo) -> None:
+    mode = (info.external_attr >> 16) & 0o170000
+    if mode == stat.S_IFLNK or info.flag_bits & 0x1:
+        raise SocialStoreError("WhatsApp export contains a link or encrypted member")
+
+
+def _validate_member_size(info: zipfile.ZipInfo) -> None:
+    if info.file_size > MAX_MEMBER_BYTES:
+        raise SocialStoreError("WhatsApp export member exceeds the byte budget")
+    compressed_budget = info.compress_size * MAX_COMPRESSION_RATIO
+    if info.file_size > READ_CHUNK_BYTES and info.file_size > compressed_budget:
+        raise SocialStoreError("WhatsApp export member exceeds the compression-ratio budget")
+
+
+def safe_zip_members(
+    archive: zipfile.ZipFile, max_bytes: int, max_items: int, deadline: float
+) -> list[zipfile.ZipInfo]:
+    infos = archive.infolist()
+    if len(infos) > max_items:
+        raise SocialStoreError("WhatsApp export exceeds the member budget")
+    seen: set[str] = set()
+    total = 0
+    safe: list[zipfile.ZipInfo] = []
+    for info in infos:
+        check_deadline(deadline)
+        _validate_member_path(info, seen)
+        _validate_member_type(info)
+        if info.is_dir():
+            continue
+        _validate_member_size(info)
+        total += info.file_size
+        if total > max_bytes:
+            raise SocialStoreError("WhatsApp export exceeds the uncompressed byte budget")
+        safe.append(info)
+    return safe
+
+
+def _eocd_fields(raw: bytes) -> tuple[int, tuple[bytes, int, int, int, int, int, int, int]]:
+    eocd_start = max(0, len(raw) - 65_557)
+    eocd_offset = raw.rfind(b"PK\x05\x06", eocd_start)
+    if eocd_offset < 0 or eocd_offset + 22 > len(raw):
+        raise SocialStoreError("WhatsApp export has no valid ZIP directory")
+    return eocd_offset, struct.unpack_from("<4s4H2LH", raw, eocd_offset)
+
+
+def _validate_eocd(
+    raw_size: int,
+    eocd_offset: int,
+    fields: tuple[bytes, int, int, int, int, int, int, int],
+    max_items: int,
+) -> tuple[int, int, int]:
+    _signature, disk, central_disk, disk_entries, entries, size, offset, comment = fields
+    if eocd_offset + 22 + comment != raw_size:
+        raise SocialStoreError("WhatsApp export has trailing or malformed ZIP data")
+    if 0xFFFF in {disk_entries, entries} or 0xFFFFFFFF in {size, offset}:
+        raise SocialStoreError("WhatsApp export cannot use ZIP64 metadata")
+    _validate_single_disk(disk, central_disk, disk_entries, entries)
+    if entries > max_items or offset + size > eocd_offset:
+        raise SocialStoreError("WhatsApp export ZIP directory exceeds its budget")
+    return entries, offset, size
+
+
+def _validate_single_disk(
+    disk: int, central_disk: int, disk_entries: int, entries: int
+) -> None:
+    if disk != 0 or central_disk != 0 or disk_entries != entries:
+        raise SocialStoreError("WhatsApp export cannot span multiple ZIP disks")
+
+
+def _directory_bounds(raw: bytes, max_items: int) -> tuple[int, int, int]:
+    eocd_offset, fields = _eocd_fields(raw)
+    return _validate_eocd(len(raw), eocd_offset, fields, max_items)
+
+
+def _count_directory_entries(raw: bytes, offset: int, size: int, max_items: int) -> int:
+    cursor = offset
+    central_end = offset + size
+    counted = 0
+    while cursor < central_end:
+        if cursor + 46 > central_end or raw[cursor : cursor + 4] != b"PK\x01\x02":
+            raise SocialStoreError("WhatsApp export ZIP directory is malformed")
+        name_length, extra_length, comment_length = struct.unpack_from("<HHH", raw, cursor + 28)
+        cursor += 46 + name_length + extra_length + comment_length
+        counted += 1
+        if cursor > central_end or counted > max_items:
+            raise SocialStoreError("WhatsApp export ZIP directory exceeds its budget")
+    if cursor != central_end:
+        raise SocialStoreError("WhatsApp export ZIP directory count is inconsistent")
+    return counted
+
+
+def preflight_zip(raw: bytes, max_items: int) -> None:
+    entries, offset, size = _directory_bounds(raw, max_items)
+    if _count_directory_entries(raw, offset, size, max_items) != entries:
+        raise SocialStoreError("WhatsApp export ZIP directory count is inconsistent")

--- a/.agents/scripts/knowledge_social_whatsapp.py
+++ b/.agents/scripts/knowledge_social_whatsapp.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Import safe WhatsApp exports or verified official business webhooks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from _knowledge_social_lease import (
+    RunLease,
+    RunLeaseRequest,
+    acquire_run_lease,
+    fail_active_run,
+    release_run_lease,
+)
+from _knowledge_social_whatsapp import persist_batch
+from _knowledge_social_whatsapp_export import ExportRequest, FORMAT_SPECS, parse_export
+from _knowledge_social_whatsapp_export_archive import _read_regular
+from _knowledge_social_whatsapp_webhook import (
+    MAX_WEBHOOK_BYTES,
+    WebhookRequest,
+    parse_business_webhook,
+)
+from knowledge_corpus_catalog import DEFAULT_ALIAS, resolve
+from knowledge_corpus_context import CatalogError
+from knowledge_social_store import SocialStoreError, validate_root
+
+DEFAULT_MAX_BYTES = 128 * 1024 * 1024
+DEFAULT_MAX_ITEMS = 50_000
+
+
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be an integer") from error
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be positive")
+    return parsed
+
+
+def _common(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--connection-id", required=True)
+    parser.add_argument("--observed-at", required=True, help="ISO-8601 time with timezone")
+    parser.add_argument("--base", type=Path)
+    parser.add_argument("--alias", default=DEFAULT_ALIAS)
+    parser.add_argument("--collector-id", default="whatsapp_ingest")
+    parser.add_argument("--lease-seconds", type=_positive_int, default=300)
+    parser.add_argument("--dry-run", action="store_true")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    export = commands.add_parser("export", help="parse a user-authorized chat export")
+    _common(export)
+    export.add_argument("--archive", type=Path, required=True)
+    export.add_argument("--conversation-id", required=True)
+    export.add_argument("--format", dest="format_name", choices=sorted(FORMAT_SPECS), required=True)
+    export.add_argument("--timezone", required=True, help="UTC or explicit +/-HH:MM offset")
+    export.add_argument("--max-bytes", type=_positive_int, default=DEFAULT_MAX_BYTES)
+    export.add_argument("--max-items", type=_positive_int, default=DEFAULT_MAX_ITEMS)
+    export.add_argument("--max-seconds", type=_positive_int, default=30)
+    webhook = commands.add_parser("webhook", help="verify an official Business Platform webhook")
+    _common(webhook)
+    webhook.add_argument("--payload", type=Path, required=True)
+    webhook.add_argument("--signature-env", default="WHATSAPP_WEBHOOK_SIGNATURE")
+    webhook.add_argument("--app-secret-env", default="WHATSAPP_APP_SECRET")
+    webhook.add_argument("--waba-id", required=True)
+    webhook.add_argument("--phone-number-id", required=True)
+    args = parser.parse_args()
+    if args.lease_seconds > 86_400:
+        parser.error("--lease-seconds cannot exceed 86400")
+    if args.command == "export" and (
+        args.max_bytes > 512 * 1024 * 1024
+        or args.max_items > 1_000_000
+        or args.max_seconds > 300
+    ):
+        parser.error("WhatsApp export budget exceeds the hard limit")
+    return args
+
+
+def _parse_source(args: argparse.Namespace):
+    if args.command == "export":
+        request = ExportRequest(
+            args.archive,
+            args.connection_id,
+            args.conversation_id,
+            args.format_name,
+            args.timezone,
+            args.observed_at,
+            args.max_bytes,
+            args.max_items,
+            args.max_seconds,
+        )
+        return parse_export(request)
+    secret = os.environ.get(args.app_secret_env)
+    if secret is None:
+        raise SocialStoreError("WhatsApp webhook app secret environment variable is unavailable")
+    signature = os.environ.get(args.signature_env)
+    if signature is None:
+        raise SocialStoreError("WhatsApp webhook signature environment variable is unavailable")
+    payload = _read_regular(args.payload, MAX_WEBHOOK_BYTES)
+    parsed = parse_business_webhook(WebhookRequest(
+        payload, signature, secret.encode("utf-8"), args.connection_id,
+        args.waba_id, args.phone_number_id, args.observed_at,
+    ))
+    return parsed, payload
+
+
+def _summary(parsed, *, dry_run: bool) -> dict[str, object]:
+    archive = parsed.archive
+    return {
+        "accounts": len(archive["accounts"]),
+        "activities": len(archive["activities"]),
+        "coverage": len(archive["coverage"]),
+        "dry_run": dry_run,
+        "media": len(archive["media"]),
+        "objects": len(archive["objects"]),
+        "raw_sha256": parsed.raw_sha256,
+        "status": "planned" if dry_run else "complete",
+        "stream": parsed.stream,
+    }
+
+
+def _release_safely(root: Path, lease: RunLease | None) -> None:
+    if lease is None:
+        return
+    try:
+        release_run_lease(root, lease)
+    except SocialStoreError:
+        return
+
+
+def main() -> int:
+    args = parse_args()
+    lease: RunLease | None = None
+    root: Path | None = None
+    try:
+        parsed, payload = _parse_source(args)
+        if args.dry_run:
+            print(json.dumps(_summary(parsed, dry_run=True), sort_keys=True))
+            return 0
+        base = args.base or Path.home() / ".aidevops" / ".agent-workspace" / "knowledge"
+        root = validate_root(resolve(base, args.alias, "knowledge.write"))
+        lease = acquire_run_lease(
+            root,
+            RunLeaseRequest(
+                args.connection_id,
+                parsed.stream,
+                args.collector_id,
+                "sync",
+                args.lease_seconds,
+                parsed.manifest_sha256,
+            ),
+        )
+        result = persist_batch(root, parsed, payload, lease)
+        _release_safely(root, lease)
+        lease = None
+        print(json.dumps({**_summary(parsed, dry_run=False), **result}, sort_keys=True))
+        return 0
+    except (CatalogError, OSError, SocialStoreError, ValueError) as error:
+        if root is not None and lease is not None:
+            try:
+                fail_active_run(root, lease, "whatsapp_ingest_failure")
+            except SocialStoreError:
+                pass
+            _release_safely(root, lease)
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/services/communications/whatsapp.md
+++ b/.agents/services/communications/whatsapp.md
@@ -39,6 +39,21 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
+## Knowledge-ingestion safety boundary
+
+This page documents an unofficial messaging bot. It is not an approved knowledge
+collector. Do not use Baileys, linked WhatsApp Web sessions, browser automation,
+reverse-engineered databases, or backup decryption to ingest chats. The account
+ban and Terms-of-Service risks documented below are disqualifying for knowledge
+collection, including private history mining.
+
+Knowledge ingestion is limited to user-authorized chat exports and identity- plus
+signature-verified official WhatsApp Business Platform webhooks. See
+`content/social-whatsapp.md` for the read-only routes, explicit coverage gaps,
+privacy rules, and current official references. No code in that collector can
+send messages, mutate templates or groups, link a personal session, or contact
+an unofficial endpoint.
+
 ## Minimal Setup
 
 ```typescript

--- a/.agents/tests/fixtures/knowledge-social-whatsapp/test_whatsapp_ingestion.py
+++ b/.agents/tests/fixtures/knowledge-social-whatsapp/test_whatsapp_ingestion.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Fixture-backed tests for safe WhatsApp ingestion."""
+
+from __future__ import annotations
+
+import ast
+import base64
+import hashlib
+import hmac
+import io
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+import zipfile
+from contextlib import ExitStack, contextmanager, redirect_stdout
+from dataclasses import replace
+from pathlib import Path
+from typing import Iterator
+from unittest import mock
+
+SCRIPTS = Path(__file__).resolve().parents[3] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from _knowledge_social_lease import (  # noqa: E402
+    RunLeaseRequest,
+    acquire_run_lease,
+    release_run_lease,
+)
+from _knowledge_social_whatsapp import persist_batch  # noqa: E402
+from _knowledge_social_whatsapp_export import ExportRequest, parse_export  # noqa: E402
+from _knowledge_social_whatsapp_webhook import (  # noqa: E402
+    WebhookRequest,
+    parse_business_webhook as parse_webhook_request,
+)
+from knowledge_social_store import SocialStoreError  # noqa: E402
+from knowledge_social_whatsapp import main as whatsapp_main  # noqa: E402
+
+OBSERVED_AT = "2026-07-28T08:30:00Z"
+APP_SECRET = b"fixture-secret-not-a-real-credential"
+
+
+def parse_business_webhook(
+    payload: bytes,
+    signature: str,
+    app_secret: bytes,
+    connection_id: str,
+    expected_waba_id: str,
+    expected_phone_number_id: str,
+    observed_at: str,
+):
+    return parse_webhook_request(WebhookRequest(
+        payload, signature, app_secret, connection_id,
+        expected_waba_id, expected_phone_number_id, observed_at,
+    ))
+
+
+def write_zip(path: Path, transcript: str, media: dict[str, bytes] | None = None) -> None:
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("WhatsApp Chat.txt", transcript)
+        for name, payload in (media or {}).items():
+            archive.writestr(name, payload)
+
+
+def export_request(path: Path, connection: str = "conn_export") -> ExportRequest:
+    return ExportRequest(
+        path,
+        connection,
+        "conversation_fixture",
+        "android-us-12h",
+        "+01:00",
+        OBSERVED_AT,
+        16 * 1024 * 1024,
+        100,
+        30,
+    )
+
+
+def assert_isolated_imports(test: unittest.TestCase, target: Path) -> None:
+    tree = ast.parse(target.read_text(encoding="utf-8"))
+    imports = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imports.update(node.module or "" for node in ast.walk(tree) if isinstance(node, ast.ImportFrom))
+    test.assertNotIn("subprocess", imports)
+    test.assertNotIn("socket", imports)
+    test.assertFalse(any(name.startswith(("urllib", "requests", "httpx")) for name in imports))
+    test.assertNotIn("knowledge_social_browser", imports)
+    test.assertNotIn("_knowledge_social_outbound", imports)
+
+
+def blocked_api(*_args, **_kwargs):
+    raise AssertionError("network or subprocess execution attempted")
+
+
+@contextmanager
+def blocked_runtime_apis() -> Iterator[None]:
+    targets = (
+        "socket.socket", "subprocess.Popen", "subprocess.call", "subprocess.run",
+        "subprocess.check_call", "subprocess.check_output", "os.system", "os.popen",
+        "os.spawnv", "os.spawnve",
+    )
+    with ExitStack() as stack:
+        for target in targets:
+            stack.enter_context(mock.patch(target, side_effect=blocked_api))
+        yield
+
+
+def runtime_paths(temporary: str) -> tuple[Path, Path, bytes, str, Path]:
+    transcript = Path(temporary) / "chat.txt"
+    transcript.write_text("7/28/26, 8:01 AM - Alpha: Runtime isolated\n", encoding="utf-8")
+    payload_path = Path(temporary) / "webhook.json"
+    payload = webhook_payload()
+    payload_path.write_bytes(payload)
+    signature = "sha256=" + hmac.new(APP_SECRET, payload, hashlib.sha256).hexdigest()
+    corpus = Path(temporary) / "corpus"
+    corpus.mkdir(mode=0o700)
+    return transcript, payload_path, payload, signature, corpus
+
+
+def persist_runtime_export(corpus: Path, transcript: Path):
+    parsed, raw = parse_export(export_request(transcript))
+    lease = acquire_run_lease(
+        corpus,
+        RunLeaseRequest(
+            "conn_export", "export", "runtime_persist", "sync", 300, parsed.manifest_sha256
+        ),
+    )
+    persisted = persist_batch(corpus, parsed, raw, lease)
+    release_run_lease(corpus, lease)
+    return parsed, persisted
+
+
+def run_export_cli(transcript: Path) -> None:
+    arguments = [
+        "knowledge_social_whatsapp.py", "export", "--archive", str(transcript),
+        "--connection-id", "conn_cli_export", "--conversation-id", "conversation_cli_export",
+        "--format", "android-us-12h", "--timezone", "+01:00", "--observed-at", OBSERVED_AT,
+        "--dry-run",
+    ]
+    with mock.patch.object(sys, "argv", arguments), redirect_stdout(io.StringIO()):
+        if whatsapp_main() != 0:
+            raise AssertionError("export CLI failed")
+
+
+def run_webhook_cli(payload_path: Path, signature: str) -> None:
+    arguments = [
+        "knowledge_social_whatsapp.py", "webhook", "--payload", str(payload_path),
+        "--connection-id", "conn_cli_webhook", "--waba-id", "waba_fixture",
+        "--phone-number-id", "phone_fixture", "--observed-at", OBSERVED_AT, "--dry-run",
+    ]
+    environment = {
+        "WHATSAPP_APP_SECRET": APP_SECRET.decode(),
+        "WHATSAPP_WEBHOOK_SIGNATURE": signature,
+    }
+    with (
+        mock.patch.object(sys, "argv", arguments),
+        mock.patch.dict(os.environ, environment),
+        redirect_stdout(io.StringIO()),
+    ):
+        if whatsapp_main() != 0:
+            raise AssertionError("webhook CLI failed")
+
+
+def webhook_payload(waba: str = "waba_fixture", phone: str = "phone_fixture") -> bytes:
+    value = {
+        "messaging_product": "whatsapp",
+        "metadata": {"display_phone_number": "000000", "phone_number_id": phone},
+        "messages": [
+            {"from": "contact_alpha", "id": "wamid.fixture.text", "timestamp": "1785225660", "text": {"body": "Hello"}, "type": "text"},
+            {"from": "contact_beta", "id": "wamid.fixture.reply", "timestamp": "1785225720", "context": {"id": "wamid.fixture.text"}, "text": {"body": "Reply"}, "type": "text"},
+            {"from": "contact_alpha", "id": "wamid.fixture.react", "timestamp": "1785225780", "reaction": {"message_id": "wamid.fixture.text", "emoji": "+1"}, "type": "reaction"},
+            {"from": "contact_beta", "id": "wamid.fixture.media", "timestamp": "1785225840", "image": {"id": "media_fixture", "mime_type": "image/jpeg", "sha256": base64.b64encode(b"a" * 32).decode(), "caption": "Fixture image"}, "type": "image"},
+        ],
+        "statuses": [
+            {"id": "wamid.fixture.text", "recipient_id": "contact_alpha", "status": "delivered", "timestamp": "1785225900"}
+        ],
+    }
+    root = {"object": "whatsapp_business_account", "entry": [{"id": waba, "changes": [{"field": "messages", "value": value}]}]}
+    return json.dumps(root, separators=(",", ":"), sort_keys=True).encode()
+
+
+def signed_webhook(payload: bytes, connection: str = "conn_webhook"):
+    signature = "sha256=" + hmac.new(APP_SECRET, payload, hashlib.sha256).hexdigest()
+    return parse_business_webhook(
+        payload,
+        signature,
+        APP_SECRET,
+        connection,
+        "waba_fixture",
+        "phone_fixture",
+        OBSERVED_AT,
+    )
+
+
+class WhatsAppExportTests(unittest.TestCase):
+    def test_export_parses_multiline_media_aliases_and_duplicate_occurrences(self) -> None:
+        transcript = "\n".join(
+            (
+                "7/28/26, 8:01 AM - Alpha: First line",
+                "continued line",
+                "7/28/26, 8:02 AM - Beta: fixture.jpg (file attached)",
+                "7/28/26, 8:03 AM - Alpha: repeated",
+                "7/28/26, 8:03 AM - Alpha: repeated",
+            )
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = Path(temporary) / "export.zip"
+            write_zip(archive, transcript, {"fixture.jpg": b"synthetic-image"})
+            parsed, raw = parse_export(export_request(archive))
+        self.assertEqual(hashlib.sha256(raw).hexdigest(), parsed.raw_sha256)
+        self.assertEqual(4, len(parsed.archive["objects"]))
+        self.assertEqual(2, len(parsed.archive["accounts"]))
+        self.assertEqual(1, len(parsed.archive["media"]))
+        self.assertTrue(
+            any("continued line" in record["text"] for record in parsed.archive["objects"])
+        )
+        ids = {record["remote_id"] for record in parsed.archive["objects"]}
+        self.assertEqual(4, len(ids))
+        media = parsed.archive["media"][0]
+        self.assertEqual("embedded_in_raw_archive", media["hydration_state"])
+        self.assertEqual(hashlib.sha256(b"synthetic-image").hexdigest(), media["content_sha256"])
+        coverage = {record["stream"]: record for record in parsed.archive["coverage"]}
+        self.assertEqual("partial", coverage["timestamps"]["status"])
+
+    def test_explicit_dmy_format_and_offset_are_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            transcript = Path(temporary) / "chat.txt"
+            transcript.write_text("28/07/2026, 08:01 - Alpha: Local time\n", encoding="utf-8")
+            request = ExportRequest(
+                transcript,
+                "conn_dmy",
+                "conversation_dmy",
+                "android-dmy-24h",
+                "-04:00",
+                OBSERVED_AT,
+                4096,
+                10,
+                30,
+            )
+            parsed, _raw = parse_export(request)
+        self.assertEqual("2026-07-28T08:01:00-04:00", parsed.archive["objects"][0]["created_at"])
+
+    def test_missing_media_is_explicit_partial_coverage(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = Path(temporary) / "export.zip"
+            write_zip(archive, "7/28/26, 8:01 AM - Alpha: absent.jpg (file attached)")
+            parsed, _raw = parse_export(export_request(archive))
+        coverage = {record["stream"]: record for record in parsed.archive["coverage"]}
+        self.assertEqual("partial", coverage["attachments"]["status"])
+        self.assertEqual("unavailable", coverage["reactions"]["status"])
+        self.assertEqual("unavailable", coverage["history_before_export_window"]["status"])
+
+    def test_malformed_format_and_archive_paths_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            transcript = root / "chat.txt"
+            transcript.write_text("28/07/2026, 08:01 - Alpha: Wrong selected locale\n", encoding="utf-8")
+            with self.assertRaises(SocialStoreError):
+                parse_export(export_request(transcript))
+            archive = root / "unsafe.zip"
+            with zipfile.ZipFile(archive, "w") as target:
+                target.writestr("../WhatsApp Chat.txt", "7/28/26, 8:01 AM - Alpha: Unsafe")
+            with self.assertRaises(SocialStoreError):
+                parse_export(export_request(archive))
+
+    def test_mixed_timestamp_profiles_fail_instead_of_becoming_message_text(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            transcript = Path(temporary) / "chat.txt"
+            transcript.write_text(
+                "7/28/26, 8:01 AM - Alpha: First\n"
+                "28/07/2026, 08:02 - Beta: Mixed locale\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(SocialStoreError):
+                parse_export(export_request(transcript))
+
+    def test_aliases_are_conversation_scoped_and_attribution_is_observed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            transcript = Path(temporary) / "chat.txt"
+            transcript.write_text(
+                "7/28/26, 8:01 AM - Alpha: Setting changed: fixture value\n",
+                encoding="utf-8",
+            )
+            first, _raw = parse_export(export_request(transcript))
+            second_request = replace(
+                export_request(transcript, "conn_other"),
+                conversation_id="conversation_other",
+            )
+            second, _raw = parse_export(second_request)
+        self.assertNotEqual(
+            first.archive["accounts"][0]["remote_id"],
+            second.archive["accounts"][0]["remote_id"],
+        )
+        self.assertEqual("observed", first.archive["objects"][0]["evidence_class"])
+        self.assertEqual(
+            "syntactic_alias_unverified",
+            first.archive["objects"][0]["provider_json"]["attribution_status"],
+        )
+
+    def test_high_compression_ratio_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = Path(temporary) / "compressed.zip"
+            write_zip(
+                archive,
+                "7/28/26, 8:01 AM - Alpha: compressed.bin (file attached)",
+                {"compressed.bin": b"x" * (2 * 1024 * 1024)},
+            )
+            with self.assertRaises(SocialStoreError):
+                parse_export(export_request(archive))
+
+    def test_zip_member_and_elapsed_time_budgets_fail_before_parsing(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = Path(temporary) / "budget.zip"
+            write_zip(
+                archive,
+                "7/28/26, 8:01 AM - Alpha: fixture.txt (file attached)",
+                {"fixture.txt": b"fixture"},
+            )
+            with self.assertRaises(SocialStoreError):
+                parse_export(replace(export_request(archive), max_items=1))
+            with (
+                mock.patch(
+                    "_knowledge_social_whatsapp_export.time.monotonic",
+                    side_effect=[0.0, 2.0],
+                ),
+                self.assertRaises(SocialStoreError),
+            ):
+                parse_export(replace(export_request(archive), max_seconds=1))
+
+    def test_cli_dry_run_reports_plan_without_provisioning_a_corpus(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            transcript = Path(temporary) / "chat.txt"
+            transcript.write_text(
+                "7/28/26, 8:01 AM - Alpha: Planned only\n", encoding="utf-8"
+            )
+            arguments = [
+                str(SCRIPTS / "knowledge_social_whatsapp.py"), "export",
+                "--archive", str(transcript), "--connection-id", "conn_plan",
+                "--conversation-id", "conversation_plan", "--format",
+                "android-us-12h", "--timezone", "+01:00", "--observed-at",
+                OBSERVED_AT, "--dry-run",
+            ]
+            output = io.StringIO()
+            with mock.patch.object(sys, "argv", arguments), redirect_stdout(output):
+                self.assertEqual(0, whatsapp_main())
+        result = json.loads(output.getvalue())
+        self.assertEqual(("planned", True, 1), (result["status"], result["dry_run"], result["objects"]))
+
+
+class WhatsAppWebhookTests(unittest.TestCase):
+    def test_verified_webhook_normalizes_messages_replies_reactions_media_and_status(self) -> None:
+        payload = webhook_payload()
+        parsed = signed_webhook(payload)
+        archive = parsed.archive
+        self.assertEqual(4, len(archive["objects"]))
+        self.assertEqual(2, len(archive["activities"]))
+        self.assertEqual(1, len(archive["media"]))
+        self.assertIsNone(archive["media"][0]["content_sha256"])
+        media_object = next(
+            record for record in archive["objects"] if record["remote_id"] == "wamid.fixture.media"
+        )
+        self.assertIn("provider_media_sha256_b64", media_object["provider_json"])
+        reply = next(record for record in archive["objects"] if record["remote_id"] == "wamid.fixture.reply")
+        self.assertEqual("wamid.fixture.text", reply["provider_json"]["reply_to_message_id"])
+        reaction = next(record for record in archive["activities"] if record["activity_type"] == "reaction")
+        self.assertEqual("wamid.fixture.text", reaction["object_remote_id"])
+        coverage = {record["stream"]: record["status"] for record in archive["coverage"]}
+        self.assertEqual("unavailable", coverage["history_before_connection"])
+        self.assertEqual("unavailable", coverage["personal_and_existing_group_history"])
+        signature = "sha256=" + hmac.new(APP_SECRET, payload, hashlib.sha256).hexdigest()
+        retry = parse_business_webhook(
+            payload,
+            signature,
+            APP_SECRET,
+            "conn_webhook",
+            "waba_fixture",
+            "phone_fixture",
+            "2026-07-28T08:31:00Z",
+        )
+        self.assertEqual(parsed.manifest_sha256, retry.manifest_sha256)
+
+    def test_signature_and_bound_identities_fail_closed(self) -> None:
+        payload = webhook_payload()
+        with self.assertRaises(SocialStoreError):
+            parse_business_webhook(payload, "sha256=" + "0" * 64, APP_SECRET, "conn_bad", "waba_fixture", "phone_fixture", OBSERVED_AT)
+        mismatched = webhook_payload(waba="other_waba")
+        signature = "sha256=" + hmac.new(APP_SECRET, mismatched, hashlib.sha256).hexdigest()
+        with self.assertRaises(SocialStoreError):
+            parse_business_webhook(mismatched, signature, APP_SECRET, "conn_bad", "waba_fixture", "phone_fixture", OBSERVED_AT)
+
+    def test_malformed_context_and_typed_bodies_fail_closed(self) -> None:
+        for mutation in ("context", "media", "reaction"):
+            decoded = json.loads(webhook_payload())
+            messages = decoded["entry"][0]["changes"][0]["value"]["messages"]
+            if mutation == "context":
+                messages[1]["context"] = ""
+            elif mutation == "media":
+                messages[3].pop("image")
+            else:
+                messages[2]["reaction"]["emoji"] = 1
+            payload = json.dumps(decoded, separators=(",", ":"), sort_keys=True).encode()
+            signature = "sha256=" + hmac.new(APP_SECRET, payload, hashlib.sha256).hexdigest()
+            with self.assertRaises(SocialStoreError):
+                parse_business_webhook(
+                    payload,
+                    signature,
+                    APP_SECRET,
+                    "conn_malformed",
+                    "waba_fixture",
+                    "phone_fixture",
+                    OBSERVED_AT,
+                )
+
+    def test_identity_failures_do_not_echo_private_values(self) -> None:
+        private_marker = "private-waba-marker"
+        payload = webhook_payload(waba=private_marker)
+        signature = "sha256=" + hmac.new(APP_SECRET, payload, hashlib.sha256).hexdigest()
+        with self.assertRaises(SocialStoreError) as raised:
+            parse_business_webhook(
+                payload,
+                signature,
+                APP_SECRET,
+                "conn_private",
+                "waba_fixture",
+                "phone_fixture",
+                OBSERVED_AT,
+            )
+        self.assertNotIn(private_marker, str(raised.exception))
+        mismatched = webhook_payload(phone="other_phone")
+        signature = "sha256=" + hmac.new(APP_SECRET, mismatched, hashlib.sha256).hexdigest()
+        with self.assertRaises(SocialStoreError):
+            parse_business_webhook(mismatched, signature, APP_SECRET, "conn_bad", "waba_fixture", "phone_fixture", OBSERVED_AT)
+
+
+class WhatsAppPersistenceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ["AIDEVOPS_TEST_MODE"] = "1"
+
+    def test_export_persistence_is_atomic_and_replay_safe(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            root = base / "corpus"
+            root.mkdir(mode=0o700)
+            archive = base / "export.zip"
+            write_zip(archive, "7/28/26, 8:01 AM - Alpha: Durable\n")
+            parsed, payload = parse_export(export_request(archive))
+            first = acquire_run_lease(root, RunLeaseRequest("conn_export", "export", "fixture_first", "sync", 300, parsed.manifest_sha256))
+            first_result = persist_batch(root, parsed, payload, first)
+            release_run_lease(root, first)
+            second = acquire_run_lease(root, RunLeaseRequest("conn_export", "export", "fixture_second", "sync", 300, parsed.manifest_sha256))
+            second_result = persist_batch(root, parsed, payload, second)
+            release_run_lease(root, second)
+            changed, _payload = parse_export(
+                replace(export_request(archive), timezone_name="+02:00")
+            )
+            revision = acquire_run_lease(
+                root,
+                RunLeaseRequest(
+                    "conn_export",
+                    "export",
+                    "fixture_revision",
+                    "sync",
+                    300,
+                    changed.manifest_sha256,
+                ),
+            )
+            revision_result = persist_batch(root, changed, payload, revision)
+            release_run_lease(root, revision)
+            with sqlite3.connect(root / "index" / "social.db") as database:
+                object_count = database.execute("SELECT count(*) FROM objects WHERE provider='whatsapp'").fetchone()[0]
+                batch_count = database.execute("SELECT count(*) FROM fetch_batches WHERE provider='whatsapp'").fetchone()[0]
+            raw_count = len(list((root / "sources" / "social" / "raw" / "whatsapp" / "conn_export").glob("*.json.gz")))
+        self.assertFalse(first_result["replayed"])
+        self.assertTrue(second_result["replayed"])
+        self.assertFalse(revision_result["replayed"])
+        self.assertEqual((2, 2, 1), (object_count, batch_count, raw_count))
+
+    def test_export_and_webhook_use_separate_streams(self) -> None:
+        parsed = signed_webhook(webhook_payload())
+        self.assertEqual("business_webhook", parsed.stream)
+        self.assertFalse(any(record["stream"] == "history_before_connection" and record["cursor_exhausted"] for record in parsed.archive["coverage"]))
+
+
+class WhatsAppIsolationTests(unittest.TestCase):
+    def test_collector_has_no_network_outbound_or_subprocess_reachability(self) -> None:
+        targets = list(SCRIPTS.glob("*knowledge_social_whatsapp*.py"))
+        self.assertGreaterEqual(len(targets), 5)
+        for target in targets:
+            assert_isolated_imports(self, target)
+
+    def test_runtime_collector_cannot_reach_network_or_process_apis(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            transcript, payload_path, _payload, signature, corpus = runtime_paths(temporary)
+            with blocked_runtime_apis():
+                webhook = signed_webhook(webhook_payload(), "conn_runtime")
+                parsed, persisted = persist_runtime_export(corpus, transcript)
+                run_export_cli(transcript)
+                run_webhook_cli(payload_path, signature)
+        self.assertEqual((1, 4), (len(parsed.archive["objects"]), len(webhook.archive["objects"])))
+        self.assertEqual("complete", persisted["status"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.agents/tests/test-knowledge-social-whatsapp.sh
+++ b/.agents/tests/test-knowledge-social-whatsapp.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-whatsapp.sh — safe export and official webhook tests
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export AIDEVOPS_TEST_MODE=1
+
+exec python3 "${SCRIPT_DIR}/fixtures/knowledge-social-whatsapp/test_whatsapp_ingestion.py"


### PR DESCRIPTION
## Summary

Add bounded user-export parsing and identity-bound official Business webhook ingestion with immutable replay-safe persistence and explicit unsupported-route coverage.

## Files Changed

.agents/content/social-whatsapp.md, .agents/scripts/_knowledge_social_whatsapp.py, .agents/scripts/_knowledge_social_whatsapp_contract.py, .agents/scripts/_knowledge_social_whatsapp_export.py, .agents/scripts/_knowledge_social_whatsapp_export_archive.py, .agents/scripts/_knowledge_social_whatsapp_webhook.py, .agents/scripts/_knowledge_social_whatsapp_webhook_records.py, .agents/scripts/_knowledge_social_whatsapp_zip_guard.py, .agents/scripts/knowledge_social_whatsapp.py, .agents/services/communications/whatsapp.md, .agents/tests/fixtures/knowledge-social-whatsapp/test_whatsapp_ingestion.py, .agents/tests/test-knowledge-social-whatsapp.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified: 17 WhatsApp provider tests, 35 social-sync tests, and 33 corpus tests pass; compileall, ShellCheck, changed lint, Qlty new-file (0 smells), and Qlty regression (50 to 50) pass.

Resolves #28784


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.209 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 15m and 207,215 tokens on this as a headless worker.