### PR TITLE
GH#29041: fix(github): detect standalone signature markers

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -869,7 +869,7 @@ done
 
 # --- --body case -------------------------------------------------------------
 if [[ $_body_idx -ge 0 && -n "$_body_val" ]]; then
-	if [[ "$_body_val" != *"<!-- aidevops:sig -->"* ]]; then
+	if ! grep -Fqx '<!-- aidevops:sig -->' <<<"$_body_val"; then
 		_sig_footer=$("$SIG_HELPER" footer --body "$_body_val" 2>/dev/null || echo "")
 		if [[ -n "$_sig_footer" ]]; then
 			_new_body="${_body_val}${_sig_footer}"
@@ -888,7 +888,7 @@ fi
 # gh call. The temp file is cleaned up by a background reaper because the native
 # transport may outlive setup-time shell traps.
 if [[ $_body_file_idx -ge 0 && -n "$_body_file_val" && -f "$_body_file_val" ]]; then
-	if ! grep -q "<!-- aidevops:sig -->" "$_body_file_val" 2>/dev/null; then
+	if ! grep -Fqx '<!-- aidevops:sig -->' "$_body_file_val" 2>/dev/null; then
 		_file_content=$(<"$_body_file_val") || _file_content=""
 		_sig_footer=$("$SIG_HELPER" footer --body "$_file_content" 2>/dev/null || echo "")
 		if [[ -n "$_sig_footer" ]]; then

--- a/.agents/scripts/gh-api-guards-lib.sh
+++ b/.agents/scripts/gh-api-guards-lib.sh
@@ -166,7 +166,7 @@ _shim_api_inject_body_sig() {
 			case "$_next" in
 			body=@*)
 				_bfile="${_next#body=@}"
-				if [[ -f "$_bfile" ]] && ! grep -q "<!-- aidevops:sig -->" "$_bfile" 2>/dev/null; then
+				if [[ -f "$_bfile" ]] && ! grep -Fqx '<!-- aidevops:sig -->' "$_bfile" 2>/dev/null; then
 					_bval=$(<"$_bfile") || _bval=""
 					_footer=$(_shim_sig_footer_for_body "$_bval") || true
 					[[ -n "$_footer" ]] && printf '%s' "$_footer" >>"$_bfile" || true
@@ -174,7 +174,7 @@ _shim_api_inject_body_sig() {
 				;;
 			body=*)
 				_bval="${_next#body=}"
-				if [[ "$_bval" != *"<!-- aidevops:sig -->"* ]]; then
+				if ! grep -Fqx '<!-- aidevops:sig -->' <<<"$_bval"; then
 					_footer=$(_shim_sig_footer_for_body "$_bval") || {
 						i=$((i + 2))
 						continue
@@ -196,7 +196,7 @@ _shim_api_inject_body_sig() {
 			case "$_kv" in
 			body=@*)
 				_bfile="${_kv#body=@}"
-				if [[ -f "$_bfile" ]] && ! grep -q "<!-- aidevops:sig -->" "$_bfile" 2>/dev/null; then
+				if [[ -f "$_bfile" ]] && ! grep -Fqx '<!-- aidevops:sig -->' "$_bfile" 2>/dev/null; then
 					_bval=$(<"$_bfile") || _bval=""
 					_footer=$(_shim_sig_footer_for_body "$_bval") || true
 					[[ -n "$_footer" ]] && printf '%s' "$_footer" >>"$_bfile" || true
@@ -204,7 +204,7 @@ _shim_api_inject_body_sig() {
 				;;
 			body=*)
 				_bval="${_kv#body=}"
-				if [[ "$_bval" != *"<!-- aidevops:sig -->"* ]]; then
+				if ! grep -Fqx '<!-- aidevops:sig -->' <<<"$_bval"; then
 					_footer=$(_shim_sig_footer_for_body "$_bval") || {
 						i=$((i + 1))
 						continue

--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -412,8 +412,10 @@ cmd_footer() {
 		esac
 	done
 
-	# Dedup: if the body already contains an aidevops signature, skip
-	if [[ -n "$body_to_check" ]] && [[ "$body_to_check" == *"aidevops.sh"* ]]; then
+	# Dedup only on the canonical marker occupying its own complete line.
+	# Root script references and inline marker documentation are body content,
+	# not evidence that a signature footer has already been appended.
+	if [[ -n "$body_to_check" ]] && grep -Fqx '<!-- aidevops:sig -->' <<<"$body_to_check"; then
 		return 0
 	fi
 

--- a/.agents/scripts/gh-write-policy-lib.sh
+++ b/.agents/scripts/gh-write-policy-lib.sh
@@ -906,7 +906,7 @@ _shim_prepare_ephemeral_body_file() {
 		printf '[aidevops][gh-ephemeral-body][BLOCK] Body is not a valid managed triage comment artifact.\n' >&2
 		return 1
 	fi
-	if ! grep -q '<!-- aidevops:sig -->' "$requested_body_file" 2>/dev/null; then
+	if ! grep -Fqx '<!-- aidevops:sig -->' "$requested_body_file" 2>/dev/null; then
 		printf '[aidevops][gh-ephemeral-body][BLOCK] Ephemeral body lacks the canonical signature marker.\n' >&2
 		return 1
 	fi

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -694,7 +694,7 @@ gh_issue_comment() {
 		# _gh_wrapper_auto_sig would create another pathname-backed temp copy.
 		if [[ "$ephemeral_body_file" != /* || ! -f "$ephemeral_body_file" || \
 			-L "$ephemeral_body_file" ]] || \
-			! grep -q '<!-- aidevops:sig -->' "$ephemeral_body_file" 2>/dev/null; then
+			! grep -Fqx '<!-- aidevops:sig -->' "$ephemeral_body_file" 2>/dev/null; then
 			printf '[aidevops][gh-wrapper][BLOCK] Invalid pre-signed ephemeral comment body.\n' >&2
 			return 1
 		fi

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -237,7 +237,7 @@ _rest_body_file_arg() {
 _rest_append_sig() {
 	local body_file="$1"
 	[[ -f "$body_file" ]] || return 0
-	grep -q "<!-- aidevops:sig -->" "$body_file" 2>/dev/null && return 0
+	grep -Fqx '<!-- aidevops:sig -->' "$body_file" 2>/dev/null && return 0
 	local helper="" _cand
 	for _cand in \
 		"${HOME}/.aidevops/agents/scripts/gh-signature-helper.sh" \

--- a/.agents/scripts/shared-gh-wrappers-session.sh
+++ b/.agents/scripts/shared-gh-wrappers-session.sh
@@ -414,8 +414,8 @@ _gh_wrapper_auto_sig() {
 
 	# Handle --body case
 	if [[ $body_idx -ge 0 && -n "$body_val" ]]; then
-		# Already signed — skip
-		[[ "$body_val" == *"<!-- aidevops:sig -->"* ]] && return 0
+		# Already signed — skip only for a standalone canonical marker line.
+		grep -Fqx '<!-- aidevops:sig -->' <<<"$body_val" && return 0
 		local sig_footer
 		sig_footer=$("$sig_helper" footer --body "$body_val" 2>/dev/null || echo "")
 		[[ -z "$sig_footer" ]] && return 0
@@ -434,7 +434,7 @@ _gh_wrapper_auto_sig() {
 	if [[ $body_file_idx -ge 0 && -n "$body_file_val" && -f "$body_file_val" ]]; then
 		local abs_body_file_val
 		abs_body_file_val=$(_gh_wrapper_abs_body_file_path "$body_file_val") || abs_body_file_val="$body_file_val"
-		if grep -q '<!-- aidevops:sig -->' "$abs_body_file_val" 2>/dev/null; then
+		if grep -Fqx '<!-- aidevops:sig -->' "$abs_body_file_val" 2>/dev/null; then
 			if [[ "$bf_is_eq" -eq 1 ]]; then
 				_GH_WRAPPER_SIG_MODIFIED_ARGS[body_file_idx]="--body-file=${abs_body_file_val}"
 			else

--- a/.agents/scripts/tests/lib/test-helpers.sh
+++ b/.agents/scripts/tests/lib/test-helpers.sh
@@ -180,16 +180,27 @@ _test_copy_shared_deps() {
 		fi
 	done <<<"$deps"
 
-	# Second pass: discover sub-library deps from each first-level dep.
-	# Sub-libraries (e.g. shared-gh-wrappers-session.sh) are sourced from
-	# their parent via `source "$_SHARED_GH_WRAPPERS_DIR/<filename>.sh"` or
-	# similar runtime-resolved patterns. Match unconditional source lines
-	# that reference a shared-gh-wrappers-*.sh basename.
-	local sub_deps=""
+	# Recursively discover sub-library deps. Split wrapper modules can source
+	# further shared-gh-wrappers-*.sh modules, so a single second pass leaves
+	# deeper dependencies absent from hermetic test sandboxes.
+	local dep_queue=()
 	while IFS= read -r sibling; do
-		[[ -z "$sibling" ]] && continue
-		local _sub_dep_list
-		_sub_dep_list=$(awk '
+		[[ -n "$sibling" ]] && dep_queue+=("$sibling")
+	done <<<"$deps"
+	local queue_index=0
+	while [[ $queue_index -lt ${#dep_queue[@]} ]]; do
+		sibling="${dep_queue[queue_index]}"
+		queue_index=$((queue_index + 1))
+		local sub_dep
+		while IFS= read -r sub_dep; do
+			[[ -z "$sub_dep" || -f "${dest_dir}/${sub_dep}" ]] && continue
+			[[ -f "${src_dir}/${sub_dep}" ]] || continue
+			if ! cp "${src_dir}/${sub_dep}" "${dest_dir}/${sub_dep}"; then
+				printf 'FAIL: could not copy sub-dep %s to %s\n' "$sub_dep" "$dest_dir" >&2
+				return 1
+			fi
+			dep_queue+=("$sub_dep")
+		done < <(awk '
 			/source.*shared-gh-wrappers-[a-z]/ {
 				line = $0
 				sub(/.*\//, "", line)
@@ -197,21 +208,7 @@ _test_copy_shared_deps() {
 				if (line != "" && line ~ /^shared-gh-wrappers-/) print line
 			}
 		' "${dest_dir}/${sibling}" 2>/dev/null || true)
-		[[ -n "$_sub_dep_list" ]] && sub_deps="${sub_deps}${sub_deps:+
-}${_sub_dep_list}"
-	done <<<"$deps"
-
-	# Copy sub-library deps (skip already-copied files).
-	while IFS= read -r sibling; do
-		[[ -z "$sibling" ]] && continue
-		[[ -f "${dest_dir}/${sibling}" ]] && continue
-		if [[ -f "${src_dir}/${sibling}" ]]; then
-			if ! cp "${src_dir}/${sibling}" "${dest_dir}/${sibling}"; then
-				printf 'FAIL: could not copy sub-dep %s to %s\n' "$sibling" "$dest_dir" >&2
-				return 1
-			fi
-		fi
-	done <<<"$sub_deps"
+	done
 
 	return 0
 }

--- a/.agents/scripts/tests/test-gh-api-sig-footer.sh
+++ b/.agents/scripts/tests/test-gh-api-sig-footer.sh
@@ -140,6 +140,20 @@ printf '%sRunning gh api sig-footer injection tests (t2707 / GH#20350)%s\n' \
 	"$TEST_BLUE" "$TEST_NC"
 
 # =============================================================================
+# Test 0: REST fallback dedup requires a standalone canonical marker line
+# =============================================================================
+_BODY0="${TMP}/body0.md"
+printf 'Documentation mentions <!-- aidevops:sig --> inline.\n' >"$_BODY0"
+_rest_append_sig "$_BODY0"
+marker_count=$(grep -Fxc '<!-- aidevops:sig -->' "$_BODY0" 2>/dev/null || true)
+if [[ "$marker_count" -eq 1 ]]; then
+	pass "REST fallback signs a body containing an inline marker mention"
+else
+	fail "REST fallback signs a body containing an inline marker mention" \
+		"standalone marker count was ${marker_count}, expected 1"
+fi
+
+# =============================================================================
 # Test 1: _rest_issue_create injects sig into body file
 # Use --body-file with a user-owned file so the translator doesn't clean it up
 # (tmp_body_owned=0 when body_file is provided). We can then check the file
@@ -209,10 +223,9 @@ fi
 # Set up a stub SIG_HELPER variable (normally set by the shim at init time).
 SIG_HELPER="$_STUB_SIG_HELPER"
 
-# Source only the function definitions from the shim by temporarily setting
-# a flag that prevents the exec calls and sourcing via a here-doc wrapper.
-# Strategy: use eval to extract the function bodies from the shim.
-_SHIM_SCRIPT="${SCRIPTS_DIR}/gh"
+# Source only the function definitions from the shim API guard library.
+# The shim delegates these helpers to this adjacent module.
+_SHIM_SCRIPT="${SCRIPTS_DIR}/gh-api-guards-lib.sh"
 
 # Extract and define the helper plus its direct signature dependencies.
 # This avoids executing the shim's main body which calls exec.

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -397,6 +397,19 @@ else
 	_fail "--body original content preservation" "argv: $argv"
 fi
 
+# Inline marker prose is not a completed signature footer.
+echo ""
+echo "Test 2a: inline marker prose gets a standalone signature"
+_reset_log
+"$SHIM_RUN" issue comment 123 --repo owner/repo \
+	--body "Documentation mentions <!-- aidevops:sig --> inline" 2>/dev/null
+marker_count=$(grep -Fxc '<!-- aidevops:sig -->' "$STUB_GH_LOG" 2>/dev/null || true)
+if [[ "$marker_count" -eq 1 ]]; then
+	_pass "inline marker prose receives one standalone marker"
+else
+	_fail "inline marker prose signing" "standalone marker appeared $marker_count times, expected 1"
+fi
+
 # =============================================================================
 # Test 3: gh issue comment --body with marker passes through unchanged
 # =============================================================================
@@ -424,7 +437,7 @@ fi
 echo ""
 echo "Test 4: --body-file without marker gets sig appended"
 body_file="$TMP/body.md"
-printf 'unsigned body content\n' >"$body_file"
+printf 'unsigned body cites aidevops.sh:1715\n' >"$body_file"
 _reset_log
 "$SHIM_RUN" issue comment 456 --repo owner/repo --body-file "$body_file" 2>/dev/null
 argv=$(_read_argv)
@@ -434,7 +447,7 @@ if [[ -n "$resolved_body_file" && -f "$resolved_body_file" ]] && grep -q "<!-- a
 else
 	_fail "--body-file sig injection" "argv: $argv"
 fi
-if grep -q "unsigned body content" "$body_file" && ! grep -q "<!-- aidevops:sig -->" "$body_file"; then
+if grep -q "aidevops.sh:1715" "$body_file" && ! grep -q "<!-- aidevops:sig -->" "$body_file"; then
 	_pass "original --body-file content preserved without mutation"
 else
 	_fail "--body-file original preservation" ""
@@ -1060,6 +1073,17 @@ if [[ "$argv" == *"<!-- aidevops:sig -->"* ]] && [[ "$sig_argv" == *$'--no-sessi
 	_pass "deterministic ops REST comments sign without session metrics"
 else
 	_fail "ops REST no-session signature" "argv: $argv sig argv: $sig_argv"
+fi
+
+_reset_log
+inline_api_body='Documentation mentions <!-- aidevops:sig --> inline'
+AIDEVOPS_HEADLESS=1 AIDEVOPS_REPOS_JSON="$repos_json" "$SHIM_RUN" \
+	api /repos/managed/repo/issues/789/comments -X POST -f body="$inline_api_body" 2>/dev/null
+marker_count=$(grep -Fxc '<!-- aidevops:sig -->' "$STUB_GH_LOG" 2>/dev/null || true)
+if [[ "$marker_count" -eq 1 ]]; then
+	_pass "direct REST body with inline marker prose receives a standalone marker"
+else
+	_fail "direct REST inline marker signing" "standalone marker appeared $marker_count times, expected 1"
 fi
 
 repos_json_missing_role="$TMP/repos-missing-role.json"

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -534,6 +534,23 @@ assert_contains "OpenCode CLI override still detects version" "plugin for [OpenC
 rm -rf "$tmp_home_21"
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Test 22: footer dedup uses only a standalone canonical marker line
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 22: footer dedup requires a standalone canonical marker line"
+result=$("$HELPER" footer --body "See aidevops.sh:1715 for the release entry point" \
+	--cli "OpenCode" --model "m" --tokens 1)
+assert_contains "root script reference still receives footer" "<!-- aidevops:sig -->" "$result"
+
+result=$("$HELPER" footer --body "Documentation mentions <!-- aidevops:sig --> inline" \
+	--cli "OpenCode" --model "m" --tokens 1)
+assert_contains "inline marker mention still receives footer" "<!-- aidevops:sig -->" "$result"
+
+result=$("$HELPER" footer --body $'Existing footer\n<!-- aidevops:sig -->\n---\nsigned' \
+	--cli "OpenCode" --model "m" --tokens 1)
+assert_eq "standalone marker suppresses duplicate footer" "" "$result"
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Summary
 # ─────────────────────────────────────────────────────────────────────────────
 echo ""

--- a/.agents/scripts/tests/test-gh-wrapper-auto-sig.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-auto-sig.sh
@@ -143,6 +143,19 @@ done
 assert_eq "body unchanged when already signed" "$original_body" "$body_val"
 assert_not_contains "no stub footer appended" "stub footer" "$body_val"
 
+# Inline documentation of the marker is not a completed footer.
+inline_marker_body="Documentation mentions <!-- aidevops:sig --> inline"
+_gh_wrapper_auto_sig --repo "owner/repo" --title "test" --body "$inline_marker_body"
+body_val=""
+for ((i = 0; i < ${#_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}; i++)); do
+	if [[ "${_GH_WRAPPER_SIG_MODIFIED_ARGS[i]}" == "--body" ]]; then
+		body_val="${_GH_WRAPPER_SIG_MODIFIED_ARGS[i + 1]}"
+		break
+	fi
+done
+marker_count=$(grep -Fxc '<!-- aidevops:sig -->' <<<"$body_val" || true)
+assert_eq "inline marker prose receives one standalone marker" "1" "$marker_count"
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 3: --body=VALUE form (equals syntax)
 # ─────────────────────────────────────────────────────────────────────────────
@@ -315,13 +328,13 @@ assert_eq "marker appears exactly once (no double-sign)" "1" "$marker_count"
 echo ""
 echo "Test 11 (t2393): gh_issue_comment --body-file signs temp copy"
 bf="${TMPDIR_TEST}/issue-body.md"
-printf 'Body from file content' >"$bf"
+printf 'Body from file cites aidevops.sh:1715' >"$bf"
 : >"$GH_STUB_ARGS_FILE"
 : >"$GH_STUB_BODY_FILE_CONTENT"
 gh_issue_comment 19951 --repo "owner/repo" --body-file "$bf"
 file_content=$(<"$bf")
 assert_not_contains "original file did not get signature footer" "<!-- aidevops:sig -->" "$file_content"
-assert_contains "original file still has original content" "Body from file content" "$file_content"
+assert_contains "original file still has root script reference" "aidevops.sh:1715" "$file_content"
 captured=$(<"$GH_STUB_ARGS_FILE")
 assert_contains "gh received --body-file flag" "--body-file" "$captured"
 captured_body_file=""
@@ -353,7 +366,9 @@ else
 	fi
 	captured_file_content=$(<"$GH_STUB_BODY_FILE_CONTENT")
 	assert_contains "gh received temp body-file with signature" "<!-- aidevops:sig -->" "$captured_file_content"
-	assert_contains "gh received temp body-file with original content" "Body from file content" "$captured_file_content"
+	assert_contains "gh received temp body-file with root script reference" "aidevops.sh:1715" "$captured_file_content"
+	marker_count=$(grep -Fxc '<!-- aidevops:sig -->' <<<"$captured_file_content" || true)
+	assert_eq "gh received exactly one standalone marker line" "1" "$marker_count"
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Require the canonical aidevops signature marker to occupy its own line across helper, wrapper, shim, raw API, REST fallback, and ephemeral-body paths; add direct and integrated regressions and repair nested wrapper test dependency copying.

## Files Changed

.agents/scripts/gh, .agents/scripts/gh-api-guards-lib.sh, .agents/scripts/gh-signature-helper.sh, .agents/scripts/gh-write-policy-lib.sh, .agents/scripts/shared-gh-wrappers-create.sh, .agents/scripts/shared-gh-wrappers-rest-fallback.sh, .agents/scripts/shared-gh-wrappers-session.sh, .agents/scripts/tests/lib/test-helpers.sh, .agents/scripts/tests/test-gh-api-sig-footer.sh, .agents/scripts/tests/test-gh-shim.sh, .agents/scripts/tests/test-gh-signature-helper.sh, .agents/scripts/tests/test-gh-wrapper-auto-sig.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: executed helper, wrapper, PATH shim, raw API, REST fallback, and safe-edit test harnesses successfully; bash .agents/scripts/tests/test-gh-signature-helper.sh; bash .agents/scripts/tests/test-gh-wrapper-auto-sig.sh; bash .agents/scripts/tests/test-gh-shim.sh; bash .agents/scripts/tests/test-gh-api-sig-footer.sh; bash .agents/scripts/tests/test-gh-edit-safety.sh; .agents/scripts/linters-local.sh --changed

Resolves #29041


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.209 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 14m and 153,310 tokens on this as a headless worker.