### PR TITLE
GH#29147: Aggregate PR #29127 release provenance

### DIFF
--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -180,7 +180,7 @@ Aggregation PR #29130 reviews authorized Cloudron monitoring PR #29117 at
 recovery and PR #29127 advanced `main` before publication. Its exact branch
 base is `a144e469da47bad93cd3ebfec8cda0a18429c73d`.
 
-The pending aggregation reviews authorized Qlty postflight PR #29127 at
+Aggregation PR #29148 reviews authorized Qlty postflight PR #29127 at
 `c8d6491cdf52e4ab1b8162ee793958bf7c2dfde9` because releases `v3.32.208` and
 `v3.32.209`, plus subsequent merges, advanced `main` before its explicitly
 authorized patch release completed. Its exact branch base is

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -180,6 +180,12 @@ Aggregation PR #29130 reviews authorized Cloudron monitoring PR #29117 at
 recovery and PR #29127 advanced `main` before publication. Its exact branch
 base is `a144e469da47bad93cd3ebfec8cda0a18429c73d`.
 
+The pending aggregation reviews authorized Qlty postflight PR #29127 at
+`c8d6491cdf52e4ab1b8162ee793958bf7c2dfde9` because releases `v3.32.208` and
+`v3.32.209`, plus subsequent merges, advanced `main` before its explicitly
+authorized patch release completed. Its exact branch base is
+`af4dc8979fde7864fd0d7ffc898f47629dd3241e`.
+
 Manual arbitrary-version package publication is intentionally unsupported. A
 recovery operation must use an existing tag that passes the same verifier.
 


### PR DESCRIPTION
## Summary

- Record exact-tip release aggregation PR #29148 for authorized PR #29127.
- Preserve the immutable source manifest in the final follow-up commit without rewriting the published branch.

## Why

The authorized patch release stopped before publication because `main` advanced after PR #29127 merged. The fail-closed release path requires a reviewed aggregation PR at the exact release tip rather than ancestor reachability alone.

## Files

- `.agents/reference/release-publication-controls.md`

## Verification

- `git diff --check`
- `.agents/scripts/linters-local.sh`
- `git interpret-trailers --parse` returns exactly one aggregator identity and one authorized source from the final commit.

## Risk

The change is documentation-only and does not publish a release. The branch preserves the required two-commit review history: the initial commit has no recognized aggregation trailer, while the final commit records exactly one aggregation identity and the authorized `29127@c8d6491cdf52e4ab1b8162ee793958bf7c2dfde9` source manifest.

Resolves #29147

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.209 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol
