### PR TITLE
GH#29141: Preserve GH audit snapshot uncertainty

### DIFF
--- a/.agents/reference/gh-audit-log.md
+++ b/.agents/reference/gh-audit-log.md
@@ -21,9 +21,10 @@ Each log line is a compact JSON object (NDJSON):
   "caller_line": 945,
   "pid": 12345,
   "flags": {"FORCE_ENRICH": "true"},
-  "before": {"title_len": 87, "body_len": 4678, "labels": ["status:in-review", "origin:interactive"]},
-  "after":  {"title_len": 7,  "body_len": 0,    "labels": ["auto-dispatch", "tier:thinking"]},
+  "before": {"capture_status": "ok", "title_len": 87, "body_len": 4678, "labels": ["status:in-review", "origin:interactive"]},
+  "after":  {"capture_status": "ok", "title_len": 7,  "body_len": 0,    "labels": ["auto-dispatch", "tier:thinking"]},
   "delta": {
+    "comparable": true,
     "title_delta_pct": -92,
     "body_delta_pct": -100,
     "labels_removed": ["status:in-review", "origin:interactive"],
@@ -46,9 +47,9 @@ Each log line is a compact JSON object (NDJSON):
 | `caller_line` | integer | `BASH_LINENO` of the call site |
 | `pid` | integer | Process ID of the caller |
 | `flags` | object | Relevant env vars active at call time (e.g. `FORCE_ENRICH`) |
-| `before` | object | Issue/PR state immediately before the operation |
-| `after` | object | Issue/PR state immediately after the operation |
-| `delta` | object | Computed change metrics |
+| `before` | object | Issue/PR state immediately before the operation, or an explicit unavailable snapshot |
+| `after` | object | Issue/PR state immediately after the operation, or an explicit unavailable snapshot |
+| `delta` | object | Computed change metrics; values are null when snapshots are not comparable |
 | `suspicious` | array | Anomaly signal strings (empty = normal operation) |
 
 ### Operation types (`op`)
@@ -66,20 +67,26 @@ Each log line is a compact JSON object (NDJSON):
 
 ```json
 {
+  "capture_status": "ok",
   "title_len": 87,
   "body_len": 4678,
   "labels": ["status:in-review", "origin:interactive"]
 }
 ```
 
-- `title_len`: Character length of the title (0 if unavailable)
-- `body_len`: Character length of the body (0 if unavailable)
-- `labels`: Array of label names at that point in time
+- `capture_status`: `ok` when the GitHub read succeeded; `unavailable` when it failed
+- `title_len`: Character length of the title, or `null` when capture is unavailable
+- `body_len`: Character length of the body, or `null` when capture is unavailable
+- `labels`: Array of label names at that point in time, or `null` when capture is unavailable
+
+Legacy entries without `capture_status` retain their original schema. New entries
+never encode a failed read as zero-length content or an empty label list.
 
 ### Delta object
 
 ```json
 {
+  "comparable": true,
   "title_delta_pct": -92,
   "body_delta_pct": -100,
   "labels_removed": ["status:in-review"],
@@ -87,14 +94,29 @@ Each log line is a compact JSON object (NDJSON):
 }
 ```
 
-- `title_delta_pct`: `(after - before) * 100 / before` (-100 = fully wiped, 0 = no change)
-- `body_delta_pct`: Same formula for body
-- `labels_removed`: Labels present in before but not after
-- `labels_added`: Labels present in after but not before
+- `comparable`: `true` only when both snapshots were captured successfully
+- `title_delta_pct`: `(after - before) * 100 / before` (-100 = fully wiped, 0 = no change), or `null`
+- `body_delta_pct`: Same formula for body, or `null`
+- `labels_removed`: Labels present in before but not after, or `null`
+- `labels_added`: Labels present in after but not before, or `null`
 
 ## Anomaly Taxonomy
 
 The `suspicious[]` array is populated when any of these signals fires:
+
+### `state_capture_unavailable:<phase>`
+
+**Meaning:** The `before` or `after` GitHub state read failed, so no destructive
+delta can be inferred for that operation.
+
+**Normal causes:** Transient network, authentication, or API availability errors.
+
+**Abnormal causes:** Persistent loss of audit visibility or a broken state-read path.
+
+**Investigation:** Verify the current GitHub state and inspect nearby audit entries.
+Do not treat null snapshot fields as proof that content or labels were removed.
+
+---
 
 ### `title_delta_pct<-50`
 
@@ -160,7 +182,7 @@ jq 'select(.repo == "owner/repo")' ~/.aidevops/logs/gh-audit.log | tail -20
 The GitHub Events API records rename and label events independently:
 
 ```bash
-# Show title/body changes (rename events)
+# Show title changes (rename events)
 gh api /repos/OWNER/REPO/issues/NNN/events \
   --jq '[.[] | select(.event == "renamed") | {ts: .created_at, from: .rename.from, to: .rename.to}]'
 
@@ -171,7 +193,8 @@ gh api /repos/OWNER/REPO/issues/NNN/events \
 
 ### Step 3: Restore from before-state
 
-If the audit log captured the before-state before the wipe, restore it:
+If the audit log captured the before-state before the wipe, use its lengths to
+validate candidate recovery sources:
 
 ```bash
 # Extract the before-state from the audit log
@@ -227,10 +250,11 @@ The daily routine `r-gh-audit-scan` runs `gh-audit-anomaly-helper.sh scan`:
 
 The scanner:
 1. Reads entries since the last scan (tracked in `~/.aidevops/logs/gh-audit-scanner.state`)
-2. Filters entries with `suspicious[] | length > 0`, excluding the exact
-   `approval-helper.sh` transition that removes `needs-maintainer-review` after
-   current-state V2 approval verification (the original audit entry remains
-   unchanged)
+2. Filters entries with `suspicious[] | length > 0`, excluding only exact,
+   fully comparable expected transitions: verified issue/PR approval removal of
+   `needs-maintainer-review`, and worker permission blocking that replaces active
+   lifecycle labels with `needs-maintainer-permissions` (the original audit entry
+   remains unchanged)
 3. Files a GitHub issue on `marcusquinn/aidevops` with a summary table when anomalies are found
 
 To run the scanner manually:

--- a/.agents/scripts/gh-audit-anomaly-helper.sh
+++ b/.agents/scripts/gh-audit-anomaly-helper.sh
@@ -33,12 +33,13 @@ init_log_file || true
 # Constants
 # =============================================================================
 
-readonly GH_ANOMALY_VERSION="1.0.0"
+readonly GH_ANOMALY_VERSION="1.1.0"
 readonly GH_ANOMALY_STATE_FILE_DEFAULT="${HOME}/.aidevops/logs/gh-audit-scanner.state"
 readonly GH_ANOMALY_LOG_DIR_DEFAULT="${HOME}/.aidevops/logs"
 readonly GH_ANOMALY_LOG_FILENAME="gh-audit.log"
 readonly GH_ANOMALY_DEFAULT_REPO="marcusquinn/aidevops"
 readonly GH_ANOMALY_NMR_LABEL="needs-maintainer-review"
+readonly GH_ANOMALY_PERMISSION_LABEL="needs-maintainer-permissions"
 # Maximum anomaly entries to include in an issue (prevents overly large issues)
 readonly GH_ANOMALY_MAX_ISSUE_ENTRIES=20
 
@@ -189,29 +190,60 @@ _cmd_scan_collect_anomalies() {
 	if command -v jq &>/dev/null; then
 		# Single jq pass: skip counted lines, emit only actionable anomalies.
 		# Gemini feedback (GH#20145 PR #20153): avoid one-jq-per-line in while read loops.
-		# The approval helper intentionally removes needs-maintainer-review only after
-		# its signed approval checks pass. Keep that transition in the immutable log,
-		# but do not file a daily alert when its complete provenance and delta match.
+		# Verified approvals and permission-block transitions intentionally remove
+		# protected labels. Keep them in the immutable log, but suppress alerts only
+		# when capture, provenance, proof, and the complete semantic delta match.
 		local line filtered_file
 		filtered_file="$(mktemp -t gh-audit-anomaly-filter.XXXXXX)" || {
 			_ga_warn "Could not create anomaly scan buffer"
 			return 1
 		}
+		# aidevops:trust-boundary — fail closed unless each expected transition has
+		# independently meaningful end-state evidence and no extra state change.
 		if ! tail -n +"$((skip_count + 1))" "$log_file" |
-			jq -c --arg nmr "$GH_ANOMALY_NMR_LABEL" '
-				select(try ((.suspicious | length) > 0) catch true)
-				# aidevops:trust-boundary — fail closed unless every approval transition field matches.
-				| select((try (
-					.op == "issue_edit"
-					and .caller_function == "_approval_apply_issue_lifecycle_updates"
+			jq -c --arg nmr "$GH_ANOMALY_NMR_LABEL" --arg permission "$GH_ANOMALY_PERMISSION_LABEL" '
+				def comparable_state:
+					((.before.capture_status // "ok") == "ok")
+					and ((.after.capture_status // "ok") == "ok")
+					and ((.delta.comparable // true) == true);
+				def expected_approval_transition:
+					comparable_state
+					and (
+						(.op == "issue_edit" and .caller_function == "_approval_apply_issue_lifecycle_updates")
+						or (.op == "pr_edit" and .caller_function == "_approval_apply_pr_lifecycle_updates")
+					)
 					and ((.caller_script // "") | endswith("/agents/scripts/approval-helper.sh")
 						or endswith("/.agents/scripts/approval-helper.sh"))
 					and .flags.approval_verified == "v2-current-state"
 					and .suspicious == [("protected_label_removed:" + $nmr)]
 					and (.delta.labels_removed // []) == [$nmr]
 					and (((.delta.labels_added // []) - ["auto-dispatch"]) | length == 0)
+					and (.delta.title_delta_pct == 0)
+					and (.delta.body_delta_pct == 0)
 					and ((.before.labels // []) | index($nmr) != null)
-					and ((.after.labels // []) | index($nmr) == null)
+					and ((.after.labels // []) | index($nmr) == null);
+				def expected_permission_block_transition:
+					comparable_state
+					and .op == "issue_edit"
+					and .caller_function == "permission_apply_block"
+					and ((.caller_script // "") | endswith("/agents/scripts/worker-permission-helper.sh")
+						or endswith("/.agents/scripts/worker-permission-helper.sh"))
+					and ((.after.labels // []) | index($permission) != null)
+					and (((.delta.labels_removed // []) | length) > 0)
+					and (((.delta.labels_removed // []) - [
+						"status:queued", "status:claimed", "status:in-progress", "status:in-review"
+					]) | length == 0)
+					and (((.delta.labels_added // []) - [$permission]) | length == 0)
+					and (.delta.title_delta_pct == 0)
+					and (.delta.body_delta_pct == 0)
+					and ((.suspicious // []) | length > 0)
+					and all(.suspicious[];
+						. == "protected_label_removed:status:claimed"
+						or . == "protected_label_removed:status:in-progress"
+						or . == "protected_label_removed:status:in-review");
+				select(try ((.suspicious | length) > 0) catch true)
+				| select((try (
+					expected_approval_transition or expected_permission_block_transition
 				) catch false) | not)' >"$filtered_file" 2>/dev/null; then
 			rm -f "$filtered_file"
 			_ga_warn "Malformed audit NDJSON detected — checkpoint not advanced"
@@ -273,11 +305,12 @@ BODY
 
 ## Next Steps
 
-1. Review each entry in \`~/.aidevops/logs/gh-audit.log\`
-2. Cross-reference with GitHub events API:
+1. Review each entry in \`~/.aidevops/logs/gh-audit.log\`, including each snapshot's \`capture_status\`.
+2. Verify the current GitHub state and cross-reference the events API:
    \`gh api /repos/OWNER/REPO/issues/N/events --jq '[.[] | select(.event == "renamed")]'\`
-3. If title/body wipe was unintended, restore from the before-state in the log.
-4. See \`reference/gh-audit-log.md\` for the forensics workflow.
+3. A \`state_capture_unavailable:*\` signal means the audit read failed; it is not evidence that content was wiped.
+4. If a destructive edit is confirmed, recover content from GitHub history or a committed backup. The audit log stores lengths, not content.
+5. See \`reference/gh-audit-log.md\` for the forensics workflow.
 
 <!-- gh-audit-anomaly-scanner:${scan_ts} -->
 FOOTER

--- a/.agents/scripts/gh-audit-anomaly-helper.sh
+++ b/.agents/scripts/gh-audit-anomaly-helper.sh
@@ -236,6 +236,12 @@ _cmd_scan_collect_anomalies() {
 					and (((.delta.labels_added // []) - [$permission]) | length == 0)
 					and (.delta.title_delta_pct == 0)
 					and (.delta.body_delta_pct == 0)
+					and ([.after.labels[]? | select(
+						. == "status:queued"
+						or . == "status:claimed"
+						or . == "status:in-progress"
+						or . == "status:in-review"
+					)] | length == 0)
 					and ((.suspicious // []) | length > 0)
 					and all(.suspicious[];
 						. == "protected_label_removed:status:claimed"

--- a/.agents/scripts/gh-audit-log-helper.sh
+++ b/.agents/scripts/gh-audit-log-helper.sh
@@ -20,9 +20,11 @@
 #   caller_line     — line number in caller_script
 #   pid             — process ID of the caller
 #   flags           — object of relevant env vars (FORCE_ENRICH, etc.)
-#   before          — {title_len:N, body_len:N, labels:["l1","l2"]}
-#   after           — {title_len:N, body_len:N, labels:["l1","l2"]}
-#   delta           — {title_delta_pct:N, body_delta_pct:N,
+#   before          — {capture_status:"ok|unavailable", title_len:N|null,
+#                      body_len:N|null, labels:["l1","l2"]|null}
+#   after           — same shape as before
+#   delta           — {comparable:true|false, title_delta_pct:N|null,
+#                      body_delta_pct:N|null,
 #                      labels_removed:[], labels_added:[]}
 #   suspicious      — array of anomaly signal strings (empty = normal)
 #
@@ -53,7 +55,7 @@ init_log_file || true
 # Constants
 # =============================================================================
 
-readonly GH_AUDIT_VERSION="1.0.0"
+readonly GH_AUDIT_VERSION="1.1.0"
 readonly GH_AUDIT_LOG_DIR_DEFAULT="${HOME}/.aidevops/logs"
 readonly GH_AUDIT_LOG_FILENAME="gh-audit.log"
 readonly GH_AUDIT_MAX_SIZE_MB_DEFAULT=10
@@ -337,6 +339,57 @@ _gh_audit_compute_suspicious() {
 	return 0
 }
 
+# Compute anomaly signals when one or both state snapshots were unavailable.
+# Args: before_capture_status after_capture_status
+# Output: JSON array containing phase-specific capture signals.
+_gh_audit_compute_capture_suspicious() {
+	local before_capture_status="$1"
+	local after_capture_status="$2"
+	local signals=""
+
+	if [[ "$before_capture_status" != "ok" ]]; then
+		signals='"state_capture_unavailable:before"'
+	fi
+	if [[ "$after_capture_status" != "ok" ]]; then
+		if [[ -n "$signals" ]]; then
+			signals="${signals},\"state_capture_unavailable:after\""
+		else
+			signals='"state_capture_unavailable:after"'
+		fi
+	fi
+
+	printf '[%s]\n' "$signals"
+	return 0
+}
+
+# Classify whether a captured state JSON value is safe to compare.
+# Legacy records without capture_status remain comparable when all historical
+# fields have their expected types. Missing or null fields are never treated as
+# a successfully captured empty state.
+# Args: state_json
+# Output: ok | unavailable
+_gh_audit_state_capture_status() {
+	local state_json="$1"
+	local status="unavailable"
+
+	if ! command -v jq &>/dev/null; then
+		printf '%s\n' "$status"
+		return 0
+	fi
+	status=$(printf '%s' "$state_json" | jq -r '
+		if ((.capture_status // "ok") == "ok")
+			and ((.title_len | type) == "number")
+			and ((.body_len | type) == "number")
+			and ((.labels | type) == "array")
+		then "ok"
+		else "unavailable"
+		end
+	' 2>/dev/null) || status="unavailable"
+	[[ "$status" == "ok" ]] || status="unavailable"
+	printf '%s\n' "$status"
+	return 0
+}
+
 # Validate that an operation string is in the allowed list.
 # Returns 0 if valid, 1 if not.
 _gh_audit_validate_op() {
@@ -465,6 +518,8 @@ _cmd_record_validate_args() {
 }
 
 # Extract delta fields + suspicious signals from before/after JSON.
+# Deltas are null and comparable=false when either snapshot is unavailable;
+# audit-read failures must never be reported as destructive state changes.
 # Populates caller-scoped output vars: _rd_delta_json, _rd_suspicious_json,
 # _rd_removed_csv.
 # Args: before_json after_json
@@ -473,6 +528,23 @@ _cmd_record_compute_delta() {
 	local before_json="$1" after_json="$2"
 	local before_title_len=0 before_body_len=0 before_labels_csv=""
 	local after_title_len=0 after_body_len=0 after_labels_csv=""
+	local before_capture_status after_capture_status
+	before_capture_status="$(_gh_audit_state_capture_status "$before_json")"
+	after_capture_status="$(_gh_audit_state_capture_status "$after_json")"
+
+	if [[ "$before_capture_status" != "ok" || "$after_capture_status" != "ok" ]]; then
+		if command -v jq &>/dev/null; then
+			_rd_delta_json=$(jq -c -n \
+				'{comparable: false, title_delta_pct: null, body_delta_pct: null,
+				  labels_removed: null, labels_added: null}')
+		else
+			_rd_delta_json='{"comparable":false,"title_delta_pct":null,"body_delta_pct":null,"labels_removed":null,"labels_added":null}'
+		fi
+		_rd_suspicious_json="$(_gh_audit_compute_capture_suspicious \
+			"$before_capture_status" "$after_capture_status")"
+		_rd_removed_csv=""
+		return 0
+	fi
 
 	if command -v jq &>/dev/null; then
 		before_title_len=$(printf '%s' "$before_json" | jq -r '.title_len // 0')
@@ -502,14 +574,15 @@ _cmd_record_compute_delta() {
 
 	if command -v jq &>/dev/null; then
 		_rd_delta_json=$(jq -c -n \
+			--argjson comparable true \
 			--argjson title_delta_pct "$title_delta_pct" \
 			--argjson body_delta_pct "$body_delta_pct" \
 			--argjson labels_removed "$removed_json" \
 			--argjson labels_added "$added_json" \
-			'{title_delta_pct: $title_delta_pct, body_delta_pct: $body_delta_pct,
+			'{comparable: $comparable, title_delta_pct: $title_delta_pct, body_delta_pct: $body_delta_pct,
 			  labels_removed: $labels_removed, labels_added: $labels_added}')
 	else
-		_rd_delta_json="{\"title_delta_pct\":${title_delta_pct},\"body_delta_pct\":${body_delta_pct},\"labels_removed\":${removed_json},\"labels_added\":${added_json}}"
+		_rd_delta_json="{\"comparable\":true,\"title_delta_pct\":${title_delta_pct},\"body_delta_pct\":${body_delta_pct},\"labels_removed\":${removed_json},\"labels_added\":${added_json}}"
 	fi
 
 	_rd_suspicious_json="$(_gh_audit_compute_suspicious \
@@ -569,8 +642,8 @@ _cmd_record_build_event_json() {
 #   --number N       — issue or PR number
 #
 # Optional args (all have safe defaults):
-#   --before-json J  — JSON object: {"title_len":N,"body_len":N,"labels":[]}
-#   --after-json J   — JSON object: {"title_len":N,"body_len":N,"labels":[]}
+#   --before-json J  — captured state object (omitted/invalid = unavailable)
+#   --after-json J   — captured state object (omitted/invalid = unavailable)
 #   --caller-script F
 #   --caller-function FUNC
 #   --caller-line N
@@ -588,9 +661,19 @@ cmd_record() {
 		return 1
 	fi
 
-	# Apply defaults for optional fields.
-	[[ -z "$_rr_before_json" ]] && _rr_before_json='{"title_len":0,"body_len":0,"labels":[]}'
-	[[ -z "$_rr_after_json" ]] && _rr_after_json='{"title_len":0,"body_len":0,"labels":[]}'
+	# Apply defaults for optional fields. Missing or malformed snapshots remain
+	# explicit gaps in audit visibility instead of synthetic empty GitHub state.
+	local unavailable_state='{"capture_status":"unavailable","title_len":null,"body_len":null,"labels":null}'
+	[[ -z "$_rr_before_json" ]] && _rr_before_json="$unavailable_state"
+	[[ -z "$_rr_after_json" ]] && _rr_after_json="$unavailable_state"
+	if command -v jq &>/dev/null; then
+		if ! printf '%s' "$_rr_before_json" | jq -e 'type == "object"' &>/dev/null; then
+			_rr_before_json="$unavailable_state"
+		fi
+		if ! printf '%s' "$_rr_after_json" | jq -e 'type == "object"' &>/dev/null; then
+			_rr_after_json="$unavailable_state"
+		fi
+	fi
 	[[ -z "$_rr_caller_script" ]] && _rr_caller_script="unknown"
 	[[ -z "$_rr_caller_function" ]] && _rr_caller_function="unknown"
 	[[ ! "$_rr_caller_line" =~ ^[0-9]+$ ]] && _rr_caller_line=0

--- a/.agents/scripts/gh-audit-log-helper.sh
+++ b/.agents/scripts/gh-audit-log-helper.sh
@@ -60,6 +60,9 @@ readonly GH_AUDIT_LOG_DIR_DEFAULT="${HOME}/.aidevops/logs"
 readonly GH_AUDIT_LOG_FILENAME="gh-audit.log"
 readonly GH_AUDIT_MAX_SIZE_MB_DEFAULT=10
 readonly GH_AUDIT_MAX_ROTATIONS_DEFAULT=10
+readonly GH_AUDIT_CAPTURE_OK="ok"
+readonly GH_AUDIT_CAPTURE_UNAVAILABLE="unavailable"
+readonly GH_AUDIT_UNAVAILABLE_STATE_JSON='{"capture_status":"unavailable","title_len":null,"body_len":null,"labels":null}'
 
 # Anomaly thresholds
 readonly GH_AUDIT_TITLE_SHRINK_PCT_THRESHOLD=50 # flag if title shrinks >50%
@@ -347,10 +350,10 @@ _gh_audit_compute_capture_suspicious() {
 	local after_capture_status="$2"
 	local signals=""
 
-	if [[ "$before_capture_status" != "ok" ]]; then
+	if [[ "$before_capture_status" != "$GH_AUDIT_CAPTURE_OK" ]]; then
 		signals='"state_capture_unavailable:before"'
 	fi
-	if [[ "$after_capture_status" != "ok" ]]; then
+	if [[ "$after_capture_status" != "$GH_AUDIT_CAPTURE_OK" ]]; then
 		if [[ -n "$signals" ]]; then
 			signals="${signals},\"state_capture_unavailable:after\""
 		else
@@ -370,22 +373,24 @@ _gh_audit_compute_capture_suspicious() {
 # Output: ok | unavailable
 _gh_audit_state_capture_status() {
 	local state_json="$1"
-	local status="unavailable"
+	local status="$GH_AUDIT_CAPTURE_UNAVAILABLE"
 
 	if ! command -v jq &>/dev/null; then
 		printf '%s\n' "$status"
 		return 0
 	fi
-	status=$(printf '%s' "$state_json" | jq -r '
-		if ((.capture_status // "ok") == "ok")
+	status=$(printf '%s' "$state_json" | jq -r \
+		--arg capture_ok "$GH_AUDIT_CAPTURE_OK" \
+		--arg capture_unavailable "$GH_AUDIT_CAPTURE_UNAVAILABLE" '
+		if ((.capture_status // $capture_ok) == $capture_ok)
 			and ((.title_len | type) == "number")
 			and ((.body_len | type) == "number")
 			and ((.labels | type) == "array")
-		then "ok"
-		else "unavailable"
+		then $capture_ok
+		else $capture_unavailable
 		end
-	' 2>/dev/null) || status="unavailable"
-	[[ "$status" == "ok" ]] || status="unavailable"
+	' 2>/dev/null) || status="$GH_AUDIT_CAPTURE_UNAVAILABLE"
+	[[ "$status" == "$GH_AUDIT_CAPTURE_OK" ]] || status="$GH_AUDIT_CAPTURE_UNAVAILABLE"
 	printf '%s\n' "$status"
 	return 0
 }
@@ -532,7 +537,7 @@ _cmd_record_compute_delta() {
 	before_capture_status="$(_gh_audit_state_capture_status "$before_json")"
 	after_capture_status="$(_gh_audit_state_capture_status "$after_json")"
 
-	if [[ "$before_capture_status" != "ok" || "$after_capture_status" != "ok" ]]; then
+	if [[ "$before_capture_status" != "$GH_AUDIT_CAPTURE_OK" || "$after_capture_status" != "$GH_AUDIT_CAPTURE_OK" ]]; then
 		if command -v jq &>/dev/null; then
 			_rd_delta_json=$(jq -c -n \
 				'{comparable: false, title_delta_pct: null, body_delta_pct: null,
@@ -663,15 +668,14 @@ cmd_record() {
 
 	# Apply defaults for optional fields. Missing or malformed snapshots remain
 	# explicit gaps in audit visibility instead of synthetic empty GitHub state.
-	local unavailable_state='{"capture_status":"unavailable","title_len":null,"body_len":null,"labels":null}'
-	[[ -z "$_rr_before_json" ]] && _rr_before_json="$unavailable_state"
-	[[ -z "$_rr_after_json" ]] && _rr_after_json="$unavailable_state"
+	[[ -z "$_rr_before_json" ]] && _rr_before_json="$GH_AUDIT_UNAVAILABLE_STATE_JSON"
+	[[ -z "$_rr_after_json" ]] && _rr_after_json="$GH_AUDIT_UNAVAILABLE_STATE_JSON"
 	if command -v jq &>/dev/null; then
 		if ! printf '%s' "$_rr_before_json" | jq -e 'type == "object"' &>/dev/null; then
-			_rr_before_json="$unavailable_state"
+			_rr_before_json="$GH_AUDIT_UNAVAILABLE_STATE_JSON"
 		fi
 		if ! printf '%s' "$_rr_after_json" | jq -e 'type == "object"' &>/dev/null; then
-			_rr_after_json="$unavailable_state"
+			_rr_after_json="$GH_AUDIT_UNAVAILABLE_STATE_JSON"
 		fi
 	fi
 	[[ -z "$_rr_caller_script" ]] && _rr_caller_script="unknown"

--- a/.agents/scripts/shared-gh-wrappers-safe-edit.sh
+++ b/.agents/scripts/shared-gh-wrappers-safe-edit.sh
@@ -135,67 +135,73 @@ _gh_extract_repo_from_args() {
 
 #######################################
 # Fetch issue state as JSON for the audit log.
-# Non-blocking: returns empty-state JSON on any failure.
+# Non-blocking: returns an explicitly unavailable snapshot on any failure so a
+# read outage can never masquerade as a destructive edit.
 # Args: $1=issue_num $2=repo_slug
-# Output: JSON {"title_len":N,"body_len":N,"labels":["l1",...]}
+# Output: JSON {"capture_status":"ok|unavailable","title_len":N|null,
+#               "body_len":N|null,"labels":["l1",...]|null}
 #######################################
 _gh_audit_fetch_issue_state_json() {
 	local issue_num="$1"
 	local repo="$2"
-	local empty='{"title_len":0,"body_len":0,"labels":[]}'
+	local unavailable='{"capture_status":"unavailable","title_len":null,"body_len":null,"labels":null}'
 
-	[[ -z "$issue_num" || -z "$repo" ]] && echo "$empty" && return 0
-	[[ ! "$issue_num" =~ ^[0-9]+$ ]] && echo "$empty" && return 0
+	[[ -z "$issue_num" || -z "$repo" ]] && printf '%s\n' "$unavailable" && return 0
+	[[ ! "$issue_num" =~ ^[0-9]+$ ]] && printf '%s\n' "$unavailable" && return 0
 	command -v jq &>/dev/null || {
-		echo "$empty"
+		printf '%s\n' "$unavailable"
 		return 0
 	}
 
 	local data
 	data=$(gh issue view "$issue_num" --repo "$repo" \
 		--json title,body,labels 2>/dev/null) || {
-		echo "$empty"
+		printf '%s\n' "$unavailable"
 		return 0
 	}
 
 	jq -c '{
+		capture_status: "ok",
 		title_len: ((.title // "") | length),
 		body_len:  ((.body  // "") | length),
 		labels:    ([.labels[]?.name // empty])
-	}' <<<"$data" 2>/dev/null || echo "$empty"
+	}' <<<"$data" 2>/dev/null || printf '%s\n' "$unavailable"
 	return 0
 }
 
 #######################################
 # Fetch PR state as JSON for the audit log.
-# Non-blocking: returns empty-state JSON on any failure.
+# Non-blocking: returns an explicitly unavailable snapshot on any failure so a
+# read outage can never masquerade as a destructive edit.
 # Args: $1=pr_num $2=repo_slug
-# Output: JSON {"title_len":N,"body_len":N,"labels":["l1",...]}
+# Output: JSON {"capture_status":"ok|unavailable","title_len":N|null,
+#               "body_len":N|null,"labels":["l1",...]|null}
 #######################################
 _gh_audit_fetch_pr_state_json() {
 	local pr_num="$1"
 	local repo="$2"
-	local empty='{"title_len":0,"body_len":0,"labels":[]}'
+	local unavailable='{"capture_status":"unavailable","title_len":null,"body_len":null,"labels":null}'
 
-	[[ -z "$pr_num" || -z "$repo" ]] && echo "$empty" && return 0
-	[[ ! "$pr_num" =~ ^[0-9]+$ ]] && echo "$empty" && return 0
+	[[ -z "$pr_num" || -z "$repo" ]] && printf '%s\n' "$unavailable" && return 0
+	[[ ! "$pr_num" =~ ^[0-9]+$ ]] && printf '%s\n' "$unavailable" && return 0
 	command -v jq &>/dev/null || {
-		echo "$empty"
+		printf '%s\n' "$unavailable"
 		return 0
 	}
 
 	local data
 	data=$(gh pr view "$pr_num" --repo "$repo" \
 		--json title,body,labels 2>/dev/null) || {
-		echo "$empty"
+		printf '%s\n' "$unavailable"
 		return 0
 	}
 
 	jq -c '{
+		capture_status: "ok",
 		title_len: ((.title // "") | length),
 		body_len:  ((.body  // "") | length),
 		labels:    ([.labels[]?.name // empty])
-	}' <<<"$data" 2>/dev/null || echo "$empty"
+	}' <<<"$data" 2>/dev/null || printf '%s\n' "$unavailable"
 	return 0
 }
 
@@ -228,10 +234,15 @@ _gh_audit_record_op() {
 	# aidevops:trust-boundary — caller provenance alone is spoofable. Record the
 	# exemption proof only after independently re-verifying the signed approval
 	# and authenticated actor authority against current GitHub state.
-	if [[ "$op" == "issue_edit" && "$caller_function" == "_approval_apply_issue_lifecycle_updates" ]] &&
-		command -v cmd_verify &>/dev/null; then
+	local approval_target_type=""
+	if [[ "$op" == "issue_edit" && "$caller_function" == "_approval_apply_issue_lifecycle_updates" ]]; then
+		approval_target_type="issue"
+	elif [[ "$op" == "pr_edit" && "$caller_function" == "_approval_apply_pr_lifecycle_updates" ]]; then
+		approval_target_type="pr"
+	fi
+	if [[ -n "$approval_target_type" ]] && command -v cmd_verify &>/dev/null; then
 		local approval_verification=""
-		approval_verification=$(cmd_verify issue "$number" "$repo" --require-authority 2>/dev/null) || approval_verification=""
+		approval_verification=$(cmd_verify "$approval_target_type" "$number" "$repo" --require-authority 2>/dev/null) || approval_verification=""
 		if [[ "$approval_verification" == "VERIFIED" ]]; then
 			flags_json='{"approval_verified":"v2-current-state"}'
 		fi

--- a/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
+++ b/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# Regression coverage for GH#28997: expected signed approval transitions remain
-# audited without generating daily anomaly issues.
+# Regression coverage for GH#28997 and GH#29141: expected lifecycle transitions
+# remain audited without hiding destructive changes or unavailable state reads.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 HELPER="${SCRIPT_DIR}/../gh-audit-anomaly-helper.sh"
+LOG_HELPER="${SCRIPT_DIR}/../gh-audit-log-helper.sh"
 SAFE_EDIT_HELPER="${SCRIPT_DIR}/../shared-gh-wrappers-safe-edit.sh"
 TEST_ROOT=""
 
@@ -27,29 +28,41 @@ TEST_ROOT="$(mktemp -d -t aidevops-gh-anomaly-XXXXXX)"
 LOG_FILE="${TEST_ROOT}/gh-audit.log"
 
 cat >"$LOG_FILE" <<'EOF'
-{"ts":"2026-07-31T00:00:00Z","op":"issue_edit","repo":"example/repo","number":1,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"labels":["needs-maintainer-review"]},"after":{"labels":["auto-dispatch"]},"delta":{"labels_removed":["needs-maintainer-review"],"labels_added":["auto-dispatch"]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
-{"ts":"2026-07-31T00:01:00Z","op":"issue_edit","repo":"example/repo","number":2,"caller_script":"/workspace/.agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"labels":["needs-maintainer-review"]},"after":{"labels":[]},"delta":{"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
-{"ts":"2026-07-31T00:02:00Z","op":"issue_edit","repo":"example/repo","number":3,"caller_script":"/tmp/close-issue.sh","caller_function":"main","before":{"labels":["status:in-review"]},"after":{"labels":["status:done"]},"delta":{"labels_removed":["status:in-review"],"labels_added":["status:done"]},"suspicious":["protected_label_removed:status:in-review"]}
-{"ts":"2026-07-31T00:03:00Z","op":"issue_edit","repo":"example/repo","number":4,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"labels":["needs-maintainer-review"]},"after":{"labels":["auto-dispatch"]},"delta":{"labels_removed":["needs-maintainer-review"],"labels_added":["auto-dispatch"]},"suspicious":["protected_label_removed:needs-maintainer-review","body_delta_pct=-100"]}
-{"ts":"2026-07-31T00:04:00Z","op":"issue_edit","repo":"example/repo","number":5,"caller_script":42,"caller_function":"_approval_apply_issue_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"labels":["needs-maintainer-review"]},"after":{"labels":[]},"delta":{"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
-{"ts":"2026-07-31T00:05:00Z","op":"issue_edit","repo":"example/repo","number":6,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","flags":{},"before":{"labels":["needs-maintainer-review"]},"after":{"labels":[]},"delta":{"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
+{"ts":"2026-07-31T00:00:00Z","op":"issue_edit","repo":"example/repo","number":1,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["auto-dispatch"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["needs-maintainer-review"],"labels_added":["auto-dispatch"]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
+{"ts":"2026-07-31T00:01:00Z","op":"issue_edit","repo":"example/repo","number":2,"caller_script":"/workspace/.agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":[]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
+{"ts":"2026-07-31T00:02:00Z","op":"issue_edit","repo":"example/repo","number":3,"caller_script":"/tmp/close-issue.sh","caller_function":"main","before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:done"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["status:in-review"],"labels_added":["status:done"]},"suspicious":["protected_label_removed:status:in-review"]}
+{"ts":"2026-07-31T00:03:00Z","op":"issue_edit","repo":"example/repo","number":4,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":0,"labels":["auto-dispatch"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":-100,"labels_removed":["needs-maintainer-review"],"labels_added":["auto-dispatch"]},"suspicious":["protected_label_removed:needs-maintainer-review","body_delta_pct=-100"]}
+{"ts":"2026-07-31T00:04:00Z","op":"issue_edit","repo":"example/repo","number":5,"caller_script":42,"caller_function":"_approval_apply_issue_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":[]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
+{"ts":"2026-07-31T00:05:00Z","op":"issue_edit","repo":"example/repo","number":6,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","flags":{},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":[]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
+{"ts":"2026-07-31T00:06:00Z","op":"pr_edit","repo":"example/repo","number":7,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_pr_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":[]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
+{"ts":"2026-07-31T00:07:00Z","op":"pr_edit","repo":"example/repo","number":8,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_pr_lifecycle_updates","flags":{},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":[]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
+{"ts":"2026-07-31T00:08:00Z","op":"issue_edit","repo":"example/repo","number":9,"caller_script":"/runtime/agents/scripts/worker-permission-helper.sh","caller_function":"permission_apply_block","flags":{},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-progress"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-permissions"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["status:in-progress"],"labels_added":["needs-maintainer-permissions"]},"suspicious":["protected_label_removed:status:in-progress"]}
+{"ts":"2026-07-31T00:09:00Z","op":"issue_edit","repo":"example/repo","number":10,"caller_script":"/runtime/agents/scripts/worker-permission-helper.sh","caller_function":"permission_apply_block","flags":{},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-progress"]},"after":{"capture_status":"ok","title_len":1,"body_len":0,"labels":["needs-maintainer-permissions"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":-100,"labels_removed":["status:in-progress"],"labels_added":["needs-maintainer-permissions"]},"suspicious":["protected_label_removed:status:in-progress","body_delta_pct=-100"]}
+{"ts":"2026-07-31T00:10:00Z","op":"issue_edit","repo":"example/repo","number":11,"caller_script":"/runtime/agents/scripts/worker-permission-helper.sh","caller_function":"permission_apply_block","flags":{},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-progress"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":[]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["status:in-progress"],"labels_added":[]},"suspicious":["protected_label_removed:status:in-progress"]}
+{"ts":"2026-07-31T00:11:00Z","op":"issue_edit","repo":"example/repo","number":12,"caller_script":"/runtime/agents/scripts/routine-log-helper.sh","caller_function":"_update_tracking_issue","flags":{},"before":{"capture_status":"ok","title_len":27,"body_len":1822,"labels":["routines","routine-tracking"]},"after":{"capture_status":"unavailable","title_len":null,"body_len":null,"labels":null},"delta":{"comparable":false,"title_delta_pct":null,"body_delta_pct":null,"labels_removed":null,"labels_added":null},"suspicious":["state_capture_unavailable:after"]}
 EOF
 
 output=$(GH_AUDIT_LOG_FILE="$LOG_FILE" GH_ANOMALY_STATE_FILE="${TEST_ROOT}/state.json" \
 	GH_AUDIT_QUIET=true "$HELPER" scan --all --dry-run)
 
-[[ "$output" == *"**Anomalies found:** 4"* ]] || fail "expected transitions were not excluded exactly"
+[[ "$output" == *"**Anomalies found:** 8"* ]] || fail "expected transitions were not excluded exactly"
 [[ "$output" == *"| #3 |"* ]] || fail "unexpected lifecycle transition was hidden"
 [[ "$output" == *"| #4 |"* ]] || fail "approval transition with an additional signal was hidden"
 [[ "$output" == *"| #5 |"* ]] || fail "malformed provenance was dropped instead of retained"
 [[ "$output" == *"| #6 |"* ]] || fail "unverified approval provenance was trusted"
-[[ "$output" != *"| #1 |"* && "$output" != *"| #2 |"* ]] || fail "expected approval transition remained actionable"
+[[ "$output" == *"| #8 |"* ]] || fail "unverified PR approval provenance was trusted"
+[[ "$output" == *"| #10 |"* ]] || fail "permission block with an additional signal was hidden"
+[[ "$output" == *"| #11 |"* ]] || fail "permission block without its blocker label was hidden"
+[[ "$output" == *"| #12 |"* ]] || fail "unavailable state capture was hidden"
+[[ "$output" == *"The audit log stores lengths, not content."* ]] || fail "recovery guidance overclaimed audit content"
+[[ "$output" != *"| #1 |"* && "$output" != *"| #2 |"* && "$output" != *"| #7 |"* && "$output" != *"| #9 |"* ]] ||
+	fail "an exact expected transition remained actionable"
 
 MALFORMED_LOG="${TEST_ROOT}/malformed-audit.log"
 cat >"$MALFORMED_LOG" <<'EOF'
 {"suspicious":[]}
 not-json
-{"ts":"2026-07-31T00:06:00Z","op":"issue_edit","repo":"example/repo","number":9,"caller_function":"main","suspicious":["body_delta_pct=-100"]}
+{"ts":"2026-07-31T00:12:00Z","op":"issue_edit","repo":"example/repo","number":13,"caller_function":"main","suspicious":["body_delta_pct=-100"]}
 EOF
 malformed_rc=0
 GH_AUDIT_LOG_FILE="$MALFORMED_LOG" GH_ANOMALY_STATE_FILE="${TEST_ROOT}/malformed-state.json" \
@@ -62,30 +75,97 @@ source "$SAFE_EDIT_HELPER"
 PROOF_LOG="${TEST_ROOT}/proof-audit.log"
 export GH_AUDIT_LOG_FILE="$PROOF_LOG"
 cmd_verify() {
-	printf 'VERIFIED\n'
-	return 0
+	local target_type="${1:-}"
+	local target_number="${2:-}"
+	if [[ "$target_type" == "issue" && "$target_number" == "20" ]] ||
+		[[ "$target_type" == "pr" && "$target_number" == "21" ]]; then
+		printf 'VERIFIED\n'
+		return 0
+	fi
+	printf 'WRONG_TARGET\n'
+	return 1
 }
 _gh_audit_record_op \
-	"issue_edit" "example/repo" "7" \
+	"issue_edit" "example/repo" "20" \
 	'{"title_len":1,"body_len":1,"labels":["needs-maintainer-review"]}' \
 	'{"title_len":1,"body_len":1,"labels":[]}' \
 	"/runtime/agents/scripts/approval-helper.sh" \
 	"_approval_apply_issue_lifecycle_updates" "1"
-jq -e '.flags.approval_verified == "v2-current-state"' "$PROOF_LOG" >/dev/null ||
+jq -e 'select(.number == 20) | .flags.approval_verified == "v2-current-state"' "$PROOF_LOG" >/dev/null ||
 	fail "successful current-state verification did not produce audit proof"
+_gh_audit_record_op \
+	"pr_edit" "example/repo" "21" \
+	'{"title_len":1,"body_len":1,"labels":["needs-maintainer-review"]}' \
+	'{"title_len":1,"body_len":1,"labels":[]}' \
+	"/runtime/agents/scripts/approval-helper.sh" \
+	"_approval_apply_pr_lifecycle_updates" "1"
+jq -e 'select(.number == 21) | .flags.approval_verified == "v2-current-state"' "$PROOF_LOG" >/dev/null ||
+	fail "successful PR verification did not produce audit proof"
 
 cmd_verify() {
 	printf 'STALE_APPROVAL\n'
 	return 4
 }
 _gh_audit_record_op \
-	"issue_edit" "example/repo" "8" \
+	"pr_edit" "example/repo" "22" \
 	'{"title_len":1,"body_len":1,"labels":["needs-maintainer-review"]}' \
 	'{"title_len":1,"body_len":1,"labels":[]}' \
 	"/runtime/agents/scripts/approval-helper.sh" \
-	"_approval_apply_issue_lifecycle_updates" "1"
-jq -e -s '.[1].flags == {}' "$PROOF_LOG" >/dev/null ||
+	"_approval_apply_pr_lifecycle_updates" "1"
+jq -e -s 'map(select(.number == 22))[0].flags == {}' "$PROOF_LOG" >/dev/null ||
 	fail "failed approval verification produced trusted audit proof"
 unset GH_AUDIT_LOG_FILE
+
+gh() {
+	local resource="${1:-}"
+	if [[ "$resource" != "issue" && "$resource" != "pr" ]]; then
+		return 1
+	fi
+	return 1
+}
+unavailable_issue="$(_gh_audit_fetch_issue_state_json "8" "example/repo")"
+unavailable_pr="$(_gh_audit_fetch_pr_state_json "9" "example/repo")"
+jq -e '.capture_status == "unavailable" and .title_len == null and .body_len == null and .labels == null' \
+	<<<"$unavailable_issue" >/dev/null || fail "failed issue read was encoded as an empty state"
+jq -e '.capture_status == "unavailable" and .title_len == null and .body_len == null and .labels == null' \
+	<<<"$unavailable_pr" >/dev/null || fail "failed PR read was encoded as an empty state"
+
+gh() {
+	local resource="${1:-}"
+	if [[ "$resource" != "issue" && "$resource" != "pr" ]]; then
+		return 1
+	fi
+	printf '%s\n' '{"title":"Protected title","body":"Protected body","labels":[{"name":"monitoring"}]}'
+	return 0
+}
+available_issue="$(_gh_audit_fetch_issue_state_json "8" "example/repo")"
+jq -e '.capture_status == "ok" and .title_len == 15 and .body_len == 14 and .labels == ["monitoring"]' \
+	<<<"$available_issue" >/dev/null || fail "successful issue read was not marked comparable"
+
+CAPTURE_LOG="${TEST_ROOT}/capture-audit.log"
+GH_AUDIT_LOG_FILE="$CAPTURE_LOG" GH_AUDIT_QUIET=true "$LOG_HELPER" record \
+	--op issue_edit --repo example/repo --number 23 \
+	--before-json '{"capture_status":"ok","title_len":1,"body_len":1,"labels":["monitoring"]}' \
+	--after-json '{"capture_status":"unavailable","title_len":null,"body_len":null,"labels":null}' \
+	--caller-script routine-log-helper.sh --caller-function _update_tracking_issue --caller-line 1
+jq -e '
+	.delta.comparable == false
+	and .delta.title_delta_pct == null
+	and .delta.body_delta_pct == null
+	and .delta.labels_removed == null
+	and .delta.labels_added == null
+	and .suspicious == ["state_capture_unavailable:after"]
+' "$CAPTURE_LOG" >/dev/null || fail "unavailable capture produced a destructive delta"
+
+MISSING_CAPTURE_LOG="${TEST_ROOT}/missing-capture-audit.log"
+GH_AUDIT_LOG_FILE="$MISSING_CAPTURE_LOG" GH_AUDIT_QUIET=true "$LOG_HELPER" record \
+	--op issue_edit --repo example/repo --number 24 \
+	--caller-script unknown.sh --caller-function main --caller-line 1
+jq -e '
+	.before.capture_status == "unavailable"
+	and .after.capture_status == "unavailable"
+	and .delta.comparable == false
+	and .suspicious == ["state_capture_unavailable:before", "state_capture_unavailable:after"]
+' "$MISSING_CAPTURE_LOG" >/dev/null || fail "omitted snapshots became synthetic empty state"
 
 printf 'PASS: expected approval transitions are retained in the log but excluded from alerts\n'

--- a/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
+++ b/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
@@ -40,12 +40,13 @@ cat >"$LOG_FILE" <<'EOF'
 {"ts":"2026-07-31T00:09:00Z","op":"issue_edit","repo":"example/repo","number":10,"caller_script":"/runtime/agents/scripts/worker-permission-helper.sh","caller_function":"permission_apply_block","flags":{},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-progress"]},"after":{"capture_status":"ok","title_len":1,"body_len":0,"labels":["needs-maintainer-permissions"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":-100,"labels_removed":["status:in-progress"],"labels_added":["needs-maintainer-permissions"]},"suspicious":["protected_label_removed:status:in-progress","body_delta_pct=-100"]}
 {"ts":"2026-07-31T00:10:00Z","op":"issue_edit","repo":"example/repo","number":11,"caller_script":"/runtime/agents/scripts/worker-permission-helper.sh","caller_function":"permission_apply_block","flags":{},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-progress"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":[]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["status:in-progress"],"labels_added":[]},"suspicious":["protected_label_removed:status:in-progress"]}
 {"ts":"2026-07-31T00:11:00Z","op":"issue_edit","repo":"example/repo","number":12,"caller_script":"/runtime/agents/scripts/routine-log-helper.sh","caller_function":"_update_tracking_issue","flags":{},"before":{"capture_status":"ok","title_len":27,"body_len":1822,"labels":["routines","routine-tracking"]},"after":{"capture_status":"unavailable","title_len":null,"body_len":null,"labels":null},"delta":{"comparable":false,"title_delta_pct":null,"body_delta_pct":null,"labels_removed":null,"labels_added":null},"suspicious":["state_capture_unavailable:after"]}
+{"ts":"2026-07-31T00:12:00Z","op":"issue_edit","repo":"example/repo","number":13,"caller_script":"/runtime/agents/scripts/worker-permission-helper.sh","caller_function":"permission_apply_block","flags":{},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-progress","status:in-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-review","needs-maintainer-permissions"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["status:in-progress"],"labels_added":["needs-maintainer-permissions"]},"suspicious":["protected_label_removed:status:in-progress"]}
 EOF
 
 output=$(GH_AUDIT_LOG_FILE="$LOG_FILE" GH_ANOMALY_STATE_FILE="${TEST_ROOT}/state.json" \
 	GH_AUDIT_QUIET=true "$HELPER" scan --all --dry-run)
 
-[[ "$output" == *"**Anomalies found:** 8"* ]] || fail "expected transitions were not excluded exactly"
+[[ "$output" == *"**Anomalies found:** 9"* ]] || fail "expected transitions were not excluded exactly"
 [[ "$output" == *"| #3 |"* ]] || fail "unexpected lifecycle transition was hidden"
 [[ "$output" == *"| #4 |"* ]] || fail "approval transition with an additional signal was hidden"
 [[ "$output" == *"| #5 |"* ]] || fail "malformed provenance was dropped instead of retained"
@@ -54,6 +55,7 @@ output=$(GH_AUDIT_LOG_FILE="$LOG_FILE" GH_ANOMALY_STATE_FILE="${TEST_ROOT}/state
 [[ "$output" == *"| #10 |"* ]] || fail "permission block with an additional signal was hidden"
 [[ "$output" == *"| #11 |"* ]] || fail "permission block without its blocker label was hidden"
 [[ "$output" == *"| #12 |"* ]] || fail "unavailable state capture was hidden"
+[[ "$output" == *"| #13 |"* ]] || fail "permission block with a lingering active status was hidden"
 [[ "$output" == *"The audit log stores lengths, not content."* ]] || fail "recovery guidance overclaimed audit content"
 [[ "$output" != *"| #1 |"* && "$output" != *"| #2 |"* && "$output" != *"| #7 |"* && "$output" != *"| #9 |"* ]] ||
 	fail "an exact expected transition remained actionable"
@@ -62,7 +64,7 @@ MALFORMED_LOG="${TEST_ROOT}/malformed-audit.log"
 cat >"$MALFORMED_LOG" <<'EOF'
 {"suspicious":[]}
 not-json
-{"ts":"2026-07-31T00:12:00Z","op":"issue_edit","repo":"example/repo","number":13,"caller_function":"main","suspicious":["body_delta_pct=-100"]}
+{"ts":"2026-07-31T00:13:00Z","op":"issue_edit","repo":"example/repo","number":14,"caller_function":"main","suspicious":["body_delta_pct=-100"]}
 EOF
 malformed_rc=0
 GH_AUDIT_LOG_FILE="$MALFORMED_LOG" GH_ANOMALY_STATE_FILE="${TEST_ROOT}/malformed-state.json" \


### PR DESCRIPTION
## Summary

Distinguish unavailable before/after GitHub audit reads from real empty state, retain fail-closed capture-gap alerts, and suppress only fully verified approval or permission-block transitions.

## Files Changed

.agents/reference/gh-audit-log.md, .agents/scripts/gh-audit-anomaly-helper.sh, .agents/scripts/gh-audit-log-helper.sh, .agents/scripts/shared-gh-wrappers-safe-edit.sh, .agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Local linter bundle passed; audit anomaly regression passed; gh edit safety 29/29; approval fallback 50/50; worker permission suite passed; review bundle cbd083bb2ae78f922102568b2c224cf1d004f7777ce30027ee5301d2ca78dd93.

Resolves #29141


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.209 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 21m and 257,756 tokens on this with the user in an interactive session.