### PR TITLE
GH#29151: Prevent trusted NMR automation feedback loops

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -1433,10 +1433,12 @@ _run_preflight_stages() {
 	_preflight_early_dispatch || _pflt_ed_rc=$?
 	_log_substage_timing "preflight_early_dispatch" "$_pflt_ed_start" "$_pflt_ed_rc"
 	# GH#28880: cross-repository label maintenance can take 3-5 minutes. Run it
-	# after the initial fill so already-eligible workers boot in parallel, then
-	# refill once so newly unblocked candidates remain dispatchable this cycle.
+	# after the initial fill so already-eligible workers boot in parallel. Then
+	# reconcile trusted NMR holds and refill once so every newly unblocked
+	# candidate remains dispatchable this cycle.
 	run_stage_with_timeout "preflight_label_maintenance" "$_pflt_timeout" \
 		_preflight_label_maintenance || true
+	_preflight_trusted_nmr_reconcile || true
 	local _pflt_refill_start=$SECONDS
 	local _pflt_refill_rc=0
 	_preflight_post_label_refill || _pflt_refill_rc=$?

--- a/.agents/scripts/pulse-dispatch-preflight-lib.sh
+++ b/.agents/scripts/pulse-dispatch-preflight-lib.sh
@@ -11,8 +11,8 @@
 # re-register as a new function-complexity violation if moved).
 #
 # Each helper groups one phase of preflight work: asynchronous merge-first,
-# cleanup/reap, capacity, early dispatch, label maintenance/refill, ownership
-# reconcile, and prefetch+scope.
+# cleanup/reap, capacity, early dispatch, label maintenance, trusted NMR
+# reconciliation/refill, ownership reconcile, and prefetch+scope.
 #
 # Usage: source "${SCRIPT_DIR}/pulse-dispatch-preflight-lib.sh"
 #
@@ -37,8 +37,8 @@ _PULSE_DISPATCH_PREFLIGHT_LIB_LOADED=1
 # -----------------------------------------------------------------------------
 # The helpers below group related preflight work so _run_preflight_stages
 # stays under 100 lines and each group (merge-first, cleanup/reap, capacity,
-# early dispatch, label maintenance/refill, daily scans, ownership reconcile,
-# and prefetch/scope) can be read independently.
+# early dispatch, label maintenance, trusted NMR reconciliation/refill, daily
+# scans, ownership reconcile, and prefetch/scope) can be read independently.
 
 #######################################
 # Give the existing standalone merge routine a non-blocking head start before
@@ -214,6 +214,17 @@ _preflight_label_maintenance() {
 }
 
 #######################################
+# Reconcile only NMR holds that pass the authority, provenance, breaker, and
+# security gates in auto_approve_maintainer_issues. Running this after the first
+# fill but before candidate snapshot invalidation lets newly trusted candidates
+# enter the same-cycle refill without delaying already-eligible work.
+#######################################
+_preflight_trusted_nmr_reconcile() {
+	run_stage_with_timeout "auto_approve_maintainer_issues" "$PRE_RUN_STAGE_TIMEOUT" auto_approve_maintainer_issues || true
+	return 0
+}
+
+#######################################
 # Early dispatch pass + routine comment responses.
 #
 # Fills available worker slots BEFORE heavy housekeeping. Workers take
@@ -274,8 +285,8 @@ _preflight_post_label_refill() {
 #######################################
 # Ownership normalization + issue reconciliation stages.
 # Ensures active labels reflect ownership (prevents multi-worker overlap),
-# closes issues whose linked PRs already merged, reconciles status:done
-# stuck states, and auto-approves maintainer-created issues.
+# closes issues whose linked PRs already merged, and reconciles status:done
+# stuck states. Trusted NMR reconciliation runs before the refill instead.
 #######################################
 _preflight_ownership_reconcile() {
 	# GH#21470: per-substage timing for the unwrapped prefetch_contribution_watch
@@ -296,9 +307,6 @@ _preflight_ownership_reconcile() {
 	# fetch loop; now 5N → N iterations per cycle.
 	run_stage_with_timeout "reconcile_issues_single_pass" "$PRE_RUN_STAGE_TIMEOUT" reconcile_issues_single_pass || true
 
-	# Auto-approve maintainer issues: remove needs-maintainer-review when
-	# the maintainer created or commented on the issue (GH#16842).
-	run_stage_with_timeout "auto_approve_maintainer_issues" "$PRE_RUN_STAGE_TIMEOUT" auto_approve_maintainer_issues || true
 	return 0
 }
 

--- a/.agents/scripts/pulse-issue-reconcile-parent.sh
+++ b/.agents/scripts/pulse-issue-reconcile-parent.sh
@@ -172,8 +172,8 @@ _Automated by \`_post_parent_decomposition_nudge\` in \`pulse-issue-reconcile-pa
 # Behaviour:
 #   1. Idempotency — if the <!-- parent-needs-decomposition-escalated -->
 #      marker is already present in any comment, returns 1 (no-op).
-#   2. Applies `needs-maintainer-review` so the issue surfaces in the
-#      maintainer's review queue on next interactive session start.
+#   2. Remains advisory-only: parent-task already blocks dispatch, while adding
+#      `needs-maintainer-review` would also block the auto-decomposer scanner.
 #   3. The comment body must explicitly list the four paths forward
 #      (decompose / drop label / close / file children). This is the
 #      final AI-advisory touch before the maintainer decides.
@@ -227,7 +227,7 @@ _post_parent_decomposition_escalation() {
 	local comment_body="${marker}
 ## Parent Task Decomposition — Escalation
 
-The decomposition nudge on this issue has been open for **7+ days** with no action. This issue still carries \`parent-task\` (dispatch blocked), still has zero filed children, and no auto-decompose worker issue is tracking it. Applying \`needs-maintainer-review\` so it surfaces in the maintainer queue.
+The decomposition nudge on this issue has been open for **7+ days** with no action. This issue still carries \`parent-task\` (dispatch blocked), still has zero filed children, and no auto-decompose worker issue is tracking it. This escalation is advisory only; it does not add another dispatch-blocking label.
 
 **Paths forward — pick one:**
 
@@ -241,16 +241,11 @@ The decomposition nudge on this issue has been open for **7+ days** with no acti
 
 3. **Close the issue.** If the work is no longer needed or has been superseded.
 
-4. **Let the auto-decomposer handle it.** If you want a \`tier:thinking\` worker to propose a decomposition plan automatically, remove the \`needs-maintainer-review\` label — the next pulse cycle will file a \`<!-- aidevops:generator=auto-decompose -->\` issue that dispatches a worker to decompose this parent.
+4. **Let the auto-decomposer handle it.** No label change is needed — the next eligible scanner cycle will file a \`<!-- aidevops:generator=auto-decompose -->\` issue that dispatches a \`tier:thinking\` worker to decompose this parent.
 
 See \`.agents/AGENTS.md\` → \"Parent / meta tasks\" (t1986 / t2211 / t2442) for the full rule.
 
 _Automated by \`_post_parent_decomposition_escalation\` in \`pulse-issue-reconcile-parent.sh\` (t2442). Posted once per issue via the \`<!-- parent-needs-decomposition-escalated -->\` marker; re-runs are no-ops._"
-
-	# Apply needs-maintainer-review label. Non-fatal — if it fails we still
-	# want the comment posted so the maintainer sees the escalation.
-	gh issue edit "$parent_num" --repo "$slug" \
-		--add-label "needs-maintainer-review" >/dev/null 2>&1 || true
 
 	gh_issue_comment "$parent_num" --repo "$slug" \
 		--body "$comment_body" >/dev/null 2>&1 || return 1

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -300,10 +300,10 @@ issue_has_required_approval() {
 }
 
 #######################################
-# GH#18671 / t2386: Check whether an NMR label application on an issue
-# corresponds to a *creation-time automation default* — a marker that
-# means "the pulse applied NMR by default, not because retries failed."
-# Creation defaults are safe to auto-clear so the issue can dispatch.
+# GH#18671 / t2386 / GH#29151: Check whether an NMR label application on
+# an issue corresponds to a trusted automation default or deterministic
+# workflow-reapplication marker. These signatures are safe to auto-clear
+# only after reason-coded, circuit-breaker, and security gates have passed.
 #
 # This function used to also match circuit-breaker trip markers
 # (stale-recovery-tick:escalated, cost-circuit-breaker:fired,
@@ -320,43 +320,65 @@ issue_has_required_approval() {
 # creation defaults. See t2386 brief and AGENTS.md
 # "Cryptographic issue/PR approval" for the split semantics.
 #
-# Creation-default signatures detected (t2686 extended set):
+# Automation signatures detected (t2686/GH#29151 extended set):
 #   - source:review-scanner                 — GH#18538 post-merge-review-scanner.sh (comment marker)
 #   - source:review-feedback                — quality-feedback-helper.sh (comment marker)
 #   - quality-feedback-helper.sh            — quality-feedback-helper.sh (comment body marker)
+#   - label-protection-notice                — maintainer-gate workflow reapplication by github-actions[bot]
+#   - parent-needs-decomposition-escalated   — historical parent escalation by the same label actor
 #   - review-followup / source:review-scanner / source:review-feedback labels on issue itself
 #
 # Args:
 #   $1 - issue_num  : GitHub issue number
 #   $2 - slug       : repo slug (owner/repo)
 #   $3 - label_at   : ISO8601 timestamp when NMR label was applied
+#   $4 - label_actor: actor who applied NMR (optional; required for same-actor markers)
 #
 # Exit codes:
-#   0 - creation-default signature found (NMR is a scanner default, safe to auto-clear)
-#   1 - no creation-default signature (NMR is either manual or a breaker trip)
+#   0 - trusted automation signature found (safe to auto-clear after other gates)
+#   1 - no trusted automation signature (NMR is manual, unknown, or a breaker trip)
 #######################################
 _nmr_application_has_automation_signature() {
 	local issue_num="$1"
 	local slug="$2"
 	local label_at="$3"
+	local label_actor="${4:-}"
 
 	[[ -n "$issue_num" && -n "$slug" && -n "$label_at" ]] || return 1
 
-	# Fetch all issue comments once. Filter in jq to any comment posted
-	# within a 60-second window of the label event AND containing a
-	# creation-default marker. Window math: label_at - 5s ≤
+	# Fetch all issue comments once. Flatten paginated responses before filtering
+	# so a marker on a later page cannot be lost. Filter to comments posted within
+	# a 60-second window of the label event AND containing a
+	# trusted automation marker. Window math: label_at - 5s ≤
 	# comment.created_at ≤ label_at + 60s (lower bound covers the API
 	# latency race where the comment posts before the label API call
 	# completes).
-	#
-	# Markers matched (t2686 extended set):
-	#   - source:review-scanner     — post-merge-review-scanner.sh (GH#18538)
-	#   - source:review-feedback    — quality-feedback-helper.sh scan-merged
-	#   - quality-feedback-helper.sh — approval-instructions comment body
+	local comments_json="[]"
+	comments_json=$(gh api "repos/${slug}/issues/${issue_num}/comments" --paginate --slurp 2>/dev/null) || comments_json="[]"
+	[[ -n "$comments_json" && "$comments_json" != "null" ]] || comments_json="[]"
+
 	local has_signature
-	has_signature=$(gh api "repos/${slug}/issues/${issue_num}/comments" --paginate \
-		--jq "[.[] | select((.created_at | fromdateiso8601) >= ((\"${label_at}\" | fromdateiso8601) - 5) and (.created_at | fromdateiso8601) <= ((\"${label_at}\" | fromdateiso8601) + 60)) | .body | select(test(\"source:review-scanner|source:review-feedback|quality-feedback-helper\\\\.sh\"))] | length" \
-		2>/dev/null) || has_signature=0
+	has_signature=$(printf '%s' "$comments_json" | jq -r \
+		--arg label_at "$label_at" --arg label_actor "$label_actor" '
+		(if type == "array" and (.[0]? | type) == "array" then [.[][]]
+		elif type == "array" then . else [] end)
+		| [
+			.[]
+			| select(.created_at != null)
+			| select((.created_at | fromdateiso8601) >= (($label_at | fromdateiso8601) - 5)
+				and (.created_at | fromdateiso8601) <= (($label_at | fromdateiso8601) + 60))
+			| (.body // "") as $body
+			| (.user.login // "") as $commenter
+			| select(
+				($body | test("source:review-scanner|source:review-feedback|quality-feedback-helper\\.sh"))
+				or (($body | contains("label-protection-notice"))
+					and (($commenter | ascii_downcase) == "github-actions[bot]"))
+				or (($body | contains("parent-needs-decomposition-escalated"))
+					and $label_actor != ""
+					and (($commenter | ascii_downcase) == ($label_actor | ascii_downcase)))
+			)
+		] | length
+	' 2>/dev/null) || has_signature=0
 	[[ "$has_signature" =~ ^[0-9]+$ ]] || has_signature=0
 
 	if [[ "$has_signature" -gt 0 ]]; then
@@ -913,7 +935,11 @@ _nmr_temporary_assumption_resolved() {
 	local slug="$2"
 	local code="$3"
 	local label_at="$4"
-	if [[ "$code" == "transient_infrastructure" ]]; then
+	# Recovery-loop markers classify as diagnostic ambiguity, while rate-limit
+	# and zero-session markers classify as transient infrastructure. Both may use
+	# the existing one-retry-per-breaker-release gate; stale/manual diagnostics
+	# remain preserved because _nmr_breaker_release_retry_reason rejects them.
+	if [[ "$code" == "transient_infrastructure" || "$code" == "diagnostic_ambiguity" ]]; then
 		local retry_reason=""
 		retry_reason=$(_nmr_breaker_release_retry_reason "$issue_num" "$slug" "$label_at") || retry_reason=""
 		if [[ -n "$retry_reason" ]]; then
@@ -1075,8 +1101,8 @@ _nmr_actor_event_is_manual_hold() {
 		;;
 	esac
 
-	if [[ -n "$nmr_at" ]] && _nmr_application_has_automation_signature "$issue_num" "$slug" "$nmr_at"; then
-		echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — write-authorized actor=${nmr_actor} but creation-default signature detected — classifying as automation-applied (GH#18671)" >>"$LOGFILE"
+	if [[ -n "$nmr_at" ]] && _nmr_application_has_automation_signature "$issue_num" "$slug" "$nmr_at" "$nmr_actor"; then
+		echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — write-authorized actor=${nmr_actor} but trusted automation signature detected — classifying as automation-applied (GH#18671/GH#29151)" >>"$LOGFILE"
 		return 1
 	fi
 

--- a/.agents/scripts/tests/test-issue-triage-gate-fail-closed.sh
+++ b/.agents/scripts/tests/test-issue-triage-gate-fail-closed.sh
@@ -23,15 +23,23 @@ check_pattern() {
 }
 
 main() {
-	local first_add="" first_create="" persistent_guard=""
+	local first_add="" first_create="" persistent_guard="" trusted_cleanup=""
 	first_add=$(grep -n 'await github\.rest\.issues\.addLabels' "$WORKFLOW" | head -1 | cut -d: -f1)
 	first_create=$(grep -n 'await github\.rest\.issues\.createLabel' "$WORKFLOW" | head -1 | cut -d: -f1)
 	persistent_guard=$(grep -n "issueLabels\.has('persistent')" "$WORKFLOW" | head -1 | cut -d: -f1)
+	trusted_cleanup=$(grep -n 'if (authorIsTrusted)' "$WORKFLOW" | head -1 | cut -d: -f1)
 	TESTS_RUN=$((TESTS_RUN + 1))
 	if [[ "$first_add" =~ ^[0-9]+$ && "$first_create" =~ ^[0-9]+$ && "$first_add" -lt "$first_create" ]]; then
 		printf 'PASS critical label application precedes label creation\n'
 	else
 		printf 'FAIL critical label application does not precede label creation\n' >&2
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$trusted_cleanup" =~ ^[0-9]+$ && "$persistent_guard" =~ ^[0-9]+$ && "$trusted_cleanup" -lt "$persistent_guard" ]]; then
+		printf 'PASS trusted-author NMR cleanup precedes persistent non-task guard\n'
+	else
+		printf 'FAIL persistent non-task guard still bypasses trusted-author cleanup\n' >&2
 		TESTS_FAILED=$((TESTS_FAILED + 1))
 	fi
 	TESTS_RUN=$((TESTS_RUN + 1))
@@ -50,8 +58,8 @@ main() {
 		"bare collaborator association is excluded from trusted roles"
 	check_pattern "collaborators/\{username\}/permission" \
 		"collaborator authority uses the repository permission endpoint"
-	check_pattern "persistent is itself an unconditional" \
-		"persistent bypass documents the remaining dispatch trust boundary"
+	check_pattern "Run trusted-author cleanup first" \
+		"persistent bypass documents trusted cleanup ordering"
 	check_pattern "if \(!issueLabels\.has\(label\)\)" \
 		"absent cleanup labels do not spend removal requests"
 	check_pattern "Review label is applied but welcome comment failed" \

--- a/.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh
+++ b/.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh
@@ -81,11 +81,37 @@ if [[ "${1:-}" == "api" && "$*" == *"/comments"* ]]; then
 	esac
 fi
 
+if [[ "${1:-}" == "api" && "$*" == "api repos/owner/repo/issues/42" ]]; then
+	case "${GH_SCENARIO:-}" in
+		issue-bot-trusted-owner)
+			created_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+			printf '{"user":{"login":"trusted-author"},"author_association":"OWNER","created_at":"%s"}\n' "$created_at"
+			exit 0
+			;;
+		issue-bot-trusted-collab)
+			created_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+			printf '{"user":{"login":"trusted-author"},"author_association":"COLLABORATOR","created_at":"%s"}\n' "$created_at"
+			exit 0
+			;;
+		issue-bot-stale-trusted)
+			printf '{"user":{"login":"trusted-author"},"author_association":"OWNER","created_at":"2020-01-01T00:00:00Z"}\n'
+			exit 0
+			;;
+		issue-bot-trust-api-failure) exit 1 ;;
+		*) printf '{"user":{"login":"external"},"author_association":"NONE","created_at":"2020-01-01T00:00:00Z"}\n'; exit 0 ;;
+	esac
+fi
+
 if [[ "${1:-}" == "api" && "$*" == *"collaborators/trusted-collab/permission"* ]]; then
 	case "${GH_SCENARIO:-}" in
 		issue-permission-failure|pr-permission-failure) exit 1 ;;
 		*) printf 'write\n'; exit 0 ;;
 	esac
+fi
+
+if [[ "${1:-}" == "api" && "$*" == *"collaborators/trusted-author/permission"* ]]; then
+	printf 'write\n'
+	exit 0
 fi
 
 if [[ "${1:-}" == "api" && "$*" == *"/statuses/"* ]]; then
@@ -117,9 +143,10 @@ run_issue_job() {
 	local scenario="$1"
 	local actor="${2:-maintainer}"
 	local labels_json="${3:-[]}"
+	local issue_author="${4:-external}"
 	GH_SCENARIO="$scenario" \
 		ISSUE_NUMBER=42 \
-		ISSUE_AUTHOR=external \
+		ISSUE_AUTHOR="$issue_author" \
 		ACTOR="$actor" \
 		ACTOR_ASSOCIATION=OWNER \
 		ISSUE_LABELS_JSON="$labels_json" \
@@ -199,6 +226,22 @@ test_issue_approval_paths() {
 		print_result "write-collaborator issue approval is accepted" 1 "job returned non-zero"
 	fi
 	assert_no_mutation "write-collaborator issue approval does not restore NMR"
+	: >"$GH_CALLS"
+	if run_issue_job issue-bot-trusted-owner 'github-actions[bot]' '[]' trusted-author >/dev/null 2>&1; then
+		print_result "creation-time bot cleanup is accepted for live OWNER author" 0
+	else
+		print_result "creation-time bot cleanup is accepted for live OWNER author" 1 "job returned non-zero"
+	fi
+	assert_no_mutation "trusted OWNER bot cleanup does not restore NMR"
+	: >"$GH_CALLS"
+	if run_issue_job issue-bot-trusted-collab 'github-actions[bot]' '[]' trusted-author >/dev/null 2>&1; then
+		print_result "creation-time bot cleanup is accepted for write collaborator author" 0
+	else
+		print_result "creation-time bot cleanup is accepted for write collaborator author" 1 "job returned non-zero"
+	fi
+	assert_no_mutation "trusted collaborator bot cleanup does not restore NMR"
+	assert_job_restores_nmr issue issue-bot-trust-api-failure "unverifiable bot cleanup" "github-actions[bot]"
+	assert_job_restores_nmr issue issue-bot-stale-trusted "late bot cleanup of trusted issue" "github-actions[bot]"
 	: >"$GH_CALLS"
 	run_issue_job issue-unsigned maintainer '["persistent"]' >/dev/null 2>&1 || true
 	if grep -q '^issue edit .*--add-label needs-maintainer-review' "$GH_CALLS"; then

--- a/.agents/scripts/tests/test-parent-decomposition-escalation.sh
+++ b/.agents/scripts/tests/test-parent-decomposition-escalation.sh
@@ -11,7 +11,7 @@
 #   1. _compute_parent_nudge_age_hours helper exists and uses GNU+BSD date compat
 #   2. _post_parent_decomposition_escalation helper exists with canonical marker
 #   3. Escalation uses idempotency marker <!-- parent-needs-decomposition-escalated -->
-#   4. Escalation applies needs-maintainer-review label
+#   4. Escalation remains advisory-only and does not apply needs-maintainer-review
 #   5. Escalation comment lists 4 paths forward (decompose / drop / close / auto-decompose)
 #   6. reconcile_completed_parent_tasks declares total_escalated + max_escalations counters
 #   7. Reconcile reads PARENT_DECOMPOSITION_ESCALATION_HOURS env override (default 168h)
@@ -66,6 +66,20 @@ assert_grep_fixed() {
 	return 0
 }
 
+assert_not_grep_fixed() {
+	local label="$1" pattern="$2" file="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if grep -qF -- "$pattern" "$file" 2>/dev/null; then
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  unexpected literal: $pattern"
+		echo "  in file:            $file"
+	else
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	fi
+	return 0
+}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PARENT_TARGET="$SCRIPT_DIR/pulse-issue-reconcile-parent.sh"
 ACTIONS_TARGET="$SCRIPT_DIR/pulse-issue-reconcile-actions.sh"
@@ -111,11 +125,16 @@ assert_grep_fixed \
 	'<!-- parent-needs-decomposition-escalated -->' \
 	"$PARENT_TARGET"
 
-# --- NMR label application ---
+# --- Advisory-only escalation ---
+
+assert_not_grep_fixed \
+	"6a: escalation does not apply needs-maintainer-review label" \
+	'--add-label "needs-maintainer-review"' \
+	"$PARENT_TARGET"
 
 assert_grep_fixed \
-	"6: escalation applies needs-maintainer-review label" \
-	'--add-label "needs-maintainer-review"' \
+	"6b: escalation explicitly describes advisory-only behaviour" \
+	'This escalation is advisory only; it does not add another dispatch-blocking label.' \
 	"$PARENT_TARGET"
 
 # --- Comment body — 4 paths forward ---

--- a/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
@@ -16,8 +16,9 @@
 # an independent stage so each gets its own timeout budget; t3055 then moved
 # those independent stages behind an async post-dispatch lock so housekeeping
 # cannot hold the dispatch cycle open while worker slots drain. GH#28880 also
-# keeps cross-repository label maintenance between two unwrapped fill passes so
-# already-eligible work launches before those sweeps.
+# keeps cross-repository label maintenance and trusted NMR reconciliation
+# between two unwrapped fill passes so already-eligible work launches first and
+# newly unblocked work remains eligible for the same-cycle refill.
 
 set -u
 
@@ -96,7 +97,7 @@ assert_match_count() {
 
 assert_refill_runtime_contract() {
 	local label="$1"
-	local actual_events="" expected_events="dispatch:skip;routine;invalidate:label_maintenance_complete;dispatch:normalize;"
+	local actual_events="" expected_events="dispatch:skip;routine;stage:auto_approve_maintainer_issues:7;nmr;invalidate:label_maintenance_complete;dispatch:normalize;"
 	TESTS_RUN=$((TESTS_RUN + 1))
 	actual_events=$(
 		(
@@ -106,6 +107,7 @@ assert_refill_runtime_contract() {
 			REFILL_EVENTS=""
 			STOP_FLAG=""
 			LOGFILE="/dev/null"
+			PRE_RUN_STAGE_TIMEOUT=7
 
 			_dispatch_invalidate_candidate_snapshot() {
 				local reason="$1"
@@ -124,7 +126,24 @@ assert_refill_runtime_contract() {
 				return 0
 			}
 
+			run_stage_with_timeout() {
+				local stage_name="$1"
+				local stage_timeout="$2"
+				local stage_fn="$3"
+				REFILL_EVENTS="${REFILL_EVENTS}stage:${stage_name}:${stage_timeout};"
+				if "$stage_fn"; then
+					return 0
+				fi
+				return 1
+			}
+
+			auto_approve_maintainer_issues() {
+				REFILL_EVENTS="${REFILL_EVENTS}nmr;"
+				return 0
+			}
+
 			_preflight_early_dispatch
+			_preflight_trusted_nmr_reconcile
 			_preflight_post_label_refill
 			STOP_FLAG="$PREFLIGHT_LIB"
 			_preflight_post_label_refill
@@ -264,6 +283,10 @@ assert_grep \
 	"9d: post-label refill has a dedicated helper" \
 	'^_preflight_post_label_refill\(\)' \
 	"$PREFLIGHT_LIB"
+assert_grep \
+	"9d2: trusted NMR reconciliation has a dedicated helper" \
+	'^_preflight_trusted_nmr_reconcile\(\)' \
+	"$PREFLIGHT_LIB"
 assert_order \
 	"9e: capacity completes before the initial fill" \
 	'^[[:space:]]*run_stage_with_timeout "preflight_capacity"' \
@@ -275,8 +298,13 @@ assert_order \
 	'^[[:space:]]*run_stage_with_timeout "preflight_label_maintenance"' \
 	"$ENGINE"
 assert_order \
-	"9g: label maintenance precedes the same-cycle refill" \
+	"9g: label maintenance precedes trusted NMR reconciliation" \
 	'^[[:space:]]*run_stage_with_timeout "preflight_label_maintenance"' \
+	'^[[:space:]]*_preflight_trusted_nmr_reconcile([[:space:]]|$)' \
+	"$ENGINE"
+assert_order \
+	"9g2: trusted NMR reconciliation precedes the same-cycle refill" \
+	'^[[:space:]]*_preflight_trusted_nmr_reconcile([[:space:]]|$)' \
 	'^[[:space:]]*_preflight_post_label_refill([[:space:]]|$)' \
 	"$ENGINE"
 assert_order \
@@ -297,8 +325,13 @@ assert_match_count \
 	'^[[:space:]]*dispatch_routine_comment_responses[[:space:]]*\|\|[[:space:]]*true' \
 	1 \
 	"$PREFLIGHT_LIB"
+assert_match_count \
+	"9k2: trusted NMR reconciliation runs exactly once per preflight" \
+	'^[[:space:]]*run_stage_with_timeout "auto_approve_maintainer_issues"' \
+	1 \
+	"$PREFLIGHT_LIB"
 assert_refill_runtime_contract \
-	"9l: initial fill skips dependency normalization and refill restores the default"
+	"9l: trusted NMR reconciliation completes before the normalized refill"
 
 # --- Benign expected dispatch blocks must not be surfaced as generic stage failures ---
 

--- a/.agents/scripts/tests/test-pulse-nmr-automation-signature.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-automation-signature.sh
@@ -15,9 +15,10 @@
 # loop (22 watchdog kills, 5 auto-approve cycles in one afternoon).
 #
 # Post-fix semantics:
-#   - _nmr_application_has_automation_signature  →  matches ONLY
-#     creation defaults (source:review-scanner marker/label,
-#     review-followup label). These can be auto-cleared.
+#   - _nmr_application_has_automation_signature  →  matches ONLY trusted
+#     automation defaults/provenance (scanner markers/labels and bounded
+#     workflow reapplication markers). These can be auto-cleared after
+#     reason, breaker, and security gates pass.
 #   - _nmr_application_is_circuit_breaker_trip   →  matches ONLY
 #     breaker trips (stale-recovery-tick:escalated,
 #     cost-circuit-breaker:fired, dispatch-backoff:rate_limit_nmr,
@@ -61,6 +62,7 @@ setup_test_env() {
 	mkdir -p "${TEST_ROOT}/bin"
 	export PATH="${TEST_ROOT}/bin:${PATH}"
 	export LOGFILE="${TEST_ROOT}/pulse.log"
+	export AIDEVOPS_NMR_REVALIDATION_STATE_FILE="${TEST_ROOT}/nmr-state.json"
 	: >"$LOGFILE"
 	COMMENTS_FIXTURE="${TEST_ROOT}/comments.json"
 	ISSUE_META_FIXTURE="${TEST_ROOT}/issue-meta.json"
@@ -145,64 +147,19 @@ set_timeline() {
 	printf '%s\n' "$body" >"$TIMELINE_FIXTURE"
 }
 
-# Extract helpers from the source file. Same awk-extract-and-eval
-# pattern used by the force-dispatch and bot-cleanup test suites.
 define_helpers_under_test() {
-	local sig_src breaker_src history_src security_src sort_src current_src retry_event_src retry_used_src retry_src maint_src
-	sig_src=$(awk '
-		/^_nmr_application_has_automation_signature\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	breaker_src=$(awk '
-		/^_nmr_application_is_circuit_breaker_trip\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	history_src=$(awk '
-		/^_nmr_application_has_breaker_history\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	security_src=$(awk '
-		/^_nmr_application_is_security_sensitive\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	sort_src=$(awk '
-		/^_nmr_version_sort_key\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	current_src=$(awk '
-		/^_nmr_current_aidevops_version\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	retry_event_src=$(awk '
-		/^_nmr_retry_breaker_event_json\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	retry_used_src=$(awk '
-		/^_nmr_retry_already_used_for_version\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	retry_src=$(awk '
-		/^_nmr_breaker_release_retry_reason\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	maint_src=$(awk '
-		/^_nmr_applied_by_maintainer\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	if [[ -z "$sig_src" || -z "$breaker_src" || -z "$history_src" || -z "$security_src" || -z "$sort_src" || -z "$current_src" || -z "$retry_event_src" || -z "$retry_used_src" || -z "$retry_src" || -z "$maint_src" ]]; then
-		printf 'ERROR: could not extract one of the NMR helpers from %s\n' "$NMR_SCRIPT" >&2
-		return 1
-	fi
+	unset _PULSE_NMR_APPROVAL_LOADED
 	# shellcheck disable=SC1090
-	eval "$sig_src"
-	# shellcheck disable=SC1090
-	eval "$breaker_src"
-	# shellcheck disable=SC1090
-	eval "$history_src"
-	# shellcheck disable=SC1090
-	eval "$security_src"
-	# shellcheck disable=SC1090
-	eval "$sort_src"
-	# shellcheck disable=SC1090
-	eval "$current_src"
-	# shellcheck disable=SC1090
-	eval "$retry_event_src"
-	# shellcheck disable=SC1090
-	eval "$retry_used_src"
-	# shellcheck disable=SC1090
-	eval "$retry_src"
-	# shellcheck disable=SC1090
-	eval "$maint_src"
+	source "$NMR_SCRIPT"
+	_nmr_record_revalidation_state() { return 0; }
+	_nmr_emit_decision_packet() { return 0; }
+	_notify_stale_recovery_resolved_by_pr() { return 0; }
+	_gh_actor_has_repo_write_authority() {
+		local repo_slug="$1" actor="$2" association="${3:-}"
+		[[ -n "$repo_slug" && -n "$association" ]] || return 2
+		[[ "$actor" != "external-contributor" ]]
+		return $?
+	}
 	return 0
 }
 
@@ -346,6 +303,61 @@ test_signature_detects_source_review_feedback_comment_marker() {
 		return 0
 	fi
 	print_result "signature detects source:review-feedback comment marker (t2686)" 1
+	return 0
+}
+
+test_signature_detects_actions_label_protection_notice() {
+	set_comments '[{"created_at":"2026-04-21T01:49:38Z","body":"<!-- label-protection-notice -->","user":{"login":"github-actions[bot]"}}]'
+	set_issue_meta '{"labels":[]}'
+	if _nmr_application_has_automation_signature 2572 exampleorg/examplerepo "2026-04-21T01:49:36Z" "github-actions[bot]"; then
+		print_result "signature detects actions label-protection workflow residue" 0
+		return 0
+	fi
+	print_result "signature detects actions label-protection workflow residue" 1
+	return 0
+}
+
+test_signature_detects_actions_notice_on_later_page() {
+	set_comments '[[{"created_at":"2026-04-21T01:49:38Z","body":"unrelated","user":{"login":"github-actions[bot]"}}],[{"created_at":"2026-04-21T01:49:40Z","body":"<!-- label-protection-notice -->","user":{"login":"github-actions[bot]"}}]]'
+	set_issue_meta '{"labels":[]}'
+	if _nmr_application_has_automation_signature 2572 exampleorg/examplerepo "2026-04-21T01:49:36Z" "github-actions[bot]"; then
+		print_result "signature detects workflow residue on later paginated page" 0
+		return 0
+	fi
+	print_result "signature detects workflow residue on later paginated page" 1
+	return 0
+}
+
+test_signature_rejects_external_label_protection_text() {
+	set_comments '[{"created_at":"2026-04-21T01:49:38Z","body":"<!-- label-protection-notice -->","user":{"login":"external-contributor"}}]'
+	set_issue_meta '{"labels":[]}'
+	if _nmr_application_has_automation_signature 2572 exampleorg/examplerepo "2026-04-21T01:49:36Z" "github-actions[bot]"; then
+		print_result "signature rejects attacker-copied label-protection text" 1
+		return 0
+	fi
+	print_result "signature rejects attacker-copied label-protection text" 0
+	return 0
+}
+
+test_signature_detects_same_actor_parent_escalation() {
+	set_comments '[{"created_at":"2026-04-21T01:49:38Z","body":"<!-- parent-needs-decomposition-escalated -->","user":{"login":"runner"}}]'
+	set_issue_meta '{"labels":[]}'
+	if _nmr_application_has_automation_signature 2572 exampleorg/examplerepo "2026-04-21T01:49:36Z" runner; then
+		print_result "signature detects historical same-actor parent escalation" 0
+		return 0
+	fi
+	print_result "signature detects historical same-actor parent escalation" 1
+	return 0
+}
+
+test_signature_rejects_other_actor_parent_escalation() {
+	set_comments '[{"created_at":"2026-04-21T01:49:38Z","body":"<!-- parent-needs-decomposition-escalated -->","user":{"login":"external-contributor"}}]'
+	set_issue_meta '{"labels":[]}'
+	if _nmr_application_has_automation_signature 2572 exampleorg/examplerepo "2026-04-21T01:49:36Z" runner; then
+		print_result "signature rejects copied parent escalation from another actor" 1
+		return 0
+	fi
+	print_result "signature rejects copied parent escalation from another actor" 0
 	return 0
 }
 
@@ -843,7 +855,7 @@ main() {
 		return 1
 	fi
 
-	# _nmr_application_has_automation_signature (creation defaults only)
+	# _nmr_application_has_automation_signature (trusted automation only)
 	test_signature_rejects_stale_recovery_marker
 	test_signature_rejects_cost_circuit_breaker_marker
 	test_signature_rejects_circuit_breaker_escalated_marker
@@ -854,6 +866,11 @@ main() {
 	test_signature_detects_source_review_feedback_label_fallback
 	test_signature_detects_quality_feedback_helper_comment_marker
 	test_signature_detects_source_review_feedback_comment_marker
+	test_signature_detects_actions_label_protection_notice
+	test_signature_detects_actions_notice_on_later_page
+	test_signature_rejects_external_label_protection_text
+	test_signature_detects_same_actor_parent_escalation
+	test_signature_rejects_other_actor_parent_escalation
 	test_signature_ignores_unrelated_comment_in_window
 	test_signature_detects_lower_bound_comment_before_label
 	test_signature_empty_args_returns_nonzero

--- a/.agents/scripts/tests/test-pulse-nmr-scanner-label-breaker-trip.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-scanner-label-breaker-trip.sh
@@ -65,6 +65,7 @@ setup_test_env() {
 	mkdir -p "${TEST_ROOT}/bin"
 	export PATH="${TEST_ROOT}/bin:${PATH}"
 	export LOGFILE="${TEST_ROOT}/pulse.log"
+	export AIDEVOPS_NMR_REVALIDATION_STATE_FILE="${TEST_ROOT}/nmr-state.json"
 	: >"$LOGFILE"
 	COMMENTS_FIXTURE="${TEST_ROOT}/comments.json"
 	ISSUE_META_FIXTURE="${TEST_ROOT}/issue-meta.json"
@@ -149,63 +150,19 @@ set_timeline() {
 	return 0
 }
 
-# Extract the helper chain used by _nmr_applied_by_maintainer from the source file.
 define_helpers_under_test() {
-	local sig_src breaker_src history_src security_src sort_src current_src retry_event_src retry_used_src retry_src maint_src
-	sig_src=$(awk '
-		/^_nmr_application_has_automation_signature\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	breaker_src=$(awk '
-		/^_nmr_application_is_circuit_breaker_trip\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	history_src=$(awk '
-		/^_nmr_application_has_breaker_history\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	security_src=$(awk '
-		/^_nmr_application_is_security_sensitive\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	sort_src=$(awk '
-		/^_nmr_version_sort_key\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	current_src=$(awk '
-		/^_nmr_current_aidevops_version\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	retry_event_src=$(awk '
-		/^_nmr_retry_breaker_event_json\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	retry_used_src=$(awk '
-		/^_nmr_retry_already_used_for_version\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	retry_src=$(awk '
-		/^_nmr_breaker_release_retry_reason\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	maint_src=$(awk '
-		/^_nmr_applied_by_maintainer\(\) \{/,/^}$/ { print }
-	' "$NMR_SCRIPT")
-	if [[ -z "$sig_src" || -z "$breaker_src" || -z "$history_src" || -z "$security_src" || -z "$sort_src" || -z "$current_src" || -z "$retry_event_src" || -z "$retry_used_src" || -z "$retry_src" || -z "$maint_src" ]]; then
-		printf 'ERROR: could not extract one of the NMR helpers from %s\n' "$NMR_SCRIPT" >&2
-		return 1
-	fi
+	unset _PULSE_NMR_APPROVAL_LOADED
 	# shellcheck disable=SC1090
-	eval "$sig_src"
-	# shellcheck disable=SC1090
-	eval "$breaker_src"
-	# shellcheck disable=SC1090
-	eval "$history_src"
-	# shellcheck disable=SC1090
-	eval "$security_src"
-	# shellcheck disable=SC1090
-	eval "$sort_src"
-	# shellcheck disable=SC1090
-	eval "$current_src"
-	# shellcheck disable=SC1090
-	eval "$retry_event_src"
-	# shellcheck disable=SC1090
-	eval "$retry_used_src"
-	# shellcheck disable=SC1090
-	eval "$retry_src"
-	# shellcheck disable=SC1090
-	eval "$maint_src"
+	source "$NMR_SCRIPT"
+	_nmr_record_revalidation_state() { return 0; }
+	_nmr_emit_decision_packet() { return 0; }
+	_notify_stale_recovery_resolved_by_pr() { return 0; }
+	_gh_actor_has_repo_write_authority() {
+		local repo_slug="$1" actor="$2" association="${3:-}"
+		[[ -n "$repo_slug" && -n "$association" ]] || return 2
+		[[ "$actor" != "external-contributor" ]]
+		return $?
+	}
 	return 0
 }
 

--- a/.github/workflows/issue-triage-gate.yml
+++ b/.github/workflows/issue-triage-gate.yml
@@ -30,14 +30,6 @@ jobs:
               return;
             }
 
-            // #aidevops:trust-boundary — persistent is itself an unconditional
-            // dispatch blocker. If that label is later removed, Pulse applies
-            // the ordinary author trust gate before any task lifecycle action.
-            if (issueLabels.has('persistent')) {
-              console.log(`Issue #${issue.number} is persistent — bypassing task triage`);
-              return;
-            }
-
             // OWNER/MEMBER are authoritative associations. COLLABORATOR can
             // represent read/triage access, so require a live write-level lookup.
             const trustedRoles = ['OWNER', 'MEMBER'];
@@ -76,6 +68,15 @@ jobs:
                   core.warning(`Unable to remove stale review label: ${error.message}`);
                 }
               }
+              return;
+            }
+
+            // #aidevops:trust-boundary — persistent is itself an unconditional
+            // dispatch blocker. Run trusted-author cleanup first so dashboards
+            // do not retain a redundant NMR label; untrusted persistent issues
+            // still stop here before any task lifecycle labels are added.
+            if (issueLabels.has('persistent')) {
+              console.log(`Issue #${issue.number} is persistent — bypassing task triage`);
               return;
             }
 

--- a/.github/workflows/maintainer-gate-reusable.yml
+++ b/.github/workflows/maintainer-gate-reusable.yml
@@ -553,11 +553,61 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
           ACTOR: ${{ github.actor }}
-          ACTOR_ASSOCIATION: ${{ github.event.issue.author_association }}
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Label 'needs-maintainer-review' removed from issue #$ISSUE_NUMBER by $ACTOR"
+
+          issue_author_has_live_authority() {
+            local issue_json="$1"
+            local identity="" author="" association="" permission=""
+            if ! identity=$(printf '%s' "$issue_json" | jq -r '
+              if (.user.login // "") != "" and (.author_association // "") != ""
+              then [(.user.login // ""), (.author_association // "")] | @tsv
+              else error("missing live issue author metadata") end
+            ' 2>/dev/null); then
+              return 2
+            fi
+            IFS=$'\t' read -r author association <<< "$identity"
+            [[ "$author" == "$ISSUE_AUTHOR" ]] || return 2
+            case "$association" in
+              OWNER|MEMBER) return 0 ;;
+              COLLABORATOR) ;;
+              *) return 1 ;;
+            esac
+            if ! permission=$(gh api "repos/${REPO}/collaborators/${author}/permission" \
+              --jq '.permission // "none"' 2>/dev/null); then
+              return 2
+            fi
+            case "$permission" in
+              admin|maintain|write) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
+          trusted_bot_open_cleanup_is_allowed() {
+            local issue_json="" created_at="" created_epoch="" now_epoch="" age_seconds="" authority_rc=0
+            [[ "$ACTOR" == "github-actions[bot]" ]] || return 1
+            if ! issue_json=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" 2>/dev/null); then
+              return 2
+            fi
+            created_at=$(printf '%s' "$issue_json" | jq -r '.created_at // ""' 2>/dev/null) || return 2
+            [[ -n "$created_at" ]] || return 2
+            if date --version >/dev/null 2>&1; then
+              created_epoch=$(date -u -d "$created_at" '+%s' 2>/dev/null) || return 2
+            else
+              created_epoch=$(date -j -u -f '%Y-%m-%dT%H:%M:%SZ' "$created_at" '+%s' 2>/dev/null) || return 2
+            fi
+            now_epoch=$(date -u '+%s' 2>/dev/null) || return 2
+            age_seconds=$((now_epoch - created_epoch))
+            [[ "$age_seconds" -ge 0 && "$age_seconds" -le 300 ]] || return 1
+            issue_author_has_live_authority "$issue_json" || authority_rc=$?
+            case "$authority_rc" in
+              0) return 0 ;;
+              2) return 2 ;;
+              *) return 1 ;;
+            esac
+          }
 
           approval_comments_have_maintainer_authority() {
             local comments_json="$1"
@@ -598,6 +648,23 @@ jobs:
             done <<< "$identities"
             return 1
           }
+
+          #aidevops:trust-boundary GH#29151: issue-triage removes a form-default
+          # NMR label as github-actions[bot] immediately after a trusted author
+          # opens an issue. Permit only that narrow, live-verified creation-time
+          # cleanup. Later bot removals still require cryptographic approval so
+          # an explicit human hold cannot be erased by unrelated automation.
+          if [[ "$ACTOR" == "github-actions[bot]" ]]; then
+            TRUSTED_BOT_RC=0
+            trusted_bot_open_cleanup_is_allowed || TRUSTED_BOT_RC=$?
+            if [[ "$TRUSTED_BOT_RC" -eq 0 ]]; then
+              echo "ALLOWED: creation-time triage cleanup by github-actions[bot] for a live-verified maintainer-authored issue"
+              exit 0
+            fi
+            if [[ "$TRUSTED_BOT_RC" -eq 2 ]]; then
+              echo "::warning::Unable to verify creation-time trusted-author cleanup — restoring NMR"
+            fi
+          fi
 
           #aidevops:trust-boundary GH#1894/GH#27611/GH#28622: marker text is
           # attacker-controlled and bot identity alone is not approval. Require


### PR DESCRIPTION
## Summary

Eliminate trusted workflow and Pulse NMR feedback loops while preserving manual, security, authority, and circuit-breaker holds.

## Files Changed

.agents/scripts/pulse-dispatch-engine.sh, .agents/scripts/pulse-dispatch-preflight-lib.sh, .agents/scripts/pulse-issue-reconcile-parent.sh, .agents/scripts/pulse-nmr-approval.sh, .agents/scripts/tests/test-issue-triage-gate-fail-closed.sh, .agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh, .agents/scripts/tests/test-parent-decomposition-escalation.sh, .agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh, .agents/scripts/tests/test-pulse-nmr-automation-signature.sh, .agents/scripts/tests/test-pulse-nmr-scanner-label-breaker-trip.sh, .github/workflows/issue-triage-gate.yml, .github/workflows/maintainer-gate-reusable.yml

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: actionlint and local quality gates; 10 issue-triage, 34 maintainer-gate, 48 provenance, 11 scanner-breaker, 21 parent-escalation, and 41 stage-wiring cases; adjacent NMR and housekeeping suites.

Resolves #29151


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.210 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 43m and 820,359 tokens on this with the user in an interactive session.