### PR TITLE
GH#29158: Aggregate PR #29152 release provenance

### DIFF
--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -186,7 +186,7 @@ Aggregation PR #29148 reviews authorized Qlty postflight PR #29127 at
 authorized patch release completed. Its exact branch base is
 `af4dc8979fde7864fd0d7ffc898f47629dd3241e`.
 
-A pending aggregation review covers authorized GH audit PR #29152 at
+Aggregation PR #29159 reviews authorized GH audit PR #29152 at
 `817e68674104c07951932c9cc914763f31f56b94` because protected release PR #29155
 advanced `main` after the source merged, while immutable `v3.32.210` predates
 that source. Its exact branch base is

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -186,6 +186,12 @@ Aggregation PR #29148 reviews authorized Qlty postflight PR #29127 at
 authorized patch release completed. Its exact branch base is
 `af4dc8979fde7864fd0d7ffc898f47629dd3241e`.
 
+A pending aggregation review covers authorized GH audit PR #29152 at
+`817e68674104c07951932c9cc914763f31f56b94` because protected release PR #29155
+advanced `main` after the source merged, while immutable `v3.32.210` predates
+that source. Its exact branch base is
+`71ad1b62a0da67f161a9a41992d4d4a5958b5e2c`.
+
 Manual arbitrary-version package publication is intentionally unsupported. A
 recovery operation must use an existing tag that passes the same verifier.
 


### PR DESCRIPTION
## Summary

- Record exact-tip release aggregation PR #29159 for authorized source PR #29152.
- Preserve the immutable source manifest in the final follow-up commit without rewriting the published branch.
- Keep immutable `v3.32.210` unchanged and enable the canonical helper to publish the next incremental patch.

## Why

The authorized patch release stopped before publication because protected `main` advanced to PR #29155. Immutable `v3.32.210` predates source merge `817e68674104c07951932c9cc914763f31f56b94`, so the fail-closed release path requires a reviewed aggregation PR.

## Files

- `.agents/reference/release-publication-controls.md`

## Verification

- `.agents/scripts/linters-local.sh`
- `git diff --check`
- Final commit trailers: exactly one `Aidevops-Release-Aggregator-PR: 29159` and one `Aidevops-Release-Aggregates: 29152@817e68674104c07951932c9cc914763f31f56b94`.
- Initial commit trailers: none.
- Exact-head review bundle: `01e1d1f78174aef0e2ce056db0602fd2ce239d323544d2194eb2f606b456b894` at `ff1dded826b159c60d002ad3c19115fda2f17c50`.

## Risk

The change is documentation-only and does not publish a release. The branch preserves the required two-commit review history: the initial published commit has no recognized aggregation trailer, while the final commit records exactly one aggregation identity and the authorized source manifest.

Resolves #29158

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.210 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 56m and 530,194 tokens on this with the user in an interactive session.
