### PR TITLE
GH#29054: Make profile README updates canonical-safe

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -31,6 +31,9 @@ CONTRIBUTIONS_START_MARKER='<!-- CONTRIBUTIONS-START -->'
 CONTRIBUTIONS_END_MARKER='<!-- CONTRIBUTIONS-END -->'
 PROFILE_UPDATE_LOCK_TOKEN=""
 PROFILE_UPDATE_LOCK_GRACE_SECONDS="${AIDEVOPS_PROFILE_LOCK_GRACE_SECONDS:-30}"
+PROFILE_PUBLICATION_WORKTREE=""
+PROFILE_PUBLICATION_CANONICAL_REPO=""
+PROFILE_CONTRIBUTIONS_REFRESHED=false
 
 # --- Serialize profile refreshes so scheduler overlap cannot duplicate scans/writes ---
 _profile_update_lock_dir() {
@@ -128,8 +131,74 @@ _release_profile_update_lock() {
 	return 0
 }
 
+_profile_publication_worktree_helper() {
+	printf '%s\n' "${AIDEVOPS_PROFILE_WORKTREE_HELPER:-${SCRIPT_DIR}/worktree-helper.sh}"
+	return 0
+}
+
+_cleanup_profile_publication_worktree() {
+	if [[ -z "$PROFILE_PUBLICATION_WORKTREE" ]]; then
+		return 0
+	fi
+	local worktree_path="$PROFILE_PUBLICATION_WORKTREE"
+	local canonical_repo="$PROFILE_PUBLICATION_CANONICAL_REPO"
+	local worktree_helper=""
+	worktree_helper=$(_profile_publication_worktree_helper)
+	if [[ -z "$canonical_repo" || ! -d "$canonical_repo" || ! -x "$worktree_helper" ]]; then
+		echo "Warning: profile publication worktree cleanup is unavailable: $worktree_path" >&2
+		return 1
+	fi
+	if ! (cd "$canonical_repo" && "$worktree_helper" remove "$worktree_path" --force >/dev/null); then
+		echo "Warning: profile publication worktree cleanup failed: $worktree_path" >&2
+		return 1
+	fi
+	PROFILE_PUBLICATION_WORKTREE=""
+	PROFILE_PUBLICATION_CANONICAL_REPO=""
+	return 0
+}
+
+_profile_update_exit_cleanup() {
+	_cleanup_profile_publication_worktree || true
+	_release_profile_update_lock || true
+	return 0
+}
+
+_ensure_profile_update_lock() {
+	if [[ "${AIDEVOPS_PROFILE_UPDATE_LOCK_HELD:-0}" == "1" ]]; then
+		return 0
+	fi
+	_acquire_profile_update_lock || return 1
+	export AIDEVOPS_PROFILE_UPDATE_LOCK_HELD=1
+	trap _profile_update_exit_cleanup EXIT
+	return 0
+}
+
 # --- Resolve profile repo path from repos.json ---
 _resolve_profile_repo() {
+	if [[ -n "${AIDEVOPS_PROFILE_REPO_OVERRIDE:-}" ]]; then
+		local override_git_dir=""
+		local override_common_dir=""
+		local canonical_common_dir=""
+		if [[ ! -d "$AIDEVOPS_PROFILE_REPO_OVERRIDE" ]] ||
+			! git -C "$AIDEVOPS_PROFILE_REPO_OVERRIDE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+			echo "Error: profile repository override is not a Git worktree" >&2
+			return 1
+		fi
+		override_git_dir=$(git -C "$AIDEVOPS_PROFILE_REPO_OVERRIDE" rev-parse --path-format=absolute --git-dir) || return 1
+		override_common_dir=$(git -C "$AIDEVOPS_PROFILE_REPO_OVERRIDE" rev-parse --path-format=absolute --git-common-dir) || return 1
+		if [[ "$override_git_dir" == "$override_common_dir" ]]; then
+			echo "Error: profile repository override must be a linked worktree" >&2
+			return 1
+		fi
+		if [[ -z "${AIDEVOPS_PROFILE_CANONICAL_REPO:-}" ]] ||
+			! canonical_common_dir=$(git -C "$AIDEVOPS_PROFILE_CANONICAL_REPO" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) ||
+			[[ "$canonical_common_dir" != "$override_common_dir" ]]; then
+			echo "Error: profile repository override does not match its canonical repository" >&2
+			return 1
+		fi
+		printf '%s\n' "$AIDEVOPS_PROFILE_REPO_OVERRIDE"
+		return 0
+	fi
 	local repos_json="${HOME}/.config/aidevops/repos.json"
 
 	# Try repos.json first (primary lookup)
@@ -300,8 +369,9 @@ _resolve_profile_user() {
 	fi
 
 	# Fallback to directory basename
-	local base
-	base=$(basename "$profile_repo")
+	local fallback_repo="${AIDEVOPS_PROFILE_CANONICAL_REPO:-$profile_repo}"
+	local base=""
+	base=$(basename "$fallback_repo")
 	if [[ -n "$base" ]]; then
 		echo "$base"
 		return 0
@@ -1065,7 +1135,7 @@ _update_inject_timestamp() {
 
 # --- Ensure STATS markers exist in a README, injecting or regenerating as needed ---
 # Usage: _update_inject_markers_if_needed <profile_repo> <readme_path>
-# Commits the injection to the profile repo if changes were made.
+# The caller owns the single publication commit after all transforms complete.
 _update_inject_markers_if_needed() {
 	local profile_repo="$1"
 	local readme_path="$2"
@@ -1083,8 +1153,6 @@ _update_inject_markers_if_needed() {
 			echo "Could not resolve username — injecting markers only..."
 			_inject_markers_into_readme "$readme_path"
 		fi
-		git -C "$profile_repo" add README.md
-		git -C "$profile_repo" commit -m "feat: replace default GitHub template with rich profile README" --no-verify 2>/dev/null || true
 		return 0
 	fi
 
@@ -1094,62 +1162,67 @@ _update_inject_markers_if_needed() {
 
 	echo "Markers missing from README — injecting them..."
 	_inject_markers_into_readme "$readme_path"
-	git -C "$profile_repo" add README.md
-	git -C "$profile_repo" commit -m "feat: initialize profile README with aidevops stat markers" --no-verify 2>/dev/null || true
 	return 0
 }
 
-# --- Push a profile repo commit, recovering from diverged history if needed ---
-# Usage: _update_push_with_recovery <profile_repo> <commit_msg> [extra_args...]
-# Returns 0 always (recovery is attempted on push failure).
+# --- Commit and publish one profile README update from the linked worktree ---
+# Usage: _update_push_with_recovery <profile_repo> <commit_msg>
 _update_push_with_recovery() {
 	local profile_repo="$1"
 	local commit_msg="$2"
-	shift 2
-	local extra_args=("$@")
 
-	git -C "$profile_repo" add README.md
-	git -C "$profile_repo" commit -m "$commit_msg" --no-verify 2>/dev/null || {
-		echo "No changes to commit after profile README update"
-		return 0
-	}
+	git -C "$profile_repo" add README.md || return 1
+	if ! git -C "$profile_repo" commit -m "$commit_msg" --no-verify 2>/dev/null; then
+		if git -C "$profile_repo" diff --cached --quiet -- README.md; then
+			echo "No changes to commit after profile README update"
+			return 0
+		fi
+		echo "Profile README commit failed in the publication worktree" >&2
+		return 1
+	fi
 	echo "Committed profile README update: $commit_msg"
 
-	local default_branch
-	default_branch=$(git -C "$profile_repo" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || true)
-	if [[ -z "$default_branch" ]]; then
-		default_branch=$(git -C "$profile_repo" branch --show-current 2>/dev/null || true)
+	local default_branch=""
+	default_branch=$(_profile_default_branch "$profile_repo")
+	if ! git -C "$profile_repo" push origin "HEAD:refs/heads/${default_branch}" 2>/dev/null; then
+		echo "Profile README push failed; canonical checkout was not changed" >&2
+		return 1
 	fi
-	default_branch="${default_branch:-main}"
+	echo "Pushed profile README update to origin/${default_branch}"
+	return 0
+}
 
-	if ! git -C "$profile_repo" push origin "$default_branch" 2>/dev/null; then
-		echo "Push failed — attempting recovery from diverged history..." >&2
-		local gh_user
-		gh_user=$(_resolve_profile_user "$profile_repo")
-		if [[ -n "$gh_user" ]]; then
-			local repo_slug="${gh_user}/${gh_user}"
-			_recover_diverged_profile "$profile_repo" "$repo_slug" "$default_branch" "$gh_user"
-			echo "Running fresh stats update after recovery..."
-			cmd_update "${extra_args[@]}"
-		else
-			echo "Warning: push failed and could not resolve username for recovery" >&2
-		fi
+_profile_refresh_daily_contributions() {
+	local readme_path="$1"
+	local dry_run="$2"
+	local last_contrib_file="${HOME}/.aidevops/cache/contributions-last-update"
+	local today=""
+	local last_contrib_date=""
+	PROFILE_CONTRIBUTIONS_REFRESHED=false
+	today=$(date -u +"%Y-%m-%d")
+	if [[ -f "$last_contrib_file" ]]; then
+		last_contrib_date=$(<"$last_contrib_file")
+	fi
+	if [[ "$last_contrib_date" == "$today" ]] ||
+		! grep -q '<!-- CONTRIBUTIONS-START -->' "$readme_path" 2>/dev/null; then
+		return 0
+	fi
+	echo "Daily contributions refresh triggered..."
+	if [[ "$dry_run" == true ]]; then
+		cmd_update_contributions "--dry-run" || echo "Warning: contributions update failed — continuing with stats" >&2
+	elif AIDEVOPS_PROFILE_DEFER_PUBLICATION=1 cmd_update_contributions; then
+		PROFILE_CONTRIBUTIONS_REFRESHED=true
 	else
-		echo "Pushed profile README update to origin/${default_branch}"
+		echo "Warning: contributions update failed — continuing with stats" >&2
 	fi
 	return 0
 }
 
-# --- Update the profile README ---
-cmd_update() {
+# --- Update the profile README inside an isolated publication worktree ---
+_cmd_update_in_repo() {
 	local dry_run=false
 	if [[ "${1:-}" == "--dry-run" ]]; then
 		dry_run=true
-	fi
-	if [[ "${AIDEVOPS_PROFILE_UPDATE_LOCK_HELD:-0}" != "1" ]]; then
-		_acquire_profile_update_lock || return 1
-		export AIDEVOPS_PROFILE_UPDATE_LOCK_HELD=1
-		trap _release_profile_update_lock EXIT
 	fi
 	echo "Profile README update started at $(date -u +%Y-%m-%dT%H:%M:%SZ) (dry_run=${dry_run})"
 
@@ -1167,27 +1240,8 @@ cmd_update() {
 	local new_stats
 	new_stats=$(cmd_generate)
 
-	# Daily contributions refresh — piggyback on the hourly stats job.
-	# Only runs once per day to keep API costs low (~11 core API calls/run).
-	local cache_dir="${HOME}/.aidevops/cache"
-	local last_contrib_file="${cache_dir}/contributions-last-update"
-	local today
-	today=$(date -u +"%Y-%m-%d")
-	local last_contrib_date=""
-	if [[ -f "$last_contrib_file" ]]; then
-		last_contrib_date=$(cat "$last_contrib_file" 2>/dev/null || true)
-	fi
-	if [[ "$last_contrib_date" != "$today" ]] && grep -q '<!-- CONTRIBUTIONS-START -->' "$readme_path" 2>/dev/null; then
-		echo "Daily contributions refresh triggered..."
-		if [[ "$dry_run" == true ]]; then
-			cmd_update_contributions "--dry-run" || echo "Warning: contributions update failed — continuing with stats" >&2
-		else
-			cmd_update_contributions || echo "Warning: contributions update failed — continuing with stats" >&2
-		fi
-		if [[ "$dry_run" != true ]]; then
-			git -C "$profile_repo" pull --rebase --quiet 2>/dev/null || true
-		fi
-	fi
+	# Daily contributions piggyback on the hourly stats job once per UTC day.
+	_profile_refresh_daily_contributions "$readme_path" "$dry_run"
 
 	# Ensure markers exist — inject or regenerate if missing
 	_update_inject_markers_if_needed "$profile_repo" "$readme_path"
@@ -1217,7 +1271,11 @@ cmd_update() {
 	local old_normalized new_normalized
 	old_normalized=$(_normalize_readme_for_compare "$readme_path")
 	new_normalized=$(_normalize_readme_for_compare "$tmp_file")
-	if [[ "$old_normalized" == "$new_normalized" ]]; then
+	local readme_dirty=false
+	if ! git -C "$profile_repo" diff --quiet -- README.md; then
+		readme_dirty=true
+	fi
+	if [[ "$old_normalized" == "$new_normalized" && "$readme_dirty" == false ]]; then
 		echo "No changes to profile content — skipping commit"
 		rm -f "$tmp_file"
 		return 0
@@ -1236,7 +1294,10 @@ cmd_update() {
 	# Apply changes and push
 	mv "$tmp_file" "$readme_path"
 	echo "Profile README content changed — committing and pushing"
-	_update_push_with_recovery "$profile_repo" "chore: update profile stats ($(date -u +%Y-%m-%d))" "$@"
+	_update_push_with_recovery "$profile_repo" "chore: update profile stats ($(date -u +%Y-%m-%d))" || return 1
+	if [[ "$PROFILE_CONTRIBUTIONS_REFRESHED" == true ]]; then
+		_record_contributions_update || return 1
+	fi
 
 	echo "Profile README updated and pushed"
 	return 0
@@ -1440,7 +1501,7 @@ _update_contributions_push() {
 
 	local default_branch
 	default_branch=$(_profile_default_branch "$profile_repo")
-	if ! git -C "$profile_repo" push origin "$default_branch" 2>/dev/null; then
+	if ! git -C "$profile_repo" push origin "HEAD:refs/heads/${default_branch}" 2>/dev/null; then
 		echo "Warning: push failed — contributions committed locally" >&2
 		return 1
 	fi
@@ -1538,7 +1599,7 @@ _render_contributions_candidate() {
 # --- Update contributions section between markers ---
 # Can be called standalone or from cmd_update with daily throttle.
 # Uses _generate_contributions() to fetch fork parent URLs + repos.json entries.
-cmd_update_contributions() {
+_cmd_update_contributions_in_repo() {
 	local dry_run=false
 	if [[ "${1:-}" == "--dry-run" ]]; then
 		dry_run=true
@@ -1619,8 +1680,127 @@ cmd_update_contributions() {
 		rm -f "$tmp_file"
 		return 1
 	fi
+	if [[ "${AIDEVOPS_PROFILE_DEFER_PUBLICATION:-0}" == "1" ]]; then
+		echo "Profile contributions staged for the combined README publication"
+		return 0
+	fi
 	_update_contributions_push "$profile_repo" || return 1
 	return 0
+}
+
+_profile_assert_canonical_clean() {
+	local canonical_repo="$1"
+	local status_output=""
+	if ! status_output=$(git -C "$canonical_repo" status --porcelain --untracked-files=all); then
+		echo "Error: could not verify canonical profile checkout state" >&2
+		return 1
+	fi
+	if [[ -n "$status_output" ]]; then
+		echo "Error: canonical profile checkout is not clean; refusing automated publication" >&2
+		return 1
+	fi
+	local default_branch=""
+	local ahead_count=""
+	default_branch=$(_profile_default_branch "$canonical_repo")
+	if ! ahead_count=$(git -C "$canonical_repo" rev-list --count "origin/${default_branch}..HEAD" 2>/dev/null); then
+		echo "Error: could not verify canonical profile branch state" >&2
+		return 1
+	fi
+	if [[ "$ahead_count" -gt 0 ]]; then
+		echo "Error: canonical profile checkout has unpushed commits; refusing automated publication" >&2
+		return 1
+	fi
+	return 0
+}
+
+_profile_run_in_worktree() {
+	local publication_command="$1"
+	shift
+	local canonical_repo=""
+	canonical_repo=$(_resolve_profile_repo) || return 1
+	_profile_assert_canonical_clean "$canonical_repo" || return 1
+
+	local worktree_helper=""
+	worktree_helper=$(_profile_publication_worktree_helper)
+	if [[ ! -x "$worktree_helper" ]]; then
+		echo "Error: worktree-helper.sh is required for canonical-safe profile publication" >&2
+		return 1
+	fi
+
+	local canonical_head_before=""
+	local canonical_status_before=""
+	canonical_head_before=$(git -C "$canonical_repo" rev-parse HEAD) || return 1
+	canonical_status_before=$(git -C "$canonical_repo" status --porcelain --untracked-files=all) || return 1
+
+	local worktree_base="${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME}/Git/_worktrees}"
+	local worktree_name=""
+	worktree_name="$(basename "$canonical_repo")-profile-readme-$(date -u +%Y%m%d%H%M%S)-$$-${RANDOM}"
+	local worktree_path="${worktree_base}/${worktree_name}"
+	mkdir -p "$worktree_base" || return 1
+	if ! git -C "$canonical_repo" worktree add --detach "$worktree_path" HEAD >/dev/null; then
+		echo "Error: could not create profile publication worktree" >&2
+		return 1
+	fi
+	PROFILE_PUBLICATION_WORKTREE="$worktree_path"
+	PROFILE_PUBLICATION_CANONICAL_REPO="$canonical_repo"
+
+	local default_branch=""
+	default_branch=$(_profile_default_branch "$canonical_repo")
+	if ! git -C "$worktree_path" fetch --quiet origin "$default_branch" ||
+		! git -C "$worktree_path" reset --hard FETCH_HEAD >/dev/null; then
+		echo "Error: could not prepare profile publication worktree from origin/${default_branch}" >&2
+		_cleanup_profile_publication_worktree || true
+		return 1
+	fi
+
+	local inner_status=0
+	if AIDEVOPS_PROFILE_PUBLICATION_WORKTREE=1 \
+		AIDEVOPS_PROFILE_REPO_OVERRIDE="$worktree_path" \
+		AIDEVOPS_PROFILE_CANONICAL_REPO="$canonical_repo" \
+		AIDEVOPS_PROFILE_UPDATE_LOCK_HELD=1 \
+		bash "${SCRIPT_DIR}/profile-readme-helper.sh" "$publication_command" "$@"; then
+		inner_status=0
+	else
+		inner_status=$?
+	fi
+
+	if ! _cleanup_profile_publication_worktree; then
+		echo "Error: profile publication worktree remains for guarded recovery: $worktree_path" >&2
+		return 1
+	fi
+
+	local canonical_head_after=""
+	local canonical_status_after=""
+	canonical_head_after=$(git -C "$canonical_repo" rev-parse HEAD) || return 1
+	canonical_status_after=$(git -C "$canonical_repo" status --porcelain --untracked-files=all) || return 1
+	if [[ "$canonical_head_after" != "$canonical_head_before" ||
+		"$canonical_status_after" != "$canonical_status_before" ]]; then
+		echo "Error: canonical profile checkout changed during isolated publication" >&2
+		return 1
+	fi
+	return "$inner_status"
+}
+
+# --- Update the profile README without mutating its configured canonical checkout ---
+cmd_update() {
+	if [[ "${AIDEVOPS_PROFILE_PUBLICATION_WORKTREE:-0}" == "1" ]]; then
+		_cmd_update_in_repo "$@"
+		return $?
+	fi
+	_ensure_profile_update_lock || return 1
+	_profile_run_in_worktree update "$@"
+	return $?
+}
+
+# --- Refresh contributions through the same canonical-safe publication boundary ---
+cmd_update_contributions() {
+	if [[ "${AIDEVOPS_PROFILE_PUBLICATION_WORKTREE:-0}" == "1" ]]; then
+		_cmd_update_contributions_in_repo "$@"
+		return $?
+	fi
+	_ensure_profile_update_lock || return 1
+	_profile_run_in_worktree update-contributions "$@"
+	return $?
 }
 
 # --- Main dispatch ---

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -64,6 +64,11 @@ install_helper_with_libs() {
 		"${SOURCE_HELPER%/*}/screen_time_linux_logind.py" \
 		"${SOURCE_HELPER%/*}/screen_time_linux_wtmp.py" \
 		"${SOURCE_HELPER%/*}/screen_time_history.py" "$helper_dir/"
+	cat >"${helper_dir}/worktree-helper.sh" <<EOF
+#!/usr/bin/env bash
+exec "${SOURCE_HELPER%/*}/worktree-helper.sh" "\$@"
+EOF
+	chmod +x "${helper_dir}/worktree-helper.sh"
 	return 0
 }
 
@@ -158,6 +163,13 @@ EOF
 	return 0
 }
 
+read_remote_readme() {
+	local remote_repo="$1"
+	local output_file="$2"
+	git --git-dir="$remote_repo" show main:README.md >"$output_file"
+	return $?
+}
+
 strip_dynamic_sections() {
 	local file_path="$1"
 	awk '
@@ -171,7 +183,7 @@ strip_dynamic_sections() {
 }
 
 test_update_preserves_manual_sections() {
-	local test_name="profile update preserves non-marker sections"
+	local test_name="profile update publishes once from a linked worktree and preserves the canonical checkout"
 
 	TEST_DIR=$(mktemp -d)
 	local fixture_home="${TEST_DIR}/home"
@@ -188,14 +200,23 @@ test_update_preserves_manual_sections() {
 
 	local before_file="${TEST_DIR}/before.md"
 	local after_file="${TEST_DIR}/after.md"
+	local update_output="${TEST_DIR}/update-output"
 	cp "${fixture_repo}/README.md" "${before_file}"
+	local canonical_head_before=""
+	local remote_head_before=""
+	canonical_head_before=$(git -C "$fixture_repo" rev-parse HEAD)
+	remote_head_before=$(git --git-dir="$fixture_remote" rev-parse main)
 
-	if ! HOME="${fixture_home}" bash "${helper_path}" update >/dev/null 2>&1; then
+	if ! HOME="${fixture_home}" \
+		PATH="${SOURCE_HELPER%/*}:${PATH}" \
+		AIDEVOPS_REPOS_FILE="${fixture_home}/.config/aidevops/repos.json" \
+		AIDEVOPS_WORKTREE_BASE_DIR="${TEST_DIR}/worktrees" \
+		bash "${helper_path}" update >"$update_output" 2>&1; then
 		print_result "${test_name}" 1 "helper update command failed"
 		return 0
 	fi
 
-	cp "${fixture_repo}/README.md" "${after_file}"
+	read_remote_readme "$fixture_remote" "$after_file"
 
 	local before_static
 	local after_static
@@ -211,8 +232,129 @@ test_update_preserves_manual_sections() {
 		print_result "${test_name}" 1 "manual badge lines missing after update"
 		return 0
 	fi
+	if [[ "$canonical_head_before" != "$(git -C "$fixture_repo" rev-parse HEAD)" ]] ||
+		[[ -n "$(git -C "$fixture_repo" status --porcelain --untracked-files=all)" ]] ||
+		! cmp -s "$before_file" "${fixture_repo}/README.md"; then
+		print_result "${test_name}" 1 "canonical profile checkout changed"
+		return 0
+	fi
+	if [[ "$(git --git-dir="$fixture_remote" rev-list --count "${remote_head_before}..main")" != "1" ]]; then
+		print_result "${test_name}" 1 "remote did not receive exactly one generated README commit"
+		return 0
+	fi
+	if [[ "$(git -C "$fixture_repo" worktree list --porcelain | grep -c '^worktree ' || true)" != "1" ]] ||
+		grep -q 'BLOCKED by canonical Git guard' "$update_output"; then
+		print_result "${test_name}" 1 "publication worktree was not cleaned or canonical guard blocked publication"
+		return 0
+	fi
 
 	print_result "${test_name}" 0
+	return 0
+}
+
+test_update_dry_run_is_canonical_safe() {
+	local test_name="profile update dry-run leaves canonical checkout and remote unchanged"
+	TEST_DIR=$(mktemp -d)
+	local fixture_home="${TEST_DIR}/home"
+	local fixture_repo="${TEST_DIR}/profile-repo"
+	local fixture_remote="${TEST_DIR}/profile-remote.git"
+	local helper_dir="${TEST_DIR}/helper"
+	local helper_path="${helper_dir}/profile-readme-helper.sh"
+	local output_file="${TEST_DIR}/dry-run-output"
+	mkdir -p "$helper_dir" "$fixture_home"
+	install_helper_with_libs "$helper_dir"
+	write_stub_dependencies "$helper_dir"
+	create_profile_repo_fixture "$fixture_home" "$fixture_repo" "$fixture_remote"
+
+	local canonical_head_before=""
+	local remote_head_before=""
+	canonical_head_before=$(git -C "$fixture_repo" rev-parse HEAD)
+	remote_head_before=$(git --git-dir="$fixture_remote" rev-parse main)
+	if ! HOME="$fixture_home" \
+		PATH="${SOURCE_HELPER%/*}:${PATH}" \
+		AIDEVOPS_REPOS_FILE="${fixture_home}/.config/aidevops/repos.json" \
+		AIDEVOPS_WORKTREE_BASE_DIR="${TEST_DIR}/worktrees" \
+		bash "$helper_path" update --dry-run >"$output_file" 2>&1; then
+		print_result "$test_name" 1 "dry-run command failed"
+		return 0
+	fi
+	if ! grep -q 'DRY RUN' "$output_file" ||
+		[[ "$canonical_head_before" != "$(git -C "$fixture_repo" rev-parse HEAD)" ]] ||
+		[[ "$remote_head_before" != "$(git --git-dir="$fixture_remote" rev-parse main)" ]] ||
+		[[ -n "$(git -C "$fixture_repo" status --porcelain --untracked-files=all)" ]] ||
+		[[ "$(git -C "$fixture_repo" worktree list --porcelain | grep -c '^worktree ' || true)" != "1" ]]; then
+		print_result "$test_name" 1 "dry-run mutated state or left a publication worktree"
+		return 0
+	fi
+	print_result "$test_name" 0
+	return 0
+}
+
+test_update_prepublication_failure_is_canonical_safe() {
+	local test_name="profile update pre-publication failure leaves canonical checkout unchanged"
+	TEST_DIR=$(mktemp -d)
+	local fixture_home="${TEST_DIR}/home"
+	local fixture_repo="${TEST_DIR}/profile-repo"
+	local fixture_remote="${TEST_DIR}/profile-remote.git"
+	local helper_dir="${TEST_DIR}/helper"
+	local helper_path="${helper_dir}/profile-readme-helper.sh"
+	local before_file="${TEST_DIR}/before.md"
+	mkdir -p "$helper_dir" "$fixture_home"
+	install_helper_with_libs "$helper_dir"
+	write_stub_dependencies "$helper_dir"
+	create_profile_repo_fixture "$fixture_home" "$fixture_repo" "$fixture_remote"
+	git -C "$fixture_repo" remote set-url origin "${TEST_DIR}/missing-remote.git"
+	cp "${fixture_repo}/README.md" "$before_file"
+	local canonical_head_before=""
+	canonical_head_before=$(git -C "$fixture_repo" rev-parse HEAD)
+
+	if HOME="$fixture_home" \
+		AIDEVOPS_WORKTREE_BASE_DIR="${TEST_DIR}/worktrees" \
+		bash "$helper_path" update >/dev/null 2>&1; then
+		print_result "$test_name" 1 "update unexpectedly succeeded with an unavailable remote"
+		return 0
+	fi
+	if [[ "$canonical_head_before" != "$(git -C "$fixture_repo" rev-parse HEAD)" ]] ||
+		[[ -n "$(git -C "$fixture_repo" status --porcelain --untracked-files=all)" ]] ||
+		! cmp -s "$before_file" "${fixture_repo}/README.md" ||
+		[[ "$(git -C "$fixture_repo" worktree list --porcelain | grep -c '^worktree ' || true)" != "1" ]]; then
+		print_result "$test_name" 1 "failed update changed canonical state or leaked a worktree"
+		return 0
+	fi
+	print_result "$test_name" 0
+	return 0
+}
+
+test_internal_override_rejects_canonical_checkout() {
+	local test_name="profile publication override rejects a canonical checkout target"
+	TEST_DIR=$(mktemp -d)
+	local fixture_home="${TEST_DIR}/home"
+	local fixture_repo="${TEST_DIR}/profile-repo"
+	local fixture_remote="${TEST_DIR}/profile-remote.git"
+	local helper_dir="${TEST_DIR}/helper"
+	local helper_path="${helper_dir}/profile-readme-helper.sh"
+	mkdir -p "$helper_dir" "$fixture_home"
+	install_helper_with_libs "$helper_dir"
+	write_stub_dependencies "$helper_dir"
+	create_profile_repo_fixture "$fixture_home" "$fixture_repo" "$fixture_remote"
+	local canonical_head_before=""
+	canonical_head_before=$(git -C "$fixture_repo" rev-parse HEAD)
+
+	if HOME="$fixture_home" \
+		AIDEVOPS_PROFILE_PUBLICATION_WORKTREE=1 \
+		AIDEVOPS_PROFILE_REPO_OVERRIDE="$fixture_repo" \
+		AIDEVOPS_PROFILE_CANONICAL_REPO="$fixture_repo" \
+		AIDEVOPS_PROFILE_UPDATE_LOCK_HELD=1 \
+		bash "$helper_path" update >/dev/null 2>&1; then
+		print_result "$test_name" 1 "internal override accepted the canonical checkout"
+		return 0
+	fi
+	if [[ "$canonical_head_before" != "$(git -C "$fixture_repo" rev-parse HEAD)" ]] ||
+		[[ -n "$(git -C "$fixture_repo" status --porcelain --untracked-files=all)" ]]; then
+		print_result "$test_name" 1 "rejected override still changed canonical state"
+		return 0
+	fi
+	print_result "$test_name" 0
 	return 0
 }
 
@@ -241,7 +383,8 @@ test_update_migrates_generated_readme_with_commit_history_chart() {
 		return 0
 	fi
 
-	local readme="${fixture_repo}/README.md"
+	local readme="${TEST_DIR}/remote-readme.md"
+	read_remote_readme "$fixture_remote" "$readme"
 	if [[ "$(grep -c '<picture>' "$readme")" -ne 1 ]] ||
 		! grep -Fq 'srcset="https://commit-history.com/embed/profile-repo?theme=dark"' "$readme" ||
 		! grep -Fq 'src="https://commit-history.com/embed/profile-repo"' "$readme"; then
@@ -322,7 +465,8 @@ EOF
 		return 0
 	fi
 
-	local readme="${fixture_repo}/README.md"
+	local readme="${TEST_DIR}/remote-readme.md"
+	read_remote_readme "$fixture_remote" "$readme"
 
 	# Verify markers were injected
 	if ! grep -q '<!-- STATS-START -->' "$readme"; then
@@ -414,7 +558,8 @@ EOF
 	# Run update — should detect diverged history and recover
 	HOME="${fixture_home}" bash "${helper_path}" update >/dev/null 2>&1 || true
 
-	local readme="${fixture_repo}/README.md"
+	local readme="${TEST_DIR}/remote-readme.md"
+	read_remote_readme "$fixture_remote" "$readme"
 
 	# After recovery, the README should have markers (either injected or from re-seed)
 	if ! grep -q '<!-- STATS-START -->' "$readme" 2>/dev/null; then
@@ -501,7 +646,8 @@ EOF
 		return 0
 	fi
 
-	local readme="${fixture_repo}/README.md"
+	local readme="${TEST_DIR}/remote-readme.md"
+	read_remote_readme "$fixture_remote" "$readme"
 
 	# Verify the default template is gone
 	if grep -q 'is a.*special.*repository' "$readme" 2>/dev/null; then
@@ -611,7 +757,8 @@ EOF
 		return 0
 	fi
 
-	local readme="${fixture_repo}/README.md"
+	local readme="${TEST_DIR}/remote-readme.md"
+	read_remote_readme "$fixture_remote" "$readme"
 
 	# Verify the default template is gone
 	if grep -q 'is a.*special.*repository' "$readme" 2>/dev/null; then
@@ -1119,6 +1266,12 @@ main() {
 
 	if [[ "$mode" != "--unit-only" ]]; then
 		test_update_preserves_manual_sections
+		teardown
+		test_update_dry_run_is_canonical_safe
+		teardown
+		test_update_prepublication_failure_is_canonical_safe
+		teardown
+		test_internal_override_rejects_canonical_checkout
 		teardown
 		test_update_migrates_generated_readme_with_commit_history_chart
 		teardown

--- a/.agents/scripts/tests/test-profile-readme-contributions-fail-closed.sh
+++ b/.agents/scripts/tests/test-profile-readme-contributions-fail-closed.sh
@@ -164,6 +164,13 @@ EOF
 	return 0
 }
 
+read_remote_readme() {
+	local remote_repo="$1"
+	local output_file="$2"
+	git --git-dir="$remote_repo" show main:README.md >"$output_file"
+	return $?
+}
+
 run_failure_case() {
 	local scenario="$1"
 	local case_root
@@ -463,8 +470,10 @@ test_legacy_joined_marker_is_repaired() {
 		fail "legacy joined marker is repaired" "$output"
 		return 0
 	fi
-	if [[ "$(grep -cFx '<!-- CONTRIBUTIONS-START -->' "$readme")" -ne 1 ]] ||
-		[[ "$(grep -cFx '<!-- CONTRIBUTIONS-END -->' "$readme")" -ne 1 ]]; then
+	local remote_readme="${case_root}/remote-readme.md"
+	read_remote_readme "${case_root}/remote.git" "$remote_readme"
+	if [[ "$(grep -cFx '<!-- CONTRIBUTIONS-START -->' "$remote_readme")" -ne 1 ]] ||
+		[[ "$(grep -cFx '<!-- CONTRIBUTIONS-END -->' "$remote_readme")" -ne 1 ]]; then
 		fail "legacy joined marker becomes one exact pair" "marker counts are invalid"
 		return 0
 	fi
@@ -483,7 +492,8 @@ test_successful_refresh() {
 		fail "healthy refresh succeeds" "$output"
 		return 0
 	fi
-	local readme="${profile_repo}/README.md"
+	local readme="${case_root}/remote-readme.md"
+	read_remote_readme "${case_root}/remote.git" "$readme"
 	if ! grep -Fq -- '- **[configured](https://example.invalid/configured)** -- No description' "$readme" ||
 		! grep -Fq -- '- **[fork-one](https://example.invalid/fork-one)** -- Fork description' "$readme"; then
 		fail "healthy refresh renders validated records" "expected contribution lines missing"
@@ -521,7 +531,7 @@ test_unchanged_refresh_records_throttle() {
 	fi
 	rm -f "${case_root}/home/.aidevops/cache/contributions-last-update"
 	local before_head
-	before_head=$(git -C "$profile_repo" rev-parse HEAD)
+	before_head=$(git --git-dir="${case_root}/remote.git" rev-parse main)
 	local output=""
 	if ! output=$(HOME="${case_root}/home" PATH="$run_env_path" GH_SCENARIO=success \
 		bash "$HELPER" update-contributions 2>&1); then
@@ -530,7 +540,7 @@ test_unchanged_refresh_records_throttle() {
 	fi
 	if [[ "$output" != *"Contributions unchanged"* ]] ||
 		[[ ! -f "${case_root}/home/.aidevops/cache/contributions-last-update" ]] ||
-		[[ "$before_head" != "$(git -C "$profile_repo" rev-parse HEAD)" ]]; then
+		[[ "$before_head" != "$(git --git-dir="${case_root}/remote.git" rev-parse main)" ]]; then
 		fail "unchanged refresh records throttle" "output=${output}"
 		return 0
 	fi
@@ -542,13 +552,15 @@ test_push_failure_propagates() {
 	local case_root
 	case_root=$(create_fixture "push-failure") || return 1
 	local profile_repo="${case_root}/fixture"
+	local canonical_head=""
+	canonical_head=$(git -C "$profile_repo" rev-parse HEAD)
 	git -C "$profile_repo" remote set-url origin "${case_root}/missing-remote.git"
 
 	local output=""
 	local exit_code=0
 	output=$(HOME="${case_root}/home" PATH="${case_root}/bin:${PATH}" GH_SCENARIO=success \
 		bash "$HELPER" update-contributions 2>&1) || exit_code=$?
-	if [[ "$exit_code" -eq 0 || "$output" != *"push failed"* ]]; then
+	if [[ "$exit_code" -eq 0 || "$output" != *"could not prepare profile publication worktree"* ]]; then
 		fail "push failure propagates" "exit=${exit_code} output=${output}"
 		return 0
 	fi
@@ -567,7 +579,7 @@ test_push_failure_propagates() {
 	local local_head remote_head
 	local_head=$(git -C "$profile_repo" rev-parse HEAD)
 	remote_head=$(git --git-dir="${case_root}/remote.git" rev-parse main)
-	if [[ "$local_head" != "$remote_head" ]] ||
+	if [[ "$local_head" != "$canonical_head" || "$remote_head" == "$canonical_head" ]] ||
 		[[ ! -f "${case_root}/home/.aidevops/cache/contributions-last-update" ]]; then
 		fail "push retry closes throttle after remote sync" "local=${local_head} remote=${remote_head} output=${retry_output}"
 		return 0


### PR DESCRIPTION
## Summary

Publish profile README stats and contribution refreshes from an isolated detached linked worktree, preserve canonical checkout state, consolidate generated changes into one remote commit, and clean the temporary worktree through the audited helper.

## Files Changed

.agents/scripts/profile-readme-helper.sh, .agents/scripts/tests/test-profile-readme-boundary.sh, .agents/scripts/tests/test-profile-readme-contributions-fail-closed.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 20/20 profile boundary tests; 28/28 contribution fail-closed tests; 11/11 routine scheduling tests; ShellCheck; .agents/scripts/linters-local.sh

Resolves #29054


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.210 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 52m and 293,260 tokens on this with the user in an interactive session.