### PR TITLE
GH#29158: Re-aggregate PR #29152 release provenance

### DIFF
--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -192,7 +192,7 @@ advanced `main` after the source merged, while immutable `v3.32.210` predates
 that source. Its exact branch base is
 `71ad1b62a0da67f161a9a41992d4d4a5958b5e2c`.
 
-A pending re-aggregation review covers authorized GH audit PR #29152 at
+Aggregation PR #29164 re-reviews authorized GH audit PR #29152 at
 `817e68674104c07951932c9cc914763f31f56b94` and prior aggregation PR #29159 at
 `29714078dee12f926f9a52c9eeb51a63549373e3` because subsequent maintained
 merges advanced `main` before publication. Its exact branch base is

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -192,6 +192,12 @@ advanced `main` after the source merged, while immutable `v3.32.210` predates
 that source. Its exact branch base is
 `71ad1b62a0da67f161a9a41992d4d4a5958b5e2c`.
 
+A pending re-aggregation review covers authorized GH audit PR #29152 at
+`817e68674104c07951932c9cc914763f31f56b94` and prior aggregation PR #29159 at
+`29714078dee12f926f9a52c9eeb51a63549373e3` because subsequent maintained
+merges advanced `main` before publication. Its exact branch base is
+`becf4e373d9c8a1eb509af6f90c3a0bb481c6225`.
+
 Manual arbitrary-version package publication is intentionally unsupported. A
 recovery operation must use an existing tag that passes the same verifier.
 


### PR DESCRIPTION
## Summary

- Record exact-tip re-aggregation PR #29164 for authorized source PR #29152 and prior aggregation PR #29159.
- Preserve both immutable source identities in the final follow-up commit without rewriting the published branch.
- Keep immutable `v3.32.210` unchanged and enable the canonical helper to publish the next incremental patch.

## Why

PR #29159 merged with the correct source manifest, but subsequent maintained merges advanced protected `main` before publication could start. The fail-closed release path therefore requires another reviewed exact-tip aggregation rather than ancestor reachability or branch rewriting.

## Files

- `.agents/reference/release-publication-controls.md`

## Verification

- `.agents/scripts/linters-local.sh`
- `git diff --check`
- Final commit trailers: exactly one `Aidevops-Release-Aggregator-PR: 29164`, one source for `29152@817e68674104c07951932c9cc914763f31f56b94`, and one source for `29159@29714078dee12f926f9a52c9eeb51a63549373e3`.
- Initial commit trailers: none.
- Exact-head review bundle: `3d117dbf13d943e87bbf23c4acb193d59e6f9dd9f22c3454b604350e74e5ff1d` at `1d02eef92467f718e72c49c95fd9eefcc71ce611`.

## Risk

The change is documentation-only and does not publish a release. The branch preserves the required two-commit review history: the initial published commit has no recognized aggregation trailer, while the final commit records exactly one aggregation identity and both immutable source entries.

Resolves #29158

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.210 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h 13m and 721,165 tokens on this with the user in an interactive session.
