### PR TITLE
GH#29172: Harden release postflight quota fallback

### DIFF
--- a/.agents/scripts/tests/test-release-publication-workflows.sh
+++ b/.agents/scripts/tests/test-release-publication-workflows.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)" || exit 1
 PACKAGE_WORKFLOW="${REPO_ROOT}/.github/workflows/publish-packages.yml"
+POSTFLIGHT_WORKFLOW="${REPO_ROOT}/.github/workflows/postflight.yml"
 SETTINGS_HELPER="${REPO_ROOT}/.agents/scripts/release-publication-settings-helper.sh"
 readonly SNAPSHOT_MODE="snapshot-empty"
 
@@ -117,6 +118,22 @@ assert_contains "Homebrew verification keeps its executable test selector" \
 assert_contains "Homebrew convergence compares the complete generated formula" \
 	"cmp -s homebrew/aidevops.rb" "$PACKAGE_WORKFLOW"
 assert_absent "Homebrew publication failures are not masked" "continue-on-error: true" "$PACKAGE_WORKFLOW"
+# shellcheck disable=SC2016 # Match the literal workflow expression.
+assert_contains "postflight dispatch avoids the shared installation quota" \
+	'GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}' "$PACKAGE_WORKFLOW"
+assert_contains "postflight runs only in the protected release environment" \
+	"environment: release" "$POSTFLIGHT_WORKFLOW"
+assert_contains "postflight fallback retains Actions read permission" \
+	"actions: read" "$POSTFLIGHT_WORKFLOW"
+assert_contains "postflight PAT access has an explicit trust-boundary marker" \
+	"#aidevops:trust-boundary" "$POSTFLIGHT_WORKFLOW"
+# shellcheck disable=SC2016 # Match the literal workflow shell variable.
+assert_contains "postflight rejects non-main workflow dispatches" \
+	'[[ "$GITHUB_REF" == "refs/heads/main" ]]' "$POSTFLIGHT_WORKFLOW"
+# shellcheck disable=SC2016 # Match literal workflow content and expressions.
+assert_order "postflight verifies reviewed main before exposing the PAT fallback" \
+	'[[ "$GITHUB_REF" == "refs/heads/main" ]]' \
+	'GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}' "$POSTFLIGHT_WORKFLOW"
 # shellcheck disable=SC2016 # Match the literal verifier command.
 assert_order "release provenance precedes release creation" \
 	'bash "$VERIFIER" verify' "github-release-helper.sh create" "$PACKAGE_WORKFLOW"
@@ -141,6 +158,15 @@ if [[ "$verification_count" -ne 1 ]]; then
 	exit 1
 fi
 printf 'PASS unified publication verifies provenance once before all side effects\n'
+
+# shellcheck disable=SC2016 # Match the literal workflow expression.
+postflight_token_fallback_count=$(grep -cF \
+	'GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}' "$POSTFLIGHT_WORKFLOW" || true)
+if [[ "$postflight_token_fallback_count" -ne 2 ]]; then
+	printf 'FAIL postflight must use the protected token fallback for both API polling steps\n'
+	exit 1
+fi
+printf 'PASS postflight uses the protected token fallback for both API polling steps\n'
 
 TEST_ROOT=$(mktemp -d)
 trap 'rm -rf "$TEST_ROOT"' EXIT

--- a/.github/workflows/postflight.yml
+++ b/.github/workflows/postflight.yml
@@ -15,9 +15,11 @@ jobs:
   postflight:
     name: Verify Release Health
     runs-on: ubuntu-latest
+    environment: release
     timeout-minutes: 15
     
     permissions:
+      actions: read
       contents: read
       checks: read
       security-events: read
@@ -34,6 +36,11 @@ jobs:
       env:
         RELEASE_TAG: ${{ github.event.inputs.tag }}
       run: |
+        #aidevops:trust-boundary
+        [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
+          echo "::error::Postflight must run from reviewed main"
+          exit 1
+        }
         [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
           echo "::error::Invalid release tag: $RELEASE_TAG"
           exit 1
@@ -74,7 +81,7 @@ jobs:
     
     - name: Wait for CI/CD Pipelines
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
         REPO: ${{ github.repository }}
         COMMIT_SHA: ${{ steps.release_commit.outputs.sha }}
         RELEASE_TAG: ${{ github.event.inputs.tag || '' }}
@@ -168,7 +175,7 @@ jobs:
     - name: Verify CI/CD Status
       id: cicd
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
         REPO: ${{ github.repository }}
         COMMIT_SHA: ${{ steps.release_commit.outputs.sha }}
         RELEASE_TAG: ${{ github.event.inputs.tag || '' }}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -357,7 +357,7 @@ jobs:
 
       - name: Queue exact-tag postflight
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run postflight.yml \
             --repo "$GITHUB_REPOSITORY" \


### PR DESCRIPTION
## Summary

Use the protected release token fallback for exact-tag postflight dispatch and API polling, constrain postflight to the release environment and reviewed main, and lock the contract with focused regressions.

## Files Changed

.agents/scripts/tests/test-release-publication-workflows.sh, .github/workflows/postflight.yml, .github/workflows/publish-packages.yml

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Focused publication workflow test, four adjacent postflight suites, reusable-workflow permission contracts, actionlint, ShellCheck, linters-local, and independent closeout review CLEAN (bundle 886482fd79c12d0d4429240ccdbb4209a43e0c067544629db5f39e11ea586420). Post-merge v3.32.211 reconciliation is the controlled runtime canary because protected credentials cannot be exercised safely from an unmerged branch.

Resolves #29172


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.212 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 2h 3m and 2,219,422 tokens on this with the user in an interactive session.