### PR TITLE
GH#29176: Re-aggregate remaining PR #29161 release provenance

### DIFF
--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -206,7 +206,7 @@ PR #29152 at `817e68674104c07951932c9cc914763f31f56b94`, prior aggregation PR #2
 both authorized sources. The exact branch base is
 `80d0a1cee4caf0e01514e2278d0ac3665e3c41af`.
 
-Aggregation issue #29176 records authorized workflow diagnostics PR #29161 at
+Aggregation PR #29177 re-reviews authorized workflow diagnostics PR #29161 at
 `671ed712079913857b3c5213cf4ff97ed56c4287` and unresolved combined aggregation
 PR #29169 at `f87af46e46501b5e03f9e015c4b790fae2477a22` for a fresh exact-tip review.
 Immutable `v3.32.212` settled aggregation PR #29164 and its GH audit chain;

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -206,6 +206,14 @@ PR #29152 at `817e68674104c07951932c9cc914763f31f56b94`, prior aggregation PR #2
 both authorized sources. The exact branch base is
 `80d0a1cee4caf0e01514e2278d0ac3665e3c41af`.
 
+Aggregation issue #29176 records authorized workflow diagnostics PR #29161 at
+`671ed712079913857b3c5213cf4ff97ed56c4287` and unresolved combined aggregation
+PR #29169 at `f87af46e46501b5e03f9e015c4b790fae2477a22` for a fresh exact-tip review.
+Immutable `v3.32.212` settled aggregation PR #29164 and its GH audit chain;
+postflight quota fix PR #29174 then advanced `main` with terminal
+`release:not-requested` evidence. The exact branch base is
+`dacff2107e272a059bfbba693ab5594742c55f5e`.
+
 Manual arbitrary-version package publication is intentionally unsupported. A
 recovery operation must use an existing tag that passes the same verifier.
 


### PR DESCRIPTION
## Summary

- establish a fresh exact-tip review for unresolved workflow diagnostics PR #29161 and prior combined aggregation PR #29169
- preserve the trailer-free initial commit and add the allocated PR identity only in the final commit
- exclude terminal sources already settled by `v3.32.212` and PR #29174’s `release:not-requested` evidence

## Files Changed

- `.agents/reference/release-publication-controls.md` — record the exact branch base and remaining authorized sources

## Runtime Testing

- **Risk level:** Low; documentation-only release-provenance attestation
- `git diff --check`
- `npx --no-install markdownlint-cli2 .agents/reference/release-publication-controls.md`
- `.agents/scripts/linters-local.sh`
- initial commit parsed with no recognized aggregation trailers
- final commit parses exactly one aggregator identity plus #29161 and #29169
- closeout evidence bundle: `4f912659d826588479fc583ade47e9f28bccf16996e6fd68b70f0f11f0e42b1b`

## Release Plan

Final commit `4d6ee9f715ab68e478b2bba4c6efee7cbe9776cb` contains exactly one contiguous aggregation trailer block for PRs #29161 and #29169. After required checks, squash merge, and exact-tip provenance verification, continue the already-authorized patch publication.

Resolves #29176
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.212 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 2h 45m and 2,662,694 tokens on this with the user in an interactive session.