### PR TITLE
GH#29172: Retry postflight dispatch with job-token capability

### DIFF
--- a/.agents/scripts/tests/test-release-publication-workflows.sh
+++ b/.agents/scripts/tests/test-release-publication-workflows.sh
@@ -118,9 +118,27 @@ assert_contains "Homebrew verification keeps its executable test selector" \
 assert_contains "Homebrew convergence compares the complete generated formula" \
 	"cmp -s homebrew/aidevops.rb" "$PACKAGE_WORKFLOW"
 assert_absent "Homebrew publication failures are not masked" "continue-on-error: true" "$PACKAGE_WORKFLOW"
+# shellcheck disable=SC2016 # Match literal workflow expressions and shell variables.
+assert_contains "postflight dispatch first exposes the protected PAT" \
+	'SYNC_TOKEN: ${{ secrets.SYNC_PAT }}' "$PACKAGE_WORKFLOW"
 # shellcheck disable=SC2016 # Match the literal workflow expression.
-assert_contains "postflight dispatch avoids the shared installation quota" \
-	'GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}' "$PACKAGE_WORKFLOW"
+assert_contains "postflight dispatch retains the job-token capability fallback" \
+	'JOB_TOKEN: ${{ secrets.GITHUB_TOKEN }}' "$PACKAGE_WORKFLOW"
+# shellcheck disable=SC2016 # Match the literal workflow shell variable.
+assert_contains "postflight dispatch tries the protected PAT first" \
+	'GH_TOKEN="$SYNC_TOKEN" gh workflow run postflight.yml' "$PACKAGE_WORKFLOW"
+assert_contains "postflight dispatch explains the capability fallback" \
+	'SYNC_PAT could not dispatch postflight; retrying with the job token' "$PACKAGE_WORKFLOW"
+# shellcheck disable=SC2016 # Match the literal workflow shell variable.
+assert_contains "postflight dispatch retries with the job token" \
+	'GH_TOKEN="$JOB_TOKEN" gh workflow run postflight.yml' "$PACKAGE_WORKFLOW"
+# shellcheck disable=SC2016 # Match literal workflow shell variables.
+assert_order "postflight dispatch orders quota avoidance before capability fallback" \
+	'GH_TOKEN="$SYNC_TOKEN" gh workflow run postflight.yml' \
+	'GH_TOKEN="$JOB_TOKEN" gh workflow run postflight.yml' "$PACKAGE_WORKFLOW"
+# shellcheck disable=SC2016 # Match the literal workflow shell variable.
+assert_absent "postflight dispatch does not mask a failed job-token retry" \
+	'GH_TOKEN="$JOB_TOKEN" gh workflow run postflight.yml || true' "$PACKAGE_WORKFLOW"
 assert_contains "postflight runs only in the protected release environment" \
 	"environment: release" "$POSTFLIGHT_WORKFLOW"
 assert_contains "postflight fallback retains Actions read permission" \
@@ -158,6 +176,13 @@ if [[ "$verification_count" -ne 1 ]]; then
 	exit 1
 fi
 printf 'PASS unified publication verifies provenance once before all side effects\n'
+
+postflight_dispatch_attempt_count=$(grep -cF 'gh workflow run postflight.yml' "$PACKAGE_WORKFLOW" || true)
+if [[ "$postflight_dispatch_attempt_count" -ne 2 ]]; then
+	printf 'FAIL postflight must make exactly two bounded dispatch attempts\n'
+	exit 1
+fi
+printf 'PASS postflight uses exactly two bounded dispatch attempts\n'
 
 # shellcheck disable=SC2016 # Match the literal workflow expression.
 postflight_token_fallback_count=$(grep -cF \

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -357,12 +357,22 @@ jobs:
 
       - name: Queue exact-tag postflight
         env:
-          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+          SYNC_TOKEN: ${{ secrets.SYNC_PAT }}
+          JOB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run postflight.yml \
-            --repo "$GITHUB_REPOSITORY" \
-            --ref main \
-            --field "tag=$RELEASE_TAG"
+          #aidevops:trust-boundary
+          if [[ -n "$SYNC_TOKEN" ]] && GH_TOKEN="$SYNC_TOKEN" gh workflow run postflight.yml \
+              --repo "$GITHUB_REPOSITORY" \
+              --ref main \
+              --field "tag=$RELEASE_TAG"; then
+            :
+          else
+            echo "::warning::SYNC_PAT could not dispatch postflight; retrying with the job token"
+            GH_TOKEN="$JOB_TOKEN" gh workflow run postflight.yml \
+              --repo "$GITHUB_REPOSITORY" \
+              --ref main \
+              --field "tag=$RELEASE_TAG"
+          fi
           echo "Queued Postflight Verification for $RELEASE_TAG"
 
       - name: Publication summary


### PR DESCRIPTION
## Summary

- retain `SYNC_PAT` as the first exact-tag postflight dispatch attempt to avoid shared installation quota exhaustion
- retry exactly once with the job-scoped token that has explicit `actions: write` when the PAT lacks workflow-dispatch capability
- keep publication fail-closed when both bounded attempts fail

## Runtime Canary

`v3.32.213` publication run `30715249531` completed GitHub, npm, and Homebrew publication but failed its final postflight dispatch with `HTTP 403: Resource not accessible by personal access token`. No exact-tag postflight run was created.

## Files Changed

- `.github/workflows/publish-packages.yml` — ordered PAT-first/job-token fallback
- `.agents/scripts/tests/test-release-publication-workflows.sh` — assert token exposure, ordering, exactly two attempts, and unmasked terminal failure

## Runtime Testing

- **Risk level:** Medium; release workflow credential routing
- `bash .agents/scripts/tests/test-release-publication-workflows.sh`
- `shellcheck .agents/scripts/tests/test-release-publication-workflows.sh`
- `actionlint .github/workflows/publish-packages.yml`
- `.agents/scripts/linters-local.sh`
- exact-head review evidence: `42da6474faf46ac4676426066eda10187e0100a36e0c3699a673b8dc84b05741`

## Release Verification

After merge, reconcile existing signed tag `v3.32.213` from reviewed `main`. Verify the recovery publication run succeeds, creates an exact-tag postflight run, and allows source PR #29177 receipts to become terminal.

Resolves #29172
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.212 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 3h 33m and 2,909,005 tokens on this with the user in an interactive session.