### PR TITLE
GH#29178: Reconcile stale published release receipts

### DIFF
--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -63,6 +63,33 @@ commit. A failed pre-publication attempt records both the requested and current
 source SHAs as actionable failure evidence, but creates no tag or publication.
 Retries reconcile terminal receipts and cannot publish twice.
 
+### Post-publication supersession
+
+A different recovery path applies when an older signed tag already published all
+three package channels, exact-tag postflight dispatch was its sole failed step,
+and a later independently authorized release has since become terminal. The old
+tag cannot use normal recovery because GitHub, npm, and Homebrew now converge on
+the newer version, and deploying its checkout would downgrade the runtime.
+
+`aidevops release reconcile <older-source-pr>` may mark that receipt
+`release:superseded` without publication or deployment only when it verifies:
+
+1. the older tag's immutable source provenance and correlated workflow job;
+2. successful GitHub release, npm, and Homebrew verification steps followed by
+   one failed `Queue exact-tag postflight` step and no other failed step;
+3. a strictly descendant latest signed tag with a terminal-success publication
+   run and exact current channel convergence; and
+4. a local `release:published` receipt for the latest tag's source PR.
+
+The resulting `.successor.json` receipt records both source PRs, merge SHAs,
+tags, release commits, and workflow run IDs with evidence type
+`post-publication-supersession`. It is distinct from reviewed aggregation: the
+newer tag does not retroactively claim an `Aidevops-Aggregated-Source` trailer.
+Missing, duplicated, renamed, malformed, nonterminal, or conflicting evidence
+fails closed and leaves the older receipt unchanged. `status` remains read-only,
+and this path never dispatches publication or runs `post-release` from the stale
+checkout.
+
 The aggregation PR must expose a durable review record before merge. Create it
 as a draft from an initial documentation commit, then add the allocated PR
 number and every authorized `PR@MERGE_SHA` source in a follow-up commit without

--- a/.agents/scripts/full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/full-loop-cleanup-receipt.sh
@@ -19,66 +19,194 @@ _FULL_LOOP_RECEIPT_RELEASE_PUBLISHED="published"
 _FULL_LOOP_RECEIPT_RELEASE_NOT_REQUESTED="not-requested"
 _FULL_LOOP_RECEIPT_RELEASE_SUPERSEDED="superseded"
 _FULL_LOOP_RECEIPT_PATH_RECREATED="SUPERSEDED_BY_PATH_RECREATION"
+_FULL_LOOP_RECEIPT_JSON_NUMBER_TYPE="number"
+_FULL_LOOP_RECEIPT_JSON_STRING_TYPE="string"
+_FULL_LOOP_RECEIPT_SHA40_REGEX='^[0-9a-f]{40}$'
+_FULL_LOOP_RECEIPT_TIMESTAMP_REGEX='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'
+_FULL_LOOP_RECEIPT_VERSION_TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+$'
 _FULL_LOOP_RECREATED_RECEIPT_TRANSACTION_SCHEMA="aidevops.full-loop.recreated-receipts.transaction/v1"
 _FULL_LOOP_RECEIPT_LOCK=""
 
-_full_loop_validate_aggregate_evidence() {
+_full_loop_validate_superseded_evidence() {
 	local evidence_path="$1"
 	local repo="$2"
 	local pr_number="$3"
-	jq -e --arg repo "$repo" --arg status "$_FULL_LOOP_RECEIPT_RELEASE_SUPERSEDED" --argjson pr "$pr_number" \
-		'.repository == $repo and .pr_number == $pr and .status == $status' "$evidence_path" >/dev/null 2>&1
+	local evidence_kind=""
+	case "$evidence_path" in
+	*.aggregate.json) evidence_kind="aggregate" ;;
+	*.successor.json) evidence_kind="successor" ;;
+	*) return 1 ;;
+	esac
+	jq -e --arg repo "$repo" --arg status "$_FULL_LOOP_RECEIPT_RELEASE_SUPERSEDED" \
+		--arg evidence_kind "$evidence_kind" --arg sha_regex "$_FULL_LOOP_RECEIPT_SHA40_REGEX" \
+		--arg tag_regex "$_FULL_LOOP_RECEIPT_VERSION_TAG_REGEX" \
+		--arg timestamp_regex "$_FULL_LOOP_RECEIPT_TIMESTAMP_REGEX" \
+		--arg number_type "$_FULL_LOOP_RECEIPT_JSON_NUMBER_TYPE" \
+		--arg string_type "$_FULL_LOOP_RECEIPT_JSON_STRING_TYPE" --argjson pr "$pr_number" '
+		. as $e
+		| $e.repository == $repo and $e.pr_number == $pr and $e.status == $status
+		and ($e.recorded_at | type == $string_type and test($timestamp_regex))
+		and if $evidence_kind == "aggregate" then
+			$e.schema_version == 1
+			and ($e.source_merge | type == $string_type and test($sha_regex))
+			and ($e.aggregate_pr | type == $number_type and . > 0 and floor == .)
+			and ($e.aggregate_merge | type == $string_type and test($sha_regex))
+			and ($e.release_tag | type == $string_type and test($tag_regex))
+			and ($e.release_commit | type == $string_type and test($sha_regex))
+		else $e.schema_version == 1 and $e.evidence_type == "post-publication-supersession"
+			and $e.source_pr == $pr
+			and ($e.source_merge | type == $string_type and test($sha_regex))
+			and ($e.source_release_tag | type == $string_type and test($tag_regex))
+			and ($e.source_release_commit | type == $string_type and test($sha_regex))
+			and ($e.source_workflow_run | type == $number_type and . > 0 and floor == .)
+			and ($e.successor_pr | type == $number_type and . > 0 and floor == . and . != $pr)
+			and ($e.successor_merge | type == $string_type and test($sha_regex))
+			and ($e.release_tag | type == $string_type and test($tag_regex))
+			and $e.release_tag != $e.source_release_tag
+			and ($e.release_commit | type == $string_type and test($sha_regex))
+			and $e.release_commit != $e.source_release_commit
+			and ($e.release_workflow_run | type == $number_type and . > 0 and floor == .)
+			and $e.release_workflow_run != $e.source_workflow_run
+		end
+	' "$evidence_path" >/dev/null 2>&1
 	return $?
 }
 
-_full_loop_prepare_migrated_aggregate_evidence() {
-	local source_aggregate="$1"
-	local destination_aggregate="$2"
+_full_loop_superseded_migration_evidence_path() {
+	local release_path="$1"
+	local repo="$2"
+	local pr_number="$3"
+	local aggregate_path="${release_path%.status}.aggregate.json"
+	local successor_path="${release_path%.status}.successor.json"
+	local evidence_path=""
+	if [[ -f "$aggregate_path" ]]; then
+		_full_loop_validate_superseded_evidence "$aggregate_path" "$repo" "$pr_number" || return 1
+		evidence_path="$aggregate_path"
+	fi
+	if [[ -f "$successor_path" ]]; then
+		[[ -z "$evidence_path" ]] || return 1
+		_full_loop_validate_superseded_evidence "$successor_path" "$repo" "$pr_number" || return 1
+		evidence_path="$successor_path"
+	fi
+	[[ -n "$evidence_path" ]] || return 1
+	printf '%s\n' "$evidence_path"
+	return 0
+}
+
+_full_loop_prepare_migrated_superseded_evidence() {
+	local source_evidence="$1"
+	local destination_evidence="$2"
 	local old_repo="$3"
 	local new_repo="$4"
 	local now="$5"
 	jq --arg repo "$new_repo" --arg old_repo "$old_repo" --arg now "$now" '
 		.repository = $repo
 		| .migration = {from_repository:$old_repo,to_repository:$repo,migrated_at:$now}
-	' "$source_aggregate" >"${destination_aggregate}.tmp.$$"
+	' "$source_evidence" >"${destination_evidence}.tmp.$$"
+	return $?
+}
+
+_full_loop_migrated_cleanup_receipt_matches_source() {
+	local source_receipt="$1"
+	local destination_receipt="$2"
+	local old_repo="$3"
+	local new_repo="$4"
+	local pr_number="$5"
+	[[ -f "$source_receipt" && ! -L "$source_receipt" ]] || return 1
+	[[ -f "$destination_receipt" && ! -L "$destination_receipt" ]] || return 1
+	jq -e --slurpfile destination "$destination_receipt" \
+		--arg old_repo "$old_repo" --arg new_repo "$new_repo" \
+		--arg string_type "$_FULL_LOOP_RECEIPT_JSON_STRING_TYPE" \
+		--arg timestamp_regex "$_FULL_LOOP_RECEIPT_TIMESTAMP_REGEX" --argjson pr "$pr_number" '
+		.repository == $old_repo and .pr_number == $pr
+		and ($destination | length) == 1
+		and $destination[0].repository == $new_repo and $destination[0].pr_number == $pr
+		and $destination[0].migration.from_repository == $old_repo
+		and $destination[0].migration.to_repository == $new_repo
+		and ($destination[0].migration.migrated_at | type == $string_type and test($timestamp_regex))
+		and (del(.repository,.updated_at,.migration)
+			== ($destination[0] | del(.repository,.updated_at,.migration)))
+	' "$source_receipt" >/dev/null 2>&1
+	return $?
+}
+
+_full_loop_migrated_evidence_matches_source() {
+	local source_evidence="$1"
+	local destination_evidence="$2"
+	local old_repo="$3"
+	local new_repo="$4"
+	local pr_number="$5"
+	_full_loop_validate_superseded_evidence "$source_evidence" "$old_repo" "$pr_number" || return 1
+	_full_loop_validate_superseded_evidence "$destination_evidence" "$new_repo" "$pr_number" || return 1
+	jq -e --slurpfile destination "$destination_evidence" \
+		--arg old_repo "$old_repo" --arg new_repo "$new_repo" \
+		--arg string_type "$_FULL_LOOP_RECEIPT_JSON_STRING_TYPE" \
+		--arg timestamp_regex "$_FULL_LOOP_RECEIPT_TIMESTAMP_REGEX" '
+		($destination | length) == 1
+		and $destination[0].migration.from_repository == $old_repo
+		and $destination[0].migration.to_repository == $new_repo
+		and ($destination[0].migration.migrated_at | type == $string_type and test($timestamp_regex))
+		and (del(.repository,.migration) == ($destination[0] | del(.repository,.migration)))
+	' "$source_evidence" >/dev/null 2>&1
 	return $?
 }
 
 _full_loop_migrated_destination_matches() {
 	local destination_receipt="$1"
 	local destination_release="$2"
-	local destination_aggregate="$3"
-	local new_repo="$4"
-	local old_repo="$5"
-	local pr_number="$6"
-	local release_status="$7"
+	local new_repo="$3"
+	local old_repo="$4"
+	local pr_number="$5"
+	local release_status="$6"
 	local destination_status=""
-	[[ -f "$destination_release" ]] && IFS= read -r destination_status <"$destination_release" || true
-	jq -e --arg repo "$new_repo" --arg old_repo "$old_repo" --argjson pr "$pr_number" '
-		.repository == $repo and .pr_number == $pr and .migration.from_repository == $old_repo
+	local destination_evidence=""
+	local aggregate_path="${destination_release%.status}.aggregate.json"
+	local successor_path="${destination_release%.status}.successor.json"
+	[[ -f "$destination_receipt" && ! -L "$destination_receipt" ]] || return 1
+	[[ -f "$destination_release" && ! -L "$destination_release" ]] || return 1
+	IFS= read -r destination_status <"$destination_release" || return 1
+	jq -e --arg repo "$new_repo" --arg old_repo "$old_repo" \
+		--arg string_type "$_FULL_LOOP_RECEIPT_JSON_STRING_TYPE" \
+		--arg timestamp_regex "$_FULL_LOOP_RECEIPT_TIMESTAMP_REGEX" --argjson pr "$pr_number" '
+		.repository == $repo and .pr_number == $pr
+		and .migration.from_repository == $old_repo and .migration.to_repository == $repo
+		and (.migration.migrated_at | type == $string_type and test($timestamp_regex))
 	' "$destination_receipt" >/dev/null 2>&1 || return 1
 	[[ "$destination_status" == "$release_status" ]] || return 1
-	[[ "$release_status" != "$_FULL_LOOP_RECEIPT_RELEASE_SUPERSEDED" ]] ||
-		_full_loop_validate_aggregate_evidence "$destination_aggregate" "$new_repo" "$pr_number"
-	return $?
+	if [[ "$release_status" == "$_FULL_LOOP_RECEIPT_RELEASE_SUPERSEDED" ]]; then
+		destination_evidence=$(_full_loop_superseded_migration_evidence_path \
+			"$destination_release" "$new_repo" "$pr_number") || return 1
+		[[ -f "$destination_evidence" && ! -L "$destination_evidence" ]] || return 1
+	elif [[ -e "$aggregate_path" || -L "$aggregate_path" || -e "$successor_path" || -L "$successor_path" ]]; then
+		return 1
+	fi
+	return 0
 }
 
 _full_loop_migration_source_matches() {
 	local source_receipt="$1"
 	local source_release="$2"
-	local source_aggregate="$3"
-	local old_repo="$4"
-	local pr_number="$5"
-	local release_status="$6"
+	local old_repo="$3"
+	local pr_number="$4"
+	local release_status="$5"
 	local source_status=""
-	[[ -f "$source_receipt" && -f "$source_release" ]] || return 1
+	local source_evidence=""
+	local aggregate_path="${source_release%.status}.aggregate.json"
+	local successor_path="${source_release%.status}.successor.json"
+	[[ -f "$source_receipt" && ! -L "$source_receipt" ]] || return 1
+	[[ -f "$source_release" && ! -L "$source_release" ]] || return 1
 	jq -e --arg repo "$old_repo" --argjson pr "$pr_number" \
 		'.repository == $repo and .pr_number == $pr' "$source_receipt" >/dev/null 2>&1 || return 1
 	IFS= read -r source_status <"$source_release" || return 1
 	[[ "$source_status" == "$release_status" ]] || return 1
-	[[ "$release_status" != "$_FULL_LOOP_RECEIPT_RELEASE_SUPERSEDED" ]] ||
-		_full_loop_validate_aggregate_evidence "$source_aggregate" "$old_repo" "$pr_number"
-	return $?
+	if [[ "$release_status" == "$_FULL_LOOP_RECEIPT_RELEASE_SUPERSEDED" ]]; then
+		source_evidence=$(_full_loop_superseded_migration_evidence_path \
+			"$source_release" "$old_repo" "$pr_number") || return 1
+		[[ -f "$source_evidence" && ! -L "$source_evidence" ]] || return 1
+	elif [[ -e "$aggregate_path" || -L "$aggregate_path" || -e "$successor_path" || -L "$successor_path" ]]; then
+		return 1
+	fi
+	return 0
 }
 
 _full_loop_cleanup_receipt_dir() {
@@ -437,7 +565,9 @@ _full_loop_cleanup_receipt_for_worktree_unlocked() {
 		' "$receipt_path" >/dev/null 2>&1; then
 			candidate_created_at=$(jq -r '.created_at // empty' "$receipt_path" 2>/dev/null || true)
 			candidate_is_migrated=0
-			jq -e '.migration.from_repository | type == "string" and length > 0' "$receipt_path" >/dev/null 2>&1 && candidate_is_migrated=1
+			jq -e --arg string_type "$_FULL_LOOP_RECEIPT_JSON_STRING_TYPE" \
+				'.migration.from_repository | type == $string_type and length > 0' \
+				"$receipt_path" >/dev/null 2>&1 && candidate_is_migrated=1
 			if [[ -z "$selected_path" || "$candidate_created_at" > "$selected_created_at" ]] ||
 				[[ "$candidate_created_at" == "$selected_created_at" && "$candidate_is_migrated" -eq 1 && "$selected_is_migrated" -ne 1 ]]; then
 				selected_path="$receipt_path"
@@ -895,6 +1025,146 @@ full_loop_finalize_cleanup_receipt() {
 	return 0
 }
 
+_full_loop_reconcile_complete_migration() {
+	local old_repo="$1"
+	local new_repo="$2"
+	local pr_number="$3"
+	local source_receipt="$4"
+	local source_release="$5"
+	local destination_receipt="$6"
+	local destination_release="$7"
+	local release_status="$8"
+	local source_status=""
+	local source_evidence=""
+	local destination_evidence=""
+	local source_aggregate="${source_release%.status}.aggregate.json"
+	local source_successor="${source_release%.status}.successor.json"
+
+	[[ -f "$destination_receipt" && ! -L "$destination_receipt" ]] || return 2
+	_full_loop_migrated_destination_matches "$destination_receipt" "$destination_release" \
+		"$new_repo" "$old_repo" "$pr_number" "$release_status" || return 2
+	if [[ -e "$source_receipt" || -L "$source_receipt" ]]; then
+		[[ -f "$source_receipt" && ! -L "$source_receipt" ]] || return 1
+		_full_loop_migrated_cleanup_receipt_matches_source "$source_receipt" "$destination_receipt" \
+			"$old_repo" "$new_repo" "$pr_number" || return 3
+	fi
+	if [[ -e "$source_release" || -L "$source_release" ]]; then
+		[[ -f "$source_release" && ! -L "$source_release" ]] || return 1
+		IFS= read -r source_status <"$source_release" || return 1
+		[[ "$source_status" == "$release_status" ]] || return 1
+	fi
+	if [[ "$release_status" == "$_FULL_LOOP_RECEIPT_RELEASE_SUPERSEDED" ]]; then
+		[[ ! -L "$source_aggregate" && ! -L "$source_successor" ]] || return 1
+		destination_evidence=$(_full_loop_superseded_migration_evidence_path \
+			"$destination_release" "$new_repo" "$pr_number") || return 1
+		if [[ -e "$source_aggregate" || -e "$source_successor" ]]; then
+			source_evidence=$(_full_loop_superseded_migration_evidence_path \
+				"$source_release" "$old_repo" "$pr_number") || return 1
+			_full_loop_migrated_evidence_matches_source "$source_evidence" "$destination_evidence" \
+				"$old_repo" "$new_repo" "$pr_number" || return 1
+		fi
+	elif [[ -e "$source_aggregate" || -L "$source_aggregate" || -e "$source_successor" || -L "$source_successor" ]]; then
+		return 1
+	fi
+	rm -f "$source_receipt" "$source_release" "$source_aggregate" "$source_successor"
+	return $?
+}
+
+_full_loop_prepare_partial_migration_retry() {
+	local old_repo="$1"
+	local new_repo="$2"
+	local pr_number="$3"
+	local source_receipt="$4"
+	local source_evidence="$5"
+	local destination_receipt="$6"
+	local destination_release="$7"
+	local destination_evidence="$8"
+	local release_status="$9"
+	local destination_status=""
+	local aggregate_path="${destination_release%.status}.aggregate.json"
+	local successor_path="${destination_release%.status}.successor.json"
+	local artifacts_present=0
+
+	if [[ -e "$destination_receipt" || -L "$destination_receipt" ||
+		-e "$destination_release" || -L "$destination_release" ||
+		-e "$aggregate_path" || -L "$aggregate_path" ||
+		-e "$successor_path" || -L "$successor_path" ]]; then
+		artifacts_present=1
+	fi
+	[[ "$artifacts_present" -eq 1 ]] || return 0
+	if [[ -e "$destination_receipt" || -L "$destination_receipt" ]]; then
+		_full_loop_migrated_cleanup_receipt_matches_source "$source_receipt" "$destination_receipt" \
+			"$old_repo" "$new_repo" "$pr_number" || return 1
+	fi
+	if [[ -e "$destination_release" || -L "$destination_release" ]]; then
+		[[ -f "$destination_release" && ! -L "$destination_release" ]] || return 1
+		IFS= read -r destination_status <"$destination_release" || return 1
+		[[ "$destination_status" == "$release_status" ]] || return 1
+	fi
+	if [[ "$release_status" == "$_FULL_LOOP_RECEIPT_RELEASE_SUPERSEDED" ]]; then
+		[[ -n "$source_evidence" && -n "$destination_evidence" ]] || return 1
+		case "$destination_evidence" in
+		*.aggregate.json) [[ ! -e "$successor_path" && ! -L "$successor_path" ]] || return 1 ;;
+		*.successor.json) [[ ! -e "$aggregate_path" && ! -L "$aggregate_path" ]] || return 1 ;;
+		*) return 1 ;;
+		esac
+		if [[ -e "$destination_evidence" || -L "$destination_evidence" ]]; then
+			_full_loop_migrated_evidence_matches_source "$source_evidence" "$destination_evidence" \
+				"$old_repo" "$new_repo" "$pr_number" || return 1
+		fi
+	elif [[ -e "$aggregate_path" || -L "$aggregate_path" || -e "$successor_path" || -L "$successor_path" ]]; then
+		return 1
+	fi
+	rm -f "$destination_receipt" "$destination_release" "$aggregate_path" "$successor_path"
+	return $?
+}
+
+_full_loop_write_migrated_cleanup_receipt() {
+	local old_repo="$1"
+	local new_repo="$2"
+	local release_status="$3"
+	local source_receipt="$4"
+	local destination_receipt="$5"
+	local destination_release="$6"
+	local source_evidence="$7"
+	local destination_evidence="$8"
+	local now=""
+
+	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+	mkdir -p "${destination_release%/*}" || return 1
+	jq --arg repo "$new_repo" --arg old_repo "$old_repo" --arg now "$now" '
+		.repository = $repo
+		| .updated_at = $now
+		| .migration = {from_repository:$old_repo,to_repository:$repo,migrated_at:$now}
+	' "$source_receipt" >"${destination_receipt}.tmp.$$" || return 1
+	printf '%s\n' "$release_status" >"${destination_release}.tmp.$$" || {
+		rm -f "${destination_receipt}.tmp.$$"
+		return 1
+	}
+	if [[ "$release_status" == "$_FULL_LOOP_RECEIPT_RELEASE_SUPERSEDED" ]]; then
+		_full_loop_prepare_migrated_superseded_evidence \
+			"$source_evidence" "$destination_evidence" "$old_repo" "$new_repo" "$now" || {
+			rm -f "${destination_receipt}.tmp.$$" "${destination_release}.tmp.$$" "${destination_evidence}.tmp.$$"
+			return 1
+		}
+		mv "${destination_evidence}.tmp.$$" "$destination_evidence" || {
+			rm -f "${destination_receipt}.tmp.$$" "${destination_release}.tmp.$$" "${destination_evidence}.tmp.$$"
+			return 1
+		}
+	fi
+	mv "${destination_receipt}.tmp.$$" "$destination_receipt" || {
+		rm -f "${destination_release}.tmp.$$"
+		[[ -z "$destination_evidence" ]] || rm -f "$destination_evidence"
+		return 1
+	}
+	if ! mv "${destination_release}.tmp.$$" "$destination_release"; then
+		rm -f "$destination_receipt"
+		[[ -z "$destination_evidence" ]] || rm -f "$destination_evidence"
+		return 1
+	fi
+	return 0
+}
+
 full_loop_migrate_cleanup_receipt() {
 	local old_repo="$1"
 	local new_repo="$2"
@@ -904,83 +1174,66 @@ full_loop_migrate_cleanup_receipt() {
 	local release_status="$6"
 	local source_receipt=""
 	local destination_receipt=""
-	local source_aggregate="${source_release%.status}.aggregate.json"
-	local destination_aggregate="${destination_release%.status}.aggregate.json"
-	local now=""
+	local source_evidence=""
+	local destination_evidence=""
+	local existing_destination_rc=0
 	[[ "$old_repo" != "$new_repo" ]] || return 1
 	[[ "$release_status" == "$_FULL_LOOP_RECEIPT_RELEASE_PUBLISHED" || "$release_status" == "$_FULL_LOOP_RECEIPT_RELEASE_SUPERSEDED" || "$release_status" == "$_FULL_LOOP_RECEIPT_RELEASE_NOT_REQUESTED" ]] || return 1
 	source_receipt=$(_full_loop_cleanup_receipt_path "$old_repo" "$pr_number") || return 1
 	destination_receipt=$(_full_loop_cleanup_receipt_path "$new_repo" "$pr_number") || return 1
 	_full_loop_receipt_lock_acquire || return 1
 
-	if [[ -f "$destination_receipt" ]]; then
-		if _full_loop_migrated_destination_matches "$destination_receipt" "$destination_release" "$destination_aggregate" \
-			"$new_repo" "$old_repo" "$pr_number" "$release_status"; then
-			if [[ -f "$source_receipt" ]] && jq -e --slurpfile destination "$destination_receipt" '
-				.worktree == $destination[0].worktree
-				and .branch == $destination[0].branch
-				and .created_at == $destination[0].created_at
-				and .owner.process_identity == $destination[0].owner.process_identity
-			' "$source_receipt" >/dev/null 2>&1; then
-				rm -f "$source_release" "$source_receipt" "$source_aggregate"
-			fi
-			_full_loop_receipt_lock_release
-			return 0
-		fi
+	_full_loop_reconcile_complete_migration "$old_repo" "$new_repo" "$pr_number" \
+		"$source_receipt" "$source_release" "$destination_receipt" "$destination_release" \
+		"$release_status" || existing_destination_rc=$?
+	case "$existing_destination_rc" in
+	0)
+		_full_loop_receipt_lock_release
+		return 0
+		;;
+	2) ;;
+	3)
+		_full_loop_receipt_lock_release
+		return 0
+		;;
+	*)
 		_full_loop_receipt_lock_release
 		return 1
-	fi
-	if ! _full_loop_migration_source_matches "$source_receipt" "$source_release" "$source_aggregate" \
+		;;
+	esac
+	if ! _full_loop_migration_source_matches "$source_receipt" "$source_release" \
 		"$old_repo" "$pr_number" "$release_status"; then
 		_full_loop_receipt_lock_release
 		return 1
 	fi
-	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || {
-		_full_loop_receipt_lock_release
-		return 1
-	}
-	mkdir -p "${destination_release%/*}" || {
-		_full_loop_receipt_lock_release
-		return 1
-	}
-	jq --arg repo "$new_repo" --arg old_repo "$old_repo" --arg now "$now" '
-		.repository = $repo
-		| .updated_at = $now
-		| .migration = {from_repository:$old_repo,to_repository:$repo,migrated_at:$now}
-	' "$source_receipt" >"${destination_receipt}.tmp.$$" || {
-		_full_loop_receipt_lock_release
-		return 1
-	}
-	printf '%s\n' "$release_status" >"${destination_release}.tmp.$$" || {
-		rm -f "${destination_receipt}.tmp.$$"
-		_full_loop_receipt_lock_release
-		return 1
-	}
 	if [[ "$release_status" == "$_FULL_LOOP_RECEIPT_RELEASE_SUPERSEDED" ]]; then
-		_full_loop_prepare_migrated_aggregate_evidence \
-			"$source_aggregate" "$destination_aggregate" "$old_repo" "$new_repo" "$now" || {
-			rm -f "${destination_receipt}.tmp.$$" "${destination_release}.tmp.$$"
+		source_evidence=$(_full_loop_superseded_migration_evidence_path \
+			"$source_release" "$old_repo" "$pr_number") || {
 			_full_loop_receipt_lock_release
 			return 1
 		}
-		mv "${destination_aggregate}.tmp.$$" "$destination_aggregate" || {
-			rm -f "${destination_receipt}.tmp.$$" "${destination_release}.tmp.$$"
+		case "$source_evidence" in
+		*.aggregate.json) destination_evidence="${destination_release%.status}.aggregate.json" ;;
+		*.successor.json) destination_evidence="${destination_release%.status}.successor.json" ;;
+		*)
 			_full_loop_receipt_lock_release
 			return 1
-		}
+			;;
+		esac
 	fi
-	mv "${destination_receipt}.tmp.$$" "$destination_receipt" || {
-		rm -f "${destination_release}.tmp.$$"
-		rm -f "$destination_aggregate"
-		_full_loop_receipt_lock_release
-		return 1
-	}
-	if ! mv "${destination_release}.tmp.$$" "$destination_release"; then
-		rm -f "$destination_receipt" "$destination_aggregate"
+	if ! _full_loop_prepare_partial_migration_retry "$old_repo" "$new_repo" "$pr_number" \
+		"$source_receipt" "$source_evidence" "$destination_receipt" "$destination_release" \
+		"$destination_evidence" "$release_status"; then
 		_full_loop_receipt_lock_release
 		return 1
 	fi
-	rm -f "$source_release" "$source_receipt" "$source_aggregate" || {
+	if ! _full_loop_write_migrated_cleanup_receipt \
+		"$old_repo" "$new_repo" "$release_status" "$source_receipt" \
+		"$destination_receipt" "$destination_release" "$source_evidence" "$destination_evidence"; then
+		_full_loop_receipt_lock_release
+		return 1
+	fi
+	rm -f "$source_release" "$source_receipt" "$source_evidence" || {
 		_full_loop_receipt_lock_release
 		return 1
 	}

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -28,6 +28,8 @@ _FULL_LOOP_RELEASE_NOT_REQUESTED="not-requested"
 _FULL_LOOP_RELEASE_PUBLISHED="published"
 _FULL_LOOP_RELEASE_SUPERSEDED="superseded"
 _FULL_LOOP_SHA40_REGEX='^[0-9a-f]{40}$'
+_FULL_LOOP_VERSION_TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+$'
+_FULL_LOOP_JSON_NUMBER_TYPE="number"
 _FULL_LOOP_EXECUTOR_INITIALIZED="initialized-only"
 _FULL_LOOP_EXECUTOR_IN_PROGRESS="in-progress"
 _FULL_LOOP_PHASE_FAILED="failed"
@@ -290,7 +292,7 @@ _full_loop_release_evidence_path() {
 	local pr_number="$2"
 	local evidence_type="$3"
 	local receipt_path=""
-	case "$evidence_type" in aggregate | failure) ;; *) return 1 ;; esac
+	case "$evidence_type" in aggregate | failure | successor) ;; *) return 1 ;; esac
 	receipt_path=$(_full_loop_release_receipt_path "$repo" "$pr_number") || return 1
 	printf '%s.%s.json\n' "${receipt_path%.status}" "$evidence_type"
 	return 0
@@ -317,7 +319,7 @@ _full_loop_write_release_receipt() {
 	if [[ "$status" == "$_FULL_LOOP_RELEASE_PUBLISHED" || "$status" == "$_FULL_LOOP_RELEASE_SUPERSEDED" ]]; then
 		local failure_path=""
 		failure_path=$(_full_loop_release_evidence_path "$repo" "$pr_number" failure) || return 1
-		rm -f "$failure_path"
+		rm -f "$failure_path" || return 1
 	fi
 	return 0
 }
@@ -355,11 +357,14 @@ _full_loop_write_superseded_release_receipt() {
 	local tag_name="$6"
 	local tag_commit="$7"
 	local evidence_path=""
+	local successor_path=""
 	local now=""
 	[[ "$pr_number" =~ ^[0-9]+$ && "$aggregate_pr" =~ ^[0-9]+$ ]] || return 1
 	[[ "$source_merge" =~ $_FULL_LOOP_SHA40_REGEX && "$aggregate_merge" =~ $_FULL_LOOP_SHA40_REGEX && "$tag_commit" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
-	[[ "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+	[[ "$tag_name" =~ $_FULL_LOOP_VERSION_TAG_REGEX ]] || return 1
 	evidence_path=$(_full_loop_release_evidence_path "$repo" "$pr_number" aggregate) || return 1
+	successor_path=$(_full_loop_release_evidence_path "$repo" "$pr_number" successor) || return 1
+	[[ ! -e "$successor_path" ]] || return 1
 	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
 	mkdir -p "${evidence_path%/*}" || return 1
 	jq -cn --arg repo "$repo" --arg status "$_FULL_LOOP_RELEASE_SUPERSEDED" --argjson pr_number "$pr_number" --arg source_merge "$source_merge" \
@@ -370,24 +375,127 @@ _full_loop_write_superseded_release_receipt() {
 		>"${evidence_path}.tmp.$$" || return 1
 	mv "${evidence_path}.tmp.$$" "$evidence_path" || return 1
 	_full_loop_write_release_receipt "$repo" "$pr_number" "$_FULL_LOOP_RELEASE_SUPERSEDED" || return 1
+	_full_loop_update_superseded_cleanup_receipt "$repo" "$pr_number"
+	return $?
+}
+
+_full_loop_update_superseded_cleanup_receipt() {
+	local repo="$1"
+	local pr_number="$2"
 	if declare -F full_loop_update_cleanup_release_status >/dev/null 2>&1; then
 		full_loop_update_cleanup_release_status "$repo" "$pr_number" "$_FULL_LOOP_RELEASE_SUPERSEDED" || return 1
 	fi
 	return 0
 }
 
+_full_loop_verify_aggregate_superseded_release_evidence() {
+	local evidence_path="$1"
+	local repo="$2"
+	local pr_number="$3"
+	[[ "$evidence_path" == *.aggregate.json ]] || return 1
+	_full_loop_validate_superseded_evidence "$evidence_path" "$repo" "$pr_number"
+	return $?
+}
+
+_full_loop_verify_successor_superseded_release_evidence() {
+	local evidence_path="$1"
+	local repo="$2"
+	local pr_number="$3"
+	[[ "$evidence_path" == *.successor.json ]] || return 1
+	_full_loop_validate_superseded_evidence "$evidence_path" "$repo" "$pr_number"
+	return $?
+}
+
+_full_loop_superseded_release_evidence_path() {
+	local repo="$1"
+	local pr_number="$2"
+	local aggregate_path=""
+	local successor_path=""
+	local evidence_path=""
+	aggregate_path=$(_full_loop_release_evidence_path "$repo" "$pr_number" aggregate) || return 1
+	successor_path=$(_full_loop_release_evidence_path "$repo" "$pr_number" successor) || return 1
+	if [[ -f "$aggregate_path" ]]; then
+		_full_loop_verify_aggregate_superseded_release_evidence \
+			"$aggregate_path" "$repo" "$pr_number" || return 1
+		evidence_path="$aggregate_path"
+	fi
+	if [[ -f "$successor_path" ]]; then
+		[[ -z "$evidence_path" ]] || return 1
+		_full_loop_verify_successor_superseded_release_evidence \
+			"$successor_path" "$repo" "$pr_number" || return 1
+		evidence_path="$successor_path"
+	fi
+	[[ -n "$evidence_path" ]] || return 1
+	printf '%s\n' "$evidence_path"
+	return 0
+}
+
 _full_loop_verify_superseded_release_receipt() {
 	local repo="$1"
 	local pr_number="$2"
+	_full_loop_superseded_release_evidence_path "$repo" "$pr_number" >/dev/null
+	return $?
+}
+
+_full_loop_write_successor_release_receipt() {
+	local repo="$1"
+	local source_pr="$2"
+	local source_merge="$3"
+	local source_tag="$4"
+	local source_commit="$5"
+	local source_run="$6"
+	local successor_pr="$7"
+	local successor_merge="$8"
+	local release_tag="$9"
+	shift 9
+	local release_commit="$1"
+	local release_run="$2"
+	local aggregate_path=""
 	local evidence_path=""
-	evidence_path=$(_full_loop_release_evidence_path "$repo" "$pr_number" aggregate) || return 1
-	[[ -f "$evidence_path" ]] || return 1
-	jq -e --arg repo "$repo" --arg status "$_FULL_LOOP_RELEASE_SUPERSEDED" --arg sha_regex "$_FULL_LOOP_SHA40_REGEX" --argjson pr "$pr_number" '
-		.schema_version == 1 and .status == $status and .repository == $repo and .pr_number == $pr
-		and (.source_merge | test($sha_regex)) and (.aggregate_pr | type == "number")
-		and (.aggregate_merge | test($sha_regex)) and (.release_tag | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))
-		and (.release_commit | test($sha_regex))
-	' "$evidence_path" >/dev/null 2>&1
+	local now=""
+	[[ "$source_pr" =~ ^[0-9]+$ && "$successor_pr" =~ ^[0-9]+$ && "$source_pr" != "$successor_pr" ]] || return 1
+	[[ "$source_merge" =~ $_FULL_LOOP_SHA40_REGEX && "$successor_merge" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+	[[ "$source_commit" =~ $_FULL_LOOP_SHA40_REGEX && "$release_commit" =~ $_FULL_LOOP_SHA40_REGEX && "$source_commit" != "$release_commit" ]] || return 1
+	[[ "$source_tag" =~ $_FULL_LOOP_VERSION_TAG_REGEX && "$release_tag" =~ $_FULL_LOOP_VERSION_TAG_REGEX && "$source_tag" != "$release_tag" ]] || return 1
+	[[ "$source_run" =~ ^[0-9]+$ && "$release_run" =~ ^[0-9]+$ && "$source_run" -gt 0 && "$release_run" -gt 0 && "$source_run" != "$release_run" ]] || return 1
+	aggregate_path=$(_full_loop_release_evidence_path "$repo" "$source_pr" aggregate) || return 1
+	evidence_path=$(_full_loop_release_evidence_path "$repo" "$source_pr" successor) || return 1
+	[[ ! -e "$aggregate_path" ]] || return 1
+	if [[ -f "$evidence_path" ]]; then
+		_full_loop_verify_successor_superseded_release_evidence \
+			"$evidence_path" "$repo" "$source_pr" || return 1
+		jq -e --arg source_merge "$source_merge" --arg source_tag "$source_tag" \
+			--arg source_commit "$source_commit" --argjson source_run "$source_run" \
+			--argjson successor_pr "$successor_pr" --arg successor_merge "$successor_merge" \
+			--arg release_tag "$release_tag" --arg release_commit "$release_commit" \
+			--argjson release_run "$release_run" '
+			.source_merge == $source_merge and .source_release_tag == $source_tag
+			and .source_release_commit == $source_commit and .source_workflow_run == $source_run
+			and .successor_pr == $successor_pr and .successor_merge == $successor_merge
+			and .release_tag == $release_tag and .release_commit == $release_commit
+			and .release_workflow_run == $release_run
+		' "$evidence_path" >/dev/null 2>&1 || return 1
+	else
+		now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+		mkdir -p "${evidence_path%/*}" || return 1
+		jq -cn --arg repo "$repo" --arg status "$_FULL_LOOP_RELEASE_SUPERSEDED" \
+			--arg evidence_type "post-publication-supersession" --argjson source_pr "$source_pr" \
+			--arg source_merge "$source_merge" --arg source_tag "$source_tag" \
+			--arg source_commit "$source_commit" --argjson source_run "$source_run" \
+			--argjson successor_pr "$successor_pr" --arg successor_merge "$successor_merge" \
+			--arg release_tag "$release_tag" --arg release_commit "$release_commit" \
+			--argjson release_run "$release_run" --arg now "$now" '
+			{schema_version:1,evidence_type:$evidence_type,status:$status,repository:$repo,
+			 pr_number:$source_pr,source_pr:$source_pr,source_merge:$source_merge,
+			 source_release_tag:$source_tag,source_release_commit:$source_commit,
+			 source_workflow_run:$source_run,successor_pr:$successor_pr,successor_merge:$successor_merge,
+			 release_tag:$release_tag,release_commit:$release_commit,
+			 release_workflow_run:$release_run,recorded_at:$now}
+		' >"${evidence_path}.tmp.$$" || return 1
+		mv "${evidence_path}.tmp.$$" "$evidence_path" || return 1
+	fi
+	_full_loop_write_release_receipt "$repo" "$source_pr" "$_FULL_LOOP_RELEASE_SUPERSEDED" || return 1
+	_full_loop_update_superseded_cleanup_receipt "$repo" "$source_pr"
 	return $?
 }
 
@@ -1555,10 +1663,10 @@ _full_loop_verify_aidevops_release_deploy() {
 	local expected_release_sha=""
 	if [[ "$release_status" == "$_FULL_LOOP_RELEASE_SUPERSEDED" ]]; then
 		_full_loop_verify_superseded_release_receipt "$repo" "$pr_number" || return 1
-		local aggregate_evidence=""
-		aggregate_evidence=$(_full_loop_release_evidence_path "$repo" "$pr_number" aggregate) || return 1
-		tag_name=$(jq -er '.release_tag' "$aggregate_evidence") || return 1
-		expected_release_sha=$(jq -er '.release_commit' "$aggregate_evidence") || return 1
+		local superseded_evidence=""
+		superseded_evidence=$(_full_loop_superseded_release_evidence_path "$repo" "$pr_number") || return 1
+		tag_name=$(jq -er '.release_tag' "$superseded_evidence") || return 1
+		expected_release_sha=$(jq -er '.release_commit' "$superseded_evidence") || return 1
 		version="${tag_name#v}"
 	else
 		[[ "$release_status" == "$_FULL_LOOP_RELEASE_PUBLISHED" ]] || return 1

--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -228,7 +228,8 @@ Usage:
 Release publication is provenance-bound and normally unattended. `status` is
 read-only. `reconcile` verifies the newest matching signed tag, queues an
 idempotent recovery workflow when needed, and finalizes local release receipts
-only after GitHub, npm, and Homebrew all converge.
+only after GitHub, npm, and Homebrew all converge. A published stale tag can be
+settled only by verified post-publication supersession; it is never redispatched.
 EOF
 	return 0
 }

--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -8,12 +8,20 @@ _FULL_LOOP_RELEASE_RECONCILE_LOADED=1
 
 _FULL_LOOP_RELEASE_FOUND_TAG=""
 _FULL_LOOP_RELEASE_RUN_JSON=""
+_FULL_LOOP_RELEASE_RUN_JOBS_JSON=""
 _FULL_LOOP_RELEASE_NPM_VERSION=""
 _FULL_LOOP_RELEASE_NPM_INTEGRITY=""
 _FULL_LOOP_RELEASE_EVENT_PUSH="push"
 _FULL_LOOP_RELEASE_EVENT_RECOVERY="workflow_dispatch"
 _FULL_LOOP_RELEASE_JSON_ARRAY_TYPE="array"
+_FULL_LOOP_RELEASE_JSON_NUMBER_TYPE="number"
+_FULL_LOOP_RELEASE_STATUS_COMPLETED="completed"
+_FULL_LOOP_RELEASE_CONCLUSION_FAILURE="failure"
+_FULL_LOOP_RELEASE_CONCLUSION_SKIPPED="skipped"
+_FULL_LOOP_RELEASE_CONCLUSION_SUCCESS="success"
 _FULL_LOOP_RELEASE_JSON_STRING_TYPE="string"
+_FULL_LOOP_RELEASE_MODE_RECONCILE="reconcile"
+_FULL_LOOP_RELEASE_STEP_QUEUE_POSTFLIGHT="Queue exact-tag postflight"
 _FULL_LOOP_RELEASE_PROVENANCE_PREDICATE="https://slsa.dev/provenance/v1"
 _FULL_LOOP_RELEASE_TRUE="true"
 
@@ -223,7 +231,8 @@ _full_loop_release_source_json_from_tag() {
 
 _full_loop_release_runs_payload_valid() {
 	local runs_json="$1"
-	jq -e 'type == "object" and (.workflow_runs | type == "array")' \
+	jq -e --arg array_type "$_FULL_LOOP_RELEASE_JSON_ARRAY_TYPE" \
+		'type == "object" and (.workflow_runs | type == $array_type)' \
 		<<<"$runs_json" >/dev/null
 	return $?
 }
@@ -243,12 +252,12 @@ _full_loop_release_find_workflow_run() {
 		-f event=workflow_dispatch -F per_page=50 2>/dev/null) || return 1
 	_full_loop_release_runs_payload_valid "$push_runs" || return 1
 	_full_loop_release_runs_payload_valid "$recovery_runs" || return 1
-	_FULL_LOOP_RELEASE_RUN_JSON=$(jq -cn --arg sha "$tag_commit" --arg title "$display_title" \
+	_FULL_LOOP_RELEASE_RUN_JSON=$(jq -cn --arg sha "$tag_commit" --arg tag "$tag_name" --arg title "$display_title" \
 		--arg push_event "$_FULL_LOOP_RELEASE_EVENT_PUSH" \
 		--arg recovery_event "$_FULL_LOOP_RELEASE_EVENT_RECOVERY" \
 		--arg string_type "$_FULL_LOOP_RELEASE_JSON_STRING_TYPE" \
 		--argjson push "$push_runs" --argjson recovery "$recovery_runs" '
-		([($push.workflow_runs[]? | select(.event == $push_event and .head_sha == $sha))]
+		([($push.workflow_runs[]? | select(.event == $push_event and .head_branch == $tag and .head_sha == $sha))]
 		 + [($recovery.workflow_runs[]?
 			| select(.event == $recovery_event and .head_branch == "main"
 				and ((.head_sha | type) == $string_type)
@@ -258,9 +267,11 @@ _full_loop_release_find_workflow_run() {
 	') || return 1
 	[[ -n "$_FULL_LOOP_RELEASE_RUN_JSON" && "$_FULL_LOOP_RELEASE_RUN_JSON" != "null" ]] || return 3
 	jq -e --arg string_type "$_FULL_LOOP_RELEASE_JSON_STRING_TYPE" \
+		--arg number_type "$_FULL_LOOP_RELEASE_JSON_NUMBER_TYPE" \
+		--arg completed "$_FULL_LOOP_RELEASE_STATUS_COMPLETED" \
 		--arg push_event "$_FULL_LOOP_RELEASE_EVENT_PUSH" \
 		--arg recovery_event "$_FULL_LOOP_RELEASE_EVENT_RECOVERY" '
-		((.id | type) == "number")
+		((.id | type) == $number_type)
 		and (.event == $push_event or .event == $recovery_event)
 		and ((.head_sha | type) == $string_type)
 		and (.head_sha | test("^[0-9a-f]{40}$"))
@@ -268,11 +279,96 @@ _full_loop_release_find_workflow_run() {
 		and ((.status // "") | length > 0)
 		and ((.created_at | type) == $string_type)
 		and ((.created_at // "") | length > 0)
-		and (if .status == "completed" then
+		and (if .status == $completed then
 			((.conclusion | type) == $string_type) and ((.conclusion // "") | length > 0)
 		else .conclusion == null or ((.conclusion | type) == $string_type) end)
 	' <<<"$_FULL_LOOP_RELEASE_RUN_JSON" >/dev/null || return 1
 	return 0
+}
+
+_full_loop_release_run_jobs_payload_valid() {
+	local jobs_json="$1"
+	jq -e --arg array_type "$_FULL_LOOP_RELEASE_JSON_ARRAY_TYPE" \
+		--arg number_type "$_FULL_LOOP_RELEASE_JSON_NUMBER_TYPE" '
+		type == "object" and (.total_count | type == $number_type and . >= 0 and floor == .)
+		and (.jobs | type == $array_type) and .total_count == (.jobs | length)
+	' <<<"$jobs_json" >/dev/null
+	return $?
+}
+
+_full_loop_release_fetch_run_jobs() {
+	local repo="$1"
+	local run_id="$2"
+	local jobs_json=""
+	[[ "$repo" == */* && "$run_id" =~ ^[0-9]+$ && "$run_id" -gt 0 ]] || return 1
+	_FULL_LOOP_RELEASE_RUN_JOBS_JSON=""
+	jobs_json=$(gh api --method GET "repos/${repo}/actions/runs/${run_id}/jobs" \
+		-F per_page=100 2>/dev/null) || return 1
+	_full_loop_release_run_jobs_payload_valid "$jobs_json" || return 1
+	_FULL_LOOP_RELEASE_RUN_JOBS_JSON="$jobs_json"
+	return 0
+}
+
+_full_loop_release_stale_publication_jobs_valid() {
+	local jobs_json="$1"
+	jq -e --arg array_type "$_FULL_LOOP_RELEASE_JSON_ARRAY_TYPE" \
+		--arg number_type "$_FULL_LOOP_RELEASE_JSON_NUMBER_TYPE" \
+		--arg completed "$_FULL_LOOP_RELEASE_STATUS_COMPLETED" \
+		--arg failure "$_FULL_LOOP_RELEASE_CONCLUSION_FAILURE" \
+		--arg skipped "$_FULL_LOOP_RELEASE_CONCLUSION_SKIPPED" \
+		--arg success "$_FULL_LOOP_RELEASE_CONCLUSION_SUCCESS" \
+		--arg queue_step "$_FULL_LOOP_RELEASE_STEP_QUEUE_POSTFLIGHT" '
+		. as $payload
+		| ($payload.jobs | length) == 1
+		and ($payload.jobs[0] as $job
+			| $job.name == "Publish GitHub, npm, and Homebrew"
+			and $job.status == $completed and $job.conclusion == $failure
+			and ($job.steps | type == $array_type and length > 0)
+			and ([$job.steps[] | select(.name == $queue_step)] | length == 1)
+			and ([$job.steps[] | select(.conclusion == $failure)] | length == 1)
+			and (($job.steps | map(.number)) as $numbers
+				| ($numbers | all(type == $number_type and . > 0 and floor == .))
+				and ($numbers | length) == ($numbers | unique | length))
+			and (($job.steps | map(select(.name == $queue_step))[0].number) as $queue_number
+				| ([$job.steps[] | select(.name == "Checkout verified tag")] | length == 1)
+				and ([$job.steps[] | select(.name == "Checkout verified tag" and .number < $queue_number and .status == $completed and .conclusion == $success)] | length == 1)
+				and ([$job.steps[] | select(.name == "Verify immutable release provenance")] | length == 1)
+				and ([$job.steps[] | select(.name == "Verify immutable release provenance" and .number < $queue_number and .status == $completed and .conclusion == $success)] | length == 1)
+				and ([$job.steps[] | select(.name == "Create or reconcile GitHub release")] | length == 1)
+				and ([$job.steps[] | select(.name == "Create or reconcile GitHub release" and .number < $queue_number and .status == $completed and .conclusion == $success)] | length == 1)
+				and ([$job.steps[] | select(.name == "Verify npm publication")] | length == 1)
+				and ([$job.steps[] | select(.name == "Verify npm publication" and .number < $queue_number and .status == $completed and .conclusion == $success)] | length == 1)
+				and ([$job.steps[] | select(.name == "Verify Homebrew tap")] | length == 1)
+				and ([$job.steps[] | select(.name == "Verify Homebrew tap" and .number < $queue_number and .status == $completed and .conclusion == $success)] | length == 1)
+				and ($job.steps | all(
+					.status == $completed
+					and if .name == $queue_step then .conclusion == $failure
+					else (.conclusion == $success or .conclusion == $skipped) end))))
+	' <<<"$jobs_json" >/dev/null
+	return $?
+}
+
+_full_loop_release_verify_stale_publication_run() {
+	local repo="$1"
+	local tag_name="$2"
+	local tag_commit="$3"
+	local run_id=""
+	local run_status=""
+	local run_conclusion=""
+	_full_loop_release_find_workflow_run "$repo" "$tag_name" "$tag_commit" || return 1
+	run_id=$(jq -er --arg number_type "$_FULL_LOOP_RELEASE_JSON_NUMBER_TYPE" \
+		'.id | select(type == $number_type and . > 0 and floor == .)' \
+		<<<"$_FULL_LOOP_RELEASE_RUN_JSON") || return 1
+	run_status=$(jq -er --arg string_type "$_FULL_LOOP_RELEASE_JSON_STRING_TYPE" \
+		'.status | select(type == $string_type)' \
+		<<<"$_FULL_LOOP_RELEASE_RUN_JSON") || return 1
+	run_conclusion=$(jq -er --arg string_type "$_FULL_LOOP_RELEASE_JSON_STRING_TYPE" \
+		'.conclusion | select(type == $string_type)' \
+		<<<"$_FULL_LOOP_RELEASE_RUN_JSON") || return 1
+	[[ "$run_status" == "$_FULL_LOOP_RELEASE_STATUS_COMPLETED" && "$run_conclusion" == "$_FULL_LOOP_RELEASE_CONCLUSION_FAILURE" ]] || return 1
+	_full_loop_release_fetch_run_jobs "$repo" "$run_id" || return 1
+	_full_loop_release_stale_publication_jobs_valid "$_FULL_LOOP_RELEASE_RUN_JOBS_JSON"
+	return $?
 }
 
 _full_loop_release_sha256_stream() {
@@ -540,6 +636,18 @@ _full_loop_release_prepare_tag_worktree() {
 	return 0
 }
 
+_full_loop_release_reset_tag_worktree() {
+	local release_path="${_FULL_LOOP_RELEASE_PATH:-}"
+	local control_path="${_FULL_LOOP_RELEASE_CONTROL_PATH:-}"
+	[[ -n "$release_path" ]] || return 0
+	[[ -z "$control_path" || "$release_path" != "$control_path" ]] || return 1
+	if [[ -d "$release_path" ]]; then
+		git -C "$REPO_ROOT" worktree remove "$release_path" >/dev/null 2>&1 || return 1
+	fi
+	_FULL_LOOP_RELEASE_PATH=""
+	return 0
+}
+
 _full_loop_release_finalize_reconciliation() {
 	local repo="$1"
 	local requested_pr="$2"
@@ -576,6 +684,66 @@ _full_loop_release_finalize_reconciliation() {
 	return $?
 }
 
+_full_loop_release_finalize_stale_supersession() {
+	local repo="$1"
+	local requested_pr="$2"
+	local source_tag="$3"
+	local release_tag="$4"
+	local source_json=""
+	local source_merge=""
+	local source_commit=""
+	local source_run=""
+	local release_json=""
+	local successor_pr=""
+	local successor_merge=""
+	local release_commit=""
+	local release_run=""
+	local release_receipt=""
+	local release_status=""
+
+	source_json=$(_full_loop_release_source_json_from_tag "$source_tag") || return 1
+	source_merge=$(jq -er --argjson requested "$requested_pr" '
+		if .source_pr == $requested then .source_merge
+		else .aggregated_sources[] | select(.pr == $requested) | .merge end
+	' <<<"$source_json") || return 1
+	[[ "$source_merge" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+	source_commit=$(_full_loop_release_resolve_tag_commit "$source_tag") || return 1
+	_full_loop_release_verify_stale_publication_run \
+		"$repo" "$source_tag" "$source_commit" || return 1
+	source_run=$(jq -er --arg number_type "$_FULL_LOOP_RELEASE_JSON_NUMBER_TYPE" \
+		'.id | select(type == $number_type and . > 0 and floor == .)' \
+		<<<"$_FULL_LOOP_RELEASE_RUN_JSON") || return 1
+
+	_full_loop_release_reset_tag_worktree || return 1
+	_full_loop_release_verify_tag_provenance "$repo" "$release_tag" || return 1
+	release_json=$(_full_loop_release_source_json_from_tag "$release_tag") || return 1
+	successor_pr=$(jq -er --arg number_type "$_FULL_LOOP_RELEASE_JSON_NUMBER_TYPE" \
+		'.source_pr | select(type == $number_type and . > 0 and floor == .)' \
+		<<<"$release_json") || return 1
+	successor_merge=$(jq -er --arg string_type "$_FULL_LOOP_RELEASE_JSON_STRING_TYPE" \
+		'.source_merge | select(type == $string_type)' \
+		<<<"$release_json") || return 1
+	[[ "$successor_merge" =~ $_FULL_LOOP_SHA40_REGEX && "$successor_pr" != "$requested_pr" ]] || return 1
+	release_commit=$(_full_loop_release_resolve_tag_commit "$release_tag") || return 1
+	[[ "$source_commit" != "$release_commit" ]] || return 1
+	git -C "$REPO_ROOT" merge-base --is-ancestor "$source_commit" "$release_commit" \
+		>/dev/null 2>&1 || return 1
+	_full_loop_release_inspect_remote "$repo" "$release_tag" || return 1
+	release_run=$(jq -er --arg number_type "$_FULL_LOOP_RELEASE_JSON_NUMBER_TYPE" \
+		'.id | select(type == $number_type and . > 0 and floor == .)' \
+		<<<"$_FULL_LOOP_RELEASE_RUN_JSON") || return 1
+	[[ "$source_run" != "$release_run" ]] || return 1
+	release_receipt=$(_full_loop_release_receipt_path "$repo" "$successor_pr") || return 1
+	[[ -f "$release_receipt" ]] || return 1
+	IFS= read -r release_status <"$release_receipt" || return 1
+	[[ "$release_status" == "$_FULL_LOOP_RELEASE_PUBLISHED" ]] || return 1
+
+	_full_loop_write_successor_release_receipt "$repo" "$requested_pr" "$source_merge" \
+		"$source_tag" "$source_commit" "$source_run" "$successor_pr" "$successor_merge" \
+		"$release_tag" "$release_commit" "$release_run"
+	return $?
+}
+
 _full_loop_release_existing_command() {
 	local mode="$1"
 	local requested_pr="$2"
@@ -586,7 +754,7 @@ _full_loop_release_existing_command() {
 	local receipt_path=""
 	local receipt_status=""
 
-	[[ "$mode" == "status" || "$mode" == "reconcile" ]] || return 1
+	[[ "$mode" == "status" || "$mode" == "$_FULL_LOOP_RELEASE_MODE_RECONCILE" ]] || return 1
 	[[ "$requested_pr" =~ ^[0-9]+$ ]] || return 1
 	repo=$(_full_loop_resolve_repo "${AIDEVOPS_FULL_LOOP_REPO:-}") || return 1
 	receipt_path=$(_full_loop_release_receipt_path "$repo" "$requested_pr") || return 1
@@ -608,17 +776,31 @@ _full_loop_release_existing_command() {
 	latest_tag=$(_full_loop_release_latest_tag) || return 1
 	if [[ "$tag_name" != "$latest_tag" ]]; then
 		printf 'STALE_RELEASE_TAG=%s\nLATEST_RELEASE_TAG=%s\n' "$tag_name" "$latest_tag"
-		return 1
+		if [[ "$receipt_status" == "$_FULL_LOOP_RELEASE_SUPERSEDED" ]]; then
+			_full_loop_verify_superseded_release_receipt "$repo" "$requested_pr" || return 1
+			if [[ "$mode" == "$_FULL_LOOP_RELEASE_MODE_RECONCILE" ]]; then
+				_full_loop_update_superseded_cleanup_receipt "$repo" "$requested_pr" || return 1
+			fi
+			printf 'release:superseded already recorded for PR #%s\n' "$requested_pr"
+			return 0
+		fi
+		[[ "$mode" == "$_FULL_LOOP_RELEASE_MODE_RECONCILE" ]] || return 1
+		[[ -z "$receipt_status" || "$receipt_status" == "$_FULL_LOOP_PHASE_FAILED" ]] || return 1
+		_full_loop_release_finalize_stale_supersession \
+			"$repo" "$requested_pr" "$tag_name" "$latest_tag" || return 1
+		printf 'release:superseded source_tag=%s successor_tag=%s\n' "$tag_name" "$latest_tag"
+		return 0
 	fi
 	_full_loop_release_inspect_remote "$repo" "$tag_name" || inspect_rc=$?
 	if [[ "$inspect_rc" -eq 0 ]]; then
-		if [[ "$mode" == "reconcile" ]]; then
+		if [[ "$mode" == "$_FULL_LOOP_RELEASE_MODE_RECONCILE" ]]; then
 			case "$receipt_status" in
 			"$_FULL_LOOP_RELEASE_PUBLISHED")
 				printf 'release:published already recorded for PR #%s\n' "$requested_pr"
 				;;
 			"$_FULL_LOOP_RELEASE_SUPERSEDED")
 				_full_loop_verify_superseded_release_receipt "$repo" "$requested_pr" || return 1
+				_full_loop_update_superseded_cleanup_receipt "$repo" "$requested_pr" || return 1
 				printf 'release:superseded already recorded for PR #%s\n' "$requested_pr"
 				;;
 			*)

--- a/.agents/scripts/tests/test-full-loop-completion-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-completion-evidence.sh
@@ -63,7 +63,7 @@ if [[ "${RELEASE_RUNNER_EXIT:-0}" -eq 0 ]]; then
 	receipt_base="${receipt_dir}/${repo//\//_}-${pr_number}"
 	printf '%s\n' "$status" >"${receipt_base}.status"
 	if [[ "$status" == "superseded" ]]; then
-		printf '%s\n' '{"schema_version":1,"status":"superseded","repository":"marcusquinn/aidevops","pr_number":42,"source_merge":"0000000000000000000000000000000000000001","aggregate_pr":99,"aggregate_merge":"0000000000000000000000000000000000000002","release_tag":"v3.0.0","release_commit":"0000000000000000000000000000000000000003"}' >"${receipt_base}.aggregate.json"
+		printf '%s\n' '{"schema_version":1,"status":"superseded","repository":"marcusquinn/aidevops","pr_number":42,"source_merge":"0000000000000000000000000000000000000001","aggregate_pr":99,"aggregate_merge":"0000000000000000000000000000000000000002","release_tag":"v3.0.0","release_commit":"0000000000000000000000000000000000000003","recorded_at":"2026-08-01T00:00:00Z"}' >"${receipt_base}.aggregate.json"
 	fi
 fi
 exit "${RELEASE_RUNNER_EXIT:-0}"
@@ -196,6 +196,68 @@ if AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" PATH="${ROOT}/bin:/opt/homebrew
 fi
 printf 'PASS superseded source receipts finalize truthfully and cannot be downgraded\n'
 
+successor_superseded_worktree="${ROOT}/successor-superseded-worktree"
+mkdir -p "$successor_superseded_worktree"
+successor_superseded_receipt=$(full_loop_write_cleanup_deferred marcusquinn/aidevops 49 \
+	"$successor_superseded_worktree" feature/successor-superseded \
+	"$$" successor-superseded-session pending FINALIZATION_PENDING)
+successor_supersede_runner="${ROOT}/successor-supersede-runner.sh"
+cat >"$successor_supersede_runner" <<RUNNER
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR='${SCRIPTS_DIR}'
+source '${SCRIPTS_DIR}/shared-constants.sh'
+source '${SCRIPTS_DIR}/full-loop-helper-state.sh'
+_full_loop_write_successor_release_receipt "\$@"
+RUNNER
+chmod +x "$successor_supersede_runner"
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	bash "$successor_supersede_runner" marcusquinn/aidevops 49 \
+	"$(printf '%040d' 1)" v3.0.0 "$(printf '%040d' 3)" 101 \
+	99 "$(printf '%040d' 2)" v3.0.1 "$(printf '%040d' 4)" 202
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$finalize_runner" 49 marcusquinn/aidevops >/dev/null
+jq -e '.executor_completion_state == "COMPLETE" and .release_status == "superseded"' \
+	"$successor_superseded_receipt" >/dev/null
+jq -e '.evidence_type == "post-publication-supersession" and .source_pr == 49
+	and .source_workflow_run == 101 and .successor_pr == 99 and .release_workflow_run == 202
+	and .source_release_tag == "v3.0.0" and .release_tag == "v3.0.1"' \
+	"${receipt_dir}/marcusquinn_aidevops-49.successor.json" >/dev/null
+cp "${receipt_dir}/marcusquinn_aidevops-49.successor.json" "${ROOT}/successor-evidence-before.json"
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	bash "$successor_supersede_runner" marcusquinn/aidevops 49 \
+	"$(printf '%040d' 1)" v3.0.0 "$(printf '%040d' 3)" 101 \
+	99 "$(printf '%040d' 2)" v3.0.1 "$(printf '%040d' 4)" 202
+cmp -s "${receipt_dir}/marcusquinn_aidevops-49.successor.json" "${ROOT}/successor-evidence-before.json"
+
+printf '%s\n' failed >"${receipt_dir}/marcusquinn_aidevops-50.status"
+cp "${receipt_dir}/marcusquinn_aidevops-46.aggregate.json" \
+	"${receipt_dir}/marcusquinn_aidevops-50.aggregate.json"
+if AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	bash "$successor_supersede_runner" marcusquinn/aidevops 50 \
+	"$(printf '%040d' 1)" v3.0.0 "$(printf '%040d' 3)" 101 \
+	99 "$(printf '%040d' 2)" v3.0.1 "$(printf '%040d' 4)" 202 >/dev/null 2>&1; then
+	printf 'FAIL aggregate evidence allowed a conflicting post-publication supersession receipt\n'
+	exit 1
+fi
+grep -qx 'failed' "${receipt_dir}/marcusquinn_aidevops-50.status"
+[[ ! -e "${receipt_dir}/marcusquinn_aidevops-50.successor.json" ]]
+
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	bash "$successor_supersede_runner" marcusquinn/aidevops 52 \
+	"$(printf '%040d' 1)" v3.0.0 "$(printf '%040d' 3)" 101 \
+	99 "$(printf '%040d' 2)" v3.0.1 "$(printf '%040d' 4)" 202
+if AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	bash "$supersede_runner" marcusquinn/aidevops 52 \
+	"$(printf '%040d' 1)" 99 "$(printf '%040d' 2)" v3.0.1 "$(printf '%040d' 4)" >/dev/null 2>&1; then
+	printf 'FAIL successor evidence allowed conflicting aggregate provenance\n'
+	exit 1
+fi
+[[ -f "${receipt_dir}/marcusquinn_aidevops-52.successor.json" ]]
+[[ ! -e "${receipt_dir}/marcusquinn_aidevops-52.aggregate.json" ]]
+printf 'PASS post-publication successor receipts finalize idempotently without fabricating aggregate provenance\n'
+
 alias_canonical="${ROOT}/alias-canonical"
 alias_worktree="${ROOT}/alias-worktree"
 alias_branch="bugfix/repair-pr-head"
@@ -304,6 +366,112 @@ AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$c
 	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
 	bash "$migration_runner" 44 example/old-repo example/renamed-repo >/dev/null
 printf 'PASS repository migration preserves owner, lease, creation, cleanup, and release evidence idempotently\n'
+
+successor_migration_worktree="${ROOT}/successor-migration-worktree"
+mkdir -p "$successor_migration_worktree"
+full_loop_write_cleanup_deferred example/successor-old 51 "$successor_migration_worktree" \
+	feature/successor-migration "$$" successor-migration-session pending FINALIZATION_PENDING >/dev/null
+printf '%s\n' superseded >"${receipt_dir}/example_successor-old-51.status"
+jq -cn '{schema_version:1,evidence_type:"post-publication-supersession",status:"superseded",
+	repository:"example/successor-old",pr_number:51,source_pr:51,source_merge:("1" * 40),
+	source_release_tag:"v3.0.0",source_release_commit:("2" * 40),source_workflow_run:101,
+	successor_pr:99,successor_merge:("3" * 40),release_tag:"v3.0.1",
+	release_commit:("4" * 40),release_workflow_run:202,recorded_at:"2026-08-01T00:00:00Z"}' \
+	>"${receipt_dir}/example_successor-old-51.successor.json"
+full_loop_update_cleanup_release_status example/successor-old 51 superseded
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$migration_runner" 51 example/successor-old example/successor-new >/dev/null
+[[ ! -e "${receipt_dir}/example_successor-old-51.status" ]]
+[[ ! -e "${receipt_dir}/example_successor-old-51.successor.json" ]]
+grep -qx 'superseded' "${receipt_dir}/example_successor-new-51.status"
+jq -e '.repository == "example/successor-new" and .source_pr == 51
+	and .migration.from_repository == "example/successor-old"' \
+	"${receipt_dir}/example_successor-new-51.successor.json" >/dev/null
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$migration_runner" 51 example/successor-old example/successor-new >/dev/null
+printf 'PASS repository migration preserves distinct post-publication supersession evidence idempotently\n'
+
+malformed_migration_worktree="${ROOT}/malformed-migration-worktree"
+mkdir -p "$malformed_migration_worktree"
+full_loop_write_cleanup_deferred example/malformed-old 53 "$malformed_migration_worktree" \
+	feature/malformed-migration "$$" malformed-migration-session pending FINALIZATION_PENDING >/dev/null
+printf '%s\n' superseded >"${receipt_dir}/example_malformed-old-53.status"
+jq -cn '{schema_version:1,evidence_type:"post-publication-supersession",status:"superseded",
+	repository:"example/malformed-old",pr_number:53,source_pr:53,successor_pr:99}' \
+	>"${receipt_dir}/example_malformed-old-53.successor.json"
+if AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$migration_runner" 53 example/malformed-old example/malformed-new >/dev/null 2>&1; then
+	printf 'FAIL repository migration accepted an incomplete successor evidence schema\n'
+	exit 1
+fi
+[[ -f "${cleanup_receipt_dir}/example_malformed-old-53.json" ]]
+[[ -f "${receipt_dir}/example_malformed-old-53.status" ]]
+[[ -f "${receipt_dir}/example_malformed-old-53.successor.json" ]]
+[[ ! -e "${cleanup_receipt_dir}/example_malformed-new-53.json" ]]
+printf 'PASS repository migration rejects incomplete supersession evidence without deleting its source\n'
+
+evidence_conflict_worktree="${ROOT}/evidence-conflict-worktree"
+mkdir -p "$evidence_conflict_worktree"
+full_loop_write_cleanup_deferred example/evidence-old 54 "$evidence_conflict_worktree" \
+	feature/evidence-conflict "$$" evidence-conflict-session pending FINALIZATION_PENDING >/dev/null
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	bash "$successor_supersede_runner" example/evidence-old 54 \
+	"$(printf '%040d' 1)" v3.0.0 "$(printf '%040d' 3)" 101 \
+	99 "$(printf '%040d' 2)" v3.0.1 "$(printf '%040d' 4)" 202
+jq --arg repo example/evidence-new --arg old_repo example/evidence-old \
+	'.repository = $repo | .migration = {from_repository:$old_repo,to_repository:$repo,migrated_at:"2026-08-01T01:00:00Z"}' \
+	"${cleanup_receipt_dir}/example_evidence-old-54.json" \
+	>"${cleanup_receipt_dir}/example_evidence-new-54.json"
+printf '%s\n' superseded >"${receipt_dir}/example_evidence-new-54.status"
+jq --arg repo example/evidence-new --arg old_repo example/evidence-old \
+	'.repository = $repo | .release_workflow_run = 303
+	| .migration = {from_repository:$old_repo,to_repository:$repo,migrated_at:"2026-08-01T01:00:00Z"}' \
+	"${receipt_dir}/example_evidence-old-54.successor.json" \
+	>"${receipt_dir}/example_evidence-new-54.successor.json"
+cp "${receipt_dir}/example_evidence-old-54.successor.json" "${ROOT}/evidence-conflict-source-before.json"
+if AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$migration_runner" 54 example/evidence-old example/evidence-new >/dev/null 2>&1; then
+	printf 'FAIL conflicting complete destination evidence reported a successful migration\n'
+	exit 1
+fi
+cmp -s "${receipt_dir}/example_evidence-old-54.successor.json" "${ROOT}/evidence-conflict-source-before.json"
+[[ -f "${cleanup_receipt_dir}/example_evidence-old-54.json" ]]
+jq -e '.release_workflow_run == 303' "${receipt_dir}/example_evidence-new-54.successor.json" >/dev/null
+printf 'PASS conflicting complete destination evidence cannot delete a valid migration source\n'
+
+partial_migration_worktree="${ROOT}/partial-migration-worktree"
+mkdir -p "$partial_migration_worktree"
+full_loop_write_cleanup_deferred example/partial-old 55 "$partial_migration_worktree" \
+	feature/partial-migration "$$" partial-migration-session pending FINALIZATION_PENDING >/dev/null
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	bash "$successor_supersede_runner" example/partial-old 55 \
+	"$(printf '%040d' 1)" v3.0.0 "$(printf '%040d' 3)" 101 \
+	99 "$(printf '%040d' 2)" v3.0.1 "$(printf '%040d' 4)" 202
+jq --arg repo example/partial-new --arg old_repo example/partial-old \
+	'.repository = $repo | .updated_at = "2026-08-01T02:00:00Z"
+	| .migration = {from_repository:$old_repo,to_repository:$repo,migrated_at:"2026-08-01T02:00:00Z"}' \
+	"${cleanup_receipt_dir}/example_partial-old-55.json" \
+	>"${cleanup_receipt_dir}/example_partial-new-55.json"
+jq --arg repo example/partial-new --arg old_repo example/partial-old \
+	'.repository = $repo | .migration = {from_repository:$old_repo,to_repository:$repo,migrated_at:"2026-08-01T02:00:00Z"}' \
+	"${receipt_dir}/example_partial-old-55.successor.json" \
+	>"${receipt_dir}/example_partial-new-55.successor.json"
+[[ ! -e "${receipt_dir}/example_partial-new-55.status" ]]
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$migration_runner" 55 example/partial-old example/partial-new >/dev/null
+[[ ! -e "${cleanup_receipt_dir}/example_partial-old-55.json" ]]
+[[ ! -e "${receipt_dir}/example_partial-old-55.status" ]]
+[[ ! -e "${receipt_dir}/example_partial-old-55.successor.json" ]]
+grep -qx 'superseded' "${receipt_dir}/example_partial-new-55.status"
+jq -e '.repository == "example/partial-new" and .source_pr == 55
+	and .release_workflow_run == 202 and .migration.from_repository == "example/partial-old"' \
+	"${receipt_dir}/example_partial-new-55.successor.json" >/dev/null
+printf 'PASS repository migration recovers verified partial destination publication idempotently\n'
 
 successor_worktree="${ROOT}/successor-worktree"
 mkdir -p "$successor_worktree"
@@ -526,7 +694,8 @@ printf 'PASS matching published receipt atomically promotes stale authorized lif
 
 printf '%s\n' superseded >"${receipt_dir}/marcusquinn_aidevops-47.status"
 jq -cn '{schema_version:1,status:"superseded",repository:"marcusquinn/aidevops",pr_number:47,
-	source_merge:("1" * 40),aggregate_pr:99,aggregate_merge:("2" * 40),release_tag:"v3.0.0",release_commit:("3" * 40)}' \
+	source_merge:("1" * 40),aggregate_pr:99,aggregate_merge:("2" * 40),release_tag:"v3.0.0",
+	release_commit:("3" * 40),recorded_at:"2026-08-01T00:00:00Z"}' \
 	>"${receipt_dir}/marcusquinn_aidevops-47.aggregate.json"
 superseded_handoff_output=$(AIDEVOPS_FULL_LOOP_REPO=marcusquinn/aidevops \
 	AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -19,6 +19,60 @@ mkdir -p "${TEST_ROOT}/bin" "${TEST_ROOT}/receipts"
 # shellcheck source=../full-loop-release-reconcile.sh
 source "${SCRIPT_DIR}/full-loop-release-reconcile.sh"
 
+stale_publication_jobs_fixture() {
+	local mode="${1:-valid}"
+	local jobs_json=""
+	jobs_json=$(jq -cn '
+		{total_count:1,jobs:[{id:101,name:"Publish GitHub, npm, and Homebrew",
+		status:"completed",conclusion:"failure",steps:[
+		{name:"Set up job",number:1,status:"completed",conclusion:"success"},
+		{name:"Checkout verified tag",number:2,status:"completed",conclusion:"success"},
+		{name:"Verify immutable release provenance",number:3,status:"completed",conclusion:"success"},
+		{name:"Create or reconcile GitHub release",number:4,status:"completed",conclusion:"success"},
+		{name:"Publish to npm",number:5,status:"completed",conclusion:"skipped"},
+		{name:"Verify npm publication",number:6,status:"completed",conclusion:"success"},
+		{name:"Push to Homebrew tap",number:7,status:"completed",conclusion:"skipped"},
+		{name:"Verify Homebrew tap",number:8,status:"completed",conclusion:"success"},
+		{name:"Queue exact-tag postflight",number:9,status:"completed",conclusion:"failure"},
+		{name:"Publication summary",number:10,status:"completed",conclusion:"skipped"}
+		]}]}
+	') || return 1
+	case "$mode" in
+	valid) ;;
+	queue-success) jobs_json=$(jq '.jobs[0].steps[8].conclusion = "success"' <<<"$jobs_json") || return 1 ;;
+	duplicate-npm) jobs_json=$(jq '.jobs[0].steps += [.jobs[0].steps[5]]' <<<"$jobs_json") || return 1 ;;
+	extra-failure) jobs_json=$(jq '.jobs[0].steps[3].conclusion = "failure"' <<<"$jobs_json") || return 1 ;;
+	nonterminal) jobs_json=$(jq '.jobs[0].steps[8].status = "in_progress"' <<<"$jobs_json") || return 1 ;;
+	reordered-postflight) jobs_json=$(jq '.jobs[0].steps[3].number = 9 | .jobs[0].steps[8].number = 4' <<<"$jobs_json") || return 1 ;;
+	*) return 1 ;;
+	esac
+	printf '%s\n' "$jobs_json"
+	return 0
+}
+
+valid_stale_jobs=$(stale_publication_jobs_fixture valid)
+_full_loop_release_run_jobs_payload_valid "$valid_stale_jobs" || {
+	printf 'FAIL valid workflow jobs payload was rejected\n'
+	exit 1
+}
+_full_loop_release_stale_publication_jobs_valid "$valid_stale_jobs" || {
+	printf 'FAIL exact post-publication dispatch failure evidence was rejected\n'
+	exit 1
+}
+for invalid_jobs_mode in queue-success duplicate-npm extra-failure nonterminal reordered-postflight; do
+	if _full_loop_release_stale_publication_jobs_valid \
+		"$(stale_publication_jobs_fixture "$invalid_jobs_mode")"; then
+		printf 'FAIL %s stale publication job evidence was accepted\n' "$invalid_jobs_mode"
+		exit 1
+	fi
+done
+if _full_loop_release_run_jobs_payload_valid \
+	"$(jq '.total_count = 2' <<<"$valid_stale_jobs")"; then
+	printf 'FAIL truncated workflow jobs payload was accepted\n'
+	exit 1
+fi
+printf 'PASS stale publication proof requires exact successful channels and sole postflight failure\n'
+
 _full_loop_release_tag_body() {
 	local tag_name="$1"
 	[[ "$tag_name" == "v1.2.3" ]] || return 1
@@ -338,7 +392,9 @@ if [[ "$args" == *" workflow run publish-packages.yml "* ]]; then
 	exit 0
 fi
 if [[ "$args" == *" -f event=push "* ]]; then
-	printf '%s\n' '{"workflow_runs":[{"id":10,"event":"push","head_sha":"3333333333333333333333333333333333333333","status":"completed","conclusion":"success","created_at":"2026-07-27T00:00:00Z","display_title":"push","html_url":"push-url"}]}'
+	push_branch='v1.2.3'
+	[[ "${FAKE_PUSH_BRANCH_MODE:-valid}" == "mismatch" ]] && push_branch='v9.9.9'
+	printf '{"workflow_runs":[{"id":10,"event":"push","head_branch":"%s","head_sha":"3333333333333333333333333333333333333333","status":"completed","conclusion":"success","created_at":"2026-07-27T00:00:00Z","display_title":"push","html_url":"push-url"}]}\n' "$push_branch"
 	exit 0
 fi
 if [[ "$args" == *" -f event=workflow_dispatch "* ]]; then
@@ -414,6 +470,7 @@ chmod +x "${TEST_ROOT}/bin/git" "${TEST_ROOT}/bin/npm" "${TEST_ROOT}/bin/curl"
 PATH="${TEST_ROOT}/bin:${PATH}"
 export FAKE_RUN_SCHEMA_MODE=valid
 export FAKE_RECOVERY_CORRELATION_MODE=valid
+export FAKE_PUSH_BRANCH_MODE=valid
 export FAKE_RELEASE_DRAFT=0
 export FAKE_NPM_VERSION=1.2.3
 FAKE_NPM_DIGEST=$(printf '%0128d' 0)
@@ -472,6 +529,19 @@ if [[ "$(jq -r '.id' <<<"$_FULL_LOOP_RELEASE_RUN_JSON")" != "10" ]]; then
 fi
 export FAKE_RECOVERY_CORRELATION_MODE=valid
 printf 'PASS recovery workflow correlation binds tag and workflow commits\n'
+
+export FAKE_RECOVERY_CORRELATION_MODE=mismatch
+export FAKE_PUSH_BRANCH_MODE=mismatch
+wrong_push_rc=0
+_full_loop_release_find_workflow_run test/repo v1.2.3 \
+	3333333333333333333333333333333333333333 >/dev/null 2>&1 || wrong_push_rc=$?
+if [[ "$wrong_push_rc" -ne 3 ]]; then
+	printf 'FAIL push workflow with a mismatched tag ref was accepted\n'
+	exit 1
+fi
+export FAKE_RECOVERY_CORRELATION_MODE=valid
+export FAKE_PUSH_BRANCH_MODE=valid
+printf 'PASS push workflow correlation binds the exact release tag ref\n'
 
 saved_script_dir="$SCRIPT_DIR"
 SCRIPT_DIR="${TEST_ROOT}/no-audit-helper"
@@ -580,6 +650,108 @@ FAKE_FORMULA_DRIFT=0
 export FAKE_FORMULA_DRIFT
 printf 'PASS published channel verification binds release, package, formula, and digest\n'
 
+run_stale_supersession_fixture() {
+	local mode="$1"
+	local write_log="$2"
+	(
+		_full_loop_release_source_json_from_tag() {
+			local tag_name="$1"
+			case "$tag_name" in
+			v1.2.3)
+				printf '%s\n' '{"source_pr":90,"source_merge":"1111111111111111111111111111111111111111","aggregated_sources":[]}'
+				;;
+			v1.2.4)
+				printf '%s\n' '{"source_pr":91,"source_merge":"2222222222222222222222222222222222222222","aggregated_sources":[]}'
+				;;
+			*) return 1 ;;
+			esac
+			return 0
+		}
+		_full_loop_release_resolve_tag_commit() {
+			local tag_name="$1"
+			case "$tag_name" in
+			v1.2.3) printf '%040d\n' 3 ;;
+			v1.2.4) printf '%040d\n' 4 ;;
+			*) return 1 ;;
+			esac
+			return 0
+		}
+		_full_loop_release_verify_stale_publication_run() {
+			local repo="$1"
+			local tag_name="$2"
+			local tag_commit="$3"
+			[[ "$repo" == "test/repo" && "$tag_name" == "v1.2.3" && "$tag_commit" == "$(printf '%040d' 3)" ]] || return 1
+			[[ "$mode" != "source-run" ]] || return 1
+			_FULL_LOOP_RELEASE_RUN_JSON='{"id":101}'
+			return 0
+		}
+		_full_loop_release_reset_tag_worktree() {
+			return 0
+		}
+		_full_loop_release_verify_tag_provenance() {
+			local repo="$1"
+			local tag_name="$2"
+			[[ "$repo" == "test/repo" && "$tag_name" == "v1.2.4" ]]
+			return $?
+		}
+		_full_loop_release_inspect_remote() {
+			local repo="$1"
+			local tag_name="$2"
+			[[ "$repo" == "test/repo" && "$tag_name" == "v1.2.4" ]] || return 1
+			[[ "$mode" != "latest-remote" ]] || return 1
+			_FULL_LOOP_RELEASE_RUN_JSON='{"id":202}'
+			return 0
+		}
+		_full_loop_release_receipt_path() {
+			local repo="$1"
+			local pr_number="$2"
+			[[ "$repo" == "test/repo" ]] || return 1
+			if [[ "$mode" == "receipt" ]]; then
+				printf '%s/missing-%s.status\n' "$TEST_ROOT" "$pr_number"
+			else
+				printf '%s/receipts/test_repo-%s.status\n' "$TEST_ROOT" "$pr_number"
+			fi
+			return 0
+		}
+		_full_loop_write_successor_release_receipt() {
+			local args="$*"
+			printf '%s\n' "$args" >"$write_log"
+			return 0
+		}
+		git() {
+			local args="$*"
+			[[ "$args" == *" merge-base --is-ancestor "* && "$mode" != "ancestry" ]]
+			return $?
+		}
+		_full_loop_release_finalize_stale_supersession test/repo 90 v1.2.3 v1.2.4
+	)
+	return $?
+}
+
+printf 'published\n' >"${TEST_ROOT}/receipts/test_repo-91.status"
+stale_write_log="${TEST_ROOT}/stale-successor-write.log"
+run_stale_supersession_fixture valid "$stale_write_log" || {
+	printf 'FAIL verified stale publication and terminal successor did not reconcile\n'
+	exit 1
+}
+if ! grep -qx "test/repo 90 1111111111111111111111111111111111111111 v1.2.3 $(printf '%040d' 3) 101 91 2222222222222222222222222222222222222222 v1.2.4 $(printf '%040d' 4) 202" \
+	"$stale_write_log"; then
+	printf 'FAIL post-publication supersession omitted immutable source or successor evidence\n'
+	exit 1
+fi
+for stale_failure_mode in source-run ancestry latest-remote receipt; do
+	rm -f "$stale_write_log"
+	if run_stale_supersession_fixture "$stale_failure_mode" "$stale_write_log"; then
+		printf 'FAIL %s uncertainty allowed stale release supersession\n' "$stale_failure_mode"
+		exit 1
+	fi
+	[[ ! -e "$stale_write_log" ]] || {
+		printf 'FAIL %s uncertainty wrote terminal supersession evidence\n' "$stale_failure_mode"
+		exit 1
+	}
+done
+printf 'PASS stale receipt supersession binds both releases and fails closed on uncertain evidence\n'
+
 _full_loop_resolve_repo() {
 	local requested_repo="$1"
 	printf '%s\n' "${requested_repo:-test/repo}"
@@ -619,6 +791,27 @@ _full_loop_release_finalize_reconciliation() {
 	local pr_number="$2"
 	local tag_name="$3"
 	printf '%s %s %s\n' "$repo" "$pr_number" "$tag_name" >"${TEST_ROOT}/finalize.log"
+	return 0
+}
+_full_loop_release_finalize_stale_supersession() {
+	local repo="$1"
+	local pr_number="$2"
+	local source_tag="$3"
+	local release_tag="$4"
+	printf '%s %s %s %s\n' "$repo" "$pr_number" "$source_tag" "$release_tag" \
+		>"${TEST_ROOT}/stale-finalize.log"
+	return "${STALE_FINALIZE_RC:-0}"
+}
+_full_loop_verify_superseded_release_receipt() {
+	local repo="$1"
+	local pr_number="$2"
+	[[ "$repo" == "test/repo" && "$pr_number" == "90" ]]
+	return $?
+}
+_full_loop_update_superseded_cleanup_receipt() {
+	local repo="$1"
+	local pr_number="$2"
+	printf '%s %s\n' "$repo" "$pr_number" >"${TEST_ROOT}/cleanup-update.log"
 	return 0
 }
 
@@ -686,13 +879,49 @@ _full_loop_release_latest_tag() {
 	printf 'v1.2.4\n'
 	return 0
 }
-stale_rc=0
-AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command reconcile 90 \
-	>/dev/null 2>&1 || stale_rc=$?
-if [[ "$stale_rc" -ne 1 ]]; then
-	printf 'FAIL stale release tag was allowed to republish over a newer release\n'
+printf 'failed\n' >"${TEST_ROOT}/receipts/test_repo-90.status"
+stale_status_rc=0
+AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command status 90 \
+	>/dev/null 2>&1 || stale_status_rc=$?
+if [[ "$stale_status_rc" -ne 1 || -e "${TEST_ROOT}/stale-finalize.log" ]]; then
+	printf 'FAIL read-only stale release status mutated terminal evidence\n'
 	exit 1
 fi
-printf 'PASS stale release tags cannot downgrade public channels\n'
+stale_reconcile_rc=0
+AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command reconcile 90 \
+	>/dev/null 2>&1 || stale_reconcile_rc=$?
+if [[ "$stale_reconcile_rc" -ne 0 ]] ||
+	! grep -qx 'test/repo 90 v1.2.3 v1.2.4' "${TEST_ROOT}/stale-finalize.log" ||
+	[[ -e "${TEST_ROOT}/dispatch.log" || -e "${TEST_ROOT}/finalize.log" ]]; then
+	printf 'FAIL stale release receipt did not use the no-publication supersession path\n'
+	exit 1
+fi
+
+rm -f "${TEST_ROOT}/stale-finalize.log"
+STALE_FINALIZE_RC=1
+export STALE_FINALIZE_RC
+stale_uncertain_rc=0
+AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command reconcile 90 \
+	>/dev/null 2>&1 || stale_uncertain_rc=$?
+if [[ "$stale_uncertain_rc" -ne 1 ]] || ! grep -qx 'failed' "${TEST_ROOT}/receipts/test_repo-90.status"; then
+	printf 'FAIL uncertain stale supersession replaced the failed receipt\n'
+	exit 1
+fi
+unset STALE_FINALIZE_RC
+
+printf 'superseded\n' >"${TEST_ROOT}/receipts/test_repo-90.status"
+rm -f "${TEST_ROOT}/stale-finalize.log" "${TEST_ROOT}/cleanup-update.log"
+AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command status 90 >/dev/null
+if [[ -e "${TEST_ROOT}/cleanup-update.log" ]]; then
+	printf 'FAIL read-only terminal stale status updated cleanup evidence\n'
+	exit 1
+fi
+AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command reconcile 90 >/dev/null
+if [[ -e "${TEST_ROOT}/stale-finalize.log" ]] ||
+	! grep -qx 'test/repo 90' "${TEST_ROOT}/cleanup-update.log"; then
+	printf 'FAIL terminal stale supersession evidence was finalized twice\n'
+	exit 1
+fi
+printf 'PASS stale release tags cannot downgrade channels and reconcile only through verified supersession\n'
 
 exit 0

--- a/.agents/workflows/release.md
+++ b/.agents/workflows/release.md
@@ -61,6 +61,15 @@ exact reviewed `main` workflow commit while package contents stay pinned to the
 immutable tag. Full contract: `reference/release-publication-controls.md`
 "Intervening-main recovery".
 
+If an older signed tag already completed GitHub, npm, and Homebrew publication
+but failed only while queuing postflight, do not recover it after a later release
+becomes current. `aidevops release reconcile <older-source-pr>` can instead write
+a distinct post-publication supersession receipt after verifying the older run's
+exact successful publication steps, strict release ancestry, the latest signed
+tag and channels, and the latest source's terminal published receipt. It never
+dispatches or deploys the stale tag and does not fabricate aggregate provenance.
+See `reference/release-publication-controls.md` "Post-publication supersession".
+
 **DO NOT** run separate bump/tag/push commands. **Prerequisites**: terminal-success PR checks/reviews, observed merged state/SHA, authenticated `gh`, an accessible aidevops repository, and unreleased changelog content (or changelog-only `--force`). The helper fetches `origin/main` and creates its own detached release worktree; it does not require or mutate a clean canonical checkout.
 
 **Related**: `workflows/version-bump.md` · `workflows/changelog.md` · `workflows/postflight.md` · `reference/release-artifact-provenance.md` · `.agents/scripts/validate-version-consistency.sh`
@@ -130,5 +139,6 @@ git commit -m "fix: resolve critical issue"
 |-------|----------|
 | Signed tag already exists | Do not delete or retag it. Run `aidevops release status <source-pr>` and then `aidevops release reconcile <source-pr>`. |
 | Publication queued/interrupted | Exit `8` is durable pending state. Reconcile the same source PR; never bump again for the same tag. |
+| Published tag is older than the latest release | Never republish or deploy the older tag. Reconcile it only through verified post-publication supersession; uncertain evidence remains `release:failed`. |
 | GitHub CLI not authenticated | `gh auth login` (token needs `repo` scope) |
 | Version mismatch | `./.agents/scripts/version-manager.sh validate` — see `version-bump.md` |


### PR DESCRIPTION
## Summary

Reconcile failed stale publication receipts only through an immutable, fully verified successor release; persist separate successor evidence; and migrate or finalize receipts without fabricating aggregate provenance.

## Files Changed

.agents/reference/release-publication-controls.md, .agents/scripts/full-loop-cleanup-receipt.sh, .agents/scripts/full-loop-helper-state.sh, .agents/scripts/full-loop-release-helper.sh, .agents/scripts/full-loop-release-reconcile.sh, .agents/scripts/tests/test-full-loop-completion-evidence.sh, .agents/scripts/tests/test-full-loop-release-reconcile.sh, .agents/workflows/release.md

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Focused release reconciliation, release helper, and completion-evidence suites pass; local lint, ShellCheck, Bash syntax, Markdown, secret, portability, complexity, and targeted gates pass; isolated GitHub proof reconciled v3.32.211 to v3.32.213 without touching real receipts; independent review approved.

Resolves #29178


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.213 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 4h 1m and 3,731,865 tokens on this with the user in an interactive session.