### PR TITLE
GH#29153: Restore sudo approval auth recovery

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -241,10 +241,11 @@ unset _cand
 # -----------------------------------------------------------------------------
 _SHIM_READ_REWRITE=""
 case "${1:-}:${2:-}" in
-	auth:git-credential)
-		# The Git credential-helper protocol only reads local auth storage and
-		# exchanges key/value records over stdin/stdout. Counting it as GraphQL
-		# creates false unknown-quota attempts (GH#27777); preserve it byte-for-byte.
+	auth:git-credential | auth:token)
+		# These auth commands only read local credential storage. Counting them as
+		# GraphQL creates false unknown-quota attempts, while transport framing can
+		# break keychain recovery under sudo (GH#27777, GH#29153). Preserve native
+		# stdout, stderr, and exit status byte-for-byte without logging token output.
 		_real_gh="$(_find_real_gh)" || {
 			printf '[aidevops] gh shim: real gh binary not found on PATH\n' >&2
 			exit 127

--- a/.agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh
+++ b/.agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh
@@ -176,6 +176,57 @@ run_case "sudo gh auth recovery uses absolute gh binary when sudo path is restri
 assert_not_contains "absolute path recovered token is not printed" "$LAST_OUTPUT" "path-token"
 
 # shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "sudo gh auth recovery works through the aidevops gh shim" '
+	set -uo pipefail
+	export SUDO_USER=alice
+	export HOME=/var/root
+	fixture_root=$(mktemp -d)
+	trap '\''rm -rf "$fixture_root"'\'' EXIT
+	helper_dir=${APPROVAL_HELPER_UNDER_TEST%/*}
+	shim_dir="$fixture_root/shim"
+	native_dir="$fixture_root/native"
+	mkdir -p "$shim_dir" "$native_dir"
+	for module in gh gh-native-transport-lib.sh gh-api-guards-lib.sh gh-write-policy-lib.sh gh-api-instrument.sh gh-rest-pagination-lib.sh; do
+		cp "$helper_dir/$module" "$shim_dir/$module"
+	done
+	chmod +x "$shim_dir/gh"
+	printf '\''#!/usr/bin/env bash\nif [[ "${1:-}:${2:-}" == "auth:token" ]]; then printf integrated-shim-token; exit 0; fi\nexit 1\n'\'' >"$native_dir/gh"
+	chmod +x "$native_dir/gh"
+	export PATH="$shim_dir:$native_dir:/usr/bin:/bin"
+	export AIDEVOPS_GH_API_LOG="$fixture_root/api.log"
+	id() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "-u" && -z "$arg2" ]]; then printf "0"; return 0; fi
+		if [[ "$arg1" == "-u" && "$arg2" == "alice" ]]; then printf "501"; return 0; fi
+		return 1
+	}
+	getent() { return 1; }
+	dscl() { printf "NFSHomeDirectory: /Users/alice\n"; return 0; }
+	launchctl() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "asuser" && "$arg2" == "501" && "$#" -ge 11 ]]; then
+			shift 8
+			"$@"
+			return $?
+		fi
+		return 1
+	}
+	sudo() { return 1; }
+	gh() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "auth" && "$arg2" == "status" && "${GH_TOKEN:-}" == "integrated-shim-token" ]]; then return 0; fi
+		return 1
+	}
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_require_gh_auth && [[ ! -e "$AIDEVOPS_GH_API_LOG" ]]
+' 0
+assert_not_contains "integrated shim recovered token is not printed" "$LAST_OUTPUT" "integrated-shim-token"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
 run_case "sudo gh auth failure reports recovery failure without token leakage" '
 	set -uo pipefail
 	export SUDO_USER=alice

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -755,6 +755,11 @@ if [[ "${1:-}:${2:-}" == "auth:git-credential" ]]; then
 	printf 'username=fixture\npassword=fixture\n\n'
 	exit "${NATIVE_CREDENTIAL_STATUS:-0}"
 fi
+if [[ "${1:-}:${2:-}" == "auth:token" ]]; then
+	printf 'fixture-auth-token'
+	printf 'native-auth-token-stderr\n' >&2
+	exit "${NATIVE_AUTH_TOKEN_STATUS:-0}"
+fi
 page=1
 jq_requested=0
 expect_jq=0
@@ -852,6 +857,35 @@ PATH="$NATIVE_FIXTURE:/usr/bin:/bin" NATIVE_CREDENTIAL_STATUS=17 \
 credential_failure_status=$?
 set -e
 assert_eq "local credential helper preserves native failure status" "17" "$credential_failure_status"
+
+# `gh auth token` is also a local credential read. Approval recovery executes it
+# through the invoking user's keychain session, where transport framing would
+# add dependencies and could expose credential output (GH#29153).
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+auth_token_expected_output="$TMPDIR/auth-token-output.expected"
+auth_token_actual_output="$TMPDIR/auth-token-output.actual"
+auth_token_expected_error="$TMPDIR/auth-token-error.expected"
+auth_token_actual_error="$TMPDIR/auth-token-error.actual"
+printf 'fixture-auth-token' >"$auth_token_expected_output"
+printf 'native-auth-token-stderr\n' >"$auth_token_expected_error"
+PATH="$NATIVE_FIXTURE:/usr/bin:/bin" \
+	"$SHIM_FIXTURE/gh" auth token \
+	>"$auth_token_actual_output" 2>"$auth_token_actual_error"
+auth_token_output_status=0
+cmp -s "$auth_token_expected_output" "$auth_token_actual_output" || auth_token_output_status=$?
+assert_eq "local auth token preserves stdout bytes" "0" "$auth_token_output_status"
+auth_token_error_status=0
+cmp -s "$auth_token_expected_error" "$auth_token_actual_error" || auth_token_error_status=$?
+assert_eq "local auth token preserves stderr bytes" "0" "$auth_token_error_status"
+assert_eq "local auth token invokes native gh once" "1" "$(grep -c '^auth$' "$NATIVE_ATTEMPT_LOG")"
+assert_path_absent "local auth token emits no API telemetry" "$AIDEVOPS_GH_API_LOG"
+auth_token_failure_status=0
+set +e
+PATH="$NATIVE_FIXTURE:/usr/bin:/bin" NATIVE_AUTH_TOKEN_STATUS=23 \
+	"$SHIM_FIXTURE/gh" auth token >/dev/null 2>/dev/null
+auth_token_failure_status=$?
+set -e
+assert_eq "local auth token preserves native failure status" "23" "$auth_token_failure_status"
 
 rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
 PATH="$NATIVE_FIXTURE:/usr/bin:/bin" \


### PR DESCRIPTION
## Summary

- classify `gh auth token` as a local credential read alongside `auth git-credential`
- preserve native stdout, stderr, and exit status without quota instrumentation or transport framing
- add byte-for-byte shim coverage and an integrated sudo-to-shim approval recovery fixture

## Testing

- `bash .agents/scripts/tests/test-gh-shim.sh` — 114 passed, 0 failed
- `bash .agents/scripts/tests/test-gh-shim-native-resolution.sh` — 7 passed, 0 failed
- `bash .agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh` — 10 passed, 0 failed
- `bash .agents/scripts/tests/test-gh-api-instrument.sh` — 213 passed, 0 failed
- `shellcheck .agents/scripts/approval-helper.sh .agents/scripts/gh .agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh .agents/scripts/tests/test-gh-api-instrument.sh`
- `.agents/scripts/linters-local.sh --changed` — all changed-file checks passed
- `git diff --check`

## Runtime Testing

- runtime-verified through an integrated macOS sudo/launchctl fixture using the production gh shim and native-resolution path
- confirmed that credential bytes are absent from shim telemetry and test output while explicit failure status remains fail-closed
- exact review bundle: `fd9795c0b1234733797c0354dbaf1f5f675cc00f7ebfecf9ef5637a225eec3f8` (head `92cffd0279f5b0005b4cf1cf12b273280ff111c3`, prompt-injection scan clean)

Resolves #29153

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.213 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 4h 53m and 1,069,148 tokens on this with the user in an interactive session. Overall, 4h 33m since this issue was created.
