### PR TITLE
GH#29180: fix: prevent maintenance changelog blank lines

### DIFF
--- a/.agents/scripts/tests/test-version-manager-changelog-maintenance-spacing.sh
+++ b/.agents/scripts/tests/test-version-manager-changelog-maintenance-spacing.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression guard for GH#29180: maintenance-only releases must not create
+# multiple blank lines before the next version heading.
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$TEST_SCRIPTS_DIR"
+REPO_ROOT="$(mktemp -d)"
+VERSION_FILE="${REPO_ROOT}/VERSION"
+trap 'rm -rf "$REPO_ROOT"' EXIT
+
+print_warning() {
+	return 0
+}
+
+print_success() {
+	return 0
+}
+
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/version-manager-changelog.sh"
+
+generate_changelog_content() {
+	return 0
+}
+
+cat >"${REPO_ROOT}/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+Previous unreleased content
+
+## [1.0.0] - 2026-07-31
+
+### Added
+
+- Existing release
+EOF
+
+update_changelog "1.0.1"
+npx --no-install markdownlint-cli2 "${REPO_ROOT}/CHANGELOG.md"
+
+expected="# Changelog
+
+## [Unreleased]
+
+## [1.0.1] - $(date +%Y-%m-%d)
+
+### Changed
+
+- Version bump and maintenance updates
+
+## [1.0.0] - 2026-07-31
+
+### Added
+
+- Existing release"
+actual=$(cat "${REPO_ROOT}/CHANGELOG.md")
+
+if [[ "$actual" != "$expected" ]]; then
+	printf 'FAIL maintenance changelog spacing\nExpected:\n%s\nActual:\n%s\n' "$expected" "$actual" >&2
+	exit 1
+fi
+
+printf 'PASS maintenance changelog spacing\n'

--- a/.agents/scripts/version-manager-changelog.sh
+++ b/.agents/scripts/version-manager-changelog.sh
@@ -390,8 +390,7 @@ update_changelog() {
 		print_warning "No conventional commits found for changelog generation"
 		changelog_content="### Changed
 
-- Version bump and maintenance updates
-"
+- Version bump and maintenance updates"
 	fi
 
 	# Create temp files for the update with trap cleanup


### PR DESCRIPTION
## Summary

Remove the trailing newline from fallback maintenance changelog content so the canonical separator yields exactly one blank line, and add a focused generated-output regression test with Markdown lint coverage.

## Files Changed

.agents/scripts/tests/test-version-manager-changelog-maintenance-spacing.sh, .agents/scripts/version-manager-changelog.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-version-manager-changelog-maintenance-spacing.sh; shellcheck .agents/scripts/version-manager-changelog.sh .agents/scripts/tests/test-version-manager-changelog-maintenance-spacing.sh; .agents/scripts/linters-local.sh

Resolves #29180


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.214 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 5m and 82,593 tokens on this as a headless worker.