### PR TITLE
GH#29170: Restore conflict ownership REST fallback

### DIFF
--- a/.agents/scripts/pulse-merge-conflict.sh
+++ b/.agents/scripts/pulse-merge-conflict.sh
@@ -820,7 +820,7 @@ _find_task_id_match_on_main() {
 # (origin:interactive) or external-contributor work (non-bot author,
 # no pulse origin label) must never be auto-closed.
 #
-# Fetches labels + author + authorAssociation with fail-CLOSED semantics.
+# Fetches labels + author with fail-CLOSED semantics.
 # If the metadata fetch fails, the caller must NOT close the PR.
 #
 # GH#18285: origin:interactive PRs are maintainer session work — pulse
@@ -852,7 +852,7 @@ _close_conflicting_pr_check_ownership_guard() {
 	local pr_meta meta_fetch_rc
 	meta_fetch_rc=0
 	pr_meta=$(gh pr view "$pr_number" --repo "$repo_slug" \
-		--json labels,author,authorAssociation 2>/dev/null) || meta_fetch_rc=$?
+		--json labels,author 2>/dev/null) || meta_fetch_rc=$?
 	if [[ $meta_fetch_rc -ne 0 ]]; then
 		echo "[pulse-wrapper] _close_conflicting_pr: failed to fetch metadata for PR #${pr_number} in ${repo_slug} (exit ${meta_fetch_rc}) — skipping close to protect potential origin:interactive or contributor PR (t2383, GH#20485)" >>"$LOGFILE"
 		return 0

--- a/.agents/scripts/tests/test-close-conflicting-pr-wording.sh
+++ b/.agents/scripts/tests/test-close-conflicting-pr-wording.sh
@@ -130,8 +130,8 @@ fi
 			if [[ -f "\$response" ]]; then cat "\$response"; fi
 			exit 0
 			;;
-		"labels,author,authorAssociation")
-			# GH#20485: _close_conflicting_pr_check_ownership_guard fetches
+		"labels,author")
+			# GH#20485/GH#29170: _close_conflicting_pr_check_ownership_guard fetches
 			# labels + author metadata in one call. Return pr-meta.json if
 			# present; fall back to a default that simulates a worker PR
 			# (origin:worker label, bot author) so existing tests are unaffected.
@@ -139,7 +139,7 @@ fi
 			if [[ -f "\$response" ]]; then
 				cat "\$response"
 			else
-				echo '{"labels":[{"name":"origin:worker"}],"author":{"login":"aidevops-worker[bot]"},"authorAssociation":"NONE"}'
+				echo '{"labels":[{"name":"origin:worker"}],"author":{"login":"aidevops-worker[bot]"}}'
 			fi
 			exit 0
 			;;
@@ -265,12 +265,12 @@ set_responses() {
 	: >"${TEST_ROOT}/pr-labels.txt"
 	echo "feature/test" >"${TEST_ROOT}/pr-branch.txt"
 	echo "develop" >"${TEST_ROOT}/pr-base-branch.txt"
-	# GH#20485: ownership guard metadata. Default = worker-origin bot PR
+	# GH#20485/GH#29170: ownership guard metadata. Default = worker-origin bot PR
 	# so existing close-path tests still proceed to the close logic.
 	if [[ -n "$pr_meta_json" ]]; then
 		printf '%s' "$pr_meta_json" >"${TEST_ROOT}/pr-meta.json"
 	else
-		printf '%s' '{"labels":[{"name":"origin:worker"}],"author":{"login":"aidevops-worker[bot]"},"authorAssociation":"NONE"}' \
+		printf '%s' '{"labels":[{"name":"origin:worker"}],"author":{"login":"aidevops-worker[bot]"}}' \
 			>"${TEST_ROOT}/pr-meta.json"
 	fi
 	return 0
@@ -524,7 +524,7 @@ test_no_close_for_external_contributor_pr() {
 		'[{"sha":"abc1234567890abcdef","subject":"chore: unrelated commit"},{"sha":"def4567890abcdef","subject":"feat: also unrelated"}]' \
 		'.agents/scripts/pulse-merge-conflict.sh' \
 		'.agents/scripts/pulse-merge-conflict.sh' \
-		'{"labels":[],"author":{"login":"superdav42"},"authorAssociation":"CONTRIBUTOR"}'
+		'{"labels":[],"author":{"login":"superdav42"}}'
 
 	load_functions_under_test
 
@@ -562,7 +562,7 @@ test_close_for_worker_origin_pr() {
 		'[{"sha":"abc1234567890abcdef","subject":"chore: unrelated commit"}]' \
 		'.agents/scripts/pulse-merge-conflict.sh' \
 		'.agents/scripts/pulse-merge-conflict.sh' \
-		'{"labels":[{"name":"origin:worker"}],"author":{"login":"superdav42"},"authorAssociation":"CONTRIBUTOR"}'
+		'{"labels":[{"name":"origin:worker"}],"author":{"login":"superdav42"}}'
 
 	load_functions_under_test
 
@@ -597,7 +597,7 @@ test_close_for_worker_takeover_pr() {
 		'[{"sha":"abc1234567890abcdef","subject":"chore: unrelated commit"}]' \
 		'.agents/scripts/pulse-merge-conflict.sh' \
 		'.agents/scripts/pulse-merge-conflict.sh' \
-		'{"labels":[{"name":"origin:worker-takeover"},{"name":"origin:interactive"}],"author":{"login":"marcusquinn"},"authorAssociation":"OWNER"}'
+		'{"labels":[{"name":"origin:worker-takeover"},{"name":"origin:interactive"}],"author":{"login":"marcusquinn"}}'
 
 	load_functions_under_test
 
@@ -620,7 +620,7 @@ test_close_for_worker_takeover_pr() {
 		'[{"sha":"abc1234567890abcdef","subject":"chore: unrelated commit"}]' \
 		'.agents/scripts/pulse-merge-conflict.sh' \
 		'.agents/scripts/pulse-merge-conflict.sh' \
-		'{"labels":[{"name":"origin:worker-takeover"}],"author":{"login":"superdav42"},"authorAssociation":"CONTRIBUTOR"}'
+		'{"labels":[{"name":"origin:worker-takeover"}],"author":{"login":"superdav42"}}'
 
 	load_functions_under_test
 
@@ -645,7 +645,7 @@ test_close_for_bot_author_no_label_pr() {
 		'[{"sha":"abc1234567890abcdef","subject":"chore: unrelated commit"}]' \
 		'.agents/scripts/pulse-merge-conflict.sh' \
 		'.agents/scripts/pulse-merge-conflict.sh' \
-		'{"labels":[],"author":{"login":"dependabot[bot]"},"authorAssociation":"NONE"}'
+		'{"labels":[],"author":{"login":"dependabot[bot]"}}'
 
 	load_functions_under_test
 
@@ -666,7 +666,7 @@ test_close_for_bot_author_no_label_pr() {
 
 # GH#20485: metadata fetch failure → fail CLOSED → no close.
 test_no_close_on_metadata_fetch_failure() {
-	# Simulate gh pr view returning non-zero for labels,author,authorAssociation
+	# Simulate gh pr view returning non-zero for the REST-preservable metadata shape.
 	local tmp_sandbox
 	tmp_sandbox=$(mktemp -d)
 	local stub_dir="${tmp_sandbox}/stubs"
@@ -691,7 +691,7 @@ if [[ "\$1" == "pr" && "\$2" == "view" ]]; then
     fi
     i=\$((i + 1))
   done
-  if [[ "\$field" == "labels,author,authorAssociation" ]]; then
+  if [[ "\$field" == "labels,author" ]]; then
     exit 1
   fi
 fi

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -1801,7 +1801,7 @@ unset AIDEVOPS_GH_PR_VIEW_CACHE AIDEVOPS_GH_PR_VIEW_CACHE_DIR AIDEVOPS_GH_PR_VIE
 
 : >"$GH_CALLS"
 : >"$GH_INFO_OUTPUT"
-unsupported_pr_view_fields=(statusCheckRollup reviews latestReviews reviewThreads commits files reviewDecision autoMergeRequest mergeStateStatus)
+unsupported_pr_view_fields=(authorAssociation statusCheckRollup reviews latestReviews reviewThreads commits files reviewDecision autoMergeRequest mergeStateStatus)
 unsupported_preserve_ok=1
 for field in "${unsupported_pr_view_fields[@]}"; do
 	if _rest_pr_view_can_preserve_args 123 --repo "owner/repo" --json "$field"; then
@@ -1858,12 +1858,14 @@ else
 fi
 
 if _rest_pr_view_can_preserve_args 123 --repo "owner/repo" --json title &&
+	_rest_pr_view_can_preserve_args 123 --repo "owner/repo" --json labels,author &&
 	_rest_pr_view_can_preserve_args 123 --repo "owner/repo" --json mergeable &&
 	_rest_pr_view_can_emergency_fallback_args 123 --repo "owner/repo" --json mergeable &&
+	! _rest_pr_view_can_preserve_args 123 --repo "owner/repo" --json labels,author,authorAssociation &&
 	! _rest_pr_view_can_emergency_fallback_args 123 --repo "owner/repo" --json reviewDecision; then
-	pass "gh_pr_view validators preserve exact REST and GraphQL-only fields"
+	pass "gh_pr_view validators preserve labels,author and reject GraphQL-only fields"
 else
-	fail "gh_pr_view validators preserve exact REST and GraphQL-only fields" \
+	fail "gh_pr_view validators preserve labels,author and reject GraphQL-only fields" \
 		"unexpected proactive or emergency field classification"
 fi
 

--- a/.agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh
+++ b/.agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh
@@ -101,8 +101,8 @@ $(awk '
 install_stubs() {
 	gh() {
 		printf '%s\n' "$*" >>"$GH_CALL_LOG"
-		if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"authorAssociation"* ]]; then
-			printf '{"labels":[{"name":"origin:worker"}],"author":{"login":"aidevops-worker[bot]"},"authorAssociation":"MEMBER"}\n'
+		if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"--json labels,author"* && "$*" != *"authorAssociation"* ]]; then
+			printf '{"labels":[{"name":"origin:worker"}],"author":{"login":"aidevops-worker[bot]"}}\n'
 			return 0
 		fi
 		if [[ "$1" == "pr" && "$2" == "view" && "$3" == "6130" && "$*" == *"state"* ]]; then


### PR DESCRIPTION
## Summary

Remove the unused GraphQL-only authorAssociation field from conflicting-PR ownership reads so labels and author can use the existing REST fallback under GraphQL pressure.

## Files Changed

.agents/scripts/pulse-merge-conflict.sh, .agents/scripts/tests/test-close-conflicting-pr-wording.sh, .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh, .agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 12 close-conflict tests, 22 supersession tests, 93 REST-wrapper tests, ShellCheck, and changed-file local quality gates passed.

Resolves #29170


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.214 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 40m and 642,387 tokens on this with the user in an interactive session.