### PR TITLE
GH#29187: Restore unregistered framework updates

### DIFF
--- a/.agents/scripts/canonical-recovery-helper.sh
+++ b/.agents/scripts/canonical-recovery-helper.sh
@@ -10,6 +10,10 @@ SYNC_MIRROR_CMD="sync-mirror"
 CLEAR_STALE_REBASE_CMD="clear-stale-rebase"
 CLEAR_ABANDONED_REBASE_CMD="clear-abandoned-rebase"
 AIDEVOPS_UPDATE_REASON="aidevops-update"
+#aidevops:trust-boundary
+# Framework maintenance pins its upstream identity here instead of trusting a
+# downstream project registration or a caller-controlled remote name.
+AIDEVOPS_FRAMEWORK_GITHUB_SLUG="marcusquinn/aidevops"
 ABANDONED_REBASE_MIN_AGE_SECONDS=86400
 ABANDONED_REBASE_KIND="abandoned"
 HEAD_COMMIT_EXPR='HEAD^{commit}'
@@ -132,11 +136,12 @@ registered_repo_slug() {
 }
 
 # Resolve the remote that represents the registered GitHub repository. Exact
-# fetch+push identity is required. The origin fallback is limited to local
-# mirrors where no configured remote can be parsed as GitHub at all.
+# fetch+push identity is required. Callers may allow the origin fallback for
+# local mirrors where no configured remote can be parsed as GitHub at all.
 resolve_github_remote() {
 	local repo="$1"
 	local expected_slug="$2"
+	local allow_local_mirror="${3:-true}"
 	local expected_lower=""
 	local remote_names=""
 	local remote=""
@@ -200,7 +205,7 @@ resolve_github_remote() {
 		printf '%s\n' "$candidate"
 		return 0
 	fi
-	if [[ "$candidate_count" -eq 0 && "$github_seen" -eq 0 ]] &&
+	if [[ "$allow_local_mirror" == "true" && "$candidate_count" -eq 0 && "$github_seen" -eq 0 ]] &&
 		origin_is_local_mirror "$repo"; then
 		printf 'origin\n'
 		return 0
@@ -579,14 +584,27 @@ policy_helper="${SCRIPT_DIR}/canonical-write-policy-helper.py"
 	printf 'BLOCKED: canonical branch policy helper is unavailable\n' >&2
 	exit 1
 }
-registered_slug=$(registered_repo_slug "$repo_path") || {
-	printf 'BLOCKED: registered canonical repository identity is invalid or ambiguous\n' >&2
+registered_slug=""
+expected_slug=""
+allow_local_mirror=true
+if [[ "$maintenance_reason" == "$AIDEVOPS_UPDATE_REASON" ]]; then
+	expected_slug="$AIDEVOPS_FRAMEWORK_GITHUB_SLUG"
+	allow_local_mirror=false
+else
+	registered_slug=$(registered_repo_slug "$repo_path") || {
+		printf 'BLOCKED: registered canonical repository identity is invalid or ambiguous\n' >&2
+		exit 1
+	}
+	expected_slug="$registered_slug"
+fi
+if ! canonical_remote=$(resolve_github_remote "$repo_path" "$expected_slug" "$allow_local_mirror"); then
+	if [[ "$maintenance_reason" == "$AIDEVOPS_UPDATE_REASON" ]]; then
+		printf 'BLOCKED: official aidevops GitHub remote is missing, mismatched, or ambiguous\n' >&2
+	else
+		printf 'BLOCKED: registered GitHub remote is missing, mismatched, or ambiguous\n' >&2
+	fi
 	exit 1
-}
-canonical_remote=$(resolve_github_remote "$repo_path" "$registered_slug") || {
-	printf 'BLOCKED: registered GitHub remote is missing, mismatched, or ambiguous\n' >&2
-	exit 1
-}
+fi
 target_branch=$(AIDEVOPS_CANONICAL_REMOTE="$canonical_remote" \
 	python3 "$policy_helper" resolve-branch --cwd "$repo_path" --field branch) || exit 1
 target_branch_source=$(AIDEVOPS_CANONICAL_REMOTE="$canonical_remote" \
@@ -888,6 +906,7 @@ AUDIT_LOG_FILE="$recovery_audit_file" AUDIT_QUIET=true "$audit_helper" log opera
 	--detail "issue=${issue_number:-none}" --detail "reason=${maintenance_reason:-none}" --detail "repo=${repo_path}" \
 	--detail "operation=${cmd}" --detail "target=${target_branch}" --detail "target_source=${target_branch_source}" \
 	--detail "remote=${canonical_remote}" --detail "registered_slug=${registered_slug:-none}" \
+	--detail "expected_slug=${expected_slug}" \
 	--detail "target_sha=${target_sha}" --detail "local_sha=${local_sha}" \
 	--detail "preservation_ref=${preservation_ref:-none}" --detail "backup_id=${sync_backup_id:-none}" \
 	--detail "stale_rebase_fingerprint=${stale_rebase_fingerprint:-none}" \

--- a/.agents/scripts/tests/test-aidevops-update-transaction.sh
+++ b/.agents/scripts/tests/test-aidevops-update-transaction.sh
@@ -337,6 +337,7 @@ _migrate_settings_supervisor_to_orchestration() { return 0; }
 INTEGRATION_REMOTE="$TEST_ROOT/integration.git"
 INTEGRATION_REPO="$TEST_ROOT/integration-repo"
 INTEGRATION_PEER="$TEST_ROOT/integration-peer"
+REAL_HELPER_REPO="$TEST_ROOT/real-helper-repo"
 SETUP_CALLS="$TEST_ROOT/setup-calls"
 CANONICAL_HELPER_CALLS="$TEST_ROOT/canonical-helper-calls"
 UPDATE_HELPER_DIR="$TEST_ROOT/update-helper"
@@ -358,6 +359,27 @@ printf 'updated\n' >"$INTEGRATION_PEER/runtime.txt"
 /usr/bin/git -C "$INTEGRATION_PEER" commit -am "t18162: task-prefixed update" -q
 /usr/bin/git -C "$INTEGRATION_PEER" push -q origin main
 REMOTE_SHA=$(/usr/bin/git -C "$INTEGRATION_PEER" rev-parse HEAD)
+
+/usr/bin/git clone -q "$INTEGRATION_REMOTE" "$REAL_HELPER_REPO"
+/usr/bin/git -C "$REAL_HELPER_REPO" reset -q --hard "$BASE_SHA"
+FRAMEWORK_URL="https://github.com/marcusquinn/aidevops.git"
+/usr/bin/git -C "$REAL_HELPER_REPO" config "url.${INTEGRATION_REMOTE}.insteadOf" "$FRAMEWORK_URL"
+/usr/bin/git -C "$REAL_HELPER_REPO" remote set-url origin "$FRAMEWORK_URL"
+/usr/bin/git -C "$REAL_HELPER_REPO" remote set-head origin main
+INSTALL_DIR="$REAL_HELPER_REPO"
+_AIDEVOPS_UPDATE_HELPER_DIR="$REPO_ROOT/.agents/scripts"
+if AIDEVOPS_REPOS_CONFIG="$TEST_ROOT/missing-repos.json" AIDEVOPS_REAL_GIT_BIN=/usr/bin/git \
+	_update_fetch_main main &&
+	[[ "$(/usr/bin/git -C "$REAL_HELPER_REPO" rev-parse HEAD)" == "$REMOTE_SHA" ]] &&
+	grep -q '"reason":"aidevops-update"' \
+		"$HOME/.aidevops/logs/canonical-recovery-audit.jsonl" &&
+	grep -q '"expected_slug":"marcusquinn/aidevops"' \
+		"$HOME/.aidevops/logs/canonical-recovery-audit.jsonl"; then
+	pass "real canonical helper updates an unregistered framework source checkout"
+else
+	fail "real canonical helper updates an unregistered framework source checkout" \
+		"official framework identity did not reach the remote tip"
+fi
 
 mkdir -p "$UPDATE_HELPER_DIR"
 cat >"$UPDATE_HELPER_DIR/canonical-recovery-helper.sh" <<'EOF'

--- a/.agents/scripts/tests/test-canonical-recovery-helper.sh
+++ b/.agents/scripts/tests/test-canonical-recovery-helper.sh
@@ -91,6 +91,33 @@ printf 'renamed remote ahead\n' >>"${RENAMED_UPDATER}/README.md"
 /usr/bin/git -C "$RENAMED_UPDATER" commit -q -am 'renamed remote ahead'
 /usr/bin/git -C "$RENAMED_UPDATER" push -q origin main
 renamed_remote_tip=$(/usr/bin/git -C "$RENAMED_REMOTE" rev-parse refs/heads/main)
+renamed_before=$(/usr/bin/git -C "$RENAMED_REPO" rev-parse HEAD)
+unregistered_output=""
+if unregistered_output=$(AIDEVOPS_REPOS_CONFIG="${ROOT}/missing-repos.json" AIDEVOPS_REAL_GIT_BIN=/usr/bin/git \
+	bash "$HELPER" fast-forward-current --repo "$RENAMED_REPO" --branch main \
+	--issue 28865 --confirm FAST_FORWARD_CANONICAL_BRANCH 2>&1); then
+	printf 'FAIL unregistered GitHub recovery was accepted\n'
+	exit 1
+elif [[ "$unregistered_output" == *"BLOCKED: registered GitHub remote is missing, mismatched, or ambiguous"* ]] &&
+	[[ "$(/usr/bin/git -C "$RENAMED_REPO" rev-parse HEAD)" == "$renamed_before" ]]; then
+	printf 'PASS ordinary recovery rejects an unregistered GitHub repository\n'
+else
+	printf 'FAIL unregistered GitHub recovery did not fail before mutation\n'
+	exit 1
+fi
+update_identity_output=""
+if update_identity_output=$(AIDEVOPS_REPOS_CONFIG="${ROOT}/missing-repos.json" AIDEVOPS_REAL_GIT_BIN=/usr/bin/git \
+	bash "$HELPER" fast-forward-current --repo "$RENAMED_REPO" --branch main \
+	--reason aidevops-update --confirm FAST_FORWARD_CANONICAL_BRANCH 2>&1); then
+	printf 'FAIL framework update accepted a non-framework GitHub remote\n'
+	exit 1
+elif [[ "$update_identity_output" == *"BLOCKED: official aidevops GitHub remote is missing, mismatched, or ambiguous"* ]] &&
+	[[ "$(/usr/bin/git -C "$RENAMED_REPO" rev-parse HEAD)" == "$renamed_before" ]]; then
+	printf 'PASS framework update rejects a non-framework GitHub remote\n'
+else
+	printf 'FAIL framework update identity rejection was not actionable or non-destructive\n'
+	exit 1
+fi
 printf '{"initialized_repos":[{"slug":"example/canonical-remote","path":"%s"}]}\n' \
 	"$RENAMED_REPO" >"$RENAMED_CONFIG"
 if AIDEVOPS_REPOS_CONFIG="$RENAMED_CONFIG" AIDEVOPS_REAL_GIT_BIN=/usr/bin/git \
@@ -228,11 +255,17 @@ else
 	exit 1
 fi
 
-if AIDEVOPS_REAL_GIT_BIN=/usr/bin/git bash "$HELPER" fast-forward-current --repo "$REPO" --branch develop --reason aidevops-update --confirm FAST_FORWARD_CANONICAL_BRANCH >/dev/null &&
-	grep -q '"reason":"aidevops-update"' "$HOME/.aidevops/logs/canonical-recovery-audit.jsonl"; then
-	printf 'PASS routine update fast-forward records an audited reason without an invented issue number\n'
+update_local_mirror_output=""
+if update_local_mirror_output=$(AIDEVOPS_REAL_GIT_BIN=/usr/bin/git \
+	bash "$HELPER" fast-forward-current --repo "$REPO" --branch develop \
+	--reason aidevops-update --confirm FAST_FORWARD_CANONICAL_BRANCH 2>&1); then
+	printf 'FAIL framework update accepted a local mirror without official GitHub identity\n'
+	exit 1
+elif [[ "$update_local_mirror_output" == *"BLOCKED: official aidevops GitHub remote is missing, mismatched, or ambiguous"* ]] &&
+	[[ "$(/usr/bin/git -C "$REPO" rev-parse HEAD)" == "$develop_remote_tip" ]]; then
+	printf 'PASS framework update rejects a local mirror without official GitHub identity\n'
 else
-	printf 'FAIL routine update fast-forward did not record its maintenance reason\n'
+	printf 'FAIL local-mirror framework update rejection was not actionable or non-destructive\n'
 	exit 1
 fi
 
@@ -987,10 +1020,12 @@ mkdir -p "$UPDATE_REPO"
 /usr/bin/git -C "$UPDATE_REPO" config user.name Test
 /usr/bin/git -C "$UPDATE_REPO" config user.email test@example.invalid
 /usr/bin/git -C "$UPDATE_REPO" config commit.gpgsign false
+UPDATE_FRAMEWORK_URL="https://github.com/marcusquinn/aidevops.git"
+/usr/bin/git -C "$UPDATE_REPO" config "url.${UPDATE_REMOTE}.insteadOf" "$UPDATE_FRAMEWORK_URL"
 printf 'update seed\n' >"${UPDATE_REPO}/README.md"
 /usr/bin/git -C "$UPDATE_REPO" add README.md
 /usr/bin/git -C "$UPDATE_REPO" commit -q -m seed
-/usr/bin/git -C "$UPDATE_REPO" remote add origin "$UPDATE_REMOTE"
+/usr/bin/git -C "$UPDATE_REPO" remote add origin "$UPDATE_FRAMEWORK_URL"
 /usr/bin/git -C "$UPDATE_REPO" push -q -u origin main
 /usr/bin/git -C "$UPDATE_REMOTE" symbolic-ref HEAD refs/heads/main
 /usr/bin/git -C "$UPDATE_REPO" remote set-head origin main

--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ brew install marcusquinn/tap/aidevops && aidevops update
 bash <(curl -fsSL https://aidevops.sh/install)
 ```
 
+> **Updater recovery for v3.32.213:** If `aidevops update` stops because the
+> official framework source checkout is not in the project registry, run the
+> direct installer above once, then rerun `aidevops update`. Do not add the
+> framework checkout to the downstream project registry or bypass canonical
+> remote validation.
+
 **Manual** (git clone):
 
 ```bash


### PR DESCRIPTION
## Summary

Pin the official framework slug for audited self-update while preserving strict identity checks for ordinary canonical recovery; add real-helper regression coverage and a v3.32.213 recovery note.

## Files Changed

.agents/scripts/canonical-recovery-helper.sh, .agents/scripts/tests/test-aidevops-update-transaction.sh, .agents/scripts/tests/test-canonical-recovery-helper.sh, README.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified with the production _update_fetch_main path and real canonical helper; canonical recovery suite passed; update transaction suite passed 15/15; ShellCheck and linters-local passed.

Resolves #29187


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.214 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 41m and 394,961 tokens on this with the user in an interactive session.