### PR TITLE
GH#29173: Type review-thread remediation outcomes

### DIFF
--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -20,6 +20,9 @@
 # existing PR-review loop model. The targeted merge-blocker path can opt in to
 # human-authored threads with PR_REVIEW_THREAD_RESPONSE_INCLUDE_HUMAN=true. The
 # worker must read/verify the thread before editing code or resolving/commenting.
+# Targeted dispatch has a stable outcome contract: 0=queued, 10=deferred,
+# 11=no matching thread/race converged, 12=terminal maintainer attention, and
+# 13=retryable scan or launch failure.
 
 set -euo pipefail
 
@@ -54,6 +57,9 @@ PRRTS_WORKER_CONTRACT_VERSION="3"
 # Targeted callers distinguish productive dispatch deduplication from a hard
 # launch failure so an already-remediating PR is preserved.
 PRRTS_RC_DISPATCH_DEFERRED=10
+PRRTS_RC_NO_MATCH=11
+PRRTS_RC_MAINTAINER_ATTENTION=12
+PRRTS_RC_RETRYABLE_FAILURE=13
 PRRTS_RC_GRAPHQL_EXHAUSTED=75
 PRRTS_BLOCKED_BY_CODE="code"
 PRRTS_BLOCKED_BY_INFRASTRUCTURE="infrastructure"
@@ -559,7 +565,7 @@ cmd_scan_pr() {
 	summary="$(_prrts_review_thread_summary "$repo_slug" "$pr_number")" || rc=$?
 	if [[ "$rc" -ne 0 ]]; then
 		_prrts_log "scan-pr: ${repo_slug}#${pr_number} skipped — review-thread fetch failed"
-		return 0
+		return "$rc"
 	fi
 	IFS="$PRRTS_TSV_FIELD_SEPARATOR" read -r thread_count fingerprint preview \
 		<<<"${summary//$'\t'/$PRRTS_TSV_FIELD_SEPARATOR}"
@@ -980,7 +986,7 @@ _prrts_should_dispatch() {
 			retry_stale_head_validation="$PRRTS_BOOL_TRUE"
 		else
 			_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — analysis complete and blocked by ${blocked_by:-decision}; maintainer attention pending"
-			return 1
+			return "$PRRTS_RC_MAINTAINER_ATTENTION"
 		fi
 	fi
 	age_seconds=$((now_epoch - dispatched_at))
@@ -1758,10 +1764,12 @@ _prrts_dispatch_guarded() {
 			printf 'DRY-RUN would escalate %s#%s after %s repeated unresolved thread attempt(s)\n' "$repo_slug" "$pr_number" "$attempt_count"
 		else
 			_prrts_write_state "$repo_slug" "$pr_number" "$fingerprint" "$thread_count" "$now_epoch" "$attempt_count" "$maintainer_attention" "$head_oid"
+			_prrts_write_analysis_state "$repo_slug" "$pr_number" "$PRRTS_BOOL_TRUE" \
+				"maintainer" "$PRRTS_BOOL_TRUE" "same_unresolved_thread_fingerprint"
 			_prrts_log "dispatch: ${repo_slug}#${pr_number} not launching response worker — same unresolved thread fingerprint reached attempt ${attempt_count}; maintainer attention recommended (local state/log only, no GitHub write)"
 		fi
 		_prrts_remove_lock_dir "$lock_dir"
-		return 1
+		return "$PRRTS_RC_MAINTAINER_ATTENTION"
 	fi
 	if [[ "$dry_run" == "$PRRTS_BOOL_TRUE" ]]; then
 		printf 'DRY-RUN would dispatch %s#%s (%s unresolved thread(s))\n' "$repo_slug" "$pr_number" "$thread_count"
@@ -1781,7 +1789,7 @@ _prrts_dispatch_guarded() {
 		_prrts_write_analysis_state "$repo_slug" "$pr_number" "$PRRTS_BOOL_TRUE" \
 			"$PRRTS_WORKTREE_FAILURE_BLOCKED_BY" "$failure_maintainer_attention" "$PRRTS_WORKTREE_FAILURE_REASON"
 		_prrts_remove_lock_dir "$lock_dir"
-		return 1
+		return "$PRRTS_RC_RETRYABLE_FAILURE"
 	fi
 	_prrts_write_state "$repo_slug" "$pr_number" "$fingerprint" "$thread_count" "$now_epoch" "$attempt_count" "$maintainer_attention" "$head_oid"
 	_prrts_remove_lock_dir "$lock_dir"
@@ -1870,7 +1878,7 @@ _prrts_dispatch_pr() {
 	local repo_path="$2"
 	local pr_number="$3"
 	local dry_run="$4"
-	local candidate now_epoch thread_count fingerprint title head_ref head_oid author preview dispatch_rc
+	local candidate now_epoch thread_count fingerprint title head_ref head_oid author preview dispatch_rc scan_rc
 	candidate=""
 	now_epoch=""
 	thread_count=""
@@ -1881,16 +1889,21 @@ _prrts_dispatch_pr() {
 	author=""
 	preview=""
 	dispatch_rc=0
+	scan_rc=0
 
 	if [[ -z "$repo_path" || ! -d "${repo_path/#\~/$HOME}" || ! "$pr_number" =~ ^[0-9]+$ ]]; then
 		_prrts_log "dispatch-pr: ${repo_slug}#${pr_number} skipped — repo path missing/invalid or PR number invalid (${repo_path})"
-		return 1
+		return "$PRRTS_RC_RETRYABLE_FAILURE"
 	fi
 	repo_path="${repo_path/#\~/$HOME}"
-	candidate="$(cmd_scan_pr "$repo_slug" "$pr_number")"
+	candidate="$(cmd_scan_pr "$repo_slug" "$pr_number")" || scan_rc=$?
+	if [[ "$scan_rc" -ne 0 ]]; then
+		_prrts_log "dispatch-pr: ${repo_slug}#${pr_number} retryable review-thread scan failure (scan_rc=${scan_rc})"
+		return "$PRRTS_RC_RETRYABLE_FAILURE"
+	fi
 	[[ -n "$candidate" ]] || {
 		_prrts_log "dispatch-pr: ${repo_slug}#${pr_number} has no unresolved review threads matching current filters"
-		return 1
+		return "$PRRTS_RC_NO_MATCH"
 	}
 	now_epoch="$(date +%s)"
 	IFS="$PRRTS_TSV_FIELD_SEPARATOR" read -r pr_number thread_count fingerprint title head_ref head_oid author preview \

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -71,8 +71,11 @@
 _PULSE_MERGE_LOADED=1
 PULSE_REVIEW_EVIDENCE_SCHEMA="aidevops.review-gate-evidence/v1"
 PULSE_UNKNOWN_STATE="UNKNOWN"
-# Keep synchronized with PRRTS_RC_DISPATCH_DEFERRED in the response scanner.
+# Keep synchronized with the targeted exit contract in the response scanner.
 PULSE_REVIEW_REMEDIATION_DEFERRED_RC=10
+PULSE_REVIEW_REMEDIATION_NO_MATCH_RC=11
+PULSE_REVIEW_REMEDIATION_MAINTAINER_ATTENTION_RC=12
+PULSE_REVIEW_REMEDIATION_RETRYABLE_FAILURE_RC=13
 _PULSE_MERGE_REMEDIATION_OUTCOME=""
 
 # t2863: Module-level variable defaults (set -u guards).
@@ -136,9 +139,24 @@ _pulse_merge_dispatch_review_thread_remediation() {
 		echo "[pulse-merge] review-thread remediation deferred for PR #${pr_number} in ${repo_slug} — response dispatch active or recently deduplicated ${reason}" >>"$LOGFILE"
 		return 0
 	fi
+	if [[ "$scanner_rc" -eq "$PULSE_REVIEW_REMEDIATION_NO_MATCH_RC" ]]; then
+		_PULSE_MERGE_REMEDIATION_OUTCOME="converged"
+		echo "[pulse-merge] review-thread remediation converged for PR #${pr_number} in ${repo_slug} — no matching unresolved thread remained ${reason}" >>"$LOGFILE"
+		return 0
+	fi
+	if [[ "$scanner_rc" -eq "$PULSE_REVIEW_REMEDIATION_MAINTAINER_ATTENTION_RC" ]]; then
+		_PULSE_MERGE_REMEDIATION_OUTCOME="maintainer_attention"
+		echo "[pulse-merge] review-thread remediation reached terminal maintainer attention for PR #${pr_number} in ${repo_slug} ${reason}" >>"$LOGFILE"
+		return 0
+	fi
+	if [[ "$scanner_rc" -eq "$PULSE_REVIEW_REMEDIATION_RETRYABLE_FAILURE_RC" ]]; then
+		_PULSE_MERGE_REMEDIATION_OUTCOME="failed"
+		echo "[pulse-merge] review-thread remediation scan/launch failed for PR #${pr_number} in ${repo_slug} ${reason} (scanner_rc=${scanner_rc}); retry remains available" >>"$LOGFILE"
+		return 1
+	fi
 	if [[ "$scanner_rc" -ne 0 ]]; then
 		_PULSE_MERGE_REMEDIATION_OUTCOME="failed"
-		echo "[pulse-merge] review-thread remediation dispatch failed for PR #${pr_number} in ${repo_slug} ${reason} (scanner_rc=${scanner_rc})" >>"$LOGFILE"
+		echo "[pulse-merge] review-thread remediation returned unexpected outcome for PR #${pr_number} in ${repo_slug} ${reason} (scanner_rc=${scanner_rc})" >>"$LOGFILE"
 		return 1
 	fi
 	_PULSE_MERGE_REMEDIATION_OUTCOME="queued"
@@ -315,6 +333,10 @@ _handle_changes_requested_review_gate() {
 		&& _pulse_merge_dispatch_review_thread_remediation "$pr_number" "$repo_slug" "after CHANGES_REQUESTED review gate"; then
 		if [[ "$_PULSE_MERGE_REMEDIATION_OUTCOME" == "deferred" ]]; then
 			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED; response remediation already active/deferred, preserving PR" >>"$LOGFILE"
+		elif [[ "$_PULSE_MERGE_REMEDIATION_OUTCOME" == "converged" ]]; then
+			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED; no matching unresolved thread remained after refresh, preserving PR for reevaluation" >>"$LOGFILE"
+		elif [[ "$_PULSE_MERGE_REMEDIATION_OUTCOME" == "maintainer_attention" ]]; then
+			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED; terminal review-thread maintainer attention pending, preserving PR" >>"$LOGFILE"
 		else
 			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED; review-thread remediation queued" >>"$LOGFILE"
 		fi

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -1004,6 +1004,39 @@ test_dispatch_pr_launches_targeted_worker_with_human_opt_in() {
 	return 0
 }
 
+test_dispatch_pr_reports_no_match_as_converged() {
+	setup_test_env
+	export STUB_THREADS_MODE="none"
+	local dispatch_rc=0
+	$SCANNER dispatch-pr owner/repo "${TEST_ROOT}/repo" 1 || dispatch_rc=$?
+	if [[ "$dispatch_rc" -eq 11 && ! -s "$HEADLESS_LOG" ]] &&
+		grep -q 'has no unresolved review threads matching current filters' "$LOGFILE" 2>/dev/null; then
+		print_result "dispatch-pr reports a resolved-between-snapshot race as converged" 0
+	else
+		print_result "dispatch-pr reports a resolved-between-snapshot race as converged" 1 \
+			"rc=${dispatch_rc}, headless=$(wc -c <"$HEADLESS_LOG" 2>/dev/null || printf 0), log=$(tr '\n' ';' <"$LOGFILE" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_dispatch_pr_reports_fetch_failure_as_retryable() {
+	setup_test_env
+	export STUB_THREADS_MODE="error"
+	export STUB_GRAPHQL_REMAINING="100"
+	local dispatch_rc=0
+	$SCANNER dispatch-pr owner/repo "${TEST_ROOT}/repo" 1 || dispatch_rc=$?
+	if [[ "$dispatch_rc" -eq 13 && ! -s "$HEADLESS_LOG" ]] &&
+		grep -q 'retryable review-thread scan failure (scan_rc=2)' "$LOGFILE" 2>/dev/null; then
+		print_result "dispatch-pr propagates review-thread fetch failure as retryable" 0
+	else
+		print_result "dispatch-pr propagates review-thread fetch failure as retryable" 1 \
+			"rc=${dispatch_rc}, headless=$(wc -c <"$HEADLESS_LOG" 2>/dev/null || printf 0), log=$(tr '\n' ';' <"$LOGFILE" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_dispatch_is_idempotent_for_same_fingerprint() {
 	setup_test_env
 	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
@@ -1037,26 +1070,33 @@ test_dispatch_skips_mixed_fingerprint_during_inflight_window() {
 
 test_dispatch_escalates_repeated_same_fingerprint_without_worker_loop() {
 	setup_test_env
-	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	$SCANNER dispatch-pr owner/repo "${TEST_ROOT}/repo" 1
 	wait_for_headless_log || true
 	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
-	local old_epoch=""
+	local old_epoch="" terminal_rc=0 repeat_rc=0 state_before_repeat=""
 	old_epoch="$(($(date +%s) - 4000))"
 	expire_state_dispatch_time "$state_file" "$old_epoch"
 	: >"$HEADLESS_LOG"
-	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	$SCANNER dispatch-pr owner/repo "${TEST_ROOT}/repo" 1
 	wait_for_headless_log || true
 	old_epoch="$(($(date +%s) - 4000))"
 	expire_state_dispatch_time "$state_file" "$old_epoch"
 	: >"$HEADLESS_LOG"
-	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
-	if [[ ! -s "$HEADLESS_LOG" ]] &&
+	$SCANNER dispatch-pr owner/repo "${TEST_ROOT}/repo" 1 || terminal_rc=$?
+	state_before_repeat="$(<"$state_file")"
+	$SCANNER dispatch-pr owner/repo "${TEST_ROOT}/repo" 1 || repeat_rc=$?
+	if [[ "$terminal_rc" -eq 12 && "$repeat_rc" -eq 12 && ! -s "$HEADLESS_LOG" ]] &&
 		grep -q '^attempt_count=3$' "$state_file" 2>/dev/null &&
+		grep -q '^analysis_complete=true$' "$state_file" 2>/dev/null &&
+		grep -q '^blocked_by=maintainer$' "$state_file" 2>/dev/null &&
 		grep -q '^maintainer_attention=true$' "$state_file" 2>/dev/null &&
+		grep -q '^blocker_reason=same_unresolved_thread_fingerprint$' "$state_file" 2>/dev/null &&
+		[[ "$(<"$state_file")" == "$state_before_repeat" ]] &&
 		grep -q 'not launching response worker — same unresolved thread fingerprint reached attempt 3' "$LOGFILE" 2>/dev/null; then
-		print_result "dispatch escalates repeated same fingerprint without worker loop" 0
+		print_result "dispatch-pr persists terminal same-fingerprint attention and deduplicates repeats" 0
 	else
-		print_result "dispatch escalates repeated same fingerprint without worker loop" 1 "headless=$(wc -c <"$HEADLESS_LOG" 2>/dev/null || printf 0), state=$(tr '\n' ';' <"$state_file" 2>/dev/null || printf ''), log=$(tr '\n' ';' <"$LOGFILE" 2>/dev/null || printf '')"
+		print_result "dispatch-pr persists terminal same-fingerprint attention and deduplicates repeats" 1 \
+			"terminal_rc=${terminal_rc}, repeat_rc=${repeat_rc}, headless=$(wc -c <"$HEADLESS_LOG" 2>/dev/null || printf 0), state=$(tr '\n' ';' <"$state_file" 2>/dev/null || printf ''), log=$(tr '\n' ';' <"$LOGFILE" 2>/dev/null || printf '')"
 	fi
 	teardown_test_env
 	return 0
@@ -1249,10 +1289,12 @@ test_dispatch_retries_transient_head_fetch_failure_once() {
 test_dispatch_retries_generic_infrastructure_launch_failure() {
 	setup_test_env
 	chmod -x "$HEADLESS_RUNTIME_HELPER"
-	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	local first_dispatch_rc=0
+	$SCANNER dispatch-pr owner/repo "${TEST_ROOT}/repo" 1 || first_dispatch_rc=$?
 	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
 	local first_failure_ok="false"
-	if grep -q '^analysis_complete=true$' "$state_file" 2>/dev/null &&
+	if [[ "$first_dispatch_rc" -eq 13 ]] &&
+		grep -q '^analysis_complete=true$' "$state_file" 2>/dev/null &&
 		grep -q '^blocked_by=infrastructure$' "$state_file" 2>/dev/null &&
 		grep -q '^maintainer_attention=false$' "$state_file" 2>/dev/null &&
 		grep -q '^blocker_reason=review_worker_launch_failed$' "$state_file" 2>/dev/null; then
@@ -1262,7 +1304,7 @@ test_dispatch_retries_generic_infrastructure_launch_failure() {
 	old_epoch="$(($(date +%s) - 4000))"
 	expire_state_dispatch_time "$state_file" "$old_epoch"
 	chmod +x "$HEADLESS_RUNTIME_HELPER"
-	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	$SCANNER dispatch-pr owner/repo "${TEST_ROOT}/repo" 1
 	wait_for_headless_log || true
 	if [[ "$first_failure_ok" == "true" && -s "$HEADLESS_LOG" ]] &&
 		grep -q '^attempt_count=2$' "$state_file" 2>/dev/null &&
@@ -1270,7 +1312,7 @@ test_dispatch_retries_generic_infrastructure_launch_failure() {
 		print_result "dispatch retries a generic infrastructure launch failure" 0
 	else
 		print_result "dispatch retries a generic infrastructure launch failure" 1 \
-			"first_failure_ok=${first_failure_ok}, headless=$(wc -c <"$HEADLESS_LOG" 2>/dev/null || printf 0), state=$(tr '\n' ';' <"$state_file" 2>/dev/null || printf '')"
+			"first_dispatch_rc=${first_dispatch_rc}, first_failure_ok=${first_failure_ok}, headless=$(wc -c <"$HEADLESS_LOG" 2>/dev/null || printf 0), state=$(tr '\n' ';' <"$state_file" 2>/dev/null || printf '')"
 	fi
 	teardown_test_env
 	return 0
@@ -1721,6 +1763,8 @@ main() {
 	test_dispatch_prompt_declares_precreated_worktree_contract
 	test_dispatch_prompt_marks_dynamic_metadata_untrusted
 	test_dispatch_pr_launches_targeted_worker_with_human_opt_in
+	test_dispatch_pr_reports_no_match_as_converged
+	test_dispatch_pr_reports_fetch_failure_as_retryable
 	test_dispatch_is_idempotent_for_same_fingerprint
 	test_dispatch_skips_mixed_fingerprint_during_inflight_window
 	test_dispatch_escalates_repeated_same_fingerprint_without_worker_loop

--- a/.agents/scripts/tests/test-pulse-current-state-helper.sh
+++ b/.agents/scripts/tests/test-pulse-current-state-helper.sh
@@ -99,12 +99,12 @@ os.makedirs(state_dir, exist_ok=True)
 open(os.path.join(state_dir, 'owner-repo-12.state'), 'w').write(
     'fingerprint=THREAD1\n'
     'thread_count=1\n'
-    'attempt_count=2\n'
+    'attempt_count=3\n'
     'analysis_complete=true\n'
     'maintainer_attention=true\n'
     'blocked_by=maintainer\n'
-    'blocker_reason=needs_decision\n'
-    'blocker_details=choose follow-up scope\n'
+    'attention_reason=same_unresolved_thread_fingerprint\n'
+    'blocker_reason=same_unresolved_thread_fingerprint\n'
     f'completed_at={int(now)}\n'
 )
 PY
@@ -143,7 +143,7 @@ grep -q 'API call pressure:' "$output"
 grep -q 'Prefetch cache:' "$output"
 grep -q 'Cycle state:' "$output"
 grep -q 'Review-thread maintainer attention:' "$output"
-grep -q 'needs_decision' "$output"
+grep -q 'same_unresolved_thread_fingerprint' "$output"
 grep -q 'worker_launch_total' "$output"
 grep -q 'watchdog_killed' "$output"
 grep -q 'rate_limited' "$output"
@@ -183,7 +183,8 @@ jq -e '.cycle_state.outcome == "progressed"' "$json_output" >/dev/null
 jq -e '.cycle_state.progress.kinds == ["worker-dispatched"]' "$json_output" >/dev/null
 jq -e '.review_thread_attention[0].blocked_by == "maintainer"' "$json_output" >/dev/null
 jq -e '.review_thread_attention[0].pr_number == 12' "$json_output" >/dev/null
-jq -e '.review_thread_attention[0].reason == "needs_decision"' "$json_output" >/dev/null
+jq -e '.review_thread_attention[0].reason == "same_unresolved_thread_fingerprint"' "$json_output" >/dev/null
+jq -e '.review_thread_attention[0].attempt_count == 3' "$json_output" >/dev/null
 jq -e '.objective_reconciliation.objectives_without_next_action == 1' "$json_output" >/dev/null
 jq -e '.objective_reconciliation.expired_assumptions == 1' "$json_output" >/dev/null
 jq -e '.objective_reconciliation.oldest_unverified_assumption.number == 41' "$json_output" >/dev/null

--- a/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
+++ b/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
@@ -49,6 +49,9 @@ SCANNER
 	_OW_LABEL_PAT=",origin:worker,"
 	export SCANNER_RC=0
 	PULSE_REVIEW_REMEDIATION_DEFERRED_RC=10
+	PULSE_REVIEW_REMEDIATION_NO_MATCH_RC=11
+	PULSE_REVIEW_REMEDIATION_MAINTAINER_ATTENTION_RC=12
+	PULSE_REVIEW_REMEDIATION_RETRYABLE_FAILURE_RC=13
 	_PULSE_MERGE_REMEDIATION_OUTCOME=""
 	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND=""
 	unset AIDEVOPS_CHANGES_REQUESTED_THREAD_REMEDIATION_FIRST
@@ -170,7 +173,7 @@ test_unrelated_preflight_blocker_does_not_dispatch() {
 
 test_failed_preflight_dispatch_stays_blocked_and_consumes_marker() {
 	setup_test_env
-	export SCANNER_RC=1
+	export SCANNER_RC=13
 	define_helpers_under_test || {
 		teardown_test_env
 		return 0
@@ -179,13 +182,59 @@ test_failed_preflight_dispatch_stays_blocked_and_consumes_marker() {
 
 	_pulse_merge_maybe_dispatch_preflight_remediation 77 owner/repo
 
-	if grep -q 'review-thread remediation dispatch failed for PR #77 in owner/repo' "$LOGFILE" &&
+	if grep -q 'review-thread remediation scan/launch failed for PR #77 in owner/repo' "$LOGFILE" &&
 		! grep -q 'review-thread remediation queued for PR #77 in owner/repo' "$LOGFILE" &&
 		[[ -z "$_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND" ]]; then
 		print_result "failed preflight dispatch consumes typed marker" 0
 	else
 		print_result "failed preflight dispatch consumes typed marker" 1 \
 			"marker=${_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND:-<none>}, log=$(tr '\n' ';' <"$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_no_match_preflight_dispatch_converges_and_consumes_marker() {
+	setup_test_env
+	export SCANNER_RC=11
+	define_helpers_under_test || {
+		teardown_test_env
+		return 0
+	}
+	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_REQUIRED_REVIEW_THREADS"
+
+	_pulse_merge_maybe_dispatch_preflight_remediation 77 owner/repo
+
+	if [[ "$_PULSE_MERGE_REMEDIATION_OUTCOME" == "converged" && -z "$_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND" ]] &&
+		grep -q 'review-thread remediation converged for PR #77 in owner/repo' "$LOGFILE" &&
+		! grep -q 'review-thread remediation queued for PR #77 in owner/repo' "$LOGFILE"; then
+		print_result "no-match preflight outcome converges and consumes typed marker" 0
+	else
+		print_result "no-match preflight outcome converges and consumes typed marker" 1 \
+			"outcome=${_PULSE_MERGE_REMEDIATION_OUTCOME:-<none>}, marker=${_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND:-<none>}, log=$(tr '\n' ';' <"$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_terminal_attention_preflight_dispatch_stays_fail_closed() {
+	setup_test_env
+	export SCANNER_RC=12
+	define_helpers_under_test || {
+		teardown_test_env
+		return 0
+	}
+	_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_REQUIRED_REVIEW_THREADS"
+
+	_pulse_merge_maybe_dispatch_preflight_remediation 77 owner/repo
+
+	if [[ "$_PULSE_MERGE_REMEDIATION_OUTCOME" == "maintainer_attention" && -z "$_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND" ]] &&
+		grep -q 'review-thread remediation reached terminal maintainer attention for PR #77 in owner/repo' "$LOGFILE" &&
+		! grep -q 'review-thread remediation queued for PR #77 in owner/repo' "$LOGFILE"; then
+		print_result "terminal-attention preflight outcome remains fail-closed" 0
+	else
+		print_result "terminal-attention preflight outcome remains fail-closed" 1 \
+			"outcome=${_PULSE_MERGE_REMEDIATION_OUTCOME:-<none>}, marker=${_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND:-<none>}, log=$(tr '\n' ';' <"$LOGFILE")"
 	fi
 	teardown_test_env
 	return 0
@@ -381,10 +430,74 @@ test_changes_requested_active_remediation_preserves_pr_without_routing() {
 	return 0
 }
 
+test_changes_requested_converged_remediation_preserves_pr_without_routing() {
+	setup_test_env
+	export AIDEVOPS_CHANGES_REQUESTED_THREAD_REMEDIATION_FIRST=1
+	export SCANNER_RC=11
+	define_helpers_under_test || {
+		teardown_test_env
+		return 0
+	}
+	local route_log="${TEST_ROOT}/route.log"
+	: >"$route_log"
+	_route_pr_to_fix_worker() {
+		local pr_number="$1"
+		local repo_slug="$2"
+		printf 'route %s %s\n' "$pr_number" "$repo_slug" >>"$route_log"
+		return 0
+	}
+	_pulse_merge_dismiss_coderabbit_nits() {
+		return 1
+	}
+
+	_handle_changes_requested_review_gate 77 owner/repo CHANGES_REQUESTED 42 "origin:worker" || true
+	if [[ ! -s "$route_log" ]] &&
+		grep -q 'no matching unresolved thread remained after refresh, preserving PR for reevaluation' "$LOGFILE"; then
+		print_result "converged response remediation preserves CHANGES_REQUESTED PR" 0
+	else
+		print_result "converged response remediation preserves CHANGES_REQUESTED PR" 1 \
+			"route=$(tr '\n' ';' <"$route_log"), log=$(tr '\n' ';' <"$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_changes_requested_terminal_attention_preserves_pr_without_routing() {
+	setup_test_env
+	export AIDEVOPS_CHANGES_REQUESTED_THREAD_REMEDIATION_FIRST=1
+	export SCANNER_RC=12
+	define_helpers_under_test || {
+		teardown_test_env
+		return 0
+	}
+	local route_log="${TEST_ROOT}/route.log"
+	: >"$route_log"
+	_route_pr_to_fix_worker() {
+		local pr_number="$1"
+		local repo_slug="$2"
+		printf 'route %s %s\n' "$pr_number" "$repo_slug" >>"$route_log"
+		return 0
+	}
+	_pulse_merge_dismiss_coderabbit_nits() {
+		return 1
+	}
+
+	_handle_changes_requested_review_gate 77 owner/repo CHANGES_REQUESTED 42 "origin:worker" || true
+	if [[ ! -s "$route_log" ]] &&
+		grep -q 'terminal review-thread maintainer attention pending, preserving PR' "$LOGFILE"; then
+		print_result "terminal-attention remediation preserves CHANGES_REQUESTED PR" 0
+	else
+		print_result "terminal-attention remediation preserves CHANGES_REQUESTED PR" 1 \
+			"route=$(tr '\n' ';' <"$route_log"), log=$(tr '\n' ';' <"$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_changes_requested_hard_dispatch_failure_still_routes() {
 	setup_test_env
 	export AIDEVOPS_CHANGES_REQUESTED_THREAD_REMEDIATION_FIRST=1
-	export SCANNER_RC=1
+	export SCANNER_RC=13
 	define_helpers_under_test || { teardown_test_env; return 0; }
 	local route_log="${TEST_ROOT}/route.log"
 	: >"$route_log"
@@ -398,7 +511,7 @@ test_changes_requested_hard_dispatch_failure_still_routes() {
 
 	_handle_changes_requested_review_gate 77 owner/repo CHANGES_REQUESTED 42 "origin:worker" || true
 	if grep -q 'route 77 owner/repo' "$route_log" \
-		&& grep -q 'review-thread remediation dispatch failed for PR #77 in owner/repo' "$LOGFILE"; then
+		&& grep -q 'review-thread remediation scan/launch failed for PR #77 in owner/repo' "$LOGFILE"; then
 		print_result "hard response-worker dispatch failure retains fix-worker fallback" 0
 	else
 		print_result "hard response-worker dispatch failure retains fix-worker fallback" 1 \
@@ -516,6 +629,8 @@ main() {
 	test_required_review_thread_preflight_blocker_dispatches
 	test_unrelated_preflight_blocker_does_not_dispatch
 	test_failed_preflight_dispatch_stays_blocked_and_consumes_marker
+	test_no_match_preflight_dispatch_converges_and_consumes_marker
+	test_terminal_attention_preflight_dispatch_stays_fail_closed
 	test_dry_run_preflight_blocker_never_dispatches
 	test_unresolved_conversation_dispatches_targeted_human_thread_remediation
 	test_repo_path_lookup_ignores_slug_case
@@ -524,6 +639,8 @@ main() {
 	test_changes_requested_opt_in_dispatches_remediation_without_routing
 	test_changes_requested_routes_when_remediation_unavailable
 	test_changes_requested_active_remediation_preserves_pr_without_routing
+	test_changes_requested_converged_remediation_preserves_pr_without_routing
+	test_changes_requested_terminal_attention_preserves_pr_without_routing
 	test_changes_requested_hard_dispatch_failure_still_routes
 	test_changes_requested_skips_remediation_for_external_contributor
 	test_changes_requested_empty_worker_label_pattern_does_not_match_every_label


### PR DESCRIPTION
## Summary

- Give targeted review-thread dispatch stable outcomes for queued work, deferred work, resolved/no-match convergence, terminal maintainer attention, and retryable scan or launch failure.
- Persist repeated same-fingerprint escalation as completed maintainer-attention state so Pulse exposes the durable blocker without repeatedly dispatching workers.
- Map each scanner outcome explicitly in Pulse while preserving fail-closed review semantics; Pulse never resolves threads from permission or sentiment alone.

## Files Changed

- `.agents/scripts/pr-review-thread-response-scanner.sh`
- `.agents/scripts/pulse-merge.sh`
- `.agents/scripts/tests/test-pr-review-thread-response-scanner.sh`
- `.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh`
- `.agents/scripts/tests/test-pulse-current-state-helper.sh`

## Runtime Testing

- **Risk level:** Medium
- Scanner tests: 63/63 passed.
- Pulse remediation tests: 21/21 passed.
- Merge preflight snapshot tests: 90/90 passed.
- Pulse current-state projection test passed.
- ShellCheck, Bash syntax, and changed-file local quality gates passed.

Resolves #29173

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.214 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h 8m and 955,941 tokens on this with the user in an interactive session.
