### PR TITLE
GH#29197: Allow empty continuation batches

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -615,7 +615,7 @@ _dlw_capture_reused_worktree_owner() {
 
 	local owner_pid="" owner_session="" owner_batch="" owner_task="" owner_created_at=""
 	IFS='|' read -r owner_pid owner_session owner_batch owner_task owner_created_at <<<"$owner_info"
-	if [[ ! "$owner_pid" =~ ^[0-9]+$ || -z "$owner_session" || -z "$owner_batch" ||
+	if [[ ! "$owner_pid" =~ ^[0-9]+$ || -z "$owner_session" ||
 		"$owner_task" != "$issue_number" || -z "$owner_created_at" ]]; then
 		echo "[dispatch_with_dedup] Rejected incomplete or mismatched registry owner for #${issue_number}; attempting an atomic same-task claim instead: ${worktree_path}" >>"$LOGFILE"
 		return 1

--- a/.agents/scripts/tests/test-headless-runtime-worktree-tests.sh
+++ b/.agents/scripts/tests/test-headless-runtime-worktree-tests.sh
@@ -504,8 +504,8 @@ test_worker_worktree_continuation_transfers_dirty_same_task_owner() {
 	printf 'preserve me\n' >"${worktree_dir}/continuation.txt"
 	export WORKER_ISSUE_NUMBER="22438"
 	local live_pid="$$" owner_created_at="2026-07-18T00:00:00Z"
-	set_continuation_transfer_env "$live_pid" "generation-7" "batch-7" "22438" "$owner_created_at"
-	local claim_calls=0 transfer_calls=0
+	set_continuation_transfer_env "$live_pid" "generation-7" "" "22438" "$owner_created_at"
+	local claim_calls=0 transfer_calls=0 expected_batch_seen="missing"
 
 	claim_worktree_ownership() {
 		claim_calls=$((claim_calls + 1))
@@ -514,13 +514,25 @@ test_worker_worktree_continuation_transfers_dirty_same_task_owner() {
 	check_worktree_owner() {
 		local check_path="$1"
 		[[ -n "$check_path" ]] || return 1
-		printf '%s|%s|%s|%s|%s\n' "$live_pid" "generation-7" "batch-7" "22438" "$owner_created_at"
+		printf '%s|%s|%s|%s|%s\n' "$live_pid" "generation-7" "" "22438" "$owner_created_at"
 		return 0
 	}
 	transfer_worktree_ownership_if_expected() {
 		local transfer_path="$1"
 		local transfer_branch="$2"
+		shift 2
 		[[ -n "$transfer_path" && -n "$transfer_branch" ]] || return 1
+		while [[ $# -gt 0 ]]; do
+			local option="$1"
+			case "$option" in
+			--expected-batch)
+				[[ $# -ge 2 ]] || return 1
+				expected_batch_seen="$2"
+				shift 2
+				;;
+			*) shift ;;
+			esac
+		done
 		transfer_calls=$((transfer_calls + 1))
 		return 0
 	}
@@ -533,12 +545,13 @@ test_worker_worktree_continuation_transfers_dirty_same_task_owner() {
 	clear_continuation_transfer_env
 
 	if [[ "$status" -eq 0 && "$claim_calls" -eq 0 && "$transfer_calls" -eq 1 &&
+		-z "$expected_batch_seen" &&
 		"$preserved_status" == *"continuation.txt"* ]]; then
-		print_result "dirty same-task continuation transfers without discarding edits" 0
+		print_result "empty-batch same-task continuation transfers without discarding edits" 0
 		return 0
 	fi
-	print_result "dirty same-task continuation transfers without discarding edits" 1 \
-		"status=$status claim_calls=$claim_calls transfer_calls=$transfer_calls git_status=${preserved_status:-<empty>}"
+	print_result "empty-batch same-task continuation transfers without discarding edits" 1 \
+		"status=$status claim_calls=$claim_calls transfer_calls=$transfer_calls expected_batch=${expected_batch_seen:-<empty>} git_status=${preserved_status:-<empty>}"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-precreation-failure-skip.sh
+++ b/.agents/scripts/tests/test-precreation-failure-skip.sh
@@ -471,7 +471,7 @@ STUB_OWNER_INFO=""
 unset STUB_EXISTING_WORKTREE_LINE
 
 # =============================================================================
-# Test 3c: an empty continuation batch falls through to an atomic claim
+# Test 3c: an empty continuation batch remains an exact transferable snapshot
 # =============================================================================
 export STUB_EXISTING_WORKTREE_LINE="${STUB_EXISTING_PATH} abcdef [${STUB_EXISTING_BRANCH}]"
 REGISTERED_WORKTREE_ARGS=""
@@ -481,13 +481,18 @@ STUB_CLAIM_WORKTREE_RC=0
 : >"$LOGFILE"
 _dlw_precreate_worktree "66666" "$FAKE_REPO"
 rc=$?
-expected_claim="${STUB_EXISTING_PATH}|${STUB_EXISTING_BRANCH}|66666|dispatch-precreate-66666|$$"
-if [[ "$rc" -eq 0 && "$CLAIMED_WORKTREE_ARGS" == "$expected_claim" &&
-	-z "${_DLW_WORKTREE_TRANSFER_MODE:-}" ]] &&
-	grep -Fq "Rejected incomplete or mismatched registry owner for #66666" "$LOGFILE"; then
-	pass "empty continuation batch is never exported and uses the atomic repair path"
+if [[ "$rc" -eq 0 && -z "$CLAIMED_WORKTREE_ARGS" &&
+	"${_DLW_WORKTREE_TRANSFER_MODE:-}" == "continuation" &&
+	"${_DLW_WORKTREE_EXPECTED_OWNER_PID:-}" == "12345" &&
+	"${_DLW_WORKTREE_EXPECTED_OWNER_SESSION:-}" == "generation-7" &&
+	-z "${_DLW_WORKTREE_EXPECTED_OWNER_BATCH:-}" &&
+	"${_DLW_WORKTREE_EXPECTED_OWNER_TASK:-}" == "66666" &&
+	"${_DLW_WORKTREE_EXPECTED_OWNER_CREATED_AT:-}" == "2026-07-18T00:00:00Z" ]] &&
+	grep -Fq "Preserving reused worktree until its expected continuation owner transfers" "$LOGFILE" &&
+	! grep -Fq "Rejected incomplete or mismatched registry owner for #66666" "$LOGFILE"; then
+	pass "empty continuation batch remains an exact transferable snapshot"
 else
-	fail "empty continuation batch is never exported and uses the atomic repair path" \
+	fail "empty continuation batch remains an exact transferable snapshot" \
 		"rc=$rc mode='${_DLW_WORKTREE_TRANSFER_MODE:-}' claim='$CLAIMED_WORKTREE_ARGS'"
 fi
 STUB_OWNER_INFO=""


### PR DESCRIPTION
## Summary

Treat an empty owner_batch as a valid exact ownership snapshot for ordinary single-issue reused-worktree continuation, while preserving all PID, session, task, timestamp, and atomic transfer checks.

## Files Changed

.agents/scripts/pulse-dispatch-worker-launch.sh, .agents/scripts/tests/test-headless-runtime-worktree-tests.sh, .agents/scripts/tests/test-precreation-failure-skip.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified through 47 precreation checks and the full headless runtime helper suite, including live empty-batch continuation transfer without edit loss; ShellCheck, 154 NMR trust-boundary checks, and local changed-file gates also passed.

Resolves #29197


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.215 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 21m and 291,520 tokens on this with the user in an interactive session.