### PR TITLE
GH#28867: integrate parallel knowledge providers

### DIFF
--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -43,12 +43,35 @@ a claim that the route is enabled.
 | Discourse | **Live** topics and posts | **Live/Partial** likes, bookmarks, and current reading state | **Live/Gate/Partial** notifications and private-topic metadata; **No** message bodies | **Live/Partial** groups and category preferences; **No** unverified Follow plugin | **No** watched/tracked topic inventories until search behavior is verified | Ten User API `read` streams with per-installation namespaces, repeated identity checks, exact GET routes, redirect rejection, and explicit plugin/export/history gaps. |
 | NodeBB | **Live** topics and posts | **Live/Partial** votes, bookmarks, watched topics, and category state | **Live/Partial** notifications and chat-room metadata; **No** message bodies | **Live/Partial** follows and groups | **No** plugin-provided lists | Thirteen independently checkpointed core GET streams with per-installation identity, bounded pagination, and explicit admin/plugin/export/history gaps. |
 
+## Integrated provider families
+
+These independently implemented contracts are registered by canonical provider ID
+and explicit aliases. `provider-run` requires an exact supported mode and never
+falls back to another provider or to an outbound mutation route.
+
+| Provider | Implemented mode | Explicit gaps and boundaries |
+|---|---|---|
+| Slack | **Live** Web API; **Live/Export** approved archive | Workspace identity, token visibility, plan retention, and export authority remain explicit. |
+| Discord | **Live/Gate** bounded bot-visible reads | User-token automation and unavailable private history remain unsupported. |
+| WhatsApp | **Live/Export** consumer chat archives; **Live/Gate** Business webhook events | No consumer-account polling or mutation route. |
+| Signal | **Live/Manual** offline `signal-cli` receive-event import | No remote account API, history scraping, or send reachability. |
+| Nextcloud Talk | **Live** multi-instance reads | Instance identity, room membership, retention, and webhook coverage remain explicit. |
+| Gumroad | **Live/Gate** seller-account reads | Buyer/seller visibility and unavailable private or mutation categories remain explicit. |
+| Google Business Profile | **Live/Gate** account/location reads | Listing writes and other management authority are isolated from collection. |
+| Telegram | **Live/Export** account archive; **Live/Gate** bot events | No user-account polling, private-history inference, or bot mutation route. |
+| Binance Square | **No** | Officially verified surfaces are mutation-only; no adapter, export, browser, or credential route is registered. |
+| Bluesky / AT Protocol | **Live** repository/AppView reads | Chat remains separately permissioned; account identity is a stable DID. |
+| Forem | **Live** multi-instance reads | `dev-community` and `dev.to` are aliases of `forem`, not separate providers. |
+
+HubSpot Community remains a Discourse installation and is not registered as a
+separate provider family.
+
 ## Recommended candidates
 
 | Provider family | Authored content | Interactions and curation | Mentions or messages | Relationships and subscriptions | Lists or custom feeds | Current disposition |
 |---|---|---|---|---|---|---|
 | Mastodon | **API** | **API** favourites and bookmarks | **API** notifications | **API** follows | **API** lists | Strong official-API candidate; account for instance-specific retention and limits. |
-| Bluesky / AT Protocol | **API** | **API** likes and reposts | **API/Gate** notifications or chat | **API** follows | **API** lists and feeds | Separate repository records, AppView reads, and chat authorization. |
+| Bluesky / AT Protocol | **Live** records | **Live** likes and reposts | **Live/Gate** notifications; **No/Gate** chat | **Live** follows | **Live** lists and feeds | DID-bound repository/AppView reads with separate chat authorization. |
 | Lemmy | **API** | **API** saved and votes | **API** replies and mentions | **API** communities | **API/Gate** | Verify instance version and federation-visible versus private account state. |
 | Stack Exchange | **API/Export** | **API/Export** | **API/Gate** inbox | **API/Export** associated accounts | **No** until verified | Observe API quota and per-site identity boundaries. |
 | GitHub | **API/Export** | **API** reactions, stars, and watches | **API** notifications and discussions | **API** follows, organizations, and repositories | **API/Gate** saved lists/projects | Keep developer-work evidence distinct from general social engagement. |
@@ -129,6 +152,12 @@ a claim that the route is enabled.
   evidence, public capability limits, admin-only version/plugin discovery,
   account-visible permissions, exports, retention, terms, and explicit plugin,
   message-body, and history gaps checked on 2026-07-28.
+- **Integrated provider registry:** `.agents/scripts/knowledge_social_registry.py`
+  and `.agents/tests/test-knowledge-social-registry.sh` prove order-independent
+  registration, collision rejection, exact aliases and modes, no-route failure,
+  allowlisted local execution, and the absence of fallback dispatch. Provider-
+  focused tests remain the authority for identity, pagination/import replay,
+  budgets, persistence, coverage, and mutation isolation.
 - **Quora export disposition:** `.agents/content/social-quora.md` records the
   official owner-request route, current public archive observations, absent
   schema and retention guarantees, and the identity-verification gap checked on

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -20,6 +20,7 @@ SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
 SHARE_HELPER="${SCRIPT_DIR}/knowledge_social_share.py"
 BROWSER_HELPER="${SCRIPT_DIR}/knowledge_social_browser.py"
 OPERATIONS_HELPER="${SCRIPT_DIR}/knowledge_social_operations.py"
+REGISTRY_HELPER="${SCRIPT_DIR}/knowledge_social_registry.py"
 VAULT_RUNTIME_CHECK="${SCRIPT_DIR}/vault-runtime-check.py"
 VAULT_RUNTIME_PYTHON="${HOME:+$HOME/.aidevops/.agent-workspace/python-env/vault/bin/python3}"
 
@@ -165,6 +166,9 @@ Usage:
     [--lease-seconds SECONDS] [--now-epoch EPOCH]
   knowledge-social-helper.sh receipts [--base PATH] [--alias ALIAS] \
     [--connection-id ID] [--limit 1-1000]
+  knowledge-social-helper.sh providers
+  knowledge-social-helper.sh provider-resolve --provider PROVIDER
+  knowledge-social-helper.sh provider-run --provider PROVIDER --mode MODE -- [ARGS]
 EOF
 	return 0
 }
@@ -232,6 +236,12 @@ Browser gap capture:
   Capture files are read-only artifacts from an approved profile; this helper
   cannot launch a browser or perform a platform write. Item and byte limits are
   hard bounds, and replay is content-addressed and idempotent.
+
+Provider registry:
+  providers and provider-resolve expose deterministic privacy-safe capability
+  metadata. provider-run resolves only an exact canonical ID or declared alias,
+  requires an explicit supported mode, and executes one allowlisted local
+  read/import adapter without eval or fallback. A no-route provider always fails.
 
 Encrypted workspace sharing:
   Public identity and grant files contain only opaque IDs, public keys, and signed
@@ -324,6 +334,35 @@ run_provider_sync() {
 	return 0
 }
 
+run_registry_command() {
+	local subcommand="$1"
+	shift || return 1
+	require_runtime || return 1
+	if [[ ! -r "$REGISTRY_HELPER" ]]; then
+		printf 'ERROR: social provider registry missing: %s\n' "$REGISTRY_HELPER" >&2
+		return 1
+	fi
+	case "$subcommand" in
+	providers) python3 "$REGISTRY_HELPER" list "$@" || return 1 ;;
+	provider-resolve) python3 "$REGISTRY_HELPER" resolve "$@" || return 1 ;;
+	provider-run) python3 "$REGISTRY_HELPER" run "$@" || return 1 ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
+run_query_command() {
+	local subcommand="$1"
+	shift || return 1
+	require_runtime || return 1
+	if [[ ! -r "$QUERY_HELPER" ]]; then
+		printf 'ERROR: social query implementation missing: %s\n' "$QUERY_HELPER" >&2
+		return 1
+	fi
+	python3 "$QUERY_HELPER" "$subcommand" "$@" || return 1
+	return 0
+}
+
 main() {
 	local subcommand="${1:-help}"
 	if [[ $# -gt 0 ]]; then
@@ -379,12 +418,7 @@ main() {
 		run_provider_sync NodeBB "$NODEBB_HELPER" "$@" || return 1
 		;;
 	query | annotate)
-		require_runtime || return 1
-		if [[ ! -r "$QUERY_HELPER" ]]; then
-			printf 'ERROR: social query implementation missing: %s\n' "$QUERY_HELPER" >&2
-			return 1
-		fi
-		python3 "$QUERY_HELPER" "$subcommand" "$@" || return 1
+		run_query_command "$subcommand" "$@" || return 1
 		;;
 	provider-validate | capture-browser-gap)
 		require_runtime || return 1
@@ -393,6 +427,9 @@ main() {
 			return 1
 		fi
 		python3 "$BROWSER_HELPER" "$subcommand" "$@" || return 1
+		;;
+	providers | provider-resolve | provider-run)
+		run_registry_command "$subcommand" "$@" || return 1
 		;;
 	sync-due | reconcile-due | reconcile | receipts)
 		require_runtime || return 1

--- a/.agents/scripts/knowledge_social_registry.py
+++ b/.agents/scripts/knowledge_social_registry.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Resolve and execute deterministic read-only social provider adapters."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+class ProviderRegistryError(ValueError):
+    """Raised when provider registration or routing is ambiguous."""
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    """One immutable provider identity and its supported ingestion modes."""
+
+    provider: str
+    aliases: tuple[str, ...]
+    entrypoint: str | None
+    modes: tuple[tuple[str, tuple[str, ...]], ...]
+
+
+PROVIDER_SPECS = (
+    ProviderSpec(
+        "bluesky",
+        ("at-protocol", "atproto"),
+        "knowledge_social_bluesky.py",
+        (("live", ()),),
+    ),
+    ProviderSpec("binance-square", (), None, (("no-route", ()),)),
+    ProviderSpec("discord", (), "knowledge_social_discord.py", (("live", ()),)),
+    ProviderSpec(
+        "forem",
+        ("dev-community", "dev.to"),
+        "knowledge_social_forem.py",
+        (("live", ()),),
+    ),
+    ProviderSpec(
+        "google-business-profile",
+        ("gbp",),
+        "knowledge_social_google_business_profile.py",
+        (("live", ()),),
+    ),
+    ProviderSpec("gumroad", (), "knowledge_social_gumroad.py", (("live", ()),)),
+    ProviderSpec(
+        "nextcloud-talk",
+        (),
+        "knowledge_social_nextcloud_talk.py",
+        (("live", ()),),
+    ),
+    ProviderSpec(
+        "signal",
+        (),
+        "knowledge_social_signal.py",
+        (
+            ("status", ("status",)),
+            ("inspect", ("inspect",)),
+            ("manual-import", ("import-events",)),
+        ),
+    ),
+    ProviderSpec(
+        "slack",
+        (),
+        "knowledge_social_slack.py",
+        (("live", ("api",)), ("archive", ("archive",))),
+    ),
+    ProviderSpec(
+        "telegram",
+        (),
+        "knowledge_social_telegram.py",
+        (
+            ("archive", ("import-export",)),
+            ("event", ("import-updates",)),
+            ("status", ("status",)),
+        ),
+    ),
+    ProviderSpec(
+        "whatsapp",
+        ("whats-app",),
+        "knowledge_social_whatsapp.py",
+        (("archive", ("export",)), ("event", ("webhook",))),
+    ),
+)
+
+
+def normalize_name(value: str) -> str:
+    """Return one conservative provider/alias lookup key."""
+    normalized = re.sub(r"[\s_]+", "-", value.strip().lower())
+    if not normalized or not re.fullmatch(r"[a-z0-9][a-z0-9.-]{0,63}", normalized):
+        raise ProviderRegistryError("provider identity is invalid")
+    return normalized
+
+
+def register_specs(
+    specs: Iterable[ProviderSpec],
+) -> tuple[dict[str, ProviderSpec], dict[str, str]]:
+    """Build an order-independent registry and reject every collision."""
+    providers: dict[str, ProviderSpec] = {}
+    aliases: dict[str, str] = {}
+    for spec in sorted(specs, key=lambda item: normalize_name(item.provider)):
+        provider = normalize_name(spec.provider)
+        if provider in providers or provider in aliases:
+            raise ProviderRegistryError(f"duplicate provider identity: {provider}")
+        modes = [normalize_name(mode) for mode, _prefix in spec.modes]
+        if not modes or len(modes) != len(set(modes)):
+            raise ProviderRegistryError(f"duplicate or absent modes for provider: {provider}")
+        providers[provider] = spec
+        for raw_alias in spec.aliases:
+            alias = normalize_name(raw_alias)
+            if alias in providers or alias in aliases:
+                raise ProviderRegistryError(f"duplicate provider alias: {alias}")
+            aliases[alias] = provider
+    return providers, aliases
+
+
+PROVIDERS, ALIASES = register_specs(PROVIDER_SPECS)
+
+
+def resolve_provider(value: str) -> ProviderSpec:
+    """Resolve one canonical ID or explicit alias without fallback."""
+    key = normalize_name(value)
+    provider = ALIASES.get(key, key)
+    try:
+        return PROVIDERS[provider]
+    except KeyError as error:
+        raise ProviderRegistryError(f"unknown social provider: {key}") from error
+
+
+def resolve_mode(spec: ProviderSpec, value: str) -> tuple[str, ...]:
+    """Resolve one exact supported mode without provider-name branching."""
+    mode = normalize_name(value)
+    modes = {normalize_name(name): prefix for name, prefix in spec.modes}
+    try:
+        return modes[mode]
+    except KeyError as error:
+        raise ProviderRegistryError(
+            f"unsupported mode for {spec.provider}: {mode}"
+        ) from error
+
+
+def describe(spec: ProviderSpec) -> dict[str, object]:
+    """Return privacy-safe immutable registration metadata."""
+    return {
+        "aliases": sorted(spec.aliases),
+        "available": spec.entrypoint is not None,
+        "modes": sorted(mode for mode, _prefix in spec.modes),
+        "provider": spec.provider,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    commands.add_parser("list")
+    resolve = commands.add_parser("resolve")
+    resolve.add_argument("--provider", required=True)
+    run = commands.add_parser("run")
+    run.add_argument("--provider", required=True)
+    run.add_argument("--mode", required=True)
+    run.add_argument("arguments", nargs=argparse.REMAINDER)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.command == "list":
+            result: object = [describe(PROVIDERS[key]) for key in sorted(PROVIDERS)]
+        else:
+            spec = resolve_provider(args.provider)
+            if args.command == "resolve":
+                result = describe(spec)
+            else:
+                prefix = resolve_mode(spec, args.mode)
+                if spec.entrypoint is None:
+                    raise ProviderRegistryError(
+                        f"provider has no safe ingestion route: {spec.provider}"
+                    )
+                entrypoint = Path(__file__).with_name(spec.entrypoint)
+                if not entrypoint.is_file() or entrypoint.is_symlink():
+                    raise ProviderRegistryError(
+                        f"registered provider entrypoint is unavailable: {spec.provider}"
+                    )
+                forwarded = (
+                    args.arguments[1:]
+                    if args.arguments[:1] == ["--"]
+                    else args.arguments
+                )
+                os.execv(
+                    sys.executable,
+                    [sys.executable, str(entrypoint), *prefix, *forwarded],
+                )
+                raise AssertionError("provider execution unexpectedly returned")
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    except (OSError, ProviderRegistryError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/tests/test-knowledge-social-registry.sh
+++ b/.agents/tests/test-knowledge-social-registry.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-registry.sh — Deterministic provider registration tests
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${SCRIPT_DIR}/../scripts"
+HELPER="${SCRIPTS_DIR}/knowledge-social-helper.sh"
+REGISTRY="${SCRIPTS_DIR}/knowledge_social_registry.py"
+PASS=0
+FAIL=0
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' "$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+printf 'Social provider registry tests\n'
+
+registry_summary=$(
+	python3 - "$REGISTRY" <<'PY'
+import importlib.util
+import sys
+
+spec = importlib.util.spec_from_file_location("social_registry", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+expected = {
+    "bluesky": ("live",),
+    "binance-square": ("no-route",),
+    "discord": ("live",),
+    "forem": ("live",),
+    "google-business-profile": ("live",),
+    "gumroad": ("live",),
+    "nextcloud-talk": ("live",),
+    "signal": ("inspect", "manual-import", "status"),
+    "slack": ("archive", "live"),
+    "telegram": ("archive", "event", "status"),
+    "whatsapp": ("archive", "event"),
+}
+actual = {
+    provider: tuple(sorted(mode for mode, _prefix in item.modes))
+    for provider, item in module.PROVIDERS.items()
+}
+if actual != expected:
+    raise SystemExit(f"unexpected registry: {actual}")
+
+forward = module.register_specs(module.PROVIDER_SPECS)
+reverse = module.register_specs(reversed(module.PROVIDER_SPECS))
+if tuple(forward[0]) != tuple(reverse[0]) or forward[1] != reverse[1]:
+    raise SystemExit("registration depends on input order")
+
+for alias, provider in {
+    "atproto": "bluesky",
+    "dev-community": "forem",
+    "dev.to": "forem",
+    "gbp": "google-business-profile",
+    "whats-app": "whatsapp",
+}.items():
+    if module.resolve_provider(alias).provider != provider:
+        raise SystemExit(f"alias {alias} did not resolve to {provider}")
+
+collision = module.ProviderSpec(
+    "other-provider", ("dev-community",), "unused.py", (("live", ()),)
+)
+try:
+    module.register_specs((*module.PROVIDER_SPECS, collision))
+except module.ProviderRegistryError:
+    pass
+else:
+    raise SystemExit("duplicate alias was accepted")
+
+try:
+    module.resolve_provider("unknown-provider")
+except module.ProviderRegistryError:
+    pass
+else:
+    raise SystemExit("unknown provider used a fallback")
+
+print("11:order-independent:aliases-exact:collisions-rejected:no-fallback")
+PY
+)
+assert_eq "all merged provider outcomes register deterministically" \
+	"$registry_summary" "11:order-independent:aliases-exact:collisions-rejected:no-fallback"
+
+provider_count=$("$HELPER" providers | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
+assert_eq "helper exposes the complete provider registry" "$provider_count" "11"
+
+forem_resolution=$("$HELPER" provider-resolve --provider dev-community |
+	python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["provider"] + ":" + ",".join(data["modes"]))')
+assert_eq "DEV Community resolves only to the Forem family" "$forem_resolution" "forem:live"
+
+if "$HELPER" provider-run --provider binance-square --mode no-route >/dev/null 2>&1; then
+	assert_eq "no-route outcomes cannot execute" accepted rejected
+else
+	assert_eq "no-route outcomes cannot execute" rejected rejected
+fi
+
+if "$HELPER" provider-run --provider unknown-provider --mode live >/dev/null 2>&1; then
+	assert_eq "unknown providers cannot fall back" accepted rejected
+else
+	assert_eq "unknown providers cannot fall back" rejected rejected
+fi
+
+if "$HELPER" provider-run --provider slack --mode unsupported >/dev/null 2>&1; then
+	assert_eq "unsupported provider modes fail closed" accepted rejected
+else
+	assert_eq "unsupported provider modes fail closed" rejected rejected
+fi
+
+forem_help=$("$HELPER" provider-run --provider dev.to --mode live -- --help 2>&1)
+if [[ "$forem_help" == *"Collect one bounded, read-only Forem account stream"* ]]; then
+	assert_eq "allowlisted aliases execute only their canonical local adapter" canonical canonical
+else
+	assert_eq "allowlisted aliases execute only their canonical local adapter" unexpected canonical
+fi
+
+if rg -n 'operations|outbound|publish|send|trade|wallet|payment|listing.*write' "$REGISTRY" >/dev/null; then
+	assert_eq "registry has no outbound mutation target" reachable unreachable
+else
+	assert_eq "registry has no outbound mutation target" unreachable unreachable
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Add a deterministic provider registry for eleven merged provider outcomes, exact alias and mode routing, no-route failure, helper commands, capability documentation, and aggregate regression coverage.

## Files Changed

.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md, .agents/scripts/knowledge-social-helper.sh, .agents/scripts/knowledge_social_registry.py, .agents/tests/test-knowledge-social-registry.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified with registry, social store/sync, all eleven provider-focused suites, ShellCheck, py_compile, and linters-local --changed.

Resolves #28867


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.215 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 11m and 209,601 tokens on this with the user in an interactive session.