### PR TITLE
GH#29217: Allow trusted cross-repository linked-worktree writes under ~/Git

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
@@ -170,6 +170,62 @@ test("blocks every canonical direct write and preserves linked-worktree writes",
   }
 });
 
+test("allows cross-repository linked writes only inside the trusted Git workspace", () => {
+  const { root, repo, linked } = setupRepo();
+  const outsideRoot = mkdtempSync(`${root}-sibling-`);
+  const previousWorkspace = process.env.AIDEVOPS_GIT_WORKSPACE_ROOT;
+  const foreignRepo = join(root, "foreign-repo");
+  const foreignLinked = join(root, "foreign-linked");
+  const outsideRepo = join(outsideRoot, "outside-repo");
+  const outsideLinked = join(outsideRoot, "outside-linked");
+
+  function createLinkedRepo(repoPath, linkedPath, branch) {
+    mkdirSync(repoPath);
+    execFileSync(realGit, ["init", "-q", "-b", "main"], { cwd: repoPath });
+    execFileSync(realGit, ["config", "user.name", "Test"], { cwd: repoPath });
+    execFileSync(realGit, ["config", "user.email", "test@example.invalid"], { cwd: repoPath });
+    execFileSync(realGit, ["config", "commit.gpgsign", "false"], { cwd: repoPath });
+    writeFileSync(join(repoPath, "README.md"), `${branch}\n`);
+    execFileSync(realGit, ["add", "README.md"], { cwd: repoPath });
+    execFileSync(realGit, ["commit", "-q", "-m", `${branch} seed`], { cwd: repoPath });
+    execFileSync(realGit, ["worktree", "add", "-q", "-b", `feature/${branch}`, linkedPath], { cwd: repoPath });
+  }
+
+  try {
+    createLinkedRepo(foreignRepo, foreignLinked, "foreign");
+    createLinkedRepo(outsideRepo, outsideLinked, "outside");
+    process.env.AIDEVOPS_GIT_WORKSPACE_ROOT = root;
+
+    assert.doesNotThrow(
+      () => checkCanonicalWriteSafetyGate(join(foreignLinked, "README.md"), scriptsDir, linked),
+      "linked worktrees from sibling repositories inside the trusted workspace should be writable",
+    );
+    assert.doesNotThrow(
+      () => checkCanonicalWriteSafetyGate(join(foreignLinked, "README.md"), scriptsDir, repo),
+      "canonical context must not block a structurally safe foreign linked-worktree target",
+    );
+    assert.throws(
+      () => checkCanonicalWriteSafetyGate(join(outsideLinked, "README.md"), scriptsDir, linked),
+      /limited to the trusted Git workspace/,
+    );
+
+    const escapedAlias = join(root, "outside-alias");
+    symlinkSync(outsideLinked, escapedAlias, "dir");
+    assert.throws(
+      () => checkCanonicalWriteSafetyGate(join(escapedAlias, "README.md"), scriptsDir, linked),
+      /limited to the trusted Git workspace/,
+    );
+  } finally {
+    if (previousWorkspace === undefined) {
+      delete process.env.AIDEVOPS_GIT_WORKSPACE_ROOT;
+    } else {
+      process.env.AIDEVOPS_GIT_WORKSPACE_ROOT = previousWorkspace;
+    }
+    rmSync(root, { recursive: true, force: true });
+    rmSync(outsideRoot, { recursive: true, force: true });
+  }
+});
+
 test("blocks canonical branch mutation before execution", () => {
   const { root, repo } = setupRepo();
   try {

--- a/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
@@ -13,7 +13,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 import {
@@ -178,6 +178,7 @@ test("allows cross-repository linked writes only inside the trusted Git workspac
   const foreignLinked = join(root, "foreign-linked");
   const outsideRepo = join(outsideRoot, "outside-repo");
   const outsideLinked = join(outsideRoot, "outside-linked");
+  const escapedOutsideFile = `${outsideRoot}-escaped.txt`;
 
   function createLinkedRepo(repoPath, linkedPath, branch) {
     mkdirSync(repoPath);
@@ -219,9 +220,20 @@ test("allows cross-repository linked writes only inside the trusted Git workspac
     const outsideFile = join(outsideRoot, "outside.txt");
     const outsideFileAlias = join(linked, "outside-files");
     writeFileSync(outsideFile, "outside\n");
+    writeFileSync(escapedOutsideFile, "escaped\n");
     symlinkSync(outsideRoot, outsideFileAlias, "dir");
     assert.throws(
       () => checkCanonicalWriteSafetyGate(join(outsideFileAlias, "outside.txt"), scriptsDir, linked),
+      /symlinked write target escapes/,
+    );
+    const traversedExisting = `${outsideFileAlias}${sep}..${sep}${basename(escapedOutsideFile)}`;
+    assert.throws(
+      () => checkCanonicalWriteSafetyGate(traversedExisting, scriptsDir, linked),
+      /symlinked write target escapes/,
+    );
+    const traversedMissing = `${outsideFileAlias}${sep}..${sep}${basename(outsideRoot)}-missing.txt`;
+    assert.throws(
+      () => checkCanonicalWriteSafetyGate(traversedMissing, scriptsDir, linked),
       /symlinked write target escapes/,
     );
     assert.doesNotThrow(
@@ -236,6 +248,7 @@ test("allows cross-repository linked writes only inside the trusted Git workspac
     }
     rmSync(root, { recursive: true, force: true });
     rmSync(outsideRoot, { recursive: true, force: true });
+    rmSync(escapedOutsideFile, { force: true });
   }
 });
 

--- a/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
@@ -215,6 +215,19 @@ test("allows cross-repository linked writes only inside the trusted Git workspac
       () => checkCanonicalWriteSafetyGate(join(escapedAlias, "README.md"), scriptsDir, linked),
       /limited to the trusted Git workspace/,
     );
+
+    const outsideFile = join(outsideRoot, "outside.txt");
+    const outsideFileAlias = join(linked, "outside-files");
+    writeFileSync(outsideFile, "outside\n");
+    symlinkSync(outsideRoot, outsideFileAlias, "dir");
+    assert.throws(
+      () => checkCanonicalWriteSafetyGate(join(outsideFileAlias, "outside.txt"), scriptsDir, linked),
+      /symlinked write target escapes/,
+    );
+    assert.doesNotThrow(
+      () => checkCanonicalWriteSafetyGate(outsideFile, scriptsDir, linked),
+      "an explicit sanctioned outside-Git path should retain its existing allowance",
+    );
   } finally {
     if (previousWorkspace === undefined) {
       delete process.env.AIDEVOPS_GIT_WORKSPACE_ROOT;

--- a/.agents/reference/repo-organization.md
+++ b/.agents/reference/repo-organization.md
@@ -43,6 +43,8 @@ resolve beneath `${AIDEVOPS_GIT_WORKSPACE_ROOT:-~/Git}` and the target is a link
 worktree. Canonical checkouts remain read-only regardless of their location.
 Resolved worktree, Git directory, and common-directory paths must all remain
 inside the workspace, so sibling-prefix paths and symlink escapes are denied.
+Sanctioned outside-Git paths remain separate: a symlink traversed from inside a
+Git worktree cannot use that allowance to escape the trusted workspace.
 
 ## Related
 

--- a/.agents/reference/repo-organization.md
+++ b/.agents/reference/repo-organization.md
@@ -36,6 +36,14 @@ Examples:
 
 If a clone was accidentally created at `~/Git/{repo}` but belongs to a grouped ecosystem, move or recreate it under the grouped parent before adding new worktrees. Do not overwrite an existing grouped clone; fetch the required remotes/branches into the grouped canonical repo and recreate clean linked worktrees there.
 
+## Direct-write workspace boundary
+
+Direct file-mutation tools may write across repositories when both identities
+resolve beneath `${AIDEVOPS_GIT_WORKSPACE_ROOT:-~/Git}` and the target is a linked
+worktree. Canonical checkouts remain read-only regardless of their location.
+Resolved worktree, Git directory, and common-directory paths must all remain
+inside the workspace, so sibling-prefix paths and symlink escapes are denied.
+
 ## Related
 
 - `workflows/worktree.md` — worktree mechanics

--- a/.agents/scripts/canonical-write-policy-helper.py
+++ b/.agents/scripts/canonical-write-policy-helper.py
@@ -17,189 +17,24 @@ import json
 import os
 import re
 import sys
-from dataclasses import asdict, dataclass
-from pathlib import Path
+from dataclasses import asdict
 from typing import Any
 
 from canonical_branch_policy import resolve_branch
-from canonical_git_policy import _git_output as _shared_git_output
-from canonical_git_policy import real_git
+from canonical_write_policy_paths import (
+    Classification,
+    canonical_git_workspace_root as _canonical_git_workspace_root,
+    classify_location,
+    git_output as _git_output,
+    git_symlink_origin as _git_symlink_origin,
+    git_workspace_root_from_environment,
+    is_within_workspace as _is_within_workspace,
+    repository_within_workspace as _repository_within_workspace,
+    target_probe as _target_probe,
+)
 
 
 POLICY_VERSION = "canonical-write-policy-v2"
-GIT_WORKSPACE_ROOT_ENV = "AIDEVOPS_GIT_WORKSPACE_ROOT"
-
-
-@dataclass
-class Classification:
-    """One repository-location classification."""
-
-    classification: str
-    inside_git: bool
-    repo_root: str = ""
-    git_dir: str = ""
-    common_dir: str = ""
-    branch: str = ""
-    reason: str = ""
-
-
-def _real_git() -> str:
-    explicit = os.environ.get("AIDEVOPS_REAL_GIT_BIN", "") or os.environ.get(
-        "AIDEVOPS_REAL_GIT", ""
-    )
-    if not explicit and os.path.isfile("/usr/bin/git"):
-        explicit = "/usr/bin/git"
-    return real_git(explicit)
-
-
-def _git_output(cwd: Path, *args: str) -> str:
-    try:
-        return _shared_git_output(_real_git(), str(cwd), *args)
-    except RuntimeError as exc:
-        raise RuntimeError(f"Git repository probe failed: {exc}") from exc
-
-
-def _existing_probe_path(raw_path: str) -> Path:
-    path = Path(raw_path).expanduser().resolve(strict=False)
-    if path.is_file() or path.is_symlink():
-        path = path.parent
-    while not path.exists() and path != path.parent:
-        path = path.parent
-    return path
-
-
-def _repository_probes(probe_path: Path) -> dict[str, str]:
-    return {
-        "repo_root": _git_output(probe_path, "rev-parse", "--show-toplevel"),
-        "git_dir": _git_output(probe_path, "rev-parse", "--git-dir"),
-        "common_dir": _git_output(probe_path, "rev-parse", "--git-common-dir"),
-        "branch": _git_output(probe_path, "branch", "--show-current"),
-    }
-
-
-def _absolute_probe_value(probe_path: Path, raw_value: str) -> str:
-    path = Path(raw_value)
-    if not path.is_absolute():
-        path = probe_path / path
-    return os.path.realpath(path)
-
-
-def classify_location(raw_path: str) -> Classification:
-    """Classify a path as canonical, linked, outside Git, or unknown."""
-    probe_path = _existing_probe_path(raw_path)
-    try:
-        inside = _git_output(probe_path, "rev-parse", "--is-inside-work-tree")
-    except RuntimeError as exc:
-        return Classification("unknown", False, reason=str(exc))
-    if inside != "true":
-        return Classification(
-            "outside", False, reason="path is outside a Git worktree"
-        )
-
-    try:
-        values = _repository_probes(probe_path)
-    except RuntimeError as exc:
-        return Classification("unknown", True, reason=str(exc))
-
-    required = ("repo_root", "git_dir", "common_dir")
-    if any(not values[name] for name in required):
-        return Classification(
-            "unknown",
-            True,
-            reason="required Git worktree identity could not be resolved",
-        )
-
-    repo_root = _absolute_probe_value(probe_path, values["repo_root"])
-    git_dir = _absolute_probe_value(probe_path, values["git_dir"])
-    common_dir = _absolute_probe_value(probe_path, values["common_dir"])
-    classification = "canonical" if git_dir == common_dir else "linked"
-    return Classification(
-        classification,
-        True,
-        repo_root=repo_root,
-        git_dir=git_dir,
-        common_dir=common_dir,
-        branch=values["branch"],
-        reason=(
-            "Git directory equals common directory"
-            if classification == "canonical"
-            else "Git directory is isolated beneath the common directory"
-        ),
-    )
-
-
-def _target_probe(cwd: str, file_path: str) -> str:
-    if not file_path:
-        return cwd
-    target = Path(file_path).expanduser()
-    if not target.is_absolute():
-        target = Path(cwd) / target
-    return str(target.resolve(strict=False))
-
-
-def _git_symlink_origin(cwd: str, file_path: str) -> Classification | None:
-    """Return the Git location containing a traversed symlink, if any."""
-    target = Path(file_path).expanduser()
-    if not target.is_absolute():
-        base = Path(cwd).expanduser()
-        if not base.is_absolute():
-            base = Path.cwd() / base
-        target = base / target
-    current = Path(target.anchor)
-    for part in target.parts[1:]:
-        if part in ("", "."):
-            continue
-        if part == "..":
-            current = current.parent
-            continue
-        candidate = current / part
-        if candidate.is_symlink():
-            origin = classify_location(str(current))
-            if origin.inside_git:
-                return origin
-            current = Path(os.path.realpath(candidate))
-            continue
-        current = candidate
-    return None
-
-
-def git_workspace_root_from_environment() -> str:
-    """Return the trusted Git workspace root, defaulting to ~/Git."""
-    if GIT_WORKSPACE_ROOT_ENV in os.environ:
-        return os.environ[GIT_WORKSPACE_ROOT_ENV]
-    return str(Path.home() / "Git")
-
-
-def _canonical_git_workspace_root(workspace_root: str) -> str:
-    if not workspace_root:
-        return ""
-    root = os.path.realpath(os.path.expanduser(workspace_root))
-    home = os.path.realpath(str(Path.home()))
-    if root in {os.path.abspath(os.sep), home} or not os.path.isdir(root):
-        return ""
-    return root
-
-
-def _is_within_workspace(path: str, workspace_root: str) -> bool:
-    if not path or not workspace_root:
-        return False
-    try:
-        return (
-            os.path.commonpath([os.path.realpath(path), workspace_root])
-            == workspace_root
-        )
-    except ValueError:
-        return False
-
-
-def _repository_within_workspace(
-    location: Classification, workspace_root: str
-) -> bool:
-    """Require the worktree and its shared Git metadata beneath one root."""
-    return location.inside_git and all(
-        _is_within_workspace(path, workspace_root)
-        for path in (location.repo_root, location.git_dir, location.common_dir)
-    )
 
 
 def _write_action(

--- a/.agents/scripts/canonical-write-policy-helper.py
+++ b/.agents/scripts/canonical-write-policy-helper.py
@@ -141,15 +141,24 @@ def _git_symlink_origin(cwd: str, file_path: str) -> Classification | None:
     """Return the Git location containing a traversed symlink, if any."""
     target = Path(file_path).expanduser()
     if not target.is_absolute():
-        target = Path(cwd) / target
-    target = Path(os.path.abspath(target))
+        base = Path(cwd).expanduser()
+        if not base.is_absolute():
+            base = Path.cwd() / base
+        target = base / target
     current = Path(target.anchor)
     for part in target.parts[1:]:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            current = current.parent
+            continue
         candidate = current / part
         if candidate.is_symlink():
             origin = classify_location(str(current))
             if origin.inside_git:
                 return origin
+            current = Path(os.path.realpath(candidate))
+            continue
         current = candidate
     return None
 

--- a/.agents/scripts/canonical-write-policy-helper.py
+++ b/.agents/scripts/canonical-write-policy-helper.py
@@ -26,7 +26,8 @@ from canonical_git_policy import _git_output as _shared_git_output
 from canonical_git_policy import real_git
 
 
-POLICY_VERSION = "canonical-write-policy-v1"
+POLICY_VERSION = "canonical-write-policy-v2"
+GIT_WORKSPACE_ROOT_ENV = "AIDEVOPS_GIT_WORKSPACE_ROOT"
 
 
 @dataclass
@@ -136,6 +137,45 @@ def _target_probe(cwd: str, file_path: str) -> str:
     return str(target.resolve(strict=False))
 
 
+def git_workspace_root_from_environment() -> str:
+    """Return the trusted Git workspace root, defaulting to ~/Git."""
+    if GIT_WORKSPACE_ROOT_ENV in os.environ:
+        return os.environ[GIT_WORKSPACE_ROOT_ENV]
+    return str(Path.home() / "Git")
+
+
+def _canonical_git_workspace_root(workspace_root: str) -> str:
+    if not workspace_root:
+        return ""
+    root = os.path.realpath(os.path.expanduser(workspace_root))
+    home = os.path.realpath(str(Path.home()))
+    if root in {os.path.abspath(os.sep), home} or not os.path.isdir(root):
+        return ""
+    return root
+
+
+def _is_within_workspace(path: str, workspace_root: str) -> bool:
+    if not path or not workspace_root:
+        return False
+    try:
+        return (
+            os.path.commonpath([os.path.realpath(path), workspace_root])
+            == workspace_root
+        )
+    except ValueError:
+        return False
+
+
+def _repository_within_workspace(
+    location: Classification, workspace_root: str
+) -> bool:
+    """Require the worktree and its shared Git metadata beneath one root."""
+    return location.inside_git and all(
+        _is_within_workspace(path, workspace_root)
+        for path in (location.repo_root, location.git_dir, location.common_dir)
+    )
+
+
 def check_write(cwd: str, file_path: str) -> dict[str, Any]:
     """Return one fail-closed direct-file-write decision."""
     context = classify_location(cwd)
@@ -143,6 +183,12 @@ def check_write(cwd: str, file_path: str) -> dict[str, Any]:
         target = Classification("unknown", False, reason="write target is empty")
     else:
         target = classify_location(_target_probe(cwd, file_path))
+    workspace_root = _canonical_git_workspace_root(
+        git_workspace_root_from_environment()
+    )
+    cross_repository_target = target.classification == "linked" and (
+        not context.inside_git or target.common_dir != context.common_dir
+    )
 
     if target.classification == "unknown":
         decision = "deny"
@@ -150,27 +196,39 @@ def check_write(cwd: str, file_path: str) -> dict[str, Any]:
     elif target.classification == "canonical":
         decision = "deny"
         reason = "canonical checkouts are read-only session mirrors"
-    elif (
-        target.classification == "linked"
-        and context.inside_git
-        and target.common_dir != context.common_dir
+    elif cross_repository_target and not (
+        _repository_within_workspace(context, workspace_root)
+        and _repository_within_workspace(target, workspace_root)
     ):
         decision = "deny"
-        reason = "linked worktree target belongs to a different repository"
+        reason = (
+            "cross-repository linked worktree access is limited to the "
+            "trusted Git workspace"
+        )
     else:
         decision = "allow"
         reason = (
-            "write target resolves inside an allowed linked worktree"
-            if target.classification == "linked"
-            else "write target is outside canonical worktrees"
+            "cross-repository write target resolves inside a linked worktree "
+            "within the trusted Git workspace"
+            if cross_repository_target
+            else (
+                "write target resolves inside an allowed linked worktree"
+                if target.classification == "linked"
+                else "write target is outside canonical worktrees"
+            )
         )
 
     return {
         "policy": POLICY_VERSION,
+        "git_workspace_root": workspace_root,
         "decision": decision,
         "reason": reason,
         "action": (
-            "create_or_use_linked_worktree" if decision == "deny" else "none"
+            "use_linked_worktree_under_git_workspace"
+            if decision == "deny" and cross_repository_target
+            else (
+                "create_or_use_linked_worktree" if decision == "deny" else "none"
+            )
         ),
         "context": asdict(context),
         "target": asdict(target),

--- a/.agents/scripts/canonical-write-policy-helper.py
+++ b/.agents/scripts/canonical-write-policy-helper.py
@@ -137,6 +137,23 @@ def _target_probe(cwd: str, file_path: str) -> str:
     return str(target.resolve(strict=False))
 
 
+def _git_symlink_origin(cwd: str, file_path: str) -> Classification | None:
+    """Return the Git location containing a traversed symlink, if any."""
+    target = Path(file_path).expanduser()
+    if not target.is_absolute():
+        target = Path(cwd) / target
+    target = Path(os.path.abspath(target))
+    current = Path(target.anchor)
+    for part in target.parts[1:]:
+        candidate = current / part
+        if candidate.is_symlink():
+            origin = classify_location(str(current))
+            if origin.inside_git:
+                return origin
+        current = candidate
+    return None
+
+
 def git_workspace_root_from_environment() -> str:
     """Return the trusted Git workspace root, defaulting to ~/Git."""
     if GIT_WORKSPACE_ROOT_ENV in os.environ:
@@ -176,18 +193,41 @@ def _repository_within_workspace(
     )
 
 
+def _write_action(
+    decision: str,
+    cross_repository_target: bool,
+    symlink_workspace_escape: bool,
+) -> str:
+    if decision != "deny":
+        return "none"
+    if symlink_workspace_escape:
+        return "use_direct_sanctioned_outside_path"
+    if cross_repository_target:
+        return "use_linked_worktree_under_git_workspace"
+    return "create_or_use_linked_worktree"
+
+
 def check_write(cwd: str, file_path: str) -> dict[str, Any]:
     """Return one fail-closed direct-file-write decision."""
     context = classify_location(cwd)
     if not file_path:
         target = Classification("unknown", False, reason="write target is empty")
+        target_probe = cwd
+        symlink_origin = None
     else:
-        target = classify_location(_target_probe(cwd, file_path))
+        target_probe = _target_probe(cwd, file_path)
+        target = classify_location(target_probe)
+        symlink_origin = _git_symlink_origin(cwd, file_path)
     workspace_root = _canonical_git_workspace_root(
         git_workspace_root_from_environment()
     )
     cross_repository_target = target.classification == "linked" and (
         not context.inside_git or target.common_dir != context.common_dir
+    )
+    symlink_workspace_escape = (
+        symlink_origin is not None
+        and target.classification == "outside"
+        and not _is_within_workspace(target_probe, workspace_root)
     )
 
     if target.classification == "unknown":
@@ -196,6 +236,12 @@ def check_write(cwd: str, file_path: str) -> dict[str, Any]:
     elif target.classification == "canonical":
         decision = "deny"
         reason = "canonical checkouts are read-only session mirrors"
+    elif symlink_workspace_escape:
+        decision = "deny"
+        reason = (
+            "symlinked write target escapes from a Git worktree outside the "
+            "trusted Git workspace"
+        )
     elif cross_repository_target and not (
         _repository_within_workspace(context, workspace_root)
         and _repository_within_workspace(target, workspace_root)
@@ -223,12 +269,8 @@ def check_write(cwd: str, file_path: str) -> dict[str, Any]:
         "git_workspace_root": workspace_root,
         "decision": decision,
         "reason": reason,
-        "action": (
-            "use_linked_worktree_under_git_workspace"
-            if decision == "deny" and cross_repository_target
-            else (
-                "create_or_use_linked_worktree" if decision == "deny" else "none"
-            )
+        "action": _write_action(
+            decision, cross_repository_target, symlink_workspace_escape
         ),
         "context": asdict(context),
         "target": asdict(target),

--- a/.agents/scripts/canonical_write_policy_paths.py
+++ b/.agents/scripts/canonical_write_policy_paths.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Git identity and path probes for the canonical write policy."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from canonical_git_policy import _git_output as _shared_git_output
+from canonical_git_policy import real_git
+
+
+GIT_WORKSPACE_ROOT_ENV = "AIDEVOPS_GIT_WORKSPACE_ROOT"
+
+
+@dataclass
+class Classification:
+    """One repository-location classification."""
+
+    classification: str
+    inside_git: bool
+    repo_root: str = ""
+    git_dir: str = ""
+    common_dir: str = ""
+    branch: str = ""
+    reason: str = ""
+
+
+def _real_git() -> str:
+    explicit = os.environ.get("AIDEVOPS_REAL_GIT_BIN", "") or os.environ.get(
+        "AIDEVOPS_REAL_GIT", ""
+    )
+    if not explicit and os.path.isfile("/usr/bin/git"):
+        explicit = "/usr/bin/git"
+    return real_git(explicit)
+
+
+def git_output(cwd: Path, *args: str) -> str:
+    try:
+        return _shared_git_output(_real_git(), str(cwd), *args)
+    except RuntimeError as exc:
+        raise RuntimeError(f"Git repository probe failed: {exc}") from exc
+
+
+def _existing_probe_path(raw_path: str) -> Path:
+    path = Path(raw_path).expanduser().resolve(strict=False)
+    if path.is_file() or path.is_symlink():
+        path = path.parent
+    while not path.exists() and path != path.parent:
+        path = path.parent
+    return path
+
+
+def _repository_probes(probe_path: Path) -> dict[str, str]:
+    return {
+        "repo_root": git_output(probe_path, "rev-parse", "--show-toplevel"),
+        "git_dir": git_output(probe_path, "rev-parse", "--git-dir"),
+        "common_dir": git_output(probe_path, "rev-parse", "--git-common-dir"),
+        "branch": git_output(probe_path, "branch", "--show-current"),
+    }
+
+
+def _absolute_probe_value(probe_path: Path, raw_value: str) -> str:
+    path = Path(raw_value)
+    if not path.is_absolute():
+        path = probe_path / path
+    return os.path.realpath(path)
+
+
+def classify_location(raw_path: str) -> Classification:
+    """Classify a path as canonical, linked, outside Git, or unknown."""
+    probe_path = _existing_probe_path(raw_path)
+    try:
+        inside = git_output(probe_path, "rev-parse", "--is-inside-work-tree")
+    except RuntimeError as exc:
+        return Classification("unknown", False, reason=str(exc))
+    if inside != "true":
+        return Classification(
+            "outside", False, reason="path is outside a Git worktree"
+        )
+
+    try:
+        values = _repository_probes(probe_path)
+    except RuntimeError as exc:
+        return Classification("unknown", True, reason=str(exc))
+
+    required = ("repo_root", "git_dir", "common_dir")
+    if any(not values[name] for name in required):
+        return Classification(
+            "unknown",
+            True,
+            reason="required Git worktree identity could not be resolved",
+        )
+
+    repo_root = _absolute_probe_value(probe_path, values["repo_root"])
+    git_dir = _absolute_probe_value(probe_path, values["git_dir"])
+    common_dir = _absolute_probe_value(probe_path, values["common_dir"])
+    classification = "canonical" if git_dir == common_dir else "linked"
+    return Classification(
+        classification,
+        True,
+        repo_root=repo_root,
+        git_dir=git_dir,
+        common_dir=common_dir,
+        branch=values["branch"],
+        reason=(
+            "Git directory equals common directory"
+            if classification == "canonical"
+            else "Git directory is isolated beneath the common directory"
+        ),
+    )
+
+
+def target_probe(cwd: str, file_path: str) -> str:
+    if not file_path:
+        return cwd
+    target = Path(file_path).expanduser()
+    if not target.is_absolute():
+        target = Path(cwd) / target
+    return str(target.resolve(strict=False))
+
+
+def git_symlink_origin(cwd: str, file_path: str) -> Classification | None:
+    """Return the Git location containing a traversed symlink, if any."""
+    target = Path(file_path).expanduser()
+    if not target.is_absolute():
+        base = Path(cwd).expanduser()
+        if not base.is_absolute():
+            base = Path.cwd() / base
+        target = base / target
+    current = Path(target.anchor)
+    for part in target.parts[1:]:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            current = current.parent
+            continue
+        candidate = current / part
+        if candidate.is_symlink():
+            origin = classify_location(str(current))
+            if origin.inside_git:
+                return origin
+            current = Path(os.path.realpath(candidate))
+            continue
+        current = candidate
+    return None
+
+
+def git_workspace_root_from_environment() -> str:
+    """Return the trusted Git workspace root, defaulting to ~/Git."""
+    if GIT_WORKSPACE_ROOT_ENV in os.environ:
+        return os.environ[GIT_WORKSPACE_ROOT_ENV]
+    return str(Path.home() / "Git")
+
+
+def canonical_git_workspace_root(workspace_root: str) -> str:
+    if not workspace_root:
+        return ""
+    root = os.path.realpath(os.path.expanduser(workspace_root))
+    home = os.path.realpath(str(Path.home()))
+    if root in {os.path.abspath(os.sep), home} or not os.path.isdir(root):
+        return ""
+    return root
+
+
+def is_within_workspace(path: str, workspace_root: str) -> bool:
+    if not path or not workspace_root:
+        return False
+    try:
+        return (
+            os.path.commonpath([os.path.realpath(path), workspace_root])
+            == workspace_root
+        )
+    except ValueError:
+        return False
+
+
+def repository_within_workspace(
+    location: Classification, workspace_root: str
+) -> bool:
+    """Require the worktree and its shared Git metadata beneath one root."""
+    return location.inside_git and all(
+        is_within_workspace(path, workspace_root)
+        for path in (location.repo_root, location.git_dir, location.common_dir)
+    )

--- a/tests/test-git-safety-guard.py
+++ b/tests/test-git-safety-guard.py
@@ -186,6 +186,9 @@ class CanonicalWritePolicyTests(unittest.TestCase):
         outside_root = Path(outside_temp.name)
         outside_file = outside_root / "outside.txt"
         outside_file.write_text("outside\n", encoding="utf-8")
+        escaped_outside_file = outside_root.parent / f"{outside_root.name}-escaped.txt"
+        escaped_outside_file.write_text("escaped\n", encoding="utf-8")
+        self.addCleanup(escaped_outside_file.unlink, missing_ok=True)
         alias = self.linked / "outside-alias"
         alias.symlink_to(outside_root, target_is_directory=True)
 
@@ -197,6 +200,15 @@ class CanonicalWritePolicyTests(unittest.TestCase):
             self.assertIsNotNone(denial)
             reason = denial["hookSpecificOutput"]["permissionDecisionReason"]
             self.assertIn("symlinked write target escapes", reason)
+            traversed_existing = alias / ".." / escaped_outside_file.name
+            traversal_denial = self._check(self.linked, traversed_existing)
+            self.assertIsNotNone(traversal_denial)
+            traversal_reason = traversal_denial["hookSpecificOutput"][
+                "permissionDecisionReason"
+            ]
+            self.assertIn("symlinked write target escapes", traversal_reason)
+            traversed_missing = alias / ".." / f"{outside_root.name}-missing.txt"
+            self.assertIsNotNone(self._check(self.linked, traversed_missing))
             self.assertIsNone(self._check(self.linked, outside_file))
 
     def test_linked_context_cannot_target_canonical_checkout(self):

--- a/tests/test-git-safety-guard.py
+++ b/tests/test-git-safety-guard.py
@@ -178,6 +178,27 @@ class CanonicalWritePolicyTests(unittest.TestCase):
             reason = denial["hookSpecificOutput"]["permissionDecisionReason"]
             self.assertIn("limited to the trusted Git workspace", reason)
 
+    def test_git_worktree_symlink_cannot_escape_to_outside_workspace(self):
+        outside_temp = tempfile.TemporaryDirectory(
+            prefix=f"{self.root.name}-outside-", dir=self.root.parent
+        )
+        self.addCleanup(outside_temp.cleanup)
+        outside_root = Path(outside_temp.name)
+        outside_file = outside_root / "outside.txt"
+        outside_file.write_text("outside\n", encoding="utf-8")
+        alias = self.linked / "outside-alias"
+        alias.symlink_to(outside_root, target_is_directory=True)
+
+        with mock.patch.dict(
+            canonical_write_policy.os.environ,
+            {"AIDEVOPS_GIT_WORKSPACE_ROOT": str(self.root)},
+        ):
+            denial = self._check(self.linked, alias / "outside.txt")
+            self.assertIsNotNone(denial)
+            reason = denial["hookSpecificOutput"]["permissionDecisionReason"]
+            self.assertIn("symlinked write target escapes", reason)
+            self.assertIsNone(self._check(self.linked, outside_file))
+
     def test_linked_context_cannot_target_canonical_checkout(self):
         denial = self._check(self.linked, self.repo / "README.md")
         self.assertIsNotNone(denial)

--- a/tests/test-git-safety-guard.py
+++ b/tests/test-git-safety-guard.py
@@ -79,6 +79,30 @@ class CanonicalWritePolicyTests(unittest.TestCase):
                 str(target), patch_text
             )
 
+    def _create_repo_with_linked_worktree(
+        self, root: Path, name: str
+    ) -> tuple[Path, Path]:
+        repo = root / f"{name}-repo"
+        linked = root / f"{name}-linked"
+        repo.mkdir()
+        self._git(repo, "init", "-q", "-b", "main")
+        self._git(repo, "config", "user.name", "Test")
+        self._git(repo, "config", "user.email", "test@example.invalid")
+        self._git(repo, "config", "commit.gpgsign", "false")
+        (repo / "README.md").write_text(f"{name}\n", encoding="utf-8")
+        self._git(repo, "add", "README.md")
+        self._git(repo, "commit", "-q", "-m", f"{name} seed")
+        self._git(
+            repo,
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            f"feature/{name}",
+            str(linked),
+        )
+        return repo, linked
+
     def test_planning_files_are_denied_in_canonical_develop_checkout(self):
         for relative_path in ("README.md", "TODO.md", "todo/task.md"):
             with self.subTest(relative_path=relative_path):
@@ -96,33 +120,63 @@ class CanonicalWritePolicyTests(unittest.TestCase):
         self.assertIsNone(self._check(self.repo, outside_target))
         self.assertIsNone(self._check(self.repo, self.linked / "new-file.md"))
 
-    def test_cross_repository_linked_target_is_denied(self):
-        foreign_repo = self.root / "foreign-repo"
-        foreign_linked = self.root / "foreign-linked"
-        foreign_repo.mkdir()
-        self._git(foreign_repo, "init", "-q", "-b", "main")
-        self._git(foreign_repo, "config", "user.name", "Test")
-        self._git(foreign_repo, "config", "user.email", "test@example.invalid")
-        self._git(foreign_repo, "config", "commit.gpgsign", "false")
-        (foreign_repo / "README.md").write_text("foreign\n", encoding="utf-8")
-        self._git(foreign_repo, "add", "README.md")
-        self._git(foreign_repo, "commit", "-q", "-m", "foreign seed")
-        self._git(
-            foreign_repo,
-            "worktree",
-            "add",
-            "-q",
-            "-b",
-            "feature/foreign",
-            str(foreign_linked),
+    def test_cross_repository_linked_target_is_allowed_within_workspace(self):
+        _, foreign_linked = self._create_repo_with_linked_worktree(
+            self.root, "foreign"
         )
 
-        for cwd in (self.repo, self.linked):
-            with self.subTest(cwd=cwd):
-                denial = self._check(cwd, foreign_linked / "README.md")
-                self.assertIsNotNone(denial)
-                reason = denial["hookSpecificOutput"]["permissionDecisionReason"]
-                self.assertIn("different repository", reason)
+        with mock.patch.dict(
+            canonical_write_policy.os.environ,
+            {"AIDEVOPS_GIT_WORKSPACE_ROOT": str(self.root)},
+        ):
+            for cwd in (self.repo, self.linked):
+                with self.subTest(cwd=cwd):
+                    self.assertIsNone(
+                        self._check(cwd, foreign_linked / "README.md")
+                    )
+
+    def test_cross_repository_linked_target_outside_workspace_is_denied(self):
+        outside_temp = tempfile.TemporaryDirectory(
+            prefix=f"{self.root.name}-sibling-", dir=self.root.parent
+        )
+        self.addCleanup(outside_temp.cleanup)
+        outside_root = Path(outside_temp.name)
+        _, foreign_linked = self._create_repo_with_linked_worktree(
+            outside_root, "foreign"
+        )
+
+        with mock.patch.dict(
+            canonical_write_policy.os.environ,
+            {"AIDEVOPS_GIT_WORKSPACE_ROOT": str(self.root)},
+        ):
+            denial = self._check(self.linked, foreign_linked / "README.md")
+            self.assertIsNotNone(denial)
+            reason = denial["hookSpecificOutput"]["permissionDecisionReason"]
+            self.assertIn("limited to the trusted Git workspace", reason)
+
+            alias = self.root / "foreign-alias"
+            alias.symlink_to(foreign_linked, target_is_directory=True)
+            denial = self._check(self.linked, alias / "README.md")
+            self.assertIsNotNone(denial)
+            reason = denial["hookSpecificOutput"]["permissionDecisionReason"]
+            self.assertIn("limited to the trusted Git workspace", reason)
+
+    def test_context_outside_workspace_cannot_target_foreign_linked_worktree(self):
+        outside_temp = tempfile.TemporaryDirectory()
+        self.addCleanup(outside_temp.cleanup)
+        outside_root = Path(outside_temp.name)
+        _, outside_linked = self._create_repo_with_linked_worktree(
+            outside_root, "outside"
+        )
+
+        with mock.patch.dict(
+            canonical_write_policy.os.environ,
+            {"AIDEVOPS_GIT_WORKSPACE_ROOT": str(self.root)},
+        ):
+            denial = self._check(outside_linked, self.linked / "README.md")
+            self.assertIsNotNone(denial)
+            reason = denial["hookSpecificOutput"]["permissionDecisionReason"]
+            self.assertIn("limited to the trusted Git workspace", reason)
 
     def test_linked_context_cannot_target_canonical_checkout(self):
         denial = self._check(self.linked, self.repo / "README.md")


### PR DESCRIPTION
## Summary

Allow intentional writes between linked worktrees when both repository identities resolve beneath the trusted Git workspace, while preserving canonical checkout protection and preventing symlink-based workspace escapes.

## Files Changed

- `.agents/scripts/canonical-write-policy-helper.py`
- `.agents/scripts/canonical_write_policy_paths.py`
- `tests/test-git-safety-guard.py`
- `.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs`
- `.agents/reference/repo-organization.md`

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Python policy tests (20), OpenCode Git safety tests (19), full OpenCode plugin suite (508), Python compilation, changed-file linters, PR-specific Qlty regression, exact-head required CI, and real linked/canonical path probes pass.
- **Security boundary:** canonical targets, sibling-prefix paths, repositories outside the trusted workspace, and symlinks traversed from Git worktrees to outside-Git targets remain denied; explicit sanctioned outside-Git paths remain allowed.
- **Independent review:** approved against exact head `041ccab67`; evidence bundle SHA-256 `ec1968de315a8d6cadfe282b1edc05316b8bebfa45c18f683205173d776b01fe`.

Resolves #29217
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 2h 31m and 1,461,248 tokens on this with the user in an interactive session.