### PR TITLE
GH#29230: Accelerate guarded worktree cleanup

### DIFF
--- a/.agents/scripts/cleanup-remote-branches-async-helper.sh
+++ b/.agents/scripts/cleanup-remote-branches-async-helper.sh
@@ -40,6 +40,21 @@ _lock_release() {
 	return 0
 }
 
+_lock_signal_exit() {
+	local exit_code="$1"
+	trap - EXIT INT TERM
+	_lock_release
+	exit "$exit_code"
+	return 1
+}
+
+_lock_install_traps() {
+	trap '_lock_release' EXIT
+	trap '_lock_signal_exit 130' INT
+	trap '_lock_signal_exit 143' TERM
+	return 0
+}
+
 _is_pid_alive() {
 	local pid="$1"
 	[[ -z "$pid" ]] && return 1
@@ -58,8 +73,7 @@ _is_pid_alive() {
 _lock_acquire() {
 	if mkdir "$LOCK_DIR" 2>/dev/null; then
 		printf '%s\n' "$$" >"$PID_FILE" 2>/dev/null || true
-		# shellcheck disable=SC2064
-		trap "_lock_release" EXIT INT TERM
+		_lock_install_traps
 		return 0
 	fi
 
@@ -71,8 +85,7 @@ _lock_acquire() {
 			rm -rf "$LOCK_DIR" 2>/dev/null || true
 			if mkdir "$LOCK_DIR" 2>/dev/null; then
 				printf '%s\n' "$$" >"$PID_FILE" 2>/dev/null || true
-				# shellcheck disable=SC2064
-				trap "_lock_release" EXIT INT TERM
+				_lock_install_traps
 				return 0
 			fi
 		fi

--- a/.agents/scripts/cleanup-stashes-async-helper.sh
+++ b/.agents/scripts/cleanup-stashes-async-helper.sh
@@ -43,6 +43,21 @@ _lock_release() {
 	return 0
 }
 
+_lock_signal_exit() {
+	local exit_code="$1"
+	trap - EXIT INT TERM
+	_lock_release
+	exit "$exit_code"
+	return 1
+}
+
+_lock_install_traps() {
+	trap '_lock_release' EXIT
+	trap '_lock_signal_exit 130' INT
+	trap '_lock_signal_exit 143' TERM
+	return 0
+}
+
 _is_pid_alive() {
 	local pid="$1"
 	[[ -z "$pid" ]] && return 1
@@ -61,8 +76,7 @@ _is_pid_alive() {
 _lock_acquire() {
 	if mkdir "$LOCK_DIR" 2>/dev/null; then
 		printf '%s\n' "$$" >"$PID_FILE" 2>/dev/null || true
-		# shellcheck disable=SC2064
-		trap "_lock_release" EXIT INT TERM
+		_lock_install_traps
 		return 0
 	fi
 
@@ -74,8 +88,7 @@ _lock_acquire() {
 			rm -rf "$LOCK_DIR" 2>/dev/null || true
 			if mkdir "$LOCK_DIR" 2>/dev/null; then
 				printf '%s\n' "$$" >"$PID_FILE" 2>/dev/null || true
-				# shellcheck disable=SC2064
-				trap "_lock_release" EXIT INT TERM
+				_lock_install_traps
 				return 0
 			fi
 		fi

--- a/.agents/scripts/cleanup-worktrees-async-helper.sh
+++ b/.agents/scripts/cleanup-worktrees-async-helper.sh
@@ -96,6 +96,21 @@ _lock_release() {
 	return 0
 }
 
+_lock_signal_exit() {
+	local exit_code="$1"
+	trap - EXIT INT TERM
+	_lock_release
+	exit "$exit_code"
+	return 1
+}
+
+_lock_install_traps() {
+	trap '_lock_release' EXIT
+	trap '_lock_signal_exit 130' INT
+	trap '_lock_signal_exit 143' TERM
+	return 0
+}
+
 # Check whether the PID that holds the lock is still alive.
 # Uses kill -0 (existence) + ps comm= (command-aware, guards against PID reuse).
 # Returns 0 if alive, 1 if dead or indeterminate.
@@ -127,8 +142,7 @@ _is_pid_alive() {
 _lock_acquire() {
 	if mkdir "$LOCK_DIR" 2>/dev/null; then
 		printf '%s\n' "$$" >"$PID_FILE" 2>/dev/null || true
-		# shellcheck disable=SC2064
-		trap "_lock_release" EXIT INT TERM
+		_lock_install_traps
 		return 0
 	fi
 
@@ -141,8 +155,7 @@ _lock_acquire() {
 			rm -rf "$LOCK_DIR" 2>/dev/null || true
 			if mkdir "$LOCK_DIR" 2>/dev/null; then
 				printf '%s\n' "$$" >"$PID_FILE" 2>/dev/null || true
-				# shellcheck disable=SC2064
-				trap "_lock_release" EXIT INT TERM
+				_lock_install_traps
 				return 0
 			fi
 		fi
@@ -160,13 +173,13 @@ _lock_acquire() {
 # Returns 1 (skip) if we are within the cadence window.
 _cadence_ok() {
 	if [[ ! -f "$LAST_RUN_FILE" ]]; then
-		return 0  # First run — always proceed
+		return 0 # First run — always proceed
 	fi
 
 	local last_run now elapsed cadence_secs
 	last_run=$(cat "$LAST_RUN_FILE" 2>/dev/null || echo "0")
 	if ! [[ "$last_run" =~ ^[0-9]+$ ]]; then
-		return 0  # Corrupted state file — proceed
+		return 0 # Corrupted state file — proceed
 	fi
 
 	now=$(date +%s)

--- a/.agents/scripts/full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/full-loop-cleanup-receipt.sh
@@ -544,7 +544,7 @@ full_loop_write_cleanup_deferred() {
 	return 0
 }
 
-_full_loop_cleanup_receipt_for_worktree_unlocked() {
+_full_loop_cleanup_receipt_for_worktree_unlocked_fallback() {
 	local worktree="$1"
 	local receipt_dir=""
 	local receipt_path=""
@@ -576,6 +576,56 @@ _full_loop_cleanup_receipt_for_worktree_unlocked() {
 			fi
 		fi
 	done
+	[[ -n "$selected_path" ]] || return 1
+	printf '%s\n' "$selected_path"
+	return 0
+}
+
+_full_loop_cleanup_receipt_for_worktree_unlocked() {
+	local worktree="$1"
+	local receipt_dir=""
+	local selected_path=""
+	local lookup_status=0
+
+	[[ -n "$worktree" ]] || return 1
+	receipt_dir=$(_full_loop_cleanup_receipt_dir) || return 1
+	[[ -d "$receipt_dir" ]] || return 1
+	# A cleanup pass can perform this lookup hundreds of times. Process every
+	# receipt in one jq invocation instead of launching jq once to three times
+	# per file. Malformed JSON falls back to the conservative per-file scan,
+	# which preserves the previous skip-invalid-file behaviour.
+	selected_path=$(jq -nr \
+		--arg worktree "$worktree" \
+		--arg superseded "$_FULL_LOOP_RECEIPT_PATH_RECREATED" \
+		--arg string_type "$_FULL_LOOP_RECEIPT_JSON_STRING_TYPE" '
+		reduce (
+			inputs
+			| select(type == "object")
+			| select(.worktree == $worktree)
+			| select((.receipt_disposition.state // "") != $superseded)
+			| {
+				path: input_filename,
+				created_at: (.created_at // ""),
+				is_migrated: (
+					if (((.migration.from_repository? // null) | type) == $string_type
+						and ((.migration.from_repository? // "") | length) > 0)
+					then 1 else 0 end
+				)
+			}
+		) as $candidate (
+			null;
+			if . == null
+				or $candidate.created_at > .created_at
+				or ($candidate.created_at == .created_at
+					and $candidate.is_migrated == 1 and .is_migrated != 1)
+			then $candidate else . end
+		)
+		| .path // empty
+	' "$receipt_dir"/*.json 2>/dev/null) || lookup_status=$?
+	if [[ "$lookup_status" -ne 0 ]]; then
+		_full_loop_cleanup_receipt_for_worktree_unlocked_fallback "$worktree"
+		return $?
+	fi
 	[[ -n "$selected_path" ]] || return 1
 	printf '%s\n' "$selected_path"
 	return 0

--- a/.agents/scripts/full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/full-loop-cleanup-receipt.sh
@@ -26,6 +26,7 @@ _FULL_LOOP_RECEIPT_TIMESTAMP_REGEX='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2
 _FULL_LOOP_RECEIPT_VERSION_TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+$'
 _FULL_LOOP_RECREATED_RECEIPT_TRANSACTION_SCHEMA="aidevops.full-loop.recreated-receipts.transaction/v1"
 _FULL_LOOP_RECEIPT_LOCK=""
+_FULL_LOOP_CLEANUP_OWNER_PID=""
 
 _full_loop_validate_superseded_evidence() {
 	local evidence_path="$1"
@@ -952,10 +953,13 @@ full_loop_cleanup_owner_alive() {
 	local owner_pid=""
 	local expected_identity=""
 	local observed_identity=""
+	local owner_record=""
+	_FULL_LOOP_CLEANUP_OWNER_PID=""
 
 	[[ -f "$receipt_path" ]] || return 1
-	owner_pid=$(jq -r '.owner.pid // empty' "$receipt_path" 2>/dev/null || true)
-	expected_identity=$(jq -r '.owner.process_identity // empty' "$receipt_path" 2>/dev/null || true)
+	owner_record=$(jq -r '[.owner.pid // "", .owner.process_identity // ""] | @tsv' "$receipt_path" 2>/dev/null || true)
+	IFS=$'\t' read -r owner_pid expected_identity <<<"$owner_record"
+	_FULL_LOOP_CLEANUP_OWNER_PID="$owner_pid"
 	[[ "$owner_pid" =~ ^[0-9]+$ && -n "$expected_identity" ]] || return 1
 	kill -0 "$owner_pid" 2>/dev/null || return 1
 	observed_identity=$(_full_loop_process_identity "$owner_pid") || return 1

--- a/.agents/scripts/opencode-db-archive-async-helper.sh
+++ b/.agents/scripts/opencode-db-archive-async-helper.sh
@@ -64,6 +64,21 @@ _lock_release() {
 	return 0
 }
 
+_lock_signal_exit() {
+	local exit_code="$1"
+	trap - EXIT INT TERM
+	_lock_release
+	exit "$exit_code"
+	return 1
+}
+
+_lock_install_traps() {
+	trap '_lock_release' EXIT
+	trap '_lock_signal_exit 130' INT
+	trap '_lock_signal_exit 143' TERM
+	return 0
+}
+
 # Check whether the PID that holds the lock is still alive.
 # Uses kill -0 (existence) + ps comm= (command-aware, guards against PID reuse).
 # Returns 0 if alive, 1 if dead or indeterminate.
@@ -91,8 +106,7 @@ _is_pid_alive() {
 _lock_acquire() {
 	if mkdir "$LOCK_DIR" 2>/dev/null; then
 		printf '%s\n' "$$" >"$PID_FILE" 2>/dev/null || true
-		# shellcheck disable=SC2064
-		trap "_lock_release" EXIT INT TERM
+		_lock_install_traps
 		return 0
 	fi
 
@@ -104,8 +118,7 @@ _lock_acquire() {
 			rm -rf "$LOCK_DIR" 2>/dev/null || true
 			if mkdir "$LOCK_DIR" 2>/dev/null; then
 				printf '%s\n' "$$" >"$PID_FILE" 2>/dev/null || true
-				# shellcheck disable=SC2064
-				trap "_lock_release" EXIT INT TERM
+				_lock_install_traps
 				return 0
 			fi
 		fi

--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -255,13 +255,44 @@ PY
 	return 0
 }
 
-# Resolve the registry key for a worktree path.
-# If a legacy non-normalized row already exists for an equivalent path,
-# return that stored key so ownership checks remain backward compatible.
-# Otherwise return the normalized path.
+_wt_registry_resolve_path_python() {
+	local requested_path="$1"
+	[[ -f "$WORKTREE_REGISTRY_DB" ]] || return 2
+	command -v python3 >/dev/null 2>&1 || return 2
+
+	python3 - "$WORKTREE_REGISTRY_DB" "$requested_path" <<'PY' 2>/dev/null
+import os
+import sqlite3
+import sys
+
+database_path, requested_path = sys.argv[1:]
+normalized = os.path.realpath(requested_path)
+try:
+    with sqlite3.connect(database_path) as connection:
+        rows = connection.execute("SELECT worktree_path FROM worktree_owners")
+        for (stored_path,) in rows:
+            if stored_path and os.path.realpath(stored_path) == normalized:
+                print(stored_path)
+                raise SystemExit(0)
+except sqlite3.Error:
+    raise SystemExit(2)
+print(normalized)
+PY
+	return $?
+}
+
+# Resolve the registry key for a worktree path. Resolve all legacy rows in one
+# Python process so a lookup remains O(rows) without spawning one interpreter
+# per row. If Python or SQLite access fails, retain the portable shell fallback.
 _wt_registry_lookup_path() {
 	local requested_path="$1"
-	local normalized
+	local resolved_path=""
+	if resolved_path=$(_wt_registry_resolve_path_python "$requested_path"); then
+		printf '%s' "$resolved_path"
+		return 0
+	fi
+
+	local normalized=""
 	normalized=$(_wt_normalize_path "$requested_path")
 
 	[[ ! -f "$WORKTREE_REGISTRY_DB" ]] && {

--- a/.agents/scripts/tests/test-cleanup-worktrees-async.sh
+++ b/.agents/scripts/tests/test-cleanup-worktrees-async.sh
@@ -4,11 +4,12 @@
 #
 # test-cleanup-worktrees-async.sh — Unit tests for cleanup-worktrees-async-helper.sh (GH#20554)
 #
-# Tests cover the four key behaviours from the acceptance criteria:
+# Tests cover the core lifecycle behaviours from the acceptance criteria:
 #   1. lock-held     — second invocation skips when lock is held by a live PID
 #   2. cadence-gate  — invocation skips when last-run is within the cadence window
 #   3. cold-start    — first invocation runs when no lock and no last-run file
 #   4. stale-PID     — lock reclamation when the holder PID is dead
+#   5. signal-exit   — TERM stops the helper and releases its singleton lock
 #
 # Tests do NOT call the real cleanup_worktrees (which calls gh and git across
 # all repos). Instead they inject a mock via CLEANUP_WORKTREES_ASYNC_TEST_MOCK.
@@ -189,7 +190,7 @@ test_cadence_gate() {
 	rm -f "$mock_ran"
 
 	# Write a recent last-run timestamp (30 seconds ago) — well within 10-min cadence
-	local recent_epoch=$(( $(date +%s) - 30 ))
+	local recent_epoch=$(($(date +%s) - 30))
 	printf '%s\n' "$recent_epoch" >"$last_run_file"
 
 	MOCK_CLEANUP_EXIT=0 CLEANUP_WORKTREES_ASYNC_CADENCE_MIN=10 \
@@ -320,7 +321,101 @@ test_lock_released_after_run() {
 }
 
 # ============================================================
-# TEST 9: HOME unset — explicit log dir avoids set -u unbound errors
+# TEST 9: TERM exits the helper instead of only releasing its lock
+# ============================================================
+test_term_exits_and_releases_lock() {
+	local stub_dir="${TEST_DIR}/scripts"
+	local logs_dir="${TEST_DIR}/.aidevops/logs"
+	local lock_dir="${logs_dir}/cleanup_worktrees.lock"
+	local pid_file="${lock_dir}/pid"
+	local mock_ran="${TEST_DIR}/mock-ran"
+	local helper_pid=""
+	local attempts=0
+	mkdir -p "$stub_dir"
+	rm -rf "$lock_dir"
+	rm -f "$mock_ran"
+
+	cat >"${stub_dir}/shared-constants.sh" <<'STUB'
+# stub shared-constants.sh
+STUB
+	cat >"${stub_dir}/pulse-cleanup.sh" <<STUB
+# stub pulse-cleanup.sh
+cleanup_worktrees() {
+	printf 'MOCK_RAN\n' >>"${mock_ran}"
+	while :; do
+		sleep 1
+	done
+	return 0
+}
+STUB
+	cp "$HELPER" "${stub_dir}/cleanup-worktrees-async-helper.sh"
+	chmod +x "${stub_dir}/cleanup-worktrees-async-helper.sh"
+
+	env HOME="$TEST_DIR" CLEANUP_WORKTREES_ASYNC_CADENCE_MIN=10 \
+		bash "${stub_dir}/cleanup-worktrees-async-helper.sh" >/dev/null 2>&1 &
+	helper_pid=$!
+	while [[ ! -s "$pid_file" && "$attempts" -lt 50 ]]; do
+		sleep 0.1
+		attempts=$((attempts + 1))
+	done
+	if [[ ! -s "$pid_file" ]]; then
+		kill -KILL "$helper_pid" 2>/dev/null || true
+		wait "$helper_pid" 2>/dev/null || true
+		print_result "signal-exit: helper acquires lock before TERM" 1 "lock PID file was not created"
+		return 0
+	fi
+
+	kill -TERM "$helper_pid"
+	attempts=0
+	while kill -0 "$helper_pid" 2>/dev/null && [[ "$attempts" -lt 50 ]]; do
+		sleep 0.1
+		attempts=$((attempts + 1))
+	done
+	if kill -0 "$helper_pid" 2>/dev/null; then
+		kill -KILL "$helper_pid" 2>/dev/null || true
+		wait "$helper_pid" 2>/dev/null || true
+		print_result "signal-exit: TERM stops helper and releases lock" 1 "helper remained alive after TERM"
+		return 0
+	fi
+	wait "$helper_pid" 2>/dev/null || true
+
+	if [[ ! -d "$lock_dir" ]]; then
+		print_result "signal-exit: TERM stops helper and releases lock" 0
+	else
+		print_result "signal-exit: TERM stops helper and releases lock" 1 "lock remained after helper exited"
+	fi
+	return 0
+}
+
+# ============================================================
+# TEST 10: sibling async lock helpers use the same terminating traps
+# ============================================================
+test_async_lock_helpers_install_terminating_traps() {
+	local scripts_dir="${SCRIPT_DIR}/.."
+	local helper_name=""
+	local helper_path=""
+	local invalid_helpers=""
+	for helper_name in \
+		cleanup-worktrees-async-helper.sh \
+		cleanup-stashes-async-helper.sh \
+		cleanup-remote-branches-async-helper.sh \
+		opencode-db-archive-async-helper.sh; do
+		helper_path="${scripts_dir}/${helper_name}"
+		if ! grep -Fq "trap '_lock_signal_exit 130' INT" "$helper_path" ||
+			! grep -Fq "trap '_lock_signal_exit 143' TERM" "$helper_path"; then
+			invalid_helpers="${invalid_helpers}${invalid_helpers:+, }${helper_name}"
+		fi
+	done
+	if [[ -z "$invalid_helpers" ]]; then
+		print_result "signal-exit: all async lock helpers install terminating traps" 0
+	else
+		print_result "signal-exit: all async lock helpers install terminating traps" 1 "missing terminating traps: ${invalid_helpers}"
+	fi
+	return 0
+}
+
+# ============================================================
+# TEST 11: HOME unset — explicit log dir avoids set -u unbound errors
 # ============================================================
 test_home_unset_uses_explicit_log_dir() {
 	local custom_log_dir="${TEST_DIR}/custom-logs"
@@ -360,25 +455,40 @@ main() {
 	test_last_run_updated
 
 	# Must re-setup between tests that share state
-	teardown; setup
+	teardown
+	setup
 	test_cadence_gate
 
-	teardown; setup
+	teardown
+	setup
 	test_lock_held
 
-	teardown; setup
+	teardown
+	setup
 	test_stale_pid_reclaim
 
-	teardown; setup
+	teardown
+	setup
 	test_failed_cleanup_no_last_run_update
 
-	teardown; setup
+	teardown
+	setup
 	test_skipped_cleanup_no_last_run_update
 
-	teardown; setup
+	teardown
+	setup
 	test_lock_released_after_run
 
-	teardown; setup
+	teardown
+	setup
+	test_term_exits_and_releases_lock
+
+	teardown
+	setup
+	test_async_lock_helpers_install_terminating_traps
+
+	teardown
+	setup
 	test_home_unset_uses_explicit_log_dir
 
 	echo ""

--- a/.agents/scripts/tests/test-full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/tests/test-full-loop-cleanup-receipt.sh
@@ -45,6 +45,7 @@ jq -e --argjson owner_pid "$OWNER_PID" '
 	and (.owner.process_identity | length > 0)
 ' "$receipt_one" >/dev/null
 full_loop_cleanup_owner_alive "$receipt_one"
+[[ "$_FULL_LOOP_CLEANUP_OWNER_PID" == "$OWNER_PID" ]]
 printf 'PASS deferred receipt persists external owner identity and pending lease\n'
 
 cp "$receipt_one" "${TEST_ROOT}/receipt-idempotent.json"

--- a/.agents/scripts/tests/test-full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/tests/test-full-loop-cleanup-receipt.sh
@@ -125,6 +125,48 @@ selected_receipt=$(full_loop_cleanup_receipt_for_worktree "${TEST_ROOT}/worktree
 [[ "$selected_receipt" == "$newest_receipt" ]]
 printf 'PASS reused worktree paths select the newest lifecycle receipt\n'
 
+migrated_receipt="${AIDEVOPS_FULL_LOOP_CLEANUP_DIR}/example_migrated-104.json"
+jq '.repository = "example/migrated" | .pr_number = 104
+	| .migration = {from_repository:"example/repo",to_repository:"example/migrated",migrated_at:.created_at}' \
+	"$newest_receipt" >"$migrated_receipt"
+selected_receipt=$(full_loop_cleanup_receipt_for_worktree "${TEST_ROOT}/worktree-one")
+[[ "$selected_receipt" == "$migrated_receipt" ]]
+printf 'PASS equal-time receipt lookup preserves migrated-receipt preference\n'
+
+lookup_bin="${TEST_ROOT}/lookup-bin"
+lookup_counter="${TEST_ROOT}/lookup-jq-count"
+lookup_original_path="$PATH"
+real_jq=$(command -v jq)
+mkdir -p "$lookup_bin"
+cat >"${lookup_bin}/jq" <<'LOOKUP_JQ'
+#!/usr/bin/env bash
+set -euo pipefail
+lookup_count=0
+if [[ -f "$AIDEVOPS_TEST_LOOKUP_JQ_COUNTER" ]]; then
+	IFS= read -r lookup_count <"$AIDEVOPS_TEST_LOOKUP_JQ_COUNTER" || lookup_count=0
+fi
+[[ "$lookup_count" =~ ^[0-9]+$ ]] || lookup_count=0
+printf '%s\n' "$((lookup_count + 1))" >"$AIDEVOPS_TEST_LOOKUP_JQ_COUNTER"
+exec "$AIDEVOPS_TEST_REAL_JQ" "$@"
+LOOKUP_JQ
+chmod +x "${lookup_bin}/jq"
+export AIDEVOPS_TEST_LOOKUP_JQ_COUNTER="$lookup_counter"
+export AIDEVOPS_TEST_REAL_JQ="$real_jq"
+export PATH="${lookup_bin}:${PATH}"
+selected_receipt=$(full_loop_cleanup_receipt_for_worktree "${TEST_ROOT}/worktree-one")
+export PATH="$lookup_original_path"
+unset AIDEVOPS_TEST_LOOKUP_JQ_COUNTER AIDEVOPS_TEST_REAL_JQ
+IFS= read -r lookup_count <"$lookup_counter"
+[[ "$selected_receipt" == "$migrated_receipt" && "$lookup_count" -eq 1 ]]
+printf 'PASS receipt lookup scans all valid receipts with one jq process\n'
+
+invalid_receipt="${AIDEVOPS_FULL_LOOP_CLEANUP_DIR}/invalid.json"
+printf '%s\n' '{invalid-json' >"$invalid_receipt"
+selected_receipt=$(full_loop_cleanup_receipt_for_worktree "${TEST_ROOT}/worktree-one")
+rm -f "$invalid_receipt"
+[[ "$selected_receipt" == "$migrated_receipt" ]]
+printf 'PASS malformed receipt falls back without hiding a valid lifecycle receipt\n'
+
 atomic_worktree="${TEST_ROOT}/atomic-worktree"
 mkdir -p "$atomic_worktree"
 atomic_receipt_one=$(full_loop_write_cleanup_deferred example/atomic-one 201 "$atomic_worktree" feature/atomic \

--- a/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
@@ -184,6 +184,10 @@ test_terminal_pr_cleanup_waits_for_deferred_parent_exit() {
 	(
 		cd "$repo_path" || exit 1
 		source_clean_lib_with_stubs || exit 1
+		_file_mtime_epoch() {
+			date +%s
+			return 0
+		}
 		_clean_remove_merged "main" "$repo_path" "false" "$branch" "" "true" "" >/dev/null
 	) || rc=1
 	[[ -d "$wt_path" ]] || rc=1
@@ -210,6 +214,33 @@ test_terminal_pr_cleanup_waits_for_deferred_parent_exit() {
 	[[ -f "$registry_release_marker" ]] || rc=1
 	print_result "terminal PR cleanup waits for deferred parent exit" "$rc" \
 		"Expected first pulse to defer and second pulse after owner exit to remove worktree"
+	return 0
+}
+
+test_reused_legacy_marker_pid_expires() {
+	local wt_path="${TEST_ROOT}/wt-reused-legacy-pid"
+	local marker_path="${wt_path}/.agents/.full-loop-cleanup-deferred"
+	local rc=0
+	mkdir -p "${wt_path}/.agents" || rc=1
+	printf '%s\n' "$$" >"$marker_path" || rc=1
+
+	(
+		source_clean_lib_with_stubs || exit 1
+		_file_mtime_epoch() {
+			printf '%s\n' "1"
+			return 0
+		}
+		_clean_process_age_seconds() {
+			printf '%s\n' "1"
+			return 0
+		}
+		local deferred_state=0
+		_clean_deferred_parent_alive "$wt_path" || deferred_state=$?
+		[[ "$deferred_state" -eq 2 && ! -f "$marker_path" ]]
+	) || rc=1
+
+	print_result "legacy marker rejects a process generation newer than the marker" "$rc" \
+		"Expected a live recycled PID to expire instead of extending cleanup ownership"
 	return 0
 }
 
@@ -842,6 +873,7 @@ echo "=== test-worktree-cleanup-branch-merged-owned-skip.sh ==="
 test_protected_pass_set_blocks_branch_merged_removal
 test_terminal_pr_proof_bypasses_protected_pass_skip
 test_terminal_pr_cleanup_waits_for_deferred_parent_exit
+test_reused_legacy_marker_pid_expires
 test_dead_marker_preserves_replacement_owner
 test_terminal_cleanup_requires_removal_lease
 test_cleanup_lease_released_when_removal_guard_blocks

--- a/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
@@ -467,6 +467,120 @@ test_merged_pr_list_passes_explicit_repo_slug() {
 	return 0
 }
 
+test_exact_merged_pr_batch_prefetch_covers_worktree_heads() {
+	local repo_path="${TEST_ROOT}/repo-batch-prefetch"
+	local wt_a="${TEST_ROOT}/wt-batch-prefetch-a"
+	local wt_b="${TEST_ROOT}/wt-batch-prefetch-b"
+	local branch_a="feature/gh-99040-batch-a"
+	local branch_b="feature/gh-99040-batch-b"
+	local args_file="${TEST_ROOT}/batch-prefetch-args"
+	local output=""
+	local rc=0
+	setup_repo "$repo_path" || rc=1
+	git -C "$repo_path" branch "$branch_a" || rc=1
+	git -C "$repo_path" branch "$branch_b" || rc=1
+	git -C "$repo_path" worktree add -q "$wt_a" "$branch_a" || rc=1
+	git -C "$repo_path" worktree add -q "$wt_b" "$branch_b" || rc=1
+
+	output=$(
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		_clean_query_exact_merged_pr_batch() {
+			printf '%s\n' "$*" >"$args_file"
+			printf '%s\n' "$branch_a"
+			return 0
+		}
+		_clean_build_exact_merged_pr_branches "main"
+	) || rc=1
+
+	[[ "$output" == "$branch_a" ]] || rc=1
+	grep -Fq -- "$branch_a" "$args_file" 2>/dev/null || rc=1
+	grep -Fq -- "$branch_b" "$args_file" 2>/dev/null || rc=1
+	print_result "exact merged PR batch prefetch covers registered worktree heads" "$rc" \
+		"Expected one batch to contain both worktree branch heads"
+	return 0
+}
+
+test_complete_exact_prefetch_skips_per_head_lookup() {
+	local repo_path="${TEST_ROOT}/repo-complete-prefetch"
+	local marker="${TEST_ROOT}/complete-prefetch-gh-called"
+	local rc=0
+	setup_repo "$repo_path" || rc=1
+
+	(
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		_WT_CLEAN_EXACT_PR_PREFETCH_COMPLETE=true
+		gh_pr_list() {
+			printf 'called\n' >"$marker"
+			printf '1\n'
+			return 0
+		}
+		if _clean_branch_has_exact_merged_pr "feature/gh-99041-not-merged" ""; then
+			exit 1
+		fi
+	) || rc=1
+
+	[[ ! -e "$marker" ]] || rc=1
+	print_result "complete exact merged PR prefetch skips per-head lookup" "$rc" \
+		"Expected a complete negative batch result to suppress redundant gh_pr_list calls"
+	return 0
+}
+
+test_prepared_git_branch_cache_avoids_per_branch_query() {
+	local repo_path="${TEST_ROOT}/repo-merged-cache"
+	local branch="feature/gh-99042-merged-cache"
+	local marker="${TEST_ROOT}/merged-cache-git-called"
+	local rc=0
+	setup_repo "$repo_path" || rc=1
+	git -C "$repo_path" branch "$branch" || rc=1
+
+	(
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		_clean_prepare_git_branch_caches "main"
+		git() {
+			printf 'called\n' >"$marker"
+			return 1
+		}
+		_clean_branch_is_locally_merged "$branch" "main"
+	) || rc=1
+
+	[[ ! -e "$marker" ]] || rc=1
+	print_result "prepared Git branch cache avoids per-branch query" "$rc" \
+		"Expected local merged classification to use the scan-level cache"
+	return 0
+}
+
+test_auto_clean_skips_redundant_preview_scan() {
+	local repo_path="${TEST_ROOT}/repo-auto-single-pass"
+	local scan_marker="${TEST_ROOT}/auto-single-pass-scan"
+	local remove_marker="${TEST_ROOT}/auto-single-pass-remove"
+	local rc=0
+	setup_repo "$repo_path" || rc=1
+
+	(
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		_clean_preflight_main_worktree() { printf '%s\n' "$repo_path"; return 0; }
+		_clean_prepare_git_branch_caches() { return 0; }
+		_clean_fetch_remotes() { printf 'false\n'; return 0; }
+		_clean_build_merged_pr_branches() { return 0; }
+		_clean_build_exact_merged_pr_branches() { return 0; }
+		_clean_build_open_pr_branches() { return 0; }
+		_clean_build_closed_pr_branches() { return 0; }
+		_clean_scan_merged() { printf 'called\n' >"$scan_marker"; return 0; }
+		_clean_remove_merged() { printf 'called\n' >"$remove_marker"; return 0; }
+		cmd_clean --auto --force-merged >/dev/null 2>&1
+	) || rc=1
+
+	[[ ! -e "$scan_marker" ]] || rc=1
+	[[ -e "$remove_marker" ]] || rc=1
+	print_result "automatic cleanup skips redundant preview scan" "$rc" \
+		"Expected --auto to classify only in the removal pass"
+	return 0
+}
+
 test_deleted_squash_merged_pr_metadata_wins_over_remote_deleted() {
 	local repo_path="${TEST_ROOT}/repo-deleted-squash-pr"
 	local wt_path="${TEST_ROOT}/wt-deleted-squash-pr"
@@ -881,6 +995,10 @@ test_remove_merged_reports_metadata_verification_failure
 test_squash_merged_pr_without_ancestor_proof_classifies
 test_prefetched_merged_pr_metadata_skips_exact_head_lookup
 test_merged_pr_list_passes_explicit_repo_slug
+test_exact_merged_pr_batch_prefetch_covers_worktree_heads
+test_complete_exact_prefetch_skips_per_head_lookup
+test_prepared_git_branch_cache_avoids_per_branch_query
+test_auto_clean_skips_redundant_preview_scan
 test_deleted_squash_merged_pr_metadata_wins_over_remote_deleted
 test_exact_head_merged_pr_proof_wins_when_global_list_misses
 test_exact_merged_pr_proof_recovers_unproven_traditional_merge

--- a/.agents/scripts/tests/test-worktree-registry-session-claim.sh
+++ b/.agents/scripts/tests/test-worktree-registry-session-claim.sh
@@ -125,6 +125,26 @@ PY
 	return 0
 }
 
+test_legacy_equivalent_registry_path_resolves() {
+	reset_registry
+	local real_path="${TEST_ROOT}/legacy-real-path"
+	local legacy_path="${TEST_ROOT}/legacy-symlink-path"
+	local resolved_path=""
+	local rc=0
+	mkdir -p "$real_path"
+	ln -s "$real_path" "$legacy_path"
+	_init_registry_db
+	sqlite3 "$WORKTREE_REGISTRY_DB" "
+		INSERT INTO worktree_owners (worktree_path, branch, owner_pid)
+		VALUES ('$(_wt_sql_escape "$legacy_path")', 'feature/legacy-equivalent-path', ${OWNER_PID});
+	"
+
+	resolved_path=$(_wt_registry_lookup_path "$real_path") || rc=1
+	[[ "$resolved_path" == "$legacy_path" ]] || rc=1
+	print_result "legacy equivalent registry path resolves through batched normalization" "$rc"
+	return 0
+}
+
 test_different_session_stays_blocked() {
 	reset_registry
 	local wt_path="${TEST_ROOT}/different-session"
@@ -352,6 +372,7 @@ main() {
 	start_live_pids
 	test_same_opencode_session_rolls_owner_pid
 	test_parameterized_claim_preserves_metacharacters
+	test_legacy_equivalent_registry_path_resolves
 	test_different_session_stays_blocked
 	test_empty_session_cannot_roll_owner_pid
 	test_untrusted_session_cannot_roll_owner_pid

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -38,6 +38,7 @@ _WT_CLEAN_DEFERRED_OWNER_PID=""
 _WT_CLEAN_REASON_OWNED_SKIP="owned-skip"
 _WT_CLEAN_REMOVAL_LEASE_SESSION="cleanup:$$"
 _WT_CLEAN_REMOVAL_LEASE_TASK="worktree-removal"
+_WT_CLEAN_MARKER_CLOCK_SKEW_SECONDS=2
 
 # SCRIPT_DIR fallback — covers sourcing from test harnesses or direct invocation
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
@@ -54,6 +55,71 @@ if [[ -f "${SCRIPT_DIR}/full-loop-cleanup-receipt.sh" ]]; then
 fi
 
 # --- Functions ---
+
+_clean_process_age_seconds() {
+	local owner_pid="$1"
+	local elapsed=""
+	local days=0
+	local hours=0
+	local minutes=0
+	local seconds=0
+	local colons_only=""
+	local colon_count=0
+
+	[[ "$owner_pid" =~ ^[0-9]+$ ]] || return 1
+	elapsed=$(ps -p "$owner_pid" -o etime= 2>/dev/null | tr -d ' ') || return 1
+	[[ -n "$elapsed" ]] || return 1
+	if [[ "$elapsed" == *-* ]]; then
+		days="${elapsed%%-*}"
+		elapsed="${elapsed#*-}"
+	fi
+	colons_only="${elapsed//[!:]/}"
+	colon_count="${#colons_only}"
+	if [[ "$colon_count" -eq 2 ]]; then
+		IFS=':' read -r hours minutes seconds <<<"$elapsed"
+	elif [[ "$colon_count" -eq 1 ]]; then
+		IFS=':' read -r minutes seconds <<<"$elapsed"
+	else
+		seconds="$elapsed"
+	fi
+	[[ "$days" =~ ^[0-9]+$ ]] || return 1
+	[[ "$hours" =~ ^[0-9]+$ ]] || return 1
+	[[ "$minutes" =~ ^[0-9]+$ ]] || return 1
+	[[ "$seconds" =~ ^[0-9]+$ ]] || return 1
+	days=$((10#${days}))
+	hours=$((10#${hours}))
+	minutes=$((10#${minutes}))
+	seconds=$((10#${seconds}))
+	printf '%s\n' "$((days * 86400 + hours * 3600 + minutes * 60 + seconds))"
+	return 0
+}
+
+_clean_legacy_marker_matches_process_generation() {
+	local marker_path="$1"
+	local owner_pid="$2"
+	local marker_mtime=0
+	local now_epoch=0
+	local marker_age=0
+	local process_age=0
+
+	[[ -f "$marker_path" && "$owner_pid" =~ ^[0-9]+$ ]] || return 1
+	kill -0 "$owner_pid" 2>/dev/null || return 1
+	# Legacy markers contain only a PID. Compare ages so a process that started
+	# after the marker cannot inherit cleanup ownership through PID reuse.
+	# Missing timing evidence fails closed and preserves the worktree.
+	declare -F _file_mtime_epoch >/dev/null 2>&1 || return 0
+	marker_mtime=$(_file_mtime_epoch "$marker_path" 2>/dev/null) || return 0
+	process_age=$(_clean_process_age_seconds "$owner_pid" 2>/dev/null) || return 0
+	now_epoch=$(date +%s 2>/dev/null) || return 0
+	[[ "$marker_mtime" =~ ^[0-9]+$ && "$marker_mtime" -gt 0 ]] || return 0
+	[[ "$process_age" =~ ^[0-9]+$ ]] || return 0
+	[[ "$now_epoch" =~ ^[0-9]+$ && "$now_epoch" -ge "$marker_mtime" ]] || return 0
+	marker_age=$((now_epoch - marker_mtime))
+	if [[ $((process_age + _WT_CLEAN_MARKER_CLOCK_SKEW_SECONDS)) -ge "$marker_age" ]]; then
+		return 0
+	fi
+	return 1
+}
 
 _clean_deferred_parent_alive() {
 	local wt_path="$1"
@@ -78,7 +144,7 @@ _clean_deferred_parent_alive() {
 	local owner_pid=""
 	IFS= read -r owner_pid <"$marker_path" || true
 	_WT_CLEAN_DEFERRED_OWNER_PID="$owner_pid"
-	if [[ "$owner_pid" =~ ^[0-9]+$ ]] && kill -0 "$owner_pid" 2>/dev/null; then
+	if _clean_legacy_marker_matches_process_generation "$marker_path" "$owner_pid"; then
 		return 0
 	fi
 	rm -f "$marker_path" 2>/dev/null || true

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -132,10 +132,11 @@ _clean_deferred_parent_alive() {
 	fi
 	if [[ -n "$receipt_path" && -f "$receipt_path" ]]; then
 		_WT_CLEAN_DEFERRED_RECEIPT="$receipt_path"
-		_WT_CLEAN_DEFERRED_OWNER_PID=$(jq -r '.owner.pid // empty' "$receipt_path" 2>/dev/null || true)
 		if full_loop_cleanup_owner_alive "$receipt_path"; then
+			_WT_CLEAN_DEFERRED_OWNER_PID="${_FULL_LOOP_CLEANUP_OWNER_PID:-}"
 			return 0
 		fi
+		_WT_CLEAN_DEFERRED_OWNER_PID="${_FULL_LOOP_CLEANUP_OWNER_PID:-}"
 		rm -f "$marker_path" 2>/dev/null || true
 		return 2
 	fi
@@ -567,6 +568,162 @@ _clean_repo_slug() {
 	return 0
 }
 
+_clean_gh_graphql() {
+	command -v gh >/dev/null 2>&1 || return 1
+	gh api graphql "$@"
+	return $?
+}
+
+_clean_list_worktree_branches() {
+	local default_br="$1"
+	local porcelain=""
+	local line=""
+	local branch=""
+
+	porcelain=$(git worktree list --porcelain 2>/dev/null) || return 1
+	while IFS= read -r line; do
+		if [[ "$line" =~ ^branch\ refs/heads/(.+)$ ]]; then
+			branch="${BASH_REMATCH[1]}"
+			[[ "$branch" == "$default_br" ]] || printf '%s\n' "$branch"
+		fi
+	done <<<"$porcelain"
+	return 0
+}
+
+_clean_query_exact_merged_pr_batch() {
+	local owner="$1"
+	local repo_name="$2"
+	shift 2
+	[[ $# -gt 0 ]] || return 0
+
+	local query_vars="\$owner:String!,\$name:String!"
+	local query_fields=""
+	local query=""
+	local branch=""
+	local index=0
+	local -a graphql_args=(-f "owner=$owner" -f "name=$repo_name")
+
+	for branch in "$@"; do
+		query_vars="${query_vars},\$h${index}:String!"
+		query_fields="${query_fields} q${index}:pullRequests(first:1,states:MERGED,headRefName:\$h${index}){nodes{headRefName}}"
+		graphql_args+=(-f "h${index}=$branch")
+		index=$((index + 1))
+	done
+	query="query(${query_vars}){repository(owner:\$owner,name:\$name){${query_fields}}}"
+
+	_clean_gh_graphql -f "query=$query" "${graphql_args[@]}" \
+		--jq '(.data.repository // {}) | .[] | .nodes[]? | .headRefName'
+	return $?
+}
+
+# Prefetch exact merged-PR proof for every registered worktree branch. A single
+# GraphQL request can resolve many branch heads, avoiding one network round-trip
+# per worktree when the repository has more merged PRs than the summary list.
+_clean_build_exact_merged_pr_branches() {
+	local default_br="$1"
+	local repo_slug=""
+	local owner=""
+	local repo_name=""
+	local branches=""
+	local branch=""
+	local batch_size="${AIDEVOPS_WORKTREE_PR_BATCH_SIZE:-100}"
+	local -a batch=()
+
+	[[ "$batch_size" =~ ^[0-9]+$ ]] && [[ "$batch_size" -ge 1 ]] && [[ "$batch_size" -le 100 ]] || batch_size=100
+	repo_slug=$(_clean_repo_slug 2>/dev/null || true)
+	[[ "$repo_slug" == */* ]] || return 1
+	owner="${repo_slug%%/*}"
+	repo_name="${repo_slug#*/}"
+	branches=$(_clean_list_worktree_branches "$default_br") || return 1
+	[[ -n "$branches" ]] || return 0
+
+	while IFS= read -r branch; do
+		[[ -n "$branch" ]] || continue
+		batch+=("$branch")
+		if [[ "${#batch[@]}" -ge "$batch_size" ]]; then
+			_clean_query_exact_merged_pr_batch "$owner" "$repo_name" "${batch[@]}" || return 1
+			batch=()
+		fi
+	done <<<"$branches"
+	if [[ "${#batch[@]}" -gt 0 ]]; then
+		_clean_query_exact_merged_pr_batch "$owner" "$repo_name" "${batch[@]}" || return 1
+	fi
+	return 0
+}
+
+_clean_prepare_git_branch_caches() {
+	local default_br="$1"
+	local merged_branches=""
+	local upstream_lines=""
+	local remote_branches=""
+	local branch=""
+	local remote_name=""
+	local pushed_branches=""
+	local upstream_status=0
+	local remote_status=0
+
+	_WT_CLEAN_LOCAL_MERGED_BRANCHES=""
+	_WT_CLEAN_LOCAL_MERGED_CACHE_READY=false
+	_WT_CLEAN_PUSHED_BRANCHES=""
+	_WT_CLEAN_REMOTE_BRANCHES=""
+	_WT_CLEAN_REMOTE_BRANCH_CACHE_READY=false
+
+	if merged_branches=$(git branch --format='%(refname:short)' --merged "$default_br" 2>/dev/null); then
+		_WT_CLEAN_LOCAL_MERGED_BRANCHES="$merged_branches"
+		_WT_CLEAN_LOCAL_MERGED_CACHE_READY=true
+	fi
+
+	upstream_lines=$(git for-each-ref --format='%(refname:short)%09%(upstream:remotename)' refs/heads/ 2>/dev/null) || upstream_status=$?
+	remote_branches=$(git for-each-ref --format='%(refname:lstrip=3)' refs/remotes/ 2>/dev/null) || remote_status=$?
+	if [[ "$upstream_status" -eq 0 && "$remote_status" -eq 0 ]]; then
+		while IFS=$'\t' read -r branch remote_name; do
+			[[ -n "$branch" && -n "$remote_name" ]] || continue
+			pushed_branches="${pushed_branches}${pushed_branches:+$'\n'}${branch}"
+		done <<<"$upstream_lines"
+		if [[ -n "$remote_branches" ]]; then
+			pushed_branches="${pushed_branches}${pushed_branches:+$'\n'}${remote_branches}"
+		fi
+		_WT_CLEAN_PUSHED_BRANCHES="$pushed_branches"
+		_WT_CLEAN_REMOTE_BRANCHES="$remote_branches"
+		_WT_CLEAN_REMOTE_BRANCH_CACHE_READY=true
+	fi
+	return 0
+}
+
+_clean_branch_is_locally_merged() {
+	local wt_branch="$1"
+	local default_br="$2"
+	local merged_branches=""
+
+	if [[ "$_WT_CLEAN_LOCAL_MERGED_CACHE_READY" == "true" ]]; then
+		_clean_branch_list_contains_exact "$wt_branch" "$_WT_CLEAN_LOCAL_MERGED_BRANCHES"
+		return $?
+	fi
+	merged_branches=$(git branch --format='%(refname:short)' --merged "$default_br" 2>/dev/null) || return 1
+	_clean_branch_list_contains_exact "$wt_branch" "$merged_branches"
+	return $?
+}
+
+_clean_branch_was_pushed_cached() {
+	local wt_branch="$1"
+	if [[ "$_WT_CLEAN_REMOTE_BRANCH_CACHE_READY" == "true" ]]; then
+		_clean_branch_list_contains_exact "$wt_branch" "$_WT_CLEAN_PUSHED_BRANCHES"
+		return $?
+	fi
+	branch_was_pushed "$wt_branch"
+	return $?
+}
+
+_clean_branch_exists_on_remote_cached() {
+	local wt_branch="$1"
+	if [[ "$_WT_CLEAN_REMOTE_BRANCH_CACHE_READY" == "true" ]]; then
+		_clean_branch_list_contains_exact "$wt_branch" "$_WT_CLEAN_REMOTE_BRANCHES"
+		return $?
+	fi
+	_branch_exists_on_any_remote "$wt_branch"
+	return $?
+}
+
 _WT_CLEAN_PR_PROOF_UNKNOWN_REASONS=${_WT_CLEAN_PR_PROOF_UNKNOWN_REASONS:-}
 
 _clean_pr_proof_unknown_add() {
@@ -661,6 +818,9 @@ _clean_branch_has_exact_merged_pr() {
 	if _clean_branch_list_contains_exact "$wt_branch" "$merged_prs"; then
 		return 0
 	fi
+	if [[ "$_WT_CLEAN_EXACT_PR_PREFETCH_COMPLETE" == "true" ]]; then
+		return 1
+	fi
 	if ! command -v gh_pr_list &>/dev/null; then
 		return 1
 	fi
@@ -715,6 +875,12 @@ _clean_merge_type_has_terminal_pr_proof() {
 _WT_CLEAN_PROTECTED_PATHS="${_WT_CLEAN_PROTECTED_PATHS:-}"
 _WT_CLEAN_LAST_MERGE_TYPE="${_WT_CLEAN_LAST_MERGE_TYPE:-}"
 _WT_CLEAN_LAST_AUDIT_CONTEXT="${_WT_CLEAN_LAST_AUDIT_CONTEXT:-}"
+_WT_CLEAN_LOCAL_MERGED_BRANCHES="${_WT_CLEAN_LOCAL_MERGED_BRANCHES:-}"
+_WT_CLEAN_LOCAL_MERGED_CACHE_READY="${_WT_CLEAN_LOCAL_MERGED_CACHE_READY:-false}"
+_WT_CLEAN_PUSHED_BRANCHES="${_WT_CLEAN_PUSHED_BRANCHES:-}"
+_WT_CLEAN_REMOTE_BRANCHES="${_WT_CLEAN_REMOTE_BRANCHES:-}"
+_WT_CLEAN_REMOTE_BRANCH_CACHE_READY="${_WT_CLEAN_REMOTE_BRANCH_CACHE_READY:-false}"
+_WT_CLEAN_EXACT_PR_PREFETCH_COMPLETE="${_WT_CLEAN_EXACT_PR_PREFETCH_COMPLETE:-false}"
 _WT_CLEAN_TYPE_SQUASH_MERGED_PR="squash-merged PR"
 _WT_CLEAN_TYPE_CLOSED_PR="closed PR"
 _WT_CLEAN_PROOF_GH_MERGED_PR="github-merged-pr"
@@ -941,7 +1107,7 @@ _clean_select_merge_type() {
 	local merged_prs="$4"
 	local closed_prs="$5"
 
-	if git branch --merged "$default_br" 2>/dev/null | grep -q "^\s*$wt_branch$" &&
+	if _clean_branch_is_locally_merged "$wt_branch" "$default_br" &&
 		! branch_has_zero_commits_ahead "$wt_branch" "$default_br"; then
 		printf '%s\n' "merged"
 		return 0
@@ -954,7 +1120,7 @@ _clean_select_merge_type() {
 		printf '%s\n' "$_WT_CLEAN_TYPE_CLOSED_PR"
 		return 0
 	fi
-	if [[ "$remote_unknown" == "false" ]] && branch_was_pushed "$wt_branch" && ! _branch_exists_on_any_remote "$wt_branch"; then
+	if [[ "$remote_unknown" == "false" ]] && _clean_branch_was_pushed_cached "$wt_branch" && ! _clean_branch_exists_on_remote_cached "$wt_branch"; then
 		printf '%s\n' "remote deleted"
 		return 0
 	fi
@@ -1511,6 +1677,7 @@ cmd_clean() {
 
 	local default_branch
 	default_branch=$(get_default_branch)
+	_clean_prepare_git_branch_caches "$default_branch"
 
 	# Fetch to get current remote branch state (detects deleted branches)
 	# Prune all remotes, not just origin (GH#3797)
@@ -1523,6 +1690,16 @@ cmd_clean() {
 	local merged_pr_branches
 	if ! merged_pr_branches=$(_clean_build_merged_pr_branches); then
 		_clean_pr_proof_unknown_add "unknown:merged-pr-list-unavailable"
+	fi
+	_WT_CLEAN_EXACT_PR_PREFETCH_COMPLETE=false
+	local exact_merged_pr_branches=""
+	local exact_prefetch_status=0
+	exact_merged_pr_branches=$(_clean_build_exact_merged_pr_branches "$default_branch") || exact_prefetch_status=$?
+	if [[ -n "$exact_merged_pr_branches" ]]; then
+		merged_pr_branches="${merged_pr_branches}${merged_pr_branches:+$'\n'}${exact_merged_pr_branches}"
+	fi
+	if [[ "$exact_prefetch_status" -eq 0 ]]; then
+		_WT_CLEAN_EXACT_PR_PREFETCH_COMPLETE=true
 	fi
 
 	local open_pr_branches
@@ -1537,16 +1714,17 @@ cmd_clean() {
 		_clean_pr_proof_unknown_add "unknown:closed-pr-list-unavailable"
 	fi
 
-	# First pass: scan and display merged worktrees
-	if ! _clean_scan_merged "$default_branch" "$main_worktree_path" "$remote_state_unknown" "$merged_pr_branches" "$open_pr_branches" "$force_merged" "$closed_pr_branches"; then
-		echo -e "${GREEN}No merged worktrees to clean up${NC}" >&2
-		return 0
-	fi
-
 	local response="n"
 	if [[ "$auto_mode" == "true" ]]; then
+		# The removal pass performs the complete classification and every mutable
+		# safety check. Avoid a redundant preview pass when no user confirmation
+		# is possible; interactive cleanup retains the candidate preview.
 		response="y"
 	else
+		if ! _clean_scan_merged "$default_branch" "$main_worktree_path" "$remote_state_unknown" "$merged_pr_branches" "$open_pr_branches" "$force_merged" "$closed_pr_branches"; then
+			echo -e "${GREEN}No merged worktrees to clean up${NC}" >&2
+			return 0
+		fi
 		echo "" >&2
 		echo -e "${YELLOW}Remove these worktrees? [y/N]${NC}" >&2
 		read -r response


### PR DESCRIPTION
## Summary

Accelerate fail-closed automatic worktree cleanup by batching remote PR proof and caching repeated receipt, registry, and branch-classification work; ensure asynchronous cleanup wrappers terminate owned descendants and release singleton locks on signals.

## Files Changed

.agents/scripts/cleanup-remote-branches-async-helper.sh, .agents/scripts/cleanup-stashes-async-helper.sh, .agents/scripts/cleanup-worktrees-async-helper.sh, .agents/scripts/full-loop-cleanup-receipt.sh, .agents/scripts/opencode-db-archive-async-helper.sh, .agents/scripts/shared-worktree-registry.sh, .agents/scripts/tests/test-cleanup-worktrees-async.sh, .agents/scripts/tests/test-full-loop-cleanup-receipt.sh, .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh, .agents/scripts/tests/test-worktree-registry-session-claim.sh, .agents/scripts/worktree-clean-lib.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Runtime deployment reduced registered worktrees from 291 to 77 without deleting evidence-uncertain worktrees; ShellCheck passed; focused suites passed 11/11, 19/19, 24/24, and 12/12; git diff --check passed.

Resolves #29230


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 4h 15m and 3,002,458 tokens on this with the user in an interactive session.