### PR TITLE
GH#29119: Preserve releases through protected-main PRs

### DIFF
--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -25,6 +25,9 @@ _FULL_LOOP_RELEASE_STEP_QUEUE_POSTFLIGHT="Queue exact-tag postflight"
 _FULL_LOOP_RELEASE_PROVENANCE_PREDICATE="https://slsa.dev/provenance/v1"
 _FULL_LOOP_RELEASE_TRUE="true"
 
+# shellcheck source=./version-manager-protected-main.sh
+source "${SCRIPT_DIR}/version-manager-protected-main.sh"
+
 _full_loop_release_tag_body() {
 	local tag_name="$1"
 	git -C "$REPO_ROOT" for-each-ref --format='%(contents)' "refs/tags/${tag_name}"
@@ -811,6 +814,7 @@ _full_loop_release_existing_command() {
 	local tag_name=""
 	local latest_tag=""
 	local inspect_rc=0
+	local protected_tag_state_rc=0
 	local receipt_path=""
 	local receipt_status=""
 
@@ -851,6 +855,15 @@ _full_loop_release_existing_command() {
 		printf 'release:superseded source_tag=%s successor_tag=%s\n' "$tag_name" "$latest_tag"
 		return 0
 	fi
+	_version_manager_reconcile_protected_release_tag "$repo" "$tag_name" "$mode" || protected_tag_state_rc=$?
+	[[ "$protected_tag_state_rc" -eq 0 ]] || return 1
+	case "$_VERSION_MANAGER_PROTECTED_RELEASE_RESULT" in
+	pr-pending | tag-ready | tag-pushed)
+		return 8
+		;;
+	remote-tag-present) ;;
+	*) return 1 ;;
+	esac
 	_full_loop_release_inspect_remote "$repo" "$tag_name" || inspect_rc=$?
 	if [[ "$inspect_rc" -eq 0 ]]; then
 		if [[ "$mode" == "$_FULL_LOOP_RELEASE_MODE_RECONCILE" ]]; then

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -58,6 +58,15 @@ _PULSE_MERGE_PROCESS_LOADED=1
 : "${PULSE_MERGE_CHECKPOINT_FILE:=${HOME}/.aidevops/logs/pulse-merge-checkpoint}"
 : "${PULSE_MERGE_PR_CURSOR_FILE:=${PULSE_MERGE_CHECKPOINT_FILE}.pr-cursor}"
 
+_pmp_is_protected_release_pr() {
+	local head_ref="$1"
+	local labels_csv="$2"
+
+	[[ ",${labels_csv}," == *",release,"* ]] || return 1
+	[[ "$head_ref" =~ ^chore/release-v[0-9]+\.[0-9]+\.[0-9]+-provenance$ ]] || return 1
+	return 0
+}
+
 # Load the exact-output PR-list provider cache for standalone module tests and
 # direct routine sourcing. pulse-wrapper.sh also sources this before the merge
 # modules, so the include guard in pulse-pr-list-cache.sh keeps this idempotent.

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1319,6 +1319,10 @@ _process_single_ready_pr() {
 		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — draft PR not eligible for auto-merge (GH#23525)" >>"$LOGFILE"
 		return 1
 	fi
+	if _pmp_is_protected_release_pr "$pr_head_ref_name" "$pr_labels"; then
+		echo "[pulse-wrapper] Merge pass: deferring protected release PR #${pr_number} in ${repo_slug} to provenance-preserving exact-merge reconciliation" >>"$LOGFILE"
+		return 4
+	fi
 
 	# REST-first PR lists cannot preserve GraphQL-only mergeable state, so a
 	# truly conflicting PR may enter this function as UNKNOWN. Refresh that

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -858,6 +858,14 @@ _full_loop_release_finalize_reconciliation() {
 	printf '%s %s %s\n' "$repo" "$pr_number" "$tag_name" >"${TEST_ROOT}/finalize.log"
 	return 0
 }
+_version_manager_reconcile_protected_release_tag() {
+	local repo="$1"
+	local tag_name="$2"
+	local mode="$3"
+	[[ -n "$repo" && -n "$tag_name" && ("$mode" == "status" || "$mode" == "reconcile") ]] || return 1
+	_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="remote-tag-present"
+	return 0
+}
 _full_loop_release_finalize_stale_supersession() {
 	local repo="$1"
 	local pr_number="$2"

--- a/.agents/scripts/tests/test-pulse-merge-native-auto.sh
+++ b/.agents/scripts/tests/test-pulse-merge-native-auto.sh
@@ -794,6 +794,22 @@ test_external_auto_merge_disable_failure_applies_draft_hold() {
 	return 0
 }
 
+test_protected_release_pr_uses_exact_merge_owner() {
+	# shellcheck source=../pulse-merge-process.sh
+	source "$PROCESS_SCRIPT"
+	if _pmp_is_protected_release_pr \
+		"chore/release-v1.2.3-provenance" "origin:worker,release,status:in-review" &&
+		! _pmp_is_protected_release_pr \
+			"chore/release-v1.2.3-provenance" "origin:worker,status:in-review" &&
+		! _pmp_is_protected_release_pr \
+			"feature/release-lookalike" "origin:worker,release,status:in-review"; then
+		print_result "Protected release PRs remain owned by exact-merge reconciliation" 0
+	else
+		print_result "Protected release PRs remain owned by exact-merge reconciliation" 1
+	fi
+	return 0
+}
+
 main() {
 	test_case_a_pending_ci_sets_auto_merge
 	test_case_a_missing_head_does_not_set_auto_merge
@@ -812,6 +828,7 @@ main() {
 	test_external_pending_ci_never_sets_deferred_auto_merge
 	test_external_existing_auto_merge_is_disabled
 	test_external_auto_merge_disable_failure_applies_draft_hold
+	test_protected_release_pr_uses_exact_merge_owner
 
 	printf '\n=================================\n'
 	printf 'Tests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-version-manager-protected-main-fallback.sh
+++ b/.agents/scripts/tests/test-version-manager-protected-main-fallback.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Verify a protected-main rejection preserves immutable release provenance
+# through an exact-head merge PR and idempotent tag reconciliation.
+
+set -euo pipefail
+
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_NOSYSTEM=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+REAL_GIT=$(command -p -v git 2>/dev/null || command -v git)
+REMOTE="${TEST_ROOT}/remote.git"
+REPO="${TEST_ROOT}/release"
+CONCURRENT="${TEST_ROOT}/concurrent"
+MERGER="${TEST_ROOT}/merger"
+BIN="${TEST_ROOT}/bin"
+mkdir -p "$BIN"
+
+"$REAL_GIT" init -q --bare "$REMOTE"
+"$REAL_GIT" clone -q "$REMOTE" "$REPO"
+"$REAL_GIT" -C "$REPO" switch -q -c main
+"$REAL_GIT" -C "$REPO" config user.name Test
+"$REAL_GIT" -C "$REPO" config user.email test@example.invalid
+"$REAL_GIT" -C "$REPO" config commit.gpgsign false
+printf 'seed\n' >"${REPO}/fixture.txt"
+"$REAL_GIT" -C "$REPO" add fixture.txt
+"$REAL_GIT" -C "$REPO" commit -q -m seed
+"$REAL_GIT" -C "$REPO" push -q -u origin main
+"$REAL_GIT" --git-dir="$REMOTE" symbolic-ref HEAD refs/heads/main
+
+printf '1.2.3\n' >"${REPO}/VERSION"
+"$REAL_GIT" -C "$REPO" add VERSION
+"$REAL_GIT" -C "$REPO" commit -q -m 'chore(release): bump version to 1.2.3'
+"$REAL_GIT" -C "$REPO" tag -a v1.2.3 -m 'Release v1.2.3 fixture'
+RELEASE_COMMIT=$("$REAL_GIT" -C "$REPO" rev-parse HEAD)
+TAG_OBJECT=$("$REAL_GIT" -C "$REPO" rev-parse refs/tags/v1.2.3)
+
+"$REAL_GIT" clone -q "$REMOTE" "$CONCURRENT"
+"$REAL_GIT" -C "$CONCURRENT" config user.name Test
+"$REAL_GIT" -C "$CONCURRENT" config user.email test@example.invalid
+printf 'concurrent\n' >"${CONCURRENT}/concurrent.txt"
+"$REAL_GIT" -C "$CONCURRENT" add concurrent.txt
+"$REAL_GIT" -C "$CONCURRENT" commit -q -m 'concurrent main update'
+"$REAL_GIT" -C "$CONCURRENT" push -q origin main
+CURRENT_MAIN=$("$REAL_GIT" -C "$CONCURRENT" rev-parse HEAD)
+
+cat >"${BIN}/git" <<'STUB'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >>"${FAKE_GIT_LOG:?}"
+args=" $* "
+if [[ "$args" == *" push --atomic origin HEAD:refs/heads/main --tags "* ]]; then
+	count=0
+	if [[ -f "${DIRECT_PUSH_COUNT:?}" ]]; then
+		IFS= read -r count <"$DIRECT_PUSH_COUNT"
+	fi
+	printf '%s\n' "$((count + 1))" >"$DIRECT_PUSH_COUNT"
+	printf '%s\n' \
+		'remote: error: GH006: Protected branch update failed for refs/heads/main.' \
+		'remote: error: Changes must be made through a pull request.' \
+		'remote: error: 4 of 4 required status checks are expected.' >&2
+	exit 1
+fi
+exec "${REAL_GIT:?}" "$@"
+STUB
+chmod +x "${BIN}/git"
+
+cat >"${BIN}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >>"${FAKE_GH_LOG:?}"
+if [[ "${1:-}" == "api" && " $* " == *" repos/test/repo/pulls "* ]]; then
+	if [[ ! -f "${PR_CREATED_FILE:?}" ]]; then
+		printf '[]\n'
+		exit 0
+	fi
+	branch_sha=$("${REAL_GIT:?}" ls-remote "${REMOTE:?}" \
+		'refs/heads/chore/release-v1.2.3-provenance' | cut -f1)
+	auto_merge=null
+	[[ ! -f "${AUTO_MERGE_FILE:?}" ]] || auto_merge='{"merge_method":"merge"}'
+	body="<!-- aidevops:release-provenance tag=v1.2.3 tag-object=${TAG_OBJECT:?} release-commit=${RELEASE_COMMIT:?} merge-method=merge -->"
+	jq -nc --arg branch_sha "$branch_sha" --arg body "$body" \
+		--argjson auto_merge "$auto_merge" '[{
+			number: 77,
+			state: "open",
+			merged_at: null,
+			draft: false,
+			auto_merge: $auto_merge,
+			author_association: "OWNER",
+			user: {login: "test-owner"},
+			body: $body,
+			head: {ref: "chore/release-v1.2.3-provenance", sha: $branch_sha, repo: {full_name: "test/repo"}},
+			base: {ref: "main", repo: {full_name: "test/repo"}}
+		}]'
+	exit 0
+fi
+if [[ "${1:-}" == "pr" && "${2:-}" == "create" ]]; then
+	: >"${PR_CREATED_FILE:?}"
+	printf 'created\n'
+	exit 0
+fi
+if [[ "${1:-}" == "pr" && "${2:-}" == "merge" ]]; then
+	: >"${AUTO_MERGE_FILE:?}"
+	exit 0
+fi
+if [[ "${1:-}" == "pr" && "${2:-}" == "ready" ]]; then
+	exit 0
+fi
+exit 1
+STUB
+chmod +x "${BIN}/gh"
+
+export REAL_GIT REMOTE RELEASE_COMMIT TAG_OBJECT
+export FAKE_GIT_LOG="${TEST_ROOT}/git.log"
+export FAKE_GH_LOG="${TEST_ROOT}/gh.log"
+export DIRECT_PUSH_COUNT="${TEST_ROOT}/direct-push-count"
+export PR_CREATED_FILE="${TEST_ROOT}/pr-created"
+export AUTO_MERGE_FILE="${TEST_ROOT}/auto-merge"
+export PATH="${BIN}:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export AIDEVOPS_VERSION_MANAGER_REPO_SLUG=test/repo
+
+print_error() {
+	printf 'ERROR %s\n' "$*"
+	return 0
+}
+print_info() {
+	printf 'INFO %s\n' "$*"
+	return 0
+}
+print_warning() {
+	printf 'WARNING %s\n' "$*"
+	return 0
+}
+print_success() {
+	printf 'SUCCESS %s\n' "$*"
+	return 0
+}
+
+export REPO_ROOT="$REPO"
+# shellcheck source=../version-manager-git.sh
+source "${SCRIPT_DIR}/version-manager-git.sh"
+
+push_rc=0
+push_output=$(push_changes 1.2.3 2>&1) || push_rc=$?
+if [[ "$push_rc" -ne 8 ]]; then
+	printf 'FAIL protected-main fallback returned rc=%s: %s\n' "$push_rc" "$push_output"
+	exit 1
+fi
+[[ "$(<"$DIRECT_PUSH_COUNT")" == "1" ]]
+[[ "$push_output" == *'GH006 Changes must be made through a pull request'* ]]
+printf 'PASS permanent PR-required rejection stops after one direct push\n'
+
+RECOVERY_BRANCH='chore/release-v1.2.3-provenance'
+RECOVERY_HEAD=$("$REAL_GIT" ls-remote "$REMOTE" "refs/heads/${RECOVERY_BRANCH}" | cut -f1)
+[[ "$RECOVERY_HEAD" =~ ^[0-9a-f]{40}$ ]]
+[[ "$("$REAL_GIT" -C "$REPO" rev-parse "${RECOVERY_HEAD}^1")" == "$CURRENT_MAIN" ]]
+[[ "$("$REAL_GIT" -C "$REPO" rev-parse "${RECOVERY_HEAD}^2")" == "$RELEASE_COMMIT" ]]
+"$REAL_GIT" -C "$REPO" merge-base --is-ancestor "$RELEASE_COMMIT" "$RECOVERY_HEAD"
+[[ "$("$REAL_GIT" -C "$REPO" rev-parse refs/tags/v1.2.3)" == "$TAG_OBJECT" ]]
+[[ -z "$("$REAL_GIT" ls-remote --tags "$REMOTE" refs/tags/v1.2.3)" ]]
+if grep -Eq ' rebase | commit --amend| tag -(d|s) ' "$FAKE_GIT_LOG"; then
+	printf 'FAIL recovery rewrote the release commit or tag\n'
+	exit 1
+fi
+printf 'PASS recovery branch preserves the original release commit and tag object\n'
+
+grep -q '^pr create .*--head chore/release-v1.2.3-provenance .*--base main ' "$FAKE_GH_LOG"
+grep -q "^pr merge 77 --repo test/repo --auto --merge --match-head-commit ${RECOVERY_HEAD}$" "$FAKE_GH_LOG"
+printf 'PASS recovery queues merge topology against the exact PR head\n'
+
+printf 'unreviewed descendant\n' >"${REPO}/unsafe.txt"
+"$REAL_GIT" -C "$REPO" add unsafe.txt
+"$REAL_GIT" -C "$REPO" commit -q -m 'unreviewed recovery descendant'
+UNSAFE_HEAD=$("$REAL_GIT" -C "$REPO" rev-parse HEAD)
+"$REAL_GIT" -C "$REPO" push -q origin "${UNSAFE_HEAD}:refs/heads/fixture-unsafe"
+"$REAL_GIT" --git-dir="$REMOTE" update-ref "refs/heads/${RECOVERY_BRANCH}" "$UNSAFE_HEAD"
+"$REAL_GIT" --git-dir="$REMOTE" update-ref -d refs/heads/fixture-unsafe
+merge_calls_before=$(grep -c '^pr merge ' "$FAKE_GH_LOG")
+unsafe_rc=0
+unsafe_output=$(_version_manager_queue_protected_main_release 1.2.3 2>&1) || unsafe_rc=$?
+merge_calls_after=$(grep -c '^pr merge ' "$FAKE_GH_LOG")
+[[ "$unsafe_rc" -ne 0 ]]
+[[ "$unsafe_output" == *'outside the required merge topology'* ]]
+[[ "$merge_calls_after" -eq "$merge_calls_before" ]]
+"$REAL_GIT" --git-dir="$REMOTE" update-ref "refs/heads/${RECOVERY_BRANCH}" "$RECOVERY_HEAD"
+"$REAL_GIT" -C "$REPO" update-ref "refs/remotes/origin/${RECOVERY_BRANCH}" "$RECOVERY_HEAD"
+"$REAL_GIT" -C "$REPO" checkout -q --detach "$RECOVERY_HEAD"
+printf 'PASS incompatible recovery descendants fail closed before merge queueing\n'
+
+_version_manager_reconcile_protected_release_tag test/repo v1.2.3 status >/dev/null
+[[ "$_VERSION_MANAGER_PROTECTED_RELEASE_RESULT" == "pr-pending" ]]
+[[ -z "$("$REAL_GIT" ls-remote --tags "$REMOTE" refs/tags/v1.2.3)" ]]
+printf 'PASS final tag publication remains blocked while the recovery PR is open\n'
+
+"$REAL_GIT" clone -q "$REMOTE" "$MERGER"
+"$REAL_GIT" -C "$MERGER" config user.name Test
+"$REAL_GIT" -C "$MERGER" config user.email test@example.invalid
+"$REAL_GIT" -C "$MERGER" merge -q --no-ff --no-edit "origin/${RECOVERY_BRANCH}"
+"$REAL_GIT" -C "$MERGER" push -q origin main
+
+_version_manager_reconcile_protected_release_tag test/repo v1.2.3 reconcile >/dev/null
+[[ "$_VERSION_MANAGER_PROTECTED_RELEASE_RESULT" == "tag-pushed" ]]
+REMOTE_TAG_OBJECT=$("$REAL_GIT" ls-remote --tags "$REMOTE" refs/tags/v1.2.3 | cut -f1)
+REMOTE_TAG_COMMIT=$("$REAL_GIT" ls-remote --tags "$REMOTE" 'refs/tags/v1.2.3^{}' | cut -f1)
+[[ "$REMOTE_TAG_OBJECT" == "$TAG_OBJECT" ]]
+[[ "$REMOTE_TAG_COMMIT" == "$RELEASE_COMMIT" ]]
+"$REAL_GIT" -C "$REPO" fetch -q origin main --tags
+"$REAL_GIT" -C "$REPO" merge-base --is-ancestor "$RELEASE_COMMIT" origin/main
+[[ "$("$REAL_GIT" -C "$REPO" rev-list --count --grep='^chore(release): bump version to 1.2.3$' origin/main)" == "1" ]]
+printf 'PASS merged recovery publishes the original tag object without a second bump\n'
+
+tag_pushes_before=$(grep -c 'push origin refs/tags/v1.2.3:refs/tags/v1.2.3' "$FAKE_GIT_LOG")
+_version_manager_reconcile_protected_release_tag test/repo v1.2.3 reconcile >/dev/null
+tag_pushes_after=$(grep -c 'push origin refs/tags/v1.2.3:refs/tags/v1.2.3' "$FAKE_GIT_LOG")
+[[ "$tag_pushes_after" -eq "$tag_pushes_before" ]]
+[[ "$_VERSION_MANAGER_PROTECTED_RELEASE_RESULT" == "remote-tag-present" ]]
+printf 'PASS repeated reconciliation is idempotent\n'
+
+exit 0

--- a/.agents/scripts/version-manager-git.sh
+++ b/.agents/scripts/version-manager-git.sh
@@ -40,6 +40,8 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 fi
 # shellcheck source=./task-identity-lib.sh
 source "${SCRIPT_DIR}/task-identity-lib.sh"
+# shellcheck source=./version-manager-protected-main.sh
+source "${SCRIPT_DIR}/version-manager-protected-main.sh"
 
 # Exit code 2 used by commit_version_changes to distinguish "nothing staged"
 # from "commit succeeded" (0). Callers that expect a new bump commit on HEAD
@@ -583,6 +585,7 @@ push_changes() {
 	local version="$1" # version string, e.g. "3.8.71"
 	local tag_name="v$version"
 	local release_parent=""
+	local push_output=""
 	cd "$REPO_ROOT" || exit 1
 	release_parent=$(git rev-parse HEAD^ 2>/dev/null) || {
 		print_error "Cannot resolve release source parent"
@@ -594,10 +597,27 @@ push_changes() {
 		attempt=$((attempt + 1))
 		print_info "Pushing changes to remote (attempt $attempt/$max_attempts)..."
 
-		# Use --atomic to ensure commit and tag are pushed together (all-or-nothing)
-		if git push --atomic origin HEAD:refs/heads/main --tags 2>/dev/null; then
+		# Use --atomic to ensure commit and tag are pushed together (all-or-nothing).
+		# Capture stderr so permanent branch-policy rejection is classified after
+		# one attempt rather than retried as transient contention.
+		if push_output=$(git push --atomic origin HEAD:refs/heads/main --tags 2>&1); then
 			print_success "Pushed changes and tags to remote"
 			return 0
+		fi
+		if _version_manager_push_requires_pr "$push_output"; then
+			print_error "Direct release push rejected: GH006 Changes must be made through a pull request"
+			if _version_manager_queue_protected_main_release "$version"; then
+				case "$_VERSION_MANAGER_PROTECTED_RELEASE_RESULT" in
+				remote-tag-present | tag-pushed)
+					print_success "Published preserved ${tag_name} after protected main became reachable"
+					return 0
+					;;
+				esac
+				print_success "release:queued protected-pr=${_VERSION_MANAGER_PROTECTED_PR_NUMBER:-unknown}"
+				return 8
+			fi
+			print_error "Protected-main release recovery could not create a safe PR state"
+			return 1
 		fi
 
 		# A release tag's signed provenance binds the bump commit directly to its

--- a/.agents/scripts/version-manager-protected-main.sh
+++ b/.agents/scripts/version-manager-protected-main.sh
@@ -1,0 +1,641 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# shellcheck disable=SC2016 # Markdown backticks in printf format strings are literal.
+# Protected-main release recovery shared by version-manager publication and
+# full-loop reconciliation.
+
+[[ -n "${_VERSION_MANAGER_PROTECTED_MAIN_LOADED:-}" ]] && return 0
+_VERSION_MANAGER_PROTECTED_MAIN_LOADED=1
+
+if [[ -z "${SCRIPT_DIR:-}" ]]; then
+	_vm_protected_lib_path="${BASH_SOURCE[0]%/*}"
+	[[ "$_vm_protected_lib_path" == "${BASH_SOURCE[0]}" ]] && _vm_protected_lib_path="."
+	SCRIPT_DIR="$(cd "$_vm_protected_lib_path" && pwd)"
+	unset _vm_protected_lib_path
+fi
+if ! declare -F print_error >/dev/null 2>&1; then
+	# shellcheck source=./shared-constants.sh
+	source "${SCRIPT_DIR}/shared-constants.sh"
+fi
+
+_VERSION_MANAGER_PROTECTED_PR_JSON=""
+_VERSION_MANAGER_PROTECTED_PR_NUMBER=""
+_VERSION_MANAGER_PROTECTED_RELEASE_BRANCH=""
+_VERSION_MANAGER_PROTECTED_RELEASE_HEAD=""
+_VERSION_MANAGER_PROTECTED_RELEASE_RESULT=""
+_VERSION_MANAGER_LOCAL_TAG_OBJECT=""
+_VERSION_MANAGER_LOCAL_TAG_COMMIT=""
+_VERSION_MANAGER_REMOTE_TAG_OBJECT=""
+_VERSION_MANAGER_REMOTE_TAG_COMMIT=""
+_VERSION_MANAGER_REMOTE_TAG_STATE=""
+_VERSION_MANAGER_TAG_STATE_ABSENT="absent"
+_VERSION_MANAGER_TAG_STATE_MATCHING="matching"
+_VERSION_MANAGER_RELEASE_RESULT_QUEUED="queued"
+_VERSION_MANAGER_MODE_RECONCILE="reconcile"
+
+_version_manager_push_requires_pr() {
+	local push_output="$1"
+
+	case "$push_output" in
+	*"Changes must be made through a pull request"*)
+		case "$push_output" in
+		*"GH006"* | *"GH013"* | *"protected branch hook declined"*) return 0 ;;
+		esac
+		;;
+	esac
+	return 1
+}
+
+_version_manager_protected_release_branch_name() {
+	local version="$1"
+
+	[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+	printf 'chore/release-v%s-provenance\n' "$version"
+	return 0
+}
+
+_version_manager_protected_repo_slug() {
+	local repo="${AIDEVOPS_VERSION_MANAGER_REPO_SLUG:-}"
+
+	if [[ -z "$repo" ]] && declare -F _release_repo_slug >/dev/null 2>&1; then
+		repo=$(_release_repo_slug 2>/dev/null || true)
+	fi
+	[[ "$repo" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || return 1
+	printf '%s\n' "$repo"
+	return 0
+}
+
+_version_manager_local_tag_identity() {
+	local tag_name="$1"
+	local object_type=""
+	local tag_ref="refs/tags/${tag_name}"
+
+	_VERSION_MANAGER_LOCAL_TAG_OBJECT=""
+	_VERSION_MANAGER_LOCAL_TAG_COMMIT=""
+	_VERSION_MANAGER_LOCAL_TAG_OBJECT=$(git -C "$REPO_ROOT" rev-parse "$tag_ref" 2>/dev/null) || return 1
+	_VERSION_MANAGER_LOCAL_TAG_COMMIT=$(git -C "$REPO_ROOT" rev-parse "${tag_ref}^{commit}" 2>/dev/null) || return 1
+	object_type=$(git -C "$REPO_ROOT" cat-file -t "$_VERSION_MANAGER_LOCAL_TAG_OBJECT" 2>/dev/null) || return 1
+	if [[ "$object_type" != "tag" ]]; then
+		print_error "Protected release recovery requires the original annotated tag object for ${tag_name}"
+		return 1
+	fi
+	return 0
+}
+
+_version_manager_remote_tag_identity() {
+	local tag_name="$1"
+	local refs_output=""
+	local object_id=""
+	local ref_name=""
+	local tag_ref="refs/tags/${tag_name}"
+
+	_VERSION_MANAGER_REMOTE_TAG_OBJECT=""
+	_VERSION_MANAGER_REMOTE_TAG_COMMIT=""
+	_VERSION_MANAGER_REMOTE_TAG_STATE="$_VERSION_MANAGER_TAG_STATE_ABSENT"
+	refs_output=$(git -C "$REPO_ROOT" ls-remote --tags origin \
+		"$tag_ref" "${tag_ref}^{}" 2>/dev/null) || return 1
+	while IFS=$'\t' read -r object_id ref_name; do
+		case "$ref_name" in
+		"$tag_ref") _VERSION_MANAGER_REMOTE_TAG_OBJECT="$object_id" ;;
+		"${tag_ref}^{}") _VERSION_MANAGER_REMOTE_TAG_COMMIT="$object_id" ;;
+		esac
+	done <<<"$refs_output"
+	if [[ -z "$_VERSION_MANAGER_REMOTE_TAG_OBJECT" ]]; then
+		return 0
+	fi
+	_VERSION_MANAGER_REMOTE_TAG_STATE="present"
+	[[ -n "$_VERSION_MANAGER_REMOTE_TAG_COMMIT" ]] || \
+		_VERSION_MANAGER_REMOTE_TAG_COMMIT="$_VERSION_MANAGER_REMOTE_TAG_OBJECT"
+	return 0
+}
+
+_version_manager_classify_remote_tag() {
+	local tag_name="$1"
+
+	_VERSION_MANAGER_REMOTE_TAG_STATE=""
+	_version_manager_local_tag_identity "$tag_name" || return 1
+	_version_manager_remote_tag_identity "$tag_name" || return 1
+	if [[ "$_VERSION_MANAGER_REMOTE_TAG_STATE" == "$_VERSION_MANAGER_TAG_STATE_ABSENT" ]]; then
+		return 0
+	fi
+	if [[ "$_VERSION_MANAGER_REMOTE_TAG_OBJECT" == "$_VERSION_MANAGER_LOCAL_TAG_OBJECT" &&
+		"$_VERSION_MANAGER_REMOTE_TAG_COMMIT" == "$_VERSION_MANAGER_LOCAL_TAG_COMMIT" ]]; then
+		_VERSION_MANAGER_REMOTE_TAG_STATE="$_VERSION_MANAGER_TAG_STATE_MATCHING"
+		return 0
+	fi
+	_VERSION_MANAGER_REMOTE_TAG_STATE="mismatch"
+	print_error "Remote ${tag_name} does not match the preserved local tag object"
+	return 1
+}
+
+_version_manager_remote_branch_head() {
+	local branch_name="$1"
+	local branch_line=""
+	local branch_sha=""
+	local branch_ref=""
+
+	_VERSION_MANAGER_PROTECTED_RELEASE_HEAD=""
+	branch_line=$(git -C "$REPO_ROOT" ls-remote --heads origin "refs/heads/${branch_name}" 2>/dev/null) || return 1
+	[[ -n "$branch_line" ]] || return 0
+	IFS=$'\t' read -r branch_sha branch_ref <<<"$branch_line"
+	[[ "$branch_ref" == "refs/heads/${branch_name}" && "$branch_sha" =~ ^[0-9a-f]{40}$ ]] || return 1
+	_VERSION_MANAGER_PROTECTED_RELEASE_HEAD="$branch_sha"
+	return 0
+}
+
+_version_manager_fetch_recovery_branch() {
+	local branch_name="$1"
+
+	if ! git -C "$REPO_ROOT" fetch origin \
+		"refs/heads/${branch_name}:refs/remotes/origin/${branch_name}" --quiet; then
+		return 1
+	fi
+	return 0
+}
+
+_version_manager_verify_recovery_head() {
+	local recovery_head="$1"
+	local release_commit="$2"
+	local release_parent="$3"
+	local current_main="$4"
+	local parent_line=""
+	local first_parent=""
+	local second_parent=""
+	local -a commit_and_parents=()
+
+	[[ "$recovery_head" =~ ^[0-9a-f]{40}$ ]] || return 1
+	if [[ "$recovery_head" == "$release_commit" ]]; then
+		return 0
+	fi
+	parent_line=$(git -C "$REPO_ROOT" rev-list --parents -n 1 "$recovery_head" 2>/dev/null) || return 1
+	read -r -a commit_and_parents <<<"$parent_line"
+	if [[ "${#commit_and_parents[@]}" -ne 3 ]]; then
+		print_error "Protected release recovery head contains commits outside the required merge topology"
+		return 1
+	fi
+	first_parent="${commit_and_parents[1]}"
+	second_parent="${commit_and_parents[2]}"
+	if [[ "$second_parent" != "$release_commit" ]] ||
+		! git -C "$REPO_ROOT" merge-base --is-ancestor "$release_parent" "$first_parent" ||
+		! git -C "$REPO_ROOT" merge-base --is-ancestor "$first_parent" "$current_main"; then
+		print_error "Protected release recovery head does not preserve the exact release/main parent topology"
+		return 1
+	fi
+	return 0
+}
+
+_version_manager_find_protected_release_pr() {
+	local repo="$1"
+	local branch_name="$2"
+	local owner="${repo%%/*}"
+	local pulls_json=""
+
+	_VERSION_MANAGER_PROTECTED_PR_JSON=""
+	_VERSION_MANAGER_PROTECTED_PR_NUMBER=""
+	pulls_json=$(gh api --method GET "repos/${repo}/pulls" \
+		-f "head=${owner}:${branch_name}" -f state=all -F per_page=10 2>/dev/null) || return 1
+	_VERSION_MANAGER_PROTECTED_PR_JSON=$(jq -c --arg branch "$branch_name" '
+		[.[] | select(.head.ref == $branch and .base.ref == "main")]
+		| sort_by(.number) | last // empty
+	' <<<"$pulls_json") || return 1
+	[[ -n "$_VERSION_MANAGER_PROTECTED_PR_JSON" ]] || return 0
+	_VERSION_MANAGER_PROTECTED_PR_NUMBER=$(jq -er '.number' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
+	return 0
+}
+
+_version_manager_verify_protected_pr_head() {
+	local expected_head="$1"
+	local actual_head=""
+	local base_ref=""
+
+	[[ -n "$_VERSION_MANAGER_PROTECTED_PR_JSON" ]] || return 1
+	actual_head=$(jq -r '.head.sha // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
+	base_ref=$(jq -r '.base.ref // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
+	if [[ "$actual_head" != "$expected_head" || "$base_ref" != "main" ]]; then
+		print_error "Protected release PR head/base does not match the preserved recovery branch"
+		return 1
+	fi
+	return 0
+}
+
+_version_manager_verify_protected_pr_identity() {
+	local repo="$1"
+	local branch_name="$2"
+	local version="$3"
+	local tag_object="$4"
+	local release_commit="$5"
+	local head_repo=""
+	local base_repo=""
+	local author_association=""
+	local body=""
+	local provenance_marker=""
+
+	[[ -n "$_VERSION_MANAGER_PROTECTED_PR_JSON" ]] || return 1
+	head_repo=$(jq -r '.head.repo.full_name // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
+	base_repo=$(jq -r '.base.repo.full_name // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
+	author_association=$(jq -r '.author_association // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
+	body=$(jq -r '.body // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
+	if [[ "$head_repo" != "$repo" || "$base_repo" != "$repo" ||
+		"$(jq -r '.head.ref // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON")" != "$branch_name" ]]; then
+		print_error "Protected release PR does not belong to the expected repository branch"
+		return 1
+	fi
+	#aidevops:trust-boundary — exact-head auto-merge is allowed only for a
+	# collaborator-authored same-repository PR carrying immutable provenance.
+	case "$author_association" in
+	OWNER | MEMBER | COLLABORATOR) ;;
+	*)
+		print_error "Protected release PR author is not a trusted repository collaborator"
+		return 1
+		;;
+	esac
+	provenance_marker="<!-- aidevops:release-provenance tag=v${version} tag-object=${tag_object} release-commit=${release_commit} merge-method=merge -->"
+	case "$body" in
+	*"$provenance_marker"*) ;;
+	*)
+		print_error "Protected release PR lacks matching immutable provenance metadata"
+		return 1
+		;;
+	esac
+	return 0
+}
+
+_version_manager_prepare_protected_release_head() {
+	local version="$1"
+	local release_commit="$2"
+	local release_parent="$3"
+	local branch_name="$4"
+	local push_output=""
+
+	git -C "$REPO_ROOT" fetch origin main --quiet || return 1
+	if ! git -C "$REPO_ROOT" merge-base --is-ancestor "$release_parent" origin/main; then
+		print_error "Protected release recovery refused rewritten main provenance"
+		return 1
+	fi
+
+	_version_manager_remote_branch_head "$branch_name" || return 1
+	if [[ -n "$_VERSION_MANAGER_PROTECTED_RELEASE_HEAD" ]]; then
+		_version_manager_fetch_recovery_branch "$branch_name" || return 1
+		if _version_manager_verify_recovery_head \
+			"$_VERSION_MANAGER_PROTECTED_RELEASE_HEAD" "$release_commit" \
+			"$release_parent" "$(git -C "$REPO_ROOT" rev-parse origin/main)"; then
+			return 0
+		fi
+		print_error "Existing protected release branch has incompatible provenance"
+		return 1
+	fi
+
+	if git -C "$REPO_ROOT" merge-base --is-ancestor "$release_commit" origin/main; then
+		_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="main-reachable"
+		_VERSION_MANAGER_PROTECTED_RELEASE_HEAD=$(git -C "$REPO_ROOT" rev-parse origin/main) || return 1
+		return 0
+	fi
+
+	if git -C "$REPO_ROOT" merge-base --is-ancestor origin/main "$release_commit"; then
+		git -C "$REPO_ROOT" checkout --detach --quiet "$release_commit" || return 1
+	else
+		git -C "$REPO_ROOT" checkout --detach --quiet origin/main || return 1
+		if ! git -C "$REPO_ROOT" -c commit.gpgsign=false merge --no-ff --no-edit \
+			-m "chore(release): preserve signed v${version} commit" "$release_commit"; then
+			git -C "$REPO_ROOT" merge --abort >/dev/null 2>&1 || true
+			git -C "$REPO_ROOT" checkout --detach --quiet "$release_commit" || true
+			print_error "Protected release commit conflicts with current origin/main"
+			return 1
+		fi
+	fi
+
+	_VERSION_MANAGER_PROTECTED_RELEASE_HEAD=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null) || return 1
+	if ! git -C "$REPO_ROOT" merge-base --is-ancestor "$release_commit" \
+		"$_VERSION_MANAGER_PROTECTED_RELEASE_HEAD" ||
+		! git -C "$REPO_ROOT" merge-base --is-ancestor origin/main \
+		"$_VERSION_MANAGER_PROTECTED_RELEASE_HEAD"; then
+		print_error "Protected release branch does not retain both required parents"
+		return 1
+	fi
+
+	if push_output=$(git -C "$REPO_ROOT" push origin \
+		"${_VERSION_MANAGER_PROTECTED_RELEASE_HEAD}:refs/heads/${branch_name}" 2>&1); then
+		return 0
+	fi
+	# A concurrent creator may have won the branch race. Reuse only an exact,
+	# provenance-preserving remote head; never force-update release recovery.
+	_version_manager_remote_branch_head "$branch_name" || return 1
+	if [[ -n "$_VERSION_MANAGER_PROTECTED_RELEASE_HEAD" ]]; then
+		_version_manager_fetch_recovery_branch "$branch_name" || return 1
+		if _version_manager_verify_recovery_head \
+			"$_VERSION_MANAGER_PROTECTED_RELEASE_HEAD" "$release_commit" \
+			"$release_parent" "$(git -C "$REPO_ROOT" rev-parse origin/main)"; then
+			return 0
+		fi
+	fi
+	print_error "Could not publish protected release recovery branch"
+	[[ -z "$push_output" ]] || print_info "Git rejected the recovery branch push"
+	return 1
+}
+
+_version_manager_write_protected_pr_body() {
+	local body_file="$1"
+	local repo="$2"
+	local version="$3"
+	local tag_object="$4"
+	local release_commit="$5"
+	local source_pr="${VERSION_MANAGER_SOURCE_PR:-}"
+	local signature_helper="${AIDEVOPS_VERSION_MANAGER_SIGNATURE_HELPER:-${SCRIPT_DIR}/gh-signature-helper.sh}"
+
+	{
+		printf '## Summary\n\n'
+		printf 'Route v%s through protected `main` without rebasing, amending, or recreating its signed release commit.\n\n' "$version"
+		printf '## Immutable provenance\n\n'
+		printf -- '- Release tag: `v%s`\n' "$version"
+		printf -- '- Signed tag object: `%s`\n' "$tag_object"
+		printf -- '- Release commit: `%s`\n' "$release_commit"
+		printf -- '- Required merge method: merge commit (never squash or rebase)\n'
+		if [[ "$source_pr" =~ ^[0-9]+$ ]]; then
+			printf -- '- Source publication: Ref #%s\n' "$source_pr"
+		fi
+		printf '\nRequired checks and review gates remain authoritative. The final `v%s` ref must not be pushed until this exact release commit is reachable from `main`.\n\n' "$version"
+		printf '<!-- aidevops:release-provenance tag=v%s tag-object=%s release-commit=%s merge-method=merge -->\n' \
+			"$version" "$tag_object" "$release_commit"
+	} >"$body_file" || return 1
+
+	if [[ "$repo" == "marcusquinn/aidevops" ]]; then
+		[[ -x "$signature_helper" ]] || return 1
+		bash "$signature_helper" footer >>"$body_file" || return 1
+	fi
+	return 0
+}
+
+_version_manager_queue_exact_merge() {
+	local repo="$1"
+	local branch_name="$2"
+	local expected_head="$3"
+	local pr_number="$4"
+	local version="$5"
+	local tag_object="$6"
+	local release_commit="$7"
+	local merge_output=""
+	local merge_rc=0
+	local state=""
+	local auto_merge=""
+	local is_draft=""
+
+	_version_manager_find_protected_release_pr "$repo" "$branch_name" || return 1
+	_version_manager_verify_protected_pr_head "$expected_head" || return 1
+	_version_manager_verify_protected_pr_identity "$repo" "$branch_name" "$version" \
+		"$tag_object" "$release_commit" || return 1
+	is_draft=$(jq -r '.draft // false' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
+	if [[ "$is_draft" == "true" ]]; then
+		gh pr ready "$pr_number" --repo "$repo" >/dev/null 2>&1 || return 1 # aidevops-allow: raw-gh-wrapper
+	fi
+
+	merge_output=$(gh pr merge "$pr_number" --repo "$repo" --auto --merge \
+		--match-head-commit "$expected_head" 2>&1) || merge_rc=$? # aidevops-allow: raw-gh-wrapper
+	if [[ "$merge_rc" -eq 0 ]]; then
+		_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="$_VERSION_MANAGER_RELEASE_RESULT_QUEUED"
+		return 0
+	fi
+
+	_version_manager_find_protected_release_pr "$repo" "$branch_name" || return 1
+	_version_manager_verify_protected_pr_head "$expected_head" || return 1
+	state=$(jq -r '.state // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
+	auto_merge=$(jq -r 'if .auto_merge == null then "" else "configured" end' \
+		<<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
+	if [[ "$state" == "closed" && "$(jq -r '.merged_at // ""' \
+		<<<"$_VERSION_MANAGER_PROTECTED_PR_JSON")" != "" ]]; then
+		_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="merged"
+		return 0
+	fi
+	if [[ "$auto_merge" == "configured" ]]; then
+		_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="$_VERSION_MANAGER_RELEASE_RESULT_QUEUED"
+		return 0
+	fi
+
+	# Prevent generic squash automation from destroying ancestry when native
+	# merge queueing is unavailable. Reconciliation retries the exact merge.
+	if gh pr ready "$pr_number" --repo "$repo" --undo >/dev/null 2>&1; then # aidevops-allow: raw-gh-wrapper
+		_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="queued-draft"
+		print_warning "Protected release PR #${pr_number} is preserved as a draft because exact merge queueing was unavailable"
+		return 0
+	fi
+	print_error "Could not queue or safely hold protected release PR #${pr_number}"
+	[[ -z "$merge_output" ]] || print_info "GitHub rejected the exact merge request"
+	return 1
+}
+
+_version_manager_create_or_reuse_protected_pr() {
+	local repo="$1"
+	local version="$2"
+	local branch_name="$3"
+	local recovery_head="$4"
+	local tag_object="$5"
+	local release_commit="$6"
+	local body_file=""
+	local create_output=""
+	local create_rc=0
+	local origin_label="origin:interactive"
+	local -a create_args=()
+
+	_version_manager_find_protected_release_pr "$repo" "$branch_name" || return 1
+	if [[ -z "$_VERSION_MANAGER_PROTECTED_PR_NUMBER" ]]; then
+		body_file=$(mktemp) || return 1
+		_version_manager_write_protected_pr_body "$body_file" "$repo" "$version" \
+			"$tag_object" "$release_commit" || {
+			rm -f "$body_file"
+			return 1
+		}
+		create_args=(--repo "$repo" --head "$branch_name" --base main \
+			--title "chore(release): preserve signed v${version} publication" \
+			--body-file "$body_file")
+		if [[ "$repo" == "marcusquinn/aidevops" ]]; then
+			if declare -F _version_manager_is_headless_task_worker >/dev/null 2>&1 &&
+				_version_manager_is_headless_task_worker; then
+				origin_label="origin:worker"
+			fi
+			create_args+=(--label "$origin_label" --label "status:in-review" --label "release")
+		fi
+		create_output=$(gh pr create "${create_args[@]}" 2>&1) || create_rc=$? # aidevops-allow: raw-gh-wrapper
+		rm -f "$body_file"
+		_version_manager_find_protected_release_pr "$repo" "$branch_name" || return 1
+		if [[ -z "$_VERSION_MANAGER_PROTECTED_PR_NUMBER" ]]; then
+			print_error "Protected-main push was rejected and no recovery PR could be created"
+			[[ "$create_rc" -eq 0 || -z "$create_output" ]] || print_info "GitHub rejected PR creation"
+			return 1
+		fi
+	fi
+
+	_version_manager_verify_protected_pr_head "$recovery_head" || return 1
+	_VERSION_MANAGER_PROTECTED_PR_NUMBER=$(jq -er '.number' \
+		<<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
+	_version_manager_queue_exact_merge "$repo" "$branch_name" "$recovery_head" \
+		"$_VERSION_MANAGER_PROTECTED_PR_NUMBER" "$version" "$tag_object" \
+		"$release_commit" || return 1
+	print_success "Protected release PR #${_VERSION_MANAGER_PROTECTED_PR_NUMBER} preserves v${version} provenance"
+	print_info "Required checks and review gates remain enforced on exact head ${recovery_head}"
+	return 0
+}
+
+_version_manager_publish_reachable_tag() {
+	local tag_name="$1"
+	local push_output=""
+
+	_VERSION_MANAGER_PROTECTED_RELEASE_RESULT=""
+	_version_manager_classify_remote_tag "$tag_name" || return 1
+	case "$_VERSION_MANAGER_REMOTE_TAG_STATE" in
+	matching)
+		_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="remote-tag-present"
+		return 0
+		;;
+	absent) ;;
+	*) return 1 ;;
+	esac
+	git -C "$REPO_ROOT" fetch origin main --quiet || return 1
+	if ! git -C "$REPO_ROOT" merge-base --is-ancestor \
+		"$_VERSION_MANAGER_LOCAL_TAG_COMMIT" origin/main; then
+		_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="not-reachable"
+		return 0
+	fi
+	if ! push_output=$(git -C "$REPO_ROOT" push origin \
+		"refs/tags/${tag_name}:refs/tags/${tag_name}" 2>&1); then
+		print_error "Failed to publish preserved ${tag_name} after main became reachable"
+		[[ -z "$push_output" ]] || print_info "Git rejected the exact tag push"
+		return 1
+	fi
+	_version_manager_classify_remote_tag "$tag_name" || return 1
+	[[ "$_VERSION_MANAGER_REMOTE_TAG_STATE" == "$_VERSION_MANAGER_TAG_STATE_MATCHING" ]] || return 1
+	_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="tag-pushed"
+	return 0
+}
+
+_version_manager_queue_protected_main_release() {
+	local version="$1"
+	local tag_name="v${version}"
+	local repo=""
+	local release_commit=""
+	local release_parent=""
+	local tag_object=""
+	local branch_name=""
+
+	_VERSION_MANAGER_PROTECTED_RELEASE_RESULT=""
+	_VERSION_MANAGER_PROTECTED_PR_NUMBER=""
+	_VERSION_MANAGER_PROTECTED_RELEASE_BRANCH=""
+	VERSION_MANAGER_PRESERVE_RELEASE_STATE=1
+	export VERSION_MANAGER_PRESERVE_RELEASE_STATE
+	repo=$(_version_manager_protected_repo_slug) || {
+		print_error "Cannot resolve repository for protected-main release recovery"
+		return 1
+	}
+	_version_manager_local_tag_identity "$tag_name" || return 1
+	tag_object="$_VERSION_MANAGER_LOCAL_TAG_OBJECT"
+	release_commit="$_VERSION_MANAGER_LOCAL_TAG_COMMIT"
+	release_parent=$(git -C "$REPO_ROOT" rev-parse "${release_commit}^" 2>/dev/null) || return 1
+	branch_name=$(_version_manager_protected_release_branch_name "$version") || return 1
+	_VERSION_MANAGER_PROTECTED_RELEASE_BRANCH="$branch_name"
+
+	_version_manager_prepare_protected_release_head "$version" "$release_commit" \
+		"$release_parent" "$branch_name" || return 1
+	_version_manager_local_tag_identity "$tag_name" || return 1
+	if [[ "$_VERSION_MANAGER_LOCAL_TAG_OBJECT" != "$tag_object" ||
+		"$_VERSION_MANAGER_LOCAL_TAG_COMMIT" != "$release_commit" ]]; then
+		print_error "Protected release recovery changed immutable tag provenance"
+		return 1
+	fi
+
+	if [[ "$_VERSION_MANAGER_PROTECTED_RELEASE_RESULT" == "main-reachable" ]]; then
+		_version_manager_publish_reachable_tag "$tag_name" || return 1
+		return 0
+	fi
+	_version_manager_create_or_reuse_protected_pr "$repo" "$version" "$branch_name" \
+		"$_VERSION_MANAGER_PROTECTED_RELEASE_HEAD" "$tag_object" "$release_commit" || return 1
+	_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="$_VERSION_MANAGER_RELEASE_RESULT_QUEUED"
+	return 0
+}
+
+_version_manager_reconcile_protected_release_tag() {
+	local repo="$1"
+	local tag_name="$2"
+	local mode="$3"
+	local version="${tag_name#v}"
+	local branch_name=""
+	local pr_state=""
+	local merged_at=""
+	local pr_head=""
+	local remote_branch_head=""
+
+	_VERSION_MANAGER_PROTECTED_RELEASE_RESULT=""
+	[[ "$mode" == "status" || "$mode" == "$_VERSION_MANAGER_MODE_RECONCILE" ]] || return 1
+	_version_manager_classify_remote_tag "$tag_name" || return 1
+	if [[ "$_VERSION_MANAGER_REMOTE_TAG_STATE" == "$_VERSION_MANAGER_TAG_STATE_MATCHING" ]]; then
+		_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="remote-tag-present"
+		return 0
+	fi
+	[[ "$_VERSION_MANAGER_REMOTE_TAG_STATE" == "$_VERSION_MANAGER_TAG_STATE_ABSENT" ]] || return 1
+
+	git -C "$REPO_ROOT" fetch origin main --quiet || return 1
+	if git -C "$REPO_ROOT" merge-base --is-ancestor \
+		"$_VERSION_MANAGER_LOCAL_TAG_COMMIT" origin/main; then
+		if [[ "$mode" == "status" ]]; then
+			_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="tag-ready"
+			printf 'RELEASE_TAG_STATE=ready tag=%s commit=%s\n' \
+				"$tag_name" "$_VERSION_MANAGER_LOCAL_TAG_COMMIT"
+			return 0
+		fi
+		_version_manager_publish_reachable_tag "$tag_name" || return 1
+		printf 'release:queued tag=%s correlation=%s\n' \
+			"$tag_name" "$_VERSION_MANAGER_LOCAL_TAG_COMMIT"
+		return 0
+	fi
+
+	branch_name=$(_version_manager_protected_release_branch_name "$version") || return 1
+	_version_manager_find_protected_release_pr "$repo" "$branch_name" || return 1
+	if [[ -z "$_VERSION_MANAGER_PROTECTED_PR_NUMBER" ]]; then
+		print_error "Release commit is not reachable from main and no protected recovery PR exists"
+		return 1
+	fi
+	pr_head=$(jq -r '.head.sha // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
+	_version_manager_verify_protected_pr_head "$pr_head" || return 1
+	_version_manager_remote_branch_head "$branch_name" || return 1
+	remote_branch_head="$_VERSION_MANAGER_PROTECTED_RELEASE_HEAD"
+	if [[ -z "$remote_branch_head" || "$remote_branch_head" != "$pr_head" ]]; then
+		print_error "Protected release PR head no longer matches its remote branch"
+		return 1
+	fi
+	_version_manager_fetch_recovery_branch "$branch_name" || return 1
+	if ! git -C "$REPO_ROOT" merge-base --is-ancestor \
+		"$_VERSION_MANAGER_LOCAL_TAG_COMMIT" "$pr_head"; then
+		print_error "Protected release PR does not contain the signed release commit"
+		return 1
+	fi
+	pr_state=$(jq -r '.state // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
+	merged_at=$(jq -r '.merged_at // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
+	if [[ "$pr_state" == "closed" && -n "$merged_at" ]]; then
+		git -C "$REPO_ROOT" fetch origin main --quiet || return 1
+		if ! git -C "$REPO_ROOT" merge-base --is-ancestor \
+			"$_VERSION_MANAGER_LOCAL_TAG_COMMIT" origin/main; then
+			print_error "Merged protected release PR did not preserve release ancestry"
+			return 1
+		fi
+		if [[ "$mode" == "$_VERSION_MANAGER_MODE_RECONCILE" ]]; then
+			_version_manager_publish_reachable_tag "$tag_name" || return 1
+			printf 'release:queued tag=%s correlation=%s\n' \
+				"$tag_name" "$_VERSION_MANAGER_LOCAL_TAG_COMMIT"
+		else
+			_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="tag-ready"
+		fi
+		return 0
+	fi
+	if [[ "$pr_state" != "open" ]]; then
+		print_error "Protected release PR #${_VERSION_MANAGER_PROTECTED_PR_NUMBER} closed without merge"
+		return 1
+	fi
+	if [[ "$mode" == "$_VERSION_MANAGER_MODE_RECONCILE" ]]; then
+		_version_manager_queue_exact_merge "$repo" "$branch_name" "$pr_head" \
+			"$_VERSION_MANAGER_PROTECTED_PR_NUMBER" "$version" \
+			"$_VERSION_MANAGER_LOCAL_TAG_OBJECT" \
+			"$_VERSION_MANAGER_LOCAL_TAG_COMMIT" || return 1
+	fi
+	_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="pr-pending"
+	printf 'release:queued pr=%s tag=%s head=%s\n' \
+		"$_VERSION_MANAGER_PROTECTED_PR_NUMBER" "$tag_name" "$pr_head"
+	return 0
+}

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -353,6 +353,7 @@ _release_execute() {
 	local hotfix_flag="$3"
 	local tag_name="v$new_version"
 	local publication_rc=0
+	local push_rc=0
 
 	_release_require_new_tag "$bump_type" "$tag_name"
 
@@ -389,9 +390,26 @@ _release_execute() {
 			print_error "Aborting release: tag creation failed (see above for diagnosis)"
 			exit 1
 		fi
-		if ! push_changes "$new_version"; then
+		push_changes "$new_version" || push_rc=$?
+		case "$push_rc" in
+		0) ;;
+		8)
+			_release_disable_failure_rollback
+			print_success "release:queued"
+			print_info "Protected-main PR #${_VERSION_MANAGER_PROTECTED_PR_NUMBER:-unknown} preserves the signed ${tag_name} commit"
+			print_info "Reconcile the source PR after merge: aidevops release reconcile ${VERSION_MANAGER_SOURCE_PR:-<SOURCE_PR>}"
+			return 8
+			;;
+		*)
+			if [[ "${VERSION_MANAGER_PRESERVE_RELEASE_STATE:-0}" == "1" ]]; then
+				_release_disable_failure_rollback
+				print_error "Release push failed after a protected-main policy rejection"
+				print_info "The original ${tag_name} ref and release commit were preserved for diagnosis"
+				return 1
+			fi
 			_release_handle_push_failure "$new_version"
-		fi
+			;;
+		esac
 		_publish_github_release "$new_version" || publication_rc=$?
 		if [[ "$publication_rc" -eq 8 ]]; then
 			_release_disable_failure_rollback


### PR DESCRIPTION
## Summary

- Classify permanent protected-main rejection after one atomic release push attempt instead of retrying ten times.
- Preserve the original signed release commit and annotated tag through a trusted, exact-head merge PR.
- Return a durable queued state and publish the unchanged tag only after the release commit is reachable from `main`.

## Safety and recovery

- `.agents/scripts/version-manager-protected-main.sh` validates same-repository collaborator authorship, immutable PR metadata, and release/main merge ancestry before enabling native merge topology.
- Managed recovery PRs carry the `release` label, so Pulse defers them to exact-merge reconciliation rather than squash recovery.
- `.agents/scripts/full-loop-release-reconcile.sh` resumes pending publication idempotently without another version bump.

## Testing

- `bash .agents/scripts/tests/test-version-manager-protected-main-fallback.sh`
- `bash .agents/scripts/tests/test-full-loop-release-reconcile.sh`
- `bash .agents/scripts/tests/test-version-manager-release-provenance.sh`
- `bash .agents/scripts/tests/test-pulse-merge-native-auto.sh`
- Focused ShellCheck across changed release and Pulse scripts
- `.agents/scripts/linters-local.sh`

Runtime risk: **High**. Testing evidence: **runtime-verified** fixture and integration paths.

Resolves #29119
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h 35m and 789,893 tokens on this as a headless worker.