### PR TITLE
GH#29234: Cap default Pulse dispatch ceremony parallelism at six

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -67,23 +67,21 @@ if [[ -n "${FILL_FLOOR_PER_CANDIDATE_TIMEOUT:-}" && -z "${DISPATCH_PER_CANDIDATE
 	export DISPATCH_PER_CANDIDATE_TIMEOUT
 fi
 : "${DISPATCH_PER_CANDIDATE_TIMEOUT:=30}"
-# t3005/t3014: parallel dispatch concurrency for dispatch_max.
+# t3005/t3014/GH#29234: parallel dispatch concurrency for dispatch_max.
 # Each successful dispatch takes ~30-180s (gh API ceremony + worktree-helper.sh
 # add + worker spawn) so the previous serial loop capped throughput at ~1
 # dispatch per pulse cycle.
 #
-# Default (t3014): unset → max_parallel = _effective_slots (typically 24, the
-# full slot budget). The cap inside _dispatch_max_compute_parallel still clamps at
-# _effective_slots, so the default never exceeds capacity. Setting an explicit
-# integer overrides the default. Set to 1 to retain the legacy serial behavior
-# (regression escape hatch); set to a smaller integer to ration concurrency.
+# Default (GH#29234): unset or invalid → min(6, _effective_slots). Worker-slot
+# capacity is not a safe proxy for simultaneous dispatch ceremony process trees;
+# each candidate adds API, worktree, and runtime-start overhead before occupying
+# its worker slot. Setting an explicit positive integer overrides the default,
+# while the cap inside _dispatch_max_compute_parallel still prevents concurrency
+# above _effective_slots. Set to 1 to retain the legacy serial behavior.
 #
-# Pre-t3014 default was 6 — too low to saturate the 24-slot budget under the
-# adaptive-timeout / probe-mode regime where each dispatch retries through gh
-# rate-limit backoff. Measured failure mode (cycle 21126, 2026-04-28): 10
-# candidates dispatched in parallel, only 3/10 succeeded; steady-state worker
-# count = 4 against 24-slot budget. Raising the default to _effective_slots
-# allows the 24-slot pool to fill in 1-2 cycles instead of 6+.
+# A 24-way default overloaded a 16-CPU host before workers could settle; six-way
+# dispatch restored bounded load and successful launches. Larger hosts can opt in
+# to more concurrency with DISPATCH_MAX_PARALLEL.
 #
 # Intentionally left as soft default (`:-` form, no `:=` global default) so
 # the variable stays unset for callers that read it for diagnostics.

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -2002,15 +2002,13 @@ _dispatch_maybe_engage_throttle() {
 }
 
 #######################################
-# t3005/t3014: Decide the parallelism level for the dispatch_max loop.
+# t3005/t3014/GH#29234: Decide the parallelism level for dispatch_max.
 #
 # Defaults to DISPATCH_MAX_PARALLEL when set to a positive integer.
-# When unset, empty, or non-numeric, defaults to effective_slots — i.e. the
-# full slot budget — so the parallel loop saturates the worker pool in one
-# cycle (t3014). The pre-t3014 default of 6 capped throughput at 6 dispatches
-# per cycle even when the slot budget was 24, leaving ~17 idle slots per cycle
-# under adaptive-timeout / probe-mode regimes that produce 30-180s per-candidate
-# dispatch latency.
+# When unset, empty, or non-numeric, defaults to 6 (GH#29234), then clamps to
+# effective_slots. Worker slots represent settled worker capacity, not the safe
+# number of concurrent API/worktree/runtime-start ceremony process trees. An
+# explicit positive override remains available for larger or smaller hosts.
 #
 # Always capped at the effective slot budget — never schedule more concurrent
 # dispatches than slots we'd consume. Forced to 1 when the adaptive throttle
@@ -2032,12 +2030,12 @@ _dispatch_max_compute_parallel() {
 		DISPATCH_MAX_PARALLEL="$DISPATCH_FILL_FLOOR_PARALLEL"
 		export DISPATCH_MAX_PARALLEL
 	fi
-	# t3014: when unset/empty/invalid, default to effective_slots (full budget)
-	# instead of the historical 6. Env override still wins when set to a valid
-	# positive integer; the cap below still clamps at effective_slots.
+	# GH#29234: use a conservative ceremony cap when unset/empty/invalid. An env
+	# override still wins when it is a positive integer; the effective-slot cap
+	# below remains authoritative.
 	local max_parallel="${DISPATCH_MAX_PARALLEL:-}"
 	if ! [[ "$max_parallel" =~ ^[1-9][0-9]*$ ]]; then
-		max_parallel="$effective_slots"
+		max_parallel=6
 	fi
 	if ((max_parallel > effective_slots)); then
 		max_parallel="$effective_slots"

--- a/.agents/scripts/tests/test-dispatch-max-parallel.sh
+++ b/.agents/scripts/tests/test-dispatch-max-parallel.sh
@@ -61,20 +61,44 @@ source "${SCRIPT_DIR}/pulse-dispatch-engine.sh"
 # Test 1: _dispatch_max_compute_parallel honours DISPATCH_MAX_PARALLEL
 # =============================================================================
 test_compute_max_parallel_default() {
-	# t3014: when DISPATCH_MAX_PARALLEL is unset, default is now
-	# effective_slots (full slot budget), not the historical 6. Pre-t3014
-	# the default capped throughput at 6/cycle even with a 24-slot budget,
-	# leaving ~17 slots idle per cycle under adaptive-timeout regimes.
+	# GH#29234: unset defaults to the conservative ceremony cap of 6 rather
+	# than treating the full worker-slot budget as safe launch parallelism.
 	unset DISPATCH_MAX_PARALLEL || true
 	_DISPATCH_THROTTLE_FILE="${HOME}/.aidevops/logs/dispatch-throttle"
 	rm -f "$_DISPATCH_THROTTLE_FILE"
 	local result
-	# effective_slots=24 → expect 24 (full budget, t3014 default)
+	# effective_slots=24 → expect the default ceremony cap of 6.
 	result=$(_dispatch_max_compute_parallel 24)
-	if [[ "$result" == "24" ]]; then
-		print_result "compute_max_parallel: default=effective_slots(24) when unset" 0
+	if [[ "$result" == "6" ]]; then
+		print_result "compute_max_parallel: default=6 when unset" 0
 	else
-		print_result "compute_max_parallel: default=effective_slots(24) when unset" 1 "got=${result}"
+		print_result "compute_max_parallel: default=6 when unset" 1 "got=${result}"
+	fi
+	return 0
+}
+
+test_compute_max_parallel_default_caps_at_slots() {
+	unset DISPATCH_MAX_PARALLEL || true
+	rm -f "$_DISPATCH_THROTTLE_FILE"
+	local result
+	result=$(_dispatch_max_compute_parallel 3)
+	if [[ "$result" == "3" ]]; then
+		print_result "compute_max_parallel: default caps at effective_slots (3)" 0
+	else
+		print_result "compute_max_parallel: default caps at effective_slots (3)" 1 "got=${result}"
+	fi
+	return 0
+}
+
+test_compute_max_parallel_override() {
+	export DISPATCH_MAX_PARALLEL=10
+	rm -f "$_DISPATCH_THROTTLE_FILE"
+	local result
+	result=$(_dispatch_max_compute_parallel 24)
+	if [[ "$result" == "10" ]]; then
+		print_result "compute_max_parallel: explicit positive override wins" 0
+	else
+		print_result "compute_max_parallel: explicit positive override wins" 1 "got=${result}"
 	fi
 	return 0
 }
@@ -107,17 +131,15 @@ test_compute_max_parallel_throttle_forces_serial() {
 }
 
 test_compute_max_parallel_invalid_var() {
-	# t3014: invalid value falls back to effective_slots (was 6 pre-t3014).
-	# This keeps the validator graceful — a typo'd env var doesn't trap the
-	# pulse at degraded throughput; it gets the safe full-budget default.
+	# Invalid input follows the same conservative default as unset input.
 	export DISPATCH_MAX_PARALLEL="not-a-number"
 	rm -f "$_DISPATCH_THROTTLE_FILE"
 	local result
 	result=$(_dispatch_max_compute_parallel 24)
-	if [[ "$result" == "24" ]]; then
-		print_result "compute_max_parallel: invalid env falls back to effective_slots(24)" 0
+	if [[ "$result" == "6" ]]; then
+		print_result "compute_max_parallel: invalid env falls back to 6" 0
 	else
-		print_result "compute_max_parallel: invalid env falls back to effective_slots(24)" 1 "got=${result}"
+		print_result "compute_max_parallel: invalid env falls back to 6" 1 "got=${result}"
 	fi
 	unset DISPATCH_MAX_PARALLEL || true
 	return 0
@@ -611,6 +633,8 @@ test_serial_loop_allows_unset_stop_flag() {
 # Run all tests
 # =============================================================================
 test_compute_max_parallel_default
+test_compute_max_parallel_default_caps_at_slots
+test_compute_max_parallel_override
 test_compute_max_parallel_caps_at_slots
 test_compute_max_parallel_throttle_forces_serial
 test_compute_max_parallel_invalid_var


### PR DESCRIPTION
## Summary

Default unset or invalid Pulse dispatch ceremony parallelism to six while preserving explicit overrides, effective-slot clamping, and adaptive serial throttling.

## Files Changed

.agents/scripts/pulse-dispatch-engine.sh, .agents/scripts/pulse-dispatch-lib.sh, .agents/scripts/tests/test-dispatch-max-parallel.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Runtime-verified six-way dispatch on the affected 16-CPU host; ShellCheck clean; test-dispatch-max-parallel.sh 24/24; test-dispatch-min-concurrency.sh 23/23; linters-local.sh passed; git diff --check clean.

Resolves #29234


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 4h 47m and 3,522,926 tokens on this with the user in an interactive session.