### PR TITLE
GH#29221: Add bounded Mastodon social collector

### DIFF
--- a/.agents/aidevops/knowledge-plane/05-social-operations.md
+++ b/.agents/aidevops/knowledge-plane/05-social-operations.md
@@ -39,7 +39,7 @@ transaction without rewriting raw gzip artifacts, cursors, coverage, or provider
 rows. Replay preserves both evidence and projection IDs.
 
 Candidate implementation is provider-specific, not one generic social adapter.
-The ranked children are Mastodon #29221, GitHub #29222, Stack Exchange #29223,
+Mastodon #29221 is now live. The remaining ranked children are GitHub #29222, Stack Exchange #29223,
 Miniflux #29224, Readwise Reader #29225, FreshRSS #29226, Lemmy issue #29227,
 then public-only Hacker News #29228. Each route owns its identity
 contract, stream allowlist, checkpoint semantics, and negative write-reachability
@@ -61,6 +61,15 @@ request budget, and atomically commits the raw boundary envelope, normalized
 rows, coverage, receipt, and next checkpoint. A terminal or malformed page keeps
 the previous checkpoint. Snapshot streams never infer deletion from partial
 coverage.
+
+Mastodon collection uses a user token bound to one exact HTTPS home instance and
+rechecks `GET /api/v1/accounts/verify_credentials` before every page. Authored
+statuses, favourites, bookmarks, notifications, followers, following, followed
+tags, and lists have independent snapshot checkpoints. Complete same-origin
+`Link` targets are preserved as opaque cursors; redirects and write scopes are
+rejected. Conversations, nested list membership, exports, federation,
+moderation, deletion, and operator retention remain explicit gaps. Details:
+`.agents/content/social-mastodon.md`.
 
 X collection uses the guarded official `xurl` helper. Reddit collection uses an
 optional PRAW 8 child. YouTube collection uses a standard-library HTTP child and

--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -42,6 +42,7 @@ a claim that the route is enabled.
 | Skool | **No** posts, comments, and course content | **No** reactions and saved state | **No** notifications and messages | **No** memberships, follows, and groups | **No** courses and calendar feeds | **Export/No** admin membership-question answers only. The official Zapier surface is narrow event automation, the export schema and identity contract are unpublished, and provider policy excludes browser collection. |
 | Discourse | **Live** topics and posts | **Live/Partial** likes, bookmarks, and current reading state | **Live/Gate/Partial** notifications and private-topic metadata; **No** message bodies | **Live/Partial** groups and category preferences; **No** unverified Follow plugin | **No** watched/tracked topic inventories until search behavior is verified | Ten User API `read` streams with per-installation namespaces, repeated identity checks, exact GET routes, redirect rejection, and explicit plugin/export/history gaps. |
 | NodeBB | **Live** topics and posts | **Live/Partial** votes, bookmarks, watched topics, and category state | **Live/Partial** notifications and chat-room metadata; **No** message bodies | **Live/Partial** follows and groups | **No** plugin-provided lists | Thirteen independently checkpointed core GET streams with per-installation identity, bounded pagination, and explicit admin/plugin/export/history gaps. |
+| Mastodon | **Live/Partial** authored statuses | **Live/Partial** favourites and bookmarks | **Live/Gate/Partial** notifications; **No/Gate** conversations | **Live/Partial** followers, following, and followed tags | **Live/Partial** lists; **No** nested membership | Eight exact-origin GET-only streams preserve opaque `Link` cursors and expose federation, moderation, deletion, export, and operator-retention gaps. |
 
 ## Integrated provider families
 
@@ -70,7 +71,7 @@ separate provider family.
 
 | Provider family | Authored content | Interactions and curation | Mentions or messages | Relationships and subscriptions | Lists or custom feeds | Current disposition |
 |---|---|---|---|---|---|---|
-| Mastodon | **API** | **API** favourites and bookmarks | **API/Gate** notifications and conversations | **API** follows and followed tags | **API** lists and membership | Rank 1, #29221. Mature official API; bind home-instance identity, preserve opaque `Link` cursors, and record federation/operator retention gaps. |
+| Mastodon | **Live/Partial** | **Live/Partial** favourites and bookmarks | **Live/Gate/Partial** notifications; **No/Gate** conversations | **Live/Partial** follows and followed tags | **Live/Partial** lists; **No** nested membership | #29221 implements exact-origin identity-bound reads with opaque `Link` cursors and explicit federation/operator-retention gaps. |
 | Bluesky / AT Protocol | **Live** records | **Live** likes and reposts | **Live/Gate** notifications; **No/Gate** chat | **Live** follows | **Live** lists and feeds | DID-bound repository/AppView reads with separate chat authorization. |
 | Lemmy | **API/Gate** versioned authored content | **API/Gate** saved and liked state | **API/Gate** unified v4 or split v3 inbox | **API/Gate** communities; **No** person follows | **API/Gate** v4 multicommunities | Rank 7, #29227. Implement only behind exact v4/v3 discovery; namespace local IDs and preserve opaque version-sensitive cursors. |
 | Stack Exchange | **API** authored content | **API** favourites; **No** complete vote history | **API/Gate** inbox and notifications | **API** associated site accounts; **No** follows | **No** | Rank 3, #29223. Bind network plus per-site identity, obey `backoff`, and keep archive/completeness gaps explicit. |
@@ -154,6 +155,14 @@ separate provider family.
   evidence, public capability limits, admin-only version/plugin discovery,
   account-visible permissions, exports, retention, terms, and explicit plugin,
   message-body, and history gaps checked on 2026-07-28.
+- **Live Mastodon:** `.agents/scripts/knowledge_social_mastodon.py`,
+  `.agents/scripts/_knowledge_social_mastodon*.py`, and
+  `.agents/tests/test-knowledge-social-mastodon.sh` prove home-instance identity,
+  eight independent streams, exact same-origin RFC Link resume, read-scope and
+  GET-only enforcement, credential rejection, terminal coverage, and atomic
+  persistence. `.agents/content/social-mastodon.md` records official routes,
+  scopes, pagination, default rate limits, exports, and explicit gaps checked on
+  2026-08-02.
 - **Integrated provider registry:** `.agents/scripts/knowledge_social_registry.py`
   and `.agents/tests/test-knowledge-social-registry.sh` prove order-independent
   registration, collision rejection, exact aliases and modes, no-route failure,

--- a/.agents/content/social-mastodon.md
+++ b/.agents/content/social-mastodon.md
@@ -1,0 +1,91 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Mastodon Account Knowledge Collection
+
+`knowledge_social_mastodon.py` collects bounded, read-only account evidence from
+one exact Mastodon home instance. Equal account or object IDs on different
+instances never share corpus identity. IDs remain opaque strings; persisted
+global IDs combine the keyed instance fingerprint, resource kind, and a digest
+of the provider ID.
+
+## Profile and authority contract
+
+Configure secrets through secure environment injection:
+
+```text
+MASTODON_<PROFILE>_BASE_URL
+MASTODON_<PROFILE>_ACCESS_TOKEN
+MASTODON_<PROFILE>_ORIGIN_KEY
+MASTODON_<PROFILE>_AUTH_MODE=user_token
+MASTODON_<PROFILE>_SCOPES="read:accounts read:statuses read:favourites read:bookmarks read:notifications read:follows read:lists"
+```
+
+The base must be an HTTPS origin without credentials, subpath, query, or
+fragment. `ORIGIN_KEY` is a securely stored random value of at least 32 bytes;
+HMAC-SHA-256 over the canonical origin yields the private 24-character instance
+namespace. Hosts, tokens, and origin keys never enter evidence, cursors,
+receipts, output, or errors. Redirects are rejected.
+
+The declared scope set must contain `read:accounts` (or `profile`) and the scope
+for each selected stream. Any `write` or `write:*` declaration is rejected so a
+collector profile cannot silently carry mutation authority. Scope declaration
+does not replace provider-side OAuth enforcement.
+
+Use `--account-id account_<OPAQUE_ID>`. Before collection and every page, the
+child calls `GET /api/v1/accounts/verify_credentials`, matches the exact opaque
+ID, and binds its home-instance fingerprint plus `username`, `acct`, and `uri`.
+Private `source`, profile fields, notes, URLs, images, and arbitrary response
+fields are discarded.
+
+## Implemented streams
+
+| Stream | Initial official GET route | Maximum page |
+|---|---|---:|
+| `authored_statuses` | `/api/v1/accounts/:id/statuses` | 40 |
+| `favourites` | `/api/v1/favourites` | 40 |
+| `bookmarks` | `/api/v1/bookmarks` | 40 |
+| `notifications` | `/api/v1/notifications` | 80 |
+| `followers` | `/api/v1/accounts/:id/followers` | 80 |
+| `following` | `/api/v1/accounts/:id/following` | 80 |
+| `followed_tags` | `/api/v1/followed_tags` | 100 |
+| `lists` | `/api/v1/lists` | one bounded response |
+
+Each invocation owns one stream lease. The initial identity read costs one
+request unit and every page reserves two more for identity recheck plus data
+read. `--budget` is 3-1000; `--page-size` is 1-100, while provider route limits
+remain authoritative.
+
+For every paginated stream, the complete `rel=next` target from the HTTP `Link`
+header is stored in a versioned cursor and replayed unchanged. Before use, the
+transport verifies the same scheme, host, port, exact GET route, allowlisted
+query keys, no duplicate keys, and bounded `limit`; it never parses internal
+relationship, favourite, or bookmark IDs. Snapshot completion does not infer
+deletion. Raw response, rows, coverage, cursor, and receipt commit atomically.
+
+## Boundaries
+
+Successful pages record explicit unavailable coverage for conversations,
+nested list membership, account-export import, complete federated history,
+moderation history, deleted or purged content, and instance retention. These
+cannot be inferred from current home-instance responses. Conversations require
+separate private-data consent. Account exports cover selected posts, media, and
+relationship CSVs but are not a complete notification or curation history.
+
+Default Mastodon limits are 300 requests per five minutes independently per
+account and IP, but operators may override them. The collector honors terminal
+429 responses and `Retry-After`; its local budget remains a stricter independent
+fuse.
+
+## Official evidence checked 2026-08-02
+
+- <https://docs.joinmastodon.org/methods/accounts/#verify_credentials>
+- <https://docs.joinmastodon.org/methods/accounts/#statuses>
+- <https://docs.joinmastodon.org/methods/favourites/>
+- <https://docs.joinmastodon.org/methods/bookmarks/>
+- <https://docs.joinmastodon.org/methods/notifications/>
+- <https://docs.joinmastodon.org/methods/followed_tags/>
+- <https://docs.joinmastodon.org/methods/lists/>
+- <https://docs.joinmastodon.org/api/guidelines/#pagination>
+- <https://docs.joinmastodon.org/api/rate-limits/>
+- <https://docs.joinmastodon.org/user/moving/#export>

--- a/.agents/scripts/_knowledge_social_mastodon.py
+++ b/.agents/scripts/_knowledge_social_mastodon.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Mastodon stream policy, instance identity, and opaque Link checkpoints."""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from _knowledge_social_mastodon_identity import (
+    MastodonAdapterError,
+    MastodonProviderUnavailableError,
+    account_handle,
+    instance_id,
+    namespaced_id,
+    provider_account_id,
+)
+from _knowledge_social_oauth_request import OAuthPageRequest
+from knowledge_social_import import canonical_json, reject_credentials
+
+PROVIDER = "mastodon"
+CURSOR_PREFIX = "mastodon-link-v1:"
+RETENTION_LIMIT = "instance_policy_federation_and_current_account_visibility"
+MAX_PAGE_ITEMS = 100
+ACCOUNT_AUTH_MODE = "user_token"
+
+ADAPTER_ERROR = MastodonAdapterError
+PROVIDER_UNAVAILABLE_ERROR = MastodonProviderUnavailableError
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    resource_kind: str
+    activity_mode: str
+    pagination: str = "snapshot"
+    incremental: bool = False
+    retention_limit: str | None = RETENTION_LIMIT
+    coverage_status: str | None = "partial"
+    unavailable_reason: str | None = "instance_policy_and_federation_bound"
+    cost_units: int = 2
+
+
+STREAMS = {
+    "authored_statuses": StreamSpec("status", "content_author"),
+    "favourites": StreamSpec("status", "selected_account"),
+    "bookmarks": StreamSpec("status", "selected_account"),
+    "notifications": StreamSpec("notification", "selected_account"),
+    "followers": StreamSpec("account", "relationship"),
+    "following": StreamSpec("account", "relationship"),
+    "followed_tags": StreamSpec("tag", "selected_account"),
+    "lists": StreamSpec("list", "selected_account"),
+}
+
+
+class PageRequest(OAuthPageRequest):
+    """Allowlisted request carrying an opaque next-link in stop_at."""
+
+    HANDLE_KEY = "acct"
+
+    @property
+    def acct(self) -> str:
+        return self.handle
+
+
+PAGE_REQUEST_KEYS = {
+    "action", "stream", "account_id", "provider_account_id", "acct",
+    "instance_id", "position", "stop_at", "limit",
+}
+
+
+def _text(value: Any, field: str, *, optional: bool = False, limit: int = 8192) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise MastodonAdapterError(f"Mastodon {field} is invalid")
+    if len(value.encode("utf-8")) > limit:
+        raise MastodonAdapterError(f"Mastodon {field} is invalid")
+    return value
+
+
+def _position(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise MastodonAdapterError("Mastodon page position must be positive")
+    return value
+
+
+def _encode_cursor(position: int, next_url: str) -> str:
+    payload = canonical_json({"next_url": next_url, "position": position}).encode()
+    encoded = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+    return f"{CURSOR_PREFIX}{encoded}"
+
+
+def _decode_cursor(cursor: str) -> tuple[int, str]:
+    if not cursor.startswith(CURSOR_PREFIX):
+        raise MastodonAdapterError("stored Mastodon cursor has an unsupported version")
+    try:
+        raw = cursor.removeprefix(CURSOR_PREFIX)
+        parsed = json.loads(base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4)))
+    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+        raise MastodonAdapterError("stored Mastodon cursor is invalid") from error
+    if not isinstance(parsed, dict) or set(parsed) != {"next_url", "position"}:
+        raise MastodonAdapterError("stored Mastodon cursor has an invalid shape")
+    reject_credentials(parsed)
+    next_url = _text(parsed["next_url"], "next link")
+    if next_url is None:
+        raise MastodonAdapterError("stored Mastodon cursor is invalid")
+    return _position(parsed["position"]), next_url
+
+
+def page_request(stream: str, account: dict[str, Any], state: CursorState, limit: int) -> PageRequest:
+    if stream not in STREAMS:
+        raise MastodonAdapterError("Mastodon stream is unsupported")
+    position, next_url = (1, None)
+    if state.cursor:
+        position, next_url = _decode_cursor(state.cursor)
+    selected_id = _text(account.get("id"), "selected account ID")
+    if selected_id is None:
+        raise MastodonAdapterError("verified Mastodon identity is incomplete")
+    return PageRequest(
+        stream,
+        selected_id,
+        provider_account_id(account.get("provider_account_id")),
+        account_handle(account.get("acct")),
+        instance_id(account.get("instance_id")),
+        position,
+        next_url,
+        limit,
+    )
+
+
+def parse_page_request(payload: dict[str, Any]) -> PageRequest:
+    if set(payload) != PAGE_REQUEST_KEYS or payload.get("action") != "page":
+        raise MastodonAdapterError("Mastodon read request has an invalid action shape")
+    stream = payload.get("stream")
+    if not isinstance(stream, str) or stream not in STREAMS:
+        raise MastodonAdapterError("Mastodon stream is unsupported")
+    limit = payload.get("limit")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 100:
+        raise MastodonAdapterError("Mastodon page size is invalid")
+    account_id = _text(payload.get("account_id"), "selected account ID")
+    if account_id is None:
+        raise MastodonAdapterError("Mastodon selected account ID is required")
+    return PageRequest(
+        stream,
+        account_id,
+        provider_account_id(payload.get("provider_account_id")),
+        account_handle(payload.get("acct")),
+        instance_id(payload.get("instance_id")),
+        _position(payload.get("position")),
+        _text(payload.get("stop_at"), "next link", optional=True),
+        limit,
+    )
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise MastodonAdapterError("Mastodon response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise MastodonAdapterError("Mastodon page data must be an array")
+    return data
+
+
+def page_checkpoint(
+    payload: dict[str, Any], state: CursorState, request: PageRequest
+) -> tuple[PageCheckpoint, bool]:
+    meta = payload.get("meta")
+    if not isinstance(meta, dict):
+        raise MastodonAdapterError("Mastodon page metadata must be an object")
+    reject_credentials(meta)
+    if meta.get("stream") != request.stream or instance_id(meta.get("instance_id")) != request.instance_id:
+        raise MastodonAdapterError("Mastodon page provenance is invalid")
+    if meta.get("snapshot") is not True:
+        raise MastodonAdapterError("Mastodon page pagination metadata is invalid")
+    if len(page_data(payload)) > MAX_PAGE_ITEMS:
+        raise MastodonAdapterError("Mastodon page exceeds the item safety limit")
+    next_url = _text(meta.get("next_url"), "next link", optional=True)
+    complete = meta.get("complete")
+    if not isinstance(complete, bool) or complete == (next_url is not None):
+        raise MastodonAdapterError("Mastodon page completion cursor is invalid")
+    cursor = _encode_cursor(request.position + 1, next_url) if next_url else None
+    return PageCheckpoint(cursor, state.watermark), complete

--- a/.agents/scripts/_knowledge_social_mastodon_contract.py
+++ b/.agents/scripts/_knowledge_social_mastodon_contract.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validation and serialization for the bounded Mastodon HTTP child."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_mastodon_identity import provider_account_id
+
+MAX_TEXT_BYTES = 256 * 1024
+
+
+class MastodonReadProviderError(RuntimeError):
+    """Raised for a privacy-safe local Mastodon provider failure."""
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    status: int
+    payload: Any
+    next_url: str | None = None
+    retry_after: int | None = None
+
+
+def observed_at() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def exact_keys(request: dict[str, Any], expected: set[str]) -> None:
+    if set(request) != expected:
+        raise MastodonReadProviderError("Mastodon read request has an invalid action shape")
+
+
+def request_object(payload: bytes, limit: int) -> dict[str, Any]:
+    if len(payload) > limit:
+        raise MastodonReadProviderError("Mastodon read request exceeds the safety limit")
+    try:
+        request = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise MastodonReadProviderError("Mastodon read request is not valid JSON") from error
+    if not isinstance(request, dict):
+        raise MastodonReadProviderError("Mastodon read request root must be an object")
+    return request
+
+
+def object_value(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise MastodonReadProviderError(f"Mastodon {field} must be an object")
+    return value
+
+
+def object_list(value: Any, field: str, *, limit: int) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise MastodonReadProviderError(f"Mastodon {field} must be an array of objects")
+    if len(value) > limit:
+        raise MastodonReadProviderError(f"Mastodon {field} exceeds the item safety limit")
+    return value
+
+
+def optional_text(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value:
+        raise MastodonReadProviderError(f"Mastodon {field} must be text")
+    if len(value.encode("utf-8")) > MAX_TEXT_BYTES:
+        raise MastodonReadProviderError(f"Mastodon {field} exceeds the safety limit")
+    return value
+
+
+def required_text(value: Any, field: str) -> str:
+    text = optional_text(value, field)
+    if not text:
+        raise MastodonReadProviderError(f"Mastodon {field} is required")
+    return text
+
+
+def optional_boolean(value: Any, field: str) -> bool | None:
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise MastodonReadProviderError(f"Mastodon {field} must be boolean")
+    return value
+
+
+def identity_value(payload: Any, expected_id: str, installation: str) -> dict[str, Any]:
+    """Serialize only stable allowlisted fields from verify_credentials."""
+    account = object_value(payload, "identity response")
+    local_id = required_text(account.get("id"), "account ID")
+    if provider_account_id(local_id) != provider_account_id(expected_id):
+        raise MastodonReadProviderError(
+            "selected Mastodon account does not match the configured connection"
+        )
+    username = required_text(account.get("username"), "account username")
+    acct = required_text(account.get("acct"), "account acct")
+    return {
+        "provider_account_id": local_id,
+        "username": username,
+        "acct": acct,
+        "display_name": optional_text(account.get("display_name"), "account display name"),
+        "uri": optional_text(account.get("uri"), "account URI"),
+        "instance_id": installation,
+    }
+
+
+def terminal_payload(result: ApiResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": result.status, "observed_at": observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload

--- a/.agents/scripts/_knowledge_social_mastodon_contract.py
+++ b/.agents/scripts/_knowledge_social_mastodon_contract.py
@@ -36,13 +36,17 @@ def exact_keys(request: dict[str, Any], expected: set[str]) -> None:
         raise MastodonReadProviderError("Mastodon read request has an invalid action shape")
 
 
-def request_object(payload: bytes, limit: int) -> dict[str, Any]:
+def decode_json(payload: bytes, limit: int) -> Any:
     if len(payload) > limit:
-        raise MastodonReadProviderError("Mastodon read request exceeds the safety limit")
+        raise MastodonReadProviderError("Mastodon JSON payload exceeds the safety limit")
     try:
-        request = json.loads(payload.decode("utf-8"))
+        return json.loads(payload.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise MastodonReadProviderError("Mastodon read request is not valid JSON") from error
+        raise MastodonReadProviderError("Mastodon JSON payload is invalid") from error
+
+
+def request_object(payload: bytes, limit: int) -> dict[str, Any]:
+    request = decode_json(payload, limit)
     if not isinstance(request, dict):
         raise MastodonReadProviderError("Mastodon read request root must be an object")
     return request

--- a/.agents/scripts/_knowledge_social_mastodon_http.py
+++ b/.agents/scripts/_knowledge_social_mastodon_http.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Exact-origin, redirect-free HTTP transport for Mastodon account reads."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import math
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import SplitResult, parse_qsl, urlencode, urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from _knowledge_social_mastodon_contract import ApiResult, MastodonReadProviderError
+from _knowledge_social_mastodon_routes import (
+    allowlisted_path,
+    page_limit_for_path,
+    query_keys_for_path,
+)
+
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+HTTP_TIMEOUT_SECONDS = 60
+
+
+class Headers(Protocol):
+    def get(self, key: str, default: str | None = None) -> str | None: ...
+
+
+class Response(Protocol):
+    status: int
+    headers: Headers
+
+    def __enter__(self) -> Response: ...
+    def __exit__(self, *args: Any) -> None: ...
+    def read(self, size: int = -1) -> bytes: ...
+
+
+class Opener(Protocol):
+    def open(self, request: Request, timeout: int) -> Response: ...
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    base_url: str
+    access_token: str
+    auth_mode: str
+    instance_id: str
+    scopes: frozenset[str]
+
+
+class _RejectRedirect(HTTPRedirectHandler):
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def _parsed_url(value: str) -> tuple[SplitResult, int | None]:
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError as error:
+        raise MastodonReadProviderError("Mastodon profile base URL is invalid") from error
+    return parsed, port
+
+
+def _canonical_base_url(value: str) -> str:
+    parsed, port = _parsed_url(value)
+    checks = (
+        parsed.scheme.lower() == "https",
+        parsed.hostname is not None,
+        parsed.username is None,
+        parsed.password is None,
+        parsed.path in ("", "/"),
+        not parsed.query,
+        not parsed.fragment,
+    )
+    if not all(checks):
+        raise MastodonReadProviderError("Mastodon profile base URL must be an HTTPS origin")
+    host = parsed.hostname or ""
+    rendered = f"[{host.lower()}]" if ":" in host else host.lower()
+    if port is not None and port != 443:
+        rendered = f"{rendered}:{port}"
+    return f"https://{rendered}"
+
+
+def installation_fingerprint(base_url: str, origin_key: str) -> str:
+    canonical = _canonical_base_url(base_url)
+    key = origin_key.encode()
+    if len(key) < 32:
+        raise MastodonReadProviderError(
+            "Mastodon profile origin key must be at least 32 bytes"
+        )
+    return hmac.new(key, canonical.encode(), hashlib.sha256).hexdigest()[:24]
+
+
+def _http_exports() -> Opener:
+    exports = (Request, build_opener, urlencode, urlsplit, HTTPRedirectHandler)
+    if not all(callable(item) for item in exports):
+        raise MastodonReadProviderError("Python urllib HTTP exports are unavailable")
+    return build_opener(_RejectRedirect())
+
+
+def _retry_epoch(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    return int(time.time() + math.ceil(seconds))
+
+
+def _decode_response(payload: bytes) -> Any:
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise MastodonReadProviderError("Mastodon read response exceeds the safety limit")
+    try:
+        decoded = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise MastodonReadProviderError(
+            "Mastodon read provider returned no valid JSON"
+        ) from error
+    if not isinstance(decoded, (dict, list)):
+        raise MastodonReadProviderError(
+            "Mastodon API response root must be an object or array"
+        )
+    return decoded
+
+
+def _same_origin(config: ProfileConfig, parsed: SplitResult) -> bool:
+    base = urlsplit(config.base_url)
+    return (
+        parsed.scheme.lower() == base.scheme
+        and parsed.hostname == base.hostname
+        and parsed.port == base.port
+        and parsed.username is None
+        and parsed.password is None
+        and not parsed.fragment
+    )
+
+
+def _validate_query(path: str, query: str) -> None:
+    allowed = query_keys_for_path(path)
+    try:
+        pairs = parse_qsl(query, keep_blank_values=True, strict_parsing=True)
+    except ValueError as error:
+        raise MastodonReadProviderError("Mastodon pagination query is invalid") from error
+    if len(pairs) != len({key for key, _value in pairs}):
+        raise MastodonReadProviderError("Mastodon pagination query is invalid")
+    if any(key not in allowed or not value or "\x00" in value for key, value in pairs):
+        raise MastodonReadProviderError("Mastodon pagination query is not allowlisted")
+    for key, value in pairs:
+        if key == "limit" and (
+            not value.isdigit() or not 1 <= int(value) <= page_limit_for_path(path)
+        ):
+            raise MastodonReadProviderError("Mastodon pagination limit is invalid")
+
+
+def _target_url(config: ProfileConfig, target: str, params: dict[str, str]) -> str:
+    if target.startswith("/"):
+        if not allowlisted_path(target) or set(params) - query_keys_for_path(target):
+            raise MastodonReadProviderError("Mastodon API route is not allowlisted")
+        if any(not isinstance(value, str) or not value or "\x00" in value for value in params.values()):
+            raise MastodonReadProviderError("Mastodon API query is invalid")
+        query = urlencode(params)
+        _validate_query(target, query)
+        return f"{config.base_url}{target}" + (f"?{query}" if query else "")
+    if params:
+        raise MastodonReadProviderError("Mastodon opaque next link cannot be rewritten")
+    parsed, _port = _parsed_url(target)
+    if not _same_origin(config, parsed) or not allowlisted_path(parsed.path):
+        raise MastodonReadProviderError("Mastodon pagination link is not allowlisted")
+    _validate_query(parsed.path, parsed.query)
+    return target
+
+
+def _next_link(config: ProfileConfig, header: str | None) -> str | None:
+    if not header:
+        return None
+    for match in re.finditer(r"<([^<>]+)>\s*;([^,]*)", header):
+        target, attributes = match.groups()
+        relation = re.search(r'(?:^|;)\s*rel\s*=\s*"?([^";,\s]+)', attributes)
+        if relation is not None and relation.group(1) == "next":
+            return _target_url(config, target, {})
+    return None
+
+
+def _request_for(config: ProfileConfig, url: str) -> Request:
+    return Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {config.access_token}",
+            "User-Agent": "aidevops-mastodon-knowledge/1",
+        },
+        method="GET",
+    )
+
+
+def api(
+    config: ProfileConfig,
+    opener: Opener,
+    target: str,
+    params: dict[str, str],
+) -> ApiResult:
+    """Execute one exact-origin, redirect-free, GET-only JSON request."""
+    url = _target_url(config, target, params)
+    request = _request_for(config, url)
+    try:
+        with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", 200)
+            if isinstance(status, bool) or not isinstance(status, int):
+                raise MastodonReadProviderError("Mastodon HTTP status is invalid")
+            payload = response.read(MAX_RESPONSE_BYTES + 1)
+            if not isinstance(payload, bytes):
+                raise MastodonReadProviderError("Mastodon HTTP response is invalid")
+            return ApiResult(
+                status,
+                _decode_response(payload),
+                _next_link(config, response.headers.get("Link")),
+            )
+    except HTTPError as error:
+        retry = error.headers.get("Retry-After") if error.headers is not None else None
+        return ApiResult(error.code, {}, retry_after=_retry_epoch(retry))
+    except (TimeoutError, URLError, OSError) as error:
+        raise MastodonReadProviderError("Mastodon read provider request failed") from error

--- a/.agents/scripts/_knowledge_social_mastodon_http.py
+++ b/.agents/scripts/_knowledge_social_mastodon_http.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import hashlib
 import hmac
-import json
 import math
 import re
 import time
@@ -17,7 +16,11 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import SplitResult, parse_qsl, urlencode, urlsplit
 from urllib.request import HTTPRedirectHandler, Request, build_opener
 
-from _knowledge_social_mastodon_contract import ApiResult, MastodonReadProviderError
+from _knowledge_social_mastodon_contract import (
+    ApiResult,
+    MastodonReadProviderError,
+    decode_json,
+)
 from _knowledge_social_mastodon_routes import (
     allowlisted_path,
     page_limit_for_path,
@@ -118,14 +121,7 @@ def _retry_epoch(value: str | None) -> int | None:
 
 
 def _decode_response(payload: bytes) -> Any:
-    if len(payload) > MAX_RESPONSE_BYTES:
-        raise MastodonReadProviderError("Mastodon read response exceeds the safety limit")
-    try:
-        decoded = json.loads(payload.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise MastodonReadProviderError(
-            "Mastodon read provider returned no valid JSON"
-        ) from error
+    decoded = decode_json(payload, MAX_RESPONSE_BYTES)
     if not isinstance(decoded, (dict, list)):
         raise MastodonReadProviderError(
             "Mastodon API response root must be an object or array"
@@ -135,14 +131,15 @@ def _decode_response(payload: bytes) -> Any:
 
 def _same_origin(config: ProfileConfig, parsed: SplitResult) -> bool:
     base = urlsplit(config.base_url)
-    return (
-        parsed.scheme.lower() == base.scheme
-        and parsed.hostname == base.hostname
-        and parsed.port == base.port
-        and parsed.username is None
-        and parsed.password is None
-        and not parsed.fragment
+    checks = (
+        parsed.scheme.lower() == base.scheme,
+        parsed.hostname == base.hostname,
+        parsed.port == base.port,
+        parsed.username is None,
+        parsed.password is None,
+        not parsed.fragment,
     )
+    return all(checks)
 
 
 def _validate_query(path: str, query: str) -> None:

--- a/.agents/scripts/_knowledge_social_mastodon_identity.py
+++ b/.agents/scripts/_knowledge_social_mastodon_identity.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Mastodon instance, account, and resource identity validation."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any
+
+from knowledge_social_store import SocialStoreError
+
+INSTANCE_ID = re.compile(r"^[0-9a-f]{24}$")
+RESOURCE_KIND = re.compile(r"^[a-z][a-z_]{0,31}$")
+
+
+class MastodonAdapterError(SocialStoreError):
+    """Raised when guarded Mastodon collection cannot continue safely."""
+
+
+class MastodonProviderUnavailableError(MastodonAdapterError):
+    """Raised when the bounded Mastodon HTTP child cannot complete a read."""
+
+
+def _opaque_id(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise MastodonAdapterError(f"Mastodon {field} is invalid")
+    if len(value.encode("utf-8")) > 512:
+        raise MastodonAdapterError(f"Mastodon {field} is invalid")
+    return value
+
+
+def instance_id(value: Any) -> str:
+    """Validate a privacy-safe stable home-instance fingerprint."""
+    if not isinstance(value, str) or INSTANCE_ID.fullmatch(value) is None:
+        raise MastodonAdapterError("Mastodon instance identity is invalid")
+    return value
+
+
+def provider_account_id(value: Any) -> str:
+    """Validate an opaque home-instance account ID."""
+    if isinstance(value, str) and value.startswith("account_"):
+        value = value.removeprefix("account_")
+    return _opaque_id(value, "account ID")
+
+
+def account_handle(value: Any) -> str:
+    """Validate an allowlisted account handle without interpreting federation."""
+    return _opaque_id(value, "account handle")
+
+
+def namespaced_id(installation: str, kind: str, value: str) -> str:
+    """Namespace one opaque installation-local ID without embedding its value."""
+    stable_instance = instance_id(installation)
+    if RESOURCE_KIND.fullmatch(kind) is None:
+        raise MastodonAdapterError("Mastodon resource kind is invalid")
+    opaque = _opaque_id(value, "resource ID")
+    digest = hashlib.sha256(opaque.encode("utf-8")).hexdigest()[:32]
+    return f"mst_{stable_instance}_{kind}_{digest}"

--- a/.agents/scripts/_knowledge_social_mastodon_normalize.py
+++ b/.agents/scripts/_knowledge_social_mastodon_normalize.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize allowlisted Mastodon records into provider-neutral evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_mastodon import (
+    ACCOUNT_AUTH_MODE,
+    PROVIDER,
+    RETENTION_LIMIT,
+    MastodonAdapterError,
+    instance_id,
+    page_data,
+)
+from knowledge_social_import import reject_credentials
+
+PROVENANCE = "mastodon_official_rest_api"
+GAPS = (
+    ("conversations", "separate_private_data_consent_required"),
+    ("list_members", "nested_list_member_pagination_not_enabled"),
+    ("account_exports", "operator_initiated_export_not_imported"),
+    ("federated_history", "home_instance_visibility_is_not_federation_completeness"),
+    ("moderation_history", "moderation_state_is_not_complete_account_history"),
+    ("deleted_or_purged_content", "not_available_through_current_account_reads"),
+    ("instance_retention", "instance_specific_retention_is_not_discoverable_here"),
+)
+OBJECT_TYPES = frozenset({"status", "notification", "account", "tag", "list"})
+ACTIVITY_TYPES = {
+    "authored_statuses": "authored_status",
+    "favourites": "favourite",
+    "bookmarks": "bookmark",
+    "notifications": "notification",
+    "followers": "follower",
+    "following": "following",
+    "followed_tags": "followed_tag",
+    "lists": "list_membership",
+}
+
+
+@dataclass(frozen=True)
+class PageContext:
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def _required_text(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise MastodonAdapterError(f"Mastodon record requires {key}")
+    return value
+
+
+def _optional_text(record: dict[str, Any], key: str) -> str | None:
+    value = record.get(key)
+    if value is not None and (not isinstance(value, str) or "\x00" in value):
+        raise MastodonAdapterError(f"Mastodon record {key} must be text")
+    return value
+
+
+def _observed_at(payload: dict[str, Any]) -> str:
+    value = payload.get("observed_at")
+    if not isinstance(value, str) or not value:
+        raise MastodonAdapterError("Mastodon page observed_at must be text")
+    return value
+
+
+def _coverage(observed_at: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "stream": stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": RETENTION_LIMIT,
+            "unavailable_reason": reason,
+            "status": "unavailable",
+            "observed_at": observed_at,
+        }
+        for stream, reason in GAPS
+    ]
+
+
+def _object_row(item: dict[str, Any], context: PageContext, observed_at: str) -> dict[str, Any]:
+    kind = item.get("kind")
+    if not isinstance(kind, str) or kind not in OBJECT_TYPES:
+        raise MastodonAdapterError("Mastodon page contains an unsupported item kind")
+    remote_id = _required_text(item, "remote_id")
+    text = "\n\n".join(
+        value
+        for key in ("title", "content", "spoiler_text", "name")
+        if (value := _optional_text(item, key))
+    ) or None
+    authored = context.stream == "authored_statuses"
+    provider_json = {"source": PROVENANCE, "stream": context.stream, "record": item}
+    reject_credentials(provider_json)
+    return {
+        "object_type": kind,
+        "remote_id": remote_id,
+        "account_remote_id": context.account.get("id") if authored else None,
+        "text": text,
+        "created_at": _optional_text(item, "created_at"),
+        "observed_at": observed_at,
+        "evidence_class": "authored" if authored else "observed",
+        "provider_json": provider_json,
+    }
+
+
+def _activity_row(item: dict[str, Any], context: PageContext, observed_at: str) -> dict[str, Any]:
+    selected = _required_text(context.account, "id")
+    remote_id = _required_text(item, "remote_id")
+    activity_type = ACTIVITY_TYPES[context.stream]
+    actor, target = selected, remote_id
+    if context.stream == "followers":
+        actor, target = remote_id, selected
+    elif context.stream == "notifications":
+        actor = _required_text(item, "actor_remote_id")
+    return {
+        "activity_type": activity_type,
+        "remote_id": f"{selected}_{activity_type}_{remote_id}",
+        "actor_remote_id": actor,
+        "object_remote_id": target,
+        "occurred_at": _optional_text(item, "created_at"),
+        "observed_at": observed_at,
+        "state": "active",
+        "provider_json": {"source": PROVENANCE, "stream": context.stream},
+    }
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    reject_credentials(payload)
+    observed_at = _observed_at(payload)
+    installation = instance_id(context.account.get("instance_id"))
+    items = page_data(payload)
+    policy = dict(context.policy)
+    policy.update(
+        {
+            "mastodon_auth_mode": ACCOUNT_AUTH_MODE,
+            "mastodon_instance_id": installation,
+            "mastodon_pagination": "opaque_rfc_link_next",
+            "mastodon_transport": "stdlib_urllib_get_only",
+            "mastodon_redirects": "rejected",
+        }
+    )
+    archive = {
+        "provider": PROVIDER,
+        "connection_id": context.connection_id,
+        "remote_account_id": context.account.get("id"),
+        "exported_at": observed_at,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": policy,
+        "accounts": [
+            {
+                "remote_id": context.account.get("id"),
+                "handle": context.account.get("acct"),
+                "display_name": context.account.get("name"),
+                "observed_at": observed_at,
+                "provider_json": {
+                    "source": PROVENANCE,
+                    "instance_id": installation,
+                    "provider_account_id": context.account.get("provider_account_id"),
+                    "uri": context.account.get("uri"),
+                },
+            }
+        ],
+        "objects": [_object_row(item, context, observed_at) for item in items],
+        "activities": [_activity_row(item, context, observed_at) for item in items],
+        "media": [],
+        "coverage": _coverage(observed_at),
+    }
+    reject_credentials(archive)
+    return archive

--- a/.agents/scripts/_knowledge_social_mastodon_provider.py
+++ b/.agents/scripts/_knowledge_social_mastodon_provider.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded, redirect-free, GET-only Mastodon account reader subprocess."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from functools import partial
+from typing import Any
+
+from _knowledge_social_mastodon import (
+    ACCOUNT_AUTH_MODE,
+    MastodonAdapterError,
+    PageRequest,
+    namespaced_id,
+    parse_page_request,
+    provider_account_id,
+)
+from _knowledge_social_mastodon_contract import (
+    ApiResult,
+    MastodonReadProviderError,
+    exact_keys,
+    identity_value,
+    object_value,
+    observed_at,
+    request_object,
+    terminal_payload,
+)
+from _knowledge_social_mastodon_http import (
+    MAX_RESPONSE_BYTES,
+    Opener,
+    ProfileConfig,
+    _canonical_base_url,
+    _http_exports,
+    api,
+    installation_fingerprint,
+)
+from _knowledge_social_mastodon_routes import page
+
+MAX_REQUEST_BYTES = 32 * 1024
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+SCOPE = re.compile(r"^[a-z]+(?::[a-z_]+)?$")
+STREAM_SCOPES = {
+    "authored_statuses": "read:statuses",
+    "favourites": "read:favourites",
+    "bookmarks": "read:bookmarks",
+    "notifications": "read:notifications",
+    "followers": "read:accounts",
+    "following": "read:accounts",
+    "followed_tags": "read:follows",
+    "lists": "read:lists",
+}
+
+
+def _profile_prefix(profile: str) -> str:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise MastodonReadProviderError("Mastodon profile name is invalid")
+    return f"MASTODON_{profile.upper()}"
+
+
+def _profile_value(prefix: str, suffix: str, field: str, limit: int) -> str:
+    value = os.environ.get(f"{prefix}_{suffix}", "")
+    if not value or "\x00" in value or len(value.encode()) > limit:
+        raise MastodonReadProviderError(f"Mastodon profile {field} is missing")
+    return value
+
+
+def _scopes(value: str) -> frozenset[str]:
+    scopes = frozenset(value.split())
+    if (
+        not scopes
+        or any(SCOPE.fullmatch(scope) is None for scope in scopes)
+        or any(scope == "write" or scope.startswith("write:") for scope in scopes)
+    ):
+        raise MastodonReadProviderError("Mastodon profile scopes are invalid")
+    if "read:accounts" not in scopes and "profile" not in scopes and "read" not in scopes:
+        raise MastodonReadProviderError("Mastodon profile lacks account identity scope")
+    return scopes
+
+
+def _profile(profile: str) -> ProfileConfig:
+    prefix = _profile_prefix(profile)
+    base_url = _canonical_base_url(_profile_value(prefix, "BASE_URL", "base URL", 4096))
+    token = _profile_value(prefix, "ACCESS_TOKEN", "access token", 16 * 1024)
+    origin_key = _profile_value(prefix, "ORIGIN_KEY", "origin key", 16 * 1024)
+    auth_mode = _profile_value(prefix, "AUTH_MODE", "auth mode", 64)
+    scopes = _scopes(_profile_value(prefix, "SCOPES", "scopes", 4096))
+    if auth_mode != ACCOUNT_AUTH_MODE:
+        raise MastodonReadProviderError("Mastodon profile must declare a user token")
+    return ProfileConfig(
+        base_url,
+        token,
+        auth_mode,
+        installation_fingerprint(base_url, origin_key),
+        scopes,
+    )
+
+
+def _has_scope(config: ProfileConfig, required: str) -> bool:
+    return required in config.scopes or "read" in config.scopes
+
+
+def _identity(config: ProfileConfig, opener: Opener, expected_id: str) -> dict[str, Any]:
+    result = api(config, opener, "/api/v1/accounts/verify_credentials", {})
+    if result.status != 200:
+        return terminal_payload(result)
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": identity_value(result.payload, expected_id, config.instance_id),
+    }
+
+
+def _verify_page_account(
+    request: PageRequest, data: dict[str, Any], config: ProfileConfig
+) -> None:
+    expected = namespaced_id(config.instance_id, "account", request.provider_account_id)
+    if (
+        data.get("instance_id") != request.instance_id
+        or data.get("provider_account_id") != request.provider_account_id
+        or data.get("acct") != request.acct
+        or request.account_id != expected
+    ):
+        raise MastodonReadProviderError(
+            "selected Mastodon account does not match the configured connection"
+        )
+
+
+def _dispatch(
+    request: dict[str, Any], config: ProfileConfig, opener: Opener
+) -> dict[str, Any]:
+    action = request.get("action")
+    if action == "identity":
+        exact_keys(request, {"action", "account_id"})
+        return _identity(config, opener, provider_account_id(request.get("account_id")))
+    if action != "page":
+        raise MastodonReadProviderError("Mastodon read action is unsupported")
+    page_request = parse_page_request(request)
+    if page_request.instance_id != config.instance_id:
+        raise MastodonReadProviderError(
+            "selected Mastodon instance does not match the connection"
+        )
+    required_scope = STREAM_SCOPES[page_request.stream]
+    if not _has_scope(config, required_scope):
+        raise MastodonReadProviderError("Mastodon profile lacks the selected stream scope")
+    identity = _identity(config, opener, page_request.provider_account_id)
+    if identity.get("status") != 200:
+        return identity
+    data = object_value(identity.get("data"), "account verification")
+    _verify_page_account(page_request, data, config)
+    result = page(partial(api, config, opener), page_request, data)
+    return terminal_payload(result) if isinstance(result, ApiResult) else result
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode()) > MAX_RESPONSE_BYTES:
+        raise MastodonReadProviderError("Mastodon read response exceeds the safety limit")
+    print(encoded)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        request = request_object(sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1), MAX_REQUEST_BYTES)
+        config = _profile(args.profile)
+        _emit(_dispatch(request, config, _http_exports()))
+        return 0
+    except (MastodonReadProviderError, MastodonAdapterError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - intentionally redact provider internals
+        print("ERROR: Mastodon read provider request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_mastodon_reader.py
+++ b/.agents/scripts/_knowledge_social_mastodon_reader.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and deterministic fixture readers for Mastodon collection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_mastodon import (
+    MastodonAdapterError,
+    MastodonProviderUnavailableError,
+    PageRequest,
+    account_handle,
+    instance_id,
+    namespaced_id,
+    provider_account_id,
+)
+from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
+from knowledge_social_import import reject_credentials
+
+READ_TIMEOUT_SECONDS = 120
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+SAFE_PROVIDER_FAILURES = (
+    "Python urllib HTTP exports are unavailable",
+    "Mastodon profile name is invalid",
+    "Mastodon profile base URL is missing",
+    "Mastodon profile base URL must be an HTTPS origin",
+    "Mastodon profile access token is missing",
+    "Mastodon profile origin key is missing",
+    "Mastodon profile origin key must be at least 32 bytes",
+    "Mastodon profile auth mode is missing",
+    "Mastodon profile must declare a user token",
+    "Mastodon profile scopes are missing",
+    "Mastodon profile scopes are invalid",
+    "Mastodon profile lacks account identity scope",
+    "Mastodon profile lacks the selected stream scope",
+    "selected Mastodon account does not match the configured connection",
+    "selected Mastodon instance does not match the connection",
+)
+
+
+class MastodonReader(Protocol):
+    def identity(self, expected_id: str) -> dict[str, Any]: ...
+    def page(self, request: PageRequest) -> dict[str, Any]: ...
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    if len(output.encode()) > MAX_RESPONSE_BYTES:
+        raise MastodonAdapterError("Mastodon read response exceeds the safety limit")
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise MastodonAdapterError("Mastodon read provider returned no valid JSON") from error
+    if not isinstance(payload, dict):
+        raise MastodonAdapterError("Mastodon read response root must be an object")
+    return payload
+
+
+def _provider_failure(stderr: str) -> MastodonProviderUnavailableError:
+    for message in SAFE_PROVIDER_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return MastodonProviderUnavailableError(message)
+    return MastodonProviderUnavailableError("Mastodon read provider is unavailable")
+
+
+MASTODON_READER_POLICY = GuardedOAuthPolicy(
+    "Mastodon",
+    "MASTODON",
+    "MASTODON_READ_LOG",
+    READ_TIMEOUT_SECONDS,
+    _decode_output,
+    _provider_failure,
+    MastodonProviderUnavailableError,
+    ("BASE_URL", "ACCESS_TOKEN", "ORIGIN_KEY", "AUTH_MODE", "SCOPES"),
+    "",
+)
+
+
+class GuardedMastodon(GuardedOAuthReader):
+    def __init__(self, helper: Path, profile: str) -> None:
+        super().__init__(helper, profile, MASTODON_READER_POLICY)
+
+
+def _fixture_object(value: Any, message: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise MastodonAdapterError(message)
+    return value
+
+
+class FixtureMastodon:
+    def __init__(self, path: Path) -> None:
+        self.fixture = FixtureSequence(path, "Mastodon", MastodonAdapterError)
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        del expected_id
+        return self.fixture.identity()
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        entry = self.fixture.next_page()
+        expectation = _fixture_object(
+            entry.get("expect_request", {}),
+            "Mastodon fixture request expectation must be an object",
+        )
+        actual = request.payload()
+        for key, value in expectation.items():
+            if actual.get(key) != value:
+                raise MastodonAdapterError(
+                    "Mastodon request did not resume at the expected checkpoint"
+                )
+        return _fixture_object(
+            entry.get("response", entry),
+            "Mastodon fixture page response must be an object",
+        )
+
+
+def _display_text(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise MastodonAdapterError(f"Mastodon account {field} must be text")
+    if len(value.encode()) > 256 * 1024:
+        raise MastodonAdapterError(f"Mastodon account {field} must be text")
+    return value
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    """Bind an opaque home-instance account ID to a global namespace."""
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise MastodonAdapterError("Mastodon account verification returned no account")
+    local_id = provider_account_id(data.get("provider_account_id"))
+    installation = instance_id(data.get("instance_id"))
+    acct = account_handle(data.get("acct"))
+    if local_id != provider_account_id(expected_id):
+        raise MastodonAdapterError(
+            "selected Mastodon account does not match the configured connection"
+        )
+    return {
+        "id": namespaced_id(installation, "account", local_id),
+        "provider_account_id": local_id,
+        "instance_id": installation,
+        "acct": acct,
+        "username": _display_text(data.get("username"), "username"),
+        "name": _display_text(data.get("display_name"), "display name"),
+        "uri": _display_text(data.get("uri"), "URI"),
+    }

--- a/.agents/scripts/_knowledge_social_mastodon_routes.py
+++ b/.agents/scripts/_knowledge_social_mastodon_routes.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Exact GET route allowlist, opaque pagination, and Mastodon serializers."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable
+from urllib.parse import quote, urlsplit
+
+from _knowledge_social_mastodon import PageRequest, namespaced_id
+from _knowledge_social_mastodon_contract import (
+    ApiResult,
+    MastodonReadProviderError,
+    object_list,
+    object_value,
+    observed_at,
+    optional_boolean,
+    optional_text,
+    required_text,
+)
+
+Api = Callable[[str, dict[str, str]], ApiResult]
+PageResult = ApiResult | dict[str, Any]
+
+EXACT_READ_PATHS = frozenset(
+    {
+        "/api/v1/accounts/verify_credentials",
+        "/api/v1/favourites",
+        "/api/v1/bookmarks",
+        "/api/v1/notifications",
+        "/api/v1/followed_tags",
+        "/api/v1/lists",
+    }
+)
+ACCOUNT_PATH = re.compile(r"^/api/v1/accounts/[A-Za-z0-9._~%-]+/(statuses|followers|following)$")
+LIST_ACCOUNTS_PATH = re.compile(r"^/api/v1/lists/[A-Za-z0-9._~%-]+/accounts$")
+
+STREAM_PATHS = {
+    "favourites": "/api/v1/favourites",
+    "bookmarks": "/api/v1/bookmarks",
+    "notifications": "/api/v1/notifications",
+    "followed_tags": "/api/v1/followed_tags",
+    "lists": "/api/v1/lists",
+}
+STREAM_LIMITS = {
+    "authored_statuses": 40,
+    "favourites": 40,
+    "bookmarks": 40,
+    "notifications": 80,
+    "followers": 80,
+    "following": 80,
+    "followed_tags": 100,
+    "lists": 100,
+}
+
+
+def allowlisted_path(path: str) -> bool:
+    return (
+        path in EXACT_READ_PATHS
+        or ACCOUNT_PATH.fullmatch(path) is not None
+        or LIST_ACCOUNTS_PATH.fullmatch(path) is not None
+    )
+
+
+def query_keys_for_path(path: str) -> frozenset[str]:
+    if path in ("/api/v1/accounts/verify_credentials", "/api/v1/lists"):
+        return frozenset()
+    return frozenset({"limit", "max_id", "min_id", "since_id"})
+
+
+def page_limit_for_path(path: str) -> int:
+    if path in ("/api/v1/favourites", "/api/v1/bookmarks") or path.endswith("/statuses"):
+        return 40
+    if path == "/api/v1/notifications" or path.endswith(("/followers", "/following", "/accounts")):
+        return 80
+    return 100
+
+
+def _resource_id(request: PageRequest, kind: str, value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise MastodonReadProviderError(f"Mastodon {field} is required")
+    try:
+        return namespaced_id(request.instance_id, kind, value)
+    except RuntimeError as error:
+        raise MastodonReadProviderError(str(error)) from error
+
+
+def _account(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    account_id = required_text(item.get("id"), "account ID")
+    return {
+        "kind": "account",
+        "remote_id": _resource_id(request, "account", account_id, "account ID"),
+        "provider_account_id": account_id,
+        "username": required_text(item.get("username"), "account username"),
+        "acct": required_text(item.get("acct"), "account acct"),
+        "name": optional_text(item.get("display_name"), "account display name"),
+    }
+
+
+def _status(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    status_id = required_text(item.get("id"), "status ID")
+    author = object_value(item.get("account"), "status account")
+    author_id = required_text(author.get("id"), "status account ID")
+    if request.stream == "authored_statuses" and author_id != request.provider_account_id:
+        raise MastodonReadProviderError(
+            "Mastodon authored status does not belong to the selected account"
+        )
+    return {
+        "kind": "status",
+        "remote_id": _resource_id(request, "status", status_id, "status ID"),
+        "status_id": status_id,
+        "author_remote_id": _resource_id(request, "account", author_id, "status account ID"),
+        "content": optional_text(item.get("content"), "status content"),
+        "spoiler_text": optional_text(item.get("spoiler_text"), "status spoiler text"),
+        "created_at": optional_text(item.get("created_at"), "status timestamp"),
+        "visibility": optional_text(item.get("visibility"), "status visibility"),
+        "sensitive": optional_boolean(item.get("sensitive"), "status sensitive flag"),
+    }
+
+
+def _notification(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    notification_id = required_text(item.get("id"), "notification ID")
+    actor = object_value(item.get("account"), "notification account")
+    actor_id = required_text(actor.get("id"), "notification account ID")
+    status = item.get("status")
+    status_id = None
+    if status is not None:
+        status_id = required_text(object_value(status, "notification status").get("id"), "status ID")
+    return {
+        "kind": "notification",
+        "remote_id": _resource_id(request, "notification", notification_id, "notification ID"),
+        "notification_id": notification_id,
+        "notification_type": required_text(item.get("type"), "notification type"),
+        "actor_remote_id": _resource_id(request, "account", actor_id, "notification account ID"),
+        "status_remote_id": (
+            _resource_id(request, "status", status_id, "status ID") if status_id else None
+        ),
+        "created_at": optional_text(item.get("created_at"), "notification timestamp"),
+    }
+
+
+def _tag(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    name = required_text(item.get("name"), "tag name")
+    return {
+        "kind": "tag",
+        "remote_id": _resource_id(request, "tag", name, "tag name"),
+        "name": name,
+    }
+
+
+def _list(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    list_id = required_text(item.get("id"), "list ID")
+    return {
+        "kind": "list",
+        "remote_id": _resource_id(request, "list", list_id, "list ID"),
+        "list_id": list_id,
+        "title": required_text(item.get("title"), "list title"),
+        "replies_policy": optional_text(item.get("replies_policy"), "list replies policy"),
+        "exclusive": optional_boolean(item.get("exclusive"), "list exclusive flag"),
+    }
+
+
+SERIALIZERS = {
+    "authored_statuses": _status,
+    "favourites": _status,
+    "bookmarks": _status,
+    "notifications": _notification,
+    "followers": _account,
+    "following": _account,
+    "followed_tags": _tag,
+    "lists": _list,
+}
+
+
+def _initial_path(request: PageRequest) -> tuple[str, dict[str, str]]:
+    if request.stream == "authored_statuses":
+        path = f"/api/v1/accounts/{quote(request.provider_account_id, safe='')}/statuses"
+    elif request.stream in ("followers", "following"):
+        path = f"/api/v1/accounts/{quote(request.provider_account_id, safe='')}/{request.stream}"
+    else:
+        path = STREAM_PATHS[request.stream]
+    bounded_limit = min(request.limit, STREAM_LIMITS[request.stream])
+    params = {} if request.stream == "lists" else {"limit": str(bounded_limit)}
+    return path, params
+
+
+def page(api: Api, request: PageRequest, _identity: dict[str, Any]) -> PageResult:
+    """Execute one initial route or the validated opaque next Link unchanged."""
+    initial_path, initial_params = _initial_path(request)
+    if request.stop_at is None:
+        target, params = initial_path, initial_params
+    else:
+        parsed = urlsplit(request.stop_at)
+        if parsed.scheme.lower() != "https" or not parsed.netloc or parsed.path != initial_path:
+            raise MastodonReadProviderError(
+                "Mastodon pagination link does not match the selected stream"
+            )
+        target, params = request.stop_at, {}
+    result = api(target, params)
+    if result.status != 200:
+        return result
+    source = object_list(
+        result.payload,
+        f"{request.stream} response",
+        limit=STREAM_LIMITS[request.stream],
+    )
+    records = [SERIALIZERS[request.stream](item, request) for item in source]
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": records,
+        "meta": {
+            "stream": request.stream,
+            "instance_id": request.instance_id,
+            "next_url": result.next_url,
+            "complete": result.next_url is None,
+            "snapshot": True,
+        },
+    }

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -15,6 +15,7 @@ META_HELPER="${SCRIPT_DIR}/knowledge_social_meta.py"
 MEDIUM_HELPER="${SCRIPT_DIR}/knowledge_social_medium.py"
 DISCOURSE_HELPER="${SCRIPT_DIR}/knowledge_social_discourse.py"
 NODEBB_HELPER="${SCRIPT_DIR}/knowledge_social_nodebb.py"
+MASTODON_HELPER="${SCRIPT_DIR}/knowledge_social_mastodon.py"
 QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
 SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
 SHARE_HELPER="${SCRIPT_DIR}/knowledge_social_share.py"
@@ -110,6 +111,13 @@ NodeBB synchronization:
   plugin routes, redirects, and mutations are unreachable. Installation-local
   IDs are keyed and namespaced. --budget is 3-1000 and --page-size is 1-50.
 
+Mastodon synchronization:
+  sync-mastodon binds one user token to GET /api/v1/accounts/verify_credentials
+  on an exact HTTPS home instance before every page. Eight independent streams
+  preserve same-origin RFC Link pagination without interpreting opaque IDs.
+  Write scopes, redirects, cross-origin links, and mutations are rejected.
+  --budget is 3-1000 and --page-size is 1-100.
+
 EOF
 	return 0
 }
@@ -156,6 +164,10 @@ Usage:
   knowledge-social-helper.sh sync-nodebb [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id USER_NUMERIC_ID --stream STREAM \
     --profile PROFILE [--budget UNITS] [--page-size 1-50] \
+    [--collector-id ID] [--lease-seconds SECONDS]
+  knowledge-social-helper.sh sync-mastodon [--base PATH] [--alias ALIAS] \
+    --connection-id ID --account-id OPAQUE_HOME_ACCOUNT_ID --stream STREAM \
+    --profile PROFILE [--budget UNITS] [--page-size 1-100] \
     [--collector-id ID] [--lease-seconds SECONDS]
   knowledge-social-helper.sh sync-due [--base PATH] [--alias ALIAS] \
     [--now-epoch EPOCH] [--interval-seconds SECONDS]
@@ -416,6 +428,9 @@ main() {
 		;;
 	sync-nodebb)
 		run_provider_sync NodeBB "$NODEBB_HELPER" "$@" || return 1
+		;;
+	sync-mastodon)
+		run_provider_sync Mastodon "$MASTODON_HELPER" "$@" || return 1
 		;;
 	query | annotate)
 		run_query_command "$subcommand" "$@" || return 1

--- a/.agents/scripts/knowledge_social_mastodon.py
+++ b/.agents/scripts/knowledge_social_mastodon.py
@@ -12,22 +12,24 @@ from _knowledge_social_mastodon_normalize import PageContext, normalize_page
 from _knowledge_social_mastodon_reader import FixtureMastodon, GuardedMastodon, verified_identity
 from _knowledge_social_oauth_collector import OAuthCollectorPolicy, run_oauth_collector
 
-COLLECTOR_OPTIONS = {
-    "display_name": "Mastodon",
-    "provider_module": mastodon,
-    "helper": Path(__file__).with_name("_knowledge_social_mastodon_provider.py"),
-    "fixture_reader": FixtureMastodon,
-    "live_reader": GuardedMastodon,
-    "page_context": PageContext,
-    "normalize_page": normalize_page,
-    "verified_identity": verified_identity,
-    "budget_unit": "request",
-    "max_page_size": 100,
-}
+def _policy() -> OAuthCollectorPolicy:
+    """Bind Mastodon-specific boundaries to the shared OAuth collector."""
+    return OAuthCollectorPolicy(
+        provider_module=mastodon,
+        verified_identity=verified_identity,
+        normalize_page=normalize_page,
+        page_context=PageContext,
+        display_name="Mastodon",
+        helper=Path(__file__).with_name("_knowledge_social_mastodon_provider.py"),
+        fixture_reader=FixtureMastodon,
+        live_reader=GuardedMastodon,
+        budget_unit="request",
+        max_page_size=100,
+    )
 
 
 def main() -> int:
-    return run_oauth_collector(OAuthCollectorPolicy(**COLLECTOR_OPTIONS), __doc__ or "")
+    return run_oauth_collector(_policy(), __doc__ or "")
 
 
 if __name__ == "__main__":

--- a/.agents/scripts/knowledge_social_mastodon.py
+++ b/.agents/scripts/knowledge_social_mastodon.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one bounded, read-only Mastodon account stream into a social corpus."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import _knowledge_social_mastodon as mastodon
+from _knowledge_social_mastodon_normalize import PageContext, normalize_page
+from _knowledge_social_mastodon_reader import FixtureMastodon, GuardedMastodon, verified_identity
+from _knowledge_social_oauth_collector import OAuthCollectorPolicy, run_oauth_collector
+
+COLLECTOR_OPTIONS = {
+    "display_name": "Mastodon",
+    "provider_module": mastodon,
+    "helper": Path(__file__).with_name("_knowledge_social_mastodon_provider.py"),
+    "fixture_reader": FixtureMastodon,
+    "live_reader": GuardedMastodon,
+    "page_context": PageContext,
+    "normalize_page": normalize_page,
+    "verified_identity": verified_identity,
+    "budget_unit": "request",
+    "max_page_size": 100,
+}
+
+
+def main() -> int:
+    return run_oauth_collector(OAuthCollectorPolicy(**COLLECTOR_OPTIONS), __doc__ or "")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/knowledge_social_registry.py
+++ b/.agents/scripts/knowledge_social_registry.py
@@ -51,6 +51,7 @@ PROVIDER_SPECS = (
         (("live", ()),),
     ),
     ProviderSpec("gumroad", (), "knowledge_social_gumroad.py", (("live", ()),)),
+    ProviderSpec("mastodon", (), "knowledge_social_mastodon.py", (("live", ()),)),
     ProviderSpec(
         "nextcloud-talk",
         (),

--- a/.agents/tests/test-knowledge-social-mastodon.sh
+++ b/.agents/tests/test-knowledge-social-mastodon.sh
@@ -1,0 +1,413 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-mastodon.sh — Bounded Mastodon collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MASTODON_SCRIPT="${SCRIPT_DIR}/../scripts/knowledge_social_mastodon.py"
+SOCIAL_HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+INSTANCE_A="aaaaaaaaaaaaaaaaaaaaaaaa"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' \
+			"$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c 'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_count() {
+	python3 - "$ROOT/sources/social/raw/mastodon" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+print(len(list(root.rglob("*.json.gz"))) if root.exists() else 0)
+PY
+	return 0
+}
+
+run_mastodon() {
+	local fixture="$1"
+	local connection_id="$2"
+	local stream="$3"
+	local budget="$4"
+	local page_size="$5"
+	if python3 "$MASTODON_SCRIPT" --base "$BASE" --alias personal:default \
+		--connection-id "$connection_id" --account-id account_42 \
+		--stream "$stream" --profile fixture --fixture "$fixture" \
+		--budget "$budget" --page-size "$page_size"; then
+		return 0
+	fi
+	return 1
+}
+
+expect_failure() {
+	local description="$1"
+	local fixture="$2"
+	local connection_id="$3"
+	local stream="$4"
+	if run_mastodon "$fixture" "$connection_id" "$stream" 11 40 >/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$SOCIAL_HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'Mastodon social collector tests\n'
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import ast
+import json
+import os
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+
+from _knowledge_social_mastodon import PageRequest, STREAMS, namespaced_id
+from _knowledge_social_mastodon_contract import ApiResult
+from _knowledge_social_mastodon_http import (
+    HTTP_TIMEOUT_SECONDS,
+    ProfileConfig,
+    _canonical_base_url,
+    api,
+    installation_fingerprint,
+)
+from _knowledge_social_mastodon_provider import _profile
+from _knowledge_social_mastodon_routes import (
+    EXACT_READ_PATHS,
+    allowlisted_path,
+    page,
+    page_limit_for_path,
+)
+
+assert set(STREAMS) == {
+    "authored_statuses", "favourites", "bookmarks", "notifications",
+    "followers", "following", "followed_tags", "lists",
+}
+assert all(spec.pagination == "snapshot" and spec.cost_units == 2 for spec in STREAMS.values())
+assert "/api/v1/accounts/verify_credentials" in EXACT_READ_PATHS
+assert allowlisted_path("/api/v1/accounts/42/statuses")
+assert allowlisted_path("/api/v1/accounts/42/followers")
+assert page_limit_for_path("/api/v1/accounts/42/statuses") == 40
+assert page_limit_for_path("/api/v1/notifications") == 80
+assert page_limit_for_path("/api/v1/followed_tags") == 100
+for rejected in (
+    "/api/v1/statuses/1/favourite", "/api/v1/accounts/update_credentials",
+    "/api/v1/notifications/clear", "/api/v1/lists/1/accounts/add",
+    "/api/v1/admin/accounts",
+):
+    assert not allowlisted_path(rejected)
+
+base = _canonical_base_url("https://mastodon.example.invalid/")
+instance = installation_fingerprint(base, "a" * 32)
+assert instance == installation_fingerprint("https://mastodon.example.invalid", "a" * 32)
+assert namespaced_id(instance, "status", "opaque-A") != namespaced_id(
+    instance, "status", "opaque-B"
+)
+for invalid in (
+    "http://mastodon.example.invalid", "https://user@mastodon.example.invalid",
+    "https://mastodon.example.invalid/subpath", "https://mastodon.example.invalid/?query=1",
+):
+    try:
+        _canonical_base_url(invalid)
+    except RuntimeError as error:
+        assert "example.invalid" not in str(error)
+    else:
+        raise AssertionError("unsafe Mastodon origin was accepted")
+
+os.environ.update({
+    "MASTODON_SCOPE_BASE_URL": base,
+    "MASTODON_SCOPE_ACCESS_TOKEN": "private-token",
+    "MASTODON_SCOPE_ORIGIN_KEY": "a" * 32,
+    "MASTODON_SCOPE_AUTH_MODE": "user_token",
+    "MASTODON_SCOPE_SCOPES": "read:accounts write:statuses",
+})
+try:
+    _profile("scope")
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("write-authorized Mastodon profile was accepted")
+
+
+class Headers:
+    def __init__(self, link=None):
+        self.link = link
+
+    def get(self, key, default=None):
+        return self.link if key == "Link" else default
+
+
+class Response:
+    status = 200
+
+    def __init__(self, payload, link=None):
+        self.payload = json.dumps(payload).encode()
+        self.headers = Headers(link)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def read(self, size=-1):
+        return self.payload[:size]
+
+
+class Opener:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    def open(self, request, timeout):
+        assert timeout == HTTP_TIMEOUT_SECONDS
+        assert request.method == "GET"
+        assert "private-token" not in request.full_url
+        self.requests.append(request)
+        return self.responses.pop(0)
+
+
+scopes = frozenset({"read:accounts", "read:statuses"})
+config = ProfileConfig(base, "private-token", "user_token", instance, scopes)
+next_url = "https://mastodon.example.invalid/api/v1/accounts/42/statuses?limit=2&max_id=opaque%2Fcursor"
+opener = Opener([Response([], f'<{next_url}>; rel="next"')])
+result = api(config, opener, "/api/v1/accounts/42/statuses", {"limit": "2"})
+assert result.next_url == next_url
+assert opener.requests[0].full_url.endswith("/api/v1/accounts/42/statuses?limit=2")
+try:
+    api(config, opener, "https://other.invalid/api/v1/accounts/42/statuses?limit=2", {})
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("cross-origin Mastodon next link was accepted")
+try:
+    api(
+        config,
+        Opener([]),
+        "https://mastodon.example.invalid/api/v1/accounts/42/statuses?limit=41",
+        {},
+    )
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("oversized Mastodon next-link page was accepted")
+
+request = PageRequest(
+    "authored_statuses", namespaced_id(instance, "account", "42"), "42",
+    "selected", instance, 1, None, 2,
+)
+calls = []
+
+
+def status_api(target, params):
+    calls.append((target, params))
+    return ApiResult(200, [{
+        "id": "status/opaque", "created_at": "2026-08-02T00:00:00Z",
+        "content": "<p>Bounded status</p>", "account": {
+            "id": "42", "username": "selected", "acct": "selected",
+        },
+    }], next_url)
+
+
+payload = page(status_api, request, {})
+assert payload["meta"]["next_url"] == next_url
+assert payload["data"][0]["author_remote_id"] == request.account_id
+assert calls == [("/api/v1/accounts/42/statuses", {"limit": "2"})]
+
+large_request = PageRequest(
+    "authored_statuses", namespaced_id(instance, "account", "42"), "42",
+    "selected", instance, 1, None, 100,
+)
+calls.clear()
+page(status_api, large_request, {})
+assert calls == [("/api/v1/accounts/42/statuses", {"limit": "40"})]
+
+cross_stream_request = PageRequest(
+    "authored_statuses", namespaced_id(instance, "account", "42"), "42",
+    "selected", instance, 2,
+    "https://mastodon.example.invalid/api/v1/favourites?limit=40", 40,
+)
+try:
+    page(status_api, cross_stream_request, {})
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("cross-stream Mastodon next link was accepted")
+
+sources = [path.read_text(encoding="utf-8") for path in sorted(scripts.glob("_knowledge_social_mastodon*.py"))]
+trees = [ast.parse(source) for source in sources]
+request_calls = [
+    node for tree in trees for node in ast.walk(tree)
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "Request"
+]
+assert request_calls
+for node in request_calls:
+    methods = [
+        keyword.value.value for keyword in node.keywords
+        if keyword.arg == "method" and isinstance(keyword.value, ast.Constant)
+    ]
+    assert methods == ["GET"]
+assert all("_knowledge_social_outbound" not in source for source in sources)
+PY
+assert_eq "exact origins, opaque Link pagination, scopes, routes, and GET-only AST are guarded" \
+	verified verified
+
+python3 - "$TMP_DIR/first.json" "$INSTANCE_A" <<'PY'
+import json
+import sys
+
+sys.path.insert(0, ".agents/scripts")
+from _knowledge_social_mastodon_identity import namespaced_id
+
+instance = sys.argv[2]
+next_url = "https://mastodon.example.invalid/api/v1/accounts/42/statuses?limit=1&max_id=opaque%2Fnext"
+payload = {
+    "identity": {"data": {
+        "provider_account_id": "42", "username": "selected", "acct": "selected",
+        "display_name": "Private profile", "uri": "https://mastodon.example.invalid/users/selected",
+        "instance_id": instance,
+    }},
+    "pages": [{
+        "expect_request": {"position": 1, "stop_at": None, "limit": 1},
+        "response": {
+            "status": 200, "observed_at": "2026-08-02T00:01:00Z",
+            "data": [{
+                "kind": "status", "remote_id": namespaced_id(instance, "status", "100"),
+                "status_id": "100", "author_remote_id": namespaced_id(instance, "account", "42"),
+                "content": "<p>Bounded Mastodon knowledge</p>",
+                "created_at": "2026-08-02T00:00:00Z",
+            }],
+            "meta": {"stream": "authored_statuses", "instance_id": instance,
+                     "next_url": next_url, "complete": False, "snapshot": True},
+        },
+    }],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+first_result=$(run_mastodon "$TMP_DIR/first.json" conn_mastodon authored_statuses 3 1)
+assert_eq "one bounded Mastodon page pauses at its opaque Link" \
+	"$(json_field "$first_result" status)" budget_exhausted
+assert_eq "identity plus page consumes three request units" \
+	"$(json_field "$first_result" budget_units)" 3
+assert_eq "partial page commits evidence and cursor atomically" \
+	"$(sql_value "SELECT count(*) || ':' || (SELECT backfill_complete FROM sync_cursors WHERE connection_id='conn_mastodon') FROM fetch_batches WHERE connection_id='conn_mastodon'")" \
+	"1:0"
+assert_eq "authored Mastodon text reaches FTS" \
+	"$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'bounded'")" 1
+
+python3 - "$TMP_DIR/resume.json" "$INSTANCE_A" <<'PY'
+import json
+import sys
+
+instance = sys.argv[2]
+next_url = "https://mastodon.example.invalid/api/v1/accounts/42/statuses?limit=1&max_id=opaque%2Fnext"
+payload = {
+    "identity": {"data": {"provider_account_id": "42", "username": "selected",
+                            "acct": "selected", "instance_id": instance}},
+    "pages": [{
+        "expect_request": {"position": 2, "stop_at": next_url},
+        "response": {"status": 200, "observed_at": "2026-08-02T00:02:00Z", "data": [],
+                     "meta": {"stream": "authored_statuses", "instance_id": instance,
+                              "next_url": None, "complete": True, "snapshot": True}},
+    }],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+second_result=$(run_mastodon "$TMP_DIR/resume.json" conn_mastodon authored_statuses 11 40)
+assert_eq "Mastodon resumes the exact opaque Link" \
+	"$(json_field "$second_result" status)" complete
+assert_eq "completed Mastodon snapshot clears its cursor" \
+	"$(sql_value "SELECT coalesce(cursor,'done') || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_mastodon'")" \
+	"done:1"
+
+cat >"$TMP_DIR/mismatch.json" <<JSON
+{"identity":{"data":{"provider_account_id":"43","username":"other","acct":"other","instance_id":"${INSTANCE_A}"}},"pages":[]}
+JSON
+raw_before=$(raw_count)
+expect_failure "selected-account identity mismatch is rejected" \
+	"$TMP_DIR/mismatch.json" conn_mismatch authored_statuses
+assert_eq "identity mismatch persists no raw evidence" "$(raw_count)" "$raw_before"
+
+cat >"$TMP_DIR/credential.json" <<JSON
+{"identity":{"data":{"provider_account_id":"42","username":"selected","acct":"selected","instance_id":"${INSTANCE_A}"}},
+ "pages":[{"status":200,"observed_at":"2026-08-02T00:03:00Z","access_token":"must-not-persist","data":[],
+ "meta":{"stream":"bookmarks","instance_id":"${INSTANCE_A}","next_url":null,"complete":true,"snapshot":true}}]}
+JSON
+raw_before=$(raw_count)
+expect_failure "credential-shaped Mastodon page is rejected" \
+	"$TMP_DIR/credential.json" conn_credential bookmarks
+assert_eq "credential rejection persists no raw evidence" "$(raw_count)" "$raw_before"
+
+cat >"$TMP_DIR/rate.json" <<JSON
+{"identity":{"data":{"provider_account_id":"42","username":"selected","acct":"selected","instance_id":"${INSTANCE_A}"}},
+ "pages":[{"status":429,"observed_at":"2026-08-02T00:04:00Z","retry_after":1785629400}]}
+JSON
+rate_result=$(run_mastodon "$TMP_DIR/rate.json" conn_rate notifications 11 40)
+assert_eq "rate limit becomes an explicit paused result" \
+	"$(json_field "$rate_result" failure_class):$(json_field "$rate_result" status)" \
+	"rate_limit:rate_limited"
+assert_eq "terminal response advances no checkpoint" \
+	"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_rate'")" 0
+
+assert_eq "unsupported private and historical categories remain explicit gaps" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE connection_id='conn_mastodon' AND status='unavailable' AND stream IN ('conversations','list_members','account_exports','federated_history','moderation_history','deleted_or_purged_content','instance_retention')")" 7
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/tests/test-knowledge-social-registry.sh
+++ b/.agents/tests/test-knowledge-social-registry.sh
@@ -45,6 +45,7 @@ expected = {
     "forem": ("live",),
     "google-business-profile": ("live",),
     "gumroad": ("live",),
+    "mastodon": ("live",),
     "nextcloud-talk": ("live",),
     "signal": ("inspect", "manual-import", "status"),
     "slack": ("archive", "live"),
@@ -90,14 +91,14 @@ except module.ProviderRegistryError:
 else:
     raise SystemExit("unknown provider used a fallback")
 
-print("11:order-independent:aliases-exact:collisions-rejected:no-fallback")
+print("12:order-independent:aliases-exact:collisions-rejected:no-fallback")
 PY
 )
 assert_eq "all merged provider outcomes register deterministically" \
-	"$registry_summary" "11:order-independent:aliases-exact:collisions-rejected:no-fallback"
+	"$registry_summary" "12:order-independent:aliases-exact:collisions-rejected:no-fallback"
 
 provider_count=$("$HELPER" providers | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
-assert_eq "helper exposes the complete provider registry" "$provider_count" "11"
+assert_eq "helper exposes the complete provider registry" "$provider_count" "12"
 
 forem_resolution=$("$HELPER" provider-resolve --provider dev-community |
 	python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["provider"] + ":" + ",".join(data["modes"]))')


### PR DESCRIPTION
## Summary

- add a bounded, GET-only Mastodon knowledge collector for eight account streams
- bind collection to an exact HTTPS home-instance identity and preserve validated same-origin RFC `Link` cursors
- register Mastodon in the social helper/capability catalogue and document explicit retention and coverage gaps
- enforce per-route page limits, reject redirects/cross-origin or cross-stream pagination, and persist evidence/checkpoints atomically

## Files and patterns

- `.agents/scripts/_knowledge_social_mastodon*.py` follows the guarded OAuth collector/provider split used by existing live social adapters
- `.agents/scripts/knowledge_social_mastodon.py` supplies the collector entry point
- `.agents/tests/test-knowledge-social-mastodon.sh` covers identity, scope, route, pagination, resume, rejection, and persistence boundaries
- `.agents/content/social-mastodon.md` records authority, stream coverage, official evidence, and unsupported categories

## Verification

- `bash .agents/tests/test-knowledge-social-mastodon.sh` — 14 passed
- `bash .agents/tests/test-knowledge-social-registry.sh` — 8 passed
- `.agents/scripts/linters-local.sh --changed` — passed

Resolves #29221
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 4h 37m and 2,568,385 tokens on this with the user in an interactive session.