### PR TITLE
GH#29239: Correct stale dispatch_max full-slot comments

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -486,12 +486,13 @@ _dispatch_order_idle_borrowing_candidates() {
 # and fills empty local slots. Ranking remains simple and auditable; judgment
 # stays with the pulse LLM for merges, blockers, and unusual edge cases.
 #
-# t3005/t3014: Loop body extracted into _dispatch_floor_loop /
+# t3005/t3014/GH#29234: Loop body extracted into _dispatch_floor_loop /
 # _dispatch_max_loop — the orchestrator picks one based on
-# DISPATCH_MAX_PARALLEL (t3014 default = effective_slots when unset)
-# and adaptive throttle state. Throttle mode forces serial (1 dispatch per
-# round) to preserve the existing "test the waters" recovery semantics;
-# otherwise parallel is preferred so the 24-slot pool fills in 1 cycle.
+# DISPATCH_MAX_PARALLEL (default = min(6, effective_slots) when unset or invalid)
+# and adaptive throttle state. Throttle mode forces serial (1 dispatch per round)
+# to preserve the existing "test the waters" recovery semantics; otherwise
+# bounded parallelism is preferred. Explicit positive overrides can raise the
+# ceremony cap up to effective_slots.
 #
 # Arguments:
 #   $1 - dependency normalization mode (optional: normalize or skip)


### PR DESCRIPTION
## Summary

Align the dispatch_max orchestrator comments with the merged six-way default and explicit-override contract.

## Files Changed

.agents/scripts/pulse-dispatch-engine.sh

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Comment-only diff; ShellCheck clean; exact stale-text search returned no matches; linters-local.sh passed; git diff --check clean.

Resolves #29239


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 5h 13m and 3,825,429 tokens on this with the user in an interactive session.