### PR TITLE
GH#29222: Add bounded GitHub social collector

### DIFF
--- a/.agents/aidevops/knowledge-plane/05-social-operations.md
+++ b/.agents/aidevops/knowledge-plane/05-social-operations.md
@@ -39,9 +39,10 @@ transaction without rewriting raw gzip artifacts, cursors, coverage, or provider
 rows. Replay preserves both evidence and projection IDs.
 
 Candidate implementation is provider-specific, not one generic social adapter.
-Mastodon #29221 is now live. The remaining ranked children are GitHub #29222, Stack Exchange #29223,
-Miniflux #29224, Readwise Reader #29225, FreshRSS #29226, Lemmy issue #29227,
-then public-only Hacker News #29228. Each route owns its identity
+Mastodon #29221 and GitHub #29222 are now live. The remaining ranked children
+are Stack Exchange #29223, Miniflux #29224, Readwise Reader #29225, FreshRSS
+issue #29226, Lemmy issue #29227, then public-only Hacker News #29228. Each
+route owns its identity
 contract, stream allowlist, checkpoint semantics, and negative write-reachability
 tests. Raindrop.io remains optional; Inoreader, Wallabag, Feedly, Instapaper, and
 Pocket are deferred or rejected for the reasons in
@@ -70,6 +71,14 @@ tags, and lists have independent snapshot checkpoints. Complete same-origin
 rejected. Conversations, nested list membership, exports, federation,
 moderation, deletion, and operator retention remain explicit gaps. Details:
 `.agents/content/social-mastodon.md`.
+
+GitHub collection binds `GET /user` numeric and node IDs to GraphQL `viewer`
+identity before every page. Contributions, repositories, stars, notifications,
+followers, following, organizations, subscriptions, user lists, and visible
+Projects v2 have independent snapshot checkpoints. Exact REST `Link` targets
+and GraphQL `pageInfo` cursors remain opaque. Token-family capability limits,
+reactions, migration expiry, deletion, private visibility, and organization
+audit authority remain explicit gaps. Details: `.agents/content/social-github.md`.
 
 X collection uses the guarded official `xurl` helper. Reddit collection uses an
 optional PRAW 8 child. YouTube collection uses a standard-library HTTP child and

--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -43,6 +43,7 @@ a claim that the route is enabled.
 | Discourse | **Live** topics and posts | **Live/Partial** likes, bookmarks, and current reading state | **Live/Gate/Partial** notifications and private-topic metadata; **No** message bodies | **Live/Partial** groups and category preferences; **No** unverified Follow plugin | **No** watched/tracked topic inventories until search behavior is verified | Ten User API `read` streams with per-installation namespaces, repeated identity checks, exact GET routes, redirect rejection, and explicit plugin/export/history gaps. |
 | NodeBB | **Live** topics and posts | **Live/Partial** votes, bookmarks, watched topics, and category state | **Live/Partial** notifications and chat-room metadata; **No** message bodies | **Live/Partial** follows and groups | **No** plugin-provided lists | Thirteen independently checkpointed core GET streams with per-installation identity, bounded pagination, and explicit admin/plugin/export/history gaps. |
 | Mastodon | **Live/Partial** authored statuses | **Live/Partial** favourites and bookmarks | **Live/Gate/Partial** notifications; **No/Gate** conversations | **Live/Partial** followers, following, and followed tags | **Live/Partial** lists; **No** nested membership | Eight exact-origin GET-only streams preserve opaque `Link` cursors and expose federation, moderation, deletion, export, and operator-retention gaps. |
+| GitHub | **Live/Partial** contribution calendar and repositories | **Live/Partial** stars and subscriptions; **No** complete reactions | **Live/Gate/Partial** notifications | **Live/Gate/Partial** followers, following, and organizations | **Live/Gate/Partial** user lists and visible Projects v2 | Ten numeric/node-identity-bound streams preserve REST `Link` and GraphQL `pageInfo` cursors; token family, visibility, migration expiry, deletion, and audit authority remain explicit. |
 
 ## Integrated provider families
 
@@ -75,7 +76,7 @@ separate provider family.
 | Bluesky / AT Protocol | **Live** records | **Live** likes and reposts | **Live/Gate** notifications; **No/Gate** chat | **Live** follows | **Live** lists and feeds | DID-bound repository/AppView reads with separate chat authorization. |
 | Lemmy | **API/Gate** versioned authored content | **API/Gate** saved and liked state | **API/Gate** unified v4 or split v3 inbox | **API/Gate** communities; **No** person follows | **API/Gate** v4 multicommunities | Rank 7, #29227. Implement only behind exact v4/v3 discovery; namespace local IDs and preserve opaque version-sensitive cursors. |
 | Stack Exchange | **API** authored content | **API** favourites; **No** complete vote history | **API/Gate** inbox and notifications | **API** associated site accounts; **No** follows | **No** | Rank 3, #29223. Bind network plus per-site identity, obey `backoff`, and keep archive/completeness gaps explicit. |
-| GitHub | **API/Export** contributions | **API/Partial** stars, subscriptions, and object reactions | **API/Gate/Partial** notifications and discussions | **API/Gate** follows, organizations, and repositories | **API/Gate** user lists and Projects v2 | Rank 2, #29222. Use numeric/node identity and token-family capability evidence; no complete reaction or social export claim. |
+| GitHub | **Live/Partial** contributions | **Live/Partial** stars and subscriptions; **No** complete reactions | **Live/Gate/Partial** notifications; **No** discussions | **Live/Gate/Partial** follows, organizations, and repositories | **Live/Gate/Partial** user lists and Projects v2 | #29222 implements numeric/node identity, token-family gates, opaque mixed-API cursors, and no complete reaction or social export claim. |
 | Hacker News | **API/Partial** public submissions and comments | **No** private votes or saved items | **No** | **No** | **No** | Rank 8, #29228. Bounded public history only, keyed by case-sensitive username and item ID; never infer private state. |
 | Miniflux | **API/Export** feed items | **API** read, removed, starred, and tagged state | **No** | **API/Export** subscriptions | **API/Export** categories/tags | Rank 4, #29224. Strong self-hosted identity and replay; locally enforce GET-only use of mutation-capable API keys. |
 | FreshRSS | **API/Export** feed items | **API** unread and starred state | **No** | **API/Export** subscriptions | **API/Export** folders/tags | Rank 6, #29226. Allow one non-mutating login POST, then GET-only Google Reader collection; reconcile OPML and keep Fever fallback-only. |
@@ -162,6 +163,15 @@ separate provider family.
   GET-only enforcement, credential rejection, terminal coverage, and atomic
   persistence. `.agents/content/social-mastodon.md` records official routes,
   scopes, pagination, default rate limits, exports, and explicit gaps checked on
+  2026-08-02.
+- **Live GitHub:** `.agents/scripts/knowledge_social_github.py`,
+  `.agents/scripts/_knowledge_social_github*.py`, and
+  `.agents/tests/test-knowledge-social-github.sh` prove REST plus GraphQL identity
+  binding, ten independent streams, opaque mixed-API resume, explicit token-family
+  capability, exact REST GET routes, fixed GraphQL read queries, mutation and
+  credential rejection, terminal coverage, request accounting, and atomic
+  persistence. `.agents/content/social-github.md` records official identity,
+  stream, pagination, rate-limit, migration, and completeness evidence checked on
   2026-08-02.
 - **Integrated provider registry:** `.agents/scripts/knowledge_social_registry.py`
   and `.agents/tests/test-knowledge-social-registry.sh` prove order-independent

--- a/.agents/content/social-github.md
+++ b/.agents/content/social-github.md
@@ -1,0 +1,76 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# GitHub Account Knowledge Collection
+
+`knowledge_social_github.py` collects bounded, read-only evidence from one
+GitHub.com user account. It combines the immutable REST numeric account ID with
+the GraphQL node ID. Mutable login is retained only as display and route context.
+Resource IDs use type-qualified digests of provider IDs.
+
+## Profile and authority contract
+
+Configure credentials through secure environment injection:
+
+```text
+GITHUB_<PROFILE>_ACCESS_TOKEN
+GITHUB_<PROFILE>_TOKEN_FAMILY=classic_pat|fine_grained_pat|oauth_user_token
+GITHUB_<PROFILE>_SCOPES="read:user,notifications"
+```
+
+`SCOPES` records declared classic OAuth scopes; provider-side authorization
+remains authoritative. Notifications reject fine-grained PAT profiles because
+the documented endpoint does not support them. Other missing permissions remain
+explicit provider capability outcomes rather than completeness claims.
+
+Use `--account-id account_<NUMERIC_ID>`. Before collection and every page, the
+child reads REST `GET /user` and a fixed GraphQL `viewer` query. REST `id` and
+`node_id` must equal GraphQL `databaseId` and `id`; login must also agree. No
+evidence is persisted until this binding succeeds.
+
+## Implemented streams
+
+| Stream | Read surface | Pagination |
+|---|---|---|
+| `contributions` | GraphQL `viewer.contributionsCollection.contributionCalendar` | bounded current calendar |
+| `repositories` | REST `GET /user/repos` | `Link` |
+| `stars` | REST `GET /user/starred` | `Link` |
+| `notifications` | REST `GET /notifications` | `Link` |
+| `followers` | REST `GET /user/followers` | `Link` |
+| `following` | REST `GET /user/following` | `Link` |
+| `organizations` | REST `GET /user/orgs` | `Link` |
+| `subscriptions` | REST `GET /user/subscriptions` | `Link` |
+| `user_lists` | GraphQL `viewer.lists` | `pageInfo` |
+| `projects_v2` | GraphQL `viewer.projectsV2` | `pageInfo` |
+
+The initial identity phase reserves two request units. Every page reserves three
+more for repeated REST and GraphQL identity checks plus one stream read.
+`--budget` is 5-1000 and `--page-size` is 1-100.
+
+Complete REST `rel=next` URLs and GraphQL `endCursor` strings are stored inside a
+versioned opaque checkpoint. REST resume validates HTTPS `api.github.com`, the
+exact stream route, allowlisted query keys, unique parameters, and bounded
+`per_page`, then replays the URL unchanged. GraphQL variables accept only fixed
+read-query cursors. Redirects, REST mutation routes, arbitrary GraphQL text,
+mutations, and subscriptions are unreachable.
+
+## Boundaries
+
+Successful pages record unavailable coverage for complete reactions, migration
+archives, deleted resources, resources outside current token visibility, and
+organization audit logs. User migration archives expire after seven days and do
+not contain broad social state. Contribution calendars are bounded views, not a
+complete event ledger. Snapshot completion never infers deletion.
+
+Primary and secondary GitHub limits remain authoritative. HTTP 403 and 429
+terminal outcomes pause collection without advancing the checkpoint; the local
+request, item, and response-byte limits are independent stricter fuses.
+
+## Official evidence checked 2026-08-02
+
+- <https://docs.github.com/en/rest/users/users>
+- <https://docs.github.com/en/graphql/reference/users>
+- <https://docs.github.com/en/rest/activity/notifications>
+- <https://docs.github.com/en/rest/activity/starring>
+- <https://docs.github.com/en/rest/migrations/users>
+- <https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api>

--- a/.agents/scripts/_knowledge_social_github.py
+++ b/.agents/scripts/_knowledge_social_github.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""GitHub stream policy, durable identity, and opaque mixed-API checkpoints."""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from _knowledge_social_github_identity import (
+    GitHubAdapterError,
+    GitHubProviderUnavailableError,
+    instance_id,
+    login,
+    provider_account_id,
+)
+from _knowledge_social_oauth_request import OAuthPageRequest
+from knowledge_social_import import canonical_json, reject_credentials
+
+PROVIDER = "github"
+CURSOR_PREFIX = "github-page-v1:"
+RETENTION_LIMIT = "token_capability_and_current_resource_visibility"
+MAX_PAGE_ITEMS = 100
+
+ADAPTER_ERROR = GitHubAdapterError
+PROVIDER_UNAVAILABLE_ERROR = GitHubProviderUnavailableError
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    resource_kind: str
+    activity_mode: str
+    transport: str
+    pagination: str = "snapshot"
+    incremental: bool = False
+    retention_limit: str | None = RETENTION_LIMIT
+    coverage_status: str | None = "partial"
+    unavailable_reason: str | None = "token_capability_and_visibility_bound"
+    cost_units: int = 3
+
+
+STREAMS = {
+    "contributions": StreamSpec("contribution", "content_author", "graphql"),
+    "repositories": StreamSpec("repository", "selected_account", "rest"),
+    "stars": StreamSpec("repository", "selected_account", "rest"),
+    "notifications": StreamSpec("notification", "selected_account", "rest"),
+    "followers": StreamSpec("account", "relationship", "rest"),
+    "following": StreamSpec("account", "relationship", "rest"),
+    "organizations": StreamSpec("organization", "membership", "rest"),
+    "subscriptions": StreamSpec("repository", "selected_account", "rest"),
+    "user_lists": StreamSpec("user_list", "selected_account", "graphql"),
+    "projects_v2": StreamSpec("project", "selected_account", "graphql"),
+}
+
+
+class PageRequest(OAuthPageRequest):
+    HANDLE_KEY = "login"
+
+    @property
+    def login(self) -> str:
+        return self.handle
+
+
+PAGE_REQUEST_KEYS = {
+    "action", "stream", "account_id", "provider_account_id", "login",
+    "instance_id", "position", "stop_at", "limit",
+}
+
+
+def _text(value: Any, field: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise GitHubAdapterError(f"GitHub {field} is invalid")
+    if len(value.encode()) > 16 * 1024:
+        raise GitHubAdapterError(f"GitHub {field} is invalid")
+    return value
+
+
+def _position(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise GitHubAdapterError("GitHub page position must be positive")
+    return value
+
+
+def _encode_cursor(position: int, cursor: str) -> str:
+    payload = canonical_json({"cursor": cursor, "position": position}).encode()
+    encoded = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+    return f"{CURSOR_PREFIX}{encoded}"
+
+
+def _decode_cursor(cursor: str) -> tuple[int, str]:
+    if not cursor.startswith(CURSOR_PREFIX):
+        raise GitHubAdapterError("stored GitHub cursor has an unsupported version")
+    try:
+        raw = cursor.removeprefix(CURSOR_PREFIX)
+        parsed = json.loads(base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4)))
+    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+        raise GitHubAdapterError("stored GitHub cursor is invalid") from error
+    if not isinstance(parsed, dict) or set(parsed) != {"cursor", "position"}:
+        raise GitHubAdapterError("stored GitHub cursor has an invalid shape")
+    reject_credentials(parsed)
+    opaque = _text(parsed.get("cursor"), "cursor")
+    if opaque is None:
+        raise GitHubAdapterError("stored GitHub cursor is invalid")
+    return _position(parsed.get("position")), opaque
+
+
+def page_request(stream: str, account: dict[str, Any], state: CursorState, limit: int) -> PageRequest:
+    if stream not in STREAMS:
+        raise GitHubAdapterError("GitHub stream is unsupported")
+    position, cursor = (1, None)
+    if state.cursor:
+        position, cursor = _decode_cursor(state.cursor)
+    selected = _text(account.get("id"), "selected account ID")
+    if selected is None:
+        raise GitHubAdapterError("verified GitHub identity is incomplete")
+    return PageRequest(
+        stream,
+        selected,
+        provider_account_id(account.get("provider_account_id")),
+        login(account.get("login")),
+        instance_id(account.get("instance_id")),
+        position,
+        cursor,
+        limit,
+    )
+
+
+def parse_page_request(payload: dict[str, Any]) -> PageRequest:
+    if set(payload) != PAGE_REQUEST_KEYS or payload.get("action") != "page":
+        raise GitHubAdapterError("GitHub read request has an invalid action shape")
+    stream = payload.get("stream")
+    if not isinstance(stream, str) or stream not in STREAMS:
+        raise GitHubAdapterError("GitHub stream is unsupported")
+    limit = payload.get("limit")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 100:
+        raise GitHubAdapterError("GitHub page size is invalid")
+    selected = _text(payload.get("account_id"), "selected account ID")
+    if selected is None:
+        raise GitHubAdapterError("GitHub selected account ID is required")
+    return PageRequest(
+        stream,
+        selected,
+        provider_account_id(payload.get("provider_account_id")),
+        login(payload.get("login")),
+        instance_id(payload.get("instance_id")),
+        _position(payload.get("position")),
+        _text(payload.get("stop_at"), "cursor", optional=True),
+        limit,
+    )
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise GitHubAdapterError("GitHub response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise GitHubAdapterError("GitHub page data must be an array")
+    return data
+
+
+def page_checkpoint(
+    payload: dict[str, Any], state: CursorState, request: PageRequest
+) -> tuple[PageCheckpoint, bool]:
+    meta = payload.get("meta")
+    if not isinstance(meta, dict):
+        raise GitHubAdapterError("GitHub page metadata must be an object")
+    reject_credentials(meta)
+    if meta.get("stream") != request.stream or instance_id(meta.get("instance_id")) != request.instance_id:
+        raise GitHubAdapterError("GitHub page provenance is invalid")
+    if meta.get("snapshot") is not True or meta.get("transport") != STREAMS[request.stream].transport:
+        raise GitHubAdapterError("GitHub page pagination metadata is invalid")
+    if len(page_data(payload)) > MAX_PAGE_ITEMS:
+        raise GitHubAdapterError("GitHub page exceeds the item safety limit")
+    next_cursor = _text(meta.get("next_cursor"), "next cursor", optional=True)
+    complete = meta.get("complete")
+    if not isinstance(complete, bool) or complete == (next_cursor is not None):
+        raise GitHubAdapterError("GitHub page completion cursor is invalid")
+    cursor = _encode_cursor(request.position + 1, next_cursor) if next_cursor else None
+    return PageCheckpoint(cursor, state.watermark), complete

--- a/.agents/scripts/_knowledge_social_github_contract.py
+++ b/.agents/scripts/_knowledge_social_github_contract.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validation and serialization primitives for the bounded GitHub child."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_github_identity import (
+    INSTANCE_ID,
+    account_id,
+    login,
+    node_id,
+    provider_account_id,
+)
+
+MAX_TEXT_BYTES = 256 * 1024
+
+
+class GitHubReadProviderError(RuntimeError):
+    """Raised for a privacy-safe local GitHub provider failure."""
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    status: int
+    payload: Any
+    next_url: str | None = None
+    retry_after: int | None = None
+
+
+def observed_at() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def decode_json(payload: bytes, limit: int) -> Any:
+    if len(payload) > limit:
+        raise GitHubReadProviderError("GitHub JSON payload exceeds the safety limit")
+    try:
+        return json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise GitHubReadProviderError("GitHub JSON payload is invalid") from error
+
+
+def request_object(payload: bytes, limit: int) -> dict[str, Any]:
+    request = decode_json(payload, limit)
+    if not isinstance(request, dict):
+        raise GitHubReadProviderError("GitHub read request root must be an object")
+    return request
+
+
+def object_value(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise GitHubReadProviderError(f"GitHub {field} must be an object")
+    return value
+
+
+def object_list(value: Any, field: str, *, limit: int) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise GitHubReadProviderError(f"GitHub {field} must be an array of objects")
+    if len(value) > limit:
+        raise GitHubReadProviderError(f"GitHub {field} exceeds the item safety limit")
+    return value
+
+
+def optional_text(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value:
+        raise GitHubReadProviderError(f"GitHub {field} must be text")
+    if len(value.encode()) > MAX_TEXT_BYTES:
+        raise GitHubReadProviderError(f"GitHub {field} exceeds the safety limit")
+    return value
+
+
+def required_text(value: Any, field: str) -> str:
+    text = optional_text(value, field)
+    if not text:
+        raise GitHubReadProviderError(f"GitHub {field} is required")
+    return text
+
+
+def combined_identity(rest: Any, graphql: Any, expected_id: str) -> dict[str, Any]:
+    rest_user = object_value(rest, "REST identity response")
+    graph_root = object_value(graphql, "GraphQL identity response")
+    graph_data = object_value(graph_root.get("data"), "GraphQL identity data")
+    viewer = object_value(graph_data.get("viewer"), "GraphQL viewer")
+    numeric = provider_account_id(rest_user.get("id"))
+    rest_node = node_id(rest_user.get("node_id"))
+    graph_node = node_id(viewer.get("id"))
+    graph_numeric = provider_account_id(viewer.get("databaseId"))
+    if numeric != provider_account_id(expected_id) or numeric != graph_numeric or rest_node != graph_node:
+        raise GitHubReadProviderError(
+            "selected GitHub account does not match the configured connection"
+        )
+    rest_login = login(rest_user.get("login"))
+    if rest_login.casefold() != login(viewer.get("login")).casefold():
+        raise GitHubReadProviderError("GitHub REST and GraphQL identities do not match")
+    return {
+        "id": account_id(numeric, rest_node),
+        "provider_account_id": numeric,
+        "node_id": rest_node,
+        "login": rest_login,
+        "name": optional_text(rest_user.get("name"), "account name"),
+        "bio": optional_text(rest_user.get("bio"), "account bio"),
+        "instance_id": INSTANCE_ID,
+    }
+
+
+def terminal_payload(result: ApiResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": result.status, "observed_at": observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload

--- a/.agents/scripts/_knowledge_social_github_http.py
+++ b/.agents/scripts/_knowledge_social_github_http.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Redirect-free, bounded GitHub REST reads and fixed GraphQL queries."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import SplitResult, parse_qsl, urlencode, urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from _knowledge_social_github_contract import (
+    ApiResult,
+    GitHubReadProviderError,
+    decode_json,
+)
+from _knowledge_social_github_routes import allowlisted_path, query_keys_for_path
+
+REST_ORIGIN = "https://api.github.com"
+GRAPHQL_URL = f"{REST_ORIGIN}/graphql"
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+HTTP_TIMEOUT_SECONDS = 60
+
+
+class Headers(Protocol):
+    def get(self, key: str, default: str | None = None) -> str | None: ...
+
+
+class Response(Protocol):
+    status: int
+    headers: Headers
+
+    def __enter__(self) -> Response: ...
+    def __exit__(self, *args: Any) -> None: ...
+    def read(self, size: int = -1) -> bytes: ...
+
+
+class Opener(Protocol):
+    def open(self, request: Request, timeout: int) -> Response: ...
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    access_token: str
+    token_family: str
+    scopes: frozenset[str]
+
+
+class _RejectRedirect(HTTPRedirectHandler):
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def _http_exports() -> Opener:
+    exports = (Request, build_opener, urlencode, urlsplit, HTTPRedirectHandler)
+    if not all(callable(item) for item in exports):
+        raise GitHubReadProviderError("Python urllib HTTP exports are unavailable")
+    return build_opener(_RejectRedirect())
+
+
+def _parsed_url(value: str) -> SplitResult:
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError as error:
+        raise GitHubReadProviderError("GitHub API URL is invalid") from error
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "api.github.com"
+        or port not in (None, 443)
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.fragment
+    ):
+        raise GitHubReadProviderError("GitHub API URL is not allowlisted")
+    return parsed
+
+
+def _validate_query(path: str, query: str) -> None:
+    try:
+        pairs = parse_qsl(query, keep_blank_values=True, strict_parsing=True)
+    except ValueError as error:
+        raise GitHubReadProviderError("GitHub pagination query is invalid") from error
+    allowed = query_keys_for_path(path)
+    if len(pairs) != len({key for key, _value in pairs}):
+        raise GitHubReadProviderError("GitHub pagination query is invalid")
+    for key, value in pairs:
+        if key not in allowed or not value or "\x00" in value:
+            raise GitHubReadProviderError("GitHub pagination query is not allowlisted")
+        if key == "per_page" and (not value.isdigit() or not 1 <= int(value) <= 100):
+            raise GitHubReadProviderError("GitHub pagination limit is invalid")
+
+
+def _rest_url(target: str, params: dict[str, str]) -> str:
+    if target.startswith("/"):
+        if not allowlisted_path(target) or set(params) - query_keys_for_path(target):
+            raise GitHubReadProviderError("GitHub REST route is not allowlisted")
+        if any(not value or "\x00" in value for value in params.values()):
+            raise GitHubReadProviderError("GitHub REST query is invalid")
+        query = urlencode(params)
+        _validate_query(target, query)
+        return f"{REST_ORIGIN}{target}" + (f"?{query}" if query else "")
+    if params:
+        raise GitHubReadProviderError("GitHub opaque next link cannot be rewritten")
+    parsed = _parsed_url(target)
+    if not allowlisted_path(parsed.path):
+        raise GitHubReadProviderError("GitHub pagination link route is not allowlisted")
+    _validate_query(parsed.path, parsed.query)
+    return target
+
+
+def _next_link(header: str | None) -> str | None:
+    if not header:
+        return None
+    for match in re.finditer(r"<([^<>]+)>\s*;([^,]*)", header):
+        target, attributes = match.groups()
+        relation = re.search(r'(?:^|;)\s*rel\s*=\s*"?([^";,\s]+)', attributes)
+        if relation is not None and relation.group(1) == "next":
+            return _rest_url(target, {})
+    return None
+
+
+def _retry_epoch(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    return int(time.time() + math.ceil(seconds))
+
+
+def _rate_reset(headers: Headers) -> int | None:
+    retry = _retry_epoch(headers.get("Retry-After"))
+    if retry is not None:
+        return retry
+    reset = headers.get("X-RateLimit-Reset")
+    if reset is None or not reset.isdigit():
+        return None
+    epoch = int(reset)
+    return epoch if epoch >= 0 else None
+
+
+def _decode_response(payload: bytes) -> Any:
+    decoded = decode_json(payload, MAX_RESPONSE_BYTES)
+    if not isinstance(decoded, (dict, list)):
+        raise GitHubReadProviderError("GitHub API response root must be an object or array")
+    return decoded
+
+
+def _execute(opener: Opener, request: Request) -> tuple[int, Any, Headers]:
+    try:
+        with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", 200)
+            if isinstance(status, bool) or not isinstance(status, int):
+                raise GitHubReadProviderError("GitHub HTTP status is invalid")
+            payload = response.read(MAX_RESPONSE_BYTES + 1)
+            if not isinstance(payload, bytes):
+                raise GitHubReadProviderError("GitHub HTTP response is invalid")
+            return status, _decode_response(payload), response.headers
+    except HTTPError as error:
+        headers = error.headers if error.headers is not None else _ErrorHeaders()
+        return error.code, {}, headers
+    except (TimeoutError, URLError, OSError) as error:
+        raise GitHubReadProviderError("GitHub read provider request failed") from error
+
+
+class _ErrorHeaders:
+    def get(self, key: str, default: str | None = None) -> str | None:
+        del key
+        return default
+
+
+def _headers(config: ProfileConfig) -> dict[str, str]:
+    return {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {config.access_token}",
+        "User-Agent": "aidevops-github-knowledge/1",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def rest_api(
+    config: ProfileConfig, opener: Opener, target: str, params: dict[str, str]
+) -> ApiResult:
+    """Execute one allowlisted GitHub REST GET without following redirects."""
+    request = Request(_rest_url(target, params), headers=_headers(config), method="GET")
+    status, payload, headers = _execute(opener, request)
+    return ApiResult(
+        status,
+        payload,
+        _next_link(headers.get("Link")) if status == 200 else None,
+        _rate_reset(headers),
+    )
+
+
+def graphql_api(
+    config: ProfileConfig,
+    opener: Opener,
+    query: str,
+    variables: dict[str, Any],
+) -> ApiResult:
+    """Execute one fixed read query; mutations and subscriptions are unreachable."""
+    normalized = " ".join(query.split()).casefold()
+    if not normalized.startswith("query ") or " mutation " in f" {normalized} " or " subscription " in f" {normalized} ":
+        raise GitHubReadProviderError("GitHub GraphQL operation is not a read query")
+    body = json.dumps({"query": query, "variables": variables}, sort_keys=True).encode()
+    if len(body) > 64 * 1024:
+        raise GitHubReadProviderError("GitHub GraphQL request exceeds the safety limit")
+    headers = _headers(config)
+    headers["Content-Type"] = "application/json"
+    request = Request(GRAPHQL_URL, data=body, headers=headers, method="POST")
+    status, payload, response_headers = _execute(opener, request)
+    return ApiResult(status, payload, retry_after=_rate_reset(response_headers))

--- a/.agents/scripts/_knowledge_social_github_identity.py
+++ b/.agents/scripts/_knowledge_social_github_identity.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Durable GitHub.com numeric, node, and resource identity validation."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any
+
+from knowledge_social_store import SocialStoreError
+
+INSTANCE_ID = "github-com"
+NODE_ID = re.compile(r"^[A-Za-z0-9_=-]{4,512}$")
+LOGIN = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$")
+RESOURCE_KIND = re.compile(r"^[a-z][a-z_]{0,31}$")
+
+
+class GitHubAdapterError(SocialStoreError):
+    """Raised when guarded GitHub collection cannot continue safely."""
+
+
+class GitHubProviderUnavailableError(GitHubAdapterError):
+    """Raised when the bounded GitHub HTTP child cannot complete a read."""
+
+
+def instance_id(value: Any) -> str:
+    if value != INSTANCE_ID:
+        raise GitHubAdapterError("GitHub installation identity is invalid")
+    return INSTANCE_ID
+
+
+def provider_account_id(value: Any) -> str:
+    if isinstance(value, str) and value.startswith("account_"):
+        value = value.removeprefix("account_")
+    if isinstance(value, bool):
+        raise GitHubAdapterError("GitHub numeric account ID is invalid")
+    try:
+        numeric = int(value)
+    except (TypeError, ValueError) as error:
+        raise GitHubAdapterError("GitHub numeric account ID is invalid") from error
+    if numeric < 1 or str(numeric) != str(value):
+        raise GitHubAdapterError("GitHub numeric account ID is invalid")
+    return str(numeric)
+
+
+def node_id(value: Any) -> str:
+    if not isinstance(value, str) or NODE_ID.fullmatch(value) is None:
+        raise GitHubAdapterError("GitHub node identity is invalid")
+    return value
+
+
+def login(value: Any) -> str:
+    if not isinstance(value, str) or LOGIN.fullmatch(value) is None:
+        raise GitHubAdapterError("GitHub login is invalid")
+    return value
+
+
+def namespaced_id(kind: str, value: Any) -> str:
+    if RESOURCE_KIND.fullmatch(kind) is None:
+        raise GitHubAdapterError("GitHub resource kind is invalid")
+    if isinstance(value, bool) or not isinstance(value, (str, int)):
+        raise GitHubAdapterError("GitHub resource identity is invalid")
+    opaque = str(value)
+    if not opaque or "\x00" in opaque or len(opaque.encode()) > 512:
+        raise GitHubAdapterError("GitHub resource identity is invalid")
+    digest = hashlib.sha256(opaque.encode()).hexdigest()[:32]
+    return f"gh_{kind}_{digest}"
+
+
+def account_id(numeric_id: Any, graph_node_id: Any) -> str:
+    numeric = provider_account_id(numeric_id)
+    node = node_id(graph_node_id)
+    return f"ghu_{numeric}_{hashlib.sha256(node.encode()).hexdigest()[:24]}"

--- a/.agents/scripts/_knowledge_social_github_normalize.py
+++ b/.agents/scripts/_knowledge_social_github_normalize.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize allowlisted GitHub records into provider-neutral evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_github import PROVIDER, RETENTION_LIMIT, GitHubAdapterError, page_data
+from _knowledge_social_github_identity import INSTANCE_ID
+from knowledge_social_import import reject_credentials
+
+PROVENANCE = "github_official_rest_and_graphql_apis"
+GAPS = (
+    ("reactions", "no_complete_account_centric_history_route"),
+    ("migration_archives", "operator_initiated_and_expire_after_seven_days"),
+    ("deleted_resources", "not_available_through_current_account_reads"),
+    ("private_resources", "token_capability_and_current_visibility_bound"),
+    ("organization_audit_logs", "organization_authority_and_separate_consent_required"),
+)
+OBJECT_TYPES = frozenset(
+    {"account", "contribution", "notification", "organization", "project", "repository", "user_list"}
+)
+ACTIVITY_TYPES = {
+    "contributions": "contribution",
+    "repositories": "repository_access",
+    "stars": "star",
+    "notifications": "notification",
+    "followers": "follower",
+    "following": "following",
+    "organizations": "organization_membership",
+    "subscriptions": "subscription",
+    "user_lists": "user_list",
+    "projects_v2": "project_membership",
+}
+
+
+@dataclass(frozen=True)
+class PageContext:
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def _required_text(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise GitHubAdapterError(f"GitHub record requires {key}")
+    return value
+
+
+def _optional_text(record: dict[str, Any], key: str) -> str | None:
+    value = record.get(key)
+    if value is not None and (not isinstance(value, str) or "\x00" in value):
+        raise GitHubAdapterError(f"GitHub record {key} must be text")
+    return value
+
+
+def _observed_at(payload: dict[str, Any]) -> str:
+    value = payload.get("observed_at")
+    if not isinstance(value, str) or not value:
+        raise GitHubAdapterError("GitHub page observed_at must be text")
+    return value
+
+
+def _coverage(observed_at: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "stream": stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": RETENTION_LIMIT,
+            "unavailable_reason": reason,
+            "status": "unavailable",
+            "observed_at": observed_at,
+        }
+        for stream, reason in GAPS
+    ]
+
+
+def _object_row(item: dict[str, Any], context: PageContext, observed_at: str) -> dict[str, Any]:
+    kind = item.get("kind")
+    if not isinstance(kind, str) or kind not in OBJECT_TYPES:
+        raise GitHubAdapterError("GitHub page contains an unsupported item kind")
+    remote_id = _required_text(item, "remote_id")
+    text = "\n\n".join(
+        value
+        for key in ("title", "description", "name", "full_name", "login", "reason")
+        if (value := _optional_text(item, key))
+    ) or None
+    provider_json = {"source": PROVENANCE, "stream": context.stream, "record": item}
+    reject_credentials(provider_json)
+    return {
+        "object_type": kind,
+        "remote_id": remote_id,
+        "account_remote_id": context.account.get("id") if context.stream == "contributions" else None,
+        "text": text,
+        "created_at": _optional_text(item, "created_at") or _optional_text(item, "date"),
+        "observed_at": observed_at,
+        "evidence_class": "authored" if context.stream == "contributions" else "observed",
+        "provider_json": provider_json,
+    }
+
+
+def _activity_row(item: dict[str, Any], context: PageContext, observed_at: str) -> dict[str, Any]:
+    selected = _required_text(context.account, "id")
+    remote_id = _required_text(item, "remote_id")
+    activity_type = ACTIVITY_TYPES[context.stream]
+    actor, target = selected, remote_id
+    if context.stream == "followers":
+        actor, target = remote_id, selected
+    return {
+        "activity_type": activity_type,
+        "remote_id": f"{selected}_{activity_type}_{remote_id}",
+        "actor_remote_id": actor,
+        "object_remote_id": target,
+        "occurred_at": _optional_text(item, "updated_at") or _optional_text(item, "date"),
+        "observed_at": observed_at,
+        "state": "active",
+        "provider_json": {"source": PROVENANCE, "stream": context.stream},
+    }
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    reject_credentials(payload)
+    observed_at = _observed_at(payload)
+    if context.account.get("instance_id") != INSTANCE_ID:
+        raise GitHubAdapterError("GitHub account installation identity is invalid")
+    items = page_data(payload)
+    policy = dict(context.policy)
+    policy.update(
+        {
+            "github_identity": "rest_numeric_id_plus_graphql_node_id",
+            "github_pagination": "opaque_rest_link_or_graphql_page_info_cursor",
+            "github_transport": "stdlib_urllib_rest_get_and_fixed_graphql_query_only",
+            "github_mutations": "unreachable",
+        }
+    )
+    archive = {
+        "provider": PROVIDER,
+        "connection_id": context.connection_id,
+        "remote_account_id": context.account.get("id"),
+        "exported_at": observed_at,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": policy,
+        "accounts": [
+            {
+                "remote_id": context.account.get("id"),
+                "handle": context.account.get("login"),
+                "display_name": context.account.get("name"),
+                "observed_at": observed_at,
+                "provider_json": {
+                    "source": PROVENANCE,
+                    "provider_account_id": context.account.get("provider_account_id"),
+                    "node_id": context.account.get("node_id"),
+                    "bio": context.account.get("bio"),
+                },
+            }
+        ],
+        "objects": [_object_row(item, context, observed_at) for item in items],
+        "activities": [_activity_row(item, context, observed_at) for item in items],
+        "media": [],
+        "coverage": _coverage(observed_at),
+    }
+    reject_credentials(archive)
+    return archive

--- a/.agents/scripts/_knowledge_social_github_provider.py
+++ b/.agents/scripts/_knowledge_social_github_provider.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded GitHub.com reader with GET-only REST and fixed GraphQL queries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from functools import partial
+from typing import Any
+
+from _knowledge_social_github import GitHubAdapterError, PageRequest, parse_page_request
+from _knowledge_social_github_contract import (
+    ApiResult,
+    GitHubReadProviderError,
+    combined_identity,
+    object_value,
+    observed_at,
+    request_object,
+    terminal_payload,
+)
+from _knowledge_social_github_http import (
+    MAX_RESPONSE_BYTES,
+    Opener,
+    ProfileConfig,
+    _http_exports,
+    graphql_api,
+    rest_api,
+)
+from _knowledge_social_github_identity import INSTANCE_ID, account_id, provider_account_id
+from _knowledge_social_github_routes import IDENTITY_QUERY, page
+
+MAX_REQUEST_BYTES = 32 * 1024
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+TOKEN_FAMILIES = frozenset({"classic_pat", "fine_grained_pat", "oauth_user_token"})
+STREAM_CAPABILITIES = {
+    "contributions": frozenset(TOKEN_FAMILIES),
+    "repositories": frozenset(TOKEN_FAMILIES),
+    "stars": frozenset(TOKEN_FAMILIES),
+    "notifications": frozenset({"classic_pat", "oauth_user_token"}),
+    "followers": frozenset(TOKEN_FAMILIES),
+    "following": frozenset(TOKEN_FAMILIES),
+    "organizations": frozenset(TOKEN_FAMILIES),
+    "subscriptions": frozenset(TOKEN_FAMILIES),
+    "user_lists": frozenset(TOKEN_FAMILIES),
+    "projects_v2": frozenset(TOKEN_FAMILIES),
+}
+
+
+def _profile_prefix(profile: str) -> str:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise GitHubReadProviderError("GitHub profile name is invalid")
+    return f"GITHUB_{profile.upper()}"
+
+
+def _profile_value(prefix: str, suffix: str, field: str, limit: int) -> str:
+    value = os.environ.get(f"{prefix}_{suffix}", "")
+    if not value or "\x00" in value or len(value.encode()) > limit:
+        raise GitHubReadProviderError(f"GitHub profile {field} is missing")
+    return value
+
+
+def _profile(profile: str) -> ProfileConfig:
+    prefix = _profile_prefix(profile)
+    token = _profile_value(prefix, "ACCESS_TOKEN", "access token", 16 * 1024)
+    family = _profile_value(prefix, "TOKEN_FAMILY", "token family", 64)
+    if family not in TOKEN_FAMILIES:
+        raise GitHubReadProviderError("GitHub profile token family is invalid")
+    scope_text = os.environ.get(f"{prefix}_SCOPES", "")
+    if "\x00" in scope_text or len(scope_text.encode()) > 4096:
+        raise GitHubReadProviderError("GitHub profile scopes are invalid")
+    scopes = frozenset(part.strip() for part in scope_text.split(",") if part.strip())
+    return ProfileConfig(token, family, scopes)
+
+
+def _identity(config: ProfileConfig, opener: Opener, expected_id: str) -> dict[str, Any]:
+    rest = rest_api(config, opener, "/user", {})
+    if rest.status != 200:
+        return terminal_payload(rest)
+    graph = graphql_api(config, opener, IDENTITY_QUERY, {})
+    if graph.status != 200:
+        return terminal_payload(graph)
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": combined_identity(rest.payload, graph.payload, expected_id),
+    }
+
+
+def _verify_page_account(request: PageRequest, identity: dict[str, Any]) -> None:
+    if (
+        identity.get("instance_id") != INSTANCE_ID
+        or identity.get("provider_account_id") != request.provider_account_id
+        or identity.get("login") != request.login
+        or request.account_id
+        != account_id(identity.get("provider_account_id"), identity.get("node_id"))
+    ):
+        raise GitHubReadProviderError(
+            "selected GitHub account does not match the configured connection"
+        )
+
+
+def _dispatch(request: dict[str, Any], config: ProfileConfig, opener: Opener) -> dict[str, Any]:
+    action = request.get("action")
+    if action == "identity":
+        if set(request) != {"action", "account_id"}:
+            raise GitHubReadProviderError("GitHub identity request shape is invalid")
+        return _identity(config, opener, provider_account_id(request.get("account_id")))
+    if action != "page":
+        raise GitHubReadProviderError("GitHub read action is unsupported")
+    page_request = parse_page_request(request)
+    if config.token_family not in STREAM_CAPABILITIES[page_request.stream]:
+        raise GitHubReadProviderError(
+            "GitHub profile token family cannot read the selected stream"
+        )
+    verified = _identity(config, opener, page_request.provider_account_id)
+    if verified.get("status") != 200:
+        return verified
+    identity = object_value(verified.get("data"), "account verification")
+    _verify_page_account(page_request, identity)
+    result = page(
+        partial(rest_api, config, opener),
+        partial(graphql_api, config, opener),
+        page_request,
+    )
+    return terminal_payload(result) if isinstance(result, ApiResult) else result
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode()) > MAX_RESPONSE_BYTES:
+        raise GitHubReadProviderError("GitHub read response exceeds the safety limit")
+    print(encoded)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        request = request_object(sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1), MAX_REQUEST_BYTES)
+        _emit(_dispatch(request, _profile(args.profile), _http_exports()))
+        return 0
+    except (GitHubReadProviderError, GitHubAdapterError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - intentionally redact provider internals
+        print("ERROR: GitHub read provider request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_github_reader.py
+++ b/.agents/scripts/_knowledge_social_github_reader.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and deterministic fixture readers for GitHub collection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_github import (
+    GitHubAdapterError,
+    GitHubProviderUnavailableError,
+    PageRequest,
+)
+from _knowledge_social_github_identity import (
+    INSTANCE_ID,
+    account_id,
+    login,
+    node_id,
+    provider_account_id,
+)
+from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
+from knowledge_social_import import reject_credentials
+
+READ_TIMEOUT_SECONDS = 120
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+SAFE_PROVIDER_FAILURES = (
+    "Python urllib HTTP exports are unavailable",
+    "GitHub profile name is invalid",
+    "GitHub profile access token is missing",
+    "GitHub profile token family is missing",
+    "GitHub profile token family is invalid",
+    "GitHub profile scopes are invalid",
+    "GitHub profile token family cannot read the selected stream",
+    "selected GitHub account does not match the configured connection",
+)
+
+
+class GitHubReader(Protocol):
+    def identity(self, expected_id: str) -> dict[str, Any]: ...
+    def page(self, request: PageRequest) -> dict[str, Any]: ...
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    if len(output.encode()) > MAX_RESPONSE_BYTES:
+        raise GitHubAdapterError("GitHub read response exceeds the safety limit")
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise GitHubAdapterError("GitHub read provider returned no valid JSON") from error
+    if not isinstance(payload, dict):
+        raise GitHubAdapterError("GitHub read response root must be an object")
+    return payload
+
+
+def _provider_failure(stderr: str) -> GitHubProviderUnavailableError:
+    for message in SAFE_PROVIDER_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return GitHubProviderUnavailableError(message)
+    return GitHubProviderUnavailableError("GitHub read provider is unavailable")
+
+
+GITHUB_READER_POLICY = GuardedOAuthPolicy(
+    "GitHub",
+    "GITHUB",
+    "GITHUB_READ_LOG",
+    READ_TIMEOUT_SECONDS,
+    _decode_output,
+    _provider_failure,
+    GitHubProviderUnavailableError,
+    ("ACCESS_TOKEN", "TOKEN_FAMILY", "SCOPES"),
+    "",
+)
+
+
+class GuardedGitHub(GuardedOAuthReader):
+    def __init__(self, helper: Path, profile: str) -> None:
+        super().__init__(helper, profile, GITHUB_READER_POLICY)
+
+
+def _fixture_object(value: Any, message: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise GitHubAdapterError(message)
+    return value
+
+
+class FixtureGitHub:
+    def __init__(self, path: Path) -> None:
+        self.fixture = FixtureSequence(path, "GitHub", GitHubAdapterError)
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        del expected_id
+        return self.fixture.identity()
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        entry = self.fixture.next_page()
+        expectation = _fixture_object(
+            entry.get("expect_request", {}),
+            "GitHub fixture request expectation must be an object",
+        )
+        actual = request.payload()
+        for key, value in expectation.items():
+            if actual.get(key) != value:
+                raise GitHubAdapterError(
+                    "GitHub request did not resume at the expected checkpoint"
+                )
+        return _fixture_object(
+            entry.get("response", entry),
+            "GitHub fixture page response must be an object",
+        )
+
+
+def _display_text(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value or len(value.encode()) > 256 * 1024:
+        raise GitHubAdapterError(f"GitHub account {field} must be text")
+    return value
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    """Bind REST numeric identity and GraphQL node identity before collection."""
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise GitHubAdapterError("GitHub account verification returned no account")
+    numeric = provider_account_id(data.get("provider_account_id"))
+    graph_node = node_id(data.get("node_id"))
+    handle = login(data.get("login"))
+    if numeric != provider_account_id(expected_id) or data.get("instance_id") != INSTANCE_ID:
+        raise GitHubAdapterError(
+            "selected GitHub account does not match the configured connection"
+        )
+    durable = account_id(numeric, graph_node)
+    if data.get("id") != durable:
+        raise GitHubAdapterError("GitHub account identity binding is invalid")
+    return {
+        "id": durable,
+        "provider_account_id": numeric,
+        "node_id": graph_node,
+        "instance_id": INSTANCE_ID,
+        "login": handle,
+        "name": _display_text(data.get("name"), "name"),
+        "bio": _display_text(data.get("bio"), "bio"),
+    }

--- a/.agents/scripts/_knowledge_social_github_routes.py
+++ b/.agents/scripts/_knowledge_social_github_routes.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""GitHub REST route allowlist, fixed GraphQL queries, and serializers."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+from urllib.parse import urlsplit
+
+from _knowledge_social_github import PageRequest, STREAMS
+from _knowledge_social_github_contract import (
+    ApiResult,
+    GitHubReadProviderError,
+    object_list,
+    object_value,
+    observed_at,
+    optional_text,
+    required_text,
+)
+from _knowledge_social_github_identity import namespaced_id, node_id, provider_account_id
+
+RestApi = Callable[[str, dict[str, str]], ApiResult]
+GraphApi = Callable[[str, dict[str, Any]], ApiResult]
+PageResult = ApiResult | dict[str, Any]
+
+EXACT_READ_PATHS = frozenset(
+    {
+        "/user",
+        "/user/repos",
+        "/user/starred",
+        "/notifications",
+        "/user/followers",
+        "/user/following",
+        "/user/orgs",
+        "/user/subscriptions",
+    }
+)
+STREAM_PATHS = {
+    "repositories": "/user/repos",
+    "stars": "/user/starred",
+    "notifications": "/notifications",
+    "followers": "/user/followers",
+    "following": "/user/following",
+    "organizations": "/user/orgs",
+    "subscriptions": "/user/subscriptions",
+}
+
+IDENTITY_QUERY = """
+query AidevopsViewerIdentity {
+  viewer { databaseId id login }
+}
+"""
+CONTRIBUTIONS_QUERY = """
+query AidevopsViewerContributions {
+  viewer {
+    contributionsCollection {
+      contributionCalendar {
+        weeks { contributionDays { contributionCount date } }
+      }
+    }
+  }
+}
+"""
+PROJECTS_QUERY = """
+query AidevopsViewerProjects($first: Int!, $after: String) {
+  viewer {
+    projectsV2(first: $first, after: $after) {
+      nodes { closed createdAt id number shortDescription title updatedAt }
+      pageInfo { endCursor hasNextPage }
+    }
+  }
+}
+"""
+USER_LISTS_QUERY = """
+query AidevopsViewerLists($first: Int!, $after: String) {
+  viewer {
+    lists(first: $first, after: $after) {
+      nodes { createdAt description id isPrivate name slug updatedAt }
+      pageInfo { endCursor hasNextPage }
+    }
+  }
+}
+"""
+
+
+def allowlisted_path(path: str) -> bool:
+    return path in EXACT_READ_PATHS
+
+
+def query_keys_for_path(path: str) -> frozenset[str]:
+    if path == "/user":
+        return frozenset()
+    if path == "/notifications":
+        return frozenset({"all", "participating", "per_page", "page", "since", "before"})
+    if path in ("/user/repos", "/user/starred"):
+        return frozenset({"affiliation", "direction", "page", "per_page", "sort", "visibility"})
+    return frozenset({"page", "per_page"})
+
+
+def _resource(kind: str, item: dict[str, Any]) -> str:
+    value = item.get("node_id", item.get("id"))
+    try:
+        return namespaced_id(kind, value)
+    except RuntimeError as error:
+        raise GitHubReadProviderError(str(error)) from error
+
+
+def _account(item: dict[str, Any], _request: PageRequest) -> dict[str, Any]:
+    numeric = provider_account_id(item.get("id"))
+    return {
+        "kind": "account",
+        "remote_id": _resource("account", item),
+        "provider_account_id": numeric,
+        "node_id": node_id(item.get("node_id")),
+        "login": required_text(item.get("login"), "account login"),
+    }
+
+
+def _repository(item: dict[str, Any], _request: PageRequest) -> dict[str, Any]:
+    owner = object_value(item.get("owner"), "repository owner")
+    return {
+        "kind": "repository",
+        "remote_id": _resource("repository", item),
+        "node_id": node_id(item.get("node_id")),
+        "name": required_text(item.get("name"), "repository name"),
+        "full_name": required_text(item.get("full_name"), "repository full name"),
+        "description": optional_text(item.get("description"), "repository description"),
+        "owner_remote_id": _resource("account", owner),
+        "private": item.get("private") if isinstance(item.get("private"), bool) else None,
+        "archived": item.get("archived") if isinstance(item.get("archived"), bool) else None,
+        "created_at": optional_text(item.get("created_at"), "repository creation timestamp"),
+        "updated_at": optional_text(item.get("updated_at"), "repository update timestamp"),
+    }
+
+
+def _organization(item: dict[str, Any], _request: PageRequest) -> dict[str, Any]:
+    return {
+        "kind": "organization",
+        "remote_id": _resource("organization", item),
+        "node_id": node_id(item.get("node_id")),
+        "login": required_text(item.get("login"), "organization login"),
+        "description": optional_text(item.get("description"), "organization description"),
+    }
+
+
+def _notification(item: dict[str, Any], _request: PageRequest) -> dict[str, Any]:
+    subject = object_value(item.get("subject"), "notification subject")
+    repository = object_value(item.get("repository"), "notification repository")
+    notification_id = required_text(item.get("id"), "notification ID")
+    return {
+        "kind": "notification",
+        "remote_id": namespaced_id("notification", notification_id),
+        "notification_id": notification_id,
+        "reason": required_text(item.get("reason"), "notification reason"),
+        "unread": item.get("unread") if isinstance(item.get("unread"), bool) else None,
+        "updated_at": optional_text(item.get("updated_at"), "notification timestamp"),
+        "title": required_text(subject.get("title"), "notification title"),
+        "subject_type": required_text(subject.get("type"), "notification subject type"),
+        "repository_remote_id": _resource("repository", repository),
+    }
+
+
+def _user_list(item: dict[str, Any], _request: PageRequest) -> dict[str, Any]:
+    list_id = node_id(item.get("id"))
+    return {
+        "kind": "user_list",
+        "remote_id": namespaced_id("user_list", list_id),
+        "name": required_text(item.get("name"), "user list name"),
+        "description": optional_text(item.get("description"), "user list description"),
+        "slug": required_text(item.get("slug"), "user list slug"),
+        "private": item.get("isPrivate") if isinstance(item.get("isPrivate"), bool) else None,
+        "created_at": optional_text(item.get("createdAt"), "user list creation timestamp"),
+        "updated_at": optional_text(item.get("updatedAt"), "user list update timestamp"),
+    }
+
+
+SERIALIZERS = {
+    "repositories": _repository,
+    "stars": _repository,
+    "notifications": _notification,
+    "followers": _account,
+    "following": _account,
+    "organizations": _organization,
+    "subscriptions": _repository,
+}
+
+
+def _rest_path(request: PageRequest) -> tuple[str, dict[str, str]]:
+    path = STREAM_PATHS[request.stream]
+    params = {"per_page": str(min(request.limit, 100))}
+    if request.stream == "repositories":
+        params["affiliation"] = "owner,collaborator,organization_member"
+    elif request.stream == "notifications":
+        params["all"] = "true"
+    return path, params
+
+
+def _rest_page(api: RestApi, request: PageRequest) -> PageResult:
+    initial_path, initial_params = _rest_path(request)
+    if request.stop_at is None:
+        target, params = initial_path, initial_params
+    else:
+        parsed = urlsplit(request.stop_at)
+        if parsed.scheme != "https" or parsed.netloc != "api.github.com" or parsed.path != initial_path:
+            raise GitHubReadProviderError("GitHub pagination link does not match the selected stream")
+        target, params = request.stop_at, {}
+    result = api(target, params)
+    if result.status != 200:
+        return result
+    source = object_list(result.payload, f"{request.stream} response", limit=100)
+    return _page_payload(
+        request,
+        [SERIALIZERS[request.stream](item, request) for item in source],
+        result.next_url,
+    )
+
+
+def _graph_root(result: ApiResult, field: str) -> dict[str, Any]:
+    root = object_value(result.payload, "GraphQL response")
+    if root.get("errors"):
+        raise GitHubReadProviderError("GitHub GraphQL read returned errors")
+    data = object_value(root.get("data"), "GraphQL data")
+    viewer = object_value(data.get("viewer"), "GraphQL viewer")
+    return object_value(viewer.get(field), f"GraphQL {field}")
+
+
+def _contributions(api: GraphApi, request: PageRequest) -> PageResult:
+    if request.stop_at is not None:
+        raise GitHubReadProviderError("GitHub contributions do not accept a page cursor")
+    result = api(CONTRIBUTIONS_QUERY, {})
+    if result.status != 200:
+        return result
+    collection = _graph_root(result, "contributionsCollection")
+    calendar = object_value(collection.get("contributionCalendar"), "contribution calendar")
+    weeks = object_list(calendar.get("weeks"), "contribution weeks", limit=54)
+    records: list[dict[str, Any]] = []
+    for week in weeks:
+        days = object_list(week.get("contributionDays"), "contribution days", limit=7)
+        for day in days:
+            count = day.get("contributionCount")
+            date = required_text(day.get("date"), "contribution date")
+            if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+                raise GitHubReadProviderError("GitHub contribution count is invalid")
+            if count:
+                records.append({
+                    "kind": "contribution",
+                    "remote_id": namespaced_id("contribution", date),
+                    "date": date,
+                    "count": count,
+                })
+    return _page_payload(request, records, None)
+
+
+def _projects(api: GraphApi, request: PageRequest) -> PageResult:
+    result = api(PROJECTS_QUERY, {"first": min(request.limit, 100), "after": request.stop_at})
+    if result.status != 200:
+        return result
+    connection = _graph_root(result, "projectsV2")
+    nodes = object_list(connection.get("nodes"), "GraphQL projects", limit=100)
+    info = object_value(connection.get("pageInfo"), "GraphQL project pageInfo")
+    has_next = info.get("hasNextPage")
+    if not isinstance(has_next, bool):
+        raise GitHubReadProviderError("GitHub GraphQL pageInfo is invalid")
+    cursor = required_text(info.get("endCursor"), "GraphQL end cursor") if has_next else None
+    records = []
+    for item in nodes:
+        project_id = node_id(item.get("id"))
+        records.append({
+            "kind": "project",
+            "remote_id": namespaced_id("project", project_id),
+            "node_id": project_id,
+            "number": item.get("number") if isinstance(item.get("number"), int) else None,
+            "title": required_text(item.get("title"), "project title"),
+            "description": optional_text(item.get("shortDescription"), "project description"),
+            "closed": item.get("closed") if isinstance(item.get("closed"), bool) else None,
+            "created_at": optional_text(item.get("createdAt"), "project creation timestamp"),
+            "updated_at": optional_text(item.get("updatedAt"), "project update timestamp"),
+        })
+    return _page_payload(request, records, cursor)
+
+
+def _user_lists(api: GraphApi, request: PageRequest) -> PageResult:
+    result = api(USER_LISTS_QUERY, {"first": min(request.limit, 100), "after": request.stop_at})
+    if result.status != 200:
+        return result
+    connection = _graph_root(result, "lists")
+    nodes = object_list(connection.get("nodes"), "GraphQL user lists", limit=100)
+    info = object_value(connection.get("pageInfo"), "GraphQL user list pageInfo")
+    has_next = info.get("hasNextPage")
+    if not isinstance(has_next, bool):
+        raise GitHubReadProviderError("GitHub GraphQL pageInfo is invalid")
+    cursor = required_text(info.get("endCursor"), "GraphQL end cursor") if has_next else None
+    records = [_user_list(item, request) for item in nodes]
+    return _page_payload(request, records, cursor)
+
+
+def _page_payload(
+    request: PageRequest, records: list[dict[str, Any]], next_cursor: str | None
+) -> dict[str, Any]:
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": records,
+        "meta": {
+            "stream": request.stream,
+            "instance_id": request.instance_id,
+            "transport": STREAMS[request.stream].transport,
+            "next_cursor": next_cursor,
+            "complete": next_cursor is None,
+            "snapshot": True,
+        },
+    }
+
+
+def page(rest: RestApi, graph: GraphApi, request: PageRequest) -> PageResult:
+    if request.stream == "contributions":
+        return _contributions(graph, request)
+    if request.stream == "projects_v2":
+        return _projects(graph, request)
+    if request.stream == "user_lists":
+        return _user_lists(graph, request)
+    return _rest_page(rest, request)

--- a/.agents/scripts/_knowledge_social_oauth_collector.py
+++ b/.agents/scripts/_knowledge_social_oauth_collector.py
@@ -101,6 +101,7 @@ class OAuthCollectorPolicy:
     default_budget: int = 11
     min_budget: int = 3
     max_page_size: int = 50
+    identity_cost_units: int = IDENTITY_COST_UNITS
 
 
 @dataclass
@@ -161,7 +162,7 @@ class OAuthCollector:
         self, runner: OAuthReader, initial: CollectionContext
     ) -> dict[str, Any]:
         context = initial
-        progress = CollectionProgress(budget_units=IDENTITY_COST_UNITS)
+        progress = CollectionProgress(budget_units=self.policy.identity_cost_units)
         while progress.budget_units + context.spec.cost_units <= self.args.budget:
             if context.lease is None:
                 raise self.policy.provider_module.ADAPTER_ERROR(
@@ -238,7 +239,7 @@ class OAuthCollector:
         )
         return collection_result(
             decision.output_status,
-            CollectionProgress(budget_units=IDENTITY_COST_UNITS),
+            CollectionProgress(budget_units=self.policy.identity_cost_units),
             failure_class=decision.failure_class,
             retry_after=retry_value,
             run_id=lease.run_id,

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -16,6 +16,7 @@ MEDIUM_HELPER="${SCRIPT_DIR}/knowledge_social_medium.py"
 DISCOURSE_HELPER="${SCRIPT_DIR}/knowledge_social_discourse.py"
 NODEBB_HELPER="${SCRIPT_DIR}/knowledge_social_nodebb.py"
 MASTODON_HELPER="${SCRIPT_DIR}/knowledge_social_mastodon.py"
+GITHUB_HELPER="${SCRIPT_DIR}/knowledge_social_github.py"
 QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
 SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
 SHARE_HELPER="${SCRIPT_DIR}/knowledge_social_share.py"
@@ -118,6 +119,13 @@ Mastodon synchronization:
   Write scopes, redirects, cross-origin links, and mutations are rejected.
   --budget is 3-1000 and --page-size is 1-100.
 
+GitHub synchronization:
+  sync-github binds REST /user numeric and node IDs to GraphQL viewer identity
+  before every page. Ten independent streams use exact REST GET routes or fixed
+  GraphQL read queries. REST Link targets and GraphQL pageInfo cursors remain
+  opaque; REST writes, GraphQL mutations, and redirects are unreachable.
+  --budget is 5-1000 and --page-size is 1-100.
+
 EOF
 	return 0
 }
@@ -167,6 +175,10 @@ Usage:
     [--collector-id ID] [--lease-seconds SECONDS]
   knowledge-social-helper.sh sync-mastodon [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id OPAQUE_HOME_ACCOUNT_ID --stream STREAM \
+    --profile PROFILE [--budget UNITS] [--page-size 1-100] \
+    [--collector-id ID] [--lease-seconds SECONDS]
+  knowledge-social-helper.sh sync-github [--base PATH] [--alias ALIAS] \
+    --connection-id ID --account-id NUMERIC_ACCOUNT_ID --stream STREAM \
     --profile PROFILE [--budget UNITS] [--page-size 1-100] \
     [--collector-id ID] [--lease-seconds SECONDS]
   knowledge-social-helper.sh sync-due [--base PATH] [--alias ALIAS] \
@@ -346,6 +358,20 @@ run_provider_sync() {
 	return 0
 }
 
+run_named_provider_sync() {
+	local subcommand="$1"
+	shift || return 1
+	case "$subcommand" in
+	sync-meta) run_provider_sync Meta "$META_HELPER" "$@" || return 1 ;;
+	sync-discourse) run_provider_sync Discourse "$DISCOURSE_HELPER" "$@" || return 1 ;;
+	sync-nodebb) run_provider_sync NodeBB "$NODEBB_HELPER" "$@" || return 1 ;;
+	sync-mastodon) run_provider_sync Mastodon "$MASTODON_HELPER" "$@" || return 1 ;;
+	sync-github) run_provider_sync GitHub "$GITHUB_HELPER" "$@" || return 1 ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
 run_registry_command() {
 	local subcommand="$1"
 	shift || return 1
@@ -420,17 +446,8 @@ main() {
 		fi
 		python3 "$LINKEDIN_HELPER" "$@" || return 1
 		;;
-	sync-meta)
-		run_provider_sync Meta "$META_HELPER" "$@" || return 1
-		;;
-	sync-discourse)
-		run_provider_sync Discourse "$DISCOURSE_HELPER" "$@" || return 1
-		;;
-	sync-nodebb)
-		run_provider_sync NodeBB "$NODEBB_HELPER" "$@" || return 1
-		;;
-	sync-mastodon)
-		run_provider_sync Mastodon "$MASTODON_HELPER" "$@" || return 1
+	sync-meta | sync-discourse | sync-nodebb | sync-mastodon | sync-github)
+		run_named_provider_sync "$subcommand" "$@" || return 1
 		;;
 	query | annotate)
 		run_query_command "$subcommand" "$@" || return 1

--- a/.agents/scripts/knowledge_social_github.py
+++ b/.agents/scripts/knowledge_social_github.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one bounded, read-only GitHub account stream into a social corpus."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import _knowledge_social_github as github
+from _knowledge_social_github_normalize import PageContext, normalize_page
+from _knowledge_social_github_reader import FixtureGitHub, GuardedGitHub, verified_identity
+from _knowledge_social_oauth_collector import OAuthCollectorPolicy, run_oauth_collector
+
+
+def _policy() -> OAuthCollectorPolicy:
+    """Bind GitHub-specific boundaries to the shared OAuth collector."""
+    return OAuthCollectorPolicy(
+        provider_module=github,
+        verified_identity=verified_identity,
+        normalize_page=normalize_page,
+        page_context=PageContext,
+        display_name="GitHub",
+        helper=Path(__file__).with_name("_knowledge_social_github_provider.py"),
+        fixture_reader=FixtureGitHub,
+        live_reader=GuardedGitHub,
+        budget_unit="request",
+        min_budget=5,
+        max_page_size=100,
+        identity_cost_units=2,
+    )
+
+
+def main() -> int:
+    return run_oauth_collector(_policy(), __doc__ or "")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/knowledge_social_registry.py
+++ b/.agents/scripts/knowledge_social_registry.py
@@ -51,6 +51,7 @@ PROVIDER_SPECS = (
         (("live", ()),),
     ),
     ProviderSpec("gumroad", (), "knowledge_social_gumroad.py", (("live", ()),)),
+    ProviderSpec("github", (), "knowledge_social_github.py", (("live", ()),)),
     ProviderSpec("mastodon", (), "knowledge_social_mastodon.py", (("live", ()),)),
     ProviderSpec(
         "nextcloud-talk",

--- a/.agents/tests/test-knowledge-social-github.sh
+++ b/.agents/tests/test-knowledge-social-github.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-github.sh — Bounded GitHub collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GITHUB_SCRIPT="${SCRIPT_DIR}/../scripts/knowledge_social_github.py"
+SOCIAL_HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TEMP_PARENT="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+mkdir -p "$TEMP_PARENT"
+TMP_DIR=$(mktemp -d "${TEMP_PARENT}/github-social-test.XXXXXX")
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' \
+			"$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c 'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_count() {
+	python3 - "$ROOT/sources/social/raw/github" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+print(len(list(root.rglob("*.json.gz"))) if root.exists() else 0)
+PY
+	return 0
+}
+
+run_github() {
+	local fixture="$1"
+	local connection_id="$2"
+	local stream="$3"
+	local budget="$4"
+	local page_size="$5"
+	if python3 "$GITHUB_SCRIPT" --base "$BASE" --alias personal:default \
+		--connection-id "$connection_id" --account-id account_42 \
+		--stream "$stream" --profile fixture --fixture "$fixture" \
+		--budget "$budget" --page-size "$page_size"; then
+		return 0
+	fi
+	return 1
+}
+
+expect_failure() {
+	local description="$1"
+	local fixture="$2"
+	local connection_id="$3"
+	local stream="$4"
+	if run_github "$fixture" "$connection_id" "$stream" 11 40 >/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$SOCIAL_HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'GitHub social collector tests\n'
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import ast
+import json
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+
+from _knowledge_social_collect import CursorState
+from _knowledge_social_github import PageRequest, STREAMS, page_checkpoint, page_request
+from _knowledge_social_github_contract import ApiResult, combined_identity
+from _knowledge_social_github_http import (
+    HTTP_TIMEOUT_SECONDS,
+    ProfileConfig,
+    _rate_reset,
+    graphql_api,
+    rest_api,
+)
+from _knowledge_social_github_identity import INSTANCE_ID, account_id, namespaced_id
+from _knowledge_social_github_routes import (
+    CONTRIBUTIONS_QUERY,
+    PROJECTS_QUERY,
+    USER_LISTS_QUERY,
+    allowlisted_path,
+    page,
+)
+
+assert set(STREAMS) == {
+    "contributions", "repositories", "stars", "notifications", "followers",
+    "following", "organizations", "subscriptions", "user_lists", "projects_v2",
+}
+assert all(spec.cost_units == 3 and spec.pagination == "snapshot" for spec in STREAMS.values())
+assert STREAMS["user_lists"].transport == "graphql"
+for allowed in ("/user", "/user/repos", "/notifications", "/user/subscriptions"):
+    assert allowlisted_path(allowed)
+for rejected in (
+    "/user/following/7", "/notifications/threads/1", "/repos/o/r/issues/1",
+    "/user/migrations", "/graphql",
+):
+    assert not allowlisted_path(rejected)
+
+identity = combined_identity(
+    {"id": 42, "node_id": "MDQ6VXNlcjQy", "login": "selected"},
+    {"data": {"viewer": {"databaseId": 42, "id": "MDQ6VXNlcjQy", "login": "selected"}}},
+    "42",
+)
+assert identity["id"] == account_id(42, "MDQ6VXNlcjQy")
+assert namespaced_id("repository", "opaque-A") != namespaced_id("repository", "opaque-B")
+try:
+    combined_identity(
+        {"id": 42, "node_id": "MDQ6VXNlcjQy", "login": "selected"},
+        {"data": {"viewer": {"databaseId": 43, "id": "MDQ6VXNlcjQz", "login": "other"}}},
+        "42",
+    )
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("mismatched GitHub REST and GraphQL identities were accepted")
+
+
+class Headers:
+    def __init__(self, values=None):
+        self.values = values or {}
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+
+class Response:
+    status = 200
+
+    def __init__(self, payload, headers=None):
+        self.payload = json.dumps(payload).encode()
+        self.headers = Headers(headers)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def read(self, size=-1):
+        return self.payload[:size]
+
+
+class Opener:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    def open(self, request, timeout):
+        assert timeout == HTTP_TIMEOUT_SECONDS
+        assert "private-token" not in request.full_url
+        self.requests.append(request)
+        return self.responses.pop(0)
+
+
+config = ProfileConfig("private-token", "classic_pat", frozenset({"read:user"}))
+assert _rate_reset(Headers({"X-RateLimit-Reset": "1785630000"})) == 1785630000
+next_url = "https://api.github.com/user/repos?affiliation=owner%2Ccollaborator%2Corganization_member&per_page=2&page=2"
+opener = Opener([Response([], {"Link": f'<{next_url}>; rel="next"'})])
+result = rest_api(
+    config, opener, "/user/repos",
+    {"affiliation": "owner,collaborator,organization_member", "per_page": "2"},
+)
+assert result.next_url == next_url
+assert opener.requests[0].method == "GET"
+try:
+    rest_api(config, opener, "https://api.github.com/user/following/7", {})
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("GitHub write route was accepted")
+try:
+    graphql_api(config, opener, "mutation Unsafe { addStar(input: {}) { clientMutationId } }", {})
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("GitHub GraphQL mutation was accepted")
+
+graph_opener = Opener([Response({"data": {"viewer": {"id": "MDQ6VXNlcjQy"}}})])
+graphql_api(config, graph_opener, "query Safe { viewer { id } }", {})
+assert graph_opener.requests[0].method == "POST"
+assert graph_opener.requests[0].full_url == "https://api.github.com/graphql"
+
+request = PageRequest(
+    "repositories", identity["id"], "42", "selected", INSTANCE_ID, 1, None, 2,
+)
+repository = {
+    "id": 7, "node_id": "R_kgDOopaque", "name": "project", "full_name": "selected/project",
+    "description": "Bounded GitHub knowledge", "private": True, "archived": False,
+    "owner": {"id": 42, "node_id": "MDQ6VXNlcjQy", "login": "selected"},
+}
+payload = page(lambda _target, _params: ApiResult(200, [repository], next_url), lambda *_args: None, request)
+assert payload["meta"]["next_cursor"] == next_url
+assert payload["data"][0]["kind"] == "repository"
+checkpoint, complete = page_checkpoint(payload, CursorState(None, None, False), request)
+assert not complete and checkpoint.next_cursor is not None
+resumed = page_request("repositories", identity, CursorState(checkpoint.next_cursor, None, False), 2)
+assert resumed.position == 2 and resumed.stop_at == next_url
+cross_stream = PageRequest(
+    "followers", identity["id"], "42", "selected", INSTANCE_ID, 2, next_url, 2,
+)
+try:
+    page(lambda *_args: ApiResult(200, []), lambda *_args: None, cross_stream)
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("cross-stream GitHub REST Link was accepted")
+
+for query in (CONTRIBUTIONS_QUERY, PROJECTS_QUERY, USER_LISTS_QUERY):
+    normalized = " ".join(query.split()).casefold()
+    assert normalized.startswith("query ") and "mutation" not in normalized
+
+sources = [path.read_text(encoding="utf-8") for path in sorted(scripts.glob("_knowledge_social_github*.py"))]
+trees = [ast.parse(source) for source in sources]
+request_calls = [
+    node for tree in trees for node in ast.walk(tree)
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "Request"
+]
+assert len(request_calls) == 2
+methods = {
+    keyword.value.value for node in request_calls for keyword in node.keywords
+    if keyword.arg == "method" and isinstance(keyword.value, ast.Constant)
+}
+assert methods == {"GET", "POST"}
+PY
+assert_eq "identity, route, opaque cursor, token, and mutation boundaries are guarded" \
+	verified verified
+
+python3 - "$TMP_DIR/complete.json" <<'PY'
+import json
+import sys
+
+sys.path.insert(0, ".agents/scripts")
+from _knowledge_social_github_identity import INSTANCE_ID, account_id, namespaced_id
+
+node = "MDQ6VXNlcjQy"
+durable = account_id("42", node)
+payload = {
+    "identity": {"data": {
+        "id": durable, "provider_account_id": "42", "node_id": node,
+        "login": "selected", "name": "Private profile", "instance_id": INSTANCE_ID,
+    }},
+    "pages": [{
+        "expect_request": {"position": 1, "stop_at": None, "limit": 1},
+        "response": {
+            "status": 200, "observed_at": "2026-08-02T06:00:00Z",
+            "data": [{
+                "kind": "repository", "remote_id": namespaced_id("repository", "R_kgDOopaque"),
+                "node_id": "R_kgDOopaque", "name": "project", "full_name": "selected/project",
+                "description": "Bounded GitHub knowledge",
+                "owner_remote_id": namespaced_id("account", node),
+            }],
+            "meta": {"stream": "repositories", "instance_id": INSTANCE_ID,
+                     "transport": "rest", "next_cursor": None,
+                     "complete": True, "snapshot": True},
+        },
+    }],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+result=$(run_github "$TMP_DIR/complete.json" conn_github repositories 5 1)
+assert_eq "bounded GitHub fixture completes" "$(json_field "$result" status)" complete
+assert_eq "REST plus GraphQL identity and one page consume five request units" \
+	"$(json_field "$result" budget_units)" 5
+assert_eq "GitHub repository text reaches FTS" \
+	"$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'bounded'")" 1
+assert_eq "completed GitHub snapshot records its checkpoint" \
+	"$(sql_value "SELECT coalesce(cursor,'done') || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_github'")" \
+	"done:1"
+
+python3 - "$TMP_DIR/mismatch.json" <<'PY'
+import json
+import sys
+
+payload = {"identity": {"data": {
+    "id": "wrong", "provider_account_id": "43", "node_id": "MDQ6VXNlcjQz",
+    "login": "other", "instance_id": "github-com",
+}}, "pages": []}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+raw_before=$(raw_count)
+expect_failure "selected-account identity mismatch is rejected" \
+	"$TMP_DIR/mismatch.json" conn_mismatch repositories
+assert_eq "identity mismatch persists no raw evidence" "$(raw_count)" "$raw_before"
+
+python3 - "$TMP_DIR/credential.json" <<'PY'
+import json
+import sys
+
+sys.path.insert(0, ".agents/scripts")
+from _knowledge_social_github_identity import INSTANCE_ID, account_id
+
+node = "MDQ6VXNlcjQy"
+payload = {
+    "identity": {"data": {"id": account_id("42", node), "provider_account_id": "42",
+                            "node_id": node, "login": "selected", "instance_id": INSTANCE_ID}},
+    "pages": [{"status": 200, "observed_at": "2026-08-02T06:01:00Z",
+               "access_token": "must-not-persist", "data": [],
+               "meta": {"stream": "stars", "instance_id": INSTANCE_ID,
+                        "transport": "rest", "next_cursor": None,
+                        "complete": True, "snapshot": True}}],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+raw_before=$(raw_count)
+expect_failure "credential-shaped GitHub page is rejected" \
+	"$TMP_DIR/credential.json" conn_credential stars
+assert_eq "credential rejection persists no raw evidence" "$(raw_count)" "$raw_before"
+
+assert_eq "unsupported historical categories remain explicit gaps" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE connection_id='conn_github' AND status='unavailable' AND stream IN ('reactions','migration_archives','deleted_resources','private_resources','organization_audit_logs')")" 5
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/tests/test-knowledge-social-registry.sh
+++ b/.agents/tests/test-knowledge-social-registry.sh
@@ -43,6 +43,7 @@ expected = {
     "binance-square": ("no-route",),
     "discord": ("live",),
     "forem": ("live",),
+    "github": ("live",),
     "google-business-profile": ("live",),
     "gumroad": ("live",),
     "mastodon": ("live",),
@@ -91,14 +92,14 @@ except module.ProviderRegistryError:
 else:
     raise SystemExit("unknown provider used a fallback")
 
-print("12:order-independent:aliases-exact:collisions-rejected:no-fallback")
+print("13:order-independent:aliases-exact:collisions-rejected:no-fallback")
 PY
 )
 assert_eq "all merged provider outcomes register deterministically" \
-	"$registry_summary" "12:order-independent:aliases-exact:collisions-rejected:no-fallback"
+	"$registry_summary" "13:order-independent:aliases-exact:collisions-rejected:no-fallback"
 
 provider_count=$("$HELPER" providers | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
-assert_eq "helper exposes the complete provider registry" "$provider_count" "12"
+assert_eq "helper exposes the complete provider registry" "$provider_count" "13"
 
 forem_resolution=$("$HELPER" provider-resolve --provider dev-community |
 	python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["provider"] + ":" + ",".join(data["modes"]))')


### PR DESCRIPTION
## Summary

Implement identity-bound, read-only GitHub REST and GraphQL collection with opaque checkpoints, explicit capability gaps, registry routing, and documentation.

## Files Changed

.agents/aidevops/knowledge-plane/05-social-operations.md, .agents/aidevops/knowledge-plane/06-social-provider-capabilities.md, .agents/content/social-github.md, .agents/scripts/_knowledge_social_github.py, .agents/scripts/_knowledge_social_github_contract.py, .agents/scripts/_knowledge_social_github_http.py, .agents/scripts/_knowledge_social_github_identity.py, .agents/scripts/_knowledge_social_github_normalize.py, .agents/scripts/_knowledge_social_github_provider.py, .agents/scripts/_knowledge_social_github_reader.py, .agents/scripts/_knowledge_social_github_routes.py, .agents/scripts/_knowledge_social_oauth_collector.py, .agents/scripts/knowledge-social-helper.sh, .agents/scripts/knowledge_social_github.py, .agents/scripts/knowledge_social_registry.py, .agents/tests/test-knowledge-social-github.sh, .agents/tests/test-knowledge-social-registry.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified: test-knowledge-social-github.sh passed 10/10; test-knowledge-social-registry.sh passed 8/8; test-knowledge-social-mastodon.sh passed 14/14; linters-local.sh --full completed successfully.

Resolves #29222


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 5h 25m and 3,240,054 tokens on this with the user in an interactive session.