### PR TITLE
GH#29249: Remove load-average throttles suppressing Pulse worker throughput

### DIFF
--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -387,20 +387,21 @@ Use this when a runner's dashboard is fresh but **Active Workers = 0**.
    low-concurrency signal by itself. By default,
    `orchestration.provider_account_slot_multiplier=24`, so one available
    OpenAI or Anthropic account may reach the configured `max_workers_cap` when
-   RAM/load and provider-health gates are clean. If the dashboard or
+   RAM/disk and provider-health gates are clean. If the dashboard or
    `pulse.log` `Dispatch_capacity` line shows `final_max` below `raw_max`, use
    the logged fields (`account_cap`, `provider_account_slot_multiplier`,
-   `rate_limits`, `service_interruptions`, `provider_5xx`, `auth_error_accounts`,
-   `load_points`) to identify the reducing gate. Lower concurrency explicitly
-   with `aidevops config set orchestration.provider_account_slot_multiplier <n>`
-   or `PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER=<n>` when a provider plan cannot
+   `rate_limits`, `service_interruptions`, `provider_5xx`, and
+   `auth_error_accounts`) to identify the reducing gate. Lower concurrency
+   explicitly with
+   `aidevops config set orchestration.provider_account_slot_multiplier <n>` or
+   `PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER=<n>` when a provider plan cannot
    sustain the default.
 
 5. Read the dashboard's **Worker Dispatch Diagnostics** section. It is rendered only when Active Workers is 0 and distinguishes:
    - no eligible work (`Assigned Issues=0`, `Total Issues=0`)
    - auth/model unavailable (OpenAI/Anthropic both missing)
    - canary or worker launch failure (`Last Launch Failure`)
-   - max-worker/resource gate (`Max Workers=0`, high CPU/load, memory pressure)
+   - max-worker/resource gate (`Max Workers=0`, memory or disk pressure)
    - API budget/dispatch blockers (inspect `Last Dispatch Stage` and the current-state helper output)
 
 6. Linux process counting must use the shared worker discovery path, which calls `ps axwwo pid,stat,etime,command` so long OpenCode commands are not truncated. A direct `pgrep` snapshot is not canonical because dispatch is bursty and can land between waves.
@@ -433,22 +434,23 @@ Pulse keeps a soft minimum implementation-worker floor so transient local pressu
 When active workers are below the floor:
 
 - `dispatch_max` keeps dispatch eligible up to the floor when only soft pressure is present.
-- The worker canary still checks runtime/model health. CPU/load/saturation is not a canary throttle; auth checks, GraphQL circuit breaker, stop flag, memory/process failures, and other hard safety gates still apply.
+- The worker canary still checks runtime/model health. CPU/load/saturation is diagnostic-only and never changes candidate eligibility, capacity, launch delay, or canary outcomes; auth checks, GraphQL circuit breaker, stop flag, memory/process failures, and other hard safety gates still apply.
 - Existing max worker caps above the floor still cap runaway dispatch.
 
 Set `orchestration.min_worker_concurrency=0` (or `AIDEVOPS_MIN_WORKER_CONCURRENCY=0`) to disable the floor, or set a higher/lower integer for a runner-specific target.
 
 ### Adaptive Worker Launch Staggering (t3482)
 
-Pulse staggers worker launches inside the parallel `dispatch_max` loop when live pressure signals show that a back-to-back batch is likely to waste provider budget or overload the local runtime. The first launch in a clean round is immediate; subsequent launches remain near-zero delay unless one or more pressure signals are active.
+Pulse staggers worker launches inside the parallel `dispatch_max` loop when provider, failure, or API-budget signals show that a back-to-back batch is likely to waste capacity. The first launch in a clean round is immediate; subsequent launches remain near-zero delay unless one or more pressure signals are active.
 
 Signals that increase the inter-launch delay:
 
-- High `load_per_cpu` from recent headless-runtime metrics.
 - Recent non-success worker terminal metrics, especially clustered `rate_limit` results.
 - Provider/rate-limit backoff flags.
 - Low cached GraphQL remaining budget.
 - Large in-flight launch bursts while pressure is already present.
+
+Host CPU and `load_per_cpu` remain visible in runtime metrics for diagnosis, but the OS scheduler arbitrates CPU contention; those values do not block or pace dispatch.
 
 Observability:
 
@@ -456,7 +458,7 @@ Observability:
 pulse-current-state-helper.sh --window 15m --json | jq '.dispatch_pacing'
 ```
 
-Relevant tuning knobs: `PULSE_DISPATCH_STAGGER_ADAPTIVE=0` disables adaptive staggering, `PULSE_DISPATCH_STAGGER_MAX_SECONDS` caps the delay (default 20s), `PULSE_DISPATCH_STAGGER_JITTER_MAX_SECONDS` caps deterministic jitter (default 3s), and the `PULSE_DISPATCH_STAGGER_*` threshold variables override load/failure/GraphQL sensitivity for diagnostics.
+Relevant tuning knobs: `PULSE_DISPATCH_STAGGER_ADAPTIVE=0` disables adaptive staggering, `PULSE_DISPATCH_STAGGER_MAX_SECONDS` caps the delay (default 20s), `PULSE_DISPATCH_STAGGER_JITTER_MAX_SECONDS` caps deterministic jitter (default 3s), and the `PULSE_DISPATCH_STAGGER_*` threshold variables override failure/GraphQL sensitivity for diagnostics.
 
 ### Version Guard
 

--- a/.agents/scripts/pulse-capacity.sh
+++ b/.agents/scripts/pulse-capacity.sh
@@ -45,26 +45,6 @@ get_max_workers_target() {
 }
 
 #######################################
-# Scale a decimal value by 100 for integer comparisons.
-# Arguments:
-#   $1 - decimal value
-#   $2 - fallback decimal value
-# Returns: scaled integer via stdout
-#######################################
-_pulse_capacity_float_scaled() {
-	local float_value="${1:-0}"
-	local fallback="${2:-0}"
-	python3 - "$float_value" "$fallback" <<'PY'
-import sys
-try:
-    print(int(float(sys.argv[1]) * 100))
-except (ValueError, IndexError):
-    print(int(float(sys.argv[2]) * 100))
-PY
-	return 0
-}
-
-#######################################
 # Resolve the provider that should drive round capacity planning.
 # Returns: provider token via stdout, or blank when unknown.
 #######################################
@@ -130,42 +110,7 @@ _pulse_capacity_provider_account_counts() {
 }
 
 #######################################
-# Return host load pressure points for capacity reduction.
-# Stdout: 0, 2, or 4.
-#######################################
-_pulse_capacity_load_pressure_points() {
-	local load_per_cpu="${PULSE_DISPATCH_STAGGER_LOAD_PER_CPU:-}"
-	local metrics_file="${AIDEVOPS_HEADLESS_METRICS_FILE:-${HOME}/.aidevops/logs/headless-runtime-metrics.jsonl}"
-	if [[ -z "$load_per_cpu" && -f "$metrics_file" ]]; then
-		load_per_cpu=$(awk '
-			/"load_per_cpu"[[:space:]]*:/ { line = $0 }
-			END {
-				if (line != "") {
-					sub(/^.*"load_per_cpu"[[:space:]]*:[[:space:]]*/, "", line)
-					sub(/[,}].*$/, "", line)
-					print line
-				}
-			}
-		' "$metrics_file" 2>/dev/null) || load_per_cpu=""
-	fi
-	local load_scaled=0 high_scaled moderate_scaled
-	[[ -n "$load_per_cpu" ]] && load_scaled=$(_pulse_capacity_float_scaled "$load_per_cpu" 0)
-	high_scaled=$(_pulse_capacity_float_scaled "${PULSE_DISPATCH_STAGGER_LOAD_HIGH:-8}" 8)
-	moderate_scaled=$(_pulse_capacity_float_scaled "${PULSE_DISPATCH_STAGGER_LOAD_MODERATE:-4}" 4)
-	if ((load_scaled >= high_scaled && load_scaled > 0)); then
-		printf '4\n'
-		return 0
-	fi
-	if ((load_scaled >= moderate_scaled && load_scaled > 0)); then
-		printf '2\n'
-		return 0
-	fi
-	printf '0\n'
-	return 0
-}
-
-#######################################
-# Count recent terminal worker-role provider/load health signals. Continuation
+# Count recent terminal worker-role provider health signals. Continuation
 # events remain progress evidence but never become failure/capacity pressure.
 # Stdout: "<failures> <rate_limits> <service_interruptions> <provider_5xx> <progress_heartbeats>".
 #######################################
@@ -201,7 +146,9 @@ _pulse_capacity_recent_health_counts() {
 }
 
 #######################################
-# Apply a provider/account/load-aware cap to the raw dispatch target.
+# Apply a provider/account/terminal-health-aware cap to the raw dispatch target.
+# The historical function name remains for sourced-call compatibility; host
+# load is diagnostic-only and does not participate in capacity decisions.
 # Arguments:
 #   $1 - raw max workers
 #   $2 - active workers
@@ -224,10 +171,8 @@ pulse_apply_provider_load_capacity_cap() {
 	[[ "$account_limited" =~ ^[0-9]+$ ]] || account_limited=0
 	[[ "$account_auth_errors" =~ ^[0-9]+$ ]] || account_auth_errors=0
 
-	local load_points="" failures="" rate_limits="" service_interruptions="" provider_5xx="" progress_heartbeats=""
-	load_points=$(_pulse_capacity_load_pressure_points)
+	local failures="" rate_limits="" service_interruptions="" provider_5xx="" progress_heartbeats=""
 	read -r failures rate_limits service_interruptions provider_5xx progress_heartbeats <<<"$(_pulse_capacity_recent_health_counts)"
-	[[ "$load_points" =~ ^[0-9]+$ ]] || load_points=0
 	[[ "$failures" =~ ^[0-9]+$ ]] || failures=0
 	[[ "$rate_limits" =~ ^[0-9]+$ ]] || rate_limits=0
 	[[ "$service_interruptions" =~ ^[0-9]+$ ]] || service_interruptions=0
@@ -249,7 +194,7 @@ pulse_apply_provider_load_capacity_cap() {
 	fi
 
 	local floor_allowed=1 final_max="$raw_max_workers" floor_active=0
-	if ((load_points >= 4 || rate_limits > 0 || service_interruptions > 0 || provider_5xx > 0 || failures >= 3)); then
+	if ((rate_limits > 0 || service_interruptions > 0 || provider_5xx > 0 || failures >= 3)); then
 		floor_allowed=0
 	fi
 	if ((account_cap >= 0 && min_worker_floor > 0 && account_cap < min_worker_floor)); then
@@ -266,23 +211,16 @@ pulse_apply_provider_load_capacity_cap() {
 	if ((account_cap >= 0 && final_max > account_cap)); then
 		final_max="$account_cap"
 	fi
-	if ((load_points >= 4 && final_max > 1)); then
-		final_max=$(((final_max + 1) / 2))
-	elif ((load_points >= 2 && final_max > 1)); then
-		final_max=$(((final_max * 3 + 3) / 4))
-	fi
 	if ((rate_limits > 0 || service_interruptions > 0 || provider_5xx > 0 || failures >= 3)); then
 		if ((final_max > 1)); then
 			final_max=$(((final_max + 1) / 2))
 		fi
 	fi
 	if ((active_workers > 0 && progress_heartbeats > 0)); then
-		if ((load_points >= 4 || rate_limits > 0 || service_interruptions > 0 || provider_5xx > 0 || failures >= 3)); then
+		if ((rate_limits > 0 || service_interruptions > 0 || provider_5xx > 0 || failures >= 3)); then
 			if ((final_max > active_workers)); then
 				final_max="$active_workers"
 			fi
-		elif ((load_points >= 2 && final_max > active_workers + 1)); then
-			final_max=$((active_workers + 1))
 		fi
 	fi
 	if ((final_max < 0)); then
@@ -294,15 +232,14 @@ pulse_apply_provider_load_capacity_cap() {
 
 	if declare -F _dispatch_stats_gauge >/dev/null 2>&1; then
 		_dispatch_stats_gauge "dispatch_capacity_provider_accounts_available" "$((account_available < 0 ? 0 : account_available))"
-		_dispatch_stats_gauge "dispatch_capacity_load_pressure_points" "$load_points"
 		_dispatch_stats_gauge "dispatch_capacity_recent_failures" "$failures"
 		_dispatch_stats_gauge "dispatch_capacity_recent_worker_terminal_failures" "$failures"
 		_dispatch_stats_gauge "dispatch_capacity_final_max_workers" "$final_max"
 	fi
 	local health_window_seconds="${PULSE_DISPATCH_CAPACITY_HEALTH_WINDOW_SECONDS:-900}"
 	[[ "$health_window_seconds" =~ ^[0-9]+$ ]] || health_window_seconds=900
-	printf '[pulse-wrapper] Dispatch_capacity: capacity_unit=simultaneous_workers simultaneous_target_raw=%s simultaneous_target_final=%s active_workers=%s provider=%s provider_accounts_total=%s provider_accounts_available=%s account_cap=%s provider_account_slot_multiplier=%s provider_account_slot_multiplier_source=%s override_hint="lower orchestration.provider_account_slot_multiplier or PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER if provider plan cannot sustain this concurrency" rate_limited_accounts=%s auth_error_accounts=%s load_points=%s worker_terminal_failures=%s rate_limits=%s service_interruptions=%s provider_5xx=%s worker_progress_heartbeats=%s failure_observation_window_seconds=%s task_duration_limit=none min_floor=%s floor_allowed=%s floor_active=%s\n' \
-		"$raw_max_workers" "$final_max" "$active_workers" "${provider:-unknown}" "$account_total" "$account_available" "$account_cap" "$account_multiplier" "$account_multiplier_source" "$account_limited" "$account_auth_errors" "$load_points" "$failures" "$rate_limits" "$service_interruptions" "$provider_5xx" "$progress_heartbeats" "$health_window_seconds" "$min_worker_floor" "$floor_allowed" "$floor_active" >>"${LOGFILE:-/dev/null}" 2>/dev/null || true
+	printf '[pulse-wrapper] Dispatch_capacity: capacity_unit=simultaneous_workers simultaneous_target_raw=%s simultaneous_target_final=%s active_workers=%s provider=%s provider_accounts_total=%s provider_accounts_available=%s account_cap=%s provider_account_slot_multiplier=%s provider_account_slot_multiplier_source=%s override_hint="lower orchestration.provider_account_slot_multiplier or PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER if provider plan cannot sustain this concurrency" rate_limited_accounts=%s auth_error_accounts=%s worker_terminal_failures=%s rate_limits=%s service_interruptions=%s provider_5xx=%s worker_progress_heartbeats=%s failure_observation_window_seconds=%s task_duration_limit=none min_floor=%s floor_allowed=%s floor_active=%s\n' \
+		"$raw_max_workers" "$final_max" "$active_workers" "${provider:-unknown}" "$account_total" "$account_available" "$account_cap" "$account_multiplier" "$account_multiplier_source" "$account_limited" "$account_auth_errors" "$failures" "$rate_limits" "$service_interruptions" "$provider_5xx" "$progress_heartbeats" "$health_window_seconds" "$min_worker_floor" "$floor_allowed" "$floor_active" >>"${LOGFILE:-/dev/null}" 2>/dev/null || true
 	printf '%s %s\n' "$final_max" "$floor_active"
 	return 0
 }

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -701,41 +701,6 @@ _dispatch_stats_gauge() {
 }
 
 #######################################
-# Return the latest numeric headless-runtime metric value for a key.
-#
-# Arguments:
-#   $1 - metric key
-# Stdout: numeric value, or blank when unavailable.
-#######################################
-_dispatch_latest_metric_value() {
-	local metric_key="$1"
-	local metrics_file="${AIDEVOPS_HEADLESS_METRICS_FILE:-${HOME}/.aidevops/logs/headless-runtime-metrics.jsonl}"
-	[[ -f "$metrics_file" ]] || { printf '\n'; return 0; }
-	python3 - "$metrics_file" "$metric_key" <<'PY'
-import json
-import sys
-from collections import deque
-
-path, key = sys.argv[1], sys.argv[2]
-value = ""
-try:
-    with open(path, "r", encoding="utf-8", errors="replace") as handle:
-        for raw in deque(handle, 1000):
-            try:
-                item = json.loads(raw)
-            except json.JSONDecodeError:
-                continue
-            candidate = item.get(key)
-            if isinstance(candidate, (int, float)):
-                value = str(candidate)
-except OSError:
-    pass
-print(value)
-PY
-	return 0
-}
-
-#######################################
 # Count recent worker failure/rate-limit metrics for launch pacing.
 #
 # Stdout: "<failures> <rate_limits>".
@@ -781,38 +746,6 @@ _dispatch_graphql_remaining_cached() {
 	fi
 	_DISPATCH_STAGGER_GRAPHQL_REMAINING=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || printf '\n')
 	printf '%s\n' "$_DISPATCH_STAGGER_GRAPHQL_REMAINING"
-	return 0
-}
-
-_dispatch_float_scaled() {
-	local float_value="${1:-0}"
-	local fallback="${2:-0}"
-	python3 - "$float_value" "$fallback" <<'PY'
-import sys
-try:
-    print(int(float(sys.argv[1]) * 100))
-except (ValueError, IndexError):
-    print(int(float(sys.argv[2]) * 100))
-PY
-	return 0
-}
-
-_dispatch_load_pressure_points() {
-	local load_per_cpu="${PULSE_DISPATCH_STAGGER_LOAD_PER_CPU:-}"
-	[[ -n "$load_per_cpu" ]] || load_per_cpu=$(_dispatch_latest_metric_value "load_per_cpu")
-	local load_scaled=0 high_scaled moderate_scaled
-	[[ -n "$load_per_cpu" ]] && load_scaled=$(_dispatch_float_scaled "$load_per_cpu" 0)
-	high_scaled=$(_dispatch_float_scaled "${PULSE_DISPATCH_STAGGER_LOAD_HIGH:-8}" 8)
-	moderate_scaled=$(_dispatch_float_scaled "${PULSE_DISPATCH_STAGGER_LOAD_MODERATE:-4}" 4)
-	if ((load_scaled >= high_scaled && load_scaled > 0)); then
-		printf '4\n'
-		return 0
-	fi
-	if ((load_scaled >= moderate_scaled && load_scaled > 0)); then
-		printf '2\n'
-		return 0
-	fi
-	printf '0\n'
 	return 0
 }
 
@@ -916,7 +849,6 @@ _dispatch_inter_launch_delay() {
 	fi
 
 	local pressure_points=0
-	pressure_points=$((pressure_points + $(_dispatch_load_pressure_points)))
 	local recent_failures="" recent_rate_limits="" pressure_line=""
 	pressure_line=$(_dispatch_recent_worker_pressure_counts)
 	read -r recent_failures recent_rate_limits <<<"$pressure_line"

--- a/.agents/scripts/pulse-dispatch-worker-gates.sh
+++ b/.agents/scripts/pulse-dispatch-worker-gates.sh
@@ -370,37 +370,6 @@ _dlw_opencode_storage_preflight() {
 	return 0
 }
 
-_dlw_load_preflight() {
-	local issue_number="$1"
-	local repo_slug="$2"
-	local max_load_per_cpu="${AIDEVOPS_DISPATCH_MAX_LOAD_PER_CPU:-3.0}"
-	local current_ratio=""
-
-	[[ "${AIDEVOPS_DISPATCH_LOAD_PREFLIGHT:-1}" != "0" ]] || return 0
-	current_ratio=$(python3 - <<'PY' 2>/dev/null || true
-import os
-try:
-    load = os.getloadavg()[0]
-    cpus = os.cpu_count() or 1
-    print(f"{load / cpus:.3f}")
-except Exception:
-    print("")
-PY
-)
-	[[ -n "$current_ratio" ]] || return 0
-	if ! python3 - "$current_ratio" "$max_load_per_cpu" >/dev/null 2>&1 <<'PY'
-import sys
-current = float(sys.argv[1])
-maximum = float(sys.argv[2])
-sys.exit(0 if current <= maximum else 1)
-PY
-	then
-		echo "[dispatch_with_dedup] Skipping #${issue_number} in ${repo_slug} — local load_per_cpu=${current_ratio} exceeds dispatch threshold ${max_load_per_cpu}" >>"$LOGFILE"
-		return 1
-	fi
-	return 0
-}
-
 _dlw_blocked_by_hard_stop() {
 	local issue_number="$1"
 	local repo_slug="$2"
@@ -491,9 +460,6 @@ _dlw_prebootstrap_gates() {
 		return 1
 	fi
 	if ! _dlw_opencode_storage_preflight "$issue_number" "$repo_slug"; then
-		return 1
-	fi
-	if ! _dlw_load_preflight "$issue_number" "$repo_slug"; then
 		return 1
 	fi
 	if _dlw_hold_repeated_recovery_failures "$issue_number" "$repo_slug"; then

--- a/.agents/scripts/tests/test-dispatch-min-concurrency.sh
+++ b/.agents/scripts/tests/test-dispatch-min-concurrency.sh
@@ -153,27 +153,22 @@ test_capacity_respects_existing_higher_cap() {
 	return 0
 }
 
-test_capacity_caps_by_provider_accounts_and_high_load() {
+test_capacity_high_load_is_advisory_only() {
 	reset_capacity_pressure_env
 	TEST_MAX_WORKERS=12
 	TEST_ACTIVE_WORKERS=1
 	AIDEVOPS_MIN_WORKER_CONCURRENCY=6
-	PULSE_MODEL="openai/gpt-5.5"
-	PULSE_DISPATCH_STAGGER_LOAD_PER_CPU=9
-	PULSE_PROVIDER_ACCOUNT_SLOT_MULTIPLIER=2
-	cat >"${HOME}/.aidevops/oauth-pool.json" <<'JSON'
-{"openai":[{"status":"idle"},{"status":"active"}]}
-JSON
+	PULSE_DISPATCH_STAGGER_LOAD_PER_CPU=99
 	unset _DISPATCH_MIN_WORKER_FLOOR_ACTIVE || true
 	local result capacity_file
 	capacity_file=$(mktemp)
 	_dispatch_compute_capacity >"$capacity_file"
 	result=$(<"$capacity_file")
 	rm -f "$capacity_file"
-	if [[ "$result" == "2 1 1" && "${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-0}" == "0" ]]; then
-		print_result "capacity: provider accounts and high load cap below floor" 0
+	if [[ "$result" == "12 1 11" && "${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-0}" == "1" ]]; then
+		print_result "capacity: high load remains advisory and preserves healthy floor" 0
 	else
-		print_result "capacity: provider accounts and high load cap below floor" 1 "result=${result} floor_active=${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-unset}"
+		print_result "capacity: high load remains advisory and preserves healthy floor" 1 "result=${result} floor_active=${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-unset}"
 	fi
 	return 0
 }
@@ -410,6 +405,22 @@ EOF
 		print_result "canary: at floor runs without CPU/load bypass marker" 0
 	else
 		print_result "canary: at floor runs without CPU/load bypass marker" 1 "log=$(cat "$worker_log" 2>/dev/null)"
+	fi
+	return 0
+}
+
+test_prebootstrap_ignores_deprecated_load_threshold() {
+	if (
+		_dlw_blocked_by_hard_stop() { return 1; }
+		_dlw_opencode_storage_preflight() { return 0; }
+		_dlw_hold_repeated_recovery_failures() { return 1; }
+		AIDEVOPS_DISPATCH_LOAD_PREFLIGHT=1
+		AIDEVOPS_DISPATCH_MAX_LOAD_PER_CPU=0
+		_dlw_prebootstrap_gates 104 "o/r" '{}' "$TEST_ROOT"
+	); then
+		print_result "prebootstrap: deprecated load threshold cannot block dispatch" 0
+	else
+		print_result "prebootstrap: deprecated load threshold cannot block dispatch" 1
 	fi
 	return 0
 }
@@ -815,7 +826,7 @@ EOF
 test_capacity_raises_soft_cap_to_floor
 test_capacity_reads_min_floor_from_config_default
 test_capacity_respects_existing_higher_cap
-test_capacity_caps_by_provider_accounts_and_high_load
+test_capacity_high_load_is_advisory_only
 test_capacity_uses_configured_provider_account_multiplier
 test_capacity_env_multiplier_overrides_config
 test_capacity_defaults_single_account_to_max_cap
@@ -825,6 +836,7 @@ test_capacity_clamps_provider_cap_below_active_to_zero_available
 test_throttle_does_not_force_serial_under_floor
 test_throttle_forces_serial_above_floor
 test_canary_preflight_marks_floor_without_cpu_bypass
+test_prebootstrap_ignores_deprecated_load_threshold
 test_apply_dispatch_refills_until_active_floor_after_partial_launch
 test_apply_dispatch_skips_refill_when_capacity_cap_disables_floor
 test_min_worker_floor_refill_uses_precomputed_counts

--- a/.agents/scripts/tests/test-pulse-dispatch-staggering.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-staggering.sh
@@ -55,27 +55,27 @@ delay_for_candidate() {
 	return 0
 }
 
-test_low_load_no_delay() {
+test_clean_cycle_no_delay() {
 	reset_stagger_env
 	local delay
 	delay=$(delay_for_candidate 100)
 	if [[ "$delay" == "0" ]]; then
-		print_result "staggering: low-load clean cycle has no delay" 0
+		print_result "staggering: clean cycle has no delay" 0
 	else
-		print_result "staggering: low-load clean cycle has no delay" 1 "delay=${delay}"
+		print_result "staggering: clean cycle has no delay" 1 "delay=${delay}"
 	fi
 	return 0
 }
 
-test_high_load_delay() {
+test_high_load_is_advisory_only() {
 	reset_stagger_env
 	export PULSE_DISPATCH_STAGGER_LOAD_PER_CPU=9.0
 	local delay
 	delay=$(delay_for_candidate 101)
-	if [[ "$delay" -gt 0 ]]; then
-		print_result "staggering: high load increases delay" 0
+	if [[ "$delay" == "0" ]]; then
+		print_result "staggering: high load alone adds no delay" 0
 	else
-		print_result "staggering: high load increases delay" 1 "delay=${delay}"
+		print_result "staggering: high load alone adds no delay" 1 "delay=${delay}"
 	fi
 	return 0
 }
@@ -121,7 +121,7 @@ test_graphql_low_budget_delay() {
 
 test_first_launch_never_delayed() {
 	reset_stagger_env
-	export PULSE_DISPATCH_STAGGER_LOAD_PER_CPU=99
+	export PULSE_DISPATCH_PROVIDER_BACKOFF_ACTIVE=1
 	local delay
 	delay=$(_dispatch_inter_launch_delay 0 1 '{"number":105}' 8)
 	if [[ "$delay" == "0" ]]; then
@@ -238,8 +238,8 @@ test_dispatch_ramp_handles_unset_logfile() {
 	return 0
 }
 
-test_low_load_no_delay
-test_high_load_delay
+test_clean_cycle_no_delay
+test_high_load_is_advisory_only
 test_provider_backoff_delay
 test_recent_failure_cluster_delay
 test_graphql_low_budget_delay


### PR DESCRIPTION
## Summary

Removed load average from candidate prebootstrap blocking, simultaneous worker-cap reduction, and adaptive launch pacing while retaining provider, failure, API-budget, storage, dependency, runtime, RAM, disk, stop-flag, and six-way ceremony safeguards.

## Files Changed

.agents/reference/worker-diagnostics.md, .agents/scripts/pulse-capacity.sh, .agents/scripts/pulse-dispatch-lib.sh, .agents/scripts/pulse-dispatch-worker-gates.sh, .agents/scripts/tests/test-dispatch-min-concurrency.sh, .agents/scripts/tests/test-pulse-dispatch-staggering.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused Pulse tests passed (24 minimum-concurrency, 13 staggering, 15 canary-classification, 18 worker-launch-lock, and 35 worker-count tests); ShellCheck and the changed-file local linter suite passed.

Resolves #29249


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 6h 16m and 4,493,064 tokens on this with the user in an interactive session.