### PR TITLE
GH#29248: Protect active Pulse runtime pin clears

### DIFF
--- a/.agents/reference/github-api-efficiency.md
+++ b/.agents/reference/github-api-efficiency.md
@@ -120,12 +120,19 @@ AIDEVOPS_PULSE_RUNTIME_PIN_REFRESH_SCHEDULERS=1 \
   ./setup.sh --stage pulse --non-interactive
 ```
 
-Clear the pin and reconcile Pulse after capture or failure:
+Stop the observation's collector and fuse jobs before deliberately clearing an
+active pin, then reconcile Pulse after capture or failure:
 
 ```bash
-~/.aidevops/agents/scripts/pulse-runtime-pin.sh clear
+~/.aidevops/agents/scripts/pulse-runtime-pin.sh status
+~/.aidevops/agents/scripts/pulse-runtime-pin.sh clear --force
 ./setup.sh --stage pulse --non-interactive
 ```
+
+Plain `clear` remains idempotent for missing or expired pins, but refuses to
+remove an active or invalid pin. The explicit override prevents an independent
+session from silently invalidating an owned controlled window. Pin mutations
+are serialized so expired-pin cleanup cannot race a new active pin into removal.
 
 Collectors must still bind reports to fixed activation/cutoff timestamps and
 fail closed on incomplete evidence. A Pulse pin does not authorize a release,

--- a/.agents/scripts/pulse-runtime-pin.sh
+++ b/.agents/scripts/pulse-runtime-pin.sh
@@ -16,10 +16,78 @@ _PULSE_RUNTIME_PIN_ROOT=""
 _PULSE_RUNTIME_PIN_CREATED=""
 _PULSE_RUNTIME_PIN_EXPIRES=""
 _PULSE_RUNTIME_PIN_MAX_SECONDS=172800
+_PULSE_RUNTIME_PIN_LOCK_HELD=""
 
 pulse_runtime_pin_config_path() {
 	printf '%s\n' "${AIDEVOPS_PULSE_RUNTIME_PIN_FILE:-${HOME:?HOME must be set}/.config/aidevops/pulse-runtime-pin.conf}"
 	return 0
+}
+
+# Serialize pin writers and clearers so an expired-pin cleanup cannot remove a
+# new active pin between validation and unlink. mkdir keeps the lock portable to
+# Bash 3.2 hosts; dead or incomplete owners are reclaimed with bounded waits.
+_pulse_runtime_pin_lock_acquire() {
+	local config_path="$1"
+	local lock_dir="${config_path}.lock.d"
+	local wait_seconds="${AIDEVOPS_PULSE_RUNTIME_PIN_LOCK_WAIT_SECONDS:-5}"
+	local waited=0
+	local owner_pid=""
+	local owner_missing_observations=0
+	case "$wait_seconds" in
+	'' | *[!0-9]*) wait_seconds=5 ;;
+	esac
+	mkdir -p "${config_path%/*}" || return 1
+	while ! mkdir "$lock_dir" 2>/dev/null; do
+		owner_pid=""
+		if [[ -r "$lock_dir/pid" ]]; then
+			IFS= read -r owner_pid <"$lock_dir/pid" || owner_pid=""
+		fi
+		if [[ "$owner_pid" =~ ^[0-9]+$ ]] && ! kill -0 "$owner_pid" 2>/dev/null; then
+			if rm -f "$lock_dir/pid" 2>/dev/null && rmdir "$lock_dir" 2>/dev/null; then
+				owner_missing_observations=0
+				continue
+			fi
+		fi
+		if [[ ! "$owner_pid" =~ ^[0-9]+$ ]]; then
+			owner_missing_observations=$((owner_missing_observations + 1))
+			if [[ "$owner_missing_observations" -ge 2 ]]; then
+				if rm -f "$lock_dir/pid" 2>/dev/null && rmdir "$lock_dir" 2>/dev/null; then
+					owner_missing_observations=0
+					continue
+				fi
+				owner_missing_observations=0
+			fi
+		else
+			owner_missing_observations=0
+		fi
+		[[ "$waited" -lt "$wait_seconds" ]] || return 1
+		sleep 1
+		waited=$((waited + 1))
+	done
+	printf '%s\n' "$$" >"$lock_dir/pid" || {
+		rmdir "$lock_dir" 2>/dev/null || true
+		return 1
+	}
+	_PULSE_RUNTIME_PIN_LOCK_HELD="$lock_dir"
+	return 0
+}
+
+_pulse_runtime_pin_lock_release() {
+	local lock_dir="${_PULSE_RUNTIME_PIN_LOCK_HELD:-}"
+	local owner_pid=""
+	local release_rc=0
+	[[ -n "$lock_dir" ]] || return 0
+	if [[ -r "$lock_dir/pid" ]]; then
+		IFS= read -r owner_pid <"$lock_dir/pid" || owner_pid=""
+	fi
+	if [[ "$owner_pid" != "$$" ]]; then
+		_PULSE_RUNTIME_PIN_LOCK_HELD=""
+		return 1
+	fi
+	rm -f "$lock_dir/pid" || release_rc=1
+	rmdir "$lock_dir" 2>/dev/null || release_rc=1
+	_PULSE_RUNTIME_PIN_LOCK_HELD=""
+	return "$release_rc"
 }
 
 _pulse_runtime_pin_stat_value() {
@@ -213,26 +281,39 @@ pulse_runtime_pin_set() {
 	esac
 	[[ "${#expires_epoch}" -le 12 ]] || return 2
 	expires_epoch=$((10#$expires_epoch))
-	now=$(date +%s) || return 1
-	[[ "$expires_epoch" -gt "$now" && $((expires_epoch - now)) -le "$_PULSE_RUNTIME_PIN_MAX_SECONDS" ]] || return 2
 	agents_root=$(_pulse_runtime_pin_validate_root "$requested_root") || return $?
 	config_path=$(pulse_runtime_pin_config_path) || return 1
 	config_dir="${config_path%/*}"
-	mkdir -p "$config_dir" || return 1
-	temporary=$(mktemp "$config_dir/.pulse-runtime-pin.XXXXXX") || return 1
+	_pulse_runtime_pin_lock_acquire "$config_path" || return 1
+	now=$(date +%s) || {
+		_pulse_runtime_pin_lock_release >/dev/null 2>&1 || true
+		return 1
+	}
+	if [[ "$expires_epoch" -le "$now" || $((expires_epoch - now)) -gt "$_PULSE_RUNTIME_PIN_MAX_SECONDS" ]]; then
+		_pulse_runtime_pin_lock_release >/dev/null 2>&1 || true
+		return 2
+	fi
+	temporary=$(mktemp "$config_dir/.pulse-runtime-pin.XXXXXX") || {
+		_pulse_runtime_pin_lock_release >/dev/null 2>&1 || true
+		return 1
+	}
 	chmod 600 "$temporary" || {
 		rm -f "$temporary"
+		_pulse_runtime_pin_lock_release >/dev/null 2>&1 || true
 		return 1
 	}
 	if ! printf 'schema=1\nagents_root=%s\ncreated_epoch=%s\nexpires_epoch=%s\n' \
 		"$agents_root" "$now" "$expires_epoch" >"$temporary"; then
 		rm -f "$temporary"
+		_pulse_runtime_pin_lock_release >/dev/null 2>&1 || true
 		return 1
 	fi
 	mv "$temporary" "$config_path" || {
 		rm -f "$temporary"
+		_pulse_runtime_pin_lock_release >/dev/null 2>&1 || true
 		return 1
 	}
+	_pulse_runtime_pin_lock_release || return 1
 	return 0
 }
 
@@ -254,10 +335,39 @@ pulse_runtime_pin_set_current() {
 }
 
 pulse_runtime_pin_clear() {
+	local force_flag="${1:-}"
 	local config_path=""
+	local read_rc=0
+	local clear_rc=0
+	case "$force_flag" in
+	'' | --force) ;;
+	*) return 2 ;;
+	esac
 	config_path=$(pulse_runtime_pin_config_path) || return 1
-	rm -f "$config_path" || return 1
-	return 0
+	[[ -e "$config_path" || -L "$config_path" ]] || return 0
+	if ! _pulse_runtime_pin_lock_acquire "$config_path"; then
+		printf 'Pulse runtime pin mutation is busy; refusing to clear it\n' >&2
+		return 1
+	fi
+	if [[ "$force_flag" == "--force" ]]; then
+		rm -f "$config_path" || clear_rc=1
+	else
+		_pulse_runtime_pin_read_config || read_rc=$?
+		case "$read_rc" in
+		0)
+			printf 'Pulse runtime pin is active until epoch %s; refusing to clear without --force\n' "$_PULSE_RUNTIME_PIN_EXPIRES" >&2
+			clear_rc=4
+			;;
+		1) clear_rc=0 ;;
+		3) rm -f "$config_path" || clear_rc=1 ;;
+		*)
+			printf 'Pulse runtime pin is invalid; refusing to clear without --force\n' >&2
+			clear_rc=2
+			;;
+		esac
+	fi
+	_pulse_runtime_pin_lock_release || return 1
+	return "$clear_rc"
 }
 
 pulse_runtime_pin_status() {
@@ -284,27 +394,34 @@ pulse_runtime_pin_status() {
 
 pulse_runtime_pin_main() {
 	local command_name="${1:-status}"
+	local first_arg="${2:-}"
+	local second_arg="${3:-}"
+	local arg_count="$#"
 	case "$command_name" in
 	resolve)
 		pulse_runtime_pin_resolve
 		return $?
 		;;
 	set-current)
-		[[ "$#" -eq 2 ]] || return 2
-		pulse_runtime_pin_set_current "$2" || return $?
+		[[ "$arg_count" -eq 2 ]] || return 2
+		pulse_runtime_pin_set_current "$first_arg" || return $?
 		pulse_runtime_pin_status
 		return $?
 		;;
 	set)
-		[[ "$#" -eq 3 ]] || return 2
-		pulse_runtime_pin_set "$2" "$3" || return $?
+		[[ "$arg_count" -eq 3 ]] || return 2
+		pulse_runtime_pin_set "$first_arg" "$second_arg" || return $?
 		pulse_runtime_pin_status
 		return $?
 		;;
 	clear)
-		[[ "$#" -eq 1 ]] || return 2
-		pulse_runtime_pin_clear || return $?
-		printf 'Pulse runtime pin: cleared\n'
+		[[ "$arg_count" -le 2 ]] || return 2
+		pulse_runtime_pin_clear "$first_arg" || return $?
+		if [[ "$first_arg" == "--force" ]]; then
+			printf 'Pulse runtime pin: cleared (forced)\n'
+		else
+			printf 'Pulse runtime pin: cleared\n'
+		fi
 		return 0
 		;;
 	status)
@@ -312,7 +429,7 @@ pulse_runtime_pin_main() {
 		return $?
 		;;
 	*)
-		printf 'Usage: pulse-runtime-pin.sh [status|resolve|set-current <ttl-seconds>|set <agents-root> <expires-epoch>|clear]\n' >&2
+		printf 'Usage: pulse-runtime-pin.sh [status|resolve|set-current <ttl-seconds>|set <agents-root> <expires-epoch>|clear [--force]]\n' >&2
 		return 2
 		;;
 	esac

--- a/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
+++ b/.agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh
@@ -376,7 +376,7 @@ test_count_and_byte_pressure_preserve_protected_bundles() {
 	[[ ! -d "$bundles_dir/pressure-bytes" ]] || fail "byte pressure did not prune the unprotected candidate"
 	after_checksum=$(cksum "$active_root/scripts/helper.sh" "$previous_root/scripts/helper.sh" "$live_bundle/agents/marker" "$pinned_bundle/agents/.bundle-manifest")
 	assert_eq "$before_checksum" "$after_checksum" "count and byte pressure preserve protected bundle byte identity"
-	pulse_runtime_pin_clear
+	pulse_runtime_pin_clear --force
 	return 0
 }
 
@@ -399,7 +399,7 @@ test_runtime_bundle_inventory_explains_protection() {
 	[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .reclaimable_bytes > 0')" == "true" ]] || fail "runtime inventory omitted unreferenced reclaimable bytes"
 	[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .unknown_bytes')" == "0" ]] || fail "runtime inventory left classified bundles unknown"
 	[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .protection_reasons[]' | grep -c 'active Pulse runtime pin')" -eq 1 ]] || fail "runtime inventory omitted the active Pulse pin reason"
-	pulse_runtime_pin_clear
+	pulse_runtime_pin_clear --force
 	pass "runtime inventory explains protected and reclaimable bundle bytes"
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-runtime-pin.sh
+++ b/.agents/scripts/tests/test-pulse-runtime-pin.sh
@@ -57,20 +57,73 @@ SH
 	return 0
 }
 
-test_set_resolve_and_clear() {
+test_set_resolve_and_guarded_clear() {
 	local agents_root="$1"
 	local now=""
 	local resolved=""
 	local config_path=""
+	local clear_output=""
+	local rc=0
 	now=$(date +%s)
 	pulse_runtime_pin_set "$agents_root" "$((now + 600))" || fail "valid runtime pin was rejected"
 	resolved=$(pulse_runtime_pin_resolve) || fail "valid runtime pin did not resolve"
 	[[ "$resolved" == "$agents_root" ]] || fail "runtime pin resolved the wrong bundle"
 	config_path=$(pulse_runtime_pin_config_path)
 	[[ "$(_pulse_runtime_pin_stat_value '%Lp' '%a' "$config_path")" == "600" ]] || fail "runtime pin is not mode 600"
-	pulse_runtime_pin_clear || fail "runtime pin could not be cleared"
-	[[ ! -e "$config_path" ]] || fail "runtime pin clear left its config behind"
-	pass "valid runtime pin resolves privately and clears cleanly"
+	clear_output=$(bash "$REPO_ROOT/.agents/scripts/pulse-runtime-pin.sh" clear 2>&1) || rc=$?
+	[[ "$rc" -eq 4 ]] || fail "ordinary clear did not reject an active runtime pin"
+	[[ -e "$config_path" ]] || fail "ordinary clear removed an active runtime pin"
+	[[ "$clear_output" == *"refusing to clear without --force"* ]] || fail "active-pin refusal omitted the explicit override guidance"
+	bash "$REPO_ROOT/.agents/scripts/pulse-runtime-pin.sh" clear --force >/dev/null || fail "forced runtime pin clear failed"
+	[[ ! -e "$config_path" ]] || fail "forced runtime pin clear left its config behind"
+	pulse_runtime_pin_clear || fail "missing runtime pin clear was not idempotent"
+	pass "valid runtime pin resolves privately and requires an explicit clear override"
+	return 0
+}
+
+test_expired_pin_clears_without_force() {
+	local agents_root="$1"
+	local config_path=""
+	local now=""
+	config_path=$(pulse_runtime_pin_config_path)
+	now=$(date +%s)
+	mkdir -p "${config_path%/*}"
+	printf 'schema=1\nagents_root=%s\ncreated_epoch=%s\nexpires_epoch=%s\n' \
+		"$agents_root" "$((now - 120))" "$((now - 60))" >"$config_path"
+	chmod 600 "$config_path"
+	bash "$REPO_ROOT/.agents/scripts/pulse-runtime-pin.sh" clear >/dev/null || fail "expired runtime pin did not clear without force"
+	[[ ! -e "$config_path" ]] || fail "expired runtime pin clear left its config behind"
+	pass "expired runtime pin cleanup remains idempotent without force"
+	return 0
+}
+
+test_pin_mutations_respect_live_lock() {
+	local agents_root="$1"
+	local config_path=""
+	local lock_dir=""
+	local now=""
+	local rc=0
+	now=$(date +%s)
+	pulse_runtime_pin_set "$agents_root" "$((now + 600))" || fail "lock fixture could not set a runtime pin"
+	config_path=$(pulse_runtime_pin_config_path)
+	lock_dir="${config_path}.lock.d"
+	mkdir "$lock_dir" || fail "could not create the live mutation lock fixture"
+	printf '%s\n' "$$" >"$lock_dir/pid"
+	(
+		AIDEVOPS_PULSE_RUNTIME_PIN_LOCK_WAIT_SECONDS=0
+		export AIDEVOPS_PULSE_RUNTIME_PIN_LOCK_WAIT_SECONDS
+		pulse_runtime_pin_clear --force
+	) >/dev/null 2>&1 || rc=$?
+	[[ "$rc" -eq 1 ]] || fail "forced clear bypassed a live runtime pin mutation lock"
+	[[ -e "$config_path" ]] || fail "lock contention removed the protected runtime pin"
+	rm -f "$lock_dir/pid"
+	rmdir "$lock_dir"
+	mkdir "$lock_dir" || fail "could not create the stale mutation lock fixture"
+	printf '%s\n' '99999999' >"$lock_dir/pid"
+	pulse_runtime_pin_clear --force || fail "runtime pin clear did not reclaim a stale mutation lock"
+	[[ ! -e "$config_path" ]] || fail "stale-lock recovery left the runtime pin behind"
+	[[ ! -d "$lock_dir" ]] || fail "stale-lock recovery left the mutation lock behind"
+	pass "runtime pin mutations serialize across live sessions and reclaim stale locks"
 	return 0
 }
 
@@ -111,7 +164,7 @@ test_rejects_unsafe_and_expired_configs() {
 	rc=0
 	pulse_runtime_pin_resolve >/dev/null 2>&1 || rc=$?
 	[[ "$rc" -eq 2 ]] || fail "symlinked pin config was accepted"
-	pulse_runtime_pin_clear
+	pulse_runtime_pin_clear --force
 	pass "unsafe and expired runtime pin configs fail closed"
 	return 0
 }
@@ -130,7 +183,7 @@ test_direct_entrypoints_reexec_pinned_bundle() {
 	grep -qF "$agents_root/scripts/pulse-lifecycle-helper.sh|status" "$exec_log" || fail "lifecycle helper did not re-enter the pinned bundle"
 	grep -qF "$agents_root/scripts/pulse-merge-routine.sh|--help" "$exec_log" || fail "standalone merge routine did not re-enter the pinned bundle"
 	grep -qF "$agents_root/scripts/pulse-merge-webhook-receiver.sh|--check" "$exec_log" || fail "webhook receiver did not re-enter the pinned bundle"
-	pulse_runtime_pin_clear
+	pulse_runtime_pin_clear --force
 	pass "all direct Pulse entrypoints re-enter an active pinned bundle"
 	return 0
 }
@@ -139,6 +192,7 @@ test_invalid_pin_blocks_direct_entrypoint() {
 	local agents_root="$1"
 	local now=""
 	local config_path=""
+	local clear_output=""
 	local rc=0
 	now=$(date +%s)
 	config_path=$(pulse_runtime_pin_config_path)
@@ -149,8 +203,13 @@ test_invalid_pin_blocks_direct_entrypoint() {
 	PULSE_PIN_EXEC_LOG="$TEST_ROOT/invalid-exec.log" bash "$REPO_ROOT/.agents/scripts/pulse-wrapper.sh" --self-check >/dev/null 2>&1 || rc=$?
 	[[ "$rc" -eq 2 ]] || fail "invalid pin did not block the stable Pulse entrypoint"
 	[[ ! -e "$TEST_ROOT/invalid-exec.log" ]] || fail "invalid pin executed a Pulse runtime"
-	pulse_runtime_pin_clear
-	pass "invalid runtime pin blocks direct Pulse entrypoints"
+	rc=0
+	clear_output=$(bash "$REPO_ROOT/.agents/scripts/pulse-runtime-pin.sh" clear 2>&1) || rc=$?
+	[[ "$rc" -eq 2 ]] || fail "ordinary clear did not reject an invalid runtime pin"
+	[[ -e "$config_path" ]] || fail "ordinary clear removed an invalid runtime pin"
+	[[ "$clear_output" == *"invalid; refusing to clear without --force"* ]] || fail "invalid-pin refusal omitted the explicit override guidance"
+	pulse_runtime_pin_clear --force
+	pass "invalid runtime pin blocks entrypoints and ordinary clear"
 	return 0
 }
 
@@ -231,7 +290,9 @@ main() {
 	export HOME
 	agents_root=$(write_bundle "bundle-pinned")
 	ln -s "$agents_root" "$HOME/.aidevops/agents"
-	test_set_resolve_and_clear "$agents_root"
+	test_set_resolve_and_guarded_clear "$agents_root"
+	test_expired_pin_clears_without_force "$agents_root"
+	test_pin_mutations_respect_live_lock "$agents_root"
 	test_rejects_unsafe_and_expired_configs "$agents_root"
 	test_direct_entrypoints_reexec_pinned_bundle "$agents_root"
 	test_invalid_pin_blocks_direct_entrypoint "$agents_root"


### PR DESCRIPTION
## Summary

Reject plain clear for active or invalid Pulse pins, serialize pin writes and clears, and document explicit forced cleanup.

## Files Changed

.agents/reference/github-api-efficiency.md, .agents/scripts/pulse-runtime-pin.sh, .agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh, .agents/scripts/tests/test-pulse-runtime-pin.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified: bash .agents/scripts/tests/test-pulse-runtime-pin.sh passed 9 checks with actual CLI subprocesses and filesystem lock behavior; bash .agents/scripts/tests/test-atomic-runtime-bundle-deploy.sh passed 41 checks; ShellCheck, Bash syntax, and linters-local.sh --full passed.

Resolves #29248


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.5 spent 16d 1h and 55,411,530 tokens on this with the user in an interactive session.