### PR TITLE
GH#29223: Add bounded Stack Exchange social collector

### DIFF
--- a/.agents/aidevops/knowledge-plane/05-social-operations.md
+++ b/.agents/aidevops/knowledge-plane/05-social-operations.md
@@ -39,8 +39,8 @@ transaction without rewriting raw gzip artifacts, cursors, coverage, or provider
 rows. Replay preserves both evidence and projection IDs.
 
 Candidate implementation is provider-specific, not one generic social adapter.
-Mastodon #29221 and GitHub #29222 are now live. The remaining ranked children
-are Stack Exchange #29223, Miniflux #29224, Readwise Reader #29225, FreshRSS
+Mastodon #29221, GitHub #29222, and Stack Exchange #29223 are now live. The
+remaining ranked children are Miniflux #29224, Readwise Reader #29225, FreshRSS
 issue #29226, Lemmy issue #29227, then public-only Hacker News #29228. Each
 route owns its identity
 contract, stream allowlist, checkpoint semantics, and negative write-reachability
@@ -79,6 +79,14 @@ Projects v2 have independent snapshot checkpoints. Exact REST `Link` targets
 and GraphQL `pageInfo` cursors remain opaque. Token-family capability limits,
 reactions, migration expiry, deletion, private visibility, and organization
 audit authority remain explicit gaps. Details: `.agents/content/social-github.md`.
+
+Stack Exchange collection binds OAuth `/me` network `account_id`, selected
+`api_site_parameter`, and site `user_id` before every page. Authored posts,
+questions, answers, comments, favourites, inbox, notifications, and associated
+accounts have independent per-site checkpoints. Pages stop before persistence on
+`backoff` or quota exhaustion and continue only while `has_more`. Votes, follows,
+subscriptions, lists, projects, complete archives, and inaccessible site history
+remain explicit gaps. Details: `.agents/content/social-stack-exchange.md`.
 
 X collection uses the guarded official `xurl` helper. Reddit collection uses an
 optional PRAW 8 child. YouTube collection uses a standard-library HTTP child and

--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -44,6 +44,7 @@ a claim that the route is enabled.
 | NodeBB | **Live** topics and posts | **Live/Partial** votes, bookmarks, watched topics, and category state | **Live/Partial** notifications and chat-room metadata; **No** message bodies | **Live/Partial** follows and groups | **No** plugin-provided lists | Thirteen independently checkpointed core GET streams with per-installation identity, bounded pagination, and explicit admin/plugin/export/history gaps. |
 | Mastodon | **Live/Partial** authored statuses | **Live/Partial** favourites and bookmarks | **Live/Gate/Partial** notifications; **No/Gate** conversations | **Live/Partial** followers, following, and followed tags | **Live/Partial** lists; **No** nested membership | Eight exact-origin GET-only streams preserve opaque `Link` cursors and expose federation, moderation, deletion, export, and operator-retention gaps. |
 | GitHub | **Live/Partial** contribution calendar and repositories | **Live/Partial** stars and subscriptions; **No** complete reactions | **Live/Gate/Partial** notifications | **Live/Gate/Partial** followers, following, and organizations | **Live/Gate/Partial** user lists and visible Projects v2 | Ten numeric/node-identity-bound streams preserve REST `Link` and GraphQL `pageInfo` cursors; token family, visibility, migration expiry, deletion, and audit authority remain explicit. |
+| Stack Exchange | **Live/Partial** posts, questions, answers, and comments | **Live/Partial** favourites; **No** complete votes | **Live/Gate/Partial** inbox and notifications | **Live/Partial** associated site accounts; **No** follows | **No** | Eight network-plus-site-identity-bound GET streams obey `has_more`, `backoff`, quota, and 100-item page limits while preserving archive and inaccessible-history gaps. |
 
 ## Integrated provider families
 
@@ -75,7 +76,7 @@ separate provider family.
 | Mastodon | **Live/Partial** | **Live/Partial** favourites and bookmarks | **Live/Gate/Partial** notifications; **No/Gate** conversations | **Live/Partial** follows and followed tags | **Live/Partial** lists; **No** nested membership | #29221 implements exact-origin identity-bound reads with opaque `Link` cursors and explicit federation/operator-retention gaps. |
 | Bluesky / AT Protocol | **Live** records | **Live** likes and reposts | **Live/Gate** notifications; **No/Gate** chat | **Live** follows | **Live** lists and feeds | DID-bound repository/AppView reads with separate chat authorization. |
 | Lemmy | **API/Gate** versioned authored content | **API/Gate** saved and liked state | **API/Gate** unified v4 or split v3 inbox | **API/Gate** communities; **No** person follows | **API/Gate** v4 multicommunities | Rank 7, #29227. Implement only behind exact v4/v3 discovery; namespace local IDs and preserve opaque version-sensitive cursors. |
-| Stack Exchange | **API** authored content | **API** favourites; **No** complete vote history | **API/Gate** inbox and notifications | **API** associated site accounts; **No** follows | **No** | Rank 3, #29223. Bind network plus per-site identity, obey `backoff`, and keep archive/completeness gaps explicit. |
+| Stack Exchange | **Live/Partial** authored content | **Live/Partial** favourites; **No** complete vote history | **Live/Gate/Partial** inbox and notifications | **Live/Partial** associated site accounts; **No** follows | **No** | #29223 implements network plus per-site identity, mandatory `backoff` and quota stops, bounded paging, and explicit archive/completeness gaps. |
 | GitHub | **Live/Partial** contributions | **Live/Partial** stars and subscriptions; **No** complete reactions | **Live/Gate/Partial** notifications; **No** discussions | **Live/Gate/Partial** follows, organizations, and repositories | **Live/Gate/Partial** user lists and Projects v2 | #29222 implements numeric/node identity, token-family gates, opaque mixed-API cursors, and no complete reaction or social export claim. |
 | Hacker News | **API/Partial** public submissions and comments | **No** private votes or saved items | **No** | **No** | **No** | Rank 8, #29228. Bounded public history only, keyed by case-sensitive username and item ID; never infer private state. |
 | Miniflux | **API/Export** feed items | **API** read, removed, starred, and tagged state | **No** | **API/Export** subscriptions | **API/Export** categories/tags | Rank 4, #29224. Strong self-hosted identity and replay; locally enforce GET-only use of mutation-capable API keys. |
@@ -173,6 +174,14 @@ separate provider family.
   persistence. `.agents/content/social-github.md` records official identity,
   stream, pagination, rate-limit, migration, and completeness evidence checked on
   2026-08-02.
+- **Live Stack Exchange:** `.agents/scripts/knowledge_social_stack_exchange.py`,
+  `.agents/scripts/_knowledge_social_stack_exchange*.py`, and
+  `.agents/tests/test-knowledge-social-stack-exchange.sh` prove network-plus-site
+  identity, eight independent streams, bounded page resume, mandatory `backoff`
+  and quota stops, read-scope and GET-only enforcement, credential rejection,
+  terminal coverage, and atomic persistence. `.agents/content/social-stack-exchange.md`
+  records official v2.3 identity, route, OAuth, paging, filter, quota, throttle,
+  duplicate-request, and completeness evidence checked on 2026-08-02.
 - **Integrated provider registry:** `.agents/scripts/knowledge_social_registry.py`
   and `.agents/tests/test-knowledge-social-registry.sh` prove order-independent
   registration, collision rejection, exact aliases and modes, no-route failure,

--- a/.agents/content/social-stack-exchange.md
+++ b/.agents/content/social-stack-exchange.md
@@ -1,0 +1,82 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Stack Exchange Account Knowledge Collection
+
+`knowledge_social_stack_exchange.py` collects bounded, read-only API v2.3
+evidence for one selected Stack Exchange site account. Durable identity combines
+the network `account_id`, configured `api_site_parameter`, and per-site `user_id`.
+Equal local user or content IDs on different sites never collide.
+
+## Profile and authority contract
+
+Configure credentials through secure environment injection:
+
+```text
+STACK_EXCHANGE_<PROFILE>_ACCESS_TOKEN
+STACK_EXCHANGE_<PROFILE>_SITE=stackoverflow
+STACK_EXCHANGE_<PROFILE>_SCOPES="read_inbox private_info"
+```
+
+Scopes are optional unless the selected stream requires one. `inbox` requires
+`read_inbox`. `write_access` and unknown scopes are rejected, and the child has
+no write routes. Access tokens are sent only through the authorization header;
+tokens, response credentials, and arbitrary private fields never persist.
+
+Use `--account-id account_<NETWORK_ACCOUNT_ID>`. Before collection and every
+page, the child calls `GET /2.3/me` for the configured site and verifies the
+network and site user IDs. No evidence is committed until rebinding succeeds.
+
+## Implemented streams
+
+| Stream | Official GET route | Scope |
+|---|---|---|
+| `posts` | `/me/posts` | identify |
+| `questions` | `/me/questions` | identify |
+| `answers` | `/me/answers` | identify |
+| `comments` | `/me/comments` | identify |
+| `favorites` | `/me/favorites` | identify |
+| `inbox` | `/me/inbox` | `read_inbox` |
+| `notifications` | `/me/notifications` | authenticated account |
+| `associated_accounts` | `/me/associated` | identify |
+
+The initial identity request costs one unit and every page reserves two more for
+identity rebinding and one stream read. `--budget` is 3-1000 and `--page-size` is
+1-100.
+
+Each stream has an independent versioned page cursor containing the configured
+site. Collection advances only while the response wrapper says `has_more`.
+Malformed wrappers, `backoff`, zero quota, credential-shaped fields, terminal
+responses, and lease loss preserve the previous checkpoint. `backoff` seconds
+become an explicit retry epoch; the local request, item, response-byte, and page
+limits remain stricter independent fuses.
+
+All transport requests target exact allowlisted paths under
+`https://api.stackexchange.com/2.3`, use `GET`, reject redirects, and accept only
+allowlisted paging, site, and filter parameters. The built-in `withbody` filter
+retains authored text while normalization discards unselected fields.
+
+## Boundaries
+
+Successful pages record unavailable coverage for complete votes, follows,
+subscriptions, lists, projects, a verified complete account archive, and site
+history outside current API visibility. Associated-account responses expose site
+URLs but not a complete cross-network archive. Snapshot completion never infers
+deletion.
+
+The API documents a default 10,000-request user/application daily quota, a
+30-request/second/IP ceiling, method-specific `backoff`, and heavy caching.
+Collectors avoid speculative pages and stop on every returned `backoff` or quota
+exhaustion. Mandatory account rebinding is the only intentionally repeated
+identity request; stream page requests advance monotonically.
+
+## Official evidence checked 2026-08-02
+
+- <https://api.stackexchange.com/docs>
+- <https://api.stackexchange.com/docs/authentication>
+- <https://api.stackexchange.com/docs/me-associated-users>
+- <https://api.stackexchange.com/docs/me-posts>
+- <https://api.stackexchange.com/docs/me-favorites>
+- <https://api.stackexchange.com/docs/me-inbox>
+- <https://api.stackexchange.com/docs/paging>
+- <https://api.stackexchange.com/docs/throttle>

--- a/.agents/scripts/_knowledge_social_stack_exchange.py
+++ b/.agents/scripts/_knowledge_social_stack_exchange.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Stack Exchange stream policy and independent per-site page checkpoints."""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from _knowledge_social_stack_exchange_identity import (
+    StackExchangeAdapterError,
+    StackExchangeProviderUnavailableError,
+    api_site_parameter,
+    network_account_id,
+    site_user_id,
+)
+from knowledge_social_import import canonical_json, reject_credentials
+
+PROVIDER = "stack-exchange"
+CURSOR_PREFIX = "stack-exchange-page-v1:"
+RETENTION_LIMIT = "site_visibility_token_scope_and_api_history_bound"
+MAX_PAGE_ITEMS = 100
+
+ADAPTER_ERROR = StackExchangeAdapterError
+PROVIDER_UNAVAILABLE_ERROR = StackExchangeProviderUnavailableError
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    resource_kind: str
+    activity_mode: str
+    pagination: str = "snapshot"
+    incremental: bool = False
+    retention_limit: str | None = RETENTION_LIMIT
+    coverage_status: str | None = "partial"
+    unavailable_reason: str | None = "site_visibility_and_api_history_bound"
+    cost_units: int = 2
+
+
+STREAMS = {
+    "posts": StreamSpec("post", "content_author"),
+    "questions": StreamSpec("question", "content_author"),
+    "answers": StreamSpec("answer", "content_author"),
+    "comments": StreamSpec("comment", "content_author"),
+    "favorites": StreamSpec("question", "selected_account"),
+    "inbox": StreamSpec("inbox_item", "selected_account"),
+    "notifications": StreamSpec("notification", "selected_account"),
+    "associated_accounts": StreamSpec("account", "network_membership"),
+}
+
+
+@dataclass(frozen=True)
+class PageRequest:
+    stream: str
+    account_id: str
+    network_account_id: str
+    site_user_id: str
+    api_site_parameter: str
+    page: int
+    limit: int
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "page",
+            "stream": self.stream,
+            "account_id": self.account_id,
+            "network_account_id": self.network_account_id,
+            "site_user_id": self.site_user_id,
+            "api_site_parameter": self.api_site_parameter,
+            "page": self.page,
+            "limit": self.limit,
+        }
+
+    def evidence_key(self) -> str:
+        return canonical_json(self.payload())
+
+
+PAGE_REQUEST_KEYS = {
+    "action", "stream", "account_id", "network_account_id", "site_user_id",
+    "api_site_parameter", "page", "limit",
+}
+
+
+def _text(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value or len(value.encode()) > 4096:
+        raise StackExchangeAdapterError(f"Stack Exchange {field} is invalid")
+    return value
+
+
+def _page(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or not 1 <= value <= 100000:
+        raise StackExchangeAdapterError("Stack Exchange page is invalid")
+    return value
+
+
+def _encode_cursor(page: int, site: str) -> str:
+    payload = canonical_json({"page": page, "site": site}).encode()
+    encoded = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+    return f"{CURSOR_PREFIX}{encoded}"
+
+
+def _decode_cursor(cursor: str, site: str) -> int:
+    if not cursor.startswith(CURSOR_PREFIX):
+        raise StackExchangeAdapterError(
+            "stored Stack Exchange cursor has an unsupported version"
+        )
+    try:
+        raw = cursor.removeprefix(CURSOR_PREFIX)
+        parsed = json.loads(base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4)))
+    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+        raise StackExchangeAdapterError("stored Stack Exchange cursor is invalid") from error
+    if not isinstance(parsed, dict) or set(parsed) != {"page", "site"}:
+        raise StackExchangeAdapterError("stored Stack Exchange cursor has an invalid shape")
+    reject_credentials(parsed)
+    if api_site_parameter(parsed.get("site")) != site:
+        raise StackExchangeAdapterError("stored Stack Exchange cursor belongs to another site")
+    return _page(parsed.get("page"))
+
+
+def page_request(stream: str, account: dict[str, Any], state: CursorState, limit: int) -> PageRequest:
+    if stream not in STREAMS:
+        raise StackExchangeAdapterError("Stack Exchange stream is unsupported")
+    site = api_site_parameter(account.get("api_site_parameter"))
+    page = _decode_cursor(state.cursor, site) if state.cursor else 1
+    return PageRequest(
+        stream,
+        _text(account.get("id"), "selected account ID"),
+        network_account_id(account.get("network_account_id")),
+        site_user_id(account.get("site_user_id")),
+        site,
+        page,
+        limit,
+    )
+
+
+def parse_page_request(payload: dict[str, Any]) -> PageRequest:
+    if set(payload) != PAGE_REQUEST_KEYS or payload.get("action") != "page":
+        raise StackExchangeAdapterError("Stack Exchange read request has an invalid action shape")
+    stream = payload.get("stream")
+    if not isinstance(stream, str) or stream not in STREAMS:
+        raise StackExchangeAdapterError("Stack Exchange stream is unsupported")
+    limit = payload.get("limit")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 100:
+        raise StackExchangeAdapterError("Stack Exchange page size is invalid")
+    return PageRequest(
+        stream,
+        _text(payload.get("account_id"), "selected account ID"),
+        network_account_id(payload.get("network_account_id")),
+        site_user_id(payload.get("site_user_id")),
+        api_site_parameter(payload.get("api_site_parameter")),
+        _page(payload.get("page")),
+        limit,
+    )
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise StackExchangeAdapterError("Stack Exchange response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise StackExchangeAdapterError("Stack Exchange page data must be an array")
+    return data
+
+
+def page_checkpoint(
+    payload: dict[str, Any], state: CursorState, request: PageRequest
+) -> tuple[PageCheckpoint, bool]:
+    meta = payload.get("meta")
+    if not isinstance(meta, dict):
+        raise StackExchangeAdapterError("Stack Exchange page metadata must be an object")
+    reject_credentials(meta)
+    if (
+        meta.get("stream") != request.stream
+        or api_site_parameter(meta.get("api_site_parameter")) != request.api_site_parameter
+    ):
+        raise StackExchangeAdapterError("Stack Exchange page provenance is invalid")
+    if meta.get("snapshot") is not True or len(page_data(payload)) > MAX_PAGE_ITEMS:
+        raise StackExchangeAdapterError("Stack Exchange page metadata is invalid")
+    has_more = meta.get("has_more")
+    if not isinstance(has_more, bool):
+        raise StackExchangeAdapterError("Stack Exchange has_more must be boolean")
+    cursor = _encode_cursor(request.page + 1, request.api_site_parameter) if has_more else None
+    return PageCheckpoint(cursor, state.watermark), not has_more

--- a/.agents/scripts/_knowledge_social_stack_exchange_contract.py
+++ b/.agents/scripts/_knowledge_social_stack_exchange_contract.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validation primitives for bounded Stack Exchange API wrappers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_stack_exchange_identity import (
+    account_id,
+    api_site_parameter,
+    network_account_id,
+    site_user_id,
+)
+
+MAX_TEXT_BYTES = 256 * 1024
+
+
+class StackExchangeReadProviderError(RuntimeError):
+    """Raised for a privacy-safe local Stack Exchange provider failure."""
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    status: int
+    payload: Any
+    retry_after: int | None = None
+
+
+def observed_at() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def decode_json(payload: bytes, limit: int) -> Any:
+    if len(payload) > limit:
+        raise StackExchangeReadProviderError(
+            "Stack Exchange JSON payload exceeds the safety limit"
+        )
+    try:
+        return json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise StackExchangeReadProviderError("Stack Exchange JSON payload is invalid") from error
+
+
+def request_object(payload: bytes, limit: int) -> dict[str, Any]:
+    request = decode_json(payload, limit)
+    if not isinstance(request, dict):
+        raise StackExchangeReadProviderError(
+            "Stack Exchange read request root must be an object"
+        )
+    return request
+
+
+def object_value(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise StackExchangeReadProviderError(f"Stack Exchange {field} must be an object")
+    return value
+
+
+def object_list(value: Any, field: str, *, limit: int) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise StackExchangeReadProviderError(
+            f"Stack Exchange {field} must be an array of objects"
+        )
+    if len(value) > limit:
+        raise StackExchangeReadProviderError(
+            f"Stack Exchange {field} exceeds the item safety limit"
+        )
+    return value
+
+
+def optional_text(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value or len(value.encode()) > MAX_TEXT_BYTES:
+        raise StackExchangeReadProviderError(f"Stack Exchange {field} must be text")
+    return value
+
+
+def required_text(value: Any, field: str) -> str:
+    text = optional_text(value, field)
+    if not text:
+        raise StackExchangeReadProviderError(f"Stack Exchange {field} is required")
+    return text
+
+
+def wrapper(payload: Any, *, limit: int) -> tuple[list[dict[str, Any]], bool, int | None, int]:
+    root = object_value(payload, "response")
+    if root.get("error_id") is not None:
+        raise StackExchangeReadProviderError("Stack Exchange API returned an error")
+    items = object_list(root.get("items"), "response items", limit=limit)
+    has_more = root.get("has_more", False)
+    if not isinstance(has_more, bool):
+        raise StackExchangeReadProviderError("Stack Exchange has_more must be boolean")
+    backoff = root.get("backoff")
+    if backoff is not None and (
+        isinstance(backoff, bool) or not isinstance(backoff, int) or not 1 <= backoff <= 86400
+    ):
+        raise StackExchangeReadProviderError("Stack Exchange backoff is invalid")
+    quota = root.get("quota_remaining")
+    if isinstance(quota, bool) or not isinstance(quota, int) or quota < 0:
+        raise StackExchangeReadProviderError("Stack Exchange quota_remaining is invalid")
+    return items, has_more, backoff, quota
+
+
+def identity_value(payload: Any, expected_network_id: str, site: str) -> dict[str, Any]:
+    items, _has_more, backoff, quota = wrapper(payload, limit=1)
+    if backoff is not None or quota == 0:
+        raise StackExchangeReadProviderError("Stack Exchange identity is rate limited")
+    if len(items) != 1:
+        raise StackExchangeReadProviderError("Stack Exchange account verification returned no account")
+    user = items[0]
+    network = network_account_id(user.get("account_id"))
+    local = site_user_id(user.get("user_id"))
+    selected_site = api_site_parameter(site)
+    if network != network_account_id(expected_network_id):
+        raise StackExchangeReadProviderError(
+            "selected Stack Exchange account does not match the configured connection"
+        )
+    return {
+        "id": account_id(network, selected_site, local),
+        "network_account_id": network,
+        "site_user_id": local,
+        "api_site_parameter": selected_site,
+        "display_name": optional_text(user.get("display_name"), "account display name"),
+        "link": optional_text(user.get("link"), "account link"),
+    }
+
+
+def terminal_payload(result: ApiResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": result.status, "observed_at": observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload

--- a/.agents/scripts/_knowledge_social_stack_exchange_http.py
+++ b/.agents/scripts/_knowledge_social_stack_exchange_http.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Redirect-free, bounded GET transport for Stack Exchange API v2.3."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from _knowledge_social_stack_exchange_contract import (
+    ApiResult,
+    StackExchangeReadProviderError,
+    decode_json,
+)
+from _knowledge_social_stack_exchange_routes import allowlisted_path, query_keys_for_path
+
+API_ORIGIN = "https://api.stackexchange.com"
+API_PREFIX = "/2.3"
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+HTTP_TIMEOUT_SECONDS = 60
+
+
+class Headers(Protocol):
+    def get(self, key: str, default: str | None = None) -> str | None: ...
+
+
+class Response(Protocol):
+    status: int
+    headers: Headers
+
+    def __enter__(self) -> Response: ...
+    def __exit__(self, *args: Any) -> None: ...
+    def read(self, size: int = -1) -> bytes: ...
+
+
+class Opener(Protocol):
+    def open(self, request: Request, timeout: int) -> Response: ...
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    access_token: str
+    api_site_parameter: str
+    scopes: frozenset[str]
+
+
+class _RejectRedirect(HTTPRedirectHandler):
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def _http_exports() -> Opener:
+    exports = (Request, build_opener, urlencode, HTTPRedirectHandler)
+    if not all(callable(item) for item in exports):
+        raise StackExchangeReadProviderError("Python urllib HTTP exports are unavailable")
+    return build_opener(_RejectRedirect())
+
+
+def _target_url(path: str, params: dict[str, str]) -> str:
+    if not allowlisted_path(path) or set(params) - query_keys_for_path(path):
+        raise StackExchangeReadProviderError("Stack Exchange API route is not allowlisted")
+    if any(not isinstance(value, str) or not value or "\x00" in value for value in params.values()):
+        raise StackExchangeReadProviderError("Stack Exchange API query is invalid")
+    for key in ("page", "pagesize"):
+        value = params.get(key)
+        if value is not None and not value.isdigit():
+            raise StackExchangeReadProviderError("Stack Exchange paging query is invalid")
+    if "page" in params and not 1 <= int(params["page"]) <= 100000:
+        raise StackExchangeReadProviderError("Stack Exchange page is invalid")
+    if "pagesize" in params and not 1 <= int(params["pagesize"]) <= 100:
+        raise StackExchangeReadProviderError("Stack Exchange page size is invalid")
+    query = urlencode(params)
+    return f"{API_ORIGIN}{API_PREFIX}{path}" + (f"?{query}" if query else "")
+
+
+def _decode_response(payload: bytes) -> dict[str, Any]:
+    decoded = decode_json(payload, MAX_RESPONSE_BYTES)
+    if not isinstance(decoded, dict):
+        raise StackExchangeReadProviderError(
+            "Stack Exchange API response root must be an object"
+        )
+    return decoded
+
+
+def api(
+    config: ProfileConfig,
+    opener: Opener,
+    path: str,
+    params: dict[str, str],
+) -> ApiResult:
+    """Execute one exact-origin, redirect-free, GET-only API request."""
+    request = Request(
+        _target_url(path, params),
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {config.access_token}",
+            "User-Agent": "aidevops-stack-exchange-knowledge/1",
+        },
+        method="GET",
+    )
+    try:
+        with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", 200)
+            if isinstance(status, bool) or not isinstance(status, int):
+                raise StackExchangeReadProviderError("Stack Exchange HTTP status is invalid")
+            payload = response.read(MAX_RESPONSE_BYTES + 1)
+            if not isinstance(payload, bytes):
+                raise StackExchangeReadProviderError("Stack Exchange HTTP response is invalid")
+            return ApiResult(status, _decode_response(payload))
+    except HTTPError as error:
+        return ApiResult(error.code, {})
+    except (TimeoutError, URLError, OSError) as error:
+        raise StackExchangeReadProviderError(
+            "Stack Exchange read provider request failed"
+        ) from error

--- a/.agents/scripts/_knowledge_social_stack_exchange_identity.py
+++ b/.agents/scripts/_knowledge_social_stack_exchange_identity.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Durable Stack Exchange network and per-site identity validation."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any
+
+from knowledge_social_store import SocialStoreError
+
+SITE_PARAMETER = re.compile(r"^[a-z0-9](?:[a-z0-9.-]{0,98}[a-z0-9])?$")
+RESOURCE_KIND = re.compile(r"^[a-z][a-z_]{0,31}$")
+
+
+class StackExchangeAdapterError(SocialStoreError):
+    """Raised when guarded Stack Exchange collection cannot continue safely."""
+
+
+class StackExchangeProviderUnavailableError(StackExchangeAdapterError):
+    """Raised when the bounded Stack Exchange HTTP child cannot complete a read."""
+
+
+def numeric_id(value: Any, field: str) -> str:
+    if isinstance(value, str) and value.startswith("account_"):
+        value = value.removeprefix("account_")
+    if isinstance(value, bool):
+        raise StackExchangeAdapterError(f"Stack Exchange {field} is invalid")
+    try:
+        numeric = int(value)
+    except (TypeError, ValueError) as error:
+        raise StackExchangeAdapterError(f"Stack Exchange {field} is invalid") from error
+    if numeric < 1 or str(numeric) != str(value):
+        raise StackExchangeAdapterError(f"Stack Exchange {field} is invalid")
+    return str(numeric)
+
+
+def network_account_id(value: Any) -> str:
+    return numeric_id(value, "network account ID")
+
+
+def site_user_id(value: Any) -> str:
+    return numeric_id(value, "site user ID")
+
+
+def api_site_parameter(value: Any) -> str:
+    if not isinstance(value, str) or SITE_PARAMETER.fullmatch(value) is None:
+        raise StackExchangeAdapterError("Stack Exchange API site parameter is invalid")
+    return value
+
+
+def namespaced_id(site: Any, kind: str, value: Any) -> str:
+    selected_site = api_site_parameter(site)
+    if RESOURCE_KIND.fullmatch(kind) is None:
+        raise StackExchangeAdapterError("Stack Exchange resource kind is invalid")
+    if isinstance(value, bool) or not isinstance(value, (str, int)):
+        raise StackExchangeAdapterError("Stack Exchange resource identity is invalid")
+    opaque = str(value)
+    if not opaque or "\x00" in opaque or len(opaque.encode()) > 512:
+        raise StackExchangeAdapterError("Stack Exchange resource identity is invalid")
+    digest = hashlib.sha256(f"{selected_site}\0{opaque}".encode()).hexdigest()[:32]
+    return f"se_{kind}_{digest}"
+
+
+def account_id(network_id: Any, site: Any, user_id: Any) -> str:
+    network = network_account_id(network_id)
+    selected_site = api_site_parameter(site)
+    user = site_user_id(user_id)
+    digest = hashlib.sha256(f"{selected_site}\0{user}".encode()).hexdigest()[:24]
+    return f"seu_{network}_{digest}"
+
+
+def associated_account_id(network_id: Any, site_url: Any, user_id: Any) -> str:
+    network = network_account_id(network_id)
+    user = site_user_id(user_id)
+    if not isinstance(site_url, str) or not site_url.startswith("https://"):
+        raise StackExchangeAdapterError("Stack Exchange associated site URL is invalid")
+    if "\x00" in site_url or len(site_url.encode()) > 4096:
+        raise StackExchangeAdapterError("Stack Exchange associated site URL is invalid")
+    digest = hashlib.sha256(f"{site_url.casefold()}\0{user}".encode()).hexdigest()[:24]
+    return f"sea_{network}_{digest}"

--- a/.agents/scripts/_knowledge_social_stack_exchange_normalize.py
+++ b/.agents/scripts/_knowledge_social_stack_exchange_normalize.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize allowlisted Stack Exchange records into neutral evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_stack_exchange import (
+    PROVIDER,
+    RETENTION_LIMIT,
+    StackExchangeAdapterError,
+    page_data,
+)
+from _knowledge_social_stack_exchange_identity import api_site_parameter
+from knowledge_social_import import reject_credentials
+
+PROVENANCE = "stack_exchange_api_v2_3"
+GAPS = (
+    ("votes", "complete_vote_history_not_available"),
+    ("follows", "not_available_through_verified_account_reads"),
+    ("subscriptions", "not_available_through_verified_account_reads"),
+    ("lists", "not_available_through_verified_account_reads"),
+    ("projects", "not_available_through_verified_account_reads"),
+    ("account_archive", "no_verified_complete_account_archive"),
+    ("inaccessible_site_history", "site_visibility_and_retention_bound"),
+)
+OBJECT_TYPES = frozenset(
+    {"post", "question", "answer", "comment", "inbox_item", "notification", "account"}
+)
+
+
+@dataclass(frozen=True)
+class PageContext:
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def _required_text(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise StackExchangeAdapterError(f"Stack Exchange record requires {key}")
+    return value
+
+
+def _optional_text(record: dict[str, Any], key: str) -> str | None:
+    value = record.get(key)
+    if value is not None and (not isinstance(value, str) or "\x00" in value):
+        raise StackExchangeAdapterError(f"Stack Exchange record {key} must be text")
+    return value
+
+
+def _timestamp(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise StackExchangeAdapterError(f"Stack Exchange {field} is invalid")
+    return datetime.fromtimestamp(value, UTC).isoformat().replace("+00:00", "Z")
+
+
+def _observed_at(payload: dict[str, Any]) -> str:
+    value = payload.get("observed_at")
+    if not isinstance(value, str) or not value:
+        raise StackExchangeAdapterError("Stack Exchange page observed_at must be text")
+    return value
+
+
+def _coverage(observed_at: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "stream": stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": RETENTION_LIMIT,
+            "unavailable_reason": reason,
+            "status": "unavailable",
+            "observed_at": observed_at,
+        }
+        for stream, reason in GAPS
+    ]
+
+
+def _object_row(item: dict[str, Any], context: PageContext, observed_at: str) -> dict[str, Any]:
+    kind = item.get("kind")
+    if not isinstance(kind, str) or kind not in OBJECT_TYPES:
+        raise StackExchangeAdapterError(
+            "Stack Exchange page contains an unsupported item kind"
+        )
+    remote_id = _required_text(item, "remote_id")
+    text = "\n\n".join(
+        value
+        for key in ("title", "body", "site_name")
+        if (value := _optional_text(item, key))
+    ) or None
+    authored = context.stream in {"posts", "questions", "answers", "comments"}
+    provider_json = {"source": PROVENANCE, "stream": context.stream, "record": item}
+    reject_credentials(provider_json)
+    return {
+        "object_type": kind,
+        "remote_id": remote_id,
+        "account_remote_id": context.account.get("id") if authored else None,
+        "text": text,
+        "created_at": _timestamp(item.get("created_at"), "creation timestamp"),
+        "observed_at": observed_at,
+        "evidence_class": "authored" if authored else "observed",
+        "provider_json": provider_json,
+    }
+
+
+def _activity_row(item: dict[str, Any], context: PageContext, observed_at: str) -> dict[str, Any]:
+    selected = _required_text(context.account, "id")
+    remote_id = _required_text(item, "remote_id")
+    activity_type = context.stream.removesuffix("s")
+    return {
+        "activity_type": activity_type,
+        "remote_id": f"{selected}_{activity_type}_{remote_id}",
+        "actor_remote_id": selected,
+        "object_remote_id": remote_id,
+        "occurred_at": _timestamp(item.get("created_at"), "activity timestamp"),
+        "observed_at": observed_at,
+        "state": "active",
+        "provider_json": {"source": PROVENANCE, "stream": context.stream},
+    }
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    reject_credentials(payload)
+    observed_at = _observed_at(payload)
+    site = api_site_parameter(context.account.get("api_site_parameter"))
+    items = page_data(payload)
+    policy = dict(context.policy)
+    policy.update(
+        {
+            "stack_exchange_identity": "network_account_plus_site_parameter_plus_site_user",
+            "stack_exchange_pagination": "page_until_has_more_false",
+            "stack_exchange_backoff": "terminal_before_persistence",
+            "stack_exchange_transport": "stdlib_urllib_get_only",
+        }
+    )
+    archive = {
+        "provider": PROVIDER,
+        "connection_id": context.connection_id,
+        "remote_account_id": context.account.get("id"),
+        "exported_at": observed_at,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": policy,
+        "accounts": [
+            {
+                "remote_id": context.account.get("id"),
+                "handle": context.account.get("display_name"),
+                "display_name": context.account.get("display_name"),
+                "observed_at": observed_at,
+                "provider_json": {
+                    "source": PROVENANCE,
+                    "network_account_id": context.account.get("network_account_id"),
+                    "site_user_id": context.account.get("site_user_id"),
+                    "api_site_parameter": site,
+                    "link": context.account.get("link"),
+                },
+            }
+        ],
+        "objects": [_object_row(item, context, observed_at) for item in items],
+        "activities": [_activity_row(item, context, observed_at) for item in items],
+        "media": [],
+        "coverage": _coverage(observed_at),
+    }
+    reject_credentials(archive)
+    return archive

--- a/.agents/scripts/_knowledge_social_stack_exchange_provider.py
+++ b/.agents/scripts/_knowledge_social_stack_exchange_provider.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded GET-only Stack Exchange API v2.3 account reader subprocess."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from functools import partial
+from typing import Any
+
+from _knowledge_social_stack_exchange import (
+    PageRequest,
+    StackExchangeAdapterError,
+    parse_page_request,
+)
+from _knowledge_social_stack_exchange_contract import (
+    ApiResult,
+    StackExchangeReadProviderError,
+    identity_value,
+    object_value,
+    observed_at,
+    request_object,
+    terminal_payload,
+    wrapper,
+)
+from _knowledge_social_stack_exchange_http import (
+    MAX_RESPONSE_BYTES,
+    Opener,
+    ProfileConfig,
+    _http_exports,
+    api,
+)
+from _knowledge_social_stack_exchange_identity import (
+    account_id,
+    api_site_parameter,
+    network_account_id,
+)
+from _knowledge_social_stack_exchange_routes import page
+
+MAX_REQUEST_BYTES = 32 * 1024
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+ALLOWED_SCOPES = frozenset({"read_inbox", "private_info"})
+
+
+def _profile_prefix(profile: str) -> str:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise StackExchangeReadProviderError("Stack Exchange profile name is invalid")
+    return f"STACK_EXCHANGE_{profile.upper()}"
+
+
+def _profile_value(prefix: str, suffix: str, field: str, limit: int) -> str:
+    value = os.environ.get(f"{prefix}_{suffix}", "")
+    if not value or "\x00" in value or len(value.encode()) > limit:
+        raise StackExchangeReadProviderError(f"Stack Exchange profile {field} is missing")
+    return value
+
+
+def _profile(profile: str) -> ProfileConfig:
+    prefix = _profile_prefix(profile)
+    token = _profile_value(prefix, "ACCESS_TOKEN", "access token", 16 * 1024)
+    site = api_site_parameter(_profile_value(prefix, "SITE", "site", 256))
+    scope_text = os.environ.get(f"{prefix}_SCOPES", "")
+    if "\x00" in scope_text or len(scope_text.encode()) > 4096:
+        raise StackExchangeReadProviderError("Stack Exchange profile scopes are invalid")
+    scopes = frozenset(scope_text.replace(",", " ").split())
+    if scopes - ALLOWED_SCOPES:
+        raise StackExchangeReadProviderError("Stack Exchange profile scopes are invalid")
+    return ProfileConfig(token, site, scopes)
+
+
+def _identity(config: ProfileConfig, opener: Opener, expected_id: str) -> dict[str, Any]:
+    result = api(config, opener, "/me", {"site": config.api_site_parameter})
+    if result.status != 200:
+        return terminal_payload(result)
+    _items, _has_more, backoff, quota = wrapper(result.payload, limit=1)
+    if backoff is not None:
+        return terminal_payload(ApiResult(429, {}, int(time.time()) + backoff))
+    if quota == 0:
+        return terminal_payload(ApiResult(429, {}))
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": identity_value(result.payload, expected_id, config.api_site_parameter),
+    }
+
+
+def _verify_page_account(request: PageRequest, identity: dict[str, Any]) -> None:
+    if (
+        identity.get("network_account_id") != request.network_account_id
+        or identity.get("site_user_id") != request.site_user_id
+        or identity.get("api_site_parameter") != request.api_site_parameter
+        or request.account_id
+        != account_id(
+            identity.get("network_account_id"),
+            identity.get("api_site_parameter"),
+            identity.get("site_user_id"),
+        )
+    ):
+        raise StackExchangeReadProviderError(
+            "selected Stack Exchange account does not match the configured connection"
+        )
+
+
+def _dispatch(request: dict[str, Any], config: ProfileConfig, opener: Opener) -> dict[str, Any]:
+    action = request.get("action")
+    if action == "identity":
+        if set(request) != {"action", "account_id"}:
+            raise StackExchangeReadProviderError(
+                "Stack Exchange identity request shape is invalid"
+            )
+        return _identity(config, opener, network_account_id(request.get("account_id")))
+    if action != "page":
+        raise StackExchangeReadProviderError("Stack Exchange read action is unsupported")
+    page_request = parse_page_request(request)
+    if page_request.api_site_parameter != config.api_site_parameter:
+        raise StackExchangeReadProviderError(
+            "selected Stack Exchange site does not match the connection"
+        )
+    if page_request.stream == "inbox" and "read_inbox" not in config.scopes:
+        raise StackExchangeReadProviderError(
+            "Stack Exchange profile lacks the read_inbox scope"
+        )
+    verified = _identity(config, opener, page_request.network_account_id)
+    if verified.get("status") != 200:
+        return verified
+    identity = object_value(verified.get("data"), "account verification")
+    _verify_page_account(page_request, identity)
+    result = page(partial(api, config, opener), page_request)
+    return terminal_payload(result) if isinstance(result, ApiResult) else result
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode()) > MAX_RESPONSE_BYTES:
+        raise StackExchangeReadProviderError(
+            "Stack Exchange read response exceeds the safety limit"
+        )
+    print(encoded)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        request = request_object(sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1), MAX_REQUEST_BYTES)
+        _emit(_dispatch(request, _profile(args.profile), _http_exports()))
+        return 0
+    except (StackExchangeReadProviderError, StackExchangeAdapterError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - intentionally redact provider internals
+        print("ERROR: Stack Exchange read provider request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_stack_exchange_reader.py
+++ b/.agents/scripts/_knowledge_social_stack_exchange_reader.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and deterministic fixture readers for Stack Exchange."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
+from _knowledge_social_stack_exchange import (
+    PageRequest,
+    StackExchangeAdapterError,
+    StackExchangeProviderUnavailableError,
+)
+from _knowledge_social_stack_exchange_identity import (
+    account_id,
+    api_site_parameter,
+    network_account_id,
+    site_user_id,
+)
+from knowledge_social_import import reject_credentials
+
+READ_TIMEOUT_SECONDS = 120
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+SAFE_PROVIDER_FAILURES = (
+    "Python urllib HTTP exports are unavailable",
+    "Stack Exchange profile name is invalid",
+    "Stack Exchange profile access token is missing",
+    "Stack Exchange profile site is missing",
+    "Stack Exchange profile scopes are invalid",
+    "Stack Exchange profile lacks the read_inbox scope",
+    "selected Stack Exchange account does not match the configured connection",
+    "selected Stack Exchange site does not match the connection",
+)
+
+
+class StackExchangeReader(Protocol):
+    def identity(self, expected_id: str) -> dict[str, Any]: ...
+    def page(self, request: PageRequest) -> dict[str, Any]: ...
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    if len(output.encode()) > MAX_RESPONSE_BYTES:
+        raise StackExchangeAdapterError(
+            "Stack Exchange read response exceeds the safety limit"
+        )
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise StackExchangeAdapterError(
+            "Stack Exchange read provider returned no valid JSON"
+        ) from error
+    if not isinstance(payload, dict):
+        raise StackExchangeAdapterError("Stack Exchange read response root must be an object")
+    return payload
+
+
+def _provider_failure(stderr: str) -> StackExchangeProviderUnavailableError:
+    for message in SAFE_PROVIDER_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return StackExchangeProviderUnavailableError(message)
+    return StackExchangeProviderUnavailableError(
+        "Stack Exchange read provider is unavailable"
+    )
+
+
+STACK_EXCHANGE_READER_POLICY = GuardedOAuthPolicy(
+    "Stack Exchange",
+    "STACK_EXCHANGE",
+    "STACK_EXCHANGE_READ_LOG",
+    READ_TIMEOUT_SECONDS,
+    _decode_output,
+    _provider_failure,
+    StackExchangeProviderUnavailableError,
+    ("ACCESS_TOKEN", "SITE", "SCOPES"),
+    "",
+)
+
+
+class GuardedStackExchange(GuardedOAuthReader):
+    def __init__(self, helper: Path, profile: str) -> None:
+        super().__init__(helper, profile, STACK_EXCHANGE_READER_POLICY)
+
+
+def _fixture_object(value: Any, message: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise StackExchangeAdapterError(message)
+    return value
+
+
+class FixtureStackExchange:
+    def __init__(self, path: Path) -> None:
+        self.fixture = FixtureSequence(path, "Stack Exchange", StackExchangeAdapterError)
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        del expected_id
+        return self.fixture.identity()
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        entry = self.fixture.next_page()
+        expectation = _fixture_object(
+            entry.get("expect_request", {}),
+            "Stack Exchange fixture request expectation must be an object",
+        )
+        actual = request.payload()
+        for key, value in expectation.items():
+            if actual.get(key) != value:
+                raise StackExchangeAdapterError(
+                    "Stack Exchange request did not resume at the expected checkpoint"
+                )
+        return _fixture_object(
+            entry.get("response", entry),
+            "Stack Exchange fixture page response must be an object",
+        )
+
+
+def _display_text(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value or len(value.encode()) > 256 * 1024:
+        raise StackExchangeAdapterError(f"Stack Exchange account {field} must be text")
+    return value
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise StackExchangeAdapterError(
+            "Stack Exchange account verification returned no account"
+        )
+    network = network_account_id(data.get("network_account_id"))
+    local = site_user_id(data.get("site_user_id"))
+    site = api_site_parameter(data.get("api_site_parameter"))
+    if network != network_account_id(expected_id):
+        raise StackExchangeAdapterError(
+            "selected Stack Exchange account does not match the configured connection"
+        )
+    durable = account_id(network, site, local)
+    if data.get("id") != durable:
+        raise StackExchangeAdapterError("Stack Exchange account identity binding is invalid")
+    return {
+        "id": durable,
+        "network_account_id": network,
+        "site_user_id": local,
+        "api_site_parameter": site,
+        "display_name": _display_text(data.get("display_name"), "display name"),
+        "link": _display_text(data.get("link"), "link"),
+    }

--- a/.agents/scripts/_knowledge_social_stack_exchange_routes.py
+++ b/.agents/scripts/_knowledge_social_stack_exchange_routes.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Exact Stack Exchange GET routes, wrapper policy, and serializers."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable
+
+from _knowledge_social_stack_exchange import PageRequest
+from _knowledge_social_stack_exchange_contract import (
+    ApiResult,
+    StackExchangeReadProviderError,
+    observed_at,
+    optional_text,
+    required_text,
+    wrapper,
+)
+from _knowledge_social_stack_exchange_identity import (
+    associated_account_id,
+    namespaced_id,
+    network_account_id,
+    site_user_id,
+)
+
+Api = Callable[[str, dict[str, str]], ApiResult]
+PageResult = ApiResult | dict[str, Any]
+
+EXACT_READ_PATHS = frozenset(
+    {
+        "/me",
+        "/me/posts",
+        "/me/questions",
+        "/me/answers",
+        "/me/comments",
+        "/me/favorites",
+        "/me/inbox",
+        "/me/notifications",
+        "/me/associated",
+    }
+)
+STREAM_PATHS = {
+    "posts": "/me/posts",
+    "questions": "/me/questions",
+    "answers": "/me/answers",
+    "comments": "/me/comments",
+    "favorites": "/me/favorites",
+    "inbox": "/me/inbox",
+    "notifications": "/me/notifications",
+    "associated_accounts": "/me/associated",
+}
+
+
+def allowlisted_path(path: str) -> bool:
+    return path in EXACT_READ_PATHS
+
+
+def query_keys_for_path(path: str) -> frozenset[str]:
+    if path == "/me":
+        return frozenset({"site", "filter"})
+    if path == "/me/associated":
+        return frozenset({"page", "pagesize", "filter"})
+    return frozenset({"site", "page", "pagesize", "filter"})
+
+
+def _integer(value: Any, field: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise StackExchangeReadProviderError(f"Stack Exchange {field} is invalid")
+    return value
+
+
+def _signed_integer(value: Any, field: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise StackExchangeReadProviderError(f"Stack Exchange {field} is invalid")
+    return value
+
+
+def _resource(request: PageRequest, kind: str, value: Any) -> str:
+    try:
+        return namespaced_id(request.api_site_parameter, kind, value)
+    except RuntimeError as error:
+        raise StackExchangeReadProviderError(str(error)) from error
+
+
+def _post(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    post_id = item.get("post_id", item.get("question_id", item.get("answer_id")))
+    kind = item.get("post_type", "post")
+    if kind not in ("question", "answer"):
+        kind = "post"
+    return {
+        "kind": kind,
+        "remote_id": _resource(request, kind, post_id),
+        "title": optional_text(item.get("title"), "post title"),
+        "body": optional_text(item.get("body_markdown", item.get("body")), "post body"),
+        "created_at": _integer(item.get("creation_date"), "post creation timestamp"),
+        "updated_at": _integer(item.get("last_activity_date"), "post update timestamp"),
+        "score": _signed_integer(item.get("score"), "post score"),
+    }
+
+
+def _question(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    item = dict(item)
+    item["post_type"] = "question"
+    return _post(item, request)
+
+
+def _answer(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    item = dict(item)
+    item["post_type"] = "answer"
+    return _post(item, request)
+
+
+def _comment(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    comment_id = _integer(item.get("comment_id"), "comment ID")
+    if comment_id is None:
+        raise StackExchangeReadProviderError("Stack Exchange comment ID is required")
+    return {
+        "kind": "comment",
+        "remote_id": _resource(request, "comment", comment_id),
+        "body": optional_text(item.get("body_markdown", item.get("body")), "comment body"),
+        "created_at": _integer(item.get("creation_date"), "comment creation timestamp"),
+        "post_remote_id": _resource(request, "post", item.get("post_id")),
+        "score": _signed_integer(item.get("score"), "comment score"),
+    }
+
+
+def _inbox(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    item_type = required_text(item.get("item_type"), "inbox item type")
+    identity = item.get("comment_id", item.get("answer_id", item.get("question_id")))
+    return {
+        "kind": "inbox_item",
+        "remote_id": _resource(request, "inbox_item", f"{item_type}:{identity}"),
+        "item_type": item_type,
+        "title": optional_text(item.get("title"), "inbox title"),
+        "created_at": _integer(item.get("creation_date"), "inbox timestamp"),
+        "is_unread": item.get("is_unread") if isinstance(item.get("is_unread"), bool) else None,
+    }
+
+
+def _notification(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    notification_type = required_text(item.get("notification_type"), "notification type")
+    created = _integer(item.get("creation_date"), "notification timestamp")
+    identity = f"{notification_type}:{created}:{item.get('post_id', '')}"
+    return {
+        "kind": "notification",
+        "remote_id": _resource(request, "notification", identity),
+        "notification_type": notification_type,
+        "body": optional_text(item.get("body"), "notification body"),
+        "created_at": created,
+    }
+
+
+def _associated(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    network = network_account_id(item.get("account_id"))
+    if network != request.network_account_id:
+        raise StackExchangeReadProviderError(
+            "Stack Exchange association belongs to another network account"
+        )
+    local = site_user_id(item.get("user_id"))
+    site_url = required_text(item.get("site_url"), "associated site URL")
+    return {
+        "kind": "account",
+        "remote_id": associated_account_id(network, site_url, local),
+        "network_account_id": network,
+        "site_user_id": local,
+        "site_url": site_url,
+        "site_name": optional_text(item.get("site_name"), "associated site name"),
+        "reputation": _integer(item.get("reputation"), "associated reputation"),
+    }
+
+
+SERIALIZERS = {
+    "posts": _post,
+    "questions": _question,
+    "answers": _answer,
+    "comments": _comment,
+    "favorites": _question,
+    "inbox": _inbox,
+    "notifications": _notification,
+    "associated_accounts": _associated,
+}
+
+
+def page(api: Api, request: PageRequest) -> PageResult:
+    path = STREAM_PATHS[request.stream]
+    params = {
+        "page": str(request.page),
+        "pagesize": str(min(request.limit, 100)),
+        "filter": "withbody",
+    }
+    if request.stream != "associated_accounts":
+        params["site"] = request.api_site_parameter
+    result = api(path, params)
+    if result.status != 200:
+        return result
+    items, has_more, backoff, quota = wrapper(result.payload, limit=100)
+    if backoff is not None:
+        return ApiResult(429, {}, int(time.time()) + backoff)
+    if quota == 0:
+        return ApiResult(429, {})
+    records = [SERIALIZERS[request.stream](item, request) for item in items]
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": records,
+        "meta": {
+            "stream": request.stream,
+            "api_site_parameter": request.api_site_parameter,
+            "has_more": has_more,
+            "quota_remaining": quota,
+            "snapshot": True,
+        },
+    }

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -17,6 +17,7 @@ DISCOURSE_HELPER="${SCRIPT_DIR}/knowledge_social_discourse.py"
 NODEBB_HELPER="${SCRIPT_DIR}/knowledge_social_nodebb.py"
 MASTODON_HELPER="${SCRIPT_DIR}/knowledge_social_mastodon.py"
 GITHUB_HELPER="${SCRIPT_DIR}/knowledge_social_github.py"
+STACK_EXCHANGE_HELPER="${SCRIPT_DIR}/knowledge_social_stack_exchange.py"
 QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
 SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
 SHARE_HELPER="${SCRIPT_DIR}/knowledge_social_share.py"
@@ -126,6 +127,12 @@ GitHub synchronization:
   opaque; REST writes, GraphQL mutations, and redirects are unreachable.
   --budget is 5-1000 and --page-size is 1-100.
 
+Stack Exchange synchronization:
+  sync-stack-exchange binds one network account ID to a selected API site and
+  site user ID before every page. Eight GET-only streams stop on backoff or quota
+  exhaustion, continue only while has_more, and cap pages at 100 items.
+  --budget is 3-1000 and --page-size is 1-100.
+
 EOF
 	return 0
 }
@@ -179,6 +186,10 @@ Usage:
     [--collector-id ID] [--lease-seconds SECONDS]
   knowledge-social-helper.sh sync-github [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id NUMERIC_ACCOUNT_ID --stream STREAM \
+    --profile PROFILE [--budget UNITS] [--page-size 1-100] \
+    [--collector-id ID] [--lease-seconds SECONDS]
+  knowledge-social-helper.sh sync-stack-exchange [--base PATH] [--alias ALIAS] \
+    --connection-id ID --account-id NETWORK_ACCOUNT_ID --stream STREAM \
     --profile PROFILE [--budget UNITS] [--page-size 1-100] \
     [--collector-id ID] [--lease-seconds SECONDS]
   knowledge-social-helper.sh sync-due [--base PATH] [--alias ALIAS] \
@@ -367,6 +378,7 @@ run_named_provider_sync() {
 	sync-nodebb) run_provider_sync NodeBB "$NODEBB_HELPER" "$@" || return 1 ;;
 	sync-mastodon) run_provider_sync Mastodon "$MASTODON_HELPER" "$@" || return 1 ;;
 	sync-github) run_provider_sync GitHub "$GITHUB_HELPER" "$@" || return 1 ;;
+	sync-stack-exchange) run_provider_sync "Stack Exchange" "$STACK_EXCHANGE_HELPER" "$@" || return 1 ;;
 	*) return 1 ;;
 	esac
 	return 0
@@ -446,7 +458,7 @@ main() {
 		fi
 		python3 "$LINKEDIN_HELPER" "$@" || return 1
 		;;
-	sync-meta | sync-discourse | sync-nodebb | sync-mastodon | sync-github)
+	sync-meta | sync-discourse | sync-nodebb | sync-mastodon | sync-github | sync-stack-exchange)
 		run_named_provider_sync "$subcommand" "$@" || return 1
 		;;
 	query | annotate)

--- a/.agents/scripts/knowledge_social_registry.py
+++ b/.agents/scripts/knowledge_social_registry.py
@@ -54,6 +54,12 @@ PROVIDER_SPECS = (
     ProviderSpec("github", (), "knowledge_social_github.py", (("live", ()),)),
     ProviderSpec("mastodon", (), "knowledge_social_mastodon.py", (("live", ()),)),
     ProviderSpec(
+        "stack-exchange",
+        ("stackexchange",),
+        "knowledge_social_stack_exchange.py",
+        (("live", ()),),
+    ),
+    ProviderSpec(
         "nextcloud-talk",
         (),
         "knowledge_social_nextcloud_talk.py",

--- a/.agents/scripts/knowledge_social_stack_exchange.py
+++ b/.agents/scripts/knowledge_social_stack_exchange.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one bounded Stack Exchange site-account stream into a social corpus."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import _knowledge_social_stack_exchange as stack_exchange
+from _knowledge_social_oauth_collector import OAuthCollectorPolicy, run_oauth_collector
+from _knowledge_social_stack_exchange_normalize import PageContext, normalize_page
+from _knowledge_social_stack_exchange_reader import (
+    FixtureStackExchange,
+    GuardedStackExchange,
+    verified_identity,
+)
+
+
+def _policy() -> OAuthCollectorPolicy:
+    return OAuthCollectorPolicy(
+        provider_module=stack_exchange,
+        verified_identity=verified_identity,
+        normalize_page=normalize_page,
+        page_context=PageContext,
+        display_name="Stack Exchange",
+        helper=Path(__file__).with_name("_knowledge_social_stack_exchange_provider.py"),
+        fixture_reader=FixtureStackExchange,
+        live_reader=GuardedStackExchange,
+        budget_unit="request",
+        max_page_size=100,
+    )
+
+
+def main() -> int:
+    return run_oauth_collector(_policy(), __doc__ or "")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/tests/test-knowledge-social-registry.sh
+++ b/.agents/tests/test-knowledge-social-registry.sh
@@ -50,6 +50,7 @@ expected = {
     "nextcloud-talk": ("live",),
     "signal": ("inspect", "manual-import", "status"),
     "slack": ("archive", "live"),
+    "stack-exchange": ("live",),
     "telegram": ("archive", "event", "status"),
     "whatsapp": ("archive", "event"),
 }
@@ -70,6 +71,7 @@ for alias, provider in {
     "dev-community": "forem",
     "dev.to": "forem",
     "gbp": "google-business-profile",
+    "stackexchange": "stack-exchange",
     "whats-app": "whatsapp",
 }.items():
     if module.resolve_provider(alias).provider != provider:
@@ -92,14 +94,14 @@ except module.ProviderRegistryError:
 else:
     raise SystemExit("unknown provider used a fallback")
 
-print("13:order-independent:aliases-exact:collisions-rejected:no-fallback")
+print("14:order-independent:aliases-exact:collisions-rejected:no-fallback")
 PY
 )
 assert_eq "all merged provider outcomes register deterministically" \
-	"$registry_summary" "13:order-independent:aliases-exact:collisions-rejected:no-fallback"
+	"$registry_summary" "14:order-independent:aliases-exact:collisions-rejected:no-fallback"
 
 provider_count=$("$HELPER" providers | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
-assert_eq "helper exposes the complete provider registry" "$provider_count" "13"
+assert_eq "helper exposes the complete provider registry" "$provider_count" "14"
 
 forem_resolution=$("$HELPER" provider-resolve --provider dev-community |
 	python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["provider"] + ":" + ",".join(data["modes"]))')

--- a/.agents/tests/test-knowledge-social-stack-exchange.sh
+++ b/.agents/tests/test-knowledge-social-stack-exchange.sh
@@ -1,0 +1,358 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-stack-exchange.sh — Bounded Stack Exchange collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STACK_SCRIPT="${SCRIPT_DIR}/../scripts/knowledge_social_stack_exchange.py"
+SOCIAL_HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TEMP_PARENT="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+mkdir -p "$TEMP_PARENT"
+TMP_DIR=$(mktemp -d "${TEMP_PARENT}/stack-exchange-social-test.XXXXXX")
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' \
+			"$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c 'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_count() {
+	python3 - "$ROOT/sources/social/raw/stack-exchange" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+print(len(list(root.rglob("*.json.gz"))) if root.exists() else 0)
+PY
+	return 0
+}
+
+run_stack() {
+	local fixture="$1"
+	local connection_id="$2"
+	local stream="$3"
+	local budget="$4"
+	local page_size="$5"
+	if python3 "$STACK_SCRIPT" --base "$BASE" --alias personal:default \
+		--connection-id "$connection_id" --account-id account_500 \
+		--stream "$stream" --profile fixture --fixture "$fixture" \
+		--budget "$budget" --page-size "$page_size"; then
+		return 0
+	fi
+	return 1
+}
+
+expect_failure() {
+	local description="$1"
+	local fixture="$2"
+	local connection_id="$3"
+	local stream="$4"
+	if run_stack "$fixture" "$connection_id" "$stream" 7 40 >/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$SOCIAL_HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'Stack Exchange social collector tests\n'
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import ast
+import json
+import os
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+
+from _knowledge_social_collect import CursorState
+from _knowledge_social_stack_exchange import PageRequest, STREAMS, page_checkpoint, page_request
+from _knowledge_social_stack_exchange_contract import ApiResult, identity_value, wrapper
+from _knowledge_social_stack_exchange_http import HTTP_TIMEOUT_SECONDS, ProfileConfig, api
+from _knowledge_social_stack_exchange_identity import (
+    account_id, associated_account_id, namespaced_id,
+)
+import _knowledge_social_stack_exchange_provider as provider
+from _knowledge_social_stack_exchange_provider import _profile
+from _knowledge_social_stack_exchange_routes import allowlisted_path, page
+
+assert set(STREAMS) == {
+    "posts", "questions", "answers", "comments", "favorites", "inbox",
+    "notifications", "associated_accounts",
+}
+assert all(spec.cost_units == 2 and spec.pagination == "snapshot" for spec in STREAMS.values())
+for allowed in ("/me", "/me/posts", "/me/favorites", "/me/associated"):
+    assert allowlisted_path(allowed)
+for rejected in (
+    "/questions/add", "/questions/1/favorite", "/answers/1/upvote",
+    "/access-tokens/token/invalidate", "/apps/token/de-authenticate",
+):
+    assert not allowlisted_path(rejected)
+
+identity = identity_value({
+    "items": [{"account_id": 500, "user_id": 42, "display_name": "selected"}],
+    "has_more": False, "quota_remaining": 9999,
+}, "500", "stackoverflow")
+assert identity["id"] == account_id(500, "stackoverflow", 42)
+assert namespaced_id("stackoverflow", "post", 1) != namespaced_id("superuser", "post", 1)
+assert associated_account_id(500, "https://stackoverflow.com", 42) != associated_account_id(
+    500, "https://superuser.com", 42
+)
+try:
+    identity_value({
+        "items": [{"account_id": 501, "user_id": 42}],
+        "has_more": False, "quota_remaining": 9999,
+    }, "500", "stackoverflow")
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("mismatched Stack Exchange network identity was accepted")
+
+assert wrapper({"items": [], "has_more": True, "backoff": 5, "quota_remaining": 9}, limit=100)[2] == 5
+
+os.environ.update({
+    "STACK_EXCHANGE_SCOPE_ACCESS_TOKEN": "private-token",
+    "STACK_EXCHANGE_SCOPE_SITE": "stackoverflow",
+    "STACK_EXCHANGE_SCOPE_SCOPES": "write_access",
+})
+try:
+    _profile("scope")
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("write-authorized Stack Exchange profile was accepted")
+
+
+class Headers:
+    def get(self, _key, default=None):
+        return default
+
+
+class Response:
+    status = 200
+    headers = Headers()
+
+    def __init__(self, payload):
+        self.payload = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def read(self, size=-1):
+        return self.payload[:size]
+
+
+class Opener:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    def open(self, request, timeout):
+        assert timeout == HTTP_TIMEOUT_SECONDS
+        assert request.method == "GET"
+        assert "private-token" not in request.full_url
+        self.requests.append(request)
+        return self.responses.pop(0)
+
+
+config = ProfileConfig("private-token", "stackoverflow", frozenset())
+original_api = provider.api
+provider.api = lambda *_args: ApiResult(200, {
+    "items": [{"account_id": 500, "user_id": 42}], "has_more": False,
+    "backoff": 5, "quota_remaining": 9999,
+})
+assert provider._identity(config, None, "500")["status"] == 429
+provider.api = original_api
+opener = Opener([Response({"items": [], "has_more": False, "quota_remaining": 9999})])
+api(config, opener, "/me/posts", {"site": "stackoverflow", "page": "1", "pagesize": "2", "filter": "withbody"})
+assert opener.requests[0].full_url.startswith("https://api.stackexchange.com/2.3/me/posts?")
+try:
+    api(config, opener, "/questions/add", {})
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("Stack Exchange write route was accepted")
+
+request = PageRequest(
+    "posts", identity["id"], "500", "42", "stackoverflow", 1, 2,
+)
+post = {
+    "post_id": 7, "post_type": "question", "title": "Bounded question",
+    "body_markdown": "Stack Exchange knowledge", "creation_date": 1785630000,
+    "score": -1,
+}
+payload = page(
+    lambda _path, _params: ApiResult(200, {
+        "items": [post], "has_more": True, "quota_remaining": 9998,
+    }),
+    request,
+)
+assert payload["data"][0]["score"] == -1
+checkpoint, complete = page_checkpoint(payload, CursorState(None, None, False), request)
+assert not complete and checkpoint.next_cursor is not None
+resumed = page_request("posts", identity, CursorState(checkpoint.next_cursor, None, False), 2)
+assert resumed.page == 2
+
+backoff = page(
+    lambda _path, _params: ApiResult(200, {
+        "items": [], "has_more": True, "backoff": 5, "quota_remaining": 9997,
+    }),
+    request,
+)
+assert isinstance(backoff, ApiResult) and backoff.status == 429 and backoff.retry_after is not None
+
+sources = [path.read_text(encoding="utf-8") for path in sorted(scripts.glob("_knowledge_social_stack_exchange*.py"))]
+trees = [ast.parse(source) for source in sources]
+request_calls = [
+    node for tree in trees for node in ast.walk(tree)
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "Request"
+]
+assert request_calls
+for node in request_calls:
+    methods = [
+        keyword.value.value for keyword in node.keywords
+        if keyword.arg == "method" and isinstance(keyword.value, ast.Constant)
+    ]
+    assert methods == ["GET"]
+PY
+assert_eq "identity, routes, paging, backoff, scopes, and GET-only AST are guarded" \
+	verified verified
+
+python3 - "$TMP_DIR/complete.json" <<'PY'
+import json
+import sys
+
+sys.path.insert(0, ".agents/scripts")
+from _knowledge_social_stack_exchange_identity import account_id, namespaced_id
+
+durable = account_id("500", "stackoverflow", "42")
+payload = {
+    "identity": {"data": {
+        "id": durable, "network_account_id": "500", "site_user_id": "42",
+        "api_site_parameter": "stackoverflow", "display_name": "selected",
+    }},
+    "pages": [{
+        "expect_request": {"page": 1, "limit": 1},
+        "response": {
+            "status": 200, "observed_at": "2026-08-02T06:15:00Z",
+            "data": [{
+                "kind": "question", "remote_id": namespaced_id("stackoverflow", "question", 7),
+                "title": "Bounded question", "body": "Stack Exchange knowledge",
+                "created_at": 1785630000,
+            }],
+            "meta": {"stream": "posts", "api_site_parameter": "stackoverflow",
+                     "has_more": False, "quota_remaining": 9998, "snapshot": True},
+        },
+    }],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+result=$(run_stack "$TMP_DIR/complete.json" conn_stack posts 3 1)
+assert_eq "bounded Stack Exchange fixture completes" "$(json_field "$result" status)" complete
+assert_eq "identity plus page consumes three request units" \
+	"$(json_field "$result" budget_units)" 3
+assert_eq "authored Stack Exchange text reaches FTS" \
+	"$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'knowledge'")" 1
+
+python3 - "$TMP_DIR/mismatch.json" <<'PY'
+import json
+import sys
+
+payload = {"identity": {"data": {
+    "id": "wrong", "network_account_id": "501", "site_user_id": "42",
+    "api_site_parameter": "stackoverflow",
+}}, "pages": []}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+raw_before=$(raw_count)
+expect_failure "selected-network identity mismatch is rejected" \
+	"$TMP_DIR/mismatch.json" conn_mismatch posts
+assert_eq "identity mismatch persists no raw evidence" "$(raw_count)" "$raw_before"
+
+python3 - "$TMP_DIR/credential.json" <<'PY'
+import json
+import sys
+
+sys.path.insert(0, ".agents/scripts")
+from _knowledge_social_stack_exchange_identity import account_id
+
+payload = {
+    "identity": {"data": {"id": account_id("500", "stackoverflow", "42"),
+                            "network_account_id": "500", "site_user_id": "42",
+                            "api_site_parameter": "stackoverflow"}},
+    "pages": [{"status": 200, "observed_at": "2026-08-02T06:16:00Z",
+               "access_token": "must-not-persist", "data": [],
+               "meta": {"stream": "favorites", "api_site_parameter": "stackoverflow",
+                        "has_more": False, "quota_remaining": 9997, "snapshot": True}}],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+raw_before=$(raw_count)
+expect_failure "credential-shaped Stack Exchange page is rejected" \
+	"$TMP_DIR/credential.json" conn_credential favorites
+assert_eq "credential rejection persists no raw evidence" "$(raw_count)" "$raw_before"
+
+assert_eq "unavailable history categories remain explicit gaps" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE connection_id='conn_stack' AND status='unavailable'")" 7
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add a network-plus-site identity-bound Stack Exchange API v2.3 collector with eight independently checkpointed GET-only streams, mandatory backoff and quota stops, registry routing, documentation, and fixture coverage.

## Files Changed

.agents/aidevops/knowledge-plane/05-social-operations.md, .agents/aidevops/knowledge-plane/06-social-provider-capabilities.md, .agents/content/social-stack-exchange.md, .agents/scripts/_knowledge_social_stack_exchange.py, .agents/scripts/_knowledge_social_stack_exchange_contract.py, .agents/scripts/_knowledge_social_stack_exchange_http.py, .agents/scripts/_knowledge_social_stack_exchange_identity.py, .agents/scripts/_knowledge_social_stack_exchange_normalize.py, .agents/scripts/_knowledge_social_stack_exchange_provider.py, .agents/scripts/_knowledge_social_stack_exchange_reader.py, .agents/scripts/_knowledge_social_stack_exchange_routes.py, .agents/scripts/knowledge-social-helper.sh, .agents/scripts/knowledge_social_registry.py, .agents/scripts/knowledge_social_stack_exchange.py, .agents/tests/test-knowledge-social-registry.sh, .agents/tests/test-knowledge-social-stack-exchange.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — 9 Stack Exchange collector tests and 8 provider registry tests pass; Python compilation, ShellCheck, Qlty smells, and changed-file local linters pass.

Resolves #29223


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 5h 56m and 3,557,099 tokens on this with the user in an interactive session.