### PR TITLE
GH#29224: Add bounded Miniflux social collector

### DIFF
--- a/.agents/aidevops/knowledge-plane/05-social-operations.md
+++ b/.agents/aidevops/knowledge-plane/05-social-operations.md
@@ -39,8 +39,8 @@ transaction without rewriting raw gzip artifacts, cursors, coverage, or provider
 rows. Replay preserves both evidence and projection IDs.
 
 Candidate implementation is provider-specific, not one generic social adapter.
-Mastodon #29221, GitHub #29222, and Stack Exchange #29223 are now live. The
-remaining ranked children are Miniflux #29224, Readwise Reader #29225, FreshRSS
+Mastodon #29221, GitHub #29222, Stack Exchange #29223, and Miniflux #29224 are
+now live. The remaining ranked children are Readwise Reader #29225, FreshRSS
 issue #29226, Lemmy issue #29227, then public-only Hacker News #29228. Each
 route owns its identity
 contract, stream allowlist, checkpoint semantics, and negative write-reachability
@@ -87,6 +87,14 @@ accounts have independent per-site checkpoints. Pages stop before persistence on
 `backoff` or quota exhaustion and continue only while `has_more`. Votes, follows,
 subscriptions, lists, projects, complete archives, and inaccessible site history
 remain explicit gaps. Details: `.agents/content/social-stack-exchange.md`.
+
+Miniflux collection binds `/v1/me` user identity to a keyed exact HTTPS
+installation before every page. Entries, read, removed, starred, tags, feeds,
+categories, and OPML have independent checkpoints. Entry backfill advances by
+ascending ID; later runs use `changed_after` with a one-second overlap. Only five
+exact GET routes are reachable despite mutation-capable API keys. Operator cleanup,
+pre-retention state, complete archives, and deletion inference remain explicit
+gaps. Details: `.agents/content/social-miniflux.md`.
 
 X collection uses the guarded official `xurl` helper. Reddit collection uses an
 optional PRAW 8 child. YouTube collection uses a standard-library HTTP child and

--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -45,6 +45,7 @@ a claim that the route is enabled.
 | Mastodon | **Live/Partial** authored statuses | **Live/Partial** favourites and bookmarks | **Live/Gate/Partial** notifications; **No/Gate** conversations | **Live/Partial** followers, following, and followed tags | **Live/Partial** lists; **No** nested membership | Eight exact-origin GET-only streams preserve opaque `Link` cursors and expose federation, moderation, deletion, export, and operator-retention gaps. |
 | GitHub | **Live/Partial** contribution calendar and repositories | **Live/Partial** stars and subscriptions; **No** complete reactions | **Live/Gate/Partial** notifications | **Live/Gate/Partial** followers, following, and organizations | **Live/Gate/Partial** user lists and visible Projects v2 | Ten numeric/node-identity-bound streams preserve REST `Link` and GraphQL `pageInfo` cursors; token family, visibility, migration expiry, deletion, and audit authority remain explicit. |
 | Stack Exchange | **Live/Partial** posts, questions, answers, and comments | **Live/Partial** favourites; **No** complete votes | **Live/Gate/Partial** inbox and notifications | **Live/Partial** associated site accounts; **No** follows | **No** | Eight network-plus-site-identity-bound GET streams obey `has_more`, `backoff`, quota, and 100-item page limits while preserving archive and inaccessible-history gaps. |
+| Miniflux | **Live/Partial** feed entries | **Live/Partial** read, removed, starred, and tagged state | **No** | **Live/Partial/Export** subscriptions | **Live/Partial/Export** categories and tags | Eight keyed-installation account streams use five exact GET routes, ascending entry-ID backfill, one-second `changed_after` overlap, bounded snapshots, and explicit operator-retention gaps. |
 
 ## Integrated provider families
 
@@ -79,7 +80,7 @@ separate provider family.
 | Stack Exchange | **Live/Partial** authored content | **Live/Partial** favourites; **No** complete vote history | **Live/Gate/Partial** inbox and notifications | **Live/Partial** associated site accounts; **No** follows | **No** | #29223 implements network plus per-site identity, mandatory `backoff` and quota stops, bounded paging, and explicit archive/completeness gaps. |
 | GitHub | **Live/Partial** contributions | **Live/Partial** stars and subscriptions; **No** complete reactions | **Live/Gate/Partial** notifications; **No** discussions | **Live/Gate/Partial** follows, organizations, and repositories | **Live/Gate/Partial** user lists and Projects v2 | #29222 implements numeric/node identity, token-family gates, opaque mixed-API cursors, and no complete reaction or social export claim. |
 | Hacker News | **API/Partial** public submissions and comments | **No** private votes or saved items | **No** | **No** | **No** | Rank 8, #29228. Bounded public history only, keyed by case-sensitive username and item ID; never infer private state. |
-| Miniflux | **API/Export** feed items | **API** read, removed, starred, and tagged state | **No** | **API/Export** subscriptions | **API/Export** categories/tags | Rank 4, #29224. Strong self-hosted identity and replay; locally enforce GET-only use of mutation-capable API keys. |
+| Miniflux | **Live/Partial** feed items | **Live/Partial** read, removed, starred, and tagged state | **No** | **Live/Partial/Export** subscriptions | **Live/Partial/Export** categories/tags | #29224 implements keyed installation/user identity, exact GET-only routes, incremental overlap, snapshots, and explicit operator-retention gaps. |
 | FreshRSS | **API/Export** feed items | **API** unread and starred state | **No** | **API/Export** subscriptions | **API/Export** folders/tags | Rank 6, #29226. Allow one non-mutating login POST, then GET-only Google Reader collection; reconcile OPML and keep Fever fallback-only. |
 | Readwise Reader | **API/Export** saved documents | **API/Export** tags, state, notes, and progress | **No** | **No** | **API/Export** tags and locations | Rank 5, #29225. Strong cursor/update contract, but implementation is gated on expected-account binding because token validation has no stable account ID. |
 | Other readers/read-later | **API/Export/Gate/No** | **API/Export/Gate/No** | **No** | **API/Export/Gate/No** | **API/Export/Gate/No** | Raindrop optional; Inoreader and Wallabag deferred; Feedly and Pocket rejected; Instapaper remains unverified. |
@@ -182,6 +183,15 @@ separate provider family.
   terminal coverage, and atomic persistence. `.agents/content/social-stack-exchange.md`
   records official v2.3 identity, route, OAuth, paging, filter, quota, throttle,
   duplicate-request, and completeness evidence checked on 2026-08-02.
+- **Live Miniflux:** `.agents/scripts/knowledge_social_miniflux.py`,
+  `.agents/scripts/_knowledge_social_miniflux*.py`, and
+  `.agents/tests/test-knowledge-social-miniflux.sh` prove keyed installation/user
+  identity, eight independent streams, ascending-ID resume, one-second
+  `changed_after` overlap, OPML replay, exact GET-only transport, credential
+  rejection, terminal coverage, and atomic persistence.
+  `.agents/content/social-miniflux.md` records official current identity, entries,
+  feed, category, OPML, authentication, version, and operator-retention evidence
+  checked on 2026-08-02.
 - **Integrated provider registry:** `.agents/scripts/knowledge_social_registry.py`
   and `.agents/tests/test-knowledge-social-registry.sh` prove order-independent
   registration, collision rejection, exact aliases and modes, no-route failure,

--- a/.agents/content/social-miniflux.md
+++ b/.agents/content/social-miniflux.md
@@ -1,0 +1,41 @@
+# Miniflux Account Knowledge Evidence
+
+Checked 2026-08-02 against the official Miniflux API and configuration references.
+
+## Implemented evidence
+
+- `GET /v1/me` returns the current numeric user ID and username. Collection binds
+  that identity to a keyed fingerprint of the configured exact HTTPS installation
+  and rechecks it before every persisted page.
+- Preferred API-key authentication uses the `X-Auth-Token` header. Application API
+  keys are mutation-capable, so the provider child constructs only `GET` requests,
+  rejects redirects, and allowlists only `/v1/me`, `/v1/entries`, `/v1/feeds`,
+  `/v1/categories`, and `/v1/export`.
+- `GET /v1/entries` supports `status`, `starred`, ascending `order=id`, `direction`,
+  `limit`, `after_entry_id`, and `changed_after`. Initial replay advances by entry
+  ID. Incremental runs overlap the persisted changed timestamp by one second so
+  equal-boundary updates can replay idempotently.
+- Feed and category reads are bounded snapshots. `GET /v1/export` supplies an OPML
+  subscription snapshot; partial snapshots never imply deletion.
+- Entry records expose current read, removed, starred, and tag state. Dedicated
+  streams retain independent checkpoints and neutral activity evidence.
+- The current API documents official Go and Python clients, but no Miniflux client
+  package is installed in the runtime. The provider therefore uses Python 3.14.3
+  standard-library `urllib` exports verified locally.
+
+## Explicit boundaries
+
+- Operator cleanup is configurable: read entries default to archive after 60 days,
+  unread entries after 180 days, and `-1` retains all. Current API state cannot
+  prove complete pre-retention history.
+- Feed/category/OPML snapshots are bounded by request, byte, and item limits and do
+  not prove deletion when incomplete.
+- No API-key, feed credential, password, or credential-shaped response field may
+  enter raw or normalized evidence.
+- Mutation routes for imports, feed refresh, entry updates, bookmarks, categories,
+  users, and API keys are unreachable.
+
+## Official references
+
+- <https://miniflux.app/docs/api.html>
+- <https://miniflux.app/docs/configuration.html>

--- a/.agents/scripts/_knowledge_social_miniflux.py
+++ b/.agents/scripts/_knowledge_social_miniflux.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Miniflux stream policy and independent incremental checkpoints."""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from _knowledge_social_miniflux_identity import (
+    MinifluxAdapterError,
+    MinifluxProviderUnavailableError,
+    account_id,
+    user_id,
+)
+from knowledge_social_import import canonical_json, reject_credentials
+
+PROVIDER = "miniflux"
+CURSOR_PREFIX = "miniflux-entry-v1:"
+RETENTION_LIMIT = "operator_cleanup_configuration_and_current_database_state"
+MAX_PAGE_ITEMS = 100
+
+ADAPTER_ERROR = MinifluxAdapterError
+PROVIDER_UNAVAILABLE_ERROR = MinifluxProviderUnavailableError
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    resource_kind: str
+    activity_mode: str
+    pagination: str
+    incremental: bool
+    retention_limit: str | None = RETENTION_LIMIT
+    coverage_status: str | None = "partial"
+    unavailable_reason: str | None = "operator_configurable_retention"
+    cost_units: int = 2
+
+
+STREAMS = {
+    "entries": StreamSpec("entry", "content_observed", "entry_id_changed_after", True),
+    "read": StreamSpec("entry", "selected_account", "entry_id_changed_after", True),
+    "removed": StreamSpec("entry", "selected_account", "entry_id_changed_after", True),
+    "starred": StreamSpec("entry", "selected_account", "entry_id_changed_after", True),
+    "tags": StreamSpec("tag", "selected_account", "entry_id_changed_after", True),
+    "feeds": StreamSpec("feed", "subscription", "snapshot", False),
+    "categories": StreamSpec("category", "subscription", "snapshot", False),
+    "opml": StreamSpec("feed", "subscription", "snapshot", False),
+}
+ENTRY_STREAMS = frozenset({"entries", "read", "removed", "starred", "tags"})
+
+
+@dataclass(frozen=True)
+class PageRequest:
+    stream: str
+    account_id: str
+    installation_id: str
+    user_id: str
+    after_entry_id: int
+    changed_after: int | None
+    limit: int
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "page",
+            "stream": self.stream,
+            "account_id": self.account_id,
+            "installation_id": self.installation_id,
+            "user_id": self.user_id,
+            "after_entry_id": self.after_entry_id,
+            "changed_after": self.changed_after,
+            "limit": self.limit,
+        }
+
+    def evidence_key(self) -> str:
+        return canonical_json(self.payload())
+
+
+PAGE_REQUEST_KEYS = frozenset(PageRequest.__dataclass_fields__) | {"action"}
+
+
+def _positive(value: Any, field: str, *, allow_zero: bool = False) -> int:
+    minimum = 0 if allow_zero else 1
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise MinifluxAdapterError(f"Miniflux {field} is invalid")
+    return value
+
+
+def _text(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value or len(value.encode()) > 4096:
+        raise MinifluxAdapterError(f"Miniflux {field} is invalid")
+    return value
+
+
+def _encode_cursor(after_id: int, changed_after: int | None) -> str:
+    encoded = base64.urlsafe_b64encode(
+        canonical_json({"after": after_id, "changed_after": changed_after}).encode()
+    ).decode().rstrip("=")
+    return f"{CURSOR_PREFIX}{encoded}"
+
+
+def _decode_cursor(cursor: str) -> tuple[int, int | None]:
+    if not cursor.startswith(CURSOR_PREFIX):
+        raise MinifluxAdapterError("stored Miniflux cursor has an unsupported version")
+    try:
+        raw = cursor.removeprefix(CURSOR_PREFIX)
+        payload = json.loads(base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4)))
+    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+        raise MinifluxAdapterError("stored Miniflux cursor is invalid") from error
+    if not isinstance(payload, dict) or set(payload) != {"after", "changed_after"}:
+        raise MinifluxAdapterError("stored Miniflux cursor has an invalid shape")
+    reject_credentials(payload)
+    after_id = _positive(payload.get("after"), "entry cursor", allow_zero=True)
+    changed = payload.get("changed_after")
+    if changed is not None:
+        changed = _positive(changed, "changed_after", allow_zero=True)
+    return after_id, changed
+
+
+def page_request(stream: str, account: dict[str, Any], state: CursorState, limit: int) -> PageRequest:
+    if stream not in STREAMS:
+        raise MinifluxAdapterError("Miniflux stream is unsupported")
+    after_id, changed = _decode_cursor(state.cursor) if state.cursor else (0, None)
+    if stream in ENTRY_STREAMS and state.backfill_complete and not state.cursor:
+        if state.watermark is None or not state.watermark.isdigit():
+            raise MinifluxAdapterError("stored Miniflux watermark is invalid")
+        changed = max(0, int(state.watermark) - 1)
+    return PageRequest(
+        stream,
+        _text(account.get("id"), "selected account ID"),
+        _text(account.get("installation_id"), "installation ID"),
+        user_id(account.get("user_id")),
+        after_id,
+        changed,
+        limit,
+    )
+
+
+def parse_page_request(payload: dict[str, Any]) -> PageRequest:
+    if set(payload) != PAGE_REQUEST_KEYS or payload.get("action") != "page":
+        raise MinifluxAdapterError("Miniflux read request has an invalid action shape")
+    stream = payload.get("stream")
+    if not isinstance(stream, str) or stream not in STREAMS:
+        raise MinifluxAdapterError("Miniflux stream is unsupported")
+    changed = payload.get("changed_after")
+    if changed is not None:
+        changed = _positive(changed, "changed_after", allow_zero=True)
+    limit = _positive(payload.get("limit"), "page size")
+    if limit > MAX_PAGE_ITEMS:
+        raise MinifluxAdapterError("Miniflux page size is invalid")
+    local = user_id(payload.get("user_id"))
+    installation = _text(payload.get("installation_id"), "installation ID")
+    selected = _text(payload.get("account_id"), "selected account ID")
+    if selected != account_id(installation, local):
+        raise MinifluxAdapterError("Miniflux account identity binding is invalid")
+    return PageRequest(
+        stream, selected, installation, local,
+        _positive(payload.get("after_entry_id"), "entry cursor", allow_zero=True),
+        changed, limit,
+    )
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise MinifluxAdapterError("Miniflux response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise MinifluxAdapterError("Miniflux page data must be an array")
+    return data
+
+
+def _timestamp_epoch(value: Any) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise MinifluxAdapterError("Miniflux changed timestamp is invalid")
+    try:
+        return int(datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC).timestamp())
+    except ValueError as error:
+        raise MinifluxAdapterError("Miniflux changed timestamp is invalid") from error
+
+
+def page_checkpoint(
+    payload: dict[str, Any], state: CursorState, request: PageRequest
+) -> tuple[PageCheckpoint, bool]:
+    meta = payload.get("meta")
+    if not isinstance(meta, dict) or meta.get("stream") != request.stream:
+        raise MinifluxAdapterError("Miniflux page provenance is invalid")
+    reject_credentials(meta)
+    items = page_data(payload)
+    if len(items) > request.limit or meta.get("snapshot") is not (request.stream not in ENTRY_STREAMS):
+        raise MinifluxAdapterError("Miniflux page metadata is invalid")
+    has_more = meta.get("has_more")
+    if not isinstance(has_more, bool):
+        raise MinifluxAdapterError("Miniflux has_more must be boolean")
+    next_after = meta.get("next_after_entry_id", request.after_entry_id)
+    next_after = _positive(next_after, "next entry cursor", allow_zero=True)
+    if has_more and next_after <= request.after_entry_id:
+        raise MinifluxAdapterError("Miniflux entry cursor did not advance")
+    cursor = _encode_cursor(next_after, request.changed_after) if has_more else None
+    watermark = state.watermark
+    changed_values = [_timestamp_epoch(item.get("changed_at")) for item in items]
+    observed = meta.get("watermark")
+    if observed is not None:
+        observed = _positive(observed, "watermark", allow_zero=True)
+        changed_values.append(observed)
+    present = [value for value in changed_values if value is not None]
+    if present:
+        watermark = str(max(present + ([int(watermark)] if watermark and watermark.isdigit() else [])))
+    return PageCheckpoint(cursor, watermark), not has_more

--- a/.agents/scripts/_knowledge_social_miniflux_contract.py
+++ b/.agents/scripts/_knowledge_social_miniflux_contract.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validation primitives for bounded Miniflux API responses."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_miniflux_identity import account_id, user_id
+
+MAX_TEXT_BYTES = 256 * 1024
+
+
+class MinifluxReadProviderError(RuntimeError):
+    """Raised for a privacy-safe local Miniflux provider failure."""
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    status: int
+    payload: Any
+    retry_after: int | None = None
+
+
+def observed_at() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def decode_json(payload: bytes, limit: int) -> Any:
+    if len(payload) > limit:
+        raise MinifluxReadProviderError("Miniflux JSON payload exceeds the safety limit")
+    try:
+        return json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise MinifluxReadProviderError("Miniflux JSON payload is invalid") from error
+
+
+def request_object(payload: bytes, limit: int) -> dict[str, Any]:
+    request = decode_json(payload, limit)
+    if not isinstance(request, dict):
+        raise MinifluxReadProviderError("Miniflux read request root must be an object")
+    return request
+
+
+def object_value(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise MinifluxReadProviderError(f"Miniflux {field} must be an object")
+    return value
+
+
+def object_list(value: Any, field: str, *, limit: int) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise MinifluxReadProviderError(f"Miniflux {field} must be an array of objects")
+    if len(value) > limit:
+        raise MinifluxReadProviderError(f"Miniflux {field} exceeds the item safety limit")
+    return value
+
+
+def optional_text(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value or len(value.encode()) > MAX_TEXT_BYTES:
+        raise MinifluxReadProviderError(f"Miniflux {field} must be text")
+    return value
+
+
+def identity_value(payload: Any, expected_user_id: str, instance: str) -> dict[str, Any]:
+    user = object_value(payload, "account response")
+    local = user_id(user.get("id"))
+    if local != user_id(expected_user_id):
+        raise MinifluxReadProviderError(
+            "selected Miniflux account does not match the configured connection"
+        )
+    return {
+        "id": account_id(instance, local),
+        "installation_id": instance,
+        "user_id": local,
+        "username": optional_text(user.get("username"), "account username"),
+    }
+
+
+def terminal_payload(result: ApiResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": result.status, "observed_at": observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload

--- a/.agents/scripts/_knowledge_social_miniflux_http.py
+++ b/.agents/scripts/_knowledge_social_miniflux_http.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Exact-origin, redirect-free, bounded GET transport for Miniflux."""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from _knowledge_social_miniflux_contract import (
+    ApiResult,
+    MinifluxReadProviderError,
+    decode_json,
+)
+from _knowledge_social_miniflux_identity import canonical_base_url
+from _knowledge_social_miniflux_routes import allowlisted_path, query_keys_for_path
+
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+HTTP_TIMEOUT_SECONDS = 60
+
+
+class Headers(Protocol):
+    def get(self, key: str, default: str | None = None) -> str | None: ...
+
+
+class Response(Protocol):
+    status: int
+    headers: Headers
+
+    def __enter__(self) -> Response: ...
+    def __exit__(self, *args: Any) -> None: ...
+    def read(self, size: int = -1) -> bytes: ...
+
+
+class Opener(Protocol):
+    def open(self, request: Request, timeout: int) -> Response: ...
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    base_url: str
+    api_token: str
+    origin_key: str
+    installation_id: str
+
+
+class _RejectRedirect(HTTPRedirectHandler):
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def _http_exports() -> Opener:
+    exports = (Request, build_opener, urlencode, HTTPRedirectHandler)
+    if not all(callable(item) for item in exports):
+        raise MinifluxReadProviderError("Python urllib HTTP exports are unavailable")
+    return build_opener(_RejectRedirect())
+
+
+def _retry_epoch(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    return int(time.time() + math.ceil(seconds))
+
+
+def _target_url(config: ProfileConfig, path: str, params: dict[str, str]) -> str:
+    if not allowlisted_path(path) or set(params) - query_keys_for_path(path):
+        raise MinifluxReadProviderError("Miniflux API route is not allowlisted")
+    if any(not isinstance(value, str) or not value or "\x00" in value for value in params.values()):
+        raise MinifluxReadProviderError("Miniflux API query is invalid")
+    for key in ("limit", "after_entry_id", "changed_after"):
+        value = params.get(key)
+        if value is not None and not value.isdigit():
+            raise MinifluxReadProviderError("Miniflux paging query is invalid")
+    query = urlencode(params)
+    return f"{canonical_base_url(config.base_url)}{path}" + (f"?{query}" if query else "")
+
+
+def api(
+    config: ProfileConfig, opener: Opener, path: str, params: dict[str, str]
+) -> ApiResult:
+    """Execute one exact-origin, redirect-free, GET-only request."""
+    request = Request(
+        _target_url(config, path, params),
+        headers={
+            "Accept": "application/xml" if path == "/v1/export" else "application/json",
+            "X-Auth-Token": config.api_token,
+            "User-Agent": "aidevops-miniflux-knowledge/1",
+        },
+        method="GET",
+    )
+    try:
+        with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", 200)
+            if isinstance(status, bool) or not isinstance(status, int):
+                raise MinifluxReadProviderError("Miniflux HTTP status is invalid")
+            payload = response.read(MAX_RESPONSE_BYTES + 1)
+            if not isinstance(payload, bytes) or len(payload) > MAX_RESPONSE_BYTES:
+                raise MinifluxReadProviderError("Miniflux read response exceeds the safety limit")
+            if path == "/v1/export":
+                try:
+                    decoded: Any = payload.decode("utf-8")
+                except UnicodeDecodeError as error:
+                    raise MinifluxReadProviderError("Miniflux OPML response is invalid") from error
+            else:
+                decoded = decode_json(payload, MAX_RESPONSE_BYTES)
+            return ApiResult(status, decoded)
+    except HTTPError as error:
+        retry = error.headers.get("Retry-After") if error.headers is not None else None
+        return ApiResult(error.code, {}, _retry_epoch(retry))
+    except (TimeoutError, URLError, OSError) as error:
+        raise MinifluxReadProviderError("Miniflux read provider request failed") from error

--- a/.agents/scripts/_knowledge_social_miniflux_identity.py
+++ b/.agents/scripts/_knowledge_social_miniflux_identity.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Durable Miniflux installation and account identity validation."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from typing import Any
+from urllib.parse import SplitResult, urlsplit
+
+from knowledge_social_store import SocialStoreError
+
+
+class MinifluxAdapterError(SocialStoreError):
+    """Raised when guarded Miniflux collection cannot continue safely."""
+
+
+class MinifluxProviderUnavailableError(MinifluxAdapterError):
+    """Raised when the bounded Miniflux HTTP child cannot complete a read."""
+
+
+def _parsed_url(value: str) -> tuple[SplitResult, int | None]:
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError as error:
+        raise MinifluxAdapterError("Miniflux profile base URL is invalid") from error
+    return parsed, port
+
+
+def canonical_base_url(value: Any) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise MinifluxAdapterError("Miniflux profile base URL is invalid")
+    parsed, port = _parsed_url(value)
+    checks = (
+        parsed.scheme.lower() == "https",
+        parsed.hostname is not None,
+        parsed.username is None,
+        parsed.password is None,
+        not parsed.query,
+        not parsed.fragment,
+    )
+    if not all(checks):
+        raise MinifluxAdapterError("Miniflux profile base URL must be HTTPS")
+    path = parsed.path.rstrip("/")
+    if any(marker in path for marker in ("\\", "%", "//")) or any(
+        part in (".", "..") for part in path.split("/") if part
+    ):
+        raise MinifluxAdapterError("Miniflux profile base URL is invalid")
+    host = parsed.hostname.lower()
+    rendered = f"[{host}]" if ":" in host else host
+    if port is not None and port != 443:
+        rendered = f"{rendered}:{port}"
+    return f"https://{rendered}{path}"
+
+
+def installation_id(base_url: Any, origin_key: Any) -> str:
+    canonical = canonical_base_url(base_url)
+    if not isinstance(origin_key, str) or len(origin_key.encode()) < 32:
+        raise MinifluxAdapterError(
+            "Miniflux profile origin key must be at least 32 bytes"
+        )
+    digest = hmac.new(origin_key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
+    return f"miniflux_{digest[:24]}"
+
+
+def user_id(value: Any) -> str:
+    if isinstance(value, str) and value.startswith("user_"):
+        value = value.removeprefix("user_")
+    if isinstance(value, bool):
+        raise MinifluxAdapterError("Miniflux user ID is invalid")
+    try:
+        numeric = int(value)
+    except (TypeError, ValueError) as error:
+        raise MinifluxAdapterError("Miniflux user ID is invalid") from error
+    if numeric < 1 or str(numeric) != str(value):
+        raise MinifluxAdapterError("Miniflux user ID is invalid")
+    return str(numeric)
+
+
+def account_id(instance: Any, local_user_id: Any) -> str:
+    if not isinstance(instance, str) or not instance.startswith("miniflux_"):
+        raise MinifluxAdapterError("Miniflux installation identity is invalid")
+    local = user_id(local_user_id)
+    return f"{instance}_user_{local}"
+
+
+def resource_id(instance: Any, kind: str, value: Any) -> str:
+    if not isinstance(instance, str) or not instance.startswith("miniflux_"):
+        raise MinifluxAdapterError("Miniflux installation identity is invalid")
+    if not kind.replace("_", "").isalpha() or len(kind) > 32:
+        raise MinifluxAdapterError("Miniflux resource kind is invalid")
+    if isinstance(value, bool) or not isinstance(value, (str, int)):
+        raise MinifluxAdapterError("Miniflux resource identity is invalid")
+    opaque = str(value)
+    if not opaque or "\x00" in opaque or len(opaque.encode()) > 4096:
+        raise MinifluxAdapterError("Miniflux resource identity is invalid")
+    digest = hashlib.sha256(f"{instance}\0{opaque}".encode()).hexdigest()[:32]
+    return f"mf_{kind}_{digest}"

--- a/.agents/scripts/_knowledge_social_miniflux_normalize.py
+++ b/.agents/scripts/_knowledge_social_miniflux_normalize.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize allowlisted Miniflux records into neutral evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_miniflux import PROVIDER, RETENTION_LIMIT, MinifluxAdapterError, page_data
+from knowledge_social_import import reject_credentials
+
+PROVENANCE = "miniflux_official_api"
+GAPS = (
+    ("retained_history", "operator_cleanup_configuration_can_remove_history"),
+    ("deleted_subscriptions", "partial_snapshots_do_not_prove_deletion"),
+    ("complete_account_archive", "no_verified_complete_account_archive"),
+    ("pre_retention_state", "not_recoverable_from_current_api_state"),
+)
+OBJECT_TYPES = frozenset({"entry", "feed", "category", "tag"})
+
+
+@dataclass(frozen=True)
+class PageContext:
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def _required_text(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise MinifluxAdapterError(f"Miniflux record requires {key}")
+    return value
+
+
+def _optional_text(record: dict[str, Any], key: str) -> str | None:
+    value = record.get(key)
+    if value is not None and (not isinstance(value, str) or "\x00" in value):
+        raise MinifluxAdapterError(f"Miniflux record {key} must be text")
+    return value
+
+
+def _observed_at(payload: dict[str, Any]) -> str:
+    value = payload.get("observed_at")
+    if not isinstance(value, str) or not value:
+        raise MinifluxAdapterError("Miniflux page observed_at must be text")
+    return value
+
+
+def _coverage(observed_at: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "stream": stream, "earliest_at": None, "latest_at": None,
+            "cursor_exhausted": False, "retention_limit": RETENTION_LIMIT,
+            "unavailable_reason": reason, "status": "unavailable",
+            "observed_at": observed_at,
+        }
+        for stream, reason in GAPS
+    ]
+
+
+def _object_row(item: dict[str, Any], context: PageContext, observed_at: str) -> dict[str, Any]:
+    kind = item.get("kind")
+    if not isinstance(kind, str) or kind not in OBJECT_TYPES:
+        raise MinifluxAdapterError("Miniflux page contains an unsupported item kind")
+    remote_id = _required_text(item, "remote_id")
+    text = "\n\n".join(
+        value for key in ("title", "body", "author", "category")
+        if (value := _optional_text(item, key))
+    ) or None
+    provider_json = {"source": PROVENANCE, "stream": context.stream, "record": item}
+    reject_credentials(provider_json)
+    return {
+        "object_type": kind, "remote_id": remote_id,
+        "account_remote_id": context.account.get("id"), "text": text,
+        "created_at": _optional_text(item, "created_at") or _optional_text(item, "published_at"),
+        "observed_at": observed_at, "evidence_class": "observed",
+        "provider_json": provider_json,
+    }
+
+
+def _activity_row(item: dict[str, Any], context: PageContext, observed_at: str) -> dict[str, Any]:
+    selected = _required_text(context.account, "id")
+    remote = _required_text(item, "remote_id")
+    activity_type = context.stream.removesuffix("s")
+    return {
+        "activity_type": activity_type,
+        "remote_id": f"{selected}_{activity_type}_{remote}",
+        "actor_remote_id": selected, "object_remote_id": remote,
+        "occurred_at": _optional_text(item, "changed_at") or observed_at,
+        "observed_at": observed_at, "state": "active",
+        "provider_json": {"source": PROVENANCE, "stream": context.stream},
+    }
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    reject_credentials(payload)
+    observed_at = _observed_at(payload)
+    items = page_data(payload)
+    policy = dict(context.policy)
+    policy.update({
+        "miniflux_identity": "installation_fingerprint_plus_current_user_id",
+        "miniflux_pagination": "ascending_entry_id_with_changed_after_overlap",
+        "miniflux_transport": "exact_origin_stdlib_urllib_get_only",
+        "miniflux_deletion": "never_inferred_from_partial_snapshots",
+    })
+    archive = {
+        "provider": PROVIDER, "connection_id": context.connection_id,
+        "remote_account_id": context.account.get("id"), "exported_at": observed_at,
+        "enabled_streams": list(context.enabled_streams), "policy": policy,
+        "accounts": [{
+            "remote_id": context.account.get("id"),
+            "handle": context.account.get("username"),
+            "display_name": context.account.get("username"),
+            "observed_at": observed_at,
+            "provider_json": {
+                "source": PROVENANCE,
+                "installation_id": context.account.get("installation_id"),
+                "user_id": context.account.get("user_id"),
+            },
+        }],
+        "objects": [_object_row(item, context, observed_at) for item in items],
+        "activities": [_activity_row(item, context, observed_at) for item in items],
+        "media": [], "coverage": _coverage(observed_at),
+    }
+    reject_credentials(archive)
+    return archive

--- a/.agents/scripts/_knowledge_social_miniflux_provider.py
+++ b/.agents/scripts/_knowledge_social_miniflux_provider.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded GET-only Miniflux account reader subprocess."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from functools import partial
+from typing import Any
+
+from _knowledge_social_miniflux import MinifluxAdapterError, PageRequest, parse_page_request
+from _knowledge_social_miniflux_contract import (
+    ApiResult,
+    MinifluxReadProviderError,
+    identity_value,
+    object_value,
+    observed_at,
+    request_object,
+    terminal_payload,
+)
+from _knowledge_social_miniflux_http import (
+    MAX_RESPONSE_BYTES,
+    Opener,
+    ProfileConfig,
+    _http_exports,
+    api,
+)
+from _knowledge_social_miniflux_identity import (
+    account_id,
+    canonical_base_url,
+    installation_id,
+    user_id,
+)
+from _knowledge_social_miniflux_routes import page
+
+MAX_REQUEST_BYTES = 32 * 1024
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+
+
+def _profile_prefix(profile: str) -> str:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise MinifluxReadProviderError("Miniflux profile name is invalid")
+    return f"MINIFLUX_{profile.upper()}"
+
+
+def _profile_value(prefix: str, suffix: str, field: str, limit: int) -> str:
+    value = os.environ.get(f"{prefix}_{suffix}", "")
+    if not value or "\x00" in value or len(value.encode()) > limit:
+        raise MinifluxReadProviderError(f"Miniflux profile {field} is missing")
+    return value
+
+
+def _profile(profile: str) -> ProfileConfig:
+    prefix = _profile_prefix(profile)
+    base = canonical_base_url(_profile_value(prefix, "BASE_URL", "base URL", 4096))
+    token = _profile_value(prefix, "API_TOKEN", "API token", 16 * 1024)
+    origin_key = _profile_value(prefix, "ORIGIN_KEY", "origin key", 16 * 1024)
+    return ProfileConfig(base, token, origin_key, installation_id(base, origin_key))
+
+
+def _identity(config: ProfileConfig, opener: Opener, expected_id: str) -> dict[str, Any]:
+    result = api(config, opener, "/v1/me", {})
+    if result.status != 200:
+        return terminal_payload(result)
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": identity_value(result.payload, expected_id, config.installation_id),
+    }
+
+
+def _verify_page_account(request: PageRequest, identity: dict[str, Any]) -> None:
+    if (
+        identity.get("installation_id") != request.installation_id
+        or identity.get("user_id") != request.user_id
+        or request.account_id
+        != account_id(identity.get("installation_id"), identity.get("user_id"))
+    ):
+        raise MinifluxReadProviderError(
+            "selected Miniflux account does not match the configured connection"
+        )
+
+
+def _dispatch(request: dict[str, Any], config: ProfileConfig, opener: Opener) -> dict[str, Any]:
+    action = request.get("action")
+    if action == "identity":
+        if set(request) != {"action", "account_id"}:
+            raise MinifluxReadProviderError("Miniflux identity request shape is invalid")
+        return _identity(config, opener, user_id(request.get("account_id")))
+    if action != "page":
+        raise MinifluxReadProviderError("Miniflux read action is unsupported")
+    page_request = parse_page_request(request)
+    if page_request.installation_id != config.installation_id:
+        raise MinifluxReadProviderError(
+            "selected Miniflux installation does not match the connection"
+        )
+    verified = _identity(config, opener, page_request.user_id)
+    if verified.get("status") != 200:
+        return verified
+    identity = object_value(verified.get("data"), "account verification")
+    _verify_page_account(page_request, identity)
+    result = page(partial(api, config, opener), page_request)
+    return terminal_payload(result) if isinstance(result, ApiResult) else result
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode()) > MAX_RESPONSE_BYTES:
+        raise MinifluxReadProviderError("Miniflux read response exceeds the safety limit")
+    print(encoded)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        request = request_object(sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1), MAX_REQUEST_BYTES)
+        _emit(_dispatch(request, _profile(args.profile), _http_exports()))
+        return 0
+    except (MinifluxReadProviderError, MinifluxAdapterError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - intentionally redact provider internals
+        print("ERROR: Miniflux read provider request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_miniflux_reader.py
+++ b/.agents/scripts/_knowledge_social_miniflux_reader.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and deterministic fixture readers for Miniflux."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_miniflux import (
+    MinifluxAdapterError,
+    MinifluxProviderUnavailableError,
+    PageRequest,
+)
+from _knowledge_social_miniflux_identity import account_id, user_id
+from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
+from knowledge_social_import import reject_credentials
+
+READ_TIMEOUT_SECONDS = 120
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+SAFE_PROVIDER_FAILURES = (
+    "Python urllib HTTP exports are unavailable",
+    "Miniflux profile name is invalid",
+    "Miniflux profile base URL is missing",
+    "Miniflux profile API token is missing",
+    "Miniflux profile origin key is missing",
+    "Miniflux profile base URL must be HTTPS",
+    "Miniflux profile origin key must be at least 32 bytes",
+    "selected Miniflux account does not match the configured connection",
+    "selected Miniflux installation does not match the connection",
+)
+
+
+class MinifluxReader(Protocol):
+    def identity(self, expected_id: str) -> dict[str, Any]: ...
+    def page(self, request: PageRequest) -> dict[str, Any]: ...
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    if len(output.encode()) > MAX_RESPONSE_BYTES:
+        raise MinifluxAdapterError("Miniflux read response exceeds the safety limit")
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise MinifluxAdapterError("Miniflux read provider returned no valid JSON") from error
+    if not isinstance(payload, dict):
+        raise MinifluxAdapterError("Miniflux read response root must be an object")
+    return payload
+
+
+def _provider_failure(stderr: str) -> MinifluxProviderUnavailableError:
+    for message in SAFE_PROVIDER_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return MinifluxProviderUnavailableError(message)
+    return MinifluxProviderUnavailableError("Miniflux read provider is unavailable")
+
+
+MINIFLUX_READER_POLICY = GuardedOAuthPolicy(
+    "Miniflux", "MINIFLUX", "MINIFLUX_READ_LOG", READ_TIMEOUT_SECONDS,
+    _decode_output, _provider_failure, MinifluxProviderUnavailableError,
+    ("BASE_URL", "API_TOKEN", "ORIGIN_KEY"), "",
+)
+
+
+class GuardedMiniflux(GuardedOAuthReader):
+    def __init__(self, helper: Path, profile: str) -> None:
+        super().__init__(helper, profile, MINIFLUX_READER_POLICY)
+
+
+def _fixture_object(value: Any, message: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise MinifluxAdapterError(message)
+    return value
+
+
+class FixtureMiniflux:
+    def __init__(self, path: Path) -> None:
+        self.fixture = FixtureSequence(path, "Miniflux", MinifluxAdapterError)
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        del expected_id
+        return self.fixture.identity()
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        entry = self.fixture.next_page()
+        expectation = _fixture_object(
+            entry.get("expect_request", {}),
+            "Miniflux fixture request expectation must be an object",
+        )
+        for key, value in expectation.items():
+            if request.payload().get(key) != value:
+                raise MinifluxAdapterError(
+                    "Miniflux request did not resume at the expected checkpoint"
+                )
+        return _fixture_object(
+            entry.get("response", entry),
+            "Miniflux fixture page response must be an object",
+        )
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise MinifluxAdapterError("Miniflux account verification returned no account")
+    local = user_id(data.get("user_id"))
+    if local != user_id(expected_id):
+        raise MinifluxAdapterError(
+            "selected Miniflux account does not match the configured connection"
+        )
+    instance = data.get("installation_id")
+    durable = account_id(instance, local)
+    if data.get("id") != durable:
+        raise MinifluxAdapterError("Miniflux account identity binding is invalid")
+    username = data.get("username")
+    if username is not None and (
+        not isinstance(username, str) or "\x00" in username or len(username.encode()) > 4096
+    ):
+        raise MinifluxAdapterError("Miniflux account username must be text")
+    return {
+        "id": durable, "installation_id": instance,
+        "user_id": local, "username": username,
+    }

--- a/.agents/scripts/_knowledge_social_miniflux_routes.py
+++ b/.agents/scripts/_knowledge_social_miniflux_routes.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Exact Miniflux GET routes and bounded response serializers."""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from datetime import datetime
+from typing import Any, Callable
+from xml.etree import ElementTree
+
+from _knowledge_social_miniflux import ENTRY_STREAMS, PageRequest
+from _knowledge_social_miniflux_contract import (
+    ApiResult,
+    MinifluxReadProviderError,
+    object_list,
+    object_value,
+    observed_at,
+    optional_text,
+)
+from _knowledge_social_miniflux_identity import resource_id, user_id
+
+Api = Callable[[str, dict[str, str]], ApiResult]
+PageResult = ApiResult | dict[str, Any]
+EXACT_READ_PATHS = frozenset({"/v1/me", "/v1/entries", "/v1/feeds", "/v1/categories", "/v1/export"})
+STREAM_PATHS = {
+    "entries": "/v1/entries", "read": "/v1/entries",
+    "removed": "/v1/entries", "starred": "/v1/entries",
+    "tags": "/v1/entries", "feeds": "/v1/feeds",
+    "categories": "/v1/categories", "opml": "/v1/export",
+}
+
+
+def allowlisted_path(path: str) -> bool:
+    return path in EXACT_READ_PATHS
+
+
+def query_keys_for_path(path: str) -> frozenset[str]:
+    if path == "/v1/entries":
+        return frozenset({"status", "starred", "order", "direction", "limit", "after_entry_id", "changed_after"})
+    if path == "/v1/categories":
+        return frozenset({"counts"})
+    return frozenset()
+
+
+def _integer(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise MinifluxReadProviderError(f"Miniflux {field} is invalid")
+    return value
+
+
+def _entry(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    entry_id = _integer(item.get("id"), "entry ID")
+    if user_id(item.get("user_id")) != request.user_id:
+        raise MinifluxReadProviderError("Miniflux entry belongs to another account")
+    tags = item.get("tags", [])
+    if tags is None:
+        tags = []
+    if not isinstance(tags, list) or any(not isinstance(tag, str) or not tag for tag in tags):
+        raise MinifluxReadProviderError("Miniflux entry tags are invalid")
+    return {
+        "kind": "entry",
+        "remote_id": resource_id(request.installation_id, "entry", entry_id),
+        "entry_id": entry_id,
+        "title": optional_text(item.get("title"), "entry title"),
+        "body": optional_text(item.get("content"), "entry content"),
+        "url": optional_text(item.get("url"), "entry URL"),
+        "author": optional_text(item.get("author"), "entry author"),
+        "published_at": optional_text(item.get("published_at"), "published timestamp"),
+        "created_at": optional_text(item.get("created_at"), "created timestamp"),
+        "changed_at": optional_text(item.get("changed_at"), "changed timestamp"),
+        "status": optional_text(item.get("status"), "entry status"),
+        "starred": item.get("starred") if isinstance(item.get("starred"), bool) else None,
+        "tags": tags,
+    }
+
+
+def _entry_records(items: list[dict[str, Any]], request: PageRequest) -> list[dict[str, Any]]:
+    entries = [_entry(item, request) for item in items]
+    if request.stream != "tags":
+        return entries
+    records: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        for tag in entry["tags"]:
+            remote = resource_id(request.installation_id, "tag", tag.casefold())
+            records[remote] = {
+                "kind": "tag", "remote_id": remote, "title": tag,
+                "changed_at": entry.get("changed_at"), "entry_remote_id": entry["remote_id"],
+            }
+    return list(records.values())
+
+
+def _snapshot_records(payload: Any, request: PageRequest) -> list[dict[str, Any]]:
+    items = object_list(payload, f"{request.stream} response", limit=request.limit)
+    records = []
+    for item in items:
+        remote_numeric = _integer(item.get("id"), f"{request.stream} ID")
+        if user_id(item.get("user_id")) != request.user_id:
+            raise MinifluxReadProviderError(f"Miniflux {request.stream} item belongs to another account")
+        kind = "feed" if request.stream == "feeds" else "category"
+        records.append({
+            "kind": kind,
+            "remote_id": resource_id(request.installation_id, kind, remote_numeric),
+            "title": optional_text(item.get("title"), f"{kind} title"),
+            "url": optional_text(item.get("feed_url"), "feed URL") if kind == "feed" else None,
+        })
+    return records
+
+
+def _opml_records(payload: Any, request: PageRequest) -> list[dict[str, Any]]:
+    if not isinstance(payload, str) or len(payload.encode()) > 8 * 1024 * 1024:
+        raise MinifluxReadProviderError("Miniflux OPML response is invalid")
+    try:
+        root = ElementTree.fromstring(payload)
+    except ElementTree.ParseError as error:
+        raise MinifluxReadProviderError("Miniflux OPML response is invalid") from error
+    outlines = [node for node in root.iter("outline") if node.attrib.get("xmlUrl")]
+    if len(outlines) > request.limit:
+        raise MinifluxReadProviderError("Miniflux OPML response exceeds the item safety limit")
+    return [
+        {
+            "kind": "feed",
+            "remote_id": resource_id(
+                request.installation_id, "opml_feed",
+                hashlib.sha256(node.attrib["xmlUrl"].encode()).hexdigest(),
+            ),
+            "title": optional_text(node.attrib.get("title", node.attrib.get("text")), "OPML title"),
+            "url": optional_text(node.attrib.get("xmlUrl"), "OPML feed URL"),
+            "category": optional_text(node.attrib.get("category"), "OPML category"),
+        }
+        for node in outlines
+    ]
+
+
+def _changed_epoch(items: list[dict[str, Any]]) -> int | None:
+    values = []
+    for item in items:
+        value = item.get("changed_at")
+        if value is not None:
+            try:
+                values.append(int(datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()))
+            except (AttributeError, ValueError) as error:
+                raise MinifluxReadProviderError("Miniflux changed timestamp is invalid") from error
+    return max(values) if values else None
+
+
+def page(api: Api, request: PageRequest) -> PageResult:
+    path = STREAM_PATHS[request.stream]
+    params: dict[str, str] = {}
+    if request.stream in ENTRY_STREAMS:
+        params = {
+            "order": "id", "direction": "asc", "limit": str(request.limit),
+            "after_entry_id": str(request.after_entry_id),
+        }
+        if request.changed_after is not None:
+            params["changed_after"] = str(request.changed_after)
+        if request.stream in {"read", "removed"}:
+            params["status"] = request.stream
+        elif request.stream == "starred":
+            params["starred"] = "true"
+    elif request.stream == "categories":
+        params = {"counts": "true"}
+    result = api(path, params)
+    if result.status != 200:
+        return result
+    if request.stream in ENTRY_STREAMS:
+        root = object_value(result.payload, "entries response")
+        items = object_list(root.get("entries"), "entries", limit=request.limit)
+        entries = [_entry(item, request) for item in items]
+        entry_ids = [item["entry_id"] for item in entries]
+        if entry_ids != sorted(entry_ids) or any(
+            entry_id <= request.after_entry_id for entry_id in entry_ids
+        ):
+            raise MinifluxReadProviderError("Miniflux entry IDs are not ascending")
+        records = _entry_records(items, request)
+        next_id = max((item["entry_id"] for item in entries), default=request.after_entry_id)
+        has_more = len(items) == request.limit and next_id > request.after_entry_id
+        watermark = _changed_epoch(entries) or int(time.time())
+    elif request.stream == "opml":
+        records = _opml_records(result.payload, request)
+        next_id, has_more, watermark = 0, False, None
+    else:
+        records = _snapshot_records(result.payload, request)
+        next_id, has_more, watermark = 0, False, None
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": records,
+        "meta": {
+            "stream": request.stream,
+            "has_more": has_more,
+            "next_after_entry_id": next_id,
+            "watermark": watermark,
+            "snapshot": request.stream not in ENTRY_STREAMS,
+        },
+    }

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -18,6 +18,7 @@ NODEBB_HELPER="${SCRIPT_DIR}/knowledge_social_nodebb.py"
 MASTODON_HELPER="${SCRIPT_DIR}/knowledge_social_mastodon.py"
 GITHUB_HELPER="${SCRIPT_DIR}/knowledge_social_github.py"
 STACK_EXCHANGE_HELPER="${SCRIPT_DIR}/knowledge_social_stack_exchange.py"
+MINIFLUX_HELPER="${SCRIPT_DIR}/knowledge_social_miniflux.py"
 QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
 SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
 SHARE_HELPER="${SCRIPT_DIR}/knowledge_social_share.py"
@@ -133,6 +134,12 @@ Stack Exchange synchronization:
   exhaustion, continue only while has_more, and cap pages at 100 items.
   --budget is 3-1000 and --page-size is 1-100.
 
+Miniflux synchronization:
+  sync-miniflux binds one user ID to a keyed exact HTTPS installation before
+  every page. Entries, read, removed, starred, tags, feeds, categories, and OPML
+  use GET-only routes. Entry streams resume by ascending ID and overlap
+  changed_after by one second. --budget is 3-1000 and --page-size is 1-100.
+
 EOF
 	return 0
 }
@@ -190,6 +197,10 @@ Usage:
     [--collector-id ID] [--lease-seconds SECONDS]
   knowledge-social-helper.sh sync-stack-exchange [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id NETWORK_ACCOUNT_ID --stream STREAM \
+    --profile PROFILE [--budget UNITS] [--page-size 1-100] \
+    [--collector-id ID] [--lease-seconds SECONDS]
+  knowledge-social-helper.sh sync-miniflux [--base PATH] [--alias ALIAS] \
+    --connection-id ID --account-id USER_NUMERIC_ID --stream STREAM \
     --profile PROFILE [--budget UNITS] [--page-size 1-100] \
     [--collector-id ID] [--lease-seconds SECONDS]
   knowledge-social-helper.sh sync-due [--base PATH] [--alias ALIAS] \
@@ -379,6 +390,7 @@ run_named_provider_sync() {
 	sync-mastodon) run_provider_sync Mastodon "$MASTODON_HELPER" "$@" || return 1 ;;
 	sync-github) run_provider_sync GitHub "$GITHUB_HELPER" "$@" || return 1 ;;
 	sync-stack-exchange) run_provider_sync "Stack Exchange" "$STACK_EXCHANGE_HELPER" "$@" || return 1 ;;
+	sync-miniflux) run_provider_sync Miniflux "$MINIFLUX_HELPER" "$@" || return 1 ;;
 	*) return 1 ;;
 	esac
 	return 0
@@ -458,7 +470,7 @@ main() {
 		fi
 		python3 "$LINKEDIN_HELPER" "$@" || return 1
 		;;
-	sync-meta | sync-discourse | sync-nodebb | sync-mastodon | sync-github | sync-stack-exchange)
+	sync-meta | sync-discourse | sync-nodebb | sync-mastodon | sync-github | sync-stack-exchange | sync-miniflux)
 		run_named_provider_sync "$subcommand" "$@" || return 1
 		;;
 	query | annotate)

--- a/.agents/scripts/knowledge_social_miniflux.py
+++ b/.agents/scripts/knowledge_social_miniflux.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one bounded Miniflux account stream into a social corpus."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import _knowledge_social_miniflux as miniflux
+from _knowledge_social_miniflux_normalize import PageContext, normalize_page
+from _knowledge_social_miniflux_reader import FixtureMiniflux, GuardedMiniflux, verified_identity
+from _knowledge_social_oauth_collector import OAuthCollectorPolicy, run_oauth_collector
+
+
+def _policy() -> OAuthCollectorPolicy:
+    return OAuthCollectorPolicy(
+        provider_module=miniflux,
+        verified_identity=verified_identity,
+        normalize_page=normalize_page,
+        page_context=PageContext,
+        display_name="Miniflux",
+        helper=Path(__file__).with_name("_knowledge_social_miniflux_provider.py"),
+        fixture_reader=FixtureMiniflux,
+        live_reader=GuardedMiniflux,
+        budget_unit="request",
+        max_page_size=100,
+    )
+
+
+def main() -> int:
+    return run_oauth_collector(_policy(), __doc__ or "")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/knowledge_social_registry.py
+++ b/.agents/scripts/knowledge_social_registry.py
@@ -53,6 +53,7 @@ PROVIDER_SPECS = (
     ProviderSpec("gumroad", (), "knowledge_social_gumroad.py", (("live", ()),)),
     ProviderSpec("github", (), "knowledge_social_github.py", (("live", ()),)),
     ProviderSpec("mastodon", (), "knowledge_social_mastodon.py", (("live", ()),)),
+    ProviderSpec("miniflux", (), "knowledge_social_miniflux.py", (("live", ()),)),
     ProviderSpec(
         "stack-exchange",
         ("stackexchange",),

--- a/.agents/tests/test-knowledge-social-miniflux.sh
+++ b/.agents/tests/test-knowledge-social-miniflux.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-miniflux.sh — Bounded Miniflux collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MINIFLUX_SCRIPT="${SCRIPT_DIR}/../scripts/knowledge_social_miniflux.py"
+SOCIAL_HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TEMP_PARENT="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+mkdir -p "$TEMP_PARENT"
+TMP_DIR=$(mktemp -d "${TEMP_PARENT}/miniflux-social-test.XXXXXX")
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' \
+			"$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c 'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_count() {
+	python3 - "$ROOT/sources/social/raw/miniflux" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+print(len(list(root.rglob("*.json.gz"))) if root.exists() else 0)
+PY
+	return 0
+}
+
+run_miniflux() {
+	local fixture="$1"
+	local connection_id="$2"
+	local stream="$3"
+	local budget="$4"
+	local page_size="$5"
+	if python3 "$MINIFLUX_SCRIPT" --base "$BASE" --alias personal:default \
+		--connection-id "$connection_id" --account-id user_7 \
+		--stream "$stream" --profile fixture --fixture "$fixture" \
+		--budget "$budget" --page-size "$page_size"; then
+		return 0
+	fi
+	return 1
+}
+
+expect_failure() {
+	local description="$1"
+	local fixture="$2"
+	local connection_id="$3"
+	local stream="$4"
+	if run_miniflux "$fixture" "$connection_id" "$stream" 7 40 >/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$SOCIAL_HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'Miniflux social collector tests\n'
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import ast
+import json
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+
+from _knowledge_social_collect import CursorState
+from _knowledge_social_miniflux import PageRequest, STREAMS, page_checkpoint, page_request
+from _knowledge_social_miniflux_contract import ApiResult, identity_value
+from _knowledge_social_miniflux_http import HTTP_TIMEOUT_SECONDS, ProfileConfig, api
+from _knowledge_social_miniflux_identity import account_id, installation_id, resource_id
+from _knowledge_social_miniflux_routes import allowlisted_path, page
+
+assert set(STREAMS) == {
+    "entries", "read", "removed", "starred", "tags", "feeds", "categories", "opml",
+}
+for allowed in ("/v1/me", "/v1/entries", "/v1/feeds", "/v1/categories", "/v1/export"):
+    assert allowlisted_path(allowed)
+for rejected in ("/v1/entries/1", "/v1/import", "/v1/feeds/1/refresh", "/v1/api-keys"):
+    assert not allowlisted_path(rejected)
+
+instance = installation_id("https://reader.example.test/miniflux", "o" * 32)
+identity = identity_value({"id": 7, "username": "reader"}, "7", instance)
+assert identity["id"] == account_id(instance, 7)
+assert resource_id(instance, "entry", 1) != resource_id(instance, "entry", 2)
+
+request = PageRequest("entries", identity["id"], instance, "7", 0, None, 1)
+entry = {
+    "id": 9, "user_id": 7, "title": "Bounded feed item",
+    "content": "Miniflux knowledge", "published_at": "2026-08-02T06:00:00Z",
+    "created_at": "2026-08-02T06:00:01Z", "changed_at": "2026-08-02T06:00:02Z",
+    "status": "read", "starred": True, "tags": ["research"],
+}
+payload = page(lambda _path, _params: ApiResult(200, {"total": 1, "entries": [entry]}), request)
+assert payload["data"][0]["title"] == "Bounded feed item"
+assert payload["meta"]["has_more"] is True
+checkpoint, complete = page_checkpoint(payload, CursorState(None, None, False), request)
+assert not complete and checkpoint.next_cursor is not None and checkpoint.watermark is not None
+resumed = page_request("entries", identity, CursorState(checkpoint.next_cursor, checkpoint.watermark, False), 1)
+assert resumed.after_entry_id == 9
+incremental = page_request("entries", identity, CursorState(None, checkpoint.watermark, True), 1)
+assert incremental.changed_after == int(checkpoint.watermark) - 1
+try:
+    page(
+        lambda _path, _params: ApiResult(200, {"entries": [entry]}),
+        PageRequest("entries", identity["id"], instance, "7", 9, None, 1),
+    )
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("non-advancing Miniflux entry page was accepted")
+
+opml = page(
+    lambda _path, _params: ApiResult(200, '<opml><body><outline text="Feed" xmlUrl="https://feed.example/rss"/></body></opml>'),
+    PageRequest("opml", identity["id"], instance, "7", 0, None, 5),
+)
+assert len(opml["data"]) == 1 and opml["meta"]["snapshot"] is True
+
+
+class Headers:
+    def get(self, _key, default=None):
+        return default
+
+
+class Response:
+    status = 200
+    headers = Headers()
+
+    def __init__(self, payload):
+        self.payload = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def read(self, size=-1):
+        return self.payload[:size]
+
+
+class Opener:
+    def __init__(self, response):
+        self.response = response
+        self.request = None
+
+    def open(self, request, timeout):
+        assert timeout == HTTP_TIMEOUT_SECONDS and request.method == "GET"
+        assert request.get_header("X-auth-token") == "private-token"
+        assert "private-token" not in request.full_url
+        self.request = request
+        return self.response
+
+
+config = ProfileConfig("https://reader.example.test/miniflux", "private-token", "o" * 32, instance)
+opener = Opener(Response({"entries": []}))
+api(config, opener, "/v1/entries", {"order": "id", "direction": "asc", "limit": "1", "after_entry_id": "0"})
+assert opener.request.full_url.startswith("https://reader.example.test/miniflux/v1/entries?")
+try:
+    api(config, opener, "/v1/import", {})
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("Miniflux mutation route was accepted")
+
+sources = [path.read_text(encoding="utf-8") for path in sorted(scripts.glob("_knowledge_social_miniflux*.py"))]
+trees = [ast.parse(source) for source in sources]
+request_calls = [
+    node for tree in trees for node in ast.walk(tree)
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "Request"
+]
+assert request_calls
+for node in request_calls:
+    methods = [
+        keyword.value.value for keyword in node.keywords
+        if keyword.arg == "method" and isinstance(keyword.value, ast.Constant)
+    ]
+    assert methods == ["GET"]
+PY
+assert_eq "identity, routes, incremental overlap, OPML, and GET-only AST are guarded" \
+	verified verified
+
+python3 - "$TMP_DIR/complete.json" <<'PY'
+import json
+import sys
+
+sys.path.insert(0, ".agents/scripts")
+from _knowledge_social_miniflux_identity import account_id, installation_id, resource_id
+
+instance = installation_id("https://reader.example.test/miniflux", "o" * 32)
+durable = account_id(instance, 7)
+payload = {
+    "identity": {"data": {
+        "id": durable, "installation_id": instance, "user_id": "7", "username": "reader",
+    }},
+    "pages": [{
+        "expect_request": {"after_entry_id": 0, "changed_after": None, "limit": 1},
+        "response": {
+            "status": 200, "observed_at": "2026-08-02T06:30:00Z",
+            "data": [{
+                "kind": "entry", "remote_id": resource_id(instance, "entry", 9),
+                "entry_id": 9, "title": "Bounded feed item", "body": "Miniflux knowledge",
+                "created_at": "2026-08-02T06:00:01Z", "changed_at": "2026-08-02T06:00:02Z",
+                "status": "read", "starred": True, "tags": ["research"],
+            }],
+            "meta": {"stream": "entries", "has_more": False,
+                     "next_after_entry_id": 9, "watermark": 1785650402, "snapshot": False},
+        },
+    }],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+result=$(run_miniflux "$TMP_DIR/complete.json" conn_miniflux entries 3 1)
+assert_eq "bounded Miniflux fixture completes" "$(json_field "$result" status)" complete
+assert_eq "identity plus page consumes three request units" \
+	"$(json_field "$result" budget_units)" 3
+assert_eq "Miniflux entry text reaches FTS" \
+	"$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'knowledge'")" 1
+
+python3 - "$TMP_DIR/mismatch.json" <<'PY'
+import json
+import sys
+
+payload = {"identity": {"data": {
+    "id": "wrong", "installation_id": "miniflux_wrong", "user_id": "8",
+}}, "pages": []}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+raw_before=$(raw_count)
+expect_failure "selected-account identity mismatch is rejected" \
+	"$TMP_DIR/mismatch.json" conn_mismatch entries
+assert_eq "identity mismatch persists no raw evidence" "$(raw_count)" "$raw_before"
+
+python3 - "$TMP_DIR/credential.json" <<'PY'
+import json
+import sys
+
+sys.path.insert(0, ".agents/scripts")
+from _knowledge_social_miniflux_identity import account_id, installation_id
+
+instance = installation_id("https://reader.example.test/miniflux", "o" * 32)
+payload = {
+    "identity": {"data": {"id": account_id(instance, 7),
+                             "installation_id": instance, "user_id": "7"}},
+    "pages": [{"status": 200, "observed_at": "2026-08-02T06:31:00Z",
+               "api_token": "must-not-persist", "data": [],
+               "meta": {"stream": "feeds", "has_more": False,
+                        "next_after_entry_id": 0, "watermark": None, "snapshot": True}}],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+raw_before=$(raw_count)
+expect_failure "credential-shaped Miniflux page is rejected" \
+	"$TMP_DIR/credential.json" conn_credential feeds
+assert_eq "credential rejection persists no raw evidence" "$(raw_count)" "$raw_before"
+
+assert_eq "operator-retention and archive gaps remain explicit" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE connection_id='conn_miniflux' AND status='unavailable'")" 4
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/tests/test-knowledge-social-registry.sh
+++ b/.agents/tests/test-knowledge-social-registry.sh
@@ -47,6 +47,7 @@ expected = {
     "google-business-profile": ("live",),
     "gumroad": ("live",),
     "mastodon": ("live",),
+    "miniflux": ("live",),
     "nextcloud-talk": ("live",),
     "signal": ("inspect", "manual-import", "status"),
     "slack": ("archive", "live"),
@@ -94,14 +95,14 @@ except module.ProviderRegistryError:
 else:
     raise SystemExit("unknown provider used a fallback")
 
-print("14:order-independent:aliases-exact:collisions-rejected:no-fallback")
+print("15:order-independent:aliases-exact:collisions-rejected:no-fallback")
 PY
 )
 assert_eq "all merged provider outcomes register deterministically" \
-	"$registry_summary" "14:order-independent:aliases-exact:collisions-rejected:no-fallback"
+	"$registry_summary" "15:order-independent:aliases-exact:collisions-rejected:no-fallback"
 
 provider_count=$("$HELPER" providers | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
-assert_eq "helper exposes the complete provider registry" "$provider_count" "14"
+assert_eq "helper exposes the complete provider registry" "$provider_count" "15"
 
 forem_resolution=$("$HELPER" provider-resolve --provider dev-community |
 	python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["provider"] + ":" + ",".join(data["modes"]))')


### PR DESCRIPTION
## Summary

Add a keyed-installation Miniflux collector with eight independent account streams, exact GET-only transport, ascending entry-ID backfill, changed-after overlap, bounded snapshots, OPML replay, registry routing, documentation, and fixture coverage.

## Files Changed

.agents/aidevops/knowledge-plane/05-social-operations.md, .agents/aidevops/knowledge-plane/06-social-provider-capabilities.md, .agents/content/social-miniflux.md, .agents/scripts/_knowledge_social_miniflux.py, .agents/scripts/_knowledge_social_miniflux_contract.py, .agents/scripts/_knowledge_social_miniflux_http.py, .agents/scripts/_knowledge_social_miniflux_identity.py, .agents/scripts/_knowledge_social_miniflux_normalize.py, .agents/scripts/_knowledge_social_miniflux_provider.py, .agents/scripts/_knowledge_social_miniflux_reader.py, .agents/scripts/_knowledge_social_miniflux_routes.py, .agents/scripts/knowledge-social-helper.sh, .agents/scripts/knowledge_social_miniflux.py, .agents/scripts/knowledge_social_registry.py, .agents/tests/test-knowledge-social-miniflux.sh, .agents/tests/test-knowledge-social-registry.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — 9 Miniflux collector tests, 8 registry tests, 35 social-sync tests, and 33 social-corpus tests pass; Python compilation, ShellCheck, Qlty smells, and changed-file local linters pass.

Resolves #29224


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 6h 21m and 3,713,099 tokens on this with the user in an interactive session.