### PR TITLE
GH#29225: Add bounded Readwise Reader collector

### DIFF
--- a/.agents/aidevops/knowledge-plane/05-social-operations.md
+++ b/.agents/aidevops/knowledge-plane/05-social-operations.md
@@ -39,8 +39,8 @@ transaction without rewriting raw gzip artifacts, cursors, coverage, or provider
 rows. Replay preserves both evidence and projection IDs.
 
 Candidate implementation is provider-specific, not one generic social adapter.
-Mastodon #29221, GitHub #29222, Stack Exchange #29223, and Miniflux #29224 are
-now live. The remaining ranked children are Readwise Reader #29225, FreshRSS
+Mastodon #29221, GitHub #29222, Stack Exchange #29223, Miniflux #29224, and
+Readwise Reader #29225 are now live. The remaining ranked children are FreshRSS
 issue #29226, Lemmy issue #29227, then public-only Hacker News #29228. Each
 route owns its identity
 contract, stream allowlist, checkpoint semantics, and negative write-reachability
@@ -95,6 +95,15 @@ ascending ID; later runs use `changed_after` with a one-second overlap. Only fiv
 exact GET routes are reachable despite mutation-capable API keys. Operator cleanup,
 pre-retention state, complete archives, and deletion inference remain explicit
 gaps. Details: `.agents/content/social-miniflux.md`.
+
+Readwise Reader collection compensates for `/api/v2/auth/` returning no stable
+account ID by requiring a deployment-owned account identifier and keyed expected
+token binding. A wrong but valid token fails before network collection. Documents,
+tags, notes, state, progress, locations, and optional HTML use independent opaque
+cursors with one-second `updatedAfter` overlap. Only fixed-origin auth, list, and
+tag GET routes are reachable; each invocation is capped below the documented
+20-request/minute limit. Provider identity, deletion, complete export, and
+retention remain explicit gaps. Details: `.agents/content/social-readwise-reader.md`.
 
 X collection uses the guarded official `xurl` helper. Reddit collection uses an
 optional PRAW 8 child. YouTube collection uses a standard-library HTTP child and

--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -46,6 +46,7 @@ a claim that the route is enabled.
 | GitHub | **Live/Partial** contribution calendar and repositories | **Live/Partial** stars and subscriptions; **No** complete reactions | **Live/Gate/Partial** notifications | **Live/Gate/Partial** followers, following, and organizations | **Live/Gate/Partial** user lists and visible Projects v2 | Ten numeric/node-identity-bound streams preserve REST `Link` and GraphQL `pageInfo` cursors; token family, visibility, migration expiry, deletion, and audit authority remain explicit. |
 | Stack Exchange | **Live/Partial** posts, questions, answers, and comments | **Live/Partial** favourites; **No** complete votes | **Live/Gate/Partial** inbox and notifications | **Live/Partial** associated site accounts; **No** follows | **No** | Eight network-plus-site-identity-bound GET streams obey `has_more`, `backoff`, quota, and 100-item page limits while preserving archive and inaccessible-history gaps. |
 | Miniflux | **Live/Partial** feed entries | **Live/Partial** read, removed, starred, and tagged state | **No** | **Live/Partial/Export** subscriptions | **Live/Partial/Export** categories and tags | Eight keyed-installation account streams use five exact GET routes, ascending entry-ID backfill, one-second `changed_after` overlap, bounded snapshots, and explicit operator-retention gaps. |
+| Readwise Reader | **Live/Gate/Partial** saved documents and optional HTML | **Live/Gate/Partial** notes, state, progress, and tags | **No** | **No** | **Live/Gate/Partial** tags and locations | Seven deployment-bound streams preserve opaque cursors, overlap `updatedAfter`, cap invocations below 20 requests/minute, and expose the provider identity/export boundary. |
 
 ## Integrated provider families
 
@@ -82,7 +83,7 @@ separate provider family.
 | Hacker News | **API/Partial** public submissions and comments | **No** private votes or saved items | **No** | **No** | **No** | Rank 8, #29228. Bounded public history only, keyed by case-sensitive username and item ID; never infer private state. |
 | Miniflux | **Live/Partial** feed items | **Live/Partial** read, removed, starred, and tagged state | **No** | **Live/Partial/Export** subscriptions | **Live/Partial/Export** categories/tags | #29224 implements keyed installation/user identity, exact GET-only routes, incremental overlap, snapshots, and explicit operator-retention gaps. |
 | FreshRSS | **API/Export** feed items | **API** unread and starred state | **No** | **API/Export** subscriptions | **API/Export** folders/tags | Rank 6, #29226. Allow one non-mutating login POST, then GET-only Google Reader collection; reconcile OPML and keep Fever fallback-only. |
-| Readwise Reader | **API/Export** saved documents | **API/Export** tags, state, notes, and progress | **No** | **No** | **API/Export** tags and locations | Rank 5, #29225. Strong cursor/update contract, but implementation is gated on expected-account binding because token validation has no stable account ID. |
+| Readwise Reader | **Live/Gate/Partial** saved documents | **Live/Gate/Partial** tags, state, notes, and progress | **No** | **No** | **Live/Gate/Partial** tags and locations | #29225 implements a deployment-owned account/token binding because official token validation exposes no stable account ID, plus fixed-origin GET-only cursor reads. |
 | Other readers/read-later | **API/Export/Gate/No** | **API/Export/Gate/No** | **No** | **API/Export/Gate/No** | **API/Export/Gate/No** | Raindrop optional; Inoreader and Wallabag deferred; Feedly and Pocket rejected; Instapaper remains unverified. |
 
 ## Evidence and update discipline
@@ -192,6 +193,16 @@ separate provider family.
   `.agents/content/social-miniflux.md` records official current identity, entries,
   feed, category, OPML, authentication, version, and operator-retention evidence
   checked on 2026-08-02.
+- **Live/Gated Readwise Reader:**
+  `.agents/scripts/knowledge_social_readwise_reader.py`,
+  `.agents/scripts/_knowledge_social_readwise_reader*.py`, and
+  `.agents/tests/test-knowledge-social-readwise-reader.sh` prove independent
+  deployment account/token binding, seven streams, opaque resume,
+  `updatedAfter` overlap, request-rate budgeting, exact GET-only routes,
+  credential rejection, terminal coverage, and atomic persistence.
+  `.agents/content/social-readwise-reader.md` records official auth, document,
+  tag, cursor, HTML, rate, privacy, export, retention, and terms evidence checked
+  on 2026-08-02.
 - **Integrated provider registry:** `.agents/scripts/knowledge_social_registry.py`
   and `.agents/tests/test-knowledge-social-registry.sh` prove order-independent
   registration, collision rejection, exact aliases and modes, no-route failure,

--- a/.agents/content/social-readwise-reader.md
+++ b/.agents/content/social-readwise-reader.md
@@ -1,0 +1,43 @@
+# Readwise Reader Account Knowledge Evidence
+
+Checked 2026-08-02 against the official Reader API, privacy policy, and terms.
+
+## Implemented evidence
+
+- `GET /api/v2/auth/` returns `204` for a valid token but no stable account ID.
+  Live collection therefore requires a deployment-owned account identifier,
+  binding key, and expected HMAC of that identifier plus access token. A wrong but
+  valid token cannot silently collect another account; token rotation requires an
+  intentional expected-binding update.
+- `GET /api/v3/list/` returns up to 100 documents and an opaque
+  `nextPageCursor`. `updatedAfter`, category filters, and optional
+  `withHtmlContent` support bounded document, note, state, progress, location, and
+  HTML streams with one-second update overlap.
+- `GET /api/v3/tags/` supplies a separately checkpointed opaque-cursor tag stream.
+- Document results include tags, notes, location, category, reading progress,
+  parent relationships, timestamps, summary, and optional HTML. The collector
+  emits only explicit allowlisted fields.
+- List and tag routes are documented at 20 requests per minute per token. The
+  collector caps each invocation at 19 requests including initial identity and
+  per-page identity rebinding, and preserves `Retry-After` on `429` responses.
+- No Readwise or Reader client package is installed. Python 3.14.3 standard-library
+  HTTP exports were verified locally and provide fixed-origin, redirect-free GETs.
+
+## Explicit boundaries
+
+- The official API supplies no provider-owned stable account identifier. Local
+  deployment binding is mandatory and remains an explicit **Gate**, not a claim
+  of provider identity parity.
+- List responses do not prove complete deletion history or a complete account
+  export. Privacy controls provide a separate user export route.
+- The privacy policy says retention depends on purpose, sensitivity, risk, and
+  legal requirements. The terms allow service storage practices and limits to
+  change and disclaim failure-to-store liability.
+- Reader save, update, bulk-update, delete, and webhook-management routes are
+  unreachable. Only the fixed auth, document-list, and tag-list GET paths exist.
+
+## Official references
+
+- <https://readwise.io/reader_api>
+- <https://readwise.io/privacy>
+- <https://readwise.io/tos>

--- a/.agents/scripts/_knowledge_social_readwise_reader.py
+++ b/.agents/scripts/_knowledge_social_readwise_reader.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Readwise Reader stream policy and opaque cursor checkpoints."""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from _knowledge_social_readwise_reader_identity import (
+    ReadwiseReaderAdapterError,
+    ReadwiseReaderProviderUnavailableError,
+    binding_account_id,
+)
+from knowledge_social_import import canonical_json, reject_credentials
+
+PROVIDER = "readwise-reader"
+CURSOR_PREFIX = "readwise-reader-v1:"
+RETENTION_LIMIT = "service_retention_deletion_and_export_boundary"
+MAX_PAGE_ITEMS = 100
+
+ADAPTER_ERROR = ReadwiseReaderAdapterError
+PROVIDER_UNAVAILABLE_ERROR = ReadwiseReaderProviderUnavailableError
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    resource_kind: str
+    activity_mode: str
+    pagination: str = "opaque_page_cursor"
+    incremental: bool = True
+    retention_limit: str | None = RETENTION_LIMIT
+    coverage_status: str | None = "partial"
+    unavailable_reason: str | None = "service_retention_and_api_history_bound"
+    cost_units: int = 2
+
+
+STREAMS = {
+    "documents": StreamSpec("document", "selected_account"),
+    "tags": StreamSpec("tag", "selected_account", incremental=False),
+    "notes": StreamSpec("note", "selected_account"),
+    "state": StreamSpec("document_state", "selected_account"),
+    "progress": StreamSpec("reading_progress", "selected_account"),
+    "locations": StreamSpec("location", "selected_account"),
+    "html": StreamSpec("document", "selected_account"),
+}
+
+
+@dataclass(frozen=True)
+class PageRequest:
+    stream: str
+    account_id: str
+    binding_account_id: str
+    page_cursor: str | None
+    updated_after: str | None
+    limit: int
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "page", "stream": self.stream,
+            "account_id": self.account_id,
+            "binding_account_id": self.binding_account_id,
+            "page_cursor": self.page_cursor,
+            "updated_after": self.updated_after, "limit": self.limit,
+        }
+
+    def evidence_key(self) -> str:
+        return canonical_json(self.payload())
+
+
+PAGE_REQUEST_KEYS = frozenset(PageRequest.__dataclass_fields__) | {"action"}
+
+
+def _text(value: Any, field: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str) or not value or "\x00" in value or len(value.encode()) > 4096:
+        raise ReadwiseReaderAdapterError(f"Readwise Reader {field} is invalid")
+    return value
+
+
+def _updated_after(value: Any) -> str | None:
+    text = _text(value, "updatedAfter", optional=True)
+    if text is None:
+        return None
+    try:
+        datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ReadwiseReaderAdapterError("Readwise Reader updatedAfter is invalid") from error
+    return text
+
+
+def _overlap(value: str) -> str:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00")) - timedelta(seconds=1)
+    return parsed.isoformat().replace("+00:00", "Z")
+
+
+def _encode_cursor(cursor: str, updated_after: str | None) -> str:
+    encoded = base64.urlsafe_b64encode(
+        canonical_json({"cursor": cursor, "updated_after": updated_after}).encode()
+    ).decode().rstrip("=")
+    return f"{CURSOR_PREFIX}{encoded}"
+
+
+def _decode_cursor(cursor: str) -> tuple[str, str | None]:
+    if not cursor.startswith(CURSOR_PREFIX):
+        raise ReadwiseReaderAdapterError("stored Readwise Reader cursor has an unsupported version")
+    try:
+        raw = cursor.removeprefix(CURSOR_PREFIX)
+        payload = json.loads(base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4)))
+    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+        raise ReadwiseReaderAdapterError("stored Readwise Reader cursor is invalid") from error
+    if not isinstance(payload, dict) or set(payload) != {"cursor", "updated_after"}:
+        raise ReadwiseReaderAdapterError("stored Readwise Reader cursor has an invalid shape")
+    reject_credentials(payload)
+    return _text(payload.get("cursor"), "page cursor") or "", _updated_after(payload.get("updated_after"))
+
+
+def page_request(stream: str, account: dict[str, Any], state: CursorState, limit: int) -> PageRequest:
+    if stream not in STREAMS:
+        raise ReadwiseReaderAdapterError("Readwise Reader stream is unsupported")
+    cursor, updated = _decode_cursor(state.cursor) if state.cursor else (None, None)
+    if stream != "tags" and state.backfill_complete and not state.cursor:
+        if state.watermark is None:
+            raise ReadwiseReaderAdapterError("stored Readwise Reader watermark is invalid")
+        updated = _overlap(_updated_after(state.watermark) or "")
+    return PageRequest(
+        stream, _text(account.get("id"), "selected account ID") or "",
+        binding_account_id(account.get("binding_account_id")), cursor, updated, limit,
+    )
+
+
+def parse_page_request(payload: dict[str, Any]) -> PageRequest:
+    if set(payload) != PAGE_REQUEST_KEYS or payload.get("action") != "page":
+        raise ReadwiseReaderAdapterError("Readwise Reader request has an invalid action shape")
+    stream = payload.get("stream")
+    if not isinstance(stream, str) or stream not in STREAMS:
+        raise ReadwiseReaderAdapterError("Readwise Reader stream is unsupported")
+    limit = payload.get("limit")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= MAX_PAGE_ITEMS:
+        raise ReadwiseReaderAdapterError("Readwise Reader page size is invalid")
+    return PageRequest(
+        stream, _text(payload.get("account_id"), "selected account ID") or "",
+        binding_account_id(payload.get("binding_account_id")),
+        _text(payload.get("page_cursor"), "page cursor", optional=True),
+        _updated_after(payload.get("updated_after")), limit,
+    )
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise ReadwiseReaderAdapterError("Readwise Reader response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise ReadwiseReaderAdapterError("Readwise Reader page data must be an array")
+    return data
+
+
+def page_checkpoint(
+    payload: dict[str, Any], state: CursorState, request: PageRequest
+) -> tuple[PageCheckpoint, bool]:
+    meta = payload.get("meta")
+    if not isinstance(meta, dict) or meta.get("stream") != request.stream:
+        raise ReadwiseReaderAdapterError("Readwise Reader page provenance is invalid")
+    reject_credentials(meta)
+    if len(page_data(payload)) > request.limit:
+        raise ReadwiseReaderAdapterError("Readwise Reader page exceeds the item safety limit")
+    next_cursor = _text(meta.get("next_page_cursor"), "next page cursor", optional=True)
+    cursor = _encode_cursor(next_cursor, request.updated_after) if next_cursor else None
+    watermark = _updated_after(meta.get("watermark")) or state.watermark
+    return PageCheckpoint(cursor, watermark), next_cursor is None

--- a/.agents/scripts/_knowledge_social_readwise_reader_contract.py
+++ b/.agents/scripts/_knowledge_social_readwise_reader_contract.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validation primitives for bounded Readwise Reader responses."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_readwise_reader_identity import account_id, binding_account_id
+
+MAX_TEXT_BYTES = 2 * 1024 * 1024
+
+
+class ReadwiseReaderProviderError(RuntimeError):
+    """Raised for a privacy-safe local Reader provider failure."""
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    status: int
+    payload: Any
+    retry_after: int | None = None
+
+
+def observed_at() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def decode_json(payload: bytes, limit: int) -> Any:
+    if len(payload) > limit:
+        raise ReadwiseReaderProviderError("Readwise Reader JSON exceeds the safety limit")
+    try:
+        return json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ReadwiseReaderProviderError("Readwise Reader JSON is invalid") from error
+
+
+def request_object(payload: bytes, limit: int) -> dict[str, Any]:
+    value = decode_json(payload, limit)
+    if not isinstance(value, dict):
+        raise ReadwiseReaderProviderError("Readwise Reader request must be an object")
+    return value
+
+
+def object_value(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ReadwiseReaderProviderError(f"Readwise Reader {field} must be an object")
+    return value
+
+
+def object_list(value: Any, field: str, limit: int) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise ReadwiseReaderProviderError(f"Readwise Reader {field} must be an array")
+    if len(value) > limit:
+        raise ReadwiseReaderProviderError(f"Readwise Reader {field} exceeds the item limit")
+    return value
+
+
+def optional_text(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value or len(value.encode()) > MAX_TEXT_BYTES:
+        raise ReadwiseReaderProviderError(f"Readwise Reader {field} must be text")
+    return value
+
+
+def identity_value(binding_id: str, key: str) -> dict[str, Any]:
+    selected = binding_account_id(binding_id)
+    return {
+        "id": account_id(selected, key),
+        "binding_account_id": selected,
+    }
+
+
+def terminal_payload(result: ApiResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": result.status, "observed_at": observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload

--- a/.agents/scripts/_knowledge_social_readwise_reader_http.py
+++ b/.agents/scripts/_knowledge_social_readwise_reader_http.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Redirect-free, bounded GET transport for Readwise Reader."""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from _knowledge_social_readwise_reader_contract import (
+    ApiResult,
+    ReadwiseReaderProviderError,
+    decode_json,
+)
+from _knowledge_social_readwise_reader_routes import allowlisted_path, query_keys_for_path
+
+API_ORIGIN = "https://readwise.io"
+MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+HTTP_TIMEOUT_SECONDS = 60
+
+
+class Headers(Protocol):
+    def get(self, key: str, default: str | None = None) -> str | None: ...
+
+
+class Response(Protocol):
+    status: int
+    headers: Headers
+
+    def __enter__(self) -> Response: ...
+    def __exit__(self, *args: Any) -> None: ...
+    def read(self, size: int = -1) -> bytes: ...
+
+
+class Opener(Protocol):
+    def open(self, request: Request, timeout: int) -> Response: ...
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    access_token: str
+    binding_account_id: str
+    binding_key: str
+    expected_token_binding: str
+
+
+class _RejectRedirect(HTTPRedirectHandler):
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def _http_exports() -> Opener:
+    exports = (Request, build_opener, urlencode, HTTPRedirectHandler)
+    if not all(callable(item) for item in exports):
+        raise ReadwiseReaderProviderError("Python urllib HTTP exports are unavailable")
+    return build_opener(_RejectRedirect())
+
+
+def _retry_epoch(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    return int(time.time() + math.ceil(seconds))
+
+
+def _target_url(path: str, params: dict[str, str]) -> str:
+    if not allowlisted_path(path) or set(params) - query_keys_for_path(path):
+        raise ReadwiseReaderProviderError("Readwise Reader API route is not allowlisted")
+    if any(not isinstance(value, str) or "\x00" in value or len(value.encode()) > 4096 for value in params.values()):
+        raise ReadwiseReaderProviderError("Readwise Reader API query is invalid")
+    if "limit" in params and (not params["limit"].isdigit() or not 1 <= int(params["limit"]) <= 100):
+        raise ReadwiseReaderProviderError("Readwise Reader page size is invalid")
+    query = urlencode(params)
+    return f"{API_ORIGIN}{path}" + (f"?{query}" if query else "")
+
+
+def api(config: ProfileConfig, opener: Opener, path: str, params: dict[str, str]) -> ApiResult:
+    request = Request(
+        _target_url(path, params),
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Token {config.access_token}",
+            "User-Agent": "aidevops-readwise-reader-knowledge/1",
+        },
+        method="GET",
+    )
+    try:
+        with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", 200)
+            if isinstance(status, bool) or not isinstance(status, int):
+                raise ReadwiseReaderProviderError("Readwise Reader HTTP status is invalid")
+            if path == "/api/v2/auth/" and status == 204:
+                return ApiResult(status, {})
+            payload = response.read(MAX_RESPONSE_BYTES + 1)
+            if not isinstance(payload, bytes):
+                raise ReadwiseReaderProviderError("Readwise Reader HTTP response is invalid")
+            return ApiResult(status, decode_json(payload, MAX_RESPONSE_BYTES))
+    except HTTPError as error:
+        retry = error.headers.get("Retry-After") if error.headers is not None else None
+        return ApiResult(error.code, {}, _retry_epoch(retry))
+    except (TimeoutError, URLError, OSError) as error:
+        raise ReadwiseReaderProviderError("Readwise Reader request failed") from error

--- a/.agents/scripts/_knowledge_social_readwise_reader_identity.py
+++ b/.agents/scripts/_knowledge_social_readwise_reader_identity.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Deployment-owned Readwise Reader account and token binding."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import re
+from typing import Any
+
+from knowledge_social_store import SocialStoreError
+
+ACCOUNT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+BINDING = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ReadwiseReaderAdapterError(SocialStoreError):
+    """Raised when guarded Reader collection cannot continue safely."""
+
+
+class ReadwiseReaderProviderUnavailableError(ReadwiseReaderAdapterError):
+    """Raised when the bounded Reader HTTP child cannot complete a read."""
+
+
+def binding_account_id(value: Any) -> str:
+    if not isinstance(value, str) or ACCOUNT.fullmatch(value) is None:
+        raise ReadwiseReaderAdapterError("Readwise Reader account binding ID is invalid")
+    return value
+
+
+def token_binding(token: Any, account: Any, key: Any) -> str:
+    selected = binding_account_id(account)
+    if not isinstance(token, str) or not token or "\x00" in token:
+        raise ReadwiseReaderAdapterError("Readwise Reader access token is invalid")
+    if not isinstance(key, str) or len(key.encode()) < 32:
+        raise ReadwiseReaderAdapterError(
+            "Readwise Reader binding key must be at least 32 bytes"
+        )
+    return hmac.new(key.encode(), f"{selected}\0{token}".encode(), hashlib.sha256).hexdigest()
+
+
+def expected_binding(value: Any) -> str:
+    if not isinstance(value, str) or BINDING.fullmatch(value) is None:
+        raise ReadwiseReaderAdapterError(
+            "Readwise Reader expected token binding is invalid"
+        )
+    return value
+
+
+def verify_token_binding(token: str, account: str, key: str, expected: str) -> None:
+    actual = token_binding(token, account, key)
+    if not hmac.compare_digest(actual, expected_binding(expected)):
+        raise ReadwiseReaderAdapterError(
+            "Readwise Reader token does not match the deployment account binding"
+        )
+
+
+def account_id(account: Any, key: Any) -> str:
+    selected = binding_account_id(account)
+    if not isinstance(key, str) or len(key.encode()) < 32:
+        raise ReadwiseReaderAdapterError(
+            "Readwise Reader binding key must be at least 32 bytes"
+        )
+    digest = hmac.new(key.encode(), selected.encode(), hashlib.sha256).hexdigest()[:24]
+    return f"rwr_{digest}"
+
+
+def resource_id(kind: str, value: Any) -> str:
+    if not kind.replace("_", "").isalpha() or len(kind) > 32:
+        raise ReadwiseReaderAdapterError("Readwise Reader resource kind is invalid")
+    if not isinstance(value, str) or not value or "\x00" in value or len(value.encode()) > 4096:
+        raise ReadwiseReaderAdapterError("Readwise Reader resource identity is invalid")
+    digest = hashlib.sha256(value.encode()).hexdigest()[:32]
+    return f"rwr_{kind}_{digest}"

--- a/.agents/scripts/_knowledge_social_readwise_reader_normalize.py
+++ b/.agents/scripts/_knowledge_social_readwise_reader_normalize.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize Readwise Reader records into neutral evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_readwise_reader import (
+    PROVIDER,
+    RETENTION_LIMIT,
+    ReadwiseReaderAdapterError,
+    page_data,
+)
+from knowledge_social_import import reject_credentials
+
+PROVENANCE = "readwise_reader_api_v3"
+GAPS = (
+    ("provider_account_identity", "official_token_validation_has_no_stable_account_id"),
+    ("deleted_documents", "list_api_does_not_prove_complete_deletion_history"),
+    ("complete_export", "api_is_not_documented_as_a_complete_account_export"),
+    ("pre_retention_history", "service_storage_practices_may_change"),
+)
+OBJECT_TYPES = frozenset({"document", "tag", "note", "document_state", "reading_progress", "location"})
+
+
+@dataclass(frozen=True)
+class PageContext:
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def _text(record: dict[str, Any], key: str, required: bool = False) -> str | None:
+    value = record.get(key)
+    if value is None and not required:
+        return None
+    if not isinstance(value, str) or (required and not value) or "\x00" in value:
+        raise ReadwiseReaderAdapterError(f"Readwise Reader record {key} is invalid")
+    return value
+
+
+def _observed(payload: dict[str, Any]) -> str:
+    value = payload.get("observed_at")
+    if not isinstance(value, str) or not value:
+        raise ReadwiseReaderAdapterError("Readwise Reader observed_at is invalid")
+    return value
+
+
+def _coverage(observed: str) -> list[dict[str, Any]]:
+    return [{
+        "stream": stream, "earliest_at": None, "latest_at": None,
+        "cursor_exhausted": False, "retention_limit": RETENTION_LIMIT,
+        "unavailable_reason": reason, "status": "unavailable", "observed_at": observed,
+    } for stream, reason in GAPS]
+
+
+def _object(item: dict[str, Any], context: PageContext, observed: str) -> dict[str, Any]:
+    kind = item.get("kind")
+    if kind not in OBJECT_TYPES:
+        raise ReadwiseReaderAdapterError("Readwise Reader item kind is unsupported")
+    remote = _text(item, "remote_id", True)
+    body = "\n\n".join(value for key in ("title", "body", "notes", "html", "author") if (value := _text(item, key))) or None
+    provider_json = {"source": PROVENANCE, "stream": context.stream, "record": item}
+    reject_credentials(provider_json)
+    return {
+        "object_type": kind, "remote_id": remote,
+        "account_remote_id": context.account.get("id"), "text": body,
+        "created_at": _text(item, "created_at") or _text(item, "saved_at"),
+        "observed_at": observed, "evidence_class": "observed",
+        "provider_json": provider_json,
+    }
+
+
+def _activity(item: dict[str, Any], context: PageContext, observed: str) -> dict[str, Any]:
+    selected = _text(context.account, "id", True)
+    remote = _text(item, "remote_id", True)
+    return {
+        "activity_type": context.stream.removesuffix("s"),
+        "remote_id": f"{selected}_{context.stream}_{remote}",
+        "actor_remote_id": selected, "object_remote_id": remote,
+        "occurred_at": _text(item, "updated_at") or observed,
+        "observed_at": observed, "state": "active",
+        "provider_json": {"source": PROVENANCE, "stream": context.stream},
+    }
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    reject_credentials(payload)
+    observed = _observed(payload)
+    items = page_data(payload)
+    policy = dict(context.policy)
+    policy.update({
+        "reader_identity": "deployment_account_id_plus_hmac_token_binding",
+        "reader_pagination": "opaque_page_cursor_with_updated_after_overlap",
+        "reader_transport": "fixed_origin_stdlib_urllib_get_only",
+        "reader_rate_limit": "maximum_19_requests_per_invocation_then_429_retry_after",
+    })
+    archive = {
+        "provider": PROVIDER, "connection_id": context.connection_id,
+        "remote_account_id": context.account.get("id"), "exported_at": observed,
+        "enabled_streams": list(context.enabled_streams), "policy": policy,
+        "accounts": [{
+            "remote_id": context.account.get("id"), "handle": None,
+            "display_name": None, "observed_at": observed,
+            "provider_json": {"source": PROVENANCE, "binding": "deployment_owned"},
+        }],
+        "objects": [_object(item, context, observed) for item in items],
+        "activities": [_activity(item, context, observed) for item in items],
+        "media": [], "coverage": _coverage(observed),
+    }
+    reject_credentials(archive)
+    return archive

--- a/.agents/scripts/_knowledge_social_readwise_reader_provider.py
+++ b/.agents/scripts/_knowledge_social_readwise_reader_provider.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded GET-only Readwise Reader subprocess."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from functools import partial
+from typing import Any
+
+from _knowledge_social_readwise_reader import (
+    PageRequest,
+    ReadwiseReaderAdapterError,
+    parse_page_request,
+)
+from _knowledge_social_readwise_reader_contract import (
+    ApiResult,
+    ReadwiseReaderProviderError,
+    identity_value,
+    object_value,
+    observed_at,
+    request_object,
+    terminal_payload,
+)
+from _knowledge_social_readwise_reader_http import (
+    MAX_RESPONSE_BYTES,
+    Opener,
+    ProfileConfig,
+    _http_exports,
+    api,
+)
+from _knowledge_social_readwise_reader_identity import (
+    account_id,
+    binding_account_id,
+    expected_binding,
+    verify_token_binding,
+)
+from _knowledge_social_readwise_reader_routes import page
+
+MAX_REQUEST_BYTES = 32 * 1024
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+
+
+def _prefix(profile: str) -> str:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise ReadwiseReaderProviderError("Readwise Reader profile name is invalid")
+    return f"READWISE_READER_{profile.upper()}"
+
+
+def _value(prefix: str, suffix: str, field: str, limit: int) -> str:
+    value = os.environ.get(f"{prefix}_{suffix}", "")
+    if not value or "\x00" in value or len(value.encode()) > limit:
+        raise ReadwiseReaderProviderError(f"Readwise Reader profile {field} is missing")
+    return value
+
+
+def _profile(profile: str) -> ProfileConfig:
+    prefix = _prefix(profile)
+    token = _value(prefix, "ACCESS_TOKEN", "access token", 16 * 1024)
+    binding_id = binding_account_id(_value(prefix, "ACCOUNT_ID", "account ID", 128))
+    key = _value(prefix, "BINDING_KEY", "binding key", 16 * 1024)
+    expected = expected_binding(_value(prefix, "EXPECTED_TOKEN_BINDING", "expected token binding", 64))
+    verify_token_binding(token, binding_id, key, expected)
+    return ProfileConfig(token, binding_id, key, expected)
+
+
+def _identity(config: ProfileConfig, opener: Opener, expected_id: str) -> dict[str, Any]:
+    if binding_account_id(expected_id) != config.binding_account_id:
+        raise ReadwiseReaderProviderError(
+            "selected Readwise Reader account does not match the deployment binding"
+        )
+    result = api(config, opener, "/api/v2/auth/", {})
+    if result.status != 204:
+        return terminal_payload(result)
+    return {
+        "status": 200, "observed_at": observed_at(),
+        "data": identity_value(config.binding_account_id, config.binding_key),
+    }
+
+
+def _verify_page_account(request: PageRequest, identity: dict[str, Any], config: ProfileConfig) -> None:
+    if (
+        request.binding_account_id != config.binding_account_id
+        or identity.get("binding_account_id") != request.binding_account_id
+        or request.account_id
+        != account_id(request.binding_account_id, config.binding_key)
+    ):
+        raise ReadwiseReaderProviderError(
+            "selected Readwise Reader account does not match the deployment binding"
+        )
+
+
+def _dispatch(request: dict[str, Any], config: ProfileConfig, opener: Opener) -> dict[str, Any]:
+    if request.get("action") == "identity":
+        if set(request) != {"action", "account_id"}:
+            raise ReadwiseReaderProviderError("Readwise Reader identity request shape is invalid")
+        return _identity(config, opener, binding_account_id(request.get("account_id")))
+    page_request = parse_page_request(request)
+    verified = _identity(config, opener, page_request.binding_account_id)
+    if verified.get("status") != 200:
+        return verified
+    identity = object_value(verified.get("data"), "account verification")
+    _verify_page_account(page_request, identity, config)
+    result = page(partial(api, config, opener), page_request)
+    return terminal_payload(result) if isinstance(result, ApiResult) else result
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode()) > MAX_RESPONSE_BYTES:
+        raise ReadwiseReaderProviderError("Readwise Reader response exceeds the safety limit")
+    print(encoded)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    args = parser.parse_args()
+    try:
+        request = request_object(sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1), MAX_REQUEST_BYTES)
+        _emit(_dispatch(request, _profile(args.profile), _http_exports()))
+        return 0
+    except (ReadwiseReaderProviderError, ReadwiseReaderAdapterError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - intentionally redact provider internals
+        print("ERROR: Readwise Reader request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_readwise_reader_reader.py
+++ b/.agents/scripts/_knowledge_social_readwise_reader_reader.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and fixture readers for Readwise Reader."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
+from _knowledge_social_readwise_reader import (
+    PageRequest,
+    ReadwiseReaderAdapterError,
+    ReadwiseReaderProviderUnavailableError,
+)
+from _knowledge_social_readwise_reader_identity import binding_account_id
+from knowledge_social_import import reject_credentials
+
+READ_TIMEOUT_SECONDS = 120
+MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+SAFE_FAILURES = (
+    "Python urllib HTTP exports are unavailable",
+    "Readwise Reader profile name is invalid",
+    "Readwise Reader profile access token is missing",
+    "Readwise Reader profile account ID is missing",
+    "Readwise Reader profile binding key is missing",
+    "Readwise Reader profile expected token binding is missing",
+    "Readwise Reader token does not match the deployment account binding",
+    "selected Readwise Reader account does not match the deployment binding",
+)
+
+
+class Reader(Protocol):
+    def identity(self, expected_id: str) -> dict[str, Any]: ...
+    def page(self, request: PageRequest) -> dict[str, Any]: ...
+
+
+def _decode(output: str) -> dict[str, Any]:
+    if len(output.encode()) > MAX_RESPONSE_BYTES:
+        raise ReadwiseReaderAdapterError("Readwise Reader response exceeds the safety limit")
+    try:
+        value = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise ReadwiseReaderAdapterError("Readwise Reader returned no valid JSON") from error
+    if not isinstance(value, dict):
+        raise ReadwiseReaderAdapterError("Readwise Reader response must be an object")
+    return value
+
+
+def _failure(stderr: str) -> ReadwiseReaderProviderUnavailableError:
+    for message in SAFE_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return ReadwiseReaderProviderUnavailableError(message)
+    return ReadwiseReaderProviderUnavailableError("Readwise Reader provider is unavailable")
+
+
+POLICY = GuardedOAuthPolicy(
+    "Readwise Reader", "READWISE_READER", "READWISE_READER_READ_LOG",
+    READ_TIMEOUT_SECONDS, _decode, _failure, ReadwiseReaderProviderUnavailableError,
+    ("ACCESS_TOKEN", "ACCOUNT_ID", "BINDING_KEY", "EXPECTED_TOKEN_BINDING"), "",
+)
+
+
+class GuardedReadwiseReader(GuardedOAuthReader):
+    def __init__(self, helper: Path, profile: str) -> None:
+        super().__init__(helper, profile, POLICY)
+
+
+class FixtureReadwiseReader:
+    def __init__(self, path: Path) -> None:
+        self.fixture = FixtureSequence(path, "Readwise Reader", ReadwiseReaderAdapterError)
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        del expected_id
+        return self.fixture.identity()
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        entry = self.fixture.next_page()
+        expectation = entry.get("expect_request", {})
+        if not isinstance(expectation, dict):
+            raise ReadwiseReaderAdapterError("Reader fixture expectation must be an object")
+        if any(request.payload().get(key) != value for key, value in expectation.items()):
+            raise ReadwiseReaderAdapterError("Reader request did not resume at the expected cursor")
+        response = entry.get("response", entry)
+        if not isinstance(response, dict):
+            raise ReadwiseReaderAdapterError("Reader fixture response must be an object")
+        return response
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise ReadwiseReaderAdapterError("Reader account verification returned no account")
+    selected = binding_account_id(data.get("binding_account_id"))
+    if selected != binding_account_id(expected_id):
+        raise ReadwiseReaderAdapterError(
+            "selected Readwise Reader account does not match the deployment binding"
+        )
+    durable = data.get("id")
+    if not isinstance(durable, str) or not durable.startswith("rwr_"):
+        raise ReadwiseReaderAdapterError("Readwise Reader account identity binding is invalid")
+    return {"id": durable, "binding_account_id": selected}

--- a/.agents/scripts/_knowledge_social_readwise_reader_routes.py
+++ b/.agents/scripts/_knowledge_social_readwise_reader_routes.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Exact Reader GET routes and stream serializers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Callable
+
+from _knowledge_social_readwise_reader import PageRequest
+from _knowledge_social_readwise_reader_contract import (
+    ApiResult,
+    ReadwiseReaderProviderError,
+    object_list,
+    object_value,
+    observed_at,
+    optional_text,
+)
+from _knowledge_social_readwise_reader_identity import resource_id
+
+Api = Callable[[str, dict[str, str]], ApiResult]
+PageResult = ApiResult | dict[str, Any]
+EXACT_READ_PATHS = frozenset({"/api/v2/auth/", "/api/v3/list/", "/api/v3/tags/"})
+
+
+def allowlisted_path(path: str) -> bool:
+    return path in EXACT_READ_PATHS
+
+
+def query_keys_for_path(path: str) -> frozenset[str]:
+    if path == "/api/v3/list/":
+        return frozenset({"pageCursor", "updatedAfter", "category", "limit", "withHtmlContent"})
+    if path == "/api/v3/tags/":
+        return frozenset({"pageCursor"})
+    return frozenset()
+
+
+def _required_text(value: Any, field: str) -> str:
+    result = optional_text(value, field)
+    if not result:
+        raise ReadwiseReaderProviderError(f"Readwise Reader {field} is required")
+    return result
+
+
+def _number(value: Any, field: str) -> int | float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+        raise ReadwiseReaderProviderError(f"Readwise Reader {field} is invalid")
+    return value
+
+
+def _tags(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, dict):
+        values = list(value)
+    elif isinstance(value, list):
+        values = value
+    else:
+        raise ReadwiseReaderProviderError("Readwise Reader document tags are invalid")
+    if any(not isinstance(item, str) or not item or "\x00" in item for item in values):
+        raise ReadwiseReaderProviderError("Readwise Reader document tags are invalid")
+    return values
+
+
+def _document(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    remote = resource_id("document", _required_text(item.get("id"), "document ID"))
+    base = {
+        "kind": "document", "remote_id": remote,
+        "title": optional_text(item.get("title"), "document title"),
+        "body": optional_text(item.get("summary"), "document summary"),
+        "notes": optional_text(item.get("notes"), "document notes"),
+        "html": optional_text(item.get("html_content"), "document HTML") if request.stream == "html" else None,
+        "author": optional_text(item.get("author"), "document author"),
+        "url": optional_text(item.get("url"), "document URL"),
+        "created_at": optional_text(item.get("created_at"), "created timestamp"),
+        "updated_at": optional_text(item.get("updated_at"), "updated timestamp"),
+        "saved_at": optional_text(item.get("saved_at"), "saved timestamp"),
+        "location": optional_text(item.get("location"), "document location"),
+        "category": optional_text(item.get("category"), "document category"),
+        "reading_progress": _number(item.get("reading_progress"), "reading progress"),
+        "tags": _tags(item.get("tags")),
+        "parent_remote_id": resource_id("document", item["parent_id"]) if item.get("parent_id") else None,
+    }
+    if request.stream == "notes":
+        base["kind"] = "note"
+    elif request.stream == "state":
+        base["kind"] = "document_state"
+    elif request.stream == "progress":
+        base["kind"] = "reading_progress"
+    elif request.stream == "locations":
+        base["kind"] = "location"
+    return base
+
+
+def _tag(item: dict[str, Any]) -> dict[str, Any]:
+    key = _required_text(item.get("key"), "tag key")
+    return {
+        "kind": "tag", "remote_id": resource_id("tag", key),
+        "title": optional_text(item.get("name"), "tag name") or key,
+    }
+
+
+def _watermark(items: list[dict[str, Any]]) -> str | None:
+    values = []
+    for item in items:
+        value = optional_text(item.get("updated_at"), "updated timestamp")
+        if value:
+            try:
+                parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError as error:
+                raise ReadwiseReaderProviderError("Readwise Reader updated timestamp is invalid") from error
+            values.append((parsed, value))
+    return max(values)[1] if values else None
+
+
+def page(api: Api, request: PageRequest) -> PageResult:
+    path = "/api/v3/tags/" if request.stream == "tags" else "/api/v3/list/"
+    params: dict[str, str] = {}
+    if request.page_cursor:
+        params["pageCursor"] = request.page_cursor
+    if request.stream != "tags":
+        params["limit"] = str(request.limit)
+        if request.updated_after:
+            params["updatedAfter"] = request.updated_after
+        if request.stream == "notes":
+            params["category"] = "note"
+        if request.stream == "html":
+            params["withHtmlContent"] = "true"
+    result = api(path, params)
+    if result.status != 200:
+        return result
+    root = object_value(result.payload, "list response")
+    items = object_list(root.get("results"), "results", request.limit)
+    records = [_tag(item) for item in items] if request.stream == "tags" else [
+        _document(item, request) for item in items
+    ]
+    cursor = optional_text(root.get("nextPageCursor"), "next page cursor")
+    return {
+        "status": 200, "observed_at": observed_at(), "data": records,
+        "meta": {
+            "stream": request.stream, "next_page_cursor": cursor,
+            "watermark": _watermark(items) if request.stream != "tags" else None,
+        },
+    }

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -19,6 +19,7 @@ MASTODON_HELPER="${SCRIPT_DIR}/knowledge_social_mastodon.py"
 GITHUB_HELPER="${SCRIPT_DIR}/knowledge_social_github.py"
 STACK_EXCHANGE_HELPER="${SCRIPT_DIR}/knowledge_social_stack_exchange.py"
 MINIFLUX_HELPER="${SCRIPT_DIR}/knowledge_social_miniflux.py"
+READWISE_READER_HELPER="${SCRIPT_DIR}/knowledge_social_readwise_reader.py"
 QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
 SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
 SHARE_HELPER="${SCRIPT_DIR}/knowledge_social_share.py"
@@ -140,6 +141,12 @@ Miniflux synchronization:
   use GET-only routes. Entry streams resume by ascending ID and overlap
   changed_after by one second. --budget is 3-1000 and --page-size is 1-100.
 
+Readwise Reader synchronization:
+  sync-readwise-reader requires a deployment-owned account ID plus keyed expected
+  token binding before fixed-origin token validation. Seven GET-only streams use
+  opaque cursors and one-second updatedAfter overlap. The per-invocation request
+  budget is 3-19 to remain below the documented 20/minute limit.
+
 EOF
 	return 0
 }
@@ -202,6 +209,10 @@ Usage:
   knowledge-social-helper.sh sync-miniflux [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id USER_NUMERIC_ID --stream STREAM \
     --profile PROFILE [--budget UNITS] [--page-size 1-100] \
+    [--collector-id ID] [--lease-seconds SECONDS]
+  knowledge-social-helper.sh sync-readwise-reader [--base PATH] [--alias ALIAS] \
+    --connection-id ID --account-id DEPLOYMENT_ACCOUNT_ID --stream STREAM \
+    --profile PROFILE [--budget 3-19] [--page-size 1-100] \
     [--collector-id ID] [--lease-seconds SECONDS]
   knowledge-social-helper.sh sync-due [--base PATH] [--alias ALIAS] \
     [--now-epoch EPOCH] [--interval-seconds SECONDS]
@@ -391,6 +402,7 @@ run_named_provider_sync() {
 	sync-github) run_provider_sync GitHub "$GITHUB_HELPER" "$@" || return 1 ;;
 	sync-stack-exchange) run_provider_sync "Stack Exchange" "$STACK_EXCHANGE_HELPER" "$@" || return 1 ;;
 	sync-miniflux) run_provider_sync Miniflux "$MINIFLUX_HELPER" "$@" || return 1 ;;
+	sync-readwise-reader) run_provider_sync "Readwise Reader" "$READWISE_READER_HELPER" "$@" || return 1 ;;
 	*) return 1 ;;
 	esac
 	return 0
@@ -470,7 +482,7 @@ main() {
 		fi
 		python3 "$LINKEDIN_HELPER" "$@" || return 1
 		;;
-	sync-meta | sync-discourse | sync-nodebb | sync-mastodon | sync-github | sync-stack-exchange | sync-miniflux)
+	sync-meta | sync-discourse | sync-nodebb | sync-mastodon | sync-github | sync-stack-exchange | sync-miniflux | sync-readwise-reader)
 		run_named_provider_sync "$subcommand" "$@" || return 1
 		;;
 	query | annotate)

--- a/.agents/scripts/knowledge_social_readwise_reader.py
+++ b/.agents/scripts/knowledge_social_readwise_reader.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one bounded Readwise Reader account stream into a social corpus."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import _knowledge_social_readwise_reader as reader
+from _knowledge_social_oauth_collector import OAuthCollectorPolicy, run_oauth_collector
+from _knowledge_social_readwise_reader_normalize import PageContext, normalize_page
+from _knowledge_social_readwise_reader_reader import (
+    FixtureReadwiseReader,
+    GuardedReadwiseReader,
+    verified_identity,
+)
+
+
+def _enforce_rate_budget(arguments: list[str]) -> None:
+    if "--budget" not in arguments:
+        return
+    index = arguments.index("--budget")
+    if index + 1 >= len(arguments):
+        return
+    try:
+        budget = int(arguments[index + 1])
+    except ValueError:
+        return
+    if budget > 19:
+        raise reader.ReadwiseReaderAdapterError(
+            "Readwise Reader budget cannot exceed 19 requests per invocation"
+        )
+
+
+def _policy() -> OAuthCollectorPolicy:
+    return OAuthCollectorPolicy(
+        provider_module=reader, verified_identity=verified_identity,
+        normalize_page=normalize_page, page_context=PageContext,
+        display_name="Readwise Reader",
+        helper=Path(__file__).with_name("_knowledge_social_readwise_reader_provider.py"),
+        fixture_reader=FixtureReadwiseReader, live_reader=GuardedReadwiseReader,
+        budget_unit="request", default_budget=19, max_page_size=100,
+    )
+
+
+def main() -> int:
+    try:
+        _enforce_rate_budget(sys.argv[1:])
+    except reader.ReadwiseReaderAdapterError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    return run_oauth_collector(_policy(), __doc__ or "")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/knowledge_social_registry.py
+++ b/.agents/scripts/knowledge_social_registry.py
@@ -55,6 +55,12 @@ PROVIDER_SPECS = (
     ProviderSpec("mastodon", (), "knowledge_social_mastodon.py", (("live", ()),)),
     ProviderSpec("miniflux", (), "knowledge_social_miniflux.py", (("live", ()),)),
     ProviderSpec(
+        "readwise-reader",
+        ("reader",),
+        "knowledge_social_readwise_reader.py",
+        (("live", ()),),
+    ),
+    ProviderSpec(
         "stack-exchange",
         ("stackexchange",),
         "knowledge_social_stack_exchange.py",

--- a/.agents/tests/test-knowledge-social-readwise-reader.sh
+++ b/.agents/tests/test-knowledge-social-readwise-reader.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-readwise-reader.sh — Bounded Reader collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+READER_SCRIPT="${SCRIPT_DIR}/../scripts/knowledge_social_readwise_reader.py"
+SOCIAL_HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TEMP_PARENT="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+mkdir -p "$TEMP_PARENT"
+TMP_DIR=$(mktemp -d "${TEMP_PARENT}/readwise-reader-test.XXXXXX")
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' "$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c 'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' "$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_count() {
+	python3 - "$ROOT/sources/social/raw/readwise-reader" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+print(len(list(root.rglob("*.json.gz"))) if root.exists() else 0)
+PY
+	return 0
+}
+
+run_reader() {
+	local fixture="$1"
+	local connection_id="$2"
+	local stream="$3"
+	if python3 "$READER_SCRIPT" --base "$BASE" --alias personal:default \
+		--connection-id "$connection_id" --account-id personal_reader \
+		--stream "$stream" --profile fixture --fixture "$fixture" \
+		--budget 3 --page-size 1; then
+		return 0
+	fi
+	return 1
+}
+
+expect_failure() {
+	local description="$1"
+	local fixture="$2"
+	local connection_id="$3"
+	if run_reader "$fixture" "$connection_id" documents >/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$SOCIAL_HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'Readwise Reader social collector tests\n'
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import ast
+import json
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+
+from _knowledge_social_collect import CursorState
+from _knowledge_social_readwise_reader import PageRequest, STREAMS, page_checkpoint, page_request
+from _knowledge_social_readwise_reader_contract import ApiResult, identity_value
+from _knowledge_social_readwise_reader_http import HTTP_TIMEOUT_SECONDS, ProfileConfig, api
+from _knowledge_social_readwise_reader_identity import account_id, token_binding, verify_token_binding
+from _knowledge_social_readwise_reader_routes import allowlisted_path, page
+from knowledge_social_readwise_reader import _enforce_rate_budget
+
+assert set(STREAMS) == {"documents", "tags", "notes", "state", "progress", "locations", "html"}
+assert all(allowlisted_path(path) for path in ("/api/v2/auth/", "/api/v3/list/", "/api/v3/tags/"))
+assert not allowlisted_path("/api/v3/save/") and not allowlisted_path("/api/v3/update/id/")
+
+key = "k" * 32
+binding = token_binding("selected-token", "personal_reader", key)
+verify_token_binding("selected-token", "personal_reader", key, binding)
+try:
+    verify_token_binding("wrong-valid-token", "personal_reader", key, binding)
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("wrong valid Reader token passed deployment binding")
+identity = identity_value("personal_reader", key)
+assert identity["id"] == account_id("personal_reader", key)
+
+request = PageRequest("documents", identity["id"], "personal_reader", None, None, 1)
+item = {
+    "id": "doc-1", "title": "Bounded Reader item", "summary": "Reader knowledge",
+    "created_at": "2026-08-02T07:00:00+00:00", "updated_at": "2026-08-02T07:01:00+00:00",
+    "location": "later", "reading_progress": 0.5, "tags": {"research": "Research"},
+}
+payload = page(lambda _path, _params: ApiResult(200, {"results": [item], "nextPageCursor": "opaque-A"}), request)
+checkpoint, complete = page_checkpoint(payload, CursorState(None, None, False), request)
+assert not complete and checkpoint.next_cursor and checkpoint.watermark
+resumed = page_request("documents", identity, CursorState(checkpoint.next_cursor, checkpoint.watermark, False), 1)
+assert resumed.page_cursor == "opaque-A"
+incremental = page_request("documents", identity, CursorState(None, checkpoint.watermark, True), 1)
+assert incremental.updated_after < checkpoint.watermark
+
+try:
+    _enforce_rate_budget(["--budget", "20"])
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("Reader request budget exceeded documented rate limit")
+
+
+class Headers:
+    def get(self, _key, default=None):
+        return default
+
+
+class Response:
+    headers = Headers()
+
+    def __init__(self, status, payload=b""):
+        self.status = status
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def read(self, size=-1):
+        return self.payload[:size]
+
+
+class Opener:
+    def __init__(self, response):
+        self.response = response
+        self.request = None
+
+    def open(self, request, timeout):
+        assert timeout == HTTP_TIMEOUT_SECONDS and request.method == "GET"
+        assert "selected-token" not in request.full_url
+        self.request = request
+        return self.response
+
+
+config = ProfileConfig("selected-token", "personal_reader", key, binding)
+opener = Opener(Response(204))
+assert api(config, opener, "/api/v2/auth/", {}).status == 204
+try:
+    api(config, opener, "/api/v3/save/", {})
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("Reader mutation route was accepted")
+
+sources = [path.read_text(encoding="utf-8") for path in sorted(scripts.glob("_knowledge_social_readwise_reader*.py"))]
+trees = [ast.parse(source) for source in sources]
+calls = [node for tree in trees for node in ast.walk(tree) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "Request"]
+assert calls
+for node in calls:
+    methods = [keyword.value.value for keyword in node.keywords if keyword.arg == "method" and isinstance(keyword.value, ast.Constant)]
+    assert methods == ["GET"]
+PY
+assert_eq "token binding, cursor overlap, rate budget, routes, and GET-only AST are guarded" verified verified
+
+python3 - "$TMP_DIR/complete.json" <<'PY'
+import json
+import sys
+
+payload = {
+    "identity": {"data": {"id": "rwr_fixture_account", "binding_account_id": "personal_reader"}},
+    "pages": [{
+        "expect_request": {"page_cursor": None, "updated_after": None, "limit": 1},
+        "response": {
+            "status": 200, "observed_at": "2026-08-02T07:10:00Z",
+            "data": [{"kind": "document", "remote_id": "rwr_document_fixture",
+                      "title": "Bounded Reader item", "body": "Reader knowledge",
+                      "created_at": "2026-08-02T07:00:00Z", "updated_at": "2026-08-02T07:01:00Z"}],
+            "meta": {"stream": "documents", "next_page_cursor": None,
+                     "watermark": "2026-08-02T07:01:00Z"},
+        },
+    }],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+result=$(run_reader "$TMP_DIR/complete.json" conn_reader documents)
+assert_eq "bounded Reader fixture completes" "$(json_field "$result" status)" complete
+assert_eq "identity plus page consumes three requests" "$(json_field "$result" budget_units)" 3
+assert_eq "Reader document text reaches FTS" "$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'knowledge'")" 1
+
+python3 - "$TMP_DIR/mismatch.json" <<'PY'
+import json
+import sys
+
+payload = {"identity": {"data": {"id": "rwr_other", "binding_account_id": "other_reader"}}, "pages": []}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+raw_before=$(raw_count)
+expect_failure "wrong account binding is rejected" "$TMP_DIR/mismatch.json" conn_mismatch
+assert_eq "binding mismatch persists no raw evidence" "$(raw_count)" "$raw_before"
+
+python3 - "$TMP_DIR/credential.json" <<'PY'
+import json
+import sys
+
+payload = {
+    "identity": {"data": {"id": "rwr_fixture_account", "binding_account_id": "personal_reader"}},
+    "pages": [{"status": 200, "observed_at": "2026-08-02T07:11:00Z",
+               "access_token": "must-not-persist", "data": [],
+               "meta": {"stream": "documents", "next_page_cursor": None,
+                        "watermark": "2026-08-02T07:01:00Z"}}],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+raw_before=$(raw_count)
+expect_failure "credential-shaped Reader page is rejected" "$TMP_DIR/credential.json" conn_credential
+assert_eq "credential rejection persists no raw evidence" "$(raw_count)" "$raw_before"
+assert_eq "identity, deletion, export, and retention gaps remain explicit" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE connection_id='conn_reader' AND status='unavailable'")" 4
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/tests/test-knowledge-social-registry.sh
+++ b/.agents/tests/test-knowledge-social-registry.sh
@@ -49,6 +49,7 @@ expected = {
     "mastodon": ("live",),
     "miniflux": ("live",),
     "nextcloud-talk": ("live",),
+    "readwise-reader": ("live",),
     "signal": ("inspect", "manual-import", "status"),
     "slack": ("archive", "live"),
     "stack-exchange": ("live",),
@@ -72,6 +73,7 @@ for alias, provider in {
     "dev-community": "forem",
     "dev.to": "forem",
     "gbp": "google-business-profile",
+    "reader": "readwise-reader",
     "stackexchange": "stack-exchange",
     "whats-app": "whatsapp",
 }.items():
@@ -95,14 +97,14 @@ except module.ProviderRegistryError:
 else:
     raise SystemExit("unknown provider used a fallback")
 
-print("15:order-independent:aliases-exact:collisions-rejected:no-fallback")
+print("16:order-independent:aliases-exact:collisions-rejected:no-fallback")
 PY
 )
 assert_eq "all merged provider outcomes register deterministically" \
-	"$registry_summary" "15:order-independent:aliases-exact:collisions-rejected:no-fallback"
+	"$registry_summary" "16:order-independent:aliases-exact:collisions-rejected:no-fallback"
 
 provider_count=$("$HELPER" providers | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
-assert_eq "helper exposes the complete provider registry" "$provider_count" "15"
+assert_eq "helper exposes the complete provider registry" "$provider_count" "16"
 
 forem_resolution=$("$HELPER" provider-resolve --provider dev-community |
 	python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["provider"] + ":" + ",".join(data["modes"]))')


### PR DESCRIPTION
## Summary

Add a gated Readwise Reader collector with deployment-owned account/token binding, seven independent GET-only streams, opaque cursor resume, updatedAfter overlap, 20/minute-aware request budgeting, registry routing, documentation, and fixture coverage.

## Files Changed

.agents/aidevops/knowledge-plane/05-social-operations.md, .agents/aidevops/knowledge-plane/06-social-provider-capabilities.md, .agents/content/social-readwise-reader.md, .agents/scripts/_knowledge_social_readwise_reader.py, .agents/scripts/_knowledge_social_readwise_reader_contract.py, .agents/scripts/_knowledge_social_readwise_reader_http.py, .agents/scripts/_knowledge_social_readwise_reader_identity.py, .agents/scripts/_knowledge_social_readwise_reader_normalize.py, .agents/scripts/_knowledge_social_readwise_reader_provider.py, .agents/scripts/_knowledge_social_readwise_reader_reader.py, .agents/scripts/_knowledge_social_readwise_reader_routes.py, .agents/scripts/knowledge-social-helper.sh, .agents/scripts/knowledge_social_readwise_reader.py, .agents/scripts/knowledge_social_registry.py, .agents/tests/test-knowledge-social-readwise-reader.sh, .agents/tests/test-knowledge-social-registry.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — 9 Reader collector tests, 8 registry tests, 35 social-sync tests, and 33 social-corpus tests pass; Python compilation, ShellCheck, Qlty smells, and changed-file local linters pass.

Resolves #29225


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 6h 45m and 3,808,931 tokens on this with the user in an interactive session.