### PR TITLE
GH#29093: fix(github): fail closed on mixed GH_DEBUG output

### DIFF
--- a/.agents/scripts/gh-quota-debug-filter.py
+++ b/.agents/scripts/gh-quota-debug-filter.py
@@ -60,11 +60,20 @@ def _request_ranges(lines: List[bytes]) -> List[Tuple[int, int]]:
 
 def _completion_ranges(lines: List[bytes]) -> List[Tuple[int, int]]:
     ranges: List[Tuple[int, int]] = []
-    start = 0
+    start: Optional[int] = None
+    pending_requests = 0
     for index, line in enumerate(lines):
-        if REQUEST_END.match(line.rstrip(b"\r\n")):
-            ranges.append((start, index + 1))
-            start = index + 1
+        if REQUEST_START.match(line):
+            if pending_requests == 0:
+                start = index
+            pending_requests += 1
+        if not REQUEST_END.match(line.rstrip(b"\r\n")) or pending_requests == 0:
+            continue
+        if start is None:
+            continue
+        ranges.append((start, index + 1))
+        pending_requests -= 1
+        start = index + 1 if pending_requests else None
     return ranges
 
 
@@ -174,20 +183,13 @@ def _consume_proven_cache_hit(
     return False
 
 
-def _write_sanitized_stderr(
-    lines: List[bytes], ranges: List[Tuple[int, int]]
-) -> None:
-    if not ranges:
-        # Exact-capture mode deliberately enables GH_DEBUG. If its framing ever
-        # changes, raw stderr may contain request headers or response bodies.
-        # Suppress the whole stream rather than leak it as a normal diagnostic.
-        return
-    suppressed = {
-        index for start, end in ranges for index in range(start, end)
-    }
-    for index, line in enumerate(lines):
-        if index not in suppressed:
-            sys.stderr.buffer.write(line)
+def _write_sanitized_stderr() -> None:
+    # Exact-capture mode deliberately enables GH_DEBUG. Framing proves which
+    # bytes belong to private request/response blocks, but it cannot prove that
+    # bytes outside those blocks are diagnostics rather than malformed private
+    # payloads. Until native diagnostics have a strict allowlist, suppress every
+    # line instead of forwarding unframed content.
+    return
 
 
 def main() -> int:
@@ -199,7 +201,7 @@ def main() -> int:
         return 1
     lines = data.splitlines(keepends=True)
     request_ranges = _request_ranges(lines)
-    _write_sanitized_stderr(lines, request_ranges)
+    _write_sanitized_stderr()
     if data and not request_ranges:
         # Non-empty stderr without a recognized request frame may be a changed
         # GH_DEBUG format containing private request or response data. Keep it

--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -23,6 +23,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=portable-stat.sh
 source "${SCRIPT_DIR}/portable-stat.sh"
+# shellcheck source=audit-worktree-removal-helper.sh
+source "${SCRIPT_DIR}/audit-worktree-removal-helper.sh"
 METRICS_FILE="${HOME}/.aidevops/.agent-workspace/observability/metrics.jsonl"
 OBS_DB_FILE="${HOME}/.aidevops/.agent-workspace/observability/llm-requests.db"
 OPENCODE_DB_FILE="${HOME}/.local/share/opencode/opencode.db"
@@ -136,6 +138,22 @@ _profile_publication_worktree_helper() {
 	return 0
 }
 
+_archive_and_remove_profile_publication_worktree() {
+	local worktree_path="$1"
+	local archive_path=""
+	local caller="profile-readme-helper.sh"
+	local context="recovery_path=profile-publication-archive"
+
+	archive_worktree_path_recoverably "$worktree_path" "$caller" "$context" || return 1
+	archive_path="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
+	[[ -n "$archive_path" ]] || return 1
+	remove_archived_worktree_path "$worktree_path" "$archive_path" "$caller" \
+		"profile-publication" "$context" "true" "false" || return 1
+	log_worktree_removal_event "$_WTAR_REMOVED" "$caller" "$worktree_path" \
+		"profile-publication" "recoverable" "$context"
+	return 0
+}
+
 _cleanup_profile_publication_worktree() {
 	if [[ -z "$PROFILE_PUBLICATION_WORKTREE" ]]; then
 		return 0
@@ -148,7 +166,13 @@ _cleanup_profile_publication_worktree() {
 		echo "Warning: profile publication worktree cleanup is unavailable: $worktree_path" >&2
 		return 1
 	fi
-	if ! (cd "$canonical_repo" && "$worktree_helper" remove "$worktree_path" --force >/dev/null); then
+	if (cd "$canonical_repo" && "$worktree_helper" remove "$worktree_path" >/dev/null); then
+		PROFILE_PUBLICATION_WORKTREE=""
+		PROFILE_PUBLICATION_CANONICAL_REPO=""
+		return 0
+	fi
+	if [[ -e "$worktree_path" ]] &&
+		! _archive_and_remove_profile_publication_worktree "$worktree_path"; then
 		echo "Warning: profile publication worktree cleanup failed: $worktree_path" >&2
 		return 1
 	fi

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -132,6 +132,7 @@ if [[ "$1" == "api" && "$2" == "rate_limit" ]]; then
 	exit 0
 fi
 if [[ "${GH_DEBUG:-}" == "api" && "${STUB_GH_DEBUG_RESPONSE:-0}" == "1" ]]; then
+	[[ -z "${STUB_GH_DEBUG_PREFIX:-}" ]] || printf '%s\n' "$STUB_GH_DEBUG_PREFIX" >&2
 	_stub_frame=1
 	_stub_frame_total=1
 	[[ "${STUB_GH_DEBUG_MULTI_FRAME:-0}" == "1" ]] && _stub_frame_total=3
@@ -1284,7 +1285,7 @@ GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
 	AIDEVOPS_GH_API_LOG="$exact_log" STUB_GH_DEBUG_RESPONSE=1 \
 	STUB_BOOTSTRAP_GRAPHQL_USED=200 STUB_GH_DEBUG_RESOURCE=graphql \
 	STUB_GH_DEBUG_USED=201 STUB_GH_DEBUG_REMAINING=4799 STUB_GH_DEBUG_RESET=2000 \
-	STUB_GH_DIAGNOSTIC='sanitized native diagnostic' \
+	STUB_GH_DIAGNOSTIC='unframed-private-trailing-fixture' \
 	"$SHIM_RUN" pr view 123 --repo owner/repo >/dev/null 2>"$exact_err"
 if [[ "$(_read_attempt_quota "$exact_log")" == "1" \
 	&& "$(_read_last_attempt_field "$exact_log" 15)" == "200" \
@@ -1293,12 +1294,58 @@ if [[ "$(_read_attempt_quota "$exact_log")" == "1" \
 else
 	_fail "GraphQL exact quota capture" "log: $(cat "$exact_log" 2>/dev/null || true)"
 fi
-if grep -Eq 'private-fixture-token|response-body-fixture' "$exact_err"; then
-	_fail "GH_DEBUG privacy filtering" "stderr exposed private debug content"
-elif grep -q '^sanitized native diagnostic$' "$exact_err"; then
-	_pass "GH_DEBUG request and response bodies are suppressed while native diagnostics survive"
+if [[ ! -s "$exact_err" ]]; then
+	_pass "GH_DEBUG frames and unframed trailing content are fully suppressed"
 else
-	_fail "GH_DEBUG sanitized diagnostic preservation" "stderr: $(cat "$exact_err" 2>/dev/null || true)"
+	_fail "GH_DEBUG trailing-content privacy filtering" "stderr: $(cat "$exact_err" 2>/dev/null || true)"
+fi
+
+prefix_log="$TMP/exact-unframed-prefix.log"
+prefix_err="$TMP/exact-unframed-prefix.err"
+prefix_state="$TMP/exact-unframed-prefix-state"
+: >"$prefix_log"
+GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
+	AIDEVOPS_GH_QUOTA_STATE_DIR="$prefix_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_GH_API_LOG="$prefix_log" STUB_GH_DEBUG_RESPONSE=1 \
+	STUB_GH_DEBUG_PREFIX='unframed-private-prefix-fixture' \
+	STUB_BOOTSTRAP_GRAPHQL_USED=200 STUB_GH_DEBUG_RESOURCE=graphql \
+	STUB_GH_DEBUG_USED=201 STUB_GH_DEBUG_REMAINING=4799 STUB_GH_DEBUG_RESET=2000 \
+	"$SHIM_RUN" pr view 123 --repo owner/repo >/dev/null 2>"$prefix_err"
+if [[ "$(_read_attempt_quota "$prefix_log")" == "1" && ! -s "$prefix_err" ]]; then
+	_pass "unframed content before a valid GH_DEBUG frame stays private"
+else
+	_fail "GH_DEBUG prefix privacy filtering" \
+		"log: $(cat "$prefix_log" 2>/dev/null || true) stderr: $(cat "$prefix_err" 2>/dev/null || true)"
+fi
+
+mixed_debug="$TMP/exact-malformed-mixed.debug"
+mixed_err="$TMP/exact-malformed-mixed.err"
+cat >"$mixed_debug" <<'EOF'
+unframed-private-prefix-fixture
+* Request took 1ms
+* Request at 2026-07-24 00:00:00 +0000 UTC
+> Authorization: token private-fixture-token
+
+< HTTP/2.0 200 Fixture
+< X-Ratelimit-Resource: graphql
+< X-Ratelimit-Used: 201
+< X-Ratelimit-Remaining: 4799
+< X-Ratelimit-Reset: 2000
+
+{"private":"response-body-fixture"}
+* Request took 12.5ms
+unframed-private-trailing-fixture
+* Request took 1ms
+EOF
+mixed_parsed=$(python3 "$TMP/scripts/gh-quota-debug-filter.py" \
+	"$mixed_debug" 2>"$mixed_err")
+if [[ "$(printf '%s\n' "$mixed_parsed" | grep -c $'^v1\t1$')" == "1" \
+	&& "$(printf '%s\n' "$mixed_parsed" | grep -c $'^frame\t1\t1\t200\tgraphql\t201\t')" == "1" \
+	&& ! -s "$mixed_err" ]]; then
+	_pass "malformed mixed streams retain only structurally proven attempts"
+else
+	_fail "malformed mixed-stream attribution" \
+		"parsed: $mixed_parsed stderr: $(cat "$mixed_err" 2>/dev/null || true)"
 fi
 
 failed_log="$TMP/exact-failed-rest.log"

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -55,7 +55,8 @@ install_helper_with_libs() {
 	chmod +x "${helper_path}"
 	cp "${SOURCE_DATA_LIB}" "${helper_dir}/profile-readme-data-lib.sh"
 	cp "${SOURCE_RENDER_LIB}" "${helper_dir}/profile-readme-render-lib.sh"
-	cp "${SOURCE_HELPER%/*}/portable-stat.sh" \
+	cp "${SOURCE_HELPER%/*}/audit-worktree-removal-helper.sh" \
+		"${SOURCE_HELPER%/*}/portable-stat.sh" \
 		"${SOURCE_HELPER%/*}/screen-time-interval-engine.py" \
 		"${SOURCE_HELPER%/*}/screen_time_interval_common.py" \
 		"${SOURCE_HELPER%/*}/screen_time_macos.py" \


### PR DESCRIPTION
## Summary

Suppress all unframed GH_DEBUG bytes, preserve only structurally proven request attempts, and repair the inherited profile worktree cleanup failure by using recoverable archive-first fallback removal.

## Files Changed

.agents/scripts/gh-quota-debug-filter.py, .agents/scripts/profile-readme-helper.sh, .agents/scripts/tests/test-gh-shim.sh, .agents/scripts/tests/test-profile-readme-boundary.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — shellcheck -x .agents/scripts/tests/test-gh-shim.sh .agents/scripts/profile-readme-helper.sh .agents/scripts/tests/test-profile-readme-boundary.sh; .agents/scripts/tests/test-gh-shim.sh (116 passed); bash .agents/scripts/tests/test-profile-readme-boundary.sh (20 passed); .agents/scripts/qlty-regression-helper.sh --base origin/main --head HEAD (70 to 70, delta 0); .agents/scripts/linters-local.sh

Resolves #29093


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 18m and 216,041 tokens on this as a headless worker.