### PR TITLE
GH#29243: Suppress TODO deletion diagnostics

### DIFF
--- a/.agents/scripts/pre-commit-hook.sh
+++ b/.agents/scripts/pre-commit-hook.sh
@@ -547,7 +547,7 @@ validate_todo_completions() {
 	# Find ALL tasks (including subtasks) that changed from [ ] to [x] in this commit
 	# We need to check both top-level and subtasks
 	local newly_completed
-	newly_completed=$(git diff --cached -U0 TODO.md | grep -E '^\+.*- \[x\] t[0-9]+' | sed 's/^\+//' || true)
+	newly_completed=$(git diff --cached -U0 -- TODO.md | grep -E '^\+.*- \[x\] t[0-9]+' | sed 's/^\+//' || true)
 
 	if [[ -z "$newly_completed" ]]; then
 		return 0
@@ -555,7 +555,7 @@ validate_todo_completions() {
 
 	# Also get lines that were already [x] (to skip them - not a transition)
 	local already_completed
-	already_completed=$(git diff --cached -U0 TODO.md | grep -E '^\-.*- \[x\] t[0-9]+' | sed 's/^\-//' || true)
+	already_completed=$(git diff --cached -U0 -- TODO.md | grep -E '^\-.*- \[x\] t[0-9]+' | sed 's/^\-//' || true)
 
 	local task_count=0
 	local fail_count=0
@@ -716,7 +716,7 @@ validate_parent_subtask_blocking() {
 
 	# Find tasks that changed from [ ] to [x]
 	local newly_completed
-	newly_completed=$(git diff --cached -U0 TODO.md | grep -E '^\+.*- \[x\] t[0-9]+' | sed 's/^\+//' || true)
+	newly_completed=$(git diff --cached -U0 -- TODO.md | grep -E '^\+.*- \[x\] t[0-9]+' | sed 's/^\+//' || true)
 
 	if [[ -z "$newly_completed" ]]; then
 		return 0
@@ -724,7 +724,7 @@ validate_parent_subtask_blocking() {
 
 	# Also get lines that were already [x] (to skip them)
 	local already_completed
-	already_completed=$(git diff --cached -U0 TODO.md | grep -E '^\-.*- \[x\] t[0-9]+' | sed 's/^\-//' || true)
+	already_completed=$(git diff --cached -U0 -- TODO.md | grep -E '^\-.*- \[x\] t[0-9]+' | sed 's/^\-//' || true)
 
 	local fail_count=0
 	local failed_tasks=()

--- a/.agents/scripts/tests/test-pre-commit-hook-todo-validation.sh
+++ b/.agents/scripts/tests/test-pre-commit-hook-todo-validation.sh
@@ -53,15 +53,6 @@ init_repo() {
 	return 0
 }
 
-prepare_function_hook() {
-	local function_hook="${TEST_ROOT}/pre-commit-hook.sh"
-	cp "$HOOK_PATH" "$function_hook"
-	cp "${SCRIPT_DIR}/../shared-constants.sh" "${TEST_ROOT}/shared-constants.sh"
-	sed '/^main "\$@"$/d' "$function_hook" >"${function_hook}.tmp"
-	mv "${function_hook}.tmp" "$function_hook"
-	return 0
-}
-
 run_validator() {
 	local validator="$1"
 	local staged_content="$2"
@@ -71,7 +62,12 @@ run_validator() {
 	VALIDATOR_OUTPUT=$(
 		cd "$CASE_REPO" || exit 1
 		# shellcheck source=/dev/null
-		source "${TEST_ROOT}/pre-commit-hook.sh" >/dev/null 2>&1
+		source "${SCRIPT_DIR}/../shared-constants.sh" >/dev/null 2>&1
+		# Source the hook without its trailing main invocation. Pre-sourcing
+		# shared constants keeps the validator functions available even though
+		# SCRIPT_DIR resolves against the process-substitution descriptor.
+		# shellcheck source=/dev/null
+		source <(sed '/^main "\$@"$/d' "$HOOK_PATH") >/dev/null 2>&1
 		set +e
 		"$validator" 2>&1
 		local validator_rc=$?
@@ -134,7 +130,6 @@ test_parent_with_open_subtask() {
 	return 0
 }
 
-prepare_function_hook
 test_staged_todo_deletion
 test_completion_without_evidence
 test_completion_with_evidence

--- a/.agents/scripts/tests/test-pre-commit-hook-todo-validation.sh
+++ b/.agents/scripts/tests/test-pre-commit-hook-todo-validation.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for TODO.md completion validators (GH#29243).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HOOK_PATH="${SCRIPT_DIR}/../pre-commit-hook.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=$(mktemp -d)
+CASE_REPO=""
+VALIDATOR_OUTPUT=""
+VALIDATOR_RC=0
+
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/.agent-workspace"
+
+print_result() {
+	local name="$1"
+	local rc="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+		return 0
+	fi
+	printf 'FAIL %s: %s\n' "$name" "$detail"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+init_repo() {
+	local name="$1"
+	local todo_content="$2"
+	CASE_REPO="${TEST_ROOT}/${name}"
+	mkdir -p "$CASE_REPO"
+	(
+		cd "$CASE_REPO" || exit 1
+		git init -q
+		git config user.email 'test@aidevops.local'
+		git config user.name 'Test Runner'
+		git config commit.gpgsign false
+		printf 'fixture\n' >README.md
+		printf '%s\n' "$todo_content" >TODO.md
+		git add README.md TODO.md
+		git commit -q -m 'seed fixture'
+	)
+	return 0
+}
+
+prepare_function_hook() {
+	local function_hook="${TEST_ROOT}/pre-commit-hook.sh"
+	cp "$HOOK_PATH" "$function_hook"
+	cp "${SCRIPT_DIR}/../shared-constants.sh" "${TEST_ROOT}/shared-constants.sh"
+	sed '/^main "\$@"$/d' "$function_hook" >"${function_hook}.tmp"
+	mv "${function_hook}.tmp" "$function_hook"
+	return 0
+}
+
+run_validator() {
+	local validator="$1"
+	local staged_content="$2"
+	printf '%s\n' "$staged_content" >"${CASE_REPO}/TODO.md"
+	git -C "$CASE_REPO" add TODO.md
+
+	VALIDATOR_OUTPUT=$(
+		cd "$CASE_REPO" || exit 1
+		# shellcheck source=/dev/null
+		source "${TEST_ROOT}/pre-commit-hook.sh" >/dev/null 2>&1
+		set +e
+		"$validator" 2>&1
+		local validator_rc=$?
+		printf '\n__VALIDATOR_RC__=%s\n' "$validator_rc"
+	)
+	VALIDATOR_RC=$(printf '%s\n' "$VALIDATOR_OUTPUT" | sed -n 's/^__VALIDATOR_RC__=//p')
+	return 0
+}
+
+test_staged_todo_deletion() {
+	init_repo "todo-deletion" '- [ ] t100 Keep this task open'
+	rm "${CASE_REPO}/TODO.md"
+	git -C "$CASE_REPO" add -u -- TODO.md
+
+	local output
+	local rc=0
+	output=$(cd "$CASE_REPO" && HOOK_MODE=pre-commit bash "$HOOK_PATH" 2>&1) || rc=$?
+	if [[ "$rc" -ne 0 ]]; then
+		print_result "staged TODO.md deletion passes" 1 "hook exited ${rc}: ${output}"
+		return 0
+	fi
+	if printf '%s\n' "$output" | grep -Eq 'fatal:|ambiguous argument|unknown revision or path'; then
+		print_result "staged TODO.md deletion has no Git path diagnostic" 1 "$output"
+		return 0
+	fi
+	print_result "staged TODO.md deletion has no Git path diagnostic" 0
+	return 0
+}
+
+test_completion_without_evidence() {
+	init_repo "completion-no-evidence" '- [ ] t101 Complete this task'
+	run_validator validate_todo_completions '- [x] t101 Complete this task'
+	if [[ "$VALIDATOR_RC" -eq 1 ]]; then
+		print_result "completion without evidence fails" 0
+	else
+		print_result "completion without evidence fails" 1 "expected rc=1, got ${VALIDATOR_RC}: ${VALIDATOR_OUTPUT}"
+	fi
+	return 0
+}
+
+test_completion_with_evidence() {
+	init_repo "completion-with-evidence" '- [ ] t102 Complete this task'
+	run_validator validate_todo_completions '- [x] t102 Complete this task verified:2026-08-02'
+	if [[ "$VALIDATOR_RC" -eq 0 ]]; then
+		print_result "completion with evidence passes" 0
+	else
+		print_result "completion with evidence passes" 1 "expected rc=0, got ${VALIDATOR_RC}: ${VALIDATOR_OUTPUT}"
+	fi
+	return 0
+}
+
+test_parent_with_open_subtask() {
+	init_repo "parent-open-subtask" $'- [ ] t103 Parent task\n  - [ ] t103.1 Open subtask'
+	run_validator validate_parent_subtask_blocking $'- [x] t103 Parent task verified:2026-08-02\n  - [ ] t103.1 Open subtask'
+	if [[ "$VALIDATOR_RC" -eq 1 ]]; then
+		print_result "parent completion with open subtask fails" 0
+	else
+		print_result "parent completion with open subtask fails" 1 "expected rc=1, got ${VALIDATOR_RC}: ${VALIDATOR_OUTPUT}"
+	fi
+	return 0
+}
+
+prepare_function_hook
+test_staged_todo_deletion
+test_completion_without_evidence
+test_completion_with_evidence
+test_parent_with_open_subtask
+
+printf '\nTests: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Disambiguate cached TODO.md diffs with the revision/path separator and add regression coverage for deletion, proof-log, and parent/subtask behavior

## Files Changed

.agents/scripts/pre-commit-hook.sh, .agents/scripts/tests/test-pre-commit-hook-todo-validation.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused TODO validator regression test and ShellCheck pass

Resolves #29243


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 15m and 82,960 tokens on this as a headless worker.