### PR TITLE
GH#29118: Persist cleanup receipts without canonical paths

### DIFF
--- a/.agents/scripts/full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/full-loop-cleanup-receipt.sh
@@ -1349,15 +1349,41 @@ full_loop_update_cleanup_release_status() {
 	return 0
 }
 
+full_loop_mark_cleanup_receipt_cleaned() {
+	local receipt_path="$1"
+	local worktree="$2"
+	local cleanup_log="${3:-${AIDEVOPS_CLEANUP_LOG:-${HOME}/.aidevops/logs/cleanup_worktrees.log}}"
+
+	[[ -f "$receipt_path" && -n "$worktree" && ! -e "$worktree" && -f "$cleanup_log" ]] || return 1
+	grep -Fq "worktree-removed: ${worktree} —" "$cleanup_log" || return 1
+	jq -e --arg worktree "$worktree" '.worktree == $worktree' "$receipt_path" >/dev/null 2>&1 || return 1
+	full_loop_transition_cleanup_receipt "$receipt_path" "$_FULL_LOOP_CLEANUP_CLEANED"
+	return $?
+}
+
+full_loop_mark_cleanup_cleaned_for_identity() {
+	local repo="$1"
+	local pr_number="$2"
+	local worktree="$3"
+	local cleanup_log="${4:-${AIDEVOPS_CLEANUP_LOG:-${HOME}/.aidevops/logs/cleanup_worktrees.log}}"
+	local receipt_path=""
+
+	receipt_path=$(_full_loop_cleanup_receipt_path "$repo" "$pr_number") || return 1
+	[[ -f "$receipt_path" ]] || return 1
+	jq -e --arg repo "$repo" --argjson pr_number "$pr_number" --arg worktree "$worktree" '
+		.repository == $repo and .pr_number == $pr_number and .worktree == $worktree
+	' "$receipt_path" >/dev/null 2>&1 || return 1
+	full_loop_mark_cleanup_receipt_cleaned "$receipt_path" "$worktree" "$cleanup_log"
+	return $?
+}
+
 full_loop_mark_cleanup_cleaned_for_worktree() {
 	local worktree="$1"
 	local cleanup_log="${2:-${AIDEVOPS_CLEANUP_LOG:-${HOME}/.aidevops/logs/cleanup_worktrees.log}}"
 	local receipt_path=""
 
-	[[ -n "$worktree" && ! -e "$worktree" && -f "$cleanup_log" ]] || return 1
-	grep -Fq "worktree-removed: ${worktree} —" "$cleanup_log" || return 1
 	receipt_path=$(full_loop_cleanup_receipt_for_worktree "$worktree") || return 1
-	full_loop_transition_cleanup_receipt "$receipt_path" "$_FULL_LOOP_CLEANUP_CLEANED"
+	full_loop_mark_cleanup_receipt_cleaned "$receipt_path" "$worktree" "$cleanup_log"
 	return $?
 }
 

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -1145,7 +1145,7 @@ _merge_worktree_record_matches() {
 	return 1
 }
 
-_merge_current_worktree_cleanup_plan() {
+_merge_current_worktree_cleanup_target() {
 	local pr_head_ref="$1"
 	local pr_head_oid="$2"
 	local pr_head_repo="$3"
@@ -1163,15 +1163,19 @@ _merge_current_worktree_cleanup_plan() {
 	current_head=$(git rev-parse --verify "HEAD^{commit}" 2>/dev/null || true)
 	[[ -n "$current_head" && "$current_head" == "$pr_head_oid" ]] || return 1
 
+	# Prove this is a linked worktree without depending on discovery of the
+	# canonical checkout path. The common Git directory remains authoritative
+	# even when the canonical working-tree registration is temporarily absent.
+	local git_dir=""
+	local common_dir=""
+	git_dir=$(git rev-parse --absolute-git-dir 2>/dev/null || true)
+	common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+	[[ -n "$git_dir" && -n "$common_dir" && "$git_dir" != "$common_dir" ]] || return 1
+
 	local porcelain=""
 	porcelain=$(git worktree list --porcelain 2>/dev/null || true)
 	[[ -n "$porcelain" ]] || return 1
 	_merge_worktree_record_matches "$porcelain" "$current_root" "$current_branch" "$current_head" || return 1
-
-	local canonical_dir=""
-	canonical_dir="${porcelain%%$'\n'*}"
-	canonical_dir="${canonical_dir#worktree }"
-	[[ -n "$canonical_dir" && "$canonical_dir" != "$current_root" ]] || return 1
 
 	local delete_remote_branch="1"
 	if [[ "$current_branch" != "$pr_head_ref" ]]; then
@@ -1188,11 +1192,44 @@ _merge_current_worktree_cleanup_plan() {
 		delete_remote_branch="0"
 	fi
 
-	printf '%s\t%s\t%s\t%s\n' "$current_root" "$current_branch" "$canonical_dir" "$delete_remote_branch"
+	printf '%s\t%s\t%s\n' "$current_root" "$current_branch" "$delete_remote_branch"
 	return 0
 }
 
-_merge_fresh_worktree_cleanup_plan() {
+_merge_current_canonical_dir_for_cleanup() {
+	local current_root="$1"
+	local porcelain=""
+	local canonical_dir=""
+
+	[[ -n "$current_root" ]] || return 1
+	porcelain=$(git worktree list --porcelain 2>/dev/null || true)
+	[[ -n "$porcelain" ]] || return 1
+	canonical_dir="${porcelain%%$'\n'*}"
+	canonical_dir="${canonical_dir#worktree }"
+	[[ -n "$canonical_dir" && "$canonical_dir" != "$current_root" && -d "$canonical_dir" ]] || return 1
+	printf '%s\n' "$canonical_dir"
+	return 0
+}
+
+_merge_current_worktree_cleanup_plan() {
+	local pr_head_ref="$1"
+	local pr_head_oid="$2"
+	local pr_head_repo="$3"
+	local repo="$4"
+	local cleanup_target=""
+	local worktree_path=""
+	local branch_name=""
+	local delete_remote_branch=""
+	local canonical_dir=""
+
+	cleanup_target=$(_merge_current_worktree_cleanup_target "$pr_head_ref" "$pr_head_oid" "$pr_head_repo" "$repo") || return 1
+	IFS=$'\t' read -r worktree_path branch_name delete_remote_branch <<<"$cleanup_target"
+	canonical_dir=$(_merge_current_canonical_dir_for_cleanup "$worktree_path") || return 1
+	printf '%s\t%s\t%s\t%s\n' "$worktree_path" "$branch_name" "$canonical_dir" "$delete_remote_branch"
+	return 0
+}
+
+_merge_fresh_worktree_cleanup_target() {
 	local pr_number="$1"
 	local repo="$2"
 	local pr_json=""
@@ -1212,20 +1249,37 @@ _merge_fresh_worktree_cleanup_plan() {
 		printf '%s' "$pr_json" | jq -r '[.headRefName, .headRefOid, .headRepository.nameWithOwner, .isCrossRepository] | @tsv'
 	)
 	: "$is_cross_repository"
-	_merge_current_worktree_cleanup_plan "$pr_head_ref" "$pr_head_oid" "$pr_head_repo" "$repo" || return 1
+	_merge_current_worktree_cleanup_target "$pr_head_ref" "$pr_head_oid" "$pr_head_repo" "$repo" || return 1
 	return 0
 }
 
-_merge_fresh_adopted_worktree_cleanup_plan() {
+_merge_fresh_worktree_cleanup_plan() {
+	local pr_number="$1"
+	local repo="$2"
+	local cleanup_target=""
+	local worktree_path=""
+	local branch_name=""
+	local delete_remote_branch=""
+	local canonical_dir=""
+
+	cleanup_target=$(_merge_fresh_worktree_cleanup_target "$pr_number" "$repo") || return 1
+	IFS=$'\t' read -r worktree_path branch_name delete_remote_branch <<<"$cleanup_target"
+	canonical_dir=$(_merge_current_canonical_dir_for_cleanup "$worktree_path") || return 1
+	printf '%s\t%s\t%s\t%s\n' "$worktree_path" "$branch_name" "$canonical_dir" "$delete_remote_branch"
+	return 0
+}
+
+_merge_fresh_adopted_worktree_cleanup_target() {
 	local pr_number="$1"
 	local repo="$2"
 	local pr_json=""
 	local pr_head_ref=""
 	local pr_head_oid=""
 	local pr_head_repo=""
-	local cleanup_plan=""
+	local cleanup_target=""
 	local worktree_path=""
 	local branch_name=""
+	local delete_remote_branch=""
 	local current_repo=""
 
 	pr_json=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh pr view "$pr_number" --repo "$repo" \
@@ -1242,12 +1296,13 @@ _merge_fresh_adopted_worktree_cleanup_plan() {
 	IFS=$'\t' read -r pr_head_ref pr_head_oid pr_head_repo < <(
 		printf '%s' "$pr_json" | jq -r '[.headRefName, .headRefOid, .headRepository.nameWithOwner] | @tsv'
 	)
-	cleanup_plan=$(_merge_current_worktree_cleanup_plan "$pr_head_ref" "$pr_head_oid" "$pr_head_repo" "$repo") || return 1
-	IFS=$'\t' read -r worktree_path branch_name _ <<<"$cleanup_plan"
+	cleanup_target=$(_merge_current_worktree_cleanup_target "$pr_head_ref" "$pr_head_oid" "$pr_head_repo" "$repo") || return 1
+	IFS=$'\t' read -r worktree_path branch_name delete_remote_branch <<<"$cleanup_target"
+	: "$delete_remote_branch"
 	[[ "$branch_name" == "$pr_head_ref" ]] || return 1
 	current_repo=$(_merge_current_github_repo_identity "$worktree_path" 2>/dev/null || true)
 	[[ -n "$current_repo" && "$current_repo" == "$repo" ]] || return 1
-	printf '%s\n' "$cleanup_plan"
+	printf '%s\n' "$cleanup_target"
 	return 0
 }
 
@@ -1288,14 +1343,11 @@ _merge_refresh_canonical_for_cleanup() {
 }
 
 _merge_report_canonical_sync_state() {
-	local cleanup_plan="$1"
-	if [[ -z "$cleanup_plan" ]]; then
+	local canonical_dir="$1"
+	if [[ -z "$canonical_dir" ]]; then
 		print_warning "CANONICAL_SYNC_PENDING=true reason=canonical_path_unavailable"
 		return 1
 	fi
-	local worktree_path branch_name canonical_dir delete_remote_branch
-	IFS=$'\t' read -r worktree_path branch_name canonical_dir delete_remote_branch <<<"$cleanup_plan"
-	: "$worktree_path" "$branch_name" "$delete_remote_branch"
 	local default_branch
 	default_branch=$(_merge_default_branch_for_cleanup "$canonical_dir")
 	_merge_refresh_canonical_for_cleanup "$canonical_dir" "$default_branch"
@@ -1363,12 +1415,12 @@ _merge_cleanup_linked_worktree() {
 _merge_record_deferred_cleanup_owner() {
 	local pr_number="$1"
 	local repo="$2"
-	local cleanup_plan="$3"
+	local cleanup_target="$3"
 	local release_status="${4:-pending}"
 	local executor_completion_state="${5:-FINALIZATION_PENDING}"
-	local worktree_path="" branch_name="" canonical_dir="" delete_remote_branch=""
-	IFS=$'\t' read -r worktree_path branch_name canonical_dir delete_remote_branch <<<"$cleanup_plan"
-	: "$canonical_dir" "$delete_remote_branch"
+	local worktree_path="" branch_name="" delete_remote_branch=""
+	IFS=$'\t' read -r worktree_path branch_name delete_remote_branch <<<"$cleanup_target"
+	: "$delete_remote_branch"
 	[[ -n "$worktree_path" && -n "$branch_name" ]] || return 1
 	[[ -d "$worktree_path" ]] || return 1
 
@@ -1407,7 +1459,7 @@ _merge_record_deferred_cleanup_owner() {
 cmd_adopt_merged_receipt() {
 	local pr_number="${1:-}"
 	local repo=""
-	local cleanup_plan=""
+	local cleanup_target=""
 	local release_status=""
 
 	if [[ $# -lt 1 || $# -gt 2 || ! "$pr_number" =~ ^[0-9]+$ ]]; then
@@ -1418,7 +1470,7 @@ cmd_adopt_merged_receipt() {
 		print_error "Adoption blocked: repository identity is unavailable"
 		return 1
 	}
-	cleanup_plan=$(_merge_fresh_adopted_worktree_cleanup_plan "$pr_number" "$repo") || {
+	cleanup_target=$(_merge_fresh_adopted_worktree_cleanup_target "$pr_number" "$repo") || {
 		print_error "Adoption blocked: merged PR head does not match this registered linked worktree and repository"
 		return 1
 	}
@@ -1430,7 +1482,7 @@ cmd_adopt_merged_receipt() {
 		print_error "Adoption blocked: terminal release evidence is missing or invalid"
 		return 1
 	}
-	_merge_record_deferred_cleanup_owner "$pr_number" "$repo" "$cleanup_plan" \
+	_merge_record_deferred_cleanup_owner "$pr_number" "$repo" "$cleanup_target" \
 		"$release_status" "FINALIZATION_PENDING" || {
 		print_error "Adoption blocked: cleanup receipt conflicts with existing owner, lease, or lifecycle evidence"
 		return 1
@@ -1442,10 +1494,10 @@ cmd_adopt_merged_receipt() {
 _merge_capture_session_distill_provenance() {
 	local pr_number="$1"
 	local repo="$2"
-	local cleanup_plan="$3"
-	local worktree_path branch_name canonical_dir delete_remote_branch
-	IFS=$'\t' read -r worktree_path branch_name canonical_dir delete_remote_branch <<<"$cleanup_plan"
-	: "$canonical_dir" "$delete_remote_branch"
+	local cleanup_target="$3"
+	local worktree_path branch_name delete_remote_branch
+	IFS=$'\t' read -r worktree_path branch_name delete_remote_branch <<<"$cleanup_target"
+	: "$delete_remote_branch"
 	local distill_helper="${SCRIPT_DIR}/session-distill-helper.sh"
 	[[ -x "$distill_helper" ]] || return 0
 	local session_id="${AIDEVOPS_SESSION_ID:-${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}}"
@@ -1460,8 +1512,8 @@ _merge_finalize_post_merge() {
 	local pr_number="$1"
 	local repo="$2"
 	local has_auto="$3"
-	local cleanup_plan="$4"
-	_merge_capture_session_distill_provenance "$pr_number" "$repo" "$cleanup_plan"
+	local cleanup_target="$4"
+	_merge_capture_session_distill_provenance "$pr_number" "$repo" "$cleanup_target"
 	local linked_issue=""
 	linked_issue=$(gh pr view "$pr_number" --repo "$repo" --json body \
 		--jq '.body' 2>/dev/null |
@@ -1479,8 +1531,8 @@ _merge_finalize_post_merge() {
 	fi
 
 	_merge_unlock_resources "$pr_number" "$repo"
-	if [[ "$has_auto" -eq 0 && -n "$cleanup_plan" ]]; then
-		if _merge_record_deferred_cleanup_owner "$pr_number" "$repo" "$cleanup_plan"; then
+	if [[ "$has_auto" -eq 0 && -n "$cleanup_target" ]]; then
+		if _merge_record_deferred_cleanup_owner "$pr_number" "$repo" "$cleanup_target"; then
 			print_info "LIFECYCLE_STATE=CLEANUP_DEFERRED; guarded cleanup ownership persisted outside the worktree"
 		else
 			print_warning "Post-merge worktree cleanup deferred, but durable handoff evidence could not be recorded"
@@ -1562,9 +1614,18 @@ cmd_merge() {
 		print_error "Merge blocked by review bot gate. Address bot findings or wait for reviews."
 		return 1
 	}
-	local _cleanup_plan=""
+	local _cleanup_target=""
+	local _cleanup_worktree=""
+	local _cleanup_branch=""
+	local _cleanup_delete_remote_branch=""
+	local _canonical_dir=""
 	if [[ "$has_auto" -eq 0 ]]; then
-		_cleanup_plan=$(_merge_fresh_worktree_cleanup_plan "$pr_number" "$repo" 2>/dev/null || true)
+		_cleanup_target=$(_merge_fresh_worktree_cleanup_target "$pr_number" "$repo" 2>/dev/null || true)
+		if [[ -n "$_cleanup_target" ]]; then
+			IFS=$'\t' read -r _cleanup_worktree _cleanup_branch _cleanup_delete_remote_branch <<<"$_cleanup_target"
+			: "$_cleanup_branch" "$_cleanup_delete_remote_branch"
+			_canonical_dir=$(_merge_current_canonical_dir_for_cleanup "$_cleanup_worktree" 2>/dev/null || true)
+		fi
 	fi
 	# Retarget any open PRs stacked on this branch before the head branch is
 	# deleted post-merge. GitHub auto-closes stacked children when their base
@@ -1583,11 +1644,11 @@ cmd_merge() {
 		return 1
 	fi
 	print_success "LIFECYCLE_STATE=MERGED merge_sha=${FULL_LOOP_MERGE_SHA}"
-	_merge_report_canonical_sync_state "$_cleanup_plan" || true
+	_merge_report_canonical_sync_state "$_canonical_dir" || true
 	if declare -F is_loop_active >/dev/null 2>&1 && is_loop_active; then
 		_full_loop_record_phase "postflight" "$pr_number" || return 1
 	fi
-	_merge_finalize_post_merge "$pr_number" "$repo" "$has_auto" "$_cleanup_plan"
+	_merge_finalize_post_merge "$pr_number" "$repo" "$has_auto" "$_cleanup_target"
 
 	return 0
 }

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -1816,6 +1816,7 @@ cmd_complete_after_cleanup() {
 	local pr_number="${1:-}"
 	local removed_worktree="${2:-}"
 	local repo=""
+	local release_status=""
 	[[ "$pr_number" =~ ^[0-9]+$ && -n "$removed_worktree" ]] || {
 		print_error "Usage: full-loop-helper.sh complete-after-cleanup <PR> <removed-worktree-path> [REPO]"
 		return 1
@@ -1832,24 +1833,31 @@ cmd_complete_after_cleanup() {
 		print_error "Completion blocked: no removal audit evidence for ${removed_worktree}"
 		return 1
 	}
-	if declare -F full_loop_mark_cleanup_cleaned_for_worktree >/dev/null 2>&1; then
-		full_loop_mark_cleanup_cleaned_for_worktree "$removed_worktree" || {
-			print_error "Completion blocked: durable cleanup receipt is not CLEANED for ${removed_worktree}"
-			return 1
-		}
-	fi
+	declare -F full_loop_mark_cleanup_cleaned_for_identity >/dev/null 2>&1 || {
+		print_error "Completion blocked: exact cleanup-receipt verifier is unavailable"
+		return 1
+	}
+	full_loop_mark_cleanup_cleaned_for_identity "$repo" "$pr_number" "$removed_worktree" || {
+		print_error "Completion blocked: durable cleanup receipt identity is not CLEANED for ${repo}#${pr_number} at ${removed_worktree}"
+		return 1
+	}
 	_full_loop_verify_merged_pr "$pr_number" "$repo" || {
 		print_error "Completion blocked: PR #${pr_number} lacks merged evidence"
+		return 1
+	}
+	release_status=$(_full_loop_terminal_release_status "$repo" "$pr_number") || {
+		print_error "Completion blocked: terminal release evidence is missing"
 		return 1
 	}
 	_full_loop_verify_aidevops_release_deploy "$repo" "$pr_number" || {
 		print_error "Completion blocked: release, deployment, or postflight evidence is missing"
 		return 1
 	}
+	full_loop_finalize_cleanup_receipt "$repo" "$pr_number" "$release_status" || {
+		print_error "Completion blocked: cleanup receipt conflicts with terminal release evidence"
+		return 1
+	}
 	printf "\n${BOLD}${GREEN}=== FULL DEVELOPMENT LOOP - COMPLETE ===${NC}\n"
-	local receipt_path="" release_status="$_FULL_LOOP_RELEASE_NOT_REQUESTED"
-	receipt_path=$(_full_loop_release_receipt_path "$repo" "$pr_number") || return 1
-	[[ -f "$receipt_path" ]] && IFS= read -r release_status <"$receipt_path"
 	printf "PR: #%s | Lifecycle: CLEANED | release:%s\n\n" "$pr_number" "$release_status"
 	echo "<promise>FULL_LOOP_COMPLETE</promise>"
 	return 0

--- a/.agents/scripts/tests/test-full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/tests/test-full-loop-cleanup-receipt.sh
@@ -109,7 +109,19 @@ printf 'PASS cleanup lease survives a real registry round trip with distinct run
 printf '[2026-07-21T00:00:00Z] [test] worktree-removed: %s — branch-merged — mode=permanent\n' \
 	"${TEST_ROOT}/worktree-one" >>"$AIDEVOPS_CLEANUP_LOG"
 rm -rf "${TEST_ROOT}/worktree-one"
-full_loop_mark_cleanup_cleaned_for_worktree "${TEST_ROOT}/worktree-one"
+if full_loop_mark_cleanup_cleaned_for_identity wrong/repo 101 "${TEST_ROOT}/worktree-one"; then
+	printf 'FAIL conflicting repository identity transitioned the cleanup receipt\n'
+	exit 1
+fi
+if full_loop_mark_cleanup_cleaned_for_identity example/repo 999 "${TEST_ROOT}/worktree-one"; then
+	printf 'FAIL conflicting PR identity transitioned the cleanup receipt\n'
+	exit 1
+fi
+if full_loop_mark_cleanup_cleaned_for_identity example/repo 101 "${TEST_ROOT}/different-worktree"; then
+	printf 'FAIL conflicting worktree identity transitioned the cleanup receipt\n'
+	exit 1
+fi
+full_loop_mark_cleanup_cleaned_for_identity example/repo 101 "${TEST_ROOT}/worktree-one"
 full_loop_mark_cleanup_cleaned_for_worktree "${TEST_ROOT}/worktree-one"
 jq -e '.resource_cleanup_state == "CLEANED" and .cleanup_lease.state == "released" and (.cleaned_at | length > 0)' \
 	"$receipt_one" >/dev/null
@@ -117,6 +129,7 @@ if full_loop_transition_cleanup_receipt "$receipt_one" "$_FULL_LOOP_CLEANUP_DEFE
 	printf 'FAIL terminal CLEANED receipt regressed to CLEANUP_DEFERRED\n'
 	exit 1
 fi
+printf 'PASS conflicting repository, PR, and worktree identities fail closed\n'
 printf 'PASS CLEANED transition is idempotent and irreversible\n'
 
 sleep 1

--- a/.agents/scripts/tests/test-full-loop-completion-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-completion-evidence.sh
@@ -99,7 +99,8 @@ export FULL_LOOP_MERGED_EVIDENCE_ATTEMPTS=2
 export FULL_LOOP_MERGED_EVIDENCE_DELAY_SECONDS=0
 # shellcheck source=../full-loop-cleanup-receipt.sh
 source "${SCRIPTS_DIR}/full-loop-cleanup-receipt.sh"
-full_loop_write_cleanup_deferred testorg/repo 42 "$removed_path" feature/test-cleanup "$$" test-session not-requested >/dev/null
+full_loop_write_cleanup_deferred testorg/repo 42 "$removed_path" feature/test-cleanup \
+	"$$" test-session pending FINALIZATION_PENDING >/dev/null
 
 record_runner="${ROOT}/record-runner.sh"
 cat >"$record_runner" <<RUNNER
@@ -737,13 +738,55 @@ for invalid_case in missing failed mismatched; do
 done
 printf 'PASS missing failed and mismatched receipts keep authorized lifecycle blocked\n'
 
-AIDEVOPS_CLEANUP_LOG="$cleanup_log" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null || {
+mkdir -p "$receipt_dir"
+printf '%s\n' not-requested >"${receipt_dir}/testorg_repo-42.status"
+different_removed_path="${ROOT}/different-removed-worktree"
+printf '[2026-07-11T00:00:02Z] [test] worktree-removed: %s — branch-merged — mode=permanent\n' \
+	"$different_removed_path" >>"$cleanup_log"
+if AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_CLEANUP_LOG="$cleanup_log" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" wrong/repo >/dev/null 2>&1; then
+	printf 'FAIL conflicting repository identity was accepted as complete\n'
+	exit 1
+fi
+if AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_CLEANUP_LOG="$cleanup_log" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 999 "$removed_path" testorg/repo >/dev/null 2>&1; then
+	printf 'FAIL conflicting PR identity was accepted as complete\n'
+	exit 1
+fi
+if AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_CLEANUP_LOG="$cleanup_log" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$different_removed_path" testorg/repo >/dev/null 2>&1; then
+	printf 'FAIL conflicting worktree identity was accepted as complete\n'
+	exit 1
+fi
+jq -e '.resource_cleanup_state == "CLEANUP_DEFERRED" and .executor_completion_state == "FINALIZATION_PENDING"' \
+	"${cleanup_receipt_dir}/testorg_repo-42.json" >/dev/null
+printf 'PASS completion rejects conflicting repository, PR, and worktree identities without mutation\n'
+
+release_conflict_path="${ROOT}/release-conflict-worktree"
+printf '[2026-07-11T00:00:03Z] [test] worktree-removed: %s — branch-merged — mode=permanent\n' \
+	"$release_conflict_path" >>"$cleanup_log"
+release_conflict_receipt=$(full_loop_write_cleanup_deferred testorg/repo 49 "$release_conflict_path" \
+	feature/release-conflict "$$" release-conflict-session published FINALIZATION_PENDING)
+printf '%s\n' not-requested >"${receipt_dir}/testorg_repo-49.status"
+if AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_CLEANUP_LOG="$cleanup_log" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 49 "$release_conflict_path" testorg/repo >/dev/null 2>&1; then
+	printf 'FAIL conflicting release identity was accepted as complete\n'
+	exit 1
+fi
+jq -e '.resource_cleanup_state == "CLEANED" and .executor_completion_state == "FINALIZATION_PENDING"
+	and .release_status == "published"' "$release_conflict_receipt" >/dev/null
+printf 'PASS completion preserves audited cleanup while rejecting conflicting release identity\n'
+
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_CLEANUP_LOG="$cleanup_log" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null || {
 	printf 'FAIL complete merged and cleaned evidence was rejected\n'
 	exit 1
 }
-jq -e '.resource_cleanup_state == "CLEANED" and .cleanup_lease.state == "released" and (.cleaned_at | length > 0)' \
+jq -e '.resource_cleanup_state == "CLEANED" and .cleanup_lease.state == "released"
+	and .executor_completion_state == "COMPLETE" and .release_status == "not-requested"
+	and (.cleaned_at | length > 0)' \
 	"${cleanup_receipt_dir}/testorg_repo-42.json" >/dev/null
-printf 'PASS merged and cleaned evidence completes lifecycle\n'
+printf 'PASS merged removal audit and terminal release evidence finalize the cleanup receipt\n'
 
 rm -f "${receipt_dir}/marcusquinn_aidevops-42.status"
 AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$record_runner" 42 marcusquinn/aidevops >/dev/null
@@ -762,20 +805,20 @@ fi
 printf 'PASS release:failed keeps lifecycle open\n'
 
 mkdir -p "$removed_path"
-if AIDEVOPS_CLEANUP_LOG="$cleanup_log" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null; then
+if AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_CLEANUP_LOG="$cleanup_log" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null; then
 	printf 'FAIL existing worktree was accepted as cleaned\n'
 	exit 1
 fi
 printf 'PASS existing worktree keeps cleanup pending\n'
 rm -rf "$removed_path"
 
-if COMPLETION_PR_STATE=OPEN AIDEVOPS_CLEANUP_LOG="$cleanup_log" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null; then
+if COMPLETION_PR_STATE=OPEN AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_CLEANUP_LOG="$cleanup_log" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null; then
 	printf 'FAIL open PR was accepted as complete\n'
 	exit 1
 fi
 printf 'PASS open PR blocks lifecycle completion\n'
 
-if AIDEVOPS_CLEANUP_LOG="${ROOT}/missing.log" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null; then
+if AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_CLEANUP_LOG="${ROOT}/missing.log" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" 42 "$removed_path" testorg/repo >/dev/null; then
 	printf 'FAIL absent cleanup audit was accepted as complete\n'
 	exit 1
 fi

--- a/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
@@ -519,6 +519,35 @@ test_worktree_metadata_match_rejects_missing_record() {
 	return 0
 }
 
+test_cmd_merge_persists_cleanup_without_canonical_path() {
+	setup_subject
+	local worktree_path="${TEST_ROOT}/worktrees/repo-feature-full-loop-cleanup"
+	local receipt_path="${AIDEVOPS_FULL_LOOP_CLEANUP_DIR}/example_repo-123.json"
+	local receipt_worktree=""
+	local output=""
+	local rc=0
+	receipt_worktree=$(git -C "$worktree_path" rev-parse --show-toplevel)
+
+	_merge_current_canonical_dir_for_cleanup() {
+		local current_root="$1"
+		[[ -n "$current_root" ]] || return 1
+		return 1
+	}
+
+	output=$(cmd_merge "123" "example/repo" --squash 2>&1) || rc=1
+	[[ "$output" == *"CANONICAL_SYNC_PENDING=true reason=canonical_path_unavailable"* ]] || rc=1
+	[[ "$output" == *"LIFECYCLE_STATE=CLEANUP_DEFERRED"* ]] || rc=1
+	[[ -f "$receipt_path" ]] || rc=1
+	jq -e --arg worktree "$receipt_worktree" '
+		.repository == "example/repo" and .pr_number == 123
+		and .worktree == $worktree and .branch == "feature/full-loop-cleanup"
+		and .resource_cleanup_state == "CLEANUP_DEFERRED"
+		and .executor_completion_state == "FINALIZATION_PENDING"
+	' "$receipt_path" >/dev/null || rc=1
+	print_result "canonical sync pending coexists with durable deferred cleanup" "$rc"
+	return 0
+}
+
 test_cmd_merge_defers_cleanup_for_live_process_cwd() {
 	setup_subject
 	local canonical_repo="${TEST_ROOT}/repo"
@@ -597,6 +626,8 @@ main() {
 	test_cleanup_plan_rejects_unrelated_same_content_branch
 	test_cleanup_plan_rejects_ambiguous_alias_repository
 	test_worktree_metadata_match_rejects_missing_record
+	# This fixture replaces the canonical resolver, so keep it last.
+	test_cmd_merge_persists_cleanup_without_canonical_path
 	printf '\n%d/%d tests passed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"
 	[[ "$TESTS_FAILED" -eq 0 ]] || return 1
 	return 0

--- a/.agents/scripts/tests/test-worktree-removal-audit.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit.sh
@@ -34,6 +34,7 @@ AUDIT_HELPER="${SCRIPT_DIR}/../audit-worktree-removal-helper.sh"
 COMMANDS_HELPER="${SCRIPT_DIR}/../worktree-helper-cmds.sh"
 CLEAN_HELPER="${SCRIPT_DIR}/../worktree-clean-lib.sh"
 REGISTRY_HELPER="${SCRIPT_DIR}/../shared-worktree-registry.sh"
+CLEANUP_RECEIPT_HELPER="${SCRIPT_DIR}/../full-loop-cleanup-receipt.sh"
 SKILL_PR_HELPER="${SCRIPT_DIR}/../skill-update-pr-lib.sh"
 GIT_BIN="${AIDEVOPS_TEST_GIT_BIN:-/usr/bin/git}"
 
@@ -104,6 +105,7 @@ create_git_worktree_fixture() {
 	"$GIT_BIN" init -q -b main "$repo_path" || return 1
 	"$GIT_BIN" -C "$repo_path" config user.email test@example.invalid || return 1
 	"$GIT_BIN" -C "$repo_path" config user.name 'Aidevops Test' || return 1
+	"$GIT_BIN" -C "$repo_path" config commit.gpgsign false || return 1
 	printf 'base\n' >"${repo_path}/README.md" || return 1
 	"$GIT_BIN" -C "$repo_path" add README.md || return 1
 	"$GIT_BIN" -C "$repo_path" commit -q -m init || return 1
@@ -828,6 +830,8 @@ test_manual_cleanup_archives_removes_and_prunes() {
 	local wt_path="${TEST_DIR}/manual-archive-worktree"
 	local trash_destination="${TEST_DIR}/manual-archive-trash"
 	local unregister_log="${TEST_DIR}/manual-archive-unregister.log"
+	local cleanup_receipt_dir="${TEST_DIR}/manual-cleanup-receipts"
+	local cleanup_receipt="${TEST_DIR}/manual-cleanup-receipts/example_repo-321.json"
 	local wt_root=""
 	local rc=0
 	export AIDEVOPS_CLEANUP_LOG="$log_file"
@@ -836,12 +840,18 @@ test_manual_cleanup_archives_removes_and_prunes() {
 	wt_root=$("$GIT_BIN" -C "$wt_path" rev-parse --show-toplevel 2>/dev/null) || rc=1
 	if ! (
 		unset _WORKTREE_CMDS_LIB_LOADED 2>/dev/null || true
+		unset _FULL_LOOP_CLEANUP_RECEIPT_LOADED 2>/dev/null || true
 		SCRIPT_DIR="${COMMANDS_HELPER%/*}"
 		SCRIPT_NAME="worktree-helper.sh"
 		_WTAR_WH_CALLER="worktree-helper.sh"
 		RED="" GREEN="" YELLOW="" BLUE="" NC=""
 		export AIDEVOPS_REAL_GIT_BIN="$GIT_BIN"
 		export AIDEVOPS_WORKTREE_TRASH_ROOT="$trash_destination"
+		export AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir"
+		# shellcheck source=../full-loop-cleanup-receipt.sh
+		source "$CLEANUP_RECEIPT_HELPER"
+		full_loop_write_cleanup_deferred example/repo 321 "$wt_path" feature/manual-archive \
+			"$$" manual-cleanup-test not-requested >/dev/null
 		# shellcheck source=../worktree-helper-cmds.sh
 		source "$COMMANDS_HELPER"
 		get_repo_root() {
@@ -871,8 +881,11 @@ test_manual_cleanup_archives_removes_and_prunes() {
 	fi
 	grep -Fxq "$wt_path" "$unregister_log" 2>/dev/null || rc=1
 	assert_file_contains "$log_file" "worktree-removed.*manual.*mode=trash" || rc=1
+	jq -e '.repository == "example/repo" and .pr_number == 321
+		and .resource_cleanup_state == "CLEANED" and .cleanup_lease.state == "released"' \
+		"$cleanup_receipt" >/dev/null || rc=1
 	print_result "manual_cleanup_archives_removes_and_prunes" "$rc" \
-		"Expected archive-first manual cleanup to verify metadata and unregister"
+		"Expected archive-first manual cleanup to verify metadata, unregister, and transition its exact receipt"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-worktree-removal-audit.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit.sh
@@ -34,7 +34,6 @@ AUDIT_HELPER="${SCRIPT_DIR}/../audit-worktree-removal-helper.sh"
 COMMANDS_HELPER="${SCRIPT_DIR}/../worktree-helper-cmds.sh"
 CLEAN_HELPER="${SCRIPT_DIR}/../worktree-clean-lib.sh"
 REGISTRY_HELPER="${SCRIPT_DIR}/../shared-worktree-registry.sh"
-CLEANUP_RECEIPT_HELPER="${SCRIPT_DIR}/../full-loop-cleanup-receipt.sh"
 SKILL_PR_HELPER="${SCRIPT_DIR}/../skill-update-pr-lib.sh"
 GIT_BIN="${AIDEVOPS_TEST_GIT_BIN:-/usr/bin/git}"
 
@@ -848,12 +847,10 @@ test_manual_cleanup_archives_removes_and_prunes() {
 		export AIDEVOPS_REAL_GIT_BIN="$GIT_BIN"
 		export AIDEVOPS_WORKTREE_TRASH_ROOT="$trash_destination"
 		export AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir"
-		# shellcheck source=../full-loop-cleanup-receipt.sh
-		source "$CLEANUP_RECEIPT_HELPER"
-		full_loop_write_cleanup_deferred example/repo 321 "$wt_path" feature/manual-archive \
-			"$$" manual-cleanup-test not-requested >/dev/null
 		# shellcheck source=../worktree-helper-cmds.sh
 		source "$COMMANDS_HELPER"
+		full_loop_write_cleanup_deferred example/repo 321 "$wt_path" feature/manual-archive \
+			"$$" manual-cleanup-test not-requested >/dev/null
 		get_repo_root() {
 			printf '%s\n' "$repo_path"
 			return 0

--- a/.agents/scripts/worktree-helper-cmds.sh
+++ b/.agents/scripts/worktree-helper-cmds.sh
@@ -47,6 +47,11 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _lib_path
 fi
 
+if [[ -f "${SCRIPT_DIR}/full-loop-cleanup-receipt.sh" ]]; then
+	# shellcheck source=./full-loop-cleanup-receipt.sh
+	source "${SCRIPT_DIR}/full-loop-cleanup-receipt.sh"
+fi
+
 # --- cmd_list ---
 
 # List all worktrees with branch names, merge status, and current marker.

--- a/.agents/scripts/worktree-helper-cmds.sh
+++ b/.agents/scripts/worktree-helper-cmds.sh
@@ -326,6 +326,26 @@ _remove_acquire_degraded_cleanup_lease() {
 	return 0
 }
 
+_remove_finalize_post_removal() {
+	local removed_branch="$1"
+	local cleanup_receipt="$2"
+	local path_to_remove="$3"
+
+	if [[ -n "$removed_branch" ]]; then
+		localdev_auto_branch_rm "$removed_branch"
+		preview_proxy_auto_free "$removed_branch"
+	fi
+	if [[ -z "$cleanup_receipt" ]]; then
+		return 0
+	fi
+	if ! declare -F full_loop_mark_cleanup_receipt_cleaned >/dev/null 2>&1 ||
+		! full_loop_mark_cleanup_receipt_cleaned "$cleanup_receipt" "$path_to_remove"; then
+		printf '%b\n' "${YELLOW}Partial cleanup: worktree removal was audited, but its durable cleanup receipt was not transitioned.${NC}" >&2
+		return 1
+	fi
+	return 0
+}
+
 _remove_cleanup_and_execute() {
 	local path_to_remove="$1"
 	local repo_context=""
@@ -337,9 +357,13 @@ _remove_cleanup_and_execute() {
 	local guard_status=0
 	local cleanup_lease_acquired="$_WT_BOOL_FALSE"
 	local audit_context="recovery_path=archive-first"
+	local cleanup_receipt=""
 	repo_context=$(get_repo_root) || return 1
 	if [[ "${WORKTREE_FORCE_REMOVE:-}" == "1" && "${_WT_REMOVE_DEGRADED_RECOVERY:-0}" != "1" ]]; then
 		force_remove="$_WT_BOOL_TRUE"
+	fi
+	if declare -F full_loop_cleanup_receipt_for_worktree >/dev/null 2>&1; then
+		cleanup_receipt=$(full_loop_cleanup_receipt_for_worktree "$path_to_remove" 2>/dev/null || true)
 	fi
 
 	# Capture branch name before removal for localdev cleanup (t1224.8)
@@ -412,15 +436,7 @@ _remove_cleanup_and_execute() {
 	# t2976: audit log — manual removal completed
 	log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_WH_CALLER" "$path_to_remove" "$_WT_REMOVE_MODE_MANUAL" "$completed_mode" "$audit_context"
 
-	# Localdev integration (t1224.8): auto-remove branch subdomain route
-	if [[ -n "$removed_branch" ]]; then
-		localdev_auto_branch_rm "$removed_branch"
-	fi
-
-	# Preview proxy integration (GH#21560): free port + deregister proxy route
-	if [[ -n "$removed_branch" ]]; then
-		preview_proxy_auto_free "$removed_branch"
-	fi
+	_remove_finalize_post_removal "$removed_branch" "$cleanup_receipt" "$path_to_remove" || return 1
 
 	return 0
 }


### PR DESCRIPTION
## Summary

Persist post-merge cleanup identity independently of canonical checkout discovery, transition exact audited removals to CLEANED, and finalize them against terminal release evidence.

## Files Changed

.agents/scripts/full-loop-cleanup-receipt.sh, .agents/scripts/full-loop-helper-merge.sh, .agents/scripts/full-loop-helper-state.sh, .agents/scripts/tests/test-full-loop-cleanup-receipt.sh, .agents/scripts/tests/test-full-loop-completion-evidence.sh, .agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh, .agents/scripts/tests/test-worktree-removal-audit.sh, .agents/scripts/worktree-helper-cmds.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Focused cleanup receipt, merge cleanup, completion evidence, and worktree removal suites pass on Bash 3.2.

Resolves #29118


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 14m and 122,596 tokens on this as a headless worker.