### PR TITLE
GH#29105: Finalize merge cleanup receipts idempotently

### DIFF
--- a/.agents/scripts/full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/full-loop-cleanup-receipt.sh
@@ -15,6 +15,11 @@ _FULL_LOOP_CLEANUP_DEFERRED="CLEANUP_DEFERRED"
 _FULL_LOOP_CLEANUP_LEASED="CLEANUP_LEASED"
 _FULL_LOOP_CLEANUP_CLEANED="CLEANED"
 _FULL_LOOP_EXECUTOR_COMPLETE="COMPLETE"
+_FULL_LOOP_EXECUTOR_FINALIZATION_PENDING="FINALIZATION_PENDING"
+_FULL_LOOP_CLEANUP_LEASE_PENDING="pending"
+_FULL_LOOP_OWNER_SESSION_FALLBACK="full-loop-lifecycle"
+_FULL_LOOP_RECEIPT_RELEASE_AUTHORIZED="authorized"
+_FULL_LOOP_RECEIPT_RELEASE_PENDING="$_FULL_LOOP_CLEANUP_LEASE_PENDING"
 _FULL_LOOP_RECEIPT_RELEASE_PUBLISHED="published"
 _FULL_LOOP_RECEIPT_RELEASE_NOT_REQUESTED="not-requested"
 _FULL_LOOP_RECEIPT_RELEASE_SUPERSEDED="superseded"
@@ -463,7 +468,8 @@ _full_loop_cleanup_deferred_matches() {
 		--argjson owner_pid "$owner_pid" --arg owner_identity "$owner_identity" \
 		--arg owner_session "$owner_session" --arg release_status "$release_status" \
 		--arg executor_completion_state "$executor_completion_state" \
-		--arg cleanup_deferred "$_FULL_LOOP_CLEANUP_DEFERRED" '
+		--arg cleanup_deferred "$_FULL_LOOP_CLEANUP_DEFERRED" \
+		--arg cleanup_lease_pending "$_FULL_LOOP_CLEANUP_LEASE_PENDING" '
 		.schema_version == 1
 		and .repository == $repo and .pr_number == $pr_number
 		and .worktree == $worktree and .branch == $branch
@@ -473,7 +479,7 @@ _full_loop_cleanup_deferred_matches() {
 		and .owner.pid == $owner_pid
 		and .owner.process_identity == $owner_identity
 		and .owner.session == $owner_session
-		and .cleanup_lease == {state:"pending",pid:null,acquired_at:null}
+		and .cleanup_lease == {state:$cleanup_lease_pending,pid:null,acquired_at:null}
 	' "$receipt_path" >/dev/null 2>&1
 	return $?
 }
@@ -493,7 +499,7 @@ full_loop_write_cleanup_deferred() {
 	local temp_path=""
 
 	[[ -n "$worktree" && -n "$branch" && "$owner_pid" =~ ^[0-9]+$ ]] || return 1
-	[[ "$executor_completion_state" == "FINALIZATION_PENDING" || "$executor_completion_state" == "$_FULL_LOOP_EXECUTOR_COMPLETE" ]] || return 1
+	[[ "$executor_completion_state" == "$_FULL_LOOP_EXECUTOR_FINALIZATION_PENDING" || "$executor_completion_state" == "$_FULL_LOOP_EXECUTOR_COMPLETE" ]] || return 1
 	command -v jq >/dev/null 2>&1 || return 1
 	receipt_path=$(_full_loop_cleanup_receipt_path "$repo" "$pr_number") || return 1
 	_full_loop_receipt_lock_acquire || return 1
@@ -527,10 +533,11 @@ full_loop_write_cleanup_deferred() {
 		--arg owner_session "$owner_session" --arg release_status "$release_status" \
 		--arg executor_completion_state "$executor_completion_state" \
 		--arg state "$_FULL_LOOP_CLEANUP_DEFERRED" --arg now "$now" \
+		--arg cleanup_lease_pending "$_FULL_LOOP_CLEANUP_LEASE_PENDING" \
 		'{schema_version:1,repository:$repo,pr_number:$pr_number,worktree:$worktree,branch:$branch,
 		  executor_completion_state:$executor_completion_state,resource_cleanup_state:$state,release_status:$release_status,
 		  owner:{pid:$owner_pid,process_identity:$owner_identity,session:$owner_session},
-		  cleanup_lease:{state:"pending",pid:null,acquired_at:null},created_at:$now,updated_at:$now,cleaned_at:null}' \
+		  cleanup_lease:{state:$cleanup_lease_pending,pid:null,acquired_at:null},created_at:$now,updated_at:$now,cleaned_at:null}' \
 		>"$temp_path" || {
 		_full_loop_receipt_lock_release
 		return 1
@@ -1031,22 +1038,65 @@ full_loop_finalize_cleanup_receipt() {
 	local repo="$1"
 	local pr_number="$2"
 	local release_status="$3"
+	local expected_worktree="${4:-}"
+	local expected_branch="${5:-}"
+	local expected_owner_pid="${6:-}"
+	local expected_owner_session="${7:-}"
 	local receipt_path=""
 	local current_release=""
 	local current_executor=""
+	local expected_owner_identity=""
+	local require_exact_evidence=0
 	local now=""
+	[[ $# -eq 3 || $# -eq 7 ]] || return 1
 	[[ "$release_status" == "$_FULL_LOOP_RECEIPT_RELEASE_PUBLISHED" || "$release_status" == "$_FULL_LOOP_RECEIPT_RELEASE_SUPERSEDED" || "$release_status" == "$_FULL_LOOP_RECEIPT_RELEASE_NOT_REQUESTED" ]] || return 1
+	if [[ $# -eq 7 ]]; then
+		[[ -n "$expected_worktree" && -n "$expected_branch" && "$expected_owner_pid" =~ ^[0-9]+$ ]] || return 1
+		expected_owner_identity=$(_full_loop_process_identity "$expected_owner_pid") || return 1
+		require_exact_evidence=1
+	fi
 	receipt_path=$(_full_loop_cleanup_receipt_path "$repo" "$pr_number") || return 1
 	[[ -f "$receipt_path" ]] || return 1
 	_full_loop_receipt_lock_acquire || return 1
-	if ! jq -e --arg repo "$repo" --argjson pr "$pr_number" \
+	if [[ "$require_exact_evidence" -eq 1 ]]; then
+		if ! jq -e \
+			--arg repo "$repo" --argjson pr "$pr_number" \
+			--arg worktree "$expected_worktree" --arg branch "$expected_branch" \
+			--argjson owner_pid "$expected_owner_pid" --arg owner_identity "$expected_owner_identity" \
+			--arg owner_session "$expected_owner_session" --arg release_status "$release_status" \
+			--arg release_pending "$_FULL_LOOP_RECEIPT_RELEASE_PENDING" \
+			--arg release_authorized "$_FULL_LOOP_RECEIPT_RELEASE_AUTHORIZED" \
+			--arg release_not_requested "$_FULL_LOOP_RECEIPT_RELEASE_NOT_REQUESTED" \
+			--arg cleanup_deferred "$_FULL_LOOP_CLEANUP_DEFERRED" \
+			--arg executor_complete "$_FULL_LOOP_EXECUTOR_COMPLETE" \
+			--arg executor_pending "$_FULL_LOOP_EXECUTOR_FINALIZATION_PENDING" \
+			--arg cleanup_lease_pending "$_FULL_LOOP_CLEANUP_LEASE_PENDING" '
+			.schema_version == 1
+			and .repository == $repo and .pr_number == $pr
+			and .worktree == $worktree and .branch == $branch
+			and (.executor_completion_state == $executor_pending or .executor_completion_state == $executor_complete)
+			and .resource_cleanup_state == $cleanup_deferred
+			and (
+				.release_status == $release_status
+				or .release_status == $release_pending
+				or (.release_status == $release_authorized and $release_status != $release_not_requested)
+			)
+			and .owner.pid == $owner_pid
+			and .owner.process_identity == $owner_identity
+			and .owner.session == $owner_session
+			and .cleanup_lease == {state:$cleanup_lease_pending,pid:null,acquired_at:null}
+		' "$receipt_path" >/dev/null 2>&1; then
+			_full_loop_receipt_lock_release
+			return 1
+		fi
+	elif ! jq -e --arg repo "$repo" --argjson pr "$pr_number" \
 		'.repository == $repo and .pr_number == $pr' "$receipt_path" >/dev/null 2>&1; then
 		_full_loop_receipt_lock_release
 		return 1
 	fi
 	current_executor=$(jq -r '.executor_completion_state // empty' "$receipt_path" 2>/dev/null || true)
 	current_release=$(jq -r '.release_status // empty' "$receipt_path" 2>/dev/null || true)
-	if [[ "$current_executor" != "FINALIZATION_PENDING" && "$current_executor" != "$_FULL_LOOP_EXECUTOR_COMPLETE" ]]; then
+	if [[ "$current_executor" != "$_FULL_LOOP_EXECUTOR_FINALIZATION_PENDING" && "$current_executor" != "$_FULL_LOOP_EXECUTOR_COMPLETE" ]]; then
 		_full_loop_receipt_lock_release
 		return 1
 	fi

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -1379,7 +1379,7 @@ _merge_record_deferred_cleanup_owner() {
 	[[ "$owner_pid" =~ ^[0-9]+$ ]] || owner_pid="$PPID"
 	[[ "$owner_pid" =~ ^[0-9]+$ ]] || return 1
 
-	local owner_session="${AIDEVOPS_SESSION_ID:-${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-full-loop-merge}}}"
+	local owner_session="${AIDEVOPS_SESSION_ID:-${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-$_FULL_LOOP_OWNER_SESSION_FALLBACK}}}"
 	if ! declare -F full_loop_write_cleanup_deferred >/dev/null 2>&1; then
 		return 1
 	fi
@@ -1398,7 +1398,7 @@ _merge_record_deferred_cleanup_owner() {
 	if declare -F claim_worktree_ownership >/dev/null 2>&1; then
 		claim_worktree_ownership "$worktree_path" "$branch_name" \
 			--owner-pid "$owner_pid" \
-			--session "${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-full-loop-merge}}" \
+			--session "$owner_session" \
 			--task "post-merge-cleanup" >/dev/null 2>&1 || true
 	fi
 	return 0

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -1595,18 +1595,32 @@ cmd_complete() {
 	current_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
 	local current_branch=""
 	local owner_pid=""
-	local owner_session="${AIDEVOPS_SESSION_ID:-${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-full-loop-complete}}}"
+	local owner_session="${AIDEVOPS_SESSION_ID:-${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-$_FULL_LOOP_OWNER_SESSION_FALLBACK}}}"
+	local receipt_path=""
 	current_branch=$(git branch --show-current 2>/dev/null || true)
 	owner_pid="${PPID:-}"
 	if declare -F _resolve_worktree_owner_pid >/dev/null 2>&1; then
 		owner_pid=$(_resolve_worktree_owner_pid "" 2>/dev/null || printf '%s' "${PPID:-}")
 	fi
 	if [[ -n "$current_root" && -n "$current_branch" ]] && declare -F full_loop_write_cleanup_deferred >/dev/null 2>&1; then
-		full_loop_write_cleanup_deferred "$repo" "$PR_NUMBER" "$current_root" "$current_branch" \
-			"$owner_pid" "$owner_session" "${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" >/dev/null || {
-			print_error "Cannot persist durable deferred-cleanup handoff"
-			return 1
-		}
+		receipt_path=$(_full_loop_cleanup_receipt_path "$repo" "$PR_NUMBER") || return 1
+		if [[ -f "$receipt_path" ]]; then
+			full_loop_finalize_cleanup_receipt "$repo" "$PR_NUMBER" \
+				"${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" "$current_root" "$current_branch" \
+				"$owner_pid" "$owner_session" || {
+				print_error "Cannot finalize durable deferred-cleanup handoff"
+				return 1
+			}
+		elif ! full_loop_write_cleanup_deferred "$repo" "$PR_NUMBER" "$current_root" "$current_branch" \
+			"$owner_pid" "$owner_session" "${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" >/dev/null; then
+			# A merge process may have created the receipt after the existence check.
+			full_loop_finalize_cleanup_receipt "$repo" "$PR_NUMBER" \
+				"${RELEASE_STATUS:-$_FULL_LOOP_RELEASE_NOT_REQUESTED}" "$current_root" "$current_branch" \
+				"$owner_pid" "$owner_session" || {
+				print_error "Cannot persist durable deferred-cleanup handoff"
+				return 1
+			}
+		fi
 	else
 		print_error "Cannot persist durable deferred-cleanup handoff without worktree and branch evidence"
 		return 1

--- a/.agents/scripts/tests/test-full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/tests/test-full-loop-cleanup-receipt.sh
@@ -55,6 +55,51 @@ replayed_receipt=$(full_loop_write_cleanup_deferred example/repo 101 "${TEST_ROO
 cmp -s "$receipt_one" "${TEST_ROOT}/receipt-idempotent.json"
 printf 'PASS identical deferred receipt replay is idempotent\n'
 
+finalizing_receipt=$(full_loop_write_cleanup_deferred example/repo 104 "${TEST_ROOT}/worktree-two" feature/finalize \
+	"$OWNER_PID" session-finalize not-requested FINALIZATION_PENDING)
+full_loop_finalize_cleanup_receipt example/repo 104 not-requested "${TEST_ROOT}/worktree-two" feature/finalize \
+	"$OWNER_PID" session-finalize
+jq -e '.executor_completion_state == "COMPLETE" and .resource_cleanup_state == "CLEANUP_DEFERRED"' \
+	"$finalizing_receipt" >/dev/null
+cp "$finalizing_receipt" "${TEST_ROOT}/receipt-finalized.json"
+full_loop_finalize_cleanup_receipt example/repo 104 not-requested "${TEST_ROOT}/worktree-two" feature/finalize \
+	"$OWNER_PID" session-finalize
+cmp -s "$finalizing_receipt" "${TEST_ROOT}/receipt-finalized.json"
+printf 'PASS exact deferred receipt finalization is idempotent\n'
+
+for conflict_filter in \
+	'.repository = "wrong/repo"' \
+	'.pr_number = 999' \
+	'.worktree = "/wrong/worktree"' \
+	'.branch = "feature/wrong"' \
+	'.owner.pid = 99999999' \
+	'.owner.process_identity = "wrong process generation"' \
+	'.owner.session = "wrong-session"' \
+	'.release_status = "published"' \
+	'.resource_cleanup_state = "CLEANUP_LEASED"' \
+	'.cleanup_lease = {state:"acquired",pid:99999999,acquired_at:"2026-08-02T00:00:00Z"}'; do
+	cp "${TEST_ROOT}/receipt-finalized.json" "$finalizing_receipt"
+	jq "$conflict_filter" "$finalizing_receipt" >"${finalizing_receipt}.tmp"
+	mv "${finalizing_receipt}.tmp" "$finalizing_receipt"
+	cp "$finalizing_receipt" "${TEST_ROOT}/receipt-finalize-conflict.json"
+	if full_loop_finalize_cleanup_receipt example/repo 104 not-requested "${TEST_ROOT}/worktree-two" feature/finalize \
+		"$OWNER_PID" session-finalize >/dev/null 2>&1; then
+		printf 'FAIL conflicting exact receipt evidence was finalized: %s\n' "$conflict_filter"
+		exit 1
+	fi
+	cmp -s "$finalizing_receipt" "${TEST_ROOT}/receipt-finalize-conflict.json"
+done
+rm -f "$finalizing_receipt"
+printf 'PASS exact finalization preserves conflicting repository, PR, worktree, branch, owner, release, and cleanup evidence\n'
+
+pending_release_receipt=$(full_loop_write_cleanup_deferred example/repo 105 "${TEST_ROOT}/worktree-two" \
+	feature/pending-release "$OWNER_PID" session-pending-release pending FINALIZATION_PENDING)
+full_loop_finalize_cleanup_receipt example/repo 105 not-requested "${TEST_ROOT}/worktree-two" \
+	feature/pending-release "$OWNER_PID" session-pending-release
+jq -e '.executor_completion_state == "COMPLETE" and .release_status == "not-requested"' \
+	"$pending_release_receipt" >/dev/null
+printf 'PASS exact finalization atomically converges pending cleanup release evidence\n'
+
 _WTAR_SKIPPED="skipped"
 _WTAR_WH_CALLER="test"
 _WT_CLEAN_MODE_SKIPPED="skipped"

--- a/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh
@@ -189,6 +189,25 @@ install_subject_stubs() {
 		return 0
 	}
 
+	load_state() {
+		PR_NUMBER=123
+		RELEASE_STATUS="not-requested"
+		SAVED_PROMPT="merge-cleanup-regression"
+		STARTED_AT="2026-08-02T00:00:00Z"
+		return 0
+	}
+
+	_full_loop_terminal_release_status() {
+		local repo="$1"
+		local pr_number="$2"
+		[[ -n "$repo" && "$pr_number" =~ ^[0-9]+$ ]] || return 1
+		case "$GH_RELEASE_STATUS" in
+		published | superseded | not-requested) printf '%s\n' "$GH_RELEASE_STATUS" ;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
+
 	_merge_capture_session_distill_provenance() { return 0; }
 	_merge_reconcile_closing_issues() { return 0; }
 
@@ -204,6 +223,11 @@ setup_subject() {
 	export HOME="${TEST_ROOT}/home"
 	export AIDEVOPS_SKIP_AUTO_CLAIM=1
 	export AIDEVOPS_FULL_LOOP_CLEANUP_DIR="${TEST_ROOT}/cleanup-receipts"
+	export AIDEVOPS_FULL_LOOP_RECEIPT_DIR="${TEST_ROOT}/release-receipts"
+	export AIDEVOPS_FULL_LOOP_REPO="example/repo"
+	unset AIDEVOPS_SESSION_ID OPENCODE_SESSION_ID CLAUDE_SESSION_ID
+	STATE_DIR="${TEST_ROOT}/state"
+	STATE_FILE="${STATE_DIR}/full-loop.state"
 	mkdir -p "$HOME" "${TEST_ROOT}/bin"
 	export AIDEVOPS_TEST_REAL_GIT="$FIXTURE_GIT_BIN"
 	cat >"${TEST_ROOT}/bin/git" <<'GIT'
@@ -250,6 +274,8 @@ TRASH
 	export SCRIPT_DIR="$AGENTS_SCRIPTS_DIR"
 	# shellcheck source=../shared-constants.sh
 	source "${AGENTS_SCRIPTS_DIR}/shared-constants.sh"
+	# shellcheck source=../full-loop-helper-state.sh
+	source "${AGENTS_SCRIPTS_DIR}/full-loop-helper-state.sh"
 	# shellcheck source=../full-loop-helper-merge.sh
 	source "${AGENTS_SCRIPTS_DIR}/full-loop-helper-merge.sh"
 	install_subject_stubs
@@ -299,6 +325,16 @@ test_cmd_merge_defers_current_linked_worktree() {
 		 and .cleanup_lease.state == "pending" and .worktree == $worktree and .branch == $branch
 		 and (.owner.pid | type == "number") and (.owner.process_identity | length > 0)' \
 		"$receipt_path" >/dev/null || rc=1
+	cmd_record_no_release "123" "example/repo" >/dev/null || rc=1
+	cmd_complete >/dev/null || rc=1
+	jq -e '
+		.executor_completion_state == "COMPLETE"
+		and .resource_cleanup_state == "CLEANUP_DEFERRED"
+		and .release_status == "not-requested"
+	' "$receipt_path" >/dev/null || rc=1
+	cp "$receipt_path" "${TEST_ROOT}/completed-receipt.json"
+	cmd_complete >/dev/null || rc=1
+	cmp -s "$receipt_path" "${TEST_ROOT}/completed-receipt.json" || rc=1
 	if [[ "$(git -C "$canonical_repo" branch --show-current)" != "feature/active" ]]; then
 		rc=1
 	fi
@@ -308,7 +344,27 @@ test_cmd_merge_defers_current_linked_worktree() {
 	# Cleanup is deferred before canonical refresh because the parent runtime may
 	# still use this logical project directory.
 	if [[ "$(git -C "$canonical_repo" rev-parse main)" == "$remote_main" ]]; then rc=1; fi
-	print_result "cmd_merge persists external deferred-cleanup ownership" "$rc"
+	print_result "merge then no-release completion finalizes deferred cleanup idempotently" "$rc"
+	return 0
+}
+
+test_no_release_before_merge_receipt_converges() {
+	setup_subject
+	local receipt_path="${AIDEVOPS_FULL_LOOP_CLEANUP_DIR}/example_repo-123.json"
+	local rc=0
+	cmd_record_no_release "123" "example/repo" >/dev/null || rc=1
+	[[ ! -e "$receipt_path" ]] || rc=1
+	cmd_merge "123" "example/repo" --squash >/dev/null || rc=1
+	jq -e '
+		.executor_completion_state == "FINALIZATION_PENDING"
+		and .release_status == "pending"
+	' "$receipt_path" >/dev/null || rc=1
+	cmd_complete >/dev/null || rc=1
+	jq -e '
+		.executor_completion_state == "COMPLETE"
+		and .release_status == "not-requested"
+	' "$receipt_path" >/dev/null || rc=1
+	print_result "no-release evidence recorded before merge receipt converges atomically" "$rc"
 	return 0
 }
 
@@ -586,6 +642,7 @@ main() {
 	setup_subject
 	test_refresh_canonical_reports_pending_without_mutation
 	test_cmd_merge_defers_current_linked_worktree
+	test_no_release_before_merge_receipt_converges
 	test_cmd_merge_defers_cleanup_for_live_process_cwd
 	test_cmd_merge_defers_exact_head_alias_worktree
 	test_cmd_adopt_merged_receipt_is_idempotent

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -212,7 +212,7 @@ test_update_preserves_manual_sections() {
 		AIDEVOPS_REPOS_FILE="${fixture_home}/.config/aidevops/repos.json" \
 		AIDEVOPS_WORKTREE_BASE_DIR="${TEST_DIR}/worktrees" \
 		bash "${helper_path}" update >"$update_output" 2>&1; then
-		print_result "${test_name}" 1 "helper update command failed"
+		print_result "${test_name}" 1 "helper update command failed: $(<"$update_output")"
 		return 0
 	fi
 


### PR DESCRIPTION
## Summary

Finalize merge-created cleanup receipts through complete using locked exact-evidence transitions, including receipt-creation races and shared owner-session identity; expose captured profile-boundary helper stderr when CI-only publication failures occur.

## Files Changed

.agents/scripts/full-loop-cleanup-receipt.sh, .agents/scripts/full-loop-helper-merge.sh, .agents/scripts/full-loop-helper-state.sh, .agents/scripts/gh-quota-debug-filter.py, .agents/scripts/profile-readme-helper.sh, .agents/scripts/tests/test-full-loop-cleanup-receipt.sh, .agents/scripts/tests/test-full-loop-merge-worktree-cleanup.sh, .agents/scripts/tests/test-gh-shim.sh, .agents/scripts/tests/test-profile-readme-boundary.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Focused cleanup-receipt, merge-worktree-cleanup, completion-evidence, and profile unit tests passed; ShellCheck passed; Linux profile boundary suite completed 20/20 assertions successfully.

Resolves #29105


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 57m and 393,891 tokens on this as a headless worker.