### PR TITLE
GH#29262: Add privacy-safe native read attribution

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -330,9 +330,12 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 	# Bypass — explicit override.
 	if [[ "${AIDEVOPS_GH_SHIM_NO_REST_REWRITE:-0}" == "1" ]]; then
 		_transport_path=$(_shim_classify_endpoint "${1:-}" "${2:-}")
-		_transport_caller=$(_shim_caller_label "${1:-}" "${2:-}")
-		gh_record_call "$_transport_path" "$_transport_caller" 2>/dev/null || true
-		_shim_run_transport "$REAL_GH" "$_transport_path" "$_transport_caller" 0 "$@"
+		_transport_caller=$(_shim_transport_caller_label "${1:-}" "${2:-}")
+		_transport_shape=$(_shim_read_shape_digest "$@" 2>/dev/null || printf 'shape-unknown')
+		_transport_decision="graphql-bypass:${_transport_shape}"
+		gh_record_call "$_transport_path" "$_transport_caller" "" "" "$_transport_decision" 2>/dev/null || true
+		AIDEVOPS_GH_ROUTE_DECISION="$_transport_decision" \
+			_shim_run_transport "$REAL_GH" "$_transport_path" "$_transport_caller" 0 "$@"
 		exit $?
 	fi
 
@@ -483,11 +486,13 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		# Preserve native fallback for projection/local failures because REST may
 		# have returned data that cannot safely reproduce gh output. Routes that
 		# never attempted REST are plain GraphQL selection.
-		_transport_caller=$(_shim_caller_label "${1:-}" "${2:-}")
+		_transport_caller=$(_shim_transport_caller_label "${1:-}" "${2:-}")
 		_transport_retry=$(gh_attempt_count_for_logical "$AIDEVOPS_GH_LOGICAL_ID")
 		[[ "$_transport_retry" =~ ^[0-9]+$ ]] || _transport_retry=0
 		_transport_decision=graphql-selected
 		[[ "$_SHIM_REST_REWRITE_ATTEMPTED" -eq 0 ]] || _transport_decision=rest-fallback-graphql
+		_transport_shape=$(_shim_read_shape_digest "$@" 2>/dev/null || printf 'shape-unknown')
+		_transport_decision="${_transport_decision}:${_transport_shape}"
 		gh_record_call graphql "$_transport_caller" "" "" "$_transport_decision" 2>/dev/null || true
 		AIDEVOPS_GH_ROUTE_DECISION="$_transport_decision" \
 			_shim_run_transport "$REAL_GH" graphql "$_transport_caller" "$_transport_retry" "$@"

--- a/.agents/scripts/gh-native-transport-lib.sh
+++ b/.agents/scripts/gh-native-transport-lib.sh
@@ -186,6 +186,78 @@ _shim_transport_caller_label() {
 	return 0
 }
 
+# Return a stable, privacy-safe digest for one native issue/pr read shape.
+# Repository names, references, jq/template expressions, and other argument
+# values never enter the digest input. JSON field names are retained because
+# they define the transport contract and are bounded gh identifiers.
+_shim_read_shape_digest() {
+	local sub1="${1:-}"
+	local sub2="${2:-}"
+	shift 2 2>/dev/null || true
+	local json_fields="none"
+	local has_jq=0
+	local has_template=0
+	local has_comments=0
+	local has_web=0
+	local unknown_flags=0
+	local positional_count=0
+	local expect_value=""
+	local arg=""
+	local shape=""
+	local digest=""
+
+	while [[ $# -gt 0 ]]; do
+		arg="$1"
+		shift
+		if [[ -n "$expect_value" ]]; then
+			case "$expect_value" in
+			json)
+				if [[ "$arg" =~ ^[A-Za-z0-9_,]+$ ]]; then
+					json_fields="$arg"
+				else
+					json_fields="dynamic"
+				fi
+				;;
+			jq) has_jq=1 ;;
+			template) has_template=1 ;;
+			esac
+			expect_value=""
+			continue
+		fi
+		case "$arg" in
+		--repo | -R) expect_value="private" ;;
+		--repo=* | -R?*) ;;
+		--json) expect_value="json" ;;
+		--json=*)
+			json_fields="${arg#--json=}"
+			[[ "$json_fields" =~ ^[A-Za-z0-9_,]+$ ]] || json_fields="dynamic"
+			;;
+		--jq | -q) expect_value="jq" ;;
+		--jq=* | -q=*) has_jq=1 ;;
+		--template | -t) expect_value="template" ;;
+		--template=* | -t=*) has_template=1 ;;
+		--comments) has_comments=1 ;;
+		--web) has_web=1 ;;
+		-*) unknown_flags=$((unknown_flags + 1)) ;;
+		*) positional_count=$((positional_count + 1)) ;;
+		esac
+	done
+	shape="${sub1}:${sub2}:json=${json_fields}:jq=${has_jq}:template=${has_template}:comments=${has_comments}:web=${has_web}:unknown_flags=${unknown_flags}:positionals=${positional_count}"
+	if command -v shasum >/dev/null 2>&1; then
+		digest=$(printf '%s' "$shape" | shasum -a 256 2>/dev/null) || return 1
+		digest="${digest%% *}"
+	elif command -v openssl >/dev/null 2>&1; then
+		digest=$(printf '%s' "$shape" | openssl dgst -sha256 2>/dev/null) || return 1
+		digest="${digest##* }"
+	else
+		digest=$(printf '%s' "$shape" | cksum 2>/dev/null) || return 1
+		digest="${digest%% *}"
+	fi
+	[[ "$digest" =~ ^[A-Fa-f0-9]+$ ]] || return 1
+	printf 'shape-%s' "${digest:0:12}"
+	return 0
+}
+
 _shim_transport_page() {
 	local arg=""
 	local page=1

--- a/.agents/scripts/gh-native-transport-lib.sh
+++ b/.agents/scripts/gh-native-transport-lib.sh
@@ -236,8 +236,8 @@ _shim_read_shape_digest() {
 		--jq=* | -q=*) has_jq=1 ;;
 		--template | -t) expect_value="template" ;;
 		--template=* | -t=*) has_template=1 ;;
-		--comments) has_comments=1 ;;
-		--web) has_web=1 ;;
+		--comments | -c) has_comments=1 ;;
+		--web | -w) has_web=1 ;;
 		-*) unknown_flags=$((unknown_flags + 1)) ;;
 		*) positional_count=$((positional_count + 1)) ;;
 		esac
@@ -246,14 +246,16 @@ _shim_read_shape_digest() {
 	if command -v shasum >/dev/null 2>&1; then
 		digest=$(printf '%s' "$shape" | shasum -a 256 2>/dev/null) || return 1
 		digest="${digest%% *}"
+	elif command -v sha256sum >/dev/null 2>&1; then
+		digest=$(printf '%s' "$shape" | sha256sum 2>/dev/null) || return 1
+		digest="${digest%% *}"
 	elif command -v openssl >/dev/null 2>&1; then
 		digest=$(printf '%s' "$shape" | openssl dgst -sha256 2>/dev/null) || return 1
 		digest="${digest##* }"
 	else
-		digest=$(printf '%s' "$shape" | cksum 2>/dev/null) || return 1
-		digest="${digest%% *}"
+		return 1
 	fi
-	[[ "$digest" =~ ^[A-Fa-f0-9]+$ ]] || return 1
+	[[ "$digest" =~ ^[A-Fa-f0-9]{64}$ ]] || return 1
 	printf 'shape-%s' "${digest:0:12}"
 	return 0
 }

--- a/.agents/scripts/gh-native-transport-lib.sh
+++ b/.agents/scripts/gh-native-transport-lib.sh
@@ -186,6 +186,60 @@ _shim_transport_caller_label() {
 	return 0
 }
 
+# Return a reviewed, bounded gh JSON field list or fail closed. Future gh fields
+# remain classified as dynamic until added here so arbitrary pre-validation
+# argument values can never influence telemetry digests.
+_shim_read_json_fields() {
+	local sub1="$1"
+	local sub2="$2"
+	local fields="$3"
+	local field=""
+	local -a field_list=()
+	[[ -n "$fields" && ${#fields} -le 1024 ]] || return 1
+	[[ "$fields" != ,* && "$fields" != *, && "$fields" != *,,* ]] || return 1
+	IFS=',' read -r -a field_list <<<"$fields"
+	[[ ${#field_list[@]} -gt 0 ]] || return 1
+	for field in "${field_list[@]}"; do
+		case "${sub1}:${sub2}:${field}" in
+		issue:list:assignees | issue:list:author | issue:list:blockedBy | issue:list:blocking | \
+			issue:list:body | issue:list:closed | issue:list:closedAt | issue:list:closedByPullRequestsReferences | \
+			issue:list:comments | issue:list:createdAt | issue:list:id | issue:list:isPinned | issue:list:issueType | \
+			issue:list:labels | issue:list:milestone | issue:list:number | issue:list:parent | issue:list:projectCards | \
+			issue:list:projectItems | issue:list:reactionGroups | issue:list:state | issue:list:stateReason | \
+			issue:list:subIssues | issue:list:subIssuesSummary | issue:list:title | issue:list:updatedAt | issue:list:url | \
+			issue:view:assignees | issue:view:author | issue:view:blockedBy | issue:view:blocking | \
+			issue:view:body | issue:view:closed | issue:view:closedAt | issue:view:closedByPullRequestsReferences | \
+			issue:view:comments | issue:view:createdAt | issue:view:id | issue:view:isPinned | issue:view:issueType | \
+			issue:view:labels | issue:view:milestone | issue:view:number | issue:view:parent | issue:view:projectCards | \
+			issue:view:projectItems | issue:view:reactionGroups | issue:view:state | issue:view:stateReason | \
+			issue:view:subIssues | issue:view:subIssuesSummary | issue:view:title | issue:view:updatedAt | issue:view:url | \
+			pr:list:additions | pr:list:assignees | pr:list:author | pr:list:autoMergeRequest | pr:list:baseRefName | \
+			pr:list:baseRefOid | pr:list:body | pr:list:changedFiles | pr:list:closed | pr:list:closedAt | \
+			pr:list:closingIssuesReferences | pr:list:comments | pr:list:commits | pr:list:createdAt | pr:list:deletions | \
+			pr:list:files | pr:list:fullDatabaseId | pr:list:headRefName | pr:list:headRefOid | pr:list:headRepository | \
+			pr:list:headRepositoryOwner | pr:list:id | pr:list:isCrossRepository | pr:list:isDraft | pr:list:labels | \
+			pr:list:latestReviews | pr:list:maintainerCanModify | pr:list:mergeCommit | pr:list:mergeStateStatus | \
+			pr:list:mergeable | pr:list:mergedAt | pr:list:mergedBy | pr:list:milestone | pr:list:number | \
+			pr:list:potentialMergeCommit | pr:list:projectCards | pr:list:projectItems | pr:list:reactionGroups | \
+			pr:list:reviewDecision | pr:list:reviewRequests | pr:list:reviews | pr:list:state | \
+			pr:list:statusCheckRollup | pr:list:title | pr:list:updatedAt | pr:list:url | \
+			pr:view:additions | pr:view:assignees | pr:view:author | pr:view:autoMergeRequest | pr:view:baseRefName | \
+			pr:view:baseRefOid | pr:view:body | pr:view:changedFiles | pr:view:closed | pr:view:closedAt | \
+			pr:view:closingIssuesReferences | pr:view:comments | pr:view:commits | pr:view:createdAt | pr:view:deletions | \
+			pr:view:files | pr:view:fullDatabaseId | pr:view:headRefName | pr:view:headRefOid | pr:view:headRepository | \
+			pr:view:headRepositoryOwner | pr:view:id | pr:view:isCrossRepository | pr:view:isDraft | pr:view:labels | \
+			pr:view:latestReviews | pr:view:maintainerCanModify | pr:view:mergeCommit | pr:view:mergeStateStatus | \
+			pr:view:mergeable | pr:view:mergedAt | pr:view:mergedBy | pr:view:milestone | pr:view:number | \
+			pr:view:potentialMergeCommit | pr:view:projectCards | pr:view:projectItems | pr:view:reactionGroups | \
+			pr:view:reviewDecision | pr:view:reviewRequests | pr:view:reviews | pr:view:state | \
+			pr:view:statusCheckRollup | pr:view:title | pr:view:updatedAt | pr:view:url) ;;
+		*) return 1 ;;
+		esac
+	done
+	printf '%s' "$fields"
+	return 0
+}
+
 # Return a stable, privacy-safe digest for one native issue/pr read shape.
 # Repository names, references, jq/template expressions, and other argument
 # values never enter the digest input. JSON field names are retained because
@@ -212,11 +266,7 @@ _shim_read_shape_digest() {
 		if [[ -n "$expect_value" ]]; then
 			case "$expect_value" in
 			json)
-				if [[ "$arg" =~ ^[A-Za-z0-9_,]+$ ]]; then
-					json_fields="$arg"
-				else
-					json_fields="dynamic"
-				fi
+				json_fields=$(_shim_read_json_fields "$sub1" "$sub2" "$arg" 2>/dev/null) || json_fields="dynamic"
 				;;
 			jq) has_jq=1 ;;
 			template) has_template=1 ;;
@@ -229,8 +279,7 @@ _shim_read_shape_digest() {
 		--repo=* | -R?*) ;;
 		--json) expect_value="json" ;;
 		--json=*)
-			json_fields="${arg#--json=}"
-			[[ "$json_fields" =~ ^[A-Za-z0-9_,]+$ ]] || json_fields="dynamic"
+			json_fields=$(_shim_read_json_fields "$sub1" "$sub2" "${arg#--json=}" 2>/dev/null) || json_fields="dynamic"
 			;;
 		--jq | -q) expect_value="jq" ;;
 		--jq=* | -q=*) has_jq=1 ;;

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -805,13 +805,74 @@ AIDEVOPS_GH_CALLER=pulse-wrapper.sh AIDEVOPS_GH_REST_FIRST_READS=1 \
 	--jq '.comments[] | select(.body == "private-two")' >/dev/null 2>&1 || true
 native_shape_one=$(awk -F '\t' '$9 == "logical" && $3 == "graphql" { print $6; exit }' "$native_shape_log_one")
 native_shape_two=$(awk -F '\t' '$9 == "logical" && $3 == "graphql" { print $6; exit }' "$native_shape_log_two")
-if [[ "$native_shape_one" == "$native_shape_two" && "$native_shape_one" =~ ^graphql-selected:shape-[[:xdigit:]]+$ ]] &&
+if [[ "$native_shape_one" == "$native_shape_two" && "$native_shape_one" =~ ^graphql-selected:shape-[[:xdigit:]]{12}$ ]] &&
 	awk -F '\t' '$2 == "pulse-wrapper.sh" && $9 == "logical" { found = 1 } END { exit found ? 0 : 1 }' "$native_shape_log_one" &&
 	! grep -Eq 'private-owner|private-repo|private-one|other-private|private-two|comments\[\]' "$native_shape_log_one" "$native_shape_log_two"; then
 	_pass "native read telemetry records framework caller and value-free stable shape"
 else
 	_fail "native read privacy-safe attribution" \
 		"shape_one=$native_shape_one shape_two=$native_shape_two log_one=$(cat "$native_shape_log_one" 2>/dev/null || true)"
+fi
+
+native_alias_long_log="$TMP/gh-api-native-alias-long.log"
+native_alias_short_log="$TMP/gh-api-native-alias-short.log"
+native_bypass_long_log="$TMP/gh-api-native-bypass-long.log"
+native_bypass_short_log="$TMP/gh-api-native-bypass-short.log"
+rm -f "$native_alias_long_log" "$native_alias_short_log" "$native_bypass_long_log" "$native_bypass_short_log"
+AIDEVOPS_GH_REST_FIRST_READS=1 AIDEVOPS_GH_API_LOG="$native_alias_long_log" \
+	"$SHIM_RUN" issue view 111 --repo owner/repo --comments --web >/dev/null 2>&1 || true
+AIDEVOPS_GH_REST_FIRST_READS=1 AIDEVOPS_GH_API_LOG="$native_alias_short_log" \
+	"$SHIM_RUN" issue view 999 --repo other/repo -c -w >/dev/null 2>&1 || true
+AIDEVOPS_GH_REST_FIRST_READS=1 AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	AIDEVOPS_GH_API_LOG="$native_bypass_long_log" \
+	"$SHIM_RUN" issue view 111 --repo owner/repo --comments --web >/dev/null 2>&1 || true
+AIDEVOPS_GH_REST_FIRST_READS=1 AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	AIDEVOPS_GH_API_LOG="$native_bypass_short_log" \
+	"$SHIM_RUN" issue view 999 --repo other/repo -c -w >/dev/null 2>&1 || true
+native_alias_long=$(awk -F '\t' '$9 == "logical" && $3 == "graphql" { print $6; exit }' "$native_alias_long_log")
+native_alias_short=$(awk -F '\t' '$9 == "logical" && $3 == "graphql" { print $6; exit }' "$native_alias_short_log")
+native_bypass_long=$(awk -F '\t' '$9 == "logical" && $3 == "graphql" { print $6; exit }' "$native_bypass_long_log")
+native_bypass_short=$(awk -F '\t' '$9 == "logical" && $3 == "graphql" { print $6; exit }' "$native_bypass_short_log")
+if [[ "$native_alias_long" == "$native_alias_short" && "$native_alias_long" =~ ^graphql-selected:shape-[[:xdigit:]]{12}$ ]] &&
+	[[ "$native_bypass_long" == "$native_bypass_short" && "$native_bypass_long" =~ ^graphql-bypass:shape-[[:xdigit:]]{12}$ ]]; then
+	_pass "native read shape treats short and long flag aliases identically"
+else
+	_fail "native read flag alias attribution" \
+		"fallback_long=$native_alias_long fallback_short=$native_alias_short bypass_long=$native_bypass_long bypass_short=$native_bypass_short"
+fi
+
+hash_shasum_dir="$TMP/hash-shasum"
+hash_sha256sum_dir="$TMP/hash-sha256sum"
+hash_openssl_dir="$TMP/hash-openssl"
+hash_empty_dir="$TMP/hash-empty"
+mkdir -p "$hash_shasum_dir" "$hash_sha256sum_dir" "$hash_openssl_dir" "$hash_empty_dir"
+cat >"$hash_shasum_dir/shasum" <<'EOF'
+#!/bin/bash
+IFS= read -r _input || true
+printf '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef  -\n'
+EOF
+cat >"$hash_sha256sum_dir/sha256sum" <<'EOF'
+#!/bin/bash
+IFS= read -r _input || true
+printf '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef  -\n'
+EOF
+cat >"$hash_openssl_dir/openssl" <<'EOF'
+#!/bin/bash
+IFS= read -r _input || true
+printf 'SHA2-256(stdin)= 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n'
+EOF
+chmod +x "$hash_shasum_dir/shasum" "$hash_sha256sum_dir/sha256sum" "$hash_openssl_dir/openssl"
+hash_shape_shasum=$(PATH="$hash_shasum_dir" "$BASH" -c "source \"\$1\"; _shim_read_shape_digest issue view 1 --repo private/repo --json state" _ "$TMP/scripts/gh-native-transport-lib.sh")
+hash_shape_sha256sum=$(PATH="$hash_sha256sum_dir" "$BASH" -c "source \"\$1\"; _shim_read_shape_digest issue view 1 --repo private/repo --json state" _ "$TMP/scripts/gh-native-transport-lib.sh")
+hash_shape_openssl=$(PATH="$hash_openssl_dir" "$BASH" -c "source \"\$1\"; _shim_read_shape_digest issue view 1 --repo private/repo --json state" _ "$TMP/scripts/gh-native-transport-lib.sh")
+if [[ "$hash_shape_shasum" == "shape-0123456789ab" && "$hash_shape_sha256sum" == "$hash_shape_shasum" &&
+	"$hash_shape_openssl" == "$hash_shape_shasum" ]] &&
+	PATH="$hash_empty_dir" "$BASH" -c "source \"\$1\"; ! _shim_read_shape_digest issue view 1 --repo private/repo --json state" _ \
+		"$TMP/scripts/gh-native-transport-lib.sh"; then
+	_pass "native read shape is stable across SHA-256 backends and fails closed without one"
+else
+	_fail "native read SHA-256 backend stability" \
+		"shasum=$hash_shape_shasum sha256sum=$hash_shape_sha256sum openssl=$hash_shape_openssl"
 fi
 
 echo ""

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -814,6 +814,37 @@ else
 		"shape_one=$native_shape_one shape_two=$native_shape_two log_one=$(cat "$native_shape_log_one" 2>/dev/null || true)"
 fi
 
+native_dynamic_log_one="$TMP/gh-api-native-dynamic-one.log"
+native_dynamic_log_two="$TMP/gh-api-native-dynamic-two.log"
+native_oversized_log="$TMP/gh-api-native-oversized.log"
+oversized_json_fields="state"
+while [[ ${#oversized_json_fields} -le 1024 ]]; do
+	oversized_json_fields="${oversized_json_fields},state"
+done
+rm -f "$native_dynamic_log_one" "$native_dynamic_log_two" "$native_oversized_log"
+AIDEVOPS_GH_REST_FIRST_READS=1 AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	AIDEVOPS_GH_API_LOG="$native_dynamic_log_one" \
+	"$SHIM_RUN" issue view 111 --repo owner/repo --json PrivateIdentifierOne >/dev/null 2>&1 || true
+AIDEVOPS_GH_REST_FIRST_READS=1 AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	AIDEVOPS_GH_API_LOG="$native_dynamic_log_two" \
+	"$SHIM_RUN" issue view 999 --repo other/repo --json OtherSensitiveIdentifier999 >/dev/null 2>&1 || true
+AIDEVOPS_GH_REST_FIRST_READS=1 AIDEVOPS_GH_SHIM_NO_REST_REWRITE=1 \
+	AIDEVOPS_GH_API_LOG="$native_oversized_log" \
+	"$SHIM_RUN" issue view 111 --repo owner/repo --json "$oversized_json_fields" >/dev/null 2>&1 || true
+native_dynamic_one=$(awk -F '\t' '$9 == "logical" && $3 == "graphql" { print $6; exit }' "$native_dynamic_log_one")
+native_dynamic_two=$(awk -F '\t' '$9 == "logical" && $3 == "graphql" { print $6; exit }' "$native_dynamic_log_two")
+native_oversized=$(awk -F '\t' '$9 == "logical" && $3 == "graphql" { print $6; exit }' "$native_oversized_log")
+if [[ "$native_dynamic_one" == "$native_dynamic_two" && "$native_oversized" == "$native_dynamic_one" ]] &&
+	[[ "$native_dynamic_one" =~ ^graphql-bypass:shape-[[:xdigit:]]{12}$ ]] &&
+	[[ "$native_shape_one" != "$native_dynamic_one" ]] &&
+	! grep -Eq 'PrivateIdentifierOne|OtherSensitiveIdentifier999' \
+		"$native_dynamic_log_one" "$native_dynamic_log_two" "$native_oversized_log"; then
+	_pass "native read shape admits only bounded documented JSON fields"
+else
+	_fail "native read JSON field privacy boundary" \
+		"valid=$native_shape_one dynamic_one=$native_dynamic_one dynamic_two=$native_dynamic_two oversized=$native_oversized"
+fi
+
 native_alias_long_log="$TMP/gh-api-native-alias-long.log"
 native_alias_short_log="$TMP/gh-api-native-alias-short.log"
 native_bypass_long_log="$TMP/gh-api-native-bypass-long.log"

--- a/.agents/scripts/tests/test-gh-shim.sh
+++ b/.agents/scripts/tests/test-gh-shim.sh
@@ -287,6 +287,10 @@ cp "$REPO_DIR/.agents/scripts/gh_quota_debug_response.py" "$TMP/scripts/gh_quota
 cp "$REPO_DIR/.agents/scripts/shared-gh-wrappers-rest-fallback.sh" "$TMP/scripts/shared-gh-wrappers-rest-fallback.sh"
 cp "$REPO_DIR/.agents/scripts/shared-gh-wrappers-rest-read-semantics.sh" "$TMP/scripts/shared-gh-wrappers-rest-read-semantics.sh"
 cp "$REPO_DIR/.agents/scripts/log-issue-helper.sh" "$TMP/scripts/log-issue-helper.sh"
+# Caller attribution accepts only verified framework script basenames that are
+# present beside the shim. A zero-byte fixture is sufficient for that identity
+# check; it is never executed by this harness.
+: >"$TMP/scripts/pulse-wrapper.sh"
 mkdir -p "$TMP/scripts/lib"
 cp "$REPO_DIR/.agents/scripts/lib/version.sh" "$TMP/scripts/lib/version.sh"
 cp "$REPO_DIR/.agents/scripts/lib/issue-fingerprint.sh" "$TMP/scripts/lib/issue-fingerprint.sh"
@@ -778,11 +782,36 @@ AIDEVOPS_GH_REST_FIRST_READS=1 "$SHIM_RUN" pr list --repo owner/repo \
 	--state open --json number,reviewDecision,headRefOid 2>/dev/null || true
 argv=$(_read_argv)
 if [[ "$argv" == $'pr\nlist\n--repo\nowner/repo\n--state\nopen\n--json\nnumber,reviewDecision,headRefOid' ]] &&
-	awk -F '\t' '$2 == "gh_pr_list" && $3 == "graphql" && $6 == "graphql-selected" { found = 1 } END { exit found ? 0 : 1 }' \
+	awk -F '\t' '$2 == "gh_pr_list" && $3 == "graphql" && $6 ~ /^graphql-selected:shape-[[:xdigit:]]+$/ { found = 1 } END { exit found ? 0 : 1 }' \
 		"$AIDEVOPS_GH_API_LOG"; then
 	_pass "REST-first leaves GraphQL-only pr list fields on GraphQL"
 else
 	_fail "REST-first GraphQL-only pr list preservation" "argv: $argv log: $(cat "$AIDEVOPS_GH_API_LOG" 2>/dev/null || true)"
+fi
+
+echo ""
+echo "Test 15g: native read attribution is caller-aware and privacy-safe"
+_reset_log
+native_shape_log_one="$TMP/gh-api-native-shape-one.log"
+native_shape_log_two="$TMP/gh-api-native-shape-two.log"
+rm -f "$native_shape_log_one" "$native_shape_log_two"
+AIDEVOPS_GH_CALLER=pulse-wrapper.sh AIDEVOPS_GH_REST_FIRST_READS=1 \
+	AIDEVOPS_GH_API_LOG="$native_shape_log_one" "$SHIM_RUN" issue view 111 \
+	--repo private-owner/private-repo --json state,labels,assignees,comments \
+	--jq '.comments[] | select(.body == "private-one")' >/dev/null 2>&1 || true
+AIDEVOPS_GH_CALLER=pulse-wrapper.sh AIDEVOPS_GH_REST_FIRST_READS=1 \
+	AIDEVOPS_GH_API_LOG="$native_shape_log_two" "$SHIM_RUN" issue view 999 \
+	--repo other-private/other-private --json state,labels,assignees,comments \
+	--jq '.comments[] | select(.body == "private-two")' >/dev/null 2>&1 || true
+native_shape_one=$(awk -F '\t' '$9 == "logical" && $3 == "graphql" { print $6; exit }' "$native_shape_log_one")
+native_shape_two=$(awk -F '\t' '$9 == "logical" && $3 == "graphql" { print $6; exit }' "$native_shape_log_two")
+if [[ "$native_shape_one" == "$native_shape_two" && "$native_shape_one" =~ ^graphql-selected:shape-[[:xdigit:]]+$ ]] &&
+	awk -F '\t' '$2 == "pulse-wrapper.sh" && $9 == "logical" { found = 1 } END { exit found ? 0 : 1 }' "$native_shape_log_one" &&
+	! grep -Eq 'private-owner|private-repo|private-one|other-private|private-two|comments\[\]' "$native_shape_log_one" "$native_shape_log_two"; then
+	_pass "native read telemetry records framework caller and value-free stable shape"
+else
+	_fail "native read privacy-safe attribution" \
+		"shape_one=$native_shape_one shape_two=$native_shape_two log_one=$(cat "$native_shape_log_one" 2>/dev/null || true)"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

- add privacy-safe framework-caller attribution for native issue/PR reads
- classify unsupported read shapes with stable 12-character SHA-256 digests derived only from bounded command metadata and reviewed `gh` JSON fields
- preserve native read behavior while exposing enough telemetry to identify the three residual unknown-cost paths

This is the non-closing diagnostic phase. GH#29262 remains open until a merged deployment identifies the exact exercised shapes and the final exact-cost routes pass a controlled smoke.

For #29262

## Testing

- `shellcheck .agents/scripts/gh .agents/scripts/gh-native-transport-lib.sh .agents/scripts/tests/test-gh-shim.sh`
- `.agents/scripts/tests/test-gh-shim.sh` — 120 passed, 0 failed
- `.agents/scripts/tests/test-gh-api-instrument.sh` — 213 passed, 0 failed
- `.agents/scripts/linters-local.sh`
- independent closeout review: clean for exact rebased head `3eace6d43`

## Runtime Testing

- runtime-verified with the worktree shim against a live issue read using an unsupported `state,comments` projection
- observed sanitized telemetry: framework caller classification, GraphQL path, and `graphql-selected:shape-<12 hex>` decision; command output and native semantics remained intact

## Decisions

- raw argument values, repository identities, references, jq/template expressions, and arbitrary pre-validation JSON values never enter the digest
- unsupported or oversized JSON field lists collapse to `dynamic`; unavailable SHA-256 tooling collapses to `shape-unknown`
- no release or publication is requested

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.5 spent 16d 3h and 56,994,379 tokens on this with the user in an interactive session.