### PR TITLE
GH#29228: add bounded public Hacker News collector

### DIFF
--- a/.agents/aidevops/knowledge-plane/05-social-operations.md
+++ b/.agents/aidevops/knowledge-plane/05-social-operations.md
@@ -39,10 +39,9 @@ transaction without rewriting raw gzip artifacts, cursors, coverage, or provider
 rows. Replay preserves both evidence and projection IDs.
 
 Candidate implementation is provider-specific, not one generic social adapter.
-Mastodon #29221, GitHub #29222, Stack Exchange #29223, Miniflux #29224, and
-Readwise Reader #29225 are now live. The remaining ranked children are FreshRSS
-issue #29226, Lemmy issue #29227, then public-only Hacker News #29228. Each
-route owns its identity
+Mastodon #29221, GitHub #29222, Stack Exchange #29223, Miniflux #29224,
+Readwise Reader #29225, and public-only Hacker News #29228 are now live. FreshRSS
+#29226 and Lemmy #29227 remain candidate children. Each route owns its identity
 contract, stream allowlist, checkpoint semantics, and negative write-reachability
 tests. Raindrop.io remains optional; Inoreader, Wallabag, Feedly, Instapaper, and
 Pocket are deferred or rejected for the reasons in
@@ -87,6 +86,15 @@ accounts have independent per-site checkpoints. Pages stop before persistence on
 `backoff` or quota exhaustion and continue only while `has_more`. Votes, follows,
 subscriptions, lists, projects, complete archives, and inaccessible site history
 remain explicit gaps. Details: `.agents/content/social-stack-exchange.md`.
+
+Hacker News collection observes an exact case-sensitive public username before
+each bounded official item GET. The username remains an explicitly mutable public
+selector, never authenticated identity. A versioned cursor retains the complete
+bounded submitted-ID slice so resume is independent of newly prepended IDs.
+Missing users/items and deleted/dead tombstones produce explicit unavailable
+coverage; votes, favourites, inbox, notifications, relationships, subscriptions,
+lists, removed content, and private state remain unavailable. Details:
+`.agents/content/social-hacker-news.md`.
 
 Miniflux collection binds `/v1/me` user identity to a keyed exact HTTPS
 installation before every page. Entries, read, removed, starred, tags, feeds,

--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -45,6 +45,7 @@ a claim that the route is enabled.
 | Mastodon | **Live/Partial** authored statuses | **Live/Partial** favourites and bookmarks | **Live/Gate/Partial** notifications; **No/Gate** conversations | **Live/Partial** followers, following, and followed tags | **Live/Partial** lists; **No** nested membership | Eight exact-origin GET-only streams preserve opaque `Link` cursors and expose federation, moderation, deletion, export, and operator-retention gaps. |
 | GitHub | **Live/Partial** contribution calendar and repositories | **Live/Partial** stars and subscriptions; **No** complete reactions | **Live/Gate/Partial** notifications | **Live/Gate/Partial** followers, following, and organizations | **Live/Gate/Partial** user lists and visible Projects v2 | Ten numeric/node-identity-bound streams preserve REST `Link` and GraphQL `pageInfo` cursors; token family, visibility, migration expiry, deletion, and audit authority remain explicit. |
 | Stack Exchange | **Live/Partial** posts, questions, answers, and comments | **Live/Partial** favourites; **No** complete votes | **Live/Gate/Partial** inbox and notifications | **Live/Partial** associated site accounts; **No** follows | **No** | Eight network-plus-site-identity-bound GET streams obey `has_more`, `backoff`, quota, and 100-item page limits while preserving archive and inaccessible-history gaps. |
+| Hacker News | **Live/Partial** public submissions and comments | **No** private votes or saved items | **No** | **No** | **No** | One bounded public `submitted` stream uses a mutable case-sensitive username selector and official item IDs; missing/deleted/dead and all private state remain explicit unavailable coverage. |
 | Miniflux | **Live/Partial** feed entries | **Live/Partial** read, removed, starred, and tagged state | **No** | **Live/Partial/Export** subscriptions | **Live/Partial/Export** categories and tags | Eight keyed-installation account streams use five exact GET routes, ascending entry-ID backfill, one-second `changed_after` overlap, bounded snapshots, and explicit operator-retention gaps. |
 | Readwise Reader | **Live/Gate/Partial** saved documents and optional HTML | **Live/Gate/Partial** notes, state, progress, and tags | **No** | **No** | **Live/Gate/Partial** tags and locations | Seven deployment-bound streams preserve opaque cursors, overlap `updatedAfter`, cap invocations below 20 requests/minute, and expose the provider identity/export boundary. |
 
@@ -80,7 +81,7 @@ separate provider family.
 | Lemmy | **API/Gate** versioned authored content | **API/Gate** saved and liked state | **API/Gate** unified v4 or split v3 inbox | **API/Gate** communities; **No** person follows | **API/Gate** v4 multicommunities | Rank 7, #29227. Implement only behind exact v4/v3 discovery; namespace local IDs and preserve opaque version-sensitive cursors. |
 | Stack Exchange | **Live/Partial** authored content | **Live/Partial** favourites; **No** complete vote history | **Live/Gate/Partial** inbox and notifications | **Live/Partial** associated site accounts; **No** follows | **No** | #29223 implements network plus per-site identity, mandatory `backoff` and quota stops, bounded paging, and explicit archive/completeness gaps. |
 | GitHub | **Live/Partial** contributions | **Live/Partial** stars and subscriptions; **No** complete reactions | **Live/Gate/Partial** notifications; **No** discussions | **Live/Gate/Partial** follows, organizations, and repositories | **Live/Gate/Partial** user lists and Projects v2 | #29222 implements numeric/node identity, token-family gates, opaque mixed-API cursors, and no complete reaction or social export claim. |
-| Hacker News | **API/Partial** public submissions and comments | **No** private votes or saved items | **No** | **No** | **No** | Rank 8, #29228. Bounded public history only, keyed by case-sensitive username and item ID; never infer private state. |
+| Hacker News | **Live/Partial** public submissions and comments | **No** private votes or saved items | **No** | **No** | **No** | #29228 implements bounded official Firebase user/item GETs, content-addressed submitted-ID resume, and explicit mutable-public-selector and tombstone coverage. |
 | Miniflux | **Live/Partial** feed items | **Live/Partial** read, removed, starred, and tagged state | **No** | **Live/Partial/Export** subscriptions | **Live/Partial/Export** categories/tags | #29224 implements keyed installation/user identity, exact GET-only routes, incremental overlap, snapshots, and explicit operator-retention gaps. |
 | FreshRSS | **API/Export** feed items | **API** unread and starred state | **No** | **API/Export** subscriptions | **API/Export** folders/tags | Rank 6, #29226. Allow one non-mutating login POST, then GET-only Google Reader collection; reconcile OPML and keep Fever fallback-only. |
 | Readwise Reader | **Live/Gate/Partial** saved documents | **Live/Gate/Partial** tags, state, notes, and progress | **No** | **No** | **Live/Gate/Partial** tags and locations | #29225 implements a deployment-owned account/token binding because official token validation exposes no stable account ID, plus fixed-origin GET-only cursor reads. |
@@ -184,6 +185,17 @@ separate provider family.
   terminal coverage, and atomic persistence. `.agents/content/social-stack-exchange.md`
   records official v2.3 identity, route, OAuth, paging, filter, quota, throttle,
   duplicate-request, and completeness evidence checked on 2026-08-02.
+- **Live/Partial Hacker News:**
+  `.agents/scripts/knowledge_social_hacker_news.py`,
+  `.agents/scripts/_knowledge_social_hacker_news*.py`, and
+  `.agents/tests/test-knowledge-social-hacker-news.sh` prove the case-sensitive
+  mutable public-selector boundary, bounded submitted-ID snapshots, deterministic
+  resume, missing/deleted/dead coverage, request/item/byte fuses, exact GET-only
+  routes, replay, sanitized terminal failures, and atomic lease-fenced persistence.
+  `.agents/content/social-hacker-news.md` records official Firebase v0 user/item
+  schemas, public-activity visibility, versioning, current no-rate-limit statement,
+  repository license, and absent private/authenticated categories checked on
+  2026-08-02.
 - **Live Miniflux:** `.agents/scripts/knowledge_social_miniflux.py`,
   `.agents/scripts/_knowledge_social_miniflux*.py`, and
   `.agents/tests/test-knowledge-social-miniflux.sh` prove keyed installation/user

--- a/.agents/content/social-hacker-news.md
+++ b/.agents/content/social-hacker-news.md
@@ -1,0 +1,74 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Hacker News Public Knowledge Collection
+
+`knowledge_social_hacker_news.py` collects a bounded slice of public submitted
+items for one exact, case-sensitive Hacker News username through the official
+Firebase v0 API. A username is a mutable public selector, not authenticated or
+immutable account identity. The synthetic local selector ID namespaces evidence
+without strengthening that public identity claim.
+
+## Public authority contract
+
+Use `--account-id CASE_SENSITIVE_USERNAME`, `--stream submitted`, and
+`--profile public`. The profile accepts no credential variables. Before the
+first page and before every item read, the child observes the exact public user
+route. A changed-case or mismatched returned `id` fails before evidence or a
+checkpoint is committed.
+
+Only these redirect-free routes are reachable:
+
+| Observation | Official route shape | Result |
+|---|---|---|
+| Public selector and submitted IDs | `/v0/user/<username>.json` | Public profile fields plus ordered submitted IDs, or JSON `null` |
+| One submitted item | `/v0/item/<positive-id>.json` | One current public item/tombstone, or JSON `null` |
+
+Every transport request uses `GET`. No authentication, mutation, front-page,
+updates, traversal, browser, or arbitrary URL route is present. Story URLs are
+stored as provider evidence only and are never fetched.
+
+## Budgets, checkpoints, and replay
+
+The initial user observation costs one request unit. Each item page reserves two
+units for selector re-observation plus one item GET. `--budget` is 3-1000 units;
+`--page-size` selects at most 1-100 submitted IDs. An empty public history is
+charged conservatively as one page. User and item responses have independent
+2 MiB and 512 KiB byte fuses, and the child output has a fixed aggregate cap.
+
+The versioned cursor contains the complete bounded submitted-ID slice, exact
+username, snapshot digest, and next position. Resume therefore follows the
+captured slice even if newer IDs appear before the next invocation. Each
+successful one-item observation atomically commits raw evidence, normalized
+rows, coverage, receipt, and the next cursor under the final lease fence.
+Content-addressed replay is idempotent. A malformed response, terminal status,
+credential-shaped field, selector mismatch, or stale lease preserves the prior
+checkpoint.
+
+## Public coverage boundary
+
+JSON `null` users are recorded as missing public selectors without creating an
+authenticated-account claim. Missing, `deleted`, and `dead` submitted items
+advance only with explicit item-level unavailable coverage; they never become
+empty authored objects. Live items retain the official integer ID, type, public
+author attribution, timestamp, text/title, URL, and relationship IDs that the
+current response exposes.
+
+Votes, favourites/saved items, inbox, notifications, relationships,
+subscriptions, custom lists, removed tombstone content, and every authenticated
+or private state remain `unavailable`, not empty. The collector covers only the
+bounded current `submitted` slice and does not infer deletion or complete account
+history.
+
+## Current official evidence checked 2026-08-02
+
+- <https://github.com/HackerNews/API>
+- <https://hacker-news.firebaseio.com/v0/>
+
+The official API documentation identifies usernames as case-sensitive, exposes
+only users with public activity, documents the `submitted` and item schemas,
+requires clients to tolerate added fields, and currently states that the v0 API
+has no rate limit. Its repository remains MIT-licensed and had no separate API
+authentication, mutation, retention, or usage-terms contract in the checked
+documentation. The collector treats those absences as limits—not permission for
+unbounded use—and keeps independent request, item, and byte fuses.

--- a/.agents/scripts/_knowledge_social_hacker_news.py
+++ b/.agents/scripts/_knowledge_social_hacker_news.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Hacker News public-history policy and deterministic slice checkpoints."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from _knowledge_social_hacker_news_contract import submitted_ids
+from _knowledge_social_hacker_news_identity import (
+    HackerNewsAdapterError,
+    HackerNewsProviderUnavailableError,
+    item_id,
+    selector_id,
+    username,
+)
+from knowledge_social_import import canonical_json, reject_credentials
+
+PROVIDER = "hacker-news"
+CURSOR_PREFIX = "hacker-news-submitted-v1:"
+RETENTION_LIMIT = "public_submitted_slice_and_current_item_visibility"
+MAX_SLICE_ITEMS = 100
+
+ADAPTER_ERROR = HackerNewsAdapterError
+PROVIDER_UNAVAILABLE_ERROR = HackerNewsProviderUnavailableError
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    resource_kind: str = "item"
+    activity_mode: str = "public_attribution"
+    pagination: str = "bounded_snapshot"
+    incremental: bool = False
+    retention_limit: str | None = RETENTION_LIMIT
+    coverage_status: str | None = "partial"
+    unavailable_reason: str | None = "public_selector_and_submitted_slice_bound"
+    cost_units: int = 2
+
+
+STREAMS = {"submitted": StreamSpec()}
+
+
+def _snapshot(items: tuple[int, ...]) -> str:
+    return hashlib.sha256(canonical_json(list(items)).encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class PageRequest:
+    stream: str
+    username: str
+    selector_id: str
+    items: tuple[int, ...]
+    position: int
+    snapshot_sha256: str
+
+    @property
+    def item_id(self) -> int | None:
+        return self.items[self.position] if self.position < len(self.items) else None
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "page",
+            "stream": self.stream,
+            "username": self.username,
+            "selector_id": self.selector_id,
+            "items": list(self.items),
+            "position": self.position,
+            "snapshot_sha256": self.snapshot_sha256,
+        }
+
+    def evidence_key(self) -> str:
+        return canonical_json(self.payload())
+
+
+PAGE_REQUEST_KEYS = {
+    "action",
+    "stream",
+    "username",
+    "selector_id",
+    "items",
+    "position",
+    "snapshot_sha256",
+}
+
+
+def _position(value: Any, item_count: int, *, cursor: bool = False) -> int:
+    maximum = item_count - 1 if cursor else item_count
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+        or value > maximum
+    ):
+        raise HackerNewsAdapterError("Hacker News snapshot position is invalid")
+    return value
+
+
+def _item_tuple(value: Any) -> tuple[int, ...]:
+    try:
+        items = submitted_ids(value)
+    except RuntimeError as error:
+        raise HackerNewsAdapterError(str(error)) from error
+    if len(items) > MAX_SLICE_ITEMS:
+        raise HackerNewsAdapterError("Hacker News snapshot exceeds the item budget")
+    return items
+
+
+def _encode_cursor(request: PageRequest, position: int) -> str:
+    payload = {
+        "items": list(request.items),
+        "position": position,
+        "snapshot_sha256": request.snapshot_sha256,
+        "username": request.username,
+    }
+    encoded = base64.urlsafe_b64encode(canonical_json(payload).encode("utf-8"))
+    return f"{CURSOR_PREFIX}{encoded.decode('ascii').rstrip('=')}"
+
+
+def _decode_cursor(cursor: str, selected_username: str) -> tuple[tuple[int, ...], int, str]:
+    if not cursor.startswith(CURSOR_PREFIX):
+        raise HackerNewsAdapterError(
+            "stored Hacker News cursor has an unsupported version"
+        )
+    try:
+        encoded = cursor.removeprefix(CURSOR_PREFIX)
+        parsed = json.loads(
+            base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4))
+        )
+    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+        raise HackerNewsAdapterError("stored Hacker News cursor is invalid") from error
+    if not isinstance(parsed, dict) or set(parsed) != {
+        "items",
+        "position",
+        "snapshot_sha256",
+        "username",
+    }:
+        raise HackerNewsAdapterError("stored Hacker News cursor has an invalid shape")
+    reject_credentials(parsed)
+    selected = username(parsed.get("username"))
+    if selected != username(selected_username):
+        raise HackerNewsAdapterError(
+            "stored Hacker News cursor belongs to another public selector"
+        )
+    items = _item_tuple(parsed.get("items"))
+    position = _position(parsed.get("position"), len(items), cursor=True)
+    snapshot = parsed.get("snapshot_sha256")
+    if not isinstance(snapshot, str) or snapshot != _snapshot(items):
+        raise HackerNewsAdapterError("stored Hacker News cursor snapshot is invalid")
+    return items, position, snapshot
+
+
+def page_request(
+    stream: str,
+    account: dict[str, Any],
+    state: CursorState,
+    limit: int,
+) -> PageRequest:
+    if stream != "submitted":
+        raise HackerNewsAdapterError("Hacker News stream is unsupported")
+    selected = username(account.get("username"))
+    selected_id = selector_id(selected)
+    if account.get("id") != selected_id:
+        raise HackerNewsAdapterError("Hacker News public selector binding is invalid")
+    if state.cursor:
+        items, position, snapshot = _decode_cursor(state.cursor, selected)
+    else:
+        if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 100:
+            raise HackerNewsAdapterError("Hacker News item budget is invalid")
+        raw_submitted = account.get("submitted", [])
+        items = _item_tuple(raw_submitted)[:limit]
+        position = 0
+        snapshot = _snapshot(items)
+    return PageRequest(stream, selected, selected_id, items, position, snapshot)
+
+
+def parse_page_request(payload: dict[str, Any]) -> PageRequest:
+    if set(payload) != PAGE_REQUEST_KEYS or payload.get("action") != "page":
+        raise HackerNewsAdapterError("Hacker News read request has an invalid action shape")
+    if payload.get("stream") != "submitted":
+        raise HackerNewsAdapterError("Hacker News stream is unsupported")
+    selected = username(payload.get("username"))
+    selected_id = selector_id(selected)
+    if payload.get("selector_id") != selected_id:
+        raise HackerNewsAdapterError("Hacker News public selector binding is invalid")
+    items = _item_tuple(payload.get("items"))
+    position = _position(payload.get("position"), len(items))
+    snapshot = payload.get("snapshot_sha256")
+    if not isinstance(snapshot, str) or snapshot != _snapshot(items):
+        raise HackerNewsAdapterError("Hacker News request snapshot is invalid")
+    return PageRequest("submitted", selected, selected_id, items, position, snapshot)
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise HackerNewsAdapterError("Hacker News response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(record, dict) for record in data):
+        raise HackerNewsAdapterError("Hacker News page data must be an array")
+    if len(data) > 1:
+        raise HackerNewsAdapterError("Hacker News page exceeds the item budget")
+    return data
+
+
+def _meta_integer(meta: dict[str, Any], key: str) -> int:
+    value = meta.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise HackerNewsAdapterError(f"Hacker News {key} metadata is invalid")
+    return value
+
+
+def page_checkpoint(
+    payload: dict[str, Any],
+    state: CursorState,
+    request: PageRequest,
+) -> tuple[PageCheckpoint, bool]:
+    del state
+    meta = payload.get("meta")
+    if not isinstance(meta, dict):
+        raise HackerNewsAdapterError("Hacker News page metadata must be an object")
+    reject_credentials(meta)
+    expected_item = request.item_id
+    if (
+        meta.get("stream") != request.stream
+        or meta.get("username") != request.username
+        or meta.get("selector_id") != request.selector_id
+        or meta.get("snapshot_sha256") != request.snapshot_sha256
+        or meta.get("position") != request.position
+        or meta.get("total") != len(request.items)
+        or meta.get("item_id") != expected_item
+    ):
+        raise HackerNewsAdapterError("Hacker News page provenance is invalid")
+    _meta_integer(meta, "response_bytes")
+    item_state = meta.get("item_state")
+    allowed_states = {"live", "missing", "deleted", "dead", "empty"}
+    if item_state not in allowed_states:
+        raise HackerNewsAdapterError("Hacker News item state is invalid")
+    records = page_data(payload)
+    if expected_item is None:
+        if item_state != "empty" or records:
+            raise HackerNewsAdapterError("Hacker News empty snapshot response is invalid")
+    elif len(records) != 1 or records[0].get("item_id") != expected_item:
+        raise HackerNewsAdapterError("Hacker News item response is incomplete")
+    elif records[0].get("state") != item_state:
+        raise HackerNewsAdapterError("Hacker News item state provenance is invalid")
+    complete = expected_item is None or request.position + 1 >= len(request.items)
+    cursor = None if complete else _encode_cursor(request, request.position + 1)
+    return PageCheckpoint(cursor, request.snapshot_sha256), complete

--- a/.agents/scripts/_knowledge_social_hacker_news_collector.py
+++ b/.agents/scripts/_knowledge_social_hacker_news_collector.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Shared-loop adaptation for a mutable public Hacker News username selector."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+from _knowledge_social_collect import (
+    CollectionProgress,
+    ContextRequest,
+    collection_result,
+)
+from _knowledge_social_collect_cli import (
+    CollectorCliPolicy,
+    parse_collector_args,
+    run_collector,
+)
+from _knowledge_social_collect_persist import record_terminal
+from _knowledge_social_collect_state import load_context
+from _knowledge_social_hacker_news_identity import selector_id, username
+from _knowledge_social_lease import (
+    RunLeaseRequest,
+    SocialLeaseLostError,
+    acquire_run_lease,
+    fail_active_run,
+    release_run_lease,
+)
+from _knowledge_social_oauth_collector import OAuthCollector, OAuthCollectorPolicy
+from knowledge_social_import import canonical_json, reject_credentials
+from knowledge_social_store import validate_opaque
+
+
+class HackerNewsCollector(OAuthCollector):
+    """Run shared persistence without treating the username as an opaque ID."""
+
+    def collect(
+        self,
+        args: Any,
+        root: Path,
+        collector_id: str,
+    ) -> dict[str, Any]:
+        del args
+        connection_id = validate_opaque(self.args.connection_id, "connection_id")
+        selected = username(self.args.account_id)
+        lease = acquire_run_lease(
+            root,
+            RunLeaseRequest(
+                connection_id,
+                self.args.stream,
+                collector_id,
+                "sync",
+                self.args.lease_seconds,
+            ),
+        )
+        try:
+            runner = self._runner()
+            identity = runner.identity(selected)
+            reject_credentials(identity)
+            decision = self._decision(identity)
+            if decision is not None:
+                account = {
+                    "id": selector_id(selected),
+                    "username": selected,
+                    "availability": "unavailable",
+                    "submitted": [],
+                    "identity_boundary": "public_mutable_username_selector",
+                }
+                context = replace(
+                    load_context(
+                        root,
+                        ContextRequest(
+                            self.policy.provider_module.PROVIDER,
+                            connection_id,
+                            account,
+                            self.args.stream,
+                            "none",
+                        ),
+                        self.policy.provider_module.STREAMS,
+                    ),
+                    lease=lease,
+                )
+                context = replace(
+                    context,
+                    spec=replace(
+                        context.spec,
+                        cost_units=self.policy.identity_cost_units,
+                    ),
+                )
+                retry_after = record_terminal(
+                    context,
+                    identity,
+                    canonical_json({"action": "identity", "account_id": selected}),
+                    decision,
+                )
+                return collection_result(
+                    decision.output_status,
+                    CollectionProgress(
+                        budget_units=self.policy.identity_cost_units
+                    ),
+                    failure_class=decision.failure_class,
+                    retry_after=retry_after,
+                    run_id=lease.run_id,
+                )
+            account = self.policy.verified_identity(identity, selected)
+            context = replace(
+                load_context(
+                    root,
+                    ContextRequest(
+                        self.policy.provider_module.PROVIDER,
+                        connection_id,
+                        account,
+                        self.args.stream,
+                        "none",
+                    ),
+                    self.policy.provider_module.STREAMS,
+                ),
+                lease=lease,
+            )
+            return self._collect_pages(runner, context)
+        except Exception as error:
+            try:
+                fail_active_run(root, lease, self._failure_class(error))
+            except SocialLeaseLostError:
+                pass
+            raise
+        finally:
+            release_run_lease(root, lease)
+
+
+def run_hacker_news_collector(
+    policy: OAuthCollectorPolicy, description: str
+) -> int:
+    cli_policy = CollectorCliPolicy(
+        description=description,
+        streams=tuple(policy.provider_module.STREAMS),
+        default_budget=policy.default_budget,
+        min_budget=policy.min_budget,
+        max_page_size=policy.max_page_size,
+        budget_unit=policy.budget_unit,
+    )
+    args = parse_collector_args(cli_policy)
+    return run_collector(args, HackerNewsCollector(policy, args).collect)

--- a/.agents/scripts/_knowledge_social_hacker_news_contract.py
+++ b/.agents/scripts/_knowledge_social_hacker_news_contract.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validation primitives for bounded public Hacker News API reads."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_hacker_news_identity import (
+    HackerNewsAdapterError,
+    item_id,
+    selector_id,
+    username,
+)
+
+MAX_USER_RESPONSE_BYTES = 2 * 1024 * 1024
+MAX_ITEM_RESPONSE_BYTES = 512 * 1024
+MAX_SUBMITTED_ITEMS = 100_000
+MAX_RELATED_ITEMS = 100_000
+MAX_TEXT_BYTES = 256 * 1024
+ITEM_TYPES = frozenset({"job", "story", "comment", "poll", "pollopt"})
+
+
+class HackerNewsReadProviderError(RuntimeError):
+    """Raised for a privacy-safe local Hacker News provider failure."""
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    status: int
+    payload: Any
+    response_bytes: int = 0
+    retry_after: int | None = None
+
+
+def observed_at() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def decode_json(payload: bytes, limit: int) -> Any:
+    if len(payload) > limit:
+        raise HackerNewsReadProviderError(
+            "Hacker News JSON payload exceeds the safety limit"
+        )
+    try:
+        return json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise HackerNewsReadProviderError("Hacker News JSON payload is invalid") from error
+
+
+def request_object(payload: bytes, limit: int) -> dict[str, Any]:
+    request = decode_json(payload, limit)
+    if not isinstance(request, dict):
+        raise HackerNewsReadProviderError(
+            "Hacker News read request root must be an object"
+        )
+    return request
+
+
+def _integer(value: Any, field: str, *, signed: bool = False) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise HackerNewsReadProviderError(f"Hacker News {field} is invalid")
+    if not signed and value < 0:
+        raise HackerNewsReadProviderError(f"Hacker News {field} is invalid")
+    return value
+
+
+def _boolean(value: Any, field: str) -> bool:
+    if value is None:
+        return False
+    if not isinstance(value, bool):
+        raise HackerNewsReadProviderError(f"Hacker News {field} must be boolean")
+    return value
+
+
+def optional_text(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value:
+        raise HackerNewsReadProviderError(f"Hacker News {field} must be text")
+    if len(value.encode("utf-8")) > MAX_TEXT_BYTES:
+        raise HackerNewsReadProviderError(
+            f"Hacker News {field} exceeds the text safety limit"
+        )
+    return value
+
+
+def submitted_ids(value: Any) -> tuple[int, ...]:
+    if not isinstance(value, list) or len(value) > MAX_SUBMITTED_ITEMS:
+        raise HackerNewsReadProviderError(
+            "Hacker News submitted history exceeds the item safety limit"
+        )
+    submitted = tuple(item_id(current) for current in value)
+    if len(submitted) != len(set(submitted)):
+        raise HackerNewsReadProviderError(
+            "Hacker News submitted history contains duplicate item IDs"
+        )
+    return submitted
+
+
+def _related_ids(value: Any, field: str) -> list[int] | None:
+    if value is None:
+        return None
+    if not isinstance(value, list) or len(value) > MAX_RELATED_ITEMS:
+        raise HackerNewsReadProviderError(f"Hacker News {field} is invalid")
+    return [item_id(current) for current in value]
+
+
+def user_value(payload: Any, expected_username: str) -> dict[str, Any]:
+    """Normalize one public user response as a mutable selector observation."""
+    selected = username(expected_username)
+    if payload is None:
+        return {
+            "id": selector_id(selected),
+            "username": selected,
+            "availability": "missing",
+            "submitted": [],
+        }
+    if not isinstance(payload, dict):
+        raise HackerNewsReadProviderError(
+            "Hacker News public user response must be an object or null"
+        )
+    try:
+        returned = username(payload.get("id"))
+    except HackerNewsAdapterError as error:
+        raise HackerNewsReadProviderError(str(error)) from error
+    if returned != selected:
+        raise HackerNewsReadProviderError(
+            "Hacker News public username does not match the configured selector"
+        )
+    return {
+        "id": selector_id(selected),
+        "username": selected,
+        "availability": "public",
+        "created": _integer(payload.get("created"), "user creation timestamp"),
+        "karma": _integer(payload.get("karma"), "user karma", signed=True),
+        "about": optional_text(payload.get("about"), "user about text"),
+        "submitted": list(submitted_ids(payload.get("submitted", []))),
+    }
+
+
+def _live_item(payload: dict[str, Any], expected_username: str) -> dict[str, Any]:
+    item_type = payload.get("type")
+    if item_type not in ITEM_TYPES:
+        raise HackerNewsReadProviderError("Hacker News item type is invalid")
+    try:
+        author = username(payload.get("by"))
+    except HackerNewsAdapterError as error:
+        raise HackerNewsReadProviderError(str(error)) from error
+    if author != username(expected_username):
+        raise HackerNewsReadProviderError(
+            "Hacker News item author does not match the public selector"
+        )
+    return {
+        "type": item_type,
+        "by": author,
+        "time": _integer(payload.get("time"), "item creation timestamp"),
+        "text": optional_text(payload.get("text"), "item text"),
+        "title": optional_text(payload.get("title"), "item title"),
+        "url": optional_text(payload.get("url"), "item URL"),
+        "parent": _integer(payload.get("parent"), "item parent"),
+        "poll": _integer(payload.get("poll"), "item poll"),
+        "score": _integer(payload.get("score"), "item score", signed=True),
+        "descendants": _integer(payload.get("descendants"), "item descendants"),
+        "kids": _related_ids(payload.get("kids"), "item children"),
+        "parts": _related_ids(payload.get("parts"), "item poll parts"),
+    }
+
+
+def item_value(payload: Any, expected_id: int, expected_username: str) -> dict[str, Any]:
+    """Normalize a live item or an explicit public tombstone observation."""
+    selected_id = item_id(expected_id)
+    if payload is None:
+        return {"item_id": selected_id, "state": "missing"}
+    if not isinstance(payload, dict):
+        raise HackerNewsReadProviderError(
+            "Hacker News item response must be an object or null"
+        )
+    if item_id(payload.get("id")) != selected_id:
+        raise HackerNewsReadProviderError(
+            "Hacker News item response does not match the requested item ID"
+        )
+    deleted = _boolean(payload.get("deleted"), "item deleted flag")
+    dead = _boolean(payload.get("dead"), "item dead flag")
+    state = "deleted" if deleted else "dead" if dead else "live"
+    record: dict[str, Any] = {"item_id": selected_id, "state": state}
+    if state == "live":
+        record.update(_live_item(payload, expected_username))
+    else:
+        author = payload.get("by")
+        if author is not None and username(author) != username(expected_username):
+            raise HackerNewsReadProviderError(
+                "Hacker News tombstone author does not match the public selector"
+            )
+        item_type = payload.get("type")
+        if item_type is not None and item_type not in ITEM_TYPES:
+            raise HackerNewsReadProviderError("Hacker News item type is invalid")
+        record.update({"type": item_type, "by": author})
+    return record
+
+
+def terminal_payload(result: ApiResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "status": result.status,
+        "observed_at": observed_at(),
+        "response_bytes": result.response_bytes,
+    }
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload

--- a/.agents/scripts/_knowledge_social_hacker_news_http.py
+++ b/.agents/scripts/_knowledge_social_hacker_news_http.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Redirect-free, bounded GET transport for the Hacker News Firebase API."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from _knowledge_social_hacker_news_contract import (
+    ApiResult,
+    HackerNewsReadProviderError,
+    MAX_ITEM_RESPONSE_BYTES,
+    MAX_USER_RESPONSE_BYTES,
+    decode_json,
+)
+from _knowledge_social_hacker_news_identity import item_id, username
+
+API_ORIGIN = "https://hacker-news.firebaseio.com"
+API_PREFIX = "/v0"
+HTTP_TIMEOUT_SECONDS = 60
+
+
+class Headers(Protocol):
+    def get(self, key: str, default: str | None = None) -> str | None: ...
+
+
+class Response(Protocol):
+    status: int
+    headers: Headers
+
+    def __enter__(self) -> Response: ...
+    def __exit__(self, *args: Any) -> None: ...
+    def read(self, size: int = -1) -> bytes: ...
+
+
+class Opener(Protocol):
+    def open(self, request: Request, timeout: int) -> Response: ...
+
+
+class _RejectRedirect(HTTPRedirectHandler):
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def _http_exports() -> Opener:
+    exports = (Request, build_opener, quote, HTTPRedirectHandler)
+    if not all(callable(current) for current in exports):
+        raise HackerNewsReadProviderError("Python urllib HTTP exports are unavailable")
+    return build_opener(_RejectRedirect())
+
+
+def allowlisted_route(kind: str) -> bool:
+    return kind in {"user", "item"}
+
+
+def _target_url(kind: str, selector: str | int) -> tuple[str, int]:
+    if kind == "user":
+        selected = username(selector)
+        path_selector = quote(selected, safe="")
+        limit = MAX_USER_RESPONSE_BYTES
+    elif kind == "item":
+        path_selector = str(item_id(selector))
+        limit = MAX_ITEM_RESPONSE_BYTES
+    else:
+        raise HackerNewsReadProviderError("Hacker News API route is not allowlisted")
+    return f"{API_ORIGIN}{API_PREFIX}/{kind}/{path_selector}.json", limit
+
+
+def _retry_after(headers: Headers) -> int | None:
+    value = headers.get("Retry-After")
+    if value is None:
+        return None
+    if not value.isdigit() or not 1 <= int(value) <= 86400:
+        return None
+    return int(time.time()) + int(value)
+
+
+def api(opener: Opener, kind: str, selector: str | int) -> ApiResult:
+    """Execute one exact-origin, redirect-free, GET-only Firebase request."""
+    target, limit = _target_url(kind, selector)
+    request = Request(
+        target,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "aidevops-hacker-news-knowledge/1",
+        },
+        method="GET",
+    )
+    try:
+        with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", 200)
+            if isinstance(status, bool) or not isinstance(status, int):
+                raise HackerNewsReadProviderError("Hacker News HTTP status is invalid")
+            payload = response.read(limit + 1)
+            if not isinstance(payload, bytes):
+                raise HackerNewsReadProviderError("Hacker News HTTP response is invalid")
+            return ApiResult(
+                status,
+                decode_json(payload, limit),
+                len(payload),
+                _retry_after(response.headers),
+            )
+    except HTTPError as error:
+        return ApiResult(error.code, None, retry_after=_retry_after(error.headers))
+    except (TimeoutError, URLError, OSError) as error:
+        raise HackerNewsReadProviderError(
+            "Hacker News public read provider request failed"
+        ) from error

--- a/.agents/scripts/_knowledge_social_hacker_news_identity.py
+++ b/.agents/scripts/_knowledge_social_hacker_news_identity.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Public Hacker News selector and item identity validation."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from knowledge_social_store import SocialStoreError
+
+
+class HackerNewsAdapterError(SocialStoreError):
+    """Raised when public Hacker News collection cannot continue safely."""
+
+
+class HackerNewsProviderUnavailableError(HackerNewsAdapterError):
+    """Raised when the bounded Hacker News HTTP child cannot complete a read."""
+
+
+def username(value: Any) -> str:
+    """Validate one case-sensitive public username without normalizing it."""
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise HackerNewsAdapterError("Hacker News public username is invalid")
+    if len(value.encode("utf-8")) > 256 or any(ord(character) < 32 for character in value):
+        raise HackerNewsAdapterError("Hacker News public username is invalid")
+    return value
+
+
+def selector_id(value: Any) -> str:
+    """Namespace a mutable public username without claiming account identity."""
+    selected = username(value)
+    digest = hashlib.sha256(selected.encode("utf-8")).hexdigest()[:32]
+    return f"hnu_{digest}"
+
+
+def item_id(value: Any) -> int:
+    """Validate one official positive integer item ID."""
+    if isinstance(value, bool) or not isinstance(value, int) or not 1 <= value < 2**63:
+        raise HackerNewsAdapterError("Hacker News item ID is invalid")
+    return value

--- a/.agents/scripts/_knowledge_social_hacker_news_normalize.py
+++ b/.agents/scripts/_knowledge_social_hacker_news_normalize.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize public Hacker News item observations into neutral evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_hacker_news import (
+    PROVIDER,
+    RETENTION_LIMIT,
+    HackerNewsAdapterError,
+    page_data,
+)
+from _knowledge_social_hacker_news_identity import item_id, selector_id, username
+from knowledge_social_import import reject_credentials
+
+PROVENANCE = "hacker_news_firebase_v0_public_api"
+IDENTITY_BOUNDARY = "public_mutable_case_sensitive_username_selector"
+GAPS = (
+    ("votes", "private_vote_state_not_available"),
+    ("favourites", "private_saved_state_not_available"),
+    ("inbox", "private_inbox_not_available"),
+    ("notifications", "private_notifications_not_available"),
+    ("relationships", "relationships_not_available"),
+    ("subscriptions", "subscriptions_not_available"),
+    ("lists", "custom_lists_not_available"),
+    ("deleted_dead_content", "provider_tombstones_do_not_expose_removed_content"),
+    ("private_state", "authenticated_private_state_not_available"),
+)
+ITEM_STATES = frozenset({"live", "missing", "deleted", "dead"})
+
+
+@dataclass(frozen=True)
+class PageContext:
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def _optional_text(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value:
+        raise HackerNewsAdapterError(f"Hacker News {field} must be text")
+    return value
+
+
+def _timestamp(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise HackerNewsAdapterError(f"Hacker News {field} is invalid")
+    try:
+        return datetime.fromtimestamp(value, UTC).isoformat().replace("+00:00", "Z")
+    except (OverflowError, OSError, ValueError) as error:
+        raise HackerNewsAdapterError(f"Hacker News {field} is invalid") from error
+
+
+def _observed_at(payload: dict[str, Any]) -> str:
+    value = payload.get("observed_at")
+    if not isinstance(value, str) or not value:
+        raise HackerNewsAdapterError("Hacker News page observed_at must be text")
+    return value
+
+
+def _base_coverage(observed_at: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "stream": stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": RETENTION_LIMIT,
+            "unavailable_reason": reason,
+            "status": "unavailable",
+            "observed_at": observed_at,
+        }
+        for stream, reason in GAPS
+    ]
+
+
+def _availability_coverage(
+    account: dict[str, Any], records: list[dict[str, Any]], observed_at: str
+) -> list[dict[str, Any]]:
+    coverage: list[dict[str, Any]] = []
+    if account.get("availability") == "missing":
+        coverage.append(
+            {
+                "stream": "public_selector",
+                "earliest_at": None,
+                "latest_at": None,
+                "cursor_exhausted": True,
+                "retention_limit": RETENTION_LIMIT,
+                "unavailable_reason": "public_username_not_found",
+                "status": "unavailable",
+                "observed_at": observed_at,
+            }
+        )
+    for record in records:
+        state = record.get("state")
+        if state not in ITEM_STATES:
+            raise HackerNewsAdapterError("Hacker News normalized item state is invalid")
+        if state != "live":
+            current_id = item_id(record.get("item_id"))
+            coverage.append(
+                {
+                    "stream": f"submitted_item_{current_id}",
+                    "earliest_at": None,
+                    "latest_at": None,
+                    "cursor_exhausted": True,
+                    "retention_limit": RETENTION_LIMIT,
+                    "unavailable_reason": f"public_item_{state}",
+                    "status": "unavailable",
+                    "observed_at": observed_at,
+                }
+            )
+    return coverage
+
+
+def _remote_id(record: dict[str, Any]) -> str:
+    return f"hn_item_{item_id(record.get('item_id'))}"
+
+
+def _object_row(
+    record: dict[str, Any], context: PageContext, observed_at: str
+) -> dict[str, Any]:
+    item_type = record.get("type")
+    if item_type not in {"job", "story", "comment", "poll", "pollopt"}:
+        raise HackerNewsAdapterError("Hacker News normalized item type is invalid")
+    text = "\n\n".join(
+        current
+        for key in ("title", "text", "url")
+        if (current := _optional_text(record.get(key), f"item {key}"))
+    ) or None
+    provider_json = {
+        "source": PROVENANCE,
+        "identity_boundary": IDENTITY_BOUNDARY,
+        "public_username": username(context.account.get("username")),
+        "record": record,
+    }
+    reject_credentials(provider_json)
+    return {
+        "object_type": item_type,
+        "remote_id": _remote_id(record),
+        "account_remote_id": selector_id(context.account.get("username")),
+        "text": text,
+        "created_at": _timestamp(record.get("time"), "item creation timestamp"),
+        "observed_at": observed_at,
+        "evidence_class": "public_attributed",
+        "provider_json": provider_json,
+    }
+
+
+def _activity_row(
+    record: dict[str, Any], context: PageContext, observed_at: str
+) -> dict[str, Any]:
+    selected_id = selector_id(context.account.get("username"))
+    remote_id = _remote_id(record)
+    return {
+        "activity_type": "public_submission",
+        "remote_id": f"{selected_id}_submitted_{record['item_id']}",
+        "actor_remote_id": selected_id,
+        "object_remote_id": remote_id,
+        "occurred_at": _timestamp(record.get("time"), "item creation timestamp"),
+        "observed_at": observed_at,
+        "state": "observed",
+        "provider_json": {
+            "source": PROVENANCE,
+            "identity_boundary": IDENTITY_BOUNDARY,
+        },
+    }
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    reject_credentials(payload)
+    observed_at = _observed_at(payload)
+    selected = username(context.account.get("username"))
+    selected_id = selector_id(selected)
+    if context.account.get("id") != selected_id:
+        raise HackerNewsAdapterError("Hacker News public selector binding is invalid")
+    records = page_data(payload)
+    live = [record for record in records if record.get("state") == "live"]
+    policy = dict(context.policy)
+    policy.update(
+        {
+            "hacker_news_identity": IDENTITY_BOUNDARY,
+            "hacker_news_pagination": "content_addressed_submitted_id_slice",
+            "hacker_news_transport": "stdlib_urllib_public_get_only",
+            "hacker_news_private_state": "unavailable_not_empty",
+        }
+    )
+    archive = {
+        "provider": PROVIDER,
+        "connection_id": context.connection_id,
+        "remote_account_id": selected_id,
+        "exported_at": observed_at,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": policy,
+        "accounts": [
+            {
+                "remote_id": selected_id,
+                "handle": selected,
+                "display_name": None,
+                "observed_at": observed_at,
+                "provider_json": {
+                    "source": PROVENANCE,
+                    "identity_boundary": IDENTITY_BOUNDARY,
+                    "availability": context.account.get("availability"),
+                    "created": context.account.get("created"),
+                    "karma": context.account.get("karma"),
+                    "about": context.account.get("about"),
+                },
+            }
+        ],
+        "objects": [_object_row(record, context, observed_at) for record in live],
+        "activities": [
+            _activity_row(record, context, observed_at) for record in live
+        ],
+        "media": [],
+        "coverage": [
+            *_base_coverage(observed_at),
+            *_availability_coverage(context.account, records, observed_at),
+        ],
+    }
+    reject_credentials(archive)
+    return archive

--- a/.agents/scripts/_knowledge_social_hacker_news_provider.py
+++ b/.agents/scripts/_knowledge_social_hacker_news_provider.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded GET-only public Hacker News Firebase API reader subprocess."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+from _knowledge_social_hacker_news import (
+    PageRequest,
+    parse_page_request,
+)
+from _knowledge_social_hacker_news_contract import (
+    ApiResult,
+    HackerNewsReadProviderError,
+    MAX_ITEM_RESPONSE_BYTES,
+    MAX_USER_RESPONSE_BYTES,
+    item_value,
+    observed_at,
+    request_object,
+    terminal_payload,
+    user_value,
+)
+from _knowledge_social_hacker_news_http import Opener, _http_exports, api
+from _knowledge_social_hacker_news_identity import (
+    HackerNewsAdapterError,
+    selector_id,
+    username,
+)
+
+MAX_REQUEST_BYTES = 64 * 1024
+MAX_OUTPUT_BYTES = MAX_USER_RESPONSE_BYTES + MAX_ITEM_RESPONSE_BYTES + 256 * 1024
+
+
+def _profile(profile: str) -> None:
+    if profile != "public":
+        raise HackerNewsReadProviderError(
+            "Hacker News profile must be the credential-free public profile"
+        )
+
+
+def _identity(opener: Opener, expected_username: str) -> dict[str, Any]:
+    selected = username(expected_username)
+    result = api(opener, "user", selected)
+    if result.status != 200:
+        return terminal_payload(result)
+    data = user_value(result.payload, selected)
+    data["response_bytes"] = result.response_bytes
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": data,
+    }
+
+
+def _verify_selector(request: PageRequest, identity: dict[str, Any]) -> None:
+    if (
+        identity.get("username") != request.username
+        or identity.get("id") != request.selector_id
+        or selector_id(request.username) != request.selector_id
+    ):
+        raise HackerNewsReadProviderError(
+            "Hacker News public selector changed during collection"
+        )
+
+
+def _page(opener: Opener, request: PageRequest) -> dict[str, Any]:
+    identity = _identity(opener, request.username)
+    if identity.get("status") != 200:
+        return identity
+    data = identity.get("data")
+    if not isinstance(data, dict):
+        raise HackerNewsReadProviderError(
+            "Hacker News public selector response is invalid"
+        )
+    _verify_selector(request, data)
+    user_bytes = data.get("response_bytes")
+    if isinstance(user_bytes, bool) or not isinstance(user_bytes, int) or user_bytes < 0:
+        raise HackerNewsReadProviderError(
+            "Hacker News public selector byte count is invalid"
+        )
+    current_item = request.item_id
+    if data.get("availability") == "missing" and current_item is not None:
+        return terminal_payload(ApiResult(404, None, user_bytes))
+    if current_item is None:
+        record = None
+        item_bytes = 0
+        item_state = "empty"
+    else:
+        result = api(opener, "item", current_item)
+        if result.status != 200:
+            terminal = terminal_payload(result)
+            terminal["response_bytes"] = user_bytes + result.response_bytes
+            return terminal
+        record = item_value(result.payload, current_item, request.username)
+        item_bytes = result.response_bytes
+        item_state = record["state"]
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": [] if record is None else [record],
+        "meta": {
+            "stream": request.stream,
+            "username": request.username,
+            "selector_id": request.selector_id,
+            "snapshot_sha256": request.snapshot_sha256,
+            "position": request.position,
+            "total": len(request.items),
+            "item_id": current_item,
+            "item_state": item_state,
+            "response_bytes": user_bytes + item_bytes,
+            "public_selector": True,
+        },
+    }
+
+
+def _dispatch(request: dict[str, Any], opener: Opener) -> dict[str, Any]:
+    action = request.get("action")
+    if action == "identity":
+        if set(request) != {"action", "account_id"}:
+            raise HackerNewsReadProviderError(
+                "Hacker News identity request shape is invalid"
+            )
+        return _identity(opener, username(request.get("account_id")))
+    if action != "page":
+        raise HackerNewsReadProviderError("Hacker News read action is unsupported")
+    return _page(opener, parse_page_request(request))
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode("utf-8")) > MAX_OUTPUT_BYTES:
+        raise HackerNewsReadProviderError(
+            "Hacker News read response exceeds the safety limit"
+        )
+    print(encoded)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        _profile(args.profile)
+        request = request_object(
+            sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1), MAX_REQUEST_BYTES
+        )
+        _emit(_dispatch(request, _http_exports()))
+        return 0
+    except (HackerNewsReadProviderError, HackerNewsAdapterError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - intentionally redact provider internals
+        print("ERROR: Hacker News public read provider request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_hacker_news_reader.py
+++ b/.agents/scripts/_knowledge_social_hacker_news_reader.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and deterministic fixture readers for Hacker News."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_hacker_news import PageRequest
+from _knowledge_social_hacker_news_contract import (
+    HackerNewsReadProviderError,
+    MAX_ITEM_RESPONSE_BYTES,
+    MAX_USER_RESPONSE_BYTES,
+    submitted_ids,
+)
+from _knowledge_social_hacker_news_identity import (
+    HackerNewsAdapterError,
+    HackerNewsProviderUnavailableError,
+    selector_id,
+    username,
+)
+from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
+from knowledge_social_import import reject_credentials
+
+READ_TIMEOUT_SECONDS = 120
+MAX_RESPONSE_BYTES = MAX_USER_RESPONSE_BYTES + MAX_ITEM_RESPONSE_BYTES + 256 * 1024
+SAFE_PROVIDER_FAILURES = (
+    "Python urllib HTTP exports are unavailable",
+    "Hacker News profile must be the credential-free public profile",
+    "Hacker News public username is invalid",
+    "Hacker News public selector changed during collection",
+)
+
+
+class HackerNewsReader(Protocol):
+    def identity(self, expected_id: str) -> dict[str, Any]: ...
+    def page(self, request: PageRequest) -> dict[str, Any]: ...
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    if len(output.encode("utf-8")) > MAX_RESPONSE_BYTES:
+        raise HackerNewsAdapterError(
+            "Hacker News read response exceeds the safety limit"
+        )
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise HackerNewsAdapterError(
+            "Hacker News read provider returned no valid JSON"
+        ) from error
+    if not isinstance(payload, dict):
+        raise HackerNewsAdapterError("Hacker News read response root must be an object")
+    return payload
+
+
+def _provider_failure(stderr: str) -> HackerNewsProviderUnavailableError:
+    for message in SAFE_PROVIDER_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return HackerNewsProviderUnavailableError(message)
+    return HackerNewsProviderUnavailableError(
+        "Hacker News public read provider is unavailable"
+    )
+
+
+HACKER_NEWS_READER_POLICY = GuardedOAuthPolicy(
+    "Hacker News",
+    "HACKER_NEWS",
+    "HACKER_NEWS_READ_LOG",
+    READ_TIMEOUT_SECONDS,
+    _decode_output,
+    _provider_failure,
+    HackerNewsProviderUnavailableError,
+    (),
+    "public",
+)
+
+
+class GuardedHackerNews(GuardedOAuthReader):
+    def __init__(self, helper: Path, profile: str) -> None:
+        if profile != "public":
+            raise HackerNewsProviderUnavailableError(
+                "Hacker News profile must be the credential-free public profile"
+            )
+        super().__init__(helper, profile, HACKER_NEWS_READER_POLICY)
+
+
+def _fixture_object(value: Any, message: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise HackerNewsAdapterError(message)
+    return value
+
+
+class FixtureHackerNews:
+    def __init__(self, path: Path) -> None:
+        self.fixture = FixtureSequence(path, "Hacker News", HackerNewsAdapterError)
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        del expected_id
+        return self.fixture.identity()
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        entry = self.fixture.next_page()
+        expectation = _fixture_object(
+            entry.get("expect_request", {}),
+            "Hacker News fixture request expectation must be an object",
+        )
+        actual = request.payload()
+        for key, value in expectation.items():
+            if actual.get(key) != value:
+                raise HackerNewsAdapterError(
+                    "Hacker News request did not resume at the expected checkpoint"
+                )
+        return _fixture_object(
+            entry.get("response", entry),
+            "Hacker News fixture page response must be an object",
+        )
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    """Verify only an exact public selector, never authenticated account identity."""
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise HackerNewsAdapterError(
+            "Hacker News public selector response returned no observation"
+        )
+    selected = username(data.get("username"))
+    if selected != username(expected_id) or data.get("id") != selector_id(selected):
+        raise HackerNewsAdapterError(
+            "Hacker News public username does not match the configured selector"
+        )
+    availability = data.get("availability")
+    if availability not in {"public", "missing"}:
+        raise HackerNewsAdapterError(
+            "Hacker News public selector availability is invalid"
+        )
+    try:
+        submitted = submitted_ids(data.get("submitted", []))
+    except HackerNewsReadProviderError as error:
+        raise HackerNewsAdapterError(str(error)) from error
+    response_bytes = data.get("response_bytes", 0)
+    if (
+        isinstance(response_bytes, bool)
+        or not isinstance(response_bytes, int)
+        or response_bytes < 0
+        or response_bytes > MAX_USER_RESPONSE_BYTES
+    ):
+        raise HackerNewsAdapterError(
+            "Hacker News public selector byte count is invalid"
+        )
+    return {
+        "id": selector_id(selected),
+        "username": selected,
+        "availability": availability,
+        "submitted": list(submitted),
+        "created": data.get("created"),
+        "karma": data.get("karma"),
+        "about": data.get("about"),
+        "response_bytes": response_bytes,
+        "identity_boundary": "public_mutable_username_selector",
+    }

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -18,6 +18,7 @@ NODEBB_HELPER="${SCRIPT_DIR}/knowledge_social_nodebb.py"
 MASTODON_HELPER="${SCRIPT_DIR}/knowledge_social_mastodon.py"
 GITHUB_HELPER="${SCRIPT_DIR}/knowledge_social_github.py"
 STACK_EXCHANGE_HELPER="${SCRIPT_DIR}/knowledge_social_stack_exchange.py"
+HACKER_NEWS_HELPER="${SCRIPT_DIR}/knowledge_social_hacker_news.py"
 MINIFLUX_HELPER="${SCRIPT_DIR}/knowledge_social_miniflux.py"
 READWISE_READER_HELPER="${SCRIPT_DIR}/knowledge_social_readwise_reader.py"
 QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
@@ -135,6 +136,13 @@ Stack Exchange synchronization:
   exhaustion, continue only while has_more, and cap pages at 100 items.
   --budget is 3-1000 and --page-size is 1-100.
 
+Hacker News synchronization:
+  sync-hacker-news observes one exact case-sensitive public username selector;
+  it never claims authenticated or immutable account identity. One bounded
+  submitted-ID slice resolves only official Firebase user/item GET routes.
+  --profile must be public, --budget is 3-1000 request units, and --page-size
+  is a 1-100 item slice limit.
+
 Miniflux synchronization:
   sync-miniflux binds one user ID to a keyed exact HTTPS installation before
   every page. Entries, read, removed, starred, tags, feeds, categories, and OPML
@@ -205,6 +213,10 @@ Usage:
   knowledge-social-helper.sh sync-stack-exchange [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id NETWORK_ACCOUNT_ID --stream STREAM \
     --profile PROFILE [--budget UNITS] [--page-size 1-100] \
+    [--collector-id ID] [--lease-seconds SECONDS]
+  knowledge-social-helper.sh sync-hacker-news [--base PATH] [--alias ALIAS] \
+    --connection-id ID --account-id CASE_SENSITIVE_USERNAME --stream submitted \
+    --profile public [--budget UNITS] [--page-size 1-100] \
     [--collector-id ID] [--lease-seconds SECONDS]
   knowledge-social-helper.sh sync-miniflux [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id USER_NUMERIC_ID --stream STREAM \
@@ -401,6 +413,7 @@ run_named_provider_sync() {
 	sync-mastodon) run_provider_sync Mastodon "$MASTODON_HELPER" "$@" || return 1 ;;
 	sync-github) run_provider_sync GitHub "$GITHUB_HELPER" "$@" || return 1 ;;
 	sync-stack-exchange) run_provider_sync "Stack Exchange" "$STACK_EXCHANGE_HELPER" "$@" || return 1 ;;
+	sync-hacker-news) run_provider_sync "Hacker News" "$HACKER_NEWS_HELPER" "$@" || return 1 ;;
 	sync-miniflux) run_provider_sync Miniflux "$MINIFLUX_HELPER" "$@" || return 1 ;;
 	sync-readwise-reader) run_provider_sync "Readwise Reader" "$READWISE_READER_HELPER" "$@" || return 1 ;;
 	*) return 1 ;;
@@ -482,7 +495,7 @@ main() {
 		fi
 		python3 "$LINKEDIN_HELPER" "$@" || return 1
 		;;
-	sync-meta | sync-discourse | sync-nodebb | sync-mastodon | sync-github | sync-stack-exchange | sync-miniflux | sync-readwise-reader)
+	sync-meta | sync-discourse | sync-nodebb | sync-mastodon | sync-github | sync-stack-exchange | sync-hacker-news | sync-miniflux | sync-readwise-reader)
 		run_named_provider_sync "$subcommand" "$@" || return 1
 		;;
 	query | annotate)

--- a/.agents/scripts/knowledge_social_hacker_news.py
+++ b/.agents/scripts/knowledge_social_hacker_news.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one bounded public Hacker News submitted-item slice into a social corpus."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import _knowledge_social_hacker_news as hacker_news
+from _knowledge_social_hacker_news_collector import run_hacker_news_collector
+from _knowledge_social_hacker_news_normalize import PageContext, normalize_page
+from _knowledge_social_hacker_news_reader import (
+    FixtureHackerNews,
+    GuardedHackerNews,
+    verified_identity,
+)
+from _knowledge_social_oauth_collector import OAuthCollectorPolicy
+
+
+def _policy() -> OAuthCollectorPolicy:
+    return OAuthCollectorPolicy(
+        provider_module=hacker_news,
+        verified_identity=verified_identity,
+        normalize_page=normalize_page,
+        page_context=PageContext,
+        display_name="Hacker News",
+        helper=Path(__file__).with_name("_knowledge_social_hacker_news_provider.py"),
+        fixture_reader=FixtureHackerNews,
+        live_reader=GuardedHackerNews,
+        budget_unit="request",
+        default_budget=11,
+        min_budget=3,
+        max_page_size=100,
+    )
+
+
+def main() -> int:
+    return run_hacker_news_collector(_policy(), __doc__ or "")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/knowledge_social_registry.py
+++ b/.agents/scripts/knowledge_social_registry.py
@@ -52,6 +52,12 @@ PROVIDER_SPECS = (
     ),
     ProviderSpec("gumroad", (), "knowledge_social_gumroad.py", (("live", ()),)),
     ProviderSpec("github", (), "knowledge_social_github.py", (("live", ()),)),
+    ProviderSpec(
+        "hacker-news",
+        ("hn",),
+        "knowledge_social_hacker_news.py",
+        (("live", ()),),
+    ),
     ProviderSpec("mastodon", (), "knowledge_social_mastodon.py", (("live", ()),)),
     ProviderSpec("miniflux", (), "knowledge_social_miniflux.py", (("live", ()),)),
     ProviderSpec(

--- a/.agents/tests/test-knowledge-social-hacker-news.sh
+++ b/.agents/tests/test-knowledge-social-hacker-news.sh
@@ -1,0 +1,525 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-hacker-news.sh — Public Hacker News collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HN_SCRIPT="${SCRIPT_DIR}/../scripts/knowledge_social_hacker_news.py"
+SOCIAL_HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TEMP_PARENT="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+mkdir -p "$TEMP_PARENT"
+TMP_DIR=$(mktemp -d "${TEMP_PARENT}/hacker-news-social-test.XXXXXX")
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' \
+			"$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c 'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_count() {
+	python3 - "$ROOT/sources/social/raw/hacker-news" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+print(len(list(root.rglob("*.json.gz"))) if root.exists() else 0)
+PY
+	return 0
+}
+
+run_hn() {
+	local fixture="$1"
+	local connection_id="$2"
+	local budget="$3"
+	local page_size="$4"
+	local selected_username="$5"
+	if python3 "$HN_SCRIPT" --base "$BASE" --alias personal:default \
+		--connection-id "$connection_id" --account-id "$selected_username" \
+		--stream submitted --profile public --fixture "$fixture" \
+		--budget "$budget" --page-size "$page_size"; then
+		return 0
+	fi
+	return 1
+}
+
+expect_failure() {
+	local description="$1"
+	local fixture="$2"
+	local connection_id="$3"
+	local budget="$4"
+	local page_size="$5"
+	local selected_username="$6"
+	if run_hn "$fixture" "$connection_id" "$budget" "$page_size" \
+		"$selected_username" >/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$SOCIAL_HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'Hacker News social collector tests\n'
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import ast
+import json
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+
+from _knowledge_social_collect import CursorState
+from _knowledge_social_hacker_news import (
+    PageRequest, page_checkpoint, page_request, parse_page_request,
+)
+from _knowledge_social_hacker_news_contract import item_value, user_value
+from _knowledge_social_hacker_news_http import (
+    HTTP_TIMEOUT_SECONDS, allowlisted_route, api,
+)
+from _knowledge_social_hacker_news_identity import selector_id
+
+assert selector_id("CaseUser") != selector_id("caseuser")
+missing = user_value(None, "jl")
+assert missing["availability"] == "missing" and missing["username"] == "jl"
+try:
+    user_value({"id": "caseuser", "submitted": []}, "CaseUser")
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("case-changed Hacker News username was accepted")
+
+account = {
+    "id": selector_id("CaseUser"), "username": "CaseUser",
+    "availability": "public", "submitted": [11, 12],
+}
+first = page_request("submitted", account, CursorState(None, None, False), 2)
+assert first.item_id == 11 and parse_page_request(first.payload()) == first
+payload = {
+    "status": 200, "observed_at": "2026-08-02T10:00:00Z",
+    "data": [{"item_id": 11, "state": "live", "type": "story",
+              "by": "CaseUser", "time": 1785664800, "title": "First"}],
+    "meta": {
+        "stream": "submitted", "username": "CaseUser",
+        "selector_id": selector_id("CaseUser"),
+        "snapshot_sha256": first.snapshot_sha256, "position": 0,
+        "total": 2, "item_id": 11, "item_state": "live",
+        "response_bytes": 128,
+    },
+}
+checkpoint, complete = page_checkpoint(payload, CursorState(None, None, False), first)
+assert not complete and checkpoint.next_cursor
+changed = dict(account, submitted=[99])
+resumed = page_request(
+    "submitted", changed, CursorState(checkpoint.next_cursor, checkpoint.watermark, False), 1,
+)
+assert resumed.item_id == 12 and resumed.items == (11, 12)
+
+assert item_value(None, 20, "CaseUser")["state"] == "missing"
+assert item_value({"id": 20, "deleted": True}, 20, "CaseUser")["state"] == "deleted"
+assert item_value({"id": 20, "dead": True}, 20, "CaseUser")["state"] == "dead"
+try:
+    item_value({"id": 20, "type": "story", "by": "Other"}, 20, "CaseUser")
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("item attributed to another username was accepted")
+
+
+class Headers:
+    def get(self, _key, default=None):
+        return default
+
+
+class Response:
+    status = 200
+    headers = Headers()
+
+    def __init__(self, payload):
+        self.payload = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def read(self, size=-1):
+        return self.payload[:size]
+
+
+class Opener:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    def open(self, request, timeout):
+        assert timeout == HTTP_TIMEOUT_SECONDS
+        assert request.method == "GET"
+        self.requests.append(request)
+        return self.responses.pop(0)
+
+
+opener = Opener([
+    Response({"id": "CaseUser", "submitted": [20]}),
+    Response({"id": 20, "type": "story", "by": "CaseUser"}),
+])
+assert api(opener, "user", "CaseUser").status == 200
+assert api(opener, "item", 20).status == 200
+assert opener.requests[0].full_url == "https://hacker-news.firebaseio.com/v0/user/CaseUser.json"
+assert opener.requests[1].full_url == "https://hacker-news.firebaseio.com/v0/item/20.json"
+assert allowlisted_route("user") and allowlisted_route("item")
+assert not allowlisted_route("maxitem")
+try:
+    api(opener, "updates", "CaseUser")
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("non-user/item Hacker News route was accepted")
+
+sources = [
+    path.read_text(encoding="utf-8")
+    for path in sorted(scripts.glob("_knowledge_social_hacker_news*.py"))
+]
+trees = [ast.parse(source) for source in sources]
+request_calls = [
+    node for tree in trees for node in ast.walk(tree)
+    if isinstance(node, ast.Call)
+    and isinstance(node.func, ast.Name)
+    and node.func.id == "Request"
+]
+assert request_calls
+for node in request_calls:
+    methods = [
+        keyword.value.value for keyword in node.keywords
+        if keyword.arg == "method" and isinstance(keyword.value, ast.Constant)
+    ]
+    assert methods == ["GET"]
+PY
+assert_eq "case-sensitive selector, deterministic resume, schemas, budgets, and GET-only routes are guarded" \
+	verified verified
+
+python3 - "$TMP_DIR" "$SCRIPT_DIR/../scripts" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+target = Path(sys.argv[1])
+sys.path.insert(0, sys.argv[2])
+from _knowledge_social_hacker_news import page_request
+from _knowledge_social_hacker_news_identity import selector_id
+from _knowledge_social_collect import CursorState
+
+USERNAME = "CaseUser"
+SELECTOR = selector_id(USERNAME)
+
+
+def identity(items, availability="public", username=USERNAME, selector=SELECTOR):
+    return {
+        "status": 200,
+        "observed_at": "2026-08-02T10:01:00Z",
+        "data": {
+            "id": selector,
+            "username": username,
+            "availability": availability,
+            "submitted": items,
+            "created": 1173923446,
+            "karma": 42,
+            "about": "Public profile",
+            "response_bytes": 100,
+        },
+    }
+
+
+def response(items, position, record, observed_at):
+    account = {
+        "id": SELECTOR, "username": USERNAME,
+        "availability": "public", "submitted": items,
+    }
+    request = page_request("submitted", account, CursorState(None, None, False), len(items) or 1)
+    request = type(request)(
+        request.stream, request.username, request.selector_id,
+        request.items, position, request.snapshot_sha256,
+    )
+    state = "empty" if record is None else record["state"]
+    return {
+        "status": 200,
+        "observed_at": observed_at,
+        "data": [] if record is None else [record],
+        "meta": {
+            "stream": "submitted", "username": USERNAME,
+            "selector_id": SELECTOR,
+            "snapshot_sha256": request.snapshot_sha256,
+            "position": position, "total": len(items),
+            "item_id": request.item_id, "item_state": state,
+            "response_bytes": 200,
+        },
+    }
+
+
+def write(name, identity_payload, pages):
+    (target / name).write_text(
+        json.dumps({"identity": identity_payload, "pages": pages}),
+        encoding="utf-8",
+    )
+
+
+complete_items = [101, 102]
+write("complete.json", identity(complete_items), [
+    {
+        "expect_request": {"position": 0, "items": complete_items},
+        "response": response(complete_items, 0, {
+            "item_id": 101, "state": "live", "type": "story", "by": USERNAME,
+            "time": 1785664860, "title": "Bounded story",
+            "text": "Hacker News fixture knowledge", "url": "https://example.invalid/story",
+            "score": 5, "descendants": 1, "kids": [500], "parts": None,
+            "parent": None, "poll": None,
+        }, "2026-08-02T10:02:00Z"),
+    },
+    {
+        "expect_request": {"position": 1, "items": complete_items},
+        "response": response(complete_items, 1, {
+            "item_id": 102, "state": "live", "type": "comment", "by": USERNAME,
+            "time": 1785664920, "title": None, "text": "Second public comment",
+            "url": None, "score": None, "descendants": None, "kids": None,
+            "parts": None, "parent": 101, "poll": None,
+        }, "2026-08-02T10:03:00Z"),
+    },
+])
+
+resume_items = [201, 202]
+write("resume-first.json", identity(resume_items), [{
+    "expect_request": {"position": 0, "items": resume_items},
+    "response": response(resume_items, 0, {
+        "item_id": 201, "state": "live", "type": "story", "by": USERNAME,
+        "time": 1785664980, "title": "Resume one", "text": None, "url": None,
+        "score": 1, "descendants": 0, "kids": None, "parts": None,
+        "parent": None, "poll": None,
+    }, "2026-08-02T10:04:00Z"),
+}])
+write("resume-second.json", identity([999]), [{
+    "expect_request": {"position": 1, "items": resume_items},
+    "response": response(resume_items, 1, {
+        "item_id": 202, "state": "live", "type": "comment", "by": USERNAME,
+        "time": 1785665040, "title": None, "text": "Resumed item", "url": None,
+        "score": None, "descendants": None, "kids": None, "parts": None,
+        "parent": 201, "poll": None,
+    }, "2026-08-02T10:05:00Z"),
+}])
+
+write("missing-user.json", identity([], "missing"), [{
+    "expect_request": {"position": 0, "items": []},
+    "response": response([], 0, None, "2026-08-02T10:06:00Z"),
+}])
+
+tombstone_items = [301, 302, 303]
+write("tombstones.json", identity(tombstone_items), [
+    {"response": response(tombstone_items, 0, {"item_id": 301, "state": "missing"}, "2026-08-02T10:07:00Z")},
+    {"response": response(tombstone_items, 1, {"item_id": 302, "state": "deleted", "type": None, "by": None}, "2026-08-02T10:08:00Z")},
+    {"response": response(tombstone_items, 2, {"item_id": 303, "state": "dead", "type": "story", "by": USERNAME}, "2026-08-02T10:09:00Z")},
+])
+
+write("case-mismatch.json", identity([], username="caseuser", selector=selector_id("caseuser")), [])
+
+malformed_items = [350]
+malformed = response(malformed_items, 0, {"item_id": 350, "state": "missing"}, "2026-08-02T10:10:00Z")
+malformed["meta"]["snapshot_sha256"] = "0" * 64
+write("malformed.json", identity(malformed_items), [{"response": malformed}])
+
+terminal_items = [401, 402]
+write("terminal-first.json", identity(terminal_items), [{
+    "response": response(terminal_items, 0, {
+        "item_id": 401, "state": "live", "type": "story", "by": USERNAME,
+        "time": 1785665100, "title": "Before failure", "text": None, "url": None,
+        "score": 1, "descendants": 0, "kids": None, "parts": None,
+        "parent": None, "poll": None,
+    }, "2026-08-02T10:11:00Z"),
+}])
+write("terminal-second.json", identity(terminal_items), [{
+    "expect_request": {"position": 1, "items": terminal_items},
+    "response": {"status": 500, "observed_at": "2026-08-02T10:12:00Z", "response_bytes": 10},
+}])
+write("identity-terminal.json", {
+    "status": 500, "observed_at": "2026-08-02T10:13:00Z", "response_bytes": 10,
+}, [])
+
+credential_items = [501]
+credential = response(credential_items, 0, {"item_id": 501, "state": "missing"}, "2026-08-02T10:14:00Z")
+credential["access_token"] = "must-not-persist"
+write("credential.json", identity(credential_items), [{"response": credential}])
+PY
+
+complete_result=$(run_hn "$TMP_DIR/complete.json" conn_hn_complete 5 2 CaseUser)
+assert_eq "bounded Hacker News fixture completes" \
+	"$(json_field "$complete_result" status)" complete
+assert_eq "identity and two item reads reserve five request units" \
+	"$(json_field "$complete_result" budget_units)" 5
+assert_eq "public Hacker News text reaches FTS" \
+	"$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'knowledge'")" 1
+assert_eq "public-only unavailable categories remain explicit" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE connection_id='conn_hn_complete' AND status='unavailable'")" 9
+complete_raw=$(raw_count)
+run_hn "$TMP_DIR/complete.json" conn_hn_complete 5 2 CaseUser >/dev/null
+assert_eq "exact Hacker News snapshot replay is idempotent" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='hacker-news' AND remote_id IN ('hn_item_101','hn_item_102')")" 2
+assert_eq "content-addressed replay does not duplicate raw blobs" "$(raw_count)" "$complete_raw"
+
+resume_first=$(run_hn "$TMP_DIR/resume-first.json" conn_hn_resume 3 2 CaseUser)
+assert_eq "request budget pauses a submitted-ID slice" \
+	"$(json_field "$resume_first" status)" budget_exhausted
+resume_second=$(run_hn "$TMP_DIR/resume-second.json" conn_hn_resume 3 1 CaseUser)
+assert_eq "resume uses the durable content-addressed ID slice" \
+	"$(json_field "$resume_second" status)" complete
+assert_eq "resumed snapshot retains both public items" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='hacker-news' AND remote_id IN ('hn_item_201','hn_item_202')")" 2
+
+missing_result=$(run_hn "$TMP_DIR/missing-user.json" conn_hn_missing_user 3 1 CaseUser)
+assert_eq "missing public username completes without an identity claim" \
+	"$(json_field "$missing_result" status)" complete
+assert_eq "missing public username records explicit coverage" \
+	"$(sql_value "SELECT status || ':' || unavailable_reason FROM coverage_records WHERE connection_id='conn_hn_missing_user' AND stream='public_selector'")" \
+	"unavailable:public_username_not_found"
+
+run_hn "$TMP_DIR/tombstones.json" conn_hn_tombstones 7 3 CaseUser >/dev/null
+assert_eq "missing, deleted, and dead items remain unavailable rather than empty" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE connection_id='conn_hn_tombstones' AND stream LIKE 'submitted_item_%' AND status='unavailable'")" 3
+assert_eq "tombstones do not create authored objects" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='hacker-news' AND remote_id IN ('hn_item_301','hn_item_302','hn_item_303')")" 0
+
+raw_before=$(raw_count)
+expect_failure "case-changed public username is rejected" \
+	"$TMP_DIR/case-mismatch.json" conn_hn_case 3 1 CaseUser
+expect_failure "malformed page provenance is rejected" \
+	"$TMP_DIR/malformed.json" conn_hn_malformed 3 1 CaseUser
+expect_failure "credential-shaped public payload is rejected" \
+	"$TMP_DIR/credential.json" conn_hn_credential 3 1 CaseUser
+assert_eq "rejected observations persist no raw evidence" "$(raw_count)" "$raw_before"
+
+run_hn "$TMP_DIR/terminal-first.json" conn_hn_terminal 3 2 CaseUser >/dev/null
+terminal_result=$(run_hn "$TMP_DIR/terminal-second.json" conn_hn_terminal 3 1 CaseUser)
+assert_eq "terminal item failure is sanitized" \
+	"$(json_field "$terminal_result" failure_class)" provider
+assert_eq "terminal item failure preserves its prior checkpoint" \
+	"$(sql_value "SELECT cursor IS NOT NULL FROM sync_cursors WHERE connection_id='conn_hn_terminal' AND stream='submitted'")" 1
+assert_eq "terminal item failure records failed coverage" \
+	"$(sql_value "SELECT status || ':' || unavailable_reason FROM coverage_records WHERE connection_id='conn_hn_terminal' AND stream='submitted'")" \
+	"failed:provider"
+
+identity_terminal=$(run_hn "$TMP_DIR/identity-terminal.json" conn_hn_identity_terminal 3 1 jl)
+assert_eq "terminal public-selector read is sanitized" \
+	"$(json_field "$identity_terminal" failure_class)" provider
+assert_eq "terminal public-selector read records coverage without account identity" \
+	"$(sql_value "SELECT status || ':' || unavailable_reason FROM coverage_records WHERE connection_id='conn_hn_identity_terminal' AND stream='submitted'")" \
+	"failed:provider"
+
+python3 - "$ROOT" "$SCRIPT_DIR/../scripts" <<'PY'
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[2])
+from _knowledge_social_collect import (
+    CollectionContext, ConnectionConfig, CursorState, PageCheckpoint, SuccessfulPage,
+)
+from _knowledge_social_collect_persist import persist_page
+from _knowledge_social_hacker_news import STREAMS
+from _knowledge_social_hacker_news_identity import selector_id
+from _knowledge_social_lease import (
+    RunLeaseRequest, SocialLeaseLostError, acquire_run_lease, release_run_lease,
+)
+
+root = Path(sys.argv[1])
+old = acquire_run_lease(
+    root, RunLeaseRequest("conn_hn_fence", "submitted", "old_runner", "sync", 1),
+    now_epoch=9000,
+)
+new = acquire_run_lease(
+    root, RunLeaseRequest("conn_hn_fence", "submitted", "new_runner", "sync", 10),
+    now_epoch=9001,
+)
+selected = selector_id("CaseUser")
+context = CollectionContext(
+    root, "conn_hn_fence", {"id": selected, "username": "CaseUser"},
+    "submitted", "none", ConnectionConfig(("submitted",), {"media_hydration": "none"}),
+    CursorState(None, None, False), STREAMS["submitted"], old, "hacker-news",
+)
+archive = {
+    "provider": "hacker-news", "connection_id": "conn_hn_fence",
+    "remote_account_id": selected, "exported_at": "2026-08-02T10:15:00Z",
+    "enabled_streams": ["submitted"], "policy": {"media_hydration": "none"},
+    "accounts": [], "objects": [], "activities": [], "media": [], "coverage": [],
+}
+successful = SuccessfulPage(
+    {"status": 200, "observed_at": archive["exported_at"], "data": [], "meta": {}},
+    '{"stream":"submitted"}', archive, PageCheckpoint(None, None), True, 2,
+)
+os.environ["AIDEVOPS_SOCIAL_NOW_EPOCH"] = "9001"
+try:
+    persist_page(context, successful)
+except SocialLeaseLostError:
+    pass
+else:
+    raise SystemExit("stale Hacker News collector advanced persistence")
+with sqlite3.connect(root / "index" / "social.db") as database:
+    count = database.execute(
+        "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_hn_fence'"
+    ).fetchone()[0]
+assert count == 0
+release_run_lease(root, new)
+PY
+assert_eq "stale Hacker News lease cannot commit evidence or a cursor" verified verified
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/tests/test-knowledge-social-registry.sh
+++ b/.agents/tests/test-knowledge-social-registry.sh
@@ -44,6 +44,7 @@ expected = {
     "discord": ("live",),
     "forem": ("live",),
     "github": ("live",),
+    "hacker-news": ("live",),
     "google-business-profile": ("live",),
     "gumroad": ("live",),
     "mastodon": ("live",),
@@ -73,6 +74,7 @@ for alias, provider in {
     "dev-community": "forem",
     "dev.to": "forem",
     "gbp": "google-business-profile",
+    "hn": "hacker-news",
     "reader": "readwise-reader",
     "stackexchange": "stack-exchange",
     "whats-app": "whatsapp",
@@ -97,18 +99,25 @@ except module.ProviderRegistryError:
 else:
     raise SystemExit("unknown provider used a fallback")
 
-print("16:order-independent:aliases-exact:collisions-rejected:no-fallback")
+print("17:order-independent:aliases-exact:collisions-rejected:no-fallback")
 PY
 )
 assert_eq "all merged provider outcomes register deterministically" \
-	"$registry_summary" "16:order-independent:aliases-exact:collisions-rejected:no-fallback"
+	"$registry_summary" "17:order-independent:aliases-exact:collisions-rejected:no-fallback"
 
 provider_count=$("$HELPER" providers | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
-assert_eq "helper exposes the complete provider registry" "$provider_count" "16"
+assert_eq "helper exposes the complete provider registry" "$provider_count" "17"
 
 forem_resolution=$("$HELPER" provider-resolve --provider dev-community |
 	python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["provider"] + ":" + ",".join(data["modes"]))')
 assert_eq "DEV Community resolves only to the Forem family" "$forem_resolution" "forem:live"
+
+hacker_news_help=$("$HELPER" provider-run --provider hn --mode live -- --help 2>&1)
+if [[ "$hacker_news_help" == *"bounded public Hacker News submitted-item slice"* ]]; then
+	assert_eq "Hacker News alias executes only the public local adapter" canonical canonical
+else
+	assert_eq "Hacker News alias executes only the public local adapter" unexpected canonical
+fi
 
 if "$HELPER" provider-run --provider binance-square --mode no-route >/dev/null 2>&1; then
 	assert_eq "no-route outcomes cannot execute" accepted rejected


### PR DESCRIPTION
## Summary

- Add a bounded, public-only Hacker News Firebase collector keyed by an exact case-sensitive username selector.
- Preserve immutable raw evidence, deterministic submitted-ID checkpoints, explicit public-coverage gaps, and lease fencing.
- Add focused fixture, transport, replay, terminal-failure, and write-reachability tests.

This PR is intentionally draft while registry/help wiring, capability documentation, and the full required verification suite are completed.

## Testing

- `bash .agents/tests/test-knowledge-social-hacker-news.sh`
- Python compile checks for the new collector modules
- ShellCheck for the focused test

## Runtime Testing

Runtime-verified through the fixture-backed collector, SQLite persistence, raw replay, terminal coverage, and stale-lease paths.

Resolves #29228

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 22m and 230,937 tokens on this as a headless worker.