### PR TITLE
GH#29226: Implement bounded FreshRSS account knowledge collection

### DIFF
--- a/.agents/aidevops/knowledge-plane/05-social-operations.md
+++ b/.agents/aidevops/knowledge-plane/05-social-operations.md
@@ -39,13 +39,12 @@ transaction without rewriting raw gzip artifacts, cursors, coverage, or provider
 rows. Replay preserves both evidence and projection IDs.
 
 Candidate implementation is provider-specific, not one generic social adapter.
-Mastodon #29221, GitHub #29222, Stack Exchange #29223, Miniflux #29224, and
-Readwise Reader #29225 are now live. The remaining ranked children are FreshRSS
-issue #29226, Lemmy issue #29227, then public-only Hacker News #29228. Each
-route owns its identity
-contract, stream allowlist, checkpoint semantics, and negative write-reachability
-tests. Raindrop.io remains optional; Inoreader, Wallabag, Feedly, Instapaper, and
-Pocket are deferred or rejected for the reasons in
+Mastodon #29221, GitHub #29222, Stack Exchange #29223, Miniflux #29224, Readwise
+Reader #29225, and FreshRSS #29226 are now live. The remaining ranked children
+are Lemmy issue #29227, then public-only Hacker News #29228. Each route owns its
+identity contract, stream allowlist, checkpoint semantics, and negative
+write-reachability tests. Raindrop.io remains optional; Inoreader, Wallabag,
+Feedly, Instapaper, and Pocket are deferred or rejected for the reasons in
 `.agents/content/social-provider-candidates.md`.
 
 The maintained planning and gap inventory is
@@ -95,6 +94,15 @@ ascending ID; later runs use `changed_after` with a one-second overlap. Only fiv
 exact GET routes are reachable despite mutation-capable API keys. Operator cleanup,
 pre-retention state, complete archives, and deletion inference remain explicit
 gaps. Details: `.agents/content/social-miniflux.md`.
+
+FreshRSS collection allows only the non-mutating Google Reader ClientLogin POST,
+then binds `user-info` identity to a keyed exact HTTPS installation before every
+GET-only data page. Items, unread, starred, subscriptions, folders, tags, and
+OPML have independent checkpoints; item pages preserve opaque continuations and
+overlap incremental timestamps by one second. Modification tokens and write
+routes are unreachable. Fever remains fallback-only evidence rather than a live
+route because its current authentication requires a POST on a mutation-capable
+endpoint. Details: `.agents/content/social-freshrss.md`.
 
 Readwise Reader collection compensates for `/api/v2/auth/` returning no stable
 account ID by requiring a deployment-owned account identifier and keyed expected

--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -46,6 +46,7 @@ a claim that the route is enabled.
 | GitHub | **Live/Partial** contribution calendar and repositories | **Live/Partial** stars and subscriptions; **No** complete reactions | **Live/Gate/Partial** notifications | **Live/Gate/Partial** followers, following, and organizations | **Live/Gate/Partial** user lists and visible Projects v2 | Ten numeric/node-identity-bound streams preserve REST `Link` and GraphQL `pageInfo` cursors; token family, visibility, migration expiry, deletion, and audit authority remain explicit. |
 | Stack Exchange | **Live/Partial** posts, questions, answers, and comments | **Live/Partial** favourites; **No** complete votes | **Live/Gate/Partial** inbox and notifications | **Live/Partial** associated site accounts; **No** follows | **No** | Eight network-plus-site-identity-bound GET streams obey `has_more`, `backoff`, quota, and 100-item page limits while preserving archive and inaccessible-history gaps. |
 | Miniflux | **Live/Partial** feed entries | **Live/Partial** read, removed, starred, and tagged state | **No** | **Live/Partial/Export** subscriptions | **Live/Partial/Export** categories and tags | Eight keyed-installation account streams use five exact GET routes, ascending entry-ID backfill, one-second `changed_after` overlap, bounded snapshots, and explicit operator-retention gaps. |
+| FreshRSS | **Live/Partial** feed items | **Live/Partial** unread and starred state | **No** | **Live/Partial/Export** subscriptions | **Live/Partial/Export** folders and tags | Seven installation/user-bound Google Reader streams allow only ClientLogin POST plus exact data GETs, preserve opaque continuations and OPML snapshots, and leave POST-authenticated Fever fallback unavailable. |
 | Readwise Reader | **Live/Gate/Partial** saved documents and optional HTML | **Live/Gate/Partial** notes, state, progress, and tags | **No** | **No** | **Live/Gate/Partial** tags and locations | Seven deployment-bound streams preserve opaque cursors, overlap `updatedAfter`, cap invocations below 20 requests/minute, and expose the provider identity/export boundary. |
 
 ## Integrated provider families
@@ -82,7 +83,7 @@ separate provider family.
 | GitHub | **Live/Partial** contributions | **Live/Partial** stars and subscriptions; **No** complete reactions | **Live/Gate/Partial** notifications; **No** discussions | **Live/Gate/Partial** follows, organizations, and repositories | **Live/Gate/Partial** user lists and Projects v2 | #29222 implements numeric/node identity, token-family gates, opaque mixed-API cursors, and no complete reaction or social export claim. |
 | Hacker News | **API/Partial** public submissions and comments | **No** private votes or saved items | **No** | **No** | **No** | Rank 8, #29228. Bounded public history only, keyed by case-sensitive username and item ID; never infer private state. |
 | Miniflux | **Live/Partial** feed items | **Live/Partial** read, removed, starred, and tagged state | **No** | **Live/Partial/Export** subscriptions | **Live/Partial/Export** categories/tags | #29224 implements keyed installation/user identity, exact GET-only routes, incremental overlap, snapshots, and explicit operator-retention gaps. |
-| FreshRSS | **API/Export** feed items | **API** unread and starred state | **No** | **API/Export** subscriptions | **API/Export** folders/tags | Rank 6, #29226. Allow one non-mutating login POST, then GET-only Google Reader collection; reconcile OPML and keep Fever fallback-only. |
+| FreshRSS | **Live/Partial** feed items | **Live/Partial** unread and starred state | **No** | **Live/Partial/Export** subscriptions | **Live/Partial/Export** folders/tags | #29226 implements keyed installation/user identity, one exact ClientLogin POST, exact GET-only Google Reader routes, opaque continuation resume, OPML snapshots, and an explicit unavailable Fever POST boundary. |
 | Readwise Reader | **Live/Gate/Partial** saved documents | **Live/Gate/Partial** tags, state, notes, and progress | **No** | **No** | **Live/Gate/Partial** tags and locations | #29225 implements a deployment-owned account/token binding because official token validation exposes no stable account ID, plus fixed-origin GET-only cursor reads. |
 | Other readers/read-later | **API/Export/Gate/No** | **API/Export/Gate/No** | **No** | **API/Export/Gate/No** | **API/Export/Gate/No** | Raindrop optional; Inoreader and Wallabag deferred; Feedly and Pocket rejected; Instapaper remains unverified. |
 
@@ -193,6 +194,16 @@ separate provider family.
   `.agents/content/social-miniflux.md` records official current identity, entries,
   feed, category, OPML, authentication, version, and operator-retention evidence
   checked on 2026-08-02.
+- **Live FreshRSS:** `.agents/scripts/knowledge_social_freshrss.py`,
+  `.agents/scripts/_knowledge_social_freshrss*.py`, and
+  `.agents/tests/test-knowledge-social-freshrss.sh` prove keyed installation/user
+  identity, seven independent streams, opaque continuation resume, incremental
+  overlap, bounded OPML reconciliation, credential rejection, exact ClientLogin
+  POST plus data-route GET isolation, sanitized terminal coverage, replay, and
+  lease-fenced atomic persistence. `.agents/content/social-freshrss.md` records
+  the current Google Reader identity, subscriptions, tags, item/state, OPML,
+  authentication, retention, and incompatible Fever POST boundary checked on
+  2026-08-02.
 - **Live/Gated Readwise Reader:**
   `.agents/scripts/knowledge_social_readwise_reader.py`,
   `.agents/scripts/_knowledge_social_readwise_reader*.py`, and

--- a/.agents/content/social-freshrss.md
+++ b/.agents/content/social-freshrss.md
@@ -1,0 +1,68 @@
+# FreshRSS Account Knowledge Evidence
+
+Checked 2026-08-02 against the official FreshRSS Google Reader, Fever, OPML,
+mobile-access documentation, and current upstream API source. The worker runtime
+provides Python 3.12.3 standard-library HTTP, JSON, SQLite, and XML exports; no
+third-party FreshRSS client is installed or required.
+
+## Implemented evidence
+
+- Profiles bind an exact credential-free HTTPS FreshRSS root to a keyed local
+  installation fingerprint. `POST /api/greader.php/accounts/ClientLogin` sends
+  the dedicated API username/password as form data, retains the returned
+  `Auth` value only inside the guarded child, and is the sole reachable POST.
+- `GET /api/greader.php/reader/api/0/user-info` verifies that `userId`,
+  `userName`, and `userProfileId` all match the selected case-sensitive
+  username. The installation fingerprint plus current API identity forms the
+  durable account binding and is rechecked before every data page.
+- Subscription and folder/tag snapshots use exact `subscription/list` and
+  `tag/list` GET routes. Built-in state streams are not mislabeled as user tags.
+  Partial snapshots never imply remote deletion.
+- Items use the reading-list stream with bounded `n`, oldest-first `r=o`, opaque
+  `continuation`, and a one-second `ot` overlap after initial exhaustion. Unread
+  uses the documented read-state exclusion; starred uses the exact starred-state
+  stream. State is derived from item categories without inventing an explicit
+  unread category.
+- Authenticated OPML uses the exact `subscription/export` GET route. Parsing is
+  byte/item bounded, rejects XML declarations that can define entities, and
+  preserves only safe feed metadata and folder ancestry. FreshRSS cURL extension
+  attributes and credential-shaped URL queries cannot enter evidence.
+- Seven streams (`items`, `unread`, `starred`, `subscriptions`, `folders`,
+  `tags`, and `opml`) own independent continuation/snapshot checkpoints. Login,
+  identity, and data reads spend explicit request units; generic social leases
+  fence each atomic raw-evidence, normalized-row, coverage, receipt, and
+  checkpoint commit.
+
+## Fever fallback boundary
+
+FreshRSS documents Fever as the less capable fallback, with at most 50 items per
+`since_id`/`max_id` request. Current Fever authentication requires `api_key` in
+the body of every POST, and the same endpoint accepts mutation fields. That
+conflicts with this collector's verified invariant that only ClientLogin may
+POST and every data route must GET. Fever therefore remains fallback-only
+evidence, not a live adapter route; it must not be silently selected when a
+Google Reader read fails. A future implementation needs a provider-supported
+GET/session authentication boundary or a separately reviewed contract.
+
+## Explicit boundaries
+
+- The dedicated API password is mutation-capable. Modification tokens,
+  subscription edits, tag edits, mark-all-read actions, imports, and Fever write
+  fields are unreachable by exact route, query, body, and HTTP-method allowlists.
+- Operator retention and the current database state bound available history.
+  API completion proves only the requested window, not pre-retention state or a
+  complete account archive.
+- OPML is an independent subscription snapshot, not proof of item, state, or
+  deletion completeness. Hidden feeds can differ between API and OPML views.
+- Redirects, cross-installation targets, malformed continuations, oversized
+  pages, credential-shaped data, and identity mismatch fail before persistence.
+  Terminal HTTP evidence is sanitized and never advances the prior checkpoint.
+
+## Official references
+
+- <https://freshrss.github.io/FreshRSS/en/developers/06_GoogleReader_API.html>
+- <https://freshrss.github.io/FreshRSS/en/developers/06_Fever_API.html>
+- <https://freshrss.github.io/FreshRSS/en/developers/OPML.html>
+- <https://freshrss.github.io/FreshRSS/en/users/06_Mobile_access.html>
+- <https://github.com/FreshRSS/FreshRSS/blob/edge/p/api/greader.php>
+- <https://github.com/FreshRSS/FreshRSS/blob/edge/p/api/fever.php>

--- a/.agents/scripts/_knowledge_social_freshrss.py
+++ b/.agents/scripts/_knowledge_social_freshrss.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""FreshRSS stream policy and independent continuation checkpoints."""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from _knowledge_social_freshrss_identity import (
+    FreshRSSAdapterError,
+    FreshRSSProviderUnavailableError,
+    account_id,
+    user_id,
+)
+from knowledge_social_import import canonical_json, reject_credentials
+
+PROVIDER = "freshrss"
+CURSOR_PREFIX = "freshrss-greader-v1:"
+RETENTION_LIMIT = "operator_retention_and_current_database_state"
+MAX_PAGE_ITEMS = 1000
+
+ADAPTER_ERROR = FreshRSSAdapterError
+PROVIDER_UNAVAILABLE_ERROR = FreshRSSProviderUnavailableError
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    resource_kind: str
+    activity_mode: str
+    pagination: str
+    incremental: bool
+    retention_limit: str | None = RETENTION_LIMIT
+    coverage_status: str | None = "partial"
+    unavailable_reason: str | None = "operator_retention_and_api_window"
+    cost_units: int = 3
+
+
+STREAMS = {
+    "items": StreamSpec("entry", "content_observed", "opaque_continuation", True),
+    "unread": StreamSpec("entry", "selected_account", "opaque_continuation", False),
+    "starred": StreamSpec("entry", "selected_account", "opaque_continuation", False),
+    "subscriptions": StreamSpec("feed", "subscription", "snapshot", False),
+    "folders": StreamSpec("folder", "subscription", "snapshot", False),
+    "tags": StreamSpec("tag", "selected_account", "snapshot", False),
+    "opml": StreamSpec("feed", "subscription", "snapshot", False),
+}
+ITEM_STREAMS = frozenset({"items", "unread", "starred"})
+
+
+@dataclass(frozen=True)
+class PageRequest:
+    stream: str
+    account_id: str
+    installation_id: str
+    user_id: str
+    continuation: str | None
+    newer_than: int | None
+    limit: int
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "page",
+            "stream": self.stream,
+            "account_id": self.account_id,
+            "installation_id": self.installation_id,
+            "user_id": self.user_id,
+            "continuation": self.continuation,
+            "newer_than": self.newer_than,
+            "limit": self.limit,
+        }
+
+    def evidence_key(self) -> str:
+        return canonical_json(self.payload())
+
+
+PAGE_REQUEST_KEYS = frozenset(PageRequest.__dataclass_fields__) | {"action"}
+
+
+def _positive(value: Any, field: str, *, allow_zero: bool = False) -> int:
+    minimum = 0 if allow_zero else 1
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise FreshRSSAdapterError(f"FreshRSS {field} is invalid")
+    return value
+
+
+def _text(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value or len(value.encode()) > 4096:
+        raise FreshRSSAdapterError(f"FreshRSS {field} is invalid")
+    return value
+
+
+def _continuation(value: Any) -> str | None:
+    if value is None:
+        return None
+    if (
+        not isinstance(value, str)
+        or not value
+        or "\x00" in value
+        or len(value.encode()) > 16 * 1024
+    ):
+        raise FreshRSSAdapterError("FreshRSS continuation is invalid")
+    return value
+
+
+def _encode_cursor(continuation: str, newer_than: int | None) -> str:
+    encoded = base64.urlsafe_b64encode(
+        canonical_json({"continuation": continuation, "newer_than": newer_than}).encode()
+    ).decode().rstrip("=")
+    return f"{CURSOR_PREFIX}{encoded}"
+
+
+def _decode_cursor(cursor: str) -> tuple[str, int | None]:
+    if not cursor.startswith(CURSOR_PREFIX):
+        raise FreshRSSAdapterError("stored FreshRSS cursor has an unsupported version")
+    try:
+        raw = cursor.removeprefix(CURSOR_PREFIX)
+        payload = json.loads(base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4)))
+    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+        raise FreshRSSAdapterError("stored FreshRSS cursor is invalid") from error
+    if not isinstance(payload, dict) or set(payload) != {"continuation", "newer_than"}:
+        raise FreshRSSAdapterError("stored FreshRSS cursor has an invalid shape")
+    reject_credentials(payload)
+    newer_than = payload.get("newer_than")
+    if newer_than is not None:
+        newer_than = _positive(newer_than, "newer-than cursor", allow_zero=True)
+    continuation = _continuation(payload.get("continuation"))
+    if continuation is None:
+        raise FreshRSSAdapterError("stored FreshRSS cursor is invalid")
+    return continuation, newer_than
+
+
+def page_request(
+    stream: str, account: dict[str, Any], state: CursorState, limit: int
+) -> PageRequest:
+    if stream not in STREAMS:
+        raise FreshRSSAdapterError("FreshRSS stream is unsupported")
+    continuation, newer_than = _decode_cursor(state.cursor) if state.cursor else (None, None)
+    if stream == "items" and state.backfill_complete and not state.cursor:
+        if state.watermark is None or not state.watermark.isdigit():
+            raise FreshRSSAdapterError("stored FreshRSS watermark is invalid")
+        newer_than = max(0, int(state.watermark) - 1)
+    if stream not in ITEM_STREAMS:
+        continuation, newer_than = None, None
+    return PageRequest(
+        stream,
+        _text(account.get("id"), "selected account ID"),
+        _text(account.get("installation_id"), "installation ID"),
+        user_id(account.get("user_id")),
+        continuation,
+        newer_than,
+        limit,
+    )
+
+
+def parse_page_request(payload: dict[str, Any]) -> PageRequest:
+    if set(payload) != PAGE_REQUEST_KEYS or payload.get("action") != "page":
+        raise FreshRSSAdapterError("FreshRSS read request has an invalid action shape")
+    stream = payload.get("stream")
+    if not isinstance(stream, str) or stream not in STREAMS:
+        raise FreshRSSAdapterError("FreshRSS stream is unsupported")
+    limit = _positive(payload.get("limit"), "page size")
+    if limit > MAX_PAGE_ITEMS:
+        raise FreshRSSAdapterError("FreshRSS page size is invalid")
+    newer_than = payload.get("newer_than")
+    if newer_than is not None:
+        newer_than = _positive(newer_than, "newer-than cursor", allow_zero=True)
+    continuation = _continuation(payload.get("continuation"))
+    if stream not in ITEM_STREAMS and (continuation is not None or newer_than is not None):
+        raise FreshRSSAdapterError("FreshRSS snapshot request has an invalid cursor")
+    local = user_id(payload.get("user_id"))
+    instance = _text(payload.get("installation_id"), "installation ID")
+    selected = _text(payload.get("account_id"), "selected account ID")
+    if selected != account_id(instance, local):
+        raise FreshRSSAdapterError("FreshRSS account identity binding is invalid")
+    return PageRequest(stream, selected, instance, local, continuation, newer_than, limit)
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise FreshRSSAdapterError("FreshRSS response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise FreshRSSAdapterError("FreshRSS page data must be an array")
+    return data
+
+
+def page_checkpoint(
+    payload: dict[str, Any], state: CursorState, request: PageRequest
+) -> tuple[PageCheckpoint, bool]:
+    meta = payload.get("meta")
+    if not isinstance(meta, dict) or meta.get("stream") != request.stream:
+        raise FreshRSSAdapterError("FreshRSS page provenance is invalid")
+    reject_credentials(meta)
+    items = page_data(payload)
+    expected_snapshot = request.stream not in ITEM_STREAMS
+    if len(items) > request.limit or meta.get("snapshot") is not expected_snapshot:
+        raise FreshRSSAdapterError("FreshRSS page metadata is invalid")
+    has_more = meta.get("has_more")
+    if not isinstance(has_more, bool) or expected_snapshot and has_more:
+        raise FreshRSSAdapterError("FreshRSS has_more is invalid")
+    next_continuation = _continuation(meta.get("next_continuation"))
+    if has_more and (
+        next_continuation is None or next_continuation == request.continuation
+    ):
+        raise FreshRSSAdapterError("FreshRSS continuation did not advance")
+    if not has_more and next_continuation is not None:
+        raise FreshRSSAdapterError("FreshRSS terminal page retained a continuation")
+    cursor = (
+        _encode_cursor(next_continuation, request.newer_than)
+        if next_continuation is not None
+        else None
+    )
+    watermark = state.watermark
+    observed = meta.get("watermark")
+    if observed is not None:
+        observed = _positive(observed, "watermark", allow_zero=True)
+        previous = int(watermark) if watermark and watermark.isdigit() else 0
+        watermark = str(max(previous, observed))
+    return PageCheckpoint(cursor, watermark), not has_more

--- a/.agents/scripts/_knowledge_social_freshrss_contract.py
+++ b/.agents/scripts/_knowledge_social_freshrss_contract.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validation primitives for bounded FreshRSS API responses."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import parse_qsl, urlsplit
+
+from _knowledge_social_freshrss_identity import account_id, user_id
+
+MAX_TEXT_BYTES = 256 * 1024
+SENSITIVE_QUERY_MARKERS = (
+    "api_key",
+    "auth",
+    "credential",
+    "key",
+    "passwd",
+    "password",
+    "secret",
+    "sid",
+    "token",
+)
+
+
+class FreshRSSReadProviderError(RuntimeError):
+    """Raised for a privacy-safe local FreshRSS provider failure."""
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    status: int
+    payload: Any
+    retry_after: int | None = None
+
+
+def observed_at() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def decode_json(payload: bytes, limit: int) -> Any:
+    if len(payload) > limit:
+        raise FreshRSSReadProviderError("FreshRSS JSON payload exceeds the safety limit")
+    try:
+        return json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise FreshRSSReadProviderError("FreshRSS JSON payload is invalid") from error
+
+
+def request_object(payload: bytes, limit: int) -> dict[str, Any]:
+    request = decode_json(payload, limit)
+    if not isinstance(request, dict):
+        raise FreshRSSReadProviderError("FreshRSS read request root must be an object")
+    return request
+
+
+def object_value(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise FreshRSSReadProviderError(f"FreshRSS {field} must be an object")
+    return value
+
+
+def object_list(value: Any, field: str, *, limit: int) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise FreshRSSReadProviderError(f"FreshRSS {field} must be an array of objects")
+    if len(value) > limit:
+        raise FreshRSSReadProviderError(f"FreshRSS {field} exceeds the item safety limit")
+    return value
+
+
+def optional_text(value: Any, field: str, *, limit: int = MAX_TEXT_BYTES) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value or len(value.encode()) > limit:
+        raise FreshRSSReadProviderError(f"FreshRSS {field} must be text")
+    return value
+
+
+def required_text(value: Any, field: str, *, limit: int = 4096) -> str:
+    text = optional_text(value, field, limit=limit)
+    if not text:
+        raise FreshRSSReadProviderError(f"FreshRSS {field} is required")
+    return text
+
+
+def safe_url(value: Any, field: str) -> str | None:
+    """Reject credentials and credential-shaped URL query parameters."""
+    text = optional_text(value, field, limit=64 * 1024)
+    if text is None:
+        return None
+    try:
+        parsed = urlsplit(text)
+        port = parsed.port
+    except ValueError as error:
+        raise FreshRSSReadProviderError(f"FreshRSS {field} is invalid") from error
+    if (
+        parsed.scheme.lower() not in {"http", "https"}
+        or parsed.hostname is None
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None and not 1 <= port <= 65535
+    ):
+        raise FreshRSSReadProviderError(f"FreshRSS {field} is invalid")
+    for key, _value in parse_qsl(parsed.query, keep_blank_values=True):
+        normalized = key.casefold().replace("-", "_")
+        if any(marker in normalized for marker in SENSITIVE_QUERY_MARKERS):
+            raise FreshRSSReadProviderError(
+                f"FreshRSS {field} contains credential-shaped data"
+            )
+    return text
+
+
+def login_token(payload: bytes, limit: int) -> str:
+    """Parse ClientLogin without exposing SID/Auth material to the parent."""
+    if len(payload) > limit:
+        raise FreshRSSReadProviderError("FreshRSS login response exceeds the safety limit")
+    try:
+        text = payload.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise FreshRSSReadProviderError("FreshRSS login response is invalid") from error
+    values: dict[str, str] = {}
+    for line in text.splitlines():
+        if not line:
+            continue
+        key, separator, value = line.partition("=")
+        if not separator or key in values or key not in {"SID", "LSID", "Auth"}:
+            raise FreshRSSReadProviderError("FreshRSS login response is invalid")
+        values[key] = value
+    token = values.get("Auth")
+    if (
+        not token
+        or "\x00" in token
+        or len(token.encode()) > 16 * 1024
+        or any(character.isspace() for character in token)
+    ):
+        raise FreshRSSReadProviderError("FreshRSS login response is invalid")
+    return token
+
+
+def identity_value(payload: Any, expected_user_id: str, instance: str) -> dict[str, Any]:
+    """Bind current GReader identity to the selected installation and username."""
+    root = object_value(payload, "account response")
+    expected = user_id(expected_user_id)
+    identities = tuple(
+        user_id(root.get(field)) for field in ("userId", "userName", "userProfileId")
+    )
+    if any(identity != expected for identity in identities):
+        raise FreshRSSReadProviderError(
+            "selected FreshRSS account does not match the configured connection"
+        )
+    return {
+        "id": account_id(instance, expected),
+        "installation_id": instance,
+        "user_id": expected,
+        "username": identities[1],
+    }
+
+
+def terminal_payload(result: ApiResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": result.status, "observed_at": observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload

--- a/.agents/scripts/_knowledge_social_freshrss_http.py
+++ b/.agents/scripts/_knowledge_social_freshrss_http.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Exact-origin bounded FreshRSS login and GET-only data transport."""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from _knowledge_social_freshrss_contract import (
+    ApiResult,
+    FreshRSSReadProviderError,
+    decode_json,
+    login_token,
+)
+from _knowledge_social_freshrss_identity import canonical_base_url
+from _knowledge_social_freshrss_routes import allowlisted_path, query_keys_for_path
+
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+MAX_LOGIN_BYTES = 64 * 1024
+HTTP_TIMEOUT_SECONDS = 60
+API_PREFIX = "/api/greader.php"
+LOGIN_PATH = "/accounts/ClientLogin"
+
+
+class Headers(Protocol):
+    def get(self, key: str, default: str | None = None) -> str | None: ...
+
+
+class Response(Protocol):
+    status: int
+    headers: Headers
+
+    def __enter__(self) -> Response: ...
+    def __exit__(self, *args: Any) -> None: ...
+    def read(self, size: int = -1) -> bytes: ...
+
+
+class Opener(Protocol):
+    def open(self, request: Request, timeout: int) -> Response: ...
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    base_url: str
+    username: str
+    api_password: str
+    origin_key: str
+    installation_id: str
+
+
+class _RejectRedirect(HTTPRedirectHandler):
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def _http_exports() -> Opener:
+    exports = (Request, build_opener, urlencode, HTTPRedirectHandler)
+    if not all(callable(item) for item in exports):
+        raise FreshRSSReadProviderError("Python urllib HTTP exports are unavailable")
+    return build_opener(_RejectRedirect())
+
+
+def _retry_epoch(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    return int(time.time() + math.ceil(seconds))
+
+
+def _api_root(config: ProfileConfig) -> str:
+    return f"{canonical_base_url(config.base_url)}{API_PREFIX}"
+
+
+def _target_url(config: ProfileConfig, path: str, params: dict[str, str]) -> str:
+    if not allowlisted_path(path) or set(params) - query_keys_for_path(path):
+        raise FreshRSSReadProviderError("FreshRSS API route is not allowlisted")
+    if any(
+        not isinstance(value, str)
+        or not value
+        or "\x00" in value
+        or len(value.encode()) > 16 * 1024
+        for value in params.values()
+    ):
+        raise FreshRSSReadProviderError("FreshRSS API query is invalid")
+    for key in ("n", "ot"):
+        value = params.get(key)
+        if value is not None and not value.isdigit():
+            raise FreshRSSReadProviderError("FreshRSS paging query is invalid")
+    query = urlencode(params)
+    return f"{_api_root(config)}{path}" + (f"?{query}" if query else "")
+
+
+def _status(response: Response) -> int:
+    status = getattr(response, "status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise FreshRSSReadProviderError("FreshRSS HTTP status is invalid")
+    return status
+
+
+def login(config: ProfileConfig, opener: Opener) -> ApiResult:
+    """Execute the sole allowlisted POST: non-mutating ClientLogin."""
+    form = urlencode({"Email": config.username, "Passwd": config.api_password}).encode()
+    request = Request(
+        f"{_api_root(config)}{LOGIN_PATH}",
+        data=form,
+        headers={
+            "Accept": "text/plain",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "User-Agent": "aidevops-freshrss-knowledge/1",
+        },
+        method="POST",
+    )
+    try:
+        with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            payload = response.read(MAX_LOGIN_BYTES + 1)
+            if not isinstance(payload, bytes) or len(payload) > MAX_LOGIN_BYTES:
+                raise FreshRSSReadProviderError(
+                    "FreshRSS login response exceeds the safety limit"
+                )
+            return ApiResult(_status(response), login_token(payload, MAX_LOGIN_BYTES))
+    except HTTPError as error:
+        retry = error.headers.get("Retry-After") if error.headers is not None else None
+        return ApiResult(error.code, None, _retry_epoch(retry))
+    except (TimeoutError, URLError, OSError) as error:
+        raise FreshRSSReadProviderError("FreshRSS read provider request failed") from error
+
+
+def api(
+    config: ProfileConfig,
+    opener: Opener,
+    auth: str,
+    path: str,
+    params: dict[str, str],
+) -> ApiResult:
+    """Execute one exact-origin, redirect-free, GET-only data request."""
+    if not isinstance(auth, str) or not auth or "\x00" in auth:
+        raise FreshRSSReadProviderError("FreshRSS authorization is invalid")
+    request = Request(
+        _target_url(config, path, params),
+        headers={
+            "Accept": (
+                "application/xml"
+                if path == "/reader/api/0/subscription/export"
+                else "application/json"
+            ),
+            "Authorization": f"GoogleLogin auth={auth}",
+            "User-Agent": "aidevops-freshrss-knowledge/1",
+        },
+        method="GET",
+    )
+    try:
+        with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            payload = response.read(MAX_RESPONSE_BYTES + 1)
+            if not isinstance(payload, bytes) or len(payload) > MAX_RESPONSE_BYTES:
+                raise FreshRSSReadProviderError(
+                    "FreshRSS read response exceeds the safety limit"
+                )
+            if path == "/reader/api/0/subscription/export":
+                try:
+                    decoded: Any = payload.decode("utf-8")
+                except UnicodeDecodeError as error:
+                    raise FreshRSSReadProviderError(
+                        "FreshRSS OPML response is invalid"
+                    ) from error
+            else:
+                decoded = decode_json(payload, MAX_RESPONSE_BYTES)
+            return ApiResult(_status(response), decoded)
+    except HTTPError as error:
+        retry = error.headers.get("Retry-After") if error.headers is not None else None
+        return ApiResult(error.code, {}, _retry_epoch(retry))
+    except (TimeoutError, URLError, OSError) as error:
+        raise FreshRSSReadProviderError("FreshRSS read provider request failed") from error

--- a/.agents/scripts/_knowledge_social_freshrss_identity.py
+++ b/.agents/scripts/_knowledge_social_freshrss_identity.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Durable FreshRSS installation and account identity validation."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from typing import Any
+from urllib.parse import SplitResult, urlsplit
+
+from knowledge_social_store import SocialStoreError
+
+
+class FreshRSSAdapterError(SocialStoreError):
+    """Raised when guarded FreshRSS collection cannot continue safely."""
+
+
+class FreshRSSProviderUnavailableError(FreshRSSAdapterError):
+    """Raised when the bounded FreshRSS HTTP child cannot complete a read."""
+
+
+def _parsed_url(value: str) -> tuple[SplitResult, int | None]:
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError as error:
+        raise FreshRSSAdapterError("FreshRSS profile base URL is invalid") from error
+    return parsed, port
+
+
+def canonical_base_url(value: Any) -> str:
+    """Return one credential-free exact HTTPS FreshRSS installation root."""
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise FreshRSSAdapterError("FreshRSS profile base URL is invalid")
+    parsed, port = _parsed_url(value)
+    checks = (
+        parsed.scheme.lower() == "https",
+        parsed.hostname is not None,
+        parsed.username is None,
+        parsed.password is None,
+        not parsed.query,
+        not parsed.fragment,
+    )
+    if not all(checks):
+        raise FreshRSSAdapterError("FreshRSS profile base URL must be HTTPS")
+    path = parsed.path.rstrip("/")
+    if any(marker in path for marker in ("\\", "%", "//")) or any(
+        part in (".", "..") for part in path.split("/") if part
+    ):
+        raise FreshRSSAdapterError("FreshRSS profile base URL is invalid")
+    host = parsed.hostname.lower()
+    rendered = f"[{host}]" if ":" in host else host
+    if port is not None and port != 443:
+        rendered = f"{rendered}:{port}"
+    return f"https://{rendered}{path}"
+
+
+def installation_id(base_url: Any, origin_key: Any) -> str:
+    """Key the installation identity without persisting its private URL."""
+    canonical = canonical_base_url(base_url)
+    if not isinstance(origin_key, str) or len(origin_key.encode()) < 32:
+        raise FreshRSSAdapterError(
+            "FreshRSS profile origin key must be at least 32 bytes"
+        )
+    digest = hmac.new(origin_key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
+    return f"freshrss_{digest[:24]}"
+
+
+def user_id(value: Any) -> str:
+    """Validate one case-sensitive native FreshRSS username."""
+    if (
+        not isinstance(value, str)
+        or not value
+        or value != value.strip()
+        or "\x00" in value
+        or len(value.encode()) > 256
+        or any(character.isspace() for character in value)
+    ):
+        raise FreshRSSAdapterError("FreshRSS user ID is invalid")
+    return value
+
+
+def account_id(instance: Any, local_user_id: Any) -> str:
+    """Namespace a private native username by the exact installation."""
+    if not isinstance(instance, str) or not instance.startswith("freshrss_"):
+        raise FreshRSSAdapterError("FreshRSS installation identity is invalid")
+    local = user_id(local_user_id)
+    digest = hashlib.sha256(f"{instance}\0{local}".encode()).hexdigest()[:24]
+    return f"{instance}_user_{digest}"
+
+
+def resource_id(instance: Any, kind: str, value: Any) -> str:
+    """Return one installation-qualified opaque resource ID."""
+    if not isinstance(instance, str) or not instance.startswith("freshrss_"):
+        raise FreshRSSAdapterError("FreshRSS installation identity is invalid")
+    if not kind.replace("_", "").isalpha() or len(kind) > 32:
+        raise FreshRSSAdapterError("FreshRSS resource kind is invalid")
+    if isinstance(value, bool) or not isinstance(value, (str, int)):
+        raise FreshRSSAdapterError("FreshRSS resource identity is invalid")
+    opaque = str(value)
+    if not opaque or "\x00" in opaque or len(opaque.encode()) > 4096:
+        raise FreshRSSAdapterError("FreshRSS resource identity is invalid")
+    digest = hashlib.sha256(f"{instance}\0{opaque}".encode()).hexdigest()[:32]
+    return f"frss_{kind}_{digest}"

--- a/.agents/scripts/_knowledge_social_freshrss_normalize.py
+++ b/.agents/scripts/_knowledge_social_freshrss_normalize.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize allowlisted FreshRSS records into neutral evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_freshrss import (
+    PROVIDER,
+    RETENTION_LIMIT,
+    FreshRSSAdapterError,
+    page_data,
+)
+from knowledge_social_import import reject_credentials
+
+PROVENANCE = "freshrss_google_reader_api"
+GAPS = (
+    ("retained_history", "operator_retention_can_remove_history"),
+    ("deleted_subscriptions", "partial_snapshots_do_not_prove_deletion"),
+    ("complete_account_archive", "opml_covers_subscriptions_not_complete_account_state"),
+    ("fever_live_fallback", "fever_reads_require_a_second_post_route_disallowed_by_policy"),
+)
+OBJECT_TYPES = frozenset({"entry", "feed", "folder", "tag"})
+ACTIVITY_TYPES = {
+    "items": "content_observed",
+    "unread": "unread",
+    "starred": "starred",
+    "subscriptions": "subscribed",
+    "folders": "folder_membership",
+    "tags": "tagged",
+    "opml": "subscription_exported",
+}
+
+
+@dataclass(frozen=True)
+class PageContext:
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def _required_text(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise FreshRSSAdapterError(f"FreshRSS record requires {key}")
+    return value
+
+
+def _optional_text(record: dict[str, Any], key: str) -> str | None:
+    value = record.get(key)
+    if value is not None and (not isinstance(value, str) or "\x00" in value):
+        raise FreshRSSAdapterError(f"FreshRSS record {key} must be text")
+    return value
+
+
+def _observed_at(payload: dict[str, Any]) -> str:
+    value = payload.get("observed_at")
+    if not isinstance(value, str) or not value:
+        raise FreshRSSAdapterError("FreshRSS page observed_at must be text")
+    return value
+
+
+def _coverage(observed_at: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "stream": stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": RETENTION_LIMIT,
+            "unavailable_reason": reason,
+            "status": "unavailable",
+            "observed_at": observed_at,
+        }
+        for stream, reason in GAPS
+    ]
+
+
+def _object_row(
+    item: dict[str, Any], context: PageContext, observed_at: str
+) -> dict[str, Any]:
+    kind = item.get("kind")
+    if not isinstance(kind, str) or kind not in OBJECT_TYPES:
+        raise FreshRSSAdapterError("FreshRSS page contains an unsupported item kind")
+    remote_id = _required_text(item, "remote_id")
+    text = "\n\n".join(
+        value
+        for key in ("title", "body", "author", "description", "category")
+        if (value := _optional_text(item, key))
+    ) or None
+    provider_json = {"source": PROVENANCE, "stream": context.stream, "record": item}
+    reject_credentials(provider_json)
+    return {
+        "object_type": kind,
+        "remote_id": remote_id,
+        "account_remote_id": context.account.get("id"),
+        "text": text,
+        "created_at": _optional_text(item, "created_at")
+        or _optional_text(item, "published_at"),
+        "observed_at": observed_at,
+        "evidence_class": "observed",
+        "provider_json": provider_json,
+    }
+
+
+def _activity_row(
+    item: dict[str, Any], context: PageContext, observed_at: str
+) -> dict[str, Any]:
+    selected = _required_text(context.account, "id")
+    remote = _required_text(item, "remote_id")
+    activity_type = ACTIVITY_TYPES[context.stream]
+    return {
+        "activity_type": activity_type,
+        "remote_id": f"{selected}_{activity_type}_{remote}",
+        "actor_remote_id": selected,
+        "object_remote_id": remote,
+        "occurred_at": _optional_text(item, "created_at")
+        or _optional_text(item, "published_at")
+        or observed_at,
+        "observed_at": observed_at,
+        "state": "active",
+        "provider_json": {"source": PROVENANCE, "stream": context.stream},
+    }
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    reject_credentials(payload)
+    observed_at = _observed_at(payload)
+    items = page_data(payload)
+    policy = dict(context.policy)
+    policy.update(
+        {
+            "freshrss_identity": "installation_fingerprint_plus_current_greader_user",
+            "freshrss_pagination": "opaque_continuation_with_one_second_item_overlap",
+            "freshrss_transport": "exact_clientlogin_post_then_allowlisted_get_only",
+            "freshrss_deletion": "never_inferred_from_partial_snapshots",
+            "freshrss_fever": "fallback_not_live_because_authenticated_reads_require_post",
+        }
+    )
+    archive = {
+        "provider": PROVIDER,
+        "connection_id": context.connection_id,
+        "remote_account_id": context.account.get("id"),
+        "exported_at": observed_at,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": policy,
+        "accounts": [
+            {
+                "remote_id": context.account.get("id"),
+                "handle": context.account.get("username"),
+                "display_name": context.account.get("username"),
+                "observed_at": observed_at,
+                "provider_json": {
+                    "source": PROVENANCE,
+                    "installation_id": context.account.get("installation_id"),
+                    "user_id": context.account.get("user_id"),
+                },
+            }
+        ],
+        "objects": [_object_row(item, context, observed_at) for item in items],
+        "activities": [_activity_row(item, context, observed_at) for item in items],
+        "media": [],
+        "coverage": _coverage(observed_at),
+    }
+    reject_credentials(archive)
+    return archive

--- a/.agents/scripts/_knowledge_social_freshrss_provider.py
+++ b/.agents/scripts/_knowledge_social_freshrss_provider.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded FreshRSS GReader account subprocess with one login POST."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from functools import partial
+from typing import Any
+
+from _knowledge_social_freshrss import (
+    FreshRSSAdapterError,
+    PageRequest,
+    parse_page_request,
+)
+from _knowledge_social_freshrss_contract import (
+    ApiResult,
+    FreshRSSReadProviderError,
+    identity_value,
+    object_value,
+    observed_at,
+    request_object,
+    terminal_payload,
+)
+from _knowledge_social_freshrss_http import (
+    MAX_RESPONSE_BYTES,
+    Opener,
+    ProfileConfig,
+    _http_exports,
+    api,
+    login,
+)
+from _knowledge_social_freshrss_identity import (
+    account_id,
+    canonical_base_url,
+    installation_id,
+    user_id,
+)
+from _knowledge_social_freshrss_routes import IDENTITY_PATH, page
+
+MAX_REQUEST_BYTES = 32 * 1024
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+
+
+def _profile_prefix(profile: str) -> str:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise FreshRSSReadProviderError("FreshRSS profile name is invalid")
+    return f"FRESHRSS_{profile.upper()}"
+
+
+def _profile_value(prefix: str, suffix: str, field: str, limit: int) -> str:
+    value = os.environ.get(f"{prefix}_{suffix}", "")
+    if not value or "\x00" in value or len(value.encode()) > limit:
+        raise FreshRSSReadProviderError(f"FreshRSS profile {field} is missing")
+    return value
+
+
+def _profile(profile: str) -> ProfileConfig:
+    prefix = _profile_prefix(profile)
+    base = canonical_base_url(_profile_value(prefix, "BASE_URL", "base URL", 4096))
+    username = user_id(_profile_value(prefix, "USERNAME", "username", 4096))
+    password = _profile_value(prefix, "API_PASSWORD", "API password", 16 * 1024)
+    origin_key = _profile_value(prefix, "ORIGIN_KEY", "origin key", 16 * 1024)
+    return ProfileConfig(
+        base,
+        username,
+        password,
+        origin_key,
+        installation_id(base, origin_key),
+    )
+
+
+def _authorize(config: ProfileConfig, opener: Opener) -> ApiResult:
+    result = login(config, opener)
+    if result.status != 200:
+        return result
+    if not isinstance(result.payload, str):
+        raise FreshRSSReadProviderError("FreshRSS login response is invalid")
+    return result
+
+
+def _identity(
+    config: ProfileConfig,
+    opener: Opener,
+    expected_id: str,
+    authorization: ApiResult | None = None,
+) -> dict[str, Any]:
+    authorized = authorization or _authorize(config, opener)
+    if authorized.status != 200:
+        return terminal_payload(authorized)
+    result = api(config, opener, authorized.payload, IDENTITY_PATH, {})
+    if result.status != 200:
+        return terminal_payload(result)
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": identity_value(result.payload, expected_id, config.installation_id),
+    }
+
+
+def _verify_page_account(request: PageRequest, identity: dict[str, Any]) -> None:
+    if (
+        identity.get("installation_id") != request.installation_id
+        or identity.get("user_id") != request.user_id
+        or request.account_id
+        != account_id(identity.get("installation_id"), identity.get("user_id"))
+    ):
+        raise FreshRSSReadProviderError(
+            "selected FreshRSS account does not match the configured connection"
+        )
+
+
+def _dispatch(
+    request: dict[str, Any], config: ProfileConfig, opener: Opener
+) -> dict[str, Any]:
+    action = request.get("action")
+    if action == "identity":
+        if set(request) != {"action", "account_id"}:
+            raise FreshRSSReadProviderError("FreshRSS identity request shape is invalid")
+        return _identity(config, opener, user_id(request.get("account_id")))
+    if action != "page":
+        raise FreshRSSReadProviderError("FreshRSS read action is unsupported")
+    page_request = parse_page_request(request)
+    if page_request.installation_id != config.installation_id:
+        raise FreshRSSReadProviderError(
+            "selected FreshRSS installation does not match the connection"
+        )
+    authorized = _authorize(config, opener)
+    if authorized.status != 200:
+        return terminal_payload(authorized)
+    verified = _identity(config, opener, page_request.user_id, authorized)
+    if verified.get("status") != 200:
+        return verified
+    identity = object_value(verified.get("data"), "account verification")
+    _verify_page_account(page_request, identity)
+    result = page(partial(api, config, opener, authorized.payload), page_request)
+    return terminal_payload(result) if isinstance(result, ApiResult) else result
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode()) > MAX_RESPONSE_BYTES:
+        raise FreshRSSReadProviderError("FreshRSS read response exceeds the safety limit")
+    print(encoded)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        request = request_object(
+            sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1), MAX_REQUEST_BYTES
+        )
+        _emit(_dispatch(request, _profile(args.profile), _http_exports()))
+        return 0
+    except (FreshRSSReadProviderError, FreshRSSAdapterError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - intentionally redact provider internals
+        print("ERROR: FreshRSS read provider request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_freshrss_reader.py
+++ b/.agents/scripts/_knowledge_social_freshrss_reader.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and deterministic fixture readers for FreshRSS."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_freshrss import (
+    FreshRSSAdapterError,
+    FreshRSSProviderUnavailableError,
+    PageRequest,
+)
+from _knowledge_social_freshrss_identity import account_id, user_id
+from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
+from knowledge_social_import import reject_credentials
+
+READ_TIMEOUT_SECONDS = 180
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+SAFE_PROVIDER_FAILURES = (
+    "Python urllib HTTP exports are unavailable",
+    "FreshRSS profile name is invalid",
+    "FreshRSS profile base URL is missing",
+    "FreshRSS profile username is missing",
+    "FreshRSS profile API password is missing",
+    "FreshRSS profile origin key is missing",
+    "FreshRSS profile base URL must be HTTPS",
+    "FreshRSS profile origin key must be at least 32 bytes",
+    "selected FreshRSS account does not match the configured connection",
+    "selected FreshRSS installation does not match the connection",
+)
+
+
+class FreshRSSReader(Protocol):
+    def identity(self, expected_id: str) -> dict[str, Any]: ...
+    def page(self, request: PageRequest) -> dict[str, Any]: ...
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    if len(output.encode()) > MAX_RESPONSE_BYTES:
+        raise FreshRSSAdapterError("FreshRSS read response exceeds the safety limit")
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise FreshRSSAdapterError(
+            "FreshRSS read provider returned no valid JSON"
+        ) from error
+    if not isinstance(payload, dict):
+        raise FreshRSSAdapterError("FreshRSS read response root must be an object")
+    return payload
+
+
+def _provider_failure(stderr: str) -> FreshRSSProviderUnavailableError:
+    for message in SAFE_PROVIDER_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return FreshRSSProviderUnavailableError(message)
+    return FreshRSSProviderUnavailableError("FreshRSS read provider is unavailable")
+
+
+FRESHRSS_READER_POLICY = GuardedOAuthPolicy(
+    "FreshRSS",
+    "FRESHRSS",
+    "FRESHRSS_READ_LOG",
+    READ_TIMEOUT_SECONDS,
+    _decode_output,
+    _provider_failure,
+    FreshRSSProviderUnavailableError,
+    ("BASE_URL", "USERNAME", "API_PASSWORD", "ORIGIN_KEY"),
+    "",
+)
+
+
+class GuardedFreshRSS(GuardedOAuthReader):
+    def __init__(self, helper: Path, profile: str) -> None:
+        super().__init__(helper, profile, FRESHRSS_READER_POLICY)
+
+
+def _fixture_object(value: Any, message: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise FreshRSSAdapterError(message)
+    return value
+
+
+class FixtureFreshRSS:
+    def __init__(self, path: Path) -> None:
+        self.fixture = FixtureSequence(path, "FreshRSS", FreshRSSAdapterError)
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        del expected_id
+        return self.fixture.identity()
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        entry = self.fixture.next_page()
+        expectation = _fixture_object(
+            entry.get("expect_request", {}),
+            "FreshRSS fixture request expectation must be an object",
+        )
+        for key, value in expectation.items():
+            if request.payload().get(key) != value:
+                raise FreshRSSAdapterError(
+                    "FreshRSS request did not resume at the expected checkpoint"
+                )
+        return _fixture_object(
+            entry.get("response", entry),
+            "FreshRSS fixture page response must be an object",
+        )
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise FreshRSSAdapterError("FreshRSS account verification returned no account")
+    local = user_id(data.get("user_id"))
+    if local != user_id(expected_id):
+        raise FreshRSSAdapterError(
+            "selected FreshRSS account does not match the configured connection"
+        )
+    instance = data.get("installation_id")
+    durable = account_id(instance, local)
+    if data.get("id") != durable:
+        raise FreshRSSAdapterError("FreshRSS account identity binding is invalid")
+    username = data.get("username")
+    if username is not None and user_id(username) != local:
+        raise FreshRSSAdapterError("FreshRSS account username is invalid")
+    return {
+        "id": durable,
+        "installation_id": instance,
+        "user_id": local,
+        "username": username,
+    }

--- a/.agents/scripts/_knowledge_social_freshrss_routes.py
+++ b/.agents/scripts/_knowledge_social_freshrss_routes.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Exact FreshRSS GReader GET routes and bounded response serializers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Callable
+from xml.etree import ElementTree
+
+from _knowledge_social_freshrss import ITEM_STREAMS, PageRequest
+from _knowledge_social_freshrss_contract import (
+    ApiResult,
+    FreshRSSReadProviderError,
+    object_list,
+    object_value,
+    observed_at,
+    optional_text,
+    required_text,
+    safe_url,
+)
+from _knowledge_social_freshrss_identity import resource_id
+
+Api = Callable[[str, dict[str, str]], ApiResult]
+PageResult = ApiResult | dict[str, Any]
+IDENTITY_PATH = "/reader/api/0/user-info"
+SUBSCRIPTIONS_PATH = "/reader/api/0/subscription/list"
+TAGS_PATH = "/reader/api/0/tag/list"
+ITEMS_PATH = "/reader/api/0/stream/contents/reading-list"
+STARRED_PATH = "/reader/api/0/stream/contents/user/-/state/com.google/starred"
+OPML_PATH = "/reader/api/0/subscription/export"
+EXACT_READ_PATHS = frozenset(
+    {IDENTITY_PATH, SUBSCRIPTIONS_PATH, TAGS_PATH, ITEMS_PATH, STARRED_PATH, OPML_PATH}
+)
+STREAM_PATHS = {
+    "items": ITEMS_PATH,
+    "unread": ITEMS_PATH,
+    "starred": STARRED_PATH,
+    "subscriptions": SUBSCRIPTIONS_PATH,
+    "folders": TAGS_PATH,
+    "tags": TAGS_PATH,
+    "opml": OPML_PATH,
+}
+READ_STATE = "user/-/state/com.google/read"
+STARRED_STATE = "user/-/state/com.google/starred"
+LABEL_PREFIX = "user/-/label/"
+
+
+def allowlisted_path(path: str) -> bool:
+    return path in EXACT_READ_PATHS
+
+
+def query_keys_for_path(path: str) -> frozenset[str]:
+    if path in {SUBSCRIPTIONS_PATH, TAGS_PATH}:
+        return frozenset({"output"})
+    if path in {ITEMS_PATH, STARRED_PATH}:
+        return frozenset({"output", "n", "c", "r", "ot", "xt", "it"})
+    return frozenset()
+
+
+def _opaque(value: Any, field: str, *, limit: int = 16 * 1024) -> str:
+    if isinstance(value, bool) or not isinstance(value, (str, int)):
+        raise FreshRSSReadProviderError(f"FreshRSS {field} is invalid")
+    rendered = str(value)
+    if not rendered or "\x00" in rendered or len(rendered.encode()) > limit:
+        raise FreshRSSReadProviderError(f"FreshRSS {field} is invalid")
+    return rendered
+
+
+def _epoch(value: Any, field: str) -> int:
+    if isinstance(value, bool):
+        raise FreshRSSReadProviderError(f"FreshRSS {field} is invalid")
+    try:
+        epoch = int(value)
+    except (TypeError, ValueError) as error:
+        raise FreshRSSReadProviderError(f"FreshRSS {field} is invalid") from error
+    if epoch < 0 or str(epoch) != str(value):
+        raise FreshRSSReadProviderError(f"FreshRSS {field} is invalid")
+    return epoch
+
+
+def _timestamp(value: Any, field: str, *, microseconds: bool = False) -> str | None:
+    if value is None:
+        return None
+    epoch = _epoch(value, field)
+    seconds = epoch / 1_000_000 if microseconds else epoch
+    try:
+        return datetime.fromtimestamp(seconds, UTC).isoformat().replace("+00:00", "Z")
+    except (OverflowError, OSError, ValueError) as error:
+        raise FreshRSSReadProviderError(f"FreshRSS {field} is invalid") from error
+
+
+def _string_list(value: Any, field: str, *, limit: int = 1000) -> list[str]:
+    if not isinstance(value, list) or len(value) > limit:
+        raise FreshRSSReadProviderError(f"FreshRSS {field} is invalid")
+    result = []
+    for item in value:
+        result.append(required_text(item, field, limit=4096))
+    return result
+
+
+def _first_link(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    links = object_list(value, field, limit=16)
+    for link in links:
+        href = link.get("href")
+        if href is not None:
+            return safe_url(href, f"{field} URL")
+    return None
+
+
+def _subscription(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    native = _opaque(item.get("id"), "subscription ID")
+    if not native.startswith("feed/"):
+        raise FreshRSSReadProviderError("FreshRSS subscription ID is invalid")
+    categories = object_list(item.get("categories", []), "subscription categories", limit=100)
+    folders = []
+    for category in categories:
+        category_id = required_text(category.get("id"), "subscription category ID")
+        if not category_id.startswith(LABEL_PREFIX):
+            raise FreshRSSReadProviderError("FreshRSS subscription category is invalid")
+        folders.append(
+            optional_text(category.get("label"), "subscription category label", limit=4096)
+            or category_id.removeprefix(LABEL_PREFIX)
+        )
+    return {
+        "kind": "feed",
+        "remote_id": resource_id(request.installation_id, "feed", native),
+        "native_id": native,
+        "title": optional_text(item.get("title"), "subscription title"),
+        "url": safe_url(item.get("url"), "subscription feed URL"),
+        "html_url": safe_url(item.get("htmlUrl"), "subscription site URL"),
+        "folders": folders,
+    }
+
+
+def _tag_records(payload: Any, request: PageRequest) -> list[dict[str, Any]]:
+    root = object_value(payload, "tag response")
+    values = object_list(root.get("tags"), "tags", limit=request.limit)
+    records = []
+    for item in values:
+        kind = item.get("type")
+        if kind not in {"folder", "tag"}:
+            continue
+        if kind != request.stream.removesuffix("s"):
+            continue
+        native = required_text(item.get("id"), f"{kind} ID")
+        if not native.startswith(LABEL_PREFIX):
+            raise FreshRSSReadProviderError(f"FreshRSS {kind} ID is invalid")
+        records.append(
+            {
+                "kind": kind,
+                "remote_id": resource_id(request.installation_id, kind, native),
+                "native_id": native,
+                "title": optional_text(item.get("label"), f"{kind} label", limit=4096)
+                or native.removeprefix(LABEL_PREFIX),
+                "unread_count": (
+                    _epoch(item.get("unread_count"), f"{kind} unread count")
+                    if item.get("unread_count") is not None
+                    else None
+                ),
+            }
+        )
+    if len(records) > request.limit:
+        raise FreshRSSReadProviderError("FreshRSS tag response exceeds the item safety limit")
+    return records
+
+
+def _summary(item: dict[str, Any]) -> str | None:
+    value = item.get("summary")
+    if value is None:
+        return None
+    summary = object_value(value, "entry summary")
+    return optional_text(summary.get("content"), "entry summary content")
+
+
+def _entry(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    native = _opaque(item.get("id"), "entry ID")
+    categories = _string_list(item.get("categories", []), "entry categories")
+    is_read = READ_STATE in categories
+    is_starred = STARRED_STATE in categories
+    if request.stream == "unread" and is_read:
+        raise FreshRSSReadProviderError("FreshRSS unread stream contains a read item")
+    if request.stream == "starred" and not is_starred:
+        raise FreshRSSReadProviderError("FreshRSS starred stream contains an unstarred item")
+    origin = object_value(item.get("origin", {}), "entry origin")
+    origin_id = optional_text(origin.get("streamId"), "entry origin ID", limit=4096)
+    return {
+        "kind": "entry",
+        "remote_id": resource_id(request.installation_id, "entry", native),
+        "native_id": native,
+        "title": optional_text(item.get("title"), "entry title"),
+        "body": _summary(item),
+        "author": optional_text(item.get("author"), "entry author", limit=64 * 1024),
+        "url": _first_link(item.get("canonical"), "entry canonical links")
+        or _first_link(item.get("alternate"), "entry alternate links"),
+        "published_at": _timestamp(item.get("published"), "entry published timestamp"),
+        "created_at": _timestamp(
+            item.get("timestampUsec"), "entry timestamp", microseconds=True
+        ),
+        "crawl_time_msec": (
+            _epoch(item.get("crawlTimeMsec"), "entry crawl timestamp")
+            if item.get("crawlTimeMsec") is not None
+            else None
+        ),
+        "read": is_read,
+        "starred": is_starred,
+        "labels": [value.removeprefix(LABEL_PREFIX) for value in categories if value.startswith(LABEL_PREFIX)],
+        "origin_id": origin_id,
+        "origin_title": optional_text(origin.get("title"), "entry origin title"),
+        "origin_url": safe_url(origin.get("htmlUrl"), "entry origin URL"),
+    }
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _opml_records(payload: Any, request: PageRequest) -> list[dict[str, Any]]:
+    if not isinstance(payload, str) or len(payload.encode()) > 8 * 1024 * 1024:
+        raise FreshRSSReadProviderError("FreshRSS OPML response is invalid")
+    upper = payload.upper()
+    if "<!DOCTYPE" in upper or "<!ENTITY" in upper:
+        raise FreshRSSReadProviderError("FreshRSS OPML response is invalid")
+    try:
+        root = ElementTree.fromstring(payload)
+    except ElementTree.ParseError as error:
+        raise FreshRSSReadProviderError("FreshRSS OPML response is invalid") from error
+    records: list[dict[str, Any]] = []
+
+    def visit(node: ElementTree.Element, folders: tuple[str, ...]) -> None:
+        for child in node:
+            if _local_name(child.tag) != "outline":
+                visit(child, folders)
+                continue
+            feed_url = child.attrib.get("xmlUrl")
+            title = optional_text(
+                child.attrib.get("title", child.attrib.get("text")), "OPML title", limit=4096
+            )
+            if feed_url is None:
+                visit(child, (*folders, title) if title else folders)
+                continue
+            safe_feed_url = safe_url(feed_url, "OPML feed URL")
+            records.append(
+                {
+                    "kind": "feed",
+                    "remote_id": resource_id(
+                        request.installation_id, "opml_feed", safe_feed_url
+                    ),
+                    "title": title,
+                    "url": safe_feed_url,
+                    "html_url": safe_url(child.attrib.get("htmlUrl"), "OPML site URL"),
+                    "description": optional_text(
+                        child.attrib.get("description"), "OPML description"
+                    ),
+                    "feed_type": optional_text(
+                        child.attrib.get("type"), "OPML feed type", limit=4096
+                    ),
+                    "category": "/".join(folders) or None,
+                }
+            )
+            if len(records) > request.limit:
+                raise FreshRSSReadProviderError(
+                    "FreshRSS OPML response exceeds the item safety limit"
+                )
+
+    visit(root, ())
+    return records
+
+
+def _item_page(payload: Any, request: PageRequest) -> tuple[list[dict[str, Any]], str | None, int]:
+    root = object_value(payload, "item response")
+    values = object_list(root.get("items"), "items", limit=request.limit)
+    records = [_entry(item, request) for item in values]
+    raw_continuation = root.get("continuation")
+    continuation = (
+        _opaque(raw_continuation, "continuation")
+        if raw_continuation is not None
+        else None
+    )
+    if continuation is not None and not values:
+        raise FreshRSSReadProviderError("FreshRSS empty item page retained a continuation")
+    watermark = _epoch(root.get("updated"), "item response watermark")
+    return records, continuation, watermark
+
+
+def page(api: Api, request: PageRequest) -> PageResult:
+    path = STREAM_PATHS[request.stream]
+    params: dict[str, str] = {}
+    if request.stream in ITEM_STREAMS:
+        params = {"output": "json", "n": str(request.limit), "r": "o"}
+        if request.continuation is not None:
+            params["c"] = request.continuation
+        if request.newer_than is not None:
+            params["ot"] = str(request.newer_than)
+        if request.stream == "unread":
+            params["xt"] = READ_STATE
+    elif request.stream in {"subscriptions", "folders", "tags"}:
+        params = {"output": "json"}
+    result = api(path, params)
+    if result.status != 200:
+        return result
+    if request.stream in ITEM_STREAMS:
+        records, continuation, watermark = _item_page(result.payload, request)
+        has_more = continuation is not None
+    elif request.stream == "subscriptions":
+        root = object_value(result.payload, "subscription response")
+        values = object_list(root.get("subscriptions"), "subscriptions", limit=request.limit)
+        records = [_subscription(item, request) for item in values]
+        continuation, has_more, watermark = None, False, None
+    elif request.stream in {"folders", "tags"}:
+        records = _tag_records(result.payload, request)
+        continuation, has_more, watermark = None, False, None
+    else:
+        records = _opml_records(result.payload, request)
+        continuation, has_more, watermark = None, False, None
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": records,
+        "meta": {
+            "stream": request.stream,
+            "has_more": has_more,
+            "next_continuation": continuation,
+            "watermark": watermark,
+            "snapshot": request.stream not in ITEM_STREAMS,
+        },
+    }

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -19,6 +19,7 @@ MASTODON_HELPER="${SCRIPT_DIR}/knowledge_social_mastodon.py"
 GITHUB_HELPER="${SCRIPT_DIR}/knowledge_social_github.py"
 STACK_EXCHANGE_HELPER="${SCRIPT_DIR}/knowledge_social_stack_exchange.py"
 MINIFLUX_HELPER="${SCRIPT_DIR}/knowledge_social_miniflux.py"
+FRESHRSS_HELPER="${SCRIPT_DIR}/knowledge_social_freshrss.py"
 READWISE_READER_HELPER="${SCRIPT_DIR}/knowledge_social_readwise_reader.py"
 QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
 SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
@@ -141,6 +142,14 @@ Miniflux synchronization:
   use GET-only routes. Entry streams resume by ascending ID and overlap
   changed_after by one second. --budget is 3-1000 and --page-size is 1-100.
 
+FreshRSS synchronization:
+  sync-freshrss binds the current Google Reader user to a keyed exact HTTPS
+  installation before every page. One exact ClientLogin POST obtains ephemeral
+  authorization; subscriptions, folders, tags, items, unread, starred, and OPML
+  then use exact GET-only routes with opaque continuation checkpoints. Fever
+  remains unavailable because authenticated Fever reads require another POST.
+  --budget is 5-1000 and --page-size is 1-1000.
+
 Readwise Reader synchronization:
   sync-readwise-reader requires a deployment-owned account ID plus keyed expected
   token binding before fixed-origin token validation. Seven GET-only streams use
@@ -209,6 +218,10 @@ Usage:
   knowledge-social-helper.sh sync-miniflux [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id USER_NUMERIC_ID --stream STREAM \
     --profile PROFILE [--budget UNITS] [--page-size 1-100] \
+    [--collector-id ID] [--lease-seconds SECONDS]
+  knowledge-social-helper.sh sync-freshrss [--base PATH] [--alias ALIAS] \
+    --connection-id ID --account-id FRESHRSS_USERNAME --stream STREAM \
+    --profile PROFILE [--budget UNITS] [--page-size 1-1000] \
     [--collector-id ID] [--lease-seconds SECONDS]
   knowledge-social-helper.sh sync-readwise-reader [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id DEPLOYMENT_ACCOUNT_ID --stream STREAM \
@@ -402,6 +415,7 @@ run_named_provider_sync() {
 	sync-github) run_provider_sync GitHub "$GITHUB_HELPER" "$@" || return 1 ;;
 	sync-stack-exchange) run_provider_sync "Stack Exchange" "$STACK_EXCHANGE_HELPER" "$@" || return 1 ;;
 	sync-miniflux) run_provider_sync Miniflux "$MINIFLUX_HELPER" "$@" || return 1 ;;
+	sync-freshrss) run_provider_sync FreshRSS "$FRESHRSS_HELPER" "$@" || return 1 ;;
 	sync-readwise-reader) run_provider_sync "Readwise Reader" "$READWISE_READER_HELPER" "$@" || return 1 ;;
 	*) return 1 ;;
 	esac
@@ -482,7 +496,7 @@ main() {
 		fi
 		python3 "$LINKEDIN_HELPER" "$@" || return 1
 		;;
-	sync-meta | sync-discourse | sync-nodebb | sync-mastodon | sync-github | sync-stack-exchange | sync-miniflux | sync-readwise-reader)
+	sync-meta | sync-discourse | sync-nodebb | sync-mastodon | sync-github | sync-stack-exchange | sync-miniflux | sync-freshrss | sync-readwise-reader)
 		run_named_provider_sync "$subcommand" "$@" || return 1
 		;;
 	query | annotate)

--- a/.agents/scripts/knowledge_social_freshrss.py
+++ b/.agents/scripts/knowledge_social_freshrss.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one bounded FreshRSS account stream into a social corpus."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import _knowledge_social_freshrss as freshrss
+from _knowledge_social_freshrss_normalize import PageContext, normalize_page
+from _knowledge_social_freshrss_reader import (
+    FixtureFreshRSS,
+    GuardedFreshRSS,
+    verified_identity,
+)
+from _knowledge_social_oauth_collector import OAuthCollectorPolicy, run_oauth_collector
+
+
+def _policy() -> OAuthCollectorPolicy:
+    return OAuthCollectorPolicy(
+        provider_module=freshrss,
+        verified_identity=verified_identity,
+        normalize_page=normalize_page,
+        page_context=PageContext,
+        display_name="FreshRSS",
+        helper=Path(__file__).with_name("_knowledge_social_freshrss_provider.py"),
+        fixture_reader=FixtureFreshRSS,
+        live_reader=GuardedFreshRSS,
+        budget_unit="request",
+        max_page_size=1000,
+        default_budget=14,
+        min_budget=5,
+        identity_cost_units=2,
+    )
+
+
+def main() -> int:
+    return run_oauth_collector(_policy(), __doc__ or "")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/knowledge_social_registry.py
+++ b/.agents/scripts/knowledge_social_registry.py
@@ -44,6 +44,7 @@ PROVIDER_SPECS = (
         "knowledge_social_forem.py",
         (("live", ()),),
     ),
+    ProviderSpec("freshrss", (), "knowledge_social_freshrss.py", (("live", ()),)),
     ProviderSpec(
         "google-business-profile",
         ("gbp",),

--- a/.agents/tests/test-knowledge-social-freshrss.sh
+++ b/.agents/tests/test-knowledge-social-freshrss.sh
@@ -1,0 +1,543 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-freshrss.sh — Bounded FreshRSS collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FRESHRSS_SCRIPT="${SCRIPT_DIR}/../scripts/knowledge_social_freshrss.py"
+SOCIAL_HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TEMP_PARENT="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+mkdir -p "$TEMP_PARENT"
+TMP_DIR=$(mktemp -d "${TEMP_PARENT}/freshrss-social-test.XXXXXX")
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' \
+			"$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c 'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_count() {
+	python3 - "$ROOT/sources/social/raw/freshrss" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+print(len(list(root.rglob("*.json.gz"))) if root.exists() else 0)
+PY
+	return 0
+}
+
+run_freshrss() {
+	local fixture="$1"
+	local connection_id="$2"
+	local stream="$3"
+	local budget="$4"
+	local page_size="$5"
+	if python3 "$FRESHRSS_SCRIPT" --base "$BASE" --alias personal:default \
+		--connection-id "$connection_id" --account-id reader \
+		--stream "$stream" --profile fixture --fixture "$fixture" \
+		--budget "$budget" --page-size "$page_size"; then
+		return 0
+	fi
+	return 1
+}
+
+expect_failure() {
+	local description="$1"
+	local fixture="$2"
+	local connection_id="$3"
+	local stream="$4"
+	if run_freshrss "$fixture" "$connection_id" "$stream" 8 10 >/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$SOCIAL_HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'FreshRSS social collector tests\n'
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import ast
+import json
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+
+from _knowledge_social_collect import CursorState
+from _knowledge_social_freshrss import PageRequest, STREAMS, page_checkpoint, page_request
+from _knowledge_social_freshrss_contract import ApiResult, identity_value
+from _knowledge_social_freshrss_http import (
+    API_PREFIX,
+    HTTP_TIMEOUT_SECONDS,
+    LOGIN_PATH,
+    ProfileConfig,
+    api,
+    login,
+)
+from _knowledge_social_freshrss_identity import account_id, installation_id, resource_id
+from _knowledge_social_freshrss_routes import (
+    ITEMS_PATH,
+    OPML_PATH,
+    STARRED_PATH,
+    SUBSCRIPTIONS_PATH,
+    TAGS_PATH,
+    allowlisted_path,
+    page,
+)
+
+assert set(STREAMS) == {
+    "items", "unread", "starred", "subscriptions", "folders", "tags", "opml",
+}
+for allowed in (
+    "/reader/api/0/user-info", SUBSCRIPTIONS_PATH, TAGS_PATH,
+    ITEMS_PATH, STARRED_PATH, OPML_PATH,
+):
+    assert allowlisted_path(allowed)
+for rejected in (
+    "/reader/api/0/token",
+    "/reader/api/0/subscription/edit",
+    "/reader/api/0/edit-tag",
+    "/reader/api/0/mark-all-as-read",
+    "/api/fever.php",
+):
+    assert not allowlisted_path(rejected)
+
+instance = installation_id("https://reader.example.test/freshrss", "o" * 32)
+identity = identity_value(
+    {"userId": "reader", "userName": "reader", "userProfileId": "reader"},
+    "reader",
+    instance,
+)
+assert identity["id"] == account_id(instance, "reader")
+assert resource_id(instance, "entry", "tag:google.com,2005:reader/item/1") != resource_id(
+    instance, "entry", "tag:google.com,2005:reader/item/2"
+)
+
+item = {
+    "id": "tag:google.com,2005:reader/item/9",
+    "crawlTimeMsec": "1785650402000",
+    "timestampUsec": "1785650402000000",
+    "published": 1785650402,
+    "title": "Bounded feed item",
+    "author": "Author",
+    "canonical": [{"href": "https://site.example/article"}],
+    "categories": ["user/-/label/research"],
+    "origin": {
+        "streamId": "feed/7",
+        "title": "Example feed",
+        "htmlUrl": "https://site.example/",
+    },
+    "summary": {"content": "FreshRSS knowledge"},
+}
+request = PageRequest("items", identity["id"], instance, "reader", None, None, 1)
+observed_requests = []
+
+
+def item_api(path, params):
+    observed_requests.append((path, params))
+    return ApiResult(
+        200,
+        {"id": "reading-list", "updated": 1785650402, "items": [item], "continuation": "c-1"},
+    )
+
+
+payload = page(item_api, request)
+assert observed_requests == [(ITEMS_PATH, {"output": "json", "n": "1", "r": "o"})]
+assert payload["data"][0]["title"] == "Bounded feed item"
+checkpoint, complete = page_checkpoint(payload, CursorState(None, None, False), request)
+assert not complete and checkpoint.next_cursor is not None
+resumed = page_request(
+    "items", identity, CursorState(checkpoint.next_cursor, checkpoint.watermark, False), 1
+)
+assert resumed.continuation == "c-1" and resumed.newer_than is None
+incremental = page_request(
+    "items", identity, CursorState(None, checkpoint.watermark, True), 1
+)
+assert incremental.newer_than == 1785650401
+
+unread = page(
+    lambda path, params: ApiResult(200, {"updated": 1785650402, "items": [item]}),
+    PageRequest("unread", identity["id"], instance, "reader", None, None, 10),
+)
+assert unread["data"][0]["read"] is False
+starred_item = dict(item, categories=["user/-/state/com.google/starred"])
+starred = page(
+    lambda path, params: ApiResult(200, {"updated": 1785650402, "items": [starred_item]}),
+    PageRequest("starred", identity["id"], instance, "reader", None, None, 10),
+)
+assert starred["data"][0]["starred"] is True
+
+subscriptions = page(
+    lambda path, params: ApiResult(200, {"subscriptions": [{
+        "id": "feed/7", "title": "Example", "url": "https://feed.example/rss",
+        "htmlUrl": "https://site.example/",
+        "categories": [{"id": "user/-/label/Research", "label": "Research"}],
+    }]}),
+    PageRequest("subscriptions", identity["id"], instance, "reader", None, None, 10),
+)
+assert subscriptions["data"][0]["folders"] == ["Research"]
+
+tag_payload = {"tags": [
+    {"id": "user/-/label/Research", "label": "Research", "type": "folder"},
+    {"id": "user/-/label/Pinned", "label": "Pinned", "type": "tag", "unread_count": 0},
+    {"id": "user/-/state/com.google/read"},
+]}
+folders = page(
+    lambda path, params: ApiResult(200, tag_payload),
+    PageRequest("folders", identity["id"], instance, "reader", None, None, 10),
+)
+tags = page(
+    lambda path, params: ApiResult(200, tag_payload),
+    PageRequest("tags", identity["id"], instance, "reader", None, None, 10),
+)
+assert [record["kind"] for record in folders["data"]] == ["folder"]
+assert [record["kind"] for record in tags["data"]] == ["tag"]
+
+opml = page(
+    lambda path, params: ApiResult(
+        200,
+        '<opml xmlns:frss="https://freshrss.org/opml"><body><outline text="Research">'
+        '<outline text="Feed" type="rss" xmlUrl="https://feed.example/rss" '
+        'htmlUrl="https://site.example/" frss:CURLOPT_COOKIE="must-not-persist"/>'
+        '</outline></body></opml>',
+    ),
+    PageRequest("opml", identity["id"], instance, "reader", None, None, 10),
+)
+assert opml["data"][0]["category"] == "Research"
+assert "CURLOPT" not in json.dumps(opml)
+
+
+class Headers:
+    def get(self, _key, default=None):
+        return default
+
+
+class Response:
+    status = 200
+    headers = Headers()
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def read(self, size=-1):
+        return self.payload[:size]
+
+
+class Opener:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    def open(self, request, timeout):
+        assert timeout == HTTP_TIMEOUT_SECONDS
+        self.requests.append(request)
+        return self.responses.pop(0)
+
+
+config = ProfileConfig(
+    "https://reader.example.test/freshrss", "reader", "private-password", "o" * 32, instance
+)
+opener = Opener([
+    Response(b"SID=reader/hash\nLSID=null\nAuth=reader/hash\n"),
+    Response(b'{"subscriptions": []}'),
+])
+authorized = login(config, opener)
+assert authorized.payload == "reader/hash"
+api(config, opener, authorized.payload, SUBSCRIPTIONS_PATH, {"output": "json"})
+assert opener.requests[0].method == "POST"
+assert opener.requests[0].full_url.endswith(f"{API_PREFIX}{LOGIN_PATH}")
+assert "private-password" not in opener.requests[0].full_url
+assert opener.requests[1].method == "GET"
+assert opener.requests[1].get_header("Authorization") == "GoogleLogin auth=reader/hash"
+
+http_source = (scripts / "_knowledge_social_freshrss_http.py").read_text(encoding="utf-8")
+tree = ast.parse(http_source)
+methods = {}
+for node in tree.body:
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name in {"login", "api"}:
+        methods[node.name] = [
+            keyword.value.value
+            for call in ast.walk(node)
+            if isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Name)
+            and call.func.id == "Request"
+            for keyword in call.keywords
+            if keyword.arg == "method" and isinstance(keyword.value, ast.Constant)
+        ]
+assert methods == {"login": ["POST"], "api": ["GET"]}
+all_sources = "\n".join(
+    path.read_text(encoding="utf-8")
+    for path in sorted(scripts.glob("_knowledge_social_freshrss*.py"))
+)
+assert "/reader/api/0/token" not in all_sources
+assert "fever.php" not in all_sources
+PY
+assert_eq "identity, routes, pagination, snapshots, and POST/GET AST are guarded" \
+	verified verified
+
+python3 - "$TMP_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, ".agents/scripts")
+from _knowledge_social_freshrss_identity import account_id, installation_id, resource_id
+
+target = Path(sys.argv[1])
+instance = installation_id("https://reader.example.test/freshrss", "o" * 32)
+durable = account_id(instance, "reader")
+identity = {
+    "status": 200,
+    "data": {
+        "id": durable,
+        "installation_id": instance,
+        "user_id": "reader",
+        "username": "reader",
+    },
+}
+
+
+def record(native, title, body, *, read=False, starred=False):
+    return {
+        "kind": "entry",
+        "remote_id": resource_id(instance, "entry", native),
+        "native_id": native,
+        "title": title,
+        "body": body,
+        "author": "Author",
+        "url": f"https://site.example/{native}",
+        "published_at": "2026-08-02T06:00:02Z",
+        "created_at": "2026-08-02T06:00:02Z",
+        "read": read,
+        "starred": starred,
+        "labels": ["research"],
+    }
+
+
+def response(stream, data, *, continuation=None, watermark=None, snapshot=False):
+    return {
+        "status": 200,
+        "observed_at": "2026-08-02T06:30:00Z",
+        "data": data,
+        "meta": {
+            "stream": stream,
+            "has_more": continuation is not None,
+            "next_continuation": continuation,
+            "watermark": watermark,
+            "snapshot": snapshot,
+        },
+    }
+
+
+def write(name, pages, selected_identity=identity):
+    (target / name).write_text(
+        json.dumps({"identity": selected_identity, "pages": pages}), encoding="utf-8"
+    )
+
+
+write("items-first.json", [{
+    "expect_request": {"continuation": None, "newer_than": None, "limit": 1},
+    "response": response(
+        "items", [record("entry-1", "First item", "FreshRSS first knowledge")],
+        continuation="opaque-cursor", watermark=1785650402,
+    ),
+}])
+write("items-second.json", [{
+    "expect_request": {"continuation": "opaque-cursor", "newer_than": None, "limit": 1},
+    "response": response(
+        "items", [record("entry-2", "Second item", "FreshRSS resumed knowledge")],
+        watermark=1785650403,
+    ),
+}])
+write("items-replay.json", [{
+    "expect_request": {"continuation": None, "newer_than": 1785650402, "limit": 1},
+    "response": response(
+        "items", [record("entry-2", "Second item", "FreshRSS resumed knowledge")],
+        watermark=1785650403,
+    ),
+}])
+
+snapshot_rows = {
+    "subscriptions": [{
+        "kind": "feed", "remote_id": resource_id(instance, "feed", "feed/7"),
+        "native_id": "feed/7", "title": "Example feed",
+        "url": "https://feed.example/rss", "html_url": "https://site.example/",
+        "folders": ["Research"],
+    }],
+    "folders": [{
+        "kind": "folder", "remote_id": resource_id(instance, "folder", "Research"),
+        "native_id": "user/-/label/Research", "title": "Research", "unread_count": None,
+    }],
+    "tags": [{
+        "kind": "tag", "remote_id": resource_id(instance, "tag", "Pinned"),
+        "native_id": "user/-/label/Pinned", "title": "Pinned", "unread_count": 0,
+    }],
+    "opml": [{
+        "kind": "feed", "remote_id": resource_id(instance, "opml_feed", "https://feed.example/rss"),
+        "title": "Example feed", "url": "https://feed.example/rss",
+        "html_url": "https://site.example/", "description": None,
+        "feed_type": "rss", "category": "Research",
+    }],
+}
+for stream, rows in snapshot_rows.items():
+    write(
+        f"{stream}.json",
+        [{"response": response(stream, rows, snapshot=True)}],
+    )
+
+write("unread.json", [{
+    "response": response(
+        "unread", [record("entry-3", "Unread item", "Unread knowledge")],
+        watermark=1785650404,
+    ),
+}])
+write("starred.json", [{
+    "response": response(
+        "starred", [record("entry-4", "Starred item", "Starred knowledge", starred=True)],
+        watermark=1785650405,
+    ),
+}])
+
+write("credential.json", [{
+    "response": {
+        **response("subscriptions", [], snapshot=True),
+        "api_password": "must-not-persist",
+    },
+}])
+write("malformed.json", [{
+    "response": {
+        **response("items", [], continuation="stuck", watermark=1785650402),
+        "meta": {
+            "stream": "items", "has_more": True, "next_continuation": "",
+            "watermark": 1785650402, "snapshot": False,
+        },
+    },
+}])
+write("terminal.json", [{
+    "response": {"status": 500, "observed_at": "2026-08-02T06:30:00Z"},
+}])
+wrong = {
+    "status": 200,
+    "data": {
+        "id": account_id(instance, "other"), "installation_id": instance,
+        "user_id": "other", "username": "other",
+    },
+}
+write("mismatch.json", [], wrong)
+PY
+
+result=$(run_freshrss "$TMP_DIR/items-first.json" conn_freshrss items 5 1)
+assert_eq "bounded first page stops at its request budget" \
+	"$(json_field "$result" status)" budget_exhausted
+assert_eq "login, identity, and one data page consume five units" \
+	"$(json_field "$result" budget_units)" 5
+
+result=$(run_freshrss "$TMP_DIR/items-second.json" conn_freshrss items 5 1)
+assert_eq "opaque continuation resumes to completion" \
+	"$(json_field "$result" status)" complete
+assert_eq "resumed FreshRSS text reaches FTS" \
+	"$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'resumed'")" 1
+
+objects_before=$(sql_value "SELECT count(*) FROM objects WHERE provider='freshrss'")
+run_freshrss "$TMP_DIR/items-replay.json" conn_freshrss items 5 1 >/dev/null
+assert_eq "incremental overlap replays idempotently" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='freshrss'")" "$objects_before"
+
+for stream in subscriptions folders tags unread starred opml; do
+	run_freshrss "$TMP_DIR/${stream}.json" conn_freshrss "$stream" 5 10 >/dev/null
+done
+assert_eq "all seven fixture-proven streams retain independent checkpoints" \
+	"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_freshrss'")" 7
+
+objects_before=$(sql_value "SELECT count(*) FROM objects WHERE provider='freshrss'")
+run_freshrss "$TMP_DIR/subscriptions.json" conn_freshrss subscriptions 5 10 >/dev/null
+assert_eq "subscription snapshot replay never duplicates or infers deletion" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='freshrss'")" "$objects_before"
+
+raw_before=$(raw_count)
+expect_failure "selected-account identity mismatch is rejected" \
+	"$TMP_DIR/mismatch.json" conn_mismatch items
+assert_eq "identity mismatch persists no raw evidence" "$(raw_count)" "$raw_before"
+
+expect_failure "credential-shaped FreshRSS page is rejected" \
+	"$TMP_DIR/credential.json" conn_credential subscriptions
+assert_eq "credential rejection preserves prior evidence" "$(raw_count)" "$raw_before"
+
+expect_failure "malformed continuation is rejected" \
+	"$TMP_DIR/malformed.json" conn_malformed items
+assert_eq "malformed page preserves its absent checkpoint" \
+	"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_malformed'")" 0
+
+raw_before=$(raw_count)
+result=$(run_freshrss "$TMP_DIR/terminal.json" conn_terminal items 5 10)
+assert_eq "terminal provider failure is sanitized" "$(json_field "$result" status)" failed
+assert_eq "terminal failure emits one sanitized raw boundary" \
+	"$(raw_count)" "$((raw_before + 1))"
+assert_eq "terminal failure preserves its absent checkpoint" \
+	"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_terminal'")" 0
+
+assert_eq "retention, deletion, archive, and Fever POST gaps remain explicit" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE connection_id='conn_freshrss' AND status='unavailable'")" 4
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/tests/test-knowledge-social-registry.sh
+++ b/.agents/tests/test-knowledge-social-registry.sh
@@ -43,6 +43,7 @@ expected = {
     "binance-square": ("no-route",),
     "discord": ("live",),
     "forem": ("live",),
+    "freshrss": ("live",),
     "github": ("live",),
     "google-business-profile": ("live",),
     "gumroad": ("live",),
@@ -97,14 +98,14 @@ except module.ProviderRegistryError:
 else:
     raise SystemExit("unknown provider used a fallback")
 
-print("16:order-independent:aliases-exact:collisions-rejected:no-fallback")
+print("17:order-independent:aliases-exact:collisions-rejected:no-fallback")
 PY
 )
 assert_eq "all merged provider outcomes register deterministically" \
-	"$registry_summary" "16:order-independent:aliases-exact:collisions-rejected:no-fallback"
+	"$registry_summary" "17:order-independent:aliases-exact:collisions-rejected:no-fallback"
 
 provider_count=$("$HELPER" providers | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
-assert_eq "helper exposes the complete provider registry" "$provider_count" "16"
+assert_eq "helper exposes the complete provider registry" "$provider_count" "17"
 
 forem_resolution=$("$HELPER" provider-resolve --provider dev-community |
 	python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["provider"] + ":" + ",".join(data["modes"]))')


### PR DESCRIPTION
## Summary

- Adds the installation-bound FreshRSS Google Reader collector core.
- Restricts credentials to ClientLogin and exact GET-only data routes.
- Preserves opaque continuation checkpoints and bounded OPML snapshots.

## Implementation checkpoint

Focused fixture tests, registry/CLI wiring, documentation, and final verification are still in progress on this draft.

## Runtime Testing

- Python 3.12.3 standard-library imports and collector modules compile.

Resolves #29226
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 18m and 199,535 tokens on this as a headless worker.