### PR TITLE
GH#29208: reduce OAuth pool auth file complexity

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool-auth-handlers.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-auth-handlers.mjs
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/**
+ * OAuth Pool — Provider Auth Handlers
+ *
+ * Contains provider token exchange callbacks and Cursor credential acquisition.
+ * Auth hook descriptors remain in oauth-pool-auth.mjs.
+ *
+ * @module oauth-pool-auth-handlers
+ */
+
+import { execSync } from "child_process";
+
+import {
+  ANTHROPIC_CLIENT_ID, ANTHROPIC_REDIRECT_URI,
+  GOOGLE_CLIENT_ID, GOOGLE_REDIRECT_URI,
+  OPENAI_CLIENT_ID, OPENAI_ISSUER, OPENAI_REDIRECT_URI,
+} from "./oauth-pool-constants.mjs";
+
+import {
+  ANTHROPIC_USER_AGENT, OPENCODE_USER_AGENT,
+  fetchTokenEndpoint, fetchOpenAITokenEndpoint, fetchGoogleTokenEndpoint,
+} from "./oauth-pool-token-endpoint.mjs";
+
+import {
+  decodeCursorJWT, readCursorAuthJsonCredentials,
+  readCursorStateDbCredentials, isCursorAgentAvailable,
+} from "./oauth-pool-refresh.mjs";
+
+import {
+  saveAccountAndInject, resolveEmailFromJWTClaims,
+  resolveEmailFromEndpoint, extractOpenAIAccountId, acquireAuthCode,
+} from "./oauth-pool-callback.mjs";
+
+import {
+  injectPoolToken, injectOpenAIPoolToken,
+  injectCursorPoolToken, injectGooglePoolToken,
+} from "./oauth-pool.mjs";
+
+async function resolveAnthropicEmail(accessToken) {
+  for (const endpoint of [
+    "https://console.anthropic.com/api/auth/user",
+    "https://api.anthropic.com/api/auth/user",
+  ]) {
+    const email = await resolveEmailFromEndpoint(
+      accessToken, endpoint,
+      { "User-Agent": ANTHROPIC_USER_AGENT },
+      ["email", "email_address", "user.email", "account.email"],
+    );
+    if (email) {
+      console.error(`[aidevops] OAuth pool: resolved email ${email} from ${endpoint}`);
+      return email;
+    }
+  }
+  console.error("[aidevops] OAuth pool: could not resolve email from profile API");
+  return null;
+}
+
+export async function handleAnthropicCallback(code, pkce, expectedState, email, client) {
+  const hashIdx = code.indexOf("#");
+  const authCode = hashIdx >= 0 ? code.substring(0, hashIdx) : code;
+  const returnedState = hashIdx >= 0 ? code.substring(hashIdx + 1) : undefined;
+  // Validate state when present. In manual code-paste flows the user may paste
+  // only the authorization code without the state fragment, so we accept absent
+  // state rather than failing valid flows. When state IS returned it must match.
+  if (returnedState !== undefined && returnedState !== expectedState) {
+    console.error("[aidevops] OAuth pool: Anthropic state mismatch — possible CSRF");
+    return { type: "failed" };
+  }
+  const result = await fetchTokenEndpoint(
+    JSON.stringify({
+      code: authCode, state: returnedState, grant_type: "authorization_code",
+      client_id: ANTHROPIC_CLIENT_ID, redirect_uri: ANTHROPIC_REDIRECT_URI,
+      code_verifier: pkce.verifier,
+    }),
+    "token exchange",
+  );
+  if (!result.ok) return { type: "failed" };
+  const json = await result.json();
+  let resolvedEmail = email;
+  if (resolvedEmail === "unknown" && json.access_token) {
+    resolvedEmail = (await resolveAnthropicEmail(json.access_token)) || "unknown";
+  }
+  return saveAccountAndInject({
+    provider: "anthropic", client, email: resolvedEmail,
+    tokenData: { refresh: json.refresh_token, access: json.access_token, expires: Date.now() + json.expires_in * 1000 },
+    envKey: "ANTHROPIC_API_KEY", authId: "anthropic", injectFn: injectPoolToken,
+  });
+}
+
+export async function handleOpenAICallback(code, pkce, email, callbackState, client) {
+  const authCode = await acquireAuthCode(code, callbackState);
+  if (!authCode) return { type: "failed" };
+  const cleanCode = authCode.split(/[&#?]/)[0];
+  const params = new URLSearchParams({
+    grant_type: "authorization_code", code: cleanCode,
+    redirect_uri: OPENAI_REDIRECT_URI, client_id: OPENAI_CLIENT_ID,
+    code_verifier: pkce.verifier,
+  });
+  const result = await fetchOpenAITokenEndpoint(params, "token exchange");
+  if (!result.ok) return { type: "failed" };
+  const json = await result.json();
+  let resolvedEmail = email;
+  let accountId = "";
+  if (json.access_token) {
+    accountId = extractOpenAIAccountId(json.access_token);
+    if (resolvedEmail === "unknown") resolvedEmail = resolveEmailFromJWTClaims(json.access_token) || "unknown";
+    if (resolvedEmail === "unknown") {
+      resolvedEmail = (await resolveEmailFromEndpoint(
+        json.access_token, `${OPENAI_ISSUER}/userinfo`, { "User-Agent": OPENCODE_USER_AGENT },
+      )) || "unknown";
+      if (resolvedEmail !== "unknown") console.error(`[aidevops] OAuth pool: resolved OpenAI email ${resolvedEmail}`);
+    }
+  }
+  return saveAccountAndInject({
+    provider: "openai", client, email: resolvedEmail,
+    tokenData: { refresh: json.refresh_token || "", access: json.access_token, expires: Date.now() + (json.expires_in || 3600) * 1000 },
+    extras: { accountId }, envKey: "OPENAI_API_KEY", authId: "openai", injectFn: injectOpenAIPoolToken,
+  });
+}
+
+export async function handleCursorAuthorize(email, client) {
+  let creds = readCursorAuthJsonCredentials(email);
+  if (creds) console.error("[aidevops] OAuth pool: found Cursor credentials in auth.json");
+  if (!creds) {
+    creds = readCursorStateDbCredentials(email);
+    if (creds) console.error("[aidevops] OAuth pool: found Cursor credentials in state DB");
+  }
+  if (!creds) {
+    if (!isCursorAgentAvailable()) {
+      console.error("[aidevops] OAuth pool: cursor-agent not found");
+      return { type: "failed" };
+    }
+    console.error("[aidevops] OAuth pool: running cursor-agent login...");
+    try {
+      execSync("cursor-agent login", { encoding: "utf-8", timeout: 120_000, stdio: ["inherit", "pipe", "pipe"] });
+      creds = readCursorAuthJsonCredentials(email);
+    } catch (err) {
+      console.error(`[aidevops] OAuth pool: cursor-agent login failed: ${err.message}`);
+      return { type: "failed" };
+    }
+  }
+  if (!creds) {
+    console.error("[aidevops] OAuth pool: no Cursor access token obtained");
+    return { type: "failed" };
+  }
+  const resolvedEmail = (email === "unknown" && creds.email) ? creds.email : email;
+  const tokenInfo = decodeCursorJWT(creds.access);
+  return saveAccountAndInject({
+    provider: "cursor", client, email: resolvedEmail,
+    tokenData: { refresh: creds.refresh || "", access: creds.access, expires: tokenInfo.expiresAt || (Date.now() + 3600_000) },
+    injectFn: injectCursorPoolToken, successExtras: { key: "cursor-pool" },
+  });
+}
+
+// NOTE: expectedState cannot be validated in this flow. GOOGLE_REDIRECT_URI is
+// the OOB (urn:ietf:wg:oauth:2.0:oob) redirect, which causes Google to display
+// the authorization code directly in the browser page rather than performing an
+// HTTP redirect. Because there is no redirect, the state nonce is never returned
+// to our process. We still include state in the authorize URL to prevent
+// redirect-level CSRF; the absence of callback-side validation is an inherent
+// limitation of the OOB grant type, not a fixable bug in this code.
+// eslint-disable-next-line no-unused-vars
+export async function handleGoogleCallback(code, pkce, expectedState, email, client) {
+  const authCode = code?.trim();
+  if (!authCode || authCode.length < 5) return { type: "failed" };
+  const result = await fetchGoogleTokenEndpoint(
+    JSON.stringify({
+      code: authCode, grant_type: "authorization_code",
+      client_id: GOOGLE_CLIENT_ID, redirect_uri: GOOGLE_REDIRECT_URI,
+      code_verifier: pkce.verifier,
+    }),
+    "Google token exchange",
+  );
+  if (!result.ok) return { type: "failed" };
+  const json = await result.json();
+  let resolvedEmail = email;
+  if (json.id_token && resolvedEmail === "unknown") {
+    resolvedEmail = resolveEmailFromJWTClaims(json.id_token) || "unknown";
+    if (resolvedEmail !== "unknown") console.error(`[aidevops] OAuth pool: resolved Google email ${resolvedEmail} from ID token`);
+  }
+  if (resolvedEmail === "unknown" && json.access_token) {
+    resolvedEmail = (await resolveEmailFromEndpoint(json.access_token, "https://www.googleapis.com/oauth2/v3/userinfo")) || "unknown";
+    if (resolvedEmail !== "unknown") console.error(`[aidevops] OAuth pool: resolved Google email ${resolvedEmail}`);
+  }
+  return saveAccountAndInject({
+    provider: "google", client, email: resolvedEmail,
+    tokenData: { refresh: json.refresh_token || "", access: json.access_token, expires: Date.now() + (json.expires_in || 3600) * 1000 },
+    envKey: "GOOGLE_OAUTH_ACCESS_TOKEN", injectFn: injectGooglePoolToken,
+  });
+}

--- a/.agents/plugins/opencode-aidevops/oauth-pool-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-auth.mjs
@@ -1,18 +1,15 @@
 /**
  * OAuth Pool — Auth Hooks & Handlers (t2128 refactor)
  *
- * Contains: provider auth hooks (anthropic, openai, cursor, google)
- * and token exchange handlers. Provider registration is re-exported
- * from oauth-pool-auth-provider.mjs.
+ * Contains provider auth hooks (anthropic, openai, cursor, google).
+ * Token exchange handlers live in oauth-pool-auth-handlers.mjs, and provider
+ * registration is re-exported from oauth-pool-auth-provider.mjs.
  *
- * Depends on: oauth-pool-constants, oauth-pool-token-endpoint,
- * oauth-pool-storage, oauth-pool-refresh, oauth-pool-callback,
- * and oauth-pool.mjs (for inject functions).
+ * Depends on: oauth-pool-constants, oauth-pool-storage, oauth-pool-callback,
+ * and oauth-pool-auth-handlers.
  *
  * @module oauth-pool-auth
  */
-
-import { execSync } from "child_process";
 
 import {
   ANTHROPIC_CLIENT_ID, ANTHROPIC_OAUTH_AUTHORIZE_URL,
@@ -23,191 +20,16 @@ import {
   GOOGLE_REDIRECT_URI, GOOGLE_OAUTH_SCOPES,
 } from "./oauth-pool-constants.mjs";
 
-import {
-  ANTHROPIC_USER_AGENT, OPENCODE_USER_AGENT,
-  fetchTokenEndpoint, fetchOpenAITokenEndpoint, fetchGoogleTokenEndpoint,
-} from "./oauth-pool-token-endpoint.mjs";
-
 import { getAccounts } from "./oauth-pool-storage.mjs";
 
 import {
-  decodeCursorJWT, readCursorAuthJsonCredentials,
-  readCursorStateDbCredentials, isCursorAgentAvailable,
-} from "./oauth-pool-refresh.mjs";
-
-import {
-  generatePKCE, generateState, makeEmailPrompt, saveAccountAndInject,
-  resolveEmailFromJWTClaims, resolveEmailFromEndpoint,
-  extractOpenAIAccountId, acquireAuthCode, initCallbackServerSafe,
+  generatePKCE, generateState, makeEmailPrompt, initCallbackServerSafe,
 } from "./oauth-pool-callback.mjs";
 
 import {
-  injectPoolToken, injectOpenAIPoolToken,
-  injectCursorPoolToken, injectGooglePoolToken,
-} from "./oauth-pool.mjs";
-
-import { OPENAI_ISSUER } from "./oauth-pool-constants.mjs";
-
-// ---------------------------------------------------------------------------
-// Anthropic email resolution
-// ---------------------------------------------------------------------------
-
-async function resolveAnthropicEmail(accessToken) {
-  for (const endpoint of [
-    "https://console.anthropic.com/api/auth/user",
-    "https://api.anthropic.com/api/auth/user",
-  ]) {
-    const email = await resolveEmailFromEndpoint(
-      accessToken, endpoint,
-      { "User-Agent": ANTHROPIC_USER_AGENT },
-      ["email", "email_address", "user.email", "account.email"],
-    );
-    if (email) {
-      console.error(`[aidevops] OAuth pool: resolved email ${email} from ${endpoint}`);
-      return email;
-    }
-  }
-  console.error("[aidevops] OAuth pool: could not resolve email from profile API");
-  return null;
-}
-
-// ---------------------------------------------------------------------------
-// Provider callback handlers
-// ---------------------------------------------------------------------------
-
-async function handleAnthropicCallback(code, pkce, expectedState, email, client) {
-  const hashIdx = code.indexOf("#");
-  const authCode = hashIdx >= 0 ? code.substring(0, hashIdx) : code;
-  const returnedState = hashIdx >= 0 ? code.substring(hashIdx + 1) : undefined;
-  // Validate state when present. In manual code-paste flows the user may paste
-  // only the authorization code without the state fragment, so we accept absent
-  // state rather than failing valid flows. When state IS returned it must match.
-  if (returnedState !== undefined && returnedState !== expectedState) {
-    console.error("[aidevops] OAuth pool: Anthropic state mismatch — possible CSRF");
-    return { type: "failed" };
-  }
-  const result = await fetchTokenEndpoint(
-    JSON.stringify({
-      code: authCode, state: returnedState, grant_type: "authorization_code",
-      client_id: ANTHROPIC_CLIENT_ID, redirect_uri: ANTHROPIC_REDIRECT_URI,
-      code_verifier: pkce.verifier,
-    }),
-    "token exchange",
-  );
-  if (!result.ok) return { type: "failed" };
-  const json = await result.json();
-  let resolvedEmail = email;
-  if (resolvedEmail === "unknown" && json.access_token) {
-    resolvedEmail = (await resolveAnthropicEmail(json.access_token)) || "unknown";
-  }
-  return saveAccountAndInject({
-    provider: "anthropic", client, email: resolvedEmail,
-    tokenData: { refresh: json.refresh_token, access: json.access_token, expires: Date.now() + json.expires_in * 1000 },
-    envKey: "ANTHROPIC_API_KEY", authId: "anthropic", injectFn: injectPoolToken,
-  });
-}
-
-async function handleOpenAICallback(code, pkce, email, callbackState, client) {
-  const authCode = await acquireAuthCode(code, callbackState);
-  if (!authCode) return { type: "failed" };
-  const cleanCode = authCode.split(/[&#?]/)[0];
-  const params = new URLSearchParams({
-    grant_type: "authorization_code", code: cleanCode,
-    redirect_uri: OPENAI_REDIRECT_URI, client_id: OPENAI_CLIENT_ID,
-    code_verifier: pkce.verifier,
-  });
-  const result = await fetchOpenAITokenEndpoint(params, "token exchange");
-  if (!result.ok) return { type: "failed" };
-  const json = await result.json();
-  let resolvedEmail = email;
-  let accountId = "";
-  if (json.access_token) {
-    accountId = extractOpenAIAccountId(json.access_token);
-    if (resolvedEmail === "unknown") resolvedEmail = resolveEmailFromJWTClaims(json.access_token) || "unknown";
-    if (resolvedEmail === "unknown") {
-      resolvedEmail = (await resolveEmailFromEndpoint(
-        json.access_token, `${OPENAI_ISSUER}/userinfo`, { "User-Agent": OPENCODE_USER_AGENT },
-      )) || "unknown";
-      if (resolvedEmail !== "unknown") console.error(`[aidevops] OAuth pool: resolved OpenAI email ${resolvedEmail}`);
-    }
-  }
-  return saveAccountAndInject({
-    provider: "openai", client, email: resolvedEmail,
-    tokenData: { refresh: json.refresh_token || "", access: json.access_token, expires: Date.now() + (json.expires_in || 3600) * 1000 },
-    extras: { accountId }, envKey: "OPENAI_API_KEY", authId: "openai", injectFn: injectOpenAIPoolToken,
-  });
-}
-
-async function handleCursorAuthorize(email, client) {
-  let creds = readCursorAuthJsonCredentials(email);
-  if (creds) console.error("[aidevops] OAuth pool: found Cursor credentials in auth.json");
-  if (!creds) {
-    creds = readCursorStateDbCredentials(email);
-    if (creds) console.error("[aidevops] OAuth pool: found Cursor credentials in state DB");
-  }
-  if (!creds) {
-    if (!isCursorAgentAvailable()) {
-      console.error("[aidevops] OAuth pool: cursor-agent not found");
-      return { type: "failed" };
-    }
-    console.error("[aidevops] OAuth pool: running cursor-agent login...");
-    try {
-      execSync("cursor-agent login", { encoding: "utf-8", timeout: 120_000, stdio: ["inherit", "pipe", "pipe"] });
-      creds = readCursorAuthJsonCredentials(email);
-    } catch (err) {
-      console.error(`[aidevops] OAuth pool: cursor-agent login failed: ${err.message}`);
-      return { type: "failed" };
-    }
-  }
-  if (!creds) {
-    console.error("[aidevops] OAuth pool: no Cursor access token obtained");
-    return { type: "failed" };
-  }
-  const resolvedEmail = (email === "unknown" && creds.email) ? creds.email : email;
-  const tokenInfo = decodeCursorJWT(creds.access);
-  return saveAccountAndInject({
-    provider: "cursor", client, email: resolvedEmail,
-    tokenData: { refresh: creds.refresh || "", access: creds.access, expires: tokenInfo.expiresAt || (Date.now() + 3600_000) },
-    injectFn: injectCursorPoolToken, successExtras: { key: "cursor-pool" },
-  });
-}
-
-// NOTE: expectedState cannot be validated in this flow. GOOGLE_REDIRECT_URI is
-// the OOB (urn:ietf:wg:oauth:2.0:oob) redirect, which causes Google to display
-// the authorization code directly in the browser page rather than performing an
-// HTTP redirect. Because there is no redirect, the state nonce is never returned
-// to our process. We still include state in the authorize URL to prevent
-// redirect-level CSRF; the absence of callback-side validation is an inherent
-// limitation of the OOB grant type, not a fixable bug in this code.
-// eslint-disable-next-line no-unused-vars
-async function handleGoogleCallback(code, pkce, expectedState, email, client) {
-  const authCode = code?.trim();
-  if (!authCode || authCode.length < 5) return { type: "failed" };
-  const result = await fetchGoogleTokenEndpoint(
-    JSON.stringify({
-      code: authCode, grant_type: "authorization_code",
-      client_id: GOOGLE_CLIENT_ID, redirect_uri: GOOGLE_REDIRECT_URI,
-      code_verifier: pkce.verifier,
-    }),
-    "Google token exchange",
-  );
-  if (!result.ok) return { type: "failed" };
-  const json = await result.json();
-  let resolvedEmail = email;
-  if (json.id_token && resolvedEmail === "unknown") {
-    resolvedEmail = resolveEmailFromJWTClaims(json.id_token) || "unknown";
-    if (resolvedEmail !== "unknown") console.error(`[aidevops] OAuth pool: resolved Google email ${resolvedEmail} from ID token`);
-  }
-  if (resolvedEmail === "unknown" && json.access_token) {
-    resolvedEmail = (await resolveEmailFromEndpoint(json.access_token, "https://www.googleapis.com/oauth2/v3/userinfo")) || "unknown";
-    if (resolvedEmail !== "unknown") console.error(`[aidevops] OAuth pool: resolved Google email ${resolvedEmail}`);
-  }
-  return saveAccountAndInject({
-    provider: "google", client, email: resolvedEmail,
-    tokenData: { refresh: json.refresh_token || "", access: json.access_token, expires: Date.now() + (json.expires_in || 3600) * 1000 },
-    envKey: "GOOGLE_OAUTH_ACCESS_TOKEN", injectFn: injectGooglePoolToken,
-  });
-}
+  handleAnthropicCallback, handleOpenAICallback,
+  handleCursorAuthorize, handleGoogleCallback,
+} from "./oauth-pool-auth-handlers.mjs";
 
 // ---------------------------------------------------------------------------
 // Auth hooks (thin wrappers)

--- a/.agents/plugins/opencode-aidevops/tests/test-oauth-pool-auth-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-oauth-pool-auth-hooks.mjs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createPoolAuthHook, createOpenAIPoolAuthHook,
+  createCursorPoolAuthHook, createGooglePoolAuthHook,
+} from "../oauth-pool-auth.mjs";
+
+test("pool auth hooks preserve provider and method metadata", () => {
+  const hooks = [
+    [createPoolAuthHook({}), "anthropic-pool", "oauth"],
+    [createOpenAIPoolAuthHook({}), "openai-pool", "oauth"],
+    [createCursorPoolAuthHook({}), "cursor-pool", "api"],
+    [createGooglePoolAuthHook({}), "google-pool", "oauth"],
+  ];
+
+  for (const [hook, provider, type] of hooks) {
+    assert.equal(hook.provider, provider);
+    assert.equal(hook.methods.length, 1);
+    assert.equal(hook.methods[0].type, type);
+    assert.equal(hook.methods[0].prompts[0].key, "email");
+    assert.equal(typeof hook.methods[0].authorize, "function");
+  }
+});
+
+test("Anthropic authorization keeps PKCE and state callback wiring", async () => {
+  const method = createPoolAuthHook({}).methods[0];
+  const authorization = await method.authorize({ email: "account@example.test" });
+  const url = new URL(authorization.url);
+
+  assert.equal(url.searchParams.get("code"), "true");
+  assert.equal(url.searchParams.get("response_type"), "code");
+  assert.equal(url.searchParams.get("code_challenge_method"), "S256");
+  assert.ok(url.searchParams.get("code_challenge"));
+  assert.ok(url.searchParams.get("state"));
+  assert.match(authorization.instructions, /account@example\.test/);
+  assert.equal(authorization.method, "code");
+  assert.equal(typeof authorization.callback, "function");
+});
+
+test("Google authorization keeps offline consent and callback wiring", async () => {
+  const method = createGooglePoolAuthHook({}).methods[0];
+  const authorization = await method.authorize({ email: "account@example.test" });
+  const url = new URL(authorization.url);
+
+  assert.equal(url.searchParams.get("response_type"), "code");
+  assert.equal(url.searchParams.get("code_challenge_method"), "S256");
+  assert.equal(url.searchParams.get("access_type"), "offline");
+  assert.equal(url.searchParams.get("prompt"), "consent");
+  assert.ok(url.searchParams.get("code_challenge"));
+  assert.ok(url.searchParams.get("state"));
+  assert.equal(authorization.method, "code");
+  assert.equal(typeof authorization.callback, "function");
+});


### PR DESCRIPTION
## Summary

Separate provider callback handlers from OAuth hook descriptors to remove the target file-complexity smell while preserving the public auth surface.

## Files Changed

.agents/plugins/opencode-aidevops/oauth-pool-auth-handlers.mjs, .agents/plugins/opencode-aidevops/oauth-pool-auth.mjs, .agents/plugins/opencode-aidevops/tests/test-oauth-pool-auth-hooks.mjs

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Node syntax and facade import checks pass; OpenCode plugin suite passes 512/512; Qlty reports zero smells on all changed modules.

## Complexity Bump Justification

This behavior-preserving split removes the cited finding from `oauth-pool-auth.mjs`. Isolated base/head scans with Qlty 0.631.0 reduce repository smells from 66 to 65 and `qlty:file-complexity` findings from 44 to 43; both new files report zero smells. The `ratchet-bump` label records the split evidence while the absolute-threshold failure (65 actual vs 49 threshold) remains pre-existing repository debt. No threshold is raised and no PR-specific smell is introduced.

Resolves #29208


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 10m and 136,355 tokens on this as a headless worker.
