### PR TITLE
GH#29209: reduce OAuth pool display complexity

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool-display.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-display.mjs
@@ -1,9 +1,9 @@
 /**
  * OAuth Pool — Display Formatting & Action Handlers (t2128)
  *
- * Status formatting helpers, token validity checks, and individual
- * pool tool action handlers. Extracted from oauth-pool-tool.mjs
- * for complexity reduction.
+ * Individual pool tool action handlers. Health-check formatting and token
+ * validity checks live in oauth-pool-health-check.mjs and are re-exported here
+ * to preserve the original public API.
  *
  * @module oauth-pool-display
  */
@@ -13,87 +13,11 @@ import {
   withPoolLock, loadPool, savePool, getPoolFilePath,
 } from "./oauth-pool-storage.mjs";
 import {
-  ANTHROPIC_USER_AGENT, OPENCODE_USER_AGENT,
-} from "./oauth-pool-token-endpoint.mjs";
-import {
   getEndpointCooldownValue, resetEndpointCooldown,
 } from "./oauth-pool-token-endpoint.mjs";
-import { GOOGLE_HEALTH_CHECK_URL } from "./oauth-pool-constants.mjs";
-
-// ---------------------------------------------------------------------------
-// Display formatting helpers
-// ---------------------------------------------------------------------------
-
-export function formatDuration(ms) {
-  const mins = Math.floor(ms / 60000);
-  const hours = Math.floor(mins / 60);
-  return hours > 0 ? `${hours}h ${mins % 60}m` : `${mins}m`;
-}
-
-export function formatAgo(ms) {
-  const mins = Math.floor(ms / 60000);
-  const hours = Math.floor(mins / 60);
-  return hours > 0 ? `${hours}h ${mins % 60}m ago` : `${mins}m ago`;
-}
-
-function interpretValidityStatus(status, okOn403, on403msg) {
-  if (status === 401) return "INVALID (401 -- needs refresh)";
-  if (status === 403 && okOn403) return on403msg || "OK";
-  if (status >= 200 && status < 300) return "OK";
-  return `HTTP ${status}`;
-}
-
-async function checkAccountTokenValidity(prov, account) {
-  try {
-    if (prov === "anthropic") {
-      const r = await fetch("https://api.anthropic.com/v1/models", {
-        method: "GET",
-        headers: {
-          "Authorization": `Bearer ${account.access}`,
-          "User-Agent": ANTHROPIC_USER_AGENT,
-          "anthropic-version": "2023-06-01",
-          "anthropic-beta": "oauth-2025-04-20",
-        },
-      });
-      return interpretValidityStatus(r.status, true);
-    }
-    if (prov === "openai") {
-      const r = await fetch("https://api.openai.com/v1/models", {
-        headers: { "Authorization": `Bearer ${account.access}`, "User-Agent": OPENCODE_USER_AGENT },
-      });
-      return interpretValidityStatus(r.status, false);
-    }
-    if (prov === "google") {
-      const r = await fetch(GOOGLE_HEALTH_CHECK_URL, {
-        headers: { "Authorization": `Bearer ${account.access}` },
-      });
-      return interpretValidityStatus(r.status, true, "OK (403 -- token valid, check AI Pro/Ultra subscription)");
-    }
-    return `(skipped -- ${prov} uses proxy)`;
-  } catch (err) { return `ERROR (${err.code || err.message})`; }
-}
-
-async function formatAccountCheckLines(prov, account, now) {
-  const lines = [`  ${account.email}:`];
-  const expiresIn = account.expires - now;
-  lines.push(expiresIn <= 0
-    ? `    Token: EXPIRED (${new Date(account.expires).toLocaleString()})`
-    : `    Token: expires in ${formatDuration(expiresIn)}`);
-  lines.push(`    Status: ${account.status}`);
-  if (account.cooldownUntil && account.cooldownUntil > now) {
-    lines.push(`    Cooldown: ${Math.ceil((account.cooldownUntil - now) / 60000)}m remaining`);
-  }
-  if (account.lastUsed) lines.push(`    Last used: ${formatAgo(now - new Date(account.lastUsed).getTime())}`);
-  lines.push(`    Refresh token: ${account.refresh ? "present" : "MISSING"}`);
-  if (account.access && expiresIn > 0) {
-    lines.push(`    Validity: ${await checkAccountTokenValidity(prov, account)}`);
-  } else if (expiresIn <= 0) {
-    lines.push(`    Validity: EXPIRED -- will auto-refresh on next use`);
-  } else {
-    lines.push(`    Validity: no access token`);
-  }
-  return lines.join("\n");
-}
+export {
+  formatDuration, formatAgo, poolActionCheck,
+} from "./oauth-pool-health-check.mjs";
 
 // ---------------------------------------------------------------------------
 // Pool tool action handlers
@@ -205,24 +129,4 @@ export function poolActionSetPriority(provider, email, priority) {
       ? `Cleared priority for ${email} (defaults to LRU order).`
       : `Set priority ${p} for ${email}. Higher-priority accounts preferred during rotation.`;
   });
-}
-
-export async function poolActionCheck(providerArg, now) {
-  const provs = providerArg ? [providerArg] : ["anthropic", "openai", "cursor", "google"];
-  const results = [];
-  for (const prov of provs) {
-    const accts = getAccounts(prov);
-    if (accts.length === 0) continue;
-    results.push(`\n## ${prov} (${accts.length} account${accts.length === 1 ? "" : "s"})`);
-    for (const a of accts) results.push(await formatAccountCheckLines(prov, a, now));
-    const epCd = getEndpointCooldownValue(prov);
-    results.push(epCd > now
-      ? `  Token endpoint: RATE LIMITED (${Math.ceil((epCd - now) / 60000)}m remaining)`
-      : `  Token endpoint: OK`);
-    const pending = getPendingToken(prov);
-    if (pending) results.push(`  PENDING: Unassigned token (added: ${pending.added})`);
-  }
-  return results.length === 0
-    ? `No accounts in any pool.\n\nTo add: run \`opencode auth login\` (Ctrl+A), select a pool provider, enter email, complete OAuth, then switch to the main provider.`
-    : `OAuth Pool Health Check${results.join("\n")}`;
 }

--- a/.agents/plugins/opencode-aidevops/oauth-pool-health-check.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-health-check.mjs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/**
+ * OAuth Pool — Health Check Formatting
+ *
+ * Formats account health details and checks provider access-token validity.
+ * Pool management action handlers remain in oauth-pool-display.mjs.
+ *
+ * @module oauth-pool-health-check
+ */
+
+import { getAccounts, getPendingToken } from "./oauth-pool-storage.mjs";
+import {
+  ANTHROPIC_USER_AGENT, OPENCODE_USER_AGENT,
+  getEndpointCooldownValue,
+} from "./oauth-pool-token-endpoint.mjs";
+import { GOOGLE_HEALTH_CHECK_URL } from "./oauth-pool-constants.mjs";
+
+export function formatDuration(ms) {
+  const mins = Math.floor(ms / 60000);
+  const hours = Math.floor(mins / 60);
+  return hours > 0 ? `${hours}h ${mins % 60}m` : `${mins}m`;
+}
+
+export function formatAgo(ms) {
+  const mins = Math.floor(ms / 60000);
+  const hours = Math.floor(mins / 60);
+  return hours > 0 ? `${hours}h ${mins % 60}m ago` : `${mins}m ago`;
+}
+
+function interpretValidityStatus(status, okOn403, on403msg) {
+  if (status === 401) return "INVALID (401 -- needs refresh)";
+  if (status === 403 && okOn403) return on403msg || "OK";
+  if (status >= 200 && status < 300) return "OK";
+  return `HTTP ${status}`;
+}
+
+async function checkAccountTokenValidity(prov, account) {
+  try {
+    if (prov === "anthropic") {
+      const r = await fetch("https://api.anthropic.com/v1/models", {
+        method: "GET",
+        headers: {
+          "Authorization": `Bearer ${account.access}`,
+          "User-Agent": ANTHROPIC_USER_AGENT,
+          "anthropic-version": "2023-06-01",
+          "anthropic-beta": "oauth-2025-04-20",
+        },
+      });
+      return interpretValidityStatus(r.status, true);
+    }
+    if (prov === "openai") {
+      const r = await fetch("https://api.openai.com/v1/models", {
+        headers: { "Authorization": `Bearer ${account.access}`, "User-Agent": OPENCODE_USER_AGENT },
+      });
+      return interpretValidityStatus(r.status, false);
+    }
+    if (prov === "google") {
+      const r = await fetch(GOOGLE_HEALTH_CHECK_URL, {
+        headers: { "Authorization": `Bearer ${account.access}` },
+      });
+      return interpretValidityStatus(r.status, true, "OK (403 -- token valid, check AI Pro/Ultra subscription)");
+    }
+    return `(skipped -- ${prov} uses proxy)`;
+  } catch (err) { return `ERROR (${err.code || err.message})`; }
+}
+
+async function formatAccountCheckLines(prov, account, now) {
+  const lines = [`  ${account.email}:`];
+  const expiresIn = account.expires - now;
+  lines.push(expiresIn <= 0
+    ? `    Token: EXPIRED (${new Date(account.expires).toLocaleString()})`
+    : `    Token: expires in ${formatDuration(expiresIn)}`);
+  lines.push(`    Status: ${account.status}`);
+  if (account.cooldownUntil && account.cooldownUntil > now) {
+    lines.push(`    Cooldown: ${Math.ceil((account.cooldownUntil - now) / 60000)}m remaining`);
+  }
+  if (account.lastUsed) lines.push(`    Last used: ${formatAgo(now - new Date(account.lastUsed).getTime())}`);
+  lines.push(`    Refresh token: ${account.refresh ? "present" : "MISSING"}`);
+  if (account.access && expiresIn > 0) {
+    lines.push(`    Validity: ${await checkAccountTokenValidity(prov, account)}`);
+  } else if (expiresIn <= 0) {
+    lines.push(`    Validity: EXPIRED -- will auto-refresh on next use`);
+  } else {
+    lines.push(`    Validity: no access token`);
+  }
+  return lines.join("\n");
+}
+
+export async function poolActionCheck(providerArg, now) {
+  const provs = providerArg ? [providerArg] : ["anthropic", "openai", "cursor", "google"];
+  const results = [];
+  for (const prov of provs) {
+    const accts = getAccounts(prov);
+    if (accts.length === 0) continue;
+    results.push(`\n## ${prov} (${accts.length} account${accts.length === 1 ? "" : "s"})`);
+    for (const a of accts) results.push(await formatAccountCheckLines(prov, a, now));
+    const epCd = getEndpointCooldownValue(prov);
+    results.push(epCd > now
+      ? `  Token endpoint: RATE LIMITED (${Math.ceil((epCd - now) / 60000)}m remaining)`
+      : `  Token endpoint: OK`);
+    const pending = getPendingToken(prov);
+    if (pending) results.push(`  PENDING: Unassigned token (added: ${pending.added})`);
+  }
+  return results.length === 0
+    ? `No accounts in any pool.\n\nTo add: run \`opencode auth login\` (Ctrl+A), select a pool provider, enter email, complete OAuth, then switch to the main provider.`
+    : `OAuth Pool Health Check${results.join("\n")}`;
+}

--- a/.agents/plugins/opencode-aidevops/tests/test-oauth-pool-display.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-oauth-pool-display.mjs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  formatDuration, formatAgo, poolActionCheck,
+} from "../oauth-pool-display.mjs";
+import { poolActionCheck as healthCheckAction } from "../oauth-pool-health-check.mjs";
+
+test("display formatting keeps minute and hour output", () => {
+  assert.equal(formatDuration(59_999), "0m");
+  assert.equal(formatDuration(3_900_000), "1h 5m");
+  assert.equal(formatAgo(3_900_000), "1h 5m ago");
+});
+
+test("display module preserves the health-check action export", () => {
+  assert.equal(poolActionCheck, healthCheckAction);
+});


### PR DESCRIPTION
## Summary

Separate OAuth pool health-check formatting and token validity logic from pool management actions to remove the target file-complexity smell while preserving the public display-module surface.

## Files Changed

- `.agents/plugins/opencode-aidevops/oauth-pool-display.mjs`
- `.agents/plugins/opencode-aidevops/oauth-pool-health-check.mjs`
- `.agents/plugins/opencode-aidevops/tests/test-oauth-pool-display.mjs`

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Node syntax checks pass; the OpenCode plugin suite passes 515/515; changed-file linters pass; the focused display tests pass 2/2; Qlty reports zero smells on all changed files.

## Complexity Bump Justification

This behavior-preserving split removes the cited finding from `oauth-pool-display.mjs`. Isolated base/head scans with Qlty 0.631.0 reduce repository smells from 65 to 64 and `qlty:file-complexity` findings from 43 to 42; the new source file reports zero smells. The `ratchet-bump` label records the split evidence while the absolute-threshold failure remains pre-existing repository debt. No threshold is raised and no PR-specific smell is introduced.

Resolves #29209

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 9m and 141,690 tokens on this as a headless worker.
