### PR TITLE
GH#29214: Deduplicate Forem identity validation

### DIFF
--- a/.agents/scripts/_knowledge_social_forem_identity.py
+++ b/.agents/scripts/_knowledge_social_forem_identity.py
@@ -25,11 +25,20 @@ class ForemProviderUnavailableError(ForemAdapterError):
     """Raised when the bounded Forem HTTP child cannot complete a read."""
 
 
+def _validated_text(value: Any, pattern: re.Pattern[str], message: str) -> str:
+    """Return text matching an allowlist or raise the adapter error."""
+    if not isinstance(value, str) or pattern.fullmatch(value) is None:
+        raise ForemAdapterError(message)
+    return value
+
+
 def instance_id(value: Any) -> str:
     """Validate a privacy-safe stable installation fingerprint."""
-    if not isinstance(value, str) or INSTANCE_ID.fullmatch(value) is None:
-        raise ForemAdapterError("Forem installation identity is invalid")
-    return value
+    return _validated_text(
+        value,
+        INSTANCE_ID,
+        "Forem installation identity is invalid",
+    )
 
 
 def provider_account_id(value: Any) -> str:
@@ -37,16 +46,12 @@ def provider_account_id(value: Any) -> str:
     text = str(value) if isinstance(value, int) and not isinstance(value, bool) else value
     if isinstance(text, str) and text.startswith("user_"):
         text = text.removeprefix("user_")
-    if not isinstance(text, str) or PROVIDER_ACCOUNT_ID.fullmatch(text) is None:
-        raise ForemAdapterError("Forem account ID is invalid")
-    return text
+    return _validated_text(text, PROVIDER_ACCOUNT_ID, "Forem account ID is invalid")
 
 
 def username(value: Any) -> str:
     """Validate the selected Forem username returned by authenticated identity."""
-    if not isinstance(value, str) or USERNAME.fullmatch(value) is None:
-        raise ForemAdapterError("Forem account username is invalid")
-    return value
+    return _validated_text(value, USERNAME, "Forem account username is invalid")
 
 
 def namespaced_id(installation: str, kind: str, value: str) -> str:
@@ -54,6 +59,5 @@ def namespaced_id(installation: str, kind: str, value: str) -> str:
     stable_instance = instance_id(installation)
     if RESOURCE_KIND.fullmatch(kind) is None:
         raise ForemAdapterError("Forem resource kind is invalid")
-    if not isinstance(value, str) or RESOURCE_ID.fullmatch(value) is None:
-        raise ForemAdapterError("Forem resource ID is invalid")
-    return f"frm_{stable_instance}_{kind}_{value}"
+    stable_value = _validated_text(value, RESOURCE_ID, "Forem resource ID is invalid")
+    return f"frm_{stable_instance}_{kind}_{stable_value}"

--- a/.agents/tests/test-knowledge-social-forem.sh
+++ b/.agents/tests/test-knowledge-social-forem.sh
@@ -165,6 +165,12 @@ from _knowledge_social_forem_http import (
     api,
     installation_fingerprint,
 )
+from _knowledge_social_forem_identity import (
+    ForemAdapterError,
+    instance_id,
+    provider_account_id,
+    username,
+)
 from _knowledge_social_forem_provider import _dispatch, _profile
 from _knowledge_social_forem_normalize import PageContext, normalize_page
 from _knowledge_social_forem_routes import EXACT_READ_PATHS, allowlisted_path, page
@@ -190,9 +196,25 @@ instance_a = installation_fingerprint(base_a, "a" * 32)
 instance_b = installation_fingerprint(base_b, "b" * 32)
 assert base_a == "https://forem-a.example.invalid/community"
 assert instance_a != instance_b
+assert instance_id(instance_a) == instance_a
+assert provider_account_id(42) == "42"
+assert provider_account_id("user_42") == "42"
+assert username("selected-user") == "selected-user"
+assert namespaced_id(instance_a, "user", "42") == f"frm_{instance_a}_user_42"
 assert namespaced_id(instance_a, "user", "42") != namespaced_id(
     instance_b, "user", "42"
 )
+for validator, rejected in (
+    (instance_id, "a" * 23),
+    (provider_account_id, True),
+    (username, "selected user"),
+):
+    try:
+        validator(rejected)
+    except ForemAdapterError:
+        pass
+    else:
+        raise AssertionError("unsafe Forem identity value was accepted")
 for invalid in (
     "http://forem.example.invalid",
     "https://user@forem.example.invalid",


### PR DESCRIPTION
## Summary

Centralize Forem allowlist checks behind a private validator while preserving the existing identity API and error behavior; add focused valid and rejected identity coverage.

## Files Changed

.agents/scripts/_knowledge_social_forem_identity.py, .agents/tests/test-knowledge-social-forem.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Qlty 0.636.0 reports zero smells for the target; Python 3.14.3 byte-compilation, bash syntax, ShellCheck, and the focused Forem suite pass (31/31).

Resolves #29214


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 7m and 108,133 tokens on this as a headless worker.