### PR TITLE
GH#29219: keep stall reviews out of complexity metrics

### DIFF
--- a/.agents/scripts/migrate-simplification-debt-labels.sh
+++ b/.agents/scripts/migrate-simplification-debt-labels.sh
@@ -12,7 +12,7 @@
 #   Title matches "simplification: reduce function ..."     → function-complexity-debt
 #   Title matches "simplification: re-queue ..."            → function-complexity-debt
 #   Title matches "reduce N Qlty smells"                    → function-complexity-debt
-#   Title matches "LLM complexity sweep"                    → function-complexity-debt
+#   Title matches an LLM stall/sweep review                  → skip (meta work)
 #   Otherwise                                               → skip (manual triage)
 #
 # Idempotent: issues that already have the new label are skipped.
@@ -121,11 +121,13 @@ _classify_title() {
 		return 0
 	fi
 
-	# LLM sweep issues
+	# LLM sweep issues are meta reviews, not measured function violations.
+	# Classifying them as function-complexity-debt inflates the open count and
+	# makes closing a review look like real simplification throughput.
 	# Format: "perf: simplification debt stalled — LLM sweep needed ..."
 	# Format: "LLM complexity sweep: ..."
 	if printf '%s' "$title" | grep -qiE '(simplification debt stalled|LLM complexity sweep|LLM sweep needed)'; then
-		printf 'function-complexity-debt'
+		printf 'skip'
 		return 0
 	fi
 

--- a/.agents/scripts/pulse-simplification-orchestration.sh
+++ b/.agents/scripts/pulse-simplification-orchestration.sh
@@ -447,18 +447,21 @@ _complexity_scan_sweep_check() {
 	sweep_result=$("$scan_helper" sweep-check "$aidevops_slug" 2>>"$LOGFILE") || sweep_result=""
 	if [[ "$sweep_result" == needed* ]]; then
 		echo "[pulse-wrapper] LLM sweep triggered: ${sweep_result}" >>"$LOGFILE"
-		# Create a one-off issue for the LLM sweep if none exists (t1855: check both title patterns)
+		# Create a one-off issue for the LLM sweep if none exists (t1855: check
+		# both title patterns). Sweep reviews are meta work and intentionally do
+		# not carry function-complexity-debt, so dedup by title rather than label.
 		local sweep_issue_exists
 		sweep_issue_exists=$(gh_issue_list --repo "$aidevops_slug" \
-			--label "function-complexity-debt" --state open \
+			--state open \
 			--search "in:title \"simplification debt stalled\" OR in:title \"LLM complexity sweep\"" \
 			--json number --jq 'length' 2>/dev/null) || sweep_issue_exists="0"
+		[[ "$sweep_issue_exists" =~ ^[0-9]+$ ]] || sweep_issue_exists="0"
 		if [[ "${sweep_issue_exists:-0}" -eq 0 ]]; then
 			local sweep_reason
 			sweep_reason=$(echo "$sweep_result" | cut -d'|' -f2)
 			gh_create_issue --repo "$aidevops_slug" \
 				--title "LLM complexity sweep: review stalled function-complexity debt" \
-				--label "function-complexity-debt" --label "auto-dispatch" --label "tier:thinking" --label "worker-ready" \
+				--label "quality-debt" --label "auto-dispatch" --label "tier:thinking" --label "worker-ready" \
 				--body "## Daily LLM sweep (automated, GH#15285)
 
 **Trigger:** ${sweep_reason}
@@ -469,6 +472,7 @@ The deterministic complexity scan detected that function-complexity debt has not
 2. Re-prioritize the backlog based on actual impact
 3. Close issues that are no longer relevant (files deleted, already simplified)
 4. Suggest new decomposition strategies for stuck files
+5. Check pulse logs for \`local_capacity_gate\`; if present, verify worktree cleanup is live and reducing the affected repo below \`AIDEVOPS_MAX_WORKTREES\` before changing safety caps
 
 ### Scope
 

--- a/.agents/scripts/pulse-simplification-scan.sh
+++ b/.agents/scripts/pulse-simplification-scan.sh
@@ -264,12 +264,15 @@ _complexity_run_llm_sweep() {
 	local maintainer="$3"
 
 	# Dedup: check if an open sweep issue already exists (t1855).
-	# Both sweep code paths use different title patterns — check both.
+	# Both sweep code paths use different title patterns — check both. Stall
+	# reviews deliberately do not carry function-complexity-debt because they
+	# are meta work, so title-based dedup must not depend on that label.
 	local sweep_exists
 	sweep_exists=$(gh_issue_list --repo "$aidevops_slug" \
-		--label "function-complexity-debt" --state open \
-		--search "in:title \"simplification debt stalled\"" \
+		--state open \
+		--search "in:title \"simplification debt stalled\" OR in:title \"LLM complexity sweep\"" \
 		--json number --jq 'length' 2>/dev/null) || sweep_exists="0"
+	[[ "$sweep_exists" =~ ^[0-9]+$ ]] || sweep_exists="0"
 	if [[ "${sweep_exists:-0}" -gt 0 ]]; then
 		echo "[pulse-wrapper] Complexity LLM sweep: skipping — open stall issue already exists" >>"$LOGFILE"
 		printf '%s\n' "$now_epoch" >"$COMPLEXITY_LLM_SWEEP_LAST_RUN"
@@ -292,13 +295,14 @@ The simplification debt count has not decreased in the last $((${COMPLEXITY_LLM_
 
 1. Are the open function-complexity-debt issues actionable? Check for issues that are blocked, stale, or need maintainer review.
 2. Are workers dispatching on function-complexity-debt issues? Check recent pulse logs for dispatch activity.
-3. Is the open cap (500) being hit? If so, consider raising it or closing stale issues.
+3. Is the open debt cap (500) or the local worktree cap (\`AIDEVOPS_MAX_WORKTREES\`, default 200) being hit? Check pulse logs for \`local_capacity_gate\` and verify cleanup liveness before changing either safety cap.
 4. Are there systemic blockers (e.g., all remaining issues require architectural decisions)?
 
 ### Suggested actions
 
 - Review the oldest 10 open function-complexity-debt issues and close any that are no longer relevant.
 - Check if \`tier:simple\` and \`tier:standard\` issues are being dispatched — if not, verify the pulse is routing them correctly.
+- If dispatch reports \`local_capacity_gate\`, verify \`cleanup-worktrees-async-helper.sh\` is live and reducing the affected repo's registered worktree count; do not raise safety caps while recoverable worktrees remain.
 - If debt is growing, consider lowering \`COMPLEXITY_MD_MIN_LINES\` or \`COMPLEXITY_FILE_VIOLATION_THRESHOLD\` to catch more candidates.
 
 ### Worker Guidance
@@ -332,9 +336,12 @@ This is an automated stall-detection sweep. The LLM should review the actual iss
 	# t1955: Don't self-assign on issue creation — let dispatch_with_dedup handle
 	# assignment. Self-assigning creates a phantom claim that triggers stale recovery
 	# on other runners, producing audit trail gaps.
+	# A stall review is quality-debt meta work, not a function violation. Giving
+	# it the function-complexity-debt label would inflate the open debt count and
+	# make closing the review look like real simplification throughput.
 	if gh_create_issue --repo "$aidevops_slug" \
 		--title "perf: simplification debt stalled — LLM sweep needed ($(date -u +%Y-%m-%d))" \
-		--label "function-complexity-debt" $sweep_review_label --label "tier:thinking" --label "worker-ready" \
+		--label "quality-debt" $sweep_review_label --label "tier:thinking" --label "worker-ready" \
 		--body "$sweep_body" >/dev/null 2>&1; then
 		echo "[pulse-wrapper] Complexity LLM sweep: created stall-review issue" >>"$LOGFILE"
 	else

--- a/.agents/scripts/tests/test-migration-simplification-labels.sh
+++ b/.agents/scripts/tests/test-migration-simplification-labels.sh
@@ -133,7 +133,7 @@ _classify_title() {
 		return 0
 	fi
 	if printf '%s' "$title" | grep -qiE '(simplification debt stalled|LLM complexity sweep|LLM sweep needed)'; then
-		printf 'function-complexity-debt'
+		printf 'skip'
 		return 0
 	fi
 	printf 'skip'
@@ -144,7 +144,7 @@ _classify_title() {
 # Tests — _classify_title classification logic
 # =============================================================================
 printf '\n=== test-migration-simplification-labels.sh (t2168) ===\n\n'
-printf '--- Classification tests ---\n\n'
+printf '%s\n\n' '--- Classification tests ---'
 
 # ---- Test 1: file-size-debt — legacy "simplification-debt: <path> exceeds N lines" ----
 result=$(_classify_title "simplification-debt: .agents/scripts/issue-sync-helper.sh exceeds 2000 lines")
@@ -176,17 +176,17 @@ assert_eq \
 	"re-queue title → function-complexity-debt" \
 	"function-complexity-debt" "$result"
 
-# ---- Test 6: function-complexity-debt — LLM sweep ----
+# ---- Test 6: skip — LLM sweep meta review ----
 result=$(_classify_title "perf: simplification debt stalled — LLM sweep needed (2026-04-01)")
 assert_eq \
-	"LLM sweep stall title → function-complexity-debt" \
-	"function-complexity-debt" "$result"
+	"LLM sweep stall title → skip (meta review)" \
+	"skip" "$result"
 
-# ---- Test 7: function-complexity-debt — LLM complexity sweep ----
+# ---- Test 7: skip — LLM complexity sweep meta review ----
 result=$(_classify_title "LLM complexity sweep: review stalled function-complexity debt")
 assert_eq \
-	"LLM complexity sweep title → function-complexity-debt" \
-	"function-complexity-debt" "$result"
+	"LLM complexity sweep title → skip (meta review)" \
+	"skip" "$result"
 
 # ---- Test 8: skip — ambiguous/unmatched title ----
 result=$(_classify_title "fix: update authentication logic")

--- a/.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh
@@ -12,6 +12,7 @@
 #   - _complexity_llm_sweep_due: returns 0 when interval elapsed and debt stalled
 #   - _complexity_llm_sweep_due: tolerates an unset sweep interval under set -u
 #   - _complexity_recent_debt_closures: tolerates empty arithmetic inputs under set -u
+#   - _complexity_run_llm_sweep: creates meta reviews outside measured function debt
 #   - _complexity_scan_check_interval: returns 0 when no last-run file
 #   - _complexity_scan_check_interval: returns 1 when interval not elapsed
 
@@ -19,6 +20,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 SCAN_SCRIPT="${SCRIPT_DIR}/../pulse-simplification-scan.sh"
+ORCHESTRATION_SCRIPT="${SCRIPT_DIR}/../pulse-simplification-orchestration.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -30,6 +32,8 @@ TEST_ROOT=""
 ORIGINAL_HOME="${HOME}"
 ORIGINAL_PATH="${PATH}"
 GH_GRAPHQL_LOG=""
+GH_ISSUE_LIST_LOG=""
+GH_CREATE_ISSUE_LOG=""
 
 print_result() {
 	local test_name="$1"
@@ -58,14 +62,19 @@ setup_test_env() {
 	mkdir -p "${HOME}/.aidevops/logs"
 	LOGFILE="${HOME}/.aidevops/logs/pulse.log"
 	GH_GRAPHQL_LOG="${TEST_ROOT}/graphql.log"
+	GH_ISSUE_LIST_LOG="${TEST_ROOT}/issue-list.log"
+	GH_CREATE_ISSUE_LOG="${TEST_ROOT}/create-issue.log"
 	COMPLEXITY_SCAN_LAST_RUN="${HOME}/.aidevops/logs/complexity-scan-last-run"
 	COMPLEXITY_SCAN_INTERVAL=900
 	COMPLEXITY_SCAN_TREE_HASH_FILE="${HOME}/.aidevops/logs/complexity-scan-tree-hash"
 	COMPLEXITY_LLM_SWEEP_LAST_RUN="${HOME}/.aidevops/logs/complexity-llm-sweep-last-run"
 	COMPLEXITY_LLM_SWEEP_INTERVAL=21600
 	COMPLEXITY_DEBT_COUNT_FILE="${HOME}/.aidevops/logs/complexity-debt-count"
+	PULSE_START_EPOCH=0
 	: >"$GH_GRAPHQL_LOG"
-	export LOGFILE GH_GRAPHQL_LOG
+	: >"$GH_ISSUE_LIST_LOG"
+	: >"$GH_CREATE_ISSUE_LOG"
+	export LOGFILE GH_GRAPHQL_LOG GH_ISSUE_LIST_LOG GH_CREATE_ISSUE_LOG PULSE_START_EPOCH
 	# shellcheck source=/dev/null
 	source "$SCAN_SCRIPT"
 	return 0
@@ -87,8 +96,14 @@ _fixture_git() {
 }
 
 gh_issue_list() {
+	printf '%s\n' "$*" >>"$GH_ISSUE_LIST_LOG"
 	gh issue list "$@"
 	return $?
+}
+
+gh_create_issue() {
+	printf '%s\n' "$*" >"$GH_CREATE_ISSUE_LOG"
+	return 0
 }
 
 make_test_repo() {
@@ -318,6 +333,47 @@ test_llm_sweep_due_when_zero_recent_closures() {
 	return 0
 }
 
+test_llm_sweep_meta_review_is_not_measured_debt() {
+	install_fake_gh_for_sweep
+	: >"$GH_ISSUE_LIST_LOG"
+	: >"$GH_CREATE_ISSUE_LOG"
+	export GH_ISSUE_LIST_JSON='[]'
+	export _COMPLEXITY_SCAN_SKIP_REVIEW_GATE=true
+
+	_complexity_run_llm_sweep "test/repo" "100000" "maintainer"
+
+	local list_args create_args
+	list_args=$(<"$GH_ISSUE_LIST_LOG")
+	create_args=$(<"$GH_CREATE_ISSUE_LOG")
+	if [[ "$list_args" == *'in:title "simplification debt stalled" OR in:title "LLM complexity sweep"'* ]] \
+		&& [[ "$list_args" != *'--label function-complexity-debt'* ]] \
+		&& [[ "$create_args" == *'--label quality-debt'* ]] \
+		&& [[ "$create_args" != *'--label function-complexity-debt'* ]] \
+		&& [[ "$create_args" == *'local_capacity_gate'* ]]; then
+		print_result "_complexity_run_llm_sweep: meta review stays outside measured debt" 0
+	else
+		print_result "_complexity_run_llm_sweep: meta review stays outside measured debt" 1 \
+			"list=${list_args}; create=${create_args}"
+	fi
+	unset GH_ISSUE_LIST_JSON _COMPLEXITY_SCAN_SKIP_REVIEW_GATE
+	return 0
+}
+
+test_both_stall_issue_creators_use_meta_label() {
+	local old_inline_label="--label \"function-complexity-debt\" \$sweep_review_label --label \"tier:thinking\" --label \"worker-ready\""
+	local old_helper_label='--label "function-complexity-debt" --label "auto-dispatch" --label "tier:thinking" --label "worker-ready"'
+	local new_helper_label='--label "quality-debt" --label "auto-dispatch" --label "tier:thinking" --label "worker-ready"'
+
+	if ! grep -qF -- "$old_inline_label" "$SCAN_SCRIPT" \
+		&& ! grep -qF -- "$old_helper_label" "$ORCHESTRATION_SCRIPT" \
+		&& grep -qF -- "$new_helper_label" "$ORCHESTRATION_SCRIPT"; then
+		print_result "complexity stall creators label reviews as meta quality debt" 0
+	else
+		print_result "complexity stall creators label reviews as meta quality debt" 1
+	fi
+	return 0
+}
+
 test_recent_closures_defaults_empty_arithmetic_inputs() {
 	install_fake_gh_for_sweep
 	export GH_RECENT_CLOSURES=0
@@ -416,6 +472,8 @@ main() {
 	test_llm_sweep_check_interval_guard
 	test_llm_sweep_skips_when_recent_closures_exist
 	test_llm_sweep_due_when_zero_recent_closures
+	test_llm_sweep_meta_review_is_not_measured_debt
+	test_both_stall_issue_creators_use_meta_label
 	test_recent_closures_defaults_empty_arithmetic_inputs
 	test_llm_sweep_unset_interval_does_not_trip_strict_mode
 	test_check_interval_due_when_no_last_run


### PR DESCRIPTION
## Summary

- keep generated simplification-stall reviews outside the measured `function-complexity-debt` backlog
- deduplicate both stall-review title variants without relying on the removed metric label
- surface observed `local_capacity_gate` and worktree-cleanup checks in future stall-review guidance

## Files changed

- `.agents/scripts/pulse-simplification-scan.sh`
- `.agents/scripts/pulse-simplification-orchestration.sh`
- `.agents/scripts/migrate-simplification-debt-labels.sh`
- focused regression tests under `.agents/scripts/tests/`

## Testing

- `.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh` — 17 passed
- `.agents/scripts/tests/test-migration-simplification-labels.sh` — 18 passed
- ShellCheck across all five changed shell files — clean

## Runtime Testing

- **Risk level:** Low
- **Evidence:** Self-assessed with deterministic issue-creation fixtures; no production issue was created by the test path

## Key decisions

- classify a stall review as `quality-debt` meta work so its creation and closure cannot distort open-debt or recent-throughput metrics
- preserve worker dispatchability with `auto-dispatch`, `tier:thinking`, and `worker-ready`
- retain fail-closed worktree capacity limits and improve diagnosis instead of raising safety caps

Resolves #29219

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 18m and 269,990 tokens on this as a headless worker.