### PR TITLE
GH#29262: Eliminate residual Pulse quota unknowns

### DIFF
--- a/.agents/scripts/pr-supersession-helper.sh
+++ b/.agents/scripts/pr-supersession-helper.sh
@@ -302,32 +302,62 @@ _psh_find_merged_closer_for_closed_issue() {
 	local repo_slug="$1"
 	local issue_number="$2"
 	local current_pr="$3"
+	local owner="${repo_slug%%/*}"
+	local name="${repo_slug#*/}"
+	local response=""
+	local reported_cost=""
+	local closer_number=""
 
 	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 1
 	[[ "$current_pr" =~ ^[0-9]+$ ]] || return 1
+	[[ "$repo_slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || return 1
+	[[ -n "$owner" && -n "$name" ]] || return 1
 
-	local issue_json issue_state closer_numbers closer_number pr_state merged_at
-	issue_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
-		--json state,closedByPullRequestsReferences 2>/dev/null) || return 1
-	issue_state=$(printf '%s' "$issue_json" | jq -r '.state // empty' 2>/dev/null) || issue_state=""
-	[[ "$issue_state" == "CLOSED" ]] || return 1
-
-	closer_numbers=$(printf '%s' "$issue_json" | jq -r '.closedByPullRequestsReferences[]?.number // empty' 2>/dev/null) || closer_numbers=""
-	while IFS= read -r closer_number; do
-		[[ "$closer_number" =~ ^[0-9]+$ ]] || continue
-		[[ "$closer_number" != "$current_pr" ]] || continue
-		pr_state=$(gh pr view "$closer_number" --repo "$repo_slug" \
-			--json state,mergedAt --jq '.state // empty' 2>/dev/null) || pr_state=""
-		merged_at=$(gh pr view "$closer_number" --repo "$repo_slug" \
-			--json mergedAt --jq '.mergedAt // empty' 2>/dev/null) || merged_at=""
-		if [[ "$pr_state" == "MERGED" || -n "$merged_at" ]]; then
-			printf '%s' "$closer_number"
-			return 0
-		fi
-	done <<EOF
-$closer_numbers
-EOF
-	return 1
+	# `closedByPullRequestsReferences` is GraphQL-only. Keep the supersession
+	# trust gate on one fixed, response-metered request instead of opaque native
+	# issue/PR views. Reject truncated connections and mismatched repositories so
+	# an incomplete snapshot can never authorize closing a worker PR.
+	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub.
+	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="pulse-supersession-closing-pr-exact-cost" \
+		gh api graphql -F owner="$owner" -F name="$name" -F number="$issue_number" -f query='
+		query($owner: String!, $name: String!, $number: Int!) {
+			repository(owner: $owner, name: $name) {
+				nameWithOwner
+				issue(number: $number) {
+					state
+					closedByPullRequestsReferences(first: 100) {
+						nodes { number state mergedAt repository { nameWithOwner } }
+						pageInfo { hasNextPage }
+					}
+				}
+			}
+			rateLimit { cost }
+		}' 2>/dev/null) || return 1
+	reported_cost=$(printf '%s' "$response" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || return 1
+	[[ "$reported_cost" =~ ^[1-9][0-9]*$ ]] || return 1
+	closer_number=$(printf '%s' "$response" | jq -er \
+		--arg repo "$repo_slug" --arg current_pr "$current_pr" '
+		.data.repository as $repository
+		| select(($repository.nameWithOwner | ascii_downcase) == ($repo | ascii_downcase))
+		| $repository.issue as $issue
+		| select($issue != null and $issue.state == "CLOSED")
+		| $issue.closedByPullRequestsReferences
+		| select(.pageInfo.hasNextPage == false)
+		| [.nodes[]?
+			| select(
+				(.repository.nameWithOwner | ascii_downcase) == ($repo | ascii_downcase)
+				and (.number | tostring) != $current_pr
+				and .state == "MERGED"
+				and ((.mergedAt // "") | length) > 0
+			)
+			| .number]
+		| first
+		| select(type == "number")
+	' 2>/dev/null) || return 1
+	[[ "$closer_number" =~ ^[0-9]+$ ]] || return 1
+	printf '%s' "$closer_number"
+	return 0
 }
 
 _psh_classify_json() {

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1793,7 +1793,7 @@ process_pr() {
 	# JSON object with metadata used by draft, label, stale, and repair-routing
 	# gates.
 	local pr_obj
-	pr_obj=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
+	pr_obj=$(AIDEVOPS_GH_REST_FIRST_READS=1 gh_pr_view "$pr_number" --repo "$repo_slug" \
 		--json "$(_pulse_merge_ready_pr_json_fields)" 2>/dev/null) || pr_obj=""
 
 	if [[ -z "$pr_obj" || "$pr_obj" == "null" ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-pr-json-fields.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-json-fields.sh
@@ -41,7 +41,7 @@ PROCESS_PR_TEST_STATE="OPEN"
 gh_pr_view() {
 	local pr_number="$1"
 	[[ -n "$PROCESS_PR_TEST_CALL_LOG" ]] || return 1
-	printf '%s\n' "$pr_number" >>"$PROCESS_PR_TEST_CALL_LOG"
+	printf '%s|%s\n' "$pr_number" "${AIDEVOPS_GH_REST_FIRST_READS:-0}" >>"$PROCESS_PR_TEST_CALL_LOG"
 	printf '{"number":%s,"state":"%s"}\n' "$pr_number" "$PROCESS_PR_TEST_STATE"
 	return 0
 }
@@ -102,7 +102,7 @@ test_callers_use_shared_field_helper() {
 }
 
 test_process_pr_runtime_reuses_one_view() {
-	local helper_src normalize_src process_src call_log payload_log log_file call_count payload failure=""
+	local helper_src normalize_src process_src call_log payload_log log_file call_count call_line payload failure=""
 	helper_src=$(awk '
 		/^_pulse_merge_ready_pr_json_fields\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
@@ -133,8 +133,10 @@ test_process_pr_runtime_reuses_one_view() {
 		failure="process_pr rejected a lowercase open prefetched state"
 	else
 		call_count=$(wc -l <"$call_log" | tr -d ' ')
+		call_line=$(<"$call_log")
 		payload=$(<"$payload_log")
 		[[ "$call_count" == "1" ]] || failure="gh_pr_view calls=${call_count}"
+		[[ "$call_line" == "42|1" ]] || failure="webhook PR view did not force REST-first routing: ${call_line}"
 		[[ "$payload" == *'"state":"open"'* ]] || failure="prefetched state was not forwarded"
 	fi
 	if [[ -z "$failure" ]]; then
@@ -145,8 +147,10 @@ test_process_pr_runtime_reuses_one_view() {
 			failure="process_pr accepted a MERGED prefetched state"
 		else
 			call_count=$(wc -l <"$call_log" | tr -d ' ')
+			call_line=$(<"$call_log")
 			payload=$(<"$payload_log")
 			[[ "$call_count" == "1" ]] || failure="closed-state gh_pr_view calls=${call_count}"
+			[[ "$call_line" == "42|1" ]] || failure="closed-state PR view did not force REST-first routing: ${call_line}"
 			[[ -z "$payload" ]] || failure="closed-state PR reached merge processing"
 		fi
 	fi
@@ -156,7 +160,7 @@ test_process_pr_runtime_reuses_one_view() {
 		print_result "process_pr runtime reuses one PR view and state gate" 1 "$failure"
 		return 0
 	fi
-	print_result "process_pr runtime reuses one PR view and state gate" 0
+	print_result "process_pr runtime uses one REST-first PR view and state gate" 0
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh
+++ b/.agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh
@@ -20,6 +20,13 @@ TEST_ISSUE_LABELS_RC=0
 TEST_PARENT_LABELS=""
 TEST_COMMIT_SUBJECT="t3571: merged equivalent fix (#9001)"
 TEST_LINKED_ISSUE="23105"
+TEST_GRAPHQL_COST="1"
+TEST_GRAPHQL_HAS_NEXT_PAGE="false"
+TEST_GRAPHQL_REPOSITORY="exampleorg/examplerepo"
+TEST_GRAPHQL_ISSUE_STATE="CLOSED"
+TEST_GRAPHQL_CLOSER_NUMBER="6130"
+TEST_GRAPHQL_CLOSER_STATE="MERGED"
+TEST_GRAPHQL_CLOSER_MERGED_AT="2026-06-02T14:53:00Z"
 
 pass() {
 	local name="$1"
@@ -37,6 +44,19 @@ fail() {
 	if [[ -n "$detail" ]]; then
 		printf '     %s\n' "$detail"
 	fi
+	return 0
+}
+
+_print_supersession_graphql_response() {
+	printf '{"data":{"repository":{"nameWithOwner":"%s","issue":{"state":"%s","closedByPullRequestsReferences":{"nodes":[{"number":%s,"state":"%s","mergedAt":"%s","repository":{"nameWithOwner":"%s"}}],"pageInfo":{"hasNextPage":%s}}}},"rateLimit":{"cost":%s}}}\n' \
+		"$TEST_GRAPHQL_REPOSITORY" \
+		"$TEST_GRAPHQL_ISSUE_STATE" \
+		"$TEST_GRAPHQL_CLOSER_NUMBER" \
+		"$TEST_GRAPHQL_CLOSER_STATE" \
+		"$TEST_GRAPHQL_CLOSER_MERGED_AT" \
+		"$TEST_GRAPHQL_REPOSITORY" \
+		"$TEST_GRAPHQL_HAS_NEXT_PAGE" \
+		"$TEST_GRAPHQL_COST"
 	return 0
 }
 
@@ -100,7 +120,16 @@ $(awk '
 
 install_stubs() {
 	gh() {
+		local command="${1:-}"
+		local subcommand="${2:-}"
 		printf '%s\n' "$*" >>"$GH_CALL_LOG"
+		if [[ "$command" == "api" && "$subcommand" == "graphql" ]]; then
+			printf 'graphql-env route=%s response-cost=%s\n' \
+				"${AIDEVOPS_GH_ROUTE_DECISION:-}" \
+				"${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" >>"$GH_CALL_LOG"
+			_print_supersession_graphql_response
+			return 0
+		fi
 		if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"--json labels,author"* && "$*" != *"authorAssociation"* ]]; then
 			printf '{"labels":[{"name":"origin:worker"}],"author":{"login":"aidevops-worker[bot]"}}\n'
 			return 0
@@ -195,6 +224,13 @@ reset_case() {
 	export TEST_PARENT_LABELS=""
 	export TEST_COMMIT_SUBJECT="t3571: merged equivalent fix (#9001)"
 	export TEST_LINKED_ISSUE="23105"
+	export TEST_GRAPHQL_COST="1"
+	export TEST_GRAPHQL_HAS_NEXT_PAGE="false"
+	export TEST_GRAPHQL_REPOSITORY="exampleorg/examplerepo"
+	export TEST_GRAPHQL_ISSUE_STATE="CLOSED"
+	export TEST_GRAPHQL_CLOSER_NUMBER="6130"
+	export TEST_GRAPHQL_CLOSER_STATE="MERGED"
+	export TEST_GRAPHQL_CLOSER_MERGED_AT="2026-06-02T14:53:00Z"
 	return 0
 }
 
@@ -295,8 +331,63 @@ test_merge_ready_duplicate_pr_closed_before_merge() {
 	reset_case
 	_pm_close_superseded_duplicate_pr_if_issue_solved "6131" "exampleorg/examplerepo" "6125" "origin:worker"
 	assert_log_contains "$GH_CALL_LOG" "pr close 6131" "merge-ready duplicate closes current PR"
-	assert_log_contains "$GH_CALL_LOG" "issue view 6125" "merge-ready duplicate checks linked issue closer"
+	assert_log_contains "$GH_CALL_LOG" "api graphql" "merge-ready duplicate uses fixed GraphQL closer query"
+	assert_log_contains "$GH_CALL_LOG" "graphql-env route=pulse-supersession-closing-pr-exact-cost response-cost=1" "merge-ready duplicate attributes response-owned GraphQL cost"
+	assert_log_not_contains "$GH_CALL_LOG" "issue view 6125" "merge-ready duplicate avoids native issue view"
+	assert_log_not_contains "$GH_CALL_LOG" "pr view 6130" "merge-ready duplicate avoids native closer PR views"
 	assert_log_contains "$GH_CALL_LOG" "merged PR #6130" "merge-ready duplicate comment cites merged PR"
+	return 0
+}
+
+test_supersession_graphql_fail_closed_guards() {
+	reset_case
+	TEST_GRAPHQL_CLOSER_NUMBER="6131"
+	if _psh_find_merged_closer_for_closed_issue "exampleorg/examplerepo" "6125" "6131" >/dev/null; then
+		fail "supersession ignores current PR as closer" "Expected current PR reference to be excluded"
+	else
+		pass "supersession ignores current PR as closer"
+	fi
+
+	reset_case
+	TEST_GRAPHQL_CLOSER_STATE="OPEN"
+	TEST_GRAPHQL_CLOSER_MERGED_AT=""
+	if _psh_find_merged_closer_for_closed_issue "exampleorg/examplerepo" "6125" "6131" >/dev/null; then
+		fail "supersession ignores unmerged closer" "Expected open PR reference to be excluded"
+	else
+		pass "supersession ignores unmerged closer"
+	fi
+
+	reset_case
+	TEST_GRAPHQL_ISSUE_STATE="OPEN"
+	if _psh_find_merged_closer_for_closed_issue "exampleorg/examplerepo" "6125" "6131" >/dev/null; then
+		fail "supersession requires closed issue" "Expected open issue to fail closed"
+	else
+		pass "supersession requires closed issue"
+	fi
+
+	reset_case
+	TEST_GRAPHQL_COST="0"
+	if _psh_find_merged_closer_for_closed_issue "exampleorg/examplerepo" "6125" "6131" >/dev/null; then
+		fail "supersession rejects invalid GraphQL cost" "Expected zero response-owned cost to fail closed"
+	else
+		pass "supersession rejects invalid GraphQL cost"
+	fi
+
+	reset_case
+	TEST_GRAPHQL_HAS_NEXT_PAGE="true"
+	if _psh_find_merged_closer_for_closed_issue "exampleorg/examplerepo" "6125" "6131" >/dev/null; then
+		fail "supersession rejects truncated closer connection" "Expected hasNextPage=true to fail closed"
+	else
+		pass "supersession rejects truncated closer connection"
+	fi
+
+	reset_case
+	TEST_GRAPHQL_REPOSITORY="untrusted/example"
+	if _psh_find_merged_closer_for_closed_issue "exampleorg/examplerepo" "6125" "6131" >/dev/null; then
+		fail "supersession rejects mismatched repository" "Expected repository mismatch to fail closed"
+	else
+		pass "supersession rejects mismatched repository"
+	fi
 	return 0
 }
 
@@ -325,6 +416,7 @@ main() {
 	test_label_lookup_failure_skips_issue_closure
 	test_protected_precheck_skips_draft_interactive_without_metadata_fetch
 	test_merge_ready_duplicate_pr_closed_before_merge
+	test_supersession_graphql_fail_closed_guards
 	test_followup_label_preserves_duplicate_guard
 
 	printf '\nTests run: %s, failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Route supersession closer lookup through one response-metered fixed GraphQL query and force webhook PR reads through REST-first routing.

## Files Changed

.agents/scripts/pr-supersession-helper.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-merge-pr-json-fields.sh, .agents/scripts/tests/test-pulse-merge-superseded-duplicates.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — ShellCheck; focused Pulse suites (37 assertions); linters-local.sh

Resolves #29262


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 24m and 466,404 tokens on this as a headless worker.