### PR TITLE
GH#29262: Close remaining Pulse quota attribution gaps

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -216,6 +216,87 @@ _PAD_TRIAGE_REVIEW_APPROVE_COLOR="${_PAD_TRIAGE_REVIEW_APPROVE_COLOR:-0E8A16}"
 _PAD_TRIAGE_REVIEW_FEEDBACK_COLOR="${_PAD_TRIAGE_REVIEW_FEEDBACK_COLOR:-FBCA04}"
 _PAD_TRIAGE_REVIEW_DECLINE_COLOR="${_PAD_TRIAGE_REVIEW_DECLINE_COLOR:-D73A4A}"
 
+_triage_recommendation_label_contract() {
+	printf '%s\t%s\t%s\n' \
+		"$_PAD_TRIAGE_REVIEW_APPROVE_LABEL" "$_PAD_TRIAGE_REVIEW_APPROVE_COLOR" \
+		"Advisory automated triage recommendation: approve" \
+		"$_PAD_TRIAGE_REVIEW_FEEDBACK_LABEL" "$_PAD_TRIAGE_REVIEW_FEEDBACK_COLOR" \
+		"Advisory automated triage recommendation: request changes" \
+		"$_PAD_TRIAGE_REVIEW_DECLINE_LABEL" "$_PAD_TRIAGE_REVIEW_DECLINE_COLOR" \
+		"Advisory automated triage recommendation: decline"
+	return 0
+}
+
+# Return a bounded JSON snapshot of repository labels. Explicit page numbers
+# prevent a malformed pagination response from creating an unbounded read loop.
+_triage_recommendation_labels_snapshot() {
+	local repo_slug="$1"
+	local page=1
+	local page_size=100
+	local max_pages=10
+	local response=""
+	local response_count=""
+	local snapshot='[]'
+
+	while [[ "$page" -le "$max_pages" ]]; do
+		response=$(AIDEVOPS_GH_ROUTE_DECISION="pulse-triage-label-inventory-rest" \
+			gh api -X GET "/repos/${repo_slug}/labels?per_page=${page_size}&page=${page}" 2>/dev/null) || return 1
+		response_count=$(printf '%s' "$response" | jq -er --arg array_type "$_PAD_JSON_ARRAY_TYPE" \
+			'if type == $array_type then length else error("labels response has an invalid type") end' \
+			2>/dev/null) || return 1
+		snapshot=$(jq -cn --argjson current "$snapshot" --argjson page "$response" '
+			$current + [$page[] | {
+				name: (.name // ""),
+				color: ((.color // "") | ascii_downcase),
+				description: (.description // "")
+			}]') || return 1
+		if [[ "$response_count" -lt "$page_size" ]]; then
+			printf '%s\n' "$snapshot"
+			return 0
+		fi
+		page=$((page + 1))
+	done
+	return 1
+}
+
+_triage_recommendation_label_state() {
+	local snapshot="$1"
+	local expected_name="$2"
+	local expected_color="$3"
+	local expected_description="$4"
+	printf '%s' "$snapshot" | jq -er --arg name "$expected_name" --arg color "$expected_color" \
+		--arg description "$expected_description" '
+		[.[] | select((.name | ascii_downcase) == ($name | ascii_downcase))][0] as $label
+		| if $label == null then "missing"
+		elif (($label.color | ascii_downcase) == ($color | ascii_downcase)) and
+			($label.description == $description) then "current"
+		else "drifted"
+		end'
+	return $?
+}
+
+_triage_recommendation_label_write() {
+	local action="$1"
+	local repo_slug="$2"
+	local label_name="$3"
+	local color="$4"
+	local description="$5"
+	local encoded_name=""
+
+	if [[ "$action" == "create" ]]; then
+		AIDEVOPS_GH_ROUTE_DECISION="pulse-triage-label-create-rest" \
+			gh api -X POST "/repos/${repo_slug}/labels" -f name="$label_name" \
+			-f color="$color" -f description="$description" >/dev/null 2>&1
+		return $?
+	fi
+	[[ "$action" == "update" ]] || return 1
+	encoded_name=$(jq -rn --arg name "$label_name" '$name | @uri') || return 1
+	AIDEVOPS_GH_ROUTE_DECISION="pulse-triage-label-update-rest" \
+		gh api -X PATCH "/repos/${repo_slug}/labels/${encoded_name}" -f new_name="$label_name" \
+		-f color="$color" -f description="$description" >/dev/null 2>&1
+	return $?
+}
+
 #######################################
 # Provision the three canonical, mutually exclusive advisory recommendation
 # labels. Failure is propagated so no review comment can be posted without its
@@ -223,19 +304,31 @@ _PAD_TRIAGE_REVIEW_DECLINE_COLOR="${_PAD_TRIAGE_REVIEW_DECLINE_COLOR:-D73A4A}"
 #######################################
 _ensure_triage_recommendation_labels() {
 	local repo_slug="$1"
-	[[ -n "$repo_slug" ]] || return 1
-	gh label create "$_PAD_TRIAGE_REVIEW_APPROVE_LABEL" --repo "$repo_slug" \
-		--color "$_PAD_TRIAGE_REVIEW_APPROVE_COLOR" \
-		--description "Advisory automated triage recommendation: approve" \
-		--force >/dev/null 2>&1 || return 1
-	gh label create "$_PAD_TRIAGE_REVIEW_FEEDBACK_LABEL" --repo "$repo_slug" \
-		--color "$_PAD_TRIAGE_REVIEW_FEEDBACK_COLOR" \
-		--description "Advisory automated triage recommendation: request changes" \
-		--force >/dev/null 2>&1 || return 1
-	gh label create "$_PAD_TRIAGE_REVIEW_DECLINE_LABEL" --repo "$repo_slug" \
-		--color "$_PAD_TRIAGE_REVIEW_DECLINE_COLOR" \
-		--description "Advisory automated triage recommendation: decline" \
-		--force >/dev/null 2>&1 || return 1
+	local labels_snapshot=""
+	local label_name=""
+	local color=""
+	local description=""
+	local label_state=""
+	[[ "$repo_slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || return 1
+	labels_snapshot=$(_triage_recommendation_labels_snapshot "$repo_slug") || return 1
+
+	while IFS=$'\t' read -r label_name color description; do
+		[[ -n "$label_name" ]] || continue
+		label_state=$(_triage_recommendation_label_state "$labels_snapshot" "$label_name" \
+			"$color" "$description") || return 1
+		case "$label_state" in
+		current) continue ;;
+		missing)
+			_triage_recommendation_label_write create "$repo_slug" "$label_name" \
+				"$color" "$description" || return 1
+			;;
+		drifted)
+			_triage_recommendation_label_write update "$repo_slug" "$label_name" \
+				"$color" "$description" || return 1
+			;;
+		*) return 1 ;;
+		esac
+	done < <(_triage_recommendation_label_contract)
 	return 0
 }
 

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -2293,17 +2293,63 @@ _verified_worker_closing_pr() {
 	local issue_number="$2"
 	local branch_name="$3"
 	local head_oid="$4"
-	local candidates=""
-	candidates=$(gh pr list --repo "$repo_slug" --state merged --head "$branch_name" --limit 100 \
-		--json number,state,mergedAt,headRefName,headRefOid,closingIssuesReferences 2>/dev/null) || return 2
+	local owner="${repo_slug%%/*}"
+	local repo_name="${repo_slug#*/}"
+	local response=""
+	local reported_cost=""
+	[[ "$repo_slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || return 2
+	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 2
+	[[ -n "$branch_name" ]] || return 2
+	[[ "$head_oid" =~ ^([0-9a-f]{40}|[0-9a-f]{64})$ ]] || return 2
+
+	# Both connections are bounded. Their pageInfo fields are part of the trust
+	# proof so truncated evidence can never authorize worker termination.
+	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub.
+	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="pulse-zombie-merged-pr-exact-cost" \
+		gh api graphql -F owner="$owner" -F name="$repo_name" -F head="$branch_name" -f query='
+		query($owner: String!, $name: String!, $head: String!) {
+			repository(owner: $owner, name: $name) {
+				nameWithOwner
+				pullRequests(first: 100, states: MERGED, headRefName: $head) {
+					nodes {
+						number
+						state
+						mergedAt
+						headRefName
+						headRefOid
+						closingIssuesReferences(first: 100) {
+							nodes { number repository { nameWithOwner } }
+							pageInfo { hasNextPage }
+						}
+					}
+					pageInfo { hasNextPage }
+				}
+			}
+			rateLimit { cost }
+		}' 2>/dev/null) || return 2
+	reported_cost=$(printf '%s' "$response" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || return 2
+	[[ "$reported_cost" =~ ^[1-9][0-9]*$ ]] || return 2
+
 	local verification="" verified_count="" verified_pr=""
-	verification=$(printf '%s' "$candidates" | jq -r --arg issue "$issue_number" --arg branch "$branch_name" --arg head "$head_oid" '
-		if length >= 100 then "limit"
+	verification=$(printf '%s' "$response" | jq -er --arg repo "$repo_slug" --arg issue "$issue_number" \
+		--arg branch "$branch_name" --arg head "$head_oid" '
+		select(((.errors // []) | length) == 0)
+		| .data.repository as $repository
+		| select(($repository.nameWithOwner // "" | ascii_downcase) == ($repo | ascii_downcase))
+		| $repository.pullRequests as $pull_requests
+		| [$pull_requests.nodes[]? | select(
+			.state == "MERGED" and (.mergedAt // "") != "" and
+			.headRefName == $branch and .headRefOid == $head
+		)] as $head_matches
+		| if ($pull_requests.pageInfo.hasNextPage != false) or
+			any($head_matches[]?; .closingIssuesReferences.pageInfo.hasNextPage != false)
+		then "limit"
 		else
-			[.[] | select(
-				.state == "MERGED" and (.mergedAt // "") != "" and
-				.headRefName == $branch and .headRefOid == $head and
-				([.closingIssuesReferences[]?.number | tostring] | index($issue)) != null
+			[$head_matches[] | select(
+				([.closingIssuesReferences.nodes[]?
+					| select((.repository.nameWithOwner // "" | ascii_downcase) == ($repo | ascii_downcase))
+					| .number | tostring] | index($issue)) != null
 			)] as $verified |
 			[($verified | length | tostring), ($verified[0].number // "" | tostring)] | @tsv
 		end

--- a/.agents/scripts/tests/test-pulse-cleanup-unregister.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-unregister.sh
@@ -399,11 +399,23 @@ gh() {
 		printf '%s\n' "${GH_ISSUE_STATE:-OPEN}"
 		return 0
 	fi
-	if [[ "$subcommand" == "pr" && "$action" == "list" ]]; then
+	if [[ "$subcommand" == "api" && "$action" == "graphql" ]]; then
 		[[ "${GH_API_FAIL:-0}" == "0" ]] || return 1
-		jq -cn --argjson number "${GH_MERGED_PR:-3964}" --argjson issue "${GH_CLOSING_ISSUE:-3964}" \
+		printf 'graphql-env response-cost=%s route=%s\n' \
+			"${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" \
+			"${AIDEVOPS_GH_ROUTE_DECISION:-}" >>"${GH_LOG:?}"
+		jq -cn --arg repo "${GH_GRAPHQL_REPO:-exampleorg/examplerepo}" \
+			--argjson number "${GH_MERGED_PR:-3964}" --argjson issue "${GH_CLOSING_ISSUE:-3964}" \
 			--arg branch "${GH_PR_BRANCH:?}" --arg head "${GH_PR_HEAD:?}" \
-			'[{number:$number,state:"MERGED",mergedAt:"2026-07-15T12:00:00Z",headRefName:$branch,headRefOid:$head,closingIssuesReferences:[{number:$issue}]}]'
+			--argjson pr_has_next "${GH_PR_PAGE_HAS_NEXT:-false}" \
+			--argjson closing_has_next "${GH_CLOSING_PAGE_HAS_NEXT:-false}" \
+			--argjson cost "${GH_GRAPHQL_COST:-1}" '
+			{data:{repository:{nameWithOwner:$repo,pullRequests:{nodes:[{
+				number:$number,state:"MERGED",mergedAt:"2026-07-15T12:00:00Z",
+				headRefName:$branch,headRefOid:$head,
+				closingIssuesReferences:{nodes:[{number:$issue,repository:{nameWithOwner:$repo}}],
+					pageInfo:{hasNextPage:$closing_has_next}}
+			}],pageInfo:{hasNextPage:$pr_has_next}}},rateLimit:{cost:$cost}}}'
 		return 0
 	fi
 	return 1
@@ -526,9 +538,15 @@ test_zombie_reaper_uses_ledger_repo_and_pid() {
 	SCRIPT_DIR="$original_script_dir"
 
 	grep -Fxq '123' "$kill_log" || fail "zombie reaper did not kill the ledger PID"
-	grep -q -- '--repo exampleorg/examplerepo' "$gh_log" || fail "zombie reaper did not query the ledger repo"
-	grep -q -- '--head feature/worker-3964' "$gh_log" || fail "zombie reaper did not bind merged PR lookup to worker branch"
+	grep -q -- '-F owner=exampleorg -F name=examplerepo' "$gh_log" || fail "zombie reaper did not query the ledger repo"
+	grep -q -- '-F head=feature/worker-3964' "$gh_log" || fail "zombie reaper did not bind merged PR lookup to worker branch"
 	grep -q 'closingIssuesReferences' "$gh_log" || fail "zombie reaper did not verify structured closing references"
+	grep -q 'pageInfo { hasNextPage }' "$gh_log" || fail "zombie reaper did not request pagination proof"
+	grep -q 'rateLimit { cost }' "$gh_log" || fail "zombie reaper did not request response-owned cost"
+	grep -q 'graphql-env response-cost=1 route=pulse-zombie-merged-pr-exact-cost' "$gh_log" || fail "zombie reaper GraphQL route was not attributed exactly"
+	if grep -q '^pr list ' "$gh_log"; then
+		fail "zombie reaper used an opaque native PR list"
+	fi
 	grep -q 'record-outcome.*--reason merged_pr_reap' "$ledger_log" || fail "zombie reaper did not record typed terminal telemetry"
 	grep -q 'complete.*--lease-token lease-3964.*--reason merged_pr_reap' "$ledger_log" || fail "zombie reaper did not complete the exact lease"
 	grep -q 'PR #5000 already merged in exampleorg/examplerepo' "$LOGFILE" || fail "missing ledger-repo reap audit log"
@@ -604,6 +622,36 @@ test_zombie_reaper_fails_closed_on_stale_or_indeterminate_evidence() {
 	return 0
 }
 
+test_worker_closing_pr_fails_closed_on_truncated_or_unmetered_graphql() {
+	local gh_log="${TEST_ROOT}/gh-truncated-closing-pr.log"
+	local head_oid="1111111111111111111111111111111111111111"
+	local verification_rc=0
+	: >"$gh_log"
+	export GH_LOG="$gh_log" GH_API_FAIL=0 GH_MERGED_PR=5003 GH_CLOSING_ISSUE=3964
+	export GH_PR_BRANCH="feature/worker-3964-truncated" GH_PR_HEAD="$head_oid"
+
+	export GH_PR_PAGE_HAS_NEXT=true GH_CLOSING_PAGE_HAS_NEXT=false GH_GRAPHQL_COST=1
+	_verified_worker_closing_pr "exampleorg/examplerepo" "3964" "$GH_PR_BRANCH" "$head_oid" \
+		>/dev/null || verification_rc=$?
+	[[ "$verification_rc" -eq 2 ]] || fail "truncated merged PR connection did not fail closed"
+
+	verification_rc=0
+	export GH_PR_PAGE_HAS_NEXT=false GH_CLOSING_PAGE_HAS_NEXT=true
+	_verified_worker_closing_pr "exampleorg/examplerepo" "3964" "$GH_PR_BRANCH" "$head_oid" \
+		>/dev/null || verification_rc=$?
+	[[ "$verification_rc" -eq 2 ]] || fail "truncated closing-issue connection did not fail closed"
+
+	verification_rc=0
+	export GH_CLOSING_PAGE_HAS_NEXT=false GH_GRAPHQL_COST=0
+	_verified_worker_closing_pr "exampleorg/examplerepo" "3964" "$GH_PR_BRANCH" "$head_oid" \
+		>/dev/null || verification_rc=$?
+	[[ "$verification_rc" -eq 2 ]] || fail "nonpositive GraphQL cost did not fail closed"
+
+	unset GH_PR_PAGE_HAS_NEXT GH_CLOSING_PAGE_HAS_NEXT GH_GRAPHQL_COST
+	pass "worker closing PR proof rejects truncated or unmetered GraphQL"
+	return 0
+}
+
 test_permanent_removal_failure_has_no_git_fallback() {
 	local repo_path="${TEST_ROOT}/repo-no-fallback"
 	local wt_path="${TEST_ROOT}/wt-no-fallback"
@@ -647,6 +695,7 @@ test_zombie_reaper_requires_ledger_repo
 test_zombie_reaper_uses_ledger_repo_and_pid
 test_zombie_reaper_rejects_unverified_completion
 test_zombie_reaper_fails_closed_on_stale_or_indeterminate_evidence
+test_worker_closing_pr_fails_closed_on_truncated_or_unmetered_graphql
 test_permanent_removal_failure_has_no_git_fallback
 test_degraded_orphan_removal_is_recoverable
 test_degraded_orphan_lock_race_is_preserved

--- a/.agents/scripts/tests/test-triage-output-shape.sh
+++ b/.agents/scripts/tests/test-triage-output-shape.sh
@@ -40,6 +40,9 @@ EPHEMERAL_BODY_LOG=""
 MOCK_COMMENT_WRITE_FAILURE=0
 MOCK_REVIEW_LABEL_WRITE_FAILURE=0
 MOCK_PR_REVISION_PAIR=""
+MOCK_LABELS_JSON=""
+MOCK_LABEL_INVENTORY_FAILURE=0
+MOCK_LABEL_WRITE_FAILURE=0
 readonly EXPECTED_TEXT_SNAPSHOT_HASH="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 MOCK_CURRENT_TEXT_SNAPSHOT_HASH="$EXPECTED_TEXT_SNAPSHOT_HASH"
 readonly EXPECTED_PUBLIC_REVISION="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -107,6 +110,9 @@ SIG_STUB
 	MOCK_COMMENT_WRITE_FAILURE=0
 	MOCK_REVIEW_LABEL_WRITE_FAILURE=0
 	MOCK_PR_REVISION_PAIR=""
+	MOCK_LABELS_JSON='[{"name":"review:approve","color":"0e8a16","description":"Advisory automated triage recommendation: approve"},{"name":"review:feedback","color":"fbca04","description":"Advisory automated triage recommendation: request changes"},{"name":"review:decline","color":"d73a4a","description":"Advisory automated triage recommendation: decline"}]'
+	MOCK_LABEL_INVENTORY_FAILURE=0
+	MOCK_LABEL_WRITE_FAILURE=0
 	MOCK_CURRENT_TEXT_SNAPSHOT_HASH="$EXPECTED_TEXT_SNAPSHOT_HASH"
 	MOCK_CURRENT_PUBLIC_REVISION="$EXPECTED_PUBLIC_REVISION"
 	unset TRIAGE_TEST_RUNTIME_EXIT_STATUS TRIAGE_TEST_SIGNATURE_FAILURE 2>/dev/null || true
@@ -177,6 +183,19 @@ gh() {
 		return 0
 		;;
 	api)
+		if [[ "$call_args" == *"/labels?per_page=100&page="* ]]; then
+			printf 'label-route=%s\n' "${AIDEVOPS_GH_ROUTE_DECISION:-}" >>"$GH_CALL_LOG"
+			[[ "$MOCK_LABEL_INVENTORY_FAILURE" -eq 0 ]] || return 1
+			printf '%s\n' "$MOCK_LABELS_JSON"
+			return 0
+		fi
+		if [[ "$call_args" == *"/repos/owner/repo/labels"* && \
+			( "$call_args" == *"-X POST"* || "$call_args" == *"-X PATCH"* ) ]]; then
+			printf 'label-route=%s\n' "${AIDEVOPS_GH_ROUTE_DECISION:-}" >>"$GH_CALL_LOG"
+			[[ "$MOCK_LABEL_WRITE_FAILURE" -eq 0 ]] || return 1
+			printf '%s\n' '{}'
+			return 0
+		fi
 		if [[ "$call_args" == *"/comments?per_page=100"* ]]; then
 			printf '%s\n' '[[{"id":1,"user":{"login":"external"},"author_association":"CONTRIBUTOR","body":"Stable test comment","created_at":"2026-07-27T00:01:00Z","updated_at":"2026-07-27T00:01:00Z"}]]'
 			return 0
@@ -691,6 +710,63 @@ test_recommendation_labels_map_exact_decisions() {
 		detail="${detail} decline-missing"
 	}
 	print_result "exact triage decisions map to canonical advisory labels" "$ok" "$detail"
+	teardown_test_env
+}
+
+test_recommendation_label_provisioning_uses_bounded_rest_routes() {
+	setup_test_env
+	load_helpers_under_test
+	MOCK_LABELS_JSON='[{"name":"review:approve","color":"0e8a16","description":"Advisory automated triage recommendation: approve"},{"name":"review:feedback","color":"000000","description":"stale"}]'
+	local ok=0 detail="" inventory_count=0
+	_ensure_triage_recommendation_labels "owner/repo" || ok=1
+	inventory_count=$(grep -c '^api -X GET /repos/owner/repo/labels?per_page=100&page=1$' \
+		"$GH_CALL_LOG" 2>/dev/null || true)
+	[[ "$inventory_count" -eq 1 ]] || {
+		ok=1
+		detail="${detail} inventory-count=${inventory_count}"
+	}
+	grep -q '^api -X PATCH /repos/owner/repo/labels/review%3Afeedback ' "$GH_CALL_LOG" || {
+		ok=1
+		detail="${detail} feedback-update-missing"
+	}
+	grep -q '^api -X POST /repos/owner/repo/labels -f name=review:decline ' "$GH_CALL_LOG" || {
+		ok=1
+		detail="${detail} decline-create-missing"
+	}
+	if grep -Eq '^label create |--force|name=review:approve' "$GH_CALL_LOG"; then
+		ok=1
+		detail="${detail} current-label-written-or-force-used"
+	fi
+	grep -q '^label-route=pulse-triage-label-inventory-rest$' "$GH_CALL_LOG" || ok=1
+	grep -q '^label-route=pulse-triage-label-update-rest$' "$GH_CALL_LOG" || ok=1
+	grep -q '^label-route=pulse-triage-label-create-rest$' "$GH_CALL_LOG" || ok=1
+	print_result "recommendation labels use bounded successful REST create/update routes" \
+		"$ok" "$detail"
+	teardown_test_env
+}
+
+test_recommendation_label_inventory_stops_at_page_bound() {
+	setup_test_env
+	load_helpers_under_test
+	MOCK_LABELS_JSON=$(jq -cn '[range(0; 100) | {
+		name: ("fixture-" + tostring), color: "ffffff", description: "fixture"
+	}]')
+	local ok=0 detail="" inventory_count=0
+	if _ensure_triage_recommendation_labels "owner/repo"; then
+		ok=1
+		detail="unbounded inventory returned success"
+	fi
+	inventory_count=$(grep -c '^api -X GET /repos/owner/repo/labels?per_page=100&page=' \
+		"$GH_CALL_LOG" 2>/dev/null || true)
+	[[ "$inventory_count" -eq 10 ]] || {
+		ok=1
+		detail="${detail} inventory-count=${inventory_count}"
+	}
+	if grep -Eq '^api -X (POST|PATCH) /repos/owner/repo/labels' "$GH_CALL_LOG"; then
+		ok=1
+		detail="${detail} write-after-truncation"
+	fi
+	print_result "recommendation label inventory fails closed at its page bound" "$ok" "$detail"
 	teardown_test_env
 }
 
@@ -1254,6 +1330,8 @@ main() {
 	test_review_shape_enforces_exact_contract
 	test_dispatch_accepts_clean_review_in_json
 	test_recommendation_labels_map_exact_decisions
+	test_recommendation_label_provisioning_uses_bounded_rest_routes
+	test_recommendation_label_inventory_stops_at_page_bound
 	test_review_label_write_failure_blocks_comment_and_cache
 	test_signature_failure_blocks_comment_transport
 	test_dispatch_rejects_issue_schema_for_pr

--- a/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
+++ b/.agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh
@@ -501,6 +501,62 @@ test_exact_merged_pr_batch_prefetch_covers_worktree_heads() {
 	return 0
 }
 
+test_exact_merged_pr_batch_uses_response_owned_cost() {
+	local repo_path="${TEST_ROOT}/repo-batch-cost"
+	local args_file="${TEST_ROOT}/batch-cost-args"
+	local branch="feature/gh-99043-batch-cost"
+	local output=""
+	local rc=0
+	setup_repo "$repo_path" || rc=1
+
+	output=$(
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		_clean_gh_graphql() {
+			printf 'response-cost=%s route=%s args=%s\n' \
+				"${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" \
+				"${AIDEVOPS_GH_ROUTE_DECISION:-}" "$*" >"$args_file"
+			printf '%s\n' '{"data":{"repository":{"q0":{"nodes":[{"headRefName":"feature/gh-99043-batch-cost"}]}},"rateLimit":{"cost":2}}}'
+			return 0
+		}
+		_clean_query_exact_merged_pr_batch "testowner" "testrepo" "$branch"
+	) || rc=1
+
+	[[ "$output" == "$branch" ]] || rc=1
+	grep -Fq 'response-cost=1' "$args_file" 2>/dev/null || rc=1
+	grep -Fq 'route=worktree-clean-merged-pr-batch-exact-cost' "$args_file" 2>/dev/null || rc=1
+	grep -Fq 'rateLimit{cost}' "$args_file" 2>/dev/null || rc=1
+	if grep -Fq -- '--jq' "$args_file" 2>/dev/null; then
+		rc=1
+	fi
+	print_result "exact merged PR batch uses response-owned GraphQL cost" "$rc" \
+		"Expected a raw metered response, positive cost validation, and local projection"
+	return 0
+}
+
+test_exact_merged_pr_batch_rejects_nonpositive_cost() {
+	local repo_path="${TEST_ROOT}/repo-batch-invalid-cost"
+	local rc=0
+	setup_repo "$repo_path" || rc=1
+
+	(
+		cd "$repo_path" || exit 1
+		source_clean_lib_with_stubs || exit 1
+		_clean_gh_graphql() {
+			printf '%s\n' '{"data":{"repository":{},"rateLimit":{"cost":0}}}'
+			return 0
+		}
+		if _clean_query_exact_merged_pr_batch "testowner" "testrepo" \
+			"feature/gh-99044-invalid-cost" >/dev/null; then
+			exit 1
+		fi
+	) || rc=1
+
+	print_result "exact merged PR batch rejects nonpositive response cost" "$rc" \
+		"Expected an unmetered GraphQL response to fail closed"
+	return 0
+}
+
 test_complete_exact_prefetch_skips_per_head_lookup() {
 	local repo_path="${TEST_ROOT}/repo-complete-prefetch"
 	local marker="${TEST_ROOT}/complete-prefetch-gh-called"
@@ -996,6 +1052,8 @@ test_squash_merged_pr_without_ancestor_proof_classifies
 test_prefetched_merged_pr_metadata_skips_exact_head_lookup
 test_merged_pr_list_passes_explicit_repo_slug
 test_exact_merged_pr_batch_prefetch_covers_worktree_heads
+test_exact_merged_pr_batch_uses_response_owned_cost
+test_exact_merged_pr_batch_rejects_nonpositive_cost
 test_complete_exact_prefetch_skips_per_head_lookup
 test_prepared_git_branch_cache_avoids_per_branch_query
 test_auto_clean_skips_redundant_preview_scan

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -599,6 +599,8 @@ _clean_query_exact_merged_pr_batch() {
 	local query_vars="\$owner:String!,\$name:String!"
 	local query_fields=""
 	local query=""
+	local response=""
+	local reported_cost=""
 	local branch=""
 	local index=0
 	local -a graphql_args=(-f "owner=$owner" -f "name=$repo_name")
@@ -609,10 +611,14 @@ _clean_query_exact_merged_pr_batch() {
 		graphql_args+=(-f "h${index}=$branch")
 		index=$((index + 1))
 	done
-	query="query(${query_vars}){repository(owner:\$owner,name:\$name){${query_fields}}}"
+	query="query(${query_vars}){repository(owner:\$owner,name:\$name){${query_fields}} rateLimit{cost}}"
 
-	_clean_gh_graphql -f "query=$query" "${graphql_args[@]}" \
-		--jq '(.data.repository // {}) | .[] | .nodes[]? | .headRefName'
+	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="worktree-clean-merged-pr-batch-exact-cost" \
+		_clean_gh_graphql -f "query=$query" "${graphql_args[@]}") || return 1
+	reported_cost=$(printf '%s' "$response" | jq -r '.data.rateLimit.cost // empty' 2>/dev/null) || return 1
+	[[ "$reported_cost" =~ ^[1-9][0-9]*$ ]] || return 1
+	printf '%s' "$response" | jq -r '(.data.repository // {}) | .[] | .nodes[]? | .headRefName'
 	return $?
 }
 


### PR DESCRIPTION
## Summary

Meter worktree cleanup and zombie-reaper GraphQL reads from response-owned rateLimit.cost, and replace triage label force-upserts with bounded successful REST create/update routes.

## Files Changed

.agents/scripts/pulse-ancillary-dispatch.sh, .agents/scripts/pulse-cleanup.sh, .agents/scripts/tests/test-pulse-cleanup-unregister.sh, .agents/scripts/tests/test-triage-output-shape.sh, .agents/scripts/tests/test-worktree-cleanup-branch-merged-owned-skip.sh, .agents/scripts/worktree-clean-lib.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Local linters passed; ShellCheck passed for all changed shell files; focused worktree, Pulse cleanup, triage, supersession, residual REST, and gh-shim suites passed; isolated qlty regression scan reported 61 to 61 smells.

Resolves #29262


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.5 spent 16d 12h and 58,143,225 tokens on this with the user in an interactive session.