### PR TITLE
GH#29318: Add bounded Ghost publication knowledge collection

### DIFF
--- a/.agents/aidevops/knowledge-plane/05-social-operations.md
+++ b/.agents/aidevops/knowledge-plane/05-social-operations.md
@@ -40,8 +40,8 @@ rows. Replay preserves both evidence and projection IDs.
 
 Candidate implementation is provider-specific, not one generic social adapter.
 Mastodon #29221, GitHub #29222, Stack Exchange #29223, Miniflux #29224,
-Readwise Reader #29225, Lemmy #29227, and public-only Hacker News #29228 are now
-live. FreshRSS #29226 is the remaining ranked child. Each route owns its identity
+Readwise Reader #29225, Lemmy #29227, public-only Hacker News #29228, and Ghost
+#29318 are now live. FreshRSS #29226 is the remaining ranked child. Each route owns its identity
 contract, stream allowlist, checkpoint semantics, and negative write-reachability
 tests. Raindrop.io remains optional; Inoreader, Wallabag, Feedly, Instapaper, and
 Pocket are deferred or rejected for the reasons in
@@ -61,6 +61,14 @@ request budget, and atomically commits the raw boundary envelope, normalized
 rows, coverage, receipt, and next checkpoint. A terminal or malformed page keeps
 the previous checkpoint. Snapshot streams never infer deletion from partial
 coverage.
+
+Ghost collection binds an opaque operator-selected publication ID to the exact
+frontend URL returned by unauthenticated `GET /ghost/api/admin/site/` before
+every page. Four independent snapshot streams use only Ghost v6 Content API GET
+routes for published posts, pages, public tags, and public authors. The Content
+credential is isolated in a child process and never reaches evidence; redirects,
+Admin authentication, mutation-capable routes, members, newsletters, comments,
+and automated exports are unreachable. Details: `.agents/content/social-ghost.md`.
 
 Mastodon collection uses a user token bound to one exact HTTPS home instance and
 rechecks `GET /api/v1/accounts/verify_credentials` before every page. Authored

--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -38,6 +38,7 @@ a claim that the route is enabled.
 | Instagram | **Live/Gate/Export** Professional media | **No/Export** comments and saved activity | **No/Export** mentions | **No/Export** followers and following | **No/Export** saved collections | One Page-connected Business/Creator `/media` stream; personal accounts and unimplemented per-media edges remain explicit. |
 | Threads | **Live/Gate/Export** posts | **No/Export** likes and repost history | **Live/Gate/Export** authored replies and mentions; **No** messages | **No/Export** followers and following | **No** custom feeds | Three product-scoped streams with app-scoped identity, independent cursors, and stream-specific permission gates. |
 | Medium | **Live/Export** authored posts; **Live/Partial** explicit responses | **Live/Export/No** bookmarks, claps, highlights, and list membership when present | **No** | **Live/Export/No** publication membership and follows when present | **Live/Export/No** owned lists when present | Identity-verified native HTML ZIP import with exact replay, bounded local parsing, and per-archive complete/unavailable coverage; legacy API access is not live parity. |
+| Ghost | **Live/Partial** published posts and pages; **Gate** drafts | **No** private reactions or member engagement | **No/Gate** comments; no stable documented integration route | **Live/Partial** public authors; **Gate/No** members and newsletter subscriptions | **Live/Partial** public tags; **Gate** newsletters | Four v6 Content API snapshots bind the exact publication URL before every page; Admin credentials, member PII, comments, automated exports, redirects, and writes remain disabled. |
 | Quora | **Export/No** answers, questions, posts, and comments | **Export/No** bookmarks; **No** upvotes and other curation | **No** | **Export/No** user follows; **No** followed topics or Spaces | **No** | The official export has no published schema. Public content samples lack authoritative owner identity, and the companion account-data schema is unpublished; no adapter or CLI route is enabled. |
 | Skool | **No** posts, comments, and course content | **No** reactions and saved state | **No** notifications and messages | **No** memberships, follows, and groups | **No** courses and calendar feeds | **Export/No** admin membership-question answers only. The official Zapier surface is narrow event automation, the export schema and identity contract are unpublished, and provider policy excludes browser collection. |
 | Discourse | **Live** topics and posts | **Live/Partial** likes, bookmarks, and current reading state | **Live/Gate/Partial** notifications and private-topic metadata; **No** message bodies | **Live/Partial** groups and category preferences; **No** unverified Follow plugin | **No** watched/tracked topic inventories until search behavior is verified | Ten User API `read` streams with per-installation namespaces, repeated identity checks, exact GET routes, redirect rejection, and explicit plugin/export/history gaps. |
@@ -69,6 +70,7 @@ falls back to another provider or to an outbound mutation route.
 | Binance Square | **No** | Officially verified surfaces are mutation-only; no adapter, export, browser, or credential route is registered. |
 | Bluesky / AT Protocol | **Live** repository/AppView reads | Chat remains separately permissioned; account identity is a stable DID. |
 | Forem | **Live** multi-instance reads | `dev-community` and `dev.to` are aliases of `forem`, not separate providers. |
+| Ghost | **Live** public publication reads | Content API v6 only; Admin credentials and private member/newsletter/comment data are not registered. |
 
 HubSpot Community remains a Discourse installation and is not registered as a
 separate provider family.
@@ -139,6 +141,15 @@ separate provider family.
   `.agents/content/social-medium.md` records the official HTML-ZIP export,
   unsupported legacy API, terms, retention, historical community schema
   evidence, and unverified categories checked on 2026-07-28.
+- **Live Ghost publication:** `.agents/scripts/knowledge_social_ghost.py`,
+  `.agents/scripts/_knowledge_social_ghost*.py`, and
+  `.agents/tests/test-knowledge-social-ghost.sh` prove exact publication URL
+  binding, four independent v6 Content API snapshots, strict numeric
+  pagination, public-tag and author minimization, content-credential rejection,
+  redirect and mutation isolation, terminal coverage, replay, and final lease
+  fencing. `.agents/content/social-ghost.md` records current official Content
+  and Admin authentication, permissions, routes, exports, privacy, retention,
+  and unsupported evidence checked on 2026-08-02.
 - **Live Discourse:** `.agents/scripts/knowledge_social_discourse.py`,
   `.agents/scripts/_knowledge_social_discourse*.py`, and
   `.agents/tests/test-knowledge-social-discourse.sh` prove ten independently

--- a/.agents/content/social-ghost.md
+++ b/.agents/content/social-ghost.md
@@ -1,0 +1,190 @@
+---
+description: Identity-bound Ghost public publication knowledge collection
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  webfetch: true
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Ghost Publication Knowledge
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Collector**: `knowledge-social-helper.sh sync-ghost`
+- **Live evidence**: published posts, resource pages, public tags, and public
+  authors through four independently checkpointed Ghost v6 Content API streams
+- **Identity**: an opaque profile `SITE_ID` plus the exact configured `SITE_URL`,
+  rechecked against unauthenticated `GET /ghost/api/admin/site/` before every page
+- **Authentication**: public-read Content API credential only; Admin API keys,
+  staff tokens, user sessions, and JWT generation are unreachable
+- **Isolation**: exact GET paths, fixed v6 header, rejected redirects, bounded
+  response/page sizes, no arbitrary filters, and no browser or mutation fallback
+- **Private categories**: members, newsletters, staff, drafts, and comments remain
+  gated or unavailable; no private record is normalized
+
+<!-- AI-CONTEXT-END -->
+
+## Evidence boundary
+
+The route and official documentation were checked on 2026-08-02. The worker
+runtime is Python 3.12.3. Standard-library `urllib.request`, `urllib.parse`, and
+`json` exports are present. Python `requests` and `jwt` happen to be installed,
+but this adapter imports neither. Neither `@tryghost/content-api` nor
+`@tryghost/admin-api` is installed in the repository. The official clients are
+therefore reference evidence rather than runtime dependencies.
+
+Ghost's current Content API is a stable, read-only surface rooted at
+`https://{admin_domain}/ghost/api/content/`. A custom integration supplies a hex
+Content API credential in the `key` query parameter. Ghost explicitly describes
+that credential as safe for browser/public-data use, while warning that private
+sites should still control distribution:
+https://docs.ghost.org/content-api.md.
+
+The current JavaScript client documentation identifies
+`@tryghost/content-api` and says integrations should set `version: "v6.0"`:
+https://docs.ghost.org/content-api/javascript.md. This implementation uses the
+equivalent `Accept-Version: v6.0` header. Ghost responds with `Content-Version`
+when version negotiation is used, and documents stable API compatibility for a
+minimum of two years:
+https://docs.ghost.org/faq/api-versioning/.
+
+The unauthenticated Admin `site` endpoint returns the frontend URL and Ghost
+version, including when the admin and frontend domains differ. It is the only
+Admin-path request in the allowlist and carries no credential:
+https://docs.ghost.org/admin-api/site/overview.md.
+
+## Implemented Content API contract
+
+| Category | Disposition | Exact route and boundary |
+|---|---|---|
+| Posts | **Live/Partial** | `GET /ghost/api/content/posts/`; published/currently visible content only |
+| Pages | **Live/Partial** | `GET /ghost/api/content/pages/`; resource pages, not dynamic routes |
+| Tags | **Live/Partial** | `GET /ghost/api/content/tags/` with fixed `visibility:public`; internal and unused tags excluded |
+| Authors | **Live/Partial** | `GET /ghost/api/content/authors/`; only authors associated with published posts, with location/social/profile media omitted |
+| Members | **Gate/No** | Stable Admin reads exist but expose email, geolocation, notes, subscriptions, payment metadata, activity, suppression state, and signed unsubscribe URLs; no route is enabled |
+| Newsletters | **Gate** | Stable Admin reads exist, but the same integration authority also exposes newsletter mutation; no minimum read-only credential is documented |
+| Comments | **No/Gate** | No stable comment endpoint is listed for integrations in the current Admin API contract; theme rendering is not an account-history API |
+| Exports | **Export/Gate** | Owner-driven Content & settings JSON is documented in Ghost Admin; no automated export endpoint or fixture-validated importer is enabled |
+
+Official resource and parameter contracts:
+
+- posts: https://docs.ghost.org/content-api/posts.md
+- pages: https://docs.ghost.org/content-api/pages.md
+- tags: https://docs.ghost.org/content-api/tags.md
+- authors: https://docs.ghost.org/content-api/authors.md
+- parameters and maximum 100-item pages:
+  https://docs.ghost.org/content-api/parameters.md
+- numeric `meta.pagination` shape:
+  https://docs.ghost.org/content-api/pagination.md
+
+Posts and pages request only the documented `html,plaintext` formats. Tags and
+authors request only `count.posts`. The child serializes an allowlist of stable
+IDs, titles/names, slugs, public text, and timestamps before evidence crosses the
+process boundary. URLs, code injection, images, social handles, author location,
+and unknown response fields are discarded. Tags must still report public
+visibility after the server-side filter.
+
+Each browse response must contain the requested numeric page and limit, a
+consistent total/pages pair, exact previous/next values, no more than 100 objects,
+and an advancing next page. A malformed page, unexpected resource wrapper,
+oversized response, repeated cursor, HTTP terminal result, or credential-shaped
+field commits neither raw evidence nor a checkpoint. Snapshot completion never
+infers deletion from a later partial run.
+
+The Content API says its cacheable public reads can be fetched without a provider
+limit. The collector still budgets one initial identity request and two units per
+page (identity recheck plus content read), caps each invocation at 1,000 units,
+and caps pages at 100 items. Provider or hosting-layer throttling remains terminal
+for the invocation and preserves prior state.
+
+## Admin and PII gate
+
+The Admin API supports integration JWTs, staff access JWTs, and user sessions.
+Admin keys are secret `id:hex-secret` values used to mint HS256 tokens with a
+maximum five-minute expiry and `/admin/` audience. Current integration
+permissions are a fixed set that includes both reads and writes for posts, pages,
+tags, tiers, newsletters, offers, members, labels, and other management surfaces:
+https://docs.ghost.org/admin-api.md. The official `@tryghost/admin-api` client
+demonstrates add/edit/delete and upload methods as well as reads:
+https://docs.ghost.org/admin-api/javascript.md.
+
+That credential cannot satisfy a minimum-privilege, read-only collector boundary.
+The live child accepts only a hex Content API credential and an exact
+`AUTH_MODE=content_api_key`; a colon-delimited Admin key, JWT, Authorization
+header, staff token, or session cookie is not accepted or inherited. Exact route
+tests reject `/members/`, `/newsletters/`, `/users/`, `/comments/`, `/db/`, and
+every POST/PUT/PATCH/DELETE construction.
+
+Members are especially sensitive. The official response includes email, name,
+notes, geolocation, subscription and Stripe references, engagement counts,
+last-seen state, commenting/suppression state, and an unsubscribe URL:
+https://docs.ghost.org/admin-api/members/overview.md. Newsletter records can
+include sender addresses and configuration, and their integration endpoint is
+also mutable:
+https://docs.ghost.org/admin-api/newsletters/overview.md. Neither category is
+needed to build public publication knowledge, so minimization is a hard gate
+rather than a redaction heuristic.
+
+## Profile and collection
+
+Store profile values outside the repository. Never place a Content credential,
+Admin credential, signed token, private site URL, or export in an issue, fixture,
+command argument, log, or evidence row.
+
+| Profile variable | Contract |
+|---|---|
+| `GHOST_<PROFILE>_ADMIN_URL` | Exact HTTPS admin base, including an installation subpath but excluding `/ghost/api/...` |
+| `GHOST_<PROFILE>_SITE_URL` | Exact expected HTTPS frontend URL returned by the site identity endpoint |
+| `GHOST_<PROFILE>_SITE_ID` | Operator-selected opaque ID; must equal `--account-id` |
+| `GHOST_<PROFILE>_CONTENT_API_KEY` | Hex Content API credential; isolated to the child and omitted from output |
+| `GHOST_<PROFILE>_ORIGIN_KEY` | At least 32 bytes, used to HMAC the admin origin into a private installation namespace |
+| `GHOST_<PROFILE>_AUTH_MODE` | Exactly `content_api_key` |
+
+```bash
+knowledge-social-helper.sh sync-ghost \
+  --connection-id conn_ghost_publication \
+  --account-id ghost_publication \
+  --stream posts \
+  --profile publication \
+  --budget 11 \
+  --page-size 100
+```
+
+Run pages, tags, and authors separately so each stream owns its cursor, lease,
+coverage, and terminal result. A valid credential for another site still fails
+because the exact expected frontend URL and keyed admin-origin namespace are
+rebound before each content page. HTTP redirects are never followed, including
+custom-domain redirects; configure the final admin base and expected frontend
+URL explicitly.
+
+## Exports, retention, privacy, and terms
+
+Ghost documents an owner-driven **Content & settings** JSON download in Admin,
+plus separate routes/redirects, theme, and image backup steps. It does not
+document that UI export as a stable authenticated API endpoint or a complete
+members/comments archive:
+https://docs.ghost.org/migration/ghost.md. Until a sanitized current owner export
+proves identity, schema, completeness, and credential scrubbing, no importer is
+registered.
+
+Ghost's hosted-service privacy policy retains personal data only while needed for
+the collection purpose, business/legal needs, or applicable law; it gives no
+publication-specific API history or deletion SLA:
+https://ghost.org/privacy/. Ghost's terms make operators responsible for lawful
+content rights and backups, prohibit unauthorized downloading and personal-data
+collection, and require avoiding excessive service load:
+https://ghost.org/terms/.
+
+Keep each corpus owner-only and purpose-bound. Public API availability is not a
+license to retain personal author data indefinitely. Remove evidence when
+authority or purpose ends, do not share raw records by default, and never claim
+that a completed snapshot includes deleted, unpublished, historical, member, or
+comment evidence.

--- a/.agents/scripts/_knowledge_social_ghost.py
+++ b/.agents/scripts/_knowledge_social_ghost.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Ghost publication stream policy and durable snapshot checkpoints."""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from _knowledge_social_ghost_identity import (
+    GhostAdapterError,
+    GhostProviderUnavailableError,
+    instance_id,
+    namespaced_id,
+    provider_account_id,
+)
+from _knowledge_social_oauth_request import OAuthPageRequest
+from knowledge_social_import import canonical_json, reject_credentials
+
+PROVIDER = "ghost"
+CURSOR_PREFIX = "ghost-v1:"
+RETENTION_LIMIT = "current_publication_visibility_and_operator_retention"
+MAX_PAGE_ITEMS = 100
+ACCOUNT_AUTH_MODE = "content_api_key"
+
+ADAPTER_ERROR = GhostAdapterError
+PROVIDER_UNAVAILABLE_ERROR = GhostProviderUnavailableError
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    """Static collection and coverage policy for one Ghost stream."""
+
+    resource_kind: str
+    activity_mode: str
+    pagination: str
+    incremental: bool
+    retention_limit: str | None
+    coverage_status: str | None = None
+    unavailable_reason: str | None = None
+    cost_units: int = 2
+
+
+def _snapshot(resource_kind: str, activity_mode: str) -> StreamSpec:
+    return StreamSpec(
+        resource_kind,
+        activity_mode,
+        "snapshot",
+        False,
+        RETENTION_LIMIT,
+    )
+
+
+STREAMS = {
+    "posts": _snapshot("post", "content_author"),
+    "pages": _snapshot("page", "content_author"),
+    "tags": _snapshot("tag", "selected_account"),
+    "authors": _snapshot("author", "selected_account"),
+}
+
+
+class PageRequest(OAuthPageRequest):
+    """Allowlisted bounded request passed to the Ghost HTTP subprocess."""
+
+    HANDLE_KEY = "site_id"
+
+    @property
+    def site_id(self) -> str:
+        return self.handle
+
+
+PAGE_REQUEST_KEYS = {
+    "action",
+    "stream",
+    "account_id",
+    "provider_account_id",
+    "site_id",
+    "instance_id",
+    "position",
+    "stop_at",
+    "limit",
+}
+
+
+def _checkpoint_id(value: Any, field: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if (
+        not isinstance(value, str)
+        or not value
+        or "\x00" in value
+        or len(value.encode("utf-8")) > 512
+    ):
+        raise GhostAdapterError(f"Ghost {field} is invalid")
+    return value
+
+
+def _position(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise GhostAdapterError(f"Ghost {field} must be positive")
+    return value
+
+
+def _encode_cursor(position: int) -> str:
+    encoded = base64.urlsafe_b64encode(
+        canonical_json({"position": position}).encode()
+    ).decode("ascii").rstrip("=")
+    return f"{CURSOR_PREFIX}{encoded}"
+
+
+def _decode_cursor(cursor: str) -> int:
+    if not cursor.startswith(CURSOR_PREFIX):
+        raise GhostAdapterError("stored Ghost cursor has an unsupported version")
+    encoded = cursor.removeprefix(CURSOR_PREFIX)
+    try:
+        parsed = json.loads(
+            base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4))
+        )
+    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+        raise GhostAdapterError("stored Ghost cursor is invalid") from error
+    if not isinstance(parsed, dict) or set(parsed) != {"position"}:
+        raise GhostAdapterError("stored Ghost cursor has an invalid shape")
+    reject_credentials(parsed)
+    return _position(parsed["position"], "cursor position")
+
+
+def page_request(
+    stream: str,
+    account: dict[str, Any],
+    state: CursorState,
+    limit: int,
+) -> PageRequest:
+    """Build one allowlisted request from durable per-stream state."""
+    if stream not in STREAMS:
+        raise GhostAdapterError("Ghost stream is unsupported")
+    selected_id = _checkpoint_id(account.get("id"), "selected account ID")
+    if selected_id is None:
+        raise GhostAdapterError("verified Ghost identity is incomplete")
+    site = provider_account_id(account.get("provider_account_id"))
+    position = _decode_cursor(state.cursor) if state.cursor else 1
+    return PageRequest(
+        stream,
+        selected_id,
+        site,
+        provider_account_id(account.get("site_id")),
+        instance_id(account.get("instance_id")),
+        position,
+        None,
+        limit,
+    )
+
+
+def parse_page_request(payload: dict[str, Any]) -> PageRequest:
+    """Validate the exact child-process page request shape."""
+    if set(payload) != PAGE_REQUEST_KEYS or payload.get("action") != "page":
+        raise GhostAdapterError("Ghost read request has an invalid action shape")
+    stream = payload.get("stream")
+    if not isinstance(stream, str) or stream not in STREAMS:
+        raise GhostAdapterError("Ghost stream is unsupported")
+    limit = payload.get("limit")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 100:
+        raise GhostAdapterError("Ghost page size is invalid")
+    account_id = _checkpoint_id(payload.get("account_id"), "selected account ID")
+    if account_id is None:
+        raise GhostAdapterError("Ghost selected account ID is required")
+    if payload.get("stop_at") is not None:
+        raise GhostAdapterError("Ghost snapshot request cannot contain a watermark")
+    return PageRequest(
+        stream,
+        account_id,
+        provider_account_id(payload.get("provider_account_id")),
+        provider_account_id(payload.get("site_id")),
+        instance_id(payload.get("instance_id")),
+        _position(payload.get("position"), "page position"),
+        None,
+        limit,
+    )
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    """Return a validated HTTP-like status from a Ghost response."""
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise GhostAdapterError("Ghost response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise GhostAdapterError("Ghost page data must be an array")
+    return data
+
+
+@dataclass(frozen=True)
+class PageMetadata:
+    next_position: int | None
+    newest_id: str | None
+    complete: bool
+
+
+def _page_metadata(payload: dict[str, Any], request: PageRequest) -> PageMetadata:
+    meta = payload.get("meta")
+    if not isinstance(meta, dict):
+        raise GhostAdapterError("Ghost page metadata must be an object")
+    reject_credentials(meta)
+    if meta.get("stream") != request.stream:
+        raise GhostAdapterError("Ghost page provenance is invalid")
+    if instance_id(meta.get("instance_id")) != request.instance_id:
+        raise GhostAdapterError("Ghost page provenance is invalid")
+    next_value = meta.get("next_position")
+    next_position = None if next_value is None else _position(next_value, "next page")
+    if next_position is not None and next_position <= request.position:
+        raise GhostAdapterError("Ghost next page position did not advance")
+    complete = meta.get("complete")
+    if not isinstance(complete, bool) or complete == (next_position is not None):
+        raise GhostAdapterError("Ghost page completion cursor is invalid")
+    if meta.get("snapshot") is not True:
+        raise GhostAdapterError("Ghost page pagination metadata is invalid")
+    return PageMetadata(
+        next_position,
+        _checkpoint_id(meta.get("newest_id"), "newest ID", optional=True),
+        complete,
+    )
+
+
+def page_checkpoint(
+    payload: dict[str, Any],
+    state: CursorState,
+    request: PageRequest,
+) -> tuple[PageCheckpoint, bool]:
+    """Calculate one atomic per-installation, per-stream checkpoint."""
+    meta = _page_metadata(payload, request)
+    if len(page_data(payload)) > MAX_PAGE_ITEMS:
+        raise GhostAdapterError("Ghost page exceeds the item safety limit")
+    next_cursor = _encode_cursor(meta.next_position) if meta.next_position else None
+    return PageCheckpoint(next_cursor, state.watermark), meta.complete

--- a/.agents/scripts/_knowledge_social_ghost_contract.py
+++ b/.agents/scripts/_knowledge_social_ghost_contract.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validation and serialization for the bounded Ghost HTTP child."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_ghost_identity import (
+    GhostAdapterError,
+    instance_id,
+    provider_account_id,
+)
+
+MAX_TEXT_BYTES = 1024 * 1024
+SITE_VERSION = re.compile(r"^(?P<major>[0-9]{1,3})\.[0-9]{1,3}(?:\.[0-9]{1,3})?$")
+
+
+class GhostReadProviderError(RuntimeError):
+    """Raised for a privacy-safe local Ghost provider failure."""
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    status: int
+    payload: Any
+    retry_after: int | None = None
+
+
+def observed_at() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def exact_keys(request: dict[str, Any], expected: set[str]) -> None:
+    if set(request) != expected:
+        raise GhostReadProviderError("Ghost read request has an invalid action shape")
+
+
+def request_object(payload: bytes, limit: int) -> dict[str, Any]:
+    if len(payload) > limit:
+        raise GhostReadProviderError("Ghost read request exceeds the safety limit")
+    try:
+        request = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise GhostReadProviderError("Ghost read request is not valid JSON") from error
+    if not isinstance(request, dict):
+        raise GhostReadProviderError("Ghost read request root must be an object")
+    return request
+
+
+def object_value(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise GhostReadProviderError(f"Ghost {field} must be an object")
+    return value
+
+
+def object_list(value: Any, field: str, *, limit: int) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise GhostReadProviderError(f"Ghost {field} must be an array of objects")
+    if len(value) > limit:
+        raise GhostReadProviderError(f"Ghost {field} exceeds the item safety limit")
+    return value
+
+
+def optional_text(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value:
+        raise GhostReadProviderError(f"Ghost {field} must be text")
+    if len(value.encode("utf-8")) > MAX_TEXT_BYTES:
+        raise GhostReadProviderError(f"Ghost {field} exceeds the safety limit")
+    return value
+
+
+def required_text(value: Any, field: str) -> str:
+    text = optional_text(value, field)
+    if not text:
+        raise GhostReadProviderError(f"Ghost {field} is required")
+    return text
+
+
+def non_negative_integer(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise GhostReadProviderError(f"Ghost {field} must be a non-negative integer")
+    return value
+
+
+def positive_integer(value: Any, field: str) -> int:
+    number = non_negative_integer(value, field)
+    if number < 1:
+        raise GhostReadProviderError(f"Ghost {field} must be positive")
+    return number
+
+
+def site_version(value: Any) -> str:
+    version = required_text(value, "site version")
+    match = SITE_VERSION.fullmatch(version)
+    if match is None or int(match.group("major")) < 6:
+        raise GhostReadProviderError("Ghost site does not satisfy API v6")
+    return version
+
+
+def identity_value(
+    payload: Any,
+    expected_id: str,
+    installation: str,
+) -> dict[str, Any]:
+    """Serialize only non-sensitive fields from the unauthenticated site route."""
+    site = object_value(object_value(payload, "site response").get("site"), "site")
+    return {
+        "provider_account_id": provider_account_id(expected_id),
+        "site_id": provider_account_id(expected_id),
+        "display_name": required_text(site.get("title"), "site title"),
+        "version": site_version(site.get("version")),
+        "instance_id": instance_id(installation),
+    }
+
+
+def terminal_payload(result: ApiResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": result.status, "observed_at": observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload
+
+
+__all__ = [
+    "ApiResult",
+    "GhostAdapterError",
+    "GhostReadProviderError",
+    "exact_keys",
+    "identity_value",
+    "non_negative_integer",
+    "object_list",
+    "object_value",
+    "observed_at",
+    "optional_text",
+    "positive_integer",
+    "request_object",
+    "required_text",
+    "site_version",
+    "terminal_payload",
+]

--- a/.agents/scripts/_knowledge_social_ghost_http.py
+++ b/.agents/scripts/_knowledge_social_ghost_http.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Exact-origin, redirect-free HTTP transport for Ghost Content API reads."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import math
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import SplitResult, urlencode, urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from _knowledge_social_ghost_contract import ApiResult, GhostReadProviderError
+from _knowledge_social_ghost_routes import SITE_PATH, STREAM_PATHS, allowlisted_path
+
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+HTTP_TIMEOUT_SECONDS = 60
+ACCEPT_VERSION = "v6.0"
+
+
+class Response(Protocol):
+    status: int
+
+    def __enter__(self) -> Response: ...
+
+    def __exit__(self, *args: Any) -> None: ...
+
+    def read(self, size: int = -1) -> bytes: ...
+
+
+class Opener(Protocol):
+    def open(self, request: Request, timeout: int) -> Response: ...
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    """Validated public-read profile and privacy-safe installation identity."""
+
+    admin_url: str
+    site_url: str
+    site_id: str
+    content_api_key: str
+    auth_mode: str
+    instance_id: str
+
+
+class _RejectRedirect(HTTPRedirectHandler):
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def _parsed_url(value: str) -> tuple[SplitResult, int | None]:
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError as error:
+        raise GhostReadProviderError("Ghost profile URL is invalid") from error
+    return parsed, port
+
+
+def _validate_origin(parsed: SplitResult) -> None:
+    checks = (
+        parsed.scheme.lower() == "https",
+        parsed.hostname is not None,
+        parsed.username is None,
+        parsed.password is None,
+        not parsed.query,
+        not parsed.fragment,
+    )
+    if not all(checks):
+        raise GhostReadProviderError("Ghost profile URL must be HTTPS")
+
+
+def _canonical_path(path: str, *, admin: bool) -> str:
+    result = path.rstrip("/")
+    if any(marker in result for marker in ("\\", "%", "//")):
+        raise GhostReadProviderError("Ghost profile URL is invalid")
+    if any(part in (".", "..") for part in result.split("/") if part):
+        raise GhostReadProviderError("Ghost profile URL is invalid")
+    lowered = result.lower()
+    if admin and (lowered.endswith("/ghost") or "/ghost/api" in lowered):
+        raise GhostReadProviderError("Ghost profile admin URL must omit the API path")
+    return result
+
+
+def _canonical_url(value: str, *, admin: bool) -> str:
+    parsed, port = _parsed_url(value)
+    _validate_origin(parsed)
+    host = parsed.hostname or ""
+    rendered = f"[{host.lower()}]" if ":" in host else host.lower()
+    if port is not None and port != 443:
+        rendered = f"{rendered}:{port}"
+    return f"https://{rendered}{_canonical_path(parsed.path, admin=admin)}"
+
+
+def _canonical_admin_url(value: str) -> str:
+    """Canonicalize one HTTPS admin base without exposing it in failures."""
+    return _canonical_url(value, admin=True)
+
+
+def _canonical_site_url(value: str) -> str:
+    """Canonicalize one expected HTTPS publication URL."""
+    return _canonical_url(value, admin=False)
+
+
+def installation_fingerprint(admin_url: str, origin_key: str) -> str:
+    canonical = _canonical_admin_url(admin_url)
+    key = origin_key.encode()
+    if len(key) < 32:
+        raise GhostReadProviderError("Ghost profile origin key must be at least 32 bytes")
+    return hmac.new(key, canonical.encode(), hashlib.sha256).hexdigest()[:24]
+
+
+def _http_exports() -> Opener:
+    exports = (Request, build_opener, urlencode, urlsplit, HTTPRedirectHandler)
+    if not all(callable(item) for item in exports):
+        raise GhostReadProviderError("Python urllib HTTP exports are unavailable")
+    return build_opener(_RejectRedirect())
+
+
+def _retry_epoch(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    return int(time.time() + math.ceil(seconds))
+
+
+def _parse_json(payload: bytes) -> Any:
+    try:
+        return json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise GhostReadProviderError("Ghost read provider returned no valid JSON") from error
+
+
+def _decode_response(payload: bytes) -> Any:
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise GhostReadProviderError("Ghost read response exceeds the safety limit")
+    value = _parse_json(payload)
+    if not isinstance(value, dict):
+        raise GhostReadProviderError("Ghost API response root must be an object")
+    return value
+
+
+def _query_keys(path: str) -> frozenset[str]:
+    if path == SITE_PATH:
+        return frozenset()
+    if path in (STREAM_PATHS["posts"], STREAM_PATHS["pages"]):
+        return frozenset({"page", "limit", "formats"})
+    if path == STREAM_PATHS["tags"]:
+        return frozenset({"page", "limit", "filter", "include"})
+    if path == STREAM_PATHS["authors"]:
+        return frozenset({"page", "limit", "include"})
+    return frozenset()
+
+
+def _validate_api_request(path: str, params: dict[str, str]) -> None:
+    if not allowlisted_path(path) or set(params) != _query_keys(path):
+        raise GhostReadProviderError("Ghost API route is not allowlisted")
+    for key, value in params.items():
+        if not isinstance(key, str) or not isinstance(value, str) or "\x00" in value:
+            raise GhostReadProviderError("Ghost API query is invalid")
+    if path == SITE_PATH:
+        return
+    try:
+        page = int(params["page"])
+        limit = int(params["limit"])
+    except (KeyError, ValueError) as error:
+        raise GhostReadProviderError("Ghost API pagination query is invalid") from error
+    if page < 1 or not 1 <= limit <= 100:
+        raise GhostReadProviderError("Ghost API pagination query is invalid")
+    if "formats" in params and params["formats"] != "html,plaintext":
+        raise GhostReadProviderError("Ghost Content API formats are invalid")
+    if "filter" in params and params["filter"] != "visibility:public":
+        raise GhostReadProviderError("Ghost tag visibility filter is invalid")
+    if "include" in params and params["include"] != "count.posts":
+        raise GhostReadProviderError("Ghost Content API include is invalid")
+
+
+def _http_status(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise GhostReadProviderError("Ghost HTTP status is invalid")
+    return value
+
+
+def _request_for(config: ProfileConfig, path: str, params: dict[str, str]) -> Request:
+    query_params = dict(params)
+    if path != SITE_PATH:
+        query_params["key"] = config.content_api_key
+    query = f"?{urlencode(query_params)}" if query_params else ""
+    return Request(
+        f"{config.admin_url}{path}{query}",
+        headers={
+            "Accept": "application/json",
+            "Accept-Version": ACCEPT_VERSION,
+            "User-Agent": "aidevops-ghost-knowledge/1",
+        },
+        method="GET",
+    )
+
+
+def _read_result(response: Response) -> ApiResult:
+    status = _http_status(getattr(response, "status", 200))
+    payload = response.read(MAX_RESPONSE_BYTES + 1)
+    if not isinstance(payload, bytes):
+        raise GhostReadProviderError("Ghost HTTP response is invalid")
+    return ApiResult(status, _decode_response(payload))
+
+
+def _error_result(error: HTTPError) -> ApiResult:
+    retry = error.headers.get("Retry-After") if error.headers is not None else None
+    return ApiResult(_http_status(error.code), {}, _retry_epoch(retry))
+
+
+def api(
+    config: ProfileConfig,
+    opener: Opener,
+    path: str,
+    params: dict[str, str],
+) -> ApiResult:
+    """Execute one exact-origin, redirect-free, GET-only JSON request."""
+    _validate_api_request(path, params)
+    request = _request_for(config, path, params)
+    try:
+        with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            return _read_result(response)
+    except HTTPError as error:
+        return _error_result(error)
+    except (TimeoutError, URLError, OSError) as error:
+        raise GhostReadProviderError("Ghost read provider request failed") from error

--- a/.agents/scripts/_knowledge_social_ghost_identity.py
+++ b/.agents/scripts/_knowledge_social_ghost_identity.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Ghost installation, publication, and resource identity validation."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from knowledge_social_store import SocialStoreError
+
+INSTANCE_ID = re.compile(r"^[0-9a-f]{24}$")
+SITE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{2,127}$")
+RESOURCE_KIND = re.compile(r"^[a-z][a-z_]{0,31}$")
+RESOURCE_ID = re.compile(r"^[A-Za-z0-9_.~-]{1,200}$")
+
+
+class GhostAdapterError(SocialStoreError):
+    """Raised when guarded Ghost collection cannot continue safely."""
+
+
+class GhostProviderUnavailableError(GhostAdapterError):
+    """Raised when the bounded Ghost HTTP child cannot complete a read."""
+
+
+def _validated_text(value: Any, pattern: re.Pattern[str], message: str) -> str:
+    if not isinstance(value, str) or pattern.fullmatch(value) is None:
+        raise GhostAdapterError(message)
+    return value
+
+
+def instance_id(value: Any) -> str:
+    """Validate a privacy-safe stable Ghost installation fingerprint."""
+    return _validated_text(value, INSTANCE_ID, "Ghost installation identity is invalid")
+
+
+def provider_account_id(value: Any) -> str:
+    """Validate one operator-selected opaque publication identity."""
+    return _validated_text(value, SITE_ID, "Ghost publication ID is invalid")
+
+
+def namespaced_id(installation: str, kind: str, value: str) -> str:
+    """Namespace installation-local Ghost resource IDs for shared storage."""
+    stable_installation = instance_id(installation)
+    if RESOURCE_KIND.fullmatch(kind) is None:
+        raise GhostAdapterError("Ghost resource kind is invalid")
+    stable_value = _validated_text(value, RESOURCE_ID, "Ghost resource ID is invalid")
+    return f"gst_{stable_installation}_{kind}_{stable_value}"

--- a/.agents/scripts/_knowledge_social_ghost_normalize.py
+++ b/.agents/scripts/_knowledge_social_ghost_normalize.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize allowlisted Ghost public records into provider-neutral evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_ghost import (
+    ACCOUNT_AUTH_MODE,
+    PROVIDER,
+    RETENTION_LIMIT,
+    GhostAdapterError,
+    instance_id,
+    page_data,
+)
+from _knowledge_social_ghost_http import ACCEPT_VERSION
+from knowledge_social_import import reject_credentials
+
+PROVENANCE = "ghost_content_api_v6"
+GAPS = (
+    ("members", "sensitive_admin_member_records_are_not_enabled"),
+    ("newsletters", "mutation_capable_admin_authority_is_not_enabled"),
+    ("comments", "no_stable_documented_content_or_integration_read_route"),
+    ("account_export", "manual_owner_export_is_not_fixture_validated"),
+    ("staff_and_owner_identity", "privileged_admin_identity_is_not_enabled"),
+    ("drafts_and_unpublished", "mutation_capable_admin_authority_is_not_enabled"),
+    ("deleted_or_purged_content", "not_available_through_current_public_reads"),
+    ("provider_retention", "no_publication_specific_retention_guarantee"),
+)
+OBJECT_TYPES = frozenset({"post", "page", "tag", "author"})
+
+
+@dataclass(frozen=True)
+class PageContext:
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def _required_text(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise GhostAdapterError(f"Ghost record requires {key}")
+    return value
+
+
+def _optional_text(record: dict[str, Any], key: str) -> str | None:
+    value = record.get(key)
+    if value is not None and (not isinstance(value, str) or "\x00" in value):
+        raise GhostAdapterError(f"Ghost record {key} must be text")
+    return value
+
+
+def _observed_at(payload: dict[str, Any]) -> str:
+    value = payload.get("observed_at")
+    if not isinstance(value, str) or not value:
+        raise GhostAdapterError("Ghost page observed_at must be text")
+    return value
+
+
+def _text(record: dict[str, Any]) -> str | None:
+    values = [
+        value
+        for key in (
+            "title",
+            "plaintext",
+            "custom_excerpt",
+            "excerpt",
+            "name",
+            "description",
+            "bio",
+        )
+        if (value := _optional_text(record, key))
+    ]
+    return "\n\n".join(dict.fromkeys(values)) or None
+
+
+def _coverage(observed_at: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "stream": stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": RETENTION_LIMIT,
+            "unavailable_reason": reason,
+            "status": "unavailable",
+            "observed_at": observed_at,
+        }
+        for stream, reason in GAPS
+    ]
+
+
+def _item_kind(item: dict[str, Any]) -> str:
+    kind = item.get("kind")
+    if not isinstance(kind, str) or kind not in OBJECT_TYPES:
+        raise GhostAdapterError("Ghost page contains an unsupported item kind")
+    return kind
+
+
+def _occurred_at(item: dict[str, Any]) -> str | None:
+    return _optional_text(item, "published_at") or _optional_text(item, "created_at")
+
+
+def _object_row(
+    item: dict[str, Any], context: PageContext, observed_at: str, installation: str
+) -> dict[str, Any]:
+    kind = _item_kind(item)
+    remote_id = _required_text(item, "remote_id")
+    published = kind in ("post", "page")
+    provider_json = {
+        "source": PROVENANCE,
+        "instance_id": installation,
+        "stream": context.stream,
+        "record": item,
+    }
+    reject_credentials(provider_json)
+    return {
+        "object_type": kind,
+        "remote_id": remote_id,
+        "account_remote_id": context.account.get("id") if published else None,
+        "text": _text(item),
+        "created_at": _occurred_at(item),
+        "observed_at": observed_at,
+        "evidence_class": "published" if published else "observed",
+        "provider_json": provider_json,
+    }
+
+
+def _activity_rows(
+    items: list[dict[str, Any]],
+    context: PageContext,
+    observed_at: str,
+    installation: str,
+) -> list[dict[str, Any]]:
+    if context.stream not in ("posts", "pages"):
+        return []
+    account_id = _required_text(context.account, "id")
+    return [
+        {
+            "activity_type": f"published_{_item_kind(item)}",
+            "remote_id": f"{account_id}_published_{_required_text(item, 'remote_id')}",
+            "actor_remote_id": account_id,
+            "object_remote_id": _required_text(item, "remote_id"),
+            "occurred_at": _occurred_at(item),
+            "observed_at": observed_at,
+            "state": "active",
+            "provider_json": {
+                "source": PROVENANCE,
+                "instance_id": installation,
+                "stream": context.stream,
+            },
+        }
+        for item in items
+    ]
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    """Build provider-neutral rows and explicit Ghost trust-boundary gaps."""
+    reject_credentials(payload)
+    observed_at = _observed_at(payload)
+    installation = instance_id(context.account.get("instance_id"))
+    items = page_data(payload)
+    objects = [_object_row(item, context, observed_at, installation) for item in items]
+    policy = dict(context.policy)
+    policy.update(
+        {
+            "ghost_auth_mode": ACCOUNT_AUTH_MODE,
+            "ghost_api_version": ACCEPT_VERSION,
+            "ghost_instance_id": installation,
+            "ghost_transport": "stdlib_urllib_get_only",
+            "ghost_redirects": "rejected",
+            "ghost_admin_routes": "unauthenticated_site_identity_only",
+            "ghost_private_records": "members_comments_and_staff_excluded",
+        }
+    )
+    archive = {
+        "provider": PROVIDER,
+        "connection_id": context.connection_id,
+        "remote_account_id": context.account.get("id"),
+        "exported_at": observed_at,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": policy,
+        "accounts": [
+            {
+                "remote_id": context.account.get("id"),
+                "handle": context.account.get("site_id"),
+                "display_name": context.account.get("name"),
+                "observed_at": observed_at,
+                "provider_json": {
+                    "source": PROVENANCE,
+                    "instance_id": installation,
+                    "provider_account_id": context.account.get("provider_account_id"),
+                    "site_version": context.account.get("version"),
+                },
+            }
+        ],
+        "objects": objects,
+        "activities": _activity_rows(items, context, observed_at, installation),
+        "media": [],
+        "coverage": _coverage(observed_at),
+    }
+    reject_credentials(archive)
+    return archive

--- a/.agents/scripts/_knowledge_social_ghost_provider.py
+++ b/.agents/scripts/_knowledge_social_ghost_provider.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded, redirect-free, GET-only Ghost Content API reader subprocess."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from functools import partial
+from typing import Any
+
+from _knowledge_social_ghost import (
+    ACCOUNT_AUTH_MODE,
+    GhostAdapterError,
+    PageRequest,
+    namespaced_id,
+    parse_page_request,
+    provider_account_id,
+)
+from _knowledge_social_ghost_contract import (
+    ApiResult,
+    GhostReadProviderError,
+    exact_keys,
+    identity_value,
+    object_value,
+    request_object,
+    required_text,
+    terminal_payload,
+)
+from _knowledge_social_ghost_http import (
+    MAX_RESPONSE_BYTES,
+    Opener,
+    ProfileConfig,
+    _canonical_admin_url,
+    _canonical_site_url,
+    _http_exports,
+    api,
+    installation_fingerprint,
+)
+from _knowledge_social_ghost_routes import SITE_PATH, page
+
+MAX_REQUEST_BYTES = 32 * 1024
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+CONTENT_KEY = re.compile(r"^[0-9a-fA-F]{16,256}$")
+
+
+def _profile_prefix(profile: str) -> str:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise GhostReadProviderError("Ghost profile name is invalid")
+    return f"GHOST_{profile.upper()}"
+
+
+def _profile_value(prefix: str, suffix: str, field: str, limit: int) -> str:
+    value = os.environ.get(f"{prefix}_{suffix}", "")
+    if not value or "\x00" in value or len(value.encode()) > limit:
+        raise GhostReadProviderError(f"Ghost profile {field} is missing")
+    return value
+
+
+def _profile(profile: str) -> ProfileConfig:
+    prefix = _profile_prefix(profile)
+    values = tuple(
+        _profile_value(prefix, suffix, field, limit)
+        for suffix, field, limit in (
+            ("ADMIN_URL", "admin URL", 4096),
+            ("SITE_URL", "site URL", 4096),
+            ("SITE_ID", "site ID", 128),
+            ("CONTENT_API_KEY", "Content API credential", 1024),
+            ("ORIGIN_KEY", "origin key", 16 * 1024),
+            ("AUTH_MODE", "auth mode", 64),
+        )
+    )
+    admin_url, site_url, site_id, content_key, origin_key, auth_mode = values
+    admin_url = _canonical_admin_url(admin_url)
+    site_url = _canonical_site_url(site_url)
+    site_id = provider_account_id(site_id)
+    if CONTENT_KEY.fullmatch(content_key) is None:
+        raise GhostReadProviderError("Ghost profile Content API credential is invalid")
+    if auth_mode != ACCOUNT_AUTH_MODE:
+        raise GhostReadProviderError(
+            "Ghost profile must declare a public Content API credential"
+        )
+    return ProfileConfig(
+        admin_url,
+        site_url,
+        site_id,
+        content_key,
+        auth_mode,
+        installation_fingerprint(admin_url, origin_key),
+    )
+
+
+def _identity(config: ProfileConfig, opener: Opener, expected_id: str) -> dict[str, Any]:
+    selected_id = provider_account_id(expected_id)
+    if selected_id != config.site_id:
+        raise GhostReadProviderError(
+            "selected Ghost publication does not match the configured connection"
+        )
+    result = api(config, opener, SITE_PATH, {})
+    if result.status != 200:
+        return terminal_payload(result)
+    site = object_value(
+        object_value(result.payload, "site response").get("site"), "site"
+    )
+    observed_url = _canonical_site_url(required_text(site.get("url"), "site URL"))
+    if observed_url != config.site_url:
+        raise GhostReadProviderError(
+            "selected Ghost site URL does not match the configured connection"
+        )
+    return {
+        "status": 200,
+        "data": identity_value(result.payload, selected_id, config.instance_id),
+    }
+
+
+def _verify_page_account(
+    request: PageRequest, data: dict[str, Any], config: ProfileConfig
+) -> None:
+    expected = namespaced_id(config.instance_id, "site", config.site_id)
+    if (
+        data.get("instance_id") != request.instance_id
+        or data.get("provider_account_id") != request.provider_account_id
+        or data.get("site_id") != request.site_id
+        or request.account_id != expected
+    ):
+        raise GhostReadProviderError(
+            "selected Ghost publication does not match the configured connection"
+        )
+
+
+def _dispatch(
+    request: dict[str, Any], config: ProfileConfig, opener: Opener
+) -> dict[str, Any]:
+    action = request.get("action")
+    if action == "identity":
+        exact_keys(request, {"action", "account_id"})
+        return _identity(config, opener, provider_account_id(request.get("account_id")))
+    if action != "page":
+        raise GhostReadProviderError("Ghost read action is unsupported")
+    page_request = parse_page_request(request)
+    if page_request.instance_id != config.instance_id:
+        raise GhostReadProviderError(
+            "selected Ghost installation does not match the connection"
+        )
+    identity = _identity(config, opener, page_request.provider_account_id)
+    if identity.get("status") != 200:
+        return identity
+    data = object_value(identity.get("data"), "publication verification")
+    _verify_page_account(page_request, data, config)
+    result = page(partial(api, config, opener), page_request, data)
+    return terminal_payload(result) if isinstance(result, ApiResult) else result
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode()) > MAX_RESPONSE_BYTES:
+        raise GhostReadProviderError("Ghost read response exceeds the safety limit")
+    print(encoded)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        request = request_object(
+            sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1), MAX_REQUEST_BYTES
+        )
+        config = _profile(args.profile)
+        _emit(_dispatch(request, config, _http_exports()))
+        return 0
+    except (GhostReadProviderError, GhostAdapterError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - intentionally redact provider internals
+        print("ERROR: Ghost read provider request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_ghost_reader.py
+++ b/.agents/scripts/_knowledge_social_ghost_reader.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and deterministic fixture readers for Ghost collection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_ghost import (
+    GhostAdapterError,
+    GhostProviderUnavailableError,
+    PageRequest,
+    instance_id,
+    namespaced_id,
+    provider_account_id,
+)
+from _knowledge_social_ghost_contract import site_version
+from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
+from knowledge_social_import import reject_credentials
+
+READ_TIMEOUT_SECONDS = 120
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+SAFE_PROVIDER_FAILURES = (
+    "Python urllib HTTP exports are unavailable",
+    "Ghost profile name is invalid",
+    "Ghost profile admin URL is missing",
+    "Ghost profile site URL is missing",
+    "Ghost profile site ID is missing",
+    "Ghost profile Content API credential is missing",
+    "Ghost profile Content API credential is invalid",
+    "Ghost profile origin key is missing",
+    "Ghost profile origin key must be at least 32 bytes",
+    "Ghost profile auth mode is missing",
+    "Ghost profile must declare a public Content API credential",
+    "selected Ghost publication does not match the configured connection",
+    "selected Ghost installation does not match the connection",
+    "selected Ghost site URL does not match the configured connection",
+)
+
+
+class GhostReader(Protocol):
+    def identity(self, expected_id: str) -> dict[str, Any]: ...
+
+    def page(self, request: PageRequest) -> dict[str, Any]: ...
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    if len(output.encode()) > MAX_RESPONSE_BYTES:
+        raise GhostAdapterError("Ghost read response exceeds the safety limit")
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise GhostAdapterError("Ghost read provider returned no valid JSON") from error
+    if not isinstance(payload, dict):
+        raise GhostAdapterError("Ghost read response root must be an object")
+    return payload
+
+
+def _provider_failure(stderr: str) -> GhostProviderUnavailableError:
+    for message in SAFE_PROVIDER_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return GhostProviderUnavailableError(message)
+    return GhostProviderUnavailableError("Ghost read provider is unavailable")
+
+
+GHOST_READER_POLICY = GuardedOAuthPolicy(
+    "Ghost",
+    "GHOST",
+    "GHOST_READ_LOG",
+    READ_TIMEOUT_SECONDS,
+    _decode_output,
+    _provider_failure,
+    GhostProviderUnavailableError,
+    (
+        "ADMIN_URL",
+        "SITE_URL",
+        "SITE_ID",
+        "CONTENT_API_KEY",
+        "ORIGIN_KEY",
+        "AUTH_MODE",
+    ),
+    "",
+)
+
+
+class GuardedGhost(GuardedOAuthReader):
+    """Execute only publication identity and allowlisted Content API reads."""
+
+    def __init__(self, helper: Path, profile: str) -> None:
+        super().__init__(helper, profile, GHOST_READER_POLICY)
+
+
+def _fixture_object(value: Any, message: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise GhostAdapterError(message)
+    return value
+
+
+class FixtureGhost:
+    """Deterministic HTTP substitute for pagination and failure fixtures."""
+
+    def __init__(self, path: Path) -> None:
+        self.fixture = FixtureSequence(path, "Ghost", GhostAdapterError)
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        del expected_id
+        return self.fixture.identity()
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        entry = self.fixture.next_page()
+        expectation = _fixture_object(
+            entry.get("expect_request", {}),
+            "Ghost fixture request expectation must be an object",
+        )
+        actual = request.payload()
+        for key, value in expectation.items():
+            if actual.get(key) != value:
+                raise GhostAdapterError(
+                    "Ghost request did not resume at the expected checkpoint"
+                )
+        return _fixture_object(
+            entry.get("response", entry),
+            "Ghost fixture page response must be an object",
+        )
+
+
+def _display_text(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise GhostAdapterError(f"Ghost publication {field} must be text")
+    if len(value.encode()) > 256 * 1024:
+        raise GhostAdapterError(f"Ghost publication {field} must be text")
+    return value
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    """Bind an expected publication ID to one privacy-safe installation."""
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise GhostAdapterError("Ghost publication verification returned no site")
+    local_id = provider_account_id(data.get("provider_account_id"))
+    site = provider_account_id(data.get("site_id"))
+    installation = instance_id(data.get("instance_id"))
+    if local_id != provider_account_id(expected_id) or site != local_id:
+        raise GhostAdapterError(
+            "selected Ghost publication does not match the configured connection"
+        )
+    return {
+        "id": namespaced_id(installation, "site", local_id),
+        "provider_account_id": local_id,
+        "site_id": site,
+        "instance_id": installation,
+        "version": site_version(data.get("version")),
+        "name": _display_text(data.get("display_name"), "display name"),
+    }

--- a/.agents/scripts/_knowledge_social_ghost_routes.py
+++ b/.agents/scripts/_knowledge_social_ghost_routes.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Exact GET routes, pagination, and serializers for Ghost Content API reads."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from _knowledge_social_ghost import PageRequest, namespaced_id
+from _knowledge_social_ghost_contract import (
+    ApiResult,
+    GhostReadProviderError,
+    non_negative_integer,
+    object_list,
+    object_value,
+    observed_at,
+    optional_text,
+    positive_integer,
+    required_text,
+)
+from knowledge_social_import import reject_credentials
+
+Api = Callable[[str, dict[str, str]], ApiResult]
+PageResult = ApiResult | dict[str, Any]
+
+SITE_PATH = "/ghost/api/admin/site/"
+STREAM_PATHS = {
+    "posts": "/ghost/api/content/posts/",
+    "pages": "/ghost/api/content/pages/",
+    "tags": "/ghost/api/content/tags/",
+    "authors": "/ghost/api/content/authors/",
+}
+EXACT_READ_PATHS = frozenset({SITE_PATH, *STREAM_PATHS.values()})
+
+
+def allowlisted_path(path: str) -> bool:
+    return path in EXACT_READ_PATHS
+
+
+def _resource_id(request: PageRequest, kind: str, value: Any, field: str) -> str:
+    text = required_text(value, field)
+    try:
+        return namespaced_id(request.instance_id, kind, text)
+    except RuntimeError as error:
+        raise GhostReadProviderError(str(error)) from error
+
+
+def _content(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    kind = "post" if request.stream == "posts" else "page"
+    local_id = required_text(item.get("id"), f"{kind} ID")
+    return {
+        "kind": kind,
+        "remote_id": _resource_id(request, kind, local_id, f"{kind} ID"),
+        "resource_id": local_id,
+        "uuid": optional_text(item.get("uuid"), f"{kind} UUID"),
+        "title": required_text(item.get("title"), f"{kind} title"),
+        "slug": required_text(item.get("slug"), f"{kind} slug"),
+        "html": optional_text(item.get("html"), f"{kind} HTML"),
+        "plaintext": optional_text(item.get("plaintext"), f"{kind} plaintext"),
+        "excerpt": optional_text(item.get("excerpt"), f"{kind} excerpt"),
+        "custom_excerpt": optional_text(
+            item.get("custom_excerpt"), f"{kind} custom excerpt"
+        ),
+        "created_at": optional_text(item.get("created_at"), f"{kind} created timestamp"),
+        "updated_at": optional_text(item.get("updated_at"), f"{kind} updated timestamp"),
+        "published_at": optional_text(
+            item.get("published_at"), f"{kind} published timestamp"
+        ),
+    }
+
+
+def _count_posts(item: dict[str, Any], field: str) -> int | None:
+    count = item.get("count")
+    if count is None:
+        return None
+    value = object_value(count, f"{field} count").get("posts")
+    return non_negative_integer(value, f"{field} post count")
+
+
+def _tag(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    if item.get("visibility") != "public":
+        raise GhostReadProviderError("Ghost Content API returned a non-public tag")
+    local_id = required_text(item.get("id"), "tag ID")
+    return {
+        "kind": "tag",
+        "remote_id": _resource_id(request, "tag", local_id, "tag ID"),
+        "resource_id": local_id,
+        "name": required_text(item.get("name"), "tag name"),
+        "slug": required_text(item.get("slug"), "tag slug"),
+        "description": optional_text(item.get("description"), "tag description"),
+        "post_count": _count_posts(item, "tag"),
+    }
+
+
+def _author(item: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    local_id = required_text(item.get("id"), "author ID")
+    return {
+        "kind": "author",
+        "remote_id": _resource_id(request, "author", local_id, "author ID"),
+        "resource_id": local_id,
+        "name": required_text(item.get("name"), "author name"),
+        "slug": required_text(item.get("slug"), "author slug"),
+        "bio": optional_text(item.get("bio"), "author bio"),
+        "post_count": _count_posts(item, "author"),
+    }
+
+
+SERIALIZERS = {
+    "posts": _content,
+    "pages": _content,
+    "tags": _tag,
+    "authors": _author,
+}
+
+
+def _pagination(
+    payload: dict[str, Any], request: PageRequest
+) -> tuple[int | None, bool]:
+    meta = object_value(payload.get("meta"), "pagination metadata")
+    pagination = object_value(meta.get("pagination"), "pagination")
+    page_number = positive_integer(pagination.get("page"), "pagination page")
+    page_limit = positive_integer(pagination.get("limit"), "pagination limit")
+    pages = positive_integer(pagination.get("pages"), "pagination pages")
+    total = non_negative_integer(pagination.get("total"), "pagination total")
+    if page_number != request.position or page_limit != request.limit or page_number > pages:
+        raise GhostReadProviderError("Ghost pagination does not match the request")
+    next_value = pagination.get("next")
+    next_position = (
+        None if next_value is None else positive_integer(next_value, "next page")
+    )
+    previous = pagination.get("prev")
+    if previous is not None:
+        previous = positive_integer(previous, "previous page")
+    expected_previous = None if page_number == 1 else page_number - 1
+    if previous != expected_previous:
+        raise GhostReadProviderError("Ghost previous-page metadata is invalid")
+    if next_position is None:
+        if page_number != pages:
+            raise GhostReadProviderError("Ghost pagination ended before the final page")
+    elif next_position != page_number + 1 or next_position > pages:
+        raise GhostReadProviderError("Ghost next-page metadata is invalid")
+    if total == 0 and (page_number != 1 or pages != 1):
+        raise GhostReadProviderError("Ghost empty pagination metadata is invalid")
+    return next_position, next_position is None
+
+
+def _params(request: PageRequest) -> dict[str, str]:
+    params = {"page": str(request.position), "limit": str(request.limit)}
+    if request.stream in ("posts", "pages"):
+        params["formats"] = "html,plaintext"
+    elif request.stream == "tags":
+        params["filter"] = "visibility:public"
+        params["include"] = "count.posts"
+    else:
+        params["include"] = "count.posts"
+    return params
+
+
+def page(api: Api, request: PageRequest, _identity: dict[str, Any]) -> PageResult:
+    """Execute only reviewed official GET routes for one public stream."""
+    result = api(STREAM_PATHS[request.stream], _params(request))
+    if result.status != 200:
+        return result
+    payload = object_value(result.payload, f"{request.stream} response")
+    reject_credentials(payload)
+    source = object_list(
+        payload.get(request.stream), f"{request.stream} response", limit=request.limit
+    )
+    next_position, complete = _pagination(payload, request)
+    records = [SERIALIZERS[request.stream](item, request) for item in source]
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": records,
+        "meta": {
+            "stream": request.stream,
+            "instance_id": request.instance_id,
+            "next_position": next_position,
+            "newest_id": records[0].get("remote_id") if records else None,
+            "complete": complete,
+            "snapshot": True,
+        },
+    }

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -18,6 +18,7 @@ NODEBB_HELPER="${SCRIPT_DIR}/knowledge_social_nodebb.py"
 MASTODON_HELPER="${SCRIPT_DIR}/knowledge_social_mastodon.py"
 LEMMY_HELPER="${SCRIPT_DIR}/knowledge_social_lemmy.py"
 GITHUB_HELPER="${SCRIPT_DIR}/knowledge_social_github.py"
+GHOST_HELPER="${SCRIPT_DIR}/knowledge_social_ghost.py"
 STACK_EXCHANGE_HELPER="${SCRIPT_DIR}/knowledge_social_stack_exchange.py"
 HACKER_NEWS_HELPER="${SCRIPT_DIR}/knowledge_social_hacker_news.py"
 MINIFLUX_HELPER="${SCRIPT_DIR}/knowledge_social_miniflux.py"
@@ -167,6 +168,19 @@ EOF
 	return 0
 }
 
+usage_sync_ghost() {
+	cat <<'EOF'
+Ghost synchronization:
+  sync-ghost binds an operator-selected publication ID to the exact HTTPS URL
+  returned by unauthenticated GET /ghost/api/admin/site/ before every page. It
+  exposes only Ghost v6 Content API posts, pages, public tags, and public authors.
+  Admin credentials, member/newsletter records, comments, exports, redirects,
+  and mutations are unreachable. --budget is 3-1000 and --page-size is 1-100.
+
+EOF
+	return 0
+}
+
 usage_commands() {
 	cat <<'EOF'
 Usage:
@@ -217,6 +231,10 @@ Usage:
   knowledge-social-helper.sh sync-lemmy [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id PERSON_NUMERIC_ID --stream STREAM \
     --profile PROFILE [--budget UNITS] [--page-size 1-50] \
+    [--collector-id ID] [--lease-seconds SECONDS]
+  knowledge-social-helper.sh sync-ghost [--base PATH] [--alias ALIAS] \
+    --connection-id ID --account-id OPAQUE_SITE_ID --stream posts|pages|tags|authors \
+    --profile PROFILE [--budget UNITS] [--page-size 1-100] \
     [--collector-id ID] [--lease-seconds SECONDS]
   knowledge-social-helper.sh sync-github [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id NUMERIC_ACCOUNT_ID --stream STREAM \
@@ -303,6 +321,7 @@ Medium account export:
 
 EOF
 	usage_sync
+	usage_sync_ghost
 	cat <<'EOF'
 Deterministic routines:
   sync-due and reconcile-due return sorted privacy-safe work plans. Every sync or
@@ -424,6 +443,7 @@ run_named_provider_sync() {
 	sync-nodebb) run_provider_sync NodeBB "$NODEBB_HELPER" "$@" || return 1 ;;
 	sync-mastodon) run_provider_sync Mastodon "$MASTODON_HELPER" "$@" || return 1 ;;
 	sync-lemmy) run_provider_sync Lemmy "$LEMMY_HELPER" "$@" || return 1 ;;
+	sync-ghost) run_provider_sync Ghost "$GHOST_HELPER" "$@" || return 1 ;;
 	sync-github) run_provider_sync GitHub "$GITHUB_HELPER" "$@" || return 1 ;;
 	sync-stack-exchange) run_provider_sync "Stack Exchange" "$STACK_EXCHANGE_HELPER" "$@" || return 1 ;;
 	sync-hacker-news) run_provider_sync "Hacker News" "$HACKER_NEWS_HELPER" "$@" || return 1 ;;
@@ -508,7 +528,7 @@ main() {
 		fi
 		python3 "$LINKEDIN_HELPER" "$@" || return 1
 		;;
-	sync-meta | sync-discourse | sync-nodebb | sync-mastodon | sync-lemmy | sync-github | sync-stack-exchange | sync-hacker-news | sync-miniflux | sync-readwise-reader)
+	sync-meta | sync-discourse | sync-nodebb | sync-mastodon | sync-lemmy | sync-ghost | sync-github | sync-stack-exchange | sync-hacker-news | sync-miniflux | sync-readwise-reader)
 		run_named_provider_sync "$subcommand" "$@" || return 1
 		;;
 	query | annotate)

--- a/.agents/scripts/knowledge_social_ghost.py
+++ b/.agents/scripts/knowledge_social_ghost.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one bounded, read-only Ghost publication stream into a social corpus."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import _knowledge_social_ghost as ghost
+from _knowledge_social_ghost_normalize import PageContext, normalize_page
+from _knowledge_social_ghost_reader import FixtureGhost, GuardedGhost, verified_identity
+from _knowledge_social_oauth_collector import OAuthCollectorPolicy, run_oauth_collector
+
+COLLECTOR_OPTIONS = {
+    "display_name": "Ghost",
+    "provider_module": ghost,
+    "helper": Path(__file__).with_name("_knowledge_social_ghost_provider.py"),
+    "fixture_reader": FixtureGhost,
+    "live_reader": GuardedGhost,
+    "page_context": PageContext,
+    "normalize_page": normalize_page,
+    "verified_identity": verified_identity,
+    "budget_unit": "request",
+    "max_page_size": 100,
+}
+
+
+def main() -> int:
+    return run_oauth_collector(OAuthCollectorPolicy(**COLLECTOR_OPTIONS), __doc__ or "")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/knowledge_social_registry.py
+++ b/.agents/scripts/knowledge_social_registry.py
@@ -52,6 +52,7 @@ PROVIDER_SPECS = (
     ),
     ProviderSpec("gumroad", (), "knowledge_social_gumroad.py", (("live", ()),)),
     ProviderSpec("github", (), "knowledge_social_github.py", (("live", ()),)),
+    ProviderSpec("ghost", (), "knowledge_social_ghost.py", (("live", ()),)),
     ProviderSpec(
         "hacker-news",
         ("hn",),

--- a/.agents/tests/test-knowledge-social-ghost.sh
+++ b/.agents/tests/test-knowledge-social-ghost.sh
@@ -1,0 +1,642 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-ghost.sh — Identity-bound Ghost Content API tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GHOST_SCRIPT="${SCRIPT_DIR}/../scripts/knowledge_social_ghost.py"
+SOCIAL_HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+INSTANCE_A="aaaaaaaaaaaaaaaaaaaaaaaa"
+SITE_ID="ghost_publication"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' \
+			"$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c \
+		'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_count() {
+	python3 - "$ROOT/sources/social/raw/ghost" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+print(len(list(root.rglob("*.json.gz"))) if root.exists() else 0)
+PY
+	return 0
+}
+
+run_ghost() {
+	local fixture="$1"
+	local connection_id="$2"
+	local stream="$3"
+	local budget="$4"
+	local page_size="$5"
+	if python3 "$GHOST_SCRIPT" --base "$BASE" --alias personal:default \
+		--connection-id "$connection_id" --account-id "$SITE_ID" \
+		--stream "$stream" --profile fixture --fixture "$fixture" \
+		--budget "$budget" --page-size "$page_size"; then
+		return 0
+	fi
+	return 1
+}
+
+expect_sync_failure() {
+	local description="$1"
+	local fixture="$2"
+	local connection_id="$3"
+	local stream="$4"
+	if run_ghost "$fixture" "$connection_id" "$stream" 11 100 \
+		>/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+run_terminal_fixture() {
+	local name="$1"
+	local status="$2"
+	local expected_failure="$3"
+	local expected_coverage="$4"
+	local fixture="${TMP_DIR}/terminal-${name}.json"
+	python3 - "$fixture" "$INSTANCE_A" "$SITE_ID" "$status" <<'PY'
+import json
+import sys
+
+status = int(sys.argv[4])
+page = {"status": status, "observed_at": "2026-08-02T12:00:00Z"}
+if status == 429:
+    page["retry_after"] = 1785690000
+payload = {
+    "identity": {"data": {
+        "provider_account_id": sys.argv[3],
+        "site_id": sys.argv[3],
+        "instance_id": sys.argv[2],
+        "version": "6.0",
+    }},
+    "pages": [page],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+	local result=""
+	result=$(run_ghost "$fixture" "conn_terminal_${name}" authors 11 100)
+	assert_eq "${status} Ghost response is terminal" \
+		"$(json_field "$result" failure_class)" "$expected_failure"
+	assert_eq "${status} terminal response records explicit coverage" \
+		"$(sql_value "SELECT status || ':' || unavailable_reason FROM coverage_records WHERE connection_id='conn_terminal_${name}' AND stream='authors'")" \
+		"${expected_coverage}:${expected_failure}"
+	assert_eq "${status} terminal response advances no checkpoint" \
+		"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_terminal_${name}'")" 0
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$SOCIAL_HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'Ghost social collector tests\n'
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+
+from _knowledge_social_ghost import PageRequest, STREAMS, namespaced_id
+from _knowledge_social_ghost_contract import ApiResult, GhostReadProviderError
+from _knowledge_social_ghost_http import (
+    ACCEPT_VERSION,
+    HTTP_TIMEOUT_SECONDS,
+    ProfileConfig,
+    _canonical_admin_url,
+    _canonical_site_url,
+    _http_exports,
+    api,
+    installation_fingerprint,
+)
+from _knowledge_social_ghost_provider import _dispatch, _profile
+from _knowledge_social_ghost_routes import (
+    EXACT_READ_PATHS,
+    SITE_PATH,
+    STREAM_PATHS,
+    allowlisted_path,
+    page,
+)
+
+instance = "a" * 24
+site_id = "ghost_publication"
+content_key = "a" * 26
+admin_url = _canonical_admin_url("https://admin.example.invalid/publication/")
+site_url = _canonical_site_url("https://www.example.invalid/")
+
+assert set(STREAMS) == {"posts", "pages", "tags", "authors"}
+assert all(spec.pagination == "snapshot" for spec in STREAMS.values())
+assert all(spec.cost_units == 2 for spec in STREAMS.values())
+assert ACCEPT_VERSION == "v6.0"
+assert EXACT_READ_PATHS == {
+    SITE_PATH,
+    "/ghost/api/content/posts/",
+    "/ghost/api/content/pages/",
+    "/ghost/api/content/tags/",
+    "/ghost/api/content/authors/",
+}
+for rejected in (
+    "/ghost/api/admin/posts/",
+    "/ghost/api/admin/members/",
+    "/ghost/api/admin/newsletters/",
+    "/ghost/api/admin/users/",
+    "/ghost/api/admin/comments/",
+    "/ghost/api/admin/db/",
+    "/ghost/api/content/settings/",
+):
+    assert not allowlisted_path(rejected)
+
+assert admin_url == "https://admin.example.invalid/publication"
+assert site_url == "https://www.example.invalid"
+assert installation_fingerprint(admin_url, "a" * 32) != installation_fingerprint(
+    admin_url, "b" * 32
+)
+for invalid in (
+    "http://admin.example.invalid",
+    "https://user@admin.example.invalid",
+    "https://admin.example.invalid/%2e%2e/ghost",
+    "https://admin.example.invalid/ghost/api/admin",
+):
+    try:
+        _canonical_admin_url(invalid)
+    except RuntimeError as error:
+        assert "admin.example.invalid" not in str(error)
+    else:
+        raise AssertionError("unsafe Ghost admin URL was accepted")
+
+os.environ["GHOST_SCOPE_ADMIN_URL"] = admin_url
+os.environ["GHOST_SCOPE_SITE_URL"] = site_url
+os.environ["GHOST_SCOPE_SITE_ID"] = site_id
+os.environ["GHOST_SCOPE_CONTENT_API_KEY"] = content_key
+os.environ["GHOST_SCOPE_ORIGIN_KEY"] = "a" * 32
+os.environ["GHOST_SCOPE_AUTH_MODE"] = "admin_api_key"
+try:
+    _profile("scope")
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("Ghost Admin authority was accepted")
+
+os.environ["GHOST_SCOPE_AUTH_MODE"] = "content_api_key"
+os.environ["GHOST_SCOPE_CONTENT_API_KEY"] = "header.payload.signature"
+try:
+    _profile("scope")
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("JWT-shaped Ghost credential was accepted")
+
+
+class Response:
+    status = 200
+
+    def __init__(self, payload):
+        self.payload = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def read(self, size=-1):
+        return self.payload[:size]
+
+
+class Opener:
+    def __init__(self, payloads):
+        self.payloads = list(payloads)
+        self.requests = []
+
+    def open(self, request, timeout):
+        assert timeout == HTTP_TIMEOUT_SECONDS
+        assert request.method == "GET"
+        assert request.get_header("Accept-version") == ACCEPT_VERSION
+        assert request.get_header("Authorization") is None
+        self.requests.append(request)
+        return Response(self.payloads.pop(0))
+
+
+config = ProfileConfig(
+    admin_url,
+    site_url,
+    site_id,
+    content_key,
+    "content_api_key",
+    instance,
+)
+opener = Opener([
+    {"site": {"title": "Publication", "url": site_url, "version": "6.0"}},
+    {"posts": [], "meta": {"pagination": {
+        "page": 1, "limit": 2, "pages": 1, "total": 0,
+        "next": None, "prev": None,
+    }}},
+])
+identity_result = api(config, opener, SITE_PATH, {})
+assert identity_result.status == 200
+assert "key=" not in opener.requests[0].full_url
+content_result = api(
+    config,
+    opener,
+    STREAM_PATHS["posts"],
+    {"page": "1", "limit": "2", "formats": "html,plaintext"},
+)
+assert content_result.status == 200
+query = parse_qs(urlsplit(opener.requests[1].full_url).query)
+assert query["key"] == [content_key]
+assert "Authorization" not in dict(opener.requests[1].header_items())
+assert callable(_http_exports().open)
+try:
+    api(config, opener, "/ghost/api/admin/members/", {})
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("Ghost private Admin route was reachable")
+
+good_identity = Opener([
+    {"site": {
+        "title": "Public Knowledge",
+        "description": "not persisted",
+        "url": site_url,
+        "version": "6.0",
+    }}
+])
+identity = _dispatch(
+    {"action": "identity", "account_id": site_id}, config, good_identity
+)
+encoded_identity = json.dumps(identity, sort_keys=True)
+assert content_key not in encoded_identity
+assert site_url not in encoded_identity
+assert identity["data"]["provider_account_id"] == site_id
+
+wrong_site = Opener([
+    {"site": {
+        "title": "Other Publication",
+        "url": "https://other.example.invalid/",
+        "version": "6.0",
+    }}
+])
+try:
+    _dispatch({"action": "identity", "account_id": site_id}, config, wrong_site)
+except GhostReadProviderError:
+    pass
+else:
+    raise AssertionError("cross-site Ghost identity was accepted")
+
+
+def request_for(stream, position=1, limit=2):
+    return PageRequest(
+        stream,
+        namespaced_id(instance, "site", site_id),
+        site_id,
+        site_id,
+        instance,
+        position,
+        None,
+        limit,
+    )
+
+
+post_calls = []
+
+
+def posts_api(path, params):
+    post_calls.append((path, params))
+    return ApiResult(200, {
+        "posts": [{
+            "id": "post-1",
+            "uuid": "post-uuid",
+            "title": "Bounded Ghost knowledge",
+            "slug": "bounded-ghost-knowledge",
+            "html": "<p>Published text</p>",
+            "plaintext": "Published text",
+            "published_at": "2026-08-02T10:00:00Z",
+            "url": "https://cross-site.example.invalid/not-persisted",
+            "feature_image": "https://cross-site.example.invalid/image.jpg",
+        }],
+        "meta": {"pagination": {
+            "page": 1, "limit": 2, "pages": 1, "total": 1,
+            "next": None, "prev": None,
+        }},
+    })
+
+
+posts = page(posts_api, request_for("posts"), {})
+assert post_calls == [(STREAM_PATHS["posts"], {
+    "page": "1", "limit": "2", "formats": "html,plaintext",
+})]
+assert posts["data"][0]["remote_id"] == namespaced_id(instance, "post", "post-1")
+assert "url" not in posts["data"][0]
+assert "feature_image" not in posts["data"][0]
+
+
+def authors_api(_path, _params):
+    return ApiResult(200, {
+        "authors": [{
+            "id": "author-1",
+            "name": "Public Author",
+            "slug": "public-author",
+            "bio": "Published biography",
+            "email": "omitted@example.invalid",
+            "location": "omitted",
+            "website": "https://omitted.example.invalid",
+            "count": {"posts": 4},
+        }],
+        "meta": {"pagination": {
+            "page": 1, "limit": 2, "pages": 1, "total": 1,
+            "next": None, "prev": None,
+        }},
+    })
+
+
+authors = page(authors_api, request_for("authors"), {})
+assert set(authors["data"][0]) == {
+    "kind", "remote_id", "resource_id", "name", "slug", "bio", "post_count"
+}
+assert authors["data"][0]["post_count"] == 4
+
+
+def bad_pagination(_path, _params):
+    return ApiResult(200, {
+        "pages": [],
+        "meta": {"pagination": {
+            "page": 1, "limit": 2, "pages": 2, "total": 3,
+            "next": 1, "prev": None,
+        }},
+    })
+
+
+try:
+    page(bad_pagination, request_for("pages"), {})
+except GhostReadProviderError:
+    pass
+else:
+    raise AssertionError("non-advancing Ghost pagination was accepted")
+
+
+def private_tag(_path, _params):
+    return ApiResult(200, {
+        "tags": [{
+            "id": "tag-1", "name": "Private", "slug": "hash-private",
+            "visibility": "internal",
+        }],
+        "meta": {"pagination": {
+            "page": 1, "limit": 2, "pages": 1, "total": 1,
+            "next": None, "prev": None,
+        }},
+    })
+
+
+try:
+    page(private_tag, request_for("tags"), {})
+except GhostReadProviderError:
+    pass
+else:
+    raise AssertionError("internal Ghost tag was accepted")
+PY
+assert_eq "Ghost Content/Admin boundaries and transport contract" verified verified
+
+cat >"$TMP_DIR/posts-first.json" <<JSON
+{
+  "identity":{"data":{"provider_account_id":"${SITE_ID}","site_id":"${SITE_ID}","instance_id":"${INSTANCE_A}","version":"6.0","display_name":"Public Knowledge"}},
+  "pages":[{
+    "expect_request":{"position":1,"stop_at":null,"instance_id":"${INSTANCE_A}"},
+    "response":{"status":200,"observed_at":"2026-08-02T12:01:00Z",
+      "data":[{"kind":"post","remote_id":"gst_${INSTANCE_A}_post_post-1","resource_id":"post-1","title":"Bounded Ghost knowledge","slug":"bounded","plaintext":"Fixture text","published_at":"2026-08-02T10:00:00Z"}],
+      "meta":{"stream":"posts","instance_id":"${INSTANCE_A}","next_position":2,"newest_id":"gst_${INSTANCE_A}_post_post-1","complete":false,"snapshot":true}}
+  }]
+}
+JSON
+first_result=$(run_ghost "$TMP_DIR/posts-first.json" conn_posts posts 3 1)
+assert_eq "bounded Ghost run pauses after its request budget" \
+	"$(json_field "$first_result" status)" budget_exhausted
+assert_eq "first Ghost page persists a resumable cursor" \
+	"$(sql_value "SELECT backfill_complete || ':' || (cursor IS NOT NULL) FROM sync_cursors WHERE connection_id='conn_posts' AND stream='posts'")" \
+	"0:1"
+assert_eq "published Ghost text reaches FTS" \
+	"$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'bounded'")" 1
+
+cat >"$TMP_DIR/posts-resume.json" <<JSON
+{
+  "identity":{"data":{"provider_account_id":"${SITE_ID}","site_id":"${SITE_ID}","instance_id":"${INSTANCE_A}","version":"6.0","display_name":"Public Knowledge"}},
+  "pages":[{
+    "expect_request":{"position":2,"stop_at":null,"instance_id":"${INSTANCE_A}"},
+    "response":{"status":200,"observed_at":"2026-08-02T12:02:00Z",
+      "data":[{"kind":"post","remote_id":"gst_${INSTANCE_A}_post_post-2","resource_id":"post-2","title":"Older Ghost knowledge","slug":"older","plaintext":"Older fixture text","published_at":"2026-08-01T10:00:00Z"}],
+      "meta":{"stream":"posts","instance_id":"${INSTANCE_A}","next_position":null,"newest_id":"gst_${INSTANCE_A}_post_post-2","complete":true,"snapshot":true}}
+  }]
+}
+JSON
+second_result=$(run_ghost "$TMP_DIR/posts-resume.json" conn_posts posts 11 1)
+assert_eq "Ghost snapshot resumes from its independent page" \
+	"$(json_field "$second_result" status)" complete
+assert_eq "completed Ghost snapshot clears its page cursor" \
+	"$(sql_value "SELECT coalesce(cursor,'done') || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_posts' AND stream='posts'")" \
+	"done:1"
+assert_eq "Ghost posts persist publication objects and activities" \
+	"$(sql_value "SELECT (SELECT count(*) FROM objects WHERE provider='ghost' AND object_type='post') || ':' || (SELECT count(*) FROM activities WHERE provider='ghost' AND activity_type='published_post')")" \
+	"2:2"
+
+cat >"$TMP_DIR/identity-mismatch.json" <<JSON
+{"identity":{"data":{"provider_account_id":"other_publication","site_id":"other_publication","instance_id":"${INSTANCE_A}","version":"6.0"}},"pages":[]}
+JSON
+identity_raw_before=$(raw_count)
+expect_sync_failure "selected Ghost publication mismatch is rejected" \
+	"$TMP_DIR/identity-mismatch.json" conn_identity posts
+assert_eq "identity mismatch creates no raw evidence" \
+	"$(raw_count)" "$identity_raw_before"
+
+cat >"$TMP_DIR/credential.json" <<JSON
+{
+  "identity":{"data":{"provider_account_id":"${SITE_ID}","site_id":"${SITE_ID}","instance_id":"${INSTANCE_A}","version":"6.0"}},
+  "pages":[{"status":200,"observed_at":"2026-08-02T12:03:00Z","api_key":"redacted","data":[],
+    "meta":{"stream":"authors","instance_id":"${INSTANCE_A}","next_position":null,"newest_id":null,"complete":true,"snapshot":true}}]
+}
+JSON
+credential_raw_before=$(raw_count)
+expect_sync_failure "credential-shaped Ghost pages are rejected" \
+	"$TMP_DIR/credential.json" conn_credential authors
+assert_eq "credential rejection creates no raw evidence" \
+	"$(raw_count)" "$credential_raw_before"
+
+cat >"$TMP_DIR/malformed.json" <<JSON
+{
+  "identity":{"data":{"provider_account_id":"${SITE_ID}","site_id":"${SITE_ID}","instance_id":"${INSTANCE_A}","version":"6.0"}},
+  "pages":[{"status":200,"observed_at":"2026-08-02T12:04:00Z","data":[],
+    "meta":{"stream":"pages","instance_id":"${INSTANCE_A}","next_position":1,"newest_id":null,"complete":false,"snapshot":true}}]
+}
+JSON
+expect_sync_failure "non-advancing Ghost fixture cursor is rejected" \
+	"$TMP_DIR/malformed.json" conn_malformed pages
+assert_eq "malformed Ghost page advances no checkpoint" \
+	"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_malformed'")" 0
+
+run_terminal_fixture forbidden 403 authorization failed
+run_terminal_fixture rate 429 rate_limit paused
+run_terminal_fixture provider 500 provider failed
+
+cat >"$TMP_DIR/tags.json" <<JSON
+{
+  "identity":{"data":{"provider_account_id":"${SITE_ID}","site_id":"${SITE_ID}","instance_id":"${INSTANCE_A}","version":"6.0","display_name":"Public Knowledge"}},
+  "pages":[{"status":200,"observed_at":"2026-08-02T12:05:00Z",
+    "data":[{"kind":"tag","remote_id":"gst_${INSTANCE_A}_tag_tag-1","resource_id":"tag-1","name":"Knowledge","slug":"knowledge","description":"Public taxonomy","post_count":2}],
+    "meta":{"stream":"tags","instance_id":"${INSTANCE_A}","next_position":null,"newest_id":"gst_${INSTANCE_A}_tag_tag-1","complete":true,"snapshot":true}}]
+}
+JSON
+run_ghost "$TMP_DIR/tags.json" conn_tags tags 11 100 >/dev/null
+tag_batches=$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_tags'")
+tag_raw=$(raw_count)
+run_ghost "$TMP_DIR/tags.json" conn_tags tags 11 100 >/dev/null
+assert_eq "exact Ghost snapshot replay is idempotent" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_tags'"):$(raw_count)" \
+	"${tag_batches}:${tag_raw}"
+assert_eq "private Ghost categories remain explicit gaps" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE connection_id='conn_tags' AND status='unavailable' AND stream IN ('members','newsletters','comments','account_export','staff_and_owner_identity','drafts_and_unpublished','deleted_or_purged_content','provider_retention')")" 8
+
+python3 - "$ROOT" "$SCRIPT_DIR/../scripts" <<'PY'
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[2])
+from _knowledge_social_collect import (
+    CollectionContext,
+    ConnectionConfig,
+    CursorState,
+    PageCheckpoint,
+    SuccessfulPage,
+)
+from _knowledge_social_collect_persist import persist_page
+from _knowledge_social_ghost import STREAMS
+from _knowledge_social_lease import (
+    RunLeaseRequest,
+    SocialLeaseLostError,
+    acquire_run_lease,
+    release_run_lease,
+)
+
+root = Path(sys.argv[1])
+old = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_ghost_fence", "tags", "old_runner", "sync", 1),
+    now_epoch=9000,
+)
+new = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_ghost_fence", "tags", "new_runner", "sync", 10),
+    now_epoch=9001,
+)
+account_id = "gst_aaaaaaaaaaaaaaaaaaaaaaaa_site_ghost_publication"
+context = CollectionContext(
+    root,
+    "conn_ghost_fence",
+    {"id": account_id},
+    "tags",
+    "none",
+    ConnectionConfig(("tags",), {"media_hydration": "none"}),
+    CursorState(None, None, False),
+    STREAMS["tags"],
+    old,
+    "ghost",
+)
+archive = {
+    "provider": "ghost",
+    "connection_id": "conn_ghost_fence",
+    "remote_account_id": account_id,
+    "exported_at": "2026-08-02T12:06:00Z",
+    "enabled_streams": ["tags"],
+    "policy": {"media_hydration": "none"},
+    "accounts": [],
+    "objects": [],
+    "activities": [],
+    "media": [],
+    "coverage": [],
+}
+successful = SuccessfulPage(
+    {"status": 200, "observed_at": archive["exported_at"], "data": [], "meta": {}},
+    '{"stream":"tags"}',
+    archive,
+    PageCheckpoint(None, None),
+    True,
+    2,
+)
+os.environ["AIDEVOPS_SOCIAL_NOW_EPOCH"] = "9001"
+try:
+    persist_page(context, successful)
+except SocialLeaseLostError:
+    pass
+else:
+    raise SystemExit("stale Ghost collector advanced persistence")
+with sqlite3.connect(root / "index" / "social.db") as database:
+    count = database.execute(
+        "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_ghost_fence'"
+    ).fetchone()[0]
+assert count == 0
+release_run_lease(root, new)
+PY
+assert_eq "stale Ghost lease cannot commit evidence or a cursor" verified verified
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/tests/test-knowledge-social-registry.sh
+++ b/.agents/tests/test-knowledge-social-registry.sh
@@ -44,6 +44,7 @@ expected = {
     "discord": ("live",),
     "forem": ("live",),
     "github": ("live",),
+    "ghost": ("live",),
     "hacker-news": ("live",),
     "google-business-profile": ("live",),
     "gumroad": ("live",),
@@ -100,14 +101,14 @@ except module.ProviderRegistryError:
 else:
     raise SystemExit("unknown provider used a fallback")
 
-print("18:order-independent:aliases-exact:collisions-rejected:no-fallback")
+print("19:order-independent:aliases-exact:collisions-rejected:no-fallback")
 PY
 )
 assert_eq "all merged provider outcomes register deterministically" \
-	"$registry_summary" "18:order-independent:aliases-exact:collisions-rejected:no-fallback"
+	"$registry_summary" "19:order-independent:aliases-exact:collisions-rejected:no-fallback"
 
 provider_count=$("$HELPER" providers | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
-assert_eq "helper exposes the complete provider registry" "$provider_count" "18"
+assert_eq "helper exposes the complete provider registry" "$provider_count" "19"
 
 forem_resolution=$("$HELPER" provider-resolve --provider dev-community |
 	python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["provider"] + ":" + ",".join(data["modes"]))')


### PR DESCRIPTION
Draft checkpoint: add a bounded Ghost v6 Content API collector for public posts, pages, tags, and authors; bind every page to configured publication identity; keep Admin API, member PII, comments, exports, redirects, and writes outside the live route. Documentation, registry wiring, and deterministic fixture verification continue on this PR. Resolves #29318.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 15m and 241,235 tokens on this as a headless worker.