### PR TITLE
GH#29319: Add bounded beehiiv account knowledge collection

### DIFF
--- a/.agents/aidevops/knowledge-plane/05-social-operations.md
+++ b/.agents/aidevops/knowledge-plane/05-social-operations.md
@@ -41,10 +41,11 @@ rows. Replay preserves both evidence and projection IDs.
 Candidate implementation is provider-specific, not one generic social adapter.
 Mastodon #29221, GitHub #29222, Stack Exchange #29223, Miniflux #29224,
 Readwise Reader #29225, Lemmy #29227, public-only Hacker News #29228, and
-Hashnode #29323 are now live. FreshRSS #29226 is the remaining ranked child. Each
-route owns its identity contract, stream allowlist, checkpoint semantics, and
-negative write-reachability tests. Raindrop.io remains optional; Inoreader,
-Wallabag, Feedly, Instapaper, and Pocket are deferred or rejected for the reasons in
+Hashnode #29323 and the publication-scoped beehiiv route #29319 are now live.
+FreshRSS #29226 is the remaining ranked child. Each route owns its identity
+contract, stream allowlist, checkpoint semantics, and negative write-reachability
+tests. Raindrop.io remains optional; Inoreader, Wallabag, Feedly, Instapaper, and
+Pocket are deferred or rejected for the reasons in
 `.agents/content/social-provider-candidates.md`.
 
 The maintained planning and gap inventory is
@@ -153,6 +154,16 @@ cursors with one-second `updatedAfter` overlap. Only fixed-origin auth, list, an
 tag GET routes are reachable; each invocation is capped below the documented
 20-request/minute limit. Provider identity, deletion, complete export, and
 retention remain explicit gaps. Details: `.agents/content/social-readwise-reader.md`.
+
+beehiiv collection binds the configured `pub_...` ID, publication name, and
+organization name to a credential whose `GET /v2/publications` result exposes
+exactly that publication before every page. Confirmed posts and their
+paywall-enforced free web HTML use bounded API-v2 offset pages; the current post
+endpoint documents page numbers rather than the API's preferred opaque cursor
+shape, so the collector caps the route at page 100 and records partial coverage.
+Subscriber records, segments, engagement statistics, premium content, remote
+media, exports, redirects, and mutations are unreachable. Details:
+`.agents/content/social-beehiiv.md`.
 
 X collection uses the guarded official `xurl` helper. Reddit collection uses an
 optional PRAW 8 child. YouTube collection uses a standard-library HTTP child and

--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -38,6 +38,7 @@ a claim that the route is enabled.
 | Instagram | **Live/Gate/Export** Professional media | **No/Export** comments and saved activity | **No/Export** mentions | **No/Export** followers and following | **No/Export** saved collections | One Page-connected Business/Creator `/media` stream; personal accounts and unimplemented per-media edges remain explicit. |
 | Threads | **Live/Gate/Export** posts | **No/Export** likes and repost history | **Live/Gate/Export** authored replies and mentions; **No** messages | **No/Export** followers and following | **No** custom feeds | Three product-scoped streams with app-scoped identity, independent cursors, and stream-specific permission gates. |
 | Medium | **Live/Export** authored posts; **Live/Partial** explicit responses | **Live/Export/No** bookmarks, claps, highlights, and list membership when present | **No** | **Live/Export/No** publication membership and follows when present | **Live/Export/No** owned lists when present | Identity-verified native HTML ZIP import with exact replay, bounded local parsing, and per-archive complete/unavailable coverage; legacy API access is not live parity. |
+| beehiiv | **Live/Partial/Export** confirmed posts and paywall-enforced free web content; **Export** drafts and archives | **No** subscriber-derived engagement statistics | **No** | **Gate/Export/No** subscriber records are excluded pending an explicit PII need and authorization | **Gate/No** segments and newsletter-list membership expose audience structure and are not collected | One expected, singly visible publication; exact GET-only API-v2 routes, bounded page replay, 100-page cap, and no subscriber PII, premium expansion, remote media, dashboard automation, or mutation reachability. |
 | Quora | **Export/No** answers, questions, posts, and comments | **Export/No** bookmarks; **No** upvotes and other curation | **No** | **Export/No** user follows; **No** followed topics or Spaces | **No** | The official export has no published schema. Public content samples lack authoritative owner identity, and the companion account-data schema is unpublished; no adapter or CLI route is enabled. |
 | Skool | **No** posts, comments, and course content | **No** reactions and saved state | **No** notifications and messages | **No** memberships, follows, and groups | **No** courses and calendar feeds | **Export/No** admin membership-question answers only. The official Zapier surface is narrow event automation, the export schema and identity contract are unpublished, and provider policy excludes browser collection. |
 | Substack | **Export/No** publication posts; **No** Notes | **No** comments, likes, restacks, or saved Notes | **No** | **No** reader subscriptions or publication memberships | **No** | Creator ZIP/CSV exports lack published identity/schema contracts; public RSS is not account history, and **Gate/No** bestseller analytics require interactive MCP sign-in and consent. No adapter or CLI route is enabled. |
@@ -52,6 +53,7 @@ a claim that the route is enabled.
 | Hashnode | **Live** posts; **Live/Gate** owned publications and drafts | **Live/Partial** comments and likes received; **No** authored-comment or reaction history | **No** messages or notifications | **Live/Partial** followers and following | **No** | Eight viewer-bound streams use nine fixed GraphQL read documents, repeated author/publication ownership checks, opaque nested cursors, and **Export/Gate** account-archive coverage pending a current identity-bearing schema. |
 | Miniflux | **Live/Partial** feed entries | **Live/Partial** read, removed, starred, and tagged state | **No** | **Live/Partial/Export** subscriptions | **Live/Partial/Export** categories and tags | Eight keyed-installation account streams use five exact GET routes, ascending entry-ID backfill, one-second `changed_after` overlap, bounded snapshots, and explicit operator-retention gaps. |
 | Readwise Reader | **Live/Gate/Partial** saved documents and optional HTML | **Live/Gate/Partial** notes, state, progress, and tags | **No** | **No** | **Live/Gate/Partial** tags and locations | Seven deployment-bound streams preserve opaque cursors, overlap `updatedAfter`, cap invocations below 20 requests/minute, and expose the provider identity/export boundary. |
+| beehiiv | **Live/Partial/Export** confirmed post metadata and free web HTML | **No** subscriber-derived post statistics | **No** | **Gate/Export/No** subscriber PII | **Gate/No** segments and newsletter-list membership | Publication ID/name/organization rebinding before each page; API-key scope must expose exactly one publication. |
 
 ## Integrated provider families
 
@@ -242,6 +244,15 @@ separate provider family.
   `.agents/content/social-readwise-reader.md` records official auth, document,
   tag, cursor, HTML, rate, privacy, export, retention, and terms evidence checked
   on 2026-08-02.
+- **Live/Gated beehiiv:** `.agents/scripts/knowledge_social_beehiiv.py`,
+  `.agents/scripts/_knowledge_social_beehiiv*.py`, and
+  `.agents/tests/test-knowledge-social-beehiiv.sh` prove a singly visible expected
+  publication, repeated ID/name/organization verification, bounded API-v2 post
+  pages, exact replay, terminal and malformed-page safety, credential rejection,
+  stale-lease fencing, and fixed-origin GET-only mutation isolation.
+  `.agents/content/social-beehiiv.md` records official API-v2 authentication,
+  endpoint-specific pagination, organization quota, plan/export gates, privacy,
+  terms, and excluded subscriber fields checked on 2026-08-02.
 - **Integrated provider registry:** `.agents/scripts/knowledge_social_registry.py`
   and `.agents/tests/test-knowledge-social-registry.sh` prove order-independent
   registration, collision rejection, exact aliases and modes, no-route failure,

--- a/.agents/content/social-beehiiv.md
+++ b/.agents/content/social-beehiiv.md
@@ -1,0 +1,125 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# beehiiv account knowledge
+
+Checked on 2026-08-02. The enabled route is deliberately publication-scoped and
+posts-only. It is not a general beehiiv workspace, audience, or export client.
+
+## Current disposition
+
+| Category | Disposition | Boundary |
+|---|---|---|
+| Publications | **Live** | One configured `pub_...` ID, name, and organization must be the only publication visible to the credential. |
+| Posts | **Live/Partial** | Confirmed post metadata plus `free_web_content`; future scheduled items are skipped, premium expansion and statistics are never requested. |
+| Subscriptions | **Gate/Export/No** | The API and dashboard export expose email, status, tier, custom fields, and statistics. No subscriber endpoint or import route is enabled without a separate account-knowledge need, authorization, and field-by-field minimization. |
+| Segments | **Gate/No** | Segment membership can return subscription IDs or subscriber records. No route is enabled. |
+| Exports | **Export** | Creator-initiated post and subscriber CSV exports exist; dashboard automation is prohibited and no schema is treated as stable without a private fixture. |
+
+## Official contract
+
+The current official developer index identifies API v2 and the fixed
+`https://api.beehiiv.com/v2` origin:
+<https://developers.beehiiv.com/llms.txt>. Requests use bearer authentication.
+API keys may be restricted to selected publications; a restricted key returns
+only allowed publications from `GET /v2/publications`, while out-of-scope IDs
+return `404`:
+<https://developers.beehiiv.com/welcome/create-an-api-key.md>.
+
+OAuth authorization-code clients can request the separate
+`publications:read`, `posts:read`, `subscriptions:read`, and `segments:read`
+scopes. This collector needs only the first two and does not implement the OAuth
+authorization exchange itself:
+<https://developers.beehiiv.com/oauth2.md>.
+
+The enabled calls are exactly:
+
+- `GET /v2/publications?limit=2&page=1` for publication scope and identity;
+- `GET /v2/publications/{publicationId}/posts` with `status=confirmed`,
+  `expand=free_web_content`, ascending creation order, and bounded page/limit.
+
+Official endpoint schemas:
+<https://developers.beehiiv.com/api-reference/publications/index.md> and
+<https://developers.beehiiv.com/api-reference/posts/index.md>.
+
+The general API guide recommends opaque `cursor`, `next_cursor`, and `has_more`
+pagination, and deprecates page offsets beyond a hard page-100 boundary. The
+current publication and post endpoint schemas still document `page`,
+`total_pages`, and `total_results`. The adapter follows the endpoint-specific
+schema, versions its local page cursor, caps requests at page 100, and records
+partial coverage instead of claiming an exhaustive history:
+<https://developers.beehiiv.com/welcome/pagination.md>.
+
+The organization-wide limit is 180 requests per minute. Each page costs two
+provider requests because identity is rechecked immediately before the post
+read; the initial identity costs one. The CLI caps an invocation at 59 requests,
+honors `RateLimit-Reset` or a valid `Retry-After`, and persists no new checkpoint
+for `429` or another terminal response:
+<https://developers.beehiiv.com/welcome/rate-limiting.md>.
+
+## Identity and authorization boundary
+
+Each local profile supplies `BEEHIIV_<PROFILE>_ACCESS_TOKEN`,
+`BEEHIIV_<PROFILE>_PUBLICATION_ID`,
+`BEEHIIV_<PROFILE>_PUBLICATION_NAME`, and
+`BEEHIIV_<PROFILE>_ORGANIZATION_NAME`. The command's `--account-id` must equal
+the configured publication ID. Before state is loaded and before every post
+page, the provider requires exactly one visible publication and exact ID, name,
+and organization equality. A workspace-wide credential with multiple visible
+publications is rejected even if the requested ID is valid.
+
+The API does not expose an immutable human owner ID or prove legal ownership.
+The deployment owner remains responsible for configuring only a creator-owned
+publication and, for API keys, restricting the key to that publication. Mutable
+name and organization checks intentionally fail closed until local expectations
+are updated after a legitimate rename.
+
+## Privacy and persistence
+
+Retained post fields are stable post ID, title/subtitle, public author
+attribution, timestamps, status, subject/preview text, slug/web URL, audience,
+platform, content tags, selected SEO metadata, visibility flags, and
+paywall-enforced free web HTML. Author names are retained because they are direct
+publication-content attribution. No remote media is fetched.
+
+The adapter never requests or stores subscriber emails, custom fields, tiers,
+segment membership, newsletter-list membership, per-recipient events, click
+detail, post statistics, or premium HTML. Credential-shaped fixture/provider
+payloads fail before raw or normalized persistence. Every successful page writes
+one immutable bounded response and its normalized projection atomically under a
+lease-fencing token; replay is content-addressed and stale leases cannot advance
+evidence or cursors.
+
+beehiiv's privacy policy uses purpose-based retention rather than promising one
+universal history window, so deletion and pre-retention history remain explicit
+gaps: <https://www.beehiiv.com/privacy>. The terms preserve creator ownership of
+submitted content while prohibiting unauthorized automated extraction; this
+route uses documented APIs only: <https://www.beehiiv.com/tou> and
+<https://www.beehiiv.com/aup>.
+
+## Exports and plans
+
+The official dashboard workflow can export all post metadata/content and Quick
+or Full subscriber CSVs. Jobs are asynchronous and download links expire after
+24 hours. The public API index documents no export-job route, so the collector
+does not automate the dashboard, email links, redirects, or browser sessions:
+<https://www.beehiiv.com/support/article/12258595483543-exporting-post-content-or-subscriber-data-from-beehiiv>.
+
+Current pricing advertises API access across publication plans but product and
+endpoint entitlement can change. `401`, `403`, and publication-hidden `404`
+responses are terminal authorization/availability evidence, never a reason to
+fall back to scraping: <https://www.beehiiv.com/pricing>.
+
+## Usage
+
+```bash
+aidevops secret BEEHIIV_PERSONAL_ACCESS_TOKEN \
+  BEEHIIV_PERSONAL_PUBLICATION_ID BEEHIIV_PERSONAL_PUBLICATION_NAME \
+  BEEHIIV_PERSONAL_ORGANIZATION_NAME -- \
+  knowledge-social-helper.sh sync-beehiiv --alias personal:default \
+  --connection-id CONNECTION_ID --account-id PUBLICATION_ID \
+  --stream posts --profile personal --budget 19 --page-size 100
+```
+
+The credential remains in the secret execution context. Never put it in command
+arguments, fixtures, logs, corpus rows, issue text, or repository files.

--- a/.agents/scripts/_knowledge_social_beehiiv.py
+++ b/.agents/scripts/_knowledge_social_beehiiv.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""beehiiv publication identity, post policy, and durable page checkpoints."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from knowledge_social_import import canonical_json, reject_credentials
+from knowledge_social_store import SocialStoreError
+
+PROVIDER = "beehiiv"
+CURSOR_PREFIX = "beehiiv-v2-page:"
+RETENTION_LIMIT = "provider_retention_offset_page_100_and_deletion_boundary"
+MAX_PAGE_ITEMS = 100
+MAX_PAGE_NUMBER = 100
+MAX_TEXT_BYTES = 2 * 1024 * 1024
+PUBLICATION = re.compile(r"^pub_[A-Za-z0-9_-]{1,123}$")
+POST = re.compile(r"^post_[A-Za-z0-9_-]{1,123}$")
+
+
+class BeehiivAdapterError(SocialStoreError):
+    """Raised when guarded beehiiv collection cannot continue safely."""
+
+
+class BeehiivProviderUnavailableError(BeehiivAdapterError):
+    """Raised when the bounded beehiiv HTTP child cannot complete a read."""
+
+
+class BeehiivProviderError(RuntimeError):
+    """Raised for a privacy-safe local beehiiv provider failure."""
+
+
+ADAPTER_ERROR = BeehiivAdapterError
+PROVIDER_UNAVAILABLE_ERROR = BeehiivProviderUnavailableError
+
+
+def publication_id(value: Any) -> str:
+    """Validate one stable, prefixed beehiiv publication identity."""
+    if not isinstance(value, str) or PUBLICATION.fullmatch(value) is None:
+        raise BeehiivAdapterError("beehiiv publication ID is invalid")
+    return value
+
+
+def post_id(value: Any) -> str:
+    """Validate one stable, prefixed beehiiv post identity."""
+    if not isinstance(value, str) or POST.fullmatch(value) is None:
+        raise BeehiivAdapterError("beehiiv post ID is invalid")
+    return value
+
+
+def _text(value: Any, field: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str):
+        raise BeehiivAdapterError(f"beehiiv {field} is invalid")
+    if not value and not optional:
+        raise BeehiivAdapterError(f"beehiiv {field} is invalid")
+    if "\x00" in value or len(value.encode()) > MAX_TEXT_BYTES:
+        raise BeehiivAdapterError(f"beehiiv {field} is invalid")
+    return value
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    """One intentionally narrow beehiiv stream contract."""
+
+    resource_kind: str
+    activity_mode: str
+    pagination: str = "offset_page_v2"
+    incremental: bool = False
+    retention_limit: str | None = RETENTION_LIMIT
+    coverage_status: str | None = "partial"
+    unavailable_reason: str | None = "offset_page_100_and_provider_retention_boundary"
+    cost_units: int = 2
+
+
+STREAMS = {"posts": StreamSpec("post", "selected_publication")}
+
+
+@dataclass(frozen=True)
+class PageRequest:
+    """A selected-publication post page with an evidence-stable request key."""
+
+    stream: str
+    account_id: str
+    page: int
+    limit: int
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "page",
+            "stream": self.stream,
+            "account_id": self.account_id,
+            "page": self.page,
+            "limit": self.limit,
+        }
+
+    def evidence_key(self) -> str:
+        return canonical_json(self.payload())
+
+
+PAGE_REQUEST_KEYS = frozenset(PageRequest.__dataclass_fields__) | {"action"}
+
+
+def _decode_cursor(value: str) -> int:
+    if not value.startswith(CURSOR_PREFIX):
+        raise BeehiivAdapterError("stored beehiiv cursor has an unsupported version")
+    page = value.removeprefix(CURSOR_PREFIX)
+    if not page.isdigit() or not 1 <= int(page) <= MAX_PAGE_NUMBER:
+        raise BeehiivAdapterError("stored beehiiv cursor is invalid")
+    return int(page)
+
+
+def _encode_cursor(page: int) -> str:
+    if not 1 <= page <= MAX_PAGE_NUMBER:
+        raise BeehiivAdapterError("next beehiiv page exceeds the supported API boundary")
+    return f"{CURSOR_PREFIX}{page}"
+
+
+def page_request(
+    stream: str, account: dict[str, Any], state: CursorState, limit: int
+) -> PageRequest:
+    """Build the next bounded snapshot page for the selected publication."""
+    if stream not in STREAMS:
+        raise BeehiivAdapterError("beehiiv stream is unsupported")
+    page = _decode_cursor(state.cursor) if state.cursor else 1
+    return PageRequest(stream, publication_id(account.get("id")), page, limit)
+
+
+def parse_page_request(payload: dict[str, Any]) -> PageRequest:
+    """Reject every provider request outside the exact post-page shape."""
+    if set(payload) != PAGE_REQUEST_KEYS or payload.get("action") != "page":
+        raise BeehiivAdapterError("beehiiv request has an invalid action shape")
+    stream = payload.get("stream")
+    if not isinstance(stream, str) or stream not in STREAMS:
+        raise BeehiivAdapterError("beehiiv stream is unsupported")
+    page = payload.get("page")
+    limit = payload.get("limit")
+    if isinstance(page, bool) or not isinstance(page, int) or not 1 <= page <= MAX_PAGE_NUMBER:
+        raise BeehiivAdapterError("beehiiv page number is invalid")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= MAX_PAGE_ITEMS:
+        raise BeehiivAdapterError("beehiiv page size is invalid")
+    return PageRequest(stream, publication_id(payload.get("account_id")), page, limit)
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise BeehiivAdapterError("beehiiv response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise BeehiivAdapterError("beehiiv page data must be an array")
+    return data
+
+
+def _non_negative_int(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise BeehiivAdapterError(f"beehiiv {field} is invalid")
+    return value
+
+
+def page_checkpoint(
+    payload: dict[str, Any], state: CursorState, request: PageRequest
+) -> tuple[PageCheckpoint, bool]:
+    """Validate page provenance before advancing the offset checkpoint."""
+    meta = payload.get("meta")
+    expected_keys = {"stream", "publication_id", "page", "total_pages", "total_results"}
+    if not isinstance(meta, dict) or set(meta) != expected_keys:
+        raise BeehiivAdapterError("beehiiv page provenance is invalid")
+    reject_credentials(meta)
+    if meta.get("stream") != request.stream:
+        raise BeehiivAdapterError("beehiiv page stream does not match the request")
+    if publication_id(meta.get("publication_id")) != request.account_id:
+        raise BeehiivAdapterError("beehiiv page belongs to another publication")
+    page = _non_negative_int(meta.get("page"), "response page")
+    total_pages = _non_negative_int(meta.get("total_pages"), "total pages")
+    total_results = _non_negative_int(meta.get("total_results"), "total results")
+    items = page_data(payload)
+    if page != request.page or page < 1:
+        raise BeehiivAdapterError("beehiiv response page does not match the request")
+    if len(items) > request.limit or total_results < len(items):
+        raise BeehiivAdapterError("beehiiv page exceeds the declared safety bounds")
+    if total_pages == 0:
+        if items or page != 1 or total_results != 0:
+            raise BeehiivAdapterError("beehiiv empty pagination metadata is inconsistent")
+        return PageCheckpoint(None, state.watermark), True
+    if page > total_pages:
+        raise BeehiivAdapterError("beehiiv response page exceeds total pages")
+    final_page = min(total_pages, MAX_PAGE_NUMBER)
+    complete = page >= final_page
+    next_cursor = None if complete else _encode_cursor(page + 1)
+    return PageCheckpoint(next_cursor, state.watermark), complete
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    """Bind storage to one explicitly configured, singly visible publication."""
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise BeehiivAdapterError("beehiiv publication verification returned no identity")
+    selected = publication_id(data.get("id"))
+    if selected != publication_id(expected_id):
+        raise BeehiivAdapterError("selected beehiiv publication does not match expected identity")
+    if data.get("scope_verified") is not True:
+        raise BeehiivAdapterError("beehiiv publication-scoped authorization is not verified")
+    created = data.get("created")
+    referral = data.get("referral_program_enabled")
+    if isinstance(created, bool) or not isinstance(created, (int, float)) or created < 0:
+        raise BeehiivAdapterError("beehiiv publication creation time is invalid")
+    if not isinstance(referral, bool):
+        raise BeehiivAdapterError("beehiiv publication referral state is invalid")
+    return {
+        "id": selected,
+        "name": _text(data.get("name"), "publication name"),
+        "organization_name": _text(data.get("organization_name"), "organization name"),
+        "created": created,
+        "referral_program_enabled": referral,
+        "scope_verified": True,
+    }
+
+
+PROVENANCE = "beehiiv_api_v2"
+GAPS = (
+    ("draft_and_archived_posts", "default_live_route_collects_confirmed_posts_only"),
+    ("premium_post_content", "premium_content_expansion_is_not_requested"),
+    ("post_engagement_stats", "subscriber_derived_engagement_metrics_are_excluded"),
+    ("subscriptions", "subscriber_pii_requires_separate_justification_and_authorization"),
+    ("segments", "segment_membership_can_expose_subscriber_pii"),
+    ("post_export", "creator_initiated_dashboard_export_is_not_automated"),
+    ("subscriber_export", "sensitive_creator_initiated_export_is_not_imported"),
+    ("deletion_history", "api_does_not_prove_complete_deleted_post_history"),
+)
+
+
+@dataclass(frozen=True)
+class PageContext:
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def _record_text(record: dict[str, Any], key: str) -> str | None:
+    return _text(record.get(key), f"post {key}", optional=True)
+
+
+def _string_list(record: dict[str, Any], key: str) -> list[str]:
+    value = record.get(key, [])
+    if (
+        not isinstance(value, list)
+        or len(value) > 100
+        or any(not isinstance(item, str) or not item or "\x00" in item for item in value)
+    ):
+        raise BeehiivAdapterError(f"beehiiv post {key} is invalid")
+    return value
+
+
+def _coverage(observed: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "stream": stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": RETENTION_LIMIT,
+            "unavailable_reason": reason,
+            "status": "unavailable",
+            "observed_at": observed,
+        }
+        for stream, reason in GAPS
+    ]
+
+
+def _object(record: dict[str, Any], context: PageContext, observed: str) -> dict[str, Any]:
+    if record.get("kind") != "post":
+        raise BeehiivAdapterError("beehiiv item kind is unsupported")
+    remote = post_id(record.get("remote_id"))
+    authors = _string_list(record, "authors")
+    tags = _string_list(record, "content_tags")
+    text_parts = [
+        value
+        for value in (
+            _record_text(record, "title"),
+            _record_text(record, "subtitle"),
+            _record_text(record, "subject_line"),
+            _record_text(record, "preview_text"),
+            _record_text(record, "free_web_content"),
+            "\n".join(authors) or None,
+        )
+        if value
+    ]
+    metadata = {
+        key: value
+        for key, value in record.items()
+        if key not in {"free_web_content", "kind", "remote_id"}
+    }
+    metadata["content_tags"] = tags
+    reject_credentials(metadata)
+    return {
+        "object_type": "post",
+        "remote_id": remote,
+        "account_remote_id": context.account.get("id"),
+        "text": "\n\n".join(text_parts) or None,
+        "created_at": _record_text(record, "publish_date")
+        or _record_text(record, "created_at"),
+        "observed_at": observed,
+        "evidence_class": "authored",
+        "provider_json": {
+            "source": PROVENANCE,
+            "stream": context.stream,
+            "record": metadata,
+        },
+    }
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    """Normalize confirmed post content while excluding subscriber-level data."""
+    reject_credentials(payload)
+    observed = _text(payload.get("observed_at"), "observed_at")
+    if observed is None:
+        raise BeehiivAdapterError("beehiiv observed_at is invalid")
+    items = page_data(payload)
+    policy = dict(context.policy)
+    policy.update(
+        {
+            "beehiiv_identity": "single_visible_publication_plus_expected_id_name_and_organization",
+            "beehiiv_pagination": "endpoint_documented_offset_pages_capped_at_100",
+            "beehiiv_privacy": "subscriber_pii_segments_stats_and_premium_content_excluded",
+            "beehiiv_transport": "fixed_origin_stdlib_urllib_get_only_redirect_rejecting",
+        }
+    )
+    archive = {
+        "provider": PROVIDER,
+        "connection_id": context.connection_id,
+        "remote_account_id": context.account.get("id"),
+        "exported_at": observed,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": policy,
+        "accounts": [
+            {
+                "remote_id": context.account.get("id"),
+                "handle": None,
+                "display_name": context.account.get("name"),
+                "observed_at": observed,
+                "provider_json": {
+                    "source": PROVENANCE,
+                    "organization_name": context.account.get("organization_name"),
+                    "created": context.account.get("created"),
+                    "referral_program_enabled": context.account.get(
+                        "referral_program_enabled"
+                    ),
+                    "publication_scope_verified": True,
+                },
+            }
+        ],
+        "objects": [_object(item, context, observed) for item in items],
+        "activities": [],
+        "media": [],
+        "coverage": _coverage(observed),
+    }
+    reject_credentials(archive)
+    return archive

--- a/.agents/scripts/_knowledge_social_beehiiv_http.py
+++ b/.agents/scripts/_knowledge_social_beehiiv_http.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Redirect-free, bounded GET transport for the beehiiv API v2."""
+
+from __future__ import annotations
+
+import math
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from _knowledge_social_beehiiv import BeehiivProviderError, publication_id
+
+API_ORIGIN = "https://api.beehiiv.com/v2"
+MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+HTTP_TIMEOUT_SECONDS = 60
+POST_PATH = re.compile(r"^/publications/(pub_[A-Za-z0-9_-]{1,123})/posts$")
+
+
+class Headers(Protocol):
+    def get(self, key: str, default: str | None = None) -> str | None: ...
+
+
+class Response(Protocol):
+    status: int
+    headers: Headers
+
+    def __enter__(self) -> Response: ...
+    def __exit__(self, *args: Any) -> None: ...
+    def read(self, size: int = -1) -> bytes: ...
+
+
+class Opener(Protocol):
+    def open(self, request: Request, timeout: int) -> Response: ...
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    access_token: str
+    publication_id: str
+    publication_name: str
+    organization_name: str
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    status: int
+    payload: Any
+    retry_after: int | None = None
+
+
+class _RejectRedirect(HTTPRedirectHandler):
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def http_opener() -> Opener:
+    exports = (Request, build_opener, urlencode, HTTPRedirectHandler)
+    if not all(callable(item) for item in exports):
+        raise BeehiivProviderError("Python urllib HTTP exports are unavailable")
+    return build_opener(_RejectRedirect())
+
+
+def allowlisted_path(path: str) -> bool:
+    return path == "/publications" or POST_PATH.fullmatch(path) is not None
+
+
+def query_keys_for_path(path: str) -> frozenset[str]:
+    if path == "/publications":
+        return frozenset({"limit", "page"})
+    if POST_PATH.fullmatch(path):
+        return frozenset({"expand", "limit", "page", "status", "order_by", "direction"})
+    return frozenset()
+
+
+def _validate_query(path: str, params: dict[str, str]) -> None:
+    if not allowlisted_path(path) or set(params) - query_keys_for_path(path):
+        raise BeehiivProviderError("beehiiv API route is not allowlisted")
+    if any(
+        not isinstance(value, str) or "\x00" in value or len(value.encode()) > 4096
+        for value in params.values()
+    ):
+        raise BeehiivProviderError("beehiiv API query is invalid")
+    if "limit" in params and (
+        not params["limit"].isdigit() or not 1 <= int(params["limit"]) <= 100
+    ):
+        raise BeehiivProviderError("beehiiv page size is invalid")
+    if "page" in params and (
+        not params["page"].isdigit() or not 1 <= int(params["page"]) <= 100
+    ):
+        raise BeehiivProviderError("beehiiv page number is invalid")
+    expected = {
+        "expand": "free_web_content",
+        "status": "confirmed",
+        "order_by": "created",
+        "direction": "asc",
+    }
+    if any(key in params and params[key] != value for key, value in expected.items()):
+        raise BeehiivProviderError("beehiiv post query exceeds the read policy")
+
+
+def target_url(path: str, params: dict[str, str]) -> str:
+    _validate_query(path, params)
+    match = POST_PATH.fullmatch(path)
+    if match:
+        publication_id(match.group(1))
+    query = urlencode(params)
+    return f"{API_ORIGIN}{path}" + (f"?{query}" if query else "")
+
+
+def _decode_json(payload: bytes) -> Any:
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise BeehiivProviderError("beehiiv JSON exceeds the safety limit")
+    try:
+        import json
+
+        return json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise BeehiivProviderError("beehiiv JSON is invalid") from error
+
+
+def _absolute_reset(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        reset = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(reset) or reset < 0:
+        return None
+    return math.ceil(reset)
+
+
+def _retry_seconds(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    return int(time.time() + math.ceil(seconds))
+
+
+def _retry_epoch(headers: Headers | None) -> int | None:
+    if headers is None:
+        return None
+    return _absolute_reset(headers.get("RateLimit-Reset")) or _retry_seconds(
+        headers.get("Retry-After")
+    )
+
+
+def api(
+    config: ProfileConfig, opener: Opener, path: str, params: dict[str, str]
+) -> ApiResult:
+    request = Request(
+        target_url(path, params),
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {config.access_token}",
+            "User-Agent": "aidevops-beehiiv-knowledge/1",
+        },
+        method="GET",
+    )
+    try:
+        with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", 200)
+            if isinstance(status, bool) or not isinstance(status, int):
+                raise BeehiivProviderError("beehiiv HTTP status is invalid")
+            if status != 200:
+                return ApiResult(status, {}, _retry_epoch(response.headers))
+            payload = response.read(MAX_RESPONSE_BYTES + 1)
+            if not isinstance(payload, bytes):
+                raise BeehiivProviderError("beehiiv HTTP response is invalid")
+            return ApiResult(status, _decode_json(payload))
+    except HTTPError as error:
+        return ApiResult(error.code, {}, _retry_epoch(error.headers))
+    except (TimeoutError, URLError, OSError) as error:
+        raise BeehiivProviderError("beehiiv request failed") from error

--- a/.agents/scripts/_knowledge_social_beehiiv_posts.py
+++ b/.agents/scripts/_knowledge_social_beehiiv_posts.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Privacy-minimized normalization for beehiiv publication posts."""
+
+from __future__ import annotations
+
+import math
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_beehiiv import BeehiivProviderError, post_id
+from knowledge_social_import import reject_credentials
+
+MAX_TEXT_BYTES = 2 * 1024 * 1024
+
+
+def _object(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise BeehiivProviderError(f"beehiiv {field} must be an object")
+    return value
+
+
+def _text(
+    value: Any, field: str, *, optional: bool = False, limit: int = 64 * 1024
+) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str):
+        raise BeehiivProviderError(f"beehiiv {field} is invalid")
+    if not value and not optional:
+        raise BeehiivProviderError(f"beehiiv {field} is invalid")
+    if "\x00" in value or len(value.encode()) > limit:
+        raise BeehiivProviderError(f"beehiiv {field} is invalid")
+    return value
+
+
+def _epoch(value: Any, field: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise BeehiivProviderError(f"beehiiv {field} is invalid")
+    if not math.isfinite(value) or value < 0:
+        raise BeehiivProviderError(f"beehiiv {field} is invalid")
+    try:
+        return datetime.fromtimestamp(value, UTC).isoformat().replace("+00:00", "Z")
+    except (OverflowError, OSError, ValueError) as error:
+        raise BeehiivProviderError(f"beehiiv {field} is invalid") from error
+
+
+def _string(value: Any, field: str) -> str:
+    if not isinstance(value, str):
+        raise BeehiivProviderError(f"beehiiv post {field} is invalid")
+    if not value or "\x00" in value or len(value.encode()) > 4096:
+        raise BeehiivProviderError(f"beehiiv post {field} is invalid")
+    return value
+
+
+def _strings(value: Any, field: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or len(value) > 100:
+        raise BeehiivProviderError(f"beehiiv post {field} is invalid")
+    return [_string(item, field) for item in value]
+
+
+def _enum(value: Any, field: str, allowed: frozenset[str]) -> str:
+    text = _text(value, f"post {field}")
+    if text not in allowed:
+        raise BeehiivProviderError(f"beehiiv post {field} is unsupported")
+    return text
+
+
+def _boolean(value: Any, field: str, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise BeehiivProviderError(f"beehiiv post {field} is invalid")
+    return value
+
+
+def _free_web_content(item: dict[str, Any]) -> str | None:
+    content_value = item.get("content")
+    if content_value is None:
+        return None
+    content = _object(content_value, "post content")
+    if content.get("premium") not in (None, {}):
+        raise BeehiivProviderError("beehiiv premium post content is outside the read policy")
+    free_value = content.get("free")
+    if free_value is None:
+        return None
+    free = _object(free_value, "free post content")
+    return _text(
+        free.get("web"), "free web content", optional=True, limit=MAX_TEXT_BYTES
+    )
+
+
+def normalize_post(
+    item: dict[str, Any], observed_epoch: float
+) -> dict[str, Any] | None:
+    """Validate and minimize one confirmed post without audience statistics."""
+    reject_credentials(item)
+    if item.get("stats") not in (None, {}):
+        raise BeehiivProviderError("beehiiv post statistics are outside the privacy policy")
+    status = _enum(item.get("status"), "status", frozenset({"confirmed"}))
+    publish_value = item.get("publish_date")
+    publish_date = _epoch(publish_value, "post publish date", optional=True)
+    if publish_value is not None and float(publish_value) > observed_epoch:
+        return None
+    return {
+        "kind": "post",
+        "remote_id": post_id(item.get("id")),
+        "title": _text(item.get("title"), "post title", optional=True),
+        "subtitle": _text(item.get("subtitle"), "post subtitle", optional=True),
+        "authors": _strings(item.get("authors"), "authors"),
+        "created_at": _epoch(item.get("created"), "post creation time", optional=True),
+        "status": status,
+        "publish_date": publish_date,
+        "displayed_date": _epoch(
+            item.get("displayed_date"), "post displayed date", optional=True
+        ),
+        "subject_line": _text(
+            item.get("subject_line"), "post subject line", optional=True
+        ),
+        "preview_text": _text(
+            item.get("preview_text"), "post preview text", optional=True
+        ),
+        "slug": _text(item.get("slug"), "post slug", optional=True),
+        "web_url": _text(item.get("web_url"), "post web URL", optional=True),
+        "audience": _enum(
+            item.get("audience"),
+            "audience",
+            frozenset({"free", "premium", "both"}),
+        ),
+        "platform": _enum(
+            item.get("platform"),
+            "platform",
+            frozenset({"web", "email", "both"}),
+        ),
+        "content_tags": _strings(item.get("content_tags"), "content tags"),
+        "meta_default_description": _text(
+            item.get("meta_default_description"), "post meta description", optional=True
+        ),
+        "meta_default_title": _text(
+            item.get("meta_default_title"), "post meta title", optional=True
+        ),
+        "hidden_from_feed": _boolean(item.get("hidden_from_feed"), "hidden state"),
+        "enforce_gated_content": _boolean(
+            item.get("enforce_gated_content"), "gated-content state"
+        ),
+        "free_web_content": _free_web_content(item),
+    }

--- a/.agents/scripts/_knowledge_social_beehiiv_provider.py
+++ b/.agents/scripts/_knowledge_social_beehiiv_provider.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded GET-only beehiiv publication subprocess."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import UTC, datetime
+from functools import partial
+from typing import Any, Callable
+
+from _knowledge_social_beehiiv import (
+    BeehiivAdapterError,
+    BeehiivProviderError,
+    PageRequest,
+    parse_page_request,
+    publication_id,
+)
+from _knowledge_social_beehiiv_http import (
+    MAX_RESPONSE_BYTES,
+    ApiResult,
+    Opener,
+    ProfileConfig,
+    api,
+    http_opener,
+)
+from _knowledge_social_beehiiv_posts import normalize_post
+from knowledge_social_import import reject_credentials
+
+MAX_REQUEST_BYTES = 32 * 1024
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+Api = Callable[[str, dict[str, str]], ApiResult]
+
+
+def _observed_at() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _prefix(profile: str) -> str:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise BeehiivProviderError("beehiiv profile name is invalid")
+    return f"BEEHIIV_{profile.upper()}"
+
+
+def _value(prefix: str, suffix: str, field: str, limit: int) -> str:
+    value = os.environ.get(f"{prefix}_{suffix}", "")
+    if not value or "\x00" in value or len(value.encode()) > limit:
+        raise BeehiivProviderError(f"beehiiv profile {field} is missing")
+    return value
+
+
+def _profile(profile: str) -> ProfileConfig:
+    prefix = _prefix(profile)
+    token = _value(prefix, "ACCESS_TOKEN", "access token", 16 * 1024)
+    selected = publication_id(_value(prefix, "PUBLICATION_ID", "publication ID", 128))
+    name = _value(prefix, "PUBLICATION_NAME", "publication name", 4096)
+    organization = _value(prefix, "ORGANIZATION_NAME", "organization name", 4096)
+    return ProfileConfig(token, selected, name, organization)
+
+
+def _object(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise BeehiivProviderError(f"beehiiv {field} must be an object")
+    return value
+
+
+def _objects(value: Any, field: str, limit: int) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise BeehiivProviderError(f"beehiiv {field} must be an array")
+    if len(value) > limit:
+        raise BeehiivProviderError(f"beehiiv {field} exceeds the item limit")
+    return value
+
+
+def _text(
+    value: Any,
+    field: str,
+    *,
+    optional: bool = False,
+    limit: int = 64 * 1024,
+) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str):
+        raise BeehiivProviderError(f"beehiiv {field} is invalid")
+    if not value and not optional:
+        raise BeehiivProviderError(f"beehiiv {field} is invalid")
+    if "\x00" in value or len(value.encode()) > limit:
+        raise BeehiivProviderError(f"beehiiv {field} is invalid")
+    return value
+
+
+def _non_negative_int(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise BeehiivProviderError(f"beehiiv {field} is invalid")
+    return value
+
+
+def _terminal(result: ApiResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": result.status, "observed_at": _observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload
+
+
+def _identity(
+    config: ProfileConfig, opener: Opener, expected_id: str
+) -> dict[str, Any]:
+    if publication_id(expected_id) != config.publication_id:
+        raise BeehiivProviderError(
+            "selected beehiiv publication does not match the configured publication"
+        )
+    result = api(config, opener, "/publications", {"limit": "2", "page": "1"})
+    if result.status != 200:
+        return _terminal(result)
+    root = _object(result.payload, "publications response")
+    reject_credentials(root)
+    items = _objects(root.get("data"), "publications", 2)
+    page = _non_negative_int(root.get("page"), "publication page")
+    total_pages = _non_negative_int(root.get("total_pages"), "publication total pages")
+    total_results = _non_negative_int(root.get("total_results"), "publication total results")
+    if page != 1 or total_pages != 1 or total_results != 1 or len(items) != 1:
+        raise BeehiivProviderError(
+            "beehiiv credential is not bound to exactly one visible publication"
+        )
+    item = items[0]
+    selected = publication_id(item.get("id"))
+    name = _text(item.get("name"), "publication name")
+    organization = _text(item.get("organization_name"), "organization name")
+    created = item.get("created")
+    referral = item.get("referral_program_enabled")
+    if (
+        selected != config.publication_id
+        or name != config.publication_name
+        or organization != config.organization_name
+    ):
+        raise BeehiivProviderError("beehiiv publication identity does not match expectations")
+    if isinstance(created, bool) or not isinstance(created, (int, float)) or created < 0:
+        raise BeehiivProviderError("beehiiv publication creation time is invalid")
+    if not isinstance(referral, bool):
+        raise BeehiivProviderError("beehiiv publication referral state is invalid")
+    return {
+        "status": 200,
+        "observed_at": _observed_at(),
+        "data": {
+            "id": selected,
+            "name": name,
+            "organization_name": organization,
+            "created": created,
+            "referral_program_enabled": referral,
+            "scope_verified": True,
+        },
+    }
+
+
+def _posts(api_call: Api, request: PageRequest) -> ApiResult | dict[str, Any]:
+    result = api_call(
+        f"/publications/{request.account_id}/posts",
+        {
+            "expand": "free_web_content",
+            "limit": str(request.limit),
+            "page": str(request.page),
+            "status": "confirmed",
+            "order_by": "created",
+            "direction": "asc",
+        },
+    )
+    if result.status != 200:
+        return result
+    root = _object(result.payload, "posts response")
+    reject_credentials(root)
+    items = _objects(root.get("data"), "posts", request.limit)
+    page = _non_negative_int(root.get("page"), "post response page")
+    total_pages = _non_negative_int(root.get("total_pages"), "post total pages")
+    total_results = _non_negative_int(root.get("total_results"), "post total results")
+    response_limit = _non_negative_int(root.get("limit"), "post response limit")
+    if page != request.page or response_limit > request.limit:
+        raise BeehiivProviderError("beehiiv post pagination does not match the request")
+    observed = datetime.now(UTC)
+    records = [
+        record
+        for item in items
+        if (record := normalize_post(item, observed.timestamp()))
+    ]
+    return {
+        "status": 200,
+        "observed_at": observed.isoformat().replace("+00:00", "Z"),
+        "data": records,
+        "meta": {
+            "stream": request.stream,
+            "publication_id": request.account_id,
+            "page": page,
+            "total_pages": total_pages,
+            "total_results": total_results,
+        },
+    }
+
+
+def _dispatch(
+    request: dict[str, Any], config: ProfileConfig, opener: Opener
+) -> dict[str, Any]:
+    if request.get("action") == "identity":
+        if set(request) != {"action", "account_id"}:
+            raise BeehiivProviderError("beehiiv identity request shape is invalid")
+        return _identity(config, opener, publication_id(request.get("account_id")))
+    page_request = parse_page_request(request)
+    identity = _identity(config, opener, page_request.account_id)
+    if identity.get("status") != 200:
+        return identity
+    data = _object(identity.get("data"), "publication verification")
+    if data.get("id") != page_request.account_id or data.get("scope_verified") is not True:
+        raise BeehiivProviderError("beehiiv page publication identity is not verified")
+    result = _posts(partial(api, config, opener), page_request)
+    return _terminal(result) if isinstance(result, ApiResult) else result
+
+
+def _request_object(payload: bytes) -> dict[str, Any]:
+    if len(payload) > MAX_REQUEST_BYTES:
+        raise BeehiivProviderError("beehiiv request exceeds the safety limit")
+    try:
+        value = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise BeehiivProviderError("beehiiv request is invalid") from error
+    if not isinstance(value, dict):
+        raise BeehiivProviderError("beehiiv request must be an object")
+    reject_credentials(value)
+    return value
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode()) > MAX_RESPONSE_BYTES:
+        raise BeehiivProviderError("beehiiv response exceeds the safety limit")
+    print(encoded)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    args = parser.parse_args()
+    try:
+        request = _request_object(sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1))
+        _emit(_dispatch(request, _profile(args.profile), http_opener()))
+        return 0
+    except (BeehiivProviderError, BeehiivAdapterError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - intentionally redact provider internals
+        print("ERROR: beehiiv request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_beehiiv_reader.py
+++ b/.agents/scripts/_knowledge_social_beehiiv_reader.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and fixture readers for one beehiiv publication."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+from _knowledge_social_beehiiv import (
+    BeehiivAdapterError,
+    BeehiivProviderUnavailableError,
+    PageRequest,
+    verified_identity,
+)
+from _knowledge_social_fixture import FixturePageReader
+from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
+
+READ_TIMEOUT_SECONDS = 120
+MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+SAFE_FAILURES = (
+    "Python urllib HTTP exports are unavailable",
+    "beehiiv profile name is invalid",
+    "beehiiv profile access token is missing",
+    "beehiiv profile publication ID is missing",
+    "beehiiv profile publication name is missing",
+    "beehiiv profile organization name is missing",
+    "selected beehiiv publication does not match the configured publication",
+    "beehiiv credential is not bound to exactly one visible publication",
+    "beehiiv publication identity does not match expectations",
+)
+
+
+class Reader(Protocol):
+    def identity(self, expected_id: str) -> dict[str, Any]: ...
+    def page(self, request: PageRequest) -> dict[str, Any]: ...
+
+
+def _decode(output: str) -> dict[str, Any]:
+    if len(output.encode()) > MAX_RESPONSE_BYTES:
+        raise BeehiivAdapterError("beehiiv response exceeds the safety limit")
+    try:
+        value = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise BeehiivAdapterError("beehiiv returned no valid JSON") from error
+    if not isinstance(value, dict):
+        raise BeehiivAdapterError("beehiiv response must be an object")
+    return value
+
+
+def _failure(stderr: str) -> BeehiivProviderUnavailableError:
+    for message in SAFE_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return BeehiivProviderUnavailableError(message)
+    return BeehiivProviderUnavailableError("beehiiv provider is unavailable")
+
+
+POLICY = GuardedOAuthPolicy(
+    "beehiiv",
+    "BEEHIIV",
+    "BEEHIIV_READ_LOG",
+    READ_TIMEOUT_SECONDS,
+    _decode,
+    _failure,
+    BeehiivProviderUnavailableError,
+    ("ACCESS_TOKEN", "PUBLICATION_ID", "PUBLICATION_NAME", "ORGANIZATION_NAME"),
+    "",
+)
+
+
+class GuardedBeehiivReader(GuardedOAuthReader):
+    def __init__(self, helper: Path, profile: str) -> None:
+        super().__init__(helper, profile, POLICY)
+
+
+class FixtureBeehiivReader(FixturePageReader):
+    def __init__(self, path: Path) -> None:
+        super().__init__(path, "beehiiv", BeehiivAdapterError)
+
+
+__all__ = (
+    "FixtureBeehiivReader",
+    "GuardedBeehiivReader",
+    "verified_identity",
+)

--- a/.agents/scripts/_knowledge_social_discord_reader.py
+++ b/.agents/scripts/_knowledge_social_discord_reader.py
@@ -15,7 +15,7 @@ from _knowledge_social_discord import (
     PageRequest,
     snowflake,
 )
-from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_fixture import FixturePageReader
 from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
 from knowledge_social_import import reject_credentials
 
@@ -81,31 +81,11 @@ class GuardedDiscordBot(GuardedOAuthReader):
         super().__init__(helper, profile, DISCORD_BOT_POLICY)
 
 
-def _fixture_page(entry: dict[str, Any], request: PageRequest) -> dict[str, Any]:
-    expectation = entry.get("expect_request", {})
-    if not isinstance(expectation, dict):
-        raise DiscordAdapterError("Discord fixture expectation must be an object")
-    actual = request.payload()
-    if any(actual.get(key) != value for key, value in expectation.items()):
-        raise DiscordAdapterError("Discord request did not resume at the checkpoint")
-    response = entry.get("response", entry)
-    if not isinstance(response, dict):
-        raise DiscordAdapterError("Discord fixture page must be an object")
-    return response
-
-
-class FixtureDiscord:
+class FixtureDiscord(FixturePageReader):
     """Deterministic provider substitute for Discord collection fixtures."""
 
     def __init__(self, path: Path) -> None:
-        self.fixture = FixtureSequence(path, "Discord", DiscordAdapterError)
-
-    def identity(self, expected_id: str) -> dict[str, Any]:
-        del expected_id
-        return self.fixture.identity()
-
-    def page(self, request: PageRequest) -> dict[str, Any]:
-        return _fixture_page(self.fixture.next_page(), request)
+        super().__init__(path, "Discord", DiscordAdapterError)
 
 
 def _bool(value: Any, field: str) -> bool:

--- a/.agents/scripts/_knowledge_social_fixture.py
+++ b/.agents/scripts/_knowledge_social_fixture.py
@@ -51,7 +51,6 @@ class FixtureSequence:
         self.position += 1
         return page
 
-
 class FixturePageReader:
     """Match provider page requests against one deterministic fixture sequence."""
 
@@ -65,7 +64,7 @@ class FixturePageReader:
             raise self.error_type(f"{self.provider} {message}")
         return value
 
-    def identity(self, expected_id: str) -> dict[str, Any]:
+    def identity(self, expected_id: str | None = None) -> dict[str, Any]:
         del expected_id
         return self.fixture.identity()
 

--- a/.agents/scripts/_knowledge_social_github_http.py
+++ b/.agents/scripts/_knowledge_social_github_http.py
@@ -70,14 +70,11 @@ def _parsed_url(value: str) -> SplitResult:
         port = parsed.port
     except ValueError as error:
         raise GitHubReadProviderError("GitHub API URL is invalid") from error
-    if (
-        parsed.scheme != "https"
-        or parsed.hostname != "api.github.com"
-        or port not in (None, 443)
-        or parsed.username is not None
-        or parsed.password is not None
-        or parsed.fragment
-    ):
+    if parsed.scheme != "https" or parsed.hostname != "api.github.com":
+        raise GitHubReadProviderError("GitHub API URL is not allowlisted")
+    if port not in (None, 443) or parsed.username is not None:
+        raise GitHubReadProviderError("GitHub API URL is not allowlisted")
+    if parsed.password is not None or parsed.fragment:
         raise GitHubReadProviderError("GitHub API URL is not allowlisted")
     return parsed
 

--- a/.agents/scripts/_knowledge_social_github_reader.py
+++ b/.agents/scripts/_knowledge_social_github_reader.py
@@ -9,7 +9,7 @@ import json
 from pathlib import Path
 from typing import Any, Protocol
 
-from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_fixture import FixturePageReader
 from _knowledge_social_github import (
     GitHubAdapterError,
     GitHubProviderUnavailableError,
@@ -81,36 +81,9 @@ class GuardedGitHub(GuardedOAuthReader):
         super().__init__(helper, profile, GITHUB_READER_POLICY)
 
 
-def _fixture_object(value: Any, message: str) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        raise GitHubAdapterError(message)
-    return value
-
-
-class FixtureGitHub:
+class FixtureGitHub(FixturePageReader):
     def __init__(self, path: Path) -> None:
-        self.fixture = FixtureSequence(path, "GitHub", GitHubAdapterError)
-
-    def identity(self, expected_id: str) -> dict[str, Any]:
-        del expected_id
-        return self.fixture.identity()
-
-    def page(self, request: PageRequest) -> dict[str, Any]:
-        entry = self.fixture.next_page()
-        expectation = _fixture_object(
-            entry.get("expect_request", {}),
-            "GitHub fixture request expectation must be an object",
-        )
-        actual = request.payload()
-        for key, value in expectation.items():
-            if actual.get(key) != value:
-                raise GitHubAdapterError(
-                    "GitHub request did not resume at the expected checkpoint"
-                )
-        return _fixture_object(
-            entry.get("response", entry),
-            "GitHub fixture page response must be an object",
-        )
+        super().__init__(path, "GitHub", GitHubAdapterError)
 
 
 def _display_text(value: Any, field: str) -> str | None:

--- a/.agents/scripts/_knowledge_social_google_business_profile_reader.py
+++ b/.agents/scripts/_knowledge_social_google_business_profile_reader.py
@@ -9,7 +9,7 @@ import json
 from pathlib import Path
 from typing import Any, Protocol
 
-from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_fixture import FixturePageReader
 from _knowledge_social_google_business_profile import (
     GoogleBusinessProfileAdapterError,
     GoogleBusinessProfileProviderUnavailableError,
@@ -89,39 +89,13 @@ class GuardedGoogleBusinessProfileOAuth(GuardedOAuthReader):
         super().__init__(helper, profile, GBP_OAUTH_POLICY)
 
 
-def _fixture_page(entry: dict[str, Any], request: PageRequest) -> dict[str, Any]:
-    expectation = entry.get("expect_request", {})
-    if not isinstance(expectation, dict):
-        raise GoogleBusinessProfileAdapterError(
-            "Google Business Profile fixture request expectation must be an object"
-        )
-    actual = request.payload()
-    if any(actual.get(key) != value for key, value in expectation.items()):
-        raise GoogleBusinessProfileAdapterError(
-            "Google Business Profile request did not resume at the expected checkpoint"
-        )
-    response = entry.get("response", entry)
-    if not isinstance(response, dict):
-        raise GoogleBusinessProfileAdapterError(
-            "Google Business Profile fixture response must be an object"
-        )
-    return response
-
-
-class FixtureGoogleBusinessProfile:
+class FixtureGoogleBusinessProfile(FixturePageReader):
     """Deterministic substitute for hierarchy, pagination, and failure fixtures."""
 
     def __init__(self, path: Path) -> None:
-        self.fixture = FixtureSequence(
+        super().__init__(
             path, "Google Business Profile", GoogleBusinessProfileAdapterError
         )
-
-    def identity(self, expected_id: str) -> dict[str, Any]:
-        del expected_id
-        return self.fixture.identity()
-
-    def page(self, request: PageRequest) -> dict[str, Any]:
-        return _fixture_page(self.fixture.next_page(), request)
 
 
 def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:

--- a/.agents/scripts/_knowledge_social_linkedin_reader.py
+++ b/.agents/scripts/_knowledge_social_linkedin_reader.py
@@ -9,7 +9,7 @@ import json
 from pathlib import Path
 from typing import Any, Protocol
 
-from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_fixture import FixturePageReader
 from _knowledge_social_linkedin import (
     LinkedInAdapterError,
     LinkedInProviderUnavailableError,
@@ -79,35 +79,11 @@ class GuardedLinkedInOAuth(GuardedOAuthReader):
         super().__init__(helper, profile, LINKEDIN_OAUTH_POLICY)
 
 
-def _fixture_page(entry: dict[str, Any], request: PageRequest) -> dict[str, Any]:
-    expectation = entry.get("expect_request", {})
-    if not isinstance(expectation, dict):
-        raise LinkedInAdapterError(
-            "LinkedIn fixture request expectation must be an object"
-        )
-    actual = request.payload()
-    if any(actual.get(key) != value for key, value in expectation.items()):
-        raise LinkedInAdapterError(
-            "LinkedIn request did not resume at the expected checkpoint"
-        )
-    response = entry.get("response", entry)
-    if not isinstance(response, dict):
-        raise LinkedInAdapterError("LinkedIn fixture page response must be an object")
-    return response
-
-
-class FixtureLinkedIn:
+class FixtureLinkedIn(FixturePageReader):
     """Deterministic OAuth substitute for pagination and failure fixtures."""
 
     def __init__(self, path: Path) -> None:
-        self.fixture = FixtureSequence(path, "LinkedIn", LinkedInAdapterError)
-
-    def identity(self, expected_id: str) -> dict[str, Any]:
-        del expected_id
-        return self.fixture.identity()
-
-    def page(self, request: PageRequest) -> dict[str, Any]:
-        return _fixture_page(self.fixture.next_page(), request)
+        super().__init__(path, "LinkedIn", LinkedInAdapterError)
 
 
 def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, str]:

--- a/.agents/scripts/_knowledge_social_mastodon_reader.py
+++ b/.agents/scripts/_knowledge_social_mastodon_reader.py
@@ -9,7 +9,7 @@ import json
 from pathlib import Path
 from typing import Any, Protocol
 
-from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_fixture import FixturePageReader
 from _knowledge_social_mastodon import (
     MastodonAdapterError,
     MastodonProviderUnavailableError,
@@ -85,36 +85,9 @@ class GuardedMastodon(GuardedOAuthReader):
         super().__init__(helper, profile, MASTODON_READER_POLICY)
 
 
-def _fixture_object(value: Any, message: str) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        raise MastodonAdapterError(message)
-    return value
-
-
-class FixtureMastodon:
+class FixtureMastodon(FixturePageReader):
     def __init__(self, path: Path) -> None:
-        self.fixture = FixtureSequence(path, "Mastodon", MastodonAdapterError)
-
-    def identity(self, expected_id: str) -> dict[str, Any]:
-        del expected_id
-        return self.fixture.identity()
-
-    def page(self, request: PageRequest) -> dict[str, Any]:
-        entry = self.fixture.next_page()
-        expectation = _fixture_object(
-            entry.get("expect_request", {}),
-            "Mastodon fixture request expectation must be an object",
-        )
-        actual = request.payload()
-        for key, value in expectation.items():
-            if actual.get(key) != value:
-                raise MastodonAdapterError(
-                    "Mastodon request did not resume at the expected checkpoint"
-                )
-        return _fixture_object(
-            entry.get("response", entry),
-            "Mastodon fixture page response must be an object",
-        )
+        super().__init__(path, "Mastodon", MastodonAdapterError)
 
 
 def _display_text(value: Any, field: str) -> str | None:

--- a/.agents/scripts/_knowledge_social_meta_reader.py
+++ b/.agents/scripts/_knowledge_social_meta_reader.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Protocol
 
 from _knowledge_social_collect_cli import guarded_reader_environment
-from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_fixture import FixturePageReader
 from _knowledge_social_meta import (
     MetaAdapterError,
     MetaProviderUnavailableError,
@@ -87,34 +87,17 @@ class GuardedMetaOAuth(GuardedOAuthReader):
         )
 
 
-def _fixture_page(entry: dict[str, Any], request: PageRequest) -> dict[str, Any]:
-    expectation = entry.get("expect_request", {})
-    if not isinstance(expectation, dict):
-        raise MetaAdapterError("Meta fixture request expectation must be an object")
-    actual = request.payload()
-    if any(actual.get(key) != value for key, value in expectation.items()):
-        raise MetaAdapterError("Meta request did not resume at the expected checkpoint")
-    response = entry.get("response", entry)
-    if not isinstance(response, dict):
-        raise MetaAdapterError("Meta fixture page response must be an object")
-    return response
-
-
-class FixtureMeta:
+class FixtureMeta(FixturePageReader):
     """Deterministic OAuth substitute for product pagination and failures."""
 
     def __init__(self, path: Path, product: str) -> None:
         self.product = product
-        self.fixture = FixtureSequence(path, f"Meta {product}", MetaAdapterError)
-
-    def identity(self, expected_id: str) -> dict[str, Any]:
-        del expected_id
-        return self.fixture.identity()
+        super().__init__(path, f"Meta {product}", MetaAdapterError)
 
     def page(self, request: PageRequest) -> dict[str, Any]:
         if request.product != self.product:
             raise MetaAdapterError("Meta fixture product does not match the request")
-        return _fixture_page(self.fixture.next_page(), request)
+        return super().page(request)
 
 
 def verified_identity(

--- a/.agents/scripts/_knowledge_social_reddit_reader.py
+++ b/.agents/scripts/_knowledge_social_reddit_reader.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, Protocol
 
 from _knowledge_social_collect_cli import GuardedReaderProcess
-from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_fixture import FixturePageReader
 from _knowledge_social_reddit import (
     PageRequest,
     RedditAdapterError,
@@ -126,30 +126,11 @@ class GuardedPraw:
         return self.process.run(request.payload())
 
 
-def _fixture_page(entry: dict[str, Any], request: PageRequest) -> dict[str, Any]:
-    expectation = entry.get("expect_request", {})
-    if not isinstance(expectation, dict):
-        raise RedditAdapterError("Reddit fixture request expectation must be an object")
-    actual = request.payload()
-    if any(actual.get(key) != value for key, value in expectation.items()):
-        raise RedditAdapterError("Reddit request did not resume at the expected checkpoint")
-    response = entry.get("response", entry)
-    if not isinstance(response, dict):
-        raise RedditAdapterError("Reddit fixture page response must be an object")
-    return response
-
-
-class FixtureReddit:
+class FixtureReddit(FixturePageReader):
     """Deterministic PRAW substitute for pagination and failure fixtures."""
 
     def __init__(self, path: Path) -> None:
-        self.fixture = FixtureSequence(path, "Reddit", RedditAdapterError)
-
-    def identity(self) -> dict[str, Any]:
-        return self.fixture.identity()
-
-    def page(self, request: PageRequest) -> dict[str, Any]:
-        return _fixture_page(self.fixture.next_page(), request)
+        super().__init__(path, "Reddit", RedditAdapterError)
 
 
 def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:

--- a/.agents/scripts/_knowledge_social_stack_exchange_reader.py
+++ b/.agents/scripts/_knowledge_social_stack_exchange_reader.py
@@ -9,7 +9,7 @@ import json
 from pathlib import Path
 from typing import Any, Protocol
 
-from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_fixture import FixturePageReader
 from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
 from _knowledge_social_stack_exchange import (
     PageRequest,
@@ -86,36 +86,9 @@ class GuardedStackExchange(GuardedOAuthReader):
         super().__init__(helper, profile, STACK_EXCHANGE_READER_POLICY)
 
 
-def _fixture_object(value: Any, message: str) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        raise StackExchangeAdapterError(message)
-    return value
-
-
-class FixtureStackExchange:
+class FixtureStackExchange(FixturePageReader):
     def __init__(self, path: Path) -> None:
-        self.fixture = FixtureSequence(path, "Stack Exchange", StackExchangeAdapterError)
-
-    def identity(self, expected_id: str) -> dict[str, Any]:
-        del expected_id
-        return self.fixture.identity()
-
-    def page(self, request: PageRequest) -> dict[str, Any]:
-        entry = self.fixture.next_page()
-        expectation = _fixture_object(
-            entry.get("expect_request", {}),
-            "Stack Exchange fixture request expectation must be an object",
-        )
-        actual = request.payload()
-        for key, value in expectation.items():
-            if actual.get(key) != value:
-                raise StackExchangeAdapterError(
-                    "Stack Exchange request did not resume at the expected checkpoint"
-                )
-        return _fixture_object(
-            entry.get("response", entry),
-            "Stack Exchange fixture page response must be an object",
-        )
+        super().__init__(path, "Stack Exchange", StackExchangeAdapterError)
 
 
 def _display_text(value: Any, field: str) -> str | None:

--- a/.agents/scripts/_knowledge_social_youtube_reader.py
+++ b/.agents/scripts/_knowledge_social_youtube_reader.py
@@ -9,7 +9,7 @@ import json
 from pathlib import Path
 from typing import Any, Protocol
 
-from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_fixture import FixturePageReader
 from _knowledge_social_oauth_reader import (
     GuardedOAuthPolicy,
     GuardedOAuthReader,
@@ -77,33 +77,11 @@ class GuardedYouTubeOAuth(GuardedOAuthReader):
         super().__init__(helper, profile, YOUTUBE_OAUTH_POLICY)
 
 
-def _fixture_page(entry: dict[str, Any], request: PageRequest) -> dict[str, Any]:
-    expectation = entry.get("expect_request", {})
-    if not isinstance(expectation, dict):
-        raise YouTubeAdapterError("YouTube fixture request expectation must be an object")
-    actual = request.payload()
-    if any(actual.get(key) != value for key, value in expectation.items()):
-        raise YouTubeAdapterError(
-            "YouTube request did not resume at the expected checkpoint"
-        )
-    response = entry.get("response", entry)
-    if not isinstance(response, dict):
-        raise YouTubeAdapterError("YouTube fixture page response must be an object")
-    return response
-
-
-class FixtureYouTube:
+class FixtureYouTube(FixturePageReader):
     """Deterministic OAuth substitute for pagination and failure fixtures."""
 
     def __init__(self, path: Path) -> None:
-        self.fixture = FixtureSequence(path, "YouTube", YouTubeAdapterError)
-
-    def identity(self, expected_id: str) -> dict[str, Any]:
-        del expected_id
-        return self.fixture.identity()
-
-    def page(self, request: PageRequest) -> dict[str, Any]:
-        return _fixture_page(self.fixture.next_page(), request)
+        super().__init__(path, "YouTube", YouTubeAdapterError)
 
 
 def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -23,6 +23,7 @@ HACKER_NEWS_HELPER="${SCRIPT_DIR}/knowledge_social_hacker_news.py"
 HASHNODE_HELPER="${SCRIPT_DIR}/knowledge_social_hashnode.py"
 MINIFLUX_HELPER="${SCRIPT_DIR}/knowledge_social_miniflux.py"
 READWISE_READER_HELPER="${SCRIPT_DIR}/knowledge_social_readwise_reader.py"
+BEEHIIV_HELPER="${SCRIPT_DIR}/knowledge_social_beehiiv.py"
 QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
 SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
 SHARE_HELPER="${SCRIPT_DIR}/knowledge_social_share.py"
@@ -145,6 +146,14 @@ Stack Exchange synchronization:
   exhaustion, continue only while has_more, and cap pages at 100 items.
   --budget is 3-1000 and --page-size is 1-100.
 
+EOF
+	usage_sync_more || return 1
+	return 0
+}
+
+usage_sync_more() {
+	cat <<'EOF'
+
 Hacker News synchronization:
   sync-hacker-news observes one exact case-sensitive public username selector;
   it never claims authenticated or immutable account identity. One bounded
@@ -163,6 +172,13 @@ Readwise Reader synchronization:
   token binding before fixed-origin token validation. Seven GET-only streams use
   opaque cursors and one-second updatedAfter overlap. The per-invocation request
   budget is 3-19 to remain below the documented 20/minute limit.
+
+beehiiv synchronization:
+  sync-beehiiv requires one expected publication ID, name, and organization plus
+  a credential that exposes exactly that publication. The fixed-origin API v2
+  route collects confirmed posts and paywall-enforced free web content only.
+  Subscriber PII, segments, engagement stats, premium content, redirects, and
+  every mutation route are excluded. --budget is 3-59 and pages are 1-100 items.
 
 EOF
 	return 0
@@ -254,6 +270,10 @@ Usage:
   knowledge-social-helper.sh sync-readwise-reader [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id DEPLOYMENT_ACCOUNT_ID --stream STREAM \
     --profile PROFILE [--budget 3-19] [--page-size 1-100] \
+    [--collector-id ID] [--lease-seconds SECONDS]
+  knowledge-social-helper.sh sync-beehiiv [--base PATH] [--alias ALIAS] \
+    --connection-id ID --account-id PUBLICATION_ID --stream posts \
+    --profile PROFILE [--budget 3-59] [--page-size 1-100] \
     [--collector-id ID] [--lease-seconds SECONDS]
   knowledge-social-helper.sh sync-due [--base PATH] [--alias ALIAS] \
     [--now-epoch EPOCH] [--interval-seconds SECONDS]
@@ -448,6 +468,7 @@ run_named_provider_sync() {
 	sync-hashnode) run_provider_sync Hashnode "$HASHNODE_HELPER" "$@" || return 1 ;;
 	sync-miniflux) run_provider_sync Miniflux "$MINIFLUX_HELPER" "$@" || return 1 ;;
 	sync-readwise-reader) run_provider_sync "Readwise Reader" "$READWISE_READER_HELPER" "$@" || return 1 ;;
+	sync-beehiiv) run_provider_sync beehiiv "$BEEHIIV_HELPER" "$@" || return 1 ;;
 	*) return 1 ;;
 	esac
 	return 0
@@ -527,7 +548,7 @@ main() {
 		fi
 		python3 "$LINKEDIN_HELPER" "$@" || return 1
 		;;
-	sync-meta | sync-discourse | sync-nodebb | sync-mastodon | sync-lemmy | sync-github | sync-stack-exchange | sync-hacker-news | sync-hashnode | sync-miniflux | sync-readwise-reader)
+	sync-meta | sync-discourse | sync-nodebb | sync-mastodon | sync-lemmy | sync-github | sync-stack-exchange | sync-hacker-news | sync-hashnode | sync-miniflux | sync-readwise-reader | sync-beehiiv)
 		run_named_provider_sync "$subcommand" "$@" || return 1
 		;;
 	query | annotate)

--- a/.agents/scripts/knowledge_social_beehiiv.py
+++ b/.agents/scripts/knowledge_social_beehiiv.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one bounded, creator-owned beehiiv publication post stream."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import _knowledge_social_beehiiv as beehiiv
+from _knowledge_social_beehiiv import PageContext, normalize_page
+from _knowledge_social_beehiiv_reader import (
+    FixtureBeehiivReader,
+    GuardedBeehiivReader,
+    verified_identity,
+)
+from _knowledge_social_oauth_collector import OAuthCollectorPolicy, run_oauth_collector
+
+MAX_REQUEST_BUDGET = 59
+
+
+def _enforce_rate_budget(arguments: list[str]) -> None:
+    if "--budget" not in arguments:
+        return
+    index = arguments.index("--budget")
+    if index + 1 >= len(arguments):
+        return
+    try:
+        budget = int(arguments[index + 1])
+    except ValueError:
+        return
+    if budget > MAX_REQUEST_BUDGET:
+        raise beehiiv.BeehiivAdapterError(
+            "beehiiv budget cannot exceed 59 requests per invocation"
+        )
+
+
+def _policy() -> OAuthCollectorPolicy:
+    return OAuthCollectorPolicy(
+        provider_module=beehiiv,
+        verified_identity=verified_identity,
+        normalize_page=normalize_page,
+        page_context=PageContext,
+        display_name="beehiiv",
+        helper=Path(__file__).with_name("_knowledge_social_beehiiv_provider.py"),
+        fixture_reader=FixtureBeehiivReader,
+        live_reader=GuardedBeehiivReader,
+        budget_unit="request",
+        default_budget=19,
+        max_page_size=100,
+    )
+
+
+def main() -> int:
+    try:
+        _enforce_rate_budget(sys.argv[1:])
+    except beehiiv.BeehiivAdapterError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    return run_oauth_collector(_policy(), __doc__ or "")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/knowledge_social_registry.py
+++ b/.agents/scripts/knowledge_social_registry.py
@@ -37,6 +37,7 @@ PROVIDER_SPECS = (
         (("live", ()),),
     ),
     ProviderSpec("binance-square", (), None, (("no-route", ()),)),
+    ProviderSpec("beehiiv", (), "knowledge_social_beehiiv.py", (("live", ()),)),
     ProviderSpec("discord", (), "knowledge_social_discord.py", (("live", ()),)),
     ProviderSpec(
         "forem",

--- a/.agents/tests/test-knowledge-social-beehiiv.sh
+++ b/.agents/tests/test-knowledge-social-beehiiv.sh
@@ -1,0 +1,684 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-beehiiv.sh — Publication-scoped beehiiv collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BEEHIIV_SCRIPT="${SCRIPT_DIR}/../scripts/knowledge_social_beehiiv.py"
+SOCIAL_HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TEMP_PARENT="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+mkdir -p "$TEMP_PARENT"
+TMP_DIR=$(mktemp -d "${TEMP_PARENT}/beehiiv-test.XXXXXX")
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+PUBLICATION_ID="pub_fixture_publication"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' "$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c 'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' "$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_count() {
+	local connection_id="${1:-}"
+	python3 - "$ROOT/sources/social/raw/beehiiv" "$connection_id" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+connection = sys.argv[2]
+if connection:
+    root = root / connection
+print(len(list(root.rglob("*.json.gz"))) if root.exists() else 0)
+PY
+	return 0
+}
+
+run_fixture() {
+	local fixture="$1"
+	local connection_id="$2"
+	python3 "$BEEHIIV_SCRIPT" --base "$BASE" --alias personal:default \
+		--connection-id "$connection_id" --account-id "$PUBLICATION_ID" \
+		--stream posts --profile fixture --fixture "$fixture" \
+		--budget 5 --page-size 1
+	return $?
+}
+
+expect_failure() {
+	local description="$1"
+	local fixture="$2"
+	local connection_id="$3"
+	if run_fixture "$fixture" "$connection_id" >/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$SOCIAL_HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'beehiiv social collector tests\n'
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import ast
+import json
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+
+from _knowledge_social_beehiiv import (
+    PageRequest,
+    STREAMS,
+    page_checkpoint,
+    page_request,
+)
+from _knowledge_social_beehiiv_http import (
+    HTTP_TIMEOUT_SECONDS,
+    ApiResult,
+    ProfileConfig,
+    _RejectRedirect,
+    allowlisted_path,
+    api,
+    target_url,
+)
+from _knowledge_social_beehiiv_provider import _identity, _posts
+from _knowledge_social_collect import CursorState
+from knowledge_social_beehiiv import _enforce_rate_budget
+
+publication_id = "pub_fixture_publication"
+other_publication_id = "pub_other_publication"
+assert set(STREAMS) == {"posts"}
+assert allowlisted_path("/publications")
+assert allowlisted_path(f"/publications/{publication_id}/posts")
+assert not allowlisted_path(f"/publications/{publication_id}/subscriptions")
+assert not allowlisted_path(f"/publications/{publication_id}/segments")
+assert not allowlisted_path(f"/publications/{publication_id}/posts/post_one")
+assert _RejectRedirect().redirect_request() is None
+
+url = target_url(
+    f"/publications/{publication_id}/posts",
+    {
+        "expand": "free_web_content",
+        "limit": "1",
+        "page": "1",
+        "status": "confirmed",
+        "order_by": "created",
+        "direction": "asc",
+    },
+)
+assert url.startswith("https://api.beehiiv.com/v2/publications/")
+assert "free_web_content" in url and "access" not in url
+for invalid_path in (
+    f"/publications/{publication_id}/subscriptions",
+    f"/publications/{publication_id}/segments",
+    f"/publications/{publication_id}/posts/post_one",
+):
+    try:
+        target_url(invalid_path, {})
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError(f"beehiiv route was reachable: {invalid_path}")
+
+account = {
+    "id": publication_id,
+    "name": "Fixture Publication",
+    "organization_name": "Fixture Organization",
+    "created": 1700000000,
+    "referral_program_enabled": False,
+    "scope_verified": True,
+}
+first = PageRequest("posts", publication_id, 1, 1)
+first_payload = {
+    "status": 200,
+    "observed_at": "2026-08-02T10:00:00Z",
+    "data": [],
+    "meta": {
+        "stream": "posts",
+        "publication_id": publication_id,
+        "page": 1,
+        "total_pages": 2,
+        "total_results": 2,
+    },
+}
+checkpoint, complete = page_checkpoint(first_payload, CursorState(None, None, False), first)
+assert not complete and checkpoint.next_cursor
+resumed = page_request("posts", account, CursorState(checkpoint.next_cursor, None, False), 1)
+assert resumed.page == 2
+try:
+    page_checkpoint(
+        {
+            **first_payload,
+            "meta": {**first_payload["meta"], "publication_id": other_publication_id},
+        },
+        CursorState(None, None, False),
+        first,
+    )
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("cross-publication beehiiv page advanced a checkpoint")
+
+try:
+    _enforce_rate_budget(["--budget", "60"])
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("beehiiv request budget exceeded the conservative quota")
+
+
+class Headers:
+    def __init__(self, values=None):
+        self.values = values or {}
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+
+class Response:
+    def __init__(self, payload, status=200, headers=None):
+        self.payload = payload
+        self.status = status
+        self.headers = Headers(headers)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def read(self, size=-1):
+        return self.payload[:size]
+
+
+class Opener:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    def open(self, request, timeout):
+        assert timeout == HTTP_TIMEOUT_SECONDS and request.method == "GET"
+        assert "fixture-token" not in request.full_url
+        self.requests.append(request)
+        return self.responses.pop(0)
+
+
+config = ProfileConfig(
+    "fixture-token",
+    publication_id,
+    "Fixture Publication",
+    "Fixture Organization",
+)
+publication = {
+    "id": publication_id,
+    "name": "Fixture Publication",
+    "organization_name": "Fixture Organization",
+    "created": 1700000000,
+    "referral_program_enabled": False,
+}
+identity_body = json.dumps(
+    {
+        "data": [publication],
+        "limit": 2,
+        "page": 1,
+        "total_results": 1,
+        "total_pages": 1,
+    }
+).encode()
+identity = _identity(config, Opener([Response(identity_body)]), publication_id)
+assert identity["data"]["id"] == publication_id
+assert identity["data"]["scope_verified"] is True
+
+wide_scope = json.dumps(
+    {
+        "data": [publication, {**publication, "id": other_publication_id}],
+        "limit": 2,
+        "page": 1,
+        "total_results": 2,
+        "total_pages": 1,
+    }
+).encode()
+try:
+    _identity(config, Opener([Response(wide_scope)]), publication_id)
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("workspace-wide beehiiv credential passed publication scoping")
+
+raw_post = {
+    "id": "post_fixture_one",
+    "title": "Bounded beehiiv knowledge",
+    "subtitle": "Fixture subtitle",
+    "authors": ["Fixture Author"],
+    "created": 1700000000,
+    "status": "confirmed",
+    "publish_date": 1700000100,
+    "displayed_date": 1700000100,
+    "subject_line": "Fixture subject",
+    "preview_text": "Fixture preview",
+    "slug": "fixture-post",
+    "web_url": "https://example.invalid/p/fixture-post",
+    "audience": "free",
+    "platform": "web",
+    "content_tags": ["knowledge"],
+    "hidden_from_feed": False,
+    "enforce_gated_content": False,
+    "content": {"free": {"web": "<p>Fixture body</p>"}},
+}
+post_page = _posts(
+    lambda path, params: ApiResult(
+        200,
+        {
+            "data": [raw_post],
+            "limit": 1,
+            "page": 1,
+            "total_results": 1,
+            "total_pages": 1,
+        },
+    ),
+    first,
+)
+assert post_page["data"][0]["remote_id"] == "post_fixture_one"
+assert post_page["data"][0]["free_web_content"] == "<p>Fixture body</p>"
+assert "stats" not in post_page["data"][0]
+
+scheduled = {**raw_post, "id": "post_future", "publish_date": 4102444800}
+scheduled_page = _posts(
+    lambda path, params: ApiResult(
+        200,
+        {
+            "data": [scheduled],
+            "limit": 1,
+            "page": 1,
+            "total_results": 1,
+            "total_pages": 1,
+        },
+    ),
+    first,
+)
+assert scheduled_page["data"] == []
+
+opener = Opener([Response(identity_body)])
+assert api(config, opener, "/publications", {"limit": "2", "page": "1"}).status == 200
+rate = Opener([Response(b"", status=429, headers={"RateLimit-Reset": "2000000000"})])
+limited = api(config, rate, "/publications", {"limit": "2", "page": "1"})
+assert limited.status == 429 and limited.retry_after == 2000000000
+
+provider_sources = [
+    (scripts / "_knowledge_social_beehiiv_http.py").read_text(encoding="utf-8"),
+    (scripts / "_knowledge_social_beehiiv_provider.py").read_text(encoding="utf-8"),
+]
+assert all("/subscriptions" not in source and "/segments" not in source for source in provider_sources)
+trees = [ast.parse(source) for source in provider_sources]
+calls = [
+    node
+    for tree in trees
+    for node in ast.walk(tree)
+    if isinstance(node, ast.Call)
+    and isinstance(node.func, ast.Name)
+    and node.func.id == "Request"
+]
+assert calls
+for node in calls:
+    methods = [
+        keyword.value.value
+        for keyword in node.keywords
+        if keyword.arg == "method" and isinstance(keyword.value, ast.Constant)
+    ]
+    assert methods == ["GET"]
+PY
+assert_eq "identity, scope, pagination, quota, redirects, and GET routes are guarded" verified verified
+
+help_output=$("$SOCIAL_HELPER" help 2>&1)
+if [[ "$help_output" == *"sync-beehiiv"* && "$help_output" == *"PUBLICATION_ID"* ]]; then
+	assert_eq "provider-neutral helper exposes the bounded beehiiv route" exposed exposed
+else
+	assert_eq "provider-neutral helper exposes the bounded beehiiv route" missing exposed
+fi
+
+python3 - "$TMP_DIR" "$PUBLICATION_ID" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+target = Path(sys.argv[1])
+publication_id = sys.argv[2]
+identity = {
+    "data": {
+        "id": publication_id,
+        "name": "Fixture Publication",
+        "organization_name": "Fixture Organization",
+        "created": 1700000000,
+        "referral_program_enabled": False,
+        "scope_verified": True,
+    }
+}
+
+
+def record(post_id, title, body, published):
+    return {
+        "kind": "post",
+        "remote_id": post_id,
+        "title": title,
+        "subtitle": "Fixture subtitle",
+        "authors": ["Fixture Author"],
+        "created_at": published,
+        "status": "confirmed",
+        "publish_date": published,
+        "displayed_date": published,
+        "subject_line": "Fixture subject",
+        "preview_text": "Fixture preview",
+        "slug": post_id,
+        "web_url": f"https://example.invalid/p/{post_id}",
+        "audience": "free",
+        "platform": "web",
+        "content_tags": ["knowledge"],
+        "meta_default_description": None,
+        "meta_default_title": None,
+        "hidden_from_feed": False,
+        "enforce_gated_content": False,
+        "free_web_content": body,
+    }
+
+
+def page(number, total, item, observed):
+    return {
+        "expect_request": {"page": number, "limit": 1},
+        "response": {
+            "status": 200,
+            "observed_at": observed,
+            "data": [item],
+            "meta": {
+                "stream": "posts",
+                "publication_id": publication_id,
+                "page": number,
+                "total_pages": total,
+                "total_results": total,
+            },
+        },
+    }
+
+
+complete = {
+    "identity": identity,
+    "pages": [
+        page(
+            1,
+            2,
+            record(
+                "post_fixture_one",
+                "Bounded beehiiv knowledge",
+                "<p>First fixture body</p>",
+                "2026-08-02T09:00:00Z",
+            ),
+            "2026-08-02T10:00:00Z",
+        ),
+        page(
+            2,
+            2,
+            record(
+                "post_fixture_two",
+                "Second publication post",
+                "<p>Second fixture body</p>",
+                "2026-08-02T09:30:00Z",
+            ),
+            "2026-08-02T10:01:00Z",
+        ),
+    ],
+}
+(target / "complete.json").write_text(json.dumps(complete), encoding="utf-8")
+
+mismatch = {
+    "identity": {
+        "data": {
+            **identity["data"],
+            "id": "pub_other_publication",
+        }
+    },
+    "pages": [],
+}
+(target / "mismatch.json").write_text(json.dumps(mismatch), encoding="utf-8")
+
+cross = {
+    "identity": identity,
+    "pages": [
+        {
+            **complete["pages"][0],
+            "response": {
+                **complete["pages"][0]["response"],
+                "meta": {
+                    **complete["pages"][0]["response"]["meta"],
+                    "publication_id": "pub_other_publication",
+                },
+            },
+        }
+    ],
+}
+(target / "cross.json").write_text(json.dumps(cross), encoding="utf-8")
+
+credential = {
+    "identity": identity,
+    "pages": [
+        {
+            **complete["pages"][0],
+            "response": {
+                **complete["pages"][0]["response"],
+                "access_token": "fixture-must-not-persist",
+            },
+        }
+    ],
+}
+(target / "credential.json").write_text(json.dumps(credential), encoding="utf-8")
+
+malformed = {
+    "identity": identity,
+    "pages": [
+        {
+            **complete["pages"][0],
+            "response": {
+                **complete["pages"][0]["response"],
+                "meta": {
+                    key: value
+                    for key, value in complete["pages"][0]["response"]["meta"].items()
+                    if key != "total_results"
+                },
+            },
+        }
+    ],
+}
+(target / "malformed.json").write_text(json.dumps(malformed), encoding="utf-8")
+
+terminal = {
+    "identity": {"status": 403, "observed_at": "2026-08-02T10:02:00Z"},
+    "pages": [],
+}
+(target / "terminal.json").write_text(json.dumps(terminal), encoding="utf-8")
+PY
+
+result=$(run_fixture "$TMP_DIR/complete.json" conn_beehiiv)
+assert_eq "bounded two-page beehiiv fixture completes" "$(json_field "$result" status)" complete
+assert_eq "identity plus two pages consumes five requests" "$(json_field "$result" budget_units)" 5
+assert_eq "publication identity persists before post projections" \
+	"$(sql_value "SELECT remote_id || ':' || display_name FROM accounts WHERE provider='beehiiv'")" \
+	"${PUBLICATION_ID}:Fixture Publication"
+assert_eq "confirmed free post content reaches FTS" \
+	"$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'bounded'")" 1
+assert_eq "subscriber, segment, export, stats, premium, and deletion gaps stay explicit" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE connection_id='conn_beehiiv' AND status='unavailable'")" 8
+assert_eq "successful page exhaustion advances only the selected stream" \
+	"$(sql_value "SELECT coalesce(cursor, 'none') || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_beehiiv' AND stream='posts'")" \
+	"none:1"
+
+batch_count=$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_beehiiv'")
+raw_before=$(raw_count conn_beehiiv)
+object_count=$(sql_value "SELECT count(*) FROM objects WHERE provider='beehiiv'")
+run_fixture "$TMP_DIR/complete.json" conn_beehiiv >/dev/null
+assert_eq "exact beehiiv replay is content-addressed" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_beehiiv'"):$(raw_count conn_beehiiv):$(sql_value "SELECT count(*) FROM objects WHERE provider='beehiiv'")" \
+	"${batch_count}:${raw_before}:${object_count}"
+
+raw_all_before=$(raw_count)
+expect_failure "wrong publication identity is rejected before persistence" \
+	"$TMP_DIR/mismatch.json" conn_mismatch
+assert_eq "identity mismatch writes no raw evidence" "$(raw_count)" "$raw_all_before"
+
+expect_failure "cross-publication page provenance is rejected" \
+	"$TMP_DIR/cross.json" conn_cross
+assert_eq "cross-publication rejection writes no raw evidence" "$(raw_count)" "$raw_all_before"
+
+expect_failure "credential-shaped beehiiv payload is rejected" \
+	"$TMP_DIR/credential.json" conn_credential
+assert_eq "credential rejection writes no raw evidence" "$(raw_count)" "$raw_all_before"
+
+cursor_before=$(sql_value "SELECT coalesce(cursor, 'none') || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_beehiiv' AND stream='posts'")
+expect_failure "malformed beehiiv page fails closed" \
+	"$TMP_DIR/malformed.json" conn_beehiiv
+assert_eq "malformed page preserves the prior checkpoint" \
+	"$(sql_value "SELECT coalesce(cursor, 'none') || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_beehiiv' AND stream='posts'")" \
+	"$cursor_before"
+assert_eq "malformed page writes no new raw evidence" "$(raw_count conn_beehiiv)" "$raw_before"
+
+terminal=$(run_fixture "$TMP_DIR/terminal.json" conn_plan_gate)
+assert_eq "plan or authorization gate is terminal" \
+	"$(json_field "$terminal" status):$(json_field "$terminal" failure_class)" \
+	"failed:authorization"
+assert_eq "terminal authorization response advances no checkpoint" \
+	"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_plan_gate'")" 0
+
+python3 - "$ROOT" "$SCRIPT_DIR/../scripts" <<'PY'
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[2])
+from _knowledge_social_beehiiv import STREAMS
+from _knowledge_social_collect import (
+    CollectionContext,
+    ConnectionConfig,
+    CursorState,
+    PageCheckpoint,
+    SuccessfulPage,
+)
+from _knowledge_social_collect_persist import persist_page
+from _knowledge_social_lease import (
+    RunLeaseRequest,
+    SocialLeaseLostError,
+    acquire_run_lease,
+    release_run_lease,
+)
+
+root = Path(sys.argv[1])
+old = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_beehiiv_fence", "posts", "old_runner", "sync", 1),
+    now_epoch=9000,
+)
+new = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_beehiiv_fence", "posts", "new_runner", "sync", 10),
+    now_epoch=9001,
+)
+publication_id = "pub_fixture_publication"
+context = CollectionContext(
+    root,
+    "conn_beehiiv_fence",
+    {"id": publication_id},
+    "posts",
+    "none",
+    ConnectionConfig(("posts",), {"media_hydration": "none"}),
+    CursorState(None, None, False),
+    STREAMS["posts"],
+    old,
+    "beehiiv",
+)
+archive = {
+    "provider": "beehiiv",
+    "connection_id": "conn_beehiiv_fence",
+    "remote_account_id": publication_id,
+    "exported_at": "2026-08-02T10:03:00Z",
+    "enabled_streams": ["posts"],
+    "policy": {"media_hydration": "none"},
+    "accounts": [],
+    "objects": [],
+    "activities": [],
+    "media": [],
+    "coverage": [],
+}
+successful = SuccessfulPage(
+    {"status": 200, "observed_at": archive["exported_at"], "data": [], "meta": {}},
+    '{"stream":"posts"}',
+    archive,
+    PageCheckpoint(None, None),
+    True,
+    2,
+)
+os.environ["AIDEVOPS_SOCIAL_NOW_EPOCH"] = "9001"
+try:
+    persist_page(context, successful)
+except SocialLeaseLostError:
+    pass
+else:
+    raise SystemExit("stale beehiiv collector advanced persistence")
+with sqlite3.connect(root / "index" / "social.db") as database:
+    cursor_count = database.execute(
+        "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_beehiiv_fence'"
+    ).fetchone()[0]
+    batch_count = database.execute(
+        "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_beehiiv_fence'"
+    ).fetchone()[0]
+assert cursor_count == 0 and batch_count == 0
+release_run_lease(root, new)
+PY
+assert_eq "stale beehiiv lease cannot commit evidence or a cursor" verified verified
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/tests/test-knowledge-social-registry.sh
+++ b/.agents/tests/test-knowledge-social-registry.sh
@@ -39,6 +39,7 @@ sys.modules[spec.name] = module
 spec.loader.exec_module(module)
 
 expected = {
+    "beehiiv": ("live",),
     "bluesky": ("live",),
     "binance-square": ("no-route",),
     "discord": ("live",),
@@ -101,14 +102,14 @@ except module.ProviderRegistryError:
 else:
     raise SystemExit("unknown provider used a fallback")
 
-print("19:order-independent:aliases-exact:collisions-rejected:no-fallback")
+print("20:order-independent:aliases-exact:collisions-rejected:no-fallback")
 PY
 )
 assert_eq "all merged provider outcomes register deterministically" \
-	"$registry_summary" "19:order-independent:aliases-exact:collisions-rejected:no-fallback"
+	"$registry_summary" "20:order-independent:aliases-exact:collisions-rejected:no-fallback"
 
 provider_count=$("$HELPER" providers | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
-assert_eq "helper exposes the complete provider registry" "$provider_count" "19"
+assert_eq "helper exposes the complete provider registry" "$provider_count" "20"
 
 forem_resolution=$("$HELPER" provider-resolve --provider dev-community |
 	python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["provider"] + ":" + ",".join(data["modes"]))')


### PR DESCRIPTION
Draft implementation checkpoint. Resolves #29319. Core files: .agents/scripts/_knowledge_social_beehiiv*.py and .agents/scripts/knowledge_social_beehiiv.py. Pattern: the shared identity-bound OAuth collector with a fixed-origin GET-only child. Remaining work: helper and registry wiring, capability documentation, focused fixtures, stale-lease and replay coverage, and full verification.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 26m and 212,063 tokens on this as a headless worker.