### PR TITLE
GH#29330: Diagnose approval quota exhaustion

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -89,6 +89,8 @@ readonly _PERMISSION_BLOCKER_TRUE="true"
 readonly _PERMISSION_APPROVAL_REJECTED_EVENT="permission_approval_rejected"
 readonly _PERMISSION_GRANT_PERSISTENCE_FAILED_EVENT="permission_grant_persistence_failed"
 
+_APPROVAL_GH_RATE_LIMIT_RESET=""
+
 _run_worker_blocker_logger() {
 	local logger="$1"
 	shift
@@ -219,10 +221,44 @@ _print_error() {
 	return 0
 }
 
+_approval_probe_core_rate_limit() {
+	local quota=""
+	local remaining=""
+	local reset=""
+
+	# The endpoint is zero-cost, but it must still respect any active shared
+	# secondary cooldown rather than creating a diagnostic bypass.
+	if command -v _gh_secondary_cooldown_preflight >/dev/null 2>&1; then
+		_gh_secondary_cooldown_preflight read >/dev/null 2>&1 || return 1
+	fi
+
+	if ! quota=$(gh api rate_limit --jq '[.resources.core.remaining,.resources.core.reset] | @tsv' 2>/dev/null); then
+		return 1
+	fi
+	IFS=$'\t' read -r remaining reset <<<"$quota"
+	if [[ ! "$remaining" =~ ^[0-9]+$ || ! "$reset" =~ ^[0-9]+$ ]]; then
+		return 1
+	fi
+
+	printf '%s\t%s' "$remaining" "$reset"
+	return 0
+}
+
+_approval_report_core_rate_limit() {
+	local reset="$1"
+	_print_error "GitHub core API rate limit is exhausted for the invoking user's credential (reset epoch: ${reset})"
+	_print_info "Wait until reset epoch ${reset} before retrying. Re-authentication or forwarding GH_TOKEN will not help before reset."
+	return 0
+}
+
 _approval_use_gh_token() {
 	local token="${1:-}"
 	local previous_token="${GH_TOKEN:-}"
 	local token_was_set="${GH_TOKEN+x}"
+	local quota=""
+	local remaining=""
+	local reset=""
+	_APPROVAL_GH_RATE_LIMIT_RESET=""
 
 	if [[ -z "$token" ]]; then
 		return 1
@@ -231,6 +267,12 @@ _approval_use_gh_token() {
 	export GH_TOKEN="$token"
 	if gh auth status >/dev/null 2>&1; then
 		return 0
+	fi
+	if quota=$(_approval_probe_core_rate_limit); then
+		IFS=$'\t' read -r remaining reset <<<"$quota"
+		if [[ "$remaining" == "0" ]]; then
+			_APPROVAL_GH_RATE_LIMIT_RESET="$reset"
+		fi
 	fi
 
 	if [[ -n "$token_was_set" ]]; then
@@ -296,6 +338,7 @@ _approval_user_gh_token() {
 }
 
 _require_gh_auth() {
+	_APPROVAL_GH_RATE_LIMIT_RESET=""
 	if gh auth status >/dev/null 2>&1; then
 		return 0
 	fi
@@ -307,6 +350,10 @@ _require_gh_auth() {
 		if _approval_use_gh_token "$user_token"; then
 			return 0
 		fi
+		if [[ -n "$_APPROVAL_GH_RATE_LIMIT_RESET" ]]; then
+			_approval_report_core_rate_limit "$_APPROVAL_GH_RATE_LIMIT_RESET"
+			return 1
+		fi
 
 		# Read token directly from gh config file for non-keyring storage.
 		local real_home
@@ -317,6 +364,10 @@ _require_gh_auth() {
 			file_token=$(awk '/oauth_token:/{print $2; exit}' "$gh_hosts" 2>/dev/null || true)
 			if _approval_use_gh_token "$file_token"; then
 				return 0
+			fi
+			if [[ -n "$_APPROVAL_GH_RATE_LIMIT_RESET" ]]; then
+				_approval_report_core_rate_limit "$_APPROVAL_GH_RATE_LIMIT_RESET"
+				return 1
 			fi
 		fi
 	fi

--- a/.agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh
+++ b/.agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh
@@ -227,6 +227,90 @@ run_case "sudo gh auth recovery works through the aidevops gh shim" '
 assert_not_contains "integrated shim recovered token is not printed" "$LAST_OUTPUT" "integrated-shim-token"
 
 # shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "sudo gh auth classifies recovered token core exhaustion" '
+	set -uo pipefail
+	export SUDO_USER=alice
+	export HOME=/var/root
+	probe_log=$(mktemp)
+	trap '\''rm -f "$probe_log"'\'' EXIT
+	id() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "-u" && -z "$arg2" ]]; then printf "0"; return 0; fi
+		if [[ "$arg1" == "-u" && "$arg2" == "alice" ]]; then printf "501"; return 0; fi
+		return 1
+	}
+	getent() { return 1; }
+	dscl() { printf "NFSHomeDirectory: /Users/alice\n"; return 0; }
+	launchctl() { printf "exhausted-user-token"; return 0; }
+	sudo() { return 1; }
+	gh() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "auth" && "$arg2" == "status" ]]; then return 1; fi
+		if [[ "$arg1" == "api" && "$arg2" == "rate_limit" ]]; then
+			printf "%s\n" "$*" >"$probe_log"
+			[[ "${GH_TOKEN:-}" == "exhausted-user-token" ]] || return 1
+			printf "0\t1785697847\n"
+			return 0
+		fi
+		return 1
+	}
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	auth_rc=0
+	_require_gh_auth || auth_rc=$?
+	[[ "$auth_rc" -eq 1 ]] || exit 1
+	[[ "$(<"$probe_log")" == "api rate_limit --jq [.resources.core.remaining,.resources.core.reset] | @tsv" ]]
+' 0
+assert_contains "core exhaustion is diagnosed" "$LAST_OUTPUT" "GitHub core API rate limit is exhausted"
+assert_contains "core exhaustion reports reset epoch" "$LAST_OUTPUT" "1785697847"
+assert_contains "core exhaustion explains credentials cannot repair quota" "$LAST_OUTPUT" "Re-authentication or forwarding GH_TOKEN will not help before reset"
+assert_not_contains "core exhaustion does not report generic auth recovery failure" "$LAST_OUTPUT" "automatic recovery from the invoking user's gh auth failed"
+assert_not_contains "exhausted recovered token is not printed" "$LAST_OUTPUT" "exhausted-user-token"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "sudo gh auth quota probe obeys shared cooldown" '
+	set -uo pipefail
+	export SUDO_USER=alice
+	export HOME=/var/root
+	probe_log=$(mktemp)
+	rm -f "$probe_log"
+	trap '\''rm -f "$probe_log"'\'' EXIT
+	id() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "-u" && -z "$arg2" ]]; then printf "0"; return 0; fi
+		if [[ "$arg1" == "-u" && "$arg2" == "alice" ]]; then printf "501"; return 0; fi
+		return 1
+	}
+	getent() { return 1; }
+	dscl() { printf "NFSHomeDirectory: /Users/alice\n"; return 0; }
+	launchctl() { printf "cooldown-user-token"; return 0; }
+	sudo() { return 1; }
+	gh() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "auth" && "$arg2" == "status" ]]; then return 1; fi
+		if [[ "$arg1" == "api" && "$arg2" == "rate_limit" ]]; then
+			printf "called\n" >"$probe_log"
+			printf "0\t1785697847\n"
+			return 0
+		fi
+		return 1
+	}
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_gh_secondary_cooldown_preflight() { return 75; }
+	auth_rc=0
+	_require_gh_auth || auth_rc=$?
+	[[ "$auth_rc" -eq 1 && ! -e "$probe_log" ]]
+' 0
+assert_contains "cooldown-blocked probe preserves generic auth failure" "$LAST_OUTPUT" "automatic recovery from the invoking user's gh auth failed"
+assert_not_contains "cooldown-blocked probe is not misclassified" "$LAST_OUTPUT" "GitHub core API rate limit is exhausted"
+assert_not_contains "cooldown-blocked recovered token is not printed" "$LAST_OUTPUT" "cooldown-user-token"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
 run_case "sudo gh auth failure reports recovery failure without token leakage" '
 	set -uo pipefail
 	export SUDO_USER=alice
@@ -249,6 +333,7 @@ run_case "sudo gh auth failure reports recovery failure without token leakage" '
 ' 1
 assert_contains "auth failure explains automatic recovery" "$LAST_OUTPUT" "automatic recovery from the invoking user's gh auth failed"
 assert_not_contains "failed token is not printed" "$LAST_OUTPUT" "bad-token"
+assert_not_contains "invalid token is not misclassified as quota exhaustion" "$LAST_OUTPUT" "GitHub core API rate limit is exhausted"
 
 printf '\n===========================================\n'
 printf 'Results: %s passed, %s failed\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary

Classify a recovered GitHub credential with proven core quota exhaustion before the generic sudo authentication failure, while preserving fail-closed recovery and token redaction.

## Files Changed

.agents/scripts/approval-helper.sh, .agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified with macOS Bash 3.2 mocked sudo, Keychain, restricted PATH, invalid-token, exhausted-token, and cooldown paths; 21 focused assertions, 102 adjacent approval assertions, 120 gh-shim assertions, ShellCheck, and changed-file linters pass

Resolves #29330


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 4h 31m and 1,255,129 tokens on this with the user in an interactive session.