### PR TITLE
GH#29292: Isolate Pulse cleanup services from parent cgroup

### DIFF
--- a/.agents/scripts/cleanup-stashes-async-helper.sh
+++ b/.agents/scripts/cleanup-stashes-async-helper.sh
@@ -3,9 +3,9 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 # cleanup-stashes-async-helper.sh — Async background stash cleanup runner (GH#21997).
 #
-# Designed to be invoked via nohup from _preflight_cleanup_and_ledger so slow
-# stash auditing, including any GitHub API calls made by stash-audit-helper.sh,
-# never blocks the pulse's early dispatch path.
+# Designed to be invoked by _preflight_launch_async_cleanup from
+# _preflight_cleanup_and_ledger. Linux systemd hosts use a transient user
+# service outside the parent pulse cgroup; other hosts retain a nohup fallback.
 
 set -euo pipefail
 

--- a/.agents/scripts/cleanup-worktrees-async-helper.sh
+++ b/.agents/scripts/cleanup-worktrees-async-helper.sh
@@ -3,9 +3,9 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 # cleanup-worktrees-async-helper.sh — Async background worktree cleanup runner (GH#20554).
 #
-# Designed to be invoked via nohup from _preflight_cleanup_and_ledger in
-# pulse-dispatch-engine.sh so slow gh API calls during cleanup never block
-# the pulse's main dispatch cycle.
+# Designed to be invoked by _preflight_launch_async_cleanup from
+# _preflight_cleanup_and_ledger. Linux systemd hosts use a transient user
+# service outside the parent pulse cgroup; other hosts retain a nohup fallback.
 #
 # Lifecycle:
 #   1. Acquire a mkdir-based single-runner lock (~/.aidevops/logs/cleanup_worktrees.lock).
@@ -14,10 +14,10 @@
 #   4. Update ~/.aidevops/logs/cleanup_worktrees.last-run on success.
 #   5. Release lock on EXIT/INT/TERM (trap).
 #
-# Usage (from pulse-dispatch-engine.sh):
-#   nohup "${SCRIPT_DIR}/cleanup-worktrees-async-helper.sh" \
-#     >>"${HOME}/.aidevops/logs/cleanup_worktrees.log" 2>&1 &
-#   disown $! 2>/dev/null || true
+# Usage (from pulse-dispatch-preflight-lib.sh):
+#   _preflight_launch_async_cleanup \
+#     "${SCRIPT_DIR}/cleanup-worktrees-async-helper.sh" \
+#     "${HOME}/.aidevops/logs/cleanup_worktrees.log" "worktrees"
 #
 # DO NOT call cleanup_worktrees inline in pulse-dispatch-engine.sh after
 # this helper is deployed — use this wrapper instead.

--- a/.agents/scripts/pulse-dispatch-preflight-lib.sh
+++ b/.agents/scripts/pulse-dispatch-preflight-lib.sh
@@ -29,6 +29,7 @@
 # Include guard
 [[ -n "${_PULSE_DISPATCH_PREFLIGHT_LIB_LOADED:-}" ]] && return 0
 _PULSE_DISPATCH_PREFLIGHT_LIB_LOADED=1
+_PREFLIGHT_CLEANUP_SYSTEMD_UNIT_SEQUENCE=0
 
 # --- Preflight helper functions (extracted) ---
 
@@ -39,6 +40,115 @@ _PULSE_DISPATCH_PREFLIGHT_LIB_LOADED=1
 # stays under 100 lines and each group (merge-first, cleanup/reap, capacity,
 # early dispatch, label maintenance, trusted NMR reconciliation/refill, daily
 # scans, ownership reconcile, and prefetch/scope) can be read independently.
+
+#######################################
+# Return 0 when a Linux systemd user manager can own transient cleanup
+# services outside the parent pulse cgroup (GH#29292).
+#######################################
+_preflight_cleanup_systemd_user_service_available() {
+	[[ "${AIDEVOPS_SKIP_SYSTEMD_CLEANUP_SERVICE:-0}" == "1" ]] && return 1
+	[[ "$(uname -s 2>/dev/null || printf '%s' unknown)" == "Linux" ]] || return 1
+	command -v systemd-run >/dev/null 2>&1 || return 1
+	command -v systemctl >/dev/null 2>&1 || return 1
+	systemctl --user show-environment >/dev/null 2>&1 || return 1
+	return 0
+}
+
+_preflight_cleanup_systemd_unit_name() {
+	local cleanup_name="$1"
+	local sequence="$2"
+	printf 'aidevops-cleanup-%s-%s-%s\n' "$cleanup_name" "$$" "$sequence"
+	return 0
+}
+
+#######################################
+# Submit one cleanup helper to a bounded transient user service. The child is
+# started without shell evaluation and receives only non-secret operational
+# settings needed by the cleanup helpers; credentials are resolved from HOME.
+# Args: $1=helper path, $2=log path, $3=stable cleanup name
+#######################################
+_preflight_launch_systemd_cleanup() {
+	local helper="$1"
+	local log_file="$2"
+	local cleanup_name="$3"
+	local runtime_max="${AIDEVOPS_CLEANUP_SYSTEMD_RUNTIME_MAX_SEC:-3600}"
+	[[ "$runtime_max" =~ ^[1-9][0-9]*$ ]] || runtime_max=3600
+
+	local unit_name=""
+	_PREFLIGHT_CLEANUP_SYSTEMD_UNIT_SEQUENCE=$((_PREFLIGHT_CLEANUP_SYSTEMD_UNIT_SEQUENCE + 1))
+	unit_name=$(_preflight_cleanup_systemd_unit_name \
+		"$cleanup_name" "$_PREFLIGHT_CLEANUP_SYSTEMD_UNIT_SEQUENCE")
+	local env_bin=""
+	env_bin=$(command -v env 2>/dev/null || true)
+	[[ -n "$env_bin" && -n "${HOME:-}" ]] || return 1
+	mkdir -p "$(dirname "$log_file")" 2>/dev/null || return 1
+
+	local -a allowed_env_names=(
+		XDG_CONFIG_HOME XDG_CACHE_HOME XDG_DATA_HOME XDG_STATE_HOME XDG_RUNTIME_DIR
+		AIDEVOPS_LOG_DIR AIDEVOPS_TEMP_DIR AIDEVOPS_WORKTREE_BASE_DIR
+		AIDEVOPS_HEADLESS_METRICS_FILE AIDEVOPS_ORPHAN_TRASH_ROOT
+		AIDEVOPS_SKIP_INFRA_FAILURE_ESCALATION
+		AIDEVOPS_DIRTY_BACKUP_ROOT AIDEVOPS_DIRTY_BACKUP_RETENTION_DAYS
+		AIDEVOPS_DIRTY_BACKUP_MAX_UNTRACKED_FILES AIDEVOPS_DIRTY_BACKUP_MAX_UNTRACKED_BYTES
+		AIDEVOPS_REAL_GIT_BIN AIDEVOPS_SESSION_KEY AIDEVOPS_TASK_ID
+		WORKER_SESSION_KEY WORKER_TASK_NUMBER
+		CLEANUP_WORKTREES_ASYNC_CADENCE_MIN DIRTY_WORKTREE_BACKUP_RETENTION_DAYS
+		CLEANUP_STASHES_ASYNC_CADENCE_MIN CLEANUP_REMOTE_BRANCHES_ASYNC_CADENCE_MIN
+		AIDEVOPS_REMOTE_BRANCH_CLEANUP_MIN_GH_REMAINING
+		AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_RATE_LIMIT
+		AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_GH AIDEVOPS_REMOTE_BRANCH_CLEANUP_APPLY
+		AIDEVOPS_REMOTE_BRANCH_CLEANUP_INCLUDE_CLOSED_PR
+		DISPATCH_COOLDOWN_AFTER_LAUNCH_FAILURE_SECONDS ORPHAN_MAX_AGE
+		ORPHAN_WORKTREE_GRACE_SECS ORPHAN_DETACHED_REVIEW_ARCHIVE_SECS
+		ORPHAN_GENERATED_CLEAN_ARCHIVE_SECS ORPHAN_GENERATED_DIRTY_ARCHIVE_SECS
+		ORPHAN_LOCAL_COMMIT_ARCHIVE_SECS PULSE_IDLE_CPU_THRESHOLD
+	)
+	local -a child_env=("HOME=${HOME}" "PATH=${PATH:-/usr/local/bin:/usr/bin:/bin}")
+	local env_name="" env_value=""
+	for env_name in "${allowed_env_names[@]}"; do
+		env_value="${!env_name:-}"
+		[[ -n "$env_value" ]] && child_env+=("${env_name}=${env_value}")
+	done
+
+	systemd-run --user --unit="$unit_name" --collect --quiet --no-block \
+		--description="aidevops ${cleanup_name} async cleanup" \
+		--property=Type=exec \
+		--property="RuntimeMaxSec=${runtime_max}" \
+		--property=TimeoutStopSec=30 \
+		--property=KillMode=control-group \
+		--property=SendSIGKILL=yes \
+		--property=Nice=10 \
+		--property=IOSchedulingClass=idle \
+		--property="StandardOutput=append:${log_file}" \
+		--property="StandardError=append:${log_file}" \
+		"$env_bin" -i "${child_env[@]}" "$helper" </dev/null >/dev/null 2>>"$log_file"
+	return $?
+}
+
+#######################################
+# Launch cleanup outside the parent pulse cgroup where systemd is available,
+# retaining the existing nohup behaviour on other platforms or submission
+# failure. Helper-level locks and cadence gates remain authoritative.
+# Args: $1=helper path, $2=log path, $3=stable cleanup name
+#######################################
+_preflight_launch_async_cleanup() {
+	local helper="$1"
+	local log_file="$2"
+	local cleanup_name="$3"
+
+	if _preflight_cleanup_systemd_user_service_available; then
+		if _preflight_launch_systemd_cleanup "$helper" "$log_file" "$cleanup_name"; then
+			echo "[pulse-wrapper] ${cleanup_name} cleanup started in an isolated transient user service" >>"${LOGFILE:-/dev/null}"
+			return 0
+		fi
+		echo "[pulse-wrapper] ${cleanup_name} transient cleanup submission failed; using nohup fallback" >>"${LOGFILE:-/dev/null}"
+	fi
+
+	nohup "$helper" </dev/null >>"$log_file" 2>&1 &
+	local helper_pid=$!
+	disown "$helper_pid" 2>/dev/null || true
+	return 0
+}
 
 #######################################
 # Give the existing standalone merge routine a non-blocking head start before
@@ -89,45 +199,41 @@ _preflight_cleanup_and_ledger() {
 		[[ "$_temp_cleanup_timeout" =~ ^[0-9]+$ ]] || _temp_cleanup_timeout=60
 		run_stage_with_timeout "cleanup_stale_temp_worktrees" "$_temp_cleanup_timeout" cleanup_stale_temp_worktrees || true
 	fi
-	# GH#20554: Worktree cleanup is moved to an async background job so a slow
-	# cleanup (20+ worktrees × 2-5s gh API calls each) never hits a hard timeout
-	# and blocks the pulse cycle. The helper enforces a single-runner lock and
-	# a cadence gate (CLEANUP_WORKTREES_ASYNC_CADENCE_MIN, default 10 min) so
-	# concurrent pulse invocations do not spawn duplicate cleanup processes.
+	# GH#20554/GH#29292: Worktree cleanup is moved to an async background job so
+	# a slow cleanup (20+ worktrees × 2-5s gh API calls each) never blocks the
+	# pulse cycle. On systemd it runs in a transient user service so the parent
+	# pulse TimeoutStartSec cannot kill it. The helper retains its single-runner
+	# lock and cadence gate (CLEANUP_WORKTREES_ASYNC_CADENCE_MIN, default 10 min).
 	# Progress and last-run timestamp: ~/.aidevops/logs/cleanup_worktrees.*
 	local _cleanup_async_helper="${SCRIPT_DIR}/cleanup-worktrees-async-helper.sh"
 	if [[ -x "$_cleanup_async_helper" ]]; then
-		nohup "$_cleanup_async_helper" \
-			>>"${HOME}/.aidevops/logs/cleanup_worktrees.log" 2>&1 &
-		disown $! 2>/dev/null || true
+		_preflight_launch_async_cleanup "$_cleanup_async_helper" \
+			"${HOME}/.aidevops/logs/cleanup_worktrees.log" "worktrees"
 	else
 		# Fallback: synchronous with short timeout (old GH#18979 behaviour)
 		run_stage_with_timeout "cleanup_worktrees" 60 cleanup_worktrees || true
 	fi
-	# GH#21997: Stash cleanup is moved to an async background job so slow
-	# stash auditing (including gh API calls inside stash-audit-helper.sh) cannot
-	# stall pulse preflight before early dispatch. The helper enforces a
-	# single-runner lock and cadence gate (CLEANUP_STASHES_ASYNC_CADENCE_MIN,
-	# default 10 min). Progress: ~/.aidevops/logs/cleanup_stashes.*
+	# GH#21997/GH#29292: Stash cleanup uses the same isolated async launcher so
+	# slow auditing cannot stall preflight or share the parent pulse lifetime.
+	# The helper retains its single-runner lock and cadence gate.
+	# Progress: ~/.aidevops/logs/cleanup_stashes.*
 	local _cleanup_stashes_async_helper="${SCRIPT_DIR}/cleanup-stashes-async-helper.sh"
 	if [[ -x "$_cleanup_stashes_async_helper" ]]; then
-		nohup "$_cleanup_stashes_async_helper" \
-			>>"${HOME}/.aidevops/logs/cleanup_stashes.log" 2>&1 &
-		disown $! 2>/dev/null || true
+		_preflight_launch_async_cleanup "$_cleanup_stashes_async_helper" \
+			"${HOME}/.aidevops/logs/cleanup_stashes.log" "stashes"
 	else
 		# Fallback: synchronous with the standard pre-run stage timeout.
 		run_stage_with_timeout "cleanup_stashes" "$PRE_RUN_STAGE_TIMEOUT" cleanup_stashes || true
 	fi
-	# GH#22415: Remote branch cleanup is moved to an async background job so
-	# cross-repo branch audits and optional safe deletes do not block preflight.
-	# The helper is dry-run by default, enforces a single-runner lock/cadence gate,
-	# and skips when GitHub API budget is below the configured floor.
+	# GH#22415/GH#29292: Remote branch cleanup uses the isolated async launcher so
+	# cross-repo audits do not block preflight or share the parent pulse lifetime.
+	# The helper remains dry-run by default, retains its lock/cadence gate, and
+	# skips when GitHub API budget is below the configured floor.
 	# Progress: ~/.aidevops/logs/cleanup_remote_branches.*
 	local _cleanup_remote_branches_async_helper="${SCRIPT_DIR}/cleanup-remote-branches-async-helper.sh"
 	if [[ -x "$_cleanup_remote_branches_async_helper" ]]; then
-		nohup "$_cleanup_remote_branches_async_helper" \
-			>>"${HOME}/.aidevops/logs/cleanup_remote_branches.log" 2>&1 &
-		disown $! 2>/dev/null || true
+		_preflight_launch_async_cleanup "$_cleanup_remote_branches_async_helper" \
+			"${HOME}/.aidevops/logs/cleanup_remote_branches.log" "remote-branches"
 	fi
 
 	# GH#25136: OpenCode DB archive/VACUUM is heavy SQLite maintenance, not

--- a/.agents/scripts/tests/test-systemd-unit-generation.sh
+++ b/.agents/scripts/tests/test-systemd-unit-generation.sh
@@ -19,6 +19,8 @@ REPO_SCRIPTS_DIR="${REPO_ROOT}/.agents/scripts"
 
 # shellcheck source=../setup/modules/schedulers-linux.sh
 source "${REPO_SCRIPTS_DIR}/setup/modules/schedulers-linux.sh"
+# shellcheck source=../pulse-dispatch-preflight-lib.sh
+source "${REPO_SCRIPTS_DIR}/pulse-dispatch-preflight-lib.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -430,6 +432,157 @@ test_no_literal_quotes_in_reposync_unit() {
 	return 0
 }
 
+write_cleanup_launcher_stubs() {
+	local bin_dir="$1"
+	mkdir -p "$bin_dir"
+	cat >"${bin_dir}/uname" <<'STUB'
+#!/usr/bin/env bash
+printf 'Linux\n'
+exit 0
+STUB
+	cat >"${bin_dir}/systemctl" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+	cat >"${bin_dir}/systemd-run" <<'STUB'
+#!/usr/bin/env bash
+{
+	printf 'CALL'
+	for arg in "$@"; do
+		printf '\t%s' "$arg"
+	done
+	printf '\n'
+} >>"$SYSTEMD_RUN_CAPTURE"
+[[ "${SYSTEMD_RUN_FAIL:-0}" == "1" ]] && exit 1
+exit 0
+STUB
+	cat >"${bin_dir}/nohup" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$NOHUP_CAPTURE"
+exit 0
+STUB
+	chmod +x "${bin_dir}/uname" "${bin_dir}/systemctl" \
+		"${bin_dir}/systemd-run" "${bin_dir}/nohup"
+	return 0
+}
+
+write_cleanup_launcher_helpers() {
+	local helper_dir="$1"
+	local helper_name=""
+	mkdir -p "$helper_dir"
+	for helper_name in worktrees stashes remote-branches; do
+		cat >"${helper_dir}/${helper_name}.sh" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+		chmod +x "${helper_dir}/${helper_name}.sh"
+	done
+	return 0
+}
+
+test_cleanup_helpers_use_transient_systemd_units() {
+	local tmpdir=""
+	local capture="" fallback_capture="" parent_log=""
+	local calls=0 unit_count=0 launch_call_count=0 rc=0
+	local merge_first_source="" cleanup_source=""
+	tmpdir=$(mktemp -d)
+	capture="${tmpdir}/systemd-run.log"
+	fallback_capture="${tmpdir}/nohup.log"
+	parent_log="${tmpdir}/pulse.log"
+	write_cleanup_launcher_stubs "${tmpdir}/bin"
+	write_cleanup_launcher_helpers "${tmpdir}/helpers"
+
+	(
+		export HOME="${tmpdir}/home"
+		export PATH="${tmpdir}/bin:${PATH}"
+		export XDG_CONFIG_HOME="${tmpdir}/xdg-config"
+		export CLEANUP_WORKTREES_ASYNC_CADENCE_MIN=23
+		export AIDEVOPS_DIRTY_BACKUP_MAX_UNTRACKED_FILES=1234
+		export AIDEVOPS_REMOTE_BRANCH_CLEANUP_APPLY=1
+		export SYSTEMD_RUN_CAPTURE="$capture"
+		export NOHUP_CAPTURE="$fallback_capture"
+		export UNRELATED_ENV_SENTINEL="must-not-cross-boundary"
+		export GH_TOKEN="must-not-cross-boundary"
+		LOGFILE="$parent_log"
+		_preflight_launch_async_cleanup "${tmpdir}/helpers/worktrees.sh" "${tmpdir}/worktrees.log" "worktrees"
+		_preflight_launch_async_cleanup "${tmpdir}/helpers/stashes.sh" "${tmpdir}/stashes.log" "stashes"
+		_preflight_launch_async_cleanup "${tmpdir}/helpers/remote-branches.sh" "${tmpdir}/remote-branches.log" "remote-branches"
+	)
+
+	calls=$(wc -l <"$capture" | tr -d ' ')
+	unit_count=$(grep -oE -- '--unit=[^[:space:]]+' "$capture" | sort -u | wc -l | tr -d ' ')
+	[[ "$calls" == "3" && "$unit_count" == "3" ]] || rc=1
+	for required in \
+		'--collect' '--no-block' '--property=Type=exec' '--property=RuntimeMaxSec=3600' \
+		'--property=TimeoutStopSec=30' '--property=KillMode=control-group' \
+		'--property=SendSIGKILL=yes' '--property=Nice=10' \
+		'--property=IOSchedulingClass=idle' $'\t-i\t' \
+		"HOME=${tmpdir}/home" "PATH=${tmpdir}/bin:" \
+		"XDG_CONFIG_HOME=${tmpdir}/xdg-config" \
+		'CLEANUP_WORKTREES_ASYNC_CADENCE_MIN=23' \
+		'AIDEVOPS_DIRTY_BACKUP_MAX_UNTRACKED_FILES=1234' \
+		'AIDEVOPS_REMOTE_BRANCH_CLEANUP_APPLY=1'; do
+		grep -qF -- "$required" "$capture" || rc=1
+	done
+	for unit_prefix in worktrees stashes remote-branches; do
+		grep -qE -- "--unit=aidevops-cleanup-${unit_prefix}-[0-9]+-[0-9]+" "$capture" || rc=1
+		grep -qF -- "--property=StandardOutput=append:${tmpdir}/${unit_prefix}.log" "$capture" || rc=1
+		grep -qF -- "--property=StandardError=append:${tmpdir}/${unit_prefix}.log" "$capture" || rc=1
+		grep -qF -- "${tmpdir}/helpers/${unit_prefix}.sh" "$capture" || rc=1
+	done
+	if grep -qE 'UNRELATED_ENV_SENTINEL=|GH_TOKEN=' "$capture"; then
+		rc=1
+	fi
+	[[ ! -s "$fallback_capture" ]] || rc=1
+	merge_first_source=$(declare -f _preflight_start_merge_first)
+	[[ "$merge_first_source" == *"nohup"* ]] || rc=1
+	[[ "$merge_first_source" != *"_preflight_launch_async_cleanup"* ]] || rc=1
+	cleanup_source=$(declare -f _preflight_cleanup_and_ledger)
+	launch_call_count=$(printf '%s\n' "$cleanup_source" | grep -c '_preflight_launch_async_cleanup')
+	[[ "$launch_call_count" == "3" && "$cleanup_source" != *"nohup"* ]] || rc=1
+
+	rm -rf "$tmpdir"
+	print_result "cleanup helpers use isolated transient units with an environment allowlist" "$rc"
+	return 0
+}
+
+test_cleanup_transient_failure_falls_back_once() {
+	local tmpdir=""
+	local capture="" fallback_capture="" parent_log=""
+	local attempts=0 systemd_calls=0 fallback_calls=0 rc=0
+	tmpdir=$(mktemp -d)
+	capture="${tmpdir}/systemd-run.log"
+	fallback_capture="${tmpdir}/nohup.log"
+	parent_log="${tmpdir}/pulse.log"
+	write_cleanup_launcher_stubs "${tmpdir}/bin"
+	write_cleanup_launcher_helpers "${tmpdir}/helpers"
+
+	(
+		export HOME="${tmpdir}/home"
+		export PATH="${tmpdir}/bin:${PATH}"
+		export SYSTEMD_RUN_CAPTURE="$capture"
+		export SYSTEMD_RUN_FAIL=1
+		export NOHUP_CAPTURE="$fallback_capture"
+		export AIDEVOPS_CLEANUP_SYSTEMD_RUNTIME_MAX_SEC="invalid"
+		LOGFILE="$parent_log"
+		_preflight_launch_async_cleanup "${tmpdir}/helpers/worktrees.sh" "${tmpdir}/worktrees.log" "worktrees"
+		while [[ ! -s "$fallback_capture" && "$attempts" -lt 20 ]]; do
+			sleep 0.05
+			attempts=$((attempts + 1))
+		done
+	)
+
+	systemd_calls=$(wc -l <"$capture" | tr -d ' ')
+	fallback_calls=$(wc -l <"$fallback_capture" | tr -d ' ')
+	[[ "$systemd_calls" == "1" && "$fallback_calls" == "1" ]] || rc=1
+	grep -qF -- '--property=RuntimeMaxSec=3600' "$capture" || rc=1
+	grep -qF -- "${tmpdir}/helpers/worktrees.sh" "$fallback_capture" || rc=1
+
+	rm -rf "$tmpdir"
+	print_result "failed transient cleanup submission uses exactly one nohup fallback" "$rc"
+	return 0
+}
+
 # --- Main ---
 
 main() {
@@ -455,6 +608,8 @@ main() {
 	test_no_literal_quotes_in_scheduler_unit
 	test_no_literal_quotes_in_autoupdate_unit
 	test_no_literal_quotes_in_reposync_unit
+	test_cleanup_helpers_use_transient_systemd_units
+	test_cleanup_transient_failure_falls_back_once
 
 	printf '\n%s/%s tests passed.\n' \
 		"$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"


### PR DESCRIPTION
## Summary

Run the three Pulse asynchronous cleanup helpers as bounded transient systemd user services on Linux while preserving non-systemd and failed-submission nohup fallback, existing logs, locks, cadence gates, and the separate merge-first path. Restrict child processes to an explicit non-secret operational environment.

## Files Changed

.agents/scripts/cleanup-stashes-async-helper.sh, .agents/scripts/cleanup-worktrees-async-helper.sh, .agents/scripts/pulse-dispatch-preflight-lib.sh, .agents/scripts/tests/test-systemd-unit-generation.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: test-systemd-unit-generation.sh (7/7), test-cleanup-worktrees-async.sh (11/11), test-pulse-stash-cleanup-nonblocking.sh (PASS), test-cleanup-remote-branches-async.sh (5/5), ShellCheck, bash -n, and linters-local.sh --changed

Resolves #29292


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 4h 38m and 1,363,780 tokens on this with the user in an interactive session.