### PR TITLE
GH#29323: Add bounded Hashnode account collection

### DIFF
--- a/.agents/aidevops/knowledge-plane/05-social-operations.md
+++ b/.agents/aidevops/knowledge-plane/05-social-operations.md
@@ -40,11 +40,11 @@ rows. Replay preserves both evidence and projection IDs.
 
 Candidate implementation is provider-specific, not one generic social adapter.
 Mastodon #29221, GitHub #29222, Stack Exchange #29223, Miniflux #29224,
-Readwise Reader #29225, Lemmy #29227, and public-only Hacker News #29228 are now
-live. FreshRSS #29226 is the remaining ranked child. Each route owns its identity
-contract, stream allowlist, checkpoint semantics, and negative write-reachability
-tests. Raindrop.io remains optional; Inoreader, Wallabag, Feedly, Instapaper, and
-Pocket are deferred or rejected for the reasons in
+Readwise Reader #29225, Lemmy #29227, public-only Hacker News #29228, and
+Hashnode #29323 are now live. FreshRSS #29226 is the remaining ranked child. Each
+route owns its identity contract, stream allowlist, checkpoint semantics, and
+negative write-reachability tests. Raindrop.io remains optional; Inoreader,
+Wallabag, Feedly, Instapaper, and Pocket are deferred or rejected for the reasons in
 `.agents/content/social-provider-candidates.md`.
 
 The maintained planning and gap inventory is
@@ -115,6 +115,17 @@ Missing users/items and deleted/dead tombstones produce explicit unavailable
 coverage; votes, favourites, inbox, notifications, relationships, subscriptions,
 lists, removed content, and private state remain unavailable. Details:
 `.agents/content/social-hacker-news.md`.
+
+Hashnode collection binds the authenticated GraphQL viewer ID and username before
+every page, then revalidates publication and authored-content ownership. Profile,
+owned publications, authored posts, publication drafts, comments and likes
+received on authored posts, followers, and following have independent opaque
+checkpoints. Nine fixed query documents are reachable; arbitrary GraphQL,
+mutations, subscriptions, redirects, partial responses, and unowned resources are
+rejected. Publication and draft visibility remains Pro- and authority-gated;
+authored comments elsewhere, reaction history, messages, notifications, nested
+comment replies, and an unversioned historical export remain explicit gaps.
+Details: `.agents/content/social-hashnode.md`.
 
 Miniflux collection binds `/v1/me` user identity to a keyed exact HTTPS
 installation before every page. Entries, read, removed, starred, tags, feeds,

--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -48,6 +48,7 @@ a claim that the route is enabled.
 | GitHub | **Live/Partial** contribution calendar and repositories | **Live/Partial** stars and subscriptions; **No** complete reactions | **Live/Gate/Partial** notifications | **Live/Gate/Partial** followers, following, and organizations | **Live/Gate/Partial** user lists and visible Projects v2 | Ten numeric/node-identity-bound streams preserve REST `Link` and GraphQL `pageInfo` cursors; token family, visibility, migration expiry, deletion, and audit authority remain explicit. |
 | Stack Exchange | **Live/Partial** posts, questions, answers, and comments | **Live/Partial** favourites; **No** complete votes | **Live/Gate/Partial** inbox and notifications | **Live/Partial** associated site accounts; **No** follows | **No** | Eight network-plus-site-identity-bound GET streams obey `has_more`, `backoff`, quota, and 100-item page limits while preserving archive and inaccessible-history gaps. |
 | Hacker News | **Live/Partial** public submissions and comments | **No** private votes or saved items | **No** | **No** | **No** | One bounded public `submitted` stream uses a mutable case-sensitive username selector and official item IDs; missing/deleted/dead and all private state remain explicit unavailable coverage. |
+| Hashnode | **Live** posts; **Live/Gate** owned publications and drafts | **Live/Partial** comments and likes received; **No** authored-comment or reaction history | **No** messages or notifications | **Live/Partial** followers and following | **No** | Eight viewer-bound streams use nine fixed GraphQL read documents, repeated author/publication ownership checks, opaque nested cursors, and **Export/Gate** account-archive coverage pending a current identity-bearing schema. |
 | Miniflux | **Live/Partial** feed entries | **Live/Partial** read, removed, starred, and tagged state | **No** | **Live/Partial/Export** subscriptions | **Live/Partial/Export** categories and tags | Eight keyed-installation account streams use five exact GET routes, ascending entry-ID backfill, one-second `changed_after` overlap, bounded snapshots, and explicit operator-retention gaps. |
 | Readwise Reader | **Live/Gate/Partial** saved documents and optional HTML | **Live/Gate/Partial** notes, state, progress, and tags | **No** | **No** | **Live/Gate/Partial** tags and locations | Seven deployment-bound streams preserve opaque cursors, overlap `updatedAfter`, cap invocations below 20 requests/minute, and expose the provider identity/export boundary. |
 
@@ -84,6 +85,7 @@ separate provider family.
 | Stack Exchange | **Live/Partial** authored content | **Live/Partial** favourites; **No** complete vote history | **Live/Gate/Partial** inbox and notifications | **Live/Partial** associated site accounts; **No** follows | **No** | #29223 implements network plus per-site identity, mandatory `backoff` and quota stops, bounded paging, and explicit archive/completeness gaps. |
 | GitHub | **Live/Partial** contributions | **Live/Partial** stars and subscriptions; **No** complete reactions | **Live/Gate/Partial** notifications; **No** discussions | **Live/Gate/Partial** follows, organizations, and repositories | **Live/Gate/Partial** user lists and Projects v2 | #29222 implements numeric/node identity, token-family gates, opaque mixed-API cursors, and no complete reaction or social export claim. |
 | Hacker News | **Live/Partial** public submissions and comments | **No** private votes or saved items | **No** | **No** | **No** | #29228 implements bounded official Firebase user/item GETs, content-addressed submitted-ID resume, and explicit mutable-public-selector and tombstone coverage. |
+| Hashnode | **Live** posts; **Live/Gate** publications and drafts | **Live/Partial** received comments and likes; **No** account-centric authored history | **No** | **Live/Partial** followers and following | **No** | #29323 implements authenticated viewer rebinding, owned-resource checks, fixed GraphQL reads, nested opaque resume, and an explicit **Export/Gate** archive boundary. |
 | Miniflux | **Live/Partial** feed items | **Live/Partial** read, removed, starred, and tagged state | **No** | **Live/Partial/Export** subscriptions | **Live/Partial/Export** categories/tags | #29224 implements keyed installation/user identity, exact GET-only routes, incremental overlap, snapshots, and explicit operator-retention gaps. |
 | FreshRSS | **API/Export** feed items | **API** unread and starred state | **No** | **API/Export** subscriptions | **API/Export** folders/tags | Rank 6, #29226. Allow one non-mutating login POST, then GET-only Google Reader collection; reconcile OPML and keep Fever fallback-only. |
 | Readwise Reader | **Live/Gate/Partial** saved documents | **Live/Gate/Partial** tags, state, notes, and progress | **No** | **No** | **Live/Gate/Partial** tags and locations | #29225 implements a deployment-owned account/token binding because official token validation exposes no stable account ID, plus fixed-origin GET-only cursor reads. |
@@ -208,6 +210,17 @@ separate provider family.
   `.agents/content/social-hacker-news.md` records official Firebase v0 user/item
   schemas, public-activity visibility, versioning, current no-rate-limit statement,
   repository license, and absent private/authenticated categories checked on
+  2026-08-02.
+- **Live/Gated Hashnode:** `.agents/scripts/knowledge_social_hashnode.py`,
+  `.agents/scripts/_knowledge_social_hashnode*.py`, and
+  `.agents/tests/test-knowledge-social-hashnode.sh` prove authenticated viewer
+  rebinding, author and publication ownership, eight independent streams, opaque
+  simple and nested GraphQL cursor resume, fixed query and variable allowlists,
+  mutation and redirect isolation, partial-error and malformed-node rejection,
+  credential rejection, terminal coverage, request accounting, deterministic
+  replay, and atomic lease-fenced persistence. `.agents/content/social-hashnode.md`
+  records current official schema, auth, pagination, limits, publication/Pro
+  gates, privacy, export, retention, terms, and unsupported evidence checked on
   2026-08-02.
 - **Live Miniflux:** `.agents/scripts/knowledge_social_miniflux.py`,
   `.agents/scripts/_knowledge_social_miniflux*.py`, and

--- a/.agents/content/social-hashnode.md
+++ b/.agents/content/social-hashnode.md
@@ -1,0 +1,86 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Hashnode Account Knowledge Collection
+
+`knowledge_social_hashnode.py` collects bounded, read-only evidence for one
+authenticated Hashnode author. It uses the official GraphQL endpoint with nine
+fixed read-query documents; callers cannot supply GraphQL text, operation names,
+fields, or mutation-capable routes.
+
+## Identity and authority contract
+
+Configure one personal access token through secure environment injection:
+
+```text
+HASHNODE_<PROFILE>_PAT
+```
+
+Use `--account-id` with the stable ID returned by the authenticated `me` query.
+Before collection and every page, the child re-reads `me` and requires both that
+ID and the selected username to match. Publication, post, draft, comment target,
+and reaction target reads additionally verify that their author or publication
+owner is the selected account. Team publications or provider-side permission
+changes therefore fail closed rather than widening collection.
+
+## Implemented streams
+
+| Stream | Fixed read surface | Disposition |
+|---|---|---|
+| `profile` | authenticated `me` | **Live** |
+| `publications` | authenticated viewer's owned publications | **Live/Gate**: publication access remains provider-plan-bound |
+| `posts` | selected user's authored posts | **Live** |
+| `drafts` | drafts inside each verified owned publication | **Live/Gate**: requires provider-side publication and Pro access |
+| `comments` | comments received on verified authored posts | **Live/Partial**: nested reply pages and comments authored elsewhere are not available |
+| `reactions` | accounts in `likedBy` on verified authored posts | **Live/Partial**: this is received likes, not the viewer's reaction history |
+| `followers` | authenticated viewer followers | **Live/Partial**: current visible snapshot only |
+| `following` | authenticated viewer follows | **Live/Partial**: current visible snapshot only |
+
+Messages, notifications, account-centric authored-comment history, and
+account-centric reaction history have no verified official query and remain
+**No**. The privacy policy provides an account-data access route, but the public
+JSON export guide is historical and publishes neither a current versioned schema
+nor a stable identity contract. Archive ingestion therefore remains
+**Export/Gate** until a current private fixture proves those boundaries.
+
+## Pagination, cost, and persistence
+
+Every stream owns an independent versioned checkpoint. Simple GraphQL
+connections preserve their opaque `endCursor`. Drafts, comments, and reactions
+use versioned nested state so the outer publication or post cursor cannot be
+confused with the inner connection cursor. A repeated cursor, malformed edge,
+partial GraphQL response, or ownership mismatch stops before page persistence.
+
+The initial identity query costs one local unit. Every page reserves two units:
+one repeated identity query and one fixed stream query. `--budget` is 3-1000 and
+`--page-size` is 1-50, below the documented ordinary 100-item and draft 50-item
+connection limits. The official guidance also documents a maximum query depth of
+10, a 100 KB request body, and an advisory request ceiling; the collector's fixed
+documents and local budget are stricter independent fuses.
+
+Successful pages atomically commit immutable raw evidence, normalized rows,
+coverage, a receipt, and the next checkpoint. Terminal responses append bounded
+diagnostic evidence without advancing or replacing the prior checkpoint.
+Credential-shaped values, stale leases, partial GraphQL errors, malformed nodes,
+redirects, arbitrary queries, subscriptions, and mutations are rejected.
+
+## Completeness and retention boundaries
+
+Snapshot completion means only that the current API-visible connection was
+exhausted; it never infers deletion. Visibility can depend on account state,
+publication ownership, team authority, and Hashnode Pro access. Hashnode does not
+publish a complete social-activity ledger or a fixed retention guarantee for all
+account categories, so historical completeness and deleted resources remain
+explicit gaps.
+
+## Official evidence checked 2026-08-02
+
+- <https://github.com/Hashnode/gql-skill>
+- <https://github.com/Hashnode/gql-skill/blob/ebd06df0fe29d00d2e7f6e3673fefdbe8ef57b3d/skills/gql-api/SKILL.md>
+- <https://github.com/Hashnode/gql-skill/blob/ebd06df0fe29d00d2e7f6e3673fefdbe8ef57b3d/skills/gql-api/references/schema.graphql>
+- <https://github.com/Hashnode/gql-skill/blob/ebd06df0fe29d00d2e7f6e3673fefdbe8ef57b3d/skills/gql-api/references/queries.md>
+- <https://github.com/Hashnode/gql-skill/blob/ebd06df0fe29d00d2e7f6e3673fefdbe8ef57b3d/skills/gql-api/references/auth-and-roles.md>
+- <https://github.com/Hashnode/gql-skill/blob/ebd06df0fe29d00d2e7f6e3673fefdbe8ef57b3d/skills/gql-api/references/errors-and-limits.md>
+- <https://github.com/Hashnode/support/blob/ef1109bb3e0b05549d235871db7d040aa2e08142/docs/export-articles.md>
+- <https://hashnode.com/privacy>
+- <https://hashnode.com/terms>

--- a/.agents/scripts/_knowledge_social_fixture.py
+++ b/.agents/scripts/_knowledge_social_fixture.py
@@ -7,7 +7,11 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
+
+
+class FixturePageRequest(Protocol):
+    def payload(self) -> dict[str, Any]: ...
 
 
 class FixtureSequence:
@@ -46,3 +50,38 @@ class FixtureSequence:
         page = pages[self.position]
         self.position += 1
         return page
+
+
+class FixturePageReader:
+    """Match provider page requests against one deterministic fixture sequence."""
+
+    def __init__(self, path: Path, provider: str, error_type: type[Exception]) -> None:
+        self.provider = provider
+        self.error_type = error_type
+        self.fixture = FixtureSequence(path, provider, error_type)
+
+    def _object(self, value: Any, message: str) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            raise self.error_type(f"{self.provider} {message}")
+        return value
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        del expected_id
+        return self.fixture.identity()
+
+    def page(self, request: FixturePageRequest) -> dict[str, Any]:
+        entry = self.fixture.next_page()
+        expectation = self._object(
+            entry.get("expect_request", {}),
+            "fixture request expectation must be an object",
+        )
+        actual = request.payload()
+        for key, value in expectation.items():
+            if actual.get(key) != value:
+                raise self.error_type(
+                    f"{self.provider} request did not resume at the expected checkpoint"
+                )
+        return self._object(
+            entry.get("response", entry),
+            "fixture page response must be an object",
+        )

--- a/.agents/scripts/_knowledge_social_hashnode.py
+++ b/.agents/scripts/_knowledge_social_hashnode.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Hashnode stream policy and opaque GraphQL connection checkpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from _knowledge_social_hashnode_identity import (
+    HashnodeAdapterError,
+    HashnodeProviderUnavailableError,
+    instance_id,
+    provider_account_id,
+    username,
+)
+from _knowledge_social_oauth_request import OAuthPageRequest, OAuthRequestCodec
+from knowledge_social_import import reject_credentials
+
+PROVIDER = "hashnode"
+CURSOR_PREFIX = "hashnode-page-v1:"
+RETENTION_LIMIT = "account_active_or_provider_visibility_and_pro_plan_bound"
+MAX_PAGE_ITEMS = 50
+
+ADAPTER_ERROR = HashnodeAdapterError
+PROVIDER_UNAVAILABLE_ERROR = HashnodeProviderUnavailableError
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    resource_kind: str
+    activity_mode: str
+    transport: str = "graphql"
+    pagination: str = "snapshot"
+    incremental: bool = False
+    retention_limit: str | None = RETENTION_LIMIT
+    coverage_status: str | None = "partial"
+    unavailable_reason: str | None = "current_api_visibility_and_plan_bound"
+    cost_units: int = 2
+
+
+STREAMS = {
+    "profile": StreamSpec("profile", "selected_account"),
+    "publications": StreamSpec("publication", "publication_owner"),
+    "posts": StreamSpec("post", "content_author"),
+    "drafts": StreamSpec("draft", "content_author"),
+    "comments": StreamSpec("comment", "comment_received"),
+    "reactions": StreamSpec("reaction", "reaction_received"),
+    "followers": StreamSpec("account", "follower"),
+    "following": StreamSpec("account", "following"),
+}
+
+
+class PageRequest(OAuthPageRequest):
+    HANDLE_KEY = "username"
+
+    @property
+    def username(self) -> str:
+        return self.handle
+
+
+REQUEST_CODEC = OAuthRequestCodec(
+    display_name="Hashnode",
+    cursor_prefix=CURSOR_PREFIX,
+    cursor_key="state",
+    handle_key=PageRequest.HANDLE_KEY,
+    max_page_size=MAX_PAGE_ITEMS,
+    max_text_bytes=64 * 1024,
+    streams=frozenset(STREAMS),
+    request_type=PageRequest,
+    error_type=HashnodeAdapterError,
+    account_validator=provider_account_id,
+    handle_validator=username,
+    instance_validator=instance_id,
+)
+PAGE_REQUEST_KEYS = REQUEST_CODEC.request_keys
+
+
+def page_request(
+    stream: str, account: dict[str, Any], state: CursorState, limit: int
+) -> PageRequest:
+    request = REQUEST_CODEC.collection_request(stream, account, state.cursor, limit)
+    if not isinstance(request, PageRequest):
+        raise HashnodeAdapterError("Hashnode request codec returned an invalid type")
+    return request
+
+
+def parse_page_request(payload: dict[str, Any]) -> PageRequest:
+    request = REQUEST_CODEC.provider_request(payload)
+    if not isinstance(request, PageRequest):
+        raise HashnodeAdapterError("Hashnode request codec returned an invalid type")
+    return request
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise HashnodeAdapterError("Hashnode response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise HashnodeAdapterError("Hashnode page data must be an array")
+    return data
+
+
+def page_checkpoint(
+    payload: dict[str, Any], state: CursorState, request: PageRequest
+) -> tuple[PageCheckpoint, bool]:
+    meta = payload.get("meta")
+    if not isinstance(meta, dict):
+        raise HashnodeAdapterError("Hashnode page metadata must be an object")
+    reject_credentials(meta)
+    if (
+        meta.get("stream") != request.stream
+        or instance_id(meta.get("instance_id")) != request.instance_id
+        or meta.get("transport") != "graphql"
+        or meta.get("snapshot") is not True
+    ):
+        raise HashnodeAdapterError("Hashnode page provenance is invalid")
+    if len(page_data(payload)) > MAX_PAGE_ITEMS:
+        raise HashnodeAdapterError("Hashnode page exceeds the item safety limit")
+    next_state = REQUEST_CODEC.text(
+        meta.get("next_cursor"), "next cursor", optional=True
+    )
+    complete = meta.get("complete")
+    if not isinstance(complete, bool) or complete == (next_state is not None):
+        raise HashnodeAdapterError("Hashnode page completion cursor is invalid")
+    cursor = (
+        REQUEST_CODEC.encode_cursor(request.position + 1, next_state)
+        if next_state
+        else None
+    )
+    return PageCheckpoint(cursor, state.watermark), complete

--- a/.agents/scripts/_knowledge_social_hashnode_contract.py
+++ b/.agents/scripts/_knowledge_social_hashnode_contract.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validation primitives for the bounded Hashnode GraphQL child."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import urlsplit
+
+from _knowledge_social_hashnode_identity import (
+    INSTANCE_ID,
+    account_id,
+    provider_account_id,
+    username,
+)
+
+MAX_TEXT_BYTES = 512 * 1024
+
+
+class HashnodeReadProviderError(RuntimeError):
+    """Raised for a privacy-safe local Hashnode provider failure."""
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    status: int
+    payload: Any
+    retry_after: int | None = None
+
+
+def observed_at() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def decode_json(payload: bytes, limit: int) -> Any:
+    if len(payload) > limit:
+        raise HashnodeReadProviderError("Hashnode JSON payload exceeds the safety limit")
+    try:
+        return json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise HashnodeReadProviderError("Hashnode JSON payload is invalid") from error
+
+
+def request_object(payload: bytes, limit: int) -> dict[str, Any]:
+    request = decode_json(payload, limit)
+    if not isinstance(request, dict):
+        raise HashnodeReadProviderError("Hashnode read request root must be an object")
+    return request
+
+
+def object_value(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise HashnodeReadProviderError(f"Hashnode {field} must be an object")
+    return value
+
+
+def object_list(value: Any, field: str, *, limit: int) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise HashnodeReadProviderError(
+            f"Hashnode {field} must be an array of objects"
+        )
+    if len(value) > limit:
+        raise HashnodeReadProviderError(
+            f"Hashnode {field} exceeds the item safety limit"
+        )
+    return value
+
+
+def optional_text(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value:
+        raise HashnodeReadProviderError(f"Hashnode {field} must be text")
+    if len(value.encode()) > MAX_TEXT_BYTES:
+        raise HashnodeReadProviderError(f"Hashnode {field} exceeds the safety limit")
+    return value
+
+
+def required_text(value: Any, field: str) -> str:
+    text = optional_text(value, field)
+    if not text:
+        raise HashnodeReadProviderError(f"Hashnode {field} is required")
+    return text
+
+
+def public_url(value: Any, field: str) -> str | None:
+    text = optional_text(value, field)
+    if text is None:
+        return None
+    try:
+        parsed = urlsplit(text)
+        port = parsed.port
+    except ValueError as error:
+        raise HashnodeReadProviderError(f"Hashnode {field} is invalid") from error
+    if parsed.scheme != "https" or not parsed.hostname:
+        raise HashnodeReadProviderError(f"Hashnode {field} is not a safe public URL")
+    if port not in (None, 443):
+        raise HashnodeReadProviderError(f"Hashnode {field} is not a safe public URL")
+    if parsed.username is not None or parsed.password is not None:
+        raise HashnodeReadProviderError(f"Hashnode {field} is not a safe public URL")
+    if parsed.query or parsed.fragment:
+        raise HashnodeReadProviderError(f"Hashnode {field} is not a safe public URL")
+    return text
+
+
+def nonnegative_int(value: Any, field: str, *, optional: bool = False) -> int | None:
+    if value is None and optional:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise HashnodeReadProviderError(f"Hashnode {field} must be non-negative")
+    return value
+
+
+def terminal_payload(result: ApiResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": result.status, "observed_at": observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload
+
+
+def identity_record(payload: Any, expected_id: str) -> dict[str, Any]:
+    root = object_value(payload, "GraphQL identity response")
+    data = object_value(root.get("data"), "GraphQL identity data")
+    viewer = object_value(data.get("me"), "GraphQL viewer")
+    remote = provider_account_id(viewer.get("id"))
+    if remote != provider_account_id(expected_id):
+        raise HashnodeReadProviderError(
+            "selected Hashnode account does not match the configured connection"
+        )
+    handle = username(viewer.get("username"))
+    bio = viewer.get("bio")
+    bio_text = None
+    if bio is not None:
+        bio_text = optional_text(object_value(bio, "viewer bio").get("text"), "viewer bio")
+    return {
+        "id": account_id(remote),
+        "provider_account_id": remote,
+        "username": handle,
+        "name": optional_text(viewer.get("name"), "viewer name"),
+        "bio": bio_text,
+        "tagline": optional_text(viewer.get("tagline"), "viewer tagline"),
+        "location": optional_text(viewer.get("location"), "viewer location"),
+        "date_joined": optional_text(viewer.get("dateJoined"), "viewer join date"),
+        "instance_id": INSTANCE_ID,
+    }

--- a/.agents/scripts/_knowledge_social_hashnode_http.py
+++ b/.agents/scripts/_knowledge_social_hashnode_http.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Redirect-free Hashnode transport for exact allowlisted read queries."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from _knowledge_social_hashnode_contract import (
+    ApiResult,
+    HashnodeReadProviderError,
+    decode_json,
+)
+from _knowledge_social_hashnode_routes import ALLOWED_QUERIES, QUERY_VARIABLES
+from knowledge_social_import import reject_credentials
+
+GRAPHQL_URL = "https://gql-beta.hashnode.com/"
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+MAX_REQUEST_BYTES = 100 * 1024
+HTTP_TIMEOUT_SECONDS = 60
+OPERATION = re.compile(r"^query\s+AidevopsHashnode[A-Za-z0-9_]*\b")
+
+
+class Headers(Protocol):
+    def get(self, key: str, default: str | None = None) -> str | None: ...
+
+
+class Response(Protocol):
+    status: int
+    headers: Headers
+
+    def __enter__(self) -> Response: ...
+    def __exit__(self, *args: Any) -> None: ...
+    def read(self, size: int = -1) -> bytes: ...
+
+
+class Opener(Protocol):
+    def open(self, request: Request, timeout: int) -> Response: ...
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    personal_access_token: str
+
+
+class _RejectRedirect(HTTPRedirectHandler):
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def _http_exports() -> Opener:
+    exports = (Request, build_opener, HTTPRedirectHandler)
+    if not all(callable(item) for item in exports):
+        raise HashnodeReadProviderError("Python urllib HTTP exports are unavailable")
+    return build_opener(_RejectRedirect())
+
+
+def _retry_epoch(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    return int(time.time() + math.ceil(seconds))
+
+
+def _headers(config: ProfileConfig) -> dict[str, str]:
+    return {
+        "Accept": "application/json",
+        "Authorization": f"Bearer {config.personal_access_token}",
+        "Content-Type": "application/json",
+        "User-Agent": "aidevops-hashnode-knowledge/1",
+    }
+
+
+def _validate_variables(query: str, variables: dict[str, Any]) -> None:
+    if set(variables) != QUERY_VARIABLES[query]:
+        raise HashnodeReadProviderError("Hashnode GraphQL variables are not allowlisted")
+    reject_credentials(variables)
+    for key, value in variables.items():
+        if key == "first":
+            if isinstance(value, bool) or not isinstance(value, int) or not 1 <= value <= 50:
+                raise HashnodeReadProviderError("Hashnode GraphQL page size is invalid")
+        elif value is not None:
+            if not isinstance(value, str) or not value or "\x00" in value:
+                raise HashnodeReadProviderError("Hashnode GraphQL variable is invalid")
+            if len(value.encode()) > 64 * 1024:
+                raise HashnodeReadProviderError("Hashnode GraphQL variable is invalid")
+
+
+def _request_body(query: str, variables: dict[str, Any]) -> bytes:
+    if query not in ALLOWED_QUERIES:
+        raise HashnodeReadProviderError("Hashnode GraphQL query is not allowlisted")
+    normalized = " ".join(query.split())
+    if (
+        OPERATION.match(normalized) is None
+        or re.search(r"\b(?:mutation|subscription)\b", normalized, re.IGNORECASE)
+    ):
+        raise HashnodeReadProviderError("Hashnode GraphQL operation is not a read query")
+    _validate_variables(query, variables)
+    body = json.dumps(
+        {"query": query, "variables": variables}, sort_keys=True, separators=(",", ":")
+    ).encode()
+    if len(body) > MAX_REQUEST_BYTES:
+        raise HashnodeReadProviderError("Hashnode GraphQL request exceeds the safety limit")
+    return body
+
+
+def _decode_response(payload: bytes) -> dict[str, Any]:
+    decoded = decode_json(payload, MAX_RESPONSE_BYTES)
+    if not isinstance(decoded, dict):
+        raise HashnodeReadProviderError("Hashnode API response root must be an object")
+    reject_credentials(decoded)
+    return decoded
+
+
+def _execute(opener: Opener, request: Request) -> tuple[int, dict[str, Any], Headers]:
+    try:
+        with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", 200)
+            if isinstance(status, bool) or not isinstance(status, int):
+                raise HashnodeReadProviderError("Hashnode HTTP status is invalid")
+            payload = response.read(MAX_RESPONSE_BYTES + 1)
+            if not isinstance(payload, bytes):
+                raise HashnodeReadProviderError("Hashnode HTTP response is invalid")
+            return status, _decode_response(payload), response.headers
+    except HTTPError as error:
+        headers = error.headers if error.headers is not None else _ErrorHeaders()
+        return error.code, {}, headers
+    except (TimeoutError, URLError, OSError) as error:
+        raise HashnodeReadProviderError("Hashnode read provider request failed") from error
+
+
+class _ErrorHeaders:
+    def get(self, key: str, default: str | None = None) -> str | None:
+        del key
+        return default
+
+
+def _graphql_error_status(payload: dict[str, Any]) -> int | None:
+    errors = payload.get("errors")
+    if errors is None or errors == []:
+        return None
+    if not isinstance(errors, list) or any(not isinstance(item, dict) for item in errors):
+        return 500
+    statuses = []
+    mapping = {
+        "UNAUTHENTICATED": 401,
+        "FORBIDDEN": 403,
+        "NOT_FOUND": 404,
+        "BAD_USER_INPUT": 400,
+        "INTERNAL_SERVER_ERROR": 500,
+    }
+    for item in errors:
+        extensions = item.get("extensions")
+        if not isinstance(extensions, dict):
+            statuses.append(500)
+            continue
+        code = extensions.get("code")
+        statuses.append(mapping.get(code, 500) if isinstance(code, str) else 500)
+    for status in (401, 403, 429, 500, 404, 400):
+        if status in statuses:
+            return status
+    return 500
+
+
+def graphql_api(
+    config: ProfileConfig,
+    opener: Opener,
+    query: str,
+    variables: dict[str, Any],
+) -> ApiResult:
+    """Execute one exact read query; mutations and redirects are unreachable."""
+    request = Request(
+        GRAPHQL_URL,
+        data=_request_body(query, variables),
+        headers=_headers(config),
+        method="POST",
+    )
+    status, payload, headers = _execute(opener, request)
+    retry_after = _retry_epoch(headers.get("Retry-After"))
+    if status != 200:
+        return ApiResult(status, {}, retry_after)
+    graph_status = _graphql_error_status(payload)
+    if graph_status is not None:
+        return ApiResult(graph_status, {}, retry_after)
+    return ApiResult(200, payload, retry_after)

--- a/.agents/scripts/_knowledge_social_hashnode_identity.py
+++ b/.agents/scripts/_knowledge_social_hashnode_identity.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Durable Hashnode account and resource identity validation."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any
+
+from knowledge_social_store import SocialStoreError
+
+INSTANCE_ID = "hashnode-gql-beta"
+OPAQUE_ID = re.compile(r"^[A-Za-z0-9_-]{8,256}$")
+USERNAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
+RESOURCE_KIND = re.compile(r"^[a-z][a-z_]{0,31}$")
+
+
+class HashnodeAdapterError(SocialStoreError):
+    """Raised when guarded Hashnode collection cannot continue safely."""
+
+
+class HashnodeProviderUnavailableError(HashnodeAdapterError):
+    """Raised when the bounded Hashnode HTTP child cannot complete a read."""
+
+
+def instance_id(value: Any) -> str:
+    if value != INSTANCE_ID:
+        raise HashnodeAdapterError("Hashnode API identity is invalid")
+    return INSTANCE_ID
+
+
+def provider_account_id(value: Any) -> str:
+    if isinstance(value, str) and value.startswith("account_"):
+        value = value.removeprefix("account_")
+    if not isinstance(value, str) or OPAQUE_ID.fullmatch(value) is None:
+        raise HashnodeAdapterError("Hashnode account ID is invalid")
+    return value
+
+
+def username(value: Any) -> str:
+    if not isinstance(value, str) or USERNAME.fullmatch(value) is None:
+        raise HashnodeAdapterError("Hashnode username is invalid")
+    return value
+
+
+def opaque_id(value: Any, field: str) -> str:
+    if not isinstance(value, str) or OPAQUE_ID.fullmatch(value) is None:
+        raise HashnodeAdapterError(f"Hashnode {field} is invalid")
+    return value
+
+
+def namespaced_id(kind: str, value: Any) -> str:
+    if RESOURCE_KIND.fullmatch(kind) is None:
+        raise HashnodeAdapterError("Hashnode resource kind is invalid")
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise HashnodeAdapterError("Hashnode resource identity is invalid")
+    if len(value.encode()) > 1024:
+        raise HashnodeAdapterError("Hashnode resource identity is invalid")
+    digest = hashlib.sha256(value.encode()).hexdigest()[:32]
+    return f"hn_{kind}_{digest}"
+
+
+def account_id(value: Any) -> str:
+    remote = provider_account_id(value)
+    return f"hnu_{hashlib.sha256(remote.encode()).hexdigest()[:32]}"

--- a/.agents/scripts/_knowledge_social_hashnode_normalize.py
+++ b/.agents/scripts/_knowledge_social_hashnode_normalize.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize allowlisted Hashnode records into provider-neutral evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_hashnode import (
+    PROVIDER,
+    RETENTION_LIMIT,
+    HashnodeAdapterError,
+    page_data,
+)
+from _knowledge_social_hashnode_identity import INSTANCE_ID, account_id, namespaced_id
+from knowledge_social_import import reject_credentials
+
+PROVENANCE = "hashnode_official_gql_beta_fixed_queries"
+GAPS = (
+    ("authored_comments_elsewhere", "no_account_centric_comment_history_query", "unavailable"),
+    ("reaction_history", "no_account_centric_reaction_history_query", "unavailable"),
+    ("comment_replies", "nested_reply_pages_are_not_collected", "partial"),
+    ("messages", "no_official_account_message_query", "unavailable"),
+    ("notifications", "no_official_account_notification_query", "unavailable"),
+    ("account_export", "published_json_schema_and_identity_contract_unavailable", "unavailable"),
+)
+OBJECT_TYPES = {
+    "profile": "profile",
+    "publication": "publication",
+    "post": "post",
+    "draft": "draft",
+    "comment": "comment",
+    "reaction": "reaction",
+    "account": "account",
+}
+ACTIVITY_TYPES = {
+    "profile": "profile_observed",
+    "publication": "publication_owner",
+    "post": "content_author",
+    "draft": "draft_author",
+    "comment": "comment_received",
+    "reaction": "like_received",
+    "account": "relationship",
+}
+
+
+@dataclass(frozen=True)
+class PageContext:
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def _required_text(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise HashnodeAdapterError(f"Hashnode record requires {key}")
+    return value
+
+
+def _optional_text(record: dict[str, Any], key: str) -> str | None:
+    value = record.get(key)
+    if value is not None and (not isinstance(value, str) or "\x00" in value):
+        raise HashnodeAdapterError(f"Hashnode record {key} must be text")
+    return value
+
+
+def _observed_at(payload: dict[str, Any]) -> str:
+    value = payload.get("observed_at")
+    if not isinstance(value, str) or not value:
+        raise HashnodeAdapterError("Hashnode page observed_at must be text")
+    return value
+
+
+def _selected_account(context: PageContext, observed_at: str) -> dict[str, Any]:
+    return {
+        "remote_id": _required_text(context.account, "id"),
+        "handle": _required_text(context.account, "username"),
+        "display_name": _optional_text(context.account, "name"),
+        "observed_at": observed_at,
+        "provider_json": {
+            "source": PROVENANCE,
+            "provider_account_id": context.account.get("provider_account_id"),
+            "bio": context.account.get("bio"),
+            "tagline": context.account.get("tagline"),
+            "location": context.account.get("location"),
+            "date_joined": context.account.get("date_joined"),
+        },
+    }
+
+
+def _record_account(value: Any, observed_at: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise HashnodeAdapterError("Hashnode record account must be an object")
+    remote = _required_text(value, "provider_account_id")
+    return {
+        "remote_id": account_id(remote),
+        "handle": _required_text(value, "username"),
+        "display_name": _optional_text(value, "name"),
+        "observed_at": observed_at,
+        "provider_json": {"source": PROVENANCE, "provider_account_id": remote},
+    }
+
+
+def _accounts(
+    items: list[dict[str, Any]], context: PageContext, observed_at: str
+) -> list[dict[str, Any]]:
+    accounts = {_required_text(context.account, "id"): _selected_account(context, observed_at)}
+    for item in items:
+        values = []
+        for key in ("author", "actor"):
+            if item.get(key) is not None:
+                values.append(item[key])
+        if item.get("kind") == "account":
+            values.append(item)
+        for value in values:
+            account = _record_account(value, observed_at)
+            accounts[account["remote_id"]] = account
+    return list(accounts.values())
+
+
+def _record_text(item: dict[str, Any]) -> str | None:
+    values = []
+    for key in ("title", "subtitle", "name", "tagline", "about", "bio", "text", "markdown"):
+        value = _optional_text(item, key)
+        if value and value not in values:
+            values.append(value)
+    return "\n\n".join(values) or None
+
+
+def _record_author(item: dict[str, Any], selected: str) -> str:
+    account = item.get("author", item.get("actor"))
+    if item.get("kind") == "account":
+        account = item
+    if account is None:
+        return selected
+    return _record_account(account, "unused")["remote_id"]
+
+
+def _object_row(
+    item: dict[str, Any], context: PageContext, observed_at: str
+) -> dict[str, Any]:
+    kind = item.get("kind")
+    if not isinstance(kind, str) or kind not in OBJECT_TYPES:
+        raise HashnodeAdapterError("Hashnode page contains an unsupported item kind")
+    selected = _required_text(context.account, "id")
+    provider_json = {"source": PROVENANCE, "stream": context.stream, "record": item}
+    reject_credentials(provider_json)
+    created_at = None
+    for key in ("published_at", "date_added", "updated_at", "date_joined"):
+        if (created_at := _optional_text(item, key)) is not None:
+            break
+    return {
+        "object_type": OBJECT_TYPES[kind],
+        "remote_id": _required_text(item, "remote_id"),
+        "account_remote_id": _record_author(item, selected),
+        "text": _record_text(item),
+        "created_at": created_at,
+        "observed_at": observed_at,
+        "evidence_class": "authored" if kind in {"post", "draft"} else "observed",
+        "provider_json": provider_json,
+    }
+
+
+def _activity_row(
+    item: dict[str, Any], context: PageContext, observed_at: str
+) -> dict[str, Any]:
+    kind = _required_text(item, "kind")
+    selected = _required_text(context.account, "id")
+    remote = _required_text(item, "remote_id")
+    actor = _record_author(item, selected)
+    target = remote
+    activity_type = ACTIVITY_TYPES[kind]
+    if kind == "comment":
+        target = _required_text(item["post"], "remote_id")
+    elif kind == "reaction":
+        target = _required_text(item["post"], "remote_id")
+    elif kind == "account":
+        relation = _required_text(item, "relation")
+        activity_type = relation
+        external = account_id(_required_text(item, "provider_account_id"))
+        actor, target = (external, selected) if relation == "followers" else (selected, external)
+    occurred_at = None
+    for key in ("published_at", "date_added", "updated_at", "date_joined"):
+        if (occurred_at := _optional_text(item, key)) is not None:
+            break
+    return {
+        "activity_type": activity_type,
+        "remote_id": namespaced_id("activity", f"{activity_type}:{remote}"),
+        "actor_remote_id": actor,
+        "object_remote_id": target,
+        "occurred_at": occurred_at,
+        "observed_at": observed_at,
+        "state": "active",
+        "provider_json": {"source": PROVENANCE, "stream": context.stream},
+    }
+
+
+def _coverage(observed_at: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "stream": stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": RETENTION_LIMIT,
+            "unavailable_reason": reason,
+            "status": status,
+            "observed_at": observed_at,
+        }
+        for stream, reason, status in GAPS
+    ]
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    reject_credentials(payload)
+    observed_at = _observed_at(payload)
+    if context.account.get("instance_id") != INSTANCE_ID:
+        raise HashnodeAdapterError("Hashnode account API identity is invalid")
+    items = page_data(payload)
+    policy = dict(context.policy)
+    policy.update(
+        {
+            "hashnode_identity": "authenticated_viewer_id_and_username",
+            "hashnode_ownership": "publication_and_authored_content_owner_rechecked",
+            "hashnode_pagination": "opaque_independent_connection_cursors",
+            "hashnode_transport": "stdlib_urllib_fixed_graphql_queries_only",
+            "hashnode_mutations": "unreachable",
+        }
+    )
+    archive = {
+        "provider": PROVIDER,
+        "connection_id": context.connection_id,
+        "remote_account_id": context.account.get("id"),
+        "exported_at": observed_at,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": policy,
+        "accounts": _accounts(items, context, observed_at),
+        "objects": [_object_row(item, context, observed_at) for item in items],
+        "activities": [_activity_row(item, context, observed_at) for item in items],
+        "media": [],
+        "coverage": _coverage(observed_at),
+    }
+    reject_credentials(archive)
+    return archive

--- a/.agents/scripts/_knowledge_social_hashnode_provider.py
+++ b/.agents/scripts/_knowledge_social_hashnode_provider.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded Hashnode gql-beta reader with fixed query-only transport."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from functools import partial
+from typing import Any
+
+from _knowledge_social_hashnode import (
+    HashnodeAdapterError,
+    PageRequest,
+    parse_page_request,
+)
+from _knowledge_social_hashnode_contract import (
+    ApiResult,
+    HashnodeReadProviderError,
+    identity_record,
+    object_value,
+    observed_at,
+    request_object,
+    terminal_payload,
+)
+from _knowledge_social_hashnode_http import (
+    MAX_RESPONSE_BYTES,
+    Opener,
+    ProfileConfig,
+    _http_exports,
+    graphql_api,
+)
+from _knowledge_social_hashnode_identity import account_id, provider_account_id
+from _knowledge_social_hashnode_routes import IDENTITY_QUERY, page
+
+MAX_REQUEST_BYTES = 32 * 1024
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+
+
+def _profile_prefix(profile: str) -> str:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise HashnodeReadProviderError("Hashnode profile name is invalid")
+    return f"HASHNODE_{profile.upper()}"
+
+
+def _profile(profile: str) -> ProfileConfig:
+    prefix = _profile_prefix(profile)
+    token = os.environ.get(f"{prefix}_PAT", "")
+    if not token or "\x00" in token or len(token.encode()) > 16 * 1024:
+        raise HashnodeReadProviderError("Hashnode profile personal access token is missing")
+    return ProfileConfig(token)
+
+
+def _identity(config: ProfileConfig, opener: Opener, expected_id: str) -> dict[str, Any]:
+    result = graphql_api(config, opener, IDENTITY_QUERY, {})
+    if result.status != 200:
+        return terminal_payload(result)
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": identity_record(result.payload, expected_id),
+    }
+
+
+def _verify_page_account(request: PageRequest, identity: dict[str, Any]) -> None:
+    if (
+        identity.get("provider_account_id") != request.provider_account_id
+        or identity.get("username") != request.username
+        or identity.get("instance_id") != request.instance_id
+        or request.account_id != account_id(identity.get("provider_account_id"))
+    ):
+        raise HashnodeReadProviderError(
+            "selected Hashnode account does not match the configured connection"
+        )
+
+
+def _dispatch(
+    request: dict[str, Any], config: ProfileConfig, opener: Opener
+) -> dict[str, Any]:
+    action = request.get("action")
+    if action == "identity":
+        if set(request) != {"action", "account_id"}:
+            raise HashnodeReadProviderError("Hashnode identity request shape is invalid")
+        return _identity(config, opener, provider_account_id(request.get("account_id")))
+    if action != "page":
+        raise HashnodeReadProviderError("Hashnode read action is unsupported")
+    page_request = parse_page_request(request)
+    verified = _identity(config, opener, page_request.provider_account_id)
+    if verified.get("status") != 200:
+        return verified
+    identity = object_value(verified.get("data"), "account verification")
+    _verify_page_account(page_request, identity)
+    result = page(partial(graphql_api, config, opener), page_request)
+    return terminal_payload(result) if isinstance(result, ApiResult) else result
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode()) > MAX_RESPONSE_BYTES:
+        raise HashnodeReadProviderError("Hashnode read response exceeds the safety limit")
+    print(encoded)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        request = request_object(
+            sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1), MAX_REQUEST_BYTES
+        )
+        _emit(_dispatch(request, _profile(args.profile), _http_exports()))
+        return 0
+    except (HashnodeReadProviderError, HashnodeAdapterError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - intentionally redact provider internals
+        print("ERROR: Hashnode read provider request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_hashnode_reader.py
+++ b/.agents/scripts/_knowledge_social_hashnode_reader.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and deterministic fixture readers for Hashnode collection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+from _knowledge_social_fixture import FixturePageReader
+from _knowledge_social_hashnode import (
+    HashnodeAdapterError,
+    HashnodeProviderUnavailableError,
+    PageRequest,
+)
+from _knowledge_social_hashnode_identity import (
+    INSTANCE_ID,
+    account_id,
+    provider_account_id,
+    username,
+)
+from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
+from knowledge_social_import import reject_credentials
+
+READ_TIMEOUT_SECONDS = 120
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+SAFE_PROVIDER_FAILURES = (
+    "Python urllib HTTP exports are unavailable",
+    "Hashnode profile name is invalid",
+    "Hashnode profile personal access token is missing",
+    "selected Hashnode account does not match the configured connection",
+)
+
+
+class HashnodeReader(Protocol):
+    def identity(self, expected_id: str) -> dict[str, Any]: ...
+    def page(self, request: PageRequest) -> dict[str, Any]: ...
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    if len(output.encode()) > MAX_RESPONSE_BYTES:
+        raise HashnodeAdapterError("Hashnode read response exceeds the safety limit")
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise HashnodeAdapterError("Hashnode read provider returned no valid JSON") from error
+    if not isinstance(payload, dict):
+        raise HashnodeAdapterError("Hashnode read response root must be an object")
+    return payload
+
+
+def _provider_failure(stderr: str) -> HashnodeProviderUnavailableError:
+    for message in SAFE_PROVIDER_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return HashnodeProviderUnavailableError(message)
+    return HashnodeProviderUnavailableError("Hashnode read provider is unavailable")
+
+
+HASHNODE_READER_POLICY = GuardedOAuthPolicy(
+    "Hashnode",
+    "HASHNODE",
+    "HASHNODE_READ_LOG",
+    READ_TIMEOUT_SECONDS,
+    _decode_output,
+    _provider_failure,
+    HashnodeProviderUnavailableError,
+    ("PAT",),
+    "",
+)
+
+
+class GuardedHashnode(GuardedOAuthReader):
+    def __init__(self, helper: Path, profile: str) -> None:
+        super().__init__(helper, profile, HASHNODE_READER_POLICY)
+
+
+class FixtureHashnode(FixturePageReader):
+    def __init__(self, path: Path) -> None:
+        super().__init__(path, "Hashnode", HashnodeAdapterError)
+
+
+def _display_text(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value or len(value.encode()) > 512 * 1024:
+        raise HashnodeAdapterError(f"Hashnode account {field} must be text")
+    return value
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    """Bind the authenticated Hashnode viewer before collection."""
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise HashnodeAdapterError("Hashnode account verification returned no account")
+    remote = provider_account_id(data.get("provider_account_id"))
+    handle = username(data.get("username"))
+    if remote != provider_account_id(expected_id) or data.get("instance_id") != INSTANCE_ID:
+        raise HashnodeAdapterError(
+            "selected Hashnode account does not match the configured connection"
+        )
+    durable = account_id(remote)
+    if data.get("id") != durable:
+        raise HashnodeAdapterError("Hashnode account identity binding is invalid")
+    return {
+        "id": durable,
+        "provider_account_id": remote,
+        "instance_id": INSTANCE_ID,
+        "username": handle,
+        "name": _display_text(data.get("name"), "name"),
+        "bio": _display_text(data.get("bio"), "bio"),
+        "tagline": _display_text(data.get("tagline"), "tagline"),
+        "location": _display_text(data.get("location"), "location"),
+        "date_joined": _display_text(data.get("date_joined"), "join date"),
+    }

--- a/.agents/scripts/_knowledge_social_hashnode_routes.py
+++ b/.agents/scripts/_knowledge_social_hashnode_routes.py
@@ -1,0 +1,701 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Fixed Hashnode read queries, connection pagination, and serializers."""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from _knowledge_social_hashnode import PageRequest
+from _knowledge_social_hashnode_contract import (
+    ApiResult,
+    HashnodeReadProviderError,
+    nonnegative_int,
+    object_list,
+    object_value,
+    observed_at,
+    optional_text,
+    public_url,
+    required_text,
+)
+from _knowledge_social_hashnode_identity import (
+    INSTANCE_ID,
+    namespaced_id,
+    opaque_id,
+    provider_account_id,
+    username,
+)
+from knowledge_social_import import canonical_json, reject_credentials
+
+GraphApi = Callable[[str, dict[str, Any]], ApiResult]
+PageResult = ApiResult | dict[str, Any]
+ROUTE_CURSOR_PREFIX = "hashnode-route-v1:"
+
+
+@dataclass(frozen=True)
+class NestedRoute:
+    root_field: str
+    outer_field: str
+    inner_field: str
+    outer_validator: Callable[[dict[str, Any], PageRequest], dict[str, Any]]
+    serializer: Callable[
+        [dict[str, Any], dict[str, Any], PageRequest], dict[str, Any]
+    ]
+
+IDENTITY_FIELDS = """
+    id username name tagline location dateJoined
+    bio { text }
+"""
+IDENTITY_QUERY = f"""
+query AidevopsHashnodeIdentity {{
+  me {{ {IDENTITY_FIELDS} }}
+}}
+"""
+PROFILE_QUERY = f"""
+query AidevopsHashnodeProfile {{
+  me {{ {IDENTITY_FIELDS} }}
+}}
+"""
+PUBLICATIONS_QUERY = """
+query AidevopsHashnodePublications($first: Int!, $after: String) {
+  me {
+    id username
+    publications(first: $first, after: $after) {
+      edges {
+        cursor
+        node {
+          id title url isTeam followersCount about { text }
+          author { id username name }
+        }
+      }
+      pageInfo { endCursor hasNextPage }
+    }
+  }
+}
+"""
+POSTS_QUERY = """
+query AidevopsHashnodePosts($username: String!, $first: Int!, $after: String) {
+  user(username: $username) {
+    id username
+    posts(first: $first, after: $after) {
+      edges {
+        cursor
+        node {
+          id title subtitle slug url brief publishedAt updatedAt
+          reactionCount responseCount replyCount
+          content { markdown text }
+          author { id username name }
+          publication { id title url author { id username } }
+          tags { id name slug }
+        }
+      }
+      pageInfo { endCursor hasNextPage }
+    }
+  }
+}
+"""
+DRAFTS_QUERY = """
+query AidevopsHashnodeDrafts(
+  $publicationAfter: String, $first: Int!, $after: String
+) {
+  me {
+    id username
+    publications(first: 1, after: $publicationAfter) {
+      edges {
+        cursor
+        node {
+          id title url author { id username }
+          drafts(first: $first, after: $after) {
+            edges {
+              cursor
+              node {
+                id title subtitle slug updatedAt scheduledDate isSubmittedForReview
+                content { markdown text }
+                author { id username name }
+                tags { id name slug }
+              }
+            }
+            pageInfo { endCursor hasNextPage }
+          }
+        }
+      }
+      pageInfo { endCursor hasNextPage }
+    }
+  }
+}
+"""
+COMMENTS_QUERY = """
+query AidevopsHashnodeComments(
+  $username: String!, $postAfter: String, $first: Int!, $after: String
+) {
+  user(username: $username) {
+    id username
+    posts(first: 1, after: $postAfter) {
+      edges {
+        cursor
+        node {
+          id title author { id username }
+          publication { id title author { id username } }
+          comments(first: $first, after: $after) {
+            edges {
+              cursor
+              node {
+                id dateAdded totalReactions content { text }
+                author { id username name }
+              }
+            }
+            pageInfo { endCursor hasNextPage }
+          }
+        }
+      }
+      pageInfo { endCursor hasNextPage }
+    }
+  }
+}
+"""
+REACTIONS_QUERY = """
+query AidevopsHashnodeReactions(
+  $username: String!, $postAfter: String, $first: Int!, $after: String
+) {
+  user(username: $username) {
+    id username
+    posts(first: 1, after: $postAfter) {
+      edges {
+        cursor
+        node {
+          id title author { id username }
+          publication { id title author { id username } }
+          likedBy(first: $first, after: $after) {
+            edges { cursor node { id username name } }
+            pageInfo { endCursor hasNextPage }
+          }
+        }
+      }
+      pageInfo { endCursor hasNextPage }
+    }
+  }
+}
+"""
+FOLLOWERS_QUERY = """
+query AidevopsHashnodeFollowers($first: Int!, $after: String) {
+  me {
+    id username
+    followers(first: $first, after: $after) {
+      edges { cursor node { id username name tagline } }
+      pageInfo { endCursor hasNextPage }
+    }
+  }
+}
+"""
+FOLLOWING_QUERY = """
+query AidevopsHashnodeFollowing($first: Int!, $after: String) {
+  me {
+    id username
+    follows(first: $first, after: $after) {
+      edges { cursor node { id username name tagline } }
+      pageInfo { endCursor hasNextPage }
+    }
+  }
+}
+"""
+
+QUERY_VARIABLES = {
+    IDENTITY_QUERY: frozenset(),
+    PROFILE_QUERY: frozenset(),
+    PUBLICATIONS_QUERY: frozenset({"first", "after"}),
+    POSTS_QUERY: frozenset({"username", "first", "after"}),
+    DRAFTS_QUERY: frozenset({"publicationAfter", "first", "after"}),
+    COMMENTS_QUERY: frozenset({"username", "postAfter", "first", "after"}),
+    REACTIONS_QUERY: frozenset({"username", "postAfter", "first", "after"}),
+    FOLLOWERS_QUERY: frozenset({"first", "after"}),
+    FOLLOWING_QUERY: frozenset({"first", "after"}),
+}
+ALLOWED_QUERIES = frozenset(QUERY_VARIABLES)
+
+
+def _route_state(value: str | None) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not value.startswith(ROUTE_CURSOR_PREFIX):
+        raise HashnodeReadProviderError("Hashnode route cursor has an unsupported version")
+    try:
+        raw = value.removeprefix(ROUTE_CURSOR_PREFIX)
+        parsed = json.loads(base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4)))
+    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+        raise HashnodeReadProviderError("Hashnode route cursor is invalid") from error
+    if not isinstance(parsed, dict):
+        raise HashnodeReadProviderError("Hashnode route cursor has an invalid shape")
+    reject_credentials(parsed)
+    return parsed
+
+
+def _encode_route_state(state: dict[str, Any]) -> str:
+    reject_credentials(state)
+    encoded = base64.urlsafe_b64encode(canonical_json(state).encode()).decode("ascii")
+    return f"{ROUTE_CURSOR_PREFIX}{encoded.rstrip('=')}"
+
+
+def _graphql_root(result: ApiResult, field: str) -> dict[str, Any]:
+    root = object_value(result.payload, "GraphQL response")
+    if root.get("errors"):
+        raise HashnodeReadProviderError("Hashnode GraphQL read returned errors")
+    data = object_value(root.get("data"), "GraphQL data")
+    return object_value(data.get(field), f"GraphQL {field}")
+
+
+def _verify_account(node: dict[str, Any], request: PageRequest) -> None:
+    if (
+        provider_account_id(node.get("id")) != request.provider_account_id
+        or username(node.get("username")) != request.username
+    ):
+        raise HashnodeReadProviderError(
+            "selected Hashnode account does not match the configured connection"
+        )
+
+
+def _content(value: Any, field: str) -> dict[str, str | None]:
+    if value is None:
+        return {"markdown": None, "text": None}
+    content = object_value(value, field)
+    return {
+        "markdown": optional_text(content.get("markdown"), f"{field} markdown"),
+        "text": optional_text(content.get("text"), f"{field} text"),
+    }
+
+
+def _account(node: dict[str, Any]) -> dict[str, Any]:
+    remote = provider_account_id(node.get("id"))
+    return {
+        "provider_account_id": remote,
+        "remote_id": namespaced_id("account", remote),
+        "username": username(node.get("username")),
+        "name": optional_text(node.get("name"), "account name"),
+        "tagline": optional_text(node.get("tagline"), "account tagline"),
+    }
+
+
+def _publication(node: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    publication_id = opaque_id(node.get("id"), "publication ID")
+    author = object_value(node.get("author"), "publication author")
+    _verify_account(author, request)
+    about = _content(node.get("about"), "publication about")
+    is_team = node.get("isTeam")
+    if is_team is not None and not isinstance(is_team, bool):
+        raise HashnodeReadProviderError("Hashnode publication team flag is invalid")
+    return {
+        "kind": "publication",
+        "remote_id": namespaced_id("publication", publication_id),
+        "publication_id": publication_id,
+        "title": required_text(node.get("title"), "publication title"),
+        "url": public_url(node.get("url"), "publication URL"),
+        "about": about["text"],
+        "is_team": is_team,
+        "followers_count": nonnegative_int(
+            node.get("followersCount"), "publication follower count", optional=True
+        ),
+        "author": _account(author),
+    }
+
+
+def _tags(value: Any) -> list[dict[str, str]]:
+    tags = object_list(value or [], "post tags", limit=15)
+    return [
+        {
+            "id": opaque_id(item.get("id"), "tag ID"),
+            "name": required_text(item.get("name"), "tag name"),
+            "slug": required_text(item.get("slug"), "tag slug"),
+        }
+        for item in tags
+    ]
+
+
+def _publication_summary(value: Any, request: PageRequest) -> dict[str, Any]:
+    publication = object_value(value, "post publication")
+    publication_id = opaque_id(publication.get("id"), "publication ID")
+    author = object_value(publication.get("author"), "publication author")
+    _verify_account(author, request)
+    return {
+        "remote_id": namespaced_id("publication", publication_id),
+        "publication_id": publication_id,
+        "title": required_text(publication.get("title"), "publication title"),
+        "url": public_url(publication.get("url"), "publication URL"),
+    }
+
+
+def _post(node: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    post_id = opaque_id(node.get("id"), "post ID")
+    author = object_value(node.get("author"), "post author")
+    _verify_account(author, request)
+    content = _content(node.get("content"), "post content")
+    return {
+        "kind": "post",
+        "remote_id": namespaced_id("post", post_id),
+        "post_id": post_id,
+        "title": required_text(node.get("title"), "post title"),
+        "subtitle": optional_text(node.get("subtitle"), "post subtitle"),
+        "slug": required_text(node.get("slug"), "post slug"),
+        "url": public_url(node.get("url"), "post URL"),
+        "brief": optional_text(node.get("brief"), "post brief"),
+        "markdown": content["markdown"],
+        "text": content["text"],
+        "published_at": required_text(node.get("publishedAt"), "post publish date"),
+        "updated_at": optional_text(node.get("updatedAt"), "post update date"),
+        "reaction_count": nonnegative_int(node.get("reactionCount"), "reaction count"),
+        "response_count": nonnegative_int(node.get("responseCount"), "response count"),
+        "reply_count": nonnegative_int(node.get("replyCount"), "reply count"),
+        "author": _account(author),
+        "publication": _publication_summary(node.get("publication"), request),
+        "tags": _tags(node.get("tags")),
+    }
+
+
+def _draft(
+    node: dict[str, Any], publication: dict[str, Any], request: PageRequest
+) -> dict[str, Any]:
+    draft_id = opaque_id(node.get("id"), "draft ID")
+    author = object_value(node.get("author"), "draft author")
+    _verify_account(author, request)
+    content = _content(node.get("content"), "draft content")
+    review = node.get("isSubmittedForReview")
+    if review is not None and not isinstance(review, bool):
+        raise HashnodeReadProviderError("Hashnode draft review flag is invalid")
+    return {
+        "kind": "draft",
+        "remote_id": namespaced_id("draft", draft_id),
+        "draft_id": draft_id,
+        "title": optional_text(node.get("title"), "draft title"),
+        "subtitle": optional_text(node.get("subtitle"), "draft subtitle"),
+        "slug": optional_text(node.get("slug"), "draft slug"),
+        "markdown": content["markdown"],
+        "text": content["text"],
+        "updated_at": required_text(node.get("updatedAt"), "draft update date"),
+        "scheduled_at": optional_text(node.get("scheduledDate"), "draft schedule date"),
+        "submitted_for_review": review,
+        "author": _account(author),
+        "publication": publication,
+        "tags": _tags(node.get("tags")),
+    }
+
+
+def _post_context(node: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    post_id = opaque_id(node.get("id"), "post ID")
+    author = object_value(node.get("author"), "post author")
+    _verify_account(author, request)
+    return {
+        "remote_id": namespaced_id("post", post_id),
+        "post_id": post_id,
+        "title": required_text(node.get("title"), "post title"),
+        "publication": _publication_summary(node.get("publication"), request),
+    }
+
+
+def _comment(
+    node: dict[str, Any], post: dict[str, Any], _request: PageRequest
+) -> dict[str, Any]:
+    comment_id = opaque_id(node.get("id"), "comment ID")
+    content = _content(node.get("content"), "comment content")
+    return {
+        "kind": "comment",
+        "remote_id": namespaced_id("comment", comment_id),
+        "comment_id": comment_id,
+        "text": content["text"],
+        "date_added": required_text(node.get("dateAdded"), "comment date"),
+        "reaction_count": nonnegative_int(
+            node.get("totalReactions"), "comment reaction count"
+        ),
+        "author": _account(object_value(node.get("author"), "comment author")),
+        "post": post,
+    }
+
+
+def _reaction(
+    node: dict[str, Any], post: dict[str, Any], _request: PageRequest
+) -> dict[str, Any]:
+    actor = _account(node)
+    return {
+        "kind": "reaction",
+        "remote_id": namespaced_id(
+            "reaction", f"{post['post_id']}:{actor['provider_account_id']}:like"
+        ),
+        "reaction_type": "like",
+        "actor": actor,
+        "post": post,
+    }
+
+
+def _page_info(connection: dict[str, Any]) -> tuple[bool, str | None]:
+    info = object_value(connection.get("pageInfo"), "connection pageInfo")
+    has_next = info.get("hasNextPage")
+    if not isinstance(has_next, bool):
+        raise HashnodeReadProviderError("Hashnode connection pageInfo is invalid")
+    end = optional_text(info.get("endCursor"), "connection end cursor")
+    if has_next and not end:
+        raise HashnodeReadProviderError("Hashnode connection omitted its next cursor")
+    return has_next, end
+
+
+def _edges(
+    connection: dict[str, Any], field: str, limit: int
+) -> list[tuple[str, dict[str, Any]]]:
+    edges = object_list(connection.get("edges"), f"{field} edges", limit=limit)
+    return [
+        (
+            required_text(edge.get("cursor"), f"{field} edge cursor"),
+            object_value(edge.get("node"), f"{field} edge node"),
+        )
+        for edge in edges
+    ]
+
+
+def _next_cursor(current: str | None, has_next: bool, end: str | None) -> str | None:
+    if not has_next:
+        return None
+    if end == current:
+        raise HashnodeReadProviderError("Hashnode connection cursor did not advance")
+    return end
+
+
+def _page_payload(
+    request: PageRequest, records: list[dict[str, Any]], next_cursor: str | None
+) -> dict[str, Any]:
+    return {
+        "status": 200,
+        "observed_at": observed_at(),
+        "data": records,
+        "meta": {
+            "stream": request.stream,
+            "instance_id": INSTANCE_ID,
+            "transport": "graphql",
+            "next_cursor": next_cursor,
+            "complete": next_cursor is None,
+            "snapshot": True,
+        },
+    }
+
+
+def _simple_connection(
+    result: ApiResult,
+    request: PageRequest,
+    root_field: str,
+    connection_field: str,
+    serializer: Callable[[dict[str, Any], PageRequest], dict[str, Any]],
+) -> PageResult:
+    if result.status != 200:
+        return result
+    state = _route_state(request.stop_at)
+    if set(state) - {"after"}:
+        raise HashnodeReadProviderError("Hashnode route cursor has an invalid shape")
+    after = optional_text(state.get("after"), "route cursor")
+    root = _graphql_root(result, root_field)
+    _verify_account(root, request)
+    connection = object_value(root.get(connection_field), f"{connection_field} connection")
+    edges = _edges(connection, connection_field, request.limit)
+    has_next, end = _page_info(connection)
+    next_after = _next_cursor(after, has_next, end)
+    next_state = _encode_route_state({"after": next_after}) if next_after else None
+    return _page_payload(
+        request, [serializer(node, request) for _cursor, node in edges], next_state
+    )
+
+
+def _nested_connection(
+    result: ApiResult,
+    request: PageRequest,
+    route: NestedRoute,
+) -> PageResult:
+    if result.status != 200:
+        return result
+    state = _route_state(request.stop_at)
+    expected = {"outer_after", "inner_after", "outer_id"}
+    if set(state) - expected:
+        raise HashnodeReadProviderError("Hashnode nested cursor has an invalid shape")
+    outer_after = optional_text(state.get("outer_after"), "outer cursor")
+    inner_after = optional_text(state.get("inner_after"), "inner cursor")
+    prior_outer_id = optional_text(state.get("outer_id"), "outer resource ID")
+    if (inner_after is None) != (prior_outer_id is None):
+        raise HashnodeReadProviderError("Hashnode nested cursor is incomplete")
+    root = _graphql_root(result, route.root_field)
+    _verify_account(root, request)
+    outer = object_value(
+        root.get(route.outer_field), f"{route.outer_field} connection"
+    )
+    outer_edges = _edges(outer, route.outer_field, 1)
+    outer_has_next, outer_end = _page_info(outer)
+    if not outer_edges:
+        if outer_has_next:
+            raise HashnodeReadProviderError("Hashnode nested connection page is empty")
+        return _page_payload(request, [], None)
+    outer_cursor, outer_node = outer_edges[0]
+    if outer_end != outer_cursor:
+        raise HashnodeReadProviderError("Hashnode outer connection cursor is inconsistent")
+    outer_context = route.outer_validator(outer_node, request)
+    outer_id = required_text(outer_context.get("remote_id"), "outer resource ID")
+    if prior_outer_id is not None and prior_outer_id != outer_id:
+        raise HashnodeReadProviderError("Hashnode nested cursor changed resources")
+    inner = object_value(
+        outer_node.get(route.inner_field), f"{route.inner_field} connection"
+    )
+    inner_edges = _edges(inner, route.inner_field, request.limit)
+    inner_has_next, inner_end = _page_info(inner)
+    records = [
+        route.serializer(node, outer_context, request) for _cursor, node in inner_edges
+    ]
+    if inner_has_next:
+        next_inner = _next_cursor(inner_after, True, inner_end)
+        next_state = {
+            "outer_after": outer_after,
+            "inner_after": next_inner,
+            "outer_id": outer_id,
+        }
+    elif outer_has_next:
+        next_outer = _next_cursor(outer_after, True, outer_end)
+        next_state = {
+            "outer_after": next_outer,
+            "inner_after": None,
+            "outer_id": None,
+        }
+    else:
+        return _page_payload(request, records, None)
+    return _page_payload(request, records, _encode_route_state(next_state))
+
+
+def _profile(api: GraphApi, request: PageRequest) -> PageResult:
+    if request.stop_at is not None:
+        raise HashnodeReadProviderError("Hashnode profile does not accept a page cursor")
+    result = api(PROFILE_QUERY, {})
+    if result.status != 200:
+        return result
+    viewer = _graphql_root(result, "me")
+    _verify_account(viewer, request)
+    bio = _content(viewer.get("bio"), "profile bio")
+    record = {
+        "kind": "profile",
+        "remote_id": namespaced_id("profile", request.provider_account_id),
+        "username": request.username,
+        "name": optional_text(viewer.get("name"), "profile name"),
+        "tagline": optional_text(viewer.get("tagline"), "profile tagline"),
+        "location": optional_text(viewer.get("location"), "profile location"),
+        "date_joined": optional_text(viewer.get("dateJoined"), "profile join date"),
+        "bio": bio["text"],
+    }
+    return _page_payload(request, [record], None)
+
+
+def _publications(api: GraphApi, request: PageRequest) -> PageResult:
+    state = _route_state(request.stop_at)
+    after = optional_text(state.get("after"), "publication cursor")
+    result = api(PUBLICATIONS_QUERY, {"first": request.limit, "after": after})
+    return _simple_connection(
+        result, request, "me", "publications", _publication
+    )
+
+
+def _posts(api: GraphApi, request: PageRequest) -> PageResult:
+    state = _route_state(request.stop_at)
+    after = optional_text(state.get("after"), "post cursor")
+    result = api(
+        POSTS_QUERY,
+        {"username": request.username, "first": request.limit, "after": after},
+    )
+    return _simple_connection(result, request, "user", "posts", _post)
+
+
+def _draft_publication(node: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    summary = _publication_summary(node, request)
+    return {**summary, "remote_id": summary["remote_id"]}
+
+
+def _drafts(api: GraphApi, request: PageRequest) -> PageResult:
+    state = _route_state(request.stop_at)
+    result = api(
+        DRAFTS_QUERY,
+        {
+            "publicationAfter": state.get("outer_after"),
+            "first": request.limit,
+            "after": state.get("inner_after"),
+        },
+    )
+    return _nested_connection(
+        result,
+        request,
+        NestedRoute("me", "publications", "drafts", _draft_publication, _draft),
+    )
+
+
+def _post_interactions(
+    api: GraphApi,
+    request: PageRequest,
+    query: str,
+    route: NestedRoute,
+) -> PageResult:
+    state = _route_state(request.stop_at)
+    result = api(
+        query,
+        {
+            "username": request.username,
+            "postAfter": state.get("outer_after"),
+            "first": request.limit,
+            "after": state.get("inner_after"),
+        },
+    )
+    return _nested_connection(result, request, route)
+
+
+def _comments(api: GraphApi, request: PageRequest) -> PageResult:
+    return _post_interactions(
+        api,
+        request,
+        COMMENTS_QUERY,
+        NestedRoute("user", "posts", "comments", _post_context, _comment),
+    )
+
+
+def _reactions(api: GraphApi, request: PageRequest) -> PageResult:
+    return _post_interactions(
+        api,
+        request,
+        REACTIONS_QUERY,
+        NestedRoute("user", "posts", "likedBy", _post_context, _reaction),
+    )
+
+
+def _relationship(node: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    return {"kind": "account", "relation": request.stream, **_account(node)}
+
+
+def _followers(api: GraphApi, request: PageRequest) -> PageResult:
+    state = _route_state(request.stop_at)
+    result = api(
+        FOLLOWERS_QUERY,
+        {"first": request.limit, "after": state.get("after")},
+    )
+    return _simple_connection(result, request, "me", "followers", _relationship)
+
+
+def _following(api: GraphApi, request: PageRequest) -> PageResult:
+    state = _route_state(request.stop_at)
+    result = api(
+        FOLLOWING_QUERY,
+        {"first": request.limit, "after": state.get("after")},
+    )
+    return _simple_connection(result, request, "me", "follows", _relationship)
+
+
+ROUTES = {
+    "profile": _profile,
+    "publications": _publications,
+    "posts": _posts,
+    "drafts": _drafts,
+    "comments": _comments,
+    "reactions": _reactions,
+    "followers": _followers,
+    "following": _following,
+}
+
+
+def page(api: GraphApi, request: PageRequest) -> PageResult:
+    return ROUTES[request.stream](api, request)

--- a/.agents/scripts/_knowledge_social_oauth_request.py
+++ b/.agents/scripts/_knowledge_social_oauth_request.py
@@ -5,10 +5,12 @@
 
 from __future__ import annotations
 
+import base64
+import json
 from dataclasses import dataclass
-from typing import Any, ClassVar
+from typing import Any, Callable, ClassVar
 
-from knowledge_social_import import canonical_json
+from knowledge_social_import import canonical_json, reject_credentials
 
 
 @dataclass(frozen=True)
@@ -41,3 +43,134 @@ class OAuthPageRequest:
 
     def evidence_key(self) -> str:
         return canonical_json(self.payload())
+
+
+@dataclass(frozen=True)
+class OAuthRequestCodec:
+    """Build and validate one provider's standard OAuth page envelope."""
+
+    display_name: str
+    cursor_prefix: str
+    cursor_key: str
+    handle_key: str
+    max_page_size: int
+    max_text_bytes: int
+    streams: frozenset[str]
+    request_type: type[OAuthPageRequest]
+    error_type: type[Exception]
+    account_validator: Callable[[Any], str]
+    handle_validator: Callable[[Any], str]
+    instance_validator: Callable[[Any], str]
+
+    @property
+    def request_keys(self) -> frozenset[str]:
+        return frozenset(
+            {
+                "action",
+                "stream",
+                "account_id",
+                "provider_account_id",
+                self.handle_key,
+                "instance_id",
+                "position",
+                "stop_at",
+                "limit",
+            }
+        )
+
+    def _error(self, message: str) -> Exception:
+        return self.error_type(f"{self.display_name} {message}")
+
+    def text(self, value: Any, field: str, *, optional: bool = False) -> str | None:
+        if value is None:
+            if optional:
+                return None
+            raise self._error(f"{field} is invalid")
+        if not isinstance(value, str) or not value or "\x00" in value:
+            raise self._error(f"{field} is invalid")
+        if len(value.encode()) > self.max_text_bytes:
+            raise self._error(f"{field} is invalid")
+        return value
+
+    def _position(self, value: Any) -> int:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise self._error("page position must be positive")
+        if value < 1:
+            raise self._error("page position must be positive")
+        return value
+
+    def _stream(self, value: Any) -> str:
+        if not isinstance(value, str) or value not in self.streams:
+            raise self._error("stream is unsupported")
+        return value
+
+    def _limit(self, value: Any) -> int:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise self._error("page size is invalid")
+        if not 1 <= value <= self.max_page_size:
+            raise self._error("page size is invalid")
+        return value
+
+    def encode_cursor(self, position: int, state: str) -> str:
+        payload = canonical_json({"position": position, self.cursor_key: state}).encode()
+        encoded = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+        return f"{self.cursor_prefix}{encoded}"
+
+    def decode_cursor(self, cursor: str) -> tuple[int, str]:
+        if not cursor.startswith(self.cursor_prefix):
+            raise self._error("stored cursor has an unsupported version")
+        try:
+            raw = cursor.removeprefix(self.cursor_prefix)
+            parsed = json.loads(base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4)))
+        except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+            raise self._error("stored cursor is invalid") from error
+        expected = {"position", self.cursor_key}
+        if not isinstance(parsed, dict) or set(parsed) != expected:
+            raise self._error("stored cursor has an invalid shape")
+        reject_credentials(parsed)
+        state = self.text(parsed.get(self.cursor_key), "stored cursor")
+        if state is None:
+            raise self._error("stored cursor is invalid")
+        return self._position(parsed.get("position")), state
+
+    def collection_request(
+        self,
+        stream: str,
+        account: dict[str, Any],
+        cursor: str | None,
+        limit: int,
+    ) -> OAuthPageRequest:
+        checked_stream = self._stream(stream)
+        position, state = self.decode_cursor(cursor) if cursor else (1, None)
+        selected = self.text(account.get("id"), "selected account ID")
+        if selected is None:
+            raise self._error("verified identity is incomplete")
+        return self.request_type(
+            checked_stream,
+            selected,
+            self.account_validator(account.get("provider_account_id")),
+            self.handle_validator(account.get(self.handle_key)),
+            self.instance_validator(account.get("instance_id")),
+            position,
+            state,
+            self._limit(limit),
+        )
+
+    def provider_request(self, payload: dict[str, Any]) -> OAuthPageRequest:
+        if set(payload) != self.request_keys:
+            raise self._error("read request has an invalid action shape")
+        if payload.get("action") != "page":
+            raise self._error("read request has an invalid action shape")
+        selected = self.text(payload.get("account_id"), "selected account ID")
+        if selected is None:
+            raise self._error("selected account ID is required")
+        return self.request_type(
+            self._stream(payload.get("stream")),
+            selected,
+            self.account_validator(payload.get("provider_account_id")),
+            self.handle_validator(payload.get(self.handle_key)),
+            self.instance_validator(payload.get("instance_id")),
+            self._position(payload.get("position")),
+            self.text(payload.get("stop_at"), "cursor state", optional=True),
+            self._limit(payload.get("limit")),
+        )

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -20,6 +20,7 @@ LEMMY_HELPER="${SCRIPT_DIR}/knowledge_social_lemmy.py"
 GITHUB_HELPER="${SCRIPT_DIR}/knowledge_social_github.py"
 STACK_EXCHANGE_HELPER="${SCRIPT_DIR}/knowledge_social_stack_exchange.py"
 HACKER_NEWS_HELPER="${SCRIPT_DIR}/knowledge_social_hacker_news.py"
+HASHNODE_HELPER="${SCRIPT_DIR}/knowledge_social_hashnode.py"
 MINIFLUX_HELPER="${SCRIPT_DIR}/knowledge_social_miniflux.py"
 READWISE_READER_HELPER="${SCRIPT_DIR}/knowledge_social_readwise_reader.py"
 QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
@@ -167,6 +168,18 @@ EOF
 	return 0
 }
 
+usage_sync_hashnode() {
+	cat <<'EOF'
+Hashnode synchronization:
+  sync-hashnode binds the authenticated viewer ID and username before every
+  fixed GraphQL read page. Eight independent streams reject arbitrary GraphQL,
+  mutations, partial errors, redirects, and unowned resources.
+  --budget is 3-1000 and --page-size is 1-50.
+
+EOF
+	return 0
+}
+
 usage_commands() {
 	cat <<'EOF'
 Usage:
@@ -229,6 +242,10 @@ Usage:
   knowledge-social-helper.sh sync-hacker-news [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id CASE_SENSITIVE_USERNAME --stream submitted \
     --profile public [--budget UNITS] [--page-size 1-100] \
+    [--collector-id ID] [--lease-seconds SECONDS]
+  knowledge-social-helper.sh sync-hashnode [--base PATH] [--alias ALIAS] \
+    --connection-id ID --account-id HASHNODE_ACCOUNT_ID --stream STREAM \
+    --profile PROFILE [--budget UNITS] [--page-size 1-50] \
     [--collector-id ID] [--lease-seconds SECONDS]
   knowledge-social-helper.sh sync-miniflux [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id USER_NUMERIC_ID --stream STREAM \
@@ -303,6 +320,7 @@ Medium account export:
 
 EOF
 	usage_sync
+	usage_sync_hashnode
 	cat <<'EOF'
 Deterministic routines:
   sync-due and reconcile-due return sorted privacy-safe work plans. Every sync or
@@ -427,6 +445,7 @@ run_named_provider_sync() {
 	sync-github) run_provider_sync GitHub "$GITHUB_HELPER" "$@" || return 1 ;;
 	sync-stack-exchange) run_provider_sync "Stack Exchange" "$STACK_EXCHANGE_HELPER" "$@" || return 1 ;;
 	sync-hacker-news) run_provider_sync "Hacker News" "$HACKER_NEWS_HELPER" "$@" || return 1 ;;
+	sync-hashnode) run_provider_sync Hashnode "$HASHNODE_HELPER" "$@" || return 1 ;;
 	sync-miniflux) run_provider_sync Miniflux "$MINIFLUX_HELPER" "$@" || return 1 ;;
 	sync-readwise-reader) run_provider_sync "Readwise Reader" "$READWISE_READER_HELPER" "$@" || return 1 ;;
 	*) return 1 ;;
@@ -508,7 +527,7 @@ main() {
 		fi
 		python3 "$LINKEDIN_HELPER" "$@" || return 1
 		;;
-	sync-meta | sync-discourse | sync-nodebb | sync-mastodon | sync-lemmy | sync-github | sync-stack-exchange | sync-hacker-news | sync-miniflux | sync-readwise-reader)
+	sync-meta | sync-discourse | sync-nodebb | sync-mastodon | sync-lemmy | sync-github | sync-stack-exchange | sync-hacker-news | sync-hashnode | sync-miniflux | sync-readwise-reader)
 		run_named_provider_sync "$subcommand" "$@" || return 1
 		;;
 	query | annotate)

--- a/.agents/scripts/knowledge_social_hashnode.py
+++ b/.agents/scripts/knowledge_social_hashnode.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one bounded, read-only Hashnode account stream into a social corpus."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import _knowledge_social_hashnode as hashnode
+from _knowledge_social_hashnode_normalize import PageContext, normalize_page
+from _knowledge_social_hashnode_reader import (
+    FixtureHashnode,
+    GuardedHashnode,
+    verified_identity,
+)
+from _knowledge_social_oauth_collector import OAuthCollectorPolicy, run_oauth_collector
+
+
+HASHNODE_POLICY = OAuthCollectorPolicy(
+    provider_module=hashnode,
+    verified_identity=verified_identity,
+    normalize_page=normalize_page,
+    page_context=PageContext,
+    display_name="Hashnode",
+    helper=Path(__file__).with_name("_knowledge_social_hashnode_provider.py"),
+    fixture_reader=FixtureHashnode,
+    live_reader=GuardedHashnode,
+    budget_unit="query",
+    min_budget=3,
+    max_page_size=50,
+    identity_cost_units=1,
+)
+
+
+def main() -> int:
+    return run_oauth_collector(HASHNODE_POLICY, __doc__ or "")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/knowledge_social_registry.py
+++ b/.agents/scripts/knowledge_social_registry.py
@@ -58,6 +58,7 @@ PROVIDER_SPECS = (
         "knowledge_social_hacker_news.py",
         (("live", ()),),
     ),
+    ProviderSpec("hashnode", (), "knowledge_social_hashnode.py", (("live", ()),)),
     ProviderSpec("lemmy", (), "knowledge_social_lemmy.py", (("live", ()),)),
     ProviderSpec("mastodon", (), "knowledge_social_mastodon.py", (("live", ()),)),
     ProviderSpec("miniflux", (), "knowledge_social_miniflux.py", (("live", ()),)),

--- a/.agents/tests/test-knowledge-social-hashnode.sh
+++ b/.agents/tests/test-knowledge-social-hashnode.sh
@@ -1,0 +1,664 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-hashnode.sh — Bounded Hashnode collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHNODE_SCRIPT="${SCRIPT_DIR}/../scripts/knowledge_social_hashnode.py"
+SOCIAL_HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TEMP_PARENT="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+mkdir -p "$TEMP_PARENT"
+TMP_DIR=$(mktemp -d "${TEMP_PARENT}/hashnode-social-test.XXXXXX")
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+PASS=0
+FAIL=0
+ACCOUNT_ID="65b000000000000000000042"
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' \
+			"$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c 'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_count() {
+	python3 - "$ROOT/sources/social/raw/hashnode" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+print(len(list(root.rglob("*.json.gz"))) if root.exists() else 0)
+PY
+	return 0
+}
+
+run_hashnode() {
+	local fixture="$1"
+	local connection_id="$2"
+	local stream="$3"
+	local budget="$4"
+	local page_size="$5"
+	if python3 "$HASHNODE_SCRIPT" --base "$BASE" --alias personal:default \
+		--connection-id "$connection_id" --account-id "account_${ACCOUNT_ID}" \
+		--stream "$stream" --profile fixture --fixture "$fixture" \
+		--budget "$budget" --page-size "$page_size"; then
+		return 0
+	fi
+	return 1
+}
+
+expect_failure() {
+	local description="$1"
+	local fixture="$2"
+	local connection_id="$3"
+	local stream="$4"
+	if run_hashnode "$fixture" "$connection_id" "$stream" 3 2 >/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$SOCIAL_HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'Hashnode social collector tests\n'
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import ast
+import json
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+
+from _knowledge_social_collect import CursorState
+from _knowledge_social_hashnode import PageRequest, STREAMS, page_checkpoint, page_request
+from _knowledge_social_hashnode_contract import ApiResult
+from _knowledge_social_hashnode_http import (
+    GRAPHQL_URL,
+    HTTP_TIMEOUT_SECONDS,
+    ProfileConfig,
+    _graphql_error_status,
+    graphql_api,
+)
+from _knowledge_social_hashnode_identity import INSTANCE_ID, account_id, namespaced_id
+from _knowledge_social_hashnode_routes import (
+    ALLOWED_QUERIES,
+    COMMENTS_QUERY,
+    IDENTITY_QUERY,
+    PUBLICATIONS_QUERY,
+    _encode_route_state,
+    page,
+)
+
+UID = "65b000000000000000000000042"
+OTHER = "65b000000000000000000000043"
+PUBLICATION = "65c000000000000000000042"
+POST = "65d000000000000000000042"
+COMMENT = "65e000000000000000000042"
+
+assert set(STREAMS) == {
+    "profile", "publications", "posts", "drafts", "comments", "reactions",
+    "followers", "following",
+}
+assert all(spec.cost_units == 2 and spec.transport == "graphql" for spec in STREAMS.values())
+assert len(ALLOWED_QUERIES) == 9
+for query in ALLOWED_QUERIES:
+    normalized = " ".join(query.split()).casefold()
+    assert normalized.startswith("query aidevopshashnode")
+    assert "mutation" not in normalized and "subscription" not in normalized
+
+
+class Headers:
+    def __init__(self, values=None):
+        self.values = values or {}
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+
+class Response:
+    status = 200
+
+    def __init__(self, payload, headers=None):
+        self.payload = json.dumps(payload).encode()
+        self.headers = Headers(headers)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def read(self, size=-1):
+        return self.payload[:size]
+
+
+class Opener:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    def open(self, request, timeout):
+        assert timeout == HTTP_TIMEOUT_SECONDS
+        assert "private-pat" not in request.full_url
+        assert "private-pat" not in (request.data or b"").decode()
+        self.requests.append(request)
+        return self.responses.pop(0)
+
+
+identity_payload = {"data": {"me": {
+    "id": UID, "username": "selected", "name": "Selected", "bio": None,
+    "tagline": None, "location": None, "dateJoined": "2024-01-01T00:00:00Z",
+}}}
+config = ProfileConfig("private-pat")
+opener = Opener([Response(identity_payload)])
+result = graphql_api(config, opener, IDENTITY_QUERY, {})
+assert result.status == 200
+assert opener.requests[0].method == "POST"
+assert opener.requests[0].full_url == GRAPHQL_URL
+assert opener.requests[0].get_header("Authorization") == "Bearer private-pat"
+
+for unsafe in (
+    "mutation Unsafe { publishPost(input: {}) { post { id } } }",
+    IDENTITY_QUERY + " ",
+):
+    try:
+        graphql_api(config, Opener([]), unsafe, {})
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("unallowlisted Hashnode GraphQL document was accepted")
+
+partial = {
+    "data": {"me": {"id": UID}},
+    "errors": [{"message": "redacted", "extensions": {"code": "FORBIDDEN"}}],
+}
+partial_result = graphql_api(config, Opener([Response(partial)]), IDENTITY_QUERY, {})
+assert partial_result.status == 403 and partial_result.payload == {}
+assert _graphql_error_status({"errors": [{"extensions": {"code": "NOT_FOUND"}}]}) == 404
+
+try:
+    graphql_api(
+        config,
+        Opener([Response({"data": {"me": identity_payload["data"]["me"]},
+                          "access_token": "must-not-persist"})]),
+        IDENTITY_QUERY,
+        {},
+    )
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("credential-shaped Hashnode response was accepted")
+
+request = PageRequest(
+    "publications", account_id(UID), UID, "selected", INSTANCE_ID, 1, None, 2,
+)
+
+
+def publication_payload(author_id=UID, author_name="selected", end="pub-cursor-1", has_next=True):
+    return {"data": {"me": {
+        "id": UID,
+        "username": "selected",
+        "publications": {
+            "edges": [{
+                "cursor": end,
+                "node": {
+                    "id": PUBLICATION,
+                    "title": "Owned publication",
+                    "url": "https://selected.hashnode.dev",
+                    "isTeam": False,
+                    "followersCount": 3,
+                    "about": {"text": "About"},
+                    "author": {"id": author_id, "username": author_name, "name": "Selected"},
+                },
+            }],
+            "pageInfo": {"endCursor": end, "hasNextPage": has_next},
+        },
+    }}}
+
+
+first = page(lambda *_args: ApiResult(200, publication_payload()), request)
+assert first["meta"]["complete"] is False
+checkpoint, complete = page_checkpoint(first, CursorState(None, None, False), request)
+assert not complete and checkpoint.next_cursor
+resumed = page_request(
+    "publications",
+    {"id": account_id(UID), "provider_account_id": UID,
+     "username": "selected", "instance_id": INSTANCE_ID},
+    CursorState(checkpoint.next_cursor, None, False),
+    2,
+)
+assert resumed.position == 2 and resumed.stop_at
+try:
+    page(lambda *_args: ApiResult(200, publication_payload()), resumed)
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("Hashnode cursor loop was accepted")
+
+try:
+    page(
+        lambda *_args: ApiResult(200, publication_payload(OTHER, "other", has_next=False)),
+        request,
+    )
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("Hashnode publication ownership mismatch was accepted")
+
+malformed = publication_payload(has_next=False)
+malformed["data"]["me"]["publications"]["edges"][0]["node"].pop("title")
+try:
+    page(lambda *_args: ApiResult(200, malformed), request)
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("malformed Hashnode publication was accepted")
+
+comment_request = PageRequest(
+    "comments", account_id(UID), UID, "selected", INSTANCE_ID, 1, None, 2,
+)
+
+
+def comments_payload(comment_end="comment-cursor-1", comments_next=True, posts_next=True):
+    return {"data": {"user": {
+        "id": UID,
+        "username": "selected",
+        "posts": {
+            "edges": [{
+                "cursor": "post-cursor-1",
+                "node": {
+                    "id": POST,
+                    "title": "Bounded post",
+                    "author": {"id": UID, "username": "selected"},
+                    "publication": {
+                        "id": PUBLICATION,
+                        "title": "Owned publication",
+                        "author": {"id": UID, "username": "selected"},
+                    },
+                    "comments": {
+                        "edges": [{
+                            "cursor": comment_end,
+                            "node": {
+                                "id": COMMENT,
+                                "dateAdded": "2026-08-02T10:00:00Z",
+                                "totalReactions": 1,
+                                "content": {"text": "Useful response"},
+                                "author": {"id": OTHER, "username": "reader", "name": "Reader"},
+                            },
+                        }],
+                        "pageInfo": {"endCursor": comment_end, "hasNextPage": comments_next},
+                    },
+                },
+            }],
+            "pageInfo": {"endCursor": "post-cursor-1", "hasNextPage": posts_next},
+        },
+    }}}
+
+
+comments_first = page(lambda *_args: ApiResult(200, comments_payload()), comment_request)
+comments_checkpoint, comments_complete = page_checkpoint(
+    comments_first, CursorState(None, None, False), comment_request
+)
+assert not comments_complete and comments_first["data"][0]["kind"] == "comment"
+comments_resumed = page_request(
+    "comments",
+    {"id": account_id(UID), "provider_account_id": UID,
+     "username": "selected", "instance_id": INSTANCE_ID},
+    CursorState(comments_checkpoint.next_cursor, None, False),
+    2,
+)
+comments_second = page(
+    lambda *_args: ApiResult(200, comments_payload("comment-cursor-2", False, True)),
+    comments_resumed,
+)
+assert comments_second["meta"]["complete"] is False
+assert comments_second["meta"]["next_cursor"] == _encode_route_state({
+    "outer_after": "post-cursor-1", "inner_after": None, "outer_id": None,
+})
+
+sources = [
+    path.read_text(encoding="utf-8")
+    for path in sorted(scripts.glob("_knowledge_social_hashnode*.py"))
+]
+trees = [ast.parse(source) for source in sources]
+request_calls = [
+    node for tree in trees for node in ast.walk(tree)
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    and node.func.id == "Request"
+]
+assert len(request_calls) == 1
+methods = {
+    keyword.value.value for node in request_calls for keyword in node.keywords
+    if keyword.arg == "method" and isinstance(keyword.value, ast.Constant)
+}
+assert methods == {"POST"}
+assert COMMENTS_QUERY in ALLOWED_QUERIES and PUBLICATIONS_QUERY in ALLOWED_QUERIES
+PY
+assert_eq "identity, ownership, fixed-query, nested cursor, and mutation boundaries are guarded" \
+	verified verified
+
+python3 - "$TMP_DIR/complete.json" "$ACCOUNT_ID" <<'PY'
+import json
+import sys
+
+sys.path.insert(0, ".agents/scripts")
+from _knowledge_social_hashnode_identity import INSTANCE_ID, account_id, namespaced_id
+
+uid = sys.argv[2]
+publication = "65c000000000000000000042"
+post = "65d000000000000000000042"
+author = {
+    "provider_account_id": uid,
+    "remote_id": namespaced_id("account", uid),
+    "username": "selected",
+    "name": "Selected",
+    "tagline": None,
+}
+payload = {
+    "identity": {"data": {
+        "id": account_id(uid),
+        "provider_account_id": uid,
+        "username": "selected",
+        "name": "Selected",
+        "bio": "Account bio",
+        "instance_id": INSTANCE_ID,
+    }},
+    "pages": [{
+        "expect_request": {"position": 1, "stop_at": None, "limit": 2},
+        "response": {
+            "status": 200,
+            "observed_at": "2026-08-02T10:00:00Z",
+            "data": [{
+                "kind": "post",
+                "remote_id": namespaced_id("post", post),
+                "post_id": post,
+                "title": "Bounded Hashnode knowledge",
+                "subtitle": None,
+                "slug": "bounded-hashnode-knowledge",
+                "url": "https://selected.hashnode.dev/bounded-hashnode-knowledge",
+                "brief": "Bounded fixture",
+                "markdown": "# Bounded Hashnode knowledge",
+                "text": "Bounded Hashnode knowledge",
+                "published_at": "2026-08-02T09:00:00Z",
+                "updated_at": None,
+                "reaction_count": 2,
+                "response_count": 1,
+                "reply_count": 0,
+                "author": author,
+                "publication": {
+                    "remote_id": namespaced_id("publication", publication),
+                    "publication_id": publication,
+                    "title": "Owned publication",
+                    "url": "https://selected.hashnode.dev",
+                },
+                "tags": [],
+            }],
+            "meta": {
+                "stream": "posts",
+                "instance_id": INSTANCE_ID,
+                "transport": "graphql",
+                "next_cursor": None,
+                "complete": True,
+                "snapshot": True,
+            },
+        },
+    }],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+result=$(run_hashnode "$TMP_DIR/complete.json" conn_hashnode posts 3 2)
+assert_eq "bounded Hashnode fixture completes" "$(json_field "$result" status)" complete
+assert_eq "viewer verification plus one page consume three query units" \
+	"$(json_field "$result" budget_units)" 3
+assert_eq "Hashnode post text reaches FTS" \
+	"$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'bounded'")" 1
+assert_eq "completed Hashnode snapshot records its checkpoint" \
+	"$(sql_value "SELECT coalesce(cursor,'done') || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_hashnode'")" \
+	"done:1"
+raw_complete=$(raw_count)
+run_hashnode "$TMP_DIR/complete.json" conn_hashnode posts 3 2 >/dev/null
+assert_eq "exact Hashnode replay keeps one normalized post" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='hashnode' AND object_type='post'")" 1
+assert_eq "exact Hashnode replay reuses immutable raw evidence" "$(raw_count)" "$raw_complete"
+
+python3 - "$TMP_DIR/mismatch.json" <<'PY'
+import json
+import sys
+
+payload = {"identity": {"data": {
+    "id": "wrong",
+    "provider_account_id": "65b000000000000000000000043",
+    "username": "other",
+    "instance_id": "hashnode-gql-beta",
+}}, "pages": []}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+raw_before=$(raw_count)
+expect_failure "selected-account identity mismatch is rejected" \
+	"$TMP_DIR/mismatch.json" conn_mismatch posts
+assert_eq "identity mismatch persists no raw evidence" "$(raw_count)" "$raw_before"
+
+python3 - "$TMP_DIR/credential.json" "$ACCOUNT_ID" <<'PY'
+import json
+import sys
+
+sys.path.insert(0, ".agents/scripts")
+from _knowledge_social_hashnode_identity import INSTANCE_ID, account_id
+
+uid = sys.argv[2]
+payload = {
+    "identity": {"data": {
+        "id": account_id(uid), "provider_account_id": uid,
+        "username": "selected", "instance_id": INSTANCE_ID,
+    }},
+    "pages": [{
+        "status": 200,
+        "observed_at": "2026-08-02T10:01:00Z",
+        "access_token": "must-not-persist",
+        "data": [],
+        "meta": {
+            "stream": "posts", "instance_id": INSTANCE_ID,
+            "transport": "graphql", "next_cursor": None,
+            "complete": True, "snapshot": True,
+        },
+    }],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+raw_before=$(raw_count)
+expect_failure "credential-shaped Hashnode page is rejected" \
+	"$TMP_DIR/credential.json" conn_credential posts
+assert_eq "credential rejection persists no raw evidence" "$(raw_count)" "$raw_before"
+
+python3 - "$TMP_DIR/paused.json" "$TMP_DIR/terminal.json" "$ACCOUNT_ID" <<'PY'
+import json
+import sys
+
+sys.path.insert(0, ".agents/scripts")
+from _knowledge_social_hashnode_identity import INSTANCE_ID, account_id
+from _knowledge_social_hashnode_routes import _encode_route_state
+
+uid = sys.argv[3]
+identity = {"data": {
+    "id": account_id(uid), "provider_account_id": uid,
+    "username": "selected", "instance_id": INSTANCE_ID,
+}}
+paused = {
+    "identity": identity,
+    "pages": [{
+        "status": 200,
+        "observed_at": "2026-08-02T10:02:00Z",
+        "data": [],
+        "meta": {
+            "stream": "posts", "instance_id": INSTANCE_ID,
+            "transport": "graphql",
+            "next_cursor": _encode_route_state({"after": "post-cursor-next"}),
+            "complete": False, "snapshot": True,
+        },
+    }],
+}
+terminal = {
+    "identity": identity,
+    "pages": [{
+        "expect_request": {"position": 2},
+        "response": {"status": 503, "observed_at": "2026-08-02T10:03:00Z"},
+    }],
+}
+for path, payload in ((sys.argv[1], paused), (sys.argv[2], terminal)):
+    with open(path, "w", encoding="utf-8") as target:
+        json.dump(payload, target)
+PY
+paused_result=$(run_hashnode "$TMP_DIR/paused.json" conn_terminal posts 3 2)
+assert_eq "bounded query budget checkpoints an incomplete page" \
+	"$(json_field "$paused_result" status)" budget_exhausted
+terminal_cursor_before=$(sql_value "SELECT cursor FROM sync_cursors WHERE connection_id='conn_terminal'")
+terminal_raw_before=$(raw_count)
+terminal_result=$(run_hashnode "$TMP_DIR/terminal.json" conn_terminal posts 3 2)
+assert_eq "terminal Hashnode response is classified" \
+	"$(json_field "$terminal_result" status)" failed
+assert_eq "terminal response preserves the prior checkpoint" \
+	"$(sql_value "SELECT cursor FROM sync_cursors WHERE connection_id='conn_terminal'")" \
+	"$terminal_cursor_before"
+assert_eq "terminal response appends diagnostics without replacing prior evidence" \
+	"$(raw_count)" "$((terminal_raw_before + 1))"
+
+python3 - "$ROOT" "$SCRIPT_DIR/../scripts" <<'PY'
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[2])
+from _knowledge_social_collect import (
+    CollectionContext,
+    ConnectionConfig,
+    CursorState,
+    PageCheckpoint,
+    SuccessfulPage,
+)
+from _knowledge_social_collect_persist import persist_page
+from _knowledge_social_hashnode import STREAMS
+from _knowledge_social_lease import (
+    RunLeaseRequest,
+    SocialLeaseLostError,
+    acquire_run_lease,
+    release_run_lease,
+)
+
+root = Path(sys.argv[1])
+old = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_hashnode_fence", "posts", "old_runner", "sync", 1),
+    now_epoch=9000,
+)
+new = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_hashnode_fence", "posts", "new_runner", "sync", 10),
+    now_epoch=9001,
+)
+context = CollectionContext(
+    root,
+    "conn_hashnode_fence",
+    {"id": "hnu_selected", "username": "selected"},
+    "posts",
+    "none",
+    ConnectionConfig(("posts",), {"media_hydration": "none"}),
+    CursorState(None, None, False),
+    STREAMS["posts"],
+    old,
+    "hashnode",
+)
+archive = {
+    "provider": "hashnode",
+    "connection_id": "conn_hashnode_fence",
+    "remote_account_id": "hnu_selected",
+    "exported_at": "2026-08-02T10:04:00Z",
+    "enabled_streams": ["posts"],
+    "policy": {"media_hydration": "none"},
+    "accounts": [],
+    "objects": [],
+    "activities": [],
+    "media": [],
+    "coverage": [],
+}
+page_data = SuccessfulPage(
+    {"status": 200, "observed_at": archive["exported_at"], "data": [], "meta": {}},
+    '{"stream":"posts"}',
+    archive,
+    PageCheckpoint(None, None),
+    True,
+    2,
+)
+os.environ["AIDEVOPS_SOCIAL_NOW_EPOCH"] = "9001"
+try:
+    persist_page(context, page_data)
+except SocialLeaseLostError:
+    pass
+else:
+    raise SystemExit("stale Hashnode collector advanced persistence")
+with sqlite3.connect(root / "index" / "social.db") as database:
+    cursor = database.execute(
+        "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_hashnode_fence'"
+    ).fetchone()[0]
+assert cursor == 0
+release_run_lease(root, new)
+PY
+assert_eq "stale Hashnode lease cannot commit evidence or a cursor" verified verified
+
+assert_eq "unsupported Hashnode private categories remain explicit gaps" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE connection_id='conn_hashnode' AND status IN ('partial','unavailable') AND stream IN ('authored_comments_elsewhere','reaction_history','comment_replies','messages','notifications','account_export')")" 6
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/tests/test-knowledge-social-registry.sh
+++ b/.agents/tests/test-knowledge-social-registry.sh
@@ -45,6 +45,7 @@ expected = {
     "forem": ("live",),
     "github": ("live",),
     "hacker-news": ("live",),
+    "hashnode": ("live",),
     "google-business-profile": ("live",),
     "gumroad": ("live",),
     "lemmy": ("live",),
@@ -100,14 +101,14 @@ except module.ProviderRegistryError:
 else:
     raise SystemExit("unknown provider used a fallback")
 
-print("18:order-independent:aliases-exact:collisions-rejected:no-fallback")
+print("19:order-independent:aliases-exact:collisions-rejected:no-fallback")
 PY
 )
 assert_eq "all merged provider outcomes register deterministically" \
-	"$registry_summary" "18:order-independent:aliases-exact:collisions-rejected:no-fallback"
+	"$registry_summary" "19:order-independent:aliases-exact:collisions-rejected:no-fallback"
 
 provider_count=$("$HELPER" providers | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
-assert_eq "helper exposes the complete provider registry" "$provider_count" "18"
+assert_eq "helper exposes the complete provider registry" "$provider_count" "19"
 
 forem_resolution=$("$HELPER" provider-resolve --provider dev-community |
 	python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["provider"] + ":" + ",".join(data["modes"]))')
@@ -118,6 +119,20 @@ if [[ "$hacker_news_help" == *"bounded public Hacker News submitted-item slice"*
 	assert_eq "Hacker News alias executes only the public local adapter" canonical canonical
 else
 	assert_eq "Hacker News alias executes only the public local adapter" unexpected canonical
+fi
+
+hashnode_help=$("$HELPER" provider-run --provider hashnode --mode live -- --help 2>&1)
+if [[ "$hashnode_help" == *"bounded, read-only Hashnode account stream"* ]]; then
+	assert_eq "Hashnode registry executes only the guarded local adapter" canonical canonical
+else
+	assert_eq "Hashnode registry executes only the guarded local adapter" unexpected canonical
+fi
+
+hashnode_sync_help=$("$HELPER" sync-hashnode --help 2>&1)
+if [[ "$hashnode_sync_help" == *"bounded, read-only Hashnode account stream"* ]]; then
+	assert_eq "Hashnode helper executes the same guarded local adapter" canonical canonical
+else
+	assert_eq "Hashnode helper executes the same guarded local adapter" unexpected canonical
 fi
 
 if "$HELPER" provider-run --provider binance-square --mode no-route >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Add authenticated, fixed-query Hashnode GraphQL collection for eight independently checkpointed account streams, with explicit export and unsupported-category gates.

## Files Changed

.agents/aidevops/knowledge-plane/05-social-operations.md, .agents/aidevops/knowledge-plane/06-social-provider-capabilities.md, .agents/content/social-hashnode.md, .agents/scripts/_knowledge_social_fixture.py, .agents/scripts/_knowledge_social_hashnode.py, .agents/scripts/_knowledge_social_hashnode_contract.py, .agents/scripts/_knowledge_social_hashnode_http.py, .agents/scripts/_knowledge_social_hashnode_identity.py, .agents/scripts/_knowledge_social_hashnode_normalize.py, .agents/scripts/_knowledge_social_hashnode_provider.py, .agents/scripts/_knowledge_social_hashnode_reader.py, .agents/scripts/_knowledge_social_hashnode_routes.py, .agents/scripts/_knowledge_social_oauth_request.py, .agents/scripts/knowledge-social-helper.sh, .agents/scripts/knowledge_social_hashnode.py, .agents/scripts/knowledge_social_registry.py, .agents/tests/test-knowledge-social-hashnode.sh, .agents/tests/test-knowledge-social-registry.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Hashnode 17/17, registry 11/11, social sync 35/35, and corpus 45/45 pass; changed Python compiles; ShellCheck and linters-local --changed pass; local Qlty new-file scan reports 0 smells and regression scan reports 60 to 60.

Resolves #29323


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 47m and 672,064 tokens on this as a headless worker.