### PR TITLE
GH#29321: add guarded Patreon account knowledge collection

### DIFF
--- a/.agents/aidevops/knowledge-plane/05-social-operations.md
+++ b/.agents/aidevops/knowledge-plane/05-social-operations.md
@@ -154,6 +154,16 @@ tag GET routes are reachable; each invocation is capped below the documented
 20-request/minute limit. Provider identity, deletion, complete export, and
 retention remain explicit gaps. Details: `.agents/content/social-readwise-reader.md`.
 
+Patreon collection binds API v2 `/identity` creator status to an explicit set of
+creator-owned campaigns before every page. Account, campaigns, posts, benefits
+and tiers, and current memberships have independent checkpoints. Posts require
+`campaigns.posts`; memberships additionally require `campaigns.members`, the
+exact `membership-services` purpose, and a local HMAC key. Member names, email,
+addresses, direct provider member IDs, and patron-owned memberships are never
+requested or persisted. The invocation cap is 99 requests, below the documented
+per-token minute limit. Creator CSV export remains unwired because Patreon does
+not publish a versioned import schema. Details: `.agents/content/social-patreon.md`.
+
 X collection uses the guarded official `xurl` helper. Reddit collection uses an
 optional PRAW 8 child. YouTube collection uses a standard-library HTTP child and
 OAuth user identity; it never reuses the service-account research helper:
@@ -174,6 +184,12 @@ aidevops secret YOUTUBE_PERSONAL_ACCESS_TOKEN -- \
   knowledge-social-helper.sh sync-youtube --alias personal:default \
   --connection-id YOUTUBE_CONNECTION_ID --account-id STABLE_CHANNEL_ID \
   --stream authored_videos --profile personal --budget 11 --page-size 50
+
+aidevops secret PATREON_CREATOR_ACCESS_TOKEN PATREON_CREATOR_CAMPAIGN_IDS \
+  PATREON_CREATOR_SCOPES -- \
+  knowledge-social-helper.sh sync-patreon --alias personal:default \
+  --connection-id PATREON_CONNECTION_ID --account-id CREATOR_USER_ID \
+  --stream posts --profile creator --budget 20 --page-size 100
 ```
 
 Every Reddit stream has an independent cursor. Authored content, inbox activity,
@@ -197,6 +213,15 @@ Later, saved third-party playlists, and complete authored-comment history remain
 explicit unavailable/export-unverified coverage. API metadata carries the current
 30-day refresh/delete retention boundary. Details and official evidence:
 `.agents/content/social-youtube.md`.
+
+Patreon profiles use `PATREON_<PROFILE>_ACCESS_TOKEN`,
+`PATREON_<PROFILE>_CAMPAIGN_IDS`, and `PATREON_<PROFILE>_SCOPES`. Base collection
+requires exactly the `identity` and `campaigns` read scopes plus only the optional
+stream scope. Membership collection also requires
+`PATREON_<PROFILE>_MEMBER_DATA_PURPOSE=membership-services` and a private
+`PATREON_<PROFILE>_PII_KEY` of at least 32 bytes. Token issuance and rotation stay
+outside the collector, and no Patreon write, webhook, browser, or patron-profile
+route is reachable.
 
 ## Approval-bound account operations
 

--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -38,6 +38,7 @@ a claim that the route is enabled.
 | Instagram | **Live/Gate/Export** Professional media | **No/Export** comments and saved activity | **No/Export** mentions | **No/Export** followers and following | **No/Export** saved collections | One Page-connected Business/Creator `/media` stream; personal accounts and unimplemented per-media edges remain explicit. |
 | Threads | **Live/Gate/Export** posts | **No/Export** likes and repost history | **Live/Gate/Export** authored replies and mentions; **No** messages | **No/Export** followers and following | **No** custom feeds | Three product-scoped streams with app-scoped identity, independent cursors, and stream-specific permission gates. |
 | Medium | **Live/Export** authored posts; **Live/Partial** explicit responses | **Live/Export/No** bookmarks, claps, highlights, and list membership when present | **No** | **Live/Export/No** publication membership and follows when present | **Live/Export/No** owned lists when present | Identity-verified native HTML ZIP import with exact replay, bounded local parsing, and per-archive complete/unavailable coverage; legacy API access is not live parity. |
+| Patreon | **Live/Gate** creator campaign posts | **No** patron curation or creator-side interaction history | **No** messages, comments, or mentions | **Live/Gate** minimized current creator memberships; **No** patron-owned memberships or subscriptions | **Live** creator campaigns, tiers, and benefits | Creator-owned campaign allowlist, exact read scopes, identity and ownership recheck, 99-request cap, opaque cursors, and a membership-services purpose gate; no patron-account collection. |
 | Quora | **Export/No** answers, questions, posts, and comments | **Export/No** bookmarks; **No** upvotes and other curation | **No** | **Export/No** user follows; **No** followed topics or Spaces | **No** | The official export has no published schema. Public content samples lack authoritative owner identity, and the companion account-data schema is unpublished; no adapter or CLI route is enabled. |
 | Skool | **No** posts, comments, and course content | **No** reactions and saved state | **No** notifications and messages | **No** memberships, follows, and groups | **No** courses and calendar feeds | **Export/No** admin membership-question answers only. The official Zapier surface is narrow event automation, the export schema and identity contract are unpublished, and provider policy excludes browser collection. |
 | Substack | **Export/No** publication posts; **No** Notes | **No** comments, likes, restacks, or saved Notes | **No** | **No** reader subscriptions or publication memberships | **No** | Creator ZIP/CSV exports lack published identity/schema contracts; public RSS is not account history, and **Gate/No** bestseller analytics require interactive MCP sign-in and consent. No adapter or CLI route is enabled. |
@@ -143,6 +144,16 @@ separate provider family.
   `.agents/content/social-medium.md` records the official HTML-ZIP export,
   unsupported legacy API, terms, retention, historical community schema
   evidence, and unverified categories checked on 2026-07-28.
+- **Live/Gated Patreon creator data:**
+  `.agents/scripts/knowledge_social_patreon.py`,
+  `.agents/scripts/_knowledge_social_patreon*.py`, and
+  `.agents/tests/test-knowledge-social-patreon.sh` prove selected creator and
+  campaign ownership, exact read-scope policy, five independent streams,
+  cursor-loop rejection, the 99-request fuse, member-data purpose and HMAC
+  minimization, terminal coverage, credential rejection, stale-lease fencing,
+  GET-only transport, and atomic persistence. `.agents/content/social-patreon.md`
+  records the current API v2, rate, creator-export, privacy-purpose, role, and
+  unsupported-category evidence checked on 2026-08-02.
 - **Live Discourse:** `.agents/scripts/knowledge_social_discourse.py`,
   `.agents/scripts/_knowledge_social_discourse*.py`, and
   `.agents/tests/test-knowledge-social-discourse.sh` prove ten independently

--- a/.agents/content/social-patreon.md
+++ b/.agents/content/social-patreon.md
@@ -1,0 +1,113 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Patreon Creator Account Knowledge Collection
+
+Checked 2026-08-02 against Patreon's official developer documentation, creator
+portal, export guidance, support material, and legal policies.
+
+## Implemented boundary
+
+`knowledge-social-helper.sh sync-patreon` collects bounded API v2 evidence only
+for explicitly selected campaigns owned by the authenticated creator. Patreon
+users can be both patrons and creators, so creator status alone is insufficient:
+the child verifies `/identity`, fetches the authenticated user's campaigns, and
+proves every configured campaign is owned before the first page and before every
+later page.
+
+API v1 client creation was restricted and deprecated on 2026-03-25. The collector
+uses only the current API v2 root and Python standard-library HTTP; no Patreon
+client package is installed or required. Redirects and every method except `GET`
+are unreachable.
+
+Configure one lowercase profile with:
+
+- `PATREON_<PROFILE>_ACCESS_TOKEN`;
+- `PATREON_<PROFILE>_CAMPAIGN_IDS`, containing 1-20 comma-separated numeric IDs;
+- `PATREON_<PROFILE>_SCOPES`, containing `identity campaigns` and only an optional
+  stream scope described below.
+
+Token issuance, refresh, and rotation happen outside the collector. A typical
+creator-post run is:
+
+```bash
+aidevops secret PATREON_CREATOR_ACCESS_TOKEN PATREON_CREATOR_CAMPAIGN_IDS \
+  PATREON_CREATOR_SCOPES -- \
+  knowledge-social-helper.sh sync-patreon --alias personal:default \
+  --connection-id PATREON_CONNECTION_ID --account-id CREATOR_USER_ID \
+  --stream posts --profile creator --budget 20 --page-size 100
+```
+
+## Streams and permissions
+
+| Stream | API v2 evidence | Additional gate |
+|---|---|---|
+| `account` | Selected creator role and configured owned campaign IDs | Base `identity campaigns` scopes |
+| `campaigns` | Creator-owned campaign metadata | Base scopes |
+| `posts` | Campaign posts visible to the creator token | `campaigns.posts` |
+| `benefits` | Campaign benefits and related tier metadata | Base scopes |
+| `memberships` | Minimized current entitlement and tier state | `campaigns.members`, purpose, and HMAC key |
+
+The exact accepted scope set is `identity`, `campaigns`, `campaigns.posts`, and
+`campaigns.members`. Sensitive identity/member email and address scopes, every
+write-prefixed scope, duplicate scopes, and unknown scopes fail before a provider
+request. The adapter never accesses the authenticated user's patron memberships.
+
+## Membership-purpose and PII gate
+
+Patreon's creator privacy terms limit member data to providing and administering
+membership services. The `memberships` stream therefore remains gated unless all
+of these are present:
+
+- `campaigns.members` in the selected profile's exact scope list;
+- `PATREON_<PROFILE>_MEMBER_DATA_PURPOSE=membership-services`;
+- a private `PATREON_<PROFILE>_PII_KEY` containing at least 32 bytes.
+
+The key converts each direct member ID to a provider-local keyed HMAC identifier.
+Only current entitlement amount, free-trial/gift state, patron status, pledge
+cadence, and entitled tier IDs are accepted. Names, email addresses, postal
+addresses, direct member IDs, and unexpected member attributes are rejected and
+cannot enter raw or normalized evidence. Membership rows are marked protected
+business evidence, not general social relationships.
+
+## Pagination, budgets, and persistence
+
+Patreon documents cursor pagination through `page[count]`, `page[cursor]`, and
+`meta.pagination.cursors.next`. Each stream owns an independent checkpoint. The
+cursor envelope also carries the selected campaign and a bounded history of
+cursor hashes; a repeated cursor fails instead of looping. Multi-campaign streams
+advance through only the explicit campaign allowlist.
+
+The documented limits include 100 requests per minute per access token and 100
+requests per two seconds per client, with additional edge limits for repeated bad
+requests. One invocation is capped at 99 requests and each page is capped at 100
+items. `429` evidence preserves a bounded `Retry-After` value and stops without
+advancing the checkpoint.
+
+Every successful page stores its request boundary, raw response, normalized rows,
+coverage, receipt, and next cursor atomically under the final lease fence. A
+malformed, unauthorized, unavailable, rate-limited, looping, or stale-lease page
+cannot advance beyond the last coherent checkpoint.
+
+## Explicit gaps
+
+- Patron-owned memberships, subscriptions, followed creators, and patron payment
+  history are not collected. `identity.memberships` is deliberately rejected.
+- Comments, direct messages, mentions, likes, curation, lives, webhooks, and every
+  mutation route have no collector path.
+- Current API visibility is not represented as complete historical, deletion, or
+  retention coverage.
+- Patreon documents creator pledge-data CSV export, but publishes no stable,
+  versioned schema and selected-account binding suitable for this importer. No CSV
+  or browser route is enabled.
+- Member information remains purpose-limited and deletable even though raw fetch
+  evidence is content-addressed; local immutability does not override provider
+  privacy or legal obligations.
+
+## Official references
+
+- <https://docs.patreon.com>
+- <https://www.patreon.com/portal>
+- <https://www.patreon.com/portal/how-to/export-pledge-data>
+- <https://www.patreon.com/policy/legal>
+- <https://support.patreon.com/hc/en-us/articles/360026912432>

--- a/.agents/scripts/_knowledge_social_patreon.py
+++ b/.agents/scripts/_knowledge_social_patreon.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Patreon creator identity, stream policy, and opaque cursor checkpoints."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from knowledge_social_import import canonical_json, reject_credentials
+
+PROVIDER = "patreon"
+CURSOR_PREFIX = "patreon-v2:"
+RETENTION_LIMIT = "current_api_visibility_and_creator_privacy_purpose"
+OPAQUE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,159}$")
+CAMPAIGN_ID = re.compile(r"^[1-9][0-9]{0,31}$")
+MAX_CURSOR_BYTES = 4096
+MAX_CURSOR_HISTORY = 256
+
+
+class PatreonAdapterError(RuntimeError):
+    """Raised when Patreon evidence violates the local collector contract."""
+
+
+class PatreonProviderUnavailableError(PatreonAdapterError):
+    """Raised when the isolated Patreon reader cannot run safely."""
+
+
+ADAPTER_ERROR = PatreonAdapterError
+PROVIDER_UNAVAILABLE_ERROR = PatreonProviderUnavailableError
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    """Static collection and coverage policy for one Patreon stream."""
+
+    resource_kind: str
+    activity_mode: str
+    pagination: str
+    incremental: bool
+    retention_limit: str | None
+    coverage_status: str | None = None
+    unavailable_reason: str | None = None
+    cost_units: int = 3
+
+
+STREAMS = {
+    "account": StreamSpec("creator_account", "selected_account", "snapshot", False, RETENTION_LIMIT),
+    "campaigns": StreamSpec("campaign", "creator_campaign", "campaign_sequence", False, RETENTION_LIMIT),
+    "posts": StreamSpec("post", "creator_post", "cursor", False, RETENTION_LIMIT),
+    "memberships": StreamSpec("membership", "current_entitlement", "cursor", False, RETENTION_LIMIT),
+    "benefits": StreamSpec("benefit", "campaign_benefit", "campaign_sequence", False, RETENTION_LIMIT),
+}
+
+
+def provider_id(value: Any, field: str = "ID") -> str:
+    """Validate one opaque Patreon identifier without exposing it in errors."""
+    if not isinstance(value, str) or OPAQUE_ID.fullmatch(value) is None:
+        raise PatreonAdapterError(f"Patreon {field} is invalid")
+    return value
+
+
+def campaign_id(value: Any, field: str = "campaign ID") -> str:
+    """Validate one documented numeric Patreon campaign identifier."""
+    if not isinstance(value, str) or CAMPAIGN_ID.fullmatch(value) is None:
+        raise PatreonAdapterError(f"Patreon {field} is invalid")
+    return value
+
+
+def selected_campaign_ids(value: Any) -> tuple[str, ...]:
+    """Validate the explicit creator-owned campaign allowlist."""
+    if not isinstance(value, (list, tuple)) or not 1 <= len(value) <= 20:
+        raise PatreonAdapterError("Patreon selected campaigns must contain 1-20 IDs")
+    selected = tuple(campaign_id(item, "selected campaign ID") for item in value)
+    if len(selected) != len(set(selected)):
+        raise PatreonAdapterError("Patreon selected campaigns contain duplicates")
+    return tuple(sorted(selected, key=int))
+
+
+def _optional_cursor(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if (
+        not isinstance(value, str)
+        or not value
+        or "\x00" in value
+        or len(value.encode()) > MAX_CURSOR_BYTES
+    ):
+        raise PatreonAdapterError(f"Patreon {field} is invalid")
+    return value
+
+
+def _cursor_digest(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _encode_cursor(campaign: str, cursor: str | None, seen: tuple[str, ...]) -> str:
+    payload = {"campaign_id": campaign, "cursor": cursor, "seen": list(seen)}
+    encoded = base64.urlsafe_b64encode(canonical_json(payload).encode()).decode().rstrip("=")
+    return f"{CURSOR_PREFIX}{encoded}"
+
+
+def _decode_cursor(value: str) -> tuple[str, str | None, tuple[str, ...]]:
+    if not value.startswith(CURSOR_PREFIX) or len(value.encode()) > 32 * 1024:
+        raise PatreonAdapterError("stored Patreon cursor has an unsupported version")
+    encoded = value.removeprefix(CURSOR_PREFIX)
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4)))
+    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+        raise PatreonAdapterError("stored Patreon cursor is invalid") from error
+    if not isinstance(payload, dict) or set(payload) != {"campaign_id", "cursor", "seen"}:
+        raise PatreonAdapterError("stored Patreon cursor has an invalid shape")
+    reject_credentials(payload)
+    campaign = campaign_id(payload.get("campaign_id"), "cursor campaign ID")
+    cursor = _optional_cursor(payload.get("cursor"), "cursor value")
+    seen_value = payload.get("seen")
+    if (
+        not isinstance(seen_value, list)
+        or len(seen_value) > MAX_CURSOR_HISTORY
+        or any(not isinstance(item, str) or not re.fullmatch(r"[0-9a-f]{64}", item) for item in seen_value)
+        or len(seen_value) != len(set(seen_value))
+    ):
+        raise PatreonAdapterError("stored Patreon cursor history is invalid")
+    seen = tuple(seen_value)
+    if cursor is None and seen:
+        raise PatreonAdapterError("stored Patreon campaign cursor history is inconsistent")
+    if cursor is not None and _cursor_digest(cursor) not in seen:
+        raise PatreonAdapterError("stored Patreon cursor history is incomplete")
+    return campaign, cursor, seen
+
+
+@dataclass(frozen=True)
+class PageRequest:
+    """Allowlisted request passed to the isolated Patreon HTTP child."""
+
+    stream: str
+    account_id: str
+    campaign_ids: tuple[str, ...]
+    campaign_id: str | None
+    cursor: str | None
+    seen_cursors: tuple[str, ...]
+    limit: int
+    member_data_authorized: bool
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "page",
+            "stream": self.stream,
+            "account_id": self.account_id,
+            "campaign_ids": list(self.campaign_ids),
+            "campaign_id": self.campaign_id,
+            "cursor": self.cursor,
+            "seen_cursors": list(self.seen_cursors),
+            "limit": self.limit,
+            "member_data_authorized": self.member_data_authorized,
+        }
+
+    def evidence_key(self) -> str:
+        return canonical_json(self.payload())
+
+
+def _request_campaign(
+    stream: str, campaigns: tuple[str, ...], state: CursorState
+) -> tuple[str | None, str | None, tuple[str, ...]]:
+    if stream == "account":
+        if state.cursor is not None:
+            raise PatreonAdapterError("Patreon account stream cannot use a campaign cursor")
+        return None, None, ()
+    if state.cursor is None:
+        return campaigns[0], None, ()
+    selected, cursor, seen = _decode_cursor(state.cursor)
+    if selected not in campaigns:
+        raise PatreonAdapterError("stored Patreon cursor targets an unselected campaign")
+    return selected, cursor, seen
+
+
+def page_request(stream: str, account: dict[str, Any], state: CursorState, limit: int) -> PageRequest:
+    """Build one request from an independent per-stream checkpoint."""
+    if stream not in STREAMS:
+        raise PatreonAdapterError("Patreon stream is unsupported")
+    account_id = provider_id(account.get("id"), "selected account ID")
+    remote_id = provider_id(account.get("provider_account_id"), "provider account ID")
+    if account_id != remote_id:
+        raise PatreonAdapterError("selected Patreon account does not match the configured connection")
+    campaigns = selected_campaign_ids(account.get("campaign_ids"))
+    authorized = account.get("member_data_authorized")
+    if not isinstance(authorized, bool):
+        raise PatreonAdapterError("Patreon member-data authorization is invalid")
+    if stream == "memberships" and not authorized:
+        raise PatreonAdapterError("Patreon memberships require the membership-services purpose gate")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 100:
+        raise PatreonAdapterError("Patreon page safety limit is invalid")
+    selected, cursor, seen = _request_campaign(stream, campaigns, state)
+    return PageRequest(stream, account_id, campaigns, selected, cursor, seen, limit, authorized)
+
+
+def parse_page_request(payload: dict[str, Any]) -> PageRequest:
+    """Validate the exact child-process page request shape."""
+    expected = {
+        "action", "stream", "account_id", "campaign_ids", "campaign_id",
+        "cursor", "seen_cursors", "limit", "member_data_authorized",
+    }
+    if set(payload) != expected or payload.get("action") != "page":
+        raise PatreonAdapterError("Patreon read request has an invalid action shape")
+    stream = payload.get("stream")
+    if not isinstance(stream, str) or stream not in STREAMS:
+        raise PatreonAdapterError("Patreon stream is unsupported")
+    account = provider_id(payload.get("account_id"), "selected account ID")
+    campaigns = selected_campaign_ids(payload.get("campaign_ids"))
+    selected = payload.get("campaign_id")
+    if stream == "account":
+        if selected is not None:
+            raise PatreonAdapterError("Patreon account request cannot select a campaign")
+    else:
+        selected = campaign_id(selected, "request campaign ID")
+        if selected not in campaigns:
+            raise PatreonAdapterError("Patreon read request targets an unselected campaign")
+    cursor = _optional_cursor(payload.get("cursor"), "request cursor")
+    seen_value = payload.get("seen_cursors")
+    if not isinstance(seen_value, list):
+        raise PatreonAdapterError("Patreon request cursor history must be an array")
+    seen = tuple(seen_value)
+    if len(seen) > MAX_CURSOR_HISTORY or len(seen) != len(set(seen)):
+        raise PatreonAdapterError("Patreon request cursor history is invalid")
+    if any(not isinstance(item, str) or not re.fullmatch(r"[0-9a-f]{64}", item) for item in seen):
+        raise PatreonAdapterError("Patreon request cursor history is invalid")
+    if cursor is None and seen:
+        raise PatreonAdapterError("Patreon request cursor history is inconsistent")
+    if cursor is not None and _cursor_digest(cursor) not in seen:
+        raise PatreonAdapterError("Patreon request cursor history is incomplete")
+    limit = payload.get("limit")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 100:
+        raise PatreonAdapterError("Patreon page safety limit is invalid")
+    authorized = payload.get("member_data_authorized")
+    if not isinstance(authorized, bool) or (stream == "memberships" and not authorized):
+        raise PatreonAdapterError("Patreon member-data authorization is invalid")
+    return PageRequest(stream, account, campaigns, selected, cursor, seen, limit, authorized)
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise PatreonAdapterError("Patreon response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise PatreonAdapterError("Patreon page data must be an array")
+    return data
+
+
+def _next_campaign(request: PageRequest) -> str | None:
+    if request.campaign_id is None:
+        return None
+    index = request.campaign_ids.index(request.campaign_id)
+    return request.campaign_ids[index + 1] if index + 1 < len(request.campaign_ids) else None
+
+
+def page_checkpoint(
+    payload: dict[str, Any], state: CursorState, request: PageRequest
+) -> tuple[PageCheckpoint, bool]:
+    """Validate cursor progress before an atomic evidence/checkpoint commit."""
+    data = page_data(payload)
+    if len(data) > request.limit:
+        raise PatreonAdapterError("Patreon page exceeds the item safety limit")
+    meta = payload.get("meta")
+    expected = {"stream", "campaign_id", "next_cursor", "next_campaign_id", "complete"}
+    if not isinstance(meta, dict) or set(meta) != expected or meta.get("stream") != request.stream:
+        raise PatreonAdapterError("Patreon page provenance is invalid")
+    reject_credentials(meta)
+    if meta.get("campaign_id") != request.campaign_id:
+        raise PatreonAdapterError("Patreon page campaign does not match the selected campaign")
+    complete = meta.get("complete")
+    if not isinstance(complete, bool):
+        raise PatreonAdapterError("Patreon page completion metadata is invalid")
+    next_cursor = _optional_cursor(meta.get("next_cursor"), "next cursor")
+    next_campaign_value = meta.get("next_campaign_id")
+    next_campaign = (
+        campaign_id(next_campaign_value, "next campaign ID")
+        if next_campaign_value is not None
+        else None
+    )
+    if complete:
+        if next_cursor is not None or next_campaign is not None:
+            raise PatreonAdapterError("completed Patreon page cannot retain a cursor")
+        return PageCheckpoint(None, state.watermark), True
+    if (next_cursor is None) == (next_campaign is None):
+        raise PatreonAdapterError("Patreon page requires exactly one advancing cursor")
+    if next_campaign is not None:
+        if next_campaign != _next_campaign(request):
+            raise PatreonAdapterError("Patreon page did not advance to the next selected campaign")
+        return PageCheckpoint(_encode_cursor(next_campaign, None, ()), state.watermark), False
+    assert next_cursor is not None
+    digest = _cursor_digest(next_cursor)
+    if digest in request.seen_cursors:
+        raise PatreonAdapterError("Patreon pagination cursor loop was detected")
+    if len(request.seen_cursors) >= MAX_CURSOR_HISTORY:
+        raise PatreonAdapterError("Patreon pagination exceeds the cursor history safety limit")
+    seen = (*request.seen_cursors, digest)
+    assert request.campaign_id is not None
+    return PageCheckpoint(
+        _encode_cursor(request.campaign_id, next_cursor, seen), state.watermark
+    ), False

--- a/.agents/scripts/_knowledge_social_patreon_contract.py
+++ b/.agents/scripts/_knowledge_social_patreon_contract.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Strict JSON:API validation and privacy-minimized Patreon records."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from typing import Any
+
+from _knowledge_social_patreon import (
+    MAX_CURSOR_BYTES,
+    PatreonAdapterError,
+    campaign_id,
+    provider_id,
+)
+from knowledge_social_import import reject_credentials
+
+DOCUMENT_KEYS = frozenset({"data", "included", "links", "meta", "jsonapi"})
+RESOURCE_KEYS = frozenset({"attributes", "id", "links", "relationships", "type"})
+IDENTIFIER_KEYS = frozenset({"id", "meta", "type"})
+
+CAMPAIGN_ATTRIBUTES = frozenset(
+    {
+        "created_at",
+        "creation_name",
+        "currency",
+        "is_monthly",
+        "is_nsfw",
+        "name",
+        "patron_count",
+        "published_at",
+        "summary",
+        "url",
+    }
+)
+POST_ATTRIBUTES = frozenset(
+    {"content", "is_paid", "is_public", "published_at", "title", "url"}
+)
+BENEFIT_ATTRIBUTES = frozenset(
+    {
+        "benefit_type",
+        "created_at",
+        "description",
+        "is_deleted",
+        "is_ended",
+        "is_published",
+        "title",
+    }
+)
+TIER_ATTRIBUTES = frozenset(
+    {
+        "amount_cents",
+        "created_at",
+        "description",
+        "edited_at",
+        "published",
+        "published_at",
+        "requires_shipping",
+        "title",
+        "url",
+    }
+)
+MEMBER_ATTRIBUTES = frozenset(
+    {
+        "currently_entitled_amount_cents",
+        "is_free_trial",
+        "is_gifted",
+        "patron_status",
+        "pledge_cadence",
+    }
+)
+
+
+def object_value(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise PatreonAdapterError(f"Patreon {field} must be an object")
+    return value
+
+
+def array_value(value: Any, field: str, limit: int = 1000) -> list[Any]:
+    if not isinstance(value, list) or len(value) > limit:
+        raise PatreonAdapterError(f"Patreon {field} must be a bounded array")
+    return value
+
+
+def _document(payload: Any) -> dict[str, Any]:
+    root = object_value(payload, "response")
+    reject_credentials(root)
+    if not set(root).issubset(DOCUMENT_KEYS) or "data" not in root:
+        raise PatreonAdapterError("Patreon response has an unsupported JSON:API shape")
+    return root
+
+
+def _attributes(resource: dict[str, Any], allowed: frozenset[str]) -> dict[str, Any]:
+    attributes = resource.get("attributes", {})
+    if not isinstance(attributes, dict) or not set(attributes).issubset(allowed):
+        raise PatreonAdapterError("Patreon resource contains unrequested attributes")
+    reject_credentials(attributes)
+    return attributes
+
+
+def _resource(
+    value: Any,
+    resource_type: str,
+    allowed_attributes: frozenset[str],
+    allowed_relationships: frozenset[str] = frozenset(),
+) -> tuple[str, dict[str, Any], dict[str, Any]]:
+    resource = object_value(value, f"{resource_type} resource")
+    if not set(resource).issubset(RESOURCE_KEYS) or resource.get("type") != resource_type:
+        raise PatreonAdapterError(f"Patreon {resource_type} resource has an invalid shape")
+    remote_id = provider_id(resource.get("id"), f"{resource_type} ID")
+    attributes = _attributes(resource, allowed_attributes)
+    relationships = resource.get("relationships", {})
+    if not isinstance(relationships, dict) or not set(relationships).issubset(
+        allowed_relationships
+    ):
+        raise PatreonAdapterError(
+            f"Patreon {resource_type} resource contains unrequested relationships"
+        )
+    return remote_id, attributes, relationships
+
+
+def _identifier(value: Any, resource_type: str) -> str:
+    identifier = object_value(value, f"{resource_type} relationship identifier")
+    if not set(identifier).issubset(IDENTIFIER_KEYS) or identifier.get("type") != resource_type:
+        raise PatreonAdapterError(
+            f"Patreon {resource_type} relationship identifier is invalid"
+        )
+    return provider_id(identifier.get("id"), f"{resource_type} relationship ID")
+
+
+def _relationship_ids(
+    relationships: dict[str, Any],
+    name: str,
+    resource_type: str,
+    *,
+    required: bool = False,
+) -> tuple[str, ...]:
+    relation = relationships.get(name)
+    if relation is None:
+        if required:
+            raise PatreonAdapterError(f"Patreon {name} relationship is missing")
+        return ()
+    relation_object = object_value(relation, f"{name} relationship")
+    if not set(relation_object).issubset({"data", "links", "meta"}) or "data" not in relation_object:
+        raise PatreonAdapterError(f"Patreon {name} relationship has an invalid shape")
+    data = relation_object["data"]
+    values = data if isinstance(data, list) else ([] if data is None else [data])
+    identifiers = tuple(_identifier(item, resource_type) for item in values)
+    if len(identifiers) != len(set(identifiers)):
+        raise PatreonAdapterError(f"Patreon {name} relationship contains duplicates")
+    return identifiers
+
+
+def _optional_text(value: Any, field: str, maximum: int = 64 * 1024) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value or len(value.encode()) > maximum:
+        raise PatreonAdapterError(f"Patreon {field} must be bounded text")
+    return value
+
+
+def _optional_integer(value: Any, field: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise PatreonAdapterError(f"Patreon {field} must be an integer")
+    return value
+
+
+def _optional_boolean(value: Any, field: str) -> bool | None:
+    if value is not None and not isinstance(value, bool):
+        raise PatreonAdapterError(f"Patreon {field} must be a boolean")
+    return value
+
+
+def _next_cursor(root: dict[str, Any]) -> str | None:
+    meta = root.get("meta")
+    if meta is None:
+        return None
+    metadata = object_value(meta, "pagination metadata")
+    pagination = metadata.get("pagination")
+    if pagination is None:
+        return None
+    page = object_value(pagination, "pagination")
+    cursors = page.get("cursors")
+    if cursors is None:
+        return None
+    values = object_value(cursors, "pagination cursors")
+    cursor = values.get("next")
+    if cursor is None:
+        return None
+    if (
+        not isinstance(cursor, str)
+        or not cursor
+        or "\x00" in cursor
+        or len(cursor.encode()) > MAX_CURSOR_BYTES
+    ):
+        raise PatreonAdapterError("Patreon next pagination cursor is invalid")
+    return cursor
+
+
+def identity_record(payload: Any, expected_id: str) -> dict[str, Any]:
+    """Validate the minimal identity response and require an active creator role."""
+    root = _document(payload)
+    remote_id, attributes, relationships = _resource(
+        root.get("data"), "user", frozenset({"is_creator"})
+    )
+    if relationships:
+        raise PatreonAdapterError("Patreon identity returned unrequested relationships")
+    if remote_id != provider_id(expected_id, "selected account ID"):
+        raise PatreonAdapterError(
+            "selected Patreon account does not match the configured connection"
+        )
+    if attributes.get("is_creator") is not True:
+        raise PatreonAdapterError("selected Patreon account is not an active creator")
+    if root.get("included") not in (None, []):
+        raise PatreonAdapterError("Patreon identity returned unrequested includes")
+    return {
+        "kind": "creator_account",
+        "remote_id": f"creator_account_{remote_id}",
+        "is_creator": True,
+    }
+
+
+def owned_campaign_ids(payload: Any) -> tuple[tuple[str, ...], str | None]:
+    """Validate the bounded list of campaigns owned by the authorized user."""
+    root = _document(payload)
+    data = array_value(root.get("data"), "campaign ownership data", 1000)
+    identifiers = []
+    for value in data:
+        remote_id, attributes, relationships = _resource(
+            value, "campaign", frozenset()
+        )
+        if attributes or relationships:
+            raise PatreonAdapterError(
+                "Patreon campaign ownership response was not identity-minimized"
+            )
+        identifiers.append(campaign_id(remote_id))
+    if len(identifiers) != len(set(identifiers)):
+        raise PatreonAdapterError("Patreon campaign ownership response contains duplicates")
+    if root.get("included") not in (None, []):
+        raise PatreonAdapterError("Patreon campaign ownership returned unrequested includes")
+    return tuple(identifiers), _next_cursor(root)
+
+
+def _campaign_values(attributes: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "created_at": _optional_text(attributes.get("created_at"), "campaign created_at"),
+        "creation_name": _optional_text(attributes.get("creation_name"), "campaign creation_name"),
+        "currency": _optional_text(attributes.get("currency"), "campaign currency", 32),
+        "is_monthly": _optional_boolean(attributes.get("is_monthly"), "campaign is_monthly"),
+        "is_nsfw": _optional_boolean(attributes.get("is_nsfw"), "campaign is_nsfw"),
+        "name": _optional_text(attributes.get("name"), "campaign name"),
+        "patron_count": _optional_integer(attributes.get("patron_count"), "campaign patron_count"),
+        "published_at": _optional_text(attributes.get("published_at"), "campaign published_at"),
+        "summary": _optional_text(attributes.get("summary"), "campaign summary", 2 * 1024 * 1024),
+        "url": _optional_text(attributes.get("url"), "campaign URL"),
+    }
+
+
+def campaign_record(payload: Any, expected_campaign_id: str) -> dict[str, Any]:
+    """Validate one selected creator-owned campaign detail response."""
+    root = _document(payload)
+    remote_id, attributes, relationships = _resource(
+        root.get("data"), "campaign", CAMPAIGN_ATTRIBUTES
+    )
+    expected = campaign_id(expected_campaign_id)
+    if remote_id != expected or relationships:
+        raise PatreonAdapterError("Patreon campaign detail does not match the selected campaign")
+    if root.get("included") not in (None, []):
+        raise PatreonAdapterError("Patreon campaign detail returned unrequested includes")
+    return {"kind": "campaign", "remote_id": f"campaign_{remote_id}", "campaign_id": remote_id, **_campaign_values(attributes)}
+
+
+def _campaign_relationship(
+    relationships: dict[str, Any], expected_campaign_id: str
+) -> None:
+    if "campaign" not in relationships:
+        return
+    identifiers = _relationship_ids(relationships, "campaign", "campaign", required=True)
+    if identifiers != (campaign_id(expected_campaign_id),):
+        raise PatreonAdapterError("Patreon resource belongs to an unselected campaign")
+
+
+def post_records(payload: Any, expected_campaign_id: str) -> tuple[list[dict[str, Any]], str | None]:
+    """Validate a creator post page without requesting author/member identity."""
+    root = _document(payload)
+    campaign = campaign_id(expected_campaign_id)
+    records = []
+    for value in array_value(root.get("data"), "post data"):
+        remote_id, attributes, relationships = _resource(
+            value, "post", POST_ATTRIBUTES, frozenset({"campaign"})
+        )
+        _campaign_relationship(relationships, campaign)
+        records.append(
+            {
+                "kind": "post",
+                "remote_id": f"post_{remote_id}",
+                "campaign_id": campaign,
+                "content": _optional_text(attributes.get("content"), "post content", 2 * 1024 * 1024),
+                "is_paid": _optional_boolean(attributes.get("is_paid"), "post is_paid"),
+                "is_public": _optional_boolean(attributes.get("is_public"), "post is_public"),
+                "published_at": _optional_text(attributes.get("published_at"), "post published_at"),
+                "title": _optional_text(attributes.get("title"), "post title"),
+                "url": _optional_text(attributes.get("url"), "post URL"),
+            }
+        )
+    if root.get("included") not in (None, []):
+        raise PatreonAdapterError("Patreon posts returned unrequested includes")
+    return records, _next_cursor(root)
+
+
+def _included_resources(
+    root: dict[str, Any], allowed: dict[str, frozenset[str]]
+) -> dict[tuple[str, str], tuple[dict[str, Any], dict[str, Any]]]:
+    included = root.get("included", [])
+    values = array_value(included, "included resources")
+    resources: dict[tuple[str, str], tuple[dict[str, Any], dict[str, Any]]] = {}
+    relationships_by_type = {
+        "benefit": frozenset({"campaign", "tiers"}),
+        "tier": frozenset({"benefits", "campaign"}),
+    }
+    for value in values:
+        item = object_value(value, "included resource")
+        resource_type = item.get("type")
+        if not isinstance(resource_type, str) or resource_type not in allowed:
+            raise PatreonAdapterError("Patreon response contains an unrequested include type")
+        remote_id, attributes, relationships = _resource(
+            item,
+            resource_type,
+            allowed[resource_type],
+            relationships_by_type.get(resource_type, frozenset()),
+        )
+        key = (resource_type, remote_id)
+        if key in resources:
+            raise PatreonAdapterError("Patreon included resources contain duplicates")
+        resources[key] = (attributes, relationships)
+    return resources
+
+
+def benefit_records(payload: Any, expected_campaign_id: str) -> list[dict[str, Any]]:
+    """Validate campaign benefits and tiers with exact include linkage."""
+    root = _document(payload)
+    campaign = campaign_id(expected_campaign_id)
+    remote_id, _attributes_value, relationships = _resource(
+        root.get("data"),
+        "campaign",
+        frozenset({"name"}),
+        frozenset({"benefits", "tiers"}),
+    )
+    if remote_id != campaign:
+        raise PatreonAdapterError("Patreon benefits belong to an unselected campaign")
+    benefit_ids = _relationship_ids(relationships, "benefits", "benefit", required=True)
+    tier_ids = _relationship_ids(relationships, "tiers", "tier", required=True)
+    included = _included_resources(
+        root, {"benefit": BENEFIT_ATTRIBUTES, "tier": TIER_ATTRIBUTES}
+    )
+    if {item_id for item_type, item_id in included if item_type == "benefit"} != set(benefit_ids):
+        raise PatreonAdapterError("Patreon benefit includes do not match campaign linkage")
+    if {item_id for item_type, item_id in included if item_type == "tier"} != set(tier_ids):
+        raise PatreonAdapterError("Patreon tier includes do not match campaign linkage")
+    records = []
+    for benefit in benefit_ids:
+        attributes, item_relationships = included[("benefit", benefit)]
+        _campaign_relationship(item_relationships, campaign)
+        records.append(
+            {
+                "kind": "benefit",
+                "remote_id": f"benefit_{campaign}_{benefit}",
+                "campaign_id": campaign,
+                "benefit_type": _optional_text(attributes.get("benefit_type"), "benefit type"),
+                "created_at": _optional_text(attributes.get("created_at"), "benefit created_at"),
+                "description": _optional_text(attributes.get("description"), "benefit description"),
+                "is_deleted": _optional_boolean(attributes.get("is_deleted"), "benefit is_deleted"),
+                "is_ended": _optional_boolean(attributes.get("is_ended"), "benefit is_ended"),
+                "is_published": _optional_boolean(attributes.get("is_published"), "benefit is_published"),
+                "title": _optional_text(attributes.get("title"), "benefit title"),
+            }
+        )
+    for tier in tier_ids:
+        attributes, item_relationships = included[("tier", tier)]
+        _campaign_relationship(item_relationships, campaign)
+        records.append(
+            {
+                "kind": "tier",
+                "remote_id": f"tier_{campaign}_{tier}",
+                "campaign_id": campaign,
+                "amount_cents": _optional_integer(attributes.get("amount_cents"), "tier amount_cents"),
+                "created_at": _optional_text(attributes.get("created_at"), "tier created_at"),
+                "description": _optional_text(attributes.get("description"), "tier description"),
+                "edited_at": _optional_text(attributes.get("edited_at"), "tier edited_at"),
+                "published": _optional_boolean(attributes.get("published"), "tier published"),
+                "published_at": _optional_text(attributes.get("published_at"), "tier published_at"),
+                "requires_shipping": _optional_boolean(attributes.get("requires_shipping"), "tier requires_shipping"),
+                "title": _optional_text(attributes.get("title"), "tier title"),
+                "url": _optional_text(attributes.get("url"), "tier URL"),
+            }
+        )
+    return records
+
+
+def _member_reference(pii_key: bytes, campaign: str, member_id: str) -> str:
+    digest = hmac.new(
+        pii_key, f"{campaign}:{member_id}".encode(), hashlib.sha256
+    ).hexdigest()
+    return f"member_{digest[:32]}"
+
+
+def membership_records(
+    pii_key: bytes, payload: Any, expected_campaign_id: str
+) -> tuple[list[dict[str, Any]], str | None]:
+    """Minimize current member entitlements and discard direct member identity."""
+    if len(pii_key) < 32:
+        raise PatreonAdapterError("Patreon profile PII key must be at least 32 bytes")
+    root = _document(payload)
+    campaign = campaign_id(expected_campaign_id)
+    raw_members = []
+    referenced_tiers: set[str] = set()
+    for value in array_value(root.get("data"), "membership data"):
+        remote_id, attributes, relationships = _resource(
+            value,
+            "member",
+            MEMBER_ATTRIBUTES,
+            frozenset({"campaign", "currently_entitled_tiers"}),
+        )
+        _campaign_relationship(relationships, campaign)
+        tiers = _relationship_ids(
+            relationships,
+            "currently_entitled_tiers",
+            "tier",
+            required=True,
+        )
+        referenced_tiers.update(tiers)
+        raw_members.append((remote_id, attributes, tiers))
+    included = _included_resources(root, {"tier": TIER_ATTRIBUTES})
+    included_tiers = {item_id for item_type, item_id in included if item_type == "tier"}
+    if included_tiers != referenced_tiers:
+        raise PatreonAdapterError("Patreon membership tier includes do not match entitlement linkage")
+    records = []
+    for remote_id, attributes, tiers in raw_members:
+        records.append(
+            {
+                "kind": "membership",
+                "remote_id": _member_reference(pii_key, campaign, remote_id),
+                "campaign_id": campaign,
+                "currently_entitled_amount_cents": _optional_integer(
+                    attributes.get("currently_entitled_amount_cents"),
+                    "membership currently_entitled_amount_cents",
+                ),
+                "is_free_trial": _optional_boolean(
+                    attributes.get("is_free_trial"), "membership is_free_trial"
+                ),
+                "is_gifted": _optional_boolean(
+                    attributes.get("is_gifted"), "membership is_gifted"
+                ),
+                "patron_status": _optional_text(
+                    attributes.get("patron_status"), "membership patron_status"
+                ),
+                "pledge_cadence": _optional_text(
+                    attributes.get("pledge_cadence"), "membership pledge_cadence"
+                ),
+                "tier_ids": [f"tier_{campaign}_{tier}" for tier in tiers],
+            }
+        )
+    return records, _next_cursor(root)

--- a/.agents/scripts/_knowledge_social_patreon_normalize.py
+++ b/.agents/scripts/_knowledge_social_patreon_normalize.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize creator-owned, privacy-minimized Patreon records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_patreon import (
+    PROVIDER,
+    RETENTION_LIMIT,
+    PatreonAdapterError,
+    page_data,
+)
+from knowledge_social_import import reject_credentials
+
+PROVENANCE = "patreon_api_v2_get"
+GAPS = (
+    ("patron_memberships", "identity_memberships_scope_and_patron_role_are_not_collected"),
+    ("member_identity", "member_names_users_emails_addresses_and_notes_are_excluded"),
+    ("pledge_history", "pledge_history_include_is_not_requested"),
+    ("member_deliverables", "benefit_fulfilment_records_are_not_requested"),
+    ("comments_reactions", "no_verified_creator_account_history_route"),
+    ("messages_community", "no_verified_creator_account_history_route"),
+    ("lives", "early_access_and_write_capable_surface_is_excluded"),
+    ("webhooks", "webhook_write_scope_and_mutation_routes_are_excluded"),
+    ("creator_csv", "dashboard_export_has_no_published_versioned_schema"),
+    ("post_export", "no_documented_creator_post_export_contract"),
+    ("deleted_resources", "only_records_retained_by_the_current_api_are_visible"),
+    ("provider_retention", "no_documented_api_history_retention_guarantee"),
+)
+EXPECTED_KINDS = {
+    "account": frozenset({"creator_account"}),
+    "campaigns": frozenset({"campaign"}),
+    "posts": frozenset({"post"}),
+    "memberships": frozenset({"membership"}),
+    "benefits": frozenset({"benefit", "tier"}),
+}
+ACTIVITY_TYPES = {
+    "account": "creator_profile",
+    "campaigns": "campaign_state",
+    "posts": "creator_post",
+    "memberships": "membership_state",
+    "benefits": "benefit_state",
+}
+
+
+@dataclass(frozen=True)
+class PageContext:
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def _required_text(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise PatreonAdapterError(f"Patreon record requires {field}")
+    return value
+
+
+def _optional_text(value: Any, field: str) -> str | None:
+    if value is not None and (not isinstance(value, str) or "\x00" in value):
+        raise PatreonAdapterError(f"Patreon record {field} must be text")
+    return value
+
+
+def _observed_at(payload: dict[str, Any]) -> str:
+    return _required_text(payload.get("observed_at"), "observed_at")
+
+
+def _coverage(observed_at: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "stream": stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": RETENTION_LIMIT,
+            "unavailable_reason": reason,
+            "status": "unavailable",
+            "observed_at": observed_at,
+        }
+        for stream, reason in GAPS
+    ]
+
+
+def _text(item: dict[str, Any]) -> str | None:
+    kind = item.get("kind")
+    fields = {
+        "creator_account": (),
+        "campaign": ("name", "creation_name", "summary"),
+        "post": ("title", "content"),
+        "membership": (),
+        "benefit": ("title", "description"),
+        "tier": ("title", "description"),
+    }[kind]
+    values = [_optional_text(item.get(field), field) for field in fields]
+    return "\n\n".join(value for value in values if value) or None
+
+
+def _object(
+    item: dict[str, Any], context: PageContext, observed_at: str
+) -> dict[str, Any]:
+    kind = _required_text(item.get("kind"), "kind")
+    if kind not in EXPECTED_KINDS[context.stream]:
+        raise PatreonAdapterError("Patreon page contains an unsupported item kind")
+    remote_id = _required_text(item.get("remote_id"), "remote_id")
+    protected = context.stream == "memberships"
+    provider_json = {
+        "source": PROVENANCE,
+        "stream": context.stream,
+        "classification": "protected_business" if protected else "creator_owned",
+        "record": item,
+    }
+    reject_credentials(provider_json)
+    return {
+        "object_type": kind,
+        "remote_id": remote_id,
+        "account_remote_id": context.account.get("id"),
+        "text": _text(item),
+        "created_at": _optional_text(
+            item.get("created_at") or item.get("published_at"), "record time"
+        ),
+        "observed_at": observed_at,
+        "evidence_class": "protected_business" if protected else "authored",
+        "provider_json": provider_json,
+    }
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    """Build corpus rows while excluding direct member identity and credentials."""
+    reject_credentials(payload)
+    observed_at = _observed_at(payload)
+    account_id = _required_text(context.account.get("id"), "selected account ID")
+    items = page_data(payload)
+    objects = [_object(item, context, observed_at) for item in items]
+    activities = [
+        {
+            "activity_type": ACTIVITY_TYPES[context.stream],
+            "remote_id": f"{account_id}_{context.stream}_{item['remote_id']}",
+            "actor_remote_id": account_id,
+            "object_remote_id": item["remote_id"],
+            "occurred_at": _optional_text(
+                item.get("published_at") or item.get("created_at"), "activity time"
+            ),
+            "observed_at": observed_at,
+            "state": "active",
+            "provider_json": {"source": PROVENANCE, "stream": context.stream},
+        }
+        for item in items
+    ]
+    policy = dict(context.policy)
+    policy.update(
+        {
+            "patreon_api_version": "v2",
+            "patreon_transport": "stdlib_urllib_get_only",
+            "patreon_identity": "creator_user_plus_explicit_owned_campaigns",
+            "patreon_scopes": "identity campaigns plus stream-specific read scope",
+            "patreon_member_pii": "excluded_and_member_ids_keyed_hmac_sha256",
+            "patreon_member_purpose": "membership_services_gate",
+            "patreon_oauth_redirects": "outside_collector_and_not_followed",
+            "patreon_exports": "documented_csv_unwired",
+            "patreon_webhooks_and_lives": "disabled",
+        }
+    )
+    campaigns = context.account.get("campaign_ids")
+    if not isinstance(campaigns, list):
+        raise PatreonAdapterError("Patreon selected campaign identity is invalid")
+    archive = {
+        "provider": PROVIDER,
+        "connection_id": context.connection_id,
+        "remote_account_id": account_id,
+        "exported_at": observed_at,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": policy,
+        "accounts": [
+            {
+                "remote_id": account_id,
+                "handle": None,
+                "display_name": None,
+                "observed_at": observed_at,
+                "provider_json": {
+                    "source": PROVENANCE,
+                    "role": "creator",
+                    "campaign_ids": campaigns,
+                },
+            }
+        ],
+        "objects": objects,
+        "activities": activities,
+        "media": [],
+        "coverage": _coverage(observed_at),
+    }
+    reject_credentials(archive)
+    return archive

--- a/.agents/scripts/_knowledge_social_patreon_provider.py
+++ b/.agents/scripts/_knowledge_social_patreon_provider.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded, redirect-free, GET-only Patreon API v2 creator reader."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from _knowledge_social_patreon import (
+    PageRequest,
+    PatreonAdapterError,
+    campaign_id,
+    parse_page_request,
+    provider_id,
+    selected_campaign_ids,
+)
+from _knowledge_social_patreon_contract import (
+    benefit_records,
+    campaign_record,
+    identity_record,
+    membership_records,
+    object_value,
+    owned_campaign_ids,
+    post_records,
+)
+
+API_ROOT = "https://www.patreon.com/api/oauth2/v2"
+MAX_REQUEST_BYTES = 32 * 1024
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+MAX_ERROR_BYTES = 64 * 1024
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+BASE_SCOPES = frozenset({"identity", "campaigns"})
+OPTIONAL_READ_SCOPES = frozenset({"campaigns.posts", "campaigns.members"})
+ALLOWED_SCOPES = BASE_SCOPES | OPTIONAL_READ_SCOPES
+SENSITIVE_SCOPES = frozenset(
+    {
+        "identity[email]",
+        "identity.memberships",
+        "campaigns.members[email]",
+        "campaigns.members.address",
+    }
+)
+STREAM_SCOPES = {
+    "account": frozenset(),
+    "campaigns": frozenset(),
+    "posts": frozenset({"campaigns.posts"}),
+    "memberships": frozenset({"campaigns.members"}),
+    "benefits": frozenset(),
+}
+CAMPAIGN_FIELDS = (
+    "created_at,creation_name,currency,is_monthly,is_nsfw,name,patron_count,"
+    "published_at,summary,url"
+)
+POST_FIELDS = "content,is_paid,is_public,published_at,title,url"
+BENEFIT_FIELDS = (
+    "benefit_type,created_at,description,is_deleted,is_ended,is_published,title"
+)
+TIER_FIELDS = (
+    "amount_cents,created_at,description,edited_at,published,published_at,"
+    "requires_shipping,title,url"
+)
+MEMBER_FIELDS = (
+    "currently_entitled_amount_cents,is_free_trial,is_gifted,patron_status,"
+    "pledge_cadence"
+)
+
+
+class PatreonReadProviderError(RuntimeError):
+    """Raised for a privacy-safe local provider failure."""
+
+
+class RejectRedirects(HTTPRedirectHandler):
+    """Reject redirects so bearer credentials never cross origins."""
+
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+@dataclass(frozen=True)
+class Profile:
+    access_token: str
+    campaign_ids: tuple[str, ...]
+    scopes: frozenset[str]
+    pii_key: bytes | None
+    member_data_purpose: str | None
+
+    @property
+    def member_data_authorized(self) -> bool:
+        return (
+            "campaigns.members" in self.scopes
+            and self.member_data_purpose == "membership-services"
+            and self.pii_key is not None
+        )
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    status: int
+    payload: Any
+    retry_after: int | None = None
+
+
+ApiCall = Callable[[Profile, str, dict[str, str]], ApiResult]
+
+
+def _observed_at() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _profile_value(prefix: str, suffix: str) -> str:
+    return os.environ.get(f"{prefix}_{suffix}", "").strip()
+
+
+def _profile(profile: str) -> Profile:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise PatreonReadProviderError("Patreon profile name is invalid")
+    prefix = f"PATREON_{profile.upper()}"
+    token = _profile_value(prefix, "ACCESS_TOKEN")
+    if not token or "\x00" in token or len(token.encode()) > 16 * 1024:
+        raise PatreonReadProviderError("Patreon profile access token is missing")
+    raw_campaigns = _profile_value(prefix, "CAMPAIGN_IDS")
+    if not raw_campaigns:
+        raise PatreonReadProviderError("Patreon profile campaign IDs are missing")
+    try:
+        campaigns = selected_campaign_ids(
+            [item.strip() for item in raw_campaigns.split(",") if item.strip()]
+        )
+    except PatreonAdapterError as error:
+        raise PatreonReadProviderError("Patreon profile campaign IDs are invalid") from error
+    raw_scopes = _profile_value(prefix, "SCOPES")
+    if not raw_scopes:
+        raise PatreonReadProviderError("Patreon profile scopes are missing")
+    scope_values = tuple(item for item in raw_scopes.replace(",", " ").split() if item)
+    scopes = frozenset(scope_values)
+    if len(scope_values) != len(scopes):
+        raise PatreonReadProviderError("Patreon profile scopes contain duplicates")
+    if any(not re.fullmatch(r"[A-Za-z0-9.\[\]:_-]+", item) for item in scopes):
+        raise PatreonReadProviderError("Patreon profile scopes are invalid")
+    if scopes - ALLOWED_SCOPES or scopes & SENSITIVE_SCOPES or any(
+        item.startswith("w:") for item in scopes
+    ):
+        raise PatreonReadProviderError(
+            "Patreon profile includes unsupported or sensitive scopes"
+        )
+    if not BASE_SCOPES.issubset(scopes):
+        raise PatreonReadProviderError("Patreon profile is missing required read scopes")
+    raw_key = _profile_value(prefix, "PII_KEY")
+    pii_key = raw_key.encode() if raw_key else None
+    if pii_key is not None and len(pii_key) < 32:
+        raise PatreonReadProviderError("Patreon profile PII key must be at least 32 bytes")
+    purpose = _profile_value(prefix, "MEMBER_DATA_PURPOSE") or None
+    if purpose not in (None, "membership-services"):
+        raise PatreonReadProviderError("Patreon profile member-data purpose is invalid")
+    return Profile(token, campaigns, scopes, pii_key, purpose)
+
+
+def _path_allowed(profile: Profile, path: str) -> bool:
+    if path in {"/identity", "/campaigns"}:
+        return True
+    parts = path.strip("/").split("/")
+    if len(parts) not in (2, 3) or parts[0] != "campaigns":
+        return False
+    try:
+        selected = campaign_id(parts[1])
+    except PatreonAdapterError:
+        return False
+    if selected not in profile.campaign_ids:
+        return False
+    return len(parts) == 2 or parts[2] in {"posts", "members"}
+
+
+def _retry_after(headers: Any, payload: Any) -> int | None:
+    header = headers.get("Retry-After") if headers is not None else None
+    if isinstance(header, str) and header.isdigit():
+        return min(int(header), 86400)
+    if not isinstance(payload, dict):
+        return None
+    errors = payload.get("errors")
+    if not isinstance(errors, list) or not errors or not isinstance(errors[0], dict):
+        return None
+    value = errors[0].get("retry_after_seconds")
+    if isinstance(value, str) and value.isdigit():
+        value = int(value)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return min(value, 86400)
+
+
+def _decode_json(payload: bytes, field: str) -> Any:
+    try:
+        return json.loads(payload.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise PatreonReadProviderError(f"Patreon API returned no valid {field} JSON") from error
+
+
+def _request(profile: Profile, path: str, params: dict[str, str]) -> ApiResult:
+    if not _path_allowed(profile, path):
+        raise PatreonReadProviderError("Patreon read route is unsupported")
+    query = f"?{urlencode(params)}" if params else ""
+    request = Request(
+        f"{API_ROOT}{path}{query}",
+        headers={
+            "Accept": "application/vnd.api+json",
+            "Authorization": f"Bearer {profile.access_token}",
+            "User-Agent": "aidevops-patreon-knowledge/1",
+        },
+        method="GET",
+    )
+    try:
+        with build_opener(RejectRedirects).open(request, timeout=60) as response:
+            raw = response.read(MAX_RESPONSE_BYTES + 1)
+            status = int(response.status)
+            headers = response.headers
+    except HTTPError as error:
+        status = int(error.code)
+        headers = error.headers
+        raw = error.read(MAX_ERROR_BYTES + 1)
+        if 300 <= status < 400:
+            return ApiResult(502, {})
+        payload = _decode_json(raw, "error") if raw and len(raw) <= MAX_ERROR_BYTES else {}
+        return ApiResult(status, {}, _retry_after(headers, payload))
+    except (OSError, URLError) as error:
+        raise PatreonReadProviderError("Patreon API request failed") from error
+    if len(raw) > MAX_RESPONSE_BYTES:
+        raise PatreonReadProviderError("Patreon API response exceeds the byte safety limit")
+    payload = _decode_json(raw, "response")
+    return ApiResult(status, payload, _retry_after(headers, payload))
+
+
+def _terminal(result: ApiResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": result.status, "observed_at": _observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload
+
+
+def _identity(
+    profile: Profile, expected_id: str, api: ApiCall = _request
+) -> dict[str, Any]:
+    identity = api(
+        profile,
+        "/identity",
+        {
+            "fields[user]": "is_creator",
+            "json-api-use-default-includes": "false",
+        },
+    )
+    if identity.status != 200:
+        return _terminal(identity)
+    account = identity_record(identity.payload, expected_id)
+    campaigns = api(
+        profile,
+        "/campaigns",
+        {"json-api-use-default-includes": "false", "page[count]": "1000"},
+    )
+    if campaigns.status != 200:
+        return _terminal(campaigns)
+    owned, _next = owned_campaign_ids(campaigns.payload)
+    if not set(profile.campaign_ids).issubset(owned):
+        raise PatreonReadProviderError(
+            "selected Patreon campaign is not owned by the authenticated creator"
+        )
+    remote_id = provider_id(expected_id, "selected account ID")
+    return {
+        "status": 200,
+        "observed_at": _observed_at(),
+        "data": {
+            "provider_account_id": remote_id,
+            "role": "creator",
+            "is_creator": account["is_creator"],
+            "campaign_ids": list(profile.campaign_ids),
+            "member_data_authorized": profile.member_data_authorized,
+        },
+    }
+
+
+def _require_stream_scope(profile: Profile, stream: str) -> None:
+    if not STREAM_SCOPES[stream].issubset(profile.scopes):
+        raise PatreonReadProviderError("Patreon profile is missing required read scopes")
+    if stream != "memberships":
+        return
+    if profile.member_data_purpose != "membership-services":
+        raise PatreonReadProviderError(
+            "Patreon memberships require the membership-services purpose gate"
+        )
+    if profile.pii_key is None:
+        raise PatreonReadProviderError("Patreon profile PII key is missing")
+
+
+def _next_campaign(request: PageRequest) -> str | None:
+    if request.campaign_id is None:
+        return None
+    index = request.campaign_ids.index(request.campaign_id)
+    return request.campaign_ids[index + 1] if index + 1 < len(request.campaign_ids) else None
+
+
+def _page_meta(
+    request: PageRequest, next_cursor: str | None
+) -> dict[str, Any]:
+    next_campaign = None if next_cursor is not None else _next_campaign(request)
+    return {
+        "stream": request.stream,
+        "campaign_id": request.campaign_id,
+        "next_cursor": next_cursor,
+        "next_campaign_id": next_campaign,
+        "complete": next_cursor is None and next_campaign is None,
+    }
+
+
+def _page_params(request: PageRequest, fields: dict[str, str]) -> dict[str, str]:
+    params = {
+        **fields,
+        "json-api-use-default-includes": "false",
+        "page[count]": str(request.limit),
+    }
+    if request.cursor is not None:
+        params["page[cursor]"] = request.cursor
+    return params
+
+
+def _page(
+    profile: Profile,
+    request: PageRequest,
+    identity: dict[str, Any],
+    api: ApiCall = _request,
+) -> dict[str, Any]:
+    data = object_value(identity.get("data"), "verified identity")
+    if data.get("provider_account_id") != request.account_id:
+        raise PatreonReadProviderError(
+            "selected Patreon account does not match the configured connection"
+        )
+    if tuple(data.get("campaign_ids", ())) != request.campaign_ids:
+        raise PatreonReadProviderError(
+            "selected Patreon campaign is not owned by the authenticated creator"
+        )
+    if data.get("member_data_authorized") is not request.member_data_authorized:
+        raise PatreonReadProviderError("Patreon member-data authorization changed")
+    observed_at = _observed_at()
+    if request.stream == "account":
+        records = [
+            {
+                "kind": "creator_account",
+                "remote_id": f"creator_account_{request.account_id}",
+                "is_creator": True,
+                "campaign_ids": list(request.campaign_ids),
+            }
+        ]
+        next_cursor = None
+    else:
+        assert request.campaign_id is not None
+        path = f"/campaigns/{request.campaign_id}"
+        if request.stream == "campaigns":
+            result = api(
+                profile,
+                path,
+                {
+                    "fields[campaign]": CAMPAIGN_FIELDS,
+                    "json-api-use-default-includes": "false",
+                },
+            )
+            if result.status != 200:
+                return _terminal(result)
+            records = [campaign_record(result.payload, request.campaign_id)]
+            next_cursor = None
+        elif request.stream == "posts":
+            result = api(
+                profile,
+                f"{path}/posts",
+                _page_params(request, {"fields[post]": POST_FIELDS}),
+            )
+            if result.status != 200:
+                return _terminal(result)
+            records, next_cursor = post_records(result.payload, request.campaign_id)
+        elif request.stream == "benefits":
+            result = api(
+                profile,
+                path,
+                {
+                    "fields[benefit]": BENEFIT_FIELDS,
+                    "fields[campaign]": "name",
+                    "fields[tier]": TIER_FIELDS,
+                    "include": "benefits,tiers",
+                    "json-api-use-default-includes": "false",
+                },
+            )
+            if result.status != 200:
+                return _terminal(result)
+            records = benefit_records(result.payload, request.campaign_id)
+            next_cursor = None
+        else:
+            assert request.stream == "memberships"
+            assert profile.pii_key is not None
+            result = api(
+                profile,
+                f"{path}/members",
+                _page_params(
+                    request,
+                    {
+                        "fields[member]": MEMBER_FIELDS,
+                        "fields[tier]": TIER_FIELDS,
+                        "include": "currently_entitled_tiers",
+                    },
+                ),
+            )
+            if result.status != 200:
+                return _terminal(result)
+            records, next_cursor = membership_records(
+                profile.pii_key, result.payload, request.campaign_id
+            )
+    if len(records) > request.limit:
+        raise PatreonReadProviderError("Patreon page exceeds the configured item safety limit")
+    return {
+        "status": 200,
+        "observed_at": observed_at,
+        "data": records,
+        "meta": _page_meta(request, next_cursor),
+    }
+
+
+def _request_object(payload: bytes) -> dict[str, Any]:
+    if len(payload) > MAX_REQUEST_BYTES:
+        raise PatreonReadProviderError("Patreon read request exceeds the safety limit")
+    try:
+        request = json.loads(payload.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise PatreonReadProviderError("Patreon read request is not valid JSON") from error
+    return object_value(request, "read request")
+
+
+def _dispatch(
+    request: dict[str, Any], profile: Profile, api: ApiCall = _request
+) -> dict[str, Any]:
+    action = request.get("action")
+    if action == "identity":
+        if set(request) != {"action", "account_id"}:
+            raise PatreonReadProviderError("Patreon identity request shape is invalid")
+        return _identity(
+            profile, provider_id(request.get("account_id"), "selected account ID"), api
+        )
+    if action != "page":
+        raise PatreonReadProviderError("Patreon read action is unsupported")
+    page_request = parse_page_request(request)
+    if page_request.campaign_ids != profile.campaign_ids:
+        raise PatreonReadProviderError(
+            "selected Patreon campaign is not owned by the authenticated creator"
+        )
+    _require_stream_scope(profile, page_request.stream)
+    identity = _identity(profile, page_request.account_id, api)
+    if identity.get("status") != 200:
+        return identity
+    return _page(profile, page_request, identity, api)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    args = parser.parse_args()
+    try:
+        request = _request_object(sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1))
+        payload = _dispatch(request, _profile(args.profile))
+        encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+        if len(encoded.encode()) > MAX_RESPONSE_BYTES:
+            raise PatreonReadProviderError("Patreon read response exceeds the safety limit")
+        print(encoded)
+        return 0
+    except (PatreonReadProviderError, PatreonAdapterError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - redact provider, creator, and member internals
+        print("ERROR: Patreon read provider request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_patreon_reader.py
+++ b/.agents/scripts/_knowledge_social_patreon_reader.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and deterministic fixture readers for Patreon collection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
+from _knowledge_social_patreon import (
+    PageRequest,
+    PatreonAdapterError,
+    PatreonProviderUnavailableError,
+    provider_id,
+    selected_campaign_ids,
+)
+from knowledge_social_import import reject_credentials
+
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+SAFE_FAILURES = (
+    "Patreon profile name is invalid",
+    "Patreon profile access token is missing",
+    "Patreon profile campaign IDs are missing",
+    "Patreon profile scopes are missing",
+    "Patreon profile includes unsupported or sensitive scopes",
+    "Patreon profile is missing required read scopes",
+    "Patreon memberships require the membership-services purpose gate",
+    "Patreon profile PII key is missing",
+    "Patreon profile PII key must be at least 32 bytes",
+    "selected Patreon account does not match the configured connection",
+    "selected Patreon campaign is not owned by the authenticated creator",
+)
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    if len(output.encode()) > MAX_RESPONSE_BYTES:
+        raise PatreonAdapterError("Patreon read response exceeds the safety limit")
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise PatreonAdapterError("Patreon read provider returned no valid JSON") from error
+    if not isinstance(payload, dict):
+        raise PatreonAdapterError("Patreon read response root must be an object")
+    return payload
+
+
+def _provider_failure(stderr: str) -> PatreonProviderUnavailableError:
+    for message in SAFE_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return PatreonProviderUnavailableError(message)
+    return PatreonProviderUnavailableError("Patreon read provider is unavailable")
+
+
+READER_POLICY = GuardedOAuthPolicy(
+    "Patreon",
+    "PATREON",
+    "PATREON_READ_LOG",
+    120,
+    _decode_output,
+    _provider_failure,
+    PatreonProviderUnavailableError,
+    (
+        "ACCESS_TOKEN",
+        "CAMPAIGN_IDS",
+        "SCOPES",
+        "PII_KEY",
+        "MEMBER_DATA_PURPOSE",
+    ),
+)
+
+
+def _fixture_page(fixture: FixtureSequence, request: PageRequest) -> dict[str, Any]:
+    entry = fixture.next_page()
+    expectation = entry.get("expect_request", {})
+    if not isinstance(expectation, dict):
+        raise PatreonAdapterError("Patreon fixture expectation must be an object")
+    actual = request.payload()
+    if any(actual.get(key) != value for key, value in expectation.items()):
+        raise PatreonAdapterError("Patreon request did not resume at the expected checkpoint")
+    response = entry.get("response", entry)
+    if not isinstance(response, dict):
+        raise PatreonAdapterError("Patreon fixture page response must be an object")
+    return response
+
+
+class GuardedPatreon(GuardedOAuthReader):
+    """Execute only identity and allowlisted GET reads in a bounded child."""
+
+    def __init__(self, helper: Path, profile: str) -> None:
+        super().__init__(helper, profile, READER_POLICY)
+
+
+class FixturePatreon:
+    """Deterministic HTTP substitute for pagination and failure fixtures."""
+
+    def __init__(self, path: Path) -> None:
+        self.fixture = FixtureSequence(path, "Patreon", PatreonAdapterError)
+
+    def identity(self, expected_id: str) -> dict[str, Any]:
+        del expected_id
+        return self.fixture.identity()
+
+    def page(self, request: PageRequest) -> dict[str, Any]:
+        return _fixture_page(self.fixture, request)
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    """Bind every run to one creator and an explicit owned-campaign allowlist."""
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise PatreonAdapterError("Patreon account verification returned no account")
+    remote_id = provider_id(data.get("provider_account_id"), "account ID")
+    if remote_id != provider_id(expected_id, "selected account ID"):
+        raise PatreonAdapterError(
+            "selected Patreon account does not match the configured connection"
+        )
+    if data.get("role") != "creator" or data.get("is_creator") is not True:
+        raise PatreonAdapterError("selected Patreon account is not an active creator")
+    campaigns = selected_campaign_ids(data.get("campaign_ids"))
+    authorized = data.get("member_data_authorized")
+    if not isinstance(authorized, bool):
+        raise PatreonAdapterError("Patreon member-data authorization is invalid")
+    return {
+        "id": remote_id,
+        "provider_account_id": remote_id,
+        "role": "creator",
+        "is_creator": True,
+        "campaign_ids": list(campaigns),
+        "member_data_authorized": authorized,
+    }

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -13,6 +13,7 @@ YOUTUBE_HELPER="${SCRIPT_DIR}/knowledge_social_youtube.py"
 LINKEDIN_HELPER="${SCRIPT_DIR}/knowledge_social_linkedin.py"
 META_HELPER="${SCRIPT_DIR}/knowledge_social_meta.py"
 MEDIUM_HELPER="${SCRIPT_DIR}/knowledge_social_medium.py"
+PATREON_HELPER="${SCRIPT_DIR}/knowledge_social_patreon.py"
 DISCOURSE_HELPER="${SCRIPT_DIR}/knowledge_social_discourse.py"
 NODEBB_HELPER="${SCRIPT_DIR}/knowledge_social_nodebb.py"
 MASTODON_HELPER="${SCRIPT_DIR}/knowledge_social_mastodon.py"
@@ -180,6 +181,19 @@ EOF
 	return 0
 }
 
+usage_patreon_sync() {
+	cat <<'EOF'
+Patreon synchronization:
+  sync-patreon verifies one creator identity and every explicitly configured,
+  creator-owned campaign before each page. Account, campaign, post, benefit, and
+  purpose-gated current-membership streams have independent checkpoints.
+  --budget is a hard 5-99 request limit and --page-size is 1-100 items. Patron
+  memberships, sensitive member scopes, redirects, and mutation routes are rejected.
+
+EOF
+	return 0
+}
+
 usage_commands() {
 	cat <<'EOF'
 Usage:
@@ -206,6 +220,10 @@ Usage:
   knowledge-social-helper.sh sync-youtube [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id CHANNEL_ID --stream STREAM --profile PROFILE \
     [--budget UNITS] [--page-size 1-50] [--collector-id ID] \
+    [--lease-seconds SECONDS]
+  knowledge-social-helper.sh sync-patreon [--base PATH] [--alias ALIAS] \
+    --connection-id ID --account-id CREATOR_USER_ID --stream STREAM --profile PROFILE \
+    [--budget 5-99] [--page-size 1-100] [--collector-id ID] \
     [--lease-seconds SECONDS]
   knowledge-social-helper.sh sync-linkedin [--base PATH] [--alias ALIAS] \
     --connection-id ID --account-id MEMBER_ID --stream STREAM --profile PROFILE \
@@ -321,6 +339,7 @@ Medium account export:
 EOF
 	usage_sync
 	usage_sync_hashnode
+	usage_patreon_sync
 	cat <<'EOF'
 Deterministic routines:
   sync-due and reconcile-due return sorted privacy-safe work plans. Every sync or
@@ -438,6 +457,7 @@ run_named_provider_sync() {
 	shift || return 1
 	case "$subcommand" in
 	sync-meta) run_provider_sync Meta "$META_HELPER" "$@" || return 1 ;;
+	sync-patreon) run_provider_sync Patreon "$PATREON_HELPER" "$@" || return 1 ;;
 	sync-discourse) run_provider_sync Discourse "$DISCOURSE_HELPER" "$@" || return 1 ;;
 	sync-nodebb) run_provider_sync NodeBB "$NODEBB_HELPER" "$@" || return 1 ;;
 	sync-mastodon) run_provider_sync Mastodon "$MASTODON_HELPER" "$@" || return 1 ;;
@@ -527,7 +547,7 @@ main() {
 		fi
 		python3 "$LINKEDIN_HELPER" "$@" || return 1
 		;;
-	sync-meta | sync-discourse | sync-nodebb | sync-mastodon | sync-lemmy | sync-github | sync-stack-exchange | sync-hacker-news | sync-hashnode | sync-miniflux | sync-readwise-reader)
+	sync-meta | sync-patreon | sync-discourse | sync-nodebb | sync-mastodon | sync-lemmy | sync-github | sync-stack-exchange | sync-hacker-news | sync-hashnode | sync-miniflux | sync-readwise-reader)
 		run_named_provider_sync "$subcommand" "$@" || return 1
 		;;
 	query | annotate)

--- a/.agents/scripts/knowledge_social_patreon.py
+++ b/.agents/scripts/knowledge_social_patreon.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one bounded, read-only Patreon creator stream into a social corpus."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import _knowledge_social_patreon as patreon
+from _knowledge_social_oauth_collector import OAuthCollectorPolicy, run_oauth_collector
+from _knowledge_social_patreon_normalize import PageContext, normalize_page
+from _knowledge_social_patreon_reader import (
+    FixturePatreon,
+    GuardedPatreon,
+    verified_identity,
+)
+
+MAX_INVOCATION_BUDGET = 99
+
+
+def _enforce_rate_budget(arguments: list[str]) -> None:
+    if "--budget" not in arguments:
+        return
+    index = arguments.index("--budget")
+    if index + 1 >= len(arguments):
+        return
+    try:
+        budget = int(arguments[index + 1])
+    except ValueError:
+        return
+    if budget > MAX_INVOCATION_BUDGET:
+        raise patreon.PatreonAdapterError(
+            "Patreon budget cannot exceed 99 requests per invocation"
+        )
+
+
+def _policy() -> OAuthCollectorPolicy:
+    return OAuthCollectorPolicy(
+        display_name="Patreon",
+        provider_module=patreon,
+        helper=Path(__file__).with_name("_knowledge_social_patreon_provider.py"),
+        fixture_reader=FixturePatreon,
+        live_reader=GuardedPatreon,
+        page_context=PageContext,
+        normalize_page=normalize_page,
+        verified_identity=verified_identity,
+        budget_unit="request",
+        default_budget=20,
+        min_budget=5,
+        max_page_size=100,
+        identity_cost_units=2,
+    )
+
+
+def main() -> int:
+    try:
+        _enforce_rate_budget(sys.argv[1:])
+    except patreon.PatreonAdapterError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    return run_oauth_collector(_policy(), __doc__ or "")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/knowledge_social_registry.py
+++ b/.agents/scripts/knowledge_social_registry.py
@@ -80,6 +80,7 @@ PROVIDER_SPECS = (
         "knowledge_social_nextcloud_talk.py",
         (("live", ()),),
     ),
+    ProviderSpec("patreon", (), "knowledge_social_patreon.py", (("live", ()),)),
     ProviderSpec(
         "signal",
         (),

--- a/.agents/tests/test-knowledge-social-patreon.sh
+++ b/.agents/tests/test-knowledge-social-patreon.sh
@@ -1,0 +1,478 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-patreon.sh — bounded Patreon creator collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="${SCRIPT_DIR}/../scripts"
+COLLECTOR="${SCRIPTS}/knowledge_social_patreon.py"
+CORPUS_HELPER="${SCRIPTS}/knowledge-corpus-helper.sh"
+SOCIAL_HELPER="${SCRIPTS}/knowledge-social-helper.sh"
+DOC="${SCRIPT_DIR}/../content/social-patreon.md"
+MATRIX="${SCRIPT_DIR}/../aidevops/knowledge-plane/06-social-provider-capabilities.md"
+OPERATIONS="${SCRIPT_DIR}/../aidevops/knowledge-plane/05-social-operations.md"
+TMP_DIR=$(mktemp -d)
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+ACCOUNT_ID="creator_123"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' "$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c 'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' "$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_text() {
+	python3 - "$ROOT/sources/social/raw/patreon" <<'PY'
+import gzip
+import sys
+from pathlib import Path
+root = Path(sys.argv[1])
+print("\n".join(gzip.open(path, "rt", encoding="utf-8").read() for path in root.rglob("*.json.gz")))
+PY
+	return 0
+}
+
+run_fixture() {
+	local fixture="$1"
+	local connection="$2"
+	local stream="$3"
+	shift 3
+	if python3 "$COLLECTOR" --base "$BASE" --alias personal:default \
+		--connection-id "$connection" --account-id "$ACCOUNT_ID" \
+		--stream "$stream" --profile fixture --fixture "$fixture" "$@"; then
+		return 0
+	fi
+	return 1
+}
+
+run_terminal_case() {
+	local name="$1"
+	local status="$2"
+	local expected_failure="$3"
+	local fixture="${TMP_DIR}/terminal-${name}.json"
+	python3 - "$fixture" "$ACCOUNT_ID" "$status" <<'PY'
+import json
+import sys
+
+payload = {
+    "identity": {"data": {
+        "provider_account_id": sys.argv[2], "role": "creator", "is_creator": True,
+        "campaign_ids": ["101", "202"], "member_data_authorized": False,
+    }},
+    "pages": [{"status": int(sys.argv[3]), "observed_at": "2026-08-02T21:03:00Z"}],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as target:
+    json.dump(payload, target)
+PY
+	local result=""
+	result=$(run_fixture "$fixture" "conn_terminal_${name}" posts)
+	assert_eq "${status} response is terminal without checkpoint advancement" \
+		"$(json_field "$result" failure_class):$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_terminal_${name}'")" \
+		"${expected_failure}:0"
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$SOCIAL_HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'Patreon social collector tests\n'
+
+python3 - "$SCRIPTS" <<'PY'
+import ast
+import json
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+
+from _knowledge_social_collect import CursorState
+from _knowledge_social_patreon import PageRequest, STREAMS, page_checkpoint, page_request
+from _knowledge_social_patreon_contract import benefit_records, membership_records
+from _knowledge_social_patreon_provider import (
+    ApiResult, Profile, PatreonReadProviderError, _dispatch,
+)
+from knowledge_social_patreon import _enforce_rate_budget
+
+assert set(STREAMS) == {"account", "campaigns", "posts", "memberships", "benefits"}
+profile = Profile(
+    "fixture-token", ("101", "202"),
+    frozenset({"identity", "campaigns", "campaigns.posts", "campaigns.members"}),
+    b"p" * 32, "membership-services",
+)
+calls = []
+
+def api(_profile, path, params):
+    calls.append((path, params))
+    if path == "/identity":
+        return ApiResult(200, {"data": {
+            "type": "user", "id": "creator_123", "attributes": {"is_creator": True},
+        }})
+    if path == "/campaigns":
+        return ApiResult(200, {"data": [
+            {"type": "campaign", "id": "101"},
+            {"type": "campaign", "id": "202"},
+        ], "meta": {"pagination": {"cursors": {"next": None}}}})
+    if path == "/campaigns/101/posts":
+        return ApiResult(200, {"data": [{
+            "type": "post", "id": "post-1",
+            "attributes": {"title": "Creator update", "content": "Bounded content", "is_public": False},
+            "relationships": {"campaign": {"data": {"type": "campaign", "id": "101"}}},
+        }], "meta": {"pagination": {"cursors": {"next": "cursor-a"}}}})
+    raise AssertionError(path)
+
+request = PageRequest("posts", "creator_123", ("101", "202"), "101", None, (), 100, True)
+page = _dispatch(request.payload(), profile, api)
+assert page["data"][0]["remote_id"] == "post_post-1"
+assert page["meta"]["next_cursor"] == "cursor-a"
+post_params = calls[-1][1]
+assert "email" not in json.dumps(post_params).lower()
+assert post_params["json-api-use-default-includes"] == "false"
+
+def wrong_campaign_api(_profile, path, _params):
+    if path == "/identity":
+        return ApiResult(200, {"data": {
+            "type": "user", "id": "creator_123", "attributes": {"is_creator": True},
+        }})
+    return ApiResult(200, {"data": [{"type": "campaign", "id": "999"}]})
+
+try:
+    _dispatch({"action": "identity", "account_id": "creator_123"}, profile, wrong_campaign_api)
+except PatreonReadProviderError:
+    pass
+else:
+    raise SystemExit("unowned Patreon campaign was accepted")
+
+malformed_benefits = {
+    "data": {
+        "type": "campaign", "id": "101", "attributes": {"name": "Campaign"},
+        "relationships": {
+            "benefits": {"data": [{"type": "benefit", "id": "b1"}]},
+            "tiers": {"data": [{"type": "tier", "id": "t1"}]},
+        },
+    },
+    "included": [
+        {"type": "benefit", "id": "b1", "attributes": {"title": "Benefit"}},
+        {"type": "tier", "id": "wrong-tier", "attributes": {"title": "Tier"}},
+    ],
+}
+try:
+    benefit_records(malformed_benefits, "101")
+except Exception:
+    pass
+else:
+    raise SystemExit("malformed Patreon includes were accepted")
+
+member_payload = {
+    "data": [{
+        "type": "member", "id": "direct-member-id",
+        "attributes": {"patron_status": "active_patron", "currently_entitled_amount_cents": 500},
+        "relationships": {"currently_entitled_tiers": {"data": [{"type": "tier", "id": "t1"}]}},
+    }],
+    "included": [{"type": "tier", "id": "t1", "attributes": {"title": "Supporter"}}],
+    "meta": {"pagination": {"cursors": {"next": None}}},
+}
+members, cursor = membership_records(b"p" * 32, member_payload, "101")
+assert cursor is None and members[0]["remote_id"].startswith("member_")
+assert "direct-member-id" not in json.dumps(members)
+member_payload["data"][0]["attributes"]["full_name"] = "Must not persist"
+try:
+    membership_records(b"p" * 32, member_payload, "101")
+except Exception:
+    pass
+else:
+    raise SystemExit("unrequested Patreon member PII was accepted")
+
+account = {
+    "id": "creator_123", "provider_account_id": "creator_123",
+    "campaign_ids": ["101", "202"], "member_data_authorized": False,
+}
+first = page_request("posts", account, CursorState(None, None, False), 100)
+checkpoint, complete = page_checkpoint({
+    "data": [],
+    "meta": {"stream": "posts", "campaign_id": "101", "next_cursor": "loop-a", "next_campaign_id": None, "complete": False},
+}, CursorState(None, None, False), first)
+assert not complete and checkpoint.next_cursor
+resumed = page_request("posts", account, CursorState(checkpoint.next_cursor, None, False), 100)
+try:
+    page_checkpoint({
+        "data": [],
+        "meta": {"stream": "posts", "campaign_id": "101", "next_cursor": "loop-a", "next_campaign_id": None, "complete": False},
+    }, CursorState(checkpoint.next_cursor, None, False), resumed)
+except Exception:
+    pass
+else:
+    raise SystemExit("Patreon pagination cursor loop was accepted")
+
+try:
+    _enforce_rate_budget(["--budget", "100"])
+except Exception:
+    pass
+else:
+    raise SystemExit("Patreon invocation exceeded the documented token rate budget")
+
+sources = [path.read_text(encoding="utf-8") for path in scripts.glob("*knowledge_social_patreon*.py")]
+trees = [ast.parse(source) for source in sources]
+request_calls = [
+    node for tree in trees for node in ast.walk(tree)
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "Request"
+]
+assert len(request_calls) == 1
+methods = [
+    keyword.value.value for keyword in request_calls[0].keywords
+    if keyword.arg == "method" and isinstance(keyword.value, ast.Constant)
+]
+assert methods == ["GET"]
+for forbidden in (
+    'method="POST"', 'method="PUT"', 'method="PATCH"', 'method="DELETE"',
+    "playwright", "selenium", "_knowledge_social_outbound", "/webhooks", "/lives",
+):
+    assert all(forbidden not in source for source in sources)
+PY
+assert_eq "identity, ownership, fields, includes, minimization, cursors, and GET-only AST are guarded" verified verified
+
+helper_help=$("$SOCIAL_HELPER" help)
+sync_help=$("$SOCIAL_HELPER" sync-patreon --help 2>&1)
+if [[ "$helper_help" == *"sync-patreon"* && "$helper_help" == *"5-99"* &&
+	"$sync_help" == *"bounded, read-only Patreon creator stream"* ]]; then
+	assert_eq "helper advertises only the bounded Patreon creator route" guarded guarded
+else
+	assert_eq "helper advertises only the bounded Patreon creator route" missing guarded
+fi
+
+registry_resolution=$("$SOCIAL_HELPER" provider-resolve --provider patreon |
+	python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["provider"] + ":" + ",".join(data["modes"]))')
+assert_eq "registry exposes only Patreon live collection" "$registry_resolution" "patreon:live"
+
+if rg -Fq '| Patreon |' "$MATRIX" &&
+	rg -Fq 'Patron-owned memberships' "$DOC" &&
+	rg -Fq 'PATREON_<PROFILE>_MEMBER_DATA_PURPOSE=membership-services' "$OPERATIONS"; then
+	assert_eq "documentation preserves creator, patron, and member-purpose boundaries" documented documented
+else
+	assert_eq "documentation preserves creator, patron, and member-purpose boundaries" missing documented
+fi
+
+cat >"$TMP_DIR/campaign-first.json" <<JSON
+{"identity":{"data":{"provider_account_id":"${ACCOUNT_ID}","role":"creator","is_creator":true,"campaign_ids":["101","202"],"member_data_authorized":false}},"pages":[{
+  "expect_request":{"campaign_id":"101","cursor":null,"limit":100},
+  "response":{"status":200,"observed_at":"2026-08-02T20:00:00Z","data":[
+    {"kind":"campaign","remote_id":"campaign_101","campaign_id":"101","name":"First Campaign","summary":"Creator campaign knowledge"}],
+  "meta":{"stream":"campaigns","campaign_id":"101","next_cursor":null,"next_campaign_id":"202","complete":false}}}]}
+JSON
+first=$(run_fixture "$TMP_DIR/campaign-first.json" conn_campaigns campaigns --budget 5)
+assert_eq "one selected campaign page pauses with a durable campaign cursor" "$(json_field "$first" status)" budget_exhausted
+assert_eq "first campaign evidence reaches corpus search" "$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'knowledge'")" 1
+
+cat >"$TMP_DIR/campaign-resume.json" <<JSON
+{"identity":{"data":{"provider_account_id":"${ACCOUNT_ID}","role":"creator","is_creator":true,"campaign_ids":["101","202"],"member_data_authorized":false}},"pages":[{
+  "expect_request":{"campaign_id":"202","cursor":null},
+  "response":{"status":200,"observed_at":"2026-08-02T20:01:00Z","data":[
+    {"kind":"campaign","remote_id":"campaign_202","campaign_id":"202","name":"Second Campaign"}],
+  "meta":{"stream":"campaigns","campaign_id":"202","next_cursor":null,"next_campaign_id":null,"complete":true}}}]}
+JSON
+second=$(run_fixture "$TMP_DIR/campaign-resume.json" conn_campaigns campaigns)
+assert_eq "explicit campaign sequence resumes and completes" "$(json_field "$second" status)" complete
+assert_eq "only selected creator campaigns persist" "$(sql_value "SELECT count(*) FROM objects WHERE provider='patreon' AND object_type='campaign'")" 2
+
+cat >"$TMP_DIR/posts-first.json" <<JSON
+{"identity":{"data":{"provider_account_id":"${ACCOUNT_ID}","role":"creator","is_creator":true,"campaign_ids":["101","202"],"member_data_authorized":false}},"pages":[{
+  "expect_request":{"campaign_id":"101","cursor":null},
+  "response":{"status":200,"observed_at":"2026-08-02T20:02:00Z","data":[
+    {"kind":"post","remote_id":"post_1","campaign_id":"101","title":"Private update","content":"Fixture-proven Patreon post","is_public":false,"published_at":"2026-08-01T10:00:00Z"}],
+  "meta":{"stream":"posts","campaign_id":"101","next_cursor":"cursor-a","next_campaign_id":null,"complete":false}}}]}
+JSON
+post_first=$(run_fixture "$TMP_DIR/posts-first.json" conn_posts posts --budget 5)
+assert_eq "opaque post cursor pauses independently" "$(json_field "$post_first" status)" budget_exhausted
+
+cat >"$TMP_DIR/posts-resume.json" <<JSON
+{"identity":{"data":{"provider_account_id":"${ACCOUNT_ID}","role":"creator","is_creator":true,"campaign_ids":["101","202"],"member_data_authorized":false}},"pages":[{
+  "expect_request":{"campaign_id":"101","cursor":"cursor-a"},
+  "response":{"status":200,"observed_at":"2026-08-02T20:03:00Z","data":[],
+  "meta":{"stream":"posts","campaign_id":"101","next_cursor":null,"next_campaign_id":"202","complete":false}}},{
+  "expect_request":{"campaign_id":"202","cursor":null},
+  "response":{"status":200,"observed_at":"2026-08-02T20:04:00Z","data":[],
+  "meta":{"stream":"posts","campaign_id":"202","next_cursor":null,"next_campaign_id":null,"complete":true}}}]}
+JSON
+post_second=$(run_fixture "$TMP_DIR/posts-resume.json" conn_posts posts --budget 8)
+assert_eq "post cursor and campaign fanout complete atomically" "$(json_field "$post_second" status)" complete
+assert_eq "post text is searchable" "$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'Patreon'")" 1
+
+cat >"$TMP_DIR/membership.json" <<JSON
+{"identity":{"data":{"provider_account_id":"${ACCOUNT_ID}","role":"creator","is_creator":true,"campaign_ids":["101","202"],"member_data_authorized":true}},"pages":[{
+  "response":{"status":200,"observed_at":"2026-08-02T20:05:00Z","data":[
+    {"kind":"membership","remote_id":"member_0123456789abcdef0123456789abcdef","campaign_id":"101","currently_entitled_amount_cents":500,"patron_status":"active_patron","tier_ids":["tier_101_t1"]}],
+  "meta":{"stream":"memberships","campaign_id":"101","next_cursor":null,"next_campaign_id":"202","complete":false}}}]}
+JSON
+membership=$(run_fixture "$TMP_DIR/membership.json" conn_members memberships --budget 5)
+assert_eq "purpose-gated minimized membership snapshot persists" "$(json_field "$membership" status)" budget_exhausted
+assert_eq "membership evidence is protected business data" \
+	"$(sql_value "SELECT evidence_class FROM objects WHERE provider='patreon' AND object_type='membership'")" protected_business
+persisted=$(raw_text)
+if [[ "$persisted" == *"direct-member-id"* || "$persisted" == *"full_name"* || "$persisted" == *"email"* || "$persisted" == *"address"* ]]; then
+	assert_eq "raw membership evidence excludes direct member PII" leaked excluded
+else
+	assert_eq "raw membership evidence excludes direct member PII" excluded excluded
+fi
+
+cat >"$TMP_DIR/mismatch.json" <<'JSON'
+{"identity":{"data":{"provider_account_id":"other_creator","role":"creator","is_creator":true,"campaign_ids":["101"],"member_data_authorized":false}},"pages":[]}
+JSON
+if run_fixture "$TMP_DIR/mismatch.json" conn_mismatch campaigns >/dev/null 2>&1; then
+	assert_eq "creator identity mismatch is rejected before persistence" accepted rejected
+else
+	assert_eq "creator identity mismatch is rejected before persistence" rejected rejected
+fi
+assert_eq "identity mismatch creates no connection" "$(sql_value "SELECT count(*) FROM connections WHERE connection_id='conn_mismatch'")" 0
+
+cat >"$TMP_DIR/campaign-mismatch.json" <<JSON
+{"identity":{"data":{"provider_account_id":"${ACCOUNT_ID}","role":"creator","is_creator":true,"campaign_ids":["101","202"],"member_data_authorized":false}},"pages":[{
+  "status":200,"observed_at":"2026-08-02T20:06:00Z","data":[],
+  "meta":{"stream":"posts","campaign_id":"202","next_cursor":null,"next_campaign_id":null,"complete":true}}]}
+JSON
+if run_fixture "$TMP_DIR/campaign-mismatch.json" conn_campaign_mismatch posts >/dev/null 2>&1; then
+	assert_eq "page campaign mismatch is rejected before persistence" accepted rejected
+else
+	assert_eq "page campaign mismatch is rejected before persistence" rejected rejected
+fi
+assert_eq "campaign mismatch preserves empty prior state" "$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_campaign_mismatch'")" 0
+
+cat >"$TMP_DIR/credential.json" <<JSON
+{"identity":{"data":{"provider_account_id":"${ACCOUNT_ID}","role":"creator","is_creator":true,"campaign_ids":["101","202"],"member_data_authorized":false}},"pages":[{
+  "status":200,"observed_at":"2026-08-02T20:07:00Z","data":[{"kind":"post","remote_id":"post_bad","client_secret":"must-not-persist"}],
+  "meta":{"stream":"posts","campaign_id":"101","next_cursor":null,"next_campaign_id":null,"complete":true}}]}
+JSON
+if run_fixture "$TMP_DIR/credential.json" conn_credential posts >/dev/null 2>&1; then
+	assert_eq "credential-shaped provider payload is rejected" accepted rejected
+else
+	assert_eq "credential-shaped provider payload is rejected" rejected rejected
+fi
+assert_eq "credential rejection preserves empty prior state" "$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_credential'")" 0
+
+cat >"$TMP_DIR/cursor-loop.json" <<JSON
+{"identity":{"data":{"provider_account_id":"${ACCOUNT_ID}","role":"creator","is_creator":true,"campaign_ids":["101","202"],"member_data_authorized":false}},"pages":[
+  {"response":{"status":200,"observed_at":"2026-08-02T20:08:00Z","data":[{"kind":"post","remote_id":"loop_1","campaign_id":"101"}],"meta":{"stream":"posts","campaign_id":"101","next_cursor":"loop-a","next_campaign_id":null,"complete":false}}},
+  {"expect_request":{"cursor":"loop-a"},"response":{"status":200,"observed_at":"2026-08-02T20:09:00Z","data":[{"kind":"post","remote_id":"loop_2","campaign_id":"101"}],"meta":{"stream":"posts","campaign_id":"101","next_cursor":"loop-b","next_campaign_id":null,"complete":false}}},
+  {"expect_request":{"cursor":"loop-b"},"response":{"status":200,"observed_at":"2026-08-02T20:10:00Z","data":[{"kind":"post","remote_id":"loop_3","campaign_id":"101"}],"meta":{"stream":"posts","campaign_id":"101","next_cursor":"loop-a","next_campaign_id":null,"complete":false}}}
+]}
+JSON
+if run_fixture "$TMP_DIR/cursor-loop.json" conn_loop posts --budget 11 >/dev/null 2>&1; then
+	assert_eq "multi-page cursor loop is rejected" accepted rejected
+else
+	assert_eq "multi-page cursor loop is rejected" rejected rejected
+fi
+assert_eq "cursor loop preserves the last coherent page and checkpoint" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='patreon' AND remote_id IN ('loop_1','loop_2')")" 2
+assert_eq "cursor loop never persists the looping page" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='patreon' AND remote_id='loop_3'")" 0
+
+cat >"$TMP_DIR/rate.json" <<JSON
+{"identity":{"data":{"provider_account_id":"${ACCOUNT_ID}","role":"creator","is_creator":true,"campaign_ids":["101","202"],"member_data_authorized":false}},"pages":[{"status":429,"observed_at":"2026-08-02T20:11:00Z","retry_after":60}]}
+JSON
+rate=$(run_fixture "$TMP_DIR/rate.json" conn_rate posts)
+assert_eq "rate limit pauses without checkpoint advancement" "$(json_field "$rate" failure_class):$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_rate'")" rate_limit:0
+run_terminal_case forbidden 403 authorization
+run_terminal_case unavailable 404 unavailable
+run_terminal_case provider 500 provider
+
+python3 - "$ROOT" "$SCRIPTS" <<'PY'
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[2])
+from _knowledge_social_collect import (
+    CollectionContext, ConnectionConfig, CursorState, PageCheckpoint, SuccessfulPage,
+)
+from _knowledge_social_collect_persist import persist_page
+from _knowledge_social_lease import (
+    RunLeaseRequest, SocialLeaseLostError, acquire_run_lease, release_run_lease,
+)
+from _knowledge_social_patreon import STREAMS
+
+root = Path(sys.argv[1])
+old = acquire_run_lease(
+    root, RunLeaseRequest("conn_patreon_fence", "posts", "old_runner", "sync", 1),
+    now_epoch=9000,
+)
+new = acquire_run_lease(
+    root, RunLeaseRequest("conn_patreon_fence", "posts", "new_runner", "sync", 10),
+    now_epoch=9001,
+)
+context = CollectionContext(
+    root, "conn_patreon_fence",
+    {"id": "creator_123", "campaign_ids": ["101"], "member_data_authorized": False},
+    "posts", "none", ConnectionConfig(("posts",), {"media_hydration": "none"}),
+    CursorState(None, None, False), STREAMS["posts"], old, "patreon",
+)
+archive = {
+    "provider": "patreon", "connection_id": "conn_patreon_fence",
+    "remote_account_id": "creator_123", "exported_at": "2026-08-02T20:12:00Z",
+    "enabled_streams": ["posts"], "policy": {"media_hydration": "none"},
+    "accounts": [], "objects": [], "activities": [], "media": [], "coverage": [],
+}
+successful = SuccessfulPage(
+    {"status": 200, "observed_at": archive["exported_at"], "data": [], "meta": {}},
+    '{"stream":"posts"}', archive, PageCheckpoint(None, None), True, 3,
+)
+os.environ["AIDEVOPS_SOCIAL_NOW_EPOCH"] = "9001"
+try:
+    persist_page(context, successful)
+except SocialLeaseLostError:
+    pass
+else:
+    raise SystemExit("stale Patreon collector advanced persistence")
+with sqlite3.connect(root / "index" / "social.db") as database:
+    count = database.execute(
+        "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_patreon_fence'"
+    ).fetchone()[0]
+assert count == 0
+release_run_lease(root, new)
+PY
+assert_eq "stale Patreon lease cannot commit evidence or a cursor" verified verified
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/tests/test-knowledge-social-registry.sh
+++ b/.agents/tests/test-knowledge-social-registry.sh
@@ -52,6 +52,7 @@ expected = {
     "mastodon": ("live",),
     "miniflux": ("live",),
     "nextcloud-talk": ("live",),
+    "patreon": ("live",),
     "readwise-reader": ("live",),
     "signal": ("inspect", "manual-import", "status"),
     "slack": ("archive", "live"),
@@ -101,14 +102,14 @@ except module.ProviderRegistryError:
 else:
     raise SystemExit("unknown provider used a fallback")
 
-print("19:order-independent:aliases-exact:collisions-rejected:no-fallback")
+print("20:order-independent:aliases-exact:collisions-rejected:no-fallback")
 PY
 )
 assert_eq "all merged provider outcomes register deterministically" \
-	"$registry_summary" "19:order-independent:aliases-exact:collisions-rejected:no-fallback"
+	"$registry_summary" "20:order-independent:aliases-exact:collisions-rejected:no-fallback"
 
 provider_count=$("$HELPER" providers | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
-assert_eq "helper exposes the complete provider registry" "$provider_count" "19"
+assert_eq "helper exposes the complete provider registry" "$provider_count" "20"
 
 forem_resolution=$("$HELPER" provider-resolve --provider dev-community |
 	python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["provider"] + ":" + ",".join(data["modes"]))')
@@ -133,6 +134,13 @@ if [[ "$hashnode_sync_help" == *"bounded, read-only Hashnode account stream"* ]]
 	assert_eq "Hashnode helper executes the same guarded local adapter" canonical canonical
 else
 	assert_eq "Hashnode helper executes the same guarded local adapter" unexpected canonical
+fi
+
+patreon_help=$("$HELPER" provider-run --provider patreon --mode live -- --help 2>&1)
+if [[ "$patreon_help" == *"bounded, read-only Patreon creator stream"* ]]; then
+	assert_eq "Patreon executes only the guarded creator adapter" canonical canonical
+else
+	assert_eq "Patreon executes only the guarded creator adapter" unexpected canonical
 fi
 
 if "$HELPER" provider-run --provider binance-square --mode no-route >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Add a bounded Patreon API v2 creator collector with owned-campaign rebinding, exact read scopes, purpose-gated HMAC-minimized membership data, registry and helper wiring, and explicit unsupported-role and category documentation.

## Files Changed

`.agents/aidevops/knowledge-plane/05-social-operations.md`, `.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md`, `.agents/content/social-patreon.md`, `.agents/scripts/_knowledge_social_patreon.py`, `.agents/scripts/_knowledge_social_patreon_contract.py`, `.agents/scripts/_knowledge_social_patreon_normalize.py`, `.agents/scripts/_knowledge_social_patreon_provider.py`, `.agents/scripts/_knowledge_social_patreon_reader.py`, `.agents/scripts/knowledge-social-helper.sh`, `.agents/scripts/knowledge_social_patreon.py`, `.agents/scripts/knowledge_social_registry.py`, `.agents/tests/test-knowledge-social-patreon.sh`, `.agents/tests/test-knowledge-social-registry.sh`

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Patreon suite 28/28; registry 12/12; social sync 35/35; knowledge corpus 45/45; changed Python compilation and ShellCheck passed; `.agents/scripts/linters-local.sh --changed` passed; focused security review confirmed fixed-origin GET-only transport, filtered credential environment, redirect rejection, bounded responses, and no direct member PII persistence.

Resolves #29321


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 55m and 895,051 tokens on this as a headless worker.
