### PR TITLE
GH#29320: Record bounded Google Sites knowledge no-route

### DIFF
--- a/.agents/aidevops/knowledge-plane/05-social-operations.md
+++ b/.agents/aidevops/knowledge-plane/05-social-operations.md
@@ -62,6 +62,16 @@ profile and Notes activity. No manifest, provider registry entry, helper command
 RSS/browser fallback, or persistence path is added. The evidence and activation
 gate are recorded in `.agents/content/social-substack.md`.
 
+Google Sites has no enabled collection route. The deprecated Sites API is
+classic-only and cannot access rebuilt Sites. Drive exposes a Sites MIME type and
+file metadata, but its supported export table provides no Sites content format or
+modern revision-history route. User Takeout is an identity/schema-unverified
+export candidate, the Data Portability API has no Sites scope, and organization
+export requires super-admin authority. No provider registry entry, helper command,
+Drive OAuth request, Takeout importer, browser fallback, or persistence path is
+added. The evidence and activation gate are recorded in
+`.agents/content/social-google-sites.md`.
+
 ## Live account collection
 
 Live collectors verify the selected stable account before the first evidence

--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -41,6 +41,7 @@ a claim that the route is enabled.
 | Quora | **Export/No** answers, questions, posts, and comments | **Export/No** bookmarks; **No** upvotes and other curation | **No** | **Export/No** user follows; **No** followed topics or Spaces | **No** | The official export has no published schema. Public content samples lack authoritative owner identity, and the companion account-data schema is unpublished; no adapter or CLI route is enabled. |
 | Skool | **No** posts, comments, and course content | **No** reactions and saved state | **No** notifications and messages | **No** memberships, follows, and groups | **No** courses and calendar feeds | **Export/No** admin membership-question answers only. The official Zapier surface is narrow event automation, the export schema and identity contract are unpublished, and provider policy excludes browser collection. |
 | Substack | **Export/No** publication posts; **No** Notes | **No** comments, likes, restacks, or saved Notes | **No** | **No** reader subscriptions or publication memberships | **No** | Creator ZIP/CSV exports lack published identity/schema contracts; public RSS is not account history, and **Gate/No** bestseller analytics require interactive MCP sign-in and consent. No adapter or CLI route is enabled. |
+| Google Sites | **Export/No** modern site content; **No** classic live API | **No** | **No** | **API/No** owner/editor metadata; **No** subscriptions | **No** | Drive exposes Sites MIME metadata but no documented Sites content, revision, or export MIME route; Takeout remains schema-free **Export/No**, and organization export is **Gate/No**. No adapter or CLI route is enabled. |
 | Discourse | **Live** topics and posts | **Live/Partial** likes, bookmarks, and current reading state | **Live/Gate/Partial** notifications and private-topic metadata; **No** message bodies | **Live/Partial** groups and category preferences; **No** unverified Follow plugin | **No** watched/tracked topic inventories until search behavior is verified | Ten User API `read` streams with per-installation namespaces, repeated identity checks, exact GET routes, redirect rejection, and explicit plugin/export/history gaps. |
 | NodeBB | **Live** topics and posts | **Live/Partial** votes, bookmarks, watched topics, and category state | **Live/Partial** notifications and chat-room metadata; **No** message bodies | **Live/Partial** follows and groups | **No** plugin-provided lists | Thirteen independently checkpointed core GET streams with per-installation identity, bounded pagination, and explicit admin/plugin/export/history gaps. |
 | Mastodon | **Live/Partial** authored statuses | **Live/Partial** favourites and bookmarks | **Live/Gate/Partial** notifications; **No/Gate** conversations | **Live/Partial** followers, following, and followed tags | **Live/Partial** lists; **No** nested membership | Eight exact-origin GET-only streams preserve opaque `Link` cursors and expose federation, moderation, deletion, export, and operator-retention gaps. |
@@ -253,6 +254,16 @@ separate provider family.
   proves that no provider module, registry entry, helper command, browser
   selector, or **Live** matrix claim is reachable until an identity-bearing,
   redirect-free official route is fixture-validated.
+- **Google Sites no-route disposition:**
+  `.agents/content/social-google-sites.md` separately records the deprecated
+  classic-only Sites API, Drive MIME/metadata and export-format boundary, user
+  Takeout, Data Portability scope omission, organization export gate, OAuth
+  identity/scopes, quotas, retention, and policy evidence checked on 2026-08-02.
+  `.agents/tests/test-knowledge-social-google-sites.sh` proves that no provider
+  module, registry entry, helper command, Drive metadata/export request, Takeout
+  importer, browser selector, or **Live** claim is reachable until exact account,
+  ownership, site-resource, format, pagination, and replay bindings are fixture-
+  validated.
 - **All candidate rows:** the provider child owns current official documentation,
   account/export samples, auth scopes, dependency versions, local exported
   symbols, retention evidence, and explicit unsupported findings.

--- a/.agents/content/social-google-sites.md
+++ b/.agents/content/social-google-sites.md
@@ -1,0 +1,261 @@
+---
+description: Modern and classic Google Sites API, Drive, and export no-route disposition
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  webfetch: true
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Google Sites Account Knowledge
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Importer**: none; no Google Sites provider module, registry entry, helper
+  command, Drive client, Takeout importer, or browser route exists
+- **Modern Sites**: Drive documents a Google Sites MIME type and file metadata,
+  but no supported Sites content, page, revision-history, or export MIME contract
+- **Classic Sites**: the deprecated Sites API is classic-only and cannot access
+  rebuilt Sites; Google's migration program is complete
+- **Export surfaces**: user Google Takeout includes Sites content, while Workspace
+  Data Export is administrator-gated; neither publishes a stable Sites archive
+  identity or versioned schema suitable for ingestion
+- **Current disposition**: **API/No** for Drive metadata, **Export/No** for user
+  Sites archives, **Gate/No** for organization exports, and **No** for live site
+  content, revisions, interactions, subscriptions, or lists
+- **Activation rule**: accept only an explicitly selected, user-owned site ID and
+  a documented content format or identity-bearing private export before adding
+  parsing, persistence, or CLI wiring
+
+No API client, metadata collector, export importer, or browser route is enabled.
+
+<!-- AI-CONTEXT-END -->
+
+## Evidence boundary
+
+The official product, Drive, Takeout, Data Portability, identity, quota, and
+policy surfaces were checked on 2026-08-02. No third-party endpoint, private
+network call, response field, error code, or client symbol is mapped. Metadata
+availability is not represented as site-content availability.
+
+Google's Sites developer page is explicit that the Sites API is deprecated, may
+stop working at any time, can access only classic Sites, and cannot access the
+rebuilt Sites product launched in 2016:
+https://developers.google.com/workspace/sites.
+
+The separate official migration notice set January 30, 2023 as the deadline for
+remaining classic Sites, and Google's January 2025 Workspace recap says the
+migration from classic Sites is complete:
+http://workspaceupdates.googleblog.com/2022/11/migrate-classic-google-sites-by-january-30-2023.html
+and
+http://workspaceupdates.googleblog.com/2025/01/release-notes-01-24-2025.html.
+
+The classic API's historical page, content, comment, attachment, ACL, and
+revision methods therefore do not authorize a modern Sites collector. This route
+does not send requests to that deprecated API or infer that migrated content
+retains classic resource IDs.
+
+## Drive metadata is not Sites content
+
+Drive's supported-MIME reference lists `application/vnd.google-apps.site` as
+Google Sites and says MIME types can filter query results:
+https://developers.google.com/workspace/drive/api/guides/mime-types.
+
+The reference does not distinguish modern from classic Sites or claim that the
+MIME resource exposes pages, rendered content, embeds, attachments, comments, or
+revision history. `files.list` lists all files, including trashed files by
+default, and supports query filters and page tokens:
+https://developers.google.com/workspace/drive/api/reference/rest/v3/files/list.
+
+The Drive `File` resource exposes metadata such as `id`, `mimeType`, `name`,
+`createdTime`, `modifiedTime`, `ownedByMe`, `owners`, `permissions`, `driveId`,
+`resourceKey`, and `webViewLink`:
+https://developers.google.com/workspace/drive/api/reference/rest/v3/files.
+
+That reference also says `driveId` is populated for shared-drive items, while
+`owners` is not populated for those items. A future user-owned route must reject
+shared-drive resources rather than weakening the owner binding. A browser
+`webViewLink`, thumbnail link, resource key, or export link is metadata, not
+authority to crawl, redirect, or download arbitrary content.
+
+`files.get` can retrieve one exact file's metadata by ID. Its `alt=media` content
+path applies to files stored in Drive, while the page directs Google Workspace
+documents to `files.export`:
+https://developers.google.com/workspace/drive/api/reference/rest/v3/files/get.
+
+Metadata methods accept `drive.metadata.readonly`, but Google classifies that
+all-file metadata scope as sensitive. Google recommends the non-sensitive
+`drive.file` scope for files explicitly opened or shared with an app and says to
+request the narrowest scope possible:
+https://developers.google.com/workspace/drive/api/guides/api-specific-auth.
+
+Drive `about.get(fields=user)` can return the current user's `permissionId` and
+email address:
+https://developers.google.com/workspace/drive/api/guides/user-info.
+
+For account identity, Google OpenID Connect says the `sub` claim is unique,
+never reused, and unchanged when email changes; email must not be the primary
+identifier:
+https://developers.google.com/identity/protocols/oauth2/openid-connect.
+
+These primitives could bind an explicitly selected file's metadata to an
+expected Google account, but they expose no documented site corpus. A metadata-
+only adapter would advertise collection without collecting the requested site
+content or history, so no Drive OAuth scope or collector is enabled.
+
+## No documented Drive content or revision route
+
+`files.export` requires a requested MIME type from Drive's supported export
+table and limits exported content to 10 MB:
+https://developers.google.com/workspace/drive/api/reference/rest/v3/files/export.
+
+The current export table lists Documents, Spreadsheets, Presentations, Drawings,
+Apps Script, and Google Vids, but no Google Sites document type or export MIME
+type:
+https://developers.google.com/workspace/drive/api/guides/ref-export-formats.
+
+This is a documented omission, not permission to guess an HTML, ZIP, PDF, or
+other target. The newer `files.download` method accepts only supported Workspace
+document MIME types, says its unspecified default may change, and does not add a
+Sites format:
+https://developers.google.com/workspace/drive/api/reference/rest/v3/files/download.
+
+The Drive `File.headRevisionId` field is documented only for binary Drive files,
+and `files.download.revisionId` supports blob files, Docs, and Sheets. Neither is
+a documented modern Sites revision-history route. No export request, default
+download, browser render, published-site crawl, or revision inference is made.
+
+## Takeout and administrator export gates
+
+Google's product-specific export help says a Drive download includes Sites and
+lists draft and published sites, embedded URLs and pages, navigation, themes,
+site content, attachments, lists, page templates, and site owners:
+https://support.google.com/docs/answer/9759608.
+
+The general Takeout workflow is user-initiated, may omit changes made between
+request and archive creation, and can delay risky requests:
+https://support.google.com/accounts/answer/3024190.
+
+Neither page publishes a Sites container layout, schema version, immutable site
+resource ID, account identity field, modern-versus-classic marker, revision
+semantics, segmentation contract, generation quota, or per-file expiry. The
+category is therefore **Export/No** until a current private owner archive proves
+identity, format, completeness, and replay behavior.
+
+Google does expose a programmatic Data Portability API, but its page says the
+published scope list contains every supported scope. The current list contains
+no Google Sites or Google Drive scope:
+https://developers.google.com/data-portability/user-guide/scopes.
+
+The archive-job API cannot widen that product allowlist:
+https://developers.google.com/data-portability/reference/rest.
+
+Workspace's Data Export tool exports organization data to Cloud Storage and can
+include the same Drive/Sites data available through Takeout. It requires a
+super-administrator account at least 30 days old and 2-Step Verification, has a
+security delay, can take up to 14 days, and places broad organization data into
+an archive:
+https://support.google.com/a/answer/100458.
+
+That is an administrator-controlled **Gate/No** route, not authority for a
+personal site collector. This implementation does not request super-admin
+access, enumerate organization users, fetch Cloud Storage archive objects, or
+ingest organization-wide data.
+
+## Requested coverage
+
+| Requested category | Current official evidence | Disposition |
+|---|---|---|
+| Modern site pages and authored content | Manual Takeout includes Sites content; no Drive/Sites content API or published archive schema | **Export/No** |
+| Modern site resource metadata | Drive exposes a Sites MIME type and file metadata, but metadata alone is not a site corpus | **API/No** |
+| Modern page or site revision history | No modern Sites API or documented Drive revision/export route | **No** |
+| Classic Sites content and revisions | Deprecated classic-only API; migration program is complete | **No** |
+| Embeds, attachments, navigation, themes, and templates | Named by Takeout help without a versioned artifact contract | **Export/No** |
+| Site owners, editors, and permissions | Drive metadata and Takeout owner data exist, but no enabled identity-bound collection route | **API/No** |
+| Comments, mentions, messages, notifications, and interaction history | No supported modern Sites account-history route was verified | **No** |
+| Site subscriptions, relationships, lists, or custom feeds | No supported route was verified | **No** |
+| User-requested Sites archive | Manual Google Takeout workflow with unpublished Sites schema and resource binding | **Export/No** |
+| Organization-wide Sites export | Workspace super-admin Data Export workflow | **Gate/No** |
+
+An unavailable category is not a successful empty result. Drive metadata cannot
+fill a site-content category, and organization exports cannot be reclassified as
+ordinary user authority.
+
+## Pagination, quotas, and failure boundary
+
+Although no route is enabled, the future activation contract is explicit.
+`files.list` and `permissions.list` use opaque `nextPageToken` values; rejected
+tokens restart from the first page, and `incompleteSearch=true` means results are
+missing. Permissions can also be paginated:
+https://developers.google.com/workspace/drive/api/reference/rest/v3/permissions/list.
+
+Drive's current quota model charges reads, lists, and downloads differently and
+uses `403` and `429` for rate-limit failures. It requires bounded exponential
+backoff rather than indefinite retries:
+https://developers.google.com/workspace/drive/api/guides/limits.
+
+A future collector must keep independent account, resource, permission, content,
+and export checkpoints. Any missing page, rejected token, incomplete search,
+quota stop, malformed response, account or site mismatch, redirect, unsupported
+format, or stale lease must leave prior evidence and checkpoints unchanged.
+
+## Why ingestion is disabled
+
+The social-store contract requires both authoritative selected-account/resource
+identity and supported content semantics before raw persistence. Drive can prove
+that an exact file is Sites-shaped and expose ownership metadata, but the
+official export table provides no Sites content format or revision route.
+Takeout exposes content through an interactive, schema-free artifact; the Data
+Portability API has no Sites scope; administrator export is over-broad.
+
+Implementing from filenames, site names, public URLs, `webViewLink`, guessed
+export MIME types, default downloads, published-site crawling, redirects,
+screenshots, or caller-supplied account labels would permit wrong-site or
+cross-account persistence. No placeholder adapter, registry entry, helper
+command, OAuth request, browser selector, or persistence path is added.
+`.agents/tests/test-knowledge-social-google-sites.sh` enforces that negative
+contract.
+
+## Activation checklist
+
+Before enabling any Google Sites route:
+
+1. Revalidate modern and classic Sites, Drive, Takeout, Data Portability, Admin
+   export, OAuth, quota, retention, and User Data Policy documentation.
+2. Use OpenID Connect `sub` plus the expected Drive `permissionId` to bind the
+   selected Google account; treat email only as local corroboration.
+3. Require explicit user-selected site resource IDs. Prefer `drive.file`; do not
+   enumerate unrelated Drive content or silently widen to all-file scopes.
+4. For every resource, require exact ID, `application/vnd.google-apps.site`,
+   `ownedByMe=true`, the expected owner permission ID, `trashed=false`, and no
+   shared-drive `driveId` before any evidence write.
+5. Use only an officially documented Sites content/export format. Reject default
+   MIME selection, browser/view/thumbnail/export URLs, redirects, resource-key
+   substitution, and cross-site responses.
+6. For a private Takeout artifact, prove the selected account and site ID inside
+   the artifact before raw persistence; reject traversal, links, duplicate paths,
+   malformed members, credentials, unknown schemas, and unexplained categories.
+7. Add hard request, item, page, permission, byte, and retry budgets; preserve
+   opaque page tokens, reject incomplete searches, stop on quota/terminal errors,
+   and commit each independent checkpoint atomically behind a final lease fence.
+8. Test account and site rebinding, ownership changes, shared-drive responses,
+   pagination restart, malformed exports, schema drift, quota stops, redirects,
+   content-addressed replay, stale leases, and static isolation from every write
+   or mutation path.
+9. Register and advertise only fixture-proven categories; retain explicit
+   **Export**, **Gate**, or **No** coverage for all unsupported surfaces.
+
+Google's User Data Policy requires minimum relevant permissions, prominent data
+disclosures, secure handling, and Limited Use of sensitive or restricted data:
+https://developers.google.com/terms/api-services-user-data-policy.
+
+OAuth policy additionally requires the smallest necessary scope and permanent
+token deletion after revocation:
+https://developers.google.com/identity/protocols/oauth2/policies.

--- a/.agents/tests/test-knowledge-social-google-sites.sh
+++ b/.agents/tests/test-knowledge-social-google-sites.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-google-sites.sh — Google Sites no-route contract tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SCRIPTS_DIR="${REPO_ROOT}/.agents/scripts"
+HELPER="${SCRIPTS_DIR}/knowledge-social-helper.sh"
+BROWSER="${SCRIPTS_DIR}/knowledge_social_browser.py"
+REGISTRY="${SCRIPTS_DIR}/knowledge_social_registry.py"
+OPERATIONS="${REPO_ROOT}/.agents/aidevops/knowledge-plane/05-social-operations.md"
+MATRIX="${REPO_ROOT}/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md"
+DOC="${REPO_ROOT}/.agents/content/social-google-sites.md"
+PASS=0
+FAIL=0
+
+record_pass() {
+	local description="$1"
+	PASS=$((PASS + 1))
+	printf '  PASS  %s\n' "$description"
+	return 0
+}
+
+record_fail() {
+	local description="$1"
+	FAIL=$((FAIL + 1))
+	printf '  FAIL  %s\n' "$description"
+	return 0
+}
+
+assert_contains() {
+	local file="$1"
+	local expected="$2"
+	local description="$3"
+	if grep -Fq -- "$expected" "$file"; then
+		record_pass "$description"
+	else
+		record_fail "$description"
+	fi
+	return 0
+}
+
+printf 'Google Sites account knowledge no-route contract\n'
+
+assert_contains "$DOC" 'https://developers.google.com/workspace/sites' \
+	'classic-only deprecated Sites API evidence is recorded'
+assert_contains "$DOC" \
+	'https://developers.google.com/workspace/drive/api/guides/mime-types' \
+	'Drive Sites MIME metadata evidence is recorded'
+assert_contains "$DOC" \
+	'https://developers.google.com/workspace/drive/api/guides/ref-export-formats' \
+	'Drive export-format omission is recorded'
+assert_contains "$DOC" 'https://support.google.com/docs/answer/9759608' \
+	'official Takeout Sites coverage is recorded'
+assert_contains "$DOC" \
+	'https://developers.google.com/data-portability/user-guide/scopes' \
+	'Data Portability product-scope boundary is recorded'
+assert_contains "$DOC" 'https://support.google.com/a/answer/100458' \
+	'Workspace administrator export gate is recorded'
+assert_contains "$DOC" \
+	'No API client, metadata collector, export importer, or browser route is enabled.' \
+	'documentation states every disabled route explicitly'
+assert_contains "$OPERATIONS" 'Google Sites has no enabled collection route.' \
+	'operations guide records the disabled route'
+
+google_sites_row=$(grep -F '| Google Sites |' "$MATRIX" || true)
+if [[ -z "$google_sites_row" ]]; then
+	record_fail 'capability matrix contains a Google Sites row'
+else
+	record_pass 'capability matrix contains a Google Sites row'
+fi
+if [[ "$google_sites_row" == *'**Live'* ]]; then
+	record_fail 'capability matrix keeps Google Sites non-Live'
+else
+	record_pass 'capability matrix keeps Google Sites non-Live'
+fi
+if [[ "$google_sites_row" == *'**Export/No** modern site content; **No** classic live API'* &&
+	"$google_sites_row" == *'**API/No** owner/editor metadata; **No** subscriptions'* &&
+	"$google_sites_row" == *'schema-free **Export/No**'* &&
+	"$google_sites_row" == *'organization export is **Gate/No**'* ]]; then
+	record_pass 'modern, classic, metadata, export, and admin gates remain explicit'
+else
+	record_fail 'modern, classic, metadata, export, and admin gates remain explicit'
+fi
+
+if [[ -e "${SCRIPTS_DIR}/knowledge_social_google_sites.py" ]]; then
+	record_fail 'no Google Sites provider entry point exists'
+else
+	record_pass 'no Google Sites provider entry point exists'
+fi
+shopt -s nullglob
+google_sites_modules=("${SCRIPTS_DIR}"/_knowledge_social_google_sites*.py)
+shopt -u nullglob
+if [[ "${#google_sites_modules[@]}" -eq 0 ]]; then
+	record_pass 'no placeholder Google Sites support modules exist'
+else
+	record_fail 'no placeholder Google Sites support modules exist'
+fi
+
+if grep -Eiq 'GOOGLE_SITES_HELPER|import-google-sites|sync-google-sites|collect-google-sites' "$HELPER"; then
+	record_fail 'social helper exposes no Google Sites route'
+else
+	record_pass 'social helper exposes no Google Sites route'
+fi
+if grep -Eiq 'google[-_]sites' "$BROWSER"; then
+	record_fail 'browser collector exposes no Google Sites selector'
+else
+	record_pass 'browser collector exposes no Google Sites selector'
+fi
+if grep -Eiq 'google[-_]sites' "$REGISTRY"; then
+	record_fail 'provider registry exposes no Google Sites route'
+else
+	record_pass 'provider registry exposes no Google Sites route'
+fi
+
+if "$HELPER" import-google-sites-export \
+	--archive "${SCRIPT_DIR}/fixtures/untrusted-google-sites-export.zip" \
+	--connection-id conn_google_sites_test --account-id account_google_sites_test \
+	>/dev/null 2>&1; then
+	record_fail 'export-shaped input cannot reach persistence'
+else
+	record_pass 'export-shaped input cannot reach persistence'
+fi
+if "$HELPER" sync-google-sites --site-id site_google_sites_test \
+	--connection-id conn_google_sites_test --account-id account_google_sites_test \
+	>/dev/null 2>&1; then
+	record_fail 'site-shaped input cannot reach a Drive metadata route'
+else
+	record_pass 'site-shaped input cannot reach a Drive metadata route'
+fi
+if "$HELPER" provider-run --provider google-sites --mode no-route \
+	>/dev/null 2>&1; then
+	record_fail 'provider dispatch cannot execute a Google Sites placeholder'
+else
+	record_pass 'provider dispatch cannot execute a Google Sites placeholder'
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -ne 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Document the official modern/classic Google Sites API, Drive metadata/export, Takeout, Data Portability, and administrator-export boundaries; record a fail-closed no-route disposition and add a negative reachability contract.

## Files Changed

.agents/aidevops/knowledge-plane/05-social-operations.md, .agents/aidevops/knowledge-plane/06-social-provider-capabilities.md, .agents/content/social-google-sites.md, .agents/tests/test-knowledge-social-google-sites.sh

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Static-only verification: Google Sites contract test (19 passed); social registry (9 passed); social sync (35 passed); social operations (56 passed); knowledge corpus (45 passed); ShellCheck, Python compilation, git diff --check, and linters-local.sh --changed all passed. Closeout evidence bundle 2277b815b78d77d4466aec835d5f3d9d556ee7ffed5fa7b2eaefb5f250be8d74 reviewed clean.

Resolves #29320


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 21m and 388,102 tokens on this as a headless worker.