### PR TITLE
GH#29342: Reuse shared Forem fixture reader

### DIFF
--- a/.agents/scripts/_knowledge_social_forem_reader.py
+++ b/.agents/scripts/_knowledge_social_forem_reader.py
@@ -9,7 +9,7 @@ import json
 from pathlib import Path
 from typing import Any, Protocol
 
-from _knowledge_social_fixture import FixtureSequence
+from _knowledge_social_fixture import FixturePageReader
 from _knowledge_social_forem import (
     ForemAdapterError,
     ForemProviderUnavailableError,
@@ -84,38 +84,11 @@ class GuardedForem(GuardedOAuthReader):
         super().__init__(helper, profile, FOREM_READER_POLICY)
 
 
-def _fixture_object(value: Any, message: str) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        raise ForemAdapterError(message)
-    return value
-
-
-class FixtureForem:
+class FixtureForem(FixturePageReader):
     """Deterministic HTTP substitute for pagination and failure fixtures."""
 
     def __init__(self, path: Path) -> None:
-        self.fixture = FixtureSequence(path, "Forem", ForemAdapterError)
-
-    def identity(self, expected_id: str) -> dict[str, Any]:
-        del expected_id
-        return self.fixture.identity()
-
-    def page(self, request: PageRequest) -> dict[str, Any]:
-        entry = self.fixture.next_page()
-        expectation = _fixture_object(
-            entry.get("expect_request", {}),
-            "Forem fixture request expectation must be an object",
-        )
-        actual = request.payload()
-        for key, value in expectation.items():
-            if actual.get(key) != value:
-                raise ForemAdapterError(
-                    "Forem request did not resume at the expected checkpoint"
-                )
-        return _fixture_object(
-            entry.get("response", entry),
-            "Forem fixture page response must be an object",
-        )
+        super().__init__(path, "Forem", ForemAdapterError)
 
 
 def _display_text(value: Any, field: str) -> str | None:


### PR DESCRIPTION
## Summary

Reuse the shared deterministic fixture reader for Forem instead of maintaining a provider-local copy of the request-validation flow.

## Changes

- `.agents/scripts/_knowledge_social_forem_reader.py`: make `FixtureForem` a thin `FixturePageReader` subclass.
- Preserve the provider-specific class, error type, request validation, and exact error wording through the existing shared constructor contract.
- Remove 27 lines of duplicated fixture mechanics without changing the public API.

## Testing

- `python3 -m py_compile .agents/scripts/_knowledge_social_forem_reader.py .agents/scripts/_knowledge_social_fixture.py`
- `bash .agents/tests/test-knowledge-social-forem.sh` (31 passed, 0 failed)
- `~/.qlty/bin/qlty smells .agents/scripts/_knowledge_social_forem_reader.py --no-snippets --quiet` (zero findings)
- `git diff --check origin/main...HEAD`

## Qlty Baseline Evidence

- The PR-specific Qlty regression gate and Qlty maintainability scan pass.
- The target-file scan reports zero findings, removing the cited `qlty:similar-code` result.
- The advisory absolute scan reports 58 repository-wide smells against threshold 49, improved from the issue baseline of 60; this PR neither raises the threshold nor uses an unrelated-baseline override.

## Runtime Testing

- Self-assessed low-risk structural refactor; the deterministic Forem integration suite exercised pagination, resume checkpoints, identity mismatch handling, terminal provider responses, and stale-lease fencing.

Resolves #29342

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 17m and 183,291 tokens on this as a headless worker.
