### PR TITLE
GH#29339: Reduce Mastodon request duplication

### DIFF
--- a/.agents/scripts/_knowledge_social_mastodon.py
+++ b/.agents/scripts/_knowledge_social_mastodon.py
@@ -111,6 +111,15 @@ def _decode_cursor(cursor: str) -> tuple[int, str]:
     return _position(parsed["position"]), next_url
 
 
+def _request_identity(identity: dict[str, Any]) -> tuple[str, str, str]:
+    """Validate fields shared by collection and provider requests."""
+    return (
+        provider_account_id(identity.get("provider_account_id")),
+        account_handle(identity.get("acct")),
+        instance_id(identity.get("instance_id")),
+    )
+
+
 def page_request(stream: str, account: dict[str, Any], state: CursorState, limit: int) -> PageRequest:
     if stream not in STREAMS:
         raise MastodonAdapterError("Mastodon stream is unsupported")
@@ -121,14 +130,7 @@ def page_request(stream: str, account: dict[str, Any], state: CursorState, limit
     if selected_id is None:
         raise MastodonAdapterError("verified Mastodon identity is incomplete")
     return PageRequest(
-        stream,
-        selected_id,
-        provider_account_id(account.get("provider_account_id")),
-        account_handle(account.get("acct")),
-        instance_id(account.get("instance_id")),
-        position,
-        next_url,
-        limit,
+        stream, selected_id, *_request_identity(account), position, next_url, limit,
     )
 
 
@@ -147,9 +149,7 @@ def parse_page_request(payload: dict[str, Any]) -> PageRequest:
     return PageRequest(
         stream,
         account_id,
-        provider_account_id(payload.get("provider_account_id")),
-        account_handle(payload.get("acct")),
-        instance_id(payload.get("instance_id")),
+        *_request_identity(payload),
         _position(payload.get("position")),
         _text(payload.get("stop_at"), "next link", optional=True),
         limit,


### PR DESCRIPTION
## Summary

Extract shared Mastodon request identity validation so collection and provider request builders no longer duplicate the same field assembly.

## Files Changed

.agents/scripts/_knowledge_social_mastodon.py

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — python3 -m py_compile .agents/scripts/_knowledge_social_mastodon.py; bash .agents/tests/test-knowledge-social-mastodon.sh (14 passed); qlty smells .agents/scripts/_knowledge_social_mastodon.py --no-snippets --quiet (0 smells)

Resolves #29339


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 11m and 122,695 tokens on this as a headless worker.