### PR TITLE
GH#29357: reduce OAuth pool auth file complexity

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool-auth-anthropic.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-auth-anthropic.mjs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/**
+ * OAuth Pool — Anthropic Auth Hook
+ *
+ * @module oauth-pool-auth-anthropic
+ */
+
+import {
+  ANTHROPIC_CLIENT_ID, ANTHROPIC_OAUTH_AUTHORIZE_URL,
+  ANTHROPIC_REDIRECT_URI, ANTHROPIC_OAUTH_SCOPES,
+} from "./oauth-pool-constants.mjs";
+import { getAccounts } from "./oauth-pool-storage.mjs";
+import {
+  generatePKCE, generateState, makeEmailPrompt,
+} from "./oauth-pool-callback.mjs";
+import { handleAnthropicCallback } from "./oauth-pool-auth-handlers.mjs";
+
+export function createPoolAuthHook(client) {
+  return {
+    provider: "anthropic-pool",
+    methods: [{
+      get label() {
+        const a = getAccounts("anthropic");
+        return a.length === 0
+          ? "Add Account to Pool (Claude Pro/Max)"
+          : `Add Account to Pool (${a.length} account${a.length === 1 ? "" : "s"})`;
+      },
+      type: "oauth",
+      prompts: [makeEmailPrompt("anthropic")],
+      authorize: async (inputs) => {
+        const email = inputs?.email || "unknown";
+        const pkce = generatePKCE();
+        const state = generateState(); // separate nonce — pkce.verifier stays secret
+        const url = new URL(ANTHROPIC_OAUTH_AUTHORIZE_URL);
+        url.searchParams.set("code", "true");
+        url.searchParams.set("client_id", ANTHROPIC_CLIENT_ID);
+        url.searchParams.set("response_type", "code");
+        url.searchParams.set("redirect_uri", ANTHROPIC_REDIRECT_URI);
+        url.searchParams.set("scope", ANTHROPIC_OAUTH_SCOPES);
+        url.searchParams.set("code_challenge", pkce.challenge);
+        url.searchParams.set("code_challenge_method", "S256");
+        url.searchParams.set("state", state);
+        return {
+          url: url.toString(),
+          instructions: `Adding account: ${email}\nPaste the authorization code here: `,
+          method: "code",
+          callback: (code) => handleAnthropicCallback(code, pkce, state, email, client),
+        };
+      },
+    }],
+  };
+}

--- a/.agents/plugins/opencode-aidevops/oauth-pool-auth-google.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-auth-google.mjs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/**
+ * OAuth Pool — Google Auth Hook
+ *
+ * @module oauth-pool-auth-google
+ */
+
+import {
+  GOOGLE_CLIENT_ID, GOOGLE_OAUTH_AUTHORIZE_URL,
+  GOOGLE_REDIRECT_URI, GOOGLE_OAUTH_SCOPES,
+} from "./oauth-pool-constants.mjs";
+import { getAccounts } from "./oauth-pool-storage.mjs";
+import {
+  generatePKCE, generateState, makeEmailPrompt,
+} from "./oauth-pool-callback.mjs";
+import { handleGoogleCallback } from "./oauth-pool-auth-handlers.mjs";
+
+export function createGooglePoolAuthHook(client) {
+  return {
+    provider: "google-pool",
+    methods: [{
+      get label() {
+        const a = getAccounts("google");
+        return a.length === 0
+          ? "Add Account to Pool (Google AI Pro/Ultra/Workspace)"
+          : `Add Account to Pool (${a.length} account${a.length === 1 ? "" : "s"})`;
+      },
+      type: "oauth",
+      prompts: [makeEmailPrompt("google", "you@gmail.com")],
+      authorize: async (inputs) => {
+        const email = inputs?.email || "unknown";
+        const pkce = generatePKCE();
+        const state = generateState(); // separate nonce — pkce.verifier stays secret
+        const url = new URL(GOOGLE_OAUTH_AUTHORIZE_URL);
+        url.searchParams.set("client_id", GOOGLE_CLIENT_ID);
+        url.searchParams.set("response_type", "code");
+        url.searchParams.set("redirect_uri", GOOGLE_REDIRECT_URI);
+        url.searchParams.set("scope", GOOGLE_OAUTH_SCOPES);
+        url.searchParams.set("code_challenge", pkce.challenge);
+        url.searchParams.set("code_challenge_method", "S256");
+        url.searchParams.set("access_type", "offline");
+        url.searchParams.set("prompt", "consent");
+        url.searchParams.set("state", state);
+        return {
+          url: url.toString(),
+          instructions: [
+            `Adding Google AI account: ${email}`,
+            "1. A browser window will open to accounts.google.com",
+            "2. Sign in with your Google AI Pro/Ultra or Workspace account",
+            "3. Copy the authorization code shown in the browser",
+            "4. Paste the authorization code here: ",
+          ].join("\n"),
+          method: "code",
+          callback: (code) => handleGoogleCallback(code, pkce, state, email, client),
+        };
+      },
+    }],
+  };
+}

--- a/.agents/plugins/opencode-aidevops/oauth-pool-auth-openai.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-auth-openai.mjs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/**
+ * OAuth Pool — OpenAI Auth Hook
+ *
+ * @module oauth-pool-auth-openai
+ */
+
+import {
+  OPENAI_CLIENT_ID, OPENAI_OAUTH_AUTHORIZE_URL,
+  OPENAI_REDIRECT_URI, OPENAI_OAUTH_SCOPES,
+} from "./oauth-pool-constants.mjs";
+import { getAccounts } from "./oauth-pool-storage.mjs";
+import {
+  generatePKCE, generateState, makeEmailPrompt, initCallbackServerSafe,
+} from "./oauth-pool-callback.mjs";
+import { handleOpenAICallback } from "./oauth-pool-auth-handlers.mjs";
+
+export function createOpenAIPoolAuthHook(client) {
+  return {
+    provider: "openai-pool",
+    methods: [{
+      get label() {
+        const a = getAccounts("openai");
+        return a.length === 0
+          ? "Add Account to Pool (ChatGPT Plus/Pro)"
+          : `Add Account to Pool (${a.length} account${a.length === 1 ? "" : "s"})`;
+      },
+      type: "oauth",
+      prompts: [makeEmailPrompt("openai")],
+      authorize: async (inputs) => {
+        const email = inputs?.email || "unknown";
+        const pkce = generatePKCE();
+        const state = generateState(); // separate nonce — pkce.verifier stays secret
+        const cs = await initCallbackServerSafe(state);
+        const url = new URL(OPENAI_OAUTH_AUTHORIZE_URL);
+        url.searchParams.set("client_id", OPENAI_CLIENT_ID);
+        url.searchParams.set("response_type", "code");
+        url.searchParams.set("redirect_uri", OPENAI_REDIRECT_URI);
+        url.searchParams.set("scope", OPENAI_OAUTH_SCOPES);
+        url.searchParams.set("code_challenge", pkce.challenge);
+        url.searchParams.set("code_challenge_method", "S256");
+        url.searchParams.set("state", state);
+        return {
+          url: url.toString(),
+          instructions: [
+            `Adding OpenAI account: ${email}`,
+            "1. A browser window will open to auth.openai.com",
+            "2. Sign in with your ChatGPT Plus/Pro account",
+            cs.ready ? "3. The code will be captured automatically" : "3. Copy the authorization code from the browser URL",
+            cs.ready ? "4. Press Enter here to complete (or paste manually): " : "4. Paste the authorization code here: ",
+          ].join("\n"),
+          method: "code",
+          callback: (code) => handleOpenAICallback(code, pkce, email, cs, client),
+        };
+      },
+    }],
+  };
+}

--- a/.agents/plugins/opencode-aidevops/oauth-pool-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-auth.mjs
@@ -1,117 +1,24 @@
 /**
  * OAuth Pool — Auth Hooks & Handlers (t2128 refactor)
  *
- * Contains provider auth hooks (anthropic, openai, cursor, google).
- * Token exchange handlers live in oauth-pool-auth-handlers.mjs, and provider
- * registration is re-exported from oauth-pool-auth-provider.mjs.
+ * Re-exports the browser OAuth provider hooks and contains the lightweight
+ * Cursor API auth hook. Token exchange handlers live in
+ * oauth-pool-auth-handlers.mjs, and provider registration is re-exported from
+ * oauth-pool-auth-provider.mjs.
  *
- * Depends on: oauth-pool-constants, oauth-pool-storage, oauth-pool-callback,
- * and oauth-pool-auth-handlers.
+ * Depends on: oauth-pool-storage, oauth-pool-callback, and
+ * oauth-pool-auth-handlers.
  *
  * @module oauth-pool-auth
  */
 
-import {
-  ANTHROPIC_CLIENT_ID, ANTHROPIC_OAUTH_AUTHORIZE_URL,
-  ANTHROPIC_REDIRECT_URI, ANTHROPIC_OAUTH_SCOPES,
-  OPENAI_CLIENT_ID, OPENAI_OAUTH_AUTHORIZE_URL,
-  OPENAI_REDIRECT_URI, OPENAI_OAUTH_SCOPES,
-  GOOGLE_CLIENT_ID, GOOGLE_OAUTH_AUTHORIZE_URL,
-  GOOGLE_REDIRECT_URI, GOOGLE_OAUTH_SCOPES,
-} from "./oauth-pool-constants.mjs";
-
 import { getAccounts } from "./oauth-pool-storage.mjs";
-
-import {
-  generatePKCE, generateState, makeEmailPrompt, initCallbackServerSafe,
-} from "./oauth-pool-callback.mjs";
-
-import {
-  handleAnthropicCallback, handleOpenAICallback,
-  handleCursorAuthorize, handleGoogleCallback,
-} from "./oauth-pool-auth-handlers.mjs";
+import { makeEmailPrompt } from "./oauth-pool-callback.mjs";
+import { handleCursorAuthorize } from "./oauth-pool-auth-handlers.mjs";
 
 // ---------------------------------------------------------------------------
 // Auth hooks (thin wrappers)
 // ---------------------------------------------------------------------------
-
-export function createPoolAuthHook(client) {
-  return {
-    provider: "anthropic-pool",
-    methods: [{
-      get label() {
-        const a = getAccounts("anthropic");
-        return a.length === 0
-          ? "Add Account to Pool (Claude Pro/Max)"
-          : `Add Account to Pool (${a.length} account${a.length === 1 ? "" : "s"})`;
-      },
-      type: "oauth",
-      prompts: [makeEmailPrompt("anthropic")],
-      authorize: async (inputs) => {
-        const email = inputs?.email || "unknown";
-        const pkce = generatePKCE();
-        const state = generateState(); // separate nonce — pkce.verifier stays secret
-        const url = new URL(ANTHROPIC_OAUTH_AUTHORIZE_URL);
-        url.searchParams.set("code", "true");
-        url.searchParams.set("client_id", ANTHROPIC_CLIENT_ID);
-        url.searchParams.set("response_type", "code");
-        url.searchParams.set("redirect_uri", ANTHROPIC_REDIRECT_URI);
-        url.searchParams.set("scope", ANTHROPIC_OAUTH_SCOPES);
-        url.searchParams.set("code_challenge", pkce.challenge);
-        url.searchParams.set("code_challenge_method", "S256");
-        url.searchParams.set("state", state);
-        return {
-          url: url.toString(),
-          instructions: `Adding account: ${email}\nPaste the authorization code here: `,
-          method: "code",
-          callback: (code) => handleAnthropicCallback(code, pkce, state, email, client),
-        };
-      },
-    }],
-  };
-}
-
-export function createOpenAIPoolAuthHook(client) {
-  return {
-    provider: "openai-pool",
-    methods: [{
-      get label() {
-        const a = getAccounts("openai");
-        return a.length === 0
-          ? "Add Account to Pool (ChatGPT Plus/Pro)"
-          : `Add Account to Pool (${a.length} account${a.length === 1 ? "" : "s"})`;
-      },
-      type: "oauth",
-      prompts: [makeEmailPrompt("openai")],
-      authorize: async (inputs) => {
-        const email = inputs?.email || "unknown";
-        const pkce = generatePKCE();
-        const state = generateState(); // separate nonce — pkce.verifier stays secret
-        const cs = await initCallbackServerSafe(state);
-        const url = new URL(OPENAI_OAUTH_AUTHORIZE_URL);
-        url.searchParams.set("client_id", OPENAI_CLIENT_ID);
-        url.searchParams.set("response_type", "code");
-        url.searchParams.set("redirect_uri", OPENAI_REDIRECT_URI);
-        url.searchParams.set("scope", OPENAI_OAUTH_SCOPES);
-        url.searchParams.set("code_challenge", pkce.challenge);
-        url.searchParams.set("code_challenge_method", "S256");
-        url.searchParams.set("state", state);
-        return {
-          url: url.toString(),
-          instructions: [
-            `Adding OpenAI account: ${email}`,
-            "1. A browser window will open to auth.openai.com",
-            "2. Sign in with your ChatGPT Plus/Pro account",
-            cs.ready ? "3. The code will be captured automatically" : "3. Copy the authorization code from the browser URL",
-            cs.ready ? "4. Press Enter here to complete (or paste manually): " : "4. Paste the authorization code here: ",
-          ].join("\n"),
-          method: "code",
-          callback: (code) => handleOpenAICallback(code, pkce, email, cs, client),
-        };
-      },
-    }],
-  };
-}
 
 export function createCursorPoolAuthHook(client) {
   return {
@@ -130,47 +37,7 @@ export function createCursorPoolAuthHook(client) {
   };
 }
 
-export function createGooglePoolAuthHook(client) {
-  return {
-    provider: "google-pool",
-    methods: [{
-      get label() {
-        const a = getAccounts("google");
-        return a.length === 0
-          ? "Add Account to Pool (Google AI Pro/Ultra/Workspace)"
-          : `Add Account to Pool (${a.length} account${a.length === 1 ? "" : "s"})`;
-      },
-      type: "oauth",
-      prompts: [makeEmailPrompt("google", "you@gmail.com")],
-      authorize: async (inputs) => {
-        const email = inputs?.email || "unknown";
-        const pkce = generatePKCE();
-        const state = generateState(); // separate nonce — pkce.verifier stays secret
-        const url = new URL(GOOGLE_OAUTH_AUTHORIZE_URL);
-        url.searchParams.set("client_id", GOOGLE_CLIENT_ID);
-        url.searchParams.set("response_type", "code");
-        url.searchParams.set("redirect_uri", GOOGLE_REDIRECT_URI);
-        url.searchParams.set("scope", GOOGLE_OAUTH_SCOPES);
-        url.searchParams.set("code_challenge", pkce.challenge);
-        url.searchParams.set("code_challenge_method", "S256");
-        url.searchParams.set("access_type", "offline");
-        url.searchParams.set("prompt", "consent");
-        url.searchParams.set("state", state);
-        return {
-          url: url.toString(),
-          instructions: [
-            `Adding Google AI account: ${email}`,
-            "1. A browser window will open to accounts.google.com",
-            "2. Sign in with your Google AI Pro/Ultra or Workspace account",
-            "3. Copy the authorization code shown in the browser",
-            "4. Paste the authorization code here: ",
-          ].join("\n"),
-          method: "code",
-          callback: (code) => handleGoogleCallback(code, pkce, state, email, client),
-        };
-      },
-    }],
-  };
-}
-
+export { createPoolAuthHook } from "./oauth-pool-auth-anthropic.mjs";
+export { createOpenAIPoolAuthHook } from "./oauth-pool-auth-openai.mjs";
+export { createGooglePoolAuthHook } from "./oauth-pool-auth-google.mjs";
 export { registerPoolProvider } from "./oauth-pool-auth-provider.mjs";


### PR DESCRIPTION
## Summary

Split Anthropic, OpenAI, and Google auth hooks into focused provider modules while preserving oauth-pool-auth.mjs as the public facade.

## Complexity Bump Justification

The split moves existing provider functions from `.agents/plugins/opencode-aidevops/oauth-pool-auth.mjs:38` into focused modules. Scanner evidence is base=1 target-file smell from issue #29357; local Qlty 0.631.0 reports head=0 and new=0 across all changed modules, while CI pins Qlty 0.636.0 for exact-head confirmation. No threshold is raised and no new behavior is introduced.

## Files Changed

.agents/plugins/opencode-aidevops/oauth-pool-auth-anthropic.mjs, .agents/plugins/opencode-aidevops/oauth-pool-auth-google.mjs, .agents/plugins/opencode-aidevops/oauth-pool-auth-openai.mjs, .agents/plugins/opencode-aidevops/oauth-pool-auth.mjs

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Node syntax checks and focused OAuth auth-hook tests pass; Qlty 0.631.0 reports no smells on changed modules.

Resolves #29357


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 8m and 108,164 tokens on this as a headless worker.