### PR TITLE
GH#29358: reduce OAuth pool display complexity

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool-account-actions.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-account-actions.mjs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/**
+ * OAuth Pool — Account Management Actions
+ *
+ * Mutating pool tool actions for account removal, cooldown resets, pending
+ * token assignment, and priority updates.
+ *
+ * @module oauth-pool-account-actions
+ */
+
+import {
+  getAccounts, getPendingToken, removeAccount, assignPendingToken,
+  withPoolLock, loadPool, savePool,
+} from "./oauth-pool-storage.mjs";
+import { resetEndpointCooldown } from "./oauth-pool-token-endpoint.mjs";
+
+export function poolActionRemove(provider, email) {
+  if (!email) return "Error: email is required for remove action. Usage: remove <email>";
+  if (!removeAccount(provider, email)) return `Account ${email} not found in ${provider} pool.`;
+  const remaining = getAccounts(provider).length;
+  return `Removed ${email} from ${provider} pool (${remaining} account${remaining === 1 ? "" : "s"} remaining).`;
+}
+
+export function poolActionResetCooldowns(provider) {
+  const wasGated = resetEndpointCooldown(provider);
+  const resetCount = withPoolLock(() => {
+    const pool = loadPool();
+    let count = 0;
+    if (pool[provider]) {
+      for (const a of pool[provider]) {
+        if (a.cooldownUntil) { a.cooldownUntil = null; a.status = "idle"; count++; }
+      }
+      savePool(pool);
+    }
+    return count;
+  });
+  const parts = [];
+  if (wasGated) parts.push("token endpoint cooldown cleared");
+  if (resetCount > 0) parts.push(`${resetCount} account cooldown${resetCount === 1 ? "" : "s"} cleared`);
+  if (parts.length === 0) parts.push("no active cooldowns");
+  return `Reset (${provider}): ${parts.join(", ")}. Token endpoint requests will proceed on next attempt.`;
+}
+
+export function poolActionAssignPending(provider, accounts, email) {
+  const pending = getPendingToken(provider);
+  if (!pending) return `No pending token for ${provider}.`;
+  if (!email) {
+    return `Pending ${provider} token found (added: ${pending.added}). Assign to: ${accounts.map((a) => a.email).join(", ")}\n\nUsage: assign-pending with email parameter.`;
+  }
+  return assignPendingToken(provider, email)
+    ? `Assigned pending token to ${email} in ${provider} pool.`
+    : `Failed: account ${email} not found. Available: ${accounts.map((a) => a.email).join(", ")}`;
+}
+
+export function poolActionSetPriority(provider, email, priority) {
+  if (!email) return "Error: email is required for set-priority action.";
+  if (priority === undefined || priority === null) return "Error: priority (integer) is required.";
+  const p = Number(priority);
+  if (!Number.isInteger(p)) return `Error: priority must be an integer, got: ${priority}`;
+  return withPoolLock(() => {
+    const pool = loadPool();
+    const accts = pool[provider] || [];
+    const idx = accts.findIndex((a) => a.email === email);
+    if (idx < 0) return `Account ${email} not found in ${provider} pool.`;
+    if (p === 0) delete accts[idx].priority; else accts[idx].priority = p;
+    savePool(pool);
+    return p === 0
+      ? `Cleared priority for ${email} (defaults to LRU order).`
+      : `Set priority ${p} for ${email}. Higher-priority accounts preferred during rotation.`;
+  });
+}

--- a/.agents/plugins/opencode-aidevops/oauth-pool-display.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool-display.mjs
@@ -1,23 +1,24 @@
 /**
  * OAuth Pool — Display Formatting & Action Handlers (t2128)
  *
- * Individual pool tool action handlers. Health-check formatting and token
- * validity checks live in oauth-pool-health-check.mjs and are re-exported here
- * to preserve the original public API.
+ * Read-only pool tool action handlers. Health checks and mutating account
+ * actions live in focused modules and are re-exported here to preserve the
+ * original public API.
  *
  * @module oauth-pool-display
  */
 
 import {
-  getAccounts, getPendingToken, removeAccount, assignPendingToken,
-  withPoolLock, loadPool, savePool, getPoolFilePath,
+  getAccounts, getPendingToken, getPoolFilePath,
 } from "./oauth-pool-storage.mjs";
-import {
-  getEndpointCooldownValue, resetEndpointCooldown,
-} from "./oauth-pool-token-endpoint.mjs";
+import { getEndpointCooldownValue } from "./oauth-pool-token-endpoint.mjs";
 export {
   formatDuration, formatAgo, poolActionCheck,
 } from "./oauth-pool-health-check.mjs";
+export {
+  poolActionRemove, poolActionResetCooldowns,
+  poolActionAssignPending, poolActionSetPriority,
+} from "./oauth-pool-account-actions.mjs";
 
 // ---------------------------------------------------------------------------
 // Pool tool action handlers
@@ -38,13 +39,6 @@ export function poolActionList(provider, accounts, hint, now) {
     ? `\n\nPENDING: Unassigned token (added: ${pending.added}). Use assign-pending <email> to assign it.`
     : "";
   return `${provider} pool (${accounts.length} account${accounts.length === 1 ? "" : "s"}):\n\n${lines.join("\n")}${pl}`;
-}
-
-export function poolActionRemove(provider, email) {
-  if (!email) return "Error: email is required for remove action. Usage: remove <email>";
-  if (!removeAccount(provider, email)) return `Account ${email} not found in ${provider} pool.`;
-  const remaining = getAccounts(provider).length;
-  return `Removed ${email} from ${provider} pool (${remaining} account${remaining === 1 ? "" : "s"} remaining).`;
 }
 
 export function poolActionStatus(provider, accounts, hint, now) {
@@ -69,26 +63,6 @@ export function poolActionStatus(provider, accounts, hint, now) {
   ].join("\n");
 }
 
-export function poolActionResetCooldowns(provider) {
-  const wasGated = resetEndpointCooldown(provider);
-  const resetCount = withPoolLock(() => {
-    const pool = loadPool();
-    let count = 0;
-    if (pool[provider]) {
-      for (const a of pool[provider]) {
-        if (a.cooldownUntil) { a.cooldownUntil = null; a.status = "idle"; count++; }
-      }
-      savePool(pool);
-    }
-    return count;
-  });
-  const parts = [];
-  if (wasGated) parts.push("token endpoint cooldown cleared");
-  if (resetCount > 0) parts.push(`${resetCount} account cooldown${resetCount === 1 ? "" : "s"} cleared`);
-  if (parts.length === 0) parts.push("no active cooldowns");
-  return `Reset (${provider}): ${parts.join(", ")}. Token endpoint requests will proceed on next attempt.`;
-}
-
 export async function poolActionRotate(client, provider, accounts, resolveInjectFn) {
   if (accounts.length < 2) {
     const pn = { anthropic: "Anthropic Pool", openai: "OpenAI Pool", cursor: "Cursor Pool", google: "Google Pool" };
@@ -100,33 +74,4 @@ export async function poolActionRotate(client, provider, accounts, resolveInject
   }
   const newest = [...getAccounts(provider)].sort((a, b) => new Date(b.lastUsed || 0) - new Date(a.lastUsed || 0))[0];
   return `Rotated (${provider}): now using ${newest?.email || "unknown"}. Previous: ${current?.email || "unknown"}.`;
-}
-
-export function poolActionAssignPending(provider, accounts, email) {
-  const pending = getPendingToken(provider);
-  if (!pending) return `No pending token for ${provider}.`;
-  if (!email) {
-    return `Pending ${provider} token found (added: ${pending.added}). Assign to: ${accounts.map((a) => a.email).join(", ")}\n\nUsage: assign-pending with email parameter.`;
-  }
-  return assignPendingToken(provider, email)
-    ? `Assigned pending token to ${email} in ${provider} pool.`
-    : `Failed: account ${email} not found. Available: ${accounts.map((a) => a.email).join(", ")}`;
-}
-
-export function poolActionSetPriority(provider, email, priority) {
-  if (!email) return "Error: email is required for set-priority action.";
-  if (priority === undefined || priority === null) return "Error: priority (integer) is required.";
-  const p = Number(priority);
-  if (!Number.isInteger(p)) return `Error: priority must be an integer, got: ${priority}`;
-  return withPoolLock(() => {
-    const pool = loadPool();
-    const accts = pool[provider] || [];
-    const idx = accts.findIndex((a) => a.email === email);
-    if (idx < 0) return `Account ${email} not found in ${provider} pool.`;
-    if (p === 0) delete accts[idx].priority; else accts[idx].priority = p;
-    savePool(pool);
-    return p === 0
-      ? `Cleared priority for ${email} (defaults to LRU order).`
-      : `Set priority ${p} for ${email}. Higher-priority accounts preferred during rotation.`;
-  });
 }

--- a/.agents/plugins/opencode-aidevops/tests/test-oauth-pool-display.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-oauth-pool-display.mjs
@@ -6,8 +6,16 @@ import assert from "node:assert/strict";
 
 import {
   formatDuration, formatAgo, poolActionCheck,
+  poolActionRemove, poolActionResetCooldowns,
+  poolActionAssignPending, poolActionSetPriority,
 } from "../oauth-pool-display.mjs";
 import { poolActionCheck as healthCheckAction } from "../oauth-pool-health-check.mjs";
+import {
+  poolActionRemove as accountRemoveAction,
+  poolActionResetCooldowns as accountResetCooldownsAction,
+  poolActionAssignPending as accountAssignPendingAction,
+  poolActionSetPriority as accountSetPriorityAction,
+} from "../oauth-pool-account-actions.mjs";
 
 test("display formatting keeps minute and hour output", () => {
   assert.equal(formatDuration(59_999), "0m");
@@ -17,4 +25,11 @@ test("display formatting keeps minute and hour output", () => {
 
 test("display module preserves the health-check action export", () => {
   assert.equal(poolActionCheck, healthCheckAction);
+});
+
+test("display module preserves account action exports", () => {
+  assert.equal(poolActionRemove, accountRemoveAction);
+  assert.equal(poolActionResetCooldowns, accountResetCooldownsAction);
+  assert.equal(poolActionAssignPending, accountAssignPendingAction);
+  assert.equal(poolActionSetPriority, accountSetPriorityAction);
 });


### PR DESCRIPTION
## Summary

- Move mutating OAuth pool account actions into a focused module.
- Preserve the existing `oauth-pool-display.mjs` public exports through direct re-exports.
- Cover the re-export identities with a focused regression test.

Resolves #29358

## Verification

- `node --check oauth-pool-display.mjs`
- `node --check oauth-pool-account-actions.mjs`
- `node --test tests/test-oauth-pool-display.mjs`
- `npm test -- --test-concurrency=1` (525 tests)
- `bun run typecheck`
- `qlty smells .agents/plugins/opencode-aidevops/oauth-pool-display.mjs .agents/plugins/opencode-aidevops/oauth-pool-account-actions.mjs --no-snippets --quiet`

## Runtime Testing

Runtime-verified: the complete OpenCode plugin suite exercised module loading and OAuth pool paths, while focused tests confirmed direct re-export identity. The split retains unchanged function bodies and public APIs.

## Complexity Bump Justification

- The issue records Qlty file complexity `base=62` against threshold `49` for `.agents/plugins/opencode-aidevops/oauth-pool-display.mjs`.
- `.agents/plugins/opencode-aidevops/oauth-pool-display.mjs:18` now re-exports four unchanged mutating handlers from `.agents/plugins/opencode-aidevops/oauth-pool-account-actions.mjs:19`.
- Pinned Qlty v0.636.0 reports `base=1` smell and `head=0` smells across both affected modules, with `new=0` smells in the added module.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 18m and 187,014 tokens on this as a headless worker.