### PR TITLE
GH#29283: Handle null advisory repository slugs

### DIFF
--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -756,7 +756,7 @@ _pmrc_configured_advisory_contexts_json() {
 		return 0
 	fi
 	contexts=$(jq -c --arg slug "$repo_slug" --arg array_type "$PMRC_JSON_ARRAY" '
-		(first(.initialized_repos[]? | select((.slug | ascii_downcase) == ($slug | ascii_downcase)))
+		((first(.initialized_repos[]? | select(((.slug // "") | ascii_downcase) == ($slug | ascii_downcase))) // {})
 		| .review_gate.advisory_check_contexts // []) as $contexts
 		| if ($contexts | type) == $array_type and all($contexts[]; type == "string" and length > 0)
 			then ($contexts | unique)
@@ -814,7 +814,12 @@ _pmrc_snapshot_checks_acceptable() {
 	_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON="[]"
 
 	required_json=$(printf '%s' "$required_contexts" | jq -Rsc '[split("\n")[] | select(length > 0)]') || return 1
-	configured_contexts_json=$(_pmrc_configured_advisory_contexts_json "$repo_slug") || return 1
+	configured_contexts_json=$(_pmrc_configured_advisory_contexts_json "$repo_slug") || {
+		_PULSE_MERGE_PREFLIGHT_BLOCKER_KIND="$PMRC_BLOCKER_SNAPSHOT_UNAVAILABLE"
+		_pmrc_snapshot_log_failure "$repo_slug" "${PMRC_SUBJECT_PR_PREFIX}${pr_number}" \
+			"configured advisory-context lookup"
+		return 1
+	}
 	rows=$(jq -r --argjson required "$required_json" --arg failure "$PMRC_CHECK_FAILURE" '.[] | . as $check | ($check.members // [$check]) as $members | [
 		$check.name,
 		($check.family // $check.name),

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -12,9 +12,13 @@ TEST_ROOT="$(mktemp -d -t pulse-preflight-snapshot.XXXXXX)"
 LOGFILE="${TEST_ROOT}/pulse.log"
 AIDEVOPS_REPOS_JSON="${TEST_ROOT}/repos.json"
 export AIDEVOPS_REPOS_JSON
-cat >"$AIDEVOPS_REPOS_JSON" <<'EOF'
+write_default_repos_json() {
+	cat >"$AIDEVOPS_REPOS_JSON" <<'EOF'
 {"initialized_repos":[{"slug":"owner/repo","review_gate":{"advisory_check_contexts":["CodeFactor"]}}]}
 EOF
+	return 0
+}
+write_default_repos_json
 PULSE_MERGE_QUIET_PERIOD_SECONDS=30
 PULSE_MERGE_NOW_EPOCH="$(_pmrc_iso_to_epoch '2026-01-01T00:10:00Z')"
 PULSE_MERGE_INFRA_RERUN_STATE_DIR="${TEST_ROOT}/infra-reruns"
@@ -370,6 +374,59 @@ assert_effective_rules_have_exact_rest_cost() {
 	return 0
 }
 
+assert_configured_advisory_contexts_are_null_safe() {
+	local contexts="" rc=0
+	cat >"$AIDEVOPS_REPOS_JSON" <<'EOF'
+{"initialized_repos":[{"slug":null},{"slug":"owner/repo","review_gate":{"advisory_check_contexts":["CodeFactor"]}}]}
+EOF
+	contexts=$(_pmrc_configured_advisory_contexts_json "OWNER/REPO") || rc=$?
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 && "$contexts" == '["CodeFactor"]' ]]; then
+		printf 'PASS null repository slug does not poison a later advisory-context match\n'
+	else
+		printf 'FAIL null repository slug lookup (rc=%s, output=%s)\n' "$rc" "$contexts"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+
+	contexts=""
+	rc=0
+	contexts=$(_pmrc_configured_advisory_contexts_json "other/repo") || rc=$?
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 && "$contexts" == '[]' ]]; then
+		printf 'PASS unmatched repository slug returns an empty advisory-context array\n'
+	else
+		printf 'FAIL unmatched repository slug lookup (rc=%s, output=%s)\n' "$rc" "$contexts"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+
+	write_default_repos_json
+	return 0
+}
+
+assert_malformed_advisory_contexts_fail_closed_once() {
+	local failure_count=0
+	cat >"$AIDEVOPS_REPOS_JSON" <<'EOF'
+{"initialized_repos":[{"slug":"owner/repo","review_gate":{"advisory_check_contexts":{"private-sentinel":true}}}]}
+EOF
+	assert_gate_blocker "malformed advisory contexts fail closed" \
+		happy_advisory 1 "$PMRC_BLOCKER_SNAPSHOT_UNAVAILABLE"
+	failure_count=$(grep -cF \
+		"configured advisory-context lookup failed for PR #7 in owner/repo" \
+		"$LOGFILE" || true)
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$failure_count" -eq 1 ]] &&
+		! grep -qF "private-sentinel" "$LOGFILE" &&
+		! grep -qF "$AIDEVOPS_REPOS_JSON" "$LOGFILE"; then
+		printf 'PASS malformed advisory contexts emit one privacy-safe failure log\n'
+	else
+		printf 'FAIL malformed advisory-context logging was duplicated or exposed input details\n'
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+
+	write_default_repos_json
+	return 0
+}
+
 set_live_evidence() {
 	local status="$1"
 	local head_sha="${2:-sha-reviewed}"
@@ -484,6 +541,8 @@ main() {
 	assert_infrastructure_rerun_unset_defaults_safe
 	assert_infrastructure_rerun_unset_logfile_safe
 	assert_effective_rules_have_exact_rest_cost
+	assert_configured_advisory_contexts_are_null_safe
+	assert_malformed_advisory_contexts_fail_closed_once
 	assert_snapshot_acquisition_failures_are_audited
 	assert_gate "large paginated check payload streams without argument overflow" large_payload 0
 	assert_large_bot_activity_streams


### PR DESCRIPTION
## Summary

Normalize optional repository slugs before case-insensitive advisory-context matching so a local-only null slug cannot poison later repositories. Return an empty array for no match and preserve fail-closed behavior for malformed configuration with one contextual, privacy-safe snapshot failure log.

## Files Changed

.agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: test-pulse-merge-preflight-snapshot.sh (95/95), test-pulse-merge-admin-safety-check.sh (17/17), test-pulse-merge-required-checks-filter.sh (57/57), test-pulse-merge-update-branch.sh (16/16), test-gh-check-status-cache.sh (PASS), ShellCheck, bash -n, and linters-local.sh --changed. test-pulse-merge-phantom-pending-checks.sh retained the same 6 pre-existing failures reproduced on origin/main.

Resolves #29283


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 12h 27m and 1,585,704 tokens on this with the user in an interactive session.