### PR TITLE
GH#29288: fix: flag dual feedback stalls

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -321,6 +321,24 @@ _handle_changes_requested_review_gate() {
 	fi
 
 	local _cr_label_list=",${_cr_pr_labels},"
+	# GH#29288: a completed CI-repair route followed by a completed review route
+	# leaves an open worker PR that neither pipeline can own. Once required CI has
+	# healed, surface that dual-failure state for a maintainer instead of silently
+	# repeating the CHANGES_REQUESTED skip forever. Adding the conservative label
+	# never clears the review or weakens any merge gate.
+	if [[ "$_cr_label_list" == *",ci-feedback-routed,"* \
+		&& "$_cr_label_list" == *",review-routed-to-issue,"* \
+		&& "$_cr_label_list" != *",needs-maintainer-review,"* ]] \
+		&& declare -F _check_required_checks_passing >/dev/null 2>&1 \
+		&& _check_required_checks_passing "$repo_slug" "$pr_number" >/dev/null 2>&1; then
+		if gh api --silent "repos/${repo_slug}/issues/${pr_number}/labels" \
+			-X POST -f 'labels[]=needs-maintainer-review'; then
+			echo "[pulse-merge] stalled PR #${pr_number} in ${repo_slug} — dual-failure state (ci-feedback-routed + review-routed-to-issue) with required CI green: flagging for maintainer (GH#29288)" >>"$LOGFILE"
+		else
+			echo "[pulse-merge] stalled PR #${pr_number} in ${repo_slug} — dual-failure state detected but needs-maintainer-review label write failed (GH#29288)" >>"$LOGFILE"
+		fi
+		return 1
+	fi
 	# Optional policy override (GH#26535): by default CHANGES_REQUESTED worker
 	# PRs keep the historical fast-routing behaviour below. Operators who prefer
 	# preserving the PR/review context can opt in to a remediation-first cycle.

--- a/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
+++ b/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
@@ -341,6 +341,69 @@ test_changes_requested_routes_by_default() {
 	return 0
 }
 
+test_changes_requested_dual_feedback_stall_flags_maintainer() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+	local route_log="${TEST_ROOT}/route.log"
+	local label_log="${TEST_ROOT}/label.log"
+	: >"$route_log"
+	: >"$label_log"
+	_check_required_checks_passing() { return 0; }
+	gh() {
+		printf '%s\n' "$*" >>"$label_log"
+		return 0
+	}
+	_route_pr_to_fix_worker() {
+		printf 'route\n' >>"$route_log"
+		return 0
+	}
+	_pulse_merge_dismiss_coderabbit_nits() { return 1; }
+
+	_handle_changes_requested_review_gate 77 owner/repo CHANGES_REQUESTED 42 \
+		"origin:worker,ci-feedback-routed,review-routed-to-issue" || true
+	if [[ ! -s "$route_log" ]] \
+		&& grep -qF 'repos/owner/repo/issues/77/labels -X POST -f labels[]=needs-maintainer-review' "$label_log" \
+		&& grep -qF 'dual-failure state (ci-feedback-routed + review-routed-to-issue) with required CI green: flagging for maintainer' "$LOGFILE"; then
+		print_result "dual feedback stall with green CI flags maintainer" 0
+	else
+		print_result "dual feedback stall with green CI flags maintainer" 1 \
+			"route=$(tr '\n' ';' <"$route_log"), label=$(tr '\n' ';' <"$label_log"), log=$(tr '\n' ';' <"$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_changes_requested_dual_feedback_stall_waits_for_green_ci() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+	local route_log="${TEST_ROOT}/route.log"
+	local label_log="${TEST_ROOT}/label.log"
+	: >"$route_log"
+	: >"$label_log"
+	_check_required_checks_passing() { return 1; }
+	gh() {
+		printf '%s\n' "$*" >>"$label_log"
+		return 0
+	}
+	_route_pr_to_fix_worker() {
+		printf 'route\n' >>"$route_log"
+		return 0
+	}
+	_pulse_merge_dismiss_coderabbit_nits() { return 1; }
+
+	_handle_changes_requested_review_gate 77 owner/repo CHANGES_REQUESTED 42 \
+		"origin:worker,ci-feedback-routed,review-routed-to-issue" || true
+	if grep -q '^route$' "$route_log" && [[ ! -s "$label_log" ]] \
+		&& ! grep -qF 'flagging for maintainer' "$LOGFILE"; then
+		print_result "dual feedback stall waits for green CI before flagging" 0
+	else
+		print_result "dual feedback stall waits for green CI before flagging" 1 \
+			"route=$(tr '\n' ';' <"$route_log"), label=$(tr '\n' ';' <"$label_log"), log=$(tr '\n' ';' <"$LOGFILE")"
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_changes_requested_opt_in_dispatches_remediation_without_routing() {
 	setup_test_env
 	export AIDEVOPS_CHANGES_REQUESTED_THREAD_REMEDIATION_FIRST=1
@@ -636,6 +699,8 @@ main() {
 	test_repo_path_lookup_ignores_slug_case
 	test_other_merge_failures_do_not_dispatch_review_thread_remediation
 	test_changes_requested_routes_by_default
+	test_changes_requested_dual_feedback_stall_flags_maintainer
+	test_changes_requested_dual_feedback_stall_waits_for_green_ci
 	test_changes_requested_opt_in_dispatches_remediation_without_routing
 	test_changes_requested_routes_when_remediation_unavailable
 	test_changes_requested_active_remediation_preserves_pr_without_routing


### PR DESCRIPTION
## Summary

Detect worker PRs carrying both CI-feedback and review-routing labels after required CI heals, then add needs-maintainer-review and emit an explicit stall diagnostic instead of silently cycling.

## Files Changed

.agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh; shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh

Resolves #29288


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 4m and 104,641 tokens on this as a headless worker.