### PR TITLE
GH#29363: reduce tools module complexity

### DIFF
--- a/.agents/plugins/opencode-aidevops/hook-status-tool.mjs
+++ b/.agents/plugins/opencode-aidevops/hook-status-tool.mjs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { execFileSync } from "child_process";
+import { lstatSync, realpathSync } from "fs";
+import { isAbsolute, join, resolve } from "path";
+import { inspectHookFile } from "./hook-file-inspection.mjs";
+import { resolveGitWorktree } from "./pre-edit-check-tool.mjs";
+
+const HOOK_MARKERS = {
+  "pre-commit": {
+    quality: "# aidevops-pre-commit-hook",
+    markdoc: "# aidevops-markdoc-validate-hook",
+  },
+  "pre-push": {
+    ghWrapper: "# aidevops-gh-wrapper-guard",
+    quality: "# aidevops-pre-push-quality-hook",
+  },
+};
+
+function resolveGitMetadataPath(worktree, selector) {
+  const rawPath = execFileSync(
+    "git",
+    ["-C", worktree, "rev-parse", selector],
+    {
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+    },
+  ).trim();
+  return realpathSync(isAbsolute(rawPath) ? rawPath : resolve(worktree, rawPath));
+}
+
+function inspectGitHooks(worktree) {
+  const gitDir = resolveGitMetadataPath(worktree, "--git-dir");
+  const commonDir = resolveGitMetadataPath(worktree, "--git-common-dir");
+  const hooksDir = join(commonDir, "hooks");
+  let hooksDirectoryStatus = "missing";
+  let directorySafe = false;
+  try {
+    const hooksStat = lstatSync(hooksDir);
+    if (hooksStat.isSymbolicLink()) hooksDirectoryStatus = "unsafe-symlink";
+    else if (hooksStat.isDirectory()) {
+      hooksDirectoryStatus = "directory";
+      directorySafe = true;
+    } else hooksDirectoryStatus = "unsupported-file-type";
+  } catch {
+    hooksDirectoryStatus = "missing";
+  }
+
+  return {
+    schema: "aidevops-hook-status/v1",
+    sharedGitDirectory: gitDir !== commonDir,
+    hooksDirectory: hooksDirectoryStatus,
+    hooks: Object.fromEntries(Object.entries(HOOK_MARKERS).map(([hookName, markers]) => [
+      hookName,
+      inspectHookFile(hooksDir, hookName, markers, directorySafe),
+    ])),
+  };
+}
+
+/**
+ * Create the bounded Git hook status tool.
+ * @param {function} tool - OpenCode tool factory
+ * @param {object} z - OpenCode tool schema helpers
+ * @param {{workerWorktree?: string}} [options] - Tool-specific runtime overrides
+ * @returns {object} Tool definition
+ */
+export function createHookStatusTool(tool, z, options = {}) {
+  return tool({
+    description:
+      "Inspect known aidevops Git hook markers for an existing worktree without reading canonical .git/hooks through file tools. " +
+      "Use this for pre-commit/pre-push hook integrity checks. Returns statuses only—never hook contents or filesystem paths.",
+    args: {
+      workdir: z.string().optional().describe("Optional existing Git worktree; defaults to the current worktree"),
+    },
+    async execute(args) {
+      args = args && typeof args === "object" ? args : {};
+      const requestedWorkdir = args.workdir || process.cwd();
+      const targetWorkdir = resolveGitWorktree(requestedWorkdir);
+      if (!targetWorkdir) return "Hook status unavailable: target must resolve to an existing Git worktree";
+
+      const workerWorktree = options.workerWorktree ?? process.env.WORKER_WORKTREE_PATH ?? "";
+      if (workerWorktree) {
+        const boundWorktree = resolveGitWorktree(workerWorktree);
+        if (!boundWorktree || boundWorktree !== targetWorkdir) {
+          return "Hook status denied: headless workers may inspect only their assigned worktree";
+        }
+      }
+
+      try {
+        return JSON.stringify(inspectGitHooks(targetWorkdir), null, 2);
+      } catch {
+        return "Hook status unavailable: Git metadata could not be validated";
+      }
+    },
+  });
+}

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -1,8 +1,7 @@
-import { execFileSync } from "child_process";
-import { existsSync, lstatSync, realpathSync } from "fs";
-import { isAbsolute, join, resolve } from "path";
-import { inspectHookFile } from "./hook-file-inspection.mjs";
-import { createPreEditCheckTool, resolveGitWorktree } from "./pre-edit-check-tool.mjs";
+import { existsSync } from "fs";
+import { join } from "path";
+import { createHookStatusTool } from "./hook-status-tool.mjs";
+import { createPreEditCheckTool } from "./pre-edit-check-tool.mjs";
 
 export let tool;
 try {
@@ -167,89 +166,6 @@ function createMemoryTool(scriptsDir, run) {
   });
 }
 
-const HOOK_MARKERS = {
-  "pre-commit": {
-    quality: "# aidevops-pre-commit-hook",
-    markdoc: "# aidevops-markdoc-validate-hook",
-  },
-  "pre-push": {
-    ghWrapper: "# aidevops-gh-wrapper-guard",
-    quality: "# aidevops-pre-push-quality-hook",
-  },
-};
-
-function resolveGitMetadataPath(worktree, selector) {
-  const rawPath = execFileSync(
-    "git",
-    ["-C", worktree, "rev-parse", selector],
-    {
-      encoding: "utf-8",
-      timeout: 5000,
-      stdio: ["ignore", "pipe", "ignore"],
-    },
-  ).trim();
-  return realpathSync(isAbsolute(rawPath) ? rawPath : resolve(worktree, rawPath));
-}
-
-function inspectGitHooks(worktree) {
-  const gitDir = resolveGitMetadataPath(worktree, "--git-dir");
-  const commonDir = resolveGitMetadataPath(worktree, "--git-common-dir");
-  const hooksDir = join(commonDir, "hooks");
-  let hooksDirectoryStatus = "missing";
-  let directorySafe = false;
-  try {
-    const hooksStat = lstatSync(hooksDir);
-    if (hooksStat.isSymbolicLink()) hooksDirectoryStatus = "unsafe-symlink";
-    else if (hooksStat.isDirectory()) {
-      hooksDirectoryStatus = "directory";
-      directorySafe = true;
-    } else hooksDirectoryStatus = "unsupported-file-type";
-  } catch {
-    hooksDirectoryStatus = "missing";
-  }
-
-  return {
-    schema: "aidevops-hook-status/v1",
-    sharedGitDirectory: gitDir !== commonDir,
-    hooksDirectory: hooksDirectoryStatus,
-    hooks: Object.fromEntries(Object.entries(HOOK_MARKERS).map(([hookName, markers]) => [
-      hookName,
-      inspectHookFile(hooksDir, hookName, markers, directorySafe),
-    ])),
-  };
-}
-
-function createHookStatusTool(options = {}) {
-  return tool({
-    description:
-      "Inspect known aidevops Git hook markers for an existing worktree without reading canonical .git/hooks through file tools. " +
-      "Use this for pre-commit/pre-push hook integrity checks. Returns statuses only—never hook contents or filesystem paths.",
-    args: {
-      workdir: z.string().optional().describe("Optional existing Git worktree; defaults to the current worktree"),
-    },
-    async execute(args) {
-      args = args && typeof args === "object" ? args : {};
-      const requestedWorkdir = args.workdir || process.cwd();
-      const targetWorkdir = resolveGitWorktree(requestedWorkdir);
-      if (!targetWorkdir) return "Hook status unavailable: target must resolve to an existing Git worktree";
-
-      const workerWorktree = options.workerWorktree ?? process.env.WORKER_WORKTREE_PATH ?? "";
-      if (workerWorktree) {
-        const boundWorktree = resolveGitWorktree(workerWorktree);
-        if (!boundWorktree || boundWorktree !== targetWorkdir) {
-          return "Hook status denied: headless workers may inspect only their assigned worktree";
-        }
-      }
-
-      try {
-        return JSON.stringify(inspectGitHooks(targetWorkdir), null, 2);
-      } catch {
-        return "Hook status unavailable: Git metadata could not be validated";
-      }
-    },
-  });
-}
-
 /**
  * Create all tool definitions for the plugin.
  *
@@ -285,7 +201,7 @@ export function createTools(scriptsDir, run, options = {}) {
     aidevops: createAidevopsTool(run),
     aidevops_memory: createMemoryTool(scriptsDir, run),
     aidevops_pre_edit_check: createPreEditCheckTool(tool, z, scriptsDir, options.preEditTimeoutMs),
-    aidevops_hook_status: createHookStatusTool({ workerWorktree: options.workerWorktree }),
+    aidevops_hook_status: createHookStatusTool(tool, z, { workerWorktree: options.workerWorktree }),
   };
   if (typeof options.poolToolFactory === "function") {
     tools["model-accounts-pool"] = options.poolToolFactory();


### PR DESCRIPTION
## Summary

Extracted bounded Git hook-status inspection into a focused sibling module while preserving the createTools registry and tool behavior.

## Files Changed

.agents/plugins/opencode-aidevops/hook-status-tool.mjs, .agents/plugins/opencode-aidevops/tools.mjs

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — node --check; focused hook-status and schema tests (5/5); serial plugin suite (529/529); TypeScript check; Qlty reports zero smells for both changed modules.

## Complexity Bump Justification

- **Scanner evidence:** The issue baseline reports one `qlty:file-complexity` smell at `.agents/plugins/opencode-aidevops/tools.mjs:1` with total complexity 62. The exact head reports no Qlty smells for that file or the extracted `.agents/plugins/opencode-aidevops/hook-status-tool.mjs:1`.
- **Measurement:** base=1 target smell (complexity 62), head=0 target smells, new=0 smells.
- **Reason:** Existing hook-status inspection moved intact into a focused sibling module. Any split identity delta is structural rather than a new behavior or complexity increase.

Resolves #29363


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 14m and 190,927 tokens on this as a headless worker.
