### PR TITLE
GH#29330: Diagnose sudo approval quota from failed response

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -222,26 +222,28 @@ _print_error() {
 }
 
 _approval_probe_core_rate_limit() {
-	local quota=""
-	local remaining=""
-	local reset=""
-
-	# The endpoint is zero-cost, but it must still respect any active shared
-	# secondary cooldown rather than creating a diagnostic bypass.
+	local response=""
+	local api_rc=0
+	# The diagnostic request must respect any active shared secondary cooldown.
 	if command -v _gh_secondary_cooldown_preflight >/dev/null 2>&1; then
 		_gh_secondary_cooldown_preflight read >/dev/null 2>&1 || return 1
 	fi
-
-	if ! quota=$(gh api rate_limit --jq '[.resources.core.remaining,.resources.core.reset] | @tsv' 2>/dev/null); then
-		return 1
-	fi
-	IFS=$'\t' read -r remaining reset <<<"$quota"
-	if [[ ! "$remaining" =~ ^[0-9]+$ || ! "$reset" =~ ^[0-9]+$ ]]; then
-		return 1
-	fi
-
-	printf '%s\t%s' "$remaining" "$reset"
-	return 0
+	response=$(gh api user --include --silent 2>/dev/null) || api_rc=$?
+	[[ "$api_rc" -ne 0 && -n "$response" ]] || return 1
+	printf '%s\n' "$response" | awk '
+		{ sub(/\r$/, "", $0) }
+		$1 ~ /^HTTP\// { status = $2 }
+		tolower($1) == "x-ratelimit-remaining:" { remaining = $2 }
+		tolower($1) == "x-ratelimit-reset:" { reset = $2 }
+		tolower($1) == "x-ratelimit-resource:" { resource = tolower($2) }
+		END {
+			if (status == "403" && remaining == "0" && reset ~ /^[0-9]+$/ && resource == "core") {
+				printf "%s\t%s", remaining, reset
+				exit 0
+			}
+			exit 1
+		}'
+	return $?
 }
 
 _approval_report_core_rate_limit() {

--- a/.agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh
+++ b/.agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh
@@ -227,7 +227,57 @@ run_case "sudo gh auth recovery works through the aidevops gh shim" '
 assert_not_contains "integrated shim recovered token is not printed" "$LAST_OUTPUT" "integrated-shim-token"
 
 # shellcheck disable=SC2016  # literal script is evaluated in the child bash.
-run_case "sudo gh auth classifies recovered token core exhaustion" '
+run_case "sudo gh auth diagnoses core exhaustion through the aidevops gh shim" '
+	set -uo pipefail
+	export SUDO_USER=alice
+	export HOME=/var/root
+	fixture_root=$(mktemp -d)
+	trap '\''rm -rf "$fixture_root"'\'' EXIT
+	helper_dir=${APPROVAL_HELPER_UNDER_TEST%/*}
+	shim_dir="$fixture_root/shim"
+	native_dir="$fixture_root/native"
+	mkdir -p "$shim_dir" "$native_dir"
+	for module in gh gh-native-transport-lib.sh gh-api-guards-lib.sh gh-write-policy-lib.sh gh-api-instrument.sh gh-rest-pagination-lib.sh; do
+		cp "$helper_dir/$module" "$shim_dir/$module"
+	done
+	chmod +x "$shim_dir/gh"
+	printf '\''#!/usr/bin/env bash\nif [[ "${1:-}:${2:-}" == "auth:token" ]]; then printf integrated-exhausted-token; exit 0; fi\nif [[ "${1:-}:${2:-}" == "auth:status" ]]; then exit 1; fi\nif [[ "${1:-}:${2:-}:${3:-}:${4:-}" == "api:user:--include:--silent" ]]; then\n  printf "HTTP/2.0 403 Forbidden\\r\\n"\n  printf "X-RateLimit-Remaining: 0\\r\\n"\n  printf "X-RateLimit-Reset: 1785697847\\r\\n"\n  printf "X-RateLimit-Resource: core\\r\\n\\r\\n"\n  exit 1\nfi\nif [[ "${1:-}:${2:-}" == "api:rate_limit" ]]; then printf "4652\\t1785700000\\n"; exit 0; fi\nexit 1\n'\'' >"$native_dir/gh"
+	chmod +x "$native_dir/gh"
+	export PATH="$shim_dir:$native_dir:/usr/bin:/bin"
+	export AIDEVOPS_GH_API_LOG="$fixture_root/api.log"
+	id() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "-u" && -z "$arg2" ]]; then printf "0"; return 0; fi
+		if [[ "$arg1" == "-u" && "$arg2" == "alice" ]]; then printf "501"; return 0; fi
+		return 1
+	}
+	getent() { return 1; }
+	dscl() { printf "NFSHomeDirectory: /Users/alice\n"; return 0; }
+	launchctl() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "asuser" && "$arg2" == "501" && "$#" -ge 11 ]]; then
+			shift 8
+			"$@"
+			return $?
+		fi
+		return 1
+	}
+	sudo() { return 1; }
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	auth_rc=0
+	_require_gh_auth || auth_rc=$?
+	[[ "$auth_rc" -eq 1 ]]
+' 0
+assert_contains "integrated shim core exhaustion is diagnosed" "$LAST_OUTPUT" "GitHub core API rate limit is exhausted"
+assert_contains "integrated shim diagnosis reports reset epoch" "$LAST_OUTPUT" "1785697847"
+assert_not_contains "integrated shim diagnosis avoids generic auth failure" "$LAST_OUTPUT" "automatic recovery from the invoking user's gh auth failed"
+assert_not_contains "integrated exhausted token is not printed" "$LAST_OUTPUT" "integrated-exhausted-token"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "sudo gh auth trusts failed user response over stale rate-limit endpoint" '
 	set -uo pipefail
 	export SUDO_USER=alice
 	export HOME=/var/root
@@ -247,11 +297,22 @@ run_case "sudo gh auth classifies recovered token core exhaustion" '
 	gh() {
 		local arg1="${1:-}"
 		local arg2="${2:-}"
+		local arg3="${3:-}"
+		local arg4="${4:-}"
 		if [[ "$arg1" == "auth" && "$arg2" == "status" ]]; then return 1; fi
-		if [[ "$arg1" == "api" && "$arg2" == "rate_limit" ]]; then
+		if [[ "$arg1" == "api" && "$arg2" == "user" && "$arg3" == "--include" && "$arg4" == "--silent" ]]; then
 			printf "%s\n" "$*" >"$probe_log"
 			[[ "${GH_TOKEN:-}" == "exhausted-user-token" ]] || return 1
-			printf "0\t1785697847\n"
+			printf "HTTP/2.0 403 Forbidden\r\n"
+			printf "X-RateLimit-Remaining: 0\r\n"
+			printf "X-RateLimit-Reset: 1785697847\r\n"
+			printf "X-RateLimit-Resource: core\r\n\r\n"
+			printf "{\"message\":\"API rate limit exceeded\"}\n"
+			return 1
+		fi
+		if [[ "$arg1" == "api" && "$arg2" == "rate_limit" ]]; then
+			printf "%s\n" "$*" >"$probe_log"
+			printf "4652\t1785700000\n"
 			return 0
 		fi
 		return 1
@@ -261,13 +322,55 @@ run_case "sudo gh auth classifies recovered token core exhaustion" '
 	auth_rc=0
 	_require_gh_auth || auth_rc=$?
 	[[ "$auth_rc" -eq 1 ]] || exit 1
-	[[ "$(<"$probe_log")" == "api rate_limit --jq [.resources.core.remaining,.resources.core.reset] | @tsv" ]]
+	[[ "$(<"$probe_log")" == "api user --include --silent" ]]
 ' 0
 assert_contains "core exhaustion is diagnosed" "$LAST_OUTPUT" "GitHub core API rate limit is exhausted"
 assert_contains "core exhaustion reports reset epoch" "$LAST_OUTPUT" "1785697847"
 assert_contains "core exhaustion explains credentials cannot repair quota" "$LAST_OUTPUT" "Re-authentication or forwarding GH_TOKEN will not help before reset"
 assert_not_contains "core exhaustion does not report generic auth recovery failure" "$LAST_OUTPUT" "automatic recovery from the invoking user's gh auth failed"
 assert_not_contains "exhausted recovered token is not printed" "$LAST_OUTPUT" "exhausted-user-token"
+assert_not_contains "failed user response body is not printed" "$LAST_OUTPUT" "API rate limit exceeded"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "sudo gh auth does not classify invalid token headers as core exhaustion" '
+	set -uo pipefail
+	export SUDO_USER=alice
+	export HOME=/var/root
+	id() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "-u" && -z "$arg2" ]]; then printf "0"; return 0; fi
+		if [[ "$arg1" == "-u" && "$arg2" == "alice" ]]; then printf "501"; return 0; fi
+		return 1
+	}
+	getent() { return 1; }
+	dscl() { printf "NFSHomeDirectory: /Users/alice\n"; return 0; }
+	launchctl() { printf "invalid-user-token"; return 0; }
+	sudo() { return 1; }
+	gh() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		local arg3="${3:-}"
+		local arg4="${4:-}"
+		if [[ "$arg1" == "auth" && "$arg2" == "status" ]]; then return 1; fi
+		if [[ "$arg1" == "api" && "$arg2" == "user" && "$arg3" == "--include" && "$arg4" == "--silent" ]]; then
+			printf "HTTP/2.0 401 Unauthorized\r\n"
+			printf "X-RateLimit-Remaining: 0\r\n"
+			printf "X-RateLimit-Reset: 1785697847\r\n"
+			printf "X-RateLimit-Resource: core\r\n\r\n"
+			printf "{\"message\":\"Bad credentials\"}\n"
+			return 1
+		fi
+		return 1
+	}
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_require_gh_auth
+' 1
+assert_contains "invalid token preserves generic auth failure" "$LAST_OUTPUT" "automatic recovery from the invoking user's gh auth failed"
+assert_not_contains "invalid token is not diagnosed as core exhaustion" "$LAST_OUTPUT" "GitHub core API rate limit is exhausted"
+assert_not_contains "invalid token response body is not printed" "$LAST_OUTPUT" "Bad credentials"
+assert_not_contains "invalid recovered token is not printed" "$LAST_OUTPUT" "invalid-user-token"
 
 # shellcheck disable=SC2016  # literal script is evaluated in the child bash.
 run_case "sudo gh auth quota probe obeys shared cooldown" '
@@ -292,10 +395,9 @@ run_case "sudo gh auth quota probe obeys shared cooldown" '
 		local arg1="${1:-}"
 		local arg2="${2:-}"
 		if [[ "$arg1" == "auth" && "$arg2" == "status" ]]; then return 1; fi
-		if [[ "$arg1" == "api" && "$arg2" == "rate_limit" ]]; then
+		if [[ "$arg1" == "api" && "$arg2" == "user" ]]; then
 			printf "called\n" >"$probe_log"
-			printf "0\t1785697847\n"
-			return 0
+			return 1
 		fi
 		return 1
 	}


### PR DESCRIPTION
## Summary

Replace the stale /rate_limit diagnostic with the authoritative failed /user response headers. Classify exhaustion only for HTTP 403, core remaining zero, and a numeric reset; preserve generic authentication failures otherwise. Add direct and real-shim regressions while keeping tokens and response bodies private.

## Files Changed

.agents/scripts/approval-helper.sh, .agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Ran the sudo gh-auth suite (32 passed), adjacent approval suites, the gh-shim suite (120 passed), ShellCheck, and .agents/scripts/linters-local.sh. Runtime-verified the real aidevops gh shim against synthetic native transport and confirmed live native and shimmed gh api user --include --silent produce header-only output.

Resolves #29330


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 13h 37m and 2,210,303 tokens on this with the user in an interactive session.