### PR TITLE
GH#29288: Make feedback routing head-bound and retryable

### DIFF
--- a/.agents/scripts/pulse-merge-feedback-finalizer.sh
+++ b/.agents/scripts/pulse-merge-feedback-finalizer.sh
@@ -1,0 +1,588 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Shared, head-bound finalization for Pulse feedback routing.
+
+[[ -n "${_PULSE_MERGE_FEEDBACK_FINALIZER_LOADED:-}" ]] && return 0
+_PULSE_MERGE_FEEDBACK_FINALIZER_LOADED=1
+
+PULSE_FEEDBACK_ROUTE_DEFERRED_RC=75
+PULSE_FEEDBACK_ROUTE_MAINTAINER_RC=76
+PULSE_FEEDBACK_ROUTE_CLOSED_STATE="CLOSED"
+PULSE_FEEDBACK_ROUTE_HOLD_LABEL="needs-maintainer-review"
+PULSE_FEEDBACK_ROUTE_OPEN_STATE="OPEN"
+
+_feedback_route_gh_write() {
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout write gh "$@"
+		return $?
+	fi
+	gh "$@"
+	return $?
+}
+
+_feedback_route_labels_include() {
+	local labels="$1"
+	local expected_label="$2"
+	[[ ",${labels}," == *",${expected_label},"* ]]
+	return $?
+}
+
+_feedback_route_labels_block_routing() {
+	local labels="$1"
+
+	if _feedback_route_labels_include "$labels" "no-takeover" \
+		|| _feedback_route_labels_include "$labels" "external-contributor" \
+		|| _feedback_route_labels_include "$labels" "$PULSE_FEEDBACK_ROUTE_HOLD_LABEL"; then
+		return 0
+	fi
+	if _feedback_route_labels_include "$labels" "origin:interactive" \
+		&& ! _feedback_route_labels_include "$labels" "origin:worker-takeover"; then
+		return 0
+	fi
+	return 1
+}
+
+_feedback_route_terminal_label_for_kind() {
+	local kind="$1"
+	case "$kind" in
+	review) printf '%s\n' 'review-routed-to-issue' ;;
+	conflict) printf '%s\n' 'conflict-feedback-routed' ;;
+	ci) printf '%s\n' 'ci-feedback-routed' ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
+_feedback_route_body_has_other_head_evidence() {
+	local issue_body="$1"
+	local kind="$2"
+	local pr_number="$3"
+	local start_marker="$4"
+	local completion_marker="$5"
+	local start_prefix="<!-- feedback-route:start:${kind}:PR${pr_number}:SHA"
+	local completion_prefix="<!-- feedback-route:complete:${kind}:PR${pr_number}:SHA"
+
+	if printf '%s' "$issue_body" | grep -F "$start_prefix" | grep -qvF "$start_marker"; then
+		return 0
+	fi
+	if printf '%s' "$issue_body" | grep -F "$completion_prefix" | grep -qvF "$completion_marker"; then
+		return 0
+	fi
+	return 1
+}
+
+_feedback_route_issue_endpoint() {
+	local repo_slug="$1"
+	local linked_issue="$2"
+	printf 'repos/%s/issues/%s' "$repo_slug" "$linked_issue"
+	return 0
+}
+
+_feedback_route_marker() {
+	local phase="$1"
+	local kind="$2"
+	local pr_number="$3"
+	local expected_head="$4"
+	printf '<!-- feedback-route:%s:%s:PR%s:SHA%s -->' "$phase" "$kind" "$pr_number" "$expected_head"
+	return 0
+}
+
+_feedback_route_pr_snapshot() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local endpoint="repos/${repo_slug}/pulls/${pr_number}"
+	local filter='[if .merged_at != null then "MERGED" else ((.state // "") | ascii_upcase) end, (.head.sha // ""), ([.labels[].name] | join(","))] | @tsv'
+
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read gh api "$endpoint" --jq "$filter" 2>/dev/null
+		return $?
+	fi
+	gh api "$endpoint" --jq "$filter" 2>/dev/null
+	return $?
+}
+
+_feedback_route_issue_body() {
+	local linked_issue="$1"
+	local repo_slug="$2"
+	local endpoint=""
+	endpoint=$(_feedback_route_issue_endpoint "$repo_slug" "$linked_issue")
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read gh api "$endpoint" --jq '.body // ""' 2>/dev/null
+		return $?
+	fi
+	gh api "$endpoint" --jq '.body // ""' 2>/dev/null
+	return $?
+}
+
+_feedback_route_issue_snapshot() {
+	local linked_issue="$1"
+	local repo_slug="$2"
+	local endpoint=""
+	endpoint=$(_feedback_route_issue_endpoint "$repo_slug" "$linked_issue")
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read gh api "$endpoint" \
+			--jq '[([.labels[].name] | join(",")), ([.assignees[].login] | join(","))] | @tsv' 2>/dev/null
+		return $?
+	fi
+	gh api "$endpoint" \
+		--jq '[([.labels[].name] | join(",")), ([.assignees[].login] | join(","))] | @tsv' 2>/dev/null
+	return $?
+}
+
+_feedback_route_issue_is_ready() {
+	local linked_issue="$1"
+	local repo_slug="$2"
+	local source_label="$3"
+	local snapshot=""
+	local labels=""
+	local assignees=""
+
+	snapshot=$(_feedback_route_issue_snapshot "$linked_issue" "$repo_slug") || return 1
+	IFS=$'\t' read -r labels assignees <<<"$snapshot"
+	_feedback_route_labels_include "$labels" "status:available" || return 1
+	_feedback_route_labels_include "$labels" "$source_label" || return 1
+	_feedback_route_labels_include "$labels" "origin:worker" || return 1
+	! _feedback_route_labels_include "$labels" "origin:interactive" || return 1
+	! _feedback_route_labels_include "$labels" "origin:worker-takeover" || return 1
+	! _feedback_route_labels_include "$labels" "$PULSE_FEEDBACK_ROUTE_HOLD_LABEL" || return 1
+	[[ -z "$assignees" ]] || return 1
+	return 0
+}
+
+_feedback_route_body_contains() {
+	local linked_issue="$1"
+	local repo_slug="$2"
+	local marker="$3"
+	local body=""
+	body=$(_feedback_route_issue_body "$linked_issue" "$repo_slug") || return 1
+	printf '%s' "$body" | grep -qF "$marker"
+	return $?
+}
+
+_feedback_route_hold_for_maintainer() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local linked_issue="$3"
+	local reason="$4"
+	local issue_hold_rc=0
+	local pr_hold_rc=0
+
+	if declare -F set_issue_status >/dev/null 2>&1; then
+		set_issue_status "$linked_issue" "$repo_slug" "in-review" \
+			--add-label "$PULSE_FEEDBACK_ROUTE_HOLD_LABEL" >/dev/null 2>&1 || issue_hold_rc=$?
+	else
+		_feedback_route_gh_write issue edit "$linked_issue" --repo "$repo_slug" \
+			--add-label "status:in-review" --add-label "$PULSE_FEEDBACK_ROUTE_HOLD_LABEL" \
+			--remove-label "status:available" >/dev/null 2>&1 || issue_hold_rc=$?
+	fi
+	_feedback_route_gh_write pr edit "$pr_number" --repo "$repo_slug" \
+		--add-label "$PULSE_FEEDBACK_ROUTE_HOLD_LABEL" >/dev/null 2>&1 || pr_hold_rc=$?
+	echo "[pulse-wrapper] feedback finalizer: preserving PR #${pr_number} and issue #${linked_issue} in ${repo_slug} for maintainer review — ${reason} (issue_hold_rc=${issue_hold_rc}, pr_hold_rc=${pr_hold_rc})" >>"$LOGFILE"
+	return "$PULSE_FEEDBACK_ROUTE_MAINTAINER_RC"
+}
+
+_feedback_route_defer() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local linked_issue="$3"
+	local reason="$4"
+	echo "[pulse-wrapper] feedback finalizer: deferred PR #${pr_number} and issue #${linked_issue} in ${repo_slug} — ${reason}" >>"$LOGFILE"
+	return "$PULSE_FEEDBACK_ROUTE_DEFERRED_RC"
+}
+
+_feedback_route_transition_and_verify() {
+	local linked_issue="$1"
+	local repo_slug="$2"
+	local source_label="$3"
+	local clear_hold="${4:-0}"
+
+	_transition_issue_for_redispatch "$linked_issue" "$repo_slug" "$source_label" "$clear_hold" || return 1
+	_feedback_route_issue_is_ready "$linked_issue" "$repo_slug" "$source_label"
+	return $?
+}
+
+_feedback_route_apply_terminal_label() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local expected_head="$3"
+	local terminal_label="$4"
+	local snapshot=""
+	local pr_state=""
+	local current_head=""
+	local labels=""
+
+	_feedback_route_gh_write pr edit "$pr_number" --repo "$repo_slug" --add-label "$terminal_label" >/dev/null 2>&1 || return 1
+	snapshot=$(_feedback_route_pr_snapshot "$pr_number" "$repo_slug") || return 1
+	IFS=$'\t' read -r pr_state current_head labels <<<"$snapshot"
+	[[ "$pr_state" == "$PULSE_FEEDBACK_ROUTE_CLOSED_STATE" && "$current_head" == "$expected_head" ]] || return 1
+	_feedback_route_labels_include "$labels" "$terminal_label" || return 1
+	_feedback_route_gh_write pr edit "$pr_number" --repo "$repo_slug" --remove-label "$PULSE_FEEDBACK_ROUTE_HOLD_LABEL" >/dev/null 2>&1 || true
+	return 0
+}
+
+_feedback_route_prepare_start() {
+	local kind="$1"
+	local pr_number="$2"
+	local repo_slug="$3"
+	local linked_issue="$4"
+	local expected_head="$5"
+	local pr_state="$6"
+	local issue_body="$7"
+	local start_marker="$8"
+	local legacy_marker="$9"
+	local feedback_section="${10}"
+	local caller="${11}"
+	local legacy_match="${12:-$legacy_marker}"
+
+	if printf '%s' "$issue_body" | grep -qF "$start_marker"; then
+		return 0
+	fi
+	if printf '%s' "$issue_body" | grep -qF "$legacy_match"; then
+		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+			"legacy ${kind} route marker has no head-bound start evidence"
+		return $?
+	fi
+	if [[ "$pr_state" != "$PULSE_FEEDBACK_ROUTE_OPEN_STATE" ]]; then
+		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+			"new ${kind} route expected OPEN at head ${expected_head}, observed ${pr_state:-unknown}"
+		return $?
+	fi
+
+	_append_feedback_to_issue "$linked_issue" "$repo_slug" "$start_marker" \
+		"${legacy_marker}
+${feedback_section}" "$caller" || {
+		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "could not persist the head-bound ${kind} route start marker"
+		return $?
+	}
+	if ! _feedback_route_body_contains "$linked_issue" "$repo_slug" "$start_marker"; then
+		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "head-bound ${kind} route start marker was not verifiable after write"
+		return $?
+	fi
+	return 0
+}
+
+_feedback_route_restore_after_postclose_failure() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local linked_issue="$3"
+	local expected_head="$4"
+	local reason="$5"
+	local snapshot=""
+	local pr_state=""
+	local current_head=""
+	local labels=""
+
+	_feedback_route_gh_write pr reopen "$pr_number" --repo "$repo_slug" >/dev/null 2>&1 || {
+		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+			"${reason}; compensating reopen failed"
+		return $?
+	}
+	snapshot=$(_feedback_route_pr_snapshot "$pr_number" "$repo_slug") || snapshot=""
+	IFS=$'\t' read -r pr_state current_head labels <<<"$snapshot"
+	if [[ "$pr_state" != "$PULSE_FEEDBACK_ROUTE_OPEN_STATE" || "$current_head" != "$expected_head" ]]; then
+		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+			"${reason}; compensating reopen could not verify the original head"
+		return $?
+	fi
+	_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "${reason}; restored OPEN state for retry"
+	return $?
+}
+
+_feedback_route_finish_closed() {
+	local kind="$1"
+	local pr_number="$2"
+	local repo_slug="$3"
+	local linked_issue="$4"
+	local expected_head="$5"
+	local terminal_label="$6"
+	local completion_marker="$7"
+	local caller="$8"
+	local closed_by_this_call="$9"
+
+	if ! _append_feedback_to_issue "$linked_issue" "$repo_slug" "$completion_marker" "" "$caller"; then
+		if [[ "$closed_by_this_call" == "1" ]]; then
+			_feedback_route_restore_after_postclose_failure "$pr_number" "$repo_slug" "$linked_issue" \
+				"$expected_head" "could not persist ${kind} completion evidence"
+			return $?
+		fi
+		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+			"closed ${kind} route could not persist completion evidence"
+		return $?
+	fi
+	if ! _feedback_route_body_contains "$linked_issue" "$repo_slug" "$completion_marker"; then
+		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+			"closed ${kind} route completion evidence could not be verified after write"
+		return $?
+	fi
+
+	if ! _feedback_route_apply_terminal_label "$pr_number" "$repo_slug" "$expected_head" "$terminal_label"; then
+		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+			"completed ${kind} route could not apply and verify terminal label ${terminal_label}"
+		return $?
+	fi
+	echo "[pulse-wrapper] feedback finalizer: completed ${kind} route for PR #${pr_number} head ${expected_head} to issue #${linked_issue} in ${repo_slug}" >>"$LOGFILE"
+	return 0
+}
+
+_feedback_route_resume_completed() {
+	local kind="$1"
+	local pr_number="$2"
+	local repo_slug="$3"
+	local linked_issue="$4"
+	local expected_head="$5"
+	local pr_state="$6"
+	local source_label="$7"
+	local terminal_label="$8"
+	local labels="$9"
+
+	if [[ "$pr_state" == "$PULSE_FEEDBACK_ROUTE_OPEN_STATE" ]]; then
+		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+			"completed same-head ${kind} route was reopened; refusing automatic re-close"
+		return $?
+	fi
+	if [[ "$pr_state" != "$PULSE_FEEDBACK_ROUTE_CLOSED_STATE" ]]; then
+		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+			"completed ${kind} route expected CLOSED at head ${expected_head}, observed ${pr_state:-unknown}"
+		return $?
+	fi
+	if _feedback_route_labels_include "$labels" "$terminal_label"; then
+		if _feedback_route_issue_is_ready "$linked_issue" "$repo_slug" "$source_label"; then
+			return 0
+		fi
+		if ! _feedback_route_transition_and_verify "$linked_issue" "$repo_slug" "$source_label" 1; then
+			_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "completed ${kind} route could not restore redispatch issue state"
+			return $?
+		fi
+		return 0
+	fi
+	if ! _feedback_route_transition_and_verify "$linked_issue" "$repo_slug" "$source_label" 1; then
+		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "completed ${kind} route could not re-verify redispatch issue state"
+		return $?
+	fi
+	if ! _feedback_route_apply_terminal_label "$pr_number" "$repo_slug" "$expected_head" "$terminal_label"; then
+		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+			"completed ${kind} route could not recover terminal label ${terminal_label}"
+		return $?
+	fi
+	return 0
+}
+
+_feedback_route_close_and_finish() {
+	local kind="$1"
+	local pr_number="$2"
+	local repo_slug="$3"
+	local linked_issue="$4"
+	local expected_head="$5"
+	local terminal_label="$6"
+	local completion_marker="$7"
+	local caller="$8"
+	local close_comment="$9"
+	local pr_state="${10}"
+	local start_marker="${11}"
+	local snapshot=""
+	local current_head=""
+	local labels=""
+	local close_rc=0
+	local close_snapshot_rc=0
+	local closed_by_this_call=0
+
+	if [[ "$pr_state" == "$PULSE_FEEDBACK_ROUTE_OPEN_STATE" ]]; then
+		_feedback_route_gh_write pr close "$pr_number" --repo "$repo_slug" \
+			--comment "${close_comment}
+
+${start_marker}" >/dev/null 2>&1 || close_rc=$?
+		[[ "$close_rc" -eq 0 ]] && closed_by_this_call=1
+		snapshot=$(_feedback_route_pr_snapshot "$pr_number" "$repo_slug") || close_snapshot_rc=$?
+		if [[ "$close_snapshot_rc" -ne 0 || -z "$snapshot" ]]; then
+			if [[ "$closed_by_this_call" -eq 1 ]]; then
+				_feedback_route_restore_after_postclose_failure "$pr_number" "$repo_slug" "$linked_issue" \
+					"$expected_head" "PR snapshot unavailable after acknowledged ${kind} close"
+				return $?
+			fi
+			_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+				"${kind} close outcome is unknown after failed close and unavailable verification"
+			return $?
+		fi
+		IFS=$'\t' read -r pr_state current_head labels <<<"$snapshot"
+		if [[ "$current_head" != "$expected_head" ]]; then
+			if [[ "$closed_by_this_call" -eq 1 ]]; then
+				_feedback_route_restore_after_postclose_failure "$pr_number" "$repo_slug" "$linked_issue" \
+					"$expected_head" "${kind} route head changed during close (${expected_head} to ${current_head:-unknown})"
+				return $?
+			fi
+			_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+				"${kind} route head changed during an ambiguous close (${expected_head} to ${current_head:-unknown})"
+			return $?
+		fi
+		if [[ "$pr_state" != "$PULSE_FEEDBACK_ROUTE_CLOSED_STATE" ]]; then
+			_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "${kind} PR close was not verified (close_rc=${close_rc})"
+			return $?
+		fi
+		if declare -F _pulse_merge_invalidate_pr_list_cache >/dev/null 2>&1; then
+			_pulse_merge_invalidate_pr_list_cache "$repo_slug" "closed feedback-routed PR #${pr_number}"
+		fi
+		_feedback_route_finish_closed "$kind" "$pr_number" "$repo_slug" "$linked_issue" \
+			"$expected_head" "$terminal_label" "$completion_marker" "$caller" "$closed_by_this_call"
+		return $?
+	fi
+	if [[ "$pr_state" != "$PULSE_FEEDBACK_ROUTE_CLOSED_STATE" ]]; then
+		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+			"started ${kind} route expected OPEN or CLOSED at head ${expected_head}, observed ${pr_state:-unknown}"
+		return $?
+	fi
+	_feedback_route_finish_closed "$kind" "$pr_number" "$repo_slug" "$linked_issue" \
+		"$expected_head" "$terminal_label" "$completion_marker" "$caller" 0
+	return $?
+}
+
+_finalize_feedback_route() {
+	local kind="$1"
+	local pr_number="$2"
+	local repo_slug="$3"
+	local linked_issue="$4"
+	local expected_head="$5"
+	local source_label="$6"
+	local terminal_label="$7"
+	local legacy_marker="$8"
+	local feedback_section="$9"
+	local caller="${10}"
+	local close_comment="${11}"
+	local legacy_match="${12:-$legacy_marker}"
+	local start_marker=""
+	local completion_marker=""
+	local snapshot=""
+	local pr_state=""
+	local current_head=""
+	local labels=""
+	local issue_body=""
+
+	if [[ "${DRY_RUN:-0}" == "1" ]]; then
+		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "dry-run forbids ${kind} finalization writes"
+		return $?
+	fi
+	[[ "$expected_head" =~ ^[0-9A-Za-z]{7,64}$ ]] || {
+		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "missing or malformed expected head for ${kind} route"
+		return $?
+	}
+	start_marker=$(_feedback_route_marker start "$kind" "$pr_number" "$expected_head")
+	completion_marker=$(_feedback_route_marker complete "$kind" "$pr_number" "$expected_head")
+	snapshot=$(_feedback_route_pr_snapshot "$pr_number" "$repo_slug") || {
+		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "current PR snapshot unavailable before ${kind} finalization"
+		return $?
+	}
+	IFS=$'\t' read -r pr_state current_head labels <<<"$snapshot"
+	if [[ "$current_head" != "$expected_head" ]]; then
+		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+			"${kind} route head drifted from ${expected_head} to ${current_head:-unknown}"
+		return $?
+	fi
+	if _feedback_route_labels_block_routing "$labels"; then
+		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" \
+			"current PR ownership labels prohibit ${kind} finalization"
+		return $?
+	fi
+	issue_body=$(_feedback_route_issue_body "$linked_issue" "$repo_slug") || {
+		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "linked issue body unavailable before ${kind} finalization"
+		return $?
+	}
+	if printf '%s' "$issue_body" | grep -qF "$completion_marker"; then
+		_feedback_route_resume_completed "$kind" "$pr_number" "$repo_slug" "$linked_issue" \
+			"$expected_head" "$pr_state" "$source_label" "$terminal_label" "$labels"
+		return $?
+	fi
+	if _feedback_route_body_has_other_head_evidence "$issue_body" "$kind" "$pr_number" \
+		"$start_marker" "$completion_marker"; then
+		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+			"existing ${kind} route evidence belongs to a different PR head"
+		return $?
+	fi
+	if [[ "$pr_state" != "$PULSE_FEEDBACK_ROUTE_OPEN_STATE" \
+		&& "$pr_state" != "$PULSE_FEEDBACK_ROUTE_CLOSED_STATE" ]]; then
+		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+			"started ${kind} route expected OPEN or CLOSED at head ${expected_head}, observed ${pr_state:-unknown}"
+		return $?
+	fi
+	_feedback_route_prepare_start "$kind" "$pr_number" "$repo_slug" "$linked_issue" \
+		"$expected_head" "$pr_state" "$issue_body" "$start_marker" "$legacy_marker" \
+		"$feedback_section" "$caller" "$legacy_match" || return $?
+	if ! _feedback_route_transition_and_verify "$linked_issue" "$repo_slug" "$source_label"; then
+		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "${kind} issue transition was not fully verified"
+		return $?
+	fi
+	snapshot=$(_feedback_route_pr_snapshot "$pr_number" "$repo_slug") || {
+		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "PR snapshot unavailable after ${kind} issue transition"
+		return $?
+	}
+	IFS=$'\t' read -r pr_state current_head labels <<<"$snapshot"
+	if [[ "$current_head" != "$expected_head" ]]; then
+		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+			"${kind} route head changed after issue transition (${expected_head} to ${current_head:-unknown})"
+		return $?
+	fi
+	if _feedback_route_labels_block_routing "$labels"; then
+		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+			"PR ownership labels changed during ${kind} finalization"
+		return $?
+	fi
+	_feedback_route_close_and_finish "$kind" "$pr_number" "$repo_slug" "$linked_issue" \
+		"$expected_head" "$terminal_label" "$completion_marker" "$caller" \
+		"$close_comment" "$pr_state" "$start_marker"
+	return $?
+}
+
+_feedback_route_guard_existing_terminal_label() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local linked_issue="$3"
+	local kind="$4"
+	local snapshot=""
+	local pr_state=""
+	local current_head=""
+	local labels=""
+	local issue_body=""
+	local start_marker=""
+	local completion_marker=""
+	local terminal_label=""
+	local marker_prefix="<!-- feedback-route:start:${kind}:PR${pr_number}:SHA"
+
+	snapshot=$(_feedback_route_pr_snapshot "$pr_number" "$repo_slug") || {
+		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "cannot inspect existing ${kind} terminal label"
+		return $?
+	}
+	IFS=$'\t' read -r pr_state current_head labels <<<"$snapshot"
+	terminal_label=$(_feedback_route_terminal_label_for_kind "$kind") || {
+		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "unknown feedback route kind ${kind}"
+		return $?
+	}
+	if _feedback_route_labels_block_routing "$labels"; then
+		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" \
+			"current PR ownership labels prohibit ${kind} route recovery"
+		return $?
+	fi
+	if ! _feedback_route_labels_include "$labels" "$terminal_label"; then
+		return 0
+	fi
+	issue_body=$(_feedback_route_issue_body "$linked_issue" "$repo_slug") || {
+		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "cannot inspect route evidence behind existing ${kind} terminal label"
+		return $?
+	}
+	start_marker=$(_feedback_route_marker start "$kind" "$pr_number" "$current_head")
+	completion_marker=$(_feedback_route_marker complete "$kind" "$pr_number" "$current_head")
+	if [[ "$pr_state" == "$PULSE_FEEDBACK_ROUTE_OPEN_STATE" ]] && printf '%s' "$issue_body" | grep -qF "$completion_marker"; then
+		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+			"completed same-head ${kind} route was manually reopened"
+		return $?
+	fi
+	if [[ "$pr_state" == "$PULSE_FEEDBACK_ROUTE_OPEN_STATE" ]] && printf '%s' "$issue_body" | grep -qF "$start_marker"; then
+		return 0
+	fi
+	if printf '%s' "$issue_body" | grep -qF "$marker_prefix"; then
+		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+			"existing ${kind} route evidence belongs to a different PR head"
+		return $?
+	fi
+	_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
+		"legacy ${kind} terminal label has no unambiguous head-bound route evidence"
+	return $?
+}

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -28,7 +28,7 @@
 #   - _build_review_feedback_section      (t2093)
 #   - _append_feedback_to_issue           (GH#20057, shared helper)
 #   - _transition_issue_for_redispatch    (GH#20057, shared helper)
-#   - _close_and_label_feedback_pr        (GH#20057, shared helper)
+#   - _finalize_feedback_route            (GH#29288, sourced state machine)
 #   - _build_ci_feedback_section          (GH#20057, extracted builder)
 #   - _dispatch_ci_fix_worker             (t2093 follow-up)
 #   - _classify_conflicts_by_pattern      (t2987, pattern classifier)
@@ -37,8 +37,8 @@
 #   - _dispatch_conflict_fix_worker       (t2093 follow-up)
 #   - _dispatch_pr_fix_worker             (t2093)
 #
-# All functions fail-open: missing helpers, API errors, or malformed
-# state never block the merge pass — they log and return 0.
+# Routing failures remain isolated from unrelated PRs, but incomplete
+# finalization returns a typed deferred/maintainer outcome to the merge loop.
 
 # Include guard — prevent double-sourcing.
 [[ -n "${_PULSE_MERGE_FEEDBACK_LOADED:-}" ]] && return 0
@@ -48,6 +48,13 @@ _PULSE_MERGE_FEEDBACK_LOADED=1
 # Ensures LOGFILE is safe to dereference in all functions when this module
 # is sourced outside the pulse-wrapper.sh bootstrap context.
 : "${LOGFILE:=${HOME}/.aidevops/logs/pulse.log}"
+
+_feedback_finalizer_path="${BASH_SOURCE[0]%/*}/pulse-merge-feedback-finalizer.sh"
+if [[ -r "$_feedback_finalizer_path" ]]; then
+	# shellcheck source=./pulse-merge-feedback-finalizer.sh
+	source "$_feedback_finalizer_path"
+fi
+unset _feedback_finalizer_path
 
 #######################################
 # Build the markdown "Review Feedback" section for routing to a linked
@@ -87,9 +94,9 @@ _build_review_feedback_section() {
 	header="## Review Feedback routed from PR #${pr_number} (t2093)
 
 This section was auto-generated when the deterministic merge pass detected
-\`reviewDecision=CHANGES_REQUESTED\` on the linked worker PR. The PR has been
-closed and this issue re-entered the dispatch queue. The next worker should
-address the findings below and open a fresh PR against this issue.
+\`reviewDecision=CHANGES_REQUESTED\` on the linked worker PR. A head-bound
+finalizer is routing the issue for redispatch. The next worker should address
+the findings below and open a fresh PR against this issue.
 
 See the original PR for full context: https://github.com/${repo_slug}/pull/${pr_number}
 "
@@ -188,11 +195,13 @@ ${feedback_section}"
 #   $1 - linked_issue  (issue number)
 #   $2 - repo_slug     (owner/repo)
 #   $3 - source_label  (e.g. "source:ci-feedback")
+#   $4 - clear_hold    (optional: 1 removes needs-maintainer-review on recovery)
 #######################################
 _transition_issue_for_redispatch() {
 	local linked_issue="$1"
 	local repo_slug="$2"
 	local source_label="$3"
+	local clear_hold="${4:-0}"
 	local _assignees=""
 	_assignees=$(gh issue view "$linked_issue" --repo "$repo_slug" --json assignees --jq '.assignees[].login' 2>/dev/null) || _assignees=""
 
@@ -205,45 +214,27 @@ _transition_issue_for_redispatch() {
 	while IFS= read -r _assignee; do
 		[[ -n "$_assignee" ]] && _redispatch_flags+=(--remove-assignee "$_assignee")
 	done <<<"$_assignees"
+	if [[ "$clear_hold" == "1" ]]; then
+		_redispatch_flags+=(--remove-label "needs-maintainer-review")
+	fi
 
 	if declare -F set_issue_status >/dev/null 2>&1; then
-		set_issue_status "$linked_issue" "$repo_slug" "available" \
-			--add-label "$source_label" "${_redispatch_flags[@]}" >/dev/null 2>&1 || true
+		if ! set_issue_status "$linked_issue" "$repo_slug" "available" \
+			--add-label "$source_label" "${_redispatch_flags[@]}" >/dev/null 2>&1; then
+			echo "[pulse-wrapper] feedback finalizer: failed to transition issue #${linked_issue} in ${repo_slug} to status:available" >>"$LOGFILE"
+			return 1
+		fi
 	else
-		gh issue edit "$linked_issue" --repo "$repo_slug" \
+		if ! _feedback_route_gh_write issue edit "$linked_issue" --repo "$repo_slug" \
 			--add-label "status:available" --add-label "$source_label" \
 			"${_redispatch_flags[@]}" \
 			--remove-label "status:queued" --remove-label "status:in-progress" \
 			--remove-label "status:in-review" --remove-label "status:claimed" \
-			>/dev/null 2>&1 || true
-	fi
-	return 0
-}
-
-#######################################
-# Close a feedback-routed PR with an explanatory comment and apply an
-# idempotency label.
-#
-# Args:
-#   $1 - pr_number
-#   $2 - repo_slug
-#   $3 - close_comment  (markdown body for the close comment)
-#   $4 - label          (e.g. "ci-feedback-routed")
-#######################################
-_close_and_label_feedback_pr() {
-	local pr_number="$1"
-	local repo_slug="$2"
-	local close_comment="$3"
-	local label="$4"
-
-	if gh pr close "$pr_number" --repo "$repo_slug" \
-		--comment "$close_comment" >/dev/null 2>&1; then
-		if declare -F _pulse_merge_invalidate_pr_list_cache >/dev/null 2>&1; then
-			_pulse_merge_invalidate_pr_list_cache "$repo_slug" "closed feedback-routed PR #${pr_number}"
+			>/dev/null 2>&1; then
+			echo "[pulse-wrapper] feedback finalizer: fallback transition failed for issue #${linked_issue} in ${repo_slug}" >>"$LOGFILE"
+			return 1
 		fi
 	fi
-	gh pr edit "$pr_number" --repo "$repo_slug" \
-		--add-label "$label" >/dev/null 2>&1 || true
 	return 0
 }
 
@@ -275,8 +266,8 @@ _build_ci_feedback_section() {
 	cat <<-EOF
 		## CI Repair Feedback (from PR #${pr_number})
 
-		The previous worker's PR #${pr_number} had terminal failed CI checks. The PR has been
-		closed and this issue re-queued for dispatch. The next worker should address these failures.
+		The previous worker's PR #${pr_number} had terminal failed CI checks. A head-bound
+		finalizer is routing this issue for redispatch. The next worker should address these failures.
 
 		### Terminal failed checks
 
@@ -461,6 +452,10 @@ _dispatch_ci_fix_worker() {
 	[[ "$pr_number" =~ ^[0-9]+$ ]] || return 0
 	[[ -n "$repo_slug" ]] || return 0
 	[[ "$linked_issue" =~ ^[0-9]+$ ]] || return 0
+	if [[ "${DRY_RUN:-0}" == "1" ]]; then
+		echo "[pulse-wrapper] feedback finalizer: deferred PR #${pr_number} and issue #${linked_issue} in ${repo_slug} — dry-run forbids CI repair dispatch and feedback finalization writes" >>"$LOGFILE"
+		return "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}"
+	fi
 	local initial_head_sha=""
 	initial_head_sha=$(gh pr view "$pr_number" --repo "$repo_slug" --json headRefOid --jq '.headRefOid // ""' 2>/dev/null) || initial_head_sha=""
 	if [[ -z "$initial_head_sha" ]]; then
@@ -544,9 +539,10 @@ _dispatch_ci_fix_worker() {
 	fi
 
 	echo "[pulse-wrapper] _dispatch_ci_fix_worker: durable fallback authorized for PR #${pr_number} in ${repo_slug}: ${fallback_reason}" >>"$LOGFILE"
+	local route_rc=0
 	_route_ci_repair_fallback "$pr_number" "$repo_slug" "$linked_issue" "$pr_head_sha" \
-		"$pr_head_ref" "$failure_fingerprint" "$fallback_reason" "$feedback_section" "$failing_checks"
-	return 0
+		"$pr_head_ref" "$failure_fingerprint" "$fallback_reason" "$feedback_section" "$failing_checks" || route_rc=$?
+	return "$route_rc"
 }
 
 #######################################
@@ -564,38 +560,30 @@ _route_ci_repair_fallback() {
 	local failing_checks="$9"
 	local marker_prefix="<!-- ci-feedback-fallback:PR${pr_number}:SHA${pr_head_sha:-unknown}"
 	local marker="${marker_prefix} -->"
-	local current_body=""
+	local legacy_match="<!-- ci-feedback-fallback:PR${pr_number}:SHA"
 	: "$failure_fingerprint"
+	if [[ "${DRY_RUN:-0}" == "1" ]]; then
+		echo "[pulse-wrapper] feedback finalizer: deferred PR #${pr_number} and issue #${linked_issue} in ${repo_slug} — dry-run forbids CI feedback finalization writes" >>"$LOGFILE"
+		return "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}"
+	fi
+	if ! declare -F _finalize_feedback_route >/dev/null 2>&1; then
+		echo "[pulse-wrapper] _dispatch_ci_fix_worker: feedback finalizer unavailable for PR #${pr_number} in ${repo_slug}" >>"$LOGFILE"
+		return "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}"
+	fi
 
-	gh label create "ci-feedback-routed" --repo "$repo_slug" --color "E4E669" \
+	_feedback_route_gh_write label create "ci-feedback-routed" --repo "$repo_slug" --color "E4E669" \
 		--description "Worker PR with failing CI routed to linked issue for re-dispatch" \
 		--force >/dev/null 2>&1 || true
-	gh label create "source:ci-feedback" --repo "$repo_slug" --color "FEF2C0" \
+	_feedback_route_gh_write label create "source:ci-feedback" --repo "$repo_slug" --color "FEF2C0" \
 		--description "Issue carries CI failure feedback routed from a closed worker PR" \
 		--force >/dev/null 2>&1 || true
-	current_body=$(gh issue view "$linked_issue" --repo "$repo_slug" \
-		--json body --jq '.body // ""' 2>/dev/null) || current_body=""
-	# Match both the PR/head marker and the legacy marker that appended :FP...
-	# so an upgrade cannot replay an already-routed fallback.
-	if [[ -n "$current_body" ]] && printf '%s' "$current_body" | grep -qF "$marker_prefix"; then
-		echo "[pulse-wrapper] _dispatch_ci_fix_worker: issue #${linked_issue} already has CI repair fallback marker for PR #${pr_number} head ${pr_head_sha:-unknown} — skipping duplicate fallback" >>"$LOGFILE"
-		return 0
-	fi
 	feedback_section="${feedback_section}
 
 ### In-place repair fallback
 
 - Reason: ${fallback_reason}
 - Retry: re-run the deterministic merge pass after restoring access to branch \`${pr_head_ref:-unknown}\`; keep PR #${pr_number} open until that retry is impossible."
-	_append_feedback_to_issue "$linked_issue" "$repo_slug" "$marker" \
-		"$feedback_section" "_dispatch_ci_fix_worker" || return 0
-
-	# Transition issue to available for re-dispatch
-	_transition_issue_for_redispatch "$linked_issue" "$repo_slug" "source:ci-feedback"
-
-	# Close the PR with feedback summary
-	_close_and_label_feedback_pr "$pr_number" "$repo_slug" \
-		"## CI repair feedback routed to issue #${linked_issue}
+	local close_comment="## CI repair feedback routed to issue #${linked_issue}
 
 This worker PR had terminal failed CI checks. The check details have been appended
 to the linked issue body so the next worker can address them.
@@ -603,11 +591,15 @@ to the linked issue body so the next worker can address them.
 Terminal failed checks:
 ${failing_checks}
 
-_Closed by deterministic merge pass (pulse-merge.sh)._" \
-		"ci-feedback-routed"
-
-	echo "[pulse-wrapper] _dispatch_ci_fix_worker: in-place repair impossible for PR #${pr_number}; routed fallback to issue #${linked_issue} in ${repo_slug}: ${fallback_reason}" >>"$LOGFILE"
-	return 0
+_Closed by deterministic merge pass (pulse-merge.sh)._"
+	local finalize_rc=0
+	_finalize_feedback_route "ci" "$pr_number" "$repo_slug" "$linked_issue" "$pr_head_sha" \
+		"source:ci-feedback" "ci-feedback-routed" "$marker" "$feedback_section" \
+		"_dispatch_ci_fix_worker" "$close_comment" "$legacy_match" || finalize_rc=$?
+	if [[ "$finalize_rc" -eq 0 ]]; then
+		echo "[pulse-wrapper] _dispatch_ci_fix_worker: in-place repair impossible for PR #${pr_number}; routed fallback to issue #${linked_issue} in ${repo_slug}: ${fallback_reason}" >>"$LOGFILE"
+	fi
+	return "$finalize_rc"
 }
 
 #######################################
@@ -1849,12 +1841,20 @@ _dispatch_conflict_fix_worker() {
 	[[ "$pr_number" =~ ^[0-9]+$ ]] || return 0
 	[[ -n "$repo_slug" ]] || return 0
 	[[ "$linked_issue" =~ ^[0-9]+$ ]] || return 0
+	if [[ "${DRY_RUN:-0}" == "1" ]]; then
+		echo "[pulse-wrapper] feedback finalizer: deferred PR #${pr_number} and issue #${linked_issue} in ${repo_slug} — dry-run forbids conflict feedback finalization writes" >>"$LOGFILE"
+		return "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}"
+	fi
+	if ! declare -F _finalize_feedback_route >/dev/null 2>&1; then
+		echo "[pulse-wrapper] _dispatch_conflict_fix_worker: feedback finalizer unavailable for PR #${pr_number} in ${repo_slug}" >>"$LOGFILE"
+		return "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}"
+	fi
 
 	# Create labels (idempotent, --force)
-	gh label create "conflict-feedback-routed" --repo "$repo_slug" --color "D4C5F9" \
+	_feedback_route_gh_write label create "conflict-feedback-routed" --repo "$repo_slug" --color "D4C5F9" \
 		--description "Worker PR with merge conflicts routed to linked issue for re-dispatch" \
 		--force >/dev/null 2>&1 || true
-	gh label create "source:conflict-feedback" --repo "$repo_slug" --color "E6D8FA" \
+	_feedback_route_gh_write label create "source:conflict-feedback" --repo "$repo_slug" --color "E6D8FA" \
 		--description "Issue carries conflict context routed from a closed worker PR" \
 		--force >/dev/null 2>&1 || true
 
@@ -1871,8 +1871,7 @@ _dispatch_conflict_fix_worker() {
 		pr_file_count=$(printf '%s\n' "$pr_files" | grep -c '^.' || true)
 	fi
 
-	# Get the closed PR's head commit SHA (t2426) — reachable for >=30 days after close
-	# and lets the next worker cherry-pick instead of rewriting from scratch.
+	# Snapshot the PR head before finalization so every later write is generation-bound.
 	local pr_head_sha
 	pr_head_sha=$(gh pr view "$pr_number" --repo "$repo_slug" \
 		--json headRefOid --jq '.headRefOid' 2>/dev/null) || pr_head_sha=""
@@ -1890,25 +1889,20 @@ _dispatch_conflict_fix_worker() {
 		"$pr_number" "$pr_title" "$pr_files" "$pr_head_sha" \
 		"$default_branch" "$pr_file_count")
 
-	# Append to issue body (marker-guarded, t2383 fail-safe)
 	local marker="<!-- conflict-feedback:PR${pr_number} -->"
-	_append_feedback_to_issue "$linked_issue" "$repo_slug" "$marker" \
-		"$feedback_section" "_dispatch_conflict_fix_worker" || return 0
-
-	# Transition issue to available for re-dispatch
-	_transition_issue_for_redispatch "$linked_issue" "$repo_slug" "source:conflict-feedback"
-
-	# Close the PR with conflict context
-	_close_and_label_feedback_pr "$pr_number" "$repo_slug" \
-		"## Merge conflict feedback routed to issue #${linked_issue}
+	local close_comment="## Merge conflict feedback routed to issue #${linked_issue}
 
 This worker PR had semantic merge conflicts with \`${default_branch}\` that \`update-branch\` could not resolve. The conflict context and file list have been appended to the linked issue body so the next worker can re-implement on top of current \`${default_branch}\`.
 
-_Closed by deterministic merge pass (pulse-merge.sh)._" \
-		"conflict-feedback-routed"
-
-	echo "[pulse-wrapper] _dispatch_conflict_fix_worker: routed conflict feedback from PR #${pr_number} to issue #${linked_issue} in ${repo_slug}" >>"$LOGFILE"
-	return 0
+_Closed by deterministic merge pass (pulse-merge.sh)._"
+	local finalize_rc=0
+	_finalize_feedback_route "conflict" "$pr_number" "$repo_slug" "$linked_issue" "$pr_head_sha" \
+		"source:conflict-feedback" "conflict-feedback-routed" "$marker" "$feedback_section" \
+		"_dispatch_conflict_fix_worker" "$close_comment" || finalize_rc=$?
+	if [[ "$finalize_rc" -eq 0 ]]; then
+		echo "[pulse-wrapper] _dispatch_conflict_fix_worker: routed conflict feedback from PR #${pr_number} to issue #${linked_issue} in ${repo_slug}" >>"$LOGFILE"
+	fi
+	return "$finalize_rc"
 }
 
 #######################################
@@ -1934,11 +1928,11 @@ _Closed by deterministic merge pass (pulse-merge.sh)._" \
 #   4. Closes the stuck PR with an explanatory comment and tags it
 #      `review-routed-to-issue` as a belt-and-suspenders idempotency flag.
 #
-# Interactive PRs and external-contributor PRs are filtered out by the
-# caller (`_check_pr_merge_gates`) — they have their own review flows.
+# Interactive, external-contributor, no-takeover, and maintainer-held PRs are
+# filtered by `_route_pr_to_fix_worker` before this helper is called.
 #
-# Fail-open: any API failure is logged and swallowed. The merge pass must
-# continue processing other PRs.
+# Partial finalization returns a typed deferred or maintainer outcome. The
+# merge-loop boundary logs that outcome and continues processing unrelated PRs.
 #
 # Reference patterns:
 #   - `quality-feedback-helper.sh` — bot review comment extraction
@@ -1958,14 +1952,31 @@ _dispatch_pr_fix_worker() {
 	[[ "$pr_number" =~ ^[0-9]+$ ]] || return 0
 	[[ -n "$repo_slug" ]] || return 0
 	[[ "$linked_issue" =~ ^[0-9]+$ ]] || return 0
+	if ! declare -F _finalize_feedback_route >/dev/null 2>&1; then
+		echo "[pulse-wrapper] _dispatch_pr_fix_worker: feedback finalizer unavailable for PR #${pr_number} in ${repo_slug}" >>"$LOGFILE"
+		return "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}"
+	fi
+	if [[ "${DRY_RUN:-0}" == "1" ]]; then
+		echo "[pulse-wrapper] feedback finalizer: deferred PR #${pr_number} and issue #${linked_issue} in ${repo_slug} — dry-run forbids review feedback finalization writes" >>"$LOGFILE"
+		return "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}"
+	fi
+	local route_snapshot=""
+	local route_state=""
+	local expected_head=""
+	local route_labels=""
+	route_snapshot=$(_feedback_route_pr_snapshot "$pr_number" "$repo_slug") || {
+		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "initial review-route PR snapshot unavailable"
+		return $?
+	}
+	IFS=$'\t' read -r route_state expected_head route_labels <<<"$route_snapshot"
 
 	# Ensure the idempotency + origin labels exist on the repo (idempotent,
 	# --force, swallowed failures). quality-feedback-helper.sh also creates
 	# source:review-feedback — redundant creation is harmless.
-	gh label create "review-routed-to-issue" --repo "$repo_slug" --color "D93F0B" \
+	_feedback_route_gh_write label create "review-routed-to-issue" --repo "$repo_slug" --color "D93F0B" \
 		--description "Worker PR with CHANGES_REQUESTED routed to linked issue for re-dispatch (t2093)" \
 		--force >/dev/null 2>&1 || true
-	gh label create "source:review-feedback" --repo "$repo_slug" --color "C2E0C6" \
+	_feedback_route_gh_write label create "source:review-feedback" --repo "$repo_slug" --color "C2E0C6" \
 		--description "Issue carries review feedback routed from a closed worker PR" \
 		--force >/dev/null 2>&1 || true
 
@@ -1999,15 +2010,7 @@ _dispatch_pr_fix_worker() {
 		return 0
 	fi
 
-	# --- Append to linked issue body (marker-guarded, t2383 fail-safe) ---
 	local marker="<!-- t2093:review-feedback:PR${pr_number} -->"
-	_append_feedback_to_issue "$linked_issue" "$repo_slug" "$marker" \
-		"$feedback_section" "_dispatch_pr_fix_worker" || return 0
-
-	# --- Transition issue status to available for re-dispatch ---
-	_transition_issue_for_redispatch "$linked_issue" "$repo_slug" "source:review-feedback"
-
-	# --- Close the stuck PR with explanatory comment ---
 	local close_comment
 	close_comment="## Review feedback routed to linked issue #${linked_issue} (t2093)
 
@@ -2026,13 +2029,12 @@ The next worker will see the updated issue body, address the review findings, an
 open a fresh PR against issue #${linked_issue}.
 
 _Closed by deterministic merge pass (pulse-merge.sh, t2093)._"
-
-	# Mark the PR as routed so any racing merge-pass re-read (via cached
-	# listing) skips re-processing. This is belt-and-suspenders — closed
-	# PRs are already excluded from the merge cycle's open-PR query.
-	_close_and_label_feedback_pr "$pr_number" "$repo_slug" \
-		"$close_comment" "review-routed-to-issue"
-
-	echo "[pulse-wrapper] _dispatch_pr_fix_worker: routed review feedback from PR #${pr_number} to issue #${linked_issue} in ${repo_slug} (t2093)" >>"$LOGFILE"
-	return 0
+	local finalize_rc=0
+	_finalize_feedback_route "review" "$pr_number" "$repo_slug" "$linked_issue" "$expected_head" \
+		"source:review-feedback" "review-routed-to-issue" "$marker" "$feedback_section" \
+		"_dispatch_pr_fix_worker" "$close_comment" || finalize_rc=$?
+	if [[ "$finalize_rc" -eq 0 ]]; then
+		echo "[pulse-wrapper] _dispatch_pr_fix_worker: routed review feedback from PR #${pr_number} to issue #${linked_issue} in ${repo_slug} (t2093)" >>"$LOGFILE"
+	fi
+	return "$finalize_rc"
 }

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -757,12 +757,13 @@ _dispatch_pr_repair_by_kind() {
 	local linked_issue="$4"
 	local pr_title="$5"
 	local checks_json="$6"
+	local dispatch_rc=0
 	case "$kind" in
-		review) _dispatch_pr_fix_worker "$pr_number" "$repo_slug" "$linked_issue" || true ;;
-		conflict) _dispatch_conflict_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "$pr_title" || true ;;
-		ci) _dispatch_ci_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "$checks_json" || true ;;
+		review) _dispatch_pr_fix_worker "$pr_number" "$repo_slug" "$linked_issue" || dispatch_rc=$? ;;
+		conflict) _dispatch_conflict_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "$pr_title" || dispatch_rc=$? ;;
+		ci) _dispatch_ci_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "$checks_json" || dispatch_rc=$? ;;
 	esac
-	return 0
+	return "$dispatch_rc"
 }
 
 _route_issue_origin_is_trusted() {
@@ -783,6 +784,39 @@ _route_issue_origin_is_trusted() {
 	return 0
 }
 
+_route_pr_issue_labels_for_dispatch() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local linked_issue="$3"
+	local issue_labels=""
+
+	if ! issue_labels=$(gh api "repos/${repo_slug}/issues/${linked_issue}" \
+		--jq '[.labels[].name] | join(",")' 2>/dev/null); then
+		echo "[pulse-wrapper] _route_pr_to_fix_worker: linked issue #${linked_issue} metadata unavailable for PR #${pr_number} in ${repo_slug} — refusing destructive routing" >>"$LOGFILE"
+		return "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}"
+	fi
+	[[ ",${issue_labels}," != *",needs-maintainer-review,"* ]] || return 1
+	printf '%s\n' "$issue_labels"
+	return 0
+}
+
+_route_pr_feedback_terminal_guard() {
+	local has_routed_label="$1"
+	local pr_number="$2"
+	local repo_slug="$3"
+	local linked_issue="$4"
+	local kind="$5"
+	local routed_label="$6"
+
+	[[ "$has_routed_label" -eq 1 ]] || return 0
+	if ! declare -F _feedback_route_guard_existing_terminal_label >/dev/null 2>&1; then
+		echo "[pulse-wrapper] _route_pr_to_fix_worker: feedback finalizer unavailable behind ${routed_label} on PR #${pr_number} in ${repo_slug}" >>"$LOGFILE"
+		return "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}"
+	fi
+	_feedback_route_guard_existing_terminal_label "$pr_number" "$repo_slug" "$linked_issue" "$kind"
+	return $?
+}
+
 #######################################
 # Route a PR to the appropriate fix worker based on origin label and kind.
 #
@@ -801,7 +835,8 @@ _route_issue_origin_is_trusted() {
 #   $8 = head_ref_oid  (optional — passed to staleness check)
 #   $9 = checks_json   (optional — head-bound terminal blocker evidence for CI repair)
 #
-# Returns: 0 if dispatched, 1 if not routable (no match or excluded)
+# Returns: 0 if dispatched, 1 if not routable, 75 if finalization is deferred,
+#          or 76 if ambiguous state was preserved for maintainer review.
 #
 # Design: case-statement dispatch over kind — no dynamic function calls.
 # Per-kind return semantics are handled by the CALLER, not here.
@@ -822,6 +857,8 @@ _route_pr_to_fix_worker() {
 	local issue_has_worker_origin=0
 	local label_list=""
 	local takeover_pattern=",origin:worker-takeover,"
+	local has_routed_label=0
+	local issue_labels_rc=0
 
 	# No linked issue → nothing to route to
 	[[ -z "$linked_issue" ]] && return 1
@@ -848,25 +885,24 @@ _route_pr_to_fix_worker() {
 			;;
 	esac
 
-	# Check exclusion labels — already routed or no-takeover
-	if [[ "$label_list" == *",${routed_label},"* ]] \
-		|| [[ "$label_list" == *",no-takeover,"* ]]; then
+	# These labels preserve explicit human/external ownership before any route
+	# recovery can inspect or mutate the PR and linked issue.
+	if [[ "$label_list" == *",no-takeover,"* \
+		|| "$label_list" == *",needs-maintainer-review,"* \
+		|| "$label_list" == *",external-contributor,"* ]]; then
 		return 1
+	fi
+	if [[ "$label_list" == *",${routed_label},"* ]]; then
+		has_routed_label=1
 	fi
 
-	# Review gate has an additional exclusion for external contributors
-	if [[ "$kind" == "review" ]] && [[ "$label_list" == *",external-contributor,"* ]]; then
-		return 1
-	fi
+	# A linked issue on explicit maintainer hold is never rewritten or reopened.
+	issue_labels=$(_route_pr_issue_labels_for_dispatch "$pr_number" "$repo_slug" "$linked_issue") || issue_labels_rc=$?
+	[[ "$issue_labels_rc" -eq 0 ]] || return "$issue_labels_rc"
 
 	if [[ "$label_list" != *",origin:worker,"* \
 		&& "$label_list" != *"$takeover_pattern"* \
 		&& "$label_list" != *",origin:interactive,"* ]]; then
-		if ! issue_labels=$(gh api "repos/${repo_slug}/issues/${linked_issue}" \
-			--jq '[.labels[].name] | join(",")' 2>/dev/null); then
-			echo "[pulse-wrapper] _route_pr_to_fix_worker: linked issue #${linked_issue} metadata unavailable for PR #${pr_number} in ${repo_slug} — refusing destructive routing" >>"$LOGFILE"
-			return 1
-		fi
 		if [[ ",${issue_labels}," == *",origin:worker,"* ]]; then
 			issue_has_worker_origin=1
 		fi
@@ -879,8 +915,10 @@ _route_pr_to_fix_worker() {
 		[[ "$issue_has_worker_origin" -eq 0 ]] \
 			|| _route_issue_origin_is_trusted "$pr_number" "$repo_slug" "$linked_issue" \
 			|| return 1
+		_route_pr_feedback_terminal_guard "$has_routed_label" "$pr_number" "$repo_slug" \
+			"$linked_issue" "$kind" "$routed_label" || return $?
 		_dispatch_pr_repair_by_kind "$kind" "$pr_number" "$repo_slug" "$linked_issue" "$pr_title" "$checks_json"
-		return 0
+		return $?
 	fi
 
 	# Stale interactive PRs: handover first, then dispatch
@@ -896,8 +934,10 @@ _route_pr_to_fix_worker() {
 			echo "[pulse-wrapper] _route_pr_to_fix_worker: origin:worker-takeover not confirmed for PR #${pr_number} in ${repo_slug} — refusing destructive routing" >>"$LOGFILE"
 			return 1
 		fi
+		_route_pr_feedback_terminal_guard "$has_routed_label" "$pr_number" "$repo_slug" \
+			"$linked_issue" "$kind" "$routed_label" || return $?
 		_dispatch_pr_repair_by_kind "$kind" "$pr_number" "$repo_slug" "$linked_issue" "$pr_title" "$checks_json"
-		return 0
+		return $?
 	fi
 
 	# Not routable (no matching origin label or not stale)

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -321,24 +321,6 @@ _handle_changes_requested_review_gate() {
 	fi
 
 	local _cr_label_list=",${_cr_pr_labels},"
-	# GH#29288: a completed CI-repair route followed by a completed review route
-	# leaves an open worker PR that neither pipeline can own. Once required CI has
-	# healed, surface that dual-failure state for a maintainer instead of silently
-	# repeating the CHANGES_REQUESTED skip forever. Adding the conservative label
-	# never clears the review or weakens any merge gate.
-	if [[ "$_cr_label_list" == *",ci-feedback-routed,"* \
-		&& "$_cr_label_list" == *",review-routed-to-issue,"* \
-		&& "$_cr_label_list" != *",needs-maintainer-review,"* ]] \
-		&& declare -F _check_required_checks_passing >/dev/null 2>&1 \
-		&& _check_required_checks_passing "$repo_slug" "$pr_number" >/dev/null 2>&1; then
-		if gh api --silent "repos/${repo_slug}/issues/${pr_number}/labels" \
-			-X POST -f 'labels[]=needs-maintainer-review'; then
-			echo "[pulse-merge] stalled PR #${pr_number} in ${repo_slug} — dual-failure state (ci-feedback-routed + review-routed-to-issue) with required CI green: flagging for maintainer (GH#29288)" >>"$LOGFILE"
-		else
-			echo "[pulse-merge] stalled PR #${pr_number} in ${repo_slug} — dual-failure state detected but needs-maintainer-review label write failed (GH#29288)" >>"$LOGFILE"
-		fi
-		return 1
-	fi
 	# Optional policy override (GH#26535): by default CHANGES_REQUESTED worker
 	# PRs keep the historical fast-routing behaviour below. Operators who prefer
 	# preserving the PR/review context can opt in to a remediation-first cycle.
@@ -363,7 +345,13 @@ _handle_changes_requested_review_gate() {
 
 	# If remediation is unavailable or fails to dispatch, route worker-authored
 	# PRs for fix dispatch and skip the merge (t2203: consolidated in helper).
-	_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "review" "$_cr_pr_labels" || true
+	local review_route_rc=0
+	_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "review" "$_cr_pr_labels" || review_route_rc=$?
+	if [[ "$review_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" ]]; then
+		echo "[pulse-wrapper] Merge pass: review feedback finalization deferred for PR #${pr_number} in ${repo_slug}; preserving retryable route state" >>"$LOGFILE"
+	elif [[ "$review_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" ]]; then
+		echo "[pulse-wrapper] Merge pass: review feedback finalization for PR #${pr_number} in ${repo_slug} requires maintainer review" >>"$LOGFILE"
+	fi
 	echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED" >>"$LOGFILE"
 	return 1
 }
@@ -1411,9 +1399,16 @@ _process_single_ready_pr() {
 			# PRs to fix workers before the protected-close precheck. Active
 			# interactive PRs remain protected because _route_pr_to_fix_worker only
 			# accepts origin:interactive after _interactive_pr_is_stale passes.
-				if _route_pr_to_fix_worker "$pr_number" "$repo_slug" "$_t2116_linked_issue" "conflict" "$pr_labels" "$pr_title" "$pr_updated_at" "$pr_head_ref_oid"; then
+				local _conflict_route_rc=0
+				_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$_t2116_linked_issue" "conflict" "$pr_labels" "$pr_title" "$pr_updated_at" "$pr_head_ref_oid" || _conflict_route_rc=$?
+				if [[ "$_conflict_route_rc" -eq 0 ]]; then
 					[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
 					return 2
+				fi
+				if [[ "$_conflict_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" \
+					|| "$_conflict_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" ]]; then
+					[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
+					return 1
 				fi
 
 			# GH#23371: some PRs are already known to be protected from
@@ -1530,7 +1525,12 @@ _process_single_ready_pr() {
 				return 1
 			fi
 			# CI failure: route to fix worker if applicable (t2203: consolidated).
-			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" "$pr_labels" "" "$pr_updated_at" "$pr_head_ref_oid" || true
+			local _ci_route_rc=0
+			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" "$pr_labels" "" "$pr_updated_at" "$pr_head_ref_oid" || _ci_route_rc=$?
+			if [[ "$_ci_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" \
+				|| "$_ci_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" ]]; then
+				echo "[pulse-wrapper] Merge pass: CI feedback route for PR #${pr_number} in ${repo_slug} remains partial; preserving the PR for retry or maintainer review" >>"$LOGFILE"
+			fi
 			[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}branch_protection_s" "$_branch_protection_start"
 			return 1
 		fi
@@ -1595,9 +1595,14 @@ _process_single_ready_pr() {
 	if ! _pulse_merge_final_trust_gate "$pr_number" "$repo_slug" "$pr_head_ref_oid"; then
 		_pulse_merge_maybe_dispatch_preflight_remediation "$pr_number" "$repo_slug"
 		if [[ "${_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON:-[]}" != "[]" ]]; then
+			local _preflight_route_rc=0
 			_route_pr_to_fix_worker "$pr_number" "$repo_slug" "$linked_issue" "ci" \
 				"$pr_labels" "" "$pr_updated_at" "$pr_head_ref_oid" \
-				"$_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON" || true
+				"$_PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON" || _preflight_route_rc=$?
+			if [[ "$_preflight_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" \
+				|| "$_preflight_route_rc" -eq "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" ]]; then
+				echo "[pulse-wrapper] Merge pass: preflight feedback route for PR #${pr_number} in ${repo_slug} remains partial" >>"$LOGFILE"
+			fi
 		fi
 		return 1
 	fi

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
 FEEDBACK_SCRIPT="${SCRIPT_DIR}/../pulse-merge-feedback.sh"
+FINALIZER_SCRIPT="${SCRIPT_DIR}/../pulse-merge-feedback-finalizer.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -59,6 +60,10 @@ setup_test_env() {
 	mkdir -p "${TEST_ROOT}/repo"
 	TEST_PR_HEAD_SHA="abcdef0123456789abcdef0123456789abcdef01"
 	export TEST_PR_HEAD_SHA
+	printf 'OPEN\n' >"${TEST_ROOT}/pr-state.txt"
+	printf 'origin:worker\n' >"${TEST_ROOT}/pr-labels.txt"
+	printf 'status:in-review,origin:interactive\n' >"${TEST_ROOT}/issue-labels.txt"
+	printf 'stale-owner\n' >"${TEST_ROOT}/issue-assignees.txt"
 	cat >"${TEST_ROOT}/bin/headless-runtime-helper.sh" <<'EOF'
 #!/usr/bin/env bash
 printf '%s|%s|%s|%s|%s|%s|%s|%s\n' "${AIDEVOPS_PR_REPAIR_NUMBER:-}" "${AIDEVOPS_PR_REPAIR_HEAD_SHA:-}" "${AIDEVOPS_PR_REPAIR_HEAD_REF:-}" "${AIDEVOPS_PR_REPAIR_FINGERPRINT:-}" "${AIDEVOPS_PR_REPAIR_OWNERSHIP_MODE:-}" "${WORKER_WORKTREE_PATH:-}" "${WORKER_NO_EXIT_PUSH:-}" "$*" >>"${GH_LOG}"
@@ -124,7 +129,7 @@ if [[ "${1:-} ${2:-}" == "pr view" ]]; then
 		exit 0
 	fi
 	if [[ "$*" == *"--json labels"* ]]; then
-		printf 'origin:worker\n'
+		cat "${TEST_ROOT}/pr-labels.txt"
 		exit 0
 	fi
 	if [[ "$*" == *"--json headRefOid"* ]]; then
@@ -135,6 +140,43 @@ if [[ "${1:-} ${2:-}" == "pr view" ]]; then
 		fi
 		exit 0
 	fi
+	exit 0
+fi
+
+if [[ "${1:-} ${2:-}" == "pr close" ]]; then
+	printf 'CLOSED\n' >"${TEST_ROOT}/pr-state.txt"
+	exit 0
+fi
+
+if [[ "${1:-} ${2:-}" == "pr reopen" ]]; then
+	printf 'OPEN\n' >"${TEST_ROOT}/pr-state.txt"
+	exit 0
+fi
+
+if [[ "${1:-} ${2:-}" == "pr edit" ]]; then
+	_labels=$(<"${TEST_ROOT}/pr-labels.txt")
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--add-label)
+			shift
+			_value="${1:-}"
+			[[ ",${_labels}," == *",${_value},"* ]] || _labels="${_labels:+${_labels},}${_value}"
+			;;
+		--remove-label)
+			shift
+			_value="${1:-}"
+			_next=""
+			IFS=',' read -r -a _parts <<<"$_labels"
+			for _part in "${_parts[@]}"; do
+				[[ "$_part" == "$_value" ]] && continue
+				_next="${_next:+${_next},}${_part}"
+			done
+			_labels="$_next"
+			;;
+		esac
+		shift || true
+	done
+	printf '%s\n' "$_labels" >"${TEST_ROOT}/pr-labels.txt"
 	exit 0
 fi
 
@@ -203,6 +245,10 @@ _append_gh_mock_routes() {
 	fi
 
 if [[ "${1:-} ${2:-}" == "issue view" ]]; then
+	if [[ "$*" == *"--json assignees"* ]]; then
+		cat "${TEST_ROOT}/issue-assignees.txt"
+		exit 0
+	fi
 	if [[ "$*" == *"--json body"* ]]; then
 		cat "${TEST_ROOT}/issue-body.txt"
 		exit 0
@@ -211,14 +257,52 @@ if [[ "${1:-} ${2:-}" == "issue view" ]]; then
 fi
 
 if [[ "${1:-} ${2:-}" == "issue edit" ]]; then
+	_labels=$(<"${TEST_ROOT}/issue-labels.txt")
+	_assignees=$(<"${TEST_ROOT}/issue-assignees.txt")
 	while [[ $# -gt 0 ]]; do
-		if [[ "$1" == "--body" ]]; then
+		_action="$1"
+		if [[ "$_action" == "--body" ]]; then
 			shift
 			printf '%s' "$1" >"${TEST_ROOT}/issue-body.txt"
-			exit 0
+		elif [[ "$_action" == "--add-label" ]]; then
+			shift
+			_value="${1:-}"
+			[[ ",${_labels}," == *",${_value},"* ]] || _labels="${_labels:+${_labels},}${_value}"
+		elif [[ "$_action" == "--remove-label" ]]; then
+			shift
+			_value="${1:-}"
+			_next=""
+			IFS=',' read -r -a _parts <<<"$_labels"
+			for _part in "${_parts[@]}"; do
+				[[ "$_part" == "$_value" ]] && continue
+				_next="${_next:+${_next},}${_part}"
+			done
+			_labels="$_next"
+		elif [[ "$_action" == "--remove-assignee" ]]; then
+			shift
+			_value="${1:-}"
+			[[ "$_assignees" == "$_value" ]] && _assignees=""
 		fi
-		shift
+		shift || true
 	done
+	printf '%s\n' "$_labels" >"${TEST_ROOT}/issue-labels.txt"
+	printf '%s' "$_assignees" >"${TEST_ROOT}/issue-assignees.txt"
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/pulls/100" ]]; then
+	printf '%s\t%s\t%s\n' "$(<"${TEST_ROOT}/pr-state.txt")" "$TEST_PR_HEAD_SHA" \
+		"$(<"${TEST_ROOT}/pr-labels.txt")"
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/issues/42" ]]; then
+	if [[ "$*" == *".body"* ]]; then
+		cat "${TEST_ROOT}/issue-body.txt"
+	else
+		printf '%s\t%s\n' "$(<"${TEST_ROOT}/issue-labels.txt")" \
+			"$(<"${TEST_ROOT}/issue-assignees.txt")"
+	fi
 	exit 0
 fi
 
@@ -312,6 +396,7 @@ define_process_helper() {
 	_pulse_merge_final_trust_gate() { _PULSE_FINAL_REQUIRES_SYNCHRONOUS_MERGE=0; _PULSE_MERGE_PREFLIGHT_BLOCKING_CHECKS_JSON="$PREFLIGHT_EVIDENCE"; return "$PREFLIGHT_RC"; }
 	_pulse_merge_maybe_dispatch_preflight_remediation() { return 0; }
 	_close_conflicting_pr() { return 0; }
+	_pmp_is_protected_release_pr() { return 1; }
 	_pmp_normalize_mergeable_state_into() { return 0; }
 	gh_pr_view() { gh pr view "$@"; return $?; }
 	printf -v PR_OBJECT '%s' '{"number":100,"state":"OPEN","mergeable":"MERGEABLE","reviewDecision":"","author":{"login":"worker-bot"},"title":"t1: fix"}'
@@ -333,7 +418,6 @@ define_feedback_helpers() {
 		_ci_repair_required_checks_json
 		_append_feedback_to_issue
 		_transition_issue_for_redispatch
-		_close_and_label_feedback_pr
 		_ci_repair_write_state
 		_ci_repair_process_start
 		_ci_repair_pid_is_live
@@ -411,6 +495,9 @@ EOF
 		# shellcheck disable=SC1090
 		eval "$fn_src"
 	done
+	unset _PULSE_MERGE_FEEDBACK_FINALIZER_LOADED
+	# shellcheck disable=SC1090
+	source "$FINALIZER_SCRIPT"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -27,6 +27,7 @@ TESTS_FAILED=0
 TEST_ROOT=""
 GH_LOG=""
 TIMEOUT_CALL_LOG=""
+EVENT_LOG=""
 
 print_result() {
 	local test_name="$1"
@@ -51,10 +52,20 @@ print_result() {
 reset_mock_state() {
 	: >"$GH_LOG"
 	: >"$TIMEOUT_CALL_LOG"
-	unset TEST_TIMEOUT_FAIL_PATTERN
+	: >"$EVENT_LOG"
+	unset DRY_RUN TEST_TIMEOUT_FAIL_PATTERN TEST_FAIL_TRANSITION TEST_FAIL_CLOSE \
+		TEST_FAIL_REOPEN TEST_FAIL_BODY_PHASE TEST_FAIL_TERMINAL_LABEL \
+		TEST_DRIFT_AFTER_TRANSITION_HEAD TEST_FAIL_PR_SNAPSHOT_AFTER_CLOSE \
+		TEST_ADD_NMR_DURING_TRANSITION TEST_ADD_PR_PROTECTION_DURING_TRANSITION
+	rm -f "${TEST_ROOT}/pr-close-observed" "${TEST_ROOT}/pr-snapshot-failure-consumed"
 	: >"${TEST_ROOT}/issue-body.txt"
 	: >"${TEST_ROOT}/reviews.json"
 	: >"${TEST_ROOT}/comments.json"
+	printf 'OPEN\n' >"${TEST_ROOT}/pr-state.txt"
+	printf 'abc123repairsha\n' >"${TEST_ROOT}/pr-head.txt"
+	printf 'origin:worker,auto-dispatch\n' >"${TEST_ROOT}/pr-labels.txt"
+	printf 'status:in-review,origin:interactive\n' >"${TEST_ROOT}/issue-labels.txt"
+	printf 'stale-owner\n' >"${TEST_ROOT}/issue-assignees.txt"
 	# Defaults: populated reviews + comments, empty issue body.
 	cat >"${TEST_ROOT}/reviews.json" <<'EOF'
 [{"user":{"login":"coderabbitai[bot]"},"state":"CHANGES_REQUESTED","body":"Two issues in the new helper. Please address before merge.","html_url":"https://github.com/owner/repo/pull/100#pullrequestreview-1"}]
@@ -73,9 +84,11 @@ setup_test_paths() {
 	: >"$LOGFILE"
 	GH_LOG="${TEST_ROOT}/gh-calls.log"
 	TIMEOUT_CALL_LOG="${TEST_ROOT}/timeout-calls.log"
+	EVENT_LOG="${TEST_ROOT}/route-events.log"
 	: >"$GH_LOG"
 	: >"$TIMEOUT_CALL_LOG"
-	export TEST_ROOT GH_LOG TIMEOUT_CALL_LOG
+	: >"$EVENT_LOG"
+	export TEST_ROOT GH_LOG TIMEOUT_CALL_LOG EVENT_LOG
 	return 0
 }
 
@@ -105,7 +118,7 @@ case "$_subcmd" in
 	;;
 "pr view")
 	if [[ "$*" == *"--json labels"* ]]; then
-		printf '%s\n' "origin:worker,auto-dispatch"
+		cat "${TEST_ROOT}/pr-labels.txt"
 		exit 0
 	fi
 	if [[ "$*" == *"headRefOid,headRefName,isCrossRepository,maintainerCanModify"* ]]; then
@@ -137,12 +150,69 @@ case "$_subcmd" in
 	fi
 	exit 0
 	;;
-"pr close" | "pr edit")
+"pr close")
+	printf 'pr-close\n' >>"${EVENT_LOG}"
+	: >"${TEST_ROOT}/pr-close-observed"
+	if [[ "${TEST_FAIL_CLOSE:-0}" == "1" ]]; then
+		exit 1
+	fi
+	printf 'CLOSED\n' >"${TEST_ROOT}/pr-state.txt"
+	exit 0
+	;;
+"pr reopen")
+	printf 'pr-reopen\n' >>"${EVENT_LOG}"
+	if [[ "${TEST_FAIL_REOPEN:-0}" == "1" ]]; then
+		exit 1
+	fi
+	printf 'OPEN\n' >"${TEST_ROOT}/pr-state.txt"
+	exit 0
+	;;
+GHEOF
+	return 0
+}
+
+append_gh_mock_pr_edit_cases() {
+	cat >>"${TEST_ROOT}/bin/gh" <<'GHEOF'
+"pr edit")
+	if [[ "$*" == *"--add-label review-routed-to-issue"* \
+		|| "$*" == *"--add-label conflict-feedback-routed"* \
+		|| "$*" == *"--add-label ci-feedback-routed"* ]]; then
+		printf 'pr-terminal-label\n' >>"${EVENT_LOG}"
+		if [[ "${TEST_FAIL_TERMINAL_LABEL:-0}" == "1" ]]; then
+			exit 1
+		fi
+	fi
+	_labels=$(<"${TEST_ROOT}/pr-labels.txt")
+	while [[ $# -gt 0 ]]; do
+		_action="$1"
+		case "$_action" in
+		--add-label)
+			shift
+			_value="${1:-}"
+			if [[ ",${_labels}," != *",${_value},"* ]]; then
+				_labels="${_labels:+${_labels},}${_value}"
+			fi
+			;;
+		--remove-label)
+			shift
+			_value="${1:-}"
+			_next=""
+			IFS=',' read -r -a _parts <<<"$_labels"
+			for _part in "${_parts[@]}"; do
+				[[ "$_part" == "$_value" ]] && continue
+				_next="${_next:+${_next},}${_part}"
+			done
+			_labels="$_next"
+			;;
+		esac
+		shift || true
+	done
+	printf '%s\n' "$_labels" >"${TEST_ROOT}/pr-labels.txt"
 	exit 0
 	;;
 "issue view")
 	if [[ "$*" == *"--json assignees"* ]]; then
-		printf '%s\n' 'stale-owner'
+		cat "${TEST_ROOT}/issue-assignees.txt"
 		exit 0
 	fi
 	if [[ "$*" == *"--json body"* ]]; then
@@ -151,16 +221,75 @@ case "$_subcmd" in
 	fi
 	exit 0
 	;;
+GHEOF
+	return 0
+}
+
+append_gh_mock_issue_edit_cases() {
+	cat >>"${TEST_ROOT}/bin/gh" <<'GHEOF'
 "issue edit")
-	# Capture the --body argument so subsequent views see the updated body.
+	_is_transition=0
+	if [[ "$*" == *"--body"* ]]; then
+		_body_phase="start"
+		if [[ "$*" == *"feedback-route:complete"* ]]; then
+			_body_phase="complete"
+		fi
+		printf 'issue-body-%s\n' "$_body_phase" >>"${EVENT_LOG}"
+		if [[ "${TEST_FAIL_BODY_PHASE:-}" == "$_body_phase" ]]; then
+			exit 1
+		fi
+	elif [[ "$*" == *"--add-label status:available"* ]]; then
+		_is_transition=1
+		printf 'issue-transition\n' >>"${EVENT_LOG}"
+		if [[ "${TEST_FAIL_TRANSITION:-0}" == "1" ]]; then
+			exit 1
+		fi
+	fi
+	_labels=$(<"${TEST_ROOT}/issue-labels.txt")
+	_assignees=$(<"${TEST_ROOT}/issue-assignees.txt")
 	while [[ $# -gt 0 ]]; do
-		if [[ "$1" == "--body" ]]; then
+		_action="$1"
+		if [[ "$_action" == "--body" ]]; then
 			shift
 			printf '%s' "$1" >"${TEST_ROOT}/issue-body.txt"
-			break
+		elif [[ "$_action" == "--add-label" ]]; then
+			shift
+			_value="${1:-}"
+			if [[ ",${_labels}," != *",${_value},"* ]]; then
+				_labels="${_labels:+${_labels},}${_value}"
+			fi
+		elif [[ "$_action" == "--remove-label" ]]; then
+			shift
+			_value="${1:-}"
+			_next=""
+			IFS=',' read -r -a _parts <<<"$_labels"
+			for _part in "${_parts[@]}"; do
+				[[ "$_part" == "$_value" ]] && continue
+				_next="${_next:+${_next},}${_part}"
+			done
+			_labels="$_next"
+		elif [[ "$_action" == "--remove-assignee" ]]; then
+			shift
+			_value="${1:-}"
+			[[ "$_assignees" == "$_value" ]] && _assignees=""
 		fi
-		shift
+		shift || true
 	done
+	if [[ "${TEST_ADD_NMR_DURING_TRANSITION:-0}" == "1" && "$_is_transition" -eq 1 \
+		&& ",${_labels}," != *",needs-maintainer-review,"* ]]; then
+		_labels="${_labels:+${_labels},}needs-maintainer-review"
+	fi
+	printf '%s\n' "$_labels" >"${TEST_ROOT}/issue-labels.txt"
+	printf '%s' "$_assignees" >"${TEST_ROOT}/issue-assignees.txt"
+	if [[ -n "${TEST_DRIFT_AFTER_TRANSITION_HEAD:-}" && "$_is_transition" -eq 1 ]]; then
+		printf '%s\n' "$TEST_DRIFT_AFTER_TRANSITION_HEAD" >"${TEST_ROOT}/pr-head.txt"
+	fi
+	if [[ -n "${TEST_ADD_PR_PROTECTION_DURING_TRANSITION:-}" && "$_is_transition" -eq 1 ]]; then
+		_pr_labels=$(<"${TEST_ROOT}/pr-labels.txt")
+		if [[ ",${_pr_labels}," != *",${TEST_ADD_PR_PROTECTION_DURING_TRANSITION},"* ]]; then
+			printf '%s,%s\n' "$_pr_labels" "$TEST_ADD_PR_PROTECTION_DURING_TRANSITION" >"${TEST_ROOT}/pr-labels.txt"
+		fi
+	fi
 	exit 0
 	;;
 esac
@@ -197,6 +326,25 @@ if [[ "${1:-}" == "api" ]]; then
 		fi
 		exit 0
 	fi
+	if [[ "${2:-}" == "repos/owner/repo/pulls/100" ]]; then
+		if [[ "${TEST_FAIL_PR_SNAPSHOT_AFTER_CLOSE:-0}" == "1" \
+			&& -f "${TEST_ROOT}/pr-close-observed" \
+			&& ! -f "${TEST_ROOT}/pr-snapshot-failure-consumed" ]]; then
+			: >"${TEST_ROOT}/pr-snapshot-failure-consumed"
+			exit 1
+		fi
+		printf '%s\t%s\t%s\n' "$(<"${TEST_ROOT}/pr-state.txt")" \
+			"$(<"${TEST_ROOT}/pr-head.txt")" "$(<"${TEST_ROOT}/pr-labels.txt")"
+		exit 0
+	fi
+	if [[ "${2:-}" == "repos/owner/repo/issues/42" ]]; then
+		if [[ "$_jq_filter" == *".body"* ]]; then
+			cat "${TEST_ROOT}/issue-body.txt"
+		else
+			printf '%s\t%s\n' "$(<"${TEST_ROOT}/issue-labels.txt")" "$(<"${TEST_ROOT}/issue-assignees.txt")"
+		fi
+		exit 0
+	fi
 fi
 
 exit 0
@@ -211,6 +359,8 @@ setup_test_env() {
 	# subcommand. Reads/writes to files under TEST_ROOT so tests can
 	# inspect/alter state between runs.
 	write_gh_mock_command_cases
+	append_gh_mock_pr_edit_cases
+	append_gh_mock_issue_edit_cases
 	append_gh_mock_api_cases
 	chmod +x "${TEST_ROOT}/bin/gh"
 	return 0
@@ -223,16 +373,16 @@ teardown_test_env() {
 	return 0
 }
 
-# Extract helpers under test and eval them in this shell. Same pattern
-# as test-pulse-merge-rebase-nudge.sh.
-#
-# GH#20057: _dispatch_pr_fix_worker now delegates to three shared helpers
-# (_append_feedback_to_issue, _transition_issue_for_redispatch,
-# _close_and_label_feedback_pr). All four must be eval'd into the test shell
-# for the dispatch tests to reach their assertions.
+# Source the feedback module so its head-bound finalizer dependency is exercised
+# exactly as Pulse loads it in production.
 define_helpers_under_test() {
-	local fn fn_src
 	gh_issue_edit_safe() { gh issue edit "$@"; return $?; }
+	_pulse_merge_invalidate_pr_list_cache() {
+		local repo_slug="$1"
+		local reason="$2"
+		printf 'pr-cache-invalidate %s %s\n' "$repo_slug" "$reason" >>"$EVENT_LOG"
+		return 0
+	}
 	gh_pr_checks_exact_json() {
 		local repo_slug="$1"
 		local pr_number="$2"
@@ -241,37 +391,9 @@ define_helpers_under_test() {
 		printf '%s\n' '[{"name":"Lint","bucket":"fail","state":"FAILURE","link":"https://github.com/owner/repo/actions/runs/123/job/456"}]'
 		return 1
 	}
-	# Functions to extract, in source order. _build_review_feedback_section
-	# is used by the "build section" tests; the three shared helpers are
-	# required by the refactored _dispatch_pr_fix_worker body.
-	local fns=(
-		_build_review_feedback_section
-		_append_feedback_to_issue
-		_transition_issue_for_redispatch
-		_close_and_label_feedback_pr
-		_ci_check_url_has_infra_failure_log
-		_ci_actionable_failed_checks_markdown
-		_ci_terminal_failed_check_results
-		_build_ci_feedback_section
-		_ci_repair_required_checks_json
-		_route_ci_repair_fallback
-		_ci_repair_hash_text
-		_dispatch_ci_fix_worker
-		_dispatch_pr_fix_worker
-	)
-	for fn in "${fns[@]}"; do
-		fn_src=$(awk -v name="$fn" '
-			$0 ~ "^" name "\\(\\) \\{" { capture = 1 }
-			capture { print }
-			capture && /^}$/ { capture = 0; exit }
-		' "$MERGE_SCRIPT")
-		if [[ -z "$fn_src" ]]; then
-			printf 'ERROR: could not extract %s from %s\n' "$fn" "$MERGE_SCRIPT" >&2
-			return 1
-		fi
-		# shellcheck disable=SC1090
-		eval "$fn_src"
-	done
+	unset _PULSE_MERGE_FEEDBACK_LOADED _PULSE_MERGE_FEEDBACK_FINALIZER_LOADED
+	# shellcheck disable=SC1090
+	source "$MERGE_SCRIPT"
 	_classify_ci_failures_by_pattern() { return 0; }
 	return 0
 }
@@ -380,6 +502,13 @@ test_dispatch_appends_to_issue_body_and_closes_pr() {
 			"Expected '--remove-assignee stale-owner' in call log"
 		return 0
 	fi
+	local actual_events=""
+	actual_events=$(<"$EVENT_LOG")
+	if [[ "$actual_events" != $'issue-body-start\nissue-transition\npr-close\npr-cache-invalidate owner/repo closed feedback-routed PR #100\nissue-body-complete\npr-terminal-label' ]]; then
+		print_result "dispatch commits route phases in safe order" 1 \
+			"events=$(tr '\n' ';' <"$EVENT_LOG")"
+		return 0
+	fi
 	print_result "dispatch appends body, closes PR, transitions labels" 0
 	return 0
 }
@@ -413,9 +542,9 @@ test_dispatch_timeout_fails_open_without_routing_empty_feedback() {
 	return 0
 }
 
-test_dispatch_idempotent_when_marker_already_present() {
+test_dispatch_preserves_ambiguous_legacy_marker() {
 	reset_mock_state
-	# Pre-seed the issue body with the marker.
+	# Pre-seed only the legacy marker, without head-bound start/completion evidence.
 	cat >"${TEST_ROOT}/issue-body.txt" <<'EOF'
 Original body.
 
@@ -424,23 +553,371 @@ Previously routed feedback content.
 EOF
 	: >"$GH_LOG"
 
-	_dispatch_pr_fix_worker "100" "owner/repo" "42"
+	local dispatch_rc=0
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || dispatch_rc=$?
 
-	# The body should not have been edited again (issue edit --body should
-	# not appear in call log). The PR close + label ops still fire —
-	# idempotency is scoped to the body append only.
 	if grep -qE 'gh issue edit [0-9]+ --repo [^ ]+ --body' "$GH_LOG"; then
-		print_result "dispatch skips body update when marker already present" 1 \
+		print_result "legacy route marker remains untouched" 1 \
 			"Unexpected 'issue edit --body' call. Log: $(cat "$GH_LOG")"
 		return 0
 	fi
-	# Sanity check: the marker call path was taken (log entry should mention it).
-	if ! grep -qF 'already has routed feedback marker' "$LOGFILE"; then
-		print_result "dispatch skips body update when marker already present" 1 \
-			"Expected idempotency log message in $LOGFILE"
+	if [[ "$dispatch_rc" -ne "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" ]] \
+		|| grep -qF 'gh pr close 100' "$GH_LOG" \
+		|| ! grep -qF 'needs-maintainer-review' "$GH_LOG" \
+		|| ! grep -qF 'legacy review route marker has no head-bound start evidence' "$LOGFILE"; then
+		print_result "ambiguous legacy route is preserved for maintainer review" 1 \
+			"rc=${dispatch_rc}; gh=$(tr '\n' ';' <"$GH_LOG"); log=$(tr '\n' ';' <"$LOGFILE")"
 		return 0
 	fi
-	print_result "dispatch skips body update when marker already present" 0
+	print_result "ambiguous legacy route is preserved for maintainer review" 0
+	return 0
+}
+
+review_route_is_complete() {
+	local start_count=0
+	local completion_count=0
+	start_count=$(grep -cF '<!-- feedback-route:start:review:PR100:SHAabc123repairsha -->' \
+		"${TEST_ROOT}/issue-body.txt" 2>/dev/null || true)
+	completion_count=$(grep -cF '<!-- feedback-route:complete:review:PR100:SHAabc123repairsha -->' \
+		"${TEST_ROOT}/issue-body.txt" 2>/dev/null || true)
+	[[ "$start_count" -eq 1 && "$completion_count" -eq 1 ]] || return 1
+	[[ "$(<"${TEST_ROOT}/pr-state.txt")" == "CLOSED" ]] || return 1
+	[[ ",$(<"${TEST_ROOT}/pr-labels.txt")," == *",review-routed-to-issue,"* ]] || return 1
+	return 0
+}
+
+test_dispatch_retries_after_transition_failure() {
+	reset_mock_state
+	export TEST_FAIL_TRANSITION=1
+	local first_rc=0
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || first_rc=$?
+	unset TEST_FAIL_TRANSITION
+
+	if [[ "$first_rc" -ne "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" \
+		|| "$(<"${TEST_ROOT}/pr-state.txt")" != "OPEN" \
+		|| "$(<"${TEST_ROOT}/issue-body.txt")" != *"feedback-route:start:review:PR100:SHAabc123repairsha"* \
+		|| "$(<"${TEST_ROOT}/issue-body.txt")" == *"feedback-route:complete:review:PR100:SHAabc123repairsha"* ]]; then
+		print_result "transition failure preserves a resumable started route" 1 \
+			"rc=${first_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); events=$(tr '\n' ';' <"$EVENT_LOG")"
+		return 0
+	fi
+
+	local retry_rc=0
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || retry_rc=$?
+	if [[ "$retry_rc" -ne 0 ]] || ! review_route_is_complete; then
+		print_result "started route resumes after issue transition recovers" 1 \
+			"rc=${retry_rc}; body=$(tr '\n' ';' <"${TEST_ROOT}/issue-body.txt"); labels=$(<"${TEST_ROOT}/pr-labels.txt")"
+		return 0
+	fi
+	print_result "transition failure defers and resumes without duplicate start evidence" 0
+	return 0
+}
+
+test_dispatch_preserves_maintainer_hold_racing_transition() {
+	reset_mock_state
+	export TEST_ADD_NMR_DURING_TRANSITION=1
+	local dispatch_rc=0
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || dispatch_rc=$?
+	unset TEST_ADD_NMR_DURING_TRANSITION
+
+	if [[ "$dispatch_rc" -ne "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" \
+		|| "$(<"${TEST_ROOT}/pr-state.txt")" != "OPEN" \
+		|| ",$(<"${TEST_ROOT}/issue-labels.txt")," != *",needs-maintainer-review,"* ]] \
+		|| grep -qF 'gh pr close 100' "$GH_LOG"; then
+		print_result "maintainer hold racing issue transition blocks close" 1 \
+			"rc=${dispatch_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); issue_labels=$(<"${TEST_ROOT}/issue-labels.txt"); events=$(tr '\n' ';' <"$EVENT_LOG")"
+		return 0
+	fi
+	print_result "maintainer hold racing issue transition is preserved" 0
+	return 0
+}
+
+test_dispatch_retries_after_close_failure() {
+	reset_mock_state
+	export TEST_FAIL_CLOSE=1
+	local first_rc=0
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || first_rc=$?
+	unset TEST_FAIL_CLOSE
+
+	if [[ "$first_rc" -ne "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" \
+		|| "$(<"${TEST_ROOT}/pr-state.txt")" != "OPEN" \
+		|| "$(<"${TEST_ROOT}/issue-body.txt")" == *"feedback-route:complete:review:PR100:SHAabc123repairsha"* ]]; then
+		print_result "close failure preserves an incomplete open route" 1 \
+			"rc=${first_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); events=$(tr '\n' ';' <"$EVENT_LOG")"
+		return 0
+	fi
+
+	local retry_rc=0
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || retry_rc=$?
+	if [[ "$retry_rc" -ne 0 ]] || ! review_route_is_complete; then
+		print_result "open route resumes after PR close recovers" 1 \
+			"rc=${retry_rc}; body=$(tr '\n' ';' <"${TEST_ROOT}/issue-body.txt"); events=$(tr '\n' ';' <"$EVENT_LOG")"
+		return 0
+	fi
+	print_result "close failure defers and resumes without terminal-state drift" 0
+	return 0
+}
+
+test_dispatch_reopens_when_close_verification_fails() {
+	reset_mock_state
+	export TEST_FAIL_PR_SNAPSHOT_AFTER_CLOSE=1
+	local first_rc=0
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || first_rc=$?
+	unset TEST_FAIL_PR_SNAPSHOT_AFTER_CLOSE
+
+	if [[ "$first_rc" -ne "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" \
+		|| "$(<"${TEST_ROOT}/pr-state.txt")" != "OPEN" \
+		|| "$(<"${TEST_ROOT}/issue-body.txt")" == *"feedback-route:complete:review:PR100:SHAabc123repairsha"* ]] \
+		|| ! grep -qF 'pr-reopen' "$EVENT_LOG"; then
+		print_result "unverified acknowledged close compensates by reopening" 1 \
+			"rc=${first_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); events=$(tr '\n' ';' <"$EVENT_LOG")"
+		return 0
+	fi
+
+	local retry_rc=0
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || retry_rc=$?
+	if [[ "$retry_rc" -ne 0 ]] || ! review_route_is_complete; then
+		print_result "route resumes after close verification recovers" 1 \
+			"rc=${retry_rc}; body=$(tr '\n' ';' <"${TEST_ROOT}/issue-body.txt"); events=$(tr '\n' ';' <"$EVENT_LOG")"
+		return 0
+	fi
+	print_result "close verification failure reopens and resumes safely" 0
+	return 0
+}
+
+test_dispatch_reopens_after_completion_write_failure() {
+	reset_mock_state
+	export TEST_FAIL_BODY_PHASE="complete"
+	local first_rc=0
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || first_rc=$?
+	unset TEST_FAIL_BODY_PHASE
+
+	if [[ "$first_rc" -ne "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" \
+		|| "$(<"${TEST_ROOT}/pr-state.txt")" != "OPEN" \
+		|| "$(<"${TEST_ROOT}/issue-body.txt")" == *"feedback-route:complete:review:PR100:SHAabc123repairsha"* \
+		|| ! -s "$EVENT_LOG" ]] \
+		|| ! grep -qF 'pr-reopen' "$EVENT_LOG"; then
+		print_result "post-close completion failure compensates by reopening" 1 \
+			"rc=${first_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); events=$(tr '\n' ';' <"$EVENT_LOG")"
+		return 0
+	fi
+
+	local retry_rc=0
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || retry_rc=$?
+	if [[ "$retry_rc" -ne 0 ]] || ! review_route_is_complete; then
+		print_result "compensated route completes on retry" 1 \
+			"rc=${retry_rc}; body=$(tr '\n' ';' <"${TEST_ROOT}/issue-body.txt"); events=$(tr '\n' ';' <"$EVENT_LOG")"
+		return 0
+	fi
+	print_result "completion-write failure reopens and resumes safely" 0
+	return 0
+}
+
+test_dispatch_recovers_terminal_label_failure() {
+	reset_mock_state
+	export TEST_FAIL_TERMINAL_LABEL=1
+	local first_rc=0
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || first_rc=$?
+	unset TEST_FAIL_TERMINAL_LABEL
+
+	if [[ "$first_rc" -ne "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" \
+		|| "$(<"${TEST_ROOT}/pr-state.txt")" != "CLOSED" \
+		|| "$(<"${TEST_ROOT}/issue-body.txt")" != *"feedback-route:complete:review:PR100:SHAabc123repairsha"* \
+		|| ",$(<"${TEST_ROOT}/pr-labels.txt")," == *",review-routed-to-issue,"* ]]; then
+		print_result "terminal-label failure exposes partial completion" 1 \
+			"rc=${first_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); labels=$(<"${TEST_ROOT}/pr-labels.txt")"
+		return 0
+	fi
+
+	# Production routing honors both hold labels before recovery. Simulate the
+	# maintainer releasing that explicit hold, then verify the completion marker
+	# lets the finalizer recover only the missing terminal label.
+	printf 'origin:worker,auto-dispatch\n' >"${TEST_ROOT}/pr-labels.txt"
+	printf 'status:in-review,origin:worker,source:review-feedback\n' >"${TEST_ROOT}/issue-labels.txt"
+	local retry_rc=0
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || retry_rc=$?
+	if [[ "$retry_rc" -ne 0 ]] || ! review_route_is_complete \
+		|| [[ ",$(<"${TEST_ROOT}/issue-labels.txt")," == *",needs-maintainer-review,"* \
+			|| ",$(<"${TEST_ROOT}/pr-labels.txt")," == *",needs-maintainer-review,"* ]]; then
+		print_result "completed route recovers a missing terminal label" 1 \
+			"rc=${retry_rc}; issue_labels=$(<"${TEST_ROOT}/issue-labels.txt"); pr_labels=$(<"${TEST_ROOT}/pr-labels.txt")"
+		return 0
+	fi
+	print_result "required terminal-label failure recovers after maintainer release" 0
+	return 0
+}
+
+test_dispatch_holds_on_head_drift() {
+	reset_mock_state
+	export TEST_DRIFT_AFTER_TRANSITION_HEAD="def456newhead"
+	local dispatch_rc=0
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || dispatch_rc=$?
+	unset TEST_DRIFT_AFTER_TRANSITION_HEAD
+
+	if [[ "$dispatch_rc" -ne "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" \
+		|| "$(<"${TEST_ROOT}/pr-state.txt")" != "OPEN" \
+		|| "$(<"${TEST_ROOT}/issue-body.txt")" == *"feedback-route:complete:review:PR100:SHAabc123repairsha"* \
+		|| ",$(<"${TEST_ROOT}/pr-labels.txt")," != *",needs-maintainer-review,"* \
+		|| ",$(<"${TEST_ROOT}/issue-labels.txt")," != *",needs-maintainer-review,"* ]]; then
+		print_result "head drift preserves the changed PR for maintainer review" 1 \
+			"rc=${dispatch_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); head=$(<"${TEST_ROOT}/pr-head.txt"); events=$(tr '\n' ';' <"$EVENT_LOG")"
+		return 0
+	fi
+	print_result "head drift never closes a different PR generation" 0
+	return 0
+}
+
+test_dispatch_holds_when_ownership_changes_during_transition() {
+	reset_mock_state
+	export TEST_ADD_PR_PROTECTION_DURING_TRANSITION="no-takeover"
+	local dispatch_rc=0
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || dispatch_rc=$?
+	unset TEST_ADD_PR_PROTECTION_DURING_TRANSITION
+
+	if [[ "$dispatch_rc" -ne "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" \
+		|| "$(<"${TEST_ROOT}/pr-state.txt")" != "OPEN" \
+		|| ",$(<"${TEST_ROOT}/pr-labels.txt")," != *",no-takeover,"* \
+		|| ",$(<"${TEST_ROOT}/pr-labels.txt")," != *",needs-maintainer-review,"* ]] \
+		|| grep -qF 'gh pr close 100' "$GH_LOG"; then
+		print_result "ownership change during transition preserves the PR" 1 \
+			"rc=${dispatch_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); labels=$(<"${TEST_ROOT}/pr-labels.txt"); events=$(tr '\n' ';' <"$EVENT_LOG")"
+		return 0
+	fi
+	print_result "ownership labels are revalidated before close" 0
+	return 0
+}
+
+test_dispatch_holds_prior_ci_head_evidence() {
+	reset_mock_state
+	cat >"${TEST_ROOT}/issue-body.txt" <<'EOF'
+Original issue body.
+
+<!-- feedback-route:start:ci:PR100:SHAold123head -->
+<!-- ci-feedback-fallback:PR100:SHAold123head -->
+Previously routed CI feedback.
+EOF
+	local dispatch_rc=0
+	_route_ci_repair_fallback "100" "owner/repo" "42" "abc123repairsha" \
+		"feature/worker" "fingerprint" "retry budget exhausted" \
+		"## CI Failure Feedback" "- **Unit**: failure" || dispatch_rc=$?
+
+	if [[ "$dispatch_rc" -ne "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" \
+		|| "$(<"${TEST_ROOT}/pr-state.txt")" != "OPEN" \
+		|| "$(<"${TEST_ROOT}/issue-body.txt")" == *"feedback-route:start:ci:PR100:SHAabc123repairsha"* ]] \
+		|| grep -qF 'gh pr close 100' "$GH_LOG" \
+		|| ! grep -qF 'different PR head' "$LOGFILE"; then
+		print_result "prior CI route evidence blocks a new-head close" 1 \
+			"rc=${dispatch_rc}; body=$(tr '\n' ';' <"${TEST_ROOT}/issue-body.txt"); events=$(tr '\n' ';' <"$EVENT_LOG")"
+		return 0
+	fi
+	print_result "changed-head CI route evidence is preserved for maintainer review" 0
+	return 0
+}
+
+test_dispatch_does_not_transition_started_merged_route() {
+	reset_mock_state
+	cat >"${TEST_ROOT}/issue-body.txt" <<'EOF'
+Original issue body.
+
+<!-- feedback-route:start:review:PR100:SHAabc123repairsha -->
+<!-- t2093:review-feedback:PR100 -->
+Previously routed review feedback.
+EOF
+	printf 'MERGED\n' >"${TEST_ROOT}/pr-state.txt"
+	local dispatch_rc=0
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || dispatch_rc=$?
+
+	if [[ "$dispatch_rc" -ne "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" ]] \
+		|| grep -qF 'issue-transition' "$EVENT_LOG" \
+		|| grep -qF 'gh pr close 100' "$GH_LOG"; then
+		print_result "started merged route remains untouched" 1 \
+			"rc=${dispatch_rc}; events=$(tr '\n' ';' <"$EVENT_LOG"); gh=$(tr '\n' ';' <"$GH_LOG")"
+		return 0
+	fi
+	print_result "non-open started route is held before issue transition" 0
+	return 0
+}
+
+test_terminal_guard_rechecks_current_label() {
+	reset_mock_state
+	local guard_rc=0
+	_feedback_route_guard_existing_terminal_label "100" "owner/repo" "42" "review" || guard_rc=$?
+
+	if [[ "$guard_rc" -ne 0 ]] || grep -qF 'needs-maintainer-review' "$GH_LOG"; then
+		print_result "terminal guard accepts a stale caller label after live removal" 1 \
+			"rc=${guard_rc}; labels=$(<"${TEST_ROOT}/pr-labels.txt"); gh=$(tr '\n' ';' <"$GH_LOG")"
+		return 0
+	fi
+	print_result "terminal guard revalidates the live routed label" 0
+	return 0
+}
+
+test_dispatch_holds_reopened_completed_route() {
+	reset_mock_state
+	cat >"${TEST_ROOT}/issue-body.txt" <<'EOF'
+Original issue body.
+
+<!-- feedback-route:start:review:PR100:SHAabc123repairsha -->
+<!-- t2093:review-feedback:PR100 -->
+Previously routed feedback.
+<!-- feedback-route:complete:review:PR100:SHAabc123repairsha -->
+EOF
+	printf 'origin:worker,auto-dispatch,review-routed-to-issue\n' >"${TEST_ROOT}/pr-labels.txt"
+	local dispatch_rc=0
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || dispatch_rc=$?
+
+	if [[ "$dispatch_rc" -ne "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" \
+		|| "$(<"${TEST_ROOT}/pr-state.txt")" != "OPEN" ]] \
+		|| grep -qF 'gh pr close 100' "$GH_LOG" \
+		|| ! grep -qF 'completed same-head review route was reopened' "$LOGFILE"; then
+		print_result "manually reopened completed route remains open" 1 \
+			"rc=${dispatch_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); gh=$(tr '\n' ';' <"$GH_LOG")"
+		return 0
+	fi
+	print_result "completed same-head route is never automatically reclosed" 0
+	return 0
+}
+
+test_dispatch_dry_run_has_no_writes() {
+	reset_mock_state
+	export DRY_RUN=1
+	local review_rc=0
+	local conflict_rc=0
+	local ci_rc=0
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || review_rc=$?
+	_dispatch_conflict_fix_worker "100" "owner/repo" "42" "Conflict" || conflict_rc=$?
+	_route_ci_repair_fallback "100" "owner/repo" "42" "abc123repairsha" \
+		"feature/worker" "fingerprint" "retry budget exhausted" \
+		"## CI Failure Feedback" "- **Unit**: failure" || ci_rc=$?
+	unset DRY_RUN
+
+	if [[ "$review_rc" -ne "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" \
+		|| "$conflict_rc" -ne "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" \
+		|| "$ci_rc" -ne "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" ]] \
+		|| grep -Eq '^gh (label create|issue edit|pr (close|edit|reopen))' "$GH_LOG"; then
+		print_result "dry-run feedback routing performs no writes" 1 \
+			"review_rc=${review_rc}; conflict_rc=${conflict_rc}; ci_rc=${ci_rc}; gh=$(tr '\n' ';' <"$GH_LOG")"
+		return 0
+	fi
+	print_result "dry-run preserves route state without mutations" 0
+	return 0
+}
+
+test_conflict_dispatch_uses_shared_finalizer() {
+	reset_mock_state
+	local dispatch_rc=0
+	_dispatch_conflict_fix_worker "100" "owner/repo" "42" "Resolve generated-file conflict" || dispatch_rc=$?
+
+	if [[ "$dispatch_rc" -ne 0 \
+		|| "$(<"${TEST_ROOT}/pr-state.txt")" != "CLOSED" \
+		|| "$(<"${TEST_ROOT}/issue-body.txt")" != *"feedback-route:start:conflict:PR100:SHAabc123repairsha"* \
+		|| "$(<"${TEST_ROOT}/issue-body.txt")" != *"feedback-route:complete:conflict:PR100:SHAabc123repairsha"* \
+		|| ",$(<"${TEST_ROOT}/pr-labels.txt")," != *",conflict-feedback-routed,"* ]]; then
+		print_result "conflict route uses shared head-bound finalizer" 1 \
+			"rc=${dispatch_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); labels=$(<"${TEST_ROOT}/pr-labels.txt"); body=$(tr '\n' ';' <"${TEST_ROOT}/issue-body.txt")"
+		return 0
+	fi
+	print_result "conflict route uses shared head-bound finalizer" 0
 	return 0
 }
 
@@ -528,7 +1005,12 @@ _subcmd="${1:-} ${2:-}"
 
 case "$_subcmd" in
 "label create") exit 0 ;;
-"pr view") exit 0 ;;
+"pr view")
+	if [[ "$*" == *"headRefOid"* ]]; then
+		printf 'abc123head\n'
+	fi
+	exit 0
+	;;
 "pr close" | "pr edit") exit 0 ;;
 "issue view") exit 1 ;;
 "issue edit")
@@ -546,6 +1028,10 @@ if [[ "${1:-}" == "api" ]]; then
 			break
 		fi
 	done
+	if [[ "$*" == *"/pulls/100"* && "$*" != *"/reviews"* && "$*" != *"/comments"* ]]; then
+		printf 'OPEN\tabc123head\t\n'
+		exit 0
+	fi
 	if [[ "$*" == *"/pulls/"*"/reviews"* ]]; then
 		if [[ -n "$_jq_filter" ]]; then
 			jq "$_jq_filter" <"${TEST_ROOT}/reviews.json"
@@ -571,12 +1057,14 @@ GHEOF
 	: >"$LOGFILE"
 	rm -f "${TEST_ROOT}/clobber-marker.txt"
 
-	_dispatch_pr_fix_worker "100" "owner/repo" "42"
+	local dispatch_rc=0
+	_dispatch_pr_fix_worker "100" "owner/repo" "42" || dispatch_rc=$?
 
 	# The clobber marker should NOT exist (issue edit should not have been called)
-	if [[ -f "${TEST_ROOT}/clobber-marker.txt" ]]; then
+	if [[ -f "${TEST_ROOT}/clobber-marker.txt" \
+		|| "$dispatch_rc" -ne "${PULSE_FEEDBACK_ROUTE_DEFERRED_RC:-75}" ]]; then
 		print_result "t2383: dispatch skips body edit on issue view failure" 1 \
-			"gh issue edit was called after gh issue view failure — data loss risk"
+			"gh issue edit was called after gh issue view failure or rc was not deferred (rc=${dispatch_rc})"
 		return 0
 	fi
 
@@ -607,9 +1095,9 @@ test_ci_dispatch_dedupes_by_pr_head_marker() {
 	[[ "$body_edit_count" =~ ^[0-9]+$ ]] || body_edit_count=0
 	[[ "$pr_close_count" =~ ^[0-9]+$ ]] || pr_close_count=0
 
-	if [[ "$body_edit_count" -ne 1 ]]; then
-		print_result "CI repair dispatch writes issue body exactly once per PR/head" 1 \
-			"Expected 1 body edit, got ${body_edit_count}. Log: $(cat "$GH_LOG")"
+	if [[ "$body_edit_count" -ne 2 ]]; then
+		print_result "CI repair dispatch writes start and completion evidence once per PR/head" 1 \
+			"Expected 2 body edits, got ${body_edit_count}. Log: $(cat "$GH_LOG")"
 		return 0
 	fi
 	if [[ "$pr_close_count" -ne 1 ]]; then
@@ -622,9 +1110,10 @@ test_ci_dispatch_dedupes_by_pr_head_marker() {
 			"Expected fallback marker in issue body. Body: $(cat "${TEST_ROOT}/issue-body.txt")"
 		return 0
 	fi
-	if ! grep -qF 'already has CI repair fallback marker' "$LOGFILE"; then
-		print_result "CI repair dispatch logs duplicate skip" 1 \
-			"Expected duplicate skip log. Log: $(cat "$LOGFILE")"
+	if ! grep -qF '<!-- feedback-route:start:ci:PR100:SHAabc123repairsha -->' "${TEST_ROOT}/issue-body.txt" \
+		|| ! grep -qF '<!-- feedback-route:complete:ci:PR100:SHAabc123repairsha -->' "${TEST_ROOT}/issue-body.txt"; then
+		print_result "CI repair fallback stores head-bound start and completion evidence" 1 \
+			"Expected transaction markers in issue body. Body: $(cat "${TEST_ROOT}/issue-body.txt")"
 		return 0
 	fi
 	print_result "CI repair fallback dedupes changed evidence per PR/head" 0
@@ -645,7 +1134,21 @@ main() {
 	test_dispatch_appends_to_issue_body_and_closes_pr
 	test_dispatch_wraps_paginated_feedback_reads
 	test_dispatch_timeout_fails_open_without_routing_empty_feedback
-	test_dispatch_idempotent_when_marker_already_present
+	test_dispatch_preserves_ambiguous_legacy_marker
+	test_dispatch_retries_after_transition_failure
+	test_dispatch_preserves_maintainer_hold_racing_transition
+	test_dispatch_retries_after_close_failure
+	test_dispatch_reopens_when_close_verification_fails
+	test_dispatch_reopens_after_completion_write_failure
+	test_dispatch_recovers_terminal_label_failure
+	test_dispatch_holds_on_head_drift
+	test_dispatch_holds_when_ownership_changes_during_transition
+	test_dispatch_holds_prior_ci_head_evidence
+	test_dispatch_does_not_transition_started_merged_route
+	test_terminal_guard_rechecks_current_label
+	test_dispatch_holds_reopened_completed_route
+	test_dispatch_dry_run_has_no_writes
+	test_conflict_dispatch_uses_shared_finalizer
 	test_dispatch_noop_when_no_substantive_feedback
 	test_dispatch_noop_on_invalid_inputs
 	test_dispatch_clears_in_progress_labels_as_fallback

--- a/.agents/scripts/tests/test-pulse-merge-pr-context.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-context.sh
@@ -50,6 +50,8 @@ define_functions_under_test() {
 		/^_attempt_pr_ci_rebase_retry\(\) \{/,/^}$/ { print }
 		/^_dispatch_pr_repair_by_kind\(\) \{/,/^}$/ { print }
 		/^_route_issue_origin_is_trusted\(\) \{/,/^}$/ { print }
+		/^_route_pr_issue_labels_for_dispatch\(\) \{/,/^}$/ { print }
+		/^_route_pr_feedback_terminal_guard\(\) \{/,/^}$/ { print }
 		/^_route_pr_to_fix_worker\(\) \{/,/^}$/ { print }
 	' "$PROCESS_SCRIPT")
 	if [[ -z "$fn_src" ]]; then
@@ -62,6 +64,10 @@ define_functions_under_test() {
 }
 
 install_stubs() {
+	ISSUE_LABELS="origin:worker,status:in-review"
+	ISSUE_METADATA_FAIL=0
+	PR_AUTHOR="maintainer"
+	ROUTE_GUARD_RC=0
 	gh() {
 		local arg1="${1:-}"
 		local arg2="${2:-}"
@@ -72,6 +78,7 @@ install_stubs() {
 			return 0
 		fi
 		if [[ "$arg1" == "api" && "$args" == *"repos/owner/repo/issues/456"* ]]; then
+			[[ "${ISSUE_METADATA_FAIL:-0}" == "1" ]] && return 1
 			printf '%s\n' "${ISSUE_LABELS:-origin:worker,status:in-review}"
 			return 0
 		fi
@@ -100,6 +107,7 @@ install_stubs() {
 	_dispatch_ci_fix_worker() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; printf 'dispatch-ci %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" >>"$GH_CALL_LOG"; return 0; }
 	_dispatch_pr_fix_worker() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; printf 'dispatch-review %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" >>"$GH_CALL_LOG"; return 0; }
 	_dispatch_conflict_fix_worker() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; printf 'dispatch-conflict %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" >>"$GH_CALL_LOG"; return 0; }
+	_feedback_route_guard_existing_terminal_label() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; local kind="$4"; printf 'route-guard %s %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" "$kind" >>"$GH_CALL_LOG"; return "$ROUTE_GUARD_RC"; }
 	_interactive_pr_is_stale() { return 1; }
 	_is_collaborator_author() { local author="$1"; [[ "$author" == "maintainer" ]]; return $?; }
 	return 0
@@ -254,6 +262,86 @@ test_missing_pr_label_metadata_fails_closed() {
 	return 0
 }
 
+test_explicit_ownership_labels_block_route_recovery() {
+	local labels=""
+	for labels in "origin:worker,no-takeover,review-routed-to-issue" \
+		"origin:worker,external-contributor,review-routed-to-issue" \
+		"origin:worker,needs-maintainer-review,review-routed-to-issue"; do
+		install_stubs
+		: >"$GH_CALL_LOG"
+		_route_pr_to_fix_worker "9010" "owner/repo" "456" "review" "$labels" || true
+		if grep -Eq 'route-guard|dispatch-' "$GH_CALL_LOG"; then
+			fail "explicit ownership labels block route recovery" \
+				"labels=${labels}; calls=$(tr '\n' ';' <"$GH_CALL_LOG")"
+			return 0
+		fi
+	done
+	pass "no-takeover, external, and maintainer holds precede route recovery"
+	return 0
+}
+
+test_linked_issue_maintainer_hold_blocks_route_recovery() {
+	install_stubs
+	ISSUE_LABELS="origin:worker,status:in-review,needs-maintainer-review"
+	: >"$GH_CALL_LOG"
+	_route_pr_to_fix_worker "9011" "owner/repo" "456" "ci" \
+		"origin:worker,ci-feedback-routed" || true
+	if grep -Eq 'route-guard|dispatch-' "$GH_CALL_LOG"; then
+		fail "linked issue maintainer hold blocks route recovery" \
+			"calls=$(tr '\n' ';' <"$GH_CALL_LOG")"
+		return 0
+	fi
+	pass "linked issue maintainer hold blocks route recovery"
+	return 0
+}
+
+test_linked_issue_metadata_failure_is_retryable() {
+	install_stubs
+	ISSUE_METADATA_FAIL=1
+	: >"$GH_CALL_LOG"
+	local route_rc=0
+	_route_pr_to_fix_worker "9014" "owner/repo" "456" "conflict" \
+		"origin:worker" || route_rc=$?
+	if [[ "$route_rc" -ne 75 ]] || grep -Eq 'route-guard|dispatch-' "$GH_CALL_LOG"; then
+		fail "linked issue metadata failure is retryable" \
+			"rc=${route_rc}; calls=$(tr '\n' ';' <"$GH_CALL_LOG")"
+		return 0
+	fi
+	pass "linked issue metadata failure preserves destructive routes for retry"
+	return 0
+}
+
+test_fresh_interactive_route_does_not_enter_terminal_guard() {
+	install_stubs
+	: >"$GH_CALL_LOG"
+	_route_pr_to_fix_worker "9012" "owner/repo" "456" "review" \
+		"origin:interactive,review-routed-to-issue" || true
+	if grep -Eq 'route-guard|dispatch-' "$GH_CALL_LOG"; then
+		fail "fresh interactive route does not enter terminal guard" \
+			"calls=$(tr '\n' ';' <"$GH_CALL_LOG")"
+		return 0
+	fi
+	pass "fresh interactive ownership is checked before route recovery"
+	return 0
+}
+
+test_trusted_worker_terminal_guard_outcome_propagates() {
+	install_stubs
+	ROUTE_GUARD_RC=75
+	: >"$GH_CALL_LOG"
+	local route_rc=0
+	_route_pr_to_fix_worker "9013" "owner/repo" "456" "ci" \
+		"origin:worker,ci-feedback-routed" || route_rc=$?
+	if [[ "$route_rc" -ne 75 ]] || ! grep -qF 'route-guard 9013 owner/repo 456 ci' "$GH_CALL_LOG" \
+		|| grep -qF 'dispatch-ci' "$GH_CALL_LOG"; then
+		fail "trusted worker terminal guard outcome propagates" \
+			"rc=${route_rc}; calls=$(tr '\n' ';' <"$GH_CALL_LOG")"
+		return 0
+	fi
+	pass "trusted worker partial-route outcome propagates without dispatch"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -269,6 +357,11 @@ main() {
 	test_interactive_route_requires_confirmed_handover
 	test_interactive_route_dispatches_after_confirmed_takeover
 	test_missing_pr_label_metadata_fails_closed
+	test_explicit_ownership_labels_block_route_recovery
+	test_linked_issue_maintainer_hold_blocks_route_recovery
+	test_linked_issue_metadata_failure_is_retryable
+	test_fresh_interactive_route_does_not_enter_terminal_guard
+	test_trusted_worker_terminal_guard_outcome_propagates
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]
 	return $?

--- a/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
+++ b/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
@@ -341,64 +341,47 @@ test_changes_requested_routes_by_default() {
 	return 0
 }
 
-test_changes_requested_dual_feedback_stall_flags_maintainer() {
+test_changes_requested_translates_maintainer_route_outcome() {
 	setup_test_env
 	define_helpers_under_test || { teardown_test_env; return 0; }
 	local route_log="${TEST_ROOT}/route.log"
-	local label_log="${TEST_ROOT}/label.log"
 	: >"$route_log"
-	: >"$label_log"
-	_check_required_checks_passing() { return 0; }
-	gh() {
-		printf '%s\n' "$*" >>"$label_log"
-		return 0
-	}
 	_route_pr_to_fix_worker() {
 		printf 'route\n' >>"$route_log"
-		return 0
+		return 76
 	}
 	_pulse_merge_dismiss_coderabbit_nits() { return 1; }
 
-	_handle_changes_requested_review_gate 77 owner/repo CHANGES_REQUESTED 42 \
-		"origin:worker,ci-feedback-routed,review-routed-to-issue" || true
-	if [[ ! -s "$route_log" ]] \
-		&& grep -qF 'repos/owner/repo/issues/77/labels -X POST -f labels[]=needs-maintainer-review' "$label_log" \
-		&& grep -qF 'dual-failure state (ci-feedback-routed + review-routed-to-issue) with required CI green: flagging for maintainer' "$LOGFILE"; then
-		print_result "dual feedback stall with green CI flags maintainer" 0
+	_handle_changes_requested_review_gate 77 owner/repo CHANGES_REQUESTED 42 "origin:worker" || true
+	if grep -q '^route$' "$route_log" \
+		&& grep -qF 'feedback finalization for PR #77 in owner/repo requires maintainer review' "$LOGFILE"; then
+		print_result "CHANGES_REQUESTED translates maintainer route outcome" 0
 	else
-		print_result "dual feedback stall with green CI flags maintainer" 1 \
-			"route=$(tr '\n' ';' <"$route_log"), label=$(tr '\n' ';' <"$label_log"), log=$(tr '\n' ';' <"$LOGFILE")"
+		print_result "CHANGES_REQUESTED translates maintainer route outcome" 1 \
+			"route=$(tr '\n' ';' <"$route_log"), log=$(tr '\n' ';' <"$LOGFILE")"
 	fi
 	teardown_test_env
 	return 0
 }
 
-test_changes_requested_dual_feedback_stall_waits_for_green_ci() {
+test_changes_requested_translates_deferred_route_outcome() {
 	setup_test_env
 	define_helpers_under_test || { teardown_test_env; return 0; }
 	local route_log="${TEST_ROOT}/route.log"
-	local label_log="${TEST_ROOT}/label.log"
 	: >"$route_log"
-	: >"$label_log"
-	_check_required_checks_passing() { return 1; }
-	gh() {
-		printf '%s\n' "$*" >>"$label_log"
-		return 0
-	}
 	_route_pr_to_fix_worker() {
 		printf 'route\n' >>"$route_log"
-		return 0
+		return 75
 	}
 	_pulse_merge_dismiss_coderabbit_nits() { return 1; }
 
-	_handle_changes_requested_review_gate 77 owner/repo CHANGES_REQUESTED 42 \
-		"origin:worker,ci-feedback-routed,review-routed-to-issue" || true
-	if grep -q '^route$' "$route_log" && [[ ! -s "$label_log" ]] \
-		&& ! grep -qF 'flagging for maintainer' "$LOGFILE"; then
-		print_result "dual feedback stall waits for green CI before flagging" 0
+	_handle_changes_requested_review_gate 77 owner/repo CHANGES_REQUESTED 42 "origin:worker" || true
+	if grep -q '^route$' "$route_log" \
+		&& grep -qF 'feedback finalization deferred for PR #77 in owner/repo; preserving retryable route state' "$LOGFILE"; then
+		print_result "CHANGES_REQUESTED translates deferred route outcome" 0
 	else
-		print_result "dual feedback stall waits for green CI before flagging" 1 \
-			"route=$(tr '\n' ';' <"$route_log"), label=$(tr '\n' ';' <"$label_log"), log=$(tr '\n' ';' <"$LOGFILE")"
+		print_result "CHANGES_REQUESTED translates deferred route outcome" 1 \
+			"route=$(tr '\n' ';' <"$route_log"), log=$(tr '\n' ';' <"$LOGFILE")"
 	fi
 	teardown_test_env
 	return 0
@@ -699,8 +682,8 @@ main() {
 	test_repo_path_lookup_ignores_slug_case
 	test_other_merge_failures_do_not_dispatch_review_thread_remediation
 	test_changes_requested_routes_by_default
-	test_changes_requested_dual_feedback_stall_flags_maintainer
-	test_changes_requested_dual_feedback_stall_waits_for_green_ci
+	test_changes_requested_translates_maintainer_route_outcome
+	test_changes_requested_translates_deferred_route_outcome
 	test_changes_requested_opt_in_dispatches_remediation_without_routing
 	test_changes_requested_routes_when_remediation_unavailable
 	test_changes_requested_active_remediation_preserves_pr_without_routing


### PR DESCRIPTION
## Summary

Added a shared, generation-bound state machine that resumes partial review, conflict, and CI feedback routes while preserving ambiguous, changed-head, and manually reopened PR state for maintainers.

## Files Changed

.agents/scripts/pulse-merge-feedback-finalizer.sh, .agents/scripts/pulse-merge-feedback.sh, .agents/scripts/pulse-merge-process.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh, .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh, .agents/scripts/tests/test-pulse-merge-pr-context.sh, .agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — runtime-verified with Bash 3.2 feedback-routing fixtures (25 + 28 + 15 + 23 passing), adjacent merge-gate suites, ShellCheck, full local linters, and the Pulse wrapper canary.

Resolves #29288


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 15h 3m and 3,399,252 tokens on this with the user in an interactive session.