### PR TITLE
GH#29309: Fix Linux worktree recovery storage semantics

### DIFF
--- a/.agents/reference/storage-lifecycle.md
+++ b/.agents/reference/storage-lifecycle.md
@@ -64,6 +64,7 @@ Reference, lease, recovery, and audit checks remain hard vetoes.
 | `~/.aidevops/.agent-workspace/observability` | framework | audit, archive, cache | Part streams and tool metadata are bounded at ingestion; runtime events use a 30-day active candidate window, verified immutable archive partitions, compacted low-value summaries, pinned recovery state, and append-only manifests | Measure defaults across routine/high-activity installations before changing the active window or adding any archive deletion policy |
 | `~/.aidevops/agents-backups` | framework | rollback, archive | Setup computes a dry-run plan under 10-snapshot, 180-day, and 4 GiB soft limits; the newest snapshot is always protected | Tune defaults from broader measurements without weakening rollback or attribution checks |
 | `~/.aidevops/logs/worker-failure-excerpts` | framework | recovery, archive | Excerpts are capped at 64 KiB; each session retains its newest evidence while older duplicates converge under 3-excerpt, 30-day, and 192 KiB soft limits | Add terminal issue/PR awareness before reclaiming the newest evidence for any session |
+| `~/.aidevops/recovery/worktrees` (Linux and non-macOS) | framework | recovery, unknown | Archive-first removal copies worktree and Git administrative state into an attributable bucket; `worktree-helper.sh recovery` reports current and legacy buckets without deleting them | Keep all buckets protected for manual review until a producer-specific restore and retention policy can prove them reclaimable |
 | Pulse active logs and `~/.aidevops/logs/pulse-archive` | framework | active, archive | Pulse preserves active descriptors while gzip-rotating 50 MiB hot/wrapper logs and 1 MiB timing logs; cold archives converge under 1 GiB | Keep rotation producer-owned and never replace it with generic unlink-by-age cleanup |
 | OpenCode data under its application-data root | joint | active, recovery, archive, unknown | OpenCode owns session and DB formats; aidevops archive/maintenance helpers coordinate selected operations | Separate logical retention from WAL/fragmentation maintenance; report only classifications proven through OpenCode-aware queries |
 | npm and other package-manager caches | external | cache | Package manager owns lifecycle | Context-only reporting; no aidevops aggregate deletion |
@@ -71,6 +72,29 @@ Reference, lease, recovery, and audit checks remain hard vetoes.
 
 The inventory is intentionally conservative. A child implementation may split a
 row when one path contains artifacts with different owners or safety classes.
+
+### Recoverable Worktree Archives
+
+Recoverable worktree archives are coupled safety snapshots rather than generic
+discarded files. On macOS their default root remains `$HOME/.Trash`, where that
+path has OS Trash semantics. On Linux and other platforms the default is the
+framework-owned `$HOME/.aidevops/recovery/worktrees`; normal “Empty Trash” must
+not silently delete these recovery snapshots. Operators can continue to select
+an absolute root with `AIDEVOPS_WORKTREE_TRASH_ROOT` (or the legacy
+`AIDEVOPS_ORPHAN_TRASH_ROOT` fallback).
+
+Each new bucket records `framework` ownership, the `recovery` safety class, and
+a `manual-review` policy beside its Git recovery identity. A completion marker
+is written only after archive integrity and source identity validation. Run
+`worktree-helper.sh recovery` for a read-only inventory. On non-macOS systems it
+also reports attributable legacy `$HOME/.Trash/aidevops-worktree-cleanup-*`
+buckets. The command reports framework-owned default roots separately from
+joint OS Trash or operator-selected roots. Incomplete, symlinked, or
+unrecognised buckets are `unknown`; the inventory never migrates or deletes
+them. Markerless v1 buckets are attributed only when the original archive
+integrity validator still proves their Git recovery structure. Existing archive
+integrity, lock, identity, late-write, detached-HEAD, and interruption checks
+remain authoritative.
 
 ### Runtime Bundle Retention Overrides
 

--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -74,6 +74,8 @@ _WT_GIT_STATUS_FIELD_PREFIX="aidevops-git-status "
 _WT_RECOVERY_FORMAT="aidevops-worktree-recovery-v1"
 _WT_RECOVERY_DIR_NAME=".aidevops-worktree-recovery"
 _WT_RECOVERY_COMPLETE_MARKER="archive-complete"
+_WT_RECOVERY_STORAGE_OWNER="framework"
+_WT_RECOVERY_ROOT_UNAVAILABLE="unavailable"
 _WT_RECOVERY_BRANCH_DETACHED="detached"
 WORKTREE_RECOVERABLE_ARCHIVE_PATH=""
 
@@ -747,6 +749,43 @@ _worktree_legacy_recovery_bucket_is_valid() {
 	return 0
 }
 
+_worktree_recovery_v2_metadata_is_present() {
+	local bucket="$1"
+	local recovery_dir="${bucket}/${_WT_RECOVERY_DIR_NAME}"
+	local metadata_name=""
+
+	for metadata_name in "$_WT_RECOVERY_COMPLETE_MARKER" storage-owner storage-class storage-policy storage-root; do
+		if [[ -e "$recovery_dir/$metadata_name" || -L "$recovery_dir/$metadata_name" ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+_worktree_recovery_storage_contract_is_valid() {
+	local bucket="$1"
+	local expected_root="$2"
+	local recovery_dir="${bucket}/${_WT_RECOVERY_DIR_NAME}"
+	local storage_owner=""
+	local storage_class=""
+	local storage_policy=""
+	local storage_root=""
+	local metadata_name=""
+
+	for metadata_name in storage-owner storage-class storage-policy storage-root; do
+		[[ -f "$recovery_dir/$metadata_name" && ! -L "$recovery_dir/$metadata_name" ]] || return 1
+	done
+	IFS= read -r storage_owner <"$recovery_dir/storage-owner" || return 1
+	IFS= read -r storage_class <"$recovery_dir/storage-class" || return 1
+	IFS= read -r storage_policy <"$recovery_dir/storage-policy" || return 1
+	IFS= read -r storage_root <"$recovery_dir/storage-root" || return 1
+	[[ "$storage_owner" == "$_WT_RECOVERY_STORAGE_OWNER" ]] || return 1
+	[[ "$storage_class" == "recovery" ]] || return 1
+	[[ "$storage_policy" == "manual-review" ]] || return 1
+	[[ "$storage_root" == "$expected_root" ]] || return 1
+	return 0
+}
+
 _worktree_recovery_inventory_root() {
 	local root_path="$1"
 	local store_role="$2"
@@ -759,10 +798,10 @@ _worktree_recovery_inventory_root() {
 	local state="unknown"
 
 	if [[ -d "$root_path" ]]; then
-		root_real=$(cd "$root_path" 2>/dev/null && pwd -P) || root_state="unavailable"
-		[[ "$root_state" == "unavailable" ]] || root_state="present"
+		root_real=$(cd "$root_path" 2>/dev/null && pwd -P) || root_state="$_WT_RECOVERY_ROOT_UNAVAILABLE"
+		[[ "$root_state" == "$_WT_RECOVERY_ROOT_UNAVAILABLE" ]] || root_state="present"
 	elif [[ -e "$root_path" || -L "$root_path" ]]; then
-		root_state="unavailable"
+		root_state="$_WT_RECOVERY_ROOT_UNAVAILABLE"
 	fi
 	printf 'store\t%s\t%s\trecovery\tmanual-review\t%s\t%s\n' \
 		"$store_role" "$root_owner" "$root_state" "$root_real"
@@ -778,20 +817,26 @@ _worktree_recovery_inventory_root() {
 			-f "$bucket/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" &&
 			! -L "$bucket/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" ]]; then
 			IFS= read -r format <"$bucket/${_WT_RECOVERY_DIR_NAME}/format" || format=""
-			IFS= read -r completion <\
+			IFS= read -r completion < \
 				"$bucket/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" || completion=""
-			[[ "$format" == "$_WT_RECOVERY_FORMAT" &&
-				"$completion" == "$_WT_RECOVERY_FORMAT" ]] && state="attributed"
+			if [[ "$format" == "$_WT_RECOVERY_FORMAT" &&
+				"$completion" == "$_WT_RECOVERY_FORMAT" ]] &&
+				_worktree_recovery_storage_contract_is_valid "$bucket" "$root_real" &&
+				_worktree_legacy_recovery_bucket_is_valid "$bucket"; then
+				state="attributed"
+			fi
 		elif [[ -d "$bucket" && ! -L "$bucket" &&
 			-f "$bucket/${_WT_RECOVERY_DIR_NAME}/format" &&
 			! -L "$bucket/${_WT_RECOVERY_DIR_NAME}/format" ]]; then
 			IFS= read -r format <"$bucket/${_WT_RECOVERY_DIR_NAME}/format" || format=""
 			if [[ "$format" == "$_WT_RECOVERY_FORMAT" ]] &&
+				! _worktree_recovery_v2_metadata_is_present "$bucket" &&
 				_worktree_legacy_recovery_bucket_is_valid "$bucket"; then
 				state="attributed-legacy"
 			fi
 		fi
-		printf 'bucket\t%s\tframework\t%s\t%s\n' "$store_role" "$state" "$bucket"
+		printf 'bucket\t%s\t%s\t%s\t%s\n' \
+			"$store_role" "$_WT_RECOVERY_STORAGE_OWNER" "$state" "$bucket"
 	done
 	return 0
 }
@@ -874,7 +919,7 @@ archive_worktree_path_recoverably() {
 	mkdir "$recovery_dir" 2>/dev/null || return 1
 	_worktree_copy_directory_once "$_WT_ID_ADMIN_REAL" "$recovery_admin" || return 1
 	_worktree_write_recovery_identity "$recovery_dir" || return 1
-	printf '%s\n' "framework" >"${recovery_dir}/storage-owner" || return 1
+	printf '%s\n' "$_WT_RECOVERY_STORAGE_OWNER" >"${recovery_dir}/storage-owner" || return 1
 	printf '%s\n' "recovery" >"${recovery_dir}/storage-class" || return 1
 	printf '%s\n' "manual-review" >"${recovery_dir}/storage-policy" || return 1
 	printf '%s\n' "$recovery_root_real" >"${recovery_dir}/storage-root" || return 1

--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -35,6 +35,8 @@
 #
 # Environment:
 #   AIDEVOPS_CLEANUP_LOG — override log file path (default: ~/.aidevops/logs/cleanup_worktrees.log)
+#   AIDEVOPS_WORKTREE_TRASH_ROOT — override recoverable archive root
+#   AIDEVOPS_ORPHAN_TRASH_ROOT — legacy fallback archive-root override
 #
 # Compatibility: bash 3.2+ (macOS default). Uses printf, not echo -e.
 # Fail-open: log write failures are silently swallowed — callers must not depend on
@@ -71,6 +73,7 @@ _WT_GIT_REASON_REMOVE_FAILED="git-worktree-remove-failed"
 _WT_GIT_STATUS_FIELD_PREFIX="aidevops-git-status "
 _WT_RECOVERY_FORMAT="aidevops-worktree-recovery-v1"
 _WT_RECOVERY_DIR_NAME=".aidevops-worktree-recovery"
+_WT_RECOVERY_COMPLETE_MARKER="archive-complete"
 _WT_RECOVERY_BRANCH_DETACHED="detached"
 WORKTREE_RECOVERABLE_ARCHIVE_PATH=""
 
@@ -691,17 +694,155 @@ _worktree_archive_source_matches() {
 	return 0
 }
 
+# Recoverable archives are framework-owned recovery data, not ordinary Trash on
+# platforms where $HOME/.Trash has no OS meaning. macOS keeps its established
+# OS Trash destination; Linux and other platforms use an explicit aidevops store.
+# Explicit operator overrides retain precedence on every platform.
+_worktree_recovery_store_root() {
+	local platform="${1:-}"
+	local configured_root="${AIDEVOPS_WORKTREE_TRASH_ROOT:-${AIDEVOPS_ORPHAN_TRASH_ROOT:-}}"
+
+	if [[ -n "$configured_root" ]]; then
+		[[ "$configured_root" == /* ]] || return 1
+		printf '%s\n' "$configured_root"
+		return 0
+	fi
+	[[ -n "${HOME:-}" ]] || return 1
+	if [[ -z "$platform" ]]; then
+		platform=$(uname -s 2>/dev/null) || return 1
+	fi
+	case "$platform" in
+	Darwin) printf '%s/.Trash\n' "$HOME" ;;
+	*) printf '%s/.aidevops/recovery/worktrees\n' "$HOME" ;;
+	esac
+	return 0
+}
+
+_worktree_legacy_recovery_root() {
+	local platform="${1:-}"
+
+	[[ -n "${HOME:-}" ]] || return 1
+	if [[ -z "$platform" ]]; then
+		platform=$(uname -s 2>/dev/null) || return 1
+	fi
+	[[ "$platform" != "Darwin" ]] || return 1
+	printf '%s/.Trash\n' "$HOME"
+	return 0
+}
+
+_worktree_legacy_recovery_bucket_is_valid() {
+	local bucket="$1"
+	local recovery_dir="${bucket}/${_WT_RECOVERY_DIR_NAME}"
+	local recorded_gitdir=""
+	local archive_path=""
+
+	[[ -f "$recovery_dir/admin/gitdir" && ! -L "$recovery_dir/admin/gitdir" ]] || return 1
+	IFS= read -r recorded_gitdir <"$recovery_dir/admin/gitdir" || return 1
+	case "$recorded_gitdir" in
+	"$bucket"/*/.git) archive_path="${recorded_gitdir%/.git}" ;;
+	*) return 1 ;;
+	esac
+	[[ "${archive_path%/*}" == "$bucket" ]] || return 1
+	_worktree_recovery_archive_is_valid "$archive_path" || return 1
+	return 0
+}
+
+_worktree_recovery_inventory_root() {
+	local root_path="$1"
+	local store_role="$2"
+	local root_owner="$3"
+	local root_real="$root_path"
+	local root_state="missing"
+	local bucket=""
+	local completion=""
+	local format=""
+	local state="unknown"
+
+	if [[ -d "$root_path" ]]; then
+		root_real=$(cd "$root_path" 2>/dev/null && pwd -P) || root_state="unavailable"
+		[[ "$root_state" == "unavailable" ]] || root_state="present"
+	elif [[ -e "$root_path" || -L "$root_path" ]]; then
+		root_state="unavailable"
+	fi
+	printf 'store\t%s\t%s\trecovery\tmanual-review\t%s\t%s\n' \
+		"$store_role" "$root_owner" "$root_state" "$root_real"
+	[[ "$root_state" == "present" ]] || return 0
+	for bucket in "$root_real"/aidevops-worktree-cleanup-*; do
+		[[ -e "$bucket" || -L "$bucket" ]] || continue
+		state="unknown"
+		if [[ -d "$bucket" && ! -L "$bucket" &&
+			-d "$bucket/${_WT_RECOVERY_DIR_NAME}" &&
+			! -L "$bucket/${_WT_RECOVERY_DIR_NAME}" &&
+			-f "$bucket/${_WT_RECOVERY_DIR_NAME}/format" &&
+			! -L "$bucket/${_WT_RECOVERY_DIR_NAME}/format" &&
+			-f "$bucket/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" &&
+			! -L "$bucket/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" ]]; then
+			IFS= read -r format <"$bucket/${_WT_RECOVERY_DIR_NAME}/format" || format=""
+			IFS= read -r completion <\
+				"$bucket/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" || completion=""
+			[[ "$format" == "$_WT_RECOVERY_FORMAT" &&
+				"$completion" == "$_WT_RECOVERY_FORMAT" ]] && state="attributed"
+		elif [[ -d "$bucket" && ! -L "$bucket" &&
+			-f "$bucket/${_WT_RECOVERY_DIR_NAME}/format" &&
+			! -L "$bucket/${_WT_RECOVERY_DIR_NAME}/format" ]]; then
+			IFS= read -r format <"$bucket/${_WT_RECOVERY_DIR_NAME}/format" || format=""
+			if [[ "$format" == "$_WT_RECOVERY_FORMAT" ]] &&
+				_worktree_legacy_recovery_bucket_is_valid "$bucket"; then
+				state="attributed-legacy"
+			fi
+		fi
+		printf 'bucket\t%s\tframework\t%s\t%s\n' "$store_role" "$state" "$bucket"
+	done
+	return 0
+}
+
+# Read-only, fail-closed inventory for current and attributable legacy buckets.
+# Unknown or interrupted buckets are reported, never treated as reclaimable.
+worktree_recovery_inventory() {
+	local platform="${1:-}"
+	local current_root=""
+	local current_root_compare=""
+	local current_owner="framework"
+	local legacy_root=""
+	local legacy_root_compare=""
+
+	if [[ -z "$platform" ]]; then
+		platform=$(uname -s 2>/dev/null) || return 1
+	fi
+	if [[ "$platform" == "Darwin" ||
+		-n "${AIDEVOPS_WORKTREE_TRASH_ROOT:-${AIDEVOPS_ORPHAN_TRASH_ROOT:-}}" ]]; then
+		current_owner="joint"
+	fi
+	current_root=$(_worktree_recovery_store_root "$platform") || return 1
+	current_root_compare="$current_root"
+	if [[ -d "$current_root" ]]; then
+		current_root_compare=$(cd "$current_root" 2>/dev/null && pwd -P) || return 1
+	fi
+	_worktree_recovery_inventory_root "$current_root" "current" "$current_owner" || return 1
+	if legacy_root=$(_worktree_legacy_recovery_root "$platform"); then
+		legacy_root_compare="$legacy_root"
+		if [[ -d "$legacy_root" ]]; then
+			legacy_root_compare=$(cd "$legacy_root" 2>/dev/null && pwd -P) || return 1
+		fi
+		if [[ "$legacy_root_compare" != "$current_root_compare" ]]; then
+			_worktree_recovery_inventory_root "$legacy_root" "legacy" "joint" || return 1
+		fi
+	fi
+	return 0
+}
+
 archive_worktree_path_recoverably() {
 	local wt_path="$1"
 	local caller="$2"
 	local context="${3:-}"
 	local wt_path_real="$wt_path"
-	local trash_root="${AIDEVOPS_WORKTREE_TRASH_ROOT:-${AIDEVOPS_ORPHAN_TRASH_ROOT:-}}"
-	local trash_root_real=""
-	local trash_bucket=""
+	local recovery_root=""
+	local recovery_root_real=""
+	local recovery_bucket=""
 	local archive_path=""
 	local recovery_dir=""
 	local recovery_admin=""
+	local completion_marker_tmp=""
 	local worktree_basename=""
 	local git_state=""
 
@@ -714,35 +855,38 @@ archive_worktree_path_recoverably() {
 		_worktree_log_git_refusal "$wt_path" "$caller" "$git_state" "$context"
 		return 1
 	fi
-	if [[ -z "$trash_root" ]]; then
-		[[ -n "${HOME:-}" ]] || return 1
-		trash_root="${HOME}/.Trash"
-	fi
-	[[ "$trash_root" == /* ]] || return 1
-	mkdir -p "$trash_root" 2>/dev/null || return 1
-	trash_root_real=$(cd "$trash_root" 2>/dev/null && pwd -P) || return 1
-	case "$trash_root_real" in
+	recovery_root=$(_worktree_recovery_store_root) || return 1
+	mkdir -p "$recovery_root" 2>/dev/null || return 1
+	recovery_root_real=$(cd "$recovery_root" 2>/dev/null && pwd -P) || return 1
+	case "$recovery_root_real" in
 	"$wt_path_real" | "$wt_path_real"/*) return 1 ;;
 	esac
 	worktree_basename="${wt_path%/}"
 	worktree_basename="${worktree_basename##*/}"
 	[[ -n "$worktree_basename" && "$worktree_basename" != "." &&
 		"$worktree_basename" != "$_WT_RECOVERY_DIR_NAME" ]] || return 1
-	trash_bucket="${trash_root_real}/aidevops-worktree-cleanup-$(date -u '+%Y%m%dT%H%M%SZ')-$$-${RANDOM}"
-	archive_path="${trash_bucket}/${worktree_basename}"
-	recovery_dir="${trash_bucket}/${_WT_RECOVERY_DIR_NAME}"
+	recovery_bucket="${recovery_root_real}/aidevops-worktree-cleanup-$(date -u '+%Y%m%dT%H%M%SZ')-$$-${RANDOM}"
+	archive_path="${recovery_bucket}/${worktree_basename}"
+	recovery_dir="${recovery_bucket}/${_WT_RECOVERY_DIR_NAME}"
 	recovery_admin="${recovery_dir}/admin"
-	mkdir "$trash_bucket" 2>/dev/null || return 1
+	mkdir "$recovery_bucket" 2>/dev/null || return 1
 	_worktree_copy_directory_once "$wt_path_real" "$archive_path" || return 1
 	mkdir "$recovery_dir" 2>/dev/null || return 1
 	_worktree_copy_directory_once "$_WT_ID_ADMIN_REAL" "$recovery_admin" || return 1
 	_worktree_write_recovery_identity "$recovery_dir" || return 1
+	printf '%s\n' "framework" >"${recovery_dir}/storage-owner" || return 1
+	printf '%s\n' "recovery" >"${recovery_dir}/storage-class" || return 1
+	printf '%s\n' "manual-review" >"${recovery_dir}/storage-policy" || return 1
+	printf '%s\n' "$recovery_root_real" >"${recovery_dir}/storage-root" || return 1
 	printf '%s\n' "$_WT_ID_HEAD" >"${recovery_admin}/HEAD" || return 1
 	printf '%s\n' "$_WT_ID_COMMON_REAL" >"${recovery_admin}/commondir" || return 1
 	printf '%s\n' "${archive_path}/.git" >"${recovery_admin}/gitdir" || return 1
 	printf 'gitdir: %s\n' "$recovery_admin" >"${archive_path}/.git" || return 1
 	_worktree_recovery_archive_is_valid "$archive_path" || return 1
 	_worktree_archive_source_matches "$wt_path" "$archive_path" || return 1
+	completion_marker_tmp="${recovery_dir}/.${_WT_RECOVERY_COMPLETE_MARKER}.$$-${RANDOM}"
+	printf '%s\n' "$_WT_RECOVERY_FORMAT" >"$completion_marker_tmp" || return 1
+	mv "$completion_marker_tmp" "${recovery_dir}/${_WT_RECOVERY_COMPLETE_MARKER}" || return 1
 	git_state=$(_worktree_git_lock_state "$wt_path" "$wt_path_real") ||
 		git_state="$_WT_GIT_STATE_UNREADABLE"
 	if [[ "$git_state" != "$_WT_GIT_STATE_CLEAR" ]]; then

--- a/.agents/scripts/tests/test-worktree-removal-audit.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit.sh
@@ -592,36 +592,67 @@ test_recovery_inventory_reports_legacy_buckets_fail_closed() {
 	local override_link="${fixture_home}/operator-recovery"
 	local legacy_alias="${fixture_home}/legacy-recovery-alias"
 	local legacy_root="${fixture_home}/.Trash"
-	local valid_bucket="${current_root}/aidevops-worktree-cleanup-valid"
+	local spoofed_bucket="${current_root}/aidevops-worktree-cleanup-spoofed"
 	local unknown_bucket="${legacy_root}/aidevops-worktree-cleanup-interrupted"
-	local legacy_repo="${TEST_DIR}/legacy-inventory-repo"
-	local legacy_worktree="${TEST_DIR}/legacy-inventory-worktree"
+	local current_repo="${TEST_DIR}/current-inventory-repo"
+	local current_worktree="${TEST_DIR}/current-inventory-worktree"
+	local current_archive=""
+	local current_bucket=""
+	local interrupted_repo="${TEST_DIR}/interrupted-inventory-repo"
+	local interrupted_worktree="${TEST_DIR}/interrupted-inventory-worktree"
+	local interrupted_archive=""
+	local interrupted_bucket=""
+	local legacy_repo="${TEST_DIR}/legacy-v1-inventory-repo"
+	local legacy_worktree="${TEST_DIR}/legacy-v1-inventory-worktree"
 	local legacy_archive=""
+	local legacy_bucket=""
+	local recovery_dir=""
 	local output=""
 	local alias_output=""
 	local rc=0
 
-	mkdir -p "$valid_bucket/${_WT_RECOVERY_DIR_NAME}" \
+	mkdir -p "$spoofed_bucket/${_WT_RECOVERY_DIR_NAME}" \
 		"$unknown_bucket/${_WT_RECOVERY_DIR_NAME}" || rc=1
-	printf '%s\n' "$_WT_RECOVERY_FORMAT" >"$valid_bucket/${_WT_RECOVERY_DIR_NAME}/format" || rc=1
-	printf '%s\n' "$_WT_RECOVERY_FORMAT" >\
-		"$valid_bucket/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" || rc=1
-	printf '%s\n' "$_WT_RECOVERY_FORMAT" >\
+	printf '%s\n' "$_WT_RECOVERY_FORMAT" >"$spoofed_bucket/${_WT_RECOVERY_DIR_NAME}/format" || rc=1
+	printf '%s\n' "$_WT_RECOVERY_FORMAT" > \
+		"$spoofed_bucket/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" || rc=1
+	printf '%s\n' "$_WT_RECOVERY_FORMAT" > \
 		"$unknown_bucket/${_WT_RECOVERY_DIR_NAME}/format" || rc=1
+	spoofed_bucket=$(cd "$spoofed_bucket" 2>/dev/null && pwd -P) || rc=1
+	unknown_bucket=$(cd "$unknown_bucket" 2>/dev/null && pwd -P) || rc=1
 	ln -s "$current_root" "$override_link" || rc=1
 	ln -s "$legacy_root" "$legacy_alias" || rc=1
+	create_git_worktree_fixture "$current_repo" "$current_worktree" "feature/current-inventory" || rc=1
+	AIDEVOPS_WORKTREE_TRASH_ROOT="$current_root" AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" \
+		archive_worktree_path_recoverably "$current_worktree" "test.sh" "current-inventory" || rc=1
+	current_archive="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
+	current_bucket="${current_archive%/*}"
+	create_git_worktree_fixture "$interrupted_repo" "$interrupted_worktree" \
+		"feature/interrupted-inventory" || rc=1
+	AIDEVOPS_WORKTREE_TRASH_ROOT="$legacy_root" AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" \
+		archive_worktree_path_recoverably "$interrupted_worktree" "test.sh" \
+		"interrupted-inventory" || rc=1
+	interrupted_archive="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
+	interrupted_bucket="${interrupted_archive%/*}"
+	rm -f "$interrupted_bucket/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" || rc=1
 	create_git_worktree_fixture "$legacy_repo" "$legacy_worktree" "feature/legacy-inventory" || rc=1
 	AIDEVOPS_WORKTREE_TRASH_ROOT="$legacy_root" AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" \
 		archive_worktree_path_recoverably "$legacy_worktree" "test.sh" "legacy-inventory" || rc=1
 	legacy_archive="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
-	rm -f "${legacy_archive%/*}/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" || rc=1
+	legacy_bucket="${legacy_archive%/*}"
+	recovery_dir="$legacy_bucket/${_WT_RECOVERY_DIR_NAME}"
+	rm -f "$recovery_dir/${_WT_RECOVERY_COMPLETE_MARKER}" \
+		"$recovery_dir/storage-owner" "$recovery_dir/storage-class" \
+		"$recovery_dir/storage-policy" "$recovery_dir/storage-root" || rc=1
 	output=$(HOME="$fixture_home" AIDEVOPS_WORKTREE_TRASH_ROOT="$override_link" \
 		AIDEVOPS_ORPHAN_TRASH_ROOT="" worktree_recovery_inventory "Linux") || rc=1
 	printf '%s\n' "$output" | grep -Fq $'store\tcurrent\tjoint\trecovery\tmanual-review\tpresent\t' || rc=1
 	printf '%s\n' "$output" | grep -Fq $'store\tlegacy\tjoint\trecovery\tmanual-review\tpresent\t' || rc=1
-	printf '%s\n' "$output" | grep -Fq $'bucket\tcurrent\tframework\tattributed\t' || rc=1
-	printf '%s\n' "$output" | grep -Fq $'bucket\tlegacy\tframework\tunknown\t' || rc=1
-	printf '%s\n' "$output" | grep -Fq $'bucket\tlegacy\tframework\tattributed-legacy\t' || rc=1
+	printf '%s\n' "$output" | grep -Fq $'bucket\tcurrent\tframework\tattributed\t'"$current_bucket" || rc=1
+	printf '%s\n' "$output" | grep -Fq $'bucket\tcurrent\tframework\tunknown\t'"$spoofed_bucket" || rc=1
+	printf '%s\n' "$output" | grep -Fq $'bucket\tlegacy\tframework\tunknown\t'"$unknown_bucket" || rc=1
+	printf '%s\n' "$output" | grep -Fq $'bucket\tlegacy\tframework\tunknown\t'"$interrupted_bucket" || rc=1
+	printf '%s\n' "$output" | grep -Fq $'bucket\tlegacy\tframework\tattributed-legacy\t'"$legacy_bucket" || rc=1
 	alias_output=$(HOME="$fixture_home" AIDEVOPS_WORKTREE_TRASH_ROOT="$legacy_alias" \
 		AIDEVOPS_ORPHAN_TRASH_ROOT="" worktree_recovery_inventory "Linux") || rc=1
 	[[ "$(printf '%s\n' "$alias_output" | grep -c '^store')" -eq 1 ]] || rc=1

--- a/.agents/scripts/tests/test-worktree-removal-audit.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit.sh
@@ -565,6 +565,71 @@ RACE_GIT
 # Recoverable cleanup creates a complete archive while the registered source is
 # still intact, then lets native Git remove the source and exact metadata.
 # =============================================================================
+test_recovery_store_selects_platform_semantics() {
+	local fixture_home="${TEST_DIR}/platform-home"
+	local override_root="${TEST_DIR}/operator-archive-root"
+	local actual=""
+	local rc=0
+
+	mkdir -p "$fixture_home" || rc=1
+	actual=$(HOME="$fixture_home" AIDEVOPS_WORKTREE_TRASH_ROOT="" \
+		AIDEVOPS_ORPHAN_TRASH_ROOT="" _worktree_recovery_store_root "Linux") || rc=1
+	[[ "$actual" == "$fixture_home/.aidevops/recovery/worktrees" ]] || rc=1
+	actual=$(HOME="$fixture_home" AIDEVOPS_WORKTREE_TRASH_ROOT="" \
+		AIDEVOPS_ORPHAN_TRASH_ROOT="" _worktree_recovery_store_root "Darwin") || rc=1
+	[[ "$actual" == "$fixture_home/.Trash" ]] || rc=1
+	actual=$(HOME="$fixture_home" AIDEVOPS_WORKTREE_TRASH_ROOT="$override_root" \
+		AIDEVOPS_ORPHAN_TRASH_ROOT="" _worktree_recovery_store_root "Linux") || rc=1
+	[[ "$actual" == "$override_root" ]] || rc=1
+	print_result "recovery_store_selects_platform_semantics" "$rc" \
+		"Expected Linux recovery ownership, macOS Trash, and explicit override precedence"
+	return 0
+}
+
+test_recovery_inventory_reports_legacy_buckets_fail_closed() {
+	local fixture_home="${TEST_DIR}/inventory-home"
+	local current_root="${fixture_home}/.aidevops/recovery/worktrees"
+	local override_link="${fixture_home}/operator-recovery"
+	local legacy_alias="${fixture_home}/legacy-recovery-alias"
+	local legacy_root="${fixture_home}/.Trash"
+	local valid_bucket="${current_root}/aidevops-worktree-cleanup-valid"
+	local unknown_bucket="${legacy_root}/aidevops-worktree-cleanup-interrupted"
+	local legacy_repo="${TEST_DIR}/legacy-inventory-repo"
+	local legacy_worktree="${TEST_DIR}/legacy-inventory-worktree"
+	local legacy_archive=""
+	local output=""
+	local alias_output=""
+	local rc=0
+
+	mkdir -p "$valid_bucket/${_WT_RECOVERY_DIR_NAME}" \
+		"$unknown_bucket/${_WT_RECOVERY_DIR_NAME}" || rc=1
+	printf '%s\n' "$_WT_RECOVERY_FORMAT" >"$valid_bucket/${_WT_RECOVERY_DIR_NAME}/format" || rc=1
+	printf '%s\n' "$_WT_RECOVERY_FORMAT" >\
+		"$valid_bucket/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" || rc=1
+	printf '%s\n' "$_WT_RECOVERY_FORMAT" >\
+		"$unknown_bucket/${_WT_RECOVERY_DIR_NAME}/format" || rc=1
+	ln -s "$current_root" "$override_link" || rc=1
+	ln -s "$legacy_root" "$legacy_alias" || rc=1
+	create_git_worktree_fixture "$legacy_repo" "$legacy_worktree" "feature/legacy-inventory" || rc=1
+	AIDEVOPS_WORKTREE_TRASH_ROOT="$legacy_root" AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" \
+		archive_worktree_path_recoverably "$legacy_worktree" "test.sh" "legacy-inventory" || rc=1
+	legacy_archive="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
+	rm -f "${legacy_archive%/*}/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" || rc=1
+	output=$(HOME="$fixture_home" AIDEVOPS_WORKTREE_TRASH_ROOT="$override_link" \
+		AIDEVOPS_ORPHAN_TRASH_ROOT="" worktree_recovery_inventory "Linux") || rc=1
+	printf '%s\n' "$output" | grep -Fq $'store\tcurrent\tjoint\trecovery\tmanual-review\tpresent\t' || rc=1
+	printf '%s\n' "$output" | grep -Fq $'store\tlegacy\tjoint\trecovery\tmanual-review\tpresent\t' || rc=1
+	printf '%s\n' "$output" | grep -Fq $'bucket\tcurrent\tframework\tattributed\t' || rc=1
+	printf '%s\n' "$output" | grep -Fq $'bucket\tlegacy\tframework\tunknown\t' || rc=1
+	printf '%s\n' "$output" | grep -Fq $'bucket\tlegacy\tframework\tattributed-legacy\t' || rc=1
+	alias_output=$(HOME="$fixture_home" AIDEVOPS_WORKTREE_TRASH_ROOT="$legacy_alias" \
+		AIDEVOPS_ORPHAN_TRASH_ROOT="" worktree_recovery_inventory "Linux") || rc=1
+	[[ "$(printf '%s\n' "$alias_output" | grep -c '^store')" -eq 1 ]] || rc=1
+	print_result "recovery_inventory_reports_legacy_buckets_fail_closed" "$rc" \
+		"Expected attributed current and unknown legacy buckets to remain visible and protected"
+	return 0
+}
+
 test_recoverable_archive_then_native_remove() {
 	local repo_path="${TEST_DIR}/archive-repo"
 	local wt_path="${TEST_DIR}/archive-worktree"
@@ -581,6 +646,10 @@ test_recoverable_archive_then_native_remove() {
 		"$wt_path" "test.sh" "archive-test" || rc=1
 	archive_path="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
 	[[ -d "$wt_path" && -d "$archive_path" && -e "$archive_path/.git" ]] || rc=1
+	[[ "$(<"${archive_path%/*}/${_WT_RECOVERY_DIR_NAME}/storage-owner")" == "framework" ]] || rc=1
+	[[ "$(<"${archive_path%/*}/${_WT_RECOVERY_DIR_NAME}/storage-class")" == "recovery" ]] || rc=1
+	[[ "$(<"${archive_path%/*}/${_WT_RECOVERY_DIR_NAME}/storage-policy")" == "manual-review" ]] || rc=1
+	[[ "$(<"${archive_path%/*}/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}")" == "$_WT_RECOVERY_FORMAT" ]] || rc=1
 	metadata=$("$GIT_BIN" -C "$repo_path" worktree list --porcelain) || rc=1
 	printf '%s\n' "$metadata" | grep -Fqx "worktree $wt_root" || rc=1
 	AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" remove_archived_worktree_path \
@@ -1882,6 +1951,8 @@ test_git_lock_parser_handles_unusual_paths_and_adjacent_blocks
 test_git_lock_parser_rejects_malformed_blocks
 test_missing_worktree_physical_parent_alias
 test_permanent_helper_preserves_lock_acquired_after_guard
+test_recovery_store_selects_platform_semantics
+test_recovery_inventory_reports_legacy_buckets_fail_closed
 test_recoverable_archive_then_native_remove
 test_recoverable_archive_preserves_late_lock
 test_recovery_archive_preserves_index_and_dirty_files

--- a/.agents/scripts/worktree-helper-cmds.sh
+++ b/.agents/scripts/worktree-helper-cmds.sh
@@ -682,7 +682,11 @@ COMMANDS
                          --force-merged: force-remove dirty worktrees when PR is
                            confirmed merged (dirty state = abandoned WIP). Also
                            detects squash merges via gh pr list.
-                         Skips worktrees owned by other active sessions (t189)
+                          Skips worktrees owned by other active sessions (t189)
+
+  recovery               Read-only inventory of current and legacy recoverable
+                         worktree archives. Attributed and unknown buckets remain
+                         protected for manual review; this command never deletes.
 
   registry [list|prune]  View or prune the ownership registry (t189, t197)
                          list: Show all registered worktrees with ownership info
@@ -757,6 +761,15 @@ NOTES
   - Main worktree cannot be removed
 
 EOF
+	return 0
+}
+
+cmd_recovery() {
+	if [[ "$#" -ne 0 ]]; then
+		printf '%s\n' "Usage: worktree-helper.sh recovery" >&2
+		return 1
+	fi
+	worktree_recovery_inventory || return 1
 	return 0
 }
 

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -21,6 +21,7 @@
 #   status                 Show current worktree info
 #   switch <branch>        Open/create worktree for branch (prints path)
 #   clean [--auto] [--force-merged]  Remove worktrees for merged branches
+#   recovery              Inventory current and legacy recovery archives
 #   help                   Show this help
 #
 # Examples:
@@ -152,6 +153,9 @@ main() {
 		;;
 	clean)
 		cmd_clean "$@"
+		;;
+	recovery)
+		cmd_recovery "$@"
 		;;
 	registry | reg)
 		cmd_registry "$@"


### PR DESCRIPTION
## Summary

- route Linux and other non-macOS recoverable worktree archives to the framework-owned `$HOME/.aidevops/recovery/worktrees` store while preserving macOS Trash and explicit override behavior
- add a read-only `worktree-helper.sh recovery` inventory that distinguishes framework, joint, current, legacy, attributed, and unknown storage without deleting or migrating data
- preserve archive integrity with an atomic completion marker and validate markerless v1 legacy archives before attribution

## Testing

- `bash .agents/scripts/tests/test-worktree-removal-audit.sh` — 47/47 passed
- `shellcheck` on all changed shell files
- `.agents/scripts/lint-shell-portability.sh` on all changed shell files
- `.agents/scripts/linters-local.sh --changed` — passed
- independent high-risk review completed; findings repaired with focused regression coverage

## Runtime Testing

- runtime-verified through isolated archive creation/removal, symlink-root inventory, markerless legacy validation, lock-race, dirty/index, detached-HEAD, and interruption fixtures

Resolves #29309
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 24m and 198,802 tokens on this as a headless worker.