### PR TITLE
GH#29377: Isolate merge-stuck audit fixtures

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -91,7 +91,7 @@ assert_gt() {
 }
 
 # ---------------------------------------------------------------------------
-# Setup: locate files, isolate PULSE_STATS_FILE, source the modules.
+# Setup: locate files, isolate runtime state, source the modules.
 # ---------------------------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MODULE="$SCRIPT_DIR/pulse-merge-stuck.sh"
@@ -106,12 +106,14 @@ for required in "$MODULE" "$STATS_HELPER" "$MERGE_SCRIPT"; do
 	fi
 done
 
-# Isolate state writes to a temp file so the live ~/.aidevops/logs/pulse-stats.json
-# is not perturbed. Cleanup on exit.
+# Isolate state and audit writes so tests cannot perturb live user logs. Recovery
+# tests call the audited close wrapper with stub issue numbers, so the audit path
+# must be redirected before sourcing the module and its shared wrappers.
 TEST_TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/test-pulse-merge-stuck-XXXXXX")
 trap 'rm -rf "$TEST_TMPDIR"' EXIT
 export PULSE_STATS_FILE="$TEST_TMPDIR/pulse-stats.json"
 export LOGFILE="$TEST_TMPDIR/pulse.log"
+export GH_AUDIT_LOG_FILE="$TEST_TMPDIR/gh-audit.log"
 
 # Source the helpers. pulse-stats-helper.sh sets -euo pipefail; turn that off
 # after source so a single failed assertion doesn't abort the whole suite.


### PR DESCRIPTION
## Summary

Redirect merge-stuck regression-test audit records into the test temp directory so fixture close operations cannot generate live anomaly alerts.

## Files Changed

.agents/scripts/tests/test-pulse-merge-stuck.sh

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — shellcheck .agents/scripts/tests/test-pulse-merge-stuck.sh; .agents/scripts/tests/test-pulse-merge-stuck.sh (66 tests, 0 failures)

Resolves #29377


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 5m and 114,754 tokens on this as a headless worker.