### PR TITLE
GH#29384: Stabilize signed approval reconciliation

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -1006,6 +1006,10 @@ _approve_target() {
 	fi
 
 	if ! _post_issue_approval_updates "$target_type" "$target_number" "$slug"; then
+		# The signed comment already passed current-state verification. Queue the
+		# bounded reconciliation path even when synchronous lifecycle writes race
+		# label-protection automation or hit a transient API failure.
+		_kick_pulse_after_approval "$target_type" "$target_number" "$slug"
 		_print_error "Approval signed, but post-approval protection updates did not reach the required state"
 		return 1
 	fi

--- a/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
+++ b/.agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh
@@ -279,12 +279,12 @@ run_case "post-approval protection failure blocks final success" '
 	gh_issue_comment() { return 0; }
 	cmd_verify() { printf "VERIFIED"; return 0; }
 	_post_issue_approval_updates() { return 1; }
-	_kick_pulse_after_approval() { printf "SHOULD_NOT_KICK"; return 0; }
+	_kick_pulse_after_approval() { printf "KICKED_RECONCILIATION"; return 0; }
 	_approve_target issue 123 marcusquinn/aidevops
 ' 1
 assert_contains "post-approval failure suppresses final success" "$LAST_OUTPUT" "post-approval protection updates did not reach the required state"
 assert_not_contains "post-approval failure does not print success" "$LAST_OUTPUT" "Issue #123 approved and signed"
-assert_not_contains "post-approval failure does not kick pulse" "$LAST_OUTPUT" "SHOULD_NOT_KICK"
+assert_contains "post-approval failure queues bounded reconciliation" "$LAST_OUTPUT" "KICKED_RECONCILIATION"
 
 # GH#28717: target reconciliation accepts only the current authenticated actor's
 # signed comment when that actor has maintainer-equivalent authority.

--- a/.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh
+++ b/.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh
@@ -72,12 +72,12 @@ if [[ "${1:-}" == "api" && "$*" == *"/comments"* ]]; then
 	case "${GH_SCENARIO:-}" in
 		issue-api-failure|pr-approval-failure) exit 1 ;;
 		issue-invalid|pr-invalid) printf '{"message":"rate limited"}\n'; exit 0 ;;
-		issue-signed|pr-signed) printf '[[{"body":"<!-- aidevops-signed-approval -->","user":{"login":"maintainer"},"author_association":"OWNER"}]]\n'; exit 0 ;;
-		issue-other-maintainer|pr-other-maintainer) printf '[[{"body":"<!-- aidevops-signed-approval -->","user":{"login":"owner"},"author_association":"OWNER"}]]\n'; exit 0 ;;
-		issue-collab|pr-collab|issue-permission-failure|pr-permission-failure) printf '[[{"body":"<!-- aidevops-signed-approval -->","user":{"login":"trusted-collab"},"author_association":"COLLABORATOR"}]]\n'; exit 0 ;;
-		issue-forged|pr-forged) printf '[[{"body":"<!-- aidevops-signed-approval -->","user":{"login":"external"},"author_association":"NONE"}]]\n'; exit 0 ;;
-		issue-bot|pr-bot) printf '[[{"body":"<!-- aidevops-signed-approval -->","user":{"login":"github-actions[bot]"},"author_association":"NONE"}]]\n'; exit 0 ;;
-		issue-unsigned|pr-unsigned) printf '[[]]\n'; exit 0 ;;
+		issue-signed|pr-signed) printf '[{"body":"<!-- aidevops-signed-approval -->","user":{"login":"maintainer"},"author_association":"OWNER"}]\n'; exit 0 ;;
+		issue-other-maintainer|pr-other-maintainer) printf '[{"body":"<!-- aidevops-signed-approval -->","user":{"login":"owner"},"author_association":"OWNER"}]\n'; exit 0 ;;
+		issue-collab|pr-collab|issue-permission-failure|pr-permission-failure) printf '[{"body":"<!-- aidevops-signed-approval -->","user":{"login":"trusted-collab"},"author_association":"COLLABORATOR"}]\n'; exit 0 ;;
+		issue-forged|pr-forged) printf '[{"body":"<!-- aidevops-signed-approval -->","user":{"login":"external"},"author_association":"NONE"}]\n'; exit 0 ;;
+		issue-bot|pr-bot) printf '[{"body":"<!-- aidevops-signed-approval -->","user":{"login":"github-actions[bot]"},"author_association":"NONE"}]\n'; exit 0 ;;
+		issue-unsigned|pr-unsigned) printf '[]\n'; exit 0 ;;
 	esac
 fi
 
@@ -358,6 +358,18 @@ EOF
 	return 0
 }
 
+test_workflow_uses_explicit_page_aggregation() {
+	local workflow_source=""
+	workflow_source=$(<"$WORKFLOW_FILE")
+	if [[ "$workflow_source" == *"set -o pipefail; gh api --paginate"* ]] &&
+		[[ "$workflow_source" == *"| jq -s '.'"* ]]; then
+		print_result "maintainer gate aggregates paginated pages with pipeline failure propagation" 0
+	else
+		print_result "maintainer gate aggregates paginated pages with pipeline failure propagation" 1 "missing explicit fail-closed page aggregation"
+	fi
+	return 0
+}
+
 main() {
 	setup_test_env
 	trap teardown_test_env EXIT
@@ -365,6 +377,7 @@ main() {
 	test_pr_approval_paths
 	test_live_pr_nmr_blocks_before_comments
 	test_slurp_and_jq_are_separate
+	test_workflow_uses_explicit_page_aggregation
 	printf '\nTests run: %d\nTests failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then
 		return 1

--- a/.github/workflows/maintainer-gate-reusable.yml
+++ b/.github/workflows/maintainer-gate-reusable.yml
@@ -672,8 +672,8 @@ jobs:
           # actor who removed the label. Any lookup uncertainty restores the
           # existing hold instead of converting missing evidence into authority.
           APPROVAL_COMMENTS=""
-          if ! APPROVAL_COMMENTS=$(gh api --paginate --slurp \
-            "repos/${REPO}/issues/${ISSUE_NUMBER}/comments?per_page=100" 2>/dev/null); then
+          if ! APPROVAL_COMMENTS=$(set -o pipefail; gh api --paginate \
+            "repos/${REPO}/issues/${ISSUE_NUMBER}/comments?per_page=100" | jq -s '.'); then
             echo "::error::Unable to read approval comments for issue #$ISSUE_NUMBER — restoring NMR"
           else
             APPROVAL_RC=0
@@ -695,8 +695,8 @@ jobs:
           # Post a comment explaining why
           NOTICE_COMMENTS=""
           EXISTING=""
-          if ! NOTICE_COMMENTS=$(gh api --paginate --slurp \
-            "repos/${REPO}/issues/${ISSUE_NUMBER}/comments?per_page=100" 2>/dev/null); then
+          if ! NOTICE_COMMENTS=$(set -o pipefail; gh api --paginate \
+            "repos/${REPO}/issues/${ISSUE_NUMBER}/comments?per_page=100" | jq -s '.'); then
             echo "::warning::Unable to check for an existing label-protection notice — skipping comment"
             exit 0
           fi
@@ -1124,8 +1124,8 @@ jobs:
           # the label-removal actor; bot identity, malformed data, and lookup
           # uncertainty restore NMR.
           APPROVAL_COMMENTS=""
-          if ! APPROVAL_COMMENTS=$(gh api --paginate --slurp \
-            "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" 2>/dev/null); then
+          if ! APPROVAL_COMMENTS=$(set -o pipefail; gh api --paginate \
+            "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" | jq -s '.'); then
             echo "::error::Unable to read approval comments for PR #$PR_NUMBER — restoring NMR"
           else
             APPROVAL_RC=0
@@ -1147,8 +1147,8 @@ jobs:
           # Post a comment explaining why (only once)
           NOTICE_COMMENTS=""
           EXISTING=""
-          if ! NOTICE_COMMENTS=$(gh api --paginate --slurp \
-            "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" 2>/dev/null); then
+          if ! NOTICE_COMMENTS=$(set -o pipefail; gh api --paginate \
+            "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" | jq -s '.'); then
             echo "::warning::Unable to check for an existing PR label-protection notice — skipping comment"
             exit 0
           fi


### PR DESCRIPTION
## Summary

Replace the failing native gh pagination slurp path with explicit fail-closed page aggregation for issue and PR approval guards, and queue bounded Pulse reconciliation after a verified approval when synchronous lifecycle updates race protection automation.

## Files Changed

.agents/scripts/approval-helper.sh, .agents/scripts/tests/test-approval-helper-rest-lock-fallback.sh, .agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh, .github/workflows/maintainer-gate-reusable.yml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Local linters passed; actionlint, Bash syntax, and ShellCheck passed; maintainer-gate regression 35/35; approval lifecycle regression 50/50; approval content binding 39/39; Pulse NMR suites 29/29; live paginated GitHub reads recognized both existing signed approvals.

Resolves #29384


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 56m and 504,173 tokens on this with the user in an interactive session.