### PR TITLE
GH#29376: Retry zero-session review workers

### DIFF
--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -907,6 +907,56 @@ _push_wip_commits_on_exit() {
 }
 
 #######################################
+# Persist a caller-requested terminal outcome for local recovery loops.
+# The path must be absolute and its parent must already exist.
+# Args: $1=session, $2=reason, $3=session count
+#######################################
+_hrff_write_external_outcome() {
+	local session_key="$1"
+	local reason="$2"
+	local session_count="$3"
+	local outcome_file="${_WORKER_EXTERNAL_OUTCOME_FILE:-}"
+	local outcome_id="${_WORKER_EXTERNAL_OUTCOME_ID:-}"
+	local outcome_dir="" tmp_file="" finished_at=""
+
+	[[ -n "$outcome_file" && "$outcome_id" =~ ^[A-Za-z0-9._-]+$ ]] || return 0
+	case "$outcome_file" in
+	/*) ;;
+	*) return 1 ;;
+	esac
+	outcome_dir="${outcome_file%/*}"
+	[[ -d "$outcome_dir" && ! -L "$outcome_dir" && -O "$outcome_dir" && ! -L "$outcome_file" ]] || return 1
+	reason="${reason//$'\r'/_}"
+	reason="${reason//$'\n'/_}"
+	reason="${reason//=/_}"
+	session_key="${session_key//$'\r'/_}"
+	session_key="${session_key//$'\n'/_}"
+	session_key="${session_key//=/_}"
+	[[ "$session_count" =~ ^[0-9]+$ ]] || session_count=0
+	finished_at="$(date +%s)"
+	tmp_file=$(mktemp "${outcome_file}.tmp.XXXXXX") || return 1
+	[[ -f "$tmp_file" && ! -L "$tmp_file" && -O "$tmp_file" ]] || {
+		rm -f "$tmp_file" 2>/dev/null || true
+		return 1
+	}
+	if ! {
+		printf 'session_key=%s\n' "$session_key"
+		printf 'outcome_id=%s\n' "$outcome_id"
+		printf 'reason=%s\n' "$reason"
+		printf 'session_count=%s\n' "$session_count"
+		printf 'finished_at=%s\n' "$finished_at"
+	} >"$tmp_file"; then
+		rm -f "$tmp_file" 2>/dev/null || true
+		return 1
+	fi
+	if ! mv -f "$tmp_file" "$outcome_file"; then
+		rm -f "$tmp_file" 2>/dev/null || true
+		return 1
+	fi
+	return 0
+}
+
+#######################################
 # Archive dirty worktree changes as a local binary patch.
 # Best-effort fallback when exit-time commit/push cannot preserve the work.
 #
@@ -967,6 +1017,9 @@ _hrff_finalize_exit_trap() {
 		else
 			reason="worker_dirty_work_preserved"
 		fi
+	fi
+	if ! _hrff_write_external_outcome "$session_key" "$reason" "$session_count"; then
+		print_warning "[exit-trap] failed to persist external outcome for session=${session_key}"
 	fi
 	if declare -F _emit_worker_runtime_event >/dev/null 2>&1; then
 		if [[ "$reason" == "worker_complete" ]]; then

--- a/.agents/scripts/headless-runtime-worker-prepare.sh
+++ b/.agents/scripts/headless-runtime-worker-prepare.sh
@@ -304,6 +304,10 @@ _cmd_run_prepare() {
 	local session_key="$1"
 	local work_dir="$2"
 	local role="${3:-$_HRW_ROLE_WORKER}"
+	unset _WORKER_EXTERNAL_OUTCOME_FILE _WORKER_EXTERNAL_OUTCOME_ID 2>/dev/null || true
+	_WORKER_EXTERNAL_OUTCOME_FILE="${AIDEVOPS_HEADLESS_OUTCOME_FILE:-}"
+	_WORKER_EXTERNAL_OUTCOME_ID="${AIDEVOPS_HEADLESS_OUTCOME_ID:-}"
+	unset AIDEVOPS_HEADLESS_OUTCOME_FILE AIDEVOPS_HEADLESS_OUTCOME_ID 2>/dev/null || true
 	_WORKER_RUNTIME_LAUNCH_STARTED=0
 	unset _WORKER_PRELAUNCH_FAILURE_REASON 2>/dev/null || true
 	if _headless_private_workload_enabled; then

--- a/.agents/scripts/pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/pr-review-thread-response-scanner.sh
@@ -40,6 +40,7 @@ PR_REVIEW_THREAD_RESPONSE_PR_LIMIT="${PR_REVIEW_THREAD_RESPONSE_PR_LIMIT:-50}"
 PR_REVIEW_THREAD_RESPONSE_MAX_PER_REPO="${PR_REVIEW_THREAD_RESPONSE_MAX_PER_REPO:-2}"
 PR_REVIEW_THREAD_RESPONSE_COOLDOWN="${PR_REVIEW_THREAD_RESPONSE_COOLDOWN:-3600}"
 PR_REVIEW_THREAD_RESPONSE_INFLIGHT_TTL="${PR_REVIEW_THREAD_RESPONSE_INFLIGHT_TTL:-300}"
+PR_REVIEW_THREAD_RESPONSE_INFRASTRUCTURE_FAILURE_COOLDOWN="${PR_REVIEW_THREAD_RESPONSE_INFRASTRUCTURE_FAILURE_COOLDOWN:-90}"
 PR_REVIEW_THREAD_RESPONSE_LOCK_STALE="${PR_REVIEW_THREAD_RESPONSE_LOCK_STALE:-600}"
 PR_REVIEW_THREAD_RESPONSE_ESCALATE_AFTER="${PR_REVIEW_THREAD_RESPONSE_ESCALATE_AFTER:-3}"
 PR_REVIEW_THREAD_RESPONSE_MODEL="${PR_REVIEW_THREAD_RESPONSE_MODEL:-}"
@@ -74,11 +75,13 @@ PRRTS_WORKTREE_EXPECTED_OWNER_SESSION=""
 PRRTS_WORKTREE_EXPECTED_OWNER_BATCH=""
 PRRTS_WORKTREE_EXPECTED_OWNER_TASK=""
 PRRTS_WORKTREE_EXPECTED_OWNER_CREATED_AT=""
+PRRTS_WORKER_OUTCOME_ID=""
 
 _prrts_ensure_dirs() {
 	local log_dir=""
 	log_dir="$(dirname "$LOGFILE")"
 	mkdir -p "$log_dir" "$STATE_DIR" 2>/dev/null || true
+	chmod 700 "$STATE_DIR" 2>/dev/null || true
 	return 0
 }
 
@@ -678,6 +681,15 @@ _prrts_state_file() {
 	return 0
 }
 
+_prrts_outcome_file() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local safe_slug=""
+	safe_slug="$(_prrts_safe_slug "$repo_slug")"
+	printf '%s/%s-%s.outcome\n' "$STATE_DIR" "$safe_slug" "$pr_number"
+	return 0
+}
+
 _prrts_lock_dir() {
 	local repo_slug="$1"
 	local pr_number="$2"
@@ -853,12 +865,13 @@ _prrts_read_state() {
 	local head_sha_var="${8:-}"
 	local blocker_reason_var="${9:-}"
 	local worker_contract_version_var="${10:-}"
+	local outcome_id_var="${11:-}"
 	local key="" value=""
 	local state_fingerprint="" state_dispatched_at="0"
 	local state_attempt_count="0"
 	local state_last_head_sha=""
 	local state_analysis_complete="$PRRTS_BOOL_FALSE" state_blocked_by="" state_maintainer_attention="$PRRTS_BOOL_FALSE"
-	local state_blocker_reason="" state_worker_contract_version=""
+	local state_blocker_reason="" state_worker_contract_version="" state_outcome_id=""
 	if [[ -f "$state_file" ]]; then
 		while IFS='=' read -r key value; do
 			case "$key" in
@@ -872,6 +885,7 @@ _prrts_read_state() {
 			attention_reason) [[ -n "$state_blocker_reason" ]] || state_blocker_reason="$value" ;;
 			blocker_reason) state_blocker_reason="$value" ;;
 			worker_contract_version) state_worker_contract_version="$value" ;;
+			outcome_id) state_outcome_id="$value" ;;
 			esac
 		done <"$state_file"
 	fi
@@ -902,6 +916,72 @@ _prrts_read_state() {
 	if [[ -n "$worker_contract_version_var" ]]; then
 		printf -v "$worker_contract_version_var" '%s' "$state_worker_contract_version"
 	fi
+	if [[ -n "$outcome_id_var" ]]; then
+		printf -v "$outcome_id_var" '%s' "$state_outcome_id"
+	fi
+	return 0
+}
+
+_prrts_read_outcome() {
+	local outcome_file="$1"
+	local reason_var="$2"
+	local session_count_var="$3"
+	local finished_at_var="$4"
+	local outcome_id_var="$5"
+	local key value
+	local parsed_reason="" parsed_session_count="" parsed_finished_at="0" parsed_outcome_id=""
+	if [[ -f "$outcome_file" ]]; then
+		while IFS='=' read -r key value; do
+			case "$key" in
+			reason) parsed_reason="$value" ;;
+			session_count) parsed_session_count="$value" ;;
+			finished_at) parsed_finished_at="$value" ;;
+			outcome_id) parsed_outcome_id="$value" ;;
+			esac
+		done <"$outcome_file"
+	fi
+	[[ "$parsed_session_count" =~ ^[0-9]+$ ]] || parsed_session_count=""
+	[[ "$parsed_finished_at" =~ ^[0-9]+$ ]] || parsed_finished_at=0
+	printf -v "$reason_var" '%s' "$parsed_reason"
+	printf -v "$session_count_var" '%s' "$parsed_session_count"
+	printf -v "$finished_at_var" '%s' "$parsed_finished_at"
+	printf -v "$outcome_id_var" '%s' "$parsed_outcome_id"
+	return 0
+}
+
+_prrts_is_zero_session_infrastructure_outcome() {
+	local expected_outcome_id="$1"
+	local observed_outcome_id="$2"
+	local outcome_reason="$3"
+	local outcome_session_count="$4"
+	local outcome_finished_at="$5"
+	local dispatched_at="$6"
+	local now_epoch="$7"
+	local latest_allowed=""
+
+	[[ -n "$expected_outcome_id" && "$observed_outcome_id" == "$expected_outcome_id" ]] || return 1
+	[[ "$outcome_reason" == "worker_noop_zero_output" && "$outcome_session_count" == "0" ]] || return 1
+	[[ "$outcome_finished_at" =~ ^[0-9]{1,12}$ && "$dispatched_at" =~ ^[0-9]{1,12}$ && "$now_epoch" =~ ^[0-9]{1,12}$ ]] || return 1
+	latest_allowed=$((now_epoch + 5))
+	[[ "$outcome_finished_at" -ge "$dispatched_at" && "$outcome_finished_at" -le "$latest_allowed" ]]
+	return $?
+}
+
+_prrts_zero_session_retry_status() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local now_epoch="$3"
+	local outcome_finished_at="$4"
+	local cooldown="$5"
+	local age_seconds=$((now_epoch - outcome_finished_at))
+
+	[[ "$age_seconds" -ge 0 ]] || age_seconds=0
+	_prrts_log "dispatch: ${repo_slug}#${pr_number} worker_noop_zero_output session_count=0 — classifying as infrastructure failure"
+	if [[ "$age_seconds" -lt "$cooldown" ]]; then
+		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — infrastructure-failure short cooldown active ${age_seconds}s after zero-session exit"
+		return "$PRRTS_RC_DISPATCH_DEFERRED"
+	fi
+	_prrts_log "dispatch: ${repo_slug}#${pr_number} retrying after infrastructure-failure short cooldown (${age_seconds}s)"
 	return 0
 }
 
@@ -932,16 +1012,21 @@ _prrts_should_dispatch() {
 	local attempt_var="${6:-}"
 	local repeated_var="${7:-}"
 	local same_head_var="${8:-}"
-	local state_file="" last_fingerprint="" dispatched_at="0" cooldown="" inflight_ttl="" age_seconds="0"
+	local state_file="" outcome_file="" last_fingerprint="" dispatched_at="0" cooldown="" inflight_ttl="" age_seconds="0"
 	local last_attempt_count="0" next_attempt_count="1" state_repeated_same_fingerprint="$PRRTS_BOOL_FALSE"
 	local last_head_sha="" state_same_head_sha="$PRRTS_BOOL_FALSE"
 	local analysis_complete="$PRRTS_BOOL_FALSE" blocked_by="" maintainer_attention="$PRRTS_BOOL_FALSE"
 	local blocker_reason="" retry_stale_head_validation="$PRRTS_BOOL_FALSE" worker_contract_version=""
-	local stored_contract_label=""
+	local stored_contract_label="" outcome_reason="" outcome_session_count="" outcome_finished_at="0"
+	local expected_outcome_id="" observed_outcome_id="" infrastructure_failure_cooldown=""
+	local zero_session_infrastructure_failure="$PRRTS_BOOL_FALSE"
 	state_file="$(_prrts_state_file "$repo_slug" "$pr_number")"
+	outcome_file="$(_prrts_outcome_file "$repo_slug" "$pr_number")"
 	cooldown="$(_prrts_normalise_int "$PR_REVIEW_THREAD_RESPONSE_COOLDOWN" "3600" "60")"
 	inflight_ttl="$(_prrts_normalise_int "$PR_REVIEW_THREAD_RESPONSE_INFLIGHT_TTL" "300" "1")"
-	_prrts_read_state "$state_file" last_fingerprint dispatched_at last_attempt_count analysis_complete blocked_by maintainer_attention last_head_sha blocker_reason worker_contract_version
+	infrastructure_failure_cooldown="$(_prrts_normalise_int "$PR_REVIEW_THREAD_RESPONSE_INFRASTRUCTURE_FAILURE_COOLDOWN" "90" "1")"
+	_prrts_read_state "$state_file" last_fingerprint dispatched_at last_attempt_count analysis_complete blocked_by maintainer_attention last_head_sha blocker_reason worker_contract_version expected_outcome_id
+	_prrts_read_outcome "$outcome_file" outcome_reason outcome_session_count outcome_finished_at observed_outcome_id
 	if [[ "$worker_contract_version" != "$PRRTS_WORKER_CONTRACT_VERSION" &&
 		"$fingerprint" == "$last_fingerprint" &&
 		"$maintainer_attention" == "$PRRTS_BOOL_TRUE" &&
@@ -967,6 +1052,15 @@ _prrts_should_dispatch() {
 			next_attempt_count=$((last_attempt_count + 1))
 		fi
 	fi
+	if [[ "$state_repeated_same_fingerprint" == "$PRRTS_BOOL_TRUE" && "$state_same_head_sha" == "$PRRTS_BOOL_TRUE" ]] &&
+		_prrts_is_zero_session_infrastructure_outcome "$expected_outcome_id" "$observed_outcome_id" \
+			"$outcome_reason" "$outcome_session_count" "$outcome_finished_at" "$dispatched_at" "$now_epoch"; then
+		zero_session_infrastructure_failure="$PRRTS_BOOL_TRUE"
+		# A zero-session launch never invoked a model, so it does not consume a
+		# meaningful same-fingerprint remediation attempt.
+		next_attempt_count="$last_attempt_count"
+		[[ "$next_attempt_count" -gt 0 ]] || next_attempt_count=1
+	fi
 	if [[ -n "$attempt_var" ]]; then
 		printf -v "$attempt_var" '%s' "$next_attempt_count"
 	fi
@@ -990,6 +1084,10 @@ _prrts_should_dispatch() {
 		fi
 	fi
 	age_seconds=$((now_epoch - dispatched_at))
+	if [[ "$zero_session_infrastructure_failure" == "$PRRTS_BOOL_TRUE" ]]; then
+		_prrts_zero_session_retry_status "$repo_slug" "$pr_number" "$now_epoch" "$outcome_finished_at" "$infrastructure_failure_cooldown"
+		return $?
+	fi
 	if [[ "$dispatched_at" -gt 0 && "$age_seconds" -lt "$inflight_ttl" ]]; then
 		_prrts_log "dispatch: ${repo_slug}#${pr_number} skipped — dispatch state active ${age_seconds}s ago"
 		return "$PRRTS_RC_DISPATCH_DEFERRED"
@@ -1013,6 +1111,7 @@ _prrts_write_state() {
 	local attempt_count="${6:-1}"
 	local maintainer_attention="${7:-false}"
 	local head_sha="${8:-}"
+	local outcome_id="${9:-}"
 	local state_file=""
 	_prrts_ensure_dirs
 	[[ "$attempt_count" =~ ^[0-9]+$ ]] || attempt_count=1
@@ -1024,6 +1123,9 @@ _prrts_write_state() {
 		printf 'attempt_count=%s\n' "$attempt_count"
 		printf 'last_head_sha=%s\n' "$head_sha"
 		printf 'worker_contract_version=%s\n' "$PRRTS_WORKER_CONTRACT_VERSION"
+		if [[ -n "$outcome_id" ]]; then
+			printf 'outcome_id=%s\n' "$outcome_id"
+		fi
 		if [[ "$maintainer_attention" == "$PRRTS_BOOL_TRUE" ]]; then
 			printf 'maintainer_attention=true\n'
 			printf 'attention_reason=same_unresolved_thread_fingerprint\n'
@@ -1046,7 +1148,7 @@ _prrts_write_analysis_state() {
 	local value=""
 	local now_epoch=""
 	local details=""
-	local fingerprint="" dispatched_at="0" thread_count="0" attempt_count="0" last_head_sha="" worker_contract_version=""
+	local fingerprint="" dispatched_at="0" thread_count="0" attempt_count="0" last_head_sha="" worker_contract_version="" outcome_id=""
 	_prrts_ensure_dirs
 	state_file="$(_prrts_state_file "$repo_slug" "$pr_number")"
 	if [[ -f "$state_file" ]]; then
@@ -1058,6 +1160,7 @@ _prrts_write_analysis_state() {
 			attempt_count) attempt_count="$value" ;;
 			last_head_sha) last_head_sha="$value" ;;
 			worker_contract_version) worker_contract_version="$value" ;;
+			outcome_id) outcome_id="$value" ;;
 			esac
 		done <"$state_file"
 	fi
@@ -1081,6 +1184,9 @@ _prrts_write_analysis_state() {
 		printf 'last_head_sha=%s\n' "$last_head_sha"
 		if [[ -n "$worker_contract_version" ]]; then
 			printf 'worker_contract_version=%s\n' "$worker_contract_version"
+		fi
+		if [[ -n "$outcome_id" ]]; then
+			printf 'outcome_id=%s\n' "$outcome_id"
 		fi
 		printf 'analysis_complete=%s\n' "$analysis_complete"
 		printf 'blocked_by=%s\n' "$blocked_by"
@@ -1662,7 +1768,11 @@ _prrts_dispatch_worker() {
 	local preview="$7"
 	local head_ref="$8"
 	local head_oid="$9"
-	local prompt_file="" session_key="" model="" worker_worktree_path="" worker_pid="" detach_mode=""
+	local outcome_id="${10}"
+	local now_epoch="${11}"
+	local attempt_count="${12}"
+	local maintainer_attention="${13}"
+	local prompt_file="" session_key="" model="" worker_worktree_path="" worker_pid="" detach_mode="" outcome_file=""
 	local worker_task="" repair_linked_issue="" worker_login=""
 	local -a cmd worker_cmd
 
@@ -1686,6 +1796,9 @@ _prrts_dispatch_worker() {
 	[[ -n "$worker_task" ]] || return 1
 	prompt_file="$(_prrts_write_prompt_file "$repo_slug" "$worker_worktree_path" "$pr_number" "$title" "$thread_count" "$fingerprint" "$preview")"
 	session_key="$(_prrts_session_key "$repo_slug" "$pr_number")"
+	outcome_file="$(_prrts_outcome_file "$repo_slug" "$pr_number")"
+	_prrts_ensure_dirs
+	rm -f "$outcome_file"
 	cmd=("$HEADLESS_RUNTIME_HELPER" run
 		--role worker
 		--session-key "$session_key"
@@ -1715,7 +1828,12 @@ _prrts_dispatch_worker() {
 		"AIDEVOPS_PR_REPAIR_ISSUE_ASSIGNEE=${worker_login}"
 		"AIDEVOPS_PR_REPAIR_HEAD_SHA=${head_oid}"
 		"AIDEVOPS_PR_REPAIR_HEAD_REF=${head_ref}"
+		"AIDEVOPS_HEADLESS_OUTCOME_FILE=${outcome_file}"
+		"AIDEVOPS_HEADLESS_OUTCOME_ID=${outcome_id}"
 		"${cmd[@]}")
+	# Persist the generation immediately before the detached worker becomes
+	# runnable, so immediate terminal callbacks cannot be overwritten.
+	_prrts_write_state "$repo_slug" "$pr_number" "$fingerprint" "$thread_count" "$now_epoch" "$attempt_count" "$maintainer_attention" "$head_oid" "$outcome_id"
 	if command -v setsid >/dev/null 2>&1; then
 		detach_mode="setsid+nohup"
 		setsid nohup "${worker_cmd[@]}" </dev/null >>"$LOGFILE" 2>&1 3>&- 4>&- 5>&- 6>&- 7>&- 8>&- 9>&- &
@@ -1781,7 +1899,9 @@ _prrts_dispatch_guarded() {
 		_prrts_remove_lock_dir "$lock_dir"
 		return 0
 	fi
-	if ! _prrts_dispatch_worker "$repo_slug" "$repo_path" "$pr_number" "$title" "$thread_count" "$fingerprint" "$preview" "$head_ref" "$head_oid"; then
+	PRRTS_WORKER_OUTCOME_ID="$(date +%s)-$$-${RANDOM}"
+	if ! _prrts_dispatch_worker "$repo_slug" "$repo_path" "$pr_number" "$title" "$thread_count" "$fingerprint" "$preview" \
+		"$head_ref" "$head_oid" "$PRRTS_WORKER_OUTCOME_ID" "$now_epoch" "$attempt_count" "$maintainer_attention"; then
 		if _prrts_prelaunch_failure_needs_maintainer_attention "$PRRTS_WORKTREE_FAILURE_BLOCKED_BY"; then
 			failure_maintainer_attention="$PRRTS_BOOL_TRUE"
 		fi
@@ -1791,7 +1911,6 @@ _prrts_dispatch_guarded() {
 		_prrts_remove_lock_dir "$lock_dir"
 		return "$PRRTS_RC_RETRYABLE_FAILURE"
 	fi
-	_prrts_write_state "$repo_slug" "$pr_number" "$fingerprint" "$thread_count" "$now_epoch" "$attempt_count" "$maintainer_attention" "$head_oid"
 	_prrts_remove_lock_dir "$lock_dir"
 	return 0
 }

--- a/.agents/scripts/tests/test-headless-runtime-contract-tests.sh
+++ b/.agents/scripts/tests/test-headless-runtime-contract-tests.sh
@@ -169,6 +169,10 @@ test_sensitive_temp_preflight_aborts_before_worker_ownership() {
 	detail=$(
 		exec 2>&1
 		export AIDEVOPS_SENSITIVE_TEMP_DIR="${unsafe_parent}/nested"
+		export AIDEVOPS_HEADLESS_OUTCOME_FILE="${TEST_ROOT}/prrts.outcome"
+		export AIDEVOPS_HEADLESS_OUTCOME_ID="dispatch-29376"
+		export _WORKER_EXTERNAL_OUTCOME_FILE="poison-file"
+		export _WORKER_EXTERNAL_OUTCOME_ID="poison-id"
 		_acquire_session_lock() { return 0; }
 		_exit_trap_handler() { return 0; }
 		aidevops_runtime_bundle_lease_release() { return 0; }
@@ -181,13 +185,18 @@ test_sensitive_temp_preflight_aborts_before_worker_ownership() {
 			return 0
 		}
 		local prepare_status=0
+		local internal_exported="no"
 		_cmd_run_prepare "issue-28796" "$TEST_ROOT" "worker" || prepare_status=$?
-		printf 'status=%s reason=%s launch_started=%s\n' \
+		export -p | grep -q '_WORKER_EXTERNAL_OUTCOME_' && internal_exported="yes"
+		printf 'status=%s reason=%s launch_started=%s outcome_file=%s outcome_id=%s inherited_file=%s inherited_id=%s internal_exported=%s\n' \
 			"$prepare_status" "${_WORKER_PRELAUNCH_FAILURE_REASON:-}" \
-			"${_WORKER_RUNTIME_LAUNCH_STARTED:-}"
+			"${_WORKER_RUNTIME_LAUNCH_STARTED:-}" "${_WORKER_EXTERNAL_OUTCOME_FILE:-}" \
+			"${_WORKER_EXTERNAL_OUTCOME_ID:-}" "${AIDEVOPS_HEADLESS_OUTCOME_FILE:-unset}" \
+			"${AIDEVOPS_HEADLESS_OUTCOME_ID:-unset}" "$internal_exported"
 	)
 
 	if [[ "$detail" == *"status=86 reason=worker_sensitive_temp_preflight_failed launch_started=0"* && \
+		"$detail" == *"outcome_file=${TEST_ROOT}/prrts.outcome outcome_id=dispatch-29376 inherited_file=unset inherited_id=unset internal_exported=no"* && \
 		"$detail" == *"[sensitive-temp] rejected component="* && \
 		"$detail" == *" owner_uid="* && "$detail" == *" mode="* && \
 		! -e "$ownership_marker" ]]; then

--- a/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
+++ b/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
@@ -181,6 +181,28 @@ check_pool_retry_seconds "short_retry_after" "retry after 120 seconds" "rate_lim
 check_pool_retry_seconds "over_max_retry_after" "retry after 2 days" "rate_limit" "21600"
 check_pool_retry_seconds "auth_error_fallback" "authentication failed" "auth_error" "3600"
 
+OUTCOME_FILE="$FIXTURE_DIR/prrts.outcome"
+_WORKER_EXTERNAL_OUTCOME_FILE="$OUTCOME_FILE"
+_WORKER_EXTERNAL_OUTCOME_ID="dispatch-29376"
+_hrff_write_external_outcome "pr-review-thread-response-owner-repo-1" "worker_noop_zero_output" "0"
+assert_eq "external outcome dispatch identity persisted" "dispatch-29376" \
+	"$(awk -F= '$1 == "outcome_id" { print $2 }' "$OUTCOME_FILE")"
+assert_eq "external outcome reason persisted" "worker_noop_zero_output" \
+	"$(awk -F= '$1 == "reason" { print $2 }' "$OUTCOME_FILE")"
+assert_eq "external outcome session count persisted" "0" \
+	"$(awk -F= '$1 == "session_count" { print $2 }' "$OUTCOME_FILE")"
+assert_eq "external outcome has numeric completion time" "true" \
+	"$(awk -F= '$1 == "finished_at" && $2 ~ /^[0-9]+$/ { print "true" }' "$OUTCOME_FILE")"
+OUTCOME_TARGET="$FIXTURE_DIR/outcome-target"
+printf 'unchanged\n' >"$OUTCOME_TARGET"
+rm -f "$OUTCOME_FILE"
+ln -s "$OUTCOME_TARGET" "$OUTCOME_FILE"
+OUTCOME_WRITE_RC=0
+_hrff_write_external_outcome "pr-review-thread-response-owner-repo-1" "worker_noop_zero_output" "0" || OUTCOME_WRITE_RC=$?
+assert_eq "external outcome rejects destination symlink" "1" "$OUTCOME_WRITE_RC"
+assert_eq "external outcome symlink target remains unchanged" "unchanged" "$(<"$OUTCOME_TARGET")"
+unset _WORKER_EXTERNAL_OUTCOME_FILE _WORKER_EXTERNAL_OUTCOME_ID
+
 echo
 echo "${TEST_BLUE}=== Summary ===${TEST_NC}"
 echo "Tests run:    $TESTS_RUN"

--- a/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
+++ b/.agents/scripts/tests/test-pr-review-thread-response-scanner.sh
@@ -230,10 +230,16 @@ printf 'AIDEVOPS_WORKTREE_EXPECTED_OWNER_CREATED_AT=%s\n' "${AIDEVOPS_WORKTREE_E
 printf 'AIDEVOPS_PR_REPAIR_NUMBER=%s\n' "${AIDEVOPS_PR_REPAIR_NUMBER:-}" >>"${HEADLESS_ENV_CAPTURE}"
 printf 'AIDEVOPS_PR_REPAIR_HEAD_SHA=%s\n' "${AIDEVOPS_PR_REPAIR_HEAD_SHA:-}" >>"${HEADLESS_ENV_CAPTURE}"
 printf 'AIDEVOPS_PR_REPAIR_HEAD_REF=%s\n' "${AIDEVOPS_PR_REPAIR_HEAD_REF:-}" >>"${HEADLESS_ENV_CAPTURE}"
+printf 'AIDEVOPS_HEADLESS_OUTCOME_FILE=%s\n' "${AIDEVOPS_HEADLESS_OUTCOME_FILE:-}" >>"${HEADLESS_ENV_CAPTURE}"
+printf 'AIDEVOPS_HEADLESS_OUTCOME_ID=%s\n' "${AIDEVOPS_HEADLESS_OUTCOME_ID:-}" >>"${HEADLESS_ENV_CAPTURE}"
 if [[ -n "$prompt_file" && -f "$prompt_file" ]]; then
 	cp "$prompt_file" "${HEADLESS_PROMPT_CAPTURE}"
 fi
 printf '%s\n' "${prompt_file}" >>"${HEADLESS_LOG}"
+if [[ "${STUB_HEADLESS_MARK_COMPLETE:-false}" == "true" ]]; then
+	"${PRRTS_SCANNER_UNDER_TEST}" mark-complete owner/repo "${WORKER_ISSUE_NUMBER}" immediate_worker_completion
+fi
+printf 'complete\n' >>"${HEADLESS_COMPLETE_LOG}"
 exit 0
 HEADLESS_STUB
 	chmod +x "${TEST_ROOT}/headless-runtime-helper.sh"
@@ -322,12 +328,14 @@ setup_test_env() {
 	unset STUB_REMOTE_HEAD_INITIAL STUB_REMOTE_HEAD_AFTER_FETCH STUB_WORKTREE_ACTUAL_HEAD STUB_WORKTREE_HELPER_FAIL
 	unset STUB_WORKTREE_REGISTER_OWNER STUB_WORKTREE_OWNER_PID STUB_WORKTREE_OWNER_SESSION
 	unset STUB_ACTIVE_RESPONSE_WORKER
-	unset PR_REVIEW_THREAD_RESPONSE_ESCALATE_AFTER
+	unset STUB_HEADLESS_MARK_COMPLETE
+	unset PR_REVIEW_THREAD_RESPONSE_ESCALATE_AFTER PR_REVIEW_THREAD_RESPONSE_INFRASTRUCTURE_FAILURE_COOLDOWN
 	TEST_ROOT="$(mktemp -d -t prrts.XXXXXX)"
 	export HOME="${TEST_ROOT}/home"
 	export LOGFILE="${TEST_ROOT}/scanner.log"
 	export AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR="${TEST_ROOT}/state"
 	export HEADLESS_LOG="${TEST_ROOT}/headless.log"
+	export HEADLESS_COMPLETE_LOG="${TEST_ROOT}/headless-complete.log"
 	export HEADLESS_ARGS_CAPTURE="${TEST_ROOT}/headless-args.txt"
 	export HEADLESS_ENV_CAPTURE="${TEST_ROOT}/headless-env.txt"
 	export HEADLESS_PROMPT_CAPTURE="${TEST_ROOT}/prompt.md"
@@ -358,10 +366,13 @@ setup_test_env() {
 	export GRAPHQL_BODY_CAPTURE="${TEST_ROOT}/graphql-body.txt"
 	export GRAPHQL_BODY_FLAG_CAPTURE="${TEST_ROOT}/graphql-body-flag.txt"
 	export PR_REVIEW_THREAD_RESPONSE_COOLDOWN=3600
+	export PR_REVIEW_THREAD_RESPONSE_INFRASTRUCTURE_FAILURE_COOLDOWN=90
+	export PRRTS_SCANNER_UNDER_TEST="$SCANNER"
 	: >"$GRAPHQL_MUTATIONS_LOG"
 	: >"$GRAPHQL_BODY_CAPTURE"
 	: >"$GRAPHQL_BODY_FLAG_CAPTURE"
 	: >"$HEADLESS_LOG"
+	: >"$HEADLESS_COMPLETE_LOG"
 	: >"$DETACH_LAUNCH_LOG"
 	: >"$GIT_FETCH_CWD_LOG"
 	rm -f "$GIT_FETCHED_HEAD_STATE"
@@ -679,6 +690,32 @@ wait_for_headless_log() {
 	return 1
 }
 
+wait_for_state_marker() {
+	local state_file="$1"
+	local marker="$2"
+	local attempts=0
+	while [[ "$attempts" -lt 10 ]]; do
+		if grep -q "$marker" "$state_file" 2>/dev/null; then
+			return 0
+		fi
+		sleep 1
+		attempts=$((attempts + 1))
+	done
+	return 1
+}
+
+wait_for_headless_completion() {
+	local attempts=0
+	while [[ "$attempts" -lt 10 ]]; do
+		if [[ -s "$HEADLESS_COMPLETE_LOG" ]]; then
+			return 0
+		fi
+		sleep 1
+		attempts=$((attempts + 1))
+	done
+	return 1
+}
+
 expire_state_dispatch_time() {
 	local state_file="$1"
 	local dispatched_at="$2"
@@ -692,6 +729,35 @@ expire_state_dispatch_time() {
 	done <"$state_file" >"$tmp_file"
 	mv "$tmp_file" "$state_file"
 	return 0
+}
+
+write_worker_outcome() {
+	local outcome_file="$1"
+	local reason="$2"
+	local session_count="$3"
+	local finished_at="$4"
+	local outcome_id="$5"
+	{
+		printf 'session_key=pr-review-thread-response-owner-repo-1\n'
+		printf 'outcome_id=%s\n' "$outcome_id"
+		printf 'reason=%s\n' "$reason"
+		printf 'session_count=%s\n' "$session_count"
+		printf 'finished_at=%s\n' "$finished_at"
+	} >"$outcome_file"
+	return 0
+}
+
+read_state_value() {
+	local state_file="$1"
+	local wanted_key="$2"
+	local key="" value=""
+	while IFS='=' read -r key value; do
+		if [[ "$key" == "$wanted_key" ]]; then
+			printf '%s\n' "$value"
+			return 0
+		fi
+	done <"$state_file"
+	return 1
 }
 
 test_scan_finds_unresolved_bot_thread() {
@@ -1047,6 +1113,129 @@ test_dispatch_is_idempotent_for_same_fingerprint() {
 		print_result "dispatch skips same fingerprint during cooldown" 0
 	else
 		print_result "dispatch skips same fingerprint during cooldown" 1 "second dispatch unexpectedly launched"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_dispatch_preserves_immediate_worker_terminal_state() {
+	setup_test_env
+	export STUB_HEADLESS_MARK_COMPLETE=true
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
+	wait_for_state_marker "$state_file" '^analysis_complete=true$' || true
+	wait_for_headless_completion || true
+	if grep -q '^analysis_complete=true$' "$state_file" 2>/dev/null &&
+		grep -q '^blocker_reason=immediate_worker_completion$' "$state_file" 2>/dev/null; then
+		print_result "dispatch preserves immediate worker terminal state" 0
+	else
+		print_result "dispatch preserves immediate worker terminal state" 1 \
+			"state=$(tr '\n' ';' <"$state_file" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_dispatch_retries_zero_session_infrastructure_failure_after_short_cooldown() {
+	setup_test_env
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	wait_for_headless_log || true
+	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
+	local outcome_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.outcome"
+	local old_epoch="" outcome_id=""
+	outcome_id="$(read_state_value "$state_file" outcome_id)"
+	old_epoch="$(($(date +%s) - 120))"
+	expire_state_dispatch_time "$state_file" "$old_epoch"
+	write_worker_outcome "$outcome_file" "worker_noop_zero_output" "0" "$((old_epoch + 1))" "$outcome_id"
+	: >"$HEADLESS_LOG"
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	wait_for_headless_log || true
+	if [[ -s "$HEADLESS_LOG" ]] &&
+		grep -q '^attempt_count=1$' "$state_file" 2>/dev/null &&
+		grep -Fxq "AIDEVOPS_HEADLESS_OUTCOME_FILE=${outcome_file}" "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
+		grep -Fxq "AIDEVOPS_HEADLESS_OUTCOME_ID=$(read_state_value "$state_file" outcome_id)" "$HEADLESS_ENV_CAPTURE" 2>/dev/null &&
+		grep -q 'worker_noop_zero_output session_count=0 — classifying as infrastructure failure' "$LOGFILE" 2>/dev/null &&
+		grep -q 'retrying after infrastructure-failure short cooldown' "$LOGFILE" 2>/dev/null; then
+		print_result "dispatch retries zero-session infrastructure failure after short cooldown" 0
+	else
+		print_result "dispatch retries zero-session infrastructure failure after short cooldown" 1 \
+			"headless=$(wc -c <"$HEADLESS_LOG" 2>/dev/null || printf 0), state=$(tr '\n' ';' <"$state_file" 2>/dev/null || printf ''), log=$(tr '\n' ';' <"$LOGFILE" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_dispatch_defers_zero_session_infrastructure_failure_during_short_cooldown() {
+	setup_test_env
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	wait_for_headless_log || true
+	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
+	local outcome_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.outcome"
+	local old_epoch="" outcome_id=""
+	outcome_id="$(read_state_value "$state_file" outcome_id)"
+	old_epoch="$(($(date +%s) - 30))"
+	expire_state_dispatch_time "$state_file" "$old_epoch"
+	write_worker_outcome "$outcome_file" "worker_noop_zero_output" "0" "$((old_epoch + 1))" "$outcome_id"
+	: >"$HEADLESS_LOG"
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	if [[ ! -s "$HEADLESS_LOG" ]] &&
+		grep -q 'infrastructure-failure short cooldown active' "$LOGFILE" 2>/dev/null; then
+		print_result "dispatch defers zero-session infrastructure failure during short cooldown" 0
+	else
+		print_result "dispatch defers zero-session infrastructure failure during short cooldown" 1 \
+			"headless=$(wc -c <"$HEADLESS_LOG" 2>/dev/null || printf 0), log=$(tr '\n' ';' <"$LOGFILE" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_dispatch_preserves_full_cooldown_after_model_session() {
+	setup_test_env
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	wait_for_headless_log || true
+	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
+	local outcome_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.outcome"
+	local old_epoch="" outcome_id=""
+	outcome_id="$(read_state_value "$state_file" outcome_id)"
+	old_epoch="$(($(date +%s) - 400))"
+	expire_state_dispatch_time "$state_file" "$old_epoch"
+	write_worker_outcome "$outcome_file" "worker_noop_zero_output" "1" "$((old_epoch + 1))" "$outcome_id"
+	: >"$HEADLESS_LOG"
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	if [[ ! -s "$HEADLESS_LOG" ]] &&
+		grep -q 'same thread fingerprint dispatched' "$LOGFILE" 2>/dev/null &&
+		! grep -q 'classifying as infrastructure failure' "$LOGFILE" 2>/dev/null; then
+		print_result "dispatch preserves full cooldown after a model session" 0
+	else
+		print_result "dispatch preserves full cooldown after a model session" 1 \
+			"headless=$(wc -c <"$HEADLESS_LOG" 2>/dev/null || printf 0), log=$(tr '\n' ';' <"$LOGFILE" 2>/dev/null || printf '')"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_dispatch_rejects_mismatched_or_future_outcomes() {
+	setup_test_env
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	wait_for_headless_log || true
+	local state_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.state"
+	local outcome_file="${AIDEVOPS_PR_REVIEW_THREAD_RESPONSE_STATE_DIR}/owner-repo-1.outcome"
+	local old_epoch="" outcome_id=""
+	outcome_id="$(read_state_value "$state_file" outcome_id)"
+	old_epoch="$(($(date +%s) - 400))"
+	expire_state_dispatch_time "$state_file" "$old_epoch"
+	write_worker_outcome "$outcome_file" "worker_noop_zero_output" "0" "$((old_epoch + 1))" "stale-${outcome_id}"
+	: >"$HEADLESS_LOG"
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	write_worker_outcome "$outcome_file" "worker_noop_zero_output" "0" "$(($(date +%s) + 3600))" "$outcome_id"
+	$SCANNER dispatch owner/repo "${TEST_ROOT}/repo"
+	if [[ ! -s "$HEADLESS_LOG" ]] &&
+		grep -q 'same thread fingerprint dispatched' "$LOGFILE" 2>/dev/null &&
+		! grep -q 'classifying as infrastructure failure' "$LOGFILE" 2>/dev/null; then
+		print_result "dispatch rejects mismatched and future zero-session outcomes" 0
+	else
+		print_result "dispatch rejects mismatched and future zero-session outcomes" 1 \
+			"headless=$(wc -c <"$HEADLESS_LOG" 2>/dev/null || printf 0), log=$(tr '\n' ';' <"$LOGFILE" 2>/dev/null || printf '')"
 	fi
 	teardown_test_env
 	return 0
@@ -1766,6 +1955,11 @@ main() {
 	test_dispatch_pr_reports_no_match_as_converged
 	test_dispatch_pr_reports_fetch_failure_as_retryable
 	test_dispatch_is_idempotent_for_same_fingerprint
+	test_dispatch_preserves_immediate_worker_terminal_state
+	test_dispatch_retries_zero_session_infrastructure_failure_after_short_cooldown
+	test_dispatch_defers_zero_session_infrastructure_failure_during_short_cooldown
+	test_dispatch_preserves_full_cooldown_after_model_session
+	test_dispatch_rejects_mismatched_or_future_outcomes
 	test_dispatch_skips_mixed_fingerprint_during_inflight_window
 	test_dispatch_escalates_repeated_same_fingerprint_without_worker_loop
 	test_dispatch_retries_escalated_previous_worker_contract


### PR DESCRIPTION
## Summary

Persist headless worker outcomes and retry PR review responders after a 90-second infrastructure cooldown when OpenCode creates no session

## Files Changed

.agents/scripts/headless-runtime-failure.sh, .agents/scripts/pr-review-thread-response-scanner.sh, .agents/scripts/tests/test-headless-runtime-failure-classification.sh, .agents/scripts/tests/test-pr-review-thread-response-scanner.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — ShellCheck; PR review scanner suite (66 tests); headless runtime failure classification suite (60 tests)

Resolves #29376


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 12m and 136,954 tokens on this as a headless worker.