### PR TITLE
GH#29303: Add patch release checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve complete, bounded review feedback across paginated review and comment results (#29392)
+
 ## [3.32.216] - 2026-08-02
 
 ### Changed


### PR DESCRIPTION
## Summary

- add an explicit changelog checkpoint for the complete review-feedback routing fix merged in PR #29392
- provide a fresh exact-tip PR for the newly authorized patch release because PR #29392 already has irreversible `release:not-requested` lifecycle evidence

## Files Changed

- `CHANGELOG.md`: document bounded multiline and paginated review-feedback preservation under `Unreleased`

## Verification

- `git diff --check`
- `.agents/scripts/linters-local.sh --changed`
- Markdown lint, Secretlint, file-size regression, and affected changed-file gates passed

## Release Intent

- after this PR reaches terminal-success checks and merges at the exact `main` tip, publish the next patch release through `aidevops release patch <this-pr>`
- use incremental local deployment; do not rewrite or replace PR #29392's terminal no-release receipt

Ref #29303
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.216 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 7h 7m and 2,248,718 tokens on this with the user in an interactive session.