### PR TITLE
GH#29397: Reconcile protected-main tag before remote ref exists

### DIFF
--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -48,6 +48,48 @@ _full_loop_release_verify_tag_provenance() {
 	return $?
 }
 
+_full_loop_release_verify_protected_source_provenance() {
+	local repo="$1"
+	local tag_name="$2"
+	local verifier="${SCRIPT_DIR}/release-provenance-helper.sh"
+
+	[[ -x "$verifier" ]] || return 1
+	_full_loop_release_prepare_tag_worktree "$tag_name" || return 1
+	(
+		cd "$_FULL_LOOP_RELEASE_PATH" || exit 1
+		bash "$verifier" verify-local-source --tag "$tag_name" --repo "$repo" >/dev/null
+	)
+	return $?
+}
+
+_full_loop_release_verify_candidate_tag_provenance() {
+	local repo="$1"
+	local tag_name="$2"
+	local protected_state_rc=0
+
+	_version_manager_classify_remote_tag "$tag_name" || return 1
+	case "$_VERSION_MANAGER_REMOTE_TAG_STATE" in
+	"$_VERSION_MANAGER_TAG_STATE_MATCHING")
+		_full_loop_release_verify_tag_provenance "$repo" "$tag_name"
+		return $?
+		;;
+	"$_VERSION_MANAGER_TAG_STATE_ABSENT")
+		_full_loop_release_verify_protected_source_provenance "$repo" "$tag_name" || return 1
+		_version_manager_reconcile_protected_release_tag "$repo" "$tag_name" status \
+			>/dev/null || protected_state_rc=$?
+		[[ "$protected_state_rc" -eq 0 ]] || return 1
+		case "$_VERSION_MANAGER_PROTECTED_RELEASE_RESULT" in
+		pr-pending | tag-ready) return 0 ;;
+		remote-tag-present)
+			_full_loop_release_verify_tag_provenance "$repo" "$tag_name"
+			return $?
+			;;
+		esac
+		;;
+	esac
+	return 1
+}
+
 _full_loop_release_candidate_tags_for_pr() {
 	local requested_pr="$1"
 	local ref_format='%(refname:short)%1f'
@@ -123,7 +165,7 @@ _full_loop_release_find_tag_for_pr() {
 			return 1
 		fi
 		[[ "$requested_present" == "$_FULL_LOOP_RELEASE_TRUE" ]] || continue
-		_full_loop_release_verify_tag_provenance "$repo" "$candidate_tag" || return 1
+		_full_loop_release_verify_candidate_tag_provenance "$repo" "$candidate_tag" || return 1
 		_FULL_LOOP_RELEASE_FOUND_TAG="$candidate_tag"
 		return 0
 	done <<<"$candidate_tags"

--- a/.agents/scripts/release-provenance-helper.sh
+++ b/.agents/scripts/release-provenance-helper.sh
@@ -574,7 +574,7 @@ _release_provenance_verify() {
 			"$repo_slug" "$tag_name" "$_RELEASE_PROVENANCE_TAG_COMMIT" \
 			"$_RELEASE_PROVENANCE_TAG_OBJECT" || return 1
 	fi
-	[[ "$verification_scope" != "$_RELEASE_PROVENANCE_SCOPE_LOCAL_SOURCE" ]] || \
+	[[ "$verification_scope" != "$_RELEASE_PROVENANCE_SCOPE_LOCAL_SOURCE" ]] ||
 		verification_label=" local source"
 
 	printf 'release-provenance: verified %s%s at %s from PR #%s\n' \

--- a/.agents/scripts/release-provenance-helper.sh
+++ b/.agents/scripts/release-provenance-helper.sh
@@ -10,6 +10,8 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 # shellcheck source=release-authorization-manifest-helper.sh
 source "${SCRIPT_DIR}/release-authorization-manifest-helper.sh"
 _RELEASE_PROVENANCE_TAG_REF_PREFIX="refs/tags/"
+_RELEASE_PROVENANCE_SCOPE_REMOTE="remote"
+_RELEASE_PROVENANCE_SCOPE_LOCAL_SOURCE="local-source"
 
 _release_provenance_error() {
 	local message="$1"
@@ -21,12 +23,15 @@ _release_provenance_usage() {
 	cat <<'USAGE'
 Usage:
   release-provenance-helper.sh verify --tag TAG --repo OWNER/REPO [--branch BRANCH]
+  release-provenance-helper.sh verify-local-source --tag TAG --repo OWNER/REPO [--branch BRANCH]
   release-provenance-helper.sh resolve-authorization --source-pr PR --repo OWNER/REPO [--branch BRANCH] [--expected-sources PR[,PR...]]
   release-provenance-helper.sh resolve-tag-authorization --tag TAG --source-pr PR --repo OWNER/REPO [--branch BRANCH] [--expected-sources PR@SHA[,PR@SHA...]]
   release-provenance-helper.sh resolve-source --source-pr PR --repo OWNER/REPO [--branch BRANCH] [--expected-sources PR[,PR...]]
 
 Verifies that a release tag is signed, version-consistent, reachable from the
 canonical branch, and bound to a merged source PR through immutable tag trailers.
+The local-source mode omits remote-tag and canonical-branch reachability checks;
+callers must pair it with exact protected-release PR and ancestry verification.
 USAGE
 	return 0
 }
@@ -530,6 +535,8 @@ _release_provenance_verify() {
 	local tag_name="$1"
 	local repo_slug="$2"
 	local branch_name="$3"
+	local verification_scope="${4:-$_RELEASE_PROVENANCE_SCOPE_REMOTE}"
+	local verification_label=""
 
 	[[ "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
 		_release_provenance_error "tag must be a complete semantic version"
@@ -543,6 +550,8 @@ _release_provenance_verify() {
 		_release_provenance_error "invalid canonical branch"
 		return 1
 	}
+	[[ "$verification_scope" == "$_RELEASE_PROVENANCE_SCOPE_REMOTE" ||
+		"$verification_scope" == "$_RELEASE_PROVENANCE_SCOPE_LOCAL_SOURCE" ]] || return 1
 	_release_provenance_verify_versions "$tag_name" || return 1
 	_release_provenance_verify_local_tag "$tag_name" || return 1
 	_release_provenance_load_trailers "$tag_name" || return 1
@@ -551,7 +560,8 @@ _release_provenance_verify() {
 		_release_provenance_error "cannot refresh origin/${branch_name}"
 		return 1
 	}
-	if ! git merge-base --is-ancestor "$_RELEASE_PROVENANCE_TAG_COMMIT" "origin/${branch_name}" 2>/dev/null; then
+	if [[ "$verification_scope" == "$_RELEASE_PROVENANCE_SCOPE_REMOTE" ]] &&
+		! git merge-base --is-ancestor "$_RELEASE_PROVENANCE_TAG_COMMIT" "origin/${branch_name}" 2>/dev/null; then
 		_release_provenance_error "release tag commit is not reachable from origin/${branch_name}"
 		return 1
 	fi
@@ -559,12 +569,17 @@ _release_provenance_verify() {
 		"$repo_slug" "$branch_name" "$_RELEASE_PROVENANCE_SOURCE_PR" \
 		"$_RELEASE_PROVENANCE_SOURCE_MERGE" "$_RELEASE_PROVENANCE_TAG_COMMIT" || return 1
 	_release_provenance_verify_aggregate_manifest "$repo_slug" "$branch_name" || return 1
-	_release_provenance_verify_github_tag \
-		"$repo_slug" "$tag_name" "$_RELEASE_PROVENANCE_TAG_COMMIT" \
-		"$_RELEASE_PROVENANCE_TAG_OBJECT" || return 1
+	if [[ "$verification_scope" == "$_RELEASE_PROVENANCE_SCOPE_REMOTE" ]]; then
+		_release_provenance_verify_github_tag \
+			"$repo_slug" "$tag_name" "$_RELEASE_PROVENANCE_TAG_COMMIT" \
+			"$_RELEASE_PROVENANCE_TAG_OBJECT" || return 1
+	fi
+	[[ "$verification_scope" != "$_RELEASE_PROVENANCE_SCOPE_LOCAL_SOURCE" ]] || \
+		verification_label=" local source"
 
-	printf 'release-provenance: verified %s at %s from PR #%s\n' \
-		"$tag_name" "$_RELEASE_PROVENANCE_TAG_COMMIT" "$_RELEASE_PROVENANCE_SOURCE_PR"
+	printf 'release-provenance: verified %s%s at %s from PR #%s\n' \
+		"$tag_name" "$verification_label" \
+		"$_RELEASE_PROVENANCE_TAG_COMMIT" "$_RELEASE_PROVENANCE_SOURCE_PR"
 	return 0
 }
 
@@ -578,7 +593,7 @@ main() {
 	local expected_sources=""
 
 	case "$command" in
-	verify | resolve-authorization | resolve-tag-authorization | resolve-source) ;;
+	verify | verify-local-source | resolve-authorization | resolve-tag-authorization | resolve-source) ;;
 	help | --help | -h)
 		_release_provenance_usage
 		return 0
@@ -634,7 +649,13 @@ main() {
 		return $?
 	fi
 	[[ -n "$tag_name" ]] || return 1
-	_release_provenance_verify "$tag_name" "$repo_slug" "$branch_name"
+	if [[ "$command" == "verify-local-source" ]]; then
+		_release_provenance_verify "$tag_name" "$repo_slug" "$branch_name" \
+			"$_RELEASE_PROVENANCE_SCOPE_LOCAL_SOURCE"
+		return $?
+	fi
+	_release_provenance_verify "$tag_name" "$repo_slug" "$branch_name" \
+		"$_RELEASE_PROVENANCE_SCOPE_REMOTE"
 	return $?
 }
 

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -241,6 +241,12 @@ legacy_found_tag_file="${TEST_ROOT}/legacy-found-tag.txt"
 		[[ "$repo" == "test/repo" && "$tag_name" == "v1.2.4" ]]
 		return $?
 	}
+	_version_manager_classify_remote_tag() {
+		local tag_name="$1"
+		[[ "$tag_name" == "v1.2.4" ]] || return 1
+		_VERSION_MANAGER_REMOTE_TAG_STATE="$_VERSION_MANAGER_TAG_STATE_MATCHING"
+		return 0
+	}
 	_full_loop_release_find_tag_for_pr test/repo 89 || exit 1
 	printf '%s\n' "$_FULL_LOOP_RELEASE_FOUND_TAG"
 ) >"$legacy_found_tag_file"
@@ -360,8 +366,7 @@ export FAKE_VERIFY_LOG FAKE_POST_RELEASE_LOG FAKE_PERSIST_LOG FAKE_OLD_RUNTIME_L
 cat >"${TEST_ROOT}/runtime/release-provenance-helper.sh" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
-printf '%s\n' "$PWD" >"${FAKE_VERIFY_LOG:?}"
-printf '%s\n' "$*" >>"${FAKE_VERIFY_LOG:?}"
+printf 'cwd=%s\nargs=%s\n' "$PWD" "$*" >>"${FAKE_VERIFY_LOG:?}"
 STUB
 cat >"${TEST_ROOT}/runtime/version-manager.sh" <<'STUB'
 #!/usr/bin/env bash
@@ -384,6 +389,7 @@ chmod +x "${TEST_ROOT}/runtime/release-provenance-helper.sh" \
 
 saved_script_dir="$SCRIPT_DIR"
 SCRIPT_DIR="${TEST_ROOT}/runtime"
+: >"$FAKE_VERIFY_LOG"
 _full_loop_release_prepare_tag_worktree() {
 	local tag_name="$1"
 	[[ "$tag_name" == "v1.2.3" ]] || return 1
@@ -391,12 +397,14 @@ _full_loop_release_prepare_tag_worktree() {
 	return 0
 }
 if ! _full_loop_release_verify_tag_provenance test/repo v1.2.3 ||
-	! grep -qx "${TEST_ROOT}/tag-checkout" "$FAKE_VERIFY_LOG" ||
-	! grep -qx 'verify --tag v1.2.3 --repo test/repo' "$FAKE_VERIFY_LOG"; then
+	! _full_loop_release_verify_protected_source_provenance test/repo v1.2.3 ||
+	! grep -qx "cwd=${TEST_ROOT}/tag-checkout" "$FAKE_VERIFY_LOG" ||
+	! grep -qx 'args=verify --tag v1.2.3 --repo test/repo' "$FAKE_VERIFY_LOG" ||
+	! grep -qx 'args=verify-local-source --tag v1.2.3 --repo test/repo' "$FAKE_VERIFY_LOG"; then
 	printf 'FAIL release provenance was not verified from the detached tag checkout\n'
 	exit 1
 fi
-printf 'PASS release provenance verification runs from the detached tag checkout\n'
+printf 'PASS remote and protected-source provenance verification run from the detached tag checkout\n'
 
 _full_loop_validate_release_candidates() {
 	local repo="$1"
@@ -816,6 +824,103 @@ for stale_failure_mode in source-run ancestry latest-remote receipt; do
 	}
 done
 printf 'PASS stale receipt supersession binds both releases and fails closed on uncertain evidence\n'
+
+protected_state_log="${TEST_ROOT}/protected-state.log"
+protected_source_log="${TEST_ROOT}/protected-source.log"
+protected_push_log="${TEST_ROOT}/protected-push.log"
+protected_remote_verify_log="${TEST_ROOT}/protected-remote-verify.log"
+export protected_state_log protected_source_log protected_push_log protected_remote_verify_log
+(
+	git() {
+		local args="$*"
+		case "$args" in
+		*" fetch origin --tags --quiet"*) return 0 ;;
+		*" for-each-ref "*)
+			printf 'v1.2.3\x1f90\x1f1111111111111111111111111111111111111111\x1f\n'
+			;;
+		*" log --all --fixed-strings "*) return 0 ;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
+	_full_loop_resolve_repo() {
+		local requested_repo="$1"
+		printf '%s\n' "${requested_repo:-test/repo}"
+		return 0
+	}
+	_full_loop_release_receipt_path() {
+		local repo="$1"
+		local pr_number="$2"
+		printf '%s/protected-%s-%s.status\n' "$TEST_ROOT" "${repo//\//_}" "$pr_number"
+		return 0
+	}
+	_full_loop_release_tag_body() {
+		local tag_name="$1"
+		[[ "$tag_name" == "v1.2.3" ]] || return 1
+		printf '%s\n' \
+			'Aidevops-Source-PR: 90' \
+			'Aidevops-Source-Merge: 1111111111111111111111111111111111111111'
+		return 0
+	}
+	_full_loop_release_source_json_from_tag() {
+		local tag_name="$1"
+		[[ "$tag_name" == "v1.2.3" ]] || return 1
+		printf '%s\n' '{"source_pr":90,"source_merge":"1111111111111111111111111111111111111111","aggregated_sources":[]}'
+		return 0
+	}
+	_version_manager_classify_remote_tag() {
+		local tag_name="$1"
+		[[ "$tag_name" == "v1.2.3" ]] || return 1
+		_VERSION_MANAGER_REMOTE_TAG_STATE="$_VERSION_MANAGER_TAG_STATE_ABSENT"
+		return 0
+	}
+	_full_loop_release_verify_tag_provenance() {
+		local repo="$1"
+		local tag_name="$2"
+		printf '%s %s\n' "$repo" "$tag_name" >"$protected_remote_verify_log"
+		return 1
+	}
+	_full_loop_release_verify_protected_source_provenance() {
+		local repo="$1"
+		local tag_name="$2"
+		printf '%s %s\n' "$repo" "$tag_name" >>"$protected_source_log"
+		return 0
+	}
+	_version_manager_reconcile_protected_release_tag() {
+		local repo="$1"
+		local tag_name="$2"
+		local mode="$3"
+		printf '%s %s %s\n' "$repo" "$tag_name" "$mode" >>"$protected_state_log"
+		if [[ "$mode" == "reconcile" ]]; then
+			printf '%s %s\n' "$repo" "$tag_name" >"$protected_push_log"
+			_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="tag-pushed"
+		else
+			_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="tag-ready"
+		fi
+		return 0
+	}
+	_full_loop_release_latest_tag() {
+		printf 'v1.2.3\n'
+		return 0
+	}
+	status_rc=0
+	AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command status 90 \
+		>/dev/null 2>&1 || status_rc=$?
+	[[ "$status_rc" -eq 8 && ! -e "$protected_push_log" ]] || exit 1
+	reconcile_rc=0
+	AIDEVOPS_FULL_LOOP_REPO=test/repo _full_loop_release_existing_command reconcile 90 \
+		>/dev/null 2>&1 || reconcile_rc=$?
+	[[ "$reconcile_rc" -eq 8 ]] || exit 1
+)
+if [[ -e "$protected_remote_verify_log" ]] ||
+	! grep -qx 'test/repo v1.2.3' "$protected_push_log" ||
+	[[ "$(grep -c '^test/repo v1.2.3 status$' "$protected_state_log")" -ne 3 ]] ||
+	[[ "$(grep -c '^test/repo v1.2.3 reconcile$' "$protected_state_log")" -ne 1 ]] ||
+	[[ "$(grep -c '^test/repo v1.2.3$' "$protected_source_log")" -ne 2 ]]; then
+	printf 'FAIL public reconciliation did not preserve the read-only protected-tag discovery boundary\n'
+	exit 1
+fi
+printf 'PASS public status is read-only and reconcile reaches exact protected-tag publication\n'
 
 _full_loop_resolve_repo() {
 	local requested_repo="$1"

--- a/.agents/scripts/tests/test-release-provenance-helper.sh
+++ b/.agents/scripts/tests/test-release-provenance-helper.sh
@@ -82,6 +82,17 @@ run_helper() {
 	return $?
 }
 
+run_local_source_helper() {
+	local mode="${1:-valid}"
+	(
+		cd "$REPO" || exit 1
+		export PROVENANCE_MODE="$mode"
+		PATH="${BIN}:/opt/homebrew/bin:/usr/bin:/bin" \
+			bash "$HELPER" verify-local-source --tag v1.2.3 --repo test/repo
+	) || return 1
+	return 0
+}
+
 assert_rejected() {
 	local name="$1"
 	local mode="$2"
@@ -117,6 +128,15 @@ if run_helper >/dev/null 2>&1; then
 	exit 1
 fi
 printf 'PASS non-main release commit is rejected\n'
+run_local_source_helper >/dev/null || {
+	printf 'FAIL protected local source provenance was rejected before main ancestry converged\n'
+	exit 1
+}
+if run_local_source_helper pr-mismatch >/dev/null 2>&1; then
+	printf 'FAIL protected local source provenance accepted a mismatched source PR\n'
+	exit 1
+fi
+printf 'PASS protected local source mode preserves strict source provenance without remote-tag inference\n'
 git -C "$REPO" push -q --force origin "${TAG_COMMIT}:main"
 
 git -C "$REPO" tag -d v1.2.3 >/dev/null

--- a/.agents/scripts/tests/test-version-manager-protected-main-fallback.sh
+++ b/.agents/scripts/tests/test-version-manager-protected-main-fallback.sh
@@ -78,19 +78,31 @@ if [[ "${1:-}" == "api" && " $* " == *" repos/test/repo/pulls "* ]]; then
 		printf '[]\n'
 		exit 0
 	fi
-	branch_sha=$("${REAL_GIT:?}" ls-remote "${REMOTE:?}" \
-		'refs/heads/chore/release-v1.2.3-provenance' | cut -f1)
+	if [[ -f "${PR_MERGED_FILE:?}" ]]; then
+		branch_sha="${RECOVERY_HEAD:?}"
+	else
+		branch_sha=$("${REAL_GIT:?}" ls-remote "${REMOTE:?}" \
+			'refs/heads/chore/release-v1.2.3-provenance' | cut -f1)
+	fi
 	auto_merge=null
+	pr_state=open
+	merged_at=null
+	if [[ -f "${PR_MERGED_FILE:?}" ]]; then
+		pr_state=closed
+		merged_at='"2026-08-03T00:00:00Z"'
+	fi
+	author_association="${PR_AUTHOR_ASSOCIATION:-OWNER}"
 	[[ ! -f "${AUTO_MERGE_FILE:?}" ]] || auto_merge='{"merge_method":"merge"}'
 	body="<!-- aidevops:release-provenance tag=v1.2.3 tag-object=${TAG_OBJECT:?} release-commit=${RELEASE_COMMIT:?} merge-method=merge -->"
 	jq -nc --arg branch_sha "$branch_sha" --arg body "$body" \
-		--argjson auto_merge "$auto_merge" '[{
+		--arg pr_state "$pr_state" --arg author_association "$author_association" \
+		--argjson merged_at "$merged_at" --argjson auto_merge "$auto_merge" '[{
 			number: 77,
-			state: "open",
-			merged_at: null,
+			state: $pr_state,
+			merged_at: $merged_at,
 			draft: false,
 			auto_merge: $auto_merge,
-			author_association: "OWNER",
+			author_association: $author_association,
 			user: {login: "test-owner"},
 			body: $body,
 			head: {ref: "chore/release-v1.2.3-provenance", sha: $branch_sha, repo: {full_name: "test/repo"}},
@@ -120,6 +132,7 @@ export FAKE_GH_LOG="${TEST_ROOT}/gh.log"
 export DIRECT_PUSH_COUNT="${TEST_ROOT}/direct-push-count"
 export PR_CREATED_FILE="${TEST_ROOT}/pr-created"
 export AUTO_MERGE_FILE="${TEST_ROOT}/auto-merge"
+export PR_MERGED_FILE="${TEST_ROOT}/pr-merged"
 export PATH="${BIN}:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 export AIDEVOPS_VERSION_MANAGER_REPO_SLUG=test/repo
 
@@ -156,6 +169,7 @@ printf 'PASS permanent PR-required rejection stops after one direct push\n'
 
 RECOVERY_BRANCH='chore/release-v1.2.3-provenance'
 RECOVERY_HEAD=$("$REAL_GIT" ls-remote "$REMOTE" "refs/heads/${RECOVERY_BRANCH}" | cut -f1)
+export RECOVERY_HEAD
 [[ "$RECOVERY_HEAD" =~ ^[0-9a-f]{40}$ ]]
 [[ "$("$REAL_GIT" -C "$REPO" rev-parse "${RECOVERY_HEAD}^1")" == "$CURRENT_MAIN" ]]
 [[ "$("$REAL_GIT" -C "$REPO" rev-parse "${RECOVERY_HEAD}^2")" == "$RELEASE_COMMIT" ]]
@@ -196,6 +210,26 @@ merge_calls_after=$(grep -c '^pr merge ' "$FAKE_GH_LOG")
 "$REAL_GIT" -C "$REPO" checkout -q --detach "$RECOVERY_HEAD"
 printf 'PASS incompatible recovery descendants fail closed before merge queueing\n'
 
+export PR_AUTHOR_ASSOCIATION=NONE
+if _version_manager_reconcile_protected_release_tag test/repo v1.2.3 status \
+	>/dev/null 2>&1; then
+	printf 'FAIL untrusted protected release PR authorized tag reconciliation\n'
+	exit 1
+fi
+unset PR_AUTHOR_ASSOCIATION
+[[ -z "$("$REAL_GIT" ls-remote --tags "$REMOTE" refs/tags/v1.2.3)" ]]
+printf 'PASS protected release reconciliation requires a trusted PR author\n'
+
+"$REAL_GIT" -C "$REPO" tag -f -a v1.2.3 -m 'replacement tag object' "$RELEASE_COMMIT"
+if _version_manager_reconcile_protected_release_tag test/repo v1.2.3 status \
+	>/dev/null 2>&1; then
+	printf 'FAIL replacement local tag object matched protected release evidence\n'
+	exit 1
+fi
+"$REAL_GIT" -C "$REPO" update-ref refs/tags/v1.2.3 "$TAG_OBJECT"
+[[ -z "$("$REAL_GIT" ls-remote --tags "$REMOTE" refs/tags/v1.2.3)" ]]
+printf 'PASS protected release reconciliation binds the exact preserved tag object\n'
+
 _version_manager_reconcile_protected_release_tag test/repo v1.2.3 status >/dev/null
 [[ "$_VERSION_MANAGER_PROTECTED_RELEASE_RESULT" == "pr-pending" ]]
 [[ -z "$("$REAL_GIT" ls-remote --tags "$REMOTE" refs/tags/v1.2.3)" ]]
@@ -206,6 +240,27 @@ printf 'PASS final tag publication remains blocked while the recovery PR is open
 "$REAL_GIT" -C "$MERGER" config user.email test@example.invalid
 "$REAL_GIT" -C "$MERGER" merge -q --no-ff --no-edit "origin/${RECOVERY_BRANCH}"
 "$REAL_GIT" -C "$MERGER" push -q origin main
+MERGED_MAIN=$("$REAL_GIT" -C "$MERGER" rev-parse HEAD)
+: >"$PR_MERGED_FILE"
+"$REAL_GIT" --git-dir="$REMOTE" update-ref -d "refs/heads/${RECOVERY_BRANCH}"
+
+tag_pushes_before=$({ grep -c 'push origin refs/tags/v1.2.3:refs/tags/v1.2.3' "$FAKE_GIT_LOG" || true; })
+_version_manager_reconcile_protected_release_tag test/repo v1.2.3 status >/dev/null
+tag_pushes_after=$({ grep -c 'push origin refs/tags/v1.2.3:refs/tags/v1.2.3' "$FAKE_GIT_LOG" || true; })
+[[ "$tag_pushes_after" -eq "$tag_pushes_before" ]]
+[[ "$_VERSION_MANAGER_PROTECTED_RELEASE_RESULT" == "tag-ready" ]]
+[[ -z "$("$REAL_GIT" ls-remote --tags "$REMOTE" refs/tags/v1.2.3)" ]]
+printf 'PASS merged protected release status remains read-only after branch deletion\n'
+
+"$REAL_GIT" --git-dir="$REMOTE" update-ref refs/heads/main "$CURRENT_MAIN"
+if _version_manager_reconcile_protected_release_tag test/repo v1.2.3 reconcile \
+	>/dev/null 2>&1; then
+	printf 'FAIL merged PR metadata bypassed release ancestry verification\n'
+	exit 1
+fi
+[[ -z "$("$REAL_GIT" ls-remote --tags "$REMOTE" refs/tags/v1.2.3)" ]]
+"$REAL_GIT" --git-dir="$REMOTE" update-ref refs/heads/main "$MERGED_MAIN"
+printf 'PASS merged protected release still requires exact main ancestry\n'
 
 _version_manager_reconcile_protected_release_tag test/repo v1.2.3 reconcile >/dev/null
 [[ "$_VERSION_MANAGER_PROTECTED_RELEASE_RESULT" == "tag-pushed" ]]

--- a/.agents/scripts/version-manager-protected-main.sh
+++ b/.agents/scripts/version-manager-protected-main.sh
@@ -107,7 +107,7 @@ _version_manager_remote_tag_identity() {
 		return 0
 	fi
 	_VERSION_MANAGER_REMOTE_TAG_STATE="present"
-	[[ -n "$_VERSION_MANAGER_REMOTE_TAG_COMMIT" ]] || \
+	[[ -n "$_VERSION_MANAGER_REMOTE_TAG_COMMIT" ]] ||
 		_VERSION_MANAGER_REMOTE_TAG_COMMIT="$_VERSION_MANAGER_REMOTE_TAG_OBJECT"
 	return 0
 }
@@ -311,7 +311,7 @@ _version_manager_prepare_protected_release_head() {
 	if ! git -C "$REPO_ROOT" merge-base --is-ancestor "$release_commit" \
 		"$_VERSION_MANAGER_PROTECTED_RELEASE_HEAD" ||
 		! git -C "$REPO_ROOT" merge-base --is-ancestor origin/main \
-		"$_VERSION_MANAGER_PROTECTED_RELEASE_HEAD"; then
+			"$_VERSION_MANAGER_PROTECTED_RELEASE_HEAD"; then
 		print_error "Protected release branch does not retain both required parents"
 		return 1
 	fi
@@ -446,8 +446,8 @@ _version_manager_create_or_reuse_protected_pr() {
 			rm -f "$body_file"
 			return 1
 		}
-		create_args=(--repo "$repo" --head "$branch_name" --base main \
-			--title "chore(release): preserve signed v${version} publication" \
+		create_args=(--repo "$repo" --head "$branch_name" --base main
+			--title "chore(release): preserve signed v${version} publication"
 			--body-file "$body_file")
 		if [[ "$repo" == "marcusquinn/aidevops" ]]; then
 			if declare -F _version_manager_is_headless_task_worker >/dev/null 2>&1 &&

--- a/.agents/scripts/version-manager-protected-main.sh
+++ b/.agents/scripts/version-manager-protected-main.sh
@@ -33,6 +33,8 @@ _VERSION_MANAGER_TAG_STATE_ABSENT="absent"
 _VERSION_MANAGER_TAG_STATE_MATCHING="matching"
 _VERSION_MANAGER_RELEASE_RESULT_QUEUED="queued"
 _VERSION_MANAGER_MODE_RECONCILE="reconcile"
+_VERSION_MANAGER_PR_STATE_OPEN="open"
+_VERSION_MANAGER_PR_STATE_CLOSED="closed"
 
 _version_manager_push_requires_pr() {
 	local push_output="$1"
@@ -401,7 +403,7 @@ _version_manager_queue_exact_merge() {
 	state=$(jq -r '.state // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
 	auto_merge=$(jq -r 'if .auto_merge == null then "" else "configured" end' \
 		<<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
-	if [[ "$state" == "closed" && "$(jq -r '.merged_at // ""' \
+	if [[ "$state" == "$_VERSION_MANAGER_PR_STATE_CLOSED" && "$(jq -r '.merged_at // ""' \
 		<<<"$_VERSION_MANAGER_PROTECTED_PR_JSON")" != "" ]]; then
 		_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="merged"
 		return 0
@@ -577,35 +579,41 @@ _version_manager_reconcile_protected_release_tag() {
 	release_parent=$(git -C "$REPO_ROOT" rev-parse \
 		"${_VERSION_MANAGER_LOCAL_TAG_COMMIT}^" 2>/dev/null) || return 1
 	current_main=$(git -C "$REPO_ROOT" rev-parse origin/main 2>/dev/null) || return 1
-	if git -C "$REPO_ROOT" merge-base --is-ancestor \
-		"$_VERSION_MANAGER_LOCAL_TAG_COMMIT" origin/main; then
-		if [[ "$mode" == "status" ]]; then
-			_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="tag-ready"
-			printf 'RELEASE_TAG_STATE=ready tag=%s commit=%s\n' \
-				"$tag_name" "$_VERSION_MANAGER_LOCAL_TAG_COMMIT"
-			return 0
-		fi
-		_version_manager_publish_reachable_tag "$tag_name" || return 1
-		printf 'release:queued tag=%s correlation=%s\n' \
-			"$tag_name" "$_VERSION_MANAGER_LOCAL_TAG_COMMIT"
-		return 0
-	fi
-
 	branch_name=$(_version_manager_protected_release_branch_name "$version") || return 1
 	_version_manager_find_protected_release_pr "$repo" "$branch_name" || return 1
 	if [[ -z "$_VERSION_MANAGER_PROTECTED_PR_NUMBER" ]]; then
-		print_error "Release commit is not reachable from main and no protected recovery PR exists"
+		print_error "No protected release PR exists for preserved ${tag_name}"
 		return 1
 	fi
 	pr_head=$(jq -r '.head.sha // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
 	_version_manager_verify_protected_pr_head "$pr_head" || return 1
+	_version_manager_verify_protected_pr_identity "$repo" "$branch_name" "$version" \
+		"$_VERSION_MANAGER_LOCAL_TAG_OBJECT" "$_VERSION_MANAGER_LOCAL_TAG_COMMIT" || return 1
+	pr_state=$(jq -r '.state // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
+	merged_at=$(jq -r '.merged_at // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
+	if [[ "$pr_state" == "$_VERSION_MANAGER_PR_STATE_CLOSED" && -z "$merged_at" ]]; then
+		print_error "Protected release PR #${_VERSION_MANAGER_PROTECTED_PR_NUMBER} closed without merge"
+		return 1
+	fi
+	if [[ "$pr_state" != "$_VERSION_MANAGER_PR_STATE_OPEN" &&
+		"$pr_state" != "$_VERSION_MANAGER_PR_STATE_CLOSED" ]]; then
+		return 1
+	fi
 	_version_manager_remote_branch_head "$branch_name" || return 1
 	remote_branch_head="$_VERSION_MANAGER_PROTECTED_RELEASE_HEAD"
-	if [[ -z "$remote_branch_head" || "$remote_branch_head" != "$pr_head" ]]; then
+	if [[ -n "$remote_branch_head" && "$remote_branch_head" != "$pr_head" ]]; then
 		print_error "Protected release PR head no longer matches its remote branch"
 		return 1
 	fi
-	_version_manager_fetch_recovery_branch "$branch_name" || return 1
+	if [[ -n "$remote_branch_head" ]]; then
+		_version_manager_fetch_recovery_branch "$branch_name" || return 1
+	elif [[ "$pr_state" == "$_VERSION_MANAGER_PR_STATE_OPEN" ]]; then
+		print_error "Open protected release PR head no longer has its remote branch"
+		return 1
+	elif ! git -C "$REPO_ROOT" cat-file -e "${pr_head}^{commit}" 2>/dev/null; then
+		print_error "Merged protected release PR head is unavailable for verification"
+		return 1
+	fi
 	_version_manager_verify_recovery_head "$pr_head" \
 		"$_VERSION_MANAGER_LOCAL_TAG_COMMIT" "$release_parent" "$current_main" || return 1
 	if ! git -C "$REPO_ROOT" merge-base --is-ancestor \
@@ -613,13 +621,15 @@ _version_manager_reconcile_protected_release_tag() {
 		print_error "Protected release PR does not contain the signed release commit"
 		return 1
 	fi
-	pr_state=$(jq -r '.state // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
-	merged_at=$(jq -r '.merged_at // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
-	if [[ "$pr_state" == "closed" && -n "$merged_at" ]]; then
+	if [[ "$pr_state" == "$_VERSION_MANAGER_PR_STATE_CLOSED" && -n "$merged_at" ]]; then
 		git -C "$REPO_ROOT" fetch origin main --quiet || return 1
 		if ! git -C "$REPO_ROOT" merge-base --is-ancestor \
 			"$_VERSION_MANAGER_LOCAL_TAG_COMMIT" origin/main; then
 			print_error "Merged protected release PR did not preserve release ancestry"
+			return 1
+		fi
+		if ! git -C "$REPO_ROOT" merge-base --is-ancestor "$pr_head" origin/main; then
+			print_error "Merged protected release PR head is not reachable from main"
 			return 1
 		fi
 		if [[ "$mode" == "$_VERSION_MANAGER_MODE_RECONCILE" ]]; then
@@ -630,10 +640,6 @@ _version_manager_reconcile_protected_release_tag() {
 			_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="tag-ready"
 		fi
 		return 0
-	fi
-	if [[ "$pr_state" != "open" ]]; then
-		print_error "Protected release PR #${_VERSION_MANAGER_PROTECTED_PR_NUMBER} closed without merge"
-		return 1
 	fi
 	if [[ "$mode" == "$_VERSION_MANAGER_MODE_RECONCILE" ]]; then
 		_version_manager_queue_exact_merge "$repo" "$branch_name" "$pr_head" \


### PR DESCRIPTION
## Summary

- Let release reconciliation validate a preserved local source tag when its remote ref is intentionally absent.
- Require exact protected-PR identity, trusted authorship, merged head ancestry, and immutable tag identity before publication.
- Preserve normal remote-tag verification once the remote ref exists.

## Testing

- `bash .agents/scripts/tests/test-release-provenance-helper.sh`
- `bash .agents/scripts/tests/test-full-loop-release-reconcile.sh`
- `bash .agents/scripts/tests/test-version-manager-protected-main-fallback.sh`
- ShellCheck and pre-commit quality gates

## Runtime Testing

- `runtime-verified`: disposable Git remotes exercise pending, merged, deleted-branch, replacement-tag, ancestry-failure, exact-push, and idempotent reconciliation states.

Resolves #29397

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.217 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 17m and 229,517 tokens on this as a headless worker.