### PR TITLE
t18190: Restrict needs-maintainer-review to external trust gates

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -103,7 +103,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 - Never create tracking issues with raw `gh issue create`; use aidevops wrappers, or immediately normalize with `origin:interactive`, `status:in-review`, and the appropriate type label.
 - Interactive issue pickup: for repos where you have maintainer-equivalent access, immediately run `interactive-session-helper.sh claim <N> <owner/repo>`; for external non-maintainer repos, never run claim/dispatch/label routines — submit a PR when possible and leave at most one concise issue comment explaining the proposed solution. Details: `workflows/git-workflow.md`.
 - Worker/maintainer gate interpretation: an unassigned managed-repo issue is not a maintainer blocker for an OWNER/MEMBER interactive session; claim it and continue. For headless workers, work only on the dispatched issue/PR and treat mismatched linked-issue writes as out of scope unless the dispatcher explicitly assigned that target.
-- Interactive admin/maintainer sessions may use admin merge when branch policy only blocks self-review/review count after gates pass; never bypass `needs-maintainer-review` without crypto approval. Details: `reference/auto-merge.md`.
+- Interactive admin/maintainer sessions may use admin merge when branch policy only blocks self-review/review count after gates pass. A live external/unknown-author `needs-maintainer-review` gate requires crypto approval; write-authorized authors are normalized without self-approval. Details: `reference/auto-merge.md`.
 - Interactive sessions never switch, detach, create, rename, or delete branches/refs in a canonical repository, and never edit there. All work—including releases—uses a linked worktree under `${AIDEVOPS_WORKTREE_BASE_DIR:-~/Git/_worktrees}` (flat `<repo>-<slug>` names), never runtime temp dirs. Existing sibling worktrees remain valid until cleanup. User approval does not override this parallel-session invariant; explicitly authorized canonical synchronization and branch recovery use their separate audited helper paths. Headless implementation workers use worktree+PR unless explicitly planning-only.
 - Canonical checkouts are read-only service mirrors, not session-owned stores. Never stash/reset/clean unexpected state directly; the audited mirror-sync path must preserve and verify it before convergence. Details: `reference/dirty-worktree-preservation.md`.
 - Pre-edit passes only in a linked worktree; canonical checkouts return 1 interactively or 2 headlessly with worktree guidance. Do not revert others' changes without explicit request.
@@ -115,7 +115,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 
 - Managed-repo issues, PRs, and comments that describe work MUST include worker-ready context: files to modify, reference pattern, verification, and explicit note when paths cannot be known. Brief template source: `templates/brief-template.md`.
 - Use GitHub wrappers for managed-repo issue/PR creation so origin labels and signatures are applied; never hand-compose signature footers. PR/issue/comment bodies must satisfy same-command `--body-file` discipline. Thread-clean reading and non-collaborator body immunity: `reference/gh-command-discipline.md`.
-- Auto-generated issue triage outcomes: verify premise first; falsified → close with rationale; correct+obvious → implement+PR; correct+ambiguous only → decision-ready comment + `needs-maintainer-review`. Scope/style uncertainty is not NMR. Full templates: `reference/worker-discipline.md`.
+- Auto-generated issue triage outcomes: verify premise first; falsified → close with rationale; correct+obvious → implement+PR; correct+ambiguous only → decision-ready comment + `hold-for-review`. Scope/style uncertainty is not a review hold. Full templates: `reference/worker-discipline.md`.
 - Parent/research tasks: `parent-task` is a permanent dispatch block; PRs against parent issues use `For #NNN`/`Ref #NNN` until the final child/phase. New worker-ready implementation issues default to auto-dispatch because issue creation authorizes implementation; use `no-auto-dispatch` only for an explicit recorded durable hold. If implementing an auto-dispatch issue interactively, use `interactive-start-helper.sh --issue <N> --repo <owner/repo> --task "..." --auto-dispatch`.
 
 ### Quality and diagnostics
@@ -151,7 +151,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 
 ## Task Lifecycle
 
-Task creation, briefs/tiers/dispatchability, auto-dispatch/completion, routines, cross-repo tasks, repos.json, parent lifecycle, origin labels, auto-merge, cryptographic approvals, and NMR automation live in `reference/task-lifecycle.md`.
+Task creation, briefs/tiers/dispatchability, auto-dispatch/completion, routines, cross-repo tasks, repos.json, parent lifecycle, origin labels, auto-merge, cryptographic approvals, and review-block semantics live in `reference/task-lifecycle.md`.
 
 ## Git Workflow
 

--- a/.agents/aidevops/knowledge-plane/04-enrichment-index-review.md
+++ b/.agents/aidevops/knowledge-plane/04-enrichment-index-review.md
@@ -193,7 +193,7 @@ Three trust classes determine what happens to each inbox item:
 |-------|---------|--------|
 | `auto_promote` | `meta.json` `trust: "trusted"\|"authoritative"`, OR `ingested_by` matches a configured bot/email, OR `source_uri` starts with a trusted path | Direct promotion: inbox → staging → sources + audit entry |
 | `review_gate` | `ingested_by` matches `trust.review_gate.from_emails` | Staged + `kind:knowledge-review` issue filed with `auto-dispatch` (light review, worker-handled) |
-| `untrusted` | Default (`"*"`) | Staged + `kind:knowledge-review` issue filed with `needs-maintainer-review` (requires crypto-approval) |
+| `untrusted` | Default (`"*"`) | Staged + `kind:knowledge-review` issue filed with `hold-for-review` for manual content inspection |
 
 ### Trust Config
 
@@ -219,7 +219,7 @@ Defined in `_knowledge/_config/knowledge.json` (written at provision time from
 Override per-repo after provisioning: edit `_knowledge/_config/knowledge.json`
 directly. The config is versioned in `sources/` — changes are tracked in git.
 
-### NMR Issues
+### Review Issues
 
 Untrusted and review_gate sources produce `kind:knowledge-review` GitHub
 issues. Each issue body includes:
@@ -228,15 +228,17 @@ issues. Each issue body includes:
 - Trust class and review instructions
 - Text preview (first 500 chars) of the source content
 
-**Untrusted**: issues carry `needs-maintainer-review`. Approve with:
+**Untrusted**: issues carry `hold-for-review`. After inspecting the staged source, promote it with:
 
 ```bash
-sudo aidevops approve issue <N>
+knowledge-review-helper.sh promote <source-id>
 ```
 
-This triggers `knowledge-review-helper.sh promote <source-id>`, which moves
-the source from `_knowledge/staging/` to `_knowledge/sources/`, updates
-`meta.json` with `state: "promoted"`, and closes the issue.
+The command moves the source from `_knowledge/staging/` to
+`_knowledge/sources/`, updates `meta.json` with `state: "promoted"`, and writes
+the audit entry. Close the review issue after promotion succeeds. This is a
+content-safety hold, not an external-author authority gate, so no cryptographic
+self-approval is required.
 
 **Review-gate**: issues carry `auto-dispatch`. A worker reviews and can promote
 by calling the same `promote` subcommand.
@@ -251,12 +253,14 @@ Every action is appended to `_knowledge/index/audit.log` (JSONL):
 {"ts":"2026-04-27T12:00:00Z","action":"promoted","source_id":"ext-doc","actor":"maintainer","extra":"actor:maintainer path:approve_hook"}
 ```
 
-`_knowledge/index/` is gitignored — the audit log is local only.
+`_knowledge/index/` is gitignored — the audit log is local only. The legacy
+`nmr_filed` action/state name remains for compatibility with existing source
+metadata; newly filed issues use `hold-for-review`.
 
 ### Routine r040
 
 ```text
-- [x] r040 Knowledge review gate — classify inbox items by trust, auto-promote or NMR-file repeat:cron(*/15 * * * *) ~1m run:scripts/knowledge-review-helper.sh tick
+- [x] r040 Knowledge review gate — classify inbox items by trust, auto-promote or review-file repeat:cron(*/15 * * * *) ~1m run:scripts/knowledge-review-helper.sh tick
 ```
 
 To disable: change `[x]` to `[ ]` in `TODO.md` and commit.
@@ -267,7 +271,7 @@ To disable: change `[x]` to `[ ]` in `TODO.md` and commit.
 # Manual tick (same as r040 routine)
 ~/.aidevops/agents/scripts/knowledge-review-helper.sh tick
 
-# Explicit promotion (called automatically by approve hook)
+# Explicit promotion after reviewing staged content
 ~/.aidevops/agents/scripts/knowledge-review-helper.sh promote <source-id>
 
 # Manual audit entry

--- a/.agents/reference/attribution-monitoring.md
+++ b/.agents/reference/attribution-monitoring.md
@@ -57,7 +57,7 @@ Keep exact search strings private, but monitor for distinctive aidevops
 behaviour clusters as well as literal source strings:
 
 - prompt-injection scanning for issue, PR, web, MCP, and tool-output content;
-- `needs-maintainer-review` gates, NMR automation, and cryptographic approvals;
+- external-author `needs-maintainer-review` gates, trusted-author normalization, and cryptographic approvals;
 - interactive issue/PR locking through origin labels, active statuses, and claim stamps;
 - linked-worktree safety and pre-edit gates;
 - review-bot settlement gates before merge;

--- a/.agents/reference/auto-merge.md
+++ b/.agents/reference/auto-merge.md
@@ -94,7 +94,7 @@ ALL criteria must hold:
 
 1. PR carries the `origin:worker` label.
 2. Linked issue (via `Resolves #NNN` / `Closes #NNN` / `Fixes #NNN`) was authored by a user with `OWNER` or `MEMBER` association — **OR** the issue author's GitHub login is listed in `.agents/configs/trusted-issue-authors.conf` (t3062: peer runners trusted as operators, not external contributors) — **OR** the linked issue has a cryptographic approval signature (`aidevops:approval-signature:` in a comment body), proving a maintainer has personally vouched for the work with their SSH key (t3052).
-3. Linked issue never carried `needs-maintainer-review` OR NMR was cleared via **cryptographic** approval (`sudo aidevops approve issue N`), not via `auto_approve_maintainer_issues`.
+3. Neither the PR nor linked issue currently carries `needs-maintainer-review`. Historical NMR does not force an OWNER/MEMBER, authenticated write-authorized author, or trusted peer runner to self-approve; an external author satisfies criterion 2 only through verified cryptographic approval.
 4. All required status checks PASS or SKIPPED.
 5. No `CHANGES_REQUESTED` review from any reviewer with non-bot association.
 6. PR is **not a draft**.
@@ -114,17 +114,17 @@ The allowlist allows peer runners (separate machine/account, `COLLABORATOR` asso
 
 **Config file:** `.agents/configs/trusted-issue-authors.conf` — one GitHub login per line; `#` comments and blank lines ignored. Deployed copy: `~/.aidevops/agents/configs/trusted-issue-authors.conf`. Override path: `AIDEVOPS_TRUSTED_AUTHORS_CONF` env var.
 
-**What the allowlist bypasses:** the `OWNER`/`MEMBER` `author_association` check only. Everything else still applies: the NMR crypto-vs-auto gate (criterion 3), the feature flag, draft/hold-for-review/CHANGES_REQUESTED gates, and CI checks.
+**What the allowlist bypasses:** the `OWNER`/`MEMBER` `author_association` check only. Everything else still applies: the live NMR gate, feature flag, draft/hold-for-review/CHANGES_REQUESTED gates, and CI checks.
 
-**What it does NOT bypass:** A trusted-author issue that received `needs-maintainer-review` and was auto-approved (not crypto-cleared) still blocks — the closed-loop prevention from t2449 criterion 3 is independent of criterion 2.
+**What it does NOT bypass:** A live `needs-maintainer-review` label still blocks. Trusted-author legacy NMR is normalized without fabricating approval; external-author NMR requires verified cryptographic approval and label clearance.
 
-**Security posture:** Allowlist entries are local-trust grants from the maintainer of the runner machine. A rogue allowlist entry cannot bypass CI or NMR-crypto gates; it only relaxes the GitHub author_association check which is itself a proxy for maintainer trust.
+**Security posture:** Allowlist entries are local-trust grants from the maintainer of the runner machine. They cannot bypass CI, a live NMR gate, or PR-specific external merge authority; they only relax the GitHub author-association proxy.
 
-### Security Gate: NMR Crypto-vs-Auto Distinction (Criterion 3)
+### Security Gate: External-Author NMR Authority
 
-`auto_approve_maintainer_issues` runs as the pulse's own GitHub token — if auto-approval were accepted as NMR clearance, any review-scanner issue could auto-spawn a worker AND auto-merge without human touch (closed loop).
+`auto_approve_maintainer_issues` uses live issue-author authority as the invariant. A verified write-authorized author never self-approves: accidental automation residue is removed and an intentional review decision becomes `hold-for-review`, without posting an approval marker.
 
-Cryptographic approval (`sudo aidevops approve issue N`) requires the maintainer's root-protected SSH key, which workers cannot access — this is the only reliable human-in-the-loop signal.
+An external or unverifiable author remains gated. Cryptographic approval (`sudo aidevops approve issue N`) requires the maintainer's root-protected SSH key, which workers cannot access, and is the only authority signal that clears that external boundary.
 
 ### Author-Association Gate Crypto Bypass (t3063)
 
@@ -153,17 +153,15 @@ Symmetric extension of t3052 to the **deterministic merge cascade** — the `_ch
 
 Configured review-provider failures use `review_gate.advisory_check_contexts`. An exact named non-required failure is advisory only after the final trust gate reruns the read-only review helper and obtains typed `aidevops.review-gate-evidence/v1` for the exact PR head, a permitted author-class outcome, and resolved review threads. Duplicate maintainer-gate aliases are one audited family and remain blocking; all other check-run and commit-status sources retain independent failure identity.
 
-## NMR Automation Signatures (t2386, Split Semantics)
+## NMR Authority Normalization and Legacy Signatures
 
-The pulse runs as the maintainer's GitHub token, so `needs-maintainer-review` label events always record the maintainer as actor. `auto_approve_maintainer_issues` in `pulse-nmr-approval.sh` distinguishes three cases by comment markers:
+Current producers reserve `needs-maintainer-review` for external-author authority. Internal decisions use `hold-for-review`; machine-recoverable dependency, cost, stale-worker, and infrastructure failures use `status:blocked`, cooldowns, or root-cause meta-issues.
 
-- **Creation-default** (`source:review-scanner` comment marker, or `review-followup` / `source:review-scanner` label on issue) → scanner applied NMR by default at creation time; auto-approval CLEARS NMR so the issue can dispatch.
-- **Circuit-breaker trip** (`stale-recovery-tick:escalated`, `cost-circuit-breaker:fired`, `circuit-breaker-escalated` comment markers) → t2007/t2008 safety mechanism fired after retry/cost limit exceeded; auto-approval PRESERVES NMR. Clear with `sudo aidevops approve issue <N>` once the underlying problem is fixed.
-- **Manual hold** (no markers) → genuine maintainer decision to pause the issue; auto-approval PRESERVES NMR.
+`pulse-nmr-approval.sh` still recognizes historical scanner, breaker, and manual-hold signatures so pre-migration issues fail safely while being normalized. For a write-authorized author, it clears accidental/default residue or translates an intentional hold to `hold-for-review`; it never manufactures cryptographic approval. For an external or unverifiable author, NMR remains until valid cryptographic approval.
 
-**Background — why the split matters:** Pre-t2386, both automation cases were conflated. The result was the GH#19756 infinite loop: stale-recovery applied NMR → auto-approve stripped it → worker re-dispatched → crashed → stale-recovery re-applied NMR. 22 watchdog kills + 5 auto-approve cycles in one afternoon. The split prevents this by preserving NMR on circuit-breaker trips.
+Historical breaker signatures remain recognized to prevent the GH#19756 loop while old issues are reconciled. New breaker paths never use NMR, so clearing an author-authority gate cannot blind-redispatch an unresolved machine failure.
 
-Two helpers enforce the split: `_nmr_application_has_automation_signature` (creation defaults only) and `_nmr_application_is_circuit_breaker_trip` (breaker trips only). Regression test: `.agents/scripts/tests/test-pulse-nmr-automation-signature.sh::test_19756_loop_prevention_breaker_trip_preserves_nmr`.
+Compatibility helpers `_nmr_application_has_automation_signature` and `_nmr_application_is_circuit_breaker_trip` classify legacy events. New producer regressions must instead prove internal holds avoid NMR and preserve any independent live external gate.
 
 ## t3068 — Approval-Triggered Pulse Kick
 

--- a/.agents/reference/dispatch-blockers.md
+++ b/.agents/reference/dispatch-blockers.md
@@ -14,11 +14,11 @@ Applied to GitHub issues. The pulse checks these before spawning a worker.
 
 | Label | Enforced by | Rationale |
 |-------|-------------|-----------|
-| `parent-task` | `dispatch-dedup-helper.sh` `_is_assigned_check_parent_task` | Epics/trackers — children implement, not this issue. Cannot be overridden by NMR clearance (t2211). |
+| `parent-task` | `dispatch-dedup-helper.sh` `_is_assigned_check_parent_task` | Epics/trackers — children implement, not this issue. Permanent until explicitly removed; review-label normalization cannot override it (t2211). |
 | `meta` | Same as `parent-task` — treated as an alias | Alternative spelling of `parent-task`. |
 | `no-auto-dispatch` | `dispatch-dedup-helper.sh` `_is_assigned_check_no_auto_dispatch` (t2832), `issue-sync-lib.sh`, `interactive-session-helper.sh` lockdown | Durable explicit manual hold for issues. Blocks dispatch (`NO_AUTO_DISPATCH_BLOCKED`), ordinary/bulk/pulse enrich, and decomposition. Routine interactive ownership uses `status:in-review` + assignment instead. The explicit maintainer-only `issue-sync-helper.sh sync-body tNNN` exception can update only the authoritative body while continuously verifying the hold and all metadata; it cannot dispatch, change labels, or bypass a genuine claim. Applied by `interactive-session-helper.sh lockdown`. |
-| `hold-for-review` | `dispatch-dedup-helper.sh` `_is_assigned_check_hold_for_review`, `issue-sync-lib.sh`; PR merge checks below | Confirmed unresolved manual or security review hold. On issues, same dispatch-block intent as `no-auto-dispatch` (`HOLD_FOR_REVIEW_BLOCKED` signal). On PRs, blocks auto-merge until a maintainer removes the label. Scanner availability, temporary-file, input, and execution failures are infrastructure retries and must not apply this label. |
-| `needs-maintainer-review` | `pulse-nmr-approval.sh` `auto_approve_maintainer_issues` | Requires maintainer cryptographic approval (`sudo aidevops approve issue <N>`) before dispatch. |
+| `hold-for-review` | `dispatch-dedup-helper.sh` `_is_assigned_check_hold_for_review`, `issue-sync-lib.sh`; PR merge checks below | Confirmed unresolved internal, manual, policy, or security review hold. On issues, same dispatch-block intent as `no-auto-dispatch` (`HOLD_FOR_REVIEW_BLOCKED` signal). On PRs, blocks auto-merge until a maintainer removes the label. It does not represent missing author authority and needs no cryptographic self-approval. Scanner availability, temporary-file, input, and execution failures are infrastructure retries and must not apply this label. |
+| `needs-maintainer-review` | `pulse-nmr-approval.sh` `auto_approve_maintainer_issues`, external-author workflows | External-author authority gate. Authors without verified write authority require maintainer cryptographic approval (`sudo aidevops approve issue <N>`) before dispatch. Write-authorized authors never self-approve: intentional holds normalize to `hold-for-review`, accidental/automated residue is removed, and unknown authority fails closed. |
 | `needs-maintainer-permissions` | `worker-permission-helper.sh`, `dispatch-dedup-helper.sh`, `pulse-dispatch-core.sh`, candidate filters | Worker paused after requesting a capability outside its sandbox. Only the request-specific signed permission command clears this label; dispatch also verifies historical applications against the matching unexpired grant, so removing the label alone cannot bypass the hold. It is distinct from scope/trust approval. |
 | `needs-credentials` | `label-sync-helper.sh` SYSTEM_LABELS | Task requires credentials, API keys, or account access — cannot be completed by a headless worker autonomously. Add when the TODO entry has `#no-auto-dispatch` due to credential dependency. |
 | `persistent` | `pulse-issue-reconcile.sh` | Monitoring/tracking issue — must not be dispatched as a code task. |
@@ -26,7 +26,7 @@ Applied to GitHub issues. The pulse checks these before spawning a worker.
 | `contributor` | `pulse-issue-reconcile.sh` | Contributor health dashboard — pulse-managed, not a dispatch target. |
 | `quality-review` | `pulse-issue-reconcile.sh` | Daily quality review tracker — pulse-managed. |
 | `routine-tracking` | `pulse-issue-reconcile.sh` | Routine execution tracking — pulse skips these unconditionally. |
-| `status:blocked` | `dispatch-dedup-helper.sh` `_has_active_claim` | Blocked on incomplete dependent tasks (`blocked-by:` edges). |
+| `status:blocked` | `dispatch-dedup-helper.sh`, dependency and circuit-breaker recovery | Machine-recoverable structural block: incomplete dependencies, exhausted retry/cost limits, or infrastructure repair. Restore `status:available` only after the blocker is verified resolved. |
 
 Permission grants are limited to exact-pattern `bash` and `external_directory` requests, bound to the issue, request digest, worker session, branch, and worktree hash, and expire after four hours. Action-only permissions and credential-bearing or unbounded paths remain non-grantable.
 
@@ -103,7 +103,7 @@ To add a new label-level dispatch blocker:
 ## Cross-References
 
 - `reference/auto-dispatch.md` — combined signal rule (`(active status label) AND (non-self assignee)`) and full dispatch lifecycle
-- `reference/auto-merge.md` — auto-merge timing rules (t2411, t2449) and NMR semantics
+- `reference/auto-merge.md` — auto-merge timing rules (t2411, t2449) and external-author NMR semantics
 - `reference/parent-task-lifecycle.md` — `parent-task` label lifecycle in detail (t2442)
 - `reference/worker-diagnostics.md` — pre-dispatch eligibility gate (t2424) and circuit breakers
 - `.agents/scripts/dispatch-dedup-helper.sh` — `is-assigned` command and all layer checks

--- a/.agents/reference/gh-audit-log.md
+++ b/.agents/reference/gh-audit-log.md
@@ -152,7 +152,7 @@ Do not treat null snapshot fields as proof that content or labels were removed.
 - `status:claimed` — dispatched but not yet started
 - `origin:interactive` — human session ownership
 - `no-auto-dispatch` — explicit opt-out of pulse dispatch
-- `needs-maintainer-review` — human review gate in place
+- `needs-maintainer-review` — external-author authority gate in place
 
 **Normal causes:** Intentional state transitions (e.g., `status:in-review` → `status:done` on PR merge).
 

--- a/.agents/reference/parent-task-lifecycle.md
+++ b/.agents/reference/parent-task-lifecycle.md
@@ -2,7 +2,7 @@
 
 A `parent-task` label is a *permanent dispatch block* — it must be paired with a concrete decomposition plan, or it becomes backlog rot.
 
-**Key rule:** `#parent` is the only reliable dispatch block for maintainer-authored issues. Once a maintainer files with `#parent`, `auto_approve_maintainer_issues()` cannot override it via NMR clearance — `parent-task` short-circuits `dispatch-dedup-helper.sh is-assigned` with `PARENT_TASK_BLOCKED` upstream of the approval path. (t2211)
+**Key rule:** `#parent` is the permanent structural dispatch block for a roadmap or decomposition issue. Authority-label normalization cannot override it: `parent-task` short-circuits `dispatch-dedup-helper.sh is-assigned` with `PARENT_TASK_BLOCKED`. (t2211)
 
 ## Five Cooperating Enforcement Mechanisms
 
@@ -38,16 +38,16 @@ Per-parent state file (`AUTO_DECOMPOSER_PARENT_STATE`) prevents re-filing the sa
 
 Constants in `pulse-wrapper.sh`: `AUTO_DECOMPOSER_INTERVAL`, `AUTO_DECOMPOSER_PARENT_STATE`. Maintainer-only (skips `role: contributor` repos).
 
-### 5. 7-Day NMR Escalation (Fix #4)
+### 5. 7-Day Advisory Escalation (Fix #4)
 
-If the advisory nudge is ≥7 days old and still zero children exist, `_post_parent_decomposition_escalation` applies `needs-maintainer-review` and posts a comment listing the four paths forward:
+If the advisory nudge is ≥7 days old and still zero children exist, `_post_parent_decomposition_escalation` posts an idempotent advisory comment listing the four paths forward:
 
 1. Decompose into children
 2. Drop the `parent-task` label
 3. Close the issue
 4. Let the auto-decomposer handle it
 
-**Escalation never removes `parent-task`** — that would defeat the only reliable dispatch block (per t2211). The label removal instruction appears only as user-facing guidance inside a markdown code fence.
+The escalation adds no second blocker: `parent-task` already blocks direct implementation and must remain visible to the auto-decomposer. It never removes `parent-task`; the label removal instruction appears only as user-facing guidance inside a markdown code fence.
 
 Env override: `PARENT_DECOMPOSITION_ESCALATION_HOURS` (default 168). Capped at `max_escalations` per reconcile pass. Dedup via `<!-- parent-needs-decomposition-escalated -->` marker.
 
@@ -119,7 +119,7 @@ The `<!-- phase-auto-fire:on -->` HTML comment is the opt-in for narrative phase
 
 ### Close Guard
 
-The close guard (t2755 Phase 2) prevents premature parent-task closure while any declared phase is still unfiled or open. If a PR uses a closing keyword (`Closes #NNN`) on a parent-task issue that still has pending phases, the merge is accepted but the issue is re-opened with an explanatory comment.
+The close guard (t2755 Phase 2) prevents premature parent-task closure while any declared phase is still unfiled or open. If a PR uses a closing keyword (`Closes #NNN`) on a parent-task issue that still has pending phases, the merge is accepted but the issue is re-opened with an explanatory comment. Deterministic incomplete close-contract repairs use `hold-for-review`; the ordinary 7-day decomposition escalation remains advisory-only.
 
 ## Use Cases
 

--- a/.agents/reference/progressive-disclosure.md
+++ b/.agents/reference/progressive-disclosure.md
@@ -105,7 +105,7 @@ for f in files:
 
 | File | Contents | When to Load |
 |------|----------|--------------|
-| `reference/auto-merge.md` | Full t2411/t2449 criteria + NMR split semantics | Working on PR merge rules or debugging auto-merge behaviour |
+| `reference/auto-merge.md` | Full t2411/t2449 criteria + external-author NMR semantics | Working on PR merge rules or debugging auto-merge behaviour |
 | `reference/auto-dispatch.md` | Origin labels, dedup signal, #auto-dispatch mechanics, issue-sync auto-completion | Debugging dispatch blocks, changing origin labels |
 | `reference/parent-task-lifecycle.md` | 5 decomposition enforcement mechanisms | Working with parent-task labeled issues |
 | `reference/repos-json-fields.md` | Full repos.json field reference | Adding/editing repo registration |

--- a/.agents/reference/task-lifecycle.md
+++ b/.agents/reference/task-lifecycle.md
@@ -11,7 +11,7 @@ When to load:
 - Deciding whether a task should be auto-dispatched, parent-blocked, or implemented interactively.
 - Updating task completion state or linking verification evidence.
 - Creating tasks in another registered repo or editing `repos.json`.
-- Diagnosing issue/PR lifecycle labels, origin labels, auto-merge eligibility, cryptographic approvals, or NMR automation.
+- Diagnosing issue/PR lifecycle labels, origin labels, auto-merge eligibility, cryptographic approvals, or external-author NMR normalization.
 
 For prompt-economy reasons these rules live here rather than in always-on AGENTS.md context. The pointer in AGENTS.md (`## Task Lifecycle`) names the key lifecycle topics so a `grep` in AGENTS.md still finds this forwarding address.
 
@@ -138,7 +138,7 @@ routine uncertainty into `#no-auto-dispatch`.
 
 **Auto-merge timing (t2411/GH#23238):** `origin:interactive` PRs from `OWNER`/`MEMBER` auto-merge only when CI passes, no CHANGES_REQUESTED, not draft, no `hold-for-review`, and merge throughput is explicitly opted in by `allow-auto-merge`, `AIDEVOPS_INTERACTIVE_PR_AUTO_MERGE=1`, global `orchestration.interactive_pr_auto_merge=true`, or per-repo `repos.json` `interactive_pr_auto_merge=true`. Default is manual/draft. `/pr-loop` or an explicit finalise/ready request is the normal signal to make a draft PR ready. Full checklist and user preference precedence: `reference/auto-merge.md`.
 
-**Auto-merge timing (t2449, t3052, t3062) — `origin:worker` (worker-briefed):** `origin:worker` PRs auto-merge when the linked issue was filed by `OWNER`/`MEMBER` OR the issue author login is in the trusted-issue-author allowlist (`.agents/configs/trusted-issue-authors.conf`, t3062) OR the linked issue has a cryptographic approval signature from a maintainer (`sudo aidevops approve issue N`), NMR was never applied OR was cleared via **cryptographic** approval (not `auto_approve_maintainer_issues`), and CI passes. Feature flag: `AIDEVOPS_WORKER_BRIEFED_AUTO_MERGE` (default 1=on). Full 9-criterion checklist + security rationale: `reference/auto-merge.md`.
+**Auto-merge timing (t2449, t3052, t3062) — `origin:worker` (worker-briefed):** `origin:worker` PRs auto-merge when the linked issue was filed by `OWNER`/`MEMBER`, its author has authenticated write authority, its author is in the trusted-issue-author allowlist (`.agents/configs/trusted-issue-authors.conf`, t3062), OR the linked issue has verified cryptographic maintainer approval (`sudo aidevops approve issue N`); no live NMR/hold gate remains; and CI passes. Historical NMR does not force a trusted author to self-approve. Feature flag: `AIDEVOPS_WORKER_BRIEFED_AUTO_MERGE` (default 1=on). Full 9-criterion checklist + security rationale: `reference/auto-merge.md`.
 
 **Admin merge authority:** Interactive sessions run as the repo admin/owner. For maintainer-owned or maintainer-approved work (`OWNER`/`MEMBER` PR author, maintainer-authored linked issue, trusted issue author, or valid crypto approval), `REVIEW_REQUIRED`, stale branch-protection state, or a self-blocking framework gate is not a user-action blocker once non-gate CI is green and no human `CHANGES_REQUESTED` review exists. Use `gh pr merge <N> --repo <slug> --admin --squash --delete-branch` when needed and record the evidence. Only keep the merge gated when the issue/PR originates from a non-maintainer and lacks cryptographic maintainer approval.
 
@@ -158,9 +158,9 @@ Architecture: `dispatch_with_dedup` → `check_dispatch_dedup` Layer 6 is the ca
 
 Use for: decomposition epics, roadmap trackers, research summaries. **Do not use for:** issues that should be implemented as a single unit.
 
-**Maintainer-authored research tasks MUST use `#parent` (t2211):** if a maintainer files an issue without `#auto-dispatch` and it later escalates to `needs-maintainer-review` (e.g. because a worker picked it up anyway via stale-recovery or a TODO-first flow), `auto_approve_maintainer_issues()` at `pulse-nmr-approval.sh:468-470` unconditionally adds the `auto-dispatch` label when removing NMR. Body prose like "Do NOT `#auto-dispatch`" is silently overridden — the auto-approval path intentionally converts NMR'd maintainer-authored issues into dispatchable ones (approver intent wins). `#parent` is the only reliable dispatch block in this case because its `parent-task` label short-circuits `dispatch-dedup-helper.sh is-assigned` with `PARENT_TASK_BLOCKED` upstream of the approval path. Practical rule: any investigation, research, or "think-before-acting" issue the maintainer files should carry `#parent` from the start.
+**Maintainer-authored roadmap/research tasks use `#parent` (t2211):** `parent-task` is the permanent structural dispatch block for work implemented only through children. It short-circuits `dispatch-dedup-helper.sh is-assigned` with `PARENT_TASK_BLOCKED`, independent of authority-label normalization. Use `no-auto-dispatch` for a durable explicit manual stop on a normal issue and `hold-for-review` for a specific unresolved decision; body prose alone is not a dispatch block.
 
-**Parent-task decomposition lifecycle (t2442):** A `parent-task` label must be paired with a decomposition plan or it becomes backlog rot. Five cooperating enforcement mechanisms: no-markers warning at creation, prose-pattern child extraction, advisory nudge (posted on next pulse cycle after ≥4h, env `PARENT_TASK_NUDGE_SECONDS`), auto-decomposer scanner (every pulse cycle, 4h nudge-age threshold, 4h re-file gate, env `PARENT_TASK_REFILE_GATE_SECONDS`), and 7-day NMR escalation. Escalation never removes `parent-task`. Full detail: `reference/parent-task-lifecycle.md`.
+**Parent-task decomposition lifecycle (t2442):** A `parent-task` label must be paired with a decomposition plan or it becomes backlog rot. Five cooperating enforcement mechanisms: no-markers warning at creation, prose-pattern child extraction, advisory nudge (posted on next pulse cycle after ≥4h, env `PARENT_TASK_NUDGE_SECONDS`), auto-decomposer scanner (every pulse cycle, 4h nudge-age threshold, 4h re-file gate, env `PARENT_TASK_REFILE_GATE_SECONDS`), and a 7-day advisory escalation. Escalation never removes `parent-task` or adds a redundant blocker. Deterministic incomplete close-contract repairs separately use `hold-for-review`. Full detail: `reference/parent-task-lifecycle.md`.
 
 Completion: NEVER mark `[x]` without merged PR (`pr:#NNN`) or `verified:YYYY-MM-DD`. Use `task-complete-helper.sh`. Every completed task must link to its verification evidence — work without an audit trail is unverifiable and may be reverted.
 
@@ -205,13 +205,10 @@ Full rules: `reference/planning-detail.md`
 
 For multi-runner coordination (concurrent pulse runners across machines), see `reference/cross-runner-coordination.md`.
 
-## Cryptographic approval and NMR automation
+## Cryptographic approval and review-block semantics
 
 **Cryptographic issue/PR approval (human-only gate):** `sudo aidevops approve issue <number> [owner/repo]` — SSH-signed approval comment; workers cannot forge it (private key is root-only). Setup once with `sudo aidevops approve setup`. Verify: `aidevops approve verify <number>`. This is distinct from the `ai-approved` label (which is a simple collaborator gate, not cryptographic).
 
-**NMR automation signatures (t2386, split semantics):** `auto_approve_maintainer_issues` in `pulse-nmr-approval.sh` distinguishes three cases:
-- **Creation-default** (`source:review-scanner` marker/label) → auto-approval CLEARS NMR so the issue can dispatch.
-- **Circuit-breaker trip** (`stale-recovery-tick:escalated`, `cost-circuit-breaker:fired` markers) → auto-approval PRESERVES NMR. Clear with `sudo aidevops approve issue <N>` once the problem is fixed.
-- **Manual hold** (no markers) → auto-approval PRESERVES NMR.
+**Canonical split:** `needs-maintainer-review` means missing external-author authority and requires cryptographic approval. `hold-for-review` means an internal/manual content, policy, architecture, or security decision and is removed explicitly after review. `status:blocked`, cooldown state, or a root-cause meta-issue represents a machine-recoverable structural/circuit-breaker failure.
 
-Background and infinite-loop root cause (t2386): `reference/auto-merge.md` (NMR section).
+`auto_approve_maintainer_issues` verifies live author authority. Write-authorized authors never self-approve: legacy accidental NMR is cleared, intentional NMR becomes `hold-for-review`, and no synthetic approval marker is posted. Unknown authority fails closed. Legacy automation signatures remain recognized only for safe migration and loop prevention; full rationale: `reference/auto-merge.md`.

--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -87,7 +87,7 @@ Stale recovery is globally bounded by the GitHub-backed recovery markers. The
 default threshold of two includes silent/phantom assignments: a stale timeout is
 itself terminal no-progress evidence even when a crashed launcher omitted its
 terminal marker. The first recovery emits one combined recovery/tick comment;
-the second applies `needs-maintainer-review`. An open PR is durable progress, so
+the second applies machine-recoverable `status:blocked`. An open PR is durable progress, so
 stale recovery preserves its ownership and emits no synthetic reset comment.
 
 ## Progress-Blocker Evidence
@@ -491,7 +491,7 @@ CLAIM_RELEASED reason=launch_recovery:no_worker_process runner=<login> ts=<ISO>
 **Mitigation already in place**:
 - After 3 consecutive `no_worker_process` failures in a round, the canary cache is invalidated — next dispatch re-runs the canary to detect broken runtimes.
 - `no_worker_process` failures are classified as `crash_type=no_work` (t2815) — cascade tier escalation is **skipped** (t2387). The issue retries at the same tier so the next attempt runs cheaply once the infrastructure issue clears.
-- After `NO_WORK_NMR_THRESHOLD` (default 3) consecutive infra failures per issue, the per-issue no_work circuit breaker (t2769) applies `needs-maintainer-review` with a `cost-circuit-breaker:no_work_loop` marker.
+- After `NO_WORK_NMR_THRESHOLD` (legacy variable name; default 3) consecutive infra failures per issue, the per-issue no_work circuit breaker (t2769) applies `status:blocked`, posts the backward-compatible `cost-circuit-breaker:no_work_loop` marker, and files a root-cause meta-issue.
 - `fast_fail_record` increments the per-issue failure counter for backoff.
 
 **Diagnostic**:
@@ -624,8 +624,8 @@ However, the more impactful failure mode is the canary FAILING (Path 1), not pas
 `crash_type=no_work` before calling `fast_fail_record`. This routes through the t2387
 infra-failure guard in `escalate_issue_tier`, which skips tier escalation and keeps
 the issue at its current tier. Same-tier retry applies; after `NO_WORK_NMR_THRESHOLD`
-(default 3) consecutive failures the t2769 no_work circuit breaker applies
-`needs-maintainer-review`. The cascade no longer fires on infrastructure failures where
+(legacy variable name; default 3) consecutive failures the t2769 no_work circuit breaker applies
+`status:blocked` and files a root-cause meta-issue. The cascade no longer fires on infrastructure failures where
 the worker never spawned.
 
 #### Diagnostic gap (the core infrastructure finding)
@@ -742,7 +742,7 @@ and no explicit `crash_type` was provided, the effective crash type is now force
 This routes through the t2387 infra-failure guard in `escalate_issue_tier`, which skips tier
 escalation entirely. Observable change:
 - Before: 2 consecutive `no_worker_process` → tier:standard upgraded to tier:thinking → opus dispatch → same infra failure.
-- After: 2 consecutive `no_worker_process` → same-tier retry (no tier change). After `NO_WORK_NMR_THRESHOLD` (default 3) failures, the t2769 no_work circuit breaker applies `needs-maintainer-review`.
+- After: 2 consecutive `no_worker_process` → same-tier retry (no tier change). After `NO_WORK_NMR_THRESHOLD` (legacy variable name; default 3) failures, the t2769 no_work circuit breaker applies `status:blocked` and files a root-cause meta-issue.
 
 **Crash type classification for `recover_failed_launch_state`**:
 
@@ -864,7 +864,7 @@ After worktree pre-creation, `pulse-dispatch-worker-launch.sh` calls `dispatch-d
 
 The hold is branch-specific: a different branch or a different issue does not inherit the count. Triage the diagnostic by running the suggested `gh pr list --head <branch>` command; if the branch already has the intended PR, link/merge it, otherwise remove or reset the stale issue-linked worktree/branch so a fresh branch can dispatch.
 
-If the issue later shows repeated `<!-- aidevops-signed-approval -->` comments followed by fresh `needs-maintainer-review` labels but no new breaker comment, treat it as the same unresolved recovery episode. `pulse-nmr-approval.sh` preserves NMR from prior breaker history across marker-less relabels and only allows one automatic retry for the breaker-version lineage after a newer aidevops release; later unrelated patch releases stay held until `sudo aidevops approve issue <N> <repo>` after inspecting the branch/worktree evidence.
+Current orphan-loop recovery uses `status:blocked`; the root-cause repair or an operator who has inspected preserved branch/worktree evidence restores `status:available`. Legacy issues may still show signed-approval/NMR cycles from pre-migration releases. Treat those labels as compatibility evidence, normalize trusted-author residue without self-approval, and never use authority approval as a substitute for fixing the unresolved machine failure.
 
 ## GitHub API Budget, Instrumentation, and Cache Priming
 

--- a/.agents/reference/worker-discipline.md
+++ b/.agents/reference/worker-discipline.md
@@ -31,9 +31,9 @@ When dispatched against an auto-generated issue body (review-followup, quality-d
 
 - **A. Premise falsified → close the issue** with a `> Premise falsified. <claim>. <code reality>. Not acting.` rationale comment. No PR. The closing comment trains the next session and the noise filter.
 - **B. Premise correct + obvious fix → implement and PR** with normal lifecycle gate (`Resolves #<this-issue>`).
-- **C. Premise correct but genuinely ambiguous** (architecture / policy / breaking change the worker cannot resolve autonomously) → post a decision comment containing: **Premise check** (one line), **Analysis** (2-4 bullets on trade-offs), **Recommended path** (what you would do if the call were yours, with rationale), **Specific question** (yes/no or pick-one — not open-ended). Then apply `needs-maintainer-review` and stop. The human wakes up to a ready-to-approve recommendation, not a blank task.
+- **C. Premise correct but genuinely ambiguous** (architecture / policy / breaking change the worker cannot resolve autonomously) → post a decision comment containing: **Premise check** (one line), **Analysis** (2-4 bullets on trade-offs), **Recommended path** (what you would do if the call were yours, with rationale), **Specific question** (yes/no or pick-one — not open-ended). Then apply `hold-for-review` and stop. The human wakes up to a decision-ready recommendation, not a blank task. `needs-maintainer-review` is reserved for missing external-author authority.
 
-Ambiguity about scope or style is NOT Outcome C. Applying `needs-maintainer-review` at issue creation time — the "punt analysis to a human who hands it back to an AI" anti-pattern — is forbidden. Reasoning responsibility applies here too: you do the thinking.
+Ambiguity about scope or style is NOT Outcome C. Applying any review hold at issue creation time merely to punt analysis to a human is forbidden. Reasoning responsibility applies here too: you do the thinking.
 
 ## Worker scope enforcement (t1894)
 

--- a/.agents/scripts/auto-decomposer-scanner.sh
+++ b/.agents/scripts/auto-decomposer-scanner.sh
@@ -489,7 +489,7 @@ that existed when this issue was filed.
   requires an architectural / policy / breaking-change decision you
   cannot resolve autonomously: post a decision comment with
   **Premise check**, **Analysis**, **Recommended path**, and
-  **Specific question**, then apply \`needs-maintainer-review\`.
+  **Specific question**, then apply \`hold-for-review\`.
   Ambiguity about scope or style is NOT Outcome C.
 MD
 	return 0

--- a/.agents/scripts/circuit-breaker-meta-filer.sh
+++ b/.agents/scripts/circuit-breaker-meta-filer.sh
@@ -5,9 +5,8 @@
 # circuit breakers (t2007 cost, t2769 no_work) trip (t3076).
 #
 # Background:
-#   The existing breakers halt dispatch and apply needs-maintainer-review.
-#   NMR is a maintainer-queue dead-end — it surfaces the problem but does
-#   not move it forward. This helper turns each trip into a self-healing
+#   The existing breakers halt dispatch with status:blocked. This helper turns
+#   each trip into a self-healing
 #   cycle:
 #
 #     breaker fires → forensics gathered → meta-issue filed with hypothesis
@@ -59,8 +58,8 @@
 #
 # Released by:
 #   - pulse-merge.sh               (when meta-PR merges, removes blocked-by
-#                                  on the original; clears NMR if no other
-#                                  breaker markers remain)
+#                                  on the original; restores status:available
+#                                  if no other blockers remain)
 
 set -uo pipefail
 
@@ -285,7 +284,7 @@ The breaker tripping is the SYMPTOM. This issue is for finding and fixing the RO
 
 ## Why
 
-The existing breaker (\`${breaker_label}\`) halts dispatch and applies \`needs-maintainer-review\` on the original, but does not move the underlying problem forward. NMR is a maintainer-queue dead-end. Filing this meta-issue converts the trip into a self-healing cycle: forensics → hypothesis → fix → original unblocks automatically.
+The existing breaker (\`${breaker_label}\`) halts dispatch with \`status:blocked\` on the original. Filing this meta-issue converts the trip into a self-healing cycle: forensics → hypothesis → fix → original unblocks automatically.
 
 The original (#${issue_number}) gets a \`blocked-by\` label pointing at this meta-issue and clears automatically when this meta-issue's PR merges (handled by \`pulse-merge.sh::_unblock_circuit_breaker_meta_original\`).
 
@@ -357,8 +356,8 @@ Treat the original (#${issue_number}) as evidence, not as the work to do. The wo
 
 ### Reference pattern
 
-- Existing breaker NMR application paths in \`worker-lifecycle-common.sh\` (no_work) and \`dispatch-dedup-cost.sh\` (cost) for the trip → label → comment flow that this filer hooks into.
-- \`pulse-nmr-approval.sh::_nmr_application_is_circuit_breaker_trip\` for the marker-recognition pattern (this filer's marker \`${_CB_META_MARKER}\` is also recognised).
+- Existing structural breaker paths in \`worker-lifecycle-common.sh\` (no_work) and \`dispatch-dedup-cost.sh\` (cost) for the trip → \`status:blocked\` → comment flow that this filer hooks into.
+- \`pulse-nmr-approval.sh::_nmr_application_is_circuit_breaker_trip\` only for backward-compatible recognition of pre-migration NMR episodes (this filer's marker \`${_CB_META_MARKER}\` is also recognised).
 
 ### Forensics: pulse log slice (last ${max_lines} lines mentioning the issue)
 
@@ -377,7 +376,7 @@ ${stages_slice:-(no matching stage records)}
 1. Root cause identified and named explicitly in the PR description (which file/function/race).
 2. Fix lands as a normal PR with \`Resolves #<this>\` (NOT \`Resolves #${issue_number}\` — this meta-issue is the unit of work, the original is downstream).
 3. PR merge automatically removes the meta blocker label that points from the original issue to this meta-issue via \`_unblock_circuit_breaker_meta_original\`.
-4. If no other circuit-breaker markers remain on #${issue_number}, NMR is also cleared automatically.
+4. If no other \`blocked-by:*\` labels remain on #${issue_number}, \`status:available\` is restored automatically.
 5. A regression test exists for the specific failure mode identified (test in \`.agents/scripts/tests/\`).
 
 ### Verification
@@ -385,7 +384,7 @@ ${stages_slice:-(no matching stage records)}
 \`\`\`bash
 # After the fix lands and #${issue_number} unblocks, dispatch should proceed normally:
 gh issue view ${issue_number} --repo ${repo_slug} --json labels --jq '[.labels[].name]'
-# Expect: no needs-maintainer-review, no blocked-by label for the meta-issue
+# Expect: status:available and no blocked-by label for the meta-issue
 
 # Re-run the regression tests:
 bash .agents/scripts/tests/test-circuit-breaker-meta-filer.sh
@@ -493,8 +492,17 @@ _cb_meta_link_original() {
 	# unblock independently (matches t2442 parent-task linkage style).
 	local blocked_label
 	blocked_label=$(_cb_meta_blocked_label "$repo_slug" "$meta_repo" "$meta_number")
-	gh issue edit "$original_issue" --repo "$repo_slug" \
-		--add-label "$blocked_label" 2>/dev/null || true
+	if ! set_issue_status "$original_issue" "$repo_slug" "blocked" \
+		--add-label "$blocked_label" >/dev/null 2>&1; then
+		gh issue edit "$original_issue" --repo "$repo_slug" \
+			--remove-label "status:available" \
+			--remove-label "status:queued" \
+			--remove-label "status:claimed" \
+			--remove-label "status:in-progress" \
+			--remove-label "status:in-review" \
+			--add-label "status:blocked" \
+			--add-label "$blocked_label" >/dev/null 2>&1 || true
+	fi
 
 	local tracking_ref="#${meta_number}"
 	if [[ "$repo_slug" != "$meta_repo" ]]; then
@@ -511,7 +519,7 @@ The **${breaker_label}** breaker tripped after ${failure_count} consecutive fail
 
 → Tracking: ${tracking_ref}
 
-This issue is now \`${blocked_label}\` and will unblock automatically when the meta-issue's PR merges. NMR will also clear if no other breaker markers remain.
+This issue is now \`status:blocked\` by \`${blocked_label}\` and will unblock automatically when the meta-issue's PR merges.
 
 _Auto-filed by \`circuit-breaker-meta-filer.sh\` (t3076). Set \`AIDEVOPS_CIRCUIT_BREAKER_META_FILE_DISABLE=1\` to suppress._"
 
@@ -685,45 +693,27 @@ _cb_meta_extract_original() {
 }
 
 #######################################
-# Check whether any OTHER circuit-breaker trip markers remain in the
-# original issue's comments. Used to decide whether NMR can be cleared
-# alongside the blocked-by label removal.
-#
-# Markers checked:
-#   cost-circuit-breaker:fired
-#   cost-circuit-breaker:no_work_loop
-#   stale-recovery-tick:escalated
-#   circuit-breaker-escalated
-#
-# Args: $1=original_issue, $2=repo_slug, $3=meta_number_to_ignore
-# Returns: 0 if other markers remain, 1 if none remain (NMR safe to clear)
+# Check whether any current blocked-by label remains after one meta fix merges.
+# Immutable historical comments cannot represent current blocker state.
+# Args: $1=original_issue, $2=repo_slug
+# Returns: 0 if another blocker remains, 1 if dispatch may be restored
 #######################################
-_cb_meta_other_markers_remain() {
+_cb_meta_other_blockers_remain() {
 	local original_issue="$1"
 	local repo_slug="$2"
-
-	local comments
-	comments=$(gh api "repos/${repo_slug}/issues/${original_issue}/comments" \
-		--paginate 2>/dev/null) || return 0
-
-	local hits
-	hits=$(printf '%s' "$comments" |
-		jq -r '.[].body // ""' 2>/dev/null |
-		grep -cE '(cost-circuit-breaker:(fired|no_work_loop)|stale-recovery-tick:escalated|circuit-breaker-escalated)' \
-			2>/dev/null) || hits=0
-	[[ "$hits" =~ ^[0-9]+$ ]] || hits=0
-
-	# We expect at least one trip marker (the one this meta-issue resolved).
-	# More than one means another breaker also tripped and is still
-	# unresolved — keep NMR.
-	[[ "$hits" -gt 1 ]] && return 0
+	local blocked_count=""
+	blocked_count=$(gh issue view "$original_issue" --repo "$repo_slug" \
+		--json labels --jq '[.labels[]?.name | select(startswith("blocked-by:"))] | length' \
+		2>/dev/null) || return 0
+	[[ "$blocked_count" =~ ^[0-9]+$ ]] || return 0
+	[[ "$blocked_count" -gt 0 ]] && return 0
 	return 1
 }
 
 #######################################
 # Unblock an original issue when its meta-issue's PR has merged.
-# Removes the blocked-by label for the meta; if no other breaker markers remain,
-# also clears needs-maintainer-review and posts an unblock comment.
+# Removes the blocked-by label for the meta; if no other current blocker labels
+# remain, restores status:available and posts an unblock comment.
 # Idempotent — second call is a no-op.
 #
 # Args: $1=meta_issue_number, $2=repo_slug
@@ -779,11 +769,11 @@ cmd_unblock_on_merge() {
 			--remove-label "blocked-by:#${meta_number}" 2>/dev/null || true
 	fi
 
-	local nmr_cleared="no"
-	if ! _cb_meta_other_markers_remain "$original_issue" "$original_repo"; then
-		gh issue edit "$original_issue" --repo "$original_repo" \
-			--remove-label "needs-maintainer-review" 2>/dev/null || true
-		nmr_cleared="yes"
+	local dispatch_released="no"
+	if ! _cb_meta_other_blockers_remain "$original_issue" "$original_repo"; then
+		if set_issue_status "$original_issue" "$original_repo" "available" 2>/dev/null; then
+			dispatch_released="yes"
+		fi
 	fi
 
 	gh_issue_comment "$original_issue" --repo "$original_repo" \
@@ -792,13 +782,13 @@ cmd_unblock_on_merge() {
 
 The meta-issue ${repo_slug}#${meta_number} (which was diagnosing the breaker trip on this issue) has merged its fix. \`${blocked_label}\` has been removed.
 
-NMR cleared: **${nmr_cleared}** _(no other breaker markers remained)_.
+Dispatch released: **${dispatch_released}** _(no other \`blocked-by:*\` labels remained)_.
 
 If dispatch should now proceed, the next pulse cycle will pick this up.
 
 _Auto-released by \`circuit-breaker-meta-filer.sh\` (t3076) via \`pulse-merge.sh::_handle_post_merge_actions\`._" 2>/dev/null || true
 
-	log_success "[circuit-breaker-meta-filer] unblocked ${original_repo}#${original_issue} (meta=${repo_slug}#${meta_number}, nmr_cleared=${nmr_cleared})" >&2
+	log_success "[circuit-breaker-meta-filer] unblocked ${original_repo}#${original_issue} (meta=${repo_slug}#${meta_number}, dispatch_released=${dispatch_released})" >&2
 	return 0
 }
 

--- a/.agents/scripts/dispatch-backoff-helper.sh
+++ b/.agents/scripts/dispatch-backoff-helper.sh
@@ -19,7 +19,7 @@
 #   1        | 5 min  (300s)   — single fluke; retry quickly
 #   2        | 30 min (1800s)  — pattern emerging; cool off
 #   3        | 2h     (7200s)  — systemic; wait for capacity recovery
-#   4+       | 24h    (86400s) — apply needs-maintainer-review too
+#   4+       | 24h    (86400s) — one-shot extended-cooldown notice
 #
 # Subcommands:
 #   check <issue_num> [<slug>]  — exit 0 if clear, exit 1 if cooldown active,
@@ -40,7 +40,7 @@
 #   DISPATCH_BACKOFF_METRICS_FILE     — path to headless-runtime-metrics.jsonl
 #                                       (default: ~/.aidevops/logs/headless-runtime-metrics.jsonl)
 #   DISPATCH_BACKOFF_LOOKBACK_SECS    — how far back to count failures (default 604800 = 7 days)
-#   DISPATCH_BACKOFF_NMR_THRESHOLD    — failure count at which to request NMR (default 4)
+#   DISPATCH_BACKOFF_NMR_THRESHOLD    — legacy-named threshold for the extended cooldown notice (default 4)
 #   DISPATCH_PROVIDER_BACKOFF_WINDOW_SECS — provider/model pressure window (default 900 = 15 min)
 #   DISPATCH_PROVIDER_BACKOFF_THRESHOLD   — rate_limit count that trips pressure cooldown (default 6)
 #   DISPATCH_PROVIDER_BACKOFF_COOLDOWN_SECS — provider/model cooldown after last event (default 300 = 5 min)
@@ -49,8 +49,8 @@
 # Integration:
 #   Sourced by pulse-dispatch-engine.sh. The check_dispatch_backoff() function
 #   is called in _dispatch_should_skip_candidate() after fast_fail_is_skipped().
-#   For NMR application (failure >= threshold), the caller reads the "NMR_REQUIRED"
-#   marker from stderr and applies the label via gh.
+#   At the extended-notice threshold, the caller reads BACKOFF_NOTICE_REQUIRED
+#   and posts a one-shot diagnostic. The cooldown remains the dispatch block.
 #
 # Counter:
 #   dispatch_backoff_skipped in ~/.aidevops/logs/pulse-stats.json
@@ -79,14 +79,14 @@ LOGFILE="${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}"
 # Configuration (overridable via environment).
 DISPATCH_BACKOFF_METRICS_FILE="${DISPATCH_BACKOFF_METRICS_FILE:-${HOME}/.aidevops/logs/headless-runtime-metrics.jsonl}"
 DISPATCH_BACKOFF_LOOKBACK_SECS="${DISPATCH_BACKOFF_LOOKBACK_SECS:-604800}"  # 7 days
-DISPATCH_BACKOFF_NMR_THRESHOLD="${DISPATCH_BACKOFF_NMR_THRESHOLD:-4}"       # 4+ failures → NMR
+DISPATCH_BACKOFF_NMR_THRESHOLD="${DISPATCH_BACKOFF_NMR_THRESHOLD:-4}"       # legacy name: 4+ failures → extended notice
 DISPATCH_PROVIDER_BACKOFF_WINDOW_SECS="${DISPATCH_PROVIDER_BACKOFF_WINDOW_SECS:-900}"
 DISPATCH_PROVIDER_BACKOFF_THRESHOLD="${DISPATCH_PROVIDER_BACKOFF_THRESHOLD:-6}"
 DISPATCH_PROVIDER_BACKOFF_COOLDOWN_SECS="${DISPATCH_PROVIDER_BACKOFF_COOLDOWN_SECS:-300}"
 : "${AIDEVOPS_RATE_LIMIT_RELEASE_CIRCUIT_OVERRIDE:=0}"
 
 # Backoff intervals in seconds (indexed by failure count; index 0 unused).
-# Index >= NMR_THRESHOLD uses the last entry (86400 = 24h).
+# Index >= the extended-notice threshold uses the last entry (86400 = 24h).
 readonly _BACKOFF_SCHEDULE=(0 300 1800 7200 86400)  # [0]=unused [1]=5m [2]=30m [3]=2h [4+]=24h
 
 # Log prefix for all messages from this module.
@@ -479,15 +479,15 @@ check_dispatch_backoff() {
 			date -d "@${next_eligible}" '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || \
 			printf 'epoch:%s' "$next_eligible")
 
-		local nmr_flag=""
+		local notice_flag=""
 		if [[ "$count" -ge "$DISPATCH_BACKOFF_NMR_THRESHOLD" ]]; then
-			nmr_flag=" NMR_REQUIRED"
+			notice_flag=" BACKOFF_NOTICE_REQUIRED"
 		fi
 
 		printf 'BACKOFF_ACTIVE reason=rate_limit_cooldown count=%s cooldown=%ss wait=%ss next=%s%s\n' \
-			"$count" "$cooldown_secs" "$wait_remaining" "$next_human" "$nmr_flag" >&2
+			"$count" "$cooldown_secs" "$wait_remaining" "$next_human" "$notice_flag" >&2
 
-		echo "${_DB_LOG_PREFIX} BACKOFF_ACTIVE #${issue_number} (${repo_slug}) count=${count} cooldown=${cooldown_secs}s wait=${wait_remaining}s next=${next_human}${nmr_flag}" >>"$LOGFILE"
+		echo "${_DB_LOG_PREFIX} BACKOFF_ACTIVE #${issue_number} (${repo_slug}) count=${count} cooldown=${cooldown_secs}s wait=${wait_remaining}s next=${next_human}${notice_flag}" >>"$LOGFILE"
 
 		# Increment stats counter.
 		if declare -F pulse_stats_increment >/dev/null 2>&1; then
@@ -503,11 +503,11 @@ check_dispatch_backoff() {
 }
 
 #######################################
-# Apply needs-maintainer-review to an issue when rate_limit failures
-# have exceeded the NMR threshold. Called by the dispatch engine when
-# check_dispatch_backoff returns 1 AND the stderr contains "NMR_REQUIRED".
+# Post a one-shot diagnostic when rate_limit failures exceed the extended
+# backoff threshold. The time-bounded cooldown remains the machine-recoverable
+# dispatch block; no maintainer trust label is applied.
 #
-# Idempotent: only applies NMR once per issue (uses a marker comment).
+# Idempotent: only posts the notice once per issue (uses a marker comment).
 # Best-effort: failures are logged but never fatal.
 #
 # Args:
@@ -515,35 +515,31 @@ check_dispatch_backoff() {
 #   $2 - repo_slug
 #   $3 - failure_count
 #######################################
-_db_apply_nmr_if_needed() {
+_db_record_extended_backoff_notice() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local failure_count="$3"
 
-	local nmr_marker="<!-- dispatch-backoff:rate_limit_nmr -->"
+	local notice_marker="<!-- dispatch-backoff:extended_cooldown -->"
 
 	# Idempotency check.
-	local existing_nmr=""
-	existing_nmr=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
-		--jq "[.[] | select(.body | contains(\"dispatch-backoff:rate_limit_nmr\"))] | length" \
-		2>/dev/null) || existing_nmr=""
-	if [[ "$existing_nmr" =~ ^[1-9][0-9]*$ ]]; then
-		echo "${_DB_LOG_PREFIX} NMR already applied for #${issue_number} (${repo_slug}) — skipping" >>"$LOGFILE"
+	local existing_notice=""
+	existing_notice=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+		--jq "[.[] | select(.body | contains(\"dispatch-backoff:extended_cooldown\"))] | length" \
+		2>/dev/null) || existing_notice=""
+	if [[ "$existing_notice" =~ ^[1-9][0-9]*$ ]]; then
+		echo "${_DB_LOG_PREFIX} extended-backoff notice already posted for #${issue_number} (${repo_slug}) — skipping" >>"$LOGFILE"
 		return 0
 	fi
 
-	# Apply the label.
-	gh issue edit "$issue_number" --repo "$repo_slug" \
-		--add-label "needs-maintainer-review" 2>/dev/null || true
-
 	# Post diagnostic comment.
-	local body="${nmr_marker}
+	local body="${notice_marker}
 ## Rate-Limit Backoff Circuit Breaker (t2781)
 
 **Trigger:** ${failure_count} rate_limit failure(s) for this issue within the lookback window (threshold: ${DISPATCH_BACKOFF_NMR_THRESHOLD}).
-**Action:** Applied \`needs-maintainer-review\`. Further automated dispatch is suspended for 24h and until the label is removed.
+**Action:** Extended the machine-managed cooldown to 24h. Dispatch resumes automatically after capacity recovers and the cooldown elapses.
 
-**Why this is different from other NMR trips:** Worker rate_limit failures are NOT a problem with the issue body or model tier — they indicate provider capacity exhaustion specific to this issue's account/provider pairing. Escalating to a higher tier would not help.
+**Why this remains a cooldown:** Worker rate_limit failures are NOT a problem with author authority, issue content, or model tier — they indicate provider capacity exhaustion specific to this issue's account/provider pairing. Escalating to a higher tier would not help.
 
 **Possible causes:**
 - Provider rate limits for the account(s) dispatching this issue are exhausted
@@ -554,9 +550,9 @@ _db_apply_nmr_if_needed() {
 1. Check \`aidevops status\` for current GraphQL budget and account pool state
 2. Rotate or add accounts via \`model-accounts-pool-helper.sh\`
 3. Wait for provider rate-limit reset (typically 1h for Anthropic, 24h for OpenAI tier limits)
-4. Remove \`needs-maintainer-review\` to re-enable dispatch once capacity recovers
+4. No trust approval is needed; the next eligible pulse retries automatically
 
-_Per-issue rate_limit backoff circuit breaker (t2781). The \`dispatch-backoff:rate_limit_nmr\` marker is recognised by \`_nmr_application_is_circuit_breaker_trip\` in \`pulse-nmr-approval.sh\` (t2386 split semantics: auto-approval preserves NMR)._"
+_Per-issue rate_limit backoff circuit breaker (t2781). The cooldown state, not a review label, is the dispatch fuse._"
 
 	if declare -F gh_issue_comment >/dev/null 2>&1; then
 		gh_issue_comment "$issue_number" --repo "$repo_slug" --body "$body" 2>/dev/null || true
@@ -564,7 +560,7 @@ _Per-issue rate_limit backoff circuit breaker (t2781). The \`dispatch-backoff:ra
 		gh issue comment "$issue_number" --repo "$repo_slug" --body "$body" 2>/dev/null || true
 	fi
 
-	echo "${_DB_LOG_PREFIX} NMR applied for #${issue_number} (${repo_slug}) count=${failure_count}" >>"$LOGFILE"
+	echo "${_DB_LOG_PREFIX} extended-backoff notice posted for #${issue_number} (${repo_slug}) count=${failure_count}" >>"$LOGFILE"
 	return 0
 }
 
@@ -609,12 +605,12 @@ _main() {
 				1)
 					printf '%s\n' "$backoff_stderr_output"
 
-					# Apply NMR if needed (NMR_REQUIRED in output).
-					if printf '%s' "$backoff_stderr_output" | grep -q 'NMR_REQUIRED'; then
+					# Post the extended-cooldown notice once at the threshold.
+					if printf '%s' "$backoff_stderr_output" | grep -q 'BACKOFF_NOTICE_REQUIRED'; then
 						local count_field
 						count_field=$(printf '%s' "$backoff_stderr_output" | grep -oE 'count=[0-9]+' | head -1 | cut -d= -f2)
 						[[ "$count_field" =~ ^[0-9]+$ ]] || count_field="$DISPATCH_BACKOFF_NMR_THRESHOLD"
-						_db_apply_nmr_if_needed "$issue_number" "$slug" "$count_field"
+						_db_record_extended_backoff_notice "$issue_number" "$slug" "$count_field"
 					fi
 					return 1
 					;;
@@ -634,7 +630,7 @@ _main() {
 			printf 'Environment:\n'
 			printf '  DISPATCH_BACKOFF_METRICS_FILE      path to headless-runtime-metrics.jsonl\n'
 			printf '  DISPATCH_BACKOFF_LOOKBACK_SECS     lookback window in seconds (default 604800 = 7 days)\n'
-			printf '  DISPATCH_BACKOFF_NMR_THRESHOLD     failure count triggering NMR (default 4)\n'
+			printf '  DISPATCH_BACKOFF_NMR_THRESHOLD     legacy name: failure count triggering extended notice (default 4)\n'
 			printf '  AIDEVOPS_SKIP_DISPATCH_BACKOFF=1   emergency bypass\n'
 			return 0
 			;;

--- a/.agents/scripts/dispatch-dedup-cost.sh
+++ b/.agents/scripts/dispatch-dedup-cost.sh
@@ -25,9 +25,9 @@ _DISPATCH_DEDUP_COST_LOADED=1
 # ─────────────────────────────────────────
 # Tracks cumulative token spend across all worker attempts on an issue
 # by parsing signature-footer patterns ("spent N tokens" / "has used N
-# tokens") from comments. When spend exceeds the tier-appropriate budget
-# the breaker fires: applies needs-maintainer-review label, posts one
-# explanatory comment per issue, and emits the COST_BUDGET_EXCEEDED signal.
+# tokens") from comments. When spend exceeds the tier-appropriate budget,
+# the breaker applies status:blocked, posts one explanatory comment per issue,
+# and emits the COST_BUDGET_EXCEEDED signal.
 #
 # Design (paired with t1986 parent-task guard and t2008 stale escalation):
 #   1. The breaker check runs in is_assigned() AFTER the parent-task
@@ -40,9 +40,8 @@ _DISPATCH_DEDUP_COST_LOADED=1
 #   3. Failure mode: fail-open. If we can't compute spend (gh failure,
 #      no comments, jq error), allow dispatch. The breaker is a safety
 #      net, not a hard gate. The other dedup layers still apply.
-#   4. Side effects are idempotent on both the needs-maintainer-review label
-#      and prior cost-circuit-breaker:fired marker. If the label is missing
-#      after an approval loop, re-apply NMR but do not post another comment.
+#   4. Side effects are idempotent through the status state machine and the
+#      prior cost-circuit-breaker:fired marker.
 #######################################
 
 #######################################
@@ -207,8 +206,8 @@ _issue_has_cost_breaker_comment() {
 }
 
 #######################################
-# Apply cost-breaker side effects: label + at most one explanatory comment.
-# Idempotent — if needs-maintainer-review is already present, no-op.
+# Apply cost-breaker side effects: structural block + one explanatory comment.
+# The root-cause meta-issue provides the machine-recoverable release path.
 #
 # Args:
 #   $1 = issue number
@@ -217,7 +216,6 @@ _issue_has_cost_breaker_comment() {
 #   $4 = budget (tokens, integer)
 #   $5 = tier short name (simple|standard|thinking)
 #   $6 = attempts count (integer)
-#   $7 = "true" if needs-maintainer-review label already set (skip side effects)
 #######################################
 _apply_cost_breaker_side_effects() {
 	local issue_number="$1"
@@ -226,16 +224,9 @@ _apply_cost_breaker_side_effects() {
 	local budget="$4"
 	local tier="$5"
 	local attempts="$6"
-	local has_label="$7"
-
-	if [[ "$has_label" == "true" ]]; then
-		# Already escalated — no double-comment, signal still emitted by caller
-		return 0
-	fi
-
-	# Apply needs-maintainer-review label without touching core status labels
-	set_issue_status "$issue_number" "$repo_slug" "" \
-		--add-label "needs-maintainer-review" 2>/dev/null || true
+	# NMR is an external-author trust gate, not a circuit breaker. Preserve any
+	# independently valid trust gate while recording the budget stop as lifecycle state.
+	set_issue_status "$issue_number" "$repo_slug" "blocked" 2>/dev/null || true
 
 	local _spent_k=$((spent / 1000))
 	local _budget_k=$((budget / 1000))
@@ -253,7 +244,7 @@ _apply_cost_breaker_side_effects() {
 
 Cumulative spend **${_spent_k}K tokens** across **${attempts}** worker attempt(s) exceeds \`tier:${tier}\` budget of **${_budget_k}K tokens**.
 
-Further automated dispatch is suspended. Applied \`needs-maintainer-review\` label.
+Further automated dispatch is suspended with \`status:blocked\` while a root-cause meta-issue is investigated.
 
 Maintainer review required before further dispatch. Possible causes:
 - Brief is unimplementable as written (refine scope or split the task)
@@ -261,13 +252,7 @@ Maintainer review required before further dispatch. Possible causes:
 - Worker stuck in a loop (model can't decompose the task — escalate tier)
 - Wrong tier assigned (downgrade a tier:thinking task to standard, or vice versa)
 
-After investigating, approve another dispatch with:
-
-\`\`\`bash
-sudo aidevops approve issue ${issue_number} ${repo_slug}
-\`\`\`
-
-Remove \`needs-maintainer-review\` after investigating the root cause to re-enable dispatch.
+The circuit-breaker meta flow restores \`status:available\` automatically after its fix merges. Manual recovery should requeue only after the root cause is fixed.
 
 _This is the cost-runaway fail-safe from t2007 (paired with t1986 parent-task guard and t2008 stale-recovery escalation)._
 <!-- ops:end -->" 2>/dev/null || true
@@ -276,15 +261,15 @@ _This is the cost-runaway fail-safe from t2007 (paired with t1986 parent-task gu
 	# t3076: file root-cause meta-issue with forensics and dispatch a
 	# tier:thinking worker against it. Idempotent — second trip on the
 	# same original is a no-op. Best-effort: failures are logged but
-	# never propagate (NMR is the canonical block, the meta-issue is
-	# the self-healing channel).
+	# never propagate (status:blocked is canonical; the meta-issue is the
+	# self-healing channel).
 	local _cb_meta_filer="${SCRIPT_DIR:-${HOME}/.aidevops/agents/scripts}/circuit-breaker-meta-filer.sh"
 	if [[ -x "$_cb_meta_filer" ]]; then
 		"$_cb_meta_filer" file \
 			--issue "$issue_number" --repo "$repo_slug" \
 			--breaker cost --tier "$tier" \
 			--spent "$spent" --budget "$budget" \
-			--attempts "$attempts" >/dev/null 2>&1 || true
+			--failure-count "$attempts" >/dev/null 2>&1 || true
 	fi
 
 	return 0
@@ -387,25 +372,9 @@ _check_cost_budget() {
 		"$_audit_log_helper" log cost-circuit-breaker "$_cost_trip_msg" >/dev/null 2>&1 || true
 	fi
 
-	# Over budget — check if needs-maintainer-review is already set (idempotency).
-	# When called via the CLI subcommand the caller doesn't pass issue_meta_json,
-	# so fetch it ourselves on the slow path. The hot path (is_assigned)
-	# always passes pre-fetched metadata to avoid a double round-trip.
-	if [[ -z "$issue_meta_json" ]]; then
-		issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
-			--json state,assignees,labels 2>/dev/null) || issue_meta_json=""
-	fi
-	local has_label="false"
-	if [[ -n "$issue_meta_json" ]]; then
-		local label_hit
-		label_hit=$(printf '%s' "$issue_meta_json" |
-			jq -r '[(.labels // [])[].name] | index("needs-maintainer-review") != null' 2>/dev/null) || label_hit="false"
-		[[ "$label_hit" == "true" ]] && has_label="true"
-	fi
-
-	# Apply side effects (no-op if has_label=true)
+	# Apply the structural block and marker-idempotent diagnostics.
 	_apply_cost_breaker_side_effects "$issue_number" "$repo_slug" \
-		"$spent" "$budget" "${tier#tier:}" "$attempts" "$has_label"
+		"$spent" "$budget" "${tier#tier:}" "$attempts"
 
 	# Emit signal for caller pattern matching (mirrors PARENT_TASK_BLOCKED)
 	printf 'COST_BUDGET_EXCEEDED (spent=%dK budget=%dK tier=%s attempts=%d)\n' \

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -1027,7 +1027,7 @@ _is_assigned_check_hold_for_review() {
 # across many issues simultaneously when one runner is unhealthy.
 #
 # Complementary to:
-#   - t2769 (per-issue 3-stack circuit breaker → NMR escalation)
+#   - t2769 (per-issue 3-stack circuit breaker → status:blocked + meta-repair)
 #   - t2897 (per-runner health breaker, 10 events / 6h → runner pause)
 # This guard is per-issue and short (default 30 min), so it absorbs
 # transient runner failures before the longer-horizon breakers fire.
@@ -1468,8 +1468,8 @@ check_worker_orphan_remote_children() {
 # is_assigned helper: cost-per-issue circuit breaker (t2007).
 #
 # Aggregate token spend across all worker attempts; if the cumulative total
-# exceeds the tier-appropriate budget, apply needs-maintainer-review and
-# block dispatch. Fail-open on aggregation errors so unrelated GitHub API
+# exceeds the tier-appropriate budget, apply status:blocked and stop dispatch.
+# Fail-open on aggregation errors so unrelated GitHub API
 # hiccups don't starve the queue. Closes the cost-runaway hole that t1986
 # (parent-task guard) and t2008 (stale-recovery escalation) leave open: an
 # issue with a correct tier assignment that workers can never finish

--- a/.agents/scripts/dispatch-dedup-recovery-loop.sh
+++ b/.agents/scripts/dispatch-dedup-recovery-loop.sh
@@ -103,7 +103,7 @@ _ddh_apply_recovery_loop_hold() {
 	local comments_json="$8"
 	local existing_block="0"
 
-	set_issue_status "$issue_number" "$repo_slug" "" --add-label "needs-maintainer-review" >/dev/null 2>&1 || true
+	set_issue_status "$issue_number" "$repo_slug" "blocked" >/dev/null 2>&1 || true
 
 	existing_block=$(_ddh_count_recovery_loop_blocks "$comments_json")
 	if [[ "$existing_block" -eq 0 ]]; then
@@ -115,7 +115,7 @@ _ddh_apply_recovery_loop_hold() {
 		version="${version:-unknown}"
 		local diag=""
 		# shellcheck disable=SC2016 # Backticks are literal Markdown, not command substitution.
-		diag=$(printf '<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->\n<!-- worker-recovery-loop:blocked count=%s threshold=%s window_s=%s latest=%s version=%s -->\n<!-- dispatch-circuit-breaker:worker_recovery_loop -->\n## Dispatch paused: repeated worker recovery failures\n\nThis issue has produced %s worker recovery-failure outcome(s) within the last %s seconds. Those outcomes mean workers produced branch evidence but the automation could not confirm a PR, so another redispatch would likely add more audit comments without solving the issue.\n\n**Action:** applied `needs-maintainer-review` and cleared active status labels. Automated dispatch is suspended until a human reviews the runner worktrees/logs, recovers any branch output, or lands a setup-side fix.\n\n**Verification before re-enabling:** confirm a PR exists for the work or confirm there is no unrecovered worker branch output left to preserve, then remove `needs-maintainer-review`.\n<!-- ops:end -->' \
+		diag=$(printf '<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->\n<!-- worker-recovery-loop:blocked count=%s threshold=%s window_s=%s latest=%s version=%s -->\n<!-- dispatch-circuit-breaker:worker_recovery_loop -->\n## Dispatch paused: repeated worker recovery failures\n\nThis issue has produced %s worker recovery-failure outcome(s) within the last %s seconds. Those outcomes mean workers produced branch evidence but the automation could not confirm a PR, so another redispatch would likely add more audit comments without solving the issue.\n\n**Action:** applied `status:blocked` and cleared active status labels. Automated dispatch is suspended until a human reviews the runner worktrees/logs, recovers any branch output, or lands a setup-side fix.\n\n**Verification before re-enabling:** confirm a PR exists for the work or confirm there is no unrecovered worker branch output left to preserve, then restore `status:available`.\n<!-- ops:end -->' \
 			"$count" "$threshold" "$window_s" "${latest_iso:-unknown}" "$version" "$count" "$window_s")
 		gh api "$comments_post_endpoint" --method POST --field body="$diag" >/dev/null 2>&1 || true
 	fi

--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -22,6 +22,8 @@
 #######################################
 STALE_ASSIGNMENT_THRESHOLD_SECONDS="${STALE_ASSIGNMENT_THRESHOLD_SECONDS:-${DISPATCH_COMMENT_MAX_AGE:-600}}"
 _DDS_NMR_LABEL="needs-maintainer-review"
+_DDS_STRUCTURAL_BLOCK_LABEL="status:blocked"
+_DDS_STATUS_BLOCKED="blocked"
 _DDS_KIND_DRAFT="draft_checkpoint"
 _DDS_KIND_READY="ready"
 _DDS_KIND_READY_FAILED="ready_failed"
@@ -315,7 +317,7 @@ _stale_recovery_find_open_pr() {
 # Preserve a stale worker draft for exact-branch continuation.
 #
 # A draft PR is durable implementation progress, so stale recovery must not
-# unassign its issue owner or convert it into a permanent NMR hold. The pulse
+# unassign its issue owner or convert it into a permanent structural hold. The pulse
 # caller consumes this signal and launches a bounded direct-PR continuation
 # worker whose runtime ownership fence is bound to the exact open PR head.
 #
@@ -339,7 +341,7 @@ _stale_recovery_preserve_draft_checkpoint() {
 }
 
 #######################################
-# Verify that a blocking NMR transition is visible before releasing ownership.
+# Verify that a structural stale-recovery block is visible before releasing ownership.
 # Args: issue number, repo slug, stale assignees CSV
 #######################################
 _stale_recovery_verify_blocking_transition() {
@@ -350,12 +352,12 @@ _stale_recovery_verify_blocking_transition() {
 
 	issue_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
 		--json state,labels,assignees 2>/dev/null) || return 1
-	printf '%s' "$issue_json" | jq -e --arg nmr "$_DDS_NMR_LABEL" --arg stale "$stale_assignees" '
+	printf '%s' "$issue_json" | jq -e --arg blocked "$_DDS_STRUCTURAL_BLOCK_LABEL" --arg stale "$stale_assignees" '
 		($stale | split(",") | map(select(length > 0))) as $stale_users |
 		([.labels[]?.name]) as $labels |
 		([.assignees[]?.login]) as $current_users |
 		.state == "OPEN" and
-		($labels | index($nmr)) != null and
+		($labels | index($blocked)) != null and
 		($labels | index("status:queued")) == null and
 		($labels | index("status:in-progress")) == null and
 		([ $stale_users[] as $user | select(($current_users | index($user)) != null) ] | length == 0)
@@ -385,7 +387,7 @@ _stale_recovery_escalate_pr_checkpoint() {
 	local ifs_was_set=0
 	local assignee=""
 	local -a assignees=()
-	local -a transition_args=(--add-label "$_DDS_NMR_LABEL" --remove-label "auto-dispatch")
+	local -a transition_args=(--remove-label "auto-dispatch")
 
 	if [[ "$checkpoint_kind" == "$_DDS_KIND_READY_FAILED" ]]; then
 		description="ready PR with terminally failed checks"
@@ -407,7 +409,7 @@ _stale_recovery_escalate_pr_checkpoint() {
 		[[ -n "$assignee" ]] && transition_args+=(--remove-assignee "$assignee")
 	done
 
-	if ! set_issue_status "$issue_number" "$repo_slug" "" "${transition_args[@]}"; then
+	if ! set_issue_status "$issue_number" "$repo_slug" "$_DDS_STATUS_BLOCKED" "${transition_args[@]}"; then
 		printf 'STALE_PR_ESCALATION_FAILED: issue #%s in %s — blocking transition failed; ownership retained\n' "$issue_number" "$repo_slug"
 		return 1
 	fi
@@ -419,17 +421,17 @@ _stale_recovery_escalate_pr_checkpoint() {
 	gh_issue_comment "$issue_number" --repo "$repo_slug" \
 		--body "<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
 <!-- stale-pr-checkpoint:escalated pr=${pr_number} kind=${checkpoint_kind} -->
-**PR checkpoint requires continuation review**
+**PR checkpoint requires structural repair**
 
 The ${description} #${pr_number} preserves committed progress but is not completion evidence. Ordinary redispatch remains blocked to avoid a competing implementation.
 
 Previously assigned to: ${stale_assignees}
 Stale reason: ${reason}
 
-Applied \`${_DDS_NMR_LABEL}\`. Continue or repair the existing PR before re-enabling dispatch.
+Applied \`${_DDS_STRUCTURAL_BLOCK_LABEL}\`. Continue or repair the existing PR, then return the linked issue to \`status:available\`.
 <!-- ops:end -->" 2>/dev/null || true
 	printf '%s: issue #%s in %s — PR #%s preserved, applied %s\n' \
-		"$event" "$issue_number" "$repo_slug" "$pr_number" "$_DDS_NMR_LABEL"
+		"$event" "$issue_number" "$repo_slug" "$pr_number" "$_DDS_STRUCTURAL_BLOCK_LABEL"
 	return 0
 }
 
@@ -453,11 +455,10 @@ _stale_recovery_find_open_pr_activity() {
 }
 
 #######################################
-# Escalate to needs-maintainer-review after the stale-recovery threshold
-# is reached (t2008).
+# Apply a structural block after the stale-recovery threshold is reached (t2008).
 #
-# Unassigns stale workers, clears status labels via set_issue_status, adds
-# needs-maintainer-review, and posts an explanatory comment. Emits
+# Unassigns stale workers, sets status:blocked via set_issue_status, and posts
+# an explanatory comment. Emits
 # STALE_ESCALATED on stdout for caller pattern matching.
 #
 # Args:
@@ -467,7 +468,7 @@ _stale_recovery_find_open_pr_activity() {
 #   $4 = reason for latest stale
 #   $5 = threshold
 #   $6 = prior tick count
-# Returns: 0 (always — all gh ops are fire-and-forget)
+# Returns: 0 on a verified transition, 1 when the block cannot be verified
 #######################################
 _stale_recovery_escalate() {
 	local issue_number="$1"
@@ -487,19 +488,24 @@ _stale_recovery_escalate() {
 	local -a _esc_assignee_arr=()
 	IFS=',' read -ra _esc_assignee_arr <<<"$stale_assignees"
 	IFS="$_esc_ifs"
-	# t2033: build remove-assignee flags and clear all core status labels
-	# in one atomic edit via set_issue_status (empty target = clear only).
-	# NMR is a dispatch hold, so remove auto-dispatch in the same mutation;
+	# t2033: build remove-assignee flags and set the structural blocker in one
+	# atomic edit via set_issue_status. Remove auto-dispatch in the same mutation;
 	# otherwise a racing recovery can restore status:available and make the
 	# held issue look runnable to idle-backoff even though dispatch rejects it.
 	local -a _esc_extra=(
-		--add-label "$_DDS_NMR_LABEL"
 		--remove-label "auto-dispatch"
 	)
 	for _esc_assignee in "${_esc_assignee_arr[@]}"; do
 		_esc_extra+=(--remove-assignee "$_esc_assignee")
 	done
-	set_issue_status "$issue_number" "$repo_slug" "" "${_esc_extra[@]}" || true
+	if ! set_issue_status "$issue_number" "$repo_slug" "$_DDS_STATUS_BLOCKED" "${_esc_extra[@]}"; then
+		printf 'STALE_ESCALATION_FAILED: issue #%s in %s — structural block transition failed; ownership retained\n' "$issue_number" "$repo_slug"
+		return 1
+	fi
+	if ! _stale_recovery_verify_blocking_transition "$issue_number" "$repo_slug" "$stale_assignees"; then
+		printf 'STALE_ESCALATION_FAILED: issue #%s in %s — structural block not visible; ownership retained\n' "$issue_number" "$repo_slug"
+		return 1
+	fi
 
 	# Post escalation comment explaining the suspension
 	gh_issue_comment "$issue_number" --repo "$repo_slug" \
@@ -513,12 +519,12 @@ Previously assigned to: ${stale_assignees}
 Reason for latest stale: ${reason}
 Recovery count: ${_prior_ticks} (threshold: ${_threshold})
 
-Marked \`needs-maintainer-review\`. Remove this label after investigating why workers keep failing (wrong brief, unimplementable scope, missing dependency, etc.) to re-enable dispatch.
+Marked \`status:blocked\`. Investigate why workers keep failing (wrong brief, unimplementable scope, missing dependency, etc.), then return the issue to \`status:available\` when the structural blocker is resolved.
 
 _This escalation is the \"no-progress fail-safe\" from t2008 (paired with t1986 parent-task guard and t2007 cost circuit breaker)._
 <!-- ops:end -->" \
 		2>/dev/null || true
-	printf 'STALE_ESCALATED: issue #%s in %s — unassigned %s, applied needs-maintainer-review (threshold %s reached after %s ticks)\n' \
+	printf 'STALE_ESCALATED: issue #%s in %s — unassigned %s, applied status:blocked (threshold %s reached after %s ticks)\n' \
 		"$issue_number" "$repo_slug" "$stale_assignees" "$_threshold" "$_prior_ticks"
 	return 0
 }
@@ -601,11 +607,11 @@ _stale_recovery_apply_blocked_by_hold() {
 		printf 'STALE_RECHECK_BLOCKED: issue #%s in %s — evidence changed before blocked takeover\n' "$issue_number" "$repo_slug"
 		return 0
 	fi
-	if ! set_issue_status "$issue_number" "$repo_slug" "blocked" "${recov_extra[@]}"; then
+	if ! set_issue_status "$issue_number" "$repo_slug" "$_DDS_STATUS_BLOCKED" "${recov_extra[@]}"; then
 		printf 'STALE_RECOVERY_UNCERTAIN: issue #%s in %s — blocked transition failed\n' "$issue_number" "$repo_slug"
 		return 1
 	fi
-	if ! _stale_recovery_verify_transition "$issue_number" "$repo_slug" "blocked" "$stale_assignees"; then
+	if ! _stale_recovery_verify_transition "$issue_number" "$repo_slug" "$_DDS_STATUS_BLOCKED" "$stale_assignees"; then
 		printf 'STALE_RECOVERY_UNCERTAIN: issue #%s in %s — blocked transition verification failed\n' "$issue_number" "$repo_slug"
 		return 1
 	fi
@@ -722,7 +728,7 @@ _This recovery prevents the orphaned-assignment deadlock where offline runners p
 #      - Worker draft: preserve ownership and emit an exact-head continuation
 #        signal for the pulse caller.
 #      - Ready PR: preserve ownership and stop; the PR is durable progress.
-#      - Ready PR with terminal code/check failure: escalate to NMR.
+#      - Ready PR with terminal code/check failure: apply a structural block.
 #      - Else increment the global recovery count. At the threshold, escalate
 #        immediately. A stale assignment is itself terminal no-progress evidence.
 #      - Under threshold, record the tick inside the single recovery comment.
@@ -742,7 +748,7 @@ _recover_stale_assignment() {
 
 	# ── Stale-recovery escalation check (t2008) ──────────────────────────
 	# After STALE_RECOVERY_THRESHOLD consecutive recoveries without a PR, stop
-	# resetting to status:available and apply needs-maintainer-review instead.
+	# resetting to status:available and apply status:blocked instead.
 	# Counter is stored as structured comment markers for cross-runner correctness.
 	# Config: .agents/configs/dispatch-stale-recovery.conf
 	local _threshold _prior_ticks _open_pr _open_pr_number _open_pr_kind _comments_pages _latest_dispatch_ts _next_tick
@@ -790,7 +796,7 @@ _recover_stale_assignment() {
 	fi
 	_next_tick=$((_prior_ticks + 1))
 	if [[ "$_next_tick" -ge "$_threshold" ]]; then
-		_stale_recovery_escalate "$issue_number" "$repo_slug" "$stale_assignees" "$reason" "$_threshold" "$_next_tick" "$_latest_dispatch_ts"
+		_stale_recovery_escalate "$issue_number" "$repo_slug" "$stale_assignees" "$reason" "$_threshold" "$_next_tick" "$_latest_dispatch_ts" || return 1
 		return 0
 	fi
 	# ── End stale-recovery escalation check ──────────────────────────────

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -69,6 +69,7 @@ _DSI_APPROVAL_HELPER="${_DSI_SCRIPT_DIR}/approval-helper.sh"
 _DSI_DISPATCH_BASE_BRANCH=""
 _DSI_STATE_RECOVERING="recovering"
 _DSI_UNKNOWN_VALUE="<unknown>"
+_DSI_JSON_TRUE="true"
 _DSI_CLAIM_WON=0
 _DSI_CLAIM_COMMENT_ID=""
 _DSI_TARGET_JSON=""
@@ -163,7 +164,7 @@ _dsi_target_is_pull_request() {
 	target_json=$(gh api "repos/${repo_slug}/issues/${issue_number}" 2>/dev/null) || return 2
 	_DSI_TARGET_JSON="$target_json"
 	has_pull_request=$(printf '%s' "$target_json" | jq -r 'has("pull_request")' 2>/dev/null) || return 2
-	if [[ "$has_pull_request" == "true" ]]; then
+	if [[ "$has_pull_request" == "$_DSI_JSON_TRUE" ]]; then
 		return 0
 	fi
 	if [[ "$has_pull_request" == "false" ]]; then
@@ -203,27 +204,28 @@ _dsi_guard_issue_author_trust() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local issue_json="${_DSI_TARGET_JSON:-}"
-	local author_meta="" author_association="NONE" author_type="" author_login=""
+	local author_meta="" author_association="NONE" author_type="" author_login="" external_source="false"
 
 	if [[ -z "$issue_json" ]]; then
 		issue_json=$(gh api "repos/${repo_slug}/issues/${issue_number}" 2>/dev/null) || issue_json=""
 	fi
 	if [[ -n "$issue_json" ]]; then
 		author_meta=$(printf '%s' "$issue_json" | jq -r \
-			'[.author_association // "NONE", .user.type // "", .user.login // ""] | join("|")' 2>/dev/null) || author_meta=""
+			'[.author_association // "NONE", .user.type // "", .user.login // "", (([.labels[]?.name] | index("external-contributor") != null) | tostring)] | join("|")' 2>/dev/null) || author_meta=""
 	fi
 	if [[ -n "$author_meta" ]]; then
-		IFS='|' read -r author_association author_type author_login <<<"$author_meta"
+		IFS='|' read -r author_association author_type author_login external_source <<<"$author_meta"
 	fi
 	[[ -n "$author_association" ]] || author_association="NONE"
-	if [[ "$author_type" == "Bot" ]]; then
+	if [[ "$author_type" == "Bot" && "$external_source" != "$_DSI_JSON_TRUE" ]]; then
 		return 0
 	fi
 
-	local authority_rc=0
-	if declare -F _gh_actor_has_repo_write_authority >/dev/null 2>&1; then
+	local authority_rc=1
+	if [[ "$external_source" != "$_DSI_JSON_TRUE" ]] && declare -F _gh_actor_has_repo_write_authority >/dev/null 2>&1; then
+		authority_rc=0
 		_gh_actor_has_repo_write_authority "$repo_slug" "$author_login" "$author_association" || authority_rc=$?
-	else
+	elif [[ "$external_source" != "$_DSI_JSON_TRUE" ]]; then
 		authority_rc=2
 	fi
 	if [[ "$authority_rc" -eq 0 ]]; then
@@ -252,7 +254,7 @@ _dsi_guard_issue_author_trust() {
 		gh issue edit "$issue_number" --repo "$repo_slug" \
 			--add-label "needs-maintainer-review" >/dev/null 2>&1 || true
 	fi
-	_dsi_err "Issue #${issue_number} in ${repo_slug} has untrusted or unknown author authority (${author_association}; ${AIDEVOPS_GH_ACTOR_AUTHORITY_REASON:-unknown}) and no verified approval; refusing manual worker dispatch"
+	_dsi_err "Issue #${issue_number} in ${repo_slug} has untrusted, external-source, or unknown author authority (${author_association}; external_source=${external_source}; ${AIDEVOPS_GH_ACTOR_AUTHORITY_REASON:-unknown}) and no verified approval; refusing manual worker dispatch"
 	return 1
 }
 

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -699,22 +699,23 @@ _linked_issue_author_allows_start() {
 	local issue_num="$1"
 	local repo="$2"
 	local raw_issue="$3"
-	local author_meta="" author_association="NONE" author_type="" author_login=""
+	local author_meta="" author_association="NONE" author_type="" author_login="" external_source="false"
 
 	author_meta=$(printf '%s' "$raw_issue" | jq -r \
-		'[.author_association // "NONE", .user.type // "", .user.login // ""] | join("|")' 2>/dev/null) || author_meta=""
+		'[.author_association // "NONE", .user.type // "", .user.login // "", (([.labels[]?.name] | index("external-contributor") != null) | tostring)] | join("|")' 2>/dev/null) || author_meta=""
 	if [[ -n "$author_meta" ]]; then
-		IFS='|' read -r author_association author_type author_login <<<"$author_meta"
+		IFS='|' read -r author_association author_type author_login external_source <<<"$author_meta"
 	fi
 	[[ -n "$author_association" ]] || author_association="NONE"
-	if [[ "$author_type" == "Bot" ]]; then
+	if [[ "$author_type" == "Bot" && "$external_source" != "true" ]]; then
 		return 0
 	fi
 
-	local authority_rc=0
-	if declare -F _gh_actor_has_repo_write_authority >/dev/null 2>&1; then
+	local authority_rc=1
+	if [[ "$external_source" != "true" ]] && declare -F _gh_actor_has_repo_write_authority >/dev/null 2>&1; then
+		authority_rc=0
 		_gh_actor_has_repo_write_authority "$repo" "$author_login" "$author_association" || authority_rc=$?
-	else
+	elif [[ "$external_source" != "true" ]]; then
 		authority_rc=2
 	fi
 	if [[ "$authority_rc" -eq 0 ]]; then
@@ -740,7 +741,7 @@ _linked_issue_author_allows_start() {
 		fi
 	fi
 
-	_FULL_LOOP_LINKED_AUTHOR_GATE_REASON="author_association=${author_association}, authority=${AIDEVOPS_GH_ACTOR_AUTHORITY_REASON:-unknown}, approval=${verification:-unavailable}"
+	_FULL_LOOP_LINKED_AUTHOR_GATE_REASON="author_association=${author_association}, external_source=${external_source}, authority=${AIDEVOPS_GH_ACTOR_AUTHORITY_REASON:-unknown}, approval=${verification:-unavailable}"
 	return 1
 }
 

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -38,6 +38,7 @@ _HRW_REASON_WORKER_COMPLETE="worker_complete"
 _HRW_TELEMETRY_SUCCESS="success"
 _HRW_TELEMETRY_FAILED="failed"
 _HRW_TELEMETRY_DEFERRED="deferred"
+_HRW_STATUS_CHECKPOINTED="checkpointed"
 _HRW_REASON_DRAFT_CHECKPOINT="worker_draft_checkpoint"
 _HRW_REASON_DRAFT_ESCALATION_FAILED="worker_draft_checkpoint_escalation_failed"
 _HRW_REASON_CLOSED_UNMERGED="worker_closed_unmerged_pr"
@@ -48,7 +49,6 @@ _HRW_REASON_OWNERSHIP_LOST="worker_ownership_lost"
 _HRW_REASON_SENSITIVE_TEMP_PREFLIGHT="worker_sensitive_temp_preflight_failed"
 _HRW_EVENT_FAILED="worker.failed"
 _HRW_EVENT_DEFERRED="worker.deferred"
-_HRW_NMR_LABEL="needs-maintainer-review"
 _HRW_PERMISSION_PERSISTENCE_FAILED="permission_request_persistence_failed"
 _HRW_SPOTLIGHT_MARKER=".metadata_never_index"
 _HRW_RECOVERY_CLASSIFICATION=""
@@ -653,9 +653,10 @@ _worker_produced_output() {
 }
 
 #######################################
-# Escalate an exhausted draft or terminally failed ready PR. The claim is only
-# released after the blocking NMR label is applied and read back. Failed or
-# invisible transitions retain ownership so ordinary dispatch cannot race.
+# Preserve an exhausted worker draft for exact-head continuation. The issue
+# remains assigned and in-review while auto-dispatch is disabled; stale recovery
+# can then route the exact existing PR instead of launching a competing branch.
+# Failed or invisible transitions retain the claim.
 # Args: $1=session key, $2=repo slug, $3=lifecycle state, $4=release reason
 #######################################
 _escalate_worker_pr_checkpoint() {
@@ -665,7 +666,7 @@ _escalate_worker_pr_checkpoint() {
 	local release_reason="${4:-$_HRW_REASON_DRAFT_CHECKPOINT}"
 	local issue_number=""
 	local runner_login=""
-	local -a transition_args=(--add-label "$_HRW_NMR_LABEL" --remove-label "auto-dispatch")
+	local -a transition_args=(--remove-label "auto-dispatch")
 
 	issue_number=$(printf '%s' "$session_key" | grep -oE '[0-9]+$' || true)
 	if [[ -z "$issue_number" || -z "$repo_slug" ]]; then
@@ -675,37 +676,47 @@ _escalate_worker_pr_checkpoint() {
 	fi
 	if declare -F _hrff_resolve_release_runner_login >/dev/null 2>&1; then
 		runner_login=$(_hrff_resolve_release_runner_login)
-		[[ -n "$runner_login" ]] && transition_args+=(--remove-assignee "$runner_login")
+		[[ -n "$runner_login" ]] && transition_args+=(--add-assignee "$runner_login")
 	fi
 	if declare -F set_issue_status >/dev/null 2>&1; then
-		if ! set_issue_status "$issue_number" "$repo_slug" "" "${transition_args[@]}"; then
+		if ! set_issue_status "$issue_number" "$repo_slug" "in-review" "${transition_args[@]}"; then
 			_HRW_RECOVERY_CLASSIFICATION="$_HRW_REASON_DRAFT_ESCALATION_FAILED"
-			print_warning "[lifecycle] ${_HRW_RECOVERY_CLASSIFICATION} session=${session_key} — blocking transition failed; retaining claim"
+			print_warning "[lifecycle] ${_HRW_RECOVERY_CLASSIFICATION} session=${session_key} — continuation transition failed; retaining claim"
 			return 0
 		fi
 	elif ! gh issue edit "$issue_number" --repo "$repo_slug" \
-		--add-label "$_HRW_NMR_LABEL" --remove-label "auto-dispatch" >/dev/null 2>&1; then
+		--add-label "status:in-review" \
+		--remove-label "status:available,status:queued,status:in-progress" \
+		"${transition_args[@]}" >/dev/null 2>&1; then
 		_HRW_RECOVERY_CLASSIFICATION="$_HRW_REASON_DRAFT_ESCALATION_FAILED"
-		print_warning "[lifecycle] ${_HRW_RECOVERY_CLASSIFICATION} session=${session_key} — blocking transition failed; retaining claim"
+		print_warning "[lifecycle] ${_HRW_RECOVERY_CLASSIFICATION} session=${session_key} — continuation transition failed; retaining claim"
 		return 0
 	fi
-	if ! _worker_pr_checkpoint_block_visible "$issue_number" "$repo_slug"; then
+	if ! _worker_pr_checkpoint_block_visible "$issue_number" "$repo_slug" "$runner_login"; then
 		_HRW_RECOVERY_CLASSIFICATION="$_HRW_REASON_DRAFT_ESCALATION_FAILED"
-		print_warning "[lifecycle] ${_HRW_RECOVERY_CLASSIFICATION} session=${session_key} — blocking label not visible; retaining claim"
+		print_warning "[lifecycle] ${_HRW_RECOVERY_CLASSIFICATION} session=${session_key} — continuation state not visible; retaining claim"
 		return 0
 	fi
 
 	_hrw_release_dispatch_claim "$session_key" "$release_reason"
 	_HRW_RECOVERY_CLASSIFICATION="$release_reason"
-	print_warning "[lifecycle] worker_pr_checkpoint_escalated session=${session_key} state=${lifecycle_state} — maintainer review required"
+	print_warning "[lifecycle] worker_pr_checkpoint_preserved session=${session_key} state=${lifecycle_state} — exact-head continuation pending"
 	return 0
 }
 
 _worker_pr_checkpoint_block_visible() {
 	local issue_number="$1"
 	local repo_slug="$2"
-	gh issue view "$issue_number" --repo "$repo_slug" --json labels 2>/dev/null \
-		| jq -e --arg nmr "$_HRW_NMR_LABEL" '([.labels[]?.name] | index($nmr)) != null' >/dev/null 2>&1
+	local expected_runner="${3:-}"
+	gh issue view "$issue_number" --repo "$repo_slug" --json state,labels,assignees 2>/dev/null \
+		| jq -e --arg runner "$expected_runner" '
+			([.labels[]?.name]) as $labels |
+			([.assignees[]?.login]) as $assignees |
+			.state == "OPEN" and
+			($labels | index("status:in-review")) != null and
+			(["status:available", "status:queued", "status:in-progress", "auto-dispatch"] - $labels | length) == 4 and
+			($runner == "" or ($assignees | index($runner)) != null)
+		' >/dev/null 2>&1
 	return $?
 }
 
@@ -970,13 +981,13 @@ _handle_worker_dirty_worktree() {
 				--worktree "$work_dir" \
 				--branch "$branch_name" \
 				--changed-paths "$status_summary" \
-				--recoverability "checkpointed" 2>/dev/null || true
+				--recoverability "$_HRW_STATUS_CHECKPOINTED" 2>/dev/null || true
 		fi
 		_hrw_release_dispatch_claim "$session_key" "$_HRW_REASON_DRAFT_CHECKPOINT"
 		_HRW_RECOVERY_CLASSIFICATION="$_HRW_REASON_DRAFT_CHECKPOINT"
 		_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_DEFERRED"
 		_HRW_FINAL_RUNTIME_EVENT="$_HRW_EVENT_DEFERRED"
-		_HRW_FINAL_RUNTIME_STATUS="checkpointed"
+		_HRW_FINAL_RUNTIME_STATUS="$_HRW_STATUS_CHECKPOINTED"
 		_HRW_FINAL_RUNTIME_CLASSIFICATION="$_HRW_REASON_DRAFT_CHECKPOINT"
 		print_info "[lifecycle] worker_dirty_worktree_checkpointed session=${session_key} branch=${branch_name:-<none>}"
 		return 0
@@ -1818,7 +1829,7 @@ _hrw_finish_success_run() {
 	#   branch_orphan         — branch pushed but no PR → auto-recover
 	#   local_branch_unpushed — local commits but no remote branch/PR → push+recover
 	#   dirty_worktree        — local edits exist but no commit/PR → preserve marker
-	#   draft_checkpoint      — durable but incomplete PR → explicit escalation
+	#   draft_checkpoint      — durable but incomplete PR → exact-head continuation
 	#   pr_exists             — PR confirmed, or fail-open → worker_complete
 	#
 	# Fail-open semantics are preserved: when signals cannot be evaluated (no git
@@ -1851,7 +1862,10 @@ _hrw_finish_success_run() {
 			_escalate_worker_pr_checkpoint "$session_key" "${DISPATCH_REPO_SLUG:-}" "$output_class"
 			release_needed=0
 			if [[ "$_HRW_RECOVERY_CLASSIFICATION" == "$_HRW_REASON_DRAFT_CHECKPOINT" ]]; then
-				_hrw_mark_failed_terminal_state "$_HRW_STATUS_ESCALATED" "$_HRW_RECOVERY_CLASSIFICATION"
+				_HRW_TERMINAL_OUTCOME="$_HRW_TELEMETRY_DEFERRED"
+				_HRW_FINAL_RUNTIME_EVENT="$_HRW_EVENT_DEFERRED"
+				_HRW_FINAL_RUNTIME_STATUS="$_HRW_STATUS_CHECKPOINTED"
+				_HRW_FINAL_RUNTIME_CLASSIFICATION="$_HRW_RECOVERY_CLASSIFICATION"
 			else
 				_hrw_mark_failed_terminal_state "$_HRW_STATUS_FAILED" "$_HRW_RECOVERY_CLASSIFICATION"
 			fi

--- a/.agents/scripts/issue-sync-lib-compose.sh
+++ b/.agents/scripts/issue-sync-lib-compose.sh
@@ -188,7 +188,7 @@ Without at least one of these, this issue will:
 
 1. Sit blocked (no worker can pick it up).
 2. Receive a decomposition nudge on the next pulse cycle (\`<!-- parent-needs-decomposition -->\`).
-3. Escalate to \`needs-maintainer-review\` after 7 days if still unresolved (t2442).
+3. Receive a one-time advisory escalation after 7 days if still unresolved (t2442).
 4. Be picked up by the auto-decomposer scanner after 4h if the nudge sits (t2442/t2949) — a \`tier:thinking\` worker will be dispatched to propose a decomposition plan.
 
 **Quick fixes — pick one:**

--- a/.agents/scripts/knowledge-review-helper.sh
+++ b/.agents/scripts/knowledge-review-helper.sh
@@ -4,13 +4,13 @@
 # knowledge-review-helper.sh — Knowledge plane review gate routine (t2845)
 #
 # Scans _knowledge/inbox/ for pending sources, classifies them by trust ladder,
-# auto-promotes maintainer/trusted drops, and files NMR-gated GitHub issues for
-# untrusted sources. Designed to be run as pulse routine r040 every 15 minutes.
+# auto-promotes maintainer/trusted drops, and files explicitly held GitHub
+# review issues for untrusted sources. Designed to run as pulse routine r040.
 #
 # Usage (pulse routine r040):
 #   scripts/knowledge-review-helper.sh tick
 #
-# Usage (crypto-approval hook, called by pulse-nmr-approval.sh):
+# Usage (after explicit maintainer content review):
 #   knowledge-review-helper.sh promote <source-id>
 #
 # Usage (manual audit entry):
@@ -19,13 +19,13 @@
 # Trust classification (from _knowledge/_config/knowledge.json → trust):
 #   auto_promote  → maintainer drops / trusted paths+emails+bots → promote directly
 #   review_gate   → trusted partner emails → file kind:knowledge-review + auto-dispatch
-#   untrusted     → default ("*") → file kind:knowledge-review + needs-maintainer-review
+#   untrusted     → default ("*") → file kind:knowledge-review + hold-for-review
 #
 # Audit log: _knowledge/index/audit.log (JSONL, one record per action)
 #
 # Pattern reference: .agents/scripts/knowledge-helper.sh (provisioning)
 #                    .agents/scripts/email-poll-helper.sh (pulse routine)
-#                    .agents/scripts/pulse-nmr-approval.sh (NMR flow)
+#                    .agents/reference/dispatch-blockers.md (review holds)
 
 set -euo pipefail
 
@@ -382,8 +382,8 @@ ${preview}
 
 ## Review Actions
 
-- Approve: \`sudo aidevops approve issue <this-issue-number> ${repo_slug}\`
-  This triggers \`knowledge-review-helper.sh promote ${source_id}\`
+- Approve: after reviewing the staged source, run
+  \`knowledge-review-helper.sh promote ${source_id}\`, then close this issue.
 - Reject: close the issue without approving (source stays in staging/)
 
 Source staged at: \`_knowledge/staging/${source_id}/\`
@@ -396,6 +396,7 @@ BODY
 
 # ---------------------------------------------------------------------------
 # _file_nmr_issue — create a GitHub issue for a review-required source
+# The legacy function/state name is retained for on-disk compatibility.
 # Returns the issue URL on success
 # ---------------------------------------------------------------------------
 
@@ -420,7 +421,7 @@ _file_nmr_issue() {
 
 	local labels="kind:knowledge-review"
 	if [[ "$trust_class" == "untrusted" ]]; then
-		labels="${labels},needs-maintainer-review"
+		labels="${labels},hold-for-review"
 	else
 		labels="${labels},auto-dispatch"
 	fi
@@ -700,18 +701,18 @@ cmd_help() {
 knowledge-review-helper.sh — Knowledge plane review gate routine (t2845)
 
 Subcommands:
-  tick                       Scan inbox, classify trust, auto-promote or NMR-file
-  promote <source-id>        Promote from staging -> sources (called by approve hook)
+  tick                       Scan inbox, classify trust, auto-promote or file review
+  promote <source-id>        Promote a reviewed source from staging -> sources
   audit-log <action> <id>    Append JSONL entry to _knowledge/index/audit.log
   help                       Show this help
 
 Trust classification (from _knowledge/_config/knowledge.json .trust):
   auto_promote  maintainer/trusted drops → promoted directly + audit-logged
   review_gate   trusted partner email   → kind:knowledge-review + auto-dispatch
-  untrusted     default ("*")           → kind:knowledge-review + needs-maintainer-review
+  untrusted     default ("*")           → kind:knowledge-review + hold-for-review
 
-Crypto-approval flow (untrusted sources):
-  sudo aidevops approve issue <N> <owner/repo>  →  promotes source from staging/ to sources/
+Review flow (untrusted sources):
+  inspect staged content → knowledge-review-helper.sh promote <source-id> → close issue
 
 Audit log location: _knowledge/index/audit.log (JSONL)
 HELP
@@ -748,4 +749,6 @@ main() {
 	return 0
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]:-$0}" == "$0" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/label-sync-helper.sh
+++ b/.agents/scripts/label-sync-helper.sh
@@ -118,7 +118,7 @@ SYSTEM_LABELS=(
 	"security|D73A4A|Security-sensitive issue"
 	"security-adjacent|D73A4A|Security-adjacent issue requiring human attention"
 	"needs-review|D73A4A|Flagged for human review by AI supervisor"
-	"needs-maintainer-review|D73A4A|Requires maintainer approval before work begins"
+	"needs-maintainer-review|D73A4A|External-author gate requiring maintainer approval before work begins"
 	"needs-maintainer-permissions|B60205|Block: background work paused for a scoped maintainer permission grant"
 	"security-review|D73A4A|Requires security review — suspicious AI request"
 	"parent-task|D4C5F9|Parent/meta task — children implement, not this issue"

--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -31,12 +31,11 @@
 #          pulse stage records a healthy yielded run instead of a hard timeout.
 #        SCANNER_CURSOR_DIR (default ~/.aidevops/logs/post-merge-review-scanner)
 #          — directory for per-repo resume cursors and fresh run logs.
-#        SCANNER_NEEDS_REVIEW (default false) — opt-in escape hatch to apply
-#          needs-maintainer-review at creation time. Normally the worker
-#          itself triages (verify premise → implement / close-wontfix /
-#          escalate-with-recommendation), so this should stay off. Flip to
-#          true only for pipelines where every bot finding genuinely needs
-#          human sign-off before any automated action.
+#        SCANNER_HOLD_FOR_REVIEW (default false) — opt-in escape hatch to apply
+#          hold-for-review at creation time. Normally the worker itself triages
+#          (verify premise → implement / close-wontfix /
+#          escalate-with-recommendation), so this should stay off. The legacy
+#          SCANNER_NEEDS_REVIEW variable remains a compatibility alias.
 #
 # Subcommands:
 #   scan             — scan recent merged PRs and create new review-followup issues
@@ -60,7 +59,7 @@
 #        judgment call the worker cannot make (architecture / policy /
 #        breaking change) → post a decision comment containing analysis,
 #        a recommended path, and the specific question that needs input,
-#        then apply needs-maintainer-review. The human reads a ready-to-
+#        then apply hold-for-review. The human reads a ready-to-
 #        approve recommendation, not a blank triage task.
 #
 #   This is the same rule as AGENTS.md "Reasoning responsibility":
@@ -105,7 +104,7 @@ SCANNER_PR_LIMIT="${SCANNER_PR_LIMIT:-1000}"
 SCANNER_MAX_COMMENTS="${SCANNER_MAX_COMMENTS:-10}"
 SCANNER_DIFFHUNK_LINES="${SCANNER_DIFFHUNK_LINES:-12}"
 SCANNER_REFRESH_LIMIT="${SCANNER_REFRESH_LIMIT:-200}"
-SCANNER_NEEDS_REVIEW="${SCANNER_NEEDS_REVIEW:-false}"
+SCANNER_HOLD_FOR_REVIEW="${SCANNER_HOLD_FOR_REVIEW:-${SCANNER_NEEDS_REVIEW:-false}}"
 SCANNER_BUDGET_SECONDS="${SCANNER_BUDGET_SECONDS:-540}"
 if [[ -z "${SCANNER_CURSOR_DIR:-}" ]]; then
 	if [[ -n "${HOME:-}" ]]; then
@@ -596,7 +595,7 @@ comment** with exactly these fields:
 - **Specific question:** the single decision the human needs to make
   (yes/no or pick-one, not open-ended).
 
-Then apply \`needs-maintainer-review\` and stop. The human wakes up to a
+Then apply \`hold-for-review\` and stop. The human wakes up to a
 ready-to-approve recommendation, not a blank task.
 
 > **Ambiguity about scope or style is not Outcome C.** Per
@@ -866,9 +865,9 @@ create_issue() {
 	# The worker itself verifies the bot's premise and picks one of three
 	# outcomes: close-as-falsified (Outcome A), implement-and-PR (B), or
 	# escalate-with-recommendation (C). We do NOT apply
-	# needs-maintainer-review unconditionally — that would be the exact
+	# hold-for-review unconditionally — that would be the exact
 	# "punt analysis to a human who hands it back to an AI" anti-pattern
-	# this script is meant to avoid. SCANNER_NEEDS_REVIEW is an opt-in
+	# this script is meant to avoid. SCANNER_HOLD_FOR_REVIEW is an opt-in
 	# escape hatch; the worker guidance inside the issue body carries the
 	# enforcement.
 	#
@@ -880,22 +879,20 @@ create_issue() {
 	# produces origin:worker. The hardcoding is a source-of-truth
 	# assertion: this scanner is by definition pulse-only output and
 	# should never ship origin:interactive regardless of caller context.
-	# GH#20631: tier:standard belongs in base labels — NMR'd issues also need
-	# a tier label so the dispatcher can pick them up after NMR auto-approval
-	# clears needs-maintainer-review and adds auto-dispatch. Without it,
-	# approved issues have auto-dispatch but no tier:*, leaving them stalled.
+	# GH#20631: tier:standard belongs in base labels so issues remain
+	# dispatchable after a maintainer removes an explicit review hold.
 	local label_list="$SCANNER_LABEL,source:review-scanner,origin:worker,tier:standard"
-	if [[ "$SCANNER_NEEDS_REVIEW" == "true" ]]; then
-		gh label create "needs-maintainer-review" --repo "$repo" \
-			--description "Requires human triage before worker dispatch" \
+	if [[ "$SCANNER_HOLD_FOR_REVIEW" == "true" ]]; then
+		gh label create "hold-for-review" --repo "$repo" \
+			--description "Explicit maintainer review hold" \
 			--color "B60205" || true
-		label_list="${label_list},needs-maintainer-review"
+		label_list="${label_list},hold-for-review"
 	else
 		# GH#20530 (t2748): scanner-emitted issues are dispatchable by default.
 		# Without auto-dispatch, pulse cannot pick them up and they sit unworked
 		# indefinitely (observed: 9 issues stalled when this branch was missing).
-		# NMR'd issues skip this branch — NMR auto-approval (pulse-nmr-approval.sh)
-		# adds auto-dispatch on clear, so we don't double-apply here.
+		# Explicitly held issues skip this branch until a maintainer removes the
+		# hold and deliberately restores dispatch intent.
 		label_list="${label_list},auto-dispatch"
 	fi
 

--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -49,6 +49,7 @@ _PAD_TRIAGE_OUTCOME_POSTED="posted"
 _PAD_TRIAGE_OUTCOME_REVIEW_FAILED="review_failed"
 _PAD_TRIAGE_OUTCOME_INFRASTRUCTURE_FAILED="infrastructure_failed"
 _PAD_TRIAGE_LAST_OUTCOME=""
+_PAD_REVIEW_HOLD_LABEL="hold-for-review"
 _PAD_GITHUB_COMMENTS_READ_MALFORMED_REASON="github-comments-read-malformed"
 _PAD_GITHUB_COMMENTS_SNAPSHOT_TOO_LARGE_REASON="github-comments-snapshot-too-large"
 _PAD_TRIAGE_MAX_COMMENTS=100
@@ -754,11 +755,11 @@ _triage_mark_security_hold() {
 	gh label create "security-review" --repo "$repo_slug" --color "D73A4A" \
 		--description "Requires security review — suspicious AI request" --force \
 		>/dev/null 2>&1 || true
-	gh label create "hold-for-review" --repo "$repo_slug" --color "D73A4A" \
+	gh label create "$_PAD_REVIEW_HOLD_LABEL" --repo "$repo_slug" --color "D73A4A" \
 		--description "Opt-out: block issue auto-dispatch or PR auto-merge for maintainer review" --force \
 		>/dev/null 2>&1 || true
 	if ! gh issue edit "$issue_num" --repo "$repo_slug" \
-		--add-label "security-review" --add-label "hold-for-review" \
+		--add-label "security-review" --add-label "$_PAD_REVIEW_HOLD_LABEL" \
 		>/dev/null 2>&1; then
 		echo "[pulse-wrapper] SECURITY: failed to persist triage security hold for #${issue_num} in ${repo_slug}; model invocation remains blocked (reason=${reason})" >>"$LOGFILE"
 	fi
@@ -2838,8 +2839,9 @@ dispatch_triage_reviews() {
 #######################################
 # Relabel status:needs-info issues where contributor has replied
 #
-# Reads the pre-fetched needs-info reply status from STATE_FILE and
-# transitions replied issues to needs-maintainer-review.
+# Reads the pre-fetched needs-info reply status from STATE_FILE and transitions
+# replied issues according to live author authority: external/unknown authors
+# return to NMR triage; trusted authors use hold-for-review without self-approval.
 #
 # Arguments:
 #   $1 - repos JSON path (default: REPOS_JSON)
@@ -2855,12 +2857,47 @@ relabel_needs_info_replies() {
 	while IFS='|' read -r issue_num repo_slug; do
 		[[ -n "$issue_num" && -n "$repo_slug" ]] || continue
 
-		gh issue edit "$issue_num" --repo "$repo_slug" \
-			--remove-label "status:needs-info" \
-			--add-label "needs-maintainer-review" 2>/dev/null || true
+		local author_meta="" author_association="NONE" author_type="" author_login="" external_source="false"
+		author_meta=$(gh api "repos/${repo_slug}/issues/${issue_num}" \
+			--jq '[.author_association // "NONE", .user.type // "", .user.login // "", (([.labels[]?.name] | index("external-contributor") != null) | tostring)] | join("|")' \
+			2>/dev/null) || author_meta=""
+		if [[ -z "$author_meta" ]]; then
+			echo "[pulse-wrapper] relabel_needs_info_replies: authority lookup failed for #${issue_num} in ${repo_slug}; preserving status:needs-info" >>"$LOGFILE"
+			continue
+		fi
+		IFS='|' read -r author_association author_type author_login external_source <<<"$author_meta"
+
+		local authority_rc=1 review_label="needs-maintainer-review"
+		if [[ "$external_source" != "true" ]]; then
+			authority_rc=2
+			if [[ "$author_type" == "Bot" ]]; then
+				authority_rc=0
+			elif declare -F _gh_actor_has_repo_write_authority >/dev/null 2>&1; then
+				authority_rc=0
+				_gh_actor_has_repo_write_authority "$repo_slug" "$author_login" "$author_association" || authority_rc=$?
+			fi
+		fi
+		if [[ "$authority_rc" -eq 0 ]]; then
+			review_label="$_PAD_REVIEW_HOLD_LABEL"
+		elif [[ "$authority_rc" -eq 2 ]]; then
+			echo "[pulse-wrapper] relabel_needs_info_replies: author authority uncertain for #${issue_num} in ${repo_slug}; failing closed to NMR (${AIDEVOPS_GH_ACTOR_AUTHORITY_REASON:-unknown})" >>"$LOGFILE"
+		fi
+
+		local edit_rc=0
+		if declare -F gh_issue_edit_safe >/dev/null 2>&1; then
+			gh_issue_edit_safe "$issue_num" --repo "$repo_slug" \
+				--remove-label "status:needs-info" --add-label "$review_label" >/dev/null 2>&1 || edit_rc=$?
+		else
+			gh issue edit "$issue_num" --repo "$repo_slug" \
+				--remove-label "status:needs-info" --add-label "$review_label" >/dev/null 2>&1 || edit_rc=$?
+		fi
+		if [[ "$edit_rc" -ne 0 ]]; then
+			echo "[pulse-wrapper] relabel_needs_info_replies: transition failed for #${issue_num} in ${repo_slug} (target=${review_label}, rc=${edit_rc})" >>"$LOGFILE"
+			continue
+		fi
 		gh_issue_comment "$issue_num" --repo "$repo_slug" \
-			--body "Contributor replied to the information request. Relabeled to \`needs-maintainer-review\` for re-evaluation." \
-			2>/dev/null || true
+			--body "The issue author replied to the information request. Relabeled to \`${review_label}\` for re-evaluation." \
+			2>/dev/null || echo "[pulse-wrapper] relabel_needs_info_replies: transition comment failed for #${issue_num} in ${repo_slug}" >>"$LOGFILE"
 	done < <(sed -n 's/^replied|//p' "$state_file" 2>/dev/null || true)
 
 	return 0

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -928,11 +928,9 @@ _consecutive_zero_session_failures() {
 # worker) what the symptom is, how it differs from regular failures, and
 # what diagnostics to run BEFORE re-dispatching at the same tier.
 #
-# The body intentionally does NOT remove auto-dispatch — that's the
-# caller's job. It carries the `dispatch-infrastructure-failure` marker
-# so `auto_approve_maintainer_issues` PRESERVES the NMR label rather than
-# clearing it (t2386 split semantics: this is a circuit-breaker family
-# trip, not a creation-default scanner-filed issue).
+# The body intentionally does NOT remove auto-dispatch — that's the caller's
+# job. It carries the backward-compatible `dispatch-infrastructure-failure`
+# marker while `status:blocked` provides the machine-recoverable dispatch fuse.
 #
 # Args:
 #   $1 - issue_number: for the worker-log path hint
@@ -964,17 +962,11 @@ A \`session_count=0\` release indicates the worker died in setup (sandbox crash,
    - \`${log_path_hint}\`
    - \`${log_path_hint}.*\` (rotated copies)
 2. Identify the failure family — sandbox / auth / OpenCode / prompt / SIGTERM source.
-3. Once the underlying issue is fixed, clear NMR with:
-
-\`\`\`bash
-sudo aidevops approve issue ${issue_number} ${repo_slug}
-\`\`\`
-
-This applies the cryptographic approval signature that takes precedence over the \`dispatch-infrastructure-failure\` marker, allowing the next dispatch to proceed.
+3. Once the underlying issue is fixed and no recoverable worker output remains, restore \`status:available\`.
 
 ### Why dispatch is paused
 
-Re-dispatching this issue without a setup-side fix would (a) burn another worker on the same failure mode, (b) not surface diagnostics the maintainer hasn't already seen, and (c) progress the cost circuit breaker without producing useful output. The \`needs-maintainer-review\` label + \`dispatch-infrastructure-failure\` marker pause the dispatch loop until a human verifies the failure family and lands a fix.
+Re-dispatching this issue without a setup-side fix would (a) burn another worker on the same failure mode, (b) not surface diagnostics the maintainer hasn't already seen, and (c) progress the cost circuit breaker without producing useful output. The \`status:blocked\` lifecycle state + \`dispatch-infrastructure-failure\` marker pause the dispatch loop until the failure family is fixed.
 MARKER_EOF
 	return 0
 }
@@ -1035,9 +1027,9 @@ _pulse_cleanup_issue_open_for_write() {
 # t3050: per-issue infra-failure escalation. Before posting the
 # crash_type=no_work failure comment, check whether the most recent
 # CLAIM_RELEASED comments already carry session_count=0 in a row. If 2+
-# consecutive zero-session releases are detected, apply
-# needs-maintainer-review with a dispatch-infrastructure-failure marker
-# instead of re-dispatching — the loop won't break by retrying.
+# consecutive zero-session releases are detected, apply `status:blocked` with a
+# dispatch-infrastructure-failure marker instead of re-dispatching — the loop
+# won't break by retrying.
 #
 # Args:
 #   $1 - wt_branch_age: branch name (non-empty; caller checks)
@@ -1076,22 +1068,19 @@ _record_orphan_crash_classification() {
 
 	# t3050: per-issue infra-failure escalation. If the last 2 CLAIM_RELEASED
 	# comments both carry session_count=0, the issue is repeatedly killing
-	# workers in setup. Apply NMR with the dispatch-infrastructure-failure
-	# marker so auto_approve_maintainer_issues PRESERVES NMR (t2386 split
-	# semantics) and the dispatch loop pauses until a maintainer fixes
-	# the underlying setup-side issue. Best-effort, idempotent: failure
+	# workers in setup. Apply status:blocked with the
+	# dispatch-infrastructure-failure marker so the dispatch loop pauses until a
+	# maintainer fixes the underlying setup-side issue. Best-effort, idempotent: failure
 	# falls through to the legacy "Worker failed" comment path below.
 	# Skip when AIDEVOPS_SKIP_INFRA_FAILURE_ESCALATION=1 (test/diagnostic bypass).
 	if [[ "${AIDEVOPS_SKIP_INFRA_FAILURE_ESCALATION:-0}" != "1" ]] \
 		&& _consecutive_zero_session_failures "$orphan_issue_num" "$repo_slug_age" 2; then
-		echo "[pulse-wrapper] Orphan cleanup: dispatch-infrastructure-failure detected for #${orphan_issue_num} (${repo_slug_age}) — applying needs-maintainer-review" >>"$LOGFILE"
-		# Apply NMR label (best-effort — gh_issue_edit_safe is from shared-gh-wrappers.sh)
-		if declare -F gh_issue_edit_safe >/dev/null 2>&1; then
-			gh_issue_edit_safe "$orphan_issue_num" --repo "$repo_slug_age" \
-				--add-label "needs-maintainer-review" >/dev/null 2>&1 || true
+		echo "[pulse-wrapper] Orphan cleanup: dispatch-infrastructure-failure detected for #${orphan_issue_num} (${repo_slug_age}) — applying status:blocked" >>"$LOGFILE"
+		if declare -F set_issue_status >/dev/null 2>&1; then
+			set_issue_status "$orphan_issue_num" "$repo_slug_age" "blocked" >/dev/null 2>&1 || true
 		else
 			gh issue edit "$orphan_issue_num" --repo "$repo_slug_age" \
-				--add-label "needs-maintainer-review" >/dev/null 2>&1 || true
+				--add-label "status:blocked" >/dev/null 2>&1 || true
 		fi
 		# Post the worker-mentoring advisory comment carrying the marker.
 		local _advisory_body

--- a/.agents/scripts/pulse-dirty-pr-sweep.sh
+++ b/.agents/scripts/pulse-dirty-pr-sweep.sh
@@ -1103,8 +1103,8 @@ _Triggered by \`pulse-dirty-pr-sweep.sh\` (t2350 / GH#19948)._"
 
 # Notify action: post an informational comment once (idempotent via marker).
 # This does NOT block merge, does NOT apply a label, does NOT dispatch a worker.
-# It only posts an idempotent comment. For a real escalation (maintainer review
-# required), use `needs-maintainer-review` labelling via `set_issue_status` instead.
+# It only posts an idempotent comment. For an explicit maintainer review hold,
+# use `hold-for-review`; NMR remains reserved for external-author trust gates.
 _dirty_pr_action_notify() {
 	local pr_number="$1"
 	local repo_slug="$2"

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -751,21 +751,25 @@ _check_external_issue_author_gate() {
 
 	local issue_author_meta=""
 	issue_author_meta=$(gh api "repos/${repo_slug}/issues/${issue_number}" \
-		--jq '[.author_association // "NONE", .user.type // "", .user.login // ""] | join("|")' 2>/dev/null) || issue_author_meta=""
+		--jq '[.author_association // "NONE", .user.type // "", .user.login // "", (([.labels[]?.name] | index("external-contributor") != null) | tostring)] | join("|")' 2>/dev/null) || issue_author_meta=""
 
 	local author_association="NONE"
 	local author_type=""
 	local author_login=""
+	local external_source="false"
 	if [[ -n "$issue_author_meta" ]]; then
-		IFS='|' read -r author_association author_type author_login <<<"$issue_author_meta"
+		IFS='|' read -r author_association author_type author_login external_source <<<"$issue_author_meta"
 	fi
 	[[ -n "$author_association" ]] || author_association="NONE"
 
-	if [[ "$author_type" == "Bot" ]]; then
+	if [[ "$author_type" == "Bot" && "$external_source" != "true" ]]; then
 		return 1
 	fi
-	local authority_rc=0
-	_gh_actor_has_repo_write_authority "$repo_slug" "$author_login" "$author_association" || authority_rc=$?
+	local authority_rc=1
+	if [[ "$external_source" != "true" ]]; then
+		authority_rc=0
+		_gh_actor_has_repo_write_authority "$repo_slug" "$author_login" "$author_association" || authority_rc=$?
+	fi
 	if [[ "$authority_rc" -eq 0 ]]; then
 		return 1
 	fi
@@ -788,7 +792,7 @@ _check_external_issue_author_gate() {
 		fi
 	fi
 
-	echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: author_association=${author_association}, author_type=${author_type:-unknown}, authority=${AIDEVOPS_GH_ACTOR_AUTHORITY_REASON:-unknown}; applying ${nmr_label} until cryptographic approval lands (GH#22399)" >>"$LOGFILE"
+	echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: author_association=${author_association}, author_type=${author_type:-unknown}, external_source=${external_source}, authority=${AIDEVOPS_GH_ACTOR_AUTHORITY_REASON:-unknown}; applying ${nmr_label} until cryptographic approval lands (GH#22399)" >>"$LOGFILE"
 	if declare -F gh_issue_edit_safe >/dev/null 2>&1; then
 		gh_issue_edit_safe "$issue_number" --repo "$repo_slug" \
 			--add-label "$nmr_label" >/dev/null 2>&1 || true

--- a/.agents/scripts/pulse-dispatch-dedup-layers.sh
+++ b/.agents/scripts/pulse-dispatch-dedup-layers.sh
@@ -330,7 +330,7 @@ _dedup_layer6_assignee_and_stale() {
 		# GH#27853: exhausted stale-recovery paths are terminal outcomes. Route
 		# them through the same idempotent consolidation dispatcher used by
 		# substantive-thread triage, then block this cycle so a stale candidate
-		# snapshot cannot launch a competing worker after NMR was applied.
+		# snapshot cannot launch a competing worker after a structural block.
 		if [[ "$assigned_output" == *STALE_ESCALATED* || "$assigned_output" == *STALE_PR_ESCALATED* ]]; then
 			local _stale_breaker_source="stale-recovery-threshold"
 			[[ "$assigned_output" == *STALE_PR_ESCALATED* ]] && _stale_breaker_source="stale-pr-checkpoint"

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -1431,7 +1431,7 @@ _run_preflight_stages() {
 	_log_substage_timing "preflight_early_dispatch" "$_pflt_ed_start" "$_pflt_ed_rc"
 	# GH#28880: cross-repository label maintenance can take 3-5 minutes. Run it
 	# after the initial fill so already-eligible workers boot in parallel. Then
-	# reconcile trusted NMR holds and refill once so every newly unblocked
+	# normalize trusted-author NMR residue and refill once so every newly unblocked
 	# candidate remains dispatchable this cycle.
 	run_stage_with_timeout "preflight_label_maintenance" "$_pflt_timeout" \
 		_preflight_label_maintenance || true

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -1377,13 +1377,13 @@ _dispatch_skip_for_backoff() {
 		if [[ "$_backoff_rc" -eq 1 ]]; then
 			echo "[pulse-wrapper] Dispatch_max: skipping #${issue_number} (${repo_slug}) — ${_backoff_output}" >>"$LOGFILE"
 			_dispatch_stats_increment "dispatch_candidate_skipped_backoff"
-			# Apply NMR when the backoff helper signals 4th+ failure threshold.
-			if printf '%s' "$_backoff_output" | grep -q 'NMR_REQUIRED'; then
+			# Record the extended cooldown once at the 4th+ failure threshold.
+			if printf '%s' "$_backoff_output" | grep -q 'BACKOFF_NOTICE_REQUIRED'; then
 				local _backoff_count=""
 				_backoff_count=$(printf '%s' "$_backoff_output" | grep -oE 'count=[0-9]+' | head -1 | cut -d= -f2)
 				[[ "$_backoff_count" =~ ^[0-9]+$ ]] || _backoff_count="${DISPATCH_BACKOFF_NMR_THRESHOLD:-4}"
-				declare -F _db_apply_nmr_if_needed >/dev/null 2>&1 && \
-					_db_apply_nmr_if_needed "$issue_number" "$repo_slug" "$_backoff_count" || true
+				declare -F _db_record_extended_backoff_notice >/dev/null 2>&1 && \
+					_db_record_extended_backoff_notice "$issue_number" "$repo_slug" "$_backoff_count" || true
 			fi
 			return 0
 		fi

--- a/.agents/scripts/pulse-dispatch-preflight-lib.sh
+++ b/.agents/scripts/pulse-dispatch-preflight-lib.sh
@@ -320,8 +320,8 @@ _preflight_label_maintenance() {
 }
 
 #######################################
-# Reconcile only NMR holds that pass the authority, provenance, breaker, and
-# security gates in auto_approve_maintainer_issues. Running this after the first
+# Normalize NMR only after live author-authority, provenance, breaker, and
+# security classification in auto_approve_maintainer_issues. Running this after the first
 # fill but before candidate snapshot invalidation lets newly trusted candidates
 # enter the same-cycle refill without delaying already-eligible work.
 #######################################

--- a/.agents/scripts/pulse-dispatch-worker-prompt.sh
+++ b/.agents/scripts/pulse-dispatch-worker-prompt.sh
@@ -407,10 +407,14 @@ _dlw_hold_repeated_zero_output() {
 	fi
 
 	echo "[dispatch_with_dedup] Holding #${issue_number} in ${repo_slug}: ${zero_count} zero-output or zero-attempt failures; applying dispatch infrastructure hold" >>"$LOGFILE"
-	gh issue edit "$issue_number" --repo "$repo_slug" \
-		--add-label "needs-maintainer-review" \
-		--remove-label "status:available" \
-		--remove-label "status:queued" >/dev/null 2>&1 || true
+	if declare -F set_issue_status >/dev/null 2>&1; then
+		set_issue_status "$issue_number" "$repo_slug" "blocked" >/dev/null 2>&1 || true
+	else
+		gh issue edit "$issue_number" --repo "$repo_slug" \
+			--add-label "status:blocked" \
+			--remove-label "status:available" \
+			--remove-label "status:queued" >/dev/null 2>&1 || true
+	fi
 	gh issue comment "$issue_number" --repo "$repo_slug" --body "<!-- dispatch-infrastructure-failure -->
 ## Dispatch infrastructure failure detected
 

--- a/.agents/scripts/pulse-fast-fail.sh
+++ b/.agents/scripts/pulse-fast-fail.sh
@@ -743,8 +743,8 @@ _fast_fail_reset_locked() {
 # under backoff and should not be interfered with.
 #
 # Safety ceiling (t2397): after FAST_FAIL_AGE_OUT_MAX_RESETS consecutive
-# auto-resets without a successful dispatch, applies needs-maintainer-review
-# to prevent infinite token burn on genuinely broken issues.
+# auto-resets without a successful dispatch, structurally blocks non-capacity
+# failures and routes them to terminal consolidation.
 #
 # Arguments: $1 issue_number, $2 repo_slug
 #######################################
@@ -811,13 +811,24 @@ _fast_fail_age_out_locked() {
 	new_reset_count=$((existing_reset_count + 1))
 	local max_resets="${FAST_FAIL_AGE_OUT_MAX_RESETS:-3}"
 
-	# Safety ceiling: after max_resets consecutive auto-resets, escalate to maintainer.
+	# Safety ceiling: capacity failures remain time-bounded and self-healing;
+	# other repeated failures become structurally blocked and consolidated.
 	if [[ "$new_reset_count" -gt "$max_resets" ]]; then
-		echo "[pulse-wrapper] fast_fail_age_out: #${issue_number} (${repo_slug}) exceeded ${max_resets} auto-resets without success — applying needs-maintainer-review" >>"$LOGFILE"
-		gh issue edit "$issue_number" --repo "$repo_slug" --add-label "needs-maintainer-review" >>"$LOGFILE" 2>&1 || true
 		case "$existing_reason" in
-		rate_limit* | backoff) return 0 ;;
-		*) return 2 ;;
+		rate_limit* | backoff)
+			new_reset_count="$max_resets"
+			echo "[pulse-wrapper] fast_fail_age_out: #${issue_number} (${repo_slug}) reached ${max_resets} capacity resets — retaining bounded automatic recovery" >>"$LOGFILE"
+			;;
+		*)
+			echo "[pulse-wrapper] fast_fail_age_out: #${issue_number} (${repo_slug}) exceeded ${max_resets} auto-resets without success — applying status:blocked" >>"$LOGFILE"
+			if declare -F set_issue_status >/dev/null 2>&1; then
+				set_issue_status "$issue_number" "$repo_slug" "blocked" >>"$LOGFILE" 2>&1 || true
+			else
+				gh issue edit "$issue_number" --repo "$repo_slug" \
+					--add-label "status:blocked" >>"$LOGFILE" 2>&1 || true
+			fi
+			return 2
+			;;
 		esac
 	fi
 

--- a/.agents/scripts/pulse-issue-reconcile-actions.sh
+++ b/.agents/scripts/pulse-issue-reconcile-actions.sh
@@ -461,14 +461,14 @@ _Posted once by parent close-contract reconciliation._"
 	return 0
 }
 
-_mark_parent_needs_decomposition() {
+_mark_parent_review_hold() {
 	local slug="$1" parent_num="$2"
 	if declare -F gh_issue_edit_safe >/dev/null 2>&1; then
 		gh_issue_edit_safe "$parent_num" --repo "$slug" \
-			--add-label "needs-maintainer-review" >/dev/null 2>&1 || true
+			--add-label "hold-for-review" >/dev/null 2>&1 || true
 	else
 		gh issue edit "$parent_num" --repo "$slug" \
-			--add-label "needs-maintainer-review" >/dev/null 2>&1 || true
+			--add-label "hold-for-review" >/dev/null 2>&1 || true
 	fi
 	return 0
 }
@@ -493,7 +493,7 @@ _repair_closed_parent_contract() {
 
 	gh issue reopen "$parent_num" --repo "$slug" >/dev/null 2>&1 || return 1
 	_post_parent_close_contract_nudge "$slug" "$parent_num" "$reason" "$marker" || true
-	_mark_parent_needs_decomposition "$slug" "$parent_num"
+	_mark_parent_review_hold "$slug" "$parent_num"
 	echo "[pulse-wrapper] Reconcile parent-task: reopened #${parent_num} in ${slug} — incomplete close contract (${reason})" >>"${LOGFILE:-/dev/null}"
 	return 0
 }
@@ -563,7 +563,7 @@ _try_close_parent_tracker() {
 				"$_PARENT_CLOSE_CONTRACT_REASON" \
 				"<!-- parent-close-contract-incomplete:${_PARENT_CLOSE_CONTRACT_REASON} -->" || true
 		fi
-		_mark_parent_needs_decomposition "$slug" "$parent_num"
+		_mark_parent_review_hold "$slug" "$parent_num"
 		echo "[pulse-wrapper] Reconcile parent-task: kept #${parent_num} open in ${slug} — incomplete close contract (${_PARENT_CLOSE_CONTRACT_REASON})" >>"${LOGFILE:-/dev/null}"
 		return 1
 	fi

--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -1100,9 +1100,11 @@ Thanks for filing this issue. Because it was created by a contributor outside th
 
 This comment is idempotent; the HTML sentinel prevents duplicates on subsequent pulse cycles."
 
-	# Fetch authorAssociation and PR marker (fail-closed: unknown → external, t2450).
+	# Fetch live author authority and PR marker (fail-closed: unknown → external,
+	# t2450/GH#29394). A bare COLLABORATOR association is not sufficient because
+	# it may represent read/triage access.
 	# GitHub PRs share the Issues API namespace; labelless backfill must never bless them as origin:worker/tier:standard.
-	local issue_json="" assoc="" is_pull_request=""
+	local issue_json="" assoc="" author_type="" author_login="" is_pull_request=""
 	issue_json=$(gh api "repos/${slug}/issues/${issue_num}" 2>/dev/null || echo '{}')
 	is_pull_request=$(printf '%s' "$issue_json" | jq -r 'has("pull_request")' 2>/dev/null || echo "false")
 	if [[ "$is_pull_request" == "true" ]]; then
@@ -1110,10 +1112,25 @@ This comment is idempotent; the HTML sentinel prevents duplicates on subsequent 
 		return 1
 	fi
 	assoc=$(printf '%s' "$issue_json" | jq -r '.author_association // "NONE"' 2>/dev/null || echo "NONE")
+	author_type=$(printf '%s' "$issue_json" | jq -r '.user.type // ""' 2>/dev/null || echo "")
+	author_login=$(printf '%s' "$issue_json" | jq -r '.user.login // ""' 2>/dev/null || echo "")
 	local is_external="$_PIR_BOOL_TRUE"
-	case "$assoc" in
-		OWNER | MEMBER | COLLABORATOR) is_external="$_PIR_BOOL_FALSE" ;;
-	esac
+	if [[ "$author_type" == "Bot" ]]; then
+		is_external="$_PIR_BOOL_FALSE"
+	else
+		case "$assoc" in
+		OWNER | MEMBER) is_external="$_PIR_BOOL_FALSE" ;;
+		COLLABORATOR)
+			local authority_rc=0
+			if declare -F _gh_actor_has_repo_write_authority >/dev/null 2>&1; then
+				_gh_actor_has_repo_write_authority "$slug" "$author_login" "$assoc" || authority_rc=$?
+			else
+				authority_rc=2
+			fi
+			[[ "$authority_rc" -eq 0 ]] && is_external="$_PIR_BOOL_FALSE"
+			;;
+		esac
+	fi
 
 	# Choose sentinel for idempotency check
 	local check_sentinel="$sentinel"

--- a/.agents/scripts/pulse-merge-feedback-finalizer.sh
+++ b/.agents/scripts/pulse-merge-feedback-finalizer.sh
@@ -10,7 +10,8 @@ PULSE_FEEDBACK_ROUTE_DEFERRED_RC=75
 PULSE_FEEDBACK_ROUTE_MAINTAINER_RC=76
 PULSE_FEEDBACK_ROUTE_HANDLED_RC=77
 PULSE_FEEDBACK_ROUTE_CLOSED_STATE="CLOSED"
-PULSE_FEEDBACK_ROUTE_HOLD_LABEL="needs-maintainer-review"
+PULSE_FEEDBACK_ROUTE_HOLD_LABEL="hold-for-review"
+PULSE_FEEDBACK_ROUTE_NMR_LABEL="needs-maintainer-review"
 PULSE_FEEDBACK_ROUTE_OPEN_STATE="OPEN"
 
 _feedback_route_gh_write() {
@@ -34,7 +35,8 @@ _feedback_route_labels_block_routing() {
 
 	if _feedback_route_labels_include "$labels" "no-takeover" \
 		|| _feedback_route_labels_include "$labels" "external-contributor" \
-		|| _feedback_route_labels_include "$labels" "$PULSE_FEEDBACK_ROUTE_HOLD_LABEL"; then
+		|| _feedback_route_labels_include "$labels" "$PULSE_FEEDBACK_ROUTE_HOLD_LABEL" \
+		|| _feedback_route_labels_include "$labels" "$PULSE_FEEDBACK_ROUTE_NMR_LABEL"; then
 		return 0
 	fi
 	if _feedback_route_labels_include "$labels" "origin:interactive" \
@@ -193,6 +195,7 @@ _feedback_route_issue_is_ready() {
 	! _feedback_route_labels_include "$labels" "origin:interactive" || return 1
 	! _feedback_route_labels_include "$labels" "origin:worker-takeover" || return 1
 	! _feedback_route_labels_include "$labels" "$PULSE_FEEDBACK_ROUTE_HOLD_LABEL" || return 1
+	! _feedback_route_labels_include "$labels" "$PULSE_FEEDBACK_ROUTE_NMR_LABEL" || return 1
 	[[ -z "$assignees" ]] || return 1
 	return 0
 }

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -309,7 +309,7 @@ ${feedback_section}"
 #   $1 - linked_issue  (issue number)
 #   $2 - repo_slug     (owner/repo)
 #   $3 - source_label  (e.g. "source:ci-feedback")
-#   $4 - clear_hold    (optional: 1 removes needs-maintainer-review on recovery)
+#   $4 - clear_hold    (optional: 1 removes hold-for-review on recovery)
 #######################################
 _transition_issue_for_redispatch() {
 	local linked_issue="$1"
@@ -329,7 +329,7 @@ _transition_issue_for_redispatch() {
 		[[ -n "$_assignee" ]] && _redispatch_flags+=(--remove-assignee "$_assignee")
 	done <<<"$_assignees"
 	if [[ "$clear_hold" == "1" ]]; then
-		_redispatch_flags+=(--remove-label "needs-maintainer-review")
+		_redispatch_flags+=(--remove-label "hold-for-review")
 	fi
 
 	if declare -F set_issue_status >/dev/null 2>&1; then

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -1089,7 +1089,7 @@ _issue_has_verified_crypto_approval() {
 # Nine criteria (see GH#20204):
 #   1. PR carries origin:worker label (caller pre-checks)
 #   2. Linked issue authored by OWNER or MEMBER
-#   3. NMR never applied OR cleared via cryptographic approval (not auto-approval)
+#   3. Linked issue has live maintainer-author authority or cryptographic approval
 #   4. All required status checks PASS/SKIPPED (checked by general gates)
 #   5. No CHANGES_REQUESTED from human reviewers (checked by general gates)
 #   6. PR is not a draft
@@ -1155,15 +1155,7 @@ _attempt_worker_briefed_auto_merge() {
 		issue_author_permission="$precomputed_pr_author_permission"
 	fi
 
-	# Fetch auto-approval signal once for the NMR crypto-vs-auto check (t2449).
-	# Cryptographic approval is verified separately via approval-helper.sh; do not
-	# trust marker-string presence in comments as a security gate.
 	local _not_true_status="not-verified"
-	local _has_auto=""
-	_has_auto=$(gh api "${_issue_api}/comments" --jq '
-		any(.[].body | strings; contains("auto-approved-maintainer-issue"))
-	' 2>/dev/null) || _has_auto="$_not_true_status"
-
 	local _has_crypto="$_not_true_status"
 	if _issue_has_verified_crypto_approval "$linked_issue" "$repo_slug"; then
 		_has_crypto="true"
@@ -1188,18 +1180,10 @@ _attempt_worker_briefed_auto_merge() {
 		fi
 	fi
 
-	# Gate: NMR crypto-vs-auto approval check.
-	# If NMR was ever applied to the linked issue, it must have been cleared
-	# via cryptographic approval (sudo aidevops approve issue N), NOT via
-	# auto_approve_maintainer_issues. Auto-approval runs as the pulse's own
-	# GitHub token — accepting it here would create a closed loop with zero
-	# human touchpoints (scanner → issue → dispatch → worker → PR → merge).
-	if [[ "$_has_auto" == "true" && "$_has_crypto" != "true" ]]; then
-		echo "[pulse-merge] worker-briefed auto-merge: skipping PR #${pr_number} in ${repo_slug} — linked issue #${linked_issue} NMR was auto-approved only (no crypto clearance) (t2449)" >>"$LOGFILE"
-		return 1
-	fi
-
-	# All gates pass — eligible for worker-briefed auto-merge
+	# Historical NMR/normalization comments are not current authority signals.
+	# Live issue-author authority above is sufficient; external authors still
+	# require verified cryptographic approval and live NMR remains blocked by the
+	# general merge gates.
 	echo "[pulse-merge] worker-briefed auto-merge: PR #${pr_number} in ${repo_slug} passed all gates (issue #${linked_issue}, author_assoc=${issue_author_assoc}, crypto_approved=${_has_crypto}) (t2449/t3052)" >>"$LOGFILE"
 	return 0
 }

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# pulse-nmr-approval.sh — Needs-maintainer-review (NMR) cache, approval requirement checks, and maintainer auto-approve.
+# pulse-nmr-approval.sh — External-author NMR cache, approval checks, and trusted-author normalization.
 #
 # Extracted from pulse-wrapper.sh in Phase 2 of the phased decomposition
 # (parent: GH#18356, plan: todo/plans/pulse-wrapper-decomposition.md §6).
@@ -21,6 +21,7 @@
 #   - _ever_nmr_cache_set_locked
 #   - _ever_nmr_cache_set
 #   - issue_was_ever_nmr
+#   - _nmr_issue_author_has_repo_write_authority
 #   - issue_has_required_approval
 #   - _nmr_applied_by_maintainer
 #   - _nmr_application_is_security_sensitive
@@ -28,11 +29,12 @@
 #   - _find_qualifying_pr_for_stale_recovery
 #   - _notify_stale_recovery_resolved_by_pr
 #   - _nmr_current_actor_can_post_maintainer_approval
+#   - _nmr_apply_auto_approval_transition
 #   - auto_approve_maintainer_issues
 #
-# This is a pure move from pulse-wrapper.sh. The function bodies are
-# byte-identical to their pre-extraction form. Any change must go in a
-# separate follow-up PR after the full decomposition (Phase 12) lands.
+# Changes in this module must preserve the external-author trust boundary:
+# unknown authority fails closed, while write-authorized authors never
+# fabricate or require self-approval.
 
 # Include guard — prevent double-sourcing.
 [[ -n "${_PULSE_NMR_APPROVAL_LOADED:-}" ]] && return 0
@@ -68,6 +70,12 @@ NMR_CLASS_GENUINE_AUTHORITY="genuine-authority"
 NMR_CLASS_TEMPORARY="temporary"
 NMR_SOURCE_DEFAULT="default"
 NMR_STATUS_HUMAN_AUTHORITY="human-authority-required"
+NMR_TRANSITION_TRUSTED_CLEAR="trusted-clear"
+NMR_TRANSITION_TRUSTED_HOLD="trusted-hold"
+NMR_TRANSITION_CRYPTO_APPROVED="crypto-approved"
+NMR_AUTO_RESULT_NORMALIZED="normalized"
+NMR_AUTO_RESULT_APPROVED="approved"
+_NMR_AUTO_TRANSITION_RESULT=""
 
 _nmr_metadata_json() {
 	local code="$1"
@@ -214,8 +222,8 @@ _ever_nmr_cache_set() {
 #######################################
 # Check if an issue was ever labeled needs-maintainer-review (t1894).
 # Uses the immutable GitHub timeline API — label removal does not erase
-# the history. This is the provenance gate: once an issue is tagged NMR,
-# it requires cryptographic approval forever, regardless of current labels.
+# the history. This provenance remains relevant for external-author issues;
+# write-authorized authors are independently trusted and must not self-approve.
 #
 # Arguments:
 #   $1 - issue number
@@ -266,8 +274,54 @@ issue_was_ever_nmr() {
 }
 
 #######################################
+# Verify the live issue author's repository authority.
+#
+# NMR is an external-author trust gate. OWNER/MEMBER authority comes from live
+# issue metadata; COLLABORATOR must be backed by authenticated write+ permission.
+# Any missing or unverifiable metadata fails closed.
+#
+# Arguments: issue number, repo slug
+# Returns: 0=write-authorized author, 1=external author, 2=lookup failure
+#######################################
+_nmr_issue_author_has_repo_write_authority() {
+	local issue_num="$1"
+	local slug="$2"
+	local issue_meta=""
+	local identity=""
+	local issue_author=""
+	local issue_assoc=""
+	local issue_author_type=""
+	local authority_rc=0
+
+	[[ -n "$issue_num" && -n "$slug" ]] || return 2
+	issue_meta=$(gh api "$(_nmr_issue_api_path "$issue_num" "$slug")" 2>/dev/null) || return 2
+	# A trusted bot may have generated this issue from an external contribution.
+	# The explicit provenance label keeps that source authority gate intact.
+	if printf '%s' "$issue_meta" | jq -e \
+		'[.labels[]?.name] | index("external-contributor") != null' >/dev/null 2>&1; then
+		return 1
+	fi
+	identity=$(printf '%s' "$issue_meta" | jq -r '
+		if (.user.login // "") != "" and (.author_association // "") != ""
+		then [(.user.login // ""), (.author_association // ""), (.user.type // "")] | @tsv
+		else error("missing live issue author metadata") end
+	' 2>/dev/null) || return 2
+	IFS=$'\t' read -r issue_author issue_assoc issue_author_type <<<"$identity"
+	[[ -n "$issue_author" && -n "$issue_assoc" ]] || return 2
+	[[ "$issue_author_type" == "Bot" ]] && return 0
+
+	_gh_actor_has_repo_write_authority "$slug" "$issue_author" "$issue_assoc" || authority_rc=$?
+	case "$authority_rc" in
+	0) return 0 ;;
+	1) return 1 ;;
+	*) return 2 ;;
+	esac
+}
+
+#######################################
 # Check if an issue requires cryptographic approval and has it (t1894).
-# Combines the "ever-NMR" provenance check with signature verification.
+# Combines external-author authority, "ever-NMR" provenance, and signature
+# verification. A write-authorized issue author never needs self-approval.
 #
 # Arguments:
 #   $1 - issue number
@@ -282,6 +336,13 @@ issue_has_required_approval() {
 
 	# If it was never NMR-labeled, no approval needed
 	if ! issue_was_ever_nmr "$issue_num" "$slug" "$known_status"; then
+		return 0
+	fi
+
+	# #aidevops:trust-boundary — history cannot turn a trusted author into an
+	# external contributor. Unknown live authority still falls through to the
+	# cryptographic gate rather than weakening it.
+	if _nmr_issue_author_has_repo_write_authority "$issue_num" "$slug"; then
 		return 0
 	fi
 
@@ -300,10 +361,10 @@ issue_has_required_approval() {
 }
 
 #######################################
-# GH#18671 / t2386 / GH#29151: Check whether an NMR label application on
-# an issue corresponds to a trusted automation default or deterministic
-# workflow-reapplication marker. These signatures are safe to auto-clear
-# only after reason-coded, circuit-breaker, and security gates have passed.
+# GH#18671 / t2386 / GH#29151: Recognize historical NMR automation defaults
+# and deterministic workflow-reapplication markers. Current internal producers
+# use hold-for-review or status:blocked; these signatures remain for safe
+# compatibility normalization of pre-migration issues.
 #
 # This function used to also match circuit-breaker trip markers
 # (stale-recovery-tick:escalated, cost-circuit-breaker:fired,
@@ -314,11 +375,9 @@ issue_has_required_approval() {
 # sessions and fired 22 watchdog kills + 5 auto-approve cycles in one
 # afternoon before the loop was diagnosed.
 #
-# Breaker trip detection now lives in `_nmr_application_is_circuit_breaker_trip`
-# below. `_nmr_applied_by_maintainer` consults both helpers and routes
-# breaker trips to "preserve NMR" while still auto-clearing
-# creation defaults. See t2386 brief and AGENTS.md
-# "Cryptographic issue/PR approval" for the split semantics.
+# Breaker trip detection lives in `_nmr_application_is_circuit_breaker_trip`
+# below. `_nmr_applied_by_maintainer` consults both helpers so legacy machine
+# failures cannot blind-redispatch while current producers use structural state.
 #
 # Automation signatures detected (t2686/GH#29151 extended set):
 #   - source:review-scanner                 — GH#18538 post-merge-review-scanner.sh (comment marker)
@@ -402,7 +461,7 @@ _nmr_application_has_automation_signature() {
 	#   - source:review-scanner     — post-merge-review-scanner.sh
 	#   - source:review-feedback    — quality-feedback-helper.sh scan-merged
 	local issue_meta_json
-	issue_meta_json=$(gh api "repos/${slug}/issues/${issue_num}" 2>/dev/null) || issue_meta_json=""
+	issue_meta_json=$(gh api "$(_nmr_issue_api_path "$issue_num" "$slug")" 2>/dev/null) || issue_meta_json=""
 
 	local has_bot_label=0
 	if [[ -n "$issue_meta_json" ]]; then
@@ -436,16 +495,13 @@ _nmr_application_has_automation_signature() {
 }
 
 #######################################
-# t2386: Check whether an NMR label application corresponds to a
-# circuit-breaker trip — one of the automated safety mechanisms that
-# STOPS further dispatch when a retry limit has been exceeded or a
-# cost budget has been exhausted.
+# t2386 compatibility: Check whether a historical NMR label application
+# corresponds to a circuit-breaker trip. Current breakers use status:blocked,
+# cooldowns, or root-cause meta-issues instead of an authority label.
 #
-# Breaker trips MUST preserve NMR. auto_approve_maintainer_issues
-# skips issues with a breaker-trip signature, leaving NMR in place
-# until a human runs `sudo aidevops approve issue <N>` after reviewing
-# why the breaker tripped. This is the safety mechanism whose defeat
-# caused the #19756 infinite-loop incident.
+# Legacy breaker trips remain held during normalization so an author-authority
+# cleanup cannot trigger the #19756 retry loop. New breaker producers must not
+# apply NMR.
 #
 # Breaker-trip signatures detected:
 #   - <!-- stale-recovery-tick:escalated   — t2008 stale recovery (retry limit)
@@ -463,7 +519,7 @@ _nmr_application_has_automation_signature() {
 #   $3 - label_at   : ISO8601 timestamp when NMR label was applied
 #
 # Exit codes:
-#   0 - breaker-trip signature found (NMR must be preserved)
+#   0 - legacy breaker-trip signature found (structural hold must be preserved)
 #   1 - no breaker-trip signature
 #######################################
 _nmr_application_is_circuit_breaker_trip() {
@@ -523,7 +579,7 @@ _nmr_application_is_circuit_breaker_trip() {
 #######################################
 # Check whether the current NMR label is part of an unresolved breaker episode.
 #
-# Recovery-loop incidents: a recovery/cost/no-work breaker can apply NMR with a
+# Legacy recovery-loop incidents: a recovery/cost/no-work breaker can apply NMR with a
 # marker, then a later automated retry can fail and re-apply NMR without
 # reposting the original marker. Looking only at the latest label event then
 # misclassifies the issue as a safe maintainer-authored automation default and
@@ -531,7 +587,7 @@ _nmr_application_is_circuit_breaker_trip() {
 #
 # This helper deliberately searches breaker markers at or before the latest NMR
 # label event. Once a breaker marker exists, the NMR remains a real hold until
-# cryptographic approval or a newer aidevops release allows one retry.
+# safe structural normalization or a newer aidevops release allows one retry.
 #
 # Args:
 #   $1 - issue_num  : GitHub issue number
@@ -585,16 +641,13 @@ _nmr_application_has_breaker_history() {
 #######################################
 # Check whether an NMR issue is security-sensitive.
 #
-# Security-labelled work must not be auto-cleared by the generic
-# creation-default path. The NMR label is the human review gate for findings
-# involving credentials, auth, approval/merge gates, supply chain, and similar
-# security boundaries. A scanner provenance marker proves automation created
-# the issue; it does not prove the recommended remediation is safe to dispatch.
+# Security-labelled work must not be auto-dispatched by a generic creation-
+# default cleanup. Trusted-author security review becomes hold-for-review;
+# external-author security work retains NMR until authority is approved.
 #
 # <!-- aidevops:trust-boundary -->
 # Treat the public `security` and `security-review` labels as authoritative
-# current-state holds. Once present, NMR requires cryptographic approval instead
-# of maintainer auto-approval.
+# current-state review holds independent of author authority.
 #
 # Args:
 #   $1 - issue_num  : GitHub issue number
@@ -1090,13 +1143,13 @@ _nmr_actor_event_is_manual_hold() {
 
 	local nmr_actor_authority_rc=0
 	#aidevops:trust-boundary -- a transient authority lookup must preserve an
-	# identified actor's NMR hold rather than silently treating it as automation.
+	# identified actor's review-hold intent rather than silently treating it as automation.
 	_gh_actor_has_repo_write_authority "$slug" "$nmr_actor" "COLLABORATOR" || nmr_actor_authority_rc=$?
 	case "$nmr_actor_authority_rc" in
 	0) ;;
 	1) return 1 ;;
 	*)
-		echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — authority lookup failed for actor=${nmr_actor}; preserving NMR" >>"$LOGFILE"
+		echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — authority lookup failed for actor=${nmr_actor}; preserving hold semantics" >>"$LOGFILE"
 		return 0
 		;;
 	esac
@@ -1114,10 +1167,9 @@ _nmr_actor_event_is_manual_hold() {
 }
 
 #######################################
-# Check if the needs-maintainer-review label was most recently applied
-# by a write-authorized maintainer (indicating a manual hold), OR by a
-# circuit breaker trip (which must be treated as a hold even though
-# the token actor is the maintainer).
+# Classify a trusted-author NMR application as an intentional hold or safe
+# automation residue. Intentional/legacy breaker state becomes an internal hold;
+# creation-default residue can be removed without self-approval.
 #
 # GH#18671 / t2386: the pulse runs as a write-authorized GitHub token,
 # so a maintainer-equivalent label actor matches all three cases:
@@ -1126,8 +1178,8 @@ _nmr_actor_event_is_manual_hold() {
 #   3. Circuit breaker trips (t2007 cost / t2008 stale) — MUST preserve
 #   4. Security-sensitive automation applies NMR — MUST preserve
 #
-# Cases 1, 3, and 4 are "preserve NMR" (return 0); case 2 is
-# "auto-clear OK" (return 1). The split is driven by companion helpers:
+# Cases 1, 3, and 4 are "preserve hold semantics" (return 0); case 2 is
+# "trusted normalization may clear" (return 1). Companion helpers provide
 # `_nmr_application_has_automation_signature` (creation defaults),
 # `_nmr_application_is_circuit_breaker_trip` (breaker trips), and
 # `_nmr_application_is_security_sensitive` (security review boundary).
@@ -1139,11 +1191,9 @@ _nmr_actor_event_is_manual_hold() {
 #   $2 - slug       : repo slug (owner/repo)
 #   $3 - maintainer : maintainer GitHub login
 #
-# Returns 0 if the maintainer applied NMR AND no creation-default
-#           signature is present (manual hold or breaker trip — do NOT
-#           auto-approve).
-# Returns 1 if NMR was applied by a scanner default or the actor is
-#           unknown (auto-approve OK).
+# Returns 0 for an intentional/manual, breaker, or security hold.
+# Returns 1 for trusted automation residue that may be removed without an
+#           approval marker.
 #######################################
 _nmr_applied_by_maintainer() {
 	local issue_num="$1"
@@ -1187,7 +1237,7 @@ _nmr_applied_by_maintainer() {
 				echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — ${release_retry_reason}; allowing one auto-approval retry" >>"$LOGFILE"
 				return 1
 			fi
-			echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — circuit breaker tripped by actor=${nmr_actor:-unknown} — PRESERVING NMR, requires 'sudo aidevops approve issue ${issue_num} ${slug}' (t2386/t3566)" >>"$LOGFILE"
+			echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — legacy circuit breaker tripped by actor=${nmr_actor:-unknown}; preserving structural hold semantics for trusted-author normalization (t2386/t3566)" >>"$LOGFILE"
 			# t3049: check if a subsequent worker produced a clean approved PR
 			# that resolves the stale-recovery false positive. Posts a one-shot
 			# notification to the maintainer if so. Does NOT clear NMR.
@@ -1205,7 +1255,7 @@ _nmr_applied_by_maintainer() {
 				echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — prior breaker marker found; ${history_retry_reason}; allowing one auto-approval retry" >>"$LOGFILE"
 				return 1
 			fi
-			echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — prior circuit breaker marker remains active after latest NMR relabel by actor=${nmr_actor:-unknown} — PRESERVING NMR, requires 'sudo aidevops approve issue ${issue_num} ${slug}' (t2386/t3566)" >>"$LOGFILE"
+			echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — prior circuit breaker marker remains active after latest NMR relabel by actor=${nmr_actor:-unknown}; preserving structural hold semantics for trusted-author normalization (t2386/t3566)" >>"$LOGFILE"
 			_notify_stale_recovery_resolved_by_pr "$issue_num" "$slug" "$nmr_at" || true
 			return 0
 		fi
@@ -1216,7 +1266,7 @@ _nmr_applied_by_maintainer() {
 		security_metadata=$(_nmr_metadata_json "security" "$NMR_CLASS_GENUINE_AUTHORITY" "security-label" true)
 		_nmr_record_revalidation_state "$issue_num" "$slug" "$security_metadata" "$nmr_at" "$NMR_STATUS_HUMAN_AUTHORITY" || true
 		_nmr_emit_decision_packet "$issue_num" "$slug" "security" || true
-		echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — security-sensitive label present — PRESERVING NMR, requires 'sudo aidevops approve issue ${issue_num} ${slug}'" >>"$LOGFILE"
+		echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — security-sensitive label present; preserving review-hold semantics for trusted-author normalization" >>"$LOGFILE"
 		return 0
 	fi
 
@@ -1313,13 +1363,13 @@ notify_ever_nmr_without_approval() {
 }
 
 #######################################
-# Verify that this runner is allowed to post maintainer-authority approval
-# comments for the upstream repo.
+# Verify that this runner may normalize a trusted-author NMR issue for the
+# upstream repo.
 #
 # <!-- aidevops:trust-boundary -->
 # Local repos.json can be wrong or copied to an external contributor's machine.
-# Before automation posts `aidevops-signed-approval` or says "maintainer is
-# author", self-validate against GitHub: the current token actor must have
+# Before automation removes or translates NMR, self-validate against GitHub:
+# the current token actor must have
 # write/maintain/admin permission on the target repo, and the issue author must
 # independently have write/maintain/admin authority. This includes account-pool
 # collaborators that create trusted scanner issues in a user-owned repository.
@@ -1343,26 +1393,49 @@ _nmr_current_actor_can_post_maintainer_approval() {
 	local issue_api_path
 	printf -v issue_api_path 'repos/%s/issues/%s' "$slug" "$issue_num"
 	issue_meta=$(gh api "$issue_api_path" 2>/dev/null) || issue_meta=""
-	[[ -n "$issue_meta" ]] || return 1
+	if [[ -z "$issue_meta" ]]; then
+		echo "[pulse-wrapper] trusted-author NMR normalization deferred for #${issue_num} in ${slug}: live issue metadata lookup failed" >>"$LOGFILE"
+		return 1
+	fi
+	if printf '%s' "$issue_meta" | jq -e \
+		'[.labels[]?.name] | index("external-contributor") != null' >/dev/null 2>&1; then
+		echo "[pulse-wrapper] trusted-author NMR normalization skipped for #${issue_num} in ${slug}: explicit external-contributor provenance requires approval" >>"$LOGFILE"
+		return 1
+	fi
 
 	local issue_author
 	local issue_assoc
+	local issue_author_type
 	issue_author=$(printf '%s' "$issue_meta" | jq -r '.user.login // empty' 2>/dev/null) || issue_author=""
 	issue_assoc=$(printf '%s' "$issue_meta" | jq -r '.author_association // "NONE"' 2>/dev/null) || issue_assoc="NONE"
+	issue_author_type=$(printf '%s' "$issue_meta" | jq -r '.user.type // ""' 2>/dev/null) || issue_author_type=""
 	[[ "$issue_author" == "$listed_author" ]] || return 1
 
 	# #aidevops:trust-boundary — never infer author authority from the mutable
 	# configured maintainer field or author_association alone.
-	_gh_actor_has_repo_write_authority "$slug" "$issue_author" "$issue_assoc" || return 1
+	if [[ "$issue_author_type" != "Bot" ]]; then
+		local issue_authority_rc=0
+		_gh_actor_has_repo_write_authority "$slug" "$issue_author" "$issue_assoc" || issue_authority_rc=$?
+		if [[ "$issue_authority_rc" -ne 0 ]]; then
+			[[ "$issue_authority_rc" -eq 2 ]] && echo "[pulse-wrapper] trusted-author NMR normalization deferred for #${issue_num} in ${slug}: issue-author authority lookup failed (${AIDEVOPS_GH_ACTOR_AUTHORITY_REASON:-unknown})" >>"$LOGFILE"
+			return 1
+		fi
+	fi
 
 	local actor
 	actor=$(gh api user --jq '.login // empty' 2>/dev/null) || actor=""
-	[[ -n "$actor" ]] || return 1
+	if [[ -z "$actor" ]]; then
+		echo "[pulse-wrapper] trusted-author NMR normalization deferred for #${issue_num} in ${slug}: current token identity lookup failed" >>"$LOGFILE"
+		return 1
+	fi
 
 	local actor_permission
 	# #aidevops:trust-boundary — maintainer approval posting requires confirmed
 	# write+ access; transient permission lookup failures fail closed.
-	_gh_collaborator_permission_lookup "$slug" "$actor" actor_permission || return 1
+	if ! _gh_collaborator_permission_lookup "$slug" "$actor" actor_permission; then
+		echo "[pulse-wrapper] trusted-author NMR normalization deferred for #${issue_num} in ${slug}: current token permission lookup failed (${AIDEVOPS_GH_COLLAB_PERMISSION_REASON:-unknown})" >>"$LOGFILE"
+		return 1
+	fi
 	case "$actor_permission" in
 	admin | maintain | write) return 0 ;;
 	*) return 1 ;;
@@ -1629,7 +1702,8 @@ _handle_knowledge_review_promotion() {
 	[[ -n "$issue_num" && -n "$slug" ]] || return 0
 
 	# Shared API path (avoids repeated literal, which would trip the string-literal ratchet)
-	local issue_api="repos/${slug}/issues/${issue_num}"
+	local issue_api=""
+	issue_api=$(_nmr_issue_api_path "$issue_num" "$slug")
 
 	# Only act on kind:knowledge-review issues
 	local has_kr_label
@@ -1682,9 +1756,9 @@ Knowledge source \`${source_id}\` promoted from staging to \`sources/\` after cr
 }
 
 #######################################
-# Restore the complete dispatchable state after trusted NMR approval.
-# Stale escalation removes both core status labels and auto-dispatch, so the
-# approval transition must not depend on a racing recovery writer.
+# Restore the complete dispatchable state after trusted-author normalization or
+# verified external approval. Legacy stale escalation removed both core status
+# labels and auto-dispatch, so this transition is self-contained.
 # Args: issue number, repo slug
 #######################################
 _nmr_restore_dispatchable_state() {
@@ -1698,32 +1772,107 @@ _nmr_restore_dispatchable_state() {
 	fi
 	gh issue edit "$issue_num" --repo "$slug" \
 		--remove-label "needs-maintainer-review" \
-		--add-label "status:available" \
-		--add-label "auto-dispatch" >/dev/null 2>&1
+		--add-label "status:available,auto-dispatch" >/dev/null 2>&1
 	return $?
 }
 
 #######################################
-# Auto-approve needs-maintainer-review issues using cryptographic
-# signature verification (t1894, replaces GH#16842 comment-based check).
+# Preserve intentional hold semantics while removing NMR from a trusted-author
+# issue. NMR is only an external trust gate; hold-for-review is the explicit
+# internal/manual hold.
+# Args: issue number, repo slug
+#######################################
+_nmr_translate_trusted_author_hold() {
+	local issue_num="$1"
+	local slug="$2"
+	if declare -F set_issue_status >/dev/null 2>&1; then
+		set_issue_status "$issue_num" "$slug" "" \
+			--remove-label "needs-maintainer-review" \
+			--add-label "hold-for-review" >/dev/null 2>&1
+		return $?
+	fi
+	gh issue edit "$issue_num" --repo "$slug" \
+		--remove-label "needs-maintainer-review" \
+		--add-label "hold-for-review" >/dev/null 2>&1
+	return $?
+}
+
+#######################################
+# Apply one trusted-author normalization or cryptographically approved external
+# transition. The caller owns aggregate counters; this helper records the
+# successful result in _NMR_AUTO_TRANSITION_RESULT.
+# Args: issue number, repo slug, transition kind, approval reason
+#######################################
+_nmr_apply_auto_approval_transition() {
+	local issue_num="$1"
+	local slug="$2"
+	local transition_kind="$3"
+	local approval_reason="$4"
+	_NMR_AUTO_TRANSITION_RESULT=""
+
+	case "$transition_kind" in
+	"$NMR_TRANSITION_TRUSTED_CLEAR")
+		if _nmr_restore_dispatchable_state "$issue_num" "$slug"; then
+			echo "[pulse-wrapper] Normalized trusted-author NMR on #${issue_num} in ${slug} — ${approval_reason}; no approval marker posted" >>"$LOGFILE"
+			_NMR_AUTO_TRANSITION_RESULT="$NMR_AUTO_RESULT_NORMALIZED"
+		else
+			echo "[pulse-wrapper] Trusted-author NMR normalization FAILED for #${issue_num} in ${slug}" >>"$LOGFILE"
+		fi
+		;;
+	"$NMR_TRANSITION_TRUSTED_HOLD")
+		if _nmr_translate_trusted_author_hold "$issue_num" "$slug"; then
+			echo "[pulse-wrapper] Translated trusted-author NMR on #${issue_num} in ${slug} to hold-for-review; no self-approval required" >>"$LOGFILE"
+			_NMR_AUTO_TRANSITION_RESULT="$NMR_AUTO_RESULT_NORMALIZED"
+		else
+			echo "[pulse-wrapper] Trusted-author hold translation FAILED for #${issue_num} in ${slug}" >>"$LOGFILE"
+		fi
+		;;
+	"$NMR_TRANSITION_CRYPTO_APPROVED")
+		# Lock before posting the trusted marker so untrusted comments cannot race
+		# the maintainer gate. The worker unlocks after dispatch completes.
+		gh issue lock "$issue_num" --repo "$slug" --reason "resolved" >/dev/null 2>&1 || true
+		gh_issue_comment "$issue_num" --repo "$slug" \
+			--body "<!-- aidevops-signed-approval -->
+<!-- stale-recovery-tick:0 (reset: auto-approved by maintainer — ${approval_reason}) -->
+Auto-approved: ${approval_reason}. Stale recovery tick reset." \
+			2>/dev/null || true
+
+		local edit_exit=0
+		_nmr_restore_dispatchable_state "$issue_num" "$slug" || edit_exit=$?
+		if [[ "$edit_exit" -eq 0 ]]; then
+			_NMR_AUTO_TRANSITION_RESULT="$NMR_AUTO_RESULT_APPROVED"
+			echo "[pulse-wrapper] Auto-approved #${issue_num} in ${slug} — ${approval_reason} (locked + approval marker + tick reset)" >>"$LOGFILE"
+			# t2845: promote knowledge-review source when applicable.
+			_handle_knowledge_review_promotion "$issue_num" "$slug" || true
+		else
+			echo "[pulse-wrapper] Auto-approve label update FAILED for #${issue_num} in ${slug} (exit: ${edit_exit}) — approval marker posted but labels unchanged" >>"$LOGFILE"
+		fi
+		;;
+	esac
+
+	return 0
+}
+
+#######################################
+# Normalize trusted-author NMR and process cryptographically approved external
+# NMR issues (t1894, replaces GH#16842 comment-based checks).
 #
 # The review gate exists for external contributions. Approval requires
 # a cryptographically signed comment posted via `sudo aidevops approve
 # issue <number>`. This ensures only a human with the system password
 # (and root access to the approval signing key) can approve issues.
 #
-# Fallback: maintainer-equivalent authored issues are still auto-approved (a
-# trusted scanner account should not gate its own issues), UNLESS a write-
-# authorized maintainer manually applied NMR — that signals an intentional hold
-# and must be preserved. Comment-based approval is removed — workers
-# share the same GitHub account so any comment from the account is
-# indistinguishable from a human comment.
+# Write-authorized authors never self-approve. Automation residue is removed
+# without an approval marker; an intentional/manual hold is translated to
+# hold-for-review. Comment-based approval remains forbidden because workers share
+# the same GitHub account and cannot prove human authority.
 #######################################
 auto_approve_maintainer_issues() {
 	local repos_json="$REPOS_JSON"
 	[[ -f "$repos_json" ]] || return 0
 
 	local total_approved=0
+	local total_normalized=0
 	local approval_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/approval-helper.sh"
 
 	while IFS='|' read -r slug maintainer; do
@@ -1747,67 +1896,50 @@ auto_approve_maintainer_issues() {
 			i=$((i + 1))
 			[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
 
-			local should_approve=false
+			local transition_kind=""
 			local approval_reason=""
 			_NMR_AUTO_APPROVAL_REASON_OVERRIDE=""
 
-			# Case 1: a maintainer-equivalent actor created the issue — auto-approve
-			# unless a write-authorized maintainer applied an intentional hold.
+			# Case 1: a write-authorized author never needs self-approval. Translate
+			# intentional/manual NMR to hold-for-review; otherwise remove the stray
+			# trust label and restore the dispatchable lifecycle state.
 			if _nmr_current_actor_can_post_maintainer_approval "$issue_num" "$slug" "$maintainer" "$issue_author"; then
 				if _nmr_applied_by_maintainer "$issue_num" "$slug" "$maintainer"; then
-					echo "[pulse-wrapper] Skipping auto-approve for #${issue_num} in ${slug} — NMR manually applied by maintainer" >>"$LOGFILE"
+					transition_kind="$NMR_TRANSITION_TRUSTED_HOLD"
+					approval_reason="trusted-author NMR hold translated to hold-for-review"
 				else
-					should_approve=true
+					transition_kind="$NMR_TRANSITION_TRUSTED_CLEAR"
 					approval_reason="${_NMR_AUTO_APPROVAL_REASON_OVERRIDE:-write-authorized maintainer is author, NMR applied by automation}"
 				fi
 			fi
 
 			# Case 2: cryptographic approval signature found
-			if [[ "$should_approve" == "false" && -f "$approval_helper" ]]; then
+			if [[ -z "$transition_kind" && -f "$approval_helper" ]]; then
 				local verify_result
 				verify_result=$(bash "$approval_helper" verify "$issue_num" "$slug" 2>/dev/null) || verify_result=""
 				if [[ "$verify_result" == "VERIFIED" ]]; then
-					should_approve=true
+					transition_kind="$NMR_TRANSITION_CRYPTO_APPROVED"
 					approval_reason="cryptographic approval verified"
 				fi
 			fi
 
-			if [[ "$should_approve" == "true" ]]; then
-				# Lock the issue BEFORE posting the approval marker to prevent
-				# comment prompt-injection. The marker (<!-- aidevops-signed-approval -->)
-				# is trusted by maintainer-gate.yml — if an attacker could post a
-				# comment containing it, they could bypass the NMR gate. Locking
-				# ensures only collaborators can comment during the approval window.
-				# The issue stays locked through dispatch (t1934) and unlocks after
-				# the worker completes.
-				gh issue lock "$issue_num" --repo "$slug" --reason "resolved" >/dev/null 2>&1 || true
-
-				# Post the approval marker BEFORE removing the label.
-				# maintainer-gate.yml checks for <!-- aidevops-signed-approval -->
-				# when NMR is removed — if the marker is missing, it re-adds NMR.
-				# Also resets the stale-recovery tick counter.
-				gh_issue_comment "$issue_num" --repo "$slug" \
-					--body "<!-- aidevops-signed-approval -->
-<!-- stale-recovery-tick:0 (reset: auto-approved by maintainer — ${approval_reason}) -->
-Auto-approved: ${approval_reason}. Stale recovery tick reset." \
-					2>/dev/null || true
-
-				_nmr_restore_dispatchable_state "$issue_num" "$slug"
-				local edit_exit=$?
-				if [[ "$edit_exit" -eq 0 ]]; then
-					echo "[pulse-wrapper] Auto-approved #${issue_num} in ${slug} — ${approval_reason} (locked + approval marker + tick reset)" >>"$LOGFILE"
-					total_approved=$((total_approved + 1))
-					# t2845: promote knowledge-review source if this is a kind:knowledge-review issue
-					_handle_knowledge_review_promotion "$issue_num" "$slug" || true
-				else
-					echo "[pulse-wrapper] Auto-approve label update FAILED for #${issue_num} in ${slug} (exit: ${edit_exit}) — approval marker posted but labels unchanged" >>"$LOGFILE"
-				fi
-			fi
+			_nmr_apply_auto_approval_transition "$issue_num" "$slug" "$transition_kind" "$approval_reason"
+			case "$_NMR_AUTO_TRANSITION_RESULT" in
+			"$NMR_AUTO_RESULT_NORMALIZED")
+				total_normalized=$((total_normalized + 1))
+				;;
+			"$NMR_AUTO_RESULT_APPROVED")
+				total_approved=$((total_approved + 1))
+				;;
+			esac
 		done
 	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.maintainer // (.slug | split("/")[0]))"' "$repos_json" 2>/dev/null)
 
 	if [[ "$total_approved" -gt 0 ]]; then
 		echo "[pulse-wrapper] Auto-approve maintainer issues: approved ${total_approved} issue(s)" >>"$LOGFILE"
+	fi
+	if [[ "$total_normalized" -gt 0 ]]; then
+		echo "[pulse-wrapper] Trusted-author NMR normalization: normalized ${total_normalized} issue(s)" >>"$LOGFILE"
 	fi
 
 	return 0

--- a/.agents/scripts/pulse-simplification-issues.sh
+++ b/.agents/scripts/pulse-simplification-issues.sh
@@ -400,10 +400,11 @@ _complexity_scan_process_single_md_file() {
 	local issue_body
 	issue_body=$(_complexity_scan_md_build_full_body "$file_path" "$line_count" "$topic_label" "$recheck_mode" "$state_file")
 
-	# Build label list — skip needs-maintainer-review when user is maintainer (GH#16786)
+	# Non-maintainer admins receive an explicit review hold; NMR is reserved for
+	# external-author trust gates (GH#16786/GH#29394).
 	local review_label=""
 	if [[ "${_COMPLEXITY_SCAN_SKIP_REVIEW_GATE:-false}" != "true" ]]; then
-		review_label="--label needs-maintainer-review"
+		review_label="--label hold-for-review"
 	fi
 
 	local create_ok=false
@@ -582,10 +583,10 @@ _complexity_scan_sh_create_issue() {
 	issue_body=$(_complexity_scan_sh_build_issue_body_with_sig "$file_path" "$violation_count" "$details")
 
 	local issue_title="simplification: reduce function complexity in ${file_path} (${violation_count} functions >${COMPLEXITY_FUNC_LINE_THRESHOLD} lines)"
-	# Skip needs-maintainer-review when user is maintainer (GH#16786)
+	# Non-maintainer admins receive an explicit review hold.
 	local review_label_sh=""
 	if [[ "${_COMPLEXITY_SCAN_SKIP_REVIEW_GATE:-false}" != "true" ]]; then
-		review_label_sh="--label needs-maintainer-review"
+		review_label_sh="--label hold-for-review"
 	fi
 	# t1955: Don't self-assign — let dispatch_with_dedup handle assignment.
 	# shellcheck disable=SC2086

--- a/.agents/scripts/pulse-simplification-scan.sh
+++ b/.agents/scripts/pulse-simplification-scan.sh
@@ -327,10 +327,11 @@ This is an automated stall-detection sweep. The LLM should review the actual iss
 		--tokens 0 --time "$_sweep_elapsed" --session-type routine 2>/dev/null || true)
 	sweep_body="${sweep_body}${sig_footer}"
 
-	# Skip needs-maintainer-review when user is maintainer (GH#16786)
+	# Non-maintainer admins receive hold-for-review; NMR is reserved for
+	# external-author trust gates (GH#16786/GH#29394).
 	local sweep_review_label=""
 	if [[ "${_COMPLEXITY_SCAN_SKIP_REVIEW_GATE:-false}" != "true" ]]; then
-		sweep_review_label="--label needs-maintainer-review"
+		sweep_review_label="--label hold-for-review"
 	fi
 	# shellcheck disable=SC2086
 	# t1955: Don't self-assign on issue creation — let dispatch_with_dedup handle
@@ -578,9 +579,8 @@ _complexity_scan_permission_gate() {
 		esac
 	fi
 
-	# When the authenticated user IS the repo maintainer, skip the
-	# needs-maintainer-review label — the standard auto-dispatch + PR
-	# review flow provides sufficient gating (GH#16786).
+	# When the authenticated user IS the configured maintainer, skip the explicit
+	# hold — the standard auto-dispatch + PR review flow is sufficient (GH#16786).
 	local maintainer_from_config
 	maintainer_from_config=$(jq -r --arg slug "$aidevops_slug" \
 		'.initialized_repos[] | select(.slug == $slug) | .maintainer // empty' \

--- a/.agents/scripts/pulse-wrapper-config.sh
+++ b/.agents/scripts/pulse-wrapper-config.sh
@@ -254,7 +254,7 @@ FAST_FAIL_INITIAL_BACKOFF_SECS="${FAST_FAIL_INITIAL_BACKOFF_SECS:-600}" # 10 min
 FAST_FAIL_MAX_BACKOFF_SECS="${FAST_FAIL_MAX_BACKOFF_SECS:-604800}"      # 7-day max backoff
 FAST_FAIL_AGE_OUT_SECONDS="${FAST_FAIL_AGE_OUT_SECONDS:-86400}"         # Auto-reset HARD STOP after 24h quiet period (t2397)
 FAST_FAIL_AGE_OUT_MIN_COUNT="${FAST_FAIL_AGE_OUT_MIN_COUNT:-5}"         # Only age-out issues at/above HARD STOP threshold (t2397)
-FAST_FAIL_AGE_OUT_MAX_RESETS="${FAST_FAIL_AGE_OUT_MAX_RESETS:-3}"       # Max auto-resets before NMR escalation (t2397)
+FAST_FAIL_AGE_OUT_MAX_RESETS="${FAST_FAIL_AGE_OUT_MAX_RESETS:-3}"       # Max auto-resets before status:blocked escalation (t2397)
 
 EVER_NMR_CACHE_FILE="${EVER_NMR_CACHE_FILE:-${HOME}/.aidevops/.agent-workspace/supervisor/ever-nmr-cache.json}"
 EVER_NMR_NEGATIVE_CACHE_TTL_SECS="${EVER_NMR_NEGATIVE_CACHE_TTL_SECS:-300}" # Recheck negative results after 5 min

--- a/.agents/scripts/quality-feedback-issues-lib.sh
+++ b/.agents/scripts/quality-feedback-issues-lib.sh
@@ -363,9 +363,11 @@ _build_quality_debt_labels() {
 	fi
 
 	# GH#17916: External PRs get needs-maintainer-review so the dispatch gate
-	# actually blocks until the maintainer approves. Maintainer PRs skip this.
+	# actually blocks until the maintainer approves. Preserve the external-origin
+	# provenance because the generated issue itself is authored by trusted
+	# automation. Maintainer PRs skip this gate.
 	if [[ "$is_maintainer_pr" != "true" ]]; then
-		label_args="${label_args},needs-maintainer-review"
+		label_args="${label_args},external-contributor,needs-maintainer-review"
 	fi
 
 	printf '%s' "$label_args"
@@ -625,7 +627,7 @@ _create_or_append_file_issue() {
 #      Avoids a gh api call on solo-maintainer repos (the common case).
 #   2. Collaborator-permission probe:
 #      gh api repos/{slug}/collaborators/{user}/permission.
-#      Accepts permission ∈ {admin, maintain}. Fail-closed on API errors
+#      Accepts permission ∈ {admin, maintain, write}. Fail-closed on API errors
 #      (404, 403, network failure) — an unreachable API is not a trust
 #      signal; default to NOT maintainer-equivalent so NMR still applies.
 #
@@ -661,7 +663,8 @@ _is_maintainer_equivalent_author() {
 		return 0
 	fi
 
-	# Stage 2: collaborator permission probe. Accepts admin or maintain.
+	# Stage 2: collaborator permission probe. NMR is an external-authority gate,
+	# so every authenticated write-level collaborator is trusted here.
 	# #aidevops:trust-boundary — maintainer-equivalent classification requires
 	# confirmed admin/maintain; lookup failures fail closed separately from none.
 	local collab_permission=""
@@ -669,7 +672,7 @@ _is_maintainer_equivalent_author() {
 		echo "[quality-feedback] permission check failed for author ${pr_author} on ${repo_slug} (HTTP ${AIDEVOPS_GH_COLLAB_PERMISSION_HTTP:-unknown}) — not treating as maintainer-equivalent" >&2
 		return 1
 	}
-	if [[ "$collab_permission" == "admin" || "$collab_permission" == "maintain" ]]; then
+	if [[ "$collab_permission" == "admin" || "$collab_permission" == "maintain" || "$collab_permission" == "write" ]]; then
 		echo "[quality-feedback] author ${pr_author} has ${collab_permission} permission on ${repo_slug} — treating as maintainer-equivalent (t2686)" >&2
 		return 0
 	fi

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -186,6 +186,87 @@ _gh_ci_prepare_status_label() {
 	return 0
 }
 
+# GH#29394: NMR is reserved for external-author trust gates. Wrapper-created
+# issues are authored by the authenticated token actor, so a live write-level
+# permission check can safely translate a legacy trusted-author NMR request to
+# the structural hold-for-review label before the issue-created event fires.
+# Unknown or insufficient permission fails closed and preserves NMR.
+_GH_CI_TRUST_NORMALIZED_ARGS=()
+_gh_ci_replace_nmr_label_csv() {
+	local labels_csv="$1"
+	local old_ifs="${IFS-}"
+	local ifs_was_set=0
+	local label=""
+	local normalized=""
+	local hold_seen=0
+	local -a labels=()
+
+	[[ -n "${IFS+x}" ]] && ifs_was_set=1
+	IFS=',' read -ra labels <<<"$labels_csv"
+	if [[ "$ifs_was_set" -eq 1 ]]; then
+		IFS="$old_ifs"
+	else
+		unset IFS
+	fi
+
+	for label in "${labels[@]}"; do
+		[[ "$label" == "needs-maintainer-review" ]] && label="hold-for-review"
+		if [[ "$label" == "hold-for-review" ]]; then
+			[[ "$hold_seen" -eq 1 ]] && continue
+			hold_seen=1
+		fi
+		if [[ -n "$normalized" ]]; then
+			normalized="${normalized},${label}"
+		else
+			normalized="$label"
+		fi
+	done
+	printf '%s\n' "$normalized"
+	return 0
+}
+
+_gh_ci_prepare_trusted_nmr_labels() {
+	_GH_CI_TRUST_NORMALIZED_ARGS=("$@")
+	_gh_wrapper_args_have_label "needs-maintainer-review" "$@" || return 0
+	# A trusted automation account can create an issue from external source
+	# material. The explicit provenance label keeps that authority boundary from
+	# being mistaken for a self-review hold.
+	if _gh_wrapper_args_have_label "external-contributor" "$@"; then
+		print_info "[INFO] GH#29394: preserving external-origin needs-maintainer-review"
+		return 0
+	fi
+
+	local target_repo=""
+	target_repo=$(_gh_extract_repo_from_args "$@" 2>/dev/null || true)
+	[[ -n "$target_repo" ]] || return 0
+	declare -F _gh_current_user_allows_repo_write >/dev/null 2>&1 || return 0
+	if ! _gh_current_user_allows_repo_write "$target_repo" >/dev/null 2>&1; then
+		print_warning "[WARN] GH#29394: preserving needs-maintainer-review because creator write authority could not be verified (${AIDEVOPS_GH_WRITE_PERMISSION_REASON:-unknown})"
+		return 0
+	fi
+
+	local i=0
+	local labels_csv=""
+	while [[ "$i" -lt ${#_GH_CI_TRUST_NORMALIZED_ARGS[@]} ]]; do
+		case "${_GH_CI_TRUST_NORMALIZED_ARGS[i]}" in
+		--label)
+			if [[ $((i + 1)) -lt ${#_GH_CI_TRUST_NORMALIZED_ARGS[@]} ]]; then
+				labels_csv=$(_gh_ci_replace_nmr_label_csv "${_GH_CI_TRUST_NORMALIZED_ARGS[i + 1]}")
+				_GH_CI_TRUST_NORMALIZED_ARGS[i + 1]="$labels_csv"
+				i=$((i + 1))
+			fi
+			;;
+		--label=*)
+			labels_csv=$(_gh_ci_replace_nmr_label_csv "${_GH_CI_TRUST_NORMALIZED_ARGS[i]#--label=}")
+			_GH_CI_TRUST_NORMALIZED_ARGS[i]="--label=${labels_csv}"
+			;;
+		esac
+		i=$((i + 1))
+	done
+	print_info "[INFO] GH#29394: translated trusted-author needs-maintainer-review to hold-for-review"
+	return 0
+}
+
 _GH_CI_CONTRACT_ARGS=()
 _gh_ci_prepare_parent_close_contract() {
 	local is_parent_task="$1"
@@ -317,11 +398,16 @@ gh_create_issue() {
 	_gh_ci_prepare_parent_contract_and_signature "$@"
 	set -- "${_GH_CI_READY_ARGS[@]}"
 
+	# Fold derived labels into one list, then normalize trusted-author NMR before
+	# building either the GraphQL or REST creation command.
 	if [[ ${#_todo_label_args[@]} -gt 0 ]]; then
-		_gh_ci_prepare_status_label "$@" "${_todo_label_args[@]}"
+		_gh_ci_prepare_trusted_nmr_labels "$@" "${_todo_label_args[@]}"
 	else
-		_gh_ci_prepare_status_label "$@"
+		_gh_ci_prepare_trusted_nmr_labels "$@"
 	fi
+	set -- "${_GH_CI_TRUST_NORMALIZED_ARGS[@]}"
+	_todo_label_args=()
+	_gh_ci_prepare_status_label "$@"
 
 	# Build command arrays safely; avoid empty-arg injection (GH#22056).
 	local -a _issue_cmd=(gh issue create "$@")
@@ -329,10 +415,6 @@ gh_create_issue() {
 	if [[ ${#_GH_CI_STATUS_LABEL_ARGS[@]} -gt 0 ]]; then
 		_issue_cmd+=("${_GH_CI_STATUS_LABEL_ARGS[@]}")
 		_rest_args+=("${_GH_CI_STATUS_LABEL_ARGS[@]}")
-	fi
-	if [[ ${#_todo_label_args[@]} -gt 0 ]]; then
-		_issue_cmd+=("${_todo_label_args[@]}")
-		_rest_args+=("${_todo_label_args[@]}")
 	fi
 	if [[ ${#_origin_label_args[@]} -gt 0 ]]; then
 		_issue_cmd+=("${_origin_label_args[@]}")

--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -748,8 +748,7 @@ _verify_issue_status_convergence() {
 #   $2 — repo slug (owner/repo)
 #   $3 — new status: one of available|queued|claimed|in-progress|in-review|done|blocked
 #        OR empty string to clear all core status labels without adding one
-#        (used by stale-recovery escalation which applies needs-maintainer-review
-#        instead of a core status)
+#        (used only when a caller intentionally wants no lifecycle status)
 #   $@ — additional gh issue edit flags passed through verbatim (e.g.,
 #        --add-assignee, --remove-assignee, --add-label "other-non-status-label")
 #
@@ -764,8 +763,8 @@ _verify_issue_status_convergence() {
 #       --add-assignee "$worker_login" \
 #       --add-label "origin:worker"
 #
-#   set_issue_status 18444 owner/repo "" \
-#       --add-label "needs-maintainer-review"
+#   set_issue_status 18444 owner/repo blocked \
+#       --add-label "hold-for-review"
 #######################################
 set_issue_status() {
 	gh_record_call rest set_issue_status 2>/dev/null || true

--- a/.agents/scripts/stats-quality-sweep-issues.sh
+++ b/.agents/scripts/stats-quality-sweep-issues.sh
@@ -560,7 +560,7 @@ This file contributes to a verified repository-wide threshold deficit on the cur
 
 ### Dispatch and review policy
 
-Trusted maintainer-owned sweeps label safe structural cleanup for bounded autonomous dispatch at \`tier:thinking\`. External or unverified automation retains \`needs-maintainer-review\`; reserve that gate for an actual behavior, API, security, or architecture trade-off rather than model strength alone.
+Trusted maintainer-owned sweeps label safe structural cleanup for bounded autonomous dispatch at \`tier:thinking\`. External or unverified creators retain \`needs-maintainer-review\` only until authority is approved. If trusted automation identifies a genuine behavior, API, security, or architecture decision, use \`hold-for-review\`; model strength alone is not a review gate.
 BODY
 	return 0
 }

--- a/.agents/scripts/tests/test-circuit-breaker-meta-filer.sh
+++ b/.agents/scripts/tests/test-circuit-breaker-meta-filer.sh
@@ -11,8 +11,8 @@
 #       existing meta-issue URL without creating a duplicate
 #   (3) honours AIDEVOPS_CIRCUIT_BREAKER_META_FILE_DISABLE=1 as a no-op
 #   (4) validates --breaker as one of {cost,no_work}
-#   (5) unblock-on-merge removes blocked-by:#<meta> from the original
-#       and clears NMR when no other breaker markers remain
+#   (5) unblock-on-merge removes blocked-by:#<meta> from the original and
+#       restores status:available when no other current blockers remain
 #
 # Modeled on test-cost-circuit-breaker.sh (t2007).
 
@@ -61,10 +61,12 @@ FIXTURE_COMMENTS_JSON="${TEST_ROOT}/fixture-comments.json"
 FIXTURE_META_BODY="${TEST_ROOT}/fixture-meta-body"
 FIXTURE_HAS_FRAMEWORK_SOURCE="${TEST_ROOT}/fixture-has-framework-source"
 FIXTURE_REPO_PRIVATE="${TEST_ROOT}/fixture-repo-private"
+FIXTURE_BLOCKED_BY_COUNT="${TEST_ROOT}/fixture-blocked-by-count"
 echo '[]' >"$FIXTURE_COMMENTS_JSON"
 echo '' >"$FIXTURE_META_BODY"
 printf '1' >"$FIXTURE_HAS_FRAMEWORK_SOURCE"
 printf 'false' >"$FIXTURE_REPO_PRIVATE"
+printf '0' >"$FIXTURE_BLOCKED_BY_COUNT"
 
 write_stub_gh() {
 	cat >"${STUB_DIR}/gh" <<STUB
@@ -93,6 +95,17 @@ fi
 # gh api repos/SLUG/issues/N/comments --paginate
 if [[ "\$1" == "api" ]]; then
 	case "\$2" in
+		/repos/*/labels*)
+			printf 'status:available\t0e8a16\tTask is available for claiming\n'
+			printf 'status:queued\tfbca04\tWorker dispatched, not yet started\n'
+			printf 'status:claimed\tf9d0c4\tInteractive session claimed this task\n'
+			printf 'status:in-progress\t1d76db\tWorker actively running\n'
+			printf 'status:in-review\t5319e7\tPR open, awaiting review/merge\n'
+			printf 'status:done\t6f42c1\tTask is complete\n'
+			printf 'status:blocked\td93f0b\tWaiting on blocker task\n'
+			exit 0 ;;
+		/repos/*/issues/*)
+			exit 1 ;;
 		repos/*/contents/.agents/scripts/circuit-breaker-meta-filer.sh*)
 			if [[ "\$(cat "${FIXTURE_HAS_FRAMEWORK_SOURCE}")" == "1" ]]; then
 				echo '{"type":"file"}'
@@ -121,6 +134,12 @@ fi
 
 # gh issue comment N --repo SLUG --body B
 if [[ "\$1" == "issue" && "\$2" == "comment" ]]; then
+	exit 0
+fi
+
+# gh issue view N --json labels --jq ...
+if [[ "\$1" == "issue" && "\$2" == "view" ]]; then
+	cat "${FIXTURE_BLOCKED_BY_COUNT}"
 	exit 0
 fi
 
@@ -174,6 +193,7 @@ reset_stubs() {
 	echo '' >"$FIXTURE_META_BODY"
 	printf '1' >"$FIXTURE_HAS_FRAMEWORK_SOURCE"
 	printf 'false' >"$FIXTURE_REPO_PRIVATE"
+	printf '0' >"$FIXTURE_BLOCKED_BY_COUNT"
 	return 0
 }
 
@@ -268,10 +288,11 @@ else
 	print_result "cross-repo: create call targets framework repo" 1 "stub log: $(cat "$STUB_LOG")"
 fi
 
-if grep -qE 'issue edit 4003 --repo exampleorg/examplerepo --add-label blocked-by:marcusquinn/aidevops#99999' "$STUB_LOG"; then
-	print_result "cross-repo: original gets full blocked-by label" 0
+if grep -qE 'issue edit 4003 --repo exampleorg/examplerepo .*--add-label status:blocked .*--add-label blocked-by:marcusquinn/aidevops#99999' "$STUB_LOG" &&
+	! grep -q -- '--add-label needs-maintainer-review' "$STUB_LOG"; then
+	print_result "cross-repo: original gets structural block and full blocked-by label" 0
 else
-	print_result "cross-repo: original gets full blocked-by label" 1 "stub log: $(cat "$STUB_LOG")"
+	print_result "cross-repo: original gets structural block and full blocked-by label" 1 "stub log: $(cat "$STUB_LOG")"
 fi
 
 if grep -q 'circuit-breaker-meta-filed:marcusquinn/aidevops#99999' "$STUB_LOG"; then
@@ -421,6 +442,13 @@ else
 	print_result "unblock: removes blocked-by:#<meta>" 1 "stub log: $(cat "$STUB_LOG")"
 fi
 
+if grep -qE 'issue edit 21840 .*--add-label status:available' "$STUB_LOG" \
+	&& ! grep -q -- '--remove-label needs-maintainer-review' "$STUB_LOG"; then
+	print_result "unblock: restores status:available without clearing NMR" 0
+else
+	print_result "unblock: restores status:available without clearing NMR" 1 "stub log: $(cat "$STUB_LOG")"
+fi
+
 # Assert: an unblock comment was posted on #21840
 if grep -qE 'issue comment 21840 ' "$STUB_LOG"; then
 	print_result "unblock: posts unblock comment on original" 0
@@ -460,6 +488,29 @@ if grep -qE 'issue comment 4003 --repo exampleorg/examplerepo' "$STUB_LOG"; then
 	print_result "unblock-cross-repo: posts comment on original repo" 0
 else
 	print_result "unblock-cross-repo: posts comment on original repo" 1 "stub log: $(cat "$STUB_LOG")"
+fi
+
+# =============================================================================
+# Test 5c: unblock-on-merge — another current blocked-by label keeps blocked
+# =============================================================================
+reset_stubs
+printf '1' >"$FIXTURE_BLOCKED_BY_COUNT"
+cat >"$FIXTURE_META_BODY" <<'EOF'
+## Tracking original issue
+
+- Original: marcusquinn/aidevops#21840
+- Breaker: `t2769 no_work` (`cost-circuit-breaker:no_work_loop`)
+EOF
+
+OUT=$("$META_FILER" unblock-on-merge \
+	--meta 99999 --repo marcusquinn/aidevops 2>&1)
+RC=$?
+if [[ "$RC" -eq 0 ]] \
+	&& ! grep -q -- '--add-label status:available' "$STUB_LOG" \
+	&& ! grep -q -- '--remove-label needs-maintainer-review' "$STUB_LOG"; then
+	print_result "unblock-other-blocker: preserves blocked lifecycle and NMR" 0
+else
+	print_result "unblock-other-blocker: preserves blocked lifecycle and NMR" 1 "rc=$RC output=$OUT stub log: $(cat "$STUB_LOG")"
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-cost-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-cost-circuit-breaker.sh
@@ -227,10 +227,12 @@ else
 	print_result "cost breaker trip writes diagnostic log line" 1 "(log=$(tr '\n' ' ' <"$LOGFILE" 2>/dev/null))"
 fi
 
-if grep -q 'sudo aidevops approve issue 18002 owner/repo' "$STUB_LOG" 2>/dev/null; then
-	print_result "cost breaker comment includes approval command" 0
+if grep -q 'issue edit 18002 .*--add-label status:blocked' "$STUB_LOG" 2>/dev/null &&
+	! grep -q -- '--add-label needs-maintainer-review' "$STUB_LOG" 2>/dev/null &&
+	! grep -q -- '--remove-label needs-maintainer-review' "$STUB_LOG" 2>/dev/null; then
+	print_result "cost breaker uses structural blocked state without mutating NMR" 0
 else
-	print_result "cost breaker comment includes approval command" 1 "(stub_log=$(tr '\n' ' ' <"$STUB_LOG" 2>/dev/null))"
+	print_result "cost breaker uses structural blocked state without mutating NMR" 1 "(stub_log=$(tr '\n' ' ' <"$STUB_LOG" 2>/dev/null))"
 fi
 
 # =============================================================================
@@ -283,16 +285,14 @@ else
 fi
 
 # =============================================================================
-# Assertion 7 — side-effect idempotency: when needs-maintainer-review is
-# already present, _apply_cost_breaker_side_effects must NOT post a new
-# `gh issue comment` call. We measure by comparing stub log lines before
-# and after a second over-budget invocation on the same issue.
+# Assertion 7 — side-effect idempotency uses the immutable breaker marker,
+# not a legacy NMR label or generic blocked status.
 # =============================================================================
 # Fresh log so the count is local to this assertion
 : >"$STUB_LOG"
-# Fixture: over budget AND needs-maintainer-review already on the issue
-write_fixture_issue '[{"name":"tier:standard"},{"name":"needs-maintainer-review"}]'
-write_fixture_comments "500000,400000"
+# Fixture: over budget, structurally blocked, and already carrying the marker.
+write_fixture_issue '[{"name":"tier:standard"},{"name":"status:blocked"}]'
+write_fixture_comments_with_existing_cost_marker "500000,400000"
 run_check_cost_budget 18007 "owner/repo" "standard"
 # The signal must still be emitted (so dispatch is blocked)…
 if [[ "$rc" -eq 0 && "$output" == *"COST_BUDGET_EXCEEDED"* ]]; then
@@ -307,9 +307,9 @@ else
 	idem_no_comment_ok=0
 fi
 if [[ "$idem_signal_ok" -eq 0 && "$idem_no_comment_ok" -eq 0 ]]; then
-	print_result "side-effect idempotency (label present → no double-comment)" 0
+	print_result "side-effect idempotency (marker present → no double-comment)" 0
 else
-	print_result "side-effect idempotency (label present → no double-comment)" 1 \
+	print_result "side-effect idempotency (marker present → no double-comment)" 1 \
 		"(signal_ok=$idem_signal_ok no_comment_ok=$idem_no_comment_ok output='$output')"
 fi
 

--- a/.agents/scripts/tests/test-dispatch-backoff-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-backoff-helper.sh
@@ -10,7 +10,7 @@
 #   3. 1st failure: 5min cooldown (300s) — blocks dispatch during window
 #   4. 2nd failure: 30min cooldown (1800s)
 #   5. 3rd failure: 2h cooldown (7200s)
-#   6. 4th+ failure: 24h cooldown + NMR_REQUIRED flag in stderr
+#   6. 4th+ failure: 24h cooldown + BACKOFF_NOTICE_REQUIRED flag in stderr
 #   7. Fails open on JSONL read error (missing file)
 #   8. Emergency bypass via AIDEVOPS_SKIP_DISPATCH_BACKOFF=1
 #   9. Stats counter increments on backoff block
@@ -18,7 +18,7 @@
 #  11. rate_limit_fast and provider metadata-only rate-limit signals count toward per-issue backoff
 #
 # Stub strategy: write a fixture JSONL file with controlled timestamps.
-# No gh stubs needed for the check subcommand (NMR application tests use gh stubs).
+# No gh stubs needed for the check subcommand (notice-posting tests use gh stubs).
 
 set -uo pipefail
 
@@ -74,7 +74,7 @@ pulse_stats_increment() {
 }
 export -f pulse_stats_increment
 
-# Stub gh for NMR tests — captures calls without network.
+# Stub gh for notice tests — captures calls without network.
 gh() {
 	printf '[gh-stub] %s\n' "$*" >>"${TMP}/gh-calls.log"
 	return 0
@@ -267,8 +267,8 @@ test_three_failures_blocked() {
 	return 0
 }
 
-# --- Test 6: 4+ failures → 24h cooldown + NMR_REQUIRED ---
-test_four_failures_nmr() {
+# --- Test 6: 4+ failures → 24h cooldown + BACKOFF_NOTICE_REQUIRED ---
+test_four_failures_notice() {
 	reset_test_state
 	local now
 	now=$(date +%s)
@@ -288,10 +288,10 @@ test_four_failures_nmr() {
 	else
 		fail "4-failure output shows 86400s cooldown" "output: ${output}"
 	fi
-	if printf '%s' "$output" | grep -q 'NMR_REQUIRED'; then
-		pass "4-failure output contains NMR_REQUIRED"
+	if printf '%s' "$output" | grep -q 'BACKOFF_NOTICE_REQUIRED'; then
+		pass "4-failure output contains BACKOFF_NOTICE_REQUIRED"
 	else
-		fail "4-failure output contains NMR_REQUIRED" "output: ${output}"
+		fail "4-failure output contains BACKOFF_NOTICE_REQUIRED" "output: ${output}"
 	fi
 	return 0
 }
@@ -436,8 +436,8 @@ test_provider_pressure_blocks_pool() {
 	return 0
 }
 
-# --- Test 14: rate_limit_fast entries trigger per-issue 24h cooldown + NMR_REQUIRED ---
-test_rate_limit_fast_entries_trigger_nmr() {
+# --- Test 14: rate_limit_fast entries trigger per-issue 24h cooldown + notice ---
+test_rate_limit_fast_entries_trigger_notice() {
 	reset_test_state
 	local now
 	now=$(date +%s)
@@ -452,10 +452,10 @@ test_rate_limit_fast_entries_trigger_nmr() {
 	else
 		fail "rate_limit_fast entries trigger per-issue backoff" "got exit ${rc} output=${output}"
 	fi
-	if printf '%s' "$output" | grep -q 'NMR_REQUIRED'; then
-		pass "rate_limit_fast 4+ entries emit NMR_REQUIRED"
+	if printf '%s' "$output" | grep -q 'BACKOFF_NOTICE_REQUIRED'; then
+		pass "rate_limit_fast 4+ entries emit BACKOFF_NOTICE_REQUIRED"
 	else
-		fail "rate_limit_fast 4+ entries emit NMR_REQUIRED" "output: ${output}"
+		fail "rate_limit_fast 4+ entries emit BACKOFF_NOTICE_REQUIRED" "output: ${output}"
 	fi
 	return 0
 }
@@ -501,10 +501,10 @@ test_provider_metadata_rate_limit_entries_count() {
 	else
 		fail "provider metadata-only rate limits trigger per-issue backoff" "got exit ${rc} output=${output}"
 	fi
-	if printf '%s' "$output" | grep -q 'NMR_REQUIRED'; then
-		pass "provider metadata-only 4+ entries emit NMR_REQUIRED"
+	if printf '%s' "$output" | grep -q 'BACKOFF_NOTICE_REQUIRED'; then
+		pass "provider metadata-only 4+ entries emit BACKOFF_NOTICE_REQUIRED"
 	else
-		fail "provider metadata-only 4+ entries emit NMR_REQUIRED" "output: ${output}"
+		fail "provider metadata-only 4+ entries emit BACKOFF_NOTICE_REQUIRED" "output: ${output}"
 	fi
 	return 0
 }
@@ -517,7 +517,7 @@ test_one_failure_elapsed_clear
 test_one_failure_within_cooldown_blocked
 test_two_failures_blocked
 test_three_failures_blocked
-test_four_failures_nmr
+test_four_failures_notice
 test_missing_jsonl_fail_open
 test_bypass
 test_stats_counter_incremented
@@ -525,7 +525,7 @@ test_ac3_two_failures_blocks_third
 test_old_events_ignored
 test_different_issue_not_affected
 test_provider_pressure_blocks_pool
-test_rate_limit_fast_entries_trigger_nmr
+test_rate_limit_fast_entries_trigger_notice
 test_mixed_rate_limit_entries_aggregate
 test_provider_metadata_rate_limit_entries_count
 

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -744,6 +744,13 @@ test_issue_author_guard_blocks_missing_label_bypass() {
 	[[ "$rc" -eq 1 && "$out" == *"no verified approval"* ]] && check=0
 	print_result "issue-author guard blocks missing-label bypass" "$check" "rc=$rc output=$out"
 
+	_DSI_TARGET_JSON='{"author_association":"NONE","user":{"login":"github-actions[bot]","type":"Bot"},"labels":[{"name":"external-contributor"}]}'
+	rc=0
+	out=$(_dsi_guard_issue_author_trust 28700 owner/repo 2>&1) || rc=$?
+	check=1
+	[[ "$rc" -eq 1 && "$out" == *"external_source=true"* ]] && check=0
+	print_result "issue-author guard blocks external-origin bot without approval" "$check" "rc=$rc output=$out"
+
 	printf '%s\n' '#!/usr/bin/env bash' 'printf "VERIFIED\n"' >"$helper"
 	rc=0
 	_dsi_guard_issue_author_trust 28700 owner/repo >/dev/null 2>&1 || rc=$?

--- a/.agents/scripts/tests/test-fast-fail-age-out.sh
+++ b/.agents/scripts/tests/test-fast-fail-age-out.sh
@@ -21,7 +21,7 @@
 #   4. After reset, fast_fail_is_skipped returns 1 (safe to dispatch)
 #   5. reset_count increments on each age-out
 #   6. After FAST_FAIL_AGE_OUT_MAX_RESETS, the counter is not reset
-#   7. After FAST_FAIL_AGE_OUT_MAX_RESETS, NMR is applied
+#   7. After FAST_FAIL_AGE_OUT_MAX_RESETS, status:blocked is applied
 #   8. Exhausted age-out retries route to consolidation
 #   9. Issue comment posted once per age-out event
 #  10. Infra/no_work hard stops use FAST_FAIL_INFRA_AGE_OUT_SECONDS
@@ -140,6 +140,17 @@ source "${SCRIPTS_DIR}/pulse-fast-fail.sh" >/dev/null 2>&1 || {
 	exit 1
 }
 
+# Capture lifecycle transitions after the production module has sourced the
+# shared wrapper implementation.
+set_issue_status() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local status="$3"
+	shift 3
+	printf 'set_issue_status %s %s %s %s\n' "$issue_number" "$repo_slug" "$status" "$*" >>"${GH_CALLS}"
+	return 0
+}
+
 printf '%sRunning fast_fail_age_out tests (t2397)%s\n' "$TEST_BLUE" "$TEST_NC"
 
 # =============================================================================
@@ -240,17 +251,17 @@ else
 fi
 
 # =============================================================================
-# Test 6 — after MAX_RESETS, NMR label applied (not another reset)
+# Test 6 — after MAX_RESETS, structural block applied (not another reset)
 # =============================================================================
 : >"$GH_CALLS"
-# reset_count=3 means this would be the 4th reset (> max=3), so NMR fires.
+# reset_count=3 means this would be the 4th reset (> max=3), so the block fires.
 _write_ff_entry "105" "6" "20" "3"
 CONSOLIDATION_CALLS=0
 LAST_CONSOLIDATION=""
 
 fast_fail_age_out "105" "test/repo" 2>/dev/null || true
 
-# count should NOT have been reset to 0 (ceiling triggered NMR instead)
+# count should NOT have been reset to 0 (ceiling triggered a structural block instead)
 result_count=$(jq -r '."test/repo/105".count // -1' "$FAST_FAIL_STATE_FILE" 2>/dev/null) || result_count="-1"
 gh_calls_content=$(cat "$GH_CALLS" 2>/dev/null || true)
 
@@ -261,11 +272,12 @@ else
 		"expected count=6 (unchanged), got count=${result_count}"
 fi
 
-if printf '%s' "$gh_calls_content" | grep -q "needs-maintainer-review"; then
-	pass "after MAX_RESETS exceeded → needs-maintainer-review label applied"
+if printf '%s' "$gh_calls_content" | grep -q "set_issue_status 105 test/repo blocked" \
+	&& ! printf '%s' "$gh_calls_content" | grep -q -- "--add-label needs-maintainer-review"; then
+	pass "after MAX_RESETS exceeded → status:blocked applied without NMR"
 else
-	fail "after MAX_RESETS exceeded → needs-maintainer-review label applied" \
-		"expected 'needs-maintainer-review' in gh calls: ${gh_calls_content}"
+	fail "after MAX_RESETS exceeded → status:blocked applied without NMR" \
+		"expected blocked lifecycle transition without NMR addition: ${gh_calls_content}"
 fi
 
 if [[ "$CONSOLIDATION_CALLS" -eq 1 && "$LAST_CONSOLIDATION" == "105|test/repo|fast-fail-age-out-ceiling|maximum automatic resets exhausted" ]]; then

--- a/.agents/scripts/tests/test-full-loop-external-issue-author-gate.sh
+++ b/.agents/scripts/tests/test-full-loop-external-issue-author-gate.sh
@@ -118,6 +118,8 @@ main() {
 		printf 'FAIL external block did not attempt containment label\n' >&2
 		TESTS_FAILED=$((TESTS_FAILED + 1))
 	fi
+	check_gate "external-origin bot without approval blocks" 1 \
+		'{"author_association":"NONE","user":{"login":"github-actions[bot]","type":"Bot"},"labels":[{"name":"external-contributor"}]}'
 
 	: >"$GH_CALLS"
 	write_approval_helper VERIFIED

--- a/.agents/scripts/tests/test-generated-issue-worker-labels.sh
+++ b/.agents/scripts/tests/test-generated-issue-worker-labels.sh
@@ -137,6 +137,11 @@ test_simplification_md_labels() {
 	assert_create_contains "md simplification has status available" "--label status:available"
 	assert_create_contains "md simplification has worker origin" "--label origin:worker"
 	assert_create_contains "md simplification has standard tier" "--label tier:standard"
+	reset_create_log
+	_COMPLEXITY_SCAN_SKIP_REVIEW_GATE=false _complexity_scan_process_single_md_file \
+		".agents/reference/example-held.md" "501" "marcusquinn/aidevops" "$PWD" "" "marcusquinn" >/dev/null
+	assert_create_contains "md simplification review gate uses hold-for-review" "--label hold-for-review"
+	assert_create_not_contains "md simplification review gate never uses NMR" "needs-maintainer-review"
 	return 0
 }
 
@@ -161,6 +166,7 @@ test_quality_feedback_labels() {
 	[[ "$maintainer_labels" == *"origin:worker"* ]] && print_result "quality labels include worker origin" 0 || print_result "quality labels include worker origin" 1 "$maintainer_labels"
 	[[ "$maintainer_labels" == *"tier:standard"* ]] && print_result "quality labels include tier" 0 || print_result "quality labels include tier" 1 "$maintainer_labels"
 	[[ "$external_labels" == *"needs-maintainer-review"* && "$external_labels" == *"auto-dispatch"* ]] && print_result "external quality labels keep NMR with dispatch label" 0 || print_result "external quality labels keep NMR with dispatch label" 1 "$external_labels"
+	[[ "$external_labels" == *"external-contributor"* ]] && print_result "external quality labels preserve source authority provenance" 0 || print_result "external quality labels preserve source authority provenance" 1 "$external_labels"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-gh-wrapper-nmr-normalization.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-nmr-normalization.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Trusted-author creation-time NMR normalization regression coverage.
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPT_DIR="$(cd "${TEST_DIR}/.." && pwd)" || exit 1
+
+# shellcheck source=../shared-gh-wrappers-create.sh
+source "${SCRIPT_DIR}/shared-gh-wrappers-create.sh"
+
+_gh_wrapper_args_have_label() {
+	local expected="$1"
+	shift
+	local previous=""
+	local arg=""
+	for arg in "$@"; do
+		if [[ "$previous" == "--label" && ",${arg}," == *",${expected},"* ]]; then
+			return 0
+		fi
+		if [[ "$arg" == --label=* && ",${arg#--label=}," == *",${expected},"* ]]; then
+			return 0
+		fi
+		previous="$arg"
+	done
+	return 1
+}
+
+_gh_extract_repo_from_args() {
+	local previous=""
+	local arg=""
+	for arg in "$@"; do
+		if [[ "$previous" == "--repo" ]]; then
+			printf '%s\n' "$arg"
+			return 0
+		fi
+		if [[ "$arg" == --repo=* ]]; then
+			printf '%s\n' "${arg#--repo=}"
+			return 0
+		fi
+		previous="$arg"
+	done
+	return 1
+}
+
+print_info() {
+	return 0
+}
+
+print_warning() {
+	return 0
+}
+
+CURRENT_WRITE_ALLOWED=1
+_gh_current_user_allows_repo_write() {
+	local repo_slug="$1"
+	[[ -n "$repo_slug" ]] || return 1
+	[[ "$CURRENT_WRITE_ALLOWED" -eq 1 ]] || return 1
+	return 0
+}
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	exit 1
+}
+
+_gh_ci_prepare_trusted_nmr_labels --repo owner/repo \
+	--label 'bug,needs-maintainer-review,auto-dispatch'
+[[ "${_GH_CI_TRUST_NORMALIZED_ARGS[*]}" == *"bug,hold-for-review,auto-dispatch"* ]] ||
+	fail "trusted creator NMR was not translated"
+
+_gh_ci_prepare_trusted_nmr_labels --repo=owner/repo \
+	--label='needs-maintainer-review,hold-for-review,bug'
+[[ "${_GH_CI_TRUST_NORMALIZED_ARGS[*]}" == *"--label=hold-for-review,bug"* ]] ||
+	fail "hold-for-review was not deduplicated"
+
+_gh_ci_prepare_trusted_nmr_labels --repo owner/repo \
+	--label 'quality-debt,external-contributor,needs-maintainer-review'
+[[ "${_GH_CI_TRUST_NORMALIZED_ARGS[*]}" == *"external-contributor,needs-maintainer-review"* ]] ||
+	fail "external-origin authority gate was normalized as trusted self-review"
+
+CURRENT_WRITE_ALLOWED=0
+_gh_ci_prepare_trusted_nmr_labels --repo owner/repo \
+	--label 'bug,needs-maintainer-review'
+[[ "${_GH_CI_TRUST_NORMALIZED_ARGS[*]}" == *"bug,needs-maintainer-review"* ]] ||
+	fail "unknown or external creator did not retain NMR"
+
+printf 'PASS: trusted-author wrapper NMR normalization\n'

--- a/.agents/scripts/tests/test-headless-runtime-checkpoint-tests.sh
+++ b/.agents/scripts/tests/test-headless-runtime-checkpoint-tests.sh
@@ -162,7 +162,7 @@ test_post_pr_handoff_rejects_mismatched_head_or_missing_summary() {
 	return 0
 }
 
-test_failed_worker_draft_checkpoint_escalates_without_completion() {
+test_failed_worker_draft_checkpoint_preserves_continuation_without_completion() {
 	local result=""
 	local escalation_marker="${TEST_ROOT}/draft-checkpoint-escalated"
 	rm -f "$escalation_marker"
@@ -178,10 +178,11 @@ test_failed_worker_draft_checkpoint_escalates_without_completion() {
 			_hrw_resolve_default_branch() { printf 'main'; return 0; }
 			_pr_handoff_state_for_branch_or_issue() { printf 'draft_checkpoint|456'; return 0; }
 			_release_dispatch_claim() { printf 'release=%s\n' "$2"; return 0; }
-			set_issue_status() { : >"$escalation_marker"; return 0; }
+			_hrff_resolve_release_runner_login() { printf 'worker-bot'; return 0; }
+			set_issue_status() { printf '%s\n' "$*" >"$escalation_marker"; return 0; }
 			gh() {
 				if [[ "${*}" == *"issue view 99999"* ]]; then
-					printf '%s\n' '{"labels":[{"name":"needs-maintainer-review"}]}'
+					printf '%s\n' '{"state":"OPEN","labels":[{"name":"status:in-review"},{"name":"needs-maintainer-review"}],"assignees":[{"login":"worker-bot"}]}'
 				fi
 				return 0
 			}
@@ -189,10 +190,16 @@ test_failed_worker_draft_checkpoint_escalates_without_completion() {
 			printf 'classification=%s\n' "${_HRW_RECOVERY_CLASSIFICATION:-}"
 		)
 	)
-	if [[ "$result" == *"release=worker_draft_checkpoint"* && -f "$escalation_marker" && "$result" == *"classification=worker_draft_checkpoint"* ]]; then
-		print_result "failed worker draft checkpoint escalates without worker_complete" 0
+	local transition=""
+	transition=$(<"$escalation_marker")
+	if [[ "$result" == *"release=worker_draft_checkpoint"* && \
+		"$transition" == *"99999 test-owner/test-repo in-review"* && \
+		"$transition" != *"needs-maintainer-review"* && \
+		"$transition" == *"--add-assignee worker-bot"* && \
+		"$result" == *"classification=worker_draft_checkpoint"* ]]; then
+		print_result "failed worker draft checkpoint preserves exact-head continuation without worker_complete" 0
 	else
-		print_result "failed worker draft checkpoint escalates without worker_complete" 1 "$result"
+		print_result "failed worker draft checkpoint preserves exact-head continuation without worker_complete" 1 "result=${result} transition=${transition}"
 	fi
 	return 0
 }
@@ -295,9 +302,9 @@ test_failed_worker_draft_retains_claim_when_block_not_visible() {
 		)
 	)
 	if [[ "$result" == *"classification=worker_draft_checkpoint_escalation_failed"* && "$result" != *"unexpected-release="* ]]; then
-		print_result "draft checkpoint retains claim when blocking label read-back fails" 0
+		print_result "draft checkpoint retains claim when continuation read-back fails" 0
 	else
-		print_result "draft checkpoint retains claim when blocking label read-back fails" 1 "$result"
+		print_result "draft checkpoint retains claim when continuation read-back fails" 1 "$result"
 	fi
 	return 0
 }
@@ -327,7 +334,7 @@ test_protected_draft_is_not_mutated_or_completed() {
 	return 0
 }
 
-test_checkpoint_terminal_telemetry_is_failed_escalated() {
+test_checkpoint_terminal_telemetry_is_deferred() {
 	local fixture_class="draft_checkpoint"
 	local expected_reason="worker_draft_checkpoint"
 	local result
@@ -340,10 +347,10 @@ test_checkpoint_terminal_telemetry_is_failed_escalated() {
 				"$_HRW_FINAL_RUNTIME_STATUS" "$_HRW_FINAL_RUNTIME_CLASSIFICATION"
 		)
 	)
-	if [[ "$result" == "failed|worker.failed|escalated|${expected_reason}" ]]; then
-		print_result "${fixture_class} records failed/escalated terminal telemetry" 0
+	if [[ "$result" == "deferred|worker.deferred|checkpointed|${expected_reason}" ]]; then
+		print_result "${fixture_class} records deferred checkpoint telemetry" 0
 	else
-		print_result "${fixture_class} records failed/escalated terminal telemetry" 1 "$result"
+		print_result "${fixture_class} records deferred checkpoint telemetry" 1 "$result"
 	fi
 	return 0
 }
@@ -498,15 +505,14 @@ test_pr_checkpoint_lifecycle_cases() {
 	test_post_pr_handoff_propagates_classifier_failure
 	test_post_pr_handoff_treats_ci_as_monitoring_state
 	test_post_pr_handoff_rejects_mismatched_head_or_missing_summary
-	test_failed_worker_draft_checkpoint_escalates_without_completion
+	test_failed_worker_draft_checkpoint_preserves_continuation_without_completion
 	test_dirty_worktree_checkpoint_is_deferred_not_complete
 	test_exit_trap_dirty_checkpoint_is_deferred_not_complete
 	test_failed_worker_draft_retains_claim_when_block_not_visible
 	test_protected_draft_is_not_mutated_or_completed
-	test_checkpoint_terminal_telemetry_is_failed_escalated
+	test_checkpoint_terminal_telemetry_is_deferred
 	test_failed_ci_ready_pr_is_durable_handoff
 	test_closed_unmerged_pr_is_failed_not_completed
 	test_failed_worker_ready_pr_remains_completed_handoff
 	return 0
 }
-

--- a/.agents/scripts/tests/test-issue-triage-gate-fail-closed.sh
+++ b/.agents/scripts/tests/test-issue-triage-gate-fail-closed.sh
@@ -56,6 +56,10 @@ main() {
 		"label creation requires an independent missing-label confirmation"
 	check_pattern "const trustedRoles = \['OWNER', 'MEMBER'\]" \
 		"bare collaborator association is excluded from trusted roles"
+	check_pattern "issue\.user\.type === 'Bot' \|\|" \
+		"trusted bots run through stale-NMR cleanup instead of returning early"
+	check_pattern "hasExternalAuthoritySource = issueLabels\.has\('external-contributor'\)" \
+		"trusted automation preserves explicit external-source authority gates"
 	check_pattern "collaborators/\{username\}/permission" \
 		"collaborator authority uses the repository permission endpoint"
 	check_pattern "Run trusted-author cleanup first" \

--- a/.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh
+++ b/.agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh
@@ -241,7 +241,13 @@ test_issue_approval_paths() {
 	fi
 	assert_no_mutation "trusted collaborator bot cleanup does not restore NMR"
 	assert_job_restores_nmr issue issue-bot-trust-api-failure "unverifiable bot cleanup" "github-actions[bot]"
-	assert_job_restores_nmr issue issue-bot-stale-trusted "late bot cleanup of trusted issue" "github-actions[bot]"
+	: >"$GH_CALLS"
+	if run_issue_job issue-bot-stale-trusted 'github-actions[bot]' '[]' trusted-author >/dev/null 2>&1; then
+		print_result "late bot cleanup is accepted for live OWNER author" 0
+	else
+		print_result "late bot cleanup is accepted for live OWNER author" 1 "job returned non-zero"
+	fi
+	assert_no_mutation "late trusted-author cleanup does not restore NMR"
 	: >"$GH_CALLS"
 	run_issue_job issue-unsigned maintainer '["persistent"]' >/dev/null 2>&1 || true
 	if grep -q '^issue edit .*--add-label needs-maintainer-review' "$GH_CALLS"; then

--- a/.agents/scripts/tests/test-maintainer-gate-origin-worker-api-failure.sh
+++ b/.agents/scripts/tests/test-maintainer-gate-origin-worker-api-failure.sh
@@ -146,6 +146,21 @@ test_confirmed_external_is_remediated() {
 	return 0
 }
 
+test_read_only_collaborator_author_is_remediated() {
+	: >"$GH_CALLS"
+	if run_job external COLLABORATOR >/dev/null 2>&1; then
+		print_result "read-only collaborator author completes external remediation" 0
+	else
+		print_result "read-only collaborator author completes external remediation" 1 "job returned non-zero"
+	fi
+	if grep -q '^issue edit .*--add-label needs-maintainer-review' "$GH_CALLS"; then
+		print_result "read-only collaborator author receives NMR gate" 0
+	else
+		print_result "read-only collaborator author receives NMR gate" 1 "expected NMR issue edit"
+	fi
+	return 0
+}
+
 test_unknown_author_association_is_non_mutating() {
 	: >"$GH_CALLS"
 	if run_job unknown-association API_ERROR >/dev/null 2>&1; then
@@ -183,6 +198,7 @@ main() {
 	test_api_failure_is_non_mutating
 	test_trusted_collaborator_is_allowed
 	test_confirmed_external_is_remediated
+	test_read_only_collaborator_author_is_remediated
 	test_unknown_author_association_is_non_mutating
 	test_owner_authored_unlabel_is_restored_from_webhook
 	printf '\nTests run: %d\nTests failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-nmr-hold-comment-locked.sh
+++ b/.agents/scripts/tests/test-nmr-hold-comment-locked.sh
@@ -29,12 +29,30 @@ const execute = new Function(
   'github',
   'context',
   'console',
+  'core',
   `return (async () => {\n${script}\n})();`
 );
 
-async function runScenario({ locked = false, comments = [], createError } = {}) {
-  const calls = { paginate: 0, createComment: 0, logs: [] };
+async function runScenario({
+  locked = false,
+  comments = [],
+  createError,
+  association = 'CONTRIBUTOR',
+  userType = 'User',
+  permission = 'read',
+  labels = [],
+  removeError
+} = {}) {
+  const calls = {
+    paginate: 0,
+    createComment: 0,
+    addLabels: 0,
+    removeLabel: 0,
+    logs: [],
+    warnings: []
+  };
   const github = {
+    request: async () => ({ data: { permission } }),
     paginate: async () => {
       calls.paginate += 1;
       return comments;
@@ -45,6 +63,13 @@ async function runScenario({ locked = false, comments = [], createError } = {}) 
         createComment: async () => {
           calls.createComment += 1;
           if (createError) throw createError;
+        },
+        addLabels: async () => {
+          calls.addLabels += 1;
+        },
+        removeLabel: async () => {
+          calls.removeLabel += 1;
+          if (removeError) throw removeError;
         }
       }
     }
@@ -56,12 +81,15 @@ async function runScenario({ locked = false, comments = [], createError } = {}) 
       issue: {
         number: 42,
         locked,
-        author_association: 'MEMBER'
+        author_association: association,
+        user: { login: 'issue-author', type: userType },
+        labels: labels.map(name => ({ name }))
       }
     }
   };
   const testConsole = { log: message => calls.logs.push(message) };
-  await execute(github, context, testConsole);
+  const core = { warning: message => calls.warnings.push(message) };
+  await execute(github, context, testConsole, core);
   return calls;
 }
 
@@ -74,6 +102,35 @@ async function main() {
   const unlocked = await runScenario();
   assert.equal(unlocked.paginate, 1, 'unlocked issue must preserve paginated dedup');
   assert.equal(unlocked.createComment, 1, 'unlocked issue without guidance must post once');
+
+  const trustedOwner = await runScenario({ association: 'OWNER' });
+  assert.equal(trustedOwner.addLabels, 1, 'trusted OWNER NMR must become a structural hold');
+  assert.equal(trustedOwner.removeLabel, 1, 'trusted OWNER NMR must be removed');
+  assert.equal(trustedOwner.paginate, 0, 'trusted normalization must not post external approval guidance');
+
+  const trustedCollaborator = await runScenario({
+    association: 'COLLABORATOR',
+    permission: 'write'
+  });
+  assert.equal(trustedCollaborator.addLabels, 1, 'write collaborator NMR must become a structural hold');
+  assert.equal(trustedCollaborator.removeLabel, 1, 'write collaborator NMR must be removed');
+
+  const externalOriginBot = await runScenario({
+    association: 'NONE',
+    userType: 'Bot',
+    labels: ['external-contributor']
+  });
+  assert.equal(externalOriginBot.addLabels, 0, 'external-origin bot NMR must not become an internal hold');
+  assert.equal(externalOriginBot.removeLabel, 0, 'external-origin bot NMR must remain live');
+  assert.equal(externalOriginBot.createComment, 1, 'external-origin bot NMR must receive approval guidance');
+
+  const failedRemoval = new Error('rate limited');
+  failedRemoval.status = 429;
+  await assert.rejects(
+    runScenario({ association: 'MEMBER', removeError: failedRemoval }),
+    failedRemoval,
+    'trusted normalization failure must remain observable'
+  );
 
   const deduplicated = await runScenario({
     comments: [{ body: '<!-- nmr-hold-guidance --> already posted' }]

--- a/.agents/scripts/tests/test-no-work-prelaunch-skip.sh
+++ b/.agents/scripts/tests/test-no-work-prelaunch-skip.sh
@@ -6,7 +6,7 @@
 #
 # A canary or worktree-precreation launch-control skip can be reported as a
 # no_work reason before a worker process reaches the issue brief. That reason
-# must not trip the t2769 no_work NMR breaker, while genuine post-launch no_work
+# must not trip the t2769 no_work structural breaker, while genuine post-launch no_work
 # failures still use the existing threshold behaviour.
 
 set -uo pipefail
@@ -78,7 +78,7 @@ gh_issue_comment() {
 	return 0
 }
 
-test_prelaunch_reason_skips_nmr_breaker() {
+test_prelaunch_reason_skips_breaker() {
 	reset_observations
 	local output=""
 	output=$(_log_no_work_skip_escalation \
@@ -86,22 +86,22 @@ test_prelaunch_reason_skips_nmr_breaker() {
 		"worker canary preflight failed before worktree pre-creation; will retry next cycle" 2>&1)
 
 	if [[ "$BREAKER_CALLS" -ne 0 ]]; then
-		fail "prelaunch no_work skip does not apply NMR" "breaker payload: ${LAST_BREAKER_PAYLOAD}"
+		fail "prelaunch no_work skip does not apply structural blocker" "breaker payload: ${LAST_BREAKER_PAYLOAD}"
 		return 0
 	fi
 	if [[ "$COMMENT_CALLS" -ne 0 ]]; then
 		fail "prelaunch no_work skip does not post diagnostic comment" "comment calls: ${COMMENT_CALLS}"
 		return 0
 	fi
-	if [[ "$output" != *"NMR breaker skipped for pre-launch reason"* ]]; then
+	if [[ "$output" != *"no_work breaker skipped for pre-launch reason"* ]]; then
 		fail "prelaunch no_work skip logs audit line" "output: ${output}"
 		return 0
 	fi
-	pass "prelaunch no_work skip bypasses NMR breaker"
+	pass "prelaunch no_work skip bypasses structural breaker"
 	return 0
 }
 
-test_worker_launch_rc_2_skips_nmr_breaker() {
+test_worker_launch_rc_2_skips_breaker() {
 	reset_observations
 	local output=""
 	output=$(_log_no_work_skip_escalation \
@@ -109,14 +109,14 @@ test_worker_launch_rc_2_skips_nmr_breaker() {
 		"dispatch_aborted:worker_launch_rc_2" 2>&1)
 
 	if [[ "$BREAKER_CALLS" -ne 0 ]]; then
-		fail "worker_launch_rc_2 skip does not apply NMR" "breaker payload: ${LAST_BREAKER_PAYLOAD}"
+		fail "worker_launch_rc_2 skip does not apply structural blocker" "breaker payload: ${LAST_BREAKER_PAYLOAD}"
 		return 0
 	fi
-	if [[ "$output" != *"NMR breaker skipped for pre-launch reason"* ]]; then
+	if [[ "$output" != *"no_work breaker skipped for pre-launch reason"* ]]; then
 		fail "worker_launch_rc_2 skip logs audit line" "output: ${output}"
 		return 0
 	fi
-	pass "worker_launch_rc_2 bypasses no_work NMR breaker"
+	pass "worker_launch_rc_2 bypasses no_work structural breaker"
 	return 0
 }
 
@@ -171,29 +171,29 @@ test_sensitive_temp_preflight_skips_fast_fail_state() {
 	return 0
 }
 
-test_postlaunch_noop_still_applies_nmr_breaker() {
+test_postlaunch_noop_still_applies_structural_breaker() {
 	reset_observations
 	_log_no_work_skip_escalation \
 		"4003" "exampleorg/examplerepo" "3" \
 		"worker_noop_zero_output" >/dev/null 2>&1
 
 	if [[ "$BREAKER_CALLS" -ne 1 ]]; then
-		fail "postlaunch no_work still applies NMR" "breaker calls: ${BREAKER_CALLS}"
+		fail "postlaunch no_work still applies structural blocker" "breaker calls: ${BREAKER_CALLS}"
 		return 0
 	fi
 	if [[ "$LAST_BREAKER_PAYLOAD" != "4003|exampleorg/examplerepo|3|3|worker_noop_zero_output" ]]; then
 		fail "postlaunch no_work breaker payload is preserved" "payload: ${LAST_BREAKER_PAYLOAD}"
 		return 0
 	fi
-	pass "postlaunch no_work still applies NMR breaker"
+	pass "postlaunch no_work still applies structural breaker"
 	return 0
 }
 
-test_prelaunch_reason_skips_nmr_breaker
-test_worker_launch_rc_2_skips_nmr_breaker
+test_prelaunch_reason_skips_breaker
+test_worker_launch_rc_2_skips_breaker
 test_launch_preflight_reason_skips_fast_fail_state
 test_sensitive_temp_preflight_skips_fast_fail_state
-test_postlaunch_noop_still_applies_nmr_breaker
+test_postlaunch_noop_still_applies_structural_breaker
 
 printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]] || exit 1

--- a/.agents/scripts/tests/test-parent-decomposition-escalation.sh
+++ b/.agents/scripts/tests/test-parent-decomposition-escalation.sh
@@ -204,7 +204,7 @@ assert_grep_fixed \
 	"$PARENT_TARGET"
 
 # --- t2211 constraint: escalation preserves parent-task label ---
-# Escalation applies NMR but must NEVER execute a `gh issue edit
+# Escalation remains advisory and must NEVER execute a `gh issue edit
 # --remove-label parent-task` on the escalated issue — that would
 # defeat the dispatch block. The ONLY time `--remove-label parent-task`
 # may appear is inside the comment body's markdown code fence as an

--- a/.agents/scripts/tests/test-parent-task-lifecycle.sh
+++ b/.agents/scripts/tests/test-parent-task-lifecycle.sh
@@ -127,7 +127,7 @@ assert_grep() {
 assert_grep_fixed() {
 	local label="$1" pattern="$2" file="$3"
 	TESTS_RUN=$((TESTS_RUN + 1))
-	if grep -qF "$pattern" "$file" 2>/dev/null; then
+	if grep -qF -- "$pattern" "$file" 2>/dev/null; then
 		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
 	else
 		TESTS_FAILED=$((TESTS_FAILED + 1))
@@ -384,6 +384,14 @@ assert_grep_fixed \
 assert_grep_fixed \
 	'B7g: unchecked parent criteria are deterministic close blockers' \
 	'_PARENT_CLOSE_CONTRACT_REASON="unchecked-criteria"' \
+	"$ACTIONS_TARGET"
+assert_grep_fixed \
+	'B7h: incomplete parent close contracts use an explicit review hold' \
+	'_mark_parent_review_hold "$slug" "$parent_num"' \
+	"$ACTIONS_TARGET"
+assert_grep_fixed \
+	'B7i: parent review hold applies hold-for-review' \
+	'--add-label "hold-for-review"' \
 	"$ACTIONS_TARGET"
 
 # B8: call site passes issue_body as 5th arg

--- a/.agents/scripts/tests/test-post-merge-review-scanner.sh
+++ b/.agents/scripts/tests/test-post-merge-review-scanner.sh
@@ -968,6 +968,39 @@ recover_creation_marker stub/repo 42 false
 ' _ "$SCANNER" 2>&1)
 assert_contains "existing issue repairs missing source-PR marker" "RECOVERED:123" "$out"
 
+echo ""
+echo "Test: explicit scanner hold uses hold-for-review, never NMR"
+out=$(SCANNER_HOLD_FOR_REVIEW=true bash -c '
+set -euo pipefail
+source "$1"
+gh() { return 0; }
+gh_create_issue() {
+	printf "CREATE_ARGS:%s\n" "$*"
+	printf "https://github.com/stub/repo/issues/123\n"
+	return 0
+}
+create_issue stub/repo 42 title body false
+' _ "$SCANNER" 2>&1)
+assert_contains "explicit scanner hold applies hold-for-review" "hold-for-review" "$out"
+assert_not_contains "explicit scanner hold never applies NMR" "needs-maintainer-review" "$out"
+assert_not_contains "explicit scanner hold omits auto-dispatch" "auto-dispatch" "$out"
+
+echo ""
+echo "Test: legacy SCANNER_NEEDS_REVIEW alias translates to hold-for-review"
+out=$(SCANNER_NEEDS_REVIEW=true SCANNER_HOLD_FOR_REVIEW='' bash -c '
+set -euo pipefail
+source "$1"
+gh() { return 0; }
+gh_create_issue() {
+	printf "CREATE_ARGS:%s\n" "$*"
+	printf "https://github.com/stub/repo/issues/124\n"
+	return 0
+}
+create_issue stub/repo 43 title body false
+' _ "$SCANNER" 2>&1)
+assert_contains "legacy scanner hold alias applies hold-for-review" "hold-for-review" "$out"
+assert_not_contains "legacy scanner hold alias never applies NMR" "needs-maintainer-review" "$out"
+
 install_ok_gh
 
 # -----------------------------------------------------------------------------

--- a/.agents/scripts/tests/test-pr-triage-gate-fail-closed.sh
+++ b/.agents/scripts/tests/test-pr-triage-gate-fail-closed.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Verify PR triage does not trust a read-only COLLABORATOR association.
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+WORKFLOW="${TEST_DIR}/../../../.github/workflows/pr-triage-gate.yml"
+TESTS_RUN=0
+TESTS_FAILED=0
+
+check_pattern() {
+	local pattern="$1"
+	local name="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if grep -qE -- "$pattern" "$WORKFLOW"; then
+		printf 'PASS %s\n' "$name"
+		return 0
+	fi
+	printf 'FAIL %s\n' "$name" >&2
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+main() {
+	check_pattern "const trustedRoles = \['OWNER', 'MEMBER'\]" \
+		"bare collaborator association is excluded from trusted PR roles"
+	check_pattern "association === 'COLLABORATOR'" \
+		"collaborator PR authority uses a separate verification path"
+	check_pattern "collaborators/\{username\}/permission" \
+		"collaborator PR authority uses the repository permission endpoint"
+	check_pattern "\['admin', 'maintain', 'write'\]\.includes" \
+		"write-level collaborator permissions bypass external triage"
+	check_pattern "preserving PR triage gate" \
+		"permission lookup uncertainty fails closed"
+	check_pattern "labels: \['needs-maintainer-review', 'external-contributor'\]" \
+		"untrusted PRs receive the external authority gate"
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]]
+	return $?
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-pulse-dispatch-core-external-author-gate.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-external-author-gate.sh
@@ -58,6 +58,7 @@ setup_case() {
 	local author_type="${2:-User}"
 	local approval_result="${3:-}"
 	local authority_rc="${4:-1}"
+	local external_source="${5:-false}"
 	MOCK_AUTHORITY_RC="$authority_rc"
 
 	TEST_ROOT=$(mktemp -d 2>/dev/null || mktemp -d -t aidevops-gh22399)
@@ -70,7 +71,7 @@ setup_case() {
 	: >"$LOGFILE"
 
 	cat >"${TEST_ROOT}/issue-meta.tsv" <<EOF
-${association}|${author_type}|fixture-author
+${association}|${author_type}|fixture-author|${external_source}
 EOF
 	cat >"${TEST_ROOT}/bin/gh" <<'EOF'
 #!/usr/bin/env bash
@@ -189,6 +190,21 @@ test_collaborator_permission_lookup_failure_blocks() {
 	return 0
 }
 
+test_external_origin_bot_without_approval_blocks() {
+	setup_case "NONE" "Bot" "" 0 true
+	if _check_external_issue_author_gate 24 "owner/repo"; then
+		if grep -q -- '--add-label needs-maintainer-review' "$GH_CALLS_FILE"; then
+			print_result "external-origin bot without approval blocks and applies NMR" 0
+		else
+			print_result "external-origin bot without approval blocks and applies NMR" 1 "NMR label was not applied"
+		fi
+	else
+		print_result "external-origin bot without approval blocks and applies NMR" 1 "Expected gate to block"
+	fi
+	cleanup_case
+	return 0
+}
+
 test_external_author_with_crypto_approval_allows_dispatch() {
 	setup_case "CONTRIBUTOR" "User" "VERIFIED"
 	if _check_external_issue_author_gate 3 "owner/repo"; then
@@ -247,6 +263,7 @@ main() {
 	test_collaborator_author_allows_dispatch
 	test_read_collaborator_without_approval_blocks
 	test_collaborator_permission_lookup_failure_blocks
+	test_external_origin_bot_without_approval_blocks
 	test_external_author_with_crypto_approval_allows_dispatch
 	test_external_author_with_unverifiable_approval_blocks_without_reapplying_nmr
 	test_author_lookup_failure_fails_closed

--- a/.agents/scripts/tests/test-pulse-labelless-reconcile.sh
+++ b/.agents/scripts/tests/test-pulse-labelless-reconcile.sh
@@ -7,12 +7,15 @@
 #
 # Strategy: stub `gh` as a bash function (PATH-shadow won't work because the
 # reconcile module runs with the pulse's prepended PATH) so we can intercept
-# every call. Five fixture issues:
+# every call. Eight fixture issues:
 #   #500 — aidevops-shaped + labelless + MEMBER author          (MUST be blessed internal)
 #   #501 — non-aidevops shape (random bug title)                (MUST be ignored)
 #   #502 — aidevops-shaped + already has origin:worker          (MUST be ignored)
 #   #503 — aidevops-shaped + labelless + CONTRIBUTOR author     (MUST be gated external, t2450)
 #   #504 — aidevops-shaped + labelless + NONE author, no tags   (MUST be gated external, t2450)
+#   #505 — aidevops-shaped + labelless + read collaborator       (MUST be gated external)
+#   #506 — aidevops-shaped + labelless + write collaborator      (MUST be blessed internal)
+#   #507 — aidevops-shaped + labelless + trusted bot             (MUST be blessed internal)
 #
 # Assertions — internal path (unchanged from t2112):
 #   - #500 edit adds origin:worker, tier:standard, and body tags (ai, security)
@@ -90,6 +93,24 @@ FIXTURE_ISSUES_JSON=$(
     "title": "GH#9999: propose additional dedup layer",
     "body": "External NONE-authored labelless aidevops-shaped issue with no body tags.",
     "labels": []
+  },
+  {
+    "number": 505,
+    "title": "t2550: read collaborator proposal",
+    "body": "Read-only collaborator issue.",
+    "labels": []
+  },
+  {
+    "number": 506,
+    "title": "t2551: write collaborator task",
+    "body": "Write-authorized collaborator issue.",
+    "labels": []
+  },
+  {
+    "number": 507,
+    "title": "t2552: trusted automation task",
+    "body": "Trusted bot issue.",
+    "labels": []
   }
 ]
 JSON
@@ -108,6 +129,18 @@ export -f set_issue_status
 
 # shellcheck disable=SC1090
 source "$RECONCILE_SRC"
+
+_gh_actor_has_repo_write_authority() {
+	local repo_slug="$1"
+	local author_login="$2"
+	local association="$3"
+	[[ -n "$repo_slug" && "$association" == "COLLABORATOR" ]] || return 2
+	case "$author_login" in
+	write-collab) return 0 ;;
+	read-collab) return 1 ;;
+	*) return 2 ;;
+	esac
+}
 
 # Stub the t2393 comment wrappers so reconcile_labelless_aidevops_issues's
 # `gh_issue_comment` call reaches the test's gh mock. The real wrappers live
@@ -153,9 +186,12 @@ gh() {
 			*/issues/*)
 				local num="${sub##*/}"
 				case "$num" in
-					500 | 501 | 502) printf '%s' '{"author_association":"MEMBER"}' ;;
-					503) printf '%s' '{"author_association":"CONTRIBUTOR"}' ;;
-					504) printf '%s' '{"author_association":"NONE"}' ;;
+					500 | 501 | 502) printf '%s' '{"author_association":"MEMBER","user":{"login":"member","type":"User"}}' ;;
+					503) printf '%s' '{"author_association":"CONTRIBUTOR","user":{"login":"external","type":"User"}}' ;;
+					504) printf '%s' '{"author_association":"NONE","user":{"login":"unknown","type":"User"}}' ;;
+					505) printf '%s' '{"author_association":"COLLABORATOR","user":{"login":"read-collab","type":"User"}}' ;;
+					506) printf '%s' '{"author_association":"COLLABORATOR","user":{"login":"write-collab","type":"User"}}' ;;
+					507) printf '%s' '{"author_association":"NONE","user":{"login":"github-actions[bot]","type":"Bot"}}' ;;
 					*) printf '%s' '{"author_association":"NONE"}' ;;
 				esac
 				return 0
@@ -217,14 +253,31 @@ edit_501=$(grep -c '^gh issue edit 501 --repo test/repo' "$TRACE_FILE" || true)
 edit_502=$(grep -c '^gh issue edit 502 --repo test/repo' "$TRACE_FILE" || true)
 comment_500=$(grep -c '^gh issue comment 500 --repo test/repo' "$TRACE_FILE" || true)
 comment_501=$(grep -c '^gh issue comment 501 --repo test/repo' "$TRACE_FILE" || true)
-rest_comment_reads=$(grep -cE '^gh api repos/test/repo/issues/(500|503|504)/comments\?per_page=100 --paginate --slurp$' "$TRACE_FILE" || true)
+rest_comment_reads=$(grep -cE '^gh api repos/test/repo/issues/(500|503|504|505|506|507)/comments\?per_page=100 --paginate --slurp$' "$TRACE_FILE" || true)
 native_comment_reads=$(grep -cE '^gh issue view .*--json comments' "$TRACE_FILE" || true)
 
-if [[ "$rest_comment_reads" -ne 3 || "$native_comment_reads" -ne 0 ]]; then
-	printf 'FAIL: expected 3 paginated REST comment reads and 0 native comment views; got REST=%d native=%d\n' \
+if [[ "$rest_comment_reads" -ne 6 || "$native_comment_reads" -ne 0 ]]; then
+	printf 'FAIL: expected 6 paginated REST comment reads and 0 native comment views; got REST=%d native=%d\n' \
 		"$rest_comment_reads" "$native_comment_reads"
 	failed=1
 fi
+
+# GH#29394: COLLABORATOR must be live permission-checked, while trusted bots
+# retain the automation fast path.
+edit_line_505=$(grep '^gh issue edit 505 --repo test/repo' "$TRACE_FILE" | head -1)
+if [[ "$edit_line_505" != *"--add-label needs-maintainer-review"* || "$edit_line_505" == *"--add-label origin:worker"* ]]; then
+	printf 'FAIL: #505 read collaborator did not retain the external-authority gate\n'
+	printf '  got: %s\n' "$edit_line_505"
+	failed=1
+fi
+for trusted_num in 506 507; do
+	trusted_line=$(grep "^gh issue edit ${trusted_num} --repo test/repo" "$TRACE_FILE" | head -1)
+	if [[ "$trusted_line" != *"--add-label origin:worker"* || "$trusted_line" != *"--add-label tier:standard"* || "$trusted_line" == *"needs-maintainer-review"* ]]; then
+		printf 'FAIL: #%s trusted author did not receive internal backfill labels\n' "$trusted_num"
+		printf '  got: %s\n' "$trusted_line"
+		failed=1
+	fi
+done
 
 # #500 MUST be edited at least once
 if [[ "$edit_500" -lt 1 ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -613,7 +613,8 @@ EOF
 	fi
 	if [[ "$dispatch_rc" -ne "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" ]] \
 		|| grep -qF 'gh pr close 100' "$GH_LOG" \
-		|| ! grep -qF 'needs-maintainer-review' "$GH_LOG" \
+		|| ! grep -qF -- '--add-label hold-for-review' "$GH_LOG" \
+		|| grep -qF -- '--add-label needs-maintainer-review' "$GH_LOG" \
 		|| ! grep -qF 'legacy review route marker has no head-bound start evidence' "$LOGFILE"; then
 		print_result "ambiguous legacy route is preserved for maintainer review" 1 \
 			"rc=${dispatch_rc}; gh=$(tr '\n' ';' <"$GH_LOG"); log=$(tr '\n' ';' <"$LOGFILE")"
@@ -788,7 +789,9 @@ test_dispatch_recovers_terminal_label_failure() {
 	_dispatch_pr_fix_worker "100" "owner/repo" "42" || retry_rc=$?
 	if [[ "$retry_rc" -ne 0 ]] || ! review_route_is_complete \
 		|| [[ ",$(<"${TEST_ROOT}/issue-labels.txt")," == *",needs-maintainer-review,"* \
-			|| ",$(<"${TEST_ROOT}/pr-labels.txt")," == *",needs-maintainer-review,"* ]]; then
+			|| ",$(<"${TEST_ROOT}/pr-labels.txt")," == *",needs-maintainer-review,"* \
+			|| ",$(<"${TEST_ROOT}/issue-labels.txt")," == *",hold-for-review,"* \
+			|| ",$(<"${TEST_ROOT}/pr-labels.txt")," == *",hold-for-review,"* ]]; then
 		print_result "completed route recovers a missing terminal label" 1 \
 			"rc=${retry_rc}; issue_labels=$(<"${TEST_ROOT}/issue-labels.txt"); pr_labels=$(<"${TEST_ROOT}/pr-labels.txt")"
 		return 0
@@ -807,8 +810,9 @@ test_dispatch_holds_on_head_drift() {
 	if [[ "$dispatch_rc" -ne "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" \
 		|| "$(<"${TEST_ROOT}/pr-state.txt")" != "OPEN" \
 		|| "$(<"${TEST_ROOT}/issue-body.txt")" == *"feedback-route:complete:review:PR100:SHAabc123repairsha"* \
-		|| ",$(<"${TEST_ROOT}/pr-labels.txt")," != *",needs-maintainer-review,"* \
-		|| ",$(<"${TEST_ROOT}/issue-labels.txt")," != *",needs-maintainer-review,"* ]]; then
+		|| ",$(<"${TEST_ROOT}/pr-labels.txt")," != *",hold-for-review,"* \
+		|| ",$(<"${TEST_ROOT}/issue-labels.txt")," != *",hold-for-review,"* ]] \
+		|| grep -qF -- '--add-label needs-maintainer-review' "$GH_LOG"; then
 		print_result "head drift preserves the changed PR for maintainer review" 1 \
 			"rc=${dispatch_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); head=$(<"${TEST_ROOT}/pr-head.txt"); events=$(tr '\n' ';' <"$EVENT_LOG")"
 		return 0
@@ -827,7 +831,7 @@ test_dispatch_holds_when_ownership_changes_during_transition() {
 	if [[ "$dispatch_rc" -ne "${PULSE_FEEDBACK_ROUTE_MAINTAINER_RC:-76}" \
 		|| "$(<"${TEST_ROOT}/pr-state.txt")" != "OPEN" \
 		|| ",$(<"${TEST_ROOT}/pr-labels.txt")," != *",no-takeover,"* \
-		|| ",$(<"${TEST_ROOT}/pr-labels.txt")," != *",needs-maintainer-review,"* ]] \
+		|| ",$(<"${TEST_ROOT}/pr-labels.txt")," != *",hold-for-review,"* ]] \
 		|| grep -qF 'gh pr close 100' "$GH_LOG"; then
 		print_result "ownership change during transition preserves the PR" 1 \
 			"rc=${dispatch_rc}; state=$(<"${TEST_ROOT}/pr-state.txt"); labels=$(<"${TEST_ROOT}/pr-labels.txt"); events=$(tr '\n' ';' <"$EVENT_LOG")"
@@ -893,7 +897,8 @@ test_terminal_guard_rechecks_current_label() {
 	local guard_rc=0
 	_feedback_route_guard_existing_terminal_label "100" "owner/repo" "42" "review" || guard_rc=$?
 
-	if [[ "$guard_rc" -ne 0 ]] || grep -qF 'needs-maintainer-review' "$GH_LOG"; then
+	if [[ "$guard_rc" -ne 0 ]] \
+		|| grep -Eq -- '--add-label (needs-maintainer-review|hold-for-review)' "$GH_LOG"; then
 		print_result "terminal guard accepts a stale caller label after live removal" 1 \
 			"rc=${guard_rc}; labels=$(<"${TEST_ROOT}/pr-labels.txt"); gh=$(tr '\n' ';' <"$GH_LOG")"
 		return 0

--- a/.agents/scripts/tests/test-pulse-merge-worker-briefed.sh
+++ b/.agents/scripts/tests/test-pulse-merge-worker-briefed.sh
@@ -8,7 +8,7 @@
 #   Case (a): origin:worker + issue-author=OWNER + green CI + no NMR → auto-merges
 #   Case (b): origin:worker + issue-author=MEMBER + green + no NMR → auto-merges
 #   Case (c): origin:worker + issue-author=CONTRIBUTOR → does NOT auto-merge
-#   Case (d): origin:worker + NMR auto-approved (not crypto) → does NOT auto-merge
+#   Case (d): origin:worker + trusted-author legacy auto-normalization → auto-merges
 #   Case (e): origin:worker + NMR cleared via crypto approval → auto-merges
 #   Case (f): origin:worker + hold-for-review label → does NOT auto-merge
 #   Case (g): origin:worker + human CHANGES_REQUESTED → does NOT auto-merge
@@ -293,14 +293,15 @@ test_case_c_contributor_issue_blocked() {
 }
 
 # =============================================================================
-# Case (d): NMR auto-approved only (no crypto) → blocked
+# Case (d): trusted-author legacy auto-normalization residue → passes
 # =============================================================================
-test_case_d_nmr_auto_approved_blocked() {
+test_case_d_trusted_author_normalization_passes() {
 	setup_test_env
 	define_helpers_under_test || { teardown_test_env; return 0; }
 
 	printf '{"author_association":"OWNER"}' >"${TEST_ROOT}/issue.json"
-	# Comments contain auto-approval marker but NO crypto signature
+	# Historical auto-approval marker is residue, not a current trust gate. The
+	# live OWNER author independently establishes authority.
 	printf '[{"body":"auto-approved-maintainer-issue: cleared NMR"}]' >"${TEST_ROOT}/comments.json"
 	export AIDEVOPS_WORKER_BRIEFED_AUTO_MERGE=1
 
@@ -308,15 +309,10 @@ test_case_d_nmr_auto_approved_blocked() {
 	_attempt_worker_briefed_auto_merge "103" "owner/repo" "origin:worker" "false" "45" && result=0 || result=$?
 
 	if [[ "$result" -eq 0 ]]; then
-		print_result "Case (d): NMR auto-approved only → blocked" 1 \
-			"Expected non-zero exit, got 0 (auto-approval without crypto should block)"
+		print_result "Case (d): trusted-author normalization residue → passes" 0
 	else
-		if grep -q "auto-approved only" "$LOGFILE" 2>/dev/null; then
-			print_result "Case (d): NMR auto-approved only → blocked" 0
-		else
-			print_result "Case (d): NMR auto-approved only → blocked" 1 \
-				"Exit was non-zero but expected log message not found"
-		fi
+		print_result "Case (d): trusted-author normalization residue → passes" 1 \
+			"Expected exit 0, got ${result}"
 	fi
 	teardown_test_env
 	return 0
@@ -876,7 +872,7 @@ main() {
 	test_case_a_owner_issue_passes
 	test_case_b_member_issue_passes
 	test_case_c_contributor_issue_blocked
-	test_case_d_nmr_auto_approved_blocked
+	test_case_d_trusted_author_normalization_passes
 	test_case_e_nmr_crypto_cleared_passes
 	test_case_f_hold_for_review_blocked
 	test_case_g_changes_requested_is_upstream

--- a/.agents/scripts/tests/test-pulse-nmr-maintainer-authority.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-maintainer-authority.sh
@@ -36,8 +36,11 @@ setup_test_env() {
 	export REPOS_JSON="${TEST_ROOT}/repos.json"
 	export POSTED_COMMENT="${TEST_ROOT}/posted-comment.txt"
 	export STATUS_CALLS_FILE="${TEST_ROOT}/status-calls.txt"
+	export AGENTS_DIR="${TEST_ROOT}"
 	export ISSUE_ASSOC="OWNER"
 	export ISSUE_API_AUTHOR="maintainer"
+	export ISSUE_AUTHOR_TYPE="User"
+	export ISSUE_LABELS_JSON='[]'
 	export ISSUE_LIST_AUTHOR="maintainer"
 	export ACTOR_PERMISSION="write"
 	export AUTHOR_PERMISSION="write"
@@ -84,7 +87,9 @@ if [[ "${1:-}" == "api" ]]; then
 		exit 0
 	fi
 	if [[ "$path" == */issues/24479 ]]; then
-		printf '{"user":{"login":"%s"},"author_association":"%s","labels":[]}\n' "${ISSUE_API_AUTHOR:-maintainer}" "${ISSUE_ASSOC:-NONE}"
+		printf '{"user":{"login":"%s","type":"%s"},"author_association":"%s","labels":%s}\n' \
+			"${ISSUE_API_AUTHOR:-maintainer}" "${ISSUE_AUTHOR_TYPE:-User}" \
+			"${ISSUE_ASSOC:-NONE}" "${ISSUE_LABELS_JSON:-[]}"
 		exit 0
 	fi
 	if [[ "$path" == */timeline ]]; then
@@ -113,6 +118,7 @@ teardown_test_env() {
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
 		rm -rf "$TEST_ROOT"
 	fi
+	unset AGENTS_DIR
 	return 0
 }
 
@@ -202,10 +208,10 @@ test_allows_owner_author_with_write_permission() {
 	export ISSUE_ASSOC="OWNER"
 	export ACTOR_PERMISSION="write"
 	run_auto_approve
-	if grep -q 'aidevops-signed-approval' "$POSTED_COMMENT" 2>/dev/null; then
-		print_result "auto-approval allows upstream OWNER author and write-capable runner" 0
+	if ! grep -q 'aidevops-signed-approval' "$POSTED_COMMENT" 2>/dev/null; then
+		print_result "trusted OWNER normalization does not post a synthetic approval" 0
 	else
-		print_result "auto-approval allows upstream OWNER author and write-capable runner" 1 "approval comment missing"
+		print_result "trusted OWNER normalization does not post a synthetic approval" 1 "unexpected approval marker"
 	fi
 	if grep -q -- '^24479 owner/repo available --remove-label needs-maintainer-review --add-label auto-dispatch$' "$STATUS_CALLS_FILE" 2>/dev/null; then
 		print_result "auto-approval atomically restores complete dispatchable state" 0
@@ -223,10 +229,11 @@ test_allows_write_authorized_collaborator() {
 	export ISSUE_ASSOC="COLLABORATOR"
 	export AUTHOR_PERMISSION="write"
 	run_auto_approve
-	if grep -q 'aidevops-signed-approval' "$POSTED_COMMENT" 2>/dev/null; then
-		print_result "auto-approval allows write-authorized collaborator issues" 0
+	if ! grep -q 'aidevops-signed-approval' "$POSTED_COMMENT" 2>/dev/null \
+		&& grep -q -- 'available --remove-label needs-maintainer-review --add-label auto-dispatch' "$STATUS_CALLS_FILE" 2>/dev/null; then
+		print_result "trusted collaborator normalization clears NMR without synthetic approval" 0
 	else
-		print_result "auto-approval allows write-authorized collaborator issues" 1 "approval comment missing"
+		print_result "trusted collaborator normalization clears NMR without synthetic approval" 1 "unexpected approval marker or missing status transition"
 	fi
 	teardown_test_env
 	return 0
@@ -248,6 +255,30 @@ test_blocks_read_only_collaborator() {
 	return 0
 }
 
+test_external_origin_bot_requires_approval() {
+	setup_test_env
+	export ISSUE_LIST_AUTHOR="github-actions[bot]"
+	export ISSUE_API_AUTHOR="github-actions[bot]"
+	export ISSUE_AUTHOR_TYPE="Bot"
+	export ISSUE_ASSOC="NONE"
+	export ISSUE_LABELS_JSON='[{"name":"external-contributor"},{"name":"needs-maintainer-review"}]'
+	run_auto_approve
+	if [[ ! -s "$POSTED_COMMENT" && ! -s "$STATUS_CALLS_FILE" ]]; then
+		print_result "trusted bot preserves explicit external-origin approval gate" 0
+	else
+		print_result "trusted bot preserves explicit external-origin approval gate" 1 "unexpected approval or status transition"
+	fi
+	# shellcheck disable=SC1090
+	source "$NMR_SCRIPT"
+	if issue_has_required_approval 24479 owner/repo true; then
+		print_result "external-origin bot still requires cryptographic approval" 1 "authority gate was bypassed"
+	else
+		print_result "external-origin bot still requires cryptographic approval" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
 test_preserves_peer_maintainer_manual_hold() {
 	setup_test_env
 	export ISSUE_LIST_AUTHOR="trusted-author"
@@ -256,10 +287,39 @@ test_preserves_peer_maintainer_manual_hold() {
 	export AUTHOR_PERMISSION="write"
 	export NMR_TIMELINE_JSON='[{"event":"labeled","label":{"name":"needs-maintainer-review"},"actor":{"login":"trusted-author"},"created_at":"2026-07-30T20:00:00Z"}]'
 	run_auto_approve
-	if ! grep -q 'aidevops-signed-approval' "$POSTED_COMMENT" 2>/dev/null && [[ ! -s "$STATUS_CALLS_FILE" ]]; then
-		print_result "auto-approval preserves peer maintainer manual NMR hold" 0
+	if ! grep -q 'aidevops-signed-approval' "$POSTED_COMMENT" 2>/dev/null \
+		&& grep -q -- '--remove-label needs-maintainer-review --add-label hold-for-review' "$STATUS_CALLS_FILE" 2>/dev/null; then
+		print_result "trusted manual NMR becomes hold-for-review without self-approval" 0
 	else
-		print_result "auto-approval preserves peer maintainer manual NMR hold" 1 "unexpected approval or status transition"
+		print_result "trusted manual NMR becomes hold-for-review without self-approval" 1 "unexpected approval marker or missing hold translation"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_ever_nmr_history_bypasses_self_approval_for_trusted_author() {
+	setup_test_env
+	# shellcheck disable=SC1090
+	source "$NMR_SCRIPT"
+	if issue_has_required_approval 24479 owner/repo true; then
+		print_result "ever-NMR history does not require trusted OWNER self-approval" 0
+	else
+		print_result "ever-NMR history does not require trusted OWNER self-approval" 1 "trusted author remained blocked"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_ever_nmr_history_still_blocks_external_author() {
+	setup_test_env
+	export ISSUE_API_AUTHOR="external-contributor"
+	export ISSUE_ASSOC="NONE"
+	# shellcheck disable=SC1090
+	source "$NMR_SCRIPT"
+	if issue_has_required_approval 24479 owner/repo true; then
+		print_result "ever-NMR history still requires external-author approval" 1 "external author bypassed approval"
+	else
+		print_result "ever-NMR history still requires external-author approval" 0
 	fi
 	teardown_test_env
 	return 0
@@ -272,7 +332,10 @@ main() {
 	test_allows_owner_author_with_write_permission
 	test_allows_write_authorized_collaborator
 	test_blocks_read_only_collaborator
+	test_external_origin_bot_requires_approval
 	test_preserves_peer_maintainer_manual_hold
+	test_ever_nmr_history_bypasses_self_approval_for_trusted_author
+	test_ever_nmr_history_still_blocks_external_author
 	printf '\nTests run: %d\n' "$TESTS_RUN"
 	printf 'Tests failed: %d\n' "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-prefetch-label-count.sh
+++ b/.agents/scripts/tests/test-pulse-prefetch-label-count.sh
@@ -14,6 +14,8 @@ NMR_LIVE_JSON="[]"
 NMR_LIVE_EXIT=0
 NI_LIVE_JSON="[]"
 LIVE_CALLS_FILE=""
+AUTHOR_META_RESULT="NONE|Bot|github-actions[bot]|false"
+RELABEL_CALLS_FILE=""
 
 print_result() {
 	local name="$1"
@@ -31,9 +33,11 @@ print_result() {
 setup() {
 	TEST_ROOT=$(mktemp -d)
 	LIVE_CALLS_FILE="$TEST_ROOT/live-calls.log"
+	RELABEL_CALLS_FILE="$TEST_ROOT/relabel-calls.log"
 	export LOGFILE="$TEST_ROOT/pulse.log"
 	export PULSE_PREFETCH_CACHE_FILE="$TEST_ROOT/prefetch-cache.json"
 	: >"$LIVE_CALLS_FILE"
+	: >"$RELABEL_CALLS_FILE"
 	: >"$LOGFILE"
 	return 0
 }
@@ -57,6 +61,8 @@ source "$SCRIPTS_DIR/pulse-prefetch-workers.sh"
 source "$SCRIPTS_DIR/pulse-prefetch-secondary.sh"
 # shellcheck source=../pulse-prefetch-orchestration.sh
 source "$SCRIPTS_DIR/pulse-prefetch-orchestration.sh"
+# shellcheck source=../pulse-ancillary-dispatch.sh
+source "$SCRIPTS_DIR/pulse-ancillary-dispatch.sh"
 
 _prefetch_cache_get() {
 	local slug="$1"
@@ -88,11 +94,25 @@ gh() {
 	local command="$1"
 	shift
 	if [[ "$command" == "api" ]]; then
+		if [[ "${1:-}" == "repos/owner/repo/issues/84" ]]; then
+			printf '%s\n' "$AUTHOR_META_RESULT"
+			return 0
+		fi
 		printf '0\n'
 		return 0
 	fi
 	: "$@"
 	return 1
+}
+
+gh_issue_edit_safe() {
+	printf 'edit %s\n' "$*" >>"$RELABEL_CALLS_FILE"
+	return 0
+}
+
+gh_issue_comment() {
+	printf 'comment %s\n' "$*" >>"$RELABEL_CALLS_FILE"
+	return 0
 }
 
 _prefetch_ni_fetch_issues() {
@@ -311,11 +331,42 @@ test_needs_info_consumer() {
 	return 0
 }
 
+test_needs_info_relabel_authority() {
+	local state_file="$TEST_ROOT/needs-info-state.txt"
+	local calls=""
+	export STATE_FILE="$state_file"
+	printf 'replied|84|owner/repo\n' >"$state_file"
+
+	AUTHOR_META_RESULT='NONE|Bot|github-actions[bot]|true'
+	: >"$RELABEL_CALLS_FILE"
+	relabel_needs_info_replies
+	calls=$(<"$RELABEL_CALLS_FILE")
+	if [[ "$calls" == *"--add-label needs-maintainer-review"* && \
+		"$calls" != *"--add-label hold-for-review"* ]]; then
+		print_result "external-origin bot reply preserves NMR authority gate" 0
+	else
+		print_result "external-origin bot reply preserves NMR authority gate" 1
+	fi
+
+	AUTHOR_META_RESULT='NONE|Bot|github-actions[bot]|false'
+	: >"$RELABEL_CALLS_FILE"
+	relabel_needs_info_replies
+	calls=$(<"$RELABEL_CALLS_FILE")
+	if [[ "$calls" == *"--add-label hold-for-review"* && \
+		"$calls" != *"--add-label needs-maintainer-review"* ]]; then
+		print_result "trusted bot reply uses internal review hold" 0
+	else
+		print_result "trusted bot reply uses internal review hold" 1
+	fi
+	return 0
+}
+
 printf '=== test-pulse-prefetch-label-count.sh ===\n'
 test_predicate_contract
 test_nmr_consumer
 test_untrusted_cache_falls_through_live_query
 test_needs_info_consumer
+test_needs_info_relabel_authority
 test_atomic_triage_state_refresh
 test_failed_live_nmr_read_is_not_false_empty
 printf '\nResults: %s run, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-quality-feedback-trust-bar.sh
+++ b/.agents/scripts/tests/test-quality-feedback-trust-bar.sh
@@ -14,8 +14,8 @@
 #
 # Post-fix semantics:
 #   - Stage 1: maintainer fast-path (repos.json .maintainer or slug owner)
-#   - Stage 2: collaborator permission probe (admin OR maintain → trusted)
-#   - Fail-closed on API errors, missing write permission, unknown user
+#   - Stage 2: collaborator permission probe (admin/maintain/write → trusted)
+#   - Fail-closed on API errors, read-only permission, unknown user
 #
 # This test never hits the real GitHub API — the `gh` CLI is stubbed via a
 # shell script on PATH that serves fixture responses.
@@ -193,17 +193,16 @@ test_maintain_collaborator_is_trusted() {
 	return 0
 }
 
-test_write_collaborator_is_not_trusted() {
-	# Stage 2: non-maintainer with write permission → NOT trusted.
-	# Write collaborators can push branches but have not been granted the
-	# same institutional trust as admin/maintain.
+test_write_collaborator_is_trusted() {
+	# Stage 2: write permission is authenticated repository authority. NMR is
+	# reserved for external/read-only authors, not a higher maintainer-role bar.
 	set_permission_fixture '{"permission":"write"}'
 	if _is_maintainer_equivalent_author "contributor-dev" "exampleorg/examplerepo"; then
-		print_result "write collaborator NOT treated as maintainer-equivalent (t2686)" 1 \
-			"Expected exit 1 — write permission is below the trust bar"
+		print_result "write collaborator treated as repository-authorized (GH#29394)" 0
 		return 0
 	fi
-	print_result "write collaborator NOT treated as maintainer-equivalent (t2686)" 0
+	print_result "write collaborator treated as repository-authorized (GH#29394)" 1 \
+		"Expected exit 0 — write permission satisfies the external-authority gate"
 	return 0
 }
 
@@ -276,7 +275,7 @@ main() {
 	test_maintainer_fast_path_matches
 	test_admin_collaborator_is_trusted
 	test_maintain_collaborator_is_trusted
-	test_write_collaborator_is_not_trusted
+	test_write_collaborator_is_trusted
 	test_api_failure_is_fail_closed
 	test_none_permission_is_not_trusted
 	test_empty_author_returns_nonzero

--- a/.agents/scripts/tests/test-stale-recovery-escalation.sh
+++ b/.agents/scripts/tests/test-stale-recovery-escalation.sh
@@ -9,7 +9,7 @@
 #   1. First recovery (0 prior ticks) → tick:1 posted, status:available added
 #   2. Second recovery (1 prior tick) → tick:2 posted, status:available added
 #   3. Third recovery (2 prior ticks = threshold) → STALE_ESCALATED emitted,
-#      needs-maintainer-review applied, status:available NOT added
+#      status:blocked applied, status:available NOT added
 #   4. Open ready PR: durable progress is preserved without synthetic reset.
 #   5. Open worker draft: assignment is preserved and exact-head continuation
 #      is requested without NMR mutation.
@@ -103,9 +103,9 @@ if [[ "\$1" == "api" && "\$2" == *"/issues/99999"* && "\$*" != *"--method"* ]]; 
 	available)
 		printf '%s\n' '{"state":"OPEN","labels":[{"name":"status:available"}],"assignees":[]}'
 		;;
-	nmr)
+	blocked)
 		if [[ "${transition_visible}" == "1" ]]; then
-			printf '%s\n' '{"state":"OPEN","labels":[{"name":"needs-maintainer-review"}],"assignees":[]}'
+			printf '%s\n' '{"state":"OPEN","labels":[{"name":"status:blocked"}],"assignees":[]}'
 		else
 			printf '%s\n' '{"state":"OPEN","labels":[],"assignees":[{"login":"stale-runner"}]}'
 		fi
@@ -170,17 +170,17 @@ fi
 # remain silent successes.
 if [[ "\$1" == "issue" ]]; then
 	if [[ "\$2" == "edit" ]]; then
-		if [[ "\$*" == *"needs-maintainer-review"* ]]; then
-			printf '%s\n' nmr >"${TEST_ROOT}/transition_state"
+		if [[ "\$*" == *"--add-label status:blocked"* ]]; then
+			printf '%s\n' blocked >"${TEST_ROOT}/transition_state"
 		else
 			printf '%s\n' available >"${TEST_ROOT}/transition_state"
 		fi
 		exit 0
 	fi
 	if [[ "\$2" == "view" && "\$*" == *"--json state,labels,assignees"* ]]; then
-		if [[ "${open_pr}" == *"draft_checkpoint"* || "${open_pr}" == *"ready_failed"* ]]; then
+		if [[ -f "${TEST_ROOT}/transition_state" && "\$(cat "${TEST_ROOT}/transition_state")" == "blocked" ]]; then
 			if [[ "${transition_visible}" == "1" ]]; then
-				printf '%s\n' '{"state":"OPEN","labels":[{"name":"needs-maintainer-review"}],"assignees":[]}'
+				printf '%s\n' '{"state":"OPEN","labels":[{"name":"status:blocked"}],"assignees":[]}'
 			else
 				printf '%s\n' '{"state":"OPEN","labels":[],"assignees":[{"login":"stale-runner"}]}'
 			fi
@@ -298,11 +298,12 @@ else
 	print_result "Escalation: STALE_RECOVERED NOT emitted (no re-dispatch loop)" 1 "(got: '$output')"
 fi
 
-# needs-maintainer-review must be applied (check gh issue edit call in log)
-if grep -q "needs-maintainer-review" "$GH_CALLS_FILE" 2>/dev/null; then
-	print_result "Escalation: needs-maintainer-review label applied" 0
+# status:blocked must be applied without adding NMR.
+if grep -q -- "--add-label status:blocked" "$GH_CALLS_FILE" 2>/dev/null && \
+	! grep -q -- "--add-label needs-maintainer-review" "$GH_CALLS_FILE" 2>/dev/null; then
+	print_result "Escalation: status:blocked applied without NMR" 0
 else
-	print_result "Escalation: needs-maintainer-review label applied" 1 "(gh calls: $(head -10 "$GH_CALLS_FILE" 2>/dev/null))"
+	print_result "Escalation: status:blocked applied without NMR" 1 "(gh calls: $(head -10 "$GH_CALLS_FILE" 2>/dev/null))"
 fi
 
 # status:available must NOT be --add-label'd in escalation path
@@ -314,11 +315,11 @@ else
 fi
 
 # auto-dispatch must be removed in the same escalation mutation so a later
-# status recovery cannot make this NMR-held issue appear runnable.
+# status recovery cannot make this structurally blocked issue appear runnable.
 if grep -q -- "--remove-label auto-dispatch" "$GH_CALLS_FILE" 2>/dev/null; then
-	print_result "Escalation: auto-dispatch removed with NMR hold" 0
+	print_result "Escalation: auto-dispatch removed with structural block" 0
 else
-	print_result "Escalation: auto-dispatch removed with NMR hold" 1 "(gh calls: $(cat "$GH_CALLS_FILE" 2>/dev/null))"
+	print_result "Escalation: auto-dispatch removed with structural block" 1 "(gh calls: $(cat "$GH_CALLS_FILE" 2>/dev/null))"
 fi
 
 # =============================================================================
@@ -378,10 +379,10 @@ else
 	print_result "Worker draft checkpoint requests continuation without issue mutation" 1 "(got: '$output')"
 fi
 
-if ! echo "$output" | grep -q "STALE_DRAFT_ESCALATED\|needs-maintainer-review"; then
-	print_result "Worker draft checkpoint never enters stale NMR escalation" 0
+if ! echo "$output" | grep -q "STALE_DRAFT_ESCALATED\|status:blocked"; then
+	print_result "Worker draft checkpoint never enters stale structural escalation" 0
 else
-	print_result "Worker draft checkpoint never enters stale NMR escalation" 1 "(got: '$output')"
+	print_result "Worker draft checkpoint never enters stale structural escalation" 1 "(got: '$output')"
 fi
 
 for unsafe_kind in draft_bare draft_mismatch; do
@@ -462,17 +463,19 @@ fi
 # =============================================================================
 
 run_recover 0 "81|ready_failed" 1
-if echo "$output" | grep -q "STALE_READY_FAILED_ESCALATED" && grep -q "needs-maintainer-review" "$GH_CALLS_FILE"; then
-	print_result "Terminal ready PR escalates after verified NMR read-back" 0
+if echo "$output" | grep -q "STALE_READY_FAILED_ESCALATED" && \
+	grep -q -- "--add-label status:blocked" "$GH_CALLS_FILE" && \
+	! grep -q -- "--add-label needs-maintainer-review" "$GH_CALLS_FILE"; then
+	print_result "Terminal ready PR escalates after verified structural-block read-back" 0
 else
-	print_result "Terminal ready PR escalates after verified NMR read-back" 1 "(got: '$output')"
+	print_result "Terminal ready PR escalates after verified structural-block read-back" 1 "(got: '$output')"
 fi
 
 run_recover 0 "81|ready_failed" 0
 if [[ "$rc" -ne 0 ]] && echo "$output" | grep -q "STALE_PR_ESCALATION_FAILED"; then
-	print_result "Terminal ready PR retains ownership when NMR transition is invisible" 0
+	print_result "Terminal ready PR retains ownership when structural block is invisible" 0
 else
-	print_result "Terminal ready PR retains ownership when NMR transition is invisible" 1 "(rc=$rc got: '$output')"
+	print_result "Terminal ready PR retains ownership when structural block is invisible" 1 "(rc=$rc got: '$output')"
 fi
 
 export PATH="$OLD_PATH"

--- a/.agents/scripts/tests/test-worker-reliability-self-heal.sh
+++ b/.agents/scripts/tests/test-worker-reliability-self-heal.sh
@@ -107,6 +107,8 @@ _install_log_stubs() {
 	log_info() { printf '[info] %s\n' "$*" >>"$LOG_FILE" 2>/dev/null || true; }
 	log_warn() { printf '[warn] %s\n' "$*" >>"$LOG_FILE" 2>/dev/null || true; }
 	log_error() { printf '[error] %s\n' "$*" >>"$LOG_FILE" 2>/dev/null || true; }
+	# Extracted preservation helper depends on the launch-level privacy guard.
+	_headless_private_workload_enabled() { return 1; }
 	return 0
 }
 
@@ -402,7 +404,7 @@ NMR_APPROVAL_SCRIPT="${NMR_APPROVAL_SCRIPT:-$(dirname "$LIFECYCLE_SCRIPT")/pulse
 
 test_no_work_circuit_breaker_threshold_guard() {
 	# _log_no_work_skip_escalation must reference NO_WORK_NMR_THRESHOLD
-	# and delegate to the NMR breaker when the threshold is reached.
+	# and delegate to the legacy-named structural breaker when the threshold is reached.
 
 	# Assertion 1: NO_WORK_NMR_THRESHOLD is referenced in the function body.
 	local fn_src
@@ -419,14 +421,14 @@ test_no_work_circuit_breaker_threshold_guard() {
 		return 0
 	fi
 
-	# Assertion 2: the function delegates to the dedicated NMR breaker helper.
+	# Assertion 2: the function delegates to the dedicated structural breaker helper.
 	if ! printf '%s\n' "$fn_src" | grep -q '_apply_no_work_nmr_breaker'; then
 		print_result "t2769: no_work circuit breaker threshold guard" 1 \
 			"_apply_no_work_nmr_breaker not called in _log_no_work_skip_escalation"
 		return 0
 	fi
 
-	# Assertion 3: the NMR path appears BEFORE the below-threshold diagnostic path
+	# Assertion 3: the breaker path appears BEFORE the below-threshold diagnostic path
 	# (threshold check is the first branch; diagnostic is the fallthrough).
 	local nmr_line diag_line
 	nmr_line=$(printf '%s\n' "$fn_src" | grep -n '_apply_no_work_nmr_breaker' | head -1 | cut -d: -f1)
@@ -447,7 +449,7 @@ test_no_work_circuit_breaker_threshold_guard() {
 }
 
 test_no_work_circuit_breaker_marker_posted() {
-	# The actual NMR path must post the machine marker, while the below-threshold
+	# The structural breaker path must post the legacy machine marker, while the below-threshold
 	# explanatory prose must not quote it and contaminate reason classification.
 
 	local breaker_src="" skip_src=""

--- a/.agents/scripts/tests/test-workflow-cascade-lint.sh
+++ b/.agents/scripts/tests/test-workflow-cascade-lint.sh
@@ -370,20 +370,20 @@ test_output_md_report() {
 test_real_nmr_hold_workflow() {
 	local nmr_file=".github/workflows/nmr-hold-comment.yml"
 	if [ ! -f "$nmr_file" ]; then
-		print_result "real: nmr-hold-comment.yml flagged as VULN" 1 "file not found"
+		print_result "real: nmr-hold-comment.yml avoids cancellation cascade" 1 "file not found"
 		return 0
 	fi
 	local output rc
 	output=$(bash "$SCRIPT_UNDER_TEST" "$nmr_file" 2>&1)
 	rc=$?
 	local failed=0
-	if [[ $rc -ne 1 ]]; then
+	if [[ $rc -ne 0 ]]; then
 		failed=1
 	fi
-	if ! echo "$output" | grep -q "VULN"; then
+	if echo "$output" | grep -q "VULN"; then
 		failed=1
 	fi
-	print_result "real: nmr-hold-comment.yml flagged as VULN" "$failed" "exit=$rc"
+	print_result "real: nmr-hold-comment.yml avoids cancellation cascade" "$failed" "exit=$rc"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-zero-output-url-fallback.sh
+++ b/.agents/scripts/tests/test-zero-output-url-fallback.sh
@@ -61,6 +61,17 @@ source "${SCRIPTS_DIR}/pulse-dispatch-worker-launch.sh" >/dev/null 2>&1 || {
 	exit 1
 }
 
+# Capture semantic lifecycle transitions after the sourced modules have loaded
+# the production wrapper implementation.
+set_issue_status() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local status="$3"
+	shift 3
+	printf 'set_issue_status %s %s %s %s\n' "$issue_number" "$repo_slug" "$status" "$*" >>"${TMP}/gh-calls.log"
+	return 0
+}
+
 write_state() {
 	local count="$1"
 	local reason="${2:-worker_noop_zero_output}"
@@ -162,12 +173,13 @@ _dlw_hold_repeated_zero_output 123 owner/repo
 hold_rc=$?
 gh_calls=$(tr '\n' ' ' <"${TMP}/gh-calls.log" 2>/dev/null || true)
 if [[ "$hold_rc" -eq 0 ]] \
-	&& printf '%s' "$gh_calls" | grep -q 'needs-maintainer-review' \
+	&& printf '%s' "$gh_calls" | grep -q 'set_issue_status 123 owner/repo blocked' \
 	&& printf '%s' "$gh_calls" | grep -q 'dispatch-infrastructure-failure' \
+	&& ! printf '%s' "$gh_calls" | grep -q -- '--add-label needs-maintainer-review' \
 	&& ! printf '%s' "$gh_calls" | grep -q 'needs-brief-rewrite'; then
-	pass "continued zero-output launches hold dispatch for infrastructure review"
+	pass "continued zero-output launches apply structural infrastructure block"
 else
-	fail "continued zero-output launches hold dispatch for infrastructure review" \
+	fail "continued zero-output launches apply structural infrastructure block" \
 		"rc=${hold_rc}; gh_calls=${gh_calls}"
 fi
 
@@ -179,7 +191,9 @@ _dlw_hold_repeated_zero_output 123 owner/repo
 comment_hold_rc=$?
 comment_gh_calls=$(tr '\n' ' ' <"${TMP}/gh-calls.log" 2>/dev/null || true)
 if [[ "$comment_hold_rc" -eq 0 ]] \
+	&& printf '%s' "$comment_gh_calls" | grep -q 'set_issue_status 123 owner/repo blocked' \
 	&& printf '%s' "$comment_gh_calls" | grep -q 'dispatch-infrastructure-failure' \
+	&& ! printf '%s' "$comment_gh_calls" | grep -q -- '--add-label needs-maintainer-review' \
 	&& ! printf '%s' "$comment_gh_calls" | grep -q 'needs-brief-rewrite'; then
 	pass "comment evidence triggers infrastructure hold when state count is low"
 else
@@ -197,7 +211,9 @@ shared_metrics_hold_rc=$?
 shared_metrics_hold_calls=$(tr '\n' ' ' <"${TMP}/gh-calls.log" 2>/dev/null || true)
 hold_api_calls=$(wc -l <"${TMP}/gh-api-calls.log" | tr -d '[:space:]')
 if [[ "$shared_metrics_hold_rc" -eq 0 ]] \
+	&& printf '%s' "$shared_metrics_hold_calls" | grep -q 'set_issue_status 123 owner/repo blocked' \
 	&& printf '%s' "$shared_metrics_hold_calls" | grep -q 'dispatch-infrastructure-failure' \
+	&& ! printf '%s' "$shared_metrics_hold_calls" | grep -q -- '--add-label needs-maintainer-review' \
 	&& ! printf '%s' "$shared_metrics_hold_calls" | grep -q 'needs-brief-rewrite' \
 	&& [[ "$hold_api_calls" == "1" ]]; then
 	pass "zero-output hold reuses comment bloat metrics for evidence count"

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -42,6 +42,7 @@
 # Include guard
 [[ -n "${_WORKER_LIFECYCLE_COMMON_LOADED:-}" ]] && return 0
 _WORKER_LIFECYCLE_COMMON_LOADED=1
+_WLC_STATUS_BLOCKED="blocked"
 
 _ensure_worker_lineage() {
 	local session_key="$1"
@@ -1132,7 +1133,7 @@ _count_issue_comments_containing_marker() {
 # t3076: file a root-cause meta-issue with forensics when the no_work
 # breaker fires. Idempotent — second trip on the same original is a
 # no-op (filer self-checks via marker comment). Best-effort: failures
-# are swallowed; NMR remains the canonical block on the original.
+# are swallowed; status:blocked remains the canonical block on the original.
 #
 # Args: $1=issue_number, $2=repo_slug, $3=failure_count, $4=reason
 # Returns: 0 always
@@ -1160,8 +1161,8 @@ _file_circuit_breaker_meta_no_work() {
 # refresh race). Tier escalation is the wrong response to infra failures:
 # a more expensive model cannot fix an FD leak. We keep the issue at its
 # current tier, let the next retry attempt run cheaply after the infra
-# issue resolves, and rely on the existing circuit breakers to apply NMR
-# on cost/staleness thresholds if retries keep failing.
+# issue resolves, and rely on the existing circuit breakers to apply
+# machine-recoverable structural blocks if retries keep failing.
 #
 # Idempotent: checks for a prior comment with the marker
 # <!-- no-work-escalation-skip --> and skips if present, so a cascade of
@@ -1175,15 +1176,13 @@ _file_circuit_breaker_meta_no_work() {
 # Returns: 0 always (best-effort, never fatal)
 #######################################
 #######################################
-# Apply the no_work NMR circuit breaker (t2769) when failure_count
-# reaches the threshold: idempotent NMR label + comment with the
-# `cost-circuit-breaker:no_work_loop` marker that
-# `_nmr_application_is_circuit_breaker_trip` recognises (t2386 split
-# semantics — auto-approval preserves NMR), then file the t3076
-# root-cause meta-issue.
+# Apply the no_work lifecycle circuit breaker (t2769) when failure_count
+# reaches the threshold: idempotent status:blocked state + comment with the
+# backward-compatible `cost-circuit-breaker:no_work_loop` marker, then file the
+# t3076 root-cause meta-issue.
 #
 # Args: $1=issue_number, $2=repo_slug, $3=failure_count,
-#        $4=nmr_threshold, $5=reason
+#        $4=legacy-named threshold, $5=reason
 # Returns: 0 always (best-effort, never fatal)
 #######################################
 _apply_no_work_nmr_breaker() {
@@ -1195,13 +1194,12 @@ _apply_no_work_nmr_breaker() {
 	existing_nmr=$(_count_issue_comments_containing_marker \
 		"$issue_number" "$repo_slug" "$nmr_marker") || existing_nmr=""
 	if [[ "$existing_nmr" =~ ^[1-9][0-9]*$ ]]; then
-		printf '[worker-lifecycle][t2769] no_work NMR circuit breaker already applied for #%s (%s, count=%s)\n' \
+		printf '[worker-lifecycle][t2769] no_work circuit breaker already applied for #%s (%s, count=%s)\n' \
 			"$issue_number" "$repo_slug" "$failure_count" >&2 || true
 		return 0
 	fi
 
-	gh issue edit "$issue_number" --repo "$repo_slug" \
-		--add-label "needs-maintainer-review" 2>/dev/null || true
+	set_issue_status "$issue_number" "$repo_slug" "$_WLC_STATUS_BLOCKED" 2>/dev/null || true
 
 	local safe_reason
 	safe_reason=$(_sanitize_markdown "$reason")
@@ -1211,7 +1209,7 @@ _apply_no_work_nmr_breaker() {
 ## no_work Circuit Breaker Fired (t2769)
 
 **Trigger:** ${failure_count} consecutive worker failure(s) classified as \`no_work\` (threshold: ${nmr_threshold}).
-**Action:** Applied \`needs-maintainer-review\`. Further automated dispatch is suspended.
+**Action:** Applied \`status:blocked\`. Further automated dispatch is suspended.
 **Last failure reason:** ${safe_reason}
 
 **Why this class of failure does not cascade tiers:** \`no_work\` usually means the worker crashed during runtime setup before reading any target files (FD exhaustion, plugin init failure, auth refresh race) or stale-recovery falsely concluded no progress. A more expensive model cannot fix an infrastructure problem it never reached.
@@ -1223,11 +1221,11 @@ _apply_no_work_nmr_breaker() {
 - Branch naming race at dispatch time
 - Stale-recovery false positive on long issue threads (check dispatch-dedup-stale comment pagination and recent-activity aggregation)
 
-Remove \`needs-maintainer-review\` after investigating the root cause to re-enable dispatch.
+The linked root-cause meta-issue restores \`status:available\` after its fix merges. Manual recovery should requeue only after preserving any worker output.
 
-_Per-issue no_work circuit breaker (t2769). The \`${nmr_marker}\` marker is recognised by \`_nmr_application_is_circuit_breaker_trip\` in \`pulse-nmr-approval.sh\` (t2386 split semantics: auto-approval preserves NMR)._" 2>/dev/null || true
+_Per-issue no_work circuit breaker (t2769). The \`${nmr_marker}\` marker remains backward-compatible evidence for legacy NMR reconciliation._" 2>/dev/null || true
 
-	printf '[worker-lifecycle][t2769] no_work NMR circuit breaker fired for #%s (%s, count=%s)\n' \
+	printf '[worker-lifecycle][t2769] no_work circuit breaker fired for #%s (%s, count=%s)\n' \
 		"$issue_number" "$repo_slug" "$failure_count" >&2 || true
 
 	_file_circuit_breaker_meta_no_work "$issue_number" "$repo_slug" \
@@ -1240,7 +1238,7 @@ _Per-issue no_work circuit breaker (t2769). The \`${nmr_marker}\` marker is reco
 # preflight.
 #
 # These launch-control skips are not evidence that a worker reached the brief,
-# so they must not participate in the t2769 per-issue no_work NMR breaker.
+# so they must not participate in the t2769 per-issue no_work breaker.
 # Legitimate post-launch no_work reasons (for example worker_noop_zero_output)
 # still flow through the existing breaker path unchanged.
 #
@@ -1291,8 +1289,8 @@ _worker_failure_reason_is_completion_infrastructure() {
 	github_api_timeout | command_policy_timeout | prepared_commit_push_blocked | completed_locally_remote_completion_blocked | \
 		*"GitHub API timeout"* | *"github api timeout"* | \
 		*"command-policy timeout"* | *"command policy timeout"* | \
-		*"prepared commit"*"push"*"blocked"* | \
-		*"completed locally"*"remote completion"*"blocked"*)
+		*"prepared commit"*"push"*"$_WLC_STATUS_BLOCKED"* | \
+		*"completed locally"*"remote completion"*"$_WLC_STATUS_BLOCKED"*)
 		return 0
 		;;
 	*)
@@ -1319,14 +1317,13 @@ _log_no_work_skip_escalation() {
 	local nmr_threshold="${NO_WORK_NMR_THRESHOLD:-3}"
 
 	if _no_work_reason_is_prelaunch_skip "$reason"; then
-		printf '[worker-lifecycle][t2769] no_work NMR breaker skipped for pre-launch reason on #%s (%s, count=%s): %s\n' \
+		printf '[worker-lifecycle][t2769] no_work breaker skipped for pre-launch reason on #%s (%s, count=%s): %s\n' \
 			"$issue_number" "$repo_slug" "$failure_count" "$reason" >&2 || true
 		return 0
 	fi
 
 	# Circuit-breaker path (t2769): when failure_count >= threshold,
-	# apply NMR + file root-cause meta-issue. Auto-approval preserves NMR
-	# via the marker (t2386 split semantics).
+	# apply status:blocked + file a root-cause meta-issue.
 	if [[ "$failure_count" -ge "$nmr_threshold" ]]; then
 		_apply_no_work_nmr_breaker "$issue_number" "$repo_slug" \
 			"$failure_count" "$nmr_threshold" "$reason"
@@ -1363,7 +1360,7 @@ ${marker}
 
 **Why no cascade:** \`no_work\` means the worker never produced reliable implementation evidence — it crashed during runtime setup (FD exhaustion, plugin init failure, branch naming race, auth refresh race) or stale-recovery falsely concluded no progress. A more expensive model cannot fix an infrastructure problem it never reached. Cascading to \`tier:thinking\` would waste capacity on a problem the mapped standard or simple model can handle once the infrastructure clears.
 
-After ${nmr_threshold} consecutive \`no_work\` failures the per-issue no_work circuit breaker (t2769) applies \`needs-maintainer-review\` with a dedicated machine marker, so auto-approval correctly preserves NMR.
+After ${nmr_threshold} consecutive \`no_work\` failures the per-issue no_work circuit breaker (t2769) applies \`status:blocked\` and files a machine-recoverable root-cause meta-issue.
 
 _Automated by \`escalate_issue_tier()\` no_work skip (t2387) in worker-lifecycle-common.sh_
 <!-- ops:end -->"
@@ -1388,8 +1385,8 @@ _Automated by \`escalate_issue_tier()\` no_work skip (t2387) in worker-lifecycle
 #     auth refresh race). **Short-circuits BEFORE tier cascade** (t2387) —
 #     a more expensive model cannot fix infrastructure. Keeps the issue
 #     at its current tier and posts a diagnostic comment via
-#     _log_no_work_skip_escalation; existing circuit breakers apply NMR
-#     on cost/staleness thresholds if retries persist.
+#     _log_no_work_skip_escalation; existing circuit breakers apply structural
+#     status blocks on cost/staleness thresholds if retries persist.
 #   - "partial" / other: default threshold (2). Model got partway, may
 #     succeed with a continuation or fresh attempt.
 #

--- a/.agents/templates/knowledge-review-nmr-body.md
+++ b/.agents/templates/knowledge-review-nmr-body.md
@@ -22,14 +22,14 @@ verify the content is safe to commit.
 
 ## Review Actions
 
-**Approve** (promote source to `sources/` and close this issue):
+**Approve** after reviewing the staged source (promote it to `sources/`):
 
 ```bash
-sudo aidevops approve issue <this-issue-number> {{REPO_SLUG}}
+knowledge-review-helper.sh promote {{SOURCE_ID}}
 ```
 
-This triggers `knowledge-review-helper.sh promote {{SOURCE_ID}}`, which moves
-the source from `_knowledge/staging/{{SOURCE_ID}}/` to
+After promotion succeeds, close this issue. The command moves the source from
+`_knowledge/staging/{{SOURCE_ID}}/` to
 `_knowledge/sources/{{SOURCE_ID}}/` and updates the audit log.
 
 **Reject** (keep source in staging, do not promote):

--- a/.agents/tests/test-knowledge-review.sh
+++ b/.agents/tests/test-knowledge-review.sh
@@ -9,7 +9,7 @@
 # Tests:
 #   1. shellcheck — zero violations
 #   2. auto-promotion path — maintainer trust → moves inbox → sources + audit
-#   3. NMR-file path — untrusted → moves to staging, audit record written
+#   3. review-file path — untrusted → moves to staging, audit record written
 #   4. review_gate path — review_gate email → staged (no GH slug, no issue filed)
 #   5. idempotent tick — re-run on already-staged source does not double-process
 #   6. promote subcommand — moves staging → sources, updates meta.json state
@@ -17,6 +17,7 @@
 #   8. trust ladder — explicit trust:trusted meta field triggers auto-promote
 #   9. trusted/authoritative meta field — both trigger auto-promote
 #  10. missing meta.json — skipped gracefully
+#  11. untrusted review issue — hold-for-review, never NMR, manual promotion guidance
 #
 # Mocking strategy: create a minimal _knowledge/ directory tree in a temp dir,
 # set KNOWLEDGE_ROOT and CWD so the helper picks it up, then inspect results.
@@ -177,7 +178,7 @@ test_auto_promote_trusted_meta() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 3: NMR-file path — unverified source moves to staging + audit entry
+# Test 3: legacy review-file state path — unverified source moves to staging + audit entry
 # ---------------------------------------------------------------------------
 
 test_untrusted_staged_and_audited() {
@@ -408,6 +409,58 @@ test_missing_meta() {
 }
 
 # ---------------------------------------------------------------------------
+# Test 11: untrusted review issues use an explicit content-review hold
+# ---------------------------------------------------------------------------
+
+test_untrusted_review_issue_labels() {
+	local name="untrusted review issue uses hold-for-review without NMR"
+	local plane="${TEST_TMPDIR}/t11"
+	local label_log="${TEST_TMPDIR}/t11-labels.log"
+	local body_log="${TEST_TMPDIR}/t11-body.md"
+	make_plane "$plane"
+	make_trust_config "$plane"
+	make_source "$plane" "src-held-001" "unverified" "stranger@external.com"
+	mv "${plane}/inbox/src-held-001" "${plane}/staging/src-held-001"
+
+	LABEL_LOG="$label_log" BODY_LOG="$body_log" PLANE="$plane" HELPER_PATH="$HELPER" bash -c '
+		set -euo pipefail
+		source "$HELPER_PATH"
+		gh_create_issue() {
+			local expect=""
+			local arg=""
+			for arg in "$@"; do
+				if [[ "$expect" == "label" ]]; then
+					printf "%s\n" "$arg" >"$LABEL_LOG"
+					expect=""
+				elif [[ "$expect" == "body" ]]; then
+					cp "$arg" "$BODY_LOG"
+					expect=""
+				elif [[ "$arg" == "--label" ]]; then
+					expect="label"
+				elif [[ "$arg" == "--body-file" ]]; then
+					expect="body"
+				fi
+			done
+			printf "https://github.com/owner/repo/issues/123\n"
+			return 0
+		}
+		meta_json=$(jq "." "$PLANE/staging/src-held-001/meta.json")
+		_file_nmr_issue "$PLANE" "src-held-001" "$meta_json" "untrusted" "owner/repo" >/dev/null
+	' 2>/dev/null
+
+	local labels=""
+	labels=$(<"$label_log")
+	if [[ "$labels" == *"hold-for-review"* && "$labels" != *"needs-maintainer-review"* ]] \
+		&& grep -qF 'knowledge-review-helper.sh promote src-held-001' "$body_log" \
+		&& ! grep -qF 'sudo aidevops approve issue' "$body_log"; then
+		pass "$name"
+	else
+		fail "$name" "labels=${labels}"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 
@@ -424,6 +477,7 @@ main() {
 	test_auto_promote_trusted_bot
 	test_auto_promote_authoritative
 	test_missing_meta
+	test_untrusted_review_issue_labels
 
 	teardown
 

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -290,7 +290,7 @@ Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `m
 
 **Qlty New-File Smell Gate (t2068):** CI fails when brand-new source files ship with smells; details/override/local check: `reference/shell-style-guide.md` "Quality gate pattern reference".
 
-**Cryptographic approval + NMR automation (t2386):** moved to `reference/task-lifecycle.md`; read before approving issues/PRs or clearing/preserving NMR.
+**Cryptographic approval + review-block semantics:** moved to `reference/task-lifecycle.md`; read before approving external issues/PRs or changing NMR, `hold-for-review`, or structural blocker state.
 
 **Task-ID collision guard (t2047):** t-IDs in commit subjects MUST be claimed via `claim-task-id.sh`; enforcement details live in `reference/shell-style-guide.md` "Quality gate pattern reference".
 

--- a/.agents/workflows/log-issue-aidevops.md
+++ b/.agents/workflows/log-issue-aidevops.md
@@ -41,7 +41,7 @@ these keywords.
 | Workaround applied | Likely systemic fix |
 |---|---|
 | Applied `complexity-bump-ok` label to bypass a false-positive gate | Gate needs refinement for specific false-positive class |
-| `sudo aidevops approve` to unblock auto-approved issue stuck in NMR | NMR classification logic has a gap |
+| `sudo aidevops approve` suggested for a write-authorized issue stuck in NMR | Author-authority normalization has a gap; trusted authors must not self-approve |
 | Manually ran `pre-edit-check.sh` because hook didn't fire | Hook installation or detection issue |
 | `gh pr edit --base main` after an `origin:interactive` PR stacked on a feature branch | Stacked-PR retarget logic needs extending to grandchildren |
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report a bug — please use /log-issue-aidevops in your AI assistant for best results
 title: "Bug: "
-labels: ["bug", "needs-maintainer-review"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest an improvement or new feature
 title: "Feature: "
-labels: ["enhancement", "needs-maintainer-review"]
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/performance_optimization.yml
+++ b/.github/ISSUE_TEMPLATE/performance_optimization.yml
@@ -1,7 +1,7 @@
 name: Performance Optimization
 description: Report a performance issue — requires actual measurements
 title: "Perf: "
-labels: ["performance", "needs-maintainer-review"]
+labels: ["performance"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/issue-triage-gate.yml
+++ b/.github/workflows/issue-triage-gate.yml
@@ -24,17 +24,17 @@ jobs:
             const association = issue.author_association;
             const issueLabels = new Set((issue.labels || []).map(label => label.name));
 
-            // Bot accounts always bypass triage (github-actions[bot], dependabot, etc.)
-            if (issue.user.type === 'Bot') {
-              console.log(`Author ${author} is a bot — bypassing triage`);
-              return;
-            }
-
             // OWNER/MEMBER are authoritative associations. COLLABORATOR can
             // represent read/triage access, so require a live write-level lookup.
+            // Repository-installed bots are trusted automation authors, but still
+            // run through stale-NMR cleanup below instead of returning early.
+            // An explicit external-contributor label records external source
+            // provenance even when trusted automation authored the issue.
             const trustedRoles = ['OWNER', 'MEMBER'];
-            let authorIsTrusted = trustedRoles.includes(association);
-            if (!authorIsTrusted && association === 'COLLABORATOR') {
+            const hasExternalAuthoritySource = issueLabels.has('external-contributor');
+            let authorIsTrusted = !hasExternalAuthoritySource &&
+              (issue.user.type === 'Bot' || trustedRoles.includes(association));
+            if (!hasExternalAuthoritySource && !authorIsTrusted && association === 'COLLABORATOR') {
               try {
                 const permissionResponse = await github.request(
                   'GET /repos/{owner}/{repo}/collaborators/{username}/permission',
@@ -65,7 +65,8 @@ jobs:
                     name: 'needs-maintainer-review'
                   });
                 } catch (error) {
-                  core.warning(`Unable to remove stale review label: ${error.message}`);
+                  core.error(`Unable to remove stale review label: ${error.message}`);
+                  throw error;
                 }
               }
               return;

--- a/.github/workflows/maintainer-gate-reusable.yml
+++ b/.github/workflows/maintainer-gate-reusable.yml
@@ -560,16 +560,19 @@ jobs:
 
           issue_author_has_live_authority() {
             local issue_json="$1"
-            local identity="" author="" association="" permission=""
+            local identity="" author="" association="" author_type="" external_source="" permission=""
             if ! identity=$(printf '%s' "$issue_json" | jq -r '
               if (.user.login // "") != "" and (.author_association // "") != ""
-              then [(.user.login // ""), (.author_association // "")] | @tsv
+              then [(.user.login // ""), (.author_association // ""), (.user.type // ""),
+                (([.labels[]?.name] | index("external-contributor") != null) | tostring)] | @tsv
               else error("missing live issue author metadata") end
             ' 2>/dev/null); then
               return 2
             fi
-            IFS=$'\t' read -r author association <<< "$identity"
+            IFS=$'\t' read -r author association author_type external_source <<< "$identity"
             [[ "$author" == "$ISSUE_AUTHOR" ]] || return 2
+            [[ "$external_source" != "true" ]] || return 1
+            [[ "$author_type" == "Bot" ]] && return 0
             case "$association" in
               OWNER|MEMBER) return 0 ;;
               COLLABORATOR) ;;
@@ -581,30 +584,6 @@ jobs:
             fi
             case "$permission" in
               admin|maintain|write) return 0 ;;
-              *) return 1 ;;
-            esac
-          }
-
-          trusted_bot_open_cleanup_is_allowed() {
-            local issue_json="" created_at="" created_epoch="" now_epoch="" age_seconds="" authority_rc=0
-            [[ "$ACTOR" == "github-actions[bot]" ]] || return 1
-            if ! issue_json=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" 2>/dev/null); then
-              return 2
-            fi
-            created_at=$(printf '%s' "$issue_json" | jq -r '.created_at // ""' 2>/dev/null) || return 2
-            [[ -n "$created_at" ]] || return 2
-            if date --version >/dev/null 2>&1; then
-              created_epoch=$(date -u -d "$created_at" '+%s' 2>/dev/null) || return 2
-            else
-              created_epoch=$(date -j -u -f '%Y-%m-%dT%H:%M:%SZ' "$created_at" '+%s' 2>/dev/null) || return 2
-            fi
-            now_epoch=$(date -u '+%s' 2>/dev/null) || return 2
-            age_seconds=$((now_epoch - created_epoch))
-            [[ "$age_seconds" -ge 0 && "$age_seconds" -le 300 ]] || return 1
-            issue_author_has_live_authority "$issue_json" || authority_rc=$?
-            case "$authority_rc" in
-              0) return 0 ;;
-              2) return 2 ;;
               *) return 1 ;;
             esac
           }
@@ -649,21 +628,22 @@ jobs:
             return 1
           }
 
-          #aidevops:trust-boundary GH#29151: issue-triage removes a form-default
-          # NMR label as github-actions[bot] immediately after a trusted author
-          # opens an issue. Permit only that narrow, live-verified creation-time
-          # cleanup. Later bot removals still require cryptographic approval so
-          # an explicit human hold cannot be erased by unrelated automation.
-          if [[ "$ACTOR" == "github-actions[bot]" ]]; then
-            TRUSTED_BOT_RC=0
-            trusted_bot_open_cleanup_is_allowed || TRUSTED_BOT_RC=$?
-            if [[ "$TRUSTED_BOT_RC" -eq 0 ]]; then
-              echo "ALLOWED: creation-time triage cleanup by github-actions[bot] for a live-verified maintainer-authored issue"
-              exit 0
-            fi
-            if [[ "$TRUSTED_BOT_RC" -eq 2 ]]; then
-              echo "::warning::Unable to verify creation-time trusted-author cleanup — restoring NMR"
-            fi
+          #aidevops:trust-boundary GH#29151/GH#29394: NMR is an external-author
+          # trust gate, not a hold for write-authorized issue authors. Permit any
+          # removal actor when the live issue author independently has write
+          # authority. Unknown authority still fails closed and restores NMR.
+          LIVE_ISSUE_JSON=""
+          LIVE_AUTHOR_RC=2
+          if LIVE_ISSUE_JSON=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" 2>/dev/null); then
+            LIVE_AUTHOR_RC=0
+            issue_author_has_live_authority "$LIVE_ISSUE_JSON" || LIVE_AUTHOR_RC=$?
+          fi
+          if [[ "$LIVE_AUTHOR_RC" -eq 0 ]]; then
+            echo "ALLOWED: NMR removal from live-verified write-authorized issue author"
+            exit 0
+          fi
+          if [[ "$LIVE_AUTHOR_RC" -eq 2 ]]; then
+            echo "::warning::Unable to verify live issue-author authority — restoring NMR"
           fi
 
           #aidevops:trust-boundary GH#1894/GH#27611/GH#28622: marker text is
@@ -1298,7 +1278,23 @@ jobs:
             # visibly instead of creating an irreversible ever-NMR record.
             EXTERNAL_AUTHOR="true"
             case "$ISSUE_AUTHOR_ASSOC" in
-              OWNER|MEMBER|COLLABORATOR) EXTERNAL_AUTHOR="false" ;;
+              OWNER|MEMBER) EXTERNAL_AUTHOR="false" ;;
+              COLLABORATOR)
+                ISSUE_AUTHOR_PERM=""
+                if ! ISSUE_AUTHOR_PERM=$(gh api "repos/${REPO}/collaborators/${ISSUE_AUTHOR}/permission" \
+                  --jq '.permission // "none"' 2>/dev/null); then
+                  echo "::error::Unable to verify permission for issue author $ISSUE_AUTHOR — leaving labels unchanged"
+                  exit 1
+                fi
+                case "$ISSUE_AUTHOR_PERM" in
+                  write|admin|maintain) EXTERNAL_AUTHOR="false" ;;
+                  none|read|triage) ;;
+                  *)
+                    echo "::error::Unexpected permission value for issue author $ISSUE_AUTHOR — leaving labels unchanged"
+                    exit 1
+                    ;;
+                esac
+                ;;
               CONTRIBUTOR|FIRST_TIME_CONTRIBUTOR|FIRST_TIMER|MANNEQUIN|NONE) ;;
               *)
                 echo "::error::Unexpected author association for issue #$ISSUE_NUMBER (author=$ISSUE_AUTHOR) — leaving labels unchanged"

--- a/.github/workflows/nmr-hold-comment.yml
+++ b/.github/workflows/nmr-hold-comment.yml
@@ -3,12 +3,12 @@
 #
 # NMR Hold Guidance Comment
 #
-# When the needs-maintainer-review label is added to any issue, this workflow
-# posts a comment explaining the hold and providing the approve command.
+# When the needs-maintainer-review label is added to an issue, this workflow
+# converts trusted-author uses to hold-for-review and posts approval guidance
+# only for external-author trust gates.
 #
-# Covers two scenarios:
-# 1. Collaborator self-applying NMR as a "hold" to prevent pulse dispatch
-# 2. Fallback for external issues where issue-triage-gate didn't post guidance
+# Trusted authors use hold-for-review for an intentional manual hold. NMR is
+# reserved for external authors who require cryptographic trust approval.
 #
 # Deduplicates against comments already posted by:
 # - issue-triage-gate.yml (on issue opened for non-collaborators)
@@ -58,6 +58,57 @@ jobs:
               return;
             }
 
+            // #aidevops:trust-boundary — NMR is only an external-author trust
+            // gate. OWNER/MEMBER are authoritative webhook associations;
+            // COLLABORATOR requires a live write-level permission lookup.
+            // Trusted automation can also file an issue derived from an external
+            // contribution; preserve that explicitly labelled source boundary.
+            const issueLabels = new Set((issue.labels || []).map(label => label.name));
+            const hasExternalAuthoritySource = issueLabels.has('external-contributor');
+            let authorIsTrusted = !hasExternalAuthoritySource &&
+              (issue.user?.type === 'Bot' ||
+                ['OWNER', 'MEMBER'].includes(issue.author_association));
+            if (!hasExternalAuthoritySource && !authorIsTrusted && issue.author_association === 'COLLABORATOR') {
+              try {
+                const permissionResponse = await github.request(
+                  'GET /repos/{owner}/{repo}/collaborators/{username}/permission',
+                  {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    username: issue.user.login
+                  }
+                );
+                authorIsTrusted = ['admin', 'maintain', 'write'].includes(
+                  permissionResponse.data.permission
+                );
+              } catch (error) {
+                core.warning(`Unable to verify collaborator permission for ${issue.user.login}; preserving the external trust gate: ${error.message}`);
+              }
+            }
+
+            if (authorIsTrusted) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['hold-for-review']
+              });
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: 'needs-maintainer-review'
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+              console.log(`Normalized trusted-author NMR on #${issueNumber} to hold-for-review`);
+              return;
+            }
+
             // Dedup: check for existing comments with the approve command.
             // Covers prior posts from issue-triage-gate, maintainer-gate
             // label protection, or a previous run of this workflow.
@@ -80,39 +131,18 @@ jobs:
               return;
             }
 
-            // Determine context: collaborator holding their own issue vs external triage
-            const association = issue.author_association;
-            const trustedRoles = ['OWNER', 'MEMBER', 'COLLABORATOR'];
-            const isCollaboratorIssue = trustedRoles.includes(association);
-
-            let body;
-            if (isCollaboratorIssue) {
-              body = [
-                '<!-- nmr-hold-guidance -->',
-                '**Issue held from dispatch.** The `needs-maintainer-review` label prevents the pulse supervisor from dispatching workers for this issue.',
-                '',
-                'When ready to release it for work:',
-                '```',
-                `sudo aidevops approve issue ${issueNumber}`,
-                '```',
-                '',
-                'This posts a cryptographic approval comment and removes the label, allowing the pipeline to process the issue on the next pulse cycle.'
-              ].join('\n');
-            } else {
-              // Non-collaborator issue where triage gate somehow missed posting.
-              // Provides the same guidance as a fallback.
-              body = [
-                '<!-- nmr-hold-guidance -->',
-                'This issue requires maintainer review before it can be processed by the pipeline.',
-                '',
-                'A maintainer can approve it using:',
-                '```',
-                `sudo aidevops approve issue ${issueNumber}`,
-                '```',
-                '',
-                'This posts a cryptographic approval comment and removes the label, allowing the pipeline to process the issue on the next pulse cycle.'
-              ].join('\n');
-            }
+            // External issue where the triage gate did not already post guidance.
+            const body = [
+              '<!-- nmr-hold-guidance -->',
+              'This externally authored issue requires maintainer trust review before it can be processed by the pipeline.',
+              '',
+              'A maintainer can approve it using:',
+              '```',
+              `sudo aidevops approve issue ${issueNumber}`,
+              '```',
+              '',
+              'This posts a cryptographic approval comment and removes the label, allowing the pipeline to process the issue on the next pulse cycle.'
+            ].join('\n');
 
             try {
               await github.rest.issues.createComment({
@@ -132,4 +162,4 @@ jobs:
               throw error;
             }
 
-            console.log(`Posted hold guidance comment on #${issueNumber} (collaborator=${isCollaboratorIssue}, actor=${actor})`);
+            console.log(`Posted external-author trust guidance on #${issueNumber} (actor=${actor})`);

--- a/.github/workflows/pr-triage-gate.yml
+++ b/.github/workflows/pr-triage-gate.yml
@@ -38,20 +38,34 @@ jobs:
             const author = pr.user.login;
             const association = pr.author_association;
 
-            // Bot accounts always bypass triage
-            if (pr.user.type === 'Bot') {
-              console.log(`Author ${author} is a bot — bypassing triage`);
-              return;
+            // OWNER/MEMBER and repository-installed bots are trusted. A bare
+            // COLLABORATOR association can represent read/triage access, so it
+            // requires a live write-level permission lookup.
+            // CONTRIBUTOR (has previous merged PRs) is NOT trusted
+            const trustedRoles = ['OWNER', 'MEMBER'];
+            let authorIsTrusted = pr.user.type === 'Bot' ||
+              trustedRoles.includes(association);
+            if (!authorIsTrusted && association === 'COLLABORATOR') {
+              try {
+                const permissionResponse = await github.request(
+                  'GET /repos/{owner}/{repo}/collaborators/{username}/permission',
+                  {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    username: author
+                  }
+                );
+                authorIsTrusted = ['admin', 'maintain', 'write'].includes(
+                  permissionResponse.data.permission
+                );
+              } catch (error) {
+                core.warning(`Unable to verify collaborator permission for ${author}; preserving PR triage gate: ${error.message}`);
+              }
             }
 
-            // Maintainers and collaborators bypass triage
-            // OWNER, MEMBER, COLLABORATOR are trusted roles
-            // CONTRIBUTOR (has previous merged PRs) is NOT trusted
-            const trustedRoles = ['OWNER', 'MEMBER', 'COLLABORATOR'];
-
             // #aidevops:trust-boundary GH#17671/GH#28567
-            if (trustedRoles.includes(association)) {
-              console.log(`Author ${author} has role ${association} — bypassing triage`);
+            if (authorIsTrusted) {
+              console.log(`Author ${author} has verified trusted authority — bypassing triage`);
               return;
             }
 
@@ -63,7 +77,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 name: 'needs-maintainer-review',
-                description: 'External issue awaiting maintainer review before pipeline pickup',
+                description: 'External contribution awaiting maintainer approval before pipeline pickup',
                 color: 'FBCA04'
               });
             } catch (e) {

--- a/TODO.md
+++ b/TODO.md
@@ -86,7 +86,7 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 ## Routines
 
 - [x] r-gh-audit-scan Scan gh-audit.log for anomalies repeat:daily(@09:00) run:scripts/gh-audit-anomaly-helper.sh scan
-- [x] r040 Knowledge review gate — classify inbox items by trust, auto-promote or NMR-file repeat:cron(*/15 * * * *) ~1m run:scripts/knowledge-review-helper.sh tick
+- [x] r040 Knowledge review gate — classify inbox items by trust, auto-promote or review-file repeat:cron(*/15 * * * *) ~1m run:scripts/knowledge-review-helper.sh tick
 - [x] r041 Knowledge enrichment — extract structured fields from freshly-promoted sources repeat:cron(*/30 * * * *) ~2m run:scripts/document-enrich-helper.sh tick
 - [x] r042 Knowledge index build — incremental PageIndex tree across corpus repeat:cron(*/60 * * * *) ~2m run:scripts/knowledge-index-helper.sh build
 - [x] r044 IMAP mailbox polling — fetch new emails to _knowledge/inbox/ repeat:cron(*/10 * * * *) ~1m run:scripts/email-poll-helper.sh tick
@@ -1215,6 +1215,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 - [x] t18184 Fix status-label reconciliation and REST issue edit array safety #bug #efficiency #framework #github-api #no-auto-dispatch ref:GH#28912 pr:#28933 completed:2026-07-30
 
 - [ ] t18189 Route standard workload tier through OpenAI Luna max reasoning #type:enhancement ref:GH#29070
+
+- [ ] t18190 Restrict needs-maintainer-review to external trust gates #auto-dispatch #bug ref:GH#29394
 
 ## In Progress
 


### PR DESCRIPTION
## Summary

Reserve needs-maintainer-review for external or unknown authority, normalize trusted-author residues without self-approval, and route internal review or recoverable failures through explicit hold and blocked states.

## Files Changed

.agents/AGENTS.md, .agents/aidevops/knowledge-plane/04-enrichment-index-review.md, .agents/reference/attribution-monitoring.md, .agents/reference/auto-merge.md, .agents/reference/dispatch-blockers.md, .agents/reference/gh-audit-log.md, .agents/reference/parent-task-lifecycle.md, .agents/reference/progressive-disclosure.md, .agents/reference/task-lifecycle.md, .agents/reference/worker-diagnostics.md, .agents/reference/worker-discipline.md, .agents/scripts/auto-decomposer-scanner.sh, .agents/scripts/circuit-breaker-meta-filer.sh, .agents/scripts/dispatch-backoff-helper.sh, .agents/scripts/dispatch-dedup-cost.sh, .agents/scripts/dispatch-dedup-helper.sh, .agents/scripts/dispatch-dedup-recovery-loop.sh, .agents/scripts/dispatch-dedup-stale.sh, .agents/scripts/dispatch-single-issue-helper.sh, .agents/scripts/full-loop-helper-state.sh, .agents/scripts/headless-runtime-worker.sh, .agents/scripts/issue-sync-lib-compose.sh, .agents/scripts/knowledge-review-helper.sh, .agents/scripts/label-sync-helper.sh, .agents/scripts/post-merge-review-scanner.sh, .agents/scripts/pulse-ancillary-dispatch.sh, .agents/scripts/pulse-cleanup.sh, .agents/scripts/pulse-dirty-pr-sweep.sh, .agents/scripts/pulse-dispatch-core.sh, .agents/scripts/pulse-dispatch-dedup-layers.sh, .agents/scripts/pulse-dispatch-engine.sh, .agents/scripts/pulse-dispatch-lib.sh, .agents/scripts/pulse-dispatch-preflight-lib.sh, .agents/scripts/pulse-dispatch-worker-prompt.sh, .agents/scripts/pulse-fast-fail.sh, .agents/scripts/pulse-issue-reconcile-actions.sh, .agents/scripts/pulse-issue-reconcile.sh, .agents/scripts/pulse-merge-feedback-finalizer.sh, .agents/scripts/pulse-merge-feedback.sh, .agents/scripts/pulse-merge-process.sh, .agents/scripts/pulse-nmr-approval.sh, .agents/scripts/pulse-simplification-issues.sh, .agents/scripts/pulse-simplification-scan.sh, .agents/scripts/pulse-wrapper-config.sh, .agents/scripts/quality-feedback-issues-lib.sh, .agents/scripts/shared-gh-wrappers-create.sh, .agents/scripts/shared-gh-wrappers-status.sh, .agents/scripts/stats-quality-sweep-issues.sh, .agents/scripts/tests/test-circuit-breaker-meta-filer.sh, .agents/scripts/tests/test-cost-circuit-breaker.sh, .agents/scripts/tests/test-dispatch-backoff-helper.sh, .agents/scripts/tests/test-dispatch-single-issue-helper.sh, .agents/scripts/tests/test-fast-fail-age-out.sh, .agents/scripts/tests/test-full-loop-external-issue-author-gate.sh, .agents/scripts/tests/test-generated-issue-worker-labels.sh, .agents/scripts/tests/test-gh-wrapper-nmr-normalization.sh, .agents/scripts/tests/test-headless-runtime-checkpoint-tests.sh, .agents/scripts/tests/test-issue-triage-gate-fail-closed.sh, .agents/scripts/tests/test-maintainer-gate-approval-api-failure.sh, .agents/scripts/tests/test-maintainer-gate-origin-worker-api-failure.sh, .agents/scripts/tests/test-nmr-hold-comment-locked.sh, .agents/scripts/tests/test-no-work-prelaunch-skip.sh, .agents/scripts/tests/test-parent-decomposition-escalation.sh, .agents/scripts/tests/test-parent-task-lifecycle.sh, .agents/scripts/tests/test-post-merge-review-scanner.sh, .agents/scripts/tests/test-pr-triage-gate-fail-closed.sh, .agents/scripts/tests/test-pulse-dispatch-core-external-author-gate.sh, .agents/scripts/tests/test-pulse-labelless-reconcile.sh, .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh, .agents/scripts/tests/test-pulse-merge-worker-briefed.sh, .agents/scripts/tests/test-pulse-nmr-maintainer-authority.sh, .agents/scripts/tests/test-pulse-prefetch-label-count.sh, .agents/scripts/tests/test-quality-feedback-trust-bar.sh, .agents/scripts/tests/test-stale-recovery-escalation.sh, .agents/scripts/tests/test-worker-reliability-self-heal.sh, .agents/scripts/tests/test-workflow-cascade-lint.sh, .agents/scripts/tests/test-zero-output-url-fallback.sh, .agents/scripts/worker-lifecycle-common.sh, .agents/templates/knowledge-review-nmr-body.md, .agents/tests/test-knowledge-review.sh, .agents/workflows/git-workflow.md, .agents/workflows/log-issue-aidevops.md, .github/ISSUE_TEMPLATE/bug_report.yml, .github/ISSUE_TEMPLATE/feature_request.yml, .github/ISSUE_TEMPLATE/performance_optimization.yml, .github/workflows/issue-triage-gate.yml, .github/workflows/maintainer-gate-reusable.yml, .github/workflows/nmr-hold-comment.yml, .github/workflows/pr-triage-gate.yml, TODO.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: executed changed strict and full local lint, plus authority, approval, workflow JavaScript, dispatch, and needs-info shell regression suites; all passed.

Resolves #29394


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.217 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 2h 41m and 3,362,558 tokens on this with the user in an interactive session.