### PR TITLE
GH#29405: Restore strict broad-ratchet signal after baseline drift

### DIFF
--- a/.agents/scripts/linters-local-ratchet.sh
+++ b/.agents/scripts/linters-local-ratchet.sh
@@ -5,9 +5,9 @@
 # Local Linters — Ratchet Quality Check Sub-Library
 # =============================================================================
 # Ratchet system extracted from linters-local.sh (GH#21418).
-# Tracks anti-pattern counts against a stored baseline. Counts can only stay
-# the same or decrease — never increase. Prevents gradual quality regression
-# without requiring zero violations immediately.
+# Tracks anti-pattern counts against the default-branch merge-base. Counts can
+# only stay the same or decrease — never increase. The stored snapshot is
+# retained for provenance and compatibility, not as the active comparison.
 #
 # Baseline: .agents/configs/ratchets.json
 # Exceptions: .agents/configs/ratchet-exceptions/{pattern}.txt
@@ -50,6 +50,9 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 #   linters-local.sh                  # advisory ratchet check
 #   linters-local.sh --strict         # blocking ratchet check
 #   linters-local.sh --update-baseline # re-count and write new baseline
+
+readonly RATCHET_SCHEMA_VERSION=2
+readonly RATCHET_COUNTER_VERSION=2
 
 # _ratchet_step_timeout_seconds: read and validate per-ratchet timeout.
 # Returns: timeout seconds via stdout
@@ -134,9 +137,10 @@ _ratchet_count_with_progress() {
 _ratchet_count_bare_positional() {
 	local scripts_dir="$1"
 	local count=0
-	count=$(rg '\$[1-9]' --type sh "$scripts_dir" 2>/dev/null |
+	[[ -d "$scripts_dir" ]] || return 1
+	count=$(rg '\$[1-9]' --type sh --no-filename "$scripts_dir" 2> /dev/null |
 		grep -v 'local.*=.*\$[1-9]' |
-		grep -cv '^\s*#') || count=0
+		grep -cv '^[[:space:]]*#') || count=0
 	[[ "$count" =~ ^[0-9]+$ ]] || count=0
 	echo "$count"
 	return 0
@@ -147,10 +151,11 @@ _ratchet_count_bare_positional() {
 _ratchet_count_hardcoded_path() {
 	local scripts_dir="$1"
 	local count=0
+	[[ -d "$scripts_dir" ]] || return 1
 	# Tilde is intentional: we search for the literal string ~/.aidevops in scripts
 	# shellcheck disable=SC2088
-	count=$(rg '~/.aidevops|/Users/' --type sh "$scripts_dir" 2>/dev/null |
-		grep -v '^\s*#' |
+	count=$(rg '~/.aidevops|/Users/' --type sh --no-filename "$scripts_dir" 2> /dev/null |
+		grep -v '^[[:space:]]*#' |
 		grep -cv '# ') || count=0
 	[[ "$count" =~ ^[0-9]+$ ]] || count=0
 	echo "$count"
@@ -162,7 +167,8 @@ _ratchet_count_hardcoded_path() {
 _ratchet_count_broad_catch() {
 	local scripts_dir="$1"
 	local count=0
-	count=$(rg '\|\| true' --type sh "$scripts_dir" 2>/dev/null |
+	[[ -d "$scripts_dir" ]] || return 1
+	count=$(rg '\|\| true' --type sh --no-filename "$scripts_dir" 2> /dev/null |
 		wc -l | tr -d '[:space:]') || count=0
 	[[ "$count" =~ ^[0-9]+$ ]] || count=0
 	echo "$count"
@@ -174,27 +180,52 @@ _ratchet_count_broad_catch() {
 _ratchet_count_silent_errors() {
 	local scripts_dir="$1"
 	local count=0
-	count=$(rg '2>/dev/null' --type sh "$scripts_dir" 2>/dev/null |
+	[[ -d "$scripts_dir" ]] || return 1
+	count=$(rg '2>/dev/null' --type sh --no-filename "$scripts_dir" 2> /dev/null |
 		wc -l | tr -d '[:space:]') || count=0
 	[[ "$count" =~ ^[0-9]+$ ]] || count=0
 	echo "$count"
 	return 0
 }
 
-# _ratchet_count_missing_return: count files with functions but fewer return statements
+# _ratchet_count_missing_return: count files containing a function with no return
+# Arguments: $1=scripts_dir
 # Returns: count via stdout
 _ratchet_count_missing_return() {
-	[[ ${#ALL_SH_FILES[@]} -gt 0 ]] || {
+	local scripts_dir="$1"
+	local shell_files=()
+	[[ -d "$scripts_dir" ]] || return 1
+	while IFS= read -r file; do
+		[[ -n "$file" ]] && shell_files+=("$file")
+	done < <(rg --files --type sh "$scripts_dir" | grep -v '/_archive/' | LC_ALL=C sort)
+
+	[[ ${#shell_files[@]} -gt 0 ]] || {
 		echo "0"
 		return 0
 	}
 	awk '
-		function finish_file() { if (returns < functions) missing++ }
-		FNR == 1 { if (NR > 1) finish_file(); functions = 0; returns = 0 }
-		/^[a-zA-Z_][a-zA-Z0-9_]*\(\) \{$/ { functions++ }
-		/return [0-9]+|return \$/ { returns++ }
+		function finish_function() {
+			if (in_function && !has_return) file_missing = 1
+			in_function = 0
+			has_return = 0
+		}
+		function finish_file() {
+			finish_function()
+			if (file_missing) missing++
+		}
+		FNR == 1 {
+			if (NR > 1) finish_file()
+			file_missing = 0
+		}
+		/^[a-zA-Z_][a-zA-Z0-9_]*\(\) \{$/ {
+			finish_function()
+			in_function = 1
+			next
+		}
+		in_function && /return[[:space:]]+([0-9]+|\$)/ { has_return = 1 }
+		in_function && /^}$/ { finish_function() }
 		END { finish_file(); print missing + 0 }
-	' "${ALL_SH_FILES[@]}"
+	' "${shell_files[@]}"
 	return 0
 }
 
@@ -237,7 +268,7 @@ _ratchet_check_pattern() {
 	else
 		local regression=$((effective_current - effective_baseline))
 		if [[ "$strict_mode" == "true" ]]; then
-			print_error "  FAIL: ${name} ${effective_baseline} -> ${effective_current} (regressed by ${regression}) — run --update-baseline after fixing"
+			print_error "  FAIL: ${name} ${effective_baseline} -> ${effective_current} (regressed by ${regression}) — remove the introduced occurrence"
 		else
 			print_warning "  WARN: ${name} ${effective_baseline} -> ${effective_current} (regressed by ${regression}) — advisory only (use --strict to block)"
 		fi
@@ -256,78 +287,235 @@ _ratchet_count_all() {
 	count_hardcoded=$(_ratchet_count_with_progress "hardcoded_aidevops_path" "_ratchet_count_hardcoded_path" "$scripts_dir") || return 1
 	count_broad=$(_ratchet_count_with_progress "broad_catch_or_true" "_ratchet_count_broad_catch" "$scripts_dir") || return 1
 	count_silent=$(_ratchet_count_with_progress "silent_errors" "_ratchet_count_silent_errors" "$scripts_dir") || return 1
-	count_missing=$(_ratchet_count_with_progress "missing_return_files" "_ratchet_count_missing_return" "") || return 1
+	count_missing=$(_ratchet_count_with_progress "missing_return_files" "_ratchet_count_missing_return" "$scripts_dir") || return 1
 	echo "$count_bare $count_hardcoded $count_broad $count_silent $count_missing"
 	return 0
 }
 
-# _ratchet_write_baseline: build and write (or dry-run) a new baseline JSON file
-# Arguments: $1=baseline_file $2=count_bare $3=count_hardcoded $4=count_broad $5=count_silent $6=count_missing
-# Returns: 0 on success, 1 on jq failure
-_ratchet_write_baseline() {
-	local baseline_file="$1"
-	local count_bare="$2"
-	local count_hardcoded="$3"
-	local count_broad="$4"
-	local count_silent="$5"
-	local count_missing="$6"
+# _ratchet_resolve_base_ref: resolve a verified default-branch merge-base.
+# Arguments: $1=repo_root
+# Returns: full commit SHA via stdout, 1 when no safe base is available.
+_ratchet_resolve_base_ref() {
+	local repo_root="$1"
+	local configured_ref="${RATCHET_BASE_REF:-}"
+	local default_ref=""
+	local candidate=""
+	local base_ref=""
 
-	local now
-	now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-	local new_json
-	new_json=$(jq -n \
-		--arg updated "$now" \
-		--argjson bare "$count_bare" \
-		--argjson hardcoded "$count_hardcoded" \
-		--argjson broad "$count_broad" \
-		--argjson silent "$count_silent" \
-		--argjson missing "$count_missing" \
-		'{
-			version: 1,
-			updated: $updated,
-			description: "Ratchet baselines for code quality regression prevention. Counts can only stay the same or decrease — never increase. Run linters-local.sh --update-baseline to lock in improvements.",
-			ratchets: {
-				bare_positional_params: {
-					count: $bare,
-					description: "$1/$2 etc. used directly in function bodies (should use local var=\"$1\")",
-					pattern: "\\$[1-9]",
-					exclude: "local.*=.*\\$[1-9]"
-				},
-				hardcoded_aidevops_path: {
-					count: $hardcoded,
-					description: "Literal ~/.aidevops or /Users/ instead of \${HOME}/.aidevops or variable",
-					pattern: "~/.aidevops|/Users/"
-				},
-				broad_catch_or_true: {
-					count: $broad,
-					description: "|| true used to suppress errors without specific handling",
-					pattern: "\\|\\| true"
-				},
-				silent_errors: {
-					count: $silent,
-					description: "2>/dev/null used to silently discard errors without handling",
-					pattern: "2>/dev/null"
-				},
-				missing_return_files: {
-					count: $missing,
-					description: "Files containing functions without explicit return 0 or return 1",
-					pattern: "functions_without_return"
-				}
-			}
-		}') || {
-		print_error "Ratchets: failed to generate baseline JSON"
-		return 1
-	}
-
-	if [[ "${RATCHET_DRY_RUN:-false}" == "true" ]]; then
-		print_info "Ratchets: --dry-run mode, would write baseline:"
-		echo "$new_json" | jq '.ratchets | to_entries[] | "  \(.key): \(.value.count)"' -r
-		return 0
+	if [[ -n "$configured_ref" ]]; then
+		git -C "$repo_root" rev-parse --verify "${configured_ref}^{commit}" 2> /dev/null
+		return $?
 	fi
 
-	echo "$new_json" >"$baseline_file"
-	print_success "Ratchets: baseline updated in $baseline_file"
-	echo "$new_json" | jq '.ratchets | to_entries[] | "  \(.key): \(.value.count)"' -r
+	default_ref=$(git -C "$repo_root" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2> /dev/null || :)
+	for candidate in "$default_ref" origin/main main origin/master master; do
+		[[ -n "$candidate" ]] || continue
+		base_ref=$(git -C "$repo_root" merge-base HEAD "$candidate" 2> /dev/null || :)
+		if [[ -n "$base_ref" ]]; then
+			printf '%s\n' "$base_ref"
+			return 0
+		fi
+	done
+	return 1
+}
+
+# _ratchet_make_temp_dir: create an internal comparison directory.
+# Returns: directory path via stdout.
+_ratchet_make_temp_dir() {
+	local temp_parent="${AIDEVOPS_TEMP_DIR:-${TMPDIR:-/tmp}}"
+	local temp_dir=""
+	temp_dir=$(mktemp -d "${temp_parent%/}/ratchet-tree.XXXXXX") || return 1
+	printf '%s\n' "$temp_dir"
+	return 0
+}
+
+# _ratchet_count_ref: count all patterns in one verified Git commit.
+# Arguments: $1=repo_root $2=commit_ref
+# Returns: five space-separated counts via stdout.
+_ratchet_count_ref() {
+	local repo_root="$1"
+	local commit_ref="$2"
+	local temp_dir=""
+	local counts=""
+	temp_dir=$(_ratchet_make_temp_dir) || return 1
+
+	if ! git -C "$repo_root" archive "$commit_ref" -- .agents/scripts .gitignore | tar -x -C "$temp_dir"; then
+		print_error "Ratchets: failed to materialize base tree ${commit_ref}" >&2
+		rm -rf "$temp_dir"
+		return 1
+	fi
+	if ! counts=$(_ratchet_count_all "${temp_dir}/.agents/scripts"); then
+		rm -rf "$temp_dir"
+		return 1
+	fi
+	rm -rf "$temp_dir"
+	printf '%s\n' "$counts"
+	return 0
+}
+
+# _ratchet_counts_increased: detect whether any current count exceeds a snapshot.
+# Arguments: $1=current_counts $2=previous_counts
+# Returns: 0 when an increase exists, 1 otherwise.
+_ratchet_counts_increased() {
+	local current_counts="$1"
+	local previous_counts="$2"
+	local current_bare current_hardcoded current_broad current_silent current_missing
+	local previous_bare previous_hardcoded previous_broad previous_silent previous_missing
+	read -r current_bare current_hardcoded current_broad current_silent current_missing <<<"$current_counts"
+	read -r previous_bare previous_hardcoded previous_broad previous_silent previous_missing <<<"$previous_counts"
+	if ((current_bare > previous_bare || current_hardcoded > previous_hardcoded || current_broad > previous_broad || current_silent > previous_silent || current_missing > previous_missing)); then
+		return 0
+	fi
+	return 1
+}
+
+# _ratchet_verify_update_tree: ensure snapshot counts bind to committed scripts.
+# Arguments: $1=repo_root
+# Returns: 0 when the scripts tree is clean, 1 otherwise.
+_ratchet_verify_update_tree() {
+	local repo_root="$1"
+	local untracked=""
+	if ! git -C "$repo_root" diff --quiet -- .agents/scripts || ! git -C "$repo_root" diff --cached --quiet -- .agents/scripts; then
+		print_error "Ratchets: commit script changes before updating provenance"
+		return 1
+	fi
+	untracked=$(git -C "$repo_root" ls-files --others --exclude-standard -- .agents/scripts)
+	if [[ -n "$untracked" ]]; then
+		print_error "Ratchets: untracked script files prevent a verified snapshot"
+		return 1
+	fi
+	return 0
+}
+
+# _ratchet_build_baseline_json: render schema-v2 provenance and compatibility counts.
+# Arguments: $1=updated $2=source_commit $3=scripts_tree $4=base_commit
+#            $5=current_counts $6=previous_schema $7=previous_counter
+#            $8=previous_source $9=previous_updated $10=previous_counts
+#            $11=migration_json
+# Returns: JSON via stdout.
+_ratchet_build_baseline_json() {
+	local updated="$1" source_commit="$2" scripts_tree="$3" base_commit="$4" current_counts="$5"
+	local previous_schema="$6" previous_counter="$7" previous_source="$8" previous_updated="$9"
+	local previous_counts="${10}" migration_json="${11}"
+	jq -n \
+		--argjson schema "$RATCHET_SCHEMA_VERSION" --argjson counter "$RATCHET_COUNTER_VERSION" \
+		--arg updated "$updated" --arg source "$source_commit" --arg tree "$scripts_tree" --arg base "$base_commit" \
+		--arg current "$current_counts" --argjson previous_schema "$previous_schema" \
+		--argjson previous_counter "$previous_counter" --arg previous_source "$previous_source" \
+		--arg previous_updated "$previous_updated" --arg previous "$previous_counts" \
+		--argjson migration "$migration_json" '
+		($current | split(" ") | map(tonumber)) as $c |
+		($previous | split(" ") | map(tonumber)) as $p |
+		{
+			version: $schema,
+			counter_version: $counter,
+			updated: $updated,
+			description: "Compatibility snapshot with verified provenance; active checks compare the working tree with its default-branch merge-base.",
+			comparison: {mode: "merge-base", fail_closed_without_base: true},
+			provenance: {
+				source_commit: $source,
+				scripts_tree: $tree,
+				comparison_base_commit: $base,
+				migration: $migration,
+				previous_snapshot: {
+					schema_version: $previous_schema, counter_version: $previous_counter,
+					source_commit: $previous_source, updated: $previous_updated,
+					counts: {bare_positional_params: $p[0], hardcoded_aidevops_path: $p[1], broad_catch_or_true: $p[2], silent_errors: $p[3], missing_return_files: $p[4]}
+				}
+			},
+			ratchets: {
+				bare_positional_params: {count: $c[0], description: "Direct positional parameters in function bodies", pattern: "positional_parameter"},
+				hardcoded_aidevops_path: {count: $c[1], description: "Literal user-specific framework paths", pattern: "hardcoded_user_path"},
+				broad_catch_or_true: {count: $c[2], description: "Broad success fallback", pattern: "broad_success_fallback"},
+				silent_errors: {count: $c[3], description: "Discarded standard error", pattern: "discarded_standard_error"},
+				missing_return_files: {count: $c[4], description: "Files containing a function without an explicit return", pattern: "functions_without_return"}
+			}
+		}'
+	return $?
+}
+
+# _ratchet_write_json_atomically: validate and replace a baseline on one filesystem.
+# Arguments: $1=baseline_file $2=new_json
+# Returns: 0 on success, 1 without changing the baseline on failure.
+_ratchet_write_json_atomically() {
+	local baseline_file="$1"
+	local new_json="$2"
+	local temp_file=""
+	temp_file=$(mktemp "${baseline_file}.tmp.XXXXXX") || return 1
+	if ! printf '%s\n' "$new_json" >"$temp_file" || ! jq -e . "$temp_file" > /dev/null; then
+		rm -f "$temp_file"
+		print_error "Ratchets: generated baseline failed validation"
+		return 1
+	fi
+	if ! mv "$temp_file" "$baseline_file"; then
+		rm -f "$temp_file"
+		print_error "Ratchets: atomic baseline replacement failed"
+		return 1
+	fi
+	return 0
+}
+
+# _ratchet_write_baseline: validate and write (or dry-run) a provenance snapshot.
+# Arguments: $1=baseline_file $2=repo_root $3=current_counts
+# Returns: 0 on success, 1 when provenance or migration evidence is incomplete.
+_ratchet_write_baseline() {
+	local baseline_file="$1" repo_root="$2" current_counts="$3"
+	local previous_schema=0 previous_counter=1 previous_counts="0 0 0 0 0"
+	local previous_source="" previous_updated="" source_commit="" scripts_tree="" base_commit=""
+	local verified_counts="" migration_json="null" migration_reason="" new_json="" now=""
+
+	[[ -f "$baseline_file" ]] && previous_schema=$(jq -r '.version // 0' "$baseline_file" 2> /dev/null || printf '0')
+	[[ -f "$baseline_file" ]] && previous_counter=$(jq -r '.counter_version // 1' "$baseline_file" 2> /dev/null || printf '1')
+	[[ -f "$baseline_file" ]] && previous_counts=$(_ratchet_load_baselines "$baseline_file")
+	[[ -f "$baseline_file" ]] && previous_updated=$(jq -r '.updated // ""' "$baseline_file" 2> /dev/null || :)
+	[[ -f "$baseline_file" ]] && previous_source=$(jq -r '.provenance.source_commit // ""' "$baseline_file" 2> /dev/null || :)
+
+	_ratchet_verify_update_tree "$repo_root" || return 1
+	source_commit=$(git -C "$repo_root" rev-parse HEAD 2> /dev/null) || return 1
+	scripts_tree=$(git -C "$repo_root" rev-parse 'HEAD:.agents/scripts' 2> /dev/null) || return 1
+	base_commit=$(_ratchet_resolve_base_ref "$repo_root") || {
+		print_error "Ratchets: baseline update requires a verified default-branch base"
+		return 1
+	}
+	verified_counts=$(_ratchet_count_ref "$repo_root" "$source_commit") || return 1
+	if [[ "$verified_counts" != "$current_counts" ]]; then
+		print_error "Ratchets: working-tree counts do not match committed source ${source_commit}"
+		return 1
+	fi
+
+	if [[ "$previous_schema" -ne "$RATCHET_SCHEMA_VERSION" ]] || _ratchet_counts_increased "$current_counts" "$previous_counts"; then
+		if [[ "${RATCHET_ALLOW_MIGRATION:-false}" != "true" ]]; then
+			print_error "Ratchets: snapshot increases/schema migration require --migrate-baseline with recorded evidence"
+			return 1
+		fi
+		migration_reason="${RATCHET_MIGRATION_REASON:-}"
+		[[ -n "$migration_reason" ]] || {
+			print_error "Ratchets: RATCHET_MIGRATION_REASON is required for migration"
+			return 1
+		}
+		[[ -n "$previous_source" ]] || previous_source="${RATCHET_PREVIOUS_SOURCE_COMMIT:-}"
+		git -C "$repo_root" rev-parse --verify "${previous_source}^{commit}" > /dev/null 2>&1 || {
+			print_error "Ratchets: previous source commit is missing or unavailable"
+			return 1
+		}
+		migration_json=$(jq -n --arg reason "$migration_reason" --arg source "$previous_source" \
+			--argjson schema "$previous_schema" --argjson counter "$previous_counter" \
+			'{reason: $reason, previous_source_commit: $source, previous_schema_version: $schema, previous_counter_version: $counter}') || return 1
+	else
+		migration_json=$(jq -c '.provenance.migration // null' "$baseline_file") || return 1
+	fi
+
+	now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+	new_json=$(_ratchet_build_baseline_json "$now" "$source_commit" "$scripts_tree" "$base_commit" "$current_counts" \
+		"$previous_schema" "$previous_counter" "$previous_source" "$previous_updated" "$previous_counts" "$migration_json") || return 1
+	if [[ "${RATCHET_DRY_RUN:-false}" == "true" ]]; then
+		print_info "Ratchets: --dry-run mode, validated baseline follows:"
+		printf '%s\n' "$new_json" | jq -r '.ratchets | to_entries[] | "  \(.key): \(.value.count)"'
+		return 0
+	fi
+	_ratchet_write_json_atomically "$baseline_file" "$new_json" || return 1
+	print_success "Ratchets: baseline provenance updated in $baseline_file"
+	printf '%s\n' "$new_json" | jq -r '.ratchets | to_entries[] | "  \(.key): \(.value.count)"'
 	return 0
 }
 
@@ -338,11 +526,11 @@ _ratchet_write_baseline() {
 _ratchet_load_baselines() {
 	local baseline_file="$1"
 	local baseline_bare baseline_hardcoded baseline_broad baseline_silent baseline_missing
-	baseline_bare=$(jq -r '.ratchets.bare_positional_params.count // 0' "$baseline_file" 2>/dev/null) || baseline_bare=0
-	baseline_hardcoded=$(jq -r '.ratchets.hardcoded_aidevops_path.count // 0' "$baseline_file" 2>/dev/null) || baseline_hardcoded=0
-	baseline_broad=$(jq -r '.ratchets.broad_catch_or_true.count // 0' "$baseline_file" 2>/dev/null) || baseline_broad=0
-	baseline_silent=$(jq -r '.ratchets.silent_errors.count // 0' "$baseline_file" 2>/dev/null) || baseline_silent=0
-	baseline_missing=$(jq -r '.ratchets.missing_return_files.count // 0' "$baseline_file" 2>/dev/null) || baseline_missing=0
+	baseline_bare=$(jq -r '.ratchets.bare_positional_params.count // 0' "$baseline_file" 2> /dev/null) || baseline_bare=0
+	baseline_hardcoded=$(jq -r '.ratchets.hardcoded_aidevops_path.count // 0' "$baseline_file" 2> /dev/null) || baseline_hardcoded=0
+	baseline_broad=$(jq -r '.ratchets.broad_catch_or_true.count // 0' "$baseline_file" 2> /dev/null) || baseline_broad=0
+	baseline_silent=$(jq -r '.ratchets.silent_errors.count // 0' "$baseline_file" 2> /dev/null) || baseline_silent=0
+	baseline_missing=$(jq -r '.ratchets.missing_return_files.count // 0' "$baseline_file" 2> /dev/null) || baseline_missing=0
 	echo "$baseline_bare $baseline_hardcoded $baseline_broad $baseline_silent $baseline_missing"
 	return 0
 }
@@ -387,11 +575,25 @@ _ratchet_run_checks() {
 	fi
 
 	if [[ "$strict_mode" == "true" ]]; then
-		print_error "Ratchets: ${ratchet_failures} pattern(s) regressed — fix violations or run --update-baseline to accept"
+		print_error "Ratchets: ${ratchet_failures} pattern(s) regressed against the verified merge-base"
 		return 1
 	fi
 
-	print_warning "Ratchets: ${ratchet_failures} pattern(s) regressed (advisory — use --strict to block, --update-baseline to accept)"
+	print_warning "Ratchets: ${ratchet_failures} pattern(s) regressed against the verified merge-base (advisory — use --strict to block)"
+	return 0
+}
+
+# _ratchet_validate_baseline_config: require the active schema and counter version.
+# Arguments: $1=baseline_file
+# Returns: 0 when compatible, 1 with an actionable diagnostic otherwise.
+_ratchet_validate_baseline_config() {
+	local baseline_file="$1"
+	if ! jq -e --argjson schema "$RATCHET_SCHEMA_VERSION" --argjson counter "$RATCHET_COUNTER_VERSION" \
+		'.version == $schema and .counter_version == $counter and .comparison.mode == "merge-base" and (.provenance.source_commit | type == "string")' \
+		"$baseline_file" > /dev/null 2>&1; then
+		print_error "Ratchets: baseline schema/counter mismatch; run the explicit migration workflow"
+		return 1
+	fi
 	return 0
 }
 
@@ -401,12 +603,15 @@ _ratchet_run_checks() {
 check_ratchets() {
 	echo -e "${BLUE}Checking Ratchet Quality Gates (t1878)...${NC}"
 
-	local scripts_dir
-	scripts_dir="$(git rev-parse --show-toplevel 2>/dev/null)/.agents/scripts" || scripts_dir=".agents/scripts"
-	local baseline_file
-	baseline_file="$(git rev-parse --show-toplevel 2>/dev/null)/.agents/configs/ratchets.json" || baseline_file=".agents/configs/ratchets.json"
-	local exceptions_dir
-	exceptions_dir="$(git rev-parse --show-toplevel 2>/dev/null)/.agents/configs/ratchet-exceptions" || exceptions_dir=".agents/configs/ratchet-exceptions"
+	local repo_root="" scripts_dir="" baseline_file="" exceptions_dir=""
+	local strict_mode="${RATCHET_STRICT:-false}"
+	repo_root=$(git rev-parse --show-toplevel 2> /dev/null) || {
+		print_error "Ratchets: repository root unavailable"
+		return 1
+	}
+	scripts_dir="${repo_root}/.agents/scripts"
+	baseline_file="${repo_root}/.agents/configs/ratchets.json"
+	exceptions_dir="${repo_root}/.agents/configs/ratchet-exceptions"
 
 	if ! command -v rg &>/dev/null; then
 		print_warning "Ratchets: rg (ripgrep) not installed — skipping (install: brew install ripgrep)"
@@ -428,26 +633,40 @@ check_ratchets() {
 
 	# --update-baseline / --init-baseline: write new baseline and exit
 	if [[ "${RATCHET_UPDATE_BASELINE:-false}" == "true" ]]; then
-		_ratchet_write_baseline "$baseline_file" "$count_bare" "$count_hardcoded" "$count_broad" "$count_silent" "$count_missing"
+		_ratchet_write_baseline "$baseline_file" "$repo_root" "$counts"
 		return $?
 	fi
 
-	# Check baseline file exists
 	if [[ ! -f "$baseline_file" ]]; then
-		print_warning "Ratchets: no baseline found at $baseline_file — run --init-baseline to create"
+		if [[ "$strict_mode" == "true" ]]; then
+			print_error "Ratchets: no provenance config found at $baseline_file"
+			return 1
+		fi
+		print_warning "Ratchets: no provenance config found at $baseline_file"
 		return 0
 	fi
+	_ratchet_validate_baseline_config "$baseline_file" || return 1
 
-	# Load baselines and exceptions
-	local baselines exceptions
+	local base_ref="" base_counts="" exceptions=""
 	local baseline_bare baseline_hardcoded baseline_broad baseline_silent baseline_missing
 	local exc_bare exc_hardcoded exc_broad exc_silent exc_missing
-	baselines=$(_ratchet_load_baselines "$baseline_file")
+	base_ref=$(_ratchet_resolve_base_ref "$repo_root") || {
+		if [[ "$strict_mode" == "true" ]]; then
+			print_error "Ratchets: default-branch merge-base unavailable; strict comparison is incomplete"
+			return 1
+		fi
+		print_warning "Ratchets: default-branch merge-base unavailable; advisory comparison skipped"
+		return 0
+	}
+	print_info "Ratchets: comparing working tree with ${base_ref} (counter v${RATCHET_COUNTER_VERSION})"
+	base_counts=$(_ratchet_count_ref "$repo_root" "$base_ref") || {
+		print_error "Ratchets: failed to count the verified base tree"
+		return 1
+	}
 	exceptions=$(_ratchet_load_all_exceptions "$exceptions_dir")
-	read -r baseline_bare baseline_hardcoded baseline_broad baseline_silent baseline_missing <<<"$baselines"
+	read -r baseline_bare baseline_hardcoded baseline_broad baseline_silent baseline_missing <<<"$base_counts"
 	read -r exc_bare exc_hardcoded exc_broad exc_silent exc_missing <<<"$exceptions"
 
-	local strict_mode="${RATCHET_STRICT:-false}"
 	_ratchet_run_checks "$strict_mode" \
 		"$count_bare" "$count_hardcoded" "$count_broad" "$count_silent" "$count_missing" \
 		"$baseline_bare" "$baseline_hardcoded" "$baseline_broad" "$baseline_silent" "$baseline_missing" \

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -36,8 +36,9 @@
 #   --full              Release-boundary path: run every gate without cache/time-budget downgrade
 #   --strict            Make ratchet failures and broad-gate timeouts blocking
 # Ratchet flags:
-#   --update-baseline   Re-count all patterns and write new ratchets.json baseline
+#   --update-baseline   Record only same/lower committed compatibility counts
 #   --init-baseline     Same as --update-baseline (alias for first-time setup)
+#   --migrate-baseline  Explicit schema/count migration; requires evidence env vars
 #   --strict            Make ratchet failures blocking (default: advisory)
 #   --changed           Fast PR mode: run changed-file safety gates only
 #   --fast-pr           Alias for --changed
@@ -185,6 +186,10 @@ _linters_local_parse_args() {
 			;;
 		--update-baseline | --init-baseline)
 			export RATCHET_UPDATE_BASELINE=true
+			;;
+		--migrate-baseline)
+			export RATCHET_UPDATE_BASELINE=true
+			export RATCHET_ALLOW_MIGRATION=true
 			;;
 		--strict)
 			export RATCHET_STRICT=true

--- a/.agents/scripts/tests/test-linters-local-ratchet-timeout.sh
+++ b/.agents/scripts/tests/test-linters-local-ratchet-timeout.sh
@@ -85,15 +85,84 @@ test_missing_return_counter_scans_inventory_once() {
 	source_ratchet_helpers
 	local tmp_dir count
 	tmp_dir=$(mktemp -d)
-	printf 'one() {\n\treturn 0\n}\ntwo() {\n\t:\n}\n' >"${tmp_dir}/missing.sh"
+	printf 'one() {\n\tif true; then\n\t\treturn 0\n\tfi\n\treturn 1\n}\ntwo() {\n\t:\n}\n' >"${tmp_dir}/missing.sh"
 	printf 'complete() {\n\treturn 0\n}\n' >"${tmp_dir}/complete.sh"
-	ALL_SH_FILES=("${tmp_dir}/missing.sh" "${tmp_dir}/complete.sh")
-	count=$(_ratchet_count_missing_return)
+	count=$(_ratchet_count_missing_return "$tmp_dir")
 	if [[ "$count" -eq 1 ]]; then
-		print_result "ratchet missing-return counter preserves per-file semantics" 0
+		print_result "ratchet missing-return counter cannot be masked by extra returns" 0
 	else
-		print_result "ratchet missing-return counter preserves per-file semantics" 1 "count=$count"
+		print_result "ratchet missing-return counter cannot be masked by extra returns" 1 "count=$count"
 	fi
+	rm -rf "$tmp_dir"
+	return 0
+}
+
+write_clean_ratchet_fixture() {
+	local target_dir="$1"
+	mkdir -p "$target_dir"
+	printf 'complete() {\n\treturn 0\n}\n' >"${target_dir}/fixture.sh"
+	return 0
+}
+
+write_regressed_ratchet_fixture() {
+	local pattern_name="$1"
+	local target_dir="$2"
+	mkdir -p "$target_dir"
+	case "$pattern_name" in
+	bare_positional_params)
+		printf 'uses_arg() {\n\tprintf "%%s\\n" "%s%s"\n\treturn 0\n}\n' '$' '1' >"${target_dir}/fixture.sh"
+		;;
+	hardcoded_aidevops_path)
+		# shellcheck disable=SC2088  # Fixture needs a literal tilde path.
+		printf 'path=%s%s\n' '~/' '.aidevops' >"${target_dir}/fixture.sh"
+		;;
+	broad_catch_or_true)
+		printf 'false %s%s\n' '||' ' true' >"${target_dir}/fixture.sh"
+		;;
+	silent_errors)
+		printf 'false %s%s\n' '2>' '/dev/null' >"${target_dir}/fixture.sh"
+		;;
+	missing_return_files)
+		printf 'complete() {\n\treturn 0\n}\nincomplete() {\n\t:\n}\n' >"${target_dir}/fixture.sh"
+		;;
+	esac
+	return 0
+}
+
+ratchet_fixture_count() {
+	local pattern_name="$1"
+	local target_dir="$2"
+	case "$pattern_name" in
+	bare_positional_params) _ratchet_count_bare_positional "$target_dir" ;;
+	hardcoded_aidevops_path) _ratchet_count_hardcoded_path "$target_dir" ;;
+	broad_catch_or_true) _ratchet_count_broad_catch "$target_dir" ;;
+	silent_errors) _ratchet_count_silent_errors "$target_dir" ;;
+	missing_return_files) _ratchet_count_missing_return "$target_dir" ;;
+	esac
+	return $?
+}
+
+test_each_ratchet_blocks_regression_and_allows_improvement() {
+	source_ratchet_helpers
+	local tmp_dir pattern_name clean_count regressed_count regression_rc improvement_rc
+	local patterns=(bare_positional_params hardcoded_aidevops_path broad_catch_or_true silent_errors missing_return_files)
+	tmp_dir=$(mktemp -d)
+	for pattern_name in "${patterns[@]}"; do
+		write_clean_ratchet_fixture "${tmp_dir}/${pattern_name}/clean"
+		write_regressed_ratchet_fixture "$pattern_name" "${tmp_dir}/${pattern_name}/regressed"
+		clean_count=$(ratchet_fixture_count "$pattern_name" "${tmp_dir}/${pattern_name}/clean")
+		regressed_count=$(ratchet_fixture_count "$pattern_name" "${tmp_dir}/${pattern_name}/regressed")
+		regression_rc=0
+		improvement_rc=0
+		_ratchet_check_pattern "$pattern_name" "$regressed_count" "$clean_count" 0 true > /dev/null 2>&1 || regression_rc=$?
+		_ratchet_check_pattern "$pattern_name" "$clean_count" "$regressed_count" 0 true > /dev/null 2>&1 || improvement_rc=$?
+		if [[ "$clean_count" -eq 0 && "$regressed_count" -eq 1 && "$regression_rc" -eq 1 && "$improvement_rc" -eq 0 ]]; then
+			print_result "ratchet delta: ${pattern_name} blocks +1 and permits -1" 0
+		else
+			print_result "ratchet delta: ${pattern_name} blocks +1 and permits -1" 1 \
+				"clean=$clean_count regressed=$regressed_count regression_rc=$regression_rc improvement_rc=$improvement_rc"
+		fi
+	done
 	rm -rf "$tmp_dir"
 	return 0
 }
@@ -102,6 +171,7 @@ main() {
 	test_ratchet_counter_times_out_with_diagnostic
 	test_ratchet_counter_reports_progress_and_value
 	test_missing_return_counter_scans_inventory_once
+	test_each_ratchet_blocks_regression_and_allows_improvement
 
 	echo ""
 	if [ "$TESTS_FAILED" -eq 0 ]; then


### PR DESCRIPTION
## Summary

Compare all five broad anti-pattern counters against a verified default-branch merge-base and require explicit provenance for compatibility-snapshot migrations.

## Files Changed

.agents/scripts/linters-local-ratchet.sh, .agents/scripts/linters-local.sh, .agents/scripts/tests/test-linters-local-ratchet-timeout.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Runtime-verified focused ratchet fixtures, changed-mode orchestration, pre-commit ratchets, Bash syntax, and ShellCheck pass; broad verification remains in progress on this draft.

Resolves #29405


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.218 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 28m and 253,982 tokens on this as a headless worker.