### PR TITLE
GH#29387: Version and inventory recoverable worktree archives

### DIFF
--- a/.agents/reference/storage-lifecycle.md
+++ b/.agents/reference/storage-lifecycle.md
@@ -64,7 +64,7 @@ Reference, lease, recovery, and audit checks remain hard vetoes.
 | `~/.aidevops/.agent-workspace/observability` | framework | audit, archive, cache | Part streams and tool metadata are bounded at ingestion; runtime events use a 30-day active candidate window, verified immutable archive partitions, compacted low-value summaries, pinned recovery state, and append-only manifests | Measure defaults across routine/high-activity installations before changing the active window or adding any archive deletion policy |
 | `~/.aidevops/agents-backups` | framework | rollback, archive | Setup computes a dry-run plan under 10-snapshot, 180-day, and 4 GiB soft limits; the newest snapshot is always protected | Tune defaults from broader measurements without weakening rollback or attribution checks |
 | `~/.aidevops/logs/worker-failure-excerpts` | framework | recovery, archive | Excerpts are capped at 64 KiB; each session retains its newest evidence while older duplicates converge under 3-excerpt, 30-day, and 192 KiB soft limits | Add terminal issue/PR awareness before reclaiming the newest evidence for any session |
-| `~/.aidevops/recovery/worktrees` (Linux and non-macOS) | framework | recovery, unknown | Archive-first removal copies worktree and Git administrative state into an attributable bucket; `worktree-helper.sh recovery` reports current and legacy buckets without deleting them | Keep all buckets protected for manual review until a producer-specific restore and retention policy can prove them reclaimable |
+| `~/.aidevops/recovery/worktrees` (Linux and non-macOS) | framework | recovery, unknown | Archive-first removal copies worktree and Git administrative state into an attributable bucket; `worktree-helper.sh recovery` and shared storage status report current/legacy count and bytes without deleting them | Keep all buckets protected with zero reclaimable bytes until an exact producer-specific plan proves them reclaimable |
 | Pulse active logs and `~/.aidevops/logs/pulse-archive` | framework | active, archive | Pulse preserves active descriptors while gzip-rotating 50 MiB hot/wrapper logs and 1 MiB timing logs; cold archives converge under 1 GiB | Keep rotation producer-owned and never replace it with generic unlink-by-age cleanup |
 | OpenCode data under its application-data root | joint | active, recovery, archive, unknown | OpenCode owns session and DB formats; aidevops archive/maintenance helpers coordinate selected operations | Separate logical retention from WAL/fragmentation maintenance; report only classifications proven through OpenCode-aware queries |
 | npm and other package-manager caches | external | cache | Package manager owns lifecycle | Context-only reporting; no aidevops aggregate deletion |
@@ -83,18 +83,34 @@ not silently delete these recovery snapshots. Operators can continue to select
 an absolute root with `AIDEVOPS_WORKTREE_TRASH_ROOT` (or the legacy
 `AIDEVOPS_ORPHAN_TRASH_ROOT` fallback).
 
-Each new bucket records `framework` ownership, the `recovery` safety class, and
-a `manual-review` policy beside its Git recovery identity. A completion marker
-is written only after archive integrity and source identity validation. Run
-`worktree-helper.sh recovery` for a read-only inventory. On non-macOS systems it
-also reports attributable legacy `$HOME/.Trash/aidevops-worktree-cleanup-*`
-buckets. The command reports framework-owned default roots separately from
-joint OS Trash or operator-selected roots. Incomplete, symlinked, or
-unrecognised buckets are `unknown`; the inventory never migrates or deletes
-them. Markerless v1 buckets are attributed only when the original archive
-integrity validator still proves their Git recovery structure. Existing archive
-integrity, lock, identity, late-write, detached-HEAD, and interruption checks
-remain authoritative.
+New buckets use the additive `aidevops-worktree-recovery-v2` evidence contract.
+Alongside stable Git identity, each records creation time, producer/context,
+optional runtime session identity, archive completion, source-removal outcome,
+`framework` ownership, the `recovery` safety class, and a `manual-review`
+policy. The completion marker is written only after archive integrity and source
+identity validation; successful native removal then atomically advances the
+source outcome from `pending` to `removed`.
+
+Readers remain compatible with complete v1 buckets from the platform-storage
+transition and markerless legacy v1 buckets whose original Git recovery
+structure still validates. Partial v2 evidence is never reinterpreted as v1.
+Older readers reject v2 and therefore fail closed without damaging an archive.
+
+Run `worktree-helper.sh recovery` for a read-only count/byte report with
+protected/unknown reasons. The same producer summary appears as one
+`worktree-recovery` record in shared storage status; `reclaimable_bytes` remains
+zero in this phase. On non-macOS systems, inventory also includes attributable
+legacy `$HOME/.Trash/aidevops-worktree-cleanup-*` buckets. Framework-owned
+default roots remain distinct from joint OS Trash or operator-selected roots.
+Incomplete, symlinked, unrecognised, or unsized buckets are `unknown`; inventory
+never migrates, rewrites, or deletes them.
+
+An originating OpenCode or Claude session identifier is recovery guidance, not
+deletion proof. Session history can reconstruct text edits and intent but may be
+archived, unavailable, or incomplete and does not prove preservation of ignored
+or binary files, permissions, symlinks, index state, or detached Git metadata.
+Existing archive integrity, lock, identity, late-write, detached-HEAD, and
+interruption checks remain authoritative.
 
 ### Runtime Bundle Retention Overrides
 

--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -55,7 +55,9 @@ _WTAR_SKIPPED="skipped"
 _WTAR_FIXTURE_REMOVED="fixture-removed"
 _WTAR_MODE_SKIPPED="skipped"
 _WTAR_BOOL_TRUE="true"
-_WT_CWD_VISIBILITY_COMPLETE="complete"
+_WT_STATE_COMPLETE="complete"
+_WT_STATE_UNAVAILABLE="unavailable"
+_WT_CWD_VISIBILITY_COMPLETE="$_WT_STATE_COMPLETE"
 _WT_CWD_VISIBILITY_DEGRADED="degraded"
 _WT_CWD_VISIBILITY_UNUSABLE="unusable"
 _WT_CWD_CAPTURE_DEGRADED_RC=2
@@ -71,12 +73,16 @@ _WT_GIT_REASON_UNREADABLE="git-metadata-unreadable"
 _WT_GIT_REASON_IDENTITY_CHANGED="git-worktree-identity-changed"
 _WT_GIT_REASON_REMOVE_FAILED="git-worktree-remove-failed"
 _WT_GIT_STATUS_FIELD_PREFIX="aidevops-git-status "
-_WT_RECOVERY_FORMAT="aidevops-worktree-recovery-v1"
+_WT_RECOVERY_FORMAT_V1="aidevops-worktree-recovery-v1"
+_WT_RECOVERY_FORMAT_V2="aidevops-worktree-recovery-v2"
+_WT_RECOVERY_FORMAT="$_WT_RECOVERY_FORMAT_V2"
 _WT_RECOVERY_DIR_NAME=".aidevops-worktree-recovery"
 _WT_RECOVERY_COMPLETE_MARKER="archive-complete"
 _WT_RECOVERY_STORAGE_OWNER="framework"
-_WT_RECOVERY_ROOT_UNAVAILABLE="unavailable"
+_WT_RECOVERY_ROOT_UNAVAILABLE="$_WT_STATE_UNAVAILABLE"
 _WT_RECOVERY_BRANCH_DETACHED="detached"
+_WT_RECOVERY_OUTCOME_PENDING="pending"
+_WT_RECOVERY_OUTCOME_REMOVED="removed"
 WORKTREE_RECOVERABLE_ARCHIVE_PATH=""
 
 _WT_ID_REAL_GIT=""
@@ -616,6 +622,95 @@ _worktree_recovery_dir_for_archive() {
 	return 0
 }
 
+_worktree_recovery_format_is_supported() {
+	local format="$1"
+	case "$format" in
+	"$_WT_RECOVERY_FORMAT_V1" | "$_WT_RECOVERY_FORMAT_V2") return 0 ;;
+	esac
+	return 1
+}
+
+_worktree_recovery_line_payload_is_valid() {
+	local payload="$1"
+	[[ -n "$payload" ]] || return 1
+	case "$payload" in
+	*$'\n'* | *$'\r'*) return 1 ;;
+	esac
+	return 0
+}
+
+_worktree_recovery_v2_contract_is_valid() {
+	local recovery_dir="$1"
+	local created_at=""
+	local producer=""
+	local producer_context=""
+	local session_id=""
+	local archive_outcome=""
+	local source_outcome=""
+	local metadata_name=""
+
+	for metadata_name in created-at producer producer-context session-id archive-outcome source-removal-outcome; do
+		[[ -f "$recovery_dir/$metadata_name" && ! -L "$recovery_dir/$metadata_name" ]] || return 1
+	done
+	IFS= read -r created_at <"$recovery_dir/created-at" || return 1
+	IFS= read -r producer <"$recovery_dir/producer" || return 1
+	IFS= read -r producer_context <"$recovery_dir/producer-context" || return 1
+	IFS= read -r session_id <"$recovery_dir/session-id" || return 1
+	IFS= read -r archive_outcome <"$recovery_dir/archive-outcome" || return 1
+	IFS= read -r source_outcome <"$recovery_dir/source-removal-outcome" || return 1
+	[[ "$created_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || return 1
+	_worktree_recovery_line_payload_is_valid "$producer" || return 1
+	_worktree_recovery_line_payload_is_valid "$producer_context" || return 1
+	[[ "$session_id" == "$_WT_STATE_UNAVAILABLE" || "$session_id" =~ ^[A-Za-z0-9._:-]+$ ]] || return 1
+	[[ "$archive_outcome" == "$_WT_STATE_COMPLETE" ]] || return 1
+	case "$source_outcome" in
+	"$_WT_RECOVERY_OUTCOME_PENDING" | "$_WT_RECOVERY_OUTCOME_REMOVED") return 0 ;;
+	esac
+	return 1
+}
+
+_worktree_write_recovery_v2_metadata() {
+	local recovery_dir="$1"
+	local caller="$2"
+	local context="${3:-unspecified}"
+	local created_at=""
+	local session_id="${AIDEVOPS_SESSION_ID:-${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-unavailable}}}"
+
+	[[ -n "$context" ]] || context="unspecified"
+	created_at=$(date -u +%Y-%m-%dT%H:%M:%SZ) || return 1
+	_worktree_recovery_line_payload_is_valid "$caller" || return 1
+	_worktree_recovery_line_payload_is_valid "$context" || return 1
+	[[ "$session_id" == "$_WT_STATE_UNAVAILABLE" || "$session_id" =~ ^[A-Za-z0-9._:-]+$ ]] || session_id="$_WT_STATE_UNAVAILABLE"
+	printf '%s\n' "$created_at" >"${recovery_dir}/created-at" || return 1
+	printf '%s\n' "$caller" >"${recovery_dir}/producer" || return 1
+	printf '%s\n' "$context" >"${recovery_dir}/producer-context" || return 1
+	printf '%s\n' "$session_id" >"${recovery_dir}/session-id" || return 1
+	printf '%s\n' "$_WT_STATE_COMPLETE" >"${recovery_dir}/archive-outcome" || return 1
+	printf '%s\n' "$_WT_RECOVERY_OUTCOME_PENDING" >"${recovery_dir}/source-removal-outcome" || return 1
+	return 0
+}
+
+_worktree_recovery_record_source_outcome() {
+	local archive_path="$1"
+	local outcome="$2"
+	local recovery_dir=""
+	local format=""
+	local outcome_tmp=""
+
+	case "$outcome" in
+	"$_WT_RECOVERY_OUTCOME_PENDING" | "$_WT_RECOVERY_OUTCOME_REMOVED") ;;
+	*) return 1 ;;
+	esac
+	recovery_dir=$(_worktree_recovery_dir_for_archive "$archive_path") || return 1
+	IFS= read -r format <"$recovery_dir/format" || return 1
+	[[ "$format" == "$_WT_RECOVERY_FORMAT_V2" ]] || return 0
+	outcome_tmp="${recovery_dir}/.source-removal-outcome.$$-${RANDOM}"
+	printf '%s\n' "$outcome" >"$outcome_tmp" || return 1
+	mv "$outcome_tmp" "$recovery_dir/source-removal-outcome" || return 1
+	_worktree_recovery_v2_contract_is_valid "$recovery_dir" || return 1
+	return 0
+}
+
 _worktree_write_recovery_identity() {
 	local recovery_dir="$1"
 
@@ -649,7 +744,10 @@ _worktree_recovery_archive_is_valid() {
 	IFS= read -r format <"${recovery_dir}/format" || return 1
 	IFS= read -r expected_head <"${recovery_dir}/head" || return 1
 	IFS= read -r expected_branch <"${recovery_dir}/branch" || return 1
-	[[ "$format" == "$_WT_RECOVERY_FORMAT" ]] || return 1
+	_worktree_recovery_format_is_supported "$format" || return 1
+	if [[ "$format" == "$_WT_RECOVERY_FORMAT_V2" ]]; then
+		_worktree_recovery_v2_contract_is_valid "$recovery_dir" || return 1
+	fi
 	_worktree_git_head_payload_is_valid "$expected_head" || return 1
 	if [[ "$expected_branch" != "$_WT_RECOVERY_BRANCH_DETACHED" ]]; then
 		_worktree_git_branch_payload_is_valid "$expected_branch" || return 1
@@ -749,12 +847,13 @@ _worktree_legacy_recovery_bucket_is_valid() {
 	return 0
 }
 
-_worktree_recovery_v2_metadata_is_present() {
+_worktree_recovery_extended_metadata_is_present() {
 	local bucket="$1"
 	local recovery_dir="${bucket}/${_WT_RECOVERY_DIR_NAME}"
 	local metadata_name=""
 
-	for metadata_name in "$_WT_RECOVERY_COMPLETE_MARKER" storage-owner storage-class storage-policy storage-root; do
+	for metadata_name in "$_WT_RECOVERY_COMPLETE_MARKER" storage-owner storage-class storage-policy storage-root \
+		created-at producer producer-context session-id archive-outcome source-removal-outcome; do
 		if [[ -e "$recovery_dir/$metadata_name" || -L "$recovery_dir/$metadata_name" ]]; then
 			return 0
 		fi
@@ -819,8 +918,8 @@ _worktree_recovery_inventory_root() {
 			IFS= read -r format <"$bucket/${_WT_RECOVERY_DIR_NAME}/format" || format=""
 			IFS= read -r completion < \
 				"$bucket/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" || completion=""
-			if [[ "$format" == "$_WT_RECOVERY_FORMAT" &&
-				"$completion" == "$_WT_RECOVERY_FORMAT" ]] &&
+			if _worktree_recovery_format_is_supported "$format" &&
+				[[ "$completion" == "$format" ]] &&
 				_worktree_recovery_storage_contract_is_valid "$bucket" "$root_real" &&
 				_worktree_legacy_recovery_bucket_is_valid "$bucket"; then
 				state="attributed"
@@ -829,8 +928,8 @@ _worktree_recovery_inventory_root() {
 			-f "$bucket/${_WT_RECOVERY_DIR_NAME}/format" &&
 			! -L "$bucket/${_WT_RECOVERY_DIR_NAME}/format" ]]; then
 			IFS= read -r format <"$bucket/${_WT_RECOVERY_DIR_NAME}/format" || format=""
-			if [[ "$format" == "$_WT_RECOVERY_FORMAT" ]] &&
-				! _worktree_recovery_v2_metadata_is_present "$bucket" &&
+			if [[ "$format" == "$_WT_RECOVERY_FORMAT_V1" ]] &&
+				! _worktree_recovery_extended_metadata_is_present "$bucket" &&
 				_worktree_legacy_recovery_bucket_is_valid "$bucket"; then
 				state="attributed-legacy"
 			fi
@@ -919,6 +1018,7 @@ archive_worktree_path_recoverably() {
 	mkdir "$recovery_dir" 2>/dev/null || return 1
 	_worktree_copy_directory_once "$_WT_ID_ADMIN_REAL" "$recovery_admin" || return 1
 	_worktree_write_recovery_identity "$recovery_dir" || return 1
+	_worktree_write_recovery_v2_metadata "$recovery_dir" "$caller" "$context" || return 1
 	printf '%s\n' "$_WT_RECOVERY_STORAGE_OWNER" >"${recovery_dir}/storage-owner" || return 1
 	printf '%s\n' "recovery" >"${recovery_dir}/storage-class" || return 1
 	printf '%s\n' "manual-review" >"${recovery_dir}/storage-policy" || return 1
@@ -1174,6 +1274,8 @@ remove_archived_worktree_path() {
 		[[ "$allow_degraded" == "$_WTAR_BOOL_TRUE" && "$guard_status" -eq "$_WT_CWD_CAPTURE_DEGRADED_RC" ]] || return 1
 	fi
 	_worktree_remove_with_native_git "$wt_path" "$caller" "$context" "$force_remove" "$archive_path" || return 1
+	_worktree_recovery_archive_is_valid "$archive_path" || return 1
+	_worktree_recovery_record_source_outcome "$archive_path" "$_WT_RECOVERY_OUTCOME_REMOVED" || return 1
 	_worktree_recovery_archive_is_valid "$archive_path" || return 1
 	return 0
 }

--- a/.agents/scripts/storage-inventory-helper.sh
+++ b/.agents/scripts/storage-inventory-helper.sh
@@ -25,6 +25,10 @@ if [[ -f "$SCRIPT_DIR/opencode-db-safety-lib.sh" ]]; then
 	source "$SCRIPT_DIR/opencode-db-safety-lib.sh"
 	OPENCODE_STORAGE_PROBES_AVAILABLE=1
 fi
+if [[ -f "$SCRIPT_DIR/worktree-recovery-lifecycle-helper.sh" ]]; then
+	# shellcheck source=worktree-recovery-lifecycle-helper.sh
+	source "$SCRIPT_DIR/worktree-recovery-lifecycle-helper.sh"
+fi
 
 STORAGE_SCHEMA_VERSION=2
 STORAGE_SIZE_TIMEOUT_TENTHS="${AIDEVOPS_STORAGE_SIZE_TIMEOUT_TENTHS:-20}"
@@ -676,6 +680,36 @@ _storage_observability_record() {
 	return 0
 }
 
+_storage_worktree_recovery_record() {
+	local report=""
+	local home_label="~"
+	local display_path="${home_label}/.aidevops/recovery/worktrees and attributable legacy roots"
+
+	if ! declare -F worktree_recovery_lifecycle_json >/dev/null 2>&1; then
+		_storage_emit_measured_record "worktree-recovery" "worktree-helper" "$display_path" \
+			"$STORAGE_UNKNOWN" "recovery" "manual-review; no deletion authority" "$STORAGE_UNKNOWN" \
+			"producer inventory helper is unavailable" "Restore the deployed worktree recovery helper; leave archives untouched" \
+			"${STORAGE_JSON_NULL}|unavailable|classification-unavailable"
+		return 0
+	fi
+	report=$(worktree_recovery_lifecycle_json 2>/dev/null || true)
+	if [[ -z "$report" ]] || ! printf '%s\n' "$report" | jq -e '
+		type == "object" and .schema == "aidevops.worktree-recovery-inventory/v1" and
+		(.reclaimable_bytes == 0) and
+		((.total_bytes == null and .protected_bytes == null and .unknown_bytes == null) or
+		 (.total_bytes >= 0 and .protected_bytes >= 0 and .unknown_bytes >= 0 and
+		  .total_bytes == (.protected_bytes + .reclaimable_bytes + .unknown_bytes)))
+	' >/dev/null 2>&1; then
+		_storage_emit_measured_record "worktree-recovery" "worktree-helper" "$display_path" \
+			"$STORAGE_UNKNOWN" "recovery" "manual-review; no deletion authority" "$STORAGE_UNKNOWN" \
+			"producer inventory output is unavailable or invalid" "Run worktree-helper.sh recovery; leave archives untouched" \
+			"${STORAGE_JSON_NULL}|unavailable|classification-unavailable"
+		return 0
+	fi
+	printf '%s\n' "$report" | jq -c 'del(.schema, .buckets)'
+	return 0
+}
+
 _storage_inventory_records() {
 	local home_label="~"
 	local framework_owner="$STORAGE_OWNER_FRAMEWORK"
@@ -685,6 +719,7 @@ _storage_inventory_records() {
 	local pulse_producer="$STORAGE_PRODUCER_PULSE"
 	_storage_emit_runtime_bundle_record
 	_storage_observability_record
+	_storage_worktree_recovery_record
 	_storage_emit_retention_record "agent-backups" "setup-backup" "${home_label}/.aidevops/agents-backups" "${HOME:+$HOME/.aidevops/agents-backups}" "$STORAGE_SAFETY_MIXED" "10 snapshots, 180 days, and 4 GiB soft limits" "newest verified rollback and retention trash" "Setup computes a dry run before confirmed producer-owned rotation" "_backup_retention_plan"
 	_storage_emit_retention_record "worker-failure-excerpts" "headless-runtime" "${home_label}/.aidevops/logs/worker-failure-excerpts" "${HOME:+$HOME/.aidevops/logs/worker-failure-excerpts}" "$STORAGE_SAFETY_MIXED" "64 KiB per excerpt; 3 excerpts, 30 days, and 192 KiB per session soft limits" "newest unresolved recovery evidence per session" "Headless runtime computes a dry run after each preserved failure" "_storage_worker_excerpt_plan"
 	_storage_emit_record "pulse-hot-log" "$pulse_producer" "${home_label}/.aidevops/logs/pulse.log" "${HOME:+$HOME/.aidevops/logs/pulse.log}" "$framework_owner" "$active_class" "50 MiB active-file cap with gzip archive rotation" "$protected_disposition" "$active_writer_reason" "Use pulse-owned rotate_pulse_log; never unlink the active file"

--- a/.agents/scripts/tests/test-storage-inventory-helper.sh
+++ b/.agents/scripts/tests/test-storage-inventory-helper.sh
@@ -6,9 +6,15 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HELPER="$SCRIPT_DIR/../storage-inventory-helper.sh"
+AUDIT_HELPER="$SCRIPT_DIR/../audit-worktree-removal-helper.sh"
+GIT_BIN="${AIDEVOPS_TEST_GIT_BIN:-/usr/bin/git}"
 TEST_ROOT="$(mktemp -d -t aidevops-storage-inventory.XXXXXX)"
 HOME="$TEST_ROOT/home"
 export HOME
+AIDEVOPS_WORKTREE_TRASH_ROOT="$HOME/.aidevops/recovery/worktrees"
+export AIDEVOPS_WORKTREE_TRASH_ROOT
+# shellcheck source=../audit-worktree-removal-helper.sh
+source "$AUDIT_HELPER"
 
 cleanup() {
 	rm -rf "$TEST_ROOT"
@@ -44,6 +50,24 @@ make_fixture() {
 	return 0
 }
 
+make_recovery_fixture() {
+	local repo_path="$TEST_ROOT/recovery-repo"
+	local worktree_path="$TEST_ROOT/recovery-worktree"
+
+	"$GIT_BIN" init -q -b main "$repo_path" || return 1
+	"$GIT_BIN" -C "$repo_path" config user.email test@example.invalid || return 1
+	"$GIT_BIN" -C "$repo_path" config user.name 'Aidevops Test' || return 1
+	"$GIT_BIN" -C "$repo_path" config commit.gpgsign false || return 1
+	printf 'base\n' >"$repo_path/README.md" || return 1
+	"$GIT_BIN" -C "$repo_path" add README.md || return 1
+	"$GIT_BIN" -C "$repo_path" commit -q -m init || return 1
+	"$GIT_BIN" -C "$repo_path" worktree add -q -b feature/recovery-inventory \
+		"$worktree_path" main || return 1
+	AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" archive_worktree_path_recoverably \
+		"$worktree_path" "test-storage-inventory-helper.sh" "storage-inventory" || return 1
+	return 0
+}
+
 fixture_checksum() {
 	cksum \
 		"$HOME/.aidevops/runtime-bundles/bundle-a/data" \
@@ -59,6 +83,7 @@ fixture_checksum() {
 }
 
 make_fixture
+make_recovery_fixture
 before_checksum=$(fixture_checksum)
 report=$(bash "$HELPER" json)
 after_checksum=$(fixture_checksum)
@@ -66,7 +91,7 @@ after_checksum=$(fixture_checksum)
 
 [[ "$(printf '%s' "$report" | jq -r '.schema_version')" == "2" ]] || fail "schema version missing"
 [[ "$(printf '%s' "$report" | jq -r '.read_only')" == "true" ]] || fail "read-only marker missing"
-[[ "$(printf '%s' "$report" | jq '.stores | length')" == "15" ]] || fail "expected explicit producer and split OpenCode stores"
+[[ "$(printf '%s' "$report" | jq '.stores | length')" == "16" ]] || fail "expected explicit producer and split OpenCode stores"
 [[ "$(printf '%s' "$report" | jq '[.stores[].reclaimable_bytes] | add')" == "0" ]] || fail "foundation report suggested reclaimable bytes"
 [[ "$(printf '%s' "$report" | jq '[.stores[] | select(.total_bytes != null) | (.total_bytes == (.protected_bytes + .reclaimable_bytes + .unknown_bytes))] | all')" == "true" ]] || fail "storage categories did not reconcile with totals"
 [[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .unknown_bytes > 0')" == "true" ]] || fail "runtime bundles were not fail-closed unknown"
@@ -77,9 +102,13 @@ after_checksum=$(fixture_checksum)
 [[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "opencode-active-db") | .owner')" == "joint" ]] || fail "OpenCode active DB ownership was not bounded"
 [[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "opencode-active-db") | .safety_class')" == "unknown" ]] || fail "unavailable OpenCode schema did not fail closed"
 [[ "$(printf '%s' "$report" | jq '[.stores[] | select(.store_id | startswith("opencode-")) | .reclaimable_bytes] | add')" == "0" ]] || fail "OpenCode report exposed cleanup candidates"
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "worktree-recovery") | .bucket_count')" == "1" ]] || fail "worktree recovery archive was not inventoried"
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "worktree-recovery") | .total_bytes > 0')" == "true" ]] || fail "worktree recovery bytes were not measured"
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "worktree-recovery") | .protected_bytes == .total_bytes')" == "true" ]] || fail "attributed worktree recovery bytes were not protected"
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "worktree-recovery") | .reclaimable_bytes')" == "0" ]] || fail "worktree recovery inventory granted deletion authority"
 
 home_unset_report=$(env -u HOME -u SUDO_USER -u AIDEVOPS_OPENCODE_DATA_DIR -u AIDEVOPS_OPENCODE_DB_PATH -u OPENCODE_DB_PATH -u OPENCODE_DB -u AIDEVOPS_NPM_CACHE_DIR bash "$HELPER" json)
-[[ "$(printf '%s' "$home_unset_report" | jq '.stores | length')" == "15" ]] || fail "HOME-unset inventory did not return every store"
+[[ "$(printf '%s' "$home_unset_report" | jq '.stores | length')" == "16" ]] || fail "HOME-unset inventory did not return every store"
 [[ "$(printf '%s' "$home_unset_report" | jq -r '[.stores[] | .error == "home-unavailable"] | all')" == "true" ]] || fail "HOME-unset stores did not fail closed"
 
 report=$(BACKUP_KEEP_COUNT=1 AIDEVOPS_WORKER_EXCERPT_KEEP_COUNT=1 bash "$HELPER" json)
@@ -122,6 +151,7 @@ printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$FAILING_DU"
 chmod +x "$FAILING_DU"
 report=$(AIDEVOPS_STORAGE_DU_COMMAND="$FAILING_DU" bash "$HELPER" json)
 [[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "runtime-bundles") | .error')" == "sizing-failed" ]] || fail "sizing failure was not visible"
+[[ "$(printf '%s' "$report" | jq -r '.stores[] | select(.store_id == "worktree-recovery") | .error')" == "sizing-failed" ]] || fail "worktree recovery sizing failure was not visible"
 
 SLOW_DU="$TEST_ROOT/slow-du"
 printf '%s\n' '#!/usr/bin/env bash' 'sleep 5' >"$SLOW_DU"

--- a/.agents/scripts/tests/test-worktree-removal-audit.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit.sh
@@ -602,6 +602,10 @@ test_recovery_inventory_reports_legacy_buckets_fail_closed() {
 	local interrupted_worktree="${TEST_DIR}/interrupted-inventory-worktree"
 	local interrupted_archive=""
 	local interrupted_bucket=""
+	local compat_repo="${TEST_DIR}/compat-v1-inventory-repo"
+	local compat_worktree="${TEST_DIR}/compat-v1-inventory-worktree"
+	local compat_archive=""
+	local compat_bucket=""
 	local legacy_repo="${TEST_DIR}/legacy-v1-inventory-repo"
 	local legacy_worktree="${TEST_DIR}/legacy-v1-inventory-worktree"
 	local legacy_archive=""
@@ -635,15 +639,30 @@ test_recovery_inventory_reports_legacy_buckets_fail_closed() {
 	interrupted_archive="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
 	interrupted_bucket="${interrupted_archive%/*}"
 	rm -f "$interrupted_bucket/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" || rc=1
+	create_git_worktree_fixture "$compat_repo" "$compat_worktree" "feature/compat-v1-inventory" || rc=1
+	AIDEVOPS_WORKTREE_TRASH_ROOT="$legacy_root" AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" \
+		archive_worktree_path_recoverably "$compat_worktree" "test.sh" "compat-v1-inventory" || rc=1
+	compat_archive="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
+	compat_bucket="${compat_archive%/*}"
+	recovery_dir="$compat_bucket/${_WT_RECOVERY_DIR_NAME}"
+	printf '%s\n' "$_WT_RECOVERY_FORMAT_V1" >"$recovery_dir/format" || rc=1
+	printf '%s\n' "$_WT_RECOVERY_FORMAT_V1" >"$recovery_dir/${_WT_RECOVERY_COMPLETE_MARKER}" || rc=1
+	rm -f "$recovery_dir/created-at" "$recovery_dir/producer" \
+		"$recovery_dir/producer-context" "$recovery_dir/session-id" \
+		"$recovery_dir/archive-outcome" "$recovery_dir/source-removal-outcome" || rc=1
 	create_git_worktree_fixture "$legacy_repo" "$legacy_worktree" "feature/legacy-inventory" || rc=1
 	AIDEVOPS_WORKTREE_TRASH_ROOT="$legacy_root" AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" \
 		archive_worktree_path_recoverably "$legacy_worktree" "test.sh" "legacy-inventory" || rc=1
 	legacy_archive="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
 	legacy_bucket="${legacy_archive%/*}"
 	recovery_dir="$legacy_bucket/${_WT_RECOVERY_DIR_NAME}"
+	printf '%s\n' "$_WT_RECOVERY_FORMAT_V1" >"$recovery_dir/format" || rc=1
 	rm -f "$recovery_dir/${_WT_RECOVERY_COMPLETE_MARKER}" \
 		"$recovery_dir/storage-owner" "$recovery_dir/storage-class" \
-		"$recovery_dir/storage-policy" "$recovery_dir/storage-root" || rc=1
+		"$recovery_dir/storage-policy" "$recovery_dir/storage-root" \
+		"$recovery_dir/created-at" "$recovery_dir/producer" \
+		"$recovery_dir/producer-context" "$recovery_dir/session-id" \
+		"$recovery_dir/archive-outcome" "$recovery_dir/source-removal-outcome" || rc=1
 	output=$(HOME="$fixture_home" AIDEVOPS_WORKTREE_TRASH_ROOT="$override_link" \
 		AIDEVOPS_ORPHAN_TRASH_ROOT="" worktree_recovery_inventory "Linux") || rc=1
 	printf '%s\n' "$output" | grep -Fq $'store\tcurrent\tjoint\trecovery\tmanual-review\tpresent\t' || rc=1
@@ -652,6 +671,7 @@ test_recovery_inventory_reports_legacy_buckets_fail_closed() {
 	printf '%s\n' "$output" | grep -Fq $'bucket\tcurrent\tframework\tunknown\t'"$spoofed_bucket" || rc=1
 	printf '%s\n' "$output" | grep -Fq $'bucket\tlegacy\tframework\tunknown\t'"$unknown_bucket" || rc=1
 	printf '%s\n' "$output" | grep -Fq $'bucket\tlegacy\tframework\tunknown\t'"$interrupted_bucket" || rc=1
+	printf '%s\n' "$output" | grep -Fq $'bucket\tlegacy\tframework\tattributed\t'"$compat_bucket" || rc=1
 	printf '%s\n' "$output" | grep -Fq $'bucket\tlegacy\tframework\tattributed-legacy\t'"$legacy_bucket" || rc=1
 	alias_output=$(HOME="$fixture_home" AIDEVOPS_WORKTREE_TRASH_ROOT="$legacy_alias" \
 		AIDEVOPS_ORPHAN_TRASH_ROOT="" worktree_recovery_inventory "Linux") || rc=1
@@ -673,13 +693,19 @@ test_recoverable_archive_then_native_remove() {
 
 	create_git_worktree_fixture "$repo_path" "$wt_path" "feature/archive" || rc=1
 	wt_root=$("$GIT_BIN" -C "$wt_path" rev-parse --show-toplevel 2>/dev/null) || rc=1
-	AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" archive_worktree_path_recoverably \
+	AIDEVOPS_SESSION_ID="ses_test_recovery" AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" archive_worktree_path_recoverably \
 		"$wt_path" "test.sh" "archive-test" || rc=1
 	archive_path="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
 	[[ -d "$wt_path" && -d "$archive_path" && -e "$archive_path/.git" ]] || rc=1
+	[[ "$(<"${archive_path%/*}/${_WT_RECOVERY_DIR_NAME}/format")" == "$_WT_RECOVERY_FORMAT_V2" ]] || rc=1
 	[[ "$(<"${archive_path%/*}/${_WT_RECOVERY_DIR_NAME}/storage-owner")" == "framework" ]] || rc=1
 	[[ "$(<"${archive_path%/*}/${_WT_RECOVERY_DIR_NAME}/storage-class")" == "recovery" ]] || rc=1
 	[[ "$(<"${archive_path%/*}/${_WT_RECOVERY_DIR_NAME}/storage-policy")" == "manual-review" ]] || rc=1
+	[[ "$(<"${archive_path%/*}/${_WT_RECOVERY_DIR_NAME}/producer")" == "test.sh" ]] || rc=1
+	[[ "$(<"${archive_path%/*}/${_WT_RECOVERY_DIR_NAME}/producer-context")" == "archive-test" ]] || rc=1
+	[[ "$(<"${archive_path%/*}/${_WT_RECOVERY_DIR_NAME}/session-id")" == "ses_test_recovery" ]] || rc=1
+	[[ "$(<"${archive_path%/*}/${_WT_RECOVERY_DIR_NAME}/archive-outcome")" == "complete" ]] || rc=1
+	[[ "$(<"${archive_path%/*}/${_WT_RECOVERY_DIR_NAME}/source-removal-outcome")" == "pending" ]] || rc=1
 	[[ "$(<"${archive_path%/*}/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}")" == "$_WT_RECOVERY_FORMAT" ]] || rc=1
 	metadata=$("$GIT_BIN" -C "$repo_path" worktree list --porcelain) || rc=1
 	printf '%s\n' "$metadata" | grep -Fqx "worktree $wt_root" || rc=1
@@ -691,6 +717,7 @@ test_recoverable_archive_then_native_remove() {
 		rc=1
 	fi
 	[[ ! -e "$wt_path" && -d "$archive_path" && -e "$archive_path/.git" ]] || rc=1
+	[[ "$(<"${archive_path%/*}/${_WT_RECOVERY_DIR_NAME}/source-removal-outcome")" == "removed" ]] || rc=1
 	print_result "recoverable_archive_then_native_remove" "$rc" \
 		"Expected archive retention after native source and metadata removal"
 	return 0

--- a/.agents/scripts/worktree-helper-cmds.sh
+++ b/.agents/scripts/worktree-helper-cmds.sh
@@ -769,7 +769,11 @@ cmd_recovery() {
 		printf '%s\n' "Usage: worktree-helper.sh recovery" >&2
 		return 1
 	fi
-	worktree_recovery_inventory || return 1
+	if declare -F worktree_recovery_lifecycle_status >/dev/null 2>&1; then
+		worktree_recovery_lifecycle_status || return 1
+	else
+		worktree_recovery_inventory || return 1
+	fi
 	return 0
 }
 

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -71,6 +71,10 @@ if [[ -f "${SCRIPT_DIR}/audit-worktree-removal-helper.sh" ]]; then
 	# shellcheck source=audit-worktree-removal-helper.sh
 	source "${SCRIPT_DIR}/audit-worktree-removal-helper.sh"
 fi
+if [[ -f "${SCRIPT_DIR}/worktree-recovery-lifecycle-helper.sh" ]]; then
+	# shellcheck source=worktree-recovery-lifecycle-helper.sh
+	source "${SCRIPT_DIR}/worktree-recovery-lifecycle-helper.sh"
+fi
 # Caller ID used in every log_worktree_removal_event call below (avoids repeated literals).
 _WTAR_WH_CALLER="worktree-helper.sh"
 

--- a/.agents/scripts/worktree-recovery-lifecycle-helper.sh
+++ b/.agents/scripts/worktree-recovery-lifecycle-helper.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# worktree-recovery-lifecycle-helper.sh — Read-only recovery archive inventory.
+
+[[ "${_WORKTREE_RECOVERY_LIFECYCLE_HELPER_LOADED:-}" == "1" ]] && return 0
+_WORKTREE_RECOVERY_LIFECYCLE_HELPER_LOADED=1
+
+WORKTREE_RECOVERY_INVENTORY_SCHEMA="aidevops.worktree-recovery-inventory/v1"
+WORKTREE_RECOVERY_INVALID_RECORD="invalid-inventory-record"
+WORKTREE_RECOVERY_UNAVAILABLE="unavailable"
+
+WORKTREE_RECOVERY_LIFECYCLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 1
+if [[ -f "$WORKTREE_RECOVERY_LIFECYCLE_DIR/shared-constants.sh" ]]; then
+	# shellcheck source=shared-constants.sh
+	source "$WORKTREE_RECOVERY_LIFECYCLE_DIR/shared-constants.sh"
+fi
+if ! declare -F worktree_recovery_inventory >/dev/null 2>&1; then
+	# shellcheck source=audit-worktree-removal-helper.sh
+	source "$WORKTREE_RECOVERY_LIFECYCLE_DIR/audit-worktree-removal-helper.sh"
+fi
+
+_worktree_recovery_measure_path() {
+	local path="$1"
+	local du_command="${AIDEVOPS_WORKTREE_RECOVERY_DU_COMMAND:-${AIDEVOPS_STORAGE_DU_COMMAND:-du}}"
+	local timeout_tenths="${AIDEVOPS_WORKTREE_RECOVERY_SIZE_TIMEOUT_TENTHS:-${AIDEVOPS_STORAGE_SIZE_TIMEOUT_TENTHS:-20}}"
+	local output_file=""
+	local pid=""
+	local elapsed=0
+	local kib=""
+	local ignored=""
+
+	case "$timeout_tenths" in
+	'' | *[!0-9]*) timeout_tenths=20 ;;
+	esac
+	if [[ -L "$path" ]]; then
+		printf 'null|unavailable|bucket-is-symlink'
+		return 0
+	fi
+	if [[ ! -d "$path" ]]; then
+		printf 'null|unavailable|bucket-is-unavailable'
+		return 0
+	fi
+	if [[ ! -r "$path" ]]; then
+		printf 'null|unavailable|bucket-is-unreadable'
+		return 0
+	fi
+	if ! command -v "$du_command" >/dev/null 2>&1; then
+		printf 'null|unavailable|sizing-command-unavailable'
+		return 0
+	fi
+	output_file=$(mktemp "${AIDEVOPS_TEMP_DIR:-${TMPDIR:-/tmp}}/aidevops-worktree-recovery-size.XXXXXX") || {
+		printf 'null|unavailable|temporary-file-unavailable'
+		return 0
+	}
+	LC_ALL=C "$du_command" -sk "$path" >"$output_file" 2>/dev/null &
+	pid=$!
+	while kill -0 "$pid" 2>/dev/null; do
+		if [[ "$elapsed" -ge "$timeout_tenths" ]]; then
+			kill "$pid" 2>/dev/null || true
+			wait "$pid" 2>/dev/null || true
+			rm -f "$output_file"
+			printf 'null|unavailable|sizing-timeout'
+			return 0
+		fi
+		sleep 0.1
+		elapsed=$((elapsed + 1))
+	done
+	if ! wait "$pid"; then
+		rm -f "$output_file"
+		printf 'null|unavailable|sizing-failed'
+		return 0
+	fi
+	IFS=$'\t ' read -r kib ignored <"$output_file" || kib=""
+	rm -f "$output_file"
+	case "$kib" in
+	'' | *[!0-9]*) printf 'null|unavailable|invalid-size-output' ;;
+	*) printf '%s|exact|' "$((kib * 1024))" ;;
+	esac
+	return 0
+}
+
+_worktree_recovery_unavailable_json() {
+	local error="$1"
+	local display_path="$2"
+	jq -cn \
+		--arg schema "$WORKTREE_RECOVERY_INVENTORY_SCHEMA" \
+		--arg confidence "$WORKTREE_RECOVERY_UNAVAILABLE" \
+		--arg error "$error" \
+		--arg path "$display_path" \
+		'{schema:$schema,store_id:"worktree-recovery",producer:"worktree-helper",path:$path,owner:"unknown",safety_class:"recovery",policy:"manual-review; no deletion authority",total_bytes:null,protected_bytes:null,reclaimable_bytes:0,unknown_bytes:null,protection_reasons:["recovery classification or sizing is unavailable"],sizing_confidence:$confidence,next_action:"Restore HOME and run worktree-helper.sh recovery; leave archives untouched",error:$error,root_count:0,bucket_count:0,protected_count:0,reclaimable_count:0,unknown_count:0,buckets:[]}'
+	return 0
+}
+
+_worktree_recovery_display_path() {
+	local platform="$1"
+	local configured_root="${AIDEVOPS_WORKTREE_TRASH_ROOT:-${AIDEVOPS_ORPHAN_TRASH_ROOT:-}}"
+	local home_label="~"
+	if [[ -n "$configured_root" ]]; then
+		printf 'configured worktree recovery root and attributable legacy roots'
+	elif [[ "$platform" == "Darwin" ]]; then
+		printf '%s/.Trash attributable worktree recovery buckets' "$home_label"
+	else
+		printf '%s/.aidevops/recovery/worktrees and attributable legacy roots' "$home_label"
+	fi
+	return 0
+}
+
+_worktree_recovery_encode_report() {
+	local entries_file="$1"
+	local display_path="$2"
+	local report_owner="$3"
+	local report_error="$4"
+	local root_count="$5"
+	local bucket_count="$6"
+	local protected_count="$7"
+	local unknown_count="$8"
+	local total_bytes="$9"
+	local protected_bytes="${10}"
+	local unknown_bytes="${11}"
+	local confidence="$WORKTREE_RECOVERY_UNAVAILABLE"
+
+	[[ -n "$report_error" ]] || confidence="exact"
+	jq -sc \
+		--arg schema "$WORKTREE_RECOVERY_INVENTORY_SCHEMA" \
+		--arg path "$display_path" \
+		--arg owner "$report_owner" \
+		--arg error "$report_error" \
+		--arg confidence "$confidence" \
+		--argjson root_count "$root_count" \
+		--argjson bucket_count "$bucket_count" \
+		--argjson protected_count "$protected_count" \
+		--argjson unknown_count "$unknown_count" \
+		--argjson total_bytes "$total_bytes" \
+		--argjson protected_bytes "$protected_bytes" \
+		--argjson unknown_bytes "$unknown_bytes" \
+		'{schema:$schema,store_id:"worktree-recovery",producer:"worktree-helper",path:$path,owner:$owner,safety_class:"recovery",policy:"manual-review; v1/v2 compatibility; no deletion authority",total_bytes:$total_bytes,protected_bytes:$protected_bytes,reclaimable_bytes:0,unknown_bytes:$unknown_bytes,protection_reasons:["complete attributable archives remain protected; incomplete, malformed, symlinked, or unrecognised archives remain unknown"],sizing_confidence:$confidence,next_action:"Use worktree-helper.sh recovery for bucket details; no cleanup is available in this phase",error:(if $error == "" then null else $error end),root_count:$root_count,bucket_count:$bucket_count,protected_count:$protected_count,reclaimable_count:0,unknown_count:$unknown_count,archive_formats:["aidevops-worktree-recovery-v1","aidevops-worktree-recovery-v2"],buckets:.}' \
+		"$entries_file"
+	return $?
+}
+
+worktree_recovery_lifecycle_json() {
+	local platform="${1:-}"
+	local display_path="" inventory="" entries_file=""
+	local record_type="" store_role="" owner="" state="" path=""
+	local extra_one=""
+	local extra_two=""
+	local measured=""
+	local bytes=""
+	local confidence=""
+	local measure_error=""
+	local report_owner="framework"
+	local report_error=""
+	local root_count=0
+	local bucket_count=0
+	local protected_count=0
+	local unknown_count=0
+	local protected_bytes=0
+	local unknown_bytes=0
+	local total_bytes=0
+	local jq_status=0
+
+	if [[ -z "$platform" ]]; then
+		platform=$(uname -s 2>/dev/null) || platform="unknown"
+	fi
+	display_path=$(_worktree_recovery_display_path "$platform") || return 1
+	if [[ -z "${HOME:-}" ]]; then
+		_worktree_recovery_unavailable_json "home-unavailable" "$display_path"
+		return 0
+	fi
+	if ! command -v jq >/dev/null 2>&1; then
+		printf '{"schema":"%s","error":"jq-unavailable"}\n' "$WORKTREE_RECOVERY_INVENTORY_SCHEMA"
+		return 1
+	fi
+	if ! inventory=$(worktree_recovery_inventory "$platform"); then
+		_worktree_recovery_unavailable_json "classification-unavailable" "$display_path"
+		return 0
+	fi
+	entries_file=$(mktemp "${AIDEVOPS_TEMP_DIR:-${TMPDIR:-/tmp}}/aidevops-worktree-recovery-inventory.XXXXXX") || {
+		_worktree_recovery_unavailable_json "temporary-file-unavailable" "$display_path"
+		return 0
+	}
+	while IFS=$'\t' read -r record_type store_role owner state path extra_one extra_two; do
+		case "$record_type" in
+		store)
+			root_count=$((root_count + 1))
+			[[ "$owner" != "joint" ]] || report_owner="joint"
+			if [[ "$extra_one" == "$WORKTREE_RECOVERY_UNAVAILABLE" ]]; then
+				report_error="root-unavailable"
+			fi
+			case "$extra_two" in
+			*$'\t'*) report_error="$WORKTREE_RECOVERY_INVALID_RECORD" ;;
+			esac
+			;;
+		bucket)
+			bucket_count=$((bucket_count + 1))
+			if [[ -n "$extra_one" || -n "$extra_two" ]]; then
+				report_error="$WORKTREE_RECOVERY_INVALID_RECORD"
+				continue
+			fi
+			measured=$(_worktree_recovery_measure_path "$path")
+			IFS='|' read -r bytes confidence measure_error <<<"$measured"
+			if [[ "$bytes" == "null" ]]; then
+				report_error="${measure_error:-sizing-unavailable}"
+				unknown_count=$((unknown_count + 1))
+			else
+				total_bytes=$((total_bytes + bytes))
+				case "$state" in
+				attributed | attributed-legacy)
+					protected_count=$((protected_count + 1))
+					protected_bytes=$((protected_bytes + bytes))
+					;;
+				*)
+					unknown_count=$((unknown_count + 1))
+					unknown_bytes=$((unknown_bytes + bytes))
+					;;
+				esac
+			fi
+			jq -cn --arg role "$store_role" --arg state "$state" --arg path "$path" \
+				--arg confidence "$confidence" --arg error "$measure_error" --argjson bytes "$bytes" \
+				'{role:$role,state:$state,path:$path,bytes:$bytes,sizing_confidence:$confidence,error:(if $error == "" then null else $error end)}' \
+				>>"$entries_file" || report_error="entry-encoding-failed"
+			;;
+		'') ;;
+		*) report_error="$WORKTREE_RECOVERY_INVALID_RECORD" ;;
+		esac
+	done <<<"$inventory"
+	if [[ -n "$report_error" ]]; then
+		total_bytes=null
+		protected_bytes=null
+		unknown_bytes=null
+	fi
+	_worktree_recovery_encode_report "$entries_file" "$display_path" "$report_owner" "$report_error" \
+		"$root_count" "$bucket_count" "$protected_count" "$unknown_count" \
+		"$total_bytes" "$protected_bytes" "$unknown_bytes"
+	jq_status=$?
+	rm -f "$entries_file"
+	return "$jq_status"
+}
+
+_worktree_recovery_format_bytes() {
+	local bytes="$1"
+	if [[ "$bytes" == "null" ]]; then
+		printf 'unavailable'
+	elif [[ "$bytes" -ge 1073741824 ]]; then
+		printf '%s.%s GiB' "$((bytes / 1073741824))" "$(((bytes % 1073741824) * 10 / 1073741824))"
+	elif [[ "$bytes" -ge 1048576 ]]; then
+		printf '%s.%s MiB' "$((bytes / 1048576))" "$(((bytes % 1048576) * 10 / 1048576))"
+	elif [[ "$bytes" -ge 1024 ]]; then
+		printf '%s.%s KiB' "$((bytes / 1024))" "$(((bytes % 1024) * 10 / 1024))"
+	else
+		printf '%s B' "$bytes"
+	fi
+	return 0
+}
+
+worktree_recovery_lifecycle_status() {
+	local platform="${1:-}"
+	local report=""
+	local total_bytes=""
+	local protected_bytes=""
+	local unknown_bytes=""
+
+	report=$(worktree_recovery_lifecycle_json "$platform") || return 1
+	total_bytes=$(printf '%s\n' "$report" | jq -r '.total_bytes') || return 1
+	protected_bytes=$(printf '%s\n' "$report" | jq -r '.protected_bytes') || return 1
+	unknown_bytes=$(printf '%s\n' "$report" | jq -r '.unknown_bytes') || return 1
+	printf 'Worktree Recovery Inventory (read-only)\n'
+	printf '  buckets: %s protected, %s unknown, %s total\n' \
+		"$(printf '%s\n' "$report" | jq -r '.protected_count')" \
+		"$(printf '%s\n' "$report" | jq -r '.unknown_count')" \
+		"$(printf '%s\n' "$report" | jq -r '.bucket_count')"
+	printf '  bytes:   %s protected, %s unknown, %s total\n' \
+		"$(_worktree_recovery_format_bytes "$protected_bytes")" \
+		"$(_worktree_recovery_format_bytes "$unknown_bytes")" \
+		"$(_worktree_recovery_format_bytes "$total_bytes")"
+	printf '%s\n' "$report" | jq -r '.buckets[] | "  [\(.state)] \(.role): \(.path) (\(if .bytes == null then "size unavailable" else (.bytes | tostring) + " bytes" end))"'
+	printf 'No cleanup was performed. OpenCode session history may aid recovery, but never authorizes deletion.\n'
+	return 0
+}
+
+_worktree_recovery_lifecycle_usage() {
+	printf '%s\n' 'Usage: worktree-recovery-lifecycle-helper.sh [status|json]'
+	return 0
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	case "${1:-status}" in
+	json) worktree_recovery_lifecycle_json ;;
+	status) worktree_recovery_lifecycle_status ;;
+	help | --help | -h) _worktree_recovery_lifecycle_usage ;;
+	*)
+		_worktree_recovery_lifecycle_usage >&2
+		exit 1
+		;;
+	esac
+fi

--- a/README.md
+++ b/README.md
@@ -2394,7 +2394,13 @@ wt merge
 # Creates: ~/Git/{repo}-feature-my-feature/ (cd there manually)
 ~/.aidevops/agents/scripts/worktree-helper.sh list
 ~/.aidevops/agents/scripts/worktree-helper.sh clean
+# Read-only count/byte inventory of retained recovery archives
+~/.aidevops/agents/scripts/worktree-helper.sh recovery
 ```
+
+Recovery inventory classifies attributable archives as protected or unknown and
+never deletes them. OpenCode session history can aid reconstruction, but it does
+not replace archive integrity evidence or authorize cleanup.
 
 **Benefits:**
 - Run tests on one branch while coding on another


### PR DESCRIPTION
## Summary

Adds additive v2 recovery evidence, preserves v1 compatibility, and exposes one read-only zero-reclaimable storage inventory record. For #29312.

## Files Changed

.agents/reference/storage-lifecycle.md, .agents/scripts/audit-worktree-removal-helper.sh, .agents/scripts/storage-inventory-helper.sh, .agents/scripts/tests/test-storage-inventory-helper.sh, .agents/scripts/tests/test-worktree-removal-audit.sh, .agents/scripts/worktree-helper-cmds.sh, .agents/scripts/worktree-helper.sh, .agents/scripts/worktree-recovery-lifecycle-helper.sh, README.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — 47/47 worktree-removal tests; storage-inventory integration test; strict changed-file lint; live read-only recovery status command

Resolves #29387


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.218 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 40m and 561,382 tokens on this with the user in an interactive session.