### PR TITLE
GH#29388: Add exact-manifest worktree recovery cleanup planning

### DIFF
--- a/.agents/reference/storage-lifecycle.md
+++ b/.agents/reference/storage-lifecycle.md
@@ -105,6 +105,33 @@ default roots remain distinct from joint OS Trash or operator-selected roots.
 Incomplete, symlinked, unrecognised, or unsized buckets are `unknown`; inventory
 never migrates, rewrites, or deletes them.
 
+Run `worktree-helper.sh recovery plan --output <absolute-path>` to persist a
+versioned `aidevops.worktree-recovery-plan/v1` JSON review artifact. The output
+path must be new, absolute, non-symlinked, and writable. The helper builds the
+complete document in a mode-0600 temporary file beside the destination and
+publishes it atomically without replacing an existing path. Plan generation is
+read-only for every recovery root and archive; it never moves, rewrites, or
+deletes a bucket.
+
+The envelope records its producer, generation time, deterministic plan ID,
+source roots, reconciled entry/byte totals, and ordered `candidate`, `protected`,
+and `unknown` entries. Each attributable entry binds the exact physical bucket
+and archive paths to its format, Git HEAD/branch, source/admin/common identity,
+archive index and completion-marker digests, expected allocated bytes, observed
+local/remote evidence, disposition, and reason codes. Unchanged evidence yields
+the same entries and plan ID; the generation timestamp remains observational.
+
+Candidate status requires a valid complete archive, completed source removal,
+a clean tracked/untracked/ignored Git state, an exact merged commit, a closed
+linked task, no open pull request, no live Git worktree/registry/claim/process
+reference, and exact readable sizing. Positive live or unfinished evidence is
+`protected`. Missing APIs, process visibility, identity, validation, or sizing
+is `unknown`. Identity and allocated bytes are read again immediately before an
+entry is emitted, so concurrent drift downgrades only that entry. Age, size, and
+OpenCode or Claude session history never prove reclaimability. Plan files grant
+no deletion authority; only a future version-matched apply command may consume
+candidate entries after repeating every mutable proof.
+
 An originating OpenCode or Claude session identifier is recovery guidance, not
 deletion proof. Session history can reconstruct text edits and intent but may be
 archived, unavailable, or incomplete and does not prove preservation of ignored

--- a/.agents/reference/storage-lifecycle.md
+++ b/.agents/reference/storage-lifecycle.md
@@ -114,9 +114,11 @@ read-only for every recovery root and archive; it never moves, rewrites, or
 deletes a bucket.
 
 The envelope records its producer, generation time, deterministic plan ID,
-source roots, reconciled entry/byte totals, and ordered `candidate`, `protected`,
-and `unknown` entries. Each attributable entry binds the exact physical bucket
-and archive paths to its format, Git HEAD/branch, source/admin/common identity,
+inventory completeness/error state, source roots, reconciled entry/byte totals,
+and ordered `candidate`, `protected`, and `unknown` entries. An incomplete global
+inventory produces no candidates; a partial report downgrades its reported
+entries to unknown. Each attributable entry binds the exact physical bucket and
+archive paths to its format, Git HEAD/branch, source/admin/common identity,
 archive index and completion-marker digests, expected allocated bytes, observed
 local/remote evidence, disposition, and reason codes. Unchanged evidence yields
 the same entries and plan ID; the generation timestamp remains observational.

--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression tests for exact, read-only worktree recovery cleanup plans.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${SCRIPT_DIR}/.."
+GIT_BIN="${AIDEVOPS_TEST_GIT_BIN:-/usr/bin/git}"
+TEST_DIR=""
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1"
+	local status="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+	else
+		printf 'FAIL %s\n' "$name"
+		[[ -z "$detail" ]] || printf '  %s\n' "$detail"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+setup() {
+	TEST_DIR=$(mktemp -d)
+	trap teardown EXIT
+	return 0
+}
+
+teardown() {
+	[[ -z "$TEST_DIR" || ! -d "$TEST_DIR" ]] || rm -rf "$TEST_DIR"
+	return 0
+}
+
+create_archived_fixture() {
+	local repo_path="$1"
+	local worktree_path="$2"
+	local recovery_root="$3"
+	local branch_name="$4"
+
+	"$GIT_BIN" init -q -b main "$repo_path" || return 1
+	"$GIT_BIN" -C "$repo_path" config user.email test@example.invalid || return 1
+	"$GIT_BIN" -C "$repo_path" config user.name 'Aidevops Test' || return 1
+	"$GIT_BIN" -C "$repo_path" config commit.gpgsign false || return 1
+	printf 'base\n' >"${repo_path}/README.md" || return 1
+	"$GIT_BIN" -C "$repo_path" add README.md || return 1
+	"$GIT_BIN" -C "$repo_path" commit -q -m init || return 1
+	"$GIT_BIN" -C "$repo_path" worktree add -q -b "$branch_name" "$worktree_path" || return 1
+	AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" \
+		archive_worktree_path_recoverably "$worktree_path" "test.sh" "recovery-plan" || return 1
+	AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" remove_archived_worktree_path \
+		"$worktree_path" "$WORKTREE_RECOVERABLE_ARCHIVE_PATH" "test.sh" "recovery-plan" \
+		"recovery_path=archive-first" "false" "false" || return 1
+	printf '%s\n' "$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
+	return 0
+}
+
+archive_tree_digest() {
+	local bucket_path="$1"
+	local parent_path="${bucket_path%/*}"
+	local base_name="${bucket_path##*/}"
+	local digest=""
+
+	if command -v shasum >/dev/null 2>&1; then
+		digest=$(tar -cf - -C "$parent_path" "$base_name" | shasum -a 256) || return 1
+	elif command -v sha256sum >/dev/null 2>&1; then
+		digest=$(tar -cf - -C "$parent_path" "$base_name" | sha256sum) || return 1
+	else
+		return 1
+	fi
+	digest="${digest%%[[:space:]]*}"
+	printf '%s\n' "$digest"
+	return 0
+}
+
+install_external_evidence_stub() {
+	_worktree_recovery_plan_external_evidence_json() {
+		jq -cn '{commit:"merged",open_pr:"clear",task:"closed",issue_number:"29388",repo:"example/repo"}'
+		return 0
+	}
+	return 0
+}
+
+install_clear_evidence_stubs() {
+	_worktree_recovery_plan_git_state() { printf 'clear\n'; return 0; }
+	_worktree_recovery_plan_worktree_reference_state() { printf 'clear\n'; return 0; }
+	_worktree_recovery_plan_registry_state() { printf 'clear\n'; return 0; }
+	_worktree_recovery_plan_claim_state() { printf 'clear\n'; return 0; }
+	_worktree_recovery_plan_process_state() { printf 'clear\n'; return 0; }
+	install_external_evidence_stub
+	return 0
+}
+
+test_exact_plan_writes_candidate_without_mutation() {
+	local home_path="${TEST_DIR}/candidate-home"
+	local repo_path="${TEST_DIR}/candidate-repo"
+	local worktree_path="${TEST_DIR}/candidate-worktree"
+	local recovery_root="${home_path}/recovery"
+	local output_path="${TEST_DIR}/candidate-plan.json"
+	local second_output_path="${TEST_DIR}/candidate-plan-second.json"
+	local archive_path="" marker_path="" marker_digest_before="" marker_digest_after=""
+	local bucket_path="" tree_digest_before="" tree_digest_after=""
+	local rc=0
+
+	mkdir -p "$home_path" "$recovery_root" || rc=1
+	archive_path=$(create_archived_fixture "$repo_path" "$worktree_path" "$recovery_root" \
+		"bugfix/gh29388-recovery-plan") || rc=1
+	marker_path="${archive_path%/*}/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}"
+	bucket_path="${archive_path%/*}"
+	marker_digest_before=$(_worktree_recovery_plan_sha256_file "$marker_path") || rc=1
+	tree_digest_before=$(archive_tree_digest "$bucket_path") || rc=1
+	install_external_evidence_stub
+	HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		cmd_recovery plan --output "$output_path" >/dev/null || rc=1
+	HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		cmd_recovery plan --output "$second_output_path" >/dev/null || rc=1
+	marker_digest_after=$(_worktree_recovery_plan_sha256_file "$marker_path") || rc=1
+	tree_digest_after=$(archive_tree_digest "$bucket_path") || rc=1
+	[[ "$marker_digest_before" == "$marker_digest_after" ]] || rc=1
+	[[ "$tree_digest_before" == "$tree_digest_after" ]] || rc=1
+	[[ ! -e "$worktree_path" && -d "$archive_path" ]] || rc=1
+	jq -e --arg archive "$archive_path" '
+		.schema == "aidevops.worktree-recovery-plan/v1" and .producer == "worktree-helper" and
+		.read_only == true and (.source_roots | length == 1) and .entry_count == 1 and
+		.sized_entry_count == 1 and .unavailable_size_count == 0 and
+		.candidate_count == 1 and .protected_count == 0 and .unknown_count == 0 and
+		(.candidate_bytes > 0) and .candidate_bytes == .expected_allocated_bytes and
+		(.plan_id | startswith("sha256:")) and
+		(.entries | length == 1) and .entries[0].archive_path == $archive and
+		.entries[0].disposition == "candidate" and
+		.entries[0].expected_allocated_bytes > 0 and
+		(.entries[0].identity.identity_digest | startswith("sha256:")) and
+		(.entries[0].identity.index_digest | startswith("sha256:"))
+	' "$output_path" >/dev/null || rc=1
+	[[ "$(jq -cS '.entries' "$output_path")" == "$(jq -cS '.entries' "$second_output_path")" ]] || rc=1
+	[[ "$(jq -r '.plan_id' "$output_path")" == "$(jq -r '.plan_id' "$second_output_path")" ]] || rc=1
+	print_result "exact_plan_writes_candidate_without_mutation" "$rc" \
+		"Expected one identity-bound candidate and unchanged recovery evidence"
+	return 0
+}
+
+test_git_state_detects_recovery_data() {
+	local home_path="${TEST_DIR}/dirty-home"
+	local repo_path="${TEST_DIR}/dirty-repo"
+	local worktree_path="${TEST_DIR}/dirty-worktree"
+	local recovery_root="${home_path}/recovery"
+	local archive_path="" identity="" state=""
+	local rc=0
+
+	mkdir -p "$home_path" "$recovery_root" || rc=1
+	archive_path=$(create_archived_fixture "$repo_path" "$worktree_path" "$recovery_root" \
+		"bugfix/gh29388-dirty-plan") || rc=1
+	identity=$(_worktree_recovery_plan_identity_json "${archive_path%/*}") || rc=1
+	printf 'changed\n' >"${archive_path}/README.md" || rc=1
+	state=$(_worktree_recovery_plan_git_state "$identity") || rc=1
+	[[ "$state" == "dirty" ]] || rc=1
+	"$GIT_BIN" -C "$archive_path" checkout -q -- README.md || rc=1
+	printf 'untracked\n' >"${archive_path}/unique.bin" || rc=1
+	state=$(_worktree_recovery_plan_git_state "$identity") || rc=1
+	[[ "$state" == "dirty" ]] || rc=1
+	rm -f "${archive_path}/unique.bin"
+	printf '*.cache\n' >>"${repo_path}/.git/info/exclude" || rc=1
+	printf 'ignored\n' >"${archive_path}/unique.cache" || rc=1
+	state=$(_worktree_recovery_plan_git_state "$identity") || rc=1
+	[[ "$state" == "dirty" ]] || rc=1
+	print_result "git_state_detects_recovery_data" "$rc" \
+		"Expected tracked, untracked, and ignored recovery data to veto candidates"
+	return 0
+}
+
+test_plan_output_refuses_unsafe_targets() {
+	local existing_path="${TEST_DIR}/existing-plan.json"
+	local symlink_path="${TEST_DIR}/symlink-plan.json"
+	local target_path="${TEST_DIR}/symlink-target.json"
+	local home_path="${TEST_DIR}/unsafe-home"
+	local recovery_root="${home_path}/recovery"
+	local unwritable_dir="${TEST_DIR}/unwritable"
+	local unwritable_path="${unwritable_dir}/plan.json"
+	local rc=0
+
+	mkdir -p "$recovery_root" "$unwritable_dir" || rc=1
+	printf '{}\n' >"$existing_path" || rc=1
+	printf '{}\n' >"$target_path" || rc=1
+	ln -s "$target_path" "$symlink_path" || rc=1
+	if worktree_recovery_plan_write "$existing_path" >/dev/null 2>&1; then rc=1; fi
+	if worktree_recovery_plan_write "$symlink_path" >/dev/null 2>&1; then rc=1; fi
+	if worktree_recovery_plan_write "relative-plan.json" >/dev/null 2>&1; then rc=1; fi
+	chmod 500 "$unwritable_dir" || rc=1
+	if HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		worktree_recovery_plan_write "$unwritable_path" >/dev/null 2>&1; then rc=1; fi
+	chmod 700 "$unwritable_dir" || rc=1
+	[[ "$(<"$existing_path")" == '{}' && -L "$symlink_path" ]] || rc=1
+	[[ ! -e "$unwritable_path" && ! -L "$unwritable_path" ]] || rc=1
+	print_result "plan_output_refuses_unsafe_targets" "$rc" \
+		"Expected existing, symlinked, and relative outputs to fail without mutation"
+	return 0
+}
+
+test_classification_fails_closed() {
+	local identity='{"source_removal_outcome":"removed","branch":"refs/heads/bugfix/gh29388-plan"}'
+	local clear_external='{"commit":"merged","open_pr":"clear","task":"closed"}'
+	local evidence="" result=""
+	local protected_case=""
+	local rc=0
+
+	evidence=$(jq -cn --argjson external "$clear_external" \
+		'{git:"dirty",worktree:"clear",registry:"clear",claim:"clear",process:"clear",external:$external}') || rc=1
+	result=$(_worktree_recovery_plan_classification_json "$identity" "$evidence" true) || rc=1
+	[[ "$(printf '%s\n' "$result" | jq -r '.disposition')" == "protected" ]] || rc=1
+	evidence=$(jq -cn --argjson external "$clear_external" \
+		'{git:"clear",worktree:"clear",registry:"clear",claim:"unavailable",process:"clear",external:$external}') || rc=1
+	result=$(_worktree_recovery_plan_classification_json "$identity" "$evidence" true) || rc=1
+	[[ "$(printf '%s\n' "$result" | jq -r '.disposition')" == "unknown" ]] || rc=1
+	result=$(_worktree_recovery_plan_classification_json "$identity" "$evidence" false) || rc=1
+	[[ "$(printf '%s\n' "$result" | jq -r '.reasons[0]')" == "identity-or-size-changed" ]] || rc=1
+	for protected_case in worktree registry claim process; do
+		evidence=$(jq -cn --arg field "$protected_case" --argjson external "$clear_external" \
+			'{git:"clear",worktree:"clear",registry:"clear",claim:"clear",process:"clear",external:$external} | .[$field]="active"') || rc=1
+		result=$(_worktree_recovery_plan_classification_json "$identity" "$evidence" true) || rc=1
+		[[ "$(printf '%s\n' "$result" | jq -r '.disposition')" == "protected" ]] || rc=1
+	done
+	for clear_external in \
+		'{"commit":"unproven","open_pr":"clear","task":"closed"}' \
+		'{"commit":"merged","open_pr":"active","task":"closed"}' \
+		'{"commit":"merged","open_pr":"clear","task":"open"}'; do
+		evidence=$(jq -cn --argjson external "$clear_external" \
+			'{git:"clear",worktree:"clear",registry:"clear",claim:"clear",process:"clear",external:$external}') || rc=1
+		result=$(_worktree_recovery_plan_classification_json "$identity" "$evidence" true) || rc=1
+		[[ "$(printf '%s\n' "$result" | jq -r '.disposition')" == "protected" ]] || rc=1
+	done
+	clear_external='{"commit":"unavailable","open_pr":"unavailable","task":"unavailable"}'
+	evidence=$(jq -cn --argjson external "$clear_external" \
+		'{git:"clear",worktree:"clear",registry:"clear",claim:"clear",process:"clear",external:$external}') || rc=1
+	result=$(_worktree_recovery_plan_classification_json "$identity" "$evidence" true) || rc=1
+	[[ "$(printf '%s\n' "$result" | jq -r '.disposition')" == "unknown" ]] || rc=1
+	identity='{"source_removal_outcome":"removed","branch":"detached"}'
+	result=$(_worktree_recovery_plan_classification_json "$identity" "$evidence" true) || rc=1
+	[[ "$(printf '%s\n' "$result" | jq -r '.disposition')" == "protected" ]] || rc=1
+	print_result "classification_fails_closed" "$rc" \
+		"Expected dirty evidence to protect and unavailable or changed evidence to remain unknown"
+	return 0
+}
+
+test_plan_records_malformed_bucket_unknown() {
+	local home_path="${TEST_DIR}/malformed-home"
+	local recovery_root="${home_path}/recovery"
+	local malformed_bucket="${recovery_root}/aidevops-worktree-cleanup-malformed"
+	local output_path="${TEST_DIR}/malformed-plan.json"
+	local rc=0
+
+	mkdir -p "${malformed_bucket}/${_WT_RECOVERY_DIR_NAME}" || rc=1
+	printf '%s\n' "$_WT_RECOVERY_FORMAT_V2" > \
+		"${malformed_bucket}/${_WT_RECOVERY_DIR_NAME}/format" || rc=1
+	HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		worktree_recovery_plan_write "$output_path" >/dev/null || rc=1
+	jq -e '.candidate_count == 0 and .unknown_count == 1 and
+		.entries[0].reasons == ["archive-unrecognised-or-incomplete"]' \
+		"$output_path" >/dev/null || rc=1
+	print_result "plan_records_malformed_bucket_unknown" "$rc" \
+		"Expected malformed archives to remain visible but never become candidates"
+	return 0
+}
+
+test_size_drift_downgrades_only_entry() {
+	local home_path="${TEST_DIR}/drift-home"
+	local repo_path="${TEST_DIR}/drift-repo"
+	local worktree_path="${TEST_DIR}/drift-worktree"
+	local recovery_root="${home_path}/recovery"
+	local archive_path="" bucket_path="" measured="" expected_bytes="" entry=""
+	local rc=0
+
+	mkdir -p "$home_path" "$recovery_root" || rc=1
+	archive_path=$(create_archived_fixture "$repo_path" "$worktree_path" "$recovery_root" \
+		"bugfix/gh29388-drift-plan") || rc=1
+	bucket_path="${archive_path%/*}"
+	measured=$(_worktree_recovery_measure_path "$bucket_path") || rc=1
+	IFS='|' read -r expected_bytes _ _ <<<"$measured"
+	entry=$(
+		install_clear_evidence_stubs
+		_worktree_recovery_measure_path() {
+			local ignored_path="$1"
+			: "$ignored_path"
+			printf '%s|exact|' "$((expected_bytes + 1024))"
+			return 0
+		}
+		_worktree_recovery_plan_attributed_entry_json "current" "$bucket_path" "$expected_bytes"
+	) || rc=1
+	[[ "$(printf '%s\n' "$entry" | jq -r '.disposition')" == "unknown" ]] || rc=1
+	[[ "$(printf '%s\n' "$entry" | jq -r '.reasons[0]')" == "identity-or-size-changed" ]] || rc=1
+	print_result "size_drift_downgrades_only_entry" "$rc" \
+		"Expected a late byte change to downgrade the affected entry"
+	return 0
+}
+
+# shellcheck source=../audit-worktree-removal-helper.sh
+source "${SCRIPTS_DIR}/audit-worktree-removal-helper.sh"
+# shellcheck source=../worktree-recovery-lifecycle-helper.sh
+source "${SCRIPTS_DIR}/worktree-recovery-lifecycle-helper.sh"
+# shellcheck source=../worktree-helper-cmds.sh
+source "${SCRIPTS_DIR}/worktree-helper-cmds.sh"
+
+setup
+printf '=== test-worktree-recovery-lifecycle.sh ===\n'
+test_git_state_detects_recovery_data
+test_exact_plan_writes_candidate_without_mutation
+test_plan_output_refuses_unsafe_targets
+test_classification_fails_closed
+test_plan_records_malformed_bucket_unknown
+test_size_drift_downgrades_only_entry
+printf '\nResults: %s run, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -142,7 +142,8 @@ test_exact_plan_writes_candidate_without_mutation() {
 	[[ ! -e "$worktree_path" && -d "$archive_path" ]] || rc=1
 	jq -e --arg archive "$archive_path" '
 		.schema == "aidevops.worktree-recovery-plan/v1" and .producer == "worktree-helper" and
-		.read_only == true and (.source_roots | length == 1) and .entry_count == 1 and
+		.read_only == true and .inventory_complete == true and .inventory_error == null and
+		(.source_roots | length == 1) and .entry_count == 1 and
 		.sized_entry_count == 1 and .unavailable_size_count == 0 and
 		.candidate_count == 1 and .protected_count == 0 and .unknown_count == 0 and
 		(.candidate_bytes > 0) and .candidate_bytes == .expected_allocated_bytes and
@@ -313,6 +314,26 @@ test_size_drift_downgrades_only_entry() {
 	return 0
 }
 
+test_global_inventory_failure_is_explicit() {
+	local plan=""
+	local rc=0
+
+	plan=$(
+		worktree_recovery_inventory() {
+			return 1
+		}
+		worktree_recovery_plan_json "Linux"
+	) || rc=1
+	printf '%s\n' "$plan" | jq -e '
+		.inventory_complete == false and
+		.inventory_error == "classification-unavailable" and
+		.candidate_count == 0 and .entry_count == 0
+	' >/dev/null || rc=1
+	print_result "global_inventory_failure_is_explicit" "$rc" \
+		"Expected a failed global scan to produce no candidates and an explicit error"
+	return 0
+}
+
 # shellcheck source=../audit-worktree-removal-helper.sh
 source "${SCRIPTS_DIR}/audit-worktree-removal-helper.sh"
 # shellcheck source=../worktree-recovery-lifecycle-helper.sh
@@ -328,5 +349,6 @@ test_plan_output_refuses_unsafe_targets
 test_classification_fails_closed
 test_plan_records_malformed_bucket_unknown
 test_size_drift_downgrades_only_entry
+test_global_inventory_failure_is_explicit
 printf '\nResults: %s run, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -88,11 +88,26 @@ install_external_evidence_stub() {
 }
 
 install_clear_evidence_stubs() {
-	_worktree_recovery_plan_git_state() { printf 'clear\n'; return 0; }
-	_worktree_recovery_plan_worktree_reference_state() { printf 'clear\n'; return 0; }
-	_worktree_recovery_plan_registry_state() { printf 'clear\n'; return 0; }
-	_worktree_recovery_plan_claim_state() { printf 'clear\n'; return 0; }
-	_worktree_recovery_plan_process_state() { printf 'clear\n'; return 0; }
+	_worktree_recovery_plan_git_state() {
+		printf 'clear\n'
+		return 0
+	}
+	_worktree_recovery_plan_worktree_reference_state() {
+		printf 'clear\n'
+		return 0
+	}
+	_worktree_recovery_plan_registry_state() {
+		printf 'clear\n'
+		return 0
+	}
+	_worktree_recovery_plan_claim_state() {
+		printf 'clear\n'
+		return 0
+	}
+	_worktree_recovery_plan_process_state() {
+		printf 'clear\n'
+		return 0
+	}
 	install_external_evidence_stub
 	return 0
 }

--- a/.agents/scripts/worktree-helper-cmds.sh
+++ b/.agents/scripts/worktree-helper-cmds.sh
@@ -687,6 +687,9 @@ COMMANDS
   recovery               Read-only inventory of current and legacy recoverable
                          worktree archives. Attributed and unknown buckets remain
                          protected for manual review; this command never deletes.
+  recovery plan --output <absolute-path>
+                         Write an exact read-only cleanup plan. Existing or
+                         symlinked outputs and ambiguous evidence fail closed.
 
   registry [list|prune]  View or prune the ownership registry (t189, t197)
                          list: Show all registered worktrees with ownership info
@@ -765,15 +768,35 @@ EOF
 }
 
 cmd_recovery() {
-	if [[ "$#" -ne 0 ]]; then
-		printf '%s\n' "Usage: worktree-helper.sh recovery" >&2
+	local action="${1:-status}"
+	local output_path=""
+
+	case "$action" in
+	status)
+		[[ "$#" -eq 0 || ("$#" -eq 1 && "$1" == "status") ]] || {
+			printf '%s\n' "Usage: worktree-helper.sh recovery [plan --output <absolute-path>]" >&2
+			return 1
+		}
+		if declare -F worktree_recovery_lifecycle_status >/dev/null 2>&1; then
+			worktree_recovery_lifecycle_status || return 1
+		else
+			worktree_recovery_inventory || return 1
+		fi
+		;;
+	plan)
+		[[ "$#" -eq 3 && "$2" == "--output" ]] || {
+			printf '%s\n' "Usage: worktree-helper.sh recovery plan --output <absolute-path>" >&2
+			return 1
+		}
+		output_path="$3"
+		declare -F worktree_recovery_plan_write >/dev/null 2>&1 || return 1
+		worktree_recovery_plan_write "$output_path" || return 1
+		;;
+	*)
+		printf '%s\n' "Usage: worktree-helper.sh recovery [plan --output <absolute-path>]" >&2
 		return 1
-	fi
-	if declare -F worktree_recovery_lifecycle_status >/dev/null 2>&1; then
-		worktree_recovery_lifecycle_status || return 1
-	else
-		worktree_recovery_inventory || return 1
-	fi
+		;;
+	esac
 	return 0
 }
 

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -21,7 +21,8 @@
 #   status                 Show current worktree info
 #   switch <branch>        Open/create worktree for branch (prints path)
 #   clean [--auto] [--force-merged]  Remove worktrees for merged branches
-#   recovery              Inventory current and legacy recovery archives
+#   recovery [plan --output <absolute-path>]
+#                         Inventory archives or write an exact read-only plan
 #   help                   Show this help
 #
 # Examples:

--- a/.agents/scripts/worktree-recovery-lifecycle-helper.sh
+++ b/.agents/scripts/worktree-recovery-lifecycle-helper.sh
@@ -13,6 +13,11 @@ WORKTREE_RECOVERY_PLAN_SCHEMA="aidevops.worktree-recovery-plan/v1"
 WORKTREE_RECOVERY_PLAN_DISPOSITION_CANDIDATE="candidate"
 WORKTREE_RECOVERY_PLAN_DISPOSITION_PROTECTED="protected"
 WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN="unknown"
+WORKTREE_RECOVERY_PLAN_STATE_ACTIVE="active"
+WORKTREE_RECOVERY_PLAN_STATE_CLEAR="clear"
+WORKTREE_RECOVERY_PLAN_CONFIDENCE_EXACT="exact"
+WORKTREE_RECOVERY_PLAN_JSON_NULL="null"
+WORKTREE_RECOVERY_PRODUCER="worktree-helper"
 
 WORKTREE_RECOVERY_LIFECYCLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 1
 if [[ -f "$WORKTREE_RECOVERY_LIFECYCLE_DIR/shared-constants.sh" ]]; then
@@ -89,10 +94,12 @@ _worktree_recovery_unavailable_json() {
 	local display_path="$2"
 	jq -cn \
 		--arg schema "$WORKTREE_RECOVERY_INVENTORY_SCHEMA" \
+		--arg producer "$WORKTREE_RECOVERY_PRODUCER" \
+		--arg unknown "$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" \
 		--arg confidence "$WORKTREE_RECOVERY_UNAVAILABLE" \
 		--arg error "$error" \
 		--arg path "$display_path" \
-		'{schema:$schema,store_id:"worktree-recovery",producer:"worktree-helper",path:$path,owner:"unknown",safety_class:"recovery",policy:"manual-review; no deletion authority",total_bytes:null,protected_bytes:null,reclaimable_bytes:0,unknown_bytes:null,protection_reasons:["recovery classification or sizing is unavailable"],sizing_confidence:$confidence,next_action:"Restore HOME and run worktree-helper.sh recovery; leave archives untouched",error:$error,root_count:0,bucket_count:0,protected_count:0,reclaimable_count:0,unknown_count:0,buckets:[]}'
+		'{schema:$schema,store_id:"worktree-recovery",producer:$producer,path:$path,owner:$unknown,safety_class:"recovery",policy:"manual-review; no deletion authority",total_bytes:null,protected_bytes:null,reclaimable_bytes:0,unknown_bytes:null,protection_reasons:["recovery classification or sizing is unavailable"],sizing_confidence:$confidence,next_action:"Restore HOME and run worktree-helper.sh recovery; leave archives untouched",error:$error,root_count:0,bucket_count:0,protected_count:0,reclaimable_count:0,unknown_count:0,buckets:[]}'
 	return 0
 }
 
@@ -124,9 +131,10 @@ _worktree_recovery_encode_report() {
 	local unknown_bytes="${11}"
 	local confidence="$WORKTREE_RECOVERY_UNAVAILABLE"
 
-	[[ -n "$report_error" ]] || confidence="exact"
+	[[ -n "$report_error" ]] || confidence="$WORKTREE_RECOVERY_PLAN_CONFIDENCE_EXACT"
 	jq -sc \
 		--arg schema "$WORKTREE_RECOVERY_INVENTORY_SCHEMA" \
+		--arg producer "$WORKTREE_RECOVERY_PRODUCER" \
 		--arg path "$display_path" \
 		--arg owner "$report_owner" \
 		--arg error "$report_error" \
@@ -138,7 +146,7 @@ _worktree_recovery_encode_report() {
 		--argjson total_bytes "$total_bytes" \
 		--argjson protected_bytes "$protected_bytes" \
 		--argjson unknown_bytes "$unknown_bytes" \
-		'{schema:$schema,store_id:"worktree-recovery",producer:"worktree-helper",path:$path,owner:$owner,safety_class:"recovery",policy:"manual-review; v1/v2 compatibility; no deletion authority",total_bytes:$total_bytes,protected_bytes:$protected_bytes,reclaimable_bytes:0,unknown_bytes:$unknown_bytes,protection_reasons:["complete attributable archives remain protected; incomplete, malformed, symlinked, or unrecognised archives remain unknown"],sizing_confidence:$confidence,next_action:"Use worktree-helper.sh recovery for bucket details; no cleanup is available in this phase",error:(if $error == "" then null else $error end),root_count:$root_count,bucket_count:$bucket_count,protected_count:$protected_count,reclaimable_count:0,unknown_count:$unknown_count,archive_formats:["aidevops-worktree-recovery-v1","aidevops-worktree-recovery-v2"],buckets:.}' \
+		'{schema:$schema,store_id:"worktree-recovery",producer:$producer,path:$path,owner:$owner,safety_class:"recovery",policy:"manual-review; v1/v2 compatibility; no deletion authority",total_bytes:$total_bytes,protected_bytes:$protected_bytes,reclaimable_bytes:0,unknown_bytes:$unknown_bytes,protection_reasons:["complete attributable archives remain protected; incomplete, malformed, symlinked, or unrecognised archives remain unknown"],sizing_confidence:$confidence,next_action:"Use worktree-helper.sh recovery for bucket details; no cleanup is available in this phase",error:(if $error == "" then null else $error end),root_count:$root_count,bucket_count:$bucket_count,protected_count:$protected_count,reclaimable_count:0,unknown_count:$unknown_count,archive_formats:["aidevops-worktree-recovery-v1","aidevops-worktree-recovery-v2"],buckets:.}' \
 		"$entries_file"
 	return $?
 }
@@ -165,7 +173,7 @@ worktree_recovery_lifecycle_json() {
 	local jq_status=0
 
 	if [[ -z "$platform" ]]; then
-		platform=$(uname -s 2>/dev/null) || platform="unknown"
+		platform=$(uname -s 2>/dev/null) || platform="$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN"
 	fi
 	display_path=$(_worktree_recovery_display_path "$platform") || return 1
 	if [[ -z "${HOME:-}" ]]; then
@@ -206,7 +214,7 @@ worktree_recovery_lifecycle_json() {
 			bucket_count=$((bucket_count + 1))
 			measured=$(_worktree_recovery_measure_path "$path")
 			IFS='|' read -r bytes confidence measure_error <<<"$measured"
-			if [[ "$bytes" == "null" ]]; then
+			if [[ "$bytes" == "$WORKTREE_RECOVERY_PLAN_JSON_NULL" ]]; then
 				report_error="${measure_error:-sizing-unavailable}"
 				unknown_count=$((unknown_count + 1))
 			else
@@ -348,7 +356,8 @@ _worktree_recovery_plan_identity_json() {
 	local bucket_path="$1"
 	local bucket_real="" archive_path="" recovery_dir="" format=""
 	local source_real="" source_inode="" admin_real="" admin_inode=""
-	local common_real="" head="" branch="" created_at="" producer=""
+	local common_real="" head="" created_at="" producer=""
+	local branch=""
 	local producer_context="" session_id="" source_outcome="legacy-v1"
 	local index_digest="" completion_digest="legacy-marker-absent"
 	local identity_material="" identity_digest=""
@@ -421,7 +430,7 @@ _worktree_recovery_plan_git_state() {
 	elif [[ -s "$status_file" ]]; then
 		printf '%s\n' "dirty"
 	else
-		printf '%s\n' "clear"
+		printf '%s\n' "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR"
 	fi
 	rm -f "$status_file"
 	return 0
@@ -429,7 +438,8 @@ _worktree_recovery_plan_git_state() {
 
 _worktree_recovery_plan_worktree_reference_state() {
 	local identity_json="$1"
-	local archive_path="" source_path="" branch="" listing=""
+	local archive_path="" source_path="" listing=""
+	local branch=""
 	local line=""
 
 	archive_path=$(printf '%s\n' "$identity_json" | jq -r '.archive_path') || return 1
@@ -442,12 +452,12 @@ _worktree_recovery_plan_worktree_reference_state() {
 	while IFS= read -r line; do
 		case "$line" in
 		"worktree $source_path" | "branch $branch")
-			printf '%s\n' "active"
+			printf '%s\n' "$WORKTREE_RECOVERY_PLAN_STATE_ACTIVE"
 			return 0
 			;;
 		esac
 	done <<<"$listing"
-	printf '%s\n' "clear"
+	printf '%s\n' "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR"
 	return 0
 }
 
@@ -457,7 +467,7 @@ _worktree_recovery_plan_registry_state() {
 
 	source_path=$(printf '%s\n' "$identity_json" | jq -r '.source_path') || return 1
 	if [[ ! -e "${WORKTREE_REGISTRY_DB:-}" ]]; then
-		printf '%s\n' "clear"
+		printf '%s\n' "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR"
 		return 0
 	fi
 	if ! command -v sqlite3 >/dev/null 2>&1 || [[ ! -f "$WORKTREE_REGISTRY_DB" || -L "$WORKTREE_REGISTRY_DB" ]]; then
@@ -471,21 +481,22 @@ _worktree_recovery_plan_registry_state() {
 		return 0
 	}
 	case "$owner_count" in
-	0) printf '%s\n' "clear" ;;
+	0) printf '%s\n' "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" ;;
 	*[!0-9]* | '') printf '%s\n' "$WORKTREE_RECOVERY_UNAVAILABLE" ;;
-	*) printf '%s\n' "active" ;;
+	*) printf '%s\n' "$WORKTREE_RECOVERY_PLAN_STATE_ACTIVE" ;;
 	esac
 	return 0
 }
 
 _worktree_recovery_plan_claim_state() {
 	local identity_json="$1"
-	local source_path="" branch="" helper="" claim_rc=0
+	local source_path="" helper="" claim_rc=0
+	local branch=""
 
 	source_path=$(printf '%s\n' "$identity_json" | jq -r '.source_path') || return 1
 	branch=$(printf '%s\n' "$identity_json" | jq -r '.branch') || return 1
 	[[ "$branch" == refs/heads/* ]] || {
-		printf '%s\n' "active"
+		printf '%s\n' "$WORKTREE_RECOVERY_PLAN_STATE_ACTIVE"
 		return 0
 	}
 	if [[ -x "$WORKTREE_RECOVERY_LIFECYCLE_DIR/interactive-session-helper.sh" ]]; then
@@ -499,8 +510,8 @@ _worktree_recovery_plan_claim_state() {
 	"$helper" branch-has-active-claim "${branch#refs/heads/}" --worktree "$source_path" \
 		>/dev/null 2>&1 || claim_rc=$?
 	case "$claim_rc" in
-	0) printf '%s\n' "active" ;;
-	1) printf '%s\n' "clear" ;;
+	0) printf '%s\n' "$WORKTREE_RECOVERY_PLAN_STATE_ACTIVE" ;;
+	1) printf '%s\n' "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" ;;
 	*) printf '%s\n' "$WORKTREE_RECOVERY_UNAVAILABLE" ;;
 	esac
 	return 0
@@ -522,9 +533,9 @@ _worktree_recovery_plan_process_state() {
 	if _worktree_cwd_snapshot_contains_path "$source_path" "$source_path" "$snapshot" ||
 		_worktree_cwd_snapshot_contains_path "$archive_path" "$archive_path" "$snapshot" ||
 		_worktree_cwd_snapshot_contains_path "$bucket_path" "$bucket_path" "$snapshot"; then
-		printf '%s\n' "active"
+		printf '%s\n' "$WORKTREE_RECOVERY_PLAN_STATE_ACTIVE"
 	elif [[ "$snapshot_rc" -eq 0 ]]; then
-		printf '%s\n' "clear"
+		printf '%s\n' "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR"
 	else
 		printf '%s\n' "$WORKTREE_RECOVERY_UNAVAILABLE"
 	fi
@@ -564,7 +575,8 @@ _worktree_recovery_plan_issue_number() {
 
 _worktree_recovery_plan_external_evidence_json() {
 	local identity_json="$1"
-	local archive_path="" branch="" branch_name="" head="" repo_slug=""
+	local archive_path="" branch_name="" head="" repo_slug=""
+	local branch=""
 	local issue_number="" pr_json="" issue_state="" issue_state_normalized=""
 	local open_count="" merged_count=""
 
@@ -573,20 +585,23 @@ _worktree_recovery_plan_external_evidence_json() {
 	head=$(printf '%s\n' "$identity_json" | jq -r '.head') || return 1
 	branch_name="${branch#refs/heads/}"
 	repo_slug=$(_worktree_recovery_plan_repo_slug "$archive_path") || {
-		jq -cn '{commit:"unavailable",open_pr:"unavailable",task:"unavailable",issue_number:null,repo:null}'
+		jq -cn --arg unavailable "$WORKTREE_RECOVERY_UNAVAILABLE" \
+			'{commit:$unavailable,open_pr:$unavailable,task:$unavailable,issue_number:null,repo:null}'
 		return 0
 	}
 	issue_number=$(_worktree_recovery_plan_issue_number "$branch" 2>/dev/null || true)
 	if ! command -v gh >/dev/null 2>&1; then
 		jq -cn --arg repo "$repo_slug" --arg issue "$issue_number" \
-			'{commit:"unavailable",open_pr:"unavailable",task:"unavailable",issue_number:(if $issue == "" then null else $issue end),repo:$repo}'
+			--arg unavailable "$WORKTREE_RECOVERY_UNAVAILABLE" \
+			'{commit:$unavailable,open_pr:$unavailable,task:$unavailable,issue_number:(if $issue == "" then null else $issue end),repo:$repo}'
 		return 0
 	fi
 	if ! pr_json=$(gh pr list --repo "$repo_slug" --head "$branch_name" --state all \
 		--limit 100 --json number,state,mergedAt,headRefOid 2>/dev/null) ||
 		! printf '%s\n' "$pr_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
 		jq -cn --arg repo "$repo_slug" --arg issue "$issue_number" \
-			'{commit:"unavailable",open_pr:"unavailable",task:"unavailable",issue_number:(if $issue == "" then null else $issue end),repo:$repo}'
+			--arg unavailable "$WORKTREE_RECOVERY_UNAVAILABLE" \
+			'{commit:$unavailable,open_pr:$unavailable,task:$unavailable,issue_number:(if $issue == "" then null else $issue end),repo:$repo}'
 		return 0
 	fi
 	open_count=$(printf '%s\n' "$pr_json" | jq '[.[] | select(.state == "OPEN")] | length') || return 1
@@ -601,7 +616,7 @@ _worktree_recovery_plan_external_evidence_json() {
 	issue_state_normalized=$(printf '%s' "$issue_state" | tr '[:upper:]' '[:lower:]') || return 1
 	jq -cn --arg repo "$repo_slug" --arg issue "$issue_number" \
 		--arg commit "$([[ "$merged_count" -gt 0 ]] && printf merged || printf unproven)" \
-		--arg open_pr "$([[ "$open_count" -gt 0 ]] && printf active || printf clear)" \
+		--arg open_pr "$([[ "$open_count" -gt 0 ]] && printf '%s' "$WORKTREE_RECOVERY_PLAN_STATE_ACTIVE" || printf '%s' "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR")" \
 		--arg task "$issue_state_normalized" \
 		'{commit:$commit,open_pr:$open_pr,task:$task,issue_number:(if $issue == "" then null else $issue end),repo:$repo}'
 	return $?
@@ -618,10 +633,12 @@ _worktree_recovery_plan_evidence_json() {
 	claim_state=$(_worktree_recovery_plan_claim_state "$identity_json") || return 1
 	process_state=$(_worktree_recovery_plan_process_state "$identity_json") || return 1
 	external_json=$(_worktree_recovery_plan_external_evidence_json "$identity_json") || return 1
-	printf '%s\n' "$external_json" | jq -e '
+	printf '%s\n' "$external_json" | jq -e \
+		--arg clear "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" \
+		--arg unavailable "$WORKTREE_RECOVERY_UNAVAILABLE" '
 		type == "object" and
-		(.commit | IN("merged","unproven","unavailable")) and
-		(.open_pr | IN("active","clear","unavailable")) and
+		(.commit | IN("merged","unproven",$unavailable)) and
+		(.open_pr | IN("active",$clear,$unavailable)) and
 		(.task | type == "string")
 	' >/dev/null 2>&1 || return 1
 	jq -cn \
@@ -641,23 +658,26 @@ _worktree_recovery_plan_classification_json() {
 		--arg candidate "$WORKTREE_RECOVERY_PLAN_DISPOSITION_CANDIDATE" \
 		--arg protected "$WORKTREE_RECOVERY_PLAN_DISPOSITION_PROTECTED" \
 		--arg unknown "$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" \
+		--arg active "$WORKTREE_RECOVERY_PLAN_STATE_ACTIVE" \
+		--arg clear "$WORKTREE_RECOVERY_PLAN_STATE_CLEAR" \
+		--arg unavailable "$WORKTREE_RECOVERY_UNAVAILABLE" \
 		--argjson identity "$identity_json" --argjson evidence "$evidence_json" \
 		--argjson stable "$stable" '
 		if $stable != true then {disposition:$unknown,reasons:["identity-or-size-changed"]}
 		elif $evidence.git == "dirty" then {disposition:$protected,reasons:["archive-worktree-dirty"]}
-		elif $evidence.worktree == "active" then {disposition:$protected,reasons:["active-git-worktree-reference"]}
-		elif $evidence.registry == "active" then {disposition:$protected,reasons:["active-registry-owner"]}
-		elif $evidence.claim == "active" then {disposition:$protected,reasons:["active-session-claim"]}
-		elif $evidence.process == "active" then {disposition:$protected,reasons:["active-process-reference"]}
-		elif $evidence.external.open_pr == "active" then {disposition:$protected,reasons:["open-pull-request"]}
+		elif $evidence.worktree == $active then {disposition:$protected,reasons:["active-git-worktree-reference"]}
+		elif $evidence.registry == $active then {disposition:$protected,reasons:["active-registry-owner"]}
+		elif $evidence.claim == $active then {disposition:$protected,reasons:["active-session-claim"]}
+		elif $evidence.process == $active then {disposition:$protected,reasons:["active-process-reference"]}
+		elif $evidence.external.open_pr == $active then {disposition:$protected,reasons:["open-pull-request"]}
 		elif $identity.source_removal_outcome != "removed" then {disposition:$protected,reasons:["source-removal-not-complete"]}
 		elif ($identity.branch | startswith("refs/heads/") | not) then {disposition:$protected,reasons:["detached-or-unresolved-branch"]}
 		elif ([ $evidence.git,$evidence.worktree,$evidence.registry,$evidence.claim,$evidence.process,
-			$evidence.external.commit,$evidence.external.open_pr,$evidence.external.task ] | index("unavailable")) != null
+			$evidence.external.commit,$evidence.external.open_pr,$evidence.external.task ] | index($unavailable)) != null
 		then {disposition:$unknown,reasons:["required-evidence-unavailable"]}
 		elif $evidence.external.commit != "merged" then {disposition:$protected,reasons:["exact-commit-not-merged"]}
 		elif $evidence.external.task != "closed" then {disposition:$protected,reasons:["linked-task-not-closed"]}
-		elif ([ $evidence.git,$evidence.worktree,$evidence.registry,$evidence.claim,$evidence.process ] | all(. == "clear"))
+		elif ([ $evidence.git,$evidence.worktree,$evidence.registry,$evidence.claim,$evidence.process ] | all(. == $clear))
 		then {disposition:$candidate,reasons:["all-required-evidence-clear"]}
 		else {disposition:$unknown,reasons:["unrecognised-evidence-state"]}
 		end'
@@ -677,7 +697,8 @@ _worktree_recovery_plan_attributed_entry_json() {
 	identity_after=$(_worktree_recovery_plan_identity_json "$bucket_path") || return 1
 	measured_after=$(_worktree_recovery_measure_path "$bucket_path") || return 1
 	IFS='|' read -r bytes_after confidence_after measure_error_after <<<"$measured_after"
-	if [[ "$identity_before" == "$identity_after" && "$confidence_after" == "exact" &&
+	if [[ "$identity_before" == "$identity_after" &&
+		"$confidence_after" == "$WORKTREE_RECOVERY_PLAN_CONFIDENCE_EXACT" &&
 		"$bytes_after" == "$expected_bytes" ]]; then
 		stable=true
 	fi
@@ -697,8 +718,8 @@ _worktree_recovery_plan_unknown_entry_json() {
 	local reason="$4"
 
 	jq -cn --arg role "$role" --arg path "$bucket_path" --arg reason "$reason" \
-		--argjson bytes "$bytes" \
-		'{role:$role,path:$path,archive_path:null,expected_allocated_bytes:$bytes,identity:null,evidence:null,disposition:"unknown",reasons:[$reason]}'
+		--arg unknown "$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" --argjson bytes "$bytes" \
+		'{role:$role,path:$path,archive_path:null,expected_allocated_bytes:$bytes,identity:null,evidence:null,disposition:$unknown,reasons:[$reason]}'
 	return $?
 }
 
@@ -723,11 +744,12 @@ _worktree_recovery_plan_entries_json() {
 		role=$(printf '%s\n' "$row_json" | jq -r '.role') || result_status=1
 		state=$(printf '%s\n' "$row_json" | jq -r '.state') || result_status=1
 		bucket_path=$(printf '%s\n' "$row_json" | jq -r '.path') || result_status=1
-		bytes=$(printf '%s\n' "$row_json" | jq -r '.bytes // "null"') || result_status=1
+		bytes=$(printf '%s\n' "$row_json" | jq -r --arg null_value "$WORKTREE_RECOVERY_PLAN_JSON_NULL" '.bytes // $null_value') || result_status=1
 		confidence=$(printf '%s\n' "$row_json" | jq -r '.sizing_confidence') || result_status=1
 		[[ "$result_status" -eq 0 ]] || break
 		if [[ "$state" == "attributed" || "$state" == "attributed-legacy" ]]; then
-			if [[ "$bytes" == "null" || "$confidence" != "exact" ]]; then
+			if [[ "$bytes" == "$WORKTREE_RECOVERY_PLAN_JSON_NULL" ||
+				"$confidence" != "$WORKTREE_RECOVERY_PLAN_CONFIDENCE_EXACT" ]]; then
 				entry_json=$(_worktree_recovery_plan_unknown_entry_json \
 					"$role" "$bucket_path" "$bytes" "sizing-unavailable") || result_status=1
 			elif ! entry_json=$(_worktree_recovery_plan_attributed_entry_json \
@@ -758,7 +780,7 @@ worktree_recovery_plan_json() {
 
 	command -v jq >/dev/null 2>&1 || return 1
 	if [[ -z "$platform" ]]; then
-		platform=$(uname -s 2>/dev/null) || platform="unknown"
+		platform=$(uname -s 2>/dev/null) || platform="$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN"
 	fi
 	entries_json=$(_worktree_recovery_plan_entries_json "$platform") || return 1
 	plan_material=$(jq -cn --arg schema "$WORKTREE_RECOVERY_PLAN_SCHEMA" \
@@ -767,20 +789,24 @@ worktree_recovery_plan_json() {
 	generated_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
 	jq -cn --arg schema "$WORKTREE_RECOVERY_PLAN_SCHEMA" \
 		--arg plan_id "sha256:$plan_digest" --arg generated_at "$generated_at" \
+		--arg producer "$WORKTREE_RECOVERY_PRODUCER" \
+		--arg candidate "$WORKTREE_RECOVERY_PLAN_DISPOSITION_CANDIDATE" \
+		--arg protected "$WORKTREE_RECOVERY_PLAN_DISPOSITION_PROTECTED" \
+		--arg unknown "$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" \
 		--argjson entries "$entries_json" '
 		def parent_path: .[0:rindex("/")];
-		{schema:$schema,producer:"worktree-helper",plan_id:$plan_id,generated_at:$generated_at,read_only:true,
+		{schema:$schema,producer:$producer,plan_id:$plan_id,generated_at:$generated_at,read_only:true,
 		source_roots:([$entries[].path | parent_path] | unique),
 		entry_count:($entries | length),
 		sized_entry_count:([$entries[] | select(.expected_allocated_bytes | type == "number")] | length),
 		unavailable_size_count:([$entries[] | select(.expected_allocated_bytes == null)] | length),
 		expected_allocated_bytes:([$entries[].expected_allocated_bytes | numbers] | add // 0),
-		candidate_count:([$entries[] | select(.disposition == "candidate")] | length),
-		candidate_bytes:([$entries[] | select(.disposition == "candidate") | .expected_allocated_bytes] | add // 0),
-		protected_count:([$entries[] | select(.disposition == "protected")] | length),
-		protected_bytes:([$entries[] | select(.disposition == "protected") | .expected_allocated_bytes | numbers] | add // 0),
-		unknown_count:([$entries[] | select(.disposition == "unknown")] | length),
-		unknown_bytes:([$entries[] | select(.disposition == "unknown") | .expected_allocated_bytes | numbers] | add // 0),
+		candidate_count:([$entries[] | select(.disposition == $candidate)] | length),
+		candidate_bytes:([$entries[] | select(.disposition == $candidate) | .expected_allocated_bytes] | add // 0),
+		protected_count:([$entries[] | select(.disposition == $protected)] | length),
+		protected_bytes:([$entries[] | select(.disposition == $protected) | .expected_allocated_bytes | numbers] | add // 0),
+		unknown_count:([$entries[] | select(.disposition == $unknown)] | length),
+		unknown_bytes:([$entries[] | select(.disposition == $unknown) | .expected_allocated_bytes | numbers] | add // 0),
 		entries:$entries}'
 	return $?
 }

--- a/.agents/scripts/worktree-recovery-lifecycle-helper.sh
+++ b/.agents/scripts/worktree-recovery-lifecycle-helper.sh
@@ -9,6 +9,10 @@ _WORKTREE_RECOVERY_LIFECYCLE_HELPER_LOADED=1
 WORKTREE_RECOVERY_INVENTORY_SCHEMA="aidevops.worktree-recovery-inventory/v1"
 WORKTREE_RECOVERY_INVALID_RECORD="invalid-inventory-record"
 WORKTREE_RECOVERY_UNAVAILABLE="unavailable"
+WORKTREE_RECOVERY_PLAN_SCHEMA="aidevops.worktree-recovery-plan/v1"
+WORKTREE_RECOVERY_PLAN_DISPOSITION_CANDIDATE="candidate"
+WORKTREE_RECOVERY_PLAN_DISPOSITION_PROTECTED="protected"
+WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN="unknown"
 
 WORKTREE_RECOVERY_LIFECYCLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 1
 if [[ -f "$WORKTREE_RECOVERY_LIFECYCLE_DIR/shared-constants.sh" ]]; then
@@ -141,7 +145,7 @@ _worktree_recovery_encode_report() {
 
 worktree_recovery_lifecycle_json() {
 	local platform="${1:-}"
-	local display_path="" inventory="" entries_file=""
+	local display_path="" inventory="" entries_file="" raw_record=""
 	local record_type="" store_role="" owner="" state="" path=""
 	local extra_one=""
 	local extra_two=""
@@ -172,7 +176,7 @@ worktree_recovery_lifecycle_json() {
 		printf '{"schema":"%s","error":"jq-unavailable"}\n' "$WORKTREE_RECOVERY_INVENTORY_SCHEMA"
 		return 1
 	fi
-	if ! inventory=$(worktree_recovery_inventory "$platform"); then
+	if ! inventory=$(GIT_OPTIONAL_LOCKS=0 worktree_recovery_inventory "$platform"); then
 		_worktree_recovery_unavailable_json "classification-unavailable" "$display_path"
 		return 0
 	fi
@@ -180,24 +184,26 @@ worktree_recovery_lifecycle_json() {
 		_worktree_recovery_unavailable_json "temporary-file-unavailable" "$display_path"
 		return 0
 	}
-	while IFS=$'\t' read -r record_type store_role owner state path extra_one extra_two; do
+	while IFS= read -r raw_record; do
+		record_type="${raw_record%%$'\t'*}"
+		store_role=""
+		owner=""
+		state=""
+		path=""
+		extra_one=""
+		extra_two=""
 		case "$record_type" in
 		store)
+			IFS=$'\t' read -r record_type store_role owner state path extra_one extra_two <<<"$raw_record"
 			root_count=$((root_count + 1))
 			[[ "$owner" != "joint" ]] || report_owner="joint"
 			if [[ "$extra_one" == "$WORKTREE_RECOVERY_UNAVAILABLE" ]]; then
 				report_error="root-unavailable"
 			fi
-			case "$extra_two" in
-			*$'\t'*) report_error="$WORKTREE_RECOVERY_INVALID_RECORD" ;;
-			esac
 			;;
 		bucket)
+			IFS=$'\t' read -r record_type store_role owner state path <<<"$raw_record"
 			bucket_count=$((bucket_count + 1))
-			if [[ -n "$extra_one" || -n "$extra_two" ]]; then
-				report_error="$WORKTREE_RECOVERY_INVALID_RECORD"
-				continue
-			fi
 			measured=$(_worktree_recovery_measure_path "$path")
 			IFS='|' read -r bytes confidence measure_error <<<"$measured"
 			if [[ "$bytes" == "null" ]]; then
@@ -279,14 +285,556 @@ worktree_recovery_lifecycle_status() {
 	return 0
 }
 
+_worktree_recovery_plan_sha256_text() {
+	local payload="$1"
+	local digest=""
+	if command -v shasum >/dev/null 2>&1; then
+		digest=$(printf '%s' "$payload" | shasum -a 256 2>/dev/null) || return 1
+	elif command -v sha256sum >/dev/null 2>&1; then
+		digest=$(printf '%s' "$payload" | sha256sum 2>/dev/null) || return 1
+	else
+		return 1
+	fi
+	digest="${digest%%[[:space:]]*}"
+	[[ "$digest" =~ ^[0-9a-fA-F]{64}$ ]] || return 1
+	printf '%s\n' "$digest" | tr '[:upper:]' '[:lower:]'
+	return 0
+}
+
+_worktree_recovery_plan_sha256_file() {
+	local file_path="$1"
+	local digest=""
+	[[ -f "$file_path" && ! -L "$file_path" ]] || return 1
+	if command -v shasum >/dev/null 2>&1; then
+		digest=$(shasum -a 256 "$file_path" 2>/dev/null) || return 1
+	elif command -v sha256sum >/dev/null 2>&1; then
+		digest=$(sha256sum "$file_path" 2>/dev/null) || return 1
+	else
+		return 1
+	fi
+	digest="${digest%%[[:space:]]*}"
+	[[ "$digest" =~ ^[0-9a-fA-F]{64}$ ]] || return 1
+	printf '%s\n' "$digest" | tr '[:upper:]' '[:lower:]'
+	return 0
+}
+
+_worktree_recovery_plan_read_line() {
+	local file_path="$1"
+	local value=""
+	[[ -f "$file_path" && ! -L "$file_path" ]] || return 1
+	IFS= read -r value <"$file_path" || return 1
+	_worktree_recovery_line_payload_is_valid "$value" || return 1
+	printf '%s\n' "$value"
+	return 0
+}
+
+_worktree_recovery_plan_archive_path() {
+	local bucket_path="$1"
+	local recovery_dir="${bucket_path}/${_WT_RECOVERY_DIR_NAME}"
+	local recorded_gitdir=""
+	local archive_path=""
+
+	recorded_gitdir=$(_worktree_recovery_plan_read_line "$recovery_dir/admin/gitdir") || return 1
+	case "$recorded_gitdir" in
+	"$bucket_path"/*/.git) archive_path="${recorded_gitdir%/.git}" ;;
+	*) return 1 ;;
+	esac
+	[[ "${archive_path%/*}" == "$bucket_path" ]] || return 1
+	printf '%s\n' "$archive_path"
+	return 0
+}
+
+_worktree_recovery_plan_identity_json() {
+	local bucket_path="$1"
+	local bucket_real="" archive_path="" recovery_dir="" format=""
+	local source_real="" source_inode="" admin_real="" admin_inode=""
+	local common_real="" head="" branch="" created_at="" producer=""
+	local producer_context="" session_id="" source_outcome="legacy-v1"
+	local index_digest="" completion_digest="legacy-marker-absent"
+	local identity_material="" identity_digest=""
+
+	[[ -d "$bucket_path" && ! -L "$bucket_path" ]] || return 1
+	bucket_real=$(cd "$bucket_path" 2>/dev/null && pwd -P) || return 1
+	[[ "$bucket_real" == "$bucket_path" ]] || return 1
+	archive_path=$(_worktree_recovery_plan_archive_path "$bucket_path") || return 1
+	GIT_OPTIONAL_LOCKS=0 _worktree_recovery_archive_is_valid "$archive_path" || return 1
+	recovery_dir="${bucket_path}/${_WT_RECOVERY_DIR_NAME}"
+	format=$(_worktree_recovery_plan_read_line "$recovery_dir/format") || return 1
+	source_real=$(_worktree_recovery_plan_read_line "$recovery_dir/source-real") || return 1
+	source_inode=$(_worktree_recovery_plan_read_line "$recovery_dir/source-inode") || return 1
+	admin_real=$(_worktree_recovery_plan_read_line "$recovery_dir/admin-real") || return 1
+	admin_inode=$(_worktree_recovery_plan_read_line "$recovery_dir/admin-inode") || return 1
+	common_real=$(_worktree_recovery_plan_read_line "$recovery_dir/common-real") || return 1
+	head=$(_worktree_recovery_plan_read_line "$recovery_dir/head") || return 1
+	branch=$(_worktree_recovery_plan_read_line "$recovery_dir/branch") || return 1
+	if [[ "$format" == "$_WT_RECOVERY_FORMAT_V2" ]]; then
+		created_at=$(_worktree_recovery_plan_read_line "$recovery_dir/created-at") || return 1
+		producer=$(_worktree_recovery_plan_read_line "$recovery_dir/producer") || return 1
+		producer_context=$(_worktree_recovery_plan_read_line "$recovery_dir/producer-context") || return 1
+		session_id=$(_worktree_recovery_plan_read_line "$recovery_dir/session-id") || return 1
+		source_outcome=$(_worktree_recovery_plan_read_line "$recovery_dir/source-removal-outcome") || return 1
+	fi
+	index_digest=$(_worktree_recovery_plan_sha256_file "$recovery_dir/admin/index") || return 1
+	if [[ -f "$recovery_dir/${_WT_RECOVERY_COMPLETE_MARKER}" ]]; then
+		completion_digest=$(_worktree_recovery_plan_sha256_file \
+			"$recovery_dir/${_WT_RECOVERY_COMPLETE_MARKER}") || return 1
+	fi
+	identity_material=$(printf '%s\n' \
+		"format=$format" "bucket=$bucket_real" "archive=$archive_path" \
+		"source-real=$source_real" "source-inode=$source_inode" \
+		"admin-real=$admin_real" "admin-inode=$admin_inode" \
+		"common-real=$common_real" "head=$head" "branch=$branch" \
+		"created-at=$created_at" "producer=$producer" \
+		"producer-context=$producer_context" "session-id=$session_id" \
+		"source-outcome=$source_outcome" "index-digest=$index_digest" \
+		"completion-digest=$completion_digest") || return 1
+	identity_digest=$(_worktree_recovery_plan_sha256_text "$identity_material") || return 1
+	jq -cn \
+		--arg bucket_path "$bucket_real" --arg archive_path "$archive_path" \
+		--arg format "$format" --arg identity_digest "sha256:$identity_digest" \
+		--arg source_path "$source_real" --arg source_inode "$source_inode" \
+		--arg admin_path "$admin_real" --arg admin_inode "$admin_inode" \
+		--arg common_path "$common_real" --arg head "$head" --arg branch "$branch" \
+		--arg created_at "$created_at" --arg producer "$producer" \
+		--arg producer_context "$producer_context" --arg session_id "$session_id" \
+		--arg source_outcome "$source_outcome" --arg index_digest "sha256:$index_digest" \
+		--arg completion_digest "$completion_digest" \
+		'{bucket_path:$bucket_path,archive_path:$archive_path,format:$format,identity_digest:$identity_digest,index_digest:$index_digest,completion_digest:(if ($completion_digest | startswith("legacy-")) then $completion_digest else "sha256:" + $completion_digest end),source_path:$source_path,source_inode:$source_inode,admin_path:$admin_path,admin_inode:$admin_inode,common_path:$common_path,head:$head,branch:$branch,created_at:(if $created_at == "" then null else $created_at end),producer:(if $producer == "" then null else $producer end),producer_context:(if $producer_context == "" then null else $producer_context end),session_id:(if $session_id == "" then null else $session_id end),source_removal_outcome:$source_outcome}'
+	return $?
+}
+
+_worktree_recovery_plan_git_state() {
+	local identity_json="$1"
+	local archive_path=""
+	local status_file=""
+	local status_rc=0
+
+	archive_path=$(printf '%s\n' "$identity_json" | jq -r '.archive_path') || return 1
+	status_file=$(mktemp "${AIDEVOPS_TEMP_DIR:-${TMPDIR:-/tmp}}/aidevops-worktree-recovery-status.XXXXXX") || {
+		printf '%s\n' "$WORKTREE_RECOVERY_UNAVAILABLE"
+		return 0
+	}
+	GIT_OPTIONAL_LOCKS=0 git -C "$archive_path" status --porcelain=v1 -z \
+		--untracked-files=all --ignored=matching >"$status_file" 2>/dev/null || status_rc=$?
+	if [[ "$status_rc" -ne 0 ]]; then
+		printf '%s\n' "$WORKTREE_RECOVERY_UNAVAILABLE"
+	elif [[ -s "$status_file" ]]; then
+		printf '%s\n' "dirty"
+	else
+		printf '%s\n' "clear"
+	fi
+	rm -f "$status_file"
+	return 0
+}
+
+_worktree_recovery_plan_worktree_reference_state() {
+	local identity_json="$1"
+	local archive_path="" source_path="" branch="" listing=""
+	local line=""
+
+	archive_path=$(printf '%s\n' "$identity_json" | jq -r '.archive_path') || return 1
+	source_path=$(printf '%s\n' "$identity_json" | jq -r '.source_path') || return 1
+	branch=$(printf '%s\n' "$identity_json" | jq -r '.branch') || return 1
+	if ! listing=$(GIT_OPTIONAL_LOCKS=0 git -C "$archive_path" worktree list --porcelain 2>/dev/null); then
+		printf '%s\n' "$WORKTREE_RECOVERY_UNAVAILABLE"
+		return 0
+	fi
+	while IFS= read -r line; do
+		case "$line" in
+		"worktree $source_path" | "branch $branch")
+			printf '%s\n' "active"
+			return 0
+			;;
+		esac
+	done <<<"$listing"
+	printf '%s\n' "clear"
+	return 0
+}
+
+_worktree_recovery_plan_registry_state() {
+	local identity_json="$1"
+	local source_path="" escaped_path="" owner_count=""
+
+	source_path=$(printf '%s\n' "$identity_json" | jq -r '.source_path') || return 1
+	if [[ ! -e "${WORKTREE_REGISTRY_DB:-}" ]]; then
+		printf '%s\n' "clear"
+		return 0
+	fi
+	if ! command -v sqlite3 >/dev/null 2>&1 || [[ ! -f "$WORKTREE_REGISTRY_DB" || -L "$WORKTREE_REGISTRY_DB" ]]; then
+		printf '%s\n' "$WORKTREE_RECOVERY_UNAVAILABLE"
+		return 0
+	fi
+	escaped_path="${source_path//\'/\'\'}"
+	owner_count=$(sqlite3 "$WORKTREE_REGISTRY_DB" \
+		"SELECT COUNT(*) FROM worktree_owners WHERE worktree_path = '${escaped_path}';" 2>/dev/null) || {
+		printf '%s\n' "$WORKTREE_RECOVERY_UNAVAILABLE"
+		return 0
+	}
+	case "$owner_count" in
+	0) printf '%s\n' "clear" ;;
+	*[!0-9]* | '') printf '%s\n' "$WORKTREE_RECOVERY_UNAVAILABLE" ;;
+	*) printf '%s\n' "active" ;;
+	esac
+	return 0
+}
+
+_worktree_recovery_plan_claim_state() {
+	local identity_json="$1"
+	local source_path="" branch="" helper="" claim_rc=0
+
+	source_path=$(printf '%s\n' "$identity_json" | jq -r '.source_path') || return 1
+	branch=$(printf '%s\n' "$identity_json" | jq -r '.branch') || return 1
+	[[ "$branch" == refs/heads/* ]] || {
+		printf '%s\n' "active"
+		return 0
+	}
+	if [[ -x "$WORKTREE_RECOVERY_LIFECYCLE_DIR/interactive-session-helper.sh" ]]; then
+		helper="$WORKTREE_RECOVERY_LIFECYCLE_DIR/interactive-session-helper.sh"
+	elif [[ -x "${HOME:-}/.aidevops/agents/scripts/interactive-session-helper.sh" ]]; then
+		helper="${HOME}/.aidevops/agents/scripts/interactive-session-helper.sh"
+	else
+		printf '%s\n' "$WORKTREE_RECOVERY_UNAVAILABLE"
+		return 0
+	fi
+	"$helper" branch-has-active-claim "${branch#refs/heads/}" --worktree "$source_path" \
+		>/dev/null 2>&1 || claim_rc=$?
+	case "$claim_rc" in
+	0) printf '%s\n' "active" ;;
+	1) printf '%s\n' "clear" ;;
+	*) printf '%s\n' "$WORKTREE_RECOVERY_UNAVAILABLE" ;;
+	esac
+	return 0
+}
+
+_worktree_recovery_plan_process_state() {
+	local identity_json="$1"
+	local source_path="" archive_path="" bucket_path="" snapshot=""
+	local snapshot_rc=0
+
+	source_path=$(printf '%s\n' "$identity_json" | jq -r '.source_path') || return 1
+	archive_path=$(printf '%s\n' "$identity_json" | jq -r '.archive_path') || return 1
+	bucket_path=$(printf '%s\n' "$identity_json" | jq -r '.bucket_path') || return 1
+	if snapshot=$(capture_worktree_process_cwds); then
+		snapshot_rc=0
+	else
+		snapshot_rc=$?
+	fi
+	if _worktree_cwd_snapshot_contains_path "$source_path" "$source_path" "$snapshot" ||
+		_worktree_cwd_snapshot_contains_path "$archive_path" "$archive_path" "$snapshot" ||
+		_worktree_cwd_snapshot_contains_path "$bucket_path" "$bucket_path" "$snapshot"; then
+		printf '%s\n' "active"
+	elif [[ "$snapshot_rc" -eq 0 ]]; then
+		printf '%s\n' "clear"
+	else
+		printf '%s\n' "$WORKTREE_RECOVERY_UNAVAILABLE"
+	fi
+	return 0
+}
+
+_worktree_recovery_plan_repo_slug() {
+	local archive_path="$1"
+	local remote_url="" repo_slug=""
+
+	remote_url=$(GIT_OPTIONAL_LOCKS=0 git -C "$archive_path" remote get-url origin 2>/dev/null) || return 1
+	case "$remote_url" in
+	https://github.com/*) repo_slug="${remote_url#https://github.com/}" ;;
+	git@github.com:*) repo_slug="${remote_url#git@github.com:}" ;;
+	ssh://git@github.com/*) repo_slug="${remote_url#ssh://git@github.com/}" ;;
+	*) return 1 ;;
+	esac
+	repo_slug="${repo_slug%.git}"
+	[[ "$repo_slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || return 1
+	printf '%s\n' "$repo_slug"
+	return 0
+}
+
+_worktree_recovery_plan_issue_number() {
+	local branch="$1"
+	branch="${branch#refs/heads/}"
+	if [[ "$branch" =~ gh[-]?([0-9]+) ]]; then
+		printf '%s\n' "${BASH_REMATCH[1]}"
+		return 0
+	fi
+	if [[ "$branch" =~ (^|/)fix/([0-9]{3,})([-/]|$) ]]; then
+		printf '%s\n' "${BASH_REMATCH[2]}"
+		return 0
+	fi
+	return 1
+}
+
+_worktree_recovery_plan_external_evidence_json() {
+	local identity_json="$1"
+	local archive_path="" branch="" branch_name="" head="" repo_slug=""
+	local issue_number="" pr_json="" issue_state="" issue_state_normalized=""
+	local open_count="" merged_count=""
+
+	archive_path=$(printf '%s\n' "$identity_json" | jq -r '.archive_path') || return 1
+	branch=$(printf '%s\n' "$identity_json" | jq -r '.branch') || return 1
+	head=$(printf '%s\n' "$identity_json" | jq -r '.head') || return 1
+	branch_name="${branch#refs/heads/}"
+	repo_slug=$(_worktree_recovery_plan_repo_slug "$archive_path") || {
+		jq -cn '{commit:"unavailable",open_pr:"unavailable",task:"unavailable",issue_number:null,repo:null}'
+		return 0
+	}
+	issue_number=$(_worktree_recovery_plan_issue_number "$branch" 2>/dev/null || true)
+	if ! command -v gh >/dev/null 2>&1; then
+		jq -cn --arg repo "$repo_slug" --arg issue "$issue_number" \
+			'{commit:"unavailable",open_pr:"unavailable",task:"unavailable",issue_number:(if $issue == "" then null else $issue end),repo:$repo}'
+		return 0
+	fi
+	if ! pr_json=$(gh pr list --repo "$repo_slug" --head "$branch_name" --state all \
+		--limit 100 --json number,state,mergedAt,headRefOid 2>/dev/null) ||
+		! printf '%s\n' "$pr_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
+		jq -cn --arg repo "$repo_slug" --arg issue "$issue_number" \
+			'{commit:"unavailable",open_pr:"unavailable",task:"unavailable",issue_number:(if $issue == "" then null else $issue end),repo:$repo}'
+		return 0
+	fi
+	open_count=$(printf '%s\n' "$pr_json" | jq '[.[] | select(.state == "OPEN")] | length') || return 1
+	merged_count=$(printf '%s\n' "$pr_json" | jq --arg head "$head" \
+		'[.[] | select(.mergedAt != null and .headRefOid == $head)] | length') || return 1
+	if [[ -n "$issue_number" ]]; then
+		issue_state=$(gh issue view "$issue_number" --repo "$repo_slug" \
+			--json state --jq '.state // empty' 2>/dev/null) || issue_state="$WORKTREE_RECOVERY_UNAVAILABLE"
+	else
+		issue_state="unlinked"
+	fi
+	issue_state_normalized=$(printf '%s' "$issue_state" | tr '[:upper:]' '[:lower:]') || return 1
+	jq -cn --arg repo "$repo_slug" --arg issue "$issue_number" \
+		--arg commit "$([[ "$merged_count" -gt 0 ]] && printf merged || printf unproven)" \
+		--arg open_pr "$([[ "$open_count" -gt 0 ]] && printf active || printf clear)" \
+		--arg task "$issue_state_normalized" \
+		'{commit:$commit,open_pr:$open_pr,task:$task,issue_number:(if $issue == "" then null else $issue end),repo:$repo}'
+	return $?
+}
+
+_worktree_recovery_plan_evidence_json() {
+	local identity_json="$1"
+	local git_state="" worktree_state="" registry_state="" claim_state=""
+	local process_state="" external_json=""
+
+	git_state=$(_worktree_recovery_plan_git_state "$identity_json") || return 1
+	worktree_state=$(_worktree_recovery_plan_worktree_reference_state "$identity_json") || return 1
+	registry_state=$(_worktree_recovery_plan_registry_state "$identity_json") || return 1
+	claim_state=$(_worktree_recovery_plan_claim_state "$identity_json") || return 1
+	process_state=$(_worktree_recovery_plan_process_state "$identity_json") || return 1
+	external_json=$(_worktree_recovery_plan_external_evidence_json "$identity_json") || return 1
+	printf '%s\n' "$external_json" | jq -e '
+		type == "object" and
+		(.commit | IN("merged","unproven","unavailable")) and
+		(.open_pr | IN("active","clear","unavailable")) and
+		(.task | type == "string")
+	' >/dev/null 2>&1 || return 1
+	jq -cn \
+		--arg git "$git_state" --arg worktree "$worktree_state" \
+		--arg registry "$registry_state" --arg claim "$claim_state" \
+		--arg process "$process_state" --argjson external "$external_json" \
+		'{git:$git,worktree:$worktree,registry:$registry,claim:$claim,process:$process,external:$external}'
+	return $?
+}
+
+_worktree_recovery_plan_classification_json() {
+	local identity_json="$1"
+	local evidence_json="$2"
+	local stable="$3"
+
+	jq -cn \
+		--arg candidate "$WORKTREE_RECOVERY_PLAN_DISPOSITION_CANDIDATE" \
+		--arg protected "$WORKTREE_RECOVERY_PLAN_DISPOSITION_PROTECTED" \
+		--arg unknown "$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" \
+		--argjson identity "$identity_json" --argjson evidence "$evidence_json" \
+		--argjson stable "$stable" '
+		if $stable != true then {disposition:$unknown,reasons:["identity-or-size-changed"]}
+		elif $evidence.git == "dirty" then {disposition:$protected,reasons:["archive-worktree-dirty"]}
+		elif $evidence.worktree == "active" then {disposition:$protected,reasons:["active-git-worktree-reference"]}
+		elif $evidence.registry == "active" then {disposition:$protected,reasons:["active-registry-owner"]}
+		elif $evidence.claim == "active" then {disposition:$protected,reasons:["active-session-claim"]}
+		elif $evidence.process == "active" then {disposition:$protected,reasons:["active-process-reference"]}
+		elif $evidence.external.open_pr == "active" then {disposition:$protected,reasons:["open-pull-request"]}
+		elif $identity.source_removal_outcome != "removed" then {disposition:$protected,reasons:["source-removal-not-complete"]}
+		elif ($identity.branch | startswith("refs/heads/") | not) then {disposition:$protected,reasons:["detached-or-unresolved-branch"]}
+		elif ([ $evidence.git,$evidence.worktree,$evidence.registry,$evidence.claim,$evidence.process,
+			$evidence.external.commit,$evidence.external.open_pr,$evidence.external.task ] | index("unavailable")) != null
+		then {disposition:$unknown,reasons:["required-evidence-unavailable"]}
+		elif $evidence.external.commit != "merged" then {disposition:$protected,reasons:["exact-commit-not-merged"]}
+		elif $evidence.external.task != "closed" then {disposition:$protected,reasons:["linked-task-not-closed"]}
+		elif ([ $evidence.git,$evidence.worktree,$evidence.registry,$evidence.claim,$evidence.process ] | all(. == "clear"))
+		then {disposition:$candidate,reasons:["all-required-evidence-clear"]}
+		else {disposition:$unknown,reasons:["unrecognised-evidence-state"]}
+		end'
+	return $?
+}
+
+_worktree_recovery_plan_attributed_entry_json() {
+	local role="$1"
+	local bucket_path="$2"
+	local expected_bytes="$3"
+	local identity_before="" identity_after="" evidence_json="" measured_after=""
+	local bytes_after="" confidence_after="" measure_error_after="" stable=false
+	local classification_json=""
+
+	identity_before=$(_worktree_recovery_plan_identity_json "$bucket_path") || return 1
+	evidence_json=$(_worktree_recovery_plan_evidence_json "$identity_before") || return 1
+	identity_after=$(_worktree_recovery_plan_identity_json "$bucket_path") || return 1
+	measured_after=$(_worktree_recovery_measure_path "$bucket_path") || return 1
+	IFS='|' read -r bytes_after confidence_after measure_error_after <<<"$measured_after"
+	if [[ "$identity_before" == "$identity_after" && "$confidence_after" == "exact" &&
+		"$bytes_after" == "$expected_bytes" ]]; then
+		stable=true
+	fi
+	classification_json=$(_worktree_recovery_plan_classification_json \
+		"$identity_after" "$evidence_json" "$stable") || return 1
+	jq -cn --arg role "$role" --argjson bytes "$expected_bytes" \
+		--argjson identity "$identity_after" --argjson evidence "$evidence_json" \
+		--argjson classification "$classification_json" \
+		'{role:$role,path:$identity.bucket_path,archive_path:$identity.archive_path,expected_allocated_bytes:$bytes,identity:$identity,evidence:$evidence,disposition:$classification.disposition,reasons:$classification.reasons}'
+	return $?
+}
+
+_worktree_recovery_plan_unknown_entry_json() {
+	local role="$1"
+	local bucket_path="$2"
+	local bytes="$3"
+	local reason="$4"
+
+	jq -cn --arg role "$role" --arg path "$bucket_path" --arg reason "$reason" \
+		--argjson bytes "$bytes" \
+		'{role:$role,path:$path,archive_path:null,expected_allocated_bytes:$bytes,identity:null,evidence:null,disposition:"unknown",reasons:[$reason]}'
+	return $?
+}
+
+_worktree_recovery_plan_entries_json() {
+	local platform="$1"
+	local inventory_json="" entries_file="" rows_file="" entry_json=""
+	local row_json="" role="" state="" bucket_path="" bytes="" confidence=""
+	local result_status=0
+
+	inventory_json=$(worktree_recovery_lifecycle_json "$platform") || return 1
+	entries_file=$(mktemp "${AIDEVOPS_TEMP_DIR:-${TMPDIR:-/tmp}}/aidevops-worktree-recovery-plan-entries.XXXXXX") || return 1
+	rows_file=$(mktemp "${AIDEVOPS_TEMP_DIR:-${TMPDIR:-/tmp}}/aidevops-worktree-recovery-plan-rows.XXXXXX") || {
+		rm -f "$entries_file"
+		return 1
+	}
+	if ! printf '%s\n' "$inventory_json" | jq -c '.buckets[]' \
+		>"$rows_file"; then
+		rm -f "$entries_file" "$rows_file"
+		return 1
+	fi
+	while IFS= read -r row_json; do
+		role=$(printf '%s\n' "$row_json" | jq -r '.role') || result_status=1
+		state=$(printf '%s\n' "$row_json" | jq -r '.state') || result_status=1
+		bucket_path=$(printf '%s\n' "$row_json" | jq -r '.path') || result_status=1
+		bytes=$(printf '%s\n' "$row_json" | jq -r '.bytes // "null"') || result_status=1
+		confidence=$(printf '%s\n' "$row_json" | jq -r '.sizing_confidence') || result_status=1
+		[[ "$result_status" -eq 0 ]] || break
+		if [[ "$state" == "attributed" || "$state" == "attributed-legacy" ]]; then
+			if [[ "$bytes" == "null" || "$confidence" != "exact" ]]; then
+				entry_json=$(_worktree_recovery_plan_unknown_entry_json \
+					"$role" "$bucket_path" "$bytes" "sizing-unavailable") || result_status=1
+			elif ! entry_json=$(_worktree_recovery_plan_attributed_entry_json \
+				"$role" "$bucket_path" "$bytes"); then
+				entry_json=$(_worktree_recovery_plan_unknown_entry_json \
+					"$role" "$bucket_path" "$bytes" "classification-unavailable") || result_status=1
+			fi
+		else
+			entry_json=$(_worktree_recovery_plan_unknown_entry_json \
+				"$role" "$bucket_path" "$bytes" "archive-unrecognised-or-incomplete") || result_status=1
+		fi
+		[[ "$result_status" -eq 0 ]] || break
+		printf '%s\n' "$entry_json" >>"$entries_file" || {
+			result_status=1
+			break
+		}
+	done <"$rows_file"
+	if [[ "$result_status" -eq 0 ]]; then
+		jq -sc 'sort_by(.path)' "$entries_file" || result_status=1
+	fi
+	rm -f "$entries_file" "$rows_file"
+	return "$result_status"
+}
+
+worktree_recovery_plan_json() {
+	local platform="${1:-}"
+	local entries_json="" plan_material="" plan_digest="" generated_at=""
+
+	command -v jq >/dev/null 2>&1 || return 1
+	if [[ -z "$platform" ]]; then
+		platform=$(uname -s 2>/dev/null) || platform="unknown"
+	fi
+	entries_json=$(_worktree_recovery_plan_entries_json "$platform") || return 1
+	plan_material=$(jq -cn --arg schema "$WORKTREE_RECOVERY_PLAN_SCHEMA" \
+		--argjson entries "$entries_json" '{schema:$schema,entries:$entries}') || return 1
+	plan_digest=$(_worktree_recovery_plan_sha256_text "$plan_material") || return 1
+	generated_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+	jq -cn --arg schema "$WORKTREE_RECOVERY_PLAN_SCHEMA" \
+		--arg plan_id "sha256:$plan_digest" --arg generated_at "$generated_at" \
+		--argjson entries "$entries_json" '
+		def parent_path: .[0:rindex("/")];
+		{schema:$schema,producer:"worktree-helper",plan_id:$plan_id,generated_at:$generated_at,read_only:true,
+		source_roots:([$entries[].path | parent_path] | unique),
+		entry_count:($entries | length),
+		sized_entry_count:([$entries[] | select(.expected_allocated_bytes | type == "number")] | length),
+		unavailable_size_count:([$entries[] | select(.expected_allocated_bytes == null)] | length),
+		expected_allocated_bytes:([$entries[].expected_allocated_bytes | numbers] | add // 0),
+		candidate_count:([$entries[] | select(.disposition == "candidate")] | length),
+		candidate_bytes:([$entries[] | select(.disposition == "candidate") | .expected_allocated_bytes] | add // 0),
+		protected_count:([$entries[] | select(.disposition == "protected")] | length),
+		protected_bytes:([$entries[] | select(.disposition == "protected") | .expected_allocated_bytes | numbers] | add // 0),
+		unknown_count:([$entries[] | select(.disposition == "unknown")] | length),
+		unknown_bytes:([$entries[] | select(.disposition == "unknown") | .expected_allocated_bytes | numbers] | add // 0),
+		entries:$entries}'
+	return $?
+}
+
+worktree_recovery_plan_write() {
+	local output_path="$1"
+	local parent_path="" parent_real="" base_name="" canonical_output=""
+	local temp_path="" plan_json=""
+	local previous_umask=""
+
+	[[ "$output_path" == /* && "$output_path" != */ ]] || return 1
+	[[ ! -e "$output_path" && ! -L "$output_path" ]] || return 1
+	parent_path="${output_path%/*}"
+	base_name="${output_path##*/}"
+	[[ -n "$parent_path" && -n "$base_name" && -d "$parent_path" && ! -L "$parent_path" ]] || return 1
+	parent_real=$(cd "$parent_path" 2>/dev/null && pwd -P) || return 1
+	[[ -w "$parent_real" ]] || return 1
+	canonical_output="${parent_real}/${base_name}"
+	[[ ! -e "$canonical_output" && ! -L "$canonical_output" ]] || return 1
+	plan_json=$(worktree_recovery_plan_json) || return 1
+	previous_umask=$(umask)
+	umask 077
+	temp_path=$(mktemp "${parent_real}/.${base_name}.tmp.XXXXXX") || {
+		umask "$previous_umask"
+		return 1
+	}
+	umask "$previous_umask"
+	if ! printf '%s\n' "$plan_json" >"$temp_path" || ! chmod 600 "$temp_path" ||
+		! jq -e --arg schema "$WORKTREE_RECOVERY_PLAN_SCHEMA" \
+			'.schema == $schema and .read_only == true' "$temp_path" >/dev/null 2>&1 ||
+		! ln "$temp_path" "$canonical_output" 2>/dev/null; then
+		rm -f "$temp_path"
+		return 1
+	fi
+	rm -f "$temp_path"
+	printf '%s\n' "$output_path"
+	return 0
+}
+
 _worktree_recovery_lifecycle_usage() {
-	printf '%s\n' 'Usage: worktree-recovery-lifecycle-helper.sh [status|json]'
+	printf '%s\n' 'Usage: worktree-recovery-lifecycle-helper.sh [status|json|plan --output <absolute-path>]'
 	return 0
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
 	case "${1:-status}" in
 	json) worktree_recovery_lifecycle_json ;;
+	plan)
+		[[ "$#" -eq 3 && "$2" == "--output" ]] || {
+			_worktree_recovery_lifecycle_usage >&2
+			exit 1
+		}
+		worktree_recovery_plan_write "$3"
+		;;
 	status) worktree_recovery_lifecycle_status ;;
 	help | --help | -h) _worktree_recovery_lifecycle_usage ;;
 	*)

--- a/.agents/scripts/worktree-recovery-lifecycle-helper.sh
+++ b/.agents/scripts/worktree-recovery-lifecycle-helper.sh
@@ -725,11 +725,13 @@ _worktree_recovery_plan_unknown_entry_json() {
 
 _worktree_recovery_plan_entries_json() {
 	local platform="$1"
-	local inventory_json="" entries_file="" rows_file="" entry_json=""
+	local inventory_json="" inventory_error="" entries_file="" rows_file=""
+	local entry_json="" entries_json=""
 	local row_json="" role="" state="" bucket_path="" bytes="" confidence=""
 	local result_status=0
 
 	inventory_json=$(worktree_recovery_lifecycle_json "$platform") || return 1
+	inventory_error=$(printf '%s\n' "$inventory_json" | jq -r '.error // empty') || return 1
 	entries_file=$(mktemp "${AIDEVOPS_TEMP_DIR:-${TMPDIR:-/tmp}}/aidevops-worktree-recovery-plan-entries.XXXXXX") || return 1
 	rows_file=$(mktemp "${AIDEVOPS_TEMP_DIR:-${TMPDIR:-/tmp}}/aidevops-worktree-recovery-plan-rows.XXXXXX") || {
 		rm -f "$entries_file"
@@ -747,7 +749,10 @@ _worktree_recovery_plan_entries_json() {
 		bytes=$(printf '%s\n' "$row_json" | jq -r --arg null_value "$WORKTREE_RECOVERY_PLAN_JSON_NULL" '.bytes // $null_value') || result_status=1
 		confidence=$(printf '%s\n' "$row_json" | jq -r '.sizing_confidence') || result_status=1
 		[[ "$result_status" -eq 0 ]] || break
-		if [[ "$state" == "attributed" || "$state" == "attributed-legacy" ]]; then
+		if [[ -n "$inventory_error" ]]; then
+			entry_json=$(_worktree_recovery_plan_unknown_entry_json \
+				"$role" "$bucket_path" "$bytes" "inventory-report-incomplete") || result_status=1
+		elif [[ "$state" == "attributed" || "$state" == "attributed-legacy" ]]; then
 			if [[ "$bytes" == "$WORKTREE_RECOVERY_PLAN_JSON_NULL" ||
 				"$confidence" != "$WORKTREE_RECOVERY_PLAN_CONFIDENCE_EXACT" ]]; then
 				entry_json=$(_worktree_recovery_plan_unknown_entry_json \
@@ -768,7 +773,11 @@ _worktree_recovery_plan_entries_json() {
 		}
 	done <"$rows_file"
 	if [[ "$result_status" -eq 0 ]]; then
-		jq -sc 'sort_by(.path)' "$entries_file" || result_status=1
+		entries_json=$(jq -sc 'sort_by(.path)' "$entries_file") || result_status=1
+	fi
+	if [[ "$result_status" -eq 0 ]]; then
+		jq -cn --arg error "$inventory_error" --argjson entries "$entries_json" \
+			'{inventory_complete:($error == ""),inventory_error:(if $error == "" then null else $error end),entries:$entries}' || result_status=1
 	fi
 	rm -f "$entries_file" "$rows_file"
 	return "$result_status"
@@ -776,15 +785,21 @@ _worktree_recovery_plan_entries_json() {
 
 worktree_recovery_plan_json() {
 	local platform="${1:-}"
-	local entries_json="" plan_material="" plan_digest="" generated_at=""
+	local entries_bundle="" entries_json="" inventory_complete="" inventory_error=""
+	local plan_material="" plan_digest="" generated_at=""
 
 	command -v jq >/dev/null 2>&1 || return 1
 	if [[ -z "$platform" ]]; then
 		platform=$(uname -s 2>/dev/null) || platform="$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN"
 	fi
-	entries_json=$(_worktree_recovery_plan_entries_json "$platform") || return 1
+	entries_bundle=$(_worktree_recovery_plan_entries_json "$platform") || return 1
+	entries_json=$(printf '%s\n' "$entries_bundle" | jq -c '.entries') || return 1
+	inventory_complete=$(printf '%s\n' "$entries_bundle" | jq -c '.inventory_complete') || return 1
+	inventory_error=$(printf '%s\n' "$entries_bundle" | jq -r '.inventory_error // empty') || return 1
 	plan_material=$(jq -cn --arg schema "$WORKTREE_RECOVERY_PLAN_SCHEMA" \
-		--argjson entries "$entries_json" '{schema:$schema,entries:$entries}') || return 1
+		--arg error "$inventory_error" --argjson complete "$inventory_complete" \
+		--argjson entries "$entries_json" \
+		'{schema:$schema,inventory_complete:$complete,inventory_error:(if $error == "" then null else $error end),entries:$entries}') || return 1
 	plan_digest=$(_worktree_recovery_plan_sha256_text "$plan_material") || return 1
 	generated_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
 	jq -cn --arg schema "$WORKTREE_RECOVERY_PLAN_SCHEMA" \
@@ -793,9 +808,11 @@ worktree_recovery_plan_json() {
 		--arg candidate "$WORKTREE_RECOVERY_PLAN_DISPOSITION_CANDIDATE" \
 		--arg protected "$WORKTREE_RECOVERY_PLAN_DISPOSITION_PROTECTED" \
 		--arg unknown "$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" \
+		--arg error "$inventory_error" --argjson complete "$inventory_complete" \
 		--argjson entries "$entries_json" '
 		def parent_path: .[0:rindex("/")];
 		{schema:$schema,producer:$producer,plan_id:$plan_id,generated_at:$generated_at,read_only:true,
+		inventory_complete:$complete,inventory_error:(if $error == "" then null else $error end),
 		source_roots:([$entries[].path | parent_path] | unique),
 		entry_count:($entries | length),
 		sized_entry_count:([$entries[] | select(.expected_allocated_bytes | type == "number")] | length),


### PR DESCRIPTION
## Summary

- add `worktree-helper.sh recovery plan --output <absolute-path>` with a versioned, deterministic JSON plan envelope
- classify candidate, protected, and unknown archives from exact Git, task, PR, claim, registry, process, identity, and size evidence
- publish plans atomically without replacing existing targets or mutating recovery archives
- add focused clean, dirty, malformed, drift, output-safety, determinism, and global-failure fixtures
- document the plan schema and no-deletion boundary

## Verification

- `bash .agents/scripts/tests/test-worktree-recovery-lifecycle.sh` — 7/7 passed
- `bash .agents/scripts/tests/test-worktree-removal-audit.sh` — 47/47 passed
- `shellcheck .agents/scripts/worktree-recovery-lifecycle-helper.sh .agents/scripts/worktree-helper-cmds.sh .agents/scripts/worktree-helper.sh .agents/scripts/tests/test-worktree-recovery-lifecycle.sh .agents/scripts/tests/test-worktree-removal-audit.sh`
- `.agents/scripts/lint-shell-portability.sh .agents/scripts/worktree-recovery-lifecycle-helper.sh .agents/scripts/worktree-helper-cmds.sh .agents/scripts/worktree-helper.sh .agents/scripts/tests/test-worktree-recovery-lifecycle.sh`
- `.agents/scripts/linters-local.sh --changed`

Resolves #29388
For #29312

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.218 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h 30m and 1,068,906 tokens on this with the user in an interactive session.