### PR TITLE
GH#29413: fix: bootstrap linked worktree JavaScript dependencies

### DIFF
--- a/.agents/hooks/repo-verify-pre-push.sh
+++ b/.agents/hooks/repo-verify-pre-push.sh
@@ -241,6 +241,26 @@ _emit_mentor_fail() {
 	printf '\n' >&2
 }
 
+_typecheck_missing_bun_dev_dependencies() {
+	local log_file="$1"
+	[[ -f "$REPO_ROOT/package.json" && -f "$REPO_ROOT/bun.lock" ]] || return 1
+	[[ ! -x "$REPO_ROOT/node_modules/.bin/tsc" && -f "$log_file" ]] || return 1
+	grep -Eiq '(tsc([^[:alnum:]_]|$).*(command not found|not found)|(command not found|not found).*tsc([^[:alnum:]_]|$))' \
+		"$log_file" 2>/dev/null || return 1
+	return 0
+}
+
+_emit_missing_bun_dev_dependencies() {
+	_log BLOCK "typecheck could not start: missing JavaScript dev dependencies"
+	printf '\n' >&2
+	printf '  Resolution:\n' >&2
+	printf '    1. Run: bun install\n' >&2
+	printf '    2. Re-run: %s\n' "$VERIFY_TYPECHECK" >&2
+	printf '    3. git push (re-runs repo verification)\n' >&2
+	printf '\n' >&2
+	return 0
+}
+
 # ----- main orchestration -------------------------------------------------
 
 main() {
@@ -295,7 +315,11 @@ main() {
 	# Typecheck never auto-fixes — semantic failures need code changes
 	if [[ -n "$VERIFY_TYPECHECK" ]]; then
 		if ! _run_check 'typecheck' "$VERIFY_TYPECHECK"; then
-			_emit_mentor_fail 'typecheck' '' "$VERIFY_TYPECHECK"
+			if _typecheck_missing_bun_dev_dependencies "${LAST_FAIL_LOG:-}"; then
+				_emit_missing_bun_dev_dependencies
+			else
+				_emit_mentor_fail 'typecheck' '' "$VERIFY_TYPECHECK"
+			fi
 			overall=1
 		fi
 	fi

--- a/.agents/scripts/tests/test-repo-verify-pre-push-hook.sh
+++ b/.agents/scripts/tests/test-repo-verify-pre-push-hook.sh
@@ -19,8 +19,9 @@
 #  10. package.json: format:fix script is preferred over format_fix
 #  11. defaults conf: Cargo.toml triggers RUST_CARGO toolchain (cargo fmt --check)
 #  12. typecheck failure NEVER auto-fixes — exit 1 even with AUTOFIX=1
-#  13. Working tree dirty: warn + skip (exit 0)
-#  14. shellcheck on the hook itself
+#  13. Missing bun-installed tsc is diagnosed as missing dev dependencies
+#  14. Working tree dirty: warn + skip (exit 0)
+#  15. shellcheck on the hook itself
 #
 # Tests are hermetic: each scenario builds a temporary git repo and invokes
 # the hook as a subprocess. No network, no live GitHub API, no aidevops state.
@@ -328,7 +329,27 @@ JSON
 	rm -rf "$repo"
 }
 
-# Test 13: dirty working tree → warn + skip
+# Test 13: missing bun-installed tsc → dependency remediation
+{
+	repo=$(_mk_repo)
+	cat >"$repo/.aidevops.json" <<'JSON'
+{ "verify": { "typecheck": "echo 'tsc: command not found' >&2; false" } }
+JSON
+	cat >"$repo/package.json" <<'JSON'
+{ "name": "fixture", "devDependencies": { "typescript": "^5.0.0" } }
+JSON
+	printf '{}\n' >"$repo/bun.lock"
+	(cd "$repo" && /usr/bin/git add . && /usr/bin/git commit -q -m 'add bun typecheck fixture')
+	out=$(_run_hook "$repo" AIDEVOPS_PREPUSH_AUTOFIX=1)
+	ec=$(printf '%s' "$out" | head -n 1)
+	stderr=$(printf '%s' "$out" | tail -n +2)
+	assert_eq '13. missing tsc → exit 1' '1' "$ec"
+	assert_contains '13b. missing tsc → dependency diagnosis' 'missing JavaScript dev dependencies' "$stderr"
+	assert_contains '13c. missing tsc → exact remediation' 'Run: bun install' "$stderr"
+	rm -rf "$repo"
+}
+
+# Test 14: dirty working tree → warn + skip
 {
 	repo=$(_mk_repo)
 	cat >"$repo/.aidevops.json" <<'JSON'
@@ -340,24 +361,24 @@ JSON
 	out=$(_run_hook "$repo")
 	ec=$(printf '%s' "$out" | head -n 1)
 	stderr=$(printf '%s' "$out" | tail -n +2)
-	assert_eq '13. dirty WT → exit 0 (warn + skip)' '0' "$ec"
-	assert_contains '13b. dirty WT → warn message present' 'working tree has uncommitted changes' "$stderr"
+	assert_eq '14. dirty WT → exit 0 (warn + skip)' '0' "$ec"
+	assert_contains '14b. dirty WT → warn message present' 'working tree has uncommitted changes' "$stderr"
 	rm -rf "$repo"
 }
 
-# Test 14: shellcheck on the hook itself (regression — quality gate)
+# Test 15: shellcheck on the hook itself (regression — quality gate)
 {
 	if command -v shellcheck >/dev/null 2>&1; then
 		TESTS_RUN=$((TESTS_RUN + 1))
 		if shellcheck "$HOOK" >/dev/null 2>&1; then
-			printf '%sPASS%s: 14. hook passes shellcheck\n' "$TEST_GREEN" "$TEST_NC"
+			printf '%sPASS%s: 15. hook passes shellcheck\n' "$TEST_GREEN" "$TEST_NC"
 		else
 			TESTS_FAILED=$((TESTS_FAILED + 1))
-			printf '%sFAIL%s: 14. hook fails shellcheck\n' "$TEST_RED" "$TEST_NC"
+			printf '%sFAIL%s: 15. hook fails shellcheck\n' "$TEST_RED" "$TEST_NC"
 			shellcheck "$HOOK" || true
 		fi
 	else
-		printf '%sSKIP%s: 14. shellcheck not installed\n' "$TEST_BLUE" "$TEST_NC"
+		printf '%sSKIP%s: 15. shellcheck not installed\n' "$TEST_BLUE" "$TEST_NC"
 	fi
 }
 

--- a/.agents/scripts/tests/test-worktree-js-dependency-bootstrap.sh
+++ b/.agents/scripts/tests/test-worktree-js-dependency-bootstrap.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+ADD_HELPER="${TEST_DIR}/../worktree-helper-add.sh"
+ROOT=$(mktemp -d)
+trap 'rm -rf "$ROOT"' EXIT
+
+print_info() { return 0; }
+print_success() { return 0; }
+print_warning() {
+	local message="$1"
+	printf '%s\n' "$message" >&2
+	return 0
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$ADD_HELPER")" && pwd)" || exit 1
+# shellcheck source=../worktree-helper-add.sh
+source "$ADD_HELPER"
+
+FAKE_BIN="${ROOT}/bin"
+WORKTREE="${ROOT}/aidevops-worktree"
+ORDINARY="${ROOT}/ordinary-worktree"
+mkdir -p "$FAKE_BIN" "$WORKTREE/.agents/scripts" "$ORDINARY/.agents/scripts"
+cat >"${FAKE_BIN}/bun" <<'BUN'
+#!/usr/bin/env bash
+mkdir -p node_modules/.bin
+printf '#!/usr/bin/env bash\nexit 0\n' >node_modules/.bin/tsc
+chmod +x node_modules/.bin/tsc
+printf '%s\n' "$*" >"${BUN_ARGS_LOG}"
+BUN
+chmod +x "${FAKE_BIN}/bun"
+export PATH="${FAKE_BIN}:${PATH}"
+export BUN_ARGS_LOG="${ROOT}/bun-args.log"
+
+printf '{ "name": "aidevops", "devDependencies": { "typescript": "^5.0.0" } }\n' >"${WORKTREE}/package.json"
+printf '{}\n' >"${WORKTREE}/bun.lock"
+printf '#!/usr/bin/env bash\n' >"${WORKTREE}/aidevops.sh"
+
+_bootstrap_aidevops_worktree_js_deps "$WORKTREE"
+[[ -x "${WORKTREE}/node_modules/.bin/tsc" ]] || {
+	printf 'FAIL aidevops worktree bootstrap did not install tsc\n'
+	exit 1
+}
+[[ "$(cat "$BUN_ARGS_LOG")" == "install --frozen-lockfile" ]] || {
+	printf 'FAIL aidevops worktree bootstrap used unexpected bun arguments\n'
+	exit 1
+}
+printf 'PASS aidevops worktree bootstraps locked JavaScript dev dependencies\n'
+
+rm -f "$BUN_ARGS_LOG"
+printf '{ "name": "ordinary-project", "devDependencies": { "typescript": "^5.0.0" } }\n' >"${ORDINARY}/package.json"
+printf '{}\n' >"${ORDINARY}/bun.lock"
+printf '#!/usr/bin/env bash\n' >"${ORDINARY}/aidevops.sh"
+_bootstrap_aidevops_worktree_js_deps "$ORDINARY"
+[[ ! -e "$BUN_ARGS_LOG" && ! -e "${ORDINARY}/node_modules/.bin/tsc" ]] || {
+	printf 'FAIL ordinary project triggered aidevops dependency bootstrap\n'
+	exit 1
+}
+printf 'PASS ordinary projects do not run implicit bun install\n'

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -36,6 +36,7 @@ _WORKTREE_ADD_LIB_LOADED=1
 : "${WORKTREE_NODE_MODULES_RESTORE_ENABLED:=1}"
 : "${WORKTREE_NODE_MODULES_RESTORE_LOCK_TIMEOUT_S:=2}"
 : "${WORKTREE_NODE_MODULES_RESTORE_MAX_DIRS:=2}"
+: "${AIDEVOPS_WORKTREE_JS_BOOTSTRAP_ENABLED:=1}"
 
 # Defensive SCRIPT_DIR fallback
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
@@ -411,6 +412,40 @@ _restore_worktree_node_modules() {
 		fi
 	done < <(find "$wt_path" -maxdepth 3 -name "package.json" -not -path "*/node_modules/*" 2>/dev/null)
 	_restore_worktree_node_modules_release_lock "$_lock_dir"
+	return 0
+}
+
+# Install the aidevops repository's locked JavaScript dependencies when the
+# canonical checkout could not provide node_modules. Keep this deliberately
+# repo-specific: worktree-helper.sh also creates worktrees for user projects,
+# whose package lifecycle scripts must never run implicitly.
+_bootstrap_aidevops_worktree_js_deps() {
+	local wt_path="$1"
+	local package_file="${wt_path}/package.json"
+
+	[[ "$AIDEVOPS_WORKTREE_JS_BOOTSTRAP_ENABLED" == "1" ]] || return 0
+	[[ -f "$package_file" && -f "${wt_path}/bun.lock" ]] || return 0
+	[[ -f "${wt_path}/aidevops.sh" && -d "${wt_path}/.agents/scripts" ]] || return 0
+	grep -Eq '"name"[[:space:]]*:[[:space:]]*"aidevops"' "$package_file" 2>/dev/null || return 0
+	[[ ! -x "${wt_path}/node_modules/.bin/tsc" ]] || return 0
+
+	if ! command -v bun >/dev/null 2>&1; then
+		print_warning "aidevops JavaScript dev dependencies are missing in ${wt_path}"
+		print_warning "Run: (cd \"${wt_path}\" && bun install)"
+		return 0
+	fi
+
+	print_info "Installing aidevops JavaScript dev dependencies in ${wt_path}..."
+	if (cd "$wt_path" && bun install --frozen-lockfile); then
+		if [[ -x "${wt_path}/node_modules/.bin/tsc" ]]; then
+			print_success "Bootstrapped aidevops JavaScript dev dependencies"
+			return 0
+		fi
+		print_warning "bun install completed but node_modules/.bin/tsc is still missing"
+	else
+		print_warning "Automatic aidevops JavaScript dependency bootstrap failed"
+	fi
+	print_warning "Run: (cd \"${wt_path}\" && bun install)"
 	return 0
 }
 
@@ -1215,6 +1250,7 @@ cmd_add() {
 	local _repo_root=""
 	_repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || _repo_root=""
 	_restore_worktree_node_modules "$path" "$_repo_root"
+	_bootstrap_aidevops_worktree_js_deps "$path"
 
 	# t2885: exclude the new worktree from macOS Spotlight + Time Machine.
 	# Worktrees are ephemeral — persistent state lives on the git remote.


### PR DESCRIPTION
## Summary

Bootstrap locked JavaScript dev dependencies for fresh aidevops worktrees and diagnose missing bun-installed tsc distinctly during pre-push verification.

## Files Changed

.agents/hooks/repo-verify-pre-push.sh, .agents/scripts/tests/test-repo-verify-pre-push-hook.sh, .agents/scripts/tests/test-worktree-js-dependency-bootstrap.sh, .agents/scripts/worktree-helper-add.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-worktree-js-dependency-bootstrap.sh; bash .agents/scripts/tests/test-repo-verify-pre-push-hook.sh; bash .agents/scripts/tests/test-worktree-fresh-base.sh; bash .agents/scripts/tests/test-pre-edit-check.sh; shellcheck and bash -n on changed shell files; bun run typecheck

Resolves #29413


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.218 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 9m and 112,823 tokens on this as a headless worker.