### PR TITLE
GH#29415: Gate Linux systemd and scheduler regressions in CI

### DIFF
--- a/.agents/scripts/tests/test-systemd-unit-generation.sh
+++ b/.agents/scripts/tests/test-systemd-unit-generation.sh
@@ -148,13 +148,18 @@ WantedBy=multi-user.target
 	return 0
 }
 
-test_real_scheduler_unit_uses_control_group() {
+test_real_scheduler_units_verify() {
 	local tmpdir=""
 	local service_name="aidevops-killmode-test-$$"
 	local service_file=""
-	local kill_mode=""
+	local timer_file=""
+	local service_text=""
+	local timer_text=""
+	local verify_output=""
+	local rc=0
 	tmpdir=$(mktemp -d)
 	service_file="${tmpdir}/home/.config/systemd/user/${service_name}.service"
+	timer_file="${tmpdir}/home/.config/systemd/user/${service_name}.timer"
 	mkdir -p "${tmpdir}/bin" "${tmpdir}/home"
 	printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"${tmpdir}/bin/systemctl"
 	chmod +x "${tmpdir}/bin/systemctl"
@@ -165,15 +170,33 @@ test_real_scheduler_unit_uses_control_group() {
 		_install_scheduler_systemd "$service_name" "true" "60" \
 			"${tmpdir}/scheduler.log" "" "false" "false" "" "60" >/dev/null 2>&1 || true
 	)
-	kill_mode=$(grep -E '^KillMode=' "$service_file" 2>/dev/null || true)
-	rm -rf "$tmpdir"
 
-	if [[ "$kill_mode" == "KillMode=control-group" ]]; then
-		print_result "real shared scheduler unit uses control-group cleanup" 0
+	if [[ ! -f "$service_file" || ! -f "$timer_file" ]]; then
+		rc=1
 	else
-		print_result "real shared scheduler unit uses control-group cleanup" 1 \
-			"Expected KillMode=control-group, got: ${kill_mode:-missing}"
+		service_text=$(<"$service_file")
+		timer_text=$(<"$timer_file")
+		[[ "$service_text" == *"KillMode=control-group"* ]] || rc=1
+		[[ "$service_text" == *"ExecStart=/bin/bash -lc"* ]] || rc=1
+		[[ "$timer_text" == *"OnUnitActiveSec=60"* ]] || rc=1
+		[[ "$timer_text" == *"Persistent=true"* ]] || rc=1
+
+		if command -v systemd-analyze >/dev/null 2>&1; then
+			if ! verify_output=$(systemd-analyze verify "$service_file" "$timer_file" 2>&1); then
+				rc=1
+			fi
+		else
+			verify_output="systemd-analyze unavailable; static unit assertions used"
+		fi
 	fi
+
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "real shared scheduler service and timer verify" 0
+	else
+		print_result "real shared scheduler service and timer verify" 1 \
+			"service=${service_file}: ${service_text//$'\n'/ | }; timer=${timer_file}: ${timer_text//$'\n'/ | }; verify=${verify_output:-not run}"
+	fi
+	rm -rf "$tmpdir"
 	return 0
 }
 
@@ -587,7 +610,7 @@ test_cleanup_transient_failure_falls_back_once() {
 
 main() {
 	printf 'Running systemd unit generation tests...\n\n'
-	test_real_scheduler_unit_uses_control_group
+	test_real_scheduler_units_verify
 	test_standalone_templates_use_control_group
 
 	if systemd_analyze_available; then

--- a/.github/workflows/linux-systemd-smoke.yml
+++ b/.github/workflows/linux-systemd-smoke.yml
@@ -1,0 +1,46 @@
+name: Linux systemd smoke
+
+on:
+  push:
+    branches: [ main, develop ]
+    paths:
+      - '.agents/scripts/**'
+      - '.github/workflows/linux-systemd-smoke.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.agents/scripts/**'
+      - '.github/workflows/linux-systemd-smoke.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  linux-systemd-smoke:
+    name: Linux systemd smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Linux systemd smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tests=(
+            .agents/scripts/tests/test-systemd-unit-generation.sh
+            .agents/scripts/tests/test-routine-systemd-calendar.sh
+            .agents/scripts/tests/test-scheduler-dedup-linux.sh
+          )
+
+          for test_script in "${tests[@]}"; do
+            printf '\n==> %s\n' "$test_script"
+            if ! bash "$test_script"; then
+              printf '::error file=%s::Linux systemd smoke failed: %s\n' \
+                "$test_script" "$test_script"
+              exit 1
+            fi
+          done


### PR DESCRIPTION
## Summary

Add a low-cost Ubuntu systemd smoke workflow and validate generated scheduler service/timer units with systemd-analyze plus static fallbacks

## Files Changed

.agents/scripts/tests/test-systemd-unit-generation.sh, .github/workflows/linux-systemd-smoke.yml

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — shellcheck .agents/scripts/tests/test-systemd-unit-generation.sh; bash .agents/scripts/tests/test-systemd-unit-generation.sh; bash .agents/scripts/tests/test-routine-systemd-calendar.sh; bash .agents/scripts/tests/test-scheduler-dedup-linux.sh; pre-commit workflow YAML validation

Resolves #29415


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.218 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 5m and 93,382 tokens on this as a headless worker.