### PR TITLE
GH#29416: feat: require platform fix regression evidence

### DIFF
--- a/.agents/reference/bash-compat.md
+++ b/.agents/reference/bash-compat.md
@@ -62,6 +62,11 @@ Regression pattern: a fix for one axis breaks the other. Recent production failu
 
 **Test both platforms before merging.** ShellCheck catches neither axis — manual review and regression tests required.
 
+CI also runs `.agents/scripts/platform-fix-regression-evidence.sh`: PRs that
+claim Linux/macOS or coreutils portability fixes must update a targeted test or
+include a substantive `## Regression Evidence` rationale. Documentation-only
+changes are exempt; see `todo/plans/shell-portability-hardening.md` for context.
+
 ## Bash 3.2 Compatibility (macOS default shell)
 
 macOS ships bash 3.2.57. All shell scripts MUST work on this version.

--- a/.agents/scripts/platform-fix-regression-evidence.sh
+++ b/.agents/scripts/platform-fix-regression-evidence.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Validate regression evidence for PRs that claim platform-specific fixes.
+
+set -euo pipefail
+
+_platform_evidence_usage() {
+	cat <<'EOF'
+Usage: platform-fix-regression-evidence.sh --title TITLE --body-file FILE --files-file FILE
+
+The files file must contain one changed path per line.
+EOF
+	return 0
+}
+
+_platform_evidence_die() {
+	local message="$1"
+	printf 'platform regression evidence: %s\n' "$message" >&2
+	return 1
+}
+
+_platform_fix_triggered() {
+	local metadata="$1"
+	printf '%s\n' "$metadata" | grep -qiE '(^|[^[:alnum:]_])(linux|ubuntu|systemd|cron|macos|darwin|bash[[:space:]]+3[.]2|portability|coreutils|mktemp|stat|readlink|getent)([^[:alnum:]_]|$)'
+	return $?
+}
+
+_platform_changed_test() {
+	local files_file="$1"
+	local path=""
+	while IFS= read -r path; do
+		case "$path" in
+		.agents/scripts/tests/*)
+			printf '%s\n' "$path"
+			return 0
+			;;
+		esac
+	done <"$files_file"
+	return 1
+}
+
+_platform_docs_only() {
+	local files_file="$1"
+	local path=""
+	local saw_path=0
+	while IFS= read -r path; do
+		[[ -z "$path" ]] && continue
+		saw_path=1
+		case "$path" in
+		*.md | *.mdx | *.rst | docs/* | todo/*) ;;
+		*) return 1 ;;
+		esac
+	done <"$files_file"
+	[[ "$saw_path" -eq 1 ]] || return 1
+	return 0
+}
+
+_platform_has_regression_evidence() {
+	local body_file="$1"
+	local line=""
+	local in_section=0
+	local rationale=""
+	local normalized=""
+
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		if printf '%s\n' "$line" | grep -qiE '^[[:space:]]*#{1,6}[[:space:]]+Regression[[:space:]]+Evidence[[:space:]]*:?[[:space:]]*$'; then
+			in_section=1
+			continue
+		fi
+		if [[ "$in_section" -eq 1 ]] && printf '%s\n' "$line" | grep -qE '^[[:space:]]*#{1,6}[[:space:]]+'; then
+			break
+		fi
+		if [[ "$in_section" -eq 1 ]] && [[ -n "${line//[[:space:]]/}" ]]; then
+			case "$line" in
+			'<!--'*'-->') ;;
+			*) rationale="${rationale} ${line}" ;;
+			esac
+		fi
+	done <"$body_file"
+
+	normalized=$(printf '%s' "$rationale" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]`*_.,:;-')
+	case "$normalized" in
+	"" | n/a | na | none | tbd | todo) return 1 ;;
+	esac
+	[[ "${#rationale}" -ge 20 ]] || return 1
+	return 0
+}
+
+main() {
+	local -a args=("$@")
+	local title=""
+	local body_file=""
+	local files_file=""
+	local body=""
+	local changed_test=""
+	local arg=""
+	local arg_count="${#args[@]}"
+	local index=0
+
+	while [[ "$index" -lt "$arg_count" ]]; do
+		arg="${args[$index]}"
+		case "$arg" in
+		--title)
+			((index += 1))
+			[[ "$index" -lt "$arg_count" ]] || {
+				_platform_evidence_die '--title requires a value'
+				return 1
+			}
+			title="${args[$index]}"
+			;;
+		--body-file)
+			((index += 1))
+			[[ "$index" -lt "$arg_count" ]] || {
+				_platform_evidence_die '--body-file requires a value'
+				return 1
+			}
+			body_file="${args[$index]}"
+			;;
+		--files-file)
+			((index += 1))
+			[[ "$index" -lt "$arg_count" ]] || {
+				_platform_evidence_die '--files-file requires a value'
+				return 1
+			}
+			files_file="${args[$index]}"
+			;;
+		-h | --help)
+			_platform_evidence_usage
+			return 0
+			;;
+		*)
+			_platform_evidence_die "unknown argument: $arg"
+			return 1
+			;;
+		esac
+		((index += 1))
+	done
+
+	[[ -n "$title" ]] || {
+		_platform_evidence_die '--title is required'
+		return 1
+	}
+	[[ -r "$body_file" ]] || {
+		_platform_evidence_die 'body file is missing or unreadable'
+		return 1
+	}
+	[[ -r "$files_file" ]] || {
+		_platform_evidence_die 'changed-files file is missing or unreadable'
+		return 1
+	}
+
+	body=$(<"$body_file")
+	if ! _platform_fix_triggered "${title}"$'\n'"${body}"; then
+		printf 'platform regression evidence: not required (no platform-fix terms)\n'
+		return 0
+	fi
+	if _platform_docs_only "$files_file"; then
+		printf 'platform regression evidence: not required (docs-only changes)\n'
+		return 0
+	fi
+	if changed_test=$(_platform_changed_test "$files_file"); then
+		printf 'platform regression evidence: passed (changed %s)\n' "$changed_test"
+		return 0
+	fi
+	if _platform_has_regression_evidence "$body_file"; then
+		printf 'platform regression evidence: passed (PR rationale supplied)\n'
+		return 0
+	fi
+
+	printf '%s\n' '::error::Platform-fix PRs must change a test under .agents/scripts/tests/ or include a non-empty "## Regression Evidence" rationale explaining why automated regression is not possible.' >&2
+	printf '%s\n' 'See .agents/reference/bash-compat.md and todo/plans/shell-portability-hardening.md.' >&2
+	return 1
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-platform-fix-regression-evidence.sh
+++ b/.agents/scripts/tests/test-platform-fix-regression-evidence.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../platform-fix-regression-evidence.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/platform-regression-evidence.XXXXXX")"
+
+cleanup() {
+	local test_root="$TEST_ROOT"
+	rm -rf "$test_root"
+	return 0
+}
+trap cleanup EXIT
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	exit 1
+	return 1
+}
+
+assert_contains() {
+	local value="$1"
+	local expected="$2"
+	local label="$3"
+	[[ "$value" == *"$expected"* ]] || fail "${label}: missing ${expected}"
+	return 0
+}
+
+run_pass_case() {
+	local label="$1"
+	local title="$2"
+	local body="$3"
+	local files="$4"
+	local output=""
+	printf '%s\n' "$body" >"${TEST_ROOT}/body.md"
+	printf '%s\n' "$files" >"${TEST_ROOT}/files.txt"
+	if ! output=$("$HELPER" --title "$title" --body-file "${TEST_ROOT}/body.md" --files-file "${TEST_ROOT}/files.txt" 2>&1); then
+		fail "${label}: expected pass, got ${output}"
+	fi
+	assert_contains "$output" 'platform regression evidence:' "$label"
+	return 0
+}
+
+run_fail_case() {
+	local label="$1"
+	local title="$2"
+	local body="$3"
+	local files="$4"
+	local output=""
+	printf '%s\n' "$body" >"${TEST_ROOT}/body.md"
+	printf '%s\n' "$files" >"${TEST_ROOT}/files.txt"
+	if output=$("$HELPER" --title "$title" --body-file "${TEST_ROOT}/body.md" --files-file "${TEST_ROOT}/files.txt" 2>&1); then
+		fail "${label}: expected failure, got ${output}"
+	fi
+	assert_contains "$output" 'must change a test under .agents/scripts/tests/' "$label"
+	return 0
+}
+
+run_pass_case \
+	'no trigger' \
+	'Improve status statistics reporting' \
+	'No platform-specific behavior changes.' \
+	'.agents/scripts/stats-helper.sh'
+
+run_pass_case \
+	'trigger with test change' \
+	'Fix Linux stat portability' \
+	'Use the portable file timestamp wrapper.' \
+	$'.agents/scripts/file-helper.sh\n.agents/scripts/tests/test-file-helper.sh'
+
+run_pass_case \
+	'trigger with evidence section' \
+	'Handle getent fallback on macOS' \
+	$'## Regression Evidence\nAutomated coverage is not possible because this branch requires a managed directory service.' \
+	'.agents/scripts/account-helper.sh'
+
+run_fail_case \
+	'trigger without evidence' \
+	'Fix systemd cron behavior on Ubuntu' \
+	'Correct the generated service.' \
+	'.agents/scripts/schedulers.sh'
+
+run_fail_case \
+	'placeholder evidence' \
+	'Improve Bash 3.2 portability' \
+	$'## Regression Evidence\nTBD' \
+	'.agents/scripts/compat-helper.sh'
+
+run_pass_case \
+	'docs-only false positive' \
+	'Document Linux portability guidance' \
+	'Clarify the supported platforms.' \
+	$'.agents/reference/bash-compat.md\ntodo/plans/shell-portability-hardening.md'
+
+printf 'PASS platform-fix regression evidence policy cases\n'

--- a/.github/workflows/platform-fix-regression-evidence.yml
+++ b/.github/workflows/platform-fix-regression-evidence.yml
@@ -1,0 +1,39 @@
+name: Platform Fix Regression Evidence
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  regression-evidence:
+    name: Platform Fix Regression Evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Check out pull request
+        uses: actions/checkout@v4
+
+      - name: Collect pull request metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          printf '%s\n' "$PR_BODY" > "$RUNNER_TEMP/pr-body.md"
+          gh api --paginate \
+            "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
+            --jq '.[].filename' > "$RUNNER_TEMP/pr-files.txt"
+
+      - name: Require regression evidence for platform fixes
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          bash .agents/scripts/platform-fix-regression-evidence.sh \
+            --title "$PR_TITLE" \
+            --body-file "$RUNNER_TEMP/pr-body.md" \
+            --files-file "$RUNNER_TEMP/pr-files.txt"


### PR DESCRIPTION
## Summary

Add a diff-scoped policy helper and pull-request gate that require targeted test changes or a substantive Regression Evidence rationale for claimed platform fixes, while exempting unrelated and docs-only changes.

## Files Changed

.agents/reference/bash-compat.md, .agents/scripts/platform-fix-regression-evidence.sh, .agents/scripts/tests/test-platform-fix-regression-evidence.sh, .github/workflows/platform-fix-regression-evidence.yml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-platform-fix-regression-evidence.sh; bash -n and shellcheck for the new helper and tests; staged workflow YAML validation via pre-commit hook

Resolves #29416


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.218 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 6m and 103,741 tokens on this as a headless worker.