### PR TITLE
t18191: Separate task ID hook and transport timeouts

### DIFF
--- a/.agents/scripts/claim-task-id-counter.sh
+++ b/.agents/scripts/claim-task-id-counter.sh
@@ -253,6 +253,60 @@ _run_git_with_ssh_fallback() {
 	return $rc
 }
 
+# Run the pre-push hook once, outside the remote transport timeout. Git normally
+# includes hook execution in the `git push` process, which caused a valid but
+# slow repo-verify gate to exhaust CAS_HTTPS_TIMEOUT_S and be misreported as
+# retriable contention (GH#29417). The subsequent push uses --no-verify.
+# Args: $1 local commit SHA, $2 expected remote commit SHA.
+# Returns: 0 when no hook exists or it passes; 1 on remote lookup, hook timeout,
+# or hook failure. Diagnostics identify the phase and elapsed time.
+_cas_run_pre_push_hook() {
+	local local_sha="$1"
+	local remote_sha="$2"
+	local remote_ref="refs/heads/${COUNTER_BRANCH}"
+	local started_at=""
+	local finished_at=""
+	local elapsed=0
+	local remote_url=""
+	local hook_path=""
+	local hook_rc=0
+
+	started_at=$(date +%s)
+	remote_url=$(git remote get-url "$REMOTE_NAME" 2>/dev/null) || {
+		finished_at=$(date +%s)
+		elapsed=$((finished_at - started_at))
+		log_error "CAS remote configuration validation failed after ${elapsed}s for remote ${REMOTE_NAME}"
+		return 1
+	}
+	finished_at=$(date +%s)
+	elapsed=$((finished_at - started_at))
+	log_info "CAS remote configuration validated in ${elapsed}s"
+
+	hook_path=$(git rev-parse --git-path hooks/pre-push 2>/dev/null) || {
+		log_error "Could not resolve the pre-push hook path"
+		return 1
+	}
+	[[ -x "$hook_path" ]] || return 0
+
+	started_at=$(date +%s)
+	timeout_sec "${CAS_HOOK_TIMEOUT_S:-300}" "$hook_path" "$REMOTE_NAME" "$remote_url" \
+		<<<"${local_sha} ${local_sha} ${remote_ref} ${remote_sha}" >/dev/null || hook_rc=$?
+	finished_at=$(date +%s)
+	elapsed=$((finished_at - started_at))
+
+	if [[ $hook_rc -eq 124 ]]; then
+		log_error "Pre-push hook timed out after ${elapsed}s (limit=${CAS_HOOK_TIMEOUT_S:-300}s); remote push was not attempted"
+		return 1
+	fi
+	if [[ $hook_rc -ne 0 ]]; then
+		log_error "Pre-push hook failed after ${elapsed}s with rc=${hook_rc}; remote push was not attempted"
+		return 1
+	fi
+
+	log_info "Pre-push hook completed in ${elapsed}s (limit=${CAS_HOOK_TIMEOUT_S:-300}s)"
+	return 0
+}
+
 # Prefer the conventional dedicated branch when neither CLI nor project config
 # selected a counter branch. The candidate is accepted only when its counter is
 # at least the default-branch counter and the TODO-derived seed, preventing an
@@ -400,6 +454,22 @@ _cas_push_rejection_is_protected_branch() {
 		return 0
 	fi
 	return 1
+}
+
+# Detect an actual compare-and-swap race. Only these failures are retriable;
+# transport, authentication, hook, and provider-policy failures are hard errors.
+_cas_push_rejection_is_non_fast_forward() {
+	local push_stderr="$1"
+	printf '%s\n' "$push_stderr" | grep -Eiq \
+		'non-fast-forward|\(fetch first\)|stale info|remote ref updated since checkout'
+	return $?
+}
+
+_cas_push_rejection_is_auth_failure() {
+	local push_stderr="$1"
+	printf '%s\n' "$push_stderr" | grep -Eiq \
+		'authentication failed|could not read Username|permission denied \(publickey\)|http[^[:space:]]* 40[13]|repository not found'
+	return $?
 }
 
 # Emit protected-branch guidance without exposing full remote URLs or stderr.
@@ -1006,24 +1076,26 @@ _cas_build_and_push() {
 	# into the captured result and poisons downstream arithmetic parsing.
 	# Hook stderr stays visible for error diagnosis.
 	#
-	# GH#21904: wrap with `timeout_sec` + SSH fallback so an HTTPS credential-
-	# helper hang (osxkeychain etc.) cannot stall the push.  The SSH fallback
-	# returns the same exit codes as a direct push, so the conflict (rc=1)
-	# vs success (rc=0) handling below is unchanged.
+	# GH#21904: wrap remote transport with `timeout_sec` + SSH fallback so an
+	# HTTPS credential-helper hang cannot stall the push. GH#29417 runs the hook
+	# first with its own budget, then skips Git's duplicate hook invocation.
 	local push_rc=0
 	local push_stderr=""
 	local push_err_file=""
+	if ! _cas_run_pre_push_hook "$commit_sha" "$pinned_sha"; then
+		return 1
+	fi
 	push_err_file=$(mktemp "${TMPDIR:-/tmp}/claim-task-id-push.XXXXXX" 2>/dev/null) || push_err_file=""
 	if [[ -n "$push_err_file" ]]; then
 		_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
 			-c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
-			push -q "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}" >/dev/null 2>"$push_err_file" || push_rc=$?
+			push --no-verify -q "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}" >/dev/null 2>"$push_err_file" || push_rc=$?
 		push_stderr=$(<"$push_err_file")
 		rm -f "$push_err_file" 2>/dev/null || true
 	else
 		_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
 			-c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
-			push -q "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}" >/dev/null || push_rc=$?
+			push --no-verify -q "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}" >/dev/null || push_rc=$?
 	fi
 	if [[ $push_rc -ne 0 ]]; then
 		if _cas_push_rejection_is_protected_branch "$push_stderr"; then
@@ -1031,14 +1103,22 @@ _cas_build_and_push() {
 			return "$CAS_PROTECTED_BRANCH_RC"
 		fi
 		if [[ $push_rc -eq 124 ]]; then
-			log_warn "Push timed out (HTTPS + SSH fallback both unavailable) — treating as retriable conflict"
-		else
-			log_warn "Push failed (conflict — another session claimed an ID)"
+			log_error "Push transport/authentication timed out after ${CAS_HTTPS_TIMEOUT_S:-30}s; CAS update was not retried as contention"
+			return 1
 		fi
-		_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
-			-c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
-			fetch -q "$REMOTE_NAME" "$COUNTER_BRANCH" >/dev/null || true
-		return 2
+		if _cas_push_rejection_is_auth_failure "$push_stderr"; then
+			log_error "Push authentication failed; verify credentials for remote ${REMOTE_NAME}"
+			return 1
+		fi
+		if _cas_push_rejection_is_non_fast_forward "$push_stderr"; then
+			log_warn "Push failed (conflict — another session claimed an ID)"
+			_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
+				-c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
+				fetch -q "$REMOTE_NAME" "$COUNTER_BRANCH" >/dev/null || true
+			return 2
+		fi
+		log_error "Push failed with rc=${push_rc} before the CAS update; failure is not a retriable conflict"
+		return 1
 	fi
 
 	_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \

--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -156,14 +156,18 @@ CAS_WALL_TIMEOUT_S=${CAS_WALL_TIMEOUT_S:-30}
 # Per-git-command timeout (seconds).  Wraps git fetch/push in the CAS path
 # to prevent indefinite hangs on index.lock contention or network stalls.
 CAS_GIT_CMD_TIMEOUT_S=${CAS_GIT_CMD_TIMEOUT_S:-10}
-# GH#21904: wall-clock timeout for each individual `git fetch`/`git push` call
-# in the CAS path.  Wraps the call with `timeout_sec` so credential-helper
-# hangs (osxkeychain, libsecret, manager-core) cannot stall a session past
-# this budget.  Distinct from CAS_GIT_CMD_TIMEOUT_S which only sets git's
-# `http.lowSpeedTime` (transport-level, fires only after bytes start flowing
-# — does not catch credential negotiation hangs).
+# GH#21904: wall-clock timeout for each individual remote `git fetch`/`git
+# push` call in the CAS path. The CAS push runs its pre-push hook separately,
+# then uses `git push --no-verify`, so local validation no longer consumes this
+# transport budget (GH#29417). Distinct from CAS_GIT_CMD_TIMEOUT_S which only
+# sets git's `http.lowSpeedTime` after bytes start flowing.
 # Memory: mem_20260430054453_5f0d112e (HTTPS push hung; SSH workaround verified).
 CAS_HTTPS_TIMEOUT_S=${CAS_HTTPS_TIMEOUT_S:-30}
+# Pre-push validation can include the repository's full format/lint/typecheck
+# gate. Give that local work its own budget and classify its timeout as a hard
+# validation failure rather than CAS contention. The hook still runs exactly
+# once before either HTTPS or SSH transport is attempted.
+CAS_HOOK_TIMEOUT_S=${CAS_HOOK_TIMEOUT_S:-300}
 # GH#21904: when 1 (default), a `git fetch`/`git push` that times out on an
 # HTTPS GitHub remote is retried once via the SSH-equivalent URL.  Set to 0
 # to disable fallback (e.g. on hosts where SSH to github.com is blocked and

--- a/.agents/scripts/tests/test-claim-task-id-https-ssh-fallback.sh
+++ b/.agents/scripts/tests/test-claim-task-id-https-ssh-fallback.sh
@@ -11,8 +11,8 @@
 #      and rejects (rc=1, empty stdout) non-GitHub or already-SSH inputs.
 #   2. _run_git_with_ssh_fallback wraps a git command with timeout_sec and
 #      returns 124 transparently when the command times out.
-#   3. CAS_HTTPS_TIMEOUT_S / CAS_SSH_FALLBACK_ENABLED constants exist and
-#      are referenced in the counter sub-library.
+#   3. CAS_HTTPS_TIMEOUT_S / CAS_HOOK_TIMEOUT_S / CAS_SSH_FALLBACK_ENABLED
+#      constants exist and are referenced in the counter sub-library.
 #   4. The CAS push and fetch call sites in claim-task-id-counter.sh route
 #      through _run_git_with_ssh_fallback (no more raw `git push`/`git fetch`
 #      against $REMOTE_NAME).
@@ -73,9 +73,13 @@ source "$COUNTER_LIB"
 # Test 1: source check — new constants exist
 # ---------------------------------------------------------------------------
 test_constants_exist() {
-	local name="source check: CAS_HTTPS_TIMEOUT_S + CAS_SSH_FALLBACK_ENABLED defined"
+	local name="source check: CAS transport, hook, and SSH fallback settings defined"
 	if ! grep -q 'CAS_HTTPS_TIMEOUT_S=' "$CLAIM_SCRIPT"; then
 		fail "$name" "CAS_HTTPS_TIMEOUT_S not found in claim-task-id.sh"
+		return 0
+	fi
+	if ! grep -q 'CAS_HOOK_TIMEOUT_S=' "$CLAIM_SCRIPT"; then
+		fail "$name" "CAS_HOOK_TIMEOUT_S not found in claim-task-id.sh"
 		return 0
 	fi
 	if ! grep -q 'CAS_SSH_FALLBACK_ENABLED=' "$CLAIM_SCRIPT"; then
@@ -192,11 +196,11 @@ test_ssh_url_conversion_empty() {
 # Test 8: timeout passthrough — fast command returns its own rc, not 124
 # ---------------------------------------------------------------------------
 test_run_git_passthrough_no_timeout() {
-	local name='_run_git_with_ssh_fallback: fast "git --version" returns 0, not 124'
+	local name='_run_git_with_ssh_fallback: fast "git version" returns 0, not 124'
 	local rc=0
-	# 5s timeout; --version returns immediately. Suppress stdout to keep the
+	# 5s timeout; version returns immediately. Suppress stdout to keep the
 	# test output clean.
-	_run_git_with_ssh_fallback 5 --version >/dev/null 2>&1 || rc=$?
+	_run_git_with_ssh_fallback 5 version >/dev/null 2>&1 || rc=$?
 	if [[ $rc -ne 0 ]]; then
 		fail "$name" "expected rc=0, got rc=${rc}"
 		return 0
@@ -362,7 +366,262 @@ SHIM_EOF
 }
 
 # ---------------------------------------------------------------------------
-# Test 12: source check — CAS push/fetch call sites use the helper
+# Test 12: pre-push validation has an independent timeout and receives Git's
+# hook protocol. A hook that outlives the transport budget must still pass when
+# it completes inside CAS_HOOK_TIMEOUT_S.
+# ---------------------------------------------------------------------------
+test_pre_push_hook_uses_independent_budget() {
+	local name="CAS push: pre-push hook uses an independent validation budget"
+	local tmpdir=""
+	local output=""
+	local rc=0
+	local input=""
+	tmpdir=$(mktemp -d 2>/dev/null) || {
+		fail "$name" "could not create tmpdir"
+		return 0
+	}
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir' 2>/dev/null || true" RETURN
+
+	cat >"${tmpdir}/git" <<'SHIM_EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "remote" && "${2:-}" == "get-url" ]]; then
+	printf '%s\n' 'https://github.com/owner/repo.git'
+	exit 0
+fi
+if [[ "${1:-}" == "rev-parse" && "${2:-}" == "--git-path" ]]; then
+	printf '%s\n' "$TEST_HOOK_PATH"
+	exit 0
+fi
+exit 1
+SHIM_EOF
+	cat >"${tmpdir}/pre-push" <<'HOOK_EOF'
+#!/usr/bin/env bash
+IFS= read -r line
+printf '%s\n' "$line" >"$TEST_HOOK_INPUT"
+sleep 1
+exit 0
+HOOK_EOF
+	chmod +x "${tmpdir}/git" "${tmpdir}/pre-push"
+
+	output=$(
+		export PATH="${tmpdir}:$PATH"
+		export TEST_HOOK_PATH="${tmpdir}/pre-push"
+		export TEST_HOOK_INPUT="${tmpdir}/hook-input"
+		CAS_HTTPS_TIMEOUT_S=0.1 CAS_HOOK_TIMEOUT_S=3 \
+			_cas_run_pre_push_hook "local-sha" "remote-sha" 2>&1
+	) || rc=$?
+	input=$(<"${tmpdir}/hook-input")
+
+	if [[ $rc -ne 0 ]]; then
+		fail "$name" "expected hook success, got rc=${rc}: ${output}"
+		return 0
+	fi
+	if [[ "$input" != "local-sha local-sha refs/heads/${COUNTER_BRANCH} remote-sha" ]]; then
+		fail "$name" "unexpected hook protocol input: ${input}"
+		return 0
+	fi
+	if ! printf '%s\n' "$output" | grep -q 'Pre-push hook completed in'; then
+		fail "$name" "missing hook phase timing: ${output}"
+		return 0
+	fi
+	pass "$name"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 13: hook timeouts and failures are blocking and explicitly diagnosed.
+# ---------------------------------------------------------------------------
+test_pre_push_hook_failures_are_blocking() {
+	local name="CAS push: hook timeout and failure are blocking with phase diagnostics"
+	local tmpdir=""
+	local output=""
+	local rc=0
+	tmpdir=$(mktemp -d 2>/dev/null) || {
+		fail "$name" "could not create tmpdir"
+		return 0
+	}
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir' 2>/dev/null || true" RETURN
+
+	cat >"${tmpdir}/git" <<'SHIM_EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "remote" && "${2:-}" == "get-url" ]]; then
+	printf '%s\n' 'https://github.com/owner/repo.git'
+	exit 0
+fi
+if [[ "${1:-}" == "rev-parse" && "${2:-}" == "--git-path" ]]; then
+	printf '%s\n' "$TEST_HOOK_PATH"
+	exit 0
+fi
+exit 1
+SHIM_EOF
+	cat >"${tmpdir}/pre-push" <<'HOOK_EOF'
+#!/usr/bin/env bash
+sleep 5
+HOOK_EOF
+	chmod +x "${tmpdir}/git" "${tmpdir}/pre-push"
+
+	output=$(
+		export PATH="${tmpdir}:$PATH"
+		export TEST_HOOK_PATH="${tmpdir}/pre-push"
+		CAS_HOOK_TIMEOUT_S=1 _cas_run_pre_push_hook "local-sha" "remote-sha" 2>&1
+	) || rc=$?
+	if [[ $rc -ne 1 ]] || ! printf '%s\n' "$output" | grep -q 'Pre-push hook timed out.*remote push was not attempted'; then
+		fail "$name" "timeout was not blocking/diagnosed: rc=${rc}: ${output}"
+		return 0
+	fi
+
+	cat >"${tmpdir}/pre-push" <<'HOOK_EOF'
+#!/usr/bin/env bash
+exit 7
+HOOK_EOF
+	chmod +x "${tmpdir}/pre-push"
+	rc=0
+	output=$(
+		export PATH="${tmpdir}:$PATH"
+		export TEST_HOOK_PATH="${tmpdir}/pre-push"
+		CAS_HOOK_TIMEOUT_S=3 _cas_run_pre_push_hook "local-sha" "remote-sha" 2>&1
+	) || rc=$?
+	if [[ $rc -ne 1 ]] || ! printf '%s\n' "$output" | grep -q 'Pre-push hook failed.*rc=7.*remote push was not attempted'; then
+		fail "$name" "hook failure was not blocking/diagnosed: rc=${rc}: ${output}"
+		return 0
+	fi
+
+	pass "$name"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 14: an actual CAS push succeeds when its pre-push hook outlives the
+# transport timeout, because validation and remote I/O have separate budgets.
+# ---------------------------------------------------------------------------
+test_slow_hook_does_not_consume_transport_budget() {
+	local name="CAS push: slow valid hook does not consume transport timeout"
+	local tmpdir=""
+	local bare_dir=""
+	local work_dir=""
+	local hook_path=""
+	local pinned_sha=""
+	local output=""
+	local rc=0
+	local remote_counter=""
+	local hook_calls=""
+	tmpdir=$(mktemp -d 2>/dev/null) || {
+		fail "$name" "could not create tmpdir"
+		return 0
+	}
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir' 2>/dev/null || true" RETURN
+	bare_dir="${tmpdir}/remote.git"
+	work_dir="${tmpdir}/work"
+
+	git init --bare --initial-branch=main "$bare_dir" >/dev/null 2>&1 || {
+		fail "$name" "could not initialize bare remote"
+		return 0
+	}
+	git clone "$bare_dir" "$work_dir" >/dev/null 2>&1 || {
+		fail "$name" "could not clone fixture"
+		return 0
+	}
+	git -C "$work_dir" config user.email "test@test.local"
+	git -C "$work_dir" config user.name "Test"
+	git -C "$work_dir" config commit.gpgsign false
+	printf '1000\n' >"${work_dir}/.task-counter"
+	printf '# Tasks\n' >"${work_dir}/TODO.md"
+	git -C "$work_dir" add .task-counter TODO.md
+	git -C "$work_dir" commit -m "chore: seed CAS fixture" >/dev/null 2>&1 || {
+		fail "$name" "could not commit fixture"
+		return 0
+	}
+	git -C "$work_dir" push origin main >/dev/null 2>&1 || {
+		fail "$name" "could not seed remote"
+		return 0
+	}
+	pinned_sha=$(git -C "$work_dir" rev-parse HEAD) || {
+		fail "$name" "could not resolve fixture HEAD"
+		return 0
+	}
+	hook_path=$(git -C "$work_dir" rev-parse --git-path hooks/pre-push) || {
+		fail "$name" "could not resolve fixture hook path"
+		return 0
+	}
+	[[ "$hook_path" == /* ]] || hook_path="${work_dir}/${hook_path}"
+	cat >"$hook_path" <<'HOOK_EOF'
+#!/usr/bin/env bash
+printf 'called\n' >>"$TEST_HOOK_CALL_LOG"
+sleep 2
+exit 0
+HOOK_EOF
+	chmod +x "$hook_path"
+
+	output=$(
+		cd "$work_dir" || exit 1
+		export TEST_HOOK_CALL_LOG="${tmpdir}/hook-calls"
+		REMOTE_NAME=origin
+		COUNTER_BRANCH=main
+		COUNTER_FILE=.task-counter
+		CAS_GIT_CMD_TIMEOUT_S=1
+		CAS_HTTPS_TIMEOUT_S=1
+		CAS_HOOK_TIMEOUT_S=5
+		CAS_SSH_FALLBACK_ENABLED=0
+		_cas_build_and_push "$pinned_sha" 1001 "chore: claim integration test" 2>&1
+	) || rc=$?
+	remote_counter=$(git --git-dir="$bare_dir" show main:.task-counter 2>/dev/null | tr -d '[:space:]')
+	if [[ -f "${tmpdir}/hook-calls" ]]; then
+		hook_calls=$(wc -l <"${tmpdir}/hook-calls" 2>/dev/null | tr -d '[:space:]')
+	else
+		hook_calls="0"
+	fi
+
+	if [[ $rc -ne 0 ]]; then
+		fail "$name" "expected CAS push success, got rc=${rc}: ${output}"
+		return 0
+	fi
+	if [[ "$remote_counter" != "1001" ]]; then
+		fail "$name" "expected remote counter 1001, got ${remote_counter:-<empty>}"
+		return 0
+	fi
+	if [[ "$hook_calls" != "1" ]]; then
+		fail "$name" "expected hook to run once, got ${hook_calls:-0}"
+		return 0
+	fi
+	if ! printf '%s\n' "$output" | grep -q 'Pre-push hook completed in'; then
+		fail "$name" "missing hook timing diagnostic: ${output}"
+		return 0
+	fi
+	pass "$name"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 15: only genuine non-fast-forward failures are retriable, while auth is
+# separately classified. The actual push must skip the already-run hook.
+# ---------------------------------------------------------------------------
+test_push_failure_classifiers() {
+	local name="CAS push: conflict and authentication diagnostics are distinct"
+	if ! _cas_push_rejection_is_non_fast_forward ' ! [rejected] abc -> main (non-fast-forward)'; then
+		fail "$name" "non-fast-forward rejection was not classified as contention"
+		return 0
+	fi
+	if _cas_push_rejection_is_non_fast_forward 'fatal: Authentication failed for repository'; then
+		fail "$name" "authentication failure was classified as contention"
+		return 0
+	fi
+	if ! _cas_push_rejection_is_auth_failure 'fatal: Authentication failed for repository'; then
+		fail "$name" "authentication failure was not classified"
+		return 0
+	fi
+	if ! grep -q 'push --no-verify -q' "$COUNTER_LIB"; then
+		fail "$name" "transport push does not skip duplicate pre-push hook execution"
+		return 0
+	fi
+	pass "$name"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 16: source check — CAS push/fetch call sites use the helper
 # Verifies _cas_fetch_and_pin, _cas_build_and_push, read_remote_counter and
 # bootstrap_remote_counter all route via _run_git_with_ssh_fallback. A future
 # regression that inserts a raw `git push` or `git fetch` against $REMOTE_NAME
@@ -420,6 +679,10 @@ main() {
 	test_fallback_disabled_short_circuits
 	test_non_timeout_failure_falls_back_to_ssh
 	test_timeout_falls_back_to_ssh
+	test_pre_push_hook_uses_independent_budget
+	test_pre_push_hook_failures_are_blocking
+	test_slow_hook_does_not_consume_transport_budget
+	test_push_failure_classifiers
 	test_call_sites_use_helper
 
 	printf '\n'

--- a/.agents/scripts/tests/test-claim-task-id-stdout-isolation.sh
+++ b/.agents/scripts/tests/test-claim-task-id-stdout-isolation.sh
@@ -17,10 +17,10 @@
 #   claim-task-id.sh: line NNN: [0;34m[INFO][0m ... new counter: 2459:
 #       syntax error in expression (error token is "[0;34m[INFO][0m...")
 #
-# `git push -q` suppresses git's own progress output but does NOT
-# suppress hook stdout.  Complementary defense is redirecting stdout
-# to /dev/null inside the CAS helpers (caller-side isolation), which
-# is what this test exercises.
+# The hook now runs explicitly before `git push --no-verify -q`, and both
+# phases suppress stdout. Complementary defense is redirecting stdout to
+# /dev/null inside the CAS helpers (caller-side isolation), which is what this
+# test exercises.
 #
 # Sibling test: test-stdout-narration-hygiene.sh (GH#20212) covers the
 # hook-side of the same class of bugs.  This test covers the
@@ -100,7 +100,7 @@ _contains_ansi() {
 #
 # We extract each target function body with awk and then check the
 # redirect is present on the relevant git push/fetch line.  A bare
-# `git push -q "$REMOTE_NAME" …` WITHOUT `>/dev/null` is the regression
+# `git push [--no-verify] -q "$REMOTE_NAME" …` WITHOUT `>/dev/null` is the regression
 # we are defending against.
 # ---------------------------------------------------------------------------
 
@@ -124,20 +124,21 @@ test_cas_build_push_redirects_push_stdout() {
 	local body
 	body=$(_func_body _cas_build_and_push "$CLAIM_SCRIPT")
 
-	# Look for a `push -q "$REMOTE_NAME"` line that also has `>/dev/null`.
+	# Look for a push line that also has `>/dev/null`; GH#29417 inserts
+	# --no-verify because the hook has already run with its own timeout.
 	local push_line
 	# shellcheck disable=SC2016  # single-quoted regex matches literal "$REMOTE_NAME" in source
-	push_line=$(printf '%s\n' "$body" | grep -E 'push -q "\$REMOTE_NAME"' | head -1 || true)
+	push_line=$(printf '%s\n' "$body" | grep -E 'push (--no-verify )?-q "\$REMOTE_NAME"' | head -1 || true)
 
 	if [[ -z "$push_line" ]]; then
-		fail "$name" "could not locate 'push -q \"\$REMOTE_NAME\"' in _cas_build_and_push"
+		fail "$name" "could not locate CAS push command in _cas_build_and_push"
 		return 0
 	fi
 
 	# Multi-line continuation: check the whole function body for the
 	# redirect appearing on the same logical statement as the push.
 	# shellcheck disable=SC2016  # single-quoted regex matches literal "$REMOTE_NAME" in source
-	if printf '%s\n' "$body" | grep -qE 'push -q "\$REMOTE_NAME"[^\n]*>/dev/null'; then
+	if printf '%s\n' "$body" | grep -qE 'push (--no-verify )?-q "\$REMOTE_NAME"[^\n]*>/dev/null'; then
 		pass "$name"
 	else
 		fail "$name" "push line lacks >/dev/null redirect: ${push_line}"


### PR DESCRIPTION
## Summary

Run pre-push validation once with its own timeout, reserve the CAS transport timeout for remote I/O, and classify hook, authentication, policy, and non-fast-forward failures distinctly.

## Files Changed

.agents/scripts/claim-task-id-counter.sh, .agents/scripts/claim-task-id.sh, .agents/scripts/tests/test-claim-task-id-https-ssh-fallback.sh, .agents/scripts/tests/test-claim-task-id-stdout-isolation.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Six targeted claim-task-id suites passed (43 assertions total), including a real CAS push whose 2s hook exceeds its 1s transport budget; ShellCheck and `bun run typecheck` passed; the complete pre-push gate passed.

Resolves #29417

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.218 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 24m and 205,970 tokens on this as a headless worker.
