### PR TITLE
GH#29389: Add explicit worktree recovery plan apply

### DIFF
--- a/.agents/reference/storage-lifecycle.md
+++ b/.agents/reference/storage-lifecycle.md
@@ -146,7 +146,8 @@ worktree-helper.sh recovery apply \
 ```
 
 Apply accepts only the exact supported producer manifest and its bound token.
-It rejects relative or symlinked inputs, existing mismatched receipts,
+It rejects relative or symlinked inputs, existing mismatched receipts or
+reservations,
 unsupported schemas, duplicate paths or identities, candidates outside an
 attributable recovery root, and any summary or digest mismatch. Archive creation
 and apply contend on the same exclusive producer lock. The lock records PID,
@@ -154,20 +155,26 @@ process start time, and an owner token; live, malformed, ambiguous, or
 unverifiable ownership blocks mutation, while only conclusively stale ownership
 may be reclaimed.
 
-Under the lock, apply revalidates every candidate and all mutable evidence before
-moving any candidate. It then rechecks each exact identity and allocated byte
-count immediately before a same-filesystem rename into that recovery root's
-`.retention-trash/<transaction-id>/` directory. An atomically replaced journal
-lists every permitted original and staged path; removal operates only on those
-journal entries, never a wildcard or a newly discovered archive. Interrupted
-rename or removal windows remain attributable and can resume only from the exact
-plan and journal.
+Under the lock, apply first creates or validates a mode-0600, plan-bound
+`aidevops.worktree-recovery-apply-reservation/v1` at the requested receipt path.
+This reservation prevents a concurrent plan from deleting data and then losing
+its receipt to a path collision. An exact retry may resume an incomplete
+reservation; a different plan fails before mutation. Apply then revalidates every
+candidate and all mutable evidence before moving any candidate. It rechecks each
+exact identity and allocated byte count immediately before a same-filesystem
+rename into that recovery root's `.retention-trash/<transaction-id>/` directory.
+An atomically replaced journal lists every permitted original and staged path;
+removal operates only on those journal entries, never a wildcard or a newly
+discovered archive. Empty initialization directories and deterministic
+journal-next files are recoverable, while any unrelated transaction artifact
+fails closed. Interrupted initialization, rename, journal update, or removal
+windows remain attributable and can resume only from the exact plan and journal.
 
-Success atomically publishes a new mode-0600
+Success atomically replaces the exact reservation with a mode-0600
 `aidevops.worktree-recovery-apply-receipt/v1` receipt containing the plan and
 transaction identities, confirmation binding, times, exact paths and archive
 identities, expected/observed bytes, and terminal outcomes. Replaying the same
-complete receipt is a no-op; a conflicting receipt fails closed. Protected,
+complete receipt is a no-op; a conflicting receipt or reservation fails closed. Protected,
 unknown, unrelated Trash, and newly created content remain untouched. This
 explicit command does not add age-based or automatic recovery deletion.
 

--- a/.agents/reference/storage-lifecycle.md
+++ b/.agents/reference/storage-lifecycle.md
@@ -106,7 +106,7 @@ Incomplete, symlinked, unrecognised, or unsized buckets are `unknown`; inventory
 never migrates, rewrites, or deletes them.
 
 Run `worktree-helper.sh recovery plan --output <absolute-path>` to persist a
-versioned `aidevops.worktree-recovery-plan/v1` JSON review artifact. The output
+versioned `aidevops.worktree-recovery-plan/v2` JSON review artifact. The output
 path must be new, absolute, non-symlinked, and writable. The helper builds the
 complete document in a mode-0600 temporary file beside the destination and
 publishes it atomically without replacing an existing path. Plan generation is
@@ -122,6 +122,9 @@ archive paths to its format, Git HEAD/branch, source/admin/common identity,
 archive index and completion-marker digests, expected allocated bytes, observed
 local/remote evidence, disposition, and reason codes. Unchanged evidence yields
 the same entries and plan ID; the generation timestamp remains observational.
+The v2 confirmation token binds that plan ID to the exact candidate count,
+expected allocated bytes, schema, and permanent-delete action. Earlier or
+tokenless plan versions are never upgraded into destructive authorization.
 
 Candidate status requires a valid complete archive, completed source removal,
 a clean tracked/untracked/ignored Git state, an exact merged commit, a closed
@@ -131,8 +134,42 @@ reference, and exact readable sizing. Positive live or unfinished evidence is
 is `unknown`. Identity and allocated bytes are read again immediately before an
 entry is emitted, so concurrent drift downgrades only that entry. Age, size, and
 OpenCode or Claude session history never prove reclaimability. Plan files grant
-no deletion authority; only a future version-matched apply command may consume
-candidate entries after repeating every mutable proof.
+no deletion authority by themselves.
+
+After reviewing a v2 plan, an operator may run:
+
+```bash
+worktree-helper.sh recovery apply \
+  --plan <absolute-path> \
+  --receipt <absolute-new-path> \
+  --confirm <manifest-token>
+```
+
+Apply accepts only the exact supported producer manifest and its bound token.
+It rejects relative or symlinked inputs, existing mismatched receipts,
+unsupported schemas, duplicate paths or identities, candidates outside an
+attributable recovery root, and any summary or digest mismatch. Archive creation
+and apply contend on the same exclusive producer lock. The lock records PID,
+process start time, and an owner token; live, malformed, ambiguous, or
+unverifiable ownership blocks mutation, while only conclusively stale ownership
+may be reclaimed.
+
+Under the lock, apply revalidates every candidate and all mutable evidence before
+moving any candidate. It then rechecks each exact identity and allocated byte
+count immediately before a same-filesystem rename into that recovery root's
+`.retention-trash/<transaction-id>/` directory. An atomically replaced journal
+lists every permitted original and staged path; removal operates only on those
+journal entries, never a wildcard or a newly discovered archive. Interrupted
+rename or removal windows remain attributable and can resume only from the exact
+plan and journal.
+
+Success atomically publishes a new mode-0600
+`aidevops.worktree-recovery-apply-receipt/v1` receipt containing the plan and
+transaction identities, confirmation binding, times, exact paths and archive
+identities, expected/observed bytes, and terminal outcomes. Replaying the same
+complete receipt is a no-op; a conflicting receipt fails closed. Protected,
+unknown, unrelated Trash, and newly created content remain untouched. This
+explicit command does not add age-based or automatic recovery deletion.
 
 An originating OpenCode or Claude session identifier is recovery guidance, not
 deletion proof. Session history can reconstruct text edits and intent but may be

--- a/.agents/reference/storage-lifecycle.md
+++ b/.agents/reference/storage-lifecycle.md
@@ -158,8 +158,10 @@ may be reclaimed.
 Under the lock, apply first creates or validates a mode-0600, plan-bound
 `aidevops.worktree-recovery-apply-reservation/v1` at the requested receipt path.
 This reservation prevents a concurrent plan from deleting data and then losing
-its receipt to a path collision. An exact retry may resume an incomplete
-reservation; a different plan fails before mutation. Apply then revalidates every
+its receipt to a path collision. The reservation binds a uniquely allocated
+mode-0600 completion file created before mutation; receipt publication never
+claims or removes a predictable adjacent path. An exact retry may resume an incomplete
+reservation; a different plan or replaced completion file fails before mutation. Apply then revalidates every
 candidate and all mutable evidence before moving any candidate. It rechecks each
 exact identity and allocated byte count immediately before a same-filesystem
 rename into that recovery root's `.retention-trash/<transaction-id>/` directory.

--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -83,7 +83,14 @@ _WT_RECOVERY_ROOT_UNAVAILABLE="$_WT_STATE_UNAVAILABLE"
 _WT_RECOVERY_BRANCH_DETACHED="detached"
 _WT_RECOVERY_OUTCOME_PENDING="pending"
 _WT_RECOVERY_OUTCOME_REMOVED="removed"
+_WT_RECOVERY_PRODUCER_LOCK_NAME=".aidevops-worktree-recovery.lock"
+_WT_RECOVERY_LOCK_STATE_LIVE="live"
+_WT_RECOVERY_LOCK_STATE_STALE="stale"
+_WT_RECOVERY_LOCK_STATE_UNCERTAIN="uncertain"
 WORKTREE_RECOVERABLE_ARCHIVE_PATH=""
+WORKTREE_RECOVERY_PRODUCER_LOCK_PATH=""
+WORKTREE_RECOVERY_PRODUCER_LOCK_TOKEN=""
+WORKTREE_RECOVERY_PRODUCER_LOCK_LSTART=""
 
 _WT_ID_REAL_GIT=""
 _WT_ID_SOURCE_REAL=""
@@ -975,7 +982,146 @@ worktree_recovery_inventory() {
 	return 0
 }
 
-archive_worktree_path_recoverably() {
+_worktree_recovery_process_lstart() {
+	local pid="$1"
+	local process_lstart=""
+
+	[[ "$pid" =~ ^[0-9]+$ ]] || return 1
+	process_lstart=$(LC_ALL=C TZ=UTC ps -ww -p "$pid" -o lstart= 2>/dev/null || true)
+	process_lstart="${process_lstart#"${process_lstart%%[![:space:]]*}"}"
+	[[ -n "$process_lstart" ]] || return 1
+	printf '%s\n' "$process_lstart"
+	return 0
+}
+
+_worktree_recovery_lock_owner_state() {
+	local lock_path="$1"
+	local owner_pid=""
+	local owner_lstart=""
+	local current_lstart=""
+	local metadata_name=""
+
+	[[ -d "$lock_path" && ! -L "$lock_path" ]] || {
+		printf '%s\n' "$_WT_RECOVERY_LOCK_STATE_UNCERTAIN"
+		return 0
+	}
+	for metadata_name in pid lstart token initialized; do
+		[[ -f "$lock_path/$metadata_name" && ! -L "$lock_path/$metadata_name" ]] || {
+			printf '%s\n' "$_WT_RECOVERY_LOCK_STATE_UNCERTAIN"
+			return 0
+		}
+	done
+	IFS= read -r owner_pid <"$lock_path/pid" || owner_pid=""
+	IFS= read -r owner_lstart <"$lock_path/lstart" || owner_lstart=""
+	[[ "$owner_pid" =~ ^[0-9]+$ && -n "$owner_lstart" ]] || {
+		printf '%s\n' "$_WT_RECOVERY_LOCK_STATE_UNCERTAIN"
+		return 0
+	}
+	if ! kill -0 "$owner_pid" 2>/dev/null; then
+		printf '%s\n' "$_WT_RECOVERY_LOCK_STATE_STALE"
+		return 0
+	fi
+	current_lstart=$(_worktree_recovery_process_lstart "$owner_pid" 2>/dev/null || true)
+	if [[ -z "$current_lstart" ]]; then
+		if kill -0 "$owner_pid" 2>/dev/null; then
+			printf '%s\n' "$_WT_RECOVERY_LOCK_STATE_UNCERTAIN"
+		else
+			printf '%s\n' "$_WT_RECOVERY_LOCK_STATE_STALE"
+		fi
+	elif [[ "$current_lstart" == "$owner_lstart" ]]; then
+		printf '%s\n' "$_WT_RECOVERY_LOCK_STATE_LIVE"
+	else
+		printf '%s\n' "$_WT_RECOVERY_LOCK_STATE_STALE"
+	fi
+	return 0
+}
+
+_worktree_recovery_acquire_producer_lock() {
+	local recovery_root="$1"
+	local lock_path="${recovery_root}/${_WT_RECOVERY_PRODUCER_LOCK_NAME}"
+	local reclaim_path=""
+	local owner_state=""
+	local process_lstart=""
+	local owner_token=""
+	local observed_pid=""
+	local observed_lstart=""
+	local observed_token=""
+	local reclaimed_pid=""
+	local reclaimed_lstart=""
+	local reclaimed_token=""
+	local reclaim_state=""
+	local attempt=0
+
+	WORKTREE_RECOVERY_PRODUCER_LOCK_PATH=""
+	WORKTREE_RECOVERY_PRODUCER_LOCK_TOKEN=""
+	WORKTREE_RECOVERY_PRODUCER_LOCK_LSTART=""
+	[[ -d "$recovery_root" && ! -L "$recovery_root" ]] || return 1
+	process_lstart=$(_worktree_recovery_process_lstart "$$") || return 1
+	owner_token="$$-${RANDOM}-$(date -u '+%Y%m%dT%H%M%SZ')"
+	while [[ "$attempt" -lt 2 ]]; do
+		if mkdir "$lock_path" 2>/dev/null; then
+			if ! printf '%s\n' "$$" >"$lock_path/pid" ||
+				! printf '%s\n' "$process_lstart" >"$lock_path/lstart" ||
+				! printf '%s\n' "$owner_token" >"$lock_path/token" ||
+				! printf '%s\n' "complete" >"$lock_path/initialized"; then
+				rm -f "$lock_path/pid" "$lock_path/lstart" "$lock_path/token" \
+					"$lock_path/initialized" 2>/dev/null || true
+				rmdir "$lock_path" 2>/dev/null || true
+				return 1
+			fi
+			WORKTREE_RECOVERY_PRODUCER_LOCK_PATH="$lock_path"
+			WORKTREE_RECOVERY_PRODUCER_LOCK_TOKEN="$owner_token"
+			WORKTREE_RECOVERY_PRODUCER_LOCK_LSTART="$process_lstart"
+			return 0
+		fi
+		[[ -e "$lock_path" || -L "$lock_path" ]] || return 1
+		owner_state=$(_worktree_recovery_lock_owner_state "$lock_path") || return 1
+		[[ "$owner_state" == "$_WT_RECOVERY_LOCK_STATE_STALE" ]] || return 1
+		IFS= read -r observed_pid <"$lock_path/pid" || return 1
+		IFS= read -r observed_lstart <"$lock_path/lstart" || return 1
+		IFS= read -r observed_token <"$lock_path/token" || return 1
+		reclaim_path="${lock_path}.reclaim.$$-${RANDOM}"
+		mv "$lock_path" "$reclaim_path" 2>/dev/null || return 1
+		reclaim_state=$(_worktree_recovery_lock_owner_state "$reclaim_path") || return 1
+		IFS= read -r reclaimed_pid <"$reclaim_path/pid" || return 1
+		IFS= read -r reclaimed_lstart <"$reclaim_path/lstart" || return 1
+		IFS= read -r reclaimed_token <"$reclaim_path/token" || return 1
+		if [[ "$reclaim_state" != "$_WT_RECOVERY_LOCK_STATE_STALE" ||
+			"$reclaimed_pid" != "$observed_pid" || "$reclaimed_lstart" != "$observed_lstart" ||
+			"$reclaimed_token" != "$observed_token" ]]; then
+			if [[ ! -e "$lock_path" && ! -L "$lock_path" ]]; then
+				mv "$reclaim_path" "$lock_path" 2>/dev/null || true
+			fi
+			return 1
+		fi
+		rm -rf "$reclaim_path" || return 1
+		attempt=$((attempt + 1))
+	done
+	return 1
+}
+
+_worktree_recovery_release_producer_lock() {
+	local lock_path="${WORKTREE_RECOVERY_PRODUCER_LOCK_PATH:-}"
+	local owner_pid=""
+	local owner_lstart=""
+	local owner_token=""
+
+	[[ -n "$lock_path" && -d "$lock_path" && ! -L "$lock_path" ]] || return 1
+	IFS= read -r owner_pid <"$lock_path/pid" || return 1
+	IFS= read -r owner_lstart <"$lock_path/lstart" || return 1
+	IFS= read -r owner_token <"$lock_path/token" || return 1
+	[[ "$owner_pid" == "$$" && "$owner_lstart" == "$WORKTREE_RECOVERY_PRODUCER_LOCK_LSTART" &&
+		"$owner_token" == "$WORKTREE_RECOVERY_PRODUCER_LOCK_TOKEN" ]] || return 1
+	rm -f "$lock_path/initialized" "$lock_path/pid" "$lock_path/lstart" \
+		"$lock_path/token" || return 1
+	rmdir "$lock_path" || return 1
+	WORKTREE_RECOVERY_PRODUCER_LOCK_PATH=""
+	WORKTREE_RECOVERY_PRODUCER_LOCK_TOKEN=""
+	WORKTREE_RECOVERY_PRODUCER_LOCK_LSTART=""
+	return 0
+}
+
+_archive_worktree_path_recoverably_under_lock() {
 	local wt_path="$1"
 	local caller="$2"
 	local context="${3:-}"
@@ -1040,6 +1186,29 @@ archive_worktree_path_recoverably() {
 	fi
 	WORKTREE_RECOVERABLE_ARCHIVE_PATH="$archive_path"
 	return 0
+}
+
+archive_worktree_path_recoverably() {
+	local wt_path="$1"
+	local caller="$2"
+	local context="${3:-}"
+	local recovery_root=""
+	local recovery_root_real=""
+	local archive_status=0
+	local hold_seconds="${AIDEVOPS_WORKTREE_RECOVERY_TEST_HOLD_LOCK_SECONDS:-0}"
+
+	WORKTREE_RECOVERABLE_ARCHIVE_PATH=""
+	recovery_root=$(_worktree_recovery_store_root) || return 1
+	mkdir -p "$recovery_root" 2>/dev/null || return 1
+	recovery_root_real=$(cd "$recovery_root" 2>/dev/null && pwd -P) || return 1
+	_worktree_recovery_acquire_producer_lock "$recovery_root_real" || return 1
+	case "$hold_seconds" in
+	'' | *[!0-9]*) hold_seconds=0 ;;
+	esac
+	[[ "$hold_seconds" -eq 0 ]] || sleep "$hold_seconds"
+	_archive_worktree_path_recoverably_under_lock "$wt_path" "$caller" "$context" || archive_status=$?
+	_worktree_recovery_release_producer_lock || archive_status=1
+	return "$archive_status"
 }
 
 _worktree_guard_path_is_usable() {

--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -564,7 +564,10 @@ test_apply_preflight_drift_stages_nothing() {
 	if HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
 		cmd_recovery apply --plan "$plan_path" --receipt "$receipt_path" \
 		--confirm "$confirmation" >/dev/null 2>&1; then rc=1; fi
-	[[ -d "$bucket_a" && -d "$bucket_b" && ! -e "$receipt_path" ]] || rc=1
+	[[ -d "$bucket_a" && -d "$bucket_b" && -f "$receipt_path" ]] || rc=1
+	jq -e '
+		.schema == "aidevops.worktree-recovery-apply-reservation/v1" and .complete == false
+	' "$receipt_path" >/dev/null || rc=1
 	for staged_path in "$recovery_root"/.retention-trash/apply-*/candidate-*; do
 		[[ -e "$staged_path" || -L "$staged_path" ]] || continue
 		staged_count=$((staged_count + 1))
@@ -602,7 +605,9 @@ test_apply_resumes_move_and_delete_crash_windows() {
 		[[ -f "$candidate_journal" ]] || continue
 		journal_path="$candidate_journal"
 	done
-	[[ -n "$journal_path" && ! -e "$bucket_path" && ! -e "$move_receipt" ]] || rc=1
+	[[ -n "$journal_path" && ! -e "$bucket_path" && -f "$move_receipt" ]] || rc=1
+	jq -e '.schema == "aidevops.worktree-recovery-apply-reservation/v1" and .complete == false' \
+		"$move_receipt" >/dev/null || rc=1
 	staged_path=$(jq -r '.entries[0].staged_path' "$journal_path") || rc=1
 	[[ "$(jq -r '.entries[0].state' "$journal_path")" == "planned" && -d "$staged_path" ]] || rc=1
 	HOME="$move_home" AIDEVOPS_WORKTREE_TRASH_ROOT="$move_root" cmd_recovery apply \
@@ -625,7 +630,9 @@ test_apply_resumes_move_and_delete_crash_windows() {
 		[[ -f "$candidate_journal" ]] || continue
 		journal_path="$candidate_journal"
 	done
-	[[ -n "$journal_path" && ! -e "$bucket_path" && ! -e "$delete_receipt" ]] || rc=1
+	[[ -n "$journal_path" && ! -e "$bucket_path" && -f "$delete_receipt" ]] || rc=1
+	jq -e '.schema == "aidevops.worktree-recovery-apply-reservation/v1" and .complete == false' \
+		"$delete_receipt" >/dev/null || rc=1
 	staged_path=$(jq -r '.entries[0].staged_path' "$journal_path") || rc=1
 	[[ "$(jq -r '.entries[0].state' "$journal_path")" == "staged" && ! -e "$staged_path" ]] || rc=1
 	HOME="$delete_home" AIDEVOPS_WORKTREE_TRASH_ROOT="$delete_root" cmd_recovery apply \
@@ -634,6 +641,88 @@ test_apply_resumes_move_and_delete_crash_windows() {
 	[[ -f "$delete_receipt" ]] || rc=1
 	print_result "apply_resumes_move_and_delete_crash_windows" "$rc" \
 		"Expected retries to reconcile exact journal state after rename or delete interruption"
+	return 0
+}
+
+test_apply_resumes_transaction_initialization_crashes() {
+	local dir_home="${TEST_DIR}/transaction-dir-home"
+	local dir_root="${dir_home}/recovery"
+	local dir_plan="${TEST_DIR}/transaction-dir-plan.json"
+	local dir_receipt="${TEST_DIR}/transaction-dir-receipt.json"
+	local next_home="${TEST_DIR}/journal-next-home"
+	local next_root="${next_home}/recovery"
+	local next_plan="${TEST_DIR}/journal-next-plan.json"
+	local next_receipt="${TEST_DIR}/journal-next-receipt.json"
+	local archive_path="" bucket_path="" confirmation="" next_path=""
+	local rc=0
+
+	archive_path=$(create_candidate_plan_fixture "$dir_home" "${TEST_DIR}/transaction-dir-repo" \
+		"${TEST_DIR}/transaction-dir-worktree" "$dir_root" \
+		"bugfix/gh29389-transaction-dir-interrupt" "$dir_plan") || rc=1
+	bucket_path="${archive_path%/*}"
+	confirmation=$(jq -r '.confirmation_token' "$dir_plan") || rc=1
+	if AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_TRANSACTION_DIR=1 HOME="$dir_home" \
+		AIDEVOPS_WORKTREE_TRASH_ROOT="$dir_root" cmd_recovery apply --plan "$dir_plan" \
+		--receipt "$dir_receipt" --confirm "$confirmation" >/dev/null 2>&1; then rc=1; fi
+	[[ -d "$bucket_path" && -f "$dir_receipt" ]] || rc=1
+	HOME="$dir_home" AIDEVOPS_WORKTREE_TRASH_ROOT="$dir_root" cmd_recovery apply \
+		--plan "$dir_plan" --receipt "$dir_receipt" --confirm "$confirmation" >/dev/null || rc=1
+	[[ ! -e "$bucket_path" ]] || rc=1
+
+	archive_path=$(create_candidate_plan_fixture "$next_home" "${TEST_DIR}/journal-next-repo" \
+		"${TEST_DIR}/journal-next-worktree" "$next_root" \
+		"bugfix/gh29389-journal-next-interrupt" "$next_plan") || rc=1
+	bucket_path="${archive_path%/*}"
+	confirmation=$(jq -r '.confirmation_token' "$next_plan") || rc=1
+	if AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_JOURNAL_NEXT=1 HOME="$next_home" \
+		AIDEVOPS_WORKTREE_TRASH_ROOT="$next_root" cmd_recovery apply --plan "$next_plan" \
+		--receipt "$next_receipt" --confirm "$confirmation" >/dev/null 2>&1; then rc=1; fi
+	for next_path in "$next_root"/.retention-trash/apply-*/.journal.json.next; do
+		[[ -f "$next_path" && -d "$bucket_path" ]] || rc=1
+	done
+	HOME="$next_home" AIDEVOPS_WORKTREE_TRASH_ROOT="$next_root" cmd_recovery apply \
+		--plan "$next_plan" --receipt "$next_receipt" --confirm "$confirmation" >/dev/null || rc=1
+	[[ ! -e "$bucket_path" ]] || rc=1
+	print_result "apply_resumes_transaction_initialization_crashes" "$rc" \
+		"Expected empty transaction directories and journal-next files to resume safely"
+	return 0
+}
+
+test_receipt_reservation_blocks_conflicting_plan() {
+	local home_path="${TEST_DIR}/reservation-home"
+	local recovery_root="${home_path}/recovery"
+	local first_plan="${TEST_DIR}/reservation-first-plan.json"
+	local second_plan="${TEST_DIR}/reservation-second-plan.json"
+	local receipt_path="${TEST_DIR}/reservation-receipt.json"
+	local first_archive="" first_bucket="" first_confirmation=""
+	local second_archive="" second_bucket="" second_confirmation=""
+	local rc=0
+
+	first_archive=$(create_candidate_plan_fixture "$home_path" "${TEST_DIR}/reservation-first-repo" \
+		"${TEST_DIR}/reservation-first-worktree" "$recovery_root" \
+		"bugfix/gh29389-reservation-first" "$first_plan") || rc=1
+	first_bucket="${first_archive%/*}"
+	first_confirmation=$(jq -r '.confirmation_token' "$first_plan") || rc=1
+	if AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_RECEIPT_RESERVATION=1 HOME="$home_path" \
+		AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" cmd_recovery apply --plan "$first_plan" \
+		--receipt "$receipt_path" --confirm "$first_confirmation" >/dev/null 2>&1; then rc=1; fi
+	second_archive=$(create_candidate_plan_fixture "$home_path" "${TEST_DIR}/reservation-second-repo" \
+		"${TEST_DIR}/reservation-second-worktree" "$recovery_root" \
+		"bugfix/gh29389-reservation-second" "$second_plan") || rc=1
+	second_bucket="${second_archive%/*}"
+	second_confirmation=$(jq -r '.confirmation_token' "$second_plan") || rc=1
+	if HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" cmd_recovery apply \
+		--plan "$second_plan" --receipt "$receipt_path" --confirm "$second_confirmation" \
+		>/dev/null 2>&1; then rc=1; fi
+	[[ -d "$first_bucket" && -d "$second_bucket" ]] || rc=1
+	HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" cmd_recovery apply \
+		--plan "$first_plan" --receipt "$receipt_path" --confirm "$first_confirmation" >/dev/null || rc=1
+	[[ ! -e "$first_bucket" && -d "$second_bucket" ]] || rc=1
+	jq -e --arg plan_id "$(jq -r '.plan_id' "$first_plan")" \
+		'.schema == "aidevops.worktree-recovery-apply-receipt/v1" and
+		.complete == true and .plan_id == $plan_id' "$receipt_path" >/dev/null || rc=1
+	print_result "receipt_reservation_blocks_conflicting_plan" "$rc" \
+		"Expected one plan-bound reservation to block conflicting deletion and permit exact retry"
 	return 0
 }
 
@@ -736,6 +825,8 @@ test_apply_removes_only_candidates_and_replays_receipt
 test_apply_rejects_unsafe_manifest_and_cli_inputs
 test_apply_preflight_drift_stages_nothing
 test_apply_resumes_move_and_delete_crash_windows
+test_apply_resumes_transaction_initialization_crashes
+test_receipt_reservation_blocks_conflicting_plan
 test_shared_producer_lock_fails_closed_and_reclaims_stale
 test_apply_handles_attributable_legacy_root_transaction
 printf '\nResults: %s run, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -726,6 +726,64 @@ test_receipt_reservation_blocks_conflicting_plan() {
 	return 0
 }
 
+test_receipt_publication_owns_only_reserved_temp() {
+	local kind="" home_path="" recovery_root="" plan_path="" receipt_path=""
+	local archive_path="" bucket_path="" confirmation="" sidecar_path=""
+	local collision_home="${TEST_DIR}/completion-collision-home"
+	local collision_root="${collision_home}/recovery"
+	local collision_plan="${TEST_DIR}/completion-collision-plan.json"
+	local collision_receipt="${TEST_DIR}/completion-collision-receipt.json"
+	local completion_path=""
+	local rc=0
+
+	printf 'symlink sentinel\n' >"${TEST_DIR}/sidecar-symlink-target" || rc=1
+	for kind in regular directory symlink; do
+		home_path="${TEST_DIR}/sidecar-${kind}-home"
+		recovery_root="${home_path}/recovery"
+		plan_path="${TEST_DIR}/sidecar-${kind}-plan.json"
+		receipt_path="${TEST_DIR}/sidecar-${kind}-receipt.json"
+		sidecar_path="${receipt_path%/*}/.${receipt_path##*/}.next"
+		archive_path=$(create_candidate_plan_fixture "$home_path" \
+			"${TEST_DIR}/sidecar-${kind}-repo" "${TEST_DIR}/sidecar-${kind}-worktree" \
+			"$recovery_root" "bugfix/gh29389-sidecar-${kind}" "$plan_path") || rc=1
+		bucket_path="${archive_path%/*}"
+		confirmation=$(jq -r '.confirmation_token' "$plan_path") || rc=1
+		case "$kind" in
+		regular) printf 'regular sentinel\n' >"$sidecar_path" || rc=1 ;;
+		directory) mkdir "$sidecar_path" || rc=1 ;;
+		symlink) ln -s "${TEST_DIR}/sidecar-symlink-target" "$sidecar_path" || rc=1 ;;
+		esac
+		HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" cmd_recovery apply \
+			--plan "$plan_path" --receipt "$receipt_path" --confirm "$confirmation" >/dev/null || rc=1
+		[[ ! -e "$bucket_path" && -f "$receipt_path" ]] || rc=1
+		case "$kind" in
+		regular) [[ "$(<"$sidecar_path")" == "regular sentinel" ]] || rc=1 ;;
+		directory) [[ -d "$sidecar_path" && ! -L "$sidecar_path" ]] || rc=1 ;;
+		symlink) [[ -L "$sidecar_path" && "$(<"${TEST_DIR}/sidecar-symlink-target")" == "symlink sentinel" ]] || rc=1 ;;
+		esac
+	done
+
+	archive_path=$(create_candidate_plan_fixture "$collision_home" \
+		"${TEST_DIR}/completion-collision-repo" "${TEST_DIR}/completion-collision-worktree" \
+		"$collision_root" "bugfix/gh29389-completion-collision" "$collision_plan") || rc=1
+	bucket_path="${archive_path%/*}"
+	confirmation=$(jq -r '.confirmation_token' "$collision_plan") || rc=1
+	if AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_RECEIPT_RESERVATION=1 \
+		HOME="$collision_home" AIDEVOPS_WORKTREE_TRASH_ROOT="$collision_root" cmd_recovery apply \
+		--plan "$collision_plan" --receipt "$collision_receipt" --confirm "$confirmation" \
+		>/dev/null 2>&1; then rc=1; fi
+	completion_path=$(jq -r '.completion_path' "$collision_receipt") || rc=1
+	rm -f "$completion_path" || rc=1
+	mkdir "$completion_path" || rc=1
+	if HOME="$collision_home" AIDEVOPS_WORKTREE_TRASH_ROOT="$collision_root" cmd_recovery apply \
+		--plan "$collision_plan" --receipt "$collision_receipt" --confirm "$confirmation" \
+		>/dev/null 2>&1; then rc=1; fi
+	[[ -d "$bucket_path" && -d "$completion_path" ]] || rc=1
+	print_result "receipt_publication_owns_only_reserved_temp" "$rc" \
+		"Expected adjacent sentinels preserved and reserved-temp replacement detected before deletion"
+	return 0
+}
+
 test_shared_producer_lock_fails_closed_and_reclaims_stale() {
 	local home_path="${TEST_DIR}/lock-home"
 	local recovery_root="${home_path}/recovery"
@@ -827,6 +885,7 @@ test_apply_preflight_drift_stages_nothing
 test_apply_resumes_move_and_delete_crash_windows
 test_apply_resumes_transaction_initialization_crashes
 test_receipt_reservation_blocks_conflicting_plan
+test_receipt_publication_owns_only_reserved_temp
 test_shared_producer_lock_fails_closed_and_reclaims_stale
 test_apply_handles_attributable_legacy_root_transaction
 printf '\nResults: %s run, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# Regression tests for exact, read-only worktree recovery cleanup plans.
+# Regression tests for exact worktree recovery planning and explicit apply.
 
 set -euo pipefail
 
@@ -9,6 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="${SCRIPT_DIR}/.."
 GIT_BIN="${AIDEVOPS_TEST_GIT_BIN:-/usr/bin/git}"
 TEST_DIR=""
+TEST_LEGACY_RECOVERY_ROOT=""
 TESTS_RUN=0
 TESTS_FAILED=0
 
@@ -38,11 +39,10 @@ teardown() {
 	return 0
 }
 
-create_archived_fixture() {
+create_unarchived_fixture() {
 	local repo_path="$1"
 	local worktree_path="$2"
-	local recovery_root="$3"
-	local branch_name="$4"
+	local branch_name="$3"
 
 	"$GIT_BIN" init -q -b main "$repo_path" || return 1
 	"$GIT_BIN" -C "$repo_path" config user.email test@example.invalid || return 1
@@ -52,12 +52,86 @@ create_archived_fixture() {
 	"$GIT_BIN" -C "$repo_path" add README.md || return 1
 	"$GIT_BIN" -C "$repo_path" commit -q -m init || return 1
 	"$GIT_BIN" -C "$repo_path" worktree add -q -b "$branch_name" "$worktree_path" || return 1
+	return 0
+}
+
+create_archived_fixture() {
+	local repo_path="$1"
+	local worktree_path="$2"
+	local recovery_root="$3"
+	local branch_name="$4"
+
+	create_unarchived_fixture "$repo_path" "$worktree_path" "$branch_name" || return 1
 	AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" \
 		archive_worktree_path_recoverably "$worktree_path" "test.sh" "recovery-plan" || return 1
 	AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" remove_archived_worktree_path \
 		"$worktree_path" "$WORKTREE_RECOVERABLE_ARCHIVE_PATH" "test.sh" "recovery-plan" \
 		"recovery_path=archive-first" "false" "false" || return 1
 	printf '%s\n' "$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
+	return 0
+}
+
+create_candidate_plan_fixture() {
+	local home_path="$1"
+	local repo_path="$2"
+	local worktree_path="$3"
+	local recovery_root="$4"
+	local branch_name="$5"
+	local plan_path="$6"
+	local archive_path=""
+
+	mkdir -p "$home_path" "$recovery_root" || return 1
+	archive_path=$(create_archived_fixture "$repo_path" "$worktree_path" "$recovery_root" \
+		"$branch_name") || return 1
+	install_clear_evidence_stubs
+	HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		cmd_recovery plan --output "$plan_path" >/dev/null || return 1
+	printf '%s\n' "$archive_path"
+	return 0
+}
+
+resign_test_plan() {
+	local plan_path="$1"
+	local plan_material=""
+	local plan_digest=""
+	local candidate_count=""
+	local candidate_bytes=""
+	local confirmation=""
+	local temp_path="${plan_path}.resign.$$"
+
+	plan_material=$(_worktree_recovery_apply_plan_material "$plan_path") || return 1
+	plan_digest=$(_worktree_recovery_plan_sha256_text "$plan_material") || return 1
+	candidate_count=$(jq -r '.candidate_count' "$plan_path") || return 1
+	candidate_bytes=$(jq -r '.candidate_bytes' "$plan_path") || return 1
+	confirmation=$(_worktree_recovery_plan_confirmation_token \
+		"sha256:$plan_digest" "$candidate_count" "$candidate_bytes") || return 1
+	jq -c --arg plan_id "sha256:$plan_digest" --arg confirmation "$confirmation" \
+		'.plan_id = $plan_id | .confirmation_token = $confirmation' \
+		"$plan_path" >"$temp_path" || return 1
+	mv "$temp_path" "$plan_path" || return 1
+	return 0
+}
+
+write_test_producer_lock() {
+	local recovery_root="$1"
+	local owner_pid="$2"
+	local owner_lstart="$3"
+	local lock_path="${recovery_root}/${_WT_RECOVERY_PRODUCER_LOCK_NAME}"
+
+	mkdir "$lock_path" || return 1
+	printf '%s\n' "$owner_pid" >"$lock_path/pid" || return 1
+	printf '%s\n' "$owner_lstart" >"$lock_path/lstart" || return 1
+	printf '%s\n' "fixture-lock-token" >"$lock_path/token" || return 1
+	printf '%s\n' "complete" >"$lock_path/initialized" || return 1
+	return 0
+}
+
+remove_test_producer_lock() {
+	local recovery_root="$1"
+	local lock_path="${recovery_root}/${_WT_RECOVERY_PRODUCER_LOCK_NAME}"
+
+	rm -f "$lock_path/pid" "$lock_path/lstart" "$lock_path/token" "$lock_path/initialized" || return 1
+	rmdir "$lock_path" || return 1
 	return 0
 }
 
@@ -141,13 +215,14 @@ test_exact_plan_writes_candidate_without_mutation() {
 	[[ "$tree_digest_before" == "$tree_digest_after" ]] || rc=1
 	[[ ! -e "$worktree_path" && -d "$archive_path" ]] || rc=1
 	jq -e --arg archive "$archive_path" '
-		.schema == "aidevops.worktree-recovery-plan/v1" and .producer == "worktree-helper" and
+		.schema == "aidevops.worktree-recovery-plan/v2" and .producer == "worktree-helper" and
 		.read_only == true and .inventory_complete == true and .inventory_error == null and
 		(.source_roots | length == 1) and .entry_count == 1 and
 		.sized_entry_count == 1 and .unavailable_size_count == 0 and
 		.candidate_count == 1 and .protected_count == 0 and .unknown_count == 0 and
 		(.candidate_bytes > 0) and .candidate_bytes == .expected_allocated_bytes and
 		(.plan_id | startswith("sha256:")) and
+		(.confirmation_token | startswith("apply-sha256:")) and
 		(.entries | length == 1) and .entries[0].archive_path == $archive and
 		.entries[0].disposition == "candidate" and
 		.entries[0].expected_allocated_bytes > 0 and
@@ -334,6 +409,313 @@ test_global_inventory_failure_is_explicit() {
 	return 0
 }
 
+test_apply_removes_only_candidates_and_replays_receipt() {
+	local home_path="${TEST_DIR}/apply-home"
+	local repo_path="${TEST_DIR}/apply-repo"
+	local worktree_path="${TEST_DIR}/apply-worktree"
+	local recovery_root="${home_path}/recovery"
+	local malformed_bucket="${recovery_root}/aidevops-worktree-cleanup-unknown"
+	local plan_path="${TEST_DIR}/apply-plan.json"
+	local receipt_path="${TEST_DIR}/apply-receipt.json"
+	local archive_path=""
+	local bucket_path=""
+	local confirmation=""
+	local rc=0
+
+	mkdir -p "$recovery_root" "${malformed_bucket}/${_WT_RECOVERY_DIR_NAME}" || rc=1
+	printf '%s\n' "$_WT_RECOVERY_FORMAT_V2" > \
+		"${malformed_bucket}/${_WT_RECOVERY_DIR_NAME}/format" || rc=1
+	archive_path=$(create_archived_fixture "$repo_path" "$worktree_path" "$recovery_root" \
+		"bugfix/gh29389-apply-success") || rc=1
+	bucket_path="${archive_path%/*}"
+	install_clear_evidence_stubs
+	HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		cmd_recovery plan --output "$plan_path" >/dev/null || rc=1
+	confirmation=$(jq -r '.confirmation_token' "$plan_path") || rc=1
+	HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		cmd_recovery apply --plan "$plan_path" --receipt "$receipt_path" \
+		--confirm "$confirmation" >/dev/null || rc=1
+	[[ ! -e "$bucket_path" && -d "$malformed_bucket" && -f "$receipt_path" ]] || rc=1
+	jq -e '
+		.schema == "aidevops.worktree-recovery-apply-receipt/v1" and
+		.complete == true and .candidate_count == 1 and
+		.expected_allocated_bytes == .observed_allocated_bytes and
+		(.entries | length == 1) and .entries[0].outcome == "removed"
+	' "$receipt_path" >/dev/null || rc=1
+	HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		cmd_recovery apply --receipt "$receipt_path" --confirm "$confirmation" \
+		--plan "$plan_path" >/dev/null || rc=1
+	[[ ! -e "$bucket_path" && -d "$malformed_bucket" ]] || rc=1
+	print_result "apply_removes_only_candidates_and_replays_receipt" "$rc" \
+		"Expected exact candidate deletion, unknown preservation, an auditable receipt, and safe replay"
+	return 0
+}
+
+test_apply_rejects_unsafe_manifest_and_cli_inputs() {
+	local home_path="${TEST_DIR}/reject-home"
+	local repo_path="${TEST_DIR}/reject-repo"
+	local worktree_path="${TEST_DIR}/reject-worktree"
+	local recovery_root="${home_path}/recovery"
+	local plan_path="${TEST_DIR}/reject-plan.json"
+	local duplicate_plan="${TEST_DIR}/duplicate-plan.json"
+	local outside_plan="${TEST_DIR}/outside-plan.json"
+	local unsupported_plan="${TEST_DIR}/unsupported-plan.json"
+	local symlink_plan="${TEST_DIR}/reject-symlink-plan.json"
+	local mismatched_receipt="${TEST_DIR}/mismatched-receipt.json"
+	local receipt_path="${TEST_DIR}/rejected-receipt.json"
+	local candidate_plan=""
+	local candidate_receipt=""
+	local outside_root="${TEST_DIR}/outside-root"
+	local archive_path=""
+	local bucket_path=""
+	local confirmation=""
+	local rc=0
+
+	archive_path=$(create_candidate_plan_fixture "$home_path" "$repo_path" "$worktree_path" \
+		"$recovery_root" "bugfix/gh29389-reject-inputs" "$plan_path") || rc=1
+	bucket_path="${archive_path%/*}"
+	confirmation=$(jq -r '.confirmation_token' "$plan_path") || rc=1
+	install_clear_evidence_stubs
+	if HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		cmd_recovery apply --plan "$plan_path" --receipt "$receipt_path" \
+		--confirm "apply-sha256:$(printf '0%.0s' {1..64})" >/dev/null 2>&1; then rc=1; fi
+	if cmd_recovery apply --plan "$plan_path" --plan "$plan_path" \
+		--receipt "$receipt_path" --confirm "$confirmation" >/dev/null 2>&1; then rc=1; fi
+	if cmd_recovery apply --plan "$plan_path" --receipt "$receipt_path" \
+		--unknown value --confirm "$confirmation" >/dev/null 2>&1; then rc=1; fi
+	if cmd_recovery apply --plan "$plan_path" --receipt "$receipt_path" >/dev/null 2>&1; then rc=1; fi
+	if HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		worktree_recovery_apply "relative-plan.json" "$receipt_path" "$confirmation" \
+		>/dev/null 2>&1; then rc=1; fi
+	if HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		worktree_recovery_apply "$plan_path" "relative-receipt.json" "$confirmation" \
+		>/dev/null 2>&1; then rc=1; fi
+	candidate_receipt="${archive_path}/unsafe-receipt.json"
+	if HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		worktree_recovery_apply "$plan_path" "$candidate_receipt" "$confirmation" \
+		>/dev/null 2>&1; then rc=1; fi
+	candidate_plan="${archive_path}/unsafe-plan.json"
+	jq -c '.' "$plan_path" >"$candidate_plan" || rc=1
+	if HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		worktree_recovery_apply "$candidate_plan" "$receipt_path" "$confirmation" \
+		>/dev/null 2>&1; then rc=1; fi
+	ln -s "$plan_path" "$symlink_plan" || rc=1
+	if HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		worktree_recovery_apply "$symlink_plan" "$receipt_path" "$confirmation" \
+		>/dev/null 2>&1; then rc=1; fi
+	printf '{}\n' >"$mismatched_receipt" || rc=1
+	if HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		worktree_recovery_apply "$plan_path" "$mismatched_receipt" "$confirmation" \
+		>/dev/null 2>&1; then rc=1; fi
+	jq -c '.schema = "aidevops.worktree-recovery-plan/unsupported"' \
+		"$plan_path" >"$unsupported_plan" || rc=1
+	if HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		worktree_recovery_apply "$unsupported_plan" "$receipt_path" "$confirmation" \
+		>/dev/null 2>&1; then rc=1; fi
+	jq -c '
+		.entries += [.entries[0]] |
+		.entry_count += 1 | .sized_entry_count += 1 |
+		.expected_allocated_bytes += .entries[0].expected_allocated_bytes |
+		.candidate_count += 1 | .candidate_bytes += .entries[0].expected_allocated_bytes
+	' "$plan_path" >"$duplicate_plan" || rc=1
+	resign_test_plan "$duplicate_plan" || rc=1
+	if HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		worktree_recovery_apply "$duplicate_plan" "$receipt_path" \
+		"$(jq -r '.confirmation_token' "$duplicate_plan")" >/dev/null 2>&1; then rc=1; fi
+	mkdir -p "$outside_root" || rc=1
+	jq -c --arg path "${outside_root}/forged-bucket" \
+		--arg archive "${outside_root}/forged-bucket/archive" \
+		'.entries[0].path = $path | .entries[0].archive_path = $archive' \
+		"$plan_path" >"$outside_plan" || rc=1
+	resign_test_plan "$outside_plan" || rc=1
+	if HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		worktree_recovery_apply "$outside_plan" "$receipt_path" \
+		"$(jq -r '.confirmation_token' "$outside_plan")" >/dev/null 2>&1; then rc=1; fi
+	[[ -d "$bucket_path" && ! -e "$receipt_path" && ! -L "$receipt_path" &&
+		! -e "$candidate_receipt" ]] || rc=1
+	print_result "apply_rejects_unsafe_manifest_and_cli_inputs" "$rc" \
+		"Expected malformed consent, parser input, receipts, schemas, duplicates, and roots to fail closed"
+	return 0
+}
+
+test_apply_preflight_drift_stages_nothing() {
+	local home_path="${TEST_DIR}/preflight-home"
+	local recovery_root="${home_path}/recovery"
+	local plan_path="${TEST_DIR}/preflight-plan.json"
+	local receipt_path="${TEST_DIR}/preflight-receipt.json"
+	local archive_a="" archive_b="" bucket_a="" bucket_b="" confirmation=""
+	local staged_count=0
+	local rc=0
+
+	mkdir -p "$recovery_root" || rc=1
+	archive_a=$(create_archived_fixture "${TEST_DIR}/preflight-repo-a" \
+		"${TEST_DIR}/preflight-worktree-a" "$recovery_root" \
+		"bugfix/gh29389-preflight-a") || rc=1
+	archive_b=$(create_archived_fixture "${TEST_DIR}/preflight-repo-b" \
+		"${TEST_DIR}/preflight-worktree-b" "$recovery_root" \
+		"bugfix/gh29389-preflight-b") || rc=1
+	bucket_a="${archive_a%/*}"
+	bucket_b="${archive_b%/*}"
+	install_clear_evidence_stubs
+	HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		cmd_recovery plan --output "$plan_path" >/dev/null || rc=1
+	confirmation=$(jq -r '.confirmation_token' "$plan_path") || rc=1
+	printf 'late drift\n' >"${archive_b}/late-drift.bin" || rc=1
+	if HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		cmd_recovery apply --plan "$plan_path" --receipt "$receipt_path" \
+		--confirm "$confirmation" >/dev/null 2>&1; then rc=1; fi
+	[[ -d "$bucket_a" && -d "$bucket_b" && ! -e "$receipt_path" ]] || rc=1
+	for staged_path in "$recovery_root"/.retention-trash/apply-*/candidate-*; do
+		[[ -e "$staged_path" || -L "$staged_path" ]] || continue
+		staged_count=$((staged_count + 1))
+	done
+	[[ "$staged_count" -eq 0 ]] || rc=1
+	print_result "apply_preflight_drift_stages_nothing" "$rc" \
+		"Expected one late candidate drift to leave the complete batch at original paths"
+	return 0
+}
+
+test_apply_resumes_move_and_delete_crash_windows() {
+	local move_home="${TEST_DIR}/move-home"
+	local move_root="${move_home}/recovery"
+	local move_plan="${TEST_DIR}/move-plan.json"
+	local move_receipt="${TEST_DIR}/move-receipt.json"
+	local delete_home="${TEST_DIR}/delete-home"
+	local delete_root="${delete_home}/recovery"
+	local delete_plan="${TEST_DIR}/delete-plan.json"
+	local delete_receipt="${TEST_DIR}/delete-receipt.json"
+	local archive_path="" bucket_path="" confirmation="" journal_path="" staged_path=""
+	local candidate_journal=""
+	local rc=0
+
+	archive_path=$(create_candidate_plan_fixture "$move_home" "${TEST_DIR}/move-repo" \
+		"${TEST_DIR}/move-worktree" "$move_root" "bugfix/gh29389-move-interrupt" \
+		"$move_plan") || rc=1
+	bucket_path="${archive_path%/*}"
+	confirmation=$(jq -r '.confirmation_token' "$move_plan") || rc=1
+	install_clear_evidence_stubs
+	if AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_MOVE=1 HOME="$move_home" \
+		AIDEVOPS_WORKTREE_TRASH_ROOT="$move_root" cmd_recovery apply \
+		--plan "$move_plan" --receipt "$move_receipt" --confirm "$confirmation" \
+		>/dev/null 2>&1; then rc=1; fi
+	for candidate_journal in "$move_root"/.retention-trash/apply-*/journal.json; do
+		[[ -f "$candidate_journal" ]] || continue
+		journal_path="$candidate_journal"
+	done
+	[[ -n "$journal_path" && ! -e "$bucket_path" && ! -e "$move_receipt" ]] || rc=1
+	staged_path=$(jq -r '.entries[0].staged_path' "$journal_path") || rc=1
+	[[ "$(jq -r '.entries[0].state' "$journal_path")" == "planned" && -d "$staged_path" ]] || rc=1
+	HOME="$move_home" AIDEVOPS_WORKTREE_TRASH_ROOT="$move_root" cmd_recovery apply \
+		--plan "$move_plan" --receipt "$move_receipt" --confirm "$confirmation" \
+		>/dev/null || rc=1
+	[[ -f "$move_receipt" && ! -e "$staged_path" ]] || rc=1
+
+	archive_path=$(create_candidate_plan_fixture "$delete_home" "${TEST_DIR}/delete-repo" \
+		"${TEST_DIR}/delete-worktree" "$delete_root" "bugfix/gh29389-delete-interrupt" \
+		"$delete_plan") || rc=1
+	bucket_path="${archive_path%/*}"
+	confirmation=$(jq -r '.confirmation_token' "$delete_plan") || rc=1
+	install_clear_evidence_stubs
+	if AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_DELETE=1 HOME="$delete_home" \
+		AIDEVOPS_WORKTREE_TRASH_ROOT="$delete_root" cmd_recovery apply \
+		--plan "$delete_plan" --receipt "$delete_receipt" --confirm "$confirmation" \
+		>/dev/null 2>&1; then rc=1; fi
+	journal_path=""
+	for candidate_journal in "$delete_root"/.retention-trash/apply-*/journal.json; do
+		[[ -f "$candidate_journal" ]] || continue
+		journal_path="$candidate_journal"
+	done
+	[[ -n "$journal_path" && ! -e "$bucket_path" && ! -e "$delete_receipt" ]] || rc=1
+	staged_path=$(jq -r '.entries[0].staged_path' "$journal_path") || rc=1
+	[[ "$(jq -r '.entries[0].state' "$journal_path")" == "staged" && ! -e "$staged_path" ]] || rc=1
+	HOME="$delete_home" AIDEVOPS_WORKTREE_TRASH_ROOT="$delete_root" cmd_recovery apply \
+		--plan "$delete_plan" --receipt "$delete_receipt" --confirm "$confirmation" \
+		>/dev/null || rc=1
+	[[ -f "$delete_receipt" ]] || rc=1
+	print_result "apply_resumes_move_and_delete_crash_windows" "$rc" \
+		"Expected retries to reconcile exact journal state after rename or delete interruption"
+	return 0
+}
+
+test_shared_producer_lock_fails_closed_and_reclaims_stale() {
+	local home_path="${TEST_DIR}/lock-home"
+	local recovery_root="${home_path}/recovery"
+	local plan_path="${TEST_DIR}/lock-plan.json"
+	local receipt_path="${TEST_DIR}/lock-receipt.json"
+	local archive_path="" bucket_path="" confirmation="" live_lstart=""
+	local source_repo="${TEST_DIR}/lock-source-repo"
+	local source_worktree="${TEST_DIR}/lock-source-worktree"
+	local lock_path="${recovery_root}/${_WT_RECOVERY_PRODUCER_LOCK_NAME}"
+	local rc=0
+
+	archive_path=$(create_candidate_plan_fixture "$home_path" "${TEST_DIR}/lock-repo" \
+		"${TEST_DIR}/lock-worktree" "$recovery_root" "bugfix/gh29389-lock-apply" \
+		"$plan_path") || rc=1
+	bucket_path="${archive_path%/*}"
+	confirmation=$(jq -r '.confirmation_token' "$plan_path") || rc=1
+	create_unarchived_fixture "$source_repo" "$source_worktree" \
+		"bugfix/gh29389-lock-archive" || rc=1
+	live_lstart=$(_worktree_recovery_process_lstart "$$") || rc=1
+	write_test_producer_lock "$recovery_root" "$$" "$live_lstart" || rc=1
+	install_clear_evidence_stubs
+	if HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		cmd_recovery apply --plan "$plan_path" --receipt "$receipt_path" \
+		--confirm "$confirmation" >/dev/null 2>&1; then rc=1; fi
+	if HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" archive_worktree_path_recoverably \
+		"$source_worktree" "test.sh" "shared-lock" >/dev/null 2>&1; then rc=1; fi
+	[[ -d "$bucket_path" && -d "$source_worktree" && ! -e "$receipt_path" ]] || rc=1
+	remove_test_producer_lock "$recovery_root" || rc=1
+	mkdir "$lock_path" || rc=1
+	if HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		cmd_recovery apply --plan "$plan_path" --receipt "$receipt_path" \
+		--confirm "$confirmation" >/dev/null 2>&1; then rc=1; fi
+	rmdir "$lock_path" || rc=1
+	write_test_producer_lock "$recovery_root" "999999999" "stale-process-generation" || rc=1
+	HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" cmd_recovery apply \
+		--plan "$plan_path" --receipt "$receipt_path" --confirm "$confirmation" \
+		>/dev/null || rc=1
+	[[ ! -e "$bucket_path" && -f "$receipt_path" && ! -e "$lock_path" ]] || rc=1
+	print_result "shared_producer_lock_fails_closed_and_reclaims_stale" "$rc" \
+		"Expected live/malformed locks to block both producers and a proven stale lock to be reclaimed"
+	return 0
+}
+
+test_apply_handles_attributable_legacy_root_transaction() {
+	local home_path="${TEST_DIR}/legacy-home"
+	local current_root="${home_path}/current-recovery"
+	local legacy_root="${home_path}/.Trash"
+	local plan_path="${TEST_DIR}/legacy-plan.json"
+	local receipt_path="${TEST_DIR}/legacy-receipt.json"
+	local archive_path="" bucket_path="" confirmation=""
+	local rc=0
+
+	mkdir -p "$current_root" "$legacy_root" || rc=1
+	archive_path=$(create_archived_fixture "${TEST_DIR}/legacy-repo" \
+		"${TEST_DIR}/legacy-worktree" "$legacy_root" \
+		"bugfix/gh29389-legacy-transaction") || rc=1
+	bucket_path="${archive_path%/*}"
+	TEST_LEGACY_RECOVERY_ROOT="$legacy_root"
+	_worktree_legacy_recovery_root() {
+		local ignored_platform="${1:-}"
+		: "$ignored_platform"
+		printf '%s\n' "$TEST_LEGACY_RECOVERY_ROOT"
+		return 0
+	}
+	install_clear_evidence_stubs
+	HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$current_root" \
+		cmd_recovery plan --output "$plan_path" >/dev/null || rc=1
+	confirmation=$(jq -r '.confirmation_token' "$plan_path") || rc=1
+	HOME="$home_path" AIDEVOPS_WORKTREE_TRASH_ROOT="$current_root" cmd_recovery apply \
+		--plan "$plan_path" --receipt "$receipt_path" --confirm "$confirmation" \
+		>/dev/null || rc=1
+	[[ ! -e "$bucket_path" && -f "$receipt_path" &&
+		! -d "$legacy_root/.retention-trash" && ! -d "$current_root/.retention-trash" ]] || rc=1
+	print_result "apply_handles_attributable_legacy_root_transaction" "$rc" \
+		"Expected one locked journal to stage and clean an exact candidate in an attributable legacy root"
+	return 0
+}
+
 # shellcheck source=../audit-worktree-removal-helper.sh
 source "${SCRIPTS_DIR}/audit-worktree-removal-helper.sh"
 # shellcheck source=../worktree-recovery-lifecycle-helper.sh
@@ -350,5 +732,11 @@ test_classification_fails_closed
 test_plan_records_malformed_bucket_unknown
 test_size_drift_downgrades_only_entry
 test_global_inventory_failure_is_explicit
+test_apply_removes_only_candidates_and_replays_receipt
+test_apply_rejects_unsafe_manifest_and_cli_inputs
+test_apply_preflight_drift_stages_nothing
+test_apply_resumes_move_and_delete_crash_windows
+test_shared_producer_lock_fails_closed_and_reclaims_stale
+test_apply_handles_attributable_legacy_root_transaction
 printf '\nResults: %s run, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-worktree-removal-audit.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit.sh
@@ -1988,6 +1988,44 @@ test_manual_guard_refusal_diagnostics() {
 }
 
 # =============================================================================
+# Archive publication uses the same exclusive producer lock as recovery apply.
+# =============================================================================
+test_recoverable_archive_honours_shared_producer_lock() {
+	local repo_path="${TEST_DIR}/producer-lock-repo"
+	local wt_path="${TEST_DIR}/producer-lock-worktree"
+	local recovery_root="${TEST_DIR}/producer-lock-recovery"
+	local lock_path="${recovery_root}/${_WT_RECOVERY_PRODUCER_LOCK_NAME}"
+	local process_lstart=""
+	local archive_path=""
+	local rc=0
+
+	create_git_worktree_fixture "$repo_path" "$wt_path" "feature/producer-lock" || rc=1
+	mkdir -p "$recovery_root" "$lock_path" || rc=1
+	process_lstart=$(_worktree_recovery_process_lstart "$$") || rc=1
+	printf '%s\n' "$$" >"$lock_path/pid" || rc=1
+	printf '%s\n' "$process_lstart" >"$lock_path/lstart" || rc=1
+	printf '%s\n' "archive-lock-fixture" >"$lock_path/token" || rc=1
+	printf '%s\n' "complete" >"$lock_path/initialized" || rc=1
+	if AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" \
+		archive_worktree_path_recoverably "$wt_path" "test.sh" "producer-lock"; then
+		rc=1
+	fi
+	[[ -d "$wt_path" && -d "$lock_path" ]] || rc=1
+	if compgen -G "${recovery_root}/aidevops-worktree-cleanup-*" >/dev/null; then rc=1; fi
+	rm -f "$lock_path/pid" "$lock_path/lstart" "$lock_path/token" "$lock_path/initialized" || rc=1
+	rmdir "$lock_path" || rc=1
+	AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" AIDEVOPS_REAL_GIT_BIN="$GIT_BIN" \
+		archive_worktree_path_recoverably "$wt_path" "test.sh" "producer-lock" || rc=1
+	archive_path="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
+	[[ -d "$archive_path" &&
+		-f "${archive_path%/*}/${_WT_RECOVERY_DIR_NAME}/${_WT_RECOVERY_COMPLETE_MARKER}" &&
+		! -e "$lock_path" ]] || rc=1
+	print_result "recoverable_archive_honours_shared_producer_lock" "$rc" \
+		"Expected a live apply-compatible lock to block archive publication through its completion marker"
+	return 0
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -2042,6 +2080,7 @@ test_proc_snapshot_requires_usable_evidence_after_foreign_skips
 test_proc_snapshot_ignores_vanished_entry
 test_guard_reason_is_machine_readable
 test_manual_guard_refusal_diagnostics
+test_recoverable_archive_honours_shared_producer_lock
 
 echo ""
 echo "Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed."

--- a/.agents/scripts/worktree-helper-cmds.sh
+++ b/.agents/scripts/worktree-helper-cmds.sh
@@ -690,6 +690,10 @@ COMMANDS
   recovery plan --output <absolute-path>
                          Write an exact read-only cleanup plan. Existing or
                          symlinked outputs and ambiguous evidence fail closed.
+  recovery apply --plan <absolute-path> --receipt <absolute-new-path>
+                 --confirm <manifest-token>
+                         Apply only exact candidates from a supported plan after
+                         locked revalidation, staging, and receipt publication.
 
   registry [list|prune]  View or prune the ownership registry (t189, t197)
                          list: Show all registered worktrees with ownership info
@@ -770,11 +774,15 @@ EOF
 cmd_recovery() {
 	local action="${1:-status}"
 	local output_path=""
+	local plan_path=""
+	local receipt_path=""
+	local confirmation=""
+	local option=""
 
 	case "$action" in
 	status)
 		[[ "$#" -eq 0 || ("$#" -eq 1 && "$1" == "status") ]] || {
-			printf '%s\n' "Usage: worktree-helper.sh recovery [plan --output <absolute-path>]" >&2
+			printf '%s\n' "Usage: worktree-helper.sh recovery [plan --output <absolute-path>|apply --plan <absolute-path> --receipt <absolute-new-path> --confirm <manifest-token>]" >&2
 			return 1
 		}
 		if declare -F worktree_recovery_lifecycle_status >/dev/null 2>&1; then
@@ -792,8 +800,38 @@ cmd_recovery() {
 		declare -F worktree_recovery_plan_write >/dev/null 2>&1 || return 1
 		worktree_recovery_plan_write "$output_path" || return 1
 		;;
+	apply)
+		shift
+		while [[ "$#" -gt 0 ]]; do
+			option="$1"
+			shift
+			[[ "$#" -gt 0 ]] || return 1
+			case "$option" in
+			--plan)
+				[[ -z "$plan_path" ]] || return 1
+				plan_path="$1"
+				;;
+			--receipt)
+				[[ -z "$receipt_path" ]] || return 1
+				receipt_path="$1"
+				;;
+			--confirm)
+				[[ -z "$confirmation" ]] || return 1
+				confirmation="$1"
+				;;
+			*) return 1 ;;
+			esac
+			shift
+		done
+		[[ -n "$plan_path" && -n "$receipt_path" && -n "$confirmation" ]] || {
+			printf '%s\n' "Usage: worktree-helper.sh recovery apply --plan <absolute-path> --receipt <absolute-new-path> --confirm <manifest-token>" >&2
+			return 1
+		}
+		declare -F worktree_recovery_apply >/dev/null 2>&1 || return 1
+		worktree_recovery_apply "$plan_path" "$receipt_path" "$confirmation" || return 1
+		;;
 	*)
-		printf '%s\n' "Usage: worktree-helper.sh recovery [plan --output <absolute-path>]" >&2
+		printf '%s\n' "Usage: worktree-helper.sh recovery [plan --output <absolute-path>|apply --plan <absolute-path> --receipt <absolute-new-path> --confirm <manifest-token>]" >&2
 		return 1
 		;;
 	esac

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -21,8 +21,8 @@
 #   status                 Show current worktree info
 #   switch <branch>        Open/create worktree for branch (prints path)
 #   clean [--auto] [--force-merged]  Remove worktrees for merged branches
-#   recovery [plan --output <absolute-path>]
-#                         Inventory archives or write an exact read-only plan
+#   recovery [plan|apply] Inventory archives, write a plan, or explicitly apply
+#                         one exact manifest with a new receipt
 #   help                   Show this help
 #
 # Examples:

--- a/.agents/scripts/worktree-recovery-apply-helper.sh
+++ b/.agents/scripts/worktree-recovery-apply-helper.sh
@@ -20,6 +20,7 @@ WORKTREE_RECOVERY_APPLY_JSON_TYPE_STRING="string"
 WORKTREE_RECOVERY_APPLY_TRASH_SEGMENT="/.retention-trash/"
 WORKTREE_RECOVERY_APPLY_VALIDATED_METADATA=""
 WORKTREE_RECOVERY_APPLY_VALIDATED_PLAN_JSON=""
+WORKTREE_RECOVERY_APPLY_RECEIPT_COMPLETION_PATH=""
 
 _worktree_recovery_apply_canonical_path() {
 	local path="$1"
@@ -249,16 +250,18 @@ _worktree_recovery_apply_new_receipt_path() {
 _worktree_recovery_apply_reservation_json() {
 	local apply_metadata="$1"
 	local transaction_id="$2"
+	local completion_path="$3"
 	local reserved_at=""
 
 	reserved_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
 	printf '%s\n' "$apply_metadata" | jq -c \
 		--arg schema "$WORKTREE_RECOVERY_APPLY_RESERVATION_SCHEMA" \
-		--arg transaction_id "$transaction_id" --arg reserved_at "$reserved_at" '
+		--arg transaction_id "$transaction_id" --arg reserved_at "$reserved_at" \
+		--arg completion_path "$completion_path" '
 		{schema:$schema,complete:false,plan_id:.plan_id,plan_digest:.plan_digest,
 		confirmation:.confirmation,candidate_count:.candidate_count,
 		expected_allocated_bytes:.candidate_bytes,transaction_id:$transaction_id,
-		reserved_at:$reserved_at}'
+		reserved_at:$reserved_at,completion_path:$completion_path}'
 	return $?
 }
 
@@ -266,15 +269,18 @@ _worktree_recovery_apply_validate_reservation() {
 	local receipt_path="$1"
 	local apply_metadata="$2"
 	local transaction_id="$3"
+	local canonical_receipt=""
+	local completion_path=""
 
-	_worktree_recovery_apply_canonical_path "$receipt_path" >/dev/null || return 1
+	WORKTREE_RECOVERY_APPLY_RECEIPT_COMPLETION_PATH=""
+	canonical_receipt=$(_worktree_recovery_apply_canonical_path "$receipt_path") || return 1
 	[[ -f "$receipt_path" && ! -L "$receipt_path" && -r "$receipt_path" ]] || return 1
 	jq -e --argjson expected "$apply_metadata" \
 		--arg schema "$WORKTREE_RECOVERY_APPLY_RESERVATION_SCHEMA" \
 		--arg transaction_id "$transaction_id" \
 		--arg string_type "$WORKTREE_RECOVERY_APPLY_JSON_TYPE_STRING" '
 		type == "object" and
-		(keys | sort) == (["candidate_count","complete","confirmation",
+		(keys | sort) == (["candidate_count","complete","completion_path","confirmation",
 			"expected_allocated_bytes","plan_digest","plan_id","reserved_at","schema",
 			"transaction_id"] | sort) and
 		.schema == $schema and .complete == false and
@@ -282,9 +288,36 @@ _worktree_recovery_apply_validate_reservation() {
 		.confirmation == $expected.confirmation and
 		.candidate_count == $expected.candidate_count and
 		.expected_allocated_bytes == $expected.candidate_bytes and
-		.transaction_id == $transaction_id and (.reserved_at | type == $string_type)
-	' "$receipt_path" >/dev/null 2>&1
-	return $?
+		.transaction_id == $transaction_id and (.reserved_at | type == $string_type) and
+		(.completion_path | type == $string_type)
+	' "$receipt_path" >/dev/null 2>&1 || return 1
+	completion_path=$(jq -r '.completion_path' "$receipt_path") || return 1
+	[[ "$completion_path" == "${canonical_receipt%/*}/.${canonical_receipt##*/}.apply."* &&
+		-f "$completion_path" && ! -L "$completion_path" && -w "$completion_path" ]] || return 1
+	WORKTREE_RECOVERY_APPLY_RECEIPT_COMPLETION_PATH="$completion_path"
+	return 0
+}
+
+_worktree_recovery_apply_allocate_receipt_completion() {
+	local receipt_path="$1"
+	local parent_path="${receipt_path%/*}"
+	local base_name="${receipt_path##*/}"
+	local completion_path=""
+	local previous_umask=""
+
+	previous_umask=$(umask)
+	umask 077
+	completion_path=$(mktemp "${parent_path}/.${base_name}.apply.XXXXXX") || {
+		umask "$previous_umask"
+		return 1
+	}
+	umask "$previous_umask"
+	chmod 600 "$completion_path" || {
+		rm -f "$completion_path"
+		return 1
+	}
+	printf '%s\n' "$completion_path"
+	return 0
 }
 
 # Reserve the caller-selected receipt path before any archive mutation. Return 2
@@ -294,6 +327,7 @@ _worktree_recovery_apply_ensure_receipt_reservation() {
 	local apply_metadata="$2"
 	local transaction_id="$3"
 	local reservation_json=""
+	local completion_path=""
 
 	if [[ -e "$receipt_path" || -L "$receipt_path" ]]; then
 		if _worktree_recovery_apply_validate_receipt_replay "$receipt_path" "$apply_metadata"; then
@@ -304,11 +338,38 @@ _worktree_recovery_apply_ensure_receipt_reservation() {
 		return 0
 	fi
 	_worktree_recovery_apply_new_receipt_path "$receipt_path" || return 1
+	completion_path=$(_worktree_recovery_apply_allocate_receipt_completion "$receipt_path") || return 1
 	reservation_json=$(_worktree_recovery_apply_reservation_json \
-		"$apply_metadata" "$transaction_id") || return 1
-	_worktree_recovery_apply_publish_new "$receipt_path" "$reservation_json" || return 1
+		"$apply_metadata" "$transaction_id" "$completion_path") || {
+		rm -f "$completion_path"
+		return 1
+	}
+	_worktree_recovery_apply_publish_new "$receipt_path" "$reservation_json" || {
+		rm -f "$completion_path"
+		return 1
+	}
 	_worktree_recovery_apply_validate_reservation \
 		"$receipt_path" "$apply_metadata" "$transaction_id"
+	return $?
+}
+
+_worktree_recovery_apply_publish_reserved_receipt() {
+	local receipt_path="$1"
+	local apply_metadata="$2"
+	local transaction_id="$3"
+	local receipt_json="$4"
+	local completion_path=""
+
+	_worktree_recovery_apply_validate_reservation \
+		"$receipt_path" "$apply_metadata" "$transaction_id" || return 1
+	completion_path="$WORKTREE_RECOVERY_APPLY_RECEIPT_COMPLETION_PATH"
+	printf '%s\n' "$receipt_json" >"$completion_path" || return 1
+	chmod 600 "$completion_path" || return 1
+	_worktree_recovery_apply_validate_reservation \
+		"$receipt_path" "$apply_metadata" "$transaction_id" || return 1
+	[[ "$completion_path" == "$WORKTREE_RECOVERY_APPLY_RECEIPT_COMPLETION_PATH" ]] || return 1
+	mv "$completion_path" "$receipt_path" || return 1
+	_worktree_recovery_apply_validate_receipt_replay "$receipt_path" "$apply_metadata"
 	return $?
 }
 
@@ -907,10 +968,8 @@ _worktree_recovery_apply_under_lock() {
 	_worktree_recovery_apply_validate_all_staged "$journal_path" || return 1
 	_worktree_recovery_apply_remove_staged "$journal_path" || return 1
 	receipt_json=$(_worktree_recovery_apply_receipt_json "$journal_path" "$apply_metadata") || return 1
-	_worktree_recovery_apply_validate_reservation \
-		"$receipt_path" "$apply_metadata" "$transaction_id" || return 1
-	_worktree_recovery_apply_atomic_replace "$receipt_path" "$receipt_json" || return 1
-	_worktree_recovery_apply_validate_receipt_replay "$receipt_path" "$apply_metadata" || return 1
+	_worktree_recovery_apply_publish_reserved_receipt \
+		"$receipt_path" "$apply_metadata" "$transaction_id" "$receipt_json" || return 1
 	_worktree_recovery_apply_cleanup_transaction "$journal_path" || return 1
 	return 0
 }
@@ -919,7 +978,6 @@ worktree_recovery_apply() {
 	local plan_path="$1"
 	local receipt_path="$2"
 	local supplied_confirmation="$3"
-	local apply_metadata=""
 	local plan_json=""
 	local recovery_root=""
 	local recovery_root_real=""
@@ -927,8 +985,8 @@ worktree_recovery_apply() {
 
 	command -v jq >/dev/null 2>&1 || return 1
 	_worktree_recovery_apply_validate_plan "$plan_path" "$supplied_confirmation" || return 1
-	apply_metadata="$WORKTREE_RECOVERY_APPLY_VALIDATED_METADATA"
 	plan_json="$WORKTREE_RECOVERY_APPLY_VALIDATED_PLAN_JSON"
+	receipt_path=$(_worktree_recovery_apply_canonical_path "$receipt_path") || return 1
 	_worktree_recovery_apply_validate_control_path_scope \
 		"$receipt_path" "$plan_json" || return 1
 	recovery_root=$(_worktree_recovery_store_root) || return 1

--- a/.agents/scripts/worktree-recovery-apply-helper.sh
+++ b/.agents/scripts/worktree-recovery-apply-helper.sh
@@ -17,6 +17,7 @@ WORKTREE_RECOVERY_APPLY_OUTCOME_REMOVED="$WORKTREE_RECOVERY_APPLY_STATE_REMOVED"
 WORKTREE_RECOVERY_APPLY_JSON_TYPE_NUMBER="number"
 WORKTREE_RECOVERY_APPLY_JSON_TYPE_OBJECT="object"
 WORKTREE_RECOVERY_APPLY_JSON_TYPE_STRING="string"
+WORKTREE_RECOVERY_APPLY_TRASH_SEGMENT="/.retention-trash/"
 WORKTREE_RECOVERY_APPLY_VALIDATED_METADATA=""
 WORKTREE_RECOVERY_APPLY_VALIDATED_PLAN_JSON=""
 
@@ -317,6 +318,7 @@ _worktree_recovery_apply_transaction_entries() {
 
 	printf '%s\n' "$plan_json" | jq -c --arg candidate "$WORKTREE_RECOVERY_PLAN_DISPOSITION_CANDIDATE" \
 		--arg transaction_id "$transaction_id" \
+		--arg trash_segment "$WORKTREE_RECOVERY_APPLY_TRASH_SEGMENT" \
 		--arg planned "$WORKTREE_RECOVERY_APPLY_STATE_PLANNED" \
 		--arg pending "$WORKTREE_RECOVERY_APPLY_OUTCOME_PENDING" '
 		def parent_path: .[0:rindex("/")];
@@ -324,7 +326,7 @@ _worktree_recovery_apply_transaction_entries() {
 		[.entries[] | select(.disposition == $candidate)] | to_entries | map(
 			.key as $index | .value as $entry |
 			{index:$index,role:$entry.role,original_path:$entry.path,
-			staged_path:(($entry.path | parent_path) + "/.retention-trash/" + $transaction_id +
+			staged_path:(($entry.path | parent_path) + $trash_segment + $transaction_id +
 				"/candidate-" + ($index | tostring) + "-" + ($entry.path | base_name)),
 			archive_name:($entry.archive_path | base_name),
 			expected_allocated_bytes:$entry.expected_allocated_bytes,
@@ -435,10 +437,11 @@ _worktree_recovery_apply_validate_uninitialized_transaction_dirs() {
 	local transaction_dirs=""
 
 	transaction_dirs=$(printf '%s\n' "$entries_json" | jq -c \
-		--arg recovery_root "$recovery_root" --arg transaction_id "$transaction_id" '
+		--arg recovery_root "$recovery_root" --arg transaction_id "$transaction_id" \
+		--arg trash_segment "$WORKTREE_RECOVERY_APPLY_TRASH_SEGMENT" '
 		([$recovery_root] + [.[] | .original_path as $original_path |
 			$original_path[0:($original_path | rindex("/"))]]) | unique |
-		map(. + "/.retention-trash/" + $transaction_id)
+		map(. + $trash_segment + $transaction_id)
 	') || return 1
 	while IFS= read -r transaction_dir; do
 		[[ -e "$transaction_dir" || -L "$transaction_dir" ]] || continue
@@ -499,14 +502,15 @@ _worktree_recovery_apply_validate_transaction_scope() {
 	local transaction_dir=""
 	local artifact=""
 
-	jq -e --arg string_type "$WORKTREE_RECOVERY_APPLY_JSON_TYPE_STRING" '
+	jq -e --arg string_type "$WORKTREE_RECOVERY_APPLY_JSON_TYPE_STRING" \
+		--arg trash_segment "$WORKTREE_RECOVERY_APPLY_TRASH_SEGMENT" '
 		.transaction_id as $transaction_id |
 		all(.entries[];
 			.original_path as $original_path | .staged_path as $staged_path |
 			($staged_path | type == $string_type) and
 			($staged_path[0:($staged_path | rindex("/"))] ==
 				($original_path[0:($original_path | rindex("/"))] +
-				"/.retention-trash/" + $transaction_id)))
+				$trash_segment + $transaction_id)))
 	' "$journal_path" >/dev/null 2>&1 || return 1
 	while IFS= read -r transaction_dir; do
 		[[ -d "$transaction_dir" && ! -L "$transaction_dir" ]] || return 1

--- a/.agents/scripts/worktree-recovery-apply-helper.sh
+++ b/.agents/scripts/worktree-recovery-apply-helper.sh
@@ -7,6 +7,7 @@
 _WORKTREE_RECOVERY_APPLY_HELPER_LOADED=1
 
 WORKTREE_RECOVERY_APPLY_RECEIPT_SCHEMA="aidevops.worktree-recovery-apply-receipt/v1"
+WORKTREE_RECOVERY_APPLY_RESERVATION_SCHEMA="aidevops.worktree-recovery-apply-reservation/v1"
 WORKTREE_RECOVERY_APPLY_TRANSACTION_SCHEMA="aidevops.worktree-recovery-apply-transaction/v1"
 WORKTREE_RECOVERY_APPLY_STATE_PLANNED="planned"
 WORKTREE_RECOVERY_APPLY_STATE_STAGED="staged"
@@ -244,6 +245,72 @@ _worktree_recovery_apply_new_receipt_path() {
 	return 0
 }
 
+_worktree_recovery_apply_reservation_json() {
+	local apply_metadata="$1"
+	local transaction_id="$2"
+	local reserved_at=""
+
+	reserved_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+	printf '%s\n' "$apply_metadata" | jq -c \
+		--arg schema "$WORKTREE_RECOVERY_APPLY_RESERVATION_SCHEMA" \
+		--arg transaction_id "$transaction_id" --arg reserved_at "$reserved_at" '
+		{schema:$schema,complete:false,plan_id:.plan_id,plan_digest:.plan_digest,
+		confirmation:.confirmation,candidate_count:.candidate_count,
+		expected_allocated_bytes:.candidate_bytes,transaction_id:$transaction_id,
+		reserved_at:$reserved_at}'
+	return $?
+}
+
+_worktree_recovery_apply_validate_reservation() {
+	local receipt_path="$1"
+	local apply_metadata="$2"
+	local transaction_id="$3"
+
+	_worktree_recovery_apply_canonical_path "$receipt_path" >/dev/null || return 1
+	[[ -f "$receipt_path" && ! -L "$receipt_path" && -r "$receipt_path" ]] || return 1
+	jq -e --argjson expected "$apply_metadata" \
+		--arg schema "$WORKTREE_RECOVERY_APPLY_RESERVATION_SCHEMA" \
+		--arg transaction_id "$transaction_id" \
+		--arg string_type "$WORKTREE_RECOVERY_APPLY_JSON_TYPE_STRING" '
+		type == "object" and
+		(keys | sort) == (["candidate_count","complete","confirmation",
+			"expected_allocated_bytes","plan_digest","plan_id","reserved_at","schema",
+			"transaction_id"] | sort) and
+		.schema == $schema and .complete == false and
+		.plan_id == $expected.plan_id and .plan_digest == $expected.plan_digest and
+		.confirmation == $expected.confirmation and
+		.candidate_count == $expected.candidate_count and
+		.expected_allocated_bytes == $expected.candidate_bytes and
+		.transaction_id == $transaction_id and (.reserved_at | type == $string_type)
+	' "$receipt_path" >/dev/null 2>&1
+	return $?
+}
+
+# Reserve the caller-selected receipt path before any archive mutation. Return 2
+# only when an exact completed receipt proves this plan already finished.
+_worktree_recovery_apply_ensure_receipt_reservation() {
+	local receipt_path="$1"
+	local apply_metadata="$2"
+	local transaction_id="$3"
+	local reservation_json=""
+
+	if [[ -e "$receipt_path" || -L "$receipt_path" ]]; then
+		if _worktree_recovery_apply_validate_receipt_replay "$receipt_path" "$apply_metadata"; then
+			return 2
+		fi
+		_worktree_recovery_apply_validate_reservation \
+			"$receipt_path" "$apply_metadata" "$transaction_id" || return 1
+		return 0
+	fi
+	_worktree_recovery_apply_new_receipt_path "$receipt_path" || return 1
+	reservation_json=$(_worktree_recovery_apply_reservation_json \
+		"$apply_metadata" "$transaction_id") || return 1
+	_worktree_recovery_apply_publish_new "$receipt_path" "$reservation_json" || return 1
+	_worktree_recovery_apply_validate_reservation \
+		"$receipt_path" "$apply_metadata" "$transaction_id"
+	return $?
+}
+
 _worktree_recovery_apply_transaction_entries() {
 	local plan_json="$1"
 	local transaction_id="$2"
@@ -272,19 +339,30 @@ _worktree_recovery_apply_atomic_replace() {
 	local payload="$2"
 	local parent_path="${output_path%/*}"
 	local base_name="${output_path##*/}"
-	local temp_path=""
+	local temp_path="${parent_path}/.${base_name}.next"
 	local previous_umask=""
 
 	[[ -d "$parent_path" && ! -L "$parent_path" ]] || return 1
+	if [[ -e "$temp_path" || -L "$temp_path" ]]; then
+		[[ -f "$temp_path" && ! -L "$temp_path" ]] || return 1
+		rm -f "$temp_path" || return 1
+	fi
 	previous_umask=$(umask)
 	umask 077
-	temp_path=$(mktemp "${parent_path}/.${base_name}.tmp.XXXXXX") || {
+	if ! (set -C && printf '%s\n' "$payload" >"$temp_path"); then
 		umask "$previous_umask"
 		return 1
-	}
+	fi
 	umask "$previous_umask"
-	if ! printf '%s\n' "$payload" >"$temp_path" || ! chmod 600 "$temp_path" ||
-		! mv "$temp_path" "$output_path"; then
+	if ! chmod 600 "$temp_path"; then
+		rm -f "$temp_path"
+		return 1
+	fi
+	if [[ "$base_name" == "journal.json" &&
+		"${AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_JOURNAL_NEXT:-0}" == "1" ]]; then
+		return 1
+	fi
+	if ! mv "$temp_path" "$output_path"; then
 		rm -f "$temp_path"
 		return 1
 	fi
@@ -334,6 +412,47 @@ _worktree_recovery_apply_prepare_transaction_dir() {
 		mkdir "$transaction_dir" || return 1
 	fi
 	return 0
+}
+
+_worktree_recovery_apply_discard_next_file() {
+	local output_path="$1"
+	local next_path="${output_path%/*}/.${output_path##*/}.next"
+
+	[[ -e "$next_path" || -L "$next_path" ]] || return 0
+	[[ -f "$next_path" && ! -L "$next_path" ]] || return 1
+	rm -f "$next_path"
+	return $?
+}
+
+_worktree_recovery_apply_validate_uninitialized_transaction_dirs() {
+	local recovery_root="$1"
+	local entries_json="$2"
+	local transaction_id="$3"
+	local journal_path="$4"
+	local journal_next="${journal_path%/*}/.${journal_path##*/}.next"
+	local transaction_dir=""
+	local artifact=""
+	local transaction_dirs=""
+
+	transaction_dirs=$(printf '%s\n' "$entries_json" | jq -c \
+		--arg recovery_root "$recovery_root" --arg transaction_id "$transaction_id" '
+		([$recovery_root] + [.[] | .original_path as $original_path |
+			$original_path[0:($original_path | rindex("/"))]]) | unique |
+		map(. + "/.retention-trash/" + $transaction_id)
+	') || return 1
+	while IFS= read -r transaction_dir; do
+		[[ -e "$transaction_dir" || -L "$transaction_dir" ]] || continue
+		[[ -d "$transaction_dir" && ! -L "$transaction_dir" ]] || return 1
+		for artifact in "$transaction_dir"/.* "$transaction_dir"/*; do
+			[[ -e "$artifact" || -L "$artifact" ]] || continue
+			case "${artifact##*/}" in
+			. | ..) continue ;;
+			esac
+			[[ "$artifact" == "$journal_next" && -f "$artifact" && ! -L "$artifact" ]] || return 1
+		done
+	done < <(printf '%s\n' "$transaction_dirs" | jq -r '.[]')
+	_worktree_recovery_apply_discard_next_file "$journal_path"
+	return $?
 }
 
 _worktree_recovery_apply_expected_journal() {
@@ -726,25 +845,40 @@ _worktree_recovery_apply_under_lock() {
 	local journal_json=""
 	local source_root=""
 	local receipt_json=""
+	local receipt_status=0
 
 	_worktree_recovery_apply_validate_plan "$plan_path" "$supplied_confirmation" || return 1
 	apply_metadata="$WORKTREE_RECOVERY_APPLY_VALIDATED_METADATA"
 	plan_json="$WORKTREE_RECOVERY_APPLY_VALIDATED_PLAN_JSON"
+	_worktree_recovery_apply_validate_control_path_scope \
+		"$receipt_path" "$plan_json" || return 1
 	plan_digest=$(printf '%s\n' "$apply_metadata" | jq -r '.plan_digest | sub("^sha256:"; "")') || return 1
 	transaction_id="apply-${plan_digest}"
 	entries_json=$(_worktree_recovery_apply_transaction_entries "$plan_json" "$transaction_id") || return 1
 	transaction_dir="${recovery_root}/.retention-trash/${transaction_id}"
 	journal_path="${transaction_dir}/journal.json"
-	if [[ -e "$transaction_dir" || -L "$transaction_dir" ]]; then
-		[[ -d "$transaction_dir" && ! -L "$transaction_dir" && -f "$journal_path" && ! -L "$journal_path" ]] || return 1
+	_worktree_recovery_apply_ensure_receipt_reservation \
+		"$receipt_path" "$apply_metadata" "$transaction_id" || receipt_status=$?
+	if [[ "$receipt_status" -eq 2 ]]; then
+		return 0
+	fi
+	[[ "$receipt_status" -eq 0 ]] || return "$receipt_status"
+	if [[ "${AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_RECEIPT_RESERVATION:-0}" == "1" ]]; then
+		return 1
+	fi
+	if [[ -f "$journal_path" && ! -L "$journal_path" ]]; then
 		started_at=$(jq -r '.started_at // empty' "$journal_path") || return 1
 	else
+		[[ ! -e "$journal_path" && ! -L "$journal_path" ]] || return 1
+		_worktree_recovery_apply_validate_uninitialized_transaction_dirs \
+			"$recovery_root" "$entries_json" "$transaction_id" "$journal_path" || return 1
 		started_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
 	fi
 	expected_journal=$(_worktree_recovery_apply_expected_journal \
 		"$transaction_id" "$apply_metadata" "$entries_json" "$started_at") || return 1
 	if [[ -f "$journal_path" ]]; then
 		_worktree_recovery_apply_validate_existing_journal "$journal_path" "$expected_journal" || return 1
+		_worktree_recovery_apply_discard_next_file "$journal_path" || return 1
 	else
 		_worktree_recovery_apply_prepare_transaction_dir "$recovery_root" "$transaction_id" || return 1
 		while IFS= read -r source_root; do
@@ -753,6 +887,9 @@ _worktree_recovery_apply_under_lock() {
 			[.[] | .original_path as $original_path |
 				$original_path[0:($original_path | rindex("/"))]] | unique[]
 		')
+		if [[ "${AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_TRANSACTION_DIR:-0}" == "1" ]]; then
+			return 1
+		fi
 		journal_json="$expected_journal"
 		_worktree_recovery_apply_atomic_replace "$journal_path" "$journal_json" || return 1
 	fi
@@ -766,7 +903,10 @@ _worktree_recovery_apply_under_lock() {
 	_worktree_recovery_apply_validate_all_staged "$journal_path" || return 1
 	_worktree_recovery_apply_remove_staged "$journal_path" || return 1
 	receipt_json=$(_worktree_recovery_apply_receipt_json "$journal_path" "$apply_metadata") || return 1
-	_worktree_recovery_apply_publish_new "$receipt_path" "$receipt_json" || return 1
+	_worktree_recovery_apply_validate_reservation \
+		"$receipt_path" "$apply_metadata" "$transaction_id" || return 1
+	_worktree_recovery_apply_atomic_replace "$receipt_path" "$receipt_json" || return 1
+	_worktree_recovery_apply_validate_receipt_replay "$receipt_path" "$apply_metadata" || return 1
 	_worktree_recovery_apply_cleanup_transaction "$journal_path" || return 1
 	return 0
 }
@@ -787,12 +927,6 @@ worktree_recovery_apply() {
 	plan_json="$WORKTREE_RECOVERY_APPLY_VALIDATED_PLAN_JSON"
 	_worktree_recovery_apply_validate_control_path_scope \
 		"$receipt_path" "$plan_json" || return 1
-	if [[ -e "$receipt_path" || -L "$receipt_path" ]]; then
-		_worktree_recovery_apply_validate_receipt_replay "$receipt_path" "$apply_metadata" || return 1
-		printf '%s\n' "$receipt_path"
-		return 0
-	fi
-	_worktree_recovery_apply_new_receipt_path "$receipt_path" || return 1
 	recovery_root=$(_worktree_recovery_store_root) || return 1
 	[[ -d "$recovery_root" && ! -L "$recovery_root" ]] || return 1
 	recovery_root_real=$(cd "$recovery_root" 2>/dev/null && pwd -P) || return 1

--- a/.agents/scripts/worktree-recovery-apply-helper.sh
+++ b/.agents/scripts/worktree-recovery-apply-helper.sh
@@ -1,0 +1,806 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Exact-manifest mutation boundary for worktree recovery archives.
+
+[[ "${_WORKTREE_RECOVERY_APPLY_HELPER_LOADED:-}" == "1" ]] && return 0
+_WORKTREE_RECOVERY_APPLY_HELPER_LOADED=1
+
+WORKTREE_RECOVERY_APPLY_RECEIPT_SCHEMA="aidevops.worktree-recovery-apply-receipt/v1"
+WORKTREE_RECOVERY_APPLY_TRANSACTION_SCHEMA="aidevops.worktree-recovery-apply-transaction/v1"
+WORKTREE_RECOVERY_APPLY_STATE_PLANNED="planned"
+WORKTREE_RECOVERY_APPLY_STATE_STAGED="staged"
+WORKTREE_RECOVERY_APPLY_STATE_REMOVED="removed"
+WORKTREE_RECOVERY_APPLY_OUTCOME_PENDING="pending"
+WORKTREE_RECOVERY_APPLY_OUTCOME_REMOVED="$WORKTREE_RECOVERY_APPLY_STATE_REMOVED"
+WORKTREE_RECOVERY_APPLY_JSON_TYPE_NUMBER="number"
+WORKTREE_RECOVERY_APPLY_JSON_TYPE_OBJECT="object"
+WORKTREE_RECOVERY_APPLY_JSON_TYPE_STRING="string"
+WORKTREE_RECOVERY_APPLY_VALIDATED_METADATA=""
+WORKTREE_RECOVERY_APPLY_VALIDATED_PLAN_JSON=""
+
+_worktree_recovery_apply_canonical_path() {
+	local path="$1"
+	local parent_path=""
+	local parent_real=""
+	local base_name=""
+
+	[[ "$path" == /* && "$path" != */ ]] || return 1
+	parent_path="${path%/*}"
+	base_name="${path##*/}"
+	[[ -n "$parent_path" && -n "$base_name" && -d "$parent_path" && ! -L "$parent_path" ]] || return 1
+	parent_real=$(cd "$parent_path" 2>/dev/null && pwd -P) || return 1
+	printf '%s/%s\n' "$parent_real" "$base_name"
+	return 0
+}
+
+_worktree_recovery_apply_plan_material_json() {
+	local plan_json="$1"
+
+	printf '%s\n' "$plan_json" | jq -c --arg schema "$WORKTREE_RECOVERY_PLAN_SCHEMA" '
+		{schema:$schema,inventory_complete:.inventory_complete,
+		inventory_error:.inventory_error,entries:.entries}'
+	return $?
+}
+
+_worktree_recovery_apply_plan_material() {
+	local plan_path="$1"
+	local plan_json=""
+
+	[[ -f "$plan_path" && ! -L "$plan_path" && -r "$plan_path" ]] || return 1
+	plan_json=$(<"$plan_path")
+	[[ -n "$plan_json" ]] || return 1
+	_worktree_recovery_apply_plan_material_json "$plan_json"
+	return $?
+}
+
+_worktree_recovery_apply_validate_candidate_roots() {
+	local plan_json="$1"
+	local current_root=""
+	local current_real=""
+	local legacy_root=""
+	local legacy_real=""
+
+	current_root=$(_worktree_recovery_store_root) || return 1
+	[[ -d "$current_root" && ! -L "$current_root" ]] || return 1
+	current_real=$(cd "$current_root" 2>/dev/null && pwd -P) || return 1
+	if legacy_root=$(_worktree_legacy_recovery_root 2>/dev/null); then
+		if [[ -d "$legacy_root" && ! -L "$legacy_root" ]]; then
+			legacy_real=$(cd "$legacy_root" 2>/dev/null && pwd -P) || return 1
+		fi
+	fi
+	printf '%s\n' "$plan_json" | jq -e --arg candidate "$WORKTREE_RECOVERY_PLAN_DISPOSITION_CANDIDATE" \
+		--arg current "$current_real" --arg legacy "$legacy_real" '
+		all(.entries[] | select(.disposition == $candidate);
+			.path as $candidate_path |
+			$candidate_path[0:($candidate_path | rindex("/"))] as $candidate_root |
+			$candidate_root == $current or ($legacy != "" and $candidate_root == $legacy))
+	' >/dev/null 2>&1
+	return $?
+}
+
+_worktree_recovery_apply_validate_control_path_scope() {
+	local control_path="$1"
+	local plan_json="$2"
+	local canonical_control=""
+
+	canonical_control=$(_worktree_recovery_apply_canonical_path "$control_path") || return 1
+	printf '%s\n' "$plan_json" | jq -e --arg control "$canonical_control" \
+		--arg candidate "$WORKTREE_RECOVERY_PLAN_DISPOSITION_CANDIDATE" '
+		all(.entries[] | select(.disposition == $candidate);
+			.path as $candidate_path |
+			$control != $candidate_path and
+			($control | startswith($candidate_path + "/") | not))
+	' >/dev/null 2>&1
+	return $?
+}
+
+_worktree_recovery_apply_validate_plan_shape() {
+	local plan_json="$1"
+
+	printf '%s\n' "$plan_json" | jq -e --arg schema "$WORKTREE_RECOVERY_PLAN_SCHEMA" \
+		--arg producer "$WORKTREE_RECOVERY_PRODUCER" \
+		--arg candidate "$WORKTREE_RECOVERY_PLAN_DISPOSITION_CANDIDATE" \
+		--arg protected "$WORKTREE_RECOVERY_PLAN_DISPOSITION_PROTECTED" \
+		--arg unknown "$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" \
+		--arg number_type "$WORKTREE_RECOVERY_APPLY_JSON_TYPE_NUMBER" \
+		--arg object_type "$WORKTREE_RECOVERY_APPLY_JSON_TYPE_OBJECT" \
+		--arg string_type "$WORKTREE_RECOVERY_APPLY_JSON_TYPE_STRING" '
+		.entries as $entries |
+		.source_roots as $source_roots |
+		type == $object_type and .schema == $schema and .producer == $producer and
+		.read_only == true and .inventory_complete == true and .inventory_error == null and
+		(.generated_at | type == $string_type) and
+		(.plan_id | test("^sha256:[0-9a-f]{64}$")) and
+		(.confirmation_token | test("^apply-sha256:[0-9a-f]{64}$")) and
+		($source_roots | type == "array") and
+		([$source_roots[] | select(type != $string_type or (startswith("/") | not) or
+			test("[\u0000-\u001f\u007f]"))] | length == 0) and
+		($entries | type == "array") and .entry_count == ($entries | length) and
+		([.entry_count,.sized_entry_count,.unavailable_size_count,.expected_allocated_bytes,
+			.candidate_count,.candidate_bytes,.protected_count,.protected_bytes,
+			.unknown_count,.unknown_bytes] |
+			all(type == $number_type and . >= 0 and . == floor)) and
+		.entry_count == (.sized_entry_count + .unavailable_size_count) and
+		.entry_count == (.candidate_count + .protected_count + .unknown_count) and
+		.candidate_count > 0 and .candidate_count == ([$entries[] | select(.disposition == $candidate)] | length) and
+		.protected_count == ([$entries[] | select(.disposition == $protected)] | length) and
+		.unknown_count == ([$entries[] | select(.disposition == $unknown)] | length) and
+		.candidate_bytes == ([$entries[] | select(.disposition == $candidate) | .expected_allocated_bytes] | add // 0) and
+		.protected_bytes == ([$entries[] | select(.disposition == $protected) | .expected_allocated_bytes | numbers] | add // 0) and
+		.unknown_bytes == ([$entries[] | select(.disposition == $unknown) | .expected_allocated_bytes | numbers] | add // 0) and
+		.expected_allocated_bytes == ([$entries[].expected_allocated_bytes | numbers] | add // 0) and
+		.sized_entry_count == ([$entries[] | select(.expected_allocated_bytes | type == $number_type)] | length) and
+		.unavailable_size_count == ([$entries[] | select(.expected_allocated_bytes == null)] | length) and
+		([$entries[] | select(
+			(.path | type != $string_type) or (.path | startswith("/") | not) or
+			(.path | endswith("/")) or (.path | test("[\u0000-\u001f\u007f]")) or
+			((.expected_allocated_bytes | type) | IN($number_type, "null") | not) or
+			(.disposition | IN($candidate, $protected, $unknown) | not))] | length == 0) and
+		([$entries[] | select(.disposition == $candidate) | . as $entry |
+			select(($entry.path | type != $string_type) or ($entry.path | startswith("/") | not) or
+			($entry.path | test("/aidevops-worktree-cleanup-[A-Za-z0-9._-]+$") | not) or
+			($entry.archive_path | type != $string_type) or
+			($entry.archive_path | test("[\u0000-\u001f\u007f]")) or
+			($entry.archive_path[0:($entry.archive_path | rindex("/"))] != $entry.path) or
+			($entry.expected_allocated_bytes | type != $number_type) or $entry.expected_allocated_bytes <= 0 or
+			($entry.identity | type != $object_type) or ($entry.evidence | type != $object_type) or
+			($entry.identity.bucket_path != $entry.path) or
+			($entry.identity.archive_path != $entry.archive_path) or
+			($entry.reasons != ["all-required-evidence-clear"]) or
+			($entry.identity.identity_digest | test("^sha256:[0-9a-f]{64}$") | not))] | length == 0) and
+		($source_roots == ([$entries[] | .path as $entry_path |
+			$entry_path[0:($entry_path | rindex("/"))]] | unique)) and
+		([$entries[].path] as $entry_paths |
+			($entry_paths | length) == ($entry_paths | unique | length)) and
+		([$entries[] | .identity.identity_digest? // empty] as $entry_identities |
+			($entry_identities | length) == ($entry_identities | unique | length))
+	' >/dev/null 2>&1
+	return $?
+}
+
+_worktree_recovery_apply_validate_plan() {
+	local plan_path="$1"
+	local supplied_confirmation="$2"
+	local canonical_plan=""
+	local plan_json=""
+	local plan_material=""
+	local plan_id_digest=""
+	local expected_plan_id=""
+	local plan_id=""
+	local candidate_count=""
+	local candidate_bytes=""
+	local expected_confirmation=""
+	local plan_file_digest=""
+	local apply_metadata=""
+
+	WORKTREE_RECOVERY_APPLY_VALIDATED_METADATA=""
+	WORKTREE_RECOVERY_APPLY_VALIDATED_PLAN_JSON=""
+	canonical_plan=$(_worktree_recovery_apply_canonical_path "$plan_path") || return 1
+	[[ -f "$canonical_plan" && ! -L "$canonical_plan" && -r "$canonical_plan" ]] || return 1
+	plan_json=$(<"$canonical_plan")
+	[[ -n "$plan_json" ]] || return 1
+	_worktree_recovery_apply_validate_plan_shape "$plan_json" || return 1
+	_worktree_recovery_apply_validate_candidate_roots "$plan_json" || return 1
+	_worktree_recovery_apply_validate_control_path_scope \
+		"$canonical_plan" "$plan_json" || return 1
+	plan_material=$(_worktree_recovery_apply_plan_material_json "$plan_json") || return 1
+	plan_id_digest=$(_worktree_recovery_plan_sha256_text "$plan_material") || return 1
+	expected_plan_id="sha256:$plan_id_digest"
+	plan_id=$(printf '%s\n' "$plan_json" | jq -r '.plan_id') || return 1
+	[[ "$plan_id" == "$expected_plan_id" ]] || return 1
+	candidate_count=$(printf '%s\n' "$plan_json" | jq -r '.candidate_count') || return 1
+	candidate_bytes=$(printf '%s\n' "$plan_json" | jq -r '.candidate_bytes') || return 1
+	expected_confirmation=$(_worktree_recovery_plan_confirmation_token \
+		"$plan_id" "$candidate_count" "$candidate_bytes") || return 1
+	[[ "$(printf '%s\n' "$plan_json" | jq -r '.confirmation_token')" == "$expected_confirmation" &&
+	"$supplied_confirmation" == "$expected_confirmation" ]] || return 1
+	plan_file_digest=$(_worktree_recovery_plan_sha256_text "$plan_json") || return 1
+	apply_metadata=$(jq -cn --arg plan_path "$canonical_plan" --arg plan_id "$plan_id" \
+		--arg plan_digest "sha256:$plan_file_digest" --arg confirmation "$expected_confirmation" \
+		--argjson candidate_count "$candidate_count" --argjson candidate_bytes "$candidate_bytes" \
+		'{plan_path:$plan_path,plan_id:$plan_id,plan_digest:$plan_digest,
+		confirmation:$confirmation,candidate_count:$candidate_count,candidate_bytes:$candidate_bytes}') || return 1
+	WORKTREE_RECOVERY_APPLY_VALIDATED_METADATA="$apply_metadata"
+	WORKTREE_RECOVERY_APPLY_VALIDATED_PLAN_JSON="$plan_json"
+	return 0
+}
+
+_worktree_recovery_apply_validate_receipt_replay() {
+	local receipt_path="$1"
+	local apply_metadata="$2"
+	local plan_id=""
+	local plan_digest=""
+	local confirmation=""
+	local candidate_count=""
+	local candidate_bytes=""
+
+	_worktree_recovery_apply_canonical_path "$receipt_path" >/dev/null || return 1
+	[[ -f "$receipt_path" && ! -L "$receipt_path" && -r "$receipt_path" ]] || return 1
+	plan_id=$(printf '%s\n' "$apply_metadata" | jq -r '.plan_id') || return 1
+	plan_digest=$(printf '%s\n' "$apply_metadata" | jq -r '.plan_digest') || return 1
+	confirmation=$(printf '%s\n' "$apply_metadata" | jq -r '.confirmation') || return 1
+	candidate_count=$(printf '%s\n' "$apply_metadata" | jq -r '.candidate_count') || return 1
+	candidate_bytes=$(printf '%s\n' "$apply_metadata" | jq -r '.candidate_bytes') || return 1
+	jq -e --arg schema "$WORKTREE_RECOVERY_APPLY_RECEIPT_SCHEMA" \
+		--arg plan_id "$plan_id" --arg plan_digest "$plan_digest" \
+		--arg confirmation "$confirmation" --argjson candidate_count "$candidate_count" \
+		--argjson candidate_bytes "$candidate_bytes" \
+		--arg removed "$WORKTREE_RECOVERY_APPLY_OUTCOME_REMOVED" '
+		.schema == $schema and .complete == true and .plan_id == $plan_id and
+		.plan_digest == $plan_digest and .confirmation == $confirmation and
+		.candidate_count == $candidate_count and .expected_allocated_bytes == $candidate_bytes and
+		.observed_allocated_bytes == $candidate_bytes and (.entries | length == $candidate_count) and
+		([.entries[] | select(.outcome != $removed)] | length == 0)
+	' "$receipt_path" >/dev/null 2>&1
+	return $?
+}
+
+_worktree_recovery_apply_new_receipt_path() {
+	local receipt_path="$1"
+
+	_worktree_recovery_apply_canonical_path "$receipt_path" >/dev/null || return 1
+	[[ ! -e "$receipt_path" && ! -L "$receipt_path" && -w "${receipt_path%/*}" ]] || return 1
+	return 0
+}
+
+_worktree_recovery_apply_transaction_entries() {
+	local plan_json="$1"
+	local transaction_id="$2"
+
+	printf '%s\n' "$plan_json" | jq -c --arg candidate "$WORKTREE_RECOVERY_PLAN_DISPOSITION_CANDIDATE" \
+		--arg transaction_id "$transaction_id" \
+		--arg planned "$WORKTREE_RECOVERY_APPLY_STATE_PLANNED" \
+		--arg pending "$WORKTREE_RECOVERY_APPLY_OUTCOME_PENDING" '
+		def parent_path: .[0:rindex("/")];
+		def base_name: .[rindex("/") + 1:];
+		[.entries[] | select(.disposition == $candidate)] | to_entries | map(
+			.key as $index | .value as $entry |
+			{index:$index,role:$entry.role,original_path:$entry.path,
+			staged_path:(($entry.path | parent_path) + "/.retention-trash/" + $transaction_id +
+				"/candidate-" + ($index | tostring) + "-" + ($entry.path | base_name)),
+			archive_name:($entry.archive_path | base_name),
+			expected_allocated_bytes:$entry.expected_allocated_bytes,
+			identity:$entry.identity,evidence:$entry.evidence,reasons:$entry.reasons,
+			state:$planned,observed_allocated_bytes:null,staged_at:null,removed_at:null,outcome:$pending})
+	'
+	return $?
+}
+
+_worktree_recovery_apply_atomic_replace() {
+	local output_path="$1"
+	local payload="$2"
+	local parent_path="${output_path%/*}"
+	local base_name="${output_path##*/}"
+	local temp_path=""
+	local previous_umask=""
+
+	[[ -d "$parent_path" && ! -L "$parent_path" ]] || return 1
+	previous_umask=$(umask)
+	umask 077
+	temp_path=$(mktemp "${parent_path}/.${base_name}.tmp.XXXXXX") || {
+		umask "$previous_umask"
+		return 1
+	}
+	umask "$previous_umask"
+	if ! printf '%s\n' "$payload" >"$temp_path" || ! chmod 600 "$temp_path" ||
+		! mv "$temp_path" "$output_path"; then
+		rm -f "$temp_path"
+		return 1
+	fi
+	return 0
+}
+
+_worktree_recovery_apply_publish_new() {
+	local output_path="$1"
+	local payload="$2"
+	local parent_path="${output_path%/*}"
+	local base_name="${output_path##*/}"
+	local temp_path=""
+	local previous_umask=""
+
+	[[ ! -e "$output_path" && ! -L "$output_path" ]] || return 1
+	previous_umask=$(umask)
+	umask 077
+	temp_path=$(mktemp "${parent_path}/.${base_name}.tmp.XXXXXX") || {
+		umask "$previous_umask"
+		return 1
+	}
+	umask "$previous_umask"
+	if ! printf '%s\n' "$payload" >"$temp_path" || ! chmod 600 "$temp_path" ||
+		! ln "$temp_path" "$output_path" 2>/dev/null; then
+		rm -f "$temp_path"
+		return 1
+	fi
+	rm -f "$temp_path"
+	return 0
+}
+
+_worktree_recovery_apply_prepare_transaction_dir() {
+	local source_root="$1"
+	local transaction_id="$2"
+	local trash_root="${source_root}/.retention-trash"
+	local transaction_dir="${trash_root}/${transaction_id}"
+
+	[[ -d "$source_root" && ! -L "$source_root" ]] || return 1
+	if [[ -e "$trash_root" || -L "$trash_root" ]]; then
+		[[ -d "$trash_root" && ! -L "$trash_root" ]] || return 1
+	else
+		mkdir "$trash_root" || return 1
+	fi
+	if [[ -e "$transaction_dir" || -L "$transaction_dir" ]]; then
+		[[ -d "$transaction_dir" && ! -L "$transaction_dir" ]] || return 1
+	else
+		mkdir "$transaction_dir" || return 1
+	fi
+	return 0
+}
+
+_worktree_recovery_apply_expected_journal() {
+	local transaction_id="$1"
+	local apply_metadata="$2"
+	local entries_json="$3"
+	local started_at="$4"
+
+	jq -cn --arg schema "$WORKTREE_RECOVERY_APPLY_TRANSACTION_SCHEMA" \
+		--arg transaction_id "$transaction_id" \
+		--arg plan_id "$(printf '%s\n' "$apply_metadata" | jq -r '.plan_id')" \
+		--arg plan_digest "$(printf '%s\n' "$apply_metadata" | jq -r '.plan_digest')" \
+		--arg confirmation "$(printf '%s\n' "$apply_metadata" | jq -r '.confirmation')" \
+		--arg started_at "$started_at" --argjson entries "$entries_json" \
+		'{schema:$schema,transaction_id:$transaction_id,plan_id:$plan_id,
+		plan_digest:$plan_digest,confirmation:$confirmation,started_at:$started_at,entries:$entries}'
+	return $?
+}
+
+_worktree_recovery_apply_validate_existing_journal() {
+	local journal_path="$1"
+	local expected_journal="$2"
+
+	[[ -f "$journal_path" && ! -L "$journal_path" ]] || return 1
+	jq -e --argjson expected "$expected_journal" \
+		--arg planned "$WORKTREE_RECOVERY_APPLY_STATE_PLANNED" \
+		--arg staged "$WORKTREE_RECOVERY_APPLY_STATE_STAGED" \
+		--arg removed "$WORKTREE_RECOVERY_APPLY_STATE_REMOVED" \
+		--arg string_type "$WORKTREE_RECOVERY_APPLY_JSON_TYPE_STRING" '
+		.schema == $expected.schema and .transaction_id == $expected.transaction_id and
+		.plan_id == $expected.plan_id and .plan_digest == $expected.plan_digest and
+		.confirmation == $expected.confirmation and (.started_at | type == $string_type) and
+		([.entries[] | .state] | all(. == $planned or . == $staged or . == $removed)) and
+		([.entries[] | {index,role,original_path,staged_path,archive_name,
+			expected_allocated_bytes,identity,evidence,reasons}] ==
+		 [$expected.entries[] | {index,role,original_path,staged_path,archive_name,
+			expected_allocated_bytes,identity,evidence,reasons}])
+	' "$journal_path" >/dev/null 2>&1
+	return $?
+}
+
+_worktree_recovery_apply_validate_transaction_scope() {
+	local journal_path="$1"
+	local transaction_dir=""
+	local artifact=""
+
+	jq -e --arg string_type "$WORKTREE_RECOVERY_APPLY_JSON_TYPE_STRING" '
+		.transaction_id as $transaction_id |
+		all(.entries[];
+			.original_path as $original_path | .staged_path as $staged_path |
+			($staged_path | type == $string_type) and
+			($staged_path[0:($staged_path | rindex("/"))] ==
+				($original_path[0:($original_path | rindex("/"))] +
+				"/.retention-trash/" + $transaction_id)))
+	' "$journal_path" >/dev/null 2>&1 || return 1
+	while IFS= read -r transaction_dir; do
+		[[ -d "$transaction_dir" && ! -L "$transaction_dir" ]] || return 1
+		for artifact in "$transaction_dir"/.* "$transaction_dir"/*; do
+			[[ -e "$artifact" || -L "$artifact" ]] || continue
+			case "${artifact##*/}" in
+			. | ..) continue ;;
+			journal.json)
+				[[ "$artifact" == "$journal_path" && -f "$artifact" && ! -L "$artifact" ]] || return 1
+				;;
+			*)
+				jq -e --arg artifact "$artifact" \
+					'any(.entries[]; .staged_path == $artifact)' "$journal_path" >/dev/null 2>&1 || return 1
+				;;
+			esac
+		done
+	done < <(jq -r --arg journal_dir "${journal_path%/*}" '
+		([.entries[] | .staged_path as $staged_path |
+			$staged_path[0:($staged_path | rindex("/"))]] + [$journal_dir]) | unique[]
+	' "$journal_path")
+	return 0
+}
+
+_worktree_recovery_apply_expected_entry() {
+	local row_json="$1"
+
+	printf '%s\n' "$row_json" | jq -c '
+		{role:.role,path:.original_path,archive_path:.identity.archive_path,
+		expected_allocated_bytes:.expected_allocated_bytes,identity:.identity,evidence:.evidence,
+		disposition:"candidate",reasons:.reasons}'
+	return $?
+}
+
+_worktree_recovery_apply_validate_original_entry() {
+	local row_json="$1"
+	local role=""
+	local original_path=""
+	local staged_path=""
+	local expected_bytes=""
+	local current_entry=""
+	local expected_entry=""
+
+	role=$(printf '%s\n' "$row_json" | jq -r '.role') || return 1
+	original_path=$(printf '%s\n' "$row_json" | jq -r '.original_path') || return 1
+	staged_path=$(printf '%s\n' "$row_json" | jq -r '.staged_path') || return 1
+	expected_bytes=$(printf '%s\n' "$row_json" | jq -r '.expected_allocated_bytes') || return 1
+	[[ -d "$original_path" && ! -L "$original_path" && ! -e "$staged_path" && ! -L "$staged_path" ]] || return 1
+	current_entry=$(_worktree_recovery_plan_attributed_entry_json \
+		"$role" "$original_path" "$expected_bytes") || return 1
+	expected_entry=$(_worktree_recovery_apply_expected_entry "$row_json") || return 1
+	[[ "$(printf '%s\n' "$current_entry" | jq -cS '.')" == "$(printf '%s\n' "$expected_entry" | jq -cS '.')" ]] || return 1
+	return 0
+}
+
+_worktree_recovery_apply_validate_staged_entry() {
+	local row_json="$1"
+	local original_path=""
+	local staged_path=""
+	local archive_name=""
+	local expected_bytes=""
+	local measured=""
+	local measured_bytes=""
+	local confidence=""
+	local staged_recovery=""
+	local expected_value=""
+	local actual_value=""
+	local digest=""
+	local process_snapshot=""
+	local identity_field=""
+
+	original_path=$(printf '%s\n' "$row_json" | jq -r '.original_path') || return 1
+	staged_path=$(printf '%s\n' "$row_json" | jq -r '.staged_path') || return 1
+	archive_name=$(printf '%s\n' "$row_json" | jq -r '.archive_name') || return 1
+	expected_bytes=$(printf '%s\n' "$row_json" | jq -r '.expected_allocated_bytes') || return 1
+	[[ ! -e "$original_path" && ! -L "$original_path" && -d "$staged_path" && ! -L "$staged_path" ]] || return 1
+	measured=$(_worktree_recovery_measure_path "$staged_path") || return 1
+	IFS='|' read -r measured_bytes confidence _ <<<"$measured"
+	[[ "$confidence" == "$WORKTREE_RECOVERY_PLAN_CONFIDENCE_EXACT" && "$measured_bytes" == "$expected_bytes" ]] || return 1
+	staged_recovery="${staged_path}/${_WT_RECOVERY_DIR_NAME}"
+	[[ -d "$staged_recovery" && ! -L "$staged_recovery" &&
+		-d "${staged_path}/${archive_name}" && ! -L "${staged_path}/${archive_name}" ]] || return 1
+	for identity_field in format source-real head branch; do
+		expected_value=$(printf '%s\n' "$row_json" | jq -r --arg field "$identity_field" '
+			if $field == "source-real" then .identity.source_path else .identity[$field] end') || return 1
+		actual_value=$(_worktree_recovery_plan_read_line "$staged_recovery/$identity_field") || return 1
+		[[ "$actual_value" == "$expected_value" ]] || return 1
+	done
+	digest=$(_worktree_recovery_plan_sha256_file "$staged_recovery/admin/index") || return 1
+	[[ "sha256:$digest" == "$(printf '%s\n' "$row_json" | jq -r '.identity.index_digest')" ]] || return 1
+	expected_value=$(printf '%s\n' "$row_json" | jq -r '.identity.completion_digest') || return 1
+	if [[ "$expected_value" == "legacy-marker-absent" ]]; then
+		[[ ! -e "$staged_recovery/${_WT_RECOVERY_COMPLETE_MARKER}" ]] || return 1
+	else
+		digest=$(_worktree_recovery_plan_sha256_file \
+			"$staged_recovery/${_WT_RECOVERY_COMPLETE_MARKER}") || return 1
+		[[ "sha256:$digest" == "$expected_value" ]] || return 1
+	fi
+	process_snapshot=$(capture_worktree_process_cwds) || return 1
+	if _worktree_cwd_snapshot_contains_path "$staged_path" "$staged_path" "$process_snapshot"; then
+		return 1
+	fi
+	return 0
+}
+
+_worktree_recovery_apply_preflight_journal() {
+	local journal_path="$1"
+	local row_json=""
+	local state=""
+	local original_path=""
+	local staged_path=""
+
+	while IFS= read -r row_json; do
+		state=$(printf '%s\n' "$row_json" | jq -r '.state') || return 1
+		original_path=$(printf '%s\n' "$row_json" | jq -r '.original_path') || return 1
+		staged_path=$(printf '%s\n' "$row_json" | jq -r '.staged_path') || return 1
+		case "$state" in
+		"$WORKTREE_RECOVERY_APPLY_STATE_PLANNED")
+			_worktree_recovery_apply_validate_original_entry "$row_json" || return 1
+			;;
+		"$WORKTREE_RECOVERY_APPLY_STATE_STAGED")
+			_worktree_recovery_apply_validate_staged_entry "$row_json" || return 1
+			;;
+		"$WORKTREE_RECOVERY_APPLY_STATE_REMOVED")
+			[[ ! -e "$original_path" && ! -L "$original_path" &&
+				! -e "$staged_path" && ! -L "$staged_path" ]] || return 1
+			;;
+		*) return 1 ;;
+		esac
+	done < <(jq -c '.entries[]' "$journal_path")
+	return 0
+}
+
+_worktree_recovery_apply_update_entry() {
+	local journal_path="$1"
+	local index="$2"
+	local state="$3"
+	local observed_bytes="$4"
+	local timestamp="$5"
+	local outcome="$6"
+	local updated=""
+
+	updated=$(jq -c --argjson index "$index" --arg state "$state" \
+		--argjson observed_bytes "$observed_bytes" --arg timestamp "$timestamp" \
+		--arg outcome "$outcome" --arg staged "$WORKTREE_RECOVERY_APPLY_STATE_STAGED" \
+		--arg removed "$WORKTREE_RECOVERY_APPLY_STATE_REMOVED" '
+		.entries[$index].state = $state |
+		.entries[$index].observed_allocated_bytes = $observed_bytes |
+		.entries[$index].outcome = $outcome |
+		if $state == $staged then .entries[$index].staged_at = $timestamp
+		elif $state == $removed then .entries[$index].removed_at = $timestamp
+		else . end
+	' "$journal_path") || return 1
+	_worktree_recovery_apply_atomic_replace "$journal_path" "$updated"
+	return $?
+}
+
+_worktree_recovery_apply_reconcile_interrupted_entries() {
+	local journal_path="$1"
+	local row_json=""
+	local state=""
+	local index=""
+	local original_path=""
+	local staged_path=""
+	local expected_bytes=""
+	local timestamp=""
+
+	while IFS= read -r row_json; do
+		state=$(printf '%s\n' "$row_json" | jq -r '.state') || return 1
+		index=$(printf '%s\n' "$row_json" | jq -r '.index') || return 1
+		original_path=$(printf '%s\n' "$row_json" | jq -r '.original_path') || return 1
+		staged_path=$(printf '%s\n' "$row_json" | jq -r '.staged_path') || return 1
+		expected_bytes=$(printf '%s\n' "$row_json" | jq -r '.expected_allocated_bytes') || return 1
+		if [[ "$state" == "$WORKTREE_RECOVERY_APPLY_STATE_PLANNED" &&
+			! -e "$original_path" && ! -L "$original_path" &&
+			-d "$staged_path" && ! -L "$staged_path" ]]; then
+			_worktree_recovery_apply_validate_staged_entry "$row_json" || return 1
+			timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+			_worktree_recovery_apply_update_entry "$journal_path" "$index" \
+				"$WORKTREE_RECOVERY_APPLY_STATE_STAGED" "$expected_bytes" \
+				"$timestamp" "$WORKTREE_RECOVERY_APPLY_OUTCOME_PENDING" || return 1
+		elif [[ "$state" == "$WORKTREE_RECOVERY_APPLY_STATE_STAGED" &&
+			! -e "$original_path" && ! -L "$original_path" &&
+			! -e "$staged_path" && ! -L "$staged_path" ]]; then
+			timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+			_worktree_recovery_apply_update_entry "$journal_path" "$index" \
+				"$WORKTREE_RECOVERY_APPLY_STATE_REMOVED" "$expected_bytes" \
+				"$timestamp" "$WORKTREE_RECOVERY_APPLY_OUTCOME_REMOVED" || return 1
+		fi
+	done < <(jq -c '.entries[]' "$journal_path")
+	return 0
+}
+
+_worktree_recovery_apply_stage_candidates() {
+	local journal_path="$1"
+	local row_json=""
+	local state=""
+	local index=""
+	local original_path=""
+	local staged_path=""
+	local expected_bytes=""
+	local timestamp=""
+
+	while IFS= read -r row_json; do
+		state=$(printf '%s\n' "$row_json" | jq -r '.state') || return 1
+		[[ "$state" == "$WORKTREE_RECOVERY_APPLY_STATE_PLANNED" ]] || continue
+		index=$(printf '%s\n' "$row_json" | jq -r '.index') || return 1
+		original_path=$(printf '%s\n' "$row_json" | jq -r '.original_path') || return 1
+		staged_path=$(printf '%s\n' "$row_json" | jq -r '.staged_path') || return 1
+		expected_bytes=$(printf '%s\n' "$row_json" | jq -r '.expected_allocated_bytes') || return 1
+		_worktree_recovery_apply_validate_original_entry "$row_json" || return 1
+		mv "$original_path" "$staged_path" || return 1
+		if [[ "${AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_MOVE:-0}" == "1" ]]; then
+			return 1
+		fi
+		timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+		_worktree_recovery_apply_update_entry "$journal_path" "$index" \
+			"$WORKTREE_RECOVERY_APPLY_STATE_STAGED" "$expected_bytes" \
+			"$timestamp" "$WORKTREE_RECOVERY_APPLY_OUTCOME_PENDING" || return 1
+	done < <(jq -c '.entries[]' "$journal_path")
+	return 0
+}
+
+_worktree_recovery_apply_validate_all_staged() {
+	local journal_path="$1"
+	local row_json=""
+	local state=""
+
+	while IFS= read -r row_json; do
+		state=$(printf '%s\n' "$row_json" | jq -r '.state') || return 1
+		case "$state" in
+		"$WORKTREE_RECOVERY_APPLY_STATE_STAGED")
+			_worktree_recovery_apply_validate_staged_entry "$row_json" || return 1
+			;;
+		"$WORKTREE_RECOVERY_APPLY_STATE_REMOVED") ;;
+		*) return 1 ;;
+		esac
+	done < <(jq -c '.entries[]' "$journal_path")
+	return 0
+}
+
+_worktree_recovery_apply_remove_staged() {
+	local journal_path="$1"
+	local row_json=""
+	local state=""
+	local index=""
+	local staged_path=""
+	local expected_bytes=""
+	local timestamp=""
+	local removed_this_run=0
+
+	while IFS= read -r row_json; do
+		state=$(printf '%s\n' "$row_json" | jq -r '.state') || return 1
+		[[ "$state" == "$WORKTREE_RECOVERY_APPLY_STATE_STAGED" ]] || continue
+		index=$(printf '%s\n' "$row_json" | jq -r '.index') || return 1
+		staged_path=$(printf '%s\n' "$row_json" | jq -r '.staged_path') || return 1
+		expected_bytes=$(printf '%s\n' "$row_json" | jq -r '.expected_allocated_bytes') || return 1
+		_worktree_recovery_apply_validate_staged_entry "$row_json" || return 1
+		rm -rf -- "$staged_path" || return 1
+		[[ ! -e "$staged_path" && ! -L "$staged_path" ]] || return 1
+		if [[ "${AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_DELETE:-0}" == "1" ]]; then
+			return 1
+		fi
+		timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+		_worktree_recovery_apply_update_entry "$journal_path" "$index" \
+			"$WORKTREE_RECOVERY_APPLY_STATE_REMOVED" "$expected_bytes" \
+			"$timestamp" "$WORKTREE_RECOVERY_APPLY_OUTCOME_REMOVED" || return 1
+		removed_this_run=$((removed_this_run + 1))
+		if [[ "${AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_REMOVE:-0}" == "1" &&
+			"$removed_this_run" -eq 1 ]]; then
+			return 1
+		fi
+	done < <(jq -c '.entries[]' "$journal_path")
+	return 0
+}
+
+_worktree_recovery_apply_receipt_json() {
+	local journal_path="$1"
+	local apply_metadata="$2"
+	local completed_at=""
+
+	completed_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+	jq -c --arg schema "$WORKTREE_RECOVERY_APPLY_RECEIPT_SCHEMA" \
+		--arg completed_at "$completed_at" \
+		--argjson metadata "$apply_metadata" \
+		--arg removed "$WORKTREE_RECOVERY_APPLY_OUTCOME_REMOVED" '
+		{schema:$schema,complete:true,plan_id:.plan_id,plan_digest:.plan_digest,
+		confirmation:.confirmation,transaction_id:.transaction_id,
+		started_at:.started_at,completed_at:$completed_at,
+		candidate_count:(.entries | length),
+		expected_allocated_bytes:([.entries[].expected_allocated_bytes] | add // 0),
+		observed_allocated_bytes:([.entries[].observed_allocated_bytes] | add // 0),
+		entries:[.entries[] | {original_path,staged_path,identity,
+			expected_allocated_bytes,observed_allocated_bytes,outcome,staged_at,removed_at}]} |
+		select(.plan_id == $metadata.plan_id and .plan_digest == $metadata.plan_digest and
+			.confirmation == $metadata.confirmation and .candidate_count == $metadata.candidate_count and
+			.expected_allocated_bytes == $metadata.candidate_bytes and
+			.observed_allocated_bytes == $metadata.candidate_bytes and
+			([.entries[] | select(.outcome != $removed)] | length == 0))
+	' "$journal_path"
+	return $?
+}
+
+_worktree_recovery_apply_cleanup_transaction() {
+	local journal_path="$1"
+	local transaction_dir=""
+	local trash_root=""
+	local dirs_json=""
+
+	dirs_json=$(jq -c --arg journal_dir "${journal_path%/*}" '
+		([.entries[] | .staged_path as $staged_path |
+			$staged_path[0:($staged_path | rindex("/"))]] + [$journal_dir]) | unique
+	' "$journal_path") || return 1
+	rm -f "$journal_path" || return 1
+	while IFS= read -r transaction_dir; do
+		rmdir "$transaction_dir" 2>/dev/null || true
+		trash_root="${transaction_dir%/*}"
+		rmdir "$trash_root" 2>/dev/null || true
+	done < <(printf '%s\n' "$dirs_json" | jq -r '.[]')
+	return 0
+}
+
+_worktree_recovery_apply_under_lock() {
+	local plan_path="$1"
+	local receipt_path="$2"
+	local supplied_confirmation="$3"
+	local recovery_root="$4"
+	local apply_metadata=""
+	local plan_json=""
+	local plan_digest=""
+	local transaction_id=""
+	local entries_json=""
+	local transaction_dir=""
+	local journal_path=""
+	local expected_journal=""
+	local started_at=""
+	local journal_json=""
+	local source_root=""
+	local receipt_json=""
+
+	_worktree_recovery_apply_validate_plan "$plan_path" "$supplied_confirmation" || return 1
+	apply_metadata="$WORKTREE_RECOVERY_APPLY_VALIDATED_METADATA"
+	plan_json="$WORKTREE_RECOVERY_APPLY_VALIDATED_PLAN_JSON"
+	plan_digest=$(printf '%s\n' "$apply_metadata" | jq -r '.plan_digest | sub("^sha256:"; "")') || return 1
+	transaction_id="apply-${plan_digest}"
+	entries_json=$(_worktree_recovery_apply_transaction_entries "$plan_json" "$transaction_id") || return 1
+	transaction_dir="${recovery_root}/.retention-trash/${transaction_id}"
+	journal_path="${transaction_dir}/journal.json"
+	if [[ -e "$transaction_dir" || -L "$transaction_dir" ]]; then
+		[[ -d "$transaction_dir" && ! -L "$transaction_dir" && -f "$journal_path" && ! -L "$journal_path" ]] || return 1
+		started_at=$(jq -r '.started_at // empty' "$journal_path") || return 1
+	else
+		started_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+	fi
+	expected_journal=$(_worktree_recovery_apply_expected_journal \
+		"$transaction_id" "$apply_metadata" "$entries_json" "$started_at") || return 1
+	if [[ -f "$journal_path" ]]; then
+		_worktree_recovery_apply_validate_existing_journal "$journal_path" "$expected_journal" || return 1
+	else
+		_worktree_recovery_apply_prepare_transaction_dir "$recovery_root" "$transaction_id" || return 1
+		while IFS= read -r source_root; do
+			_worktree_recovery_apply_prepare_transaction_dir "$source_root" "$transaction_id" || return 1
+		done < <(printf '%s\n' "$entries_json" | jq -r '
+			[.[] | .original_path as $original_path |
+				$original_path[0:($original_path | rindex("/"))]] | unique[]
+		')
+		journal_json="$expected_journal"
+		_worktree_recovery_apply_atomic_replace "$journal_path" "$journal_json" || return 1
+	fi
+	_worktree_recovery_apply_validate_transaction_scope "$journal_path" || return 1
+	_worktree_recovery_apply_reconcile_interrupted_entries "$journal_path" || return 1
+	_worktree_recovery_apply_preflight_journal "$journal_path" || return 1
+	_worktree_recovery_apply_stage_candidates "$journal_path" || return 1
+	if [[ "${AIDEVOPS_WORKTREE_RECOVERY_TEST_INTERRUPT_AFTER_STAGE:-0}" == "1" ]]; then
+		return 1
+	fi
+	_worktree_recovery_apply_validate_all_staged "$journal_path" || return 1
+	_worktree_recovery_apply_remove_staged "$journal_path" || return 1
+	receipt_json=$(_worktree_recovery_apply_receipt_json "$journal_path" "$apply_metadata") || return 1
+	_worktree_recovery_apply_publish_new "$receipt_path" "$receipt_json" || return 1
+	_worktree_recovery_apply_cleanup_transaction "$journal_path" || return 1
+	return 0
+}
+
+worktree_recovery_apply() {
+	local plan_path="$1"
+	local receipt_path="$2"
+	local supplied_confirmation="$3"
+	local apply_metadata=""
+	local plan_json=""
+	local recovery_root=""
+	local recovery_root_real=""
+	local apply_status=0
+
+	command -v jq >/dev/null 2>&1 || return 1
+	_worktree_recovery_apply_validate_plan "$plan_path" "$supplied_confirmation" || return 1
+	apply_metadata="$WORKTREE_RECOVERY_APPLY_VALIDATED_METADATA"
+	plan_json="$WORKTREE_RECOVERY_APPLY_VALIDATED_PLAN_JSON"
+	_worktree_recovery_apply_validate_control_path_scope \
+		"$receipt_path" "$plan_json" || return 1
+	if [[ -e "$receipt_path" || -L "$receipt_path" ]]; then
+		_worktree_recovery_apply_validate_receipt_replay "$receipt_path" "$apply_metadata" || return 1
+		printf '%s\n' "$receipt_path"
+		return 0
+	fi
+	_worktree_recovery_apply_new_receipt_path "$receipt_path" || return 1
+	recovery_root=$(_worktree_recovery_store_root) || return 1
+	[[ -d "$recovery_root" && ! -L "$recovery_root" ]] || return 1
+	recovery_root_real=$(cd "$recovery_root" 2>/dev/null && pwd -P) || return 1
+	_worktree_recovery_acquire_producer_lock "$recovery_root_real" || return 1
+	_worktree_recovery_apply_under_lock "$plan_path" "$receipt_path" \
+		"$supplied_confirmation" "$recovery_root_real" || apply_status=$?
+	_worktree_recovery_release_producer_lock || apply_status=1
+	[[ "$apply_status" -eq 0 ]] || return "$apply_status"
+	printf '%s\n' "$receipt_path"
+	return 0
+}

--- a/.agents/scripts/worktree-recovery-lifecycle-helper.sh
+++ b/.agents/scripts/worktree-recovery-lifecycle-helper.sh
@@ -9,7 +9,7 @@ _WORKTREE_RECOVERY_LIFECYCLE_HELPER_LOADED=1
 WORKTREE_RECOVERY_INVENTORY_SCHEMA="aidevops.worktree-recovery-inventory/v1"
 WORKTREE_RECOVERY_INVALID_RECORD="invalid-inventory-record"
 WORKTREE_RECOVERY_UNAVAILABLE="unavailable"
-WORKTREE_RECOVERY_PLAN_SCHEMA="aidevops.worktree-recovery-plan/v1"
+WORKTREE_RECOVERY_PLAN_SCHEMA="aidevops.worktree-recovery-plan/v2"
 WORKTREE_RECOVERY_PLAN_DISPOSITION_CANDIDATE="candidate"
 WORKTREE_RECOVERY_PLAN_DISPOSITION_PROTECTED="protected"
 WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN="unknown"
@@ -323,6 +323,28 @@ _worktree_recovery_plan_sha256_file() {
 	digest="${digest%%[[:space:]]*}"
 	[[ "$digest" =~ ^[0-9a-fA-F]{64}$ ]] || return 1
 	printf '%s\n' "$digest" | tr '[:upper:]' '[:lower:]'
+	return 0
+}
+
+_worktree_recovery_plan_confirmation_token() {
+	local plan_id="$1"
+	local candidate_count="$2"
+	local candidate_bytes="$3"
+	local confirmation_material=""
+	local confirmation_digest=""
+
+	[[ "$plan_id" =~ ^sha256:[0-9a-f]{64}$ ]] || return 1
+	case "$candidate_count:$candidate_bytes" in
+	*[!0-9:]*) return 1 ;;
+	esac
+	confirmation_material=$(printf '%s\n' \
+		"schema=$WORKTREE_RECOVERY_PLAN_SCHEMA" \
+		"plan-id=$plan_id" \
+		"candidate-count=$candidate_count" \
+		"candidate-bytes=$candidate_bytes" \
+		"action=permanently-delete-exact-candidates") || return 1
+	confirmation_digest=$(_worktree_recovery_plan_sha256_text "$confirmation_material") || return 1
+	printf 'apply-sha256:%s\n' "$confirmation_digest"
 	return 0
 }
 
@@ -786,7 +808,8 @@ _worktree_recovery_plan_entries_json() {
 worktree_recovery_plan_json() {
 	local platform="${1:-}"
 	local entries_bundle="" entries_json="" inventory_complete="" inventory_error=""
-	local plan_material="" plan_digest="" generated_at=""
+	local plan_material="" plan_digest="" generated_at="" plan_json=""
+	local candidate_count="" candidate_bytes="" confirmation_token=""
 
 	command -v jq >/dev/null 2>&1 || return 1
 	if [[ -z "$platform" ]]; then
@@ -802,7 +825,7 @@ worktree_recovery_plan_json() {
 		'{schema:$schema,inventory_complete:$complete,inventory_error:(if $error == "" then null else $error end),entries:$entries}') || return 1
 	plan_digest=$(_worktree_recovery_plan_sha256_text "$plan_material") || return 1
 	generated_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
-	jq -cn --arg schema "$WORKTREE_RECOVERY_PLAN_SCHEMA" \
+	plan_json=$(jq -cn --arg schema "$WORKTREE_RECOVERY_PLAN_SCHEMA" \
 		--arg plan_id "sha256:$plan_digest" --arg generated_at "$generated_at" \
 		--arg producer "$WORKTREE_RECOVERY_PRODUCER" \
 		--arg candidate "$WORKTREE_RECOVERY_PLAN_DISPOSITION_CANDIDATE" \
@@ -824,7 +847,13 @@ worktree_recovery_plan_json() {
 		protected_bytes:([$entries[] | select(.disposition == $protected) | .expected_allocated_bytes | numbers] | add // 0),
 		unknown_count:([$entries[] | select(.disposition == $unknown)] | length),
 		unknown_bytes:([$entries[] | select(.disposition == $unknown) | .expected_allocated_bytes | numbers] | add // 0),
-		entries:$entries}'
+		entries:$entries}') || return 1
+	candidate_count=$(printf '%s\n' "$plan_json" | jq -r '.candidate_count') || return 1
+	candidate_bytes=$(printf '%s\n' "$plan_json" | jq -r '.candidate_bytes') || return 1
+	confirmation_token=$(_worktree_recovery_plan_confirmation_token \
+		"sha256:$plan_digest" "$candidate_count" "$candidate_bytes") || return 1
+	printf '%s\n' "$plan_json" | jq -c --arg confirmation_token "$confirmation_token" \
+		'. + {confirmation_token:$confirmation_token}'
 	return $?
 }
 
@@ -863,8 +892,13 @@ worktree_recovery_plan_write() {
 	return 0
 }
 
+if [[ -f "$WORKTREE_RECOVERY_LIFECYCLE_DIR/worktree-recovery-apply-helper.sh" ]]; then
+	# shellcheck source=worktree-recovery-apply-helper.sh
+	source "$WORKTREE_RECOVERY_LIFECYCLE_DIR/worktree-recovery-apply-helper.sh"
+fi
+
 _worktree_recovery_lifecycle_usage() {
-	printf '%s\n' 'Usage: worktree-recovery-lifecycle-helper.sh [status|json|plan --output <absolute-path>]'
+	printf '%s\n' 'Usage: worktree-recovery-lifecycle-helper.sh [status|json|plan --output <absolute-path>|apply --plan <absolute-path> --receipt <absolute-new-path> --confirm <manifest-token>]'
 	return 0
 }
 
@@ -877,6 +911,14 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
 			exit 1
 		}
 		worktree_recovery_plan_write "$3"
+		;;
+	apply)
+		[[ "$#" -eq 7 && "$2" == "--plan" && "$4" == "--receipt" && "$6" == "--confirm" ]] || {
+			_worktree_recovery_lifecycle_usage >&2
+			exit 1
+		}
+		declare -F worktree_recovery_apply >/dev/null 2>&1 || exit 1
+		worktree_recovery_apply "$3" "$5" "$7"
 		;;
 	status) worktree_recovery_lifecycle_status ;;
 	help | --help | -h) _worktree_recovery_lifecycle_usage ;;


### PR DESCRIPTION
## Summary

Add a manifest-bound, lock-protected recovery apply flow with transactional staging, resumable deletion, and atomic receipts.

## Files Changed

.agents/reference/storage-lifecycle.md, .agents/scripts/audit-worktree-removal-helper.sh, .agents/scripts/tests/test-worktree-recovery-lifecycle.sh, .agents/scripts/tests/test-worktree-removal-audit.sh, .agents/scripts/worktree-helper-cmds.sh, .agents/scripts/worktree-helper.sh, .agents/scripts/worktree-recovery-apply-helper.sh, .agents/scripts/worktree-recovery-lifecycle-helper.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — 16/16 lifecycle tests; 48/48 removal-audit tests; changed-file lint, ShellCheck, portability, and diff checks pass. Independent closeout review is clean for bundle `15493706e7c2802de3ba11a364943f3301328f5c146ffc007c865ffc565405da` at head `70555ba20305a7e045b5a6135f20725dfa804b81`.

Resolves #29389


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.218 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 2h 53m and 2,023,060 tokens on this with the user in an interactive session.
