### PR TITLE
GH#29425: Emit canonical claimed task IDs

### DIFF
--- a/.agents/reference/task-identity-parser-inventory.md
+++ b/.agents/reference/task-identity-parser-inventory.md
@@ -10,7 +10,7 @@ remaining numeric-only production parsers retain explicit owners.
 
 | Consumer group | Representative production files | Migration concern |
 |---|---|---|
-| Allocation and counters | `claim-task-id.sh`, `claim-task-id-counter.sh`, `claim-task-id-issue.sh` | Preserve legacy emission until the coordinator gate enables namespaced IDs |
+| Allocation and counters | `claim-task-id.sh`, `claim-task-id-counter.sh`, `claim-task-id-issue.sh` | Emit canonical unpadded legacy IDs until the coordinator gate enables namespaced IDs |
 | TODO parsing and issue sync | Migrated: `issue-sync-lib-parse.sh`, `issue-sync-lib-ref.sh`, `issue-sync-helper-commands.sh`. Remaining owner (issue-sync): `issue-sync-helper-enrich.sh`, `issue-sync-helper-close.sh` | Parse tokens through the codec and require explicit repository context for legacy resolution |
 | Dependency resolution | Migrated: `pulse-dep-graph.sh`. Remaining owner (lifecycle): `issue-sync-relationships.sh`, `parent-status-helper.sh` | Do not strip the `t` prefix or assume the identity body is numeric |
 | Brief and plan lookup | Migrated: `task-brief-helper.sh`. Remaining owner (planning): `verify-brief.sh`, `list-todo-helper.sh`, `todo-ready.sh`, `show-plan-helper.sh` | Use canonical tokens as opaque filename and lookup keys after validation |
@@ -24,6 +24,10 @@ The migration must inventory tests with each production consumer, retain
 numeric-only fixtures, and add namespaced and malformed fixtures. Matches in
 examples, generated patches, vendored content, or unrelated words such as
 `timeout` are not production parsers and must not be mechanically rewritten.
+
+Historical zero-padded IDs remain migration input for counter seeding and
+collision detection, but they are not canonical aliases. Migrations must reject
+an ambiguous rewrite when both a padded token and its unpadded form exist.
 
 The dependency cache currently validates at most 500 fetched issues through the
 shared shell codec. The pulse-performance owner should restore batched cache

--- a/.agents/scripts/claim-task-id-counter.sh
+++ b/.agents/scripts/claim-task-id-counter.sh
@@ -41,6 +41,12 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _lib_path
 fi
 
+_claim_counter_lib_dir="${BASH_SOURCE[0]%/*}"
+[[ "$_claim_counter_lib_dir" == "${BASH_SOURCE[0]}" ]] && _claim_counter_lib_dir="."
+# shellcheck source=./task-identity-lib.sh
+source "${_claim_counter_lib_dir}/task-identity-lib.sh"
+unset _claim_counter_lib_dir
+
 # =============================================================================
 # Formatting Helpers
 # =============================================================================
@@ -50,13 +56,26 @@ fi
 # callers must not reconcile and attempt the same forbidden push again.
 CAS_PROTECTED_BRANCH_RC="${CAS_PROTECTED_BRANCH_RC:-4}"
 
+# Format a numeric sequence as a canonical legacy task identity.
+# Args: $1 numeric sequence.
+_format_legacy_task_id() {
+	local sequence="$1"
+	task_identity_format "legacy" "" "$sequence" ""
+	return $?
+}
+
 # Format a task ID range for log messages and commit subjects.
 # Args: $1 first numeric ID, $2 last numeric ID.
-# Outputs: e.g. "t042..t045"
+# Outputs: e.g. "t42..t45"
 _format_task_range() {
 	local first_num="$1"
 	local last_num="$2"
-	printf 't%03d..t%03d' "$first_num" "$last_num"
+	local first_id=""
+	local last_id=""
+	first_id=$(_format_legacy_task_id "$first_num") || return 1
+	last_id=$(_format_legacy_task_id "$last_num") || return 1
+	printf '%s..%s' "$first_id" "$last_id"
+	return 0
 }
 
 # Machine-local coordinator integration. Legacy CAS remains authoritative unless
@@ -75,7 +94,7 @@ _task_coordinator_shadow_legacy() {
 	cli=$(_task_coordinator_cli)
 	local operation_id="legacy-${AIDEVOPS_SESSION_ID:-${BASHPID:-$$}}-${first_id}-${count}"
 	local legacy_id=""
-	printf -v legacy_id 't%03d' "$first_id"
+	legacy_id=$(_format_legacy_task_id "$first_id") || return 1
 	if ! node "$cli" allocate --operation-id "$operation_id" --count "$count" \
 		--legacy-id "$legacy_id" --payload '{"source":"legacy-cas-shadow"}' >/dev/null; then
 		log_warn "Task coordinator shadow write failed; legacy CAS allocation remains valid"
@@ -123,7 +142,7 @@ _append_claim_audit_log() {
 	ts=$(date -u +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)
 	pid="${BASHPID:-$$}"
 	sid="${AIDEVOPS_SESSION_ID:-${Claude_SESSION_ID:-${OPENCODE_SESSION_ID:-unknown}}}"
-	tid=$(printf 't%03d' "$first_id")
+	tid=$(_format_legacy_task_id "$first_id") || return 0
 
 	# Tab-separated; single append is atomic on POSIX filesystems for short writes.
 	printf '%s\t%s\t%s\t%s\t%s\t%ss\n' \
@@ -1165,7 +1184,7 @@ allocate_counter_cas() {
 
 	local commit_msg="chore: claim task ID"
 	if [[ "$count" -eq 1 ]]; then
-		commit_msg="chore: claim $(printf 't%03d' "$first_id") [${nonce}]"
+		commit_msg="chore: claim $(_format_legacy_task_id "$first_id") [${nonce}]"
 	else
 		commit_msg="chore: claim $(_format_task_range "$first_id" "$last_id") [${nonce}]"
 	fi
@@ -1240,7 +1259,7 @@ allocate_online() {
 		case $cas_result in
 		0)
 			# go for it — CAS succeeded on this attempt
-			log_success "Claimed $(printf 't%03d' "$first_id") (attempt ${attempt}, ${elapsed}s)"
+			log_success "Claimed $(_format_legacy_task_id "$first_id") (attempt ${attempt}, ${elapsed}s)"
 			# Phase 3 (t2569 / GH#20001): structured audit log.
 			_append_claim_audit_log "$first_id" "$attempt" "$elapsed"
 			_task_coordinator_shadow_legacy "$first_id" "$count"
@@ -1313,7 +1332,7 @@ _allocate_online_with_collision_check() {
 		fi
 
 		total_skips=$((total_skips + 1))
-		log_info "TODO.md collision: t$(printf '%03d' "$collision_id") already exists — skipping (${total_skips}/${max_skips})"
+		log_info "TODO.md collision: $(_format_legacy_task_id "$collision_id") already exists — skipping (${total_skips}/${max_skips})"
 
 		if [[ $total_skips -ge $max_skips ]]; then
 			log_error "TODO.md collision guard: exhausted ${max_skips} skip attempts"
@@ -1362,7 +1381,7 @@ allocate_offline() {
 			--no-verify --no-gpg-sign "$COUNTER_FILE" || true
 	)
 
-	log_warn "Allocated $(printf 't%03d' "$first_id") with offset (reconcile when back online)"
+	log_warn "Allocated $(_format_legacy_task_id "$first_id") with offset (reconcile when back online)"
 
 	echo "$first_id"
 	return 0

--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -915,7 +915,7 @@ _main_emit_online_dry_run_allocation() {
 	local current=""
 	current=$(read_remote_counter "$REPO_PATH" 2>/dev/null || read_local_counter "$REPO_PATH" 2>/dev/null || echo "?")
 	if [[ "$current" =~ ^[0-9]+$ ]]; then
-		log_info "Would allocate $(printf 't%03d' "$current")..$(printf 't%03d' "$((current + ALLOC_COUNT - 1))") (counter at ${current})"
+		log_info "Would allocate $(_format_task_range "$current" "$((current + ALLOC_COUNT - 1))") (counter at ${current})"
 	else
 		log_info "Would allocate task ID (counter unreadable: ${current})"
 	fi
@@ -954,7 +954,7 @@ _main_resolve_allocation() {
 		local _allocation_rc=0
 		first_id_out=$(_allocate_online_with_collision_check "$REPO_PATH" "$ALLOC_COUNT") || _allocation_rc=$?
 		if [[ $_allocation_rc -eq 0 ]]; then
-			log_success "Allocated task ID: $(printf 't%03d' "$first_id_out")"
+			log_success "Allocated task ID: $(_format_legacy_task_id "$first_id_out")"
 		elif [[ $_allocation_rc -eq ${CAS_PROTECTED_BRANCH_RC:-4} ]]; then
 			return "$_allocation_rc"
 		else
@@ -966,7 +966,7 @@ _main_resolve_allocation() {
 					first_id_out=$(_allocate_online_with_collision_check "$REPO_PATH" "$ALLOC_COUNT") || _retry_allocation_rc=$?
 					if [[ $_retry_allocation_rc -eq 0 ]]; then
 						allocation_status="recovered_contention"
-						log_success "Allocated task ID after counter reconciliation: $(printf 't%03d' "$first_id_out")"
+						log_success "Allocated task ID after counter reconciliation: $(_format_legacy_task_id "$first_id_out")"
 					elif [[ $_retry_allocation_rc -eq ${CAS_PROTECTED_BRANCH_RC:-4} ]]; then
 						return "$_retry_allocation_rc"
 					else
@@ -1013,9 +1013,9 @@ _main_resolve_allocation() {
 	fi
 
 	if [[ "$allocation_status" == "normal_success" ]]; then
-		_task_counter_status "normal_success" "task_id=$(printf 't%03d' "$first_id_out")"
+		_task_counter_status "normal_success" "task_id=$(_format_legacy_task_id "$first_id_out")"
 	elif [[ "$allocation_status" == "recovered_contention" ]]; then
-		_task_counter_status "recovered_contention" "task_id=$(printf 't%03d' "$first_id_out")"
+		_task_counter_status "recovered_contention" "task_id=$(_format_legacy_task_id "$first_id_out")"
 	fi
 
 	# Communicate results back to caller via stdout key=value pairs
@@ -1050,7 +1050,7 @@ _main_create_issues() {
 			local i
 			for ((i = first_id; i <= last_id; i++)); do
 				local issue_title
-				issue_title="$(printf 't%03d' "$i"): ${TASK_TITLE}"
+				issue_title="$(_format_legacy_task_id "$i"): ${TASK_TITLE}"
 				local issue_num=""
 
 				case "$platform" in
@@ -1070,7 +1070,7 @@ _main_create_issues() {
 						first_issue_num="$issue_num"
 					fi
 				else
-					log_warn "Issue creation failed for $(printf 't%03d' "$i") (non-fatal — ID is secured)"
+					log_warn "Issue creation failed for $(_format_legacy_task_id "$i") (non-fatal — ID is secured)"
 					issue_nums+=("")
 				fi
 			done
@@ -1104,12 +1104,16 @@ _main_output_results() {
 	local issue_nums_csv="$6"
 
 	local last_id=$((first_id + ALLOC_COUNT - 1))
+	local first_task_id=""
+	local last_task_id=""
+	first_task_id=$(_format_legacy_task_id "$first_id") || return 1
+	last_task_id=$(_format_legacy_task_id "$last_id") || return 1
 
 	if [[ "$ALLOC_COUNT" -eq 1 ]]; then
-		printf "task_id=t%03d\n" "$first_id"
+		printf 'task_id=%s\n' "$first_task_id"
 	else
-		printf "task_id=t%03d\n" "$first_id"
-		printf "task_id_last=t%03d\n" "$last_id"
+		printf 'task_id=%s\n' "$first_task_id"
+		printf 'task_id_last=%s\n' "$last_task_id"
 		echo "task_count=${ALLOC_COUNT}"
 	fi
 
@@ -1704,7 +1708,7 @@ main() {
 	# Non-blocking: failure to find the entry leaves TASK_LABELS unchanged.
 	if [[ "$NO_ISSUE" == "false" ]] && [[ "$is_offline" == "false" ]]; then
 		local _task_id_for_scan
-		printf -v _task_id_for_scan 't%03d' "$first_id"
+		_task_id_for_scan=$(_format_legacy_task_id "$first_id") || return 1
 		local _todo_derived_labels=""
 		_todo_derived_labels=$(_scan_todo_labels_for_task "$_task_id_for_scan" "$REPO_PATH") || true
 		if [[ -n "$_todo_derived_labels" ]]; then

--- a/.agents/scripts/tests/test-claim-task-id-canonical-format.sh
+++ b/.agents/scripts/tests/test-claim-task-id-canonical-format.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for GH#29425 canonical low-sequence task IDs.
+
+set -u
+
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${TEST_SCRIPT_DIR}/.." && pwd)" || exit 1
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+# shellcheck source=../claim-task-id.sh
+source "${SCRIPTS_DIR}/claim-task-id.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+	local message="$1"
+	PASS_COUNT=$((PASS_COUNT + 1))
+	printf 'PASS %s\n' "$message"
+	return 0
+}
+
+fail() {
+	local message="$1"
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	printf 'FAIL %s\n' "$message" >&2
+	return 0
+}
+
+assert_equal() {
+	local expected="$1"
+	local actual="$2"
+	local message="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		pass "$message"
+		return 0
+	fi
+	fail "${message}: expected '${expected}', got '${actual}'"
+	return 1
+}
+
+test_canonical_sequences() {
+	local sequence=""
+	local expected=""
+	local actual=""
+	while IFS=' ' read -r sequence expected; do
+		actual=$(_format_legacy_task_id "$sequence") || return 1
+		assert_equal "$expected" "$actual" "sequence ${sequence} formats canonically" || return 1
+		task_identity_validate "$actual" || {
+			fail "formatted identity ${actual} is rejected by the canonical codec"
+			return 1
+		}
+	done <<'CASES'
+1 t1
+4 t4
+42 t42
+999 t999
+1000 t1000
+CASES
+	return 0
+}
+
+test_canonical_range_and_output() {
+	local actual=""
+	actual=$(_format_task_range 4 6) || return 1
+	assert_equal "t4..t6" "$actual" "task ranges use canonical identities" || return 1
+
+	ALLOC_COUNT=1
+	actual=$(_main_output_results 4 false "" false "" "") || return 1
+	assert_equal $'task_id=t4\nref=none' "$actual" "single allocation output is canonical" || return 1
+
+	ALLOC_COUNT=3
+	actual=$(_main_output_results 998 false "" false "" "") || return 1
+	assert_equal $'task_id=t998\ntask_id_last=t1000\ntask_count=3\nref=none' "$actual" \
+		"batch allocation crosses the former padding boundary" || return 1
+	return 0
+}
+
+CAPTURED_TITLE_FILE="${TEST_ROOT}/captured-title"
+
+check_cli() {
+	local platform="$1"
+	[[ "$platform" == "github" ]]
+	return $?
+}
+
+create_github_issue() {
+	local title="$1"
+	local description="$2"
+	local labels="$3"
+	local repo_path="$4"
+	: "$description" "$labels" "$repo_path"
+	printf '%s\n' "$title" >"$CAPTURED_TITLE_FILE"
+	printf '123\n'
+	return 0
+}
+
+test_issue_title_and_consumers() {
+	local output=""
+	local parsed=""
+	local what=""
+
+	ALLOC_COUNT=1
+	TASK_TITLE="canonical low task"
+	TASK_DESCRIPTION="description"
+	TASK_LABELS=""
+	REPO_PATH="$TEST_ROOT"
+	_main_create_issues 4 github >/dev/null || return 1
+	assert_equal "t4: canonical low task" "$(<"$CAPTURED_TITLE_FILE")" \
+		"issue title receives the exact canonical identity" || return 1
+
+	parsed=$(parse_task_line '- [ ] t4 canonical low task tier:standard') || return 1
+	if printf '%s\n' "$parsed" | grep -qx 'task_id=t4'; then
+		pass "canonical allocation round-trips through TODO parsing"
+	else
+		fail "TODO parser did not preserve t4"
+		return 1
+	fi
+
+	mkdir -p "${TEST_ROOT}/todo/tasks"
+	cat >"${TEST_ROOT}/todo/tasks/t4-brief.md" <<'BRIEF'
+## What
+
+Canonical low-sequence brief.
+BRIEF
+	what=$(_read_brief_what_section "t4" "$TEST_ROOT") || return 1
+	assert_equal $'\nCanonical low-sequence brief.' "$what" \
+		"canonical allocation round-trips through brief lookup" || return 1
+
+	printf '%s\n' '- [x] t004 historical padded task' >"${TEST_ROOT}/TODO.md"
+	if _id_exists_in_todo 4 "$TEST_ROOT" && ! task_identity_validate t004; then
+		pass "historical padded IDs remain migration-readable but non-canonical"
+	else
+		fail "historical padded compatibility or canonical rejection changed"
+		return 1
+	fi
+
+	output=$(task_identity_format legacy "" 4 "") || return 1
+	assert_equal "t4" "$output" "allocation helper agrees with the public codec" || return 1
+	return 0
+}
+
+main() {
+	test_canonical_sequences || return 1
+	test_canonical_range_and_output || return 1
+	test_issue_title_and_consumers || return 1
+	if [[ "$FAIL_COUNT" -ne 0 ]]; then
+		printf '%d test(s) failed\n' "$FAIL_COUNT" >&2
+		return 1
+	fi
+	printf '%d assertions passed\n' "$PASS_COUNT"
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Emit canonical unpadded legacy task IDs from the claim allocator while retaining padded historical IDs only for migration collision detection.

## Files Changed

.agents/reference/task-identity-parser-inventory.md, .agents/scripts/claim-task-id-counter.sh, .agents/scripts/claim-task-id.sh, .agents/scripts/tests/test-claim-task-id-canonical-format.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Canonical-format regression assertions, identity codec suite, issue-sync and allocator suites, ShellCheck, and local linters passed.

Resolves #29425


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.218 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 20m and 357,223 tokens on this with the user in an interactive session.