### PR TITLE
GH#29319: Add bounded beehiiv account knowledge collection

### DIFF
--- a/.agents/aidevops/knowledge-plane/05-social-operations.md
+++ b/.agents/aidevops/knowledge-plane/05-social-operations.md
@@ -41,8 +41,8 @@ rows. Replay preserves both evidence and projection IDs.
 Candidate implementation is provider-specific, not one generic social adapter.
 Mastodon #29221, GitHub #29222, Stack Exchange #29223, Miniflux #29224,
 Readwise Reader #29225, FreshRSS #29350, Lemmy #29227, public-only
-Hacker News #29228, and Hashnode #29323 are now live. Each route owns its
-identity contract, stream allowlist, checkpoint semantics, and negative
+Hacker News #29228, Hashnode #29323, and beehiiv #29319 are now live. Each route
+owns its identity contract, stream allowlist, checkpoint semantics, and negative
 write-reachability tests.
 Raindrop.io remains optional; Inoreader, Wallabag, Feedly, Instapaper, and Pocket
 are deferred or rejected for the reasons in
@@ -174,6 +174,17 @@ addresses, direct provider member IDs, and patron-owned memberships are never
 requested or persisted. The invocation cap is 99 requests, below the documented
 per-token minute limit. Creator CSV export remains unwired because Patreon does
 not publish a versioned import schema. Details: `.agents/content/social-patreon.md`.
+
+beehiiv collection requires an explicit creator-ownership attestation, then binds
+the configured `pub_...` ID, publication name, and organization name to a
+credential whose `GET /v2/publications` result exposes exactly that publication
+before every page. Confirmed posts and their
+paywall-enforced free web HTML use bounded API-v2 offset pages; the current post
+endpoint documents page numbers rather than the API's preferred opaque cursor
+shape, so the collector caps the route at page 100 and records partial coverage.
+Subscriber records, segments, engagement statistics, premium content, remote
+media, exports, redirects, and mutations are unreachable. Details:
+`.agents/content/social-beehiiv.md`.
 
 X collection uses the guarded official `xurl` helper. Reddit collection uses an
 optional PRAW 8 child. YouTube collection uses a standard-library HTTP child and

--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -39,6 +39,7 @@ a claim that the route is enabled.
 | Threads | **Live/Gate/Export** posts | **No/Export** likes and repost history | **Live/Gate/Export** authored replies and mentions; **No** messages | **No/Export** followers and following | **No** custom feeds | Three product-scoped streams with app-scoped identity, independent cursors, and stream-specific permission gates. |
 | Medium | **Live/Export** authored posts; **Live/Partial** explicit responses | **Live/Export/No** bookmarks, claps, highlights, and list membership when present | **No** | **Live/Export/No** publication membership and follows when present | **Live/Export/No** owned lists when present | Identity-verified native HTML ZIP import with exact replay, bounded local parsing, and per-archive complete/unavailable coverage; legacy API access is not live parity. |
 | Patreon | **Live/Gate** creator campaign posts | **No** patron curation or creator-side interaction history | **No** messages, comments, or mentions | **Live/Gate** minimized current creator memberships; **No** patron-owned memberships or subscriptions | **Live** creator campaigns, tiers, and benefits | Creator-owned campaign allowlist, exact read scopes, identity and ownership recheck, 99-request cap, opaque cursors, and a membership-services purpose gate; no patron-account collection. |
+| beehiiv | **Gate/Live/Partial/Export** confirmed posts and paywall-enforced free web content; **Export** drafts and archives | **No** subscriber-derived engagement statistics | **No** | **Gate/Export/No** subscriber records are excluded pending an explicit PII need and authorization | **Gate/No** segments and newsletter-list membership expose audience structure and are not collected | Explicit creator-ownership attestation plus one expected, singly visible publication; exact GET-only API-v2 routes, bounded page replay, 100-page cap, and no subscriber PII, premium expansion, remote media, dashboard automation, or mutation reachability. |
 | Quora | **Export/No** answers, questions, posts, and comments | **Export/No** bookmarks; **No** upvotes and other curation | **No** | **Export/No** user follows; **No** followed topics or Spaces | **No** | The official export has no published schema. Public content samples lack authoritative owner identity, and the companion account-data schema is unpublished; no adapter or CLI route is enabled. |
 | Skool | **No** posts, comments, and course content | **No** reactions and saved state | **No** notifications and messages | **No** memberships, follows, and groups | **No** courses and calendar feeds | **Export/No** admin membership-question answers only. The official Zapier surface is narrow event automation, the export schema and identity contract are unpublished, and provider policy excludes browser collection. |
 | Substack | **Export/No** publication posts; **No** Notes | **No** comments, likes, restacks, or saved Notes | **No** | **No** reader subscriptions or publication memberships | **No** | Creator ZIP/CSV exports lack published identity/schema contracts; public RSS is not account history, and **Gate/No** bestseller analytics require interactive MCP sign-in and consent. No adapter or CLI route is enabled. |
@@ -92,6 +93,7 @@ separate provider family.
 | Miniflux | **Live/Partial** feed items | **Live/Partial** read, removed, starred, and tagged state | **No** | **Live/Partial/Export** subscriptions | **Live/Partial/Export** categories/tags | #29224 implements keyed installation/user identity, exact GET-only routes, incremental overlap, snapshots, and explicit operator-retention gaps. |
 | FreshRSS | **Live/Partial** feed items | **Live/Partial** unread and starred state | **No** | **Live/Partial/Export** subscriptions | **Live/Partial/Export** folders/tags | #29350 implements keyed installation/user identity, one exact ClientLogin POST, exact GET-only Google Reader routes, cycle-safe opaque continuation resume, strict OPML snapshots, bounded invocation costs, and an explicit unavailable Fever POST boundary. |
 | Readwise Reader | **Live/Gate/Partial** saved documents | **Live/Gate/Partial** tags, state, notes, and progress | **No** | **No** | **Live/Gate/Partial** tags and locations | #29225 implements a deployment-owned account/token binding because official token validation exposes no stable account ID, plus fixed-origin GET-only cursor reads. |
+| beehiiv | **Gate/Live/Partial/Export** confirmed post metadata and free web HTML | **No** subscriber-derived post statistics | **No** | **Gate/Export/No** subscriber PII | **Gate/No** segments and newsletter-list membership | #29319 implements an explicit creator-ownership attestation plus publication ID/name/organization rebinding before each page; API-key scope must expose exactly one publication. |
 | Other readers/read-later | **API/Export/Gate/No** | **API/Export/Gate/No** | **No** | **API/Export/Gate/No** | **API/Export/Gate/No** | Raindrop optional; Inoreader and Wallabag deferred; Feedly and Pocket rejected; Instapaper remains unverified. |
 
 ## Evidence and update discipline
@@ -264,6 +266,16 @@ separate provider family.
   `.agents/content/social-readwise-reader.md` records official auth, document,
   tag, cursor, HTML, rate, privacy, export, retention, and terms evidence checked
   on 2026-08-02.
+- **Live/Gated beehiiv:** `.agents/scripts/knowledge_social_beehiiv.py`,
+  `.agents/scripts/_knowledge_social_beehiiv*.py`, and
+  `.agents/tests/test-knowledge-social-beehiiv.sh` prove an explicit
+  creator-ownership attestation, a singly visible expected publication, repeated
+  ID/name/organization verification, bounded API-v2 post pages, exact replay,
+  terminal and malformed-page safety, credential rejection, stale-lease fencing,
+  and fixed-origin GET-only mutation isolation.
+  `.agents/content/social-beehiiv.md` records official API-v2 authentication,
+  endpoint-specific pagination, organization quota, plan/export gates, privacy,
+  terms, and excluded subscriber fields checked on 2026-08-03.
 - **Integrated provider registry:** `.agents/scripts/knowledge_social_registry.py`
   and `.agents/tests/test-knowledge-social-registry.sh` prove order-independent
   registration, collision rejection, exact aliases and modes, no-route failure,

--- a/.agents/configs/allowed-urls.txt
+++ b/.agents/configs/allowed-urls.txt
@@ -37,6 +37,7 @@ api.aigateway.com
 api.anthropic.com
 api.app.outscraper.com
 api.au.snyk.io
+api.beehiiv.com
 api.blocklist.de
 api.builtwith.com
 api.capsolver.com

--- a/.agents/content/social-beehiiv.md
+++ b/.agents/content/social-beehiiv.md
@@ -1,0 +1,133 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# beehiiv account knowledge
+
+Checked on 2026-08-03. The enabled route is deliberately publication-scoped and
+posts-only. It is not a general beehiiv workspace, audience, or export client.
+
+## Current disposition
+
+| Category | Disposition | Boundary |
+|---|---|---|
+| Publications | **Gate/Live** | A creator-ownership attestation bound to one configured `pub_...` ID is required; its exact ID, name, and organization must be the only publication visible to the credential. |
+| Posts | **Gate/Live/Partial** | After the ownership and identity gate, confirmed post metadata plus `free_web_content`; future scheduled items are skipped, premium expansion and statistics are never requested. |
+| Subscriptions | **Gate/Export/No** | The API and dashboard export expose email, status, tier, custom fields, and statistics. No subscriber endpoint or import route is enabled without a separate account-knowledge need, authorization, and field-by-field minimization. |
+| Segments | **Gate/No** | Segment membership can return subscription IDs or subscriber records. No route is enabled. |
+| Exports | **Export** | Creator-initiated post and subscriber CSV exports exist; dashboard automation is prohibited and no schema is treated as stable without a private fixture. |
+
+## Official contract
+
+The current official developer index identifies API v2 and the fixed
+`https://api.beehiiv.com/v2` origin:
+<https://developers.beehiiv.com/llms.txt>. Requests use bearer authentication.
+API keys may be restricted to selected publications; a restricted key returns
+only allowed publications from `GET /v2/publications`, while out-of-scope IDs
+return `404`:
+<https://developers.beehiiv.com/welcome/create-an-api-key.md>.
+
+OAuth authorization-code clients can request the separate
+`publications:read`, `posts:read`, `subscriptions:read`, and `segments:read`
+scopes. This collector needs only the first two and does not implement the OAuth
+authorization exchange itself:
+<https://developers.beehiiv.com/oauth2.md>.
+
+The enabled calls are exactly:
+
+- `GET /v2/publications?limit=2&page=1` for publication scope and identity;
+- `GET /v2/publications/{publicationId}/posts` with `status=confirmed`,
+  `expand=free_web_content`, ascending creation order, and bounded page/limit.
+
+Official endpoint schemas:
+<https://developers.beehiiv.com/api-reference/publications/index.md> and
+<https://developers.beehiiv.com/api-reference/posts/index.md>.
+
+The general API guide recommends opaque `cursor`, `next_cursor`, and `has_more`
+pagination, and deprecates page offsets beyond a hard page-100 boundary. The
+current publication and post endpoint schemas still document `page`,
+`total_pages`, and `total_results`. The adapter follows the endpoint-specific
+schema, versions its local page cursor, caps requests at page 100, and records
+partial coverage instead of claiming an exhaustive history:
+<https://developers.beehiiv.com/welcome/pagination.md>.
+
+The organization-wide limit is 180 requests per minute. Each page costs two
+provider requests because identity is rechecked immediately before the post
+read; the initial identity costs one. The CLI caps an invocation at 59 requests,
+honors `RateLimit-Reset` or a valid `Retry-After`, and persists no new checkpoint
+for `429` or another terminal response:
+<https://developers.beehiiv.com/welcome/rate-limiting.md>.
+
+## Identity and authorization boundary
+
+Each local profile supplies `BEEHIIV_<PROFILE>_ACCESS_TOKEN`,
+`BEEHIIV_<PROFILE>_PUBLICATION_ID`,
+`BEEHIIV_<PROFILE>_PUBLICATION_NAME`, and
+`BEEHIIV_<PROFILE>_ORGANIZATION_NAME`, plus
+`BEEHIIV_<PROFILE>_CREATOR_OWNED_PUBLICATION_ID` as an explicit deployment-owner
+attestation. The attested and configured publication IDs must match. The
+command's `--account-id` must equal that ID. Before state is loaded and before
+every post page, the provider requires the attestation, exactly one visible
+publication, and exact ID, name, and organization equality. A workspace-wide
+credential with multiple visible publications is rejected even if the requested
+ID is valid.
+
+The API does not expose an immutable human owner ID or prove legal ownership, so
+the additional local value is an operator attestation rather than a provider
+claim. Without it, the live route is gated before any API call or state advance.
+Fixtures prove missing, mismatched, and response-level ownership attestations
+fail closed; they do not claim to prove legal ownership. The deployment owner
+remains responsible for attesting only a creator-owned publication and, for API
+keys, restricting the key to that publication. Mutable name and organization
+checks intentionally fail closed until local expectations are updated after a
+legitimate rename.
+
+## Privacy and persistence
+
+Retained post fields are stable post ID, title/subtitle, public author
+attribution, timestamps, status, subject/preview text, slug/web URL, audience,
+platform, content tags, selected SEO metadata, visibility flags, and
+paywall-enforced free web HTML. Author names are retained because they are direct
+publication-content attribution. No remote media is fetched.
+
+The adapter never requests or stores subscriber emails, custom fields, tiers,
+segment membership, newsletter-list membership, per-recipient events, click
+detail, post statistics, or premium HTML. Credential-shaped fixture/provider
+payloads fail before raw or normalized persistence. Every successful page writes
+one immutable bounded response and its normalized projection atomically under a
+lease-fencing token; replay is content-addressed and stale leases cannot advance
+evidence or cursors.
+
+beehiiv's privacy policy uses purpose-based retention rather than promising one
+universal history window, so deletion and pre-retention history remain explicit
+gaps: <https://www.beehiiv.com/privacy>. The terms preserve creator ownership of
+submitted content while prohibiting unauthorized automated extraction; this
+route uses documented APIs only: <https://www.beehiiv.com/tou> and
+<https://www.beehiiv.com/aup>.
+
+## Exports and plans
+
+The official dashboard workflow can export all post metadata/content and Quick
+or Full subscriber CSVs. Jobs are asynchronous and download links expire after
+24 hours. The public API index documents no export-job route, so the collector
+does not automate the dashboard, email links, redirects, or browser sessions:
+<https://www.beehiiv.com/support/article/12258595483543-exporting-post-content-or-subscriber-data-from-beehiiv>.
+
+Current pricing advertises API access across publication plans but product and
+endpoint entitlement can change. `401`, `403`, and publication-hidden `404`
+responses are terminal authorization/availability evidence, never a reason to
+fall back to scraping: <https://www.beehiiv.com/pricing>.
+
+## Usage
+
+```bash
+aidevops secret BEEHIIV_PERSONAL_ACCESS_TOKEN \
+  BEEHIIV_PERSONAL_PUBLICATION_ID BEEHIIV_PERSONAL_PUBLICATION_NAME \
+  BEEHIIV_PERSONAL_ORGANIZATION_NAME \
+  BEEHIIV_PERSONAL_CREATOR_OWNED_PUBLICATION_ID -- \
+  knowledge-social-helper.sh sync-beehiiv --alias personal:default \
+  --connection-id CONNECTION_ID --account-id PUBLICATION_ID \
+  --stream posts --profile personal --budget 19 --page-size 100
+```
+
+The credential remains in the secret execution context. Never put it in command
+arguments, fixtures, logs, corpus rows, issue text, or repository files.

--- a/.agents/scripts/_knowledge_social_beehiiv.py
+++ b/.agents/scripts/_knowledge_social_beehiiv.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""beehiiv publication identity, post policy, and durable page checkpoints."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from knowledge_social_import import canonical_json, reject_credentials
+from knowledge_social_store import SocialStoreError
+
+PROVIDER = "beehiiv"
+CURSOR_PREFIX = "beehiiv-v2-page:"
+RETENTION_LIMIT = "provider_retention_offset_page_100_and_deletion_boundary"
+MAX_PAGE_ITEMS = 100
+MAX_PAGE_NUMBER = 100
+MAX_TEXT_BYTES = 2 * 1024 * 1024
+PUBLICATION = re.compile(r"^pub_[A-Za-z0-9_-]{1,123}$")
+POST = re.compile(r"^post_[A-Za-z0-9_-]{1,123}$")
+
+
+class BeehiivAdapterError(SocialStoreError):
+    """Raised when guarded beehiiv collection cannot continue safely."""
+
+
+class BeehiivProviderUnavailableError(BeehiivAdapterError):
+    """Raised when the bounded beehiiv HTTP child cannot complete a read."""
+
+
+class BeehiivProviderError(RuntimeError):
+    """Raised for a privacy-safe local beehiiv provider failure."""
+
+
+ADAPTER_ERROR = BeehiivAdapterError
+PROVIDER_UNAVAILABLE_ERROR = BeehiivProviderUnavailableError
+
+
+def publication_id(value: Any) -> str:
+    """Validate one stable, prefixed beehiiv publication identity."""
+    if not isinstance(value, str) or PUBLICATION.fullmatch(value) is None:
+        raise BeehiivAdapterError("beehiiv publication ID is invalid")
+    return value
+
+
+def post_id(value: Any) -> str:
+    """Validate one stable, prefixed beehiiv post identity."""
+    if not isinstance(value, str) or POST.fullmatch(value) is None:
+        raise BeehiivAdapterError("beehiiv post ID is invalid")
+    return value
+
+
+def _text(value: Any, field: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str):
+        raise BeehiivAdapterError(f"beehiiv {field} is invalid")
+    if not value and not optional:
+        raise BeehiivAdapterError(f"beehiiv {field} is invalid")
+    if "\x00" in value or len(value.encode()) > MAX_TEXT_BYTES:
+        raise BeehiivAdapterError(f"beehiiv {field} is invalid")
+    return value
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    """One intentionally narrow beehiiv stream contract."""
+
+    resource_kind: str
+    activity_mode: str
+    pagination: str = "offset_page_v2"
+    incremental: bool = False
+    retention_limit: str | None = RETENTION_LIMIT
+    coverage_status: str | None = "partial"
+    unavailable_reason: str | None = "offset_page_100_and_provider_retention_boundary"
+    cost_units: int = 2
+
+
+STREAMS = {"posts": StreamSpec("post", "selected_publication")}
+
+
+@dataclass(frozen=True)
+class PageRequest:
+    """A selected-publication post page with an evidence-stable request key."""
+
+    stream: str
+    account_id: str
+    page: int
+    limit: int
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "page",
+            "stream": self.stream,
+            "account_id": self.account_id,
+            "page": self.page,
+            "limit": self.limit,
+        }
+
+    def evidence_key(self) -> str:
+        return canonical_json(self.payload())
+
+
+PAGE_REQUEST_KEYS = frozenset(PageRequest.__dataclass_fields__) | {"action"}
+
+
+def _decode_cursor(value: str) -> int:
+    if not value.startswith(CURSOR_PREFIX):
+        raise BeehiivAdapterError("stored beehiiv cursor has an unsupported version")
+    page = value.removeprefix(CURSOR_PREFIX)
+    if not page.isdigit() or not 1 <= int(page) <= MAX_PAGE_NUMBER:
+        raise BeehiivAdapterError("stored beehiiv cursor is invalid")
+    return int(page)
+
+
+def _encode_cursor(page: int) -> str:
+    if not 1 <= page <= MAX_PAGE_NUMBER:
+        raise BeehiivAdapterError("next beehiiv page exceeds the supported API boundary")
+    return f"{CURSOR_PREFIX}{page}"
+
+
+def page_request(
+    stream: str, account: dict[str, Any], state: CursorState, limit: int
+) -> PageRequest:
+    """Build the next bounded snapshot page for the selected publication."""
+    if stream not in STREAMS:
+        raise BeehiivAdapterError("beehiiv stream is unsupported")
+    page = _decode_cursor(state.cursor) if state.cursor else 1
+    return PageRequest(stream, publication_id(account.get("id")), page, limit)
+
+
+def parse_page_request(payload: dict[str, Any]) -> PageRequest:
+    """Reject every provider request outside the exact post-page shape."""
+    if set(payload) != PAGE_REQUEST_KEYS or payload.get("action") != "page":
+        raise BeehiivAdapterError("beehiiv request has an invalid action shape")
+    stream = payload.get("stream")
+    if not isinstance(stream, str) or stream not in STREAMS:
+        raise BeehiivAdapterError("beehiiv stream is unsupported")
+    page = payload.get("page")
+    limit = payload.get("limit")
+    if isinstance(page, bool) or not isinstance(page, int) or not 1 <= page <= MAX_PAGE_NUMBER:
+        raise BeehiivAdapterError("beehiiv page number is invalid")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= MAX_PAGE_ITEMS:
+        raise BeehiivAdapterError("beehiiv page size is invalid")
+    return PageRequest(stream, publication_id(payload.get("account_id")), page, limit)
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise BeehiivAdapterError("beehiiv response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise BeehiivAdapterError("beehiiv page data must be an array")
+    return data
+
+
+def _non_negative_int(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise BeehiivAdapterError(f"beehiiv {field} is invalid")
+    return value
+
+
+@dataclass(frozen=True)
+class PageMetadata:
+    """Validated offset totals and raw or normalized item count."""
+
+    page: int
+    total_pages: int
+    total_results: int
+    item_count: int
+
+
+def validate_page_metadata(
+    metadata: PageMetadata,
+    request: PageRequest,
+    *,
+    exact_items: bool,
+) -> None:
+    """Reject contradictory offset metadata before a page can advance state."""
+    if metadata.page != request.page or metadata.page < 1:
+        raise BeehiivAdapterError("beehiiv response page does not match the request")
+    expected_pages = (metadata.total_results + request.limit - 1) // request.limit
+    if metadata.total_pages != expected_pages:
+        raise BeehiivAdapterError("beehiiv pagination totals are inconsistent")
+    if metadata.total_pages == 0:
+        if metadata.page != 1 or metadata.item_count != 0:
+            raise BeehiivAdapterError("beehiiv empty pagination metadata is inconsistent")
+        return
+    if metadata.page > metadata.total_pages:
+        raise BeehiivAdapterError("beehiiv response page exceeds total pages")
+    remaining = metadata.total_results - ((metadata.page - 1) * request.limit)
+    expected_items = min(request.limit, remaining)
+    if metadata.item_count > expected_items or (
+        exact_items and metadata.item_count != expected_items
+    ):
+        raise BeehiivAdapterError("beehiiv page items contradict pagination totals")
+
+
+def page_checkpoint(
+    payload: dict[str, Any], state: CursorState, request: PageRequest
+) -> tuple[PageCheckpoint, bool]:
+    """Validate page provenance before advancing the offset checkpoint."""
+    meta = payload.get("meta")
+    expected_keys = {"stream", "publication_id", "page", "total_pages", "total_results"}
+    if not isinstance(meta, dict) or set(meta) != expected_keys:
+        raise BeehiivAdapterError("beehiiv page provenance is invalid")
+    reject_credentials(meta)
+    if meta.get("stream") != request.stream:
+        raise BeehiivAdapterError("beehiiv page stream does not match the request")
+    if publication_id(meta.get("publication_id")) != request.account_id:
+        raise BeehiivAdapterError("beehiiv page belongs to another publication")
+    page = _non_negative_int(meta.get("page"), "response page")
+    total_pages = _non_negative_int(meta.get("total_pages"), "total pages")
+    total_results = _non_negative_int(meta.get("total_results"), "total results")
+    items = page_data(payload)
+    validate_page_metadata(
+        PageMetadata(page, total_pages, total_results, len(items)),
+        request,
+        exact_items=False,
+    )
+    if total_pages == 0:
+        return PageCheckpoint(None, state.watermark), True
+    final_page = min(total_pages, MAX_PAGE_NUMBER)
+    complete = page >= final_page
+    next_cursor = None if complete else _encode_cursor(page + 1)
+    return PageCheckpoint(next_cursor, state.watermark), complete
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    """Bind storage to one explicitly configured, singly visible publication."""
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise BeehiivAdapterError("beehiiv publication verification returned no identity")
+    selected = publication_id(data.get("id"))
+    if selected != publication_id(expected_id):
+        raise BeehiivAdapterError("selected beehiiv publication does not match expected identity")
+    if data.get("scope_verified") is not True:
+        raise BeehiivAdapterError("beehiiv publication-scoped authorization is not verified")
+    if data.get("ownership_attested") is not True:
+        raise BeehiivAdapterError("beehiiv creator ownership is not attested")
+    created = data.get("created")
+    referral = data.get("referral_program_enabled")
+    if isinstance(created, bool) or not isinstance(created, (int, float)) or created < 0:
+        raise BeehiivAdapterError("beehiiv publication creation time is invalid")
+    if not isinstance(referral, bool):
+        raise BeehiivAdapterError("beehiiv publication referral state is invalid")
+    return {
+        "id": selected,
+        "name": _text(data.get("name"), "publication name"),
+        "organization_name": _text(data.get("organization_name"), "organization name"),
+        "created": created,
+        "referral_program_enabled": referral,
+        "scope_verified": True,
+        "ownership_attested": True,
+    }
+
+
+PROVENANCE = "beehiiv_api_v2"
+GAPS = (
+    ("draft_and_archived_posts", "default_live_route_collects_confirmed_posts_only"),
+    ("premium_post_content", "premium_content_expansion_is_not_requested"),
+    ("post_engagement_stats", "subscriber_derived_engagement_metrics_are_excluded"),
+    ("subscriptions", "subscriber_pii_requires_separate_justification_and_authorization"),
+    ("segments", "segment_membership_can_expose_subscriber_pii"),
+    ("post_export", "creator_initiated_dashboard_export_is_not_automated"),
+    ("subscriber_export", "sensitive_creator_initiated_export_is_not_imported"),
+    ("deletion_history", "api_does_not_prove_complete_deleted_post_history"),
+)
+
+
+@dataclass(frozen=True)
+class PageContext:
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def _record_text(record: dict[str, Any], key: str) -> str | None:
+    return _text(record.get(key), f"post {key}", optional=True)
+
+
+def _string_list(record: dict[str, Any], key: str) -> list[str]:
+    value = record.get(key, [])
+    if (
+        not isinstance(value, list)
+        or len(value) > 100
+        or any(not isinstance(item, str) or not item or "\x00" in item for item in value)
+    ):
+        raise BeehiivAdapterError(f"beehiiv post {key} is invalid")
+    return value
+
+
+def _coverage(observed: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "stream": stream,
+            "earliest_at": None,
+            "latest_at": None,
+            "cursor_exhausted": False,
+            "retention_limit": RETENTION_LIMIT,
+            "unavailable_reason": reason,
+            "status": "unavailable",
+            "observed_at": observed,
+        }
+        for stream, reason in GAPS
+    ]
+
+
+def _object(record: dict[str, Any], context: PageContext, observed: str) -> dict[str, Any]:
+    if record.get("kind") != "post":
+        raise BeehiivAdapterError("beehiiv item kind is unsupported")
+    remote = post_id(record.get("remote_id"))
+    authors = _string_list(record, "authors")
+    tags = _string_list(record, "content_tags")
+    text_parts = [
+        value
+        for value in (
+            _record_text(record, "title"),
+            _record_text(record, "subtitle"),
+            _record_text(record, "subject_line"),
+            _record_text(record, "preview_text"),
+            _record_text(record, "free_web_content"),
+            "\n".join(authors) or None,
+        )
+        if value
+    ]
+    metadata = {
+        key: value
+        for key, value in record.items()
+        if key not in {"free_web_content", "kind", "remote_id"}
+    }
+    metadata["content_tags"] = tags
+    reject_credentials(metadata)
+    return {
+        "object_type": "post",
+        "remote_id": remote,
+        "account_remote_id": context.account.get("id"),
+        "text": "\n\n".join(text_parts) or None,
+        "created_at": _record_text(record, "publish_date")
+        or _record_text(record, "created_at"),
+        "observed_at": observed,
+        "evidence_class": "authored",
+        "provider_json": {
+            "source": PROVENANCE,
+            "stream": context.stream,
+            "record": metadata,
+        },
+    }
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    """Normalize confirmed post content while excluding subscriber-level data."""
+    reject_credentials(payload)
+    observed = _text(payload.get("observed_at"), "observed_at")
+    if observed is None:
+        raise BeehiivAdapterError("beehiiv observed_at is invalid")
+    items = page_data(payload)
+    policy = dict(context.policy)
+    policy.update(
+        {
+            "beehiiv_identity": "single_visible_publication_plus_expected_id_name_and_organization",
+            "beehiiv_pagination": "endpoint_documented_offset_pages_capped_at_100",
+            "beehiiv_privacy": "subscriber_pii_segments_stats_and_premium_content_excluded",
+            "beehiiv_transport": "fixed_origin_stdlib_urllib_get_only_redirect_rejecting",
+        }
+    )
+    archive = {
+        "provider": PROVIDER,
+        "connection_id": context.connection_id,
+        "remote_account_id": context.account.get("id"),
+        "exported_at": observed,
+        "enabled_streams": list(context.enabled_streams),
+        "policy": policy,
+        "accounts": [
+            {
+                "remote_id": context.account.get("id"),
+                "handle": None,
+                "display_name": context.account.get("name"),
+                "observed_at": observed,
+                "provider_json": {
+                    "source": PROVENANCE,
+                    "organization_name": context.account.get("organization_name"),
+                    "created": context.account.get("created"),
+                    "referral_program_enabled": context.account.get(
+                        "referral_program_enabled"
+                    ),
+                    "publication_scope_verified": True,
+                },
+            }
+        ],
+        "objects": [_object(item, context, observed) for item in items],
+        "activities": [],
+        "media": [],
+        "coverage": _coverage(observed),
+    }
+    reject_credentials(archive)
+    return archive

--- a/.agents/scripts/_knowledge_social_beehiiv_http.py
+++ b/.agents/scripts/_knowledge_social_beehiiv_http.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Redirect-free, bounded GET transport for the beehiiv API v2."""
+
+from __future__ import annotations
+
+import math
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from _knowledge_social_beehiiv import BeehiivProviderError, publication_id
+
+API_ORIGIN = "https://api.beehiiv.com/v2"
+MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+HTTP_TIMEOUT_SECONDS = 60
+POST_PATH = re.compile(r"^/publications/(pub_[A-Za-z0-9_-]{1,123})/posts$")
+
+
+class Headers(Protocol):
+    def get(self, key: str, default: str | None = None) -> str | None: ...
+
+
+class Response(Protocol):
+    status: int
+    headers: Headers
+
+    def __enter__(self) -> Response: ...
+    def __exit__(self, *args: Any) -> None: ...
+    def read(self, size: int = -1) -> bytes: ...
+
+
+class Opener(Protocol):
+    def open(self, request: Request, timeout: int) -> Response: ...
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    access_token: str
+    publication_id: str
+    publication_name: str
+    organization_name: str
+    creator_owned_publication_id: str
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    status: int
+    payload: Any
+    retry_after: int | None = None
+
+
+class _RejectRedirect(HTTPRedirectHandler):
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def http_opener() -> Opener:
+    exports = (Request, build_opener, urlencode, HTTPRedirectHandler)
+    if not all(callable(item) for item in exports):
+        raise BeehiivProviderError("Python urllib HTTP exports are unavailable")
+    return build_opener(_RejectRedirect())
+
+
+def allowlisted_path(path: str) -> bool:
+    return path == "/publications" or POST_PATH.fullmatch(path) is not None
+
+
+def query_keys_for_path(path: str) -> frozenset[str]:
+    if path == "/publications":
+        return frozenset({"limit", "page"})
+    if POST_PATH.fullmatch(path):
+        return frozenset({"expand", "limit", "page", "status", "order_by", "direction"})
+    return frozenset()
+
+
+def _validate_query(path: str, params: dict[str, str]) -> None:
+    if not allowlisted_path(path) or set(params) - query_keys_for_path(path):
+        raise BeehiivProviderError("beehiiv API route is not allowlisted")
+    if any(
+        not isinstance(value, str) or "\x00" in value or len(value.encode()) > 4096
+        for value in params.values()
+    ):
+        raise BeehiivProviderError("beehiiv API query is invalid")
+    if "limit" in params and (
+        not params["limit"].isdigit() or not 1 <= int(params["limit"]) <= 100
+    ):
+        raise BeehiivProviderError("beehiiv page size is invalid")
+    if "page" in params and (
+        not params["page"].isdigit() or not 1 <= int(params["page"]) <= 100
+    ):
+        raise BeehiivProviderError("beehiiv page number is invalid")
+    expected = {
+        "expand": "free_web_content",
+        "status": "confirmed",
+        "order_by": "created",
+        "direction": "asc",
+    }
+    if any(key in params and params[key] != value for key, value in expected.items()):
+        raise BeehiivProviderError("beehiiv post query exceeds the read policy")
+
+
+def target_url(path: str, params: dict[str, str]) -> str:
+    _validate_query(path, params)
+    match = POST_PATH.fullmatch(path)
+    if match:
+        publication_id(match.group(1))
+    query = urlencode(params)
+    return f"{API_ORIGIN}{path}" + (f"?{query}" if query else "")
+
+
+def _decode_json(payload: bytes) -> Any:
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise BeehiivProviderError("beehiiv JSON exceeds the safety limit")
+    try:
+        import json
+
+        return json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise BeehiivProviderError("beehiiv JSON is invalid") from error
+
+
+def _absolute_reset(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        reset = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(reset) or reset < 0:
+        return None
+    return math.ceil(reset)
+
+
+def _retry_seconds(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    return int(time.time() + math.ceil(seconds))
+
+
+def _retry_epoch(headers: Headers | None) -> int | None:
+    if headers is None:
+        return None
+    return _absolute_reset(headers.get("RateLimit-Reset")) or _retry_seconds(
+        headers.get("Retry-After")
+    )
+
+
+def api(
+    config: ProfileConfig, opener: Opener, path: str, params: dict[str, str]
+) -> ApiResult:
+    request = Request(
+        target_url(path, params),
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {config.access_token}",
+            "User-Agent": "aidevops-beehiiv-knowledge/1",
+        },
+        method="GET",
+    )
+    try:
+        with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", 200)
+            if isinstance(status, bool) or not isinstance(status, int):
+                raise BeehiivProviderError("beehiiv HTTP status is invalid")
+            if status != 200:
+                return ApiResult(status, {}, _retry_epoch(response.headers))
+            payload = response.read(MAX_RESPONSE_BYTES + 1)
+            if not isinstance(payload, bytes):
+                raise BeehiivProviderError("beehiiv HTTP response is invalid")
+            return ApiResult(status, _decode_json(payload))
+    except HTTPError as error:
+        return ApiResult(error.code, {}, _retry_epoch(error.headers))
+    except (TimeoutError, URLError, OSError) as error:
+        raise BeehiivProviderError("beehiiv request failed") from error

--- a/.agents/scripts/_knowledge_social_beehiiv_posts.py
+++ b/.agents/scripts/_knowledge_social_beehiiv_posts.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Privacy-minimized normalization for beehiiv publication posts."""
+
+from __future__ import annotations
+
+import math
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_beehiiv import BeehiivProviderError, post_id
+from knowledge_social_import import reject_credentials
+
+MAX_TEXT_BYTES = 2 * 1024 * 1024
+
+
+def _object(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise BeehiivProviderError(f"beehiiv {field} must be an object")
+    return value
+
+
+def validated_text(
+    value: Any, field: str, *, optional: bool = False, limit: int = 64 * 1024
+) -> str | None:
+    if value is None and optional:
+        return None
+    if not isinstance(value, str):
+        raise BeehiivProviderError(f"beehiiv {field} is invalid")
+    if not value and not optional:
+        raise BeehiivProviderError(f"beehiiv {field} is invalid")
+    if "\x00" in value or len(value.encode()) > limit:
+        raise BeehiivProviderError(f"beehiiv {field} is invalid")
+    return value
+
+
+def _epoch(value: Any, field: str, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise BeehiivProviderError(f"beehiiv {field} is invalid")
+    if not math.isfinite(value) or value < 0:
+        raise BeehiivProviderError(f"beehiiv {field} is invalid")
+    try:
+        return datetime.fromtimestamp(value, UTC).isoformat().replace("+00:00", "Z")
+    except (OverflowError, OSError, ValueError) as error:
+        raise BeehiivProviderError(f"beehiiv {field} is invalid") from error
+
+
+def _string(value: Any, field: str) -> str:
+    if not isinstance(value, str):
+        raise BeehiivProviderError(f"beehiiv post {field} is invalid")
+    if not value or "\x00" in value or len(value.encode()) > 4096:
+        raise BeehiivProviderError(f"beehiiv post {field} is invalid")
+    return value
+
+
+def _strings(value: Any, field: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or len(value) > 100:
+        raise BeehiivProviderError(f"beehiiv post {field} is invalid")
+    return [_string(item, field) for item in value]
+
+
+def _enum(value: Any, field: str, allowed: frozenset[str]) -> str:
+    text = validated_text(value, f"post {field}")
+    if text not in allowed:
+        raise BeehiivProviderError(f"beehiiv post {field} is unsupported")
+    return text
+
+
+def _boolean(value: Any, field: str, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise BeehiivProviderError(f"beehiiv post {field} is invalid")
+    return value
+
+
+def _free_web_content(item: dict[str, Any]) -> str | None:
+    content_value = item.get("content")
+    if content_value is None:
+        return None
+    content = _object(content_value, "post content")
+    if content.get("premium") not in (None, {}):
+        raise BeehiivProviderError("beehiiv premium post content is outside the read policy")
+    free_value = content.get("free")
+    if free_value is None:
+        return None
+    free = _object(free_value, "free post content")
+    return validated_text(
+        free.get("web"), "free web content", optional=True, limit=MAX_TEXT_BYTES
+    )
+
+
+def normalize_post(
+    item: dict[str, Any], observed_epoch: float
+) -> dict[str, Any] | None:
+    """Validate and minimize one confirmed post without audience statistics."""
+    reject_credentials(item)
+    if item.get("stats") not in (None, {}):
+        raise BeehiivProviderError("beehiiv post statistics are outside the privacy policy")
+    status = _enum(item.get("status"), "status", frozenset({"confirmed"}))
+    publish_value = item.get("publish_date")
+    publish_date = _epoch(publish_value, "post publish date", optional=True)
+    if publish_value is not None and float(publish_value) > observed_epoch:
+        return None
+    return {
+        "kind": "post",
+        "remote_id": post_id(item.get("id")),
+        "title": validated_text(item.get("title"), "post title", optional=True),
+        "subtitle": validated_text(item.get("subtitle"), "post subtitle", optional=True),
+        "authors": _strings(item.get("authors"), "authors"),
+        "created_at": _epoch(item.get("created"), "post creation time", optional=True),
+        "status": status,
+        "publish_date": publish_date,
+        "displayed_date": _epoch(
+            item.get("displayed_date"), "post displayed date", optional=True
+        ),
+        "subject_line": validated_text(
+            item.get("subject_line"), "post subject line", optional=True
+        ),
+        "preview_text": validated_text(
+            item.get("preview_text"), "post preview text", optional=True
+        ),
+        "slug": validated_text(item.get("slug"), "post slug", optional=True),
+        "web_url": validated_text(item.get("web_url"), "post web URL", optional=True),
+        "audience": _enum(
+            item.get("audience"),
+            "audience",
+            frozenset({"free", "premium", "both"}),
+        ),
+        "platform": _enum(
+            item.get("platform"),
+            "platform",
+            frozenset({"web", "email", "both"}),
+        ),
+        "content_tags": _strings(item.get("content_tags"), "content tags"),
+        "meta_default_description": validated_text(
+            item.get("meta_default_description"), "post meta description", optional=True
+        ),
+        "meta_default_title": validated_text(
+            item.get("meta_default_title"), "post meta title", optional=True
+        ),
+        "hidden_from_feed": _boolean(item.get("hidden_from_feed"), "hidden state"),
+        "enforce_gated_content": _boolean(
+            item.get("enforce_gated_content"), "gated-content state"
+        ),
+        "free_web_content": _free_web_content(item),
+    }

--- a/.agents/scripts/_knowledge_social_beehiiv_provider.py
+++ b/.agents/scripts/_knowledge_social_beehiiv_provider.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded GET-only beehiiv publication subprocess."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import UTC, datetime
+from functools import partial
+from typing import Any, Callable
+
+from _knowledge_social_beehiiv import (
+    BeehiivAdapterError,
+    BeehiivProviderError,
+    PageMetadata,
+    PageRequest,
+    parse_page_request,
+    publication_id,
+    validate_page_metadata,
+)
+from _knowledge_social_beehiiv_http import (
+    MAX_RESPONSE_BYTES,
+    ApiResult,
+    Opener,
+    ProfileConfig,
+    api,
+    http_opener,
+)
+from _knowledge_social_beehiiv_posts import normalize_post, validated_text
+from knowledge_social_import import reject_credentials
+
+MAX_REQUEST_BYTES = 32 * 1024
+PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9_]{0,63}$")
+Api = Callable[[str, dict[str, str]], ApiResult]
+
+
+def _observed_at() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _prefix(profile: str) -> str:
+    if PROFILE_NAME.fullmatch(profile) is None:
+        raise BeehiivProviderError("beehiiv profile name is invalid")
+    return f"BEEHIIV_{profile.upper()}"
+
+
+def _value(prefix: str, suffix: str, field: str, limit: int) -> str:
+    value = os.environ.get(f"{prefix}_{suffix}", "")
+    if not value or "\x00" in value or len(value.encode()) > limit:
+        raise BeehiivProviderError(f"beehiiv profile {field} is missing")
+    return value
+
+
+def _profile(profile: str) -> ProfileConfig:
+    prefix = _prefix(profile)
+    token = _value(prefix, "ACCESS_TOKEN", "access token", 16 * 1024)
+    selected = publication_id(_value(prefix, "PUBLICATION_ID", "publication ID", 128))
+    name = _value(prefix, "PUBLICATION_NAME", "publication name", 4096)
+    organization = _value(prefix, "ORGANIZATION_NAME", "organization name", 4096)
+    ownership = publication_id(
+        _value(
+            prefix,
+            "CREATOR_OWNED_PUBLICATION_ID",
+            "creator-owned publication ID",
+            128,
+        )
+    )
+    if ownership != selected:
+        raise BeehiivProviderError(
+            "beehiiv profile creator ownership attestation does not match publication"
+        )
+    return ProfileConfig(token, selected, name, organization, ownership)
+
+
+def _object(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise BeehiivProviderError(f"beehiiv {field} must be an object")
+    return value
+
+
+def _objects(value: Any, field: str, limit: int) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise BeehiivProviderError(f"beehiiv {field} must be an array")
+    if len(value) > limit:
+        raise BeehiivProviderError(f"beehiiv {field} exceeds the item limit")
+    return value
+
+
+def _non_negative_int(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise BeehiivProviderError(f"beehiiv {field} is invalid")
+    return value
+
+
+def _terminal(result: ApiResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": result.status, "observed_at": _observed_at()}
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload
+
+
+def _identity(
+    config: ProfileConfig, opener: Opener, expected_id: str
+) -> dict[str, Any]:
+    if publication_id(expected_id) != config.publication_id:
+        raise BeehiivProviderError(
+            "selected beehiiv publication does not match the configured publication"
+        )
+    if config.creator_owned_publication_id != config.publication_id:
+        raise BeehiivProviderError(
+            "beehiiv profile creator ownership attestation does not match publication"
+        )
+    result = api(config, opener, "/publications", {"limit": "2", "page": "1"})
+    if result.status != 200:
+        return _terminal(result)
+    root = _object(result.payload, "publications response")
+    reject_credentials(root)
+    items = _objects(root.get("data"), "publications", 2)
+    page = _non_negative_int(root.get("page"), "publication page")
+    total_pages = _non_negative_int(root.get("total_pages"), "publication total pages")
+    total_results = _non_negative_int(root.get("total_results"), "publication total results")
+    if page != 1 or total_pages != 1 or total_results != 1 or len(items) != 1:
+        raise BeehiivProviderError(
+            "beehiiv credential is not bound to exactly one visible publication"
+        )
+    item = items[0]
+    selected = publication_id(item.get("id"))
+    name = validated_text(item.get("name"), "publication name")
+    organization = validated_text(item.get("organization_name"), "organization name")
+    created = item.get("created")
+    referral = item.get("referral_program_enabled")
+    if (
+        selected != config.publication_id
+        or name != config.publication_name
+        or organization != config.organization_name
+    ):
+        raise BeehiivProviderError("beehiiv publication identity does not match expectations")
+    if isinstance(created, bool) or not isinstance(created, (int, float)) or created < 0:
+        raise BeehiivProviderError("beehiiv publication creation time is invalid")
+    if not isinstance(referral, bool):
+        raise BeehiivProviderError("beehiiv publication referral state is invalid")
+    return {
+        "status": 200,
+        "observed_at": _observed_at(),
+        "data": {
+            "id": selected,
+            "name": name,
+            "organization_name": organization,
+            "created": created,
+            "referral_program_enabled": referral,
+            "scope_verified": True,
+            "ownership_attested": True,
+        },
+    }
+
+
+def _posts(api_call: Api, request: PageRequest) -> ApiResult | dict[str, Any]:
+    result = api_call(
+        f"/publications/{request.account_id}/posts",
+        {
+            "expand": "free_web_content",
+            "limit": str(request.limit),
+            "page": str(request.page),
+            "status": "confirmed",
+            "order_by": "created",
+            "direction": "asc",
+        },
+    )
+    if result.status != 200:
+        return result
+    root = _object(result.payload, "posts response")
+    reject_credentials(root)
+    items = _objects(root.get("data"), "posts", request.limit)
+    page = _non_negative_int(root.get("page"), "post response page")
+    total_pages = _non_negative_int(root.get("total_pages"), "post total pages")
+    total_results = _non_negative_int(root.get("total_results"), "post total results")
+    response_limit = _non_negative_int(root.get("limit"), "post response limit")
+    if response_limit != request.limit:
+        raise BeehiivProviderError("beehiiv post pagination does not match the request")
+    validate_page_metadata(
+        PageMetadata(page, total_pages, total_results, len(items)),
+        request,
+        exact_items=True,
+    )
+    observed = datetime.now(UTC)
+    records = [
+        record
+        for item in items
+        if (record := normalize_post(item, observed.timestamp()))
+    ]
+    return {
+        "status": 200,
+        "observed_at": observed.isoformat().replace("+00:00", "Z"),
+        "data": records,
+        "meta": {
+            "stream": request.stream,
+            "publication_id": request.account_id,
+            "page": page,
+            "total_pages": total_pages,
+            "total_results": total_results,
+        },
+    }
+
+
+def _dispatch(
+    request: dict[str, Any], config: ProfileConfig, opener: Opener
+) -> dict[str, Any]:
+    if request.get("action") == "identity":
+        if set(request) != {"action", "account_id"}:
+            raise BeehiivProviderError("beehiiv identity request shape is invalid")
+        return _identity(config, opener, publication_id(request.get("account_id")))
+    page_request = parse_page_request(request)
+    identity = _identity(config, opener, page_request.account_id)
+    if identity.get("status") != 200:
+        return identity
+    data = _object(identity.get("data"), "publication verification")
+    if (
+        data.get("id") != page_request.account_id
+        or data.get("scope_verified") is not True
+        or data.get("ownership_attested") is not True
+    ):
+        raise BeehiivProviderError("beehiiv page publication identity is not verified")
+    result = _posts(partial(api, config, opener), page_request)
+    return _terminal(result) if isinstance(result, ApiResult) else result
+
+
+def _request_object(payload: bytes) -> dict[str, Any]:
+    if len(payload) > MAX_REQUEST_BYTES:
+        raise BeehiivProviderError("beehiiv request exceeds the safety limit")
+    try:
+        value = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise BeehiivProviderError("beehiiv request is invalid") from error
+    if not isinstance(value, dict):
+        raise BeehiivProviderError("beehiiv request must be an object")
+    reject_credentials(value)
+    return value
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode()) > MAX_RESPONSE_BYTES:
+        raise BeehiivProviderError("beehiiv response exceeds the safety limit")
+    print(encoded)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    args = parser.parse_args()
+    try:
+        request = _request_object(sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1))
+        _emit(_dispatch(request, _profile(args.profile), http_opener()))
+        return 0
+    except (BeehiivProviderError, BeehiivAdapterError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - intentionally redact provider internals
+        print("ERROR: beehiiv request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_beehiiv_reader.py
+++ b/.agents/scripts/_knowledge_social_beehiiv_reader.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and fixture readers for one beehiiv publication."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+from _knowledge_social_beehiiv import (
+    BeehiivAdapterError,
+    BeehiivProviderUnavailableError,
+    PageRequest,
+    verified_identity,
+)
+from _knowledge_social_fixture import FixturePageReader
+from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
+
+READ_TIMEOUT_SECONDS = 120
+MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+SAFE_FAILURES = (
+    "Python urllib HTTP exports are unavailable",
+    "beehiiv profile name is invalid",
+    "beehiiv profile access token is missing",
+    "beehiiv profile publication ID is missing",
+    "beehiiv profile publication name is missing",
+    "beehiiv profile organization name is missing",
+    "beehiiv profile creator-owned publication ID is missing",
+    "beehiiv profile creator ownership attestation does not match publication",
+    "selected beehiiv publication does not match the configured publication",
+    "beehiiv credential is not bound to exactly one visible publication",
+    "beehiiv publication identity does not match expectations",
+)
+
+
+class Reader(Protocol):
+    def identity(self, expected_id: str) -> dict[str, Any]: ...
+    def page(self, request: PageRequest) -> dict[str, Any]: ...
+
+
+def _decode(output: str) -> dict[str, Any]:
+    if len(output.encode()) > MAX_RESPONSE_BYTES:
+        raise BeehiivAdapterError("beehiiv response exceeds the safety limit")
+    try:
+        value = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise BeehiivAdapterError("beehiiv returned no valid JSON") from error
+    if not isinstance(value, dict):
+        raise BeehiivAdapterError("beehiiv response must be an object")
+    return value
+
+
+def _failure(stderr: str) -> BeehiivProviderUnavailableError:
+    for message in SAFE_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return BeehiivProviderUnavailableError(message)
+    return BeehiivProviderUnavailableError("beehiiv provider is unavailable")
+
+
+POLICY = GuardedOAuthPolicy(
+    "beehiiv",
+    "BEEHIIV",
+    "BEEHIIV_READ_LOG",
+    READ_TIMEOUT_SECONDS,
+    _decode,
+    _failure,
+    BeehiivProviderUnavailableError,
+    (
+        "ACCESS_TOKEN",
+        "PUBLICATION_ID",
+        "PUBLICATION_NAME",
+        "ORGANIZATION_NAME",
+        "CREATOR_OWNED_PUBLICATION_ID",
+    ),
+    "",
+)
+
+
+class GuardedBeehiivReader(GuardedOAuthReader):
+    def __init__(self, helper: Path, profile: str) -> None:
+        super().__init__(helper, profile, POLICY)
+
+
+class FixtureBeehiivReader(FixturePageReader):
+    def __init__(self, path: Path) -> None:
+        super().__init__(path, "beehiiv", BeehiivAdapterError)
+
+
+__all__ = (
+    "FixtureBeehiivReader",
+    "GuardedBeehiivReader",
+    "verified_identity",
+)

--- a/.agents/scripts/_knowledge_social_oauth_collector.py
+++ b/.agents/scripts/_knowledge_social_oauth_collector.py
@@ -103,6 +103,7 @@ class OAuthCollectorPolicy:
     max_page_size: int = 50
     identity_cost_units: int = IDENTITY_COST_UNITS
     max_budget: int = 1000
+    preflight: Callable[[argparse.Namespace], None] | None = None
 
 
 @dataclass
@@ -253,6 +254,8 @@ class OAuthCollector:
         collector_id: str,
     ) -> dict[str, Any]:
         del args
+        if self.policy.preflight is not None:
+            self.policy.preflight(self.args)
         connection_id = validate_opaque(self.args.connection_id, "connection_id")
         account_id = validate_opaque(self.args.account_id, "account_id")
         lease = acquire_run_lease(

--- a/.agents/scripts/knowledge-social-helper.sh
+++ b/.agents/scripts/knowledge-social-helper.sh
@@ -25,6 +25,7 @@ HASHNODE_HELPER="${SCRIPT_DIR}/knowledge_social_hashnode.py"
 MINIFLUX_HELPER="${SCRIPT_DIR}/knowledge_social_miniflux.py"
 FRESHRSS_HELPER="${SCRIPT_DIR}/knowledge_social_freshrss.py"
 READWISE_READER_HELPER="${SCRIPT_DIR}/knowledge_social_readwise_reader.py"
+BEEHIIV_HELPER="${SCRIPT_DIR}/knowledge_social_beehiiv.py"
 QUERY_HELPER="${SCRIPT_DIR}/knowledge_social_query.py"
 SYNC_HELPER="${SCRIPT_DIR}/knowledge_social_sync.py"
 SHARE_HELPER="${SCRIPT_DIR}/knowledge_social_share.py"
@@ -90,6 +91,14 @@ Readwise Reader synchronization:
   token binding before fixed-origin token validation. Seven GET-only streams use
   opaque cursors and one-second updatedAfter overlap. The per-invocation request
   budget is 3-19 to remain below the documented 20/minute limit.
+
+beehiiv synchronization:
+  sync-beehiiv requires a creator-ownership attestation bound to one expected
+  publication ID, name, and organization, plus a credential that exposes exactly
+  that publication. The fixed-origin API v2 route collects confirmed posts and
+  paywall-enforced free web content only.
+  Subscriber PII, segments, engagement stats, premium content, redirects, and
+  every mutation route are excluded. --budget is 3-59 and pages are 1-100 items.
 
 EOF
 	return 0
@@ -309,8 +318,19 @@ EOF
 	return 0
 }
 
+usage_beehiiv_command() {
+	cat <<'EOF'
+  knowledge-social-helper.sh sync-beehiiv [--base PATH] [--alias ALIAS] \
+    --connection-id ID --account-id PUBLICATION_ID --stream posts \
+    --profile PROFILE [--budget 3-59] [--page-size 1-100] \
+    [--collector-id ID] [--lease-seconds SECONDS]
+EOF
+	return 0
+}
+
 usage() {
 	usage_commands
+	usage_beehiiv_command
 	usage_operations
 	cat <<'EOF'
   knowledge-social-helper.sh identity-export [--base PATH] [--vault-dir DIR] --output FILE
@@ -489,6 +509,7 @@ run_named_provider_sync() {
 	sync-miniflux) run_provider_sync Miniflux "$MINIFLUX_HELPER" "$@" || return 1 ;;
 	sync-freshrss) run_provider_sync FreshRSS "$FRESHRSS_HELPER" "$@" || return 1 ;;
 	sync-readwise-reader) run_provider_sync "Readwise Reader" "$READWISE_READER_HELPER" "$@" || return 1 ;;
+	sync-beehiiv) run_provider_sync beehiiv "$BEEHIIV_HELPER" "$@" || return 1 ;;
 	*) return 1 ;;
 	esac
 	return 0
@@ -568,7 +589,7 @@ main() {
 		fi
 		python3 "$LINKEDIN_HELPER" "$@" || return 1
 		;;
-	sync-meta | sync-patreon | sync-discourse | sync-nodebb | sync-mastodon | sync-lemmy | sync-github | sync-stack-exchange | sync-hacker-news | sync-hashnode | sync-miniflux | sync-freshrss | sync-readwise-reader)
+	sync-meta | sync-patreon | sync-discourse | sync-nodebb | sync-mastodon | sync-lemmy | sync-github | sync-stack-exchange | sync-hacker-news | sync-hashnode | sync-miniflux | sync-freshrss | sync-readwise-reader | sync-beehiiv)
 		run_named_provider_sync "$subcommand" "$@" || return 1
 		;;
 	query | annotate)

--- a/.agents/scripts/knowledge_social_beehiiv.py
+++ b/.agents/scripts/knowledge_social_beehiiv.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect one bounded, creator-owned beehiiv publication post stream."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+import _knowledge_social_beehiiv as beehiiv
+from _knowledge_social_beehiiv import PageContext, normalize_page
+from _knowledge_social_beehiiv_reader import (
+    FixtureBeehiivReader,
+    GuardedBeehiivReader,
+    verified_identity,
+)
+from _knowledge_social_oauth_collector import OAuthCollectorPolicy, run_oauth_collector
+from _knowledge_social_oauth_reader import PROFILE_NAME
+
+MAX_REQUEST_BUDGET = 59
+
+
+def _ownership_preflight(args: argparse.Namespace) -> None:
+    """Reject an absent or mismatched local ownership claim before leasing."""
+    if args.fixture is not None:
+        return
+    if PROFILE_NAME.fullmatch(args.profile) is None:
+        raise beehiiv.BeehiivAdapterError("beehiiv profile name is invalid")
+    prefix = f"BEEHIIV_{args.profile.upper()}"
+    configured_value = os.environ.get(f"{prefix}_PUBLICATION_ID", "")
+    ownership_value = os.environ.get(
+        f"{prefix}_CREATOR_OWNED_PUBLICATION_ID", ""
+    )
+    if not configured_value:
+        raise beehiiv.BeehiivAdapterError("beehiiv profile publication ID is missing")
+    if not ownership_value:
+        raise beehiiv.BeehiivAdapterError(
+            "beehiiv profile creator-owned publication ID is missing"
+        )
+    configured = beehiiv.publication_id(configured_value)
+    ownership = beehiiv.publication_id(ownership_value)
+    if configured != beehiiv.publication_id(args.account_id):
+        raise beehiiv.BeehiivAdapterError(
+            "selected beehiiv publication does not match the configured publication"
+        )
+    if ownership != configured:
+        raise beehiiv.BeehiivAdapterError(
+            "beehiiv profile creator ownership attestation does not match publication"
+        )
+
+
+def _policy() -> OAuthCollectorPolicy:
+    return OAuthCollectorPolicy(
+        provider_module=beehiiv,
+        verified_identity=verified_identity,
+        normalize_page=normalize_page,
+        page_context=PageContext,
+        display_name="beehiiv",
+        helper=Path(__file__).with_name("_knowledge_social_beehiiv_provider.py"),
+        fixture_reader=FixtureBeehiivReader,
+        live_reader=GuardedBeehiivReader,
+        budget_unit="request",
+        default_budget=19,
+        max_page_size=100,
+        max_budget=MAX_REQUEST_BUDGET,
+        preflight=_ownership_preflight,
+    )
+
+
+def main() -> int:
+    return run_oauth_collector(_policy(), __doc__ or "")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/knowledge_social_registry.py
+++ b/.agents/scripts/knowledge_social_registry.py
@@ -36,6 +36,7 @@ PROVIDER_SPECS = (
         "knowledge_social_bluesky.py",
         (("live", ()),),
     ),
+    ProviderSpec("beehiiv", (), "knowledge_social_beehiiv.py", (("live", ()),)),
     ProviderSpec("binance-square", (), None, (("no-route", ()),)),
     ProviderSpec("discord", (), "knowledge_social_discord.py", (("live", ()),)),
     ProviderSpec(

--- a/.agents/tests/test-knowledge-social-beehiiv.sh
+++ b/.agents/tests/test-knowledge-social-beehiiv.sh
@@ -1,0 +1,826 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-beehiiv.sh — Publication-scoped beehiiv collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BEEHIIV_SCRIPT="${SCRIPT_DIR}/../scripts/knowledge_social_beehiiv.py"
+SOCIAL_HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TEMP_PARENT="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+mkdir -p "$TEMP_PARENT"
+TMP_DIR=$(mktemp -d "${TEMP_PARENT}/beehiiv-test.XXXXXX")
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+PUBLICATION_ID="pub_fixture_publication"
+OTHER_PUBLICATION_ID="pub_other_publication"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' "$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c 'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' "$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_count() {
+	local connection_id="${1:-}"
+	python3 - "$ROOT/sources/social/raw/beehiiv" "$connection_id" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+connection = sys.argv[2]
+if connection:
+    root = root / connection
+print(len(list(root.rglob("*.json.gz"))) if root.exists() else 0)
+PY
+	return 0
+}
+
+run_fixture() {
+	local fixture="$1"
+	local connection_id="$2"
+	shift 2
+	python3 "$BEEHIIV_SCRIPT" --base "$BASE" --alias personal:default \
+		--connection-id "$connection_id" --account-id "$PUBLICATION_ID" \
+		--stream posts --profile fixture --fixture "$fixture" \
+		--budget 5 --page-size 1 "$@" || return 1
+	return 0
+}
+
+run_live_profile() {
+	local profile="$1"
+	local connection_id="$2"
+	python3 "$BEEHIIV_SCRIPT" --base "$BASE" --alias personal:default \
+		--connection-id "$connection_id" --account-id "$PUBLICATION_ID" \
+		--stream posts --profile "$profile" --budget 3 --page-size 1 || return 1
+	return 0
+}
+
+expect_failure() {
+	local description="$1"
+	local fixture="$2"
+	local connection_id="$3"
+	if run_fixture "$fixture" "$connection_id" >/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$SOCIAL_HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'beehiiv social collector tests\n'
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import ast
+import json
+import os
+import sys
+from pathlib import Path
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+
+from _knowledge_social_beehiiv import (
+    PageRequest,
+    STREAMS,
+    page_checkpoint,
+    page_request,
+)
+from _knowledge_social_beehiiv_http import (
+    HTTP_TIMEOUT_SECONDS,
+    ApiResult,
+    ProfileConfig,
+    _RejectRedirect,
+    allowlisted_path,
+    api,
+    target_url,
+)
+from _knowledge_social_beehiiv_provider import _identity, _posts, _profile
+from _knowledge_social_collect import CursorState
+from knowledge_social_beehiiv import _policy
+
+publication_id = "pub_fixture_publication"
+other_publication_id = "pub_other_publication"
+assert set(STREAMS) == {"posts"}
+assert _policy().max_budget == 59
+assert allowlisted_path("/publications")
+assert allowlisted_path(f"/publications/{publication_id}/posts")
+assert not allowlisted_path(f"/publications/{publication_id}/subscriptions")
+assert not allowlisted_path(f"/publications/{publication_id}/segments")
+assert not allowlisted_path(f"/publications/{publication_id}/posts/post_one")
+assert _RejectRedirect().redirect_request() is None
+
+url = target_url(
+    f"/publications/{publication_id}/posts",
+    {
+        "expand": "free_web_content",
+        "limit": "1",
+        "page": "1",
+        "status": "confirmed",
+        "order_by": "created",
+        "direction": "asc",
+    },
+)
+assert url.startswith("https://api.beehiiv.com/v2/publications/")
+assert "free_web_content" in url and "access" not in url
+for invalid_path in (
+    f"/publications/{publication_id}/subscriptions",
+    f"/publications/{publication_id}/segments",
+    f"/publications/{publication_id}/posts/post_one",
+):
+    try:
+        target_url(invalid_path, {})
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError(f"beehiiv route was reachable: {invalid_path}")
+
+account = {
+    "id": publication_id,
+    "name": "Fixture Publication",
+    "organization_name": "Fixture Organization",
+    "created": 1700000000,
+    "referral_program_enabled": False,
+    "scope_verified": True,
+}
+first = PageRequest("posts", publication_id, 1, 1)
+first_payload = {
+    "status": 200,
+    "observed_at": "2026-08-02T10:00:00Z",
+    "data": [],
+    "meta": {
+        "stream": "posts",
+        "publication_id": publication_id,
+        "page": 1,
+        "total_pages": 2,
+        "total_results": 2,
+    },
+}
+checkpoint, complete = page_checkpoint(first_payload, CursorState(None, None, False), first)
+assert not complete and checkpoint.next_cursor
+resumed = page_request("posts", account, CursorState(checkpoint.next_cursor, None, False), 1)
+assert resumed.page == 2
+try:
+    page_checkpoint(
+        {
+            **first_payload,
+            "meta": {**first_payload["meta"], "publication_id": other_publication_id},
+        },
+        CursorState(None, None, False),
+        first,
+    )
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("cross-publication beehiiv page advanced a checkpoint")
+
+profile_prefix = "BEEHIIV_OWNERSHIP_FIXTURE"
+profile_values = {
+    "ACCESS_TOKEN": "fixture-token",
+    "PUBLICATION_ID": publication_id,
+    "PUBLICATION_NAME": "Fixture Publication",
+    "ORGANIZATION_NAME": "Fixture Organization",
+}
+for suffix, value in profile_values.items():
+    os.environ[f"{profile_prefix}_{suffix}"] = value
+try:
+    _profile("ownership_fixture")
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("beehiiv profile without ownership attestation was accepted")
+os.environ[f"{profile_prefix}_CREATOR_OWNED_PUBLICATION_ID"] = other_publication_id
+try:
+    _profile("ownership_fixture")
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("beehiiv mismatched ownership attestation was accepted")
+os.environ[f"{profile_prefix}_CREATOR_OWNED_PUBLICATION_ID"] = publication_id
+assert _profile("ownership_fixture").creator_owned_publication_id == publication_id
+for suffix in (*profile_values, "CREATOR_OWNED_PUBLICATION_ID"):
+    os.environ.pop(f"{profile_prefix}_{suffix}")
+
+
+class Headers:
+    def __init__(self, values=None):
+        self.values = values or {}
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+
+class Response:
+    def __init__(self, payload, status=200, headers=None):
+        self.payload = payload
+        self.status = status
+        self.headers = Headers(headers)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def read(self, size=-1):
+        return self.payload[:size]
+
+
+class Opener:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    def open(self, request, timeout):
+        assert timeout == HTTP_TIMEOUT_SECONDS and request.method == "GET"
+        assert "fixture-token" not in request.full_url
+        self.requests.append(request)
+        return self.responses.pop(0)
+
+
+config = ProfileConfig(
+    "fixture-token",
+    publication_id,
+    "Fixture Publication",
+    "Fixture Organization",
+    publication_id,
+)
+publication = {
+    "id": publication_id,
+    "name": "Fixture Publication",
+    "organization_name": "Fixture Organization",
+    "created": 1700000000,
+    "referral_program_enabled": False,
+}
+identity_body = json.dumps(
+    {
+        "data": [publication],
+        "limit": 2,
+        "page": 1,
+        "total_results": 1,
+        "total_pages": 1,
+    }
+).encode()
+identity = _identity(config, Opener([Response(identity_body)]), publication_id)
+assert identity["data"]["id"] == publication_id
+assert identity["data"]["scope_verified"] is True
+assert identity["data"]["ownership_attested"] is True
+
+unowned_config = ProfileConfig(
+    "fixture-token",
+    publication_id,
+    "Fixture Publication",
+    "Fixture Organization",
+    other_publication_id,
+)
+try:
+    _identity(unowned_config, Opener([]), publication_id)
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("beehiiv unowned publication configuration was accepted")
+
+wide_scope = json.dumps(
+    {
+        "data": [publication, {**publication, "id": other_publication_id}],
+        "limit": 2,
+        "page": 1,
+        "total_results": 2,
+        "total_pages": 1,
+    }
+).encode()
+try:
+    _identity(config, Opener([Response(wide_scope)]), publication_id)
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("workspace-wide beehiiv credential passed publication scoping")
+
+raw_post = {
+    "id": "post_fixture_one",
+    "title": "Bounded beehiiv knowledge",
+    "subtitle": "Fixture subtitle",
+    "authors": ["Fixture Author"],
+    "created": 1700000000,
+    "status": "confirmed",
+    "publish_date": 1700000100,
+    "displayed_date": 1700000100,
+    "subject_line": "Fixture subject",
+    "preview_text": "Fixture preview",
+    "slug": "fixture-post",
+    "web_url": "https://example.invalid/p/fixture-post",
+    "audience": "free",
+    "platform": "web",
+    "content_tags": ["knowledge"],
+    "hidden_from_feed": False,
+    "enforce_gated_content": False,
+    "content": {"free": {"web": "<p>Fixture body</p>"}},
+}
+post_page = _posts(
+    lambda path, params: ApiResult(
+        200,
+        {
+            "data": [raw_post],
+            "limit": 1,
+            "page": 1,
+            "total_results": 1,
+            "total_pages": 1,
+        },
+    ),
+    first,
+)
+assert post_page["data"][0]["remote_id"] == "post_fixture_one"
+assert post_page["data"][0]["free_web_content"] == "<p>Fixture body</p>"
+assert "stats" not in post_page["data"][0]
+
+for contradiction in (
+    {"limit": 2},
+    {"total_pages": 2},
+    {"data": []},
+):
+    payload = {
+        "data": [raw_post],
+        "limit": 1,
+        "page": 1,
+        "total_results": 1,
+        "total_pages": 1,
+        **contradiction,
+    }
+    try:
+        _posts(lambda path, params, value=payload: ApiResult(200, value), first)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("contradictory beehiiv pagination metadata was accepted")
+
+scheduled = {**raw_post, "id": "post_future", "publish_date": 4102444800}
+scheduled_page = _posts(
+    lambda path, params: ApiResult(
+        200,
+        {
+            "data": [scheduled],
+            "limit": 1,
+            "page": 1,
+            "total_results": 1,
+            "total_pages": 1,
+        },
+    ),
+    first,
+)
+assert scheduled_page["data"] == []
+
+opener = Opener([Response(identity_body)])
+assert api(config, opener, "/publications", {"limit": "2", "page": "1"}).status == 200
+rate = Opener([Response(b"", status=429, headers={"RateLimit-Reset": "2000000000"})])
+limited = api(config, rate, "/publications", {"limit": "2", "page": "1"})
+assert limited.status == 429 and limited.retry_after == 2000000000
+
+provider_sources = [
+    (scripts / "_knowledge_social_beehiiv_http.py").read_text(encoding="utf-8"),
+    (scripts / "_knowledge_social_beehiiv_provider.py").read_text(encoding="utf-8"),
+]
+assert all("/subscriptions" not in source and "/segments" not in source for source in provider_sources)
+trees = [ast.parse(source) for source in provider_sources]
+calls = [
+    node
+    for tree in trees
+    for node in ast.walk(tree)
+    if isinstance(node, ast.Call)
+    and isinstance(node.func, ast.Name)
+    and node.func.id == "Request"
+]
+assert calls
+for node in calls:
+    methods = [
+        keyword.value.value
+        for keyword in node.keywords
+        if keyword.arg == "method" and isinstance(keyword.value, ast.Constant)
+    ]
+    assert methods == ["GET"]
+PY
+assert_eq "identity, scope, pagination, quota, redirects, and GET routes are guarded" verified verified
+
+help_output=$("$SOCIAL_HELPER" help 2>&1)
+if [[ "$help_output" == *"sync-beehiiv"* && "$help_output" == *"PUBLICATION_ID"* ]]; then
+	assert_eq "provider-neutral helper exposes the bounded beehiiv route" exposed exposed
+else
+	assert_eq "provider-neutral helper exposes the bounded beehiiv route" missing exposed
+fi
+
+if BEEHIIV_PREFLIGHT_MISSING_PUBLICATION_ID="$PUBLICATION_ID" \
+	run_live_profile preflight_missing conn_preflight_missing >/dev/null 2>&1; then
+	assert_eq "missing ownership fails before the live reader" accepted rejected
+else
+	assert_eq "missing ownership fails before the live reader" rejected rejected
+fi
+if BEEHIIV_PREFLIGHT_MISMATCH_PUBLICATION_ID="$PUBLICATION_ID" \
+	BEEHIIV_PREFLIGHT_MISMATCH_CREATOR_OWNED_PUBLICATION_ID="$OTHER_PUBLICATION_ID" \
+	run_live_profile preflight_mismatch conn_preflight_mismatch >/dev/null 2>&1; then
+	assert_eq "mismatched ownership fails before the live reader" accepted rejected
+else
+	assert_eq "mismatched ownership fails before the live reader" rejected rejected
+fi
+assert_eq "ownership preflight leaves durable run state untouched" \
+	"$(sql_value "SELECT (SELECT count(*) FROM collector_lease_generations WHERE connection_id LIKE 'conn_preflight_%') + (SELECT count(*) FROM collector_leases WHERE connection_id LIKE 'conn_preflight_%') + (SELECT count(*) FROM sync_runs WHERE connection_id LIKE 'conn_preflight_%')")" 0
+assert_eq "ownership preflight writes no raw evidence" "$(raw_count)" 0
+
+python3 - "$TMP_DIR" "$PUBLICATION_ID" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+target = Path(sys.argv[1])
+publication_id = sys.argv[2]
+identity = {
+    "data": {
+        "id": publication_id,
+        "name": "Fixture Publication",
+        "organization_name": "Fixture Organization",
+        "created": 1700000000,
+        "referral_program_enabled": False,
+        "scope_verified": True,
+        "ownership_attested": True,
+    }
+}
+
+
+def record(post_id, title, body, published):
+    return {
+        "kind": "post",
+        "remote_id": post_id,
+        "title": title,
+        "subtitle": "Fixture subtitle",
+        "authors": ["Fixture Author"],
+        "created_at": published,
+        "status": "confirmed",
+        "publish_date": published,
+        "displayed_date": published,
+        "subject_line": "Fixture subject",
+        "preview_text": "Fixture preview",
+        "slug": post_id,
+        "web_url": f"https://example.invalid/p/{post_id}",
+        "audience": "free",
+        "platform": "web",
+        "content_tags": ["knowledge"],
+        "meta_default_description": None,
+        "meta_default_title": None,
+        "hidden_from_feed": False,
+        "enforce_gated_content": False,
+        "free_web_content": body,
+    }
+
+
+def page(number, total, item, observed):
+    return {
+        "expect_request": {"page": number, "limit": 1},
+        "response": {
+            "status": 200,
+            "observed_at": observed,
+            "data": [item],
+            "meta": {
+                "stream": "posts",
+                "publication_id": publication_id,
+                "page": number,
+                "total_pages": total,
+                "total_results": total,
+            },
+        },
+    }
+
+
+complete = {
+    "identity": identity,
+    "pages": [
+        page(
+            1,
+            2,
+            record(
+                "post_fixture_one",
+                "Bounded beehiiv knowledge",
+                "<p>First fixture body</p>",
+                "2026-08-02T09:00:00Z",
+            ),
+            "2026-08-02T10:00:00Z",
+        ),
+        page(
+            2,
+            2,
+            record(
+                "post_fixture_two",
+                "Second publication post",
+                "<p>Second fixture body</p>",
+                "2026-08-02T09:30:00Z",
+            ),
+            "2026-08-02T10:01:00Z",
+        ),
+    ],
+}
+(target / "complete.json").write_text(json.dumps(complete), encoding="utf-8")
+
+mismatch = {
+    "identity": {
+        "data": {
+            **identity["data"],
+            "id": "pub_other_publication",
+        }
+    },
+    "pages": [],
+}
+(target / "mismatch.json").write_text(json.dumps(mismatch), encoding="utf-8")
+
+unowned = {
+    "identity": {
+        "data": {
+            **identity["data"],
+            "ownership_attested": False,
+        }
+    },
+    "pages": [],
+}
+(target / "unowned.json").write_text(json.dumps(unowned), encoding="utf-8")
+
+cross = {
+    "identity": identity,
+    "pages": [
+        {
+            **complete["pages"][0],
+            "response": {
+                **complete["pages"][0]["response"],
+                "meta": {
+                    **complete["pages"][0]["response"]["meta"],
+                    "publication_id": "pub_other_publication",
+                },
+            },
+        }
+    ],
+}
+(target / "cross.json").write_text(json.dumps(cross), encoding="utf-8")
+
+credential = {
+    "identity": identity,
+    "pages": [
+        {
+            **complete["pages"][0],
+            "response": {
+                **complete["pages"][0]["response"],
+                "access_token": "fixture-must-not-persist",
+            },
+        }
+    ],
+}
+(target / "credential.json").write_text(json.dumps(credential), encoding="utf-8")
+
+malformed = {
+    "identity": identity,
+    "pages": [
+        {
+            **complete["pages"][0],
+            "response": {
+                **complete["pages"][0]["response"],
+                "meta": {
+                    key: value
+                    for key, value in complete["pages"][0]["response"]["meta"].items()
+                    if key != "total_results"
+                },
+            },
+        }
+    ],
+}
+(target / "malformed.json").write_text(json.dumps(malformed), encoding="utf-8")
+
+contradictory = {
+    "identity": identity,
+    "pages": [
+        {
+            **complete["pages"][0],
+            "response": {
+                **complete["pages"][0]["response"],
+                "meta": {
+                    **complete["pages"][0]["response"]["meta"],
+                    "total_results": 1,
+                },
+            },
+        }
+    ],
+}
+(target / "contradictory.json").write_text(
+    json.dumps(contradictory), encoding="utf-8"
+)
+
+terminal = {
+    "identity": {"status": 403, "observed_at": "2026-08-02T10:02:00Z"},
+    "pages": [],
+}
+(target / "terminal.json").write_text(json.dumps(terminal), encoding="utf-8")
+PY
+
+if run_fixture "$TMP_DIR/complete.json" conn_budget_equals --budget=60 >/dev/null 2>&1; then
+	assert_eq "equals-form budget above the provider fuse is rejected" accepted rejected
+else
+	assert_eq "equals-form budget above the provider fuse is rejected" rejected rejected
+fi
+if run_fixture "$TMP_DIR/complete.json" conn_budget_duplicate --budget 60 >/dev/null 2>&1; then
+	assert_eq "duplicate budget cannot bypass the provider fuse" accepted rejected
+else
+	assert_eq "duplicate budget cannot bypass the provider fuse" rejected rejected
+fi
+
+result=$(run_fixture "$TMP_DIR/complete.json" conn_beehiiv)
+assert_eq "bounded two-page beehiiv fixture completes" "$(json_field "$result" status)" complete
+assert_eq "identity plus two pages consumes five requests" "$(json_field "$result" budget_units)" 5
+assert_eq "publication identity persists before post projections" \
+	"$(sql_value "SELECT remote_id || ':' || display_name FROM accounts WHERE provider='beehiiv'")" \
+	"${PUBLICATION_ID}:Fixture Publication"
+assert_eq "confirmed free post content reaches FTS" \
+	"$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'bounded'")" 1
+assert_eq "subscriber, segment, export, stats, premium, and deletion gaps stay explicit" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE connection_id='conn_beehiiv' AND status='unavailable'")" 8
+assert_eq "successful page exhaustion advances only the selected stream" \
+	"$(sql_value "SELECT coalesce(cursor, 'none') || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_beehiiv' AND stream='posts'")" \
+	"none:1"
+
+batch_count=$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_beehiiv'")
+raw_before=$(raw_count conn_beehiiv)
+object_count=$(sql_value "SELECT count(*) FROM objects WHERE provider='beehiiv'")
+run_fixture "$TMP_DIR/complete.json" conn_beehiiv >/dev/null
+assert_eq "exact beehiiv replay is content-addressed" \
+	"$(sql_value "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_beehiiv'"):$(raw_count conn_beehiiv):$(sql_value "SELECT count(*) FROM objects WHERE provider='beehiiv'")" \
+	"${batch_count}:${raw_before}:${object_count}"
+
+raw_all_before=$(raw_count)
+expect_failure "wrong publication identity is rejected before persistence" \
+	"$TMP_DIR/mismatch.json" conn_mismatch
+assert_eq "identity mismatch writes no raw evidence" "$(raw_count)" "$raw_all_before"
+
+expect_failure "missing creator-ownership attestation is rejected before persistence" \
+	"$TMP_DIR/unowned.json" conn_unowned
+assert_eq "ownership rejection advances no checkpoint" \
+	"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_unowned'")" 0
+assert_eq "ownership rejection writes no raw evidence" "$(raw_count)" "$raw_all_before"
+
+expect_failure "cross-publication page provenance is rejected" \
+	"$TMP_DIR/cross.json" conn_cross
+assert_eq "cross-publication rejection writes no raw evidence" "$(raw_count)" "$raw_all_before"
+
+expect_failure "credential-shaped beehiiv payload is rejected" \
+	"$TMP_DIR/credential.json" conn_credential
+assert_eq "credential rejection writes no raw evidence" "$(raw_count)" "$raw_all_before"
+
+cursor_before=$(sql_value "SELECT coalesce(cursor, 'none') || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_beehiiv' AND stream='posts'")
+expect_failure "malformed beehiiv page fails closed" \
+	"$TMP_DIR/malformed.json" conn_beehiiv
+assert_eq "malformed page preserves the prior checkpoint" \
+	"$(sql_value "SELECT coalesce(cursor, 'none') || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_beehiiv' AND stream='posts'")" \
+	"$cursor_before"
+assert_eq "malformed page writes no new raw evidence" "$(raw_count conn_beehiiv)" "$raw_before"
+
+expect_failure "contradictory beehiiv pagination fails closed" \
+	"$TMP_DIR/contradictory.json" conn_beehiiv
+assert_eq "contradictory pagination preserves the prior checkpoint" \
+	"$(sql_value "SELECT coalesce(cursor, 'none') || ':' || backfill_complete FROM sync_cursors WHERE connection_id='conn_beehiiv' AND stream='posts'")" \
+	"$cursor_before"
+assert_eq "contradictory pagination writes no new raw evidence" \
+	"$(raw_count conn_beehiiv)" "$raw_before"
+
+terminal=$(run_fixture "$TMP_DIR/terminal.json" conn_plan_gate)
+assert_eq "plan or authorization gate is terminal" \
+	"$(json_field "$terminal" status):$(json_field "$terminal" failure_class)" \
+	"failed:authorization"
+assert_eq "terminal authorization response advances no checkpoint" \
+	"$(sql_value "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_plan_gate'")" 0
+
+python3 - "$ROOT" "$SCRIPT_DIR/../scripts" <<'PY'
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[2])
+from _knowledge_social_beehiiv import STREAMS
+from _knowledge_social_collect import (
+    CollectionContext,
+    ConnectionConfig,
+    CursorState,
+    PageCheckpoint,
+    SuccessfulPage,
+)
+from _knowledge_social_collect_persist import persist_page
+from _knowledge_social_lease import (
+    RunLeaseRequest,
+    SocialLeaseLostError,
+    acquire_run_lease,
+    release_run_lease,
+)
+
+root = Path(sys.argv[1])
+old = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_beehiiv_fence", "posts", "old_runner", "sync", 1),
+    now_epoch=9000,
+)
+new = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_beehiiv_fence", "posts", "new_runner", "sync", 10),
+    now_epoch=9001,
+)
+publication_id = "pub_fixture_publication"
+context = CollectionContext(
+    root,
+    "conn_beehiiv_fence",
+    {"id": publication_id},
+    "posts",
+    "none",
+    ConnectionConfig(("posts",), {"media_hydration": "none"}),
+    CursorState(None, None, False),
+    STREAMS["posts"],
+    old,
+    "beehiiv",
+)
+archive = {
+    "provider": "beehiiv",
+    "connection_id": "conn_beehiiv_fence",
+    "remote_account_id": publication_id,
+    "exported_at": "2026-08-02T10:03:00Z",
+    "enabled_streams": ["posts"],
+    "policy": {"media_hydration": "none"},
+    "accounts": [],
+    "objects": [],
+    "activities": [],
+    "media": [],
+    "coverage": [],
+}
+successful = SuccessfulPage(
+    {"status": 200, "observed_at": archive["exported_at"], "data": [], "meta": {}},
+    '{"stream":"posts"}',
+    archive,
+    PageCheckpoint(None, None),
+    True,
+    2,
+)
+os.environ["AIDEVOPS_SOCIAL_NOW_EPOCH"] = "9001"
+try:
+    persist_page(context, successful)
+except SocialLeaseLostError:
+    pass
+else:
+    raise SystemExit("stale beehiiv collector advanced persistence")
+with sqlite3.connect(root / "index" / "social.db") as database:
+    cursor_count = database.execute(
+        "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_beehiiv_fence'"
+    ).fetchone()[0]
+    batch_count = database.execute(
+        "SELECT count(*) FROM fetch_batches WHERE connection_id='conn_beehiiv_fence'"
+    ).fetchone()[0]
+assert cursor_count == 0 and batch_count == 0
+release_run_lease(root, new)
+PY
+assert_eq "stale beehiiv lease cannot commit evidence or a cursor" verified verified
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/tests/test-knowledge-social-registry.sh
+++ b/.agents/tests/test-knowledge-social-registry.sh
@@ -39,6 +39,7 @@ sys.modules[spec.name] = module
 spec.loader.exec_module(module)
 
 expected = {
+    "beehiiv": ("live",),
     "bluesky": ("live",),
     "binance-square": ("no-route",),
     "discord": ("live",),
@@ -103,14 +104,14 @@ except module.ProviderRegistryError:
 else:
     raise SystemExit("unknown provider used a fallback")
 
-print("21:order-independent:aliases-exact:collisions-rejected:no-fallback")
+print("22:order-independent:aliases-exact:collisions-rejected:no-fallback")
 PY
 )
 assert_eq "all merged provider outcomes register deterministically" \
-	"$registry_summary" "21:order-independent:aliases-exact:collisions-rejected:no-fallback"
+	"$registry_summary" "22:order-independent:aliases-exact:collisions-rejected:no-fallback"
 
 provider_count=$("$HELPER" providers | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
-assert_eq "helper exposes the complete provider registry" "$provider_count" "21"
+assert_eq "helper exposes the complete provider registry" "$provider_count" "22"
 
 forem_resolution=$("$HELPER" provider-resolve --provider dev-community |
 	python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["provider"] + ":" + ",".join(data["modes"]))')
@@ -149,6 +150,13 @@ if [[ "$freshrss_sync_help" == *"Collect one bounded FreshRSS account stream"* ]
 	assert_eq "FreshRSS helper executes the same guarded local adapter" canonical canonical
 else
 	assert_eq "FreshRSS helper executes the same guarded local adapter" unexpected canonical
+fi
+
+beehiiv_help=$("$HELPER" provider-run --provider beehiiv --mode live -- --help 2>&1)
+if [[ "$beehiiv_help" == *"Collect one bounded, creator-owned beehiiv publication post stream"* ]]; then
+	assert_eq "beehiiv registry executes only the guarded local adapter" canonical canonical
+else
+	assert_eq "beehiiv registry executes only the guarded local adapter" unexpected canonical
 fi
 
 patreon_help=$("$HELPER" provider-run --provider patreon --mode live -- --help 2>&1)


### PR DESCRIPTION
## Summary

- Adds a bounded, publication-scoped beehiiv API v2 collector for creator-owned publication posts.
- Runs local ownership preflight before lease acquisition, then validates response ownership and pagination before normalization or checkpoint advancement.
- Uses fixed-origin, redirect-free, GET-only transport, conservative request quotas, replay-safe persistence, registry/helper wiring, documentation, and fixtures.
- Excludes subscriber PII, segments, engagement statistics, premium expansion, exports, remote media, dashboard automation, and all mutations.

## Files Changed

- Collector and shared orchestration: `.agents/scripts/knowledge_social_beehiiv.py`, `.agents/scripts/_knowledge_social_beehiiv*.py`, `.agents/scripts/_knowledge_social_oauth_collector.py`.
- Registry and CLI wiring: `.agents/scripts/knowledge_social_registry.py`, `.agents/scripts/knowledge-social-helper.sh`.
- Documentation and policy: `.agents/content/social-beehiiv.md`, `.agents/aidevops/knowledge-plane/05-social-operations.md`, `.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md`, `.agents/configs/allowed-urls.txt`.
- Verification: `.agents/tests/test-knowledge-social-beehiiv.sh`, `.agents/tests/test-knowledge-social-registry.sh`.

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — beehiiv 33/33, registry 15/15, social sync 35/35, corpus 45/45; isolated Qlty regression 43 → 43; six new source files with zero smells; changed-file linters and pre-push validation passed.

## Key Decisions

- `BEEHIIV_<PROFILE>_CREATOR_OWNED_PUBLICATION_ID` is an explicit local operator attestation, not API or legal proof of ownership.
- Ownership, malformed-page, authorization, quota, and stale-lease failures leave checkpoints and raw evidence unchanged.
- Publications/posts remain documented as Gate/Live and Gate/Live/Partial rather than overstating coverage.

Resolves #29319
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.219 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h 17m and 948,771 tokens on this as a headless worker.