### PR TITLE
GH#29215: remove Forem collector Qlty duplication

### DIFF
--- a/.agents/scripts/knowledge_social_forem.py
+++ b/.agents/scripts/knowledge_social_forem.py
@@ -12,22 +12,24 @@ from _knowledge_social_forem_normalize import PageContext, normalize_page
 from _knowledge_social_forem_reader import FixtureForem, GuardedForem, verified_identity
 from _knowledge_social_oauth_collector import OAuthCollectorPolicy, run_oauth_collector
 
-COLLECTOR_OPTIONS = {
-    "display_name": "Forem",
-    "provider_module": forem,
-    "helper": Path(__file__).with_name("_knowledge_social_forem_provider.py"),
-    "fixture_reader": FixtureForem,
-    "live_reader": GuardedForem,
-    "page_context": PageContext,
-    "normalize_page": normalize_page,
-    "verified_identity": verified_identity,
-    "budget_unit": "request",
-    "max_page_size": 100,
-}
+
+def _collector_policy() -> OAuthCollectorPolicy:
+    return OAuthCollectorPolicy(
+        display_name="Forem",
+        provider_module=forem,
+        helper=Path(__file__).with_name("_knowledge_social_forem_provider.py"),
+        fixture_reader=FixtureForem,
+        live_reader=GuardedForem,
+        page_context=PageContext,
+        normalize_page=normalize_page,
+        verified_identity=verified_identity,
+        budget_unit="request",
+        max_page_size=100,
+    )
 
 
 def main() -> int:
-    return run_oauth_collector(OAuthCollectorPolicy(**COLLECTOR_OPTIONS), __doc__ or "")
+    return run_oauth_collector(_collector_policy(), __doc__ or "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Replace the duplicated Forem collector options module shape with a typed policy factory while preserving all provider callbacks and limits.

## Files Changed

.agents/scripts/knowledge_social_forem.py

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Qlty reports zero Forem-related smells; qlty check passes; Python compilation passes; Forem collector suite passes 31/31; changed-file local linters pass.

Resolves #29215


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.218 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 10m and 82,769 tokens on this with the user in an interactive session.