### PR TITLE
GH#29428: Verify extensionless issue paths

### DIFF
--- a/.agents/scripts/tests/test-verify-issue-close-helper-pr-files.sh
+++ b/.agents/scripts/tests/test-verify-issue-close-helper-pr-files.sh
@@ -42,6 +42,9 @@ if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
 	203 | 204)
 		printf '## Implementation target\nUpdate the extensionless repository path `.agents/scripts/gh`.\n'
 		;;
+	205)
+		printf '## Implementation target\nUpdate `.agents/scripts/target.sh`; evidence is at `https://example.com/unrelated/gh`.\n'
+		;;
 	*)
 		exit 1
 		;;
@@ -67,6 +70,9 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
 		printf '{"files":[{"path":".agents/scripts/gh"}]}\n'
 		;;
 	105)
+		printf '{"files":[{"path":"unrelated/gh"}]}\n'
+		;;
+	106)
 		printf '{"files":[{"path":"unrelated/gh"}]}\n'
 		;;
 	*)
@@ -140,6 +146,7 @@ assert_check_passes "independent general target survives a supporting specific p
 assert_check_rejects "specific target cannot be satisfied by an unrelated same-basename file" 202 103
 assert_check_passes "extensionless repository path matches the exact PR file" 104 203
 assert_check_rejects "extensionless repository path rejects an unrelated same-basename file" 204 105
+assert_check_rejects "backtick URL cannot supply an extensionless repository path" 205 106
 
 printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
 if [[ "$FAIL" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-verify-issue-close-helper-pr-files.sh
+++ b/.agents/scripts/tests/test-verify-issue-close-helper-pr-files.sh
@@ -39,6 +39,9 @@ if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
 	202)
 		printf '## Implementation target\nUpdate `.agents/scripts/setup/modules/config.sh`; the `config.sh` implementation is defective.\n'
 		;;
+	203 | 204)
+		printf '## Implementation target\nUpdate the extensionless repository path `.agents/scripts/gh`.\n'
+		;;
 	*)
 		exit 1
 		;;
@@ -59,6 +62,12 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
 		;;
 	103)
 		printf '{"files":[{"path":"unrelated/config.sh"}]}\n'
+		;;
+	104)
+		printf '{"files":[{"path":".agents/scripts/gh"}]}\n'
+		;;
+	105)
+		printf '{"files":[{"path":"unrelated/gh"}]}\n'
 		;;
 	*)
 		printf '{"files":[]}\n'
@@ -129,6 +138,8 @@ assert_check_passes "merged PR files null falls back to REST pull files endpoint
 assert_check_passes "standard gh pr view files array still parses" 101
 assert_check_passes "independent general target survives a supporting specific path" 102 201
 assert_check_rejects "specific target cannot be satisfied by an unrelated same-basename file" 202 103
+assert_check_passes "extensionless repository path matches the exact PR file" 104 203
+assert_check_rejects "extensionless repository path rejects an unrelated same-basename file" 204 105
 
 printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
 if [[ "$FAIL" -gt 0 ]]; then

--- a/.agents/scripts/verify-issue-close-helper.sh
+++ b/.agents/scripts/verify-issue-close-helper.sh
@@ -74,11 +74,11 @@ extract_file_paths_from_text() {
 	fi
 
 	# Pattern 2: Backtick-enclosed repository paths, including extensionless
-	# executables such as `.agents/scripts/gh`. Requiring a slash and restricting
-	# the first segment avoids treating URL hosts as repository paths.
+	# executables such as `.agents/scripts/gh`. Inspect whole backtick tokens so a
+	# URL cannot yield a path-like substring after its hostname.
 	local backtick_paths
 	# shellcheck disable=SC2016 # Literal backtick regex, not shell expansion.
-	backtick_paths=$(printf '%s' "$text" | grep -oE '`(\.[a-zA-Z0-9_-]+|[a-zA-Z0-9_-]+)/[a-zA-Z0-9._/-]+(:[0-9]+(-[0-9]+)?)?`' | tr -d '`' | sed 's/:[0-9]*\(-[0-9]*\)\{0,1\}$//' | sort -u || true)
+	backtick_paths=$(printf '%s' "$text" | grep -oE '`[a-zA-Z0-9._:/-]+`' | tr -d '`' | grep '/' | grep -v '://' | sed 's/:[0-9]*\(-[0-9]*\)\{0,1\}$//' | grep -E '^(\.[a-zA-Z0-9_-]+|[a-zA-Z0-9_-]+)/[a-zA-Z0-9._/-]*[a-zA-Z0-9._-]$' | sort -u || true)
 	if [[ -n "$backtick_paths" ]]; then
 		paths="${paths}${backtick_paths}"$'\n'
 	fi

--- a/.agents/scripts/verify-issue-close-helper.sh
+++ b/.agents/scripts/verify-issue-close-helper.sh
@@ -73,7 +73,18 @@ extract_file_paths_from_text() {
 		paths="${paths}${dir_paths}"$'\n'
 	fi
 
-	# Pattern 2: Backtick-enclosed file references (e.g., `schedulers.sh`, `pulse-wrapper.sh:6098`)
+	# Pattern 2: Backtick-enclosed repository paths, including extensionless
+	# executables such as `.agents/scripts/gh`. Requiring a slash and restricting
+	# the first segment avoids treating URL hosts as repository paths.
+	local backtick_paths
+	# shellcheck disable=SC2016 # Literal backtick regex, not shell expansion.
+	backtick_paths=$(printf '%s' "$text" | grep -oE '`(\.[a-zA-Z0-9_-]+|[a-zA-Z0-9_-]+)/[a-zA-Z0-9._/-]+(:[0-9]+(-[0-9]+)?)?`' | tr -d '`' | sed 's/:[0-9]*\(-[0-9]*\)\{0,1\}$//' | sort -u || true)
+	if [[ -n "$backtick_paths" ]]; then
+		paths="${paths}${backtick_paths}"$'\n'
+	fi
+
+	# Pattern 3: Backtick-enclosed file references without directory separators
+	# (e.g., `schedulers.sh`, `pulse-wrapper.sh:6098`).
 	local backtick_files
 	# shellcheck disable=SC2016 # Literal backtick regex, not shell expansion.
 	backtick_files=$(printf '%s' "$text" | grep -oE '`[a-zA-Z0-9._/-]+\.(sh|ts|js|py|md|json|yaml|yml|toml|go|rs|tsx|jsx|css|html|sql|rb|php|java|c|h|cpp|hpp)(:[0-9]+(-[0-9]+)?)?`' | tr -d '`' | sed 's/:[0-9]*\(-[0-9]*\)\{0,1\}$//' | sort -u || true)
@@ -81,7 +92,7 @@ extract_file_paths_from_text() {
 		paths="${paths}${backtick_files}"$'\n'
 	fi
 
-	# Pattern 3: Bare filenames with common extensions mentioned outside backticks
+	# Pattern 4: Bare filenames with common extensions mentioned outside backticks
 	# More conservative — requires word boundaries
 	local bare_files
 	bare_files=$(printf '%s' "$text" | grep -oE '\b[a-zA-Z0-9_-]+\.(sh|ts|js|py|json|yaml|yml|toml|go|rs)\b' | sort -u || true)


### PR DESCRIPTION
## Summary

Recognize backtick-enclosed extensionless repository paths without accepting URL-derived or unrelated same-basename matches.

## Files Changed

.agents/scripts/tests/test-verify-issue-close-helper-pr-files.sh, .agents/scripts/verify-issue-close-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 7 focused overlap tests pass; live #29049/#29136 verification passes; ShellCheck and linters-local.sh --changed pass.

Resolves #29428


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.218 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 13m and 195,639 tokens on this with the user in an interactive session.