### PR TITLE
GH#29393: Revalidate recovered complexity stalls

### DIFF
--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -38,6 +38,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/shared-constants.sh"
 
+: "${REPOS_JSON:=${HOME}/.config/aidevops/repos.json}"
+
+if [[ -f "${SCRIPT_DIR}/shared-gh-collaborator-permission.sh" ]]; then
+	# shellcheck source=./shared-gh-collaborator-permission.sh
+	source "${SCRIPT_DIR}/shared-gh-collaborator-permission.sh"
+fi
+
 if [[ -f "${SCRIPT_DIR}/pulse-repo-meta.sh" ]]; then
 	# shellcheck source=./pulse-repo-meta.sh
 	source "${SCRIPT_DIR}/pulse-repo-meta.sh"
@@ -125,6 +132,7 @@ _register_validators() {
 	_VALIDATOR_REGISTRY["large-file-simplification-gate"]="_validator_large_file_simplification_gate"
 	_VALIDATOR_REGISTRY["agent-doc-simplification-gate"]="_validator_agent_doc_simplification_gate"
 	_VALIDATOR_REGISTRY["function-complexity-gate"]="_validator_function_complexity_gate"
+	_VALIDATOR_REGISTRY["complexity-stall-sweep"]="_validator_complexity_stall_sweep"
 	_VALIDATOR_REGISTRY["upstream-watch"]="_validator_upstream_watch"
 	_VALIDATOR_REGISTRY["runtime-audit"]="_validator_runtime_audit"
 	return 0
@@ -191,6 +199,60 @@ Closing this stale zero-progress meta-issue in the pre-dispatch validator so aut
 		_log "WARN" "#${issue_number}: failed to close recovered zero-progress meta-issue"
 	_log "INFO" "#${issue_number}: zero-progress meta premise recovered — issue closed, dispatch blocked"
 	return 10
+}
+
+# Re-check a simplification-debt stall immediately before worker dispatch. A
+# closure inside the original stall window proves throughput resumed, making
+# the diagnostic meta-issue stale. API ambiguity fails open to preserve work.
+_validator_complexity_stall_sweep() {
+	local slug="$1"
+	local stall_hours="${STALL_WINDOW_HOURS:-6}"
+	local now_epoch=""
+	local since_epoch=""
+	local since_date=""
+	local recent_closures=""
+
+	if [[ ! "$stall_hours" =~ ^[1-9][0-9]*$ ]]; then
+		_log "WARN" "complexity-stall-sweep validator: invalid stall_hours=${stall_hours}"
+		return 20
+	fi
+
+	now_epoch=$(date +%s) || return 20
+	since_epoch=$((now_epoch - stall_hours * 3600))
+	since_date=$(date -u -d "@${since_epoch}" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null) ||
+		since_date=$(date -u -r "$since_epoch" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null) ||
+		since_date=""
+	if [[ -z "$since_date" ]]; then
+		_log "WARN" "complexity-stall-sweep validator: unable to calculate closure window"
+		return 20
+	fi
+
+	recent_closures=$(gh api graphql \
+		-f query="query { search(query:\"repo:${slug} label:function-complexity-debt is:issue is:closed closed:>${since_date}\", type:ISSUE) { issueCount } }" \
+		--jq '.data.search.issueCount' 2>/dev/null) || {
+		_log "WARN" "complexity-stall-sweep validator: recent-closure lookup failed"
+		return 20
+	}
+	if [[ ! "$recent_closures" =~ ^[0-9]+$ ]]; then
+		_log "WARN" "complexity-stall-sweep validator: malformed closure count"
+		return 20
+	fi
+
+	if [[ "$recent_closures" -gt 0 ]]; then
+		# #aidevops:trust-boundary — this validator can trigger a comment and
+		# issue close. Confirm live write authority before returning falsified.
+		if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 ||
+			! repo_allows_pulse_write_actions "$slug"; then
+			_log "WARN" "complexity-stall-sweep validator: recovery detected but runner lacks repo write permission"
+			return 20
+		fi
+		VALIDATOR_RATIONALE="Throughput resumed: ${recent_closures} function-complexity-debt issue(s) closed in the last ${stall_hours}h. The stall premise recovered before dispatch."
+		_log "INFO" "complexity-stall-sweep validator: ${recent_closures} recent closure(s) — premise falsified"
+		return 10
+	fi
+
+	_log "INFO" "complexity-stall-sweep validator: zero recent closures — premise holds"
+	return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -1638,11 +1700,12 @@ cmd_validate() {
 		return 0
 	fi
 
-	# Extract optional attributes: cited_file, threshold, upstream_slug, detector
+	# Extract optional attributes: cited_file, threshold, upstream_slug, detector, stall_hours
 	CITED_FILE=$(printf '%s' "$generator_line" | grep -oE 'cited_file=[^ >]+' | sed 's/cited_file=//' 2>/dev/null) || CITED_FILE=""
 	CITED_THRESHOLD=$(printf '%s' "$generator_line" | grep -oE 'threshold=[0-9]+' | sed 's/threshold=//' 2>/dev/null) || CITED_THRESHOLD=""
 	UPSTREAM_SLUG=$(printf '%s' "$generator_line" | grep -oE 'upstream_slug=[^ >]+' | sed 's/upstream_slug=//' 2>/dev/null) || UPSTREAM_SLUG=""
 	DETECTOR_ID=$(printf '%s' "$generator_line" | grep -oE 'detector=[a-z0-9_-]+' | sed 's/detector=//' 2>/dev/null) || DETECTOR_ID=""
+	STALL_WINDOW_HOURS=$(printf '%s' "$generator_line" | grep -oE 'stall_hours=[0-9]+' | sed 's/stall_hours=//' 2>/dev/null) || STALL_WINDOW_HOURS=""
 
 	_log "INFO" "#${issue_number}: generator=${generator} cited_file=${CITED_FILE:-<none>} threshold=${CITED_THRESHOLD:-<none>} detector=${DETECTOR_ID:-<none>}"
 

--- a/.agents/scripts/pulse-simplification-scan.sh
+++ b/.agents/scripts/pulse-simplification-scan.sh
@@ -285,7 +285,9 @@ _complexity_run_llm_sweep() {
 	fi
 
 	local sweep_body
-	sweep_body="## Simplification debt stall — LLM sweep (automated, GH#15285)
+	sweep_body="<!-- aidevops:generator=complexity-stall-sweep stall_hours=$((${COMPLEXITY_LLM_SWEEP_INTERVAL:-21600} / 3600)) -->
+
+## Simplification debt stall — LLM sweep (automated, GH#15285)
 
 **Open function-complexity-debt issues:** ${current_count:-unknown}
 

--- a/.agents/scripts/tests/test-pre-dispatch-validator.sh
+++ b/.agents/scripts/tests/test-pre-dispatch-validator.sh
@@ -11,6 +11,8 @@
 #   test_bypass_env_var             — AIDEVOPS_SKIP_PREDISPATCH_VALIDATOR=1 → exit 0
 #   test_zero_progress_meta_recovered_blocks_dispatch — recovered meta issue → exit 10
 #   test_zero_progress_meta_active_allows_dispatch    — active meta issue → exit 0
+#   test_complexity_stall_recovered_blocks_dispatch   — resumed throughput → exit 10
+#   test_complexity_stall_active_allows_dispatch      — zero throughput → exit 0
 
 set -euo pipefail
 
@@ -160,16 +162,59 @@ if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/issues/[0-9]+\
 fi
 
 if [[ "\${1:-}" == "api" ]] && [[ "\${2:-}" == "user" ]]; then
-	printf 'runner\n'
+	printf 'marcusquinn\n'
 	exit 0
 fi
 
-if [[ "\${1:-}" == "api" ]] && printf '%s' "\$*" | grep -qE '/repos/.*/collaborators/runner/permission'; then
+if [[ "\${1:-}" == "api" ]] && printf '%s' "\$*" | grep -qE '/repos/.*/collaborators/marcusquinn/permission'; then
 	printf 'HTTP/2.0 200 OK\n\n{"permission":"${permission_value}"}\n'
 	exit 0
 fi
 
 if [[ "\${1:-}" == "issue" ]]; then
+	exit 0
+fi
+
+printf 'unsupported gh invocation: %s\n' "\$*" >&2
+exit 1
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+create_gh_stub_complexity_stall_body() {
+	local recent_closures="$1"
+	local permission_value="${2:-write}"
+	local body_file="${TEST_ROOT}/issue_body.txt"
+	local actions_file="${TEST_ROOT}/gh-actions.log"
+	printf '<!-- aidevops:generator=complexity-stall-sweep stall_hours=6 -->\n## Simplification debt stall\n' >"$body_file"
+
+	cat >"${TEST_ROOT}/bin/gh" <<GHEOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/issues/[0-9]+\$'; then
+	python3 -c "import sys; sys.stdout.write(open('${body_file}').read())" 2>/dev/null
+	exit 0
+fi
+
+if [[ "\${1:-}" == "api" ]] && [[ "\${2:-}" == "graphql" ]]; then
+	printf '%s\n' '${recent_closures}'
+	exit 0
+fi
+
+if [[ "\${1:-}" == "api" ]] && [[ "\${2:-}" == "user" ]]; then
+	printf 'marcusquinn\n'
+	exit 0
+fi
+
+if [[ "\${1:-}" == "api" ]] && printf '%s' "\$*" | grep -qE '/repos/.*/collaborators/marcusquinn/permission'; then
+	printf 'HTTP/2.0 200 OK\n\n{"permission":"${permission_value}"}\n'
+	exit 0
+fi
+
+if [[ "\${1:-}" == "issue" ]]; then
+	printf '%s\n' "\$*" >>'${actions_file}'
 	exit 0
 fi
 
@@ -525,13 +570,13 @@ test_zero_progress_meta_recovered_blocks_dispatch() {
 	create_gh_stub_zero_progress_body "write"
 	write_zero_progress_stats "0"
 
-	local rc=0
-	"$HELPER_SCRIPT" validate "52" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+	local rc=0 output=""
+	output=$("$HELPER_SCRIPT" validate "52" "marcusquinn/aidevops" 2>&1) || rc=$?
 
 	if [[ "$rc" -eq 10 ]]; then
 		print_result "zero_progress meta recovered exits 10" 0
 	else
-		print_result "zero_progress meta recovered exits 10" 1 "Expected exit 10, got ${rc}"
+		print_result "zero_progress meta recovered exits 10" 1 "Expected exit 10, got ${rc}: ${output}"
 	fi
 
 	teardown_test_env
@@ -699,6 +744,57 @@ test_function_complexity_sweep_missing_cited_file_allows_dispatch() {
 	return 0
 }
 
+test_complexity_stall_recovered_blocks_dispatch() {
+	setup_test_env
+	create_gh_stub_complexity_stall_body "2"
+
+	local rc=0 output=""
+	output=$("$HELPER_SCRIPT" validate "29393" "marcusquinn/aidevops" 2>&1) || rc=$?
+
+	if [[ "$rc" -eq 10 ]] && grep -q "close 29393" "${TEST_ROOT}/gh-actions.log" 2>/dev/null; then
+		print_result "complexity stall recovery closes stale meta issue" 0
+	else
+		print_result "complexity stall recovery closes stale meta issue" 1 "Expected exit 10 and close action, got ${rc}: ${output}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+test_complexity_stall_active_allows_dispatch() {
+	setup_test_env
+	create_gh_stub_complexity_stall_body "0"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "29393" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 0 ]] && [[ ! -s "${TEST_ROOT}/gh-actions.log" ]]; then
+		print_result "active complexity stall remains dispatchable" 0
+	else
+		print_result "active complexity stall remains dispatchable" 1 "Expected exit 0 without close action, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+test_complexity_stall_recovered_readonly_fails_open() {
+	setup_test_env
+	create_gh_stub_complexity_stall_body "2" "read"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "29393" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 20 ]] && [[ ! -s "${TEST_ROOT}/gh-actions.log" ]]; then
+		print_result "complexity stall recovery requires live write authority" 0
+	else
+		print_result "complexity stall recovery requires live write authority" 1 "Expected exit 20 without close action, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -719,6 +815,9 @@ main() {
 	test_zero_progress_meta_recovered_blocks_dispatch
 	test_zero_progress_meta_recovered_readonly_allows_dispatch_without_write
 	test_zero_progress_meta_active_allows_dispatch
+	test_complexity_stall_recovered_blocks_dispatch
+	test_complexity_stall_active_allows_dispatch
+	test_complexity_stall_recovered_readonly_fails_open
 	test_review_feedback_extended_extensions
 	test_review_feedback_keyword_scoring_whole_words
 	test_review_feedback_preserves_version_directory_paths

--- a/.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh
@@ -345,11 +345,12 @@ test_llm_sweep_meta_review_is_not_measured_debt() {
 	local list_args create_args
 	list_args=$(<"$GH_ISSUE_LIST_LOG")
 	create_args=$(<"$GH_CREATE_ISSUE_LOG")
-	if [[ "$list_args" == *'in:title "simplification debt stalled" OR in:title "LLM complexity sweep"'* ]] \
-		&& [[ "$list_args" != *'--label function-complexity-debt'* ]] \
-		&& [[ "$create_args" == *'--label quality-debt'* ]] \
-		&& [[ "$create_args" != *'--label function-complexity-debt'* ]] \
-		&& [[ "$create_args" == *'local_capacity_gate'* ]]; then
+	if [[ "$list_args" == *'in:title "simplification debt stalled" OR in:title "LLM complexity sweep"'* ]] &&
+		[[ "$list_args" != *'--label function-complexity-debt'* ]] &&
+		[[ "$create_args" == *'--label quality-debt'* ]] &&
+		[[ "$create_args" != *'--label function-complexity-debt'* ]] &&
+		[[ "$create_args" == *'local_capacity_gate'* ]] &&
+		[[ "$create_args" == *'aidevops:generator=complexity-stall-sweep stall_hours=6'* ]]; then
 		print_result "_complexity_run_llm_sweep: meta review stays outside measured debt" 0
 	else
 		print_result "_complexity_run_llm_sweep: meta review stays outside measured debt" 1 \


### PR DESCRIPTION
## Summary

Add a generator marker and pre-dispatch validator so simplification-stall meta issues close when recent debt throughput has resumed; also restore standalone authority checks by initializing repo metadata.

## Files Changed

.agents/scripts/pre-dispatch-validator-helper.sh, .agents/scripts/pulse-simplification-scan.sh, .agents/scripts/tests/test-pre-dispatch-validator.sh, .agents/scripts/tests/test-pulse-wrapper-complexity-scan.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 19 pre-dispatch validator tests; 17 complexity scan tests; 20 repository authority tests; ShellCheck; bash -n; linters-local.sh

Resolves #29393


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.219 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 19m and 222,142 tokens on this with the user in an interactive session.