### PR TITLE
GH#29432: apply retention overrides to scheduled updates

### DIFF
--- a/.agents/configs/plist-env-overrides.json.txt
+++ b/.agents/configs/plist-env-overrides.json.txt
@@ -8,5 +8,11 @@
     "_AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD_doc": "Canonical default is 0.05, defined in .agents/configs/pulse-rate-limit.conf (GH#20638, lowered from 0.30 in t2896/GH#21034). Override here only if you need a value different from that canonical default. launchd plists cannot source conf files at plist-parse time, so an override must be set explicitly.",
     "_AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD": "0.05",
     "_AIDEVOPS_SKIP_TIER_VALIDATOR": "1"
+  },
+  "com.aidevops.aidevops-auto-update": {
+    "_doc": "Retention examples for scheduled updates — rename (remove leading _) to activate.",
+    "_AIDEVOPS_RUNTIME_BUNDLE_MAX_COUNT": "5",
+    "_AIDEVOPS_RUNTIME_BUNDLE_MAX_BYTES": "1073741824",
+    "_BACKUP_KEEP_COUNT": "3"
   }
 }

--- a/.agents/reference/plist-env-overrides.md
+++ b/.agents/reference/plist-env-overrides.md
@@ -7,9 +7,10 @@ losing them on every `aidevops update` or `setup.sh` run.
 
 `setup.sh` regenerates launchd plists on every run (~every 10 min via
 `aidevops update`). Any manual edits to
-`~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist` or
-`~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-merge.plist` are
-silently wiped.
+`~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist`,
+`~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-merge.plist`, or
+`~/Library/LaunchAgents/com.aidevops.aidevops-auto-update.plist` are silently
+wiped.
 
 The override file survives framework updates because it lives in the stable
 user config root, outside replaceable runtime bundles.
@@ -29,6 +30,11 @@ nano ~/.config/aidevops/plist-env-overrides.json
 # 3. Run setup.sh to regenerate the plist with your overrides
 ~/.aidevops/agents/../setup.sh --non-interactive
 # or: aidevops update
+
+# For com.aidevops.aidevops-auto-update, reload that agent after changing
+# its own environment so the running scheduler adopts the new plist:
+aidevops auto-update disable
+aidevops auto-update enable
 ```
 
 ## File Format
@@ -50,16 +56,31 @@ Keys prefixed with `_` are skipped — they serve as in-file comments.
 
 ## Supported Labels
 
-The main Pulse and dedicated merge-pass supervisors are handled:
+The main Pulse, dedicated merge-pass, and scheduled auto-update agents are handled:
 
 | Label | Plist |
 |-------|-------|
 | `com.aidevops.aidevops-supervisor-pulse` | `~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist` |
 | `com.aidevops.aidevops-supervisor-merge` | `~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-merge.plist` |
+| `com.aidevops.aidevops-auto-update` | `~/Library/LaunchAgents/com.aidevops.aidevops-auto-update.plist` |
 
 Additional labels can be supported by extending
 their plist generators to call `_build_plist_env_overrides_xml` from
-`.agents/scripts/setup/modules/schedulers-pulse.sh`.
+`.agents/scripts/plist-env-overrides-lib.sh`.
+
+## Worked Example: Bound Scheduled Update Storage
+
+To apply lower runtime-bundle and setup-backup ceilings to background updates:
+
+```json
+{
+  "com.aidevops.aidevops-auto-update": {
+    "AIDEVOPS_RUNTIME_BUNDLE_MAX_COUNT": "5",
+    "AIDEVOPS_RUNTIME_BUNDLE_MAX_BYTES": "1073741824",
+    "BACKUP_KEEP_COUNT": "3"
+  }
+}
+```
 
 ## Worked Example: Tune Per-Runner Thresholds
 

--- a/.agents/reference/storage-lifecycle.md
+++ b/.agents/reference/storage-lifecycle.md
@@ -205,6 +205,12 @@ limits: the active bundle, previous rollback bundle, Pulse-pinned bundle, and
 every live-leased bundle remain protected even when an override is lower than
 the protected bundle count or bytes.
 
+On macOS, persist these values for scheduled updates under the
+`com.aidevops.aidevops-auto-update` label in
+`~/.config/aidevops/plist-env-overrides.json`; the generated auto-update
+LaunchAgent injects them into its environment. See
+`reference/plist-env-overrides.md` for the file format and setup steps.
+
 ### Runtime Bundle Dependency Decision
 
 Runtime activation continues to verify the OpenCode host's existing dependency

--- a/.agents/scripts/auto-update-helper-scheduler.sh
+++ b/.agents/scripts/auto-update-helper-scheduler.sh
@@ -35,6 +35,12 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
     unset _lib_path
 fi
 
+_auto_update_scheduler_dir="${BASH_SOURCE[0]%/*}"
+[[ "$_auto_update_scheduler_dir" == "${BASH_SOURCE[0]}" ]] && _auto_update_scheduler_dir="."
+# shellcheck source=plist-env-overrides-lib.sh
+source "${_auto_update_scheduler_dir}/plist-env-overrides-lib.sh"
+unset _auto_update_scheduler_dir
+
 # --- Functions ---
 
 #######################################
@@ -88,6 +94,8 @@ _generate_auto_update_plist() {
 	local interval_seconds="$2"
 	local env_path="$3"
 	env_path=$(aidevops_launchd_sanitized_path "$env_path")
+	local env_overrides_xml
+	env_overrides_xml=$(_build_plist_env_overrides_xml "$LAUNCHD_LABEL")
 
 	cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
@@ -111,7 +119,7 @@ _generate_auto_update_plist() {
 	<dict>
 		<key>PATH</key>
 		<string>${env_path}</string>
-	</dict>
+${env_overrides_xml}	</dict>
 	<key>RunAtLoad</key>
 	<false/>
 	<key>KeepAlive</key>

--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -66,6 +66,8 @@ _resolve_script_path() {
 SCRIPT_DIR="$(_resolve_script_path)" || exit
 unset -f _resolve_script_path
 source "${SCRIPT_DIR}/shared-constants.sh"
+# shellcheck source=plist-env-overrides-lib.sh
+source "${SCRIPT_DIR}/plist-env-overrides-lib.sh"
 
 init_log_file
 
@@ -202,6 +204,8 @@ _generate_auto_update_plist() {
 	local interval_seconds="$2"
 	local env_path="$3"
 	env_path=$(aidevops_launchd_sanitized_path "$env_path")
+	local env_overrides_xml
+	env_overrides_xml=$(_build_plist_env_overrides_xml "$LAUNCHD_LABEL")
 
 	cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
@@ -225,7 +229,7 @@ _generate_auto_update_plist() {
 	<dict>
 		<key>PATH</key>
 		<string>${env_path}</string>
-	</dict>
+${env_overrides_xml}	</dict>
 	<key>RunAtLoad</key>
 	<false/>
 	<key>KeepAlive</key>

--- a/.agents/scripts/plist-env-overrides-lib.sh
+++ b/.agents/scripts/plist-env-overrides-lib.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Shared plist environment override helpers for launchd scheduler generators.
+
+[[ -n "${_PLIST_ENV_OVERRIDES_LIB_LOADED:-}" ]] && return 0
+_PLIST_ENV_OVERRIDES_LIB_LOADED=1
+
+_plist_env_overrides_file() {
+	local stable_file="$HOME/.config/aidevops/plist-env-overrides.json"
+	local legacy_file="$HOME/.aidevops/agents/configs/plist-env-overrides.json"
+
+	if [[ -f "$stable_file" ]]; then
+		printf '%s' "$stable_file"
+	elif [[ -f "$legacy_file" ]]; then
+		printf '%s' "$legacy_file"
+	else
+		printf '%s' "$stable_file"
+	fi
+	return 0
+}
+
+_plist_env_xml_escape() {
+	local value="$1"
+	value="${value//&/\&amp;}"
+	value="${value//</\&lt;}"
+	value="${value//>/\&gt;}"
+	value="${value//\"/\&quot;}"
+	value="${value//\'/\&apos;}"
+	printf '%s' "$value"
+	return 0
+}
+
+_build_plist_env_overrides_xml() {
+	local label="$1"
+	local override_file="${2:-}"
+	local indent="${3:-		}"
+	[[ -n "$override_file" ]] || override_file=$(_plist_env_overrides_file)
+
+	[[ -f "$override_file" ]] || return 0
+	if ! command -v jq >/dev/null 2>&1; then
+		echo "[schedulers] WARN: jq not found; skipping plist-env-overrides.json injection" >&2
+		return 0
+	fi
+	if ! jq empty "$override_file" 2>/dev/null; then
+		echo "[schedulers] WARN: plist-env-overrides.json is malformed; skipping injection (file: $override_file)" >&2
+		return 0
+	fi
+
+	local pairs
+	pairs=$(jq -r --arg label "$label" '
+		.[$label] // {} |
+		to_entries[] |
+		select(.key | startswith("_") | not) |
+		"\(.key)=\(.value)"
+	' "$override_file" 2>/dev/null) || return 0
+	[[ -n "$pairs" ]] || return 0
+
+	local line key value xml_key xml_value
+	while IFS= read -r line; do
+		[[ -n "$line" ]] || continue
+		key="${line%%=*}"
+		value="${line#*=}"
+		xml_key=$(_plist_env_xml_escape "$key")
+		xml_value=$(_plist_env_xml_escape "$value")
+		printf '%s<key>%s</key>\n%s<string>%s</string>\n' \
+			"$indent" "$xml_key" "$indent" "$xml_value"
+	done <<<"$pairs"
+	return 0
+}

--- a/.agents/scripts/setup/modules/schedulers-pulse.sh
+++ b/.agents/scripts/setup/modules/schedulers-pulse.sh
@@ -39,6 +39,12 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _sched_pulse_lib_path
 fi
 
+_schedulers_pulse_dir="${BASH_SOURCE[0]%/*}"
+[[ "$_schedulers_pulse_dir" == "${BASH_SOURCE[0]}" ]] && _schedulers_pulse_dir="."
+# shellcheck source=../../plist-env-overrides-lib.sh
+source "${_schedulers_pulse_dir}/../../plist-env-overrides-lib.sh"
+unset _schedulers_pulse_dir
+
 # --- Functions ---
 
 # Resolve the modern bash binary path for use in launchd ProgramArguments.
@@ -735,78 +741,6 @@ _cleanup_old_pulse_plists() {
 _build_pulse_headless_env_xml() {
 	# Intentionally empty — model config read from credentials.sh at runtime.
 	printf '%s' ""
-	return 0
-}
-
-# Read user-owned plist env override file and emit XML key/string pairs
-# for the matching label's env vars. Keys prefixed with _ are skipped
-# (used as comments in the JSON template).
-#
-# Args: $1=plist_label (e.g. "com.aidevops.aidevops-supervisor-pulse")
-#       $2=override_file (absolute path; default ~/.config/aidevops/plist-env-overrides.json)
-#       $3=indent (string to prepend each line; default "\t\t")
-#
-# Returns 0 on success (including empty result when label not found).
-# Prints WARN to stderr and returns 0 when file is present but malformed.
-# Emits nothing when file is absent.
-_plist_env_overrides_file() {
-	local stable_file="$HOME/.config/aidevops/plist-env-overrides.json"
-	local legacy_file="$HOME/.aidevops/agents/configs/plist-env-overrides.json"
-
-	if [[ -f "$stable_file" ]]; then
-		printf '%s' "$stable_file"
-	elif [[ -f "$legacy_file" ]]; then
-		# Compatibility fallback for installs that have not run bundle migration yet.
-		printf '%s' "$legacy_file"
-	else
-		printf '%s' "$stable_file"
-	fi
-	return 0
-}
-
-_build_plist_env_overrides_xml() {
-	local _label="$1"
-	local _override_file="${2:-}"
-	local _indent="${3:-		}"
-	[[ -n "$_override_file" ]] || _override_file=$(_plist_env_overrides_file)
-
-	# Missing file is the normal case (user has not created the override file yet)
-	[[ -f "$_override_file" ]] || return 0
-
-	# Require jq — without it we cannot parse JSON safely
-	if ! command -v jq >/dev/null 2>&1; then
-		echo "[schedulers] WARN: jq not found; skipping plist-env-overrides.json injection" >&2
-		return 0
-	fi
-
-	# Validate JSON
-	if ! jq empty "$_override_file" 2>/dev/null; then
-		echo "[schedulers] WARN: plist-env-overrides.json is malformed; skipping injection (file: $_override_file)" >&2
-		return 0
-	fi
-
-	# Extract key=value pairs for the matching label; skip _ prefixed keys
-	local _pairs
-	_pairs=$(jq -r --arg label "$_label" '
-		.[$label] // {} |
-		to_entries[] |
-		select(.key | startswith("_") | not) |
-		"\(.key)=\(.value)"
-	' "$_override_file" 2>/dev/null) || return 0
-
-	[[ -z "$_pairs" ]] && return 0
-
-	local _line _key _val _xml_key _xml_val
-	while IFS= read -r _line; do
-		[[ -z "$_line" ]] && continue
-		_key="${_line%%=*}"
-		_val="${_line#*=}"
-		_xml_key=$(_xml_escape "$_key")
-		_xml_val=$(_xml_escape "$_val")
-		printf '%s<key>%s</key>\n%s<string>%s</string>\n' \
-			"$_indent" "$_xml_key" "$_indent" "$_xml_val"
-	done <<<"$_pairs"
-
 	return 0
 }
 

--- a/.agents/scripts/tests/test-launchd-sanitized-path.sh
+++ b/.agents/scripts/tests/test-launchd-sanitized-path.sh
@@ -163,11 +163,43 @@ test_auto_update_plist_filters_polluted_env_path() {
 	return 0
 }
 
+test_auto_update_plist_injects_label_overrides() {
+	local original_home="$HOME"
+	local override_file="$TEST_DIR/home/.config/aidevops/plist-env-overrides.json"
+	local plist ok
+	HOME="$TEST_DIR/home"
+	mkdir -p "${override_file%/*}"
+	cat >"$override_file" <<'EOF'
+{
+  "com.test.aidevops-auto-update": {
+    "AIDEVOPS_RUNTIME_BUNDLE_MAX_COUNT": "3",
+    "BACKUP_KEEP_COUNT": "2"
+  }
+}
+EOF
+
+	plist=$(_generate_auto_update_plist "/bin/true" "600" "/usr/bin:/bin")
+	ok=0
+	[[ "$plist" == *"<key>AIDEVOPS_RUNTIME_BUNDLE_MAX_COUNT</key>"* ]] || ok=1
+	[[ "$plist" == *"<string>3</string>"* ]] || ok=1
+	[[ "$plist" == *"<key>BACKUP_KEEP_COUNT</key>"* ]] || ok=1
+	[[ "$plist" == *"<string>2</string>"* ]] || ok=1
+	HOME="$original_home"
+
+	if [[ "$ok" -eq 0 ]]; then
+		pass "test_auto_update_plist_injects_label_overrides"
+	else
+		fail "test_auto_update_plist_injects_label_overrides" "generated plist omitted auto-update overrides"
+	fi
+	return 0
+}
+
 main() {
 	setup
 	test_sanitized_path_filters_unsafe_entries
 	test_sanitized_path_preserves_unset_ifs
 	test_auto_update_plist_filters_polluted_env_path
+	test_auto_update_plist_injects_label_overrides
 
 	printf 'Ran %d tests, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]] || return 1


### PR DESCRIPTION
## Summary

Share plist override parsing across scheduler generators and inject auto-update label overrides so background updates honor configured storage ceilings.

## Files Changed

.agents/configs/plist-env-overrides.json.txt, .agents/reference/plist-env-overrides.md, .agents/reference/storage-lifecycle.md, .agents/scripts/auto-update-helper-scheduler.sh, .agents/scripts/auto-update-helper.sh, .agents/scripts/plist-env-overrides-lib.sh, .agents/scripts/setup/modules/schedulers-pulse.sh, .agents/scripts/tests/test-launchd-sanitized-path.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — ShellCheck; local linters; plist override, launchd path/install, runtime bundle deployment, and systemd generation tests.

Resolves #29432


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.219 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 28m and 138,355 tokens on this with the user in an interactive session.