### PR TITLE
GH#29322: Add bounded Notion Sites knowledge collection

### DIFF
--- a/.agents/aidevops/knowledge-plane/05-social-operations.md
+++ b/.agents/aidevops/knowledge-plane/05-social-operations.md
@@ -47,6 +47,11 @@ negative write-reachability tests. Raindrop.io remains optional; Inoreader,
 Wallabag, Feedly, Instapaper, and Pocket are deferred or rejected for the reasons
 in `.agents/content/social-provider-candidates.md`.
 
+Notion Sites #29322 is also live as an integration-scoped document route. It is
+not a public-site crawler: the selected bot workspace and an explicit root-page
+UUID allowlist are rebound before every content request. Details:
+`.agents/content/social-notion-sites.md`.
+
 The maintained planning and gap inventory is
 `06-social-provider-capabilities.md`. A matrix entry is not implementation
 authority: every provider child must revalidate current official API/export
@@ -192,6 +197,17 @@ shape, so the collector caps the route at page 100 and records partial coverage.
 Subscriber records, segments, engagement statistics, premium content, remote
 media, exports, redirects, and mutations are unreachable. Details:
 `.agents/content/social-beehiiv.md`.
+
+Notion Sites collection binds `/v1/users/me` bot and workspace identity before
+every content request. It starts only from explicit root page UUIDs, follows
+returned child blocks/pages and database data sources through a durable bounded
+queue, and optionally lists unresolved comments when the connection has that
+capability. Search, linked-page references, copied synced-block sources, external
+embeds, redirects, and file URLs are never traversal targets. File metadata is
+retained without URLs or downloads. The exact data-source query POST is the only
+non-GET request and cannot mutate provider state. A public Site URL, workspace-
+wide visibility, or a valid token without the expected workspace/root binding
+never grants collection authority. Details: `.agents/content/social-notion-sites.md`.
 
 X collection uses the guarded official `xurl` helper. Reddit collection uses an
 optional PRAW 8 child. YouTube collection uses a standard-library HTTP child and

--- a/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
+++ b/.agents/aidevops/knowledge-plane/06-social-provider-capabilities.md
@@ -53,6 +53,7 @@ a claim that the route is enabled.
 | Stack Exchange | **Live/Partial** posts, questions, answers, and comments | **Live/Partial** favourites; **No** complete votes | **Live/Gate/Partial** inbox and notifications | **Live/Partial** associated site accounts; **No** follows | **No** | Eight network-plus-site-identity-bound GET streams obey `has_more`, `backoff`, quota, and 100-item page limits while preserving archive and inaccessible-history gaps. |
 | Hacker News | **Live/Partial** public submissions and comments | **No** private votes or saved items | **No** | **No** | **No** | One bounded public `submitted` stream uses a mutable case-sensitive username selector and official item IDs; missing/deleted/dead and all private state remain explicit unavailable coverage. |
 | Hashnode | **Live** posts; **Live/Gate** owned publications and drafts | **Live/Partial** comments and likes received; **No** authored-comment or reaction history | **No** messages or notifications | **Live/Partial** followers and following | **No** | Eight viewer-bound streams use nine fixed GraphQL read documents, repeated author/publication ownership checks, opaque nested cursors, and **Export/Gate** account-archive coverage pending a current identity-bearing schema. |
+| Notion Sites | **Live/Gate/Partial** allowlisted pages, blocks, and database rows | **No** account-wide interaction route | **Live/Gate/Partial** unresolved comments; **Export/Gate** resolved comments; **No** messages | **No** workspace-wide discovery | **Live/Gate/Partial** child databases/data sources | Official API bot/workspace identity plus explicit root UUIDs; a public Site URL grants no API authority, Search is disabled, and files/embeds are metadata-only non-fetch targets. |
 | Miniflux | **Live/Partial** feed entries | **Live/Partial** read, removed, starred, and tagged state | **No** | **Live/Partial/Export** subscriptions | **Live/Partial/Export** categories and tags | Eight keyed-installation account streams use five exact GET routes, ascending entry-ID backfill, one-second `changed_after` overlap, bounded snapshots, and explicit operator-retention gaps. |
 | FreshRSS | **Live/Partial** feed items | **Live/Partial** unread and starred state | **No** | **Live/Partial/Export** subscriptions | **Live/Partial/Export** folders and tags | Seven installation/user-bound Google Reader streams allow only ClientLogin POST plus exact data GETs, preserve opaque continuations and OPML snapshots, and leave POST-authenticated Fever fallback unavailable. |
 | Readwise Reader | **Live/Gate/Partial** saved documents and optional HTML | **Live/Gate/Partial** notes, state, progress, and tags | **No** | **No** | **Live/Gate/Partial** tags and locations | Seven deployment-bound streams preserve opaque cursors, overlap `updatedAfter`, cap invocations below 20 requests/minute, and expose the provider identity/export boundary. |
@@ -77,6 +78,7 @@ falls back to another provider or to an outbound mutation route.
 | Bluesky / AT Protocol | **Live** repository/AppView reads | Chat remains separately permissioned; account identity is a stable DID. |
 | Forem | **Live** multi-instance reads | `dev-community` and `dev.to` are aliases of `forem`, not separate providers. |
 | Ghost | **Live** public publication reads | Content API v6 only; Admin credentials and private member/newsletter/comment data are not registered. |
+| Notion Sites | **Live/Gate** official API root traversal | Integration bot/workspace/root binding is mandatory; public URLs, Search, external fetches, and mutations are excluded. |
 
 HubSpot Community remains a Discourse installation and is not registered as a
 separate provider family.
@@ -287,6 +289,16 @@ separate provider family.
   `.agents/content/social-beehiiv.md` records official API-v2 authentication,
   endpoint-specific pagination, organization quota, plan/export gates, privacy,
   terms, and excluded subscriber fields checked on 2026-08-03.
+- **Live/Gated Notion Sites:** `.agents/scripts/knowledge_social_notion.py`,
+  `.agents/scripts/_knowledge_social_notion*.py`, and
+  `.agents/tests/test-knowledge-social-notion.sh` prove bot/workspace/root
+  rebinding, descendant-only queue traversal, opaque pagination, page/block/
+  request/byte/depth bounds, unresolved-comment capability gating, URL-free file
+  metadata, exact fixed-origin routes, one read-only data-source query POST,
+  redirect and mutation isolation, terminal/malformed response preservation, and
+  lease-fenced persistence. `.agents/content/social-notion-sites.md` records the
+  official Sites, API, identity, content, comments, file, export, pagination,
+  rate, and Search boundaries checked on 2026-08-02.
 - **Integrated provider registry:** `.agents/scripts/knowledge_social_registry.py`
   and `.agents/tests/test-knowledge-social-registry.sh` prove order-independent
   registration, collision rejection, exact aliases and modes, no-route failure,

--- a/.agents/content/social-notion-sites.md
+++ b/.agents/content/social-notion-sites.md
@@ -1,0 +1,133 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Notion Sites Knowledge Collection
+
+`knowledge_social_notion.py` collects one bounded tree from explicit page UUIDs
+through the official Notion API. It does not crawl a published Notion Site. A
+public Site URL allows web viewing only and is never accepted as an account ID,
+root selector, API credential, or collection grant.
+
+## Current capability disposition
+
+Checked against current official documentation on 2026-08-02. **Live** means the
+fixture-tested adapter is reachable; **Gate** means the configured connection
+must have the provider capability and content access; **Export** is a separate
+owner/admin route not implemented by this adapter; **No** means the route is
+deliberately unreachable.
+
+| Category | Disposition | Boundary |
+|---|---|---|
+| Published root page and nested blocks/pages | **Live/Gate/Partial** | Integration bot, expected workspace UUID, and explicit root page UUIDs must all match. Only descendants returned by the API are scheduled. |
+| Child databases and data-source rows | **Live/Gate/Partial** | Only `child_database` blocks discovered below a root are retrieved. Only their returned data-source IDs are queried. Linked references are not followed. |
+| Open/unresolved page and block comments | **Live/Gate/Partial** | Disabled by default; requires the connection's read-comment capability. |
+| Resolved comments | **Export/Gate** | The public API does not return them. HTML/workspace exports can include comments under owner/admin authority. No export importer is exposed here. |
+| Notion-hosted files | **Live/Gate/Partial** metadata; **No** bytes | Kind and expiry metadata are retained without the signed URL. The one-hour URL is never fetched or persisted. |
+| External files, embeds, bookmarks, and link previews | **No** fetch | Their presence is retained as URL-free metadata; targets, redirects, iframes, and previews are never fetched. |
+| Workspace-wide Search | **No** | Search is title-oriented, eventually indexed, and not exhaustive. It is neither an authorization source nor an inventory route. |
+| Unlisted public Site pages or Site metadata | **No** | A Site URL alone proves neither account identity nor integration access. |
+| Workspace export | **Export/Gate** | UI export requires member/admin authority; Admin API export is Enterprise-only and uses separate organization-bot scope. |
+| Mutations, webhooks, browser capture, or public crawling | **No** | No create/update/delete route, webhook listener, browser, arbitrary URL, or crawler is reachable. |
+
+## Identity and authorization contract
+
+The secret profile contains one integration token and non-secret expected
+bindings named `NOTION_<PROFILE>_WORKSPACE_ID` and
+`NOTION_<PROFILE>_ROOT_PAGE_IDS`. Root IDs are a comma-separated allowlist of
+1–20 UUIDs; URLs and names are rejected. The profile may also set:
+
+- `NOTION_<PROFILE>_INCLUDE_COMMENTS=true|false` (default `false`);
+- `NOTION_<PROFILE>_MAX_DEPTH` (default 8, hard maximum 20);
+- `NOTION_<PROFILE>_MAX_PAGES` (default 500, hard maximum 10,000);
+- `NOTION_<PROFILE>_MAX_BLOCKS` (default 5,000, hard maximum 100,000);
+- `NOTION_<PROFILE>_MAX_BYTES` (default 16 MiB, hard maximum 256 MiB).
+
+Store the access token as `NOTION_<PROFILE>_ACCESS_TOKEN` with `aidevops secret`;
+never place its value in a command, issue, fixture, or log. Invoke the canonical
+registry route with the expected workspace UUID as `--account-id`:
+
+```bash
+aidevops secret NOTION_WORK_ACCESS_TOKEN -- \
+  knowledge-social-helper.sh provider-run \
+  --provider notion-sites --mode live -- \
+  --alias personal:default \
+  --connection-id CONNECTION_ID \
+  --account-id EXPECTED_WORKSPACE_UUID \
+  --stream site_tree --profile work \
+  --budget 21 --page-size 100
+```
+
+`GET /v1/users/me` must return a bot in the exact configured workspace before
+the first write and before every content request. Profile roots and limits must
+also equal the values bound into the durable cursor. Rotating a profile to a
+different workspace, root set, or budget fails before evidence advances.
+
+## Traversal, pagination, and persistence
+
+The child process can reach only these reviewed fixed-origin routes:
+
+| Purpose | Method and route |
+|---|---|
+| Bot/workspace identity | `GET /v1/users/me` |
+| Root or discovered page properties | `GET /v1/pages/{uuid}` |
+| One level of block children | `GET /v1/blocks/{uuid}/children` |
+| Discovered child database metadata | `GET /v1/databases/{uuid}` |
+| Rows in a discovered data source | `POST /v1/data_sources/{uuid}/query` |
+| Optional unresolved comments | `GET /v1/comments?block_id={uuid}` |
+
+The query POST is an official read operation with a body limited to
+`page_size` and an opaque `start_cursor`; it cannot carry a filter, mutation, or
+caller-selected URL. Every other provider request is GET. Redirects are rejected.
+
+The versioned cursor binds workspace, roots, comment policy, API version, limits,
+the pending descendant queue, scheduled IDs, and cumulative page/block/byte
+counts. Provider `next_cursor` values remain opaque. Child pages, nested blocks,
+and data-source rows are scheduled only from a response whose parent matches the
+current queue head. `link_to_page`, copied synced-block sources, relations,
+mentions, and Search never add tasks.
+
+Each content step reserves two request units: one identity recheck and one data
+read. The identity observation reserves one unit. The reader paces live calls
+below the documented average three requests/second per connection and preserves
+`Retry-After` on 429/529 responses. Budget exhaustion leaves the last atomic
+checkpoint resumable. A malformed page, non-advancing cursor, incomplete result,
+parent/workspace mismatch, depth/page/block/byte/queue exhaustion, credential-
+shaped text, terminal response, or stale lease commits neither that response nor
+its next checkpoint.
+
+Raw evidence contains the adapter's URL-free projection, not expiring signed
+file URLs. Normalized rows preserve plain text, timestamps, stable UUIDs, parent
+bindings, publication presence, file disposition, and explicit unavailable
+coverage. They do not claim a complete workspace, deletion history, resolved
+comment history, relation closure, or indefinite retention.
+
+## Official evidence
+
+- Sites publishing and public visibility:
+  <https://www.notion.com/help/public-pages-and-web-publishing>
+- API authentication and cursor pagination:
+  <https://developers.notion.com/reference/intro>
+- Internal connection content access:
+  <https://developers.notion.com/guides/get-started/internal-connections>
+- Bot and workspace identity:
+  <https://developers.notion.com/reference/get-self>
+- Page properties and the 25-reference limit:
+  <https://developers.notion.com/reference/retrieve-a-page>
+- Recursive block-child reads:
+  <https://developers.notion.com/reference/get-block-children>
+- Databases, data sources, and the 10,000-result query boundary:
+  <https://developers.notion.com/reference/retrieve-database>,
+  <https://developers.notion.com/reference/query-a-data-source>
+- Unresolved comments and capability gate:
+  <https://developers.notion.com/reference/list-comments>
+- Expiring file URLs:
+  <https://developers.notion.com/guides/data-apis/retrieving-files>
+- Per-connection/workspace rate and payload limits:
+  <https://developers.notion.com/reference/request-limits>
+- Search incompleteness:
+  <https://developers.notion.com/reference/search-optimizations-and-limitations>
+- UI exports and backups:
+  <https://www.notion.com/help/export-your-content>,
+  <https://www.notion.com/help/back-up-your-data>
+- Enterprise Admin API export:
+  <https://developers.notion.com/reference/admin/enqueue-space-export>

--- a/.agents/scripts/_knowledge_social_notion.py
+++ b/.agents/scripts/_knowledge_social_notion.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Notion root-bound traversal policy and durable queue checkpoints."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_collect import CursorState
+from _knowledge_social_notion_identity import (
+    NotionAdapterError,
+    NotionProviderUnavailableError,
+    bounded_integer,
+    notion_id,
+    root_page_ids,
+)
+from knowledge_social_import import canonical_json, reject_credentials
+
+PROVIDER = "notion-sites"
+API_VERSION = "2026-03-11"
+CURSOR_PREFIX = "notion-sites-v1:"
+RETENTION_LIMIT = "connection_access_and_notion_workspace_retention"
+MAX_CURSOR_BYTES = 512 * 1024
+TASK_KINDS = frozenset({"page", "blocks", "database", "data_source", "comments"})
+
+ADAPTER_ERROR = NotionAdapterError
+PROVIDER_UNAVAILABLE_ERROR = NotionProviderUnavailableError
+
+
+@dataclass(frozen=True)
+class StreamSpec:
+    resource_kind: str = "notion_object"
+    activity_mode: str = "authorized_content"
+    pagination: str = "opaque_cursor_and_durable_queue"
+    incremental: bool = False
+    retention_limit: str | None = RETENTION_LIMIT
+    coverage_status: str | None = "partial"
+    unavailable_reason: str | None = "explicit_root_descendants_only"
+    cost_units: int = 2
+
+
+STREAMS = {"site_tree": StreamSpec()}
+
+
+@dataclass(frozen=True)
+class Limits:
+    max_depth: int
+    max_pages: int
+    max_blocks: int
+    max_bytes: int
+
+    def payload(self) -> dict[str, int]:
+        return {
+            "max_blocks": self.max_blocks,
+            "max_bytes": self.max_bytes,
+            "max_depth": self.max_depth,
+            "max_pages": self.max_pages,
+        }
+
+
+def limits_value(value: Any) -> Limits:
+    if not isinstance(value, dict) or set(value) != {
+        "max_blocks",
+        "max_bytes",
+        "max_depth",
+        "max_pages",
+    }:
+        raise NotionAdapterError("Notion traversal limits have an invalid shape")
+    return Limits(
+        bounded_integer(value["max_depth"], "maximum depth", 0, 20),
+        bounded_integer(value["max_pages"], "maximum pages", 1, 10_000),
+        bounded_integer(value["max_blocks"], "maximum blocks", 1, 100_000),
+        bounded_integer(value["max_bytes"], "maximum bytes", 65_536, 268_435_456),
+    )
+
+
+@dataclass(frozen=True)
+class Task:
+    kind: str
+    resource_id: str
+    depth: int
+    cursor: str | None = None
+    parent_kind: str | None = None
+    parent_id: str | None = None
+    database_id: str | None = None
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "cursor": self.cursor,
+            "database_id": self.database_id,
+            "depth": self.depth,
+            "kind": self.kind,
+            "parent_id": self.parent_id,
+            "parent_kind": self.parent_kind,
+            "resource_id": self.resource_id,
+        }
+
+    def key(self) -> str:
+        return canonical_json(
+            [self.kind, self.resource_id, self.parent_kind, self.parent_id, self.database_id]
+        )
+
+
+TASK_KEYS = {
+    "cursor",
+    "database_id",
+    "depth",
+    "kind",
+    "parent_id",
+    "parent_kind",
+    "resource_id",
+}
+
+
+def _optional_id(value: Any, field: str) -> str | None:
+    return None if value is None else notion_id(value, field)
+
+
+def _cursor_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    if (
+        not isinstance(value, str)
+        or not value
+        or "\x00" in value
+        or len(value.encode("utf-8")) > 4096
+    ):
+        raise NotionAdapterError("Notion pagination cursor is invalid")
+    return value
+
+
+def task_value(value: Any, limits: Limits) -> Task:
+    if not isinstance(value, dict) or set(value) != TASK_KEYS:
+        raise NotionAdapterError("Notion traversal task has an invalid shape")
+    kind = value.get("kind")
+    if kind not in TASK_KINDS:
+        raise NotionAdapterError("Notion traversal task kind is unsupported")
+    depth = bounded_integer(value.get("depth"), "task depth", 0, limits.max_depth)
+    parent_kind = value.get("parent_kind")
+    if parent_kind not in {None, "page_id", "block_id", "database_id", "data_source_id"}:
+        raise NotionAdapterError("Notion traversal parent kind is invalid")
+    parent_id = _optional_id(value.get("parent_id"), "task parent ID")
+    if (parent_kind is None) != (parent_id is None):
+        raise NotionAdapterError("Notion traversal parent binding is incomplete")
+    database_id = _optional_id(value.get("database_id"), "task database ID")
+    if kind == "data_source" and (
+        database_id is None
+        or parent_kind != "database_id"
+        or parent_id != database_id
+    ):
+        raise NotionAdapterError("Notion data source task requires its database binding")
+    if kind == "database" and parent_kind not in {"page_id", "block_id"}:
+        raise NotionAdapterError("Notion database task requires its descendant parent")
+    if kind == "page" and parent_kind not in {None, "page_id", "block_id"}:
+        raise NotionAdapterError("Notion page task parent binding is invalid")
+    if parent_kind == "data_source_id" and (
+        kind not in {"blocks", "comments"} or database_id is None
+    ):
+        raise NotionAdapterError("Notion row task database binding is invalid")
+    if parent_kind != "data_source_id" and kind != "data_source" and database_id is not None:
+        raise NotionAdapterError("Notion traversal database binding is unexpected")
+    return Task(
+        kind,
+        notion_id(value.get("resource_id"), "task resource ID"),
+        depth,
+        _cursor_value(value.get("cursor")),
+        parent_kind,
+        parent_id,
+        database_id,
+    )
+
+
+@dataclass(frozen=True)
+class TraversalState:
+    queue: tuple[Task, ...]
+    scheduled: frozenset[str]
+    pages: int
+    blocks: int
+    response_bytes: int
+
+
+def _binding(workspace_id: str, roots: tuple[str, ...], limits: Limits, comments: bool) -> str:
+    return hashlib.sha256(
+        canonical_json(
+            {
+                "api_version": API_VERSION,
+                "include_comments": comments,
+                "limits": limits.payload(),
+                "root_page_ids": list(roots),
+                "workspace_id": workspace_id,
+            }
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _account(account: dict[str, Any]) -> tuple[str, tuple[str, ...], Limits, bool, str]:
+    workspace = notion_id(account.get("workspace_id"), "workspace ID")
+    if notion_id(account.get("id"), "account ID") != workspace:
+        raise NotionAdapterError("Notion workspace identity binding is invalid")
+    roots = root_page_ids(account.get("root_page_ids"))
+    limits = limits_value(account.get("limits"))
+    comments = account.get("include_comments")
+    if not isinstance(comments, bool):
+        raise NotionAdapterError("Notion comment collection policy must be boolean")
+    return workspace, roots, limits, comments, _binding(workspace, roots, limits, comments)
+
+
+def _initial_state(roots: tuple[str, ...], limits: Limits) -> TraversalState:
+    queue = tuple(Task("page", root, 0) for root in roots)
+    return TraversalState(queue, frozenset(task.key() for task in queue), 0, 0, 0)
+
+
+def _encode_state(state: TraversalState, binding: str) -> str:
+    payload = {
+        "binding": binding,
+        "blocks": state.blocks,
+        "pages": state.pages,
+        "queue": [task.payload() for task in state.queue],
+        "response_bytes": state.response_bytes,
+        "scheduled": sorted(state.scheduled),
+    }
+    raw = canonical_json(payload).encode("utf-8")
+    if len(raw) > MAX_CURSOR_BYTES:
+        raise NotionAdapterError("Notion traversal checkpoint exceeds the safety limit")
+    encoded = base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+    return f"{CURSOR_PREFIX}{encoded}"
+
+
+def _decode_state(cursor: str, binding: str, limits: Limits) -> TraversalState:
+    if not cursor.startswith(CURSOR_PREFIX):
+        raise NotionAdapterError("stored Notion cursor has an unsupported version")
+    try:
+        encoded = cursor.removeprefix(CURSOR_PREFIX)
+        raw = base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4))
+        if len(raw) > MAX_CURSOR_BYTES:
+            raise ValueError("cursor too large")
+        parsed = json.loads(raw)
+    except (UnicodeError, ValueError, json.JSONDecodeError) as error:
+        raise NotionAdapterError("stored Notion cursor is invalid") from error
+    if not isinstance(parsed, dict) or set(parsed) != {
+        "binding",
+        "blocks",
+        "pages",
+        "queue",
+        "response_bytes",
+        "scheduled",
+    }:
+        raise NotionAdapterError("stored Notion cursor has an invalid shape")
+    reject_credentials(parsed)
+    if parsed.get("binding") != binding:
+        raise NotionAdapterError("stored Notion cursor belongs to another root policy")
+    queue_value = parsed.get("queue")
+    scheduled_value = parsed.get("scheduled")
+    if not isinstance(queue_value, list) or not isinstance(scheduled_value, list):
+        raise NotionAdapterError("stored Notion traversal queue is invalid")
+    queue = tuple(task_value(item, limits) for item in queue_value)
+    scheduled = frozenset(scheduled_value)
+    if any(not isinstance(item, str) or not item for item in scheduled_value):
+        raise NotionAdapterError("stored Notion scheduled set is invalid")
+    if len(scheduled) != len(scheduled_value) or any(task.key() not in scheduled for task in queue):
+        raise NotionAdapterError("stored Notion scheduled set is inconsistent")
+    pages = bounded_integer(parsed.get("pages"), "stored page count", 0, limits.max_pages)
+    blocks = bounded_integer(parsed.get("blocks"), "stored block count", 0, limits.max_blocks)
+    response_bytes = bounded_integer(
+        parsed.get("response_bytes"), "stored byte count", 0, limits.max_bytes
+    )
+    return TraversalState(queue, scheduled, pages, blocks, response_bytes)
+
+
+@dataclass(frozen=True)
+class PageRequest:
+    workspace_id: str
+    root_page_ids: tuple[str, ...]
+    limits: Limits
+    include_comments: bool
+    binding: str
+    task: Task
+    page_size: int
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "action": "page",
+            "binding": self.binding,
+            "include_comments": self.include_comments,
+            "limits": self.limits.payload(),
+            "page_size": self.page_size,
+            "root_page_ids": list(self.root_page_ids),
+            "stream": "site_tree",
+            "task": self.task.payload(),
+            "workspace_id": self.workspace_id,
+        }
+
+    def evidence_key(self) -> str:
+        return canonical_json(self.payload())
+
+    def digest(self) -> str:
+        return hashlib.sha256(self.evidence_key().encode("utf-8")).hexdigest()
+
+
+PAGE_REQUEST_KEYS = {
+    "action",
+    "binding",
+    "include_comments",
+    "limits",
+    "page_size",
+    "root_page_ids",
+    "stream",
+    "task",
+    "workspace_id",
+}
+
+
+def page_request(
+    stream: str, account: dict[str, Any], state: CursorState, limit: int
+) -> PageRequest:
+    if stream != "site_tree":
+        raise NotionAdapterError("Notion stream is unsupported")
+    workspace, roots, limits, comments, binding = _account(account)
+    page_size = bounded_integer(limit, "page size", 1, 100)
+    traversal = (
+        _decode_state(state.cursor, binding, limits)
+        if state.cursor
+        else _initial_state(roots, limits)
+    )
+    if not traversal.queue:
+        raise NotionAdapterError("Notion traversal checkpoint is already complete")
+    return PageRequest(
+        workspace, roots, limits, comments, binding, traversal.queue[0], page_size
+    )
+
+
+def parse_page_request(payload: dict[str, Any]) -> PageRequest:
+    if set(payload) != PAGE_REQUEST_KEYS or payload.get("action") != "page":
+        raise NotionAdapterError("Notion read request has an invalid action shape")
+    if payload.get("stream") != "site_tree":
+        raise NotionAdapterError("Notion stream is unsupported")
+    workspace = notion_id(payload.get("workspace_id"), "workspace ID")
+    roots = root_page_ids(payload.get("root_page_ids"))
+    limits = limits_value(payload.get("limits"))
+    comments = payload.get("include_comments")
+    if not isinstance(comments, bool):
+        raise NotionAdapterError("Notion comment collection policy must be boolean")
+    binding = _binding(workspace, roots, limits, comments)
+    if payload.get("binding") != binding:
+        raise NotionAdapterError("Notion request root binding is invalid")
+    page_size = bounded_integer(payload.get("page_size"), "page size", 1, 100)
+    return PageRequest(
+        workspace,
+        roots,
+        limits,
+        comments,
+        binding,
+        task_value(payload.get("task"), limits),
+        page_size,
+    )
+
+
+from _knowledge_social_notion_checkpoint import page_checkpoint, page_data, response_status

--- a/.agents/scripts/_knowledge_social_notion.py
+++ b/.agents/scripts/_knowledge_social_notion.py
@@ -134,20 +134,22 @@ def _cursor_value(value: Any) -> str | None:
     return value
 
 
-def task_value(value: Any, limits: Limits) -> Task:
-    if not isinstance(value, dict) or set(value) != TASK_KEYS:
-        raise NotionAdapterError("Notion traversal task has an invalid shape")
-    kind = value.get("kind")
-    if kind not in TASK_KINDS:
-        raise NotionAdapterError("Notion traversal task kind is unsupported")
-    depth = bounded_integer(value.get("depth"), "task depth", 0, limits.max_depth)
+def _task_parent_binding(value: dict[str, Any]) -> tuple[str | None, str | None]:
     parent_kind = value.get("parent_kind")
     if parent_kind not in {None, "page_id", "block_id", "database_id", "data_source_id"}:
         raise NotionAdapterError("Notion traversal parent kind is invalid")
     parent_id = _optional_id(value.get("parent_id"), "task parent ID")
     if (parent_kind is None) != (parent_id is None):
         raise NotionAdapterError("Notion traversal parent binding is incomplete")
-    database_id = _optional_id(value.get("database_id"), "task database ID")
+    return parent_kind, parent_id
+
+
+def _validate_task_binding(
+    kind: str,
+    parent_kind: str | None,
+    parent_id: str | None,
+    database_id: str | None,
+) -> None:
     if kind == "data_source" and (
         database_id is None
         or parent_kind != "database_id"
@@ -164,6 +166,18 @@ def task_value(value: Any, limits: Limits) -> Task:
         raise NotionAdapterError("Notion row task database binding is invalid")
     if parent_kind != "data_source_id" and kind != "data_source" and database_id is not None:
         raise NotionAdapterError("Notion traversal database binding is unexpected")
+
+
+def task_value(value: Any, limits: Limits) -> Task:
+    if not isinstance(value, dict) or set(value) != TASK_KEYS:
+        raise NotionAdapterError("Notion traversal task has an invalid shape")
+    kind = value.get("kind")
+    if kind not in TASK_KINDS:
+        raise NotionAdapterError("Notion traversal task kind is unsupported")
+    depth = bounded_integer(value.get("depth"), "task depth", 0, limits.max_depth)
+    parent_kind, parent_id = _task_parent_binding(value)
+    database_id = _optional_id(value.get("database_id"), "task database ID")
+    _validate_task_binding(kind, parent_kind, parent_id, database_id)
     return Task(
         kind,
         notion_id(value.get("resource_id"), "task resource ID"),

--- a/.agents/scripts/_knowledge_social_notion_checkpoint.py
+++ b/.agents/scripts/_knowledge_social_notion_checkpoint.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Validate Notion traversal results and advance durable queue checkpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from _knowledge_social_collect import CursorState, PageCheckpoint
+from _knowledge_social_notion_identity import NotionAdapterError
+from knowledge_social_import import reject_credentials
+
+
+def response_status(payload: dict[str, Any]) -> int:
+    status = payload.get("status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise NotionAdapterError("Notion response status must be an integer")
+    return status
+
+
+def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data", [])
+    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
+        raise NotionAdapterError("Notion page data must be an array")
+    return data
+
+
+def _nonnegative(meta: dict[str, Any], key: str) -> int:
+    value = meta.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise NotionAdapterError(f"Notion {key} metadata is invalid")
+    return value
+
+
+def _page_discovery_valid(current: Any, candidate: Any) -> bool:
+    return (
+        candidate.depth == current.depth
+        and candidate.resource_id == current.resource_id
+        and candidate.kind in {"blocks", "comments"}
+        and candidate.parent_kind is None
+    )
+
+
+def _block_discovery_valid(current: Any, candidate: Any) -> bool:
+    parent_valid = (
+        candidate.parent_kind == "block_id"
+        if candidate.kind == "comments"
+        else candidate.parent_kind in {"page_id", "block_id"}
+    )
+    return (
+        candidate.depth == current.depth + 1
+        and candidate.kind in {"blocks", "comments", "page", "database"}
+        and candidate.parent_id == current.resource_id
+        and parent_valid
+    )
+
+
+def _database_discovery_valid(current: Any, candidate: Any) -> bool:
+    return all(
+        (
+            candidate.depth == current.depth,
+            candidate.kind == "data_source",
+            candidate.parent_kind == "database_id",
+            candidate.database_id == current.resource_id,
+            candidate.parent_id == current.resource_id,
+        )
+    )
+
+
+def _data_source_discovery_valid(current: Any, candidate: Any) -> bool:
+    return all(
+        (
+            candidate.depth == current.depth + 1,
+            candidate.kind in {"blocks", "comments"},
+            candidate.parent_kind == "data_source_id",
+            candidate.parent_id == current.resource_id,
+            candidate.database_id == current.database_id,
+        )
+    )
+
+
+def _validate_discovery(current: Any, candidate: Any) -> None:
+    validators = {
+        "page": _page_discovery_valid,
+        "blocks": _block_discovery_valid,
+        "database": _database_discovery_valid,
+        "data_source": _data_source_discovery_valid,
+    }
+    validator = validators.get(current.kind)
+    if validator is None or not validator(current, candidate):
+        raise NotionAdapterError("Notion traversal attempted to escape its authorized descendants")
+
+
+def _metadata(payload: dict[str, Any], request: Any) -> tuple[Any, ...]:
+    from _knowledge_social_notion import _cursor_value, task_value
+
+    meta = payload.get("meta")
+    if not isinstance(meta, dict):
+        raise NotionAdapterError("Notion page metadata must be an object")
+    reject_credentials(meta)
+    if meta.get("request_sha256") != request.digest() or meta.get("task") != request.task.payload():
+        raise NotionAdapterError("Notion page provenance is invalid")
+    if meta.get("request_status", "complete") != "complete":
+        raise NotionAdapterError("Notion returned an incomplete result set")
+    limit_reason = meta.get("limit_reason")
+    if limit_reason is not None:
+        if limit_reason not in {"blocks", "bytes", "depth", "pages", "queue"}:
+            raise NotionAdapterError("Notion traversal limit reason is invalid")
+        raise NotionAdapterError(f"Notion {limit_reason} safety limit exhausted")
+    next_cursor = _cursor_value(meta.get("next_cursor"))
+    if next_cursor is not None and next_cursor == request.task.cursor:
+        raise NotionAdapterError("Notion pagination cursor did not advance")
+    discoveries_value = meta.get("discoveries", [])
+    if not isinstance(discoveries_value, list):
+        raise NotionAdapterError("Notion traversal discoveries are invalid")
+    discoveries = tuple(task_value(item, request.limits) for item in discoveries_value)
+    for candidate in discoveries:
+        _validate_discovery(request.task, candidate)
+    return (
+        next_cursor,
+        discoveries,
+        _nonnegative(meta, "page_count"),
+        _nonnegative(meta, "block_count"),
+        _nonnegative(meta, "response_bytes"),
+    )
+
+
+def _continued_task(request: Any, next_cursor: str) -> Any:
+    from _knowledge_social_notion import Task
+
+    task = request.task
+    return Task(
+        task.kind,
+        task.resource_id,
+        task.depth,
+        next_cursor,
+        task.parent_kind,
+        task.parent_id,
+        task.database_id,
+    )
+
+
+def _bounded_totals(traversal: Any, request: Any, counts: tuple[int, int, int]) -> tuple[int, int, int]:
+    total_pages = traversal.pages + counts[0]
+    total_blocks = traversal.blocks + counts[1]
+    total_bytes = traversal.response_bytes + counts[2]
+    if total_pages > request.limits.max_pages:
+        raise NotionAdapterError("Notion pages safety limit exhausted")
+    if total_blocks > request.limits.max_blocks:
+        raise NotionAdapterError("Notion blocks safety limit exhausted")
+    if total_bytes > request.limits.max_bytes:
+        raise NotionAdapterError("Notion bytes safety limit exhausted")
+    return total_pages, total_blocks, total_bytes
+
+
+def page_checkpoint(
+    payload: dict[str, Any], state: CursorState, request: Any
+) -> tuple[PageCheckpoint, bool]:
+    from _knowledge_social_notion import (
+        TraversalState,
+        _decode_state,
+        _encode_state,
+        _initial_state,
+    )
+
+    data = page_data(payload)
+    if len(data) > request.page_size:
+        raise NotionAdapterError("Notion response exceeds the configured page size")
+    traversal = (
+        _decode_state(state.cursor, request.binding, request.limits)
+        if state.cursor
+        else _initial_state(request.root_page_ids, request.limits)
+    )
+    if not traversal.queue or traversal.queue[0] != request.task:
+        raise NotionAdapterError("Notion response does not match the durable queue head")
+    next_cursor, discoveries, pages, blocks, response_bytes = _metadata(payload, request)
+    totals = _bounded_totals(traversal, request, (pages, blocks, response_bytes))
+    queue = list(traversal.queue[1:])
+    scheduled = set(traversal.scheduled)
+    if next_cursor is not None:
+        queue.insert(0, _continued_task(request, next_cursor))
+    for candidate in discoveries:
+        if candidate.key() not in scheduled:
+            queue.append(candidate)
+            scheduled.add(candidate.key())
+    maximum_tasks = request.limits.max_pages + request.limits.max_blocks * 3 + 100
+    if len(scheduled) > maximum_tasks:
+        raise NotionAdapterError("Notion queue safety limit exhausted")
+    next_state = TraversalState(tuple(queue), frozenset(scheduled), *totals)
+    complete = not next_state.queue
+    cursor = None if complete else _encode_state(next_state, request.binding)
+    return PageCheckpoint(cursor, request.binding), complete

--- a/.agents/scripts/_knowledge_social_notion_contract.py
+++ b/.agents/scripts/_knowledge_social_notion_contract.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Response validation and redaction for official Notion API reads."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from _knowledge_social_notion_files import file_descriptors, parent_value
+from _knowledge_social_notion_values import (
+    NotionReadProviderError,
+    list_value,
+    object_value,
+    optional_text,
+    plain_text,
+)
+
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class ApiResult:
+    status: int
+    payload: Any
+    response_bytes: int = 0
+    retry_after: int | None = None
+
+
+def observed_at() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def decode_json(payload: bytes) -> Any:
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise NotionReadProviderError("Notion JSON payload exceeds the safety limit")
+    try:
+        return json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise NotionReadProviderError("Notion JSON payload is invalid") from error
+
+
+def terminal_payload(result: ApiResult) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "observed_at": observed_at(),
+        "response_bytes": result.response_bytes,
+        "status": result.status,
+    }
+    if result.retry_after is not None:
+        payload["retry_after"] = result.retry_after
+    return payload

--- a/.agents/scripts/_knowledge_social_notion_files.py
+++ b/.agents/scripts/_knowledge_social_notion_files.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""URL-free Notion file metadata and authorized parent validation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from _knowledge_social_notion_identity import notion_id
+from _knowledge_social_notion_values import (
+    NotionReadProviderError,
+    object_value,
+    optional_text,
+)
+
+MAX_FILES_PER_RESPONSE = 1_000
+
+
+def _file_descriptor(value: dict[str, Any]) -> dict[str, Any] | None:
+    file_type = value.get("type")
+    if file_type == "file":
+        source = object_value(value.get("file"), "hosted file")
+        optional_text(source.get("url"), "hosted file URL", maximum=16 * 1024)
+        return {
+            "disposition": "metadata_only_not_fetched",
+            "expiry_time": optional_text(source.get("expiry_time"), "file expiry", maximum=128),
+            "kind": "notion_hosted",
+        }
+    if file_type == "external":
+        source = object_value(value.get("external"), "external file")
+        optional_text(source.get("url"), "external file URL", maximum=16 * 1024)
+        return {"disposition": "external_target_not_fetched", "kind": "external"}
+    if file_type == "file_upload":
+        source = object_value(value.get("file_upload"), "file upload")
+        return {
+            "disposition": "metadata_only_not_fetched",
+            "id": notion_id(source.get("id"), "file upload ID"),
+            "kind": "file_upload",
+        }
+    return None
+
+
+def _walk_files(value: Any, output: list[dict[str, Any]]) -> None:
+    if isinstance(value, dict):
+        descriptor = _file_descriptor(value)
+        if descriptor is not None:
+            output.append(descriptor)
+            return
+        for key, child in value.items():
+            if key not in {"url", "href", "public_url"}:
+                _walk_files(child, output)
+    elif isinstance(value, list):
+        for child in value:
+            _walk_files(child, output)
+
+
+def file_descriptors(value: Any) -> list[dict[str, Any]]:
+    """Return URL-free file metadata and reject credential-shaped source URLs."""
+    files: list[dict[str, Any]] = []
+    _walk_files(value, files)
+    if len(files) > MAX_FILES_PER_RESPONSE:
+        raise NotionReadProviderError("Notion response contains too many file references")
+    return files
+
+
+def parent_value(
+    value: Any,
+    expected_kind: str | None = None,
+    expected_id: str | None = None,
+    database_id: str | None = None,
+) -> dict[str, Any]:
+    parent = object_value(value, "parent")
+    kind = parent.get("type")
+    if kind == "workspace":
+        if parent.get("workspace") is not True:
+            raise NotionReadProviderError("Notion workspace parent is invalid")
+        normalized: dict[str, Any] = {"type": "workspace"}
+    elif kind in {"page_id", "block_id", "database_id", "data_source_id"}:
+        normalized = {"type": kind, kind: notion_id(parent.get(kind), f"{kind} parent")}
+        if kind == "data_source_id":
+            normalized["database_id"] = notion_id(
+                parent.get("database_id"), "data source parent database ID"
+            )
+    else:
+        raise NotionReadProviderError("Notion parent type is unsupported")
+    if expected_kind is not None and (
+        normalized.get("type") != expected_kind or normalized.get(expected_kind) != expected_id
+    ):
+        raise NotionReadProviderError("Notion response escaped the authorized parent binding")
+    if database_id is not None and normalized.get("database_id") != database_id:
+        raise NotionReadProviderError("Notion response database binding changed")
+    return normalized

--- a/.agents/scripts/_knowledge_social_notion_http.py
+++ b/.agents/scripts/_knowledge_social_notion_http.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Fixed-origin, redirect-free transport for allowlisted Notion reads."""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from _knowledge_social_notion import API_VERSION, PageRequest
+from _knowledge_social_notion_contract import (
+    ApiResult,
+    MAX_RESPONSE_BYTES,
+    NotionReadProviderError,
+    decode_json,
+)
+
+API_ORIGIN = "https://api.notion.com"
+HTTP_TIMEOUT_SECONDS = 60
+
+
+class Response(Protocol):
+    status: int
+
+    def __enter__(self) -> Response: ...
+    def __exit__(self, *args: Any) -> None: ...
+    def read(self, size: int = -1) -> bytes: ...
+
+
+class Opener(Protocol):
+    def open(self, request: Request, timeout: int) -> Response: ...
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    access_token: str
+    workspace_id: str
+    root_page_ids: tuple[str, ...]
+    include_comments: bool
+    max_depth: int
+    max_pages: int
+    max_blocks: int
+    max_bytes: int
+
+
+class _RejectRedirect(HTTPRedirectHandler):
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def http_opener() -> Opener:
+    exports = (Request, build_opener, urlencode, HTTPRedirectHandler)
+    if not all(callable(item) for item in exports):
+        raise NotionReadProviderError("Python urllib HTTP exports are unavailable")
+    return build_opener(_RejectRedirect())
+
+
+def _retry_epoch(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(seconds) or seconds < 0:
+        return None
+    return int(time.time() + math.ceil(seconds))
+
+
+def _headers(config: ProfileConfig) -> dict[str, str]:
+    return {
+        "Accept": "application/json",
+        "Authorization": f"Bearer {config.access_token}",
+        "Notion-Version": API_VERSION,
+        "User-Agent": "aidevops-notion-sites-knowledge/1",
+    }
+
+
+def _request(
+    config: ProfileConfig,
+    method: str,
+    path: str,
+    params: dict[str, str] | None = None,
+    body: dict[str, Any] | None = None,
+) -> Request:
+    query = f"?{urlencode(params)}" if params else ""
+    data = None
+    headers = _headers(config)
+    if body is not None:
+        data = json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    return Request(f"{API_ORIGIN}{path}{query}", data=data, headers=headers, method=method)
+
+
+def _read(response: Response) -> ApiResult:
+    status = getattr(response, "status", 200)
+    if isinstance(status, bool) or not isinstance(status, int):
+        raise NotionReadProviderError("Notion HTTP status is invalid")
+    payload = response.read(MAX_RESPONSE_BYTES + 1)
+    if not isinstance(payload, bytes):
+        raise NotionReadProviderError("Notion HTTP response is invalid")
+    decoded = decode_json(payload)
+    if not isinstance(decoded, (dict, list)):
+        raise NotionReadProviderError("Notion API response root must be an object or array")
+    return ApiResult(status, decoded, len(payload))
+
+
+def _error(error: HTTPError) -> ApiResult:
+    retry = error.headers.get("Retry-After") if error.headers is not None else None
+    return ApiResult(error.code, {}, 0, _retry_epoch(retry))
+
+
+def execute(config: ProfileConfig, opener: Opener, request: Request) -> ApiResult:
+    try:
+        with opener.open(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            return _read(response)
+    except HTTPError as error:
+        return _error(error)
+    except (TimeoutError, URLError, OSError) as error:
+        raise NotionReadProviderError("Notion read provider request failed") from error
+
+
+def identity_api(config: ProfileConfig, opener: Opener) -> ApiResult:
+    return execute(config, opener, _request(config, "GET", "/v1/users/me"))
+
+
+def task_api(config: ProfileConfig, opener: Opener, request: PageRequest) -> ApiResult:
+    """Execute only reviewed content-read routes; the sole POST is a query."""
+    task = request.task
+    cursor_params = {"page_size": str(request.page_size)}
+    if task.cursor is not None:
+        cursor_params["start_cursor"] = task.cursor
+    if task.kind == "page":
+        api_request = _request(config, "GET", f"/v1/pages/{task.resource_id}")
+    elif task.kind == "blocks":
+        api_request = _request(
+            config,
+            "GET",
+            f"/v1/blocks/{task.resource_id}/children",
+            cursor_params,
+        )
+    elif task.kind == "database":
+        api_request = _request(config, "GET", f"/v1/databases/{task.resource_id}")
+    elif task.kind == "comments":
+        api_request = _request(
+            config,
+            "GET",
+            "/v1/comments",
+            {"block_id": task.resource_id, **cursor_params},
+        )
+    elif task.kind == "data_source":
+        body: dict[str, Any] = {"page_size": request.page_size}
+        if task.cursor is not None:
+            body["start_cursor"] = task.cursor
+        api_request = _request(
+            config,
+            "POST",
+            f"/v1/data_sources/{task.resource_id}/query",
+            body=body,
+        )
+    else:
+        raise NotionReadProviderError("Notion API route is not allowlisted")
+    return execute(config, opener, api_request)

--- a/.agents/scripts/_knowledge_social_notion_identity.py
+++ b/.agents/scripts/_knowledge_social_notion_identity.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Stable identity primitives for authorized Notion workspace reads."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+
+class NotionAdapterError(ValueError):
+    """Raised when Notion evidence violates the local collection contract."""
+
+
+class NotionProviderUnavailableError(RuntimeError):
+    """Raised when the guarded Notion reader cannot execute safely."""
+
+
+def notion_id(value: Any, field: str) -> str:
+    """Return one canonical UUID without accepting URLs or arbitrary selectors."""
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise NotionAdapterError(f"Notion {field} must be a UUID")
+    try:
+        parsed = uuid.UUID(value)
+    except (AttributeError, ValueError) as error:
+        raise NotionAdapterError(f"Notion {field} must be a UUID") from error
+    return str(parsed)
+
+
+def root_page_ids(value: Any) -> tuple[str, ...]:
+    """Validate a small explicit root allowlist and reject duplicate aliases."""
+    if not isinstance(value, (list, tuple)) or not 1 <= len(value) <= 20:
+        raise NotionAdapterError("Notion requires between 1 and 20 root page IDs")
+    roots = tuple(notion_id(item, "root page ID") for item in value)
+    if len(roots) != len(set(roots)):
+        raise NotionAdapterError("Notion root page IDs must be unique")
+    return roots
+
+
+def bounded_integer(
+    value: Any, field: str, minimum: int, maximum: int
+) -> int:
+    """Validate one explicit traversal budget."""
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < minimum
+        or value > maximum
+    ):
+        raise NotionAdapterError(
+            f"Notion {field} must be between {minimum} and {maximum}"
+        )
+    return value

--- a/.agents/scripts/_knowledge_social_notion_normalize.py
+++ b/.agents/scripts/_knowledge_social_notion_normalize.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize root-bound Notion observations into neutral evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from _knowledge_social_notion import PROVIDER, RETENTION_LIMIT, page_data
+from _knowledge_social_notion_identity import NotionAdapterError, notion_id
+from knowledge_social_import import reject_credentials
+
+PROVENANCE = "notion_public_api_2026_03_11_explicit_roots"
+FIXED_COVERAGE = (
+    (
+        "resolved_comments",
+        "unavailable",
+        "public_api_lists_only_open_unresolved_comments",
+    ),
+    (
+        "file_bytes",
+        "unavailable",
+        "signed_and_external_file_targets_are_never_fetched",
+    ),
+    (
+        "external_embeds",
+        "unavailable",
+        "external_embed_and_bookmark_targets_are_never_fetched",
+    ),
+    (
+        "workspace_search",
+        "unavailable",
+        "title_search_is_not_an_authorized_or_exhaustive_inventory_route",
+    ),
+    (
+        "notion_site_metadata",
+        "unavailable",
+        "public_site_url_is_not_an_account_api_or_authority_grant",
+    ),
+    (
+        "workspace_export",
+        "unavailable",
+        "owner_or_enterprise_admin_export_is_a_separate_import_route",
+    ),
+)
+
+
+@dataclass(frozen=True)
+class PageContext:
+    connection_id: str
+    account: dict[str, Any]
+    stream: str
+    enabled_streams: tuple[str, ...]
+    policy: dict[str, Any]
+
+
+def _observed_at(payload: dict[str, Any]) -> str:
+    value = payload.get("observed_at")
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise NotionAdapterError("Notion page observed_at must be text")
+    return value
+
+
+def _optional_text(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value:
+        raise NotionAdapterError(f"Notion normalized {field} must be text")
+    return value
+
+
+def _remote_id(kind: str, value: Any) -> str:
+    return f"notion_{kind}_{notion_id(value, f'{kind} ID').replace('-', '')}"
+
+
+def _object(record: dict[str, Any], context: PageContext, observed_at: str) -> dict[str, Any]:
+    kind = record.get("kind")
+    if kind not in {"page", "block", "database", "comment"}:
+        raise NotionAdapterError("Notion normalized object kind is invalid")
+    text = _optional_text(record.get("text"), "object text")
+    provider_json = {
+        "record": record,
+        "root_page_ids": context.account.get("root_page_ids"),
+        "source": PROVENANCE,
+        "workspace_id": context.account.get("workspace_id"),
+    }
+    reject_credentials(provider_json)
+    return {
+        "account_remote_id": notion_id(
+            context.account.get("workspace_id"), "workspace ID"
+        ),
+        "created_at": _optional_text(record.get("created_at"), "creation time"),
+        "evidence_class": "authorized_integration_content",
+        "object_type": kind,
+        "observed_at": observed_at,
+        "provider_json": provider_json,
+        "remote_id": _remote_id(kind, record.get("id")),
+        "text": text,
+    }
+
+
+def _coverage(observed_at: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "cursor_exhausted": False,
+            "earliest_at": None,
+            "latest_at": None,
+            "observed_at": observed_at,
+            "retention_limit": RETENTION_LIMIT,
+            "status": status,
+            "stream": stream,
+            "unavailable_reason": reason,
+        }
+        for stream, status, reason in FIXED_COVERAGE
+    ]
+
+
+def normalize_page(payload: dict[str, Any], context: PageContext) -> dict[str, Any]:
+    reject_credentials(payload)
+    observed_at = _observed_at(payload)
+    workspace = notion_id(context.account.get("workspace_id"), "workspace ID")
+    if notion_id(context.account.get("id"), "account ID") != workspace:
+        raise NotionAdapterError("Notion workspace identity binding is invalid")
+    records = page_data(payload)
+    policy = dict(context.policy)
+    policy.update(
+        {
+            "notion_api_version": "2026-03-11",
+            "notion_authority": "integration_workspace_plus_explicit_root_page_ids",
+            "notion_comments": "unresolved_only_when_profile_capability_is_enabled",
+            "notion_files": "metadata_only_no_remote_fetch",
+            "notion_pagination": "opaque_cursor_with_durable_bounded_queue",
+            "notion_search": "disabled",
+        }
+    )
+    archive = {
+        "accounts": [
+            {
+                "display_name": _optional_text(
+                    context.account.get("workspace_name"), "workspace name"
+                ),
+                "handle": None,
+                "observed_at": observed_at,
+                "provider_json": {
+                    "bot_id": context.account.get("bot_id"),
+                    "owner_type": context.account.get("owner_type"),
+                    "root_page_ids": context.account.get("root_page_ids"),
+                    "source": PROVENANCE,
+                },
+                "remote_id": workspace,
+            }
+        ],
+        "activities": [],
+        "connection_id": context.connection_id,
+        "coverage": _coverage(observed_at),
+        "enabled_streams": list(context.enabled_streams),
+        "exported_at": observed_at,
+        "media": [],
+        "objects": [_object(record, context, observed_at) for record in records],
+        "policy": policy,
+        "provider": PROVIDER,
+        "remote_account_id": workspace,
+    }
+    reject_credentials(archive)
+    return archive

--- a/.agents/scripts/_knowledge_social_notion_provider.py
+++ b/.agents/scripts/_knowledge_social_notion_provider.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Root-bound official Notion API reader subprocess."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import Any
+
+from _knowledge_social_notion import Limits, PageRequest, parse_page_request
+from _knowledge_social_notion_contract import (
+    ApiResult,
+    NotionReadProviderError,
+    object_value,
+    observed_at,
+    optional_text,
+    terminal_payload,
+)
+from _knowledge_social_notion_http import (
+    Opener,
+    ProfileConfig,
+    http_opener,
+    identity_api,
+    task_api,
+)
+from _knowledge_social_notion_identity import (
+    NotionAdapterError,
+    bounded_integer,
+    notion_id,
+    root_page_ids,
+)
+from _knowledge_social_notion_result import _handle_result
+from knowledge_social_import import reject_credentials
+
+MAX_REQUEST_BYTES = 128 * 1024
+MAX_OUTPUT_BYTES = 8 * 1024 * 1024
+PROFILE_DEFAULTS = {
+    "MAX_BLOCKS": 5_000,
+    "MAX_BYTES": 16 * 1024 * 1024,
+    "MAX_DEPTH": 8,
+    "MAX_PAGES": 500,
+}
+
+
+def _required(name: str) -> str:
+    value = os.environ.get(name)
+    if not value or "\x00" in value or "\n" in value or "\r" in value:
+        raise NotionReadProviderError("Notion profile configuration is incomplete")
+    return value
+
+
+def _profile_integer(prefix: str, suffix: str, minimum: int, maximum: int) -> int:
+    raw = os.environ.get(f"{prefix}_{suffix}")
+    if raw is None:
+        value = PROFILE_DEFAULTS[suffix]
+    else:
+        try:
+            value = int(raw)
+        except ValueError as error:
+            raise NotionReadProviderError("Notion profile limit is invalid") from error
+    try:
+        return bounded_integer(value, suffix.lower().replace("_", " "), minimum, maximum)
+    except NotionAdapterError as error:
+        raise NotionReadProviderError(str(error)) from error
+
+
+def _profile(profile: str) -> ProfileConfig:
+    prefix = f"NOTION_{profile.upper()}"
+    try:
+        workspace = notion_id(_required(f"{prefix}_WORKSPACE_ID"), "profile workspace ID")
+        roots = root_page_ids(
+            [item.strip() for item in _required(f"{prefix}_ROOT_PAGE_IDS").split(",")]
+        )
+    except NotionAdapterError as error:
+        raise NotionReadProviderError(str(error)) from error
+    comments_raw = os.environ.get(f"{prefix}_INCLUDE_COMMENTS", "false").lower()
+    if comments_raw not in {"true", "false"}:
+        raise NotionReadProviderError("Notion comment collection policy is invalid")
+    return ProfileConfig(
+        _required(f"{prefix}_ACCESS_TOKEN"),
+        workspace,
+        roots,
+        comments_raw == "true",
+        _profile_integer(prefix, "MAX_DEPTH", 0, 20),
+        _profile_integer(prefix, "MAX_PAGES", 1, 10_000),
+        _profile_integer(prefix, "MAX_BLOCKS", 1, 100_000),
+        _profile_integer(prefix, "MAX_BYTES", 65_536, 268_435_456),
+    )
+
+
+def _identity_data(result: ApiResult, config: ProfileConfig, expected_id: str) -> dict[str, Any]:
+    payload = object_value(result.payload, "identity response")
+    if payload.get("object") != "user" or payload.get("type") != "bot":
+        raise NotionReadProviderError("Notion profile must identify an integration bot")
+    bot = object_value(payload.get("bot"), "bot identity")
+    workspace = notion_id(bot.get("workspace_id"), "returned workspace ID")
+    if workspace != config.workspace_id or workspace != notion_id(expected_id, "expected workspace ID"):
+        raise NotionReadProviderError("Notion workspace identity does not match the connection")
+    owner = object_value(bot.get("owner"), "bot owner")
+    owner_type = owner.get("type")
+    if owner_type not in {"user", "workspace"}:
+        raise NotionReadProviderError("Notion bot owner type is invalid")
+    return {
+        "api_version": "2026-03-11",
+        "bot_id": notion_id(payload.get("id"), "bot user ID"),
+        "id": workspace,
+        "include_comments": config.include_comments,
+        "limits": {
+            "max_blocks": config.max_blocks,
+            "max_bytes": config.max_bytes,
+            "max_depth": config.max_depth,
+            "max_pages": config.max_pages,
+        },
+        "owner_type": owner_type,
+        "response_bytes": result.response_bytes,
+        "root_page_ids": list(config.root_page_ids),
+        "workspace_id": workspace,
+        "workspace_name": optional_text(bot.get("workspace_name"), "workspace name"),
+    }
+
+
+def _identity(opener: Opener, config: ProfileConfig, expected_id: str) -> dict[str, Any]:
+    result = identity_api(config, opener)
+    if result.status != 200:
+        return terminal_payload(result)
+    return {
+        "data": _identity_data(result, config, expected_id),
+        "observed_at": observed_at(),
+        "status": 200,
+    }
+
+
+def _profile_matches(request: PageRequest, config: ProfileConfig) -> None:
+    expected_limits = Limits(
+        config.max_depth, config.max_pages, config.max_blocks, config.max_bytes
+    )
+    if (
+        request.workspace_id != config.workspace_id
+        or request.root_page_ids != config.root_page_ids
+        or request.include_comments != config.include_comments
+        or request.limits != expected_limits
+    ):
+        raise NotionReadProviderError("Notion request does not match the secret profile binding")
+
+
+def _pace() -> None:
+    if os.environ.get("AIDEVOPS_TEST_MODE") != "1":
+        time.sleep(0.35)
+
+
+def _page(opener: Opener, config: ProfileConfig, request: PageRequest) -> dict[str, Any]:
+    _profile_matches(request, config)
+    identity = identity_api(config, opener)
+    if identity.status != 200:
+        return terminal_payload(identity)
+    _identity_data(identity, config, request.workspace_id)
+    _pace()
+    result = task_api(config, opener, request)
+    if result.status != 200:
+        terminal = terminal_payload(result)
+        terminal["response_bytes"] += identity.response_bytes
+        return terminal
+    payload = _handle_result(result, request)
+    payload["meta"]["response_bytes"] += identity.response_bytes
+    reject_credentials(payload)
+    _pace()
+    return payload
+
+
+def _request_object() -> dict[str, Any]:
+    raw = sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1)
+    if len(raw) > MAX_REQUEST_BYTES:
+        raise NotionReadProviderError("Notion read request exceeds the safety limit")
+    try:
+        payload = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise NotionReadProviderError("Notion read request is invalid") from error
+    if not isinstance(payload, dict):
+        raise NotionReadProviderError("Notion read request root must be an object")
+    return payload
+
+
+def _dispatch(request: dict[str, Any], opener: Opener, config: ProfileConfig) -> dict[str, Any]:
+    action = request.get("action")
+    if action == "identity":
+        if set(request) != {"action", "account_id"}:
+            raise NotionReadProviderError("Notion identity request shape is invalid")
+        return _identity(opener, config, notion_id(request.get("account_id"), "workspace ID"))
+    if action != "page":
+        raise NotionReadProviderError("Notion read action is unsupported")
+    return _page(opener, config, parse_page_request(request))
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode("utf-8")) > MAX_OUTPUT_BYTES:
+        raise NotionReadProviderError("Notion read response exceeds the safety limit")
+    print(encoded)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        _emit(_dispatch(_request_object(), http_opener(), _profile(args.profile)))
+        return 0
+    except (NotionAdapterError, NotionReadProviderError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except Exception:  # noqa: BLE001 - redact provider and credential internals
+        print("ERROR: Notion read provider request failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/_knowledge_social_notion_reader.py
+++ b/.agents/scripts/_knowledge_social_notion_reader.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Guarded live and deterministic fixture readers for Notion Sites."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+from _knowledge_social_fixture import FixturePageReader
+from _knowledge_social_notion import (
+    API_VERSION,
+    PageRequest,
+    limits_value,
+)
+from _knowledge_social_notion_identity import (
+    NotionAdapterError,
+    NotionProviderUnavailableError,
+    notion_id,
+    root_page_ids,
+)
+from _knowledge_social_oauth_reader import GuardedOAuthPolicy, GuardedOAuthReader
+from knowledge_social_import import reject_credentials
+
+READ_TIMEOUT_SECONDS = 120
+MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+SAFE_PROVIDER_FAILURES = (
+    "Python urllib HTTP exports are unavailable",
+    "Notion profile configuration is incomplete",
+    "Notion profile limit is invalid",
+    "Notion comment collection policy is invalid",
+    "Notion profile must identify an integration bot",
+    "Notion workspace identity does not match the connection",
+    "Notion request does not match the secret profile binding",
+    "Notion response escaped the authorized parent binding",
+    "Notion read provider request failed",
+)
+
+
+class NotionReader(Protocol):
+    def identity(self, expected_id: str) -> dict[str, Any]: ...
+    def page(self, request: PageRequest) -> dict[str, Any]: ...
+
+
+def _decode_output(output: str) -> dict[str, Any]:
+    if len(output.encode("utf-8")) > MAX_RESPONSE_BYTES:
+        raise NotionAdapterError("Notion read response exceeds the safety limit")
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise NotionAdapterError("Notion read provider returned no valid JSON") from error
+    if not isinstance(payload, dict):
+        raise NotionAdapterError("Notion read response root must be an object")
+    return payload
+
+
+def _provider_failure(stderr: str) -> NotionProviderUnavailableError:
+    for message in SAFE_PROVIDER_FAILURES:
+        if f"ERROR: {message}" in stderr:
+            return NotionProviderUnavailableError(message)
+    return NotionProviderUnavailableError("Notion read provider is unavailable")
+
+
+NOTION_READER_POLICY = GuardedOAuthPolicy(
+    "Notion",
+    "NOTION",
+    "NOTION_READ_LOG",
+    READ_TIMEOUT_SECONDS,
+    _decode_output,
+    _provider_failure,
+    NotionProviderUnavailableError,
+    (
+        "ACCESS_TOKEN",
+        "WORKSPACE_ID",
+        "ROOT_PAGE_IDS",
+        "INCLUDE_COMMENTS",
+        "MAX_DEPTH",
+        "MAX_PAGES",
+        "MAX_BLOCKS",
+        "MAX_BYTES",
+    ),
+    "",
+)
+
+
+class GuardedNotion(GuardedOAuthReader):
+    """Execute only the fixed official API reader with a filtered profile."""
+
+    def __init__(self, helper: Path, profile: str) -> None:
+        super().__init__(helper, profile, NOTION_READER_POLICY)
+
+
+class FixtureNotion(FixturePageReader):
+    """Deterministic substitute for queue, pagination, and failure tests."""
+
+    def __init__(self, path: Path) -> None:
+        super().__init__(path, "Notion", NotionAdapterError)
+
+
+def _optional_name(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise NotionAdapterError("Notion workspace name is invalid")
+    if len(value.encode("utf-8")) > 512:
+        raise NotionAdapterError("Notion workspace name exceeds the safety limit")
+    return value
+
+
+def verified_identity(payload: dict[str, Any], expected_id: str) -> dict[str, Any]:
+    """Bind one bot, workspace, explicit root allowlist, and traversal policy."""
+    reject_credentials(payload)
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise NotionAdapterError("Notion identity response returned no account")
+    workspace = notion_id(data.get("workspace_id"), "workspace ID")
+    if workspace != notion_id(expected_id, "expected workspace ID"):
+        raise NotionAdapterError(
+            "Notion workspace identity does not match the configured connection"
+        )
+    if data.get("api_version") != API_VERSION:
+        raise NotionAdapterError("Notion API version does not match the reviewed contract")
+    owner_type = data.get("owner_type")
+    if owner_type not in {"user", "workspace"}:
+        raise NotionAdapterError("Notion bot owner type is invalid")
+    comments = data.get("include_comments")
+    if not isinstance(comments, bool):
+        raise NotionAdapterError("Notion comment collection policy must be boolean")
+    response_bytes = data.get("response_bytes", 0)
+    if (
+        isinstance(response_bytes, bool)
+        or not isinstance(response_bytes, int)
+        or response_bytes < 0
+        or response_bytes > MAX_RESPONSE_BYTES
+    ):
+        raise NotionAdapterError("Notion identity byte count is invalid")
+    return {
+        "bot_id": notion_id(data.get("bot_id"), "bot user ID"),
+        "id": workspace,
+        "include_comments": comments,
+        "limits": limits_value(data.get("limits")).payload(),
+        "owner_type": owner_type,
+        "root_page_ids": list(root_page_ids(data.get("root_page_ids"))),
+        "workspace_id": workspace,
+        "workspace_name": _optional_name(data.get("workspace_name")),
+    }

--- a/.agents/scripts/_knowledge_social_notion_records.py
+++ b/.agents/scripts/_knowledge_social_notion_records.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Normalize root-bound Notion pages, blocks, databases, rows, and comments."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from _knowledge_social_notion import PageRequest, Task
+from _knowledge_social_notion_contract import (
+    NotionReadProviderError,
+    file_descriptors,
+    list_value,
+    object_value,
+    optional_text,
+    parent_value,
+    plain_text,
+)
+from _knowledge_social_notion_identity import notion_id
+
+
+def record_page(value: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    task = request.task
+    page_id = notion_id(value.get("id"), "page ID")
+    if value.get("object") != "page" or page_id != task.resource_id:
+        raise NotionReadProviderError("Notion page response does not match the requested page")
+    if task.parent_kind is not None:
+        parent = parent_value(value.get("parent"), task.parent_kind, task.parent_id, task.database_id)
+    else:
+        if page_id not in request.root_page_ids:
+            raise NotionReadProviderError("Notion page is not an authorized root")
+        parent = parent_value(value.get("parent"))
+    properties = object_value(value.get("properties", {}), "page properties")
+    return {
+        "created_at": optional_text(value.get("created_time"), "page creation time", maximum=128),
+        "files": file_descriptors(value),
+        "id": page_id,
+        "in_trash": value.get("in_trash") is True,
+        "kind": "page",
+        "last_edited_at": optional_text(value.get("last_edited_time"), "page edit time", maximum=128),
+        "parent": parent,
+        "published": value.get("public_url") is not None,
+        "text": plain_text(properties),
+    }
+
+
+def page_discoveries(request: PageRequest) -> list[Task]:
+    task = request.task
+    discoveries = [Task("blocks", task.resource_id, task.depth)]
+    if request.include_comments:
+        discoveries.append(Task("comments", task.resource_id, task.depth))
+    return discoveries
+
+
+def _child_task(block_type: str, block_id: str, request: PageRequest, parent: dict[str, Any]) -> Task:
+    task = request.task
+    depth = task.depth + 1
+    if block_type == "child_page":
+        return Task("page", block_id, depth, parent_kind=parent["type"], parent_id=task.resource_id)
+    if block_type == "child_database":
+        return Task("database", block_id, depth, parent_kind=parent["type"], parent_id=task.resource_id)
+    return Task("blocks", block_id, depth, parent_kind=parent["type"], parent_id=task.resource_id)
+
+
+def block_record(
+    value: dict[str, Any], request: PageRequest
+) -> tuple[dict[str, Any], list[Task], str | None]:
+    task = request.task
+    if value.get("object") != "block":
+        raise NotionReadProviderError("Notion child response contains a non-block object")
+    block_id = notion_id(value.get("id"), "block ID")
+    parent = parent_value(value.get("parent"))
+    if parent.get(parent.get("type")) != task.resource_id:
+        raise NotionReadProviderError("Notion child block escaped the requested parent")
+    block_type = value.get("type")
+    if not isinstance(block_type, str) or not block_type or "\x00" in block_type:
+        raise NotionReadProviderError("Notion block type is invalid")
+    body = value.get(block_type, {})
+    record = {
+        "block_type": block_type,
+        "created_at": optional_text(value.get("created_time"), "block creation time", maximum=128),
+        "external_target_not_fetched": block_type in {"bookmark", "embed", "link_preview"},
+        "files": file_descriptors(body),
+        "id": block_id,
+        "in_trash": value.get("in_trash") is True,
+        "kind": "block",
+        "last_edited_at": optional_text(value.get("last_edited_time"), "block edit time", maximum=128),
+        "parent": parent,
+        "text": plain_text(body),
+    }
+    discoveries: list[Task] = []
+    needs_depth = block_type in {"child_page", "child_database"} or value.get("has_children") is True
+    if needs_depth and task.depth >= request.limits.max_depth:
+        return record, discoveries, "depth"
+    if needs_depth:
+        synced = block_type == "synced_block" and isinstance(body, dict) and body.get("synced_from") is not None
+        if synced:
+            record["synced_external_target_not_followed"] = True
+        else:
+            discoveries.append(_child_task(block_type, block_id, request, parent))
+    if request.include_comments:
+        discoveries.append(
+            Task("comments", block_id, task.depth + 1, parent_kind="block_id", parent_id=task.resource_id)
+        )
+    return record, discoveries, None
+
+
+def database_record(value: dict[str, Any], request: PageRequest) -> tuple[dict[str, Any], list[Task]]:
+    task = request.task
+    database_id = notion_id(value.get("id"), "database ID")
+    if value.get("object") != "database" or database_id != task.resource_id:
+        raise NotionReadProviderError("Notion database response does not match the request")
+    parent = parent_value(value.get("parent"), task.parent_kind, task.parent_id)
+    sources = list_value(value.get("data_sources", []), "database data sources", 100)
+    discoveries = [
+        Task(
+            "data_source",
+            notion_id(source.get("id"), "data source ID"),
+            task.depth,
+            parent_kind="database_id",
+            parent_id=database_id,
+            database_id=database_id,
+        )
+        for source in sources
+    ]
+    return (
+        {
+            "files": file_descriptors(value),
+            "id": database_id,
+            "kind": "database",
+            "parent": parent,
+            "text": plain_text(value.get("title", [])),
+        },
+        discoveries,
+    )
+
+
+def row_record(value: dict[str, Any], request: PageRequest) -> tuple[dict[str, Any], list[Task]]:
+    task = request.task
+    if value.get("object") != "page":
+        raise NotionReadProviderError("Notion data source returned an unsupported child")
+    row_id = notion_id(value.get("id"), "data source row page ID")
+    parent = parent_value(value.get("parent"), "data_source_id", task.resource_id, task.database_id)
+    properties = object_value(value.get("properties", {}), "row page properties")
+    discoveries = [
+        Task(
+            "blocks",
+            row_id,
+            task.depth + 1,
+            parent_kind="data_source_id",
+            parent_id=task.resource_id,
+            database_id=task.database_id,
+        )
+    ]
+    if request.include_comments:
+        discoveries.append(
+            Task(
+                "comments",
+                row_id,
+                task.depth + 1,
+                parent_kind="data_source_id",
+                parent_id=task.resource_id,
+                database_id=task.database_id,
+            )
+        )
+    return (
+        {
+            "created_at": optional_text(value.get("created_time"), "row creation time", maximum=128),
+            "files": file_descriptors(value),
+            "id": row_id,
+            "kind": "page",
+            "parent": parent,
+            "published": value.get("public_url") is not None,
+            "text": plain_text(properties),
+        },
+        discoveries,
+    )
+
+
+def comment_record(value: dict[str, Any], request: PageRequest) -> dict[str, Any]:
+    if value.get("object") != "comment":
+        raise NotionReadProviderError("Notion comment response contains a non-comment object")
+    parent = parent_value(value.get("parent"))
+    if parent.get(parent.get("type")) != request.task.resource_id:
+        raise NotionReadProviderError("Notion comment escaped the requested resource")
+    creator = object_value(value.get("created_by"), "comment creator")
+    return {
+        "created_at": optional_text(value.get("created_time"), "comment creation time", maximum=128),
+        "created_by": notion_id(creator.get("id"), "comment creator ID"),
+        "discussion_id": notion_id(value.get("discussion_id"), "discussion ID"),
+        "files": file_descriptors(value.get("attachments", [])),
+        "id": notion_id(value.get("id"), "comment ID"),
+        "kind": "comment",
+        "parent": parent,
+        "text": plain_text(value.get("rich_text", [])),
+    }

--- a/.agents/scripts/_knowledge_social_notion_result.py
+++ b/.agents/scripts/_knowledge_social_notion_result.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Build bounded provider responses from validated Notion API results."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from _knowledge_social_notion import PageRequest, Task
+from _knowledge_social_notion_contract import (
+    ApiResult,
+    NotionReadProviderError,
+    list_value,
+    object_value,
+    observed_at,
+    optional_text,
+)
+from _knowledge_social_notion_records import (
+    block_record,
+    comment_record,
+    database_record,
+    page_discoveries,
+    record_page,
+    row_record,
+)
+
+
+def _list_response(
+    result: ApiResult, request: PageRequest
+) -> tuple[list[dict[str, Any]], str | None, str]:
+    payload = object_value(result.payload, "list response")
+    if payload.get("object") != "list":
+        raise NotionReadProviderError("Notion paginated response is not a list")
+    records = list_value(payload.get("results"), "paginated results", request.page_size)
+    has_more = payload.get("has_more")
+    if not isinstance(has_more, bool):
+        raise NotionReadProviderError("Notion pagination flag is invalid")
+    next_cursor = payload.get("next_cursor")
+    if has_more:
+        next_cursor = optional_text(next_cursor, "next cursor", maximum=4096)
+        if not next_cursor:
+            raise NotionReadProviderError("Notion pagination cursor is missing")
+    elif next_cursor is not None:
+        raise NotionReadProviderError("Notion terminal page unexpectedly returned a cursor")
+    status = object_value(payload.get("request_status", {"type": "complete"}), "request status")
+    status_type = status.get("type")
+    if status_type not in {"complete", "incomplete"}:
+        raise NotionReadProviderError("Notion request status is invalid")
+    return records, next_cursor, status_type
+
+
+def _block_result(result: ApiResult, request: PageRequest) -> tuple[Any, ...]:
+    raw_records, next_cursor, request_status = _list_response(result, request)
+    records = []
+    discoveries: list[Task] = []
+    limit_reason = None
+    for raw in raw_records:
+        record, found, current_limit = block_record(raw, request)
+        records.append(record)
+        discoveries.extend(found)
+        limit_reason = limit_reason or current_limit
+    return records, discoveries, next_cursor, request_status, limit_reason, 0, len(records)
+
+
+def _row_result(result: ApiResult, request: PageRequest) -> tuple[Any, ...]:
+    raw_records, next_cursor, request_status = _list_response(result, request)
+    records = []
+    discoveries: list[Task] = []
+    for raw in raw_records:
+        record, found = row_record(raw, request)
+        records.append(record)
+        discoveries.extend(found)
+    return records, discoveries, next_cursor, request_status, None, len(records), 0
+
+
+def _comment_result(result: ApiResult, request: PageRequest) -> tuple[Any, ...]:
+    raw_records, next_cursor, request_status = _list_response(result, request)
+    records = [comment_record(raw, request) for raw in raw_records]
+    return records, [], next_cursor, request_status, None, 0, 0
+
+
+def _result_parts(result: ApiResult, request: PageRequest) -> tuple[Any, ...]:
+    task = request.task
+    if task.kind == "page":
+        raw = object_value(result.payload, "page response")
+        return [record_page(raw, request)], page_discoveries(request), None, "complete", None, 1, 0
+    if task.kind == "blocks":
+        return _block_result(result, request)
+    if task.kind == "database":
+        raw = object_value(result.payload, "database response")
+        record, discoveries = database_record(raw, request)
+        return [record], discoveries, None, "complete", None, 0, 0
+    if task.kind == "data_source":
+        return _row_result(result, request)
+    return _comment_result(result, request)
+
+
+def _handle_result(result: ApiResult, request: PageRequest) -> dict[str, Any]:
+    records, discoveries, next_cursor, request_status, limit_reason, pages, blocks = (
+        _result_parts(result, request)
+    )
+    if pages > request.limits.max_pages:
+        limit_reason = "pages"
+    if blocks > request.limits.max_blocks:
+        limit_reason = "blocks"
+    return {
+        "data": records,
+        "meta": {
+            "block_count": blocks,
+            "discoveries": [task.payload() for task in discoveries],
+            "limit_reason": limit_reason,
+            "next_cursor": next_cursor,
+            "page_count": pages,
+            "request_sha256": request.digest(),
+            "request_status": request_status,
+            "response_bytes": result.response_bytes,
+            "task": request.task.payload(),
+        },
+        "observed_at": observed_at(),
+        "status": 200,
+    }

--- a/.agents/scripts/_knowledge_social_notion_values.py
+++ b/.agents/scripts/_knowledge_social_notion_values.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Bounded scalar, object, list, and rendered-text validation for Notion."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+MAX_TEXT_BYTES = 512 * 1024
+CREDENTIAL_VALUE = re.compile(
+    r"(?i)(?:^|[?&;\s])(?:access[_-]?token|api[_-]?key|authorization|"
+    r"client[_-]?secret|password|secret|session[_-]?token)\s*[=:]\s*[^\s&;]{4,}"
+)
+JWT_VALUE = re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b")
+
+
+class NotionReadProviderError(RuntimeError):
+    """Raised for a privacy-safe local Notion provider failure."""
+
+
+def object_value(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise NotionReadProviderError(f"Notion {field} must be an object")
+    return value
+
+
+def list_value(value: Any, field: str, limit: int) -> list[dict[str, Any]]:
+    if (
+        not isinstance(value, list)
+        or len(value) > limit
+        or any(not isinstance(item, dict) for item in value)
+    ):
+        raise NotionReadProviderError(f"Notion {field} must be a bounded object array")
+    return value
+
+
+def optional_text(value: Any, field: str, *, maximum: int = MAX_TEXT_BYTES) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or "\x00" in value:
+        raise NotionReadProviderError(f"Notion {field} must be text")
+    if len(value.encode("utf-8")) > maximum:
+        raise NotionReadProviderError(f"Notion {field} exceeds the text safety limit")
+    if CREDENTIAL_VALUE.search(value) or JWT_VALUE.search(value):
+        raise NotionReadProviderError("Notion response contains credential-shaped text")
+    return value
+
+
+def _walk_text(value: Any, output: list[str]) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key == "plain_text":
+                text = optional_text(child, "rich text")
+                if text:
+                    output.append(text)
+            elif key not in {"url", "href", "public_url"}:
+                _walk_text(child, output)
+    elif isinstance(value, list):
+        for child in value:
+            _walk_text(child, output)
+
+
+def plain_text(value: Any) -> str | None:
+    """Extract only provider-rendered plain text, never links or HTML."""
+    pieces: list[str] = []
+    _walk_text(value, pieces)
+    rendered = "\n".join(piece for piece in pieces if piece).strip()
+    if not rendered:
+        return None
+    if len(rendered.encode("utf-8")) > MAX_TEXT_BYTES:
+        raise NotionReadProviderError("Notion rendered text exceeds the safety limit")
+    return rendered

--- a/.agents/scripts/knowledge_social_notion.py
+++ b/.agents/scripts/knowledge_social_notion.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Collect a bounded authorized Notion root tree into a social corpus."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import _knowledge_social_notion as notion
+from _knowledge_social_notion_normalize import PageContext, normalize_page
+from _knowledge_social_notion_reader import (
+    FixtureNotion,
+    GuardedNotion,
+    verified_identity,
+)
+from _knowledge_social_oauth_collector import OAuthCollectorPolicy, run_oauth_collector
+
+COLLECTOR_OPTIONS = {
+    "budget_unit": "request",
+    "default_budget": 21,
+    "display_name": "Notion",
+    "fixture_reader": FixtureNotion,
+    "helper": Path(__file__).with_name("_knowledge_social_notion_provider.py"),
+    "live_reader": GuardedNotion,
+    "max_page_size": 100,
+    "normalize_page": normalize_page,
+    "page_context": PageContext,
+    "provider_module": notion,
+    "verified_identity": verified_identity,
+}
+
+
+def main() -> int:
+    return run_oauth_collector(OAuthCollectorPolicy(**COLLECTOR_OPTIONS), __doc__ or "")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/knowledge_social_registry.py
+++ b/.agents/scripts/knowledge_social_registry.py
@@ -66,6 +66,12 @@ PROVIDER_SPECS = (
     ProviderSpec("mastodon", (), "knowledge_social_mastodon.py", (("live", ()),)),
     ProviderSpec("miniflux", (), "knowledge_social_miniflux.py", (("live", ()),)),
     ProviderSpec(
+        "notion-sites",
+        ("notion",),
+        "knowledge_social_notion.py",
+        (("live", ()),),
+    ),
+    ProviderSpec(
         "readwise-reader",
         ("reader",),
         "knowledge_social_readwise_reader.py",

--- a/.agents/tests/test-knowledge-social-notion.sh
+++ b/.agents/tests/test-knowledge-social-notion.sh
@@ -1,0 +1,1142 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-knowledge-social-notion.sh — Bounded Notion Sites collector tests
+
+set -euo pipefail
+export AIDEVOPS_TEST_MODE=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NOTION_SCRIPT="${SCRIPT_DIR}/../scripts/knowledge_social_notion.py"
+SOCIAL_HELPER="${SCRIPT_DIR}/../scripts/knowledge-social-helper.sh"
+CORPUS_HELPER="${SCRIPT_DIR}/../scripts/knowledge-corpus-helper.sh"
+TEMP_PARENT="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+mkdir -p "$TEMP_PARENT"
+TMP_DIR=$(mktemp -d "${TEMP_PARENT}/notion-social-test.XXXXXX")
+BASE="${TMP_DIR}/knowledge"
+ROOT="${BASE}/_knowledge"
+WORKSPACE_ID="11111111-1111-4111-8111-111111111111"
+PASS=0
+FAIL=0
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+assert_eq() {
+	local description="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS  %s\n' "$description"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL  %s (expected=%s actual=%s)\n' \
+			"$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+json_field() {
+	local payload="$1"
+	local field="$2"
+	python3 -c 'import json,sys; print(json.loads(sys.argv[1])[sys.argv[2]])' \
+		"$payload" "$field"
+	return 0
+}
+
+sql_value() {
+	local query="$1"
+	python3 - "$ROOT/index/social.db" "$query" <<'PY'
+import sqlite3
+import sys
+
+with sqlite3.connect(sys.argv[1]) as connection:
+    print(connection.execute(sys.argv[2]).fetchone()[0])
+PY
+	return 0
+}
+
+raw_count() {
+	python3 - "$ROOT/sources/social/raw/notion-sites" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+print(len(list(root.rglob("*.json.gz"))) if root.exists() else 0)
+PY
+	return 0
+}
+
+raw_contains() {
+	local needle="$1"
+	python3 - "$ROOT/sources/social/raw/notion-sites" "$needle" <<'PY'
+import gzip
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+needle = sys.argv[2]
+matches = 0
+if root.exists():
+    for path in root.rglob("*.json.gz"):
+        with gzip.open(path, "rt", encoding="utf-8") as source:
+            matches += needle in source.read()
+print(matches)
+PY
+	return 0
+}
+
+run_notion() {
+	local fixture="$1"
+	local connection_id="$2"
+	local budget="$3"
+	local page_size="$4"
+	local workspace_id="${5:-$WORKSPACE_ID}"
+	if python3 "$NOTION_SCRIPT" --base "$BASE" --alias personal:default \
+		--connection-id "$connection_id" --account-id "$workspace_id" \
+		--stream site_tree --profile fixture --fixture "$fixture" \
+		--budget "$budget" --page-size "$page_size"; then
+		return 0
+	fi
+	return 1
+}
+
+expect_failure() {
+	local description="$1"
+	local fixture="$2"
+	local connection_id="$3"
+	local budget="$4"
+	local page_size="$5"
+	if run_notion "$fixture" "$connection_id" "$budget" "$page_size" \
+		>/dev/null 2>&1; then
+		assert_eq "$description" accepted rejected
+	else
+		assert_eq "$description" rejected rejected
+	fi
+	return 0
+}
+
+mkdir -p "$ROOT"
+chmod 0700 "$BASE" "$ROOT"
+"$CORPUS_HELPER" provision --base "$BASE" >/dev/null
+"$SOCIAL_HELPER" provision --base "$BASE" --alias personal:default >/dev/null
+
+printf 'Notion Sites social collector tests\n'
+
+python3 - "$SCRIPT_DIR/../scripts" <<'PY'
+import ast
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+scripts = Path(sys.argv[1])
+sys.path.insert(0, str(scripts))
+
+from _knowledge_social_collect import CursorState
+from _knowledge_social_notion import (
+    API_VERSION,
+    STREAMS,
+    Limits,
+    PageRequest,
+    Task,
+    TraversalState,
+    _encode_state,
+    page_checkpoint,
+    page_request,
+    parse_page_request,
+    task_value,
+)
+from _knowledge_social_notion_contract import (
+    ApiResult,
+    NotionReadProviderError,
+    file_descriptors,
+    plain_text,
+)
+from _knowledge_social_notion_http import (
+    API_ORIGIN,
+    HTTP_TIMEOUT_SECONDS,
+    ProfileConfig,
+    _RejectRedirect,
+    identity_api,
+    task_api,
+)
+from _knowledge_social_notion_identity import NotionAdapterError, notion_id
+from _knowledge_social_notion_provider import (
+    _handle_result,
+    _page,
+    _profile_matches,
+)
+
+WORKSPACE = "11111111-1111-4111-8111-111111111111"
+BOT = "22222222-2222-4222-8222-222222222222"
+ROOT = "33333333-3333-4333-8333-333333333333"
+BLOCK = "44444444-4444-4444-8444-444444444444"
+EMBED = "55555555-5555-4555-8555-555555555555"
+FILE = "66666666-6666-4666-8666-666666666666"
+DATABASE = "77777777-7777-4777-8777-777777777777"
+SOURCE = "88888888-8888-4888-8888-888888888888"
+ROW = "99999999-9999-4999-8999-999999999999"
+COMMENT = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+DISCUSSION = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+CREATOR = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+LIMITS = Limits(3, 20, 50, 1024 * 1024)
+ACCOUNT = {
+    "id": WORKSPACE,
+    "workspace_id": WORKSPACE,
+    "root_page_ids": [ROOT],
+    "include_comments": False,
+    "limits": LIMITS.payload(),
+}
+
+
+def expect_error(callback, message):
+    try:
+        callback()
+    except (NotionAdapterError, NotionReadProviderError):
+        return
+    raise AssertionError(message)
+
+
+def response(request, data=None, discoveries=None, *, cursor=None,
+             page_count=0, block_count=0, response_bytes=100,
+             request_status="complete", limit_reason=None):
+    return {
+        "status": 200,
+        "observed_at": "2026-08-02T12:00:00Z",
+        "data": data or [],
+        "meta": {
+            "block_count": block_count,
+            "discoveries": [item.payload() for item in (discoveries or [])],
+            "limit_reason": limit_reason,
+            "next_cursor": cursor,
+            "page_count": page_count,
+            "request_sha256": request.digest(),
+            "request_status": request_status,
+            "response_bytes": response_bytes,
+            "task": request.task.payload(),
+        },
+    }
+
+
+def state_for(request):
+    task = request.task
+    traversal = TraversalState((task,), frozenset({task.key()}), 0, 0, 0)
+    return CursorState(_encode_state(traversal, request.binding), None, False)
+
+
+assert set(STREAMS) == {"site_tree"}
+assert STREAMS["site_tree"].cost_units == 2
+assert notion_id(ROOT.replace("-", ""), "root") == ROOT
+expect_error(lambda: notion_id("https://example.invalid/notion-page", "root"),
+             "public Notion Site URL was accepted as a root")
+
+initial = page_request("site_tree", ACCOUNT, CursorState(None, None, False), 100)
+assert initial.task == Task("page", ROOT, 0)
+assert parse_page_request(initial.payload()) == initial
+
+first_payload = response(
+    initial,
+    [{"kind": "page", "id": ROOT, "parent": {"type": "workspace"},
+      "text": "Root"}],
+    [Task("blocks", ROOT, 0)],
+    page_count=1,
+)
+checkpoint, complete = page_checkpoint(
+    first_payload, CursorState(None, None, False), initial
+)
+assert not complete and checkpoint.next_cursor
+resumed_state = CursorState(checkpoint.next_cursor, checkpoint.watermark, False)
+resumed = page_request("site_tree", ACCOUNT, resumed_state, 100)
+assert resumed.task == Task("blocks", ROOT, 0)
+
+changed_root = dict(ACCOUNT, root_page_ids=[BLOCK])
+expect_error(
+    lambda: page_request("site_tree", changed_root, resumed_state, 100),
+    "durable cursor resumed under a different root policy",
+)
+changed_limits = dict(ACCOUNT, limits=Limits(2, 20, 50, 1024 * 1024).payload())
+expect_error(
+    lambda: page_request("site_tree", changed_limits, resumed_state, 100),
+    "durable cursor resumed under different traversal limits",
+)
+
+escaped = response(
+    resumed,
+    [],
+    [Task("page", BLOCK, 1, parent_kind="page_id", parent_id=BLOCK)],
+)
+expect_error(
+    lambda: page_checkpoint(escaped, resumed_state, resumed),
+    "discovery escaped the requested parent",
+)
+
+understated_depth = response(
+    resumed,
+    [],
+    [Task("blocks", BLOCK, 0, parent_kind="page_id", parent_id=ROOT)],
+)
+expect_error(
+    lambda: page_checkpoint(understated_depth, resumed_state, resumed),
+    "descendant discovery understated its traversal depth",
+)
+
+same_cursor_request = PageRequest(
+    resumed.workspace_id,
+    resumed.root_page_ids,
+    resumed.limits,
+    resumed.include_comments,
+    resumed.binding,
+    Task("blocks", ROOT, 0, "opaque-A"),
+    resumed.page_size,
+)
+same_cursor_payload = response(same_cursor_request, cursor="opaque-A")
+same_cursor_state = state_for(same_cursor_request)
+expect_error(
+    lambda: page_checkpoint(
+        same_cursor_payload,
+        same_cursor_state,
+        same_cursor_request,
+    ),
+    "non-advancing Notion cursor was accepted",
+)
+
+data_source_request = PageRequest(
+    initial.workspace_id,
+    initial.root_page_ids,
+    initial.limits,
+    initial.include_comments,
+    initial.binding,
+    Task(
+        "data_source", SOURCE, 1,
+        parent_kind="database_id", parent_id=DATABASE,
+        database_id=DATABASE,
+    ),
+    100,
+)
+wrong_parent = response(
+    data_source_request,
+    [],
+    [Task(
+        "blocks", ROW, 2,
+        parent_kind="data_source_id", parent_id=BLOCK,
+        database_id=DATABASE,
+    )],
+)
+data_source_state = state_for(data_source_request)
+expect_error(
+    lambda: page_checkpoint(
+        wrong_parent,
+        data_source_state,
+        data_source_request,
+    ),
+    "data-source row discovery escaped its exact data source",
+)
+
+bad_data_source_task = Task(
+    "data_source", SOURCE, 1,
+    parent_kind="page_id", parent_id=DATABASE, database_id=DATABASE,
+)
+expect_error(
+    lambda: task_value(bad_data_source_task.payload(), LIMITS),
+    "data-source task without an exact database parent was accepted",
+)
+
+for key, count in (("page_count", 21), ("block_count", 51), ("response_bytes", 1024 * 1024 + 1)):
+    kwargs = {key: count}
+    bounded = response(initial, **kwargs)
+    expect_error(
+        lambda bounded=bounded: page_checkpoint(
+            bounded, CursorState(None, None, False), initial
+        ),
+        f"{key} budget overrun was accepted",
+    )
+
+depth_limited = response(initial, limit_reason="depth")
+expect_error(
+    lambda: page_checkpoint(depth_limited, CursorState(None, None, False), initial),
+    "provider depth exhaustion advanced a checkpoint",
+)
+
+small_limits = Limits(1, 1, 1, 65536)
+small_account = dict(ACCOUNT, limits=small_limits.payload())
+small_request = page_request("site_tree", small_account, CursorState(None, None, False), 100)
+queue_request = PageRequest(
+    small_request.workspace_id,
+    small_request.root_page_ids,
+    small_request.limits,
+    small_request.include_comments,
+    small_request.binding,
+    Task("blocks", ROOT, 0),
+    small_request.page_size,
+)
+queue_state = state_for(queue_request)
+many = []
+for index in range(1, 106):
+    child_id = str(uuid.UUID(int=index))
+    many.append(Task("blocks", child_id, 1, parent_kind="page_id", parent_id=ROOT))
+queue_payload = response(queue_request, discoveries=many)
+expect_error(
+    lambda: page_checkpoint(
+        queue_payload, queue_state, queue_request
+    ),
+    "durable queue safety limit was accepted",
+)
+
+config = ProfileConfig(
+    "fixture-access-value", WORKSPACE, (ROOT,), False,
+    LIMITS.max_depth, LIMITS.max_pages, LIMITS.max_blocks, LIMITS.max_bytes,
+)
+_profile_matches(initial, config)
+expect_error(
+    lambda: _profile_matches(
+        initial,
+        ProfileConfig(
+            "fixture-access-value", WORKSPACE, (BLOCK,), False,
+            LIMITS.max_depth, LIMITS.max_pages, LIMITS.max_blocks, LIMITS.max_bytes,
+        ),
+    ),
+    "secret profile root mismatch was accepted",
+)
+
+root_raw = {
+    "object": "page",
+    "id": ROOT,
+    "parent": {"type": "workspace", "workspace": True},
+    "created_time": "2026-08-02T11:00:00Z",
+    "last_edited_time": "2026-08-02T11:01:00Z",
+    "public_url": "https://example.invalid/public-root",
+    "properties": {
+        "title": {"type": "title", "title": [{"plain_text": "Authorized root"}]},
+    },
+    "cover": {
+        "type": "file",
+        "file": {
+            "url": "https://example.invalid/signed-cover",
+            "expiry_time": "2026-08-02T12:00:00Z",
+        },
+    },
+}
+root_result = _handle_result(ApiResult(200, root_raw, 120), initial)
+encoded_root = json.dumps(root_result, sort_keys=True)
+assert "Authorized root" in encoded_root
+assert "signed-cover" not in encoded_root and "public-root" not in encoded_root
+assert root_result["data"][0]["files"][0]["kind"] == "notion_hosted"
+assert [item["kind"] for item in root_result["meta"]["discoveries"]] == ["blocks"]
+
+block_request = PageRequest(
+    initial.workspace_id, initial.root_page_ids, initial.limits,
+    initial.include_comments, initial.binding, Task("blocks", ROOT, 0), 100,
+)
+blocks_raw = {
+    "object": "list",
+    "results": [
+        {
+            "object": "block", "id": BLOCK,
+            "parent": {"type": "page_id", "page_id": ROOT},
+            "type": "paragraph", "has_children": True,
+            "paragraph": {"rich_text": [{"plain_text": "Nested knowledge"}]},
+        },
+        {
+            "object": "block", "id": EMBED,
+            "parent": {"type": "page_id", "page_id": ROOT},
+            "type": "embed", "has_children": False,
+            "embed": {"url": "https://example.invalid/embed-target"},
+        },
+        {
+            "object": "block", "id": FILE,
+            "parent": {"type": "page_id", "page_id": ROOT},
+            "type": "file", "has_children": False,
+            "file": {
+                "type": "external",
+                "external": {"url": "https://example.invalid/file-target"},
+            },
+        },
+    ],
+    "has_more": False,
+    "next_cursor": None,
+}
+blocks_result = _handle_result(ApiResult(200, blocks_raw, 240), block_request)
+encoded_blocks = json.dumps(blocks_result, sort_keys=True)
+assert "Nested knowledge" in encoded_blocks
+assert "embed-target" not in encoded_blocks and "file-target" not in encoded_blocks
+assert blocks_result["data"][1]["external_target_not_fetched"] is True
+assert blocks_result["data"][2]["files"][0]["kind"] == "external"
+assert [item["resource_id"] for item in blocks_result["meta"]["discoveries"]] == [BLOCK]
+
+database_request = PageRequest(
+    initial.workspace_id, initial.root_page_ids, initial.limits,
+    initial.include_comments, initial.binding,
+    Task("database", DATABASE, 1, parent_kind="page_id", parent_id=ROOT), 100,
+)
+database_raw = {
+    "object": "database", "id": DATABASE,
+    "parent": {"type": "page_id", "page_id": ROOT},
+    "title": [{"plain_text": "Structured notes"}],
+    "data_sources": [{"id": SOURCE, "name": "Primary"}],
+}
+database_result = _handle_result(ApiResult(200, database_raw, 100), database_request)
+assert database_result["data"][0]["kind"] == "database"
+assert database_result["meta"]["discoveries"][0]["resource_id"] == SOURCE
+
+row_request = data_source_request
+row_raw = {
+    "object": "list",
+    "results": [{
+        "object": "page", "id": ROW,
+        "parent": {
+            "type": "data_source_id", "data_source_id": SOURCE,
+            "database_id": DATABASE,
+        },
+        "properties": {
+            "title": {"type": "title", "title": [{"plain_text": "Structured row"}]},
+        },
+        "public_url": None,
+    }],
+    "has_more": True,
+    "next_cursor": "opaque-row-cursor",
+}
+row_result = _handle_result(ApiResult(200, row_raw, 100), row_request)
+assert row_result["data"][0]["text"] == "Structured row"
+assert row_result["meta"]["next_cursor"] == "opaque-row-cursor"
+assert row_result["meta"]["discoveries"][0]["parent_id"] == SOURCE
+
+comment_request = PageRequest(
+    initial.workspace_id, initial.root_page_ids, initial.limits,
+    True, initial.binding, Task("comments", ROOT, 0), 100,
+)
+comment_raw = {
+    "object": "list",
+    "results": [{
+        "object": "comment", "id": COMMENT,
+        "parent": {"type": "page_id", "page_id": ROOT},
+        "discussion_id": DISCUSSION,
+        "created_by": {"object": "user", "id": CREATOR},
+        "created_time": "2026-08-02T11:02:00Z",
+        "rich_text": [{"plain_text": "Open comment"}],
+        "attachments": [{
+            "type": "external",
+            "external": {"url": "https://example.invalid/comment-file"},
+        }],
+    }],
+    "has_more": False,
+    "next_cursor": None,
+}
+comment_result = _handle_result(ApiResult(200, comment_raw, 100), comment_request)
+encoded_comment = json.dumps(comment_result, sort_keys=True)
+assert "Open comment" in encoded_comment and "comment-file" not in encoded_comment
+assert comment_result["data"][0]["kind"] == "comment"
+
+assert plain_text({"rich_text": [{"plain_text": "Safe text"}]}) == "Safe text"
+expect_error(
+    lambda: plain_text({"rich_text": [{"plain_text": "access_token=must-not-persist"}]}),
+    "credential-shaped rich text was accepted",
+)
+files = file_descriptors({
+    "type": "external",
+    "external": {"url": "https://example.invalid/file"},
+})
+assert files == [{"disposition": "external_target_not_fetched", "kind": "external"}]
+
+
+class Headers:
+    def get(self, _key, default=None):
+        return default
+
+
+class Response:
+    status = 200
+
+    def __init__(self, payload):
+        self.payload = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def read(self, size=-1):
+        return self.payload[:size]
+
+
+class Opener:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    def open(self, request, timeout):
+        assert timeout == HTTP_TIMEOUT_SECONDS
+        self.requests.append(request)
+        return self.responses.pop(0)
+
+
+route_tasks = [
+    Task("page", ROOT, 0),
+    Task("blocks", ROOT, 0, "opaque-A"),
+    Task("database", DATABASE, 1, parent_kind="page_id", parent_id=ROOT),
+    Task("comments", ROOT, 0, "opaque-B"),
+    Task(
+        "data_source", SOURCE, 1, "opaque-C",
+        parent_kind="database_id", parent_id=DATABASE, database_id=DATABASE,
+    ),
+]
+route_opener = Opener([Response({}) for _ in range(len(route_tasks) + 1)])
+assert identity_api(config, route_opener).status == 200
+for task in route_tasks:
+    request = PageRequest(
+        WORKSPACE, (ROOT,), LIMITS, False, initial.binding, task, 17
+    )
+    assert task_api(config, route_opener, request).status == 200
+
+methods = [request.method for request in route_opener.requests]
+assert methods == ["GET", "GET", "GET", "GET", "GET", "POST"]
+assert route_opener.requests[0].full_url == f"{API_ORIGIN}/v1/users/me"
+assert route_opener.requests[1].full_url == f"{API_ORIGIN}/v1/pages/{ROOT}"
+assert route_opener.requests[3].full_url == f"{API_ORIGIN}/v1/databases/{DATABASE}"
+assert urlsplit(route_opener.requests[4].full_url).path == "/v1/comments"
+assert parse_qs(urlsplit(route_opener.requests[4].full_url).query) == {
+    "block_id": [ROOT], "page_size": ["17"], "start_cursor": ["opaque-B"],
+}
+assert route_opener.requests[5].full_url == f"{API_ORIGIN}/v1/data_sources/{SOURCE}/query"
+assert json.loads(route_opener.requests[5].data) == {
+    "page_size": 17, "start_cursor": "opaque-C",
+}
+assert all(request.full_url.startswith(f"{API_ORIGIN}/v1/") for request in route_opener.requests)
+assert _RejectRedirect().redirect_request(None) is None
+
+identity_raw = {
+    "object": "user", "type": "bot", "id": BOT,
+    "bot": {
+        "workspace_id": WORKSPACE, "workspace_name": "Fixture workspace",
+        "owner": {"type": "workspace", "workspace": True},
+    },
+}
+live_opener = Opener([Response(identity_raw), Response(root_raw)])
+live_result = _page(live_opener, config, initial)
+assert live_result["status"] == 200
+assert [request.method for request in live_opener.requests] == ["GET", "GET"]
+assert live_opener.requests[0].full_url.endswith("/v1/users/me")
+assert live_opener.requests[1].full_url.endswith(f"/v1/pages/{ROOT}")
+
+sources = [
+    path.read_text(encoding="utf-8")
+    for path in sorted(scripts.glob("_knowledge_social_notion*.py"))
+]
+trees = [ast.parse(source) for source in sources]
+verbs = {
+    node.value
+    for tree in trees
+    for node in ast.walk(tree)
+    if isinstance(node, ast.Constant)
+    and isinstance(node.value, str)
+    and node.value in {"GET", "POST", "PUT", "PATCH", "DELETE"}
+}
+assert verbs == {"GET", "POST"}
+assert all("/v1/search" not in source for source in sources)
+assert all("urlopen(" not in source and "requests." not in source for source in sources)
+PY
+assert_eq "workspace/root bindings, provider projections, budgets, redirects, and exact routes are guarded" \
+	verified verified
+
+python3 - "$TMP_DIR" "$SCRIPT_DIR/../scripts" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+target = Path(sys.argv[1])
+sys.path.insert(0, sys.argv[2])
+
+from _knowledge_social_collect import CursorState
+from _knowledge_social_notion import Limits, Task, page_checkpoint, page_request
+
+WORKSPACE = "11111111-1111-4111-8111-111111111111"
+BOT = "22222222-2222-4222-8222-222222222222"
+ROOT = "33333333-3333-4333-8333-333333333333"
+BLOCK = "44444444-4444-4444-8444-444444444444"
+DATABASE = "77777777-7777-4777-8777-777777777777"
+SOURCE = "88888888-8888-4888-8888-888888888888"
+ROW_ONE = "99999999-9999-4999-8999-999999999991"
+ROW_TWO = "99999999-9999-4999-8999-999999999992"
+COMMENT = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+DISCUSSION = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+CREATOR = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+LIMITS = Limits(4, 20, 50, 1024 * 1024)
+
+
+def account(comments=False, workspace=WORKSPACE, roots=(ROOT,)):
+    return {
+        "bot_id": BOT,
+        "id": workspace,
+        "include_comments": comments,
+        "limits": LIMITS.payload(),
+        "owner_type": "workspace",
+        "root_page_ids": list(roots),
+        "workspace_id": workspace,
+        "workspace_name": "Fixture workspace",
+    }
+
+
+def identity(comments=False, workspace=WORKSPACE, roots=(ROOT,)):
+    data = account(comments, workspace, roots)
+    data["api_version"] = "2026-03-11"
+    data["response_bytes"] = 80
+    return {
+        "status": 200,
+        "observed_at": "2026-08-02T12:10:00Z",
+        "data": data,
+    }
+
+
+def success(request, data=None, discoveries=None, *, cursor=None,
+            page_count=0, block_count=0, response_bytes=100,
+            request_status="complete", limit_reason=None, observed_at="2026-08-02T12:11:00Z"):
+    return {
+        "status": 200,
+        "observed_at": observed_at,
+        "data": data or [],
+        "meta": {
+            "block_count": block_count,
+            "discoveries": [item.payload() for item in (discoveries or [])],
+            "limit_reason": limit_reason,
+            "next_cursor": cursor,
+            "page_count": page_count,
+            "request_sha256": request.digest(),
+            "request_status": request_status,
+            "response_bytes": response_bytes,
+            "task": request.task.payload(),
+        },
+    }
+
+
+def entry(request, response):
+    return {"expect_request": {"task": request.task.payload()}, "response": response}
+
+
+def advance(state, request, payload):
+    checkpoint, complete = page_checkpoint(payload, state, request)
+    return CursorState(checkpoint.next_cursor, checkpoint.watermark, complete)
+
+
+def write(name, identity_payload, pages):
+    (target / name).write_text(
+        json.dumps({"identity": identity_payload, "pages": pages}),
+        encoding="utf-8",
+    )
+
+
+def page_record(page_id, text, parent=None):
+    return {
+        "created_at": "2026-08-02T12:00:00Z",
+        "files": [],
+        "id": page_id,
+        "in_trash": False,
+        "kind": "page",
+        "last_edited_at": "2026-08-02T12:01:00Z",
+        "parent": parent or {"type": "workspace"},
+        "published": True,
+        "text": text,
+    }
+
+
+initial_state = CursorState(None, None, False)
+
+# Minimal complete page + child-block traversal, including URL-free file metadata.
+complete_account = account()
+complete_request = page_request("site_tree", complete_account, initial_state, 100)
+complete_page = success(
+    complete_request,
+    [{
+        **page_record(ROOT, "Notion fixture knowledge"),
+        "files": [{
+            "disposition": "metadata_only_not_fetched",
+            "expiry_time": "2026-08-02T13:00:00Z",
+            "kind": "notion_hosted",
+        }],
+    }],
+    [Task("blocks", ROOT, 0)],
+    page_count=1,
+)
+complete_state = advance(initial_state, complete_request, complete_page)
+complete_blocks_request = page_request("site_tree", complete_account, complete_state, 100)
+complete_blocks = success(
+    complete_blocks_request,
+    [{
+        "block_type": "paragraph",
+        "created_at": "2026-08-02T12:00:00Z",
+        "external_target_not_fetched": False,
+        "files": [],
+        "id": BLOCK,
+        "in_trash": False,
+        "kind": "block",
+        "last_edited_at": "2026-08-02T12:01:00Z",
+        "parent": {"type": "page_id", "page_id": ROOT},
+        "text": "Nested fixture paragraph",
+    }],
+    block_count=1,
+)
+write(
+    "complete.json",
+    identity(),
+    [entry(complete_request, complete_page), entry(complete_blocks_request, complete_blocks)],
+)
+
+# Two-invocation budget resume uses the durable queue head.
+write("resume-first.json", identity(), [entry(complete_request, complete_page)])
+write("resume-second.json", identity(), [entry(complete_blocks_request, complete_blocks)])
+
+# Child database, opaque data-source cursor, and row block traversal.
+structured_account = account()
+structured_state = initial_state
+structured_pages = []
+request = page_request("site_tree", structured_account, structured_state, 100)
+payload = success(
+    request,
+    [page_record(ROOT, "Structured root")],
+    [Task("blocks", ROOT, 0)],
+    page_count=1,
+)
+structured_pages.append(entry(request, payload))
+structured_state = advance(structured_state, request, payload)
+
+request = page_request("site_tree", structured_account, structured_state, 100)
+payload = success(
+    request,
+    [{
+        "block_type": "child_database", "files": [], "id": DATABASE,
+        "in_trash": False, "kind": "block",
+        "parent": {"type": "page_id", "page_id": ROOT},
+        "text": "Fixture database",
+    }],
+    [Task("database", DATABASE, 1, parent_kind="page_id", parent_id=ROOT)],
+    block_count=1,
+)
+structured_pages.append(entry(request, payload))
+structured_state = advance(structured_state, request, payload)
+
+request = page_request("site_tree", structured_account, structured_state, 100)
+payload = success(
+    request,
+    [{
+        "files": [], "id": DATABASE, "kind": "database",
+        "parent": {"type": "page_id", "page_id": ROOT},
+        "text": "Structured notes",
+    }],
+    [Task(
+        "data_source", SOURCE, 1,
+        parent_kind="database_id", parent_id=DATABASE, database_id=DATABASE,
+    )],
+)
+structured_pages.append(entry(request, payload))
+structured_state = advance(structured_state, request, payload)
+
+request = page_request("site_tree", structured_account, structured_state, 100)
+payload = success(
+    request,
+    [page_record(
+        ROW_ONE,
+        "Structured Notion row one",
+        {"type": "data_source_id", "data_source_id": SOURCE, "database_id": DATABASE},
+    )],
+    [Task(
+        "blocks", ROW_ONE, 2,
+        parent_kind="data_source_id", parent_id=SOURCE, database_id=DATABASE,
+    )],
+    cursor="opaque-row-page",
+    page_count=1,
+)
+structured_pages.append(entry(request, payload))
+structured_state = advance(structured_state, request, payload)
+
+request = page_request("site_tree", structured_account, structured_state, 100)
+assert request.task.cursor == "opaque-row-page"
+payload = success(
+    request,
+    [page_record(
+        ROW_TWO,
+        "Structured Notion row two",
+        {"type": "data_source_id", "data_source_id": SOURCE, "database_id": DATABASE},
+    )],
+    [Task(
+        "blocks", ROW_TWO, 2,
+        parent_kind="data_source_id", parent_id=SOURCE, database_id=DATABASE,
+    )],
+    page_count=1,
+)
+structured_pages.append(entry(request, payload))
+structured_state = advance(structured_state, request, payload)
+
+for row_id in (ROW_ONE, ROW_TWO):
+    request = page_request("site_tree", structured_account, structured_state, 100)
+    assert request.task.resource_id == row_id
+    payload = success(request)
+    structured_pages.append(entry(request, payload))
+    structured_state = advance(structured_state, request, payload)
+assert structured_state.backfill_complete
+write("structured.json", identity(), structured_pages)
+
+# Comments are capability-gated and independently paginated in the queue.
+comment_account = account(comments=True)
+comment_state = initial_state
+comment_pages = []
+request = page_request("site_tree", comment_account, comment_state, 100)
+payload = success(
+    request,
+    [page_record(ROOT, "Commented root")],
+    [Task("blocks", ROOT, 0), Task("comments", ROOT, 0)],
+    page_count=1,
+)
+comment_pages.append(entry(request, payload))
+comment_state = advance(comment_state, request, payload)
+request = page_request("site_tree", comment_account, comment_state, 100)
+payload = success(request)
+comment_pages.append(entry(request, payload))
+comment_state = advance(comment_state, request, payload)
+request = page_request("site_tree", comment_account, comment_state, 100)
+payload = success(
+    request,
+    [{
+        "created_at": "2026-08-02T12:20:00Z",
+        "created_by": CREATOR,
+        "discussion_id": DISCUSSION,
+        "files": [],
+        "id": COMMENT,
+        "kind": "comment",
+        "parent": {"type": "page_id", "page_id": ROOT},
+        "text": "Open fixture comment",
+    }],
+)
+comment_pages.append(entry(request, payload))
+comment_state = advance(comment_state, request, payload)
+assert comment_state.backfill_complete
+write("comments.json", identity(comments=True), comment_pages)
+
+# Validation and terminal fixtures must preserve the previous durable boundary.
+bad_sha = dict(complete_page)
+bad_sha["meta"] = dict(complete_page["meta"], request_sha256="0" * 64)
+write("malformed.json", identity(), [entry(complete_request, bad_sha)])
+
+escape = success(
+    complete_request,
+    [],
+    [Task("page", BLOCK, 1, parent_kind="page_id", parent_id=ROOT)],
+)
+write("root-escape.json", identity(), [entry(complete_request, escape)])
+
+credential = dict(complete_page, access_token="must-not-persist")
+write("credential.json", identity(), [entry(complete_request, credential)])
+
+limited = success(complete_request, limit_reason="blocks")
+write("limit.json", identity(), [entry(complete_request, limited)])
+
+write(
+    "identity-mismatch.json",
+    identity(workspace=BLOCK),
+    [],
+)
+
+write("terminal-first.json", identity(), [entry(complete_request, complete_page)])
+write(
+    "terminal-second.json",
+    identity(),
+    [{
+        "expect_request": {"task": complete_blocks_request.task.payload()},
+        "response": {
+            "status": 500,
+            "observed_at": "2026-08-02T12:30:00Z",
+            "response_bytes": 10,
+        },
+    }],
+)
+
+write(
+    "identity-terminal.json",
+    {
+        "status": 429,
+        "observed_at": "2026-08-02T12:31:00Z",
+        "response_bytes": 0,
+        "retry_after": 1785675000,
+    },
+    [],
+)
+PY
+
+complete_result=$(run_notion "$TMP_DIR/complete.json" conn_notion_complete 5 100)
+assert_eq "bounded Notion root tree completes" \
+	"$(json_field "$complete_result" status)" complete
+assert_eq "identity and two root-tree reads consume five request units" \
+	"$(json_field "$complete_result" budget_units)" 5
+assert_eq "authorized Notion text reaches FTS" \
+	"$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'knowledge'")" 1
+assert_eq "fixed API/export gaps remain explicit" \
+	"$(sql_value "SELECT count(*) FROM coverage_records WHERE connection_id='conn_notion_complete' AND status='unavailable'")" 6
+assert_eq "signed file targets never reach raw evidence" \
+	"$(raw_contains 'signed-cover')" 0
+complete_raw=$(raw_count)
+run_notion "$TMP_DIR/complete.json" conn_notion_complete 5 100 >/dev/null
+assert_eq "exact Notion replay is idempotent" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='notion-sites' AND remote_id IN ('notion_page_33333333333343338333333333333333','notion_block_44444444444444448444444444444444')")" 2
+assert_eq "content-addressed replay does not duplicate Notion raw blobs" \
+	"$(raw_count)" "$complete_raw"
+
+resume_first=$(run_notion "$TMP_DIR/resume-first.json" conn_notion_resume 3 100)
+assert_eq "request budget pauses at a durable queue head" \
+	"$(json_field "$resume_first" status)" budget_exhausted
+resume_second=$(run_notion "$TMP_DIR/resume-second.json" conn_notion_resume 3 100)
+assert_eq "second invocation resumes the exact child-block task" \
+	"$(json_field "$resume_second" status)" complete
+
+structured_result=$(run_notion "$TMP_DIR/structured.json" conn_notion_structured 15 100)
+assert_eq "database and opaque data-source pagination complete" \
+	"$(json_field "$structured_result" status)" complete
+assert_eq "both data-source rows become authorized page evidence" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='notion-sites' AND object_type='page' AND remote_id IN ('notion_page_33333333333343338333333333333333','notion_page_99999999999949998999999999999991','notion_page_99999999999949998999999999999992')")" 3
+assert_eq "structured Notion row text reaches FTS" \
+	"$(sql_value "SELECT count(*) FROM objects_fts WHERE objects_fts MATCH 'Structured AND row'")" 2
+
+comments_result=$(run_notion "$TMP_DIR/comments.json" conn_notion_comments 7 100)
+assert_eq "capability-gated unresolved comments complete" \
+	"$(json_field "$comments_result" status)" complete
+assert_eq "unresolved comment becomes neutral object evidence" \
+	"$(sql_value "SELECT count(*) FROM objects WHERE provider='notion-sites' AND object_type='comment' AND remote_id='notion_comment_aaaaaaaaaaaa4aaa8aaaaaaaaaaaaaaa'")" 1
+
+raw_before=$(raw_count)
+expect_failure "wrong workspace identity is rejected" \
+	"$TMP_DIR/identity-mismatch.json" conn_notion_identity_mismatch 3 100
+expect_failure "root-escape discovery is rejected" \
+	"$TMP_DIR/root-escape.json" conn_notion_escape 3 100
+expect_failure "malformed request provenance is rejected" \
+	"$TMP_DIR/malformed.json" conn_notion_malformed 3 100
+expect_failure "credential-shaped page evidence is rejected" \
+	"$TMP_DIR/credential.json" conn_notion_credential 3 100
+expect_failure "provider traversal-limit response cannot advance" \
+	"$TMP_DIR/limit.json" conn_notion_limit 3 100
+assert_eq "all rejected Notion observations persist no raw evidence" \
+	"$(raw_count)" "$raw_before"
+
+run_notion "$TMP_DIR/terminal-first.json" conn_notion_terminal 3 100 >/dev/null
+terminal_cursor_before=$(sql_value "SELECT cursor FROM sync_cursors WHERE connection_id='conn_notion_terminal' AND stream='site_tree'")
+terminal_result=$(run_notion "$TMP_DIR/terminal-second.json" conn_notion_terminal 3 100)
+assert_eq "terminal Notion task failure is sanitized" \
+	"$(json_field "$terminal_result" failure_class)" provider
+assert_eq "terminal Notion task failure preserves its prior checkpoint" \
+	"$(sql_value "SELECT cursor FROM sync_cursors WHERE connection_id='conn_notion_terminal' AND stream='site_tree'")" \
+	"$terminal_cursor_before"
+assert_eq "terminal Notion task records failed stream coverage" \
+	"$(sql_value "SELECT status || ':' || unavailable_reason FROM coverage_records WHERE connection_id='conn_notion_terminal' AND stream='site_tree'")" \
+	"failed:provider"
+
+identity_terminal=$(run_notion "$TMP_DIR/identity-terminal.json" conn_notion_identity_terminal 3 100)
+assert_eq "terminal Notion identity response is sanitized" \
+	"$(json_field "$identity_terminal" failure_class)" rate_limit
+assert_eq "identity retry boundary remains observable" \
+	"$(json_field "$identity_terminal" status)" rate_limited
+
+python3 - "$ROOT" "$SCRIPT_DIR/../scripts" <<'PY'
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, sys.argv[2])
+
+from _knowledge_social_collect import (
+    CollectionContext,
+    ConnectionConfig,
+    CursorState,
+    PageCheckpoint,
+    SuccessfulPage,
+)
+from _knowledge_social_collect_persist import persist_page
+from _knowledge_social_lease import (
+    RunLeaseRequest,
+    SocialLeaseLostError,
+    acquire_run_lease,
+    release_run_lease,
+)
+from _knowledge_social_notion import STREAMS
+
+root = Path(sys.argv[1])
+workspace = "11111111-1111-4111-8111-111111111111"
+old = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_notion_fence", "site_tree", "old_runner", "sync", 1),
+    now_epoch=9000,
+)
+new = acquire_run_lease(
+    root,
+    RunLeaseRequest("conn_notion_fence", "site_tree", "new_runner", "sync", 10),
+    now_epoch=9001,
+)
+context = CollectionContext(
+    root,
+    "conn_notion_fence",
+    {"id": workspace, "workspace_id": workspace},
+    "site_tree",
+    "none",
+    ConnectionConfig(("site_tree",), {"media_hydration": "none"}),
+    CursorState(None, None, False),
+    STREAMS["site_tree"],
+    old,
+    "notion-sites",
+)
+archive = {
+    "provider": "notion-sites",
+    "connection_id": "conn_notion_fence",
+    "remote_account_id": workspace,
+    "exported_at": "2026-08-02T12:40:00Z",
+    "enabled_streams": ["site_tree"],
+    "policy": {"media_hydration": "none"},
+    "accounts": [],
+    "objects": [],
+    "activities": [],
+    "media": [],
+    "coverage": [],
+}
+successful = SuccessfulPage(
+    {"status": 200, "observed_at": archive["exported_at"], "data": [], "meta": {}},
+    '{"stream":"site_tree"}',
+    archive,
+    PageCheckpoint(None, None),
+    True,
+    2,
+)
+os.environ["AIDEVOPS_SOCIAL_NOW_EPOCH"] = "9001"
+try:
+    persist_page(context, successful)
+except SocialLeaseLostError:
+    pass
+else:
+    raise SystemExit("stale Notion collector advanced persistence")
+with sqlite3.connect(root / "index" / "social.db") as database:
+    count = database.execute(
+        "SELECT count(*) FROM sync_cursors WHERE connection_id='conn_notion_fence'"
+    ).fetchone()[0]
+assert count == 0
+release_run_lease(root, new)
+PY
+assert_eq "stale Notion lease cannot commit evidence or a cursor" verified verified
+
+assert_eq "provider documentation classifies every route as Live, Export, Gate, or No" \
+	"$(
+		python3 - "$SCRIPT_DIR/../content/social-notion-sites.md" <<'PY'
+import sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+required = ("**Live", "**Export", "**Gate", "**No")
+print("classified" if all(item in text for item in required) else "missing")
+PY
+	)" classified
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/tests/test-knowledge-social-registry.sh
+++ b/.agents/tests/test-knowledge-social-registry.sh
@@ -56,6 +56,7 @@ expected = {
     "miniflux": ("live",),
     "nextcloud-talk": ("live",),
     "patreon": ("live",),
+    "notion-sites": ("live",),
     "readwise-reader": ("live",),
     "signal": ("inspect", "manual-import", "status"),
     "slack": ("archive", "live"),
@@ -81,6 +82,7 @@ for alias, provider in {
     "dev.to": "forem",
     "gbp": "google-business-profile",
     "hn": "hacker-news",
+    "notion": "notion-sites",
     "reader": "readwise-reader",
     "stackexchange": "stack-exchange",
     "whats-app": "whatsapp",
@@ -105,14 +107,14 @@ except module.ProviderRegistryError:
 else:
     raise SystemExit("unknown provider used a fallback")
 
-print("23:order-independent:aliases-exact:collisions-rejected:no-fallback")
+print("24:order-independent:aliases-exact:collisions-rejected:no-fallback")
 PY
 )
 assert_eq "all merged provider outcomes register deterministically" \
-	"$registry_summary" "23:order-independent:aliases-exact:collisions-rejected:no-fallback"
+	"$registry_summary" "24:order-independent:aliases-exact:collisions-rejected:no-fallback"
 
 provider_count=$("$HELPER" providers | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
-assert_eq "helper exposes the complete provider registry" "$provider_count" "23"
+assert_eq "helper exposes the complete provider registry" "$provider_count" "24"
 
 forem_resolution=$("$HELPER" provider-resolve --provider dev-community |
 	python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["provider"] + ":" + ",".join(data["modes"]))')
@@ -165,6 +167,13 @@ if [[ "$patreon_help" == *"bounded, read-only Patreon creator stream"* ]]; then
 	assert_eq "Patreon executes only the guarded creator adapter" canonical canonical
 else
 	assert_eq "Patreon executes only the guarded creator adapter" unexpected canonical
+fi
+
+notion_help=$("$HELPER" provider-run --provider notion --mode live -- --help 2>&1)
+if [[ "$notion_help" == *"bounded authorized Notion root tree"* ]]; then
+	assert_eq "Notion alias executes only the root-bound local adapter" canonical canonical
+else
+	assert_eq "Notion alias executes only the root-bound local adapter" unexpected canonical
 fi
 
 if "$HELPER" provider-run --provider binance-square --mode no-route >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Add an official-API, workspace- and root-bound Notion Sites collector with fail-closed traversal budgets, URL-free file evidence, durable resume, registry wiring, capability documentation, and focused runtime fixtures.

## Files Changed

.agents/aidevops/knowledge-plane/05-social-operations.md, .agents/aidevops/knowledge-plane/06-social-provider-capabilities.md, .agents/content/social-notion-sites.md, .agents/scripts/_knowledge_social_notion.py, .agents/scripts/_knowledge_social_notion_checkpoint.py, .agents/scripts/_knowledge_social_notion_contract.py, .agents/scripts/_knowledge_social_notion_files.py, .agents/scripts/_knowledge_social_notion_http.py, .agents/scripts/_knowledge_social_notion_identity.py, .agents/scripts/_knowledge_social_notion_normalize.py, .agents/scripts/_knowledge_social_notion_provider.py, .agents/scripts/_knowledge_social_notion_reader.py, .agents/scripts/_knowledge_social_notion_records.py, .agents/scripts/_knowledge_social_notion_result.py, .agents/scripts/_knowledge_social_notion_values.py, .agents/scripts/knowledge_social_notion.py, .agents/scripts/knowledge_social_registry.py, .agents/tests/test-knowledge-social-notion.sh, .agents/tests/test-knowledge-social-registry.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified: 28 Notion traversal tests, 16 registry tests, 35 social sync tests, 45 corpus tests, Python compileall, ShellCheck, changed-file linters, zero new-file Qlty smells, zero Qlty regression, a clean CodeFactor exact-head scan, and review bundle 6247afa081982ad1feb498c1a71c0bfa821dbf2184d6b0ca7de01980c23f67c5.

Resolves #29322


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.219 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 52m and 587,722 tokens on this with the user in an interactive session.