### PR TITLE
GH#29440: chore(deps): update aiohttp to 3.14.3

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -7,7 +7,7 @@
 # Use this file for production deployments to ensure version consistency
 
 aiohappyeyeballs==2.6.2
-aiohttp==3.14.1
+aiohttp==3.14.3
 aiosignal==1.4.0
 alembic==1.18.5
 annotated-doc==0.0.4


### PR DESCRIPTION
## Summary

Updated the production dependency lock from aiohttp 3.14.1 to patched release 3.14.3, isolating the fix from the unrelated failing cryptography major update in PR #29439.

## Files Changed

requirements-lock.txt

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Full lock resolver dry-run passed; aiohttp 3.14.3 import and web.Application runtime smoke passed with pip check; pip-audit found no actionable vulnerabilities after excluding the documented no-patch diskcache finding; generated-lock test, repository typecheck, and linters-local.sh passed

Resolves #29440


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.219 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 10m and 259,069 tokens on this as a headless worker.