### PR TITLE
GH#29441: Update Vault cryptography dependency

### DIFF
--- a/.agents/configs/vault-requirements.txt
+++ b/.agents/configs/vault-requirements.txt
@@ -3,6 +3,6 @@
 
 # Dedicated aidevops Vault runtime. Exact pins keep the security boundary
 # reproducible without requiring the optional DSPy environment.
-cryptography==49.0.0
+cryptography==50.0.0
 cffi==2.1.0
 pycparser==3.0

--- a/.agents/scripts/tests/test-vault-runtime-readiness.sh
+++ b/.agents/scripts/tests/test-vault-runtime-readiness.sh
@@ -78,7 +78,8 @@ assert_eq "metadata-only status reports locked" "locked" "$($VAULT_HELPER status
 assert_eq "metadata-only setup state is readable" "migration-ready" "$($VAULT_HELPER setup-state)"
 [[ ! -e "${AIDEVOPS_VAULT_DIR}/audit.log" ]] && pass "metadata reads remain audit side-effect free" || fail "metadata reads remain audit side-effect free"
 
-missing_code=$(python3 -S - "$HELPER_DIR" <<'PY'
+missing_code=$(
+	python3 -S - "$HELPER_DIR" <<'PY'
 import sys
 
 sys.path.insert(0, sys.argv[1])
@@ -94,13 +95,13 @@ PY
 )
 assert_eq "missing crypto emits stable redacted class" "VAULT_DEPENDENCY_MISSING" "$missing_code"
 
-if grep -q '^cryptography==49\.0\.0$' "${REPO_ROOT}/.agents/configs/vault-requirements.txt" &&
+if grep -q '^cryptography==50\.0\.0$' "${REPO_ROOT}/.agents/configs/vault-requirements.txt" &&
 	grep -q 'setup_vault_python_env' "${REPO_ROOT}/setup.sh"; then
 	pass "setup wires the exact-pinned Vault runtime"
 else
 	fail "setup wires the exact-pinned Vault runtime"
 fi
-if python3 - "${REPO_ROOT}/.agents/scripts/setup/modules/tool-install.sh" <<'PY'
+if python3 - "${REPO_ROOT}/.agents/scripts/setup/modules/tool-install.sh" <<'PY'; then
 import pathlib
 import sys
 
@@ -111,7 +112,6 @@ crypto_check = fresh_setup.index('if ! "$env_python" "$runtime_check"; then')
 marker_publish = fresh_setup.index("Failed to publish the verified Vault runtime marker")
 raise SystemExit(0 if crypto_check < marker_publish else 1)
 PY
-then
 	pass "setup publishes ownership marker only after crypto verification"
 else
 	fail "setup publishes ownership marker only after crypto verification"
@@ -119,7 +119,7 @@ fi
 
 safe_home="${TEST_ROOT}/safe-home"
 safe_runtime="${safe_home}/.aidevops/.agent-workspace/python-env/vault"
-mkdir -p "$safe_home"
+(umask 077 && mkdir -p "$safe_home")
 if (umask 077 && mkdir -p "${safe_runtime%/*}" && python3 -m venv --copies "$safe_runtime"); then
 	chmod 755 "$safe_runtime"
 	printf '%s\n' "aidevops-vault-runtime-v1" >"${safe_runtime}/.aidevops-managed-runtime"

--- a/.agents/scripts/vault-runtime-check.py
+++ b/.agents/scripts/vault-runtime-check.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Optional
 
 EXPECTED = {
-    "cryptography": "49.0.0",
+    "cryptography": "50.0.0",
     "cffi": "2.1.0",
     "pycparser": "3.0",
 }


### PR DESCRIPTION
## Summary

Update the exact-pinned Vault cryptography runtime from 49.0.0 to the patched 50.0.0 release, align runtime assertions, and make the protected-runtime fixture deterministic under restrictive group umasks.

## Files Changed

.agents/configs/vault-requirements.txt, .agents/scripts/tests/test-vault-runtime-readiness.sh, .agents/scripts/vault-runtime-check.py

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: installed the exact requirements in an isolated Python 3.12 environment; vault-runtime-check.py and pip check passed with cryptography 50.0.0; pip-audit found no known vulnerabilities; Vault security suite passed 8/8; readiness test passed 20/20; linters-local.sh and bun typecheck passed with shfmt and ShellCheck clean.

Resolves #29441


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.219 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 14m and 168,692 tokens on this as a headless worker.