### PR TITLE
GH#29403: Allow converged review repair rebases

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -599,8 +599,9 @@ _pr_required_checks_pass() {
 #
 # Returns 0 if update-branch succeeded (caller should skip fix-worker
 # routing and let the next pulse cycle re-check CI on the rebased HEAD).
-# Returns 1 if the PR is already up-to-date with its base or if
-# update-branch failed (caller should fall through to fix-worker routing).
+# Returns 1 if the PR is already up-to-date with its base or if update-branch
+# failed. Standard callers may route a fix worker; review-repair callers must
+# preserve CHANGES_REQUESTED and return without merge or feedback routing.
 #
 # Rate-limit: one call per PR per merge cycle — same as t2116.
 #
@@ -611,6 +612,13 @@ _attempt_pr_ci_rebase_retry() {
 	local repo_slug="$2"
 	local _base_branch="${3:-}"
 	local _head_oid="${4:-}"
+	local _rebase_policy="${5:-standard}"
+	local _review_repair_policy="review-repair"
+
+	if [[ "$_rebase_policy" != "standard" && "$_rebase_policy" != "$_review_repair_policy" ]]; then
+		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: refusing unknown CI-drift rebase policy ${_rebase_policy}" >>"$LOGFILE"
+		return 1
+	fi
 
 	# Prefer per-cycle PR list context; direct/webhook callers may omit it.
 	if [[ -z "$_base_branch" || -z "$_head_oid" ]]; then
@@ -620,10 +628,19 @@ _attempt_pr_ci_rebase_retry() {
 		read -r _base_branch _head_oid <<< "$_pr_info"
 	fi
 
+	if [[ "$_rebase_policy" == "$_review_repair_policy" && ( -z "$_base_branch" || -z "$_head_oid" ) ]]; then
+		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: strict review-repair rebase lacks current base/head evidence; preserving CHANGES_REQUESTED" >>"$LOGFILE"
+		return 1
+	fi
+
 	if [[ -n "$_base_branch" && -n "$_head_oid" ]]; then
 		local _compare_behind
 		_compare_behind=$(gh api "repos/${repo_slug}/compare/${_base_branch}...${_head_oid}" \
 			--jq '.behind_by' 2>/dev/null) || _compare_behind=""
+		if [[ "$_rebase_policy" == "$_review_repair_policy" && ! "$_compare_behind" =~ ^[1-9][0-9]*$ ]]; then
+			echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: strict review-repair rebase requires explicit behind_by>0 evidence; preserving CHANGES_REQUESTED" >>"$LOGFILE"
+			return 1
+		fi
 		if [[ "$_compare_behind" == "0" ]]; then
 			echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: already up-to-date with ${_base_branch}, skipping CI-drift rebase (t2805)" >>"$LOGFILE"
 			return 1
@@ -635,10 +652,10 @@ _attempt_pr_ci_rebase_retry() {
 	# required-check failure. Pending/in-progress required checks are not failures,
 	# and stale failures from older head SHAs must not trigger a branch refresh.
 	local _terminal_check_rc=0
-	_check_required_checks_has_terminal_failure "$repo_slug" "$pr_number"
+	_check_required_checks_has_terminal_failure "$repo_slug" "$pr_number" "$_head_oid"
 	_terminal_check_rc=$?
 	if [[ $_terminal_check_rc -eq 1 ]]; then
-		if _check_required_checks_have_pending_or_in_progress "$repo_slug" "$pr_number" >/dev/null 2>&1; then
+		if _check_required_checks_have_pending_or_in_progress "$repo_slug" "$pr_number" "$_head_oid" >/dev/null 2>&1; then
 			echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: skipping CI-drift update-branch because required checks are active on the current head; wait for current CI or rely on native auto-merge to avoid restarting checks (GH#26406)" >>"$LOGFILE"
 			return 1
 		fi
@@ -646,7 +663,33 @@ _attempt_pr_ci_rebase_retry() {
 		return 1
 	fi
 	if [[ $_terminal_check_rc -ne 0 ]]; then
+		if [[ "$_rebase_policy" == "$_review_repair_policy" ]]; then
+			echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: terminal required-check evidence unavailable before strict review-repair rebase; preserving CHANGES_REQUESTED" >>"$LOGFILE"
+			return 1
+		fi
 		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: required-check head-state unavailable before CI-drift update-branch; fail-open to existing update-branch behaviour (GH#26406)" >>"$LOGFILE"
+	fi
+	if [[ "$_rebase_policy" == "$_review_repair_policy" ]]; then
+		local _pending_check_rc=0
+		_check_required_checks_have_pending_or_in_progress "$repo_slug" "$pr_number" "$_head_oid" >/dev/null 2>&1 || _pending_check_rc=$?
+		if [[ "$_pending_check_rc" -ne 1 ]]; then
+			if [[ "$_pending_check_rc" -eq 0 ]]; then
+				echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: strict review-repair rebase deferred because required checks remain active on the current head" >>"$LOGFILE"
+			else
+				echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: active required-check state unavailable before strict review-repair rebase; preserving CHANGES_REQUESTED" >>"$LOGFILE"
+			fi
+			return 1
+		fi
+		# #aidevops:trust-boundary — update-branch is a write. Revalidate live PR
+		# labels, linked-issue holds, author permission, external authority, and
+		# the exact expected head immediately before the repair mutation. This
+		# keeps PR-level needs-maintainer-review authoritative even though the
+		# repair-only gate intentionally stops before merge-only final checks.
+		if ! declare -F _pulse_merge_admin_safety_check >/dev/null 2>&1 \
+			|| ! _pulse_merge_admin_safety_check "$pr_number" "$repo_slug" "$_head_oid"; then
+			echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: live PR authority failed before strict review-repair rebase; preserving CHANGES_REQUESTED" >>"$LOGFILE"
+			return 1
+		fi
 	fi
 
 	echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: attempting CI-drift rebase via update-branch (t2805)" >>"$LOGFILE"

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -1318,12 +1318,13 @@ _check_ruleset_required_reviews_passing() {
 # in_progress, waiting, skipped-by-dependency, expected, absent-from-rollup,
 # and null conclusions must not trigger close/requeue/repair routing.
 #
-# Args: $1=repo_slug, $2=pr_number
+# Args: $1=repo_slug, $2=pr_number, $3=expected_head_sha (optional)
 # Returns: 0=terminal failure found, 1=no terminal failures, 2=API/parse error
 #######################################
 _check_required_checks_has_terminal_failure() {
 	local repo_slug="$1"
 	local pr_number="$2"
+	local expected_head_sha="${3:-}"
 
 	local required_contexts=""
 	required_contexts=$(_required_contexts_for_default_branch "$repo_slug") || return 2
@@ -1332,9 +1333,11 @@ _check_required_checks_has_terminal_failure() {
 		return 1
 	fi
 
-	local pr_sha=""
-	pr_sha=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
-		--json headRefOid --jq '.headRefOid // ""') || true
+	local pr_sha="$expected_head_sha"
+	if [[ -z "$pr_sha" ]]; then
+		pr_sha=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view "$pr_number" --repo "$repo_slug" \
+			--json headRefOid --jq '.headRefOid // ""') || true
+	fi
 	if [[ -z "$pr_sha" ]]; then
 		echo "[pulse-merge] _check_required_checks_has_terminal_failure: headRefOid fetch failed for PR #${pr_number} in ${repo_slug} — failing closed (t3567)" >>"$LOGFILE"
 		return 2
@@ -1386,13 +1389,14 @@ _check_required_checks_has_terminal_failure() {
 # This is the pre-update guard for branch refresh paths: mutating a PR branch
 # while required checks are still active restarts CI and wastes runner time.
 #
-# Args: $1=repo_slug, $2=pr_number
+# Args: $1=repo_slug, $2=pr_number, $3=expected_head_sha (optional)
 # Returns: 0=pending/in-progress required check found, 1=no active required
 #          checks, 2=API/parse error
 #######################################
 _check_required_checks_have_pending_or_in_progress() {
 	local repo_slug="$1"
 	local pr_number="$2"
+	local expected_head_sha="${3:-}"
 
 	local required_contexts=""
 	required_contexts=$(_required_contexts_for_default_branch "$repo_slug") || return 2
@@ -1401,9 +1405,11 @@ _check_required_checks_have_pending_or_in_progress() {
 		return 1
 	fi
 
-	local pr_sha=""
-	pr_sha=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
-		--json headRefOid --jq '.headRefOid // ""') || true
+	local pr_sha="$expected_head_sha"
+	if [[ -z "$pr_sha" ]]; then
+		pr_sha=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh_pr_view "$pr_number" --repo "$repo_slug" \
+			--json headRefOid --jq '.headRefOid // ""') || true
+	fi
 	if [[ -z "$pr_sha" ]]; then
 		echo "[pulse-merge] _check_required_checks_have_pending_or_in_progress: headRefOid fetch failed for PR #${pr_number} in ${repo_slug} — failing open for branch-update caller (GH#26406)" >>"$LOGFILE"
 		return 2

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -77,6 +77,8 @@ PULSE_REVIEW_REMEDIATION_NO_MATCH_RC=11
 PULSE_REVIEW_REMEDIATION_MAINTAINER_ATTENTION_RC=12
 PULSE_REVIEW_REMEDIATION_RETRYABLE_FAILURE_RC=13
 _PULSE_MERGE_REMEDIATION_OUTCOME=""
+PULSE_REVIEW_DECISION_CHANGES_REQUESTED="CHANGES_REQUESTED"
+PULSE_REVIEW_GATE_MODE_CI_REBASE_ONLY="ci-rebase-only"
 
 # t2863: Module-level variable defaults (set -u guards).
 # When this module is sourced standalone (e.g. pulse-merge-routine.sh, test
@@ -277,8 +279,10 @@ source "${_PULSE_MERGE_DIR}/pulse-merge-required-checks.sh"
 # CodeRabbit-only dismissal path clears stale bot nits before normal gates run.
 #
 # Returns 0 if the caller may keep evaluating merge gates.
-# Returns 1 if the PR must be skipped for review feedback handling.
-# Args: $1=pr_number, $2=repo_slug, $3=pr_review, $4=linked_issue, $5=pr_labels (optional), $6=dismissed_dest_var (optional)
+# Returns 1 if the PR remains review-blocked. A converged remediation may also
+# set review_gate_mode_dest_var=ci-rebase-only for an explicit repair-only path.
+# Args: $1=pr_number, $2=repo_slug, $3=pr_review, $4=linked_issue, $5=pr_labels (optional),
+#       $6=dismissed_dest_var (optional), $7=review_gate_mode_dest_var (optional)
 #######################################
 _handle_changes_requested_review_gate() {
 	local pr_number="$1"
@@ -287,13 +291,19 @@ _handle_changes_requested_review_gate() {
 	local linked_issue="$4"
 	local pr_labels="${5:-}"
 	local dismissed_dest_var="${6:-}"
+	local review_gate_mode_dest_var="${7:-}"
 	local _cr_pr_labels=""
+	local _changes_requested="${PULSE_REVIEW_DECISION_CHANGES_REQUESTED:-CHANGES_REQUESTED}"
+	local _ci_rebase_only="${PULSE_REVIEW_GATE_MODE_CI_REBASE_ONLY:-ci-rebase-only}"
 
 	if [[ -n "$dismissed_dest_var" && "$dismissed_dest_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
 		printf -v "$dismissed_dest_var" '%s' "0"
 	fi
+	if [[ -n "$review_gate_mode_dest_var" && "$review_gate_mode_dest_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+		printf -v "$review_gate_mode_dest_var" '%s' "merge"
+	fi
 
-	[[ "$pr_review" == "CHANGES_REQUESTED" ]] || return 0
+	[[ "$pr_review" == "$_changes_requested" ]] || return 0
 
 	# Fetch labels once — reused by both the nits-ok check and the
 	# worker-routing block below.
@@ -334,7 +344,10 @@ _handle_changes_requested_review_gate() {
 		if [[ "$_PULSE_MERGE_REMEDIATION_OUTCOME" == "deferred" ]]; then
 			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED; response remediation already active/deferred, preserving PR" >>"$LOGFILE"
 		elif [[ "$_PULSE_MERGE_REMEDIATION_OUTCOME" == "converged" ]]; then
-			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED; no matching unresolved thread remained after refresh, preserving PR for reevaluation" >>"$LOGFILE"
+			if [[ -n "$review_gate_mode_dest_var" && "$review_gate_mode_dest_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+				printf -v "$review_gate_mode_dest_var" '%s' "$_ci_rebase_only"
+			fi
+			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED; no matching unresolved thread remained after refresh, preserving the review block while allowing trust-gated CI-drift repair evaluation" >>"$LOGFILE"
 		elif [[ "$_PULSE_MERGE_REMEDIATION_OUTCOME" == "maintainer_attention" ]]; then
 			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED; terminal review-thread maintainer attention pending, preserving PR" >>"$LOGFILE"
 		else
@@ -357,11 +370,13 @@ _handle_changes_requested_review_gate() {
 }
 
 #######################################
-# Run all merge-eligibility gate checks for a single PR.
-# Returns 0 if all gates pass (PR may proceed to merge).
+# Run all merge-eligibility or repair-authority gate checks for a single PR.
+# Returns 0 if all gates for the requested mode pass. Only merge mode permits
+# the caller to proceed toward merge; ci-rebase-only must return after repair.
 # Returns 1 if any gate fails (PR should be skipped).
 # Args: $1=pr_number, $2=repo_slug, $3=pr_author, $4=pr_review, $5=linked_issue,
-#       $6=pr_labels (optional), $7=expected_head_sha (optional)
+#       $6=pr_labels (optional), $7=expected_head_sha (optional),
+#       $8=review_gate_mode (optional: merge|ci-rebase-only)
 #######################################
 _check_pr_merge_gates() {
 	local pr_number="$1"
@@ -371,6 +386,9 @@ _check_pr_merge_gates() {
 	local linked_issue="$5"
 	local pr_labels="${6:-}"
 	local expected_head_sha="${7:-}"
+	local review_gate_mode="${8:-merge}"
+	local _changes_requested="${PULSE_REVIEW_DECISION_CHANGES_REQUESTED:-CHANGES_REQUESTED}"
+	local _ci_rebase_only="${PULSE_REVIEW_GATE_MODE_CI_REBASE_ONLY:-ci-rebase-only}"
 	_PULSE_REVIEW_GATE_EVIDENCE=""
 
 	# Skip CHANGES_REQUESTED — needs a fix worker, not a merge.
@@ -388,9 +406,26 @@ _check_pr_merge_gates() {
 	# label and EVERY CHANGES_REQUESTED reviewer is coderabbitai[bot],
 	# auto-dismiss those reviews and fall through to the next gate. If any
 	# human reviewer is also blocking, the label is ignored.
-	if ! _handle_changes_requested_review_gate "$pr_number" "$repo_slug" "$pr_review" "$linked_issue" "$pr_labels"; then
+	case "$review_gate_mode" in
+	merge)
+		if ! _handle_changes_requested_review_gate "$pr_number" "$repo_slug" "$pr_review" "$linked_issue" "$pr_labels"; then
+			return 1
+		fi
+		;;
+	"$_ci_rebase_only")
+		# The early review gate already proved remediation converged. Skip only
+		# repeated review routing so the normal non-review trust gates can run.
+		# The caller must remain on the repair-only path and return before merge.
+		if [[ "$pr_review" != "$_changes_requested" ]]; then
+			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — ci-rebase-only review mode requires CHANGES_REQUESTED" >>"$LOGFILE"
+			return 1
+		fi
+		;;
+	*)
+		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — unknown review gate mode ${review_gate_mode}" >>"$LOGFILE"
 		return 1
-	fi
+		;;
+	esac
 
 	# Skip external contributor PRs (non-collaborator).
 	# t3063 crypto-approval bypass: a verified maintainer signature on the PR
@@ -493,6 +528,15 @@ _check_pr_merge_gates() {
 		if ! _attempt_worker_briefed_auto_merge "$pr_number" "$repo_slug" "$_oi_labels_str" "$_oi_is_draft" "$linked_issue" "$_author_collab_permission" "$pr_author"; then
 			return 1
 		fi
+	fi
+
+	# A converged CHANGES_REQUESTED remediation may perform a branch repair,
+	# but it cannot satisfy review. The ownership, permission, maintainer, and
+	# worker-brief trust gates above still apply; the review-bot gate remains a
+	# merge-only boundary and is re-evaluated on a later cycle after review.
+	if [[ "$review_gate_mode" == "$_ci_rebase_only" ]]; then
+		echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} passed non-review trust gates for ci-rebase-only evaluation; CHANGES_REQUESTED remains blocking" >>"$LOGFILE"
+		return 0
 	fi
 
 	# ── Review bot gate (GH#17490) ──
@@ -1433,7 +1477,10 @@ _process_single_ready_pr() {
 	# GitHub's mergeable cache to resolve. Keep this narrow: conflict handling
 	# above retains precedence, and the helper only routes/skips CHANGES_REQUESTED
 	# via the same origin-label and stale-handover checks used by the later gate.
-	if [[ "$pr_review" == "CHANGES_REQUESTED" ]]; then
+	local _review_gate_mode="merge"
+	local _changes_requested="${PULSE_REVIEW_DECISION_CHANGES_REQUESTED:-CHANGES_REQUESTED}"
+	local _ci_rebase_only="${PULSE_REVIEW_GATE_MODE_CI_REBASE_ONLY:-ci-rebase-only}"
+	if [[ "$pr_review" == "$_changes_requested" ]]; then
 		if [[ "${DRY_RUN:-0}" == "1" ]]; then
 			echo "[pulse-wrapper] DRY-RUN: PR #${pr_number} in ${repo_slug} has CHANGES_REQUESTED; would evaluate review remediation or repair routing" >>"$LOGFILE"
 			return 1
@@ -1441,9 +1488,11 @@ _process_single_ready_pr() {
 		local _early_review_linked_issue=""
 		local _early_review_dismissed="0"
 		_early_review_linked_issue=$(_extract_linked_issue "$pr_number" "$repo_slug" 2>/dev/null) || _early_review_linked_issue=""
-		if ! _handle_changes_requested_review_gate "$pr_number" "$repo_slug" "$pr_review" "$_early_review_linked_issue" "$pr_labels" _early_review_dismissed; then
-			[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
-			return 1
+		if ! _handle_changes_requested_review_gate "$pr_number" "$repo_slug" "$pr_review" "$_early_review_linked_issue" "$pr_labels" _early_review_dismissed _review_gate_mode; then
+			if [[ "$_review_gate_mode" != "$_ci_rebase_only" ]]; then
+				[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}mergeability_s" "$_mergeability_start"
+				return 1
+			fi
 		fi
 		# Avoid re-processing stale CHANGES_REQUESTED metadata in the later merge
 		# gate after the CodeRabbit-only dismissal path has already succeeded.
@@ -1474,13 +1523,36 @@ _process_single_ready_pr() {
 	# maintainer gate, external-contributor gate, review bot gate) before both
 	# merge and CI-repair paths. This preserves the security boundary for PRs
 	# that are red but would not be trusted if green.
-	if ! _check_pr_merge_gates "$pr_number" "$repo_slug" "$pr_author" "$pr_review" "$linked_issue" "$pr_labels" "$pr_head_ref_oid"; then
+	if ! _check_pr_merge_gates "$pr_number" "$repo_slug" "$pr_author" "$pr_review" "$linked_issue" "$pr_labels" "$pr_head_ref_oid" "$_review_gate_mode"; then
 		return 1
 	fi
 
-	if [[ "${DRY_RUN:-0}" != "1" ]] \
+	# Repair-only mode must reach its strict update guard without any terminal PR
+	# mutation; CHANGES_REQUESTED still owns the PR lifecycle in this cycle.
+	if [[ "$_review_gate_mode" != "$_ci_rebase_only" ]] \
+		&& [[ "${DRY_RUN:-0}" != "1" ]] \
 		&& declare -F _pm_close_superseded_duplicate_pr_if_issue_solved >/dev/null 2>&1 \
 		&& _pm_close_superseded_duplicate_pr_if_issue_solved "$pr_number" "$repo_slug" "$linked_issue" "$pr_labels"; then
+		return 1
+	fi
+
+	# A converged response-remediation cycle does not clear CHANGES_REQUESTED.
+	# It authorizes one narrowly bounded repair attempt only: all normal trust
+	# gates above must pass, the current head must have settled terminal-failure
+	# evidence, and the branch must be explicitly behind. Always return here so
+	# passing or indeterminate CI can never turn this mode into a merge bypass.
+	if [[ "$_review_gate_mode" == "$_ci_rebase_only" ]]; then
+		if [[ "${DRY_RUN:-0}" == "1" ]]; then
+			echo "[pulse-wrapper] DRY-RUN: PR #${pr_number} in ${repo_slug} remains CHANGES_REQUESTED; would evaluate strict CI-drift rebase only" >>"$LOGFILE"
+			return 1
+		fi
+		[[ -n "$timing_prefix" ]] && _branch_protection_start=$(_pmp_now_epoch)
+		if _attempt_pr_ci_rebase_retry "$pr_number" "$repo_slug" "$pr_base_ref_name" "$pr_head_ref_oid" "review-repair"; then
+			[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}branch_protection_s" "$_branch_protection_start"
+			return 1
+		fi
+		echo "[pulse-wrapper] Merge pass: preserving PR #${pr_number} in ${repo_slug} — CHANGES_REQUESTED remains blocking and strict CI-drift rebase was not eligible or did not succeed" >>"$LOGFILE"
+		[[ -n "$timing_prefix" ]] && _pmp_add_elapsed_seconds "${timing_prefix}branch_protection_s" "$_branch_protection_start"
 		return 1
 	fi
 

--- a/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
+++ b/.agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh
@@ -353,6 +353,7 @@ define_process_helper() {
 	DRY_RUN=0
 	GATE_CALLS=0
 	GATE_REVIEW_ARG=""
+	GATE_REVIEW_MODE=""
 	RESOLVE_CALLS=0
 	ROUTE_CALLS=0
 	ROUTE_ARGS=""
@@ -361,6 +362,10 @@ define_process_helper() {
 	DISMISS_CALLS=0
 	PR_REQUIRED_CHECKS_RC=1
 	REBASE_RETRY_RC=1
+	REBASE_RETRY_CALLS=0
+	REBASE_RETRY_POLICY=""
+	DUPLICATE_CLOSE_RC=1
+	DUPLICATE_CLOSE_CALLS=0
 	PREFLIGHT_RC=0
 	PREFLIGHT_EVIDENCE="[]"
 	REFRESHED_MERGEABLE="UNKNOWN"
@@ -374,12 +379,13 @@ define_process_helper() {
 	_pmp_review_decision_is_unknown() { local raw_decision="$1" _test_normalized_decision=""; _pmp_normalize_review_decision_into _test_normalized_decision "$raw_decision"; [[ "$_test_normalized_decision" == "UNKNOWN" ]]; return $?; }
 	_pmp_refresh_unknown_review_decision_into() { local dest_var="$1" pr_number="$2" repo_slug="$3" review_decision="$4"; [[ -n "$pr_number$repo_slug$review_decision" ]]; REVIEW_REFRESH_CALLS=$((REVIEW_REFRESH_CALLS + 1)); printf -v "$dest_var" '%s' "$REFRESHED_REVIEW_DECISION"; return 0; }
 	_extract_linked_issue() { local pr_number="$1" repo_slug="$2"; [[ -n "$pr_number$repo_slug" ]]; printf '42\n'; return 0; }
-	_check_pr_merge_gates() { local pr_number="$1" repo_slug="$2" pr_author="$3" pr_review="$4" linked_issue="$5"; [[ -n "$pr_number$repo_slug$pr_author$pr_review$linked_issue" ]]; GATE_CALLS=$((GATE_CALLS + 1)); GATE_REVIEW_ARG="$pr_review"; return 0; }
+	_check_pr_merge_gates() { local pr_number="$1" repo_slug="$2" pr_author="$3" pr_review="$4" linked_issue="$5" review_mode="${8:-merge}"; [[ -n "$pr_number$repo_slug$pr_author$pr_review$linked_issue" ]]; GATE_CALLS=$((GATE_CALLS + 1)); GATE_REVIEW_ARG="$pr_review"; GATE_REVIEW_MODE="$review_mode"; return 0; }
 	_pr_required_checks_pass() { local pr_number="$1" repo_slug="$2"; [[ -n "$pr_number$repo_slug" ]]; if [[ "$PR_REQUIRED_CHECKS_RC" -eq 0 ]]; then return 0; fi; return 1; }
 	_check_required_checks_passing() { local repo_slug="$1" pr_number="$2"; [[ -n "$repo_slug$pr_number" ]]; return 1; }
 	_is_trusted_dependabot_update_pr() { local pr_number="$1" repo_slug="$2" pr_author="$3"; [[ -n "$pr_number$repo_slug$pr_author" ]]; return 1; }
 	_trusted_dependabot_non_review_checks_green() { local pr_number="$1" repo_slug="$2" pr_obj="$3"; [[ -n "$pr_number$repo_slug$pr_obj" ]]; return 1; }
-	_attempt_pr_ci_rebase_retry() { local pr_number="$1" repo_slug="$2"; [[ -n "$pr_number$repo_slug" ]]; return "$REBASE_RETRY_RC"; }
+	_attempt_pr_ci_rebase_retry() { local pr_number="$1" repo_slug="$2" rebase_policy="${5:-standard}"; [[ -n "$pr_number$repo_slug" ]]; REBASE_RETRY_CALLS=$((REBASE_RETRY_CALLS + 1)); REBASE_RETRY_POLICY="$rebase_policy"; return "$REBASE_RETRY_RC"; }
+	_pm_close_superseded_duplicate_pr_if_issue_solved() { local pr_number="$1" repo_slug="$2" linked_issue="$3" pr_labels="$4"; [[ -n "$pr_number$repo_slug$linked_issue$pr_labels" ]]; DUPLICATE_CLOSE_CALLS=$((DUPLICATE_CLOSE_CALLS + 1)); return "$DUPLICATE_CLOSE_RC"; }
 	_route_pr_to_fix_worker() { local pr_number="$1" repo_slug="$2" linked_issue="$3" mode="$4" pr_labels="${5:-}" checks_json="${9:-}"; ROUTE_CALLS=$((ROUTE_CALLS + 1)); ROUTE_ARGS="${pr_number}|${repo_slug}|${linked_issue}|${mode}"; ROUTE_LABELS="$pr_labels"; ROUTE_EVIDENCE="$checks_json"; return 0; }
 	_pulse_merge_dismiss_coderabbit_nits() { local pr_number="$1" repo_slug="$2"; [[ -n "$pr_number$repo_slug" ]]; DISMISS_CALLS=$((DISMISS_CALLS + 1)); if [[ "${DISMISS_NITS_RC:-0}" -eq 0 ]]; then return 0; fi; return 1; }
 	_attempt_pr_update_branch() { return 1; }
@@ -534,6 +540,105 @@ test_rebase_success_defers_ci_repair_route() {
 		print_result "successful CI-drift rebase defers CI repair routing" 1 "route_calls=${ROUTE_CALLS}, route_args=${ROUTE_ARGS}"
 	else
 		print_result "successful CI-drift rebase defers CI repair routing" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_converged_changes_requested_runs_strict_rebase_only() {
+	setup_test_env
+	define_process_helper || { print_result "defines process helper for review-repair rebase" 1 "could not extract _process_single_ready_pr or review gate"; teardown_test_env; return 0; }
+	_pulse_merge_changes_requested_thread_remediation_first_enabled() { return 0; }
+	_pulse_merge_dispatch_review_thread_remediation() { _PULSE_MERGE_REMEDIATION_OUTCOME="converged"; return 0; }
+
+	local pr_object rc=0
+	REBASE_RETRY_RC=0
+	DUPLICATE_CLOSE_RC=0
+	printf -v pr_object '%s' '{"number":558,"state":"OPEN","mergeable":"MERGEABLE","reviewDecision":"CHANGES_REQUESTED","author":{"login":"worker-bot"},"title":"GH#503: repair drift","updatedAt":"2026-08-03T00:00:00Z","headRefOid":"sha558","headRefName":"fix/review-repair","baseRefName":"main","labels":[{"name":"origin:worker"},{"name":"status:in-review"}],"isDraft":false}'
+	_process_single_ready_pr "owner/repo" "$pr_object" || rc=$?
+
+	if [[ "$rc" -ne 1 ]]; then
+		print_result "converged CHANGES_REQUESTED runs strict rebase only" 1 "Expected skip return 1, got ${rc}"
+	elif [[ "$GATE_CALLS" -ne 1 || "$GATE_REVIEW_ARG" != "CHANGES_REQUESTED" || "$GATE_REVIEW_MODE" != "ci-rebase-only" ]]; then
+		print_result "converged CHANGES_REQUESTED runs strict rebase only" 1 "gate_calls=${GATE_CALLS}, gate_review=${GATE_REVIEW_ARG}, gate_mode=${GATE_REVIEW_MODE}"
+	elif [[ "$REBASE_RETRY_CALLS" -ne 1 || "$REBASE_RETRY_POLICY" != "review-repair" ]]; then
+		print_result "converged CHANGES_REQUESTED runs strict rebase only" 1 "rebase_calls=${REBASE_RETRY_CALLS}, policy=${REBASE_RETRY_POLICY}"
+	elif [[ "$DUPLICATE_CLOSE_CALLS" -ne 0 ]]; then
+		print_result "converged CHANGES_REQUESTED runs strict rebase only" 1 "duplicate_close_calls=${DUPLICATE_CLOSE_CALLS}"
+	elif [[ "$ROUTE_CALLS" -ne 0 ]]; then
+		print_result "converged CHANGES_REQUESTED runs strict rebase only" 1 "route_calls=${ROUTE_CALLS}, route_args=${ROUTE_ARGS}"
+	else
+		print_result "converged CHANGES_REQUESTED runs trust-gated strict rebase only" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_converged_changes_requested_never_falls_through_to_merge() {
+	setup_test_env
+	define_process_helper || { print_result "defines process helper for review-repair merge block" 1 "could not extract _process_single_ready_pr or review gate"; teardown_test_env; return 0; }
+	_pulse_merge_changes_requested_thread_remediation_first_enabled() { return 0; }
+	_pulse_merge_dispatch_review_thread_remediation() { _PULSE_MERGE_REMEDIATION_OUTCOME="converged"; return 0; }
+
+	local pr_object rc=0
+	PR_REQUIRED_CHECKS_RC=0
+	REBASE_RETRY_RC=1
+	printf -v pr_object '%s' '{"number":559,"state":"OPEN","mergeable":"MERGEABLE","reviewDecision":"CHANGES_REQUESTED","author":{"login":"worker-bot"},"title":"GH#504: preserve review block","updatedAt":"2026-08-03T00:00:00Z","headRefOid":"sha559","headRefName":"fix/review-block","baseRefName":"main","labels":[{"name":"origin:worker"},{"name":"status:in-review"}],"isDraft":false}'
+	_process_single_ready_pr "owner/repo" "$pr_object" || rc=$?
+
+	if [[ "$rc" -ne 1 || "$REBASE_RETRY_CALLS" -ne 1 || "$ROUTE_CALLS" -ne 0 ]]; then
+		print_result "converged CHANGES_REQUESTED never reaches merge" 1 "rc=${rc}, rebase_calls=${REBASE_RETRY_CALLS}, route_calls=${ROUTE_CALLS}"
+	else
+		print_result "converged CHANGES_REQUESTED remains blocking after repair-only no-op" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_repair_only_gate_stops_before_review_bot_boundary() {
+	setup_test_env
+	define_process_helper || { print_result "defines repair-only gate helper" 1 "could not extract review gate"; teardown_test_env; return 0; }
+	local gate_src="" gate_rc=0 review_bot_calls=0
+	local old_agents_dir="${AGENTS_DIR:-}"
+	gate_src=$(extract_function _check_pr_merge_gates "$MERGE_SCRIPT")
+	if [[ -z "$gate_src" ]]; then
+		print_result "repair-only gate stops before review-bot boundary" 1 "could not extract _check_pr_merge_gates"
+		teardown_test_env
+		return 0
+	fi
+	AGENTS_DIR="${TEST_ROOT}/agents"
+	mkdir -p "${AGENTS_DIR}/scripts"
+	: >"${AGENTS_DIR}/scripts/review-bot-gate-helper.sh"
+	_is_collaborator_author() { _PULSE_AUTHOR_PERMISSION_VALUE="write"; return 0; }
+	check_pr_modifies_workflows() { return 1; }
+	_pm_issue_api() { local repo_slug="$1" issue_number="$2"; printf 'repos/%s/issues/%s\n' "$repo_slug" "$issue_number"; return 0; }
+	gh() { return 0; }
+	gh_pr_view() {
+		if [[ "$*" == *"labels,isDraft"* ]]; then
+			printf '%s\n' '{"labels":[{"name":"origin:worker"}],"isDraft":false}'
+		else
+			printf 'origin:worker\n'
+		fi
+		return 0
+	}
+	_attempt_worker_briefed_auto_merge() { return 0; }
+	bash() { review_bot_calls=$((review_bot_calls + 1)); return 1; }
+	# shellcheck disable=SC1090
+	eval "$gate_src"
+
+	_check_pr_merge_gates "560" "owner/repo" "worker-bot" "CHANGES_REQUESTED" "42" "origin:worker" "sha560" "ci-rebase-only" || gate_rc=$?
+	unset -f bash gh gh_pr_view _is_collaborator_author check_pr_modifies_workflows \
+		_pm_issue_api _attempt_worker_briefed_auto_merge _check_pr_merge_gates
+	if [[ -n "$old_agents_dir" ]]; then
+		AGENTS_DIR="$old_agents_dir"
+	else
+		unset AGENTS_DIR
+	fi
+
+	if [[ "$gate_rc" -ne 0 || "$review_bot_calls" -ne 0 ]]; then
+		print_result "repair-only gate stops before review-bot boundary" 1 "gate_rc=${gate_rc}, review_bot_calls=${review_bot_calls}"
+	else
+		print_result "repair-only mode applies non-review trust gates without treating review as cleared" 0
 	fi
 	teardown_test_env
 	return 0
@@ -1111,6 +1216,9 @@ test_ci_feedback_includes_required_and_advisory_failures_together() {
 main() {
 	test_red_pr_passes_gates_before_repair_route
 	test_rebase_success_defers_ci_repair_route
+	test_converged_changes_requested_runs_strict_rebase_only
+	test_converged_changes_requested_never_falls_through_to_merge
+	test_repair_only_gate_stops_before_review_bot_boundary
 	test_preflight_terminal_blocker_routes_supplied_evidence
 	test_changes_requested_unknown_routes_before_mergeable_skip
 	test_rest_missing_review_decision_refreshes_before_ci_route

--- a/.agents/scripts/tests/test-pulse-merge-pr-context.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-context.sh
@@ -68,12 +68,19 @@ install_stubs() {
 	ISSUE_METADATA_FAIL=0
 	PR_AUTHOR="maintainer"
 	ROUTE_GUARD_RC=0
+	COMPARE_FAIL=0
+	COMPARE_BEHIND=1
+	TERMINAL_CHECK_RC=0
+	PENDING_CHECK_RC=1
+	ADMIN_SAFETY_RC=0
+	UPDATE_BRANCH_RC=0
 	gh() {
 		local arg1="${1:-}"
 		local arg2="${2:-}"
 		local args="$*"
 		printf 'gh %s\n' "$args" >>"$GH_CALL_LOG"
 		if [[ "$arg1" == "api" && "$args" == *"/compare/"* ]]; then
+			[[ "${COMPARE_FAIL:-0}" == "1" ]] && return 1
 			printf '%s\n' "${COMPARE_BEHIND:-1}"
 			return 0
 		fi
@@ -107,6 +114,10 @@ install_stubs() {
 	_dispatch_ci_fix_worker() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; printf 'dispatch-ci %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" >>"$GH_CALL_LOG"; return 0; }
 	_dispatch_pr_fix_worker() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; printf 'dispatch-review %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" >>"$GH_CALL_LOG"; return 0; }
 	_dispatch_conflict_fix_worker() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; printf 'dispatch-conflict %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" >>"$GH_CALL_LOG"; return 0; }
+	_check_required_checks_has_terminal_failure() { local repo_slug="$1"; local pr_number="$2"; local expected_head_sha="${3:-}"; printf 'terminal-check %s %s %s\n' "$repo_slug" "$pr_number" "$expected_head_sha" >>"$GH_CALL_LOG"; return "$TERMINAL_CHECK_RC"; }
+	_check_required_checks_have_pending_or_in_progress() { local repo_slug="$1"; local pr_number="$2"; local expected_head_sha="${3:-}"; printf 'pending-check %s %s %s\n' "$repo_slug" "$pr_number" "$expected_head_sha" >>"$GH_CALL_LOG"; return "$PENDING_CHECK_RC"; }
+	_pulse_merge_admin_safety_check() { local pr_number="$1"; local repo_slug="$2"; local expected_head_sha="${3:-}"; printf 'admin-safety %s %s %s\n' "$pr_number" "$repo_slug" "$expected_head_sha" >>"$GH_CALL_LOG"; return "$ADMIN_SAFETY_RC"; }
+	_pmp_update_branch_rest() { local pr_number="$1"; local repo_slug="$2"; local head_oid="$3"; printf 'update-branch %s %s %s\n' "$pr_number" "$repo_slug" "$head_oid" >>"$GH_CALL_LOG"; return "$UPDATE_BRANCH_RC"; }
 	_feedback_route_guard_existing_terminal_label() { local pr_number="$1"; local repo_slug="$2"; local linked_issue="$3"; local kind="$4"; printf 'route-guard %s %s %s %s\n' "$pr_number" "$repo_slug" "$linked_issue" "$kind" >>"$GH_CALL_LOG"; return "$ROUTE_GUARD_RC"; }
 	_interactive_pr_is_stale() { return 1; }
 	_is_collaborator_author() { local author="$1"; [[ "$author" == "maintainer" ]]; return $?; }
@@ -140,6 +151,77 @@ test_ci_rebase_fetches_when_context_missing() {
 		return 0
 	fi
 	pass "CI rebase falls back to volatile refetch"
+	return 0
+}
+
+test_review_repair_rebase_requires_explicit_behind_evidence() {
+	install_stubs
+	: >"$GH_CALL_LOG"
+	COMPARE_FAIL=1
+	local rc=0
+	_attempt_pr_ci_rebase_retry "123" "owner/repo" "main" "deadbeef" "review-repair" || rc=$?
+
+	if [[ "$rc" -ne 1 ]] || grep -q '^update-branch ' "$GH_CALL_LOG"; then
+		fail "review-repair rebase requires explicit behind evidence" "rc=${rc}; calls=$(tr '\n' ';' <"$GH_CALL_LOG")"
+		return 0
+	fi
+	pass "review-repair rebase fails closed without explicit behind evidence"
+	return 0
+}
+
+test_review_repair_rebase_waits_for_active_checks() {
+	install_stubs
+	: >"$GH_CALL_LOG"
+	COMPARE_BEHIND=1
+	PENDING_CHECK_RC=0
+	local rc=0
+	_attempt_pr_ci_rebase_retry "123" "owner/repo" "main" "deadbeef" "review-repair" || rc=$?
+
+	if [[ "$rc" -ne 1 ]] || grep -q '^update-branch ' "$GH_CALL_LOG"; then
+		fail "review-repair rebase waits for active checks" "rc=${rc}; calls=$(tr '\n' ';' <"$GH_CALL_LOG")"
+		return 0
+	fi
+	pass "review-repair rebase does not restart active required checks"
+	return 0
+}
+
+test_review_repair_rebase_revalidates_live_pr_authority() {
+	install_stubs
+	: >"$GH_CALL_LOG"
+	COMPARE_BEHIND=1
+	TERMINAL_CHECK_RC=0
+	PENDING_CHECK_RC=1
+	ADMIN_SAFETY_RC=1
+	local rc=0
+	_attempt_pr_ci_rebase_retry "123" "owner/repo" "main" "deadbeef" "review-repair" || rc=$?
+
+	if [[ "$rc" -ne 1 ]] || grep -q '^update-branch ' "$GH_CALL_LOG" \
+		|| ! grep -qF 'admin-safety 123 owner/repo deadbeef' "$GH_CALL_LOG"; then
+		fail "review-repair rebase revalidates live PR authority" "rc=${rc}; calls=$(tr '\n' ';' <"$GH_CALL_LOG")"
+		return 0
+	fi
+	pass "review-repair rebase preserves PR-level maintainer holds before update"
+	return 0
+}
+
+test_review_repair_rebase_updates_when_strictly_eligible() {
+	install_stubs
+	: >"$GH_CALL_LOG"
+	COMPARE_BEHIND=1
+	TERMINAL_CHECK_RC=0
+	PENDING_CHECK_RC=1
+	UPDATE_BRANCH_RC=0
+	local rc=0
+	_attempt_pr_ci_rebase_retry "123" "owner/repo" "main" "deadbeef" "review-repair" || rc=$?
+
+	if [[ "$rc" -ne 0 ]] || ! grep -q '^update-branch 123 owner/repo deadbeef$' "$GH_CALL_LOG" \
+		|| ! grep -qF 'terminal-check owner/repo 123 deadbeef' "$GH_CALL_LOG" \
+		|| ! grep -qF 'pending-check owner/repo 123 deadbeef' "$GH_CALL_LOG" \
+		|| ! grep -qF 'admin-safety 123 owner/repo deadbeef' "$GH_CALL_LOG"; then
+		fail "review-repair rebase updates when strictly eligible" "rc=${rc}; calls=$(tr '\n' ';' <"$GH_CALL_LOG")"
+		return 0
+	fi
+	pass "review-repair rebase updates only after settled terminal failure and behind evidence"
 	return 0
 }
 
@@ -366,6 +448,10 @@ main() {
 	install_stubs
 	test_ci_rebase_uses_provided_context
 	test_ci_rebase_fetches_when_context_missing
+	test_review_repair_rebase_requires_explicit_behind_evidence
+	test_review_repair_rebase_waits_for_active_checks
+	test_review_repair_rebase_revalidates_live_pr_authority
+	test_review_repair_rebase_updates_when_strictly_eligible
 	test_route_uses_provided_labels
 	test_route_falls_back_to_linked_worker_issue_for_ci
 	test_route_falls_back_to_linked_worker_issue_for_conflict

--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -404,6 +404,7 @@ define_function_under_test() {
 	eval_function_from_file _ruleset_required_review_count_for_default_branch "$REQUIRED_CHECKS_SCRIPT" || return 1
 	eval_function_from_file _check_ruleset_required_reviews_passing "$REQUIRED_CHECKS_SCRIPT" || return 1
 	eval_function_from_file _check_required_checks_has_terminal_failure "$REQUIRED_CHECKS_SCRIPT" || return 1
+	eval_function_from_file _check_required_checks_have_pending_or_in_progress "$REQUIRED_CHECKS_SCRIPT" || return 1
 	return 0
 }
 
@@ -707,6 +708,42 @@ test_skipping_required_allows_merge() {
 	return 0
 }
 
+test_terminal_classifier_uses_supplied_head() {
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export MOCK_GH_MODE="one_fail"
+	local actual_rc=0
+	_check_required_checks_has_terminal_failure "marcusquinn/aidevops" "19023" "review-head-terminal" || actual_rc=$?
+	if [[ "$actual_rc" -ne 0 ]]; then
+		print_result "terminal classifier binds checks to supplied head" 1 "Expected rc=0, got rc=${actual_rc}"
+	elif ! grep -Fq -- "/commits/review-head-terminal/check-runs" "$GH_CALL_LOG"; then
+		print_result "terminal classifier binds checks to supplied head" 1 "Expected supplied SHA in REST check-run call"
+	elif grep -Fq -- "pr view 19023" "$GH_CALL_LOG"; then
+		print_result "terminal classifier binds checks to supplied head" 1 "Unexpected volatile headRefOid lookup"
+	else
+		print_result "terminal classifier binds checks to supplied head" 0
+	fi
+	return 0
+}
+
+test_pending_classifier_uses_supplied_head() {
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export MOCK_GH_MODE="pending_only"
+	local actual_rc=0
+	_check_required_checks_have_pending_or_in_progress "marcusquinn/aidevops" "19023" "review-head-pending" || actual_rc=$?
+	if [[ "$actual_rc" -ne 0 ]]; then
+		print_result "pending classifier binds checks to supplied head" 1 "Expected rc=0, got rc=${actual_rc}"
+	elif ! grep -Fq -- "/commits/review-head-pending/check-runs" "$GH_CALL_LOG"; then
+		print_result "pending classifier binds checks to supplied head" 1 "Expected supplied SHA in REST check-run call"
+	elif grep -Fq -- "pr view 19023" "$GH_CALL_LOG"; then
+		print_result "pending classifier binds checks to supplied head" 1 "Unexpected volatile headRefOid lookup"
+	else
+		print_result "pending classifier binds checks to supplied head" 0
+	fi
+	return 0
+}
+
 test_ruleset_review_only_missing_blocks_merge() {
 	: >"$GH_CALL_LOG"
 	: >"$LOGFILE"
@@ -865,6 +902,8 @@ main() {
 	test_queued_required_is_non_terminal
 	test_expected_required_is_non_terminal
 	test_skipping_required_allows_merge
+	test_terminal_classifier_uses_supplied_head
+	test_pending_classifier_uses_supplied_head
 	test_ruleset_review_only_missing_blocks_merge
 	test_ruleset_review_count_accepts_prefetched_rulesets_json
 	test_ruleset_review_only_approved_allows_merge

--- a/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
+++ b/.agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh
@@ -476,7 +476,7 @@ test_changes_requested_active_remediation_preserves_pr_without_routing() {
 	return 0
 }
 
-test_changes_requested_converged_remediation_preserves_pr_without_routing() {
+test_changes_requested_converged_remediation_exposes_repair_only_mode() {
 	setup_test_env
 	export AIDEVOPS_CHANGES_REQUESTED_THREAD_REMEDIATION_FIRST=1
 	export SCANNER_RC=11
@@ -495,14 +495,16 @@ test_changes_requested_converged_remediation_preserves_pr_without_routing() {
 	_pulse_merge_dismiss_coderabbit_nits() {
 		return 1
 	}
+	local review_gate_mode="merge"
+	local gate_rc=0
 
-	_handle_changes_requested_review_gate 77 owner/repo CHANGES_REQUESTED 42 "origin:worker" || true
-	if [[ ! -s "$route_log" ]] &&
-		grep -q 'no matching unresolved thread remained after refresh, preserving PR for reevaluation' "$LOGFILE"; then
-		print_result "converged response remediation preserves CHANGES_REQUESTED PR" 0
+	_handle_changes_requested_review_gate 77 owner/repo CHANGES_REQUESTED 42 "origin:worker" "" review_gate_mode || gate_rc=$?
+	if [[ "$gate_rc" -eq 1 && "$review_gate_mode" == "ci-rebase-only" && ! -s "$route_log" ]] &&
+		grep -q 'preserving the review block while allowing trust-gated CI-drift repair evaluation' "$LOGFILE"; then
+		print_result "converged response remediation exposes repair-only mode" 0
 	else
-		print_result "converged response remediation preserves CHANGES_REQUESTED PR" 1 \
-			"route=$(tr '\n' ';' <"$route_log"), log=$(tr '\n' ';' <"$LOGFILE")"
+		print_result "converged response remediation exposes repair-only mode" 1 \
+			"gate_rc=${gate_rc}, mode=${review_gate_mode}, route=$(tr '\n' ';' <"$route_log"), log=$(tr '\n' ';' <"$LOGFILE")"
 	fi
 	teardown_test_env
 	return 0
@@ -687,7 +689,7 @@ main() {
 	test_changes_requested_opt_in_dispatches_remediation_without_routing
 	test_changes_requested_routes_when_remediation_unavailable
 	test_changes_requested_active_remediation_preserves_pr_without_routing
-	test_changes_requested_converged_remediation_preserves_pr_without_routing
+	test_changes_requested_converged_remediation_exposes_repair_only_mode
 	test_changes_requested_terminal_attention_preserves_pr_without_routing
 	test_changes_requested_hard_dispatch_failure_still_routes
 	test_changes_requested_skips_remediation_for_external_contributor


### PR DESCRIPTION
## Summary

Add a fail-closed ci-rebase-only path for converged CHANGES_REQUESTED remediation while preserving the review block and PR lifecycle.

## Files Changed

.agents/scripts/pulse-merge-process.sh, .agents/scripts/pulse-merge-required-checks.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh, .agents/scripts/tests/test-pulse-merge-pr-context.sh, .agents/scripts/tests/test-pulse-merge-required-checks-filter.sh, .agents/scripts/tests/test-pulse-merge-review-thread-remediation.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Pulse review-remediation, CI-routing, PR-context, required-check, authority, update-branch, worker-gate, routine, and REST review suites passed; ShellCheck and linters-local passed; exact independent closeout review clean.

Resolves #29403


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.219 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h 29m and 1,059,530 tokens on this with the user in an interactive session.