### PR TITLE
t18131: close residual GitHub quota evidence gaps

### DIFF
--- a/.agents/reference/github-api-efficiency.md
+++ b/.agents/reference/github-api-efficiency.md
@@ -141,7 +141,7 @@ relax quota attribution, or make concurrent uninstrumented API traffic exact.
 ### Evidence sidecar
 
 Each transport aggregate has one sidecar using
-`aidevops-github-api-efficiency-evidence/v2`. `transport_sha256` binds the
+`aidevops-github-api-efficiency-evidence/v3`. `transport_sha256` binds the
 sidecar to the exact aggregate bytes. The result also records the sidecar's own
 SHA-256 digest.
 
@@ -181,17 +181,19 @@ aggregate fetches inside the same scope. This distinguishes duplicate fetches in
 one cycle from freshness-required refreshes of an unchanged head in later cycles.
 The generation uses
 `github-api-efficiency-contract-v2-coverage-2.started-at`, so deployment starts a
-fresh bounded window automatically. Version-1 sidecars and earlier contract-2
-coverage windows remain immutable historical evidence.
+fresh bounded window automatically. Version-1 and version-2 sidecars plus
+earlier contract-2 coverage windows remain immutable historical evidence.
 
 The following is an intentionally incomplete template. Replace every required
 `null` with a privacy-safe observed value and set `complete` to `true` only when
-the whole fixed window has been reconciled. The transport digest must be 64
-lowercase hexadecimal characters.
+the whole fixed window has been reconciled. A distribution percentile remains
+`null` when its explicit sample count is observed as zero; this means “not
+applicable,” not “unknown.” The transport digest must be 64 lowercase
+hexadecimal characters.
 
 ```json
 {
-  "schema": "aidevops-github-api-efficiency-evidence/v2",
+  "schema": "aidevops-github-api-efficiency-evidence/v3",
   "transport_sha256": "<sha256-of-exact-transport-report>",
   "complete": false,
   "population": {
@@ -206,6 +208,7 @@ lowercase hexadecimal characters.
     "p50_ms": null,
     "p95_ms": null,
     "peak_attempts_per_minute": null,
+    "completed_action_samples": null,
     "completed_action_p95_ms": null
   },
   "cache": {
@@ -223,6 +226,7 @@ lowercase hexadecimal characters.
   },
   "webhook": {
     "invalidations": null,
+    "lag_samples": null,
     "lag_p50_ms": null,
     "lag_p95_ms": null,
     "duplicate_actions": null,
@@ -246,9 +250,12 @@ lowercase hexadecimal characters.
 ```
 
 Evidence values are non-negative JSON-safe numbers. Counts should remain
-integers. Repository identity is represented only by the SHA-256 digest of the
-sorted fixed repository set; do not put repository names, request payloads,
-tokens, URLs, or raw log records in the sidecar.
+integers. Sidecar v3 adds completed-action and webhook-lag sample counts so an
+observed empty distribution can remain complete without inventing a zero
+latency. Version-2 sidecars remain immutable historical evidence and are not
+accepted for new comparisons. Repository identity is represented only by the
+SHA-256 digest of the sorted fixed repository set; do not put repository names,
+request payloads, tokens, URLs, or raw log records in the sidecar.
 
 ### Evidence ownership
 
@@ -278,7 +285,10 @@ Default comparability rules:
   change by at most `25%`;
 - both reports contain exact attempts, zero unknown quota attempts, zero legacy
   or malformed records, and no unclassified transport attempts;
-- every sidecar field is known and both sidecars are marked complete;
+- every required sidecar field is known and both sidecars are marked complete;
+- a percentile may be null only when its matching sample count is zero; matching
+  empty distributions skip that metric, while one-sided sample availability is
+  noncomparable;
 - both windows contain at least one repository, Pulse cycle, and transport
   attempt.
 

--- a/.agents/scripts/dependabot-alert-monitor.sh
+++ b/.agents/scripts/dependabot-alert-monitor.sh
@@ -12,6 +12,9 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 DEPENDABOT_ALERT_MONITOR_STATE_DIR="${DEPENDABOT_ALERT_MONITOR_STATE_DIR:-${HOME}/.aidevops/cache/dependabot-alert-monitor}"
 DEPENDABOT_ALERT_MONITOR_REPOS_JSON="${DEPENDABOT_ALERT_MONITOR_REPOS_JSON:-${AIDEVOPS_REPOS_JSON:-${HOME}/.config/aidevops/repos.json}}"
 DEPENDABOT_ALERT_MONITOR_MAX_REPOS="${DEPENDABOT_ALERT_MONITOR_MAX_REPOS:-50}"
+DEPENDABOT_ALERT_MONITOR_CORE_RESERVE="${DEPENDABOT_ALERT_MONITOR_CORE_RESERVE:-250}"
+DEPENDABOT_ALERT_MONITOR_CORE_COST_PER_REPO="${DEPENDABOT_ALERT_MONITOR_CORE_COST_PER_REPO:-2}"
+_DAM_RATE_LIMIT_RC=75
 
 _dam_log() {
   local message="$1"
@@ -75,10 +78,68 @@ _dam_list_repos() {
   return $?
 }
 
+_dam_core_remaining() {
+  local remaining=""
+  remaining=$(AIDEVOPS_GH_ROUTE_DECISION="dependabot-alert-monitor-core-budget-rest" \
+    gh api rate_limit --jq '.resources.core.remaining // empty' 2>/dev/null) || return 1
+  [[ "$remaining" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "$remaining"
+  return 0
+}
+
+_dam_core_budget_allows_scan() {
+  local repo_count="$1"
+  local reserve="$DEPENDABOT_ALERT_MONITOR_CORE_RESERVE"
+  local cost_per_repo="$DEPENDABOT_ALERT_MONITOR_CORE_COST_PER_REPO"
+  local remaining=""
+  local required=0
+  [[ "$repo_count" =~ ^[0-9]+$ ]] || return 1
+  [[ "$reserve" =~ ^[0-9]+$ ]] || reserve=250
+  [[ "$cost_per_repo" =~ ^[1-9][0-9]*$ ]] || cost_per_repo=2
+  remaining=$(_dam_core_remaining) || {
+    _dam_log "core rate-limit state unavailable; skipping optional Dependabot fanout"
+    return 1
+  }
+  required=$((reserve + (repo_count * cost_per_repo)))
+  if [[ "$remaining" -lt "$required" ]]; then
+    _dam_log "core budget insufficient for Dependabot fanout: remaining=${remaining}, required=${required} (reserve=${reserve}, repos=${repo_count}, cost_per_repo=${cost_per_repo}); skipping"
+    return 1
+  fi
+  return 0
+}
+
+_dam_error_is_rate_limit() {
+  local error_text="$1"
+  local normalized=""
+  normalized=$(printf '%s' "$error_text" | tr '[:upper:]' '[:lower:]')
+  case "$normalized" in
+    *"rate limit"* | *"abuse detection"* | *"temporarily blocked"*) return 0 ;;
+  esac
+  return 1
+}
+
 _dam_fetch_alert_groups() {
   local repo_slug="$1"
   local alerts_json=""
-  alerts_json=$(gh api --paginate --slurp "repos/${repo_slug}/dependabot/alerts?state=open&per_page=100" 2>/dev/null) || return 1
+  local error_file=""
+  local error_text=""
+  local fetch_rc=0
+  error_file=$(mktemp "${AIDEVOPS_TEMP_DIR:-${TMPDIR:-/tmp}}/dependabot-alert-fetch.XXXXXX") || return 1
+  alerts_json=$(AIDEVOPS_GH_ROUTE_DECISION="dependabot-alert-monitor-alerts-rest" \
+    gh api --paginate --slurp "repos/${repo_slug}/dependabot/alerts?state=open&per_page=100" 2>"$error_file")
+  fetch_rc=$?
+  if [[ "$fetch_rc" -ne 0 ]]; then
+    error_text=$(<"$error_file")
+    rm -f "$error_file" 2>/dev/null || true
+    if _dam_error_is_rate_limit "$error_text"; then
+      return "$_DAM_RATE_LIMIT_RC"
+    fi
+    local remaining=""
+    remaining=$(_dam_core_remaining 2>/dev/null) || remaining=""
+    [[ "$remaining" == "0" ]] && return "$_DAM_RATE_LIMIT_RC"
+    return 1
+  fi
+  rm -f "$error_file" 2>/dev/null || true
   printf '%s\n' "$alerts_json" | jq -r '
     [ .[][]?
       | select(.state == "open")
@@ -231,10 +292,16 @@ dependabot_alert_monitor_scan_repo() {
   local skipped=0
   local package_name ecosystem patched_version manifests severities alert_count group_key
 
-  groups="$(_dam_fetch_alert_groups "$repo_slug")" || {
+  groups="$(_dam_fetch_alert_groups "$repo_slug")"
+  local fetch_rc=$?
+  if [[ "$fetch_rc" -eq "$_DAM_RATE_LIMIT_RC" ]]; then
+    _dam_log "GitHub rate limit reached while reading Dependabot alerts for ${repo_slug}"
+    return "$_DAM_RATE_LIMIT_RC"
+  fi
+  if [[ "$fetch_rc" -ne 0 ]]; then
     _dam_log "unable to read Dependabot alerts for ${repo_slug}; skipping"
     return 0
-  }
+  fi
 
   while IFS=$'\t' read -r package_name ecosystem patched_version manifests severities alert_count; do
     [[ -n "$package_name" ]] || continue
@@ -261,6 +328,10 @@ dependabot_alert_monitor_scan_repos() {
   local repos_json="${1:-$DEPENDABOT_ALERT_MONITOR_REPOS_JSON}"
   local dry_run="${2:-0}"
   local repo_count=0
+  local candidate_count=0
+  local max_repos="$DEPENDABOT_ALERT_MONITOR_MAX_REPOS"
+  local repo_rows=""
+  local scan_rc=0
   local repo_slug repo_path
 
   if [[ ! -f "$repos_json" ]]; then
@@ -268,15 +339,36 @@ dependabot_alert_monitor_scan_repos() {
     return 0
   fi
 
+  [[ "$max_repos" =~ ^[1-9][0-9]*$ ]] || max_repos=50
+  repo_rows=$(_dam_list_repos "$repos_json") || {
+    _dam_log "unable to read managed repositories from ${repos_json}; skipping"
+    return 0
+  }
+  while IFS=$'\t' read -r repo_slug repo_path; do
+    [[ -n "$repo_slug" ]] || continue
+    candidate_count=$((candidate_count + 1))
+    [[ "$candidate_count" -ge "$max_repos" ]] && break
+  done <<<"$repo_rows"
+  [[ "$candidate_count" -gt 0 ]] || {
+    _dam_log "scan complete across 0 managed repo(s)"
+    return 0
+  }
+  _dam_core_budget_allows_scan "$candidate_count" || return 0
+
   while IFS=$'\t' read -r repo_slug repo_path; do
     [[ -n "$repo_slug" ]] || continue
     repo_count=$((repo_count + 1))
-    if [[ "$repo_count" -gt "$DEPENDABOT_ALERT_MONITOR_MAX_REPOS" ]]; then
-      _dam_log "max repo limit reached (${DEPENDABOT_ALERT_MONITOR_MAX_REPOS}); skipping remainder"
+    if [[ "$repo_count" -gt "$max_repos" ]]; then
+      _dam_log "max repo limit reached (${max_repos}); skipping remainder"
       break
     fi
-    dependabot_alert_monitor_scan_repo "$repo_slug" "$dry_run" || true
-  done < <(_dam_list_repos "$repos_json" || true)
+    dependabot_alert_monitor_scan_repo "$repo_slug" "$dry_run"
+    scan_rc=$?
+    if [[ "$scan_rc" -eq "$_DAM_RATE_LIMIT_RC" ]]; then
+      _dam_log "stopping Dependabot fanout after rate-limit response from ${repo_slug}"
+      break
+    fi
+  done <<<"$repo_rows"
 
   _dam_log "scan complete across ${repo_count} managed repo(s)"
   return 0

--- a/.agents/scripts/dispatch-dedup-pr.sh
+++ b/.agents/scripts/dispatch-dedup-pr.sh
@@ -72,6 +72,156 @@ _ddpr_is_consolidation_task() {
 	return 1
 }
 
+_DDPR_JSON_ARRAY_TYPE="array"
+_DDPR_JSON_NUMBER_TYPE='number'
+
+_ddpr_closing_keyword_pattern() {
+	local issue_number="$1"
+	printf '%s' "(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}([^[:alnum:]_]|$)"
+	return 0
+}
+
+#######################################
+# Fetch open sibling PR candidates with response-owned GraphQL quota cost.
+#
+# Native `gh pr list` hides the multi-point GraphQL cost for this rich field
+# shape. Keep the existing 20-result search bound, but request rateLimit.cost in
+# the same response so exact-cost observations do not rely on cumulative deltas.
+#
+# Args: $1 = issue number, $2 = repo slug
+# Outputs: gh-pr-list-compatible JSON array
+# Returns: 0 for a complete response, 1 for API or validation failure
+#######################################
+_ddpr_graphql_open_siblings() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local search_query="repo:${repo_slug} is:pr is:open #${issue_number}"
+	local response="" pr_json=""
+
+	# shellcheck disable=SC2016
+	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="dispatch-dedup-open-siblings-exact-cost" \
+		gh api graphql -F queryString="$search_query" -f query='
+		query($queryString: String!) {
+			search(type: ISSUE, query: $queryString, first: 20) {
+				nodes {
+					__typename
+					... on PullRequest {
+						number title body isDraft reviewDecision
+						mergeStateStatus mergeable changedFiles
+						files(first: 100) {
+							nodes { path }
+							pageInfo { hasNextPage }
+						}
+						labels(first: 100) {
+							nodes { name }
+							pageInfo { hasNextPage }
+						}
+					}
+				}
+			}
+			rateLimit { cost }
+		}
+	' 2>/dev/null) || return 1
+
+	pr_json=$(printf '%s' "$response" | jq -ce \
+		--arg array_type "$_DDPR_JSON_ARRAY_TYPE" --arg number_type "$_DDPR_JSON_NUMBER_TYPE" '
+		select(((.errors // []) | type) == $array_type)
+		| select(((.errors // []) | length) == 0)
+		| select((.data.rateLimit.cost | type) == $number_type)
+		| select(.data.rateLimit.cost > 0 and (.data.rateLimit.cost | floor) == .data.rateLimit.cost)
+		| .data.search.nodes
+		| select(type == $array_type)
+		| select(all(.[];
+			.__typename == "PullRequest" and
+			(.number | type) == $number_type and
+			(.isDraft | type) == "boolean" and
+			((.files.nodes // []) | type) == $array_type and
+			.files.pageInfo.hasNextPage == false and
+			((.labels.nodes // []) | type) == $array_type and
+			.labels.pageInfo.hasNextPage == false
+		))
+		| map({
+			number,
+			title,
+			body,
+			isDraft,
+			reviewDecision,
+			mergeStateStatus,
+			mergeable,
+			changedFiles,
+			files: (.files.nodes // []),
+			labels: (.labels.nodes // [])
+		})
+	' 2>/dev/null) || return 1
+	printf '%s' "$pr_json"
+	return 0
+}
+
+#######################################
+# Fetch the ten newest open PR commit headlines with response-owned quota cost.
+#
+# Args: $1 = repo slug
+# Outputs: gh-pr-list-compatible JSON array
+# Returns: 0 for a complete response, 1 for API or validation failure
+#######################################
+_ddpr_graphql_open_commits() {
+	local repo_slug="$1"
+	local owner="${repo_slug%%/*}"
+	local repo="${repo_slug#*/}"
+	local response="" pr_json=""
+	[[ -n "$owner" && -n "$repo" && "$owner" != "$repo" && "$repo" != */* ]] || return 1
+
+	# shellcheck disable=SC2016
+	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="dispatch-dedup-open-commits-exact-cost" \
+		gh api graphql -f owner="$owner" -f name="$repo" -f query='
+		query($owner: String!, $name: String!) {
+			repository(owner: $owner, name: $name) {
+				pullRequests(
+					first: 10,
+					states: [OPEN],
+					orderBy: {field: CREATED_AT, direction: DESC}
+				) {
+					nodes {
+						number title isDraft
+						commits(first: 100) {
+							nodes { commit { messageHeadline } }
+							pageInfo { hasNextPage }
+						}
+					}
+				}
+			}
+			rateLimit { cost }
+		}
+	' 2>/dev/null) || return 1
+
+	pr_json=$(printf '%s' "$response" | jq -ce \
+		--arg array_type "$_DDPR_JSON_ARRAY_TYPE" --arg number_type "$_DDPR_JSON_NUMBER_TYPE" '
+		select(((.errors // []) | type) == $array_type)
+		| select(((.errors // []) | length) == 0)
+		| select((.data.rateLimit.cost | type) == $number_type)
+		| select(.data.rateLimit.cost > 0 and (.data.rateLimit.cost | floor) == .data.rateLimit.cost)
+		| .data.repository.pullRequests.nodes
+		| select(type == $array_type)
+		| select(all(.[];
+			(.number | type) == $number_type and
+			(.isDraft | type) == "boolean" and
+			(.commits.nodes | type) == $array_type and
+			.commits.pageInfo.hasNextPage == false and
+			all(.commits.nodes[]; (.commit.messageHeadline | type) == "string")
+		))
+		| map({
+			number,
+			title,
+			isDraft,
+			commits: [.commits.nodes[].commit | {messageHeadline}]
+		})
+	' 2>/dev/null) || return 1
+	printf '%s' "$pr_json"
+	return 0
+}
+
 #######################################
 # has_open_pr Check 0: healthy open sibling PRs for this issue.
 #
@@ -90,9 +240,7 @@ _has_open_pr_check_healthy_sibling() {
 	local repo_slug="$2"
 
 	local pr_json match_pr draft_pr draft_pr_number draft_pr_kind
-	pr_json=$(gh pr list --repo "$repo_slug" --state open \
-		--search "#${issue_number}" --limit 20 \
-		--json number,title,body,isDraft,reviewDecision,mergeStateStatus,mergeable,changedFiles,files,labels 2>/dev/null) || {
+	pr_json=$(_ddpr_graphql_open_siblings "$issue_number" "$repo_slug") || {
 		printf 'PR_LOOKUP_UNCERTAIN: open PR lookup failed for issue #%s in %s; dispatch is blocked\n' \
 			"$issue_number" "$repo_slug"
 		return 0
@@ -183,23 +331,27 @@ _has_open_pr_check_open_commits() {
 	local repo_slug="$2"
 
 	local open_pr_json open_pr_count
-	open_pr_json=$(gh pr list --repo "$repo_slug" --state open \
-		--json number,title,commits,isDraft --limit 10 2>/dev/null) || open_pr_json="[]"
+	open_pr_json=$(_ddpr_graphql_open_commits "$repo_slug") || {
+		printf 'PR_LOOKUP_UNCERTAIN: open PR commit lookup failed for issue #%s in %s; dispatch is blocked\n' \
+			"$issue_number" "$repo_slug"
+		return 0
+	}
 	open_pr_count=$(printf '%s' "$open_pr_json" | jq 'length' 2>/dev/null) || open_pr_count=0
 	[[ "$open_pr_count" =~ ^[0-9]+$ ]] || open_pr_count=0
 	[[ "$open_pr_count" -eq 0 ]] && return 1
 
 	# Match: closing keyword + #NNN in commit messages, or GH#NNN/#NNN in PR title
-	local close_pattern="(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}([^[:alnum:]_]|$)"
+	local close_pattern=""
+	close_pattern=$(_ddpr_closing_keyword_pattern "$issue_number")
 	local title_pattern="(GH#${issue_number}|#${issue_number})([^[:alnum:]_]|$)"
 
 	local match_pr
 	match_pr=$(printf '%s' "$open_pr_json" | jq -r --arg cp "$close_pattern" --arg tp "$title_pattern" \
-		'[.[] | select((.isDraft // false | not) and (
-			(.title // "" | test($tp)) or
-			((.commits // [])[] | .messageHeadline // "" | test($cp; "i"))
+		'[.[] | select(((.isDraft // false) | not) and (
+			((.title // "") | test($tp)) or
+			any((.commits // [])[]?; ((.messageHeadline // "") | test($cp; "i")))
 		))
-		)] | .[0].number // empty' 2>/dev/null) || match_pr=""
+		] | .[0].number // empty' 2>/dev/null) || match_pr=""
 	if [[ -n "$match_pr" ]]; then
 		printf 'open PR #%s has commits targeting issue #%s\n' "$match_pr" "$issue_number"
 		return 0
@@ -248,7 +400,7 @@ _has_open_pr_check_open_body_keyword() {
 	# Match: closing keyword + optional whitespace + #NNN or owner/repo#NNN
 	# followed by a non-word char or end-of-string (GH#18641 semantics).
 	local close_pattern
-	close_pattern="(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}([^[:alnum:]_]|$)"
+	close_pattern=$(_ddpr_closing_keyword_pattern "$issue_number")
 
 	match_pr=$(printf '%s' "$pr_json" | jq -r --arg pattern "$close_pattern" \
 		'[.[] | select((.isDraft // false | not) and (.body // "" | test($pattern; "i")))] | .[0].number // empty' \
@@ -289,7 +441,7 @@ _has_open_pr_check_merged_keywords() {
 	# Match: closing keyword + optional whitespace + #NNN or owner/repo#NNN
 	# followed by a non-word char or end-of-string (GH#18641 semantics).
 	local close_pattern
-	close_pattern="(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}([^[:alnum:]_]|$)"
+	close_pattern=$(_ddpr_closing_keyword_pattern "$issue_number")
 
 	match_pr=$(printf '%s' "$pr_json" | jq -r --arg pattern "$close_pattern" \
 		'[.[] | select(.body // "" | test($pattern; "i"))] | .[0].number // empty' \
@@ -355,7 +507,8 @@ _has_open_pr_check_task_id_title() {
 	# otherwise we allow dispatch.
 	local merged_pr_body
 	merged_pr_body=$(printf '%s' "$pr_json" | jq -r '.[0].body // empty' 2>/dev/null)
-	local close_pattern_check3="(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}([^[:alnum:]_]|$)"
+	local close_pattern_check3=""
+	close_pattern_check3=$(_ddpr_closing_keyword_pattern "$issue_number")
 	if printf '%s' "$merged_pr_body" | grep -iqE "$close_pattern_check3"; then
 		printf 'merged PR #%s found by task id %s in title\n' "$pr_number" "$task_id"
 		return 0

--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -139,6 +139,57 @@ _full_loop_review_bot_gate_helper_path() {
 	return 0
 }
 
+#######################################
+# Fetch the fixed full-loop PR readiness snapshot with response-owned cost.
+# Native `gh pr view` does not expose its GraphQL operation cost, so concurrent
+# activity can otherwise leave the benchmark attempt unattributed.
+# Args: $1=pr_number, $2=repo_slug
+# Output: gh-pr-view-compatible readiness JSON
+# Returns: 0=complete exact-cost snapshot, 1=API/validation failure
+#######################################
+_full_loop_pr_readiness_json_graphql() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local owner="${repo_slug%%/*}"
+	local name="${repo_slug#*/}"
+	local response="" pr_json=""
+	local jq_string_type="string"
+
+	[[ "$pr_number" =~ ^[0-9]+$ && -n "$owner" && -n "$name" && "$owner" != "$name" ]] || return 1
+	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub.
+	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="full-loop-readiness-exact-cost" \
+		gh api graphql -F owner="$owner" -F name="$name" -F pr="$pr_number" -f query='
+		query($owner: String!, $name: String!, $pr: Int!) {
+			repository(owner: $owner, name: $name) {
+				pullRequest(number: $pr) {
+					state
+					isDraft
+					reviewDecision
+					headRefOid
+					headRefName
+				}
+			}
+			rateLimit { cost }
+		}' 2>/dev/null) || return 1
+
+	pr_json=$(printf '%s' "$response" | jq -ce --arg string_type "$jq_string_type" '
+		select(((.errors // []) | type) == "array")
+		| select(((.errors // []) | length) == 0)
+		| select((.data.rateLimit.cost | type) == "number")
+		| select(.data.rateLimit.cost > 0 and (.data.rateLimit.cost | floor) == .data.rateLimit.cost)
+		| .data.repository.pullRequest
+		| select(type == "object")
+		| select((.state | type) == $string_type)
+		| select((.isDraft | type) == "boolean")
+		| select((.headRefOid | type) == $string_type)
+		| select((.headRefName | type) == $string_type)
+		| {state, isDraft, reviewDecision, headRefOid, headRefName}
+	' 2>/dev/null) || return 1
+	printf '%s\n' "$pr_json"
+	return 0
+}
+
 _full_loop_reconcile_stale_coderabbit_review() {
 	local pr_number="$1"
 	local repo="$2"
@@ -156,8 +207,7 @@ _full_loop_reconcile_stale_coderabbit_review() {
 		print_error "PR #${pr_number} retains changes-requested review state; automatic reconciliation was not authorized"
 		return 1
 	fi
-	refreshed_json=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh pr view "$pr_number" --repo "$repo" \
-		--json state,isDraft,reviewDecision,headRefOid,headRefName 2>/dev/null) || {
+	refreshed_json=$(_full_loop_pr_readiness_json_graphql "$pr_number" "$repo") || {
 		print_error "Cannot refresh PR #${pr_number} after CodeRabbit reconciliation"
 		return 1
 	}
@@ -176,8 +226,7 @@ _full_loop_verify_pr_readiness() {
 	local verified_head=""
 	local review_decision=""
 
-	pr_json=$(AIDEVOPS_GH_PR_VIEW_CACHE_DISABLE=1 gh pr view "$pr_number" --repo "$repo" \
-		--json state,isDraft,reviewDecision,headRefOid,headRefName 2>/dev/null) || {
+	pr_json=$(_full_loop_pr_readiness_json_graphql "$pr_number" "$repo") || {
 		print_error "Cannot read PR #${pr_number} readiness evidence"
 		return 1
 	}

--- a/.agents/scripts/github-api-efficiency-evidence.py
+++ b/.agents/scripts/github-api-efficiency-evidence.py
@@ -15,6 +15,7 @@ from typing import Any, Callable
 
 from github_api_efficiency_inputs import (
     BenchmarkInputError,
+    DISTRIBUTION_SAMPLE_FIELDS,
     EVIDENCE_GROUPS,
     EVIDENCE_SCHEMA,
     POPULATION_FIELDS,
@@ -137,6 +138,10 @@ def _sample_percentile(
     raise EvidenceBuildError(f"evidence {name} percentile could not be computed")
 
 
+def _sample_count(events: dict[str, Counter[str]], name: str) -> int:
+    return sum(events.get(name, {}).values())
+
+
 def _window_is_bounded(
     contract: Any, start: int | None, end: int | None, first: int, last: int
 ) -> bool:
@@ -217,8 +222,12 @@ def _missing_fields(payload: dict[str, Any]) -> list[str]:
             missing.append(f"population.{field}")
     for group, fields in EVIDENCE_GROUPS.items():
         for field in fields:
-            if payload[group][field] is None:
-                missing.append(f"{group}.{field}")
+            if payload[group][field] is not None:
+                continue
+            sample_field = DISTRIBUTION_SAMPLE_FIELDS.get((group, field))
+            if sample_field is not None and payload[group][sample_field] == 0:
+                continue
+            missing.append(f"{group}.{field}")
     return missing
 
 
@@ -255,6 +264,11 @@ def _build_latency(
         "peak_attempts_per_minute": _meta_count(
             meta, "peak_attempts_per_minute", covered
         ),
+        "completed_action_samples": (
+            _sample_count(events, "latency.completed_action_ms")
+            if covered
+            else None
+        ),
         "completed_action_p95_ms": (
             _sample_percentile(events, "latency.completed_action_ms", 95)
             if covered
@@ -268,6 +282,9 @@ def _build_webhook(
 ) -> dict[str, int | None]:
     return {
         "invalidations": _covered_count(events, "webhook.invalidations", covered),
+        "lag_samples": (
+            _sample_count(events, "webhook.lag_ms") if covered else None
+        ),
         "lag_p50_ms": (
             _sample_percentile(events, "webhook.lag_ms", 50) if covered else None
         ),

--- a/.agents/scripts/github_api_efficiency_inputs.py
+++ b/.agents/scripts/github_api_efficiency_inputs.py
@@ -19,7 +19,7 @@ from github_api_efficiency_metrics import (
 )
 
 
-EVIDENCE_SCHEMA = "aidevops-github-api-efficiency-evidence/v2"
+EVIDENCE_SCHEMA = "aidevops-github-api-efficiency-evidence/v3"
 TRANSPORT_SCHEMA_VERSION = 2
 _SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 _MAX_SAFE_INTEGER = 9_007_199_254_740_991
@@ -62,12 +62,14 @@ EVIDENCE_GROUPS = {
         "p50_ms",
         "p95_ms",
         "peak_attempts_per_minute",
+        "completed_action_samples",
         "completed_action_p95_ms",
     ),
     "cache": ("fresh_hits", "fresh_empty_hits", "misses", "stale", "invalidated"),
     "single_flight": ("leaders", "waits", "takeovers", "duplicate_leaders"),
     "webhook": (
         "invalidations",
+        "lag_samples",
         "lag_p50_ms",
         "lag_p95_ms",
         "duplicate_actions",
@@ -87,6 +89,11 @@ EVIDENCE_GROUPS = {
         "cycle_scoped_aggregate_check_fetches",
         "unique_cycle_scoped_actionable_heads",
     ),
+}
+DISTRIBUTION_SAMPLE_FIELDS = {
+    ("latency", "completed_action_p95_ms"): "completed_action_samples",
+    ("webhook", "lag_p50_ms"): "lag_samples",
+    ("webhook", "lag_p95_ms"): "lag_samples",
 }
 _MEASURED_EVIDENCE_FIELDS = frozenset(
     (
@@ -286,6 +293,27 @@ def _validate_evidence_groups(payload: dict[str, Any]) -> None:
             )
 
 
+def _validate_distribution_relationships(payload: dict[str, Any]) -> None:
+    for (group_name, percentile_field), sample_field in (
+        DISTRIBUTION_SAMPLE_FIELDS.items()
+    ):
+        samples = payload[group_name][sample_field]
+        percentile = payload[group_name][percentile_field]
+        context = f"evidence.{group_name}.{percentile_field}"
+        if samples is None:
+            if percentile is not None:
+                raise BenchmarkInputError(f"{context} requires a sample count")
+            continue
+        if samples == 0 and percentile is not None:
+            raise BenchmarkInputError(
+                f"{context} must be null when its sample count is zero"
+            )
+        if samples > 0 and percentile is None:
+            raise BenchmarkInputError(
+                f"{context} is required when its sample count is positive"
+            )
+
+
 def _validate_evidence(
     payload: dict[str, Any], transport_sha256: str
 ) -> None:
@@ -299,6 +327,7 @@ def _validate_evidence(
         raise BenchmarkInputError("evidence.complete must be boolean")
     _validate_population(payload)
     _validate_evidence_groups(payload)
+    _validate_distribution_relationships(payload)
     _validate_evidence_relationships(payload)
 
 

--- a/.agents/scripts/github_api_efficiency_report.py
+++ b/.agents/scripts/github_api_efficiency_report.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from github_api_efficiency_inputs import (
+    DISTRIBUTION_SAMPLE_FIELDS,
     EVIDENCE_GROUPS,
     POPULATION_FIELDS,
     Window,
@@ -66,9 +67,14 @@ def _unknown_evidence(window: Window) -> list[str]:
     )
     for group_name, fields in EVIDENCE_GROUPS.items():
         for field in fields:
+            sample_field = DISTRIBUTION_SAMPLE_FIELDS.get((group_name, field))
+            observed_empty = (
+                sample_field is not None
+                and window.evidence[group_name][sample_field] == 0
+            )
             _flag(
                 reasons,
-                window.evidence[group_name][field] is None,
+                window.evidence[group_name][field] is None and not observed_empty,
                 f"{window.label}: {group_name}.{field} is unknown",
             )
     return reasons
@@ -134,8 +140,12 @@ def _pct_change(
 
 
 def _growth_exceeds(
-    baseline: float, canary: float, maximum_pct: float
+    baseline: float | int | None,
+    canary: float | int | None,
+    maximum_pct: float,
 ) -> bool:
+    if baseline is None or canary is None:
+        return False
     if baseline == 0:
         return canary > 0
     return ((canary - baseline) / baseline) * 100 > maximum_pct
@@ -229,6 +239,20 @@ def _comparability(
             reasons,
             rate_differs,
             f"{field} rates are materially non-equivalent",
+        )
+    distribution_samples = (
+        ("latency", "completed_action_samples", "completed-action latency"),
+        ("webhook", "lag_samples", "webhook-lag latency"),
+    )
+    for group_name, sample_field, label in distribution_samples:
+        baseline_samples = baseline.evidence[group_name][sample_field]
+        canary_samples = canary.evidence[group_name][sample_field]
+        baseline_has_samples = baseline_samples is not None and baseline_samples > 0
+        canary_has_samples = canary_samples is not None and canary_samples > 0
+        _flag(
+            reasons,
+            baseline_has_samples != canary_has_samples,
+            f"{label} sample availability differs",
         )
     details = {
         "duration_ratio": round(duration_ratio, 6),
@@ -464,6 +488,18 @@ def _fmt(value: Any) -> str:
     return str(value)
 
 
+def _fmt_metric(metric: str, value: Any, values: dict[str, Any]) -> str:
+    sample_fields = {
+        "completed_action_p95_ms": "completed_action_samples",
+        "lag_p50_ms": "lag_samples",
+        "lag_p95_ms": "lag_samples",
+    }
+    sample_field = sample_fields.get(metric)
+    if value is None and sample_field is not None and values.get(sample_field) == 0:
+        return "not applicable"
+    return _fmt(value)
+
+
 def _utc(timestamp: int) -> str:
     return datetime.fromtimestamp(
         timestamp, tz=timezone.utc
@@ -486,8 +522,8 @@ def _metric_table(
     )
     for metric in baseline:
         lines.append(
-            f"| `{metric}` | {_fmt(baseline[metric])} | "
-            f"{_fmt(canary[metric])} |"
+            f"| `{metric}` | {_fmt_metric(metric, baseline[metric], baseline)} | "
+            f"{_fmt_metric(metric, canary[metric], canary)} |"
         )
     lines.append("")
 

--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -234,15 +234,25 @@ _closed_issue_worker_complete_date() {
 
 _closed_issue_aidevops_complete_date() {
 	local repo="$1" issue_number="$2"
-	local issue_json="" state_reason="" closed_at="" evidence=""
+	local issue_json="" comments_json="" state_reason="" closed_at=""
+	local issue_body="" comment_evidence="" evidence=""
 
-	issue_json=$(gh issue view "$issue_number" --repo "$repo" \
-		--json state,stateReason,closedAt,body,comments 2>/dev/null) || return 1
-	state_reason=$(printf '%s' "$issue_json" | jq -r '.stateReason // ""' 2>/dev/null) || state_reason=""
-	closed_at=$(printf '%s' "$issue_json" | jq -r '.closedAt // ""' 2>/dev/null) || closed_at=""
-	evidence=$(printf '%s' "$issue_json" | jq -r '[.body // "", (.comments[]?.body // "")] | join("\n---\n")' 2>/dev/null) || evidence=""
+	issue_json=$(AIDEVOPS_GH_ROUTE_DECISION="issue-sync-completion-issue-rest" \
+		gh api "repos/${repo}/issues/${issue_number}" 2>/dev/null) || return 1
+	comments_json=$(AIDEVOPS_GH_ROUTE_DECISION="issue-sync-completion-comments-rest" \
+		gh api --paginate --slurp \
+			"repos/${repo}/issues/${issue_number}/comments?per_page=100" 2>/dev/null) || return 1
+	state_reason=$(printf '%s' "$issue_json" | jq -r '.state_reason // .stateReason // ""' 2>/dev/null) || state_reason=""
+	closed_at=$(printf '%s' "$issue_json" | jq -r '.closed_at // .closedAt // ""' 2>/dev/null) || closed_at=""
+	issue_body=$(printf '%s' "$issue_json" | jq -r '.body // ""' 2>/dev/null) || return 1
+	comment_evidence=$(printf '%s' "$comments_json" | jq -r \
+		'[.[][]? | .body // ""] | join("\n---\n")' 2>/dev/null) || return 1
+	evidence=$(printf '%s\n---\n%s' "$issue_body" "$comment_evidence")
 
-	[[ "$state_reason" == "COMPLETED" ]] || return 1
+	case "$state_reason" in
+	COMPLETED | completed) ;;
+	*) return 1 ;;
+	esac
 	[[ "$closed_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || return 1
 	if printf '%s' "$evidence" | grep -qE 'aidevops:sig|CLAIM_RELEASED reason=worker_complete|Task t[0-9]+(\.[0-9]+)* done in TODO\.md|Completed via (\[)?PR #[0-9]+'; then
 		printf '%s\n' "${closed_at%%T*}"

--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -261,17 +261,21 @@ fetch_review_threads_json() {
 	local owner name
 	parse_repo_slug "$repo" owner name
 	local resp rc=0
+	local jq_array_type='array'
 	# SC2016: the $owner/$name/$pr tokens inside this heredoc are GraphQL
 	# variables, not bash variables. The single-quoting is required so
 	# they reach the GraphQL server unexpanded.
 	# shellcheck disable=SC2016
-	resp=$(gh api graphql \
+	resp=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="post-merge-review-threads-exact-cost" \
+		gh api graphql \
 		-F owner="$owner" -F name="$name" -F pr="$pr" \
 		-f query='
 			query($owner: String!, $name: String!, $pr: Int!) {
 				repository(owner: $owner, name: $name) {
 					pullRequest(number: $pr) {
 						reviewThreads(first: 100) {
+							pageInfo { hasNextPage }
 							nodes {
 								isResolved
 								isOutdated
@@ -290,15 +294,26 @@ fetch_review_threads_json() {
 						}
 					}
 				}
+				rateLimit { cost }
 			}
 		') || rc=$?
 	if [[ $rc -ne 0 ]]; then
 		log "fetch_review_threads_json: gh graphql failed for ${repo}#${pr} (rc=${rc})"
 		return 2
 	fi
-	# Validate the response is shaped as expected. If the API returned an
-	# error object instead of data, treat it as a fetch failure.
-	if ! printf '%s' "$resp" | jq -e '.data.repository.pullRequest.reviewThreads' >/dev/null; then
+	# Validate response-owned quota evidence and reject partial thread sets. If
+	# the API returned errors, malformed data, or more than the established
+	# 100-thread bound, treat it as a fetch failure instead of silently deciding
+	# from incomplete review evidence.
+	if ! printf '%s' "$resp" | jq -e --arg array_type "$jq_array_type" '
+		((.errors // []) | type) == $array_type and
+		((.errors // []) | length) == 0 and
+		(.data.rateLimit.cost | type) == "number" and
+		(.data.rateLimit.cost > 0) and
+		((.data.rateLimit.cost | floor) == .data.rateLimit.cost) and
+		(.data.repository.pullRequest.reviewThreads.nodes | type) == $array_type and
+		(.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage == false)
+	' >/dev/null; then
 		log "fetch_review_threads_json: malformed response for ${repo}#${pr}"
 		return 2
 	fi

--- a/.agents/scripts/pulse-dirty-pr-sweep.sh
+++ b/.agents/scripts/pulse-dirty-pr-sweep.sh
@@ -1168,6 +1168,81 @@ _dps_record_audit() {
 # Dispatcher — one repo
 # -----------------------------------------------------------------------------
 
+#######################################
+# Fetch the bounded open-PR sweep population with response-owned GraphQL cost.
+# The merge-state field is GraphQL-only; using native `gh pr list` hides a
+# multi-point cost under concurrency. Reject partial label connections rather
+# than classifying a PR from incomplete ownership metadata.
+# Args: $1=repo_slug, $2=result limit
+# Output: gh-pr-list-compatible JSON array
+# Returns: 0=complete exact-cost snapshot, 1=API/validation failure
+#######################################
+_dirty_pr_sweep_open_prs_graphql() {
+	local repo_slug="$1"
+	local result_limit="$2"
+	local owner="${repo_slug%%/*}"
+	local name="${repo_slug#*/}"
+	local response="" pr_json=""
+	local jq_array_type="array"
+
+	[[ -n "$owner" && -n "$name" && "$owner" != "$name" ]] || return 1
+	[[ "$result_limit" =~ ^[1-9][0-9]*$ && "$result_limit" -le 100 ]] || return 1
+	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub.
+	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="dirty-pr-sweep-exact-cost" \
+		gh api graphql -F owner="$owner" -F name="$name" -F limit="$result_limit" -f query='
+		query($owner: String!, $name: String!, $limit: Int!) {
+			repository(owner: $owner, name: $name) {
+				pullRequests(first: $limit, states: [OPEN], orderBy: {field: CREATED_AT, direction: DESC}) {
+					nodes {
+						number
+						title
+						mergeStateStatus
+						createdAt
+						updatedAt
+						author { login }
+						labels(first: 100) {
+							nodes { name }
+							pageInfo { hasNextPage }
+						}
+						headRefName
+						baseRefName
+						body
+					}
+				}
+			}
+			rateLimit { cost }
+		}' 2>/dev/null) || return 1
+
+	pr_json=$(printf '%s' "$response" | jq -ce --arg array_type "$jq_array_type" '
+		select(((.errors // []) | type) == $array_type)
+		| select(((.errors // []) | length) == 0)
+		| select((.data.rateLimit.cost | type) == "number")
+		| select(.data.rateLimit.cost > 0 and (.data.rateLimit.cost | floor) == .data.rateLimit.cost)
+		| .data.repository.pullRequests.nodes
+		| select(type == $array_type)
+		| select(all(.[];
+			(.number | type) == "number" and
+			(.labels.nodes | type) == $array_type and
+			.labels.pageInfo.hasNextPage == false
+		))
+		| map({
+			number,
+			title,
+			mergeStateStatus,
+			createdAt,
+			updatedAt,
+			author,
+			labels: .labels.nodes,
+			headRefName,
+			baseRefName,
+			body
+		})
+	' 2>/dev/null) || return 1
+	printf '%s\n' "$pr_json"
+	return 0
+}
+
 _dirty_pr_sweep_for_repo() {
 	local repo_slug="$1"
 	local repo_path="$2"
@@ -1175,9 +1250,8 @@ _dirty_pr_sweep_for_repo() {
 
 	local list_json err_file
 	err_file=$(mktemp) || err_file=/dev/null
-	list_json=$(gh_pr_list --repo "$repo_slug" --state open \
-		--json number,title,mergeStateStatus,createdAt,updatedAt,author,labels,headRefName,baseRefName,body \
-		--limit "$DIRTY_PR_SWEEP_BATCH_LIMIT" 2>"$err_file") || list_json="[]"
+	list_json=$(_dirty_pr_sweep_open_prs_graphql "$repo_slug" "$DIRTY_PR_SWEEP_BATCH_LIMIT" \
+		2>"$err_file") || list_json="[]"
 	[[ -z "$list_json" || "$list_json" == "null" ]] && list_json="[]"
 	rm -f "$err_file" 2>/dev/null || true
 

--- a/.agents/scripts/pulse-merge-conflict.sh
+++ b/.agents/scripts/pulse-merge-conflict.sh
@@ -529,8 +529,15 @@ _verify_pr_overlaps_commit() {
 	local commit_sha="$3"
 
 	local pr_files commit_files
-	pr_files=$(gh pr view "$pr_number" --repo "$repo_slug" \
-		--json files --jq '.files[].path' 2>/dev/null) || return 1
+	if declare -F _pulse_merge_pr_file_paths_rest >/dev/null 2>&1; then
+		pr_files=$(_pulse_merge_pr_file_paths_rest "$pr_number" "$repo_slug" 2>/dev/null) || return 1
+	else
+		# Isolated callers/tests may source this downstream module without the PR
+		# gates module. Preserve the exact REST contract in that configuration.
+		pr_files=$(AIDEVOPS_GH_ROUTE_DECISION="pulse-pr-files-rest" \
+			gh api --paginate "repos/${repo_slug}/pulls/${pr_number}/files?per_page=100" \
+				--jq '.[].filename' 2>/dev/null) || return 1
+	fi
 	[[ -n "$pr_files" ]] || return 1
 
 	commit_files=$(gh api "repos/${repo_slug}/commits/${commit_sha}" \

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -1972,16 +1972,24 @@ _dispatch_conflict_fix_worker() {
 		--description "Issue carries conflict context routed from a closed worker PR" \
 		--force >/dev/null 2>&1 || true
 
-	# Get the list of files changed in the PR (these are the conflict candidates)
+	# Get the list of files changed in the PR (these are the conflict candidates).
+	# Prefer the operation-owned REST helper from the PR gates module; retain an
+	# exact REST path for isolated module callers.
 	local pr_files
-	pr_files=$(gh pr view "$pr_number" --repo "$repo_slug" \
-		--json files --jq '[.files[].path] | join("\n")' 2>/dev/null) || pr_files="(could not fetch)"
+	local fetch_failure="(could not fetch)"
+	if declare -F _pulse_merge_pr_file_paths_rest >/dev/null 2>&1; then
+		pr_files=$(_pulse_merge_pr_file_paths_rest "$pr_number" "$repo_slug" 2>/dev/null) || pr_files="$fetch_failure"
+	else
+		pr_files=$(AIDEVOPS_GH_ROUTE_DECISION="pulse-pr-files-rest" \
+			gh api --paginate "repos/${repo_slug}/pulls/${pr_number}/files?per_page=100" \
+				--jq '.[].filename' 2>/dev/null) || pr_files="$fetch_failure"
+	fi
 
 	# File count for scope-leak heuristic (t2802). Rely on the already-fetched
 	# file list rather than a second API call — a line count of the joined
 	# output matches the files array length when pr_files fetched cleanly.
 	local pr_file_count=""
-	if [[ -n "$pr_files" ]] && [[ "$pr_files" != "(could not fetch)" ]]; then
+	if [[ -n "$pr_files" ]] && [[ "$pr_files" != "$fetch_failure" ]]; then
 		pr_file_count=$(printf '%s\n' "$pr_files" | grep -c '^.' || true)
 	fi
 

--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -240,6 +240,65 @@ _trusted_dependabot_pr_json_graphql() {
 }
 
 #######################################
+# Fetch final merge-authority metadata with response-owned GraphQL cost.
+# Native `gh pr view` hides the operation cost and can become ambiguous under
+# concurrent Pulse traffic. Keep this trust-boundary read self-metering and
+# reject partial label connections.
+# Args: $1=pr_number, $2=repo_slug
+# Output: gh-pr-view-compatible metadata JSON
+# Returns: 0=complete exact-cost snapshot, 1=API/parse/pagination failure
+#######################################
+_pulse_merge_admin_pr_json_graphql() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local owner="${repo_slug%%/*}"
+	local name="${repo_slug#*/}"
+	local response="" pr_json=""
+
+	[[ "$pr_number" =~ ^[0-9]+$ && -n "$owner" && -n "$name" && "$owner" != "$name" ]] || return 1
+	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub.
+	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="pulse-admin-authority-exact-cost" \
+		gh api graphql -F owner="$owner" -F name="$name" -F pr="$pr_number" -f query='
+		query($owner: String!, $name: String!, $pr: Int!) {
+			repository(owner: $owner, name: $name) {
+				pullRequest(number: $pr) {
+					author { login }
+					labels(first: 100) {
+						nodes { name }
+						pageInfo { hasNextPage }
+					}
+					isCrossRepository
+					headRefOid
+				}
+			}
+			rateLimit { cost }
+		}' 2>/dev/null) || return 1
+
+	pr_json=$(printf '%s' "$response" | jq -ce '
+		select(((.errors // []) | type) == "array")
+		| select(((.errors // []) | length) == 0)
+		| select((.data.rateLimit.cost | type) == "number")
+		| select(.data.rateLimit.cost > 0 and (.data.rateLimit.cost | floor) == .data.rateLimit.cost)
+		| .data.repository.pullRequest as $pr
+		| select($pr != null)
+		| select(($pr.author.login | type) == "string")
+		| select(($pr.isCrossRepository | type) == "boolean")
+		| select(($pr.headRefOid | type) == "string")
+		| select(($pr.labels.nodes | type) == "array")
+		| select($pr.labels.pageInfo.hasNextPage == false)
+		| {
+			author: $pr.author,
+			labels: $pr.labels.nodes,
+			isCrossRepository: $pr.isCrossRepository,
+			headRefOid: $pr.headRefOid
+		}
+	' 2>/dev/null) || return 1
+	printf '%s\n' "$pr_json"
+	return 0
+}
+
+#######################################
 # Verify a Dependabot PR is an authentic, maintainer-allowed version update.
 #
 # This is intentionally narrow: it only grants the collaborator/review-bot
@@ -619,17 +678,16 @@ _pulse_merge_admin_safety_check() {
 	# t2863: initialise multi-var locals at declaration time so set -u
 	# is safe even on a partial-failure path through the assignments.
 	local pr_meta_json="" labels_str="" is_fork="false" current_head_sha="" pr_author=""
-	if ! pr_meta_json=$(gh pr view "$pr_number" --repo "$repo_slug" \
-		--json author,labels,isCrossRepository,headRefOid 2>/dev/null); then
-		echo "[pulse-merge] _pulse_merge_admin_safety_check: gh pr view failed for PR #${pr_number} in ${repo_slug} — failing closed" >>"$LOGFILE"
+	if ! pr_meta_json=$(_pulse_merge_admin_pr_json_graphql "$pr_number" "$repo_slug"); then
+		echo "[pulse-merge] _pulse_merge_admin_safety_check: exact GraphQL metadata read failed for PR #${pr_number} in ${repo_slug} — failing closed" >>"$LOGFILE"
 		return 1
 	fi
 	if [[ -z "$pr_meta_json" ]]; then
-		echo "[pulse-merge] _pulse_merge_admin_safety_check: gh pr view returned empty metadata for PR #${pr_number} in ${repo_slug} — failing closed" >>"$LOGFILE"
+		echo "[pulse-merge] _pulse_merge_admin_safety_check: exact GraphQL metadata read returned empty metadata for PR #${pr_number} in ${repo_slug} — failing closed" >>"$LOGFILE"
 		return 1
 	fi
 	if ! printf '%s' "$pr_meta_json" | jq -e 'type == "object"' >/dev/null 2>&1; then
-		echo "[pulse-merge] _pulse_merge_admin_safety_check: gh pr view returned malformed metadata for PR #${pr_number} in ${repo_slug} — failing closed" >>"$LOGFILE"
+		echo "[pulse-merge] _pulse_merge_admin_safety_check: exact GraphQL metadata read returned malformed metadata for PR #${pr_number} in ${repo_slug} — failing closed" >>"$LOGFILE"
 		return 1
 	fi
 	labels_str=$(printf '%s' "$pr_meta_json" \

--- a/.agents/scripts/remote-branch-cleanup-helper.sh
+++ b/.agents/scripts/remote-branch-cleanup-helper.sh
@@ -134,7 +134,43 @@ gh_pr_branches() {
 	if ! command -v gh >/dev/null 2>&1; then
 		return 0
 	fi
-	gh pr list --repo "$(repo_slug)" --state "$state" --limit 200 --json headRefName --jq '.[].headRefName' 2>/dev/null || true
+
+	local slug=""
+	local api_state=""
+	local jq_filter=""
+	local page=1
+	local page_count=0
+	local page_json=""
+	slug=$(repo_slug)
+	[[ -n "$slug" ]] || return 0
+	case "$state" in
+	open)
+		api_state="open"
+		jq_filter='.[].head.ref'
+		;;
+	merged)
+		api_state="closed"
+		jq_filter='.[] | select(.merged_at != null) | .head.ref'
+		;;
+	closed)
+		api_state="closed"
+		jq_filter='.[] | select(.merged_at == null) | .head.ref'
+		;;
+	*) return 0 ;;
+	esac
+
+	# Preserve the previous 200-PR bound. Unbounded REST pagination can turn a
+	# cleanup pass over a mature repository into a full-history API sweep.
+	while [[ "$page" -le 2 ]]; do
+		page_json=$(AIDEVOPS_GH_ROUTE_DECISION="remote-branch-cleanup-pr-branches-rest" \
+			gh api "repos/${slug}/pulls?state=${api_state}&per_page=100&page=${page}" \
+				2>/dev/null) || return 0
+		page_count=$(printf '%s' "$page_json" | jq -r 'if type == "array" then length else -1 end' 2>/dev/null) || return 0
+		[[ "$page_count" =~ ^[0-9]+$ ]] || return 0
+		printf '%s' "$page_json" | jq -r "$jq_filter" 2>/dev/null || return 0
+		[[ "$page_count" -lt 100 ]] && break
+		page=$((page + 1))
+	done
 	return 0
 }
 

--- a/.agents/scripts/shared-claim-lifecycle.sh
+++ b/.agents/scripts/shared-claim-lifecycle.sh
@@ -236,8 +236,12 @@ _pr_handoff_state_for_branch_or_issue() {
 	fi
 
 	if [[ -n "$branch_name" ]]; then
-		if pr_json=$(gh_pr_list --repo "$repo_slug" --head "$branch_name" --state all \
-			--limit 10 --json number,state,isDraft,mergedAt,headRefOid,labels,statusCheckRollup 2>/dev/null); then
+		# This lifecycle probe only consumes REST-compatible fields. Prefer the
+		# live pulls endpoint explicitly so a healthy GraphQL pool cannot turn a
+		# recurring exact-head check into an unattributable native query.
+		if pr_json=$(AIDEVOPS_GH_REST_FIRST_READS=1 gh_pr_list \
+			--repo "$repo_slug" --head "$branch_name" --state all \
+			--limit 10 --json number,state,isDraft,mergedAt,headRefOid,labels 2>/dev/null); then
 			queried=1
 			pr_state=$(_pr_handoff_state_from_json "$pr_json" "$expected_head")
 			if [[ -n "$pr_state" ]]; then
@@ -258,7 +262,8 @@ _pr_handoff_state_for_branch_or_issue() {
 	fi
 
 	if [[ -n "$issue_number" && "$match_scope" != "head-only" ]]; then
-		if pr_json=$(gh_pr_list --repo "$repo_slug" --search "#${issue_number} in:body" --state open \
+		if pr_json=$(AIDEVOPS_GH_REST_FIRST_READS=1 gh_pr_list \
+			--repo "$repo_slug" --search "#${issue_number} in:body" --state open \
 			--limit 10 --json number 2>/dev/null); then
 			queried=1
 			pr_state=$(printf '%s' "$pr_json" | jq -r '.[0].number // empty' 2>/dev/null || true)

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -891,8 +891,9 @@ _ensure_origin_labels_for_args() {
 	case ",$_ORIGIN_LABELS_ENSURED," in
 	*",$repo,"*) return 0 ;;
 	esac
-	ensure_origin_labels_exist "$repo"
-	_ORIGIN_LABELS_ENSURED="${_ORIGIN_LABELS_ENSURED:+$_ORIGIN_LABELS_ENSURED,}$repo"
+	if ensure_origin_labels_exist "$repo"; then
+		_ORIGIN_LABELS_ENSURED="${_ORIGIN_LABELS_ENSURED:+$_ORIGIN_LABELS_ENSURED,}$repo"
+	fi
 	return 0
 }
 
@@ -901,14 +902,25 @@ _ensure_origin_labels_for_args() {
 ensure_origin_labels_exist() {
 	local repo="$1"
 	[[ -z "$repo" ]] && return 1
-	_gh_with_timeout write gh label create "origin:worker" --repo "$repo" \
-		--description "Created by headless/pulse worker session" \
-		--color "C5DEF5" 2>/dev/null || true
-	_gh_with_timeout write gh label create "origin:interactive" --repo "$repo" \
-		--description "Created by interactive user session" \
-		--color "BFD4F2" 2>/dev/null || true
-	_gh_with_timeout write gh label create "origin:worker-takeover" --repo "$repo" \
-		--description "Worker took over from interactive session" \
-		--color "D4C5F9" 2>/dev/null || true
+	local labels_snapshot=""
+	labels_snapshot=$(_gh_managed_label_names_snapshot "$repo") || return 1
+	if ! _gh_managed_label_snapshot_has "$labels_snapshot" "origin:worker"; then
+		AIDEVOPS_GH_ROUTE_DECISION="$_GH_MANAGED_LABEL_CREATE_ROUTE" \
+			_gh_with_timeout write gh label create "origin:worker" --repo "$repo" \
+			--description "Created by headless/pulse worker session" \
+			--color "C5DEF5" 2>/dev/null || return 1
+	fi
+	if ! _gh_managed_label_snapshot_has "$labels_snapshot" "origin:interactive"; then
+		AIDEVOPS_GH_ROUTE_DECISION="$_GH_MANAGED_LABEL_CREATE_ROUTE" \
+			_gh_with_timeout write gh label create "origin:interactive" --repo "$repo" \
+			--description "Created by interactive user session" \
+			--color "BFD4F2" 2>/dev/null || return 1
+	fi
+	if ! _gh_managed_label_snapshot_has "$labels_snapshot" "origin:worker-takeover"; then
+		AIDEVOPS_GH_ROUTE_DECISION="$_GH_MANAGED_LABEL_CREATE_ROUTE" \
+			_gh_with_timeout write gh label create "origin:worker-takeover" --repo "$repo" \
+			--description "Worker took over from interactive session" \
+			--color "D4C5F9" 2>/dev/null || return 1
+	fi
 	return 0
 }

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -493,6 +493,29 @@ _gh_with_timeout() {
 	return $rc
 }
 
+# Fetch repository label names once before opportunistic managed-label setup.
+# This keeps converged repositories read-only instead of relying on expected
+# HTTP 422 responses from repeated `gh label create` calls.
+_GH_MANAGED_LABEL_CREATE_ROUTE="managed-label-create-rest"
+_gh_managed_label_names_snapshot() {
+	local repo="$1"
+	[[ -n "$repo" ]] || return 1
+	AIDEVOPS_GH_ROUTE_DECISION="managed-label-inventory-rest" \
+		_gh_with_timeout read gh api "/repos/${repo}/labels?per_page=100" --paginate \
+		--jq '.[].name'
+	return $?
+}
+
+_gh_managed_label_snapshot_has() {
+	local snapshot="$1"
+	local expected_name="$2"
+	local actual_name=""
+	while IFS= read -r actual_name; do
+		[[ "$actual_name" == "$expected_name" ]] && return 0
+	done <<<"$snapshot"
+	return 1
+}
+
 # =============================================================================
 # Safe gh Edit Wrappers — Validation (GH#19857)
 # =============================================================================
@@ -946,17 +969,30 @@ set_origin_label() {
 #######################################
 # Ensure solved:* attribution labels exist on a repo (idempotent).
 # Args: $1 — repo slug (owner/repo)
-# Returns: 0 on success/no-op, 1 when repo is empty.
+# Returns: 0 on success/no-op, 1 when inventory or creation fails.
 #######################################
+_SOLVED_LABELS_ENSURED=""
 ensure_solved_labels_exist() {
 	local repo="$1"
 	[[ -z "$repo" ]] && return 1
-	_gh_with_timeout write gh label create "solved:worker" --repo "$repo" \
-		--description "Task was solved by a headless worker" \
-		--color "0E8A16" 2>/dev/null || true
-	_gh_with_timeout write gh label create "solved:interactive" --repo "$repo" \
-		--description "Task was solved by an interactive session" \
-		--color "BFD4F2" 2>/dev/null || true
+	case ",${_SOLVED_LABELS_ENSURED:-}," in
+	*",$repo,"*) return 0 ;;
+	esac
+	local labels_snapshot=""
+	labels_snapshot=$(_gh_managed_label_names_snapshot "$repo") || return 1
+	if ! _gh_managed_label_snapshot_has "$labels_snapshot" "solved:worker"; then
+		AIDEVOPS_GH_ROUTE_DECISION="$_GH_MANAGED_LABEL_CREATE_ROUTE" \
+			_gh_with_timeout write gh label create "solved:worker" --repo "$repo" \
+			--description "Task was solved by a headless worker" \
+			--color "0E8A16" 2>/dev/null || return 1
+	fi
+	if ! _gh_managed_label_snapshot_has "$labels_snapshot" "solved:interactive"; then
+		AIDEVOPS_GH_ROUTE_DECISION="$_GH_MANAGED_LABEL_CREATE_ROUTE" \
+			_gh_with_timeout write gh label create "solved:interactive" --repo "$repo" \
+			--description "Task was solved by an interactive session" \
+			--color "BFD4F2" 2>/dev/null || return 1
+	fi
+	_SOLVED_LABELS_ENSURED="${_SOLVED_LABELS_ENSURED:+$_SOLVED_LABELS_ENSURED,}$repo"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-close-conflicting-pr-wording.sh
+++ b/.agents/scripts/tests/test-close-conflicting-pr-wording.sh
@@ -57,13 +57,71 @@ print_result() {
 # Response files (written by set_responses):
 #   $TEST_ROOT/commits.json     — output for `gh api repos/.../commits` (JSON array)
 #   $TEST_ROOT/commit-files.txt — output for `gh api repos/.../commits/SHA` (lines)
-#   $TEST_ROOT/pr-files.txt     — output for `gh pr view N --json files` (lines)
+#   $TEST_ROOT/pr-files.txt     — output for pull-files REST pagination (lines)
 #   $TEST_ROOT/pr-labels.txt    — output for `gh pr view N --json labels` (lines)
 #   $TEST_ROOT/pr-branch.txt    — head branch for `gh pr view N --json headRefName`
 #   $TEST_ROOT/pr-base-branch.txt — base branch for `gh pr view N --json baseRefName`
 #
 # A missing or empty response file makes the stub exit 1, simulating a gh
 # API failure for the relevant call.
+append_stub_gh_pr_view() {
+	cat >>"${STUB_DIR}/gh" <<STUB_EOF
+if [[ "\$1" == "pr" && "\$2" == "view" ]]; then
+	field=""
+	args=("\$@")
+	i=2
+	while [[ \$i -lt \${#args[@]} ]]; do
+		if [[ "\${args[\$i]}" == "--json" ]]; then
+			j=\$((i + 1))
+			field="\${args[\$j]}"
+			break
+		fi
+		i=\$((i + 1))
+	done
+	case "\$field" in
+		"headRefName,baseRefName")
+			head_branch="feature/test"; base_branch="main"
+			[[ -f "\${TEST_ROOT}/pr-branch.txt" ]] && head_branch=\$(cat "\${TEST_ROOT}/pr-branch.txt")
+			[[ -f "\${TEST_ROOT}/pr-base-branch.txt" ]] && base_branch=\$(cat "\${TEST_ROOT}/pr-base-branch.txt")
+			printf '%s\t%s\n' "\$head_branch" "\$base_branch"
+			exit 0
+			;;
+		labels)
+			response="\${TEST_ROOT}/pr-labels.txt"
+			if [[ -f "\$response" ]]; then cat "\$response"; fi
+			exit 0
+			;;
+		"labels,author")
+			response="\${TEST_ROOT}/pr-meta.json"
+			if [[ -f "\$response" ]]; then
+				cat "\$response"
+			else
+				echo '{"labels":[{"name":"origin:worker"}],"author":{"login":"aidevops-worker[bot]"}}'
+			fi
+			exit 0
+			;;
+		files)
+			response="\${TEST_ROOT}/pr-files.txt"
+			if [[ ! -s "\$response" ]]; then exit 1; fi
+			cat "\$response"
+			exit 0
+			;;
+		headRefName)
+			response="\${TEST_ROOT}/pr-branch.txt"
+			if [[ -f "\$response" ]]; then cat "\$response"; else echo "feature/test"; fi
+			exit 0
+			;;
+		*)
+			exit 0
+			;;
+	esac
+fi
+
+exit 0
+STUB_EOF
+	return 0
+}
+
 write_stub_gh() {
 	cat >"${STUB_DIR}/gh" <<STUB_EOF
 #!/usr/bin/env bash
@@ -71,8 +129,21 @@ TEST_ROOT="${TEST_ROOT}"
 CAPTURED_COMMENT_FILE="${CAPTURED_COMMENT_FILE}"
 
 if [[ "\$1" == "api" ]]; then
-	url="\$2"
-	if [[ "\$url" =~ /commits/[a-f0-9]+\$ ]]; then
+	url=""
+	for arg in "\$@"; do
+		case "\$arg" in
+		repos/*) url="\$arg"; break ;;
+		esac
+	done
+	if [[ "\$url" =~ /pulls/[0-9]+/files ]]; then
+		[[ "\${AIDEVOPS_GH_ROUTE_DECISION:-}" == "pulse-pr-files-rest" ]] || exit 1
+		response="\${TEST_ROOT}/pr-files.txt"
+		if [[ ! -s "\$response" ]]; then
+			exit 1
+		fi
+		cat "\$response"
+		exit 0
+	elif [[ "\$url" =~ /commits/[a-f0-9]+\$ ]]; then
 		# gh api repos/X/Y/commits/SHA --jq '.files[].filename'
 		response="\${TEST_ROOT}/commit-files.txt"
 		if [[ ! -s "\$response" ]]; then
@@ -104,64 +175,8 @@ if [[ "\$1" == "pr" && "\$2" == "close" ]]; then
 	done
 	exit 0
 fi
-
-	if [[ "\$1" == "pr" && "\$2" == "view" ]]; then
-	field=""
-	args=("\$@")
-	i=2
-	while [[ \$i -lt \${#args[@]} ]]; do
-		if [[ "\${args[\$i]}" == "--json" ]]; then
-			j=\$((i + 1))
-			field="\${args[\$j]}"
-			break
-		fi
-		i=\$((i + 1))
-	done
-	case "\$field" in
-		"headRefName,baseRefName")
-			head_branch="feature/test"; base_branch="main"
-			[[ -f "\${TEST_ROOT}/pr-branch.txt" ]] && head_branch=\$(cat "\${TEST_ROOT}/pr-branch.txt")
-			[[ -f "\${TEST_ROOT}/pr-base-branch.txt" ]] && base_branch=\$(cat "\${TEST_ROOT}/pr-base-branch.txt")
-			printf '%s\t%s\n' "\$head_branch" "\$base_branch"
-			exit 0
-			;;
-		labels)
-			response="\${TEST_ROOT}/pr-labels.txt"
-			if [[ -f "\$response" ]]; then cat "\$response"; fi
-			exit 0
-			;;
-		"labels,author")
-			# GH#20485/GH#29170: _close_conflicting_pr_check_ownership_guard fetches
-			# labels + author metadata in one call. Return pr-meta.json if
-			# present; fall back to a default that simulates a worker PR
-			# (origin:worker label, bot author) so existing tests are unaffected.
-			response="\${TEST_ROOT}/pr-meta.json"
-			if [[ -f "\$response" ]]; then
-				cat "\$response"
-			else
-				echo '{"labels":[{"name":"origin:worker"}],"author":{"login":"aidevops-worker[bot]"}}'
-			fi
-			exit 0
-			;;
-		files)
-			response="\${TEST_ROOT}/pr-files.txt"
-			if [[ ! -s "\$response" ]]; then exit 1; fi
-			cat "\$response"
-			exit 0
-			;;
-		headRefName)
-			response="\${TEST_ROOT}/pr-branch.txt"
-			if [[ -f "\$response" ]]; then cat "\$response"; else echo "feature/test"; fi
-			exit 0
-			;;
-		*)
-			exit 0
-			;;
-	esac
-fi
-
-exit 0
 STUB_EOF
+	append_stub_gh_pr_view
 	chmod +x "${STUB_DIR}/gh"
 	return 0
 }

--- a/.agents/scripts/tests/test-dependabot-alert-monitor.sh
+++ b/.agents/scripts/tests/test-dependabot-alert-monitor.sh
@@ -36,33 +36,75 @@ JSON
 	return 0
 }
 
+write_fanout_repos_json() {
+	local repos_json="$1"
+	cat >"$repos_json" <<'JSON'
+{
+  "initialized_repos": [
+    {"slug": "owner/first", "pulse": true, "role": "maintainer"},
+    {"slug": "owner/second", "pulse": true, "role": "maintainer"},
+    {"slug": "owner/third", "pulse": true, "role": "maintainer"}
+  ]
+}
+JSON
+	return 0
+}
+
+TEST_CORE_REMAINING=5000
+TEST_ALERT_FAILURE_REPO=""
+TEST_ALERT_FAILURE_MESSAGE=""
+
 gh() {
 	local command="${1:-}"
 	shift || true
 	case "$command" in
 	api)
 		local endpoint=""
+		local jq_expr=""
 		while [[ $# -gt 0 ]]; do
 			case "$1" in
 			--paginate|--slurp)
 				shift
 				;;
+			--jq)
+				jq_expr="${2:-}"
+				shift 2
+				;;
 			*)
-				endpoint="$1"
+				[[ -n "$endpoint" ]] || endpoint="$1"
 				shift
 				;;
 			esac
 		done
 		printf '%s\n' "$endpoint" >>"${TEST_TMP}/api.log"
+		printf '%s|%s\n' "${AIDEVOPS_GH_ROUTE_DECISION:-unset}" "$endpoint" >>"${TEST_TMP}/routes.log"
 		case "$endpoint" in
-		repos/owner/project/dependabot/alerts*)
-			cat <<'JSON'
+		rate_limit)
+			if [[ "$jq_expr" == *'.resources.core.remaining'* ]]; then
+				printf '%s\n' "$TEST_CORE_REMAINING"
+			else
+				printf '{"resources":{"core":{"remaining":%s}}}\n' "$TEST_CORE_REMAINING"
+			fi
+			;;
+		repos/*/dependabot/alerts*)
+			local repo_slug="${endpoint#repos/}"
+			repo_slug="${repo_slug%%/dependabot/alerts*}"
+			if [[ -n "$TEST_ALERT_FAILURE_REPO" && "$repo_slug" == "$TEST_ALERT_FAILURE_REPO" ]]; then
+				printf '%s\n' "$TEST_ALERT_FAILURE_MESSAGE" >&2
+				return 1
+			fi
+			case "$repo_slug" in
+			owner/project)
+				cat <<'JSON'
 [[
   {"state":"open","dependency":{"package":{"name":"litellm","ecosystem":"pip"},"manifest_path":"requirements.txt"},"security_advisory":{"severity":"high"},"security_vulnerability":{"first_patched_version":{"identifier":"1.84.0"}}},
   {"state":"open","dependency":{"package":{"name":"litellm","ecosystem":"pip"},"manifest_path":"requirements-lock.txt"},"security_advisory":{"severity":"critical"},"security_vulnerability":{"first_patched_version":{"identifier":"1.84.0"}}},
   {"state":"open","dependency":{"package":{"name":"diskcache","ecosystem":"pip"},"manifest_path":"requirements.txt"},"security_advisory":{"severity":"medium"},"security_vulnerability":{"first_patched_version":null}}
 ]]
 JSON
+				;;
+			*) printf '[]\n' ;;
+			esac
 			;;
 		*)
 			printf '[]\n'
@@ -199,6 +241,13 @@ write_repos_json "$repos_json"
 
 dependabot_alert_monitor_scan_repos "$repos_json" "0" || fail "scan failed"
 
+if ! grep -q '^dependabot-alert-monitor-core-budget-rest|rate_limit$' "${TEST_TMP}/routes.log"; then
+	fail "core-budget preflight was not explicitly attributed"
+fi
+if ! grep -q '^dependabot-alert-monitor-alerts-rest|repos/owner/project/dependabot/alerts' "${TEST_TMP}/routes.log"; then
+	fail "Dependabot alert reads were not explicitly attributed"
+fi
+
 issue_count="$(wc -l <"${TEST_TMP}/issues.log" | tr -d ' ')"
 [[ "$issue_count" == "2" ]] || fail "expected 2 grouped issues, got ${issue_count}"
 
@@ -221,5 +270,40 @@ fi
 dependabot_alert_monitor_scan_repos "$repos_json" "0" || fail "second scan failed"
 second_issue_count="$(wc -l <"${TEST_TMP}/issues.log" | tr -d ' ')"
 [[ "$second_issue_count" == "2" ]] || fail "state dedupe created duplicate issues"
+
+# Low budget must stop before the first repository alert request.
+: >"${TEST_TMP}/api.log"
+TEST_CORE_REMAINING=251
+dependabot_alert_monitor_scan_repos "$repos_json" "1" || fail "low-budget scan failed"
+if grep -q '/dependabot/alerts' "${TEST_TMP}/api.log"; then
+	fail "low-budget preflight still entered repository fanout"
+fi
+if ! grep -q 'core budget insufficient for Dependabot fanout' "$LOGFILE"; then
+	fail "low-budget preflight did not record a decision"
+fi
+
+fanout_repos_json="${TEST_TMP}/fanout-repos.json"
+write_fanout_repos_json "$fanout_repos_json"
+TEST_CORE_REMAINING=5000
+
+# A primary/secondary rate-limit response stops the repository loop immediately.
+: >"${TEST_TMP}/api.log"
+TEST_ALERT_FAILURE_REPO="owner/first"
+TEST_ALERT_FAILURE_MESSAGE="gh: API rate limit exceeded (HTTP 403)"
+dependabot_alert_monitor_scan_repos "$fanout_repos_json" "1" || fail "rate-limited fanout scan failed"
+if grep -q 'repos/owner/second/dependabot/alerts' "${TEST_TMP}/api.log"; then
+	fail "rate-limited fanout continued to the second repository"
+fi
+if ! grep -q 'stopping Dependabot fanout after rate-limit response from owner/first' "$LOGFILE"; then
+	fail "rate-limited fanout did not log its stop decision"
+fi
+
+# Permission/configuration failures remain repo-local and do not suppress peers.
+: >"${TEST_TMP}/api.log"
+TEST_ALERT_FAILURE_MESSAGE="gh: Dependabot alerts are disabled (HTTP 403)"
+dependabot_alert_monitor_scan_repos "$fanout_repos_json" "1" || fail "repo-local failure scan failed"
+if ! grep -q 'repos/owner/second/dependabot/alerts' "${TEST_TMP}/api.log"; then
+	fail "non-rate-limit repository failure stopped the remaining fanout"
+fi
 
 printf 'PASS dependabot alert monitor grouped managed repo alerts\n'

--- a/.agents/scripts/tests/test-dirty-pr-sweep.sh
+++ b/.agents/scripts/tests/test-dirty-pr-sweep.sh
@@ -578,6 +578,66 @@ else
 fi
 
 # =============================================================================
+# Test 10: response-metered GraphQL population read is exact and fail-closed
+# =============================================================================
+
+cat >"${STUB_DIR}/gh" <<'STUB'
+#!/usr/bin/env bash
+printf 'response=%s route=%s gh %s\n' \
+	"${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" \
+	"${AIDEVOPS_GH_ROUTE_DECISION:-}" "$*" >>"$GH_CALLS_LOG"
+[[ "${1:-}" == "api" && "${2:-}" == "graphql" ]] || exit 1
+case "${DIRTY_GRAPHQL_MODE:-valid}" in
+	missing-cost)
+		printf '%s\n' '{"data":{"repository":{"pullRequests":{"nodes":[]}}}}'
+		;;
+	partial-labels)
+		printf '%s\n' '{"data":{"repository":{"pullRequests":{"nodes":[{"number":77,"title":"dirty","mergeStateStatus":"DIRTY","createdAt":"2026-08-01T00:00:00Z","updatedAt":"2026-08-02T00:00:00Z","author":{"login":"worker"},"labels":{"nodes":[{"name":"origin:worker"}],"pageInfo":{"hasNextPage":true}},"headRefName":"fix/dirty","baseRefName":"main","body":"For #77"}]}},"rateLimit":{"cost":1}}}'
+		;;
+	*)
+		printf '%s\n' '{"data":{"repository":{"pullRequests":{"nodes":[{"number":77,"title":"dirty","mergeStateStatus":"DIRTY","createdAt":"2026-08-01T00:00:00Z","updatedAt":"2026-08-02T00:00:00Z","author":{"login":"worker"},"labels":{"nodes":[{"name":"origin:worker"}],"pageInfo":{"hasNextPage":false}},"headRefName":"fix/dirty","baseRefName":"main","body":"For #77"}]}},"rateLimit":{"cost":1}}}'
+		;;
+esac
+exit 0
+STUB
+chmod +x "${STUB_DIR}/gh"
+: >"$GH_CALLS_LOG"
+export PATH="${STUB_DIR}:${PATH_ORIG}"
+export GH_CALLS_LOG
+
+DIRTY_GRAPHQL_MODE=valid
+export DIRTY_GRAPHQL_MODE
+graphql_out=""
+graphql_rc=0
+graphql_out=$(_dirty_pr_sweep_open_prs_graphql "test/repo" 100) || graphql_rc=$?
+if [[ "$graphql_rc" -eq 0 ]] \
+	&& printf '%s' "$graphql_out" | jq -e 'length == 1 and .[0].number == 77 and .[0].labels[0].name == "origin:worker"' >/dev/null \
+	&& grep -q 'response=1 route=dirty-pr-sweep-exact-cost gh api graphql' "$GH_CALLS_LOG"; then
+	print_result "exact GraphQL population read returns compatible JSON and response-owned cost" 0
+else
+	print_result "exact GraphQL population read returns compatible JSON and response-owned cost" 1 "rc=${graphql_rc}; output=${graphql_out}"
+fi
+
+DIRTY_GRAPHQL_MODE=missing-cost
+graphql_rc=0
+_dirty_pr_sweep_open_prs_graphql "test/repo" 100 >/dev/null 2>&1 || graphql_rc=$?
+if [[ "$graphql_rc" -ne 0 ]]; then
+	print_result "exact GraphQL population read rejects missing response cost" 0
+else
+	print_result "exact GraphQL population read rejects missing response cost" 1
+fi
+
+DIRTY_GRAPHQL_MODE=partial-labels
+graphql_rc=0
+_dirty_pr_sweep_open_prs_graphql "test/repo" 100 >/dev/null 2>&1 || graphql_rc=$?
+if [[ "$graphql_rc" -ne 0 ]]; then
+	print_result "exact GraphQL population read rejects partial label metadata" 0
+else
+	print_result "exact GraphQL population read rejects partial label metadata" 1
+fi
+export PATH="$PATH_ORIG"
+
+# =============================================================================
 # Summary
 # =============================================================================
 

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
@@ -17,6 +17,7 @@ TESTS_FAILED=0
 TEST_ROOT=""
 GH_FIXTURE_FILE=""
 GH_PR_VIEW_FIXTURE_FILE=""
+GH_GRAPHQL_CALL_LOG=""
 
 print_result() {
 	local test_name="$1"
@@ -46,6 +47,124 @@ _write_gh_stub() {
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Response-metered GraphQL replacements for the two rich native PR-list shapes.
+if [[ "${1:-}" == "api" && "${2:-}" == "graphql" ]]; then
+	if [[ "${GH_PR_LIST_FAIL:-0}" == "1" ]]; then
+		exit 1
+	fi
+	query_text=""
+	query_string=""
+	query_owner=""
+	query_name=""
+	shift 2
+	for argument in "$@"; do
+		case "$argument" in
+		query=*) query_text="${argument#query=}" ;;
+		queryString=*) query_string="${argument#queryString=}" ;;
+		owner=*) query_owner="${argument#owner=}" ;;
+		name=*) query_name="${argument#name=}" ;;
+		esac
+	done
+	if [[ -n "${GH_GRAPHQL_CALL_LOG:-}" ]]; then
+		printf '%s|%s|%s\n' \
+			"${AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE:-}" \
+			"${AIDEVOPS_GH_ROUTE_DECISION:-}" \
+			"$query_text" >>"$GH_GRAPHQL_CALL_LOG"
+	fi
+	graphql_cost="2"
+	if [[ "${GH_GRAPHQL_MISSING_COST:-0}" == "1" ]]; then
+		graphql_cost="null"
+	fi
+
+	if [[ "$query_text" == *"search(type: ISSUE"* ]]; then
+		local_repo="${query_string#repo:}"
+		local_repo="${local_repo%% *}"
+		local_search=""
+		if [[ "$query_string" =~ \#([0-9]+) ]]; then
+			local_search="#${BASH_REMATCH[1]}"
+		fi
+		fixture_payload="[]"
+		compound_key="${local_repo}|open|${local_search}"
+		while IFS= read -r line; do
+			[[ -n "$line" ]] || continue
+			fixture_key="${line%|*}"
+			if [[ "$fixture_key" == "$compound_key" ]]; then
+				fixture_payload="${line##*|}"
+				break
+			fi
+		done <"${GH_FIXTURE_FILE}"
+		jq -cn --argjson nodes "$fixture_payload" --argjson cost "$graphql_cost" '
+			{
+				data: {
+					search: {
+						nodes: ($nodes | map(. as $pr | {
+							__typename: "PullRequest",
+							number: $pr.number,
+							title: ($pr.title // null),
+							body: ($pr.body // null),
+							isDraft: ($pr.isDraft // false),
+							reviewDecision: ($pr.reviewDecision // null),
+							mergeStateStatus: ($pr.mergeStateStatus // null),
+							mergeable: ($pr.mergeable // null),
+							changedFiles: ($pr.changedFiles // 0),
+							files: {
+								nodes: ($pr.files // []),
+								pageInfo: {hasNextPage: ($pr.filesHasNextPage // false)}
+							},
+							labels: {
+								nodes: ($pr.labels // []),
+								pageInfo: {hasNextPage: ($pr.labelsHasNextPage // false)}
+							}
+						}))
+					},
+					rateLimit: {cost: $cost}
+				}
+			}'
+		exit 0
+	fi
+EOF
+	_append_gh_stub_graphql_tail "$stub_path"
+	_append_gh_stub_native_reads "$stub_path"
+	chmod +x "$stub_path"
+	return 0
+}
+
+_append_gh_stub_graphql_tail() {
+	local stub_path="$1"
+	cat >>"$stub_path" <<'EOF'
+	if [[ "$query_text" == *"commits(first: 100)"* ]]; then
+		jq -cn --argjson nodes "${GH_OPEN_COMMITS_JSON:-[]}" --argjson cost "$graphql_cost" '
+			{
+				data: {
+					repository: {
+						pullRequests: {
+							nodes: ($nodes | map(. as $pr | {
+								number: $pr.number,
+								title: ($pr.title // null),
+								isDraft: ($pr.isDraft // false),
+								commits: {
+									nodes: [($pr.commits // [])[] | {commit: {messageHeadline: (.messageHeadline // "")}}],
+									pageInfo: {hasNextPage: false}
+								}
+							}))
+						}
+					},
+					rateLimit: {cost: $cost}
+				}
+			}'
+		exit 0
+	fi
+
+	printf 'unsupported GraphQL query in test stub for %s/%s\n' "$query_owner" "$query_name" >&2
+	exit 1
+fi
+EOF
+	return 0
+}
+
+_append_gh_stub_native_reads() {
+	local stub_path="$1"
+	cat >>"$stub_path" <<'EOF'
 # gh pr list — returns fixture JSON for (repo, state, search) lookup.
 if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
 	if [[ "${GH_PR_LIST_FAIL:-0}" == "1" ]]; then
@@ -117,7 +236,6 @@ fi
 printf 'unsupported gh invocation in test stub: %s\n' "$*" >&2
 exit 1
 EOF
-	chmod +x "$stub_path"
 	return 0
 }
 
@@ -125,16 +243,19 @@ setup_test_env() {
 	TEST_ROOT=$(mktemp -d)
 	GH_FIXTURE_FILE="${TEST_ROOT}/gh-pr-list-fixtures.txt"
 	GH_PR_VIEW_FIXTURE_FILE="${TEST_ROOT}/gh-pr-view-fixtures.txt"
+	GH_GRAPHQL_CALL_LOG="${TEST_ROOT}/gh-graphql-calls.log"
 
 	mkdir -p "${TEST_ROOT}/bin"
 	export PATH="${TEST_ROOT}/bin:${PATH}"
 	export GH_FIXTURE_FILE
 	export GH_PR_VIEW_FIXTURE_FILE
+	export GH_GRAPHQL_CALL_LOG
 
 	_write_gh_stub "${TEST_ROOT}/bin/gh"
 
 	printf '' >"${GH_FIXTURE_FILE}"
 	printf '' >"${GH_PR_VIEW_FIXTURE_FILE}"
+	printf '' >"${GH_GRAPHQL_CALL_LOG}"
 	return 0
 }
 
@@ -198,6 +319,30 @@ test_has_open_pr_detects_task_id_fallback() {
 	fi
 
 	print_result "has-open-pr detects merged PR via task-id fallback" 1 "Expected merged PR evidence via task-id fallback"
+	return 0
+}
+
+test_has_open_pr_detects_response_metered_commit_reference() {
+	local output=""
+	export GH_OPEN_COMMITS_JSON='[{"number":1060,"title":"Implement exact quota attribution","isDraft":false,"commits":[{"messageHeadline":"Fixes #10000 with response-owned cost"}]}]'
+	printf '' >"$GH_GRAPHQL_CALL_LOG"
+
+	if output=$("$HELPER_SCRIPT" has-open-pr 10000 marcusquinn/aidevops 't10000: exact quota attribution'); then
+		unset GH_OPEN_COMMITS_JSON
+		if [[ "$output" == *"open PR #1060 has commits targeting issue #10000"* ]] && \
+			grep -qF '1|dispatch-dedup-open-commits-exact-cost|' "$GH_GRAPHQL_CALL_LOG" && \
+			grep -qF 'rateLimit { cost }' "$GH_GRAPHQL_CALL_LOG"; then
+			print_result "has-open-pr meters open-commit GraphQL from its response" 0
+			return 0
+		fi
+		print_result "has-open-pr meters open-commit GraphQL from its response" 1 \
+			"output=${output}"
+		return 0
+	fi
+
+	unset GH_OPEN_COMMITS_JSON
+	print_result "has-open-pr meters open-commit GraphQL from its response" 1 \
+		"Expected commit evidence for issue #10000"
 	return 0
 }
 
@@ -360,6 +505,46 @@ test_has_open_pr_fails_closed_when_sibling_lookup_fails() {
 
 	print_result "has-open-pr fails closed when sibling lookup is uncertain" 1 \
 		"rc=${rc} output=${output}"
+	return 0
+}
+
+test_has_open_pr_fails_closed_without_response_owned_cost() {
+	export GH_GRAPHQL_MISSING_COST=1
+	local output=""
+	local rc=0
+	output=$("$HELPER_SCRIPT" has-open-pr 18783 marcusquinn/aidevops 'missing response-owned cost') || rc=$?
+	unset GH_GRAPHQL_MISSING_COST
+
+	if [[ "$rc" -eq 0 && "$output" == PR_LOOKUP_UNCERTAIN:* ]]; then
+		print_result "has-open-pr fails closed without response-owned GraphQL cost" 0
+		return 0
+	fi
+
+	print_result "has-open-pr fails closed without response-owned GraphQL cost" 1 \
+		"rc=${rc} output=${output}"
+	return 0
+}
+
+test_has_open_pr_fails_closed_on_partial_sibling_connections() {
+	local fixture='marcusquinn/aidevops|open|#18784|[{"number":18909,"title":"Interactive checkpoint for #18784","body":"For #18784","isDraft":true,"labels":[{"name":"origin:interactive"}],"labelsHasNextPage":true}]'
+	set_gh_fixtures "$fixture"
+	local output=""
+	local rc=0
+	output=$("$HELPER_SCRIPT" has-open-pr 18784 marcusquinn/aidevops 'partial sibling labels') || rc=$?
+	if [[ "$rc" -ne 0 || "$output" != PR_LOOKUP_UNCERTAIN:* ]]; then
+		print_result "has-open-pr rejects partial sibling labels" 1 "rc=${rc} output=${output}"
+		return 0
+	fi
+
+	fixture='marcusquinn/aidevops|open|#18785|[{"number":18910,"title":"Checkpoint for #18785","body":"For #18785","isDraft":true,"filesHasNextPage":true}]'
+	set_gh_fixtures "$fixture"
+	rc=0
+	output=$("$HELPER_SCRIPT" has-open-pr 18785 marcusquinn/aidevops 'partial sibling files') || rc=$?
+	if [[ "$rc" -eq 0 && "$output" == PR_LOOKUP_UNCERTAIN:* ]]; then
+		print_result "has-open-pr rejects partial sibling connections" 0
+	else
+		print_result "has-open-pr rejects partial sibling connections" 1 "rc=${rc} output=${output}"
+	fi
 	return 0
 }
 
@@ -757,6 +942,7 @@ main() {
 
 	test_has_open_pr_detects_closing_keyword
 	test_has_open_pr_detects_task_id_fallback
+	test_has_open_pr_detects_response_metered_commit_reference
 	test_has_open_pr_returns_nonzero_without_match
 	test_has_open_pr_ignores_planning_for_reference
 	test_has_open_pr_ignores_planning_ref_reference
@@ -767,6 +953,8 @@ main() {
 	test_has_open_pr_marks_worker_draft_for_stale_routing
 	test_has_open_pr_keeps_protected_draft_unroutable
 	test_has_open_pr_fails_closed_when_sibling_lookup_fails
+	test_has_open_pr_fails_closed_without_response_owned_cost
+	test_has_open_pr_fails_closed_on_partial_sibling_connections
 	test_has_open_pr_ignores_open_body_planning_for_reference
 	test_has_open_pr_requires_open_close_keyword_for_our_issue
 	test_has_open_pr_blocks_approved_mergeable_sibling

--- a/.agents/scripts/tests/test-full-loop-efficient-orchestration.sh
+++ b/.agents/scripts/tests/test-full-loop-efficient-orchestration.sh
@@ -106,6 +106,10 @@ POST_CHECK_HEAD="abc123"
 PR_VIEW_CACHE_CONTROL_FILE="${TMP_DIR}/pr-view-cache-control.log"
 : >"$PR_VIEW_CACHE_CONTROL_FILE"
 gh() {
+	if [[ "$1" == "api" && "$2" == "graphql" ]]; then
+		printf '%s\n' '{"data":{"repository":{"pullRequest":{"state":"OPEN","isDraft":false,"reviewDecision":"","headRefOid":"abc123","headRefName":"fixture-remote"}},"rateLimit":{"cost":1}}}'
+		return 0
+	fi
 	if [[ "$1" == "api" && "$2" == "repos/owner/repo" ]]; then
 		if [[ "$CHECK_MODE" == "api-error" ]]; then
 			return 1

--- a/.agents/scripts/tests/test-full-loop-helper-coderabbit-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-helper-coderabbit-reconcile.sh
@@ -27,6 +27,18 @@ cat >"${TEST_ROOT}/bin/gh" <<'GH_STUB'
 set -euo pipefail
 printf '%s\n' "gh $*" >>"$GH_LOG"
 
+if [[ "${1:-}" == "api" && "${2:-}" == "graphql" ]]; then
+	review_decision="CHANGES_REQUESTED"
+	if grep -q "dismissals" "$GH_LOG"; then
+		review_decision=""
+	fi
+	if [[ "${READINESS_RESPONSE_MODE:-valid}" == "missing-cost" ]]; then
+		printf '{"data":{"repository":{"pullRequest":{"state":"OPEN","isDraft":false,"reviewDecision":"%s","headRefOid":"%s","headRefName":"remote-branch"}}}}\n' "$review_decision" "$CURRENT_HEAD"
+	else
+		printf '{"data":{"repository":{"pullRequest":{"state":"OPEN","isDraft":false,"reviewDecision":"%s","headRefOid":"%s","headRefName":"remote-branch"}},"rateLimit":{"cost":1}}}\n' "$review_decision" "$CURRENT_HEAD"
+	fi
+	exit 0
+fi
 if [[ "${1:-}" == "api" && "$*" == *"dismissals"* ]]; then
 	[[ "${DISMISS_FAIL:-0}" == "1" ]] && exit 1
 	exit 0
@@ -94,6 +106,7 @@ reset_fixture() {
 	export HEAD_DRIFT=0
 	export DISMISS_FAIL=0
 	export POST_REVIEW_DECISION=""
+	export READINESS_RESPONSE_MODE="valid"
 	cat >"$REVIEWS_FILE" <<EOF
 [{"id":4782275476,"user":{"login":"coderabbitai[bot]","type":"Bot"},"state":"CHANGES_REQUESTED","commit_id":"${STALE_HEAD}","submitted_at":"2026-07-26T17:52:52Z"}]
 EOF
@@ -243,6 +256,17 @@ test_full_loop_readiness_integration() {
 	else
 		record_result "full-loop readiness reconciles before required checks" 1
 	fi
+
+	: >"$GH_LOG"
+	export READINESS_RESPONSE_MODE="missing-cost"
+	rc=0
+	_full_loop_verify_pr_readiness 42 owner/repo >/dev/null 2>&1 || rc=$?
+	if [[ "$rc" -ne 0 ]] && ! grep -q "exact-checks owner/repo 42 required" "$GH_LOG"; then
+		record_result "full-loop readiness rejects missing response cost" 0
+	else
+		record_result "full-loop readiness rejects missing response cost" 1
+	fi
+	export READINESS_RESPONSE_MODE="valid"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-full-loop-remote-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-remote-evidence.sh
@@ -19,6 +19,27 @@ chmod +x "${ROOT}/helpers/review-bot-gate-helper.sh"
 
 cat >"${ROOT}/bin/gh" <<'STUB'
 #!/usr/bin/env bash
+if [[ "${1:-}" == "api" && "${2:-}" == "graphql" ]]; then
+	state="OPEN"
+	is_draft=false
+	review_decision="APPROVED"
+	case "${GH_TEST_MODE:-pass}" in
+		draft) is_draft=true ;;
+		changes) review_decision="CHANGES_REQUESTED" ;;
+		closed) state="CLOSED" ;;
+		readiness-missing-cost)
+			printf '{"data":{"repository":{"pullRequest":{"state":"OPEN","isDraft":false,"reviewDecision":"APPROVED","headRefOid":"abc123","headRefName":"remote-branch"}}}}\n'
+			exit 0
+			;;
+		readiness-errors)
+			printf '%s\n' '{"data":{"repository":{"pullRequest":{"state":"OPEN","isDraft":false,"reviewDecision":"APPROVED","headRefOid":"abc123","headRefName":"remote-branch"}},"rateLimit":{"cost":1}},"errors":[{"message":"partial"}]}'
+			exit 0
+			;;
+	esac
+	printf '{"data":{"repository":{"pullRequest":{"state":"%s","isDraft":%s,"reviewDecision":"%s","headRefOid":"abc123","headRefName":"remote-branch"}},"rateLimit":{"cost":1}}}\n' \
+		"$state" "$is_draft" "$review_decision"
+	exit 0
+fi
 if [[ "${1:-}" == "api" && "${2:-}" == "repos/testorg/testrepo" ]]; then
 	if [[ "${GH_TEST_MODE:-pass}" == "api-error" ]]; then
 		printf '%s\n' 'HTTP 503: service unavailable' >&2
@@ -184,7 +205,7 @@ run_gate cli-no-required || {
 }
 printf 'PASS canonical CLI no-required-checks evidence survives unavailable branch protection\n'
 
-for mode in draft pending changes closed api-error changed-wording malformed empty-array; do
+for mode in draft pending changes closed api-error changed-wording malformed empty-array readiness-missing-cost readiness-errors; do
 	if run_gate "$mode"; then
 		printf 'FAIL unsafe remote state was accepted: %s\n' "$mode"
 		exit 1

--- a/.agents/scripts/tests/test-github-api-efficiency-benchmark.sh
+++ b/.agents/scripts/tests/test-github-api-efficiency-benchmark.sh
@@ -100,7 +100,7 @@ from pathlib import Path
 import sys
 
 ROOT = Path(sys.argv[1])
-EVIDENCE_SCHEMA = "aidevops-github-api-efficiency-evidence/v2"
+EVIDENCE_SCHEMA = "aidevops-github-api-efficiency-evidence/v3"
 REPOSITORY_SET = "a" * 64
 
 
@@ -191,6 +191,7 @@ def evidence(*, p50, p95, burst, completed_p95, webhook_p95, complete=True):
             "p50_ms": p50,
             "p95_ms": p95,
             "peak_attempts_per_minute": burst,
+            "completed_action_samples": 20 if completed_p95 is not None else 0,
             "completed_action_p95_ms": completed_p95,
         },
         "cache": {
@@ -208,6 +209,7 @@ def evidence(*, p50, p95, burst, completed_p95, webhook_p95, complete=True):
         },
         "webhook": {
             "invalidations": 10,
+            "lag_samples": 10 if webhook_p95 is not None else 0,
             "lag_p50_ms": 100,
             "lag_p95_ms": webhook_p95,
             "duplicate_actions": 0,
@@ -264,14 +266,16 @@ PASS_EVIDENCE = evidence(
 )
 
 
-def write_case(name, canary_report, canary_evidence):
+def write_case(name, canary_report, canary_evidence, baseline_evidence=None):
     baseline_report_path = ROOT / f"{name}-baseline-report.json"
     baseline_evidence_path = ROOT / f"{name}-baseline-evidence.json"
     canary_report_path = ROOT / f"{name}-canary-report.json"
     canary_evidence_path = ROOT / f"{name}-canary-evidence.json"
 
     write_json(baseline_report_path, BASELINE_REPORT)
-    baseline_sidecar = copy.deepcopy(BASELINE_EVIDENCE)
+    baseline_sidecar = copy.deepcopy(
+        BASELINE_EVIDENCE if baseline_evidence is None else baseline_evidence
+    )
     baseline_sidecar["transport_sha256"] = hashlib.sha256(
         baseline_report_path.read_bytes()
     ).hexdigest()
@@ -286,6 +290,37 @@ def write_case(name, canary_report, canary_evidence):
 
 
 write_case("pass", PASS_REPORT, PASS_EVIDENCE)
+
+empty_baseline_evidence = copy.deepcopy(BASELINE_EVIDENCE)
+empty_canary_evidence = copy.deepcopy(PASS_EVIDENCE)
+for sidecar in (empty_baseline_evidence, empty_canary_evidence):
+    sidecar["population"]["unchanged_cycles"] = 100
+    sidecar["population"]["actionable_changes"] = 0
+    sidecar["population"]["unique_actionable_head_shas"] = 0
+    sidecar["latency"]["completed_action_samples"] = 0
+    sidecar["latency"]["completed_action_p95_ms"] = None
+    sidecar["webhook"]["invalidations"] = 0
+    sidecar["webhook"]["lag_samples"] = 0
+    sidecar["webhook"]["lag_p50_ms"] = None
+    sidecar["webhook"]["lag_p95_ms"] = None
+    sidecar["path_budgets"]["aggregate_check_fetches"] = 0
+    sidecar["path_budgets"]["cycle_scoped_aggregate_check_fetches"] = 0
+    sidecar["path_budgets"]["unique_cycle_scoped_actionable_heads"] = 0
+write_case(
+    "empty-distributions",
+    PASS_REPORT,
+    empty_canary_evidence,
+    empty_baseline_evidence,
+)
+
+sample_mismatch_evidence = copy.deepcopy(PASS_EVIDENCE)
+sample_mismatch_evidence["latency"]["completed_action_samples"] = 0
+sample_mismatch_evidence["latency"]["completed_action_p95_ms"] = None
+write_case("sample-mismatch", PASS_REPORT, sample_mismatch_evidence)
+
+invalid_distribution_evidence = copy.deepcopy(PASS_EVIDENCE)
+invalid_distribution_evidence["latency"]["completed_action_samples"] = 0
+write_case("distribution-invalid", PASS_REPORT, invalid_distribution_evidence)
 
 regression_report = transport(
     50_000,
@@ -314,6 +349,19 @@ incomplete_evidence = copy.deepcopy(PASS_EVIDENCE)
 incomplete_evidence["complete"] = False
 incomplete_evidence["latency"]["p95_ms"] = None
 write_case("incomplete", PASS_REPORT, incomplete_evidence)
+
+uncovered_distribution_evidence = copy.deepcopy(PASS_EVIDENCE)
+uncovered_distribution_evidence["complete"] = False
+uncovered_distribution_evidence["latency"]["completed_action_samples"] = None
+uncovered_distribution_evidence["latency"]["completed_action_p95_ms"] = None
+uncovered_distribution_evidence["webhook"]["lag_samples"] = None
+uncovered_distribution_evidence["webhook"]["lag_p50_ms"] = None
+uncovered_distribution_evidence["webhook"]["lag_p95_ms"] = None
+write_case(
+    "uncovered-distributions",
+    PASS_REPORT,
+    uncovered_distribution_evidence,
+)
 
 unequal_report = transport(
     50_000,
@@ -452,6 +500,13 @@ test_pass_and_determinism() {
 	else
 		record_result "identical inputs produce byte-stable reports" 1
 	fi
+
+	run_case empty-distributions
+	assert_eq "observed empty distributions can pass" "0" "$LAST_EXIT"
+	assert_jq "empty distributions are explicit and comparable" \
+		'.status == "PASS" and .windows.baseline.latency.completed_action_samples == 0 and .windows.baseline.latency.completed_action_p95_ms == null and .windows.canary.webhook.lag_samples == 0 and .windows.canary.webhook.lag_p95_ms == null' "$LAST_JSON"
+	markdown=$(<"$LAST_MARKDOWN")
+	assert_contains "Markdown distinguishes empty distributions" "not applicable" "$markdown"
 	return 0
 }
 
@@ -473,6 +528,11 @@ test_inconclusive_windows() {
 	assert_jq "incomplete evidence is INCONCLUSIVE" \
 		'.status == "INCONCLUSIVE" and (.reasons | any(contains("marked incomplete"))) and (.reasons | any(contains("latency.p95_ms is unknown")))' "$LAST_JSON"
 
+	run_case uncovered-distributions
+	assert_eq "uncovered distributions exit two" "2" "$LAST_EXIT"
+	assert_jq "uncovered distributions remain INCONCLUSIVE without crashing" \
+		'.status == "INCONCLUSIVE" and (.reasons | any(contains("completed_action_samples is unknown"))) and (.reasons | any(contains("lag_samples is unknown")))' "$LAST_JSON"
+
 	run_case unequal
 	assert_eq "unequal retained windows exit two" "2" "$LAST_EXIT"
 	assert_jq "unequal retained windows are INCONCLUSIVE" \
@@ -482,6 +542,11 @@ test_inconclusive_windows() {
 	assert_eq "non-equivalent workload exits two" "2" "$LAST_EXIT"
 	assert_jq "workload mix is part of comparability" \
 		'.status == "INCONCLUSIVE" and (.comparability.workload_rates_equivalent == false) and (.reasons | any(contains("actionable_changes rates")))' "$LAST_JSON"
+
+	run_case sample-mismatch
+	assert_eq "one-sided completed-action samples exit two" "2" "$LAST_EXIT"
+	assert_jq "one-sided completed-action samples are noncomparable" \
+		'.status == "INCONCLUSIVE" and (.reasons | any(contains("completed-action latency sample availability differs")))' "$LAST_JSON"
 
 	run_case pass 60000
 	assert_eq "pre-rollout canary exits two" "2" "$LAST_EXIT"
@@ -520,6 +585,11 @@ test_fail_closed_transport() {
 	assert_eq "inconsistent population exits two" "2" "$LAST_EXIT"
 	assert_contains "inconsistent population explains rejection" "exceed Pulse cycles" "$LAST_OUTPUT"
 	assert_missing "inconsistent population writes no JSON" "$LAST_JSON"
+
+	run_case distribution-invalid
+	assert_eq "inconsistent distribution exits two" "2" "$LAST_EXIT"
+	assert_contains "inconsistent distribution explains rejection" "must be null when its sample count is zero" "$LAST_OUTPUT"
+	assert_missing "inconsistent distribution writes no JSON" "$LAST_JSON"
 
 	run_case digest
 	assert_eq "mismatched evidence digest exits two" "2" "$LAST_EXIT"

--- a/.agents/scripts/tests/test-github-api-efficiency-evidence.sh
+++ b/.agents/scripts/tests/test-github-api-efficiency-evidence.sh
@@ -222,6 +222,26 @@ EVENTS = [
 complete = transport(EVENTS)
 write_json(ROOT / "complete-report.json", complete)
 
+empty_distribution_names = {
+    "population.unchanged_cycles",
+    "population.actionable_changes",
+    "population.actionable_head_token",
+    "latency.completed_action_ms",
+    "webhook.invalidations",
+    "webhook.lag_ms",
+    "path_budgets.aggregate_check_fetches",
+    "path_budgets.cycle_scoped_aggregate_check_fetches",
+    "path_budgets.cycle_scoped_actionable_head_token",
+}
+empty_distribution_events = [
+    event for event in EVENTS if event[0] not in empty_distribution_names
+]
+empty_distribution_events.append(("population.unchanged_cycles", "4", 1))
+write_json(
+    ROOT / "empty-distributions-report.json",
+    transport(empty_distribution_events),
+)
+
 mixed_contract_events = EVENTS + [
     ("contract", "1", 1),
     ("coverage-start", "800", 1),
@@ -296,6 +316,16 @@ test_contract_migration_evidence() {
     return 0
 }
 
+finish_test_run() {
+    printf "\nTests run: %d\n" "$TESTS_RUN"
+    if [[ "$TESTS_FAILED" -gt 0 ]]; then
+        printf "Tests failed: %d\n" "$TESTS_FAILED"
+        return 1
+    fi
+    printf "All tests passed\n"
+    return 0
+}
+
 main() {
     local complete_report="${TEST_ROOT}/complete-report.json"
     local complete_output="${TEST_ROOT}/complete-evidence.json"
@@ -309,9 +339,9 @@ main() {
     run_build "$complete_report" "$complete_output"
     assert_eq "complete evidence exits zero" "0" "$LAST_EXIT"
     assert_contains "complete evidence reports status" "evidence sidecar: complete" "$LAST_OUTPUT"
-    assert_jq "complete evidence populates every group" ".complete and .population.repository_count == 10 and .population.pulse_cycles == 4 and .population.unchanged_cycles == 3 and .population.actionable_changes == 3 and .population.unique_actionable_head_shas == 2 and .latency.p50_ms == 10 and .latency.p95_ms == 30 and .latency.peak_attempts_per_minute == 2 and .latency.completed_action_p95_ms == 200 and .cache.fresh_hits == 3 and .cache.fresh_empty_hits == 1 and .cache.misses == 2 and .cache.stale == 1 and .cache.invalidated == 1 and .single_flight.leaders == 2 and .single_flight.waits == 1 and .single_flight.takeovers == 0 and .single_flight.duplicate_leaders == 0 and .webhook.invalidations == 2 and .webhook.lag_p50_ms == 30 and .webhook.lag_p95_ms == 30 and .webhook.duplicate_actions == 0 and .webhook.missed_recoveries == 0 and .guardrails.stale_snapshot_detections == 1 and .guardrails.forced_live_refreshes == 1 and .guardrails.stale_positive_decisions == 0 and .guardrails.dispatch_dependency_violations == 0 and .guardrails.required_check_merge_preflight_mismatches == 0 and .path_budgets.aggregate_check_fetches == 2 and .path_budgets.cycle_scoped_aggregate_check_fetches == 2 and .path_budgets.unique_cycle_scoped_actionable_heads == 2 and (._meta.missing_fields | length) == 0" "$complete_output"
+    assert_jq "complete evidence populates every group" ".complete and .population.repository_count == 10 and .population.pulse_cycles == 4 and .population.unchanged_cycles == 3 and .population.actionable_changes == 3 and .population.unique_actionable_head_shas == 2 and .latency.p50_ms == 10 and .latency.p95_ms == 30 and .latency.peak_attempts_per_minute == 2 and .latency.completed_action_samples == 3 and .latency.completed_action_p95_ms == 200 and .cache.fresh_hits == 3 and .cache.fresh_empty_hits == 1 and .cache.misses == 2 and .cache.stale == 1 and .cache.invalidated == 1 and .single_flight.leaders == 2 and .single_flight.waits == 1 and .single_flight.takeovers == 0 and .single_flight.duplicate_leaders == 0 and .webhook.invalidations == 2 and .webhook.lag_samples == 3 and .webhook.lag_p50_ms == 30 and .webhook.lag_p95_ms == 30 and .webhook.duplicate_actions == 0 and .webhook.missed_recoveries == 0 and .guardrails.stale_snapshot_detections == 1 and .guardrails.forced_live_refreshes == 1 and .guardrails.stale_positive_decisions == 0 and .guardrails.dispatch_dependency_violations == 0 and .guardrails.required_check_merge_preflight_mismatches == 0 and .path_budgets.aggregate_check_fetches == 2 and .path_budgets.cycle_scoped_aggregate_check_fetches == 2 and .path_budgets.unique_cycle_scoped_actionable_heads == 2 and (._meta.missing_fields | length) == 0" "$complete_output"
     schema=$(jq -r .schema "$complete_output")
-    assert_eq "sidecar schema is versioned" "aidevops-github-api-efficiency-evidence/v2" "$schema"
+    assert_eq "sidecar schema is versioned" "aidevops-github-api-efficiency-evidence/v3" "$schema"
     repository_set=$(jq -r .population.repository_set_sha256 "$complete_output")
     assert_eq "repository population stays digest-only" "$(printf "a%.0s" {1..64})" "$repository_set"
     expected_digest=$(file_sha256 "$complete_report")
@@ -319,6 +349,11 @@ main() {
     assert_eq "sidecar binds exact transport bytes" "$expected_digest" "$actual_digest"
     mode=$(file_mode "$complete_output")
     assert_eq "sidecar output is private" "600" "$mode"
+
+    local empty_output="${TEST_ROOT}/empty-distributions-evidence.json"
+    run_build "${TEST_ROOT}/empty-distributions-report.json" "$empty_output"
+    assert_eq "observed empty distributions exit zero" "0" "$LAST_EXIT"
+    assert_jq "observed empty distributions remain complete" '.complete == true and .population.unchanged_cycles == 4 and .population.actionable_changes == 0 and .latency.completed_action_samples == 0 and .latency.completed_action_p95_ms == null and .webhook.invalidations == 0 and .webhook.lag_samples == 0 and .webhook.lag_p50_ms == null and .webhook.lag_p95_ms == null and (._meta.missing_fields | length) == 0' "$empty_output"
 
     test_contract_migration_evidence
 
@@ -334,12 +369,12 @@ main() {
     run_build "${TEST_ROOT}/incomplete-report.json" "$incomplete_output"
     assert_eq "partial coverage exits zero" "0" "$LAST_EXIT"
     assert_contains "partial coverage reports incomplete" "evidence sidecar: incomplete" "$LAST_OUTPUT"
-    assert_jq "unsupported group stays null" ".complete == false and .webhook.invalidations == null and .webhook.lag_p50_ms == null and ._meta.coverage_groups.webhook == false and (._meta.missing_fields | length) == 5" "$incomplete_output"
+    assert_jq "unsupported group stays null" ".complete == false and .webhook.invalidations == null and .webhook.lag_samples == null and .webhook.lag_p50_ms == null and ._meta.coverage_groups.webhook == false and (._meta.missing_fields | length) == 6" "$incomplete_output"
 
     local unknown_latency_output="${TEST_ROOT}/unknown-latency-evidence.json"
     run_build "${TEST_ROOT}/unknown-latency-report.json" "$unknown_latency_output"
     assert_eq "unknown latency evidence exits zero" "0" "$LAST_EXIT"
-    assert_jq "unknown latency invalidates only latency coverage" ".complete == false and .latency.p50_ms == null and .latency.p95_ms == null and .latency.peak_attempts_per_minute == null and .latency.completed_action_p95_ms == null and ._meta.coverage_groups.latency == false and (._meta.missing_fields | length) == 4" "$unknown_latency_output"
+    assert_jq "unknown latency invalidates only latency coverage" ".complete == false and .latency.p50_ms == null and .latency.p95_ms == null and .latency.peak_attempts_per_minute == null and .latency.completed_action_samples == null and .latency.completed_action_p95_ms == null and ._meta.coverage_groups.latency == false and (._meta.missing_fields | length) == 5" "$unknown_latency_output"
 
     test_hash_failure_evidence
 
@@ -387,13 +422,8 @@ main() {
     assert_contains "symlink input explains rejection" "regular, non-symlink file" "$LAST_OUTPUT"
     assert_missing "symlink input writes no sidecar" "$linked_output"
 
-    printf "\nTests run: %d\n" "$TESTS_RUN"
-    if [[ "$TESTS_FAILED" -gt 0 ]]; then
-        printf "Tests failed: %d\n" "$TESTS_FAILED"
-        return 1
-    fi
-    printf "All tests passed\n"
-    return 0
+    finish_test_run
+    return $?
 }
 
 main "$@"

--- a/.agents/scripts/tests/test-issue-sync-completion-evidence.sh
+++ b/.agents/scripts/tests/test-issue-sync-completion-evidence.sh
@@ -40,26 +40,49 @@ gh_find_merged_pr() {
 	return 0
 }
 gh() {
-	if [[ "$*" == *"issues/125/comments"* ]]; then
+	local args="$*"
+	if [[ "$args" == *"issues/125/comments"* ]]; then
 		printf '%s\n' '{"message":"Not Found","documentation_url":"https://docs.github.com/rest","status":"404"}'
 		return 1
 	fi
-	if [[ "$*" == *"issues/126/comments"* ]]; then
+	if [[ "$args" == *"issues/126/comments"* ]]; then
 		printf '%s\n' 'not-a-timestamp'
 		return 0
 	fi
-	if [[ "$*" == *"issue view 123"* ]]; then
-		printf '%s\n' '{"state":"CLOSED","stateReason":"COMPLETED","closedAt":"2026-06-30T01:53:39Z","body":"Completed interactively.\n<!-- aidevops:sig -->","comments":[]}'
+	if [[ "$args" == *"api repos/owner/repo/issues/123"* && "$args" != *"/comments"* ]]; then
+		[[ "${AIDEVOPS_GH_ROUTE_DECISION:-}" == "issue-sync-completion-issue-rest" ]] || return 1
+		printf '%s\n' '{"state":"closed","state_reason":"completed","closed_at":"2026-06-30T01:53:39Z","body":"Completed interactively.\n<!-- aidevops:sig -->"}'
 		return 0
 	fi
-	if [[ "$*" == *"issue view 124"* ]]; then
-		printf '%s\n' '{"state":"CLOSED","stateReason":"COMPLETED","closedAt":"2026-06-30T01:53:39Z","body":"Closed without aidevops evidence.","comments":[]}'
+	if [[ "$args" == *"api repos/owner/repo/issues/124"* && "$args" != *"/comments"* ]]; then
+		[[ "${AIDEVOPS_GH_ROUTE_DECISION:-}" == "issue-sync-completion-issue-rest" ]] || return 1
+		printf '%s\n' '{"state":"closed","state_reason":"completed","closed_at":"2026-06-30T01:53:39Z","body":"Closed without aidevops evidence."}'
 		return 0
 	fi
-	if [[ "$*" == *"issue view 127"* ]]; then
-		printf '%s\n' '{"state":"CLOSED","stateReason":"COMPLETED","closedAt":"not-a-timestamp","body":"<!-- aidevops:sig -->","comments":[]}'
+	if [[ "$args" == *"api repos/owner/repo/issues/127"* && "$args" != *"/comments"* ]]; then
+		[[ "${AIDEVOPS_GH_ROUTE_DECISION:-}" == "issue-sync-completion-issue-rest" ]] || return 1
+		printf '%s\n' '{"state":"closed","state_reason":"completed","closed_at":"not-a-timestamp","body":"<!-- aidevops:sig -->"}'
 		return 0
 	fi
+	if [[ "$args" == *"api repos/owner/repo/issues/128"* && "$args" != *"/comments"* ]]; then
+		[[ "${AIDEVOPS_GH_ROUTE_DECISION:-}" == "issue-sync-completion-issue-rest" ]] || return 1
+		printf '%s\n' '{"state":"closed","state_reason":"completed","closed_at":"2026-07-01T02:03:04Z","body":"Completion evidence is in a later comment page."}'
+		return 0
+	fi
+	case "$args" in
+	*"api --paginate --slurp repos/owner/repo/issues/123/comments?per_page=100"* | \
+		*"api --paginate --slurp repos/owner/repo/issues/124/comments?per_page=100"* | \
+		*"api --paginate --slurp repos/owner/repo/issues/127/comments?per_page=100"*)
+		[[ "${AIDEVOPS_GH_ROUTE_DECISION:-}" == "issue-sync-completion-comments-rest" ]] || return 1
+		printf '%s\n' '[[]]'
+		return 0
+		;;
+	*"api --paginate --slurp repos/owner/repo/issues/128/comments?per_page=100"*)
+		[[ "${AIDEVOPS_GH_ROUTE_DECISION:-}" == "issue-sync-completion-comments-rest" ]] || return 1
+		printf '%s\n' '[[],[{"body":"Completed via PR #999"}]]'
+		return 0
+		;;
+	esac
 	return 1
 }
 export -f print_warning print_info print_error print_success log_verbose gh_find_merged_pr gh
@@ -171,6 +194,16 @@ if _closed_issue_aidevops_complete_date "owner/repo" "124" >/dev/null; then
 	fail "closed issue without aidevops evidence is not completion evidence"
 else
 	pass "closed issue without aidevops evidence is not completion evidence"
+fi
+
+if completed_date=$(_closed_issue_aidevops_complete_date "owner/repo" "128"); then
+	if [[ "$completed_date" == "2026-07-01" ]]; then
+		pass "paginated REST comments provide later-page completion evidence"
+	else
+		fail "paginated REST completion evidence returned wrong completion date"
+	fi
+else
+	fail "later-page REST comment should provide completion evidence"
 fi
 
 if completed_date=$(_closed_issue_worker_complete_date "owner/repo" "125"); then

--- a/.agents/scripts/tests/test-managed-label-provisioning.sh
+++ b/.agents/scripts/tests/test-managed-label-provisioning.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for existence-aware origin:* and solved:* provisioning.
+
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)"
+TEST_ROOT=$(mktemp -d -t managed-labels.XXXXXX)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+CALL_LOG="${TEST_ROOT}/calls.log"
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	local description="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS: %s\n' "$description"
+	return 0
+}
+
+fail() {
+	local description="$1"
+	local detail="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL: %s — %s\n' "$description" "$detail" >&2
+	return 0
+}
+
+assert_count() {
+	local description="$1"
+	local expected="$2"
+	local pattern="$3"
+	local actual=0
+	actual=$(grep -c -- "$pattern" "$CALL_LOG" 2>/dev/null || true)
+	if [[ "$actual" -eq "$expected" ]]; then
+		pass "$description"
+	else
+		fail "$description" "expected ${expected}, got ${actual}: ${pattern}"
+	fi
+	return 0
+}
+
+# shellcheck source=/dev/null
+source "${SCRIPTS_DIR}/shared-gh-wrappers.sh"
+
+TEST_LABEL_SNAPSHOT=""
+TEST_INVENTORY_RC=0
+_gh_with_timeout() {
+	local op_class="$1"
+	shift
+	printf '%s route=%s %s\n' "$op_class" "${AIDEVOPS_GH_ROUTE_DECISION:-unset}" "$*" >>"$CALL_LOG"
+	if [[ "${1:-}" == "gh" && "${2:-}" == "api" ]]; then
+		[[ "$TEST_INVENTORY_RC" -eq 0 ]] || return "$TEST_INVENTORY_RC"
+		printf '%s\n' "$TEST_LABEL_SNAPSHOT"
+	fi
+	return 0
+}
+
+# A converged repository performs inventory reads but no duplicate writes.
+: >"$CALL_LOG"
+_ORIGIN_LABELS_ENSURED=""
+_SOLVED_LABELS_ENSURED=""
+TEST_INVENTORY_RC=0
+TEST_LABEL_SNAPSHOT=$'origin:worker\norigin:interactive\norigin:worker-takeover\nsolved:worker\nsolved:interactive'
+_ensure_origin_labels_for_args --repo owner/repo
+ensure_solved_labels_exist owner/repo
+assert_count "converged labels use attributed REST inventory" 2 \
+	'read route=managed-label-inventory-rest gh api /repos/owner/repo/labels?per_page=100 --paginate'
+assert_count "converged labels perform zero creates" 0 'write route=managed-label-create-rest gh label create'
+
+# Only labels absent from the snapshot are created.
+: >"$CALL_LOG"
+_ORIGIN_LABELS_ENSURED=""
+_SOLVED_LABELS_ENSURED=""
+TEST_LABEL_SNAPSHOT=$'origin:worker\norigin:interactive\nsolved:worker'
+_ensure_origin_labels_for_args --repo owner/repo
+ensure_solved_labels_exist owner/repo
+assert_count "missing origin label is created once" 1 'gh label create origin:worker-takeover '
+assert_count "missing solved label is created once" 1 'gh label create solved:interactive '
+assert_count "present origin labels are not recreated" 0 'gh label create origin:worker --repo'
+assert_count "present solved labels are not recreated" 0 'gh label create solved:worker --repo'
+
+# Failed inventory is fail-closed: do not fan out speculative writes or cache.
+: >"$CALL_LOG"
+_ORIGIN_LABELS_ENSURED=""
+_SOLVED_LABELS_ENSURED=""
+TEST_INVENTORY_RC=1
+if ensure_origin_labels_exist owner/repo; then
+	fail "origin inventory failure propagates" "expected non-zero status"
+else
+	pass "origin inventory failure propagates"
+fi
+if ensure_solved_labels_exist owner/repo; then
+	fail "solved inventory failure propagates" "expected non-zero status"
+else
+	pass "solved inventory failure propagates"
+fi
+assert_count "failed inventory performs zero creates" 0 'write route=managed-label-create-rest gh label create'
+
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf 'PASS: test-managed-label-provisioning — %d assertions\n' "$TESTS_RUN"
+	exit 0
+fi
+
+printf 'FAIL: test-managed-label-provisioning — %d/%d failed\n' "$TESTS_FAILED" "$TESTS_RUN" >&2
+exit 1

--- a/.agents/scripts/tests/test-orphan-recovery-pr-base.sh
+++ b/.agents/scripts/tests/test-orphan-recovery-pr-base.sh
@@ -103,6 +103,17 @@ install_test_overrides() {
 		return 0
 	}
 
+	# _attempt_orphan_recovery_pr consumes the richer handoff-state provider
+	# directly. Keep this base-selection test independent of live PR discovery.
+	_pr_handoff_state_for_branch_or_issue() {
+		local branch_name="$1"
+		local issue_number="$2"
+		local repo_slug="$3"
+		[[ -n "$branch_name" && -n "$issue_number" && -n "$repo_slug" ]] || return 1
+		printf 'absent|'
+		return 0
+	}
+
 	_ensure_orphan_recovery_branch_remote() {
 		local work_dir="$1"
 		local branch_name="$2"

--- a/.agents/scripts/tests/test-post-merge-review-scanner.sh
+++ b/.agents/scripts/tests/test-post-merge-review-scanner.sh
@@ -129,7 +129,7 @@ api)
 		if [[ -n "${FIX_GRAPHQL:-}" && -f "$FIX_GRAPHQL" ]]; then
 			cat "$FIX_GRAPHQL"
 		else
-			echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}'
+			echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false}}}},"rateLimit":{"cost":1}}}'
 		fi
 		;;
 	*pulls*/reviews*)
@@ -285,7 +285,7 @@ write_graphql_fixture() {
 	done
 	threads_json+="]"
 	jq -n --argjson nodes "$threads_json" \
-		'{data: {repository: {pullRequest: {reviewThreads: {nodes: $nodes}}}}}' \
+		'{data: {repository: {pullRequest: {reviewThreads: {nodes: $nodes, pageInfo: {hasNextPage: false}}}}, rateLimit: {cost: 1}}}' \
 		>"$out"
 	return 0
 }
@@ -561,7 +561,7 @@ sub="${2:-}"
 case "$cmd" in
 api)
 	case "$sub" in
-	graphql) [[ -f "${FIX_GRAPHQL:-/dev/null}" ]] && cat "$FIX_GRAPHQL" || echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}' ;;
+	graphql) [[ -f "${FIX_GRAPHQL:-/dev/null}" ]] && cat "$FIX_GRAPHQL" || echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false}}}},"rateLimit":{"cost":1}}}' ;;
 	*pulls*/reviews*) [[ -f "${FIX_REVIEWS:-/dev/null}" ]] && cat "$FIX_REVIEWS" || echo '[]' ;;
 	*pulls*/comments*) [[ -f "${FIX_COMMENTS:-/dev/null}" ]] && cat "$FIX_COMMENTS" || echo '[]' ;;
 	*) echo '{}' ;;
@@ -605,6 +605,22 @@ assert_rc "refresh propagates issue list failure" "2" "$rc"
 assert_contains "refresh logs issue list failure" "do_refresh: gh issue list failed (rc=1)" "$out"
 assert_not_contains "refresh does not treat issue list failure as empty" "No open review-followup issues found" "$out"
 install_ok_gh
+
+echo ""
+echo "Test: fetch_review_threads_json — missing response cost returns exit 2"
+printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false}}}}}}' >"$FIX_GRAPHQL"
+rc=0
+out=$(fetch_review_threads_json "stub/repo" "42" 2>&1) || rc=$?
+assert_rc "fetch_review_threads_json rejects missing response cost" "2" "$rc"
+assert_contains "missing response cost is reported as malformed" "malformed response" "$out"
+
+echo ""
+echo "Test: fetch_review_threads_json — partial thread page returns exit 2"
+printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":true}}}},"rateLimit":{"cost":1}}}' >"$FIX_GRAPHQL"
+rc=0
+out=$(fetch_review_threads_json "stub/repo" "42" 2>&1) || rc=$?
+assert_rc "fetch_review_threads_json rejects partial thread page" "2" "$rc"
+assert_contains "partial thread page is reported as malformed" "malformed response" "$out"
 
 echo ""
 echo "Test: fetch_review_threads_json — gh failure returns exit 2"

--- a/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
+++ b/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
@@ -111,21 +111,38 @@ setup_test_env() {
 	: >"$GH_LOG"
 	export TEST_ROOT GH_LOG
 
-	# Mock gh: only handles the two `gh pr view` shapes used by this gate
-	# and its delegates. Any other call exits 0 silently.
+	# Mock gh: handles the response-metered GraphQL metadata read plus the two
+	# remaining `gh pr view` shapes used by delegates. Other calls exit 0.
 	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
 #!/usr/bin/env bash
 printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
 
-# gh pr view N --repo R --json author,labels,isCrossRepository,headRefOid
-if [[ "$*" == *"--json author,labels,isCrossRepository,headRefOid"* ]]; then
+# Response-metered final-authority metadata read.
+if [[ "${1:-}" == "api" && "${2:-}" == "graphql" ]]; then
 	if [[ -f "${TEST_ROOT}/pr-meta-fail" ]]; then
 		exit 1
 	fi
 	if [[ -f "${TEST_ROOT}/pr-meta-empty" ]]; then
 		exit 0
 	fi
-	cat "${TEST_ROOT}/labels.json"
+	has_next_page=false
+	[[ -f "${TEST_ROOT}/pr-meta-partial-labels" ]] && has_next_page=true
+	response=$(jq -c --argjson has_next_page "$has_next_page" '
+		{data: {
+			repository: {pullRequest: {
+				author: .author,
+				labels: {nodes: .labels, pageInfo: {hasNextPage: $has_next_page}},
+				isCrossRepository: .isCrossRepository,
+				headRefOid: .headRefOid
+			}},
+			rateLimit: {cost: 1}
+		}}
+	' "${TEST_ROOT}/labels.json") || exit 1
+	if [[ -f "${TEST_ROOT}/pr-meta-missing-cost" ]]; then
+		printf '%s' "$response" | jq -c 'del(.data.rateLimit)'
+	else
+		printf '%s\n' "$response"
+	fi
 	exit 0
 fi
 
@@ -196,6 +213,7 @@ define_helpers_under_test() {
 		/^_extract_linked_issue\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
 	gates_src=$(awk '
+		/^_pulse_merge_admin_pr_json_graphql\(\) \{/,/^}$/ { print }
 		/^_external_pr_has_linked_issue\(\) \{/,/^}$/ { print }
 		/^_external_pr_linked_issue_crypto_approved\(\) \{/,/^}$/ { print }
 		/^_external_pr_current_head_crypto_approved\(\) \{/,/^}$/ { print }
@@ -297,7 +315,7 @@ test_case_m_pr_metadata_command_failure_is_logged() {
 	local result=0
 	_pulse_merge_admin_safety_check "940" "owner/repo" "head-current" || result=$?
 	rm -f "${TEST_ROOT}/pr-meta-fail"
-	if [[ "$result" -eq 1 ]] && grep -qF "gh pr view failed for PR #940 in owner/repo — failing closed" "$LOGFILE"; then
+	if [[ "$result" -eq 1 ]] && grep -qF "exact GraphQL metadata read failed for PR #940 in owner/repo — failing closed" "$LOGFILE"; then
 		print_result "Case M: PR metadata command failure is logged" 0
 		return 0
 	fi
@@ -311,7 +329,7 @@ test_case_n_empty_pr_metadata_is_logged() {
 	local result=0
 	_pulse_merge_admin_safety_check "941" "owner/repo" "head-current" || result=$?
 	rm -f "${TEST_ROOT}/pr-meta-empty"
-	if [[ "$result" -eq 1 ]] && grep -qF "gh pr view returned empty metadata for PR #941 in owner/repo — failing closed" "$LOGFILE"; then
+	if [[ "$result" -eq 1 ]] && grep -qF "exact GraphQL metadata read failed for PR #941 in owner/repo — failing closed" "$LOGFILE"; then
 		print_result "Case N: empty PR metadata is logged" 0
 		return 0
 	fi
@@ -324,7 +342,7 @@ test_case_o_malformed_pr_metadata_is_logged() {
 	printf '%s' '{not-json' >"${TEST_ROOT}/labels.json"
 	local result=0
 	_pulse_merge_admin_safety_check "942" "owner/repo" "head-current" || result=$?
-	if [[ "$result" -eq 1 ]] && grep -qF "gh pr view returned malformed metadata for PR #942 in owner/repo — failing closed" "$LOGFILE"; then
+	if [[ "$result" -eq 1 ]] && grep -qF "exact GraphQL metadata read failed for PR #942 in owner/repo — failing closed" "$LOGFILE"; then
 		print_result "Case O: malformed PR metadata is logged" 0
 		return 0
 	fi
@@ -337,7 +355,7 @@ test_case_p_missing_pr_identity_is_logged() {
 	printf '%s' '{"author":null,"labels":[],"isCrossRepository":false,"headRefOid":""}' >"${TEST_ROOT}/labels.json"
 	local result=0
 	_pulse_merge_admin_safety_check "943" "owner/repo" "head-current" || result=$?
-	if [[ "$result" -eq 1 ]] && grep -qF "missing head SHA or author for PR #943 in owner/repo — failing closed" "$LOGFILE"; then
+	if [[ "$result" -eq 1 ]] && grep -qF "exact GraphQL metadata read failed for PR #943 in owner/repo — failing closed" "$LOGFILE"; then
 		print_result "Case P: missing PR identity is logged" 0
 		return 0
 	fi
@@ -359,6 +377,36 @@ test_case_q_linked_issue_extraction_failure_is_logged() {
 		return 0
 	fi
 	print_result "Case Q: linked issue extraction failure is logged" 1 "rc=${result}; log=$(cat "$LOGFILE")"
+	return 0
+}
+
+test_case_r_missing_response_cost_fails_closed() {
+	: >"$LOGFILE"
+	set_fixture '[{"name":"bug"}]' 'false' '## Summary\n\nResolves #945' 'VERIFIED'
+	touch "${TEST_ROOT}/pr-meta-missing-cost"
+	local result=0
+	_pulse_merge_admin_safety_check "945" "owner/repo" "head-current" || result=$?
+	rm -f "${TEST_ROOT}/pr-meta-missing-cost"
+	if [[ "$result" -eq 1 ]] && grep -qF "exact GraphQL metadata read failed for PR #945 in owner/repo — failing closed" "$LOGFILE"; then
+		print_result "Case R: missing response cost fails closed" 0
+		return 0
+	fi
+	print_result "Case R: missing response cost fails closed" 1 "rc=${result}; log=$(cat "$LOGFILE")"
+	return 0
+}
+
+test_case_s_partial_label_connection_fails_closed() {
+	: >"$LOGFILE"
+	set_fixture '[{"name":"bug"}]' 'false' '## Summary\n\nResolves #946' 'VERIFIED'
+	touch "${TEST_ROOT}/pr-meta-partial-labels"
+	local result=0
+	_pulse_merge_admin_safety_check "946" "owner/repo" "head-current" || result=$?
+	rm -f "${TEST_ROOT}/pr-meta-partial-labels"
+	if [[ "$result" -eq 1 ]] && grep -qF "exact GraphQL metadata read failed for PR #946 in owner/repo — failing closed" "$LOGFILE"; then
+		print_result "Case S: partial label connection fails closed" 0
+		return 0
+	fi
+	print_result "Case S: partial label connection fails closed" 1 "rc=${result}; log=$(cat "$LOGFILE")"
 	return 0
 }
 
@@ -629,6 +677,8 @@ main() {
 	test_case_o_malformed_pr_metadata_is_logged
 	test_case_p_missing_pr_identity_is_logged
 	test_case_q_linked_issue_extraction_failure_is_logged
+	test_case_r_missing_response_cost_fails_closed
+	test_case_s_partial_label_connection_fails_closed
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -310,6 +310,11 @@ if [[ "${1:-}" == "api" ]]; then
 			break
 		fi
 	done
+	if [[ "$*" == *"/pulls/"*"/files"* ]]; then
+		[[ "${AIDEVOPS_GH_ROUTE_DECISION:-}" == "pulse-pr-files-rest" ]] || exit 1
+		printf '%s\n' '.agents/scripts/pulse-merge.sh'
+		exit 0
+	fi
 	if [[ "$*" == *"/pulls/"*"/reviews"* ]]; then
 		if [[ -n "$_jq_filter" ]]; then
 			jq "$_jq_filter" <"${TEST_ROOT}/reviews.json"

--- a/.agents/scripts/tests/test-pulse-residual-rest-reads.sh
+++ b/.agents/scripts/tests/test-pulse-residual-rest-reads.sh
@@ -9,6 +9,9 @@ TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 ANCILLARY_SCRIPT="${TEST_SCRIPT_DIR}/../pulse-ancillary-dispatch.sh"
 ANCILLARY_REVIEW_SCRIPT="${TEST_SCRIPT_DIR}/../pulse-ancillary-dispatch-review.sh"
 DIRTY_SWEEP_SCRIPT="${TEST_SCRIPT_DIR}/../pulse-dirty-pr-sweep.sh"
+CONFLICT_SCRIPT="${TEST_SCRIPT_DIR}/../pulse-merge-conflict.sh"
+FEEDBACK_SCRIPT="${TEST_SCRIPT_DIR}/../pulse-merge-feedback.sh"
+VERIFY_CLOSE_SCRIPT="${TEST_SCRIPT_DIR}/../verify-issue-close-helper.sh"
 
 TEST_ROOT=""
 ORIGINAL_HOME="${HOME}"
@@ -160,6 +163,12 @@ main() {
 		print_result "dirty-PR sweep avoids native GraphQL comment views" 1
 	else
 		print_result "dirty-PR sweep avoids native GraphQL comment views" 0
+	fi
+	if grep -Eq '^[[:space:]]*[^#[:space:]].*gh pr view.*--json files' \
+		"$CONFLICT_SCRIPT" "$FEEDBACK_SCRIPT" "$VERIFY_CLOSE_SCRIPT"; then
+		print_result "conflict and close evidence avoids native GraphQL PR-file views" 1
+	else
+		print_result "conflict and close evidence avoids native GraphQL PR-file views" 0
 	fi
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-remote-branch-cleanup-helper.sh
+++ b/.agents/scripts/tests/test-remote-branch-cleanup-helper.sh
@@ -109,21 +109,24 @@ install_gh_stub() {
 	cat >"${bin_dir}/gh" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
-state=""
-while [[ $# -gt 0 ]]; do
-	case "${1:-}" in
-	--state)
-		state="${2:-}"
-		shift 2
-		;;
-	*)
-		shift
-		;;
-	esac
-done
-if [[ "$state" == "open" ]]; then
-	printf '%s\n' "open-pr"
-fi
+printf '%s|%s\n' "${AIDEVOPS_GH_ROUTE_DECISION:-}" "$*" >>"${REMOTE_BRANCH_CLEANUP_GH_CALL_LOG:-/dev/null}"
+[[ "${1:-}" == "api" ]] || exit 1
+endpoint="${2:-}"
+case "$endpoint" in
+*"pulls?state=open&per_page=100&page=1"*)
+	if [[ "${REMOTE_BRANCH_CLEANUP_STUB_FULL_PAGE:-0}" == "1" ]]; then
+		jq -cn '[range(0; 100) | {head: {ref: ("open-pr-" + (. | tostring))}, merged_at: null}]'
+	else
+		printf '%s\n' '[{"head":{"ref":"open-pr"},"merged_at":null}]'
+	fi
+	;;
+*"pulls?state=open&per_page=100&page=2"*)
+	printf '%s\n' '[{"head":{"ref":"open-pr"},"merged_at":null}]'
+	;;
+*"pulls?state=closed&per_page=100&page=1"*) printf '%s\n' '[]' ;;
+*) exit 1 ;;
+esac
+exit 0
 STUB
 	chmod +x "${bin_dir}/gh"
 	return 0
@@ -158,10 +161,15 @@ setup_repo() {
 
 run_dry_run_assertions() {
 	local repo="$1"
-	local output
+	local output gh_calls
 	local gh_bin="$TEST_ROOT/bin"
+	local gh_call_log="$TEST_ROOT/gh-calls.log"
 	install_gh_stub "$gh_bin"
-	output=$(PATH="$gh_bin:$PATH" bash "$HELPER" --repo "$repo" --skip-fetch)
+	: >"$gh_call_log"
+	output=$(REMOTE_BRANCH_CLEANUP_GH_CALL_LOG="$gh_call_log" \
+		REMOTE_BRANCH_CLEANUP_STUB_FULL_PAGE=1 \
+		PATH="$gh_bin:$PATH" bash "$HELPER" --repo "$repo" --skip-fetch)
+	gh_calls=$(<"$gh_call_log")
 
 	assert_contains "$output" "would-del  merged-safe" "merged branch is a deletion candidate"
 	assert_contains "$output" "review     unmerged" "unmerged branch is manual-review only"
@@ -170,6 +178,17 @@ run_dry_run_assertions() {
 	assert_contains "$output" "skip       active-worktree" "active worktree branch is skipped"
 	assert_contains "$output" "protected/default branch" "default branch is protected"
 	assert_contains "$output" "Dry-run only" "default mode is dry-run"
+	assert_contains "$gh_calls" "remote-branch-cleanup-pr-branches-rest|api repos/" "PR branch evidence uses attributed REST reads"
+	assert_contains "$gh_calls" "pulls?state=open&per_page=100&page=1" "open PR branches use the first bounded REST page"
+	assert_contains "$gh_calls" "pulls?state=open&per_page=100&page=2" "a full first page reads the second bounded REST page"
+	if [[ "$gh_calls" == *"page=3"* || "$gh_calls" == *"--paginate"* ]]; then
+		fail "remote branch cleanup must not exceed its two-page REST bound"
+	fi
+	pass "remote branch cleanup caps REST history reads at two pages"
+	if [[ "$gh_calls" == *"pr list"* ]]; then
+		fail "remote branch cleanup must not use native gh pr list"
+	fi
+	pass "remote branch cleanup avoids native gh pr list"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-verify-issue-close-helper-pr-files.sh
+++ b/.agents/scripts/tests/test-verify-issue-close-helper-pr-files.sh
@@ -4,9 +4,9 @@
 #
 # Regression tests for verify-issue-close-helper.sh file overlap verification.
 #
-# GH#22138: `gh pr view --json files` may return `{"files":null}` for merged
-# PRs even though the pull files REST endpoint still returns the changed files.
-# The helper must treat that as a fallback condition, not a parse failure.
+# GH#22138: merged PR changed files remain available through the pull-files REST
+# endpoint. Exact-attribution close verification uses that endpoint directly
+# rather than attempting a native GraphQL files projection first.
 
 set -euo pipefail
 
@@ -52,40 +52,22 @@ if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
 	exit 0
 fi
 
-if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
-	case "${3:-}" in
-	100)
-		printf '{"files":null}\n'
-		;;
-	101)
-		printf '{"files":[{"path":".agents/scripts/verify-issue-close-helper.sh"}]}\n'
-		;;
-	102)
-		printf '{"files":[{"path":"setup.sh"},{"path":".agents/scripts/tests/test-setup-stage-timing-observability.sh"}]}\n'
-		;;
-	103)
-		printf '{"files":[{"path":"unrelated/config.sh"}]}\n'
-		;;
-	104)
-		printf '{"files":[{"path":".agents/scripts/gh"}]}\n'
-		;;
-	105)
-		printf '{"files":[{"path":"unrelated/gh"}]}\n'
-		;;
-	106)
-		printf '{"files":[{"path":"unrelated/gh"}]}\n'
-		;;
-	*)
-		printf '{"files":[]}\n'
-		;;
-	esac
-	exit 0
-fi
-
 if [[ "${1:-}" == "api" ]]; then
 	case "${3:-}" in
-	repos/owner/repo/pulls/100/files)
+	repos/owner/repo/pulls/100/files?per_page=100 | repos/owner/repo/pulls/101/files?per_page=100)
 		printf '.agents/scripts/verify-issue-close-helper.sh\n'
+		;;
+	repos/owner/repo/pulls/102/files?per_page=100)
+		printf 'setup.sh\n.agents/scripts/tests/test-setup-stage-timing-observability.sh\n'
+		;;
+	repos/owner/repo/pulls/103/files?per_page=100)
+		printf 'unrelated/config.sh\n'
+		;;
+	repos/owner/repo/pulls/104/files?per_page=100)
+		printf '.agents/scripts/gh\n'
+		;;
+	repos/owner/repo/pulls/105/files?per_page=100 | repos/owner/repo/pulls/106/files?per_page=100)
+		printf 'unrelated/gh\n'
 		;;
 	*)
 		exit 1
@@ -140,8 +122,8 @@ assert_check_rejects() {
 	return 0
 }
 
-assert_check_passes "merged PR files null falls back to REST pull files endpoint" 100
-assert_check_passes "standard gh pr view files array still parses" 101
+assert_check_passes "merged PR files come from the REST pull files endpoint" 100
+assert_check_passes "standard PR files come from the REST pull files endpoint" 101
 assert_check_passes "independent general target survives a supporting specific path" 102 201
 assert_check_rejects "specific target cannot be satisfied by an unrelated same-basename file" 202 103
 assert_check_passes "extensionless repository path matches the exact PR file" 104 203

--- a/.agents/scripts/tests/test-worker-output-classification-head-vs-search.sh
+++ b/.agents/scripts/tests/test-worker-output-classification-head-vs-search.sh
@@ -122,10 +122,14 @@ case "${1:-}" in
 	pr)
 		case "${2:-}" in
 			list)
+				if [[ "${AIDEVOPS_GH_REST_FIRST_READS:-0}" != "1" ]]; then
+					printf 'lifecycle PR probe did not request REST-first routing\n' >&2
+					exit 1
+				fi
 				if [[ "$mode" == "head" && "${STUB_HEAD_FAIL:-0}" == "1" ]]; then
 					exit 1
 				fi
-				if [[ "$json_fields" == "number,state,isDraft,mergedAt,headRefOid,labels,statusCheckRollup" ]]; then
+				if [[ "$json_fields" == "number,state,isDraft,mergedAt,headRefOid,labels" ]]; then
 					if [[ "$mode" == "head" ]]; then
 						printf '%s\n' "${STUB_HEAD_JSON:-[]}"
 					else

--- a/.agents/scripts/verify-issue-close-helper.sh
+++ b/.agents/scripts/verify-issue-close-helper.sh
@@ -116,28 +116,14 @@ get_pr_changed_files() {
 	local pr_number="$1"
 	local repo_slug="$2"
 
-	local files_json
-	files_json=$(gh pr view "$pr_number" --repo "$repo_slug" --json files 2>/dev/null) || {
-		log_error "Failed to fetch PR #${pr_number} files from ${repo_slug}"
-		return 1
-	}
-
 	local pr_files
-	pr_files=$(printf '%s' "$files_json" | jq -r '(.files // [])[]? | .path // .filename // empty' 2>/dev/null) || {
-		log_warn "Failed to parse PR #${pr_number} file list from gh pr view; trying REST fallback"
-		pr_files=""
-	}
-
-	if [[ -n "$pr_files" ]]; then
-		printf '%s\n' "$pr_files"
-		return 0
-	fi
-
-	# `gh pr view --json files` can return `null` for merged PRs on some gh/API
-	# paths. The pull files REST endpoint remains available after merge, so use
-	# it as the authoritative fallback before declaring the PR unparseable.
-	pr_files=$(gh api --paginate "repos/${repo_slug}/pulls/${pr_number}/files" --jq '.[].filename' 2>/dev/null) || {
-		log_error "Failed to fetch PR #${pr_number} file list via REST fallback"
+	# Pull-file pages remain available after merge and expose operation-owned
+	# REST accounting. Use them authoritatively instead of first attempting the
+	# native GraphQL `files` projection, which cannot report its exact cost.
+	pr_files=$(AIDEVOPS_GH_ROUTE_DECISION="verify-close-pr-files-rest" \
+		gh api --paginate "repos/${repo_slug}/pulls/${pr_number}/files?per_page=100" \
+			--jq '.[].filename' 2>/dev/null) || {
+		log_error "Failed to fetch PR #${pr_number} file list via REST"
 		return 1
 	}
 


### PR DESCRIPTION
## Summary

- Distinguish observed-empty latency distributions from unknown evidence with versioned sidecar sample counts.
- Replace recurring unattributable GitHub reads with response-metered GraphQL or exact REST routes that fail closed on partial evidence.
- Avoid duplicate managed-label writes and stop optional Dependabot fanout before or during core quota exhaustion.
- Preserve bounded cleanup scans and add regressions for incomplete pagination, missing response cost, and partial nested connections.

## Verification

- `.agents/scripts/linters-local.sh --changed`
- Evidence builder: 42 tests passed
- Benchmark comparator: 46 tests passed
- Dispatch dedup: 35 tests passed
- Post-merge scanner: 83 tests passed
- Dirty PR sweep: 23 tests passed
- Pulse feedback dispatch: 30 tests passed
- Full-loop CodeRabbit reconciliation: 14 tests passed
- Managed-label provisioning: 9 assertions passed
- Focused Dependabot, issue-sync, merge-authority, REST-route, close-verification, and remote-cleanup suites passed
- ShellCheck and Python byte-compilation passed
- Closeout bundle: `99e3487e750e1b8494a1bd9d1c401442571f7bdda17bf1a0673ae59a4010dbd5`

## Runtime Testing

- `runtime-verified`: exercised the modified shell/Python paths through temporary repositories, API fixtures, pagination boundaries, quota failures, and malformed/partial response cases.
- The production exact-runtime smoke remains intentionally post-merge so it evaluates the merged immutable bundle rather than this branch worktree.

## Decisions

- Keep incomplete or one-sided evidence `INCONCLUSIVE`; never promote unknown data to zero.
- Preserve the prior 200-PR cleanup bound while replacing native GraphQL reads.
- Keep rollout defaults and compatibility flags unchanged until homogeneous 12-hour baseline/canary evidence returns comparator `PASS`.
- Publication is not requested; merge and local deployment must not create a release.

For #27777

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.220 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.5 spent 17d 22h and 63,256,169 tokens on this with the user in an interactive session.