### PR TITLE
GH#29457: Verify trusted NMR audit transitions

### DIFF
--- a/.agents/reference/gh-audit-log.md
+++ b/.agents/reference/gh-audit-log.md
@@ -252,9 +252,10 @@ The scanner:
 1. Reads entries since the last scan (tracked in `~/.aidevops/logs/gh-audit-scanner.state`)
 2. Filters entries with `suspicious[] | length > 0`, excluding only exact,
    fully comparable expected transitions: verified issue/PR approval removal of
-   `needs-maintainer-review`, and worker permission blocking that replaces active
-   lifecycle labels with `needs-maintainer-permissions` (the original audit entry
-   remains unchanged)
+   `needs-maintainer-review`, independently revalidated trusted-author NMR
+   normalization, and worker permission blocking that replaces active lifecycle
+   labels with `needs-maintainer-permissions` (the original audit entry remains
+   unchanged)
 3. Files a GitHub issue on `marcusquinn/aidevops` with a summary table when anomalies are found
 
 To run the scanner manually:

--- a/.agents/scripts/gh-audit-anomaly-filter.jq
+++ b/.agents/scripts/gh-audit-anomaly-filter.jq
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Fail-closed expected-transition filter for gh-audit-anomaly-helper.sh.
+
+def comparable_state:
+  ((.before.capture_status // "ok") == "ok")
+  and ((.after.capture_status // "ok") == "ok")
+  and ((.delta.comparable // true) == true);
+
+def framework_script($name):
+  (.caller_script // "") as $script
+  | ["/agents/scripts/", "/.agents/scripts/"]
+  | any(.[]; . as $prefix | $script | endswith($prefix + $name));
+
+def expected_approval_transition:
+  comparable_state
+  and (
+    (.op == $issue_edit and .caller_function == "_approval_apply_issue_lifecycle_updates")
+    or (.op == "pr_edit" and .caller_function == "_approval_apply_pr_lifecycle_updates")
+  )
+  and framework_script($approval_script)
+  and .flags.approval_verified == "v2-current-state"
+  and .suspicious == [("protected_label_removed:" + $nmr)]
+  and (.delta.labels_removed // []) == [$nmr]
+  and (((.delta.labels_added // []) - ["auto-dispatch"]) | length == 0)
+  and (.delta.title_delta_pct == 0)
+  and (.delta.body_delta_pct == 0)
+  and ((.before.labels // []) | index($nmr) != null)
+  and ((.after.labels // []) | index($nmr) == null);
+
+def expected_permission_block_transition:
+  comparable_state
+  and .op == $issue_edit
+  and .caller_function == "permission_apply_block"
+  and framework_script($permission_script)
+  and ((.after.labels // []) | index($permission) != null)
+  and (((.delta.labels_removed // []) | length) > 0)
+  and (((.delta.labels_removed // []) - [
+    "status:queued", "status:claimed", "status:in-progress", "status:in-review"
+  ]) | length == 0)
+  and (((.delta.labels_added // []) - [$permission]) | length == 0)
+  and (.delta.title_delta_pct == 0)
+  and (.delta.body_delta_pct == 0)
+  and ([.after.labels[]? | select(
+    . == "status:queued"
+    or . == "status:claimed"
+    or . == "status:in-progress"
+    or . == "status:in-review"
+  )] | length == 0)
+  and ((.suspicious // []) | length > 0)
+  and all(.suspicious[];
+    . == "protected_label_removed:status:claimed"
+    or . == "protected_label_removed:status:in-progress"
+    or . == "protected_label_removed:status:in-review");
+
+def expected_trusted_author_nmr_transition:
+  comparable_state
+  and .op == $issue_edit
+  and .caller_function == "_nmr_edit_issue_labels"
+  and framework_script($nmr_script)
+  and .flags.trusted_author_nmr_verified == "v1-current-state"
+  and .suspicious == [("protected_label_removed:" + $nmr)]
+  and (.delta.labels_removed // []) == [$nmr]
+  and ((.delta.labels_added // []) == []
+    or (.delta.labels_added // []) == ["auto-dispatch"]
+    or (.delta.labels_added // []) == ["hold-for-review"])
+  and (.delta.title_delta_pct == 0)
+  and (.delta.body_delta_pct == 0)
+  and ((.before.labels // []) | index($nmr) != null)
+  and ((.after.labels // []) | index($nmr) == null);
+
+select(try ((.suspicious | length) > 0) catch true)
+| select((try (
+  expected_approval_transition
+  or expected_permission_block_transition
+  or expected_trusted_author_nmr_transition
+) catch false) | not)

--- a/.agents/scripts/gh-audit-anomaly-helper.sh
+++ b/.agents/scripts/gh-audit-anomaly-helper.sh
@@ -201,56 +201,11 @@ _cmd_scan_collect_anomalies() {
 		# aidevops:trust-boundary — fail closed unless each expected transition has
 		# independently meaningful end-state evidence and no extra state change.
 		if ! tail -n +"$((skip_count + 1))" "$log_file" |
-			jq -c --arg nmr "$GH_ANOMALY_NMR_LABEL" --arg permission "$GH_ANOMALY_PERMISSION_LABEL" '
-				def comparable_state:
-					((.before.capture_status // "ok") == "ok")
-					and ((.after.capture_status // "ok") == "ok")
-					and ((.delta.comparable // true) == true);
-				def expected_approval_transition:
-					comparable_state
-					and (
-						(.op == "issue_edit" and .caller_function == "_approval_apply_issue_lifecycle_updates")
-						or (.op == "pr_edit" and .caller_function == "_approval_apply_pr_lifecycle_updates")
-					)
-					and ((.caller_script // "") | endswith("/agents/scripts/approval-helper.sh")
-						or endswith("/.agents/scripts/approval-helper.sh"))
-					and .flags.approval_verified == "v2-current-state"
-					and .suspicious == [("protected_label_removed:" + $nmr)]
-					and (.delta.labels_removed // []) == [$nmr]
-					and (((.delta.labels_added // []) - ["auto-dispatch"]) | length == 0)
-					and (.delta.title_delta_pct == 0)
-					and (.delta.body_delta_pct == 0)
-					and ((.before.labels // []) | index($nmr) != null)
-					and ((.after.labels // []) | index($nmr) == null);
-				def expected_permission_block_transition:
-					comparable_state
-					and .op == "issue_edit"
-					and .caller_function == "permission_apply_block"
-					and ((.caller_script // "") | endswith("/agents/scripts/worker-permission-helper.sh")
-						or endswith("/.agents/scripts/worker-permission-helper.sh"))
-					and ((.after.labels // []) | index($permission) != null)
-					and (((.delta.labels_removed // []) | length) > 0)
-					and (((.delta.labels_removed // []) - [
-						"status:queued", "status:claimed", "status:in-progress", "status:in-review"
-					]) | length == 0)
-					and (((.delta.labels_added // []) - [$permission]) | length == 0)
-					and (.delta.title_delta_pct == 0)
-					and (.delta.body_delta_pct == 0)
-					and ([.after.labels[]? | select(
-						. == "status:queued"
-						or . == "status:claimed"
-						or . == "status:in-progress"
-						or . == "status:in-review"
-					)] | length == 0)
-					and ((.suspicious // []) | length > 0)
-					and all(.suspicious[];
-						. == "protected_label_removed:status:claimed"
-						or . == "protected_label_removed:status:in-progress"
-						or . == "protected_label_removed:status:in-review");
-				select(try ((.suspicious | length) > 0) catch true)
-				| select((try (
-					expected_approval_transition or expected_permission_block_transition
-				) catch false) | not)' >"$filtered_file" 2>/dev/null; then
+			jq -c --arg nmr "$GH_ANOMALY_NMR_LABEL" --arg permission "$GH_ANOMALY_PERMISSION_LABEL" \
+				--arg issue_edit "issue_edit" --arg approval_script "approval-helper.sh" \
+				--arg permission_script "worker-permission-helper.sh" \
+				--arg nmr_script "pulse-nmr-approval.sh" \
+				-f "${SCRIPT_DIR}/gh-audit-anomaly-filter.jq" >"$filtered_file" 2>/dev/null; then
 			rm -f "$filtered_file"
 			_ga_warn "Malformed audit NDJSON detected — checkpoint not advanced"
 			return 1

--- a/.agents/scripts/shared-gh-wrappers-safe-edit.sh
+++ b/.agents/scripts/shared-gh-wrappers-safe-edit.sh
@@ -26,6 +26,8 @@
 # Include guard
 [[ -n "${_SHARED_GH_WRAPPERS_SAFE_EDIT_LIB_LOADED:-}" ]] && return 0
 _SHARED_GH_WRAPPERS_SAFE_EDIT_LIB_LOADED=1
+_GH_AUDIT_ISSUE_EDIT_OP="issue_edit"
+_GH_AUDIT_NMR_LABEL="needs-maintainer-review"
 
 # Defensive SCRIPT_DIR fallback
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
@@ -235,7 +237,7 @@ _gh_audit_record_op() {
 	# exemption proof only after independently re-verifying the signed approval
 	# and authenticated actor authority against current GitHub state.
 	local approval_target_type=""
-	if [[ "$op" == "issue_edit" && "$caller_function" == "_approval_apply_issue_lifecycle_updates" ]]; then
+	if [[ "$op" == "$_GH_AUDIT_ISSUE_EDIT_OP" && "$caller_function" == "_approval_apply_issue_lifecycle_updates" ]]; then
 		approval_target_type="issue"
 	elif [[ "$op" == "pr_edit" && "$caller_function" == "_approval_apply_pr_lifecycle_updates" ]]; then
 		approval_target_type="pr"
@@ -246,6 +248,15 @@ _gh_audit_record_op() {
 		if [[ "$approval_verification" == "VERIFIED" ]]; then
 			flags_json='{"approval_verified":"v2-current-state"}'
 		fi
+	fi
+	# aidevops:trust-boundary — trusted-author NMR normalization is expected only
+	# when the immutable snapshots show a pure NMR removal and live GitHub state
+	# independently confirms both issue-author and current-token write authority.
+	if [[ "$op" == "$_GH_AUDIT_ISSUE_EDIT_OP" && "$caller_function" == "_nmr_edit_issue_labels" ]] &&
+		[[ "$caller_script" == */agents/scripts/pulse-nmr-approval.sh ||
+			"$caller_script" == */.agents/scripts/pulse-nmr-approval.sh ]] &&
+		_gh_audit_verify_trusted_author_nmr_transition "$repo" "$number" "$before_json" "$after_json"; then
+		flags_json='{"trusted_author_nmr_verified":"v1-current-state"}'
 	fi
 
 	GH_AUDIT_QUIET=true "$audit_helper" record \
@@ -260,6 +271,56 @@ _gh_audit_record_op() {
 		--flags-json "$flags_json" \
 		2>/dev/null || true
 
+	return 0
+}
+
+#######################################
+# Verify an audited trusted-author NMR normalization against live GitHub state.
+# Args: repo, issue number, before JSON, after JSON
+# Returns: 0 only for a comparable NMR removal by a write-authorized actor on a
+# write-authorized author's issue; 1 for incomplete or untrusted evidence.
+#######################################
+_gh_audit_verify_trusted_author_nmr_transition() {
+	local repo="$1"
+	local number="$2"
+	local before_json="$3"
+	local after_json="$4"
+	local issue_json=""
+	local issue_identity=""
+	local issue_author=""
+	local issue_association=""
+	local issue_author_type=""
+	local current_actor=""
+
+	[[ -n "$repo" && "$number" =~ ^[0-9]+$ ]] || return 1
+	declare -F _gh_actor_has_repo_write_authority >/dev/null 2>&1 || return 1
+	jq -e -n --arg nmr "$_GH_AUDIT_NMR_LABEL" \
+		--argjson before "$before_json" --argjson after "$after_json" '
+		($before.capture_status // "ok") == "ok"
+		and ($after.capture_status // "ok") == "ok"
+		and ([$before.labels[]?] | index($nmr) != null)
+		and ([$after.labels[]?] | index($nmr) == null)
+	' >/dev/null 2>&1 || return 1
+
+	issue_json=$(gh api "repos/${repo}/issues/${number}" 2>/dev/null) || return 1
+	printf '%s\n' "$issue_json" | jq -e --arg nmr "$_GH_AUDIT_NMR_LABEL" '
+		([.labels[]?.name] | index($nmr) == null)
+		and ([.labels[]?.name] | index("external-contributor") == null)
+	' >/dev/null 2>&1 || return 1
+	issue_identity=$(printf '%s\n' "$issue_json" | jq -r '
+		if (.user.login // "") != "" and (.author_association // "") != ""
+		then [(.user.login // ""), (.author_association // ""), (.user.type // "")] | @tsv
+		else error("missing issue identity") end
+	' 2>/dev/null) || return 1
+	IFS=$'\t' read -r issue_author issue_association issue_author_type <<<"$issue_identity"
+	[[ -n "$issue_author" && -n "$issue_association" ]] || return 1
+	if [[ "$issue_author_type" != "Bot" ]]; then
+		_gh_actor_has_repo_write_authority "$repo" "$issue_author" "$issue_association" >/dev/null 2>&1 || return 1
+	fi
+
+	current_actor=$(gh api user --jq '.login // empty' 2>/dev/null) || return 1
+	[[ -n "$current_actor" ]] || return 1
+	_gh_actor_has_repo_write_authority "$repo" "$current_actor" "COLLABORATOR" >/dev/null 2>&1 || return 1
 	return 0
 }
 
@@ -294,7 +355,7 @@ gh_issue_edit_safe() {
 		_exit=$?
 	fi
 	_after="$(_gh_audit_fetch_issue_state_json "$_num" "$_repo")"
-	_gh_audit_record_op "issue_edit" "$_repo" "$_num" "$_before" "$_after" \
+	_gh_audit_record_op "$_GH_AUDIT_ISSUE_EDIT_OP" "$_repo" "$_num" "$_before" "$_after" \
 		"${BASH_SOURCE[1]:-}" "${FUNCNAME[1]:-}" "${BASH_LINENO[0]:-0}"
 	return "$_exit"
 }

--- a/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
+++ b/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
@@ -41,12 +41,16 @@ cat >"$LOG_FILE" <<'EOF'
 {"ts":"2026-07-31T00:10:00Z","op":"issue_edit","repo":"example/repo","number":11,"caller_script":"/runtime/agents/scripts/worker-permission-helper.sh","caller_function":"permission_apply_block","flags":{},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-progress"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":[]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["status:in-progress"],"labels_added":[]},"suspicious":["protected_label_removed:status:in-progress"]}
 {"ts":"2026-07-31T00:11:00Z","op":"issue_edit","repo":"example/repo","number":12,"caller_script":"/runtime/agents/scripts/routine-log-helper.sh","caller_function":"_update_tracking_issue","flags":{},"before":{"capture_status":"ok","title_len":27,"body_len":1822,"labels":["routines","routine-tracking"]},"after":{"capture_status":"unavailable","title_len":null,"body_len":null,"labels":null},"delta":{"comparable":false,"title_delta_pct":null,"body_delta_pct":null,"labels_removed":null,"labels_added":null},"suspicious":["state_capture_unavailable:after"]}
 {"ts":"2026-07-31T00:12:00Z","op":"issue_edit","repo":"example/repo","number":13,"caller_script":"/runtime/agents/scripts/worker-permission-helper.sh","caller_function":"permission_apply_block","flags":{},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-progress","status:in-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-review","needs-maintainer-permissions"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["status:in-progress"],"labels_added":["needs-maintainer-permissions"]},"suspicious":["protected_label_removed:status:in-progress"]}
+{"ts":"2026-07-31T00:13:00Z","op":"issue_edit","repo":"example/repo","number":14,"caller_script":"/runtime/agents/scripts/pulse-nmr-approval.sh","caller_function":"_nmr_edit_issue_labels","flags":{"trusted_author_nmr_verified":"v1-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["hold-for-review","needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["hold-for-review"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
+{"ts":"2026-07-31T00:14:00Z","op":"issue_edit","repo":"example/repo","number":15,"caller_script":"/runtime/agents/scripts/pulse-nmr-approval.sh","caller_function":"_nmr_edit_issue_labels","flags":{},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":[]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
+{"ts":"2026-07-31T00:15:00Z","op":"issue_edit","repo":"example/repo","number":16,"caller_script":"/runtime/agents/scripts/pulse-nmr-approval.sh","caller_function":"_nmr_edit_issue_labels","flags":{"trusted_author_nmr_verified":"v1-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":0,"labels":["auto-dispatch"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":-100,"labels_removed":["needs-maintainer-review"],"labels_added":["auto-dispatch"]},"suspicious":["protected_label_removed:needs-maintainer-review","body_delta_pct=-100"]}
+{"ts":"2026-07-31T00:16:00Z","op":"issue_edit","repo":"example/repo","number":17,"caller_script":"/workspace/.agents/scripts/pulse-nmr-approval.sh","caller_function":"_nmr_edit_issue_labels","flags":{"trusted_author_nmr_verified":"v1-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["hold-for-review"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["needs-maintainer-review"],"labels_added":["hold-for-review"]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
 EOF
 
 output=$(GH_AUDIT_LOG_FILE="$LOG_FILE" GH_ANOMALY_STATE_FILE="${TEST_ROOT}/state.json" \
 	GH_AUDIT_QUIET=true "$HELPER" scan --all --dry-run)
 
-[[ "$output" == *"**Anomalies found:** 9"* ]] || fail "expected transitions were not excluded exactly"
+[[ "$output" == *"**Anomalies found:** 11"* ]] || fail "expected transitions were not excluded exactly"
 [[ "$output" == *"| #3 |"* ]] || fail "unexpected lifecycle transition was hidden"
 [[ "$output" == *"| #4 |"* ]] || fail "approval transition with an additional signal was hidden"
 [[ "$output" == *"| #5 |"* ]] || fail "malformed provenance was dropped instead of retained"
@@ -56,8 +60,11 @@ output=$(GH_AUDIT_LOG_FILE="$LOG_FILE" GH_ANOMALY_STATE_FILE="${TEST_ROOT}/state
 [[ "$output" == *"| #11 |"* ]] || fail "permission block without its blocker label was hidden"
 [[ "$output" == *"| #12 |"* ]] || fail "unavailable state capture was hidden"
 [[ "$output" == *"| #13 |"* ]] || fail "permission block with a lingering active status was hidden"
+[[ "$output" == *"| #15 |"* ]] || fail "unverified trusted-author NMR removal was hidden"
+[[ "$output" == *"| #16 |"* ]] || fail "trusted-author NMR transition with an additional signal was hidden"
 [[ "$output" == *"The audit log stores lengths, not content."* ]] || fail "recovery guidance overclaimed audit content"
-[[ "$output" != *"| #1 |"* && "$output" != *"| #2 |"* && "$output" != *"| #7 |"* && "$output" != *"| #9 |"* ]] ||
+[[ "$output" != *"| #1 |"* && "$output" != *"| #2 |"* && "$output" != *"| #7 |"* && "$output" != *"| #9 |"* &&
+	"$output" != *"| #14 |"* && "$output" != *"| #17 |"* ]] ||
 	fail "an exact expected transition remained actionable"
 
 MALFORMED_LOG="${TEST_ROOT}/malformed-audit.log"
@@ -116,6 +123,49 @@ _gh_audit_record_op \
 	"_approval_apply_pr_lifecycle_updates" "1"
 jq -e -s 'map(select(.number == 22))[0].flags == {}' "$PROOF_LOG" >/dev/null ||
 	fail "failed approval verification produced trusted audit proof"
+
+gh() {
+	local command="$1"
+	local resource="${2:-}"
+	[[ "$command" == "api" ]] || return 1
+	case "$resource" in
+	repos/example/repo/issues/25)
+		printf '%s\n' '{"user":{"login":"trusted-author","type":"User"},"author_association":"COLLABORATOR","labels":[{"name":"hold-for-review"}]}'
+		;;
+	repos/example/repo/issues/26)
+		printf '%s\n' '{"user":{"login":"external-author","type":"User"},"author_association":"CONTRIBUTOR","labels":[]}'
+		;;
+	user)
+		printf '%s\n' 'trusted-runner'
+		;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+_gh_actor_has_repo_write_authority() {
+	local repo_slug="$1"
+	local actor="$2"
+	local association="${3:-NONE}"
+	[[ "$repo_slug" == "example/repo" ]] || return 2
+	[[ "$actor" == "trusted-runner" || ("$actor" == "trusted-author" && "$association" == "COLLABORATOR") ]]
+	return $?
+}
+_gh_audit_record_op \
+	"issue_edit" "example/repo" "25" \
+	'{"capture_status":"ok","title_len":1,"body_len":1,"labels":["hold-for-review","needs-maintainer-review"]}' \
+	'{"capture_status":"ok","title_len":1,"body_len":1,"labels":["hold-for-review"]}' \
+	"/runtime/agents/scripts/pulse-nmr-approval.sh" \
+	"_nmr_edit_issue_labels" "1"
+jq -e 'select(.number == 25) | .flags.trusted_author_nmr_verified == "v1-current-state"' "$PROOF_LOG" >/dev/null ||
+	fail "trusted-author NMR transition did not produce current-state audit proof"
+_gh_audit_record_op \
+	"issue_edit" "example/repo" "26" \
+	'{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]}' \
+	'{"capture_status":"ok","title_len":1,"body_len":1,"labels":[]}' \
+	"/runtime/agents/scripts/pulse-nmr-approval.sh" \
+	"_nmr_edit_issue_labels" "1"
+jq -e -s 'map(select(.number == 26))[0].flags == {}' "$PROOF_LOG" >/dev/null ||
+	fail "external-author NMR removal produced trusted-author audit proof"
 unset GH_AUDIT_LOG_FILE
 
 gh() {


### PR DESCRIPTION
## Summary

- record current-state authority proof for trusted-author NMR normalization audit entries
- suppress only exact, fully comparable proven transitions while retaining all destructive or unverified anomalies
- extract the jq policy into a focused filter to preserve shell function-complexity limits

## Testing

- `bash .agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh`
- `shellcheck -S error .agents/scripts/shared-gh-wrappers-safe-edit.sh .agents/scripts/gh-audit-anomaly-helper.sh .agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh`
- `.agents/scripts/complexity-regression-helper.sh check --base origin/main --working-tree`
- `bun run typecheck`

Resolves #29457

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.220 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 16m and 195,362 tokens on this as a headless worker.