### PR TITLE
GH#29468: Harden failure miner event clustering

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -192,7 +192,9 @@ filter_signature_noise_lines() {
 			# GitHub Actions sometimes echoes shell comments from multi-line run blocks
 			# as UNKNOWN STEP log rows. Treat plain comments and xtrace-prefixed
 			# comments as noise so they cannot become systemic failure signatures.
-			if (payload ~ /^([+][[:space:]]*)*#[[:space:]]*/) {
+			# Require whitespace or end-of-line after the comment marker so the GitHub
+			# structured `##[error]` annotation remains available as evidence.
+			if (payload ~ /^([+][[:space:]]*)*#([[:space:]]+|$)/) {
 				next
 			}
 			print raw
@@ -319,7 +321,28 @@ extract_failure_signature() {
 	fi
 
 	local candidate
-	candidate=$(printf '%s\n' "$filtered_logs" | awk 'BEGIN{IGNORECASE=1} /error|exception|traceback|failed|denied|timeout|cannot|invalid|forbidden|unauthorized/ {print; exit}')
+	# Prefer an emitted workflow annotation over generic error words in the log.
+	# A malformed/unstructured gh row can retain runner-echoed shell source such as
+	# `echo "::error::..."`; requiring the annotation marker to start a payload
+	# keeps that source from masking the actual terminal error (GH#29468).
+	candidate=$(printf '%s\n' "$filtered_logs" | awk '
+		{
+			payload = $0
+			n = split($0, fields, "\t")
+			if (n >= 4) {
+				payload = fields[4]
+			}
+			sub(/^20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9:.]+Z[[:space:]]+/, "", payload)
+			gsub(/^[[:space:]]+/, "", payload)
+			if (payload ~ /^(::error::|##\[error\])/) {
+				print
+				exit
+			}
+		}
+	')
+	if [[ -z "$candidate" ]]; then
+		candidate=$(printf '%s\n' "$filtered_logs" | awk 'BEGIN{IGNORECASE=1} /error|exception|traceback|failed|denied|timeout|cannot|invalid|forbidden|unauthorized/ {print; exit}')
+	fi
 	if [[ -z "$candidate" ]]; then
 		candidate=$(printf '%s\n' "$filtered_logs" | awk 'NF {print; exit}')
 	fi
@@ -526,6 +549,24 @@ emit_event_json() {
 			affected_paths: $affected_paths,
 			annotations: $annotations
 		}'
+	return 0
+}
+
+deduplicate_failed_events_json() {
+	local events_json="$1"
+	printf '%s\n' "$events_json" | jq '
+		unique_by([
+			.repo,
+			(if ((.details_url // "") | length) > 0 then
+				"details", .details_url
+			elif .run_id != null then
+				"run", (.run_id | tostring), .check_name
+			else
+				"source", .source_kind, .source_ref, .check_name, .signature,
+				(.completed_at // "")
+			end)
+		] | join("|"))
+	'
 	return 0
 }
 
@@ -737,7 +778,9 @@ extract_failed_events_json() {
 		return 0
 	fi
 
-	jq -s '.' "$event_file"
+	local events_json
+	events_json=$(jq -s '.' "$event_file")
+	deduplicate_failed_events_json "$events_json"
 	rm -f "$event_file"
 	return 0
 }

--- a/.agents/scripts/tests/test-gh-failure-miner-signature-noise.sh
+++ b/.agents/scripts/tests/test-gh-failure-miner-signature-noise.sh
@@ -80,10 +80,19 @@ gh() {
 		printf '%s\n' '{"jobs":[{"id":84390104069,"conclusion":"failure","check_run_url":"https://api.github.com/repos/marcusquinn/aidevops/check-runs/84390104069","steps":[{"name":"Gate result","conclusion":"failure"}]}]}'
 		return 0
 	fi
+	if [[ "$first" == "api" && "$endpoint" == "repos/marcusquinn/aidevops/actions/runs/30898422945/jobs" ]]; then
+		printf '%s\n' '{"jobs":[{"id":91958107008,"conclusion":"failure","check_run_url":"https://api.github.com/repos/marcusquinn/aidevops/check-runs/91958107008","steps":[{"name":"Enforce gate","conclusion":"failure"}]}]}'
+		return 0
+	fi
 	if [[ "$first" == "run" && "$second" == "view" ]]; then
 		if [[ "${GH_LOG_SCENARIO:-}" == "echoed_runner_guard" ]]; then
 			printf 'resolve-task\tResolve task\t2026-07-14T23:00:00Z\t\033[36;1mif ! command -v git; then echo "Runner Git binary is unavailable"; exit 1; fi\033[0m\n'
 			printf 'resolve-task\tResolve task\t2026-07-14T23:00:01Z\t::error::Closing issue has no exact TODO mapping\n'
+			return 0
+		fi
+		if [[ "${GH_LOG_SCENARIO:-}" == "qlty_unstructured_source" ]]; then
+			printf '%s\n' 'Qlty Smell Regression Enforce gate 2026-08-04T10:01:52.5121359Z # t2133: simplification PRs cannot use ratchet-bump — their goal is to reduce smells, not shift them.'
+			printf '%s\n' $'Qlty Smell Regression\tEnforce gate\t2026-08-04T10:01:52.5242388Z\t##[error]Qlty smell regression detected (exit 1).'
 			return 0
 		fi
 		printf 'gate / review-bot-gate\tUNKNOWN STEP\t2026-06-30T20:14:24.8559907Z\t\033[36;1m# rate-limit grace is disabled — they cannot merge on rate-limit-only.\033[0m\n'
@@ -100,6 +109,11 @@ GH_LOG_SCENARIO="echoed_runner_guard"
 signature=$(extract_failure_signature "marcusquinn/aidevops" "29373303758" "1")
 assert_equals "runner-echoed guard source cannot mask the executed failure" "resolve-task Resolve task 2026-07-14T23:00:01Z ::error::Closing issue has no exact TODO mapping" "$signature"
 
+GH_LOG_SCENARIO="qlty_unstructured_source"
+signature=$(extract_failure_signature "marcusquinn/aidevops" "30898422945" "91958107008")
+assert_equals "GH#29468 qlty source comment cannot mask structured error" "Qlty Smell Regression Enforce gate 2026-08-04T10:01:52.5242388Z ##[error]Qlty smell regression detected (exit 1)." "$signature"
+GH_LOG_SCENARIO="echoed_runner_guard"
+
 event_file=$(mktemp)
 failed_runs_json='[{"name":"Issue sync","id":1,"conclusion":"failure","details_url":"https://github.com/marcusquinn/aidevops/actions/runs/29373303758/job/1","html_url":"https://github.com/marcusquinn/aidevops/actions/runs/29373303758","completed_at":"2026-07-14T23:00:01Z","app":{"slug":"github-actions"}}]'
 checks_json='{"check_runs":[{"name":"Issue sync","conclusion":"failure"},{"name":"ShellCheck","conclusion":"success"}]}'
@@ -114,6 +128,13 @@ below_threshold_output=$(create_systemic_issues "$events_json" "2" "3" "true" 2>
 assert_contains "single policy failure cannot create an advisory below threshold" "No systemic clusters met threshold (2)." "$below_threshold_output"
 rm -f "$event_file"
 unset GH_LOG_SCENARIO
+
+duplicate_events='[
+  {"repo":"marcusquinn/aidevops","source_kind":"pr","source_ref":"29462","check_name":"Qlty Smell Regression","signature":"same failure","details_url":"https://example.invalid/actions/runs/1/job/2","run_id":1},
+  {"repo":"marcusquinn/aidevops","source_kind":"pr","source_ref":"29467","check_name":"Qlty Smell Regression","signature":"same failure","details_url":"https://example.invalid/actions/runs/1/job/2","run_id":1}
+]'
+deduplicated_events=$(deduplicate_failed_events_json "$duplicate_events")
+assert_equals "GH#29468 repeated notification for one check run counts once" "1" "$(printf '%s\n' "$deduplicated_events" | jq 'length')"
 
 filtered=$(filter_signature_noise_lines $'job\tUNKNOWN STEP\ttime\t\033[36;1m# comment cannot merge\033[0m\njob\tStep\ttime\treal error')
 assert_equals "comment-only log lines are filtered" $'job\tStep\ttime\treal error' "$filtered"


### PR DESCRIPTION
## Summary

Prefer emitted workflow error annotations over echoed shell source and deduplicate repeated notifications for the same check run.

## Files Changed

.agents/scripts/gh-failure-miner-helper.sh, .agents/scripts/tests/test-gh-failure-miner-signature-noise.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Failure-miner signature regression suite, ShellCheck, complexity regression check, and commit hooks pass.

Resolves #29468


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.220 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 11m and 156,191 tokens on this as a headless worker.