### PR TITLE
GH#29482: Redact private repositories from audit alerts

### DIFF
--- a/.agents/reference/gh-audit-log.md
+++ b/.agents/reference/gh-audit-log.md
@@ -256,7 +256,9 @@ The scanner:
    normalization, and worker permission blocking that replaces active lifecycle
    labels with `needs-maintainer-permissions` (the original audit entry remains
    unchanged)
-3. Files a GitHub issue on `marcusquinn/aidevops` with a summary table when anomalies are found
+3. Redacts source repository names unless GitHub confirms they are public (or
+   they match the destination repository), failing closed on lookup errors
+4. Files a GitHub issue on `marcusquinn/aidevops` with a summary table when anomalies are found
 
 To run the scanner manually:
 

--- a/.agents/scripts/gh-audit-anomaly-helper.sh
+++ b/.agents/scripts/gh-audit-anomaly-helper.sh
@@ -40,6 +40,7 @@ readonly GH_ANOMALY_LOG_FILENAME="gh-audit.log"
 readonly GH_ANOMALY_DEFAULT_REPO="marcusquinn/aidevops"
 readonly GH_ANOMALY_NMR_LABEL="needs-maintainer-review"
 readonly GH_ANOMALY_PERMISSION_LABEL="needs-maintainer-permissions"
+readonly GH_ANOMALY_REDACTED_REPO="[private repository]"
 # Maximum anomaly entries to include in an issue (prevents overly large issues)
 readonly GH_ANOMALY_MAX_ISSUE_ENTRIES=20
 
@@ -119,26 +120,55 @@ _ga_write_state() {
 	return 0
 }
 
+# Return a report-safe repository name. The scanner files into a potentially
+# public repository, so source repositories must fail closed when visibility
+# cannot be proven public. The destination repository is safe to name in its
+# own issue because the issue URL already discloses it.
+# Args: source repo, destination repo
+_ga_report_repo_name() {
+	local source_repo="$1"
+	local issue_repo="$2"
+	local visibility=""
+
+	if [[ -n "$source_repo" && "$source_repo" == "$issue_repo" ]]; then
+		printf '%s\n' "$source_repo"
+		return 0
+	fi
+
+	if [[ "$source_repo" =~ ^[^/]+/[^/]+$ ]] && command -v gh &>/dev/null; then
+		visibility=$(gh api "repos/${source_repo}" --jq '.visibility // (if .private == false then "public" else "private" end)' 2>/dev/null) || visibility=""
+	fi
+	if [[ "$visibility" == "public" ]]; then
+		printf '%s\n' "$source_repo"
+		return 0
+	fi
+
+	printf '%s\n' "$GH_ANOMALY_REDACTED_REPO"
+	return 0
+}
+
 # Format a single anomaly entry for the issue body markdown table.
-# Input: NDJSON line
+# Input: NDJSON line, destination issue repo
 # Output: markdown table row
 _ga_format_anomaly_row() {
 	local entry="$1"
+	local issue_repo="$2"
 	if ! command -v jq &>/dev/null; then
 		echo "| (jq required) | | | | |"
 		return 0
 	fi
 
-	local ts op repo number suspicious caller_function
+	local ts op repo report_repo number suspicious caller_function
 	ts=$(printf '%s' "$entry" | jq -r '.ts // "?"')
 	op=$(printf '%s' "$entry" | jq -r '.op // "?"')
 	repo=$(printf '%s' "$entry" | jq -r '.repo // "?"')
+	report_repo="$(_ga_report_repo_name "$repo" "$issue_repo")"
 	number=$(printf '%s' "$entry" | jq -r '.number // "?"')
 	suspicious=$(printf '%s' "$entry" | jq -r '.suspicious | join(", ")' 2>/dev/null || echo "?")
 	caller_function=$(printf '%s' "$entry" | jq -r '.caller_function // "?"')
 
 	printf '| %s | %s | %s | #%s | %s | %s |\n' \
-		"$ts" "$op" "$repo" "$number" "$suspicious" "$caller_function"
+		"$ts" "$op" "$report_repo" "$number" "$suspicious" "$caller_function"
 
 	return 0
 }
@@ -231,11 +261,12 @@ _cmd_scan_collect_anomalies() {
 }
 
 # Build the markdown issue body for an anomaly report.
-# Args: scan_ts anomaly_count skip_count total_lines entry1 entry2 ...
+# Args: scan_ts anomaly_count skip_count total_lines issue_repo entry1 entry2 ...
 # Output: issue body markdown on stdout.
 _cmd_scan_build_issue_body() {
 	local scan_ts="$1" anomaly_count="$2" skip_count="$3" total_lines="$4"
-	shift 4
+	local issue_repo="$5"
+	shift 5
 
 	# Header (heredoc is easier to review than concatenation).
 	cat <<BODY
@@ -258,7 +289,7 @@ BODY
 				"$anomaly_count" "$GH_ANOMALY_MAX_ISSUE_ENTRIES"
 			break
 		fi
-		_ga_format_anomaly_row "$entry"
+		_ga_format_anomaly_row "$entry" "$issue_repo"
 		included=$((included + 1))
 	done
 
@@ -386,7 +417,7 @@ cmd_scan() {
 	local body_file
 	body_file="$(mktemp -t gh-audit-anomaly-body.XXXXXX)"
 	_cmd_scan_build_issue_body "$scan_ts" "$anomaly_count" "$skip_count" \
-		"$total_lines" "${_sc_anomaly_entries[@]}" >"$body_file"
+		"$total_lines" "$_sc_issue_repo" "${_sc_anomaly_entries[@]}" >"$body_file"
 
 	if [[ "$_sc_dry_run" -eq 1 ]]; then
 		_ga_info "DRY RUN — anomalies found, would file issue on ${_sc_issue_repo}"

--- a/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
+++ b/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
@@ -26,13 +26,30 @@ fail() {
 
 TEST_ROOT="$(mktemp -d -t aidevops-gh-anomaly-XXXXXX)"
 LOG_FILE="${TEST_ROOT}/gh-audit.log"
+mkdir -p "${TEST_ROOT}/bin"
+cat >"${TEST_ROOT}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/public/repo" ]]; then
+	printf '%s\n' public
+	exit 0
+fi
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/private/repo" ]]; then
+	printf '%s\n' private
+	exit 0
+fi
+exit 1
+EOF
+chmod +x "${TEST_ROOT}/bin/gh"
+PATH="${TEST_ROOT}/bin:$PATH"
+export PATH
 
 cat >"$LOG_FILE" <<'EOF'
 {"ts":"2026-07-31T00:00:00Z","op":"issue_edit","repo":"example/repo","number":1,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["auto-dispatch"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["needs-maintainer-review"],"labels_added":["auto-dispatch"]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
 {"ts":"2026-07-31T00:01:00Z","op":"issue_edit","repo":"example/repo","number":2,"caller_script":"/workspace/.agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":[]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
-{"ts":"2026-07-31T00:02:00Z","op":"issue_edit","repo":"example/repo","number":3,"caller_script":"/tmp/close-issue.sh","caller_function":"main","before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:done"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["status:in-review"],"labels_added":["status:done"]},"suspicious":["protected_label_removed:status:in-review"]}
-{"ts":"2026-07-31T00:03:00Z","op":"issue_edit","repo":"example/repo","number":4,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":0,"labels":["auto-dispatch"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":-100,"labels_removed":["needs-maintainer-review"],"labels_added":["auto-dispatch"]},"suspicious":["protected_label_removed:needs-maintainer-review","body_delta_pct=-100"]}
-{"ts":"2026-07-31T00:04:00Z","op":"issue_edit","repo":"example/repo","number":5,"caller_script":42,"caller_function":"_approval_apply_issue_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":[]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
+{"ts":"2026-07-31T00:02:00Z","op":"issue_edit","repo":"private/repo","number":3,"caller_script":"/tmp/close-issue.sh","caller_function":"main","before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:done"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["status:in-review"],"labels_added":["status:done"]},"suspicious":["protected_label_removed:status:in-review"]}
+{"ts":"2026-07-31T00:03:00Z","op":"issue_edit","repo":"inaccessible/repo","number":4,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":0,"labels":["auto-dispatch"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":-100,"labels_removed":["needs-maintainer-review"],"labels_added":["auto-dispatch"]},"suspicious":["protected_label_removed:needs-maintainer-review","body_delta_pct=-100"]}
+{"ts":"2026-07-31T00:04:00Z","op":"issue_edit","repo":"public/repo","number":5,"caller_script":42,"caller_function":"_approval_apply_issue_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":[]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
 {"ts":"2026-07-31T00:05:00Z","op":"issue_edit","repo":"example/repo","number":6,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_issue_lifecycle_updates","flags":{},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":[]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
 {"ts":"2026-07-31T00:06:00Z","op":"pr_edit","repo":"example/repo","number":7,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_pr_lifecycle_updates","flags":{"approval_verified":"v2-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":[]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
 {"ts":"2026-07-31T00:07:00Z","op":"pr_edit","repo":"example/repo","number":8,"caller_script":"/runtime/agents/scripts/approval-helper.sh","caller_function":"_approval_apply_pr_lifecycle_updates","flags":{},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":[]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["needs-maintainer-review"],"labels_added":[]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
@@ -63,6 +80,10 @@ output=$(GH_AUDIT_LOG_FILE="$LOG_FILE" GH_ANOMALY_STATE_FILE="${TEST_ROOT}/state
 [[ "$output" == *"| #15 |"* ]] || fail "unverified trusted-author NMR removal was hidden"
 [[ "$output" == *"| #16 |"* ]] || fail "trusted-author NMR transition with an additional signal was hidden"
 [[ "$output" == *"The audit log stores lengths, not content."* ]] || fail "recovery guidance overclaimed audit content"
+[[ "$output" != *"private/repo"* ]] || fail "private repository name leaked into the report"
+[[ "$output" != *"inaccessible/repo"* ]] || fail "unverified repository name leaked into the report"
+[[ "$output" == *"[private repository]"* ]] || fail "redacted repository placeholder was missing"
+[[ "$output" == *"public/repo"* ]] || fail "verified public repository name was redacted"
 [[ "$output" != *"| #1 |"* && "$output" != *"| #2 |"* && "$output" != *"| #7 |"* && "$output" != *"| #9 |"* &&
 	"$output" != *"| #14 |"* && "$output" != *"| #17 |"* ]] ||
 	fail "an exact expected transition remained actionable"


### PR DESCRIPTION
## Summary

Fail closed when rendering anomaly source repositories so private or inaccessible names are replaced with a neutral placeholder while verified public and destination repositories remain actionable.

## Files Changed

.agents/reference/gh-audit-log.md, .agents/scripts/gh-audit-anomaly-helper.sh, .agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Targeted anomaly transition regression test, ShellCheck, git diff --check, and TypeScript typecheck passed.

Resolves #29482


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.220 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 8m and 134,171 tokens on this as a headless worker.