### PR TITLE
GH#29487: Make Cloudron package monitoring reset-aware under GitHub rate limits

### DIFF
--- a/.agents/reference/routines.md
+++ b/.agents/reference/routines.md
@@ -77,6 +77,11 @@ occurrence; nonexistent spring-forward local times fail closed with a diagnostic
 Only successful runs advance `last_run`. Active runs remain blocked for up to six
 hours, and failures retry after 15 minutes by default
 (`AIDEVOPS_ROUTINE_FAILURE_RETRY_SECONDS`) rather than waiting a full period.
+GitHub API cooldown exits are recorded as `deferred`, not `failure`. Their next
+eligible attempt is persisted at the shared cooldown reset or `Retry-After`
+boundary plus up to 60 seconds of deterministic jitter
+(`AIDEVOPS_ROUTINE_COOLDOWN_JITTER_MAX_SECONDS`); Pulse does not sleep or launch
+a long-lived retry process.
 
 ## Dispatch rules
 

--- a/.agents/scripts/cloudron-package-monitor-helper.sh
+++ b/.agents/scripts/cloudron-package-monitor-helper.sh
@@ -21,6 +21,46 @@ _cloudron_monitor_error() {
 	return 1
 }
 
+_cloudron_monitor_deferred() {
+	local expires_at=""
+	expires_at="$(_gh_secondary_cooldown_expires_at 2>/dev/null || true)"
+	[[ "$expires_at" =~ ^[0-9]+$ ]] || expires_at="unknown"
+	printf 'DEFERRED: GitHub API cooldown active until epoch %s.\n' "$expires_at" >&2
+	return 75
+}
+
+_cloudron_monitor_response_bodies() {
+	local response_text="$1"
+	printf '%s\n' "$response_text" | awk '
+		{
+			line = $0
+			sub(/\r$/, "", line)
+			if (line ~ /^HTTP\//) { in_headers = 1; next }
+			if (in_headers && line == "") { in_headers = 0; next }
+			if (!in_headers) { print line }
+		}
+	'
+	return 0
+}
+
+_cloudron_monitor_fetch_releases() {
+	local upstream_slug="$1"
+	local endpoint="/repos/${upstream_slug}/releases?per_page=100"
+	local response=""
+	local api_rc=0
+	response=$(_gh_with_timeout read gh api -i "$endpoint" --paginate 2>/dev/null) || api_rc=$?
+	if [[ "$api_rc" -eq 75 ]] || _gh_secondary_cooldown_active; then
+		_cloudron_monitor_deferred
+		return $?
+	fi
+	if [[ "$api_rc" -ne 0 ]]; then
+		_cloudron_monitor_error "Could not fetch paginated GitHub releases for $upstream_slug."
+		return 1
+	fi
+	_cloudron_monitor_response_bodies "$response"
+	return 0
+}
+
 _cloudron_monitor_require_tools() {
 	command -v jq >/dev/null 2>&1 || _cloudron_monitor_error "jq is required." || return 1
 	command -v gh >/dev/null 2>&1 || _cloudron_monitor_error "GitHub CLI is required." || return 1
@@ -245,9 +285,7 @@ _cloudron_monitor_upstream_entry() {
 		'type == $array_type and length > 0 and all(.[]; type == $string_type and all(explode[]; . >= 32 and . != 127))' <<<"$tag_prefixes" >/dev/null 2>&1 ||
 		_cloudron_monitor_error "cloudron_package.upstream_tag_prefixes for $slug must be a non-empty array of strings; control characters are forbidden." || return 1
 	local releases_json=""
-	if ! releases_json=$(gh api "repos/${upstream_slug}/releases?per_page=100" --paginate); then
-		_cloudron_monitor_error "Could not fetch paginated GitHub releases for $upstream_slug." || return 1
-	fi
+	releases_json=$(_cloudron_monitor_fetch_releases "$upstream_slug") || return $?
 	local latest_version=""
 	latest_version=$(_cloudron_monitor_latest_release_version "$releases_json" "$tag_prefixes" "$upstream_slug") || return 1
 	local current_version=""
@@ -304,12 +342,18 @@ _cloudron_monitor_run() {
 	local apply="$2"
 	local failures=0
 	local entry=""
+	local entry_rc=0
 	while IFS= read -r entry; do
+		entry_rc=0
 		if [[ "$mode" == "upstream" ]]; then
-			_cloudron_monitor_upstream_entry "$entry" "$apply" || failures=$((failures + 1))
+			_cloudron_monitor_upstream_entry "$entry" "$apply" || entry_rc=$?
 		else
-			_cloudron_monitor_compatibility_entry "$entry" "$apply" || failures=$((failures + 1))
+			_cloudron_monitor_compatibility_entry "$entry" "$apply" || entry_rc=$?
 		fi
+		if [[ "$entry_rc" -eq 75 ]]; then
+			return 75
+		fi
+		[[ "$entry_rc" -eq 0 ]] || failures=$((failures + 1))
 	done < <(jq -c '.initialized_repos[] | select(.maintenance != false and .app_type == "cloudron-package")' "$REPOS_FILE")
 	[[ "$failures" -eq 0 ]] || return 1
 	return 0

--- a/.agents/scripts/pulse-routines.sh
+++ b/.agents/scripts/pulse-routines.sh
@@ -32,6 +32,50 @@
 _PULSE_ROUTINES_LOADED=1
 _ROUTINE_STATUS_SUCCESS="success"
 _ROUTINE_STATUS_FAILURE="failure"
+_ROUTINE_STATUS_DEFERRED="deferred"
+_ROUTINE_TEMPFAIL_EXIT=75
+
+_routine_now_epoch() {
+	local configured="${AIDEVOPS_ROUTINE_NOW_EPOCH:-}"
+	if [[ "$configured" =~ ^[0-9]+$ ]]; then
+		printf '%s' "$configured"
+		return 0
+	fi
+	date +%s
+	return 0
+}
+
+_routine_epoch_to_iso() {
+	local epoch="$1"
+	date -u -d "@${epoch}" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+		date -u -r "$epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null
+	return $?
+}
+
+_routine_deferred_until() {
+	local routine_id="$1"
+	local reset_epoch=""
+	local now_epoch=0
+	local jitter_max="${AIDEVOPS_ROUTINE_COOLDOWN_JITTER_MAX_SECONDS:-60}"
+	local fallback_seconds="${AIDEVOPS_ROUTINE_FAILURE_RETRY_SECONDS:-900}"
+	local checksum=""
+	local jitter=0
+	now_epoch=$(_routine_now_epoch)
+	reset_epoch="$(_gh_secondary_cooldown_expires_at 2>/dev/null || true)"
+	[[ "$fallback_seconds" =~ ^[0-9]+$ ]] || fallback_seconds=900
+	if ! [[ "$reset_epoch" =~ ^[0-9]+$ && "$reset_epoch" -gt "$now_epoch" ]]; then
+		reset_epoch=$((now_epoch + fallback_seconds))
+	fi
+	[[ "$jitter_max" =~ ^[0-9]+$ ]] || jitter_max=60
+	if [[ "$jitter_max" -gt 0 ]]; then
+		checksum=$(printf '%s' "${routine_id}:${reset_epoch}" | cksum)
+		checksum="${checksum%% *}"
+		[[ "$checksum" =~ ^[0-9]+$ ]] || checksum=0
+		jitter=$((checksum % (jitter_max + 1)))
+	fi
+	printf '%s' $((reset_epoch + jitter))
+	return 0
+}
 
 #######################################
 # Read last-run epoch for a routine ID from state file
@@ -66,8 +110,12 @@ _routine_last_run_epoch() {
 _routine_update_state() {
 	local routine_id="$1"
 	local status="$2"
+	local deferred_until="${3:-0}"
+	local now_epoch=0
 	local now_iso
-	now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	now_epoch=$(_routine_now_epoch)
+	now_iso=$(_routine_epoch_to_iso "$now_epoch") || now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	[[ "$deferred_until" =~ ^[0-9]+$ ]] || deferred_until=0
 
 	mkdir -p "$(dirname "$ROUTINE_STATE_FILE")" 2>/dev/null || true
 
@@ -79,9 +127,15 @@ _routine_update_state() {
 
 	local tmp_file
 	tmp_file=$(mktemp "$(dirname "$ROUTINE_STATE_FILE")/.routine-state.XXXXXX")
-	if echo "$existing" | jq --arg id "$routine_id" --arg ts "$now_iso" --arg st "$status" --arg success "$_ROUTINE_STATUS_SUCCESS" '
+	if echo "$existing" | jq --arg id "$routine_id" --arg ts "$now_iso" --arg st "$status" \
+		--arg success "$_ROUTINE_STATUS_SUCCESS" --arg deferred "$_ROUTINE_STATUS_DEFERRED" \
+		--argjson deferred_until "$deferred_until" '
 		.[$id] = ((.[$id] // {}) + {"last_attempt": $ts, "last_status": $st})
 		| if $st == $success then .[$id].last_run = $ts else . end
+		| if $st == $deferred then
+			.[$id].deferred_until = ([.[$id].deferred_until // 0, $deferred_until] | max)
+		  else del(.[$id].deferred_until)
+		  end
 	' >"$tmp_file" 2>/dev/null; then
 		mv "$tmp_file" "$ROUTINE_STATE_FILE"
 	else
@@ -103,6 +157,7 @@ _routine_retry_blocked() {
 	local attempt_iso=""
 	local attempt_epoch=0
 	local now_epoch=0
+	local deferred_until=0
 	[[ "$retry_seconds" =~ ^[0-9]+$ ]] || retry_seconds=900
 	[[ "$running_seconds" =~ ^[0-9]+$ ]] || running_seconds=21600
 	[[ -f "$ROUTINE_STATE_FILE" ]] || return 1
@@ -110,10 +165,14 @@ _routine_retry_blocked() {
 	attempt_iso=$(jq -r --arg id "$routine_id" '.[$id].last_attempt // empty' "$ROUTINE_STATE_FILE" 2>/dev/null || true)
 	[[ -n "$attempt_iso" ]] || return 1
 	attempt_epoch=$(date -d "$attempt_iso" +%s 2>/dev/null) || attempt_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$attempt_iso" +%s 2>/dev/null) || return 1
-	now_epoch=$(date +%s)
+	now_epoch=$(_routine_now_epoch)
 	case "$status" in
 	running) [[ $((now_epoch - attempt_epoch)) -lt "$running_seconds" ]] ;;
 	failure) [[ $((now_epoch - attempt_epoch)) -lt "$retry_seconds" ]] ;;
+	deferred)
+		deferred_until=$(jq -r --arg id "$routine_id" '.[$id].deferred_until // 0' "$ROUTINE_STATE_FILE" 2>/dev/null || true)
+		[[ "$deferred_until" =~ ^[0-9]+$ && "$now_epoch" -lt "$deferred_until" ]]
+		;;
 	*) return 1 ;;
 	esac
 	return $?
@@ -137,12 +196,13 @@ _routine_finalize_terminal() {
 	local status="$2"
 	local started_epoch="$3"
 	local session_key="${4:-}"
+	local deferred_until="${5:-0}"
 	local ended_epoch=0
 	local duration=0
 	ended_epoch=$(date +%s)
 	duration=$((ended_epoch - started_epoch))
 	[[ "$duration" -ge 0 ]] || duration=0
-	_routine_update_state "$routine_id" "$status"
+	_routine_update_state "$routine_id" "$status" "$deferred_until"
 	_routine_record_lifecycle "$routine_id" "$status" "$duration" "$session_key"
 	return 0
 }
@@ -201,6 +261,7 @@ _routine_execute() {
 	local status="$_ROUTINE_STATUS_SUCCESS"
 	local started_epoch=0
 	local exit_code=0
+	local deferred_until=0
 	started_epoch=$(date +%s)
 
 	if [[ -n "$run_script" ]]; then
@@ -222,13 +283,17 @@ _routine_execute() {
 			echo "[pulse-wrapper] routine ${routine_id}: executing script ${script_path}" >>"$LOGFILE"
 			"$script_path" >>"$LOGFILE" 2>&1 || exit_code=$?
 		fi
-		if [[ "$exit_code" -ne 0 ]]; then
+		if [[ "$exit_code" -eq "$_ROUTINE_TEMPFAIL_EXIT" ]]; then
+			status="$_ROUTINE_STATUS_DEFERRED"
+			deferred_until=$(_routine_deferred_until "$routine_id")
+			echo "[pulse-wrapper] routine ${routine_id}: deferred by GitHub API cooldown until epoch ${deferred_until}" >>"$LOGFILE"
+		elif [[ "$exit_code" -ne 0 ]]; then
 			status="$_ROUTINE_STATUS_FAILURE"
 			echo "[pulse-wrapper] routine ${routine_id}: script exited with code ${exit_code}" >>"$LOGFILE"
 		else
 			echo "[pulse-wrapper] routine ${routine_id}: script completed successfully" >>"$LOGFILE"
 		fi
-		_routine_finalize_terminal "$routine_id" "$status" "$started_epoch"
+		_routine_finalize_terminal "$routine_id" "$status" "$started_epoch" "" "$deferred_until"
 		return 0
 	fi
 

--- a/.agents/scripts/routine-log-helper.sh
+++ b/.agents/scripts/routine-log-helper.sh
@@ -6,7 +6,7 @@
 # Script-only shows $0 cost. Detailed logs stay local. (t1926)
 #
 # Usage:
-#   routine-log-helper.sh update <routine-id> --status queued|claimed|running|success|failure|cancelled [--duration SECONDS] [--tokens N] [--cost AMOUNT] [--job-id ID] [--session-key KEY]
+#   routine-log-helper.sh update <routine-id> --status queued|claimed|running|success|failure|deferred|cancelled [--duration SECONDS] [--tokens N] [--cost AMOUNT] [--job-id ID] [--session-key KEY]
 #   routine-log-helper.sh notable <routine-id> --event "description"
 #   routine-log-helper.sh create-issue <routine-id> --repo SLUG --title "rNNN: Title" [--schedule EXPR] [--type TYPE]
 #   routine-log-helper.sh status
@@ -433,7 +433,7 @@ EOF
 # Returns 1 on invalid input.
 _parse_update_args() {
 	if [[ $# -lt 1 ]]; then
-		_log_error "Usage: routine-log-helper.sh update <routine-id> --status queued|claimed|running|success|failure|cancelled [--duration SECONDS] [--tokens N] [--cost AMOUNT] [--job-id ID] [--session-key KEY]"
+		_log_error "Usage: routine-log-helper.sh update <routine-id> --status queued|claimed|running|success|failure|deferred|cancelled [--duration SECONDS] [--tokens N] [--cost AMOUNT] [--job-id ID] [--session-key KEY]"
 		return 1
 	fi
 	# shellcheck disable=SC2034
@@ -496,9 +496,9 @@ _parse_update_args() {
 	fi
 
 	case "$_UPDATE_STATUS" in
-	queued | claimed | running | success | failure | cancelled) ;;
+	queued | claimed | running | success | failure | deferred | cancelled) ;;
 	*)
-		_log_error "Status must be queued, claimed, running, success, failure, or cancelled"
+		_log_error "Status must be queued, claimed, running, success, failure, deferred, or cancelled"
 		return 1
 		;;
 	esac
@@ -1152,7 +1152,7 @@ cmd_help() {
 routine-log-helper.sh — Routine execution tracking via GitHub issue descriptions
 
 Usage:
-  routine-log-helper.sh update <routine-id> --status queued|claimed|running|success|failure|cancelled [options]
+  routine-log-helper.sh update <routine-id> --status queued|claimed|running|success|failure|deferred|cancelled [options]
     Append lifecycle evidence locally. Only success and failure update execution
     metrics, the tracking issue, streaks, and cost totals.
     Script-only routines (run:) always show $0.00 cost.

--- a/.agents/scripts/tests/test-cloudron-package-monitor.sh
+++ b/.agents/scripts/tests/test-cloudron-package-monitor.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 HELPER="${SCRIPT_DIR}/../cloudron-package-monitor-helper.sh"
+PULSE_ROUTINES="${SCRIPT_DIR}/../pulse-routines.sh"
+GH_COOLDOWN="${SCRIPT_DIR}/../shared-gh-secondary-cooldown.sh"
 TEST_ROOT=""
 PASSED=0
 FAILED=0
@@ -36,8 +38,35 @@ write_fake_commands() {
 	cat >"${bin_dir}/gh" <<'GH'
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ "${1:-}" == "api" && "${2:-}" == repos/*/releases\?per_page=100 && "${3:-}" == "--paginate" ]]; then
-    [[ "${MONITOR_API_FAIL:-false}" != true ]] || exit 1
+if [[ "${1:-}" == "api" && "$*" == *releases\?per_page=100* ]]; then
+    endpoint=""
+    for arg in "$@"; do
+        [[ "$arg" == /repos/*/releases\?per_page=100 ]] && endpoint="$arg"
+    done
+    printf 'API %s\n' "$endpoint" >>"${MONITOR_API_LOG:-/dev/null}"
+    case "${MONITOR_RATE_FIXTURE:-}" in
+        primary-403-reset)
+            printf 'HTTP/2 403\r\nX-RateLimit-Remaining: 0\r\nX-RateLimit-Reset: 9999999999\r\n\r\n{"message":"API rate limit exceeded"}\n'
+            exit 1
+            ;;
+        secondary-403-retry)
+            printf 'HTTP/2 403\r\nRetry-After: 45\r\nX-RateLimit-Remaining: 50\r\n\r\n{"message":"You have exceeded a secondary rate limit"}\n'
+            exit 1
+            ;;
+        primary-429-retry)
+            printf 'HTTP/2 429\r\nRetry-After: 30\r\nX-RateLimit-Remaining: 0\r\n\r\n{"message":"rate limit exceeded"}\n'
+            exit 1
+            ;;
+        primary-429-reset)
+            printf 'HTTP/2 429\r\nX-RateLimit-Remaining: 0\r\nX-RateLimit-Reset: 9999999999\r\n\r\n{"message":"rate limit exceeded"}\n'
+            exit 1
+            ;;
+    esac
+    if [[ "${MONITOR_API_FAIL:-false}" == true ]]; then
+        printf 'HTTP/2 500\r\n\r\n{"message":"temporary server error"}\n'
+        exit 1
+    fi
+    printf 'HTTP/2 200\r\nX-RateLimit-Remaining: 100\r\n\r\n'
     if [[ -n "${MONITOR_RELEASES_FILE:-}" ]]; then
         while IFS= read -r line || [[ -n "$line" ]]; do
             printf '%s\n' "$line"
@@ -136,6 +165,24 @@ JSON
   }]
 }
 JSON
+	return 0
+}
+
+write_two_package_fixture() {
+	local home_dir="$1"
+	local repo_dir="$2"
+	local second_repo_dir="${repo_dir}-two"
+	local repos_tmp="${home_dir}/.config/aidevops/repos.tmp.json"
+	write_fixture "$home_dir" "$repo_dir"
+	mkdir -p "$second_repo_dir"
+	cp "${repo_dir}/CloudronManifest.json" "${second_repo_dir}/CloudronManifest.json"
+	jq --arg path "$second_repo_dir" '
+		.initialized_repos += [(.initialized_repos[0]
+			| .slug = "exampleorg/example-package-two"
+			| .path = $path
+			| .cloudron_package.upstream_slug = "exampleorg/upstream-two")]
+	' "${home_dir}/.config/aidevops/repos.json" >"$repos_tmp"
+	mv "$repos_tmp" "${home_dir}/.config/aidevops/repos.json"
 	return 0
 }
 
@@ -281,6 +328,122 @@ test_monitor_fails_closed_on_release_api_error() {
 	return 0
 }
 
+assert_rate_limit_fixture() {
+	local fixture="$1"
+	local expected_status="$2"
+	local expected_classification="$3"
+	local case_root="${TEST_ROOT}/${fixture}"
+	local home_dir="${case_root}/home"
+	local repo_dir="${case_root}/package"
+	local bin_dir="${case_root}/bin"
+	local issue_log="${case_root}/issues.log"
+	local api_log="${case_root}/api.log"
+	local output=""
+	local rc=0
+	write_fake_commands "$bin_dir"
+	write_two_package_fixture "$home_dir" "$repo_dir"
+	if output=$(HOME="$home_dir" PATH="${bin_dir}:$PATH" MONITOR_TEST_LOG="$issue_log" MONITOR_API_LOG="$api_log" \
+		MONITOR_RATE_FIXTURE="$fixture" CLOUDRON_PACKAGE_ISSUE_WRAPPER="${bin_dir}/gh_create_issue" \
+		bash "$HELPER" upstream --apply 2>&1); then
+		rc=0
+	else
+		rc=$?
+	fi
+	assert_equal 75 "$rc" "${fixture} returns EX_TEMPFAIL"
+	assert_equal 1 "$(grep -c '^API ' "$api_log")" "${fixture} stops before the second registration"
+	[[ ! -f "$issue_log" ]] && assert_equal true true "${fixture} creates no issue" || assert_equal true false "${fixture} creates no issue"
+	local cooldown_file="${home_dir}/.aidevops/cache/gh-secondary-cooldown.json"
+	local state_shape=""
+	state_shape=$(jq -r '[.diagnostic.http_status, .diagnostic.body_classification] | @tsv' "$cooldown_file")
+	assert_equal "${expected_status}"$'\t'"${expected_classification}" "$state_shape" "${fixture} records shared cooldown evidence"
+	[[ "$output" == *"DEFERRED: GitHub API cooldown active until epoch"* ]] &&
+		assert_equal true true "${fixture} emits a machine-distinguishable safe status" ||
+		assert_equal true false "${fixture} emits a machine-distinguishable safe status"
+	return 0
+}
+
+test_monitor_rate_limit_fixtures() {
+	assert_rate_limit_fixture primary-403-reset 403 primary-rate-limit
+	assert_rate_limit_fixture secondary-403-retry 403 secondary-rate-limit
+	assert_rate_limit_fixture primary-429-retry 429 rate-limit-message
+	assert_rate_limit_fixture primary-429-reset 429 rate-limit-message
+	return 0
+}
+
+test_monitor_scheduler_cooldown_integration() {
+	local case_root="${TEST_ROOT}/scheduler-integration"
+	local home_dir="${case_root}/home"
+	local repo_dir="${case_root}/package"
+	local bin_dir="${case_root}/bin"
+	local issue_log="${case_root}/issues.log"
+	local api_log="${case_root}/api.log"
+	local state_file="${case_root}/routine-state.json"
+	local pulse_log="${case_root}/pulse.log"
+	local old_home="$HOME"
+	local old_path="$PATH"
+	local deferred_until=0
+	local blocked_rc=0
+	local eligible_count=0
+	local iteration=0
+	write_fake_commands "$bin_dir"
+	write_two_package_fixture "$home_dir" "$repo_dir"
+	mkdir -p "${home_dir}/.aidevops/agents/scripts"
+	cat >"${home_dir}/.aidevops/agents/scripts/rate-monitor.sh" <<WRAPPER
+#!/usr/bin/env bash
+exec bash "$HELPER" upstream --apply
+WRAPPER
+	chmod +x "${home_dir}/.aidevops/agents/scripts/rate-monitor.sh"
+
+	export HOME="$home_dir"
+	export PATH="${bin_dir}:${old_path}"
+	export MONITOR_TEST_LOG="$issue_log"
+	export MONITOR_API_LOG="$api_log"
+	export MONITOR_RATE_FIXTURE=primary-403-reset
+	export CLOUDRON_PACKAGE_ISSUE_WRAPPER="${bin_dir}/gh_create_issue"
+	export AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE="${home_dir}/.aidevops/cache/gh-secondary-cooldown.json"
+	export AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_FILE="${home_dir}/.aidevops/cache/gh-cooldown-events.jsonl"
+	export AIDEVOPS_ROUTINE_NOW_EPOCH=9999999900
+	export AIDEVOPS_ROUTINE_COOLDOWN_JITTER_MAX_SECONDS=7
+	unset _SHARED_GH_SECONDARY_COOLDOWN_LOADED _PULSE_ROUTINES_LOADED
+	# shellcheck source=../shared-gh-secondary-cooldown.sh
+	source "$GH_COOLDOWN"
+	ROUTINE_STATE_FILE="$state_file"
+	LOGFILE="$pulse_log"
+	ROUTINE_LOG_HELPER="${case_root}/missing-routine-log-helper"
+	# shellcheck source=../pulse-routines.sh
+	source "$PULSE_ROUTINES"
+
+	_routine_execute r916 "Cloudron packages" scripts/rate-monitor.sh "" "$case_root"
+	deferred_until=$(jq -r '.r916.deferred_until' "$state_file")
+	assert_equal deferred "$(jq -r '.r916.last_status' "$state_file")" "rate-limited monitor is classified as deferred"
+	[[ "$deferred_until" -ge 9999999999 && "$deferred_until" -le 10000000006 ]] &&
+		assert_equal true true "scheduler persists reset plus bounded jitter" ||
+		assert_equal true false "scheduler persists reset plus bounded jitter"
+	assert_equal 1 "$(grep -c '^API ' "$api_log")" "integrated monitor touches only the first registration"
+
+	AIDEVOPS_ROUTINE_NOW_EPOCH=$((deferred_until - 1))
+	blocked_rc=0
+	_routine_retry_blocked r916 || blocked_rc=$?
+	assert_equal 0 "$blocked_rc" "deferred routine remains blocked before eligibility"
+	AIDEVOPS_ROUTINE_NOW_EPOCH="$deferred_until"
+	for iteration in 1 2; do
+		blocked_rc=0
+		_routine_retry_blocked r916 || blocked_rc=$?
+		if [[ "$blocked_rc" -ne 0 ]]; then
+			eligible_count=$((eligible_count + 1))
+			_routine_update_state r916 running
+		fi
+	done
+	assert_equal 1 "$eligible_count" "exactly one retry becomes eligible after cooldown expiry"
+
+	export HOME="$old_home"
+	export PATH="$old_path"
+	unset MONITOR_TEST_LOG MONITOR_API_LOG MONITOR_RATE_FIXTURE CLOUDRON_PACKAGE_ISSUE_WRAPPER \
+		AIDEVOPS_GH_SECONDARY_COOLDOWN_FILE AIDEVOPS_GH_SECONDARY_COOLDOWN_EVENTS_FILE \
+		AIDEVOPS_ROUTINE_NOW_EPOCH AIDEVOPS_ROUTINE_COOLDOWN_JITTER_MAX_SECONDS
+	return 0
+}
+
 test_monitor_rejects_blank_package_title() {
 	local home_dir="${TEST_ROOT}/blank-title-home"
 	local repo_dir="${TEST_ROOT}/blank-title-package"
@@ -312,6 +475,8 @@ main() {
 	test_monitor_rejects_malformed_prefixes
 	test_monitor_rejects_control_characters_in_prefixes
 	test_monitor_fails_closed_on_release_api_error
+	test_monitor_rate_limit_fixtures
+	test_monitor_scheduler_cooldown_integration
 	test_monitor_rejects_blank_package_title
 	printf '\nRan %d tests, %d failed.\n' "$((PASSED + FAILED))" "$FAILED"
 	[[ "$FAILED" -eq 0 ]] || return 1

--- a/.agents/scripts/tests/test-routine-calendar-scheduling.sh
+++ b/.agents/scripts/tests/test-routine-calendar-scheduling.sh
@@ -138,6 +138,34 @@ assert_pulse_state_policy() {
 	local success_shape=""
 	success_shape=$(jq -r '.r001 | [has("last_run"), .last_status] | @tsv' "$ROUTINE_STATE_FILE")
 	record_result "successful run advances the calendar marker" "$success_shape" $'true\tsuccess'
+
+	AIDEVOPS_ROUTINE_NOW_EPOCH=1000
+	AIDEVOPS_ROUTINE_FAILURE_RETRY_SECONDS=900
+	_routine_update_state r002 failure
+	AIDEVOPS_ROUTINE_NOW_EPOCH=1899
+	blocked_rc=0
+	_routine_retry_blocked r002 || blocked_rc=$?
+	record_result "ordinary failure retains generic retry semantics" "$blocked_rc" 0
+	AIDEVOPS_ROUTINE_NOW_EPOCH=1900
+	blocked_rc=0
+	_routine_retry_blocked r002 || blocked_rc=$?
+	record_result "ordinary failure retries after generic boundary" "$blocked_rc" 1
+
+	AIDEVOPS_ROUTINE_NOW_EPOCH=2000
+	_routine_update_state r003 deferred 2100
+	_routine_update_state r003 deferred 2050
+	local deferred_shape=""
+	deferred_shape=$(jq -r '.r003 | [.last_status, .deferred_until, has("last_run")] | @tsv' "$ROUTINE_STATE_FILE")
+	record_result "repeated deferrals preserve the furthest eligibility boundary" "$deferred_shape" $'deferred\t2100\tfalse'
+	AIDEVOPS_ROUTINE_NOW_EPOCH=2099
+	blocked_rc=0
+	_routine_retry_blocked r003 || blocked_rc=$?
+	record_result "deferred run remains blocked before reset plus jitter" "$blocked_rc" 0
+	AIDEVOPS_ROUTINE_NOW_EPOCH=2100
+	blocked_rc=0
+	_routine_retry_blocked r003 || blocked_rc=$?
+	record_result "deferred run retries at persisted eligibility boundary" "$blocked_rc" 1
+	unset AIDEVOPS_ROUTINE_NOW_EPOCH AIDEVOPS_ROUTINE_FAILURE_RETRY_SECONDS
 	return 0
 }
 

--- a/.agents/tools/deployment/cloudron-app-packaging.md
+++ b/.agents/tools/deployment/cloudron-app-packaging.md
@@ -324,6 +324,10 @@ Core routines provide ongoing reporting:
 Both routines deduplicate package-local issues, require maintainer-equivalent
 issue authority, and fail closed on GitHub/API errors. They never execute
 upstream instructions or modify package source.
+When GitHub reports a primary or secondary rate limit, `r916` stops before the
+next package registration and records a reset-aware deferred attempt. Pulse
+retries after the shared cooldown boundary plus bounded jitter instead of using
+the generic 15-minute failure retry.
 
 **Publication boundary:** pushing a `vX.Y.Z` tag is the explicit trigger for the
 managed caller to validate and create a GitHub release. Tag creation, image


### PR DESCRIPTION
## Summary

Stop Cloudron package scans on shared GitHub cooldowns and persist reset-plus-jitter routine deferrals.

## Files Changed

.agents/reference/routines.md, .agents/scripts/cloudron-package-monitor-helper.sh, .agents/scripts/pulse-routines.sh, .agents/scripts/routine-log-helper.sh, .agents/scripts/tests/test-cloudron-package-monitor.sh, .agents/scripts/tests/test-routine-calendar-scheduling.sh, .agents/tools/deployment/cloudron-app-packaging.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime integration fixture executes r916 across two registrations, verifies first-call cooldown stop, advances the scheduler clock beyond reset plus jitter, and observes exactly one eligible retry; focused suites and ShellCheck pass.

Resolves #29487


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.220 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 14m and 177,200 tokens on this as a headless worker.