### PR TITLE
GH#29454: fix: defer pending-publication orphan TODO seeding

### DIFF
--- a/.agents/reference/planning-publication-lifecycle.md
+++ b/.agents/reference/planning-publication-lifecycle.md
@@ -17,6 +17,8 @@ Use a **hold-until-published** model with an orthogonal
 - An issue created from unpublished local planning state receives
   `publication:pending`. It does not receive `auto-dispatch` or
   `status:available`, even when those are the intended post-publication labels.
+- Creators must include `publication:pending` in the issue-create request rather
+  than add it afterward, so issue-open synchronization cannot race the blocker.
 - A task becomes publishable only when its TODO entry and worker brief (or a
   canonical stub that identifies a worker-ready issue body) are both visible on
   the repository's default branch.
@@ -237,6 +239,10 @@ release ambiguous and can either strand tasks or remove a deliberate hold.
 
 - Existing published issues without `publication:pending` retain legacy
   behavior. Do not bulk-label historical work.
+- Issue-sync pull defers orphan TODO seeding for an open issue carrying the
+  exact `publication:pending` label. Once the canonical row appears, reference
+  synchronization proceeds normally; removing the label before publication
+  restores legacy orphan recovery on the next pull.
 - New task-creation paths opt into the protocol together. During rollout, pulse
   must understand the blocker before creators can emit it, and creators must
   defer available labels before reconciliation is enabled.

--- a/.agents/scripts/issue-sync-helper-commands.sh
+++ b/.agents/scripts/issue-sync-helper-commands.sh
@@ -36,12 +36,23 @@ fi
 # cmd_pull
 # =============================================================================
 
+_print_pull_summary() {
+	local synced="$1" assignee_synced="$2" orphan_seeded="$3" orphan_skipped="$4"
+	local orphan_open="$5" orphan_closed="$6" publication_deferred="$7" orphan_list="$8"
+	printf "\n=== Pull Summary ===\nRefs synced: %d | Assignees: %d | Orphans seeded: %d | Orphans skipped: %d\n" \
+		"$synced" "$assignee_synced" "$orphan_seeded" "$orphan_skipped"
+	printf "Orphans open: %d closed: %d | Publication pending deferred: %d\n" \
+		"$orphan_open" "$orphan_closed" "$publication_deferred"
+	[[ $orphan_open -gt 0 ]] && print_warning "Open orphans: $orphan_list"
+	[[ $synced -eq 0 && $assignee_synced -eq 0 && $orphan_open -eq 0 ]] && print_success "TODO.md refs up to date"
+	return 0
+}
+
 cmd_pull() {
 	_init_cmd || return 1
 	local repo="$_CMD_REPO" todo_file="$_CMD_TODO"
 	print_info "Pulling issue refs from GitHub ($repo) to TODO.md..."
-	local synced=0 orphan_open=0 orphan_closed=0 assignee_synced=0 orphan_list="" orphan_seeded=0 orphan_skipped=0
-	local state
+	local synced=0 orphan_open=0 orphan_closed=0 assignee_synced=0 orphan_list="" orphan_seeded=0 orphan_skipped=0 publication_deferred=0 state=""
 	for state in open closed; do
 		local json
 		json=$(gh_list_issues "$repo" "$state" 200)
@@ -62,9 +73,14 @@ cmd_pull() {
 			if [[ "$existing_ref" != "$num" ]]; then
 				if [[ -z "$task_line_num" ]]; then
 					if [[ "$state" == "open" ]]; then
-						# t2698: seed a TODO.md entry for the open orphan
 						local labels_json
 						labels_json=$(echo "$issue_line" | jq -r '.labels // []' 2>/dev/null || echo "[]")
+						if _issue_labels_include_exact "$labels_json" "publication:pending"; then
+							print_info "Publication pending: deferred orphan TODO seeding for #$num ($tid)"
+							publication_deferred=$((publication_deferred + 1))
+							continue
+						fi
+						# t2698: seed a TODO.md entry for the open orphan
 						if _seed_orphan_todo_line "$num" "$tid" "$title" "$labels_json" "$todo_file" "${DRY_RUN:-}"; then
 							orphan_seeded=$((orphan_seeded + 1))
 						else
@@ -128,11 +144,8 @@ cmd_pull() {
 			fi
 		done < <(echo "$json" | jq -c '.[]' 2>/dev/null || true)
 	done
-	printf "\n=== Pull Summary ===\nRefs synced: %d | Assignees: %d | Orphans seeded: %d | Orphans skipped: %d\n" \
-		"$synced" "$assignee_synced" "$orphan_seeded" "$orphan_skipped"
-	printf "Orphans open: %d closed: %d\n" "$orphan_open" "$orphan_closed"
-	[[ $orphan_open -gt 0 ]] && print_warning "Open orphans: $orphan_list"
-	[[ $synced -eq 0 && $assignee_synced -eq 0 && $orphan_open -eq 0 ]] && print_success "TODO.md refs up to date"
+	_print_pull_summary "$synced" "$assignee_synced" "$orphan_seeded" "$orphan_skipped" \
+		"$orphan_open" "$orphan_closed" "$publication_deferred" "$orphan_list"
 	return 0
 }
 

--- a/.agents/scripts/issue-sync-helper-labels.sh
+++ b/.agents/scripts/issue-sync-helper-labels.sh
@@ -35,6 +35,15 @@ fi
 # GitHub API (gh CLI wrappers — kept for multi-call functions only)
 # =============================================================================
 
+_issue_labels_include_exact() {
+	local labels_json="$1" label_name="$2"
+	if printf '%s' "$labels_json" |
+		jq -e --arg label_name "$label_name" 'any(.[]?; .name == $label_name)' >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
 gh_list_issues() {
 	local repo="$1" state="$2" limit="$3"
 	local -a args=(

--- a/.agents/scripts/tests/test-issue-sync-pull-seeds-orphans.sh
+++ b/.agents/scripts/tests/test-issue-sync-pull-seeds-orphans.sh
@@ -5,11 +5,11 @@
 # Regression test for t2698: issue-sync-helper.sh pull must seed TODO.md
 # entries for open orphan GitHub issues instead of only reporting them.
 #
-# Tests the two new functions added to issue-sync-lib.sh:
+# Tests the orphan-seeding library functions and cmd_pull policy:
 #   _labels_json_to_tags()      — reverse-maps labels JSON to #tag tokens
 #   _seed_orphan_todo_line()    — idempotent TODO.md append for orphans
 #
-# Coverage matrix (7 cases from Acceptance criteria):
+# Coverage matrix:
 #   (a) open orphan is seeded with correct line
 #   (b) closed orphan is NOT seeded (handled by caller; lib skips none)
 #   (c) duplicate-run is a no-op (idempotency)
@@ -17,6 +17,10 @@
 #   (e) parent-task label → #parent tag (auto-dispatch maps independently)
 #   (f) dry-run emits "would seed" to stderr, TODO.md unchanged
 #   (g) missing task ID → seeding skipped with log
+#   (h) publication:pending open orphan → deferred without TODO mutation
+#   (i) near-match publication label → ordinary orphan seeding
+#   (j) publication:pending issue with a TODO row → ref sync proceeds
+#   (k) removing publication:pending → orphan seeding resumes
 set -euo pipefail
 
 PASS=0
@@ -27,6 +31,10 @@ FAIL=0
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=../issue-sync-lib.sh
 source "${SCRIPT_DIR}/issue-sync-lib.sh"
+# shellcheck source=../issue-sync-helper-labels.sh
+source "${SCRIPT_DIR}/issue-sync-helper-labels.sh"
+# shellcheck source=../issue-sync-helper-commands.sh
+source "${SCRIPT_DIR}/issue-sync-helper-commands.sh"
 
 # Stub for log_verbose — defined in issue-sync-helper.sh, not in the lib.
 # Tests source only the lib, so we provide a no-op here.
@@ -78,6 +86,27 @@ labels_json_of() {
 	return 0
 }
 
+run_pull_with_issues() {
+	local todo_file="$1" open_json="$2" closed_json="${3:-[]}" state=""
+	_CMD_REPO="owner/repo"
+	_CMD_TODO="$todo_file"
+	DRY_RUN="false"
+	_init_cmd() { return 0; }
+	gh_list_issues() {
+		local repo="$1" requested_state="$2" limit="$3"
+		: "$repo" "$limit"
+		if [[ "$requested_state" == "open" ]]; then
+			printf '%s\n' "$open_json"
+		else
+			printf '%s\n' "$closed_json"
+		fi
+		return 0
+	}
+	cmd_pull
+	state="$?"
+	return "$state"
+}
+
 # ─── (a) Open orphan seeded ──────────────────────────────────────────────────
 
 todo_a=$(make_todo)
@@ -101,15 +130,11 @@ check "$ok" "(a) open orphan seeded — #auto-dispatch tag present" "line: $seed
 
 rm -f "$todo_a"
 
-# ─── (b) Closed orphan not seeded (caller responsibility) ───────────────────
-# The caller (cmd_pull) only calls _seed_orphan_todo_line for open issues.
-# This test validates that the library function itself does NOT distinguish
-# open vs closed — that policy lives in cmd_pull.
-# We verify by simply NOT calling _seed_orphan_todo_line for a closed issue
-# and confirming no line appears.
+# ─── (b) Closed orphan not seeded ────────────────────────────────────────────
 
 todo_b=$(make_todo)
-# No call to _seed_orphan_todo_line — simulating caller's open-only guard.
+closed_issues_b='[{"number":20999,"title":"t9999: closed orphan","assignees":[],"labels":[]}]'
+run_pull_with_issues "$todo_b" '[]' "$closed_issues_b" >/dev/null
 closed_line=$(grep -E '^\- \[ \] t9999 ' "$todo_b" || echo "")
 [[ -z "$closed_line" ]] && ok=1 || ok=0
 check "$ok" "(b) closed orphan not seeded — no entry for t9999" "line: '$closed_line'"
@@ -214,6 +239,52 @@ check "$ok" "(g) empty task_id — no malformed entry seeded" \
 	"ret=$empty_ret bad_line='$bad_line'"
 
 rm -f "$todo_g"
+
+# ─── (h) Pending publication orphan is deferred ─────────────────────────────
+
+todo_h=$(make_todo)
+before_h=$(<"$todo_h")
+issues_h='[{"number":20800,"title":"t3000: pending planning publication","assignees":[],"labels":[{"name":"publication:pending"}]}]'
+output_h=$(run_pull_with_issues "$todo_h" "$issues_h" 2>&1)
+after_h=$(<"$todo_h")
+[[ "$before_h" == "$after_h" ]] && ok=1 || ok=0
+check "$ok" "(h) publication:pending orphan — TODO.md unchanged"
+printf '%s' "$output_h" | grep -q 'deferred orphan TODO seeding for #20800 (t3000)' && ok=1 || ok=0
+check "$ok" "(h) publication:pending orphan — issue identified in diagnostic" "output: $output_h"
+printf '%s' "$output_h" | grep -q 'Publication pending deferred: 1' && ok=1 || ok=0
+check "$ok" "(h) publication:pending orphan — deferred summary count is one" "output: $output_h"
+rm -f "$todo_h"
+
+# ─── (i) Exact label matching preserves ordinary orphan recovery ────────────
+
+todo_i=$(make_todo)
+issues_i='[{"number":20801,"title":"t3001: near-match publication label","assignees":[],"labels":[{"name":"publication:pending-later"}]}]'
+run_pull_with_issues "$todo_i" "$issues_i" >/dev/null
+grep -q 'ref:GH#20801' "$todo_i" && ok=1 || ok=0
+check "$ok" "(i) near-match publication label — orphan seeded normally"
+rm -f "$todo_i"
+
+# ─── (j) Existing TODO row synchronizes while publication is pending ────────
+
+todo_j=$(make_todo)
+printf '%s\n' '- [ ] t3002 canonical planning row' >>"$todo_j"
+issues_j='[{"number":20802,"title":"t3002: canonical planning row","assignees":[],"labels":[{"name":"publication:pending"}]}]'
+run_pull_with_issues "$todo_j" "$issues_j" >/dev/null
+grep -E '^\- \[ \] t3002 .*ref:GH#20802' "$todo_j" >/dev/null && ok=1 || ok=0
+check "$ok" "(j) publication:pending with existing row — ref synchronized"
+rm -f "$todo_j"
+
+# ─── (k) Removing pending label resumes orphan recovery ─────────────────────
+
+todo_k=$(make_todo)
+issues_k_pending='[{"number":20803,"title":"t3003: retry publication","assignees":[],"labels":[{"name":"publication:pending"}]}]'
+issues_k_ready='[{"number":20803,"title":"t3003: retry publication","assignees":[],"labels":[]}]'
+run_pull_with_issues "$todo_k" "$issues_k_pending" >/dev/null
+run_pull_with_issues "$todo_k" "$issues_k_ready" >/dev/null
+line_count=$(grep -c '^\- \[ \] t3003 .*ref:GH#20803' "$todo_k" 2>/dev/null || true)
+[[ "$line_count" -eq 1 ]] && ok=1 || ok=0
+check "$ok" "(k) pending label removed — orphan seeding resumes exactly once" "count=$line_count"
+rm -f "$todo_k"
 
 # ─── _labels_json_to_tags unit tests ────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Defer TODO orphan seeding for exact publication:pending labels, retain normal reference synchronization and orphan recovery, and document race-free creator behavior.

## Files Changed

.agents/reference/planning-publication-lifecycle.md, .agents/scripts/issue-sync-helper-commands.sh, .agents/scripts/issue-sync-helper-labels.sh, .agents/scripts/tests/test-issue-sync-pull-seeds-orphans.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused issue-sync pull regression suite (26 assertions), ShellCheck on changed issue-sync shell files, and .agents/scripts/linters-local.sh passed.

Resolves #29454


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.220 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 15m and 148,124 tokens on this as a headless worker.