### PR TITLE
GH#29455: Verify REST fallback PR labels

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -913,7 +913,8 @@ _rest_issue_edit() {
 		return 1
 	fi
 
-	local _issue_path="/repos/${repo}/issues/${num}"
+	local _issue_path=""
+	_issue_path=$(_rest_issue_api_path "$repo" "$num")
 	local has_deltas=0
 	if [[ ${#add_labels[@]} -gt 0 || ${#rm_labels[@]} -gt 0 ||
 		${#add_assignees[@]} -gt 0 || ${#rm_assignees[@]} -gt 0 ]]; then
@@ -935,23 +936,93 @@ _rest_issue_edit() {
 }
 
 #######################################
+# Build the REST issue API path shared by issue and PR operations.
+# Args: $1=repo_slug  $2=issue_or_pr_number
+# Outputs: API path
+#######################################
+_rest_issue_api_path() {
+	local repo="$1"
+	local num="$2"
+	printf '/repos/%s/issues/%s' "$repo" "$num"
+	return 0
+}
+
+#######################################
 # _rest_apply_labels: POST /repos/{owner}/{repo}/issues/{N}/labels.
-# PRs share GitHub's issues label endpoint. Best-effort — failures are
-# silently ignored (labels are non-critical metadata).
+# PRs share GitHub's issues label endpoint.
 #
 # Args: $1=repo_slug  $2=issue_or_pr_number  $3..=label names
-# Returns: 0 always
+# Returns: underlying API result (0 success, 1 failure)
 #######################################
 _rest_apply_labels() {
 	local repo="$1" num="$2"; shift 2
 	[[ $# -eq 0 || -z "$num" ]] && return 0
-	local -a label_args=(-X POST "/repos/${repo}/issues/${num}/labels")
+	local issue_path=""
+	issue_path=$(_rest_issue_api_path "$repo" "$num")
+	local -a label_args=(-X POST "${issue_path}/labels")
 	local _lbl
 	for _lbl in "$@"; do
 		[[ -n "$_lbl" ]] && label_args+=(-f "labels[]=${_lbl}")
 	done
-	gh api "${label_args[@]}" >/dev/null 2>&1 || true
+	_rest_api_call write gh api "${label_args[@]}" >/dev/null 2>&1 || return 1
 	return 0
+}
+
+#######################################
+# Verify that every requested label is present on an issue or PR.
+# Args: $1=repo_slug  $2=issue_or_pr_number  $3..=label names
+# Returns: 0 when all labels are present, 1 on read failure or missing labels.
+#######################################
+_rest_labels_are_present() {
+	local repo="$1" num="$2"; shift 2
+	[[ $# -eq 0 || -z "$num" ]] && return 0
+	local current_labels=""
+	local issue_path=""
+	issue_path=$(_rest_issue_api_path "$repo" "$num")
+	current_labels=$(_rest_api_call read gh api "$issue_path" --jq '.labels[].name' 2>/dev/null) || return 1
+	local expected=""
+	local current=""
+	local found=0
+	for expected in "$@"; do
+		[[ -n "$expected" ]] || continue
+		found=0
+		while IFS= read -r current || [[ -n "$current" ]]; do
+			if [[ "$current" == "$expected" ]]; then
+				found=1
+				break
+			fi
+		done <<<"$current_labels"
+		[[ $found -eq 1 ]] || return 1
+	done
+	return 0
+}
+
+#######################################
+# Apply and verify requested PR labels with bounded retries.
+# A PR already exists when this runs, so callers must not convert an exhausted
+# retry into a generic create failure that could cause a duplicate PR.
+# Args: $1=repo_slug  $2=pr_number  $3..=label names
+# Returns: 0 when verified, 1 when retries are exhausted.
+#######################################
+_rest_apply_labels_verified() {
+	local repo="$1" num="$2"; shift 2
+	[[ $# -eq 0 || -z "$num" ]] && return 0
+	local attempts="${AIDEVOPS_GH_REST_LABEL_ATTEMPTS:-3}"
+	local retry_delay="${AIDEVOPS_GH_REST_LABEL_RETRY_DELAY:-1}"
+	[[ "$attempts" =~ ^[1-5]$ ]] || attempts=3
+	[[ "$retry_delay" =~ ^[0-9]+$ ]] || retry_delay=1
+	local attempt=1
+	while [[ $attempt -le $attempts ]]; do
+		if _rest_apply_labels "$repo" "$num" "$@" \
+			&& _rest_labels_are_present "$repo" "$num" "$@"; then
+			return 0
+		fi
+		if [[ $attempt -lt $attempts && $retry_delay -gt 0 ]]; then
+			sleep "$retry_delay"
+		fi
+		attempt=$((attempt + 1))
+	done
+	return 1
 }
 
 #######################################
@@ -1091,14 +1162,17 @@ _rest_pr_create() {
 		return $rc
 	fi
 
-	printf '%s\n' "$html_url"
-
 	# Apply labels via the issues endpoint (PRs share it).
 	if [[ ${#labels[@]} -gt 0 ]]; then
 		local pr_number
 		pr_number=$(printf '%s' "$html_url" | grep -oE '[0-9]+$' || true)
-		[[ -n "$pr_number" ]] && _rest_apply_labels "$repo" "$pr_number" "${labels[@]}"
+		if [[ -z "$pr_number" ]]; then
+			printf '[aidevops] _rest_pr_create: created PR but could not resolve its number to verify requested labels\n' >&2
+		elif ! _rest_apply_labels_verified "$repo" "$pr_number" "${labels[@]}"; then
+			printf '[aidevops] _rest_pr_create: created PR #%s but could not verify requested labels after bounded retries; not retrying creation\n' "$pr_number" >&2
+		fi
 	fi
+	printf '%s\n' "$html_url"
 	return 0
 }
 
@@ -1166,7 +1240,8 @@ _rest_issue_view() {
 		return 2
 	fi
 
-	local _path="/repos/${repo}/issues/${num}"
+	local _path=""
+	_path=$(_rest_issue_api_path "$repo" "$num")
 	local _gh_cmd=(gh api "$_path")
 	if [[ -n "$json_fields" ]]; then
 		jq_expr="$(_rest_issue_object_json_jq "$json_fields" "$jq_expr")" || return 1

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -786,6 +786,55 @@ else
 fi
 
 # =============================================================================
+# Test 14b: requested PR labels are verified after application
+# =============================================================================
+: >"$GH_CALLS"
+export STUB_ISSUE_VIEW_FIXTURE='{"labels":[{"name":"origin:worker"},{"name":"auto-dispatch"}],"assignees":[]}'
+export AIDEVOPS_GH_REST_LABEL_RETRY_DELAY=0
+label_verify_stderr="${TMP}/pr-label-verify-success.stderr"
+_rest_pr_create \
+	--repo "owner/repo" \
+	--title "t9995: verified label test" \
+	--head "feature/t9995-verified-labels" \
+	--base "main" \
+	--label "origin:worker,auto-dispatch" >/dev/null 2>"$label_verify_stderr" || true
+
+if grep -qE '^api /repos/owner/repo/issues/[0-9]+ --jq \.labels\[\]\.name' "$GH_CALLS" 2>/dev/null &&
+	[[ ! -s "$label_verify_stderr" ]]; then
+	pass "_rest_pr_create verifies requested labels after REST application"
+else
+	fail "_rest_pr_create verifies requested labels after REST application" \
+		"GH_CALLS=$(cat "$GH_CALLS"); stderr=$(cat "$label_verify_stderr")"
+fi
+
+# =============================================================================
+# Test 14c: persistent label failure does not turn an existing PR into a retry
+# =============================================================================
+: >"$GH_CALLS"
+export STUB_REST_FAIL_MATCH='POST /repos/owner/repo/issues/9999/labels'
+label_failure_stderr="${TMP}/pr-label-verify-failure.stderr"
+label_failure_output=""
+label_failure_rc=0
+label_failure_output=$(_rest_pr_create \
+	--repo "owner/repo" \
+	--title "t9995: persistent label failure" \
+	--head "feature/t9995-persistent-label-failure" \
+	--base "main" \
+	--label "origin:worker" 2>"$label_failure_stderr") || label_failure_rc=$?
+pull_create_count=$(grep -cE '^api -X POST /repos/owner/repo/pulls' "$GH_CALLS" 2>/dev/null || true)
+label_apply_count=$(grep -cE '^api -X POST /repos/owner/repo/issues/9999/labels' "$GH_CALLS" 2>/dev/null || true)
+
+if [[ $label_failure_rc -eq 0 && "$label_failure_output" == "https://github.com/owner/repo/issues/9999" &&
+	"$pull_create_count" -eq 1 && "$label_apply_count" -eq 3 ]] &&
+	grep -q 'created PR #9999 but could not verify requested labels after bounded retries; not retrying creation' "$label_failure_stderr" 2>/dev/null; then
+	pass "_rest_pr_create surfaces label failure without risking duplicate PR creation"
+else
+	fail "_rest_pr_create surfaces label failure without risking duplicate PR creation" \
+		"rc=${label_failure_rc}; output=${label_failure_output}; pulls=${pull_create_count}; labels=${label_apply_count}; stderr=$(cat "$label_failure_stderr")"
+fi
+unset STUB_REST_FAIL_MATCH STUB_ISSUE_VIEW_FIXTURE AIDEVOPS_GH_REST_LABEL_RETRY_DELAY
+
+# =============================================================================
 # Test 15: gh_pr_comment → falls back to REST when primary fails AND exhausted
 # =============================================================================
 : >"$GH_CALLS"


### PR DESCRIPTION
## Summary

- Retry REST label application after creating a pull request.
- Verify every requested label before reporting success.
- Return the already-created PR URL on exhausted label retries so callers cannot create a duplicate PR.
- Centralize shared issue/PR REST paths.

## Files

- `.agents/scripts/shared-gh-wrappers-rest-fallback.sh`
- `.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh`

## Verification

- `.agents/scripts/linters-local.sh`
- `.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh` — 95/95 passed

Resolves #29455

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.220 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol
