### PR TITLE
t18193: Define provider-neutral team-interface core contracts

### DIFF
--- a/.agents/reference/team-interfaces.md
+++ b/.agents/reference/team-interfaces.md
@@ -1,0 +1,65 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Team-interface core contracts
+
+The team-interface core is the provider-neutral boundary between provider
+adapters, policy brokers, and consumers. Version 1 is defined by
+`schemas/team-interface/core-v1.schema.json` and supports closed `registry` and
+`event` documents. Existing Matrix, direct aidevops, and provider runtimes do
+not write this contract yet.
+
+## Ownership and configuration
+
+Dedicated versioned team-interface documents are authoritative for providers,
+accounts, identities, resources, capabilities, and normalized events. A future
+configuration task may add only enablement plus path or document references to
+`config.jsonc`; rich provider or team state does not belong there.
+
+The core owns normalized identifiers, capability declarations, resource
+relationships, verified actor context, requested authority, and event
+correlation. Adapters own provider-specific extraction and preserve raw source
+evidence outside the core. Policy brokers supply verified actor and authority
+inputs. Model output cannot mint, widen, or replace either input.
+
+Credentials are references only. `credential_ref` and `secret_ref` identify
+values held in approved secret storage; neither adapters nor documents place a
+token, password, private key, credential value, or secret value in this
+contract.
+
+## Identifiers and labels
+
+- Stable internal IDs survive provider renames and are used for joins,
+  authorization, correlation, and ownership.
+- A provider's opaque external ID is retained exactly as observed. Consumers
+  must not parse it or infer authority from its shape.
+- Display labels are non-authoritative presentation fields. A display name
+  cannot establish identity, ownership, or permission.
+- Provider and adapter versions describe observed software. `schema_version`
+  independently selects normalized contract semantics.
+- Event retries reuse the provider event ID, stable event ID, correlation ID,
+  and idempotency key.
+
+## Capabilities and compatibility
+
+Capability negotiation starts from each provider's declared resource kinds,
+operations, availability, and owner-review requirement. An unavailable,
+unknown, degraded, or unsupported capability never broadens authority.
+
+Compatibility detail belongs to a separate versioned document. The core carries
+only a bounded state, stable reference, and optional human-readable summary so
+consumers can fail closed while resolving richer evidence independently.
+
+## Events and extensions
+
+Inbox and outbox events use the same normalized envelope. It records provider
+and event lineage, immutable deduplication inputs, a verified actor, explicit
+targets, bounded content and attachment metadata, requested operation,
+broker-supplied authority scope, trust and scan evidence references, and
+occurrence time. Persistence must validate the complete document first.
+
+Every object is closed except the explicitly bounded scalar metadata maps.
+Provider-specific fields are not schema extensions: adapters preserve them as
+opaque source evidence referenced by stable evidence identifiers. Adding a core
+field requires a new compatible schema version or an explicit migration plan;
+unknown versions and unknown properties are rejected rather than reinterpreted.

--- a/.agents/schemas/team-interface/core-v1.schema.json
+++ b/.agents/schemas/team-interface/core-v1.schema.json
@@ -1,0 +1,315 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:aidevops:team-interface:core:v1",
+  "title": "aidevops team-interface core contract v1",
+  "oneOf": [
+    {"$ref": "#/$defs/registry_document"},
+    {"$ref": "#/$defs/event_document"}
+  ],
+  "$defs": {
+    "stable_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/-]*$"
+    },
+    "opaque_external_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024
+    },
+    "reference_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512
+    },
+    "subject_type": {
+      "enum": ["human", "agent", "service"]
+    },
+    "resource_kind": {
+      "enum": ["community", "channel", "conversation", "thread", "direct_message", "group", "other"]
+    },
+    "capability_operation": {
+      "enum": ["discover", "read", "create", "update", "delete", "moderate", "invite", "send", "receive"]
+    },
+    "verification_state": {
+      "enum": ["verified", "unverified", "revoked"]
+    },
+    "compatibility_state": {
+      "enum": ["compatible", "degraded", "unsupported", "unknown"]
+    },
+    "compatibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "reference"],
+      "properties": {
+        "state": {"$ref": "#/$defs/compatibility_state"},
+        "reference": {"$ref": "#/$defs/reference_id"},
+        "summary": {"type": "string", "minLength": 1, "maxLength": 500}
+      }
+    },
+    "capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capability_id", "resource_kinds", "operations", "availability", "owner_review_required"],
+      "properties": {
+        "capability_id": {"$ref": "#/$defs/stable_id"},
+        "resource_kinds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/resource_kind"}
+        },
+        "operations": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/capability_operation"}
+        },
+        "availability": {"enum": ["available", "degraded", "unavailable", "unknown"]},
+        "owner_review_required": {"type": "boolean"}
+      }
+    },
+    "provider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider_id", "adapter_id", "adapter_version", "provider_version", "capabilities", "compatibility"],
+      "properties": {
+        "provider_id": {"$ref": "#/$defs/stable_id"},
+        "adapter_id": {"$ref": "#/$defs/stable_id"},
+        "adapter_version": {"type": "string", "minLength": 1, "maxLength": 100},
+        "provider_version": {"type": "string", "minLength": 1, "maxLength": 100},
+        "capabilities": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/capability"}
+        },
+        "compatibility": {"$ref": "#/$defs/compatibility"}
+      }
+    },
+    "community": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["community_id", "provider_id", "provider_external_id", "account_refs", "display_label"],
+      "properties": {
+        "community_id": {"$ref": "#/$defs/stable_id"},
+        "provider_id": {"$ref": "#/$defs/stable_id"},
+        "provider_external_id": {"$ref": "#/$defs/opaque_external_id"},
+        "account_refs": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/stable_id"}
+        },
+        "display_label": {"type": "string", "minLength": 1, "maxLength": 255}
+      }
+    },
+    "account": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["account_id", "provider_id", "provider_external_id", "credential_ref", "display_label"],
+      "properties": {
+        "account_id": {"$ref": "#/$defs/stable_id"},
+        "provider_id": {"$ref": "#/$defs/stable_id"},
+        "provider_external_id": {"$ref": "#/$defs/opaque_external_id"},
+        "credential_ref": {"$ref": "#/$defs/reference_id"},
+        "display_label": {"type": "string", "minLength": 1, "maxLength": 255}
+      }
+    },
+    "identity_verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "method", "evidence_ref"],
+      "properties": {
+        "status": {
+          "allOf": [
+            {"$ref": "#/$defs/verification_state"},
+            {"const": "verified"}
+          ]
+        },
+        "method": {"enum": ["provider_signature", "provider_session", "broker_attestation", "manual_owner_review"]},
+        "evidence_ref": {"$ref": "#/$defs/reference_id"}
+      }
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["identity_id", "subject_id", "subject_type", "provider_identity_id", "provider_id", "community_id", "provider_external_id", "display_label", "verification"],
+      "properties": {
+        "identity_id": {"$ref": "#/$defs/stable_id"},
+        "subject_id": {"$ref": "#/$defs/stable_id"},
+        "subject_type": {"$ref": "#/$defs/subject_type"},
+        "provider_identity_id": {"$ref": "#/$defs/stable_id"},
+        "provider_id": {"$ref": "#/$defs/stable_id"},
+        "community_id": {"$ref": "#/$defs/stable_id"},
+        "provider_external_id": {"$ref": "#/$defs/opaque_external_id"},
+        "display_label": {"type": "string", "minLength": 1, "maxLength": 255},
+        "verification": {"$ref": "#/$defs/identity_verification"},
+        "secret_ref": {"$ref": "#/$defs/reference_id"}
+      }
+    },
+    "resource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["resource_id", "provider_id", "community_id", "provider_external_id", "kind", "display_label", "management_owner", "compatibility"],
+      "properties": {
+        "resource_id": {"$ref": "#/$defs/stable_id"},
+        "provider_id": {"$ref": "#/$defs/stable_id"},
+        "community_id": {"$ref": "#/$defs/stable_id"},
+        "provider_external_id": {"$ref": "#/$defs/opaque_external_id"},
+        "kind": {"$ref": "#/$defs/resource_kind"},
+        "parent_resource_id": {"$ref": "#/$defs/stable_id"},
+        "display_label": {"type": "string", "minLength": 1, "maxLength": 255},
+        "management_owner": {"$ref": "#/$defs/stable_id"},
+        "compatibility": {"$ref": "#/$defs/compatibility"}
+      }
+    },
+    "registry_document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "document_type", "registry_id", "providers", "communities", "accounts", "identities", "resources"],
+      "properties": {
+        "schema_version": {"const": 1},
+        "document_type": {"const": "registry"},
+        "registry_id": {"$ref": "#/$defs/stable_id"},
+        "providers": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/provider"}},
+        "communities": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/community"}},
+        "accounts": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/account"}},
+        "identities": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/identity"}},
+        "resources": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/resource"}}
+      }
+    },
+    "event_lineage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["community_id", "conversation_resource_id", "provider_event_id"],
+      "properties": {
+        "community_id": {"$ref": "#/$defs/stable_id"},
+        "conversation_resource_id": {"$ref": "#/$defs/stable_id"},
+        "thread_resource_id": {"$ref": "#/$defs/stable_id"},
+        "provider_event_id": {"$ref": "#/$defs/opaque_external_id"},
+        "parent_event_id": {"$ref": "#/$defs/stable_id"}
+      }
+    },
+    "verified_actor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["subject_id", "subject_type", "roles", "verification", "signature_status"],
+      "properties": {
+        "subject_id": {"$ref": "#/$defs/stable_id"},
+        "subject_type": {"$ref": "#/$defs/subject_type"},
+        "roles": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1, "maxLength": 100}
+        },
+        "verification": {"$ref": "#/$defs/identity_verification"},
+        "signature_status": {"enum": ["verified", "failed", "not_present"]}
+      }
+    },
+    "bounded_metadata": {
+      "type": "object",
+      "maxProperties": 16,
+      "propertyNames": {
+        "allOf": [
+          {"pattern": "^[a-z][a-z0-9_]{0,63}$"},
+          {"not": {"pattern": "(^|_)(token|password|private_key|credential_value|secret_value)($|_)"}}
+        ]
+      },
+      "additionalProperties": {
+        "anyOf": [
+          {"type": "string", "maxLength": 1000},
+          {"type": ["number", "boolean", "null"]}
+        ]
+      }
+    },
+    "attachment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["attachment_id", "media_type", "size_bytes", "digest", "metadata"],
+      "properties": {
+        "attachment_id": {"$ref": "#/$defs/stable_id"},
+        "media_type": {"type": "string", "minLength": 1, "maxLength": 255},
+        "size_bytes": {"type": "integer", "minimum": 0, "maximum": 1073741824},
+        "display_name": {"type": "string", "minLength": 1, "maxLength": 255},
+        "digest": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["algorithm", "value"],
+          "properties": {
+            "algorithm": {"const": "sha256"},
+            "value": {"type": "string", "pattern": "^[a-fA-F0-9]{64}$"}
+          }
+        },
+        "metadata": {"$ref": "#/$defs/bounded_metadata"}
+      }
+    },
+    "event_content": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["content_type", "attachments", "metadata"],
+      "properties": {
+        "content_type": {"type": "string", "minLength": 1, "maxLength": 255},
+        "text": {"type": "string", "maxLength": 100000},
+        "attachments": {"type": "array", "maxItems": 100, "items": {"$ref": "#/$defs/attachment"}},
+        "metadata": {"$ref": "#/$defs/bounded_metadata"}
+      }
+    },
+    "event_target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["agent_ref", "app_team_ref"],
+      "properties": {
+        "agent_ref": {"$ref": "#/$defs/reference_id"},
+        "app_team_ref": {"$ref": "#/$defs/reference_id"}
+      }
+    },
+    "authority_scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scopes", "broker_decision_ref"],
+      "properties": {
+        "scopes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1, "maxLength": 255}
+        },
+        "broker_decision_ref": {"$ref": "#/$defs/reference_id"}
+      }
+    },
+    "normalized_event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["event_id", "direction", "provider_id", "provider_version", "lineage", "verified_actor", "target", "content", "requested_operation", "authority_scope", "trust_profile_ref", "scan_verdict_ref", "correlation_id", "idempotency_key", "occurred_at"],
+      "properties": {
+        "event_id": {"$ref": "#/$defs/stable_id"},
+        "direction": {"enum": ["inbox", "outbox"]},
+        "provider_id": {"$ref": "#/$defs/stable_id"},
+        "provider_version": {"type": "string", "minLength": 1, "maxLength": 100},
+        "lineage": {"$ref": "#/$defs/event_lineage"},
+        "verified_actor": {"$ref": "#/$defs/verified_actor"},
+        "target": {"$ref": "#/$defs/event_target"},
+        "content": {"$ref": "#/$defs/event_content"},
+        "requested_operation": {"$ref": "#/$defs/capability_operation"},
+        "authority_scope": {"$ref": "#/$defs/authority_scope"},
+        "trust_profile_ref": {"$ref": "#/$defs/reference_id"},
+        "scan_verdict_ref": {"$ref": "#/$defs/reference_id"},
+        "correlation_id": {"$ref": "#/$defs/stable_id"},
+        "idempotency_key": {"$ref": "#/$defs/stable_id"},
+        "occurred_at": {"type": "string", "format": "date-time"}
+      }
+    },
+    "event_document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "document_type", "event"],
+      "properties": {
+        "schema_version": {"const": 1},
+        "document_type": {"const": "event"},
+        "event": {"$ref": "#/$defs/normalized_event"}
+      }
+    }
+  }
+}

--- a/.agents/scripts/tests/fixtures/team-interface/core-invalid-event.json
+++ b/.agents/scripts/tests/fixtures/team-interface/core-invalid-event.json
@@ -1,0 +1,103 @@
+{
+  "cases": [
+    {
+      "missing": "correlation_id",
+      "document": {
+        "schema_version": 1,
+        "document_type": "event",
+        "event": {
+          "event_id": "event.missing.correlation",
+          "direction": "inbox",
+          "provider_id": "matrix",
+          "provider_version": "v1.13",
+          "lineage": {
+            "community_id": "community.matrix.primary",
+            "conversation_resource_id": "resource.matrix.channel",
+            "provider_event_id": "$missing-correlation"
+          },
+          "verified_actor": {
+            "subject_id": "subject.alice",
+            "subject_type": "human",
+            "roles": ["owner"],
+            "verification": {"status": "verified", "method": "provider_signature", "evidence_ref": "evidence:event:1"},
+            "signature_status": "verified"
+          },
+          "target": {"agent_ref": "agent:build", "app_team_ref": "app-team:ops"},
+          "content": {"content_type": "text/plain", "attachments": [], "metadata": {}},
+          "requested_operation": "read",
+          "authority_scope": {"scopes": ["resource:read"], "broker_decision_ref": "authority:1"},
+          "trust_profile_ref": "trust:standard",
+          "scan_verdict_ref": "scan:1",
+          "idempotency_key": "idempotency.event.1",
+          "occurred_at": "2026-08-04T20:00:00Z"
+        }
+      }
+    },
+    {
+      "missing": "idempotency_key",
+      "document": {
+        "schema_version": 1,
+        "document_type": "event",
+        "event": {
+          "event_id": "event.missing.idempotency",
+          "direction": "inbox",
+          "provider_id": "matrix",
+          "provider_version": "v1.13",
+          "lineage": {
+            "community_id": "community.matrix.primary",
+            "conversation_resource_id": "resource.matrix.channel",
+            "provider_event_id": "$missing-idempotency"
+          },
+          "verified_actor": {
+            "subject_id": "subject.alice",
+            "subject_type": "human",
+            "roles": ["owner"],
+            "verification": {"status": "verified", "method": "provider_signature", "evidence_ref": "evidence:event:2"},
+            "signature_status": "verified"
+          },
+          "target": {"agent_ref": "agent:build", "app_team_ref": "app-team:ops"},
+          "content": {"content_type": "text/plain", "attachments": [], "metadata": {}},
+          "requested_operation": "read",
+          "authority_scope": {"scopes": ["resource:read"], "broker_decision_ref": "authority:2"},
+          "trust_profile_ref": "trust:standard",
+          "scan_verdict_ref": "scan:2",
+          "correlation_id": "correlation.event.2",
+          "occurred_at": "2026-08-04T20:00:00Z"
+        }
+      }
+    },
+    {
+      "missing": "authority_scope",
+      "document": {
+        "schema_version": 1,
+        "document_type": "event",
+        "event": {
+          "event_id": "event.missing.authority",
+          "direction": "outbox",
+          "provider_id": "buzz",
+          "provider_version": "0afeac8",
+          "lineage": {
+            "community_id": "community.buzz.primary",
+            "conversation_resource_id": "resource.buzz.conversation",
+            "provider_event_id": "event/opaque-missing-authority"
+          },
+          "verified_actor": {
+            "subject_id": "subject.agent.primary",
+            "subject_type": "agent",
+            "roles": ["assistant"],
+            "verification": {"status": "verified", "method": "broker_attestation", "evidence_ref": "evidence:event:3"},
+            "signature_status": "not_present"
+          },
+          "target": {"agent_ref": "agent:build", "app_team_ref": "app-team:ops"},
+          "content": {"content_type": "text/plain", "attachments": [], "metadata": {}},
+          "requested_operation": "send",
+          "trust_profile_ref": "trust:restricted",
+          "scan_verdict_ref": "scan:3",
+          "correlation_id": "correlation.event.3",
+          "idempotency_key": "idempotency.event.3",
+          "occurred_at": "2026-08-04T20:00:00Z"
+        }
+      }
+    }
+  ]
+}

--- a/.agents/scripts/tests/fixtures/team-interface/core-invalid-identity.json
+++ b/.agents/scripts/tests/fixtures/team-interface/core-invalid-identity.json
@@ -1,0 +1,40 @@
+{
+  "cases": [
+    {
+      "schema_version": 1,
+      "document_type": "registry",
+      "registry_id": "registry.display-name-negative",
+      "providers": [],
+      "communities": [],
+      "accounts": [],
+      "identities": [{"display_label": "Mutable name only"}],
+      "resources": []
+    },
+    {
+      "schema_version": 1,
+      "document_type": "registry",
+      "registry_id": "registry.unverified-negative",
+      "providers": [],
+      "communities": [],
+      "accounts": [],
+      "identities": [
+        {
+          "identity_id": "identity.unverified",
+          "subject_id": "subject.unknown",
+          "subject_type": "human",
+          "provider_identity_id": "provider-identity.unverified",
+          "provider_id": "matrix",
+          "community_id": "community.matrix.primary",
+          "provider_external_id": "@unknown:example.invalid",
+          "display_label": "Unknown",
+          "verification": {
+            "status": "unverified",
+            "method": "provider_session",
+            "evidence_ref": "evidence:matrix:unknown"
+          }
+        }
+      ],
+      "resources": []
+    }
+  ]
+}

--- a/.agents/scripts/tests/fixtures/team-interface/core-invalid-secret-value.json
+++ b/.agents/scripts/tests/fixtures/team-interface/core-invalid-secret-value.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "document_type": "registry",
+  "registry_id": "registry.secret-negative",
+  "providers": [
+    {
+      "provider_id": "matrix",
+      "adapter_id": "adapter.matrix",
+      "adapter_version": "1.0.0",
+      "provider_version": "v1.13",
+      "capabilities": [
+        {
+          "capability_id": "matrix.messaging",
+          "resource_kinds": ["channel"],
+          "operations": ["send"],
+          "availability": "available",
+          "owner_review_required": false
+        }
+      ],
+      "compatibility": {"state": "compatible", "reference": "compatibility:matrix:v1.13"},
+      "credential_value": "forbidden-placeholder"
+    }
+  ],
+  "communities": [],
+  "accounts": [],
+  "identities": [],
+  "resources": []
+}

--- a/.agents/scripts/tests/fixtures/team-interface/core-valid.json
+++ b/.agents/scripts/tests/fixtures/team-interface/core-valid.json
@@ -1,0 +1,263 @@
+{
+  "documents": [
+    {
+      "schema_version": 1,
+      "document_type": "registry",
+      "registry_id": "registry.primary",
+      "providers": [
+        {
+          "provider_id": "buzz",
+          "adapter_id": "adapter.buzz",
+          "adapter_version": "1.0.0",
+          "provider_version": "0afeac8",
+          "capabilities": [
+            {
+              "capability_id": "buzz.messaging",
+              "resource_kinds": ["community", "conversation", "thread"],
+              "operations": ["discover", "read", "send", "receive"],
+              "availability": "available",
+              "owner_review_required": false
+            }
+          ],
+          "compatibility": {
+            "state": "compatible",
+            "reference": "compatibility:buzz:0afeac8",
+            "summary": "Reviewed adapter baseline"
+          }
+        },
+        {
+          "provider_id": "matrix",
+          "adapter_id": "adapter.matrix",
+          "adapter_version": "1.0.0",
+          "provider_version": "v1.13",
+          "capabilities": [
+            {
+              "capability_id": "matrix.messaging",
+              "resource_kinds": ["community", "channel", "thread", "direct_message"],
+              "operations": ["discover", "read", "create", "send", "receive", "invite"],
+              "availability": "degraded",
+              "owner_review_required": true
+            }
+          ],
+          "compatibility": {
+            "state": "degraded",
+            "reference": "compatibility:matrix:v1.13"
+          }
+        }
+      ],
+      "communities": [
+        {
+          "community_id": "community.buzz.primary",
+          "provider_id": "buzz",
+          "provider_external_id": "workspace/01J-opaque",
+          "account_refs": ["account.buzz.bot"],
+          "display_label": "Buzz workspace"
+        },
+        {
+          "community_id": "community.matrix.primary",
+          "provider_id": "matrix",
+          "provider_external_id": "!opaque:example.invalid",
+          "account_refs": ["account.matrix.bot"],
+          "display_label": "Matrix space"
+        }
+      ],
+      "accounts": [
+        {
+          "account_id": "account.buzz.bot",
+          "provider_id": "buzz",
+          "provider_external_id": "managed-agent/opaque-7",
+          "credential_ref": "secret-store:buzz-bot",
+          "display_label": "Buzz agent account"
+        },
+        {
+          "account_id": "account.matrix.bot",
+          "provider_id": "matrix",
+          "provider_external_id": "@agent:example.invalid",
+          "credential_ref": "secret-store:matrix-bot",
+          "display_label": "Matrix agent account"
+        }
+      ],
+      "identities": [
+        {
+          "identity_id": "identity.alice.buzz",
+          "subject_id": "subject.alice",
+          "subject_type": "human",
+          "provider_identity_id": "provider-identity.alice.buzz",
+          "provider_id": "buzz",
+          "community_id": "community.buzz.primary",
+          "provider_external_id": "user/opaque-alice",
+          "display_label": "Alice",
+          "verification": {
+            "status": "verified",
+            "method": "broker_attestation",
+            "evidence_ref": "evidence:buzz:alice:1"
+          }
+        },
+        {
+          "identity_id": "identity.agent.matrix",
+          "subject_id": "subject.agent.primary",
+          "subject_type": "agent",
+          "provider_identity_id": "provider-identity.agent.matrix",
+          "provider_id": "matrix",
+          "community_id": "community.matrix.primary",
+          "provider_external_id": "@agent:example.invalid",
+          "display_label": "Build agent",
+          "verification": {
+            "status": "verified",
+            "method": "provider_session",
+            "evidence_ref": "evidence:matrix:agent:1"
+          },
+          "secret_ref": "secret-store:matrix-session"
+        }
+      ],
+      "resources": [
+        {
+          "resource_id": "resource.buzz.conversation",
+          "provider_id": "buzz",
+          "community_id": "community.buzz.primary",
+          "provider_external_id": "conversation/opaque-main",
+          "kind": "conversation",
+          "display_label": "Engineering",
+          "management_owner": "subject.alice",
+          "compatibility": {
+            "state": "compatible",
+            "reference": "compatibility:buzz:conversation"
+          }
+        },
+        {
+          "resource_id": "resource.buzz.thread",
+          "provider_id": "buzz",
+          "community_id": "community.buzz.primary",
+          "provider_external_id": "thread/opaque-child",
+          "kind": "thread",
+          "parent_resource_id": "resource.buzz.conversation",
+          "display_label": "Release thread",
+          "management_owner": "subject.alice",
+          "compatibility": {
+            "state": "compatible",
+            "reference": "compatibility:buzz:thread"
+          }
+        },
+        {
+          "resource_id": "resource.matrix.channel",
+          "provider_id": "matrix",
+          "community_id": "community.matrix.primary",
+          "provider_external_id": "!opaque-room:example.invalid",
+          "kind": "channel",
+          "display_label": "Operations",
+          "management_owner": "subject.alice",
+          "compatibility": {
+            "state": "degraded",
+            "reference": "compatibility:matrix:room"
+          }
+        }
+      ]
+    },
+    {
+      "schema_version": 1,
+      "document_type": "event",
+      "event": {
+        "event_id": "event.buzz.in.001",
+        "direction": "inbox",
+        "provider_id": "buzz",
+        "provider_version": "0afeac8",
+        "lineage": {
+          "community_id": "community.buzz.primary",
+          "conversation_resource_id": "resource.buzz.conversation",
+          "thread_resource_id": "resource.buzz.thread",
+          "provider_event_id": "event/opaque-in-001",
+          "parent_event_id": "event.buzz.in.000"
+        },
+        "verified_actor": {
+          "subject_id": "subject.alice",
+          "subject_type": "human",
+          "roles": ["owner", "maintainer"],
+          "verification": {
+            "status": "verified",
+            "method": "provider_signature",
+            "evidence_ref": "evidence:buzz:event:001"
+          },
+          "signature_status": "verified"
+        },
+        "target": {
+          "agent_ref": "agent:build-primary",
+          "app_team_ref": "app-team:engineering"
+        },
+        "content": {
+          "content_type": "text/markdown",
+          "text": "Review the release plan.",
+          "attachments": [
+            {
+              "attachment_id": "attachment.plan",
+              "media_type": "application/pdf",
+              "size_bytes": 2048,
+              "display_name": "plan.pdf",
+              "digest": {
+                "algorithm": "sha256",
+                "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              },
+              "metadata": {"page_count": 2}
+            }
+          ],
+          "metadata": {"source_format": "markdown"}
+        },
+        "requested_operation": "read",
+        "authority_scope": {
+          "scopes": ["resource.buzz.thread:read"],
+          "broker_decision_ref": "authority-decision:buzz:001"
+        },
+        "trust_profile_ref": "trust-profile:standard",
+        "scan_verdict_ref": "scan-verdict:buzz:001",
+        "correlation_id": "correlation.release.001",
+        "idempotency_key": "idempotency.buzz.001",
+        "occurred_at": "2026-08-04T20:00:00Z"
+      }
+    },
+    {
+      "schema_version": 1,
+      "document_type": "event",
+      "event": {
+        "event_id": "event.matrix.out.001",
+        "direction": "outbox",
+        "provider_id": "matrix",
+        "provider_version": "v1.13",
+        "lineage": {
+          "community_id": "community.matrix.primary",
+          "conversation_resource_id": "resource.matrix.channel",
+          "provider_event_id": "$opaque-out-001"
+        },
+        "verified_actor": {
+          "subject_id": "subject.agent.primary",
+          "subject_type": "agent",
+          "roles": ["assistant"],
+          "verification": {
+            "status": "verified",
+            "method": "broker_attestation",
+            "evidence_ref": "evidence:broker:agent:001"
+          },
+          "signature_status": "not_present"
+        },
+        "target": {
+          "agent_ref": "agent:build-primary",
+          "app_team_ref": "app-team:operations"
+        },
+        "content": {
+          "content_type": "text/plain",
+          "text": "Release plan reviewed.",
+          "attachments": [],
+          "metadata": {}
+        },
+        "requested_operation": "send",
+        "authority_scope": {
+          "scopes": ["resource.matrix.channel:send"],
+          "broker_decision_ref": "authority-decision:matrix:001"
+        },
+        "trust_profile_ref": "trust-profile:restricted",
+        "scan_verdict_ref": "scan-verdict:matrix:001",
+        "correlation_id": "correlation.release.001",
+        "idempotency_key": "idempotency.matrix.001",
+        "occurred_at": "2026-08-04T20:01:00Z"
+      }
+    }
+  ]
+}

--- a/.agents/scripts/tests/test-team-interface-core-schema.mjs
+++ b/.agents/scripts/tests/test-team-interface-core-schema.mjs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv2020 from "ajv/dist/2020.js";
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const schemaPath = path.join(testDirectory, "../../schemas/team-interface/core-v1.schema.json");
+const fixtureDirectory = path.join(testDirectory, "fixtures/team-interface");
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function formatErrors(errors) {
+  return (errors || [])
+    .map((error) => `${error.instancePath || "<root>"} ${error.keyword}: ${error.message}`)
+    .join("\n");
+}
+
+function assertInvalid(validate, document, label, predicate) {
+  assert.equal(validate(document), false, `${label} unexpectedly validated`);
+  assert.ok(predicate(validate.errors || []), `${label} failed for the wrong reason:\n${formatErrors(validate.errors)}`);
+}
+
+function assertSchemaHasNoSecretValueProperties(value, location = "<root>") {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertSchemaHasNoSecretValueProperties(item, `${location}/${index}`));
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+
+  if (value.properties) {
+    for (const propertyName of Object.keys(value.properties)) {
+      assert.doesNotMatch(
+        propertyName,
+        /^(token|password|private[_-]?key|credential[_-]?value|secret[_-]?value)$/i,
+        `secret-value property exposed at ${location}/properties/${propertyName}`,
+      );
+    }
+  }
+  for (const [key, child] of Object.entries(value)) {
+    assertSchemaHasNoSecretValueProperties(child, `${location}/${key}`);
+  }
+}
+
+const schema = readJson(schemaPath);
+assert.equal(schema.$schema, "https://json-schema.org/draft/2020-12/schema");
+assert.equal(schema.$id, "urn:aidevops:team-interface:core:v1");
+assertSchemaHasNoSecretValueProperties(schema);
+
+const ajv = new Ajv2020({allErrors: true, strict: false, validateFormats: false});
+const validate = ajv.compile(schema);
+const validFixture = readJson(path.join(fixtureDirectory, "core-valid.json"));
+
+for (const [index, document] of validFixture.documents.entries()) {
+  assert.equal(validate(document), true, `valid document ${index} failed:\n${formatErrors(validate.errors)}`);
+}
+assert.deepEqual(
+  validFixture.documents.filter((document) => document.document_type === "event").map((document) => document.event.direction).sort(),
+  ["inbox", "outbox"],
+);
+
+const invalidSecret = readJson(path.join(fixtureDirectory, "core-invalid-secret-value.json"));
+assertInvalid(
+  validate,
+  invalidSecret,
+  "core-invalid-secret-value",
+  (errors) => errors.some((error) => error.keyword === "additionalProperties" && error.params.additionalProperty === "credential_value"),
+);
+
+const secretBearingMetadata = structuredClone(validFixture.documents[1]);
+secretBearingMetadata.event.content.metadata.access_token = "forbidden-placeholder";
+assertInvalid(
+  validate,
+  secretBearingMetadata,
+  "secret-bearing metadata",
+  (errors) => errors.some(
+    (error) => error.keyword === "propertyNames"
+      && error.instancePath === "/event/content/metadata"
+      && error.params.propertyName === "access_token",
+  ),
+);
+
+const invalidIdentities = readJson(path.join(fixtureDirectory, "core-invalid-identity.json"));
+assertInvalid(
+  validate,
+  invalidIdentities.cases[0],
+  "core-invalid-identity display-name-only",
+  (errors) => errors.some((error) => error.keyword === "required" && error.instancePath.includes("/identities/0")),
+);
+assertInvalid(
+  validate,
+  invalidIdentities.cases[1],
+  "core-invalid-identity unverified",
+  (errors) => errors.some((error) => error.keyword === "const" && error.instancePath.endsWith("/verification/status")),
+);
+
+const invalidEvents = readJson(path.join(fixtureDirectory, "core-invalid-event.json"));
+for (const invalidEvent of invalidEvents.cases) {
+  assertInvalid(
+    validate,
+    invalidEvent.document,
+    `core-invalid-event missing ${invalidEvent.missing}`,
+    (errors) => errors.some(
+      (error) => error.keyword === "required"
+        && error.instancePath === "/event"
+        && error.params.missingProperty === invalidEvent.missing,
+    ),
+  );
+}
+
+const unknownVersion = structuredClone(validFixture.documents[0]);
+unknownVersion.schema_version = 2;
+assertInvalid(
+  validate,
+  unknownVersion,
+  "unknown schema version",
+  (errors) => errors.some((error) => error.keyword === "const" && error.instancePath === "/schema_version"),
+);
+
+const unknownProperty = structuredClone(validFixture.documents[1]);
+unknownProperty.event.provider_payload = {};
+assertInvalid(
+  validate,
+  unknownProperty,
+  "unknown event property",
+  (errors) => errors.some(
+    (error) => error.keyword === "additionalProperties"
+      && error.instancePath === "/event"
+      && error.params.additionalProperty === "provider_payload",
+  ),
+);
+
+console.log("PASS: team-interface core schema accepts provider-neutral records and rejects unsafe inputs");


### PR DESCRIPTION
## Summary

Recover PR #29499, preserve the provider-neutral core contract, and rebase it onto current main so Qlty compares the exact seven-file change instead of a stale whole-tree head

## Files Changed

.agents/reference/team-interfaces.md, .agents/schemas/team-interface/core-v1.schema.json, .agents/scripts/tests/fixtures/team-interface/core-invalid-event.json, .agents/scripts/tests/fixtures/team-interface/core-invalid-identity.json, .agents/scripts/tests/fixtures/team-interface/core-invalid-secret-value.json, .agents/scripts/tests/fixtures/team-interface/core-valid.json, .agents/scripts/tests/test-team-interface-core-schema.mjs

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Ajv 8.20.0 focused schema tests, import probe, root TypeScript check, changed-file lint and secret scan, diff checks, and unchanged-runtime assertions pass

Resolves #29494


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.220 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 33m and 358,897 tokens on this as a headless worker.