### PR TITLE
t18196: Define isolated app-team manifest contracts

### DIFF
--- a/.agents/reference/team-interface-app-teams.md
+++ b/.agents/reference/team-interface-app-teams.md
@@ -1,0 +1,99 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# App-Team Manifests
+
+`.agents/schemas/team-interface/app-team-v1.schema.json` defines portable,
+provider-neutral desired state for application teams. It references the stable
+identity, capability, resource, and reference primitives in
+`urn:aidevops:team-interface:core:v1`; it does not duplicate those records or
+provision runtime state.
+
+## Mode selection
+
+| Mode | Select when | Mutable state | Publication identity |
+|---|---|---|---|
+| `dedicated` | A specialist is a long-lived member of one app team. | Unique identity, memory namespace, registered workspace roots, and approved secret references. | Specialist identity with the initiating actor in audit context. |
+| `cloned` | A versioned specialist template is reused as a new long-lived app teammate. | The same isolation as dedicated mode, plus an immutable template-instance reference and `inherited_mutable_state: false`. | New clone identity with the initiating actor; never the source instance identity. |
+| `shared` | A team invokes a reusable capability for one request. | Stateless; memory is `none` or request-scoped. Workspaces and credentials are supplied through scoped policies and brokers. | Caller/team identity, capability, and initiating actor. It is not a persistent teammate. |
+
+Choose `shared` only when the result can be owned and published by its caller.
+Choose `cloned` rather than `dedicated` when immutable template provenance is
+part of the desired state. A runtime must not downgrade a persistent mode to a
+shared process or upgrade a shared capability into a persistent teammate.
+
+## Isolation and ownership
+
+Dedicated and cloned specialists own their `identity_ref`,
+`memory_namespace_ref`, and every `workspace_root_ref` within one app/team
+scope. Those mutable references, manifest IDs, app IDs, team IDs, and instance
+IDs must be unique across a validated manifest set. Cloning reuses only
+versioned instructions and capabilities; signing identity, conversations,
+memory, workspace, credentials, and mutable runtime state are always new.
+
+Shared records prohibit persistent identity, memory namespaces, fixed app
+workspace roots, direct team credentials, self-publication, and persistent
+teammate representation. Every shared request retains `app`, `team`,
+`community`, `project`, `actor`, and `audit` context. The caller owns the
+result, while the audit trail also records the invoked capability.
+
+The manifest is desired state, not an authority source. Display labels are
+non-authoritative and cannot substitute for IDs, identity verification, actor
+context, or policy decisions.
+
+## Reference and discovery boundaries
+
+- Use registered references such as `workspace-root:alpha` and
+  `secret-ref:alpha-build`. Secret values and raw private host paths are never
+  manifest data.
+- Use `simple`, `standard`, or `thinking` workload tiers. Canonical agent
+  discovery and runtime routing resolve current instructions, provider models,
+  and reasoning variants; manifests must not contain concrete model or
+  provider IDs.
+- Pin each manifest and specialist template to a source reference, revision,
+  and SHA-256 digest. Do not copy unversioned instructions into the manifest.
+- Provider, community, resource, workspace, credential, trust, authority, and
+  reconciliation references must resolve through their owning registries or
+  brokers before mutation begins.
+- Existing OpenCode, Matrix, Buzz, memory, and runtime configuration remain the
+  canonical implementation surfaces. This schema does not generate agents or
+  modify those systems.
+
+## Publication and audit context
+
+Persistent specialists publish as `specialist_with_actor`; the specialist is
+accountable for its output and the initiating actor remains visible. Shared
+capabilities publish as `caller`; they cannot create an independent signing or
+display-name authority. Resource bindings identify registered targets, while
+the authority policy decides whether an operation is allowed.
+
+## Validation and failure behavior
+
+Validate the complete manifest revision and all cross-document isolation
+claims before provisioning anything. Reject the manifest as a unit when a
+schema version is unknown, a stable reference is unresolved, a digest is
+invalid, mutable state collides, shared request context is incomplete, or any
+unknown property appears. Report the exact invalid reference or collision; do
+not infer a display-name identity, global namespace, host path, concrete model,
+credential, trust default, or partial fallback.
+
+Validation and retries are side-effect free. Later planners must preserve the
+manifest source revision and digest as idempotency inputs and roll back only
+resources created by their own atomic operation. Removing this additive
+contract never authorizes deletion of provider identities, memory, workspaces,
+or credentials.
+
+## Future composition
+
+Trust profiles and authority behavior remain separate contracts referenced by
+`trust_policy_ref` and `authority_policy_ref`. Field ownership and desired/live
+state reconciliation remain separate and are referenced only by
+`reconciliation_policy_ref`. Future roster generation, provider adapters, and
+app APIs must compose those contracts and resolve all references before any
+identity, team, namespace, workspace, or provider mutation.
+
+Run the contract regression test with:
+
+```bash
+node .agents/scripts/tests/test-team-interface-app-team-schema.mjs
+```

--- a/.agents/schemas/team-interface/app-team-v1.schema.json
+++ b/.agents/schemas/team-interface/app-team-v1.schema.json
@@ -1,0 +1,219 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:aidevops:team-interface:app-team:v1",
+  "title": "aidevops app-team manifest contract v1",
+  "$ref": "#/$defs/app_team_manifest",
+  "$defs": {
+    "core_stable_id": {"$ref": "urn:aidevops:team-interface:core:v1#/$defs/stable_id"},
+    "core_reference_id": {"$ref": "urn:aidevops:team-interface:core:v1#/$defs/reference_id"},
+    "registered_reference": {
+      "allOf": [
+        {"$ref": "#/$defs/core_reference_id"},
+        {"pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*:[A-Za-z0-9][A-Za-z0-9._:/-]*$"}
+      ]
+    },
+    "reference_list": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"$ref": "#/$defs/registered_reference"}
+    },
+    "source_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_ref", "revision", "digest"],
+      "properties": {
+        "source_ref": {"$ref": "#/$defs/registered_reference"},
+        "revision": {"type": "string", "minLength": 1, "maxLength": 255},
+        "digest": {"type": "string", "pattern": "^sha256:[a-fA-F0-9]{64}$"}
+      }
+    },
+    "audit_axis": {
+      "enum": ["app", "team", "community", "project", "actor", "audit"]
+    },
+    "audit_axes": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"$ref": "#/$defs/audit_axis"}
+    },
+    "common_specialist": {
+      "type": "object",
+      "required": [
+        "instance_id",
+        "template_source",
+        "workload_tier",
+        "resource_binding_refs",
+        "audit_context_requirements"
+      ],
+      "properties": {
+        "instance_id": {"$ref": "#/$defs/core_stable_id"},
+        "template_agent_id": {"$ref": "#/$defs/core_stable_id"},
+        "capability_ref": {"$ref": "#/$defs/registered_reference"},
+        "template_source": {"$ref": "#/$defs/source_metadata"},
+        "workload_tier": {"enum": ["simple", "standard", "thinking"]},
+        "resource_binding_refs": {"$ref": "#/$defs/reference_list"},
+        "audit_context_requirements": {"$ref": "#/$defs/audit_axes"}
+      },
+      "oneOf": [
+        {"required": ["template_agent_id"], "not": {"required": ["capability_ref"]}},
+        {"required": ["capability_ref"], "not": {"required": ["template_agent_id"]}}
+      ]
+    },
+    "persistent_specialist_fields": {
+      "type": "object",
+      "required": [
+        "identity_ref",
+        "memory_namespace_ref",
+        "workspace_root_refs",
+        "secret_refs",
+        "publication_mode",
+        "initiating_actor_required",
+        "persistent_teammate"
+      ],
+      "properties": {
+        "identity_ref": {"$ref": "#/$defs/registered_reference"},
+        "memory_namespace_ref": {"$ref": "#/$defs/registered_reference"},
+        "workspace_root_refs": {"$ref": "#/$defs/reference_list"},
+        "secret_refs": {"$ref": "#/$defs/reference_list"},
+        "publication_mode": {"const": "specialist_with_actor"},
+        "initiating_actor_required": {"const": true},
+        "persistent_teammate": {"const": true}
+      }
+    },
+    "dedicated_specialist": {
+      "allOf": [
+        {"$ref": "#/$defs/common_specialist"},
+        {"$ref": "#/$defs/persistent_specialist_fields"},
+        {
+          "type": "object",
+          "required": ["mode"],
+          "properties": {"mode": {"const": "dedicated"}}
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "cloned_specialist": {
+      "allOf": [
+        {"$ref": "#/$defs/common_specialist"},
+        {"$ref": "#/$defs/persistent_specialist_fields"},
+        {
+          "type": "object",
+          "required": ["mode", "clone_source", "inherited_mutable_state"],
+          "properties": {
+            "mode": {"const": "cloned"},
+            "clone_source": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["template_instance_ref", "immutable"],
+              "properties": {
+                "template_instance_ref": {"$ref": "#/$defs/registered_reference"},
+                "immutable": {"const": true}
+              }
+            },
+            "inherited_mutable_state": {"const": false}
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "shared_specialist": {
+      "allOf": [
+        {"$ref": "#/$defs/common_specialist"},
+        {
+          "type": "object",
+          "required": [
+            "mode",
+            "stateless",
+            "memory_mode",
+            "publication_mode",
+            "request_context_axes",
+            "workspace_policy_ref",
+            "credential_broker_ref",
+            "persistent_teammate"
+          ],
+          "properties": {
+            "mode": {"const": "shared"},
+            "stateless": {"const": true},
+            "memory_mode": {"enum": ["none", "request_scoped"]},
+            "publication_mode": {"const": "caller"},
+            "request_context_axes": {
+              "allOf": [
+                {"$ref": "#/$defs/audit_axes"},
+                {"contains": {"const": "app"}},
+                {"contains": {"const": "team"}},
+                {"contains": {"const": "community"}},
+                {"contains": {"const": "project"}},
+                {"contains": {"const": "actor"}},
+                {"contains": {"const": "audit"}}
+              ]
+            },
+            "workspace_policy_ref": {"$ref": "#/$defs/registered_reference"},
+            "credential_broker_ref": {"$ref": "#/$defs/registered_reference"},
+            "persistent_teammate": {"const": false}
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "specialist": {
+      "oneOf": [
+        {"$ref": "#/$defs/dedicated_specialist"},
+        {"$ref": "#/$defs/cloned_specialist"},
+        {"$ref": "#/$defs/shared_specialist"}
+      ]
+    },
+    "execution_eligibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["eligible", "policy_ref"],
+      "properties": {
+        "eligible": {"type": "boolean"},
+        "policy_ref": {"$ref": "#/$defs/registered_reference"}
+      }
+    },
+    "app_team_manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "document_type",
+        "manifest_id",
+        "app_id",
+        "team_id",
+        "source",
+        "provider_binding_refs",
+        "community_ref",
+        "resource_binding_refs",
+        "trust_policy_ref",
+        "authority_policy_ref",
+        "reconciliation_policy_ref",
+        "runner_eligibility",
+        "local_model_eligibility",
+        "specialists"
+      ],
+      "properties": {
+        "schema_version": {"const": 1},
+        "document_type": {"const": "app_team_manifest"},
+        "manifest_id": {"$ref": "#/$defs/core_stable_id"},
+        "app_id": {"$ref": "#/$defs/core_stable_id"},
+        "team_id": {"$ref": "#/$defs/core_stable_id"},
+        "display_label": {"type": "string", "minLength": 1, "maxLength": 255},
+        "source": {"$ref": "#/$defs/source_metadata"},
+        "provider_binding_refs": {"$ref": "#/$defs/reference_list"},
+        "community_ref": {"$ref": "#/$defs/registered_reference"},
+        "resource_binding_refs": {"$ref": "#/$defs/reference_list"},
+        "trust_policy_ref": {"$ref": "#/$defs/registered_reference"},
+        "authority_policy_ref": {"$ref": "#/$defs/registered_reference"},
+        "reconciliation_policy_ref": {"$ref": "#/$defs/registered_reference"},
+        "runner_eligibility": {"$ref": "#/$defs/execution_eligibility"},
+        "local_model_eligibility": {"$ref": "#/$defs/execution_eligibility"},
+        "specialists": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/specialist"}
+        }
+      }
+    }
+  }
+}

--- a/.agents/scripts/tests/fixtures/team-interface/app-team-invalid-isolation.json
+++ b/.agents/scripts/tests/fixtures/team-interface/app-team-invalid-isolation.json
@@ -1,0 +1,7 @@
+{
+  "cases": [
+    {"axis": "identity_ref", "collision": "identity:cross-app-collision"},
+    {"axis": "memory_namespace_ref", "collision": "memory:cross-app-collision"},
+    {"axis": "workspace_root_refs", "collision": ["workspace-root:cross-app-collision"]}
+  ]
+}

--- a/.agents/scripts/tests/fixtures/team-interface/app-team-invalid-secret-model.json
+++ b/.agents/scripts/tests/fixtures/team-interface/app-team-invalid-secret-model.json
@@ -1,0 +1,10 @@
+{
+  "cases": [
+    {"target": "manifest", "property": "secret_value", "value": "forbidden"},
+    {"target": "manifest", "property": "workspace_path", "value": "/private/app/root"},
+    {"target": "specialist", "property": "workspace_root_refs", "value": ["/private/app/root"]},
+    {"target": "specialist", "property": "model_id", "value": "concrete-model"},
+    {"target": "specialist", "property": "provider_id", "value": "concrete-provider"},
+    {"target": "specialist", "property": "display_name", "value": "authority-by-label"}
+  ]
+}

--- a/.agents/scripts/tests/fixtures/team-interface/app-team-invalid-shared-state.json
+++ b/.agents/scripts/tests/fixtures/team-interface/app-team-invalid-shared-state.json
@@ -1,0 +1,11 @@
+{
+  "base_specialist_index": 2,
+  "cases": [
+    {"property": "identity_ref", "value": "identity:shared-leak"},
+    {"property": "memory_namespace_ref", "value": "memory:shared-leak"},
+    {"property": "workspace_root_refs", "value": ["workspace-root:shared-static"]},
+    {"property": "secret_refs", "value": ["secret-ref:shared-direct"]},
+    {"property": "persistent_teammate", "value": true},
+    {"property": "publication_mode", "value": "specialist_with_actor"}
+  ]
+}

--- a/.agents/scripts/tests/fixtures/team-interface/app-team-valid-isolation.json
+++ b/.agents/scripts/tests/fixtures/team-interface/app-team-valid-isolation.json
@@ -1,0 +1,130 @@
+{
+  "documents": [
+    {
+      "schema_version": 1,
+      "document_type": "app_team_manifest",
+      "manifest_id": "manifest.app.red",
+      "app_id": "app.red",
+      "team_id": "team.red",
+      "source": {
+        "source_ref": "registry:app-teams",
+        "revision": "red.1",
+        "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      },
+      "provider_binding_refs": ["provider-binding:red"],
+      "community_ref": "community:red",
+      "resource_binding_refs": ["resource-binding:red"],
+      "trust_policy_ref": "trust-policy:red",
+      "authority_policy_ref": "authority-policy:red",
+      "reconciliation_policy_ref": "reconciliation-policy:red",
+      "runner_eligibility": {"eligible": true, "policy_ref": "runner-policy:red"},
+      "local_model_eligibility": {"eligible": true, "policy_ref": "local-model-policy:red"},
+      "specialists": [
+        {
+          "mode": "dedicated",
+          "instance_id": "specialist.red.build",
+          "template_agent_id": "agent.build",
+          "template_source": {
+            "source_ref": "agent-registry:build",
+            "revision": "v1",
+            "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+          },
+          "workload_tier": "standard",
+          "resource_binding_refs": ["resource-binding:red"],
+          "audit_context_requirements": ["app", "team", "community", "project", "actor", "audit"],
+          "identity_ref": "identity:red-build",
+          "memory_namespace_ref": "memory:red-build",
+          "workspace_root_refs": ["workspace-root:red"],
+          "secret_refs": ["secret-ref:red-build"],
+          "publication_mode": "specialist_with_actor",
+          "initiating_actor_required": true,
+          "persistent_teammate": true
+        },
+        {
+          "mode": "shared",
+          "instance_id": "capability.red.security",
+          "capability_ref": "capability:security-review",
+          "template_source": {
+            "source_ref": "capability-registry:security-review",
+            "revision": "v1",
+            "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+          },
+          "workload_tier": "simple",
+          "resource_binding_refs": ["request-resource:red"],
+          "audit_context_requirements": ["app", "team", "community", "project", "actor", "audit"],
+          "stateless": true,
+          "memory_mode": "none",
+          "publication_mode": "caller",
+          "request_context_axes": ["app", "team", "community", "project", "actor", "audit"],
+          "workspace_policy_ref": "workspace-policy:red-request",
+          "credential_broker_ref": "credential-broker:red-request",
+          "persistent_teammate": false
+        }
+      ]
+    },
+    {
+      "schema_version": 1,
+      "document_type": "app_team_manifest",
+      "manifest_id": "manifest.app.blue",
+      "app_id": "app.blue",
+      "team_id": "team.blue",
+      "source": {
+        "source_ref": "registry:app-teams",
+        "revision": "blue.1",
+        "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+      },
+      "provider_binding_refs": ["provider-binding:blue"],
+      "community_ref": "community:blue",
+      "resource_binding_refs": ["resource-binding:blue"],
+      "trust_policy_ref": "trust-policy:blue",
+      "authority_policy_ref": "authority-policy:blue",
+      "reconciliation_policy_ref": "reconciliation-policy:blue",
+      "runner_eligibility": {"eligible": true, "policy_ref": "runner-policy:blue"},
+      "local_model_eligibility": {"eligible": false, "policy_ref": "local-model-policy:blue"},
+      "specialists": [
+        {
+          "mode": "cloned",
+          "instance_id": "specialist.blue.content",
+          "template_agent_id": "agent.content",
+          "template_source": {
+            "source_ref": "agent-registry:content",
+            "revision": "v1",
+            "digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555"
+          },
+          "workload_tier": "thinking",
+          "resource_binding_refs": ["resource-binding:blue"],
+          "audit_context_requirements": ["app", "team", "community", "project", "actor", "audit"],
+          "identity_ref": "identity:blue-content",
+          "memory_namespace_ref": "memory:blue-content",
+          "workspace_root_refs": ["workspace-root:blue"],
+          "secret_refs": ["secret-ref:blue-content"],
+          "publication_mode": "specialist_with_actor",
+          "initiating_actor_required": true,
+          "persistent_teammate": true,
+          "clone_source": {"template_instance_ref": "template-instance:content-v1", "immutable": true},
+          "inherited_mutable_state": false
+        },
+        {
+          "mode": "shared",
+          "instance_id": "capability.blue.security",
+          "capability_ref": "capability:security-review",
+          "template_source": {
+            "source_ref": "capability-registry:security-review",
+            "revision": "v1",
+            "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+          },
+          "workload_tier": "simple",
+          "resource_binding_refs": ["request-resource:blue"],
+          "audit_context_requirements": ["app", "team", "community", "project", "actor", "audit"],
+          "stateless": true,
+          "memory_mode": "request_scoped",
+          "publication_mode": "caller",
+          "request_context_axes": ["app", "team", "community", "project", "actor", "audit"],
+          "workspace_policy_ref": "workspace-policy:blue-request",
+          "credential_broker_ref": "credential-broker:blue-request",
+          "persistent_teammate": false
+        }
+      ]
+    }
+  ]
+}

--- a/.agents/scripts/tests/fixtures/team-interface/app-team-valid-modes.json
+++ b/.agents/scripts/tests/fixtures/team-interface/app-team-valid-modes.json
@@ -1,0 +1,94 @@
+{
+  "schema_version": 1,
+  "document_type": "app_team_manifest",
+  "manifest_id": "manifest.app.alpha",
+  "app_id": "app.alpha",
+  "team_id": "team.alpha",
+  "display_label": "Alpha application team",
+  "source": {
+    "source_ref": "registry:app-teams",
+    "revision": "2026-08-04.1",
+    "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "provider_binding_refs": ["provider-binding:alpha"],
+  "community_ref": "community:alpha",
+  "resource_binding_refs": ["resource-binding:alpha-project"],
+  "trust_policy_ref": "trust-policy:alpha",
+  "authority_policy_ref": "authority-policy:alpha",
+  "reconciliation_policy_ref": "reconciliation-policy:alpha",
+  "runner_eligibility": {
+    "eligible": true,
+    "policy_ref": "runner-policy:alpha"
+  },
+  "local_model_eligibility": {
+    "eligible": false,
+    "policy_ref": "local-model-policy:alpha"
+  },
+  "specialists": [
+    {
+      "mode": "dedicated",
+      "instance_id": "specialist.alpha.build",
+      "template_agent_id": "agent.build",
+      "template_source": {
+        "source_ref": "agent-registry:build",
+        "revision": "v3.32.220",
+        "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "workload_tier": "thinking",
+      "resource_binding_refs": ["resource-binding:alpha-project"],
+      "audit_context_requirements": ["app", "team", "community", "project", "actor", "audit"],
+      "identity_ref": "identity:alpha-build",
+      "memory_namespace_ref": "memory:alpha-build",
+      "workspace_root_refs": ["workspace-root:alpha"],
+      "secret_refs": ["secret-ref:alpha-build"],
+      "publication_mode": "specialist_with_actor",
+      "initiating_actor_required": true,
+      "persistent_teammate": true
+    },
+    {
+      "mode": "cloned",
+      "instance_id": "specialist.alpha.content",
+      "template_agent_id": "agent.content",
+      "template_source": {
+        "source_ref": "agent-registry:content",
+        "revision": "v3.32.220",
+        "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      },
+      "workload_tier": "standard",
+      "resource_binding_refs": ["resource-binding:alpha-content"],
+      "audit_context_requirements": ["app", "team", "community", "project", "actor", "audit"],
+      "identity_ref": "identity:alpha-content",
+      "memory_namespace_ref": "memory:alpha-content",
+      "workspace_root_refs": ["workspace-root:alpha-content"],
+      "secret_refs": ["secret-ref:alpha-content"],
+      "publication_mode": "specialist_with_actor",
+      "initiating_actor_required": true,
+      "persistent_teammate": true,
+      "clone_source": {
+        "template_instance_ref": "template-instance:content-v1",
+        "immutable": true
+      },
+      "inherited_mutable_state": false
+    },
+    {
+      "mode": "shared",
+      "instance_id": "capability.alpha.security",
+      "capability_ref": "capability:security-review",
+      "template_source": {
+        "source_ref": "capability-registry:security-review",
+        "revision": "v1.4.0",
+        "digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+      },
+      "workload_tier": "simple",
+      "resource_binding_refs": ["resource-binding:alpha-review-request"],
+      "audit_context_requirements": ["app", "team", "community", "project", "actor", "audit"],
+      "stateless": true,
+      "memory_mode": "request_scoped",
+      "publication_mode": "caller",
+      "request_context_axes": ["app", "team", "community", "project", "actor", "audit"],
+      "workspace_policy_ref": "workspace-policy:request-scoped",
+      "credential_broker_ref": "credential-broker:security-review",
+      "persistent_teammate": false
+    }
+  ]
+}

--- a/.agents/scripts/tests/test-team-interface-app-team-schema.mjs
+++ b/.agents/scripts/tests/test-team-interface-app-team-schema.mjs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv2020 from "ajv/dist/2020.js";
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const schemaDirectory = path.join(testDirectory, "../../schemas/team-interface");
+const fixtureDirectory = path.join(testDirectory, "fixtures/team-interface");
+const requiredContextAxes = ["app", "team", "community", "project", "actor", "audit"];
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function formatErrors(errors) {
+  return (errors || [])
+    .map((error) => `${error.instancePath || "<root>"} ${error.keyword}: ${error.message}`)
+    .join("\n");
+}
+
+function assertValid(validate, document, label) {
+  assert.equal(validate(document), true, `${label} failed:\n${formatErrors(validate.errors)}`);
+}
+
+function assertInvalid(validate, document, label, predicate = () => true) {
+  assert.equal(validate(document), false, `${label} unexpectedly validated`);
+  assert.ok(predicate(validate.errors || []), `${label} failed for the wrong reason:\n${formatErrors(validate.errors)}`);
+}
+
+function assertNoForbiddenSchemaProperties(value, location = "<root>") {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoForbiddenSchemaProperties(item, `${location}/${index}`));
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+
+  if (value.properties) {
+    for (const propertyName of Object.keys(value.properties)) {
+      assert.doesNotMatch(
+        propertyName,
+        /^(token|password|private[_-]?key|credential[_-]?value|secret[_-]?value|model[_-]?id|provider[_-]?id|workspace[_-]?path|display[_-]?name)$/i,
+        `unsafe property exposed at ${location}/properties/${propertyName}`,
+      );
+    }
+  }
+  for (const [key, child] of Object.entries(value)) {
+    assertNoForbiddenSchemaProperties(child, `${location}/${key}`);
+  }
+}
+
+function claimUnique(claims, value, label) {
+  assert.equal(claims.has(value), false, `${label} collision: ${value}`);
+  claims.add(value);
+}
+
+function validateManifestSet(validate, documents) {
+  const stableIds = new Set();
+  const identityRefs = new Set();
+  const memoryRefs = new Set();
+  const workspaceRefs = new Set();
+
+  for (const [documentIndex, document] of documents.entries()) {
+    assertValid(validate, document, `manifest set document ${documentIndex}`);
+    claimUnique(stableIds, document.manifest_id, "manifest ID");
+    claimUnique(stableIds, document.app_id, "app ID");
+    claimUnique(stableIds, document.team_id, "team ID");
+
+    for (const specialist of document.specialists) {
+      claimUnique(stableIds, specialist.instance_id, "specialist instance ID");
+      if (specialist.mode === "shared") {
+        assert.deepEqual(
+          [...specialist.request_context_axes].sort(),
+          [...requiredContextAxes].sort(),
+          "shared capability must retain app, team, community, project, actor, and audit context",
+        );
+        assert.equal(specialist.publication_mode, "caller");
+        assert.equal(specialist.persistent_teammate, false);
+        continue;
+      }
+
+      claimUnique(identityRefs, specialist.identity_ref, "identity");
+      claimUnique(memoryRefs, specialist.memory_namespace_ref, "memory namespace");
+      for (const workspaceRef of specialist.workspace_root_refs) {
+        claimUnique(workspaceRefs, workspaceRef, "workspace root");
+      }
+      assert.equal(specialist.publication_mode, "specialist_with_actor");
+      assert.equal(specialist.initiating_actor_required, true);
+    }
+  }
+}
+
+const coreSchema = readJson(path.join(schemaDirectory, "core-v1.schema.json"));
+const appTeamSchema = readJson(path.join(schemaDirectory, "app-team-v1.schema.json"));
+assert.equal(appTeamSchema.$schema, "https://json-schema.org/draft/2020-12/schema");
+assert.equal(appTeamSchema.$id, "urn:aidevops:team-interface:app-team:v1");
+assertNoForbiddenSchemaProperties(appTeamSchema);
+
+const ajv = new Ajv2020({allErrors: true, strict: false, validateFormats: false});
+ajv.addSchema(coreSchema);
+const validate = ajv.compile(appTeamSchema);
+
+const validModes = readJson(path.join(fixtureDirectory, "app-team-valid-modes.json"));
+assertValid(validate, validModes, "valid mode manifest");
+assert.deepEqual(validModes.specialists.map(({mode}) => mode).sort(), ["cloned", "dedicated", "shared"]);
+assert.deepEqual(
+  validModes.specialists.map(({workload_tier: tier}) => tier).sort(),
+  ["simple", "standard", "thinking"],
+);
+
+const validIsolation = readJson(path.join(fixtureDirectory, "app-team-valid-isolation.json"));
+validateManifestSet(validate, validIsolation.documents);
+
+const invalidIsolation = readJson(path.join(fixtureDirectory, "app-team-invalid-isolation.json"));
+for (const {axis, collision} of invalidIsolation.cases) {
+  const collidingDocuments = structuredClone(validIsolation.documents);
+  const firstPersistent = collidingDocuments[0].specialists.find(({mode}) => mode !== "shared");
+  const secondPersistent = collidingDocuments[1].specialists.find(({mode}) => mode !== "shared");
+  firstPersistent[axis] = collision;
+  secondPersistent[axis] = collision;
+  assert.throws(
+    () => validateManifestSet(validate, collidingDocuments),
+    new RegExp(`${axis === "identity_ref" ? "identity" : axis === "memory_namespace_ref" ? "memory" : "workspace"}.*collision`, "i"),
+    `invalid-isolation ${axis} did not collide`,
+  );
+}
+
+const invalidSharedState = readJson(path.join(fixtureDirectory, "app-team-invalid-shared-state.json"));
+for (const invalidCase of invalidSharedState.cases) {
+  const document = structuredClone(validModes);
+  document.specialists[invalidSharedState.base_specialist_index][invalidCase.property] = invalidCase.value;
+  assertInvalid(validate, document, `invalid-shared-state ${invalidCase.property}`);
+}
+
+const inheritedCloneState = structuredClone(validModes);
+inheritedCloneState.specialists.find(({mode}) => mode === "cloned").inherited_mutable_state = true;
+assertInvalid(
+  validate,
+  inheritedCloneState,
+  "cloned inherited mutable state",
+  (errors) => errors.some((error) => error.keyword === "const" && error.instancePath.endsWith("/inherited_mutable_state")),
+);
+
+const invalidUnsafeFields = readJson(path.join(fixtureDirectory, "app-team-invalid-secret-model.json"));
+for (const invalidCase of invalidUnsafeFields.cases) {
+  const document = structuredClone(validModes);
+  const target = invalidCase.target === "manifest" ? document : document.specialists[0];
+  target[invalidCase.property] = invalidCase.value;
+  assertInvalid(validate, document, `invalid-secret-model ${invalidCase.property}`);
+}
+
+for (const invalidTier of ["fast", "provider/model", "high"]) {
+  const document = structuredClone(validModes);
+  document.specialists[0].workload_tier = invalidTier;
+  assertInvalid(
+    validate,
+    document,
+    `concrete model tier ${invalidTier}`,
+    (errors) => errors.some((error) => error.keyword === "enum" && error.instancePath.endsWith("/workload_tier")),
+  );
+}
+
+const unknownVersion = structuredClone(validModes);
+unknownVersion.schema_version = 2;
+assertInvalid(validate, unknownVersion, "unknown schema version");
+
+const unknownProperty = structuredClone(validModes);
+unknownProperty.runtime_overlay = {};
+assertInvalid(validate, unknownProperty, "unknown manifest property");
+
+console.log("PASS: app-team manifests enforce dedicated, cloned, and shared isolation contracts");


### PR DESCRIPTION
## Summary

Add the provider-neutral app-team v1 schema, mode and isolation fixtures, semantic validation, and ownership documentation.

## Files Changed

.agents/reference/team-interface-app-teams.md, .agents/schemas/team-interface/app-team-v1.schema.json, .agents/scripts/tests/fixtures/team-interface/app-team-invalid-isolation.json, .agents/scripts/tests/fixtures/team-interface/app-team-invalid-secret-model.json, .agents/scripts/tests/fixtures/team-interface/app-team-invalid-shared-state.json, .agents/scripts/tests/fixtures/team-interface/app-team-valid-isolation.json, .agents/scripts/tests/fixtures/team-interface/app-team-valid-modes.json, .agents/scripts/tests/test-team-interface-app-team-schema.mjs

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Focused Ajv schema test, Ajv multi-schema probe, TypeScript check, and pre-commit validation pass.

Resolves #29501


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.220 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 10m and 145,720 tokens on this as a headless worker.