### PR TITLE
t18194: Define adaptive ingress trust and authority contracts

### DIFF
--- a/.agents/reference/team-interface-trust.md
+++ b/.agents/reference/team-interface-trust.md
@@ -1,0 +1,170 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Team-interface ingress trust and authority
+
+The version-1 contract at
+`.agents/schemas/team-interface/trust-v1.schema.json` separates four inputs that
+must not be collapsed into one trusted/untrusted flag:
+
+1. verified actor identity and configured role grants;
+2. content provenance;
+3. attachment risk and extraction evidence; and
+4. the requested operation and capability class.
+
+It references `urn:aidevops:team-interface:core:v1` for stable IDs, verified
+actors, capability operations, and attachment metadata. Provider adapters must
+not duplicate or reinterpret those definitions. This contract defines records
+only; it does not grant tools, scan content, extract files, or write a cache.
+
+## Canonical profiles
+
+All profiles enforce signature/provenance, schema, size/type/path, correlation,
+idempotency, and output-secret controls. These structural controls are mandatory
+even when semantic scanning is not required.
+
+| Profile | Minimum screening | Default capability ceiling |
+|---|---|---|
+| `owner-local` | Structural controls. Deterministic and semantic scans are conditional for ordinary direct text, but suspicious encoding, forwarded content, unknown provenance, external attachments, findings, or elevated operations trigger stronger policy. | Configured owner operations. Administrator, secret, destructive, billing, publication, and release work requires its own explicit gate. |
+| `trusted-team` | Structural controls plus a cached deterministic prompt-pattern scan. Findings, external attachments, and elevated operations trigger semantic escalation. | Configured role operations and non-administrator operations only. |
+| `shared-member` | Deterministic scanning before model use, broker-enforced action scope, and sandboxed extraction when content must be read. | Read, answer, and draft by default; explicitly configured non-administrator operations are the maximum. |
+| `external-bridged` | Strict deterministic scanning or quarantine, bounded content, isolated attachments, and explicit external provenance. | Read or draft only. Privileged work requires a separate trusted, authorized job. |
+
+`owner-local` may skip semantic scanning only for ordinary direct text. Forwarded
+or external content, attachments, suspicious encoding, and elevated operations
+re-enter the stronger path. Internal signatures reduce scanning overhead but do
+not skip structure, authority, idempotency, or output-secret checks.
+
+## Deterministic evaluation order
+
+An ingress adapter and authority broker evaluate one event in this order:
+
+1. Verify signature and provenance, then validate the core event schema,
+   content bounds, paths, media types, correlation ID, and idempotency key.
+2. Resolve the verified actor, membership, and configured roles. Display labels
+   and membership alone are not grants.
+3. Derive exactly one trust profile from verified policy inputs.
+4. Calculate required deterministic, semantic, and attachment stages from the
+   profile, provenance, findings, attachments, and requested capability.
+5. Validate a complete cached verdict key or create a new immutable verdict.
+6. Intersect the requested capability with configured role grants and the
+   profile/policy ceiling. The decision records immutable policy and role-config
+   references; apply an explicit gate for every high-risk class.
+7. Emit one deterministic `allow`, `deny`, `review`, or `quarantine` decision
+   with reason codes and audit references.
+8. Run the output-secret guard before any response or side effect leaves the
+   broker.
+
+Scanning supplies content-risk evidence; it never supplies authority. A model
+may explain a decision but cannot add roles, grants, ceilings, gate references,
+or model-proposed scopes to the authority input.
+
+## Verdict cache and invalidation
+
+A verdict is reusable only when all of these key components match exactly:
+
+- content digest;
+- sorted attachment digests;
+- provider ID and provenance class;
+- trust profile ID;
+- scanner engine and scanner version;
+- policy version; and
+- requested capability class.
+
+Changing any component creates a different key and prevents stale fallback.
+Writers must publish the complete key and all stage evidence atomically. Partial
+stage results are never visible as `clean`. A policy rollback may reuse older
+evidence only when every key component still matches. Scanner errors are not
+cacheable terminal success; retries remain fail-closed until a new terminal
+verdict is recorded.
+
+Each verdict records structural, deterministic, semantic, and attachment stages
+as `not_required`, `not_run`, `clean`, `findings`, `quarantined`, or `error`.
+`not_required` is an explicit policy result, not an omitted stage. `not_run`,
+`findings`, `quarantined`, and `error` cannot support `allow`.
+
+For `allow`, structural evidence is always `clean`. Deterministic evidence is
+also `clean` for every non-owner profile and whenever owner-local provenance is
+not direct, an attachment is present, or a high-risk capability is requested.
+Semantic evidence is `clean` for forwarded/external provenance, attachments,
+external-bridged ingress, and elevated capabilities. Attachment evidence is
+`clean` whenever attachment digests are present. A stage may be `not_required`
+only when the selected profile and event inputs do not require it.
+
+An ingress decision binds both the immutable verdict reference and the complete
+verdict key. Before use, the broker resolves that reference and requires the
+stored key and result to match the decision's copied key/result exactly. It also
+matches provenance, profile, policy version, requested capability, provider,
+content digest, and attachment digests against the event fingerprint copied from
+the validated normalized core event. The adapter computes that fingerprint; a
+model cannot supply or alter it. An unresolved reference or any mismatch is
+stale evidence and cannot authorize the event.
+
+## Attachment handling
+
+Preflight records the core attachment metadata, source provenance, digest match,
+path and type checks, active-content, executable, archive, and macro flags.
+Extraction occurs only in a referenced sandbox. No profile permits an
+owner-trust bypass.
+
+An unsafe attachment is quarantined or rejected; it is never accepted because
+the actor is an owner. Active documents, executables, archives, macros, unsafe
+paths or types, and mismatched digests force `quarantine` or `reject`. Sandbox,
+scanner, or digest failures preserve the original attachment and fail the event
+closed without exposing partial extraction as clean evidence.
+
+## Authority ceilings and negative privilege rules
+
+Final authority is the intersection of:
+
+1. a capability granted to one of the verified actor's configured roles;
+2. the declared capability ceiling; and
+3. an explicit gate when the capability is administrator, secret access,
+   destructive, billing, publication, or release.
+
+Membership, display labels, clean scanning, attachment acceptance, and model
+suggestions cannot widen that intersection. Shared and external profiles cannot
+carry high-risk capability classes in their ceilings. A clean scan for a request
+outside configured authority still produces `deny` or `review`.
+
+Every configured grant carries the same immutable role-configuration reference
+as its decision. The broker resolves that reference, confirms the grant's role
+belongs to the verified actor, confirms every granted capability appears in the
+policy's role grant, and rejects copied, membership-derived, or model-derived
+grants. The broker also resolves the policy reference, constrains the decision
+ceiling to the selected profile ceiling, and accepts high-risk gate evidence
+only from the policy's declared gate authority. Schema constraints bind each
+`allow` to a matching grant, ceiling entry, clean scan result, accepted
+attachments, and required high-risk gate; semantic validation resolves the
+referenced records and rejects cross-record drift.
+
+## Failure and compatibility behavior
+
+- Scanner `error` produces `deny`, `review`, or `quarantine`, never clean/allow.
+- Unknown provenance produces `deny`, `review`, or `quarantine`, never an owner default.
+- An unsafe attachment produces `quarantine` or `deny`, never allow.
+- Signature, schema, sandbox, policy lookup, authority resolution, output-secret,
+  and malformed-event failures fail closed.
+- Capability escalation without a configured grant, ceiling, and required gate
+  produces `deny` or `review`.
+
+Legacy or mixed-version records without a verified actor, known profile, policy
+version, correlation/idempotency evidence, or verdict reference do not inherit
+owner authority. Unknown schema and policy versions fail closed. Existing
+prompt-guard, privacy-filter, Matrix, and Buzz behavior remains unchanged until
+future adapters explicitly adopt this contract.
+
+## Idempotency, audit, and recovery
+
+The same normalized event, idempotency key, policy version, complete verdict key,
+and requested capability reuses one terminal verdict and one authority decision.
+Concurrent writers must publish complete immutable records atomically and select
+the existing terminal record on an idempotency collision.
+
+Every decision records the verified actor and roles, configured grants, profile,
+provenance, requested operation/capability, ceiling, policy and role-config
+references, explicit gates, scan verdict reference, bound verdict key/result,
+event provider/content/attachment fingerprint, attachment decisions, reason
+codes, policy version, correlation ID, idempotency key, timestamp, output-secret
+result, and audit reference. Audit records contain references and digests, never
+credential values or extracted secret material.

--- a/.agents/schemas/team-interface/trust-v1.schema.json
+++ b/.agents/schemas/team-interface/trust-v1.schema.json
@@ -1,0 +1,735 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:aidevops:team-interface:trust:v1",
+  "title": "aidevops team-interface trust contract v1",
+  "oneOf": [
+    {"$ref": "#/$defs/trust_policy_document"},
+    {"$ref": "#/$defs/scan_verdict_document"},
+    {"$ref": "#/$defs/ingress_decision_document"}
+  ],
+  "$defs": {
+    "stable_id": {"$ref": "urn:aidevops:team-interface:core:v1#/$defs/stable_id"},
+    "reference_id": {"$ref": "urn:aidevops:team-interface:core:v1#/$defs/reference_id"},
+    "capability_operation": {"$ref": "urn:aidevops:team-interface:core:v1#/$defs/capability_operation"},
+    "verified_actor": {"$ref": "urn:aidevops:team-interface:core:v1#/$defs/verified_actor"},
+    "attachment": {"$ref": "urn:aidevops:team-interface:core:v1#/$defs/attachment"},
+    "trust_profile_id": {
+      "enum": ["owner-local", "trusted-team", "shared-member", "external-bridged"]
+    },
+    "provenance_class": {
+      "enum": ["owner_direct", "team_direct", "shared_internal", "forwarded", "external", "unknown"]
+    },
+    "capability_class": {
+      "enum": [
+        "read",
+        "answer",
+        "draft",
+        "non_admin_operation",
+        "role_operation",
+        "owner_operation",
+        "administrator",
+        "secret_access",
+        "destructive",
+        "billing",
+        "publication",
+        "release"
+      ]
+    },
+    "high_risk_capability": {
+      "enum": ["administrator", "secret_access", "destructive", "billing", "publication", "release"]
+    },
+    "structural_control": {
+      "enum": [
+        "signature_provenance",
+        "schema",
+        "size_type_path",
+        "correlation",
+        "idempotency",
+        "output_secret"
+      ]
+    },
+    "attachment_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "sandbox_required_for_extraction",
+        "owner_bypass_allowed",
+        "active_content_allowed",
+        "unsafe_outcome",
+        "max_size_bytes"
+      ],
+      "properties": {
+        "mode": {"enum": ["conditional_sandbox", "sandbox_required", "isolate_or_quarantine"]},
+        "sandbox_required_for_extraction": {"const": true},
+        "owner_bypass_allowed": {"const": false},
+        "active_content_allowed": {"const": false},
+        "unsafe_outcome": {"enum": ["quarantine", "reject"]},
+        "max_size_bytes": {"type": "integer", "minimum": 1, "maximum": 1073741824}
+      }
+    },
+    "trust_profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "profile_id",
+        "structural_controls",
+        "deterministic_scan_mode",
+        "semantic_scan_mode",
+        "attachment_policy",
+        "default_capabilities",
+        "capability_ceiling",
+        "explicit_gate_capabilities",
+        "escalation_conditions"
+      ],
+      "properties": {
+        "profile_id": {"$ref": "#/$defs/trust_profile_id"},
+        "structural_controls": {
+          "type": "array",
+          "minItems": 6,
+          "maxItems": 6,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/structural_control"},
+          "allOf": [
+            {"contains": {"const": "signature_provenance"}},
+            {"contains": {"const": "schema"}},
+            {"contains": {"const": "size_type_path"}},
+            {"contains": {"const": "correlation"}},
+            {"contains": {"const": "idempotency"}},
+            {"contains": {"const": "output_secret"}}
+          ]
+        },
+        "deterministic_scan_mode": {"enum": ["conditional", "cached_required", "required", "strict"]},
+        "semantic_scan_mode": {"enum": ["conditional", "findings_or_elevation", "external_or_elevation"]},
+        "attachment_policy": {"$ref": "#/$defs/attachment_policy"},
+        "default_capabilities": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/capability_class"}
+        },
+        "capability_ceiling": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/capability_class"}
+        },
+        "explicit_gate_capabilities": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/high_risk_capability"}
+        },
+        "escalation_conditions": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "suspicious_encoding",
+              "forwarded_content",
+              "unknown_provenance",
+              "external_attachment",
+              "elevated_operation",
+              "deterministic_findings",
+              "scanner_error",
+              "capability_escalation"
+            ]
+          }
+        }
+      }
+    },
+    "owner_local_profile": {
+      "allOf": [
+        {"$ref": "#/$defs/trust_profile"},
+        {
+          "properties": {
+            "profile_id": {"const": "owner-local"},
+            "deterministic_scan_mode": {"const": "conditional"},
+            "semantic_scan_mode": {"const": "conditional"},
+            "default_capabilities": {
+              "prefixItems": [
+                {"const": "read"},
+                {"const": "answer"},
+                {"const": "draft"},
+                {"const": "owner_operation"}
+              ],
+              "items": false
+            },
+            "explicit_gate_capabilities": {
+              "prefixItems": [
+                {"const": "administrator"},
+                {"const": "secret_access"},
+                {"const": "destructive"},
+                {"const": "billing"},
+                {"const": "publication"},
+                {"const": "release"}
+              ],
+              "items": false
+            },
+            "escalation_conditions": {
+              "allOf": [
+                {"contains": {"const": "suspicious_encoding"}},
+                {"contains": {"const": "forwarded_content"}},
+                {"contains": {"const": "unknown_provenance"}},
+                {"contains": {"const": "external_attachment"}},
+                {"contains": {"const": "elevated_operation"}},
+                {"contains": {"const": "deterministic_findings"}},
+                {"contains": {"const": "scanner_error"}},
+                {"contains": {"const": "capability_escalation"}}
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "trusted_team_profile": {
+      "allOf": [
+        {"$ref": "#/$defs/trust_profile"},
+        {
+          "properties": {
+            "profile_id": {"const": "trusted-team"},
+            "deterministic_scan_mode": {"const": "cached_required"},
+            "semantic_scan_mode": {"const": "findings_or_elevation"},
+            "default_capabilities": {
+              "prefixItems": [
+                {"const": "read"},
+                {"const": "answer"},
+                {"const": "draft"},
+                {"const": "role_operation"}
+              ],
+              "items": false
+            },
+            "capability_ceiling": {
+              "items": {"enum": ["read", "answer", "draft", "non_admin_operation", "role_operation"]}
+            },
+            "explicit_gate_capabilities": {"maxItems": 0},
+            "escalation_conditions": {
+              "allOf": [
+                {"contains": {"const": "forwarded_content"}},
+                {"contains": {"const": "unknown_provenance"}},
+                {"contains": {"const": "external_attachment"}},
+                {"contains": {"const": "elevated_operation"}},
+                {"contains": {"const": "deterministic_findings"}},
+                {"contains": {"const": "scanner_error"}},
+                {"contains": {"const": "capability_escalation"}}
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "shared_member_profile": {
+      "allOf": [
+        {"$ref": "#/$defs/trust_profile"},
+        {
+          "properties": {
+            "profile_id": {"const": "shared-member"},
+            "deterministic_scan_mode": {"const": "required"},
+            "semantic_scan_mode": {"const": "findings_or_elevation"},
+            "attachment_policy": {"properties": {"mode": {"const": "sandbox_required"}}},
+            "default_capabilities": {
+              "prefixItems": [{"const": "read"}, {"const": "answer"}, {"const": "draft"}],
+              "items": false
+            },
+            "capability_ceiling": {
+              "items": {"enum": ["read", "answer", "draft", "non_admin_operation"]}
+            },
+            "explicit_gate_capabilities": {"maxItems": 0},
+            "escalation_conditions": {
+              "allOf": [
+                {"contains": {"const": "forwarded_content"}},
+                {"contains": {"const": "unknown_provenance"}},
+                {"contains": {"const": "external_attachment"}},
+                {"contains": {"const": "elevated_operation"}},
+                {"contains": {"const": "deterministic_findings"}},
+                {"contains": {"const": "scanner_error"}},
+                {"contains": {"const": "capability_escalation"}}
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "external_bridged_profile": {
+      "allOf": [
+        {"$ref": "#/$defs/trust_profile"},
+        {
+          "properties": {
+            "profile_id": {"const": "external-bridged"},
+            "deterministic_scan_mode": {"const": "strict"},
+            "semantic_scan_mode": {"const": "external_or_elevation"},
+            "attachment_policy": {"properties": {"mode": {"const": "isolate_or_quarantine"}}},
+            "default_capabilities": {
+              "prefixItems": [{"const": "read"}, {"const": "draft"}],
+              "items": false
+            },
+            "capability_ceiling": {
+              "prefixItems": [{"const": "read"}, {"const": "draft"}],
+              "items": false
+            },
+            "explicit_gate_capabilities": {"maxItems": 0},
+            "escalation_conditions": {
+              "allOf": [
+                {"contains": {"const": "unknown_provenance"}},
+                {"contains": {"const": "external_attachment"}},
+                {"contains": {"const": "elevated_operation"}},
+                {"contains": {"const": "deterministic_findings"}},
+                {"contains": {"const": "scanner_error"}},
+                {"contains": {"const": "capability_escalation"}}
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "trust_policy_document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "document_type",
+        "policy_id",
+        "policy_version",
+        "core_schema_id",
+        "grant_configuration_ref",
+        "gate_authority_ref",
+        "role_grants",
+        "profiles",
+        "high_risk_capabilities"
+      ],
+      "properties": {
+        "schema_version": {"const": 1},
+        "document_type": {"const": "trust_policy"},
+        "policy_id": {"$ref": "#/$defs/stable_id"},
+        "policy_version": {"type": "integer", "minimum": 1},
+        "core_schema_id": {"const": "urn:aidevops:team-interface:core:v1"},
+        "grant_configuration_ref": {"$ref": "#/$defs/reference_id"},
+        "gate_authority_ref": {"$ref": "#/$defs/reference_id"},
+        "role_grants": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/configured_grant"}
+        },
+        "profiles": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "prefixItems": [
+            {"$ref": "#/$defs/owner_local_profile"},
+            {"$ref": "#/$defs/trusted_team_profile"},
+            {"$ref": "#/$defs/shared_member_profile"},
+            {"$ref": "#/$defs/external_bridged_profile"}
+          ],
+          "items": false
+        },
+        "high_risk_capabilities": {
+          "type": "array",
+          "minItems": 6,
+          "maxItems": 6,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/high_risk_capability"}
+        }
+      }
+    },
+    "verdict_key": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "content_digest",
+        "attachment_digests",
+        "provider_id",
+        "provenance_class",
+        "trust_profile_id",
+        "scanner_engine",
+        "scanner_version",
+        "policy_version",
+        "requested_capability_class"
+      ],
+      "properties": {
+        "content_digest": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "attachment_digests": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+        },
+        "provider_id": {"$ref": "#/$defs/stable_id"},
+        "provenance_class": {"$ref": "#/$defs/provenance_class"},
+        "trust_profile_id": {"$ref": "#/$defs/trust_profile_id"},
+        "scanner_engine": {"type": "string", "minLength": 1, "maxLength": 100},
+        "scanner_version": {"type": "string", "minLength": 1, "maxLength": 100},
+        "policy_version": {"type": "integer", "minimum": 1},
+        "requested_capability_class": {"$ref": "#/$defs/capability_class"}
+      }
+    },
+    "stage_status": {
+      "enum": ["not_required", "not_run", "clean", "findings", "quarantined", "error"]
+    },
+    "stage_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "evidence_refs"],
+      "properties": {
+        "status": {"$ref": "#/$defs/stage_status"},
+        "evidence_refs": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/reference_id"}
+        },
+        "summary": {"type": "string", "minLength": 1, "maxLength": 500}
+      }
+    },
+    "scan_stages": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["structural", "deterministic", "semantic", "attachment"],
+      "properties": {
+        "structural": {"$ref": "#/$defs/stage_evidence"},
+        "deterministic": {"$ref": "#/$defs/stage_evidence"},
+        "semantic": {"$ref": "#/$defs/stage_evidence"},
+        "attachment": {"$ref": "#/$defs/stage_evidence"}
+      }
+    },
+    "scan_verdict_document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "document_type", "verdict_id", "verdict_key", "stages", "result", "reusable", "created_at"],
+      "properties": {
+        "schema_version": {"const": 1},
+        "document_type": {"const": "scan_verdict"},
+        "verdict_id": {"$ref": "#/$defs/stable_id"},
+        "verdict_key": {"$ref": "#/$defs/verdict_key"},
+        "stages": {"$ref": "#/$defs/scan_stages"},
+        "result": {"enum": ["clean", "findings", "quarantined", "error"]},
+        "reusable": {"type": "boolean"},
+        "created_at": {"type": "string", "format": "date-time"}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"result": {"const": "error"}}, "required": ["result"]},
+          "then": {"properties": {"reusable": {"const": false}}}
+        }
+      ]
+    },
+    "attachment_decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "attachment",
+        "provenance_class",
+        "digest_match",
+        "path_safe",
+        "type_allowed",
+        "active_content",
+        "executable",
+        "archive",
+        "macros",
+        "owner_bypass_used",
+        "extraction",
+        "outcome",
+        "reason_codes"
+      ],
+      "properties": {
+        "attachment": {"$ref": "#/$defs/attachment"},
+        "provenance_class": {"$ref": "#/$defs/provenance_class"},
+        "digest_match": {"type": "boolean"},
+        "path_safe": {"type": "boolean"},
+        "type_allowed": {"type": "boolean"},
+        "active_content": {"type": "boolean"},
+        "executable": {"type": "boolean"},
+        "archive": {"type": "boolean"},
+        "macros": {"type": "boolean"},
+        "owner_bypass_used": {"const": false},
+        "extraction": {"enum": ["not_required", "sandboxed", "quarantined", "rejected"]},
+        "sandbox_ref": {"$ref": "#/$defs/reference_id"},
+        "outcome": {"enum": ["accept", "quarantine", "reject"]},
+        "reason_codes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/stable_id"}
+        }
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"extraction": {"const": "sandboxed"}}, "required": ["extraction"]},
+          "then": {"required": ["sandbox_ref"]}
+        },
+        {
+          "if": {
+            "anyOf": [
+              {"properties": {"digest_match": {"const": false}}, "required": ["digest_match"]},
+              {"properties": {"path_safe": {"const": false}}, "required": ["path_safe"]},
+              {"properties": {"type_allowed": {"const": false}}, "required": ["type_allowed"]},
+              {"properties": {"active_content": {"const": true}}, "required": ["active_content"]},
+              {"properties": {"executable": {"const": true}}, "required": ["executable"]},
+              {"properties": {"archive": {"const": true}}, "required": ["archive"]},
+              {"properties": {"macros": {"const": true}}, "required": ["macros"]}
+            ]
+          },
+          "then": {
+            "properties": {
+              "outcome": {"enum": ["quarantine", "reject"]},
+              "extraction": {"enum": ["quarantined", "rejected"]}
+            }
+          }
+        }
+      ]
+    },
+    "configured_grant": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role_id", "grant_basis", "configuration_ref", "capability_classes"],
+      "properties": {
+        "role_id": {"$ref": "#/$defs/stable_id"},
+        "grant_basis": {"const": "configured_role"},
+        "configuration_ref": {"$ref": "#/$defs/reference_id"},
+        "capability_classes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/capability_class"}
+        }
+      }
+    },
+    "explicit_gate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capability_class", "gate_ref", "authority_ref"],
+      "properties": {
+        "capability_class": {"$ref": "#/$defs/high_risk_capability"},
+        "gate_ref": {"$ref": "#/$defs/reference_id"},
+        "authority_ref": {"$ref": "#/$defs/reference_id"}
+      }
+    },
+    "output_secret_guard": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "evidence_ref"],
+      "properties": {
+        "status": {"enum": ["clean", "blocked", "error"]},
+        "evidence_ref": {"$ref": "#/$defs/reference_id"}
+      }
+    },
+    "allow_capability_evidence": {
+      "oneOf": [
+        {
+          "properties": {
+            "requested_capability_class": {"const": "read"},
+            "capability_ceiling": {"contains": {"const": "read"}},
+            "configured_grants": {"contains": {"properties": {"capability_classes": {"contains": {"const": "read"}}}, "required": ["capability_classes"]}}
+          }
+        },
+        {
+          "properties": {
+            "requested_capability_class": {"const": "answer"},
+            "capability_ceiling": {"contains": {"const": "answer"}},
+            "configured_grants": {"contains": {"properties": {"capability_classes": {"contains": {"const": "answer"}}}, "required": ["capability_classes"]}}
+          }
+        },
+        {
+          "properties": {
+            "requested_capability_class": {"const": "draft"},
+            "capability_ceiling": {"contains": {"const": "draft"}},
+            "configured_grants": {"contains": {"properties": {"capability_classes": {"contains": {"const": "draft"}}}, "required": ["capability_classes"]}}
+          }
+        },
+        {
+          "properties": {
+            "requested_capability_class": {"const": "non_admin_operation"},
+            "capability_ceiling": {"contains": {"const": "non_admin_operation"}},
+            "configured_grants": {"contains": {"properties": {"capability_classes": {"contains": {"const": "non_admin_operation"}}}, "required": ["capability_classes"]}}
+          }
+        },
+        {
+          "properties": {
+            "requested_capability_class": {"const": "role_operation"},
+            "capability_ceiling": {"contains": {"const": "role_operation"}},
+            "configured_grants": {"contains": {"properties": {"capability_classes": {"contains": {"const": "role_operation"}}}, "required": ["capability_classes"]}}
+          }
+        },
+        {
+          "properties": {
+            "requested_capability_class": {"const": "owner_operation"},
+            "capability_ceiling": {"contains": {"const": "owner_operation"}},
+            "configured_grants": {"contains": {"properties": {"capability_classes": {"contains": {"const": "owner_operation"}}}, "required": ["capability_classes"]}}
+          }
+        },
+        {
+          "properties": {
+            "requested_capability_class": {"const": "administrator"},
+            "capability_ceiling": {"contains": {"const": "administrator"}},
+            "configured_grants": {"contains": {"properties": {"capability_classes": {"contains": {"const": "administrator"}}}, "required": ["capability_classes"]}},
+            "explicit_gates": {"contains": {"properties": {"capability_class": {"const": "administrator"}}, "required": ["capability_class", "gate_ref"]}}
+          }
+        },
+        {
+          "properties": {
+            "requested_capability_class": {"const": "secret_access"},
+            "capability_ceiling": {"contains": {"const": "secret_access"}},
+            "configured_grants": {"contains": {"properties": {"capability_classes": {"contains": {"const": "secret_access"}}}, "required": ["capability_classes"]}},
+            "explicit_gates": {"contains": {"properties": {"capability_class": {"const": "secret_access"}}, "required": ["capability_class", "gate_ref"]}}
+          }
+        },
+        {
+          "properties": {
+            "requested_capability_class": {"const": "destructive"},
+            "capability_ceiling": {"contains": {"const": "destructive"}},
+            "configured_grants": {"contains": {"properties": {"capability_classes": {"contains": {"const": "destructive"}}}, "required": ["capability_classes"]}},
+            "explicit_gates": {"contains": {"properties": {"capability_class": {"const": "destructive"}}, "required": ["capability_class", "gate_ref"]}}
+          }
+        },
+        {
+          "properties": {
+            "requested_capability_class": {"const": "billing"},
+            "capability_ceiling": {"contains": {"const": "billing"}},
+            "configured_grants": {"contains": {"properties": {"capability_classes": {"contains": {"const": "billing"}}}, "required": ["capability_classes"]}},
+            "explicit_gates": {"contains": {"properties": {"capability_class": {"const": "billing"}}, "required": ["capability_class", "gate_ref"]}}
+          }
+        },
+        {
+          "properties": {
+            "requested_capability_class": {"const": "publication"},
+            "capability_ceiling": {"contains": {"const": "publication"}},
+            "configured_grants": {"contains": {"properties": {"capability_classes": {"contains": {"const": "publication"}}}, "required": ["capability_classes"]}},
+            "explicit_gates": {"contains": {"properties": {"capability_class": {"const": "publication"}}, "required": ["capability_class", "gate_ref"]}}
+          }
+        },
+        {
+          "properties": {
+            "requested_capability_class": {"const": "release"},
+            "capability_ceiling": {"contains": {"const": "release"}},
+            "configured_grants": {"contains": {"properties": {"capability_classes": {"contains": {"const": "release"}}}, "required": ["capability_classes"]}},
+            "explicit_gates": {"contains": {"properties": {"capability_class": {"const": "release"}}, "required": ["capability_class", "gate_ref"]}}
+          }
+        }
+      ]
+    },
+    "ingress_decision_document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "document_type",
+        "decision_id",
+        "event_ref",
+        "provider_id",
+        "event_content_digest",
+        "event_attachment_digests",
+        "policy_ref",
+        "grant_configuration_ref",
+        "verified_actor",
+        "provenance_class",
+        "trust_profile_id",
+        "configured_grants",
+        "capability_ceiling",
+        "requested_operation",
+        "requested_capability_class",
+        "explicit_gates",
+        "scan_verdict_ref",
+        "scan_verdict_key",
+        "scan_result",
+        "attachment_decisions",
+        "decision",
+        "reason_codes",
+        "policy_version",
+        "correlation_id",
+        "idempotency_key",
+        "decided_at",
+        "audit_ref",
+        "output_secret_guard"
+      ],
+      "properties": {
+        "schema_version": {"const": 1},
+        "document_type": {"const": "ingress_decision"},
+        "decision_id": {"$ref": "#/$defs/stable_id"},
+        "event_ref": {"$ref": "#/$defs/reference_id"},
+        "provider_id": {"$ref": "#/$defs/stable_id"},
+        "event_content_digest": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "event_attachment_digests": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+        },
+        "policy_ref": {"$ref": "#/$defs/reference_id"},
+        "grant_configuration_ref": {"$ref": "#/$defs/reference_id"},
+        "verified_actor": {"$ref": "#/$defs/verified_actor"},
+        "provenance_class": {"$ref": "#/$defs/provenance_class"},
+        "trust_profile_id": {"$ref": "#/$defs/trust_profile_id"},
+        "configured_grants": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/configured_grant"}
+        },
+        "capability_ceiling": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/capability_class"}
+        },
+        "requested_operation": {"$ref": "#/$defs/capability_operation"},
+        "requested_capability_class": {"$ref": "#/$defs/capability_class"},
+        "explicit_gates": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/explicit_gate"}
+        },
+        "scan_verdict_ref": {"$ref": "#/$defs/reference_id"},
+        "scan_verdict_key": {"$ref": "#/$defs/verdict_key"},
+        "scan_result": {"enum": ["clean", "findings", "quarantined", "error"]},
+        "attachment_decisions": {
+          "type": "array",
+          "maxItems": 100,
+          "items": {"$ref": "#/$defs/attachment_decision"}
+        },
+        "decision": {"enum": ["allow", "deny", "review", "quarantine"]},
+        "reason_codes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/stable_id"}
+        },
+        "policy_version": {"type": "integer", "minimum": 1},
+        "correlation_id": {"$ref": "#/$defs/stable_id"},
+        "idempotency_key": {"$ref": "#/$defs/stable_id"},
+        "decided_at": {"type": "string", "format": "date-time"},
+        "audit_ref": {"$ref": "#/$defs/reference_id"},
+        "output_secret_guard": {"$ref": "#/$defs/output_secret_guard"}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"decision": {"const": "allow"}}, "required": ["decision"]},
+          "then": {
+            "properties": {
+              "provenance_class": {"not": {"const": "unknown"}},
+              "configured_grants": {"minItems": 1},
+              "scan_result": {"const": "clean"},
+              "attachment_decisions": {
+                "items": {"properties": {"outcome": {"const": "accept"}}, "required": ["outcome"]}
+              },
+              "output_secret_guard": {
+                "properties": {"status": {"const": "clean"}},
+                "required": ["status"]
+              }
+            },
+            "allOf": [{"$ref": "#/$defs/allow_capability_evidence"}]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "decision": {"const": "allow"},
+              "trust_profile_id": {"enum": ["shared-member", "external-bridged"]}
+            },
+            "required": ["decision", "trust_profile_id"]
+          },
+          "then": {
+            "properties": {
+              "attachment_decisions": {
+                "items": {"properties": {"extraction": {"const": "sandboxed"}}, "required": ["extraction"]}
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.agents/scripts/tests/fixtures/team-interface/trust-invalid-attachment.json
+++ b/.agents/scripts/tests/fixtures/team-interface/trust-invalid-attachment.json
@@ -1,0 +1,16 @@
+{
+  "cases": [
+    {
+      "label": "active content cannot be accepted after extraction",
+      "change": {"active_content": true, "outcome": "accept", "extraction": "sandboxed"}
+    },
+    {
+      "label": "owner trust cannot bypass attachment preflight",
+      "change": {"owner_bypass_used": true}
+    },
+    {
+      "label": "a mismatched digest cannot be accepted",
+      "change": {"digest_match": false, "outcome": "accept", "extraction": "sandboxed"}
+    }
+  ]
+}

--- a/.agents/scripts/tests/fixtures/team-interface/trust-invalid-authority.json
+++ b/.agents/scripts/tests/fixtures/team-interface/trust-invalid-authority.json
@@ -1,0 +1,28 @@
+{
+  "cases": [
+    {
+      "label": "membership cannot grant administrator authority",
+      "add": {"membership_grants_administrator": true}
+    },
+    {
+      "label": "model-proposed scopes are not authority inputs",
+      "add": {"model_proposed_scopes": ["administrator"]}
+    },
+    {
+      "label": "clean scanning cannot widen a high-risk capability",
+      "change": {
+        "requested_capability_class": "administrator",
+        "capability_ceiling": ["read", "administrator"],
+        "configured_grants": [
+          {
+            "role_id": "owner",
+            "grant_basis": "configured_role",
+            "configuration_ref": "role-config:team-interface:v1",
+            "capability_classes": ["read", "administrator"]
+          }
+        ],
+        "explicit_gates": []
+      }
+    }
+  ]
+}

--- a/.agents/scripts/tests/fixtures/team-interface/trust-invalid-cache-key.json
+++ b/.agents/scripts/tests/fixtures/team-interface/trust-invalid-cache-key.json
@@ -1,0 +1,21 @@
+{
+  "cases": [
+    {
+      "label": "incomplete key omits scanner version",
+      "remove": "scanner_version"
+    },
+    {
+      "label": "stale policy key cannot reuse the verdict",
+      "change": {"policy_version": 2}
+    },
+    {
+      "label": "attachment digests must be sorted",
+      "change": {
+        "attachment_digests": [
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ]
+      }
+    }
+  ]
+}

--- a/.agents/scripts/tests/fixtures/team-interface/trust-policy-defaults.json
+++ b/.agents/scripts/tests/fixtures/team-interface/trust-policy-defaults.json
@@ -1,0 +1,210 @@
+{
+  "schema_version": 1,
+  "document_type": "trust_policy",
+  "policy_id": "team-interface.trust.default",
+  "policy_version": 1,
+  "core_schema_id": "urn:aidevops:team-interface:core:v1",
+  "grant_configuration_ref": "role-config:team-interface:v1",
+  "gate_authority_ref": "authority-broker:team-interface:v1",
+  "role_grants": [
+    {
+      "role_id": "owner",
+      "grant_basis": "configured_role",
+      "configuration_ref": "role-config:team-interface:v1",
+      "capability_classes": [
+        "read",
+        "answer",
+        "draft",
+        "non_admin_operation",
+        "role_operation",
+        "owner_operation",
+        "administrator",
+        "secret_access",
+        "destructive",
+        "billing",
+        "publication",
+        "release"
+      ]
+    },
+    {
+      "role_id": "maintainer",
+      "grant_basis": "configured_role",
+      "configuration_ref": "role-config:team-interface:v1",
+      "capability_classes": ["read", "answer", "draft", "non_admin_operation", "role_operation"]
+    },
+    {
+      "role_id": "member",
+      "grant_basis": "configured_role",
+      "configuration_ref": "role-config:team-interface:v1",
+      "capability_classes": ["read", "answer", "draft", "non_admin_operation"]
+    },
+    {
+      "role_id": "external",
+      "grant_basis": "configured_role",
+      "configuration_ref": "role-config:team-interface:v1",
+      "capability_classes": ["read", "draft"]
+    }
+  ],
+  "profiles": [
+    {
+      "profile_id": "owner-local",
+      "structural_controls": [
+        "signature_provenance",
+        "schema",
+        "size_type_path",
+        "correlation",
+        "idempotency",
+        "output_secret"
+      ],
+      "deterministic_scan_mode": "conditional",
+      "semantic_scan_mode": "conditional",
+      "attachment_policy": {
+        "mode": "conditional_sandbox",
+        "sandbox_required_for_extraction": true,
+        "owner_bypass_allowed": false,
+        "active_content_allowed": false,
+        "unsafe_outcome": "reject",
+        "max_size_bytes": 104857600
+      },
+      "default_capabilities": ["read", "answer", "draft", "owner_operation"],
+      "capability_ceiling": [
+        "read",
+        "answer",
+        "draft",
+        "non_admin_operation",
+        "role_operation",
+        "owner_operation",
+        "administrator",
+        "secret_access",
+        "destructive",
+        "billing",
+        "publication",
+        "release"
+      ],
+      "explicit_gate_capabilities": [
+        "administrator",
+        "secret_access",
+        "destructive",
+        "billing",
+        "publication",
+        "release"
+      ],
+      "escalation_conditions": [
+        "suspicious_encoding",
+        "forwarded_content",
+        "unknown_provenance",
+        "external_attachment",
+        "elevated_operation",
+        "deterministic_findings",
+        "scanner_error",
+        "capability_escalation"
+      ]
+    },
+    {
+      "profile_id": "trusted-team",
+      "structural_controls": [
+        "signature_provenance",
+        "schema",
+        "size_type_path",
+        "correlation",
+        "idempotency",
+        "output_secret"
+      ],
+      "deterministic_scan_mode": "cached_required",
+      "semantic_scan_mode": "findings_or_elevation",
+      "attachment_policy": {
+        "mode": "conditional_sandbox",
+        "sandbox_required_for_extraction": true,
+        "owner_bypass_allowed": false,
+        "active_content_allowed": false,
+        "unsafe_outcome": "reject",
+        "max_size_bytes": 52428800
+      },
+      "default_capabilities": ["read", "answer", "draft", "role_operation"],
+      "capability_ceiling": ["read", "answer", "draft", "non_admin_operation", "role_operation"],
+      "explicit_gate_capabilities": [],
+      "escalation_conditions": [
+        "forwarded_content",
+        "unknown_provenance",
+        "external_attachment",
+        "elevated_operation",
+        "deterministic_findings",
+        "scanner_error",
+        "capability_escalation"
+      ]
+    },
+    {
+      "profile_id": "shared-member",
+      "structural_controls": [
+        "signature_provenance",
+        "schema",
+        "size_type_path",
+        "correlation",
+        "idempotency",
+        "output_secret"
+      ],
+      "deterministic_scan_mode": "required",
+      "semantic_scan_mode": "findings_or_elevation",
+      "attachment_policy": {
+        "mode": "sandbox_required",
+        "sandbox_required_for_extraction": true,
+        "owner_bypass_allowed": false,
+        "active_content_allowed": false,
+        "unsafe_outcome": "quarantine",
+        "max_size_bytes": 26214400
+      },
+      "default_capabilities": ["read", "answer", "draft"],
+      "capability_ceiling": ["read", "answer", "draft", "non_admin_operation"],
+      "explicit_gate_capabilities": [],
+      "escalation_conditions": [
+        "forwarded_content",
+        "unknown_provenance",
+        "external_attachment",
+        "elevated_operation",
+        "deterministic_findings",
+        "scanner_error",
+        "capability_escalation"
+      ]
+    },
+    {
+      "profile_id": "external-bridged",
+      "structural_controls": [
+        "signature_provenance",
+        "schema",
+        "size_type_path",
+        "correlation",
+        "idempotency",
+        "output_secret"
+      ],
+      "deterministic_scan_mode": "strict",
+      "semantic_scan_mode": "external_or_elevation",
+      "attachment_policy": {
+        "mode": "isolate_or_quarantine",
+        "sandbox_required_for_extraction": true,
+        "owner_bypass_allowed": false,
+        "active_content_allowed": false,
+        "unsafe_outcome": "quarantine",
+        "max_size_bytes": 10485760
+      },
+      "default_capabilities": ["read", "draft"],
+      "capability_ceiling": ["read", "draft"],
+      "explicit_gate_capabilities": [],
+      "escalation_conditions": [
+        "unknown_provenance",
+        "external_attachment",
+        "elevated_operation",
+        "deterministic_findings",
+        "scanner_error",
+        "capability_escalation"
+      ]
+    }
+  ],
+  "high_risk_capabilities": [
+    "administrator",
+    "secret_access",
+    "destructive",
+    "billing",
+    "publication",
+    "release"
+  ]
+}

--- a/.agents/scripts/tests/fixtures/team-interface/trust-valid-decisions.json
+++ b/.agents/scripts/tests/fixtures/team-interface/trust-valid-decisions.json
@@ -1,0 +1,389 @@
+{
+  "documents": [
+    {
+      "schema_version": 1,
+      "document_type": "scan_verdict",
+      "verdict_id": "verdict.owner.clean",
+      "verdict_key": {
+        "content_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "attachment_digests": [],
+        "provider_id": "buzz",
+        "provenance_class": "owner_direct",
+        "trust_profile_id": "owner-local",
+        "scanner_engine": "prompt-guard",
+        "scanner_version": "1.0.0",
+        "policy_version": 1,
+        "requested_capability_class": "read"
+      },
+      "stages": {
+        "structural": {"status": "clean", "evidence_refs": ["evidence:structural:owner"]},
+        "deterministic": {"status": "not_required", "evidence_refs": []},
+        "semantic": {"status": "not_required", "evidence_refs": []},
+        "attachment": {"status": "not_required", "evidence_refs": []}
+      },
+      "result": "clean",
+      "reusable": true,
+      "created_at": "2026-08-04T20:30:00Z"
+    },
+    {
+      "schema_version": 1,
+      "document_type": "scan_verdict",
+      "verdict_id": "verdict.team.error",
+      "verdict_key": {
+        "content_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "attachment_digests": [],
+        "provider_id": "matrix",
+        "provenance_class": "team_direct",
+        "trust_profile_id": "trusted-team",
+        "scanner_engine": "prompt-guard",
+        "scanner_version": "1.0.0",
+        "policy_version": 1,
+        "requested_capability_class": "answer"
+      },
+      "stages": {
+        "structural": {"status": "clean", "evidence_refs": ["evidence:structural:team"]},
+        "deterministic": {"status": "error", "evidence_refs": ["evidence:scanner:error"]},
+        "semantic": {"status": "not_run", "evidence_refs": []},
+        "attachment": {"status": "not_required", "evidence_refs": []}
+      },
+      "result": "error",
+      "reusable": false,
+      "created_at": "2026-08-04T20:31:00Z"
+    },
+    {
+      "schema_version": 1,
+      "document_type": "scan_verdict",
+      "verdict_id": "verdict.shared.findings",
+      "verdict_key": {
+        "content_digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "attachment_digests": ["cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+        "provider_id": "matrix",
+        "provenance_class": "shared_internal",
+        "trust_profile_id": "shared-member",
+        "scanner_engine": "prompt-guard",
+        "scanner_version": "1.0.0",
+        "policy_version": 1,
+        "requested_capability_class": "non_admin_operation"
+      },
+      "stages": {
+        "structural": {"status": "clean", "evidence_refs": ["evidence:structural:shared"]},
+        "deterministic": {"status": "findings", "evidence_refs": ["evidence:scanner:shared"]},
+        "semantic": {"status": "findings", "evidence_refs": ["evidence:semantic:shared"]},
+        "attachment": {"status": "clean", "evidence_refs": ["evidence:attachment:shared"]}
+      },
+      "result": "findings",
+      "reusable": true,
+      "created_at": "2026-08-04T20:31:30Z"
+    },
+    {
+      "schema_version": 1,
+      "document_type": "scan_verdict",
+      "verdict_id": "verdict.external.quarantined",
+      "verdict_key": {
+        "content_digest": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "attachment_digests": ["dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+        "provider_id": "buzz",
+        "provenance_class": "external",
+        "trust_profile_id": "external-bridged",
+        "scanner_engine": "prompt-guard",
+        "scanner_version": "1.0.0",
+        "policy_version": 1,
+        "requested_capability_class": "read"
+      },
+      "stages": {
+        "structural": {"status": "clean", "evidence_refs": ["evidence:structural:external"]},
+        "deterministic": {"status": "findings", "evidence_refs": ["evidence:scanner:external"]},
+        "semantic": {"status": "not_run", "evidence_refs": []},
+        "attachment": {"status": "quarantined", "evidence_refs": ["evidence:attachment:external"]}
+      },
+      "result": "quarantined",
+      "reusable": true,
+      "created_at": "2026-08-04T20:31:45Z"
+    },
+    {
+      "schema_version": 1,
+      "document_type": "ingress_decision",
+      "decision_id": "decision.owner.allow",
+      "event_ref": "event:owner:001",
+      "provider_id": "buzz",
+      "event_content_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "event_attachment_digests": [],
+      "policy_ref": "team-interface.trust.default:v1",
+      "grant_configuration_ref": "role-config:team-interface:v1",
+      "verified_actor": {
+        "subject_id": "subject.owner",
+        "subject_type": "human",
+        "roles": ["owner"],
+        "verification": {
+          "status": "verified",
+          "method": "provider_signature",
+          "evidence_ref": "evidence:actor:owner"
+        },
+        "signature_status": "verified"
+      },
+      "provenance_class": "owner_direct",
+      "trust_profile_id": "owner-local",
+      "configured_grants": [
+        {
+          "role_id": "owner",
+          "grant_basis": "configured_role",
+          "configuration_ref": "role-config:team-interface:v1",
+          "capability_classes": ["read", "answer", "draft", "owner_operation"]
+        }
+      ],
+      "capability_ceiling": ["read", "answer", "draft", "owner_operation"],
+      "requested_operation": "read",
+      "requested_capability_class": "read",
+      "explicit_gates": [],
+      "scan_verdict_ref": "verdict.owner.clean",
+      "scan_verdict_key": {
+        "content_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "attachment_digests": [],
+        "provider_id": "buzz",
+        "provenance_class": "owner_direct",
+        "trust_profile_id": "owner-local",
+        "scanner_engine": "prompt-guard",
+        "scanner_version": "1.0.0",
+        "policy_version": 1,
+        "requested_capability_class": "read"
+      },
+      "scan_result": "clean",
+      "attachment_decisions": [],
+      "decision": "allow",
+      "reason_codes": ["configured_grant_within_ceiling"],
+      "policy_version": 1,
+      "correlation_id": "correlation.owner.001",
+      "idempotency_key": "idempotency.owner.001",
+      "decided_at": "2026-08-04T20:30:01Z",
+      "audit_ref": "audit:decision:owner:001",
+      "output_secret_guard": {"status": "clean", "evidence_ref": "evidence:secret-guard:owner"}
+    },
+    {
+      "schema_version": 1,
+      "document_type": "ingress_decision",
+      "decision_id": "decision.team.deny",
+      "event_ref": "event:team:001",
+      "provider_id": "matrix",
+      "event_content_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "event_attachment_digests": [],
+      "policy_ref": "team-interface.trust.default:v1",
+      "grant_configuration_ref": "role-config:team-interface:v1",
+      "verified_actor": {
+        "subject_id": "subject.team-member",
+        "subject_type": "human",
+        "roles": ["maintainer"],
+        "verification": {
+          "status": "verified",
+          "method": "provider_signature",
+          "evidence_ref": "evidence:actor:team"
+        },
+        "signature_status": "verified"
+      },
+      "provenance_class": "team_direct",
+      "trust_profile_id": "trusted-team",
+      "configured_grants": [
+        {
+          "role_id": "maintainer",
+          "grant_basis": "configured_role",
+          "configuration_ref": "role-config:team-interface:v1",
+          "capability_classes": ["read", "answer", "draft", "role_operation"]
+        }
+      ],
+      "capability_ceiling": ["read", "answer", "draft", "role_operation"],
+      "requested_operation": "send",
+      "requested_capability_class": "answer",
+      "explicit_gates": [],
+      "scan_verdict_ref": "verdict.team.error",
+      "scan_verdict_key": {
+        "content_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "attachment_digests": [],
+        "provider_id": "matrix",
+        "provenance_class": "team_direct",
+        "trust_profile_id": "trusted-team",
+        "scanner_engine": "prompt-guard",
+        "scanner_version": "1.0.0",
+        "policy_version": 1,
+        "requested_capability_class": "answer"
+      },
+      "scan_result": "error",
+      "attachment_decisions": [],
+      "decision": "deny",
+      "reason_codes": ["scanner_error_fail_closed"],
+      "policy_version": 1,
+      "correlation_id": "correlation.team.001",
+      "idempotency_key": "idempotency.team.001",
+      "decided_at": "2026-08-04T20:31:01Z",
+      "audit_ref": "audit:decision:team:001",
+      "output_secret_guard": {"status": "clean", "evidence_ref": "evidence:secret-guard:team"}
+    },
+    {
+      "schema_version": 1,
+      "document_type": "ingress_decision",
+      "decision_id": "decision.shared.review",
+      "event_ref": "event:shared:001",
+      "provider_id": "matrix",
+      "event_content_digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "event_attachment_digests": ["cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+      "policy_ref": "team-interface.trust.default:v1",
+      "grant_configuration_ref": "role-config:team-interface:v1",
+      "verified_actor": {
+        "subject_id": "subject.shared-member",
+        "subject_type": "human",
+        "roles": ["member"],
+        "verification": {
+          "status": "verified",
+          "method": "broker_attestation",
+          "evidence_ref": "evidence:actor:shared"
+        },
+        "signature_status": "not_present"
+      },
+      "provenance_class": "shared_internal",
+      "trust_profile_id": "shared-member",
+      "configured_grants": [
+        {
+          "role_id": "member",
+          "grant_basis": "configured_role",
+          "configuration_ref": "role-config:team-interface:v1",
+          "capability_classes": ["read", "answer", "draft"]
+        }
+      ],
+      "capability_ceiling": ["read", "answer", "draft", "non_admin_operation"],
+      "requested_operation": "create",
+      "requested_capability_class": "non_admin_operation",
+      "explicit_gates": [],
+      "scan_verdict_ref": "verdict.shared.findings",
+      "scan_verdict_key": {
+        "content_digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "attachment_digests": ["cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"],
+        "provider_id": "matrix",
+        "provenance_class": "shared_internal",
+        "trust_profile_id": "shared-member",
+        "scanner_engine": "prompt-guard",
+        "scanner_version": "1.0.0",
+        "policy_version": 1,
+        "requested_capability_class": "non_admin_operation"
+      },
+      "scan_result": "findings",
+      "attachment_decisions": [
+        {
+          "attachment": {
+            "attachment_id": "attachment.shared.pdf",
+            "media_type": "application/pdf",
+            "size_bytes": 2048,
+            "display_name": "proposal.pdf",
+            "digest": {
+              "algorithm": "sha256",
+              "value": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+            },
+            "metadata": {}
+          },
+          "provenance_class": "shared_internal",
+          "digest_match": true,
+          "path_safe": true,
+          "type_allowed": true,
+          "active_content": false,
+          "executable": false,
+          "archive": false,
+          "macros": false,
+          "owner_bypass_used": false,
+          "extraction": "sandboxed",
+          "sandbox_ref": "sandbox:attachment:shared:pdf",
+          "outcome": "accept",
+          "reason_codes": ["sandboxed_safe_attachment"]
+        }
+      ],
+      "decision": "review",
+      "reason_codes": ["capability_requires_configured_grant"],
+      "policy_version": 1,
+      "correlation_id": "correlation.shared.001",
+      "idempotency_key": "idempotency.shared.001",
+      "decided_at": "2026-08-04T20:32:00Z",
+      "audit_ref": "audit:decision:shared:001",
+      "output_secret_guard": {"status": "clean", "evidence_ref": "evidence:secret-guard:shared"}
+    },
+    {
+      "schema_version": 1,
+      "document_type": "ingress_decision",
+      "decision_id": "decision.external.quarantine",
+      "event_ref": "event:external:001",
+      "provider_id": "buzz",
+      "event_content_digest": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "event_attachment_digests": ["dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+      "policy_ref": "team-interface.trust.default:v1",
+      "grant_configuration_ref": "role-config:team-interface:v1",
+      "verified_actor": {
+        "subject_id": "subject.external",
+        "subject_type": "human",
+        "roles": ["external"],
+        "verification": {
+          "status": "verified",
+          "method": "provider_session",
+          "evidence_ref": "evidence:actor:external"
+        },
+        "signature_status": "not_present"
+      },
+      "provenance_class": "external",
+      "trust_profile_id": "external-bridged",
+      "configured_grants": [
+        {
+          "role_id": "external",
+          "grant_basis": "configured_role",
+          "configuration_ref": "role-config:team-interface:v1",
+          "capability_classes": ["read", "draft"]
+        }
+      ],
+      "capability_ceiling": ["read", "draft"],
+      "requested_operation": "read",
+      "requested_capability_class": "read",
+      "explicit_gates": [],
+      "scan_verdict_ref": "verdict.external.quarantined",
+      "scan_verdict_key": {
+        "content_digest": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "attachment_digests": ["dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+        "provider_id": "buzz",
+        "provenance_class": "external",
+        "trust_profile_id": "external-bridged",
+        "scanner_engine": "prompt-guard",
+        "scanner_version": "1.0.0",
+        "policy_version": 1,
+        "requested_capability_class": "read"
+      },
+      "scan_result": "quarantined",
+      "attachment_decisions": [
+        {
+          "attachment": {
+            "attachment_id": "attachment.external.executable",
+            "media_type": "application/octet-stream",
+            "size_bytes": 4096,
+            "display_name": "payload.bin",
+            "digest": {
+              "algorithm": "sha256",
+              "value": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+            },
+            "metadata": {}
+          },
+          "provenance_class": "external",
+          "digest_match": true,
+          "path_safe": true,
+          "type_allowed": false,
+          "active_content": false,
+          "executable": true,
+          "archive": false,
+          "macros": false,
+          "owner_bypass_used": false,
+          "extraction": "quarantined",
+          "outcome": "quarantine",
+          "reason_codes": ["unsafe_executable_attachment"]
+        }
+      ],
+      "decision": "quarantine",
+      "reason_codes": ["unsafe_attachment_quarantined"],
+      "policy_version": 1,
+      "correlation_id": "correlation.external.001",
+      "idempotency_key": "idempotency.external.001",
+      "decided_at": "2026-08-04T20:33:00Z",
+      "audit_ref": "audit:decision:external:001",
+      "output_secret_guard": {"status": "clean", "evidence_ref": "evidence:secret-guard:external"}
+    }
+  ]
+}

--- a/.agents/scripts/tests/test-team-interface-trust-schema.mjs
+++ b/.agents/scripts/tests/test-team-interface-trust-schema.mjs
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv2020 from "ajv/dist/2020.js";
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const schemaDirectory = path.join(testDirectory, "../../schemas/team-interface");
+const fixtureDirectory = path.join(testDirectory, "fixtures/team-interface");
+
+const universalControls = [
+  "signature_provenance",
+  "schema",
+  "size_type_path",
+  "correlation",
+  "idempotency",
+  "output_secret",
+];
+const highRiskCapabilities = [
+  "administrator",
+  "secret_access",
+  "destructive",
+  "billing",
+  "publication",
+  "release",
+];
+const cacheKeyFields = [
+  "content_digest",
+  "attachment_digests",
+  "provider_id",
+  "provenance_class",
+  "trust_profile_id",
+  "scanner_engine",
+  "scanner_version",
+  "policy_version",
+  "requested_capability_class",
+];
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function formatErrors(errors) {
+  return (errors || [])
+    .map((error) => `${error.instancePath || "<root>"} ${error.keyword}: ${error.message}`)
+    .join("\n");
+}
+
+function assertValid(validate, document, label) {
+  assert.equal(validate(document), true, `${label} failed:\n${formatErrors(validate.errors)}`);
+}
+
+function assertInvalid(validate, document, label, predicate = () => true) {
+  assert.equal(validate(document), false, `${label} unexpectedly validated`);
+  assert.ok(predicate(validate.errors || []), `${label} failed for the wrong reason:\n${formatErrors(validate.errors)}`);
+}
+
+function isSorted(values) {
+  return values.every((value, index) => index === 0 || values[index - 1] <= value);
+}
+
+function cacheKeyMatches(storedKey, candidateKey) {
+  if (!isSorted(storedKey.attachment_digests) || !isSorted(candidateKey.attachment_digests)) return false;
+  if (!cacheKeyFields.every((field) => Object.hasOwn(storedKey, field) && Object.hasOwn(candidateKey, field))) return false;
+  return cacheKeyFields.every((field) => JSON.stringify(storedKey[field]) === JSON.stringify(candidateKey[field]));
+}
+
+function authorityAllows(decision, policy) {
+  const requested = decision.requested_capability_class;
+  const actorRoles = new Set(decision.verified_actor.roles);
+  const profile = policy.profiles.find((candidate) => candidate.profile_id === decision.trust_profile_id);
+  const policyRef = `${policy.policy_id}:v${policy.policy_version}`;
+  const configured = decision.configured_grants.some(
+    (grant) => {
+      const policyGrant = policy.role_grants.find((candidate) => candidate.role_id === grant.role_id);
+      return actorRoles.has(grant.role_id)
+      && grant.grant_basis === "configured_role"
+      && grant.configuration_ref === decision.grant_configuration_ref
+      && policyGrant
+      && grant.capability_classes.every((capability) => policyGrant.capability_classes.includes(capability))
+      && grant.capability_classes.includes(requested);
+    },
+  );
+  const withinCeiling = profile
+    && decision.capability_ceiling.every((capability) => profile.capability_ceiling.includes(capability))
+    && decision.capability_ceiling.includes(requested);
+  const explicitHighRiskGate = !highRiskCapabilities.includes(requested)
+    || decision.explicit_gates.some(
+      (gate) => gate.capability_class === requested && gate.authority_ref === policy.gate_authority_ref,
+    );
+  return decision.policy_ref === policyRef
+    && decision.grant_configuration_ref === policy.grant_configuration_ref
+    && configured
+    && withinCeiling
+    && explicitHighRiskGate;
+}
+
+function scanSupportsAllow(verdict, decision) {
+  const blockedStatuses = new Set(["not_run", "findings", "quarantined", "error"]);
+  if (verdict.result !== "clean" || Object.values(verdict.stages).some((stage) => blockedStatuses.has(stage.status))) {
+    return false;
+  }
+  if (verdict.stages.structural.status !== "clean") return false;
+  const elevated = highRiskCapabilities.includes(decision.requested_capability_class);
+  const hasAttachments = decision.event_attachment_digests.length > 0;
+  const deterministicRequired = decision.trust_profile_id !== "owner-local"
+    || decision.provenance_class !== "owner_direct"
+    || hasAttachments
+    || elevated;
+  const semanticRequired = decision.trust_profile_id === "external-bridged"
+    || ["forwarded", "external", "unknown"].includes(decision.provenance_class)
+    || hasAttachments
+    || elevated;
+  return (!deterministicRequired || verdict.stages.deterministic.status === "clean")
+    && (!semanticRequired || verdict.stages.semantic.status === "clean")
+    && (!hasAttachments || verdict.stages.attachment.status === "clean");
+}
+
+function decisionEvidenceMatches(decision, verdicts) {
+  const verdict = verdicts.get(decision.scan_verdict_ref);
+  if (!verdict) return false;
+  const key = verdict.verdict_key;
+  return decision.scan_result === verdict.result
+    && cacheKeyMatches(key, decision.scan_verdict_key)
+    && key.provider_id === decision.provider_id
+    && key.content_digest === decision.event_content_digest
+    && JSON.stringify(key.attachment_digests) === JSON.stringify(decision.event_attachment_digests)
+    && key.provenance_class === decision.provenance_class
+    && key.trust_profile_id === decision.trust_profile_id
+    && key.policy_version === decision.policy_version
+    && key.requested_capability_class === decision.requested_capability_class
+    && decision.configured_grants.every(
+      (grant) => grant.configuration_ref === decision.grant_configuration_ref,
+    );
+}
+
+function attachmentsSupportDecision(decision) {
+  if (decision.decision !== "allow") return true;
+  const allAccepted = decision.attachment_decisions.every((attachment) => attachment.outcome === "accept");
+  const requiresSandbox = ["shared-member", "external-bridged"].includes(decision.trust_profile_id);
+  return allAccepted && (!requiresSandbox
+    || decision.attachment_decisions.every((attachment) => attachment.extraction === "sandboxed"));
+}
+
+function decisionIsSemanticallyValid(decision, verdicts, policy) {
+  if (!decisionEvidenceMatches(decision, verdicts)) return false;
+  if (decision.decision !== "allow") return !scanSupportsAllow(verdicts.get(decision.scan_verdict_ref), decision)
+    || !authorityAllows(decision, policy)
+    || decision.attachment_decisions.some((attachment) => attachment.outcome !== "accept");
+  return decision.provenance_class !== "unknown"
+    && decision.output_secret_guard.status === "clean"
+    && authorityAllows(decision, policy)
+    && scanSupportsAllow(verdicts.get(decision.scan_verdict_ref), decision)
+    && attachmentsSupportDecision(decision);
+}
+
+function applyShallowChange(value, change) {
+  return Object.assign(structuredClone(value), structuredClone(change));
+}
+
+const coreSchema = readJson(path.join(schemaDirectory, "core-v1.schema.json"));
+const trustSchema = readJson(path.join(schemaDirectory, "trust-v1.schema.json"));
+assert.equal(trustSchema.$schema, "https://json-schema.org/draft/2020-12/schema");
+assert.equal(trustSchema.$id, "urn:aidevops:team-interface:trust:v1");
+
+const ajv = new Ajv2020({allErrors: true, strict: false, validateFormats: false});
+ajv.addSchema(coreSchema);
+const validate = ajv.compile(trustSchema);
+
+const policy = readJson(path.join(fixtureDirectory, "trust-policy-defaults.json"));
+assertValid(validate, policy, "canonical trust policy");
+assert.deepEqual(policy.high_risk_capabilities.slice().sort(), highRiskCapabilities.slice().sort());
+
+const profiles = new Map(policy.profiles.map((profile) => [profile.profile_id, profile]));
+assert.deepEqual([...profiles.keys()], ["owner-local", "trusted-team", "shared-member", "external-bridged"]);
+for (const profile of profiles.values()) {
+  assert.deepEqual(profile.structural_controls.slice().sort(), universalControls.slice().sort());
+  assert.equal(profile.attachment_policy.owner_bypass_allowed, false);
+  assert.equal(profile.attachment_policy.active_content_allowed, false);
+  assert.equal(profile.attachment_policy.sandbox_required_for_extraction, true);
+  for (const capability of profile.default_capabilities) {
+    assert.ok(profile.capability_ceiling.includes(capability), `${profile.profile_id} default exceeds its ceiling`);
+  }
+}
+
+const ownerLocal = profiles.get("owner-local");
+assert.equal(ownerLocal.deterministic_scan_mode, "conditional");
+assert.equal(ownerLocal.semantic_scan_mode, "conditional");
+for (const condition of ["suspicious_encoding", "forwarded_content", "external_attachment", "elevated_operation"]) {
+  assert.ok(ownerLocal.escalation_conditions.includes(condition), `owner-local omits ${condition}`);
+}
+assert.ok(highRiskCapabilities.every((capability) => ownerLocal.explicit_gate_capabilities.includes(capability)));
+
+const trustedTeam = profiles.get("trusted-team");
+assert.equal(trustedTeam.deterministic_scan_mode, "cached_required");
+assert.ok(!trustedTeam.capability_ceiling.some((capability) => highRiskCapabilities.includes(capability)));
+
+const sharedMember = profiles.get("shared-member");
+assert.equal(sharedMember.deterministic_scan_mode, "required");
+assert.deepEqual(sharedMember.default_capabilities, ["read", "answer", "draft"]);
+assert.ok(!sharedMember.capability_ceiling.some((capability) => highRiskCapabilities.includes(capability)));
+
+const externalBridged = profiles.get("external-bridged");
+assert.equal(externalBridged.deterministic_scan_mode, "strict");
+assert.deepEqual(externalBridged.default_capabilities, ["read", "draft"]);
+assert.deepEqual(externalBridged.capability_ceiling, ["read", "draft"]);
+
+const widenedTeamPolicy = structuredClone(policy);
+widenedTeamPolicy.profiles[1].capability_ceiling.push("administrator");
+assertInvalid(validate, widenedTeamPolicy, "trusted-team high-risk ceiling widening");
+const widenedSharedDefaults = structuredClone(policy);
+widenedSharedDefaults.profiles[2].default_capabilities.push("non_admin_operation");
+assertInvalid(validate, widenedSharedDefaults, "shared-member default widening");
+const weakenedAttachmentPolicy = structuredClone(policy);
+weakenedAttachmentPolicy.profiles[0].attachment_policy.sandbox_required_for_extraction = false;
+assertInvalid(validate, weakenedAttachmentPolicy, "owner-local sandbox weakening");
+const weakenedOwnerEscalation = structuredClone(policy);
+weakenedOwnerEscalation.profiles[0].escalation_conditions = weakenedOwnerEscalation.profiles[0].escalation_conditions
+  .filter((condition) => condition !== "deterministic_findings");
+assertInvalid(validate, weakenedOwnerEscalation, "owner-local findings escalation removal");
+const weakenedTeamProvenance = structuredClone(policy);
+weakenedTeamProvenance.profiles[1].escalation_conditions = weakenedTeamProvenance.profiles[1].escalation_conditions
+  .filter((condition) => condition !== "unknown_provenance");
+assertInvalid(validate, weakenedTeamProvenance, "trusted-team provenance escalation removal");
+const weakenedSharedForwarding = structuredClone(policy);
+weakenedSharedForwarding.profiles[2].escalation_conditions = weakenedSharedForwarding.profiles[2].escalation_conditions
+  .filter((condition) => condition !== "forwarded_content");
+assertInvalid(validate, weakenedSharedForwarding, "shared-member forwarding escalation removal");
+
+const validFixture = readJson(path.join(fixtureDirectory, "trust-valid-decisions.json"));
+for (const [index, document] of validFixture.documents.entries()) {
+  assertValid(validate, document, `valid trust document ${index}`);
+}
+
+const verdicts = new Map(
+  validFixture.documents
+    .filter((document) => document.document_type === "scan_verdict")
+    .map((document) => [document.verdict_id, document]),
+);
+const decisions = new Map(
+  validFixture.documents
+    .filter((document) => document.document_type === "ingress_decision")
+    .map((document) => [document.decision_id, document]),
+);
+assert.deepEqual(new Set([...decisions.values()].map((decision) => decision.decision)), new Set(["allow", "deny", "review", "quarantine"]));
+for (const decision of decisions.values()) {
+  assert.equal(decisionEvidenceMatches(decision, verdicts), true, `${decision.decision_id} has unresolved or stale scan evidence`);
+  assert.equal(decisionIsSemanticallyValid(decision, verdicts, policy), true, `${decision.decision_id} violates semantic decision policy`);
+}
+
+const allowedDecision = decisions.get("decision.owner.allow");
+assert.equal(authorityAllows(allowedDecision, policy), true);
+assert.equal(scanSupportsAllow(verdicts.get(allowedDecision.scan_verdict_ref), allowedDecision), true);
+const fabricatedPolicyReference = structuredClone(allowedDecision);
+fabricatedPolicyReference.policy_ref = "team-interface.trust.fabricated:v1";
+assert.equal(authorityAllows(fabricatedPolicyReference, policy), false, "fabricated policy authorized ingress");
+
+const scannerErrorDecision = decisions.get("decision.team.deny");
+assert.equal(verdicts.get(scannerErrorDecision.scan_verdict_ref).result, "error");
+assert.notEqual(scannerErrorDecision.decision, "allow", "error must resolve to deny, review, or quarantine");
+
+const unknownProvenanceAllow = structuredClone(allowedDecision);
+unknownProvenanceAllow.provenance_class = "unknown";
+assertInvalid(validate, unknownProvenanceAllow, "unknown provenance allow");
+
+const scannerErrorAllow = structuredClone(scannerErrorDecision);
+scannerErrorAllow.decision = "allow";
+assertInvalid(validate, scannerErrorAllow, "scanner error allow");
+assert.equal(scanSupportsAllow(verdicts.get(scannerErrorAllow.scan_verdict_ref), scannerErrorAllow), false);
+assert.equal(decisionIsSemanticallyValid(scannerErrorAllow, verdicts, policy), false);
+
+const unsafeAttachmentAllow = structuredClone(allowedDecision);
+unsafeAttachmentAllow.attachment_decisions = [
+  structuredClone(decisions.get("decision.external.quarantine").attachment_decisions[0]),
+];
+assertInvalid(validate, unsafeAttachmentAllow, "unsafe attachment allow");
+
+const baseVerdict = verdicts.get("verdict.owner.clean");
+assert.deepEqual(Object.keys(baseVerdict.verdict_key).sort(), cacheKeyFields.slice().sort());
+assert.equal(cacheKeyMatches(baseVerdict.verdict_key, structuredClone(baseVerdict.verdict_key)), true);
+const keyChanges = {
+  content_digest: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  attachment_digests: ["ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"],
+  provider_id: "matrix",
+  provenance_class: "forwarded",
+  trust_profile_id: "trusted-team",
+  scanner_engine: "semantic-guard",
+  scanner_version: "2.0.0",
+  policy_version: 2,
+  requested_capability_class: "draft",
+};
+for (const [field, value] of Object.entries(keyChanges)) {
+  const changedKey = structuredClone(baseVerdict.verdict_key);
+  changedKey[field] = value;
+  assert.equal(cacheKeyMatches(baseVerdict.verdict_key, changedKey), false, `${field} change reused stale verdict`);
+  const staleDecision = structuredClone(allowedDecision);
+  staleDecision.scan_verdict_key = changedKey;
+  assert.equal(decisionIsSemanticallyValid(staleDecision, verdicts, policy), false, `${field} stale key authorized ingress`);
+}
+
+const copiedEventVerdict = structuredClone(allowedDecision);
+copiedEventVerdict.event_content_digest = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+assert.equal(decisionIsSemanticallyValid(copiedEventVerdict, verdicts, policy), false, "stale verdict authorized another event");
+
+const fabricatedGrantConfiguration = structuredClone(allowedDecision);
+fabricatedGrantConfiguration.grant_configuration_ref = "role-config:fabricated:v1";
+fabricatedGrantConfiguration.configured_grants[0].configuration_ref = "role-config:fabricated:v1";
+assert.equal(authorityAllows(fabricatedGrantConfiguration, policy), false, "fabricated role configuration authorized ingress");
+
+const invalidCache = readJson(path.join(fixtureDirectory, "trust-invalid-cache-key.json"));
+for (const invalidCase of invalidCache.cases) {
+  const candidateVerdict = structuredClone(baseVerdict);
+  if (invalidCase.remove) {
+    delete candidateVerdict.verdict_key[invalidCase.remove];
+    assertInvalid(validate, candidateVerdict, invalidCase.label);
+    continue;
+  }
+  Object.assign(candidateVerdict.verdict_key, invalidCase.change);
+  assertValid(validate, candidateVerdict, `${invalidCase.label} remains a well-formed distinct verdict`);
+  assert.equal(cacheKeyMatches(baseVerdict.verdict_key, candidateVerdict.verdict_key), false, invalidCase.label);
+}
+
+const invalidAuthority = readJson(path.join(fixtureDirectory, "trust-invalid-authority.json"));
+for (const invalidCase of invalidAuthority.cases) {
+  let candidate = structuredClone(allowedDecision);
+  if (invalidCase.add) {
+    candidate = applyShallowChange(candidate, invalidCase.add);
+    assertInvalid(
+      validate,
+      candidate,
+      `trust-invalid-authority: ${invalidCase.label}`,
+      (errors) => errors.some((error) => error.keyword === "additionalProperties"),
+    );
+    continue;
+  }
+  candidate = applyShallowChange(candidate, invalidCase.change);
+  assertInvalid(validate, candidate, `trust-invalid-authority: ${invalidCase.label}`);
+  assert.equal(authorityAllows(candidate, policy), false, invalidCase.label);
+}
+
+const explicitlyGatedAdministrator = applyShallowChange(allowedDecision, {
+  requested_capability_class: "administrator",
+  capability_ceiling: ["read", "administrator"],
+  configured_grants: [{
+    role_id: "owner",
+    grant_basis: "configured_role",
+    configuration_ref: "role-config:team-interface:v1",
+    capability_classes: ["read", "administrator"],
+  }],
+  explicit_gates: [{
+    capability_class: "administrator",
+    gate_ref: "gate:administrator:approved",
+    authority_ref: "authority-broker:team-interface:v1",
+  }],
+});
+const administratorVerdict = structuredClone(baseVerdict);
+administratorVerdict.verdict_id = "verdict.owner.administrator.clean";
+administratorVerdict.verdict_key.requested_capability_class = "administrator";
+administratorVerdict.stages.deterministic = {status: "clean", evidence_refs: ["evidence:scanner:administrator"]};
+administratorVerdict.stages.semantic = {status: "clean", evidence_refs: ["evidence:semantic:administrator"]};
+explicitlyGatedAdministrator.scan_verdict_ref = administratorVerdict.verdict_id;
+explicitlyGatedAdministrator.scan_verdict_key = structuredClone(administratorVerdict.verdict_key);
+const verdictsWithAdministrator = new Map(verdicts);
+verdictsWithAdministrator.set(administratorVerdict.verdict_id, administratorVerdict);
+assertValid(validate, administratorVerdict, "explicitly gated administrator verdict");
+assertValid(validate, explicitlyGatedAdministrator, "explicitly gated administrator decision");
+assert.equal(authorityAllows(explicitlyGatedAdministrator, policy), true);
+assert.equal(scanSupportsAllow(administratorVerdict, explicitlyGatedAdministrator), true);
+assert.equal(decisionIsSemanticallyValid(explicitlyGatedAdministrator, verdictsWithAdministrator, policy), true);
+
+const fabricatedGateAuthority = structuredClone(explicitlyGatedAdministrator);
+fabricatedGateAuthority.explicit_gates[0].authority_ref = "authority-broker:fabricated:v1";
+assert.equal(authorityAllows(fabricatedGateAuthority, policy), false, "fabricated gate authority authorized ingress");
+
+const safeAttachmentDecision = decisions.get("decision.shared.review").attachment_decisions[0];
+const invalidAttachments = readJson(path.join(fixtureDirectory, "trust-invalid-attachment.json"));
+for (const invalidCase of invalidAttachments.cases) {
+  const candidate = structuredClone(decisions.get("decision.shared.review"));
+  candidate.attachment_decisions[0] = applyShallowChange(safeAttachmentDecision, invalidCase.change);
+  assertInvalid(validate, candidate, `trust-invalid-attachment: ${invalidCase.label}`);
+}
+
+console.log("PASS: team-interface trust schema enforces adaptive screening, complete cache keys, and deterministic authority ceilings");


### PR DESCRIPTION
## Summary

- define the versioned adaptive ingress trust, scan-verdict cache, attachment, and deterministic authority contracts
- add canonical defaults for owner-local, trusted-team, shared-member, and external-bridged profiles
- add schema fixtures and semantic policy tests for cache invalidation and negative privilege cases

## Testing

- `node .agents/scripts/tests/test-team-interface-trust-schema.mjs`

## Runtime Testing

- `self-assessed`: additive schema, fixtures, tests, and reference documentation only; no provider or permission runtime changes

Resolves #29495
Ref #29494
Ref mission `m-20260804-5d06b1`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.220 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol
