### PR TITLE
GH#29498: Accept Buzz null-pubkey built-ins

### DIFF
--- a/.agents/scripts/buzz-desktop-helper.sh
+++ b/.agents/scripts/buzz-desktop-helper.sh
@@ -113,11 +113,20 @@ _buzz_validate_store() {
 	_buzz_validate_private_file "$BUZZ_STORE_PATH" "Buzz managed-agent store" || return 1
 	jq -e '
 		def is_array: type == "array";
+		def is_string: type == "string";
+		def command_basename:
+			if is_string then (split("/") | last) else "" end;
+		def needs_patch:
+			([.agent_command, .agent_command_override]
+				| map(command_basename)
+				| any(. == "opencode")) and
+			(((.agent_args // []) | length) == 0);
 		is_array and
 		all(.[];
 			type == "object" and
-			((.pubkey | type) == "string" and (.pubkey | length) > 0) and
-			((.agent_args == null) or (.agent_args | is_array))
+			((.agent_args == null) or (.agent_args | is_array)) and
+			((needs_patch | not) or
+				((.pubkey | is_string) and (.pubkey | length) > 0))
 		)
 	' "$BUZZ_STORE_PATH" >/dev/null 2>&1 || {
 		print_error "Buzz managed-agent store has an invalid record schema"

--- a/.agents/tests/test-buzz-desktop-helper.sh
+++ b/.agents/tests/test-buzz-desktop-helper.sh
@@ -125,6 +125,14 @@ write_store() {
     "name": "Other harness",
     "agent_command": "/usr/local/bin/goose",
     "agent_args": []
+  },
+  {
+    "pubkey": null,
+    "name": "Built-in harness",
+    "is_builtin": true,
+    "agent_command": "builtin",
+    "agent_args": [],
+    "unknown": {"preserve": true}
   }
 ]
 JSON
@@ -173,6 +181,9 @@ test_apply_is_bounded_and_private() {
 		'["acp","--cwd","/project"]'
 	assert_eq "apply preserves unrelated harness arguments" \
 		"$(jq -c '.[] | select(.pubkey == "pub-other") | .agent_args' "$TEST_STORE")" '[]'
+	assert_eq "apply accepts and preserves unrelated null-pubkey records" \
+		"$(jq -c '.[] | select(.name == "Built-in harness") | {pubkey,agent_args,unknown}' "$TEST_STORE")" \
+		'{"pubkey":null,"agent_args":[],"unknown":{"preserve":true}}'
 	assert_eq "apply preserves unknown fields" \
 		"$(jq -r '.[] | select(.pubkey == "pub-empty-path") | .unknown.preserve' "$TEST_STORE")" "true"
 	assert_file_exists "apply records private rollback state" "$TEST_STATE_FILE"


### PR DESCRIPTION
## Summary

- accept valid unrelated Buzz built-in records whose `pubkey` is null
- continue requiring a non-empty `pubkey` for OpenCode records that the compatibility migration would mutate
- preserve fail-closed behavior for malformed mutation targets

## Evidence

Live reconciliation of the shipped helper failed before mutation because Buzz Desktop 0.5.4 stores valid built-in records with null `pubkey` values. Sanitized inspection confirmed those records were unrelated to OpenCode. The validation now applies identity requirements only to records requiring the ACP patch.

## Files

- `.agents/scripts/buzz-desktop-helper.sh`
- `.agents/tests/test-buzz-desktop-helper.sh`

## Verification

- `bash .agents/tests/test-buzz-desktop-helper.sh` — 29 passed
- `shellcheck .agents/scripts/buzz-desktop-helper.sh .agents/tests/test-buzz-desktop-helper.sh`
- `bash -n .agents/scripts/buzz-desktop-helper.sh .agents/tests/test-buzz-desktop-helper.sh`
- `.agents/scripts/linters-local.sh`

For #29498

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.221 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol
