### PR TITLE
GH#29458: Preserve audit snapshots through REST fallback

### DIFF
--- a/.agents/reference/gh-audit-log.md
+++ b/.agents/reference/gh-audit-log.md
@@ -110,6 +110,9 @@ The `suspicious[]` array is populated when any of these signals fires:
 delta can be inferred for that operation.
 
 **Normal causes:** Transient network, authentication, or API availability errors.
+Audit reads use the framework read wrappers, including their REST fallback when
+GraphQL is exhausted; the signal remains actionable when every supported read
+transport is unavailable.
 
 **Abnormal causes:** Persistent loss of audit visibility or a broken state-read path.
 

--- a/.agents/scripts/shared-gh-wrappers-safe-edit.sh
+++ b/.agents/scripts/shared-gh-wrappers-safe-edit.sh
@@ -156,11 +156,17 @@ _gh_audit_fetch_issue_state_json() {
 	}
 
 	local data
-	data=$(gh issue view "$issue_num" --repo "$repo" \
-		--json title,body,labels 2>/dev/null) || {
+	if command -v gh_issue_view >/dev/null 2>&1; then
+		data=$(gh_issue_view "$issue_num" --repo "$repo" \
+			--json title,body,labels 2>/dev/null) || data=""
+	else
+		data=$(gh issue view "$issue_num" --repo "$repo" \
+			--json title,body,labels 2>/dev/null) || data=""
+	fi
+	if [[ -z "$data" ]]; then
 		printf '%s\n' "$unavailable"
 		return 0
-	}
+	fi
 
 	jq -c '{
 		capture_status: "ok",
@@ -192,11 +198,17 @@ _gh_audit_fetch_pr_state_json() {
 	}
 
 	local data
-	data=$(gh pr view "$pr_num" --repo "$repo" \
-		--json title,body,labels 2>/dev/null) || {
+	if command -v gh_pr_view >/dev/null 2>&1; then
+		data=$(gh_pr_view "$pr_num" --repo "$repo" \
+			--json title,body,labels 2>/dev/null) || data=""
+	else
+		data=$(gh pr view "$pr_num" --repo "$repo" \
+			--json title,body,labels 2>/dev/null) || data=""
+	fi
+	if [[ -z "$data" ]]; then
 		printf '%s\n' "$unavailable"
 		return 0
-	}
+	fi
 
 	jq -c '{
 		capture_status: "ok",

--- a/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
+++ b/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
@@ -200,6 +200,25 @@ jq -e -s 'map(select(.number == 27))[0].flags == {}' "$PROOF_LOG" >/dev/null ||
 unset CURRENT_ACTOR
 unset GH_AUDIT_LOG_FILE
 
+gh_issue_view() {
+	printf '%s\n' '{"title":"REST issue snapshot","body":"Protected body","labels":[{"name":"monitoring"}]}'
+	return 0
+}
+gh_pr_view() {
+	printf '%s\n' '{"title":"REST PR snapshot","body":"Protected body","labels":[{"name":"monitoring"}]}'
+	return 0
+}
+gh() {
+	return 1
+}
+wrapped_issue="$(_gh_audit_fetch_issue_state_json "8" "example/repo")"
+wrapped_pr="$(_gh_audit_fetch_pr_state_json "9" "example/repo")"
+jq -e '.capture_status == "ok" and .title_len == 19 and .body_len == 14 and .labels == ["monitoring"]' \
+	<<<"$wrapped_issue" >/dev/null || fail "issue audit capture bypassed the REST-capable read wrapper"
+jq -e '.capture_status == "ok" and .title_len == 16 and .body_len == 14 and .labels == ["monitoring"]' \
+	<<<"$wrapped_pr" >/dev/null || fail "PR audit capture bypassed the REST-capable read wrapper"
+unset -f gh_issue_view gh_pr_view
+
 gh() {
 	local resource="${1:-}"
 	if [[ "$resource" != "issue" && "$resource" != "pr" ]]; then


### PR DESCRIPTION
## Summary

Route issue and PR audit snapshots through the existing REST-capable read wrappers while retaining fail-closed unavailable snapshots when every transport fails.

## Files Changed

.agents/reference/gh-audit-log.md, .agents/scripts/shared-gh-wrappers-safe-edit.sh, .agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — anomaly transition regression passed; gh edit safety 29/29; issue read REST fallback 30/30; ShellCheck clean; linters-local passed; version consistency passed; review bundle 9181605e649c3a9c317f78b0434713c44cba8125ade04949a3f32d1288c3b013

Resolves #29458


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.221 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 10m and 179,433 tokens on this with the user in an interactive session.