### PR TITLE
t18199: Recover split issue sync availability

### DIFF
--- a/.agents/scripts/issue-sync-helper-push.sh
+++ b/.agents/scripts/issue-sync-helper-push.sh
@@ -280,7 +280,7 @@ cmd_push() {
 	print_info "Processing ${#tasks[@]} task(s) for push to $repo"
 	gh_create_label "$repo" "status:available" "0E8A16" "Task is available for claiming"
 
-	local created=0 skipped=0 failed=0
+	local created=0 skipped=0 failed=0 relationships_pending=0
 	for task_id in "${tasks[@]}"; do
 		local result
 		if ! result=$(_push_process_task "$task_id" "$repo" "$todo_file" "$project_root"); then
@@ -288,11 +288,16 @@ cmd_push() {
 		fi
 		[[ "$result" == *"CREATED"* ]] && created=$((created + 1))
 		[[ "$result" == *"SKIPPED"* ]] && skipped=$((skipped + 1))
+		[[ "$result" == *"RELATIONSHIPS_PENDING"* ]] && relationships_pending=$((relationships_pending + 1))
 	done
-	print_info "Push complete: $created created, $skipped skipped, $failed failed"
+	print_info "Push complete: $created created, $skipped skipped, $failed failed, $relationships_pending relationships pending"
 	if [[ $failed -gt 0 ]]; then
 		print_error "Issue creation failed for $failed task(s); TODO.md still contains active task(s) without GitHub refs"
 		return 1
+	fi
+	if [[ $relationships_pending -gt 0 ]]; then
+		print_error "Relationship sync remains pending for $relationships_pending created task(s); durable refs were preserved. Recovery: rerun issue-sync-helper.sh relationships"
+		return 2
 	fi
 	return 0
 }

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -138,11 +138,14 @@ verify_gh_cli() {
 		return 1
 	}
 	[[ -n "${GH_TOKEN:-}" || -n "${GITHUB_TOKEN:-}" ]] && return 0
-	gh auth status &>/dev/null 2>&1 || {
-		print_error "gh CLI not authenticated. Run: gh auth login"
-		return 1
-	}
-	return 0
+	gh auth status &>/dev/null 2>&1 && return 0
+	# Stored keyring status can be stale while an App or environment-backed
+	# credential still serves authenticated API requests. Test the capability
+	# issue sync needs before reporting authentication unavailable.
+	gh api graphql -f 'query={viewer{login}}' --jq '.data.viewer.login // empty' &>/dev/null 2>&1 && return 0
+	gh api user --jq '.login // empty' &>/dev/null 2>&1 && return 0
+	print_error "gh CLI cannot authenticate an API request. Run: gh auth login"
+	return 1
 }
 
 # Common preamble for commands that need project_root, repo, todo_file, gh auth

--- a/.agents/scripts/issue-sync-lib-ref.sh
+++ b/.agents/scripts/issue-sync-lib-ref.sh
@@ -216,6 +216,59 @@ add_pr_ref_to_todo() {
 # These mutations are NOT idempotent — duplicates return validation errors.
 # All functions suppress "already taken" / "duplicate sub-issues" errors.
 
+# Resolve an exact repository slug to its immutable GitHub node ID. GraphQL and
+# REST availability can diverge, so each transport gets one bounded attempt and
+# only a response that proves the requested owner/name may establish identity.
+# Arguments:
+#   $1 - repo slug (owner/repo)
+# Returns: repository node ID on stdout, or non-zero when identity is unproven
+_github_repository_slug_matches() {
+	local expected="$1"
+	local actual="$2"
+	local expected_normalized="" actual_normalized=""
+	[[ -n "$expected" && -n "$actual" ]] || return 1
+	expected_normalized=$(printf '%s' "$expected" | tr '[:upper:]' '[:lower:]')
+	actual_normalized=$(printf '%s' "$actual" | tr '[:upper:]' '[:lower:]')
+	[[ "$expected_normalized" == "$actual_normalized" ]] && return 0
+	return 1
+}
+
+resolve_repository_node_id() {
+	local repo="$1"
+	[[ "$repo" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || return 1
+	local owner="${repo%%/*}"
+	local name="${repo##*/}"
+	local response="" reported_cost="" repository_id="" response_slug=""
+
+	# shellcheck disable=SC2016  # GraphQL variables are expanded by GitHub, not shell.
+	response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
+		AIDEVOPS_GH_ROUTE_DECISION="issue-sync-repository-id-exact-cost" \
+		_gh_with_timeout read gh api graphql \
+		-f query='query($owner:String!,$name:String!){repository(owner:$owner,name:$name){id nameWithOwner}rateLimit{cost}}' \
+		-f owner="$owner" -f name="$name" 2>/dev/null) || response=""
+	if [[ -n "$response" ]]; then
+		reported_cost=$(printf '%s' "$response" | jq -r "$_ISLR_GRAPHQL_COST_FILTER" 2>/dev/null) || reported_cost=""
+	fi
+	if [[ -n "$response" && "$reported_cost" =~ ^[1-9][0-9]*$ ]] &&
+		IFS=$'\034' read -r repository_id response_slug < <(
+			printf '%s' "$response" | jq -r \
+				'[.data.repository.id, .data.repository.nameWithOwner] | map(. // empty) | join("\u001c")' 2>/dev/null
+		) && [[ -n "$repository_id" ]] && _github_repository_slug_matches "$repo" "$response_slug"; then
+		printf '%s\n' "$repository_id"
+		return 0
+	fi
+
+	response=$(_gh_with_timeout read gh api "repos/${repo}" 2>/dev/null) || response=""
+	if [[ -n "$response" ]] && IFS=$'\034' read -r repository_id response_slug < <(
+		printf '%s' "$response" | jq -r \
+			'[.node_id, .full_name] | map(. // empty) | join("\u001c")' 2>/dev/null
+	) && [[ -n "$repository_id" ]] && _github_repository_slug_matches "$repo" "$response_slug"; then
+		printf '%s\n' "$repository_id"
+		return 0
+	fi
+	return 1
+}
+
 # Resolve a task ID to a repository-validated GitHub issue mapping. The
 # coordinator is authoritative; ref:GH remains a migration projection that is
 # backfilled only after both repository and issue node identities are fetched.
@@ -230,7 +283,7 @@ resolve_task_gh_number() {
 	local repo="${3:-}"
 	[[ "$repo" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || return 1
 	local repository_id="" mapping="" coordinator="${SCRIPT_DIR}/task-coordinator.mjs"
-	repository_id=$(_gh_with_timeout read gh api "repos/${repo}" --jq '.node_id // ""' 2>/dev/null || true)
+	repository_id=$(resolve_repository_node_id "$repo" || true)
 	[[ -n "$repository_id" ]] || return 1
 	if [[ -f "$coordinator" ]]; then
 		mapping=$(node "$coordinator" resolve-issue --task-id "$task_id" --forge github \

--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -58,6 +58,7 @@ _NODE_ID_RATE_LIMITED_FILE=""
 _RELATIONSHIP_EDGE_SEEN_FILE=""
 _RELATIONSHIP_RESULT_FILE=""
 _RELATIONSHIP_BACKEND_CALL_FILE=""
+_RELATIONSHIP_SUCCESS_RESULT="RELS:0 RETRYABLE:0"
 _RELATIONSHIP_RETRY_RESULT="RELS:0 RETRYABLE:1"
 _RELATIONSHIP_SYNC_SCOPE_ACTIVE=0
 _RELATIONSHIP_SYNC_DEADLINE_EPOCH=
@@ -873,9 +874,17 @@ _sync_blocked_by_for_task() {
 		blocks) blocks="$value" ;;
 		esac
 	done <<<"$parsed"
-	[[ -z "$blocked_by" && -z "$blocks" ]] && return 0
+	if [[ -z "$blocked_by" && -z "$blocks" ]]; then
+		echo "$_RELATIONSHIP_SUCCESS_RESULT"
+		return 0
+	fi
 	this_gh_num=$(resolve_task_gh_number "$task_id" "$todo_file" "$repo" || true)
-	[[ -z "$this_gh_num" ]] && { log_verbose "$task_id: no ref:GH# — skipping relationships"; return 0; }
+	if [[ -z "$this_gh_num" ]]; then
+		log_verbose "$task_id: declared relationship mapping unresolved; retaining for retry"
+		_relationship_record_outcome "$_REL_OUTCOME_FAILED_RESOLUTION"
+		echo "$_RELATIONSHIP_RETRY_RESULT"
+		return 0
+	fi
 	this_node_id=$(_cached_node_id "$this_gh_num" "$repo")
 	if [[ -z "$this_node_id" ]]; then
 		log_verbose "$task_id: could not resolve node ID for #$this_gh_num"
@@ -1205,7 +1214,7 @@ cmd_relationships() {
 		_relationship_print_progress "$attempted" "$total"
 
 		# Blocked-by / blocks
-		result=$(_sync_blocked_by_for_task "$current_task" "$todo_file" "$repo" 2>/dev/null || echo "RELS:0")
+		result=$(_sync_blocked_by_for_task "$current_task" "$todo_file" "$repo" 2>/dev/null || echo "$_RELATIONSHIP_RETRY_RESULT")
 		n=$(echo "$result" | grep -oE 'RELS:[0-9]+' | head -1 | sed 's/RELS://' || echo "0")
 		blocked_set=$((blocked_set + n))
 		n=$(echo "$result" | grep -oE 'RETRYABLE:[0-9]+' | head -1 | sed 's/RETRYABLE://' || echo "0")

--- a/.agents/scripts/tests/test-issue-mapping-isolation.sh
+++ b/.agents/scripts/tests/test-issue-mapping-isolation.sh
@@ -9,7 +9,7 @@ trap 'rm -rf "$TEST_ROOT"' EXIT
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export AIDEVOPS_TASK_COORDINATOR_DB="${TEST_ROOT}/coordinator.db"
 TODO_FILE="${TEST_ROOT}/TODO.md"
-printf '%s\n' '- [ ] t101 first repository task ref:GH#42' '- [ ] t102 second repository task ref:GH#42' '- [ ] t1873.1 dotted task ref:GH#73' >"$TODO_FILE"
+printf '%s\n' '- [ ] t101 first repository task ref:GH#42' '- [ ] t102 second repository task ref:GH#42' '- [ ] t1873.1 dotted task ref:GH#73' '- [ ] t201 GraphQL repository task ref:GH#88' >"$TODO_FILE"
 
 _escape_ere() {
 	printf '%s' "$1"
@@ -34,15 +34,34 @@ _gh_with_timeout() {
 	return $?
 }
 
+REPOSITORY_TRANSPORT="rest-only"
 gh() {
 	local group="$1"
 	shift
 	if [[ "$group" == "api" ]]; then
 		local endpoint="$1"
+		if [[ "$endpoint" == "graphql" ]]; then
+			case "$REPOSITORY_TRANSPORT" in
+			graphql-only) printf '%s\n' '{"data":{"repository":{"id":"R_graphql","nameWithOwner":"owner/graphql"},"rateLimit":{"cost":1}}}' ;;
+			wrong) printf '%s\n' '{"data":{"repository":{"id":"R_wrong","nameWithOwner":"other/repo"},"rateLimit":{"cost":1}}}' ;;
+			missing-cost) printf '%s\n' '{"data":{"repository":{"id":"R_graphql","nameWithOwner":"owner/graphql"},"rateLimit":{}}}' ;;
+			malformed) printf '%s\n' '{"data":{"repository":{"nameWithOwner":"owner/graphql"},"rateLimit":{"cost":1}}}' ;;
+			*) return 1 ;;
+			esac
+			return 0
+		fi
 		case "$endpoint" in
-		repos/owner/one | repos/owner/renamed-one) printf '%s\n' R_one ;;
-		repos/owner/two) printf '%s\n' R_two ;;
-		repos/owner/dotted) printf '%s\n' R_dotted ;;
+		repos/owner/one) printf '%s\n' '{"node_id":"R_one","full_name":"owner/one"}' ;;
+		repos/owner/renamed-one) printf '%s\n' '{"node_id":"R_one","full_name":"owner/renamed-one"}' ;;
+		repos/owner/two) printf '%s\n' '{"node_id":"R_two","full_name":"owner/two"}' ;;
+		repos/owner/dotted) printf '%s\n' '{"node_id":"R_dotted","full_name":"owner/dotted"}' ;;
+		repos/owner/graphql)
+			case "$REPOSITORY_TRANSPORT" in
+			rest-only) printf '%s\n' '{"node_id":"R_rest","full_name":"owner/graphql"}' ;;
+			wrong) printf '%s\n' '{"node_id":"R_wrong","full_name":"other/repo"}' ;;
+			*) return 1 ;;
+			esac
+			;;
 		*) return 1 ;;
 		esac
 		return 0
@@ -60,6 +79,7 @@ gh() {
 		owner/one | owner/renamed-one) [[ "$issue_number" == "42" ]] && printf '%s\n' '{"id":"I_one_42","number":42,"state":"OPEN","updatedAt":"2026-07-12T10:00:00Z"}' || return 1 ;;
 		owner/two) printf '%s\n' '{"id":"I_two_42","number":42,"state":"CLOSED","updatedAt":"2026-07-12T11:00:00Z"}' ;;
 		owner/dotted) printf '%s\n' '{"id":"I_dotted_73","number":73,"state":"OPEN","updatedAt":"2026-07-12T12:00:00Z"}' ;;
+		owner/graphql) printf '%s\n' '{"id":"I_graphql_88","number":88,"state":"OPEN","updatedAt":"2026-07-12T13:00:00Z"}' ;;
 		*) return 1 ;;
 		esac
 		return 0
@@ -72,8 +92,8 @@ source "${SCRIPT_DIR}/issue-sync-lib-ref.sh"
 
 : >"$JQ_CALL_LOG"
 [[ "$(resolve_task_gh_number t101 "$TODO_FILE" owner/one)" == "42" ]]
-if [[ "$(wc -l <"$JQ_CALL_LOG" | tr -d ' ')" != "2" ]]; then
-	printf 'FAIL issue backfill did not parse fields with one jq process\n' >&2
+if [[ "$(wc -l <"$JQ_CALL_LOG" | tr -d ' ')" != "3" ]]; then
+	printf 'FAIL repository identity and issue backfill did not use bounded jq parsing\n' >&2
 	exit 1
 fi
 [[ "$(resolve_task_gh_number t102 "$TODO_FILE" owner/two)" == "42" ]]
@@ -82,12 +102,18 @@ fi
 [[ "$(node "${SCRIPT_DIR}/task-coordinator.mjs" resolve-issue --task-id t102 --repository-id R_two | jq -r '.issueId')" == "I_two_42" ]]
 require_task_issue_mapping t1873.1 "$TODO_FILE" owner/dotted 73
 
+REPOSITORY_TRANSPORT="graphql-only"
+[[ "$(resolve_task_gh_number t201 "$TODO_FILE" owner/graphql)" == "88" ]]
+[[ "$(node "${SCRIPT_DIR}/task-coordinator.mjs" resolve-issue --task-id t201 --repository-id R_graphql | jq -r '.issueId')" == "I_graphql_88" ]]
+[[ "$(resolve_repository_node_id Owner/GraphQL)" == "R_graphql" ]]
+REPOSITORY_TRANSPORT="rest-only"
+
 # Existing coordinator mappings are decoded in one jq process even when
 # optional project and cursor fields are empty.
 : >"$JQ_CALL_LOG"
 [[ "$(resolve_task_gh_number t102 "$TODO_FILE" owner/two)" == "42" ]]
-if [[ "$(wc -l <"$JQ_CALL_LOG" | tr -d ' ')" != "1" ]]; then
-	printf 'FAIL coordinator mapping did not parse fields with one jq process\n' >&2
+if [[ "$(wc -l <"$JQ_CALL_LOG" | tr -d ' ')" != "2" ]]; then
+	printf 'FAIL repository identity and coordinator mapping did not use bounded jq parsing\n' >&2
 	exit 1
 fi
 
@@ -104,6 +130,16 @@ if resolve_task_gh_number t101 "$TODO_FILE" local/only >/dev/null 2>&1; then
 	printf 'FAIL local-only repository resolved an issue write target\n' >&2
 	exit 1
 fi
+
+# Repository identity fails closed when neither transport proves the exact
+# owner/name and a non-empty node ID. GraphQL cost must come from its response.
+for REPOSITORY_TRANSPORT in wrong missing-cost malformed total-outage; do
+	if resolve_repository_node_id owner/graphql >/dev/null 2>&1; then
+		printf 'FAIL invalid repository identity was accepted (%s)\n' "$REPOSITORY_TRANSPORT" >&2
+		exit 1
+	fi
+done
+REPOSITORY_TRANSPORT="rest-only"
 
 # A conflicting projection for the same immutable task/repository fails closed.
 printf '%s\n' '- [ ] t101 conflicting task projection ref:GH#43' >"$TODO_FILE"

--- a/.agents/scripts/tests/test-issue-sync-auth-capability.sh
+++ b/.agents/scripts/tests/test-issue-sync-auth-capability.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${TEST_DIR}/.."
+
+# shellcheck source=../issue-sync-helper.sh
+source "${SCRIPTS_DIR}/issue-sync-helper.sh"
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+AUTH_STATUS="failed"
+API_TRANSPORT="failed"
+GH_CALLS=0
+gh() {
+	local group="$1"
+	local action="${2:-}"
+	GH_CALLS=$((GH_CALLS + 1))
+	if [[ "$group" == "auth" && "$action" == "status" ]]; then
+		[[ "$AUTH_STATUS" == "healthy" ]]
+		return $?
+	fi
+	if [[ "$group" == "api" && "$action" == "graphql" ]]; then
+		[[ "$API_TRANSPORT" == "graphql" ]] && printf 'fixture-user\n'
+		[[ "$API_TRANSPORT" == "graphql" ]]
+		return $?
+	fi
+	if [[ "$group" == "api" && "$action" == "user" ]]; then
+		[[ "$API_TRANSPORT" == "rest" ]] && printf 'fixture-user\n'
+		[[ "$API_TRANSPORT" == "rest" ]]
+		return $?
+	fi
+	return 1
+}
+
+GH_TOKEN="fixture-token" GITHUB_TOKEN="" verify_gh_cli || fail "explicit GH_TOKEN was rejected"
+GITHUB_TOKEN="fixture-token" GH_TOKEN="" verify_gh_cli || fail "explicit GITHUB_TOKEN was rejected"
+
+unset GH_TOKEN GITHUB_TOKEN
+AUTH_STATUS="healthy"
+API_TRANSPORT="failed"
+verify_gh_cli || fail "healthy keyring authentication was rejected"
+
+AUTH_STATUS="failed"
+for API_TRANSPORT in graphql rest; do
+	verify_gh_cli || fail "authenticated ${API_TRANSPORT} capability was rejected after stale keyring status"
+done
+
+AUTH_STATUS="failed"
+API_TRANSPORT="failed"
+auth_error=""
+if auth_error=$(verify_gh_cli 2>&1); then
+	fail "total authentication failure was accepted"
+fi
+[[ "$auth_error" == *"cannot authenticate an API request"* ]] || fail "authentication failure was not sanitized"
+[[ "$auth_error" != *"fixture-token"* ]] || fail "authentication failure exposed a token"
+
+printf 'PASS: issue sync accepts keyring, token, or authenticated API capability\n'

--- a/.agents/scripts/tests/test-issue-sync-push-failures.sh
+++ b/.agents/scripts/tests/test-issue-sync-push-failures.sh
@@ -47,6 +47,25 @@ grep -q '1 failed' "$TMPDIR_TEST/push.out" || fail "cmd_push did not report fail
 grep -q 'Issue creation failed' "$TMPDIR_TEST/push.err" || fail "cmd_push did not emit actionable failure"
 pass "cmd_push returns non-zero when issue creation fails"
 
+_push_process_task() {
+	local task_id="$1"
+	[[ "$task_id" == "t999" ]] || return 1
+	printf 'CREATED RELATIONSHIPS_PENDING\n'
+	return 0
+}
+pending_rc=0
+cmd_push "" >"$TMPDIR_TEST/pending.out" 2>"$TMPDIR_TEST/pending.err" || pending_rc=$?
+[[ "$pending_rc" -eq 2 ]] || fail "cmd_push did not distinguish pending relationships from hard failure"
+grep -q '1 relationships pending' "$TMPDIR_TEST/pending.out" || fail "cmd_push omitted pending relationship count"
+grep -q 'durable refs were preserved' "$TMPDIR_TEST/pending.err" || fail "cmd_push omitted durable relationship recovery guidance"
+pass "cmd_push returns non-zero with durable recovery for pending relationships"
+
+WORKFLOW="$ROOT_DIR/.github/workflows/issue-sync-reusable.yml"
+grep -q 'id: relationship-sync' "$WORKFLOW" || fail "workflow omitted explicit relationship recovery"
+grep -q 'issue-sync-helper.sh relationships --verbose' "$WORKFLOW" || fail "workflow did not retry durable relationship work"
+grep -q "steps.relationship-sync.outputs.pending == 'true'" "$WORKFLOW" || fail "workflow did not report unresolved relationships after persisting refs"
+pass "workflow persists refs before reporting unresolved relationship recovery"
+
 cat >"$TMPDIR_TEST/gh" <<'GH_EOF'
 #!/usr/bin/env bash
 if [[ "$1 $2" == "issue create" ]]; then
@@ -99,3 +118,62 @@ _push_create_issue t999 example/repo /tmp/todo.md 't999: title' body enhancement
 grep -q '^ASSIGN$' "$WRITE_LOG" || fail "assignment did not run after mapping validation"
 grep -q '^LOCK$' "$WRITE_LOG" || fail "lock did not run after mapping validation"
 pass "mapping validation precedes post-create assignment and lock writes"
+
+# Exercise the real immutable mapping gate after creation with independently
+# available repository metadata transports. Both valid splits must authorize
+# post-create writes; total identity outage must leave them untouched.
+_escape_ere() { local value="$1"; printf '%s' "$value"; return 0; }
+strip_code_fences() { command cat; return 0; }
+_gh_with_timeout() {
+	local operation="$1"
+	shift
+	: "$operation"
+	"$@"
+	return $?
+}
+# shellcheck source=../issue-sync-lib-ref.sh
+source "$ROOT_DIR/.agents/scripts/issue-sync-lib-ref.sh"
+SCRIPT_DIR="$TMPDIR_TEST/no-coordinator"
+SPLIT_TRANSPORT="graphql"
+gh() {
+	local group="$1"
+	local action="${2:-}"
+	if [[ "$group" == "issue" && "$action" == "create" ]]; then
+		printf 'https://github.com/example/repo/issues/123\n'
+		return 0
+	fi
+	if [[ "$group" == "issue" && "$action" == "view" ]]; then
+		printf '%s\n' '{"id":"I_123","number":123,"state":"OPEN","updatedAt":"2026-08-04T12:00:00Z"}'
+		return 0
+	fi
+	if [[ "$group" == "issue" && "$action" == "lock" ]]; then
+		printf 'LOCK\n' >>"$WRITE_LOG"
+		return 0
+	fi
+	if [[ "$group" == "api" && "$action" == "graphql" && "$SPLIT_TRANSPORT" == "graphql" ]]; then
+		printf '%s\n' '{"data":{"repository":{"id":"R_example","nameWithOwner":"example/repo"},"rateLimit":{"cost":1}}}'
+		return 0
+	fi
+	if [[ "$group" == "api" && "$action" == "repos/example/repo" && "$SPLIT_TRANSPORT" == "rest" ]]; then
+		printf '%s\n' '{"node_id":"R_example","full_name":"example/repo"}'
+		return 0
+	fi
+	return 1
+}
+printf '%s\n' '- [ ] t999 Created issue ref:GH#123' >"$TMPDIR_TEST/TODO.md"
+for SPLIT_TRANSPORT in graphql rest; do
+	: >"$WRITE_LOG"
+	_push_create_issue t999 example/repo "$TMPDIR_TEST/TODO.md" 't999: title' body enhancement '' || \
+		fail "post-create mapping failed with ${SPLIT_TRANSPORT}-only repository identity"
+	grep -q '^ASSIGN$' "$WRITE_LOG" || fail "${SPLIT_TRANSPORT}-only identity did not authorize assignment"
+	grep -q '^LOCK$' "$WRITE_LOG" || fail "${SPLIT_TRANSPORT}-only identity did not authorize locking"
+done
+pass "either validated repository identity transport authorizes post-create writes"
+
+SPLIT_TRANSPORT="outage"
+: >"$WRITE_LOG"
+if _push_create_issue t999 example/repo "$TMPDIR_TEST/TODO.md" 't999: title' body enhancement ''; then
+	fail "post-create writes succeeded without repository identity proof"
+fi
+[[ ! -s "$WRITE_LOG" ]] || fail "identity outage allowed a post-create write"
+pass "repository identity outage keeps post-create writes fail-closed"

--- a/.agents/scripts/tests/test-issue-sync-relationship-deadline.sh
+++ b/.agents/scripts/tests/test-issue-sync-relationship-deadline.sh
@@ -179,6 +179,24 @@ mixed_summary=$(_relationship_print_summary 1 0 1 2 true)
 [[ "$mixed_summary" == *"Recovery: rerun"* ]] || fail "partial summary omitted recovery command"
 pass "mixed relationship outcomes remain actionable and sanitized"
 
+# Declared relationships with no immutable self-mapping are unfinished work,
+# while a task with no relationship metadata remains a successful no-op.
+printf '%s\n' '- [ ] t3 Declared edge blocked-by:t2' '- [ ] t4 No relationship metadata' >"${TMP_DIR}/TODO.md"
+resolve_task_gh_number() {
+	local task_id="$1"
+	local todo_file="$2"
+	local repo="$3"
+	: "$task_id" "$todo_file" "$repo"
+	return 1
+}
+: >"$_RELATIONSHIP_RESULT_FILE"
+unresolved_result=$(_sync_blocked_by_for_task t3 "${TMP_DIR}/TODO.md" example/repo)
+[[ "$unresolved_result" == "RELS:0 RETRYABLE:1" ]] || fail "unresolved declared mapping was not retryable: $unresolved_result"
+grep -q '^failed:resolution$' "$_RELATIONSHIP_RESULT_FILE" || fail "unresolved mapping did not record failed resolution"
+noop_result=$(_sync_blocked_by_for_task t4 "${TMP_DIR}/TODO.md" example/repo)
+[[ "$noop_result" == "RELS:0 RETRYABLE:0" ]] || fail "relationship-free task was not a successful no-op: $noop_result"
+pass "declared mapping failures retry while relationship-free tasks no-op"
+
 _sync_blocked_by_for_task() {
 	printf 'RELS:0 RETRYABLE:0\n'
 	return 0

--- a/.agents/scripts/tests/test-issue-sync-relationship-resume.sh
+++ b/.agents/scripts/tests/test-issue-sync-relationship-resume.sh
@@ -19,6 +19,7 @@ TODO_FILE="${TMP_DIR}/TODO.md"
 ATTEMPT_LOG="${TMP_DIR}/attempts.log"
 DEADLINE_FLAG="${TMP_DIR}/deadline"
 BATCH_LIMIT=40
+BLOCKED_MODE="success"
 
 # shellcheck source=../issue-sync-helper.sh
 source "${SCRIPTS_DIR}/issue-sync-helper.sh"
@@ -52,8 +53,15 @@ _sync_blocked_by_for_task() {
 	local repo="$3"
 	: "$todo_file" "$repo"
 	printf '%s\n' "$task_id" >>"$ATTEMPT_LOG"
-	_gh_with_timeout read true >/dev/null
-	printf 'RELS:0 RETRYABLE:0\n'
+	case "$BLOCKED_MODE" in
+	success)
+		_gh_with_timeout read true >/dev/null
+		printf 'RELS:0 RETRYABLE:0\n'
+		;;
+	retry) printf 'RELS:0 RETRYABLE:1\n' ;;
+	error) return 1 ;;
+	*) return 1 ;;
+	esac
 	return 0
 }
 
@@ -133,5 +141,23 @@ small_state=$(_relationship_resume_state_file "example/small")
 [[ ! -e "$small_state" ]] || fail "completed small workset retained stale progress"
 [[ "$small_output" == *"attempted=3 complete=3/3"* && "$small_output" == *"remaining=0"* ]] || fail "small workset summary regressed"
 pass "small relationship worksets retain single-pass correctness"
+
+# A declared dependency that cannot resolve stays pending even with zero
+# backend calls. A helper error uses the same canonical retry classification.
+for BLOCKED_MODE in retry error; do
+	TEST_REPO="example/${BLOCKED_MODE}"
+	printf -- '- [ ] t1 Unresolved task blocked-by:t9 ref:GH#1\n' >"$TODO_FILE"
+	: >"$ATTEMPT_LOG"
+	rm -f "$DEADLINE_FLAG"
+	BATCH_LIMIT=100
+	unresolved_rc=0
+	unresolved_output=$(run_relationship_scoped_command cmd_relationships 2>/dev/null) || unresolved_rc=$?
+	unresolved_state=$(_relationship_resume_state_file "$TEST_REPO")
+	[[ "$unresolved_rc" -eq 1 ]] || fail "${BLOCKED_MODE} relationship result was counted complete"
+	[[ "$(grep -c '^pending=' "$unresolved_state" || true)" -eq 1 ]] || fail "${BLOCKED_MODE} relationship result was not retained in pending state"
+	[[ "$unresolved_output" == *"attempted=1 complete=0/1"* ]] || fail "${BLOCKED_MODE} summary omitted incomplete task telemetry"
+	[[ "$unresolved_output" == *"Backend calls: 0"* ]] || fail "${BLOCKED_MODE} retry unexpectedly made a backend call"
+done
+pass "unresolved and errored relationship work remain pending without backend calls"
 
 printf 'PASS: resumable relationship reconciliation regressions\n'

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -243,7 +243,13 @@ jobs:
         if: steps.check-author.outputs.skip != 'true'
         run: |
           echo "=== Creating issues for new tasks ==="
+          set +e
           bash __aidevops/.agents/scripts/issue-sync-helper.sh push --verbose
+          push_rc=$?
+          set -e
+          if [[ "$push_rc" -ne 0 && "$push_rc" -ne 2 ]]; then
+            exit "$push_rc"
+          fi
         env:
           GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
           # t1984: override origin detection and assignee target so issues
@@ -253,6 +259,23 @@ jobs:
           # so by this step the push is guaranteed human (or a non-[bot] actor).
           AIDEVOPS_SESSION_ORIGIN: ${{ endsWith(github.actor, '[bot]') && 'worker' || 'interactive' }}
           AIDEVOPS_SESSION_USER: ${{ endsWith(github.actor, '[bot]') && '' || github.actor }}
+
+      - name: Reconcile issue relationships
+        id: relationship-sync
+        if: steps.check-author.outputs.skip != 'true'
+        run: |
+          echo "=== Reconciling issue relationships ==="
+          set +e
+          bash __aidevops/.agents/scripts/issue-sync-helper.sh relationships --verbose
+          relationship_rc=$?
+          set -e
+          if [[ "$relationship_rc" -eq 0 ]]; then
+            echo "pending=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "pending=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Enrich plan-linked issues
         if: steps.check-author.outputs.skip != 'true'
@@ -292,6 +315,12 @@ jobs:
           bash __aidevops/.agents/scripts/issue-sync-helper.sh status || true
         env:
           GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Report pending relationship sync
+        if: steps.relationship-sync.outputs.pending == 'true'
+        run: |
+          echo "Relationship sync remains pending after durable TODO.md ref persistence"
+          exit 1
 
   sync-on-issue:
     name: Sync GitHub Issue → TODO.md


### PR DESCRIPTION
## Summary

Recover issue-sync auth and immutable repository mapping across split REST/GraphQL availability, while durably retaining and retrying unresolved relationships

## Files Changed

.agents/scripts/issue-sync-helper-push.sh, .agents/scripts/issue-sync-helper.sh, .agents/scripts/issue-sync-lib-ref.sh, .agents/scripts/issue-sync-relationships.sh, .agents/scripts/tests/test-issue-mapping-isolation.sh, .agents/scripts/tests/test-issue-sync-auth-capability.sh, .agents/scripts/tests/test-issue-sync-push-failures.sh, .agents/scripts/tests/test-issue-sync-relationship-deadline.sh, .agents/scripts/tests/test-issue-sync-relationship-resume.sh, .github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Five focused stubbed issue-sync suites, actionlint, changed-file lint, and independent closeout review pass

Resolves #29517


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.222 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 27m and 221,265 tokens on this as a headless worker.