### PR TITLE
GH#29523: Reconcile unpublished protected predecessors

### DIFF
--- a/.agents/scripts/full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/full-loop-cleanup-receipt.sh
@@ -59,12 +59,10 @@ _full_loop_validate_superseded_evidence() {
 			and ($e.aggregate_merge | type == $string_type and test($sha_regex))
 			and ($e.release_tag | type == $string_type and test($tag_regex))
 			and ($e.release_commit | type == $string_type and test($sha_regex))
-		else $e.schema_version == 1 and $e.evidence_type == "post-publication-supersession"
-			and $e.source_pr == $pr
+		else $e.source_pr == $pr
 			and ($e.source_merge | type == $string_type and test($sha_regex))
 			and ($e.source_release_tag | type == $string_type and test($tag_regex))
 			and ($e.source_release_commit | type == $string_type and test($sha_regex))
-			and ($e.source_workflow_run | type == $number_type and . > 0 and floor == .)
 			and ($e.successor_pr | type == $number_type and . > 0 and floor == . and . != $pr)
 			and ($e.successor_merge | type == $string_type and test($sha_regex))
 			and ($e.release_tag | type == $string_type and test($tag_regex))
@@ -72,7 +70,15 @@ _full_loop_validate_superseded_evidence() {
 			and ($e.release_commit | type == $string_type and test($sha_regex))
 			and $e.release_commit != $e.source_release_commit
 			and ($e.release_workflow_run | type == $number_type and . > 0 and floor == .)
-			and $e.release_workflow_run != $e.source_workflow_run
+			and if $e.schema_version == 1 and $e.evidence_type == "post-publication-supersession" then
+				($e.source_workflow_run | type == $number_type and . > 0 and floor == .)
+				and $e.release_workflow_run != $e.source_workflow_run
+			else $e.schema_version == 2 and $e.evidence_type == "protected-predecessor-supersession"
+				and ($e.source_release_tag_object | type == $string_type and test($sha_regex))
+				and ($e.source_protected_pr | type == $number_type and . > 0 and floor == .)
+				and ($e.source_protected_pr_head | type == $string_type and test($sha_regex))
+				and ($e.source_protected_pr_merged_at | type == $string_type and test($timestamp_regex))
+			end
 		end
 	' "$evidence_path" >/dev/null 2>&1
 	return $?

--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -24,6 +24,7 @@ _FULL_LOOP_RELEASE_MODE_RECONCILE="reconcile"
 _FULL_LOOP_RELEASE_STEP_QUEUE_POSTFLIGHT="Queue exact-tag postflight"
 _FULL_LOOP_RELEASE_PROVENANCE_PREDICATE="https://slsa.dev/provenance/v1"
 _FULL_LOOP_RELEASE_TRUE="true"
+_FULL_LOOP_RELEASE_VERSION_TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+$'
 
 # shellcheck source=./version-manager-protected-main.sh
 source "${SCRIPT_DIR}/version-manager-protected-main.sh"
@@ -789,6 +790,92 @@ _full_loop_release_finalize_reconciliation() {
 	return $?
 }
 
+_full_loop_release_write_protected_successor_receipt() {
+	local repo="$1"
+	local source_pr="$2"
+	local source_merge="$3"
+	local protected_json="$4"
+	local successor_pr="$5"
+	local successor_merge="$6"
+	local release_tag="$7"
+	local release_commit="$8"
+	local release_run="$9"
+	local source_tag=""
+	local source_tag_object=""
+	local source_commit=""
+	local protected_pr=""
+	local protected_head=""
+	local protected_merged_at=""
+	local aggregate_path=""
+	local evidence_path=""
+	local now=""
+
+	[[ "$source_pr" =~ ^[0-9]+$ && "$successor_pr" =~ ^[0-9]+$ && "$source_pr" != "$successor_pr" ]] || return 1
+	[[ "$source_merge" =~ $_FULL_LOOP_SHA40_REGEX && "$successor_merge" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+	[[ "$release_tag" =~ $_FULL_LOOP_RELEASE_VERSION_TAG_REGEX && "$release_commit" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+	[[ "$release_run" =~ ^[0-9]+$ && "$release_run" -gt 0 ]] || return 1
+	source_tag=$(jq -er '.source_tag' <<<"$protected_json") || return 1
+	source_tag_object=$(jq -er '.source_tag_object' <<<"$protected_json") || return 1
+	source_commit=$(jq -er '.source_commit' <<<"$protected_json") || return 1
+	protected_pr=$(jq -er '.protected_pr' <<<"$protected_json") || return 1
+	protected_head=$(jq -er '.protected_head' <<<"$protected_json") || return 1
+	protected_merged_at=$(jq -er '.protected_merged_at' <<<"$protected_json") || return 1
+	[[ "$source_tag" =~ $_FULL_LOOP_RELEASE_VERSION_TAG_REGEX && "$source_tag" != "$release_tag" ]] || return 1
+	[[ "$source_tag_object" =~ $_FULL_LOOP_SHA40_REGEX && "$source_commit" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+	[[ "$source_commit" != "$release_commit" && "$protected_head" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+	[[ "$protected_pr" =~ ^[0-9]+$ && -n "$protected_merged_at" ]] || return 1
+
+	aggregate_path=$(_full_loop_release_evidence_path "$repo" "$source_pr" aggregate) || return 1
+	evidence_path=$(_full_loop_release_evidence_path "$repo" "$source_pr" successor) || return 1
+	[[ ! -e "$aggregate_path" ]] || return 1
+	if [[ -f "$evidence_path" ]]; then
+		_full_loop_verify_successor_superseded_release_evidence \
+			"$evidence_path" "$repo" "$source_pr" || return 1
+		jq -e --arg source_merge "$source_merge" --arg source_tag "$source_tag" \
+			--arg source_tag_object "$source_tag_object" --arg source_commit "$source_commit" \
+			--argjson protected_pr "$protected_pr" --arg protected_head "$protected_head" \
+			--arg protected_merged_at "$protected_merged_at" --argjson successor_pr "$successor_pr" \
+			--arg successor_merge "$successor_merge" --arg release_tag "$release_tag" \
+			--arg release_commit "$release_commit" --argjson release_run "$release_run" '
+			.source_merge == $source_merge and .source_release_tag == $source_tag
+			and .source_release_tag_object == $source_tag_object
+			and .source_release_commit == $source_commit
+			and .source_protected_pr == $protected_pr
+			and .source_protected_pr_head == $protected_head
+			and .source_protected_pr_merged_at == $protected_merged_at
+			and .successor_pr == $successor_pr and .successor_merge == $successor_merge
+			and .release_tag == $release_tag and .release_commit == $release_commit
+			and .release_workflow_run == $release_run
+		' "$evidence_path" >/dev/null 2>&1 || return 1
+	else
+		now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+		mkdir -p "${evidence_path%/*}" || return 1
+		jq -cn --arg repo "$repo" --arg status "$_FULL_LOOP_RELEASE_SUPERSEDED" \
+			--arg evidence_type "protected-predecessor-supersession" --argjson source_pr "$source_pr" \
+			--arg source_merge "$source_merge" --arg source_tag "$source_tag" \
+			--arg source_tag_object "$source_tag_object" --arg source_commit "$source_commit" \
+			--argjson protected_pr "$protected_pr" --arg protected_head "$protected_head" \
+			--arg protected_merged_at "$protected_merged_at" --argjson successor_pr "$successor_pr" \
+			--arg successor_merge "$successor_merge" --arg release_tag "$release_tag" \
+			--arg release_commit "$release_commit" --argjson release_run "$release_run" --arg now "$now" '
+			{schema_version:2,evidence_type:$evidence_type,status:$status,repository:$repo,
+			 pr_number:$source_pr,source_pr:$source_pr,source_merge:$source_merge,
+			 source_release_tag:$source_tag,source_release_tag_object:$source_tag_object,
+			 source_release_commit:$source_commit,source_protected_pr:$protected_pr,
+			 source_protected_pr_head:$protected_head,
+			 source_protected_pr_merged_at:$protected_merged_at,
+			 successor_pr:$successor_pr,successor_merge:$successor_merge,
+			 release_tag:$release_tag,release_commit:$release_commit,
+			 release_workflow_run:$release_run,recorded_at:$now}
+		' >"${evidence_path}.tmp.$$" || return 1
+		mv "${evidence_path}.tmp.$$" "$evidence_path" || return 1
+	fi
+	_full_loop_write_release_receipt "$repo" "$source_pr" \
+		"$_FULL_LOOP_RELEASE_SUPERSEDED" || return 1
+	_full_loop_update_superseded_cleanup_receipt "$repo" "$source_pr"
+	return $?
+}
+
 _full_loop_release_finalize_stale_supersession() {
 	local repo="$1"
 	local requested_pr="$2"
@@ -798,6 +885,8 @@ _full_loop_release_finalize_stale_supersession() {
 	local source_merge=""
 	local source_commit=""
 	local source_run=""
+	local source_run_rc=0
+	local protected_source=""
 	local release_json=""
 	local successor_pr=""
 	local successor_merge=""
@@ -813,11 +902,18 @@ _full_loop_release_finalize_stale_supersession() {
 	' <<<"$source_json") || return 1
 	[[ "$source_merge" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
 	source_commit=$(_full_loop_release_resolve_tag_commit "$source_tag") || return 1
-	_full_loop_release_verify_stale_publication_run \
-		"$repo" "$source_tag" "$source_commit" || return 1
-	source_run=$(jq -er --arg number_type "$_FULL_LOOP_RELEASE_JSON_NUMBER_TYPE" \
-		'.id | select(type == $number_type and . > 0 and floor == .)' \
-		<<<"$_FULL_LOOP_RELEASE_RUN_JSON") || return 1
+	if _full_loop_release_verify_stale_publication_run \
+		"$repo" "$source_tag" "$source_commit"; then
+		source_run=$(jq -er --arg number_type "$_FULL_LOOP_RELEASE_JSON_NUMBER_TYPE" \
+			'.id | select(type == $number_type and . > 0 and floor == .)' \
+			<<<"$_FULL_LOOP_RELEASE_RUN_JSON") || return 1
+	else
+		_full_loop_release_find_workflow_run \
+			"$repo" "$source_tag" "$source_commit" || source_run_rc=$?
+		[[ "$source_run_rc" -eq 3 ]] || return 1
+		_full_loop_release_verify_protected_source_provenance \
+			"$repo" "$source_tag" || return 1
+	fi
 
 	_full_loop_release_reset_tag_worktree || return 1
 	_full_loop_release_verify_tag_provenance "$repo" "$release_tag" || return 1
@@ -833,19 +929,31 @@ _full_loop_release_finalize_stale_supersession() {
 	[[ "$source_commit" != "$release_commit" ]] || return 1
 	git -C "$REPO_ROOT" merge-base --is-ancestor "$source_commit" "$release_commit" \
 		>/dev/null 2>&1 || return 1
+	if [[ -z "$source_run" ]]; then
+		_version_manager_verify_protected_release_supersession \
+			"$repo" "$source_tag" "$release_commit" || return 1
+		protected_source="$_VERSION_MANAGER_PROTECTED_SUPERSESSION_JSON"
+		[[ -n "$protected_source" ]] || return 1
+	fi
 	_full_loop_release_inspect_remote "$repo" "$release_tag" || return 1
 	release_run=$(jq -er --arg number_type "$_FULL_LOOP_RELEASE_JSON_NUMBER_TYPE" \
 		'.id | select(type == $number_type and . > 0 and floor == .)' \
 		<<<"$_FULL_LOOP_RELEASE_RUN_JSON") || return 1
-	[[ "$source_run" != "$release_run" ]] || return 1
+	[[ -z "$source_run" || "$source_run" != "$release_run" ]] || return 1
 	release_receipt=$(_full_loop_release_receipt_path "$repo" "$successor_pr") || return 1
 	[[ -f "$release_receipt" ]] || return 1
 	IFS= read -r release_status <"$release_receipt" || return 1
 	[[ "$release_status" == "$_FULL_LOOP_RELEASE_PUBLISHED" ]] || return 1
 
-	_full_loop_write_successor_release_receipt "$repo" "$requested_pr" "$source_merge" \
-		"$source_tag" "$source_commit" "$source_run" "$successor_pr" "$successor_merge" \
-		"$release_tag" "$release_commit" "$release_run"
+	if [[ -n "$source_run" ]]; then
+		_full_loop_write_successor_release_receipt "$repo" "$requested_pr" "$source_merge" \
+			"$source_tag" "$source_commit" "$source_run" "$successor_pr" "$successor_merge" \
+			"$release_tag" "$release_commit" "$release_run"
+	else
+		_full_loop_release_write_protected_successor_receipt \
+			"$repo" "$requested_pr" "$source_merge" "$protected_source" \
+			"$successor_pr" "$successor_merge" "$release_tag" "$release_commit" "$release_run"
+	fi
 	return $?
 }
 

--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -25,6 +25,7 @@ _FULL_LOOP_RELEASE_STEP_QUEUE_POSTFLIGHT="Queue exact-tag postflight"
 _FULL_LOOP_RELEASE_PROVENANCE_PREDICATE="https://slsa.dev/provenance/v1"
 _FULL_LOOP_RELEASE_TRUE="true"
 _FULL_LOOP_RELEASE_VERSION_TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+$'
+_FULL_LOOP_RELEASE_TIMESTAMP_REGEX='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'
 
 # shellcheck source=./version-manager-protected-main.sh
 source "${SCRIPT_DIR}/version-manager-protected-main.sh"
@@ -823,7 +824,7 @@ _full_loop_release_write_protected_successor_receipt() {
 	[[ "$source_tag" =~ $_FULL_LOOP_RELEASE_VERSION_TAG_REGEX && "$source_tag" != "$release_tag" ]] || return 1
 	[[ "$source_tag_object" =~ $_FULL_LOOP_SHA40_REGEX && "$source_commit" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
 	[[ "$source_commit" != "$release_commit" && "$protected_head" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
-	[[ "$protected_pr" =~ ^[0-9]+$ && -n "$protected_merged_at" ]] || return 1
+	[[ "$protected_pr" =~ ^[0-9]+$ && "$protected_merged_at" =~ $_FULL_LOOP_RELEASE_TIMESTAMP_REGEX ]] || return 1
 
 	aggregate_path=$(_full_loop_release_evidence_path "$repo" "$source_pr" aggregate) || return 1
 	evidence_path=$(_full_loop_release_evidence_path "$repo" "$source_pr" successor) || return 1
@@ -870,6 +871,8 @@ _full_loop_release_write_protected_successor_receipt() {
 		' >"${evidence_path}.tmp.$$" || return 1
 		mv "${evidence_path}.tmp.$$" "$evidence_path" || return 1
 	fi
+	_full_loop_verify_successor_superseded_release_evidence \
+		"$evidence_path" "$repo" "$source_pr" || return 1
 	_full_loop_write_release_receipt "$repo" "$source_pr" \
 		"$_FULL_LOOP_RELEASE_SUPERSEDED" || return 1
 	_full_loop_update_superseded_cleanup_receipt "$repo" "$source_pr"

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -825,6 +825,176 @@ for stale_failure_mode in source-run ancestry latest-remote receipt; do
 done
 printf 'PASS stale receipt supersession binds both releases and fails closed on uncertain evidence\n'
 
+run_protected_predecessor_supersession_fixture() {
+	local mode="$1"
+	local write_log="$2"
+	(
+		_full_loop_release_source_json_from_tag() {
+			local tag_name="$1"
+			case "$tag_name" in
+			v1.2.3)
+				printf '%s\n' '{"source_pr":90,"source_merge":"1111111111111111111111111111111111111111","aggregated_sources":[]}'
+				;;
+			v1.2.4)
+				printf '%s\n' '{"source_pr":91,"source_merge":"2222222222222222222222222222222222222222","aggregated_sources":[]}'
+				;;
+			*) return 1 ;;
+			esac
+			return 0
+		}
+		_full_loop_release_resolve_tag_commit() {
+			local tag_name="$1"
+			case "$tag_name" in
+			v1.2.3) printf '%040d\n' 3 ;;
+			v1.2.4) printf '%040d\n' 4 ;;
+			*) return 1 ;;
+			esac
+			return 0
+		}
+		_full_loop_release_verify_stale_publication_run() {
+			return 1
+		}
+		_full_loop_release_find_workflow_run() {
+			local repo="$1"
+			local tag_name="$2"
+			local tag_commit="$3"
+			[[ "$repo" == "test/repo" && "$tag_name" == "v1.2.3" &&
+				"$tag_commit" == "$(printf '%040d' 3)" ]] || return 1
+			return 3
+		}
+		_full_loop_release_verify_protected_source_provenance() {
+			local repo="$1"
+			local tag_name="$2"
+			[[ "$repo" == "test/repo" && "$tag_name" == "v1.2.3" ]]
+			return $?
+		}
+		_full_loop_release_reset_tag_worktree() {
+			return 0
+		}
+		_full_loop_release_verify_tag_provenance() {
+			local repo="$1"
+			local tag_name="$2"
+			[[ "$repo" == "test/repo" && "$tag_name" == "v1.2.4" ]]
+			return $?
+		}
+		_version_manager_reconcile_protected_release_tag() {
+			local repo="$1"
+			local tag_name="$2"
+			local reconcile_mode="$3"
+			[[ "$repo" == "test/repo" && "$tag_name" == "v1.2.3" &&
+				"$reconcile_mode" == "status" ]] || return 1
+			_VERSION_MANAGER_LOCAL_TAG_OBJECT="$(printf '%040d' 2)"
+			_VERSION_MANAGER_LOCAL_TAG_COMMIT="$(printf '%040d' 3)"
+			_VERSION_MANAGER_PROTECTED_PR_NUMBER=77
+			_VERSION_MANAGER_PROTECTED_PR_JSON=$(jq -cn \
+				--arg head "$(printf '%040d' 33)" \
+				'{head:{sha:$head},merged_at:"2026-08-04T00:00:00Z"}') || return 1
+			if [[ "$mode" == "unmerged" ]]; then
+				_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="pr-pending"
+			else
+				_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="tag-ready"
+			fi
+			return 0
+		}
+		_full_loop_release_inspect_remote() {
+			local repo="$1"
+			local tag_name="$2"
+			[[ "$repo" == "test/repo" && "$tag_name" == "v1.2.4" ]] || return 1
+			_FULL_LOOP_RELEASE_RUN_JSON='{"id":202}'
+			return 0
+		}
+		_full_loop_release_receipt_path() {
+			local repo="$1"
+			local pr_number="$2"
+			[[ "$repo" == "test/repo" ]] || return 1
+			if [[ "$mode" == "receipt" ]]; then
+				printf '%s/missing-protected-%s.status\n' "$TEST_ROOT" "$pr_number"
+			else
+				printf '%s/receipts/test_repo-%s.status\n' "$TEST_ROOT" "$pr_number"
+			fi
+			return 0
+		}
+		_full_loop_release_write_protected_successor_receipt() {
+			local args="$*"
+			printf '%s\n' "$args" >"$write_log"
+			return 0
+		}
+		git() {
+			local args="$*"
+			case "$args" in
+			*" merge-base --is-ancestor "*)
+				[[ "$mode" != "unrelated" ]]
+				return $?
+				;;
+			esac
+			return 1
+		}
+		_full_loop_release_finalize_stale_supersession test/repo 90 v1.2.3 v1.2.4
+	)
+	return $?
+}
+
+protected_write_log="${TEST_ROOT}/protected-successor-write.log"
+run_protected_predecessor_supersession_fixture valid "$protected_write_log" || {
+	printf 'FAIL unpublished protected predecessor did not reconcile through a published descendant\n'
+	exit 1
+}
+if ! grep -q '"protected_pr":77' "$protected_write_log" ||
+	! grep -q '"protected_head":"0000000000000000000000000000000000000033"' "$protected_write_log"; then
+	printf 'FAIL protected predecessor supersession omitted immutable PR evidence\n'
+	exit 1
+fi
+for protected_failure_mode in unrelated unmerged receipt; do
+	rm -f "$protected_write_log"
+	if run_protected_predecessor_supersession_fixture \
+		"$protected_failure_mode" "$protected_write_log"; then
+		printf 'FAIL %s protected predecessor evidence allowed supersession\n' \
+			"$protected_failure_mode"
+		exit 1
+	fi
+	[[ ! -e "$protected_write_log" ]] || {
+		printf 'FAIL %s protected predecessor uncertainty wrote terminal evidence\n' \
+			"$protected_failure_mode"
+		exit 1
+	}
+done
+printf 'PASS unpublished protected predecessors require merged ancestry and a published successor receipt\n'
+
+(
+	export AIDEVOPS_FULL_LOOP_RECEIPT_DIR="${TEST_ROOT}/protected-evidence-receipts"
+	# shellcheck source=../full-loop-helper-state.sh
+	source "${SCRIPT_DIR}/full-loop-helper-state.sh"
+	_full_loop_update_superseded_cleanup_receipt() {
+		local repo="$1"
+		local pr_number="$2"
+		[[ "$repo" == "test/repo" && "$pr_number" == "90" ]]
+		return $?
+	}
+	protected_json=$(jq -cn \
+		--arg source_tag v1.2.3 --arg source_tag_object "$(printf '%040d' 2)" \
+		--arg source_commit "$(printf '%040d' 3)" --argjson protected_pr 77 \
+		--arg protected_head "$(printf '%040d' 33)" \
+		--arg protected_merged_at '2026-08-04T00:00:00Z' \
+		'{source_tag:$source_tag,source_tag_object:$source_tag_object,
+		  source_commit:$source_commit,protected_pr:$protected_pr,
+		  protected_head:$protected_head,protected_merged_at:$protected_merged_at}') || exit 1
+	_full_loop_release_write_protected_successor_receipt test/repo 90 \
+		1111111111111111111111111111111111111111 "$protected_json" 91 \
+		2222222222222222222222222222222222222222 v1.2.4 \
+		"$(printf '%040d' 4)" 202 || exit 1
+	evidence_path=$(_full_loop_release_evidence_path test/repo 90 successor) || exit 1
+	_full_loop_verify_successor_superseded_release_evidence \
+		"$evidence_path" test/repo 90 || exit 1
+	jq -e '.schema_version == 2
+		and .evidence_type == "protected-predecessor-supersession"
+		and .source_release_tag_object == "0000000000000000000000000000000000000002"
+		and .source_protected_pr == 77
+		and .source_protected_pr_head == "0000000000000000000000000000000000000033"
+		and .release_workflow_run == 202' "$evidence_path" >/dev/null || exit 1
+	grep -qx superseded "${AIDEVOPS_FULL_LOOP_RECEIPT_DIR}/test_repo-90.status" || exit 1
+)
+printf 'PASS protected predecessor supersession writes independently verifiable audit evidence\n'
+
 protected_state_log="${TEST_ROOT}/protected-state.log"
 protected_source_log="${TEST_ROOT}/protected-source.log"
 protected_push_log="${TEST_ROOT}/protected-push.log"

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -825,9 +825,11 @@ for stale_failure_mode in source-run ancestry latest-remote receipt; do
 done
 printf 'PASS stale receipt supersession binds both releases and fails closed on uncertain evidence\n'
 
-run_protected_predecessor_supersession_fixture() {
-	local mode="$1"
-	local write_log="$2"
+protected_write_log="${TEST_ROOT}/protected-successor-write.log"
+for mode in valid unrelated protected-ancestry unmerged malformed-merge receipt; do
+	rm -f "$protected_write_log"
+	protected_fixture_rc=0
+	write_log="$protected_write_log"
 	(
 		_full_loop_release_source_json_from_tag() {
 			local tag_name="$1"
@@ -881,14 +883,16 @@ run_protected_predecessor_supersession_fixture() {
 			local repo="$1"
 			local tag_name="$2"
 			local reconcile_mode="$3"
+			local merged_at="2026-08-04T00:00:00Z"
 			[[ "$repo" == "test/repo" && "$tag_name" == "v1.2.3" &&
 				"$reconcile_mode" == "status" ]] || return 1
+			[[ "$mode" != "malformed-merge" ]] || merged_at="not-a-timestamp"
 			_VERSION_MANAGER_LOCAL_TAG_OBJECT="$(printf '%040d' 2)"
 			_VERSION_MANAGER_LOCAL_TAG_COMMIT="$(printf '%040d' 3)"
 			_VERSION_MANAGER_PROTECTED_PR_NUMBER=77
 			_VERSION_MANAGER_PROTECTED_PR_JSON=$(jq -cn \
-				--arg head "$(printf '%040d' 33)" \
-				'{head:{sha:$head},merged_at:"2026-08-04T00:00:00Z"}') || return 1
+				--arg head "$(printf '%040d' 33)" --arg merged_at "$merged_at" \
+				'{head:{sha:$head},merged_at:$merged_at}') || return 1
 			if [[ "$mode" == "unmerged" ]]; then
 				_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="pr-pending"
 			else
@@ -923,41 +927,41 @@ run_protected_predecessor_supersession_fixture() {
 			local args="$*"
 			case "$args" in
 			*" merge-base --is-ancestor "*)
-				[[ "$mode" != "unrelated" ]]
-				return $?
+				[[ "$mode" != "unrelated" ]] || return 1
+				if [[ "$mode" == "protected-ancestry" &&
+					"$args" == *"$(printf '%040d' 33) $(printf '%040d' 4)"* ]]; then
+					return 1
+				fi
+				return 0
 				;;
 			esac
 			return 1
 		}
 		_full_loop_release_finalize_stale_supersession test/repo 90 v1.2.3 v1.2.4
-	)
-	return $?
-}
-
-protected_write_log="${TEST_ROOT}/protected-successor-write.log"
-run_protected_predecessor_supersession_fixture valid "$protected_write_log" || {
-	printf 'FAIL unpublished protected predecessor did not reconcile through a published descendant\n'
-	exit 1
-}
-if ! grep -q '"protected_pr":77' "$protected_write_log" ||
-	! grep -q '"protected_head":"0000000000000000000000000000000000000033"' "$protected_write_log"; then
-	printf 'FAIL protected predecessor supersession omitted immutable PR evidence\n'
-	exit 1
-fi
-for protected_failure_mode in unrelated unmerged receipt; do
-	rm -f "$protected_write_log"
-	if run_protected_predecessor_supersession_fixture \
-		"$protected_failure_mode" "$protected_write_log"; then
-		printf 'FAIL %s protected predecessor evidence allowed supersession\n' \
-			"$protected_failure_mode"
+	) || protected_fixture_rc=$?
+	if [[ "$mode" == "valid" ]]; then
+		if [[ "$protected_fixture_rc" -ne 0 ]]; then
+			printf 'FAIL unpublished protected predecessor did not reconcile through a published descendant\n'
+			exit 1
+		fi
+		if ! grep -q '"protected_pr":77' "$protected_write_log" ||
+			! grep -q '"protected_head":"0000000000000000000000000000000000000033"' "$protected_write_log"; then
+			printf 'FAIL protected predecessor supersession omitted immutable PR evidence\n'
+			exit 1
+		fi
+		continue
+	fi
+	if [[ "$protected_fixture_rc" -eq 0 ]]; then
+		printf 'FAIL %s protected predecessor evidence allowed supersession\n' "$mode"
 		exit 1
 	fi
 	[[ ! -e "$protected_write_log" ]] || {
 		printf 'FAIL %s protected predecessor uncertainty wrote terminal evidence\n' \
-			"$protected_failure_mode"
+			"$mode"
 		exit 1
 	}
 done
+unset mode write_log protected_fixture_rc
 printf 'PASS unpublished protected predecessors require merged ancestry and a published successor receipt\n'
 
 (
@@ -978,6 +982,17 @@ printf 'PASS unpublished protected predecessors require merged ancestry and a pu
 		'{source_tag:$source_tag,source_tag_object:$source_tag_object,
 		  source_commit:$source_commit,protected_pr:$protected_pr,
 		  protected_head:$protected_head,protected_merged_at:$protected_merged_at}') || exit 1
+	malformed_protected_json=$(jq -c '.protected_merged_at = "invalid"' \
+		<<<"$protected_json") || exit 1
+	if _full_loop_release_write_protected_successor_receipt test/repo 92 \
+		1111111111111111111111111111111111111111 "$malformed_protected_json" 93 \
+		2222222222222222222222222222222222222222 v1.2.4 \
+		"$(printf '%040d' 4)" 202; then
+		exit 1
+	fi
+	malformed_evidence=$(_full_loop_release_evidence_path test/repo 92 successor) || exit 1
+	[[ ! -e "$malformed_evidence" &&
+		! -e "${AIDEVOPS_FULL_LOOP_RECEIPT_DIR}/test_repo-92.status" ]] || exit 1
 	_full_loop_release_write_protected_successor_receipt test/repo 90 \
 		1111111111111111111111111111111111111111 "$protected_json" 91 \
 		2222222222222222222222222222222222222222 v1.2.4 \

--- a/.agents/scripts/tests/test-version-manager-protected-main-fallback.sh
+++ b/.agents/scripts/tests/test-version-manager-protected-main-fallback.sh
@@ -89,7 +89,7 @@ if [[ "${1:-}" == "api" && " $* " == *" repos/test/repo/pulls "* ]]; then
 	merged_at=null
 	if [[ -f "${PR_MERGED_FILE:?}" ]]; then
 		pr_state=closed
-		merged_at='"2026-08-03T00:00:00Z"'
+		merged_at="${PR_MERGED_AT_JSON:-\"2026-08-03T00:00:00Z\"}"
 	fi
 	author_association="${PR_AUTHOR_ASSOCIATION:-OWNER}"
 	[[ ! -f "${AUTO_MERGE_FILE:?}" ]] || auto_merge='{"merge_method":"merge"}'
@@ -251,6 +251,20 @@ tag_pushes_after=$({ grep -c 'push origin refs/tags/v1.2.3:refs/tags/v1.2.3' "$F
 [[ "$_VERSION_MANAGER_PROTECTED_RELEASE_RESULT" == "tag-ready" ]]
 [[ -z "$("$REAL_GIT" ls-remote --tags "$REMOTE" refs/tags/v1.2.3)" ]]
 printf 'PASS merged protected release status remains read-only after branch deletion\n'
+
+export PR_MERGED_AT_JSON='"not-a-timestamp"'
+tag_pushes_before=$({ grep -c 'push origin refs/tags/v1.2.3:refs/tags/v1.2.3' "$FAKE_GIT_LOG" || true; })
+if _version_manager_reconcile_protected_release_tag test/repo v1.2.3 status \
+	>/dev/null 2>&1 || _version_manager_reconcile_protected_release_tag \
+	test/repo v1.2.3 reconcile >/dev/null 2>&1; then
+	printf 'FAIL malformed protected PR merge evidence authorized reconciliation\n'
+	exit 1
+fi
+tag_pushes_after=$({ grep -c 'push origin refs/tags/v1.2.3:refs/tags/v1.2.3' "$FAKE_GIT_LOG" || true; })
+[[ "$tag_pushes_after" -eq "$tag_pushes_before" ]]
+[[ -z "$("$REAL_GIT" ls-remote --tags "$REMOTE" refs/tags/v1.2.3)" ]]
+unset PR_MERGED_AT_JSON
+printf 'PASS malformed protected PR merge evidence cannot publish a tag\n'
 
 "$REAL_GIT" --git-dir="$REMOTE" update-ref refs/heads/main "$CURRENT_MAIN"
 if _version_manager_reconcile_protected_release_tag test/repo v1.2.3 reconcile \

--- a/.agents/scripts/version-manager-protected-main.sh
+++ b/.agents/scripts/version-manager-protected-main.sh
@@ -29,6 +29,7 @@ _VERSION_MANAGER_LOCAL_TAG_COMMIT=""
 _VERSION_MANAGER_REMOTE_TAG_OBJECT=""
 _VERSION_MANAGER_REMOTE_TAG_COMMIT=""
 _VERSION_MANAGER_REMOTE_TAG_STATE=""
+_VERSION_MANAGER_PROTECTED_SUPERSESSION_JSON=""
 _VERSION_MANAGER_TAG_STATE_ABSENT="absent"
 _VERSION_MANAGER_TAG_STATE_MATCHING="matching"
 _VERSION_MANAGER_RELEASE_RESULT_QUEUED="queued"
@@ -650,5 +651,44 @@ _version_manager_reconcile_protected_release_tag() {
 	_VERSION_MANAGER_PROTECTED_RELEASE_RESULT="pr-pending"
 	printf 'release:queued pr=%s tag=%s head=%s\n' \
 		"$_VERSION_MANAGER_PROTECTED_PR_NUMBER" "$tag_name" "$pr_head"
+	return 0
+}
+
+_version_manager_verify_protected_release_supersession() {
+	local repo="$1"
+	local source_tag="$2"
+	local successor_commit="$3"
+	local source_tag_object=""
+	local source_commit=""
+	local protected_pr=""
+	local protected_head=""
+	local protected_merged_at=""
+
+	_VERSION_MANAGER_PROTECTED_SUPERSESSION_JSON=""
+	[[ "$successor_commit" =~ ^[0-9a-f]{40}$ ]] || return 1
+	_version_manager_reconcile_protected_release_tag "$repo" "$source_tag" status \
+		>/dev/null || return 1
+	[[ "$_VERSION_MANAGER_PROTECTED_RELEASE_RESULT" == "tag-ready" ]] || return 1
+
+	source_tag_object="$_VERSION_MANAGER_LOCAL_TAG_OBJECT"
+	source_commit="$_VERSION_MANAGER_LOCAL_TAG_COMMIT"
+	protected_pr="$_VERSION_MANAGER_PROTECTED_PR_NUMBER"
+	protected_head=$(jq -r '.head.sha // ""' \
+		<<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
+	protected_merged_at=$(jq -r '.merged_at // ""' \
+		<<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
+	[[ "$source_tag_object" =~ ^[0-9a-f]{40}$ && "$source_commit" =~ ^[0-9a-f]{40}$ ]] || return 1
+	[[ "$protected_pr" =~ ^[0-9]+$ && "$protected_head" =~ ^[0-9a-f]{40}$ ]] || return 1
+	[[ -n "$protected_merged_at" ]] || return 1
+	git -C "$REPO_ROOT" merge-base --is-ancestor "$source_commit" "$successor_commit" || return 1
+	git -C "$REPO_ROOT" merge-base --is-ancestor "$protected_head" "$successor_commit" || return 1
+
+	_VERSION_MANAGER_PROTECTED_SUPERSESSION_JSON=$(jq -cn \
+		--arg source_tag "$source_tag" --arg source_tag_object "$source_tag_object" \
+		--arg source_commit "$source_commit" --argjson protected_pr "$protected_pr" \
+		--arg protected_head "$protected_head" --arg protected_merged_at "$protected_merged_at" \
+		'{source_tag:$source_tag,source_tag_object:$source_tag_object,
+		  source_commit:$source_commit,protected_pr:$protected_pr,
+		  protected_head:$protected_head,protected_merged_at:$protected_merged_at}') || return 1
 	return 0
 }

--- a/.agents/scripts/version-manager-protected-main.sh
+++ b/.agents/scripts/version-manager-protected-main.sh
@@ -36,6 +36,7 @@ _VERSION_MANAGER_RELEASE_RESULT_QUEUED="queued"
 _VERSION_MANAGER_MODE_RECONCILE="reconcile"
 _VERSION_MANAGER_PR_STATE_OPEN="open"
 _VERSION_MANAGER_PR_STATE_CLOSED="closed"
+_VERSION_MANAGER_TIMESTAMP_REGEX='^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'
 
 _version_manager_push_requires_pr() {
 	local push_output="$1"
@@ -679,7 +680,7 @@ _version_manager_verify_protected_release_supersession() {
 		<<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
 	[[ "$source_tag_object" =~ ^[0-9a-f]{40}$ && "$source_commit" =~ ^[0-9a-f]{40}$ ]] || return 1
 	[[ "$protected_pr" =~ ^[0-9]+$ && "$protected_head" =~ ^[0-9a-f]{40}$ ]] || return 1
-	[[ -n "$protected_merged_at" ]] || return 1
+	[[ "$protected_merged_at" =~ $_VERSION_MANAGER_TIMESTAMP_REGEX ]] || return 1
 	git -C "$REPO_ROOT" merge-base --is-ancestor "$source_commit" "$successor_commit" || return 1
 	git -C "$REPO_ROOT" merge-base --is-ancestor "$protected_head" "$successor_commit" || return 1
 

--- a/.agents/scripts/version-manager-protected-main.sh
+++ b/.agents/scripts/version-manager-protected-main.sh
@@ -555,6 +555,23 @@ _version_manager_queue_protected_main_release() {
 	return 0
 }
 
+_version_manager_verify_protected_pr_state() {
+	local pr_state="$1"
+	local merged_at="$2"
+
+	case "$pr_state" in
+	"$_VERSION_MANAGER_PR_STATE_OPEN") [[ -z "$merged_at" ]] || return 1 ;;
+	"$_VERSION_MANAGER_PR_STATE_CLOSED")
+		if [[ ! "$merged_at" =~ $_VERSION_MANAGER_TIMESTAMP_REGEX ]]; then
+			print_error "Protected release PR #${_VERSION_MANAGER_PROTECTED_PR_NUMBER} lacks valid merge evidence"
+			return 1
+		fi
+		;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
 _version_manager_reconcile_protected_release_tag() {
 	local repo="$1"
 	local tag_name="$2"
@@ -593,14 +610,7 @@ _version_manager_reconcile_protected_release_tag() {
 		"$_VERSION_MANAGER_LOCAL_TAG_OBJECT" "$_VERSION_MANAGER_LOCAL_TAG_COMMIT" || return 1
 	pr_state=$(jq -r '.state // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
 	merged_at=$(jq -r '.merged_at // ""' <<<"$_VERSION_MANAGER_PROTECTED_PR_JSON") || return 1
-	if [[ "$pr_state" == "$_VERSION_MANAGER_PR_STATE_CLOSED" && -z "$merged_at" ]]; then
-		print_error "Protected release PR #${_VERSION_MANAGER_PROTECTED_PR_NUMBER} closed without merge"
-		return 1
-	fi
-	if [[ "$pr_state" != "$_VERSION_MANAGER_PR_STATE_OPEN" &&
-		"$pr_state" != "$_VERSION_MANAGER_PR_STATE_CLOSED" ]]; then
-		return 1
-	fi
+	_version_manager_verify_protected_pr_state "$pr_state" "$merged_at" || return 1
 	_version_manager_remote_branch_head "$branch_name" || return 1
 	remote_branch_head="$_VERSION_MANAGER_PROTECTED_RELEASE_HEAD"
 	if [[ -n "$remote_branch_head" && "$remote_branch_head" != "$pr_head" ]]; then
@@ -623,7 +633,7 @@ _version_manager_reconcile_protected_release_tag() {
 		print_error "Protected release PR does not contain the signed release commit"
 		return 1
 	fi
-	if [[ "$pr_state" == "$_VERSION_MANAGER_PR_STATE_CLOSED" && -n "$merged_at" ]]; then
+	if [[ "$pr_state" == "$_VERSION_MANAGER_PR_STATE_CLOSED" ]]; then
 		git -C "$REPO_ROOT" fetch origin main --quiet || return 1
 		if ! git -C "$REPO_ROOT" merge-base --is-ancestor \
 			"$_VERSION_MANAGER_LOCAL_TAG_COMMIT" origin/main; then


### PR DESCRIPTION
## Summary

Allow an unpublished protected predecessor release to become superseded only after its immutable tag, merged protected PR ancestry, published descendant, and source inclusion are verified; persist schema-v2 audit evidence.

## Files Changed

.agents/scripts/full-loop-cleanup-receipt.sh, .agents/scripts/full-loop-release-reconcile.sh, .agents/scripts/tests/test-full-loop-release-reconcile.sh, .agents/scripts/version-manager-protected-main.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — shellcheck on changed scripts; test-full-loop-release-reconcile.sh; test-version-manager-protected-main-fallback.sh; test-full-loop-completion-evidence.sh

Resolves #29523


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.222 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 8m and 138,380 tokens on this as a headless worker.