### PR TITLE
GH#29502: feat: define safe reconciliation and rollback contracts

### DIFF
--- a/.agents/reference/team-interface-reconciliation.md
+++ b/.agents/reference/team-interface-reconciliation.md
@@ -1,0 +1,196 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Team-interface reconciliation
+
+`schemas/team-interface/reconciliation-v1.schema.json` defines the provider-neutral
+ownership, three-way reconciliation, concurrency, receipt, retirement, and
+rollback contract. It is a record format, not an apply implementation. Provider
+adapters, desired-state planners, and review UIs must validate records against
+the schema before using them to authorize a mutation.
+
+## Identity and non-adoption
+
+Resources bind the core contract's canonical `resource_id`, `provider_id`,
+`community_id`, and opaque `provider_external_id`. `match_basis` is always
+`stable_ids`. A display label may be shown to an owner, but it never identifies,
+matches, creates ownership for, or adopts a provider record.
+
+An existing record without a verified management owner and manager marker is
+unmanaged even when its label or content resembles desired state. The planner
+emits `review_required` with `unmanaged_resource` drift evidence. It must not
+infer ownership, manufacture last-applied state, or backfill a marker from a
+name match.
+
+## Ownership policy
+
+Each versioned policy maps a normalized JSON Pointer to one ownership class:
+
+- `user_owned`: preserve the freshly observed value. Show desired differences,
+  but do not mutate the field.
+- `managed`: apply desired state only while actual still equals last-applied.
+  A difference means the user or provider modified the field, so preserve actual
+  and record drift evidence.
+- `security_required`: apply a safe desired change only while actual equals
+  last-applied. Drift requires review or execution disablement; preserving or
+  overwriting the drift silently is forbidden.
+
+Unknown fields always require review. A desired document does not grant
+ownership of unlisted provider fields. Policy versions are immutable inputs to
+a plan; changing policy produces a new observation and plan. Policy rules,
+observed fields, decisions, receipt effects, and rollback fields each contain at
+most one record per JSON Pointer. The planner rejects duplicate paths rather
+than allowing order or map conversion to choose an owner.
+
+Sensitive fields carry approved secret references and digests only. Values,
+tokens, passwords, private keys, and credential material are never valid
+reconciliation data or audit evidence.
+
+## Three-way decision algorithm
+
+For every field, the planner binds desired, last-applied, and freshly observed
+actual snapshots to a policy rule. It then makes exactly one deterministic
+decision:
+
+| Ownership and state | Decision | Reason |
+|---|---|---|
+| User-owned | `preserve_actual` | `user_owned` |
+| Managed; actual equals last-applied; desired differs | `apply_desired` | `managed_unchanged` |
+| Managed; desired already equals actual | `no_change` | `already_desired` |
+| Managed; actual differs from last-applied | `preserve_actual` | `user_modified` |
+| Security-required drift | `review_required` or `disable_execution` | `security_drift` |
+| Missing ownership or last-applied identity | `review_required` | `unmanaged_resource` |
+
+The plan references the exact reconciliation input. Resource identity,
+management owner and marker, policy/adapter versions, observation hash/time,
+field ownership, sensitivity, and all three digests must match that input. The
+two equality flags are derived from the digests and cannot be trusted as caller
+assertions. Every observed field has exactly one decision, including unknown and
+security-required fields; omission cannot bypass review or disablement. An
+adapter receives the resulting decision; it does not reinterpret ownership or
+move security policy into the provider-specific implementation. Future review
+UIs expose these decisions, reason codes, and redacted evidence but cannot turn
+a review/disable decision into apply authority.
+
+## Capability negotiation
+
+Capability evidence covers stable external IDs, managed metadata, supported
+apply semantics, and provider revision/ETag compare-and-swap. Every unattended
+`create`, `update`, `disable`, `retire`, or `rollback` plan requires all four,
+`compatible` status, and evidence whose observation/expiry interval includes
+the apply time.
+
+If any capability is absent, stale, unknown, or incompatible, the only safe
+outcomes are `owner_reviewed_draft` or `unsupported`. A draft is an artifact for
+an owner to review in the provider's supported workflow; it is not simulated
+unattended apply. Unknown schema, policy, adapter, or provider versions fail the
+same way.
+
+## Concurrency and replay
+
+Before apply, re-read the resource by stable identity. Verify all of these
+bindings against the exact plan:
+
+1. immutable `plan_hash` and `operation_id`;
+2. canonical resource, provider, community, and external IDs;
+3. desired, policy, and adapter versions;
+4. expected revision or ETag, observation hash, and observation time;
+5. verified actor and authorization references;
+6. correlation and idempotency keys; and
+7. plan expiry.
+
+Any mismatch or expiry is `conflict` with no side effect. Re-observe and create
+a new plan. Never refresh only the expected revision on an old payload.
+
+The same operation ID and plan hash may return its recorded receipt. Reusing an
+operation ID or idempotency key with a different plan hash is a hard conflict.
+`plan_hash` is SHA-256 over canonical JSON for the complete plan after removing
+only the `plan_hash` member: object keys are recursively sorted, array order is
+preserved, and JSON scalar encoding is unchanged. Any payload change therefore
+requires a new hash. Do not blindly retry timeouts, transport failures, partial
+writes, or ambiguous provider responses. Read after write by stable identity,
+record the observed outcome, and replan.
+
+Providers without atomic apply may produce per-field effects. `partial` and
+`indeterminate` receipts are non-success states and require read-after-write
+reconciliation. They must not be relabelled published because some fields
+changed. Atomicity boundaries are per provider and community; a receipt cannot
+claim a cross-provider transaction.
+
+## Receipts and failure states
+
+Every apply attempt records before/after revisions and digests, exact field
+outcomes, provider receipt and evidence references, timestamps, and redacted
+audit evidence. Durable states are:
+
+- `published`: the effect and evidence are verified;
+- `retryable`: no contradictory effect is known and bounded retry metadata can
+  authorize a later attempt;
+- `indeterminate`: an effect may exist; read-after-write is mandatory;
+- `terminal`: rejected with evidence and no silent partial success;
+- `conflict`: a CAS, expiry, identity, or replay binding failed; and
+- `partial`: at least one field effect is incomplete or unknown.
+
+A `published` receipt cannot contain an unknown field effect. `partial` and
+`indeterminate` receipts contain at least one unknown effect and explicitly
+require read-after-write reconciliation. Each planned field decision permits
+only its corresponding effect (applied, preserved, unchanged, or disabled) or
+an unknown ambiguous effect. `retryable`, `terminal`, and `conflict` receipts
+use `not_applied` for every field and cannot claim a side effect. Receipt field
+paths are unique so rollback never resolves contradictory evidence by order.
+
+Recovery begins from a fresh observation. It never assumes that an error rolled
+back provider state, repeats a create without stable-ID reconciliation, or
+overwrites preserved user fields.
+
+## Retirement
+
+Removal from desired state produces a reviewed `disable`, `archive`, or `detach`
+directive. Stable internal and external identity, receipts, and audit history
+remain attached to the retired record. Automatic delete is not an outcome or
+retirement action and cannot be represented by the schema.
+
+An adapter may expose a provider-native delete operation for unrelated manual
+work, but a reconciliation plan never authorizes it. Retirement requires the
+same fresh observation, expected revision/ETag, capability evidence, owner
+review reference, and immutable plan binding as other mutations.
+
+## Rollback
+
+Rollback is a new CAS-guarded plan, not a blind rewind. It references a verified
+`published` receipt and before-state snapshot, binds the receipt's plan hash and
+after revision, and restores only fields that are still `managed` under the
+current policy. User-owned, user-modified, unknown, and security-drift fields
+are excluded and require a new reconciliation decision.
+
+Before rollback, re-read the same stable resource and verify that current state
+still matches the receipt-bound precondition. A mismatch is conflict and replan.
+Rollback retains identity and cannot delete, recreate, or resurrect an ambiguous
+record. Provider/community rollback boundaries are explicit: successful work in
+one boundary does not imply rollback or success in another.
+
+## Audit and redaction
+
+Plans and receipts carry verified actor, authorization, operation, correlation,
+provider evidence, and audit references. Evidence is append-only and redacted;
+it records digests and approved references instead of secret or unrestricted
+provider payloads. Audit views may resolve display labels for presentation only
+after stable identity is established.
+
+Security drift, capability fallback, conflict, partial, indeterminate,
+retirement, and rollback all remain visible terminal or recovery states. UI
+code presents those facts and requests owner decisions; it does not duplicate
+or weaken the schema and planner's security rules.
+
+## Validation
+
+Run the focused contract test before integrating a planner or adapter:
+
+```bash
+node .agents/scripts/tests/test-team-interface-reconciliation-schema.mjs
+```
+
+The fixtures cover every field decision, missing capabilities, stable-ID-only
+matching, stale/expired plans, operation-hash conflicts, ambiguous receipts,
+reviewed retirement, receipt-bound rollback, automatic-delete rejection, and
+redacted audit evidence.

--- a/.agents/schemas/team-interface/reconciliation-v1.schema.json
+++ b/.agents/schemas/team-interface/reconciliation-v1.schema.json
@@ -1,0 +1,578 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:aidevops:team-interface:reconciliation:v1",
+  "title": "aidevops team-interface reconciliation contract v1",
+  "oneOf": [
+    {"$ref": "#/$defs/ownership_policy_document"},
+    {"$ref": "#/$defs/reconciliation_input_document"},
+    {"$ref": "#/$defs/reconciliation_plan_document"},
+    {"$ref": "#/$defs/apply_receipt_document"},
+    {"$ref": "#/$defs/rollback_plan_document"}
+  ],
+  "$defs": {
+    "core_stable_id": {"$ref": "urn:aidevops:team-interface:core:v1#/$defs/stable_id"},
+    "core_external_id": {"$ref": "urn:aidevops:team-interface:core:v1#/$defs/opaque_external_id"},
+    "core_reference_id": {"$ref": "urn:aidevops:team-interface:core:v1#/$defs/reference_id"},
+    "core_resource_kind": {"$ref": "urn:aidevops:team-interface:core:v1#/$defs/resource_kind"},
+    "registered_reference": {
+      "allOf": [
+        {"$ref": "#/$defs/core_reference_id"},
+        {"pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*:[A-Za-z0-9][A-Za-z0-9._:/-]*$"}
+      ]
+    },
+    "digest": {"type": "string", "pattern": "^sha256:[a-fA-F0-9]{64}$"},
+    "optional_digest": {"oneOf": [{"$ref": "#/$defs/digest"}, {"type": "null"}]},
+    "json_pointer": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024,
+      "pattern": "^/(?:[^~/]|~0|~1)*(?:/(?:[^~/]|~0|~1)*)*$"
+    },
+    "literal_value": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "value"],
+      "properties": {
+        "kind": {"const": "literal"},
+        "value": {
+          "oneOf": [
+            {"type": ["string", "number", "boolean", "null"]},
+            {"type": "array", "maxItems": 100, "items": {"type": ["string", "number", "boolean", "null"]}}
+          ]
+        }
+      }
+    },
+    "reference_value": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "reference_ref"],
+      "properties": {
+        "kind": {"const": "reference"},
+        "reference_ref": {"$ref": "#/$defs/registered_reference"}
+      }
+    },
+    "secret_reference_value": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "secret_ref"],
+      "properties": {
+        "kind": {"const": "secret_reference"},
+        "secret_ref": {"$ref": "#/$defs/registered_reference"}
+      }
+    },
+    "safe_value": {"oneOf": [{"$ref": "#/$defs/literal_value"}, {"$ref": "#/$defs/reference_value"}]},
+    "snapshot_common": {
+      "type": "object",
+      "required": ["present"],
+      "properties": {"present": {"type": "boolean"}},
+      "allOf": [
+        {
+          "if": {"properties": {"present": {"const": false}}, "required": ["present"]},
+          "then": {"not": {"anyOf": [{"required": ["digest"]}, {"required": ["data"]}]}}
+        },
+        {
+          "if": {"properties": {"present": {"const": true}}, "required": ["present"]},
+          "then": {"required": ["digest", "data"]}
+        }
+      ]
+    },
+    "safe_snapshot": {
+      "allOf": [
+        {"$ref": "#/$defs/snapshot_common"},
+        {"type": "object", "properties": {"digest": {"$ref": "#/$defs/digest"}, "data": {"$ref": "#/$defs/safe_value"}}}
+      ],
+      "unevaluatedProperties": false
+    },
+    "secret_snapshot": {
+      "allOf": [
+        {"$ref": "#/$defs/snapshot_common"},
+        {"type": "object", "properties": {"digest": {"$ref": "#/$defs/digest"}, "data": {"$ref": "#/$defs/secret_reference_value"}}}
+      ],
+      "unevaluatedProperties": false
+    },
+    "ownership_class": {"enum": ["user_owned", "managed", "security_required"]},
+    "input_ownership_class": {"enum": ["user_owned", "managed", "security_required", "unknown"]},
+    "ownership_rule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field_path", "ownership", "sensitive"],
+      "properties": {
+        "field_path": {"$ref": "#/$defs/json_pointer"},
+        "ownership": {"$ref": "#/$defs/ownership_class"},
+        "sensitive": {"type": "boolean"}
+      }
+    },
+    "ownership_policy_document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "document_type", "policy_id", "policy_version", "resource_kind", "unknown_field_ownership", "field_rules"],
+      "properties": {
+        "schema_version": {"const": 1},
+        "document_type": {"const": "ownership_policy"},
+        "policy_id": {"$ref": "#/$defs/core_stable_id"},
+        "policy_version": {"type": "string", "minLength": 1, "maxLength": 100},
+        "resource_kind": {"$ref": "#/$defs/core_resource_kind"},
+        "unknown_field_ownership": {"const": "review_required"},
+        "field_rules": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/ownership_rule"}}
+      }
+    },
+    "field_input_common": {
+      "type": "object",
+      "required": ["field_path", "ownership", "sensitive", "desired", "last_applied", "actual", "actual_observed_at"],
+      "properties": {
+        "field_path": {"$ref": "#/$defs/json_pointer"},
+        "ownership": {"$ref": "#/$defs/input_ownership_class"},
+        "sensitive": {"type": "boolean"},
+        "actual_observed_at": {"type": "string", "format": "date-time"}
+      }
+    },
+    "field_input": {
+      "oneOf": [
+        {
+          "allOf": [
+            {"$ref": "#/$defs/field_input_common"},
+            {
+              "type": "object",
+              "properties": {
+                "sensitive": {"const": false},
+                "desired": {"$ref": "#/$defs/safe_snapshot"},
+                "last_applied": {"$ref": "#/$defs/safe_snapshot"},
+                "actual": {"$ref": "#/$defs/safe_snapshot"}
+              }
+            }
+          ],
+          "unevaluatedProperties": false
+        },
+        {
+          "allOf": [
+            {"$ref": "#/$defs/field_input_common"},
+            {
+              "type": "object",
+              "properties": {
+                "sensitive": {"const": true},
+                "desired": {"$ref": "#/$defs/secret_snapshot"},
+                "last_applied": {"$ref": "#/$defs/secret_snapshot"},
+                "actual": {"$ref": "#/$defs/secret_snapshot"}
+              }
+            }
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "resource_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["resource_id", "provider_id", "community_id", "provider_external_id", "match_basis", "management_identity_status"],
+      "properties": {
+        "resource_id": {"$ref": "#/$defs/core_stable_id"},
+        "provider_id": {"$ref": "#/$defs/core_stable_id"},
+        "community_id": {"$ref": "#/$defs/core_stable_id"},
+        "provider_external_id": {"$ref": "#/$defs/core_external_id"},
+        "match_basis": {"const": "stable_ids"},
+        "management_identity_status": {"enum": ["verified", "missing"]},
+        "management_owner": {"$ref": "#/$defs/core_stable_id"},
+        "manager_marker": {"$ref": "#/$defs/registered_reference"},
+        "display_label": {"type": "string", "minLength": 1, "maxLength": 255}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"management_identity_status": {"const": "verified"}}, "required": ["management_identity_status"]},
+          "then": {"required": ["management_owner", "manager_marker"]}
+        },
+        {
+          "if": {"properties": {"management_identity_status": {"const": "missing"}}, "required": ["management_identity_status"]},
+          "then": {"not": {"anyOf": [{"required": ["management_owner"]}, {"required": ["manager_marker"]}]}}
+        }
+      ]
+    },
+    "reconciliation_input_document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "document_type", "input_id", "resource", "policy_ref", "policy_version", "adapter_version", "observed_at", "observation_hash", "fields"],
+      "properties": {
+        "schema_version": {"const": 1},
+        "document_type": {"const": "reconciliation_input"},
+        "input_id": {"$ref": "#/$defs/core_stable_id"},
+        "resource": {"$ref": "#/$defs/resource_identity"},
+        "policy_ref": {"$ref": "#/$defs/registered_reference"},
+        "policy_version": {"type": "string", "minLength": 1, "maxLength": 100},
+        "adapter_version": {"type": "string", "minLength": 1, "maxLength": 100},
+        "observed_at": {"type": "string", "format": "date-time"},
+        "observation_hash": {"$ref": "#/$defs/digest"},
+        "fields": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/field_input"}}
+      }
+    },
+    "drift_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["last_applied_digest", "actual_digest", "observed_at", "evidence_ref"],
+      "properties": {
+        "last_applied_digest": {"$ref": "#/$defs/optional_digest"},
+        "actual_digest": {"$ref": "#/$defs/optional_digest"},
+        "observed_at": {"type": "string", "format": "date-time"},
+        "evidence_ref": {"$ref": "#/$defs/registered_reference"}
+      }
+    },
+    "field_decision_common": {
+      "type": "object",
+      "required": ["field_path", "ownership", "decision", "reason", "actual_matches_last_applied", "desired_matches_actual", "desired_digest", "last_applied_digest", "actual_digest"],
+      "properties": {
+        "field_path": {"$ref": "#/$defs/json_pointer"},
+        "ownership": {"enum": ["user_owned", "managed", "security_required", "unknown"]},
+        "decision": {"enum": ["apply_desired", "preserve_actual", "no_change", "review_required", "disable_execution"]},
+        "reason": {"enum": ["user_owned", "managed_unchanged", "already_desired", "user_modified", "security_drift", "unmanaged_resource"]},
+        "actual_matches_last_applied": {"type": "boolean"},
+        "desired_matches_actual": {"type": "boolean"},
+        "desired_digest": {"$ref": "#/$defs/optional_digest"},
+        "last_applied_digest": {"$ref": "#/$defs/optional_digest"},
+        "actual_digest": {"$ref": "#/$defs/optional_digest"},
+        "drift_evidence": {"$ref": "#/$defs/drift_evidence"}
+      }
+    },
+    "field_decision": {
+      "oneOf": [
+        {
+          "allOf": [
+            {"$ref": "#/$defs/field_decision_common"},
+            {"properties": {"ownership": {"const": "user_owned"}, "decision": {"const": "preserve_actual"}, "reason": {"const": "user_owned"}}}
+          ],
+          "unevaluatedProperties": false
+        },
+        {
+          "allOf": [
+            {"$ref": "#/$defs/field_decision_common"},
+            {"properties": {"ownership": {"const": "managed"}, "actual_matches_last_applied": {"const": true}, "desired_matches_actual": {"const": false}, "decision": {"const": "apply_desired"}, "reason": {"const": "managed_unchanged"}}}
+          ],
+          "unevaluatedProperties": false
+        },
+        {
+          "allOf": [
+            {"$ref": "#/$defs/field_decision_common"},
+            {"properties": {"ownership": {"const": "managed"}, "actual_matches_last_applied": {"const": true}, "desired_matches_actual": {"const": true}, "decision": {"const": "no_change"}, "reason": {"const": "already_desired"}}}
+          ],
+          "unevaluatedProperties": false
+        },
+        {
+          "allOf": [
+            {"$ref": "#/$defs/field_decision_common"},
+            {"required": ["drift_evidence"], "properties": {"ownership": {"const": "managed"}, "actual_matches_last_applied": {"const": false}, "decision": {"const": "preserve_actual"}, "reason": {"const": "user_modified"}}}
+          ],
+          "unevaluatedProperties": false
+        },
+        {
+          "allOf": [
+            {"$ref": "#/$defs/field_decision_common"},
+            {"properties": {"ownership": {"const": "security_required"}, "actual_matches_last_applied": {"const": true}, "desired_matches_actual": {"const": false}, "decision": {"const": "apply_desired"}, "reason": {"const": "managed_unchanged"}}}
+          ],
+          "unevaluatedProperties": false
+        },
+        {
+          "allOf": [
+            {"$ref": "#/$defs/field_decision_common"},
+            {"properties": {"ownership": {"const": "security_required"}, "actual_matches_last_applied": {"const": true}, "desired_matches_actual": {"const": true}, "decision": {"const": "no_change"}, "reason": {"const": "already_desired"}}}
+          ],
+          "unevaluatedProperties": false
+        },
+        {
+          "allOf": [
+            {"$ref": "#/$defs/field_decision_common"},
+            {"required": ["drift_evidence"], "properties": {"ownership": {"const": "security_required"}, "actual_matches_last_applied": {"const": false}, "decision": {"enum": ["review_required", "disable_execution"]}, "reason": {"const": "security_drift"}}}
+          ],
+          "unevaluatedProperties": false
+        },
+        {
+          "allOf": [
+            {"$ref": "#/$defs/field_decision_common"},
+            {"required": ["drift_evidence"], "properties": {"ownership": {"const": "unknown"}, "decision": {"const": "review_required"}, "reason": {"const": "unmanaged_resource"}}}
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "capability_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stable_external_ids", "managed_metadata", "supported_apply", "revision_cas", "compatibility", "observed_at", "expires_at", "evidence_refs"],
+      "properties": {
+        "stable_external_ids": {"type": "boolean"},
+        "managed_metadata": {"type": "boolean"},
+        "supported_apply": {"type": "boolean"},
+        "revision_cas": {"type": "boolean"},
+        "compatibility": {"enum": ["compatible", "degraded", "unsupported", "unknown"]},
+        "observed_at": {"type": "string", "format": "date-time"},
+        "expires_at": {"type": "string", "format": "date-time"},
+        "evidence_refs": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"$ref": "#/$defs/registered_reference"}}
+      }
+    },
+    "management_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "management_owner", "manager_marker"],
+      "properties": {
+        "status": {"const": "verified"},
+        "management_owner": {"$ref": "#/$defs/core_stable_id"},
+        "manager_marker": {"$ref": "#/$defs/registered_reference"}
+      }
+    },
+    "cas_precondition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["revision_kind", "observed_revision", "expected_revision", "observation_hash", "observed_at"],
+      "properties": {
+        "revision_kind": {"enum": ["revision", "etag"]},
+        "observed_revision": {"type": "string", "minLength": 1, "maxLength": 1024},
+        "expected_revision": {"type": "string", "minLength": 1, "maxLength": 1024},
+        "observation_hash": {"$ref": "#/$defs/digest"},
+        "observed_at": {"type": "string", "format": "date-time"}
+      }
+    },
+    "audit_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["audit_ref", "evidence_refs", "redaction", "recorded_at"],
+      "properties": {
+        "audit_ref": {"$ref": "#/$defs/registered_reference"},
+        "evidence_refs": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"$ref": "#/$defs/registered_reference"}},
+        "redaction": {"const": "redacted"},
+        "recorded_at": {"type": "string", "format": "date-time"}
+      }
+    },
+    "retirement_directive": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action", "owner_review_ref", "stable_identity_retained", "automatic_delete"],
+      "properties": {
+        "action": {"enum": ["disable", "archive", "detach"]},
+        "owner_review_ref": {"$ref": "#/$defs/registered_reference"},
+        "stable_identity_retained": {"const": true},
+        "automatic_delete": {"const": false}
+      }
+    },
+    "reconciliation_plan_document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version", "document_type", "plan_id", "operation_id", "source_input_id", "resource_id", "provider_id", "community_id",
+        "provider_external_id", "outcome", "plan_hash", "desired_version", "policy_ref", "policy_version", "adapter_version",
+        "capabilities", "precondition", "correlation_id", "idempotency_key", "verified_actor_ref", "authorization_ref",
+        "created_at", "expires_at", "field_decisions", "audit"
+      ],
+      "properties": {
+        "schema_version": {"const": 1},
+        "document_type": {"const": "reconciliation_plan"},
+        "plan_id": {"$ref": "#/$defs/core_stable_id"},
+        "operation_id": {"$ref": "#/$defs/core_stable_id"},
+        "source_input_id": {"$ref": "#/$defs/core_stable_id"},
+        "resource_id": {"$ref": "#/$defs/core_stable_id"},
+        "provider_id": {"$ref": "#/$defs/core_stable_id"},
+        "community_id": {"$ref": "#/$defs/core_stable_id"},
+        "provider_external_id": {"$ref": "#/$defs/core_external_id"},
+        "outcome": {"enum": ["create", "update", "no_change", "review", "disable", "retire", "rollback", "owner_reviewed_draft", "unsupported"]},
+        "plan_hash": {"$ref": "#/$defs/digest"},
+        "desired_version": {"type": "string", "minLength": 1, "maxLength": 100},
+        "policy_ref": {"$ref": "#/$defs/registered_reference"},
+        "policy_version": {"type": "string", "minLength": 1, "maxLength": 100},
+        "adapter_version": {"type": "string", "minLength": 1, "maxLength": 100},
+        "capabilities": {"$ref": "#/$defs/capability_evidence"},
+        "management_binding": {"$ref": "#/$defs/management_binding"},
+        "precondition": {"$ref": "#/$defs/cas_precondition"},
+        "correlation_id": {"$ref": "#/$defs/core_stable_id"},
+        "idempotency_key": {"$ref": "#/$defs/core_stable_id"},
+        "verified_actor_ref": {"$ref": "#/$defs/registered_reference"},
+        "authorization_ref": {"$ref": "#/$defs/registered_reference"},
+        "created_at": {"type": "string", "format": "date-time"},
+        "expires_at": {"type": "string", "format": "date-time"},
+        "field_decisions": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/field_decision"}},
+        "retirement": {"$ref": "#/$defs/retirement_directive"},
+        "audit": {"$ref": "#/$defs/audit_evidence"}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"outcome": {"enum": ["create", "update", "disable", "retire", "rollback"]}}, "required": ["outcome"]},
+          "then": {
+            "required": ["management_binding"],
+            "properties": {
+              "capabilities": {
+                "properties": {
+                  "stable_external_ids": {"const": true},
+                  "managed_metadata": {"const": true},
+                  "supported_apply": {"const": true},
+                  "revision_cas": {"const": true},
+                  "compatibility": {"const": "compatible"}
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "capabilities": {
+                "anyOf": [
+                  {"properties": {"stable_external_ids": {"const": false}}},
+                  {"properties": {"managed_metadata": {"const": false}}},
+                  {"properties": {"supported_apply": {"const": false}}},
+                  {"properties": {"revision_cas": {"const": false}}},
+                  {"properties": {"compatibility": {"enum": ["degraded", "unsupported", "unknown"]}}}
+                ]
+              }
+            },
+            "required": ["capabilities"]
+          },
+          "then": {"properties": {"outcome": {"enum": ["owner_reviewed_draft", "unsupported"]}}}
+        },
+        {
+          "if": {"properties": {"outcome": {"const": "retire"}}, "required": ["outcome"]},
+          "then": {"required": ["retirement"]},
+          "else": {"not": {"required": ["retirement"]}}
+        }
+      ]
+    },
+    "field_outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field_path", "planned_decision", "effect", "before_digest", "after_digest", "evidence_ref"],
+      "properties": {
+        "field_path": {"$ref": "#/$defs/json_pointer"},
+        "planned_decision": {"enum": ["apply_desired", "preserve_actual", "no_change", "review_required", "disable_execution"]},
+        "effect": {"enum": ["applied", "preserved", "unchanged", "disabled", "not_applied", "unknown"]},
+        "before_digest": {"$ref": "#/$defs/optional_digest"},
+        "after_digest": {"$ref": "#/$defs/optional_digest"},
+        "evidence_ref": {"$ref": "#/$defs/registered_reference"}
+      },
+      "allOf": [
+        {"if": {"properties": {"planned_decision": {"const": "apply_desired"}}}, "then": {"properties": {"effect": {"enum": ["applied", "not_applied", "unknown"]}}}},
+        {"if": {"properties": {"planned_decision": {"const": "preserve_actual"}}}, "then": {"properties": {"effect": {"enum": ["preserved", "not_applied", "unknown"]}}}},
+        {"if": {"properties": {"planned_decision": {"enum": ["no_change", "review_required"]}}}, "then": {"properties": {"effect": {"enum": ["unchanged", "not_applied", "unknown"]}}}},
+        {"if": {"properties": {"planned_decision": {"const": "disable_execution"}}}, "then": {"properties": {"effect": {"enum": ["disabled", "not_applied", "unknown"]}}}}
+      ]
+    },
+    "apply_receipt_document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version", "document_type", "receipt_id", "operation_id", "plan_id", "plan_hash", "resource_id", "provider_id",
+        "community_id", "state", "before_revision", "after_revision", "before_digest", "after_digest", "field_outcomes",
+        "provider_receipt_ref", "provider_evidence_refs", "started_at", "recorded_at", "read_after_write_required", "audit"
+      ],
+      "properties": {
+        "schema_version": {"const": 1},
+        "document_type": {"const": "apply_receipt"},
+        "receipt_id": {"$ref": "#/$defs/core_stable_id"},
+        "operation_id": {"$ref": "#/$defs/core_stable_id"},
+        "plan_id": {"$ref": "#/$defs/core_stable_id"},
+        "plan_hash": {"$ref": "#/$defs/digest"},
+        "resource_id": {"$ref": "#/$defs/core_stable_id"},
+        "provider_id": {"$ref": "#/$defs/core_stable_id"},
+        "community_id": {"$ref": "#/$defs/core_stable_id"},
+        "state": {"enum": ["published", "retryable", "indeterminate", "terminal", "conflict", "partial"]},
+        "before_revision": {"type": "string", "minLength": 1, "maxLength": 1024},
+        "after_revision": {"type": "string", "minLength": 1, "maxLength": 1024},
+        "before_digest": {"$ref": "#/$defs/digest"},
+        "after_digest": {"$ref": "#/$defs/digest"},
+        "field_outcomes": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/field_outcome"}},
+        "provider_receipt_ref": {"$ref": "#/$defs/registered_reference"},
+        "provider_evidence_refs": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"$ref": "#/$defs/registered_reference"}},
+        "started_at": {"type": "string", "format": "date-time"},
+        "recorded_at": {"type": "string", "format": "date-time"},
+        "read_after_write_required": {"type": "boolean"},
+        "audit": {"$ref": "#/$defs/audit_evidence"}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"state": {"enum": ["indeterminate", "partial"]}}, "required": ["state"]},
+          "then": {
+            "properties": {
+              "read_after_write_required": {"const": true},
+              "field_outcomes": {"contains": {"properties": {"effect": {"const": "unknown"}}, "required": ["effect"]}}
+            }
+          }
+        },
+        {
+          "if": {"properties": {"state": {"const": "published"}}, "required": ["state"]},
+          "then": {"properties": {"field_outcomes": {"items": {"properties": {"effect": {"enum": ["applied", "preserved", "unchanged", "disabled"]}}}}}}
+        },
+        {
+          "if": {"properties": {"state": {"enum": ["retryable", "terminal", "conflict"]}}, "required": ["state"]},
+          "then": {"properties": {"field_outcomes": {"items": {"properties": {"effect": {"const": "not_applied"}}}}}}
+        }
+      ]
+    },
+    "rollback_field": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field_path", "ownership", "receipt_after_digest", "restore_digest"],
+      "properties": {
+        "field_path": {"$ref": "#/$defs/json_pointer"},
+        "ownership": {"const": "managed"},
+        "receipt_after_digest": {"$ref": "#/$defs/digest"},
+        "restore_digest": {"$ref": "#/$defs/digest"}
+      }
+    },
+    "receipt_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["receipt_ref", "receipt_state", "source_plan_hash", "snapshot_ref", "verified_at"],
+      "properties": {
+        "receipt_ref": {"$ref": "#/$defs/registered_reference"},
+        "receipt_state": {"const": "published"},
+        "source_plan_hash": {"$ref": "#/$defs/digest"},
+        "snapshot_ref": {"$ref": "#/$defs/registered_reference"},
+        "verified_at": {"type": "string", "format": "date-time"}
+      }
+    },
+    "rollback_plan_document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version", "document_type", "plan_id", "operation_id", "source_input_id", "plan_hash", "resource_id", "provider_id", "community_id",
+        "provider_external_id", "policy_ref", "policy_version", "adapter_version", "capabilities", "precondition", "receipt_binding",
+        "management_binding", "restore_fields", "identity_action", "delete_or_resurrect", "correlation_id", "idempotency_key", "verified_actor_ref",
+        "authorization_ref", "created_at", "expires_at", "audit"
+      ],
+      "properties": {
+        "schema_version": {"const": 1},
+        "document_type": {"const": "rollback_plan"},
+        "plan_id": {"$ref": "#/$defs/core_stable_id"},
+        "operation_id": {"$ref": "#/$defs/core_stable_id"},
+        "source_input_id": {"$ref": "#/$defs/core_stable_id"},
+        "plan_hash": {"$ref": "#/$defs/digest"},
+        "resource_id": {"$ref": "#/$defs/core_stable_id"},
+        "provider_id": {"$ref": "#/$defs/core_stable_id"},
+        "community_id": {"$ref": "#/$defs/core_stable_id"},
+        "provider_external_id": {"$ref": "#/$defs/core_external_id"},
+        "policy_ref": {"$ref": "#/$defs/registered_reference"},
+        "policy_version": {"type": "string", "minLength": 1, "maxLength": 100},
+        "adapter_version": {"type": "string", "minLength": 1, "maxLength": 100},
+        "capabilities": {
+          "allOf": [
+            {"$ref": "#/$defs/capability_evidence"},
+            {
+              "properties": {
+                "stable_external_ids": {"const": true},
+                "managed_metadata": {"const": true},
+                "supported_apply": {"const": true},
+                "revision_cas": {"const": true},
+                "compatibility": {"const": "compatible"}
+              }
+            }
+          ]
+        },
+        "precondition": {"$ref": "#/$defs/cas_precondition"},
+        "management_binding": {"$ref": "#/$defs/management_binding"},
+        "receipt_binding": {"$ref": "#/$defs/receipt_binding"},
+        "restore_fields": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/rollback_field"}},
+        "identity_action": {"const": "retain_existing"},
+        "delete_or_resurrect": {"const": false},
+        "correlation_id": {"$ref": "#/$defs/core_stable_id"},
+        "idempotency_key": {"$ref": "#/$defs/core_stable_id"},
+        "verified_actor_ref": {"$ref": "#/$defs/registered_reference"},
+        "authorization_ref": {"$ref": "#/$defs/registered_reference"},
+        "created_at": {"type": "string", "format": "date-time"},
+        "expires_at": {"type": "string", "format": "date-time"},
+        "audit": {"$ref": "#/$defs/audit_evidence"}
+      }
+    }
+  }
+}

--- a/.agents/scripts/tests/fixtures/team-interface/reconciliation-invalid-adoption-delete.json
+++ b/.agents/scripts/tests/fixtures/team-interface/reconciliation-invalid-adoption-delete.json
@@ -1,0 +1,11 @@
+{
+  "cases": [
+    {"label": "display-name adoption", "base": "reconciliation-input.agent-alpha.7", "operation": "replace", "path": "/resource/match_basis", "value": "display_label", "validation": "schema"},
+    {"label": "mutation without verified management binding", "base": "plan.agent-alpha.7", "operation": "remove", "path": "/management_binding", "validation": "schema"},
+    {"label": "mutation bound to missing source input", "base": "plan.agent-alpha.7", "operation": "replace", "path": "/source_input_id", "value": "reconciliation-input.missing", "validation": "semantic", "error": "source input"},
+    {"label": "automatic delete outcome", "base": "plan.agent-alpha.7", "operation": "replace", "path": "/outcome", "value": "delete", "validation": "schema"},
+    {"label": "retirement delete action", "base": "plan.agent-alpha.retire-9", "operation": "replace", "path": "/retirement/action", "value": "delete", "validation": "schema"},
+    {"label": "rollback resurrection", "base": "plan.agent-alpha.rollback-12", "operation": "replace", "path": "/delete_or_resurrect", "value": true, "validation": "schema"},
+    {"label": "rollback user-owned field", "base": "plan.agent-alpha.rollback-12", "operation": "replace", "path": "/restore_fields/0/ownership", "value": "user_owned", "validation": "schema"}
+  ]
+}

--- a/.agents/scripts/tests/fixtures/team-interface/reconciliation-invalid-cas.json
+++ b/.agents/scripts/tests/fixtures/team-interface/reconciliation-invalid-cas.json
@@ -1,0 +1,28 @@
+{
+  "cases": [
+    {"label": "missing expected revision", "base": "plan.agent-alpha.7", "operation": "remove", "path": "/precondition/expected_revision", "validation": "schema"},
+    {"label": "stale expected revision", "base": "plan.agent-alpha.7", "operation": "replace", "path": "/precondition/expected_revision", "value": "etag-40", "validation": "semantic", "error": "expected revision"},
+    {"label": "expired plan at apply time", "base": "plan.agent-alpha.7", "operation": "replace", "path": "/expires_at", "value": "2026-08-04T20:10:00Z", "apply_at": "2026-08-04T20:11:00Z", "validation": "semantic", "error": "expired"},
+    {"label": "changed payload with unchanged plan hash", "base": "plan.agent-alpha.7", "operation": "replace", "path": "/desired_version", "value": "desired-changed", "validation": "semantic", "error": "plan hash"},
+    {"label": "same operation changed plan hash", "base": "plan.agent-alpha.7", "operation": "replace", "path": "/plan_hash", "value": "sha256:9999999999999999999999999999999999999999999999999999999999999999", "validation": "operation_conflict", "error": "operation ID"},
+    {"label": "same idempotency key changed operation", "base": "plan.agent-alpha.7", "operation": "replace", "path": "/operation_id", "value": "operation.agent-alpha.collision", "second_path": "/plan_hash", "second_value": "sha256:9090909090909090909090909090909090909090909090909090909090909090", "validation": "idempotency_conflict", "error": "idempotency key"},
+    {"label": "decision equality flag contradicts digests", "base": "plan.agent-alpha.7", "operation": "replace", "path": "/field_decisions/1/actual_digest", "value": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "validation": "semantic", "error": "actual digest mismatch"},
+    {"label": "user-owned equality assertion contradicts digests", "base": "plan.agent-alpha.7", "operation": "replace", "path": "/field_decisions/0/actual_matches_last_applied", "value": true, "validation": "semantic", "error": "derived equality"},
+    {"label": "observed field omitted from decisions", "base": "plan.agent-alpha.7", "operation": "pop", "path": "/field_decisions", "validation": "semantic", "error": "every observed input field"},
+    {"label": "duplicate field decision path", "base": "plan.agent-alpha.7", "operation": "replace", "path": "/field_decisions/1/field_path", "value": "/display_label", "validation": "semantic", "error": "duplicate field paths"},
+    {"label": "input ownership contradicts policy", "base": "reconciliation-input.agent-alpha.7", "operation": "replace", "path": "/fields/0/ownership", "value": "managed", "validation": "semantic", "error": "ownership mismatch"},
+    {"label": "unlisted input ownership inferred", "base": "reconciliation-input.agent-alpha.7", "operation": "replace", "path": "/fields/7/ownership", "value": "managed", "validation": "semantic", "error": "absent from the ownership policy"},
+    {"label": "duplicate input field path", "base": "reconciliation-input.agent-alpha.7", "operation": "replace", "path": "/fields/1/field_path", "value": "/display_label", "validation": "semantic", "error": "duplicate field paths"},
+    {"label": "stale capability evidence", "base": "plan.agent-alpha.7", "operation": "replace", "path": "/capabilities/expires_at", "value": "2026-08-04T20:00:30Z", "validation": "semantic", "error": "capability evidence"},
+    {"label": "ambiguous receipt without read-after-write", "base": "receipt.agent-alpha.indeterminate-11", "operation": "replace", "path": "/read_after_write_required", "value": false, "validation": "schema"},
+    {"label": "published receipt with unknown effect", "base": "receipt.agent-alpha.published-7", "operation": "replace", "path": "/field_outcomes/0/effect", "value": "unknown", "validation": "schema"},
+    {"label": "partial receipt claiming complete effect", "base": "receipt.agent-alpha.partial-10", "operation": "replace", "path": "/field_outcomes/0/effect", "value": "applied", "validation": "schema"},
+    {"label": "retryable receipt claims applied effect", "base": "receipt.agent-alpha.published-7", "operation": "replace", "path": "/state", "value": "retryable", "validation": "schema"},
+    {"label": "terminal receipt claims applied effect", "base": "receipt.agent-alpha.published-7", "operation": "replace", "path": "/state", "value": "terminal", "validation": "schema"},
+    {"label": "conflict receipt claims applied effect", "base": "receipt.agent-alpha.published-7", "operation": "replace", "path": "/state", "value": "conflict", "validation": "schema"},
+    {"label": "duplicate receipt field outcome", "base": "receipt.agent-alpha.published-7", "operation": "replace", "path": "/field_outcomes/1/field_path", "value": "/model_ref", "validation": "semantic", "error": "duplicate field paths"},
+    {"label": "rollback receipt hash mismatch", "base": "plan.agent-alpha.rollback-12", "operation": "replace", "path": "/receipt_binding/source_plan_hash", "value": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "validation": "semantic", "error": "receipt plan hash"},
+    {"label": "rollback target identity mismatch", "base": "plan.agent-alpha.rollback-12", "operation": "replace", "path": "/resource_id", "value": "agent.other", "validation": "semantic", "error": "source input identity"},
+    {"label": "rollback field evidence mismatch", "base": "plan.agent-alpha.rollback-12", "operation": "replace", "path": "/restore_fields/0/receipt_after_digest", "value": "sha256:abababababababababababababababababababababababababababababababab", "validation": "semantic", "error": "field receipt digest"}
+  ]
+}

--- a/.agents/scripts/tests/fixtures/team-interface/reconciliation-invalid-overwrite.json
+++ b/.agents/scripts/tests/fixtures/team-interface/reconciliation-invalid-overwrite.json
@@ -1,0 +1,20 @@
+{
+  "cases": [
+    {
+      "label": "user-owned field silently overwritten",
+      "decision": {"field_path": "/display_label", "ownership": "user_owned", "decision": "apply_desired", "reason": "managed_unchanged", "actual_matches_last_applied": true, "desired_matches_actual": false, "desired_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111", "last_applied_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222", "actual_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"}
+    },
+    {
+      "label": "user-modified managed field silently overwritten",
+      "decision": {"field_path": "/instructions_ref", "ownership": "managed", "decision": "apply_desired", "reason": "managed_unchanged", "actual_matches_last_applied": false, "desired_matches_actual": false, "desired_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333", "last_applied_digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444", "actual_digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555"}
+    },
+    {
+      "label": "security drift silently preserved",
+      "decision": {"field_path": "/authority_ref", "ownership": "security_required", "decision": "preserve_actual", "reason": "user_modified", "actual_matches_last_applied": false, "desired_matches_actual": false, "desired_digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666", "last_applied_digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666", "actual_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777", "drift_evidence": {"last_applied_digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666", "actual_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777", "observed_at": "2026-08-04T20:00:00Z", "evidence_ref": "observation:security-drift"}}
+    },
+    {
+      "label": "unknown ownership inferred as managed",
+      "decision": {"field_path": "/unclassified", "ownership": "unknown", "decision": "apply_desired", "reason": "managed_unchanged", "actual_matches_last_applied": true, "desired_matches_actual": false, "desired_digest": null, "last_applied_digest": null, "actual_digest": "sha256:8888888888888888888888888888888888888888888888888888888888888888"}
+    }
+  ]
+}

--- a/.agents/scripts/tests/fixtures/team-interface/reconciliation-valid-plan.json
+++ b/.agents/scripts/tests/fixtures/team-interface/reconciliation-valid-plan.json
@@ -1,0 +1,350 @@
+{
+  "documents": [
+    {
+      "schema_version": 1,
+      "document_type": "ownership_policy",
+      "policy_id": "reconciliation-policy.agent-v1",
+      "policy_version": "1.0.0",
+      "resource_kind": "other",
+      "unknown_field_ownership": "review_required",
+      "field_rules": [
+        {"field_path": "/display_label", "ownership": "user_owned", "sensitive": false},
+        {"field_path": "/model_ref", "ownership": "managed", "sensitive": false},
+        {"field_path": "/startup_mode", "ownership": "managed", "sensitive": false},
+        {"field_path": "/instructions_ref", "ownership": "managed", "sensitive": false},
+        {"field_path": "/enabled", "ownership": "managed", "sensitive": false},
+        {"field_path": "/authority_ref", "ownership": "security_required", "sensitive": false},
+        {"field_path": "/credential_ref", "ownership": "security_required", "sensitive": true}
+      ]
+    },
+    {
+      "schema_version": 1,
+      "document_type": "reconciliation_input",
+      "input_id": "reconciliation-input.agent-alpha.8",
+      "resource": {"resource_id": "agent.alpha", "provider_id": "provider.example", "community_id": "community.primary", "provider_external_id": "opaque-agent-42", "match_basis": "stable_ids", "management_identity_status": "verified", "management_owner": "aidevops.team-interface", "manager_marker": "manager:agent.alpha"},
+      "policy_ref": "policy:reconciliation-policy.agent-v1",
+      "policy_version": "1.0.0",
+      "adapter_version": "2.4.0",
+      "observed_at": "2026-08-04T20:20:00Z",
+      "observation_hash": "sha256:1414141414141414141414141414141414141414141414141414141414141414",
+      "fields": [
+        {"field_path": "/model_ref", "ownership": "managed", "sensitive": false, "desired": {"present": true, "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444", "data": {"kind": "reference", "reference_ref": "model:standard"}}, "last_applied": {"present": true, "digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555", "data": {"kind": "reference", "reference_ref": "model:simple"}}, "actual": {"present": true, "digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555", "data": {"kind": "reference", "reference_ref": "model:simple"}}, "actual_observed_at": "2026-08-04T20:20:00Z"}
+      ]
+    },
+    {
+      "schema_version": 1,
+      "document_type": "reconciliation_input",
+      "input_id": "reconciliation-input.agent-alpha.7",
+      "resource": {
+        "resource_id": "agent.alpha",
+        "provider_id": "provider.example",
+        "community_id": "community.primary",
+        "provider_external_id": "opaque-agent-42",
+        "match_basis": "stable_ids",
+        "management_identity_status": "verified",
+        "management_owner": "aidevops.team-interface",
+        "manager_marker": "manager:agent.alpha",
+        "display_label": "Human-readable label"
+      },
+      "policy_ref": "policy:reconciliation-policy.agent-v1",
+      "policy_version": "1.0.0",
+      "adapter_version": "2.4.0",
+      "observed_at": "2026-08-04T20:00:00Z",
+      "observation_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "fields": [
+        {
+          "field_path": "/display_label",
+          "ownership": "user_owned",
+          "sensitive": false,
+          "desired": {"present": true, "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111", "data": {"kind": "literal", "value": "Desired label"}},
+          "last_applied": {"present": true, "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222", "data": {"kind": "literal", "value": "Old label"}},
+          "actual": {"present": true, "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333", "data": {"kind": "literal", "value": "User label"}},
+          "actual_observed_at": "2026-08-04T20:00:00Z"
+        },
+        {
+          "field_path": "/model_ref",
+          "ownership": "managed",
+          "sensitive": false,
+          "desired": {"present": true, "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444", "data": {"kind": "reference", "reference_ref": "model:standard"}},
+          "last_applied": {"present": true, "digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555", "data": {"kind": "reference", "reference_ref": "model:simple"}},
+          "actual": {"present": true, "digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555", "data": {"kind": "reference", "reference_ref": "model:simple"}},
+          "actual_observed_at": "2026-08-04T20:00:00Z"
+        },
+        {
+          "field_path": "/credential_ref",
+          "ownership": "security_required",
+          "sensitive": true,
+          "desired": {"present": true, "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666", "data": {"kind": "secret_reference", "secret_ref": "secret:provider-agent"}},
+          "last_applied": {"present": true, "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666", "data": {"kind": "secret_reference", "secret_ref": "secret:provider-agent"}},
+          "actual": {"present": true, "digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777", "data": {"kind": "secret_reference", "secret_ref": "secret:unverified-drift"}},
+          "actual_observed_at": "2026-08-04T20:00:00Z"
+        },
+        {
+          "field_path": "/startup_mode",
+          "ownership": "managed",
+          "sensitive": false,
+          "desired": {"present": true, "digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999", "data": {"kind": "literal", "value": "enabled"}},
+          "last_applied": {"present": true, "digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999", "data": {"kind": "literal", "value": "enabled"}},
+          "actual": {"present": true, "digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999", "data": {"kind": "literal", "value": "enabled"}},
+          "actual_observed_at": "2026-08-04T20:00:00Z"
+        },
+        {
+          "field_path": "/instructions_ref",
+          "ownership": "managed",
+          "sensitive": false,
+          "desired": {"present": true, "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "data": {"kind": "reference", "reference_ref": "instructions:desired"}},
+          "last_applied": {"present": true, "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "data": {"kind": "reference", "reference_ref": "instructions:last-applied"}},
+          "actual": {"present": true, "digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "data": {"kind": "reference", "reference_ref": "instructions:user-modified"}},
+          "actual_observed_at": "2026-08-04T20:00:00Z"
+        },
+        {
+          "field_path": "/authority_ref",
+          "ownership": "security_required",
+          "sensitive": false,
+          "desired": {"present": true, "digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", "data": {"kind": "reference", "reference_ref": "authority:required"}},
+          "last_applied": {"present": true, "digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", "data": {"kind": "reference", "reference_ref": "authority:required"}},
+          "actual": {"present": true, "digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", "data": {"kind": "reference", "reference_ref": "authority:unsafe-drift"}},
+          "actual_observed_at": "2026-08-04T20:00:00Z"
+        },
+        {
+          "field_path": "/enabled",
+          "ownership": "managed",
+          "sensitive": false,
+          "desired": {"present": true, "digest": "sha256:1717171717171717171717171717171717171717171717171717171717171717", "data": {"kind": "literal", "value": false}},
+          "last_applied": {"present": true, "digest": "sha256:1818181818181818181818181818181818181818181818181818181818181818", "data": {"kind": "literal", "value": true}},
+          "actual": {"present": true, "digest": "sha256:1818181818181818181818181818181818181818181818181818181818181818", "data": {"kind": "literal", "value": true}},
+          "actual_observed_at": "2026-08-04T20:00:00Z"
+        },
+        {
+          "field_path": "/unclassified_provider_field",
+          "ownership": "unknown",
+          "sensitive": false,
+          "desired": {"present": false},
+          "last_applied": {"present": false},
+          "actual": {"present": true, "digest": "sha256:1212121212121212121212121212121212121212121212121212121212121212", "data": {"kind": "literal", "value": "unmanaged"}},
+          "actual_observed_at": "2026-08-04T20:00:00Z"
+        }
+      ]
+    },
+    {
+      "schema_version": 1,
+      "document_type": "reconciliation_plan",
+      "plan_id": "plan.agent-alpha.7",
+      "operation_id": "operation.agent-alpha.7",
+      "source_input_id": "reconciliation-input.agent-alpha.7",
+      "resource_id": "agent.alpha",
+      "provider_id": "provider.example",
+      "community_id": "community.primary",
+      "provider_external_id": "opaque-agent-42",
+      "outcome": "disable",
+      "plan_hash": "sha256:677a035ec986f9414db42a198a8041a18c8eb098e837a5ff4cfc526b4dffd2d3",
+      "desired_version": "desired-7",
+      "policy_ref": "policy:reconciliation-policy.agent-v1",
+      "policy_version": "1.0.0",
+      "adapter_version": "2.4.0",
+      "capabilities": {
+        "stable_external_ids": true,
+        "managed_metadata": true,
+        "supported_apply": true,
+        "revision_cas": true,
+        "compatibility": "compatible",
+        "observed_at": "2026-08-04T19:59:00Z",
+        "expires_at": "2026-08-04T20:15:00Z",
+        "evidence_refs": ["capability:provider-example-2.4"]
+      },
+      "management_binding": {"status": "verified", "management_owner": "aidevops.team-interface", "manager_marker": "manager:agent.alpha"},
+      "precondition": {
+        "revision_kind": "etag",
+        "observed_revision": "etag-41",
+        "expected_revision": "etag-41",
+        "observation_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "observed_at": "2026-08-04T20:00:00Z"
+      },
+      "correlation_id": "correlation.agent-alpha.7",
+      "idempotency_key": "idempotency.agent-alpha.7",
+      "verified_actor_ref": "actor:owner-verified",
+      "authorization_ref": "authorization:decision-7",
+      "created_at": "2026-08-04T20:01:00Z",
+      "expires_at": "2026-08-04T20:16:00Z",
+      "field_decisions": [
+        {
+          "field_path": "/display_label",
+          "ownership": "user_owned",
+          "decision": "preserve_actual",
+          "reason": "user_owned",
+          "actual_matches_last_applied": false,
+          "desired_matches_actual": false,
+          "desired_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+          "last_applied_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+          "actual_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+        },
+        {
+          "field_path": "/model_ref",
+          "ownership": "managed",
+          "decision": "apply_desired",
+          "reason": "managed_unchanged",
+          "actual_matches_last_applied": true,
+          "desired_matches_actual": false,
+          "desired_digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+          "last_applied_digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+          "actual_digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555"
+        },
+        {
+          "field_path": "/startup_mode",
+          "ownership": "managed",
+          "decision": "no_change",
+          "reason": "already_desired",
+          "actual_matches_last_applied": true,
+          "desired_matches_actual": true,
+          "desired_digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+          "last_applied_digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+          "actual_digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999"
+        },
+        {
+          "field_path": "/instructions_ref",
+          "ownership": "managed",
+          "decision": "preserve_actual",
+          "reason": "user_modified",
+          "actual_matches_last_applied": false,
+          "desired_matches_actual": false,
+          "desired_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "last_applied_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "actual_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "drift_evidence": {
+            "last_applied_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            "actual_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+            "observed_at": "2026-08-04T20:00:00Z",
+            "evidence_ref": "observation:field-instructions-7"
+          }
+        },
+        {
+          "field_path": "/authority_ref",
+          "ownership": "security_required",
+          "decision": "review_required",
+          "reason": "security_drift",
+          "actual_matches_last_applied": false,
+          "desired_matches_actual": false,
+          "desired_digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "last_applied_digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "actual_digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "drift_evidence": {
+            "last_applied_digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            "actual_digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "observed_at": "2026-08-04T20:00:00Z",
+            "evidence_ref": "observation:security-authority-7"
+          }
+        },
+        {
+          "field_path": "/credential_ref",
+          "ownership": "security_required",
+          "decision": "disable_execution",
+          "reason": "security_drift",
+          "actual_matches_last_applied": false,
+          "desired_matches_actual": false,
+          "desired_digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+          "last_applied_digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+          "actual_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+          "drift_evidence": {
+            "last_applied_digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+            "actual_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+            "observed_at": "2026-08-04T20:00:00Z",
+            "evidence_ref": "observation:security-credential-7"
+          }
+        },
+        {
+          "field_path": "/enabled",
+          "ownership": "managed",
+          "decision": "apply_desired",
+          "reason": "managed_unchanged",
+          "actual_matches_last_applied": true,
+          "desired_matches_actual": false,
+          "desired_digest": "sha256:1717171717171717171717171717171717171717171717171717171717171717",
+          "last_applied_digest": "sha256:1818181818181818181818181818181818181818181818181818181818181818",
+          "actual_digest": "sha256:1818181818181818181818181818181818181818181818181818181818181818"
+        },
+        {
+          "field_path": "/unclassified_provider_field",
+          "ownership": "unknown",
+          "decision": "review_required",
+          "reason": "unmanaged_resource",
+          "actual_matches_last_applied": false,
+          "desired_matches_actual": false,
+          "desired_digest": null,
+          "last_applied_digest": null,
+          "actual_digest": "sha256:1212121212121212121212121212121212121212121212121212121212121212",
+          "drift_evidence": {
+            "last_applied_digest": null,
+            "actual_digest": "sha256:1212121212121212121212121212121212121212121212121212121212121212",
+            "observed_at": "2026-08-04T20:00:00Z",
+            "evidence_ref": "observation:unmanaged-field-7"
+          }
+        }
+      ],
+      "audit": {
+        "audit_ref": "audit:plan-agent-alpha-7",
+        "evidence_refs": ["observation:agent-alpha-7", "authorization:decision-7"],
+        "redaction": "redacted",
+        "recorded_at": "2026-08-04T20:01:00Z"
+      }
+    },
+    {
+      "schema_version": 1,
+      "document_type": "reconciliation_plan",
+      "plan_id": "plan.agent-alpha.draft-8",
+      "operation_id": "operation.agent-alpha.draft-8",
+      "source_input_id": "reconciliation-input.agent-alpha.8",
+      "resource_id": "agent.alpha",
+      "provider_id": "provider.example",
+      "community_id": "community.primary",
+      "provider_external_id": "opaque-agent-42",
+      "outcome": "owner_reviewed_draft",
+      "plan_hash": "sha256:2e631ca70d08420ad16e55bdb13daa37084c1ebb09e10f7a4c33bbf5b6afe895",
+      "desired_version": "desired-8",
+      "policy_ref": "policy:reconciliation-policy.agent-v1",
+      "policy_version": "1.0.0",
+      "adapter_version": "2.4.0",
+      "capabilities": {
+        "stable_external_ids": true,
+        "managed_metadata": false,
+        "supported_apply": false,
+        "revision_cas": false,
+        "compatibility": "degraded",
+        "observed_at": "2026-08-04T20:19:00Z",
+        "expires_at": "2026-08-04T20:35:00Z",
+        "evidence_refs": ["capability:provider-example-draft-only"]
+      },
+      "precondition": {
+        "revision_kind": "revision",
+        "observed_revision": "observation-only-8",
+        "expected_revision": "observation-only-8",
+        "observation_hash": "sha256:1414141414141414141414141414141414141414141414141414141414141414",
+        "observed_at": "2026-08-04T20:20:00Z"
+      },
+      "correlation_id": "correlation.agent-alpha.8",
+      "idempotency_key": "idempotency.agent-alpha.8",
+      "verified_actor_ref": "actor:owner-verified",
+      "authorization_ref": "authorization:draft-8",
+      "created_at": "2026-08-04T20:21:00Z",
+      "expires_at": "2026-08-04T20:36:00Z",
+      "field_decisions": [
+        {
+          "field_path": "/model_ref",
+          "ownership": "managed",
+          "decision": "apply_desired",
+          "reason": "managed_unchanged",
+          "actual_matches_last_applied": true,
+          "desired_matches_actual": false,
+          "desired_digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+          "last_applied_digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+          "actual_digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555"
+        }
+      ],
+      "audit": {
+        "audit_ref": "audit:draft-agent-alpha-8",
+        "evidence_refs": ["capability:provider-example-draft-only"],
+        "redaction": "redacted",
+        "recorded_at": "2026-08-04T20:21:00Z"
+      }
+    }
+  ]
+}

--- a/.agents/scripts/tests/fixtures/team-interface/reconciliation-valid-retire-rollback.json
+++ b/.agents/scripts/tests/fixtures/team-interface/reconciliation-valid-retire-rollback.json
@@ -1,0 +1,170 @@
+{
+  "documents": [
+    {
+      "schema_version": 1,
+      "document_type": "reconciliation_input",
+      "input_id": "reconciliation-input.agent-alpha.9",
+      "resource": {"resource_id": "agent.alpha", "provider_id": "provider.example", "community_id": "community.primary", "provider_external_id": "opaque-agent-42", "match_basis": "stable_ids", "management_identity_status": "verified", "management_owner": "aidevops.team-interface", "manager_marker": "manager:agent.alpha"},
+      "policy_ref": "policy:reconciliation-policy.agent-v1",
+      "policy_version": "1.0.0",
+      "adapter_version": "2.4.0",
+      "observed_at": "2026-08-04T21:00:00Z",
+      "observation_hash": "sha256:1616161616161616161616161616161616161616161616161616161616161616",
+      "fields": [
+        {"field_path": "/enabled", "ownership": "managed", "sensitive": false, "desired": {"present": true, "digest": "sha256:1717171717171717171717171717171717171717171717171717171717171717", "data": {"kind": "literal", "value": false}}, "last_applied": {"present": true, "digest": "sha256:1818181818181818181818181818181818181818181818181818181818181818", "data": {"kind": "literal", "value": true}}, "actual": {"present": true, "digest": "sha256:1818181818181818181818181818181818181818181818181818181818181818", "data": {"kind": "literal", "value": true}}, "actual_observed_at": "2026-08-04T21:00:00Z"}
+      ]
+    },
+    {
+      "schema_version": 1,
+      "document_type": "reconciliation_input",
+      "input_id": "reconciliation-input.agent-alpha.12",
+      "resource": {"resource_id": "agent.alpha", "provider_id": "provider.example", "community_id": "community.primary", "provider_external_id": "opaque-agent-42", "match_basis": "stable_ids", "management_identity_status": "verified", "management_owner": "aidevops.team-interface", "manager_marker": "manager:agent.alpha"},
+      "policy_ref": "policy:reconciliation-policy.agent-v1",
+      "policy_version": "1.0.0",
+      "adapter_version": "2.4.0",
+      "observed_at": "2026-08-04T22:00:00Z",
+      "observation_hash": "sha256:2020202020202020202020202020202020202020202020202020202020202020",
+      "fields": [
+        {"field_path": "/model_ref", "ownership": "managed", "sensitive": false, "desired": {"present": true, "digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555", "data": {"kind": "reference", "reference_ref": "model:simple"}}, "last_applied": {"present": true, "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444", "data": {"kind": "reference", "reference_ref": "model:standard"}}, "actual": {"present": true, "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444", "data": {"kind": "reference", "reference_ref": "model:standard"}}, "actual_observed_at": "2026-08-04T22:00:00Z"}
+      ]
+    },
+    {
+      "schema_version": 1,
+      "document_type": "reconciliation_plan",
+      "plan_id": "plan.agent-alpha.retire-9",
+      "operation_id": "operation.agent-alpha.retire-9",
+      "source_input_id": "reconciliation-input.agent-alpha.9",
+      "resource_id": "agent.alpha",
+      "provider_id": "provider.example",
+      "community_id": "community.primary",
+      "provider_external_id": "opaque-agent-42",
+      "outcome": "retire",
+      "plan_hash": "sha256:bd7c3aff0bf4835a4ef6229ef4605c7e68a7f0f5640f5efa0a8ebb836eb9629b",
+      "desired_version": "desired-9",
+      "policy_ref": "policy:reconciliation-policy.agent-v1",
+      "policy_version": "1.0.0",
+      "adapter_version": "2.4.0",
+      "capabilities": {"stable_external_ids": true, "managed_metadata": true, "supported_apply": true, "revision_cas": true, "compatibility": "compatible", "observed_at": "2026-08-04T21:00:00Z", "expires_at": "2026-08-04T21:15:00Z", "evidence_refs": ["capability:provider-example-2.4"]},
+      "management_binding": {"status": "verified", "management_owner": "aidevops.team-interface", "manager_marker": "manager:agent.alpha"},
+      "precondition": {"revision_kind": "etag", "observed_revision": "etag-42", "expected_revision": "etag-42", "observation_hash": "sha256:1616161616161616161616161616161616161616161616161616161616161616", "observed_at": "2026-08-04T21:00:00Z"},
+      "correlation_id": "correlation.agent-alpha.9",
+      "idempotency_key": "idempotency.agent-alpha.9",
+      "verified_actor_ref": "actor:owner-verified",
+      "authorization_ref": "authorization:retire-9",
+      "created_at": "2026-08-04T21:01:00Z",
+      "expires_at": "2026-08-04T21:16:00Z",
+      "field_decisions": [
+        {"field_path": "/enabled", "ownership": "managed", "decision": "apply_desired", "reason": "managed_unchanged", "actual_matches_last_applied": true, "desired_matches_actual": false, "desired_digest": "sha256:1717171717171717171717171717171717171717171717171717171717171717", "last_applied_digest": "sha256:1818181818181818181818181818181818181818181818181818181818181818", "actual_digest": "sha256:1818181818181818181818181818181818181818181818181818181818181818"}
+      ],
+      "retirement": {"action": "archive", "owner_review_ref": "review:retire-agent-alpha-9", "stable_identity_retained": true, "automatic_delete": false},
+      "audit": {"audit_ref": "audit:retire-agent-alpha-9", "evidence_refs": ["review:retire-agent-alpha-9"], "redaction": "redacted", "recorded_at": "2026-08-04T21:01:00Z"}
+    },
+    {
+      "schema_version": 1,
+      "document_type": "apply_receipt",
+      "receipt_id": "receipt.agent-alpha.published-7",
+      "operation_id": "operation.agent-alpha.7",
+      "plan_id": "plan.agent-alpha.7",
+      "plan_hash": "sha256:677a035ec986f9414db42a198a8041a18c8eb098e837a5ff4cfc526b4dffd2d3",
+      "resource_id": "agent.alpha",
+      "provider_id": "provider.example",
+      "community_id": "community.primary",
+      "state": "published",
+      "before_revision": "etag-41",
+      "after_revision": "etag-42",
+      "before_digest": "sha256:1919191919191919191919191919191919191919191919191919191919191919",
+      "after_digest": "sha256:2020202020202020202020202020202020202020202020202020202020202020",
+      "field_outcomes": [
+        {"field_path": "/model_ref", "planned_decision": "apply_desired", "effect": "applied", "before_digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555", "after_digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444", "evidence_ref": "provider-evidence:model-ref-7"},
+        {"field_path": "/display_label", "planned_decision": "preserve_actual", "effect": "preserved", "before_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333", "after_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333", "evidence_ref": "provider-evidence:display-label-7"}
+      ],
+      "provider_receipt_ref": "provider-receipt:operation-agent-alpha-7",
+      "provider_evidence_refs": ["provider-evidence:operation-agent-alpha-7"],
+      "started_at": "2026-08-04T20:02:00Z",
+      "recorded_at": "2026-08-04T20:02:10Z",
+      "read_after_write_required": false,
+      "audit": {"audit_ref": "audit:receipt-agent-alpha-7", "evidence_refs": ["provider-receipt:operation-agent-alpha-7"], "redaction": "redacted", "recorded_at": "2026-08-04T20:02:10Z"}
+    },
+    {
+      "schema_version": 1,
+      "document_type": "apply_receipt",
+      "receipt_id": "receipt.agent-alpha.partial-10",
+      "operation_id": "operation.agent-alpha.10",
+      "plan_id": "plan.agent-alpha.10",
+      "plan_hash": "sha256:2121212121212121212121212121212121212121212121212121212121212121",
+      "resource_id": "agent.alpha",
+      "provider_id": "provider.example",
+      "community_id": "community.primary",
+      "state": "partial",
+      "before_revision": "etag-42",
+      "after_revision": "unknown-after-partial",
+      "before_digest": "sha256:2020202020202020202020202020202020202020202020202020202020202020",
+      "after_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "field_outcomes": [
+        {"field_path": "/model_ref", "planned_decision": "apply_desired", "effect": "unknown", "before_digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444", "after_digest": null, "evidence_ref": "provider-evidence:partial-model-10"}
+      ],
+      "provider_receipt_ref": "provider-receipt:partial-agent-alpha-10",
+      "provider_evidence_refs": ["provider-evidence:partial-agent-alpha-10"],
+      "started_at": "2026-08-04T21:20:00Z",
+      "recorded_at": "2026-08-04T21:20:10Z",
+      "read_after_write_required": true,
+      "audit": {"audit_ref": "audit:partial-agent-alpha-10", "evidence_refs": ["provider-evidence:partial-agent-alpha-10"], "redaction": "redacted", "recorded_at": "2026-08-04T21:20:10Z"}
+    },
+    {
+      "schema_version": 1,
+      "document_type": "apply_receipt",
+      "receipt_id": "receipt.agent-alpha.indeterminate-11",
+      "operation_id": "operation.agent-alpha.11",
+      "plan_id": "plan.agent-alpha.11",
+      "plan_hash": "sha256:2323232323232323232323232323232323232323232323232323232323232323",
+      "resource_id": "agent.alpha",
+      "provider_id": "provider.example",
+      "community_id": "community.primary",
+      "state": "indeterminate",
+      "before_revision": "etag-42",
+      "after_revision": "unknown-after-timeout",
+      "before_digest": "sha256:2020202020202020202020202020202020202020202020202020202020202020",
+      "after_digest": "sha256:2424242424242424242424242424242424242424242424242424242424242424",
+      "field_outcomes": [
+        {"field_path": "/startup_mode", "planned_decision": "apply_desired", "effect": "unknown", "before_digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999", "after_digest": null, "evidence_ref": "provider-evidence:timeout-startup-11"}
+      ],
+      "provider_receipt_ref": "provider-receipt:timeout-agent-alpha-11",
+      "provider_evidence_refs": ["provider-evidence:timeout-agent-alpha-11"],
+      "started_at": "2026-08-04T21:30:00Z",
+      "recorded_at": "2026-08-04T21:30:10Z",
+      "read_after_write_required": true,
+      "audit": {"audit_ref": "audit:indeterminate-agent-alpha-11", "evidence_refs": ["provider-evidence:timeout-agent-alpha-11"], "redaction": "redacted", "recorded_at": "2026-08-04T21:30:10Z"}
+    },
+    {
+      "schema_version": 1,
+      "document_type": "rollback_plan",
+      "plan_id": "plan.agent-alpha.rollback-12",
+      "operation_id": "operation.agent-alpha.rollback-12",
+      "source_input_id": "reconciliation-input.agent-alpha.12",
+      "plan_hash": "sha256:a97d21ddcb5082b385b20e98480861c9b7865c56016e0728bb6d8cccd18ccee9",
+      "resource_id": "agent.alpha",
+      "provider_id": "provider.example",
+      "community_id": "community.primary",
+      "provider_external_id": "opaque-agent-42",
+      "policy_ref": "policy:reconciliation-policy.agent-v1",
+      "policy_version": "1.0.0",
+      "adapter_version": "2.4.0",
+      "capabilities": {"stable_external_ids": true, "managed_metadata": true, "supported_apply": true, "revision_cas": true, "compatibility": "compatible", "observed_at": "2026-08-04T22:00:00Z", "expires_at": "2026-08-04T22:15:00Z", "evidence_refs": ["capability:provider-example-2.4"]},
+      "precondition": {"revision_kind": "etag", "observed_revision": "etag-42", "expected_revision": "etag-42", "observation_hash": "sha256:2020202020202020202020202020202020202020202020202020202020202020", "observed_at": "2026-08-04T22:00:00Z"},
+      "management_binding": {"status": "verified", "management_owner": "aidevops.team-interface", "manager_marker": "manager:agent.alpha"},
+      "receipt_binding": {"receipt_ref": "receipt:receipt.agent-alpha.published-7", "receipt_state": "published", "source_plan_hash": "sha256:677a035ec986f9414db42a198a8041a18c8eb098e837a5ff4cfc526b4dffd2d3", "snapshot_ref": "snapshot:agent-alpha-before-7", "verified_at": "2026-08-04T22:00:00Z"},
+      "restore_fields": [
+        {"field_path": "/model_ref", "ownership": "managed", "receipt_after_digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444", "restore_digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555"}
+      ],
+      "identity_action": "retain_existing",
+      "delete_or_resurrect": false,
+      "correlation_id": "correlation.agent-alpha.rollback-12",
+      "idempotency_key": "idempotency.agent-alpha.rollback-12",
+      "verified_actor_ref": "actor:owner-verified",
+      "authorization_ref": "authorization:rollback-12",
+      "created_at": "2026-08-04T22:01:00Z",
+      "expires_at": "2026-08-04T22:16:00Z",
+      "audit": {"audit_ref": "audit:rollback-agent-alpha-12", "evidence_refs": ["receipt:receipt.agent-alpha.published-7", "snapshot:agent-alpha-before-7"], "redaction": "redacted", "recorded_at": "2026-08-04T22:01:00Z"}
+    }
+  ]
+}

--- a/.agents/scripts/tests/lib/team-interface-reconciliation-fixtures.mjs
+++ b/.agents/scripts/tests/lib/team-interface-reconciliation-fixtures.mjs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+
+export function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function formatErrors(errors) {
+  return (errors || [])
+    .map((error) => `${error.instancePath || "<root>"} ${error.keyword}: ${error.message}`)
+    .join("\n");
+}
+
+export function assertValid(validate, document, label) {
+  assert.equal(validate(document), true, `${label} failed:\n${formatErrors(validate.errors)}`);
+}
+
+export function assertInvalid(validate, document, label) {
+  assert.equal(validate(document), false, `${label} unexpectedly validated`);
+}
+
+export function documentId(document) {
+  return document.receipt_id || document.plan_id || document.input_id || document.policy_id;
+}
+
+function decodePointerSegment(segment) {
+  return segment.replaceAll("~1", "/").replaceAll("~0", "~");
+}
+
+export function applyMutation(document, invalidCase) {
+  const clone = structuredClone(document);
+  const mutate = (pointer, value, operation = "replace") => {
+    const segments = pointer.split("/").slice(1).map(decodePointerSegment);
+    const property = segments.pop();
+    let target = clone;
+    for (const segment of segments) target = target[segment];
+    if (operation === "remove") delete target[property];
+    else if (operation === "pop") target[property].pop();
+    else target[property] = value;
+  };
+  mutate(invalidCase.path, invalidCase.value, invalidCase.operation);
+  if (invalidCase.second_path) mutate(invalidCase.second_path, invalidCase.second_value);
+  return clone;
+}
+
+function stableStringify(value) {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  if (value && typeof value === "object") {
+    const entries = Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`);
+    return `{${entries.join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function canonicalPlanHash(plan) {
+  const payload = structuredClone(plan);
+  delete payload.plan_hash;
+  return `sha256:${crypto.createHash("sha256").update(stableStringify(payload)).digest("hex")}`;
+}
+
+export function assertUniquePaths(records, label) {
+  const paths = records.map(({field_path: fieldPath}) => fieldPath);
+  assert.equal(new Set(paths).size, paths.length, `${label} contains duplicate field paths`);
+}
+
+export function snapshotDigest(snapshot) {
+  return snapshot.present ? snapshot.digest : null;
+}
+
+export function collectEnumValues(value, result = []) {
+  if (Array.isArray(value)) {
+    for (const item of value) collectEnumValues(item, result);
+    return result;
+  }
+  if (!value || typeof value !== "object") return result;
+  if (Array.isArray(value.enum)) result.push(...value.enum);
+  if (Object.hasOwn(value, "const")) result.push(value.const);
+  for (const child of Object.values(value)) collectEnumValues(child, result);
+  return result;
+}
+
+export function assertNoSecretValueProperties(value, location = "<root>") {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoSecretValueProperties(item, `${location}/${index}`));
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  if (value.properties) {
+    for (const propertyName of Object.keys(value.properties)) {
+      assert.doesNotMatch(
+        propertyName,
+        /^(token|password|private[_-]?key|credential[_-]?value|secret[_-]?value)$/i,
+        `secret-value property exposed at ${location}/properties/${propertyName}`,
+      );
+    }
+  }
+  for (const [key, child] of Object.entries(value)) assertNoSecretValueProperties(child, `${location}/${key}`);
+}

--- a/.agents/scripts/tests/lib/team-interface-reconciliation-semantics.mjs
+++ b/.agents/scripts/tests/lib/team-interface-reconciliation-semantics.mjs
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import {
+  assertUniquePaths,
+  canonicalPlanHash,
+  snapshotDigest,
+} from "./team-interface-reconciliation-fixtures.mjs";
+
+export function assertInputPolicy(input, policy) {
+  assertUniquePaths(input.fields, `${input.input_id} input`);
+  assert.equal(input.policy_ref, `policy:${policy.policy_id}`, "input policy reference mismatch");
+  assert.equal(input.policy_version, policy.policy_version, "input policy version mismatch");
+  const rules = new Map(policy.field_rules.map((rule) => [rule.field_path, rule]));
+  for (const field of input.fields) {
+    const rule = rules.get(field.field_path);
+    if (field.ownership === "unknown") {
+      assert.equal(rule, undefined, "unknown ownership cannot override an explicit policy rule");
+      continue;
+    }
+    assert.ok(rule, `known field ${field.field_path} is absent from the ownership policy`);
+    assert.equal(field.ownership, rule.ownership, `ownership mismatch for ${field.field_path}`);
+    assert.equal(field.sensitive, rule.sensitive, `sensitivity mismatch for ${field.field_path}`);
+  }
+}
+
+function assertDecisionEvidence(plan, input) {
+  assertUniquePaths(plan.field_decisions, `${plan.plan_id} decisions`);
+  const inputFields = new Map(input.fields.map((field) => [field.field_path, field]));
+  assert.deepEqual(
+    plan.field_decisions.map(({field_path: fieldPath}) => fieldPath).sort(),
+    input.fields.map(({field_path: fieldPath}) => fieldPath).sort(),
+    "every observed input field must have exactly one decision",
+  );
+  for (const decision of plan.field_decisions) {
+    const field = inputFields.get(decision.field_path);
+    assert.ok(field, `decision ${decision.field_path} is absent from source input`);
+    assert.equal(decision.ownership, field.ownership, `decision ownership mismatch for ${decision.field_path}`);
+    assert.equal(decision.desired_digest, snapshotDigest(field.desired), `desired digest mismatch for ${decision.field_path}`);
+    assert.equal(
+      decision.last_applied_digest,
+      snapshotDigest(field.last_applied),
+      `last-applied digest mismatch for ${decision.field_path}`,
+    );
+    assert.equal(decision.actual_digest, snapshotDigest(field.actual), `actual digest mismatch for ${decision.field_path}`);
+    assert.equal(
+      decision.actual_matches_last_applied,
+      decision.actual_digest === decision.last_applied_digest,
+      `derived equality mismatch for ${decision.field_path} actual/last-applied`,
+    );
+    assert.equal(
+      decision.desired_matches_actual,
+      decision.desired_digest === decision.actual_digest,
+      `derived equality mismatch for ${decision.field_path} desired/actual`,
+    );
+    if (decision.drift_evidence) {
+      assert.equal(decision.drift_evidence.last_applied_digest, decision.last_applied_digest);
+      assert.equal(decision.drift_evidence.actual_digest, decision.actual_digest);
+    }
+  }
+}
+
+export function assertPlanSemantics(plan, context, applyAt = plan.created_at, checkHash = true) {
+  assert.equal(
+    plan.precondition.expected_revision,
+    plan.precondition.observed_revision,
+    "expected revision must equal the freshly observed revision",
+  );
+  assert.ok(Date.parse(plan.expires_at) > Date.parse(applyAt), "expired plan cannot be applied");
+  assert.ok(Date.parse(plan.created_at) >= Date.parse(plan.precondition.observed_at), "plan predates observation");
+  assert.ok(Date.parse(plan.created_at) >= Date.parse(plan.capabilities.observed_at), "plan predates capability evidence");
+  assert.ok(Date.parse(plan.capabilities.expires_at) > Date.parse(applyAt), "capability evidence is stale at apply time");
+
+  const input = context.inputById.get(plan.source_input_id);
+  assert.ok(input, "source input must exist");
+  for (const [planKey, resourceKey = planKey] of [
+    ["resource_id"],
+    ["provider_id"],
+    ["community_id"],
+    ["provider_external_id"],
+  ]) {
+    assert.equal(plan[planKey], input.resource[resourceKey], `source input identity mismatch for ${planKey}`);
+  }
+  assert.equal(plan.policy_ref, input.policy_ref, "plan policy reference mismatch");
+  assert.equal(plan.policy_version, input.policy_version, "plan policy version mismatch");
+  assert.equal(plan.adapter_version, input.adapter_version, "plan adapter version mismatch");
+  assert.equal(plan.precondition.observation_hash, input.observation_hash, "plan observation hash mismatch");
+  assert.equal(plan.precondition.observed_at, input.observed_at, "plan observation time mismatch");
+
+  const mutating = plan.document_type === "rollback_plan"
+    || ["create", "update", "disable", "retire", "rollback"].includes(plan.outcome);
+  if (mutating) {
+    for (const capability of ["stable_external_ids", "managed_metadata", "supported_apply", "revision_cas"]) {
+      assert.equal(plan.capabilities[capability], true, `mutating plan lacks ${capability}`);
+    }
+    assert.equal(plan.capabilities.compatibility, "compatible", "mutating plan has incompatible capabilities");
+    assert.equal(input.resource.management_identity_status, "verified", "mutating plan source is unmanaged");
+    assert.equal(plan.management_binding.status, "verified", "mutating plan lacks verified management identity");
+    assert.equal(plan.management_binding.management_owner, input.resource.management_owner, "management owner mismatch");
+    assert.equal(plan.management_binding.manager_marker, input.resource.manager_marker, "manager marker mismatch");
+  }
+
+  if (plan.field_decisions) assertDecisionEvidence(plan, input);
+  if (checkHash) assert.equal(plan.plan_hash, canonicalPlanHash(plan), "plan hash does not cover canonical payload");
+}
+
+export function recordOperation(registry, document) {
+  const recordedHash = registry.operationHashes.get(document.operation_id);
+  if (recordedHash && recordedHash !== document.plan_hash) {
+    throw new Error("operation ID reused with a different plan hash");
+  }
+  const idempotencyHash = registry.idempotencyHashes.get(document.idempotency_key);
+  if (idempotencyHash && idempotencyHash !== document.plan_hash) {
+    throw new Error("idempotency key reused with a different plan hash");
+  }
+  registry.operationHashes.set(document.operation_id, document.plan_hash);
+  registry.idempotencyHashes.set(document.idempotency_key, document.plan_hash);
+}
+
+export function assertReceiptSemantics(receipt) {
+  assertUniquePaths(receipt.field_outcomes, `${receipt.receipt_id} outcomes`);
+  const effects = receipt.field_outcomes.map(({effect}) => effect);
+  if (["partial", "indeterminate"].includes(receipt.state)) {
+    assert.ok(effects.includes("unknown"), `${receipt.state} receipt lacks an unknown effect`);
+  }
+  if (receipt.state === "published") {
+    assert.equal(effects.some((effect) => ["unknown", "not_applied"].includes(effect)), false);
+  }
+  if (["retryable", "terminal", "conflict"].includes(receipt.state)) {
+    assert.ok(effects.every((effect) => effect === "not_applied"), `${receipt.state} receipt claims a side effect`);
+  }
+}
+
+export function assertRollbackSemantics(rollback, context, applyAt = rollback.created_at) {
+  assertPlanSemantics(rollback, context, applyAt, false);
+  const {receiptByReference} = context;
+  const receipt = receiptByReference.get(rollback.receipt_binding.receipt_ref);
+  assert.ok(receipt, "rollback receipt must exist");
+  assert.equal(receipt.state, "published", "rollback receipt must be verified successful");
+  assert.equal(
+    rollback.receipt_binding.source_plan_hash,
+    receipt.plan_hash,
+    "rollback receipt plan hash must match the verified receipt",
+  );
+  assert.equal(
+    rollback.precondition.expected_revision,
+    receipt.after_revision,
+    "rollback expected revision must bind the receipt after revision",
+  );
+  for (const identityKey of ["resource_id", "provider_id", "community_id"]) {
+    assert.equal(rollback[identityKey], receipt[identityKey], `rollback receipt identity mismatch for ${identityKey}`);
+  }
+  const input = context.inputById.get(rollback.source_input_id);
+  const inputFields = new Map(input.fields.map((field) => [field.field_path, field]));
+  const receiptFields = new Map(receipt.field_outcomes.map((field) => [field.field_path, field]));
+  const policyRules = new Map(context.policy.field_rules.map((rule) => [rule.field_path, rule]));
+  assertUniquePaths(rollback.restore_fields, `${rollback.plan_id} restore fields`);
+  for (const field of rollback.restore_fields) {
+    assert.equal(field.ownership, "managed", "rollback may restore only managed fields");
+    assert.equal(policyRules.get(field.field_path)?.ownership, "managed", "rollback field is not managed by current policy");
+    const receiptField = receiptFields.get(field.field_path);
+    assert.ok(receiptField, `rollback field ${field.field_path} is absent from receipt`);
+    assert.equal(field.receipt_after_digest, receiptField.after_digest, "rollback field receipt digest mismatch");
+    assert.equal(field.restore_digest, receiptField.before_digest, "rollback restore digest mismatch");
+    assert.equal(snapshotDigest(inputFields.get(field.field_path).actual), receiptField.after_digest, "rollback actual state drifted");
+  }
+  assert.equal(rollback.plan_hash, canonicalPlanHash(rollback), "plan hash does not cover canonical payload");
+}

--- a/.agents/scripts/tests/test-team-interface-reconciliation-schema.mjs
+++ b/.agents/scripts/tests/test-team-interface-reconciliation-schema.mjs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import path from "node:path";
+import {fileURLToPath} from "node:url";
+import Ajv2020 from "ajv/dist/2020.js";
+import {
+  applyMutation,
+  assertInvalid,
+  assertNoSecretValueProperties,
+  assertUniquePaths,
+  assertValid,
+  collectEnumValues,
+  documentId,
+  readJson,
+} from "./lib/team-interface-reconciliation-fixtures.mjs";
+import {
+  assertInputPolicy,
+  assertPlanSemantics,
+  assertReceiptSemantics,
+  assertRollbackSemantics,
+  recordOperation,
+} from "./lib/team-interface-reconciliation-semantics.mjs";
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const schemaDirectory = path.join(testDirectory, "../../schemas/team-interface");
+const fixtureDirectory = path.join(testDirectory, "fixtures/team-interface");
+
+const coreSchema = readJson(path.join(schemaDirectory, "core-v1.schema.json"));
+const reconciliationSchema = readJson(path.join(schemaDirectory, "reconciliation-v1.schema.json"));
+assert.equal(reconciliationSchema.$schema, "https://json-schema.org/draft/2020-12/schema");
+assert.equal(reconciliationSchema.$id, "urn:aidevops:team-interface:reconciliation:v1");
+assertNoSecretValueProperties(reconciliationSchema);
+assert.equal(collectEnumValues(reconciliationSchema).includes("delete"), false, "automatic delete must be unrepresentable");
+
+const ajv = new Ajv2020({allErrors: true, strict: false, validateFormats: false});
+ajv.addSchema(coreSchema);
+ajv.addSchema(reconciliationSchema);
+const validate = ajv.getSchema(reconciliationSchema.$id);
+const validateFieldDecision = ajv.compile({$ref: `${reconciliationSchema.$id}#/$defs/field_decision`});
+
+const validPlanFixture = readJson(path.join(fixtureDirectory, "reconciliation-valid-plan.json"));
+const validLifecycleFixture = readJson(path.join(fixtureDirectory, "reconciliation-valid-retire-rollback.json"));
+const validDocuments = [...validPlanFixture.documents, ...validLifecycleFixture.documents];
+const documentById = new Map(validDocuments.map((document) => [documentId(document), document]));
+
+for (const document of validDocuments) {
+  assertValid(validate, document, `valid ${document.document_type} ${documentId(document)}`);
+}
+
+const policy = validDocuments.find(({document_type: type}) => type === "ownership_policy");
+assertUniquePaths(policy.field_rules, "ownership policy");
+assert.equal(policy.unknown_field_ownership, "review_required");
+const inputById = new Map(
+  validDocuments.filter(({document_type: type}) => type === "reconciliation_input")
+    .map((document) => [document.input_id, document]),
+);
+for (const reconciliationInput of inputById.values()) assertInputPolicy(reconciliationInput, policy);
+const context = {policy, inputById, receiptByReference: new Map()};
+
+const input = documentById.get("reconciliation-input.agent-alpha.7");
+assert.equal(input.resource.match_basis, "stable_ids", "display labels must not identify or adopt resources");
+const sensitiveInput = input.fields.find(({sensitive}) => sensitive);
+for (const snapshotName of ["desired", "last_applied", "actual"]) {
+  assert.equal(sensitiveInput[snapshotName].data.kind, "secret_reference", "sensitive data must remain a secret reference");
+}
+
+const decisionPlan = documentById.get("plan.agent-alpha.7");
+const decisions = new Map(decisionPlan.field_decisions.map((decision) => [decision.field_path, decision]));
+assert.equal(decisions.get("/display_label").decision, "preserve_actual");
+assert.equal(decisions.get("/model_ref").decision, "apply_desired");
+assert.equal(decisions.get("/startup_mode").decision, "no_change");
+assert.equal(decisions.get("/instructions_ref").reason, "user_modified");
+assert.equal(decisions.get("/authority_ref").decision, "review_required");
+assert.equal(decisions.get("/credential_ref").decision, "disable_execution");
+assert.equal(decisions.get("/unclassified_provider_field").reason, "unmanaged_resource");
+
+const fallbackPlan = documentById.get("plan.agent-alpha.draft-8");
+assert.equal(fallbackPlan.outcome, "owner_reviewed_draft");
+assert.ok(Object.values(fallbackPlan.capabilities).includes(false), "fallback plan must demonstrate a capability gap");
+
+const operationRegistry = {operationHashes: new Map(), idempotencyHashes: new Map()};
+for (const plan of validDocuments.filter(({document_type: type}) => type === "reconciliation_plan")) {
+  assertPlanSemantics(plan, context);
+  recordOperation(operationRegistry, plan);
+}
+
+const receipts = validDocuments.filter(({document_type: type}) => type === "apply_receipt");
+for (const receipt of receipts) assertReceiptSemantics(receipt);
+for (const receipt of receipts.filter(({state}) => ["partial", "indeterminate"].includes(state))) {
+  assert.equal(receipt.read_after_write_required, true, `${receipt.state} must require read-after-write reconciliation`);
+  assert.equal(receipt.audit.redaction, "redacted");
+}
+const receiptByReference = new Map(receipts.map((receipt) => [`receipt:${receipt.receipt_id}`, receipt]));
+context.receiptByReference = receiptByReference;
+const rollback = documentById.get("plan.agent-alpha.rollback-12");
+assertRollbackSemantics(rollback, context);
+recordOperation(operationRegistry, rollback);
+
+const invalidOverwrite = readJson(path.join(fixtureDirectory, "reconciliation-invalid-overwrite.json"));
+for (const invalidCase of invalidOverwrite.cases) {
+  assertInvalid(validateFieldDecision, invalidCase.decision, invalidCase.label);
+}
+
+const invalidCas = readJson(path.join(fixtureDirectory, "reconciliation-invalid-cas.json"));
+for (const invalidCase of invalidCas.cases) {
+  const base = documentById.get(invalidCase.base);
+  assert.ok(base, `missing fixture base ${invalidCase.base}`);
+  const mutated = applyMutation(base, invalidCase);
+  if (invalidCase.validation === "schema") {
+    assertInvalid(validate, mutated, invalidCase.label);
+    continue;
+  }
+  assertValid(validate, mutated, `${invalidCase.label} structural precondition`);
+  if (invalidCase.validation === "operation_conflict") {
+    const collisionRegistry = {operationHashes: new Map(), idempotencyHashes: new Map()};
+    recordOperation(collisionRegistry, base);
+    assert.throws(() => recordOperation(collisionRegistry, mutated), new RegExp(invalidCase.error, "i"));
+    continue;
+  }
+  if (invalidCase.validation === "idempotency_conflict") {
+    const collisionRegistry = {operationHashes: new Map(), idempotencyHashes: new Map()};
+    recordOperation(collisionRegistry, base);
+    assert.throws(() => recordOperation(collisionRegistry, mutated), new RegExp(invalidCase.error, "i"));
+    continue;
+  }
+  let semanticCheck;
+  if (mutated.document_type === "rollback_plan") {
+    semanticCheck = () => assertRollbackSemantics(mutated, context, invalidCase.apply_at);
+  } else if (mutated.document_type === "reconciliation_input") {
+    semanticCheck = () => assertInputPolicy(mutated, policy);
+  } else if (mutated.document_type === "apply_receipt") {
+    semanticCheck = () => assertReceiptSemantics(mutated);
+  } else {
+    semanticCheck = () => assertPlanSemantics(mutated, context, invalidCase.apply_at);
+  }
+  assert.throws(semanticCheck, new RegExp(invalidCase.error, "i"));
+}
+
+const invalidAdoptionDelete = readJson(
+  path.join(fixtureDirectory, "reconciliation-invalid-adoption-delete.json"),
+);
+for (const invalidCase of invalidAdoptionDelete.cases) {
+  const base = documentById.get(invalidCase.base);
+  assert.ok(base, `missing fixture base ${invalidCase.base}`);
+  const mutated = applyMutation(base, invalidCase);
+  if (invalidCase.validation === "schema") assertInvalid(validate, mutated, invalidCase.label);
+  else {
+    assertValid(validate, mutated, `${invalidCase.label} structural precondition`);
+    assert.throws(() => assertPlanSemantics(mutated, context), new RegExp(invalidCase.error, "i"));
+  }
+}
+
+console.log("PASS: reconciliation contracts preserve ownership, CAS, retirement, rollback, and audit safety");


### PR DESCRIPTION
## Summary

Added the provider-neutral reconciliation schema, safety reference, positive and negative fixtures, and split semantic test helpers to avoid the prior Qlty file-complexity regression.

## Files Changed

.agents/reference/team-interface-reconciliation.md, .agents/schemas/team-interface/reconciliation-v1.schema.json, .agents/scripts/tests/fixtures/team-interface/reconciliation-invalid-adoption-delete.json, .agents/scripts/tests/fixtures/team-interface/reconciliation-invalid-cas.json, .agents/scripts/tests/fixtures/team-interface/reconciliation-invalid-overwrite.json, .agents/scripts/tests/fixtures/team-interface/reconciliation-valid-plan.json, .agents/scripts/tests/fixtures/team-interface/reconciliation-valid-retire-rollback.json, .agents/scripts/tests/lib/team-interface-reconciliation-fixtures.mjs, .agents/scripts/tests/lib/team-interface-reconciliation-semantics.mjs, .agents/scripts/tests/test-team-interface-reconciliation-schema.mjs

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node .agents/scripts/tests/test-team-interface-reconciliation-schema.mjs; Ajv 2020 multi-schema probe; npm run typecheck; .agents/scripts/linters-local.sh --changed

Resolves #29502


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.222 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 17m and 131,657 tokens on this as a headless worker.