### PR TITLE
GH#29530: Add a Buzz-scoped OpenCode Tabby workspace profile

### DIFF
--- a/.agents/reference/tabby-profiles.md
+++ b/.agents/reference/tabby-profiles.md
@@ -4,7 +4,10 @@
 # Tabby profiles
 
 Use `.agents/scripts/tabby-profile-sync.py` to generate aidevops project profiles
-from `repos.json`.
+from `repos.json`. When `~/.buzz` exists, setup/update also generates a `Buzz`
+profile rooted there so OpenCode opens the Buzz-scoped session namespace. The
+profile is omitted when Buzz has not created that workspace, and an existing
+profile with the same working directory remains user-owned and unchanged.
 
 OpenCode profiles must not launch with `zsh -i -c opencode`. That shape runs an
 interactive zsh startup while executing a command string, which can make

--- a/.agents/scripts/setup/modules/post-setup.sh
+++ b/.agents/scripts/setup/modules/post-setup.sh
@@ -193,9 +193,9 @@ print_final_instructions() {
 	return 0
 }
 
-# Setup Tabby terminal profiles from repos.json.
-# Creates a profile per registered repo with colour-matched themes and
-# direct split-arg OpenCode launch settings.
+# Setup Tabby terminal profiles from repos.json and detected workspaces.
+# Creates a profile per registered repo plus a Buzz profile when ~/.buzz exists,
+# with colour-matched themes and direct split-arg OpenCode launch settings.
 # Skipped if Tabby is not installed.
 setup_tabby() {
 	local tabby_helper="$HOME/.aidevops/agents/scripts/tabby-helper.sh"
@@ -237,7 +237,7 @@ setup_tabby() {
 	bash "$tabby_helper" status || true
 	echo ""
 	local sync_tabby=""
-	setup_prompt sync_tabby "Sync Tabby profiles from repos.json? [Y/n]: " "Y"
+	setup_prompt sync_tabby "Sync Tabby profiles and detected workspaces? [Y/n]: " "Y"
 	if [[ "$sync_tabby" =~ ^[Yy]?$ ]]; then
 		bash "$tabby_helper" sync
 	else

--- a/.agents/scripts/tabby-helper.sh
+++ b/.agents/scripts/tabby-helper.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# tabby-helper.sh — Generate and sync Tabby terminal profiles from repos.json
+# tabby-helper.sh — Generate and sync Tabby terminal profiles
 #
-# Creates a Tabby profile for each repo in repos.json with:
+# Creates a profile for each repo in repos.json and detected workspaces with:
 # - Unique bright tab colour (dark-mode friendly)
 # - Matching built-in colour scheme (closest hue match)
 # - Direct OpenCode launch that leaves a shell open after exit
 # - Grouped under "Projects"
 #
 # Usage:
-#   tabby-helper.sh sync          # Sync profiles from repos.json (default)
+#   tabby-helper.sh sync          # Sync profiles and detected workspaces (default)
 #   tabby-helper.sh status        # Show current profile status
 #   tabby-helper.sh zshrc         # Deprecated no-op (TABBY_AUTORUN is unused)
 #   tabby-helper.sh fix-shell     # Ensure default local profile uses /bin/zsh (macOS)
@@ -71,7 +71,7 @@ cmd_sync() {
 		return 1
 	fi
 
-	_info "Syncing Tabby profiles from repos.json..."
+	_info "Syncing Tabby profiles from repos.json and detected workspaces..."
 
 	# Back up config before modifying
 	local backup="${TABBY_CONFIG}.backup"

--- a/.agents/scripts/tabby-profile-sync.py
+++ b/.agents/scripts/tabby-profile-sync.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 """
-Sync Tabby terminal profiles from aidevops repos.json.
+Sync Tabby terminal profiles from aidevops repos.json and detected workspaces.
 
-Creates a profile for each registered repo with:
+Creates a profile for each registered repo and an optional Buzz workspace with:
 - Unique bright tab colour (dark-mode friendly)
 - Matching built-in Tabby colour scheme (closest hue)
 - Direct OpenCode launch that leaves a shell open after exit
@@ -22,6 +22,7 @@ import re
 import subprocess
 import uuid
 from pathlib import Path
+from typing import Optional
 
 from tabby_colour_utils import generate_tab_colour, find_closest_scheme
 from tabby_profile_repair import (
@@ -225,9 +226,41 @@ def get_repos(repos_json_path: str) -> list[dict]:
     return result
 
 
+def get_profile_targets(
+    repos_json_path: str, home: Optional[str] = None
+) -> list[dict]:
+    """Return registered repositories plus detected special workspaces.
+
+    Buzz-backed OpenCode sessions are scoped to ``~/.buzz``. Include that
+    workspace only when it exists, preserving the normal no-unused-profile
+    behavior for users who do not have Buzz installed.
+    """
+    targets = get_repos(repos_json_path)
+    home_path = (
+        os.path.expanduser(home) if home is not None else os.path.expanduser("~")
+    )
+    buzz_path = os.path.join(home_path, ".buzz")
+    if os.path.isdir(buzz_path) and all(
+        target["path"] != buzz_path for target in targets
+    ):
+        targets.append(
+            {
+                "path": buzz_path,
+                "name": "Buzz",
+                "repo": {"path": buzz_path, "profile_kind": "buzz-workspace"},
+            }
+        )
+    return targets
+
+
 def show_status(repos: list[dict], existing_cwds: set[str]) -> None:
-    """Print status of repos vs existing Tabby profiles."""
-    print(f"Repos in repos.json: {len(repos)}")
+    """Print status of profile targets vs existing Tabby profiles."""
+    workspace_count = sum(
+        repo["repo"].get("profile_kind") == "buzz-workspace" for repo in repos
+    )
+    print(f"Repos in repos.json: {len(repos) - workspace_count}")
+    if workspace_count:
+        print(f"Detected workspaces: {workspace_count}")
     has_profile = 0
     needs_profile = 0
     for repo in repos:
@@ -273,7 +306,7 @@ def build_new_profiles(
 
 def sync_profiles(args: argparse.Namespace) -> None:
     """Perform the profile sync: discover new repos and insert their profiles."""
-    repos = get_repos(args.repos_json)
+    repos = get_profile_targets(args.repos_json)
     config_text = load_yaml_simple(args.tabby_config)
     existing_cwds = extract_existing_cwds(config_text)
 
@@ -291,7 +324,7 @@ def sync_profiles(args: argparse.Namespace) -> None:
             save_yaml(args.tabby_config, config_text)
             print(f"Repaired {repaired_count} existing Tabby profile(s).")
         else:
-            print("All repos already have Tabby profiles. Nothing to do.")
+            print("All profile targets already have Tabby profiles. Nothing to do.")
         return
 
     new_block = "\n".join(p[1] for p in new_profiles)
@@ -306,13 +339,15 @@ def sync_profiles(args: argparse.Namespace) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Sync Tabby profiles from repos.json")
+    parser = argparse.ArgumentParser(
+        description="Sync Tabby profiles from repos.json and detected workspaces"
+    )
     parser.add_argument("--repos-json", required=True, help="Path to repos.json")
     parser.add_argument("--tabby-config", required=True, help="Path to Tabby config.yaml")
     parser.add_argument("--status-only", action="store_true", help="Show status without modifying")
     args = parser.parse_args()
 
-    repos = get_repos(args.repos_json)
+    repos = get_profile_targets(args.repos_json)
     config_text = load_yaml_simple(args.tabby_config)
     existing_cwds = extract_existing_cwds(config_text)
 

--- a/tests/test-tabby-profile-sync.py
+++ b/tests/test-tabby-profile-sync.py
@@ -262,6 +262,76 @@ class TestGetReposExcludesWorktrees(unittest.TestCase):
         self.assertNotIn(str(wt), paths)
 
 
+class TestGetProfileTargets(unittest.TestCase):
+    """Detected workspaces augment, but do not pollute, repos.json targets."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name).resolve()
+        self.repos_json = self.root / "repos.json"
+        self.repos_json.write_text('{"initialized_repos": []}')
+
+    def test_existing_buzz_workspace_is_included(self):
+        buzz_path = self.root / ".buzz"
+        buzz_path.mkdir()
+
+        targets = tabby_profile_sync.get_profile_targets(
+            str(self.repos_json), home=str(self.root)
+        )
+
+        self.assertEqual(
+            targets,
+            [
+                {
+                    "path": str(buzz_path),
+                    "name": "Buzz",
+                    "repo": {
+                        "path": str(buzz_path),
+                        "profile_kind": "buzz-workspace",
+                    },
+                }
+            ],
+        )
+
+    def test_missing_buzz_workspace_is_not_included(self):
+        targets = tabby_profile_sync.get_profile_targets(
+            str(self.repos_json), home=str(self.root)
+        )
+
+        self.assertEqual(targets, [])
+
+    def test_buzz_target_builds_opencode_profile_at_workspace(self):
+        buzz_path = self.root / ".buzz"
+        buzz_path.mkdir()
+        targets = tabby_profile_sync.get_profile_targets(
+            str(self.repos_json), home=str(self.root)
+        )
+
+        profiles = tabby_profile_sync.build_new_profiles(
+            targets, existing_cwds=set(), group_id="group-1"
+        )
+
+        self.assertEqual(len(profiles), 1)
+        profile = profiles[0][1]
+        self.assertIn("  - name: Buzz", profile)
+        self.assertIn(f"      cwd: {buzz_path}", profile)
+        self.assertIn("        - 'aidevops opencode; exec zsh'", profile)
+
+    def test_registered_buzz_path_is_not_duplicated(self):
+        buzz_path = self.root / ".buzz"
+        buzz_path.mkdir()
+        self.repos_json.write_text(
+            '{{"initialized_repos": [{{"path": "{}"}}]}}'.format(buzz_path)
+        )
+
+        targets = tabby_profile_sync.get_profile_targets(
+            str(self.repos_json), home=str(self.root)
+        )
+
+        self.assertEqual([target["path"] for target in targets], [str(buzz_path)])
+
+
 class TestRepairBrokenOpenCodeLaunchProfiles(unittest.TestCase):
     """Regression coverage for Tabby OpenCode repair edge cases."""
 


### PR DESCRIPTION
## Summary

Detect ~/.buzz during Tabby profile synchronization and generate one preserved, OpenCode-rooted Buzz workspace profile.

## Files Changed

.agents/reference/tabby-profiles.md, .agents/scripts/setup/modules/post-setup.sh, .agents/scripts/tabby-helper.sh, .agents/scripts/tabby-profile-sync.py, tests/test-tabby-profile-sync.py

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: isolated CLI execution generated exactly one Buzz profile at ~/.buzz and a second sync was idempotent; 33 Python tests, 10 shell tests, py_compile, ShellCheck, and changed-file linters pass.

Resolves #29530


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.222 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 4h 30m and 2,118,828 tokens on this with the user in an interactive session.