### PR TITLE
t18200: Narrow dependency holds and release feedback claims

### DIFF
--- a/.agents/scripts/dependency-event-reconciler.sh
+++ b/.agents/scripts/dependency-event-reconciler.sh
@@ -79,12 +79,143 @@ _der_todo_blocker_tokens_valid() {
 	return 0
 }
 
+_der_labels_have_hold() {
+	local labels="$1"
+	local expected=""
+	for expected in needs-maintainer-review hold-for-review no-auto-dispatch; do
+		_der_labels_has "$labels" "$expected" && return 0
+	done
+	return 1
+}
+
+_der_text_has_strong_hold() {
+	local text="$1"
+	printf '%s\n' "$text" |
+		grep -qiE 'HUMAN_UNBLOCK_REQUIRED|Worker Watchdog Kill|Terminal[_ -]blocker([_ -]detected)?|ACTION REQUIRED|worker[_ -]blocked' && return 0
+	if printf '%s\n' "$text" | grep -qiE '\*\*BLOCKED\*\*' &&
+		printf '%s\n' "$text" | grep -qiE 'cannot proceed'; then
+		return 0
+	fi
+	return 1
+}
+
+_der_normalize_hold_line() {
+	local line="$1"
+	local prefix=""
+	local count=0
+	local quote_re='^>[[:space:]]*'
+	local list_re='^([-+*]|[0-9]+[.)])[[:space:]]+'
+	local checkbox_re='^\[[ xX]\][[:space:]]+'
+	local heading_re='^#{1,6}[[:space:]]+'
+	local emphasis_re='^(\*\*|__|\*|_)'
+
+	while [[ "$count" -lt 8 ]]; do
+		prefix=""
+		if [[ "$line" =~ ^[[:space:]]+ ]]; then
+			prefix="${BASH_REMATCH[0]}"
+		elif [[ "$line" =~ $quote_re ]]; then
+			prefix="${BASH_REMATCH[0]}"
+		elif [[ "$line" =~ $list_re ]]; then
+			prefix="${BASH_REMATCH[0]}"
+		elif [[ "$line" =~ $checkbox_re ]]; then
+			prefix="${BASH_REMATCH[0]}"
+		elif [[ "$line" =~ $heading_re ]]; then
+			prefix="${BASH_REMATCH[0]}"
+		elif [[ "$line" =~ $emphasis_re ]]; then
+			prefix="${BASH_REMATCH[0]}"
+		else
+			break
+		fi
+		line="${line#"$prefix"}"
+		count=$((count + 1))
+	done
+	printf '%s\n' "$line"
+	return 0
+}
+
+_der_line_is_operational_hold() {
+	local line="$1"
+	local normalized=""
+	local without_pipes=""
+	local pipe_count=0
+	normalized=$(_der_normalize_hold_line "$line") || return 1
+	[[ -n "$normalized" ]] || return 1
+	without_pipes="${normalized//|/}"
+	pipe_count=$((${#normalized} - ${#without_pipes}))
+	[[ "$normalized" != \|* && "$normalized" != *\| && "$pipe_count" -lt 2 ]] || return 1
+	printf '%s\n' "$normalized" |
+		grep -qiE '^(defer[[:space:]]+until|do[-[:space:]]+not[-[:space:]]+dispatch|on[-[:space:]]+hold|hold[[:space:]]+for|paused)([[:space:]:]|$)'
+	return $?
+}
+
+_der_fence_marker() {
+	local line="$1"
+	local backtick_re='^(`{3,})'
+	local tilde_re='^(~{3,})'
+	if [[ "$line" =~ $backtick_re || "$line" =~ $tilde_re ]]; then
+		printf '%s\n' "${BASH_REMATCH[1]}"
+		return 0
+	fi
+	return 1
+}
+
+_der_fence_closes() {
+	local line="$1"
+	local opener="$2"
+	local candidate=""
+	local remainder=""
+	candidate=$(_der_fence_marker "$line") || return 1
+	[[ "${candidate:0:1}" == "${opener:0:1}" && "${#candidate}" -ge "${#opener}" ]] || return 1
+	remainder="${line#"$candidate"}"
+	[[ "$remainder" =~ ^[[:space:]]*$ ]]
+	return $?
+}
+
+_der_text_has_operational_hold() {
+	local text="$1"
+	local line=""
+	local before_comment=""
+	local comment_tail=""
+	local normalized=""
+	local in_comment=false
+	local fence_marker=""
+
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		normalized=$(_der_normalize_hold_line "$line") || return 1
+		if [[ -n "$fence_marker" ]]; then
+			_der_fence_closes "$normalized" "$fence_marker" && fence_marker=""
+			continue
+		fi
+		if [[ "$in_comment" == "true" ]]; then
+			[[ "$line" == *"-->"* ]] || continue
+			line="${line#*-->}"
+			in_comment=false
+		fi
+		while [[ "$line" == *"<!--"* ]]; do
+			before_comment="${line%%<!--*}"
+			comment_tail="${line#*<!--}"
+			if [[ "$comment_tail" == *"-->"* ]]; then
+				line="${before_comment}${comment_tail#*-->}"
+			else
+				line="$before_comment"
+				in_comment=true
+				break
+			fi
+		done
+		normalized=$(_der_normalize_hold_line "$line") || return 1
+		fence_marker=$(_der_fence_marker "$normalized" || true)
+		[[ -z "$fence_marker" ]] || continue
+		_der_line_is_operational_hold "$line" && return 0
+	done <<<"$text"
+	return 1
+}
+
 _der_has_hold() {
 	local body="$1"
 	local comments="$2"
 	local labels="$3"
-	printf '%s\n%s\n%s\n' "$body" "$comments" "$labels" |
-		grep -qiE 'defer until|do[-[:space:]]not[-[:space:]]dispatch|on[-[:space:]]hold|HUMAN_UNBLOCK_REQUIRED|hold for |paused[[:space:]:]|worker[_ -]blocked|terminal[_ -]blocker|needs-maintainer-review'
+	local text="${body}"$'\n'"${comments}"
+	_der_labels_have_hold "$labels" || _der_text_has_strong_hold "$text" || _der_text_has_operational_hold "$text"
 	return $?
 }
 

--- a/.agents/scripts/pulse-merge-feedback-finalizer.sh
+++ b/.agents/scripts/pulse-merge-feedback-finalizer.sh
@@ -82,6 +82,55 @@ _feedback_route_issue_endpoint() {
 	return 0
 }
 
+_feedback_route_release_marker() {
+	local kind="$1"
+	local pr_number="$2"
+	local expected_head="$3"
+	printf '<!-- feedback-route:dispatch-release:%s:PR%s:SHA%s -->' \
+		"$kind" "$pr_number" "$expected_head"
+	return 0
+}
+
+_feedback_route_release_exists() {
+	local linked_issue="$1"
+	local repo_slug="$2"
+	local marker="$3"
+	local endpoint="repos/${repo_slug}/issues/${linked_issue}/comments?per_page=100"
+	local comments_json=""
+	# shellcheck disable=SC2016 # $marker is a jq variable supplied below.
+	local filter='any((if type == "array" and ((.[0]? | type) == "array") then .[] else . end)[]?; (.body // "") | contains($marker))'
+
+	if declare -F _gh_with_timeout >/dev/null 2>&1; then
+		comments_json=$(_gh_with_timeout read gh api "$endpoint" --paginate --slurp 2>/dev/null) || return 1
+	else
+		comments_json=$(gh api "$endpoint" --paginate --slurp 2>/dev/null) || return 1
+	fi
+	printf '%s' "$comments_json" | jq -e --arg marker "$marker" "$filter" >/dev/null 2>&1
+	return $?
+}
+
+_feedback_route_release_dispatch_claim() {
+	local kind="$1"
+	local pr_number="$2"
+	local repo_slug="$3"
+	local linked_issue="$4"
+	local expected_head="$5"
+	local marker=""
+	local comment_body=""
+
+	marker=$(_feedback_route_release_marker "$kind" "$pr_number" "$expected_head")
+	_feedback_route_release_exists "$linked_issue" "$repo_slug" "$marker" && return 0
+	comment_body="CLAIM_RELEASED reason=feedback_route_${kind} runner=pulse ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+${marker}"
+	if declare -F gh_issue_comment >/dev/null 2>&1; then
+		gh_issue_comment "$linked_issue" --repo "$repo_slug" --body "$comment_body" >/dev/null 2>&1
+		return $?
+	fi
+	_feedback_route_gh_write issue comment "$linked_issue" --repo "$repo_slug" \
+		--body "$comment_body" >/dev/null 2>&1
+	return $?
+}
+
 _feedback_route_marker() {
 	local phase="$1"
 	local kind="$2"
@@ -365,6 +414,12 @@ _feedback_route_finish_closed() {
 			"closed ${kind} route completion evidence could not be verified after write"
 		return $?
 	fi
+	if ! _feedback_route_release_dispatch_claim "$kind" "$pr_number" "$repo_slug" \
+		"$linked_issue" "$expected_head"; then
+		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" \
+			"completed ${kind} route could not retire the prior dispatch claim"
+		return $?
+	fi
 
 	if ! _feedback_route_apply_terminal_label "$pr_number" "$repo_slug" "$expected_head" "$terminal_label"; then
 		_feedback_route_hold_for_maintainer "$pr_number" "$repo_slug" "$linked_issue" \
@@ -398,16 +453,26 @@ _feedback_route_resume_completed() {
 	fi
 	if _feedback_route_labels_include "$labels" "$terminal_label"; then
 		if _feedback_route_issue_is_ready "$linked_issue" "$repo_slug" "$source_label"; then
+			_feedback_route_release_dispatch_claim "$kind" "$pr_number" "$repo_slug" \
+				"$linked_issue" "$expected_head" || return "$PULSE_FEEDBACK_ROUTE_DEFERRED_RC"
 			return 0
 		fi
 		if ! _feedback_route_transition_and_verify "$linked_issue" "$repo_slug" "$source_label" 1; then
 			_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "completed ${kind} route could not restore redispatch issue state"
 			return $?
 		fi
+		_feedback_route_release_dispatch_claim "$kind" "$pr_number" "$repo_slug" \
+			"$linked_issue" "$expected_head" || return "$PULSE_FEEDBACK_ROUTE_DEFERRED_RC"
 		return 0
 	fi
 	if ! _feedback_route_transition_and_verify "$linked_issue" "$repo_slug" "$source_label" 1; then
 		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" "completed ${kind} route could not re-verify redispatch issue state"
+		return $?
+	fi
+	if ! _feedback_route_release_dispatch_claim "$kind" "$pr_number" "$repo_slug" \
+		"$linked_issue" "$expected_head"; then
+		_feedback_route_defer "$pr_number" "$repo_slug" "$linked_issue" \
+			"completed ${kind} route could not retire the prior dispatch claim"
 		return $?
 	fi
 	if ! _feedback_route_apply_terminal_label "$pr_number" "$repo_slug" "$expected_head" "$terminal_label"; then

--- a/.agents/scripts/tests/test-dependency-event-reconciler.sh
+++ b/.agents/scripts/tests/test-dependency-event-reconciler.sh
@@ -50,6 +50,18 @@ assert_eq() {
 	return 0
 }
 
+assert_hold() {
+	local expected="$1"
+	local body="$2"
+	local comments="$3"
+	local labels="$4"
+	local name="$5"
+	local actual=0
+	_der_has_hold "$body" "$comments" "$labels" && actual=1
+	assert_eq "$expected" "$actual" "$name"
+	return 0
+}
+
 candidate() {
 	local number="$1"
 	local state="$2"
@@ -241,6 +253,38 @@ assert_eq 0 "$(run_reconcile)" "targeted search count or pagination ambiguity fa
 EDIT_COUNT=0 REREAD_LABELS="status:blocked" SEARCH_AMBIGUOUS=false BODY20=$'Blocked by: **#10**\nOn hold for maintainer'
 assert_eq 0 "$(run_reconcile)" "markdown dependency variant is found while non-dependency hold is preserved"
 
+assert_hold 1 "On hold for maintainer" "" "status:blocked" "direct classifier preserves an explicit operational hold"
+assert_hold 1 "- **Defer until security review**" "" "status:blocked" "direct classifier preserves a prefixed defer directive"
+assert_hold 1 "### On hold for maintainer" "" "status:blocked" "direct classifier preserves an operational hold heading"
+assert_hold 1 "Do-not-dispatch: migration active" "" "status:blocked" "direct classifier preserves a do-not-dispatch directive"
+assert_hold 1 "Hold for release approval" "" "status:blocked" "direct classifier preserves a hold-for directive"
+assert_hold 1 "On hold for maintainer | release manager" "" "status:blocked" "direct classifier preserves an operational hold containing one pipe"
+assert_hold 1 "" "Worker result: **BLOCKED** and cannot proceed safely" "status:blocked" "direct classifier preserves worker escalation comments"
+assert_hold 1 "" "Worker Watchdog Kill" "status:blocked" "direct classifier preserves watchdog escalation comments"
+assert_hold 1 "" "Terminal blocker detected" "status:blocked" "direct classifier preserves terminal blocker comments"
+assert_hold 1 "" "ACTION REQUIRED" "status:blocked" "direct classifier preserves action-required comments"
+assert_hold 1 "" "HUMAN_UNBLOCK_REQUIRED" "status:blocked" "direct classifier preserves human-unblock markers"
+assert_hold 1 "The labels are mentioned descriptively." "" "status:blocked,hold-for-review" "direct classifier preserves exact hold-for-review labels"
+assert_hold 1 "" "" "status:blocked,needs-maintainer-review" "direct classifier preserves exact maintainer-review labels"
+assert_hold 1 "" "" "status:blocked,no-auto-dispatch" "direct classifier preserves exact no-auto-dispatch labels"
+assert_hold 0 "The hold-for-review label is documented here." "" "status:blocked" "direct classifier ignores management-label names in prose"
+assert_hold 0 $'| Outcome | Action |\n| unknown_review | Hold for bounded review; no implementation issue |' "" "status:blocked" "direct classifier ignores hold phrases in Markdown tables"
+assert_hold 0 $'Example:\n```text\nDo not dispatch\n```' "" "status:blocked" "direct classifier ignores hold phrases in fenced examples"
+assert_hold 0 $'Example:\n~~~text\nOn hold for demonstration\n~~~' "" "status:blocked" "direct classifier ignores hold phrases in tilde-fenced examples"
+assert_hold 1 $'Example:\n```text\n<!--\nDo not dispatch\n```\nOn hold for maintainer' "" "status:blocked" "fenced comment syntax cannot hide a later operational hold"
+assert_hold 1 $'<!--\n```text\n-->\nOn hold for maintainer' "" "status:blocked" "commented fence syntax cannot hide a later operational hold"
+assert_hold 0 $'```text\nDo not dispatch\n~~~\nOn hold in the same example\n```' "" "status:blocked" "mismatched fence delimiters cannot expose example holds"
+assert_hold 0 $'````text\nDo not dispatch\n```\nOn hold in the same example\n````' "" "status:blocked" "short fence delimiters cannot close longer examples"
+assert_hold 1 $'```text\nACTION REQUIRED in generated worker output\n```' "" "status:blocked" "strong machine markers remain authoritative inside examples"
+assert_hold 0 "This reference explains why an issue may be on hold for review." "" "status:blocked" "direct classifier ignores explanatory hold prose"
+assert_hold 0 $'<!--\nPaused: example only\n-->' "" "status:blocked" "direct classifier ignores hold phrases in HTML comments"
+
+EDIT_COUNT=0 REREAD_LABELS="status:blocked" BODY20=$'Blocked by #10\n\n| Outcome | Action |\n|---|---|\n| unknown_review | Hold for bounded review; no implementation issue |'
+assert_eq 1 "$(run_reconcile)" "classification table prose does not suppress close-event reconciliation"
+
+EDIT_COUNT=0 REREAD_LABELS="status:blocked" BODY20=$'Blocked by #10\n\nThis reference explains why an issue may be on hold for review.'
+assert_eq 1 "$(run_reconcile)" "explanatory prose does not suppress close-event reconciliation"
+
 EDIT_COUNT=0 REREAD_LABELS="status:done,status:blocked" BODY20="Blocked by #10"
 assert_eq 0 "$(run_reconcile)" "status done is preserved"
 
@@ -311,6 +355,15 @@ NATIVE_NULL_NODE=false
 EDIT_COUNT=0 REREAD_LABELS="status:blocked" BODY20="Blocked by #10" COMMENTS='[[]]'
 reconcile_stale_blocked_issues owner/repo >/dev/null 2>&1 || true
 assert_eq 1 "$EDIT_COUNT" "periodic stale sweep releases issue after missed close event"
+
+EDIT_COUNT=0 REREAD_LABELS="status:blocked" BODY20=$'Blocked by #10\n\nExample:\n```text\nDo not dispatch\n```'
+reconcile_stale_blocked_issues owner/repo >/dev/null 2>&1 || true
+assert_eq 1 "$EDIT_COUNT" "periodic stale sweep ignores fenced hold examples"
+
+EDIT_COUNT=0 REREAD_LABELS="status:blocked" BODY20=$'Blocked by #10\n\n> **Paused: awaiting maintainer**'
+reconcile_stale_blocked_issues owner/repo >/dev/null 2>&1 || true
+assert_eq 0 "$EDIT_COUNT" "periodic stale sweep preserves prefixed operational hold lines"
+
 EDIT_COUNT=0 REREAD_LABELS="status:blocked" BODY20="Blocked by #10 and #11"
 stale_sweep_status=0
 reconcile_stale_blocked_issues owner/repo >/dev/null 2>&1 || stale_sweep_status=$?

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -59,6 +59,7 @@ reset_mock_state() {
 		TEST_ADD_NMR_DURING_TRANSITION TEST_ADD_PR_PROTECTION_DURING_TRANSITION
 	rm -f "${TEST_ROOT}/pr-close-observed" "${TEST_ROOT}/pr-snapshot-failure-consumed"
 	: >"${TEST_ROOT}/issue-body.txt"
+	printf '[]\n' >"${TEST_ROOT}/issue-comments.json"
 	: >"${TEST_ROOT}/reviews.json"
 	: >"${TEST_ROOT}/comments.json"
 	printf 'OPEN\n' >"${TEST_ROOT}/pr-state.txt"
@@ -157,6 +158,19 @@ case "$_subcmd" in
 		exit 1
 	fi
 	printf 'CLOSED\n' >"${TEST_ROOT}/pr-state.txt"
+	exit 0
+	;;
+"issue comment")
+	_body=""
+	for _i in "${!_all_args[@]}"; do
+		if [[ "${_all_args[$_i]}" == "--body" ]]; then
+			_body="${_all_args[$((_i + 1))]:-}"
+			break
+		fi
+	done
+	jq --arg body "$_body" '. + [{body:$body}]' "${TEST_ROOT}/issue-comments.json" \
+		>"${TEST_ROOT}/issue-comments.json.tmp"
+	mv "${TEST_ROOT}/issue-comments.json.tmp" "${TEST_ROOT}/issue-comments.json"
 	exit 0
 	;;
 "pr reopen")
@@ -348,6 +362,10 @@ if [[ "${1:-}" == "api" ]]; then
 		else
 			printf '%s\t%s\n' "$(<"${TEST_ROOT}/issue-labels.txt")" "$(<"${TEST_ROOT}/issue-assignees.txt")"
 		fi
+		exit 0
+	fi
+	if [[ "${2:-}" == "repos/owner/repo/issues/42/comments?per_page=100" ]]; then
+		printf '[%s]\n' "$(<"${TEST_ROOT}/issue-comments.json")"
 		exit 0
 	fi
 fi
@@ -1257,8 +1275,11 @@ test_ci_dispatch_dedupes_by_pr_head_marker() {
 	local body_edit_count pr_close_count
 	body_edit_count=$(grep -cE 'gh issue edit 42 --repo owner/repo --body' "$GH_LOG" 2>/dev/null || true)
 	pr_close_count=$(grep -cF 'gh pr close 100' "$GH_LOG" 2>/dev/null || true)
+	local claim_release_count
+	claim_release_count=$(grep -cF 'CLAIM_RELEASED reason=feedback_route_ci' "$GH_LOG" 2>/dev/null || true)
 	[[ "$body_edit_count" =~ ^[0-9]+$ ]] || body_edit_count=0
 	[[ "$pr_close_count" =~ ^[0-9]+$ ]] || pr_close_count=0
+	[[ "$claim_release_count" =~ ^[0-9]+$ ]] || claim_release_count=0
 
 	if [[ "$body_edit_count" -ne 2 ]]; then
 		print_result "CI repair dispatch writes start and completion evidence once per PR/head" 1 \
@@ -1268,6 +1289,11 @@ test_ci_dispatch_dedupes_by_pr_head_marker() {
 	if [[ "$pr_close_count" -ne 1 ]]; then
 		print_result "CI repair dispatch closes PR exactly once per PR/head" 1 \
 			"Expected 1 PR close, got ${pr_close_count}. Log: $(cat "$GH_LOG")"
+		return 0
+	fi
+	if [[ "$claim_release_count" -ne 1 ]]; then
+		print_result "CI repair fallback retires the prior dispatch claim exactly once" 1 \
+			"Expected 1 CLAIM_RELEASED comment, got ${claim_release_count}. Log: $(cat "$GH_LOG")"
 		return 0
 	fi
 	if ! grep -qF '<!-- ci-feedback-fallback:PR100:SHAabc123repairsha -->' "${TEST_ROOT}/issue-body.txt"; then


### PR DESCRIPTION
## Summary

Narrow natural-language dependency hold detection to explicit operational Markdown while preserving exact labels and strong machine markers; retire prior dispatch claims idempotently after CI or conflict feedback routing so continuation work can resume without the stale-comment TTL delay.

## Files Changed

.agents/scripts/dependency-event-reconciler.sh, .agents/scripts/pulse-merge-feedback-finalizer.sh, .agents/scripts/tests/test-dependency-event-reconciler.sh, .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 69 dependency reconciler tests and 30 feedback-routing tests passed; pulse stale-blocked wiring test passed; focused ShellCheck passed; changed-file lint passed with only pre-existing advisory shfmt differences; Qlty local base/head comparison improved by 2 smells.

Resolves #29520


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.223 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 20m and 377,291 tokens on this with the user in an interactive session.