### PR TITLE
GH#29534: fix: preserve squash change categories

### DIFF
--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -834,24 +834,57 @@ _merge_review_state_still_clear() {
 	return 0
 }
 
+# Resolve one authoritative Conventional Commit type from the reviewed PR's
+# commit metadata. Every commit must be conventional and use the same type;
+# mixed, WIP, or otherwise ambiguous histories deliberately produce no type.
+_merge_resolve_conventional_type_from_commits() {
+	local pr_json="$1"
+	printf '%s\n' "$pr_json" | jq -r '
+		[.commits[]?.messageHeadline // empty] as $headlines
+		| [$headlines[]
+			| try capture("^(?<type>feat|fix|docs|refactor|perf|test|chore|style|build|ci|security)(\\([^()[:cntrl:]]+\\))?!?:[[:space:]]+[^[:space:]]").type catch empty
+		] as $types
+		| ($types | unique) as $unique
+		| if ($headlines | length) > 0
+			and ($types | length) == ($headlines | length)
+			and ($unique | length) == 1
+		then $unique[0]
+		else empty
+		end
+	'
+	return 0
+}
+
 # Resolve the reviewed PR title used as the explicit squash-commit subject.
 # Accepted forms match this repository's PR/commit history: a task-prefixed
 # title (tNNN:/GH#NNN:) or a Conventional Commit type with optional scope and
-# breaking marker. Invalid titles fail before any merge mutation.
+# breaking marker. A task-prefixed prose title inherits a category only when
+# every reviewed PR commit carries the same authoritative conventional type.
+# Invalid titles fail before any merge mutation.
 _merge_resolve_squash_subject() {
 	local pr_number="$1"
 	local repo="$2"
+	local pr_json=""
 	local subject=""
 	local task_body=""
-	local conventional_ere='^(feat|fix|docs|refactor|perf|test|chore|style|build|ci)(\([^()[:cntrl:]]+\))?!?:[[:space:]]+[^[:space:]].*$'
+	local conventional_type=""
+	local conventional_ere='^(feat|fix|docs|refactor|perf|test|chore|style|build|ci|security)(\([^()[:cntrl:]]+\))?!?:[[:space:]]+[^[:space:]].*$'
 	local task_ere='^(t[0-9]+|GH#[0-9]+):[[:space:]]+[^[:space:]].*$'
 
-	subject=$(gh pr view "$pr_number" --repo "$repo" --json title --jq '.title' 2>/dev/null) || {
-		print_error "Could not retrieve PR #${pr_number} title for squash-subject validation"
+	pr_json=$(gh pr view "$pr_number" --repo "$repo" --json title,commits 2>/dev/null) || {
+		print_error "Could not retrieve PR #${pr_number} title and commit metadata for squash-subject validation"
 		return 1
 	}
+	subject=$(printf '%s\n' "$pr_json" | jq -r '.title // empty') || return 1
 	if [[ "$subject" =~ $task_ere ]]; then
 		task_body="${subject#*: }"
+		if [[ ! "$task_body" =~ $conventional_ere ]]; then
+			conventional_type=$(_merge_resolve_conventional_type_from_commits "$pr_json")
+			if [[ -n "$conventional_type" ]]; then
+				subject="${subject%%:*}: ${conventional_type}: ${task_body}"
+				task_body="${conventional_type}: ${task_body}"
+			fi
+		fi
 	fi
 	if [[ "$subject" == *$'\n'* || "$subject" == *$'\r'* ||
 		"$task_body" =~ ^[Ww][Ii][Pp][[:space:]:\(] ||

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -154,12 +154,21 @@ write_gh_stub_pr_issue_views() {
 	cat >>"${TEST_ROOT}/bin/gh" <<GHSTUB
 
 	if [[ "\$_gh_cmd" == "pr" && "\$_gh_sub" == "view" ]]; then
-	if [[ "\$*" == *"--json title --jq .title"* ]]; then
-		if [[ "$mode" == "invalid-squash-title" ]]; then
-			echo 'Document recovery'
-		else
-			echo 'GH#28721: fix: preserve reviewed squash subject'
-		fi
+	if [[ "\$*" == *"--json title,commits"* ]]; then
+		case "$mode" in
+		invalid-squash-title)
+			echo '{"title":"Document recovery","commits":[{"messageHeadline":"fix: document recovery"}]}'
+			;;
+		gh-prefix-feature)
+			echo '{"title":"GH#29530: Add a Buzz-scoped OpenCode Tabby workspace profile","commits":[{"messageHeadline":"feat: add Buzz Tabby workspace profile"}]}'
+			;;
+		gh-prefix-no-evidence)
+			echo '{"title":"GH#29530: Add a Buzz-scoped OpenCode Tabby workspace profile","commits":[{"messageHeadline":"wip: add Buzz Tabby workspace profile"}]}'
+			;;
+		*)
+			echo '{"title":"GH#28721: fix: preserve reviewed squash subject","commits":[{"messageHeadline":"wip: document recovery"}]}'
+			;;
+		esac
 		exit 0
 	fi
 	if [[ "\$*" == *"--json state,isDraft,reviewDecision,headRefOid"* ]]; then
@@ -945,6 +954,35 @@ test_wip_draft_takeover_uses_reviewed_pr_title() {
 	return 0
 }
 
+test_gh_prefixed_feature_inherits_commit_category() {
+	rm -f "${TEST_ROOT}/logs/"*.txt
+	# PR #29531 had a required GH# prefix in its reviewed title while its sole
+	# reviewed commit retained the authoritative conventional feature type.
+	create_gh_stub "gh-prefix-feature"
+
+	local rc=0
+	run_merge_execute "42" "testorg/testrepo" "--squash" "1" "0" >/dev/null 2>&1 || rc=$?
+	local expected_subject='--subject GH#29530: feat: Add a Buzz-scoped OpenCode Tabby workspace profile'
+	local subject_present=0
+	grep -q -- "$expected_subject" "${TEST_ROOT}/logs/gh-calls.txt" && subject_present=1
+	print_result "squash subject: GH-prefixed feature retains conventional category" "$((rc == 0 && subject_present == 1 ? 0 : 1))"
+	return 0
+}
+
+test_gh_prefixed_prose_without_evidence_is_not_guessed() {
+	rm -f "${TEST_ROOT}/logs/"*.txt
+	create_gh_stub "gh-prefix-no-evidence"
+
+	local rc=0
+	run_merge_execute "42" "testorg/testrepo" "--squash" "1" "0" >/dev/null 2>&1 || rc=$?
+	local bare_subject='--subject GH#29530: Add a Buzz-scoped OpenCode Tabby workspace profile'
+	local bare_present=0 guessed_present=0
+	grep -q -- "$bare_subject" "${TEST_ROOT}/logs/gh-calls.txt" && bare_present=1
+	grep -q -- '--subject GH#29530: feat:' "${TEST_ROOT}/logs/gh-calls.txt" && guessed_present=1
+	print_result "squash subject: bare GH prose is not guessed without conventional evidence" "$((rc == 0 && bare_present == 1 && guessed_present == 0 ? 0 : 1))"
+	return 0
+}
+
 test_invalid_squash_title_blocks_before_merge() {
 	rm -f "${TEST_ROOT}/logs/"*.txt
 	create_gh_stub "invalid-squash-title"
@@ -1025,11 +1063,11 @@ create_planning_handoff_fixture() {
 write_handoff_gh_stub() {
 	cat >"${TEST_ROOT}/bin/gh" <<'GHSTUB'
 #!/usr/bin/env bash
+if [[ "$1" == "api" && "$2" == "graphql" ]]; then
+	printf '{"data":{"repository":{"pullRequest":{"state":"OPEN","isDraft":false,"reviewDecision":"","headRefOid":"%s","headRefName":"main"}},"rateLimit":{"cost":1}}}\n' "${HANDOFF_EXPECTED_HEAD:?}"
+	exit 0
+fi
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
-	if [[ "$*" == *"--json state,isDraft,reviewDecision,headRefOid,headRefName"* ]]; then
-		printf '{"state":"OPEN","isDraft":false,"reviewDecision":"","headRefOid":"%s","headRefName":"main"}\n' "${HANDOFF_EXPECTED_HEAD:?}"
-		exit 0
-	fi
 	if [[ "$*" == *"--json headRefOid"* ]]; then
 		printf '%s\n' "${HANDOFF_EXPECTED_HEAD:?}"
 		exit 0
@@ -1405,6 +1443,8 @@ main() {
 	test_post_merge_unmerged_evidence_fails_closed
 	test_post_merge_api_indeterminate_fails_closed
 	test_wip_draft_takeover_uses_reviewed_pr_title
+	test_gh_prefixed_feature_inherits_commit_category
+	test_gh_prefixed_prose_without_evidence_is_not_guessed
 	test_invalid_squash_title_blocks_before_merge
 	test_non_squash_skips_subject_override
 	test_checkout_free_publication_readiness_handoff

--- a/.agents/scripts/tests/test-version-manager-changelog-id-prefix.sh
+++ b/.agents/scripts/tests/test-version-manager-changelog-id-prefix.sh
@@ -42,6 +42,27 @@ assert_classification 'GitHub issue prefix' \
 assert_classification 'plain conventional subject' \
 	'feat: retain ordinary conventional output' \
 	$'added\t- retain ordinary conventional output'
+assert_classification 'GH-prefixed feature squash from PR 29531' \
+	'GH#29530: feat: Add a Buzz-scoped OpenCode Tabby workspace profile' \
+	$'added\t- Add a Buzz-scoped OpenCode Tabby workspace profile'
+assert_classification 'ordinary fix subject' \
+	'fix: retain ordinary fix output' \
+	$'fixed\t- retain ordinary fix output'
+assert_classification 'ordinary docs subject' \
+	'docs: retain ordinary docs output' \
+	$'changed\t- Documentation: retain ordinary docs output'
+assert_classification 'ordinary refactor subject' \
+	'refactor: retain ordinary refactor output' \
+	$'changed\t- Refactor: retain ordinary refactor output'
+assert_classification 'ordinary security subject' \
+	'security: retain ordinary security output' \
+	$'security\t- retain ordinary security output'
+assert_classification 'ordinary chore subject' \
+	'chore: retain ordinary chore output' \
+	$'changed\t- Maintenance: retain ordinary chore output'
+assert_classification 'bare GH-prefixed prose remains unclassified' \
+	'GH#29530: Add a Buzz-scoped OpenCode Tabby workspace profile' \
+	''
 assert_classification 'embedded ID-like text remains unclassified' \
 	'at18079] feat: do not normalize embedded text' \
 	''


### PR DESCRIPTION
## Summary

Preserve authoritative Conventional Commit category metadata when managed GH-prefixed PR titles become squash subjects.

## Files Changed

`.agents/scripts/full-loop-helper-merge.sh` and focused merge/changelog regression tests.

## Verification

- `bash .agents/scripts/tests/test-version-manager-changelog-id-prefix.sh`
- `bash .agents/scripts/tests/test-full-loop-merge.sh` (76/76)
- ShellCheck on all changed shell files
- `.agents/scripts/linters-local.sh --changed`

Resolves #29534


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.223 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 9m and 123,983 tokens on this as a headless worker. Overall, 20m since this issue was created.
