### PR TITLE
GH#29535: fix: route interactive worker draft checkpoints

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -1399,7 +1399,7 @@ cmd_verify_pr_repair_target() {
 # continuation. Unlike ordinary PR repair, this requires draft mode, exact
 # closing linkage, worker ownership labels, and a still-runnable linked issue.
 # Args: PR number, repo slug, expected head SHA, expected head ref, linked issue,
-#       expected issue assignee
+#       expected issue assignee, original checkpoint author (optional)
 # Returns: 0=valid, 1=eligibility changed, 2=invalid/unavailable metadata
 #######################################
 cmd_verify_pr_checkpoint_target() {
@@ -1409,18 +1409,21 @@ cmd_verify_pr_checkpoint_target() {
 	local expected_head_ref="${4:-}"
 	local linked_issue="${5:-}"
 	local expected_assignee="${6:-}"
+	local checkpoint_author="${7:-$expected_assignee}"
 	local pr_json=""
 	local issue_json=""
+	local checkpoint_comments="[]"
 
 	if [[ ! "$pr_number" =~ ^[1-9][0-9]*$ || -z "$repo_slug" ||
 		! "$expected_head_sha" =~ ^[0-9a-fA-F]{40,64}$ || -z "$expected_head_ref" ||
-		! "$linked_issue" =~ ^[1-9][0-9]*$ || -z "$expected_assignee" ]]; then
+		! "$linked_issue" =~ ^[1-9][0-9]*$ || -z "$expected_assignee" ||
+		! "$checkpoint_author" =~ ^[A-Za-z0-9._-]+(\[bot\])?$ ]]; then
 		printf 'PR_CHECKPOINT_TARGET_UNKNOWN: pr=#%s repo=%s issue=#%s reason=incomplete_contract\n' \
 			"${pr_number:-missing}" "${repo_slug:-missing}" "${linked_issue:-missing}"
 		return 2
 	fi
 	pr_json=$(gh pr view "$pr_number" --repo "$repo_slug" \
-		--json number,state,isDraft,isCrossRepository,labels,headRefName,headRefOid,closingIssuesReferences 2>/dev/null) || {
+		--json number,state,isDraft,isCrossRepository,labels,headRefName,headRefOid,author,closingIssuesReferences 2>/dev/null) || {
 		printf 'PR_CHECKPOINT_TARGET_UNKNOWN: pr=#%s repo=%s issue=#%s reason=pr_metadata_unavailable\n' \
 			"$pr_number" "$repo_slug" "$linked_issue"
 		return 2
@@ -1436,9 +1439,21 @@ cmd_verify_pr_checkpoint_target() {
 			"$pr_number" "$repo_slug" "$linked_issue"
 		return 2
 	fi
+	if printf '%s' "$issue_json" | jq -e '
+		[.labels[]? | if type == "string" then . else (.name // empty) end]
+		| index("origin:interactive") != null
+	' >/dev/null 2>&1; then
+		checkpoint_comments=$(gh api "repos/${repo_slug}/issues/${linked_issue}/comments?per_page=100" \
+			--paginate --slurp 2>/dev/null) || {
+			printf 'PR_CHECKPOINT_TARGET_UNKNOWN: pr=#%s repo=%s issue=#%s reason=checkpoint_evidence_unavailable\n' \
+				"$pr_number" "$repo_slug" "$linked_issue"
+			return 2
+		}
+	fi
 	if _pr_checkpoint_pr_metadata_is_eligible "$pr_json" "$repo_slug" "$pr_number" "$linked_issue" \
-		"$expected_head_sha" "$expected_head_ref" &&
-		_pr_checkpoint_issue_metadata_is_eligible "$issue_json" "$linked_issue" "$expected_assignee"; then
+		"$expected_head_sha" "$expected_head_ref" "$checkpoint_author" &&
+		_pr_checkpoint_issue_metadata_is_eligible "$issue_json" "$linked_issue" \
+			"$expected_assignee" "$checkpoint_comments" "$checkpoint_author"; then
 		printf 'PR_CHECKPOINT_TARGET_VALID: pr=#%s repo=%s issue=#%s assignee=%s head_sha=%s head_ref=%s\n' \
 			"$pr_number" "$repo_slug" "$linked_issue" "$expected_assignee" "$expected_head_sha" "$expected_head_ref"
 		return 0
@@ -1632,7 +1647,7 @@ Usage:
     Exit 1 = PR closed/merged or head changed
     Exit 2 = contract or metadata unavailable/invalid (fail closed)
 
-  dispatch-claim-helper.sh verify-pr-checkpoint-target <pr-number> <repo-slug> <head-sha> <head-ref> <linked-issue> <expected-assignee>
+  dispatch-claim-helper.sh verify-pr-checkpoint-target <pr-number> <repo-slug> <head-sha> <head-ref> <linked-issue> <expected-assignee> [checkpoint-author]
     Verify a stale draft continuation still has its complete authorization envelope.
     Exit 0 = exact worker draft and runnable linked issue remain eligible
     Exit 1 = draft, linkage, labels, issue state, assignment, or head changed

--- a/.agents/scripts/pr-checkpoint-continuation-helper.sh
+++ b/.agents/scripts/pr-checkpoint-continuation-helper.sh
@@ -24,6 +24,7 @@ PCC_HEAD_OID=""
 PCC_ISSUE_ASSIGNEE=""
 PCC_EXPECTED_ASSIGNEE=""
 PCC_AUTHENTICATED_LOGIN=""
+PCC_CHECKPOINT_ASSIGNEE=""
 PCC_ORIGINAL_STATUS=""
 PCC_OWNERSHIP_TRANSFERRED=0
 
@@ -65,7 +66,8 @@ _prrts_prelaunch_target_fence() {
 	local expected_assignee="${PCC_EXPECTED_ASSIGNEE:-$PCC_ISSUE_ASSIGNEE}"
 	local authenticated_login="${PCC_AUTHENTICATED_LOGIN:-$PCC_ISSUE_ASSIGNEE}"
 
-	target_row=$(_pcc_target_row "$repo_slug" "$pr_number" "$PCC_LINKED_ISSUE" "$expected_assignee") || {
+	target_row=$(_pcc_target_row "$repo_slug" "$pr_number" "$PCC_LINKED_ISSUE" \
+		"$expected_assignee" "$PCC_CHECKPOINT_ASSIGNEE") || {
 		PRRTS_WORKTREE_FAILURE_REASON="pr_checkpoint_eligibility_changed_before_launch"
 		return 1
 	}
@@ -87,7 +89,7 @@ _prrts_prelaunch_target_fence() {
 		}
 		PCC_OWNERSHIP_TRANSFERRED=1
 		target_row=$(_pcc_target_row "$repo_slug" "$pr_number" "$PCC_LINKED_ISSUE" \
-			"$authenticated_login") || {
+			"$authenticated_login" "$PCC_CHECKPOINT_ASSIGNEE") || {
 			_pcc_restore_transferred_ownership "$repo_slug" "$pr_number" || true
 			PRRTS_WORKTREE_FAILURE_REASON="pr_checkpoint_post_transfer_eligibility_changed"
 			return 1
@@ -184,7 +186,7 @@ PR title: ${safe_title}
 3. Run focused lint/tests for every changed area. Hand-apply fixes; never apply
    AI-review suggestions verbatim or weaken required checks.
 4. Before pushing, run the exact-target fence:
-   \`"${ownership_helper}" verify-pr-checkpoint-target "${repair_number_ref}" "${repo_slug_ref}" "\$AIDEVOPS_PR_REPAIR_HEAD_SHA" "\$AIDEVOPS_PR_REPAIR_HEAD_REF" "${linked_issue_ref}" "${issue_assignee_ref}"\`.
+   \`"${ownership_helper}" verify-pr-checkpoint-target "${repair_number_ref}" "${repo_slug_ref}" "\$AIDEVOPS_PR_REPAIR_HEAD_SHA" "\$AIDEVOPS_PR_REPAIR_HEAD_REF" "${linked_issue_ref}" "${issue_assignee_ref}" "${PCC_CHECKPOINT_ASSIGNEE}"\`.
    Stop without pushing if it no longer reports PR_CHECKPOINT_TARGET_VALID.
 5. Commit the continuation and push without force to the existing remote branch
    using \`git push origin "HEAD:\$AIDEVOPS_PR_REPAIR_HEAD_REF"\`. Never open a
@@ -204,11 +206,32 @@ PROMPT_EOF
 	return 0
 }
 
+_pcc_issue_metadata_is_eligible() {
+	local repo_slug="$1"
+	local issue_json="$2"
+	local linked_issue="$3"
+	local expected_assignee="$4"
+	local checkpoint_assignee="$5"
+	local comments_json="[]"
+
+	if printf '%s' "$issue_json" | jq -e '
+		[.labels[]?.name]
+		| index("origin:interactive") != null
+	' >/dev/null 2>&1; then
+		comments_json=$(gh api "repos/${repo_slug}/issues/${linked_issue}/comments?per_page=100" \
+			--paginate --slurp 2>/dev/null) || return 1
+	fi
+	_pr_checkpoint_issue_metadata_is_eligible "$issue_json" "$linked_issue" \
+		"$expected_assignee" "$comments_json" "$checkpoint_assignee"
+	return $?
+}
+
 _pcc_target_row() {
 	local repo_slug="$1"
 	local pr_number="$2"
 	local linked_issue="$3"
 	local expected_assignee="${4:-}"
+	local checkpoint_assignee="${5:-$expected_assignee}"
 	local pr_json=""
 	local issue_json=""
 	local target_row=""
@@ -217,8 +240,10 @@ _pcc_target_row() {
 	pr_json=$(gh pr view "$pr_number" --repo "$repo_slug" \
 		--json number,state,title,isDraft,isCrossRepository,labels,headRefName,headRefOid,author,closingIssuesReferences 2>/dev/null) || return 1
 	issue_json=$(gh api "repos/${repo_slug}/issues/${linked_issue}" 2>/dev/null) || return 1
-	_pr_checkpoint_pr_metadata_is_eligible "$pr_json" "$repo_slug" "$pr_number" "$linked_issue" || return 1
-	_pr_checkpoint_issue_metadata_is_eligible "$issue_json" "$linked_issue" "$expected_assignee" || return 1
+	_pr_checkpoint_pr_metadata_is_eligible "$pr_json" "$repo_slug" "$pr_number" \
+		"$linked_issue" "" "" "$checkpoint_assignee" || return 1
+	_pcc_issue_metadata_is_eligible "$repo_slug" "$issue_json" "$linked_issue" \
+		"$expected_assignee" "$checkpoint_assignee" || return 1
 	issue_assignee=$(printf '%s' "$issue_json" | jq -er \
 		'.assignees[0].login | select(type == "string" and length > 0)' 2>/dev/null) || return 1
 	issue_status=$(printf '%s' "$issue_json" | jq -er '
@@ -262,8 +287,8 @@ _pcc_restore_issue_ownership() {
 	local previous_status="$5"
 	local issue_json=""
 	issue_json=$(gh api "repos/${repo_slug}/issues/${linked_issue}" 2>/dev/null) || return 1
-	_pr_checkpoint_issue_metadata_is_eligible "$issue_json" "$linked_issue" \
-		"$replacement_assignee" || return 1
+	_pcc_issue_metadata_is_eligible "$repo_slug" "$issue_json" "$linked_issue" \
+		"$replacement_assignee" "$PCC_CHECKPOINT_ASSIGNEE" || return 1
 	set_issue_status "$linked_issue" "$repo_slug" "$previous_status" \
 		--add-assignee "$previous_assignee" \
 		--remove-assignee "$replacement_assignee" >/dev/null 2>&1 || return 1
@@ -297,6 +322,7 @@ _pcc_dispatch() {
 	local issue_status=""
 	local now_epoch=""
 	local fingerprint=""
+	local dispatch_rc=0
 
 	if [[ -z "$repo_slug" || ! "$pr_number" =~ ^[0-9]+$ || ! "$linked_issue" =~ ^[0-9]+$ ||
 		-z "$expected_assignee" || -z "$authenticated_login" || ! -d "$repo_path" ]] ||
@@ -305,25 +331,40 @@ _pcc_dispatch() {
 		_pcc_usage >&2
 		return 2
 	fi
-	target_row=$(_pcc_target_row "$repo_slug" "$pr_number" "$linked_issue" "$expected_assignee") || {
+	PCC_EXPECTED_ASSIGNEE="$expected_assignee"
+	PCC_AUTHENTICATED_LOGIN="$authenticated_login"
+	PCC_CHECKPOINT_ASSIGNEE="$expected_assignee"
+	target_row=$(_pcc_target_row "$repo_slug" "$pr_number" "$linked_issue" \
+		"$expected_assignee" "$PCC_CHECKPOINT_ASSIGNEE") || {
 		printf 'PR_CHECKPOINT_CONTINUATION_BLOCKED: PR #%s in %s is not an open, unheld worker draft linked to issue #%s with an exact head\n' \
 			"$pr_number" "$repo_slug" "$linked_issue"
 		return 1
 	}
 	IFS=$'\t' read -r title PCC_HEAD_REF PCC_HEAD_OID author issue_status PCC_ISSUE_ASSIGNEE <<<"$target_row"
 	PCC_LINKED_ISSUE="$linked_issue"
-	PCC_EXPECTED_ASSIGNEE="$expected_assignee"
-	PCC_AUTHENTICATED_LOGIN="$authenticated_login"
 	PCC_ORIGINAL_STATUS="$issue_status"
 	PCC_OWNERSHIP_TRANSFERRED=0
 	[[ -n "$PCC_HEAD_REF" && "$PCC_HEAD_OID" =~ ^[0-9a-fA-F]{40,64}$ &&
 		"$PCC_ISSUE_ASSIGNEE" == "$expected_assignee" ]] || return 1
 	now_epoch=$(date +%s)
 	fingerprint="draft-checkpoint:${PCC_HEAD_OID}:contract-3"
-	if ! _prrts_dispatch_guarded "$repo_slug" "$repo_path" "$pr_number" "$title" "0" \
+	_prrts_dispatch_guarded "$repo_slug" "$repo_path" "$pr_number" "$title" "0" \
 		"$fingerprint" "stale worker draft continuation" "$now_epoch" "$PRRTS_BOOL_FALSE" \
-		"continue-pr" "$PCC_HEAD_REF" "$PCC_HEAD_OID" "$author"; then
+		"continue-pr" "$PCC_HEAD_REF" "$PCC_HEAD_OID" "$author" || dispatch_rc=$?
+	if [[ "$dispatch_rc" -eq "$PRRTS_RC_DISPATCH_DEFERRED" ]]; then
+		printf 'PR_CHECKPOINT_CONTINUATION_DEDUPLICATED: PR #%s in %s already has a bounded exact-head continuation\n' \
+			"$pr_number" "$repo_slug"
+		return 0
+	fi
+	if [[ "$dispatch_rc" -eq "$PRRTS_RC_MAINTAINER_ATTENTION" ]]; then
+		printf 'PR_CHECKPOINT_CONTINUATION_EXHAUSTED: PR #%s in %s reached durable bounded-retry state\n' \
+			"$pr_number" "$repo_slug"
+		return 1
+	fi
+	if [[ "$dispatch_rc" -ne 0 ]]; then
 		_pcc_restore_transferred_ownership "$repo_slug" "$pr_number" || true
+		printf 'PR_CHECKPOINT_CONTINUATION_BLOCKED: PR #%s in %s launch failed rc=%s\n' \
+			"$pr_number" "$repo_slug" "$dispatch_rc"
 		return 1
 	fi
 	printf 'PR_CHECKPOINT_CONTINUATION_DISPATCHED: PR #%s in %s at %s for issue #%s\n' \

--- a/.agents/scripts/pr-checkpoint-target-lib.sh
+++ b/.agents/scripts/pr-checkpoint-target-lib.sh
@@ -13,7 +13,8 @@ source "${_PCTL_SCRIPT_DIR}/pr-closing-link-lib.sh"
 unset _PCTL_SCRIPT_DIR
 
 # Args: $1=PR JSON, $2=repo slug, $3=PR number, $4=linked issue,
-#       $5=expected SHA (optional), $6=expected ref (optional)
+#       $5=expected SHA (optional), $6=expected ref (optional),
+#       $7=expected checkpoint author (optional)
 _pr_checkpoint_pr_metadata_is_eligible() {
 	local pr_json="$1"
 	local repo_slug="$2"
@@ -21,12 +22,14 @@ _pr_checkpoint_pr_metadata_is_eligible() {
 	local linked_issue="$4"
 	local expected_head_sha="${5:-}"
 	local expected_head_ref="${6:-}"
+	local expected_author="${7:-}"
 
 	[[ "$pr_number" =~ ^[1-9][0-9]*$ && "$linked_issue" =~ ^[1-9][0-9]*$ ]] || return 1
 	_pr_closing_link_matches_issue "$pr_json" "$repo_slug" "$linked_issue" || return 1
 
 	printf '%s' "$pr_json" | jq -e --argjson pr "$pr_number" \
-		--arg expected_head_sha "$expected_head_sha" --arg expected_head_ref "$expected_head_ref" '
+		--arg expected_head_sha "$expected_head_sha" --arg expected_head_ref "$expected_head_ref" \
+		--arg expected_author "$expected_author" '
 		def names: [.labels[]? | if type == "string" then . else (.name // empty) end];
 		def worker_owned: names | any(. == "origin:worker" or . == "origin:worker-takeover");
 		def protected: names | any(
@@ -37,6 +40,7 @@ _pr_checkpoint_pr_metadata_is_eligible() {
 		(.number == $pr) and (((.state // "") | ascii_upcase) == "OPEN") and
 		(.isDraft == true) and (.isCrossRepository == false) and
 		worker_owned and (protected | not) and
+		(($expected_author | length) == 0 or (.author.login // "") == $expected_author) and
 		(((.headRefName // "") | length) > 0) and (((.headRefOid // "") | length) > 0) and
 		(($expected_head_sha | length) == 0 or .headRefOid == $expected_head_sha) and
 		(($expected_head_ref | length) == 0 or .headRefName == $expected_head_ref)
@@ -44,15 +48,55 @@ _pr_checkpoint_pr_metadata_is_eligible() {
 	return 0
 }
 
-# Args: $1=REST issue JSON, $2=linked issue number, $3=expected assignee (optional)
+#######################################
+# Verify that the newest trusted coordination event is the worker's explicit
+# draft-checkpoint release. This prevents old checkpoint markers from
+# overriding a later human claim or worker dispatch.
+# Args: $1=raw paginated comments JSON, $2=checkpoint runner
+# Returns: 0 when exact trusted evidence is current, 1 otherwise
+#######################################
+_pr_checkpoint_comments_have_verified_release() {
+	local comments_json="$1"
+	local checkpoint_runner="$2"
+	local marker="CLAIM_RELEASED reason=worker_draft_checkpoint runner=${checkpoint_runner} "
+	[[ "$checkpoint_runner" =~ ^[A-Za-z0-9._-]+(\[bot\])?$ ]] || return 1
+
+	printf '%s' "$comments_json" | jq -e --arg marker "$marker" --arg array_type "array" '
+		def trusted_association:
+			. == "OWNER" or . == "MEMBER" or . == "COLLABORATOR";
+		def comments:
+			if type == $array_type and ((.[0]? | type) == $array_type) then [.[][]?]
+			elif type == $array_type then .
+			else [] end;
+		[comments[]?
+			| select((.author_association // "") | trusted_association)
+			| select((.body // "") | test("(^|\\n)(CLAIM_RELEASED reason=|DISPATCH_CLAIM |Dispatching worker|Interactive session claimed)"))
+			| {body: (.body // ""), created_at: (.created_at // ""), id: ((.id // 0) | tonumber? // 0)}]
+		| sort_by(.created_at, .id)
+		| last
+		| (.body // "")
+		| contains($marker)
+	' >/dev/null 2>&1 || return 1
+	return 0
+}
+
+# Args: $1=REST issue JSON, $2=linked issue number, $3=expected assignee (optional),
+#       $4=raw trusted-comments source JSON (optional), $5=checkpoint runner (optional)
 _pr_checkpoint_issue_metadata_is_eligible() {
 	local issue_json="$1"
 	local linked_issue="$2"
 	local expected_assignee="${3:-}"
+	local comments_json="${4:-[]}"
+	local checkpoint_runner="${5:-$expected_assignee}"
+	local interactive_checkpoint="false"
 
 	[[ "$linked_issue" =~ ^[1-9][0-9]*$ ]] || return 1
+	if _pr_checkpoint_comments_have_verified_release "$comments_json" "$checkpoint_runner"; then
+		interactive_checkpoint="true"
+	fi
 	printf '%s' "$issue_json" | jq -e --argjson issue "$linked_issue" \
-		--arg expected_assignee "$expected_assignee" '
+		--arg expected_assignee "$expected_assignee" \
+		--arg interactive_checkpoint "$interactive_checkpoint" '
 		def names: [.labels[]? | if type == "string" then . else (.name // empty) end];
 		def lifecycle_statuses: [names[] | select(startswith("status:"))];
 		def runnable_status:
@@ -64,7 +108,8 @@ _pr_checkpoint_issue_metadata_is_eligible() {
 		def protected: names | any(
 			. == "needs-maintainer-review" or . == "needs-maintainer-permissions" or
 			. == "no-auto-dispatch" or . == "hold-for-review" or . == "persistent" or
-			. == "origin:interactive" or . == "parent-task" or . == "research" or
+			(. == "origin:interactive" and $interactive_checkpoint != "true") or
+			. == "parent-task" or . == "research" or
 			. == "research-task" or . == "blocked" or . == "on hold"
 		);
 		(.number == $issue) and (((.state // "") | ascii_downcase) == "open") and

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1272,13 +1272,12 @@ _dispatch_dedup_check_layers() {
 	target_state=$(printf '%s' "$issue_meta_json" | jq -r '.state // ""' 2>/dev/null | tr '[:lower:]' '[:upper:]')
 	target_title=$(printf '%s' "$issue_meta_json" | jq -r '.title // ""' 2>/dev/null)
 
-	# GH#22948/GH#22964: interactive/review hold guard independent of assignee
-	# identity. auto-dispatch is an explicit worker handoff, so active claim
-	# liveness/staleness is delegated to Layer 6 instead of blocked here.
+	# GH#22948/GH#22964/GH#29535: interactive/review holds remain independent
+	# of assignee identity. A terminal worker draft checkpoint is the sole narrow
+	# exception: route its existing exact PR before consuming the generic hold.
 	_dss_t0=$(_ds_now_ns)
-	if _dispatch_has_interactive_hold "$issue_meta_json"; then
-		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: interactive review hold label present (GH#22948)" >>"$LOGFILE"
-		echo "[dispatch_with_dedup] DISPATCH_BLOCK_REASON reason=interactive_review_hold signal=interactive_review_hold issue=#${issue_number} repo=${repo_slug}" >>"$LOGFILE"
+	if _dispatch_interactive_hold_gate "$issue_number" "$repo_slug" "$issue_title" \
+		"$self_login" "$issue_meta_json"; then
 		_ds_record "$issue_number" "$repo_slug" "dedup.interactive_hold" "$_dss_t0"
 		return 3
 	fi

--- a/.agents/scripts/pulse-dispatch-dedup-layers.sh
+++ b/.agents/scripts/pulse-dispatch-dedup-layers.sh
@@ -17,6 +17,7 @@
 #   - _dedup_layer3_title_match
 #   - _dedup_layer4_pr_evidence
 #   - _dedup_layer5_dispatch_comment
+#   - _dispatch_interactive_hold_gate
 #   - _dedup_layer6_assignee_and_stale
 #   - _dedup_layer7_claim_lock
 
@@ -295,6 +296,91 @@ _dispatch_stale_pr_checkpoint_continuation() {
 	fi
 	echo "[pulse-wrapper] Dedup: exact-head continuation deferred for stale draft PR #${pr_number} on issue #${issue_number}; preserving duplicate-dispatch block" >>"$LOGFILE"
 	return 1
+}
+
+#######################################
+# Route the exact worker draft checkpoint produced by an interactive-provenance
+# issue before the generic interactive hold consumes the candidate. The direct
+# continuation helper independently verifies trusted terminal evidence, exact
+# PR linkage/head, worker ownership, issue ownership, and retry bounds.
+# Args: issue number, repo slug, issue title, authenticated login, issue JSON
+# Exit: 0=routed/deduplicated, 1=not a machine checkpoint, 2=verified candidate blocked
+#######################################
+_dispatch_interactive_worker_checkpoint_continuation() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local issue_title="$3"
+	local self_login="$4"
+	local issue_meta_json="$5"
+	local dedup_helper="${SCRIPT_DIR}/dispatch-dedup-helper.sh"
+	local checkpoint_output=""
+	local checkpoint_assignee=""
+	local pr_number=""
+	local continuation_signal=""
+
+	printf '%s' "$issue_meta_json" | jq -e '
+		([.labels[]?.name]) as $labels |
+		((.state // "") | ascii_upcase) == "OPEN" and
+		($labels | index("origin:interactive")) != null and
+		($labels | index("status:in-review")) != null and
+		($labels | index("auto-dispatch")) == null and
+		($labels | any(. == "hold-for-review" or . == "no-auto-dispatch" or
+			. == "needs-maintainer-review" or . == "needs-maintainer-permissions" or
+			. == "persistent" or . == "parent-task" or . == "blocked" or . == "on hold" or
+			. == "research" or . == "research-task") | not) and
+		((.assignees // []) | length) == 1
+	' >/dev/null 2>&1 || return 1
+	checkpoint_assignee=$(printf '%s' "$issue_meta_json" | jq -er '.assignees[0].login' 2>/dev/null) || return 1
+	[[ "$checkpoint_assignee" =~ ^[A-Za-z0-9._-]+(\[bot\])?$ ]] || return 1
+	if has_worker_for_repo_issue "$issue_number" "$repo_slug"; then
+		echo "[dispatch_with_dedup] Verified interactive-provenance candidate #${issue_number} retains a live worker; preserving genuine hold" >>"$LOGFILE"
+		return 1
+	fi
+	[[ -x "$dedup_helper" ]] || return 2
+	checkpoint_output=$("$dedup_helper" has-open-pr "$issue_number" "$repo_slug" "$issue_title" 2>>"$LOGFILE") || return 1
+	if [[ "$checkpoint_output" =~ WORKER_DRAFT_CHECKPOINT:[[:space:]]draft[[:space:]]PR[[:space:]]#([0-9]+) ]]; then
+		pr_number="${BASH_REMATCH[1]}"
+	else
+		return 1
+	fi
+	continuation_signal="STALE_PR_CONTINUATION: issue #${issue_number} in ${repo_slug} — PR #${pr_number} preserved for exact-head continuation assignee=${checkpoint_assignee}"
+	if _dispatch_stale_pr_checkpoint_continuation "$issue_number" "$repo_slug" \
+		"$continuation_signal" "$self_login"; then
+		return 0
+	fi
+	return 2
+}
+
+#######################################
+# Consume an interactive hold. A verified machine checkpoint gets one guarded
+# exact-PR continuation attempt; every other interactive/human hold is unchanged.
+# Args: issue number, repo slug, issue title, authenticated login, issue JSON
+# Exit: 0=hold consumed, 1=no interactive hold
+#######################################
+_dispatch_interactive_hold_gate() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local issue_title="$3"
+	local self_login="$4"
+	local issue_meta_json="$5"
+	local checkpoint_rc=0
+
+	_dispatch_has_interactive_hold "$issue_meta_json" || return 1
+	_dispatch_interactive_worker_checkpoint_continuation "$issue_number" "$repo_slug" \
+		"$issue_title" "$self_login" "$issue_meta_json" || checkpoint_rc=$?
+	case "$checkpoint_rc" in
+	0)
+		echo "[dispatch_with_dedup] DISPATCH_BLOCK_REASON reason=worker_draft_checkpoint_continuation signal=checkpoint_routed issue=#${issue_number} repo=${repo_slug}" >>"$LOGFILE"
+		return 0
+		;;
+	2)
+		echo "[dispatch_with_dedup] DISPATCH_BLOCK_REASON reason=worker_draft_checkpoint_blocked signal=exact_head_continuation_unavailable issue=#${issue_number} repo=${repo_slug}" >>"$LOGFILE"
+		return 0
+		;;
+	esac
+	echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: interactive review hold label present (GH#22948)" >>"$LOGFILE"
+	echo "[dispatch_with_dedup] DISPATCH_BLOCK_REASON reason=interactive_review_hold signal=interactive_review_hold issue=#${issue_number} repo=${repo_slug}" >>"$LOGFILE"
+	return 0
 }
 
 #######################################

--- a/.agents/scripts/tests/test-dispatch-claim-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-claim-helper.sh
@@ -1170,6 +1170,50 @@ EOF
 }
 
 #######################################
+# Assert interactive-provenance checkpoint release and ownership fencing.
+#######################################
+_assert_pr_checkpoint_interactive_provenance() {
+	local tmp_dir="$1"
+	local calls_file="$2"
+	local expected_sha="$3"
+	local valid_pr="$4"
+	local interactive_issue='{"number":42,"state":"open","labels":[{"name":"status:in-review"},{"name":"origin:interactive"}],"assignees":[{"login":"mockrunner"}]}'
+	local checkpoint_comments='[[{"id":10,"created_at":"2026-08-04T22:29:37Z","author_association":"COLLABORATOR","body":"CLAIM_RELEASED reason=worker_draft_checkpoint runner=mockrunner ts=2026-08-04T22:29:36Z"}]]'
+	local later_human_claim='[[{"id":10,"created_at":"2026-08-04T22:29:37Z","author_association":"COLLABORATOR","body":"CLAIM_RELEASED reason=worker_draft_checkpoint runner=mockrunner ts=2026-08-04T22:29:36Z"},{"id":11,"created_at":"2026-08-04T22:30:37Z","author_association":"MEMBER","body":"Interactive session claimed this issue"}]]'
+	local foreign_pr=""
+	local output=""
+	local status=0
+
+	output=$(PATH="${tmp_dir}/bin:$PATH" MOCK_CHECKPOINT_GH_CALLS="$calls_file" \
+		MOCK_CHECKPOINT_PR_JSON="$valid_pr" MOCK_CHECKPOINT_ISSUE_JSON="$interactive_issue" \
+		MOCK_CHECKPOINT_COMMENTS_JSON="$checkpoint_comments" \
+		"$CLAIM_HELPER" verify-pr-checkpoint-target 77 owner/repo "$expected_sha" feature/review 42 mockrunner 2>&1) || status=$?
+	[[ "$status" -eq 0 && "$output" == *"PR_CHECKPOINT_TARGET_VALID"* ]] \
+		&& print_result "PR checkpoint target accepts trusted interactive-provenance release" 0 \
+		|| print_result "PR checkpoint target accepts trusted interactive-provenance release" 1 "status=$status output=$output"
+
+	status=0
+	output=$(PATH="${tmp_dir}/bin:$PATH" MOCK_CHECKPOINT_GH_CALLS="$calls_file" \
+		MOCK_CHECKPOINT_PR_JSON="$valid_pr" MOCK_CHECKPOINT_ISSUE_JSON="$interactive_issue" \
+		MOCK_CHECKPOINT_COMMENTS_JSON="$later_human_claim" \
+		"$CLAIM_HELPER" verify-pr-checkpoint-target 77 owner/repo "$expected_sha" feature/review 42 mockrunner 2>&1) || status=$?
+	[[ "$status" -eq 1 && "$output" == *"PR_CHECKPOINT_TARGET_LOST"* ]] \
+		&& print_result "PR checkpoint target rejects release superseded by human claim" 0 \
+		|| print_result "PR checkpoint target rejects release superseded by human claim" 1 "status=$status output=$output"
+
+	status=0
+	foreign_pr=$(printf '%s' "$valid_pr" | jq -c '.author.login = "foreign-runner"')
+	output=$(PATH="${tmp_dir}/bin:$PATH" MOCK_CHECKPOINT_GH_CALLS="$calls_file" \
+		MOCK_CHECKPOINT_PR_JSON="$foreign_pr" MOCK_CHECKPOINT_ISSUE_JSON="$interactive_issue" \
+		MOCK_CHECKPOINT_COMMENTS_JSON="$checkpoint_comments" \
+		"$CLAIM_HELPER" verify-pr-checkpoint-target 77 owner/repo "$expected_sha" feature/review 42 mockrunner 2>&1) || status=$?
+	[[ "$status" -eq 1 && "$output" == *"PR_CHECKPOINT_TARGET_LOST"* ]] \
+		&& print_result "PR checkpoint target rejects foreign checkpoint author" 0 \
+		|| print_result "PR checkpoint target rejects foreign checkpoint author" 1 "status=$status output=$output"
+	return 0
+}
+
+#######################################
 # Test: stale draft continuation revalidates draft mode, authoritative closing
 # linkage, protected PR labels, and the linked issue lifecycle envelope.
 #######################################
@@ -1188,6 +1232,10 @@ if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/issues/42" ]]; then
 	printf '%s\n' "${MOCK_CHECKPOINT_ISSUE_JSON:?}"
 	exit 0
 fi
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/issues/42/comments?per_page=100" ]]; then
+	printf '%s\n' "${MOCK_CHECKPOINT_COMMENTS_JSON:-[]}"
+	exit 0
+fi
 exit 1
 EOF
 	chmod +x "${tmp_dir}/bin/gh"
@@ -1197,7 +1245,7 @@ EOF
 	local valid_issue='{"number":42,"state":"open","labels":[{"name":"status:in-review"}],"assignees":[{"login":"mockrunner"}]}'
 	local output=""
 	local status=0
-	valid_pr="{\"number\":77,\"state\":\"OPEN\",\"closingIssuesReferences\":[{\"number\":42,\"repository\":{\"name\":\"repo\",\"owner\":{\"login\":\"owner\"}}}],\"isDraft\":true,\"isCrossRepository\":false,\"labels\":[{\"name\":\"origin:worker\"}],\"headRefName\":\"feature/review\",\"headRefOid\":\"${expected_sha}\"}"
+	valid_pr="{\"number\":77,\"state\":\"OPEN\",\"closingIssuesReferences\":[{\"number\":42,\"repository\":{\"name\":\"repo\",\"owner\":{\"login\":\"owner\"}}}],\"isDraft\":true,\"isCrossRepository\":false,\"labels\":[{\"name\":\"origin:worker\"}],\"headRefName\":\"feature/review\",\"headRefOid\":\"${expected_sha}\",\"author\":{\"login\":\"mockrunner\"}}"
 
 	output=$(PATH="${tmp_dir}/bin:$PATH" MOCK_CHECKPOINT_GH_CALLS="$calls_file" \
 		MOCK_CHECKPOINT_PR_JSON="$valid_pr" MOCK_CHECKPOINT_ISSUE_JSON="$valid_issue" \
@@ -1262,6 +1310,8 @@ EOF
 	[[ "$status" -eq 1 && "$output" == *"PR_CHECKPOINT_TARGET_LOST"* ]] \
 		&& print_result "PR checkpoint target rejects one-for-one reassignment" 0 \
 		|| print_result "PR checkpoint target rejects one-for-one reassignment" 1 "status=$status output=$output"
+
+	_assert_pr_checkpoint_interactive_provenance "$tmp_dir" "$calls_file" "$expected_sha" "$valid_pr"
 
 	rm -rf "$tmp_dir"
 	return 0

--- a/.agents/scripts/tests/test-pr-checkpoint-continuation-helper.sh
+++ b/.agents/scripts/tests/test-pr-checkpoint-continuation-helper.sh
@@ -39,6 +39,10 @@ if [[ "$1" == "api" && "$2" == "repos/owner/repo/issues/123" ]]; then
 	printf '%s\n' "${STUB_ISSUE_JSON:-}"
 	exit 0
 fi
+if [[ "$1" == "api" && "$2" == "repos/owner/repo/issues/123/comments?per_page=100" ]]; then
+	printf '%s\n' "${STUB_COMMENTS_JSON:-[]}"
+	exit 0
+fi
 exit 1
 GH_STUB
 chmod +x "${TEST_ROOT}/bin/gh"
@@ -51,10 +55,11 @@ valid_pr_json() {
 	local body="${1:-Resolves #123}"
 	local labels="${2:-}"
 	local closing_refs="${3:-}"
+	local author="${4:-worker-bot}"
 	[[ -n "$labels" ]] || labels='[{"name":"origin:worker"}]'
 	[[ -n "$closing_refs" ]] || closing_refs='[{"number":123,"repository":{"name":"repo","owner":{"login":"owner"}}}]'
-	printf '{"number":42,"state":"OPEN","title":"Continue existing work","body":"%s","closingIssuesReferences":%s,"isDraft":true,"isCrossRepository":false,"labels":%s,"headRefName":"worker/issue-123","headRefOid":"1111111111111111111111111111111111111111","author":{"login":"worker-bot"}}\n' \
-		"$body" "$closing_refs" "$labels"
+	printf '{"number":42,"state":"OPEN","title":"Continue existing work","body":"%s","closingIssuesReferences":%s,"isDraft":true,"isCrossRepository":false,"labels":%s,"headRefName":"worker/issue-123","headRefOid":"1111111111111111111111111111111111111111","author":{"login":"%s"}}\n' \
+		"$body" "$closing_refs" "$labels" "$author"
 	return 0
 }
 
@@ -66,9 +71,16 @@ valid_issue_json() {
 	return 0
 }
 
+valid_checkpoint_comments() {
+	local runner="worker-bot"
+	printf '[[{"id":10,"created_at":"2026-08-04T22:29:37Z","author_association":"COLLABORATOR","body":"CLAIM_RELEASED reason=worker_draft_checkpoint runner=%s ts=2026-08-04T22:29:36Z"}]]\n' "$runner"
+	return 0
+}
+
 STUB_PR_JSON="$(valid_pr_json)"
 STUB_ISSUE_JSON="$(valid_issue_json)"
-export STUB_PR_JSON STUB_ISSUE_JSON
+STUB_COMMENTS_JSON='[]'
+export STUB_PR_JSON STUB_ISSUE_JSON STUB_COMMENTS_JSON
 if row=$(_pcc_target_row "owner/repo" "42" "123") && \
 	[[ "$row" == $'Continue existing work\tworker/issue-123\t1111111111111111111111111111111111111111\tworker-bot\tin-review\tworker-bot' ]]; then
 	print_result "accepts exact open worker draft linked to issue" 0
@@ -136,7 +148,42 @@ for conflicting_status in status:blocked status:done status:in-progress; do
 	fi
 done
 
+STUB_ISSUE_JSON="$(valid_issue_json '[{"name":"status:in-review"},{"name":"origin:interactive"}]')"
+STUB_COMMENTS_JSON="$(valid_checkpoint_comments)"
+if _pcc_target_row "owner/repo" "42" "123" "worker-bot" "worker-bot" >/dev/null; then
+	print_result "accepts interactive-provenance issue with current trusted checkpoint release" 0
+else
+	print_result "accepts interactive-provenance issue with current trusted checkpoint release" 1
+fi
+
+STUB_COMMENTS_JSON='[]'
+if ! _pcc_target_row "owner/repo" "42" "123" "worker-bot" "worker-bot" >/dev/null; then
+	print_result "rejects interactive-provenance issue without checkpoint release" 0
+else
+	print_result "rejects interactive-provenance issue without checkpoint release" 1
+fi
+
+STUB_COMMENTS_JSON='[[
+  {"id":10,"created_at":"2026-08-04T22:29:37Z","author_association":"COLLABORATOR","body":"CLAIM_RELEASED reason=worker_draft_checkpoint runner=worker-bot ts=2026-08-04T22:29:36Z"},
+  {"id":11,"created_at":"2026-08-04T22:30:37Z","author_association":"MEMBER","body":"Interactive session claimed this issue"}
+]]'
+if ! _pcc_target_row "owner/repo" "42" "123" "worker-bot" "worker-bot" >/dev/null; then
+	print_result "rejects replayed checkpoint release after a newer human claim" 0
+else
+	print_result "rejects replayed checkpoint release after a newer human claim" 1
+fi
+
+STUB_COMMENTS_JSON="$(valid_checkpoint_comments)"
+STUB_PR_JSON="$(valid_pr_json 'Resolves #123' '' '' 'foreign-runner')"
+if ! _pcc_target_row "owner/repo" "42" "123" "worker-bot" "worker-bot" >/dev/null; then
+	print_result "rejects foreign-authored worker checkpoint" 0
+else
+	print_result "rejects foreign-authored worker checkpoint" 1
+fi
+
+STUB_PR_JSON="$(valid_pr_json)"
 STUB_ISSUE_JSON="$(valid_issue_json)"
+STUB_COMMENTS_JSON='[]'
 
 DISPATCH_ARGS=""
 DISPATCH_RESULT=0
@@ -195,6 +242,23 @@ else
 	print_result "dispatch binds continuation to exact PR branch and head" 1 "output=${output:-missing} args=${DISPATCH_ARGS:-missing}"
 fi
 
+DISPATCH_RESULT="$PRRTS_RC_DISPATCH_DEFERRED"
+if output=$(_pcc_dispatch "owner/repo" "${TEST_ROOT}/repo" "42" "123" "worker-bot") &&
+	[[ "$output" == *PR_CHECKPOINT_CONTINUATION_DEDUPLICATED* ]]; then
+	print_result "active exact-head continuation is deduplicated as handled" 0
+else
+	print_result "active exact-head continuation is deduplicated as handled" 1 "output=${output:-missing}"
+fi
+
+DISPATCH_RESULT="$PRRTS_RC_MAINTAINER_ATTENTION"
+if ! output=$(_pcc_dispatch "owner/repo" "${TEST_ROOT}/repo" "42" "123" "worker-bot") &&
+	[[ "$output" == *PR_CHECKPOINT_CONTINUATION_EXHAUSTED* ]]; then
+	print_result "bounded retry exhaustion is explicit" 0
+else
+	print_result "bounded retry exhaustion is explicit" 1 "output=${output:-missing}"
+fi
+
+STUB_PR_JSON="$(valid_pr_json 'Resolves #123' '' '' 'stale-runner')"
 STUB_ISSUE_JSON="$(valid_issue_json '' 'stale-runner')"
 STATUS_CALLS=""
 DISPATCH_RESULT=0
@@ -225,12 +289,14 @@ else
 fi
 DISPATCH_RESULT=0
 
+STUB_PR_JSON="$(valid_pr_json)"
 PCC_LINKED_ISSUE="123"
 PCC_HEAD_REF="worker/issue-123"
 PCC_HEAD_OID="1111111111111111111111111111111111111111"
 PCC_ISSUE_ASSIGNEE="worker-bot"
 PCC_EXPECTED_ASSIGNEE="worker-bot"
 PCC_AUTHENTICATED_LOGIN="worker-bot"
+PCC_CHECKPOINT_ASSIGNEE="worker-bot"
 PCC_ORIGINAL_STATUS="in-review"
 PCC_OWNERSHIP_TRANSFERRED=0
 if [[ "$(_prrts_worker_task_id 42)" == "123" ]] &&
@@ -256,6 +322,7 @@ if [[ -f "$prompt_file" ]] && \
 	grep -q 'PR_CHECKPOINT_TARGET_VALID' "$prompt_file" && \
 	grep -Fq "\$AIDEVOPS_PR_REPAIR_LINKED_ISSUE" "$prompt_file" && \
 	grep -Fq "\$AIDEVOPS_PR_REPAIR_ISSUE_ASSIGNEE" "$prompt_file" && \
+	grep -Fq '"worker-bot"`' "$prompt_file" && \
 	grep -q "HEAD:\$AIDEVOPS_PR_REPAIR_HEAD_REF" "$prompt_file" && \
 	grep -q 'Do not create another branch' "$prompt_file"; then
 	print_result "continuation prompt preserves exact-target ownership contract" 0

--- a/.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 CORE_SCRIPT="${SCRIPT_DIR}/../pulse-dispatch-core.sh"
+LAYERS_SCRIPT="${SCRIPT_DIR}/../pulse-dispatch-dedup-layers.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -157,11 +158,31 @@ test_interactive_hold_allows_worker_issue() {
 }
 
 test_interactive_hold_emits_structured_block_reason() {
-	if grep -q 'DISPATCH_BLOCK_REASON reason=interactive_review_hold' "$CORE_SCRIPT" && grep -q 'return 3' "$CORE_SCRIPT"; then
+	if grep -q 'DISPATCH_BLOCK_REASON reason=interactive_review_hold' "$LAYERS_SCRIPT" && grep -q 'return 3' "$CORE_SCRIPT"; then
 		print_result "interactive hold emits structured benign block reason" 0
 		return 0
 	fi
 	print_result "interactive hold emits structured benign block reason" 1 "expected structured reason and benign rc=3 in dispatch core"
+	return 0
+}
+
+test_checkpoint_route_precedes_generic_interactive_hold() {
+	if grep -q '_dispatch_interactive_hold_gate' "$CORE_SCRIPT" && python3 - "$LAYERS_SCRIPT" <<'PY'
+import pathlib
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text()
+start = text.index("_dispatch_interactive_hold_gate() {")
+end = text.index("\n}\n", start)
+body = text[start:end]
+if body.index("_dispatch_interactive_worker_checkpoint_continuation") >= body.index("reason=interactive_review_hold"):
+    raise SystemExit(1)
+PY
+	then
+		print_result "verified checkpoint route precedes generic interactive hold" 0
+		return 0
+	fi
+	print_result "verified checkpoint route precedes generic interactive hold" 1
 	return 0
 }
 
@@ -198,6 +219,7 @@ main() {
 	test_interactive_hold_allows_auto_dispatch_review_handoff
 	test_interactive_hold_allows_worker_issue
 	test_interactive_hold_emits_structured_block_reason
+	test_checkpoint_route_precedes_generic_interactive_hold
 	test_pr_guard_emits_structured_block_reason
 	test_dedup_guard_emits_structured_block_reason
 

--- a/.agents/scripts/tests/test-pulse-stale-pr-continuation.sh
+++ b/.agents/scripts/tests/test-pulse-stale-pr-continuation.sh
@@ -35,6 +35,10 @@ if [[ "$1" == "is-assigned" ]]; then
 	printf '%s\n' "${STUB_ASSIGNED_OUTPUT}"
 	exit 1
 fi
+if [[ "$1" == "has-open-pr" ]]; then
+	printf '%s\n' "${STUB_OPEN_PR_OUTPUT:-}"
+	exit "${STUB_OPEN_PR_RC:-0}"
+fi
 exit 1
 DEDUP_STUB
 chmod +x "${SCRIPT_DIR}/dispatch-dedup-helper.sh"
@@ -74,6 +78,7 @@ fi
 
 ROUTE_CALLS=0
 ROUTE_RESULT=0
+LAST_ROUTE_ARGS=""
 _dispatch_stale_pr_checkpoint_continuation() {
 	local _issue_number="$1"
 	local _repo_slug="$2"
@@ -81,6 +86,7 @@ _dispatch_stale_pr_checkpoint_continuation() {
 	local _self_login="$4"
 	: "$_issue_number" "$_repo_slug" "$_assigned_output" "$_self_login"
 	ROUTE_CALLS=$((ROUTE_CALLS + 1))
+	LAST_ROUTE_ARGS="$*"
 	return "$ROUTE_RESULT"
 }
 
@@ -103,6 +109,73 @@ if _dedup_layer6_assignee_and_stale "123" "owner/repo" "runner" && [[ "$ROUTE_CA
 	print_result "changed stale evidence fails closed without continuation or redispatch" 0
 else
 	print_result "changed stale evidence fails closed without continuation or redispatch" 1
+fi
+
+STUB_ACTIVE_WORKER=0
+has_worker_for_repo_issue() {
+	local _issue_number="$1"
+	local _repo_slug="$2"
+	: "$_issue_number" "$_repo_slug"
+	if [[ "$STUB_ACTIVE_WORKER" -eq 1 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+_dispatch_has_interactive_hold() {
+	local issue_meta_json="$1"
+	if printf '%s' "$issue_meta_json" | jq -e '
+		(.labels // []) | map(.name) |
+		((index("auto-dispatch") | not) and (index("status:in-review") or index("origin:interactive")))
+	' >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
+checkpoint_meta='{"number":29507,"state":"OPEN","title":"Fixture","labels":[{"name":"origin:interactive"},{"name":"status:in-review"}],"assignees":[{"login":"stale-runner"}]}'
+export STUB_OPEN_PR_OUTPUT='WORKER_DRAFT_CHECKPOINT: draft PR #29519 is a durable checkpoint for issue #29507; ordinary redispatch is blocked'
+export STUB_OPEN_PR_RC=0
+ROUTE_CALLS=0
+ROUTE_RESULT=0
+: >"$LOGFILE"
+if _dispatch_interactive_hold_gate "29507" "owner/repo" "Fixture" "runner" "$checkpoint_meta" &&
+	[[ "$ROUTE_CALLS" -eq 1 && "$LAST_ROUTE_ARGS" == *"PR #29519"* ]] &&
+	grep -q 'reason=worker_draft_checkpoint_continuation signal=checkpoint_routed' "$LOGFILE"; then
+	print_result "#29507 interactive-provenance checkpoint routes exactly one continuation before hold" 0
+else
+	print_result "#29507 interactive-provenance checkpoint routes exactly one continuation before hold" 1
+fi
+
+ROUTE_CALLS=0
+ROUTE_RESULT=1
+: >"$LOGFILE"
+if _dispatch_interactive_hold_gate "29507" "owner/repo" "Fixture" "runner" "$checkpoint_meta" &&
+	[[ "$ROUTE_CALLS" -eq 1 ]] && grep -q 'reason=worker_draft_checkpoint_blocked' "$LOGFILE"; then
+	print_result "verified checkpoint launch failure remains an explicit block" 0
+else
+	print_result "verified checkpoint launch failure remains an explicit block" 1
+fi
+
+export STUB_OPEN_PR_OUTPUT='draft PR #29519 is a durable checkpoint for issue #29507; ordinary redispatch is blocked'
+ROUTE_CALLS=0
+: >"$LOGFILE"
+if _dispatch_interactive_hold_gate "29507" "owner/repo" "Fixture" "runner" "$checkpoint_meta" &&
+	[[ "$ROUTE_CALLS" -eq 0 ]] && grep -q 'reason=interactive_review_hold' "$LOGFILE"; then
+	print_result "otherwise identical human draft remains a genuine interactive hold" 0
+else
+	print_result "otherwise identical human draft remains a genuine interactive hold" 1
+fi
+
+export STUB_OPEN_PR_OUTPUT='WORKER_DRAFT_CHECKPOINT: draft PR #29519 is a durable checkpoint for issue #29507; ordinary redispatch is blocked'
+STUB_ACTIVE_WORKER=1
+ROUTE_CALLS=0
+: >"$LOGFILE"
+if _dispatch_interactive_hold_gate "29507" "owner/repo" "Fixture" "runner" "$checkpoint_meta" &&
+	[[ "$ROUTE_CALLS" -eq 0 ]] && grep -q 'reason=interactive_review_hold' "$LOGFILE"; then
+	print_result "live worker keeps checkpoint under genuine interactive hold" 0
+else
+	print_result "live worker keeps checkpoint under genuine interactive hold" 1
 fi
 
 if [[ "$TESTS_FAILED" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Route verified stale worker draft checkpoints into exact-head continuation before generic interactive review holds, with fail-closed ownership and target validation.

## Files Changed

.agents/scripts/dispatch-claim-helper.sh, .agents/scripts/pr-checkpoint-continuation-helper.sh, .agents/scripts/pr-checkpoint-target-lib.sh, .agents/scripts/pulse-dispatch-core.sh, .agents/scripts/pulse-dispatch-dedup-layers.sh, .agents/scripts/tests/test-dispatch-claim-helper.sh, .agents/scripts/tests/test-pr-checkpoint-continuation-helper.sh, .agents/scripts/tests/test-pulse-dispatch-core-pr-guard.sh, .agents/scripts/tests/test-pulse-stale-pr-continuation.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — All six issue-focused checkpoint, dedup, and guard suites; dispatch claim helper 80 tests; linters-local --changed; ShellCheck; Bash 3.2 compatibility regression.

Resolves #29535


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.223 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 32m and 509,270 tokens on this as a headless worker.