### PR TITLE
GH#29548: Correct Buzz release aggregation trailers

### DIFF
--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -252,7 +252,7 @@ merges advanced `main` after the source received terminal `release:not-requested
 evidence and before the user explicitly authorized publication. The exact branch
 base is `c945b97c7ac10016ad08da035b71d12bd0a391f9`.
 
-The pending corrective aggregation re-reviews authorized PR #29538 at
+Aggregation PR #29549 re-reviews authorized PR #29538 at
 `d83c027410983cf83d5f9afb5d85975b69f6e3ec` and aggregation PR #29545 at
 `9d82088812adfb1793b18746e484216b676a5887` because the latter's required
 provenance lines were separated into distinct Git trailer paragraphs. Subsequent

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -252,6 +252,13 @@ merges advanced `main` after the source received terminal `release:not-requested
 evidence and before the user explicitly authorized publication. The exact branch
 base is `c945b97c7ac10016ad08da035b71d12bd0a391f9`.
 
+The pending corrective aggregation re-reviews authorized PR #29538 at
+`d83c027410983cf83d5f9afb5d85975b69f6e3ec` and aggregation PR #29545 at
+`9d82088812adfb1793b18746e484216b676a5887` because the latter's required
+provenance lines were separated into distinct Git trailer paragraphs. Subsequent
+maintained merges advanced `main`; the exact branch base is
+`e0c71469e63192a699a3c90b464aa8999d257733`.
+
 Manual arbitrary-version package publication is intentionally unsupported. A
 recovery operation must use an existing tag that passes the same verifier.
 


### PR DESCRIPTION
## Summary

Create a corrective exact-tip release aggregation after PR #29545 separated its required provenance lines into distinct Git trailer paragraphs.

## Release provenance

- Authorized source: PR #29538 at `d83c027410983cf83d5f9afb5d85975b69f6e3ec`
- Prior aggregation: PR #29545 at `9d82088812adfb1793b18746e484216b676a5887`
- Exact branch base: `e0c71469e63192a699a3c90b464aa8999d257733`
- PR #29549 and both source merges are recorded in one contiguous trailer block

## Verification

- `git log -1 --format=%B | git interpret-trailers --parse`
- `markdownlint .agents/reference/release-publication-controls.md`
- release provenance resolver after merge

Resolves #29548
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.223 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 7h 6m and 2,575,309 tokens on this with the user in an interactive session.