### PR TITLE
GH#29556: fix: support Buzz 0.5.5 ACP reconciliation

### DIFF
--- a/.agents/scripts/buzz-desktop-helper.sh
+++ b/.agents/scripts/buzz-desktop-helper.sh
@@ -77,7 +77,7 @@ _buzz_is_running() {
 _buzz_is_affected_version() {
 	local version="$1"
 	case "$version" in
-	0.5.4) return 0 ;;
+	0.5.4 | 0.5.5) return 0 ;;
 	*) return 1 ;;
 	esac
 }
@@ -529,7 +529,7 @@ show_help() {
 	cat <<'EOF'
 Usage: aidevops buzz <status|apply|rollback|reconcile> [--quiet]
 
-Manage the reversible Buzz Desktop 0.5.4 OpenCode ACP compatibility fix.
+Manage the reversible Buzz Desktop 0.5.4-0.5.5 OpenCode ACP compatibility fix.
 
 Commands:
   status      Report whether the installed Buzz version/agents need remediation

--- a/.agents/tests/test-buzz-desktop-helper.sh
+++ b/.agents/tests/test-buzz-desktop-helper.sh
@@ -296,11 +296,15 @@ test_running_app_refuses_mutation() {
 	return 0
 }
 
-test_unknown_version_and_platform_are_noops() {
+test_verified_and_unknown_versions_are_bounded() {
+	reset_fixture
+	TEST_VERSION=0.5.5 run_helper reconcile --quiet
+	assert_eq "verified Buzz 0.5.5 release is remediated" \
+		"$(jq '[.[] | select(.agent_args == ["acp"])] | length' "$TEST_STORE")" "2"
 	reset_fixture
 	local before=""
 	before=$(file_hash "$TEST_STORE")
-	TEST_VERSION=0.5.5 run_helper reconcile --quiet
+	TEST_VERSION=0.5.6 run_helper reconcile --quiet
 	assert_eq "unknown future Buzz version is not guessed affected" "$(file_hash "$TEST_STORE")" "$before"
 	TEST_PLATFORM=Linux run_helper reconcile --quiet
 	assert_eq "non-macOS platform is unchanged" "$(file_hash "$TEST_STORE")" "$before"
@@ -375,7 +379,7 @@ main() {
 	test_rollback_restores_owned_fields
 	test_rollback_preserves_later_user_edit
 	test_running_app_refuses_mutation
-	test_unknown_version_and_platform_are_noops
+	test_verified_and_unknown_versions_are_bounded
 	test_symlink_store_fails_closed
 	test_malformed_record_fails_closed
 	test_cli_and_setup_wiring


### PR DESCRIPTION
## Summary

Implementation for issue #29556.

## Files Changed

.agents/scripts/buzz-desktop-helper.sh, .agents/tests/test-buzz-desktop-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #29556


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.225 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 8h 2m and 2,906,429 tokens on this with the user in an interactive session.