### PR TITLE
GH#29558: docs: record Buzz 0.5.5 release aggregation

### DIFF
--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -265,7 +265,7 @@ Concurrent signed `v3.32.224` publication and protected release PR #29550
 advanced `main` after the source merged. The exact branch base is
 `609c76d7411d8a3e64ef32cd132fca35898e6c1c`.
 
-The Buzz Desktop 0.5.5 ACP compatibility aggregation reviews authorized source
+Aggregation PR #29559 reviews authorized Buzz Desktop 0.5.5 ACP compatibility
 PR #29557 at `8f3b23eb37e632eb29ccdbf63d858e489a453580`. The source already recorded
 terminal `release:not-requested` evidence before the user explicitly authorized
 publication. The exact branch base is

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -265,6 +265,12 @@ Concurrent signed `v3.32.224` publication and protected release PR #29550
 advanced `main` after the source merged. The exact branch base is
 `609c76d7411d8a3e64ef32cd132fca35898e6c1c`.
 
+The Buzz Desktop 0.5.5 ACP compatibility aggregation reviews authorized source
+PR #29557 at `8f3b23eb37e632eb29ccdbf63d858e489a453580`. The source already recorded
+terminal `release:not-requested` evidence before the user explicitly authorized
+publication. The exact branch base is
+`8f3b23eb37e632eb29ccdbf63d858e489a453580`.
+
 Manual arbitrary-version package publication is intentionally unsupported. A
 recovery operation must use an existing tag that passes the same verifier.
 


### PR DESCRIPTION
## Summary

Implementation for issue #29558.

## Files Changed

.agents/reference/release-publication-controls.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — no additional evidence supplied

Resolves #29558


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.225 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 8h 22m and 2,989,570 tokens on this with the user in an interactive session.