### PR TITLE
GH#29565: fix: isolate GH edit safety audit records

### DIFF
--- a/.agents/scripts/tests/test-gh-edit-safety.sh
+++ b/.agents/scripts/tests/test-gh-edit-safety.sh
@@ -29,6 +29,14 @@ fi
 
 TESTS_RUN=0
 TESTS_FAILED=0
+TEST_ROOT="$(mktemp -d -t aidevops-gh-edit-safety-XXXXXX)" || exit 1
+export GH_AUDIT_LOG_FILE="${TEST_ROOT}/gh-audit.log"
+
+cleanup() {
+	rm -rf "$TEST_ROOT" 2>/dev/null || true
+	return 0
+}
+trap cleanup EXIT
 
 pass() {
 	local msg="$1"
@@ -69,12 +77,15 @@ gh() {
 }
 export -f gh
 
-# Stub audit-log-helper.sh — record calls but don't do anything
+# Keep audit records produced by integration calls inside the test sandbox.
 AUDIT_LOG_CALLS=()
 
 # Stub jq for config loading
 if ! command -v jq &>/dev/null; then
-	jq() { echo "{}"; return 0; }
+	jq() {
+		echo "{}"
+		return 0
+	}
 	export -f jq
 fi
 


### PR DESCRIPTION
## Summary

Route GH edit safety integration-test audit records to a disposable sandbox so test runs cannot trigger production anomaly alerts.

## Files Changed

.agents/scripts/tests/test-gh-edit-safety.sh

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — test-gh-edit-safety.sh (29/29); test-gh-audit-anomaly-expected-transitions.sh; shellcheck; shfmt; linters-local.sh; production gh-audit.log remained at 8474 lines after the test

Resolves #29565


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.226 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 7m and 318,869 tokens on this as a headless worker.