### PR TITLE
GH#29567: Exhaust audit REST capture fallback

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-safe-edit.sh
+++ b/.agents/scripts/shared-gh-wrappers-safe-edit.sh
@@ -163,6 +163,13 @@ _gh_audit_fetch_issue_state_json() {
 		data=$(gh issue view "$issue_num" --repo "$repo" \
 			--json title,body,labels 2>/dev/null) || data=""
 	fi
+	# The routed wrapper's fallback decision can itself be stale or unavailable.
+	# Audit capture is read-only, so exhaust the independent REST transport before
+	# recording a visibility gap.
+	if [[ -z "$data" ]] && command -v _rest_issue_view >/dev/null 2>&1; then
+		data=$(_rest_issue_view "$issue_num" --repo "$repo" \
+			--json title,body,labels 2>/dev/null) || data=""
+	fi
 	if [[ -z "$data" ]]; then
 		printf '%s\n' "$unavailable"
 		return 0
@@ -203,6 +210,10 @@ _gh_audit_fetch_pr_state_json() {
 			--json title,body,labels 2>/dev/null) || data=""
 	else
 		data=$(gh pr view "$pr_num" --repo "$repo" \
+			--json title,body,labels 2>/dev/null) || data=""
+	fi
+	if [[ -z "$data" ]] && command -v _rest_pr_view >/dev/null 2>&1; then
+		data=$(_rest_pr_view "$pr_num" --repo "$repo" \
 			--json title,body,labels 2>/dev/null) || data=""
 	fi
 	if [[ -z "$data" ]]; then

--- a/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
+++ b/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
@@ -217,7 +217,28 @@ jq -e '.capture_status == "ok" and .title_len == 19 and .body_len == 14 and .lab
 	<<<"$wrapped_issue" >/dev/null || fail "issue audit capture bypassed the REST-capable read wrapper"
 jq -e '.capture_status == "ok" and .title_len == 16 and .body_len == 14 and .labels == ["monitoring"]' \
 	<<<"$wrapped_pr" >/dev/null || fail "PR audit capture bypassed the REST-capable read wrapper"
-unset -f gh_issue_view gh_pr_view
+
+gh_issue_view() {
+	return 1
+}
+gh_pr_view() {
+	return 1
+}
+_rest_issue_view() {
+	printf '%s\n' '{"title":"REST issue fallback","body":"Protected body","labels":[{"name":"monitoring"}]}'
+	return 0
+}
+_rest_pr_view() {
+	printf '%s\n' '{"title":"REST PR fallback","body":"Protected body","labels":[{"name":"monitoring"}]}'
+	return 0
+}
+fallback_issue="$(_gh_audit_fetch_issue_state_json "8" "example/repo")"
+fallback_pr="$(_gh_audit_fetch_pr_state_json "9" "example/repo")"
+jq -e '.capture_status == "ok" and .title_len == 19 and .body_len == 14 and .labels == ["monitoring"]' \
+	<<<"$fallback_issue" >/dev/null || fail "failed issue wrapper did not exhaust the direct REST fallback"
+jq -e '.capture_status == "ok" and .title_len == 16 and .body_len == 14 and .labels == ["monitoring"]' \
+	<<<"$fallback_pr" >/dev/null || fail "failed PR wrapper did not exhaust the direct REST fallback"
+unset -f gh_issue_view gh_pr_view _rest_issue_view _rest_pr_view
 
 gh() {
 	local resource="${1:-}"


### PR DESCRIPTION
## Summary

Retry direct REST issue and PR state reads when the routed audit snapshot wrapper returns no data, preserving comparable audit evidence during stale fallback-state failures.

## Files Changed

.agents/scripts/shared-gh-wrappers-safe-edit.sh, .agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — ShellCheck; test-gh-audit-anomaly-expected-transitions.sh

Resolves #29567


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.226 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 8m and 164,563 tokens on this as a headless worker.