### PR TITLE
GH#29566: preserve audit snapshots across transport failures

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-safe-edit.sh
+++ b/.agents/scripts/shared-gh-wrappers-safe-edit.sh
@@ -155,11 +155,15 @@ _gh_audit_fetch_issue_state_json() {
 		return 0
 	}
 
-	local data
+	local data=""
 	if command -v gh_issue_view >/dev/null 2>&1; then
 		data=$(gh_issue_view "$issue_num" --repo "$repo" \
 			--json title,body,labels 2>/dev/null) || data=""
-	else
+	fi
+	# REST-first routing can be locally unavailable while GitHub's GraphQL
+	# transport remains healthy. Audit capture must try the independent native
+	# read before declaring the state unavailable.
+	if [[ -z "$data" ]]; then
 		data=$(gh issue view "$issue_num" --repo "$repo" \
 			--json title,body,labels 2>/dev/null) || data=""
 	fi
@@ -204,11 +208,14 @@ _gh_audit_fetch_pr_state_json() {
 		return 0
 	}
 
-	local data
+	local data=""
 	if command -v gh_pr_view >/dev/null 2>&1; then
 		data=$(gh_pr_view "$pr_num" --repo "$repo" \
 			--json title,body,labels 2>/dev/null) || data=""
-	else
+	fi
+	# Mirror issue capture: a failed REST-capable wrapper is not proof that the
+	# native GraphQL read is unavailable.
+	if [[ -z "$data" ]]; then
 		data=$(gh pr view "$pr_num" --repo "$repo" \
 			--json title,body,labels 2>/dev/null) || data=""
 	fi

--- a/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
+++ b/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
@@ -224,6 +224,27 @@ gh_issue_view() {
 gh_pr_view() {
 	return 1
 }
+gh() {
+	local resource="${1:-}"
+	local operation="${2:-}"
+	[[ "$operation" == "view" ]] || return 1
+	case "$resource" in
+	issue) printf '%s\n' '{"title":"Native issue snapshot","body":"Protected body","labels":[{"name":"monitoring"}]}' ;;
+	pr) printf '%s\n' '{"title":"Native PR snapshot","body":"Protected body","labels":[{"name":"monitoring"}]}' ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+native_fallback_issue="$(_gh_audit_fetch_issue_state_json "8" "example/repo")"
+native_fallback_pr="$(_gh_audit_fetch_pr_state_json "9" "example/repo")"
+jq -e '.capture_status == "ok" and .title_len == 21 and .body_len == 14 and .labels == ["monitoring"]' \
+	<<<"$native_fallback_issue" >/dev/null || fail "issue audit capture did not fall back after the REST-capable wrapper failed"
+jq -e '.capture_status == "ok" and .title_len == 18 and .body_len == 14 and .labels == ["monitoring"]' \
+	<<<"$native_fallback_pr" >/dev/null || fail "PR audit capture did not fall back after the REST-capable wrapper failed"
+
+gh() {
+	return 1
+}
 _rest_issue_view() {
 	printf '%s\n' '{"title":"REST issue fallback","body":"Protected body","labels":[{"name":"monitoring"}]}'
 	return 0


### PR DESCRIPTION
## Summary

Try the native GitHub read after a routed wrapper failure and before the direct REST fallback, preserving audit snapshots when REST admission is locally unavailable but GraphQL remains healthy.

## Files Changed

.agents/scripts/shared-gh-wrappers-safe-edit.sh, .agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — test-gh-edit-safety.sh (29/29); test-gh-audit-anomaly-expected-transitions.sh; test-gh-wrapper-rest-fallback.sh (95/95); linters-local.sh --changed; bun run typecheck (pre-push)

Resolves #29566


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.226 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 18m and 228,275 tokens on this as a headless worker.