### PR TITLE
GH#29575: Add exact ID lookup to memory recall

### DIFF
--- a/.agents/scripts/memory/recall.sh
+++ b/.agents/scripts/memory/recall.sh
@@ -251,6 +251,108 @@ _recall_build_fts_param() {
 }
 
 #######################################
+# Return whether a query is an exact memory or observation identifier.
+# Usage: _recall_is_exact_id <query>
+#######################################
+_recall_is_exact_id() {
+	local query="$1"
+	[[ "$query" =~ ^(mem|obs)_[A-Za-z0-9][A-Za-z0-9_-]*$ ]] || return 1
+	return 0
+}
+
+#######################################
+# Return whether a known memory table exists in a database.
+# Usage: _recall_table_exists <db_path> <table_name>
+#######################################
+_recall_table_exists() {
+	local db_path="$1"
+	local table_name="$2"
+	local exists
+
+	exists=$(db "$db_path" "SELECT COUNT(*) FROM sqlite_master WHERE type IN ('table', 'view') AND name = '$table_name';" 2>/dev/null || printf '0')
+	[[ "$exists" == "1" ]] || return 1
+	return 0
+}
+
+#######################################
+# Look up an exact memory/observation ID and normalize it as recall JSON.
+# Missing tables are skipped for compatibility with older memory databases.
+# Usage: _recall_exact_id_db <db_path> <exact_id>
+# Outputs: JSON array
+#######################################
+_recall_exact_id_db() {
+	local db_path="$1"
+	local exact_id="$2"
+	local selects=()
+	local union_sql=""
+	local select_sql
+
+	if [[ "$exact_id" == mem_* ]]; then
+		if _recall_table_exists "$db_path" "learnings"; then
+			selects+=("SELECT l.id, l.content, l.type, l.tags, l.confidence, l.created_at, '' AS last_accessed_at, 0 AS access_count, 0 AS auto_captured, 0.0 AS usefulness_score, 'live' AS truth_status, '' AS truth_evidence, '' AS replacement_id, '' AS superseded_by, 0.0 AS score, 'learning' AS record_kind, '' AS statement, '' AS observation_id FROM learnings l WHERE l.id = :exact_id")
+		fi
+		if _recall_table_exists "$db_path" "conversation_summaries"; then
+			selects+=("SELECT cs.id, cs.summary AS content, 'CONVERSATION_SUMMARY' AS type, '' AS tags, 'medium' AS confidence, cs.created_at, '' AS last_accessed_at, 0 AS access_count, 0 AS auto_captured, 0.0 AS usefulness_score, 'live' AS truth_status, '' AS truth_evidence, '' AS replacement_id, COALESCE(cs.supersedes_id, '') AS superseded_by, 0.0 AS score, 'conversation_summary' AS record_kind, cs.summary AS statement, '' AS observation_id FROM conversation_summaries cs WHERE cs.id = :exact_id")
+		fi
+		if _recall_table_exists "$db_path" "interactions"; then
+			selects+=("SELECT i.id, i.content, 'INTERACTION' AS type, i.channel AS tags, 'medium' AS confidence, i.created_at, '' AS last_accessed_at, 0 AS access_count, 0 AS auto_captured, 0.0 AS usefulness_score, 'live' AS truth_status, '' AS truth_evidence, '' AS replacement_id, '' AS superseded_by, 0.0 AS score, 'interaction' AS record_kind, i.content AS statement, '' AS observation_id FROM interactions i WHERE i.id = :exact_id")
+		fi
+	elif _recall_table_exists "$db_path" "observations"; then
+		selects+=("SELECT o.observation_id AS id, o.statement AS content, o.kind AS type, '' AS tags, o.confidence, o.created_at, '' AS last_accessed_at, 0 AS access_count, 0 AS auto_captured, 0.0 AS usefulness_score, o.status AS truth_status, '' AS truth_evidence, '' AS replacement_id, '' AS superseded_by, 0.0 AS score, 'observation' AS record_kind, o.statement, o.observation_id FROM observations o WHERE o.observation_id = :exact_id")
+	fi
+
+	if [[ ${#selects[@]} -eq 0 ]]; then
+		printf '[]'
+		return 0
+	fi
+
+	for select_sql in "${selects[@]}"; do
+		if [[ -n "$union_sql" ]]; then
+			union_sql="$union_sql UNION ALL $select_sql"
+		else
+			union_sql="$select_sql"
+		fi
+	done
+
+	local exact_results
+	exact_results=$(
+		db -json "$db_path" <<EOF
+.parameter init
+.parameter set :exact_id "$exact_id"
+$union_sql;
+EOF
+	)
+	local rc=$?
+	[[ $rc -eq 0 ]] || return "$rc"
+	printf '%s' "${exact_results:-[]}"
+	return 0
+}
+
+#######################################
+# Track an exact learning hit without creating access rows for other record types.
+# Usage: _recall_update_exact_access <db_path> <exact_id>
+#######################################
+_recall_update_exact_access() {
+	local db_path="$1"
+	local exact_id="$2"
+
+	[[ "$exact_id" == mem_* ]] || return 0
+	_recall_table_exists "$db_path" "learnings" || return 0
+	_recall_table_exists "$db_path" "learning_access" || return 0
+
+	db "$db_path" <<EOF
+.parameter init
+.parameter set :exact_id "$exact_id"
+INSERT INTO learning_access (id, last_accessed_at, access_count)
+SELECT id, datetime('now'), 1 FROM learnings WHERE id = :exact_id
+ON CONFLICT(id) DO UPDATE SET
+    last_accessed_at = datetime('now'),
+    access_count = access_count + 1;
+EOF
+	return $?
+}
+
+#######################################
 # Execute FTS5 search against a database
 # Usage: _recall_search_db <db_path> <param_query> <entity_fts_join> <entity_fts_where>
 #                          <extra_filters> <auto_join_filter> <limit>
@@ -642,6 +744,25 @@ cmd_recall() {
 	if [[ -z "$query" ]]; then
 		log_error "Query is required. Use --query \"search terms\" or --recent"
 		return 1
+	fi
+
+	# Concrete IDs are deterministic lookups, even when semantic flags are present.
+	# Do not fall through to FTS for a missing exact ID: an unrelated text match
+	# would make a traceable identifier ambiguous.
+	if _recall_is_exact_id "$query"; then
+		local exact_results exact_shared_results=""
+		exact_results=$(_recall_exact_id_db "$MEMORY_DB" "$query") || return $?
+		_recall_update_exact_access "$MEMORY_DB" "$query" || return $?
+		if [[ "$shared_mode" == true && -n "$MEMORY_NAMESPACE" ]]; then
+			local exact_global_db
+			exact_global_db=$(global_db_path)
+			if [[ -f "$exact_global_db" ]]; then
+				exact_shared_results=$(_recall_exact_id_db "$exact_global_db" "$query") || return $?
+				_recall_update_exact_access "$exact_global_db" "$query" || return $?
+			fi
+		fi
+		_recall_output "$format" "$query" "$entity_filter" "$exact_results" "$exact_shared_results" "$limit"
+		return 0
 	fi
 
 	# Handle --semantic or --hybrid mode (delegate to embeddings helper)

--- a/tests/test-memory-exact-id-recall.sh
+++ b/tests/test-memory-exact-id-recall.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)" || exit
+MEMORY_HELPER="$REPO_ROOT/.agents/scripts/memory-helper.sh"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+assert_json() {
+	local json="$1"
+	local expression="$2"
+	local message="$3"
+	printf '%s' "$json" | jq -e "$expression" >/dev/null || fail "$message"
+	return 0
+}
+
+run_memory() {
+	AIDEVOPS_MEMORY_DIR="$TEST_DIR" "$MEMORY_HELPER" "$@" || return 1
+	return 0
+}
+
+recall_json() {
+	local output
+	output=$(run_memory recall "$@" --json) || return $?
+	printf '%s' "${output##*$'\n'}"
+	return 0
+}
+
+run_memory stats >/dev/null
+
+sqlite3 "$TEST_DIR/memory.db" <<'EOF'
+INSERT INTO learnings (id, session_id, content, type, tags, confidence, created_at, event_date, project_path, source)
+VALUES ('mem_fixture_exact', 'session_fixture', 'Exact fixture phrase', 'WORKING_SOLUTION', 'fixture', 'high', '2026-08-05T12:00:00Z', '2026-08-05T12:00:00Z', '/fixture', 'manual');
+INSERT INTO observations (observation_id, kind, session_id, framework_scope, state, statement, confidence, sensitivity, consent, destination, status, created_at)
+VALUES ('obs_learning_mem_fixture_exact', 'working_solution', 'session_fixture', 'aidevops', 'explicit', 'Exact fixture phrase', 'high', 'internal', 'unspecified', 'memory', 'active', '2026-08-05T12:00:00Z');
+INSERT INTO observations (observation_id, kind, session_id, framework_scope, state, statement, confidence, sensitivity, consent, destination, status, created_at)
+VALUES ('obs_fixture_exact', 'decision', 'session_fixture', 'aidevops', 'explicit', 'Observation statement fixture', 'medium', 'internal', 'unspecified', 'memory', 'active', '2026-08-05T12:01:00Z');
+INSERT INTO entities (id, name, type) VALUES ('ent_fixture', 'Fixture', 'agent');
+INSERT INTO interactions (id, entity_id, channel, content, created_at)
+VALUES ('mem_interaction_fixture', 'ent_fixture', 'cli', 'Interaction fixture', '2026-08-05T12:02:00Z');
+INSERT INTO conversations (id, entity_id, channel, status) VALUES ('conv_fixture', 'ent_fixture', 'cli', 'closed');
+INSERT INTO conversation_summaries (id, conversation_id, summary, source_range_start, source_range_end, created_at)
+VALUES ('mem_summary_fixture', 'conv_fixture', 'Summary fixture', 'mem_interaction_fixture', 'mem_interaction_fixture', '2026-08-05T12:03:00Z');
+EOF
+
+learning_json=$(recall_json --query mem_fixture_exact)
+assert_json "$learning_json" 'length == 1 and .[0].id == "mem_fixture_exact" and .[0].record_kind == "learning"' "exact learning ID was not returned"
+
+observation_json=$(recall_json --query obs_fixture_exact)
+assert_json "$observation_json" 'length == 1 and .[0].observation_id == "obs_fixture_exact" and .[0].statement == "Observation statement fixture" and .[0].content == .[0].statement' "exact observation ID did not include its statement"
+
+interaction_json=$(recall_json --query mem_interaction_fixture)
+assert_json "$interaction_json" 'length == 1 and .[0].record_kind == "interaction" and .[0].content == "Interaction fixture"' "exact interaction ID was not normalized"
+
+summary_json=$(recall_json --query mem_summary_fixture)
+assert_json "$summary_json" 'length == 1 and .[0].record_kind == "conversation_summary" and .[0].content == "Summary fixture"' "exact conversation summary ID was not normalized"
+
+missing_json=$(recall_json --query mem_missing_fixture)
+assert_json "${missing_json:-[]}" 'length == 0' "missing exact ID fell through to full-text search"
+
+fts_json=$(recall_json --query "Exact fixture phrase")
+assert_json "$fts_json" 'length == 1 and .[0].id == "mem_fixture_exact"' "non-ID recall no longer uses full-text search"
+
+printf 'PASS: exact memory, observation, interaction, and summary ID recall\n'


### PR DESCRIPTION
## Summary

Added parameterized exact-ID recall for learning, observation, interaction, and conversation-summary records before semantic or full-text search, with graceful table compatibility.

## Files Changed

.agents/scripts/memory/recall.sh, tests/test-memory-exact-id-recall.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified with tests/test-memory-exact-id-recall.sh; regression suites test-memory-observation-contract.sh and test-memory-truth-maintenance.sh; .agents/scripts/linters-local.sh.

Resolves #29575


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.226 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 12m and 158,119 tokens on this as a headless worker.