### PR TITLE
GH#29573: fix: resolve deployed reusable workflow templates

### DIFF
--- a/.agents/scripts/check-workflows-helper.sh
+++ b/.agents/scripts/check-workflows-helper.sh
@@ -154,12 +154,30 @@ _resolve_canonical_template() {
 
 # _resolve_canonical_reusable <reusable_filename>
 # Emits the aidevops source reusable workflow path for content-update checks.
+# Installed agents trees intentionally omit .github/workflows, so fall back to
+# the registered aidevops source checkout from repos.json.
 _resolve_canonical_reusable() {
 	local _reusable_filename="$1"
 	local _repo_local="$REPO_ROOT/.github/workflows/${_reusable_filename}"
 	if [[ -n "$REPO_ROOT" && -f "$_repo_local" ]]; then
 		printf '%s\n' "$_repo_local"
 		return 0
+	fi
+
+	local _source_root=""
+	if [[ -f "$REPOS_JSON" ]]; then
+		_source_root=$(jq -r --arg s "$_DEFAULT_WORKFLOW_REUSABLE_REPO" '
+			[.initialized_repos[]? | select(.slug == $s) | .path // empty]
+			| first // empty
+		' "$REPOS_JSON" 2>/dev/null) || _source_root=""
+	fi
+	if [[ -n "$_source_root" ]]; then
+		_source_root=$(_expand_home_path "$_source_root")
+		_repo_local="$_source_root/.github/workflows/${_reusable_filename}"
+		if [[ -f "$_repo_local" ]]; then
+			printf '%s\n' "$_repo_local"
+			return 0
+		fi
 	fi
 	return 1
 }

--- a/.agents/scripts/tests/test-check-workflows-helper.sh
+++ b/.agents/scripts/tests/test-check-workflows-helper.sh
@@ -23,6 +23,7 @@
 #  19. Stale local checkout reports local evidence and upstream divergence
 #  20. Repository-scoped checks prefer a matching caller-owned linked worktree
 #      without relying on Git 2.31's --path-format option
+#  21. Installed helper resolves reusable baselines from the registered source repo
 #  13a. Verbose mirror drift shows the rendered and normalised comparison
 #
 # Strategy: Each scenario writes a temporary repos.json + temporary repo trees
@@ -621,6 +622,28 @@ else
 	_fail "repository-scoped check → caller-owned linked-worktree evidence" "json: $json_row"
 fi
 rm -rf "$TMPDIR_20"
+
+# Test 21: Installed agents trees omit source-only reusable workflow files. The
+# helper must resolve their canonical baseline from the registered aidevops repo.
+TMPDIR_21="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_21"
+INSTALLED_HELPER_21="$TMPDIR_21/.aidevops/agents/scripts/check-workflows-helper.sh"
+SOURCE_REPO_21="$TMPDIR_21/repos/aidevops-source"
+mkdir -p "$(dirname "$INSTALLED_HELPER_21")" "$SOURCE_REPO_21/.github/workflows"
+cp "$HELPER" "$INSTALLED_HELPER_21"
+cp "$REPO_ROOT/.github/workflows/issue-sync-reusable.yml" \
+	"$SOURCE_REPO_21/.github/workflows/issue-sync-reusable.yml"
+_write_repos_json "$TMPDIR_21" \
+	"$(jq -n --arg path "$SOURCE_REPO_21" '{initialized_repos: [{slug: "marcusquinn/aidevops", path: $path, local_only: false}]}')"
+json_row=$(HOME="$TMPDIR_21" bash "$INSTALLED_HELPER_21" --json \
+	--repo marcusquinn/aidevops --workflow issue-sync 2>/dev/null || true)
+result=$(printf '%s\n' "$json_row" | jq -r '.classification')
+if [[ "$result" == "CURRENT/REUSABLE" ]]; then
+	_pass "installed helper → registered source reusable baseline"
+else
+	_fail "installed helper → registered source reusable baseline" "json: $json_row"
+fi
+rm -rf "$TMPDIR_21"
 
 # ─── Summary ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Resolve canonical reusable workflow files from the registered aidevops source checkout when deployed agents trees omit .github workflows, with installed-tree regression coverage

## Files Changed

.agents/scripts/check-workflows-helper.sh, .agents/scripts/tests/test-check-workflows-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — shellcheck; 24 focused helper tests; bun run typecheck; reproduced repo-local CURRENT versus deployed NO-TEMPLATE mismatch before the fix

Resolves #29573


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.226 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 11m and 139,807 tokens on this as a headless worker.