### PR TITLE
GH#29562: Accept validated same-tree release preservation merge

### DIFF
--- a/.agents/scripts/tests/test-agent-auto-sync.sh
+++ b/.agents/scripts/tests/test-agent-auto-sync.sh
@@ -259,6 +259,7 @@ create_fake_repo() {
 	local remote_url="$2"
 	local repo_path="$TEST_DIR/$repo_name"
 
+	rm -f "$TEST_HOME/.aidevops/agents" "$TEST_HOME/.aidevops/.deployed-sha"
 	mkdir -p "$repo_path/.agents/scripts/setup/modules"
 	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git init -q "$repo_path"
 	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" config user.email test@example.invalid
@@ -275,6 +276,38 @@ create_fake_repo() {
 	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" add .
 	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" commit -qm fixture
 	printf '%s\n' "$repo_path"
+	return 0
+}
+
+prepare_active_release_preservation() {
+	local repo_path="$1"
+	local topology="$2"
+	local release_sha=""
+	local active_sha=""
+	local release_tree=""
+
+	release_sha=$(PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" rev-parse HEAD) || return 1
+	case "$topology" in
+	same-tree)
+		PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" commit --allow-empty -qm "preserve release"
+		active_sha=$(PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" rev-parse HEAD) || return 1
+		;;
+	changed-tree)
+		printf 'post-release change\n' >"$repo_path/preservation-change.txt"
+		PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" add preservation-change.txt
+		PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" commit -qm "change release tree"
+		active_sha=$(PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" rev-parse HEAD) || return 1
+		;;
+	unrelated)
+		release_tree=$(PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" rev-parse 'HEAD^{tree}') || return 1
+		active_sha=$(printf 'unrelated active bundle\n' | PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" commit-tree "$release_tree") || return 1
+		PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" checkout -q --detach "$active_sha"
+		;;
+	*) return 1 ;;
+	esac
+	invoke_release_sync "$repo_path" >/dev/null 2>&1 || return 1
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" checkout -q --detach "$release_sha"
+	printf '%s\n' "$active_sha"
 	return 0
 }
 
@@ -564,6 +597,116 @@ test_release_sync_rejects_stale_sentinel() {
 	return 0
 }
 
+test_release_sync_accepts_validated_same_tree_descendant() {
+	local repo_path
+	local release_sha=""
+	local active_sha=""
+	local output=""
+	repo_path=$(create_fake_repo "release-same-tree-descendant" "https://github.com/marcusquinn/aidevops.git")
+	release_sha=$(PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" rev-parse HEAD)
+	active_sha=$(prepare_active_release_preservation "$repo_path" same-tree)
+	: >"$TEST_DIR/sync.log"
+
+	if output=$(invoke_release_sync "$repo_path" 2>&1) &&
+		[[ ! -s "$TEST_DIR/sync.log" ]] &&
+		[[ "$output" == *"release ${release_sha:0:12}"* ]] &&
+		[[ "$output" == *"preservation merge ${active_sha:0:12}"* ]] &&
+		[[ "$output" == *"verified no-op"* ]]; then
+		print_result "release sync accepts an exact-verified same-tree preservation descendant without deployment" 0
+	else
+		print_result "release sync accepts an exact-verified same-tree preservation descendant without deployment" 1 "Expected verified no-op evidence without a deploy invocation: $output"
+	fi
+	return 0
+}
+
+test_release_sync_rejects_changed_tree_descendant() {
+	local repo_path
+	local output=""
+	repo_path=$(create_fake_repo "release-changed-tree-descendant" "https://github.com/marcusquinn/aidevops.git")
+	prepare_active_release_preservation "$repo_path" changed-tree >/dev/null
+	: >"$TEST_DIR/sync.log"
+
+	if output=$(invoke_release_sync "$repo_path" 2>&1); then
+		print_result "release sync rejects a changed-tree preservation descendant" 1 "Changed-tree descendant was reported as converged"
+	elif [[ "$output" == *"tree differs from release"* && ! -s "$TEST_DIR/sync.log" ]]; then
+		print_result "release sync rejects a changed-tree preservation descendant" 0
+	else
+		print_result "release sync rejects a changed-tree preservation descendant" 1 "Missing fail-closed changed-tree evidence: $output"
+	fi
+	return 0
+}
+
+test_release_sync_rejects_unrelated_active_commit() {
+	local repo_path
+	local output=""
+	repo_path=$(create_fake_repo "release-unrelated-active" "https://github.com/marcusquinn/aidevops.git")
+	prepare_active_release_preservation "$repo_path" unrelated >/dev/null
+	: >"$TEST_DIR/sync.log"
+
+	if output=$(invoke_release_sync "$repo_path" 2>&1); then
+		print_result "release sync rejects an unrelated active commit" 1 "Unrelated active commit was reported as converged"
+	elif [[ "$output" == *"is not a descendant of release"* && ! -s "$TEST_DIR/sync.log" ]]; then
+		print_result "release sync rejects an unrelated active commit" 0
+	else
+		print_result "release sync rejects an unrelated active commit" 1 "Missing fail-closed ancestry evidence: $output"
+	fi
+	return 0
+}
+
+test_release_sync_rejects_malformed_active_manifest() {
+	local repo_path
+	local output=""
+	repo_path=$(create_fake_repo "release-malformed-active" "https://github.com/marcusquinn/aidevops.git")
+	prepare_active_release_preservation "$repo_path" same-tree >/dev/null
+	printf 'schema=1\nstatus=validated\n' >"$TEST_HOME/.aidevops/agents/.bundle-manifest"
+	: >"$TEST_DIR/sync.log"
+
+	if output=$(invoke_release_sync "$repo_path" 2>&1); then
+		print_result "release sync rejects a malformed active manifest before deployment" 1 "Malformed active manifest was replaced or reported as converged"
+	elif [[ "$output" == *"manifest git SHA is missing or invalid"* && ! -s "$TEST_DIR/sync.log" ]]; then
+		print_result "release sync rejects a malformed active manifest before deployment" 0
+	else
+		print_result "release sync rejects a malformed active manifest before deployment" 1 "Missing fail-closed manifest evidence: $output"
+	fi
+	return 0
+}
+
+test_release_sync_rejects_same_tree_descendant_with_stale_stamp() {
+	local repo_path
+	local output=""
+	repo_path=$(create_fake_repo "release-same-tree-stale-stamp" "https://github.com/marcusquinn/aidevops.git")
+	prepare_active_release_preservation "$repo_path" same-tree >/dev/null
+	printf '1111111111111111111111111111111111111111\n' >"$TEST_HOME/.aidevops/.deployed-sha"
+	: >"$TEST_DIR/sync.log"
+
+	if output=$(invoke_release_sync "$repo_path" 2>&1); then
+		print_result "release sync rejects a same-tree descendant with a stale deployment stamp" 1 "Stale stamp was reported as converged"
+	elif [[ "$output" == *"deployed SHA"* && "$output" == *"does not match release commit"* && ! -s "$TEST_DIR/sync.log" ]]; then
+		print_result "release sync rejects a same-tree descendant with a stale deployment stamp" 0
+	else
+		print_result "release sync rejects a same-tree descendant with a stale deployment stamp" 1 "Missing exact-verifier stamp evidence: $output"
+	fi
+	return 0
+}
+
+test_release_sync_rejects_same_tree_descendant_with_stale_sentinel() {
+	local repo_path
+	local output=""
+	repo_path=$(create_fake_repo "release-same-tree-stale-sentinel" "https://github.com/marcusquinn/aidevops.git")
+	prepare_active_release_preservation "$repo_path" same-tree >/dev/null
+	printf 'stale release helper\n' >"$TEST_HOME/.aidevops/agents/scripts/version-manager-release.sh"
+	: >"$TEST_DIR/sync.log"
+
+	if output=$(invoke_release_sync "$repo_path" 2>&1); then
+		print_result "release sync rejects a same-tree descendant with a stale sentinel" 1 "Stale sentinel was reported as converged"
+	elif [[ "$output" == *"active sentinel scripts/version-manager-release.sh"* && "$output" == *"does not match release commit"* && ! -s "$TEST_DIR/sync.log" ]]; then
+		print_result "release sync rejects a same-tree descendant with a stale sentinel" 0
+	else
+		print_result "release sync rejects a same-tree descendant with a stale sentinel" 1 "Missing exact-verifier sentinel evidence: $output"
+	fi
+	return 0
+}
+
 test_release_sync_unsets_session_pins() {
 	: >"$TEST_DIR/sync-env.log"
 	local repo_path
@@ -601,6 +744,12 @@ main() {
 	test_release_sync_rejects_stale_active_bundle
 	test_release_sync_rejects_stale_deployed_sha
 	test_release_sync_rejects_stale_sentinel
+	test_release_sync_accepts_validated_same_tree_descendant
+	test_release_sync_rejects_changed_tree_descendant
+	test_release_sync_rejects_unrelated_active_commit
+	test_release_sync_rejects_malformed_active_manifest
+	test_release_sync_rejects_same_tree_descendant_with_stale_stamp
+	test_release_sync_rejects_same_tree_descendant_with_stale_sentinel
 	test_release_sync_unsets_session_pins
 
 	teardown

--- a/.agents/scripts/version-manager-release.sh
+++ b/.agents/scripts/version-manager-release.sh
@@ -540,10 +540,97 @@ validate_release_deployment_readiness() {
 	return 0
 }
 
+_AIDEVOPS_RELEASE_ACTIVE_PRESERVATION_SHA=""
+
+_verify_active_release_preservation_merge() {
+	local sync_repo_root="$1"
+	local release_sha="$2"
+	local active_link="$3"
+	local stamp_file="$4"
+	local active_manifest=""
+	local manifest_status=""
+	local manifest_sha=""
+	local active_sha=""
+	local release_tree=""
+	local active_tree=""
+	local verify_base=""
+	local verify_root=""
+	local verify_repo=""
+	local verify_exit=0
+
+	_AIDEVOPS_RELEASE_ACTIVE_PRESERVATION_SHA=""
+	[[ -e "$active_link" || -L "$active_link" ]] || return 0
+	_runtime_bundle_verify_active_link "$active_link" || return 1
+	active_manifest="$_AIDEVOPS_RUNTIME_VERIFY_ACTIVE_ROOT/.bundle-manifest"
+	manifest_status=$(_runtime_bundle_verify_manifest_value "$active_manifest" status 2>/dev/null) || manifest_status=""
+	manifest_sha=$(_runtime_bundle_verify_manifest_value "$active_manifest" git_sha 2>/dev/null) || manifest_sha=""
+	if [[ "$manifest_status" != "validated" ]]; then
+		print_error "Post-release deployment gate rejected the active bundle: manifest status is ${manifest_status:-missing}, expected validated"
+		return 1
+	fi
+	active_sha=$(git -C "$sync_repo_root" rev-parse "${manifest_sha}^{commit}" 2>/dev/null) || {
+		print_error "Post-release deployment gate rejected the active bundle: manifest git SHA is missing or invalid"
+		return 1
+	}
+	if [[ "$manifest_sha" != "$active_sha" ]]; then
+		print_error "Post-release deployment gate rejected the active bundle: manifest git SHA is not the full resolved commit"
+		return 1
+	fi
+	[[ "$active_sha" != "$release_sha" ]] || return 0
+
+	if ! git -C "$sync_repo_root" merge-base --is-ancestor "$release_sha" "$active_sha" 2>/dev/null; then
+		print_error "Post-release deployment gate rejected active source ${active_sha:0:12}: it is not a descendant of release ${release_sha:0:12}"
+		return 1
+	fi
+	release_tree=$(git -C "$sync_repo_root" rev-parse "${release_sha}^{tree}" 2>/dev/null) || {
+		print_error "Post-release deployment gate cannot resolve the release tree"
+		return 1
+	}
+	active_tree=$(git -C "$sync_repo_root" rev-parse "${active_sha}^{tree}" 2>/dev/null) || {
+		print_error "Post-release deployment gate cannot resolve the active bundle tree"
+		return 1
+	}
+	if [[ "$release_tree" != "$active_tree" ]]; then
+		print_error "Post-release deployment gate rejected active descendant ${active_sha:0:12}: its tree differs from release ${release_sha:0:12}"
+		return 1
+	fi
+
+	verify_base="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+	mkdir -p "$verify_base" || {
+		print_error "Post-release deployment gate cannot create the active-source verification workspace"
+		return 1
+	}
+	verify_root=$(mktemp -d "$verify_base/release-active-verify.XXXXXX") || {
+		print_error "Post-release deployment gate cannot allocate the active-source verification workspace"
+		return 1
+	}
+	verify_repo="$verify_root/repo"
+	if ! git clone --quiet --shared --no-checkout "$sync_repo_root" "$verify_repo" 2>/dev/null ||
+		! git -C "$verify_repo" checkout --quiet --detach "$active_sha" 2>/dev/null; then
+		print_error "Post-release deployment gate cannot materialize active source ${active_sha:0:12} for exact verification"
+		verify_exit=1
+	elif ! verify_aidevops_runtime_bundle_convergence \
+		"$verify_repo" \
+		"$active_sha" \
+		"$active_link" \
+		"$stamp_file"; then
+		verify_exit=1
+	fi
+	if ! rm -rf "$verify_root"; then
+		print_error "Post-release deployment gate could not remove the active-source verification workspace"
+		return 1
+	fi
+	[[ "$verify_exit" -eq 0 ]] || return 1
+
+	_AIDEVOPS_RELEASE_ACTIVE_PRESERVATION_SHA="$active_sha"
+	return 2
+}
+
 run_post_release_agent_sync() {
 	local sync_repo_root="${AIDEVOPS_SYNC_REPO_ROOT:-$REPO_ROOT}"
 	local remote_url
 	local release_sha=""
+	local active_preservation_exit=0
 	remote_url=$(git -C "$sync_repo_root" remote get-url origin 2>/dev/null || echo "")
 
 	if [[ "$remote_url" != *"marcusquinn/aidevops"* ]]; then
@@ -570,6 +657,19 @@ run_post_release_agent_sync() {
 		print_error "Post-release deployment gate cannot resolve the release checkout commit"
 		return 1
 	}
+	_verify_active_release_preservation_merge \
+		"$sync_repo_root" \
+		"$release_sha" \
+		"$HOME/.aidevops/agents" \
+		"$HOME/.aidevops/.deployed-sha" || active_preservation_exit=$?
+	if [[ "$active_preservation_exit" -eq 2 ]]; then
+		print_success "Post-release aidevops runtime already contains release ${release_sha:0:12} through validated preservation merge ${_AIDEVOPS_RELEASE_ACTIVE_PRESERVATION_SHA:0:12} (verified no-op)"
+		return 0
+	fi
+	if [[ "$active_preservation_exit" -ne 0 ]]; then
+		print_error "Post-release deployment gate could not verify the active runtime before deployment"
+		return 1
+	fi
 	deploy_args+=(--expected-sha "$release_sha")
 
 	print_info "Running post-release aidevops agent sync..."


### PR DESCRIPTION
## Summary

Detect an already-active validated preservation merge before release deployment, require signed-release ancestry plus identical Git trees, and reuse the exact runtime bundle verifier against the active commit before returning a no-op. Add fail-closed regressions for changed trees, unrelated commits, malformed manifests, stale stamps, and stale sentinels.

## Files Changed

.agents/scripts/tests/test-agent-auto-sync.sh, .agents/scripts/version-manager-release.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — bash .agents/scripts/tests/test-agent-auto-sync.sh (23/23); shellcheck .agents/scripts/version-manager-release.sh .agents/scripts/tests/test-agent-auto-sync.sh; .agents/scripts/linters-local.sh; review evidence b40d2a92eb5581a596146c32c3b3ddc6288054ba514b91151707110c86af955d

Resolves #29562


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.226 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 9m and 108,613 tokens on this with the user in an interactive session.