### PR TITLE
GH#29582: Accept successful stale release runs

### DIFF
--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -472,7 +472,11 @@ _full_loop_release_verify_stale_publication_run() {
 	run_conclusion=$(jq -er --arg string_type "$_FULL_LOOP_RELEASE_JSON_STRING_TYPE" \
 		'.conclusion | select(type == $string_type)' \
 		<<<"$_FULL_LOOP_RELEASE_RUN_JSON") || return 1
-	[[ "$run_status" == "$_FULL_LOOP_RELEASE_STATUS_COMPLETED" && "$run_conclusion" == "$_FULL_LOOP_RELEASE_CONCLUSION_FAILURE" ]] || return 1
+	[[ "$run_status" == "$_FULL_LOOP_RELEASE_STATUS_COMPLETED" ]] || return 1
+	if [[ "$run_conclusion" == "$_FULL_LOOP_RELEASE_CONCLUSION_SUCCESS" ]]; then
+		return 0
+	fi
+	[[ "$run_conclusion" == "$_FULL_LOOP_RELEASE_CONCLUSION_FAILURE" ]] || return 1
 	_full_loop_release_fetch_run_jobs "$repo" "$run_id" || return 1
 	_full_loop_release_stale_publication_jobs_valid "$_FULL_LOOP_RELEASE_RUN_JOBS_JSON"
 	return $?

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -73,6 +73,61 @@ if _full_loop_release_run_jobs_payload_valid \
 fi
 printf 'PASS stale publication proof requires exact successful channels and sole postflight failure\n'
 
+run_stale_publication_verification_fixture() {
+	local mode="$1"
+	(
+		_full_loop_release_find_workflow_run() {
+			local repo="$1"
+			local tag_name="$2"
+			local tag_commit="$3"
+			[[ "$repo" == "test/repo" && "$tag_name" == "v1.2.3" && "$tag_commit" == "$(printf '%040d' 3)" ]] || return 1
+			case "$mode" in
+			success)
+				_FULL_LOOP_RELEASE_RUN_JSON='{"id":101,"status":"completed","conclusion":"success"}'
+				;;
+			partial-failure | other-failure)
+				_FULL_LOOP_RELEASE_RUN_JSON='{"id":101,"status":"completed","conclusion":"failure"}'
+				;;
+			pending)
+				_FULL_LOOP_RELEASE_RUN_JSON='{"id":101,"status":"in_progress","conclusion":"success"}'
+				;;
+			cancelled)
+				_FULL_LOOP_RELEASE_RUN_JSON='{"id":101,"status":"completed","conclusion":"cancelled"}'
+				;;
+			*) return 1 ;;
+			esac
+			return 0
+		}
+		_full_loop_release_fetch_run_jobs() {
+			local repo="$1"
+			local run_id="$2"
+			[[ "$repo" == "test/repo" && "$run_id" == "101" ]] || return 1
+			case "$mode" in
+			partial-failure) _FULL_LOOP_RELEASE_RUN_JOBS_JSON="$valid_stale_jobs" ;;
+			other-failure) _FULL_LOOP_RELEASE_RUN_JOBS_JSON=$(stale_publication_jobs_fixture extra-failure) || return 1 ;;
+			*) return 1 ;;
+			esac
+			return 0
+		}
+		_full_loop_release_verify_stale_publication_run test/repo v1.2.3 "$(printf '%040d' 3)"
+	)
+	return $?
+}
+
+for accepted_publication_mode in success partial-failure; do
+	if ! run_stale_publication_verification_fixture "$accepted_publication_mode"; then
+		printf 'FAIL %s publication run was rejected as stale-release evidence\n' "$accepted_publication_mode"
+		exit 1
+	fi
+done
+for rejected_publication_mode in pending cancelled other-failure; do
+	if run_stale_publication_verification_fixture "$rejected_publication_mode"; then
+		printf 'FAIL %s publication run was accepted as stale-release evidence\n' "$rejected_publication_mode"
+		exit 1
+	fi
+done
+printf 'PASS stale release evidence accepts successful publication and fails closed otherwise\n'
+
 _full_loop_release_tag_body() {
 	local tag_name="$1"
 	[[ "$tag_name" == "v1.2.3" ]] || return 1


### PR DESCRIPTION
## Summary

- accept an exactly correlated `completed/success` predecessor release workflow as valid stale-publication evidence
- retain exact job validation for recoverable `completed/failure` publication runs
- reject pending, cancelled, and unrelated failed runs

## Root cause

Release reconciliation found the exact predecessor workflow run but required it to have `conclusion=failure`. The fallback path only accepted the workflow lookup's no-run exit code, so a fully successful predecessor publication run could satisfy neither proof path.

For source PR #29547, this left the receipt at `failed` even though `v3.32.225` was published and the verified successor `v3.32.226` was already active.

## Verification

- `bash .agents/scripts/tests/test-full-loop-release-reconcile.sh`
- `bash .agents/scripts/tests/test-full-loop-release-helper.sh`
- `bash .agents/scripts/tests/test-aidevops-release-command.sh`
- `bash .agents/scripts/tests/test-release-provenance-helper.sh`
- `shellcheck .agents/scripts/full-loop-release-reconcile.sh .agents/scripts/tests/test-full-loop-release-reconcile.sh`
- `.agents/scripts/linters-local.sh`
- live `bash .agents/scripts/full-loop-release-helper.sh reconcile 29547` recorded `release:superseded source_tag=v3.32.225 successor_tag=v3.32.226`
- independent review bundle `cabfc80c4511380fb19d8c3bb7108543e386a030d913848557b244cf447114b8`: no actionable findings

## Risk controls

- only `completed/success` bypasses failed-run job inspection
- non-terminal and non-success/non-failure conclusions remain rejected
- failed workflows still require the exact successful publication channels and sole recoverable postflight failure

Resolves #29582
Ref #29547

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.226 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 20h 19m and 4,468,629 tokens on this with the user in an interactive session.