### PR TITLE
GH#29593: review asc-cli test isolation update

### DIFF
--- a/.agents/tools/mobile/app-store-connect.md
+++ b/.agents/tools/mobile/app-store-connect.md
@@ -27,7 +27,7 @@ tools:
 - **Project pin**: `asc init --app-id <id>` (saves `.asc/project.json`, auto-used by all commands)
 - **Verify**: `asc auth check` | **Multi-account**: `asc auth use <name>`
 - **Context resolution**: explicit `--app-id` > `.asc/project.json` > prompt user to `asc init` (CI must use `--app-id` or pre-run `asc init`)
-- **GitHub**: https://github.com/tddworks/asc-cli (MIT, Swift, 130+ commands; v0.18.2 adds Resolution Center rejection details and attachment downloads through cookie-authenticated iris APIs; checked at release commit `97a60af`)
+- **GitHub**: https://github.com/tddworks/asc-cli (MIT, Swift, 130+ commands; v0.18.2 adds Resolution Center rejection details and attachment downloads through cookie-authenticated iris APIs; reviewed through `030c463` — the post-release change only stabilizes upstream affordance-registry tests and does not alter CLI behavior)
 - **Website**: https://asccli.app | **Web apps**: [Command Center](https://asccli.app/command-center), [Console](https://asccli.app/console), [Screenshot Studio](https://asccli.app/editor)
 - **Skills**: [Official](https://github.com/tddworks/asc-cli-skills) (27 command-group skills, checked at `6465c10feb89`) | [Community](https://github.com/rorkai/app-store-connect-cli-skills) (23 workflow skills for the separate community CLI, checked at `53c60a4945e5`)
 - **Requirements**: macOS 13+, App Store Connect API key, `jq` (workflow scripts use `jq -r`)


### PR DESCRIPTION
## Summary

Review asc-cli through commit 030c463 and document that its post-v0.18.2 change only stabilizes upstream tests, so no CLI workflow adoption is required

## Files Changed

.agents/tools/mobile/app-store-connect.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Pre-commit quality validation passed; git diff --check passed; changed documentation line inspected against upstream commit metadata

Resolves #29593


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.226 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 4m and 82,325 tokens on this as a headless worker.