### PR TITLE
GH#29591: validate push task IDs through associated PRs

### DIFF
--- a/.agents/hooks/task-id-collision-guard.sh
+++ b/.agents/hooks/task-id-collision-guard.sh
@@ -645,7 +645,7 @@ _associated_pr_context() {
 		return 1
 	fi
 	gh api -X GET "repos/${repository}/commits/${commit_hash}/pulls" \
-		--jq '.[] | "\(.title)\n\n\(.body // \"\")"' 2>/dev/null
+		--jq '.[] | (.title + "\n\n" + (.body // ""))' 2>/dev/null
 	return $?
 }
 

--- a/.agents/hooks/task-id-collision-guard.sh
+++ b/.agents/hooks/task-id-collision-guard.sh
@@ -21,6 +21,11 @@
 #     Used by CI to catch commits authored outside the hook.
 #     Exits 0 (all clean) or 1 (one or more violations).
 #
+#   check-push <BEFORE_SHA> <AFTER_SHA>:
+#     Scans non-merge commits in a push and supplements squash commit messages
+#     with their associated PR title/body before checking linked issue proof.
+#     Exits 0 (all clean) or 1 (one or more violations).
+#
 # Environment:
 #   TASK_ID_GUARD_DISABLE=1   — bypass for this invocation (equivalent to --no-verify)
 #   TASK_ID_GUARD_DEBUG=1     — verbose stderr trace
@@ -507,7 +512,7 @@ _check_tid() {
 		return 2
 	fi
 	if [[ "$verify_rc" -eq 1 ]]; then
-		CHECK_MESSAGE_VIOLATION="  ${tid} — numeric ID ${num} > current counter ${counter}, and not confirmed via a linked issue title\n"
+		CHECK_MESSAGE_VIOLATION="  ${tid} — numeric ID ${num} > current counter ${counter}; no matching issue title was found via a commit footer or associated PR body\n"
 		return 1
 	fi
 	return 0
@@ -633,6 +638,70 @@ _pr_commit_oids() {
 	return $?
 }
 
+_associated_pr_context() {
+	local commit_hash="$1"
+	local repository="${GITHUB_REPOSITORY:-}"
+	if [[ -z "$repository" ]] || ! command -v gh >/dev/null 2>&1; then
+		return 1
+	fi
+	gh api -X GET "repos/${repository}/commits/${commit_hash}/pulls" \
+		--jq '.[] | "\(.title)\n\n\(.body // \"\")"' 2>/dev/null
+	return $?
+}
+
+_check_push_commit() {
+	local commit_hash="$1"
+	local commit_msg=""
+	local subject=""
+	local pr_context=""
+	commit_msg=$(git log -1 --format='%s%n%n%b' "$commit_hash" 2>/dev/null) || return 0
+	subject=$(git log -1 --format='%s' "$commit_hash" 2>/dev/null) || return 0
+	pr_context=$(_associated_pr_context "$commit_hash" || true)
+	if [[ -n "$pr_context" ]]; then
+		_debug "Adding associated PR context for push commit $commit_hash"
+		commit_msg="${commit_msg}"$'\n\n'"${pr_context}"
+	fi
+
+	local rc=0
+	_check_message "$commit_msg" "$subject" || rc=$?
+	if [[ "$rc" -eq 1 ]]; then
+		printf '[task-id-guard][VIOLATION] commit %s: %s\n' "$commit_hash" "$subject" >&2
+		return 1
+	fi
+	return 0
+}
+
+_run_check_push() {
+	local before_sha="${1:-}"
+	local after_sha="${2:-HEAD}"
+	local commits=""
+	if [[ -z "$before_sha" || "$before_sha" == "0000000000000000000000000000000000000000" ]]; then
+		commits=$(git rev-list --no-walk --no-merges "$after_sha" 2>/dev/null)
+	else
+		commits=$(git rev-list --no-merges "${before_sha}..${after_sha}" 2>/dev/null)
+	fi
+	if [[ -z "$commits" ]]; then
+		_info "No non-merge commits in push range — nothing to check"
+		return 0
+	fi
+
+	local total_violations=0
+	local commit_hash
+	while IFS= read -r commit_hash; do
+		[[ -z "$commit_hash" ]] && continue
+		if ! _check_push_commit "$commit_hash"; then
+			total_violations=$((total_violations + 1))
+		fi
+	done <<<"$commits"
+
+	if [[ "$total_violations" -gt 0 ]]; then
+		printf '\n[task-id-guard][SUMMARY] %d violation(s) found in push\n' "$total_violations" >&2
+		return 1
+	fi
+	_info "Push clean — no invented t-IDs detected"
+	return 0
+}
+
 _check_pr_title() {
 	local pr_number="$1"
 	if ! command -v gh >/dev/null 2>&1; then
@@ -753,6 +822,11 @@ main() {
 	check-pr)
 		shift
 		_run_check_pr "$@"
+		return $?
+		;;
+	check-push)
+		shift
+		_run_check_push "$@"
 		return $?
 		;;
 	help | --help | -h)

--- a/.agents/scripts/tests/test-task-id-collision-guard.sh
+++ b/.agents/scripts/tests/test-task-id-collision-guard.sh
@@ -1065,6 +1065,13 @@ test_check_push_associated_pr_issue_proof() {
 	cat >"${fake_bin}/gh" <<'GHEOF'
 #!/usr/bin/env bash
 if [[ "$1" == "api" ]]; then
+	found_jq=0
+	for arg in "$@"; do
+		if [[ "$arg" == '.[] | (.title + "\n\n" + (.body // ""))' ]]; then
+			found_jq=1
+		fi
+	done
+	[[ "$found_jq" == "1" ]] || exit 1
 	printf 't99999: valid squashed change\n\nResolves #42\n'
 	exit 0
 fi

--- a/.agents/scripts/tests/test-task-id-collision-guard.sh
+++ b/.agents/scripts/tests/test-task-id-collision-guard.sh
@@ -4,7 +4,7 @@
 #
 # test-task-id-collision-guard.sh — Test harness for task-id-collision-guard.sh
 #
-# Covers all 19 acceptance criteria cases:
+# Covers all acceptance criteria cases:
 #   1. Reject: t-ID > counter AND not in linked issue title
 #   2. Allow: t-ID ≤ counter (claimed)
 #   3. Allow: cross-reference confirmed via linked issue title
@@ -24,6 +24,8 @@
 #  17. Allow: subagent/library name with t<digits> substring not extracted as t-ID (GH#21402 / t2993)
 #  18. Allow: multiple product names with embedded t<digits> cause no false positives (GH#21402 / t2993)
 #  19. Allow: cached branch-subject range claim is read even when it is the final line (GH#22558)
+#  22. Allow: push squash commit uses its associated PR body as linked-issue proof (GH#29591)
+#  23. Reject: push commit above the counter without associated issue proof (GH#29591)
 
 set -u
 
@@ -1031,6 +1033,85 @@ test_check_pr_rejects_malformed_task_brief_path() {
 }
 
 # ---------------------------------------------------------------------------
+# Case 22: Allow — a push squash commit gets linked-issue proof from its PR body
+# ---------------------------------------------------------------------------
+test_check_push_associated_pr_issue_proof() {
+	local name="case-22: check-push allows squash commit validated by associated PR issue"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	local work_repo="${tmpdir}/work"
+	mkdir -p "$work_repo"
+	git -C "$work_repo" init -q -b main
+	git -C "$work_repo" config user.email "test@test.local"
+	git -C "$work_repo" config user.name "Test"
+	git -C "$work_repo" config commit.gpgsign false
+	git -C "$work_repo" config tag.gpgsign false
+	printf '100' >"${work_repo}/.task-counter"
+	git -C "$work_repo" add .task-counter
+	git -C "$work_repo" commit -q -m "init: counter=100"
+	local before_sha
+	before_sha=$(git -C "$work_repo" rev-parse HEAD)
+	printf 'change' >"${work_repo}/change.txt"
+	git -C "$work_repo" add change.txt
+	git -C "$work_repo" commit -q -m "t99999: valid squashed change"
+	local after_sha
+	after_sha=$(git -C "$work_repo" rev-parse HEAD)
+
+	local fake_bin="${tmpdir}/bin"
+	mkdir -p "$fake_bin"
+	cat >"${fake_bin}/gh" <<'GHEOF'
+#!/usr/bin/env bash
+if [[ "$1" == "api" ]]; then
+	printf 't99999: valid squashed change\n\nResolves #42\n'
+	exit 0
+fi
+if [[ "$1" == "issue" && "$2" == "view" ]]; then
+	printf 't99999: claimed task\n'
+	exit 0
+fi
+exit 1
+GHEOF
+	chmod +x "${fake_bin}/gh"
+
+	local rc=0
+	PATH="${fake_bin}:$PATH" \
+		GITHUB_REPOSITORY="example/repo" \
+		GIT_DIR="${work_repo}/.git" \
+		GIT_WORK_TREE="$work_repo" \
+		bash "$GUARD" check-push "$before_sha" "$after_sha" 2>/dev/null || rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exit 0 (associated PR body links matching issue), got $rc"
+	fi
+
+	name="case-23: check-push rejects commit without associated PR issue proof"
+	cat >"${fake_bin}/gh" <<'GHEOF'
+#!/usr/bin/env bash
+if [[ "$1" == "api" ]]; then
+	exit 0
+fi
+exit 1
+GHEOF
+	chmod +x "${fake_bin}/gh"
+	rc=0
+	PATH="${fake_bin}:$PATH" \
+		GITHUB_REPOSITORY="example/repo" \
+		GIT_DIR="${work_repo}/.git" \
+		GIT_WORK_TREE="$work_repo" \
+		bash "$GUARD" check-push "$before_sha" "$after_sha" 2>/dev/null || rc=$?
+	if [[ "$rc" -eq 1 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exit 1 (no associated issue proof), got $rc"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 main() {
@@ -1057,6 +1138,7 @@ main() {
 	test_no_false_positive_multiple_subagent_names
 	test_check_pr_allows_canonical_task_brief_path
 	test_check_pr_rejects_malformed_task_brief_path
+	test_check_push_associated_pr_issue_proof
 
 	printf '\n'
 	printf 'Results: %s passed, %s failed\n' "$PASS" "$FAIL"

--- a/.github/workflows/task-id-collision-check.yml
+++ b/.github/workflows/task-id-collision-check.yml
@@ -5,7 +5,7 @@ name: Task-ID Collision Check
 # --no-verify bypasses) on push and pull_request events.
 #
 # The hook (client-side) and this workflow (server-side) implement the same
-# logic via task-id-collision-guard.sh check-pr <PR_NUMBER>.
+# logic via task-id-collision-guard.sh check-pr/check-push modes.
 
 on:
   push:
@@ -71,40 +71,8 @@ jobs:
             echo "Running check-pr for PR #${PR_NUMBER}"
             bash "$GUARD" check-pr "$PR_NUMBER"
           else
-            # Push event: check commits in the push range
             BEFORE="${{ github.event.before }}"
             AFTER="${{ github.event.after }}"
-            if [[ -z "$BEFORE" || "$BEFORE" == "0000000000000000000000000000000000000000" ]]; then
-              echo "New branch push — checking HEAD only"
-              MSG_FILE=$(mktemp)
-              git log -1 --format='%s%n%n%b' > "$MSG_FILE"
-              bash "$GUARD" "$MSG_FILE"
-              rm -f "$MSG_FILE"
-            else
-              echo "Push range: ${BEFORE}..${AFTER}"
-              violations=0
-              while IFS= read -r commit_hash; do
-                [[ -z "$commit_hash" ]] && continue
-                subject=$(git log -1 --format='%s' "$commit_hash")
-                # Skip merge commits
-                if echo "$subject" | grep -qE '^(Merge|fixup!|squash!)'; then
-                  continue
-                fi
-                MSG_FILE=$(mktemp)
-                git log -1 --format='%s%n%n%b' "$commit_hash" > "$MSG_FILE"
-                if ! bash "$GUARD" "$MSG_FILE" 2>&1; then
-                  echo "[task-id-guard][VIOLATION] commit $commit_hash: $subject"
-                  violations=$((violations + 1))
-                fi
-                rm -f "$MSG_FILE"
-              done < <(git rev-list "${BEFORE}..${AFTER}" 2>/dev/null)
-              if [[ "$violations" -gt 0 ]]; then
-                echo ""
-                echo "[task-id-guard][SUMMARY] $violations violation(s) found in push"
-                echo ""
-                echo "Fix: use claim-task-id.sh to allocate t-IDs before using them in commit subjects."
-                exit 1
-              fi
-              echo "[task-id-guard] Push clean — no invented t-IDs detected"
-            fi
+            echo "Push range: ${BEFORE}..${AFTER}"
+            bash "$GUARD" check-push "$BEFORE" "$AFTER"
           fi


### PR DESCRIPTION
## Summary

Resolve push-time task-ID proof from the associated PR title and body while preserving fail-closed behavior for unclaimed IDs.

## Files Changed

.agents/hooks/task-id-collision-guard.sh, .agents/scripts/tests/test-task-id-collision-guard.sh, .github/workflows/task-id-collision-check.yml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 23 task-ID guard tests and 8 reuse tests passed; ShellCheck and workflow YAML validation passed. aidevops check-workflows ran and reported unrelated repository workflow drift.

Resolves #29591


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.226 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 9m and 99,312 tokens on this as a headless worker.