### PR TITLE
GH#29590: preserve post-merge verification results

### DIFF
--- a/.agents/scripts/post-merge-verify-report-helper.sh
+++ b/.agents/scripts/post-merge-verify-report-helper.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+usage() {
+	printf 'Usage: post-merge-verify-report-helper.sh publish-comment <repo> <pr-number> <body-file>\n'
+	return 0
+}
+
+publish_comment() {
+	local repo="$1"
+	local pr_number="$2"
+	local body_file="$3"
+	local body=""
+
+	if [[ ! -f "$body_file" ]]; then
+		printf 'ERROR: report body file not found: %s\n' "$body_file" >&2
+		return 2
+	fi
+
+	body=$(<"$body_file")
+	if gh api --method POST "repos/${repo}/issues/${pr_number}/comments" -f body="$body" >/dev/null; then
+		printf 'Post-merge verification comment published through the REST issues endpoint.\n'
+		return 0
+	fi
+
+	printf '::warning::Unable to publish the post-merge verification comment. The check summary preserves the result; verify GH_TOKEN and issues:write permission.\n' >&2
+	if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+		# shellcheck disable=SC2016 # Markdown code spans are intentionally literal.
+		printf '\n> Warning: PR comment publication failed. The verification result above remains authoritative; check `GH_TOKEN` and `issues: write`.\n' >>"$GITHUB_STEP_SUMMARY"
+	fi
+	return 0
+}
+
+main() {
+	local command="${1:-help}"
+	local repo="${2:-}"
+	local pr_number="${3:-}"
+	local body_file="${4:-}"
+
+	case "$command" in
+	publish-comment)
+		if [[ -z "$repo" || -z "$pr_number" || -z "$body_file" ]]; then
+			usage
+			return 2
+		fi
+		publish_comment "$repo" "$pr_number" "$body_file"
+		return $?
+		;;
+	help | --help | -h)
+		usage
+		return 0
+		;;
+	*)
+		usage
+		return 2
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-post-merge-verify-report.sh
+++ b/.agents/scripts/tests/test-post-merge-verify-report.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${TEST_DIR}/../post-merge-verify-report-helper.sh"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+pass() {
+	local label="$1"
+	PASS=$((PASS + 1))
+	printf 'PASS: %s\n' "$label"
+	return 0
+}
+
+fail() {
+	local label="$1"
+	local detail="$2"
+	FAIL=$((FAIL + 1))
+	printf 'FAIL: %s — %s\n' "$label" "$detail"
+	return 0
+}
+
+cat >"$TMPDIR/body.md" <<'BODY'
+## Post-Merge Brief Verification
+
+Underlying verification result.
+BODY
+
+cat >"$TMPDIR/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$GH_CALL_LOG"
+if [[ "${GH_STUB_FAIL:-0}" == "1" ]]; then
+	printf 'Resource not accessible by integration\n' >&2
+	exit 1
+fi
+exit 0
+STUB
+chmod +x "$TMPDIR/gh"
+export PATH="$TMPDIR:$PATH"
+export GH_CALL_LOG="$TMPDIR/gh-calls.log"
+
+output=$(bash "$HELPER" publish-comment owner/repo 123 "$TMPDIR/body.md" 2>&1)
+rc=$?
+if [[ $rc -eq 0 ]] && grep -qF -- '--method POST repos/owner/repo/issues/123/comments' "$GH_CALL_LOG"; then
+	pass "PR comments use the REST issues endpoint"
+else
+	fail "REST comment publication" "rc=$rc output=$output"
+fi
+
+export GH_STUB_FAIL=1
+export GITHUB_STEP_SUMMARY="$TMPDIR/step-summary.md"
+printf 'Underlying verification result\n' >"$GITHUB_STEP_SUMMARY"
+output=$(bash "$HELPER" publish-comment owner/repo 123 "$TMPDIR/body.md" 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$output" == *"::warning::Unable to publish"* ]] && \
+	grep -qF 'Underlying verification result' "$GITHUB_STEP_SUMMARY" && \
+	grep -qF 'PR comment publication failed' "$GITHUB_STEP_SUMMARY"; then
+	pass "comment permission failure is fail-soft and preserves the check summary"
+else
+	fail "comment permission fallback" "rc=$rc output=$output summary=$(<"$GITHUB_STEP_SUMMARY")"
+fi
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/scripts/tests/test-verify-brief.sh
+++ b/.agents/scripts/tests/test-verify-brief.sh
@@ -558,6 +558,60 @@ BRIEF
 done
 
 # =============================================================================
+# Class H: verify execution preserves auth and classifies infrastructure
+# =============================================================================
+
+printf '\n%sClass H: verify execution infrastructure classification%s\n' "$TEST_BLUE" "$TEST_NC"
+
+cat >"$TMP/brief-gh-token.md" <<'BRIEF'
+```yaml
+verify:
+  method: bash
+  run: '[[ "$GH_TOKEN" == "workflow-token" ]]'
+```
+BRIEF
+
+output=$(GH_TOKEN=workflow-token bash "$VB_HELPER" verify "$TMP/brief-gh-token.md" 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$output" == *"PASS  [1]"* ]]; then
+	pass "H1 workflow GH_TOKEN is inherited by verify blocks"
+else
+	fail "H1 verify block auth context" "expected rc=0 and PASS, got rc=$rc; output: $output"
+fi
+
+cat >"$TMP/brief-gh-auth-failure.md" <<'BRIEF'
+```yaml
+verify:
+  method: bash
+  run: 'printf "gh CLI cannot authenticate an API request. Run: gh auth login\n" >&2; exit 1'
+```
+BRIEF
+
+output=$(bash "$VB_HELPER" verify "$TMP/brief-gh-auth-failure.md" 2>&1)
+rc=$?
+if [[ $rc -eq 3 && "$output" == *"INFRA [1]"* && "$output" == *"Infrastructure: 1"* ]]; then
+	pass "H2 missing gh auth is a typed infrastructure failure"
+else
+	fail "H2 gh auth infrastructure classification" "expected rc=3 and INFRA summary, got rc=$rc; output: $output"
+fi
+
+cat >"$TMP/brief-criteria-failure.md" <<'BRIEF'
+```yaml
+verify:
+  method: bash
+  run: 'printf "acceptance criterion mismatch\n" >&2; exit 1'
+```
+BRIEF
+
+output=$(bash "$VB_HELPER" verify "$TMP/brief-criteria-failure.md" 2>&1)
+rc=$?
+if [[ $rc -eq 1 && "$output" == *"FAIL  [1]"* && "$output" == *"Infrastructure: 0"* ]]; then
+	pass "H3 acceptance failures remain distinct from infrastructure failures"
+else
+	fail "H3 acceptance failure classification" "expected rc=1 and FAIL summary, got rc=$rc; output: $output"
+fi
+
+# =============================================================================
 # Summary
 # =============================================================================
 

--- a/.agents/scripts/verify-brief-helper.sh
+++ b/.agents/scripts/verify-brief-helper.sh
@@ -13,6 +13,7 @@
 #   0 — all bash verify blocks passed (or no blocks found)
 #   1 — one or more bash verify blocks failed
 #   2 — usage error (missing args, file not found)
+#   3 — verification could not complete because of infrastructure failure
 
 set -euo pipefail
 
@@ -40,6 +41,22 @@ _log() {
 	local msg="$*"
 	printf '[%s] %s\n' "$level" "$msg" >&2
 	return 0
+}
+
+_is_infrastructure_failure() {
+	local exit_code="$1"
+	local output="$2"
+
+	if [[ "$exit_code" -eq 124 ]]; then
+		return 0
+	fi
+
+	if printf '%s\n' "$output" | grep -qiE \
+		'gh CLI cannot authenticate an API request|not logged into any GitHub hosts|HTTP 401|Bad credentials|could not resolve host|temporary failure in name resolution|network is unreachable'; then
+		return 0
+	fi
+
+	return 1
 }
 
 # ---------------------------------------------------------------------------
@@ -184,8 +201,10 @@ _cmd_verify() {
 	local total=0
 	local passed=0
 	local failed=0
+	local infrastructure_failed=0
 	local skipped=0
 	local fail_details=""
+	local infrastructure_details=""
 
 	while IFS=$'\t' read -r idx method value; do
 		total=$((total + 1))
@@ -218,6 +237,13 @@ _cmd_verify() {
 		if [[ $exit_code -eq 0 ]]; then
 			passed=$((passed + 1))
 			printf 'PASS  [%d]\n' "$idx"
+		elif _is_infrastructure_failure "$exit_code" "$output"; then
+			infrastructure_failed=$((infrastructure_failed + 1))
+			printf 'INFRA [%d] exit_code=%d — verification environment unavailable\n' "$idx" "$exit_code"
+			if [[ -n "$output" ]]; then
+				printf '  output: %s\n' "$output"
+			fi
+			infrastructure_details="${infrastructure_details}Block ${idx} (exit ${exit_code}): ${value}\n"
 		else
 			failed=$((failed + 1))
 			printf 'FAIL  [%d] exit_code=%d\n' "$idx" "$exit_code"
@@ -230,11 +256,18 @@ _cmd_verify() {
 
 	# Summary
 	printf '\n--- Summary ---\n'
-	printf 'Total: %d  Passed: %d  Failed: %d  Skipped: %d\n' "$total" "$passed" "$failed" "$skipped"
+	printf 'Total: %d  Passed: %d  Failed: %d  Infrastructure: %d  Skipped: %d\n' \
+		"$total" "$passed" "$failed" "$infrastructure_failed" "$skipped"
 
 	if [[ $total -eq 0 ]]; then
 		_log "INFO" "No verify: blocks found — nothing to check"
 		return 0
+	fi
+
+	if [[ $infrastructure_failed -gt 0 ]]; then
+		printf '\nInfrastructure failures (retry with network access and authenticated gh):\n'
+		printf '%b' "$infrastructure_details"
+		return 3
 	fi
 
 	if [[ $failed -gt 0 ]]; then
@@ -418,8 +451,8 @@ main() {
 	if [[ "$command_status" -eq 0 ]]; then
 		return 0
 	fi
-	if [[ "$command_status" -eq 2 ]]; then
-		return 2
+	if [[ "$command_status" -eq 2 || "$command_status" -eq 3 ]]; then
+		return "$command_status"
 	fi
 	return 1
 }

--- a/.github/workflows/post-merge-verify.yml
+++ b/.github/workflows/post-merge-verify.yml
@@ -93,6 +93,9 @@ jobs:
         id: verify
         env:
           BRIEF_PATH: ${{ steps.brief.outputs.path }}
+          # Verify blocks may invoke gh-backed helpers, so propagate the
+          # permission-scoped workflow token into their shell context.
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set +e  # Capture exit code without failing the step
@@ -118,7 +121,7 @@ jobs:
       - name: Post PR comment with results
         if: steps.verify.outputs.exit_code != '' && steps.brief.outputs.exists == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           TASK_ID: ${{ steps.extract.outputs.task_id }}
           EXIT_CODE: ${{ steps.verify.outputs.exit_code }}
@@ -127,6 +130,8 @@ jobs:
         run: |
           if [[ "$EXIT_CODE" == "0" ]]; then
             STATUS="✅ All verify blocks passed"
+          elif [[ "$EXIT_CODE" == "3" ]]; then
+            STATUS="⚠️ Infrastructure failure prevented verification"
           else
             STATUS="❌ One or more verify blocks failed"
           fi
@@ -149,15 +154,21 @@ jobs:
           # Dedent the heredoc content
           COMMENT_BODY=$(echo "$COMMENT_BODY" | sed 's/^          //')
 
-          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$COMMENT_BODY"
+          REPORT_FILE="$RUNNER_TEMP/post-merge-verify-report.md"
+          printf '%s\n' "$COMMENT_BODY" > "$REPORT_FILE"
+          printf '%s\n' "$COMMENT_BODY" >> "$GITHUB_STEP_SUMMARY"
+
+          chmod +x .agents/scripts/post-merge-verify-report-helper.sh
+          .agents/scripts/post-merge-verify-report-helper.sh \
+            publish-comment "$REPO" "$PR_NUMBER" "$REPORT_FILE"
 
       # ---------------------------------------------------------------
       # Step 6: Create follow-up issue on failure
       # ---------------------------------------------------------------
       - name: Create follow-up issue on failure
-        if: steps.verify.outputs.exit_code != '0' && steps.verify.outputs.exit_code != ''
+        if: steps.verify.outputs.exit_code == '1'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TASK_ID: ${{ steps.extract.outputs.task_id }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           VERIFY_OUTPUT: ${{ steps.verify.outputs.output }}
@@ -192,3 +203,24 @@ jobs:
             --title "$TITLE" \
             --body "$BODY" \
             --label "quality-debt"
+
+      # Comment publication is deliberately fail-soft. This final step exposes
+      # the original typed verification outcome as the workflow conclusion.
+      - name: Finalize verification result
+        if: always() && steps.verify.outputs.exit_code != ''
+        env:
+          EXIT_CODE: ${{ steps.verify.outputs.exit_code }}
+        run: |
+          case "$EXIT_CODE" in
+            0)
+              exit 0
+              ;;
+            1)
+              echo "::error::Brief acceptance-criteria verification failed."
+              exit 1
+              ;;
+            *)
+              echo "::error::Brief verification infrastructure failed (exit code ${EXIT_CODE}); retry with an authenticated GitHub context."
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
## Summary

Authenticated gh-backed verify blocks, typed infrastructure failures, and fail-soft REST comment reporting with check-summary preservation.

## Files Changed

.agents/scripts/post-merge-verify-report-helper.sh, .agents/scripts/tests/test-post-merge-verify-report.sh, .agents/scripts/tests/test-verify-brief.sh, .agents/scripts/verify-brief-helper.sh, .github/workflows/post-merge-verify.yml

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified with stubbed GitHub API success and permission-failure paths; 33 verify-brief tests, 2 report tests, 7 close-verification tests, issue-sync auth capability test, ShellCheck, workflow YAML validation

Resolves #29590


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.226 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 10m and 135,574 tokens on this as a headless worker.