### PR TITLE
GH#29590: preserve post-merge verification results

### DIFF
--- a/.agents/scripts/post-merge-verify-report-helper.sh
+++ b/.agents/scripts/post-merge-verify-report-helper.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+usage() {
+	printf 'Usage:\n'
+	printf '  post-merge-verify-report-helper.sh truncate-output <output-file> <max-bytes>\n'
+	printf '  post-merge-verify-report-helper.sh publish-comment <repo> <pr-number> <body-file>\n'
+	return 0
+}
+
+truncate_output() {
+	local output_file="$1"
+	local max_bytes="$2"
+	local output_size=0
+	local truncated_file=""
+
+	if [[ ! -f "$output_file" || ! "$max_bytes" =~ ^[1-9][0-9]*$ ]]; then
+		printf 'ERROR: truncate-output requires an existing file and positive byte limit.\n' >&2
+		return 2
+	fi
+
+	output_size=$(wc -c <"$output_file")
+	if [[ "$output_size" -le "$max_bytes" ]]; then
+		return 0
+	fi
+
+	truncated_file="${output_file}.truncated.$$"
+	if ! dd if="$output_file" of="$truncated_file" bs="$max_bytes" count=1 2>/dev/null; then
+		rm -f "$truncated_file"
+		printf 'ERROR: could not truncate verification output.\n' >&2
+		return 1
+	fi
+	printf '\n[output truncated from %s bytes to %s bytes]\n' "$output_size" "$max_bytes" >>"$truncated_file"
+	mv "$truncated_file" "$output_file"
+	return 0
+}
+
+publish_comment() {
+	local repo="$1"
+	local pr_number="$2"
+	local body_file="$3"
+	local body=""
+
+	if [[ ! -f "$body_file" ]]; then
+		printf 'ERROR: report body file not found: %s\n' "$body_file" >&2
+		return 2
+	fi
+
+	body=$(<"$body_file")
+	if gh api --method POST "repos/${repo}/issues/${pr_number}/comments" -f body="$body" >/dev/null; then
+		printf 'Post-merge verification comment published through the REST issues endpoint.\n'
+		return 0
+	fi
+
+	printf '::warning::Unable to publish the post-merge verification comment. The check summary preserves the result; verify GH_TOKEN and issues:write permission.\n' >&2
+	if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+		# shellcheck disable=SC2016 # Markdown code spans are intentionally literal.
+		printf '\n> Warning: PR comment publication failed. The verification result above remains authoritative; check `GH_TOKEN` and `issues: write`.\n' >>"$GITHUB_STEP_SUMMARY"
+	fi
+	return 0
+}
+
+main() {
+	local command="${1:-help}"
+	local repo="${2:-}"
+	local pr_number="${3:-}"
+	local body_file="${4:-}"
+
+	case "$command" in
+	truncate-output)
+		truncate_output "$repo" "$pr_number"
+		return $?
+		;;
+	publish-comment)
+		if [[ -z "$repo" || -z "$pr_number" || -z "$body_file" ]]; then
+			usage
+			return 2
+		fi
+		publish_comment "$repo" "$pr_number" "$body_file"
+		return $?
+		;;
+	help | --help | -h)
+		usage
+		return 0
+		;;
+	*)
+		usage
+		return 2
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-post-merge-verify-report.sh
+++ b/.agents/scripts/tests/test-post-merge-verify-report.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${TEST_DIR}/../post-merge-verify-report-helper.sh"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+pass() {
+	local label="$1"
+	PASS=$((PASS + 1))
+	printf 'PASS: %s\n' "$label"
+	return 0
+}
+
+fail() {
+	local label="$1"
+	local detail="$2"
+	FAIL=$((FAIL + 1))
+	printf 'FAIL: %s — %s\n' "$label" "$detail"
+	return 0
+}
+
+cat >"$TMPDIR/body.md" <<'BODY'
+## Post-Merge Brief Verification
+
+Underlying verification result.
+BODY
+
+cat >"$TMPDIR/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$GH_CALL_LOG"
+if [[ "${GH_STUB_FAIL:-0}" == "1" ]]; then
+	printf 'Resource not accessible by integration\n' >&2
+	exit 1
+fi
+exit 0
+STUB
+chmod +x "$TMPDIR/gh"
+export PATH="$TMPDIR:$PATH"
+export GH_CALL_LOG="$TMPDIR/gh-calls.log"
+
+output=$(bash "$HELPER" publish-comment owner/repo 123 "$TMPDIR/body.md" 2>&1)
+rc=$?
+if [[ $rc -eq 0 ]] && grep -qF -- '--method POST repos/owner/repo/issues/123/comments' "$GH_CALL_LOG"; then
+	pass "PR comments use the REST issues endpoint"
+else
+	fail "REST comment publication" "rc=$rc output=$output"
+fi
+
+export GH_STUB_FAIL=1
+export GITHUB_STEP_SUMMARY="$TMPDIR/step-summary.md"
+printf 'Underlying verification result\n' >"$GITHUB_STEP_SUMMARY"
+output=$(bash "$HELPER" publish-comment owner/repo 123 "$TMPDIR/body.md" 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$output" == *"::warning::Unable to publish"* ]] &&
+	grep -qF 'Underlying verification result' "$GITHUB_STEP_SUMMARY" &&
+	grep -qF 'PR comment publication failed' "$GITHUB_STEP_SUMMARY"; then
+	pass "comment permission failure is fail-soft and preserves the check summary"
+else
+	fail "comment permission fallback" "rc=$rc output=$output summary=$(<"$GITHUB_STEP_SUMMARY")"
+fi
+
+printf '%0100d' 0 >"$TMPDIR/large-output.txt"
+output=$(bash "$HELPER" truncate-output "$TMPDIR/large-output.txt" 20 2>&1)
+rc=$?
+truncated_size=$(wc -c <"$TMPDIR/large-output.txt")
+if [[ $rc -eq 0 && "$truncated_size" -lt 100 ]] &&
+	grep -qF '[output truncated from 100 bytes to 20 bytes]' "$TMPDIR/large-output.txt"; then
+	pass "verification output is bounded with an explicit truncation marker"
+else
+	fail "verification output truncation" "rc=$rc size=$truncated_size output=$output"
+fi
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/scripts/tests/test-verify-brief.sh
+++ b/.agents/scripts/tests/test-verify-brief.sh
@@ -558,6 +558,161 @@ BRIEF
 done
 
 # =============================================================================
+# Class H: verify execution preserves auth and classifies infrastructure
+# =============================================================================
+
+printf '\n%sClass H: verify execution infrastructure classification%s\n' "$TEST_BLUE" "$TEST_NC"
+
+cat >"$TMP/brief-gh-token.md" <<'BRIEF'
+```yaml
+verify:
+  method: bash
+  run: '[[ "$GH_TOKEN" == "workflow-token" ]]'
+```
+BRIEF
+
+output=$(GH_TOKEN=workflow-token bash "$VB_HELPER" verify "$TMP/brief-gh-token.md" 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$output" == *"PASS  [1]"* ]]; then
+	pass "H1 workflow GH_TOKEN is inherited by verify blocks"
+else
+	fail "H1 verify block auth context" "expected rc=0 and PASS, got rc=$rc; output: $output"
+fi
+
+cat >"$TMP/brief-gh-auth-failure.md" <<'BRIEF'
+```yaml
+verify:
+  method: bash
+  run: 'printf "gh CLI cannot authenticate an API request. Run: gh auth login\n" >&2; exit 1'
+```
+BRIEF
+
+output=$(bash "$VB_HELPER" verify "$TMP/brief-gh-auth-failure.md" 2>&1)
+rc=$?
+if [[ $rc -eq 3 && "$output" == *"INFRA [1]"* && "$output" == *"Infrastructure: 1"* ]]; then
+	pass "H2 missing gh auth is a typed infrastructure failure"
+else
+	fail "H2 gh auth infrastructure classification" "expected rc=3 and INFRA summary, got rc=$rc; output: $output"
+fi
+
+cat >"$TMP/brief-criteria-failure.md" <<'BRIEF'
+```yaml
+verify:
+  method: bash
+  run: 'printf "acceptance criterion mismatch\n" >&2; exit 1'
+```
+BRIEF
+
+output=$(bash "$VB_HELPER" verify "$TMP/brief-criteria-failure.md" 2>&1)
+rc=$?
+if [[ $rc -eq 1 && "$output" == *"FAIL  [1]"* && "$output" == *"Infrastructure: 0"* ]]; then
+	pass "H3 acceptance failures remain distinct from infrastructure failures"
+else
+	fail "H3 acceptance failure classification" "expected rc=1 and FAIL summary, got rc=$rc; output: $output"
+fi
+
+cat >"$TMP/brief-mixed-failures.md" <<'BRIEF'
+```yaml
+verify:
+  method: bash
+  run: 'printf "acceptance criterion mismatch\n" >&2; exit 1'
+```
+```yaml
+verify:
+  method: bash
+  run: 'printf "Resource not accessible by integration\n" >&2; exit 1'
+```
+BRIEF
+
+output=$(bash "$VB_HELPER" verify "$TMP/brief-mixed-failures.md" 2>&1)
+rc=$?
+if [[ $rc -eq 1 && "$output" == *"Failed: 1"* && "$output" == *"Infrastructure: 1"* ]]; then
+	pass "H4 acceptance failures take precedence while retaining infrastructure evidence"
+else
+	fail "H4 mixed failure classification" "expected rc=1 with both failure classes, got rc=$rc; output: $output"
+fi
+
+cat >"$TMP/brief-exit-124.md" <<'BRIEF'
+```yaml
+verify:
+  method: bash
+  run: 'exit 124'
+```
+BRIEF
+
+output=$(bash "$VB_HELPER" verify "$TMP/brief-exit-124.md" 2>&1)
+rc=$?
+if [[ $rc -eq 1 && "$output" == *"FAIL  [1] exit_code=124"* ]]; then
+	pass "H5 exit 124 alone remains an acceptance failure"
+else
+	fail "H5 exit 124 classification" "expected rc=1 and FAIL, got rc=$rc; output: $output"
+fi
+
+cat >"$TMP/brief-integration-permission.md" <<'BRIEF'
+```yaml
+verify:
+  method: bash
+  run: 'printf "Resource not accessible by integration\n" >&2; exit 1'
+```
+BRIEF
+
+output=$(bash "$VB_HELPER" verify "$TMP/brief-integration-permission.md" 2>&1)
+rc=$?
+if [[ $rc -eq 3 && "$output" == *"INFRA [1]"* ]]; then
+	pass "H6 GitHub integration permission failures are infrastructure"
+else
+	fail "H6 integration permission classification" "expected rc=3 and INFRA, got rc=$rc; output: $output"
+fi
+
+cat >"$TMP/brief-application-403.md" <<'BRIEF'
+```yaml
+verify:
+  method: bash
+  run: 'printf "application returned HTTP 403\n" >&2; exit 1'
+```
+BRIEF
+
+output=$(bash "$VB_HELPER" verify "$TMP/brief-application-403.md" 2>&1)
+rc=$?
+if [[ $rc -eq 1 && "$output" == *"FAIL  [1]"* ]]; then
+	pass "H7 application HTTP 403 remains an acceptance failure"
+else
+	fail "H7 application 403 classification" "expected rc=1 and FAIL, got rc=$rc; output: $output"
+fi
+
+cat >"$TMP/brief-application-credentials.md" <<'BRIEF'
+```yaml
+verify:
+  method: bash
+  run: 'printf "Bad credentials\n" >&2; exit 1'
+```
+BRIEF
+
+output=$(bash "$VB_HELPER" verify "$TMP/brief-application-credentials.md" 2>&1)
+rc=$?
+if [[ $rc -eq 1 && "$output" == *"FAIL  [1]"* ]]; then
+	pass "H8 application credential failures remain acceptance failures"
+else
+	fail "H8 application credential classification" "expected rc=1 and FAIL, got rc=$rc; output: $output"
+fi
+
+cat >"$TMP/brief-token-output.md" <<'BRIEF'
+```yaml
+verify:
+  method: bash
+  run: 'printf "%s\n" "$GH_TOKEN" >&2; exit 1'
+```
+BRIEF
+
+output=$(GH_TOKEN=workflow-secret-token bash "$VB_HELPER" verify "$TMP/brief-token-output.md" 2>&1)
+rc=$?
+if [[ $rc -eq 1 && "$output" == *"[REDACTED]"* && "$output" != *"workflow-secret-token"* ]]; then
+	pass "H9 verify output redacts the inherited GitHub token"
+else
+	fail "H9 GitHub token redaction" "expected redacted output, got rc=$rc; output: $output"
+fi
+
+# =============================================================================
 # Summary
 # =============================================================================
 

--- a/.agents/scripts/verify-brief-helper.sh
+++ b/.agents/scripts/verify-brief-helper.sh
@@ -13,6 +13,7 @@
 #   0 — all bash verify blocks passed (or no blocks found)
 #   1 — one or more bash verify blocks failed
 #   2 — usage error (missing args, file not found)
+#   3 — verification could not complete because of infrastructure failure
 
 set -euo pipefail
 
@@ -39,6 +40,30 @@ _log() {
 	shift
 	local msg="$*"
 	printf '[%s] %s\n' "$level" "$msg" >&2
+	return 0
+}
+
+_is_infrastructure_failure() {
+	local output="$1"
+
+	if printf '%s\n' "$output" | grep -qiE \
+		'gh CLI cannot authenticate an API request|not logged into any GitHub hosts|gh: Bad credentials|GraphQL: Bad credentials|Resource not accessible by integration|could not resolve host|temporary failure in name resolution|network is unreachable'; then
+		return 0
+	fi
+
+	return 1
+}
+
+_redact_auth_tokens() {
+	local output="$1"
+	local token=""
+
+	for token in "${GH_TOKEN:-}" "${GITHUB_TOKEN:-}"; do
+		if [[ -n "$token" ]]; then
+			output="${output//"$token"/[REDACTED]}"
+		fi
+	done
+	printf '%s' "$output"
 	return 0
 }
 
@@ -184,8 +209,10 @@ _cmd_verify() {
 	local total=0
 	local passed=0
 	local failed=0
+	local infrastructure_failed=0
 	local skipped=0
 	local fail_details=""
+	local infrastructure_details=""
 
 	while IFS=$'\t' read -r idx method value; do
 		total=$((total + 1))
@@ -214,10 +241,18 @@ _cmd_verify() {
 		local exit_code=0
 		local output=""
 		output=$(timeout 120 bash -c "$value" 2>&1) || exit_code=$?
+		output=$(_redact_auth_tokens "$output")
 
 		if [[ $exit_code -eq 0 ]]; then
 			passed=$((passed + 1))
 			printf 'PASS  [%d]\n' "$idx"
+		elif _is_infrastructure_failure "$output"; then
+			infrastructure_failed=$((infrastructure_failed + 1))
+			printf 'INFRA [%d] exit_code=%d — verification environment unavailable\n' "$idx" "$exit_code"
+			if [[ -n "$output" ]]; then
+				printf '  output: %s\n' "$output"
+			fi
+			infrastructure_details="${infrastructure_details}Block ${idx} (exit ${exit_code}): ${value}\n"
 		else
 			failed=$((failed + 1))
 			printf 'FAIL  [%d] exit_code=%d\n' "$idx" "$exit_code"
@@ -230,7 +265,8 @@ _cmd_verify() {
 
 	# Summary
 	printf '\n--- Summary ---\n'
-	printf 'Total: %d  Passed: %d  Failed: %d  Skipped: %d\n' "$total" "$passed" "$failed" "$skipped"
+	printf 'Total: %d  Passed: %d  Failed: %d  Infrastructure: %d  Skipped: %d\n' \
+		"$total" "$passed" "$failed" "$infrastructure_failed" "$skipped"
 
 	if [[ $total -eq 0 ]]; then
 		_log "INFO" "No verify: blocks found — nothing to check"
@@ -240,7 +276,19 @@ _cmd_verify() {
 	if [[ $failed -gt 0 ]]; then
 		printf '\nFailed blocks:\n'
 		printf '%b' "$fail_details"
+	fi
+
+	if [[ $infrastructure_failed -gt 0 ]]; then
+		printf '\nInfrastructure failures (retry with network access and authenticated gh):\n'
+		printf '%b' "$infrastructure_details"
+	fi
+
+	if [[ $failed -gt 0 ]]; then
 		return 1
+	fi
+
+	if [[ $infrastructure_failed -gt 0 ]]; then
+		return 3
 	fi
 
 	return 0
@@ -418,8 +466,8 @@ main() {
 	if [[ "$command_status" -eq 0 ]]; then
 		return 0
 	fi
-	if [[ "$command_status" -eq 2 ]]; then
-		return 2
+	if [[ "$command_status" -eq 2 || "$command_status" -eq 3 ]]; then
+		return "$command_status"
 	fi
 	return 1
 }

--- a/.github/workflows/post-merge-verify.yml
+++ b/.github/workflows/post-merge-verify.yml
@@ -93,40 +93,42 @@ jobs:
         id: verify
         env:
           BRIEF_PATH: ${{ steps.brief.outputs.path }}
+          # Verify blocks may invoke gh-backed helpers, so propagate the
+          # permission-scoped workflow token into their shell context.
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set +e  # Capture exit code without failing the step
           chmod +x .agents/scripts/verify-brief-helper.sh
-          .agents/scripts/verify-brief-helper.sh verify "$BRIEF_PATH" > /tmp/verify-output.txt 2>&1
+          VERIFY_OUTPUT_FILE="$RUNNER_TEMP/verify-output.txt"
+          .agents/scripts/verify-brief-helper.sh verify "$BRIEF_PATH" > "$VERIFY_OUTPUT_FILE" 2>&1
           EXIT_CODE=$?
           set -e
 
-          cat /tmp/verify-output.txt
+          # Bound content before logs, step summaries, comments, or issues use it.
+          bash .agents/scripts/post-merge-verify-report-helper.sh \
+            truncate-output "$VERIFY_OUTPUT_FILE" 60000
+          cat "$VERIFY_OUTPUT_FILE"
 
           echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
-
-          # Use heredoc delimiter for multiline output
-          {
-            echo 'output<<VERIFY_HEREDOC_EOF'
-            cat /tmp/verify-output.txt
-            echo 'VERIFY_HEREDOC_EOF'
-          } >> "$GITHUB_OUTPUT"
 
       # ---------------------------------------------------------------
       # Step 5: Post summary comment on the PR
       # ---------------------------------------------------------------
       - name: Post PR comment with results
-        if: steps.verify.outputs.exit_code != '' && steps.brief.outputs.exists == 'true'
+        if: always() && steps.verify.outputs.exit_code != '' && steps.brief.outputs.exists == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           TASK_ID: ${{ steps.extract.outputs.task_id }}
           EXIT_CODE: ${{ steps.verify.outputs.exit_code }}
-          VERIFY_OUTPUT: ${{ steps.verify.outputs.output }}
           REPO: ${{ github.repository }}
         run: |
+          VERIFY_OUTPUT=$(<"$RUNNER_TEMP/verify-output.txt")
           if [[ "$EXIT_CODE" == "0" ]]; then
             STATUS="✅ All verify blocks passed"
+          elif [[ "$EXIT_CODE" == "3" ]]; then
+            STATUS="⚠️ Infrastructure failure prevented verification"
           else
             STATUS="❌ One or more verify blocks failed"
           fi
@@ -149,20 +151,26 @@ jobs:
           # Dedent the heredoc content
           COMMENT_BODY=$(echo "$COMMENT_BODY" | sed 's/^          //')
 
-          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$COMMENT_BODY"
+          REPORT_FILE="$RUNNER_TEMP/post-merge-verify-report.md"
+          printf '%s\n' "$COMMENT_BODY" > "$REPORT_FILE"
+          printf '%s\n' "$COMMENT_BODY" >> "$GITHUB_STEP_SUMMARY"
+
+          chmod +x .agents/scripts/post-merge-verify-report-helper.sh
+          .agents/scripts/post-merge-verify-report-helper.sh \
+            publish-comment "$REPO" "$PR_NUMBER" "$REPORT_FILE"
 
       # ---------------------------------------------------------------
       # Step 6: Create follow-up issue on failure
       # ---------------------------------------------------------------
       - name: Create follow-up issue on failure
-        if: steps.verify.outputs.exit_code != '0' && steps.verify.outputs.exit_code != ''
+        if: always() && steps.verify.outputs.exit_code == '1'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TASK_ID: ${{ steps.extract.outputs.task_id }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          VERIFY_OUTPUT: ${{ steps.verify.outputs.output }}
           REPO: ${{ github.repository }}
         run: |
+          VERIFY_OUTPUT=$(<"$RUNNER_TEMP/verify-output.txt")
           TITLE="${TASK_ID}: post-merge brief verification failed"
 
           BODY="## Post-Merge Verification Failure
@@ -192,3 +200,24 @@ jobs:
             --title "$TITLE" \
             --body "$BODY" \
             --label "quality-debt"
+
+      # Comment publication is deliberately fail-soft. This final step exposes
+      # the original typed verification outcome as the workflow conclusion.
+      - name: Finalize verification result
+        if: always() && steps.verify.outputs.exit_code != ''
+        env:
+          EXIT_CODE: ${{ steps.verify.outputs.exit_code }}
+        run: |
+          case "$EXIT_CODE" in
+            0)
+              exit 0
+              ;;
+            1)
+              echo "::error::Brief acceptance-criteria verification failed."
+              exit 1
+              ;;
+            *)
+              echo "::error::Brief verification infrastructure failed (exit code ${EXIT_CODE}); retry with an authenticated GitHub context."
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
## Summary

Authenticated gh-backed verify blocks, typed mixed-outcome handling, token-redacted bounded output, and fail-soft REST comment reporting with check-summary preservation.

## Files Changed

.agents/scripts/post-merge-verify-report-helper.sh, .agents/scripts/tests/test-post-merge-verify-report.sh, .agents/scripts/tests/test-verify-brief.sh, .agents/scripts/verify-brief-helper.sh, .github/workflows/post-merge-verify.yml

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified with stubbed GitHub API success, permission-failure, redaction, truncation, and mixed-result paths; 39 verify-brief tests, 3 report tests, 7 close-verification tests, issue-sync auth capability test, ShellCheck, local linters, workflow YAML validation

Resolves #29590


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.226 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 32m and 202,083 tokens on this as a headless worker.