### PR TITLE
GH#29592: remove social provider similar-code regression

### DIFF
--- a/.agents/scripts/_knowledge_social_google_business_profile.py
+++ b/.agents/scripts/_knowledge_social_google_business_profile.py
@@ -5,14 +5,13 @@
 
 from __future__ import annotations
 
-import base64
-import json
 import re
 import sys
 from dataclasses import dataclass
 from typing import Any
 
 from _knowledge_social_collect import CursorState, PageCheckpoint
+from _knowledge_social_oauth_request import OAuthPageResponseCodec
 from knowledge_social_import import canonical_json, reject_credentials
 from knowledge_social_store import SocialStoreError
 
@@ -34,6 +33,11 @@ class GoogleBusinessProfileProviderUnavailableError(
 
 ADAPTER_ERROR = GoogleBusinessProfileAdapterError
 PROVIDER_UNAVAILABLE_ERROR = GoogleBusinessProfileProviderUnavailableError
+PAGE_CODEC = OAuthPageResponseCodec(
+    display_name="Google Business Profile",
+    cursor_prefix=CURSOR_PREFIX,
+    error_type=GoogleBusinessProfileAdapterError,
+)
 
 
 @dataclass(frozen=True)
@@ -110,35 +114,11 @@ def resource_id(value: Any, field: str, *, optional: bool = False) -> str | None
 
 
 def _encode_cursor(cursor: dict[str, Any]) -> str:
-    reject_credentials(cursor)
-    payload = canonical_json(cursor).encode("utf-8")
-    if len(payload) > 4096:
-        raise GoogleBusinessProfileAdapterError(
-            "Google Business Profile checkpoint exceeds the safety limit"
-        )
-    encoded = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
-    return f"{CURSOR_PREFIX}{encoded}"
+    return PAGE_CODEC.encode_cursor(cursor)
 
 
 def _decode_cursor(cursor: str) -> dict[str, Any]:
-    if not cursor.startswith(CURSOR_PREFIX):
-        raise GoogleBusinessProfileAdapterError(
-            "stored Google Business Profile cursor has an unsupported version"
-        )
-    encoded = cursor.removeprefix(CURSOR_PREFIX)
-    try:
-        padding = "=" * (-len(encoded) % 4)
-        parsed = json.loads(base64.urlsafe_b64decode(encoded + padding))
-    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
-        raise GoogleBusinessProfileAdapterError(
-            "stored Google Business Profile cursor is invalid"
-        ) from error
-    if not isinstance(parsed, dict):
-        raise GoogleBusinessProfileAdapterError(
-            "stored Google Business Profile cursor has an invalid shape"
-        )
-    reject_credentials(parsed)
-    return parsed
+    return PAGE_CODEC.decode_cursor(cursor)
 
 
 def page_request(
@@ -173,22 +153,12 @@ def page_request(
 
 def response_status(payload: dict[str, Any]) -> int:
     """Return a validated HTTP-like status from a provider response."""
-    status = payload.get("status", 200)
-    if isinstance(status, bool) or not isinstance(status, int):
-        raise GoogleBusinessProfileAdapterError(
-            "Google Business Profile response status must be an integer"
-        )
-    return status
+    return PAGE_CODEC.response_status(payload)
 
 
 def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
     """Return a validated sanitized record array."""
-    data = payload.get("data", [])
-    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
-        raise GoogleBusinessProfileAdapterError(
-            "Google Business Profile page data must be an array"
-        )
-    return data
+    return PAGE_CODEC.page_data(payload)
 
 
 def page_checkpoint(

--- a/.agents/scripts/_knowledge_social_oauth_request.py
+++ b/.agents/scripts/_knowledge_social_oauth_request.py
@@ -14,6 +14,62 @@ from knowledge_social_import import canonical_json, reject_credentials
 
 
 @dataclass(frozen=True)
+class OAuthPageResponseCodec:
+    """Validate the response envelope and opaque mapping cursor for one provider."""
+
+    display_name: str
+    cursor_prefix: str
+    error_type: type[Exception]
+    max_cursor_bytes: int = 4096
+
+    def encode_cursor(self, cursor: dict[str, Any]) -> str:
+        reject_credentials(cursor)
+        payload = canonical_json(cursor).encode("utf-8")
+        if len(payload) > self.max_cursor_bytes:
+            raise self.error_type(
+                f"{self.display_name} checkpoint exceeds the safety limit"
+            )
+        encoded = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+        return f"{self.cursor_prefix}{encoded}"
+
+    def decode_cursor(self, cursor: str) -> dict[str, Any]:
+        if not cursor.startswith(self.cursor_prefix):
+            raise self.error_type(
+                f"stored {self.display_name} cursor has an unsupported version"
+            )
+        encoded = cursor.removeprefix(self.cursor_prefix)
+        try:
+            padding = "=" * (-len(encoded) % 4)
+            parsed = json.loads(base64.urlsafe_b64decode(encoded + padding))
+        except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+            raise self.error_type(
+                f"stored {self.display_name} cursor is invalid"
+            ) from error
+        if not isinstance(parsed, dict):
+            raise self.error_type(
+                f"stored {self.display_name} cursor has an invalid shape"
+            )
+        reject_credentials(parsed)
+        return parsed
+
+    def response_status(self, payload: dict[str, Any]) -> int:
+        status = payload.get("status", 200)
+        if isinstance(status, bool) or not isinstance(status, int):
+            raise self.error_type(
+                f"{self.display_name} response status must be an integer"
+            )
+        return status
+
+    def page_data(self, payload: dict[str, Any]) -> list[dict[str, Any]]:
+        data = payload.get("data", [])
+        if not isinstance(data, list) or any(
+            not isinstance(item, dict) for item in data
+        ):
+            raise self.error_type(f"{self.display_name} page data must be an array")
+        return data
+
+
+@dataclass(frozen=True)
 class OAuthPageRequest:
     """Provider-neutral request fields with a provider-specific handle key."""
 

--- a/.agents/scripts/_knowledge_social_youtube.py
+++ b/.agents/scripts/_knowledge_social_youtube.py
@@ -5,13 +5,12 @@
 
 from __future__ import annotations
 
-import base64
-import json
 import re
 from dataclasses import dataclass
 from typing import Any
 
 from _knowledge_social_collect import CursorState, PageCheckpoint
+from _knowledge_social_oauth_request import OAuthPageResponseCodec
 from knowledge_social_import import canonical_json, reject_credentials
 from knowledge_social_store import SocialStoreError
 
@@ -31,6 +30,11 @@ class YouTubeProviderUnavailableError(YouTubeAdapterError):
 
 ADAPTER_ERROR = YouTubeAdapterError
 PROVIDER_UNAVAILABLE_ERROR = YouTubeProviderUnavailableError
+PAGE_CODEC = OAuthPageResponseCodec(
+    display_name="YouTube",
+    cursor_prefix=CURSOR_PREFIX,
+    error_type=YouTubeAdapterError,
+)
 
 
 @dataclass(frozen=True)
@@ -123,27 +127,11 @@ def youtube_id(value: Any, field: str, *, optional: bool = False) -> str | None:
 
 
 def _encode_cursor(cursor: dict[str, Any]) -> str:
-    reject_credentials(cursor)
-    payload = canonical_json(cursor).encode("utf-8")
-    if len(payload) > 4096:
-        raise YouTubeAdapterError("YouTube checkpoint exceeds the safety limit")
-    encoded = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
-    return f"{CURSOR_PREFIX}{encoded}"
+    return PAGE_CODEC.encode_cursor(cursor)
 
 
 def _decode_cursor(cursor: str) -> dict[str, Any]:
-    if not cursor.startswith(CURSOR_PREFIX):
-        raise YouTubeAdapterError("stored YouTube cursor has an unsupported version")
-    encoded = cursor.removeprefix(CURSOR_PREFIX)
-    try:
-        padding = "=" * (-len(encoded) % 4)
-        parsed = json.loads(base64.urlsafe_b64decode(encoded + padding))
-    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
-        raise YouTubeAdapterError("stored YouTube cursor is invalid") from error
-    if not isinstance(parsed, dict):
-        raise YouTubeAdapterError("stored YouTube cursor has an invalid shape")
-    reject_credentials(parsed)
-    return parsed
+    return PAGE_CODEC.decode_cursor(cursor)
 
 
 def page_request(
@@ -169,18 +157,12 @@ def page_request(
 
 def response_status(payload: dict[str, Any]) -> int:
     """Return a validated HTTP-like status from a YouTube read response."""
-    status = payload.get("status", 200)
-    if isinstance(status, bool) or not isinstance(status, int):
-        raise YouTubeAdapterError("YouTube response status must be an integer")
-    return status
+    return PAGE_CODEC.response_status(payload)
 
 
 def page_data(payload: dict[str, Any]) -> list[dict[str, Any]]:
     """Return a validated provider data array."""
-    data = payload.get("data", [])
-    if not isinstance(data, list) or any(not isinstance(item, dict) for item in data):
-        raise YouTubeAdapterError("YouTube page data must be an array")
-    return data
+    return PAGE_CODEC.page_data(payload)
 
 
 def _page_meta(payload: dict[str, Any]) -> dict[str, Any]:

--- a/.agents/scripts/qlty-regression-helper.sh
+++ b/.agents/scripts/qlty-regression-helper.sh
@@ -103,28 +103,52 @@ run_qlty_sarif() {
 	local _out="$2"
 	local _cache_key=""
 	local _cache_dir=""
+	local _first=""
+	local _second=""
+	local _third=""
 	_cache_key=$(basename "$_out" .sarif)
 	_cache_dir="$TMP_DIR/cache-${_cache_key}"
+	_first="$TMP_DIR/${_cache_key}.first.sarif"
+	_second="$TMP_DIR/${_cache_key}.second.sarif"
+	_third="$TMP_DIR/${_cache_key}.third.sarif"
 	mkdir -p "$_cache_dir"
 	# --all: scan all files; --sarif: JSON output;
 	# --no-snippets: compact; --quiet: suppress progress.
 	# qlty exits non-zero when smells exist — SARIF still written to stdout.
-	# Qlty 0.619.0 and 0.635.0 can emit extra similar-code findings on the
-	# first scan of an empty cache. Warm that per-ref cache, then retain only
-	# the second scan so cold/warm runner state cannot change gate results.
+	# Qlty 0.619.0-0.636.0 can emit intermittent similar-code findings while
+	# warming an empty cache. Accept the first matching identity set from up to
+	# three scans so one transient pass cannot create or hide a regression.
 	(cd "$_dir" && XDG_CACHE_HOME="$_cache_dir" "$QLTY_BIN" smells --all --sarif --no-snippets --quiet) \
-		>/dev/null 2>/dev/null || true
+		>"$_first" 2>/dev/null || true
 	(cd "$_dir" && XDG_CACHE_HOME="$_cache_dir" "$QLTY_BIN" smells --all --sarif --no-snippets --quiet) \
-		>"$_out" 2>/dev/null || true
-	if [ ! -s "$_out" ]; then
+		>"$_second" 2>/dev/null || true
+	if [ ! -s "$_first" ] || [ ! -s "$_second" ]; then
 		log "ERROR: qlty produced no output for $_dir"
 		return 1
 	fi
-	if ! jq -e '.runs[0].results' "$_out" >/dev/null 2>&1; then
-		log "ERROR: qlty output is not valid SARIF: $_out"
+	if ! jq -e '.runs[0].results' "$_first" "$_second" >/dev/null 2>&1; then
+		log "ERROR: qlty output is not valid SARIF for $_dir"
 		return 1
 	fi
-	return 0
+	if cmp -s <(normalized_identities "$_first") <(normalized_identities "$_second"); then
+		mv "$_second" "$_out"
+		log "qlty identities stabilized after 2 scans for $_dir"
+		return 0
+	fi
+	(cd "$_dir" && XDG_CACHE_HOME="$_cache_dir" "$QLTY_BIN" smells --all --sarif --no-snippets --quiet) \
+		>"$_third" 2>/dev/null || true
+	if [ ! -s "$_third" ] || ! jq -e '.runs[0].results' "$_third" >/dev/null 2>&1; then
+		log "ERROR: qlty third scan did not produce valid SARIF for $_dir"
+		return 1
+	fi
+	if cmp -s <(normalized_identities "$_first") <(normalized_identities "$_third") ||
+		cmp -s <(normalized_identities "$_second") <(normalized_identities "$_third"); then
+		mv "$_third" "$_out"
+		log "qlty identities stabilized after 3 scans for $_dir"
+		return 0
+	fi
+	log "ERROR: qlty identities did not stabilize after 3 scans for $_dir"
+	return 1
 }
 
 create_scan_clone() {

--- a/.agents/scripts/tests/test-qlty-regression-helper.sh
+++ b/.agents/scripts/tests/test-qlty-regression-helper.sh
@@ -89,6 +89,24 @@ if [ "${QLTY_STUB_MODE:-parity}" = "cache-sensitive" ]; then
 	fi
 	exit 0
 fi
+if [ "${QLTY_STUB_MODE:-parity}" = "second-pass-unstable" ]; then
+	if [ -z "${XDG_CACHE_HOME:-}" ]; then
+		printf 'missing isolated cache\n' >&2
+		exit 2
+	fi
+	run_count=0
+	if [ -f "$XDG_CACHE_HOME/run-count" ]; then
+		run_count=$(cat "$XDG_CACHE_HOME/run-count")
+	fi
+	run_count=$((run_count + 1))
+	printf '%s\n' "$run_count" >"$XDG_CACHE_HOME/run-count"
+	if [ "$run_count" -eq 2 ]; then
+		printf '%s\n' '{"runs":[{"results":[{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"transient-a.sh"}}}]},{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"transient-b.sh"}}}]},{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"transient-c.sh"}}}]}]}]}'
+	else
+		printf '%s\n' '{"runs":[{"results":[{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"a.sh"}}}]}]}]}'
+	fi
+	exit 0
+fi
 if [ "${QLTY_STUB_MODE:-parity}" = "topology-sensitive" ]; then
 	if [ "$(basename "$PWD")" = "repo" ]; then
 		printf '%s\n' '{"runs":[{"results":[{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"direct-only.sh"}}}]}]}]}'
@@ -140,6 +158,14 @@ cache_sensitive_output=$(cd "$REPO" && "$HELPER" --base HEAD --head HEAD 2>&1)
 cache_sensitive_rc=$?
 assert_rc "cold-cache-only similar-code findings do not affect same-tree scans" "0" "$cache_sensitive_rc"
 assert_contains "both authoritative scans use warm-cache counts" "base: 1  head: 1  delta: 0" "$cache_sensitive_output"
+
+QLTY_STUB_MODE=second-pass-unstable
+export QLTY_STUB_MODE
+unstable_output=$(cd "$REPO" && "$HELPER" --base HEAD --head HEAD 2>&1)
+unstable_rc=$?
+assert_rc "one unstable second pass cannot affect same-tree scans" "0" "$unstable_rc"
+assert_contains "three-scan identity consensus is reported" "identities stabilized after 3 scans" "$unstable_output"
+assert_contains "consensus scan retains stable counts" "base: 1  head: 1  delta: 0" "$unstable_output"
 
 QLTY_STUB_MODE=topology-sensitive
 export QLTY_STUB_MODE


### PR DESCRIPTION
## Summary

Deduplicate Google Business Profile and YouTube OAuth page validation, then require repeated Qlty scans to agree so intermittent similar-code identities cannot create false regressions.

## Files Changed

- `.agents/scripts/_knowledge_social_google_business_profile.py`
- `.agents/scripts/_knowledge_social_oauth_request.py`
- `.agents/scripts/_knowledge_social_youtube.py`
- `.agents/scripts/qlty-regression-helper.sh`
- `.agents/scripts/tests/test-qlty-regression-helper.sh`

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Google Business Profile tests (14 passed), YouTube tests (56 passed), Qlty regression helper tests (23 passed), Python compile checks, ShellCheck, and `linters-local.sh`.

Resolves #29592


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.226 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 17m and 191,894 tokens on this as a headless worker.
