### PR TITLE
t18203: Generate the canonical aidevops agent roster from discovery metadata

### DIFF
--- a/.agents/product.md
+++ b/.agents/product.md
@@ -1,4 +1,5 @@
 ---
+name: product
 description: Product management - validation, onboarding, monetisation, growth, UI design, and analytics for all app types
 mode: agent
 subagents:

--- a/.agents/reference/team-interface-agent-roster.md
+++ b/.agents/reference/team-interface-agent-roster.md
@@ -1,0 +1,56 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Team-interface canonical agent roster
+
+The version-1 roster is the provider-neutral discovery boundary between
+canonical aidevops agent sources and team-interface consumers. Generate it with:
+
+```bash
+.agents/scripts/team-interface-agent-roster.py --agents-dir .agents
+```
+
+The command emits canonical JSON to stdout. `--output PATH` atomically replaces
+only that explicit caller-owned cache. It never edits OpenCode or Claude
+configuration, creates provider agents, resolves a concrete model, or copies
+instruction bodies into portable manifests.
+
+## Identity and inclusion
+
+`.agents/scripts/lib/agent_config.py::iter_primary_agent_sources()` remains the
+single inclusion and ordering implementation: root-level Markdown excluding
+`SKIP_FILES`, with `AGENT_ORDER` first and remaining display names sorted
+case-insensitively. Runtime discovery consumes that same iterator.
+
+Each portable primary requires an explicit frontmatter `name`. Its stable ID is
+`agent.<name>`; display names and filenames are presentation and source-location
+metadata, not identity. `.agents/aidevops.md` is registered separately as the
+`agent.aidevops-guide` framework guide. Duplicate, missing, or invalid names
+fail the complete generation.
+
+## Workload and provenance
+
+Frontmatter `model` values represent only the `simple`, `standard`, or
+`thinking` workload tier. An absent tier defaults to `standard`; any other value
+fails closed. Runtime routing remains responsible for selecting a provider,
+model, and reasoning variant.
+
+Every record contains an `agents:<filename>` deployment-relative source
+reference and a SHA-256 digest of the exact source bytes. It contains a bounded
+description, not instructions, absolute host paths, credentials, provider IDs,
+or model IDs. `roster_digest` hashes canonical JSON for the complete unsigned
+document, so unchanged sources and metadata produce byte-identical output.
+
+## Consumers and compatibility
+
+Buzz, Matrix, aidevops.app, app-team manifests, and launch-overlay generators
+may cache or compare this document, but must resolve `agent_id` against current
+canonical discovery before acting. A source-name change is an identity
+migration and requires explicit alias/migration data; changing only display
+name or filename while preserving `name` keeps the stable identity.
+
+Existing custom discovery fixtures without `name` continue to work through the
+filename fallback in runtime discovery. Portable roster generation is stricter:
+it rejects missing names, unreadable sources, unknown tiers, duplicate IDs,
+absolute/parent source references, unsupported formats, and output paths that
+alias agent source files. Any failure leaves a previous explicit output intact.

--- a/.agents/schemas/team-interface/agent-roster-v1.schema.json
+++ b/.agents/schemas/team-interface/agent-roster-v1.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:aidevops:team-interface:agent-roster:v1",
+  "title": "aidevops canonical agent roster contract v1",
+  "$ref": "#/$defs/agent_roster",
+  "$defs": {
+    "core_stable_id": {"$ref": "urn:aidevops:team-interface:core:v1#/$defs/stable_id"},
+    "sha256_digest": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "source_ref": {
+      "type": "string",
+      "pattern": "^agents:[A-Za-z0-9][A-Za-z0-9._/-]*\\.md$",
+      "not": {"pattern": "(^|/)\\.\\.(/|$)"}
+    },
+    "agent_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "agent_id",
+        "kind",
+        "display_name",
+        "description",
+        "source_ref",
+        "source_digest",
+        "workload_tier"
+      ],
+      "properties": {
+        "agent_id": {
+          "allOf": [
+            {"$ref": "#/$defs/core_stable_id"},
+            {"pattern": "^agent\\.[a-z0-9][a-z0-9._-]*$"}
+          ]
+        },
+        "kind": {"enum": ["primary", "framework_guide"]},
+        "display_name": {"type": "string", "minLength": 1, "maxLength": 100},
+        "description": {"type": "string", "minLength": 1, "maxLength": 1000},
+        "source_ref": {"$ref": "#/$defs/source_ref"},
+        "source_digest": {"$ref": "#/$defs/sha256_digest"},
+        "workload_tier": {"enum": ["simple", "standard", "thinking"]}
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {"kind": {"const": "framework_guide"}},
+            "required": ["kind"]
+          },
+          "then": {
+            "properties": {
+              "agent_id": {"const": "agent.aidevops-guide"},
+              "source_ref": {"const": "agents:aidevops.md"}
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {"kind": {"const": "primary"}},
+            "required": ["kind"]
+          },
+          "then": {
+            "properties": {
+              "agent_id": {"not": {"const": "agent.aidevops-guide"}}
+            }
+          }
+        }
+      ]
+    },
+    "agent_roster": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "document_type", "roster_id", "roster_digest", "agents"],
+      "properties": {
+        "schema_version": {"const": 1},
+        "document_type": {"const": "agent_roster"},
+        "roster_id": {"const": "agent-roster.aidevops"},
+        "roster_digest": {"$ref": "#/$defs/sha256_digest"},
+        "agents": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/agent_record"},
+          "contains": {
+            "type": "object",
+            "properties": {"kind": {"const": "framework_guide"}},
+            "required": ["kind"]
+          },
+          "minContains": 1,
+          "maxContains": 1
+        }
+      }
+    }
+  }
+}

--- a/.agents/scripts/lib/agent_config.py
+++ b/.agents/scripts/lib/agent_config.py
@@ -243,14 +243,15 @@ def sort_key(name):
 # AGENT DISCOVERY
 # =============================================================================
 
-def discover_primary_agents(agents_dir):
-    """Discover primary agents from root-level .md files.
+def iter_primary_agent_sources(agents_dir):
+    """Yield canonical primary-agent source records in discovery order.
 
-    Returns (primary_agents, sorted_agents, subagent_filtered_count).
+    ``source_name`` falls back to the filename stem for compatibility with
+    custom and test agents created before explicit names were required. New
+    portable consumers can require ``name_explicit`` without changing the
+    existing runtime discovery contract.
     """
-    primary_agents = {}
-    subagent_filtered_count = 0
-
+    records = []
     for filepath in glob.glob(os.path.join(agents_dir, "*.md")):
         filename = os.path.basename(filepath)
         if filename in SKIP_FILES:
@@ -260,6 +261,7 @@ def discover_primary_agents(agents_dir):
         frontmatter = parse_frontmatter(filepath)
         subagents = frontmatter.get('subagents', None)
         model_tier = frontmatter.get('model', None)
+        explicit_name = frontmatter.get('name', None)
 
         if not isinstance(subagents, (list, type(None))):
             print(f"  Warning: {display_name} has malformed subagents value "
@@ -267,11 +269,39 @@ def discover_primary_agents(agents_dir):
                   file=sys.stderr)
             subagents = None
 
-        if subagents:
+        source_name = explicit_name if explicit_name else os.path.splitext(filename)[0]
+        records.append({
+            "path": filepath,
+            "filename": filename,
+            "frontmatter": frontmatter,
+            "source_name": source_name,
+            "name_explicit": bool(explicit_name),
+            "display_name": display_name,
+            "subagents": subagents,
+            "workload_tier": model_tier,
+        })
+
+    for record in sorted(records, key=lambda item: sort_key(item["display_name"])):
+        yield record
+
+
+def discover_primary_agents(agents_dir):
+    """Discover primary agents from root-level .md files.
+
+    Returns (primary_agents, sorted_agents, subagent_filtered_count).
+    """
+    primary_agents = {}
+    subagent_filtered_count = 0
+
+    for record in iter_primary_agent_sources(agents_dir):
+        if record["subagents"]:
             subagent_filtered_count += 1
 
-        primary_agents[display_name] = get_agent_config(
-            display_name, filename, subagents, model_tier
+        primary_agents[record["display_name"]] = get_agent_config(
+            record["display_name"],
+            record["filename"],
+            record["subagents"],
+            record["workload_tier"],
         )
 
     sorted_agents = dict(sorted(primary_agents.items(), key=lambda x: sort_key(x[0])))

--- a/.agents/scripts/team-interface-agent-roster.py
+++ b/.agents/scripts/team-interface-agent-roster.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Generate the provider-neutral aidevops agent roster."""
+
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import sys
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from agent_config import WORKLOAD_TIERS, iter_primary_agent_sources  # noqa: E402
+from discovery_utils import atomic_json_write, parse_frontmatter  # noqa: E402
+
+
+AGENT_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+SOURCE_FILENAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*\.md$")
+DIGEST_PREFIX = "sha256:"
+DOCUMENT_TYPE = "agent_roster"
+ROSTER_ID = "agent-roster.aidevops"
+SCHEMA_VERSION = 1
+
+
+class RosterError(ValueError):
+    """Raised when source metadata cannot produce a safe portable roster."""
+
+
+def canonical_bytes(value):
+    """Return compact canonical JSON bytes for hashing."""
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def canonical_order(value):
+    """Recursively order mappings before stdout or atomic JSON serialization."""
+    if isinstance(value, dict):
+        return {key: canonical_order(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return [canonical_order(item) for item in value]
+    return value
+
+
+def sha256_bytes(value):
+    """Return a tagged SHA-256 digest for bytes."""
+    return DIGEST_PREFIX + hashlib.sha256(value).hexdigest()
+
+
+def require_string(value, label):
+    """Return a stripped non-empty string or raise a source error."""
+    if not isinstance(value, str) or not value.strip():
+        raise RosterError(f"{label} must be a non-empty string")
+    return value.strip()
+
+
+def source_ref(filename):
+    """Build a deployment-relative registered source reference."""
+    if Path(filename).name != filename or not SOURCE_FILENAME_PATTERN.fullmatch(filename):
+        raise RosterError(f"source filename is not relative and registered: {filename}")
+    return f"agents:{filename}"
+
+
+def source_record(record, kind="primary", agent_id=None, display_name=None):
+    """Convert one discovered source into a portable roster record."""
+    if not record["name_explicit"]:
+        raise RosterError(f"{record['filename']} is missing explicit frontmatter name")
+
+    source_name = require_string(record["source_name"], f"{record['filename']} name")
+    if not AGENT_NAME_PATTERN.fullmatch(source_name):
+        raise RosterError(f"{record['filename']} has invalid agent name: {source_name}")
+
+    tier = record["workload_tier"] or "standard"
+    if tier not in WORKLOAD_TIERS:
+        raise RosterError(f"{record['filename']} has non-canonical workload tier: {tier}")
+
+    description = require_string(
+        record["frontmatter"].get("description"),
+        f"{record['filename']} description",
+    )
+    if len(description) > 1000:
+        raise RosterError(f"{record['filename']} description exceeds 1000 characters")
+    resolved_display_name = display_name or record["display_name"]
+    if not isinstance(resolved_display_name, str) or not 1 <= len(resolved_display_name) <= 100:
+        raise RosterError(f"{record['filename']} display name must contain 1-100 characters")
+    path = Path(record["path"])
+    try:
+        content = path.read_bytes()
+    except OSError as error:
+        raise RosterError(f"cannot read source {record['filename']}: {error.strerror}") from error
+
+    return {
+        "agent_id": agent_id or f"agent.{source_name}",
+        "description": description,
+        "display_name": resolved_display_name,
+        "kind": kind,
+        "source_digest": sha256_bytes(content),
+        "source_ref": source_ref(record["filename"]),
+        "workload_tier": tier,
+    }
+
+
+def framework_guide_record(agents_dir):
+    """Load the separately registered aidevops framework guide."""
+    guide_path = agents_dir / "aidevops.md"
+    if not guide_path.is_file():
+        raise RosterError("aidevops.md framework guide is missing")
+    frontmatter = parse_frontmatter(str(guide_path))
+    name = frontmatter.get("name")
+    record = {
+        "path": str(guide_path),
+        "filename": guide_path.name,
+        "frontmatter": frontmatter,
+        "source_name": name,
+        "name_explicit": bool(name),
+        "display_name": "AI DevOps",
+        "subagents": frontmatter.get("subagents"),
+        "workload_tier": frontmatter.get("model"),
+    }
+    return source_record(
+        record,
+        kind="framework_guide",
+        agent_id="agent.aidevops-guide",
+        display_name="AI DevOps",
+    )
+
+
+def validate_unique_ids(records):
+    """Reject duplicate stable IDs before serializing a roster."""
+    seen = set()
+    for record in records:
+        agent_id = record["agent_id"]
+        if agent_id in seen:
+            raise RosterError(f"duplicate agent ID: {agent_id}")
+        seen.add(agent_id)
+
+
+def build_roster(agents_dir):
+    """Build and validate one deterministic roster document."""
+    records = [
+        source_record(record)
+        for record in iter_primary_agent_sources(str(agents_dir))
+    ]
+    records.append(framework_guide_record(agents_dir))
+    if len(records) < 2:
+        raise RosterError("roster requires at least one primary agent and the framework guide")
+    validate_unique_ids(records)
+
+    unsigned_document = {
+        "agents": records,
+        "document_type": DOCUMENT_TYPE,
+        "roster_id": ROSTER_ID,
+        "schema_version": SCHEMA_VERSION,
+    }
+    document = {
+        **unsigned_document,
+        "roster_digest": sha256_bytes(canonical_bytes(unsigned_document)),
+    }
+    return canonical_order(document)
+
+
+def ensure_output_is_not_source(output_path, agents_dir):
+    """Prevent explicit output from replacing a canonical Markdown source."""
+    resolved_output = output_path.resolve()
+    for source in agents_dir.glob("*.md"):
+        if resolved_output == source.resolve():
+            raise RosterError(f"output path aliases agent source: {source.name}")
+
+
+def parse_args(argv=None):
+    """Parse the bounded roster command line."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--agents-dir",
+        default="~/.aidevops/agents",
+        help="canonical agent source directory",
+    )
+    parser.add_argument("--format", choices=("json",), default="json")
+    parser.add_argument("--output", help="optional atomic JSON output path")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    """Generate stdout JSON or atomically replace an explicit output file."""
+    args = parse_args(argv)
+    agents_dir = Path(os.path.expanduser(args.agents_dir)).resolve()
+    if not agents_dir.is_dir():
+        raise RosterError(f"agents directory does not exist: {args.agents_dir}")
+
+    document = build_roster(agents_dir)
+    if args.output:
+        output_path = Path(os.path.expanduser(args.output))
+        ensure_output_is_not_source(output_path, agents_dir)
+        atomic_json_write(str(output_path), document, indent=2, trailing_newline=True)
+        return 0
+
+    json.dump(document, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RosterError as error:
+        print(f"team-interface-agent-roster: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/.agents/scripts/tests/test-team-interface-agent-roster.mjs
+++ b/.agents/scripts/tests/test-team-interface-agent-roster.mjs
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {spawnSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import Ajv2020 from "ajv/dist/2020.js";
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(testDirectory, "../../..");
+const rosterScript = path.join(repositoryRoot, ".agents/scripts/team-interface-agent-roster.py");
+const schemaDirectory = path.join(repositoryRoot, ".agents/schemas/team-interface");
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function runRoster(agentsDirectory, extraArguments = []) {
+  return spawnSync(
+    "python3",
+    [rosterScript, "--agents-dir", agentsDirectory, ...extraArguments],
+    {encoding: "utf8"},
+  );
+}
+
+function requireSuccess(result, label) {
+  assert.equal(result.status, 0, `${label} failed:\n${result.stderr}`);
+  return JSON.parse(result.stdout);
+}
+
+function writeAgent(directory, filename, {name, description, model, heading = "Agent"}) {
+  const metadata = [
+    "---",
+    ...(name === undefined ? [] : [`name: ${name}`]),
+    `description: ${description}`,
+    "mode: subagent",
+    ...(model === undefined ? [] : [`model: ${model}`]),
+    "---",
+    "",
+    `# ${heading}`,
+    "",
+    "Fixture instructions.",
+    "",
+  ].join("\n");
+  fs.writeFileSync(path.join(directory, filename), metadata);
+}
+
+function copy(value) {
+  return structuredClone(value);
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+const coreSchema = readJson(path.join(schemaDirectory, "core-v1.schema.json"));
+const rosterSchema = readJson(path.join(schemaDirectory, "agent-roster-v1.schema.json"));
+const ajv = new Ajv2020({allErrors: true, strict: false, validateFormats: false});
+ajv.addSchema(coreSchema);
+const validate = ajv.compile(rosterSchema);
+
+const liveFirst = runRoster(path.join(repositoryRoot, ".agents"));
+const liveRoster = requireSuccess(liveFirst, "live roster generation");
+const liveSecond = runRoster(path.join(repositoryRoot, ".agents"));
+assert.equal(liveSecond.status, 0, liveSecond.stderr);
+assert.equal(liveSecond.stdout, liveFirst.stdout, "unchanged live source must be byte-identical");
+assert.equal(validate(liveRoster), true, JSON.stringify(validate.errors, null, 2));
+
+const primaryAgents = liveRoster.agents.filter(({kind}) => kind === "primary");
+const frameworkGuides = liveRoster.agents.filter(({kind}) => kind === "framework_guide");
+assert.equal(primaryAgents.length, 13, "current source must expose 13 canonical primaries");
+assert.equal(frameworkGuides.length, 1);
+assert.equal(frameworkGuides[0].agent_id, "agent.aidevops-guide");
+assert.equal(frameworkGuides[0].workload_tier, "standard");
+assert.deepEqual(
+  primaryAgents.filter(({workload_tier}) => workload_tier === "thinking").map(({agent_id}) => agent_id).sort(),
+  ["agent.content", "agent.pr", "agent.vault"],
+);
+assert.equal(primaryAgents.filter(({workload_tier}) => workload_tier === "standard").length, 10);
+assert.equal(new Set(liveRoster.agents.map(({agent_id}) => agent_id)).size, liveRoster.agents.length);
+assert.ok(liveRoster.agents.every(({source_ref: sourceRef}) => sourceRef.startsWith("agents:")));
+assert.ok(liveRoster.agents.every(({source_ref: sourceRef}) => !path.isAbsolute(sourceRef)));
+assert.ok(liveRoster.agents.every(({source_digest: digest}) => /^sha256:[a-f0-9]{64}$/.test(digest)));
+assert.deepEqual(
+  Object.keys(liveRoster).sort(),
+  ["agents", "document_type", "roster_digest", "roster_id", "schema_version"],
+);
+
+const unsignedLive = copy(liveRoster);
+delete unsignedLive.roster_digest;
+const expectedDigest = `sha256:${crypto.createHash("sha256").update(canonicalJson(unsignedLive)).digest("hex")}`;
+assert.equal(liveRoster.roster_digest, expectedDigest, "roster digest does not cover canonical unsigned JSON");
+
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "aidevops-roster-"));
+try {
+  writeAgent(fixtureRoot, "build-plus.md", {
+    name: "build-plus",
+    description: "Fixture build agent",
+    model: "thinking",
+    heading: "Build+",
+  });
+  writeAgent(fixtureRoot, "aidevops.md", {
+    name: "aidevops",
+    description: "Fixture framework guide",
+    heading: "AI DevOps",
+  });
+
+  const initialResult = runRoster(fixtureRoot);
+  const initial = requireSuccess(initialResult, "initial sandbox roster");
+  assert.deepEqual(initial.agents.map(({agent_id}) => agent_id), ["agent.build-plus", "agent.aidevops-guide"]);
+
+  writeAgent(fixtureRoot, "zeta.md", {
+    name: "stable-zeta",
+    description: "Fixture dynamically added agent",
+    heading: "Zeta",
+  });
+  const added = requireSuccess(runRoster(fixtureRoot), "sandbox addition");
+  assert.ok(added.agents.some(({agent_id}) => agent_id === "agent.stable-zeta"));
+
+  fs.renameSync(path.join(fixtureRoot, "zeta.md"), path.join(fixtureRoot, "renamed.md"));
+  const renamed = requireSuccess(runRoster(fixtureRoot), "sandbox rename");
+  assert.ok(renamed.agents.some(({agent_id}) => agent_id === "agent.stable-zeta"));
+  assert.ok(renamed.agents.some(({source_ref: sourceRef}) => sourceRef === "agents:renamed.md"));
+
+  const beforeContentChange = renamed.agents.find(({agent_id}) => agent_id === "agent.stable-zeta");
+  fs.appendFileSync(path.join(fixtureRoot, "renamed.md"), "Changed source bytes.\n");
+  const changed = requireSuccess(runRoster(fixtureRoot), "sandbox content change");
+  const afterContentChange = changed.agents.find(({agent_id}) => agent_id === "agent.stable-zeta");
+  assert.notEqual(afterContentChange.source_digest, beforeContentChange.source_digest);
+  assert.notEqual(changed.roster_digest, renamed.roster_digest);
+  const beforeWithoutDigest = {...beforeContentChange};
+  const afterWithoutDigest = {...afterContentChange};
+  delete beforeWithoutDigest.source_digest;
+  delete afterWithoutDigest.source_digest;
+  assert.deepEqual(afterWithoutDigest, beforeWithoutDigest, "source bytes changed unrelated roster metadata");
+
+  fs.unlinkSync(path.join(fixtureRoot, "renamed.md"));
+  const removed = requireSuccess(runRoster(fixtureRoot), "sandbox removal");
+  assert.equal(removed.agents.some(({agent_id}) => agent_id === "agent.stable-zeta"), false);
+
+  const outputPath = path.join(fixtureRoot, "roster.json");
+  const outputResult = runRoster(fixtureRoot, ["--output", outputPath]);
+  assert.equal(outputResult.status, 0, outputResult.stderr);
+  const previousOutput = fs.readFileSync(outputPath, "utf8");
+  assert.ok(previousOutput.endsWith("\n"));
+
+  writeAgent(fixtureRoot, "missing-name.md", {
+    description: "Fixture missing an explicit name",
+  });
+  const missingName = runRoster(fixtureRoot, ["--output", outputPath]);
+  assert.notEqual(missingName.status, 0);
+  assert.match(missingName.stderr, /missing explicit frontmatter name/i);
+  assert.equal(fs.readFileSync(outputPath, "utf8"), previousOutput, "failed generation replaced prior output");
+  fs.unlinkSync(path.join(fixtureRoot, "missing-name.md"));
+
+  writeAgent(fixtureRoot, "duplicate.md", {
+    name: "build-plus",
+    description: "Fixture duplicate stable identity",
+  });
+  const duplicate = runRoster(fixtureRoot);
+  assert.notEqual(duplicate.status, 0);
+  assert.match(duplicate.stderr, /duplicate agent ID/i);
+  fs.unlinkSync(path.join(fixtureRoot, "duplicate.md"));
+
+  writeAgent(fixtureRoot, "bad-tier.md", {
+    name: "bad-tier",
+    description: "Fixture concrete model value",
+    model: "provider/model",
+  });
+  const badTier = runRoster(fixtureRoot);
+  assert.notEqual(badTier.status, 0);
+  assert.match(badTier.stderr, /non-canonical workload tier/i);
+  fs.unlinkSync(path.join(fixtureRoot, "bad-tier.md"));
+
+  const aliasResult = runRoster(fixtureRoot, ["--output", path.join(fixtureRoot, "build-plus.md")]);
+  assert.notEqual(aliasResult.status, 0);
+  assert.match(aliasResult.stderr, /aliases agent source/i);
+
+  const unsupported = runRoster(fixtureRoot, ["--format", "yaml"]);
+  assert.notEqual(unsupported.status, 0);
+
+  writeAgent(fixtureRoot, "unsafe name.md", {
+    name: "safe-name",
+    description: "Fixture unsafe source reference",
+  });
+  const unsafeFilename = runRoster(fixtureRoot);
+  assert.notEqual(unsafeFilename.status, 0);
+  assert.match(unsafeFilename.stderr, /not relative and registered/i);
+  fs.unlinkSync(path.join(fixtureRoot, "unsafe name.md"));
+
+  const invalidAbsolute = copy(initial);
+  invalidAbsolute.agents[0].source_ref = "agents:/private/source.md";
+  assert.equal(validate(invalidAbsolute), false, "absolute source reference unexpectedly validated");
+
+  const invalidProvider = copy(initial);
+  invalidProvider.agents[0].provider_id = "provider/concrete";
+  assert.equal(validate(invalidProvider), false, "provider-specific field unexpectedly validated");
+
+  const invalidRosterIdentity = copy(initial);
+  invalidRosterIdentity.roster_id = "agent-roster.other";
+  assert.equal(validate(invalidRosterIdentity), false, "alternate roster identity unexpectedly validated");
+
+  const invalidGuideIdentity = copy(initial);
+  invalidGuideIdentity.agents.find(({kind}) => kind === "framework_guide").agent_id = "agent.other-guide";
+  assert.equal(validate(invalidGuideIdentity), false, "alternate framework guide unexpectedly validated");
+
+  const unknownField = copy(initial);
+  unknownField.runtime_overlay = {};
+  assert.equal(validate(unknownField), false, "unknown roster field unexpectedly validated");
+} finally {
+  fs.rmSync(fixtureRoot, {recursive: true, force: true});
+}
+
+console.log("PASS: canonical agent roster is deterministic, portable, and discovery-driven");


### PR DESCRIPTION
## Summary

Add a provider-neutral canonical roster generator, closed v1 schema, stable IDs and digests, shared discovery source records, and live/sandbox regression coverage.

## Files Changed

.agents/product.md, .agents/reference/team-interface-agent-roster.md, .agents/schemas/team-interface/agent-roster-v1.schema.json, .agents/scripts/lib/agent_config.py, .agents/scripts/team-interface-agent-roster.py, .agents/scripts/tests/test-team-interface-agent-roster.mjs

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified with the live roster generator and sandbox mutation suite; shared OpenCode/Claude discovery smoke tests, Python compilation, changed-file lint, and exact branch review evidence all pass. The canonical-tier suite has one unchanged baseline fixture-label failure outside this diff.

Resolves #29543


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.226 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 13m and 176,309 tokens on this with the user in an interactive session.