### PR TITLE
GH#29607: fix: harden sudo approval auth recovery

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -77,8 +77,10 @@ readonly APPROVAL_MARKER="<!-- aidevops-signed-approval -->"
 readonly _APPROVAL_NMR_LABEL="needs-maintainer-review"
 readonly _APPROVAL_AUTO_DISPATCH_LABEL="auto-dispatch"
 readonly _APPROVAL_MISSING_FIELD="__missing__"
+readonly _APPROVAL_GH_INVALID_TOKEN="invalid-token"
 
 _APPROVAL_GH_RATE_LIMIT_RESET=""
+_APPROVAL_GH_AUTH_FAILURE=""
 
 # shellcheck source=approval-snapshot-v2.sh
 source "${SCRIPT_DIR}/approval-snapshot-v2.sh"
@@ -142,24 +144,36 @@ _print_error() {
 	return 0
 }
 
-_approval_probe_core_rate_limit() {
+_approval_probe_auth_failure() {
 	local response=""
-	local api_rc=0
 	# The diagnostic request must respect any active shared secondary cooldown.
 	if command -v _gh_secondary_cooldown_preflight >/dev/null 2>&1; then
 		_gh_secondary_cooldown_preflight read >/dev/null 2>&1 || return 1
 	fi
-	response=$(gh api user --include --silent 2>/dev/null) || api_rc=$?
-	[[ "$api_rc" -ne 0 && -n "$response" ]] || return 1
+	response=$(gh api user --include --silent 2>/dev/null) || true
+	[[ -n "$response" ]] || return 1
 	printf '%s\n' "$response" | awk '
 		{ sub(/\r$/, "", $0) }
-		$1 ~ /^HTTP\// { status = $2 }
+		$1 ~ /^HTTP\// {
+			status = $2
+			remaining = ""
+			reset = ""
+			resource = ""
+		}
 		tolower($1) == "x-ratelimit-remaining:" { remaining = $2 }
 		tolower($1) == "x-ratelimit-reset:" { reset = $2 }
 		tolower($1) == "x-ratelimit-resource:" { resource = tolower($2) }
 		END {
-			if (status == "403" && remaining == "0" && reset ~ /^[0-9]+$/ && resource == "core") {
-				printf "%s\t%s", remaining, reset
+			if (status ~ /^2[0-9][0-9]$/) {
+				printf "authenticated"
+				exit 0
+			}
+			if ((status == "403" || status == "429") && remaining == "0" && reset ~ /^[0-9]+$/ && resource == "core") {
+				printf "core-rate-limit\t%s", reset
+				exit 0
+			}
+			if (status == "401") {
+				printf "invalid-token"
 				exit 0
 			}
 			exit 1
@@ -174,14 +188,32 @@ _approval_report_core_rate_limit() {
 	return 0
 }
 
+_approval_safe_gh_host() {
+	local host="${GH_HOST:-github.com}"
+	if [[ ! "$host" =~ ^[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?$ ]]; then
+		host="github.com"
+	fi
+	printf '%s' "$host"
+	return 0
+}
+
+_approval_report_invalid_token() {
+	local host=""
+	host="$(_approval_safe_gh_host)"
+	_print_error "GitHub rejected the invoking user's stored gh credential (HTTP 401); this is not a sudo credential-forwarding failure"
+	_print_info "Replace the rejected credential as your normal user: gh auth logout -h ${host}, then gh auth login -h ${host} -s workflow. Do not forward the rejected token through GH_TOKEN."
+	return 0
+}
+
 _approval_use_gh_token() {
 	local token="${1:-}"
 	local previous_token="${GH_TOKEN:-}"
 	local token_was_set="${GH_TOKEN+x}"
-	local quota=""
-	local remaining=""
+	local failure=""
+	local failure_kind=""
 	local reset=""
 	_APPROVAL_GH_RATE_LIMIT_RESET=""
+	_APPROVAL_GH_AUTH_FAILURE=""
 
 	if [[ -z "$token" ]]; then
 		return 1
@@ -191,11 +223,19 @@ _approval_use_gh_token() {
 	if gh auth status >/dev/null 2>&1; then
 		return 0
 	fi
-	if quota=$(_approval_probe_core_rate_limit); then
-		IFS=$'\t' read -r remaining reset <<<"$quota"
-		if [[ "$remaining" == "0" ]]; then
+	if failure=$(_approval_probe_auth_failure); then
+		IFS=$'\t' read -r failure_kind reset <<<"$failure"
+		case "$failure_kind" in
+		authenticated)
+			return 0
+			;;
+		core-rate-limit)
 			_APPROVAL_GH_RATE_LIMIT_RESET="$reset"
-		fi
+			;;
+		"$_APPROVAL_GH_INVALID_TOKEN")
+			_APPROVAL_GH_AUTH_FAILURE="$failure_kind"
+			;;
+		esac
 	fi
 
 	if [[ -n "$token_was_set" ]]; then
@@ -262,6 +302,7 @@ _approval_user_gh_token() {
 
 _require_gh_auth() {
 	_APPROVAL_GH_RATE_LIMIT_RESET=""
+	_APPROVAL_GH_AUTH_FAILURE=""
 	if gh auth status >/dev/null 2>&1; then
 		return 0
 	fi
@@ -277,6 +318,10 @@ _require_gh_auth() {
 			_approval_report_core_rate_limit "$_APPROVAL_GH_RATE_LIMIT_RESET"
 			return 1
 		fi
+		if [[ "$_APPROVAL_GH_AUTH_FAILURE" == "$_APPROVAL_GH_INVALID_TOKEN" ]]; then
+			_approval_report_invalid_token
+			return 1
+		fi
 
 		# Read token directly from gh config file for non-keyring storage.
 		local real_home
@@ -290,6 +335,10 @@ _require_gh_auth() {
 			fi
 			if [[ -n "$_APPROVAL_GH_RATE_LIMIT_RESET" ]]; then
 				_approval_report_core_rate_limit "$_APPROVAL_GH_RATE_LIMIT_RESET"
+				return 1
+			fi
+			if [[ "$_APPROVAL_GH_AUTH_FAILURE" == "$_APPROVAL_GH_INVALID_TOKEN" ]]; then
+				_approval_report_invalid_token
 				return 1
 			fi
 		fi

--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -241,11 +241,13 @@ unset _cand
 # -----------------------------------------------------------------------------
 _SHIM_READ_REWRITE=""
 case "${1:-}:${2:-}" in
-	auth:git-credential | auth:token)
-		# These auth commands only read local credential storage. Counting them as
-		# GraphQL creates false unknown-quota attempts, while transport framing can
-		# break keychain recovery under sudo (GH#27777, GH#29153). Preserve native
-		# stdout, stderr, and exit status byte-for-byte without logging token output.
+	auth:*)
+		# Authentication is a credential-control path, not application API traffic.
+		# Login, logout, refresh, status, token, and git-credential may prompt or
+		# access the OS keyring. Transport framing and telemetry can alter interactive
+		# behaviour or retain sensitive diagnostics (GH#27777, GH#29153). Preserve
+		# native stdin, stdout, stderr, and exit status byte-for-byte for every auth
+		# subcommand.
 		_real_gh="$(_find_real_gh)" || {
 			printf '[aidevops] gh shim: real gh binary not found on PATH\n' >&2
 			exit 127

--- a/.agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh
+++ b/.agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh
@@ -134,6 +134,44 @@ run_case "sudo gh auth recovers token from invoking macOS user session" '
 assert_not_contains "recovered token is not printed" "$LAST_OUTPUT" "mac-user-token"
 
 # shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "sudo gh auth accepts a successful API probe after transient auth status failure" '
+	set -uo pipefail
+	export SUDO_USER=alice
+	export HOME=/var/root
+	id() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "-u" && -z "$arg2" ]]; then printf "0"; return 0; fi
+		if [[ "$arg1" == "-u" && "$arg2" == "alice" ]]; then printf "501"; return 0; fi
+		return 1
+	}
+	getent() { return 1; }
+	dscl() { printf "NFSHomeDirectory: /Users/alice\n"; return 0; }
+	launchctl() { printf "transient-status-token"; return 0; }
+	sudo() { return 1; }
+	gh() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		local arg3="${3:-}"
+		local arg4="${4:-}"
+		if [[ "$arg1" == "auth" && "$arg2" == "status" ]]; then return 1; fi
+		if [[ "$arg1" == "api" && "$arg2" == "user" && "$arg3" == "--include" && "$arg4" == "--silent" ]]; then
+			[[ "${GH_TOKEN:-}" == "transient-status-token" ]] || return 1
+			printf "HTTP/2.0 200 OK\r\n"
+			printf "X-RateLimit-Remaining: 4999\r\n"
+			printf "X-RateLimit-Resource: core\r\n\r\n"
+			return 0
+		fi
+		return 1
+	}
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_require_gh_auth
+' 0
+assert_not_contains "transient status recovered token is not printed" "$LAST_OUTPUT" "transient-status-token"
+assert_not_contains "transient status does not report sudo recovery failure" "$LAST_OUTPUT" "automatic recovery from the invoking user's gh auth failed"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
 run_case "sudo gh auth recovery uses absolute gh binary when sudo path is restricted" '
 	set -uo pipefail
 	export SUDO_USER=alice
@@ -332,7 +370,82 @@ assert_not_contains "exhausted recovered token is not printed" "$LAST_OUTPUT" "e
 assert_not_contains "failed user response body is not printed" "$LAST_OUTPUT" "API rate limit exceeded"
 
 # shellcheck disable=SC2016  # literal script is evaluated in the child bash.
-run_case "sudo gh auth does not classify invalid token headers as core exhaustion" '
+run_case "sudo gh auth diagnoses HTTP 429 core exhaustion" '
+	set -uo pipefail
+	export SUDO_USER=alice
+	export HOME=/var/root
+	id() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "-u" && -z "$arg2" ]]; then printf "0"; return 0; fi
+		if [[ "$arg1" == "-u" && "$arg2" == "alice" ]]; then printf "501"; return 0; fi
+		return 1
+	}
+	getent() { return 1; }
+	dscl() { printf "NFSHomeDirectory: /Users/alice\n"; return 0; }
+	launchctl() { printf "429-user-token"; return 0; }
+	sudo() { return 1; }
+	gh() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "auth" && "$arg2" == "status" ]]; then return 1; fi
+		if [[ "$arg1" == "api" && "$arg2" == "user" ]]; then
+			printf "HTTP/2.0 429 Too Many Requests\r\n"
+			printf "X-RateLimit-Remaining: 0\r\n"
+			printf "X-RateLimit-Reset: 1785697848\r\n"
+			printf "X-RateLimit-Resource: core\r\n\r\n"
+			return 1
+		fi
+		return 1
+	}
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_require_gh_auth
+' 1
+assert_contains "HTTP 429 core exhaustion is diagnosed" "$LAST_OUTPUT" "GitHub core API rate limit is exhausted"
+assert_contains "HTTP 429 core exhaustion reports reset epoch" "$LAST_OUTPUT" "1785697848"
+assert_not_contains "HTTP 429 exhausted token is not printed" "$LAST_OUTPUT" "429-user-token"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "sudo gh auth ignores stale quota headers across response frames" '
+	set -uo pipefail
+	export SUDO_USER=alice
+	export HOME=/var/root
+	id() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "-u" && -z "$arg2" ]]; then printf "0"; return 0; fi
+		if [[ "$arg1" == "-u" && "$arg2" == "alice" ]]; then printf "501"; return 0; fi
+		return 1
+	}
+	getent() { return 1; }
+	dscl() { printf "NFSHomeDirectory: /Users/alice\n"; return 0; }
+	launchctl() { printf "multi-frame-token"; return 0; }
+	sudo() { return 1; }
+	gh() {
+		local arg1="${1:-}"
+		local arg2="${2:-}"
+		if [[ "$arg1" == "auth" && "$arg2" == "status" ]]; then return 1; fi
+		if [[ "$arg1" == "api" && "$arg2" == "user" ]]; then
+			printf "HTTP/2.0 403 Forbidden\r\n"
+			printf "X-RateLimit-Remaining: 0\r\n"
+			printf "X-RateLimit-Reset: 1785697849\r\n"
+			printf "X-RateLimit-Resource: core\r\n\r\n"
+			printf "HTTP/2.0 429 Too Many Requests\r\n\r\n"
+			return 1
+		fi
+		return 1
+	}
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_require_gh_auth
+' 1
+assert_contains "multi-frame response preserves generic auth failure" "$LAST_OUTPUT" "automatic recovery from the invoking user's gh auth failed"
+assert_not_contains "multi-frame response does not reuse stale quota headers" "$LAST_OUTPUT" "GitHub core API rate limit is exhausted"
+assert_not_contains "multi-frame token is not printed" "$LAST_OUTPUT" "multi-frame-token"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "sudo gh auth identifies the invoking user's invalid stored token" '
 	set -uo pipefail
 	export SUDO_USER=alice
 	export HOME=/var/root
@@ -367,10 +480,25 @@ run_case "sudo gh auth does not classify invalid token headers as core exhaustio
 	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
 	_require_gh_auth
 ' 1
-assert_contains "invalid token preserves generic auth failure" "$LAST_OUTPUT" "automatic recovery from the invoking user's gh auth failed"
+assert_contains "invalid token is distinguished from sudo forwarding failure" "$LAST_OUTPUT" "this is not a sudo credential-forwarding failure"
+assert_contains "invalid token reports GitHub rejection" "$LAST_OUTPUT" "GitHub rejected the invoking user's stored gh credential (HTTP 401)"
+assert_contains "invalid token recommends clean replacement" "$LAST_OUTPUT" "gh auth logout -h github.com, then gh auth login -h github.com -s workflow"
+assert_contains "invalid token rejects forwarding workaround" "$LAST_OUTPUT" "Do not forward the rejected token through GH_TOKEN"
+assert_not_contains "invalid token avoids generic sudo recovery failure" "$LAST_OUTPUT" "automatic recovery from the invoking user's gh auth failed"
 assert_not_contains "invalid token is not diagnosed as core exhaustion" "$LAST_OUTPUT" "GitHub core API rate limit is exhausted"
 assert_not_contains "invalid token response body is not printed" "$LAST_OUTPUT" "Bad credentials"
 assert_not_contains "invalid recovered token is not printed" "$LAST_OUTPUT" "invalid-user-token"
+
+# shellcheck disable=SC2016  # literal script is evaluated in the child bash.
+run_case "invalid token guidance sanitizes an unsafe GH_HOST" '
+	set -uo pipefail
+	export GH_HOST="example.com; unexpected-command"
+	# shellcheck disable=SC1090
+	source "$APPROVAL_HELPER_UNDER_TEST" >/dev/null 2>&1
+	_approval_report_invalid_token
+' 0
+assert_contains "unsafe GH_HOST falls back to the public host" "$LAST_OUTPUT" "gh auth logout -h github.com"
+assert_not_contains "unsafe GH_HOST is not rendered in guidance" "$LAST_OUTPUT" "unexpected-command"
 
 # shellcheck disable=SC2016  # literal script is evaluated in the child bash.
 run_case "sudo gh auth quota probe obeys shared cooldown" '

--- a/.agents/scripts/tests/test-gh-api-instrument.sh
+++ b/.agents/scripts/tests/test-gh-api-instrument.sh
@@ -760,6 +760,11 @@ if [[ "${1:-}:${2:-}" == "auth:token" ]]; then
 	printf 'native-auth-token-stderr\n' >&2
 	exit "${NATIVE_AUTH_TOKEN_STATUS:-0}"
 fi
+if [[ "${1:-}:${2:-}" == "auth:refresh" ]]; then
+	printf 'native-auth-refresh-stdout\n'
+	printf 'native-auth-refresh-stderr\n' >&2
+	exit "${NATIVE_AUTH_REFRESH_STATUS:-0}"
+fi
 page=1
 jq_requested=0
 expect_jq=0
@@ -887,11 +892,44 @@ auth_token_failure_status=$?
 set -e
 assert_eq "local auth token preserves native failure status" "23" "$auth_token_failure_status"
 
+# Credential-mutating auth commands must bypass transport framing too. This
+# keeps device-flow prompts and Keychain writes under native gh control.
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+auth_refresh_expected_output="$TMPDIR/auth-refresh-output.expected"
+auth_refresh_actual_output="$TMPDIR/auth-refresh-output.actual"
+auth_refresh_expected_error="$TMPDIR/auth-refresh-error.expected"
+auth_refresh_actual_error="$TMPDIR/auth-refresh-error.actual"
+printf 'native-auth-refresh-stdout\n' >"$auth_refresh_expected_output"
+printf 'native-auth-refresh-stderr\n' >"$auth_refresh_expected_error"
+PATH="$NATIVE_FIXTURE:/usr/bin:/bin" \
+	"$SHIM_FIXTURE/gh" auth refresh -h github.com \
+	>"$auth_refresh_actual_output" 2>"$auth_refresh_actual_error"
+auth_refresh_output_status=0
+cmp -s "$auth_refresh_expected_output" "$auth_refresh_actual_output" || auth_refresh_output_status=$?
+assert_eq "auth refresh preserves stdout bytes" "0" "$auth_refresh_output_status"
+auth_refresh_error_status=0
+cmp -s "$auth_refresh_expected_error" "$auth_refresh_actual_error" || auth_refresh_error_status=$?
+assert_eq "auth refresh preserves stderr bytes" "0" "$auth_refresh_error_status"
+assert_eq "auth refresh invokes native gh once" "1" "$(grep -c '^auth$' "$NATIVE_ATTEMPT_LOG")"
+assert_path_absent "auth refresh emits no API telemetry" "$AIDEVOPS_GH_API_LOG"
+auth_refresh_failure_status=0
+set +e
+PATH="$NATIVE_FIXTURE:/usr/bin:/bin" NATIVE_AUTH_REFRESH_STATUS=29 \
+	"$SHIM_FIXTURE/gh" auth refresh -h github.com >/dev/null 2>/dev/null
+auth_refresh_failure_status=$?
+set -e
+assert_eq "auth refresh preserves native failure status" "29" "$auth_refresh_failure_status"
+
 rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
 PATH="$NATIVE_FIXTURE:/usr/bin:/bin" \
 	"$SHIM_FIXTURE/gh" auth git-credential-extra get >/dev/null
-assert_file_exists "near-match auth command retains API telemetry" "$AIDEVOPS_GH_API_LOG"
-assert_eq "near-match auth command retains one transport attempt" "1" \
+assert_path_absent "all auth control commands bypass API telemetry" "$AIDEVOPS_GH_API_LOG"
+
+rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"
+PATH="$NATIVE_FIXTURE:/usr/bin:/bin" \
+	"$SHIM_FIXTURE/gh" config get git_protocol >/dev/null
+assert_file_exists "non-auth command retains API telemetry" "$AIDEVOPS_GH_API_LOG"
+assert_eq "non-auth command retains one transport attempt" "1" \
 	"$(awk -F'\t' '$9 == "attempt" { count++ } END { print count + 0 }' "$AIDEVOPS_GH_API_LOG")"
 
 rm -f "$AIDEVOPS_GH_API_LOG" "$NATIVE_ATTEMPT_LOG"

--- a/.agents/scripts/tests/test-gh-shim-quota-cases.sh
+++ b/.agents/scripts/tests/test-gh-shim-quota-cases.sh
@@ -261,22 +261,18 @@ else
 	_fail "native multi-frame REST quota attribution" "summary: $native_multi_summary log: $(cat "$native_multi_log" 2>/dev/null || true)"
 fi
 
-native_single_log="$TMP/exact-native-single-rest.log"
-native_single_state="$TMP/exact-native-single-rest-state"
+native_single_log="$TMP/exact-native-auth-control.log"
 : >"$native_single_log"
 GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
-	AIDEVOPS_GH_QUOTA_STATE_DIR="$native_single_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
+	AIDEVOPS_TEMP_DIR="$exact_temp" \
 	AIDEVOPS_GH_API_LOG="$native_single_log" STUB_GH_DEBUG_RESPONSE=1 \
 	STUB_BOOTSTRAP_CORE_USED=100 STUB_GH_DEBUG_RESOURCE=core \
 	STUB_GH_DEBUG_STATUS=200 STUB_GH_DEBUG_USED=107 STUB_GH_DEBUG_REMAINING=4893 \
 	STUB_GH_DEBUG_RESET=2000 "$SHIM_RUN" auth status >/dev/null 2>/dev/null
-if [[ "$(_read_last_attempt_field "$native_single_log" 2)" == "gh_auth_status" \
-	&& "$(_read_last_attempt_field "$native_single_log" 3)" == "rest" \
-	&& "$(_read_last_attempt_field "$native_single_log" 15)" == "200" \
-	&& "$(_read_attempt_quota "$native_single_log")" == "1" ]]; then
-	_pass "native single-frame auth REST response records exact cost"
+if [[ ! -s "$native_single_log" ]]; then
+	_pass "native auth control bypasses exact quota transport"
 else
-	_fail "native single-frame auth REST quota attribution" "log: $(cat "$native_single_log" 2>/dev/null || true)"
+	_fail "native auth control quota bypass" "log: $(cat "$native_single_log" 2>/dev/null || true)"
 fi
 
 opaque_single_log="$TMP/exact-native-opaque-single-rest.log"
@@ -375,9 +371,9 @@ zero_frame_state="$TMP/exact-zero-frame-state"
 : >"$zero_frame_log"
 GH_TOKEN=fixture-token AIDEVOPS_GH_EXACT_QUOTA_CAPTURE=1 \
 	AIDEVOPS_GH_QUOTA_STATE_DIR="$zero_frame_state" AIDEVOPS_TEMP_DIR="$exact_temp" \
-	AIDEVOPS_GH_API_LOG="$zero_frame_log" "$SHIM_RUN" auth status >/dev/null 2>/dev/null
+	AIDEVOPS_GH_API_LOG="$zero_frame_log" "$SHIM_RUN" repo view owner/repo >/dev/null 2>/dev/null
 if [[ "$(grep -c $'\tgh-quota-bootstrap\t.*\tattempt\t' "$zero_frame_log" || true)" == "1" \
-	&& "$(grep -c $'\tgh_auth_status\t.*\tattempt\t' "$zero_frame_log" || true)" == "0" ]]; then
+	&& "$(grep -c $'\tgh_repo_view\t.*\tattempt\t' "$zero_frame_log" || true)" == "0" ]]; then
 	_pass "valid zero-response capture adds no synthetic transport attempt"
 else
 	_fail "zero-response exact capture" "log: $(cat "$zero_frame_log" 2>/dev/null || true)"


### PR DESCRIPTION
## Summary

Implementation for issue #29607.

## Files Changed

.agents/scripts/approval-helper.sh, .agents/scripts/gh, .agents/scripts/tests/test-approval-helper-sudo-gh-auth.sh, .agents/scripts/tests/test-gh-api-instrument.sh, .agents/scripts/tests/test-gh-shim-quota-cases.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: executed the changed gh shim against the live keyring; gh auth status exited successfully and gh api user returned the expected authenticated account. The isolated sudo recovery integration fixture reproduced transient auth-status failure followed by HTTP 200 and exited successfully; targeted approval, instrumentation, shim, and local linter suites passed.

Resolves #29607


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.226 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 23m and 387,230 tokens on this with the user in an interactive session.