### PR TITLE
GH#29589: defer rate-limited GitHub releases

### DIFF
--- a/.agents/scripts/github-release-helper.sh
+++ b/.agents/scripts/github-release-helper.sh
@@ -30,8 +30,9 @@
 #
 # Exit codes:
 #   0 — success
-#   1 — validation error or gh command failure
+#   1 — validation error or permanent gh command failure
 #   2 — missing dependency (gh CLI not found or not authenticated)
+#   75 — temporary GitHub rate limit; retry the same idempotent command later
 #
 # Environment:
 #   GITHUB_RELEASE_REPO  Override repo slug (same as --repo flag)
@@ -146,6 +147,34 @@ release_exists() {
 	local tag="$2"
 	gh release view "$tag" --repo "$repo" >/dev/null 2>&1
 	return $?
+}
+
+# Distinguish GitHub quota exhaustion from permanent HTTP 403 permission errors.
+_is_github_rate_limit_error() {
+	local output="$1"
+	if printf '%s\n' "$output" | LC_ALL=C grep -qiE \
+		'api rate limit exceeded|secondary rate limit|rateLimitExceeded|rate limit exceeded for installation'; then
+		return 0
+	fi
+	return 1
+}
+
+_is_github_permission_error() {
+	local output="$1"
+	if _is_github_rate_limit_error "$output"; then
+		return 1
+	fi
+	if printf '%s\n' "$output" | LC_ALL=C grep -qiE \
+		'HTTP 403|Resource not accessible by integration|Must have admin rights|permission denied'; then
+		return 0
+	fi
+	return 1
+}
+
+_print_rate_limit_deferral() {
+	print_warning "GitHub release operation deferred: installation API rate limit exhausted"
+	print_info "Re-run the same create command after the GitHub rate limit resets; existing or missing release state will be reconciled idempotently"
+	return 0
 }
 
 # =============================================================================
@@ -279,7 +308,7 @@ _resolve_create_inputs() {
 # Reconcile optional metadata without invalidating an already verified release.
 _reconcile_release_metadata() {
 	local gh_args=("$_create_tag" "--repo" "$_create_repo" "--title" "$_create_title")
-	local attempt=1 output=""
+	local attempt=1 output="" permission_failure=false
 	if [[ -n "$_create_flag_notes_file" ]]; then
 		gh_args+=("--notes-file" "$_create_flag_notes_file")
 	elif [[ -n "$_create_flag_notes" ]]; then
@@ -292,12 +321,22 @@ _reconcile_release_metadata() {
 			return 0
 		fi
 		print_warning "Release metadata reconciliation attempt $attempt/3 failed: $output"
-		if [[ "$output" == *"rate limit"* || "$output" == *"HTTP 403"* ]]; then
+		if _is_github_rate_limit_error "$output"; then
+			_print_rate_limit_deferral
+			print_warning "Release '$_create_tag' publication is verified; metadata reconciliation is deferred"
+			return 0
+		fi
+		if _is_github_permission_error "$output"; then
+			permission_failure=true
 			break
 		fi
 		((attempt++))
 	done
 
+	if [[ "$permission_failure" == true ]]; then
+		print_error "Release '$_create_tag' metadata reconciliation failed with a permanent permission error"
+		return 1
+	fi
 	if release_exists "$_create_repo" "$_create_tag"; then
 		print_warning "Release '$_create_tag' publication is verified; metadata reconciliation is deferred"
 		return 0
@@ -341,11 +380,14 @@ _execute_release_create() {
 	[[ "$_create_flag_draft" == true ]] && gh_args+=("--draft")
 	[[ "$_create_flag_prerelease" == true ]] && gh_args+=("--prerelease")
 
+	local output=""
 	print_info "Creating release..."
-	if gh release create "${gh_args[@]}"; then
+	if output=$(gh release create "${gh_args[@]}" 2>&1); then
+		[[ -n "$output" ]] && printf '%s\n' "$output"
 		print_success "Release '$_create_tag' created on $_create_repo"
 		return 0
 	else
+		[[ -n "$output" ]] && printf '%s\n' "$output" >&2
 		if release_exists "$_create_repo" "$_create_tag"; then
 			print_warning "Release '$_create_tag' now exists on $_create_repo — treating duplicate create as already complete"
 			if [[ "$_create_flag_reconcile_existing" == true ]]; then
@@ -353,6 +395,10 @@ _execute_release_create() {
 				return $?
 			fi
 			return 0
+		fi
+		if _is_github_rate_limit_error "$output"; then
+			_print_rate_limit_deferral
+			return 75
 		fi
 		print_error "Failed to create release '$_create_tag' on $_create_repo"
 		return 1
@@ -364,6 +410,7 @@ _execute_release_create() {
 # =============================================================================
 
 cmd_create() {
+	local create_rc=0
 	# Initialise state for the create subcommand (reset before each invocation)
 	_create_version=""
 	_create_flag_repo=""
@@ -379,8 +426,8 @@ cmd_create() {
 
 	_parse_create_args "$@" || return 1
 	_resolve_create_inputs || return 1
-	_execute_release_create || return 1
-	return 0
+	_execute_release_create || create_rc=$?
+	return "$create_rc"
 }
 
 cmd_draft() {

--- a/.agents/scripts/github-release-helper.sh
+++ b/.agents/scripts/github-release-helper.sh
@@ -388,6 +388,10 @@ _execute_release_create() {
 		return 0
 	else
 		[[ -n "$output" ]] && printf '%s\n' "$output" >&2
+		if _is_github_rate_limit_error "$output"; then
+			_print_rate_limit_deferral
+			return 75
+		fi
 		if release_exists "$_create_repo" "$_create_tag"; then
 			print_warning "Release '$_create_tag' now exists on $_create_repo — treating duplicate create as already complete"
 			if [[ "$_create_flag_reconcile_existing" == true ]]; then
@@ -395,10 +399,6 @@ _execute_release_create() {
 				return $?
 			fi
 			return 0
-		fi
-		if _is_github_rate_limit_error "$output"; then
-			_print_rate_limit_deferral
-			return 75
 		fi
 		print_error "Failed to create release '$_create_tag' on $_create_repo"
 		return 1

--- a/.agents/scripts/tests/test-github-release-helper-idempotent.sh
+++ b/.agents/scripts/tests/test-github-release-helper-idempotent.sh
@@ -60,6 +60,14 @@ if [[ "${1:-}" == "release" && "${2:-}" == "view" ]]; then
 fi
 
 if [[ "${1:-}" == "release" && "${2:-}" == "create" ]]; then
+	if [[ "${FAKE_CREATE_RATE_LIMIT:-0}" == "1" ]]; then
+		printf 'HTTP 403: API rate limit exceeded for installation while calling /repos/marcusquinn/aidevops/releases\n' >&2
+		exit 1
+	fi
+	if [[ "${FAKE_CREATE_PERMISSION:-0}" == "1" ]]; then
+		printf 'HTTP 403: Resource not accessible by integration\n' >&2
+		exit 1
+	fi
 	if [[ "${FAKE_CREATE_DUPLICATES:-0}" == "1" ]]; then
 		: >"$marker_file"
 		printf 'HTTP 422: Validation Failed (Release.tag_name already exists)\n' >&2
@@ -75,6 +83,10 @@ if [[ "${1:-}" == "release" && "${2:-}" == "edit" ]]; then
 		printf 'HTTP 403: API rate limit exceeded for installation\n' >&2
 		exit 1
 	fi
+	if [[ "${FAKE_EDIT_PERMISSION:-0}" == "1" ]]; then
+		printf 'HTTP 403: Resource not accessible by integration\n' >&2
+		exit 1
+	fi
 	exit 0
 fi
 
@@ -88,7 +100,10 @@ export FAKE_GH_RELEASE_MARKER="${TEST_ROOT}/release-created.marker"
 rm -f "$FAKE_GH_LOG" "$FAKE_GH_RELEASE_MARKER"
 export FAKE_RELEASE_EXISTS=1
 export FAKE_CREATE_DUPLICATES=0
+export FAKE_CREATE_RATE_LIMIT=0
+export FAKE_CREATE_PERMISSION=0
 export FAKE_EDIT_RATE_LIMIT=0
+export FAKE_EDIT_PERMISSION=0
 rc=0
 output=$("${TEST_SCRIPTS_DIR}/github-release-helper.sh" create 1.2.4 --repo marcusquinn/aidevops --notes 'notes' 2>&1) || rc=$?
 if [[ "$rc" -eq 0 && "$output" == *"already exists"* ]]; then
@@ -137,6 +152,57 @@ if [[ "$EDIT_COUNT" -eq 1 ]]; then
 	print_result 'rate-limited metadata reconciliation stops without retry storm' 0
 else
 	print_result 'rate-limited metadata reconciliation stops without retry storm' 1 "edit_count=$EDIT_COUNT"
+fi
+
+rm -f "$FAKE_GH_LOG" "$FAKE_GH_RELEASE_MARKER"
+export FAKE_RELEASE_EXISTS=0
+export FAKE_CREATE_RATE_LIMIT=1
+rc=0
+output=$("${TEST_SCRIPTS_DIR}/github-release-helper.sh" create 1.2.4 --repo marcusquinn/aidevops --notes 'notes' --reconcile-existing 2>&1) || rc=$?
+if [[ "$rc" -eq 75 && "$output" == *"operation deferred"* && "$output" == *"Re-run the same create command"* ]]; then
+	print_result 'installation rate-limited create returns recoverable deferral' 0
+else
+	print_result 'installation rate-limited create returns recoverable deferral' 1 "rc=$rc output=$output"
+fi
+
+CREATE_COUNT=$(grep -c 'release create' "$FAKE_GH_LOG" 2>/dev/null || true)
+if [[ "$CREATE_COUNT" -eq 1 ]]; then
+	print_result 'rate-limited create stops without retry storm' 0
+else
+	print_result 'rate-limited create stops without retry storm' 1 "create_count=$CREATE_COUNT"
+fi
+
+export FAKE_CREATE_RATE_LIMIT=0
+rc=0
+output=$("${TEST_SCRIPTS_DIR}/github-release-helper.sh" create 1.2.4 --repo marcusquinn/aidevops --notes 'notes' --reconcile-existing 2>&1) || rc=$?
+if [[ "$rc" -eq 0 && "$output" == *"created"* && -f "$FAKE_GH_RELEASE_MARKER" ]]; then
+	print_result 'rerun after rate-limit reset creates missing release' 0
+else
+	print_result 'rerun after rate-limit reset creates missing release' 1 "rc=$rc output=$output"
+fi
+
+rm -f "$FAKE_GH_LOG" "$FAKE_GH_RELEASE_MARKER"
+export FAKE_RELEASE_EXISTS=0
+export FAKE_CREATE_PERMISSION=1
+rc=0
+output=$("${TEST_SCRIPTS_DIR}/github-release-helper.sh" create 1.2.4 --repo marcusquinn/aidevops --notes 'notes' 2>&1) || rc=$?
+if [[ "$rc" -eq 1 && "$output" == *"Resource not accessible"* && "$output" != *"operation deferred"* ]]; then
+	print_result 'permanent create permission failure fails closed' 0
+else
+	print_result 'permanent create permission failure fails closed' 1 "rc=$rc output=$output"
+fi
+
+rm -f "$FAKE_GH_LOG" "$FAKE_GH_RELEASE_MARKER"
+export FAKE_CREATE_PERMISSION=0
+export FAKE_RELEASE_EXISTS=1
+export FAKE_EDIT_RATE_LIMIT=0
+export FAKE_EDIT_PERMISSION=1
+rc=0
+output=$("${TEST_SCRIPTS_DIR}/github-release-helper.sh" create 1.2.4 --repo marcusquinn/aidevops --notes 'notes' --reconcile-existing 2>&1) || rc=$?
+if [[ "$rc" -eq 1 && "$output" == *"permanent permission error"* && "$output" != *"metadata reconciliation is deferred"* ]]; then
+	print_result 'permanent metadata permission failure fails closed' 0
+else
+	print_result 'permanent metadata permission failure fails closed' 1 "rc=$rc output=$output"
 fi
 
 printf '\nTests run: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/tests/test-github-release-helper-idempotent.sh
+++ b/.agents/scripts/tests/test-github-release-helper-idempotent.sh
@@ -172,6 +172,13 @@ else
 	print_result 'rate-limited create stops without retry storm' 1 "create_count=$CREATE_COUNT"
 fi
 
+VIEW_COUNT=$(grep -c 'release view' "$FAKE_GH_LOG" 2>/dev/null || true)
+if [[ "$VIEW_COUNT" -eq 1 ]]; then
+	print_result 'rate-limited create avoids a second quota-bound existence check' 0
+else
+	print_result 'rate-limited create avoids a second quota-bound existence check' 1 "view_count=$VIEW_COUNT"
+fi
+
 export FAKE_CREATE_RATE_LIMIT=0
 rc=0
 output=$("${TEST_SCRIPTS_DIR}/github-release-helper.sh" create 1.2.4 --repo marcusquinn/aidevops --notes 'notes' --reconcile-existing 2>&1) || rc=$?

--- a/.agents/scripts/tests/test-release-publication-workflows.sh
+++ b/.agents/scripts/tests/test-release-publication-workflows.sh
@@ -86,6 +86,13 @@ assert_contains "checked-out commit is bound to the immutable tag" \
 	'[[ "$CHECKOUT_COMMIT" == "$TAG_COMMIT" ]]' "$PACKAGE_WORKFLOW"
 # shellcheck disable=SC2016 # Match the literal workflow shell variable.
 assert_contains "release notes cross steps through a file" '--notes-file "$RUNNER_TEMP/release-notes.md"' "$PACKAGE_WORKFLOW"
+# shellcheck disable=SC2016 # Match the literal workflow shell variable.
+assert_contains "rate-limited GitHub release create records a deferred checkpoint" \
+	'echo "deferred=true" >> "$GITHUB_OUTPUT"' "$PACKAGE_WORKFLOW"
+assert_contains "rate-limited GitHub release create has recovery guidance" \
+	"re-run this workflow with the same verified tag and correlation" "$PACKAGE_WORKFLOW"
+assert_contains "postflight waits for deferred GitHub release reconciliation" \
+	"if: steps.github-release.outputs.deferred != 'true'" "$PACKAGE_WORKFLOW"
 assert_absent "release notes cannot inject into generated workflow shell" 'steps.changelog.outputs.body' "$PACKAGE_WORKFLOW"
 assert_absent "release-note collection avoids pipefail truncation" '| head -10' "$PACKAGE_WORKFLOW"
 # shellcheck disable=SC2016 # Match the literal workflow expression.

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -120,15 +120,24 @@ jobs:
           printf '%s\n' "$BODY" > "$RUNNER_TEMP/release-notes.md"
 
       - name: Create or reconcile GitHub release
+        id: github-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          RELEASE_RC=0
           bash .agents/scripts/github-release-helper.sh create "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --tag "$RELEASE_TAG" \
             --title "$RELEASE_TAG" \
             --notes-file "$RUNNER_TEMP/release-notes.md" \
-            --reconcile-existing
+            --reconcile-existing || RELEASE_RC=$?
+          if [[ "$RELEASE_RC" -eq 75 ]]; then
+            echo "deferred=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::GitHub release creation is deferred until the installation API rate limit resets; re-run this workflow with the same verified tag and correlation"
+            exit 0
+          fi
+          [[ "$RELEASE_RC" -eq 0 ]] || exit "$RELEASE_RC"
+          echo "deferred=false" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -356,6 +365,7 @@ jobs:
           exit 1
 
       - name: Queue exact-tag postflight
+        if: steps.github-release.outputs.deferred != 'true'
         env:
           SYNC_TOKEN: ${{ secrets.SYNC_PAT }}
           JOB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -383,6 +393,10 @@ jobs:
           echo "## Release Published" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Version:** $RELEASE_VERSION" >> "$GITHUB_STEP_SUMMARY"
-          echo "**GitHub:** reconciled" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "${{ steps.github-release.outputs.deferred }}" == "true" ]]; then
+            echo "**GitHub:** deferred by installation API rate limit; re-run recovery after reset" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "**GitHub:** reconciled" >> "$GITHUB_STEP_SUMMARY"
+          fi
           echo "**npm:** verified through Trusted Publisher (OIDC)" >> "$GITHUB_STEP_SUMMARY"
           echo "**Homebrew SHA256:** $RELEASE_SHA256" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Classify installation rate limits as recoverable exit 75, preserve idempotent package publication, and defer postflight until GitHub release reconciliation succeeds.

## Files Changed

.agents/scripts/github-release-helper.sh, .agents/scripts/tests/test-github-release-helper-idempotent.sh, .agents/scripts/tests/test-release-publication-workflows.sh, .github/workflows/publish-packages.yml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime-verified with 12 mocked release-helper scenarios; release workflow and stamp-gap fixtures pass; ShellCheck, local preflight, and Qlty delta 0.

Resolves #29589


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.226 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 33m and 243,367 tokens on this with the user in an interactive session.