### PR TITLE
GH#29588: prevent synthetic maintainer gate statuses

### DIFF
--- a/.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh
+++ b/.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh
@@ -179,6 +179,81 @@ assert_contains "post_maintainer_gate_status_with_retry error" \
 # -------------------------------------------------------------------
 JOB3_RUN_SCRIPT=$(python3 -c 'import sys,yaml; data=yaml.safe_load(open(sys.argv[1])); print(data["jobs"]["retrigger-pr-checks"]["steps"][0]["run"])' "$WORKFLOW_FILE" 2>/dev/null || true)
 
+gh() {
+	local command=""
+	local subcommand=""
+	if [[ $# -gt 0 ]]; then
+		command="$1"
+		shift
+	fi
+	if [[ $# -gt 0 ]]; then
+		subcommand="$1"
+		shift
+	fi
+	local args="$*"
+	if [[ "$command" == "pr" && "$subcommand" == "list" ]]; then
+		printf '%s\n' '[{"number":101,"body":"Resolves #42","title":"fixture"}]'
+		return 0
+	fi
+	if [[ "$command" == "api" && "$subcommand" == "repos/owner/repo/pulls/101" ]]; then
+		case "$FIXTURE_LOOKUP_MODE" in
+		pr-missing)
+			printf 'gh: Not Found (HTTP 404)\n' >&2
+			return 1
+			;;
+		pr-failure) return 1 ;;
+		pr-closed)
+			printf '{"labels":%s,"assoc":"%s","author":"fixture-author","head_sha":"fixture-head","state":"closed"}\n' \
+				"$FIXTURE_LABELS_JSON" "$FIXTURE_ASSOCIATION"
+			return 0
+			;;
+		esac
+		printf '{"labels":%s,"assoc":"%s","author":"fixture-author","head_sha":"fixture-head","state":"open"}\n' \
+			"$FIXTURE_LABELS_JSON" "$FIXTURE_ASSOCIATION"
+		return 0
+	fi
+	if [[ "$command" == "api" && "$subcommand" == "repos/owner/repo/collaborators/fixture-author/permission" ]]; then
+		printf '%s\n' "$FIXTURE_PERMISSION"
+		return 0
+	fi
+	if [[ "$command" == "api" && "$subcommand" == repos/owner/repo/statuses/* ]]; then
+		local status=""
+		case "$args" in
+		*"state=success"*) status="success" ;;
+		*"state=pending"*) status="pending" ;;
+		*"state=error"*) status="error" ;;
+		esac
+		[[ -n "$status" ]] && printf '%s\n' "$status" >>"$FIXTURE_STATUS_FILE"
+		return 0
+	fi
+	if [[ "$command" == "api" && "$subcommand" == repos/owner/repo/actions/workflows/maintainer-gate.yml/runs* ]]; then
+		case "$FIXTURE_LOOKUP_MODE" in
+		failure) return 1 ;;
+		missing) printf '{"completed":null,"active":null}\n' ;;
+		active) printf '{"completed":null,"active":{"id":502,"status":"in_progress"}}\n' ;;
+		*) printf '{"completed":{"id":501,"status":"completed","conclusion":"success"},"active":null}\n' ;;
+		esac
+		return 0
+	fi
+	if [[ "$command" == "api" && "$subcommand" == "repos/owner/repo/actions/runs/501/rerun" ]]; then
+		local rerun_count=0
+		rerun_count=$(<"$FIXTURE_RERUN_FILE")
+		rerun_count=$((rerun_count + 1))
+		printf '%s' "$rerun_count" >"$FIXTURE_RERUN_FILE"
+		if [[ "$rerun_count" -gt "$FIXTURE_RERUN_FAILURES" ]]; then
+			return 0
+		fi
+		return 1
+	fi
+	return 1
+}
+
+sleep() {
+	local seconds="$1"
+	[[ -n "$seconds" ]]
+	return 0
+}
+
 run_job3_fixture() {
 	local fixture_name="$1"
 	local association="$2"
@@ -203,77 +278,6 @@ run_job3_fixture() {
 		export FIXTURE_PERMISSION="$permission" FIXTURE_RERUN_FAILURES="$rerun_failures"
 		export FIXTURE_LOOKUP_MODE="$lookup_mode" FIXTURE_STATUS_FILE="$status_file"
 		export FIXTURE_RERUN_FILE="$rerun_file"
-		gh() {
-			local command=""
-			local subcommand=""
-			if [[ $# -gt 0 ]]; then
-				command="$1"
-				shift
-			fi
-			if [[ $# -gt 0 ]]; then
-				subcommand="$1"
-				shift
-			fi
-			local args="$*"
-			if [[ "$command" == "pr" && "$subcommand" == "list" ]]; then
-				printf '%s\n' '[{"number":101,"body":"Resolves #42","title":"fixture"}]'
-				return 0
-			fi
-			if [[ "$command" == "api" && "$subcommand" == "repos/owner/repo/pulls/101" ]]; then
-				case "$FIXTURE_LOOKUP_MODE" in
-				pr-missing)
-					printf 'gh: Not Found (HTTP 404)\n' >&2
-					return 1
-					;;
-				pr-failure) return 1 ;;
-				pr-closed)
-					printf '{"labels":%s,"assoc":"%s","author":"fixture-author","head_sha":"fixture-head","state":"closed"}\n' \
-						"$FIXTURE_LABELS_JSON" "$FIXTURE_ASSOCIATION"
-					return 0
-					;;
-				esac
-				printf '{"labels":%s,"assoc":"%s","author":"fixture-author","head_sha":"fixture-head","state":"open"}\n' \
-					"$FIXTURE_LABELS_JSON" "$FIXTURE_ASSOCIATION"
-				return 0
-			fi
-			if [[ "$command" == "api" && "$subcommand" == "repos/owner/repo/collaborators/fixture-author/permission" ]]; then
-				printf '%s\n' "$FIXTURE_PERMISSION"
-				return 0
-			fi
-			if [[ "$command" == "api" && "$subcommand" == repos/owner/repo/statuses/* ]]; then
-				local status=""
-				case "$args" in
-				*"state=success"*) status="success" ;;
-				*"state=pending"*) status="pending" ;;
-				*"state=error"*) status="error" ;;
-				esac
-				[[ -n "$status" ]] && printf '%s\n' "$status" >>"$FIXTURE_STATUS_FILE"
-				return 0
-			fi
-			if [[ "$command" == "api" && "$subcommand" == repos/owner/repo/actions/workflows/maintainer-gate.yml/runs* ]]; then
-				case "$FIXTURE_LOOKUP_MODE" in
-				failure) return 1 ;;
-				missing) printf '{"completed":null,"active":null}\n' ;;
-				active) printf '{"completed":null,"active":{"id":502,"status":"in_progress"}}\n' ;;
-				*) printf '{"completed":{"id":501,"status":"completed","conclusion":"success"},"active":null}\n' ;;
-				esac
-				return 0
-			fi
-			if [[ "$command" == "api" && "$subcommand" == "repos/owner/repo/actions/runs/501/rerun" ]]; then
-				local rerun_count=0
-				rerun_count=$(<"$FIXTURE_RERUN_FILE")
-				rerun_count=$((rerun_count + 1))
-				printf '%s' "$rerun_count" >"$FIXTURE_RERUN_FILE"
-				[[ "$rerun_count" -gt "$FIXTURE_RERUN_FAILURES" ]]
-				return $?
-			fi
-			return 1
-		}
-		sleep() {
-			local seconds="$1"
-			[[ -n "$seconds" ]]
-			return 0
-		}
 		export -f gh sleep
 		bash -c "$JOB3_RUN_SCRIPT"
 	) >/dev/null 2>&1 || fixture_rc=$?

--- a/.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh
+++ b/.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh
@@ -171,6 +171,10 @@ else
 fi
 assert_contains "rerun_maintainer_gate_with_retry" \
 	"Job 3 defines bounded rerun scheduling"
+assert_contains "per_page=100" \
+	"Job 3 queries multiple exact-head workflow runs"
+assert_contains 'select\(\.status == "completed" and \(\.conclusion != null\)\)' \
+	"Job 3 selects a terminal rerunnable workflow run"
 assert_contains "post_maintainer_gate_status_with_retry error" \
 	"Job 3 replaces unresolved pending with terminal error"
 
@@ -207,6 +211,11 @@ gh() {
 				"$FIXTURE_LABELS_JSON" "$FIXTURE_ASSOCIATION"
 			return 0
 			;;
+		pr-state-missing)
+			printf '{"labels":%s,"assoc":"%s","author":"fixture-author","head_sha":"fixture-head","state":null}\n' \
+				"$FIXTURE_LABELS_JSON" "$FIXTURE_ASSOCIATION"
+			return 0
+			;;
 		esac
 		printf '{"labels":%s,"assoc":"%s","author":"fixture-author","head_sha":"fixture-head","state":"open"}\n' \
 			"$FIXTURE_LABELS_JSON" "$FIXTURE_ASSOCIATION"
@@ -231,6 +240,7 @@ gh() {
 		failure) return 1 ;;
 		missing) printf '{"completed":null,"active":null}\n' ;;
 		active) printf '{"completed":null,"active":{"id":502,"status":"in_progress"}}\n' ;;
+		active-and-completed) printf '{"completed":{"id":501,"status":"completed","conclusion":"success"},"active":{"id":502,"status":"in_progress"}}\n' ;;
 		*) printf '{"completed":{"id":501,"status":"completed","conclusion":"success"},"active":null}\n' ;;
 		esac
 		return 0
@@ -304,6 +314,7 @@ else
 	run_job3_fixture "MEMBER exemption" "MEMBER" '["origin:interactive"]' "" 0 "found" 0 "success" 0
 	run_job3_fixture "COLLABORATOR write exemption" "COLLABORATOR" '["origin:interactive"]' "write" 0 "found" 0 "success" 0
 	run_job3_fixture "accepted rerun" "NONE" '[]' "" 0 "found" 0 "pending" 1
+	run_job3_fixture "completed run selected behind active run" "NONE" '[]' "" 0 "active-and-completed" 0 "pending" 1
 	run_job3_fixture "transient rerun rejection retries" "NONE" '[]' "" 2 "found" 0 "pending" 3
 	run_job3_fixture "exhausted rerun becomes terminal" "NONE" '[]' "" 3 "found" 1 "error,pending" 3
 	run_job3_fixture "active run remains status owner" "NONE" '[]' "" 0 "active" 0 "" 0
@@ -311,6 +322,7 @@ else
 	run_job3_fixture "run lookup failure remains fail closed" "NONE" '[]' "" 0 "failure" 1 "error" 0
 	run_job3_fixture "closed PR is a non-blocking diagnostic" "NONE" '[]' "" 0 "pr-closed" 0 "" 0
 	run_job3_fixture "missing PR is a non-blocking diagnostic" "NONE" '[]' "" 0 "pr-missing" 0 "" 0
+	run_job3_fixture "missing PR state remains fail closed" "NONE" '[]' "" 0 "pr-state-missing" 1 "" 0
 	run_job3_fixture "transient PR metadata failure remains fail closed" "NONE" '[]' "" 0 "pr-failure" 1 "" 0
 fi
 

--- a/.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh
+++ b/.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh
@@ -162,8 +162,8 @@ assert_contains "GH#24546/GH#24958" \
 	"trust-boundary marker covers maintainer-operated collaborator fallback"
 assert_contains "pulls/.*PR_NUM" \
 	"Job 3 reads PR metadata from the REST pulls endpoint"
-assert_contains "author_association.*user.login.*head.sha" \
-	"Job 3 projects REST author association, login, and exact head metadata"
+assert_contains "author_association.*user.login.*head.sha.*state" \
+	"Job 3 projects REST author association, login, exact head, and state metadata"
 if grep -q 'authorAssociation' "$WORKFLOW_FILE" 2>/dev/null; then
 	print_result "Job 3 avoids unsupported gh authorAssociation projection" 1
 else
@@ -220,7 +220,19 @@ run_job3_fixture() {
 				return 0
 			fi
 			if [[ "$command" == "api" && "$subcommand" == "repos/owner/repo/pulls/101" ]]; then
-				printf '{"labels":%s,"assoc":"%s","author":"fixture-author","head_sha":"fixture-head"}\n' \
+				case "$FIXTURE_LOOKUP_MODE" in
+				pr-missing)
+					printf 'gh: Not Found (HTTP 404)\n' >&2
+					return 1
+					;;
+				pr-failure) return 1 ;;
+				pr-closed)
+					printf '{"labels":%s,"assoc":"%s","author":"fixture-author","head_sha":"fixture-head","state":"closed"}\n' \
+						"$FIXTURE_LABELS_JSON" "$FIXTURE_ASSOCIATION"
+					return 0
+					;;
+				esac
+				printf '{"labels":%s,"assoc":"%s","author":"fixture-author","head_sha":"fixture-head","state":"open"}\n' \
 					"$FIXTURE_LABELS_JSON" "$FIXTURE_ASSOCIATION"
 				return 0
 			fi
@@ -239,10 +251,12 @@ run_job3_fixture() {
 				return 0
 			fi
 			if [[ "$command" == "api" && "$subcommand" == repos/owner/repo/actions/workflows/maintainer-gate.yml/runs* ]]; then
-				if [[ "$FIXTURE_LOOKUP_MODE" == "missing" ]]; then
-					return 0
-				fi
-				printf '501\tcompleted\n'
+				case "$FIXTURE_LOOKUP_MODE" in
+				failure) return 1 ;;
+				missing) printf '{"completed":null,"active":null}\n' ;;
+				active) printf '{"completed":null,"active":{"id":502,"status":"in_progress"}}\n' ;;
+				*) printf '{"completed":{"id":501,"status":"completed","conclusion":"success"},"active":null}\n' ;;
+				esac
 				return 0
 			fi
 			if [[ "$command" == "api" && "$subcommand" == "repos/owner/repo/actions/runs/501/rerun" ]]; then
@@ -286,9 +300,14 @@ else
 	run_job3_fixture "MEMBER exemption" "MEMBER" '["origin:interactive"]' "" 0 "found" 0 "success" 0
 	run_job3_fixture "COLLABORATOR write exemption" "COLLABORATOR" '["origin:interactive"]' "write" 0 "found" 0 "success" 0
 	run_job3_fixture "accepted rerun" "NONE" '[]' "" 0 "found" 0 "pending" 1
-	run_job3_fixture "already-running bounded retry" "NONE" '[]' "" 2 "found" 0 "pending" 3
+	run_job3_fixture "transient rerun rejection retries" "NONE" '[]' "" 2 "found" 0 "pending" 3
 	run_job3_fixture "exhausted rerun becomes terminal" "NONE" '[]' "" 3 "found" 1 "error,pending" 3
-	run_job3_fixture "missing run becomes terminal" "NONE" '[]' "" 0 "missing" 1 "error,pending" 0
+	run_job3_fixture "active run remains status owner" "NONE" '[]' "" 0 "active" 0 "" 0
+	run_job3_fixture "missing run becomes terminal without pending" "NONE" '[]' "" 0 "missing" 1 "error" 0
+	run_job3_fixture "run lookup failure remains fail closed" "NONE" '[]' "" 0 "failure" 1 "error" 0
+	run_job3_fixture "closed PR is a non-blocking diagnostic" "NONE" '[]' "" 0 "pr-closed" 0 "" 0
+	run_job3_fixture "missing PR is a non-blocking diagnostic" "NONE" '[]' "" 0 "pr-missing" 0 "" 0
+	run_job3_fixture "transient PR metadata failure remains fail closed" "NONE" '[]' "" 0 "pr-failure" 1 "" 0
 fi
 
 # -------------------------------------------------------------------

--- a/.github/workflows/maintainer-gate-reusable.yml
+++ b/.github/workflows/maintainer-gate-reusable.yml
@@ -884,8 +884,13 @@ jobs:
               continue
             fi
             PR_STATE=$(printf '%s' "$PR_INFO" | jq -r '.state // empty' 2>/dev/null || true)
+            if [[ -z "$PR_STATE" ]]; then
+              echo "::error::Could not validate state for PR #$PR_NUM from REST metadata"
+              RERUN_SCHEDULING_FAILED=true
+              continue
+            fi
             if [[ "$PR_STATE" != "open" ]]; then
-              echo "::warning::PR #$PR_NUM is ${PR_STATE:-unavailable} — skipping obsolete maintainer-gate refresh"
+              echo "::warning::PR #$PR_NUM is $PR_STATE — skipping obsolete maintainer-gate refresh"
               continue
             fi
             HEAD_SHA=$(printf '%s' "$PR_INFO" | jq -r '.head_sha // empty' 2>/dev/null || true)
@@ -980,7 +985,7 @@ jobs:
             # -----------------------------------------------------------------
             RUN_LOOKUP=""
             if ! RUN_LOOKUP=$(gh api \
-              "repos/${REPO}/actions/workflows/maintainer-gate.yml/runs?head_sha=${HEAD_SHA}&event=pull_request_target&per_page=10" \
+              "repos/${REPO}/actions/workflows/maintainer-gate.yml/runs?head_sha=${HEAD_SHA}&event=pull_request_target&per_page=100" \
               --jq '{
                 completed: ([.workflow_runs[] | select(.status == "completed" and (.conclusion != null)) | {id, status, conclusion}][0] // null),
                 active: ([.workflow_runs[] | select(.status != "completed") | {id, status}][0] // null)

--- a/.github/workflows/maintainer-gate-reusable.yml
+++ b/.github/workflows/maintainer-gate-reusable.yml
@@ -873,10 +873,19 @@ jobs:
             # metadata or turn an exemption into an indefinite pending status.
             PR_INFO=""
             if ! PR_INFO=$(gh api "repos/${REPO}/pulls/${PR_NUM}" \
-              --jq '{labels: [.labels[].name], assoc: .author_association, author: .user.login, head_sha: .head.sha}' \
-              2>/dev/null); then
+              --jq '{labels: [.labels[].name], assoc: .author_association, author: .user.login, head_sha: .head.sha, state: .state}' \
+              2>&1); then
+              if printf '%s' "$PR_INFO" | grep -q 'HTTP 404'; then
+                echo "::warning::PR #$PR_NUM is no longer available — skipping obsolete maintainer-gate refresh"
+                continue
+              fi
               echo "::error::Could not read REST metadata for PR #$PR_NUM"
               RERUN_SCHEDULING_FAILED=true
+              continue
+            fi
+            PR_STATE=$(printf '%s' "$PR_INFO" | jq -r '.state // empty' 2>/dev/null || true)
+            if [[ "$PR_STATE" != "open" ]]; then
+              echo "::warning::PR #$PR_NUM is ${PR_STATE:-unavailable} — skipping obsolete maintainer-gate refresh"
               continue
             fi
             HEAD_SHA=$(printf '%s' "$PR_INFO" | jq -r '.head_sha // empty' 2>/dev/null || true)
@@ -954,16 +963,6 @@ jobs:
               fi
             fi
 
-            # Post pending status while Job 1 re-evaluates
-            # t2037: Job 3 is pure plumbing — gate evaluation is Job 1's sole responsibility
-            if ! post_maintainer_gate_status_with_retry \
-              pending \
-              "Refreshing via Job 1 rerun..."; then
-              echo "::error::Could not publish pending maintainer-gate status for PR #$PR_NUM"
-              RERUN_SCHEDULING_FAILED=true
-              continue
-            fi
-
             # -----------------------------------------------------------------
             # t2018 + t2037: Trigger Job 1 rerun so it re-evaluates gate
             # conditions against current issue state. Use full /rerun endpoint
@@ -981,26 +980,50 @@ jobs:
             # -----------------------------------------------------------------
             RUN_LOOKUP=""
             if ! RUN_LOOKUP=$(gh api \
-              "repos/${REPO}/actions/workflows/maintainer-gate.yml/runs?head_sha=${HEAD_SHA}&event=pull_request_target&per_page=1" \
-              --jq '.workflow_runs[0] | [.id, .conclusion] | @tsv' \
+              "repos/${REPO}/actions/workflows/maintainer-gate.yml/runs?head_sha=${HEAD_SHA}&event=pull_request_target&per_page=10" \
+              --jq '{
+                completed: ([.workflow_runs[] | select(.status == "completed" and (.conclusion != null)) | {id, status, conclusion}][0] // null),
+                active: ([.workflow_runs[] | select(.status != "completed") | {id, status}][0] // null)
+              }' \
               2>/dev/null); then
               mark_rerun_scheduling_failure "$PR_NUM" "Maintainer-gate refresh lookup failed"
               continue
             fi
 
-            if [[ -z "$RUN_LOOKUP" ]]; then
-              mark_rerun_scheduling_failure "$PR_NUM" "No prior maintainer-gate run found for refresh"
-            else
-              RUN_ID=$(printf '%s' "$RUN_LOOKUP" | cut -f1)
-              if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
-                mark_rerun_scheduling_failure "$PR_NUM" "Could not parse maintainer-gate run id for refresh"
-              else
-                RUN_CONCLUSION=$(printf '%s' "$RUN_LOOKUP" | cut -f2)
-                echo "Triggering Job 1 rerun (run_id=$RUN_ID, prior=$RUN_CONCLUSION) for PR #$PR_NUM"
-                if ! rerun_maintainer_gate_with_retry "$RUN_ID" "$PR_NUM"; then
-                  mark_rerun_scheduling_failure "$PR_NUM" "Maintainer-gate refresh scheduling failed after bounded retries"
-                fi
+            if ! printf '%s' "$RUN_LOOKUP" | jq -e \
+              'type == "object" and has("completed") and has("active")' >/dev/null 2>&1; then
+              mark_rerun_scheduling_failure "$PR_NUM" "Maintainer-gate refresh lookup returned malformed metadata"
+              continue
+            fi
+
+            RUN_ID=$(printf '%s' "$RUN_LOOKUP" | jq -r '.completed.id // empty')
+            if [[ -z "$RUN_ID" ]]; then
+              ACTIVE_RUN_ID=$(printf '%s' "$RUN_LOOKUP" | jq -r '.active.id // empty')
+              ACTIVE_RUN_STATUS=$(printf '%s' "$RUN_LOOKUP" | jq -r '.active.status // empty')
+              if [[ -n "$ACTIVE_RUN_ID" ]]; then
+                echo "::warning::Maintainer-gate run $ACTIVE_RUN_ID is already ${ACTIVE_RUN_STATUS:-active} for PR #$PR_NUM — leaving status ownership with that exact-head run"
+                continue
               fi
+              mark_rerun_scheduling_failure "$PR_NUM" "No prior maintainer-gate run found for refresh"
+              continue
+            fi
+
+            # Post pending only after proving that the selected exact-head run
+            # is terminal and therefore eligible for GitHub's rerun endpoint.
+            # Active-only and obsolete PR paths stay diagnostic-only so they
+            # cannot strand synthetic pending/error contexts.
+            if ! post_maintainer_gate_status_with_retry \
+              pending \
+              "Refreshing via Job 1 rerun..."; then
+              echo "::error::Could not publish pending maintainer-gate status for PR #$PR_NUM"
+              RERUN_SCHEDULING_FAILED=true
+              continue
+            fi
+
+            RUN_CONCLUSION=$(printf '%s' "$RUN_LOOKUP" | jq -r '.completed.conclusion // empty')
+            echo "Triggering Job 1 rerun (run_id=$RUN_ID, prior=$RUN_CONCLUSION) for PR #$PR_NUM"
+            if ! rerun_maintainer_gate_with_retry "$RUN_ID" "$PR_NUM"; then
+              mark_rerun_scheduling_failure "$PR_NUM" "Maintainer-gate refresh scheduling failed after bounded retries"
             fi
           done
 


### PR DESCRIPTION
## Summary

Skip obsolete PR refreshes, leave active exact-head runs as status owners, and select a completed exact-head run before posting pending and scheduling a rerun.

## Files Changed

.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh, .github/workflows/maintainer-gate-reusable.yml

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — 45 executable workflow fixtures passed; local linters passed; Qlty base 46, head 46, delta 0; review evidence digest 09a817f68ea81776005a5b797accf15166387e35c11e059ad2436e4e666e00.

Resolves #29588


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.226 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 59m and 448,370 tokens on this with the user in an interactive session.