### PR TITLE
GH#29609: bootstrap post-merge verification dependencies

### DIFF
--- a/.agents/scripts/tests/test-canonical-model-tiers.sh
+++ b/.agents/scripts/tests/test-canonical-model-tiers.sh
@@ -158,7 +158,7 @@ check_absent \
 
 check_absent \
 	"dispatch tracking labels use canonical tiers" \
-	'(dispatched|implemented|retried|failed):(haiku|sonnet|opus|flash|pro|composer2)' \
+	'(dispatched|implemented|retried|failed):(haiku|sonnet|opus|flash|pro|composer2)\b' \
 	.agents --glob '*.{md,sh,py,mjs,json,jsonc,toon}'
 
 legacy_pin_pattern='model:'"opus-4-7|AIDEVOPS_"'OPUS_ESCALATION_MODEL'

--- a/.agents/scripts/tests/test-post-merge-verify-report.sh
+++ b/.agents/scripts/tests/test-post-merge-verify-report.sh
@@ -8,6 +8,8 @@ PASS=0
 FAIL=0
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HELPER="${TEST_DIR}/../post-merge-verify-report-helper.sh"
+WORKFLOW="${TEST_DIR}/../../../.github/workflows/post-merge-verify.yml"
+PACKAGE_JSON="${TEST_DIR}/../../../package.json"
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
@@ -76,6 +78,20 @@ if [[ $rc -eq 0 && "$truncated_size" -lt 100 ]] &&
 	pass "verification output is bounded with an explicit truncation marker"
 else
 	fail "verification output truncation" "rc=$rc size=$truncated_size output=$output"
+fi
+
+if grep -qF 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6' "$WORKFLOW" &&
+	grep -qF 'bun install --frozen-lockfile --ignore-scripts' "$WORKFLOW" &&
+	grep -qF '"ajv": "^8.18.0"' "$PACKAGE_JSON"; then
+	pass "post-merge verification installs locked JavaScript dependencies without lifecycle scripts"
+else
+	fail "post-merge JavaScript dependency bootstrap" "missing direct Ajv dependency, pinned Bun setup, or locked install"
+fi
+
+if grep -qF 'sudo apt-get install --yes ripgrep' "$WORKFLOW"; then
+	pass "post-merge verification installs ripgrep for repository checks"
+else
+	fail "post-merge ripgrep bootstrap" "missing ripgrep package installation"
 fi
 
 printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"

--- a/.github/workflows/post-merge-verify.yml
+++ b/.github/workflows/post-merge-verify.yml
@@ -85,6 +85,22 @@ jobs:
             echo "No brief found at $BRIEF_PATH — skipping."
           fi
 
+      - name: Setup Bun
+        if: steps.brief.outputs.exists == 'true'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      - name: Install verification dependencies
+        if: steps.brief.outputs.exists == 'true'
+        run: |
+          set -euo pipefail
+          if ! command -v rg >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install --yes ripgrep
+          fi
+          bun install --frozen-lockfile --ignore-scripts
+
       # ---------------------------------------------------------------
       # Step 4: Run verify blocks
       # ---------------------------------------------------------------

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@types/bun": "latest",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
+        "ajv": "^8.18.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "secretlint": "^11.2.5",

--- a/package.json
+++ b/package.json
@@ -65,10 +65,11 @@
     "vite": "^7.0.0"
   },
   "devDependencies": {
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
     "@secretlint/secretlint-rule-preset-recommend": "^11.2.5",
     "@types/bun": "latest",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "ajv": "^8.18.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "secretlint": "^11.2.5",


### PR DESCRIPTION
## Summary

Install the locked JavaScript dependency graph and ripgrep before executing brief acceptance checks, declare Ajv as a direct test dependency, and prevent provider-name prefix false positives in the canonical-tier regression.

## Files Changed

.agents/scripts/tests/test-canonical-model-tiers.sh, .agents/scripts/tests/test-post-merge-verify-report.sh, .github/workflows/post-merge-verify.yml, bun.lock, package.json

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Roster, discovery smoke, canonical-tier, post-merge report, Python compile, changed-file lint, ShellCheck, and pre-commit workflow validation pass.

Resolves #29609


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.226 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 8m and 143,152 tokens on this as a headless worker.