### PR TITLE
GH#29613: docs: prepare sudo auth release checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- tolerate transient `gh auth status` failures during sudo approval recovery (#29608)
+
 ## [3.32.226] - 2026-08-05
 
 ### Changed


### PR DESCRIPTION
## Summary

Implementation for issue #29613.

## Files Changed

CHANGELOG.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — self-assessed: CHANGELOG-only release checkpoint; changelog consistency, Markdown lint, secretlint, git diff check, local linters, and patch release regression preflight passed.

Resolves #29613


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.226 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 2h 15m and 875,955 tokens on this with the user in an interactive session.