### PR TITLE
t18202: feat: add read-only team-interface runtime

### DIFF
--- a/.agents/package-lock.json
+++ b/.agents/package-lock.json
@@ -1,0 +1,69 @@
+{
+  "name": "aidevops-agent-runtime",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "aidevops-agent-runtime",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "8.20.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  }
+}

--- a/.agents/package.json
+++ b/.agents/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "aidevops-agent-runtime",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "dependencies": {
+    "ajv": "8.20.0"
+  }
+}

--- a/.agents/reference/team-interface-runtime.md
+++ b/.agents/reference/team-interface-runtime.md
@@ -1,0 +1,183 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Team-interface read-only runtime
+
+The version 1 runtime loads provider-neutral documents, invokes only trusted
+in-tree read adapters, persists validated local observations, and generates
+deterministic reconciliation plans. It does not install providers or expose an
+apply, create, update, delete, send, invite, moderation, or publication route.
+
+The initial static registry is intentionally empty. The Buzz and Matrix feature
+leaves add adapters after this core contract merges.
+
+## Commands
+
+Run the deployed helper or its repository source:
+
+```bash
+~/.aidevops/agents/scripts/team-interface-helper.sh providers
+~/.aidevops/agents/scripts/team-interface-helper.sh detect
+~/.aidevops/agents/scripts/team-interface-helper.sh status
+~/.aidevops/agents/scripts/team-interface-helper.sh doctor
+~/.aidevops/agents/scripts/team-interface-helper.sh plan --request plan-request.json
+```
+
+| Command | Reads | Writes |
+|---|---|---|
+| `providers` | Static registry and runtime selection | Nothing |
+| `detect` | Configured documents and adapter `detect()` methods | Validated local observation state only |
+| `status` | Persisted state and adapter `status()` methods | Nothing |
+| `doctor` | Config, documents, registry, and persisted-state validity | Nothing |
+| `plan` | Explicit plan request and configured ownership policy | Nothing; emits a reconciliation plan |
+
+Output is canonical JSON. The helper rejects every command outside this set
+before invoking Node.
+
+## Configuration and documents
+
+The default working config is `~/.config/aidevops/team-interface.json`.
+`AIDEVOPS_TEAM_INTERFACE_CONFIG` overrides it. Copy
+`configs/team-interface-config.json.txt` to start from a valid disabled config.
+
+The closed `runtime_config` document contains:
+
+- an explicit `enabled` flag;
+- paths to one core registry, ownership policy, and app-team manifest;
+- registered adapter IDs paired with `settings:` references; and
+- bounded document, plan, observation, adapter-read, and lock options.
+
+Relative document paths resolve from the config directory; `~/` paths resolve
+from the current home directory. Inputs are opened once without following a
+final symlink, checked by descriptor identity and type, read to one byte beyond
+their configured limit, and validated before use. Unknown fields, executable
+module paths, dynamic adapter imports, non-`settings:` adapter references, and
+inline credential values fail closed. Provider inventory output omits settings
+references. A missing config is reported as a diagnosed disabled runtime rather
+than inferred configuration.
+
+The deployed runtime imports Ajv from `.agents/package.json`. Setup installs the
+exact version and transitive integrity set in `.agents/package-lock.json`, then
+compiles the runtime validators before a candidate runtime bundle can activate.
+
+## Adapter contract
+
+`.agents/scripts/team-interface-adapters.mjs` is the only adapter registry. The
+core entrypoint composes focused config, validation, adapter, state/lock,
+planning, and command modules from the same scripts directory; those modules do
+not add another registry or executable loading path. Each tracked adapter
+supplies:
+
+- stable `adapter_id` and `provider_id` values;
+- an `adapter_version`;
+- bounded read-only capability declarations; and
+- asynchronous `detect(context)` and `status(context)` methods.
+
+The registry rejects unknown properties, duplicate adapter or capability IDs,
+missing methods, undeclared executable methods, and mutation-shaped exports.
+Capabilities are closed declarations and may contain only `discover`, `read`,
+and `receive` operations. Validated definitions and their nested capability
+values are frozen before registration. Runtime config selects a registered ID;
+it cannot supply a path to executable code.
+
+Adapter context is deeply frozen and contains validated documents, a settings
+reference, and `read_only: true`. It provides no filesystem writer, credential
+resolver, provider client, or mutation callback. Returned observations must
+validate as closed `adapter_observation` documents and must retain the adapter's
+registered identity and complete unique capability-ID set, including capability
+operations, resource kinds, and review policy. Every adapter read has a bounded
+timeout and receives an abort signal that trusted adapters must pass to their
+underlying I/O. A pre-frozen adapter definition is still recursively frozen so
+a mutable nested capability cannot bypass registration-time validation.
+
+## Local state and locking
+
+`AIDEVOPS_STATE_DIR` defaults to `~/.aidevops/state`. Runtime state is stored at
+`team-interface/state-v1.json` below that root. The directory is mode `0700` and
+the JSON state plus lock are mode `0600`.
+
+`detect` is the only command that writes state. It validates the complete next
+document before locking, then:
+
+1. acquires an exclusive bounded lock;
+2. verifies the expected generation under the lock;
+3. writes and fsyncs a private temporary file;
+4. atomically renames it and fsyncs the directory; and
+5. releases only the lock token it owns.
+
+A stale lock is reclaimed only after both its configured age threshold and
+same-host process-liveness evidence prove the recorded owner is gone. Reclaimers
+serialize through a separate marker and re-read the exact owner token before
+renaming, so a delayed contender cannot remove a replacement owner's lock. A
+live, remote-host, malformed, ambiguous, or concurrently reclaimed owner is
+never deleted. Generation drift is a conflict and preserves the prior state.
+
+When one adapter fails, a successful peer observation may advance state while
+the failing adapter's prior valid observation is preserved only when its
+adapter/provider/version and capability declaration still match the registered
+definition. An upgraded or changed definition never inherits stale capability
+evidence. If every adapter fails, no state write occurs. `status`, `doctor`, and
+`plan` never create or modify state. An explicit empty adapter selection clears
+stale persisted observations on the next `detect`; status output never exposes
+observations for adapters that are no longer selected.
+
+## Deterministic planning
+
+A `plan_request` embeds one version 1 reconciliation input plus capability,
+precondition, actor, authorization, creation, expiry, and redacted audit
+evidence. The planner binds the resource identity and management owner to the
+configured provider registry, binds the policy to the registered resource kind,
+and requires every configured policy field to appear in the input. It then
+derives exactly one decision per field using
+`reference/team-interface-reconciliation.md`. JSON Schema `date-time` fields
+receive strict calendar validation rather than being treated as unchecked
+strings.
+
+Set-like field and evidence arrays are normalized with locale-independent code
+unit ordering before hashing. The canonical request SHA-256 determines plan,
+operation, correlation, and idempotency IDs.
+Request-supplied evidence times and actor, authorization, and audit references
+are preserved. Capability evidence must cover the full plan lifetime, field and
+audit observations cannot postdate plan creation, and managed or
+security-required fields must include a present last-applied snapshot. Missing
+required evidence fails closed rather than inferring a baseline. Capability gaps
+produce `owner_reviewed_draft` or `unsupported`; security drift may produce
+`disable`; unmanaged or unknown fields produce `review`; applicable managed
+changes produce `update`; otherwise the outcome is `no_change`.
+
+`plan_hash` is SHA-256 over recursively key-sorted canonical JSON after removing
+only `plan_hash`. Identical semantic requests replay byte-for-byte. Any material
+request change produces different stable IDs and a different hash.
+
+The request supplies capability, actor, authorization, audit, and management
+marker evidence because this version is a non-mutating planner, not an authority
+broker. Its output is a dry-run artifact, never apply authorization. A future
+provider-write implementation must re-read the provider and verify every
+identity, capability, authority, CAS, expiry, and plan-hash binding required by
+`reference/team-interface-reconciliation.md` before any effect.
+
+## Diagnostics and recovery
+
+Errors expose bounded codes and messages, never file contents or unrestricted
+provider payloads. Adapter/provider exceptions become fixed runtime-owned
+messages; only runtime validation categories are retained. Other diagnostics
+redact home-directory prefixes and credential-shaped assignments, replace
+control characters, and limit messages to 500 characters. Diagnostic codes are
+limited to stable 1-100 character identifiers. Invalid config, schema, lock,
+adapter, state, policy, or planning input leaves the last valid state untouched.
+
+Repair the specific diagnosed input and rerun the read or plan command. Unknown
+schema versions and malformed historical state require explicit operator repair;
+version 1 performs no inferred migration or provider cleanup.
+
+## Verification
+
+```bash
+node .agents/scripts/tests/test-team-interface-runtime.mjs
+node .agents/scripts/tests/test-team-interface-core-schema.mjs
+node .agents/scripts/tests/test-team-interface-reconciliation-schema.mjs
+.agents/scripts/tests/test-team-interface-runtime-deps.sh
+bash -n .agents/scripts/team-interface-helper.sh
+shellcheck .agents/scripts/team-interface-helper.sh
+.agents/scripts/linters-local.sh --changed
+```

--- a/.agents/reference/team-interfaces.md
+++ b/.agents/reference/team-interfaces.md
@@ -6,15 +6,20 @@
 The team-interface core is the provider-neutral boundary between provider
 adapters, policy brokers, and consumers. Version 1 is defined by
 `schemas/team-interface/core-v1.schema.json` and supports closed `registry` and
-`event` documents. Existing Matrix, direct aidevops, and provider runtimes do
-not write this contract yet.
+`event` documents. The read-only executable surface is defined by
+`schemas/team-interface/runtime-v1.schema.json` and
+`reference/team-interface-runtime.md`. Existing Matrix, direct aidevops, and
+provider runtimes do not use an adapter from this registry yet.
 
 ## Ownership and configuration
 
 Dedicated versioned team-interface documents are authoritative for providers,
-accounts, identities, resources, capabilities, and normalized events. A future
-configuration task may add only enablement plus path or document references to
-`config.jsonc`; rich provider or team state does not belong there.
+accounts, identities, resources, capabilities, and normalized events. Runtime
+selection lives in `~/.config/aidevops/team-interface.json`, using
+`configs/team-interface-config.json.txt` as the disabled template. It contains
+only enablement, document paths, registered adapter IDs, settings references,
+and bounded runtime options. Rich provider or team state does not belong in the
+runtime config or `config.jsonc`.
 
 The core owns normalized identifiers, capability declarations, resource
 relationships, verified actor context, requested authority, and event

--- a/.agents/schemas/team-interface/runtime-v1.schema.json
+++ b/.agents/schemas/team-interface/runtime-v1.schema.json
@@ -1,0 +1,207 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:aidevops:team-interface:runtime:v1",
+  "title": "aidevops team-interface runtime contract v1",
+  "oneOf": [
+    {"$ref": "#/$defs/runtime_config_document"},
+    {"$ref": "#/$defs/runtime_state_document"},
+    {"$ref": "#/$defs/adapter_observation_document"},
+    {"$ref": "#/$defs/plan_request_document"}
+  ],
+  "$defs": {
+    "core_stable_id": {"$ref": "urn:aidevops:team-interface:core:v1#/$defs/stable_id"},
+    "core_reference_id": {"$ref": "urn:aidevops:team-interface:core:v1#/$defs/reference_id"},
+    "registered_reference": {
+      "allOf": [
+        {"$ref": "#/$defs/core_reference_id"},
+        {"pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*:[A-Za-z0-9][A-Za-z0-9._:/-]*$"}
+      ]
+    },
+    "settings_reference": {
+      "allOf": [
+        {"$ref": "#/$defs/registered_reference"},
+        {"pattern": "^settings:[A-Za-z0-9][A-Za-z0-9._:/-]*$"}
+      ]
+    },
+    "document_path": {
+      "type": "string",
+      "minLength": 6,
+      "maxLength": 4096,
+      "pattern": "^[^\\u0000]+\\.json$"
+    },
+    "document_paths": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["registry_path", "policy_path", "app_team_path"],
+      "properties": {
+        "registry_path": {"$ref": "#/$defs/document_path"},
+        "policy_path": {"$ref": "#/$defs/document_path"},
+        "app_team_path": {"$ref": "#/$defs/document_path"}
+      }
+    },
+    "adapter_selection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["adapter_id", "settings_ref"],
+      "properties": {
+        "adapter_id": {"$ref": "#/$defs/core_stable_id"},
+        "settings_ref": {"$ref": "#/$defs/settings_reference"}
+      }
+    },
+    "runtime_options": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "adapter_timeout_ms",
+        "max_document_bytes",
+        "max_plan_fields",
+        "max_state_observations",
+        "lock_timeout_ms",
+        "lock_stale_ms"
+      ],
+      "properties": {
+        "adapter_timeout_ms": {"type": "integer", "minimum": 10, "maximum": 60000},
+        "max_document_bytes": {"type": "integer", "minimum": 1024, "maximum": 10485760},
+        "max_plan_fields": {"type": "integer", "minimum": 1, "maximum": 1000},
+        "max_state_observations": {"type": "integer", "minimum": 1, "maximum": 1000},
+        "lock_timeout_ms": {"type": "integer", "minimum": 0, "maximum": 30000},
+        "lock_stale_ms": {"type": "integer", "minimum": 1000, "maximum": 3600000}
+      }
+    },
+    "runtime_config_document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "document_type", "enabled", "documents", "adapters", "options"],
+      "properties": {
+        "schema_version": {"const": 1},
+        "document_type": {"const": "runtime_config"},
+        "enabled": {"type": "boolean"},
+        "documents": {"$ref": "#/$defs/document_paths"},
+        "adapters": {
+          "type": "array",
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/adapter_selection"}
+        },
+        "options": {"$ref": "#/$defs/runtime_options"}
+      }
+    },
+    "read_only_capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capability_id", "resource_kinds", "operations", "availability", "owner_review_required"],
+      "properties": {
+        "capability_id": {"$ref": "#/$defs/core_stable_id"},
+        "resource_kinds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "urn:aidevops:team-interface:core:v1#/$defs/resource_kind"}
+        },
+        "operations": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"enum": ["discover", "read", "receive"]}
+        },
+        "availability": {"enum": ["available", "degraded", "unavailable", "unknown"]},
+        "owner_review_required": {"type": "boolean"}
+      }
+    },
+    "adapter_observation_document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "document_type",
+        "adapter_id",
+        "provider_id",
+        "adapter_version",
+        "provider_version",
+        "availability",
+        "capabilities",
+        "compatibility",
+        "observed_at",
+        "evidence_refs"
+      ],
+      "properties": {
+        "schema_version": {"const": 1},
+        "document_type": {"const": "adapter_observation"},
+        "adapter_id": {"$ref": "#/$defs/core_stable_id"},
+        "provider_id": {"$ref": "#/$defs/core_stable_id"},
+        "adapter_version": {"type": "string", "minLength": 1, "maxLength": 100},
+        "provider_version": {"type": "string", "minLength": 1, "maxLength": 100},
+        "availability": {"enum": ["available", "degraded", "unavailable", "unknown"]},
+        "capabilities": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 100,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/read_only_capability"}
+        },
+        "compatibility": {"$ref": "urn:aidevops:team-interface:core:v1#/$defs/compatibility"},
+        "observed_at": {"type": "string", "format": "date-time"},
+        "evidence_refs": {
+          "type": "array",
+          "maxItems": 100,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/registered_reference"}
+        }
+      }
+    },
+    "runtime_state_document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "document_type", "generation", "updated_at", "observations"],
+      "properties": {
+        "schema_version": {"const": 1},
+        "document_type": {"const": "runtime_state"},
+        "generation": {"type": "integer", "minimum": 1},
+        "updated_at": {"type": "string", "format": "date-time"},
+        "observations": {
+          "type": "array",
+          "maxItems": 1000,
+          "items": {"$ref": "#/$defs/adapter_observation_document"}
+        }
+      }
+    },
+    "plan_request_document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "document_type",
+        "reconciliation_input",
+        "desired_version",
+        "capabilities",
+        "precondition",
+        "security_drift_action",
+        "verified_actor_ref",
+        "authorization_ref",
+        "created_at",
+        "expires_at",
+        "audit"
+      ],
+      "properties": {
+        "schema_version": {"const": 1},
+        "document_type": {"const": "plan_request"},
+        "reconciliation_input": {
+          "$ref": "urn:aidevops:team-interface:reconciliation:v1#/$defs/reconciliation_input_document"
+        },
+        "desired_version": {"type": "string", "minLength": 1, "maxLength": 100},
+        "capabilities": {
+          "$ref": "urn:aidevops:team-interface:reconciliation:v1#/$defs/capability_evidence"
+        },
+        "precondition": {
+          "$ref": "urn:aidevops:team-interface:reconciliation:v1#/$defs/cas_precondition"
+        },
+        "security_drift_action": {"enum": ["review_required", "disable_execution"]},
+        "verified_actor_ref": {"$ref": "#/$defs/registered_reference"},
+        "authorization_ref": {"$ref": "#/$defs/registered_reference"},
+        "created_at": {"type": "string", "format": "date-time"},
+        "expires_at": {"type": "string", "format": "date-time"},
+        "audit": {"$ref": "urn:aidevops:team-interface:reconciliation:v1#/$defs/audit_evidence"}
+      }
+    }
+  }
+}

--- a/.agents/scripts/setup/modules/agent-deploy.sh
+++ b/.agents/scripts/setup/modules/agent-deploy.sh
@@ -367,6 +367,89 @@ _verify_opencode_plugin_deps() {
 	return 1
 }
 
+# _verify_agent_runtime_deps target_dir
+# Verifies the exact Ajv runtime used by deployed team-interface validators.
+_verify_agent_runtime_deps() {
+	local target_dir="$1"
+	local validators_module="$target_dir/scripts/team-interface-validators.mjs"
+	local manifest_file="$target_dir/package.json"
+
+	[[ -f "$validators_module" && -f "$manifest_file" ]] || return 1
+	command -v node >/dev/null 2>&1 || return 1
+	if node --input-type=module - "$validators_module" "$manifest_file" "$target_dir" <<'NODE'; then
+import {lstatSync, readFileSync, realpathSync} from "node:fs";
+import {createRequire} from "node:module";
+import {isAbsolute, relative, resolve, sep} from "node:path";
+import {pathToFileURL} from "node:url";
+
+const validatorsPath = process.argv[2];
+const manifestPath = process.argv[3];
+const targetPath = process.argv[4];
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+const expectedVersion = manifest.dependencies?.ajv;
+const require = createRequire(pathToFileURL(validatorsPath));
+const resolvedPackage = realpathSync(require.resolve("ajv/package.json"));
+const dependencyPath = resolve(targetPath, "node_modules");
+if (lstatSync(dependencyPath).isSymbolicLink()) {
+  throw new Error("Deployed node_modules must not be a symbolic link");
+}
+const dependencyRoot = realpathSync(dependencyPath);
+const dependencyLocation = relative(dependencyRoot, resolvedPackage);
+if (dependencyLocation === ".." || dependencyLocation.startsWith(`..${sep}`) || isAbsolute(dependencyLocation)) {
+  throw new Error("Ajv runtime resolved outside deployed node_modules");
+}
+const actualVersion = JSON.parse(readFileSync(resolvedPackage, "utf8")).version;
+if (!expectedVersion || expectedVersion !== actualVersion) {
+  throw new Error(`Ajv runtime version mismatch: expected ${expectedVersion || "unset"}, found ${actualVersion}`);
+}
+const validators = await import(pathToFileURL(validatorsPath));
+validators.createRuntimeValidators();
+NODE
+		return 0
+	fi
+	return 1
+}
+
+# _install_agent_runtime_deps target_dir
+# Installs the locked dependency set needed by deployed agent-runtime modules.
+_install_agent_runtime_deps() {
+	local target_dir="$1"
+	local validators_module="$target_dir/scripts/team-interface-validators.mjs"
+	local manifest_file="$target_dir/package.json"
+	local lock_file="$target_dir/package-lock.json"
+	local install_log=""
+	local verify_output=""
+
+	[[ -f "$validators_module" ]] || return 0
+	if verify_output=$(_verify_agent_runtime_deps "$target_dir" 2>&1); then
+		return 0
+	fi
+	if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+		print_error "Team-interface runtime dependencies require Node.js and npm: ${verify_output:-import failed}"
+		return 1
+	fi
+	if [[ ! -f "$manifest_file" || ! -f "$lock_file" ]]; then
+		print_error "Agent runtime dependency lockfile is unavailable; runtime bundle activation blocked"
+		return 1
+	fi
+	install_log=$(mktemp "${TMPDIR:-/tmp}/aidevops-agent-runtime-install.XXXXXX") || {
+		print_error "Failed to create the agent runtime dependency install log"
+		return 1
+	}
+	if ! npm ci --omit=dev --ignore-scripts --prefer-offline --no-audit --no-fund --prefix "$target_dir" >"$install_log" 2>&1; then
+		print_error "Failed to install agent runtime dependencies; runtime bundle activation blocked"
+		tail -n 12 "$install_log" >&2
+		rm -f "$install_log"
+		return 1
+	fi
+	rm -f "$install_log"
+	if ! verify_output=$(_verify_agent_runtime_deps "$target_dir" 2>&1); then
+		print_error "Agent runtime dependency verification failed after install: ${verify_output:-import failed}"
+		return 1
+	fi
+	return 0
+}
+
 # _install_opencode_plugin_deps target_dir
 # Installs and verifies node_modules for the opencode-aidevops plugin.
 # GH#17829: @bufbuild/protobuf was missing; GH#17891: only symlink on first run.
@@ -1106,6 +1189,7 @@ _deploy_agents_post_copy() {
 	local plugins_file="$4"
 
 	_set_script_permissions_and_report "$target_dir"
+	_install_agent_runtime_deps "$target_dir" || return 1
 	_install_opencode_plugin_deps "$target_dir" || return 1
 	_deploy_version_file "$target_dir" "$repo_dir"
 	_deploy_security_advisories_files "$source_dir"

--- a/.agents/scripts/team-interface-adapter-runtime.mjs
+++ b/.agents/scripts/team-interface-adapter-runtime.mjs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {assertUniqueIds, canonicalJson, deepFreeze, TeamInterfaceError} from "./team-interface-common.mjs";
+import {requireValid} from "./team-interface-validators.mjs";
+
+function adapterContext(documents, selection, abortSignal) {
+  return Object.freeze({
+    documents: deepFreeze(structuredClone(documents)),
+    runtime: Object.freeze({abort_signal: abortSignal, read_only: true, schema_version: 1}),
+    settings_ref: selection.settings_ref,
+  });
+}
+
+function assertCapabilityBinding(observation, adapter) {
+  assertUniqueIds(observation.capabilities, "capability_id", "adapter observation");
+  const declared = new Map(adapter.capabilities.map((capability) => [capability.capability_id, capability]));
+  if (observation.capabilities.length !== declared.size) {
+    throw new TeamInterfaceError("adapter_capability_mismatch", "adapter omitted a declared capability");
+  }
+  for (const capability of observation.capabilities) {
+    const source = declared.get(capability.capability_id);
+    if (!source) throw new TeamInterfaceError("adapter_capability_mismatch", "adapter returned an undeclared capability");
+    for (const property of ["operations", "resource_kinds"]) {
+      const actual = [...capability[property]].sort();
+      const expected = [...source[property]].sort();
+      if (canonicalJson(actual) !== canonicalJson(expected)) {
+        throw new TeamInterfaceError("adapter_capability_mismatch", `adapter changed capability ${property}`);
+      }
+    }
+    if (capability.owner_review_required !== source.owner_review_required) {
+      throw new TeamInterfaceError("adapter_capability_mismatch", "adapter changed capability review policy");
+    }
+  }
+}
+
+function assertObservationBinding(observation, adapter) {
+  for (const property of ["adapter_id", "provider_id", "adapter_version"]) {
+    if (observation[property] !== adapter[property]) {
+      throw new TeamInterfaceError("adapter_identity_mismatch", `adapter observation changed ${property}`);
+    }
+  }
+  assertCapabilityBinding(observation, adapter);
+}
+
+export function observationMatchesAdapterDefinition(observation, adapter) {
+  try {
+    assertObservationBinding(observation, adapter);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function boundedAdapterRead(method, selection, context, timeoutMs, controller) {
+  let timeout;
+  const read = Promise.resolve().then(() => selection.adapter[method](context));
+  const deadline = new Promise((_, reject) => {
+    timeout = setTimeout(() => {
+      controller.abort();
+      reject(new TeamInterfaceError("adapter_timeout", `${selection.adapter.adapter_id} ${method} timed out`));
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([read, deadline]);
+  } finally {
+    clearTimeout(timeout);
+    controller.abort();
+  }
+}
+
+export async function invokeAdapterRead(method, selection, documents, validators, options = {}) {
+  if (!["detect", "status"].includes(method)) {
+    throw new TeamInterfaceError("unsupported_adapter_read", "adapter read method is unsupported");
+  }
+  const controller = new AbortController();
+  const context = adapterContext(documents, selection, controller.signal);
+  const timeoutMs = options.timeoutMs ?? 5000;
+  const observation = await boundedAdapterRead(method, selection, context, timeoutMs, controller);
+  requireValid(validators.adapterObservation, observation, `${selection.adapter.adapter_id} ${method} observation`);
+  assertObservationBinding(observation, selection.adapter);
+  return structuredClone(observation);
+}

--- a/.agents/scripts/team-interface-adapter-validation.mjs
+++ b/.agents/scripts/team-interface-adapter-validation.mjs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+const READ_ONLY_OPERATIONS = new Set(["discover", "read", "receive"]);
+const RESOURCE_KINDS = new Set(["community", "channel", "conversation", "thread", "direct_message", "group", "other"]);
+const AVAILABILITY_STATES = new Set(["available", "degraded", "unavailable", "unknown"]);
+const ADAPTER_PROPERTIES = new Set(["adapter_id", "provider_id", "adapter_version", "capabilities", "detect", "status"]);
+const CAPABILITY_PROPERTIES = new Set([
+  "capability_id",
+  "resource_kinds",
+  "operations",
+  "availability",
+  "owner_review_required",
+]);
+const MUTATION_METHODS = new Set(["apply", "create", "delete", "invite", "moderate", "publish", "send", "update", "write"]);
+
+function isAsciiAlphaNumeric(character) {
+  const code = character.charCodeAt(0);
+  return (code >= 48 && code <= 57) || (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+}
+
+function isStableId(value) {
+  if (typeof value !== "string" || value.length < 1 || value.length > 255 || !isAsciiAlphaNumeric(value[0])) return false;
+  for (const character of value.slice(1)) {
+    if (!isAsciiAlphaNumeric(character) && !"._:/-".includes(character)) return false;
+  }
+  return true;
+}
+
+function requireStableId(value, label) {
+  if (!isStableId(value)) {
+    throw new TypeError(`${label} is not a valid stable ID`);
+  }
+  return value;
+}
+
+function requireVersion(value, label) {
+  if (typeof value !== "string" || value.length < 1 || value.length > 100) {
+    throw new TypeError(`${label} must contain 1-100 characters`);
+  }
+}
+
+function assertCapabilityProperties(capability, adapterId) {
+  for (const property of Object.keys(capability)) {
+    if (!CAPABILITY_PROPERTIES.has(property)) {
+      throw new TypeError(`adapter ${adapterId} capability contains unknown property ${property}`);
+    }
+  }
+}
+
+function validateResourceKinds(capability, adapterId) {
+  const kinds = capability.resource_kinds;
+  if (!Array.isArray(kinds) || kinds.length === 0) {
+    throw new TypeError(`adapter ${adapterId} capability resource kinds are required`);
+  }
+  if (new Set(kinds).size !== kinds.length) {
+    throw new TypeError(`adapter ${adapterId} capability contains duplicate resource kinds`);
+  }
+  for (const kind of kinds) {
+    if (!RESOURCE_KINDS.has(kind)) throw new TypeError(`adapter ${adapterId} capability has unknown resource kind ${kind}`);
+  }
+}
+
+function validateOperations(capability, adapterId) {
+  const operations = capability.operations;
+  if (!Array.isArray(operations) || operations.length === 0) {
+    throw new TypeError(`adapter ${adapterId} capability operations are required`);
+  }
+  if (new Set(operations).size !== operations.length) {
+    throw new TypeError(`adapter ${adapterId} capability contains duplicate operations`);
+  }
+  for (const operation of operations) {
+    if (!READ_ONLY_OPERATIONS.has(operation)) {
+      throw new TypeError(`adapter ${adapterId} declares mutation-capable operation ${operation}`);
+    }
+  }
+}
+
+function validateCapability(capability, adapterId) {
+  if (!capability || typeof capability !== "object" || Array.isArray(capability)) {
+    throw new TypeError(`adapter ${adapterId} has an invalid capability`);
+  }
+  requireStableId(capability.capability_id, `adapter ${adapterId} capability ID`);
+  assertCapabilityProperties(capability, adapterId);
+  validateResourceKinds(capability, adapterId);
+  validateOperations(capability, adapterId);
+  if (!AVAILABILITY_STATES.has(capability.availability)) {
+    throw new TypeError(`adapter ${adapterId} capability availability is invalid`);
+  }
+  if (typeof capability.owner_review_required !== "boolean") {
+    throw new TypeError(`adapter ${adapterId} capability review policy is invalid`);
+  }
+}
+
+function assertAdapterProperties(adapter, adapterId) {
+  for (const property of Object.keys(adapter)) {
+    if (!ADAPTER_PROPERTIES.has(property)) {
+      const description = MUTATION_METHODS.has(property) ? "forbidden mutation method" : "unknown property";
+      throw new TypeError(`adapter ${adapterId} exposes ${description} ${property}`);
+    }
+  }
+}
+
+function validateCapabilities(adapter, adapterId) {
+  if (!Array.isArray(adapter.capabilities) || adapter.capabilities.length === 0 || adapter.capabilities.length > 100) {
+    throw new TypeError(`adapter ${adapterId} must declare 1-100 capabilities`);
+  }
+  for (const capability of adapter.capabilities) validateCapability(capability, adapterId);
+  const ids = adapter.capabilities.map(({capability_id: capabilityId}) => capabilityId);
+  if (new Set(ids).size !== ids.length) throw new TypeError(`adapter ${adapterId} contains duplicate capability IDs`);
+}
+
+function validateMethods(adapter, adapterId) {
+  for (const method of ["detect", "status"]) {
+    if (typeof adapter[method] !== "function") throw new TypeError(`adapter ${adapterId} is missing ${method}()`);
+  }
+}
+
+export function validateAdapterDefinition(adapter) {
+  if (!adapter || typeof adapter !== "object" || Array.isArray(adapter)) {
+    throw new TypeError("adapter definition must be an object");
+  }
+  const adapterId = requireStableId(adapter.adapter_id, "adapter ID");
+  assertAdapterProperties(adapter, adapterId);
+  requireStableId(adapter.provider_id, `adapter ${adapterId} provider ID`);
+  requireVersion(adapter.adapter_version, `adapter ${adapterId} version`);
+  validateCapabilities(adapter, adapterId);
+  validateMethods(adapter, adapterId);
+  return adapter;
+}
+
+export function deepFreezeDefinition(value) {
+  if (!value || typeof value !== "object") return value;
+  for (const child of Object.values(value)) deepFreezeDefinition(child);
+  return Object.isFrozen(value) ? value : Object.freeze(value);
+}

--- a/.agents/scripts/team-interface-adapters.mjs
+++ b/.agents/scripts/team-interface-adapters.mjs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {deepFreezeDefinition, validateAdapterDefinition} from "./team-interface-adapter-validation.mjs";
+import {compareCanonicalText} from "./team-interface-common.mjs";
+
+const BUILTIN_ADAPTERS = Object.freeze([]);
+
+export {validateAdapterDefinition} from "./team-interface-adapter-validation.mjs";
+
+export function createAdapterRegistry(adapters = BUILTIN_ADAPTERS) {
+  if (!Array.isArray(adapters)) throw new TypeError("adapter registry input must be an array");
+  const entries = new Map();
+  for (const adapter of adapters) {
+    validateAdapterDefinition(adapter);
+    if (entries.has(adapter.adapter_id)) throw new TypeError(`duplicate adapter ID ${adapter.adapter_id}`);
+    entries.set(adapter.adapter_id, deepFreezeDefinition(adapter));
+  }
+  return Object.freeze({
+    get(adapterId) {
+      return entries.get(adapterId);
+    },
+    has(adapterId) {
+      return entries.has(adapterId);
+    },
+    ids() {
+      return [...entries.keys()].sort();
+    },
+    values() {
+      return [...entries.values()].sort((left, right) => compareCanonicalText(left.adapter_id, right.adapter_id));
+    },
+  });
+}
+
+export function selectConfiguredAdapters(config, registry = builtInAdapterRegistry) {
+  const selectedIds = new Set();
+  const selected = [];
+  for (const selection of config.adapters) {
+    if (selectedIds.has(selection.adapter_id)) {
+      throw new TypeError(`duplicate configured adapter ID ${selection.adapter_id}`);
+    }
+    const adapter = registry.get(selection.adapter_id);
+    if (!adapter) throw new TypeError(`unknown configured adapter ID ${selection.adapter_id}`);
+    selectedIds.add(selection.adapter_id);
+    selected.push(Object.freeze({adapter, settings_ref: selection.settings_ref}));
+  }
+  return selected.sort((left, right) => compareCanonicalText(left.adapter.adapter_id, right.adapter.adapter_id));
+}
+
+export function adapterMetadata(adapter) {
+  return {
+    adapter_id: adapter.adapter_id,
+    adapter_version: adapter.adapter_version,
+    capabilities: structuredClone(adapter.capabilities),
+    provider_id: adapter.provider_id,
+  };
+}
+
+export const builtInAdapterRegistry = createAdapterRegistry();

--- a/.agents/scripts/team-interface-common.mjs
+++ b/.agents/scripts/team-interface-common.mjs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {createHash} from "node:crypto";
+import {closeSync, constants, fstatSync, lstatSync, openSync, readSync} from "node:fs";
+import {homedir} from "node:os";
+import {isAbsolute, join, parse, resolve, sep} from "node:path";
+
+export class TeamInterfaceError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = "TeamInterfaceError";
+    this.code = code;
+  }
+}
+
+export function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    const entries = Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`);
+    return `{${entries.join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function canonicalDigest(value) {
+  return `sha256:${createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+export function compareCanonicalText(left, right) {
+  if (left === right) return 0;
+  return left < right ? -1 : 1;
+}
+
+export function existingPathStats(filePath) {
+  try {
+    return lstatSync(filePath);
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+export function assertNoSymlinkComponents(filePath) {
+  const absolutePath = resolve(filePath);
+  const root = parse(absolutePath).root;
+  let current = root;
+  for (const component of absolutePath.slice(root.length).split(sep).filter(Boolean)) {
+    current = join(current, component);
+    const stats = existingPathStats(current);
+    if (!stats) break;
+    if (stats.isSymbolicLink()) throw new TeamInterfaceError("unsafe_path", "runtime path must not traverse symbolic links");
+  }
+}
+
+export function expandRuntimePath(filePath, baseDirectory = process.cwd()) {
+  if (typeof filePath !== "string" || filePath.length === 0 || filePath.includes("\0")) {
+    throw new TeamInterfaceError("invalid_path", "runtime path is invalid");
+  }
+  let expanded = filePath;
+  if (filePath === "~") expanded = homedir();
+  else if (filePath.startsWith("~/")) expanded = join(homedir(), filePath.slice(2));
+  else if (filePath.startsWith("~")) throw new TeamInterfaceError("invalid_path", "named-home expansion is unsupported");
+  return resolve(isAbsolute(expanded) ? expanded : join(baseDirectory, expanded));
+}
+
+function openRuntimeDocument(filePath, label) {
+  try {
+    return openSync(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
+  } catch (error) {
+    if (error?.code === "ENOENT") throw new TeamInterfaceError("missing_document", `${label} is missing`);
+    if (["ELOOP", "EMLINK"].includes(error?.code)) {
+      throw new TeamInterfaceError("unsafe_path", `${label} must not be a symbolic link`);
+    }
+    throw error;
+  }
+}
+
+function assertOpenedDocument(filePath, descriptor, maxBytes, label) {
+  const stats = fstatSync(descriptor);
+  if (!stats.isFile()) throw new TeamInterfaceError("invalid_path", `${label} must be a regular file`);
+  if (stats.size > maxBytes) throw new TeamInterfaceError("document_too_large", `${label} exceeds its size limit`);
+  assertNoSymlinkComponents(filePath);
+  const currentStats = existingPathStats(filePath);
+  if (!currentStats) throw new TeamInterfaceError("unsafe_path", `${label} changed while it was opened`);
+  if (currentStats.isSymbolicLink()) throw new TeamInterfaceError("unsafe_path", `${label} changed while it was opened`);
+  if (currentStats.dev !== stats.dev) throw new TeamInterfaceError("unsafe_path", `${label} changed while it was opened`);
+  if (currentStats.ino !== stats.ino) throw new TeamInterfaceError("unsafe_path", `${label} changed while it was opened`);
+}
+
+function readDescriptorText(descriptor, maxBytes, label) {
+  const buffer = Buffer.allocUnsafe(maxBytes + 1);
+  let bytesRead = 0;
+  while (bytesRead < buffer.length) {
+    const count = readSync(descriptor, buffer, bytesRead, buffer.length - bytesRead, null);
+    if (count === 0) break;
+    bytesRead += count;
+  }
+  if (bytesRead > maxBytes) throw new TeamInterfaceError("document_too_large", `${label} exceeds its size limit`);
+  return buffer.subarray(0, bytesRead).toString("utf8");
+}
+
+function parseJson(text, label) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    if (error instanceof SyntaxError) throw new TeamInterfaceError("invalid_json", `${label} is not valid JSON`);
+    throw error;
+  }
+}
+
+export function readBoundedJson(filePath, maxBytes, label) {
+  assertNoSymlinkComponents(filePath);
+  const descriptor = openRuntimeDocument(filePath, label);
+  try {
+    assertOpenedDocument(filePath, descriptor, maxBytes, label);
+    return parseJson(readDescriptorText(descriptor, maxBytes, label), label);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+export function assertUniqueIds(records, property, label) {
+  const ids = records.map((record) => record[property]);
+  if (new Set(ids).size !== ids.length) throw new TeamInterfaceError("duplicate_identity", `${label} contains duplicate ${property} values`);
+}
+
+export function deepFreeze(value) {
+  if (!value || typeof value !== "object") return value;
+  for (const child of Object.values(value)) deepFreeze(child);
+  return Object.isFrozen(value) ? value : Object.freeze(value);
+}
+
+export function requireTimestamp(value, label) {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) throw new TeamInterfaceError("invalid_timestamp", `${label} is invalid`);
+  return timestamp;
+}

--- a/.agents/scripts/team-interface-config.mjs
+++ b/.agents/scripts/team-interface-config.mjs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {existsSync} from "node:fs";
+import {homedir} from "node:os";
+import {dirname, join} from "node:path";
+import {assertUniqueIds, expandRuntimePath, readBoundedJson} from "./team-interface-common.mjs";
+import {requireValid, validatorsFor} from "./team-interface-validators.mjs";
+
+const DEFAULT_CONFIG_PATH = join(homedir(), ".config/aidevops/team-interface.json");
+const CONFIG_MAX_BYTES = 1024 * 1024;
+
+export function loadRuntimeConfig(options = {}) {
+  const validators = validatorsFor(options.validators);
+  const requestedPath = options.configPath || process.env.AIDEVOPS_TEAM_INTERFACE_CONFIG || DEFAULT_CONFIG_PATH;
+  const configPath = expandRuntimePath(requestedPath);
+  if (!existsSync(configPath)) {
+    return Object.freeze({
+      config: null,
+      configPath,
+      configStatus: "missing",
+      documentPaths: null,
+      enabled: false,
+    });
+  }
+  const config = readBoundedJson(configPath, CONFIG_MAX_BYTES, "team-interface configuration");
+  requireValid(validators.runtimeConfig, config, "team-interface configuration");
+  assertUniqueIds(config.adapters, "adapter_id", "team-interface configuration");
+  const configDirectory = dirname(configPath);
+  const documentPaths = Object.fromEntries(
+    Object.entries(config.documents).map(([key, value]) => [key, expandRuntimePath(value, configDirectory)]),
+  );
+  return Object.freeze({
+    config,
+    configPath,
+    configStatus: "loaded",
+    documentPaths: Object.freeze(documentPaths),
+    enabled: config.enabled,
+  });
+}
+
+export function loadRuntimeDocuments(configLoad, options = {}) {
+  if (!configLoad.config || !configLoad.enabled) return null;
+  const validators = validatorsFor(options.validators);
+  const maxBytes = configLoad.config.options.max_document_bytes;
+  const registry = readBoundedJson(configLoad.documentPaths.registry_path, maxBytes, "provider registry");
+  const policy = readBoundedJson(configLoad.documentPaths.policy_path, maxBytes, "ownership policy");
+  const appTeam = readBoundedJson(configLoad.documentPaths.app_team_path, maxBytes, "app-team manifest");
+  requireValid(validators.registry, registry, "provider registry");
+  requireValid(validators.ownershipPolicy, policy, "ownership policy");
+  requireValid(validators.appTeam, appTeam, "app-team manifest");
+  return Object.freeze({appTeam, policy, registry});
+}

--- a/.agents/scripts/team-interface-core.mjs
+++ b/.agents/scripts/team-interface-core.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {resolve} from "node:path";
+import {pathToFileURL} from "node:url";
+import {canonicalJson, TeamInterfaceError} from "./team-interface-common.mjs";
+import {diagnostic} from "./team-interface-diagnostics.mjs";
+import {runDetect, runDoctor, runPlan, runProviders, runStatus} from "./team-interface-runtime-commands.mjs";
+
+export {
+  canonicalDigest,
+  canonicalJson,
+  compareCanonicalText,
+  expandRuntimePath,
+  TeamInterfaceError,
+} from "./team-interface-common.mjs";
+export {diagnostic} from "./team-interface-diagnostics.mjs";
+export {loadRuntimeConfig, loadRuntimeDocuments} from "./team-interface-config.mjs";
+export {acquireStateLock, releaseStateLock} from "./team-interface-lock.mjs";
+export {assertInputPolicy, assertInputRegistry, generatePlan} from "./team-interface-planner.mjs";
+export {runDetect, runDoctor, runPlan, runProviders, runStatus} from "./team-interface-runtime-commands.mjs";
+export {readRuntimeState, runtimeStatePaths, writeRuntimeState} from "./team-interface-state.mjs";
+export {createRuntimeValidators} from "./team-interface-validators.mjs";
+
+function parseCliArguments(argumentsList) {
+  const options = {};
+  const seen = new Set();
+  for (let index = 0; index < argumentsList.length; index += 1) {
+    const argument = argumentsList[index];
+    if (!["--config", "--request", "--state-dir"].includes(argument)) {
+      throw new TeamInterfaceError("unsupported_argument", `unsupported argument ${argument}`);
+    }
+    if (seen.has(argument)) throw new TeamInterfaceError("duplicate_argument", `duplicate argument ${argument}`);
+    const value = argumentsList[index + 1];
+    if (!value) throw new TeamInterfaceError("missing_argument", `${argument} requires a value`);
+    if (argument === "--config") options.configPath = value;
+    if (argument === "--request") options.requestPath = value;
+    if (argument === "--state-dir") options.stateRoot = value;
+    seen.add(argument);
+    index += 1;
+  }
+  return options;
+}
+
+export async function main(argumentsList = process.argv.slice(2)) {
+  const [command, ...rest] = argumentsList;
+  const supported = new Set(["providers", "detect", "status", "doctor", "plan"]);
+  if (!supported.has(command)) throw new TeamInterfaceError("unsupported_command", `unsupported command ${command || "<empty>"}`);
+  const options = parseCliArguments(rest);
+  if (command === "providers") return runProviders(options);
+  if (command === "detect") return runDetect(options);
+  if (command === "status") return runStatus(options);
+  if (command === "doctor") return runDoctor(options);
+  return runPlan(options);
+}
+
+function isDirectExecution() {
+  if (!process.argv[1]) return false;
+  return import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+}
+
+if (isDirectExecution()) {
+  try {
+    const result = await main();
+    process.stdout.write(`${canonicalJson(result)}\n`);
+    if (result?.ok === false) process.exitCode = 1;
+  } catch (error) {
+    process.stderr.write(`${canonicalJson({error: diagnostic(error)})}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/.agents/scripts/team-interface-diagnostics.mjs
+++ b/.agents/scripts/team-interface-diagnostics.mjs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {homedir} from "node:os";
+
+const DIAGNOSTIC_CODE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,99}$/;
+const ADAPTER_DIAGNOSTICS = Object.freeze({
+  adapter_capability_mismatch: "adapter observation capability mismatch",
+  adapter_identity_mismatch: "adapter observation identity mismatch",
+  adapter_timeout: "adapter read timed out",
+  duplicate_identity: "adapter observation contains duplicate identities",
+  invalid_document: "adapter observation failed validation",
+  unsupported_adapter_read: "adapter read method is unsupported",
+});
+
+function replaceControlCharacters(value) {
+  return Array.from(value, (character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127 ? " " : character;
+  }).join("");
+}
+
+function safeMessage(error) {
+  const message = error instanceof Error ? error.message : "unknown runtime failure";
+  const home = homedir();
+  const homeRedacted = home ? message.split(home).join("~") : message;
+  return replaceControlCharacters(homeRedacted
+    .replace(/\bBearer\s+[^\s,;]+/gi, "Bearer [REDACTED]")
+    .replace(/\b(token|password|private[_-]?key|credential(?:[_-]?value)?|secret(?:[_-]?value)?)\s*[:=]\s*[^\s,;]+/gi, "$1=[REDACTED]"))
+    .slice(0, 500);
+}
+
+function safeCode(error) {
+  return typeof error?.code === "string" && DIAGNOSTIC_CODE_PATTERN.test(error.code)
+    ? error.code
+    : "runtime_error";
+}
+
+export function diagnostic(error, adapterId) {
+  const adapterMessage = adapterId ? ADAPTER_DIAGNOSTICS[error?.code] : null;
+  return {
+    ...(adapterId ? {adapter_id: adapterId} : {}),
+    code: adapterId ? (adapterMessage ? safeCode(error) : "adapter_read_failed") : safeCode(error),
+    message: adapterId ? (adapterMessage || "adapter read failed") : safeMessage(error),
+  };
+}

--- a/.agents/scripts/team-interface-helper.sh
+++ b/.agents/scripts/team-interface-helper.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+CORE_SCRIPT="${SCRIPT_DIR}/team-interface-core.mjs"
+
+check_dependencies() {
+	command -v node >/dev/null 2>&1 || {
+		print_error "node is required for the team-interface runtime"
+		return 1
+	}
+	[[ -f "$CORE_SCRIPT" ]] || {
+		print_error "team-interface runtime core is unavailable"
+		return 1
+	}
+	return 0
+}
+
+show_help() {
+	cat <<'EOF'
+team-interface-helper.sh — read-only provider runtime and deterministic planner
+
+USAGE:
+  team-interface-helper.sh providers [--config PATH]
+  team-interface-helper.sh detect [--config PATH] [--state-dir PATH]
+  team-interface-helper.sh status [--config PATH] [--state-dir PATH]
+  team-interface-helper.sh doctor [--config PATH] [--state-dir PATH]
+  team-interface-helper.sh plan --request PATH [--config PATH]
+
+The initial runtime exposes no provider create, update, delete, apply, send, or
+invite command. Output is JSON.
+EOF
+	return 0
+}
+
+run_core() {
+	local command_name="${1:-}"
+	shift || true
+	check_dependencies || return 1
+	if node "$CORE_SCRIPT" "$command_name" "$@"; then
+		return 0
+	fi
+	return 1
+}
+
+main() {
+	local command_name="${1:-help}"
+	if [[ $# -gt 0 ]]; then
+		shift
+	fi
+	case "$command_name" in
+	providers | detect | status | doctor | plan)
+		run_core "$command_name" "$@"
+		return $?
+		;;
+	help | -h | --help)
+		show_help
+		return 0
+		;;
+	*)
+		print_error "unsupported read-only team-interface command: ${command_name}"
+		show_help
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/team-interface-lock-owner.mjs
+++ b/.agents/scripts/team-interface-lock-owner.mjs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {execFileSync} from "node:child_process";
+import {randomUUID} from "node:crypto";
+import {readFileSync} from "node:fs";
+import {hostname} from "node:os";
+
+function processStartFingerprint(pid) {
+  try {
+    return execFileSync("ps", ["-p", String(pid), "-o", "lstart="], {
+      encoding: "utf8",
+      timeout: 1000,
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function processIsAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    if (error?.code === "EPERM") return true;
+    throw error;
+  }
+}
+
+function validLockOwner(owner) {
+  return [
+    Boolean(owner),
+    typeof owner?.host === "string",
+    Number.isSafeInteger(owner?.pid),
+    owner?.pid > 0,
+    typeof owner?.process_started_at === "string",
+    typeof owner?.token === "string",
+    typeof owner?.created_at === "string",
+  ].every(Boolean);
+}
+
+export function readLockOwner(lockPath) {
+  try {
+    const owner = JSON.parse(readFileSync(lockPath, "utf8"));
+    return validLockOwner(owner) ? owner : null;
+  } catch {
+    return null;
+  }
+}
+
+export function lockOwnerIsActive(owner) {
+  if (owner.host !== hostname()) return true;
+  if (!processIsAlive(owner.pid)) return false;
+  const currentFingerprint = processStartFingerprint(owner.pid);
+  if (!currentFingerprint || !owner.process_started_at) return true;
+  return currentFingerprint === owner.process_started_at;
+}
+
+export function lockStillMatchesAbandonedOwner(stats, currentOwner, expectedOwner, staleMs) {
+  let matches = false;
+  if (stats && currentOwner) {
+    matches = stats.isFile();
+    if (stats.isSymbolicLink()) matches = false;
+    if (Date.now() - stats.mtimeMs < staleMs) matches = false;
+    if (currentOwner.token !== expectedOwner.token) matches = false;
+    if (currentOwner.host !== hostname()) matches = false;
+    if (lockOwnerIsActive(currentOwner)) matches = false;
+  }
+  return matches;
+}
+
+export function stateLockOwner() {
+  return Object.freeze({
+    created_at: new Date().toISOString(),
+    host: hostname(),
+    pid: process.pid,
+    process_started_at: processStartFingerprint(process.pid),
+    token: randomUUID(),
+  });
+}

--- a/.agents/scripts/team-interface-lock.mjs
+++ b/.agents/scripts/team-interface-lock.mjs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {randomUUID} from "node:crypto";
+import {chmodSync, closeSync, fsyncSync, lstatSync, mkdirSync, openSync, renameSync, rmSync, writeFileSync} from "node:fs";
+import {assertNoSymlinkComponents, canonicalJson, existingPathStats, TeamInterfaceError} from "./team-interface-common.mjs";
+import {lockOwnerIsActive, lockStillMatchesAbandonedOwner, readLockOwner, stateLockOwner} from "./team-interface-lock-owner.mjs";
+
+export function ensurePrivateStateDirectory(directory) {
+  assertNoSymlinkComponents(directory);
+  mkdirSync(directory, {mode: 0o700, recursive: true});
+  assertNoSymlinkComponents(directory);
+  const stats = lstatSync(directory);
+  if (!stats.isDirectory()) throw new TeamInterfaceError("unsafe_state", "team-interface state root is not a directory");
+  chmodSync(directory, 0o700);
+  return Object.freeze({device: stats.dev, inode: stats.ino});
+}
+
+export function assertDirectoryIdentity(directory, identity) {
+  assertNoSymlinkComponents(directory);
+  const stats = lstatSync(directory);
+  if (!stats.isDirectory() || stats.dev !== identity.device || stats.ino !== identity.inode) {
+    throw new TeamInterfaceError("unsafe_state", "team-interface state directory identity changed");
+  }
+}
+
+function reclaimAbandonedLock(lockPath, expectedOwner, staleMs) {
+  const reclaimPath = `${lockPath}.reclaim`;
+  const quarantinePath = `${lockPath}.stale-${process.pid}-${randomUUID()}`;
+  try {
+    mkdirSync(reclaimPath, {mode: 0o700});
+  } catch (error) {
+    if (error?.code === "EEXIST") return false;
+    throw error;
+  }
+  try {
+    const stats = existingPathStats(lockPath);
+    const currentOwner = readLockOwner(lockPath);
+    if (!lockStillMatchesAbandonedOwner(stats, currentOwner, expectedOwner, staleMs)) return false;
+    renameSync(lockPath, quarantinePath);
+    rmSync(quarantinePath, {force: true});
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  } finally {
+    rmSync(reclaimPath, {force: true, recursive: true});
+  }
+}
+
+function inspectExistingLock(lockPath, staleMs) {
+  const stats = existingPathStats(lockPath);
+  if (!stats) return "retry";
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    throw new TeamInterfaceError("unsafe_lock", "team-interface state lock is unsafe");
+  }
+  if (Date.now() - stats.mtimeMs < staleMs) return "wait";
+  const owner = readLockOwner(lockPath);
+  if (!owner || lockOwnerIsActive(owner)) return "wait";
+  return reclaimAbandonedLock(lockPath, owner, staleMs) ? "retry" : "wait";
+}
+
+function publishLock(lockPath, owner) {
+  if (existingPathStats(`${lockPath}.reclaim`)) return false;
+  let descriptor;
+  try {
+    descriptor = openSync(lockPath, "wx", 0o600);
+    writeFileSync(descriptor, `${canonicalJson(owner)}\n`, "utf8");
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = undefined;
+    return true;
+  } catch (error) {
+    if (descriptor !== undefined) closeSync(descriptor);
+    if (error?.code === "EEXIST") return false;
+    throw error;
+  }
+}
+
+function waitForStateLock(paths, directoryIdentity, owner, staleMs, deadline) {
+  while (true) {
+    assertDirectoryIdentity(paths.directory, directoryIdentity);
+    if (publishLock(paths.lockPath, owner)) return Object.freeze({directoryIdentity, owner, paths});
+    if (inspectExistingLock(paths.lockPath, staleMs) === "retry") continue;
+    if (Date.now() >= deadline) throw new TeamInterfaceError("lock_timeout", "team-interface state lock timed out");
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 25);
+  }
+}
+
+export function acquireStateLock(paths, options = {}) {
+  const timeoutMs = options.timeoutMs ?? 4000;
+  const staleMs = options.staleMs ?? 60000;
+  const directoryIdentity = options.directoryIdentity || ensurePrivateStateDirectory(paths.directory);
+  return waitForStateLock(paths, directoryIdentity, stateLockOwner(), staleMs, Date.now() + timeoutMs);
+}
+
+export function releaseStateLock(lock) {
+  const owner = readLockOwner(lock.paths.lockPath);
+  if (!owner || owner.token !== lock.owner.token) return false;
+  rmSync(lock.paths.lockPath, {force: true});
+  return true;
+}

--- a/.agents/scripts/team-interface-plan-decisions.mjs
+++ b/.agents/scripts/team-interface-plan-decisions.mjs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+function snapshotDigest(snapshot) {
+  return snapshot.present ? snapshot.digest : null;
+}
+
+function driftEvidence(field, requestDigest, index) {
+  return {
+    actual_digest: snapshotDigest(field.actual),
+    evidence_ref: `observation:runtime-${requestDigest.slice(7, 23)}-${index + 1}`,
+    last_applied_digest: snapshotDigest(field.last_applied),
+    observed_at: field.actual_observed_at,
+  };
+}
+
+export function fieldDecision(field, request, requestDigest, index) {
+  const desiredDigest = snapshotDigest(field.desired);
+  const lastAppliedDigest = snapshotDigest(field.last_applied);
+  const actualDigest = snapshotDigest(field.actual);
+  const actualMatchesLastApplied = actualDigest === lastAppliedDigest;
+  const desiredMatchesActual = desiredDigest === actualDigest;
+  const decision = {
+    actual_digest: actualDigest,
+    actual_matches_last_applied: actualMatchesLastApplied,
+    desired_digest: desiredDigest,
+    desired_matches_actual: desiredMatchesActual,
+    field_path: field.field_path,
+    last_applied_digest: lastAppliedDigest,
+    ownership: field.ownership,
+  };
+  if (field.ownership === "user_owned") return {...decision, decision: "preserve_actual", reason: "user_owned"};
+  if (field.ownership === "unknown") {
+    return {
+      ...decision,
+      decision: "review_required",
+      drift_evidence: driftEvidence(field, requestDigest, index),
+      reason: "unmanaged_resource",
+    };
+  }
+  if (!actualMatchesLastApplied) {
+    const securityRequired = field.ownership === "security_required";
+    return {
+      ...decision,
+      decision: securityRequired ? request.security_drift_action : "preserve_actual",
+      drift_evidence: driftEvidence(field, requestDigest, index),
+      reason: securityRequired ? "security_drift" : "user_modified",
+    };
+  }
+  if (desiredMatchesActual) return {...decision, decision: "no_change", reason: "already_desired"};
+  return {...decision, decision: "apply_desired", reason: "managed_unchanged"};
+}
+
+function capabilitiesPermitMutation(capabilities) {
+  return [
+    capabilities.stable_external_ids,
+    capabilities.managed_metadata,
+    capabilities.supported_apply,
+    capabilities.revision_cas,
+    capabilities.compatibility === "compatible",
+  ].every(Boolean);
+}
+
+export function derivePlanOutcome(request, decisions) {
+  let outcome = "no_change";
+  if (!capabilitiesPermitMutation(request.capabilities)) {
+    outcome = request.capabilities.compatibility === "unsupported" ? "unsupported" : "owner_reviewed_draft";
+  } else if (request.reconciliation_input.resource.management_identity_status !== "verified") {
+    outcome = "review";
+  } else if (decisions.some(({decision}) => decision === "disable_execution")) {
+    outcome = "disable";
+  } else if (decisions.some(({decision}) => decision === "review_required")) {
+    outcome = "review";
+  } else if (decisions.some(({decision}) => decision === "apply_desired")) {
+    outcome = "update";
+  }
+  return outcome;
+}

--- a/.agents/scripts/team-interface-planner.mjs
+++ b/.agents/scripts/team-interface-planner.mjs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {assertUniqueIds, canonicalDigest, compareCanonicalText, requireTimestamp, TeamInterfaceError} from "./team-interface-common.mjs";
+import {derivePlanOutcome, fieldDecision} from "./team-interface-plan-decisions.mjs";
+import {requireValid, validatorsFor} from "./team-interface-validators.mjs";
+
+const DEFAULT_MAX_PLAN_FIELDS = 500;
+
+function normalizedPlanRequest(request) {
+  const normalized = structuredClone(request);
+  normalized.reconciliation_input.fields.sort((left, right) => compareCanonicalText(left.field_path, right.field_path));
+  normalized.capabilities.evidence_refs.sort(compareCanonicalText);
+  normalized.audit.evidence_refs.sort(compareCanonicalText);
+  return normalized;
+}
+
+function assertManagedBaselines(fields) {
+  for (const field of fields) {
+    if (["managed", "security_required"].includes(field.ownership) && !field.last_applied.present) {
+      throw new TeamInterfaceError("missing_last_applied", "managed fields require a present last-applied snapshot");
+    }
+  }
+}
+
+function assertPrecondition(request) {
+  const input = request.reconciliation_input;
+  if (request.precondition.expected_revision !== request.precondition.observed_revision) {
+    throw new TeamInterfaceError("invalid_precondition", "expected revision must equal observed revision");
+  }
+  if (request.precondition.observation_hash !== input.observation_hash || request.precondition.observed_at !== input.observed_at) {
+    throw new TeamInterfaceError("invalid_precondition", "plan precondition does not bind the reconciliation input");
+  }
+}
+
+function assertEvidenceTimes(request) {
+  const input = request.reconciliation_input;
+  const createdAt = requireTimestamp(request.created_at, "plan creation time");
+  const expiresAt = requireTimestamp(request.expires_at, "plan expiry");
+  const observedAt = requireTimestamp(input.observed_at, "input observation time");
+  const capabilityObservedAt = requireTimestamp(request.capabilities.observed_at, "capability observation time");
+  const capabilityExpiresAt = requireTimestamp(request.capabilities.expires_at, "capability expiry");
+  const auditRecordedAt = requireTimestamp(request.audit.recorded_at, "audit record time");
+  if (expiresAt <= createdAt) throw new TeamInterfaceError("invalid_timestamp", "plan expiry must follow creation");
+  if (createdAt < observedAt || createdAt < capabilityObservedAt) {
+    throw new TeamInterfaceError("invalid_timestamp", "plan creation predates required evidence");
+  }
+  if (auditRecordedAt > createdAt) throw new TeamInterfaceError("invalid_timestamp", "audit record postdates plan creation");
+  for (const field of input.fields) {
+    if (requireTimestamp(field.actual_observed_at, "field observation time") > createdAt) {
+      throw new TeamInterfaceError("invalid_timestamp", "field observation postdates plan creation");
+    }
+  }
+  if (capabilityExpiresAt < expiresAt) {
+    throw new TeamInterfaceError("stale_capability", "capability evidence does not cover the plan lifetime");
+  }
+}
+
+function assertPlanRequestSemantics(request, maxPlanFields) {
+  const fields = request.reconciliation_input.fields;
+  assertUniqueIds(fields, "field_path", "reconciliation input");
+  if (fields.length > maxPlanFields) throw new TeamInterfaceError("plan_too_large", "plan request has too many fields");
+  assertManagedBaselines(fields);
+  assertPrecondition(request);
+  assertEvidenceTimes(request);
+}
+
+function assertFieldPolicy(field, rule) {
+  if (field.ownership === "unknown") {
+    if (rule) throw new TeamInterfaceError("policy_mismatch", "unknown field overrides a configured ownership rule");
+    return;
+  }
+  if (!rule || rule.ownership !== field.ownership || rule.sensitive !== field.sensitive) {
+    throw new TeamInterfaceError("policy_mismatch", "reconciliation field does not match configured ownership policy");
+  }
+}
+
+export function assertInputPolicy(input, policy, resourceKind) {
+  if (input.policy_ref !== `policy:${policy.policy_id}` || input.policy_version !== policy.policy_version) {
+    throw new TeamInterfaceError("policy_mismatch", "reconciliation input does not bind the configured ownership policy");
+  }
+  if (resourceKind && policy.resource_kind !== resourceKind) {
+    throw new TeamInterfaceError("policy_mismatch", "configured ownership policy does not match the registered resource kind");
+  }
+  assertUniqueIds(policy.field_rules, "field_path", "ownership policy");
+  const rules = new Map(policy.field_rules.map((rule) => [rule.field_path, rule]));
+  for (const field of input.fields) {
+    assertFieldPolicy(field, rules.get(field.field_path));
+  }
+  const observedPaths = new Set(input.fields.map(({field_path: fieldPath}) => fieldPath));
+  if (policy.field_rules.some(({field_path: fieldPath}) => !observedPaths.has(fieldPath))) {
+    throw new TeamInterfaceError("policy_mismatch", "reconciliation input omits a configured ownership field");
+  }
+}
+
+export function assertInputRegistry(input, registry) {
+  assertUniqueIds(registry.resources, "resource_id", "provider registry resources");
+  const resource = registry.resources.find(({resource_id: resourceId}) => resourceId === input.resource.resource_id);
+  if (!resource) throw new TeamInterfaceError("registry_mismatch", "reconciliation resource is not registered");
+  for (const property of ["provider_id", "community_id", "provider_external_id"]) {
+    if (input.resource[property] !== resource[property]) {
+      throw new TeamInterfaceError("registry_mismatch", `reconciliation resource does not match registered ${property}`);
+    }
+  }
+  if (
+    input.resource.management_identity_status === "verified"
+    && input.resource.management_owner !== resource.management_owner
+  ) {
+    throw new TeamInterfaceError("registry_mismatch", "reconciliation management owner does not match the provider registry");
+  }
+  return resource;
+}
+
+export function generatePlan(planRequest, options = {}) {
+  const validators = validatorsFor(options.validators);
+  if (!options.policy || !options.registry) {
+    throw new TeamInterfaceError("missing_planner_context", "planner requires configured policy and provider registry documents");
+  }
+  requireValid(validators.planRequest, planRequest, "team-interface plan request");
+  requireValid(validators.ownershipPolicy, options.policy, "configured ownership policy");
+  requireValid(validators.registry, options.registry, "configured provider registry");
+  const request = normalizedPlanRequest(planRequest);
+  assertPlanRequestSemantics(request, options.maxPlanFields || DEFAULT_MAX_PLAN_FIELDS);
+  const resource = assertInputRegistry(request.reconciliation_input, options.registry);
+  assertInputPolicy(request.reconciliation_input, options.policy, resource.kind);
+  const requestDigest = canonicalDigest(request);
+  const digestHex = requestDigest.slice(7);
+  const input = request.reconciliation_input;
+  const decisions = input.fields.map((field, index) => fieldDecision(field, request, requestDigest, index));
+  const outcome = derivePlanOutcome(request, decisions);
+  const plan = {
+    adapter_version: input.adapter_version,
+    audit: structuredClone(request.audit),
+    authorization_ref: request.authorization_ref,
+    capabilities: structuredClone(request.capabilities),
+    community_id: input.resource.community_id,
+    correlation_id: `correlation.runtime.${digestHex}`,
+    created_at: request.created_at,
+    desired_version: request.desired_version,
+    document_type: "reconciliation_plan",
+    expires_at: request.expires_at,
+    field_decisions: decisions,
+    idempotency_key: `idempotency.runtime.${digestHex}`,
+    operation_id: `operation.runtime.${digestHex}`,
+    outcome,
+    plan_id: `plan.runtime.${digestHex}`,
+    policy_ref: input.policy_ref,
+    policy_version: input.policy_version,
+    precondition: structuredClone(request.precondition),
+    provider_external_id: input.resource.provider_external_id,
+    provider_id: input.resource.provider_id,
+    resource_id: input.resource.resource_id,
+    schema_version: 1,
+    source_input_id: input.input_id,
+    verified_actor_ref: request.verified_actor_ref,
+  };
+  if (["create", "update", "disable", "retire", "rollback"].includes(outcome)) {
+    plan.management_binding = {
+      management_owner: input.resource.management_owner,
+      manager_marker: input.resource.manager_marker,
+      status: "verified",
+    };
+  }
+  plan.plan_hash = canonicalDigest(plan);
+  requireValid(validators.plan, plan, "generated reconciliation plan");
+  return plan;
+}

--- a/.agents/scripts/team-interface-runtime-commands.mjs
+++ b/.agents/scripts/team-interface-runtime-commands.mjs
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {adapterMetadata, builtInAdapterRegistry, selectConfiguredAdapters} from "./team-interface-adapters.mjs";
+import {invokeAdapterRead, observationMatchesAdapterDefinition} from "./team-interface-adapter-runtime.mjs";
+import {canonicalJson, compareCanonicalText, expandRuntimePath, readBoundedJson, TeamInterfaceError} from "./team-interface-common.mjs";
+import {loadRuntimeConfig, loadRuntimeDocuments} from "./team-interface-config.mjs";
+import {diagnostic} from "./team-interface-diagnostics.mjs";
+import {generatePlan} from "./team-interface-planner.mjs";
+import {readRuntimeState, runtimeStatePaths, writeRuntimeState} from "./team-interface-state.mjs";
+import {validatorsFor} from "./team-interface-validators.mjs";
+
+function disabledResult(command, configLoad) {
+  return {
+    command,
+    config_status: configLoad.configStatus,
+    enabled: false,
+    state_changed: false,
+  };
+}
+
+function runtimeInputs(options) {
+  const validators = validatorsFor(options.validators);
+  const configLoad = loadRuntimeConfig({...options, validators});
+  if (!configLoad.enabled) return {configLoad, validators};
+  const registry = options.registry || builtInAdapterRegistry;
+  const selections = selectConfiguredAdapters(configLoad.config, registry);
+  const documents = loadRuntimeDocuments(configLoad, {validators});
+  return {configLoad, documents, registry, selections, validators};
+}
+
+export function runProviders(options = {}) {
+  const validators = validatorsFor(options.validators);
+  const configLoad = loadRuntimeConfig({...options, validators});
+  const registry = options.registry || builtInAdapterRegistry;
+  const selections = configLoad.config ? selectConfiguredAdapters(configLoad.config, registry) : [];
+  return {
+    command: "providers",
+    config_status: configLoad.configStatus,
+    enabled: configLoad.enabled,
+    registered: registry.values().map(adapterMetadata),
+    selected: selections.map(({adapter}) => ({
+      adapter_id: adapter.adapter_id,
+      provider_id: adapter.provider_id,
+    })),
+  };
+}
+
+function selectedPriorObservations(priorState, selections) {
+  const selectedAdapters = new Map(selections.map(({adapter}) => [adapter.adapter_id, adapter]));
+  return new Map(
+    (priorState?.observations || [])
+      .filter((observation) => {
+        const adapter = selectedAdapters.get(observation.adapter_id);
+        return adapter && observationMatchesAdapterDefinition(observation, adapter);
+      })
+      .map((observation) => [observation.adapter_id, observation]),
+  );
+}
+
+function sortedSelectedObservations(state, selections) {
+  return [...selectedPriorObservations(state, selections).values()]
+    .sort((left, right) => compareCanonicalText(left.adapter_id, right.adapter_id));
+}
+
+async function detectAdapterObservations(priorState, selections, documents, validators, timeoutMs) {
+  const observations = selectedPriorObservations(priorState, selections);
+  const errors = [];
+  let successfulReads = 0;
+  for (const selection of selections) {
+    try {
+      const observation = await invokeAdapterRead("detect", selection, documents, validators, {timeoutMs});
+      observations.set(observation.adapter_id, observation);
+      successfulReads += 1;
+    } catch (error) {
+      errors.push(diagnostic(error, selection.adapter.adapter_id));
+    }
+  }
+  return {
+    errors,
+    observations: [...observations.values()].sort((left, right) => compareCanonicalText(left.adapter_id, right.adapter_id)),
+    successfulReads,
+  };
+}
+
+function persistDetectedObservations({observations, successfulReads, priorState, selections, inputs, paths, options}) {
+  const {configLoad, validators} = inputs;
+  const unchanged = canonicalJson(observations) === canonicalJson(priorState?.observations || []);
+  const writeAllowed = successfulReads > 0 || selections.length === 0;
+  if (!writeAllowed || unchanged) return {state: priorState, stateChanged: false};
+  const expectedGeneration = priorState?.generation || 0;
+  const nextState = {
+    document_type: "runtime_state",
+    generation: expectedGeneration + 1,
+    observations,
+    schema_version: 1,
+    updated_at: options.now?.() || new Date().toISOString(),
+  };
+  const state = writeRuntimeState(nextState, {
+    expectedGeneration,
+    lockStaleMs: configLoad.config.options.lock_stale_ms,
+    lockTimeoutMs: configLoad.config.options.lock_timeout_ms,
+    paths,
+    validators,
+  });
+  return {state, stateChanged: true};
+}
+
+export async function runDetect(options = {}) {
+  const inputs = runtimeInputs(options);
+  if (!inputs.configLoad.enabled) return disabledResult("detect", inputs.configLoad);
+  const {configLoad, documents, selections, validators} = inputs;
+  const paths = runtimeStatePaths(options.stateRoot);
+  const priorState = readRuntimeState({paths, validators});
+  const detected = await detectAdapterObservations(
+    priorState,
+    selections,
+    documents,
+    validators,
+    configLoad.config.options.adapter_timeout_ms,
+  );
+  if (detected.observations.length > configLoad.config.options.max_state_observations) {
+    throw new TeamInterfaceError("state_too_large", "adapter observations exceed configured state limit");
+  }
+  const persisted = persistDetectedObservations({
+    observations: detected.observations,
+    successfulReads: detected.successfulReads,
+    priorState,
+    selections,
+    inputs,
+    paths,
+    options,
+  });
+  return {
+    command: "detect",
+    enabled: true,
+    errors: detected.errors,
+    generation: persisted.state?.generation || 0,
+    observations: sortedSelectedObservations(persisted.state, selections),
+    state_changed: persisted.stateChanged,
+  };
+}
+
+export async function runStatus(options = {}) {
+  const inputs = runtimeInputs(options);
+  if (!inputs.configLoad.enabled) return disabledResult("status", inputs.configLoad);
+  const {documents, selections, validators} = inputs;
+  const paths = runtimeStatePaths(options.stateRoot);
+  const priorState = readRuntimeState({paths, validators});
+  const live = [];
+  const errors = [];
+  for (const selection of selections) {
+    try {
+      live.push(await invokeAdapterRead("status", selection, documents, validators, {
+        timeoutMs: inputs.configLoad.config.options.adapter_timeout_ms,
+      }));
+    } catch (error) {
+      errors.push(diagnostic(error, selection.adapter.adapter_id));
+    }
+  }
+  live.sort((left, right) => compareCanonicalText(left.adapter_id, right.adapter_id));
+  return {
+    command: "status",
+    enabled: true,
+    errors,
+    generation: priorState?.generation || 0,
+    live,
+    persisted: sortedSelectedObservations(priorState, selections),
+    state_changed: false,
+  };
+}
+
+export function runDoctor(options = {}) {
+  try {
+    const inputs = runtimeInputs(options);
+    if (!inputs.configLoad.enabled) {
+      return {
+        ...disabledResult("doctor", inputs.configLoad),
+        diagnostics: [{code: `config_${inputs.configLoad.configStatus}`, message: "team-interface runtime is disabled"}],
+        ok: true,
+      };
+    }
+    const state = readRuntimeState({stateRoot: options.stateRoot, validators: inputs.validators});
+    return {
+      command: "doctor",
+      diagnostics: [],
+      enabled: true,
+      generation: state?.generation || 0,
+      ok: true,
+      selected_adapters: inputs.selections.map(({adapter}) => adapter.adapter_id),
+      state_changed: false,
+    };
+  } catch (error) {
+    return {
+      command: "doctor",
+      diagnostics: [diagnostic(error)],
+      enabled: false,
+      ok: false,
+      state_changed: false,
+    };
+  }
+}
+
+export function runPlan(options = {}) {
+  const inputs = runtimeInputs(options);
+  if (!inputs.configLoad.enabled) throw new TeamInterfaceError("runtime_disabled", "team-interface runtime is disabled");
+  if (!options.requestPath) throw new TeamInterfaceError("missing_request", "plan requires --request PATH");
+  const requestPath = expandRuntimePath(options.requestPath);
+  const request = readBoundedJson(
+    requestPath,
+    inputs.configLoad.config.options.max_document_bytes,
+    "team-interface plan request",
+  );
+  return generatePlan(request, {
+    maxPlanFields: inputs.configLoad.config.options.max_plan_fields,
+    policy: inputs.documents.policy,
+    registry: inputs.documents.registry,
+    validators: inputs.validators,
+  });
+}

--- a/.agents/scripts/team-interface-state.mjs
+++ b/.agents/scripts/team-interface-state.mjs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {chmodSync, closeSync, fsyncSync, openSync, renameSync, rmSync, writeFileSync} from "node:fs";
+import {randomUUID} from "node:crypto";
+import {homedir} from "node:os";
+import {join} from "node:path";
+import {assertUniqueIds, canonicalJson, expandRuntimePath, readBoundedJson, TeamInterfaceError} from "./team-interface-common.mjs";
+import {acquireStateLock, assertDirectoryIdentity, ensurePrivateStateDirectory, releaseStateLock} from "./team-interface-lock.mjs";
+import {requireValid, validatorsFor} from "./team-interface-validators.mjs";
+
+const DEFAULT_STATE_ROOT = join(homedir(), ".aidevops/state");
+const STATE_MAX_BYTES = 10 * 1024 * 1024;
+
+export function runtimeStatePaths(stateRoot = process.env.AIDEVOPS_STATE_DIR || DEFAULT_STATE_ROOT) {
+  const root = expandRuntimePath(stateRoot);
+  const directory = join(root, "team-interface");
+  return Object.freeze({
+    directory,
+    lockPath: join(directory, "state-v1.lock"),
+    statePath: join(directory, "state-v1.json"),
+  });
+}
+
+function validateStateSemantics(state) {
+  assertUniqueIds(state.observations, "adapter_id", "runtime state");
+  return state;
+}
+
+export function readRuntimeState(options = {}) {
+  const validators = validatorsFor(options.validators);
+  const paths = options.paths || runtimeStatePaths(options.stateRoot);
+  const state = (() => {
+    try {
+      return readBoundedJson(paths.statePath, options.maxBytes || STATE_MAX_BYTES, "team-interface runtime state");
+    } catch (error) {
+      if (error?.code === "missing_document") return null;
+      throw error;
+    }
+  })();
+  if (!state) return null;
+  requireValid(validators.runtimeState, state, "team-interface runtime state");
+  return validateStateSemantics(state);
+}
+
+function fsyncDirectory(directory) {
+  const descriptor = openSync(directory, "r");
+  try {
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function atomicWriteState(paths, state, directoryIdentity) {
+  assertDirectoryIdentity(paths.directory, directoryIdentity);
+  const temporary = `${paths.statePath}.tmp-${process.pid}-${randomUUID()}`;
+  let descriptor;
+  try {
+    descriptor = openSync(temporary, "wx", 0o600);
+    writeFileSync(descriptor, `${canonicalJson(state)}\n`, "utf8");
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = undefined;
+    assertDirectoryIdentity(paths.directory, directoryIdentity);
+    renameSync(temporary, paths.statePath);
+    chmodSync(paths.statePath, 0o600);
+    fsyncDirectory(paths.directory);
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+    rmSync(temporary, {force: true});
+  }
+}
+
+export function writeRuntimeState(nextState, options = {}) {
+  const validators = validatorsFor(options.validators);
+  requireValid(validators.runtimeState, nextState, "next team-interface runtime state");
+  validateStateSemantics(nextState);
+  const expectedGeneration = options.expectedGeneration;
+  if (!Number.isSafeInteger(expectedGeneration) || expectedGeneration < 0) {
+    throw new TeamInterfaceError("invalid_generation", "expected state generation is invalid");
+  }
+  if (nextState.generation !== expectedGeneration + 1) {
+    throw new TeamInterfaceError("invalid_generation", "next state generation must increment expected generation once");
+  }
+  const paths = options.paths || runtimeStatePaths(options.stateRoot);
+  const directoryIdentity = ensurePrivateStateDirectory(paths.directory);
+  const lock = acquireStateLock(paths, {
+    directoryIdentity,
+    staleMs: options.lockStaleMs,
+    timeoutMs: options.lockTimeoutMs,
+  });
+  try {
+    const current = readRuntimeState({paths, validators});
+    const currentGeneration = current?.generation || 0;
+    if (currentGeneration !== expectedGeneration) {
+      throw new TeamInterfaceError("generation_conflict", "team-interface runtime state generation changed");
+    }
+    atomicWriteState(paths, nextState, directoryIdentity);
+    return structuredClone(nextState);
+  } finally {
+    releaseStateLock(lock);
+  }
+}

--- a/.agents/scripts/team-interface-validators.mjs
+++ b/.agents/scripts/team-interface-validators.mjs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {readFileSync} from "node:fs";
+import {dirname, join, resolve} from "node:path";
+import {fileURLToPath} from "node:url";
+import Ajv2020 from "ajv/dist/2020.js";
+import {TeamInterfaceError} from "./team-interface-common.mjs";
+
+const SCRIPT_DIRECTORY = dirname(fileURLToPath(import.meta.url));
+const SCHEMA_DIRECTORY = resolve(SCRIPT_DIRECTORY, "../schemas/team-interface");
+const DATE_TIME_PATTERN = /^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:[Zz]|[+-](\d{2}):(\d{2}))$/;
+
+let defaultValidators;
+
+function schemaFile(schemaDirectory, filename) {
+  return JSON.parse(readFileSync(join(schemaDirectory, filename), "utf8"));
+}
+
+function validDateTime(value) {
+  const match = DATE_TIME_PATTERN.exec(value);
+  if (!match) return false;
+  const [year, month, day, hour, minute, second] = match.slice(1, 7).map(Number);
+  const offsetHour = match[7] ? Number(match[7]) : 0;
+  const offsetMinute = match[8] ? Number(match[8]) : 0;
+  const maximumDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  return [
+    month >= 1,
+    month <= 12,
+    day >= 1,
+    day <= maximumDay,
+    hour <= 23,
+    minute <= 59,
+    second <= 59,
+    offsetHour <= 23,
+    offsetMinute <= 59,
+    Number.isFinite(Date.parse(value)),
+  ].every(Boolean);
+}
+
+export function createRuntimeValidators(schemaDirectory = SCHEMA_DIRECTORY) {
+  const coreSchema = schemaFile(schemaDirectory, "core-v1.schema.json");
+  const reconciliationSchema = schemaFile(schemaDirectory, "reconciliation-v1.schema.json");
+  const appTeamSchema = schemaFile(schemaDirectory, "app-team-v1.schema.json");
+  const runtimeSchema = schemaFile(schemaDirectory, "runtime-v1.schema.json");
+  const ajv = new Ajv2020({allErrors: true, strict: false, validateFormats: true});
+  ajv.addFormat("date-time", {type: "string", validate: validDateTime});
+  for (const schema of [coreSchema, reconciliationSchema, appTeamSchema, runtimeSchema]) ajv.addSchema(schema);
+  const runtimeId = runtimeSchema.$id;
+  const reconciliationId = reconciliationSchema.$id;
+  return Object.freeze({
+    adapterObservation: ajv.compile({$ref: `${runtimeId}#/$defs/adapter_observation_document`}),
+    appTeam: ajv.getSchema(appTeamSchema.$id),
+    ownershipPolicy: ajv.compile({$ref: `${reconciliationId}#/$defs/ownership_policy_document`}),
+    plan: ajv.compile({$ref: `${reconciliationId}#/$defs/reconciliation_plan_document`}),
+    planRequest: ajv.compile({$ref: `${runtimeId}#/$defs/plan_request_document`}),
+    registry: ajv.compile({$ref: `${coreSchema.$id}#/$defs/registry_document`}),
+    runtime: ajv.getSchema(runtimeId),
+    runtimeConfig: ajv.compile({$ref: `${runtimeId}#/$defs/runtime_config_document`}),
+    runtimeState: ajv.compile({$ref: `${runtimeId}#/$defs/runtime_state_document`}),
+  });
+}
+
+export function validatorsFor(value) {
+  if (value) return value;
+  defaultValidators ||= createRuntimeValidators();
+  return defaultValidators;
+}
+
+function validationMessage(validate) {
+  return (validate.errors || [])
+    .map((error) => `${error.instancePath || "<root>"} ${error.keyword}: ${error.message}`)
+    .join("; ");
+}
+
+export function requireValid(validate, value, label) {
+  if (!validate(value)) {
+    throw new TeamInterfaceError("invalid_document", `${label} failed validation: ${validationMessage(validate)}`);
+  }
+  return value;
+}

--- a/.agents/scripts/tests/fixtures/team-interface/runtime-invalid.json
+++ b/.agents/scripts/tests/fixtures/team-interface/runtime-invalid.json
@@ -1,0 +1,74 @@
+{
+  "cases": [
+    {
+      "label": "executable adapter path",
+      "document": {
+        "schema_version": 1,
+        "document_type": "runtime_config",
+        "enabled": true,
+        "documents": {
+          "registry_path": "registry-v1.json",
+          "policy_path": "ownership-policy-v1.json",
+          "app_team_path": "app-team-v1.json"
+        },
+        "adapters": [
+          {
+            "adapter_id": "adapter.mock",
+            "settings_ref": "settings:mock",
+            "module_path": "./adapter.mjs"
+          }
+        ],
+        "options": {
+          "max_document_bytes": 1048576,
+          "max_plan_fields": 100,
+          "max_state_observations": 20,
+          "lock_timeout_ms": 250,
+          "lock_stale_ms": 1000
+        }
+      }
+    },
+    {
+      "label": "secret value",
+      "document": {
+        "schema_version": 1,
+        "document_type": "runtime_config",
+        "enabled": true,
+        "documents": {
+          "registry_path": "registry-v1.json",
+          "policy_path": "ownership-policy-v1.json",
+          "app_team_path": "app-team-v1.json"
+        },
+        "adapters": [
+          {
+            "adapter_id": "adapter.mock",
+            "settings_ref": "settings:mock",
+            "secret_value": "[REDACTED]"
+          }
+        ],
+        "options": {
+          "max_document_bytes": 1048576,
+          "max_plan_fields": 100,
+          "max_state_observations": 20,
+          "lock_timeout_ms": 250,
+          "lock_stale_ms": 1000
+        }
+      }
+    },
+    {
+      "label": "malformed state",
+      "document": {
+        "schema_version": 1,
+        "document_type": "runtime_state",
+        "generation": 0,
+        "updated_at": "not-a-time",
+        "observations": []
+      }
+    }
+  ],
+  "stale_generation": {
+    "expected_generation": 2,
+    "next_generation": 3,
+    "existing_generation": 4
+  },
+  "unsupported_commands": ["apply", "create", "update", "delete", "send", "invite"]
+}

--- a/.agents/scripts/tests/fixtures/team-interface/runtime-valid.json
+++ b/.agents/scripts/tests/fixtures/team-interface/runtime-valid.json
@@ -1,0 +1,164 @@
+{
+  "runtime_config": {
+    "schema_version": 1,
+    "document_type": "runtime_config",
+    "enabled": false,
+    "documents": {
+      "registry_path": "registry-v1.json",
+      "policy_path": "ownership-policy-v1.json",
+      "app_team_path": "app-team-v1.json"
+    },
+    "adapters": [],
+    "options": {
+      "adapter_timeout_ms": 100,
+      "max_document_bytes": 1048576,
+      "max_plan_fields": 100,
+      "max_state_observations": 20,
+      "lock_timeout_ms": 250,
+      "lock_stale_ms": 1000
+    }
+  },
+  "adapter_observation": {
+    "schema_version": 1,
+    "document_type": "adapter_observation",
+    "adapter_id": "adapter.mock",
+    "provider_id": "provider.mock",
+    "adapter_version": "1.0.0",
+    "provider_version": "fixture-1",
+    "availability": "available",
+    "capabilities": [
+      {
+        "capability_id": "capability.mock.read",
+        "resource_kinds": ["other"],
+        "operations": ["discover", "read"],
+        "availability": "available",
+        "owner_review_required": false
+      }
+    ],
+    "compatibility": {
+      "state": "compatible",
+      "reference": "compatibility:mock-fixture"
+    },
+    "observed_at": "2026-08-05T20:00:00Z",
+    "evidence_refs": ["evidence:mock-fixture"]
+  },
+  "runtime_state": {
+    "schema_version": 1,
+    "document_type": "runtime_state",
+    "generation": 1,
+    "updated_at": "2026-08-05T20:00:01Z",
+    "observations": [
+      {
+        "schema_version": 1,
+        "document_type": "adapter_observation",
+        "adapter_id": "adapter.mock",
+        "provider_id": "provider.mock",
+        "adapter_version": "1.0.0",
+        "provider_version": "fixture-1",
+        "availability": "available",
+        "capabilities": [
+          {
+            "capability_id": "capability.mock.read",
+            "resource_kinds": ["other"],
+            "operations": ["discover", "read"],
+            "availability": "available",
+            "owner_review_required": false
+          }
+        ],
+        "compatibility": {
+          "state": "compatible",
+          "reference": "compatibility:mock-fixture"
+        },
+        "observed_at": "2026-08-05T20:00:00Z",
+        "evidence_refs": ["evidence:mock-fixture"]
+      }
+    ]
+  },
+  "ownership_policy": {
+    "schema_version": 1,
+    "document_type": "ownership_policy",
+    "policy_id": "runtime-policy.mock",
+    "policy_version": "1.0.0",
+    "resource_kind": "conversation",
+    "unknown_field_ownership": "review_required",
+    "field_rules": [
+      {"field_path": "/enabled", "ownership": "managed", "sensitive": false}
+    ]
+  },
+  "plan_request": {
+    "schema_version": 1,
+    "document_type": "plan_request",
+    "reconciliation_input": {
+      "schema_version": 1,
+      "document_type": "reconciliation_input",
+      "input_id": "reconciliation-input.runtime-fixture",
+      "resource": {
+        "resource_id": "resource.buzz.conversation",
+        "provider_id": "buzz",
+        "community_id": "community.buzz.primary",
+        "provider_external_id": "conversation/opaque-main",
+        "match_basis": "stable_ids",
+        "management_identity_status": "verified",
+        "management_owner": "subject.alice",
+        "manager_marker": "manager:runtime-fixture"
+      },
+      "policy_ref": "policy:runtime-policy.mock",
+      "policy_version": "1.0.0",
+      "adapter_version": "1.0.0",
+      "observed_at": "2026-08-05T20:00:00Z",
+      "observation_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "fields": [
+        {
+          "field_path": "/enabled",
+          "ownership": "managed",
+          "sensitive": false,
+          "desired": {
+            "present": true,
+            "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+            "data": {"kind": "literal", "value": false}
+          },
+          "last_applied": {
+            "present": true,
+            "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+            "data": {"kind": "literal", "value": true}
+          },
+          "actual": {
+            "present": true,
+            "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+            "data": {"kind": "literal", "value": true}
+          },
+          "actual_observed_at": "2026-08-05T20:00:00Z"
+        }
+      ]
+    },
+    "desired_version": "fixture-1",
+    "capabilities": {
+      "stable_external_ids": true,
+      "managed_metadata": true,
+      "supported_apply": true,
+      "revision_cas": true,
+      "compatibility": "compatible",
+      "observed_at": "2026-08-05T19:59:00Z",
+      "expires_at": "2026-08-05T20:30:00Z",
+      "evidence_refs": ["capability:runtime-fixture"]
+    },
+    "precondition": {
+      "revision_kind": "etag",
+      "observed_revision": "etag-fixture-1",
+      "expected_revision": "etag-fixture-1",
+      "observation_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "observed_at": "2026-08-05T20:00:00Z"
+    },
+    "security_drift_action": "disable_execution",
+    "verified_actor_ref": "actor:runtime-owner",
+    "authorization_ref": "authorization:runtime-fixture",
+    "created_at": "2026-08-05T20:01:00Z",
+    "expires_at": "2026-08-05T20:20:00Z",
+    "audit": {
+      "audit_ref": "audit:runtime-fixture",
+      "evidence_refs": ["authorization:runtime-fixture"],
+      "redaction": "redacted",
+      "recorded_at": "2026-08-05T20:01:00Z"
+    }
+  }
+}

--- a/.agents/scripts/tests/test-team-interface-runtime-deps.sh
+++ b/.agents/scripts/tests/test-team-interface-runtime-deps.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+AGENT_DEPLOY="$REPO_ROOT/.agents/scripts/setup/modules/agent-deploy.sh"
+TEMP_ROOT="${AIDEVOPS_TEMP_DIR:-$HOME/.aidevops/.agent-workspace/tmp}"
+TEST_ROOT=""
+MOCK_INSTALL_TARGET=""
+
+print_info() {
+	local message="$1"
+	: "$message"
+	return 0
+}
+print_success() {
+	local message="$1"
+	: "$message"
+	return 0
+}
+print_warning() {
+	local message="$1"
+	: "$message"
+	return 0
+}
+print_error() {
+	local message="$1"
+	printf '%s\n' "$message" >&2
+	return 0
+}
+
+cleanup() {
+	[[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT"
+	return 0
+}
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+prepare_fixture() {
+	local target_dir="$1"
+	mkdir -p "$target_dir/scripts" "$target_dir/schemas"
+	cp "$REPO_ROOT/.agents/package.json" "$target_dir/package.json"
+	cp "$REPO_ROOT/.agents/package-lock.json" "$target_dir/package-lock.json"
+	cp "$REPO_ROOT/.agents/scripts/team-interface-common.mjs" "$target_dir/scripts/team-interface-common.mjs"
+	cp "$REPO_ROOT/.agents/scripts/team-interface-validators.mjs" "$target_dir/scripts/team-interface-validators.mjs"
+	cp -R "$REPO_ROOT/.agents/schemas/team-interface" "$target_dir/schemas/team-interface"
+	return 0
+}
+
+npm() {
+	local command_name="${1:-}"
+	: "$command_name"
+	if ! node --input-type=module - "$REPO_ROOT" "$MOCK_INSTALL_TARGET" <<'NODE'; then
+import {cpSync, mkdirSync, readFileSync} from "node:fs";
+import {dirname, resolve} from "node:path";
+
+const repoRoot = process.argv[2];
+const targetRoot = process.argv[3];
+const lock = JSON.parse(readFileSync(resolve(repoRoot, ".agents/package-lock.json"), "utf8"));
+for (const packagePath of Object.keys(lock.packages)) {
+  if (!packagePath.startsWith("node_modules/")) continue;
+  const source = resolve(repoRoot, packagePath);
+  const destination = resolve(targetRoot, packagePath);
+  mkdirSync(dirname(destination), {recursive: true});
+  cpSync(source, destination, {recursive: true});
+}
+NODE
+		return 1
+	fi
+	return 0
+}
+
+main() {
+	local activation_gate="_install_agent_runtime_deps \"\$target_dir\" || return 1"
+	mkdir -p "$TEMP_ROOT"
+	TEST_ROOT=$(mktemp -d "$TEMP_ROOT/team-interface-runtime-deps.XXXXXX") || return 1
+	trap cleanup EXIT
+
+	# shellcheck source=/dev/null
+	source "$AGENT_DEPLOY"
+
+	MOCK_INSTALL_TARGET="$TEST_ROOT/deployed-agents"
+	prepare_fixture "$MOCK_INSTALL_TARGET"
+	ln -s "$REPO_ROOT/node_modules" "$TEST_ROOT/node_modules"
+	if _verify_agent_runtime_deps "$MOCK_INSTALL_TARGET" >/dev/null 2>&1; then
+		fail "dependency verification accepted an ancestor node_modules tree"
+	fi
+	_install_agent_runtime_deps "$MOCK_INSTALL_TARGET" || fail "locked deployed dependency installation failed"
+	_verify_agent_runtime_deps "$MOCK_INSTALL_TARGET" || fail "deployed runtime dependency verification failed"
+	[[ -d "$MOCK_INSTALL_TARGET/node_modules" && ! -L "$MOCK_INSTALL_TARGET/node_modules" ]] ||
+		fail "mock npm install did not provide a local deployed dependency tree"
+
+	grep -qF "$activation_gate" "$AGENT_DEPLOY" ||
+		fail "runtime bundle activation does not enforce dependency verification"
+	grep -qF -- 'npm ci --omit=dev --ignore-scripts' "$AGENT_DEPLOY" ||
+		fail "agent runtime dependency installation permits package lifecycle scripts"
+	printf 'PASS: team-interface runtime dependencies are pinned and activation-gated\n'
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-team-interface-runtime.mjs
+++ b/.agents/scripts/tests/test-team-interface-runtime.mjs
@@ -1,0 +1,746 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {spawnSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {
+  canonicalDigest,
+  createRuntimeValidators,
+  generatePlan,
+  loadRuntimeConfig,
+  readRuntimeState,
+  runDetect,
+  runDoctor,
+  runProviders,
+  runStatus,
+  runtimeStatePaths,
+  writeRuntimeState,
+} from "../team-interface-core.mjs";
+import {
+  createAdapterRegistry,
+  selectConfiguredAdapters,
+} from "../team-interface-adapters.mjs";
+import {assertNoSecretValueProperties} from "./lib/team-interface-reconciliation-fixtures.mjs";
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(testDirectory, "../../..");
+const fixtureDirectory = path.join(testDirectory, "fixtures/team-interface");
+const helperScript = path.join(repositoryRoot, ".agents/scripts/team-interface-helper.sh");
+const runtimeSchemaPath = path.join(repositoryRoot, ".agents/schemas/team-interface/runtime-v1.schema.json");
+
+function readJson(filePath) {
+  return JSON.parse(readText(filePath));
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, {mode: 0o600});
+}
+
+function readText(filePath) {
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function fileStats(filePath) {
+  return fs.statSync(filePath);
+}
+
+function ensureDirectory(directoryPath, options) {
+  fs.mkdirSync(directoryPath, options);
+}
+
+function temporaryDirectory(prefix) {
+  return fs.mkdtempSync(prefix);
+}
+
+function setFileTimes(filePath, time) {
+  fs.utimesSync(filePath, time, time);
+}
+
+function pathExists(filePath) {
+  return fs.existsSync(filePath);
+}
+
+function removePath(filePath, options) {
+  fs.rmSync(filePath, options);
+}
+
+function copy(value) {
+  return structuredClone(value);
+}
+
+function validationErrors(validate) {
+  return JSON.stringify(validate.errors || [], null, 2);
+}
+
+function requireValid(validate, document, label) {
+  assert.equal(validate(document), true, `${label} failed:\n${validationErrors(validate)}`);
+}
+
+function requireInvalid(validate, document, label) {
+  assert.equal(validate(document), false, `${label} unexpectedly validated`);
+}
+
+function unsignedPlan(plan) {
+  const unsigned = copy(plan);
+  delete unsigned.plan_hash;
+  return unsigned;
+}
+
+function readMode(filePath) {
+  return fileStats(filePath).mode & 0o777;
+}
+
+function makeObservation(source, adapterId, providerId, capabilityId, providerVersion) {
+  const observation = copy(source);
+  observation.adapter_id = adapterId;
+  observation.provider_id = providerId;
+  observation.provider_version = providerVersion;
+  observation.capabilities[0].capability_id = capabilityId;
+  observation.evidence_refs = [`evidence:${adapterId}`];
+  return observation;
+}
+
+function makeAdapter(observation, handlers = {}) {
+  return {
+    adapter_id: observation.adapter_id,
+    adapter_version: observation.adapter_version,
+    capabilities: copy(observation.capabilities),
+    provider_id: observation.provider_id,
+    async detect(context) {
+      if (handlers.detect) return handlers.detect(context);
+      return copy(observation);
+    },
+    async status(context) {
+      if (handlers.status) return handlers.status(context);
+      return copy(observation);
+    },
+  };
+}
+
+function runHelper(command, argumentsList = []) {
+  return spawnSync(helperScript, [command, ...argumentsList], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    env: {...process.env},
+  });
+}
+
+const validFixture = readJson(path.join(fixtureDirectory, "runtime-valid.json"));
+const invalidFixture = readJson(path.join(fixtureDirectory, "runtime-invalid.json"));
+const coreFixture = readJson(path.join(fixtureDirectory, "core-valid.json"));
+const providerRegistry = coreFixture.documents.find(({document_type: type}) => type === "registry");
+const runtimeSchema = readJson(runtimeSchemaPath);
+const validators = createRuntimeValidators();
+
+function plannerOptions(policy = validFixture.ownership_policy) {
+  return {policy, registry: providerRegistry, validators};
+}
+
+assert.equal(runtimeSchema.$schema, "https://json-schema.org/draft/2020-12/schema");
+assert.equal(runtimeSchema.$id, "urn:aidevops:team-interface:runtime:v1");
+assertNoSecretValueProperties(runtimeSchema);
+for (const [label, document] of Object.entries({
+  adapter_observation: validFixture.adapter_observation,
+  plan_request: validFixture.plan_request,
+  runtime_config: validFixture.runtime_config,
+  runtime_state: validFixture.runtime_state,
+})) requireValid(validators.runtime, document, label);
+requireValid(validators.ownershipPolicy, validFixture.ownership_policy, "ownership policy");
+for (const invalidCase of invalidFixture.cases) {
+  requireInvalid(validators.runtime, invalidCase.document, invalidCase.label);
+}
+for (const [label, document] of Object.entries({
+  invalid_observation_time: {
+    ...copy(validFixture.adapter_observation),
+    observed_at: "2026-02-30T20:00:00Z",
+  },
+  invalid_plan_time: {
+    ...copy(validFixture.plan_request),
+    created_at: "not-a-date",
+  },
+  invalid_state_time: {
+    ...copy(validFixture.runtime_state),
+    updated_at: "2026-13-01T20:00:00Z",
+  },
+})) requireInvalid(validators.runtime, document, label);
+
+const missingObservedCapabilities = copy(validFixture.adapter_observation);
+missingObservedCapabilities.capabilities = [];
+requireInvalid(validators.adapterObservation, missingObservedCapabilities, "missing observed capabilities");
+
+const inlineTokenConfig = copy(validFixture.runtime_config);
+inlineTokenConfig.adapters = [{adapter_id: "adapter.mock", settings_ref: "token:inline-secret"}];
+requireInvalid(validators.runtimeConfig, inlineTokenConfig, "inline token-shaped adapter setting");
+
+const firstPlan = generatePlan(validFixture.plan_request, plannerOptions());
+const replayPlan = generatePlan(copy(validFixture.plan_request), plannerOptions());
+assert.deepEqual(replayPlan, firstPlan, "identical plan requests must replay byte-for-byte");
+assert.equal(firstPlan.outcome, "update");
+assert.equal(firstPlan.field_decisions[0].decision, "apply_desired");
+assert.equal(firstPlan.plan_hash, canonicalDigest(unsignedPlan(firstPlan)));
+requireValid(validators.plan, firstPlan, "generated plan");
+
+const orderedRequest = copy(validFixture.plan_request);
+const orderedPolicy = copy(validFixture.ownership_policy);
+orderedRequest.reconciliation_input.fields.push({
+  actual: {
+    data: {kind: "literal", value: "user label"},
+    digest: "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+    present: true,
+  },
+  actual_observed_at: "2026-08-05T20:00:00Z",
+  desired: {
+    data: {kind: "literal", value: "desired label"},
+    digest: "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    present: true,
+  },
+  field_path: "/display_label",
+  last_applied: {
+    data: {kind: "literal", value: "old label"},
+    digest: "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+    present: true,
+  },
+  ownership: "user_owned",
+  sensitive: false,
+});
+orderedPolicy.field_rules.push({field_path: "/display_label", ownership: "user_owned", sensitive: false});
+orderedRequest.capabilities.evidence_refs.push("capability:runtime-secondary");
+orderedRequest.audit.evidence_refs.push("evidence:runtime-secondary");
+const reorderedRequest = copy(orderedRequest);
+reorderedRequest.reconciliation_input.fields.reverse();
+reorderedRequest.capabilities.evidence_refs.reverse();
+reorderedRequest.audit.evidence_refs.reverse();
+assert.deepEqual(
+  generatePlan(reorderedRequest, plannerOptions(orderedPolicy)),
+  generatePlan(orderedRequest, plannerOptions(orderedPolicy)),
+  "set-like input ordering must not change plan output",
+);
+
+const unicodeRequest = copy(validFixture.plan_request);
+const unicodePolicy = copy(validFixture.ownership_policy);
+for (const fieldPath of ["/ä", "/z"]) {
+  unicodeRequest.reconciliation_input.fields.push({
+    ...copy(unicodeRequest.reconciliation_input.fields[0]),
+    field_path: fieldPath,
+  });
+  unicodePolicy.field_rules.push({...copy(unicodePolicy.field_rules[0]), field_path: fieldPath});
+}
+assert.deepEqual(
+  generatePlan(unicodeRequest, plannerOptions(unicodePolicy)).field_decisions.map(({field_path: fieldPath}) => fieldPath),
+  ["/enabled", "/z", "/ä"],
+  "plan ordering must use locale-independent code-unit comparison",
+);
+
+const changedRequest = copy(validFixture.plan_request);
+changedRequest.desired_version = "fixture-2";
+const changedPlan = generatePlan(changedRequest, plannerOptions());
+assert.notEqual(changedPlan.plan_hash, firstPlan.plan_hash, "changed plan input must change the plan hash");
+assert.notEqual(changedPlan.operation_id, firstPlan.operation_id, "changed plan input must change stable IDs");
+
+const fallbackRequest = copy(validFixture.plan_request);
+fallbackRequest.capabilities.supported_apply = false;
+fallbackRequest.capabilities.compatibility = "degraded";
+const fallbackPlan = generatePlan(fallbackRequest, plannerOptions());
+assert.equal(fallbackPlan.outcome, "owner_reviewed_draft");
+assert.equal(Object.hasOwn(fallbackPlan, "management_binding"), false);
+
+const securityRequest = copy(validFixture.plan_request);
+const securityPolicy = copy(validFixture.ownership_policy);
+securityRequest.reconciliation_input.fields[0].ownership = "security_required";
+securityRequest.reconciliation_input.fields[0].actual.digest = "sha256:6666666666666666666666666666666666666666666666666666666666666666";
+securityPolicy.field_rules[0].ownership = "security_required";
+const securityPlan = generatePlan(securityRequest, plannerOptions(securityPolicy));
+assert.equal(securityPlan.field_decisions[0].decision, "disable_execution");
+assert.equal(securityPlan.outcome, "disable");
+
+for (const ownership of ["managed", "security_required"]) {
+  const missingLastAppliedRequest = copy(validFixture.plan_request);
+  const missingLastAppliedPolicy = copy(validFixture.ownership_policy);
+  missingLastAppliedRequest.reconciliation_input.fields[0].last_applied = {present: false};
+  missingLastAppliedRequest.reconciliation_input.fields[0].ownership = ownership;
+  missingLastAppliedPolicy.field_rules[0].ownership = ownership;
+  assert.throws(
+    () => generatePlan(missingLastAppliedRequest, plannerOptions(missingLastAppliedPolicy)),
+    /last-applied snapshot/i,
+  );
+}
+
+const shortCapabilityRequest = copy(validFixture.plan_request);
+shortCapabilityRequest.capabilities.expires_at = shortCapabilityRequest.created_at;
+assert.throws(
+  () => generatePlan(shortCapabilityRequest, plannerOptions()),
+  /capability evidence does not cover the plan lifetime/i,
+);
+
+const omittedSecurityPolicy = copy(validFixture.ownership_policy);
+omittedSecurityPolicy.field_rules.push({field_path: "/security_mode", ownership: "security_required", sensitive: false});
+assert.throws(
+  () => generatePlan(validFixture.plan_request, plannerOptions(omittedSecurityPolicy)),
+  /omits a configured ownership field/i,
+);
+
+const mismatchedResourceRequest = copy(validFixture.plan_request);
+mismatchedResourceRequest.reconciliation_input.resource.provider_external_id = "conversation/unregistered";
+assert.throws(
+  () => generatePlan(mismatchedResourceRequest, plannerOptions()),
+  /does not match registered provider_external_id/i,
+);
+
+let observedProviderVersion = "fixture-1";
+let mutationCalls = 0;
+const adapterCalls = [];
+const mockAdapter = makeAdapter(validFixture.adapter_observation, {
+  detect(context) {
+    adapterCalls.push("detect");
+    assert.equal(Object.isFrozen(context), true);
+    assert.equal(Object.isFrozen(context.documents), true);
+    assert.equal(context.runtime.read_only, true);
+    assert.equal(context.runtime.abort_signal instanceof AbortSignal, true);
+    assert.equal(context.runtime.abort_signal.aborted, false);
+    return {...copy(validFixture.adapter_observation), provider_version: observedProviderVersion};
+  },
+  status(context) {
+    adapterCalls.push("status");
+    assert.equal(Object.isFrozen(context), true);
+    return {...copy(validFixture.adapter_observation), provider_version: observedProviderVersion};
+  },
+});
+const mockRegistry = createAdapterRegistry([mockAdapter]);
+assert.equal(Object.isFrozen(mockAdapter), true);
+assert.equal(Object.isFrozen(mockAdapter.capabilities), true);
+assert.equal(Object.isFrozen(mockAdapter.capabilities[0]), true);
+assert.equal(Object.isFrozen(mockAdapter.capabilities[0].operations), true);
+assert.equal(Object.isFrozen(mockAdapter.capabilities[0].resource_kinds), true);
+const preFrozenAdapter = makeAdapter(validFixture.adapter_observation);
+Object.freeze(preFrozenAdapter);
+createAdapterRegistry([preFrozenAdapter]);
+assert.equal(Object.isFrozen(preFrozenAdapter.capabilities), true, "pre-frozen adapters must freeze nested capabilities");
+assert.equal(Object.isFrozen(preFrozenAdapter.capabilities[0]), true, "pre-frozen adapters must freeze capability entries");
+const selectedConfig = copy(validFixture.runtime_config);
+selectedConfig.adapters = [{adapter_id: "adapter.mock", settings_ref: "settings:mock"}];
+assert.equal(selectConfiguredAdapters(selectedConfig, mockRegistry)[0].adapter, mockAdapter);
+assert.throws(
+  () => selectConfiguredAdapters(
+    {...selectedConfig, adapters: [{adapter_id: "adapter.unknown", settings_ref: "settings:unknown"}]},
+    mockRegistry,
+  ),
+  /unknown configured adapter/i,
+);
+assert.throws(() => createAdapterRegistry([mockAdapter, mockAdapter]), /duplicate adapter/i);
+assert.throws(
+  () => createAdapterRegistry([{...makeAdapter(validFixture.adapter_observation), unknown_property: true}]),
+  /unknown property/i,
+);
+assert.throws(
+  () => createAdapterRegistry([{
+    ...makeAdapter(validFixture.adapter_observation),
+    capabilities: [{...copy(validFixture.adapter_observation.capabilities[0]), unknown_property: true}],
+  }]),
+  /capability contains unknown property/i,
+);
+assert.throws(
+  () => createAdapterRegistry([{
+    ...makeAdapter(validFixture.adapter_observation),
+    capabilities: [
+      copy(validFixture.adapter_observation.capabilities[0]),
+      copy(validFixture.adapter_observation.capabilities[0]),
+    ],
+  }]),
+  /duplicate capability IDs/i,
+);
+for (const capabilityOverride of [
+  {availability: "sometimes"},
+  {operations: ["read", "read"]},
+  {owner_review_required: "false"},
+  {resource_kinds: ["channel", "channel"]},
+  {resource_kinds: ["filesystem"]},
+]) {
+  assert.throws(
+    () => createAdapterRegistry([{
+      ...makeAdapter(validFixture.adapter_observation),
+      capabilities: [{...copy(validFixture.adapter_observation.capabilities[0]), ...capabilityOverride}],
+    }]),
+    /capability/i,
+  );
+}
+assert.throws(
+  () => createAdapterRegistry([{
+    ...mockAdapter,
+    create() {
+      mutationCalls += 1;
+    },
+  }]),
+  /forbidden mutation method/i,
+);
+assert.equal(mutationCalls, 0, "provider mutation traps must never be called");
+
+const temporaryParent = process.env.AIDEVOPS_TEMP_DIR
+  || path.join(os.homedir(), ".aidevops/.agent-workspace/tmp");
+ensureDirectory(temporaryParent, {mode: 0o700, recursive: true});
+const sandbox = temporaryDirectory(path.join(temporaryParent, "team-interface-runtime-"));
+
+try {
+  const casRoot = path.join(sandbox, "cas-state");
+  const casPaths = runtimeStatePaths(casRoot);
+  const stateOne = copy(validFixture.runtime_state);
+  writeRuntimeState(stateOne, {expectedGeneration: 0, paths: casPaths, validators});
+  assert.equal(readMode(casPaths.directory), 0o700);
+  assert.equal(readMode(casPaths.statePath), 0o600);
+  assert.equal(readRuntimeState({paths: casPaths, validators}).generation, 1);
+  assert.throws(
+    () => writeRuntimeState(stateOne, {expectedGeneration: 0, paths: casPaths, validators}),
+    /generation changed/i,
+  );
+
+  writeJson(casPaths.lockPath, {
+    created_at: "2020-01-01T00:00:00Z",
+    host: os.hostname(),
+    pid: process.pid,
+    process_started_at: "",
+    token: "live-owner",
+  });
+  setFileTimes(casPaths.lockPath, new Date(0));
+  const stateTwo = {...copy(stateOne), generation: 2, updated_at: "2026-08-05T20:00:02Z"};
+  assert.throws(
+    () => writeRuntimeState(stateTwo, {
+      expectedGeneration: 1,
+      lockStaleMs: 1,
+      lockTimeoutMs: 10,
+      paths: casPaths,
+      validators,
+    }),
+    /lock timed out/i,
+  );
+  assert.equal(pathExists(casPaths.lockPath), true, "live stale lock must not be deleted");
+  removePath(casPaths.lockPath);
+
+  writeJson(casPaths.lockPath, {
+    created_at: "2020-01-01T00:00:00Z",
+    host: os.hostname(),
+    pid: 2147483647,
+    process_started_at: "dead-owner",
+    token: "abandoned-owner",
+  });
+  setFileTimes(casPaths.lockPath, new Date(0));
+  ensureDirectory(`${casPaths.lockPath}.reclaim`, {mode: 0o700});
+  assert.throws(
+    () => writeRuntimeState(stateTwo, {
+      expectedGeneration: 1,
+      lockStaleMs: 1,
+      lockTimeoutMs: 10,
+      paths: casPaths,
+      validators,
+    }),
+    /lock timed out/i,
+  );
+  assert.equal(pathExists(casPaths.lockPath), true, "serialized reclaimer must preserve the observed lock");
+  removePath(`${casPaths.lockPath}.reclaim`, {recursive: true});
+  writeRuntimeState(stateTwo, {
+    expectedGeneration: 1,
+    lockStaleMs: 1,
+    lockTimeoutMs: 250,
+    paths: casPaths,
+    validators,
+  });
+  assert.equal(readRuntimeState({paths: casPaths, validators}).generation, 2);
+  assert.equal(pathExists(casPaths.lockPath), false, "abandoned lock must be reclaimed and released");
+
+  const configDirectory = path.join(sandbox, "config");
+  const runtimeStateRoot = path.join(sandbox, "runtime-state");
+  ensureDirectory(configDirectory, {mode: 0o700});
+  const appTeamFixture = readJson(path.join(fixtureDirectory, "app-team-valid-modes.json"));
+  const registryPath = path.join(configDirectory, "registry-v1.json");
+  const policyPath = path.join(configDirectory, "ownership-policy-v1.json");
+  const appTeamPath = path.join(configDirectory, "app-team-v1.json");
+  writeJson(registryPath, providerRegistry);
+  writeJson(policyPath, validFixture.ownership_policy);
+  writeJson(appTeamPath, appTeamFixture);
+
+  const enabledConfig = copy(selectedConfig);
+  enabledConfig.enabled = true;
+  enabledConfig.documents = {
+    app_team_path: "app-team-v1.json",
+    policy_path: "ownership-policy-v1.json",
+    registry_path: "registry-v1.json",
+  };
+  const configPath = path.join(configDirectory, "runtime-config.json");
+  writeJson(configPath, enabledConfig);
+  const configSymlink = path.join(configDirectory, "runtime-config-link.json");
+  fs.symlinkSync(configPath, configSymlink);
+  assert.throws(
+    () => loadRuntimeConfig({configPath: configSymlink, validators}),
+    /symbolic links|symbolic link/i,
+  );
+  const providers = runProviders({configPath, registry: mockRegistry, validators});
+  assert.deepEqual(providers.selected, [{adapter_id: "adapter.mock", provider_id: "provider.mock"}]);
+  assert.equal(Object.hasOwn(providers.selected[0], "settings_ref"), false, "provider output must not expose settings references");
+
+  for (const [label, mutateObservation, expectedCode, expectedMessage] of [
+    [
+      "duplicate capability identity",
+      (observation) => {
+        observation.capabilities.push({...copy(observation.capabilities[0]), availability: "degraded"});
+      },
+      "duplicate_identity",
+      "adapter observation contains duplicate identities",
+    ],
+    [
+      "undeclared capability identity",
+      (observation) => {
+        observation.capabilities[0].capability_id = "capability.undeclared.read";
+      },
+      "adapter_capability_mismatch",
+      "adapter observation capability mismatch",
+    ],
+  ]) {
+    const invalidObservationAdapter = makeAdapter(validFixture.adapter_observation, {
+      detect() {
+        const observation = copy(validFixture.adapter_observation);
+        mutateObservation(observation);
+        return observation;
+      },
+    });
+    const invalidResult = await runDetect({
+      configPath,
+      registry: createAdapterRegistry([invalidObservationAdapter]),
+      stateRoot: runtimeStateRoot,
+      validators,
+    });
+    assert.equal(invalidResult.errors.length, 1, label);
+    assert.equal(invalidResult.errors[0].code, expectedCode, label);
+    assert.equal(invalidResult.errors[0].message, expectedMessage, label);
+    assert.equal(pathExists(runtimeStatePaths(runtimeStateRoot).statePath), false, `${label} changed state`);
+  }
+
+  let timeoutSignalAborted = false;
+  const hangingAdapter = makeAdapter(validFixture.adapter_observation, {
+    detect(context) {
+      return new Promise((_, reject) => {
+        context.runtime.abort_signal.addEventListener("abort", () => {
+          timeoutSignalAborted = true;
+          reject(new Error("adapter read aborted"));
+        }, {once: true});
+      });
+    },
+  });
+  const timeoutConfig = copy(enabledConfig);
+  timeoutConfig.options.adapter_timeout_ms = 20;
+  writeJson(configPath, timeoutConfig);
+  const timeoutStartedAt = Date.now();
+  const timedOut = await runDetect({
+    configPath,
+    registry: createAdapterRegistry([hangingAdapter]),
+    stateRoot: path.join(sandbox, "timeout-state"),
+    validators,
+  });
+  assert.equal(timedOut.errors[0].code, "adapter_timeout");
+  assert.equal(timedOut.errors[0].message, "adapter read timed out");
+  assert.equal(timeoutSignalAborted, true, "adapter timeout must signal cancellation");
+  assert.equal(Date.now() - timeoutStartedAt < 1000, true, "adapter timeout must bound a hung read");
+  assert.equal(timedOut.state_changed, false);
+  writeJson(configPath, enabledConfig);
+
+  const detected = await runDetect({
+    configPath,
+    now: () => "2026-08-05T20:00:01Z",
+    registry: mockRegistry,
+    stateRoot: runtimeStateRoot,
+    validators,
+  });
+  assert.equal(detected.generation, 1);
+  assert.equal(detected.state_changed, true);
+  assert.deepEqual(adapterCalls, ["detect"]);
+  const runtimePaths = runtimeStatePaths(runtimeStateRoot);
+  const firstStateBytes = readText(runtimePaths.statePath);
+
+  const unchanged = await runDetect({
+    configPath,
+    now: () => "2026-08-05T20:00:02Z",
+    registry: mockRegistry,
+    stateRoot: runtimeStateRoot,
+    validators,
+  });
+  assert.equal(unchanged.generation, 1);
+  assert.equal(unchanged.state_changed, false);
+  assert.equal(readText(runtimePaths.statePath), firstStateBytes);
+
+  const statusBefore = fileStats(runtimePaths.statePath).mtimeMs;
+  const status = await runStatus({configPath, registry: mockRegistry, stateRoot: runtimeStateRoot, validators});
+  assert.equal(status.state_changed, false);
+  assert.equal(status.live.length, 1);
+  assert.equal(fileStats(runtimePaths.statePath).mtimeMs, statusBefore);
+  const callsBeforeDoctor = adapterCalls.length;
+  const doctor = runDoctor({configPath, registry: mockRegistry, stateRoot: runtimeStateRoot, validators});
+  assert.equal(doctor.ok, true);
+  assert.equal(adapterCalls.length, callsBeforeDoctor, "doctor must not call provider adapters");
+
+  const validStateBeforeRejections = readText(runtimePaths.statePath);
+  const unknownConfig = copy(enabledConfig);
+  unknownConfig.adapters = [{adapter_id: "adapter.unknown", settings_ref: "settings:unknown"}];
+  writeJson(configPath, unknownConfig);
+  await assert.rejects(
+    runDetect({configPath, registry: mockRegistry, stateRoot: runtimeStateRoot, validators}),
+    /unknown configured adapter/i,
+  );
+  assert.equal(readText(runtimePaths.statePath), validStateBeforeRejections);
+
+  for (const invalidCase of invalidFixture.cases.slice(0, 2)) {
+    writeJson(configPath, invalidCase.document);
+    await assert.rejects(
+      runDetect({configPath, registry: mockRegistry, stateRoot: runtimeStateRoot, validators}),
+      /failed validation/i,
+    );
+    assert.equal(readText(runtimePaths.statePath), validStateBeforeRejections);
+  }
+
+  writeJson(configPath, enabledConfig);
+  writeJson(policyPath, {document_type: "ownership_policy", schema_version: 1});
+  await assert.rejects(
+    runDetect({configPath, registry: mockRegistry, stateRoot: runtimeStateRoot, validators}),
+    /ownership policy failed validation/i,
+  );
+  assert.equal(readText(runtimePaths.statePath), validStateBeforeRejections);
+  writeJson(policyPath, validFixture.ownership_policy);
+
+  const failedObservation = makeObservation(
+    validFixture.adapter_observation,
+    "adapter.fail",
+    "provider.fail",
+    "capability.fail.read",
+    "failure-prior",
+  );
+  const failedAdapter = makeAdapter(failedObservation, {
+    detect() {
+      const failure = new Error(`${os.homedir()}/private/provider token=fixture-sensitive\n${"x".repeat(800)}\u0007`);
+      failure.code = `unsafe\n${"z".repeat(150)}`;
+      throw failure;
+    },
+    status() {
+      throw new Error("provider status unavailable");
+    },
+  });
+  const partialRegistry = createAdapterRegistry([mockAdapter, failedAdapter]);
+  const prior = readRuntimeState({paths: runtimePaths, validators});
+  writeRuntimeState({
+    ...copy(prior),
+    generation: 2,
+    observations: [...prior.observations, failedObservation].sort(
+      (left, right) => left.adapter_id.localeCompare(right.adapter_id),
+    ),
+    updated_at: "2026-08-05T20:00:03Z",
+  }, {expectedGeneration: 1, paths: runtimePaths, validators});
+  const partialConfig = copy(enabledConfig);
+  partialConfig.adapters.push({adapter_id: "adapter.fail", settings_ref: "settings:fail"});
+  writeJson(configPath, partialConfig);
+  observedProviderVersion = "fixture-2";
+  const partial = await runDetect({
+    configPath,
+    now: () => "2026-08-05T20:00:04Z",
+    registry: partialRegistry,
+    stateRoot: runtimeStateRoot,
+    validators,
+  });
+  assert.equal(partial.generation, 3);
+  assert.equal(partial.errors.length, 1);
+  assert.equal(partial.observations.find(({adapter_id: id}) => id === "adapter.fail").provider_version, "failure-prior");
+  assert.equal(partial.errors[0].message, "adapter read failed");
+  assert.equal(partial.errors[0].message.includes(os.homedir()), false);
+  assert.doesNotMatch(partial.errors[0].message, /fixture-sensitive/);
+  assert.equal(partial.errors[0].code, "adapter_read_failed");
+  assert.equal(mutationCalls, 0);
+
+  const partialStateBytes = readText(runtimePaths.statePath);
+  const partialStatus = await runStatus({
+    configPath,
+    registry: partialRegistry,
+    stateRoot: runtimeStateRoot,
+    validators,
+  });
+  assert.equal(partialStatus.errors.length, 1);
+  assert.equal(readText(runtimePaths.statePath), partialStateBytes);
+
+  const upgradedFailedAdapter = {
+    ...makeAdapter(failedObservation, {
+      detect() {
+        throw new Error("upgraded adapter unavailable");
+      },
+      status() {
+        throw new Error("upgraded adapter unavailable");
+      },
+    }),
+    adapter_version: "2.0.0",
+  };
+  const upgraded = await runDetect({
+    configPath,
+    now: () => "2026-08-05T20:00:05Z",
+    registry: createAdapterRegistry([mockAdapter, upgradedFailedAdapter]),
+    stateRoot: runtimeStateRoot,
+    validators,
+  });
+  assert.equal(upgraded.generation, 4);
+  assert.equal(upgraded.state_changed, true);
+  assert.equal(upgraded.observations.some(({adapter_id: adapterId}) => adapterId === "adapter.fail"), false);
+
+  const emptyConfig = copy(enabledConfig);
+  emptyConfig.adapters = [];
+  writeJson(configPath, emptyConfig);
+  const cleared = await runDetect({
+    configPath,
+    now: () => "2026-08-05T20:00:06Z",
+    registry: partialRegistry,
+    stateRoot: runtimeStateRoot,
+    validators,
+  });
+  assert.equal(cleared.state_changed, true);
+  assert.deepEqual(cleared.observations, []);
+  assert.deepEqual(readRuntimeState({paths: runtimePaths, validators}).observations, []);
+  const emptyStatus = await runStatus({
+    configPath,
+    registry: partialRegistry,
+    stateRoot: runtimeStateRoot,
+    validators,
+  });
+  assert.deepEqual(emptyStatus.persisted, []);
+
+  const cliConfig = copy(enabledConfig);
+  cliConfig.adapters = [];
+  const cliConfigPath = path.join(configDirectory, "cli-config.json");
+  const requestPath = path.join(configDirectory, "plan-request.json");
+  const cliStateRoot = path.join(sandbox, "cli-state");
+  writeJson(cliConfigPath, cliConfig);
+  writeJson(requestPath, validFixture.plan_request);
+  const cliCommands = ["providers", "detect", "status", "doctor"];
+  for (const command of cliCommands) {
+    const result = runHelper(command, ["--config", cliConfigPath, "--state-dir", cliStateRoot]);
+    assert.equal(result.status, 0, `${command} failed: ${result.stderr}`);
+    assert.equal(JSON.parse(result.stdout).command, command);
+  }
+  assert.equal(pathExists(runtimeStatePaths(cliStateRoot).statePath), false, "empty detection must not create state");
+  const cliPlan = runHelper("plan", ["--config", cliConfigPath, "--request", requestPath]);
+  assert.equal(cliPlan.status, 0, cliPlan.stderr);
+  assert.deepEqual(JSON.parse(cliPlan.stdout), firstPlan);
+
+  for (const command of invalidFixture.unsupported_commands) {
+    const stateBefore = pathExists(runtimeStatePaths(cliStateRoot).statePath);
+    const result = runHelper(command, ["--config", cliConfigPath]);
+    assert.notEqual(result.status, 0, `${command} unexpectedly succeeded`);
+    assert.match(result.stderr, /unsupported read-only team-interface command/i);
+    assert.equal(pathExists(runtimeStatePaths(cliStateRoot).statePath), stateBefore);
+  }
+  const duplicateArgument = runHelper("providers", ["--config", cliConfigPath, "--config", cliConfigPath]);
+  assert.notEqual(duplicateArgument.status, 0);
+  assert.match(duplicateArgument.stderr, /duplicate argument/i);
+
+  const missingConfig = path.join(sandbox, "missing-config.json");
+  const missingResult = runHelper("providers", ["--config", missingConfig]);
+  assert.equal(missingResult.status, 0, missingResult.stderr);
+  assert.equal(JSON.parse(missingResult.stdout).config_status, "missing");
+} finally {
+  removePath(sandbox, {force: true, recursive: true});
+}
+
+console.log("team-interface runtime tests passed");

--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ node_modules/
 packages/gui-web/dist/
 packages/gui-desktop/dist/
 package-lock.json
+!.agents/package-lock.json
 !.agents/plugins/opencode-aidevops/package-lock.json
 pnpm-lock.yaml
 yarn.lock

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ the required notices and preferred credit text.
 - `aidevops runtime-bundle list` - List retained validated runtime bundles; use `rollback --bundle-id <id> --reason <text>` for an explicit audited rollback
 - `aidevops gpt56-context [enable|disable|status]` - Keep GPT-5.6 at a 300K advertised context window in OpenCode (enabled by default), so 80% auto-compaction runs near 240K before long-context pricing; disable to use native provider limits
 - `aidevops buzz [status|apply|rollback]` - Inspect or manage Buzz Desktop OpenCode ACP compatibility
+- `~/.aidevops/agents/scripts/team-interface-helper.sh [providers|detect|status|doctor|plan]` - Inspect registered collaboration providers, persist read-only observations, or emit deterministic dry-run plans; no provider-write command is exposed
 - `aidevops secret` - Manage secrets (gopass encrypted, AI-safe)
 - `aidevops source-access` - Manage exact-path, session-bound source-read approvals signed via sudo
 - `aidevops security` - Full security assessment (posture, secrets, supply chain)

--- a/configs/team-interface-config.json.txt
+++ b/configs/team-interface-config.json.txt
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "document_type": "runtime_config",
+  "enabled": false,
+  "documents": {
+    "registry_path": "~/.config/aidevops/team-interface/registry-v1.json",
+    "policy_path": "~/.config/aidevops/team-interface/ownership-policy-v1.json",
+    "app_team_path": "~/.config/aidevops/team-interface/app-team-v1.json"
+  },
+  "adapters": [],
+  "options": {
+    "adapter_timeout_ms": 5000,
+    "max_document_bytes": 1048576,
+    "max_plan_fields": 500,
+    "max_state_observations": 100,
+    "lock_timeout_ms": 4000,
+    "lock_stale_ms": 60000
+  }
+}

--- a/todo/missions/m-20260804-5d06b1/mission.md
+++ b/todo/missions/m-20260804-5d06b1/mission.md
@@ -172,8 +172,8 @@ Milestones are sequential. Features within a milestone may be parallelized only 
 
 | # | Feature | Task ID | Status | Estimate | Worker | PR |
 |---|---------|---------|--------|----------|--------|----|
-| 2.1 | Implement provider registry, config loader, state store, status/doctor commands, and deterministic dry-run planner `[depends:F1.1] [depends:F1.4]` | t18202 | permission-blocked | 6h | vladimirdulov | |
-| 2.2 | Generate the canonical 13 aidevops agents plus the framework guide from discovery metadata, including workload tiers and stable IDs `[depends:F1.3]` | t18203 | permission-blocked | 3.5h | vladimirdulov | |
+| 2.1 | Implement provider registry, config loader, state store, status/doctor commands, and deterministic dry-run planner `[depends:F1.1] [depends:F1.4]` | t18202 | complete | 6h | marcusquinn | #29619 |
+| 2.2 | Generate the canonical 13 aidevops agents plus the framework guide from discovery metadata, including workload tiers and stable IDs `[depends:F1.3]` | t18203 | complete | 3.5h | marcusquinn | #29605 |
 | 2.3 | Implement the read-only Buzz adapter for installation/runtime detection, communities, agents, teams, and capability reporting `[depends:F2.1]` | pending | pending | brief first | | |
 | 2.4 | Refactor the existing Matrix integration behind the same provider/event/authority contract without behavior regression `[depends:F2.1]` | pending | pending | brief first | | |
 | 2.5 | Generate restricted OpenCode launch overlays for canonical agent selection, workload variant, interface context, and read-only conversational permissions `[depends:F2.2]` | pending | pending | brief first | | |
@@ -352,6 +352,8 @@ Feature budgets are intentionally deferred until briefs identify repositories, u
 | 2026-08-05T01:11:33Z | Milestone 2 parent and first leaves allocated | Reserved t18201 as the permanent non-dispatchable Milestone 2 tracker, t18202 for the read-only runtime core, and t18203 for canonical roster generation. Resolved the first config and roster identity boundaries; F2.3-F2.5 remain deliberately unfiled until their direct dependencies merge. |
 | 2026-08-05T01:33:56Z | Milestone 2 parent and first leaves published | Created permanent parent #29541 and worker-ready leaves #29542 and #29543, verified all three immutable repository-scoped mappings, both leaves' required labels and unassigned available state, and the native parent/sub-issue hierarchy. A REST quota failure interrupted #29543 post-create finalisation; the existing mapped issue was recovered without duplication through one bounded GraphQL mutation and independently re-read. F2.3-F2.5 remain deliberately unfiled until their direct dependencies merge. |
 | 2026-08-05T02:01:53Z | Milestone 2 worker hand-offs recorded | Both ready leaves were claimed by vladimirdulov, then moved to `needs-maintainer-permissions` without an implementation PR. Their mission rows now preserve the permission-blocked hand-off rather than presenting the leaves as unclaimed; no implementation failure or completion is inferred. |
+| 2026-08-05T22:10:07Z | Milestone 2 roster completed and runtime core resumed | Verified feature 2.2 merged through PR #29605 and marked it complete, independently unblocking feature 2.5. Maintainer-owned interactive work resumed feature 2.1 / t18202 / issue #29542 after the earlier worker released its permission-blocked claim without a PR or pushed recovery branch. |
+| 2026-08-05T23:32:47Z | Milestone 2 runtime core completed | Implemented feature 2.1 through PR #29619: a disabled-by-default provider registry and config loader, guarded local state store, read-only providers/detect/status/doctor commands, and deterministic non-mutating reconciliation planner. Contract, security, state, CLI, and regression suites passed, unblocking the Buzz and Matrix adapter leaves. |
 
 ## Recovery Log
 


### PR DESCRIPTION
## Summary

Add a provider-neutral read-only team-interface runtime with a trusted static adapter registry, validated local observations, deterministic reconciliation planning, and activation-gated dependencies for mission feature 2.1.

## Files Changed

`.agents/package-lock.json`, `.agents/package.json`, `.agents/reference/team-interface-runtime.md`, `.agents/reference/team-interfaces.md`, `.agents/schemas/team-interface/runtime-v1.schema.json`, `.agents/scripts/setup/modules/agent-deploy.sh`, `.agents/scripts/team-interface-adapter-runtime.mjs`, `.agents/scripts/team-interface-adapter-validation.mjs`, `.agents/scripts/team-interface-adapters.mjs`, `.agents/scripts/team-interface-common.mjs`, `.agents/scripts/team-interface-config.mjs`, `.agents/scripts/team-interface-core.mjs`, `.agents/scripts/team-interface-diagnostics.mjs`, `.agents/scripts/team-interface-helper.sh`, `.agents/scripts/team-interface-lock-owner.mjs`, `.agents/scripts/team-interface-lock.mjs`, `.agents/scripts/team-interface-plan-decisions.mjs`, `.agents/scripts/team-interface-planner.mjs`, `.agents/scripts/team-interface-runtime-commands.mjs`, `.agents/scripts/team-interface-state.mjs`, `.agents/scripts/team-interface-validators.mjs`, `.agents/scripts/tests/fixtures/team-interface/runtime-invalid.json`, `.agents/scripts/tests/fixtures/team-interface/runtime-valid.json`, `.agents/scripts/tests/test-team-interface-runtime-deps.sh`, `.agents/scripts/tests/test-team-interface-runtime.mjs`, `.gitignore`, `README.md`, `configs/team-interface-config.json.txt`, and `todo/missions/m-20260804-5d06b1/mission.md`.

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — all seven team-interface Node suites, the locked dependency activation test, the 46-check deployment staging suite, changed-file repository linters, and Qlty gates passed at final head `1014f6ec2fa071806c5befb3422cbc372c38de5c` (46/49 absolute, 46→46 regression, zero new-file smells).

## Security and design decisions

- Keep the initial adapter registry empty and accept only trusted in-tree adapter definitions.
- Expose no provider mutation, credential-resolution, installation, or publication route.
- Treat generated plans as non-authoritative dry-run artifacts requiring future revalidation before any write.
- Bind observations and plans to registered identities, capabilities, resources, and complete policy evidence.
- Install exact locked Ajv dependencies inside the candidate runtime bundle with lifecycle scripts disabled.
- Do not release or deploy this change without separate publication authorization.

Resolves #29542

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.228 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 4h 26m and 2,902,009 tokens on this with the user in an interactive session.
