### PR TITLE
GH#29616: add sudo-signed temporary source-read approvals

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -12,7 +12,12 @@ import { extractAndStoreIntent, consumeIntent } from "./intent-tracing.mjs";
 import { recordToolStart, consumeToolDuration } from "./timing-tracing.mjs";
 import { qualityLog, runFileQualityGate } from "./quality-logging.mjs";
 import { enrichActiveSpan, detectTaskId, detectSessionOrigin } from "./otel-enrichment.mjs";
-import { checkSecretReadGate, isReadTool } from "./quality-hooks-secret-read.mjs";
+import {
+  checkSecretReadGate,
+  isReadTool,
+  secretReadBlockReason,
+} from "./quality-hooks-secret-read.mjs";
+import { checkSecretReadWithApproval } from "./source-access-approval.mjs";
 import { checkResearchStagingAccess } from "./research-staging-guard.mjs";
 import {
   bindActiveScriptsDir,
@@ -288,6 +293,7 @@ function handleToolBefore(ctx, log, input, output) {
     "aidevops.runtime": "opencode",
   }).catch(() => {});
 
+  const sessionId = input.sessionID || input.sessionId || input.session?.id || "";
   if (isBashTool(input.tool)) {
     const bashArgs = output.args ?? {};
     const bashCwd = bashArgs.workdir || bashArgs.cwd || process.cwd();
@@ -302,7 +308,6 @@ function handleToolBefore(ctx, log, input, output) {
     );
     // t2685: pass scriptsDir + output so the hook can repair (mutate
     // output.args.command) or block (throw) as appropriate.
-    const sessionId = input.sessionID || input.sessionId || input.session?.id || "";
     const signatureModel = ctx.resolveSessionModel(sessionId);
     checkSignatureFooterGate(bashArgs.command || "", log, ctx.scriptsDir, output, {
       model: signatureModel,
@@ -310,7 +315,16 @@ function handleToolBefore(ctx, log, input, output) {
     });
   }
 
-  checkSecretReadGate(input.tool, output.args || {}, log);
+  checkSecretReadWithApproval({
+    tool: input.tool,
+    args: output.args || {},
+    sessionId,
+    scriptsDir: ctx.scriptsDir,
+    isReadTool,
+    secretReadBlockReason,
+    checkSecretReadGate,
+    log,
+  });
   checkResearchStagingAccess(input.tool, output.args || {});
 
   if (!isWriteOrEditTool(input.tool)) return;

--- a/.agents/plugins/opencode-aidevops/source-access-approval.mjs
+++ b/.agents/plugins/opencode-aidevops/source-access-approval.mjs
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, parse, relative, resolve, sep } from "node:path";
+
+export const SOURCE_ACCESS_REASON = "secret-bearing basename";
+const RECEIPT_SCHEMA = "aidevops-source-access-receipt/v1";
+const PAYLOAD_SCHEMA = "aidevops-source-access-approval/v1";
+const SIGNATURE_NAMESPACE = "aidevops-source-access-v1";
+const SIGNER_IDENTITY = "source-access@aidevops.sh";
+const MAX_TTL_SECONDS = 12 * 60 * 60;
+const MAX_SOURCE_BYTES = 10 * 1024 * 1024;
+const DEFAULT_STATE_DIR = "/var/run/aidevops/source-access";
+const DEFAULT_PUBLIC_KEY = "/etc/aidevops/source-access/source-access.pub";
+const ROOT_BROKER = "/etc/aidevops/source-access/source-access-helper.py";
+
+function readPath(args) {
+  return args?.filePath || args?.file_path || "";
+}
+
+function runSourceAccessHelper(scriptsDir, helperArgs, run = execFileSync) {
+  const helperPath = join(scriptsDir, "source-access-helper.sh");
+  return String(
+    run("/bin/bash", [helperPath, ...helperArgs], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 15000,
+    }),
+  ).trim();
+}
+
+function stableValue(value) {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, stableValue(value[key])]),
+    );
+  }
+  return value;
+}
+
+export function canonicalReceiptPayload(payload) {
+  return JSON.stringify(stableValue(payload));
+}
+
+function trustedRegularFile(filePath, trustUid) {
+  try {
+    const metadata = lstatSync(filePath);
+    return (
+      metadata.isFile() &&
+      !metadata.isSymbolicLink() &&
+      metadata.uid === trustUid &&
+      (metadata.mode & 0o022) === 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+function trustedDirectory(directoryPath, trustUid) {
+  try {
+    const metadata = lstatSync(directoryPath);
+    return (
+      metadata.isDirectory() &&
+      !metadata.isSymbolicLink() &&
+      metadata.uid === trustUid &&
+      (metadata.mode & 0o022) === 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+function hasSymlinkComponent(filePath) {
+  const absolute = resolve(filePath);
+  const root = parse(absolute).root;
+  let current = root;
+  for (const part of absolute.slice(root.length).split(sep).filter(Boolean)) {
+    current = join(current, part);
+    try {
+      if (lstatSync(current).isSymbolicLink()) return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+function approvalScopeId(sessionId, uid, filePath, reason) {
+  return createHash("sha256")
+    .update(`${sessionId}\0${uid}\0${filePath}\0${reason}`, "utf8")
+    .digest("hex");
+}
+
+function isGitTrackedFile(filePath, git, run = execFileSync) {
+  try {
+    const gitRoot = realpathSync(
+      String(
+        run(git, ["-C", dirname(filePath), "rev-parse", "--show-toplevel"], {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+          timeout: 15000,
+        }),
+      ).trim(),
+    );
+    const relativePath = relative(gitRoot, filePath);
+    if (!relativePath || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) return false;
+    run(git, ["-C", gitRoot, "ls-files", "--error-unmatch", "--", relativePath], {
+      encoding: "utf8",
+      stdio: ["ignore", "ignore", "ignore"],
+      timeout: 15000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function verificationTempRoot() {
+  return process.env.AIDEVOPS_TEMP_DIR || join(homedir(), ".aidevops", ".agent-workspace", "tmp");
+}
+
+function isManagedSnapshotPath(filePath) {
+  if (!isAbsolute(filePath)) return false;
+  const snapshotRoot = join(DEFAULT_STATE_DIR, "snapshots");
+  try {
+    const canonicalRoot = realpathSync(snapshotRoot);
+    const canonicalPath = realpathSync(filePath);
+    return canonicalPath.startsWith(`${canonicalRoot}${sep}`);
+  } catch {
+    return resolve(filePath).startsWith(`${resolve(snapshotRoot)}${sep}`);
+  }
+}
+
+function sourceDigestMatches(filePath, expectedDigest) {
+  let descriptor = -1;
+  try {
+    descriptor = openSync(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
+    const opened = fstatSync(descriptor);
+    if (!opened.isFile() || opened.nlink !== 1 || opened.size > MAX_SOURCE_BYTES) return false;
+    const content = readFileSync(descriptor);
+    if (content.length > MAX_SOURCE_BYTES) return false;
+    const current = lstatSync(filePath);
+    if (
+      !current.isFile() ||
+      current.isSymbolicLink() ||
+      current.dev !== opened.dev ||
+      current.ino !== opened.ino
+    ) {
+      return false;
+    }
+    return createHash("sha256").update(content).digest("hex") === expectedDigest;
+  } catch {
+    return false;
+  } finally {
+    if (descriptor >= 0) closeSync(descriptor);
+  }
+}
+
+/** Verify a root-owned receipt directly inside the already-loaded plugin. */
+export function verifySourceAccessReceipt({
+  sessionId,
+  filePath,
+  reason,
+  now = Math.floor(Date.now() / 1000),
+  uid = typeof process.getuid === "function" ? process.getuid() : -1,
+  trustUid = 0,
+  stateDir = DEFAULT_STATE_DIR,
+  publicKeyPath = DEFAULT_PUBLIC_KEY,
+  sshKeygen = "/usr/bin/ssh-keygen",
+  git = "/usr/bin/git",
+  gitRun = execFileSync,
+  run = execFileSync,
+}) {
+  let tempDir = "";
+  try {
+    if (!/^[A-Za-z0-9._:-]{6,256}$/.test(sessionId)) return false;
+    if (reason !== SOURCE_ACCESS_REASON || uid < 0 || !isAbsolute(filePath)) return false;
+    if (hasSymlinkComponent(filePath)) return false;
+    const canonicalPath = realpathSync(filePath);
+    if (!statSync(canonicalPath).isFile()) return false;
+    if (!isGitTrackedFile(canonicalPath, git, gitRun)) return false;
+    const approvalId = approvalScopeId(sessionId, uid, canonicalPath, reason);
+    const receiptPath = join(stateDir, "approvals", String(uid), `${approvalId}.json`);
+    if (!trustedDirectory(dirname(receiptPath), trustUid)) return false;
+    if (!trustedDirectory(dirname(publicKeyPath), trustUid)) return false;
+    if (!trustedRegularFile(receiptPath, trustUid)) return false;
+    if (!trustedRegularFile(publicKeyPath, trustUid)) return false;
+
+    const receipt = JSON.parse(readFileSync(receiptPath, "utf8"));
+    const payload = receipt?.payload;
+    if (receipt?.schema !== RECEIPT_SCHEMA || payload?.schema !== PAYLOAD_SCHEMA) return false;
+    if (payload.approval_id !== approvalId) return false;
+    if (payload.session_id !== sessionId || payload.uid !== uid) return false;
+    if (payload.path !== canonicalPath || payload.reason !== reason) return false;
+    if (!/^[a-f0-9]{64}$/.test(payload.content_sha256 || "")) return false;
+    if (!sourceDigestMatches(canonicalPath, payload.content_sha256)) return false;
+    const snapshotPath = join(stateDir, "snapshots", String(uid), `${approvalId}.source`);
+    if (payload.snapshot_path !== snapshotPath) return false;
+    if (!trustedDirectory(dirname(snapshotPath), trustUid)) return false;
+    if (!trustedRegularFile(snapshotPath, trustUid)) return false;
+    if (statSync(snapshotPath).size > MAX_SOURCE_BYTES) return false;
+    const snapshot = readFileSync(snapshotPath);
+    if (createHash("sha256").update(snapshot).digest("hex") !== payload.content_sha256) return false;
+    if (!Number.isInteger(payload.issued_at) || !Number.isInteger(payload.expires_at)) return false;
+    if (now < payload.issued_at || now >= payload.expires_at) return false;
+    if (payload.expires_at - payload.issued_at > MAX_TTL_SECONDS) return false;
+    if (typeof receipt.signature !== "string" || !receipt.signature.includes("SSH SIGNATURE")) {
+      return false;
+    }
+
+    const tempRoot = verificationTempRoot();
+    mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
+    tempDir = mkdtempSync(join(tempRoot, "source-access-verify-"));
+    chmodSync(tempDir, 0o700);
+    const signaturePath = join(tempDir, "payload.sig");
+    const allowedSignersPath = join(tempDir, "allowed_signers");
+    writeFileSync(signaturePath, receipt.signature, { mode: 0o600 });
+    const publicKey = readFileSync(publicKeyPath, "utf8").trim();
+    writeFileSync(
+      allowedSignersPath,
+      `${SIGNER_IDENTITY} namespaces="${SIGNATURE_NAMESPACE}" ${publicKey}\n`,
+      { mode: 0o600 },
+    );
+    run(
+      sshKeygen,
+      [
+        "-Y",
+        "verify",
+        "-f",
+        allowedSignersPath,
+        "-I",
+        SIGNER_IDENTITY,
+        "-n",
+        SIGNATURE_NAMESPACE,
+        "-s",
+        signaturePath,
+      ],
+      {
+        input: canonicalReceiptPayload(payload),
+        encoding: "utf8",
+        stdio: ["pipe", "ignore", "ignore"],
+        timeout: 15000,
+      },
+    );
+    return { approvedPath: snapshotPath };
+  } catch {
+    return false;
+  } finally {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Preserve the existing source-read guard while allowing one exact, signed scope.
+ * Every verifier or request failure falls back to the unchanged guard.
+ */
+export function checkSecretReadWithApproval({
+  tool,
+  args,
+  sessionId,
+  scriptsDir,
+  isReadTool,
+  secretReadBlockReason,
+  checkSecretReadGate,
+  log = () => {},
+  verify = verifySourceAccessReceipt,
+  requestRun = execFileSync,
+}) {
+  const filePath = readPath(args);
+  if (!isReadTool(tool) || !filePath) {
+    checkSecretReadGate(tool, args, log);
+    return;
+  }
+
+  if (isManagedSnapshotPath(filePath)) {
+    throw new Error("[source-access] direct reads of approval snapshots are denied");
+  }
+
+  const reason = secretReadBlockReason(filePath);
+  if (reason !== SOURCE_ACCESS_REASON || !sessionId || !scriptsDir) {
+    checkSecretReadGate(tool, args, log);
+    return;
+  }
+
+  const approval = verify({ sessionId, filePath, reason });
+  if (approval?.approvedPath) {
+    if (Object.hasOwn(args, "filePath")) args.filePath = approval.approvedPath;
+    if (Object.hasOwn(args, "file_path")) args.file_path = approval.approvedPath;
+    log("INFO", `[source-access] verified session-bound read approval for ${filePath}`);
+    return;
+  }
+
+  let requestId = "";
+  try {
+    requestId = runSourceAccessHelper(
+      scriptsDir,
+      ["request", "--session", sessionId, "--path", filePath, "--reason", reason],
+      requestRun,
+    );
+  } catch {
+    // Request generation is advisory; the original guard remains authoritative.
+  }
+
+  try {
+    checkSecretReadGate(tool, args, log);
+  } catch (error) {
+    if (!requestId) throw error;
+    const originalMessage = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `${originalMessage}\n\nTo approve only this tracked source path for this session, run:\n` +
+        `sudo -k /usr/bin/python3 ${ROOT_BROKER} approve ${requestId} --ttl 12h`,
+    );
+  }
+}

--- a/.agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import {
+  SOURCE_ACCESS_REASON,
+  canonicalReceiptPayload,
+  checkSecretReadWithApproval,
+  verifySourceAccessReceipt,
+} from "../source-access-approval.mjs";
+
+const BASE = {
+  tool: "read",
+  args: { filePath: "/repo/secret-helper.sh" },
+  sessionId: "ses_fixture_123456",
+  callId: "call_fixture_123456",
+  scriptsDir: "/framework/scripts",
+  isReadTool: (tool) => tool.toLowerCase() === "read",
+  secretReadBlockReason: () => SOURCE_ACCESS_REASON,
+  checkSecretReadGate: () => {
+    throw new Error("[secret-read-guard] blocked read: secret-bearing basename");
+  },
+};
+
+test("a valid verifier result bypasses only the exact basename reason", () => {
+  let gateCalls = 0;
+  const args = { ...BASE.args };
+  assert.doesNotThrow(() =>
+    checkSecretReadWithApproval({
+      ...BASE,
+      args,
+      checkSecretReadGate: () => {
+        gateCalls += 1;
+      },
+      verify: ({ sessionId, filePath, reason }) =>
+        sessionId === BASE.sessionId &&
+        filePath === BASE.args.filePath &&
+        reason === SOURCE_ACCESS_REASON
+          ? {
+              approvedPath: "/tmp/approved-source",
+            }
+          : false,
+      requestRun: () => {
+        throw new Error("request helper must not run");
+      },
+    }),
+  );
+  assert.equal(gateCalls, 0);
+  assert.equal(args.filePath, "/tmp/approved-source");
+});
+
+test("an unapproved scope creates a request and preserves the original block", () => {
+  const calls = [];
+  assert.throws(
+    () =>
+      checkSecretReadWithApproval({
+        ...BASE,
+        verify: () => false,
+        requestRun: (_command, args) => {
+          calls.push(args);
+          return "0123456789abcdef0123456789abcdef\n";
+        },
+      }),
+    /sudo -k \/usr\/bin\/python3 \/etc\/aidevops\/source-access\/source-access-helper.py approve 0123456789abcdef0123456789abcdef --ttl 12h/,
+  );
+  assert.deepEqual(calls.map((args) => args[1]), ["request"]);
+});
+
+test("hard-denial reasons never invoke the approval helper", () => {
+  let helperCalls = 0;
+  assert.throws(
+    () =>
+      checkSecretReadWithApproval({
+        ...BASE,
+        secretReadBlockReason: () => "private key path",
+        verify: () => {
+          helperCalls += 1;
+          return true;
+        },
+        requestRun: () => {
+          helperCalls += 1;
+          return "";
+        },
+      }),
+    /secret-read-guard/,
+  );
+  assert.equal(helperCalls, 0);
+});
+
+test("missing session identity preserves the original block without a request", () => {
+  let helperCalls = 0;
+  assert.throws(
+    () =>
+      checkSecretReadWithApproval({
+        ...BASE,
+        sessionId: "",
+        verify: () => {
+          helperCalls += 1;
+          return true;
+        },
+        requestRun: () => {
+          helperCalls += 1;
+          return "";
+        },
+      }),
+    /secret-read-guard/,
+  );
+  assert.equal(helperCalls, 0);
+});
+
+test("non-read tools retain the existing guard path", () => {
+  let gateCalls = 0;
+  checkSecretReadWithApproval({
+    ...BASE,
+    tool: "grep",
+    checkSecretReadGate: () => {
+      gateCalls += 1;
+    },
+    verify: () => {
+      throw new Error("verifier must not run");
+    },
+    requestRun: () => {
+      throw new Error("helper must not run");
+    },
+  });
+  assert.equal(gateCalls, 1);
+});
+
+test("direct reads of root-managed snapshots are denied", () => {
+  assert.throws(
+    () =>
+      checkSecretReadWithApproval({
+        ...BASE,
+        args: { filePath: "/var/run/aidevops/source-access/snapshots/501/example.source" },
+        verify: () => {
+          throw new Error("verifier must not run");
+        },
+        requestRun: () => {
+          throw new Error("request helper must not run");
+        },
+      }),
+    /direct reads of approval snapshots are denied/,
+  );
+});
+
+test("the loaded verifier accepts only the exact signed receipt", () => {
+  const tempParent = join(homedir(), ".aidevops", ".agent-workspace", "tmp");
+  mkdirSync(tempParent, { recursive: true });
+  const root = mkdtempSync(join(tempParent, "source-access-node-test-"));
+  const repo = join(root, "repo");
+  const source = join(repo, "secret-helper.sh");
+  const key = join(root, "source-access-key");
+  const stateDir = join(root, "state");
+  const uid = typeof process.getuid === "function" ? process.getuid() : 0;
+  const sessionId = "ses_fixture_123456";
+  const now = 1_800_000_000;
+
+  try {
+    mkdirSync(repo);
+    execFileSync("git", ["-C", repo, "init", "--quiet"]);
+    writeFileSync(source, "#!/usr/bin/env bash\nprintf synthetic\\n\n");
+    execFileSync("git", ["-C", repo, "add", "secret-helper.sh"]);
+    execFileSync("/usr/bin/ssh-keygen", [
+      "-q",
+      "-t",
+      "ed25519",
+      "-N",
+      "",
+      "-C",
+      "source-access@aidevops.sh",
+      "-f",
+      key,
+    ]);
+
+    const approvalId = createHash("sha256")
+      .update(`${sessionId}\0${uid}\0${source}\0${SOURCE_ACCESS_REASON}`, "utf8")
+      .digest("hex");
+    const payload = {
+      schema: "aidevops-source-access-approval/v1",
+      approval_id: approvalId,
+      request_id: "0123456789abcdef0123456789abcdef",
+      session_id: sessionId,
+      uid,
+      path: source,
+      reason: SOURCE_ACCESS_REASON,
+      content_sha256: createHash("sha256").update(readFileSync(source)).digest("hex"),
+      snapshot_path: join(stateDir, "snapshots", String(uid), `${approvalId}.source`),
+      issued_at: now,
+      expires_at: now + 3600,
+    };
+    const payloadPath = join(root, "payload.json");
+    writeFileSync(payloadPath, canonicalReceiptPayload(payload));
+    execFileSync("/usr/bin/ssh-keygen", [
+      "-Y",
+      "sign",
+      "-f",
+      key,
+      "-n",
+      "aidevops-source-access-v1",
+      payloadPath,
+    ]);
+    const signature = readFileSync(`${payloadPath}.sig`, "utf8");
+    const receiptDir = join(stateDir, "approvals", String(uid));
+    const snapshotDir = join(stateDir, "snapshots", String(uid));
+    mkdirSync(receiptDir, { recursive: true });
+    mkdirSync(snapshotDir, { recursive: true });
+    writeFileSync(payload.snapshot_path, readFileSync(source), { mode: 0o444 });
+    writeFileSync(
+      join(receiptDir, `${approvalId}.json`),
+      JSON.stringify({
+        schema: "aidevops-source-access-receipt/v1",
+        payload,
+        signature,
+      }),
+      { mode: 0o644 },
+    );
+
+    const verifierArgs = {
+      sessionId,
+      filePath: source,
+      reason: SOURCE_ACCESS_REASON,
+      now: now + 1,
+      uid,
+      trustUid: uid,
+      stateDir,
+      publicKeyPath: `${key}.pub`,
+    };
+    const approval = verifySourceAccessReceipt(verifierArgs);
+    assert.ok(approval);
+    assert.equal(readFileSync(approval.approvedPath, "utf8"), "#!/usr/bin/env bash\nprintf synthetic\\n\n");
+    assert.equal(
+      verifySourceAccessReceipt({ ...verifierArgs, sessionId: "ses_other_123456" }),
+      false,
+    );
+    assert.equal(verifySourceAccessReceipt({ ...verifierArgs, now: now + 3600 }), false);
+    writeFileSync(source, "changed\n");
+    assert.equal(verifySourceAccessReceipt(verifierArgs), false);
+    writeFileSync(source, "#!/usr/bin/env bash\nprintf synthetic\\n\n");
+    execFileSync("git", ["-C", repo, "rm", "--cached", "--quiet", "secret-helper.sh"]);
+    assert.equal(verifySourceAccessReceipt(verifierArgs), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/.agents/scripts/source-access-helper.py
+++ b/.agents/scripts/source-access-helper.py
@@ -1,0 +1,769 @@
+#!/usr/bin/env python3
+"""Human-approved, session-bound exceptions for low-confidence source-read blocks."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pwd
+import re
+import secrets
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+SCHEMA_REQUEST = "aidevops-source-access-request/v1"
+SCHEMA_RECEIPT = "aidevops-source-access-receipt/v1"
+SCHEMA_PAYLOAD = "aidevops-source-access-approval/v1"
+SIGNATURE_NAMESPACE = "aidevops-source-access-v1"
+SIGNER_IDENTITY = "source-access@aidevops.sh"
+OVERRIDABLE_REASON = "secret-bearing basename"
+MAX_TTL_SECONDS = 12 * 60 * 60
+REQUEST_REUSE_SECONDS = 60 * 60
+MAX_SOURCE_BYTES = 10 * 1024 * 1024
+ID_PATTERN = re.compile(r"^[a-f0-9]{32,64}$")
+SESSION_PATTERN = re.compile(r"^[A-Za-z0-9._:-]{6,256}$")
+ALLOWED_SUFFIXES = {
+    ".c",
+    ".cjs",
+    ".cpp",
+    ".go",
+    ".h",
+    ".hpp",
+    ".java",
+    ".js",
+    ".json",
+    ".jsx",
+    ".kt",
+    ".md",
+    ".mjs",
+    ".php",
+    ".py",
+    ".rb",
+    ".rs",
+    ".sh",
+    ".swift",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".yaml",
+    ".yml",
+}
+DENIED_NAMES = {
+    ".netrc",
+    ".npmrc",
+    ".pypirc",
+    "auth.json",
+    "credentials",
+    "credentials.json",
+    "id_dsa",
+    "id_ecdsa",
+    "id_ed25519",
+    "id_rsa",
+    "kubeconfig",
+}
+DENIED_SUFFIXES = {".jks", ".key", ".keystore", ".p12", ".pem", ".pfx"}
+GIT = "/usr/bin/git"
+SSH_KEYGEN = "/usr/bin/ssh-keygen"
+
+
+class SourceAccessError(RuntimeError):
+    """Typed user-facing failure without source content."""
+
+
+@dataclass(frozen=True)
+class Config:
+    config_dir: Path = Path("/etc/aidevops/source-access")
+    state_dir: Path = Path("/var/run/aidevops/source-access")
+    request_root: Path | None = None
+    signing_key: Path | None = None
+    trust_uid: int = 0
+
+    @property
+    def private_key(self) -> Path:
+        if self.signing_key is not None:
+            return self.signing_key
+        return self.config_dir / "private" / "source-access.key"
+
+    @property
+    def public_key(self) -> Path:
+        return self.config_dir / "source-access.pub"
+
+
+def canonical_json(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _run(command: list[str], *, input_bytes: bytes | None = None) -> subprocess.CompletedProcess[bytes]:
+    try:
+        return subprocess.run(
+            command,
+            input=input_bytes,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise SourceAccessError(f"required command failed: {command[0]}") from exc
+
+
+def _ensure_directory(path: Path, mode: int, owner_uid: int | None = None) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    os.chmod(path, mode)
+    if owner_uid is not None and os.geteuid() == 0:
+        os.chown(path, owner_uid, 0)
+
+
+def atomic_write(
+    path: Path,
+    content: bytes,
+    mode: int,
+    owner_uid: int | None = None,
+    directory_mode: int | None = None,
+) -> None:
+    parent_mode = directory_mode if directory_mode is not None else (0o755 if mode == 0o644 else 0o700)
+    _ensure_directory(path.parent, parent_mode, owner_uid)
+    descriptor, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+            os.fchmod(handle.fileno(), mode)
+            if owner_uid is not None and os.geteuid() == 0:
+                os.fchown(handle.fileno(), owner_uid, 0)
+        os.replace(temp_name, path)
+    finally:
+        try:
+            os.unlink(temp_name)
+        except FileNotFoundError:
+            pass
+
+
+def _validate_session_id(session_id: str) -> str:
+    if not SESSION_PATTERN.fullmatch(session_id):
+        raise SourceAccessError("invalid runtime session identifier")
+    return session_id
+
+
+def _validate_reason(reason: str) -> str:
+    if reason != OVERRIDABLE_REASON:
+        raise SourceAccessError("only the basename-only source guard can be approved")
+    return reason
+
+
+def _has_symlink_component(path: Path) -> bool:
+    current = Path(path.anchor)
+    for part in path.parts[1:]:
+        current /= part
+        try:
+            if stat.S_ISLNK(os.lstat(current).st_mode):
+                return True
+        except FileNotFoundError:
+            return False
+    return False
+
+
+def canonical_tracked_source(raw_path: str) -> str:
+    if not raw_path or any(ord(character) < 32 for character in raw_path):
+        raise SourceAccessError("source path is empty or contains control characters")
+    absolute = Path(os.path.abspath(os.path.expanduser(raw_path)))
+    if _has_symlink_component(absolute):
+        raise SourceAccessError("symlinked source paths cannot be approved")
+    try:
+        resolved = absolute.resolve(strict=True)
+        file_stat = resolved.stat()
+    except OSError as exc:
+        raise SourceAccessError("source path is unavailable") from exc
+    if not stat.S_ISREG(file_stat.st_mode):
+        raise SourceAccessError("source path is not a regular file")
+
+    basename = resolved.name.lower()
+    if basename.startswith(".env") or basename in DENIED_NAMES:
+        raise SourceAccessError("credential-like source paths cannot be approved")
+    if resolved.suffix.lower() in DENIED_SUFFIXES:
+        raise SourceAccessError("private key and credential containers cannot be approved")
+    if resolved.suffix.lower() not in ALLOWED_SUFFIXES:
+        raise SourceAccessError("path is not an approved source or documentation type")
+
+    root_result = _run([GIT, "-C", str(resolved.parent), "rev-parse", "--show-toplevel"])
+    if root_result.returncode != 0:
+        raise SourceAccessError("source path is not inside a Git worktree")
+    git_root = Path(root_result.stdout.decode("utf-8").strip()).resolve()
+    try:
+        relative_path = resolved.relative_to(git_root)
+    except ValueError as exc:
+        raise SourceAccessError("source path escapes its Git worktree") from exc
+    tracked_result = _run(
+        [GIT, "-C", str(git_root), "ls-files", "--error-unmatch", "--", str(relative_path)]
+    )
+    if tracked_result.returncode != 0:
+        raise SourceAccessError("only Git-tracked source files can be approved")
+    return str(resolved)
+
+
+def scope_id(session_id: str, uid: int, path: str, reason: str) -> str:
+    scope = f"{session_id}\0{uid}\0{path}\0{reason}".encode("utf-8")
+    return hashlib.sha256(scope).hexdigest()
+
+
+def secure_source_content(path: str) -> tuple[bytes, str]:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise SourceAccessError("source path could not be opened safely") from exc
+    digest = hashlib.sha256()
+    content = bytearray()
+    total = 0
+    try:
+        opened_stat = os.fstat(descriptor)
+        if not stat.S_ISREG(opened_stat.st_mode) or opened_stat.st_nlink != 1:
+            raise SourceAccessError("hard-linked or non-regular source files cannot be approved")
+        if opened_stat.st_size > MAX_SOURCE_BYTES:
+            raise SourceAccessError("source file exceeds the approval size limit")
+        while chunk := os.read(descriptor, 64 * 1024):
+            total += len(chunk)
+            if total > MAX_SOURCE_BYTES:
+                raise SourceAccessError("source file exceeds the approval size limit")
+            content.extend(chunk)
+            digest.update(chunk)
+        current_stat = os.lstat(path)
+        if (
+            not stat.S_ISREG(current_stat.st_mode)
+            or current_stat.st_dev != opened_stat.st_dev
+            or current_stat.st_ino != opened_stat.st_ino
+        ):
+            raise SourceAccessError("source path changed during approval")
+    except OSError as exc:
+        raise SourceAccessError("source path changed during approval") from exc
+    finally:
+        os.close(descriptor)
+    return bytes(content), digest.hexdigest()
+
+
+def request_directory(config: Config, home: Path) -> Path:
+    if config.request_root is not None:
+        return config.request_root
+    return home / ".aidevops" / ".agent-workspace" / "source-access" / "requests"
+
+
+def create_request(
+    config: Config,
+    *,
+    session_id: str,
+    uid: int,
+    home: Path,
+    path: str,
+    reason: str,
+    now: int | None = None,
+) -> str:
+    issued_at = int(time.time() if now is None else now)
+    session_id = _validate_session_id(session_id)
+    reason = _validate_reason(reason)
+    path = canonical_tracked_source(path)
+    directory = request_directory(config, home)
+    _ensure_directory(directory, 0o700)
+
+    for candidate in directory.glob("*.json"):
+        try:
+            existing = json.loads(candidate.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        created_at = existing.get("created_at")
+        if isinstance(created_at, bool) or not isinstance(created_at, int):
+            continue
+        if (
+            existing.get("schema") == SCHEMA_REQUEST
+            and existing.get("session_id") == session_id
+            and existing.get("uid") == uid
+            and existing.get("path") == path
+            and existing.get("reason") == reason
+            and 0 <= issued_at - created_at <= REQUEST_REUSE_SECONDS
+        ):
+            request_id = str(existing.get("request_id", ""))
+            if ID_PATTERN.fullmatch(request_id):
+                return request_id
+
+    request_id = secrets.token_hex(16)
+    request = {
+        "schema": SCHEMA_REQUEST,
+        "request_id": request_id,
+        "session_id": session_id,
+        "uid": uid,
+        "path": path,
+        "reason": reason,
+        "created_at": issued_at,
+    }
+    atomic_write(directory / f"{request_id}.json", canonical_json(request) + b"\n", 0o600)
+    return request_id
+
+
+def parse_ttl(value: str) -> int:
+    match = re.fullmatch(r"([1-9][0-9]*)([mh])", value)
+    if not match:
+        raise SourceAccessError("TTL must use minutes or hours, for example 30m or 12h")
+    amount = int(match.group(1))
+    seconds = amount * (60 if match.group(2) == "m" else 3600)
+    if seconds < 60 or seconds > MAX_TTL_SECONDS:
+        raise SourceAccessError("TTL must be between 1 minute and 12 hours")
+    return seconds
+
+
+def setup_key_material(config: Config) -> None:
+    if not _trusted_directory(config.private_key.parent, config.trust_uid):
+        raise SourceAccessError("existing approval key directory ownership or permissions are unsafe")
+    if not _trusted_private_key(config.private_key, config.trust_uid):
+        raise SourceAccessError(
+            "existing root-owned aidevops approval key is unavailable"
+        )
+    _ensure_directory(config.config_dir, 0o755, config.trust_uid)
+    result = _run(
+        [
+            SSH_KEYGEN,
+            "-y",
+            "-f",
+            str(config.private_key),
+        ]
+    )
+    if result.returncode != 0:
+        raise SourceAccessError("failed to derive the source-access verification key")
+    atomic_write(config.public_key, result.stdout.strip() + b"\n", 0o644, config.trust_uid)
+
+
+def _load_request(
+    config: Config, home: Path, request_id: str, expected_uid: int
+) -> dict[str, Any]:
+    if not ID_PATTERN.fullmatch(request_id):
+        raise SourceAccessError("invalid request identifier")
+    request_path = request_directory(config, home) / f"{request_id}.json"
+    if not _trusted_directory(request_path.parent, expected_uid) or not _trusted_file(
+        request_path, expected_uid
+    ):
+        raise SourceAccessError("source-access request ownership or permissions are unsafe")
+    try:
+        request = json.loads(request_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SourceAccessError("source-access request was not found or is malformed") from exc
+    if request.get("schema") != SCHEMA_REQUEST or request.get("request_id") != request_id:
+        raise SourceAccessError("source-access request schema or identifier is invalid")
+    return request
+
+
+def _sign_payload(config: Config, payload: dict[str, Any]) -> str:
+    if not _trusted_directory(config.private_key.parent, config.trust_uid) or not _trusted_private_key(
+        config.private_key, config.trust_uid
+    ):
+        raise SourceAccessError("source-access private key ownership or permissions are unsafe")
+    with tempfile.TemporaryDirectory(prefix="aidevops-source-access-sign-") as temp_dir:
+        payload_path = Path(temp_dir) / "payload.json"
+        payload_path.write_bytes(canonical_json(payload))
+        result = _run(
+            [
+                SSH_KEYGEN,
+                "-Y",
+                "sign",
+                "-f",
+                str(config.private_key),
+                "-n",
+                SIGNATURE_NAMESPACE,
+                str(payload_path),
+            ]
+        )
+        signature_path = Path(f"{payload_path}.sig")
+        if result.returncode != 0 or not signature_path.is_file():
+            raise SourceAccessError("failed to sign source-access approval")
+        return signature_path.read_text(encoding="utf-8")
+
+
+def approve_request(
+    config: Config,
+    *,
+    request_id: str,
+    home: Path,
+    expected_uid: int,
+    ttl_seconds: int,
+    now: int | None = None,
+    confirm: Callable[[dict[str, Any]], bool] | None = None,
+) -> dict[str, Any]:
+    issued_at = int(time.time() if now is None else now)
+    request = _load_request(config, home, request_id, expected_uid)
+    if request.get("uid") != expected_uid:
+        raise SourceAccessError("request user does not match the invoking sudo user")
+    session_id = _validate_session_id(str(request.get("session_id", "")))
+    reason = _validate_reason(str(request.get("reason", "")))
+    path = canonical_tracked_source(str(request.get("path", "")))
+    content, content_sha256 = secure_source_content(path)
+    if not config.private_key.exists() or not config.public_key.exists():
+        raise SourceAccessError("run the installed root-owned source-access broker setup first")
+    created_at = request.get("created_at")
+    if isinstance(created_at, bool) or not isinstance(created_at, int):
+        raise SourceAccessError("source-access request timestamp is invalid")
+    request_age = issued_at - created_at
+    if request_age < 0 or request_age > REQUEST_REUSE_SECONDS:
+        raise SourceAccessError("source-access request has expired; retry the blocked read")
+    confirmation_scope = {**request, "ttl_seconds": ttl_seconds}
+    if confirm is not None and not confirm(confirmation_scope):
+        raise SourceAccessError("source-access approval cancelled")
+
+    approval_id = scope_id(session_id, expected_uid, path, reason)
+    snapshot_path = (
+        config.state_dir / "snapshots" / str(expected_uid) / f"{approval_id}.source"
+    )
+    payload = {
+        "schema": SCHEMA_PAYLOAD,
+        "approval_id": approval_id,
+        "request_id": request_id,
+        "session_id": session_id,
+        "uid": expected_uid,
+        "path": path,
+        "reason": reason,
+        "content_sha256": content_sha256,
+        "snapshot_path": str(snapshot_path),
+        "issued_at": issued_at,
+        "expires_at": issued_at + ttl_seconds,
+    }
+    receipt = {
+        "schema": SCHEMA_RECEIPT,
+        "payload": payload,
+        "signature": _sign_payload(config, payload),
+    }
+    atomic_write(snapshot_path, content, 0o444, config.trust_uid, directory_mode=0o755)
+    receipt_path = config.state_dir / "approvals" / str(expected_uid) / f"{approval_id}.json"
+    atomic_write(receipt_path, canonical_json(receipt) + b"\n", 0o644, config.trust_uid)
+    try:
+        (request_directory(config, home) / f"{request_id}.json").unlink()
+    except FileNotFoundError:
+        pass
+    return payload
+
+
+def _trusted_file(path: Path, owner_uid: int) -> bool:
+    try:
+        file_stat = path.lstat()
+    except OSError:
+        return False
+    return (
+        stat.S_ISREG(file_stat.st_mode)
+        and not stat.S_ISLNK(file_stat.st_mode)
+        and file_stat.st_uid == owner_uid
+        and file_stat.st_mode & 0o022 == 0
+    )
+
+
+def _trusted_private_key(path: Path, owner_uid: int) -> bool:
+    try:
+        file_stat = path.lstat()
+    except OSError:
+        return False
+    return (
+        stat.S_ISREG(file_stat.st_mode)
+        and not stat.S_ISLNK(file_stat.st_mode)
+        and file_stat.st_uid == owner_uid
+        and file_stat.st_mode & 0o077 == 0
+    )
+
+
+def _trusted_directory(path: Path, owner_uid: int) -> bool:
+    try:
+        directory_stat = path.lstat()
+    except OSError:
+        return False
+    return (
+        stat.S_ISDIR(directory_stat.st_mode)
+        and not stat.S_ISLNK(directory_stat.st_mode)
+        and directory_stat.st_uid == owner_uid
+        and directory_stat.st_mode & 0o022 == 0
+    )
+
+
+def _verify_signature(config: Config, payload: dict[str, Any], signature: str) -> bool:
+    if not _trusted_directory(config.public_key.parent, config.trust_uid):
+        return False
+    if not _trusted_file(config.public_key, config.trust_uid):
+        return False
+    with tempfile.TemporaryDirectory(prefix="aidevops-source-access-verify-") as temp_dir:
+        temp = Path(temp_dir)
+        payload_path = temp / "payload.json"
+        signature_path = temp / "payload.sig"
+        allowed_path = temp / "allowed_signers"
+        payload_path.write_bytes(canonical_json(payload))
+        signature_path.write_text(signature, encoding="utf-8")
+        public_key = config.public_key.read_text(encoding="utf-8").strip()
+        allowed_path.write_text(
+            f'{SIGNER_IDENTITY} namespaces="{SIGNATURE_NAMESPACE}" {public_key}\n',
+            encoding="utf-8",
+        )
+        result = _run(
+            [
+                SSH_KEYGEN,
+                "-Y",
+                "verify",
+                "-f",
+                str(allowed_path),
+                "-I",
+                SIGNER_IDENTITY,
+                "-n",
+                SIGNATURE_NAMESPACE,
+                "-s",
+                str(signature_path),
+            ],
+            input_bytes=canonical_json(payload),
+        )
+        return result.returncode == 0
+
+
+def verify_approval(
+    config: Config,
+    *,
+    session_id: str,
+    uid: int,
+    path: str,
+    reason: str,
+    now: int | None = None,
+) -> bool:
+    try:
+        checked_at = int(time.time() if now is None else now)
+        session_id = _validate_session_id(session_id)
+        reason = _validate_reason(reason)
+        path = canonical_tracked_source(path)
+        approval_id = scope_id(session_id, uid, path, reason)
+        receipt_path = config.state_dir / "approvals" / str(uid) / f"{approval_id}.json"
+        if not _trusted_directory(receipt_path.parent, config.trust_uid):
+            return False
+        if not _trusted_file(receipt_path, config.trust_uid):
+            return False
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        payload = receipt.get("payload")
+        if receipt.get("schema") != SCHEMA_RECEIPT or not isinstance(payload, dict):
+            return False
+        expected = {
+            "approval_id": approval_id,
+            "session_id": session_id,
+            "uid": uid,
+            "path": path,
+            "reason": reason,
+        }
+        if any(payload.get(key) != value for key, value in expected.items()):
+            return False
+        if payload.get("schema") != SCHEMA_PAYLOAD:
+            return False
+        content_sha256 = payload.get("content_sha256")
+        if not isinstance(content_sha256, str) or not re.fullmatch(r"[a-f0-9]{64}", content_sha256):
+            return False
+        _, current_sha256 = secure_source_content(path)
+        if current_sha256 != content_sha256:
+            return False
+        expected_snapshot = config.state_dir / "snapshots" / str(uid) / f"{approval_id}.source"
+        if payload.get("snapshot_path") != str(expected_snapshot):
+            return False
+        if not _trusted_directory(expected_snapshot.parent, config.trust_uid):
+            return False
+        if not _trusted_file(expected_snapshot, config.trust_uid):
+            return False
+        if hashlib.sha256(expected_snapshot.read_bytes()).hexdigest() != content_sha256:
+            return False
+        if checked_at < int(payload.get("issued_at", 0)):
+            return False
+        if checked_at >= int(payload.get("expires_at", 0)):
+            return False
+        if int(payload["expires_at"]) - int(payload["issued_at"]) > MAX_TTL_SECONDS:
+            return False
+        signature = receipt.get("signature")
+        return isinstance(signature, str) and _verify_signature(config, payload, signature)
+    except (OSError, ValueError, TypeError, json.JSONDecodeError, SourceAccessError):
+        return False
+
+
+def revoke_approval(config: Config, *, approval_id: str, uid: int) -> None:
+    if not ID_PATTERN.fullmatch(approval_id):
+        raise SourceAccessError("invalid approval identifier")
+    receipt_path = config.state_dir / "approvals" / str(uid) / f"{approval_id}.json"
+    try:
+        receipt_path.unlink()
+    except FileNotFoundError as exc:
+        raise SourceAccessError("source-access approval was not found") from exc
+    snapshot_path = config.state_dir / "snapshots" / str(uid) / f"{approval_id}.source"
+    try:
+        snapshot_path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def list_approvals(config: Config, *, uid: int, now: int | None = None) -> list[dict[str, Any]]:
+    checked_at = int(time.time() if now is None else now)
+    results: list[dict[str, Any]] = []
+    directory = config.state_dir / "approvals" / str(uid)
+    if not directory.is_dir():
+        return results
+    for receipt_path in sorted(directory.glob("*.json")):
+        try:
+            receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+            payload = receipt["payload"]
+            results.append(
+                {
+                    "approval_id": payload["approval_id"],
+                    "session_id": payload["session_id"],
+                    "path": payload["path"],
+                    "expires_at": payload["expires_at"],
+                    "status": "active" if checked_at < int(payload["expires_at"]) else "expired",
+                }
+            )
+        except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+            continue
+    return results
+
+
+def _real_user() -> tuple[int, Path]:
+    sudo_user = os.environ.get("SUDO_USER", "")
+    if os.geteuid() == 0 and sudo_user:
+        account = pwd.getpwnam(sudo_user)
+        return account.pw_uid, Path(account.pw_dir)
+    return os.getuid(), Path.home()
+
+
+def _trusted_root_broker(config: Config) -> bool:
+    try:
+        actual = Path(__file__).resolve(strict=True)
+        expected = (config.config_dir / "source-access-helper.py").resolve(strict=True)
+        if actual != expected:
+            return False
+        current = actual
+        while True:
+            metadata = current.lstat()
+            if metadata.st_uid != config.trust_uid or metadata.st_mode & 0o022:
+                return False
+            if current == Path(current.anchor):
+                break
+            current = current.parent
+        return _trusted_file(actual, config.trust_uid)
+    except OSError:
+        return False
+
+
+def _require_root_tty(config: Config) -> None:
+    if os.geteuid() != 0:
+        raise SourceAccessError("privileged commands must use the installed root-owned source-access broker")
+    if not sys.stdin.isatty():
+        raise SourceAccessError("this command requires an interactive terminal")
+    if not _trusted_root_broker(config):
+        raise SourceAccessError("refusing privileged execution outside the root-owned source-access broker")
+
+
+def _confirm_setup() -> bool:
+    print("Reuse the root-owned aidevops approval key for source-access signatures.")
+    return input("Type SETUP SOURCE ACCESS to confirm: ") == "SETUP SOURCE ACCESS"
+
+
+def _confirm_request(request: dict[str, Any]) -> bool:
+    print("Approve temporary source-code read access:")
+    print(f"  Session: {request['session_id']}")
+    print(f"  Path:    {request['path']}")
+    print(f"  Reason:  {request['reason']}")
+    print(f"  TTL:     {request['ttl_seconds'] // 60} minutes")
+    return input("Type APPROVE SOURCE ACCESS to confirm: ") == "APPROVE SOURCE ACCESS"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="aidevops source-access")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("setup")
+    request = subparsers.add_parser("request")
+    request.add_argument("--session", required=True)
+    request.add_argument("--path", required=True)
+    request.add_argument("--reason", required=True)
+    approve = subparsers.add_parser("approve")
+    approve.add_argument("request_id")
+    approve.add_argument("--ttl", default="12h")
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("--session", required=True)
+    verify.add_argument("--path", required=True)
+    verify.add_argument("--reason", required=True)
+    verify.add_argument("--quiet", action="store_true")
+    revoke = subparsers.add_parser("revoke")
+    revoke.add_argument("approval_id")
+    subparsers.add_parser("status")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    uid, home = _real_user()
+    config = Config(signing_key=home / ".aidevops" / "approval-keys" / "private" / "approval.key")
+    try:
+        if args.command == "setup":
+            _require_root_tty(config)
+            if not _confirm_setup():
+                raise SourceAccessError("source-access setup cancelled")
+            setup_key_material(config)
+            print("Source-access trust is configured with the existing approval key.")
+            return 0
+        if args.command == "request":
+            request_id = create_request(
+                config,
+                session_id=args.session,
+                uid=uid,
+                home=home,
+                path=args.path,
+                reason=args.reason,
+            )
+            print(request_id)
+            return 0
+        if args.command == "approve":
+            _require_root_tty(config)
+            payload = approve_request(
+                config,
+                request_id=args.request_id,
+                home=home,
+                expected_uid=uid,
+                ttl_seconds=parse_ttl(args.ttl),
+                confirm=_confirm_request,
+            )
+            print(f"Approved: {payload['approval_id']}")
+            print(f"Expires epoch: {payload['expires_at']}")
+            return 0
+        if args.command == "verify":
+            valid = verify_approval(
+                config,
+                session_id=args.session,
+                uid=uid,
+                path=args.path,
+                reason=args.reason,
+            )
+            if valid and not args.quiet:
+                print("VERIFIED")
+            return 0 if valid else 1
+        if args.command == "revoke":
+            _require_root_tty(config)
+            revoke_approval(config, approval_id=args.approval_id, uid=uid)
+            print(f"Revoked: {args.approval_id}")
+            return 0
+        if args.command == "status":
+            approvals = list_approvals(config, uid=uid)
+            if not approvals:
+                print("No source-access approvals.")
+                return 0
+            for approval in approvals:
+                print(
+                    f"{approval['approval_id']}\t{approval['status']}\t"
+                    f"{approval['expires_at']}\t{approval['session_id']}\t{approval['path']}"
+                )
+            return 0
+    except SourceAccessError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 1
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/source-access-helper.sh
+++ b/.agents/scripts/source-access-helper.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+if [[ "$EUID" -eq 0 ]]; then
+	printf '%s\n' \
+		'[ERROR] Refusing to execute the user-managed source-access helper as root.' \
+		'Use the installed root-owned broker under /etc/aidevops/source-access.' >&2
+	exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "${SCRIPT_DIR}/source-access-helper.py" "$@"

--- a/.agents/scripts/tests/test-source-access-helper.py
+++ b/.agents/scripts/tests/test-source-access-helper.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+HELPER_PATH = Path(__file__).resolve().parents[1] / "source-access-helper.py"
+SPEC = importlib.util.spec_from_file_location("source_access_helper", HELPER_PATH)
+assert SPEC and SPEC.loader
+HELPER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = HELPER
+SPEC.loader.exec_module(HELPER)
+
+
+class SourceAccessHelperTests(unittest.TestCase):
+    def setUp(self) -> None:
+        temp_parent = Path(
+            os.environ.get(
+                "AIDEVOPS_TEMP_DIR",
+                Path.home() / ".aidevops" / ".agent-workspace" / "tmp",
+            )
+        )
+        temp_parent.mkdir(parents=True, exist_ok=True)
+        self.temp = tempfile.TemporaryDirectory(
+            prefix="aidevops-source-access-test-",
+            dir=temp_parent,
+        )
+        self.root = Path(self.temp.name)
+        self.repo = self.root / "repo"
+        self.repo.mkdir()
+        subprocess.run(["git", "-C", str(self.repo), "init", "--quiet"], check=True)
+        self.source = self.repo / "secret-helper.sh"
+        self.other_source = self.repo / "secret-other.sh"
+        self.source.write_text("#!/usr/bin/env bash\nprintf synthetic\\n\n", encoding="utf-8")
+        self.other_source.write_text("#!/usr/bin/env bash\nprintf other\\n\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(self.repo), "add", self.source.name, self.other_source.name],
+            check=True,
+        )
+        self.uid = os.getuid()
+        self.home = self.root / "home"
+        self.home.mkdir()
+        self.config = HELPER.Config(
+            config_dir=self.root / "system-config",
+            state_dir=self.root / "system-state",
+            request_root=self.root / "requests",
+            signing_key=self.root / "approval-private" / "approval.key",
+            trust_uid=self.uid,
+        )
+        self.config.private_key.parent.mkdir(mode=0o700)
+        subprocess.run(
+            [
+                HELPER.SSH_KEYGEN,
+                "-q",
+                "-t",
+                "ed25519",
+                "-N",
+                "",
+                "-C",
+                "aidevops-approval-signing",
+                "-f",
+                str(self.config.private_key),
+            ],
+            check=True,
+        )
+        HELPER.setup_key_material(self.config)
+        self.session = "ses_fixture_123456"
+        self.now = 1_800_000_000
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def _request(self, path: Path | None = None) -> str:
+        return HELPER.create_request(
+            self.config,
+            session_id=self.session,
+            uid=self.uid,
+            home=self.home,
+            path=str(path or self.source),
+            reason=HELPER.OVERRIDABLE_REASON,
+            now=self.now,
+        )
+
+    def _approve(self, request_id: str | None = None) -> dict[str, object]:
+        return HELPER.approve_request(
+            self.config,
+            request_id=request_id or self._request(),
+            home=self.home,
+            expected_uid=self.uid,
+            ttl_seconds=HELPER.MAX_TTL_SECONDS,
+            now=self.now,
+            confirm=lambda _request: True,
+        )
+
+    def _verify(self, **overrides: object) -> bool:
+        arguments = {
+            "session_id": self.session,
+            "uid": self.uid,
+            "path": str(self.source),
+            "reason": HELPER.OVERRIDABLE_REASON,
+            "now": self.now + 1,
+        }
+        arguments.update(overrides)
+        return HELPER.verify_approval(self.config, **arguments)
+
+    def test_exact_signed_scope_verifies(self) -> None:
+        payload = self._approve()
+        self.assertTrue(self._verify())
+        self.assertEqual(payload["expires_at"], self.now + HELPER.MAX_TTL_SECONDS)
+        snapshot_path = Path(str(payload["snapshot_path"]))
+        self.assertEqual(snapshot_path.read_bytes(), self.source.read_bytes())
+        self.assertEqual(snapshot_path.stat().st_mode & 0o777, 0o444)
+
+    def test_request_is_reused_for_the_same_scope(self) -> None:
+        first = self._request()
+        second = self._request()
+        self.assertEqual(first, second)
+
+    def test_cross_session_user_path_and_reason_fail_closed(self) -> None:
+        self._approve()
+        self.assertFalse(self._verify(session_id="ses_other_123456"))
+        self.assertFalse(self._verify(uid=self.uid + 1))
+        self.assertFalse(self._verify(path=str(self.other_source)))
+        self.assertFalse(self._verify(reason="private key path"))
+
+    def test_expired_and_future_receipts_fail_closed(self) -> None:
+        self._approve()
+        self.assertFalse(self._verify(now=self.now + HELPER.MAX_TTL_SECONDS))
+        self.assertFalse(self._verify(now=self.now - 1))
+
+    def test_source_content_change_invalidates_approval(self) -> None:
+        self._approve()
+        self.source.write_text("changed\n", encoding="utf-8")
+        self.assertFalse(self._verify())
+
+    def test_tampered_receipt_fails_signature_verification(self) -> None:
+        payload = self._approve()
+        receipt_path = (
+            self.config.state_dir
+            / "approvals"
+            / str(self.uid)
+            / f"{payload['approval_id']}.json"
+        )
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        receipt["payload"]["expires_at"] += 60
+        receipt_path.write_bytes(HELPER.canonical_json(receipt) + b"\n")
+        self.assertFalse(self._verify())
+
+    def test_revocation_is_immediate(self) -> None:
+        payload = self._approve()
+        self.assertTrue(self._verify())
+        HELPER.revoke_approval(
+            self.config,
+            approval_id=str(payload["approval_id"]),
+            uid=self.uid,
+        )
+        self.assertFalse(self._verify())
+        self.assertFalse(Path(str(payload["snapshot_path"])).exists())
+
+    def test_untracked_symlink_and_credential_like_paths_are_denied(self) -> None:
+        untracked = self.repo / "secret-untracked.sh"
+        untracked.write_text("synthetic\n", encoding="utf-8")
+        with self.assertRaisesRegex(HELPER.SourceAccessError, "Git-tracked"):
+            self._request(untracked)
+
+        link = self.repo / "secret-link.sh"
+        link.symlink_to(self.source)
+        subprocess.run(["git", "-C", str(self.repo), "add", link.name], check=True)
+        with self.assertRaisesRegex(HELPER.SourceAccessError, "symlinked"):
+            self._request(link)
+
+        credential_like = self.repo / ".env-secret.sh"
+        credential_like.write_text("synthetic\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(self.repo), "add", credential_like.name], check=True)
+        with self.assertRaisesRegex(HELPER.SourceAccessError, "credential-like"):
+            self._request(credential_like)
+
+        private_key = self.repo / "secret-private.pem"
+        private_key.write_text("synthetic\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(self.repo), "add", private_key.name], check=True)
+        with self.assertRaisesRegex(HELPER.SourceAccessError, "private key"):
+            self._request(private_key)
+
+        credential_store = self.repo / "credentials.json"
+        credential_store.write_text("{}\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(self.repo), "add", credential_store.name], check=True)
+        with self.assertRaisesRegex(HELPER.SourceAccessError, "credential-like"):
+            self._request(credential_store)
+
+        hard_link = self.repo / "secret-hard-link.sh"
+        os.link(self.source, hard_link)
+        subprocess.run(["git", "-C", str(self.repo), "add", hard_link.name], check=True)
+        hard_link_request = self._request(hard_link)
+        with self.assertRaisesRegex(HELPER.SourceAccessError, "hard-linked"):
+            self._approve(hard_link_request)
+
+    def test_ttl_parser_enforces_twelve_hour_maximum(self) -> None:
+        self.assertEqual(HELPER.parse_ttl("12h"), HELPER.MAX_TTL_SECONDS)
+        self.assertEqual(HELPER.parse_ttl("30m"), 1800)
+        with self.assertRaisesRegex(HELPER.SourceAccessError, "12 hours"):
+            HELPER.parse_ttl("13h")
+
+    def test_approval_rejects_unsafe_or_malformed_request_files(self) -> None:
+        request_id = self._request()
+        request_path = self.config.request_root / f"{request_id}.json"
+        request = json.loads(request_path.read_text(encoding="utf-8"))
+        request["created_at"] = "not-an-epoch"
+        request_path.write_bytes(HELPER.canonical_json(request) + b"\n")
+        with self.assertRaisesRegex(HELPER.SourceAccessError, "timestamp is invalid"):
+            self._approve(request_id)
+
+        request_path.chmod(0o666)
+        with self.assertRaisesRegex(HELPER.SourceAccessError, "permissions are unsafe"):
+            self._approve(request_id)
+
+    def test_malformed_receipt_fails_closed(self) -> None:
+        payload = self._approve()
+        receipt_path = (
+            self.config.state_dir
+            / "approvals"
+            / str(self.uid)
+            / f"{payload['approval_id']}.json"
+        )
+        receipt_path.write_text("{", encoding="utf-8")
+        self.assertFalse(self._verify())
+
+    def test_root_and_interactive_terminal_are_required(self) -> None:
+        with mock.patch.object(HELPER.os, "geteuid", return_value=1000):
+            with self.assertRaisesRegex(HELPER.SourceAccessError, "root-owned"):
+                HELPER._require_root_tty(self.config)
+        fake_stdin = mock.Mock()
+        fake_stdin.isatty.return_value = False
+        with mock.patch.object(HELPER.os, "geteuid", return_value=0), mock.patch.object(
+            HELPER.sys, "stdin", fake_stdin
+        ):
+            with self.assertRaisesRegex(HELPER.SourceAccessError, "interactive terminal"):
+                HELPER._require_root_tty(self.config)
+
+        fake_stdin.isatty.return_value = True
+        with mock.patch.object(HELPER.os, "geteuid", return_value=0), mock.patch.object(
+            HELPER.sys, "stdin", fake_stdin
+        ):
+            with self.assertRaisesRegex(HELPER.SourceAccessError, "root-owned source-access broker"):
+                HELPER._require_root_tty(self.config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/scripts/tests/test-source-access-helper.sh
+++ b/.agents/scripts/tests/test-source-access-helper.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "${SCRIPT_DIR}/test-source-access-helper.py"

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ the required notices and preferred credit text.
 - `aidevops gpt56-context [enable|disable|status]` - Keep GPT-5.6 at a 300K advertised context window in OpenCode (enabled by default), so 80% auto-compaction runs near 240K before long-context pricing; disable to use native provider limits
 - `aidevops buzz [status|apply|rollback]` - Inspect or manage Buzz Desktop OpenCode ACP compatibility
 - `aidevops secret` - Manage secrets (gopass encrypted, AI-safe)
+- `aidevops source-access` - Manage exact-path, session-bound source-read approvals signed via sudo
 - `aidevops security` - Full security assessment (posture, secrets, supply chain)
 - `aidevops lint audit` - Audit native lint/format/typecheck commands and repo-verify hooks
 - `aidevops lint configure --dry-run` - Preview safe evidence-based lint provisioning
@@ -210,9 +211,23 @@ aidevops security scan-secrets # Plaintext credential locations only
 aidevops security scan-deps    # Unpinned dependency check
 aidevops security check        # Per-repo security posture assessment
 aidevops security dismiss <id> # Dismiss a security advisory after taking action
+aidevops source-access status  # List temporary source-read approvals
+sudo -k /usr/bin/python3 /etc/aidevops/source-access/source-access-helper.py setup
+sudo -k /usr/bin/python3 /etc/aidevops/source-access/source-access-helper.py revoke <approval-id>
 ```
 
 Running `aidevops security` with no arguments is the single command that covers everything — user security posture, plaintext secret detection, supply chain IoC scanning, and active advisories.
+
+When a read guard identifies only a low-confidence source-code basename match, it emits a scoped request. A maintainer can run the displayed root-broker approval command. Approvals are bound to the exact runtime session, user, Git-tracked regular source path, approved content digest, and guard reason; they expire within 12 hours and never override private-key, environment-file, credential-store, hard-link, symlink, changed-content, or untracked-file denials. The plugin redirects the approved read to a root-controlled immutable snapshot of those bytes so the live path cannot be rebound after verification; revocation removes both receipt and snapshot.
+
+Privileged operations never execute the user-managed aidevops deployment as root. Resolve the immutable commit from the published, signed aidevops release metadata, substitute it for `<verified-release-commit>`, and let root fetch that reviewed broker directly over TLS. Never install the broker from the user-writable deployed tree.
+
+```bash
+sudo -k /usr/bin/install -d -o 0 -g 0 -m 0755 /etc/aidevops/source-access
+sudo -k -H /usr/bin/curl --disable --fail --location --proto '=https' --proto-redir '=https' --tlsv1.2 "https://raw.githubusercontent.com/marcusquinn/aidevops/<verified-release-commit>/.agents/scripts/source-access-helper.py" --output /etc/aidevops/source-access/source-access-helper.py
+sudo /bin/chmod 0644 /etc/aidevops/source-access/source-access-helper.py
+sudo -k /usr/bin/python3 /etc/aidevops/source-access/source-access-helper.py setup
+```
 
 **Security advisories** are delivered via `aidevops update` and shown in the session greeting until dismissed. The scanner never exposes secret values — only file locations and key names. All remediation commands should be run in a separate terminal, not inside AI chat sessions.
 

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1036,6 +1036,7 @@ _help_commands() {
 	echo "  ip-check <cmd>     IP reputation checks (check/batch/report/providers)"
 	echo "  review-gate <cmd>  Configure review_gate merge policies (rate-limit/completion)"
 	echo "  github-app-auth    GitHub App auth setup/status and API route decisions"
+	echo "  source-access <cmd> Session-bound, sudo-signed source-read approvals"
 	echo "  secret <cmd>       Manage secrets (set/list/run/init/import/status)"
 	echo "  vault <cmd>        Local encrypted Vault broker (init/unlock/lock/status/read/update)"
 	echo "  config <cmd>       Feature toggles (list/get/set/reset/path/help)"
@@ -1064,6 +1065,12 @@ _help_detailed_sections() {
 	echo "  aidevops security supply-chain scan [path] # npm supply-chain IOC scan"
 	echo "  aidevops security check      # Per-repo security posture assessment"
 	echo "  aidevops security dismiss <id> # Dismiss a security advisory"
+	echo ""
+	echo "Temporary source access:"
+	echo "  sudo -k /usr/bin/python3 /etc/aidevops/source-access/source-access-helper.py setup"
+	echo "  sudo -k /usr/bin/python3 /etc/aidevops/source-access/source-access-helper.py approve <id> --ttl 12h"
+	echo "  aidevops source-access status                    # List active/expired approvals"
+	echo "  sudo -k /usr/bin/python3 /etc/aidevops/source-access/source-access-helper.py revoke <approval-id>"
 	echo ""
 	echo "IP Reputation:"
 	echo "  aidevops ip-check check <ip> # Check IP reputation across providers"
@@ -1843,6 +1850,7 @@ main() {
 	opencode-desktop | oc-desktop) _dispatch_helper "opencode-launcher-helper.sh" "opencode-launcher-helper.sh" desktop "$@" ;;
 	opencode-sandbox | oc-sandbox) _dispatch_helper "opencode-sandbox-helper.sh" "opencode-sandbox-helper.sh" "$@" ;;
 	review-gate | review_gate) _dispatch_helper "review-gate-config-helper.sh" "review-gate-config-helper.sh" "$@" ;;
+	source-access | source_access) _dispatch_helper "source-access-helper.sh" "source-access-helper.sh" "$@" ;;
 	secret | secrets) _dispatch_helper "secret-helper.sh" "secret-helper.sh" "$@" ;;
 	vault) _dispatch_helper "vault-helper.sh" "vault-helper.sh" "$@" ;;
 	approve) _dispatch_helper "approval-helper.sh" "approval-helper.sh" "$@" ;;


### PR DESCRIPTION
## Summary

Add exact-session, exact-path source-read approvals signed with the existing root-protected approval key, content-bound root snapshots, hard-denial preservation, revocation, and OpenCode hook integration.

## Files Changed

.agents/plugins/opencode-aidevops/quality-hooks.mjs, .agents/plugins/opencode-aidevops/source-access-approval.mjs, .agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs, .agents/scripts/source-access-helper.py, .agents/scripts/source-access-helper.sh, .agents/scripts/tests/test-source-access-helper.py, .agents/scripts/tests/test-source-access-helper.sh, README.md, aidevops.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Real SSH signing and verification with root-trust fixtures; 12 Python security tests; 7 focused plugin tests; full OpenCode plugin suite (541 passing); ShellCheck; changed-file lint; independent high-risk review CLEAN at digest 00d206fef32e3707e993fb7aaa1da8bd1b0c26201d734899ae75388cbf087e5a.

Resolves #29616


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.227 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 3h 43m and 965,038 tokens on this with the user in an interactive session.