### PR TITLE
GH#29622: refactor: reduce source-access Qlty debt

### DIFF
--- a/.agents/plugins/opencode-aidevops/source-access-approval.mjs
+++ b/.agents/plugins/opencode-aidevops/source-access-approval.mjs
@@ -177,61 +177,73 @@ function sourceDigestMatches(filePath, expectedDigest) {
   }
 }
 
-/** Verify a root-owned receipt directly inside the already-loaded plugin. */
-export function verifySourceAccessReceipt({
-  sessionId,
-  filePath,
-  reason,
-  now = Math.floor(Date.now() / 1000),
-  uid = typeof process.getuid === "function" ? process.getuid() : -1,
-  trustUid = 0,
-  stateDir = DEFAULT_STATE_DIR,
-  publicKeyPath = DEFAULT_PUBLIC_KEY,
-  sshKeygen = "/usr/bin/ssh-keygen",
-  git = "/usr/bin/git",
-  gitRun = execFileSync,
-  run = execFileSync,
-}) {
-  let tempDir = "";
+function requireValidReceipt(condition) {
+  if (!condition) throw new Error("source-access receipt is invalid");
+}
+
+function validatedReceipt(options) {
+  const {
+    sessionId,
+    filePath,
+    reason,
+    now = Math.floor(Date.now() / 1000),
+    uid = typeof process.getuid === "function" ? process.getuid() : -1,
+    trustUid = 0,
+    stateDir = DEFAULT_STATE_DIR,
+    publicKeyPath = DEFAULT_PUBLIC_KEY,
+    sshKeygen = "/usr/bin/ssh-keygen",
+    git = "/usr/bin/git",
+    gitRun = execFileSync,
+    run = execFileSync,
+  } = options;
+  requireValidReceipt(/^[A-Za-z0-9._:-]{6,256}$/.test(sessionId));
+  requireValidReceipt(reason === SOURCE_ACCESS_REASON);
+  requireValidReceipt(uid >= 0);
+  requireValidReceipt(isAbsolute(filePath));
+  requireValidReceipt(!hasSymlinkComponent(filePath));
+  const canonicalPath = realpathSync(filePath);
+  requireValidReceipt(statSync(canonicalPath).isFile());
+  requireValidReceipt(isGitTrackedFile(canonicalPath, git, gitRun));
+  const approvalId = approvalScopeId(sessionId, uid, canonicalPath, reason);
+  const receiptPath = join(stateDir, "approvals", String(uid), `${approvalId}.json`);
+  requireValidReceipt(trustedDirectory(dirname(receiptPath), trustUid));
+  requireValidReceipt(trustedDirectory(dirname(publicKeyPath), trustUid));
+  requireValidReceipt(trustedRegularFile(receiptPath, trustUid));
+  requireValidReceipt(trustedRegularFile(publicKeyPath, trustUid));
+
+  const receipt = JSON.parse(readFileSync(receiptPath, "utf8"));
+  const payload = receipt?.payload;
+  requireValidReceipt(receipt?.schema === RECEIPT_SCHEMA);
+  requireValidReceipt(payload?.schema === PAYLOAD_SCHEMA);
+  requireValidReceipt(payload.approval_id === approvalId);
+  requireValidReceipt(payload.session_id === sessionId);
+  requireValidReceipt(payload.uid === uid);
+  requireValidReceipt(payload.path === canonicalPath);
+  requireValidReceipt(payload.reason === reason);
+  requireValidReceipt(/^[a-f0-9]{64}$/.test(payload.content_sha256 || ""));
+  requireValidReceipt(sourceDigestMatches(canonicalPath, payload.content_sha256));
+  const snapshotPath = join(stateDir, "snapshots", String(uid), `${approvalId}.source`);
+  requireValidReceipt(payload.snapshot_path === snapshotPath);
+  requireValidReceipt(trustedDirectory(dirname(snapshotPath), trustUid));
+  requireValidReceipt(trustedRegularFile(snapshotPath, trustUid));
+  requireValidReceipt(statSync(snapshotPath).size <= MAX_SOURCE_BYTES);
+  const snapshotDigest = createHash("sha256").update(readFileSync(snapshotPath)).digest("hex");
+  requireValidReceipt(snapshotDigest === payload.content_sha256);
+  requireValidReceipt(Number.isInteger(payload.issued_at));
+  requireValidReceipt(Number.isInteger(payload.expires_at));
+  requireValidReceipt(now >= payload.issued_at);
+  requireValidReceipt(now < payload.expires_at);
+  requireValidReceipt(payload.expires_at - payload.issued_at <= MAX_TTL_SECONDS);
+  requireValidReceipt(typeof receipt.signature === "string");
+  requireValidReceipt(receipt.signature.includes("SSH SIGNATURE"));
+  return {payload, publicKeyPath, receipt, run, snapshotPath, sshKeygen};
+}
+
+function verifyReceiptSignature({payload, publicKeyPath, receipt, run, snapshotPath, sshKeygen}) {
+  const tempRoot = verificationTempRoot();
+  mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
+  const tempDir = mkdtempSync(join(tempRoot, "source-access-verify-"));
   try {
-    if (!/^[A-Za-z0-9._:-]{6,256}$/.test(sessionId)) return false;
-    if (reason !== SOURCE_ACCESS_REASON || uid < 0 || !isAbsolute(filePath)) return false;
-    if (hasSymlinkComponent(filePath)) return false;
-    const canonicalPath = realpathSync(filePath);
-    if (!statSync(canonicalPath).isFile()) return false;
-    if (!isGitTrackedFile(canonicalPath, git, gitRun)) return false;
-    const approvalId = approvalScopeId(sessionId, uid, canonicalPath, reason);
-    const receiptPath = join(stateDir, "approvals", String(uid), `${approvalId}.json`);
-    if (!trustedDirectory(dirname(receiptPath), trustUid)) return false;
-    if (!trustedDirectory(dirname(publicKeyPath), trustUid)) return false;
-    if (!trustedRegularFile(receiptPath, trustUid)) return false;
-    if (!trustedRegularFile(publicKeyPath, trustUid)) return false;
-
-    const receipt = JSON.parse(readFileSync(receiptPath, "utf8"));
-    const payload = receipt?.payload;
-    if (receipt?.schema !== RECEIPT_SCHEMA || payload?.schema !== PAYLOAD_SCHEMA) return false;
-    if (payload.approval_id !== approvalId) return false;
-    if (payload.session_id !== sessionId || payload.uid !== uid) return false;
-    if (payload.path !== canonicalPath || payload.reason !== reason) return false;
-    if (!/^[a-f0-9]{64}$/.test(payload.content_sha256 || "")) return false;
-    if (!sourceDigestMatches(canonicalPath, payload.content_sha256)) return false;
-    const snapshotPath = join(stateDir, "snapshots", String(uid), `${approvalId}.source`);
-    if (payload.snapshot_path !== snapshotPath) return false;
-    if (!trustedDirectory(dirname(snapshotPath), trustUid)) return false;
-    if (!trustedRegularFile(snapshotPath, trustUid)) return false;
-    if (statSync(snapshotPath).size > MAX_SOURCE_BYTES) return false;
-    const snapshot = readFileSync(snapshotPath);
-    if (createHash("sha256").update(snapshot).digest("hex") !== payload.content_sha256) return false;
-    if (!Number.isInteger(payload.issued_at) || !Number.isInteger(payload.expires_at)) return false;
-    if (now < payload.issued_at || now >= payload.expires_at) return false;
-    if (payload.expires_at - payload.issued_at > MAX_TTL_SECONDS) return false;
-    if (typeof receipt.signature !== "string" || !receipt.signature.includes("SSH SIGNATURE")) {
-      return false;
-    }
-
-    const tempRoot = verificationTempRoot();
-    mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
-    tempDir = mkdtempSync(join(tempRoot, "source-access-verify-"));
     chmodSync(tempDir, 0o700);
     const signaturePath = join(tempDir, "payload.sig");
     const allowedSignersPath = join(tempDir, "allowed_signers");
@@ -264,10 +276,17 @@ export function verifySourceAccessReceipt({
       },
     );
     return { approvedPath: snapshotPath };
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+/** Verify a root-owned receipt directly inside the already-loaded plugin. */
+export function verifySourceAccessReceipt(options) {
+  try {
+    return verifyReceiptSignature(validatedReceipt(options));
   } catch {
     return false;
-  } finally {
-    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
   }
 }
 

--- a/.agents/scripts/source-access-helper.py
+++ b/.agents/scripts/source-access-helper.py
@@ -5,359 +5,137 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib.util
 import json
 import os
-import pwd
-import re
-import secrets
 import stat
-import subprocess
 import sys
 import tempfile
 import time
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
-SCHEMA_REQUEST = "aidevops-source-access-request/v1"
-SCHEMA_RECEIPT = "aidevops-source-access-receipt/v1"
-SCHEMA_PAYLOAD = "aidevops-source-access-approval/v1"
-SIGNATURE_NAMESPACE = "aidevops-source-access-v1"
-SIGNER_IDENTITY = "source-access@aidevops.sh"
-OVERRIDABLE_REASON = "secret-bearing basename"
-MAX_TTL_SECONDS = 12 * 60 * 60
-REQUEST_REUSE_SECONDS = 60 * 60
-MAX_SOURCE_BYTES = 10 * 1024 * 1024
-ID_PATTERN = re.compile(r"^[a-f0-9]{32,64}$")
-SESSION_PATTERN = re.compile(r"^[A-Za-z0-9._:-]{6,256}$")
-ALLOWED_SUFFIXES = {
-    ".c",
-    ".cjs",
-    ".cpp",
-    ".go",
-    ".h",
-    ".hpp",
-    ".java",
-    ".js",
-    ".json",
-    ".jsx",
-    ".kt",
-    ".md",
-    ".mjs",
-    ".php",
-    ".py",
-    ".rb",
-    ".rs",
-    ".sh",
-    ".swift",
-    ".toml",
-    ".ts",
-    ".tsx",
-    ".yaml",
-    ".yml",
-}
-DENIED_NAMES = {
-    ".netrc",
-    ".npmrc",
-    ".pypirc",
-    "auth.json",
-    "credentials",
-    "credentials.json",
-    "id_dsa",
-    "id_ecdsa",
-    "id_ed25519",
-    "id_rsa",
-    "kubeconfig",
-}
-DENIED_SUFFIXES = {".jks", ".key", ".keystore", ".p12", ".pem", ".pfx"}
-GIT = "/usr/bin/git"
-SSH_KEYGEN = "/usr/bin/ssh-keygen"
+_ROOT_BROKER_PATH = Path("/etc/aidevops/source-access/source-access-helper.py")
+_SOURCE_CORE_PATH = Path(__file__).resolve().with_name("source_access_core.py")
+_SOURCE_CORE_MODULE_NAME = "_aidevops_source_access_core"
+_BOOTSTRAP_TRUST_UID = 0
+_BOOTSTRAP_TRUST_ROOT = Path("/")
 
 
-class SourceAccessError(RuntimeError):
-    """Typed user-facing failure without source content."""
+def _bootstrap_require(condition: bool) -> None:
+    if not condition:
+        raise RuntimeError("refusing privileged source-access startup from untrusted broker files")
 
 
-@dataclass(frozen=True)
-class Config:
-    config_dir: Path = Path("/etc/aidevops/source-access")
-    state_dir: Path = Path("/var/run/aidevops/source-access")
-    request_root: Path | None = None
-    signing_key: Path | None = None
-    trust_uid: int = 0
-
-    @property
-    def private_key(self) -> Path:
-        if self.signing_key is not None:
-            return self.signing_key
-        return self.config_dir / "private" / "source-access.key"
-
-    @property
-    def public_key(self) -> Path:
-        return self.config_dir / "source-access.pub"
+def _validate_bootstrap_leaf(path: Path) -> None:
+    metadata = path.lstat()
+    _bootstrap_require(stat.S_ISREG(metadata.st_mode))
+    _bootstrap_require(not stat.S_ISLNK(metadata.st_mode))
+    _bootstrap_require(metadata.st_uid == _BOOTSTRAP_TRUST_UID)
+    _bootstrap_require(metadata.st_mode & 0o022 == 0)
 
 
-def canonical_json(value: Any) -> bytes:
-    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
-
-
-def _run(command: list[str], *, input_bytes: bytes | None = None) -> subprocess.CompletedProcess[bytes]:
-    try:
-        return subprocess.run(
-            command,
-            input=input_bytes,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            check=False,
-            timeout=15,
+def _validate_bootstrap_ancestors(path: Path, *, allow_symlinks: bool) -> None:
+    current = path
+    while True:
+        metadata = current.lstat()
+        is_symlink = stat.S_ISLNK(metadata.st_mode)
+        _bootstrap_require(metadata.st_uid == _BOOTSTRAP_TRUST_UID)
+        _bootstrap_require(
+            (allow_symlinks and is_symlink)
+            or (stat.S_ISDIR(metadata.st_mode) and metadata.st_mode & 0o022 == 0)
         )
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        raise SourceAccessError(f"required command failed: {command[0]}") from exc
+        if current == _BOOTSTRAP_TRUST_ROOT:
+            break
+        _bootstrap_require(current != current.parent)
+        current = current.parent
 
 
-def _ensure_directory(path: Path, mode: int, owner_uid: int | None = None) -> None:
-    path.mkdir(parents=True, exist_ok=True)
-    os.chmod(path, mode)
-    if owner_uid is not None and os.geteuid() == 0:
-        os.chown(path, owner_uid, 0)
-
-
-def atomic_write(
-    path: Path,
-    content: bytes,
-    mode: int,
-    owner_uid: int | None = None,
-    directory_mode: int | None = None,
-) -> None:
-    parent_mode = directory_mode if directory_mode is not None else (0o755 if mode == 0o644 else 0o700)
-    _ensure_directory(path.parent, parent_mode, owner_uid)
-    descriptor, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+def _validate_privileged_core_import() -> None:
+    if os.geteuid() != 0:
+        return
     try:
-        with os.fdopen(descriptor, "wb") as handle:
-            handle.write(content)
-            handle.flush()
-            os.fsync(handle.fileno())
-            os.fchmod(handle.fileno(), mode)
-            if owner_uid is not None and os.geteuid() == 0:
-                os.fchown(handle.fileno(), owner_uid, 0)
-        os.replace(temp_name, path)
-    finally:
-        try:
-            os.unlink(temp_name)
-        except FileNotFoundError:
-            pass
-
-
-def _validate_session_id(session_id: str) -> str:
-    if not SESSION_PATTERN.fullmatch(session_id):
-        raise SourceAccessError("invalid runtime session identifier")
-    return session_id
-
-
-def _validate_reason(reason: str) -> str:
-    if reason != OVERRIDABLE_REASON:
-        raise SourceAccessError("only the basename-only source guard can be approved")
-    return reason
-
-
-def _has_symlink_component(path: Path) -> bool:
-    current = Path(path.anchor)
-    for part in path.parts[1:]:
-        current /= part
-        try:
-            if stat.S_ISLNK(os.lstat(current).st_mode):
-                return True
-        except FileNotFoundError:
-            return False
-    return False
-
-
-def canonical_tracked_source(raw_path: str) -> str:
-    if not raw_path or any(ord(character) < 32 for character in raw_path):
-        raise SourceAccessError("source path is empty or contains control characters")
-    absolute = Path(os.path.abspath(os.path.expanduser(raw_path)))
-    if _has_symlink_component(absolute):
-        raise SourceAccessError("symlinked source paths cannot be approved")
-    try:
-        resolved = absolute.resolve(strict=True)
-        file_stat = resolved.stat()
+        actual = Path(__file__).resolve(strict=True)
+        expected = _ROOT_BROKER_PATH.resolve(strict=True)
+        expected_core_path = _ROOT_BROKER_PATH.with_name("source_access_core.py")
+        expected_core = expected_core_path.resolve(strict=True)
+        _bootstrap_require(actual == expected)
+        _bootstrap_require(_SOURCE_CORE_PATH.resolve(strict=True) == expected_core)
+        _validate_bootstrap_leaf(_ROOT_BROKER_PATH)
+        _validate_bootstrap_leaf(expected_core_path)
+        _validate_bootstrap_ancestors(_ROOT_BROKER_PATH.parent, allow_symlinks=True)
+        _validate_bootstrap_ancestors(expected.parent, allow_symlinks=False)
     except OSError as exc:
-        raise SourceAccessError("source path is unavailable") from exc
-    if not stat.S_ISREG(file_stat.st_mode):
-        raise SourceAccessError("source path is not a regular file")
-
-    basename = resolved.name.lower()
-    if basename.startswith(".env") or basename in DENIED_NAMES:
-        raise SourceAccessError("credential-like source paths cannot be approved")
-    if resolved.suffix.lower() in DENIED_SUFFIXES:
-        raise SourceAccessError("private key and credential containers cannot be approved")
-    if resolved.suffix.lower() not in ALLOWED_SUFFIXES:
-        raise SourceAccessError("path is not an approved source or documentation type")
-
-    root_result = _run([GIT, "-C", str(resolved.parent), "rev-parse", "--show-toplevel"])
-    if root_result.returncode != 0:
-        raise SourceAccessError("source path is not inside a Git worktree")
-    git_root = Path(root_result.stdout.decode("utf-8").strip()).resolve()
-    try:
-        relative_path = resolved.relative_to(git_root)
-    except ValueError as exc:
-        raise SourceAccessError("source path escapes its Git worktree") from exc
-    tracked_result = _run(
-        [GIT, "-C", str(git_root), "ls-files", "--error-unmatch", "--", str(relative_path)]
-    )
-    if tracked_result.returncode != 0:
-        raise SourceAccessError("only Git-tracked source files can be approved")
-    return str(resolved)
+        raise RuntimeError(
+            "refusing privileged source-access startup from unavailable broker files"
+        ) from exc
 
 
-def scope_id(session_id: str, uid: int, path: str, reason: str) -> str:
-    scope = f"{session_id}\0{uid}\0{path}\0{reason}".encode("utf-8")
-    return hashlib.sha256(scope).hexdigest()
+def _load_source_access_core() -> Any:
+    _validate_privileged_core_import()
+    spec = importlib.util.spec_from_file_location(_SOURCE_CORE_MODULE_NAME, _SOURCE_CORE_PATH)
+    _bootstrap_require(spec is not None)
+    _bootstrap_require(spec.loader is not None)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[_SOURCE_CORE_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    return module
 
 
-def secure_source_content(path: str) -> tuple[bytes, str]:
-    flags = os.O_RDONLY
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
-    try:
-        descriptor = os.open(path, flags)
-    except OSError as exc:
-        raise SourceAccessError("source path could not be opened safely") from exc
-    digest = hashlib.sha256()
-    content = bytearray()
-    total = 0
-    try:
-        opened_stat = os.fstat(descriptor)
-        if not stat.S_ISREG(opened_stat.st_mode) or opened_stat.st_nlink != 1:
-            raise SourceAccessError("hard-linked or non-regular source files cannot be approved")
-        if opened_stat.st_size > MAX_SOURCE_BYTES:
-            raise SourceAccessError("source file exceeds the approval size limit")
-        while chunk := os.read(descriptor, 64 * 1024):
-            total += len(chunk)
-            if total > MAX_SOURCE_BYTES:
-                raise SourceAccessError("source file exceeds the approval size limit")
-            content.extend(chunk)
-            digest.update(chunk)
-        current_stat = os.lstat(path)
-        if (
-            not stat.S_ISREG(current_stat.st_mode)
-            or current_stat.st_dev != opened_stat.st_dev
-            or current_stat.st_ino != opened_stat.st_ino
-        ):
-            raise SourceAccessError("source path changed during approval")
-    except OSError as exc:
-        raise SourceAccessError("source path changed during approval") from exc
-    finally:
-        os.close(descriptor)
-    return bytes(content), digest.hexdigest()
+_SOURCE_CORE = _load_source_access_core()
+ID_PATTERN = _SOURCE_CORE.ID_PATTERN
+MAX_TTL_SECONDS = _SOURCE_CORE.MAX_TTL_SECONDS
+OVERRIDABLE_REASON = _SOURCE_CORE.OVERRIDABLE_REASON
+REQUEST_REUSE_SECONDS = _SOURCE_CORE.REQUEST_REUSE_SECONDS
+SCHEMA_PAYLOAD = _SOURCE_CORE.SCHEMA_PAYLOAD
+SCHEMA_RECEIPT = _SOURCE_CORE.SCHEMA_RECEIPT
+SIGNATURE_NAMESPACE = _SOURCE_CORE.SIGNATURE_NAMESPACE
+SIGNER_IDENTITY = _SOURCE_CORE.SIGNER_IDENTITY
+SSH_KEYGEN = _SOURCE_CORE.SSH_KEYGEN
+ApprovalBinding = _SOURCE_CORE.ApprovalBinding
+ApprovalSpec = _SOURCE_CORE.ApprovalSpec
+Config = _SOURCE_CORE.Config
+RequestSpec = _SOURCE_CORE.RequestSpec
+SourceAccessError = _SOURCE_CORE.SourceAccessError
+VerificationSpec = _SOURCE_CORE.VerificationSpec
+_load_request = _SOURCE_CORE._load_request
+_run = _SOURCE_CORE._run
+_trusted_directory = _SOURCE_CORE._trusted_directory
+_trusted_file = _SOURCE_CORE._trusted_file
+_trusted_private_key = _SOURCE_CORE._trusted_private_key
+_validate_reason = _SOURCE_CORE._validate_reason
+_validate_session_id = _SOURCE_CORE._validate_session_id
+atomic_write = _SOURCE_CORE.atomic_write
+canonical_json = _SOURCE_CORE.canonical_json
+canonical_tracked_source = _SOURCE_CORE.canonical_tracked_source
+create_request = _SOURCE_CORE.create_request
+list_approvals = _SOURCE_CORE.list_approvals
+parse_ttl = _SOURCE_CORE.parse_ttl
+real_user = _SOURCE_CORE.real_user
+request_directory = _SOURCE_CORE.request_directory
+scope_id = _SOURCE_CORE.scope_id
+secure_source_content = _SOURCE_CORE.secure_source_content
+setup_key_material = _SOURCE_CORE.setup_key_material
 
-
-def request_directory(config: Config, home: Path) -> Path:
-    if config.request_root is not None:
-        return config.request_root
-    return home / ".aidevops" / ".agent-workspace" / "source-access" / "requests"
-
-
-def create_request(
-    config: Config,
-    *,
-    session_id: str,
-    uid: int,
-    home: Path,
-    path: str,
-    reason: str,
-    now: int | None = None,
-) -> str:
-    issued_at = int(time.time() if now is None else now)
-    session_id = _validate_session_id(session_id)
-    reason = _validate_reason(reason)
-    path = canonical_tracked_source(path)
-    directory = request_directory(config, home)
-    _ensure_directory(directory, 0o700)
-
-    for candidate in directory.glob("*.json"):
-        try:
-            existing = json.loads(candidate.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            continue
-        created_at = existing.get("created_at")
-        if isinstance(created_at, bool) or not isinstance(created_at, int):
-            continue
-        if (
-            existing.get("schema") == SCHEMA_REQUEST
-            and existing.get("session_id") == session_id
-            and existing.get("uid") == uid
-            and existing.get("path") == path
-            and existing.get("reason") == reason
-            and 0 <= issued_at - created_at <= REQUEST_REUSE_SECONDS
-        ):
-            request_id = str(existing.get("request_id", ""))
-            if ID_PATTERN.fullmatch(request_id):
-                return request_id
-
-    request_id = secrets.token_hex(16)
-    request = {
-        "schema": SCHEMA_REQUEST,
-        "request_id": request_id,
-        "session_id": session_id,
-        "uid": uid,
-        "path": path,
-        "reason": reason,
-        "created_at": issued_at,
-    }
-    atomic_write(directory / f"{request_id}.json", canonical_json(request) + b"\n", 0o600)
-    return request_id
-
-
-def parse_ttl(value: str) -> int:
-    match = re.fullmatch(r"([1-9][0-9]*)([mh])", value)
-    if not match:
-        raise SourceAccessError("TTL must use minutes or hours, for example 30m or 12h")
-    amount = int(match.group(1))
-    seconds = amount * (60 if match.group(2) == "m" else 3600)
-    if seconds < 60 or seconds > MAX_TTL_SECONDS:
-        raise SourceAccessError("TTL must be between 1 minute and 12 hours")
-    return seconds
-
-
-def setup_key_material(config: Config) -> None:
-    if not _trusted_directory(config.private_key.parent, config.trust_uid):
-        raise SourceAccessError("existing approval key directory ownership or permissions are unsafe")
-    if not _trusted_private_key(config.private_key, config.trust_uid):
-        raise SourceAccessError(
-            "existing root-owned aidevops approval key is unavailable"
-        )
-    _ensure_directory(config.config_dir, 0o755, config.trust_uid)
-    result = _run(
-        [
-            SSH_KEYGEN,
-            "-y",
-            "-f",
-            str(config.private_key),
-        ]
-    )
-    if result.returncode != 0:
-        raise SourceAccessError("failed to derive the source-access verification key")
-    atomic_write(config.public_key, result.stdout.strip() + b"\n", 0o644, config.trust_uid)
-
-
-def _load_request(
-    config: Config, home: Path, request_id: str, expected_uid: int
-) -> dict[str, Any]:
-    if not ID_PATTERN.fullmatch(request_id):
-        raise SourceAccessError("invalid request identifier")
-    request_path = request_directory(config, home) / f"{request_id}.json"
-    if not _trusted_directory(request_path.parent, expected_uid) or not _trusted_file(
-        request_path, expected_uid
-    ):
-        raise SourceAccessError("source-access request ownership or permissions are unsafe")
-    try:
-        request = json.loads(request_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise SourceAccessError("source-access request was not found or is malformed") from exc
-    if request.get("schema") != SCHEMA_REQUEST or request.get("request_id") != request_id:
-        raise SourceAccessError("source-access request schema or identifier is invalid")
-    return request
+__all__ = [
+    "MAX_TTL_SECONDS",
+    "OVERRIDABLE_REASON",
+    "SSH_KEYGEN",
+    "ApprovalSpec",
+    "Config",
+    "RequestSpec",
+    "SourceAccessError",
+    "VerificationSpec",
+    "approve_request",
+    "canonical_json",
+    "create_request",
+    "list_approvals",
+    "main",
+    "parse_ttl",
+    "revoke_approval",
+    "setup_key_material",
+    "verify_approval",
+]
 
 
 def _sign_payload(config: Config, payload: dict[str, Any]) -> str:
@@ -386,19 +164,10 @@ def _sign_payload(config: Config, payload: dict[str, Any]) -> str:
         return signature_path.read_text(encoding="utf-8")
 
 
-def approve_request(
-    config: Config,
-    *,
-    request_id: str,
-    home: Path,
-    expected_uid: int,
-    ttl_seconds: int,
-    now: int | None = None,
-    confirm: Callable[[dict[str, Any]], bool] | None = None,
-) -> dict[str, Any]:
-    issued_at = int(time.time() if now is None else now)
-    request = _load_request(config, home, request_id, expected_uid)
-    if request.get("uid") != expected_uid:
+def approve_request(config: Config, spec: ApprovalSpec) -> dict[str, Any]:
+    issued_at = int(time.time() if spec.now is None else spec.now)
+    request = _load_request(config, spec.home, spec.request_id, spec.expected_uid)
+    if request.get("uid") != spec.expected_uid:
         raise SourceAccessError("request user does not match the invoking sudo user")
     session_id = _validate_session_id(str(request.get("session_id", "")))
     reason = _validate_reason(str(request.get("reason", "")))
@@ -412,26 +181,26 @@ def approve_request(
     request_age = issued_at - created_at
     if request_age < 0 or request_age > REQUEST_REUSE_SECONDS:
         raise SourceAccessError("source-access request has expired; retry the blocked read")
-    confirmation_scope = {**request, "ttl_seconds": ttl_seconds}
-    if confirm is not None and not confirm(confirmation_scope):
+    confirmation_scope = {**request, "ttl_seconds": spec.ttl_seconds}
+    if spec.confirm is not None and not spec.confirm(confirmation_scope):
         raise SourceAccessError("source-access approval cancelled")
 
-    approval_id = scope_id(session_id, expected_uid, path, reason)
+    approval_id = scope_id(session_id, spec.expected_uid, path, reason)
     snapshot_path = (
-        config.state_dir / "snapshots" / str(expected_uid) / f"{approval_id}.source"
+        config.state_dir / "snapshots" / str(spec.expected_uid) / f"{approval_id}.source"
     )
     payload = {
         "schema": SCHEMA_PAYLOAD,
         "approval_id": approval_id,
-        "request_id": request_id,
+        "request_id": spec.request_id,
         "session_id": session_id,
-        "uid": expected_uid,
+        "uid": spec.expected_uid,
         "path": path,
         "reason": reason,
         "content_sha256": content_sha256,
         "snapshot_path": str(snapshot_path),
         "issued_at": issued_at,
-        "expires_at": issued_at + ttl_seconds,
+        "expires_at": issued_at + spec.ttl_seconds,
     }
     receipt = {
         "schema": SCHEMA_RECEIPT,
@@ -439,52 +208,13 @@ def approve_request(
         "signature": _sign_payload(config, payload),
     }
     atomic_write(snapshot_path, content, 0o444, config.trust_uid, directory_mode=0o755)
-    receipt_path = config.state_dir / "approvals" / str(expected_uid) / f"{approval_id}.json"
+    receipt_path = config.state_dir / "approvals" / str(spec.expected_uid) / f"{approval_id}.json"
     atomic_write(receipt_path, canonical_json(receipt) + b"\n", 0o644, config.trust_uid)
     try:
-        (request_directory(config, home) / f"{request_id}.json").unlink()
+        (request_directory(config, spec.home) / f"{spec.request_id}.json").unlink()
     except FileNotFoundError:
         pass
     return payload
-
-
-def _trusted_file(path: Path, owner_uid: int) -> bool:
-    try:
-        file_stat = path.lstat()
-    except OSError:
-        return False
-    return (
-        stat.S_ISREG(file_stat.st_mode)
-        and not stat.S_ISLNK(file_stat.st_mode)
-        and file_stat.st_uid == owner_uid
-        and file_stat.st_mode & 0o022 == 0
-    )
-
-
-def _trusted_private_key(path: Path, owner_uid: int) -> bool:
-    try:
-        file_stat = path.lstat()
-    except OSError:
-        return False
-    return (
-        stat.S_ISREG(file_stat.st_mode)
-        and not stat.S_ISLNK(file_stat.st_mode)
-        and file_stat.st_uid == owner_uid
-        and file_stat.st_mode & 0o077 == 0
-    )
-
-
-def _trusted_directory(path: Path, owner_uid: int) -> bool:
-    try:
-        directory_stat = path.lstat()
-    except OSError:
-        return False
-    return (
-        stat.S_ISDIR(directory_stat.st_mode)
-        and not stat.S_ISLNK(directory_stat.st_mode)
-        and directory_stat.st_uid == owner_uid
-        and directory_stat.st_mode & 0o022 == 0
-    )
 
 
 def _verify_signature(config: Config, payload: dict[str, Any], signature: str) -> bool:
@@ -523,64 +253,73 @@ def _verify_signature(config: Config, payload: dict[str, Any], signature: str) -
         return result.returncode == 0
 
 
-def verify_approval(
-    config: Config,
-    *,
-    session_id: str,
-    uid: int,
-    path: str,
-    reason: str,
-    now: int | None = None,
-) -> bool:
+def _require_valid_approval(condition: bool) -> None:
+    if not condition:
+        raise SourceAccessError("source-access approval is invalid")
+
+
+def _validated_receipt(config: Config, binding: ApprovalBinding) -> tuple[dict[str, Any], str]:
+    _require_valid_approval(_trusted_directory(binding.receipt_path.parent, config.trust_uid))
+    _require_valid_approval(_trusted_file(binding.receipt_path, config.trust_uid))
+    receipt = json.loads(binding.receipt_path.read_text(encoding="utf-8"))
+    _require_valid_approval(isinstance(receipt, dict))
+    payload = receipt.get("payload")
+    _require_valid_approval(receipt.get("schema") == SCHEMA_RECEIPT)
+    _require_valid_approval(isinstance(payload, dict))
+    expected = {
+        "approval_id": binding.approval_id,
+        "session_id": binding.session_id,
+        "uid": binding.uid,
+        "path": binding.path,
+        "reason": binding.reason,
+    }
+    _require_valid_approval(not any(payload.get(key) != value for key, value in expected.items()))
+    _require_valid_approval(payload.get("schema") == SCHEMA_PAYLOAD)
+    content_sha256 = payload.get("content_sha256")
+    _require_valid_approval(isinstance(content_sha256, str))
+    _require_valid_approval(len(content_sha256) == 64)
+    _require_valid_approval(all(character in "0123456789abcdef" for character in content_sha256))
+    _, current_sha256 = secure_source_content(binding.path)
+    _require_valid_approval(current_sha256 == content_sha256)
+    _require_valid_approval(payload.get("snapshot_path") == str(binding.snapshot_path))
+    _require_valid_approval(_trusted_directory(binding.snapshot_path.parent, config.trust_uid))
+    _require_valid_approval(_trusted_file(binding.snapshot_path, config.trust_uid))
+    snapshot_sha256 = hashlib.sha256(binding.snapshot_path.read_bytes()).hexdigest()
+    _require_valid_approval(snapshot_sha256 == content_sha256)
+    issued_at = payload.get("issued_at")
+    expires_at = payload.get("expires_at")
+    _require_valid_approval(isinstance(issued_at, int))
+    _require_valid_approval(not isinstance(issued_at, bool))
+    _require_valid_approval(isinstance(expires_at, int))
+    _require_valid_approval(not isinstance(expires_at, bool))
+    _require_valid_approval(binding.checked_at >= issued_at)
+    _require_valid_approval(binding.checked_at < expires_at)
+    _require_valid_approval(expires_at - issued_at <= MAX_TTL_SECONDS)
+    signature = receipt.get("signature")
+    _require_valid_approval(isinstance(signature, str))
+    return payload, signature
+
+
+def verify_approval(config: Config, spec: VerificationSpec) -> bool:
     try:
-        checked_at = int(time.time() if now is None else now)
-        session_id = _validate_session_id(session_id)
-        reason = _validate_reason(reason)
-        path = canonical_tracked_source(path)
-        approval_id = scope_id(session_id, uid, path, reason)
-        receipt_path = config.state_dir / "approvals" / str(uid) / f"{approval_id}.json"
-        if not _trusted_directory(receipt_path.parent, config.trust_uid):
-            return False
-        if not _trusted_file(receipt_path, config.trust_uid):
-            return False
-        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
-        payload = receipt.get("payload")
-        if receipt.get("schema") != SCHEMA_RECEIPT or not isinstance(payload, dict):
-            return False
-        expected = {
-            "approval_id": approval_id,
-            "session_id": session_id,
-            "uid": uid,
-            "path": path,
-            "reason": reason,
-        }
-        if any(payload.get(key) != value for key, value in expected.items()):
-            return False
-        if payload.get("schema") != SCHEMA_PAYLOAD:
-            return False
-        content_sha256 = payload.get("content_sha256")
-        if not isinstance(content_sha256, str) or not re.fullmatch(r"[a-f0-9]{64}", content_sha256):
-            return False
-        _, current_sha256 = secure_source_content(path)
-        if current_sha256 != content_sha256:
-            return False
-        expected_snapshot = config.state_dir / "snapshots" / str(uid) / f"{approval_id}.source"
-        if payload.get("snapshot_path") != str(expected_snapshot):
-            return False
-        if not _trusted_directory(expected_snapshot.parent, config.trust_uid):
-            return False
-        if not _trusted_file(expected_snapshot, config.trust_uid):
-            return False
-        if hashlib.sha256(expected_snapshot.read_bytes()).hexdigest() != content_sha256:
-            return False
-        if checked_at < int(payload.get("issued_at", 0)):
-            return False
-        if checked_at >= int(payload.get("expires_at", 0)):
-            return False
-        if int(payload["expires_at"]) - int(payload["issued_at"]) > MAX_TTL_SECONDS:
-            return False
-        signature = receipt.get("signature")
-        return isinstance(signature, str) and _verify_signature(config, payload, signature)
+        checked_at = int(time.time() if spec.now is None else spec.now)
+        session_id = _validate_session_id(spec.session_id)
+        reason = _validate_reason(spec.reason)
+        path = canonical_tracked_source(spec.path)
+        approval_id = scope_id(session_id, spec.uid, path, reason)
+        binding = ApprovalBinding(
+            approval_id=approval_id,
+            checked_at=checked_at,
+            path=path,
+            reason=reason,
+            receipt_path=config.state_dir / "approvals" / str(spec.uid) / f"{approval_id}.json",
+            session_id=session_id,
+            snapshot_path=config.state_dir / "snapshots" / str(spec.uid) / f"{approval_id}.source",
+            uid=spec.uid,
+        )
+        payload, signature = _validated_receipt(config, binding)
+        _require_valid_approval(_verify_signature(config, payload, signature))
+        return True
     except (OSError, ValueError, TypeError, json.JSONDecodeError, SourceAccessError):
         return False
 
@@ -600,42 +339,11 @@ def revoke_approval(config: Config, *, approval_id: str, uid: int) -> None:
         pass
 
 
-def list_approvals(config: Config, *, uid: int, now: int | None = None) -> list[dict[str, Any]]:
-    checked_at = int(time.time() if now is None else now)
-    results: list[dict[str, Any]] = []
-    directory = config.state_dir / "approvals" / str(uid)
-    if not directory.is_dir():
-        return results
-    for receipt_path in sorted(directory.glob("*.json")):
-        try:
-            receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
-            payload = receipt["payload"]
-            results.append(
-                {
-                    "approval_id": payload["approval_id"],
-                    "session_id": payload["session_id"],
-                    "path": payload["path"],
-                    "expires_at": payload["expires_at"],
-                    "status": "active" if checked_at < int(payload["expires_at"]) else "expired",
-                }
-            )
-        except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
-            continue
-    return results
-
-
-def _real_user() -> tuple[int, Path]:
-    sudo_user = os.environ.get("SUDO_USER", "")
-    if os.geteuid() == 0 and sudo_user:
-        account = pwd.getpwnam(sudo_user)
-        return account.pw_uid, Path(account.pw_dir)
-    return os.getuid(), Path.home()
-
-
 def _trusted_root_broker(config: Config) -> bool:
     try:
         actual = Path(__file__).resolve(strict=True)
         expected = (config.config_dir / "source-access-helper.py").resolve(strict=True)
+        expected_core = (config.config_dir / "source_access_core.py").resolve(strict=True)
         if actual != expected:
             return False
         current = actual
@@ -646,7 +354,9 @@ def _trusted_root_broker(config: Config) -> bool:
             if current == Path(current.anchor):
                 break
             current = current.parent
-        return _trusted_file(actual, config.trust_uid)
+        return _trusted_file(actual, config.trust_uid) and _trusted_file(
+            expected_core, config.trust_uid
+        )
     except OSError:
         return False
 
@@ -696,73 +406,88 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _run_setup(_args: argparse.Namespace, config: Config, _uid: int, _home: Path) -> int:
+    _require_root_tty(config)
+    if not _confirm_setup():
+        raise SourceAccessError("source-access setup cancelled")
+    setup_key_material(config)
+    print("Source-access trust is configured with the existing approval key.")
+    return 0
+
+
+def _run_request(args: argparse.Namespace, config: Config, uid: int, home: Path) -> int:
+    request_id = create_request(
+        config,
+        RequestSpec(args.session, uid, home, args.path, args.reason),
+    )
+    print(request_id)
+    return 0
+
+
+def _run_approve(args: argparse.Namespace, config: Config, uid: int, home: Path) -> int:
+    _require_root_tty(config)
+    payload = approve_request(
+        config,
+        ApprovalSpec(
+            request_id=args.request_id,
+            home=home,
+            expected_uid=uid,
+            ttl_seconds=parse_ttl(args.ttl),
+            confirm=_confirm_request,
+        ),
+    )
+    print(f"Approved: {payload['approval_id']}")
+    print(f"Expires epoch: {payload['expires_at']}")
+    return 0
+
+
+def _run_verify(args: argparse.Namespace, config: Config, uid: int, _home: Path) -> int:
+    valid = verify_approval(
+        config,
+        VerificationSpec(args.session, uid, args.path, args.reason),
+    )
+    if valid and not args.quiet:
+        print("VERIFIED")
+    return 0 if valid else 1
+
+
+def _run_revoke(args: argparse.Namespace, config: Config, uid: int, _home: Path) -> int:
+    _require_root_tty(config)
+    revoke_approval(config, approval_id=args.approval_id, uid=uid)
+    print(f"Revoked: {args.approval_id}")
+    return 0
+
+
+def _run_status(_args: argparse.Namespace, config: Config, uid: int, _home: Path) -> int:
+    approvals = list_approvals(config, uid=uid)
+    if not approvals:
+        print("No source-access approvals.")
+        return 0
+    for approval in approvals:
+        print(
+            f"{approval['approval_id']}\t{approval['status']}\t"
+            f"{approval['expires_at']}\t{approval['session_id']}\t{approval['path']}"
+        )
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    uid, home = _real_user()
+    uid, home = real_user()
     config = Config(signing_key=home / ".aidevops" / "approval-keys" / "private" / "approval.key")
+    handlers = {
+        "setup": _run_setup,
+        "request": _run_request,
+        "approve": _run_approve,
+        "verify": _run_verify,
+        "revoke": _run_revoke,
+        "status": _run_status,
+    }
     try:
-        if args.command == "setup":
-            _require_root_tty(config)
-            if not _confirm_setup():
-                raise SourceAccessError("source-access setup cancelled")
-            setup_key_material(config)
-            print("Source-access trust is configured with the existing approval key.")
-            return 0
-        if args.command == "request":
-            request_id = create_request(
-                config,
-                session_id=args.session,
-                uid=uid,
-                home=home,
-                path=args.path,
-                reason=args.reason,
-            )
-            print(request_id)
-            return 0
-        if args.command == "approve":
-            _require_root_tty(config)
-            payload = approve_request(
-                config,
-                request_id=args.request_id,
-                home=home,
-                expected_uid=uid,
-                ttl_seconds=parse_ttl(args.ttl),
-                confirm=_confirm_request,
-            )
-            print(f"Approved: {payload['approval_id']}")
-            print(f"Expires epoch: {payload['expires_at']}")
-            return 0
-        if args.command == "verify":
-            valid = verify_approval(
-                config,
-                session_id=args.session,
-                uid=uid,
-                path=args.path,
-                reason=args.reason,
-            )
-            if valid and not args.quiet:
-                print("VERIFIED")
-            return 0 if valid else 1
-        if args.command == "revoke":
-            _require_root_tty(config)
-            revoke_approval(config, approval_id=args.approval_id, uid=uid)
-            print(f"Revoked: {args.approval_id}")
-            return 0
-        if args.command == "status":
-            approvals = list_approvals(config, uid=uid)
-            if not approvals:
-                print("No source-access approvals.")
-                return 0
-            for approval in approvals:
-                print(
-                    f"{approval['approval_id']}\t{approval['status']}\t"
-                    f"{approval['expires_at']}\t{approval['session_id']}\t{approval['path']}"
-                )
-            return 0
+        return handlers[args.command](args, config, uid, home)
     except SourceAccessError as exc:
         print(f"[ERROR] {exc}", file=sys.stderr)
         return 1
-    return 1
 
 
 if __name__ == "__main__":

--- a/.agents/scripts/source_access_core.py
+++ b/.agents/scripts/source_access_core.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Core policy and request handling for temporary source access."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import pwd
+import re
+import secrets
+import stat
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+SCHEMA_REQUEST = "aidevops-source-access-request/v1"
+SCHEMA_RECEIPT = "aidevops-source-access-receipt/v1"
+SCHEMA_PAYLOAD = "aidevops-source-access-approval/v1"
+SIGNATURE_NAMESPACE = "aidevops-source-access-v1"
+SIGNER_IDENTITY = "source-access@aidevops.sh"
+OVERRIDABLE_REASON = "secret-bearing basename"
+MAX_TTL_SECONDS = 12 * 60 * 60
+REQUEST_REUSE_SECONDS = 60 * 60
+MAX_SOURCE_BYTES = 10 * 1024 * 1024
+ID_PATTERN = re.compile(r"^[a-f0-9]{32,64}$")
+SESSION_PATTERN = re.compile(r"^[A-Za-z0-9._:-]{6,256}$")
+ALLOWED_SUFFIXES = frozenset(
+    ".c .cjs .cpp .go .h .hpp .java .js .json .jsx .kt .md .mjs .php .py .rb "
+    ".rs .sh .swift .toml .ts .tsx .yaml .yml".split()
+)
+DENIED_NAMES = frozenset(
+    ".netrc .npmrc .pypirc auth.json credentials credentials.json id_dsa id_ecdsa "
+    "id_ed25519 id_rsa kubeconfig".split()
+)
+DENIED_SUFFIXES = frozenset(".jks .key .keystore .p12 .pem .pfx".split())
+GIT = "/usr/bin/git"
+SSH_KEYGEN = "/usr/bin/ssh-keygen"
+
+
+class SourceAccessError(RuntimeError):
+    """Typed user-facing failure without source content."""
+
+
+@dataclass(frozen=True)
+class Config:
+    config_dir: Path = Path("/etc/aidevops/source-access")
+    state_dir: Path = Path("/var/run/aidevops/source-access")
+    request_root: Path | None = None
+    signing_key: Path | None = None
+    trust_uid: int = 0
+
+    @property
+    def private_key(self) -> Path:
+        if self.signing_key is not None:
+            return self.signing_key
+        return self.config_dir / "private" / "source-access.key"
+
+    @property
+    def public_key(self) -> Path:
+        return self.config_dir / "source-access.pub"
+
+
+@dataclass(frozen=True)
+class RequestSpec:
+    session_id: str
+    uid: int
+    home: Path
+    path: str
+    reason: str
+    now: int | None = None
+
+
+@dataclass(frozen=True)
+class ApprovalSpec:
+    request_id: str
+    home: Path
+    expected_uid: int
+    ttl_seconds: int
+    now: int | None = None
+    confirm: Callable[[dict[str, Any]], bool] | None = None
+
+
+@dataclass(frozen=True)
+class VerificationSpec:
+    session_id: str
+    uid: int
+    path: str
+    reason: str
+    now: int | None = None
+
+
+@dataclass(frozen=True)
+class ApprovalBinding:
+    approval_id: str
+    checked_at: int
+    path: str
+    reason: str
+    receipt_path: Path
+    session_id: str
+    snapshot_path: Path
+    uid: int
+
+
+def canonical_json(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _run(command: list[str], *, input_bytes: bytes | None = None) -> subprocess.CompletedProcess[bytes]:
+    try:
+        return subprocess.run(
+            command,
+            input=input_bytes,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise SourceAccessError(f"required command failed: {command[0]}") from exc
+
+
+def _ensure_directory(path: Path, mode: int, owner_uid: int | None = None) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    os.chmod(path, mode)
+    if owner_uid is not None and os.geteuid() == 0:
+        os.chown(path, owner_uid, 0)
+
+
+def atomic_write(
+    path: Path,
+    content: bytes,
+    mode: int,
+    owner_uid: int | None = None,
+    directory_mode: int | None = None,
+) -> None:
+    parent_mode = directory_mode if directory_mode is not None else (0o755 if mode == 0o644 else 0o700)
+    _ensure_directory(path.parent, parent_mode, owner_uid)
+    descriptor, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+            os.fchmod(handle.fileno(), mode)
+            if owner_uid is not None and os.geteuid() == 0:
+                os.fchown(handle.fileno(), owner_uid, 0)
+        os.replace(temp_name, path)
+    finally:
+        try:
+            os.unlink(temp_name)
+        except FileNotFoundError:
+            pass
+
+
+def _require_source(condition: bool, message: str) -> None:
+    if not condition:
+        raise SourceAccessError(message)
+
+
+def _validate_session_id(session_id: str) -> str:
+    _require_source(SESSION_PATTERN.fullmatch(session_id) is not None, "invalid runtime session identifier")
+    return session_id
+
+
+def _validate_reason(reason: str) -> str:
+    _require_source(reason == OVERRIDABLE_REASON, "only the basename-only source guard can be approved")
+    return reason
+
+
+def _has_symlink_component(path: Path) -> bool:
+    current = Path(path.anchor)
+    for part in path.parts[1:]:
+        current /= part
+        try:
+            if stat.S_ISLNK(os.lstat(current).st_mode):
+                return True
+        except FileNotFoundError:
+            return False
+    return False
+
+
+def canonical_tracked_source(raw_path: str) -> str:
+    _require_source(bool(raw_path), "source path is empty or contains control characters")
+    _require_source(
+        all(ord(character) >= 32 for character in raw_path),
+        "source path is empty or contains control characters",
+    )
+    absolute = Path(os.path.abspath(os.path.expanduser(raw_path)))
+    _require_source(not _has_symlink_component(absolute), "symlinked source paths cannot be approved")
+    try:
+        resolved = absolute.resolve(strict=True)
+        file_stat = resolved.stat()
+    except OSError as exc:
+        raise SourceAccessError("source path is unavailable") from exc
+    _require_source(stat.S_ISREG(file_stat.st_mode), "source path is not a regular file")
+
+    basename = resolved.name.lower()
+    _require_source(
+        not basename.startswith(".env") and basename not in DENIED_NAMES,
+        "credential-like source paths cannot be approved",
+    )
+    suffix = resolved.suffix.lower()
+    _require_source(suffix not in DENIED_SUFFIXES, "private key and credential containers cannot be approved")
+    _require_source(suffix in ALLOWED_SUFFIXES, "path is not an approved source or documentation type")
+
+    root_result = _run([GIT, "-C", str(resolved.parent), "rev-parse", "--show-toplevel"])
+    _require_source(root_result.returncode == 0, "source path is not inside a Git worktree")
+    git_root = Path(root_result.stdout.decode("utf-8").strip()).resolve()
+    try:
+        relative_path = resolved.relative_to(git_root)
+    except ValueError as exc:
+        raise SourceAccessError("source path escapes its Git worktree") from exc
+    tracked_result = _run(
+        [GIT, "-C", str(git_root), "ls-files", "--error-unmatch", "--", str(relative_path)]
+    )
+    _require_source(tracked_result.returncode == 0, "only Git-tracked source files can be approved")
+    return str(resolved)
+
+
+def scope_id(session_id: str, uid: int, path: str, reason: str) -> str:
+    scope = f"{session_id}\0{uid}\0{path}\0{reason}".encode("utf-8")
+    return hashlib.sha256(scope).hexdigest()
+
+
+def secure_source_content(path: str) -> tuple[bytes, str]:
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise SourceAccessError("source path could not be opened safely") from exc
+    digest = hashlib.sha256()
+    content = bytearray()
+    total = 0
+    try:
+        opened_stat = os.fstat(descriptor)
+        _require_source(
+            stat.S_ISREG(opened_stat.st_mode) and opened_stat.st_nlink == 1,
+            "hard-linked or non-regular source files cannot be approved",
+        )
+        _require_source(
+            opened_stat.st_size <= MAX_SOURCE_BYTES,
+            "source file exceeds the approval size limit",
+        )
+        while chunk := os.read(descriptor, 64 * 1024):
+            total += len(chunk)
+            _require_source(total <= MAX_SOURCE_BYTES, "source file exceeds the approval size limit")
+            content.extend(chunk)
+            digest.update(chunk)
+        current_stat = os.lstat(path)
+        _require_source(
+            stat.S_ISREG(current_stat.st_mode)
+            and current_stat.st_dev == opened_stat.st_dev
+            and current_stat.st_ino == opened_stat.st_ino,
+            "source path changed during approval",
+        )
+    except OSError as exc:
+        raise SourceAccessError("source path changed during approval") from exc
+    finally:
+        os.close(descriptor)
+    return bytes(content), digest.hexdigest()
+
+
+def request_directory(config: Config, home: Path) -> Path:
+    return config.request_root or home / ".aidevops" / ".agent-workspace" / "source-access" / "requests"
+
+
+def _reusable_request_id(
+    existing: dict[str, Any], spec: RequestSpec, path: str, issued_at: int
+) -> str | None:
+    created_at = existing.get("created_at")
+    if isinstance(created_at, bool) or not isinstance(created_at, int):
+        return None
+    expected = {
+        "schema": SCHEMA_REQUEST,
+        "session_id": spec.session_id,
+        "uid": spec.uid,
+        "path": path,
+        "reason": spec.reason,
+    }
+    if any(existing.get(key) != value for key, value in expected.items()):
+        return None
+    request_age = issued_at - created_at
+    if request_age < 0 or request_age > REQUEST_REUSE_SECONDS:
+        return None
+    request_id = str(existing.get("request_id", ""))
+    return request_id if ID_PATTERN.fullmatch(request_id) else None
+
+
+def create_request(config: Config, spec: RequestSpec) -> str:
+    issued_at = int(time.time() if spec.now is None else spec.now)
+    session_id = _validate_session_id(spec.session_id)
+    reason = _validate_reason(spec.reason)
+    path = canonical_tracked_source(spec.path)
+    normalized_spec = RequestSpec(session_id, spec.uid, spec.home, path, reason, spec.now)
+    directory = request_directory(config, spec.home)
+    _ensure_directory(directory, 0o700)
+
+    for candidate in directory.glob("*.json"):
+        try:
+            existing = json.loads(candidate.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        reusable_id = _reusable_request_id(existing, normalized_spec, path, issued_at)
+        if reusable_id is not None:
+            return reusable_id
+
+    request_id = secrets.token_hex(16)
+    request = {
+        "schema": SCHEMA_REQUEST,
+        "request_id": request_id,
+        "session_id": session_id,
+        "uid": spec.uid,
+        "path": path,
+        "reason": reason,
+        "created_at": issued_at,
+    }
+    atomic_write(directory / f"{request_id}.json", canonical_json(request) + b"\n", 0o600)
+    return request_id
+
+
+def parse_ttl(value: str) -> int:
+    match = re.fullmatch(r"([1-9][0-9]*)([mh])", value)
+    _require_source(match is not None, "TTL must use minutes or hours, for example 30m or 12h")
+    amount = int(match.group(1))
+    seconds = amount * (60 if match.group(2) == "m" else 3600)
+    _require_source(60 <= seconds <= MAX_TTL_SECONDS, "TTL must be between 1 minute and 12 hours")
+    return seconds
+
+
+def _trusted_node(
+    path: Path,
+    owner_uid: int,
+    expected_kind: Callable[[int], bool],
+    forbidden_mode: int,
+) -> bool:
+    try:
+        metadata = path.lstat()
+    except OSError:
+        return False
+    return (
+        expected_kind(metadata.st_mode)
+        and not stat.S_ISLNK(metadata.st_mode)
+        and metadata.st_uid == owner_uid
+        and metadata.st_mode & forbidden_mode == 0
+    )
+
+
+def _trusted_file(path: Path, owner_uid: int) -> bool:
+    return _trusted_node(path, owner_uid, stat.S_ISREG, 0o022)
+
+
+def _trusted_private_key(path: Path, owner_uid: int) -> bool:
+    return _trusted_node(path, owner_uid, stat.S_ISREG, 0o077)
+
+
+def _trusted_directory(path: Path, owner_uid: int) -> bool:
+    return _trusted_node(path, owner_uid, stat.S_ISDIR, 0o022)
+
+
+def _load_request(
+    config: Config, home: Path, request_id: str, expected_uid: int
+) -> dict[str, Any]:
+    _require_source(ID_PATTERN.fullmatch(request_id) is not None, "invalid request identifier")
+    request_path = request_directory(config, home) / f"{request_id}.json"
+    trust_error = "source-access request ownership or permissions are unsafe"
+    _require_source(_trusted_directory(request_path.parent, expected_uid), trust_error)
+    _require_source(_trusted_file(request_path, expected_uid), trust_error)
+    try:
+        request = json.loads(request_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SourceAccessError("source-access request was not found or is malformed") from exc
+    schema_error = "source-access request schema or identifier is invalid"
+    _require_source(request.get("schema") == SCHEMA_REQUEST, schema_error)
+    _require_source(request.get("request_id") == request_id, schema_error)
+    return request
+
+
+def setup_key_material(config: Config) -> None:
+    _require_source(
+        _trusted_directory(config.private_key.parent, config.trust_uid),
+        "existing approval key directory ownership or permissions are unsafe",
+    )
+    _require_source(
+        _trusted_private_key(config.private_key, config.trust_uid),
+        "existing root-owned aidevops approval key is unavailable",
+    )
+    _ensure_directory(config.config_dir, 0o755, config.trust_uid)
+    result = _run(
+        [
+            SSH_KEYGEN,
+            "-y",
+            "-f",
+            str(config.private_key),
+        ]
+    )
+    _require_source(result.returncode == 0, "failed to derive the source-access verification key")
+    atomic_write(config.public_key, result.stdout.strip() + b"\n", 0o644, config.trust_uid)
+
+
+def list_approvals(config: Config, *, uid: int, now: int | None = None) -> list[dict[str, Any]]:
+    checked_at = int(time.time() if now is None else now)
+    results: list[dict[str, Any]] = []
+    directory = config.state_dir / "approvals" / str(uid)
+    if not directory.is_dir():
+        return results
+    for receipt_path in sorted(directory.glob("*.json")):
+        try:
+            receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+            payload = receipt["payload"]
+            results.append(
+                {
+                    "approval_id": payload["approval_id"],
+                    "session_id": payload["session_id"],
+                    "path": payload["path"],
+                    "expires_at": payload["expires_at"],
+                    "status": "active" if checked_at < int(payload["expires_at"]) else "expired",
+                }
+            )
+        except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+            continue
+    return results
+
+
+def real_user() -> tuple[int, Path]:
+    sudo_user = os.environ.get("SUDO_USER", "")
+    if os.geteuid() == 0 and sudo_user:
+        account = pwd.getpwnam(sudo_user)
+        return account.pw_uid, Path(account.pw_dir)
+    return os.getuid(), Path.home()

--- a/.agents/scripts/tests/test-source-access-helper.py
+++ b/.agents/scripts/tests/test-source-access-helper.py
@@ -14,7 +14,8 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-HELPER_PATH = Path(__file__).resolve().parents[1] / "source-access-helper.py"
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+HELPER_PATH = SCRIPTS_DIR / "source-access-helper.py"
 SPEC = importlib.util.spec_from_file_location("source_access_helper", HELPER_PATH)
 assert SPEC and SPEC.loader
 HELPER = importlib.util.module_from_spec(SPEC)
@@ -83,23 +84,27 @@ class SourceAccessHelperTests(unittest.TestCase):
     def _request(self, path: Path | None = None) -> str:
         return HELPER.create_request(
             self.config,
-            session_id=self.session,
-            uid=self.uid,
-            home=self.home,
-            path=str(path or self.source),
-            reason=HELPER.OVERRIDABLE_REASON,
-            now=self.now,
+            HELPER.RequestSpec(
+                session_id=self.session,
+                uid=self.uid,
+                home=self.home,
+                path=str(path or self.source),
+                reason=HELPER.OVERRIDABLE_REASON,
+                now=self.now,
+            ),
         )
 
     def _approve(self, request_id: str | None = None) -> dict[str, object]:
         return HELPER.approve_request(
             self.config,
-            request_id=request_id or self._request(),
-            home=self.home,
-            expected_uid=self.uid,
-            ttl_seconds=HELPER.MAX_TTL_SECONDS,
-            now=self.now,
-            confirm=lambda _request: True,
+            HELPER.ApprovalSpec(
+                request_id=request_id or self._request(),
+                home=self.home,
+                expected_uid=self.uid,
+                ttl_seconds=HELPER.MAX_TTL_SECONDS,
+                now=self.now,
+                confirm=lambda _request: True,
+            ),
         )
 
     def _verify(self, **overrides: object) -> bool:
@@ -111,7 +116,7 @@ class SourceAccessHelperTests(unittest.TestCase):
             "now": self.now + 1,
         }
         arguments.update(overrides)
-        return HELPER.verify_approval(self.config, **arguments)
+        return HELPER.verify_approval(self.config, HELPER.VerificationSpec(**arguments))
 
     def test_exact_signed_scope_verifies(self) -> None:
         payload = self._approve()
@@ -233,6 +238,98 @@ class SourceAccessHelperTests(unittest.TestCase):
         )
         receipt_path.write_text("{", encoding="utf-8")
         self.assertFalse(self._verify())
+        receipt_path.write_text("[]", encoding="utf-8")
+        self.assertFalse(self._verify())
+
+    def test_privileged_bootstrap_rejects_unsafe_core_before_execution(self) -> None:
+        broker = self.root / "broker"
+        broker.mkdir()
+        helper_path = broker / "source-access-helper.py"
+        helper_path.write_text("# bootstrap fixture\n", encoding="utf-8")
+        core_path = broker / "source_access_core.py"
+        marker_path = self.root / "core-executed"
+        core_source = (
+            "from pathlib import Path\n"
+            f"Path({str(marker_path)!r}).write_text('executed', encoding='utf-8')\n"
+            "VALUE = 7\n"
+        )
+        core_path.write_text(core_source, encoding="utf-8")
+        original_module = sys.modules.get(HELPER._SOURCE_CORE_MODULE_NAME)
+
+        def load_fixture() -> object:
+            with mock.patch.object(HELPER, "__file__", str(helper_path)), mock.patch.object(
+                HELPER, "_ROOT_BROKER_PATH", helper_path
+            ), mock.patch.object(HELPER, "_SOURCE_CORE_PATH", core_path), mock.patch.object(
+                HELPER, "_BOOTSTRAP_TRUST_ROOT", self.root
+            ), mock.patch.object(HELPER, "_BOOTSTRAP_TRUST_UID", self.uid), mock.patch.object(
+                HELPER.os, "geteuid", return_value=0
+            ):
+                return HELPER._load_source_access_core()
+
+        try:
+            core_path.chmod(0o666)
+            with self.assertRaisesRegex(RuntimeError, "untrusted broker files"):
+                load_fixture()
+            self.assertFalse(marker_path.exists())
+
+            core_path.chmod(0o644)
+            loaded = load_fixture()
+            self.assertTrue(marker_path.exists())
+            self.assertEqual(loaded.VALUE, 7)
+
+            marker_path.unlink()
+            broker.chmod(0o777)
+            with self.assertRaisesRegex(RuntimeError, "untrusted broker files"):
+                load_fixture()
+            self.assertFalse(marker_path.exists())
+
+            broker.chmod(0o755)
+            core_target = broker / "core-target.py"
+            core_path.replace(core_target)
+            core_path.symlink_to(core_target.name)
+            with self.assertRaisesRegex(RuntimeError, "untrusted broker files"):
+                load_fixture()
+            self.assertFalse(marker_path.exists())
+        finally:
+            if original_module is None:
+                sys.modules.pop(HELPER._SOURCE_CORE_MODULE_NAME, None)
+            else:
+                sys.modules[HELPER._SOURCE_CORE_MODULE_NAME] = original_module
+
+    def test_privileged_bootstrap_accepts_trusted_symlinked_ancestor(self) -> None:
+        canonical_root = self.root / "private" / "etc"
+        broker = canonical_root / "aidevops" / "source-access"
+        broker.mkdir(parents=True)
+        alias_root = self.root / "etc"
+        alias_root.symlink_to(Path("private") / "etc", target_is_directory=True)
+        helper_path = alias_root / "aidevops" / "source-access" / "source-access-helper.py"
+        helper_path.write_text("# bootstrap fixture\n", encoding="utf-8")
+        core_path = broker / "source_access_core.py"
+        marker_path = self.root / "aliased-core-executed"
+        core_path.write_text(
+            "from pathlib import Path\n"
+            f"Path({str(marker_path)!r}).write_text('executed', encoding='utf-8')\n"
+            "VALUE = 11\n",
+            encoding="utf-8",
+        )
+        original_module = sys.modules.get(HELPER._SOURCE_CORE_MODULE_NAME)
+
+        try:
+            with mock.patch.object(HELPER, "__file__", str(helper_path)), mock.patch.object(
+                HELPER, "_ROOT_BROKER_PATH", helper_path
+            ), mock.patch.object(HELPER, "_SOURCE_CORE_PATH", core_path), mock.patch.object(
+                HELPER, "_BOOTSTRAP_TRUST_ROOT", self.root
+            ), mock.patch.object(HELPER, "_BOOTSTRAP_TRUST_UID", self.uid), mock.patch.object(
+                HELPER.os, "geteuid", return_value=0
+            ):
+                loaded = HELPER._load_source_access_core()
+            self.assertTrue(marker_path.exists())
+            self.assertEqual(loaded.VALUE, 11)
+        finally:
+            if original_module is None:
+                sys.modules.pop(HELPER._SOURCE_CORE_MODULE_NAME, None)
+            else:
+                sys.modules[HELPER._SOURCE_CORE_MODULE_NAME] = original_module
 
     def test_root_and_interactive_terminal_are_required(self) -> None:
         with mock.patch.object(HELPER.os, "geteuid", return_value=1000):

--- a/README.md
+++ b/README.md
@@ -220,12 +220,13 @@ Running `aidevops security` with no arguments is the single command that covers 
 
 When a read guard identifies only a low-confidence source-code basename match, it emits a scoped request. A maintainer can run the displayed root-broker approval command. Approvals are bound to the exact runtime session, user, Git-tracked regular source path, approved content digest, and guard reason; they expire within 12 hours and never override private-key, environment-file, credential-store, hard-link, symlink, changed-content, or untracked-file denials. The plugin redirects the approved read to a root-controlled immutable snapshot of those bytes so the live path cannot be rebound after verification; revocation removes both receipt and snapshot.
 
-Privileged operations never execute the user-managed aidevops deployment as root. Resolve the immutable commit from the published, signed aidevops release metadata, substitute it for `<verified-release-commit>`, and let root fetch that reviewed broker directly over TLS. Never install the broker from the user-writable deployed tree.
+Privileged operations never execute the user-managed aidevops deployment as root. Resolve the immutable commit from the published, signed aidevops release metadata, substitute it for `<verified-release-commit>`, and let root fetch the reviewed broker files directly over TLS. Never install the broker from the user-writable deployed tree.
 
 ```bash
 sudo -k /usr/bin/install -d -o 0 -g 0 -m 0755 /etc/aidevops/source-access
+sudo -k -H /usr/bin/curl --disable --fail --location --proto '=https' --proto-redir '=https' --tlsv1.2 "https://raw.githubusercontent.com/marcusquinn/aidevops/<verified-release-commit>/.agents/scripts/source_access_core.py" --output /etc/aidevops/source-access/source_access_core.py
 sudo -k -H /usr/bin/curl --disable --fail --location --proto '=https' --proto-redir '=https' --tlsv1.2 "https://raw.githubusercontent.com/marcusquinn/aidevops/<verified-release-commit>/.agents/scripts/source-access-helper.py" --output /etc/aidevops/source-access/source-access-helper.py
-sudo /bin/chmod 0644 /etc/aidevops/source-access/source-access-helper.py
+sudo /bin/chmod 0644 /etc/aidevops/source-access/source_access_core.py /etc/aidevops/source-access/source-access-helper.py
 sudo -k /usr/bin/python3 /etc/aidevops/source-access/source-access-helper.py setup
 ```
 


### PR DESCRIPTION
## Summary

Split source-access policy from the privileged compatibility facade, simplify receipt validation, and validate both broker modules before exact-path import. The repository Qlty smell count falls from 58 to 46 while fail-closed approval bindings remain intact.

## Files Changed

- `.agents/plugins/opencode-aidevops/source-access-approval.mjs`: decomposed receipt validation and signature verification.
- `.agents/scripts/source-access-helper.py`: retained the CLI/approval facade and added privileged import and receipt-structure checks.
- `.agents/scripts/source_access_core.py`: extracted deterministic policy, request, trust, and key-material operations.
- `.agents/scripts/tests/test-source-access-helper.py`: expanded broker and privileged-bootstrap regression coverage.
- `README.md`: installs both root-owned broker modules.

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Python broker suite (14 tests, including malformed non-object receipts and privileged bootstrap cases), Node approval suite (7 tests), changed-file linters, npm typecheck, native macOS-arm64 and Linux-x64 Qlty threshold 46/49, regression 58 to 46, and new-file gate 0.

## Review

- Independent closeout review: CLEAN for final digest `7ab0961ac3be923f72258a60c98a966825e3280b9643f6cee445ffab1bd88a75` at head `b4da41461f595cadf73478a6a0ddd447ff76ba73`.
- Regression coverage verifies no local core code executes before trust validation, trusted macOS `/etc` → `/private/etc` ancestors remain supported, and non-object receipt JSON fails closed.

## Key Decisions

Keep a small compatibility facade and load the adjacent core by exact path only after root ownership, mode, lexical-ancestor, and canonical-ancestor checks.

Resolves #29622


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.228 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 3h 10m and 2,126,940 tokens on this with the user in an interactive session.
