### PR TITLE
GH#29616: docs: correct source-access release aggregation provenance

### DIFF
--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -283,10 +283,10 @@ Unpublished protected `v3.32.228`, merged remediation PR #29623, and subsequent
 maintained merges advanced `main`. The exact branch base is
 `6a894fa5f7a5e8ee9c919b28ce4392afb0a7f29d`.
 
-The pending corrective source-access aggregation re-reviews PR #29620 at
+Aggregation PR #29629 re-reviews PR #29620 at
 `72cca1de82cf9fd8a9e7b775f3b8dfdca8d74eca` and aggregation PR #29626 at
 `8fbcfb54a6e9e4897b44f3b79cc958065e8c385f`. GitHub auto-merge omitted the
-reviewed trailer block from that merge commit. The exact branch base is
+reviewed trailer block from the earlier merge commit. The exact branch base is
 `8fbcfb54a6e9e4897b44f3b79cc958065e8c385f`.
 
 Manual arbitrary-version package publication is intentionally unsupported. A

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -283,6 +283,12 @@ Unpublished protected `v3.32.228`, merged remediation PR #29623, and subsequent
 maintained merges advanced `main`. The exact branch base is
 `6a894fa5f7a5e8ee9c919b28ce4392afb0a7f29d`.
 
+The pending corrective source-access aggregation re-reviews PR #29620 at
+`72cca1de82cf9fd8a9e7b775f3b8dfdca8d74eca` and aggregation PR #29626 at
+`8fbcfb54a6e9e4897b44f3b79cc958065e8c385f`. GitHub auto-merge omitted the
+reviewed trailer block from that merge commit. The exact branch base is
+`8fbcfb54a6e9e4897b44f3b79cc958065e8c385f`.
+
 Manual arbitrary-version package publication is intentionally unsupported. A
 recovery operation must use an existing tag that passes the same verifier.
 


### PR DESCRIPTION
## Summary

Create a corrective exact-tip release aggregation after merge commit
`8fbcfb54a6e9e4897b44f3b79cc958065e8c385f` omitted the reviewed provenance
trailers from PR #29626.

## Release provenance

- Authorized source: PR #29620 at `72cca1de82cf9fd8a9e7b775f3b8dfdca8d74eca`.
- Prior aggregation: PR #29626 at `8fbcfb54a6e9e4897b44f3b79cc958065e8c385f`.
- Exact branch base: `8fbcfb54a6e9e4897b44f3b79cc958065e8c385f`.
- Corrective aggregation: PR #29629 at
  `f4cfe44dbc1c1a6de91e6732baf43c500129fb8d`.
- The final branch commit binds the corrective PR identity and both sources in
  one contiguous trailer block.
- The merge commit will receive that exact trailer block explicitly; auto-merge
  will not be used.
- Unpublished `v3.32.228` must be superseded rather than published directly.

## Files Changed

`.agents/reference/release-publication-controls.md`

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — changed-file lint, Markdown style, secret
  scan, `git diff --check`, exact source ancestry, and branch-base verification
  passed.

For #29616
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.228 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 7h 53m and 1,914,268 tokens on this with the user in an interactive session.