### PR TITLE
GH#29627: fix: prevent stale Qlty remediation issues

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs
@@ -215,8 +215,8 @@ test("the loaded verifier accepts only the exact signed receipt", () => {
     const signature = readFileSync(`${payloadPath}.sig`, "utf8");
     const receiptDir = join(stateDir, "approvals", String(uid));
     const snapshotDir = join(stateDir, "snapshots", String(uid));
-    mkdirSync(receiptDir, { recursive: true });
-    mkdirSync(snapshotDir, { recursive: true });
+    mkdirSync(receiptDir, { recursive: true, mode: 0o755 });
+    mkdirSync(snapshotDir, { recursive: true, mode: 0o755 });
     writeFileSync(payload.snapshot_path, readFileSync(source), { mode: 0o444 });
     writeFileSync(
       join(receiptDir, `${approvalId}.json`),

--- a/.agents/scripts/stats-quality-sweep.sh
+++ b/.agents/scripts/stats-quality-sweep.sh
@@ -180,6 +180,53 @@ run_daily_quality_sweep() {
 }
 
 #######################################
+# Verify that Qlty scanned the live remote default tip before creating issues.
+# The dashboard may still report a scan from a lagging service checkout, but
+# remediation issues must not claim that stale findings exist on the current
+# default branch.
+#
+# Arguments:
+#   $1 - repo slug (owner/repo)
+#   $2 - scanned repo path
+#######################################
+_qlty_scan_matches_remote_default() {
+	local repo_slug="$1"
+	local repo_path="$2"
+	local logfile="${LOGFILE:-/dev/null}"
+	local local_head
+	local remote_head
+	local worktree_state
+
+	if ! local_head=$(git -C "$repo_path" rev-parse --verify HEAD 2>/dev/null); then
+		printf '[stats] Qlty remediation: cannot resolve scanned HEAD for %s; skipping issue creation\n' \
+			"$repo_slug" >>"$logfile"
+		return 1
+	fi
+	if ! worktree_state=$(git -C "$repo_path" status --porcelain --untracked-files=normal 2>/dev/null); then
+		printf '[stats] Qlty remediation: cannot inspect scanned checkout for %s; skipping issue creation\n' \
+			"$repo_slug" >>"$logfile"
+		return 1
+	fi
+	if [[ -n "$worktree_state" ]]; then
+		printf '[stats] Qlty remediation: scanned checkout has local changes for %s; skipping uncommitted scan\n' \
+			"$repo_slug" >>"$logfile"
+		return 1
+	fi
+	if ! remote_head=$(gh api "repos/${repo_slug}/commits/HEAD" --jq '.sha // empty' 2>/dev/null); then
+		printf '[stats] Qlty remediation: cannot resolve remote default HEAD for %s; skipping issue creation\n' \
+			"$repo_slug" >>"$logfile"
+		return 1
+	fi
+	remote_head="${remote_head%%$'\n'*}"
+	if [[ -z "$remote_head" || "$local_head" != "$remote_head" ]]; then
+		printf '[stats] Qlty remediation: scanned HEAD %s does not match remote default %s for %s; skipping stale scan\n' \
+			"${local_head:0:12}" "${remote_head:0:12}" "$repo_slug" >>"$logfile"
+		return 1
+	fi
+	return 0
+}
+
+#######################################
 # Run Qlty CLI analysis on a repo.
 #
 # t2066: local SARIF smell count is the PRIMARY grade source. The Qlty Cloud
@@ -225,7 +272,8 @@ _sweep_qlty() {
 	# When repository-wide debt exceeds the configured absolute threshold, create
 	# bounded, per-file remediation issues from this same SARIF scan. The pulse
 	# handles dispatch deduplication, worker capacity, and active-PR collisions.
-	if [[ -n "$qlty_sarif" && "$qlty_smell_count" -gt 0 ]]; then
+	if [[ -n "$qlty_sarif" && "$qlty_smell_count" -gt 0 ]] &&
+		_qlty_scan_matches_remote_default "$repo_slug" "$repo_path"; then
 		local qlty_smell_threshold
 		qlty_smell_threshold=$(_repo_qlty_smell_threshold "$repo_path")
 		local issues_created
@@ -844,8 +892,8 @@ _simplification_issue_label_csv() {
 	# #aidevops:trust-boundary — NMR is an external-origin approval gate. When
 	# the authenticated sweep identity has repo write authority, the issue author
 	# is already trusted and should not be parked behind maintainer review.
-	if declare -F _gh_current_user_allows_repo_write >/dev/null 2>&1 \
-		&& _gh_current_user_allows_repo_write "$repo_slug"; then
+	if declare -F _gh_current_user_allows_repo_write >/dev/null 2>&1 &&
+		_gh_current_user_allows_repo_write "$repo_slug"; then
 		echo "[stats] Function-complexity-debt issues: trusted current user ${AIDEVOPS_GH_WRITE_PERMISSION_USER:-unknown} (${AIDEVOPS_GH_WRITE_PERMISSION_LEVEL:-unknown}) — skipping needs-maintainer-review" >>"$LOGFILE"
 	else
 		simplification_labels="${simplification_labels},needs-maintainer-review"

--- a/.agents/scripts/tests/test-source-access-helper.py
+++ b/.agents/scripts/tests/test-source-access-helper.py
@@ -243,9 +243,11 @@ class SourceAccessHelperTests(unittest.TestCase):
 
     def test_privileged_bootstrap_rejects_unsafe_core_before_execution(self) -> None:
         broker = self.root / "broker"
-        broker.mkdir()
+        broker.mkdir(mode=0o755)
+        broker.chmod(0o755)
         helper_path = broker / "source-access-helper.py"
         helper_path.write_text("# bootstrap fixture\n", encoding="utf-8")
+        helper_path.chmod(0o644)
         core_path = broker / "source_access_core.py"
         marker_path = self.root / "core-executed"
         core_source = (
@@ -300,10 +302,13 @@ class SourceAccessHelperTests(unittest.TestCase):
         canonical_root = self.root / "private" / "etc"
         broker = canonical_root / "aidevops" / "source-access"
         broker.mkdir(parents=True)
+        for trusted_directory in (canonical_root.parent, canonical_root, broker.parent, broker):
+            trusted_directory.chmod(0o755)
         alias_root = self.root / "etc"
         alias_root.symlink_to(Path("private") / "etc", target_is_directory=True)
         helper_path = alias_root / "aidevops" / "source-access" / "source-access-helper.py"
         helper_path.write_text("# bootstrap fixture\n", encoding="utf-8")
+        helper_path.chmod(0o644)
         core_path = broker / "source_access_core.py"
         marker_path = self.root / "aliased-core-executed"
         core_path.write_text(
@@ -312,6 +317,7 @@ class SourceAccessHelperTests(unittest.TestCase):
             "VALUE = 11\n",
             encoding="utf-8",
         )
+        core_path.chmod(0o644)
         original_module = sys.modules.get(HELPER._SOURCE_CORE_MODULE_NAME)
 
         try:

--- a/.agents/scripts/tests/test-stats-quality-sweep-qlty-cwd.sh
+++ b/.agents/scripts/tests/test-stats-quality-sweep-qlty-cwd.sh
@@ -21,10 +21,14 @@ TMP_REL_PARENT=$(mktemp -d)
 TMP_CDPATH_PARENT=$(mktemp -d)
 FAKE_BIN=$(mktemp -d)
 QLTY_PWD_FILE="${TMP_HOME}/qlty-pwd.txt"
+QLTY_CREATE_CALLS="${TMP_HOME}/qlty-create-calls.txt"
+LOCAL_HEAD="1111111111111111111111111111111111111111"
+REMOTE_HEAD="$LOCAL_HEAD"
+WORKTREE_STATE=""
 export HOME="$TMP_HOME"
 export LOGFILE="${TMP_HOME}/test.log"
 export QUALITY_SWEEP_STATE_DIR="${TMP_HOME}/state"
-export QLTY_PWD_FILE
+export QLTY_PWD_FILE QLTY_CREATE_CALLS LOCAL_HEAD REMOTE_HEAD WORKTREE_STATE
 PATH="${FAKE_BIN}:${PATH}"
 export PATH
 
@@ -51,13 +55,35 @@ exit 22
 CURL
 chmod +x "${FAKE_BIN}/curl"
 
+cat >"${FAKE_BIN}/git" <<'GIT'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *"rev-parse --verify HEAD"* ]]; then
+	printf '%s\n' "${LOCAL_HEAD:?}"
+	exit 0
+fi
+if [[ "$*" == *"status --porcelain --untracked-files=normal"* ]]; then
+	printf '%s' "${WORKTREE_STATE:-}"
+	exit 0
+fi
+exit 1
+GIT
+chmod +x "${FAKE_BIN}/git"
+
 # Source dependencies. stats-functions.sh expects shared-constants and
 # worker-lifecycle-common to be sourced first.
 source "${SCRIPTS_DIR}/shared-constants.sh"
 source "${SCRIPTS_DIR}/worker-lifecycle-common.sh"
 source "${SCRIPTS_DIR}/stats-functions.sh"
 
+gh() {
+	printf '%s\n' "$REMOTE_HEAD"
+	return 0
+}
+
 _create_simplification_issues() {
+	printf '%s\n' "called" >>"$QLTY_CREATE_CALLS"
+	printf '%s' "1"
 	return 0
 }
 
@@ -86,6 +112,38 @@ if [[ "$qlty_section" != *"scripts/example.sh"* ]]; then
 	printf '%s\n' "FAIL qlty section omitted SARIF file path"
 	exit 1
 fi
+
+if [[ "$(<"$QLTY_CREATE_CALLS")" != "called" ]]; then
+	printf '%s\n' "FAIL current default scan did not create remediation issues"
+	exit 1
+fi
+
+REMOTE_HEAD="2222222222222222222222222222222222222222"
+export REMOTE_HEAD
+_sweep_qlty "owner/repo" "$TMP_REPO" >/dev/null
+if [[ "$(<"$QLTY_CREATE_CALLS")" != "called" ]]; then
+	printf '%s\n' "FAIL stale default scan created remediation issues"
+	exit 1
+fi
+if ! grep -q 'skipping stale scan' "$LOGFILE"; then
+	printf '%s\n' "FAIL stale default scan did not record its skip reason"
+	exit 1
+fi
+
+REMOTE_HEAD="$LOCAL_HEAD"
+WORKTREE_STATE=" M scripts/example.sh"
+export REMOTE_HEAD WORKTREE_STATE
+_sweep_qlty "owner/repo" "$TMP_REPO" >/dev/null
+if [[ "$(<"$QLTY_CREATE_CALLS")" != "called" ]]; then
+	printf '%s\n' "FAIL dirty default scan created remediation issues"
+	exit 1
+fi
+if ! grep -q 'skipping uncommitted scan' "$LOGFILE"; then
+	printf '%s\n' "FAIL dirty default scan did not record its skip reason"
+	exit 1
+fi
+WORKTREE_STATE=""
+export WORKTREE_STATE
 
 mkdir -p "${TMP_REL_PARENT}/target-repo/.qlty" "${TMP_CDPATH_PARENT}/target-repo/.qlty"
 printf '%s\n' '[plugins]' >"${TMP_REL_PARENT}/target-repo/.qlty/qlty.toml"


### PR DESCRIPTION
## Summary

Prevent quality sweeps from opening remediation issues when their checkout is dirty or behind the live default branch. The reported source-access smells were already removed by PR #29623; the same stale 58-smell snapshot was used to create #29627 after the repository had fallen to 46 smells.

Also make the signed source-access Python and Node fixtures deterministic under group-writable umasks discovered while validating the original issue's focused commands.

## Files Changed

- `.agents/scripts/stats-quality-sweep.sh`: require a clean scan checkout whose HEAD matches GitHub's live default HEAD before creating remediation issues.
- `.agents/scripts/tests/test-stats-quality-sweep-qlty-cwd.sh`: cover current, stale, and dirty scan states.
- `.agents/scripts/tests/test-source-access-helper.py`: create trusted bootstrap fixtures with explicit safe modes.
- `.agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs`: create trusted receipt directories with explicit safe modes.

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — focused shell, Python, and Node suites pass; all 541 OpenCode plugin tests pass; `npm run typecheck` and changed-file linters pass.

## Quality Evidence

- Qlty smell threshold: 46 actual / 49 allowed.
- Qlty regression: 46 base / 46 head / delta 0.
- `.agents/scripts/source-access-helper.py`: 0 Qlty smells.
- Changed files: 0 Qlty smells.
- Exact-head closeout review bundle `7f8978d9b08d9055912119a67798b6e34df52199180bb55f3392bfa871bc6600`: no material defect found.

## Key Decisions

Keep dashboard telemetry available from stale checkouts, but fail closed before issue creation unless the scan is clean and based on the current remote default tip.

Resolves #29627

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.228 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 23m and 269,463 tokens on this as a headless worker. Overall, 26m since this issue was created.
