### PR TITLE
GH#29631: feat: add read-only Buzz team-interface adapter

### DIFF
--- a/.agents/schemas/team-interface/runtime-v1.schema.json
+++ b/.agents/schemas/team-interface/runtime-v1.schema.json
@@ -108,6 +108,86 @@
         "owner_review_required": {"type": "boolean"}
       }
     },
+    "inventory_community": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["community_id", "display_label", "availability"],
+      "properties": {
+        "community_id": {"$ref": "#/$defs/core_stable_id"},
+        "display_label": {"type": "string", "minLength": 1, "maxLength": 255},
+        "availability": {"enum": ["available", "degraded", "unavailable", "unknown"]}
+      }
+    },
+    "inventory_agent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["agent_id", "display_label", "agent_kind", "is_builtin", "availability"],
+      "properties": {
+        "agent_id": {"$ref": "#/$defs/core_stable_id"},
+        "display_label": {"type": "string", "minLength": 1, "maxLength": 255},
+        "agent_kind": {"enum": ["definition", "instance"]},
+        "is_builtin": {"type": "boolean"},
+        "availability": {"enum": ["available", "degraded", "unavailable", "unknown"]},
+        "community_ref": {"$ref": "#/$defs/core_stable_id"},
+        "runtime_ref": {"$ref": "#/$defs/core_stable_id"},
+        "team_ref": {"$ref": "#/$defs/core_stable_id"}
+      }
+    },
+    "inventory_team": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["team_id", "display_label", "is_builtin", "member_refs", "availability"],
+      "properties": {
+        "team_id": {"$ref": "#/$defs/core_stable_id"},
+        "display_label": {"type": "string", "minLength": 1, "maxLength": 255},
+        "is_builtin": {"type": "boolean"},
+        "member_refs": {
+          "type": "array",
+          "maxItems": 1000,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/core_stable_id"}
+        },
+        "availability": {"enum": ["available", "degraded", "unavailable", "unknown"]}
+      }
+    },
+    "inventory_runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["runtime_id", "display_label", "runtime_kind", "availability"],
+      "properties": {
+        "runtime_id": {"$ref": "#/$defs/core_stable_id"},
+        "display_label": {"type": "string", "minLength": 1, "maxLength": 255},
+        "runtime_kind": {"enum": ["builtin", "preset", "custom", "unknown"]},
+        "availability": {"enum": ["available", "degraded", "unavailable", "unknown"]}
+      }
+    },
+    "provider_inventory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["communities", "agents", "teams", "runtimes"],
+      "properties": {
+        "communities": {
+          "type": "array",
+          "maxItems": 1000,
+          "items": {"$ref": "#/$defs/inventory_community"}
+        },
+        "agents": {
+          "type": "array",
+          "maxItems": 1000,
+          "items": {"$ref": "#/$defs/inventory_agent"}
+        },
+        "teams": {
+          "type": "array",
+          "maxItems": 1000,
+          "items": {"$ref": "#/$defs/inventory_team"}
+        },
+        "runtimes": {
+          "type": "array",
+          "maxItems": 1000,
+          "items": {"$ref": "#/$defs/inventory_runtime"}
+        }
+      }
+    },
     "adapter_observation_document": {
       "type": "object",
       "additionalProperties": false,
@@ -146,7 +226,8 @@
           "maxItems": 100,
           "uniqueItems": true,
           "items": {"$ref": "#/$defs/registered_reference"}
-        }
+        },
+        "inventory": {"$ref": "#/$defs/provider_inventory"}
       }
     },
     "runtime_state_document": {

--- a/.agents/scripts/team-interface-adapter-runtime.mjs
+++ b/.agents/scripts/team-interface-adapter-runtime.mjs
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
-import {assertUniqueIds, canonicalJson, deepFreeze, TeamInterfaceError} from "./team-interface-common.mjs";
+import {
+  assertUniqueIds,
+  canonicalJson,
+  compareCanonicalText,
+  deepFreeze,
+  TeamInterfaceError,
+} from "./team-interface-common.mjs";
 import {requireValid} from "./team-interface-validators.mjs";
 
 function adapterContext(documents, selection, abortSignal) {
@@ -34,6 +40,49 @@ function assertCapabilityBinding(observation, adapter) {
   }
 }
 
+function assertCanonicalIds(records, property, label) {
+  assertUniqueIds(records, property, label);
+  const actual = records.map((record) => record[property]);
+  const expected = [...actual].sort(compareCanonicalText);
+  if (canonicalJson(actual) !== canonicalJson(expected)) {
+    throw new TeamInterfaceError("adapter_inventory_order", `${label} is not in canonical ID order`);
+  }
+}
+
+function requireInventoryRef(ref, ids, label) {
+  if (ref !== undefined && !ids.has(ref)) {
+    throw new TeamInterfaceError("adapter_inventory_reference", `${label} does not resolve`);
+  }
+}
+
+function assertInventoryBinding(observation) {
+  if (!observation.inventory) return;
+  const {communities, agents, teams, runtimes} = observation.inventory;
+  assertCanonicalIds(communities, "community_id", "adapter community inventory");
+  assertCanonicalIds(agents, "agent_id", "adapter agent inventory");
+  assertCanonicalIds(teams, "team_id", "adapter team inventory");
+  assertCanonicalIds(runtimes, "runtime_id", "adapter runtime inventory");
+
+  const communityIds = new Set(communities.map(({community_id: id}) => id));
+  const agentIds = new Set(agents.map(({agent_id: id}) => id));
+  const teamIds = new Set(teams.map(({team_id: id}) => id));
+  const runtimeIds = new Set(runtimes.map(({runtime_id: id}) => id));
+  for (const agent of agents) {
+    requireInventoryRef(agent.community_ref, communityIds, "adapter agent community reference");
+    requireInventoryRef(agent.runtime_ref, runtimeIds, "adapter agent runtime reference");
+    requireInventoryRef(agent.team_ref, teamIds, "adapter agent team reference");
+  }
+  for (const team of teams) {
+    const expected = [...team.member_refs].sort(compareCanonicalText);
+    if (canonicalJson(team.member_refs) !== canonicalJson(expected)) {
+      throw new TeamInterfaceError("adapter_inventory_order", "adapter team member references are not canonical");
+    }
+    for (const memberRef of team.member_refs) {
+      requireInventoryRef(memberRef, agentIds, "adapter team member reference");
+    }
+  }
+}
+
 function assertObservationBinding(observation, adapter) {
   for (const property of ["adapter_id", "provider_id", "adapter_version"]) {
     if (observation[property] !== adapter[property]) {
@@ -41,6 +90,7 @@ function assertObservationBinding(observation, adapter) {
     }
   }
   assertCapabilityBinding(observation, adapter);
+  assertInventoryBinding(observation);
 }
 
 export function observationMatchesAdapterDefinition(observation, adapter) {

--- a/.agents/scripts/team-interface-adapters.mjs
+++ b/.agents/scripts/team-interface-adapters.mjs
@@ -2,9 +2,10 @@
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
 import {deepFreezeDefinition, validateAdapterDefinition} from "./team-interface-adapter-validation.mjs";
+import {buzzAdapter} from "./team-interface-buzz-adapter.mjs";
 import {compareCanonicalText} from "./team-interface-common.mjs";
 
-const BUILTIN_ADAPTERS = Object.freeze([]);
+const BUILTIN_ADAPTERS = Object.freeze([buzzAdapter]);
 
 export {validateAdapterDefinition} from "./team-interface-adapter-validation.mjs";
 

--- a/.agents/scripts/team-interface-buzz-adapter.mjs
+++ b/.agents/scripts/team-interface-buzz-adapter.mjs
@@ -1,0 +1,532 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {createHash} from "node:crypto";
+import {execFile as execFileCallback} from "node:child_process";
+import {constants} from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {promisify} from "node:util";
+import {compareCanonicalText} from "./team-interface-common.mjs";
+
+const execFile = promisify(execFileCallback);
+const ADAPTER_VERSION = "1.0.0";
+const SUPPORTED_PROVIDER_VERSION = "0.5.5";
+const MAX_SOURCE_BYTES = 4 * 1024 * 1024;
+const MAX_RECORDS = 1000;
+const MAX_STORAGE_ENTRIES = 512;
+const COMMUNITIES_KEY = "buzz-communities";
+const COMMUNITY_QUERY = `SELECT hex(value) FROM ItemTable WHERE key = '${COMMUNITIES_KEY}' LIMIT 1;`;
+
+const CAPABILITIES = Object.freeze([
+  Object.freeze({
+    capability_id: "capability.buzz.installation.read",
+    resource_kinds: Object.freeze(["other"]),
+    operations: Object.freeze(["discover", "read"]),
+    availability: "unknown",
+    owner_review_required: false,
+  }),
+  Object.freeze({
+    capability_id: "capability.buzz.communities.read",
+    resource_kinds: Object.freeze(["community"]),
+    operations: Object.freeze(["discover", "read"]),
+    availability: "unknown",
+    owner_review_required: false,
+  }),
+  Object.freeze({
+    capability_id: "capability.buzz.agents.read",
+    resource_kinds: Object.freeze(["other"]),
+    operations: Object.freeze(["discover", "read"]),
+    availability: "unknown",
+    owner_review_required: false,
+  }),
+  Object.freeze({
+    capability_id: "capability.buzz.teams.read",
+    resource_kinds: Object.freeze(["group"]),
+    operations: Object.freeze(["discover", "read"]),
+    availability: "unknown",
+    owner_review_required: false,
+  }),
+  Object.freeze({
+    capability_id: "capability.buzz.runtimes.read",
+    resource_kinds: Object.freeze(["other"]),
+    operations: Object.freeze(["discover", "read"]),
+    availability: "unknown",
+    owner_review_required: false,
+  }),
+]);
+
+function abortIfRequested(signal) {
+  if (signal?.aborted) throw new DOMException("The operation was aborted", "AbortError");
+}
+
+function stableId(category, externalIdentity) {
+  const digest = createHash("sha256").update(externalIdentity).digest("hex").slice(0, 24);
+  return `${category}.buzz.${digest}`;
+}
+
+function requireString(value, label, maxLength = 255) {
+  if (typeof value !== "string" || value.length === 0 || value.length > maxLength || /[\u0000-\u001f]/u.test(value)) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value;
+}
+
+function optionalString(value, label, maxLength = 1024) {
+  if (value === undefined || value === null || value === "") return undefined;
+  return requireString(value, label, maxLength);
+}
+
+async function existingStats(filePath) {
+  try {
+    return await fs.lstat(filePath);
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function assertNoSymlinkComponents(filePath) {
+  const absolute = path.resolve(filePath);
+  const parsed = path.parse(absolute);
+  let current = parsed.root;
+  for (const component of absolute.slice(parsed.root.length).split(path.sep).filter(Boolean)) {
+    current = path.join(current, component);
+    const stats = await existingStats(current);
+    if (!stats) break;
+    if (stats.isSymbolicLink()) throw new Error("unsafe source path");
+  }
+}
+
+function assertTrustedStats(stats, {privateFile}) {
+  if (!stats.isFile()) throw new Error("source is not a regular file");
+  const currentUid = typeof process.getuid === "function" ? process.getuid() : stats.uid;
+  if (privateFile) {
+    if (stats.uid !== currentUid || (stats.mode & 0o077) !== 0) throw new Error("private source is insecure");
+  } else if (![0, currentUid].includes(stats.uid) || (stats.mode & 0o022) !== 0) {
+    throw new Error("public source is insecure");
+  }
+}
+
+async function readTrustedFile(filePath, {label, maxBytes = MAX_SOURCE_BYTES, privateFile = true, signal}) {
+  abortIfRequested(signal);
+  await assertNoSymlinkComponents(filePath);
+  let handle;
+  try {
+    handle = await fs.open(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  }
+  try {
+    const opened = await handle.stat();
+    assertTrustedStats(opened, {privateFile});
+    if (opened.size > maxBytes) throw new Error(`${label} exceeds its size limit`);
+    const bytes = await handle.readFile({signal});
+    if (bytes.length > maxBytes) throw new Error(`${label} exceeds its size limit`);
+    const current = await existingStats(filePath);
+    if (!current || current.isSymbolicLink() || current.dev !== opened.dev || current.ino !== opened.ino) {
+      throw new Error(`${label} changed while it was read`);
+    }
+    abortIfRequested(signal);
+    return bytes;
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readTrustedJson(filePath, options) {
+  const bytes = await readTrustedFile(filePath, options);
+  if (bytes === null) return null;
+  try {
+    return JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new Error(`${options.label} is malformed`);
+  }
+}
+
+function defaultPaths(homeDirectory) {
+  const applicationData = path.join(homeDirectory, "Library/Application Support/xyz.block.buzz.app");
+  return Object.freeze({
+    app: "/Applications/Buzz.app",
+    infoPlist: "/Applications/Buzz.app/Contents/Info.plist",
+    agents: path.join(applicationData, "agents/managed-agents.json"),
+    teams: path.join(applicationData, "agents/teams.json"),
+    webkit: path.join(homeDirectory, "Library/WebKit/xyz.block.buzz.app/WebsiteData"),
+  });
+}
+
+async function defaultReadVersion(paths, signal) {
+  const bytes = await readTrustedFile(paths.infoPlist, {
+    label: "Buzz application metadata",
+    maxBytes: 1024 * 1024,
+    privateFile: false,
+    signal,
+  });
+  if (bytes === null) return null;
+  const text = bytes.toString("utf8");
+  const xmlMatch = text.match(/<key>CFBundleShortVersionString<\/key>\s*<string>([^<]{1,100})<\/string>/u);
+  if (xmlMatch) return requireString(xmlMatch[1], "Buzz version", 100);
+  const {stdout} = await execFile("/usr/bin/plutil", [
+    "-extract", "CFBundleShortVersionString", "raw", "-o", "-", paths.infoPlist,
+  ], {encoding: "utf8", maxBuffer: 4096, signal});
+  return requireString(stdout.trim(), "Buzz version", 100);
+}
+
+function decodeWebKitValue(hexValue) {
+  if (typeof hexValue !== "string" || hexValue.length > MAX_SOURCE_BYTES * 2 || !/^[0-9a-f]*$/iu.test(hexValue)) {
+    throw new Error("community store value is malformed");
+  }
+  const bytes = Buffer.from(hexValue, "hex");
+  if (bytes.length % 2 === 0 && bytes.some((byte, index) => index % 2 === 1 && byte === 0)) {
+    return bytes.toString("utf16le").replace(/\0+$/u, "");
+  }
+  return bytes.toString("utf8");
+}
+
+async function collectStorageDatabases(root, signal) {
+  abortIfRequested(signal);
+  const rootStats = await existingStats(root);
+  if (!rootStats) return [];
+  if (!rootStats.isDirectory() || rootStats.isSymbolicLink()) throw new Error("community storage root is unsafe");
+  const databases = [];
+  let visited = 0;
+  async function visit(directory, depth) {
+    abortIfRequested(signal);
+    if (depth > 8) throw new Error("community storage traversal is too deep");
+    const entries = await fs.readdir(directory, {withFileTypes: true});
+    entries.sort((left, right) => compareCanonicalText(left.name, right.name));
+    for (const entry of entries) {
+      visited += 1;
+      if (visited > MAX_STORAGE_ENTRIES) throw new Error("community storage traversal is too large");
+      const entryPath = path.join(directory, entry.name);
+      const stats = await fs.lstat(entryPath);
+      if (stats.isSymbolicLink()) throw new Error("community storage contains a symbolic link");
+      if (stats.isDirectory()) await visit(entryPath, depth + 1);
+      else if (stats.isFile() && entry.name === "localstorage.sqlite3") databases.push(entryPath);
+    }
+  }
+  await visit(root, 0);
+  return databases.sort(compareCanonicalText);
+}
+
+async function defaultReadCommunities(paths, signal) {
+  const databases = await collectStorageDatabases(paths.webkit, signal);
+  if (databases.length === 0) return null;
+  for (const database of databases) {
+    await readTrustedFile(database, {
+      label: "Buzz community store",
+      maxBytes: 64 * 1024 * 1024,
+      privateFile: true,
+      signal,
+    });
+    const {stdout} = await execFile("sqlite3", ["-readonly", "-batch", "-noheader", database, COMMUNITY_QUERY], {
+      encoding: "utf8",
+      maxBuffer: MAX_SOURCE_BYTES * 2 + 1,
+      signal,
+    });
+    const encoded = stdout.trim();
+    if (!encoded) continue;
+    let records;
+    try {
+      records = JSON.parse(decodeWebKitValue(encoded));
+    } catch {
+      throw new Error("Buzz community store is malformed");
+    }
+    return records;
+  }
+  return [];
+}
+
+function requireRecordArray(value, label) {
+  if (!Array.isArray(value) || value.length > MAX_RECORDS) throw new TypeError(`${label} is invalid`);
+  for (const record of value) {
+    if (!record || typeof record !== "object" || Array.isArray(record)) throw new TypeError(`${label} is invalid`);
+  }
+  return value;
+}
+
+function normalizeCommunities(records) {
+  const relayToCommunity = new Map();
+  const communityIds = new Set();
+  const communities = requireRecordArray(records, "Buzz communities").map((record) => {
+    const externalId = requireString(record.id, "Buzz community identity", 1024);
+    const relayUrl = requireString(record.relayUrl, "Buzz community relay", 2048);
+    const communityId = stableId("community", externalId);
+    const normalizedRelay = relayUrl.replace(/\/$/u, "");
+    if (communityIds.has(communityId) || relayToCommunity.has(normalizedRelay)) {
+      throw new TypeError("Buzz community identity is duplicated");
+    }
+    communityIds.add(communityId);
+    relayToCommunity.set(normalizedRelay, communityId);
+    return {
+      community_id: communityId,
+      display_label: requireString(record.name, "Buzz community label"),
+      availability: "available",
+    };
+  }).sort((left, right) => compareCanonicalText(left.community_id, right.community_id));
+  return {communities, relayToCommunity};
+}
+
+function normalizeTeamIdentities(records) {
+  const teamIds = new Map();
+  const source = requireRecordArray(records, "Buzz teams");
+  for (const record of source) {
+    const externalId = requireString(record.id, "Buzz team identity", 1024);
+    if (teamIds.has(externalId)) throw new TypeError("Buzz team identity is duplicated");
+    teamIds.set(externalId, stableId("team", externalId));
+  }
+  return {source, teamIds};
+}
+
+function processAvailable(pid, isProcessAlive) {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
+  try {
+    return Boolean(isProcessAlive(pid));
+  } catch {
+    return false;
+  }
+}
+
+function normalizeAgents(records, {isProcessAlive, relayToCommunity, teamIds, teamsKnown}) {
+  const source = requireRecordArray(records, "Buzz managed agents");
+  const runtimeSources = new Map();
+  const deployedByTeam = new Map();
+  const agentIds = new Set();
+  const agents = source.map((record) => {
+    const pubkey = optionalString(record.pubkey, "Buzz agent public identity", 1024);
+    const definitionId = optionalString(record.slug, "Buzz agent definition identity", 1024)
+      || optionalString(record.persona_id, "Buzz agent definition identity", 1024);
+    const externalId = pubkey || definitionId;
+    if (!externalId) throw new TypeError("Buzz agent identity is missing");
+    const agentKind = pubkey ? "instance" : "definition";
+    const agentId = stableId(`agent.${agentKind}`, externalId);
+    if (agentIds.has(agentId)) throw new TypeError("Buzz agent identity is duplicated");
+    agentIds.add(agentId);
+    const agent = {
+      agent_id: agentId,
+      display_label: requireString(record.display_name || record.name, "Buzz agent label"),
+      agent_kind: agentKind,
+      is_builtin: record.is_builtin === true,
+      availability: agentKind === "definition"
+        ? (record.is_active === false ? "unavailable" : "available")
+        : (processAvailable(record.runtime_pid, isProcessAlive) ? "available" : "unavailable"),
+    };
+    const relayUrl = optionalString(record.relay_url, "Buzz agent relay", 2048)?.replace(/\/$/u, "");
+    if (relayUrl && relayToCommunity.has(relayUrl)) agent.community_ref = relayToCommunity.get(relayUrl);
+    const runtime = optionalString(record.runtime, "Buzz runtime identity", 1024);
+    if (runtime) {
+      const runtimeRef = stableId("runtime", runtime);
+      agent.runtime_ref = runtimeRef;
+      const current = runtimeSources.get(runtimeRef) || {externalId: runtime, available: false};
+      current.available ||= agent.availability === "available";
+      runtimeSources.set(runtimeRef, current);
+    }
+    const sourceTeam = optionalString(record.team_id, "Buzz team relationship", 1024);
+    if (sourceTeam && teamsKnown && !teamIds.has(sourceTeam)) {
+      throw new TypeError("Buzz agent team relationship does not resolve");
+    }
+    if (sourceTeam && teamIds.has(sourceTeam)) {
+      agent.team_ref = teamIds.get(sourceTeam);
+      if (agentKind === "instance") {
+        const members = deployedByTeam.get(agent.team_ref) || [];
+        members.push(agentId);
+        deployedByTeam.set(agent.team_ref, members);
+      }
+    }
+    return agent;
+  }).sort((left, right) => compareCanonicalText(left.agent_id, right.agent_id));
+  return {agents, deployedByTeam, runtimeSources};
+}
+
+function normalizeTeams(source, teamIds, deployedByTeam, availability = "available") {
+  return source.map((record) => {
+    const teamId = teamIds.get(record.id);
+    return {
+      team_id: teamId,
+      display_label: requireString(record.name, "Buzz team label"),
+      is_builtin: record.is_builtin === true,
+      member_refs: [...(deployedByTeam.get(teamId) || [])].sort(compareCanonicalText),
+      availability,
+    };
+  }).sort((left, right) => compareCanonicalText(left.team_id, right.team_id));
+}
+
+function normalizeRuntimes(runtimeSources) {
+  return [...runtimeSources.entries()].map(([runtimeId, source]) => ({
+    runtime_id: runtimeId,
+    display_label: requireString(source.externalId, "Buzz runtime label"),
+    runtime_kind: "unknown",
+    availability: source.available ? "available" : "unavailable",
+  })).sort((left, right) => compareCanonicalText(left.runtime_id, right.runtime_id));
+}
+
+function capabilityObservation(capability, availability) {
+  return {
+    capability_id: capability.capability_id,
+    resource_kinds: [...capability.resource_kinds],
+    operations: [...capability.operations],
+    availability,
+    owner_review_required: capability.owner_review_required,
+  };
+}
+
+async function sourceResult(reader) {
+  try {
+    const value = await reader();
+    return value === null ? {availability: "unavailable", value: null} : {availability: "available", value};
+  } catch (error) {
+    if (error?.name === "AbortError") throw error;
+    return {availability: "degraded", value: null};
+  }
+}
+
+function overallAvailability(states) {
+  if (states.every((state) => state === "available")) return "available";
+  if (states.every((state) => state === "unavailable")) return "unavailable";
+  return "degraded";
+}
+
+function unavailableObservation(now, providerVersion = "unknown") {
+  return {
+    schema_version: 1,
+    document_type: "adapter_observation",
+    adapter_id: "adapter.buzz",
+    provider_id: "buzz",
+    adapter_version: ADAPTER_VERSION,
+    provider_version: providerVersion,
+    availability: "unavailable",
+    capabilities: CAPABILITIES.map((capability) => capabilityObservation(capability, "unavailable")),
+    compatibility: {state: "unsupported", reference: "compatibility:buzz-macos-only"},
+    observed_at: now,
+    evidence_refs: ["evidence:buzz-read-only-adapter"],
+    inventory: {communities: [], agents: [], teams: [], runtimes: []},
+  };
+}
+
+export function createBuzzAdapter(dependencies = {}) {
+  const homeDirectory = dependencies.homeDirectory || os.homedir();
+  const paths = Object.freeze({...defaultPaths(homeDirectory), ...(dependencies.paths || {})});
+  const platform = dependencies.platform || process.platform;
+  const now = dependencies.now || (() => new Date().toISOString());
+  const readVersion = dependencies.readVersion || defaultReadVersion;
+  const readCommunities = dependencies.readCommunities || defaultReadCommunities;
+  const readAgents = dependencies.readAgents || ((signal) => readTrustedJson(paths.agents, {
+    label: "Buzz managed-agent store", privateFile: true, signal,
+  }));
+  const readTeams = dependencies.readTeams || ((signal) => readTrustedJson(paths.teams, {
+    label: "Buzz team store", privateFile: true, signal,
+  }));
+  const isProcessAlive = dependencies.isProcessAlive || ((pid) => {
+    process.kill(pid, 0);
+    return true;
+  });
+
+  async function observe(context) {
+    const signal = context.runtime.abort_signal;
+    abortIfRequested(signal);
+    const observedAt = now();
+    if (platform !== "darwin") return unavailableObservation(observedAt);
+    const appStats = await existingStats(paths.app);
+    if (!appStats) return unavailableObservation(observedAt);
+    if (!appStats.isDirectory() || appStats.isSymbolicLink()) return unavailableObservation(observedAt);
+
+    const versionResult = await sourceResult(() => readVersion(paths, signal));
+    const providerVersion = versionResult.value || "unknown";
+    const [communityResult, agentResult, teamResult] = await Promise.all([
+      sourceResult(() => readCommunities(paths, signal)),
+      sourceResult(() => readAgents(signal)),
+      sourceResult(() => readTeams(signal)),
+    ]);
+    abortIfRequested(signal);
+
+    let communityState = communityResult.availability;
+    let agentState = agentResult.availability;
+    let teamState = teamResult.availability;
+    let runtimeState = agentState;
+    let communities = [];
+    let agents = [];
+    let teams = [];
+    let runtimes = [];
+    let relayToCommunity = new Map();
+    let teamIds = new Map();
+    let teamSource = [];
+    let deployedByTeam = new Map();
+    if (communityState === "available") {
+      try {
+        ({communities, relayToCommunity} = normalizeCommunities(communityResult.value));
+      } catch {
+        communityState = "degraded";
+      }
+    }
+    if (teamState === "available") {
+      try {
+        ({source: teamSource, teamIds} = normalizeTeamIdentities(teamResult.value));
+      } catch {
+        teamState = "degraded";
+      }
+    }
+    if (agentState === "available") {
+      try {
+        const normalized = normalizeAgents(agentResult.value, {
+          isProcessAlive,
+          relayToCommunity,
+          teamIds,
+          teamsKnown: teamState === "available",
+        });
+        agents = normalized.agents;
+        deployedByTeam = normalized.deployedByTeam;
+        runtimes = normalizeRuntimes(normalized.runtimeSources);
+      } catch {
+        agentState = "degraded";
+        runtimeState = "degraded";
+        agents = [];
+        runtimes = [];
+      }
+    }
+    if (teamState === "available") {
+      const relationshipAvailability = agentState === "available" ? "available" : "degraded";
+      teams = normalizeTeams(teamSource, teamIds, deployedByTeam, relationshipAvailability);
+      if (relationshipAvailability === "degraded") teamState = "degraded";
+    }
+
+    const installationState = versionResult.availability === "available" ? "available" : "degraded";
+    const states = [installationState, communityState, agentState, teamState, runtimeState];
+    const compatibilityState = providerVersion === SUPPORTED_PROVIDER_VERSION ? "compatible" : "unknown";
+    return {
+      schema_version: 1,
+      document_type: "adapter_observation",
+      adapter_id: "adapter.buzz",
+      provider_id: "buzz",
+      adapter_version: ADAPTER_VERSION,
+      provider_version: providerVersion,
+      availability: overallAvailability(states),
+      capabilities: CAPABILITIES.map((capability, index) => capabilityObservation(capability, states[index])),
+      compatibility: {
+        state: compatibilityState,
+        reference: providerVersion === SUPPORTED_PROVIDER_VERSION
+          ? "compatibility:buzz-0.5.5"
+          : "compatibility:buzz-version-unknown",
+      },
+      observed_at: observedAt,
+      evidence_refs: ["evidence:buzz-read-only-adapter"],
+      inventory: {communities, agents, teams, runtimes},
+    };
+  }
+
+  return {
+    adapter_id: "adapter.buzz",
+    provider_id: "buzz",
+    adapter_version: ADAPTER_VERSION,
+    capabilities: CAPABILITIES.map((capability) => ({
+      ...capability,
+      operations: [...capability.operations],
+      resource_kinds: [...capability.resource_kinds],
+    })),
+    detect: observe,
+    status: observe,
+  };
+}
+
+export const buzzAdapter = createBuzzAdapter();

--- a/.agents/scripts/tests/fixtures/team-interface/buzz-managed-agents.json
+++ b/.agents/scripts/tests/fixtures/team-interface/buzz-managed-agents.json
@@ -1,0 +1,50 @@
+[
+  {
+    "pubkey": "",
+    "name": "Build Plus Definition",
+    "display_name": "Build+",
+    "slug": "build-plus-aidevops",
+    "runtime": "opencode",
+    "is_builtin": true,
+    "is_active": true,
+    "private_key_nsec": "nsec-fixture-secret-canary",
+    "auth_tag": "auth-fixture-secret-canary",
+    "env_vars": {"FIXTURE_SECRET": "env-fixture-secret-canary"},
+    "system_prompt": "prompt-fixture-secret-canary",
+    "agent_command": "/private/fixture/command-canary",
+    "agent_args": ["--private-arg-canary"],
+    "provider_binary_path": "/private/fixture/provider-canary",
+    "last_error": "error-fixture-secret-canary",
+    "persona_team_dir": "/private/fixture/team-canary"
+  },
+  {
+    "pubkey": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "name": "Builder Instance",
+    "display_name": "Builder",
+    "relay_url": "wss://relay.example.test",
+    "runtime": "opencode",
+    "team_id": "team-alpha",
+    "runtime_pid": 4242,
+    "is_builtin": false,
+    "is_active": true,
+    "private_key_nsec": "nsec-instance-secret-canary",
+    "auth_tag": "auth-instance-secret-canary",
+    "model": "model-private-canary",
+    "provider": "provider-private-canary",
+    "last_error": "error-instance-private-canary",
+    "log_path": "/private/fixture/log-canary"
+  },
+  {
+    "pubkey": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "name": "Stopped Instance",
+    "relay_url": "wss://relay.example.test/",
+    "runtime": null,
+    "team_id": null,
+    "runtime_pid": 5252,
+    "is_builtin": false,
+    "is_active": true,
+    "settings_ref": "settings:private-canary",
+    "source_dir": "/private/fixture/source-canary",
+    "repo_root": "/private/fixture/repo-canary"
+  }
+]

--- a/.agents/scripts/tests/fixtures/team-interface/buzz-teams.json
+++ b/.agents/scripts/tests/fixtures/team-interface/buzz-teams.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": "builtin-team:welcome",
+    "name": "Welcome Team",
+    "description": "Fixture built-in team",
+    "instructions": "instructions-private-canary",
+    "persona_ids": ["build-plus-aidevops"],
+    "is_builtin": true,
+    "source_dir": "/private/fixture/builtin-team-canary",
+    "symlink_target": "/private/fixture/symlink-canary"
+  },
+  {
+    "id": "team-alpha",
+    "name": "Alpha Team",
+    "description": "Fixture custom team",
+    "instructions": "instructions-alpha-private-canary",
+    "persona_ids": ["build-plus-aidevops"],
+    "is_builtin": false,
+    "source_dir": "/private/fixture/custom-team-canary"
+  }
+]

--- a/.agents/scripts/tests/test-team-interface-buzz-adapter.mjs
+++ b/.agents/scripts/tests/test-team-interface-buzz-adapter.mjs
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {fileURLToPath} from "node:url";
+import {createBuzzAdapter} from "../team-interface-buzz-adapter.mjs";
+import {createAdapterRegistry} from "../team-interface-adapters.mjs";
+import {createRuntimeValidators} from "../team-interface-validators.mjs";
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const fixtureDirectory = path.join(testDirectory, "fixtures/team-interface");
+const temporaryParent = process.env.AIDEVOPS_TEMP_DIR
+  || path.join(os.homedir(), ".aidevops/.agent-workspace/tmp");
+
+function copyPrivate(source, destination) {
+  fs.copyFileSync(source, destination);
+  fs.chmodSync(destination, 0o600);
+}
+
+function context(signal = new AbortController().signal) {
+  return Object.freeze({runtime: Object.freeze({abort_signal: signal, read_only: true})});
+}
+
+function capability(observation, suffix) {
+  return observation.capabilities.find(({capability_id: id}) => id.includes(suffix));
+}
+
+fs.mkdirSync(temporaryParent, {mode: 0o700, recursive: true});
+const sandbox = fs.mkdtempSync(path.join(temporaryParent, "team-interface-buzz-"));
+try {
+  const app = path.join(sandbox, "Buzz.app");
+  const data = path.join(sandbox, "data");
+  const agents = path.join(data, "managed-agents.json");
+  const teams = path.join(data, "teams.json");
+  const infoPlist = path.join(app, "Contents/Info.plist");
+  const webkit = path.join(sandbox, "WebsiteData");
+  fs.mkdirSync(path.dirname(infoPlist), {mode: 0o700, recursive: true});
+  fs.mkdirSync(data, {mode: 0o700, recursive: true});
+  fs.mkdirSync(webkit, {mode: 0o700, recursive: true});
+  fs.writeFileSync(infoPlist, "fixture metadata", {mode: 0o600});
+  copyPrivate(path.join(fixtureDirectory, "buzz-managed-agents.json"), agents);
+  copyPrivate(path.join(fixtureDirectory, "buzz-teams.json"), teams);
+
+  let versionReads = 0;
+  let communityReads = 0;
+  let processChecks = 0;
+  const dependencies = {
+    platform: "darwin",
+    paths: {app, agents, infoPlist, teams, webkit},
+    now: () => "2026-08-06T10:00:00Z",
+    async readVersion(_paths, signal) {
+      assert.equal(signal.aborted, false);
+      versionReads += 1;
+      return "0.5.5";
+    },
+    async readCommunities(_paths, signal) {
+      assert.equal(signal.aborted, false);
+      communityReads += 1;
+      return [{
+        id: "community-primary",
+        name: "Primary Community",
+        relayUrl: "wss://relay.example.test",
+        token: "community-token-private-canary",
+        nsec: "community-nsec-private-canary",
+        reposDir: "/private/fixture/repos-canary",
+      }];
+    },
+    isProcessAlive(pid) {
+      processChecks += 1;
+      return pid === 4242;
+    },
+  };
+  const adapter = createBuzzAdapter(dependencies);
+  assert.deepEqual(Object.keys(adapter).sort(), [
+    "adapter_id", "adapter_version", "capabilities", "detect", "provider_id", "status",
+  ]);
+  createAdapterRegistry([adapter]);
+
+  const beforeAgents = fs.readFileSync(agents);
+  const beforeTeams = fs.readFileSync(teams);
+  const beforeAgentTime = fs.statSync(agents).mtimeMs;
+  const detected = await adapter.detect(context());
+  const status = await adapter.status(context());
+  assert.deepEqual(status, detected, "status and detect must use the same read-only projection");
+  assert.equal(versionReads, 2);
+  assert.equal(communityReads, 2);
+  assert.equal(processChecks, 4);
+  assert.deepEqual(fs.readFileSync(agents), beforeAgents);
+  assert.deepEqual(fs.readFileSync(teams), beforeTeams);
+  assert.equal(fs.statSync(agents).mtimeMs, beforeAgentTime);
+
+  const validators = createRuntimeValidators();
+  assert.equal(validators.adapterObservation(detected), true, JSON.stringify(validators.adapterObservation.errors));
+  assert.equal(detected.availability, "available");
+  assert.equal(detected.compatibility.state, "compatible");
+  assert.equal(detected.provider_version, "0.5.5");
+  assert.deepEqual(detected.inventory.communities.map(({display_label: label}) => label), ["Primary Community"]);
+  assert.deepEqual(detected.inventory.agents.map(({agent_kind: kind}) => kind).sort(), [
+    "definition", "instance", "instance",
+  ]);
+  assert.equal(detected.inventory.runtimes.length, 1, "only referenced runtime identities are observed");
+  const active = detected.inventory.agents.find(({display_label: label}) => label === "Builder");
+  const definition = detected.inventory.agents.find(({agent_kind: kind}) => kind === "definition");
+  const stopped = detected.inventory.agents.find(({display_label: label}) => label === "Stopped Instance");
+  const alpha = detected.inventory.teams.find(({display_label: label}) => label === "Alpha Team");
+  assert.equal(active.availability, "available");
+  assert.equal(stopped.availability, "unavailable");
+  assert.equal(definition.is_builtin, true);
+  assert.equal(active.community_ref, detected.inventory.communities[0].community_id);
+  assert.equal(active.team_ref, alpha.team_id);
+  assert.deepEqual(alpha.member_refs, [active.agent_id], "persona IDs must not be treated as deployed members");
+
+  const serialized = JSON.stringify(detected);
+  for (const forbidden of [
+    "aaaaaaaaaaaaaaaa", "relay.example.test", "private-canary", "fixture/", "settings:",
+    "nsec-", "auth-", "model-private", "provider-private", "prompt-", "error-", "instructions-",
+  ]) assert.equal(serialized.includes(forbidden), false, `${forbidden} escaped the projection`);
+
+  const unknownVersion = createBuzzAdapter({...dependencies, readVersion: async () => "0.6.0"});
+  const unknown = await unknownVersion.detect(context());
+  assert.equal(unknown.compatibility.state, "unknown");
+  assert.equal(unknown.availability, "available");
+
+  let unsupportedRead = false;
+  const unsupported = createBuzzAdapter({
+    ...dependencies,
+    platform: "linux",
+    readVersion: async () => {
+      unsupportedRead = true;
+      throw new Error("must not read unsupported platform");
+    },
+  });
+  const unsupportedObservation = await unsupported.detect(context());
+  assert.equal(unsupportedObservation.availability, "unavailable");
+  assert.equal(unsupportedRead, false);
+  assert.deepEqual(unsupportedObservation.inventory, {communities: [], agents: [], teams: [], runtimes: []});
+
+  const absentApp = createBuzzAdapter({...dependencies, paths: {...dependencies.paths, app: path.join(sandbox, "missing")}});
+  assert.equal((await absentApp.detect(context())).availability, "unavailable");
+
+  const missingStores = createBuzzAdapter({
+    ...dependencies,
+    paths: {
+      ...dependencies.paths,
+      agents: path.join(data, "missing-agents.json"),
+      teams: path.join(data, "missing-teams.json"),
+    },
+    readCommunities: async () => null,
+  });
+  const missing = await missingStores.detect(context());
+  assert.equal(missing.availability, "degraded");
+  assert.equal(capability(missing, "communities").availability, "unavailable");
+  assert.deepEqual(missing.inventory, {communities: [], agents: [], teams: [], runtimes: []});
+
+  const malformedPath = path.join(data, "malformed-agents.json");
+  fs.writeFileSync(malformedPath, "{not json", {mode: 0o600});
+  const malformed = await createBuzzAdapter({
+    ...dependencies,
+    paths: {...dependencies.paths, agents: malformedPath},
+  }).detect(context());
+  assert.equal(capability(malformed, "agents").availability, "degraded");
+  assert.deepEqual(malformed.inventory.agents, []);
+
+  const oversizedPath = path.join(data, "oversized-agents.json");
+  fs.writeFileSync(oversizedPath, `["${"x".repeat(4 * 1024 * 1024)}"]`, {mode: 0o600});
+  const oversized = await createBuzzAdapter({
+    ...dependencies,
+    paths: {...dependencies.paths, agents: oversizedPath},
+  }).detect(context());
+  assert.equal(capability(oversized, "agents").availability, "degraded");
+
+  const symlinkPath = path.join(data, "linked-agents.json");
+  fs.symlinkSync(agents, symlinkPath);
+  const symlinked = await createBuzzAdapter({
+    ...dependencies,
+    paths: {...dependencies.paths, agents: symlinkPath},
+  }).detect(context());
+  assert.equal(capability(symlinked, "agents").availability, "degraded");
+
+  const abortController = new AbortController();
+  const aborting = createBuzzAdapter({
+    ...dependencies,
+    readAgents(signal) {
+      return new Promise((resolve, reject) => {
+        signal.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), {once: true});
+        setImmediate(() => resolve([]));
+      });
+    },
+  });
+  abortController.abort();
+  await assert.rejects(aborting.detect(context(abortController.signal)), {name: "AbortError"});
+
+  const renamedCommunities = createBuzzAdapter({
+    ...dependencies,
+    readCommunities: async () => [{
+      id: "community-primary",
+      name: "Renamed Label",
+      relayUrl: "wss://relay.example.test",
+    }],
+  });
+  const renamed = await renamedCommunities.detect(context());
+  assert.equal(renamed.inventory.communities[0].community_id, detected.inventory.communities[0].community_id);
+  assert.equal(renamed.inventory.communities[0].display_label, "Renamed Label");
+
+  console.log("PASS: Buzz team-interface adapter is deterministic, read-only, and redacted");
+} finally {
+  fs.rmSync(sandbox, {force: true, recursive: true});
+}

--- a/.agents/scripts/tests/test-team-interface-runtime.mjs
+++ b/.agents/scripts/tests/test-team-interface-runtime.mjs
@@ -21,6 +21,7 @@ import {
   writeRuntimeState,
 } from "../team-interface-core.mjs";
 import {
+  builtInAdapterRegistry,
   createAdapterRegistry,
   selectConfiguredAdapters,
 } from "../team-interface-adapters.mjs";
@@ -172,6 +173,59 @@ const missingObservedCapabilities = copy(validFixture.adapter_observation);
 missingObservedCapabilities.capabilities = [];
 requireInvalid(validators.adapterObservation, missingObservedCapabilities, "missing observed capabilities");
 
+const inventoryObservation = copy(validFixture.adapter_observation);
+inventoryObservation.inventory = {
+  communities: [
+    {community_id: "community.mock.alpha", display_label: "Alpha", availability: "available"},
+  ],
+  agents: [
+    {
+      agent_id: "agent.mock.alpha",
+      display_label: "Alpha Agent",
+      agent_kind: "instance",
+      is_builtin: false,
+      availability: "available",
+      community_ref: "community.mock.alpha",
+      runtime_ref: "runtime.mock.alpha",
+      team_ref: "team.mock.alpha",
+    },
+    {
+      agent_id: "agent.mock.beta",
+      display_label: "Beta Definition",
+      agent_kind: "definition",
+      is_builtin: true,
+      availability: "available",
+    },
+  ],
+  teams: [
+    {
+      team_id: "team.mock.alpha",
+      display_label: "Alpha Team",
+      is_builtin: false,
+      member_refs: ["agent.mock.alpha"],
+      availability: "available",
+    },
+  ],
+  runtimes: [
+    {
+      runtime_id: "runtime.mock.alpha",
+      display_label: "Alpha Runtime",
+      runtime_kind: "unknown",
+      availability: "available",
+    },
+  ],
+};
+requireValid(validators.adapterObservation, inventoryObservation, "provider-neutral inventory observation");
+for (const [label, mutateInventory] of [
+  ["inventory missing category", (inventory) => delete inventory.runtimes],
+  ["inventory unknown field", (inventory) => { inventory.unknown = []; }],
+  ["inventory agent private field", (inventory) => { inventory.agents[0].model = "private"; }],
+]) {
+  const invalid = copy(inventoryObservation);
+  mutateInventory(invalid.inventory);
+  requireInvalid(validators.adapterObservation, invalid, label);
+}
+
 const inlineTokenConfig = copy(validFixture.runtime_config);
 inlineTokenConfig.adapters = [{adapter_id: "adapter.mock", settings_ref: "token:inline-secret"}];
 requireInvalid(validators.runtimeConfig, inlineTokenConfig, "inline token-shaped adapter setting");
@@ -310,6 +364,8 @@ const mockAdapter = makeAdapter(validFixture.adapter_observation, {
   },
 });
 const mockRegistry = createAdapterRegistry([mockAdapter]);
+assert.deepEqual(builtInAdapterRegistry.ids(), ["adapter.buzz"]);
+assert.equal(builtInAdapterRegistry.get("adapter.buzz").provider_id, "buzz");
 assert.equal(Object.isFrozen(mockAdapter), true);
 assert.equal(Object.isFrozen(mockAdapter.capabilities), true);
 assert.equal(Object.isFrozen(mockAdapter.capabilities[0]), true);
@@ -513,6 +569,46 @@ try {
     assert.equal(invalidResult.errors.length, 1, label);
     assert.equal(invalidResult.errors[0].code, expectedCode, label);
     assert.equal(invalidResult.errors[0].message, expectedMessage, label);
+    assert.equal(pathExists(runtimeStatePaths(runtimeStateRoot).statePath), false, `${label} changed state`);
+  }
+
+  for (const [label, mutateInventory, expectedCode] of [
+    [
+      "duplicate inventory identity",
+      (inventory) => inventory.agents.push(copy(inventory.agents[0])),
+      "duplicate_identity",
+    ],
+    [
+      "non-canonical inventory order",
+      (inventory) => inventory.agents.reverse(),
+      "adapter_read_failed",
+    ],
+    [
+      "dangling inventory reference",
+      (inventory) => { inventory.agents[0].runtime_ref = "runtime.mock.missing"; },
+      "adapter_read_failed",
+    ],
+    [
+      "non-canonical team member references",
+      (inventory) => { inventory.teams[0].member_refs = ["agent.mock.beta", "agent.mock.alpha"]; },
+      "adapter_read_failed",
+    ],
+  ]) {
+    const invalidInventoryAdapter = makeAdapter(inventoryObservation, {
+      detect() {
+        const observation = copy(inventoryObservation);
+        mutateInventory(observation.inventory);
+        return observation;
+      },
+    });
+    const invalidResult = await runDetect({
+      configPath,
+      registry: createAdapterRegistry([invalidInventoryAdapter]),
+      stateRoot: runtimeStateRoot,
+      validators,
+    });
+    assert.equal(invalidResult.errors.length, 1, label);
+    assert.equal(invalidResult.errors[0].code, expectedCode, label);
     assert.equal(pathExists(runtimeStatePaths(runtimeStateRoot).statePath), false, `${label} changed state`);
   }
 


### PR DESCRIPTION
## Summary

Add the statically registered read-only Buzz adapter, provider-neutral inventories, semantic validation, and redaction-focused fixtures.

## Files Changed

.agents/schemas/team-interface/runtime-v1.schema.json, .agents/scripts/team-interface-adapter-runtime.mjs, .agents/scripts/team-interface-adapters.mjs, .agents/scripts/team-interface-buzz-adapter.mjs, .agents/scripts/tests/fixtures/team-interface/buzz-managed-agents.json, .agents/scripts/tests/fixtures/team-interface/buzz-teams.json, .agents/scripts/tests/test-team-interface-buzz-adapter.mjs, .agents/scripts/tests/test-team-interface-runtime.mjs

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: synthetic Buzz stores exercised through detect/status; node .agents/scripts/tests/test-team-interface-buzz-adapter.mjs; node .agents/scripts/tests/test-team-interface-runtime.mjs

Resolves #29631


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.229 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 16m and 216,901 tokens on this as a headless worker.