### PR TITLE
GH#29637: t18205: fix post-merge verification base refs

### DIFF
--- a/.agents/scripts/tests/test-post-merge-verify-report.sh
+++ b/.agents/scripts/tests/test-post-merge-verify-report.sh
@@ -94,6 +94,16 @@ else
 	fail "post-merge ripgrep bootstrap" "missing ripgrep package installation"
 fi
 
+# shellcheck disable=SC2016 # Workflow expressions and shell variables are intentionally literal.
+if grep -qF 'fetch-depth: 0' "$WORKFLOW" &&
+	grep -qF 'BASE_REF: ${{ github.event.pull_request.base.ref }}' "$WORKFLOW" &&
+	grep -qF 'BASE_SHA: ${{ github.event.pull_request.base.sha }}' "$WORKFLOW" &&
+	grep -qF 'git update-ref "$REMOTE_BASE_REF" "$BASE_SHA"' "$WORKFLOW"; then
+	pass "post-merge verification pins origin base ref to the pre-merge SHA"
+else
+	fail "post-merge base ref" "missing full-history checkout or pre-merge remote-ref pin"
+fi
+
 printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
 if [[ "$FAIL" -gt 0 ]]; then
 	exit 1

--- a/.github/workflows/post-merge-verify.yml
+++ b/.github/workflows/post-merge-verify.yml
@@ -59,6 +59,27 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      # Acceptance checks are authored before merge and commonly diff against
+      # origin/<base>. Pin that ref to the event's pre-merge base SHA instead of
+      # leaving it absent in the detached checkout or pointing at moving main.
+      - name: Pin verification base ref
+        if: steps.extract.outputs.task_id != ''
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          REMOTE_BASE_REF="refs/remotes/origin/${BASE_REF}"
+
+          if [[ ! "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Invalid pull request base SHA."
+            exit 1
+          fi
+          git check-ref-format "$REMOTE_BASE_REF"
+          git cat-file -e "${BASE_SHA}^{commit}"
+          git update-ref "$REMOTE_BASE_REF" "$BASE_SHA"
 
       # ---------------------------------------------------------------
       # Step 3: Check if brief exists and has verify blocks


### PR DESCRIPTION
## Summary

Pin the post-merge verifier's `origin/<base>` ref to the pull request event's pre-merge base commit so brief checks can compare the merged change against its actual baseline.

## Files Changed

- `.github/workflows/post-merge-verify.yml`: fetch complete history and pin the remote base ref before running brief checks.
- `.agents/scripts/tests/test-post-merge-verify-report.sh`: assert the workflow preserves the pre-merge baseline contract.

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — post-merge report regression (6/6), ShellCheck, workflow YAML validation, changed-file linters, Buzz/runtime/core suites, runtime dependency deployment, unchanged-file diff, Qlty new-file (0 smells), and Qlty regression (46 to 46) pass.

## Key Decision

Preserve existing `origin/main`-based acceptance commands by restoring that ref's pre-merge meaning in the verifier, rather than weakening or rewriting completed task criteria.

Resolves #29637
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.229 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 15m and 184,865 tokens on this as a headless worker.