### PR TITLE
GH#29625: bootstrap Qlty in post-merge verification

### DIFF
--- a/.agents/scripts/post-merge-verify-report-helper.sh
+++ b/.agents/scripts/post-merge-verify-report-helper.sh
@@ -22,7 +22,8 @@ truncate_output() {
 		return 2
 	fi
 
-	output_size=$(wc -c <"$output_file")
+	# BSD wc pads numeric output; normalize it before comparisons and reports.
+	output_size=$(wc -c <"$output_file" | tr -d '[:space:]')
 	if [[ "$output_size" -le "$max_bytes" ]]; then
 		return 0
 	fi

--- a/.agents/scripts/tests/test-post-merge-verify-report.sh
+++ b/.agents/scripts/tests/test-post-merge-verify-report.sh
@@ -94,6 +94,13 @@ else
 	fail "post-merge ripgrep bootstrap" "missing ripgrep package installation"
 fi
 
+if grep -qF 'QLTY_VERSION: "0.636.0"' "$WORKFLOW" &&
+	grep -qF 'qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899' "$WORKFLOW"; then
+	pass "post-merge verification installs the repository-pinned Qlty CLI"
+else
+	fail "post-merge Qlty bootstrap" "missing pinned Qlty version or install action"
+fi
+
 # shellcheck disable=SC2016 # Workflow expressions and shell variables are intentionally literal.
 if grep -qF 'fetch-depth: 0' "$WORKFLOW" &&
 	grep -qF 'BASE_REF: ${{ github.event.pull_request.base.ref }}' "$WORKFLOW" &&

--- a/.github/workflows/post-merge-verify.yml
+++ b/.github/workflows/post-merge-verify.yml
@@ -1,5 +1,10 @@
 name: Post-Merge Brief Verification
 
+# Keep post-merge acceptance checks on the same pinned Qlty CLI as required PR
+# quality gates. Brief verify blocks may call the repository Qlty helpers.
+env:
+  QLTY_VERSION: "0.636.0"
+
 # t2135: After a PR merges to main, extract the task ID from the PR title,
 # locate the corresponding brief file, parse verify: YAML blocks from its
 # acceptance criteria, and run method:bash blocks. On any failure, open a
@@ -111,6 +116,10 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
+
+      - name: Install Qlty CLI
+        if: steps.brief.outputs.exists == 'true'
+        uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899 # v2.2.0
 
       - name: Install verification dependencies
         if: steps.brief.outputs.exists == 'true'


### PR DESCRIPTION
## Summary

Install the repository-pinned Qlty CLI for post-merge brief checks and normalize BSD wc output. The same fix also Resolves #29639.

## Files Changed

.agents/scripts/post-merge-verify-report-helper.sh, .agents/scripts/tests/test-post-merge-verify-report.sh, .github/workflows/post-merge-verify.yml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-post-merge-verify-report.sh; .agents/scripts/linters-local.sh --changed; git diff --check

Resolves #29625


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.229 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 42m and 833,197 tokens on this with the user in an interactive session.