### PR TITLE
GH#29644: avoid tool-bin discovery reads

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-prompt.sh
+++ b/.agents/scripts/pulse-dispatch-worker-prompt.sh
@@ -248,6 +248,7 @@ First-pass completion contract:
 3. Validate the stated target files and verification commands against the current dependency/runtime versions before implementation.
 4. After the first coherent commit, push and create a draft PR early so progress is durable and visible to every runner. Continue implementation and local verification on that PR; do not hand off while it is draft or has unpushed changes. Once the completed exact head is pushed, the PR is non-draft, its merge summary exists, and one immediate remote check shows no terminal failure, attempt merge once. If only asynchronous CI, bot review, human approval, or native auto-merge remains, exit and hand off to pulse. Never poll those gates or bypass approval, review, CI, branch-protection, or security controls.
 5. Do not post routine dispatch, stale, or progress comments. Prefer commits, the PR, check runs, and one final completion or blocker dossier.
+6. For routine tool discovery, use `command -v TOOL`, `TOOL --version`, or repository wrappers. Do not use file-reading tools to inspect `~/.bun/bin`, `~/.qlty/bin`, or `~/.local/bin`; unrelated external-directory reads still require maintainer approval.
 EOF
 	return 0
 }

--- a/.agents/scripts/tests/test-local-permissions-check-helper.sh
+++ b/.agents/scripts/tests/test-local-permissions-check-helper.sh
@@ -80,7 +80,7 @@ assert_contains "reports denied status" "denied" "$report_output"
 assert_contains "explains Tabby Trash remediation" "grant Full Disk Access to Tabby" "$report_output"
 assert_contains "includes installed inventory" "Tabby: installed" "$report_output"
 
-unknown_output="$(LPC_UNAME=Darwin LPC_ACTIVE_HOST=Tabby LPC_TCC_ROWS="${TEST_ROOT}/missing.txt" LPC_APP_ROOTS="$apps_root" "$HELPER" report --active-host)"
+unknown_output="$(LPC_UNAME=Darwin LPC_ACTIVE_HOST=Tabby LPC_TCC_ROWS="${TEST_ROOT}/missing.txt" LPC_TCC_DB="${TEST_ROOT}/missing.db" LPC_APP_ROOTS="$apps_root" "$HELPER" report --active-host)"
 assert_contains "unreadable TCC state is unknown" "unknown" "$unknown_output"
 assert_contains "unknown is not treated as OK" "Check System Settings" "$unknown_output"
 

--- a/.agents/scripts/tests/test-worker-permission-helper.sh
+++ b/.agents/scripts/tests/test-worker-permission-helper.sh
@@ -29,6 +29,14 @@ cat >"$capture_file" <<'JSON'
     "intent": "Inspect generated SDK declarations",
     "risk": {"level": "medium", "grantable": true, "reason": "external boundary"},
     "opencode": {"request_id": "oc-1", "session_id": "ses-1"}
+  }, {
+    "request_id": "perm-tool-discovery",
+    "permission": "external_directory",
+    "patterns": ["~/.qlty/bin/*"],
+    "tool": "read",
+    "intent": "Locate the Qlty executable",
+    "risk": {"level": "medium", "grantable": true, "reason": "external boundary"},
+    "opencode": {"request_id": "oc-2", "session_id": "ses-1"}
   }]
 }
 JSON
@@ -56,6 +64,11 @@ target_marker="**Target:** \`owner/repo#123\`"
 session_marker="**Worker session:** \`issue-123\`"
 if [[ "$rendered_capabilities" != *"$capability_marker"* ]]; then
 	printf 'permission capability summary was empty or incomplete\n' >&2
+	exit 1
+fi
+# shellcheck disable=SC2016 # Markdown backticks are intentional literals.
+if [[ "$rendered_capabilities" != *'Routine tool discovery should use `command -v TOOL`'* ]]; then
+	printf 'known tool-bin read omitted command-based recovery guidance\n' >&2
 	exit 1
 fi
 printf '{invalid-json\n' >"${test_root}/invalid-envelope.json"

--- a/.agents/scripts/tests/test-zero-output-url-fallback.sh
+++ b/.agents/scripts/tests/test-zero-output-url-fallback.sh
@@ -108,10 +108,14 @@ write_state 1
 GH_COMMENT_ZERO_COUNT=0
 GH_COMMENT_METRICS=""
 normal_prompt=$(_dlw_prepare_prompt_for_launch 123 owner/repo "Test issue" "FULL EMBEDDED BRIEF")
+# shellcheck disable=SC2016 # Markdown backticks are intentional literals.
 if [[ "$normal_prompt" == *"FULL EMBEDDED BRIEF"* ]] \
 	&& [[ "$normal_prompt" == *"First-pass completion contract"* ]] \
 	&& [[ "$normal_prompt" == *"do not hand off while it is draft or has unpushed changes"* ]] \
 	&& [[ "$normal_prompt" == *"Never poll those gates or bypass approval, review, CI, branch-protection, or security controls"* ]] \
+	&& [[ "$normal_prompt" == *'routine tool discovery'* ]] \
+	&& [[ "$normal_prompt" == *'command -v TOOL'* ]] \
+	&& [[ "$normal_prompt" == *'Do not use file-reading tools to inspect `~/.bun/bin`, `~/.qlty/bin`, or `~/.local/bin`'* ]] \
 	&& [[ "$normal_prompt" != *"continue on that PR through local and remote verification"* ]]; then
 	pass "below fallback threshold keeps embedded prompt"
 else

--- a/.agents/scripts/worker-permission-helper.sh
+++ b/.agents/scripts/worker-permission-helper.sh
@@ -178,10 +178,15 @@ permission_render_capabilities() {
 	local envelope_file="$1"
 	jq -r '.capabilities[] |
 		def safe: gsub("<"; "&lt;") | gsub(">"; "&gt;");
+		def avoidable_tool_bin_read:
+			.permission == "external_directory"
+			and .tool == "read"
+			and any(.patterns[]?; test("/[.](bun|qlty)/bin/[*][*]?$|/[.]local/bin/[*][*]?$"));
 		"- **" + .permission + "** via `" + .tool + "` — "
 		+ (if (.patterns | length) == 0 then "(no pattern supplied)" else (.patterns | map(tojson | safe) | join(", ")) end)
 		+ "\n  - Reason: " + (if .intent == "" then "No additional model rationale was available." else (.intent | safe) end)
 		+ "\n  - Risk: **" + .risk.level + "** — " + (.risk.reason | safe)
+		+ (if avoidable_tool_bin_read then "\n  - Recovery: Routine tool discovery should use `command -v TOOL`, `TOOL --version`, or a repository wrapper instead of reading the install directory." else "" end)
 		+ (if .risk.grantable then "" else "\n  - **Not grantable:** sensitive scope requires an alternative approach." end)' \
 		"$envelope_file"
 	return $?


### PR DESCRIPTION
## Summary

Direct workers to command-based tool discovery and add recovery guidance when known tool-bin reads request external-directory access.

## Files Changed

.agents/scripts/pulse-dispatch-worker-prompt.sh, .agents/scripts/tests/test-local-permissions-check-helper.sh, .agents/scripts/tests/test-worker-permission-helper.sh, .agents/scripts/tests/test-zero-output-url-fallback.sh, .agents/scripts/worker-permission-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-worker-permission-helper.sh; bash .agents/scripts/tests/test-zero-output-url-fallback.sh; bash .agents/scripts/tests/test-local-permissions-check-helper.sh; .agents/scripts/linters-local.sh --changed; git diff --check

Resolves #29644


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.229 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 45m and 837,448 tokens on this with the user in an interactive session.