### PR TITLE
GH#29657: prevent pulse external-directory permission stalls

### DIFF
--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -178,6 +178,26 @@ _pulse_refresh_repo() {
 	return 0
 }
 
+_pulse_supervisor_prompt() {
+	local pulse_command="$1"
+	local state_file="$2"
+	local prompt="$pulse_command"
+
+	prompt="${pulse_command}
+
+Runtime sandbox rule: supervisor-pulse is launched from the aidevops agent workspace. Do not run Bash tool calls with workdir set to managed repository paths or any other directory outside that workspace. Use the pre-fetched state file and wrapper/helper functions from the current workspace instead. If repo/worktree data is missing, record a diagnostic and exit cleanly rather than requesting external_directory permission."
+	if [[ -f "$state_file" ]]; then
+		prompt="${prompt}
+
+Pre-fetched state file: ${state_file}
+Read this file before proceeding — it contains the current repo/PR/issue state
+gathered by pulse-wrapper.sh BEFORE this session started."
+	fi
+
+	printf '%s\n' "$prompt"
+	return 0
+}
+
 run_pulse() {
 	local underfilled_mode="${1:-0}"
 	local underfill_pct="${2:-0}"
@@ -209,14 +229,8 @@ run_pulse() {
 	if [[ "$trigger_mode" == "daily_sweep" ]]; then
 		pulse_command="/pulse-sweep"
 	fi
-	local prompt="$pulse_command"
-	if [[ -f "$STATE_FILE" ]]; then
-		prompt="${pulse_command}
-
-Pre-fetched state file: ${STATE_FILE}
-Read this file before proceeding — it contains the current repo/PR/issue state
-gathered by pulse-wrapper.sh BEFORE this session started."
-	fi
+	local prompt
+	prompt=$(_pulse_supervisor_prompt "$pulse_command" "$STATE_FILE")
 
 	# Run the provider-aware headless wrapper in background.
 	local -a pulse_cmd=("$HEADLESS_RUNTIME_HELPER" run --role pulse --session-key supervisor-pulse --dir "$PULSE_DIR" --title "Supervisor Pulse" --agent Automate --prompt "$prompt" --tier standard)
@@ -633,7 +647,7 @@ sync_todo_refs_for_repo() (
 	TMPDIR="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}" \
 		AIDEVOPS_PLANNING_BASE_SHA="$base_sha" \
 		planning_publish "$workspace" "chore: sync GitHub issue refs to TODO.md [skip ci]" \
-			origin "$branch_name" "$changed_paths" || publication_rc=$?
+		origin "$branch_name" "$changed_paths" || publication_rc=$?
 	case "$publication_rc" in
 	0) printf '[pulse-wrapper] TODO ref sync status=%s repo=%s commit=%s\n' \
 		"${PLANNING_PUBLISH_RESULT:-noop}" "$repo_slug" "${PLANNING_PUBLISHED_COMMIT:0:12}" >>"$WRAPPER_LOGFILE" ;;

--- a/.agents/scripts/tests/test-pulse-wrapper-characterization.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-characterization.sh
@@ -155,6 +155,7 @@ readonly -a EXPECTED_FUNCTIONS=(
 	"_watchdog_check_idle"
 	"_check_watchdog_conditions"
 	"_run_pulse_watchdog"
+	"_pulse_supervisor_prompt"
 	"run_pulse"
 	"cleanup_worktrees"
 	"cleanup_stashes"
@@ -865,16 +866,16 @@ test_sourcing_idempotency() {
 test_deterministic_merge_guard_uses_routine_lock() {
 	local wrapper_file="${PULSE_SCRIPTS_DIR}/pulse-wrapper.sh"
 
-	if grep -qF '.agent-workspace/locks/pulse-merge-routine.lock' "$wrapper_file" \
-		&& grep -qF "kill -0 \"\$_pmr_lock_pid\"" "$wrapper_file"; then
+	if grep -qF '.agent-workspace/locks/pulse-merge-routine.lock' "$wrapper_file" &&
+		grep -qF "kill -0 \"\$_pmr_lock_pid\"" "$wrapper_file"; then
 		print_result "deterministic merge guard checks live pulse-merge-routine PID lock" 0
 	else
 		print_result "deterministic merge guard checks live pulse-merge-routine PID lock" 1 \
 			"missing lock-dir or kill -0 guard in pulse-wrapper.sh"
 	fi
 
-	if grep -qF 'PULSE_MERGE_ROUTINE_TIMEOUT_SECONDS:-600' "$wrapper_file" \
-		&& grep -qF "window=\${_pmr_recent_window}s" "$wrapper_file"; then
+	if grep -qF 'PULSE_MERGE_ROUTINE_TIMEOUT_SECONDS:-600' "$wrapper_file" &&
+		grep -qF "window=\${_pmr_recent_window}s" "$wrapper_file"; then
 		print_result "deterministic merge timestamp guard uses routine timeout window" 0
 	else
 		print_result "deterministic merge timestamp guard uses routine timeout window" 1 \

--- a/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
@@ -119,8 +119,8 @@ else
 fi
 
 timeout_value=$(<"$TIMEOUT_CALL_FILE")
-if grep -q 'AIDEVOPS_PULSE_IDLE_AVAILABLE_WORK_TIMEOUT:-30' "$SOURCE_SCRIPT" && \
-	[[ "$timeout_value" =~ ^[0-9]+$ ]] && \
+if grep -q 'AIDEVOPS_PULSE_IDLE_AVAILABLE_WORK_TIMEOUT:-30' "$SOURCE_SCRIPT" &&
+	[[ "$timeout_value" =~ ^[0-9]+$ ]] &&
 	[[ "$timeout_value" -ge 1 && "$timeout_value" -le 30 ]]; then
 	pass "idle-work query uses bounded default timeout"
 else
@@ -159,21 +159,21 @@ _pulse_efficiency_cycle_start
 efficiency_cycle_id="${AIDEVOPS_GH_API_EFFICIENCY_CYCLE_ID:-}"
 _PULSE_EFFICIENCY_CYCLE_START_MS=$((_PULSE_EFFICIENCY_CYCLE_START_MS - 25))
 _pulse_efficiency_cycle_finish idle
-if grep -q '^contract=2$' "$EVIDENCE_FILE" \
-	&& grep -q '^coverage-start=[0-9]' "$EVIDENCE_FILE" \
-	&& grep -q '^coverage.population=2$' "$EVIDENCE_FILE" \
-	&& grep -q '^coverage.latency=2$' "$EVIDENCE_FILE" \
-	&& grep -q '^coverage.cache=2$' "$EVIDENCE_FILE" \
-	&& grep -q '^coverage.single_flight=2$' "$EVIDENCE_FILE" \
-	&& grep -q '^coverage.webhook=2$' "$EVIDENCE_FILE" \
-	&& grep -q '^coverage.guardrails=2$' "$EVIDENCE_FILE" \
-	&& grep -q '^coverage.path_budgets=2$' "$EVIDENCE_FILE" \
-	&& grep -q '^population.pulse_cycles=1$' "$EVIDENCE_FILE" \
-	&& grep -q '^population.unchanged_cycles=1$' "$EVIDENCE_FILE" \
-	&& grep -q '^coverage-end=[0-9]' "$EVIDENCE_FILE" \
-	&& [[ "$efficiency_cycle_id" =~ ^[0-9]+$ ]] \
-	&& [[ -z "${AIDEVOPS_GH_API_EFFICIENCY_CYCLE_ID:-}" ]] \
-	&& ! grep -q '^latency.completed_action_ms=' "$EVIDENCE_FILE"; then
+if grep -q '^contract=2$' "$EVIDENCE_FILE" &&
+	grep -q '^coverage-start=[0-9]' "$EVIDENCE_FILE" &&
+	grep -q '^coverage.population=2$' "$EVIDENCE_FILE" &&
+	grep -q '^coverage.latency=2$' "$EVIDENCE_FILE" &&
+	grep -q '^coverage.cache=2$' "$EVIDENCE_FILE" &&
+	grep -q '^coverage.single_flight=2$' "$EVIDENCE_FILE" &&
+	grep -q '^coverage.webhook=2$' "$EVIDENCE_FILE" &&
+	grep -q '^coverage.guardrails=2$' "$EVIDENCE_FILE" &&
+	grep -q '^coverage.path_budgets=2$' "$EVIDENCE_FILE" &&
+	grep -q '^population.pulse_cycles=1$' "$EVIDENCE_FILE" &&
+	grep -q '^population.unchanged_cycles=1$' "$EVIDENCE_FILE" &&
+	grep -q '^coverage-end=[0-9]' "$EVIDENCE_FILE" &&
+	[[ "$efficiency_cycle_id" =~ ^[0-9]+$ ]] &&
+	[[ -z "${AIDEVOPS_GH_API_EFFICIENCY_CYCLE_ID:-}" ]] &&
+	! grep -q '^latency.completed_action_ms=' "$EVIDENCE_FILE"; then
 	pass "idle cycle publishes complete typed evidence"
 else
 	fail "idle cycle publishes complete typed evidence"
@@ -204,9 +204,9 @@ _pulse_efficiency_cycle_finish idle
 rollover_marker=$(grep '^coverage-end=' "$EVIDENCE_FILE")
 rollover_record_ts=$(grep '^coverage-end=' "$EVIDENCE_TIMESTAMP_FILE")
 rollover_aggregate=$(<"$AGGREGATE_FILE")
-if [[ "$rollover_marker" == "coverage-end=2000" \
-	&& "$rollover_record_ts" == "coverage-end=2000" \
-	&& "$rollover_aggregate" == "|86400|2000" ]]; then
+if [[ "$rollover_marker" == "coverage-end=2000" &&
+	"$rollover_record_ts" == "coverage-end=2000" &&
+	"$rollover_aggregate" == "|86400|2000" ]]; then
 	pass "second rollover keeps coverage marker inside completed cutoff"
 else
 	fail "second rollover keeps coverage marker inside completed cutoff" \
@@ -219,8 +219,8 @@ _pulse_efficiency_now_seconds() {
 }
 
 _pulse_efficiency_cycle_finish idle
-if [[ "$(wc -l <"$AGGREGATE_FILE" | tr -d ' ')" == "1" ]] \
-	&& [[ "$(wc -l <"$TRIM_FILE" | tr -d ' ')" == "1" ]]; then
+if [[ "$(wc -l <"$AGGREGATE_FILE" | tr -d ' ')" == "1" ]] &&
+	[[ "$(wc -l <"$TRIM_FILE" | tr -d ' ')" == "1" ]]; then
 	pass "cycle finish aggregates and trims exactly once"
 else
 	fail "cycle finish aggregates and trims exactly once"
@@ -234,9 +234,9 @@ _pulse_efficiency_cycle_start
 _PULSE_EFFICIENCY_CYCLE_START_MS=$((_PULSE_EFFICIENCY_CYCLE_START_MS - 25))
 _pulse_record_cycle_outcome 0
 _pulse_efficiency_cycle_finish
-if [[ "$_PULSE_EFFICIENCY_CYCLE_OUTCOME" == "active" ]] \
-	&& grep -Eq '^latency.completed_action_ms=[1-9][0-9]*$' "$EVIDENCE_FILE" \
-	&& ! grep -q '^population.unchanged_cycles=' "$EVIDENCE_FILE"; then
+if [[ "$_PULSE_EFFICIENCY_CYCLE_OUTCOME" == "active" ]] &&
+	grep -Eq '^latency.completed_action_ms=[1-9][0-9]*$' "$EVIDENCE_FILE" &&
+	! grep -q '^population.unchanged_cycles=' "$EVIDENCE_FILE"; then
 	pass "active cycle records completed-action latency"
 else
 	fail "active cycle records completed-action latency"
@@ -270,9 +270,9 @@ _PULSE_HEALTH_PRS_CLOSED_CONFLICTING=0
 _PULSE_CYCLE_BLOCKER_KIND="none"
 _PULSE_EFFICIENCY_CYCLE_OUTCOME="idle"
 _pulse_record_cycle_outcome 1
-if [[ "$FINAL_TYPED_OUTCOME" == "progressed" \
-	&& "$_PULSE_EFFICIENCY_CYCLE_OUTCOME" == "active" ]] \
-	&& printf '%s' "$FINAL_PROGRESS_KINDS" | jq -e '. == ["worker-dispatched"]' >/dev/null; then
+if [[ "$FINAL_TYPED_OUTCOME" == "progressed" &&
+	"$_PULSE_EFFICIENCY_CYCLE_OUTCOME" == "active" ]] &&
+	printf '%s' "$FINAL_PROGRESS_KINDS" | jq -e '. == ["worker-dispatched"]' >/dev/null; then
 	pass "worker registration maps to typed progress and legacy active"
 else
 	fail "worker registration maps to typed progress and legacy active"
@@ -280,9 +280,9 @@ fi
 
 _PULSE_CYCLE_BLOCKER_KIND="review-gate"
 _pulse_record_cycle_outcome 2
-if [[ "$FINAL_TYPED_OUTCOME" == "blocked" \
-	&& "$_PULSE_EFFICIENCY_CYCLE_OUTCOME" == "idle" \
-	&& "$FINAL_PROGRESS_KINDS" == "[]" ]]; then
+if [[ "$FINAL_TYPED_OUTCOME" == "blocked" &&
+	"$_PULSE_EFFICIENCY_CYCLE_OUTCOME" == "idle" &&
+	"$FINAL_PROGRESS_KINDS" == "[]" ]]; then
 	pass "typed blocker maps to blocked and legacy idle"
 else
 	fail "typed blocker maps to blocked and legacy idle"
@@ -290,9 +290,9 @@ fi
 
 _PULSE_CYCLE_BLOCKER_KIND="none"
 _pulse_record_cycle_outcome 2
-if [[ "$FINAL_TYPED_OUTCOME" == "idle" \
-	&& "$_PULSE_EFFICIENCY_CYCLE_OUTCOME" == "idle" \
-	&& "$FINAL_PROGRESS_KINDS" == "[]" ]]; then
+if [[ "$FINAL_TYPED_OUTCOME" == "idle" &&
+	"$_PULSE_EFFICIENCY_CYCLE_OUTCOME" == "idle" &&
+	"$FINAL_PROGRESS_KINDS" == "[]" ]]; then
 	pass "no durable evidence maps to typed and legacy idle"
 else
 	fail "no durable evidence maps to typed and legacy idle"
@@ -310,9 +310,9 @@ first_population_log=$(<"$EVIDENCE_FILE")
 : >"$EVIDENCE_FILE"
 _prefetch_record_efficiency_population "$local_entries_b"
 repo_hash_b=$(awk -F= '$1 == "population.repository_set_sha256" {print $2}' "$EVIDENCE_FILE")
-if [[ "$repo_hash_a" =~ ^[0-9a-f]{64}$ && "$repo_hash_a" == "$repo_hash_b" ]] \
-	&& printf '%s\n' "$first_population_log" | grep -q '^population.repository_count=2$' \
-	&& ! printf '%s\n' "$first_population_log" | grep -qE 'alpha/repo|beta/repo|/private/'; then
+if [[ "$repo_hash_a" =~ ^[0-9a-f]{64}$ && "$repo_hash_a" == "$repo_hash_b" ]] &&
+	printf '%s\n' "$first_population_log" | grep -q '^population.repository_count=2$' &&
+	! printf '%s\n' "$first_population_log" | grep -qE 'alpha/repo|beta/repo|/private/'; then
 	pass "repository population evidence is deterministic and private"
 else
 	fail "repository population evidence is deterministic and private"
@@ -324,11 +324,20 @@ source "$PREFETCH_REPO"
 : >"$EVIDENCE_FILE"
 PULSE_BATCH_PREFETCH_ENABLED=0
 _prefetch_single_repo_load_snapshots alpha/repo
-if [[ "$(grep -c '^cache.misses=1$' "$EVIDENCE_FILE")" == "2" ]] \
-	&& [[ "$(grep -c '^guardrails.forced_live_refreshes=1$' "$EVIDENCE_FILE")" == "2" ]]; then
+if [[ "$(grep -c '^cache.misses=1$' "$EVIDENCE_FILE")" == "2" ]] &&
+	[[ "$(grep -c '^guardrails.forced_live_refreshes=1$' "$EVIDENCE_FILE")" == "2" ]]; then
 	pass "disabled canonical cache records forced live decisions"
 else
 	fail "disabled canonical cache records forced live decisions"
+fi
+
+SOURCE_CYCLE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/pulse-wrapper-cycle.sh"
+if grep -q 'Do not run Bash tool calls with workdir set to managed repository paths' "$SOURCE_CYCLE" &&
+	grep -q 'external_directory permission' "$SOURCE_CYCLE" &&
+	grep -q '_pulse_supervisor_prompt' "$SOURCE_CYCLE"; then
+	pass "supervisor prompt prevents external-workdir permission stalls"
+else
+	fail "supervisor prompt prevents external-workdir permission stalls"
 fi
 
 printf '\nTests run: %s failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/workflows/pulse.md
+++ b/.agents/workflows/pulse.md
@@ -59,6 +59,8 @@ RUNNER_USER=$(gh api user --jq '.login' 2>/dev/null || whoami)
 
 The wrapper already fetched all open PRs and issues. Data is in your prompt between `--- PRE-FETCHED STATE ---` markers or in the state file path provided. Use it directly — do NOT run `gh pr list` or `gh issue list` (root cause of the "only processes first repo" bug).
 
+**Sandbox rule:** this unattended pulse runs from the aidevops agent workspace, not from each repo. Do NOT run Bash with `workdir` set to a managed repo path (for example to run `git worktree list`). OpenCode treats that as high-risk `external_directory` shell access and stalls for human permission. Use pre-fetched state or wrapper/helper functions from the current workspace; if required repo/worktree data is missing, log a diagnostic and exit cleanly.
+
 ### 3. Approve and merge ready PRs (free — no worker slot needed)
 
 **Most merging is handled deterministically by `merge_ready_prs_all_repos()` in pulse-wrapper.sh** before the LLM session starts. Focus on edge cases: PRs needing CI fix workers, `CHANGES_REQUESTED`, external contributor PRs, complex merge conflicts.


### PR DESCRIPTION
Resolves #29657

## Summary
- Add a supervisor-pulse prompt builder that forbids model-initiated Bash tool calls with `workdir` set to managed repository paths outside the pulse workspace.
- Tell unattended pulse sessions to use pre-fetched state/helper functions and exit with a diagnostic instead of requesting OpenCode `external_directory` permission.
- Add regression coverage so the sandbox warning remains in the pulse wrapper prompt.

## Evidence
- Observed supervisor-pulse cycles stuck in preflight with no active workers while OpenCode permission blockers recorded `external_directory` Bash requests from repo workdirs.
- Current-state snapshot before this PR still showed dispatch alive but no active workers and 32 no-progress cycles.

## Files
- `.agents/scripts/pulse-wrapper-cycle.sh`
- `.agents/workflows/pulse.md`
- `.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh`
- `.agents/scripts/tests/test-pulse-wrapper-characterization.sh`

## Verification
- `bash .agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh`
- `bash .agents/scripts/tests/test-pulse-wrapper-characterization.sh`
- `shellcheck .agents/scripts/pulse-wrapper-cycle.sh .agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh .agents/scripts/tests/test-pulse-wrapper-characterization.sh`
- `.agents/scripts/linters-local.sh`
- `bun run typecheck` via repo pre-push verification

## Privacy
- Public body intentionally omits local/private path names; describes the failure class only.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.229 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.5
