### PR TITLE
GH#29586: harden secret redaction and root lockfiles

### DIFF
--- a/.agents/scripts/pre-commit-hook.sh
+++ b/.agents/scripts/pre-commit-hook.sh
@@ -793,7 +793,9 @@ _init_root_file_allowlist() {
 		"eslint.config.js" "eslint.config.mjs" "eslint.config.cjs"
 		"eslint.config.ts" "eslint.config.mts" "eslint.config.cts"
 		# Build/package files
-		"package.json" "bun.lock" "requirements.txt" "requirements-lock.txt"
+		"package.json" "package-lock.json" "npm-shrinkwrap.json"
+		"pnpm-lock.yaml" "yarn.lock" "bun.lock" "bun.lockb"
+		"requirements.txt" "requirements-lock.txt"
 		# Scripts
 		"setup.sh" "aidevops.sh"
 		# Public shell entrypoints. Implementation modules belong under

--- a/.agents/scripts/secret-helper.sh
+++ b/.agents/scripts/secret-helper.sh
@@ -36,6 +36,7 @@ readonly TENANTS_DIR="$CONFIG_DIR/tenants"
 readonly GOPASS_PREFIX="aidevops"
 readonly INVENTORY_MAX_NAMES=512
 readonly INVENTORY_MAX_NAME_LENGTH=128
+readonly REDACTION_INIT_ERROR="Unable to initialize secret output redaction"
 
 # Check if gopass is available and initialized
 has_gopass() {
@@ -102,7 +103,7 @@ get_secret_value() {
 	return 0
 }
 
-# Collect all secret values for redaction
+# Collect all secret values for redaction as NUL-delimited literal data.
 collect_secret_values() {
 	local -a values=()
 
@@ -137,48 +138,92 @@ collect_secret_values() {
 		done <"$cred_file"
 	done < <(resolve_credential_files)
 
-	# Output values one per line for the redaction filter
-	printf '%s\n' "${values[@]}"
+	if [[ ${#values[@]} -gt 0 ]]; then
+		printf '%s\0' "${values[@]}"
+	fi
 	return 0
 }
 
 # Redact secret values from a stream
 # Reads stdin, replaces any secret value with [REDACTED]
 redact_stream() {
-	local -a secret_values=()
+	local values_file
+	local previous_umask
+	previous_umask=$(umask)
+	umask 077
+	if ! values_file=$(mktemp); then
+		umask "$previous_umask"
+		print_error "$REDACTION_INIT_ERROR" >&2
+		return 1
+	fi
+	umask "$previous_umask"
+	trap 'rm -f "$values_file"' RETURN
 
-	# Read secret values into array
-	while IFS= read -r val; do
-		[[ -n "$val" ]] && secret_values+=("$val")
-	done < <(collect_secret_values)
+	if ! collect_secret_values >"$values_file"; then
+		print_error "$REDACTION_INIT_ERROR" >&2
+		return 1
+	fi
 
-	if [[ ${#secret_values[@]} -eq 0 ]]; then
+	if [[ ! -s "$values_file" ]]; then
 		# No secrets to redact, pass through
 		cat
 		return 0
 	fi
 
-	# Build sed script for redaction
-	# Sort by length descending to redact longer values first
-	local sed_script=""
-	local sorted_values
-	sorted_values=$(printf '%s\n' "${secret_values[@]}" | awk '{ print length, $0 }' | sort -rn | cut -d' ' -f2-)
-
-	while IFS= read -r val; do
-		[[ -z "$val" ]] && continue
-		# Escape special sed characters in the value
-		local escaped
-		escaped=$(printf '%s' "$val" | sed 's/[&/\]/\\&/g; s/\[/\\[/g; s/\]/\\]/g')
-		sed_script="${sed_script}s|${escaped}|[REDACTED]|g;"
-	done <<<"$sorted_values"
-
-	if [[ -n "$sed_script" ]]; then
-		sed "$sed_script"
-	else
-		cat
+	if ! command -v python3 >/dev/null 2>&1; then
+		print_error "$REDACTION_INIT_ERROR" >&2
+		return 1
 	fi
 
-	return 0
+	local exit_code=0
+	python3 -c '
+import sys
+
+with open(sys.argv[1], "rb") as values_handle:
+    secret_values = sorted(
+        {value for value in values_handle.read().split(b"\0") if len(value) >= 4},
+        key=len,
+        reverse=True,
+    )
+
+if not secret_values:
+    raise SystemExit("redaction values were empty")
+
+marker = b"[REDACTED]"
+maximum_length = len(secret_values[0])
+output = sys.stdout.buffer
+pending = b""
+
+def redact_available(data, final=False):
+    keep = 0 if final else maximum_length - 1
+    pieces = []
+    while len(data) > keep:
+        match = next((value for value in secret_values if data.startswith(value)), None)
+        if match is not None:
+            pieces.append(marker)
+            data = data[len(match):]
+        else:
+            pieces.append(data[:1])
+            data = data[1:]
+        if len(pieces) >= 8192:
+            output.write(b"".join(pieces))
+            output.flush()
+            pieces.clear()
+    if pieces:
+        output.write(b"".join(pieces))
+        output.flush()
+    return data
+
+while True:
+    chunk = sys.stdin.buffer.read(65536)
+    if not chunk:
+        break
+    pending = redact_available(pending + chunk)
+
+redact_available(pending, final=True)
+' "$values_file" || exit_code=$?
+
+	return "$exit_code"
 }
 
 # Build environment from gopass secrets

--- a/.agents/scripts/tests/test-pre-commit-split.sh
+++ b/.agents/scripts/tests/test-pre-commit-split.sh
@@ -268,7 +268,44 @@ test_eslint_flat_config_root_allowlist() {
 	return 0
 }
 
-# --- Test 14: arbitrary root artifacts remain rejected ---
+# --- Test 14: npm lockfiles pass staged root validation ---
+test_npm_lockfile_root_validation() {
+	local fixture_dir
+	fixture_dir=$(mktemp -d)
+	local hook_dir="${fixture_dir}/.agents/scripts"
+	local hook_output=""
+	local hook_rc=0
+
+	mkdir -p "$hook_dir"
+	cp "$TEST_SCRIPTS_DIR/pre-commit-hook.sh" "$hook_dir/pre-commit-hook.sh"
+	cp "$TEST_SCRIPTS_DIR/shared-constants.sh" "$hook_dir/shared-constants.sh"
+	git -C "$fixture_dir" init --quiet
+	printf '%s\n' '{"name":"root-allowlist-fixture"}' >"${fixture_dir}/package.json"
+	printf '%s\n' '{"name":"root-allowlist-fixture","lockfileVersion":3,"packages":{}}' >"${fixture_dir}/package-lock.json"
+	git -C "$fixture_dir" add package.json package-lock.json
+
+	hook_output=$(cd "$fixture_dir" && HOOK_MODE=pre-commit bash "$hook_dir/pre-commit-hook.sh" 2>&1) || hook_rc=$?
+	if [[ "$hook_rc" -eq 0 ]]; then
+		print_result "root validation permits package.json with package-lock.json" 0
+	else
+		print_result "root validation permits package.json with package-lock.json" 1 "$hook_output"
+	fi
+
+	printf '%s\n' 'fixture artifact' >"${fixture_dir}/VERIFY-ROOT-ARTIFACT.md"
+	git -C "$fixture_dir" add VERIFY-ROOT-ARTIFACT.md
+	hook_rc=0
+	hook_output=$(cd "$fixture_dir" && HOOK_MODE=pre-commit bash "$hook_dir/pre-commit-hook.sh" 2>&1) || hook_rc=$?
+	if [[ "$hook_rc" -ne 0 && "$hook_output" == *"VERIFY-ROOT-ARTIFACT.md"* ]]; then
+		print_result "root validation still rejects arbitrary verification artifacts" 0
+	else
+		print_result "root validation still rejects arbitrary verification artifacts" 1 "$hook_output"
+	fi
+
+	rm -rf "$fixture_dir"
+	return 0
+}
+
+# --- Test 15: arbitrary root artifacts remain absent from the allowlist ---
 test_arbitrary_root_artifact_not_allowlisted() {
 	local hook_file="$TEST_SCRIPTS_DIR/pre-commit-hook.sh"
 	local artifact_file="VERIFY-ROOT-ARTIFACT.md"
@@ -298,6 +335,7 @@ test_status_reports_pre_push
 test_pre_commit_dispatcher_sets_mode
 test_pre_push_dispatcher_sets_mode
 test_eslint_flat_config_root_allowlist
+test_npm_lockfile_root_validation
 test_arbitrary_root_artifact_not_allowlisted
 
 echo ""

--- a/.agents/scripts/tests/test-secret-helper.sh
+++ b/.agents/scripts/tests/test-secret-helper.sh
@@ -54,7 +54,20 @@ case "$cmd" in
 	ls)
 		if [[ "${1:-}" == "--flat" ]]; then
 			printf '%s\n' 'aidevops/ZETA_KEY' 'aidevops/ALPHA_KEY' 'aidevops/ALPHA_KEY'
+			if [[ -n "${AIDEVOPS_TEST_SECRET:-}" ]]; then
+				printf '%s\n' 'aidevops/REDACTION_KEY'
+			fi
 		fi
+		exit 0
+		;;
+	show)
+		if [[ "${1:-}" == "-o" ]]; then
+			shift
+		fi
+		case "${1:-}" in
+			aidevops/REDACTION_KEY) printf '%s' "${AIDEVOPS_TEST_SECRET:-}" ;;
+			*) exit 1 ;;
+		esac
 		exit 0
 		;;
 	insert)
@@ -134,7 +147,7 @@ teardown() {
 		rm -rf "$TEST_DIR"
 	fi
 	TEST_DIR=""
-	unset AIDEVOPS_TEST_DIR || true
+	unset AIDEVOPS_TEST_DIR AIDEVOPS_TEST_SECRET || true
 	return 0
 }
 
@@ -215,6 +228,49 @@ test_set_rejects_command_literal_input() {
 	return 0
 }
 
+test_run_redacts_sed_significant_literal_values() {
+	setup
+	trap 'teardown' RETURN
+	local fixture='literal|fixture&with\slashes/[].*^$'
+	export AIDEVOPS_TEST_SECRET="$fixture"
+	local output=""
+	local exit_code=0
+
+	output=$(HOME="$TEST_DIR/home" bash "$HELPER" REDACTION_KEY -- bash -c \
+		'printf "stdout:%s\n" "$REDACTION_KEY"; printf "stderr:%s\n" "$REDACTION_KEY" >&2; exit 23') || exit_code=$?
+
+	if [[ "$exit_code" -eq 23 && "$output" == $'stdout:[REDACTED]\nstderr:[REDACTED]' && "$output" != *"$fixture"* && "$output" != *"unterminated substitute pattern"* ]]; then
+		print_result "run redacts sed-significant literals on both output streams" 0
+	else
+		print_result "run redacts sed-significant literals on both output streams" 1 "Redaction or exit-status assertion failed"
+	fi
+	return 0
+}
+
+test_run_fails_closed_when_redactor_cannot_start() {
+	setup
+	trap 'teardown' RETURN
+	local fixture='literal|fixture&with\slashes/[].*^$'
+	export AIDEVOPS_TEST_SECRET="$fixture"
+	cat >"$TEST_DIR/bin/python3" <<'EOF'
+#!/usr/bin/env bash
+exit 70
+EOF
+	chmod +x "$TEST_DIR/bin/python3"
+	local output=""
+	local exit_code=0
+
+	output=$(HOME="$TEST_DIR/home" bash "$HELPER" REDACTION_KEY -- bash -c \
+		'printf "%s\n" "$REDACTION_KEY"') || exit_code=$?
+
+	if [[ "$exit_code" -ne 0 && "$output" != *"$fixture"* ]]; then
+		print_result "run fails closed when redaction initialization fails" 0
+	else
+		print_result "run fails closed when redaction initialization fails" 1 "Expected sanitized non-zero failure"
+	fi
+	return 0
+}
+
 main() {
 	echo "Running secret-helper regression tests..."
 	echo ""
@@ -222,6 +278,8 @@ main() {
 	test_set_uses_provided_stdin_value
 	test_credentials_read_unescapes_special_chars
 	test_set_rejects_command_literal_input
+	test_run_redacts_sed_significant_literal_values
+	test_run_fails_closed_when_redactor_cannot_start
 	test_inventory_is_names_only_deterministic_json
 	test_inventory_rejects_malformed_gopass_name
 	test_inventory_requires_owner_only_credentials


### PR DESCRIPTION
## Summary

Replace generated sed programs with literal streaming redaction and allow standard root dependency lockfiles

## Files Changed

.agents/scripts/pre-commit-hook.sh, .agents/scripts/secret-helper.sh, .agents/scripts/tests/test-pre-commit-split.sh, .agents/scripts/tests/test-secret-helper.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Secret helper regression suite 8/8; pre-commit split suite 16/16; ShellCheck clean; changed-file linters passed; review bundle 11cd9de69c3a358dd7d44588af765fc0f2656d1d1af3e15ee07b033a8d4bbc9d

Resolves #29586


Resolves #29603

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.229 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 2h 13m and 392,008 tokens on this with the user in an interactive session.
