### PR TITLE
GH#29661: feat: suppress Actions retries during provider incidents

### DIFF
--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -175,6 +175,11 @@ Safety boundaries:
 - Superseded active runs may be cancelled only when the operator/helper can
   prove the run belongs to the same PR/branch, its head SHA is not the latest PR
   head SHA, and the run is still queued or in progress; otherwise leave it alone.
+- Before rerunning a proven infrastructure failure, query the cached public
+  GitHub Status incident feed with `gh-status-helper.sh check-actions`. An active
+  Actions incident suppresses the rerun and classifies delayed queued checks as
+  provider saturation; an unavailable status feed fails open. Use
+  `AIDEVOPS_SKIP_GITHUB_ACTIONS_STATUS=1` only as an explicit emergency bypass.
 
 Diagnosis commands:
 

--- a/.agents/scripts/gh-status-helper.sh
+++ b/.agents/scripts/gh-status-helper.sh
@@ -53,7 +53,6 @@ readonly CACHE_MAX_AGE_SECONDS="${AIDEVOPS_GH_STATUS_CACHE_TTL:-60}"
 readonly INDICATOR_UNKNOWN="unknown"
 readonly STATUS_NETWORK_FAILURE="network_failure"
 readonly ACTIONS_COMPONENT="Actions"
-readonly ACTIONS_INCIDENTS_JQ='[.incidents[]? | select(any(.components[]?; ((.name // "") | ascii_downcase) == "actions"))]'
 
 # CLI flag state
 ARG_JSON=0
@@ -151,6 +150,25 @@ _print_component_status_json() {
 	return 0
 }
 
+_actions_incidents_json() {
+	local cache_file="$1"
+	jq -c '
+		def is_object: type == "object";
+		def valid_component:
+			is_object and (.name | type) == "string";
+		def valid_incident:
+			is_object
+			and (.components | type) == "array"
+			and all(.components[]; valid_component);
+		if (is_object | not)
+			or (.incidents | type) != "array"
+			or (all(.incidents[]; valid_incident) | not)
+		then error("invalid incidents schema")
+		else [.incidents[] | select(any(.components[]; (.name | ascii_downcase) == "actions"))]
+		end' "$cache_file" 2>/dev/null
+	return $?
+}
+
 # cmd_check — fetch overall status, classify, print summary, set exit code.
 cmd_check() {
 	if ! _ensure_cache "$STATUS_URL" "$CACHE_STATUS"; then
@@ -187,7 +205,7 @@ cmd_check() {
 		;;
 	*)
 		exit_code=3
-		label="unknown"
+		label="$INDICATOR_UNKNOWN"
 		;;
 	esac
 
@@ -216,12 +234,13 @@ cmd_check_actions() {
 		return 3
 	fi
 
-	local incident_count="" impact="none" incident_name=""
-	incident_count=$(jq "${ACTIONS_INCIDENTS_JQ} | length" "$CACHE_INCIDENTS" 2>/dev/null) || return 3
+	local actions_incidents="" incident_count="" impact="none" incident_name=""
+	actions_incidents=$(_actions_incidents_json "$CACHE_INCIDENTS") || return 3
+	incident_count=$(printf '%s' "$actions_incidents" | jq 'length' 2>/dev/null) || return 3
 	[[ "$incident_count" =~ ^[0-9]+$ ]] || return 3
 	if [[ "$incident_count" -gt 0 ]]; then
-		impact=$(jq -r "${ACTIONS_INCIDENTS_JQ} | .[0].impact // \"unknown\"" "$CACHE_INCIDENTS")
-		incident_name=$(jq -r "${ACTIONS_INCIDENTS_JQ} | .[0].name // \"GitHub Actions incident\"" "$CACHE_INCIDENTS")
+		impact=$(printf '%s' "$actions_incidents" | jq -r --arg unknown "$INDICATOR_UNKNOWN" '.[0].impact // $unknown') || return 3
+		incident_name=$(printf '%s' "$actions_incidents" | jq -r '.[0].name // "GitHub Actions incident"') || return 3
 		if [[ "$ARG_JSON" -eq 1 ]]; then
 			_print_component_status_json "incident" "$ACTIONS_COMPONENT" "" "$impact" "$incident_name"
 		else

--- a/.agents/scripts/gh-status-helper.sh
+++ b/.agents/scripts/gh-status-helper.sh
@@ -51,6 +51,9 @@ readonly CACHE_MAX_AGE_SECONDS="${AIDEVOPS_GH_STATUS_CACHE_TTL:-60}"
 
 # Indicator literal used by jq fallbacks and case branches.
 readonly INDICATOR_UNKNOWN="unknown"
+readonly STATUS_NETWORK_FAILURE="network_failure"
+readonly ACTIONS_COMPONENT="Actions"
+readonly ACTIONS_INCIDENTS_JQ='[.incidents[]? | select(any(.components[]?; ((.name // "") | ascii_downcase) == "actions"))]'
 
 # CLI flag state
 ARG_JSON=0
@@ -128,11 +131,31 @@ _ensure_cache() {
 # Subcommands
 # ----------------------------------------------------------------------
 
+_print_component_status_json() {
+	local status="$1"
+	local component="${2:-}"
+	local reason="${3:-}"
+	local impact="${4:-}"
+	local incident="${5:-}"
+	jq -n \
+		--arg status "$status" \
+		--arg component "$component" \
+		--arg reason "$reason" \
+		--arg impact "$impact" \
+		--arg incident "$incident" '
+		{status:$status}
+		+ (if $component == "" then {} else {component:$component} end)
+		+ (if $reason == "" then {} else {reason:$reason} end)
+		+ (if $impact == "" then {} else {impact:$impact} end)
+		+ (if $incident == "" then {} else {incident:$incident} end)'
+	return 0
+}
+
 # cmd_check — fetch overall status, classify, print summary, set exit code.
 cmd_check() {
 	if ! _ensure_cache "$STATUS_URL" "$CACHE_STATUS"; then
 		if [[ "$ARG_JSON" -eq 1 ]]; then
-			printf '{"status":"%s","reason":"network_failure"}\n' "$INDICATOR_UNKNOWN"
+			printf '{"status":"%s","reason":"%s"}\n' "$INDICATOR_UNKNOWN" "$STATUS_NETWORK_FAILURE"
 		else
 			printf '%s — could not reach Statuspage API\n' "$INDICATOR_UNKNOWN" >&2
 		fi
@@ -186,7 +209,7 @@ cmd_check() {
 cmd_check_actions() {
 	if ! _ensure_cache "$INCIDENTS_URL" "$CACHE_INCIDENTS"; then
 		if [[ "$ARG_JSON" -eq 1 ]]; then
-			printf '{"status":"%s","component":"Actions","reason":"network_failure"}\n' "$INDICATOR_UNKNOWN"
+			_print_component_status_json "$INDICATOR_UNKNOWN" "$ACTIONS_COMPONENT" "$STATUS_NETWORK_FAILURE"
 		else
 			printf '%s — could not reach Statuspage API\n' "$INDICATOR_UNKNOWN" >&2
 		fi
@@ -194,14 +217,13 @@ cmd_check_actions() {
 	fi
 
 	local incident_count="" impact="none" incident_name=""
-	incident_count=$(jq '[.incidents[]? | select(any(.components[]?; ((.name // "") | ascii_downcase) == "actions"))] | length' "$CACHE_INCIDENTS" 2>/dev/null) || return 3
+	incident_count=$(jq "${ACTIONS_INCIDENTS_JQ} | length" "$CACHE_INCIDENTS" 2>/dev/null) || return 3
 	[[ "$incident_count" =~ ^[0-9]+$ ]] || return 3
 	if [[ "$incident_count" -gt 0 ]]; then
-		impact=$(jq -r '[.incidents[]? | select(any(.components[]?; ((.name // "") | ascii_downcase) == "actions"))][0].impact // "unknown"' "$CACHE_INCIDENTS")
-		incident_name=$(jq -r '[.incidents[]? | select(any(.components[]?; ((.name // "") | ascii_downcase) == "actions"))][0].name // "GitHub Actions incident"' "$CACHE_INCIDENTS")
+		impact=$(jq -r "${ACTIONS_INCIDENTS_JQ} | .[0].impact // \"unknown\"" "$CACHE_INCIDENTS")
+		incident_name=$(jq -r "${ACTIONS_INCIDENTS_JQ} | .[0].name // \"GitHub Actions incident\"" "$CACHE_INCIDENTS")
 		if [[ "$ARG_JSON" -eq 1 ]]; then
-			jq -n --arg impact "$impact" --arg name "$incident_name" \
-				'{status:"incident",component:"Actions",impact:$impact,incident:$name}'
+			_print_component_status_json "incident" "$ACTIONS_COMPONENT" "" "$impact" "$incident_name"
 		else
 			printf 'incident — Actions affected by %s (%s)\n' "$incident_name" "$impact"
 		fi
@@ -209,7 +231,7 @@ cmd_check_actions() {
 	fi
 
 	if [[ "$ARG_JSON" -eq 1 ]]; then
-		printf '{"status":"operational","component":"Actions"}\n'
+		_print_component_status_json "operational" "$ACTIONS_COMPONENT"
 	else
 		printf 'operational — no unresolved Actions incident\n'
 	fi
@@ -220,7 +242,7 @@ cmd_check_actions() {
 cmd_incidents() {
 	if ! _ensure_cache "$INCIDENTS_URL" "$CACHE_INCIDENTS"; then
 		if [[ "$ARG_JSON" -eq 1 ]]; then
-			printf '{"incidents":[],"reason":"network_failure"}\n'
+			printf '{"incidents":[],"reason":"%s"}\n' "$STATUS_NETWORK_FAILURE"
 		else
 			printf '%s — could not reach Statuspage API\n' "$INDICATOR_UNKNOWN" >&2
 		fi

--- a/.agents/scripts/gh-status-helper.sh
+++ b/.agents/scripts/gh-status-helper.sh
@@ -11,6 +11,7 @@
 #
 # Usage:
 #   gh-status-helper.sh check                 # one-line summary; exit 0/1/2
+#   gh-status-helper.sh check-actions         # Actions incident circuit-breaker signal
 #   gh-status-helper.sh incidents             # list active incidents
 #   gh-status-helper.sh correlate             # markdown block for issue comments
 #   gh-status-helper.sh check --json          # JSON output for programmatic callers
@@ -179,6 +180,42 @@ cmd_check() {
 	return "$exit_code"
 }
 
+# cmd_check_actions — report whether an unresolved incident affects Actions.
+# This component-specific signal is intentionally stricter than the overall
+# status indicator: even a minor platform incident can make CI retries harmful.
+cmd_check_actions() {
+	if ! _ensure_cache "$INCIDENTS_URL" "$CACHE_INCIDENTS"; then
+		if [[ "$ARG_JSON" -eq 1 ]]; then
+			printf '{"status":"%s","component":"Actions","reason":"network_failure"}\n' "$INDICATOR_UNKNOWN"
+		else
+			printf '%s — could not reach Statuspage API\n' "$INDICATOR_UNKNOWN" >&2
+		fi
+		return 3
+	fi
+
+	local incident_count="" impact="none" incident_name=""
+	incident_count=$(jq '[.incidents[]? | select(any(.components[]?; ((.name // "") | ascii_downcase) == "actions"))] | length' "$CACHE_INCIDENTS" 2>/dev/null) || return 3
+	[[ "$incident_count" =~ ^[0-9]+$ ]] || return 3
+	if [[ "$incident_count" -gt 0 ]]; then
+		impact=$(jq -r '[.incidents[]? | select(any(.components[]?; ((.name // "") | ascii_downcase) == "actions"))][0].impact // "unknown"' "$CACHE_INCIDENTS")
+		incident_name=$(jq -r '[.incidents[]? | select(any(.components[]?; ((.name // "") | ascii_downcase) == "actions"))][0].name // "GitHub Actions incident"' "$CACHE_INCIDENTS")
+		if [[ "$ARG_JSON" -eq 1 ]]; then
+			jq -n --arg impact "$impact" --arg name "$incident_name" \
+				'{status:"incident",component:"Actions",impact:$impact,incident:$name}'
+		else
+			printf 'incident — Actions affected by %s (%s)\n' "$incident_name" "$impact"
+		fi
+		return 1
+	fi
+
+	if [[ "$ARG_JSON" -eq 1 ]]; then
+		printf '{"status":"operational","component":"Actions"}\n'
+	else
+		printf 'operational — no unresolved Actions incident\n'
+	fi
+	return 0
+}
+
 # cmd_incidents — list unresolved incidents.
 cmd_incidents() {
 	if ! _ensure_cache "$INCIDENTS_URL" "$CACHE_INCIDENTS"; then
@@ -248,6 +285,7 @@ gh-status-helper.sh — Query GitHub Statuspage API for platform health
 
 Usage:
   gh-status-helper.sh check        [--json] [--no-cache]
+  gh-status-helper.sh check-actions [--json] [--no-cache]
   gh-status-helper.sh incidents    [--json] [--no-cache]
   gh-status-helper.sh correlate              [--no-cache]
   gh-status-helper.sh -h | --help
@@ -257,6 +295,8 @@ Exit codes (check):
   1  degraded (major)
   2  outage (critical)
   3  unknown / network failure
+
+Exit codes (check-actions): 0 operational, 1 active incident, 3 unknown.
 
 Cache: ~/.aidevops/cache/gh-status-*.json (60s TTL, override via
 AIDEVOPS_GH_STATUS_CACHE_TTL).
@@ -279,7 +319,7 @@ main() {
 			print_usage
 			return 0
 			;;
-		check | incidents | correlate)
+		check | check-actions | incidents | correlate)
 			subcommand="$arg"
 			;;
 		*)
@@ -293,6 +333,7 @@ main() {
 
 	case "$subcommand" in
 	check) cmd_check ;;
+	check-actions) cmd_check_actions ;;
 	incidents) cmd_incidents ;;
 	correlate) cmd_correlate ;;
 	"")

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -425,6 +425,7 @@ _pmrc_normalize_snapshot_checks_json() {
 			$pages[]?.check_runs[]? | {
 				source: "check_run",
 				name: (.name // ""),
+				app_slug: (.app.slug // ""),
 				status: ((.status // "") | ascii_downcase),
 				conclusion: ((.conclusion // "") | ascii_downcase),
 				link: (.details_url // .html_url // ""),
@@ -434,6 +435,7 @@ _pmrc_normalize_snapshot_checks_json() {
 			$statuses.statuses[]? | ((.state // "") | ascii_downcase) as $state | {
 				source: "commit_status",
 				name: (.context // ""),
+				app_slug: "",
 				status: (if $state == $pending then $in_progress else $completed end),
 				conclusion: (if $state == $success then $success elif ($state == $failure or $state == $error) then $failure else "" end),
 				link: (.target_url // ""),
@@ -444,8 +446,7 @@ _pmrc_normalize_snapshot_checks_json() {
 		| sort_by(.source, .name, .observed_at)
 		| group_by([.source, .name])
 		| map(
-			# A conditional/skipped rerun is not newer execution evidence. Preserve
-			# the latest executed result so advisory companions cannot disappear.
+			# Preserve the latest executed result so skipped reruns cannot hide advisory companions.
 			. as $runs
 			| ([$runs[] | select(.conclusion != $skipped)] | last) as $executed
 			| $executed // last
@@ -488,11 +489,12 @@ _pmrc_normalize_snapshot_checks_json() {
 						elif ($family == $maintainer and all($effective[]; (.conclusion == $success or .conclusion == "neutral" or .conclusion == $skipped))) then $success
 						else "" end
 					),
+					app_slug: ([$effective[]?.app_slug | select(. != "")] | first // ""),
 					observed_at: ([$effective[]?.observed_at | select(. != "")] | max // ""),
-					members: [$members[] | {name, source, status, conclusion, link, observed_at}]
+					members: [$members[] | {name, source, app_slug, status, conclusion, link, observed_at}]
 				} else
 				($members | sort_by(.observed_at) | last) as $latest
-				| ($latest | del(.family_key)) + {members: [$members[] | {name, source, status, conclusion, link, observed_at}]}
+				| ($latest | del(.family_key)) + {members: [$members[] | {name, source, app_slug, status, conclusion, link, observed_at}]}
 			end
 		)
 		| sort_by(.name)

--- a/.agents/scripts/pulse-merge-required-checks.sh
+++ b/.agents/scripts/pulse-merge-required-checks.sh
@@ -5,6 +5,7 @@
 
 [[ -n "${_PULSE_MERGE_REQUIRED_CHECKS_LOADED:-}" ]] && return 0
 _PULSE_MERGE_REQUIRED_CHECKS_LOADED=1
+_PULSE_MERGE_REQUIRED_CHECKS_DIR="${BASH_SOURCE[0]%/*}"
 PMRC_CHECK_COMPLETED="completed"
 PMRC_CHECK_SUCCESS="success"
 PMRC_CHECK_FAILURE="failure"
@@ -695,6 +696,16 @@ _pmrc_is_explicit_advisory_failure() {
 	return $?
 }
 
+_pmrc_actions_incident_blocks_rerun() {
+	local helper="${AIDEVOPS_GH_STATUS_HELPER:-${_PULSE_MERGE_REQUIRED_CHECKS_DIR:-${HOME:+$HOME/.aidevops/agents/scripts}}/gh-status-helper.sh}"
+	local status_rc=0
+	[[ "${AIDEVOPS_SKIP_GITHUB_ACTIONS_STATUS:-0}" != "1" ]] || return 1
+	[[ -x "$helper" ]] || return 1
+	"$helper" check-actions --json >/dev/null 2>&1 || status_rc=$?
+	[[ "$status_rc" -eq 1 ]]
+	return $?
+}
+
 #######################################
 # Request a bounded rerun for a GitHub Actions job whose failed log proves an
 # infrastructure failure. The merge remains blocked until a later snapshot
@@ -727,6 +738,11 @@ _pmrc_rerun_infrastructure_check() {
 		! repo_allows_pulse_write_actions "$repo_slug"; then
 		echo "[pulse-merge] infrastructure rerun deferred for PR #${pr_number} check '${check_name}' in ${repo_slug} — repository writes are disabled" >>"$log_target"
 		return 1
+	fi
+
+	if _pmrc_actions_incident_blocks_rerun; then
+		echo "[pulse-merge] infrastructure rerun deferred for PR #${pr_number} check '${check_name}' in ${repo_slug} — GitHub Status reports an active Actions incident; retry amplification suppressed" >>"$log_target"
+		return 0
 	fi
 
 	mkdir -p "$state_dir" 2>/dev/null || return 1

--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -101,13 +101,13 @@ _PULSE_MERGE_STUCK_CONF="${_PULSE_MERGE_STUCK_DIR}/../configs/pulse-merge-stuck.
 if [[ -f "$_PULSE_MERGE_STUCK_CONF" ]]; then
 	# Only source values for vars that aren't already set by the env.
 	# shellcheck source=/dev/null
-	[[ -z "${AIDEVOPS_MERGE_STUCK_AGE_MINUTES:-}" ]] && \
+	[[ -z "${AIDEVOPS_MERGE_STUCK_AGE_MINUTES:-}" ]] &&
 		AIDEVOPS_MERGE_STUCK_AGE_MINUTES=$(grep -E '^AIDEVOPS_MERGE_STUCK_AGE_MINUTES=' "$_PULSE_MERGE_STUCK_CONF" 2>/dev/null | tail -1 | cut -d= -f2)
-	[[ -z "${AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES:-}" ]] && \
+	[[ -z "${AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES:-}" ]] &&
 		AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES=$(grep -E '^AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES=' "$_PULSE_MERGE_STUCK_CONF" 2>/dev/null | tail -1 | cut -d= -f2)
-	[[ -z "${AIDEVOPS_MERGE_PATTERN_MIN_PRS:-}" ]] && \
+	[[ -z "${AIDEVOPS_MERGE_PATTERN_MIN_PRS:-}" ]] &&
 		AIDEVOPS_MERGE_PATTERN_MIN_PRS=$(grep -E '^AIDEVOPS_MERGE_PATTERN_MIN_PRS=' "$_PULSE_MERGE_STUCK_CONF" 2>/dev/null | tail -1 | cut -d= -f2)
-	[[ -z "${AIDEVOPS_MERGE_STUCK_ENABLED:-}" ]] && \
+	[[ -z "${AIDEVOPS_MERGE_STUCK_ENABLED:-}" ]] &&
 		AIDEVOPS_MERGE_STUCK_ENABLED=$(grep -E '^AIDEVOPS_MERGE_STUCK_ENABLED=' "$_PULSE_MERGE_STUCK_CONF" 2>/dev/null | tail -1 | cut -d= -f2)
 fi
 
@@ -145,8 +145,8 @@ _pms_enrich_pr_state() {
 	local repo_slug="$1"
 	local pr_json="$2"
 
-	if ! declare -F _pmp_enrich_prs_with_mergeability >/dev/null 2>&1 \
-		|| ! declare -F _pmp_enrich_prs_with_review_decisions >/dev/null 2>&1; then
+	if ! declare -F _pmp_enrich_prs_with_mergeability >/dev/null 2>&1 ||
+		! declare -F _pmp_enrich_prs_with_review_decisions >/dev/null 2>&1; then
 		printf '%s' "$pr_json"
 		return 0
 	fi
@@ -182,9 +182,9 @@ readonly _PMS_JQ_REST_FAILURE_SELECTOR='def _ueq(f;v): (f // "" | ascii_upcase) 
 _pms_iso_to_epoch() {
 	local iso="$1"
 	local result
-	result=$(date -d "$iso" +%s 2>/dev/null) \
-		|| result=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null) \
-		|| result=0
+	result=$(date -d "$iso" +%s 2>/dev/null) ||
+		result=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null) ||
+		result=0
 	[[ "$result" =~ ^[0-9]+$ ]] || result=0
 	printf '%s' "$result"
 	return 0
@@ -205,11 +205,20 @@ _pms_is_eligible_stuck() {
 	labels=$(printf '%s' "$pr_obj" | jq -r '[.labels[].name] | join(",")' 2>/dev/null)
 
 	# Skip drafts unconditionally
-	[[ "$is_draft" == "true" ]] && { printf '0'; return 0; }
+	[[ "$is_draft" == "true" ]] && {
+		printf '0'
+		return 0
+	}
 	# Skip hold-for-review opt-out
-	[[ "$labels" == *"hold-for-review"* ]] && { printf '0'; return 0; }
+	[[ "$labels" == *"hold-for-review"* ]] && {
+		printf '0'
+		return 0
+	}
 	# CHANGES_REQUESTED is a real review block, not a stuck state
-	[[ "$review_decision" == "CHANGES_REQUESTED" ]] && { printf '0'; return 0; }
+	[[ "$review_decision" == "CHANGES_REQUESTED" ]] && {
+		printf '0'
+		return 0
+	}
 
 	# MERGEABLE + APPROVED is the canonical eligible-stuck path; CONFLICTING
 	# without a nudge-eligible label is the gap case we still want to detect.
@@ -240,9 +249,9 @@ _pms_check_runs_for_head() {
 	local head_sha="$2"
 	local runs=""
 	local fetch_succeeded=0
-	if [[ -n "$repo_slug" && -n "$head_sha" ]] \
-		&& declare -F _pmp_same_pass_check_evidence_get >/dev/null 2>&1 \
-		&& runs=$(_pmp_same_pass_check_evidence_get "$repo_slug" "$head_sha" 2>/dev/null); then
+	if [[ -n "$repo_slug" && -n "$head_sha" ]] &&
+		declare -F _pmp_same_pass_check_evidence_get >/dev/null 2>&1 &&
+		runs=$(_pmp_same_pass_check_evidence_get "$repo_slug" "$head_sha" 2>/dev/null); then
 		printf '%s' "$runs"
 		return 0
 	fi
@@ -284,11 +293,23 @@ _pms_queued_check_count() {
 	local runs_json="$1"
 	local count=""
 	count=$(printf '%s' "$runs_json" | jq -r \
-		'[.[]? | select((.status // "" | ascii_upcase) == "QUEUED")] | length' \
+		'[.[]? | select(
+			(.status // "" | ascii_upcase) == "QUEUED"
+			and ((.app_slug // .app.slug // "") | IN("github-actions"))
+		)] | length' \
 		2>/dev/null) || count="0"
 	[[ "$count" =~ ^[0-9]+$ ]] || count=0
 	printf '%s' "$count"
 	return 0
+}
+
+_pms_should_file_runner_saturation_issue() {
+	local is_saturated="$1"
+	local provider_incident="$2"
+	local blocked_count="$3"
+	[[ "$blocked_count" =~ ^[0-9]+$ ]] || return 1
+	[[ "$is_saturated" == "1" && "$provider_incident" != "1" && "$blocked_count" -gt 0 ]]
+	return $?
 }
 
 #######################################
@@ -376,9 +397,9 @@ _classify_stuck_pr() {
 	fi
 
 	# Conflict + no nudge label → that gap.
-	if [[ "$mergeable" == "CONFLICTING" \
-		&& "$labels" != *"origin:interactive"* \
-		&& "$labels" != *"origin:worker"* ]]; then
+	if [[ "$mergeable" == "CONFLICTING" &&
+		"$labels" != *"origin:interactive"* &&
+		"$labels" != *"origin:worker"* ]]; then
 		printf 'STUCK_CONFLICT_NO_NUDGE_LABEL'
 		return 0
 	fi
@@ -724,7 +745,10 @@ _detect_pattern_outage() {
 	# Build "fingerprint <TAB> pr_number" lines, then group by fingerprint.
 	local tmp_lines="" tmp_groups=""
 	tmp_lines=$(mktemp "${TMPDIR:-/tmp}/pms-fp-XXXXXX") || return 0
-	tmp_groups=$(mktemp "${TMPDIR:-/tmp}/pms-grp-XXXXXX") || { rm -f "$tmp_lines"; return 0; }
+	tmp_groups=$(mktemp "${TMPDIR:-/tmp}/pms-grp-XXXXXX") || {
+		rm -f "$tmp_lines"
+		return 0
+	}
 	# shellcheck disable=SC2064
 	trap "rm -f '$tmp_lines' '$tmp_groups'" RETURN
 
@@ -1231,8 +1255,8 @@ _pms_close_zero_progress_meta_issue_if_recovered() {
 	local marker_text="merge-stuck:zero-progress"
 	[[ -n "$reason" ]] || reason="merge progress recovered"
 	# #aidevops:trust-boundary — public issue comments can succeed for non-collaborators.
-	if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
-		|| ! repo_allows_pulse_write_actions "$meta_repo"; then
+	if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 ||
+		! repo_allows_pulse_write_actions "$meta_repo"; then
 		echo "[pulse-merge-stuck] _pms_close_zero_progress_meta_issue_if_recovered: skipping recovery write in ${meta_repo} — runner lacks repo write permission" >>"$LOGFILE"
 		return 0
 	fi
@@ -1301,8 +1325,8 @@ _pms_pr_counts_for_zero_progress() {
 	fi
 
 	if [[ "$labels_tokenized" == *",origin:interactive,"* ]]; then
-		if ! declare -F _interactive_pr_auto_merge_allowed >/dev/null 2>&1 \
-			|| ! _interactive_pr_auto_merge_allowed "$pr_number" "$repo_slug" "$labels_str" >/dev/null 2>&1; then
+		if ! declare -F _interactive_pr_auto_merge_allowed >/dev/null 2>&1 ||
+			! _interactive_pr_auto_merge_allowed "$pr_number" "$repo_slug" "$labels_str" >/dev/null 2>&1; then
 			echo "[pulse-merge-stuck] _pms_count_eligible_unmerged_for_repo: excluding PR #${pr_number} in ${repo_slug} — origin:interactive PR requires manual merge" >>"$LOGFILE"
 			return 1
 		fi
@@ -1322,8 +1346,8 @@ _pms_pr_counts_for_zero_progress() {
 			echo "[pulse-merge-stuck] _pms_count_eligible_unmerged_for_repo: excluding PR #${pr_number} in ${repo_slug} — external-contributor PR has no linked issue" >>"$LOGFILE"
 			return 1
 		fi
-		if ! declare -F _has_maintainer_crypto_approval >/dev/null 2>&1 \
-			|| ! _has_maintainer_crypto_approval "$pr_number" "$repo_slug"; then
+		if ! declare -F _has_maintainer_crypto_approval >/dev/null 2>&1 ||
+			! _has_maintainer_crypto_approval "$pr_number" "$repo_slug"; then
 			echo "[pulse-merge-stuck] _pms_count_eligible_unmerged_for_repo: excluding PR #${pr_number} in ${repo_slug} — external-contributor PR linked issue #${external_linked_issue} lacks crypto approval" >>"$LOGFILE"
 			return 1
 		fi
@@ -1336,8 +1360,8 @@ _pms_pr_counts_for_zero_progress() {
 	# candidate is already drained.
 	if declare -F _is_collaborator_author >/dev/null 2>&1; then
 		if ! _is_collaborator_author "$pr_author" "$repo_slug"; then
-			if ! declare -F _has_maintainer_crypto_approval >/dev/null 2>&1 \
-				|| ! _has_maintainer_crypto_approval "$pr_number" "$repo_slug"; then
+			if ! declare -F _has_maintainer_crypto_approval >/dev/null 2>&1 ||
+				! _has_maintainer_crypto_approval "$pr_number" "$repo_slug"; then
 				echo "[pulse-merge-stuck] _pms_count_eligible_unmerged_for_repo: excluding PR #${pr_number} in ${repo_slug} — author ${pr_author} is not a collaborator" >>"$LOGFILE"
 				return 1
 			fi
@@ -1383,10 +1407,13 @@ _pms_pr_counts_for_zero_progress() {
 
 _pms_count_eligible_unmerged_for_repo() {
 	local repo_slug="$1"
-	[[ -n "$repo_slug" ]] || { printf '0'; return 0; }
+	[[ -n "$repo_slug" ]] || {
+		printf '0'
+		return 0
+	}
 	local same_pass_count=""
-	if declare -F _pmp_count_same_pass_eligible_unmerged >/dev/null 2>&1 \
-		&& same_pass_count=$(_pmp_count_same_pass_eligible_unmerged "$repo_slug" 2>/dev/null); then
+	if declare -F _pmp_count_same_pass_eligible_unmerged >/dev/null 2>&1 &&
+		same_pass_count=$(_pmp_count_same_pass_eligible_unmerged "$repo_slug" 2>/dev/null); then
 		[[ "$same_pass_count" =~ ^[0-9]+$ ]] || return 2
 		printf '%s' "$same_pass_count"
 		return 0
@@ -1516,26 +1543,26 @@ _pms_handle_classified_pr() {
 	fi
 
 	case "$classification" in
-		STUCK_RUNNER_QUEUE_SATURATION)
-			# Suppress per-PR escalation — caller aggregates for meta-issue.
-			echo "[pulse-merge-stuck] _pms_handle_classified_pr: PR #${pr_num} (${repo_slug}) classified STUCK_RUNNER_QUEUE_SATURATION — suppressing per-PR escalation, will aggregate to meta-issue" >>"$LOGFILE"
-			printf 'SATURATED'
-			;;
-		STUCK_BRANCHPROTECT_404)
-			_handle_stuck_branchprotect_404 "$pr_num" "$repo_slug"
-			printf 'HANDLED'
-			;;
-		STUCK_CONFLICT_NO_NUDGE_LABEL)
-			_handle_stuck_conflict_no_nudge_label "$pr_num" "$repo_slug"
-			printf 'HANDLED'
-			;;
-		STUCK_CHECKS_FAILING|STUCK_BRANCHPROTECT_API_ERROR|STUCK_AUTH|STUCK_OTHER)
-			_escalate_individual_stuck_pr "$pr_num" "$repo_slug" "$classification" "$linked_issue" "$head_sha"
-			printf 'HANDLED'
-			;;
-		*)
-			printf 'HANDLED'
-			;;
+	STUCK_RUNNER_QUEUE_SATURATION)
+		# Suppress per-PR escalation — caller aggregates for meta-issue.
+		echo "[pulse-merge-stuck] _pms_handle_classified_pr: PR #${pr_num} (${repo_slug}) classified STUCK_RUNNER_QUEUE_SATURATION — suppressing per-PR escalation, will aggregate to meta-issue" >>"$LOGFILE"
+		printf 'SATURATED'
+		;;
+	STUCK_BRANCHPROTECT_404)
+		_handle_stuck_branchprotect_404 "$pr_num" "$repo_slug"
+		printf 'HANDLED'
+		;;
+	STUCK_CONFLICT_NO_NUDGE_LABEL)
+		_handle_stuck_conflict_no_nudge_label "$pr_num" "$repo_slug"
+		printf 'HANDLED'
+		;;
+	STUCK_CHECKS_FAILING | STUCK_BRANCHPROTECT_API_ERROR | STUCK_AUTH | STUCK_OTHER)
+		_escalate_individual_stuck_pr "$pr_num" "$repo_slug" "$classification" "$linked_issue" "$head_sha"
+		printf 'HANDLED'
+		;;
+	*)
+		printf 'HANDLED'
+		;;
 	esac
 	return 0
 }
@@ -1637,16 +1664,18 @@ pulse_merge_stuck_run_pass() {
 	local age_threshold_secs=$((AIDEVOPS_MERGE_STUCK_AGE_MINUTES * 60))
 
 	# Compute Actions runner queue saturation ONCE per repo per cycle (t3211).
-	local sat_queued=0 sat_in_progress=0 sat_ratio=0 is_saturated=0 saturation_state
+	local sat_queued=0 sat_in_progress=0 sat_ratio=0 is_saturated=0 provider_incident=0 saturation_state
 	saturation_state=$(_pms_compute_saturation_state "$repo_slug")
 	sat_queued=$(printf '%s\n' "$saturation_state" | grep -E '^queued=' | head -1 | cut -d= -f2)
 	sat_in_progress=$(printf '%s\n' "$saturation_state" | grep -E '^in_progress=' | head -1 | cut -d= -f2)
 	sat_ratio=$(printf '%s\n' "$saturation_state" | grep -E '^ratio=' | head -1 | cut -d= -f2)
 	is_saturated=$(printf '%s\n' "$saturation_state" | grep -E '^saturated=' | head -1 | cut -d= -f2)
+	provider_incident=$(printf '%s\n' "$saturation_state" | grep -E '^provider_incident=' | head -1 | cut -d= -f2) || provider_incident=0
 	[[ "$sat_queued" =~ ^[0-9]+$ ]] || sat_queued=0
 	[[ "$sat_in_progress" =~ ^[0-9]+$ ]] || sat_in_progress=0
 	[[ "$sat_ratio" =~ ^[0-9]+$ ]] || sat_ratio=0
 	[[ "$is_saturated" == "1" ]] || is_saturated=0
+	[[ "$provider_incident" == "1" ]] || provider_incident=0
 	if _pms_diagnostic_budget_exhausted; then
 		[[ -n "$completion_var" ]] && printf -v "$completion_var" '%s' '0'
 		return 0
@@ -1669,11 +1698,11 @@ pulse_merge_stuck_run_pass() {
 	# Update the gauge for this cycle's count.
 	pulse_stats_set_gauge "pulse_merge_eligible_stuck_pr_count" "$eligible_stuck_count"
 
-	# File the runner-queue-saturation meta-issue if saturation was detected
+	# File the runner-queue-saturation meta-issue if measured saturation was detected
 	# AND at least one stuck PR was classified into that bucket. The
-	# saturated-but-no-affected-PRs case (rare — saturation cleared between
-	# the helper call and the PR iteration) is intentionally a no-op.
-	if [[ "$is_saturated" == "1" && "$saturation_blocked_count" -gt 0 ]]; then
+	# saturated-but-no-affected-PRs and provider-incident cases are no-ops:
+	# neither provides measured runner-pool counts for an actionable repair issue.
+	if _pms_should_file_runner_saturation_issue "$is_saturated" "$provider_incident" "$saturation_blocked_count"; then
 		# Strip trailing comma from the aggregated PR list.
 		saturation_blocked_prs="${saturation_blocked_prs%,}"
 		_pms_file_runner_saturation_issue "$repo_slug" \
@@ -1686,7 +1715,7 @@ pulse_merge_stuck_run_pass() {
 		_detect_pattern_outage "$repo_slug" "$(printf '%b' "$stuck_pr_numbers")" "$pr_json" || true
 	fi
 
-	echo "[pulse-merge-stuck] pulse_merge_stuck_run_pass: ${repo_slug} — eligible_stuck=${eligible_stuck_count}, threshold=${AIDEVOPS_MERGE_STUCK_AGE_MINUTES}m, saturated=${is_saturated} (queued=${sat_queued}, in_progress=${sat_in_progress}, ratio=${sat_ratio}, blocked_by_saturation=${saturation_blocked_count})" >>"$LOGFILE"
+	echo "[pulse-merge-stuck] pulse_merge_stuck_run_pass: ${repo_slug} — eligible_stuck=${eligible_stuck_count}, threshold=${AIDEVOPS_MERGE_STUCK_AGE_MINUTES}m, saturated=${is_saturated} (provider_incident=${provider_incident}, queued=${sat_queued}, in_progress=${sat_in_progress}, ratio=${sat_ratio}, blocked_by_saturation=${saturation_blocked_count})" >>"$LOGFILE"
 	return 0
 }
 
@@ -1792,8 +1821,8 @@ pulse_merge_zero_progress_record() {
 	echo "[pulse-merge-stuck] pulse_merge_zero_progress_record: zero_progress_cycles=${cur}/${threshold}, eligible_unmerged=${eligible_unmerged}" >>"$LOGFILE"
 
 	# File only on the threshold-crossing edge to prevent post-close issue storms.
-	if [[ "$cur_before" -lt "$threshold" \
-		&& "$cur" -ge "$threshold" ]]; then
+	if [[ "$cur_before" -lt "$threshold" &&
+		"$cur" -ge "$threshold" ]]; then
 		local stuck_summary
 		stuck_summary=$(pulse_stats_get_gauge "pulse_merge_eligible_stuck_pr_count")
 		stuck_summary="eligible_unmerged_this_cycle=${eligible_unmerged}, eligible_stuck_count=${stuck_summary}, zero_progress_cycles=${cur}"

--- a/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
@@ -401,6 +401,7 @@ _circuit_breaker_status() {
 #   in_progress=M    (count of in-progress workflow runs)
 #   ratio=R          (integer queued / max(in_progress,1); use as advisory)
 #   saturated=0|1    (1 iff both threshold conditions hold)
+#   provider_incident=0|1 (1 iff GitHub Status reports an Actions incident)
 #
 # Returns:
 #   0 — successful query (saturated may be 0 or 1)
@@ -421,21 +422,35 @@ _check_actions_queue_saturation() {
 
 	# Empty repo_slug → cannot query → fail-open with zeros.
 	if [[ -z "$repo_slug" ]]; then
-		printf 'queued=0\nin_progress=0\nratio=0\nsaturated=0\n'
+		printf 'queued=0\nin_progress=0\nratio=0\nsaturated=0\nprovider_incident=0\n'
 		return 0
 	fi
 
 	# Emergency bypass.
 	if [[ "${AIDEVOPS_SKIP_ACTIONS_QUEUE_SATURATION:-0}" == "1" ]]; then
 		echo "${_CB_RL_LOG_PREFIX} AIDEVOPS_SKIP_ACTIONS_QUEUE_SATURATION=1 — bypassing actions queue check for ${repo_slug}" >>"$LOGFILE"
-		printf 'queued=0\nin_progress=0\nratio=0\nsaturated=0\n'
+		printf 'queued=0\nin_progress=0\nratio=0\nsaturated=0\nprovider_incident=0\n'
 		return 0
 	fi
 
 	# Disabled if QUEUED_MIN is 0.
 	if [[ "$queued_min" -eq 0 ]]; then
-		printf 'queued=0\nin_progress=0\nratio=0\nsaturated=0\n'
+		printf 'queued=0\nin_progress=0\nratio=0\nsaturated=0\nprovider_incident=0\n'
 		return 0
+	fi
+
+	# Consult the public provider status only on the stuck/queue path. The helper
+	# caches responses, and an unknown/unreachable Statuspage fails open so a
+	# third-party diagnostic dependency cannot stop healthy automation.
+	local status_helper="${AIDEVOPS_GH_STATUS_HELPER:-${SCRIPT_DIR}/gh-status-helper.sh}"
+	local status_rc=0
+	if [[ "${AIDEVOPS_SKIP_GITHUB_ACTIONS_STATUS:-0}" != "1" && -x "$status_helper" ]]; then
+		"$status_helper" check-actions --json >/dev/null 2>&1 || status_rc=$?
+		if [[ "$status_rc" -eq 1 ]]; then
+			echo "${_CB_RL_LOG_PREFIX} GitHub Status reports an active Actions incident — treating delayed queues as provider saturation" >>"$LOGFILE"
+			printf 'queued=0\nin_progress=0\nratio=0\nsaturated=1\nprovider_incident=1\n'
+			return 0
+		fi
 	fi
 
 	# Query Actions runs for queued + in_progress states. per_page=1 is
@@ -448,7 +463,7 @@ _check_actions_queue_saturation() {
 	# Fail-open on any API error — instrumentation must never break the pulse.
 	if [[ -z "$queued_json" || -z "$in_progress_json" ]]; then
 		echo "${_CB_RL_LOG_PREFIX} WARNING: gh api repos/${repo_slug}/actions/runs failed — fail-open with saturated=0" >>"$LOGFILE"
-		printf 'queued=0\nin_progress=0\nratio=0\nsaturated=0\n'
+		printf 'queued=0\nin_progress=0\nratio=0\nsaturated=0\nprovider_incident=0\n'
 		return 2
 	fi
 
@@ -476,7 +491,7 @@ _check_actions_queue_saturation() {
 		echo "${_CB_RL_LOG_PREFIX} ${repo_slug} actions queue SATURATED: queued=${queued} in_progress=${in_progress} ratio=${ratio} (thresholds queued>${queued_min} ratio>${ratio_min})" >>"$LOGFILE"
 	fi
 
-	printf 'queued=%s\nin_progress=%s\nratio=%s\nsaturated=%s\n' \
+	printf 'queued=%s\nin_progress=%s\nratio=%s\nsaturated=%s\nprovider_incident=0\n' \
 		"$queued" "$in_progress" "$ratio" "$saturated"
 	return 0
 }
@@ -528,6 +543,7 @@ _main() {
 			echo "  AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN  min queued runs (default 50; 0 disables)"
 			echo "  AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN   min queued/in_progress ratio (default 10)"
 			echo "  AIDEVOPS_SKIP_ACTIONS_QUEUE_SATURATION=1      emergency bypass"
+			echo "  AIDEVOPS_SKIP_GITHUB_ACTIONS_STATUS=1         bypass public Actions incident signal"
 			return 0
 			;;
 		*)

--- a/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
@@ -352,7 +352,7 @@ _circuit_breaker_status() {
 		local now_epoch
 		now_epoch=$(date +%s 2>/dev/null) || now_epoch=0
 		if [[ "$now_epoch" -gt 0 ]]; then
-			local secs_until_reset=$(( reset_epoch - now_epoch ))
+			local secs_until_reset=$((reset_epoch - now_epoch))
 			if [[ "$secs_until_reset" -gt 0 ]]; then
 				reset_human="${secs_until_reset}s until reset"
 			else
@@ -504,53 +504,53 @@ _main() {
 	shift || true
 
 	case "$cmd" in
-		check)
-			is_graphql_budget_sufficient
-			return $?
-			;;
-		check-actions-queue)
-			# Args: $1=repo_slug. Prints KEY=VALUE lines.
-			local repo_slug="${1:-}"
-			if [[ -z "$repo_slug" ]]; then
-				echo "Usage: pulse-rate-limit-circuit-breaker.sh check-actions-queue <owner/repo>" >&2
-				return 1
-			fi
-			_check_actions_queue_saturation "$repo_slug"
-			return $?
-			;;
-		status)
-			local status_mode="normal"
-			if [[ "${1:-}" == "--cached" ]]; then
-				status_mode="$_CB_RL_MODE_CACHED_ONLY"
-			fi
-			_circuit_breaker_status "$status_mode"
-			return 0
-			;;
-		help | --help | -h)
-			echo "pulse-rate-limit-circuit-breaker.sh — Pulse-level GraphQL rate-limit circuit breaker (t2690) + Actions queue saturation (t3211)"
-			echo ""
-			echo "Usage:"
-			echo "  pulse-rate-limit-circuit-breaker.sh check                          # exit 0=OK, 1=tripped, 2=API error"
-			echo "  pulse-rate-limit-circuit-breaker.sh check-actions-queue OWNER/REPO # KEY=VALUE: queued/in_progress/ratio/saturated"
-			echo "  pulse-rate-limit-circuit-breaker.sh status [--cached]              # human-readable status line"
-			echo ""
-			echo "Environment (GraphQL):"
-			echo "  AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD  fraction threshold (default 0.05 = 5%)"
-			echo "  AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER=1     emergency bypass"
-			echo "  AIDEVOPS_PULSE_RATE_LIMIT_CACHE_TTL       rate_limit cache TTL seconds (default 20)"
-			echo ""
-			echo "Environment (Actions queue, t3211):"
-			echo "  AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN  min queued runs (default 50; 0 disables)"
-			echo "  AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN   min queued/in_progress ratio (default 10)"
-			echo "  AIDEVOPS_SKIP_ACTIONS_QUEUE_SATURATION=1      emergency bypass"
-			echo "  AIDEVOPS_SKIP_GITHUB_ACTIONS_STATUS=1         bypass public Actions incident signal"
-			return 0
-			;;
-		*)
-			echo "Unknown command: ${cmd}" >&2
-			echo "Run: pulse-rate-limit-circuit-breaker.sh help" >&2
+	check)
+		is_graphql_budget_sufficient
+		return $?
+		;;
+	check-actions-queue)
+		# Args: $1=repo_slug. Prints KEY=VALUE lines.
+		local repo_slug="${1:-}"
+		if [[ -z "$repo_slug" ]]; then
+			echo "Usage: pulse-rate-limit-circuit-breaker.sh check-actions-queue <owner/repo>" >&2
 			return 1
-			;;
+		fi
+		_check_actions_queue_saturation "$repo_slug"
+		return $?
+		;;
+	status)
+		local status_mode="normal"
+		if [[ "${1:-}" == "--cached" ]]; then
+			status_mode="$_CB_RL_MODE_CACHED_ONLY"
+		fi
+		_circuit_breaker_status "$status_mode"
+		return 0
+		;;
+	help | --help | -h)
+		echo "pulse-rate-limit-circuit-breaker.sh — Pulse-level GraphQL rate-limit circuit breaker (t2690) + Actions queue saturation (t3211)"
+		echo ""
+		echo "Usage:"
+		echo "  pulse-rate-limit-circuit-breaker.sh check                          # exit 0=OK, 1=tripped, 2=API error"
+		echo "  pulse-rate-limit-circuit-breaker.sh check-actions-queue OWNER/REPO # KEY=VALUE: queued/in_progress/ratio/saturated"
+		echo "  pulse-rate-limit-circuit-breaker.sh status [--cached]              # human-readable status line"
+		echo ""
+		echo "Environment (GraphQL):"
+		echo "  AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD  fraction threshold (default 0.05 = 5%)"
+		echo "  AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER=1     emergency bypass"
+		echo "  AIDEVOPS_PULSE_RATE_LIMIT_CACHE_TTL       rate_limit cache TTL seconds (default 20)"
+		echo ""
+		echo "Environment (Actions queue, t3211):"
+		echo "  AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN  min queued runs (default 50; 0 disables)"
+		echo "  AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN   min queued/in_progress ratio (default 10)"
+		echo "  AIDEVOPS_SKIP_ACTIONS_QUEUE_SATURATION=1      emergency bypass"
+		echo "  AIDEVOPS_SKIP_GITHUB_ACTIONS_STATUS=1         bypass public Actions incident signal"
+		return 0
+		;;
+	*)
+		echo "Unknown command: ${cmd}" >&2
+		echo "Run: pulse-rate-limit-circuit-breaker.sh help" >&2
+		return 1
+		;;
 	esac
 }
 

--- a/.agents/scripts/tests/test-actions-queue-saturation.sh
+++ b/.agents/scripts/tests/test-actions-queue-saturation.sh
@@ -171,7 +171,7 @@ case "$1" in
 				emit_body "$body" "$@"
 				exit 0
 				;;
-			repos/*/commits/*/check-runs)
+		repos/*/commits/*/check-runs*)
 				body=$(printf '{"check_runs":%s}' "${GH_SHIM_CHECK_RUNS_JSON:-[]}")
 				emit_body "$body" "$@"
 				exit 0
@@ -439,42 +439,57 @@ if ! declare -F _classify_stuck_pr >/dev/null 2>&1; then
 	exit 1
 fi
 
+_pmrc_snapshot_checks_json() {
+	local repo_slug="$1"
+	local head_sha="$2"
+	[[ -n "$repo_slug" && -n "$head_sha" ]] || return 1
+	printf '%s\n' "${GH_SHIM_CHECK_RUNS_JSON:-[]}"
+	return 0
+}
+
 # 5a: is_saturated=1 + current-head REST checks include QUEUED → saturation.
 _reset_env
 set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha123"}' \
-	'GH_SHIM_CHECK_RUNS_JSON=[{"name":"Maintainer Gate","status":"queued","conclusion":null}]'
+	'GH_SHIM_CHECK_RUNS_JSON=[{"name":"Maintainer Gate","status":"queued","conclusion":null,"app":{"slug":"github-actions"}}]'
 classification=$(_classify_stuck_pr "12345" "marcusquinn/aidevops" "1")
 assert_eq "saturated+queued check: classification" "STUCK_RUNNER_QUEUE_SATURATION" "$classification"
 
-# 5b: is_saturated=0 + rollup has QUEUED check → falls through to STUCK_OTHER.
+# 5b: an external app queued during an Actions incident is not runner saturation.
+_reset_env
+set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha123"}' \
+	'GH_SHIM_CHECK_RUNS_JSON=[{"name":"Codacy","status":"queued","conclusion":null,"app":{"slug":"codacy-production"}}]'
+classification=$(_classify_stuck_pr "12345" "marcusquinn/aidevops" "1")
+assert_eq "saturated+external queued check: classification" "STUCK_OTHER" "$classification"
+
+# 5c: is_saturated=0 + rollup has QUEUED check → falls through to STUCK_OTHER.
 # The shim's bare repo metadata returns default_branch="main", and the
 # protection probe returns "{}" (success path) — neither STUCK_BRANCHPROTECT_*
 # branch fires. No FAILURE entries in the rollup → STUCK_OTHER.
 _reset_env
 set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha123"}' \
-	'GH_SHIM_CHECK_RUNS_JSON=[{"name":"Maintainer Gate","status":"queued","conclusion":null}]'
+	'GH_SHIM_CHECK_RUNS_JSON=[{"name":"Maintainer Gate","status":"queued","conclusion":null,"app":{"slug":"github-actions"}}]'
 classification=$(_classify_stuck_pr "12345" "marcusquinn/aidevops" "0")
 assert_eq "unsaturated+queued check: classification" "STUCK_OTHER" "$classification"
 
-# 5c: is_saturated=1 + rollup has both QUEUED and FAILURE checks → priority
+# 5d: is_saturated=1 + rollup has both QUEUED and FAILURE checks → priority
 # is QUEUED (the running outage masks per-PR failures).
 _reset_env
 set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha123"}' \
-	'GH_SHIM_CHECK_RUNS_JSON=[{"name":"Maintainer Gate","status":"queued","conclusion":null},{"name":"Lint","status":"completed","conclusion":"failure"}]'
+	'GH_SHIM_CHECK_RUNS_JSON=[{"name":"Maintainer Gate","status":"queued","conclusion":null,"app":{"slug":"github-actions"}},{"name":"Lint","status":"completed","conclusion":"failure","app":{"slug":"github-actions"}}]'
 classification=$(_classify_stuck_pr "12345" "marcusquinn/aidevops" "1")
 assert_eq "saturated+queued+failure: priority QUEUED" "STUCK_RUNNER_QUEUE_SATURATION" "$classification"
 
-# 5d: is_saturated=0 + rollup has FAILURE only → STUCK_CHECKS_FAILING.
+# 5e: is_saturated=0 + rollup has FAILURE only → STUCK_CHECKS_FAILING.
 _reset_env
 set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha123"}' \
 	'GH_SHIM_CHECK_RUNS_JSON=[{"name":"Lint","status":"completed","conclusion":"failure"}]'
 classification=$(_classify_stuck_pr "12345" "marcusquinn/aidevops" "0")
 assert_eq "unsaturated+failure only: classification" "STUCK_CHECKS_FAILING" "$classification"
 
-# 5e: Default is_saturated parameter (omitted) → treated as 0.
+# 5f: Default is_saturated parameter (omitted) → treated as 0.
 _reset_env
 set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha123"}' \
-	'GH_SHIM_CHECK_RUNS_JSON=[{"name":"Maintainer Gate","status":"queued","conclusion":null}]'
+	'GH_SHIM_CHECK_RUNS_JSON=[{"name":"Maintainer Gate","status":"queued","conclusion":null,"app":{"slug":"github-actions"}}]'
 classification=$(_classify_stuck_pr "12345" "marcusquinn/aidevops")
 assert_eq "default param: treated as is_saturated=0" "STUCK_OTHER" "$classification"
 

--- a/.agents/scripts/tests/test-actions-queue-saturation.sh
+++ b/.agents/scripts/tests/test-actions-queue-saturation.sh
@@ -301,50 +301,50 @@ echo "${TEST_BLUE}── 1. Saturation detection ──${TEST_NC}"
 _reset_env
 set_shim GH_SHIM_QUEUED_TOTAL=110 GH_SHIM_IN_PROGRESS_TOTAL=3
 out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
-assert_eq "incident shape: queued=110"          "110" "$(_field queued "$out")"
-assert_eq "incident shape: in_progress=3"       "3"   "$(_field in_progress "$out")"
-assert_eq "incident shape: ratio=36"            "36"  "$(_field ratio "$out")"
-assert_eq "incident shape: saturated=1"         "1"   "$(_field saturated "$out")"
+assert_eq "incident shape: queued=110" "110" "$(_field queued "$out")"
+assert_eq "incident shape: in_progress=3" "3" "$(_field in_progress "$out")"
+assert_eq "incident shape: ratio=36" "36" "$(_field ratio "$out")"
+assert_eq "incident shape: saturated=1" "1" "$(_field saturated "$out")"
 
 # 1b: Light load — neither absolute nor ratio threshold met.
 _reset_env
 set_shim GH_SHIM_QUEUED_TOTAL=10 GH_SHIM_IN_PROGRESS_TOTAL=10
 out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
-assert_eq "light load: queued=10"               "10"  "$(_field queued "$out")"
-assert_eq "light load: ratio=1"                 "1"   "$(_field ratio "$out")"
-assert_eq "light load: saturated=0"             "0"   "$(_field saturated "$out")"
+assert_eq "light load: queued=10" "10" "$(_field queued "$out")"
+assert_eq "light load: ratio=1" "1" "$(_field ratio "$out")"
+assert_eq "light load: saturated=0" "0" "$(_field saturated "$out")"
 
 # 1c: High absolute, healthy ratio (busy but draining) — NOT saturated.
 _reset_env
 set_shim GH_SHIM_QUEUED_TOTAL=51 GH_SHIM_IN_PROGRESS_TOTAL=10
 out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
-assert_eq "busy/healthy: queued=51"             "51"  "$(_field queued "$out")"
-assert_eq "busy/healthy: ratio=5"               "5"   "$(_field ratio "$out")"
-assert_eq "busy/healthy: saturated=0"           "0"   "$(_field saturated "$out")"
+assert_eq "busy/healthy: queued=51" "51" "$(_field queued "$out")"
+assert_eq "busy/healthy: ratio=5" "5" "$(_field ratio "$out")"
+assert_eq "busy/healthy: saturated=0" "0" "$(_field saturated "$out")"
 
 # 1d: Just above ratio threshold — IS saturated.
 _reset_env
 set_shim GH_SHIM_QUEUED_TOTAL=51 GH_SHIM_IN_PROGRESS_TOTAL=4
 out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
-assert_eq "above ratio: queued=51"              "51"  "$(_field queued "$out")"
-assert_eq "above ratio: ratio=12"               "12"  "$(_field ratio "$out")"
-assert_eq "above ratio: saturated=1"            "1"   "$(_field saturated "$out")"
+assert_eq "above ratio: queued=51" "51" "$(_field queued "$out")"
+assert_eq "above ratio: ratio=12" "12" "$(_field ratio "$out")"
+assert_eq "above ratio: saturated=1" "1" "$(_field saturated "$out")"
 
 # 1e: Just below queued threshold — NOT saturated regardless of ratio.
 _reset_env
 set_shim GH_SHIM_QUEUED_TOTAL=49 GH_SHIM_IN_PROGRESS_TOTAL=1
 out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
-assert_eq "below abs: queued=49"                "49"  "$(_field queued "$out")"
-assert_eq "below abs: ratio=49"                 "49"  "$(_field ratio "$out")"
-assert_eq "below abs: saturated=0"              "0"   "$(_field saturated "$out")"
+assert_eq "below abs: queued=49" "49" "$(_field queued "$out")"
+assert_eq "below abs: ratio=49" "49" "$(_field ratio "$out")"
+assert_eq "below abs: saturated=0" "0" "$(_field saturated "$out")"
 
 # 1f: Zero in_progress — denominator clamps to 1, ratio = queued.
 _reset_env
 set_shim GH_SHIM_QUEUED_TOTAL=200 GH_SHIM_IN_PROGRESS_TOTAL=0
 out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
-assert_eq "zero in_progress: queued=200"        "200" "$(_field queued "$out")"
-assert_eq "zero in_progress: ratio=200"         "200" "$(_field ratio "$out")"
-assert_eq "zero in_progress: saturated=1"       "1"   "$(_field saturated "$out")"
+assert_eq "zero in_progress: queued=200" "200" "$(_field queued "$out")"
+assert_eq "zero in_progress: ratio=200" "200" "$(_field ratio "$out")"
+assert_eq "zero in_progress: saturated=1" "1" "$(_field saturated "$out")"
 
 # ---------------------------------------------------------------------------
 # Test class 2: fail-open semantics
@@ -355,10 +355,11 @@ echo "${TEST_BLUE}── 2. Fail-open semantics ──${TEST_NC}"
 # 2a: gh-api error → return rc=2, saturated=0.
 _reset_env
 set_shim GH_SHIM_FAIL=1
-out=$(_check_actions_queue_saturation "marcusquinn/aidevops"); rc=$?
-assert_eq "api error: rc=2"                     "2"   "$rc"
-assert_eq "api error: saturated=0"              "0"   "$(_field saturated "$out")"
-assert_eq "api error: queued=0"                 "0"   "$(_field queued "$out")"
+out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
+rc=$?
+assert_eq "api error: rc=2" "2" "$rc"
+assert_eq "api error: saturated=0" "0" "$(_field saturated "$out")"
+assert_eq "api error: queued=0" "0" "$(_field queued "$out")"
 
 # 2b: a public Actions incident overrides low/unknown repo queue counts.
 _reset_env
@@ -366,16 +367,18 @@ export AIDEVOPS_SKIP_GITHUB_ACTIONS_STATUS=0
 export AIDEVOPS_GH_STATUS_HELPER="$SHIM_DIR/gh-actions-status"
 export GH_STATUS_SHIM_RC=1
 set_shim GH_SHIM_QUEUED_TOTAL=2 GH_SHIM_IN_PROGRESS_TOTAL=2
-out=$(_check_actions_queue_saturation "marcusquinn/aidevops"); rc=$?
-assert_eq "provider incident: rc=0"              "0" "$rc"
-assert_eq "provider incident: saturated=1"       "1" "$(_field saturated "$out")"
-assert_eq "provider incident: signal exported"   "1" "$(_field provider_incident "$out")"
+out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
+rc=$?
+assert_eq "provider incident: rc=0" "0" "$rc"
+assert_eq "provider incident: saturated=1" "1" "$(_field saturated "$out")"
+assert_eq "provider incident: signal exported" "1" "$(_field provider_incident "$out")"
 
 # 2c: Empty repo_slug → return rc=0, saturated=0 (defensive default).
 _reset_env
-out=$(_check_actions_queue_saturation ""); rc=$?
-assert_eq "empty slug: rc=0"                    "0"   "$rc"
-assert_eq "empty slug: saturated=0"             "0"   "$(_field saturated "$out")"
+out=$(_check_actions_queue_saturation "")
+rc=$?
+assert_eq "empty slug: rc=0" "0" "$rc"
+assert_eq "empty slug: saturated=0" "0" "$(_field saturated "$out")"
 
 # ---------------------------------------------------------------------------
 # Test class 3: bypass + disable controls
@@ -390,7 +393,7 @@ set_shim AIDEVOPS_SKIP_ACTIONS_QUEUE_SATURATION=1 \
 	GH_SHIM_QUEUED_TOTAL=110 GH_SHIM_IN_PROGRESS_TOTAL=3
 out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
 assert_eq "bypass env: saturated=0 despite real saturation" "0" "$(_field saturated "$out")"
-assert_eq "bypass env: queued=0 (network not consulted)"    "0" "$(_field queued "$out")"
+assert_eq "bypass env: queued=0 (network not consulted)" "0" "$(_field queued "$out")"
 
 # 3b: QUEUED_MIN=0 disables detection entirely.
 _reset_env
@@ -411,15 +414,15 @@ set_shim AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN=5 \
 	AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN=2 \
 	GH_SHIM_QUEUED_TOTAL=10 GH_SHIM_IN_PROGRESS_TOTAL=2
 out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
-assert_eq "lowered thresholds: ratio=5"          "5" "$(_field ratio "$out")"
-assert_eq "lowered thresholds: saturated=1"      "1" "$(_field saturated "$out")"
+assert_eq "lowered thresholds: ratio=5" "5" "$(_field ratio "$out")"
+assert_eq "lowered thresholds: saturated=1" "1" "$(_field saturated "$out")"
 
 # 4b: Raise QUEUED_MIN above incident shape — even canonical incident is OK.
 _reset_env
 set_shim AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN=200 \
 	GH_SHIM_QUEUED_TOTAL=110 GH_SHIM_IN_PROGRESS_TOTAL=3
 out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
-assert_eq "raised threshold: saturated=0"       "0" "$(_field saturated "$out")"
+assert_eq "raised threshold: saturated=0" "0" "$(_field saturated "$out")"
 
 # ---------------------------------------------------------------------------
 # Test class 5: integration with _classify_stuck_pr

--- a/.agents/scripts/tests/test-actions-queue-saturation.sh
+++ b/.agents/scripts/tests/test-actions-queue-saturation.sh
@@ -88,6 +88,11 @@ export LOGFILE="$TEST_TMPDIR/pulse.log"
 # emulating gh api repos/{slug}/actions/runs?status={queued,in_progress}.
 SHIM_DIR="$TEST_TMPDIR/bin"
 mkdir -p "$SHIM_DIR"
+cat >"$SHIM_DIR/gh-actions-status" <<'SHIM_EOF'
+#!/usr/bin/env bash
+exit "${GH_STATUS_SHIM_RC:-0}"
+SHIM_EOF
+chmod +x "$SHIM_DIR/gh-actions-status"
 cat >"$SHIM_DIR/gh" <<'SHIM_EOF'
 #!/usr/bin/env bash
 # Minimal gh shim for test-actions-queue-saturation.sh.
@@ -96,6 +101,7 @@ cat >"$SHIM_DIR/gh" <<'SHIM_EOF'
 #   GH_SHIM_IN_PROGRESS_TOTAL total_count for status=in_progress response (integer)
 #   GH_SHIM_FAIL              if "1", emit empty stdout + exit 1 (API error)
 #   GH_SHIM_PR_VIEW_JSON      raw JSON to return for `gh pr view` calls
+#   GH_SHIM_CHECK_RUNS_JSON   check_runs array for the current head
 
 # NOTE: `local` is invalid at script top-level in bash and aborts the
 # script before printf runs — that's why this shim must use plain vars.
@@ -165,6 +171,15 @@ case "$1" in
 				emit_body "$body" "$@"
 				exit 0
 				;;
+			repos/*/commits/*/check-runs)
+				body=$(printf '{"check_runs":%s}' "${GH_SHIM_CHECK_RUNS_JSON:-[]}")
+				emit_body "$body" "$@"
+				exit 0
+				;;
+			repos/*/commits/*/status)
+				emit_body '{"statuses":[]}' "$@"
+				exit 0
+				;;
 			*"/branches/"*"/protection"*)
 				# Pretend the branch has no protection rules. Returning
 				# success with `{}` makes the classifier fall through to
@@ -222,11 +237,15 @@ _reset_env() {
 	unset AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN
 	unset AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN
 	unset AIDEVOPS_SKIP_ACTIONS_QUEUE_SATURATION
+	unset AIDEVOPS_GH_STATUS_HELPER
+	unset GH_STATUS_SHIM_RC
+	export AIDEVOPS_SKIP_GITHUB_ACTIONS_STATUS=1
 	unset AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER
 	unset GH_SHIM_QUEUED_TOTAL
 	unset GH_SHIM_IN_PROGRESS_TOTAL
 	unset GH_SHIM_FAIL
 	unset GH_SHIM_PR_VIEW_JSON
+	unset GH_SHIM_CHECK_RUNS_JSON
 	return 0
 }
 
@@ -341,7 +360,18 @@ assert_eq "api error: rc=2"                     "2"   "$rc"
 assert_eq "api error: saturated=0"              "0"   "$(_field saturated "$out")"
 assert_eq "api error: queued=0"                 "0"   "$(_field queued "$out")"
 
-# 2b: Empty repo_slug → return rc=0, saturated=0 (defensive default).
+# 2b: a public Actions incident overrides low/unknown repo queue counts.
+_reset_env
+export AIDEVOPS_SKIP_GITHUB_ACTIONS_STATUS=0
+export AIDEVOPS_GH_STATUS_HELPER="$SHIM_DIR/gh-actions-status"
+export GH_STATUS_SHIM_RC=1
+set_shim GH_SHIM_QUEUED_TOTAL=2 GH_SHIM_IN_PROGRESS_TOTAL=2
+out=$(_check_actions_queue_saturation "marcusquinn/aidevops"); rc=$?
+assert_eq "provider incident: rc=0"              "0" "$rc"
+assert_eq "provider incident: saturated=1"       "1" "$(_field saturated "$out")"
+assert_eq "provider incident: signal exported"   "1" "$(_field provider_incident "$out")"
+
+# 2c: Empty repo_slug → return rc=0, saturated=0 (defensive default).
 _reset_env
 out=$(_check_actions_queue_saturation ""); rc=$?
 assert_eq "empty slug: rc=0"                    "0"   "$rc"
@@ -406,9 +436,10 @@ if ! declare -F _classify_stuck_pr >/dev/null 2>&1; then
 	exit 1
 fi
 
-# 5a: is_saturated=1 + rollup has QUEUED check → STUCK_RUNNER_QUEUE_SATURATION.
+# 5a: is_saturated=1 + current-head REST checks include QUEUED → saturation.
 _reset_env
-set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","statusCheckRollup":[{"name":"Maintainer Gate","status":"QUEUED","conclusion":null}]}'
+set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha123"}' \
+	'GH_SHIM_CHECK_RUNS_JSON=[{"name":"Maintainer Gate","status":"queued","conclusion":null}]'
 classification=$(_classify_stuck_pr "12345" "marcusquinn/aidevops" "1")
 assert_eq "saturated+queued check: classification" "STUCK_RUNNER_QUEUE_SATURATION" "$classification"
 
@@ -417,26 +448,30 @@ assert_eq "saturated+queued check: classification" "STUCK_RUNNER_QUEUE_SATURATIO
 # protection probe returns "{}" (success path) — neither STUCK_BRANCHPROTECT_*
 # branch fires. No FAILURE entries in the rollup → STUCK_OTHER.
 _reset_env
-set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","statusCheckRollup":[{"name":"Maintainer Gate","status":"QUEUED","conclusion":null}]}'
+set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha123"}' \
+	'GH_SHIM_CHECK_RUNS_JSON=[{"name":"Maintainer Gate","status":"queued","conclusion":null}]'
 classification=$(_classify_stuck_pr "12345" "marcusquinn/aidevops" "0")
 assert_eq "unsaturated+queued check: classification" "STUCK_OTHER" "$classification"
 
 # 5c: is_saturated=1 + rollup has both QUEUED and FAILURE checks → priority
 # is QUEUED (the running outage masks per-PR failures).
 _reset_env
-set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","statusCheckRollup":[{"name":"Maintainer Gate","status":"QUEUED","conclusion":null},{"name":"Lint","status":"COMPLETED","conclusion":"FAILURE"}]}'
+set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha123"}' \
+	'GH_SHIM_CHECK_RUNS_JSON=[{"name":"Maintainer Gate","status":"queued","conclusion":null},{"name":"Lint","status":"completed","conclusion":"failure"}]'
 classification=$(_classify_stuck_pr "12345" "marcusquinn/aidevops" "1")
 assert_eq "saturated+queued+failure: priority QUEUED" "STUCK_RUNNER_QUEUE_SATURATION" "$classification"
 
 # 5d: is_saturated=0 + rollup has FAILURE only → STUCK_CHECKS_FAILING.
 _reset_env
-set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","statusCheckRollup":[{"name":"Lint","status":"COMPLETED","conclusion":"FAILURE"}]}'
+set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha123"}' \
+	'GH_SHIM_CHECK_RUNS_JSON=[{"name":"Lint","status":"completed","conclusion":"failure"}]'
 classification=$(_classify_stuck_pr "12345" "marcusquinn/aidevops" "0")
 assert_eq "unsaturated+failure only: classification" "STUCK_CHECKS_FAILING" "$classification"
 
 # 5e: Default is_saturated parameter (omitted) → treated as 0.
 _reset_env
-set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","statusCheckRollup":[{"name":"Maintainer Gate","status":"QUEUED","conclusion":null}]}'
+set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha123"}' \
+	'GH_SHIM_CHECK_RUNS_JSON=[{"name":"Maintainer Gate","status":"queued","conclusion":null}]'
 classification=$(_classify_stuck_pr "12345" "marcusquinn/aidevops")
 assert_eq "default param: treated as is_saturated=0" "STUCK_OTHER" "$classification"
 

--- a/.agents/scripts/tests/test-gh-status-helper.sh
+++ b/.agents/scripts/tests/test-gh-status-helper.sh
@@ -64,6 +64,10 @@ cat >"$MOCK_BASE/operational/status.json" <<'EOF'
   "status": {"indicator": "none", "description": "All Systems Operational"}
 }
 EOF
+
+mkdir -p "$MOCK_BASE/malformed-incidents" "$MOCK_BASE/malformed-components"
+printf '%s\n' '{"incidents":{"bad":{"components":[{"name":"Actions"}]}}}' >"$MOCK_BASE/malformed-incidents/unresolved.json"
+printf '%s\n' '{"incidents":[{"name":"Bad schema","components":{"bad":{"name":"Actions"}}}]}' >"$MOCK_BASE/malformed-components/unresolved.json"
 cat >"$MOCK_BASE/operational/unresolved.json" <<'EOF'
 {"page": {"id": "kctbh9vrtdwd"}, "incidents": []}
 EOF
@@ -246,6 +250,20 @@ test_check_actions_component_status() {
 	return 0
 }
 
+test_check_actions_malformed_schema_fails_open() {
+	local fixture out rc
+	for fixture in malformed-incidents malformed-components; do
+		out=$(_isolated_run "$fixture" check-actions --json 2>/dev/null)
+		rc=$?
+		if [[ "$rc" -ne 3 ]]; then
+			print_result "check-actions malformed ${fixture} schema → exit 3" 1 "rc=$rc out=$out"
+		else
+			print_result "check-actions malformed ${fixture} schema → exit 3" 0
+		fi
+	done
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # incidents subcommand
 # ---------------------------------------------------------------------------
@@ -413,6 +431,7 @@ _run_tests() {
 	test_check_outage_returns_2
 	test_check_json_output
 	test_check_actions_component_status
+	test_check_actions_malformed_schema_fails_open
 	test_incidents_empty_when_operational
 	test_incidents_lists_when_degraded
 	test_incidents_json_array

--- a/.agents/scripts/tests/test-gh-status-helper.sh
+++ b/.agents/scripts/tests/test-gh-status-helper.sh
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# Test suite for gh-status-helper.sh — verifies all three subcommands
-# (check, incidents, correlate), all three exit-code branches (operational,
+# Test suite for gh-status-helper.sh — verifies status and component subcommands
+# (check, check-actions, incidents, correlate), all exit-code branches (operational,
 # degraded, outage), the 60s response cache, and network-failure handling.
 #
 # The helper supports a mock interface via AIDEVOPS_GH_STATUS_MOCK_DIR — when
@@ -122,7 +122,7 @@ cat >"$MOCK_BASE/outage/unresolved.json" <<'EOF'
       "name": "Webhooks Delayed",
       "impact": "major",
       "started_at": "2026-04-27T22:10:00Z",
-      "components": [{"id": "c2", "name": "Webhooks"}],
+      "components": [{"id": "c2", "name": "Webhooks"}, {"id": "c3", "name": "Actions"}],
       "incident_updates": [{"id": "u2", "body": "Webhook delivery queue backed up.", "created_at": "2026-04-27T22:12:00Z"}]
     }
   ]
@@ -215,6 +215,34 @@ test_check_json_output() {
 		return 0
 	fi
 	print_result "check --json status='operational'" 0
+	return 0
+}
+
+test_check_actions_component_status() {
+	local out rc
+	out=$(_isolated_run operational check-actions --json 2>/dev/null)
+	rc=$?
+	if [[ "$rc" -ne 0 || "$(printf '%s' "$out" | jq -r '.status')" != "operational" ]]; then
+		print_result "check-actions healthy component → operational" 1 "rc=$rc out=$out"
+	else
+		print_result "check-actions healthy component → operational" 0
+	fi
+
+	out=$(_isolated_run degraded check-actions --json 2>/dev/null)
+	rc=$?
+	if [[ "$rc" -ne 0 || "$(printf '%s' "$out" | jq -r '.status')" != "operational" ]]; then
+		print_result "check-actions ignores unrelated incidents" 1 "rc=$rc out=$out"
+	else
+		print_result "check-actions ignores unrelated incidents" 0
+	fi
+
+	out=$(_isolated_run outage check-actions --json 2>/dev/null)
+	rc=$?
+	if [[ "$rc" -ne 1 || "$(printf '%s' "$out" | jq -r '.status')" != "incident" ]]; then
+		print_result "check-actions active incident → exit 1" 1 "rc=$rc out=$out"
+	else
+		print_result "check-actions active incident → exit 1" 0
+	fi
 	return 0
 }
 
@@ -384,6 +412,7 @@ _run_tests() {
 	test_check_degraded_returns_1
 	test_check_outage_returns_2
 	test_check_json_output
+	test_check_actions_component_status
 	test_incidents_empty_when_operational
 	test_incidents_lists_when_degraded
 	test_incidents_json_array

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -497,6 +497,23 @@ EOF
 	return 0
 }
 
+assert_check_run_app_slug_survives_normalization() {
+	local snapshot=""
+	snapshot=$(printf '%s\n%s\n' \
+		'[{"check_runs":[{"name":"Build","status":"queued","conclusion":null,"app":{"slug":"github-actions"}}]}]' \
+		'{"statuses":[]}' |
+		_pmrc_normalize_snapshot_checks_json owner/repo sha-reviewed)
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if printf '%s' "$snapshot" | jq -e \
+		'length == 1 and .[0].name == "Build" and .[0].app_slug == "github-actions"' >/dev/null; then
+		printf 'PASS check-run app slug survives current-head normalization\n'
+	else
+		printf 'FAIL check-run app slug was lost during current-head normalization\n'
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
 assert_review_and_head_snapshot_cases() {
 	assert_gate "same-name check-run and status retain independent source failures" same_name_source_conflict 1
 	set_live_evidence PASS
@@ -563,6 +580,7 @@ main() {
 	assert_infrastructure_rerun_unset_defaults_safe
 	assert_infrastructure_rerun_unset_logfile_safe
 	assert_actions_incident_suppresses_infrastructure_rerun
+	assert_check_run_app_slug_survives_normalization
 	assert_effective_rules_have_exact_rest_cost
 	assert_configured_advisory_contexts_are_null_safe
 	assert_malformed_advisory_contexts_fail_closed_once

--- a/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh
@@ -11,7 +11,7 @@ source "${SCRIPT_DIR}/../pulse-merge-required-checks.sh"
 TEST_ROOT="$(mktemp -d -t pulse-preflight-snapshot.XXXXXX)"
 LOGFILE="${TEST_ROOT}/pulse.log"
 AIDEVOPS_REPOS_JSON="${TEST_ROOT}/repos.json"
-export AIDEVOPS_REPOS_JSON
+export AIDEVOPS_REPOS_JSON AIDEVOPS_SKIP_GITHUB_ACTIONS_STATUS=1
 write_default_repos_json() {
 	cat >"$AIDEVOPS_REPOS_JSON" <<'EOF'
 {"initialized_repos":[{"slug":"owner/repo","review_gate":{"advisory_check_contexts":["CodeFactor"]}}]}
@@ -475,6 +475,28 @@ assert_infrastructure_rerun_unset_logfile_safe() {
 	return 0
 }
 
+assert_actions_incident_suppresses_infrastructure_rerun() {
+	local helper="${TEST_ROOT}/gh-status-incident" rc=0
+	cat >"$helper" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+	chmod +x "$helper"
+	RERUN_CALLS=0
+	AIDEVOPS_SKIP_GITHUB_ACTIONS_STATUS=0 AIDEVOPS_GH_STATUS_HELPER="$helper" \
+		_pmrc_rerun_infrastructure_check owner/repo 7 required-a \
+		"https://github.com/owner/repo/actions/runs/111/job/222" || rc=$?
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 && "$RERUN_CALLS" -eq 0 ]] &&
+		grep -qF "retry amplification suppressed" "$LOGFILE"; then
+		printf 'PASS active Actions incident suppresses infrastructure rerun\n'
+	else
+		printf 'FAIL active Actions incident did not suppress rerun (rc=%s, calls=%s)\n' "$rc" "$RERUN_CALLS"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
 assert_review_and_head_snapshot_cases() {
 	assert_gate "same-name check-run and status retain independent source failures" same_name_source_conflict 1
 	set_live_evidence PASS
@@ -540,6 +562,7 @@ assert_review_and_head_snapshot_cases() {
 main() {
 	assert_infrastructure_rerun_unset_defaults_safe
 	assert_infrastructure_rerun_unset_logfile_safe
+	assert_actions_incident_suppresses_infrastructure_rerun
 	assert_effective_rules_have_exact_rest_cost
 	assert_configured_advisory_contexts_are_null_safe
 	assert_malformed_advisory_contexts_fail_closed_once

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -262,7 +262,7 @@ gh() {
 		fi
 		return 0
 	fi
-	if [[ "$command_name" == "issue" && ( "$subcommand" == "comment" || "$subcommand" == "close" ) ]]; then
+	if [[ "$command_name" == "issue" && ("$subcommand" == "comment" || "$subcommand" == "close") ]]; then
 		printf '%s\n' "gh $*" >>"$GH_CALLS"
 		return 0
 	fi
@@ -361,8 +361,8 @@ AIDEVOPS_MERGE_ZERO_PROGRESS_RECOVERY_CHECK_SECONDS=0
 : >"$LOGFILE"
 pulse_stats_set_gauge "pulse_merge_zero_progress_cycles" "0" >/dev/null 2>&1
 pulse_merge_zero_progress_record 2 0 1 >/dev/null 2>&1
-if grep -q 'deterministic conflict/close progress action(s) while zero-progress gauge was already 0' "$LOGFILE" \
-	&& ! grep -q 'after a 0-cycle zero-progress streak while zero-progress gauge was already 0' "$LOGFILE"; then
+if grep -q 'deterministic conflict/close progress action(s) while zero-progress gauge was already 0' "$LOGFILE" &&
+	! grep -q 'after a 0-cycle zero-progress streak while zero-progress gauge was already 0' "$LOGFILE"; then
 	echo "${TEST_GREEN}PASS${TEST_NC}: 5b.4: already-zero recovery reason is direct and non-contradictory"
 else
 	TESTS_FAILED=$((TESTS_FAILED + 1))
@@ -493,7 +493,10 @@ _extract_linked_issue() {
 	[[ -n "$repo_slug" ]] || return 1
 	case "$pr_number" in
 	102) return 0 ;;
-	*) printf '77'; return 0 ;;
+	*)
+		printf '77'
+		return 0
+		;;
 	esac
 }
 
@@ -536,7 +539,7 @@ unavailable_state_calls=$(grep -cF '115:example/repo:1:--json state --jq .state 
 assert_eq "6a.2: unavailable current-state reads retain the cached candidate" "1" "$unavailable_state_calls"
 
 _pms_compute_saturation_state() {
-	printf 'queued=0\nin_progress=0\nratio=0\nsaturated=0\n'
+	printf 'queued=0\nin_progress=0\nratio=0\nsaturated=0\nprovider_incident=0\n'
 	return 0
 }
 
@@ -588,9 +591,9 @@ echo ""
 # progress, not a deterministic merge failure; otherwise the zero-progress
 # detector can file false collapse issues while GitHub is completing the merge.
 TESTS_RUN=$((TESTS_RUN + 1))
-if grep -q "Merge already in progress" "$MERGE_SCRIPT" \
-	&& grep -Fq "_handle_post_merge_actions \"\$pr_number\" \"\$repo_slug\" \"\$linked_issue\" \"\$merge_summary\" \"\$_ipr_labels\"" "$MERGE_SCRIPT" \
-	&& grep -Fq "return \$?" "$MERGE_SCRIPT"; then
+if grep -q "Merge already in progress" "$MERGE_SCRIPT" &&
+	grep -Fq "_handle_post_merge_actions \"\$pr_number\" \"\$repo_slug\" \"\$linked_issue\" \"\$merge_summary\" \"\$_ipr_labels\"" "$MERGE_SCRIPT" &&
+	grep -Fq "return \$?" "$MERGE_SCRIPT"; then
 	echo "${TEST_GREEN}PASS${TEST_NC}: 6d: merge-in-progress is counted as zero-progress-breaking progress"
 else
 	TESTS_FAILED=$((TESTS_FAILED + 1))
@@ -630,7 +633,7 @@ gh_pr_check_runs_rest() {
 	local head_sha="$2"
 	[[ -n "$repo_slug" ]] || return 1
 	case "$head_sha" in
-	sha-queued) printf '[{"name":"Build","conclusion":null,"status":"queued"}]' ;;
+	sha-queued) printf '[{"name":"Build","conclusion":null,"status":"queued","app":{"slug":"github-actions"}}]' ;;
 	sha-failing) printf '[{"name":"Format","conclusion":"failure","status":"completed"},{"name":"Lint","conclusion":"timed_out","status":"completed"}]' ;;
 	sha-legacy-failing) printf '[{"context":"legacy-ci","state":"failure"}]' ;;
 	sha-legacy-error) printf '[{"context":"legacy-error","state":"error"}]' ;;
@@ -687,6 +690,14 @@ _required_contexts_from_rulesets_for_default_branch() {
 got=$(_classify_stuck_pr "201" "example/repo" "1")
 assert_eq "7a: saturated queued check classifies as runner saturation" \
 	"STUCK_RUNNER_QUEUE_SATURATION" "$got"
+
+issue_gate_rc=0
+_pms_should_file_runner_saturation_issue 1 1 2 || issue_gate_rc=$?
+assert_eq "7a.1: provider incidents do not file runner-pool repair issues" "1" "$issue_gate_rc"
+
+issue_gate_rc=0
+_pms_should_file_runner_saturation_issue 1 0 2 || issue_gate_rc=$?
+assert_eq "7a.2: measured runner saturation still files repair issues" "0" "$issue_gate_rc"
 
 got=$(_classify_stuck_pr "202" "example/repo" "0")
 assert_eq "7b: REST check-run failure classifies as checks failing" \
@@ -785,7 +796,10 @@ assert_eq "7c: maintainer review and assignee gate cluster does not file an outa
 	"" "$PMS_TEST_OUTAGE_ARGS"
 
 assert_eq "7d: mixed policy and genuine CI fingerprint remains outage-eligible" \
-	"1" "$(_pms_is_per_pr_gate_fingerprint 'CodeRabbit,CI / build'; printf '%s' "$?")"
+	"1" "$(
+		_pms_is_per_pr_gate_fingerprint 'CodeRabbit,CI / build'
+		printf '%s' "$?"
+	)"
 
 got=$(_pms_format_pr_markdown_list "11,12,13")
 assert_eq "7e: affected-PR Markdown retains the final entry" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- suppress GitHub Actions retry amplification during provider incidents
+
 ## [3.32.229] - 2026-08-06
 
 ### Added


### PR DESCRIPTION
## Summary

- add a cached GitHub Actions component-status probe that fails open when Statuspage is unavailable
- classify active Actions incidents as provider saturation during queued-check diagnosis
- suppress infrastructure reruns while a provider incident is active, with an explicit emergency bypass
- restrict incident attribution to queued GitHub Actions checks and avoid misleading runner-pool repair issues
- document the operational behavior and add regression coverage for status, saturation, and merge-preflight paths

## Implementation context

- `.agents/scripts/gh-status-helper.sh`: component-specific `check-actions` command and cached incident parsing
- `.agents/scripts/pulse-rate-limit-circuit-breaker.sh`: provider-incident queue-saturation classification
- `.agents/scripts/pulse-merge-required-checks.sh`: rerun suppression circuit breaker
- `.agents/scripts/tests/`: deterministic incident, bypass, fail-open, saturation, and preflight coverage
- `.agents/reference/worker-diagnostics.md` and `CHANGELOG.md`: operator guidance and release note

## Verification

- `.agents/scripts/tests/test-gh-status-helper.sh` — 26/26 passed
- `.agents/scripts/tests/test-actions-queue-saturation.sh` — 40/40 passed
- `.agents/scripts/tests/test-pulse-merge-stuck.sh` — 68/68 passed
- `.agents/scripts/tests/test-pulse-merge-preflight-snapshot.sh` — 97/97 passed
- `shellcheck`, `shfmt`, `git diff --check`, secretlint, Markdown checks, and `.agents/scripts/linters-local.sh` — passed applicable gates

## Review evidence

- independent closeout review: clean, no remaining P0–P3 findings
- evidence digest: `a35c465f1a70369f9da7e041b84e5cbff9183fc0735348b4abd9b05759045f9a`

## Runtime testing

- `gh-status-helper.sh check-actions --json --no-cache` correctly reports the current critical Actions incident
- remote CI and merge must remain pending until the provider incident clears; do not trigger reruns while it is active

## Risk and rollback

- status lookup failures intentionally fail open to preserve existing behavior
- `AIDEVOPS_SKIP_GITHUB_ACTIONS_STATUS=1` bypasses the provider-status circuit breaker
- rollback is limited to the status probe and its two call-site integrations

Resolves #29661
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.229 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 34m and 655,134 tokens on this with the user in an interactive session.