### PR TITLE
GH#29648: fix: route post-merge follow-ups through managed wrapper

### DIFF
--- a/.agents/scripts/post-merge-verify-report-helper.sh
+++ b/.agents/scripts/post-merge-verify-report-helper.sh
@@ -4,10 +4,13 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 usage() {
 	printf 'Usage:\n'
 	printf '  post-merge-verify-report-helper.sh truncate-output <output-file> <max-bytes>\n'
 	printf '  post-merge-verify-report-helper.sh publish-comment <repo> <pr-number> <body-file>\n'
+	printf '  post-merge-verify-report-helper.sh create-follow-up <repo> <title> <body-file>\n'
 	return 0
 }
 
@@ -64,6 +67,54 @@ publish_comment() {
 	return 0
 }
 
+load_managed_issue_wrapper() {
+	if declare -F gh_create_issue >/dev/null 2>&1; then
+		return 0
+	fi
+
+	# Load lazily so report truncation and fail-soft comment publication do not
+	# depend on the broader managed-write runtime.
+	# shellcheck source=shared-constants.sh
+	source "${SCRIPT_DIR}/shared-constants.sh"
+	if declare -F gh_create_issue >/dev/null 2>&1; then
+		return 0
+	fi
+
+	printf 'ERROR: managed issue creation wrapper is unavailable.\n' >&2
+	return 1
+}
+
+create_follow_up() {
+	local repo="$1"
+	local title="$2"
+	local body_file="$3"
+
+	if [[ ! -f "$body_file" ]]; then
+		printf 'ERROR: follow-up issue body file not found: %s\n' "$body_file" >&2
+		return 2
+	fi
+	if ! load_managed_issue_wrapper; then
+		return 1
+	fi
+
+	# The post-merge failure is actionable automation-owned work. Supply the
+	# complete dispatch metadata at creation time; gh_create_issue adds the
+	# normalized aidevops signature and enforces managed write safeguards.
+	if AIDEVOPS_SESSION_ORIGIN=worker gh_create_issue --repo "$repo" \
+		--title "$title" \
+		--body-file "$body_file" \
+		--label "quality-debt" \
+		--label "type:bug" \
+		--label "auto-dispatch" \
+		--label "tier:standard" \
+		--label "worker-ready" \
+		--label "origin:worker" \
+		--label "status:available"; then
+		return 0
+	fi
+	return 1
+}
+
 main() {
 	local command="${1:-help}"
 	local repo="${2:-}"
@@ -81,6 +132,14 @@ main() {
 			return 2
 		fi
 		publish_comment "$repo" "$pr_number" "$body_file"
+		return $?
+		;;
+	create-follow-up)
+		if [[ -z "$repo" || -z "$pr_number" || -z "$body_file" ]]; then
+			usage
+			return 2
+		fi
+		create_follow_up "$repo" "$pr_number" "$body_file"
 		return $?
 		;;
 	help | --help | -h)

--- a/.agents/scripts/tests/test-post-merge-verify-report.sh
+++ b/.agents/scripts/tests/test-post-merge-verify-report.sh
@@ -111,6 +111,36 @@ else
 	fail "post-merge base ref" "missing full-history checkout or pre-merge remote-ref pin"
 fi
 
+export MANAGED_ISSUE_CALL_LOG="$TMPDIR/managed-issue-calls.log"
+gh_create_issue() {
+	printf '%s\n' "$*" >>"$MANAGED_ISSUE_CALL_LOG"
+	printf 'https://github.com/owner/repo/issues/456\n'
+	return 0
+}
+export -f gh_create_issue
+
+output=$(bash "$HELPER" create-follow-up owner/repo "t123: verification failed" "$TMPDIR/body.md" 2>&1)
+rc=$?
+managed_call=$(<"$MANAGED_ISSUE_CALL_LOG")
+if [[ $rc -eq 0 && "$managed_call" == *"--body-file $TMPDIR/body.md"* ]] &&
+	[[ "$managed_call" == *"--label quality-debt"* ]] &&
+	[[ "$managed_call" == *"--label type:bug"* ]] &&
+	[[ "$managed_call" == *"--label auto-dispatch"* ]] &&
+	[[ "$managed_call" == *"--label origin:worker"* ]] &&
+	[[ "$managed_call" == *"--label status:available"* ]]; then
+	pass "failure follow-up issues use the managed wrapper with lifecycle metadata"
+else
+	fail "managed failure follow-up" "rc=$rc output=$output call=$managed_call"
+fi
+
+# shellcheck disable=SC2016 # Workflow shell variables are intentionally literal.
+if grep -qF 'create-follow-up "$REPO" "$TITLE" "$ISSUE_BODY_FILE"' "$WORKFLOW" &&
+	! grep -qE '^[[:space:]]+gh issue create ' "$WORKFLOW"; then
+	pass "post-merge workflow contains no raw issue creation path"
+else
+	fail "managed workflow issue creation" "workflow does not route exclusively through create-follow-up"
+fi
+
 printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
 if [[ "$FAIL" -gt 0 ]]; then
 	exit 1

--- a/.agents/scripts/tests/test-pre-commit-split.sh
+++ b/.agents/scripts/tests/test-pre-commit-split.sh
@@ -19,7 +19,10 @@
 
 set -uo pipefail
 
-TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEST_SCRIPTS_DIR="${TEST_DIR}/.."
+# shellcheck source=lib/test-helpers.sh
+source "${TEST_DIR}/lib/test-helpers.sh"
 TEST_RED=$'\033[0;31m'
 TEST_GREEN=$'\033[0;32m'
 TEST_RESET=$'\033[0m'
@@ -278,7 +281,11 @@ test_npm_lockfile_root_validation() {
 
 	mkdir -p "$hook_dir"
 	cp "$TEST_SCRIPTS_DIR/pre-commit-hook.sh" "$hook_dir/pre-commit-hook.sh"
-	cp "$TEST_SCRIPTS_DIR/shared-constants.sh" "$hook_dir/shared-constants.sh"
+	if ! _test_copy_shared_deps "$TEST_SCRIPTS_DIR" "$hook_dir"; then
+		print_result "root validation fixture copies shared dependencies" 1
+		rm -rf "$fixture_dir"
+		return 0
+	fi
 	git -C "$fixture_dir" init --quiet
 	printf '%s\n' '{"name":"root-allowlist-fixture"}' >"${fixture_dir}/package.json"
 	printf '%s\n' '{"name":"root-allowlist-fixture","lockfileVersion":3,"packages":{}}' >"${fixture_dir}/package-lock.json"

--- a/.github/workflows/post-merge-verify.yml
+++ b/.github/workflows/post-merge-verify.yml
@@ -242,10 +242,12 @@ jobs:
           # Dedent the heredoc content
           BODY=$(echo "$BODY" | sed 's/^          //')
 
-          gh issue create --repo "$REPO" \
-            --title "$TITLE" \
-            --body "$BODY" \
-            --label "quality-debt"
+          ISSUE_BODY_FILE="$RUNNER_TEMP/post-merge-verify-follow-up.md"
+          printf '%s\n' "$BODY" > "$ISSUE_BODY_FILE"
+
+          chmod +x .agents/scripts/post-merge-verify-report-helper.sh
+          .agents/scripts/post-merge-verify-report-helper.sh \
+            create-follow-up "$REPO" "$TITLE" "$ISSUE_BODY_FILE"
 
       # Comment publication is deliberately fail-soft. This final step exposes
       # the original typed verification outcome as the workflow conclusion.


### PR DESCRIPTION
## Summary

Route post-merge verification failure issues through gh_create_issue with normalized worker lifecycle labels and repair the shared-dependency test fixture that blocked prior CI

## Files Changed

.agents/scripts/post-merge-verify-report-helper.sh, .agents/scripts/tests/test-post-merge-verify-report.sh, .agents/scripts/tests/test-pre-commit-split.sh, .github/workflows/post-merge-verify.yml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — ShellCheck clean; post-merge report tests 9/9; pre-commit split tests 16/16; shared-constants dependency guard passes; TypeScript typecheck passes

Resolves #29648


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.229 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 6m and 80,719 tokens on this as a headless worker.