### PR TITLE
GH#29660: Block direct Read access to root-managed source-access snapshots

### DIFF
--- a/.agents/plugins/opencode-aidevops/source-access-approval.mjs
+++ b/.agents/plugins/opencode-aidevops/source-access-approval.mjs
@@ -307,13 +307,16 @@ export function checkSecretReadWithApproval({
   requestRun = execFileSync,
 }) {
   const filePath = readPath(args);
+  // Fail closed before tool-name classification. OpenCode hook identities can
+  // be normalized independently of their argument shape, but no direct tool
+  // invocation should ever receive a root-managed approval snapshot path.
+  if (filePath && isManagedSnapshotPath(filePath)) {
+    throw new Error("[source-access] direct reads of approval snapshots are denied");
+  }
+
   if (!isReadTool(tool) || !filePath) {
     checkSecretReadGate(tool, args, log);
     return;
-  }
-
-  if (isManagedSnapshotPath(filePath)) {
-    throw new Error("[source-access] direct reads of approval snapshots are denied");
   }
 
   const reason = secretReadBlockReason(filePath);

--- a/.agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs
@@ -13,7 +13,8 @@ import {
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   SOURCE_ACCESS_REASON,
@@ -21,6 +22,7 @@ import {
   checkSecretReadWithApproval,
   verifySourceAccessReceipt,
 } from "../source-access-approval.mjs";
+import { createQualityHooks } from "../quality-hooks.mjs";
 
 const BASE = {
   tool: "read",
@@ -154,6 +156,55 @@ test("direct reads of root-managed snapshots are denied", () => {
       }),
     /direct reads of approval snapshots are denied/,
   );
+});
+
+test("managed snapshot denial precedes read-tool classification", () => {
+  let gateCalls = 0;
+  assert.throws(
+    () =>
+      checkSecretReadWithApproval({
+        ...BASE,
+        tool: "functions.read",
+        args: { filePath: "/var/run/aidevops/source-access/snapshots/501/example.source" },
+        isReadTool: () => false,
+        checkSecretReadGate: () => {
+          gateCalls += 1;
+        },
+        verify: () => {
+          throw new Error("verifier must not run");
+        },
+        requestRun: () => {
+          throw new Error("request helper must not run");
+        },
+      }),
+    /direct reads of approval snapshots are denied/,
+  );
+  assert.equal(gateCalls, 0);
+});
+
+test("composed OpenCode before-tool hook denies the live Read argument shape", async () => {
+  const tempParent = join(homedir(), ".aidevops", ".agent-workspace", "tmp");
+  mkdirSync(tempParent, { recursive: true });
+  const logsDir = mkdtempSync(join(tempParent, "source-access-hook-test-"));
+  const scriptsDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "scripts");
+
+  try {
+    const hooks = createQualityHooks({ scriptsDir, logsDir });
+    await assert.rejects(
+      hooks.toolExecuteBefore(
+        { tool: "read", sessionID: BASE.sessionId },
+        {
+          args: {
+            filePath:
+              "/var/run/aidevops/source-access/snapshots/501/0123456789abcdef0123456789abcdef.source",
+          },
+        },
+      ),
+      /direct reads of approval snapshots are denied/,
+    );
+  } finally {
+    rmSync(logsDir, { recursive: true, force: true });
+  }
 });
 
 test("the loaded verifier accepts only the exact signed receipt", () => {


### PR DESCRIPTION
## Summary

- deny direct tool access to root-managed source-access snapshots before Read tool-name classification
- add isolated and composed-hook regression coverage for the live OpenCode argument shape
- preserve approved original-path rewrites to verified immutable snapshots

## Verification

- `node --test .agents/plugins/opencode-aidevops/tests/test-source-access-approval.mjs`
- broader quality-hook tests, changed-file lint, and disposable-runtime smoke verification remain in progress while this PR is draft

Resolves #29660

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.229 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 3m and 75,640 tokens on this as a headless worker.