### PR TITLE
GH#29616: fix: canonicalize source-access public keys

### DIFF
--- a/.agents/scripts/source_access_core.py
+++ b/.agents/scripts/source_access_core.py
@@ -386,12 +386,17 @@ def _derive_public_key(config: Config) -> bytes:
         ]
     )
     _require_source(result.returncode == 0, "failed to derive the source-access verification key")
-    public_key = result.stdout.strip()
+    public_key_output = result.stdout.strip()
+    public_key_parts = public_key_output.split()
     _require_source(
-        public_key.startswith(b"ssh-ed25519 ") and b"\n" not in public_key,
+        len(public_key_parts) >= 2
+        and public_key_parts[0] == b"ssh-ed25519"
+        and bool(public_key_parts[1])
+        and b"\n" not in public_key_output
+        and b"\r" not in public_key_output,
         "failed to derive a valid source-access verification key",
     )
-    return public_key
+    return b" ".join(public_key_parts[:2])
 
 
 def _trust_marker_content(public_key: bytes) -> bytes:

--- a/.agents/scripts/tests/test-source-access-helper.py
+++ b/.agents/scripts/tests/test-source-access-helper.py
@@ -257,12 +257,14 @@ class SourceAccessHelperTests(unittest.TestCase):
         self.assertEqual(stat.S_IMODE(dedicated_config.private_key.stat().st_mode), 0o600)
         self.assertEqual(stat.S_IMODE(dedicated_config.public_key.stat().st_mode), 0o644)
         self.assertEqual(stat.S_IMODE(dedicated_config.trust_marker.stat().st_mode), 0o644)
-        derived_public = subprocess.run(
+        derived_public_fields = subprocess.run(
             [HELPER.SSH_KEYGEN, "-y", "-f", str(dedicated_config.private_key)],
             check=True,
             capture_output=True,
             text=True,
-        ).stdout.strip()
+        ).stdout.split()
+        self.assertGreaterEqual(len(derived_public_fields), 2)
+        derived_public = " ".join(derived_public_fields[:2])
         self.assertEqual(dedicated_config.public_key.read_text(encoding="utf-8").strip(), derived_public)
         self.assertEqual(
             dedicated_config.trust_marker.read_text(encoding="utf-8"),
@@ -297,6 +299,26 @@ class SourceAccessHelperTests(unittest.TestCase):
         dedicated_config.private_key.chmod(0o600)
         with self.assertRaisesRegex(HELPER.SourceAccessError, "key binding"):
             HELPER.validate_key_material(dedicated_config)
+
+    def test_setup_canonicalizes_derived_public_key_comment(self) -> None:
+        canonical_public = self.config.public_key.read_bytes().strip()
+        commented_public = canonical_public + b" aidevops-source-access-signing\n"
+        derived_result = subprocess.CompletedProcess(
+            args=[HELPER.SSH_KEYGEN, "-y", "-f", str(self.config.private_key)],
+            returncode=0,
+            stdout=commented_public,
+            stderr=b"",
+        )
+
+        with mock.patch.object(HELPER._SOURCE_CORE, "_run", return_value=derived_result):
+            HELPER.setup_key_material(self.config)
+
+        self.assertEqual(self.config.public_key.read_bytes(), canonical_public + b"\n")
+        self.assertEqual(
+            self.config.trust_marker.read_bytes(),
+            HELPER._SOURCE_CORE._trust_marker_content(canonical_public),
+        )
+        HELPER.validate_key_material(self.config)
 
     def test_setup_records_existing_dedicated_key_binding(self) -> None:
         derived_public = self.config.public_key.read_text(encoding="utf-8").strip()


### PR DESCRIPTION
## Summary

Canonicalize ssh-keygen -y output before writing the source-access public key and trust marker, including the trailing-comment output that broke privileged setup.

## Files Changed

.agents/scripts/source_access_core.py, .agents/scripts/tests/test-source-access-helper.py

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — python3 .agents/scripts/tests/test-source-access-helper.py (18 tests); .agents/scripts/tests/test-setup-source-access-broker.sh; .agents/scripts/linters-local.sh --ci

Resolves #29616


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.230 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1d 6h and 4,832,284 tokens on this with the user in an interactive session.