### PR TITLE
GH#29679: Route issue-sync TODO publication through protected-branch-safe PRs

### DIFF
--- a/.agents/scripts/issue-sync-git-push-helper.sh
+++ b/.agents/scripts/issue-sync-git-push-helper.sh
@@ -2,84 +2,407 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# Conflict-safe git push helper for Issue Sync workflow TODO.md updates.
+# Protected-branch-safe publication for Issue Sync TODO.md projections.
 
 set -euo pipefail
 
-issue_sync_git_path() {
-	local rel_path="$1"
-	git rev-parse --git-path "$rel_path"
+ISSUE_SYNC_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=./planning-publisher.sh
+source "${ISSUE_SYNC_SCRIPT_DIR}/planning-publisher.sh"
+# shellcheck source=./shared-gh-wrappers.sh
+source "${ISSUE_SYNC_SCRIPT_DIR}/shared-gh-wrappers.sh"
+
+ISSUE_SYNC_PR_BRANCH="${AIDEVOPS_ISSUE_SYNC_PR_BRANCH:-aidevops/issue-sync-todo}"
+ISSUE_SYNC_PR_MARKER="<!-- aidevops:issue-sync-todo-pr -->"
+ISSUE_SYNC_COMMIT_SUBJECT="chore: sync GitHub issue state to TODO.md"
+ISSUE_SYNC_DEFAULT_COMMIT_MESSAGE="${ISSUE_SYNC_COMMIT_SUBJECT} [skip ci]"
+ISSUE_SYNC_LAST_PUBLISH_OUTPUT=""
+ISSUE_SYNC_BASE_SHA=""
+ISSUE_SYNC_SOURCE_BASE_SHA=""
+
+issue_sync_repo_slug() {
+	local repo_path="$1"
+	local remote_url=""
+	local slug="${GITHUB_REPOSITORY:-}"
+	if [[ "$slug" =~ ^[^/]+/[^/]+$ ]]; then
+		printf '%s\n' "$slug"
+		return 0
+	fi
+	remote_url=$(git -C "$repo_path" remote get-url origin 2>/dev/null) || return 1
+	case "$remote_url" in
+	git@github.com:*) slug="${remote_url#git@github.com:}" ;;
+	ssh://git@github.com/*) slug="${remote_url#ssh://git@github.com/}" ;;
+	https://github.com/*) slug="${remote_url#https://github.com/}" ;;
+	http://github.com/*) slug="${remote_url#http://github.com/}" ;;
+	*) return 1 ;;
+	esac
+	slug="${slug%.git}"
+	[[ "$slug" =~ ^[^/]+/[^/]+$ ]] || return 1
+	printf '%s\n' "$slug"
 	return 0
 }
 
-issue_sync_rebase_in_progress() {
-	local rebase_merge
-	local rebase_apply
-	rebase_merge=$(issue_sync_git_path "rebase-merge")
-	rebase_apply=$(issue_sync_git_path "rebase-apply")
-	[[ -d "$rebase_merge" || -d "$rebase_apply" ]]
+issue_sync_is_gh006() {
+	local output="$1"
+	[[ "$output" == *"GH006"* && "$output" == *"Protected branch update failed"* ]]
 	return $?
 }
 
-issue_sync_abort_rebase_if_needed() {
-	if issue_sync_rebase_in_progress; then
-		echo "::warning::Aborting leftover rebase before retrying TODO.md push"
-		git rebase --abort >/dev/null 2>&1 || true
+issue_sync_pr_commit_message() {
+	local commit_msg="$1"
+	local sanitized=""
+	sanitized=$(printf '%s\n' "$commit_msg" | sed -E 's/[[:space:]]*\[skip ci\]//g')
+	[[ -n "$sanitized" ]] || sanitized="$ISSUE_SYNC_COMMIT_SUBJECT"
+	printf '%s\n' "$sanitized"
+	return 0
+}
+
+issue_sync_changed_reference_numbers() {
+	local base_file="$1"
+	local candidate_file="$2"
+	local commit_msg="$3"
+	local diff_output=""
+	local diff_rc=0
+	diff_output=$(git diff --no-index --unified=0 -- "$base_file" "$candidate_file" 2>/dev/null) || diff_rc=$?
+	if [[ "$diff_rc" -ne 0 && "$diff_rc" -ne 1 ]]; then
+		return 1
+	fi
+	{
+		printf '%s\n' "$commit_msg"
+		printf '%s\n' "$diff_output"
+	} | grep -oE '(ref:GH#|pr:#|GH#|PR[[:space:]]+#[0-9]+)[0-9]*' \
+		| grep -oE '[0-9]+' \
+		| sort -nu || true
+	return 0
+}
+
+issue_sync_pr_linkage() {
+	local base_file="$1"
+	local candidate_file="$2"
+	local commit_msg="$3"
+	local reference_numbers=""
+	local reference_number=""
+	local linkage=""
+	local count=0
+	reference_numbers=$(issue_sync_changed_reference_numbers "$base_file" "$candidate_file" "$commit_msg") || return 1
+	while IFS= read -r reference_number; do
+		[[ "$reference_number" =~ ^[0-9]+$ ]] || continue
+		linkage="${linkage}- Ref #${reference_number}"$'\n'
+		count=$((count + 1))
+		[[ "$count" -lt 20 ]] || break
+	done <<<"$reference_numbers"
+	if [[ -z "$linkage" ]]; then
+		echo "::error::Cannot derive issue or PR linkage from the TODO.md publication"
+		return 1
+	fi
+	printf '%s' "$linkage"
+	return 0
+}
+
+issue_sync_planning_pr_body() {
+	local default_branch="$1"
+	local commit_msg="$2"
+	local base_file="$3"
+	local candidate_file="$4"
+	local linkage=""
+	linkage=$(issue_sync_pr_linkage "$base_file" "$candidate_file" "$commit_msg") || return 1
+	cat <<EOF
+${ISSUE_SYNC_PR_MARKER}
+## Issue-sync TODO publication
+
+- Publishes the cumulative \`TODO.md\` projection through a pull request because \`${default_branch}\` rejected direct publication with GH006.
+- Uses the deterministic \`${ISSUE_SYNC_PR_BRANCH}\` branch so retries and concurrent events update one PR.
+- Rebases the projection onto current \`${default_branch}\` while preserving unrelated TODO changes already queued in this PR.
+- Latest publication intent: \`${commit_msg}\`.
+
+## Linkage
+
+${linkage}
+## Merge behaviour
+
+- The PR title retains \`[skip ci]\` so the eventual squash commit does not start another issue-sync loop.
+- The PR branch commit intentionally omits \`[skip ci]\` so required pull-request checks still run.
+- Canonical task and forge linkage remains in the projected \`ref:GH#...\` and \`pr:#...\` metadata.
+EOF
+	return 0
+}
+
+issue_sync_capture_planning_publish() {
+	local repo_path="$1"
+	local commit_msg="$2"
+	local remote_name="$3"
+	local branch_name="$4"
+	local paths="$5"
+	local output_file="$6"
+	local rc=0
+	: >"$output_file" || return 1
+	planning_publish "$repo_path" "$commit_msg" "$remote_name" "$branch_name" "$paths" >"$output_file" 2>&1 || rc=$?
+	ISSUE_SYNC_LAST_PUBLISH_OUTPUT=$(<"$output_file")
+	if [[ -n "$ISSUE_SYNC_LAST_PUBLISH_OUTPUT" ]]; then
+		printf '%s\n' "$ISSUE_SYNC_LAST_PUBLISH_OUTPUT"
+	fi
+	return "$rc"
+}
+
+issue_sync_merge_todo_file() {
+	local current_file="$1"
+	local ancestor_file="$2"
+	local incoming_file="$3"
+	local rc=0
+	git merge-file --ours "$current_file" "$ancestor_file" "$incoming_file" >/dev/null 2>&1 || rc=$?
+	if [[ "$rc" -ne 0 ]]; then
+		echo "::error::Unable to merge concurrent TODO.md projections safely"
+		return 1
 	fi
 	return 0
 }
 
-issue_sync_reset_to_origin_branch() {
-	local branch="$1"
-	git reset --hard "origin/${branch}"
+issue_sync_read_todo_blob() {
+	local repo_path="$1"
+	local commit_sha="$2"
+	local destination="$3"
+	git -C "$repo_path" show "${commit_sha}:TODO.md" >"$destination" 2>/dev/null
+	return $?
+}
+
+issue_sync_prepare_base_snapshot() {
+	local repo_path="$1"
+	local default_branch="$2"
+	local source_file="$3"
+	local state_dir="$4"
+	local merged_file="${state_dir}/merged-todo"
+	local source_ancestor="${state_dir}/source-ancestor"
+	local latest_todo="${state_dir}/latest-base-todo"
+	local source_head=""
+
+	git -C "$repo_path" fetch -q origin "$default_branch" || return 1
+	ISSUE_SYNC_BASE_SHA=$(git -C "$repo_path" rev-parse FETCH_HEAD) || return 1
+	source_head=$(git -C "$repo_path" rev-parse "HEAD^{commit}") || return 1
+	ISSUE_SYNC_SOURCE_BASE_SHA=$(git -C "$repo_path" merge-base "$source_head" "$ISSUE_SYNC_BASE_SHA") || return 1
+	cp -p "$source_file" "$merged_file" || return 1
+	issue_sync_read_todo_blob "$repo_path" "$ISSUE_SYNC_SOURCE_BASE_SHA" "$source_ancestor" || return 1
+	issue_sync_read_todo_blob "$repo_path" "$ISSUE_SYNC_BASE_SHA" "$latest_todo" || return 1
+	issue_sync_merge_todo_file "$merged_file" "$source_ancestor" "$latest_todo" || return 1
 	return 0
 }
 
-issue_sync_neutralize_rebase_conflict() {
-	local branch="$1"
-	local attempt="$2"
-	echo "::warning::TODO.md rebase conflict on push attempt ${attempt}; aborting rebase and resetting to origin/${branch}. A later issue-sync run will re-pull missing refs."
-	git rebase --abort >/dev/null 2>&1 || true
-	issue_sync_reset_to_origin_branch "$branch"
+issue_sync_remote_branch_sha() {
+	local repo_path="$1"
+	local branch_name="$2"
+	local remote_line=""
+	local remote_sha=""
+	local remote_ref=""
+	remote_line=$(git -C "$repo_path" ls-remote --heads origin "refs/heads/${branch_name}") || return 1
+	[[ -n "$remote_line" && "$remote_line" != *$'\n'* ]] || return 2
+	IFS=$'\t' read -r remote_sha remote_ref <<<"$remote_line"
+	[[ "$remote_sha" =~ ^[0-9a-fA-F]{40,64}$ && "$remote_ref" == "refs/heads/${branch_name}" ]] || return 1
+	printf '%s\n' "$remote_sha"
 	return 0
 }
 
-issue_sync_push_todo_with_rebase_retry() {
-	local branch="$1"
-	local attempts="$2"
-	local attempt
+issue_sync_prepare_pr_snapshot() {
+	local repo_path="$1"
+	local default_branch="$2"
+	local source_file="$3"
+	local state_dir="$4"
+	local sync_sha=""
+	local sync_base=""
+	local sync_ancestor="${state_dir}/sync-ancestor"
+	local sync_todo="${state_dir}/sync-todo"
+	local branch_rc=0
 
-	for attempt in $(seq 1 "$attempts"); do
-		echo "Push attempt ${attempt}..."
-		issue_sync_abort_rebase_if_needed
-		git fetch origin "$branch" --quiet
+	issue_sync_prepare_base_snapshot "$repo_path" "$default_branch" "$source_file" "$state_dir" || return 1
+	sync_sha=$(issue_sync_remote_branch_sha "$repo_path" "$ISSUE_SYNC_PR_BRANCH") || branch_rc=$?
+	if [[ "$branch_rc" -eq 2 ]]; then
+		return 0
+	fi
+	[[ "$branch_rc" -eq 0 ]] || return 1
+	git -C "$repo_path" fetch -q origin "$ISSUE_SYNC_PR_BRANCH" || return 1
+	sync_sha=$(git -C "$repo_path" rev-parse FETCH_HEAD) || return 1
+	sync_base=$(git -C "$repo_path" merge-base "$ISSUE_SYNC_BASE_SHA" "$sync_sha") || return 1
+	issue_sync_read_todo_blob "$repo_path" "$sync_base" "$sync_ancestor" || return 1
+	issue_sync_read_todo_blob "$repo_path" "$sync_sha" "$sync_todo" || return 1
+	issue_sync_merge_todo_file "${state_dir}/merged-todo" "$sync_ancestor" "$sync_todo" || return 1
+	return 0
+}
 
-		if ! git rebase "origin/${branch}"; then
-			issue_sync_neutralize_rebase_conflict "$branch" "$attempt"
-			return 0
+issue_sync_existing_pr_url() {
+	local repo_slug="$1"
+	local default_branch="$2"
+	local existing=""
+	existing=$(gh_pr_list --repo "$repo_slug" --head "$ISSUE_SYNC_PR_BRANCH" --base "$default_branch" \
+		--state open --json number,url --jq 'if length == 0 then "" elif length == 1 then .[0].url else "MULTIPLE" end' 2>/dev/null) || return 1
+	if [[ "$existing" == "MULTIPLE" ]]; then
+		echo "::error::Multiple open issue-sync PRs exist for ${ISSUE_SYNC_PR_BRANCH}"
+		return 1
+	fi
+	printf '%s\n' "$existing"
+	return 0
+}
+
+issue_sync_ensure_planning_pr() {
+	local repo_path="$1"
+	local default_branch="$2"
+	local commit_msg="$3"
+	local state_dir="$4"
+	local repo_slug=""
+	local existing_url=""
+	local pr_url=""
+	local pr_body_file="${state_dir}/issue-sync-pr-body.md"
+	local pr_title="$ISSUE_SYNC_DEFAULT_COMMIT_MESSAGE"
+
+	repo_slug=$(issue_sync_repo_slug "$repo_path") || {
+		echo "::error::Cannot resolve GitHub repository for issue-sync PR publication"
+		return 1
+	}
+	existing_url=$(issue_sync_existing_pr_url "$repo_slug" "$default_branch") || return 1
+	if [[ -n "$existing_url" ]]; then
+		echo "::notice::Updated deterministic issue-sync PR ${existing_url}"
+		return 0
+	fi
+	issue_sync_planning_pr_body "$default_branch" "$commit_msg" \
+		"${state_dir}/latest-base-todo" "${state_dir}/merged-todo" >"$pr_body_file" || return 1
+	pr_url=$(AIDEVOPS_PR_CREATE_READY=1 gh_create_pr \
+		--repo "$repo_slug" \
+		--base "$default_branch" \
+		--head "$ISSUE_SYNC_PR_BRANCH" \
+		--title "$pr_title" \
+		--label "origin:worker" \
+		--body-file "$pr_body_file" 2>/dev/null) || {
+		pr_url=$(_gh_recover_pr_if_exists "$ISSUE_SYNC_PR_BRANCH" "$repo_slug")
+		[[ -n "$pr_url" ]] || {
+			echo "::error::Failed to create or recover deterministic issue-sync PR"
+			return 1
+		}
+	}
+	echo "::notice::Created deterministic issue-sync PR ${pr_url}"
+	return 0
+}
+
+issue_sync_publish_via_pr() {
+	local repo_path="$1"
+	local default_branch="$2"
+	local attempts="$3"
+	local commit_msg="$4"
+	local source_file="$5"
+	local state_dir="$6"
+	local branch_commit_msg=""
+	local output_file="${state_dir}/pr-publish-output"
+	local attempt=0
+	local rc=0
+	local branch_rc=0
+
+	branch_commit_msg=$(issue_sync_pr_commit_message "$commit_msg") || return 1
+	while [[ "$attempt" -lt "$attempts" ]]; do
+		attempt=$((attempt + 1))
+		issue_sync_prepare_pr_snapshot "$repo_path" "$default_branch" "$source_file" "$state_dir" || return 1
+		cp -p "${state_dir}/merged-todo" "${repo_path}/TODO.md" || return 1
+		rc=0
+		AIDEVOPS_PLANNING_PARENT_BRANCH="$default_branch" \
+			AIDEVOPS_PLANNING_BASE_SHA="$ISSUE_SYNC_BASE_SHA" \
+			PLANNING_PUBLISH_MAX_RETRIES=1 \
+			issue_sync_capture_planning_publish "$repo_path" "$branch_commit_msg" origin \
+			"$ISSUE_SYNC_PR_BRANCH" TODO.md "$output_file" || rc=$?
+		cp -p "$source_file" "${repo_path}/TODO.md" || return 1
+		if [[ "$rc" -eq 0 ]]; then
+			branch_rc=0
+			issue_sync_remote_branch_sha "$repo_path" "$ISSUE_SYNC_PR_BRANCH" >/dev/null || branch_rc=$?
+			if [[ "$branch_rc" -eq 2 ]]; then
+				echo "::warning::Issue-sync PR branch disappeared after publication; rebuilding"
+				continue
+			fi
+			[[ "$branch_rc" -eq 0 ]] || return 1
+			issue_sync_ensure_planning_pr "$repo_path" "$default_branch" "$commit_msg" "$state_dir"
+			return $?
 		fi
-
-		if git push origin "HEAD:${branch}"; then
-			echo "Push succeeded on attempt ${attempt}"
-			return 0
+		if [[ "$rc" -ne 2 ]]; then
+			return "$rc"
 		fi
-
-		echo "Push failed on attempt ${attempt}; retrying from a clean rebase state"
-		issue_sync_abort_rebase_if_needed
-		sleep $((attempt * 3))
+		echo "::warning::Issue-sync PR branch changed concurrently; rebuilding from current ${default_branch}"
 	done
+	echo "::error::Failed to update deterministic issue-sync PR after ${attempts} attempts"
+	return 1
+}
 
-	echo "::error::Failed to push TODO.md update after ${attempts} attempts"
+issue_sync_publish_todo() {
+	local default_branch="$1"
+	local attempts="$2"
+	local commit_msg="$3"
+	local repo_path=""
+	local state_dir=""
+	local source_file=""
+	local output_file=""
+	local attempt=0
+	local rc=0
+
+	[[ "$attempts" =~ ^[1-9][0-9]*$ ]] || {
+		echo "::error::Publication attempts must be a positive integer"
+		return 2
+	}
+	repo_path=$(git rev-parse --show-toplevel) || return 1
+	[[ -f "${repo_path}/TODO.md" && ! -L "${repo_path}/TODO.md" ]] || {
+		echo "::error::TODO.md must be a regular file"
+		return 1
+	}
+	state_dir=$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/issue-sync-publish.XXXXXX") || return 1
+	source_file="${state_dir}/source-todo"
+	output_file="${state_dir}/direct-publish-output"
+	cp -p "${repo_path}/TODO.md" "$source_file" || {
+		rm -rf "$state_dir"
+		return 1
+	}
+
+	while [[ "$attempt" -lt "$attempts" ]]; do
+		attempt=$((attempt + 1))
+		issue_sync_prepare_base_snapshot "$repo_path" "$default_branch" "$source_file" "$state_dir" || {
+			cp -p "$source_file" "${repo_path}/TODO.md" || true
+			rm -rf "$state_dir"
+			return 1
+		}
+		cp -p "${state_dir}/merged-todo" "${repo_path}/TODO.md" || {
+			rm -rf "$state_dir"
+			return 1
+		}
+		rc=0
+		AIDEVOPS_PLANNING_PARENT_BRANCH="" \
+			AIDEVOPS_PLANNING_BASE_SHA="$ISSUE_SYNC_BASE_SHA" \
+			PLANNING_PUBLISH_MAX_RETRIES=1 \
+			issue_sync_capture_planning_publish "$repo_path" "$commit_msg" origin \
+			"$default_branch" TODO.md "$output_file" || rc=$?
+		cp -p "$source_file" "${repo_path}/TODO.md" || {
+			rm -rf "$state_dir"
+			return 1
+		}
+		if [[ "$rc" -eq 0 ]]; then
+			rm -rf "$state_dir"
+			return 0
+		fi
+		if issue_sync_is_gh006 "$ISSUE_SYNC_LAST_PUBLISH_OUTPUT"; then
+			echo "::notice::Direct TODO.md publication is protected; routing through one deterministic PR"
+			rc=0
+			issue_sync_publish_via_pr "$repo_path" "$default_branch" "$attempts" "$commit_msg" "$source_file" "$state_dir" || rc=$?
+			rm -rf "$state_dir"
+			return "$rc"
+		fi
+		if [[ "$rc" -ne 2 ]]; then
+			rm -rf "$state_dir"
+			return "$rc"
+		fi
+		echo "::warning::TODO.md base advanced during publication; rebuilding safely"
+	done
+	rm -rf "$state_dir"
+	echo "::error::Failed to publish TODO.md after ${attempts} attempts"
 	return 1
 }
 
 issue_sync_git_push_usage() {
 	cat <<'EOF'
-Usage: issue-sync-git-push-helper.sh push-todo [branch] [attempts]
+Usage: issue-sync-git-push-helper.sh publish-todo [branch] [attempts] [commit-message]
+       issue-sync-git-push-helper.sh push-todo [branch] [attempts]
 
-Pushes the current TODO.md sync commit after rebasing onto origin/<branch>.
-On rebase conflict, aborts the rebase, resets to origin/<branch>, and exits 0
-to prevent repeated failed workflow notifications from an unresolved index.
+Publishes TODO.md with planning-publisher.sh. A terminal GH006 response updates
+one deterministic protected-branch PR instead of asking maintainers to weaken
+branch protection. The legacy push-todo command derives its message from HEAD.
 EOF
 	return 0
 }
@@ -88,21 +411,28 @@ main() {
 	local command="${1:-}"
 	local branch="${2:-main}"
 	local attempts="${3:-3}"
+	local commit_msg="${4:-}"
 
 	case "$command" in
-		push-todo)
-			issue_sync_push_todo_with_rebase_retry "$branch" "$attempts"
-			return $?
-			;;
-		-h|--help|help|"")
-			issue_sync_git_push_usage
-			return 0
-			;;
-		*)
-			echo "Unknown command: $command" >&2
-			issue_sync_git_push_usage >&2
-			return 2
-			;;
+	publish-todo)
+		[[ -n "$commit_msg" ]] || commit_msg="$ISSUE_SYNC_DEFAULT_COMMIT_MESSAGE"
+		issue_sync_publish_todo "$branch" "$attempts" "$commit_msg"
+		return $?
+		;;
+	push-todo)
+		commit_msg=$(git log -1 --pretty=%s 2>/dev/null) || commit_msg="$ISSUE_SYNC_DEFAULT_COMMIT_MESSAGE"
+		issue_sync_publish_todo "$branch" "$attempts" "$commit_msg"
+		return $?
+		;;
+	-h|--help|help|"")
+		issue_sync_git_push_usage
+		return 0
+		;;
+	*)
+		echo "Unknown command: $command" >&2
+		issue_sync_git_push_usage >&2
+		return 2
+		;;
 	esac
 }
 

--- a/.agents/scripts/planning-publisher.sh
+++ b/.agents/scripts/planning-publisher.sh
@@ -565,11 +565,29 @@ _planning_publish_resolve_parent() {
 	local target_check_rc=0
 	local default_branch=""
 	local parent_sha=""
+	local target_sha=""
+	local parent_branch="${AIDEVOPS_PLANNING_PARENT_BRANCH:-}"
 	local branch_ref="${PLANNING_BRANCH_REF_PREFIX}${branch_name}"
+
+	if [[ -n "$parent_branch" && "$parent_branch" != "$branch_name" ]]; then
+		if _planning_git -C "$repo_path" fetch -q "$remote_name" "$branch_name" 2>/dev/null; then
+			target_sha=$(_planning_git -C "$repo_path" rev-parse FETCH_HEAD) || return 1
+		elif _planning_git -C "$repo_path" ls-remote --exit-code --heads "$remote_name" "$branch_ref" >/dev/null 2>&1; then
+			_planning_git -C "$repo_path" fetch -q "$remote_name" "$branch_name" || return 1
+			target_sha=$(_planning_git -C "$repo_path" rev-parse FETCH_HEAD) || return 1
+		else
+			target_check_rc=$?
+			[[ "$target_check_rc" -eq 2 ]] || return 1
+		fi
+		_planning_git -C "$repo_path" fetch -q "$remote_name" "$parent_branch" || return 1
+		parent_sha=$(_planning_git -C "$repo_path" rev-parse FETCH_HEAD) || return 1
+		printf '%s|%s|%s\n' "$parent_sha" "$target_sha" "$target_sha"
+		return 0
+	fi
 
 	if _planning_git -C "$repo_path" fetch -q "$remote_name" "$branch_name" 2>/dev/null; then
 		parent_sha=$(_planning_git -C "$repo_path" rev-parse FETCH_HEAD) || return 1
-		printf '%s|%s\n' "$parent_sha" "$parent_sha"
+		printf '%s|%s|%s\n' "$parent_sha" "$parent_sha" "$parent_sha"
 		return 0
 	fi
 
@@ -578,7 +596,7 @@ _planning_publish_resolve_parent() {
 		# normal update lease rather than misclassifying it as absent.
 		_planning_git -C "$repo_path" fetch -q "$remote_name" "$branch_name" || return 1
 		parent_sha=$(_planning_git -C "$repo_path" rev-parse FETCH_HEAD) || return 1
-		printf '%s|%s\n' "$parent_sha" "$parent_sha"
+		printf '%s|%s|%s\n' "$parent_sha" "$parent_sha" "$parent_sha"
 		return 0
 	else
 		target_check_rc=$?
@@ -593,7 +611,7 @@ _planning_publish_resolve_parent() {
 	parent_sha=$(_planning_git -C "$repo_path" rev-parse FETCH_HEAD) || return 1
 	# An empty expected value is Git's creation-safe lease: the push succeeds
 	# only while the target ref remains absent.
-	printf '%s|\n' "$parent_sha"
+	printf '%s||\n' "$parent_sha"
 	return 0
 }
 
@@ -739,6 +757,67 @@ _planning_publish_build_candidate() {
 	return 0
 }
 
+_planning_publish_resolve_attempt() {
+	local repo_path="$1"
+	local remote_name="$2"
+	local branch_name="$3"
+	local previous_target_sha="$4"
+	local snapshot_file="$5"
+	local publication_id="$6"
+	local attempt="$7"
+	local parent_resolution=""
+	local resolution_tail=""
+	local latest_sha=""
+	local expected_sha=""
+	local target_sha=""
+	parent_resolution=$(_planning_publish_resolve_parent "$repo_path" "$remote_name" "$branch_name") || return 1
+	latest_sha="${parent_resolution%%|*}"
+	resolution_tail="${parent_resolution#*|}"
+	expected_sha="${resolution_tail%%|*}"
+	target_sha="${resolution_tail#*|}"
+	if [[ -n "${AIDEVOPS_PLANNING_PARENT_BRANCH:-}" && "$attempt" -gt 1 && \
+		"$target_sha" != "$previous_target_sha" ]]; then
+		if [[ -z "$previous_target_sha" || -z "$target_sha" ]] || \
+			_planning_publish_parent_conflicts "$repo_path" "$previous_target_sha" "$target_sha" "$snapshot_file"; then
+			_planning_publish_log_retryable_conflict "$publication_id"
+			return 2
+		fi
+	fi
+	printf '%s|%s|%s\n' "$latest_sha" "$expected_sha" "$target_sha"
+	return 0
+}
+
+_planning_publish_finish_noop_if_current() {
+	local repo_path="$1"
+	local remote_name="$2"
+	local branch_name="$3"
+	local source_head="$4"
+	local latest_sha="$5"
+	local target_sha="$6"
+	local tree_sha="$7"
+	local publication_id="$8"
+	local snapshot_file="$9"
+	local current_sha="$latest_sha"
+	local target_parent=""
+	if [[ -n "${AIDEVOPS_PLANNING_PARENT_BRANCH:-}" ]]; then
+		[[ -n "$target_sha" ]] || return 1
+		[[ "$tree_sha" == "$(_planning_git -C "$repo_path" rev-parse "${target_sha}^{tree}")" ]] || return 1
+		if [[ "$target_sha" != "$latest_sha" ]]; then
+			target_parent=$(_planning_git -C "$repo_path" rev-parse "${target_sha}^") || return 1
+			[[ "$target_parent" == "$latest_sha" ]] || return 1
+		fi
+		current_sha="$target_sha"
+	elif [[ "$tree_sha" != "$(_planning_git -C "$repo_path" rev-parse "${latest_sha}^{tree}")" ]]; then
+		return 1
+	fi
+	_planning_publish_record_noop_receipt "$repo_path" "$remote_name" "$branch_name" "$source_head" \
+		"$current_sha" "$publication_id" "$snapshot_file" || {
+		_planning_publish_log error "Remote planning state is current, but its publication handoff receipt could not be reconstructed"
+		return 3
+	}
+	return 0
+}
+
 planning_publish() {
 	local repo_path="$1"
 	local commit_msg="$2"
@@ -747,9 +826,8 @@ planning_publish() {
 	local paths="${5:-}"
 	local external_source="${6:-}"
 	local temp_dir="" snapshot_file="" index_file="" parent_sha="" tree_sha="" candidate_sha=""
-	local publication_id="" handoff_id="" attempt=0 push_rc=0 latest_sha="" expected_sha="" parent_resolution="" base_sha="${AIDEVOPS_PLANNING_BASE_SHA:-}"
-	local guard_rc=0 source_head=""
-
+	local publication_id="" handoff_id="" attempt=0 push_rc=0 latest_sha="" expected_sha="" target_sha="" previous_target_sha=""
+	local parent_resolution="" resolution_tail="" base_sha="${AIDEVOPS_PLANNING_BASE_SHA:-}" guard_rc=0 resolve_rc=0 noop_rc=1 source_head=""
 	[[ -n "$branch_name" ]] || branch_name=$(_planning_git -C "$repo_path" symbolic-ref --short HEAD 2>/dev/null) || return 1
 	_planning_publish_reset_result
 	source_head=$(_planning_git -C "$repo_path" rev-parse --verify "HEAD^{commit}" 2>/dev/null) || return 1
@@ -764,15 +842,20 @@ planning_publish() {
 	snapshot_file="$_PLANNING_PUBLISH_SNAPSHOT_FILE"
 	index_file="$_PLANNING_PUBLISH_INDEX_FILE"
 	publication_id="$PLANNING_PUBLICATION_ID"
-
 	while [[ $attempt -lt $PLANNING_PUBLISH_MAX_RETRIES ]]; do
 		attempt=$((attempt + 1))
-		parent_resolution=$(_planning_publish_resolve_parent "$repo_path" "$remote_name" "$branch_name") || {
+		resolve_rc=0
+		parent_resolution=$(_planning_publish_resolve_attempt "$repo_path" "$remote_name" "$branch_name" \
+			"$previous_target_sha" "$snapshot_file" "$publication_id" "$attempt") || resolve_rc=$?
+		if [[ "$resolve_rc" -ne 0 ]]; then
 			rm -rf "$temp_dir"
-			return 1
-		}
+			return "$resolve_rc"
+		fi
 		latest_sha="${parent_resolution%%|*}"
-		expected_sha="${parent_resolution#*|}"
+		resolution_tail="${parent_resolution#*|}"
+		expected_sha="${resolution_tail%%|*}"
+		target_sha="${resolution_tail#*|}"
+		previous_target_sha="$target_sha"
 		_planning_publish_build_index "$repo_path" "$latest_sha" "$snapshot_file" "$index_file" || {
 			rm -rf "$temp_dir"
 			return 1
@@ -785,15 +868,12 @@ planning_publish() {
 			rm -rf "$temp_dir"
 			return 1
 		}
-		if [[ "$tree_sha" == "$(_planning_git -C "$repo_path" rev-parse "${latest_sha}^{tree}")" ]]; then
-			_planning_publish_record_noop_receipt "$repo_path" "$remote_name" "$branch_name" "$source_head" \
-				"$latest_sha" "$publication_id" "$snapshot_file" || {
-				_planning_publish_log error "Remote planning state is current, but its publication handoff receipt could not be reconstructed"
-				rm -rf "$temp_dir"
-				return 3
-			}
+		noop_rc=0
+		_planning_publish_finish_noop_if_current "$repo_path" "$remote_name" "$branch_name" "$source_head" \
+			"$latest_sha" "$target_sha" "$tree_sha" "$publication_id" "$snapshot_file" || noop_rc=$?
+		if [[ "$noop_rc" -ne 1 ]]; then
 			rm -rf "$temp_dir"
-			return 0
+			return "$noop_rc"
 		fi
 		if [[ -z "$parent_sha" && -n "$base_sha" && "$base_sha" != "$latest_sha" ]] && \
 			_planning_publish_parent_conflicts "$repo_path" "$base_sha" "$latest_sha" "$snapshot_file"; then

--- a/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
+++ b/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
@@ -43,9 +43,21 @@ create_origin() {
 	git init "$seed_dir" >/dev/null
 	git_init_repo "$seed_dir"
 	cat >"$seed_dir/TODO.md" <<'EOF'
-## Ready
+## First queue
 
 - [ ] t9001 original task ref:GH#9001
+
+First queue notes remain unchanged.
+
+## Second queue
+
+- [ ] t9002 second task ref:GH#9002
+
+Second queue notes remain unchanged.
+
+## Third queue
+
+- [ ] t9003 third task ref:GH#9003
 EOF
 	git -C "$seed_dir" add TODO.md
 	git -C "$seed_dir" commit -m "seed TODO" >/dev/null
@@ -104,8 +116,340 @@ test_rebase_conflict_neutralizes_cleanly() {
 	return 0
 }
 
+write_fake_gh() {
+	local fake_bin="$1"
+	mkdir -p "$fake_bin"
+	cat >"${fake_bin}/gh" <<'GH'
+#!/usr/bin/env bash
+set -u
+{
+	printf 'gh'
+	for arg in "$@"; do
+		printf '\t%s' "$arg"
+	done
+	printf '\n'
+} >>"${GH_STUB_LOG:?}"
+
+if [[ "${1:-}" == "label" ]]; then
+	exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
+	if [[ -f "${GH_STUB_PR_MARKER:?}" ]]; then
+		printf 'https://github.com/example/repo/pull/1\n'
+	fi
+	exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "create" ]]; then
+	shift 2
+	head_branch=""
+	title_text=""
+	body_text=""
+	body_file=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--head)
+			head_branch="${2:-}"
+			shift 2
+			;;
+		--head=*)
+			head_branch="${1#--head=}"
+			shift
+			;;
+		--title)
+			title_text="${2:-}"
+			shift 2
+			;;
+		--title=*)
+			title_text="${1#--title=}"
+			shift
+			;;
+		--body)
+			body_text="${2:-}"
+			shift 2
+			;;
+		--body=*)
+			body_text="${1#--body=}"
+			shift
+			;;
+		--body-file)
+			body_file="${2:-}"
+			shift 2
+			;;
+		--body-file=*)
+			body_file="${1#--body-file=}"
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
+	if [[ -n "$body_file" ]]; then
+		body_text=$(<"$body_file")
+	fi
+	printf '%s\n' "$body_text" >"${GH_STUB_BODY:?}"
+	[[ "$body_text" == *"Ref #"* ]] || exit 3
+	printf '%s\n' "$head_branch" >"${GH_STUB_HEAD:?}"
+	printf '%s\n' "$title_text" >"${GH_STUB_TITLE:?}"
+	: >"${GH_STUB_PR_MARKER:?}"
+	printf 'https://github.com/example/repo/pull/1\n'
+	exit 0
+fi
+
+exit 0
+GH
+	chmod +x "${fake_bin}/gh"
+	return 0
+}
+
+install_main_rejection_hook() {
+	local origin_dir="$1"
+	local mode="$2"
+	cat >"${origin_dir}/hooks/pre-receive" <<EOF
+#!/usr/bin/env bash
+while read -r _old _new ref; do
+	if [[ "\$ref" != "refs/heads/main" || -f "${origin_dir}/allow-main" ]]; then
+		continue
+	fi
+	if [[ "${mode}" == "gh006" ]]; then
+		printf 'remote: error: GH006: Protected branch update failed for %s.\n' "\$ref" >&2
+		printf 'remote: error: Changes must be made through a pull request.\n' >&2
+	else
+		printf 'remote: terminal publication failure for %s.\n' "\$ref" >&2
+	fi
+	exit 1
+done
+exit 0
+EOF
+	chmod +x "${origin_dir}/hooks/pre-receive"
+	return 0
+}
+
+install_one_time_sync_branch_delete_hook() {
+	local origin_dir="$1"
+	cat >"${origin_dir}/hooks/post-receive" <<EOF
+#!/usr/bin/env bash
+while read -r _old new ref; do
+	if [[ "\$ref" != "refs/heads/aidevops/issue-sync-todo" || -f "${origin_dir}/deleted-sync-branch" ]]; then
+		continue
+	fi
+	git --git-dir="${origin_dir}" update-ref -d "\$ref" "\$new" || exit 1
+	: >"${origin_dir}/deleted-sync-branch"
+done
+exit 0
+EOF
+	chmod +x "${origin_dir}/hooks/post-receive"
+	return 0
+}
+
+run_issue_sync_helper() {
+	local work_dir="$1"
+	local fake_bin="$2"
+	local gh_log="$3"
+	local pr_marker="$4"
+	local head_file="$5"
+	local title_file="$6"
+	local output_file="$7"
+	local attempts="${8:-3}"
+	(
+		cd "$work_dir" || exit 1
+		PATH="${fake_bin}:$PATH" \
+			GITHUB_ACTIONS=true \
+			GITHUB_REPOSITORY="example/repo" \
+			GH_TOKEN="fixture-token" \
+			GH_STUB_LOG="$gh_log" \
+			GH_STUB_PR_MARKER="$pr_marker" \
+			GH_STUB_HEAD="$head_file" \
+			GH_STUB_TITLE="$title_file" \
+			GH_STUB_BODY="${title_file}.body" \
+			bash "$HELPER" publish-todo main "$attempts" \
+			"chore: sync fixture issue refs to TODO.md [skip ci]" >"$output_file" 2>&1
+	)
+	return $?
+}
+
+test_protected_branch_uses_one_rebased_pr() {
+	local origin_dir="$TMP/protected-origin.git"
+	local seed_dir="$TMP/protected-seed"
+	local work_a="$TMP/protected-work-a"
+	local work_b="$TMP/protected-work-b"
+	local fake_bin="$TMP/protected-bin"
+	local gh_log="$TMP/protected-gh.log"
+	local pr_marker="$TMP/protected-pr.marker"
+	local head_file="$TMP/protected-head.txt"
+	local title_file="$TMP/protected-title.txt"
+	local output_a="$TMP/protected-a.log"
+	local output_b="$TMP/protected-b.log"
+	local sync_ref="refs/heads/aidevops/issue-sync-todo"
+	local remote_todo=""
+	local main_todo=""
+	local main_sha=""
+	local sync_parent=""
+	local create_count=0
+	local branch_message=""
+
+	create_origin "$origin_dir" "$seed_dir"
+	git clone "$origin_dir" "$work_a" >/dev/null 2>&1
+	git clone "$origin_dir" "$work_b" >/dev/null 2>&1
+	git_init_repo "$work_a"
+	git_init_repo "$work_b"
+	write_fake_gh "$fake_bin"
+	install_main_rejection_hook "$origin_dir" gh006
+	: >"$gh_log"
+
+	perl -0pi -e 's/t9001 original task/t9001 first event/' "$work_a/TODO.md"
+	if ! run_issue_sync_helper "$work_a" "$fake_bin" "$gh_log" "$pr_marker" \
+		"$head_file" "$title_file" "$output_a" 3; then
+		printf 'Protected publication output:\n%s\n' "$(<"$output_a")" >&2
+		fail "GH006 creates a deterministic issue-sync PR"
+		return 0
+	fi
+
+	# Advance protected main with an unrelated TODO edit between events. The
+	# fixture bypass file represents a separately merged reviewed change.
+	: >"${origin_dir}/allow-main"
+	perl -0pi -e 's/t9003 third task/t9003 reviewed main edit/' "$seed_dir/TODO.md"
+	git -C "$seed_dir" add TODO.md
+	git -C "$seed_dir" commit -m "reviewed main TODO edit" >/dev/null
+	git -C "$seed_dir" push origin main >/dev/null
+	rm -f "${origin_dir}/allow-main"
+
+	perl -0pi -e 's/t9002 second task/t9002 second event/' "$work_b/TODO.md"
+	if ! run_issue_sync_helper "$work_b" "$fake_bin" "$gh_log" "$pr_marker" \
+		"$head_file" "$title_file" "$output_b" 3; then
+		fail "concurrent issue events update the deterministic PR"
+		return 0
+	fi
+
+	remote_todo=$(git --git-dir="$origin_dir" show "${sync_ref}:TODO.md")
+	main_todo=$(git --git-dir="$origin_dir" show main:TODO.md)
+	main_sha=$(git --git-dir="$origin_dir" rev-parse main)
+	sync_parent=$(git --git-dir="$origin_dir" rev-parse "${sync_ref}^")
+	branch_message=$(git --git-dir="$origin_dir" log -1 --pretty=%s "$sync_ref")
+	create_count=$(grep -c $'gh\tpr\tcreate' "$gh_log" || true)
+
+	if [[ "$remote_todo" != *"t9001 first event"* || \
+		"$remote_todo" != *"t9002 second event"* || \
+		"$remote_todo" != *"t9003 reviewed main edit"* ]]; then
+		fail "protected PR preserves concurrent and unrelated TODO edits"
+	elif [[ "$main_todo" == *"first event"* || "$main_todo" == *"second event"* ]]; then
+		fail "GH006 never mutates protected main directly"
+	elif [[ "$sync_parent" != "$main_sha" ]]; then
+		fail "stale deterministic PR branch rebases onto current main"
+	elif [[ "$create_count" -ne 1 ]]; then
+		fail "GH006 retries create exactly one PR"
+	elif [[ "$(<"$head_file")" != "aidevops/issue-sync-todo" ]]; then
+		fail "issue-sync PR uses deterministic branch identity"
+	elif [[ "$(<"$title_file")" != *"[skip ci]"* ]]; then
+		fail "issue-sync PR title preserves merge-loop prevention"
+	elif [[ "$(<"${title_file}.body")" != *"Ref #9001"* ]]; then
+		fail "issue-sync PR body preserves changed-task linkage"
+	elif [[ "$branch_message" == *"[skip ci]"* ]]; then
+		fail "issue-sync PR branch still runs required checks"
+	elif [[ "$(git -C "$work_a" status --short)" != *"TODO.md"* || \
+		"$(git -C "$work_b" status --short)" != *"TODO.md"* ]]; then
+		fail "PR fallback preserves each caller's local TODO projection"
+	else
+		pass "GH006 converges through one rebased deterministic PR"
+	fi
+	return 0
+}
+
+test_non_gh006_failure_does_not_open_pr() {
+	local origin_dir="$TMP/terminal-origin.git"
+	local seed_dir="$TMP/terminal-seed"
+	local work_dir="$TMP/terminal-work"
+	local fake_bin="$TMP/terminal-bin"
+	local gh_log="$TMP/terminal-gh.log"
+	local output_file="$TMP/terminal-output.log"
+	create_origin "$origin_dir" "$seed_dir"
+	git clone "$origin_dir" "$work_dir" >/dev/null 2>&1
+	git_init_repo "$work_dir"
+	write_fake_gh "$fake_bin"
+	install_main_rejection_hook "$origin_dir" terminal
+	: >"$gh_log"
+	perl -0pi -e 's/t9001 original task/t9001 terminal event/' "$work_dir/TODO.md"
+	if run_issue_sync_helper "$work_dir" "$fake_bin" "$gh_log" "$TMP/terminal-pr.marker" \
+		"$TMP/terminal-head" "$TMP/terminal-title" "$output_file" 2; then
+		fail "non-GH006 terminal push failure remains terminal"
+	elif git --git-dir="$origin_dir" show-ref --verify --quiet refs/heads/aidevops/issue-sync-todo; then
+		fail "non-GH006 failure unexpectedly published a PR branch"
+	elif grep -q $'gh\tpr\tcreate' "$gh_log"; then
+		fail "non-GH006 failure unexpectedly opened a PR"
+	else
+		pass "non-GH006 terminal failure does not open a PR"
+	fi
+	return 0
+}
+
+test_deleted_pr_branch_retries_before_opening_pr() {
+	local origin_dir="$TMP/deleted-origin.git"
+	local seed_dir="$TMP/deleted-seed"
+	local work_dir="$TMP/deleted-work"
+	local fake_bin="$TMP/deleted-bin"
+	local gh_log="$TMP/deleted-gh.log"
+	local pr_marker="$TMP/deleted-pr.marker"
+	local output_file="$TMP/deleted-output.log"
+	local create_count=0
+	create_origin "$origin_dir" "$seed_dir"
+	git clone "$origin_dir" "$work_dir" >/dev/null 2>&1
+	git_init_repo "$work_dir"
+	write_fake_gh "$fake_bin"
+	install_main_rejection_hook "$origin_dir" gh006
+	install_one_time_sync_branch_delete_hook "$origin_dir"
+	: >"$gh_log"
+	perl -0pi -e 's/t9002 second task/t9002 deletion-race event/' "$work_dir/TODO.md"
+	if ! run_issue_sync_helper "$work_dir" "$fake_bin" "$gh_log" "$pr_marker" \
+		"$TMP/deleted-head" "$TMP/deleted-title" "$output_file" 3; then
+		fail "deleted issue-sync PR branch is rebuilt"
+		return 0
+	fi
+	create_count=$(grep -c $'gh\tpr\tcreate' "$gh_log" || true)
+	if ! git --git-dir="$origin_dir" show-ref --verify --quiet refs/heads/aidevops/issue-sync-todo; then
+		fail "deleted issue-sync PR branch is rebuilt"
+	elif [[ "$create_count" -ne 1 || ! -f "$pr_marker" ]]; then
+		fail "rebuilt issue-sync branch opens exactly one PR"
+	else
+		pass "deleted issue-sync PR branch is rebuilt before one PR opens"
+	fi
+	return 0
+}
+
+test_noop_publishes_nothing() {
+	local origin_dir="$TMP/noop-origin.git"
+	local seed_dir="$TMP/noop-seed"
+	local work_dir="$TMP/noop-work"
+	local fake_bin="$TMP/noop-bin"
+	local gh_log="$TMP/noop-gh.log"
+	local output_file="$TMP/noop-output.log"
+	local before=""
+	local after=""
+	create_origin "$origin_dir" "$seed_dir"
+	git clone "$origin_dir" "$work_dir" >/dev/null 2>&1
+	git_init_repo "$work_dir"
+	write_fake_gh "$fake_bin"
+	: >"$gh_log"
+	before=$(git --git-dir="$origin_dir" rev-parse main)
+	if ! run_issue_sync_helper "$work_dir" "$fake_bin" "$gh_log" "$TMP/noop-pr.marker" \
+		"$TMP/noop-head" "$TMP/noop-title" "$output_file" 2; then
+		fail "no-op TODO publication succeeds"
+		return 0
+	fi
+	after=$(git --git-dir="$origin_dir" rev-parse main)
+	if [[ "$before" != "$after" || -s "$gh_log" ]]; then
+		fail "no-op TODO publication creates no commit or PR"
+	else
+		pass "no-op TODO publication creates no commit or PR"
+	fi
+	return 0
+}
+
 test_successful_push
 test_rebase_conflict_neutralizes_cleanly
+test_protected_branch_uses_one_rebased_pr
+test_non_gh006_failure_does_not_open_pr
+test_deleted_pr_branch_retries_before_opening_pr
+test_noop_publishes_nothing
 
 printf 'Tests run: %s, failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
+++ b/.agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh
@@ -222,8 +222,8 @@ else
 fi
 
 # ============================================================
-# Test 6: task-backed proof publication uses the path-allowlisted planning
-# publisher rather than direct canonical index/commit mutation.
+# Test 6: task-backed proof publication uses the protected-branch-safe issue
+# sync publisher, while PLANS.md keeps the capability-scoped planner.
 # ============================================================
 PROOF_BODY=$(printf '%s\n' "${JOB_BODY}" | awk '
 	/name:[[:space:]]+Update TODO\.md proof-log/ { capture=1 }
@@ -237,15 +237,40 @@ PLANS_BODY=$(printf '%s\n' "${JOB_BODY}" | awk '
 ')
 # shellcheck disable=SC2016 # Assert the literal workflow variable reference.
 if printf '%s\n' "${JOB_BODY}" | grep -qE 'AIDEVOPS_PLANNING_GIT_BIN=.*RUNNER_GIT' &&
-	printf '%s\n' "${PROOF_BODY}" | grep -qE 'source[[:space:]]+"?\$SCRIPT_DIR/planning-publisher\.sh"?' &&
-	printf '%s\n' "${PROOF_BODY}" | grep -qE 'planning_publish[[:space:]]' &&
+	printf '%s\n' "${PROOF_BODY}" | grep -qE 'issue-sync-git-push-helper\.sh"?[[:space:]]+publish-todo[[:space:]]+main' &&
+	! printf '%s\n' "${PROOF_BODY}" | grep -qE 'planning_publish[[:space:]]' &&
 	! printf '%s\n' "${PROOF_BODY}" | grep -qE '^[[:space:]]+git[[:space:]]+(config|add|commit|pull|push)' &&
 	printf '%s\n' "${PLANS_BODY}" | grep -qE 'planning_publish[[:space:]]' &&
 	! printf '%s\n' "${PLANS_BODY}" | grep -qE '^[[:space:]]+git[[:space:]]+(config|add|commit|pull|push)'; then
-	check 1 "task proof and plan status use capability-scoped planning publication" ""
+	check 1 "task proof uses PR-safe publication and plan status uses capability-scoped publication" ""
 else
-	check 0 "task proof and plan status use capability-scoped planning publication" \
-		"both projections must use the captured runner Git capability through planning-publisher.sh"
+	check 0 "task proof uses PR-safe publication and plan status uses capability-scoped publication" \
+		"TODO proof must use issue-sync-git-push-helper.sh; PLANS must use planning-publisher.sh"
+fi
+
+# ============================================================
+# Test 7: every legacy issue-sync TODO writer routes through the same helper.
+# The deterministic helper owns GH006 detection and PR deduplication.
+# ============================================================
+PUBLISH_CALL_COUNT=$(grep -cE 'issue-sync-git-push-helper\.sh"?[[:space:]]+publish-todo[[:space:]]+main' "$WORKFLOW_FILE" || true)
+LEGACY_PUSH_COUNT=$(grep -cE 'issue-sync-git-push-helper\.sh[[:space:]]+push-todo[[:space:]]+main' "$WORKFLOW_FILE" || true)
+if [[ "$PUBLISH_CALL_COUNT" -eq 4 && "$LEGACY_PUSH_COUNT" -eq 0 ]]; then
+	check 1 "all four TODO publication paths share the idempotent PR-safe helper" ""
+else
+	check 0 "all four TODO publication paths share the idempotent PR-safe helper" \
+		"publish calls=${PUBLISH_CALL_COUNT}, legacy pushes=${LEGACY_PUSH_COUNT}"
+fi
+
+# ============================================================
+# Test 8: missing SYNC_PAT is informational because GH006 has a durable PR
+# fallback. The workflow must not advise weakening protection or PAT bypass.
+# ============================================================
+if grep -q 'GH006 will update one protected-branch PR' "$WORKFLOW_FILE" &&
+	! grep -qE 'gh secret set SYNC_PAT|will be rejected by branch protection|bypass(es)? branch protection' "$WORKFLOW_FILE"; then
+	check 1 "credential notices describe PR fallback without bypass guidance" ""
+else
+	check 0 "credential notices describe PR fallback without bypass guidance" \
+		"stale protected-branch bypass guidance remains"
 fi
 
 # ============================================================

--- a/.agents/scripts/tests/test-issue-sync-pr-task-resolver.sh
+++ b/.agents/scripts/tests/test-issue-sync-pr-task-resolver.sh
@@ -7,7 +7,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESOLVER="${SCRIPT_DIR}/../issue-sync-pr-task-resolver.sh"
 WORKFLOW="${SCRIPT_DIR}/../../../.github/workflows/issue-sync-reusable.yml"
-MULTI_TASK_LOOP="for RESOLVED_TASK_ID in \$UPDATED_TASK_IDS"
+PROTECTED_PUBLISH_CALL='issue-sync-git-push-helper\.sh" publish-todo main 3'
+MULTI_TASK_PUBLICATION="chore: mark \\\$UPDATED_TASK_IDS complete (\\\$PROOF) \[skip ci\]"
 PAIR_MATCH="if [[ \"\${ISSUE_TASK_PAIR%%:*}\" == \"\$ISSUE_NUM\" ]]"
 MAPPED_TASK_REF="TASK_REF=\" Task \$MAPPED_TASK_ID\""
 TMP_DIR=$(mktemp -d)
@@ -95,12 +96,13 @@ else
 	FAIL=$((FAIL + 1))
 fi
 
-if grep -Fq "$MULTI_TASK_LOOP" "$WORKFLOW" &&
-	grep -q 'WORKAROUND_COMMANDS' "$WORKFLOW"; then
-	printf 'PASS: push failure emits workaround for every updated task\n'
+if grep -q "$PROTECTED_PUBLISH_CALL" "$WORKFLOW" &&
+	grep -q "$MULTI_TASK_PUBLICATION" "$WORKFLOW" &&
+	! grep -q 'WORKAROUND_COMMANDS' "$WORKFLOW"; then
+	printf 'PASS: multi-task proof publication uses the cumulative PR-safe helper\n'
 	PASS=$((PASS + 1))
 else
-	printf 'FAIL: multi-task push failure workaround is incomplete\n'
+	printf 'FAIL: multi-task proof publication bypasses the cumulative PR-safe helper\n'
 	FAIL=$((FAIL + 1))
 fi
 

--- a/.agents/scripts/tests/test-issue-sync-ref-comments.sh
+++ b/.agents/scripts/tests/test-issue-sync-ref-comments.sh
@@ -23,33 +23,33 @@ cat >"$todo_file" <<'EOF'
 # TODO
 
 <!-- Format example:
-- [ ] t003 Completed task example logged:2025-01-10
+- [ ] t3 Completed task example logged:2025-01-10
 -->
 
-- [ ] t003 Real task logged:2026-06-28
-- [ ] t004 Child task blocked-by:t003 logged:2026-06-28
+- [ ] t3 Real task logged:2026-06-28
+- [ ] t4 Child task blocked-by:t3 logged:2026-06-28
 EOF
 
-add_gh_ref_to_todo "t003" "3" "$todo_file"
+add_gh_ref_to_todo "t3" "3" "$todo_file"
 
 if grep -q 'Completed task example.*ref:GH#3' "$todo_file"; then
 	printf 'FAIL ref was added inside HTML comment example\n' >&2
 	exit 1
 fi
 
-if ! grep -q '^- \[ \] t003 Real task ref:GH#3 logged:2026-06-28' "$todo_file"; then
+if ! grep -q '^- \[ \] t3 Real task ref:GH#3 logged:2026-06-28' "$todo_file"; then
 	printf 'FAIL ref was not added to the real task line\n' >&2
 	exit 1
 fi
 
-fix_gh_ref_in_todo "t003" "3" "30" "$todo_file"
+fix_gh_ref_in_todo "t3" "3" "30" "$todo_file"
 
 if grep -q 'Completed task example.*ref:GH#30' "$todo_file"; then
 	printf 'FAIL ref fix touched HTML comment example\n' >&2
 	exit 1
 fi
 
-if ! grep -q '^- \[ \] t003 Real task ref:GH#30 logged:2026-06-28' "$todo_file"; then
+if ! grep -q '^- \[ \] t3 Real task ref:GH#30 logged:2026-06-28' "$todo_file"; then
 	printf 'FAIL ref fix did not update the real task line\n' >&2
 	exit 1
 fi

--- a/.agents/scripts/tests/test-planning-publisher.sh
+++ b/.agents/scripts/tests/test-planning-publisher.sh
@@ -67,6 +67,21 @@ run_publish() {
 	return $?
 }
 
+run_publish_with_parent() {
+	local repo="$1"
+	local branch="$2"
+	local parent_branch="$3"
+	(
+		SCRIPT_DIR="$(dirname "$PUBLISHER")"
+		# shellcheck source=../planning-publisher.sh
+		source "$PUBLISHER"
+		AIDEVOPS_PLANNING_PARENT_BRANCH="$parent_branch" \
+			AIDEVOPS_PLANNING_VALIDATOR=/usr/bin/true \
+			planning_publish "$repo" "plan: parented publication" origin "$branch" TODO.md
+	)
+	return $?
+}
+
 run_publish_with_receipt() {
 	local repo="$1"
 	local receipt_dir="$2"
@@ -762,6 +777,61 @@ HOOK
 	return 0
 }
 
+test_parent_branch_replay_is_idempotent() {
+	local name="keeps a current parented publication stable and rebases it after parent advancement"
+	local root="" repo="" branch="plan/parented" before="" after=""
+	local first_sha="" replay_sha="" rebased_sha="" main_sha="" parent_sha="" count=""
+	local rival=""
+	root=$(mktemp -d) || return 0
+	setup_repo "$root" || {
+		fail "$name" setup
+		return 0
+	}
+	repo="${root}/work"
+	printf '%s\n' '- [ ] t010 parented publication ref:GH#10' >>"${repo}/TODO.md"
+	before=$(state_digest "$repo")
+	run_publish_with_parent "$repo" "$branch" main || {
+		fail "$name" publish
+		rm -rf "$root"
+		return 0
+	}
+	first_sha=$(git --git-dir="${root}/remote.git" rev-parse "$branch")
+	sleep 1
+	run_publish_with_parent "$repo" "$branch" main || {
+		fail "$name" replay
+		rm -rf "$root"
+		return 0
+	}
+	replay_sha=$(git --git-dir="${root}/remote.git" rev-parse "$branch")
+	rival="${root}/rival"
+	git clone -q "${root}/remote.git" "$rival" || return 0
+	printf 'advanced parent\n' >>"${rival}/README.md"
+	git -C "$rival" add README.md
+	GIT_AUTHOR_NAME=Rival GIT_AUTHOR_EMAIL=rival@example.invalid GIT_COMMITTER_NAME=Rival GIT_COMMITTER_EMAIL=rival@example.invalid \
+		git -C "$rival" -c commit.gpgsign=false commit -qm 'advance parent'
+	git -C "$rival" push -q origin main
+	run_publish_with_parent "$repo" "$branch" main || {
+		fail "$name" rebase
+		rm -rf "$root"
+		return 0
+	}
+	after=$(state_digest "$repo")
+	rebased_sha=$(git --git-dir="${root}/remote.git" rev-parse "$branch")
+	main_sha=$(git --git-dir="${root}/remote.git" rev-parse main)
+	parent_sha=$(git --git-dir="${root}/remote.git" rev-parse "${branch}^")
+	count=$(git --git-dir="${root}/remote.git" log --format=%B "$branch" | grep -c 'Planning-Publication-ID:' || true)
+	if [[ "$before" == "$after" && "$first_sha" == "$replay_sha" && "$rebased_sha" != "$replay_sha" && \
+		"$parent_sha" == "$main_sha" && "$count" -eq 1 ]] &&
+		git --git-dir="${root}/remote.git" show "${branch}:TODO.md" | grep -q t010 &&
+		git --git-dir="${root}/remote.git" show "${branch}:README.md" | grep -q 'advanced parent'; then
+		pass "$name"
+	else
+		fail "$name" "parented publication invariant failed"
+	fi
+	rm -rf "$root"
+	return 0
+}
+
 test_explicit_git_capability_preserves_guarded_checkout() {
 	local name="explicit Git capability publishes planning paths while canonical guard remains active"
 	local root="" repo="" shim_dir="" before="" after="" guard_rc=0 guard_output="" count="" real_git="" real_true=""
@@ -845,6 +915,7 @@ main() {
 	test_stale_base_same_path_is_retryable
 	test_absent_remote_branch_uses_safe_parent
 	test_absent_remote_branch_creation_contention
+	test_parent_branch_replay_is_idempotent
 	test_explicit_git_capability_preserves_guarded_checkout
 	printf '%s passed, %s failed\n' "$PASS" "$FAIL"
 	[[ $FAIL -eq 0 ]] || return 1

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -53,7 +53,7 @@ on:
         description: 'Optional token with read access to a private configured helper repository'
       SYNC_PAT:
         required: false
-        description: 'Fine-grained PAT with Contents:read/write, bypasses branch protection on TODO.md push'
+        description: 'Optional fine-grained PAT with Contents:read/write for direct TODO.md publication; protected branches fall back to a PR'
 
 jobs:
   forge-event:
@@ -173,6 +173,7 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write
 
     steps:
       - name: Check commit author
@@ -190,23 +191,19 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # t2166: emit a visible warning when SYNC_PAT is unset so operators
-      # see on every run — not just after GH006 — that TODO.md push will
-      # fall back to GITHUB_TOKEN and be rejected by branch protection.
+      # Keep the active credential path visible. GH#29679 routes a terminal
+      # GH006 through one deterministic PR, so no bypass setting is required.
       # GH#20976: SYNC_PAT can also appear empty if the caller uses
       # `secrets: inherit` against a cross-account reusable workflow.
       - name: Check SYNC_PAT visibility (t2166)
         if: steps.check-author.outputs.skip != 'true'
         env:
           SYNC_PAT_PRESENT: ${{ secrets.SYNC_PAT != '' && 'true' || '' }}
-          REPO: ${{ github.repository }}
         run: |
           if [[ -z "${SYNC_PAT_PRESENT:-}" ]]; then
-            echo "::warning::SYNC_PAT not present in this run — TODO.md push will be rejected by branch protection (GH006)."
-            echo "::warning::Cause A (secret not set): gh secret set SYNC_PAT --repo ${REPO} --body '<FINE_GRAINED_PAT>' (Contents: Read and write)"
-            echo "::warning::Cause B (cross-account caller): your caller uses 'secrets: inherit' which fails cross-account — run: aidevops sync-workflows --apply (see GH#20976)"
+            echo "::notice::SYNC_PAT not present — direct TODO.md publication uses GITHUB_TOKEN; GH006 will update one protected-branch PR."
           else
-            echo "::notice::SYNC_PAT present — TODO.md push will use PAT (bypasses branch protection via enforce_admins:false)"
+            echo "::notice::SYNC_PAT present — direct TODO.md publication will use PAT; GH006 still routes through a PR."
           fi
 
       - name: Checkout
@@ -214,10 +211,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
-          # t2166: prefer SYNC_PAT so `git push` of TODO.md updates bypasses
-          # branch protection via enforce_admins:false. Falls back to
-          # GITHUB_TOKEN when unset — push will still hit GH006, but the
-          # t2166 warning step above flags the cause.
+          # Prefer SYNC_PAT for direct contents publication. Branch protection
+          # remains authoritative; GH006 is handled through a PR.
           token: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Checkout aidevops framework scripts
@@ -306,15 +301,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
 
-      - name: Commit and push TODO.md updates
+      - name: Publish TODO.md updates
         if: steps.check-author.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if git diff --quiet TODO.md 2>/dev/null; then
-            echo "No TODO.md changes to commit"
+            echo "No TODO.md changes to publish"
           else
-            git add TODO.md
-            git commit -m "chore: sync GitHub issue refs to TODO.md [skip ci]"
-            bash __aidevops/.agents/scripts/issue-sync-git-push-helper.sh push-todo main 3
+            bash __aidevops/.agents/scripts/issue-sync-git-push-helper.sh publish-todo main 3 \
+              "chore: sync GitHub issue refs to TODO.md [skip ci]"
           fi
 
       - name: Show sync status
@@ -341,6 +337,7 @@ jobs:
     permissions:
       contents: write
       issues: read
+      pull-requests: write
 
     steps:
       - name: Check issue title format
@@ -361,23 +358,19 @@ jobs:
             echo "Issue #$ISSUE_NUMBER does not have t-number prefix, skipping"
           fi
 
-      # t2166: SYNC_PAT visibility — this job also pushes TODO.md updates
-      # on every issue-opened/closed event, so it hits the same GH006 when
-      # SYNC_PAT is unset. Warn explicitly before doing any work.
+      # This job also publishes TODO.md updates on issue events. GH#29679
+      # makes a protected-branch GH006 an idempotent PR publication.
       # GH#20976: SYNC_PAT can also appear empty if the caller uses
       # `secrets: inherit` against a cross-account reusable workflow.
       - name: Check SYNC_PAT visibility (t2166)
         if: steps.check-issue.outputs.sync == 'true'
         env:
           SYNC_PAT_PRESENT: ${{ secrets.SYNC_PAT != '' && 'true' || '' }}
-          REPO: ${{ github.repository }}
         run: |
           if [[ -z "${SYNC_PAT_PRESENT:-}" ]]; then
-            echo "::warning::SYNC_PAT not present in this run — TODO.md push will be rejected by branch protection (GH006)."
-            echo "::warning::Cause A (secret not set): gh secret set SYNC_PAT --repo ${REPO} --body '<FINE_GRAINED_PAT>' (Contents: Read and write)"
-            echo "::warning::Cause B (cross-account caller): your caller uses 'secrets: inherit' which fails cross-account — run: aidevops sync-workflows --apply (see GH#20976)"
+            echo "::notice::SYNC_PAT not present — direct TODO.md publication uses GITHUB_TOKEN; GH006 will update one protected-branch PR."
           else
-            echo "::notice::SYNC_PAT present — TODO.md push will use PAT"
+            echo "::notice::SYNC_PAT present — direct TODO.md publication will use PAT; GH006 still routes through a PR."
           fi
 
       - name: Checkout
@@ -385,7 +378,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
-          # t2166: prefer SYNC_PAT to bypass branch protection on push.
+          # Prefer SYNC_PAT for direct contents publication; do not bypass
+          # protected-branch PR requirements.
           token: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Checkout aidevops framework scripts
@@ -415,17 +409,17 @@ jobs:
           echo "=== New issue opened: ${TASK_ID} (#${ISSUE_NUMBER}) ==="
           bash __aidevops/.agents/scripts/issue-sync-helper.sh pull --verbose || true
 
-      - name: Commit and push TODO.md updates
+      - name: Publish TODO.md updates
         if: steps.check-issue.outputs.sync == 'true'
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           if git diff --quiet TODO.md 2>/dev/null; then
-            echo "No TODO.md changes to commit"
+            echo "No TODO.md changes to publish"
           else
-            git add TODO.md
-            git commit -m "chore: sync ref:GH#${ISSUE_NUMBER} to TODO.md [skip ci]"
-            bash __aidevops/.agents/scripts/issue-sync-git-push-helper.sh push-todo main 3
+            bash __aidevops/.agents/scripts/issue-sync-git-push-helper.sh publish-todo main 3 \
+              "chore: sync ref:GH#${ISSUE_NUMBER} to TODO.md [skip ci]"
           fi
 
   # =========================================================================
@@ -647,6 +641,7 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write
 
     steps:
       # t2166: SYNC_PAT visibility for manual dispatch runs too.
@@ -655,21 +650,19 @@ jobs:
       - name: Check SYNC_PAT visibility (t2166)
         env:
           SYNC_PAT_PRESENT: ${{ secrets.SYNC_PAT != '' && 'true' || '' }}
-          REPO: ${{ github.repository }}
         run: |
           if [[ -z "${SYNC_PAT_PRESENT:-}" ]]; then
-            echo "::warning::SYNC_PAT not present in this run — any TODO.md push from this manual run will be rejected by branch protection (GH006)."
-            echo "::warning::Cause A (secret not set): gh secret set SYNC_PAT --repo ${REPO} --body '<FINE_GRAINED_PAT>' (Contents: Read and write)"
-            echo "::warning::Cause B (cross-account caller): your caller uses 'secrets: inherit' which fails cross-account — run: aidevops sync-workflows --apply (see GH#20976)"
+            echo "::notice::SYNC_PAT not present — direct TODO.md publication uses GITHUB_TOKEN; GH006 will update one protected-branch PR."
           else
-            echo "::notice::SYNC_PAT present — TODO.md push will use PAT"
+            echo "::notice::SYNC_PAT present — direct TODO.md publication will use PAT; GH006 still routes through a PR."
           fi
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
-          # t2166: prefer SYNC_PAT to bypass branch protection on push.
+          # Prefer SYNC_PAT for direct contents publication; protected branch
+          # requirements still route through the deterministic PR fallback.
           token: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Checkout aidevops framework scripts
@@ -696,17 +689,17 @@ jobs:
           echo "=== Running: issue-sync-helper.sh $SYNC_COMMAND ==="
           bash __aidevops/.agents/scripts/issue-sync-helper.sh "$SYNC_COMMAND" --verbose
 
-      - name: Commit and push TODO.md updates
+      - name: Publish TODO.md updates
         if: inputs.command == 'pull' || inputs.command == 'push'
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SYNC_COMMAND: ${{ inputs.command }}
         run: |
           if git diff --quiet TODO.md 2>/dev/null; then
-            echo "No TODO.md changes to commit"
+            echo "No TODO.md changes to publish"
           else
-            git add TODO.md
-            git commit -m "chore: manual issue sync ($SYNC_COMMAND) [skip ci]"
-            bash __aidevops/.agents/scripts/issue-sync-git-push-helper.sh push-todo main 3
+            bash __aidevops/.agents/scripts/issue-sync-git-push-helper.sh publish-todo main 3 \
+              "chore: manual issue sync ($SYNC_COMMAND) [skip ci]"
           fi
 
   # =========================================================================
@@ -748,14 +741,11 @@ jobs:
       - name: Check SYNC_PAT visibility (t2166)
         env:
           SYNC_PAT_PRESENT: ${{ secrets.SYNC_PAT != '' && 'true' || '' }}
-          REPO: ${{ github.repository }}
         run: |
           if [[ -z "${SYNC_PAT_PRESENT:-}" ]]; then
-            echo "::warning::SYNC_PAT not present in this run — TODO.md auto-sync push will be rejected by branch protection (GH006)."
-            echo "::warning::Cause A (secret not set): gh secret set SYNC_PAT --repo ${REPO} --body '<FINE_GRAINED_PAT>' (Contents: Read and write)"
-            echo "::warning::Cause B (cross-account caller): your caller uses 'secrets: inherit' which fails cross-account — run: aidevops sync-workflows --apply (see GH#20976)"
+            echo "::notice::SYNC_PAT not present — direct TODO.md publication uses GITHUB_TOKEN; GH006 will update one protected-branch PR."
           else
-            echo "::notice::SYNC_PAT present — TODO.md push will use PAT"
+            echo "::notice::SYNC_PAT present — direct TODO.md publication will use PAT; GH006 still routes through a PR."
           fi
 
       # t3204: pull the framework scripts up front so the closing-hygiene and
@@ -1229,18 +1219,10 @@ jobs:
           # TODO auto-complete entirely, even if the body contains closing
           # keywords. See the guard at the top of the run block.
           RANGE_SYNTAX: ${{ steps.extract.outputs.range_syntax }}
-          # t2034: gh CLI needs GH_TOKEN explicitly — without it, the t2029
-          # `gh pr comment` fallback (posted when the TODO.md push is rejected
-          # by branch protection) silently fails because gh has no auth.
-          # Verified observation: t2029's own merge run hit the t2029 fallback
-          # branch correctly but the comment never landed because gh ran
-          # without GH_TOKEN and printed nothing visible (gh's silent failure
-          # mode on missing auth).
-          # t2048: prefer SYNC_PAT for the push so branch protection bypass
-          # works via enforce_admins:false. Still falls back to GITHUB_TOKEN
-          # for the gh CLI call even when SYNC_PAT is unset — the PR comment
-          # is always useful to post regardless of which token did the push.
-          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+          # Git retains the checkout credential for direct contents pushes.
+          # GitHub API writes use the job-scoped pull-requests permission so a
+          # contents-only SYNC_PAT does not need broader scope.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # t2048: expose secret presence as a boolean-ish env var. GitHub
           # hides secret values from logs, but ${{ secrets.SYNC_PAT != '' }}
           # evaluates to 'true' or 'false' at workflow-compile time and is
@@ -1281,15 +1263,13 @@ jobs:
             exit 0
           fi
 
-          # t2048: log which credential path is active so operators can tell
-          # at a glance whether the PAT is wired up. t2166 promoted the
-          # unset-secret log from ::notice:: to ::warning:: so the missing
-          # secret surfaces in the GH Actions run summary, not just the
-          # step output.
+          # Keep the active Git credential path visible. GitHub API writes use
+          # the job-scoped GITHUB_TOKEN in both cases; direct Git publication
+          # may use SYNC_PAT, while GH006 always routes through a PR.
           if [[ -n "${SYNC_PAT_PRESENT:-}" ]]; then
-            echo "::notice::Using SYNC_PAT for push (t2048 path)"
+            echo "::notice::Using SYNC_PAT for direct TODO.md publication; GH006 will update one protected-branch PR."
           else
-            echo "::warning::SYNC_PAT not set — falling back to GITHUB_TOKEN, which will be rejected by branch protection (GH006). Fix: gh secret set SYNC_PAT --repo ${GITHUB_REPOSITORY:-REPO} --body \"<FINE_GRAINED_PAT>\" (Contents: Read and write)"
+            echo "::notice::SYNC_PAT not present — direct TODO.md publication uses GITHUB_TOKEN; GH006 will update one protected-branch PR."
           fi
 
           # GH#28464: use the same fail-closed completion predicate as direct
@@ -1345,77 +1325,10 @@ jobs:
             exit 0
           fi
 
-          # t2029: track success explicitly so a silent branch-protection
-          # rejection becomes a loud failure. Without this, GH006 rejections
-          # are hidden inside the retry loop and the workflow reports overall
-          # success even though TODO.md was never pushed — which is exactly
-          # how this workflow broke silently for ~3 weeks before t2029.
-          PUSH_SUCCEEDED=false
           SCRIPT_DIR="$GITHUB_WORKSPACE/__aidevops/.agents/scripts"
-          # shellcheck source=/dev/null
-          source "$SCRIPT_DIR/planning-publisher.sh"
-          if planning_publish \
-            "$GITHUB_WORKSPACE" \
-            "chore: mark $UPDATED_TASK_IDS complete ($PROOF) [skip ci]" \
-            origin main TODO.md; then
-            PUSH_SUCCEEDED=true
-          fi
-
-          if [[ "$PUSH_SUCCEEDED" != "true" ]]; then
-            # t2029: branch protection on personal-account repos cannot
-            # bypass required_pull_request_reviews for github-actions[bot]
-            # (HTTP 500 on the classic-protection PATCH bypass API,
-            # confirmed 2026-04-13). Make the failure loud and post a
-            # PR comment. See todo/tasks/t2029-brief.md + t2166-brief.md.
-            # t2166: the comment now leads with the root-cause fix
-            # (create SYNC_PAT) rather than the symptom workaround
-            # (task-complete-helper.sh), so maintainers can close the
-            # gap in 30s instead of papering over each merge.
-            echo "::error::Failed to push TODO.md update after 3 attempts — branch protection blocked token $([ -n "${SYNC_PAT_PRESENT:-}" ] && echo "SYNC_PAT" || echo "GITHUB_TOKEN fallback")"
-            echo "::error::Root cause fix: gh secret set SYNC_PAT --repo ${GITHUB_REPOSITORY} --body \"<PAT>\" (Contents: Read and write)"
-            echo "::error::Workaround: run task-complete-helper.sh for: $UPDATED_TASK_IDS (PR $PR_NUMBER)"
-
-            if [[ -n "${SYNC_PAT_PRESENT:-}" ]]; then
-              CAUSE_LINE="The \`SYNC_PAT\` secret is set, but the PAT lacks branch-protection bypass. Confirm the fine-grained PAT is scoped to \`${GITHUB_REPOSITORY}\` with \`Contents: Read and write\`, and that the repo admin has \`Do not allow bypassing the above settings\` disabled (classic protection) or added the PAT owner to the ruleset bypass list."
-              FIX_BLOCK="**Fix (maintainer):** verify the \`SYNC_PAT\` PAT scope and branch-protection bypass settings."
-            else
-              CAUSE_LINE="The \`SYNC_PAT\` repo secret is not set, so the workflow fell back to \`GITHUB_TOKEN\`. \`GITHUB_TOKEN\` cannot bypass \`required_approving_review_count\` on this repo's classic branch protection (\`bypass_pull_request_allowances\` is unsupported on personal-account plans — HTTP 500, confirmed 2026-04-13)."
-              FIX_BLOCK="**Root-cause fix (maintainer, ~30s):** create a fine-grained PAT with \`Contents: Read and write\` scoped to this repo, then run:
-
-          \`\`\`bash
-          gh secret set SYNC_PAT --repo ${GITHUB_REPOSITORY} --body \"<FINE_GRAINED_PAT>\"
-          \`\`\`
-
-          Next \`TODO.md\` push will use the PAT and complete the round-trip. Code path: \`sync-on-pr-merge\` + \`sync-on-push\` + \`sync-on-issue\` + \`manual-sync\` (t2048, t2166)."
-            fi
-
-            WORKAROUND_COMMANDS=""
-            for RESOLVED_TASK_ID in $UPDATED_TASK_IDS; do
-              WORKAROUND_COMMANDS="${WORKAROUND_COMMANDS}~/.aidevops/agents/scripts/task-complete-helper.sh ${RESOLVED_TASK_ID} --pr ${PR_NUMBER} --testing-level self-assessed
-          "
-            done
-
-            COMMENT_BODY="### TODO.md auto-completion blocked
-
-          The \`sync-on-pr-merge\` workflow tried to mark tasks \`$UPDATED_TASK_IDS\` complete in \`TODO.md\` with proof-log \`$PROOF\`, but the push was rejected by branch protection (GH006).
-
-          **Cause:** ${CAUSE_LINE}
-
-          ${FIX_BLOCK}
-
-          **Immediate workaround (until the secret is fixed):** run locally to complete the audit trail for this PR only:
-
-          \`\`\`bash
-          ${WORKAROUND_COMMANDS}
-          \`\`\`
-
-          Context: t2048 (PR #18677) landed the \`SYNC_PAT || GITHUB_TOKEN\` fallback code. t2166 extended it to \`sync-on-push\`/\`sync-on-issue\`/\`manual-sync\` and added visibility warnings. The operational secret still has to be created by the repo maintainer — this comment is that cue.
-
-          <!-- t2029:auto-complete-blocked -->"
-
-            gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY" 2>/dev/null || \
-              echo "::warning::Also failed to post PR comment — run the workaround command above and set SYNC_PAT"
-
+          if ! bash "$SCRIPT_DIR/issue-sync-git-push-helper.sh" publish-todo main 3 \
+            "chore: mark $UPDATED_TASK_IDS complete ($PROOF) [skip ci]"; then
+            echo "::error::TODO.md publication failed through both direct and protected-branch PR paths"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- Route all four legacy issue-sync `TODO.md` writers through `planning-publisher.sh`.
- On terminal GH006, rebase cumulative TODO state onto current `main` and update one deterministic PR branch.
- Preserve required checks by keeping `[skip ci]` in the eventual squash title, not the PR branch commit.

## Files

- `.agents/scripts/issue-sync-git-push-helper.sh`
- `.agents/scripts/planning-publisher.sh`
- `.github/workflows/issue-sync-reusable.yml`
- Focused issue-sync regression tests

## Verification so far

- `test-issue-sync-git-push-helper.sh`
- `test-issue-sync-pr-merge-checkout-order.sh`
- `test-planning-publisher.sh`
- `linters-local.sh --changed`

Resolves #29679

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.231 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 32m and 310,968 tokens on this as a headless worker. Overall, 43m since this issue was created.
