### PR TITLE
GH#29688: Restore Qlty smell threshold after PR #29673

### DIFF
--- a/.agents/plugins/opencode-aidevops/observability-tool-calls.mjs
+++ b/.agents/plugins/opencode-aidevops/observability-tool-calls.mjs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import { summarizeToolMetadata } from "./observability-retention.mjs";
+import { sqlEscape } from "./observability-sqlite.mjs";
+import { toolOutcomeFailed } from "./session-continuation-guard.mjs";
+
+/** Return whether a tool result is safe to record as successful. */
+export function toolCallSucceeded(output) {
+  return !toolOutcomeFailed(output);
+}
+
+/**
+ * Build the INSERT SQL for a tool_calls row. Pure function — no DB access or
+ * global state — so it is exhaustively testable without sqlite3.
+ *
+ * Column order must stay aligned with the `tool_calls` CREATE TABLE in
+ * observability-init.mjs.
+ *
+ * @param {object} args
+ * @param {string} args.sessionID
+ * @param {string} args.callID
+ * @param {string} args.toolName
+ * @param {string | null | undefined} args.intent
+ * @param {0 | 1} args.isSuccess
+ * @param {number | null | undefined} args.durationMs - Elapsed ms, or null/undefined to store SQL NULL
+ * @param {object | null | undefined} args.metadata - Raw metadata object; summarized before persistence
+ * @returns {string} INSERT statement ready for sqliteExec
+ */
+export function buildToolCallInsertSql({ sessionID, callID, toolName, intent, isSuccess, durationMs, metadata }) {
+  const durationSql = (durationMs !== null && durationMs !== undefined)
+    ? String(durationMs)
+    : "NULL";
+  const metadataSummary = summarizeToolMetadata(metadata);
+  const metadataValue = metadataSummary === null ? null : JSON.stringify(metadataSummary);
+
+  return `INSERT INTO tool_calls (
+    session_id, call_id, tool_name, intent, success, duration_ms, metadata
+  ) VALUES (
+    ${sqlEscape(sessionID)},
+    ${sqlEscape(callID)},
+    ${sqlEscape(toolName)},
+    ${sqlEscape(intent || null)},
+    ${isSuccess},
+    ${durationSql},
+    ${sqlEscape(metadataValue)}
+  );`;
+}

--- a/.agents/plugins/opencode-aidevops/observability.mjs
+++ b/.agents/plugins/opencode-aidevops/observability.mjs
@@ -44,9 +44,11 @@ import {
 } from "./otel-enrichment.mjs";
 import {
   PartStreamSummaryTracker,
-  summarizeToolMetadata,
 } from "./observability-retention.mjs";
-import { toolOutcomeFailed } from "./session-continuation-guard.mjs";
+import {
+  buildToolCallInsertSql,
+  toolCallSucceeded,
+} from "./observability-tool-calls.mjs";
 import {
   consumeRoutingDecision,
   getRoutingFeedback,
@@ -67,6 +69,7 @@ const COST_BACKFILL_MARKER = `${DB_PATH}.cost-backfill-v1.done`;
 
 export { getPricing };
 export { getRoutingFeedback, recordRoutingDecision };
+export { buildToolCallInsertSql, toolCallSucceeded };
 
 /**
  * Initialise the observability database with WAL mode and schema.
@@ -436,47 +439,6 @@ ON CONFLICT(session_id) DO UPDATE SET
 }
 
 /**
- * Build the INSERT SQL for a tool_calls row. Pure function — no DB access,
- * no global state — so it is exhaustively testable without sqlite3.
- *
- * Column order must stay aligned with the `tool_calls` CREATE TABLE in
- * initDatabase(). If you add or reorder columns there, update this
- * builder and its test suite (test-observability-tool-calls.mjs) in the
- * same commit.
- *
- * @param {object} args
- * @param {string} args.sessionID
- * @param {string} args.callID
- * @param {string} args.toolName
- * @param {string | null | undefined} args.intent
- * @param {0 | 1} args.isSuccess
- * @param {number | null | undefined} args.durationMs - Elapsed ms, or null/undefined to store SQL NULL
- * @param {object | null | undefined} args.metadata - Raw metadata object; summarized before persistence
- * @returns {string} INSERT statement ready for sqliteExec
- */
-export function buildToolCallInsertSql({ sessionID, callID, toolName, intent, isSuccess, durationMs, metadata }) {
-  const durationSql = (durationMs !== null && durationMs !== undefined)
-    ? String(durationMs)
-    : "NULL";
-  // sqlEscape(null) returns the literal string "NULL" — we exploit that
-  // so the metadata column renders as SQL NULL when metadata is absent.
-  const metadataSummary = summarizeToolMetadata(metadata);
-  const metadataValue = metadataSummary === null ? null : JSON.stringify(metadataSummary);
-
-  return `INSERT INTO tool_calls (
-    session_id, call_id, tool_name, intent, success, duration_ms, metadata
-  ) VALUES (
-    ${sqlEscape(sessionID)},
-    ${sqlEscape(callID)},
-    ${sqlEscape(toolName)},
-    ${sqlEscape(intent || null)},
-    ${isSuccess},
-    ${durationSql},
-    ${sqlEscape(metadataValue)}
-  );`;
-}
-
-/**
  * Record a tool call from the tool.execute.after hook.
  * Increments the in-memory counter and writes to the tool_calls table.
  *
@@ -485,10 +447,6 @@ export function buildToolCallInsertSql({ sessionID, callID, toolName, intent, is
  * @param {string | undefined} intent - LLM-provided intent string (from agent__intent field)
  * @param {number | null | undefined} [durationMs] - Elapsed milliseconds from tool.execute.before (t2184)
  */
-export function toolCallSucceeded(output) {
-  return !toolOutcomeFailed(output);
-}
-
 export function recordToolCall(input, output, intent, durationMs) {
   if (!dbReady) return;
 

--- a/.agents/plugins/opencode-aidevops/tests/test-observability-tool-calls.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-observability-tool-calls.mjs
@@ -137,7 +137,7 @@ describe("buildToolCallInsertSql — column/value alignment", () => {
       metadata: { filePath: "/tmp/x" },
     });
     const cols = extractColumns(sql);
-    // Order must match the CREATE TABLE in observability.mjs:initDatabase.
+    // Order must match the CREATE TABLE in observability-init.mjs.
     // Any drift breaks SQLite positional binding in the live path.
     assert.deepEqual(cols, [
       "session_id",


### PR DESCRIPTION
## Summary

- Extract tool-call SQL construction and outcome classification from the oversized observability facade.
- Preserve the existing public exports and runtime persistence path.
- Restore the authoritative Qlty ratchet from 50 findings on main to 49 on this head without changing the threshold or Qlty configuration.

## Provenance

PR #29673 merged with `Qlty Smell Threshold` failing at 50 > 49. Issue #29688 records the reproducible main regression and the constrained recovery contract.

## Changes

- Add `.agents/plugins/opencode-aidevops/observability-tool-calls.mjs` for the two extracted helpers.
- Keep `.agents/plugins/opencode-aidevops/observability.mjs` as the compatibility facade and unchanged runtime caller.
- Correct the existing test comment to point to `observability-init.mjs` as the schema authority.

## Verification

- `node --test .agents/plugins/opencode-aidevops/tests/test-observability-tool-calls.mjs` — 18/18 pass.
- `node --test ".agents/plugins/opencode-aidevops/tests/*.mjs"` — 595/595 pass.
- `.agents/scripts/linters-local.sh` — all changed-file checks pass.
- Qlty smell threshold — 49/49.
- Qlty regression — base 50, head 49, delta -1.
- Qlty new-file gate — 1 eligible file, 0 smells.
- `git diff --check origin/main...HEAD` — clean.

## Risk and Compatibility

- No database schema, migration, SQL output, public import, threshold, or Qlty configuration change.
- No release or deployment is included or authorized.
- Rollback is a normal revert of the single extraction commit.

Resolves #29688
Ref #29673

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.232 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1d 3h and 11,633,161 tokens on this with the user in an interactive session.