### PR TITLE
GH#29679: Fix issue-sync publication under runner Git guard

### DIFF
--- a/.agents/scripts/issue-sync-git-push-helper.sh
+++ b/.agents/scripts/issue-sync-git-push-helper.sh
@@ -20,6 +20,11 @@ ISSUE_SYNC_LAST_PUBLISH_OUTPUT=""
 ISSUE_SYNC_BASE_SHA=""
 ISSUE_SYNC_SOURCE_BASE_SHA=""
 
+issue_sync_git() {
+	_planning_git "$@"
+	return $?
+}
+
 issue_sync_repo_slug() {
 	local repo_path="$1"
 	local remote_url=""
@@ -28,7 +33,7 @@ issue_sync_repo_slug() {
 		printf '%s\n' "$slug"
 		return 0
 	fi
-	remote_url=$(git -C "$repo_path" remote get-url origin 2>/dev/null) || return 1
+	remote_url=$(issue_sync_git -C "$repo_path" remote get-url origin 2>/dev/null) || return 1
 	case "$remote_url" in
 	git@github.com:*) slug="${remote_url#git@github.com:}" ;;
 	ssh://git@github.com/*) slug="${remote_url#ssh://git@github.com/}" ;;
@@ -63,7 +68,7 @@ issue_sync_changed_reference_numbers() {
 	local commit_msg="$3"
 	local diff_output=""
 	local diff_rc=0
-	diff_output=$(git diff --no-index --unified=0 -- "$base_file" "$candidate_file" 2>/dev/null) || diff_rc=$?
+	diff_output=$(issue_sync_git diff --no-index --unified=0 -- "$base_file" "$candidate_file" 2>/dev/null) || diff_rc=$?
 	if [[ "$diff_rc" -ne 0 && "$diff_rc" -ne 1 ]]; then
 		return 1
 	fi
@@ -149,7 +154,7 @@ issue_sync_merge_todo_file() {
 	local ancestor_file="$2"
 	local incoming_file="$3"
 	local rc=0
-	git merge-file --ours "$current_file" "$ancestor_file" "$incoming_file" >/dev/null 2>&1 || rc=$?
+	issue_sync_git merge-file --ours "$current_file" "$ancestor_file" "$incoming_file" >/dev/null 2>&1 || rc=$?
 	if [[ "$rc" -ne 0 ]]; then
 		echo "::error::Unable to merge concurrent TODO.md projections safely"
 		return 1
@@ -161,7 +166,7 @@ issue_sync_read_todo_blob() {
 	local repo_path="$1"
 	local commit_sha="$2"
 	local destination="$3"
-	git -C "$repo_path" show "${commit_sha}:TODO.md" >"$destination" 2>/dev/null
+	issue_sync_git -C "$repo_path" show "${commit_sha}:TODO.md" >"$destination" 2>/dev/null
 	return $?
 }
 
@@ -175,10 +180,10 @@ issue_sync_prepare_base_snapshot() {
 	local latest_todo="${state_dir}/latest-base-todo"
 	local source_head=""
 
-	git -C "$repo_path" fetch -q origin "$default_branch" || return 1
-	ISSUE_SYNC_BASE_SHA=$(git -C "$repo_path" rev-parse FETCH_HEAD) || return 1
-	source_head=$(git -C "$repo_path" rev-parse "HEAD^{commit}") || return 1
-	ISSUE_SYNC_SOURCE_BASE_SHA=$(git -C "$repo_path" merge-base "$source_head" "$ISSUE_SYNC_BASE_SHA") || return 1
+	issue_sync_git -C "$repo_path" fetch -q origin "$default_branch" || return 1
+	ISSUE_SYNC_BASE_SHA=$(issue_sync_git -C "$repo_path" rev-parse FETCH_HEAD) || return 1
+	source_head=$(issue_sync_git -C "$repo_path" rev-parse "HEAD^{commit}") || return 1
+	ISSUE_SYNC_SOURCE_BASE_SHA=$(issue_sync_git -C "$repo_path" merge-base "$source_head" "$ISSUE_SYNC_BASE_SHA") || return 1
 	cp -p "$source_file" "$merged_file" || return 1
 	issue_sync_read_todo_blob "$repo_path" "$ISSUE_SYNC_SOURCE_BASE_SHA" "$source_ancestor" || return 1
 	issue_sync_read_todo_blob "$repo_path" "$ISSUE_SYNC_BASE_SHA" "$latest_todo" || return 1
@@ -192,7 +197,7 @@ issue_sync_remote_branch_sha() {
 	local remote_line=""
 	local remote_sha=""
 	local remote_ref=""
-	remote_line=$(git -C "$repo_path" ls-remote --heads origin "refs/heads/${branch_name}") || return 1
+	remote_line=$(issue_sync_git -C "$repo_path" ls-remote --heads origin "refs/heads/${branch_name}") || return 1
 	[[ -n "$remote_line" && "$remote_line" != *$'\n'* ]] || return 2
 	IFS=$'\t' read -r remote_sha remote_ref <<<"$remote_line"
 	[[ "$remote_sha" =~ ^[0-9a-fA-F]{40,64}$ && "$remote_ref" == "refs/heads/${branch_name}" ]] || return 1
@@ -217,9 +222,9 @@ issue_sync_prepare_pr_snapshot() {
 		return 0
 	fi
 	[[ "$branch_rc" -eq 0 ]] || return 1
-	git -C "$repo_path" fetch -q origin "$ISSUE_SYNC_PR_BRANCH" || return 1
-	sync_sha=$(git -C "$repo_path" rev-parse FETCH_HEAD) || return 1
-	sync_base=$(git -C "$repo_path" merge-base "$ISSUE_SYNC_BASE_SHA" "$sync_sha") || return 1
+	issue_sync_git -C "$repo_path" fetch -q origin "$ISSUE_SYNC_PR_BRANCH" || return 1
+	sync_sha=$(issue_sync_git -C "$repo_path" rev-parse FETCH_HEAD) || return 1
+	sync_base=$(issue_sync_git -C "$repo_path" merge-base "$ISSUE_SYNC_BASE_SHA" "$sync_sha") || return 1
 	issue_sync_read_todo_blob "$repo_path" "$sync_base" "$sync_ancestor" || return 1
 	issue_sync_read_todo_blob "$repo_path" "$sync_sha" "$sync_todo" || return 1
 	issue_sync_merge_todo_file "${state_dir}/merged-todo" "$sync_ancestor" "$sync_todo" || return 1
@@ -370,7 +375,7 @@ issue_sync_publish_todo() {
 		echo "::error::Publication attempts must be a positive integer"
 		return 2
 	}
-	repo_path=$(git rev-parse --show-toplevel) || return 1
+	repo_path=$(issue_sync_git rev-parse --show-toplevel) || return 1
 	[[ -f "${repo_path}/TODO.md" && ! -L "${repo_path}/TODO.md" ]] || {
 		echo "::error::TODO.md must be a regular file"
 		return 1
@@ -451,7 +456,7 @@ main() {
 		return $?
 		;;
 	push-todo)
-		commit_msg=$(git log -1 --pretty=%s 2>/dev/null) || commit_msg="$ISSUE_SYNC_DEFAULT_COMMIT_MESSAGE"
+		commit_msg=$(issue_sync_git log -1 --pretty=%s 2>/dev/null) || commit_msg="$ISSUE_SYNC_DEFAULT_COMMIT_MESSAGE"
 		issue_sync_publish_todo "$branch" "$attempts" "$commit_msg"
 		return $?
 		;;

--- a/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
+++ b/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
@@ -206,6 +206,22 @@ GH
 	return 0
 }
 
+write_rejecting_git_shim() {
+	local fake_bin="$1"
+	local guard_log="$2"
+	mkdir -p "$fake_bin"
+	cat >"${fake_bin}/git" <<'GIT'
+#!/usr/bin/env bash
+printf 'blocked git invocation:' >>"${GIT_GUARD_LOG:?}"
+printf ' %q' "$@" >>"${GIT_GUARD_LOG:?}"
+printf '\n' >>"${GIT_GUARD_LOG:?}"
+exit 97
+GIT
+	chmod +x "${fake_bin}/git"
+	: >"$guard_log"
+	return 0
+}
+
 install_main_rejection_hook() {
 	local origin_dir="$1"
 	local mode="$2"
@@ -258,6 +274,7 @@ run_issue_sync_helper() {
 	local primary_token="${9:-fixture-token}"
 	local fallback_token="${10:-}"
 	local reject_pr_token="${11:-}"
+	local trusted_git="${12:-}"
 	(
 		cd "$work_dir" || exit 1
 		PATH="${fake_bin}:$PATH" \
@@ -271,6 +288,8 @@ run_issue_sync_helper() {
 			GH_STUB_TITLE="$title_file" \
 			GH_STUB_BODY="${title_file}.body" \
 			GH_STUB_REJECT_PR_TOKEN="$reject_pr_token" \
+			GIT_GUARD_LOG="${output_file}.git-guard" \
+			AIDEVOPS_PLANNING_GIT_BIN="$trusted_git" \
 			bash "$HELPER" publish-todo main "$attempts" \
 			"chore: sync fixture issue refs to TODO.md [skip ci]" >"$output_file" 2>&1
 	)
@@ -461,6 +480,49 @@ test_actions_pr_creation_uses_pat_fallback() {
 	return 0
 }
 
+test_runner_git_guard_uses_trusted_git_binary() {
+	local origin_dir="$TMP/git-guard-origin.git"
+	local seed_dir="$TMP/git-guard-seed"
+	local work_dir="$TMP/git-guard-work"
+	local fake_bin="$TMP/git-guard-bin"
+	local gh_log="$TMP/git-guard-gh.log"
+	local pr_marker="$TMP/git-guard-pr.marker"
+	local output_file="$TMP/git-guard-output.log"
+	local guard_log="${output_file}.git-guard"
+	local trusted_git=""
+	trusted_git=$(command -v git) || {
+		fail "runner Git guard uses the trusted Git binary"
+		return 0
+	}
+	create_origin "$origin_dir" "$seed_dir"
+	git clone "$origin_dir" "$work_dir" >/dev/null 2>&1
+	git_init_repo "$work_dir"
+	write_fake_gh "$fake_bin"
+	write_rejecting_git_shim "$fake_bin" "$guard_log"
+	if PATH="${fake_bin}:$PATH" GIT_GUARD_LOG="$guard_log" git --version >/dev/null 2>&1; then
+		fail "runner Git guard fixture rejects PATH Git"
+		return 0
+	elif [[ ! -s "$guard_log" ]]; then
+		fail "runner Git guard fixture rejects PATH Git"
+		return 0
+	fi
+	: >"$guard_log"
+	install_main_rejection_hook "$origin_dir" gh006
+	: >"$gh_log"
+	perl -0pi -e 's/t9001 original task/t9001 guarded runner event/' "$work_dir/TODO.md"
+	if ! run_issue_sync_helper "$work_dir" "$fake_bin" "$gh_log" "$pr_marker" \
+		"$TMP/git-guard-head" "$TMP/git-guard-title" "$output_file" 3 \
+		"fixture-token" "" "" "$trusted_git"; then
+		printf 'Guarded publication output:\n%s\n' "$(<"$output_file")" >&2
+		fail "runner Git guard uses the trusted Git binary"
+	elif ! git --git-dir="$origin_dir" show-ref --verify --quiet refs/heads/aidevops/issue-sync-todo; then
+		fail "runner Git guard uses the trusted Git binary"
+	else
+		pass "runner Git guard uses the trusted Git binary"
+	fi
+	return 0
+}
+
 test_noop_publishes_nothing() {
 	local origin_dir="$TMP/noop-origin.git"
 	local seed_dir="$TMP/noop-seed"
@@ -496,6 +558,7 @@ test_protected_branch_uses_one_rebased_pr
 test_non_gh006_failure_does_not_open_pr
 test_deleted_pr_branch_retries_before_opening_pr
 test_actions_pr_creation_uses_pat_fallback
+test_runner_git_guard_uses_trusted_git_binary
 test_noop_publishes_nothing
 
 printf 'Tests run: %s, failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Route issue-sync snapshot, merge, and branch-inspection Git operations through the trusted planning Git binary so protected-publication fallback survives the canonical runner guard.

## Files Changed

.agents/scripts/issue-sync-git-push-helper.sh, .agents/scripts/tests/test-issue-sync-git-push-helper.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Runtime fixture with a rejecting PATH Git shim passes all 8 issue-sync publication tests; bash -n, ShellCheck, shell portability, and linters-local.sh pass.

Resolves #29679


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.232 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 4h 20m and 1,849,037 tokens on this with the user in an interactive session.