### PR TITLE
GH#29679: Recover stale issue-sync branches from shallow checkouts

### DIFF
--- a/.agents/scripts/issue-sync-git-push-helper.sh
+++ b/.agents/scripts/issue-sync-git-push-helper.sh
@@ -205,6 +205,29 @@ issue_sync_remote_branch_sha() {
 	return 0
 }
 
+issue_sync_fetch_pr_history() {
+	local repo_path="$1"
+	local default_branch="$2"
+	local branch_name="$3"
+	local is_shallow=""
+	is_shallow=$(issue_sync_git -C "$repo_path" rev-parse --is-shallow-repository) || {
+		echo "::error::Unable to inspect issue-sync checkout history"
+		return 1
+	}
+	if [[ "$is_shallow" == "true" ]]; then
+		issue_sync_git -C "$repo_path" fetch -q --unshallow origin \
+			"$default_branch" "$branch_name" || {
+			echo "::error::Unable to recover history for the stale issue-sync PR branch"
+			return 1
+		}
+	fi
+	issue_sync_git -C "$repo_path" fetch -q origin "$branch_name" || {
+		echo "::error::Unable to fetch the issue-sync PR branch"
+		return 1
+	}
+	return 0
+}
+
 issue_sync_prepare_pr_snapshot() {
 	local repo_path="$1"
 	local default_branch="$2"
@@ -222,7 +245,7 @@ issue_sync_prepare_pr_snapshot() {
 		return 0
 	fi
 	[[ "$branch_rc" -eq 0 ]] || return 1
-	issue_sync_git -C "$repo_path" fetch -q origin "$ISSUE_SYNC_PR_BRANCH" || return 1
+	issue_sync_fetch_pr_history "$repo_path" "$default_branch" "$ISSUE_SYNC_PR_BRANCH" || return 1
 	sync_sha=$(issue_sync_git -C "$repo_path" rev-parse FETCH_HEAD) || return 1
 	sync_base=$(issue_sync_git -C "$repo_path" merge-base "$ISSUE_SYNC_BASE_SHA" "$sync_sha") || return 1
 	issue_sync_read_todo_blob "$repo_path" "$sync_base" "$sync_ancestor" || return 1

--- a/.agents/scripts/issue-sync-git-push-helper.sh
+++ b/.agents/scripts/issue-sync-git-push-helper.sh
@@ -19,6 +19,7 @@ ISSUE_SYNC_DEFAULT_COMMIT_MESSAGE="${ISSUE_SYNC_COMMIT_SUBJECT} [skip ci]"
 ISSUE_SYNC_LAST_PUBLISH_OUTPUT=""
 ISSUE_SYNC_BASE_SHA=""
 ISSUE_SYNC_SOURCE_BASE_SHA=""
+ISSUE_SYNC_EXPECTED_TARGET_SHA=""
 
 issue_sync_git() {
 	_planning_git "$@"
@@ -210,6 +211,7 @@ issue_sync_fetch_pr_history() {
 	local default_branch="$2"
 	local branch_name="$3"
 	local is_shallow=""
+	local branch_rc=0
 	is_shallow=$(issue_sync_git -C "$repo_path" rev-parse --is-shallow-repository) || {
 		echo "::error::Unable to inspect issue-sync checkout history"
 		return 1
@@ -217,11 +219,17 @@ issue_sync_fetch_pr_history() {
 	if [[ "$is_shallow" == "true" ]]; then
 		issue_sync_git -C "$repo_path" fetch -q --unshallow origin \
 			"$default_branch" "$branch_name" || {
+			branch_rc=0
+			issue_sync_remote_branch_sha "$repo_path" "$branch_name" >/dev/null || branch_rc=$?
+			[[ "$branch_rc" -ne 2 ]] || return 2
 			echo "::error::Unable to recover history for the stale issue-sync PR branch"
 			return 1
 		}
 	fi
 	issue_sync_git -C "$repo_path" fetch -q origin "$branch_name" || {
+		branch_rc=0
+		issue_sync_remote_branch_sha "$repo_path" "$branch_name" >/dev/null || branch_rc=$?
+		[[ "$branch_rc" -ne 2 ]] || return 2
 		echo "::error::Unable to fetch the issue-sync PR branch"
 		return 1
 	}
@@ -238,15 +246,22 @@ issue_sync_prepare_pr_snapshot() {
 	local sync_ancestor="${state_dir}/sync-ancestor"
 	local sync_todo="${state_dir}/sync-todo"
 	local branch_rc=0
+	local fetch_rc=0
 
+	ISSUE_SYNC_EXPECTED_TARGET_SHA=""
 	issue_sync_prepare_base_snapshot "$repo_path" "$default_branch" "$source_file" "$state_dir" || return 1
 	sync_sha=$(issue_sync_remote_branch_sha "$repo_path" "$ISSUE_SYNC_PR_BRANCH") || branch_rc=$?
 	if [[ "$branch_rc" -eq 2 ]]; then
 		return 0
 	fi
 	[[ "$branch_rc" -eq 0 ]] || return 1
-	issue_sync_fetch_pr_history "$repo_path" "$default_branch" "$ISSUE_SYNC_PR_BRANCH" || return 1
+	issue_sync_fetch_pr_history "$repo_path" "$default_branch" "$ISSUE_SYNC_PR_BRANCH" || fetch_rc=$?
+	if [[ "$fetch_rc" -eq 2 ]]; then
+		return 0
+	fi
+	[[ "$fetch_rc" -eq 0 ]] || return 1
 	sync_sha=$(issue_sync_git -C "$repo_path" rev-parse FETCH_HEAD) || return 1
+	ISSUE_SYNC_EXPECTED_TARGET_SHA="$sync_sha"
 	sync_base=$(issue_sync_git -C "$repo_path" merge-base "$ISSUE_SYNC_BASE_SHA" "$sync_sha") || return 1
 	issue_sync_read_todo_blob "$repo_path" "$sync_base" "$sync_ancestor" || return 1
 	issue_sync_read_todo_blob "$repo_path" "$sync_sha" "$sync_todo" || return 1
@@ -359,6 +374,7 @@ issue_sync_publish_via_pr() {
 		rc=0
 		AIDEVOPS_PLANNING_PARENT_BRANCH="$default_branch" \
 			AIDEVOPS_PLANNING_BASE_SHA="$ISSUE_SYNC_BASE_SHA" \
+			AIDEVOPS_PLANNING_EXPECTED_TARGET_SHA="$ISSUE_SYNC_EXPECTED_TARGET_SHA" \
 			PLANNING_PUBLISH_MAX_RETRIES=1 \
 			issue_sync_capture_planning_publish "$repo_path" "$branch_commit_msg" origin \
 			"$ISSUE_SYNC_PR_BRANCH" TODO.md "$output_file" || rc=$?

--- a/.agents/scripts/planning-publisher.sh
+++ b/.agents/scripts/planning-publisher.sh
@@ -775,7 +775,12 @@ _planning_publish_resolve_attempt() {
 	resolution_tail="${parent_resolution#*|}"
 	expected_sha="${resolution_tail%%|*}"
 	target_sha="${resolution_tail#*|}"
-	if [[ -n "${AIDEVOPS_PLANNING_PARENT_BRANCH:-}" && "$attempt" -gt 1 && \
+	if [[ "${AIDEVOPS_PLANNING_EXPECTED_TARGET_SHA+x}" == "x" &&
+		"$target_sha" != "${AIDEVOPS_PLANNING_EXPECTED_TARGET_SHA}" ]]; then
+		_planning_publish_log_retryable_conflict "$publication_id"
+		return 2
+	fi
+	if [[ -n "${AIDEVOPS_PLANNING_PARENT_BRANCH:-}" && "$attempt" -gt 1 &&
 		"$target_sha" != "$previous_target_sha" ]]; then
 		if [[ -z "$previous_target_sha" || -z "$target_sha" ]] || \
 			_planning_publish_parent_conflicts "$repo_path" "$previous_target_sha" "$target_sha" "$snapshot_file"; then

--- a/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
+++ b/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
@@ -385,6 +385,54 @@ test_protected_branch_uses_one_rebased_pr() {
 	return 0
 }
 
+test_shallow_checkout_recovers_stale_pr_history() {
+	local origin_dir="$TMP/shallow-origin.git"
+	local seed_dir="$TMP/shallow-seed"
+	local work_dir="$TMP/shallow-work"
+	local fake_bin="$TMP/shallow-bin"
+	local gh_log="$TMP/shallow-gh.log"
+	local pr_marker="$TMP/shallow-pr.marker"
+	local output_file="$TMP/shallow-output.log"
+	local sync_ref="refs/heads/aidevops/issue-sync-todo"
+	local remote_todo=""
+	local is_shallow=""
+	create_origin "$origin_dir" "$seed_dir"
+	git -C "$seed_dir" checkout -b aidevops/issue-sync-todo >/dev/null
+	perl -0pi -e 's/t9001 original task/t9001 stale PR event/' "$seed_dir/TODO.md"
+	git -C "$seed_dir" add TODO.md
+	git -C "$seed_dir" commit -m "stale issue-sync PR event" >/dev/null
+	git -C "$seed_dir" push origin HEAD:"$sync_ref" >/dev/null
+	git -C "$seed_dir" checkout main >/dev/null
+	perl -0pi -e 's/t9003 third task/t9003 reviewed main advance/' "$seed_dir/TODO.md"
+	git -C "$seed_dir" add TODO.md
+	git -C "$seed_dir" commit -m "reviewed main advance" >/dev/null
+	git -C "$seed_dir" push origin main >/dev/null
+	git clone --depth 1 --branch main "file://${origin_dir}" "$work_dir" >/dev/null 2>&1
+	git_init_repo "$work_dir"
+	write_fake_gh "$fake_bin"
+	install_main_rejection_hook "$origin_dir" gh006
+	: >"$gh_log"
+	: >"$pr_marker"
+	perl -0pi -e 's/t9002 second task/t9002 shallow runner event/' "$work_dir/TODO.md"
+	if ! run_issue_sync_helper "$work_dir" "$fake_bin" "$gh_log" "$pr_marker" \
+		"$TMP/shallow-head" "$TMP/shallow-title" "$output_file" 3; then
+		printf 'Shallow publication output:\n%s\n' "$(<"$output_file")" >&2
+		fail "shallow checkout recovers stale issue-sync PR history"
+		return 0
+	fi
+	remote_todo=$(git --git-dir="$origin_dir" show "${sync_ref}:TODO.md")
+	is_shallow=$(git -C "$work_dir" rev-parse --is-shallow-repository)
+	if [[ "$is_shallow" != "false" ||
+		"$remote_todo" != *"t9001 stale PR event"* ||
+		"$remote_todo" != *"t9002 shallow runner event"* ||
+		"$remote_todo" != *"t9003 reviewed main advance"* ]]; then
+		fail "shallow checkout recovers stale issue-sync PR history"
+	else
+		pass "shallow checkout recovers stale issue-sync PR history"
+	fi
+	return 0
+}
+
 test_non_gh006_failure_does_not_open_pr() {
 	local origin_dir="$TMP/terminal-origin.git"
 	local seed_dir="$TMP/terminal-seed"
@@ -555,6 +603,7 @@ test_noop_publishes_nothing() {
 test_successful_push
 test_rebase_conflict_neutralizes_cleanly
 test_protected_branch_uses_one_rebased_pr
+test_shallow_checkout_recovers_stale_pr_history
 test_non_gh006_failure_does_not_open_pr
 test_deleted_pr_branch_retries_before_opening_pr
 test_actions_pr_creation_uses_pat_fallback

--- a/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
+++ b/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
@@ -222,6 +222,39 @@ GIT
 	return 0
 }
 
+write_sync_race_git_wrapper() {
+	local wrapper_path="$1"
+	cat >"$wrapper_path" <<'GIT'
+#!/usr/bin/env bash
+set -u
+args=" $* "
+case "$args" in
+*" fetch -q origin aidevops/issue-sync-todo "*)
+	count=0
+	[[ ! -f "${SYNC_GIT_COUNTER:?}" ]] || count=$(<"$SYNC_GIT_COUNTER")
+	count=$((count + 1))
+	printf '%s\n' "$count" >"$SYNC_GIT_COUNTER"
+	if [[ "$count" -eq "${SYNC_GIT_TRIGGER_COUNT:?}" ]]; then
+		case "${SYNC_GIT_ACTION:?}" in
+		advance)
+			"${REAL_GIT:?}" --git-dir="${SYNC_GIT_ORIGIN:?}" update-ref \
+				refs/heads/aidevops/issue-sync-todo "${SYNC_GIT_ADVANCE_SHA:?}"
+			;;
+		delete)
+			"${REAL_GIT:?}" --git-dir="${SYNC_GIT_ORIGIN:?}" update-ref -d \
+				refs/heads/aidevops/issue-sync-todo
+			;;
+		*) exit 98 ;;
+		esac
+	fi
+	;;
+esac
+exec "${REAL_GIT:?}" "$@"
+GIT
+	chmod +x "$wrapper_path"
+	return 0
+}
+
 install_main_rejection_hook() {
 	local origin_dir="$1"
 	local mode="$2"
@@ -433,6 +466,114 @@ test_shallow_checkout_recovers_stale_pr_history() {
 	return 0
 }
 
+test_concurrent_pr_advance_rebuilds_snapshot() {
+	local origin_dir="$TMP/race-origin.git"
+	local seed_dir="$TMP/race-seed"
+	local work_dir="$TMP/race-work"
+	local concurrent_dir="$TMP/race-concurrent"
+	local fake_bin="$TMP/race-bin"
+	local gh_log="$TMP/race-gh.log"
+	local pr_marker="$TMP/race-pr.marker"
+	local output_file="$TMP/race-output.log"
+	local wrapper="$TMP/race-git"
+	local counter="$TMP/race-counter"
+	local sync_ref="refs/heads/aidevops/issue-sync-todo"
+	local concurrent_sha=""
+	local remote_todo=""
+	local real_git=""
+	real_git=$(command -v git) || return 1
+	create_origin "$origin_dir" "$seed_dir"
+	git -C "$seed_dir" checkout -b aidevops/issue-sync-todo >/dev/null
+	perl -0pi -e 's/t9001 original task/t9001 stale PR event/' "$seed_dir/TODO.md"
+	git -C "$seed_dir" add TODO.md
+	git -C "$seed_dir" commit -m "stale issue-sync PR event" >/dev/null
+	git -C "$seed_dir" push origin HEAD:"$sync_ref" >/dev/null
+	git -C "$seed_dir" checkout main >/dev/null
+	git clone --branch aidevops/issue-sync-todo "$origin_dir" "$concurrent_dir" >/dev/null 2>&1
+	git_init_repo "$concurrent_dir"
+	perl -0pi -e 's/t9003 third task/t9003 concurrent PR event/' "$concurrent_dir/TODO.md"
+	git -C "$concurrent_dir" add TODO.md
+	git -C "$concurrent_dir" commit -m "concurrent issue-sync PR event" >/dev/null
+	concurrent_sha=$(git -C "$concurrent_dir" rev-parse HEAD)
+	git -C "$concurrent_dir" push origin HEAD:refs/heads/concurrent-candidate >/dev/null
+	git clone "$origin_dir" "$work_dir" >/dev/null 2>&1
+	git_init_repo "$work_dir"
+	write_fake_gh "$fake_bin"
+	write_sync_race_git_wrapper "$wrapper"
+	install_main_rejection_hook "$origin_dir" gh006
+	: >"$gh_log"
+	: >"$pr_marker"
+	perl -0pi -e 's/t9002 second task/t9002 current runner event/' "$work_dir/TODO.md"
+	if ! (
+		export REAL_GIT="$real_git" SYNC_GIT_ORIGIN="$origin_dir" SYNC_GIT_COUNTER="$counter"
+		export SYNC_GIT_TRIGGER_COUNT=2 SYNC_GIT_ACTION=advance SYNC_GIT_ADVANCE_SHA="$concurrent_sha"
+		run_issue_sync_helper "$work_dir" "$fake_bin" "$gh_log" "$pr_marker" \
+			"$TMP/race-head" "$TMP/race-title" "$output_file" 3 \
+			"fixture-token" "" "" "$wrapper"
+	); then
+		fail "concurrent issue-sync PR advance rebuilds the snapshot"
+		return 0
+	fi
+	remote_todo=$(git --git-dir="$origin_dir" show "${sync_ref}:TODO.md")
+	if [[ "$remote_todo" != *"t9001 stale PR event"* ||
+		"$remote_todo" != *"t9002 current runner event"* ||
+		"$remote_todo" != *"t9003 concurrent PR event"* ]]; then
+		fail "concurrent issue-sync PR advance rebuilds the snapshot"
+	elif ! grep -q "branch changed concurrently" "$output_file"; then
+		fail "concurrent issue-sync PR advance rebuilds the snapshot"
+	else
+		pass "concurrent issue-sync PR advance rebuilds the snapshot"
+	fi
+	return 0
+}
+
+test_pr_branch_deletion_during_fetch_rebuilds() {
+	local origin_dir="$TMP/fetch-delete-origin.git"
+	local seed_dir="$TMP/fetch-delete-seed"
+	local work_dir="$TMP/fetch-delete-work"
+	local fake_bin="$TMP/fetch-delete-bin"
+	local gh_log="$TMP/fetch-delete-gh.log"
+	local output_file="$TMP/fetch-delete-output.log"
+	local wrapper="$TMP/fetch-delete-git"
+	local counter="$TMP/fetch-delete-counter"
+	local sync_ref="refs/heads/aidevops/issue-sync-todo"
+	local create_count=0
+	local real_git=""
+	real_git=$(command -v git) || return 1
+	create_origin "$origin_dir" "$seed_dir"
+	git -C "$seed_dir" checkout -b aidevops/issue-sync-todo >/dev/null
+	perl -0pi -e 's/t9001 original task/t9001 deletion race event/' "$seed_dir/TODO.md"
+	git -C "$seed_dir" add TODO.md
+	git -C "$seed_dir" commit -m "deletion race event" >/dev/null
+	git -C "$seed_dir" push origin HEAD:"$sync_ref" >/dev/null
+	git -C "$seed_dir" checkout main >/dev/null
+	git clone "$origin_dir" "$work_dir" >/dev/null 2>&1
+	git_init_repo "$work_dir"
+	write_fake_gh "$fake_bin"
+	write_sync_race_git_wrapper "$wrapper"
+	install_main_rejection_hook "$origin_dir" gh006
+	: >"$gh_log"
+	perl -0pi -e 's/t9002 second task/t9002 deletion recovery event/' "$work_dir/TODO.md"
+	if ! (
+		export REAL_GIT="$real_git" SYNC_GIT_ORIGIN="$origin_dir" SYNC_GIT_COUNTER="$counter"
+		export SYNC_GIT_TRIGGER_COUNT=1 SYNC_GIT_ACTION=delete SYNC_GIT_ADVANCE_SHA=unused
+		run_issue_sync_helper "$work_dir" "$fake_bin" "$gh_log" "$TMP/fetch-delete-pr.marker" \
+			"$TMP/fetch-delete-head" "$TMP/fetch-delete-title" "$output_file" 3 \
+			"fixture-token" "" "" "$wrapper"
+	); then
+		fail "issue-sync PR deletion during fetch rebuilds safely"
+		return 0
+	fi
+	create_count=$(grep -c $'gh\tpr\tcreate' "$gh_log" || true)
+	if ! git --git-dir="$origin_dir" show-ref --verify --quiet "$sync_ref" ||
+		[[ "$create_count" -ne 1 ]]; then
+		fail "issue-sync PR deletion during fetch rebuilds safely"
+	else
+		pass "issue-sync PR deletion during fetch rebuilds safely"
+	fi
+	return 0
+}
+
 test_non_gh006_failure_does_not_open_pr() {
 	local origin_dir="$TMP/terminal-origin.git"
 	local seed_dir="$TMP/terminal-seed"
@@ -604,6 +745,8 @@ test_successful_push
 test_rebase_conflict_neutralizes_cleanly
 test_protected_branch_uses_one_rebased_pr
 test_shallow_checkout_recovers_stale_pr_history
+test_concurrent_pr_advance_rebuilds_snapshot
+test_pr_branch_deletion_during_fetch_rebuilds
 test_non_gh006_failure_does_not_open_pr
 test_deleted_pr_branch_retries_before_opening_pr
 test_actions_pr_creation_uses_pat_fallback


### PR DESCRIPTION
## Summary

Recover complete deterministic-branch history in depth-1 runners and fence the exact snapshot target so concurrent branch advances or deletions rebuild without losing TODO projections.

## Files Changed

- `.agents/scripts/issue-sync-git-push-helper.sh`
- `.agents/scripts/planning-publisher.sh`
- `.agents/scripts/tests/test-issue-sync-git-push-helper.sh`

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — All 11 issue-sync publication tests and 18 planning-publisher tests pass, including shallow-history, concurrent-advance, and fetch-deletion races; `bash -n`, ShellCheck, shell portability, and `linters-local.sh` pass.

Resolves #29679


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.232 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 5h 3m and 2,005,008 tokens on this with the user in an interactive session.
