### PR TITLE
GH#29676: Fail closed on routed review metadata uncertainty

### DIFF
--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -977,6 +977,17 @@ _rf_extract_keywords() {
 	return 0
 }
 
+_rf_has_routed_review_evidence() {
+	local issue_body="$1"
+
+	if printf '%s\n' "$issue_body" | grep -Eq \
+		'^[[:space:]]*<!--[[:space:]]feedback-route:(start|complete):review:PR[0-9]+:SHA[^[:space:]>]+[[:space:]]*-->[[:space:]]*$|^##[[:space:]]+Review Feedback routed from PR[[:space:]]+#[0-9]+([[:space:]].*)?$'; then
+		return 0
+	fi
+
+	return 1
+}
+
 _rf_issue_in_supersession_scope() {
 	local issue_body="$1"
 	local labels="$2"
@@ -984,6 +995,9 @@ _rf_issue_in_supersession_scope() {
 	local title_lc=""
 
 	if _rf_is_review_followup_scope "$issue_body" "$labels" "$title"; then
+		return 0
+	fi
+	if _rf_has_routed_review_evidence "$issue_body"; then
 		return 0
 	fi
 	local labels_lc=""
@@ -1475,6 +1489,11 @@ _rf_resolve_supersession_context() {
 	local source_sha=""
 	local routed_review_at=""
 	local routed_payload=""
+	local has_routed_evidence=0
+
+	if _rf_has_routed_review_evidence "$issue_body"; then
+		has_routed_evidence=1
+	fi
 
 	_RF_CONTEXT_SOURCE_PR=""
 	_RF_CONTEXT_SEARCH_AFTER="$created_at"
@@ -1484,12 +1503,16 @@ _rf_resolve_supersession_context() {
 	_RF_CONTEXT_STRICT_MODE="false"
 	if ! _RF_CONTEXT_SOURCE_PR=$(_rf_extract_source_pr_number "$issue_body" "$issue_title"); then
 		_RF_CONTEXT_SOURCE_PR=""
+		if [[ "$has_routed_evidence" -eq 1 ]]; then
+			_log "WARN" "#${issue_number}: routed review evidence has no resolvable source PR — dispatch blocked for this cycle"
+			return 30
+		fi
 		return 0
 	fi
 
 	routed_payload=$(_rf_extract_routed_review_payload "$issue_body" "$_RF_CONTEXT_SOURCE_PR" 2>/dev/null || true)
 	if ! source_pr_meta=$(_rf_get_source_pr_metadata "$slug" "$_RF_CONTEXT_SOURCE_PR"); then
-		if [[ -n "$routed_payload" ]]; then
+		if [[ "$has_routed_evidence" -eq 1 ]]; then
 			_log "WARN" "#${issue_number}: routed source PR #${_RF_CONTEXT_SOURCE_PR} metadata lookup failed — dispatch blocked for this cycle"
 			return 30
 		fi
@@ -1505,6 +1528,10 @@ _rf_resolve_supersession_context() {
 		return 0
 	fi
 	if [[ -z "$routed_payload" ]]; then
+		if [[ "$has_routed_evidence" -eq 1 ]]; then
+			_log "WARN" "#${issue_number}: routed source PR #${_RF_CONTEXT_SOURCE_PR} has no bounded finding payload — dispatch blocked for this cycle"
+			return 30
+		fi
 		_log "WARN" "#${issue_number}: source PR #${_RF_CONTEXT_SOURCE_PR} is unmerged without a routed finding payload — using issue-created supersession window"
 		_RF_CONTEXT_SOURCE_PR=""
 		return 0
@@ -1543,7 +1570,8 @@ _detect_review_feedback_supersession() {
 	local issue_title=""
 	local labels=""
 	issue_meta=$(gh api "$issue_api_path" --jq '[.created_at // "", .title // "", ([.labels[]?.name] | join(","))] | @tsv' 2>/dev/null) || {
-		if printf '%s' "$issue_body" | grep -Eq 'aidevops:generator=review-followup|source:review-scanner|review-followup:PR|Unaddressed review bot suggestions'; then
+		if _rf_has_routed_review_evidence "$issue_body" ||
+			printf '%s' "$issue_body" | grep -Eq 'aidevops:generator=review-followup|source:review-scanner|review-followup:PR|Unaddressed review bot suggestions'; then
 			_log "WARN" "#${issue_number}: review-followup metadata lookup failed — dispatch blocked for this cycle"
 			return 30
 		fi
@@ -1564,6 +1592,10 @@ _detect_review_feedback_supersession() {
 	fi
 
 	if [[ -z "$created_at" || "$created_at" != *T* ]]; then
+		if _rf_has_routed_review_evidence "$issue_body"; then
+			_log "WARN" "#${issue_number}: routed review metadata omitted created_at — dispatch blocked for this cycle"
+			return 30
+		fi
 		_log "WARN" "#${issue_number}: missing created_at metadata — review-feedback supersession check fails open"
 		return 0
 	fi

--- a/.agents/scripts/tests/test-pre-dispatch-validator.sh
+++ b/.agents/scripts/tests/test-pre-dispatch-validator.sh
@@ -407,6 +407,7 @@ GHEOF
 create_gh_stub_routed_review_feedback() {
 	local candidate_merged_at="$1"
 	local candidate_file="$2"
+	local issue_metadata_mode="${3:-normal}"
 	local actions_file="${TEST_ROOT}/review-actions.log"
 	: >"$actions_file"
 
@@ -430,7 +431,17 @@ The permission boundary escape remains in src/runtime-guard.sh:42; enforce the r
 <!-- feedback-route:complete:review:PR73:SHAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:EVIDENCEfixture -->
 BODYEOF
 	else
-		printf '2026-05-07T00:00:00Z\tOriginal implementation task\tsource:review-feedback\n'
+		case '${issue_metadata_mode}' in
+		metadata-failure)
+			exit 1
+			;;
+		missing-created)
+			printf '\tOriginal implementation task\t\n'
+			;;
+		*)
+			printf '2026-05-07T00:00:00Z\tOriginal implementation task\t\n'
+			;;
+		esac
 	fi
 	exit 0
 fi
@@ -827,6 +838,40 @@ test_routed_review_closes_for_matching_post_review_merge() {
 	return 0
 }
 
+test_routed_review_metadata_failure_blocks_dispatch() {
+	setup_test_env
+	create_gh_stub_routed_review_feedback "2026-05-08T13:00:00Z" "src/runtime-guard.sh" "metadata-failure"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "47" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 30 && ! -s "${TEST_ROOT}/review-actions.log" ]]; then
+		print_result "routed_review metadata failure blocks dispatch without mutation" 0
+	else
+		print_result "routed_review metadata failure blocks dispatch without mutation" 1 "Expected exit 30 without issue mutation, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+test_routed_review_missing_created_at_blocks_dispatch() {
+	setup_test_env
+	create_gh_stub_routed_review_feedback "2026-05-08T13:00:00Z" "src/runtime-guard.sh" "missing-created"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "47" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 30 && ! -s "${TEST_ROOT}/review-actions.log" ]]; then
+		print_result "routed_review missing created_at blocks dispatch without mutation" 0
+	else
+		print_result "routed_review missing created_at blocks dispatch without mutation" 1 "Expected exit 30 without issue mutation, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
 test_function_complexity_sweep_duplicate_closes_later_issue() {
 	setup_test_env
 	create_gh_stub_function_complexity_duplicate
@@ -948,6 +993,8 @@ main() {
 	test_source_review_scanner_label_enters_supersession_scope
 	test_routed_review_ignores_merge_before_requested_changes
 	test_routed_review_closes_for_matching_post_review_merge
+	test_routed_review_metadata_failure_blocks_dispatch
+	test_routed_review_missing_created_at_blocks_dispatch
 	test_function_complexity_sweep_duplicate_closes_later_issue
 	test_function_complexity_sweep_missing_cited_file_allows_dispatch
 

--- a/.agents/scripts/tests/test-pre-dispatch-validator.sh
+++ b/.agents/scripts/tests/test-pre-dispatch-validator.sh
@@ -420,7 +420,14 @@ actions_file="${actions_file}"
 
 if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/issues/47\$'; then
 	if printf '%s' "\$args" | grep -qF '.body // ""'; then
-		cat <<'BODYEOF'
+		if [[ '${issue_metadata_mode}' == "empty-payload" ]]; then
+			cat <<'BODYEOF'
+Original implementation task.
+<!-- feedback-route:start:review:PR73:SHAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:EVIDENCEfixture -->
+<!-- feedback-route:complete:review:PR73:SHAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:EVIDENCEfixture -->
+BODYEOF
+		else
+			cat <<'BODYEOF'
 Original implementation task mentions broad overlay config work in TODO.md and todo/missions/example/mission.md.
 <!-- feedback-route:start:review:PR73:SHAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:EVIDENCEfixture -->
 ## Review Feedback routed from PR #73 (t2093)
@@ -430,6 +437,7 @@ Original implementation task mentions broad overlay config work in TODO.md and t
 The permission boundary escape remains in src/runtime-guard.sh:42; enforce the restricted capability guard.
 <!-- feedback-route:complete:review:PR73:SHAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:EVIDENCEfixture -->
 BODYEOF
+		fi
 	else
 		case '${issue_metadata_mode}' in
 		metadata-failure)
@@ -447,6 +455,9 @@ BODYEOF
 fi
 
 if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/pulls/73\$'; then
+	if [[ '${issue_metadata_mode}' == "source-metadata-failure" ]]; then
+		exit 1
+	fi
 	printf 'closed||2026-05-09T00:00:00Z\n'
 	exit 0
 fi
@@ -872,6 +883,40 @@ test_routed_review_missing_created_at_blocks_dispatch() {
 	return 0
 }
 
+test_routed_review_source_metadata_failure_blocks_dispatch() {
+	setup_test_env
+	create_gh_stub_routed_review_feedback "2026-05-08T13:00:00Z" "src/runtime-guard.sh" "source-metadata-failure"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "47" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 30 && ! -s "${TEST_ROOT}/review-actions.log" ]]; then
+		print_result "routed_review source metadata failure blocks dispatch without mutation" 0
+	else
+		print_result "routed_review source metadata failure blocks dispatch without mutation" 1 "Expected exit 30 without issue mutation, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+test_routed_review_empty_payload_blocks_dispatch() {
+	setup_test_env
+	create_gh_stub_routed_review_feedback "2026-05-08T13:00:00Z" "src/runtime-guard.sh" "empty-payload"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "47" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 30 && ! -s "${TEST_ROOT}/review-actions.log" ]]; then
+		print_result "routed_review empty payload blocks dispatch without mutation" 0
+	else
+		print_result "routed_review empty payload blocks dispatch without mutation" 1 "Expected exit 30 without issue mutation, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
 test_function_complexity_sweep_duplicate_closes_later_issue() {
 	setup_test_env
 	create_gh_stub_function_complexity_duplicate
@@ -995,6 +1040,8 @@ main() {
 	test_routed_review_closes_for_matching_post_review_merge
 	test_routed_review_metadata_failure_blocks_dispatch
 	test_routed_review_missing_created_at_blocks_dispatch
+	test_routed_review_source_metadata_failure_blocks_dispatch
+	test_routed_review_empty_payload_blocks_dispatch
 	test_function_complexity_sweep_duplicate_closes_later_issue
 	test_function_complexity_sweep_missing_cited_file_allows_dispatch
 


### PR DESCRIPTION
## Summary

Recognize only exact routed-review markers and headings as supersession evidence, then block dispatch when issue metadata, source identity, or bounded payload evidence is uncertain.

## Files Changed

.agents/scripts/pre-dispatch-validator-helper.sh, .agents/scripts/tests/test-pre-dispatch-validator.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — 28 pre-dispatch validator tests, 77 dispatch integration tests, 30 feedback-routing tests, Bash syntax, ShellCheck, shfmt, and changed-file linters pass on the rebased head.

Resolves #29676


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.232 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1d 4h and 12,853,238 tokens on this with the user in an interactive session.
