### PR TITLE
t18210: fix(issue-sync): dedupe stale deterministic task additions

### DIFF
--- a/.agents/scripts/issue-sync-git-push-helper.sh
+++ b/.agents/scripts/issue-sync-git-push-helper.sh
@@ -175,32 +175,59 @@ issue_sync_task_ids() {
 	return 0
 }
 
-# A stale deterministic branch and current main can independently add the same
-# logical task at different file locations. Track only IDs absent from their
-# common ancestor; historical duplicates must remain outside this repair scope.
-issue_sync_find_concurrent_task_additions() {
-	local current_file="$1"
-	local ancestor_file="$2"
-	local incoming_file="$3"
-	local state_dir="$4"
-	local current_ids="${state_dir}/current-task-ids"
+# Track task IDs added by the stale deterministic branch after its common
+# ancestor. Seeding their canonical rows into the current side prevents an
+# `--ours` same-hunk resolution from discarding queued branch additions.
+issue_sync_find_branch_task_additions() {
+	local ancestor_file="$1"
+	local incoming_file="$2"
+	local state_dir="$3"
 	local ancestor_ids="${state_dir}/ancestor-task-ids"
 	local incoming_ids="${state_dir}/incoming-task-ids"
-	local overlapping_ids="${state_dir}/overlapping-task-ids"
-	local concurrent_ids="${state_dir}/concurrent-task-additions"
+	local branch_additions="${state_dir}/branch-task-additions"
 
-	issue_sync_task_ids "$current_file" >"$current_ids" || return 1
 	issue_sync_task_ids "$ancestor_file" >"$ancestor_ids" || return 1
 	issue_sync_task_ids "$incoming_file" >"$incoming_ids" || return 1
-	comm -12 "$current_ids" "$incoming_ids" >"$overlapping_ids" || return 1
-	comm -23 "$overlapping_ids" "$ancestor_ids" >"$concurrent_ids" || return 1
+	comm -23 "$incoming_ids" "$ancestor_ids" >"$branch_additions" || return 1
+	return 0
+}
+
+issue_sync_seed_branch_task_additions() {
+	local current_file="$1"
+	local incoming_file="$2"
+	local state_dir="$3"
+	local branch_additions="${state_dir}/branch-task-additions"
+	local combined_todo="${state_dir}/combined-task-additions"
+	local canonical_lines="${state_dir}/canonical-branch-task-lines"
+	local winner_lines="${state_dir}/branch-task-winners"
+	local winner_ids="${state_dir}/branch-task-winner-ids"
+	local line=""
+	[[ -s "$branch_additions" ]] || return 0
+
+	awk '1' "$current_file" "$incoming_file" >"$combined_todo" || return 1
+	_unique_todo_task_snapshot "$combined_todo" >"$canonical_lines" || return 1
+	awk '
+		FNR == NR { wanted[$1] = 1; next }
+		match($0, /^[[:space:]]*-[[:space:]]+\[[ x>-]\][[:space:]]+/) {
+			remaining = substr($0, RLENGTH + 1)
+			split(remaining, fields, /[[:space:]]+/)
+			if (fields[1] in wanted) { print }
+		}
+	' "$branch_additions" "$canonical_lines" >"$winner_lines" || return 1
+	issue_sync_task_ids "$winner_lines" >"$winner_ids" || return 1
+	cmp -s "$branch_additions" "$winner_ids" || return 1
+
+	printf '\n' >>"$current_file" || return 1
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		printf '%s\n' "$line" >>"$current_file" || return 1
+	done <"$winner_lines"
 	return 0
 }
 
 issue_sync_dedupe_concurrent_task_additions() {
 	local todo_file="$1"
 	local state_dir="$2"
-	local concurrent_ids="${state_dir}/concurrent-task-additions"
+	local concurrent_ids="${state_dir}/branch-task-additions"
 	local canonical_lines="${state_dir}/canonical-task-lines"
 	local filtered_todo="${state_dir}/deduplicated-todo"
 	[[ -s "$concurrent_ids" ]] || return 0
@@ -367,8 +394,9 @@ issue_sync_prepare_pr_snapshot() {
 	sync_base=$(issue_sync_git -C "$repo_path" merge-base "$ISSUE_SYNC_BASE_SHA" "$sync_sha") || return 1
 	issue_sync_read_todo_blob "$repo_path" "$sync_base" "$sync_ancestor" || return 1
 	issue_sync_read_todo_blob "$repo_path" "$sync_sha" "$sync_todo" || return 1
-	issue_sync_find_concurrent_task_additions "${state_dir}/merged-todo" \
-		"$sync_ancestor" "$sync_todo" "$state_dir" || return 1
+	issue_sync_find_branch_task_additions "$sync_ancestor" "$sync_todo" "$state_dir" || return 1
+	issue_sync_seed_branch_task_additions "${state_dir}/merged-todo" \
+		"$sync_todo" "$state_dir" || return 1
 	issue_sync_merge_todo_file "${state_dir}/merged-todo" "$sync_ancestor" "$sync_todo" || return 1
 	issue_sync_dedupe_concurrent_task_additions "${state_dir}/merged-todo" "$state_dir" || return 1
 	return 0

--- a/.agents/scripts/issue-sync-git-push-helper.sh
+++ b/.agents/scripts/issue-sync-git-push-helper.sh
@@ -11,6 +11,8 @@ ISSUE_SYNC_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 source "${ISSUE_SYNC_SCRIPT_DIR}/planning-publisher.sh"
 # shellcheck source=./shared-gh-wrappers.sh
 source "${ISSUE_SYNC_SCRIPT_DIR}/shared-gh-wrappers.sh"
+# shellcheck source=./issue-sync-lib-parse.sh
+source "${ISSUE_SYNC_SCRIPT_DIR}/issue-sync-lib-parse.sh"
 
 ISSUE_SYNC_PR_BRANCH="${AIDEVOPS_ISSUE_SYNC_PR_BRANCH:-aidevops/issue-sync-todo}"
 ISSUE_SYNC_PR_MARKER="<!-- aidevops:issue-sync-todo-pr -->"
@@ -165,15 +167,18 @@ issue_sync_merge_todo_file() {
 
 issue_sync_task_ids() {
 	local todo_file="$1"
-	sed -nE 's/^[[:space:]]*- \[[ x-]\][[:space:]]+([tr][0-9]+(\.[0-9]+)*)([[:space:]].*|$)/\1/p' \
-		"$todo_file" | LC_ALL=C sort -u
+	local snapshot=""
+	snapshot=$(_unique_todo_task_snapshot "$todo_file") || return 1
+	printf '%s\n' "$snapshot" |
+		sed -nE 's/^[[:space:]]*- \[[ x>-]\][[:space:]]+(t[0-9]+(\.[0-9]+)*)([[:space:]].*|$)/\1/p' |
+		LC_ALL=C sort -u || return 1
 	return 0
 }
 
 # A stale deterministic branch and current main can independently add the same
-# logical task at different file locations. Keep the current canonical entry;
-# unique branch additions still flow through the subsequent three-way merge.
-issue_sync_prune_concurrent_task_additions() {
+# logical task at different file locations. Track only IDs absent from their
+# common ancestor; historical duplicates must remain outside this repair scope.
+issue_sync_find_concurrent_task_additions() {
 	local current_file="$1"
 	local ancestor_file="$2"
 	local incoming_file="$3"
@@ -183,28 +188,80 @@ issue_sync_prune_concurrent_task_additions() {
 	local incoming_ids="${state_dir}/incoming-task-ids"
 	local overlapping_ids="${state_dir}/overlapping-task-ids"
 	local concurrent_ids="${state_dir}/concurrent-task-additions"
-	local filtered_incoming="${state_dir}/filtered-sync-todo"
-	local line=""
-	local task_id=""
 
 	issue_sync_task_ids "$current_file" >"$current_ids" || return 1
 	issue_sync_task_ids "$ancestor_file" >"$ancestor_ids" || return 1
 	issue_sync_task_ids "$incoming_file" >"$incoming_ids" || return 1
 	comm -12 "$current_ids" "$incoming_ids" >"$overlapping_ids" || return 1
 	comm -23 "$overlapping_ids" "$ancestor_ids" >"$concurrent_ids" || return 1
+	return 0
+}
+
+issue_sync_dedupe_concurrent_task_additions() {
+	local todo_file="$1"
+	local state_dir="$2"
+	local concurrent_ids="${state_dir}/concurrent-task-additions"
+	local canonical_lines="${state_dir}/canonical-task-lines"
+	local filtered_todo="${state_dir}/deduplicated-todo"
 	[[ -s "$concurrent_ids" ]] || return 0
 
-	: >"$filtered_incoming" || return 1
-	while IFS= read -r line || [[ -n "$line" ]]; do
-		task_id=$(printf '%s\n' "$line" |
-			sed -nE 's/^[[:space:]]*- \[[ x-]\][[:space:]]+([tr][0-9]+(\.[0-9]+)*)([[:space:]].*|$)/\1/p')
-		if [[ -n "$task_id" ]] && grep -Fxq -- "$task_id" "$concurrent_ids"; then
-			continue
-		fi
-		printf '%s\n' "$line" >>"$filtered_incoming" || return 1
-	done <"$incoming_file"
-	mv "$filtered_incoming" "$incoming_file" || return 1
-	echo "::notice::Current TODO.md entries supersede stale issue-sync additions for matching task IDs"
+	_unique_todo_task_snapshot "$todo_file" >"$canonical_lines" || return 1
+	if ! awk -v wanted_file="$concurrent_ids" -v canonical_file="$canonical_lines" \
+		-v todo_file="$todo_file" '
+		function task_id(line, remaining, fields) {
+			if (!match(line, /^[[:space:]]*-[[:space:]]+\[[ x>-]\][[:space:]]+/)) { return "" }
+			remaining = substr(line, RLENGTH + 1)
+			split(remaining, fields, /[[:space:]]+/)
+			return fields[1]
+		}
+		function without_comments(raw, line, out, pos) {
+			line = raw
+			out = ""
+			while (length(line) > 0) {
+				if (in_comment) {
+					pos = index(line, "-->")
+					if (pos == 0) { line = ""; break }
+					line = substr(line, pos + 3)
+					in_comment = 0
+				} else {
+					pos = index(line, "<!--")
+					if (pos == 0) { out = out line; line = ""; break }
+					out = out substr(line, 1, pos - 1)
+					line = substr(line, pos + 4)
+					in_comment = 1
+				}
+			}
+			return out
+		}
+		FILENAME == wanted_file { wanted[$1] = 1; next }
+		FILENAME == canonical_file {
+			id = task_id($0)
+			if (id in wanted) { canonical[id] = $0 }
+			next
+		}
+		FILENAME == todo_file {
+			raw = $0
+			if (raw ~ /^[[:space:]]*```/) { in_fence = !in_fence; print raw; next }
+			if (in_fence) { print raw; next }
+			normalized = without_comments(raw)
+			id = task_id(normalized)
+			if (id in wanted) {
+				if (!kept[id] && normalized == canonical[id]) { print raw; kept[id] = 1 }
+				next
+			}
+			print raw
+		}
+		END {
+			for (id in wanted) {
+				if (!(id in canonical) || !kept[id]) { failed = 1 }
+			}
+			exit failed
+		}
+	' "$concurrent_ids" "$canonical_lines" "$todo_file" >"$filtered_todo"; then
+		return 1
+	fi
+	mv "$filtered_todo" "$todo_file" || return 1
+	echo "::notice::Selected the richest live TODO.md entry for concurrent stale-branch task additions"
 	return 0
 }
 
@@ -310,9 +367,10 @@ issue_sync_prepare_pr_snapshot() {
 	sync_base=$(issue_sync_git -C "$repo_path" merge-base "$ISSUE_SYNC_BASE_SHA" "$sync_sha") || return 1
 	issue_sync_read_todo_blob "$repo_path" "$sync_base" "$sync_ancestor" || return 1
 	issue_sync_read_todo_blob "$repo_path" "$sync_sha" "$sync_todo" || return 1
-	issue_sync_prune_concurrent_task_additions "${state_dir}/merged-todo" \
+	issue_sync_find_concurrent_task_additions "${state_dir}/merged-todo" \
 		"$sync_ancestor" "$sync_todo" "$state_dir" || return 1
 	issue_sync_merge_todo_file "${state_dir}/merged-todo" "$sync_ancestor" "$sync_todo" || return 1
+	issue_sync_dedupe_concurrent_task_additions "${state_dir}/merged-todo" "$state_dir" || return 1
 	return 0
 }
 

--- a/.agents/scripts/issue-sync-git-push-helper.sh
+++ b/.agents/scripts/issue-sync-git-push-helper.sh
@@ -163,6 +163,51 @@ issue_sync_merge_todo_file() {
 	return 0
 }
 
+issue_sync_task_ids() {
+	local todo_file="$1"
+	sed -nE 's/^[[:space:]]*- \[[ x-]\][[:space:]]+([tr][0-9]+(\.[0-9]+)*)([[:space:]].*|$)/\1/p' \
+		"$todo_file" | LC_ALL=C sort -u
+	return 0
+}
+
+# A stale deterministic branch and current main can independently add the same
+# logical task at different file locations. Keep the current canonical entry;
+# unique branch additions still flow through the subsequent three-way merge.
+issue_sync_prune_concurrent_task_additions() {
+	local current_file="$1"
+	local ancestor_file="$2"
+	local incoming_file="$3"
+	local state_dir="$4"
+	local current_ids="${state_dir}/current-task-ids"
+	local ancestor_ids="${state_dir}/ancestor-task-ids"
+	local incoming_ids="${state_dir}/incoming-task-ids"
+	local overlapping_ids="${state_dir}/overlapping-task-ids"
+	local concurrent_ids="${state_dir}/concurrent-task-additions"
+	local filtered_incoming="${state_dir}/filtered-sync-todo"
+	local line=""
+	local task_id=""
+
+	issue_sync_task_ids "$current_file" >"$current_ids" || return 1
+	issue_sync_task_ids "$ancestor_file" >"$ancestor_ids" || return 1
+	issue_sync_task_ids "$incoming_file" >"$incoming_ids" || return 1
+	comm -12 "$current_ids" "$incoming_ids" >"$overlapping_ids" || return 1
+	comm -23 "$overlapping_ids" "$ancestor_ids" >"$concurrent_ids" || return 1
+	[[ -s "$concurrent_ids" ]] || return 0
+
+	: >"$filtered_incoming" || return 1
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		task_id=$(printf '%s\n' "$line" |
+			sed -nE 's/^[[:space:]]*- \[[ x-]\][[:space:]]+([tr][0-9]+(\.[0-9]+)*)([[:space:]].*|$)/\1/p')
+		if [[ -n "$task_id" ]] && grep -Fxq -- "$task_id" "$concurrent_ids"; then
+			continue
+		fi
+		printf '%s\n' "$line" >>"$filtered_incoming" || return 1
+	done <"$incoming_file"
+	mv "$filtered_incoming" "$incoming_file" || return 1
+	echo "::notice::Current TODO.md entries supersede stale issue-sync additions for matching task IDs"
+	return 0
+}
+
 issue_sync_read_todo_blob() {
 	local repo_path="$1"
 	local commit_sha="$2"
@@ -265,6 +310,8 @@ issue_sync_prepare_pr_snapshot() {
 	sync_base=$(issue_sync_git -C "$repo_path" merge-base "$ISSUE_SYNC_BASE_SHA" "$sync_sha") || return 1
 	issue_sync_read_todo_blob "$repo_path" "$sync_base" "$sync_ancestor" || return 1
 	issue_sync_read_todo_blob "$repo_path" "$sync_sha" "$sync_todo" || return 1
+	issue_sync_prune_concurrent_task_additions "${state_dir}/merged-todo" \
+		"$sync_ancestor" "$sync_todo" "$state_dir" || return 1
 	issue_sync_merge_todo_file "${state_dir}/merged-todo" "$sync_ancestor" "$sync_todo" || return 1
 	return 0
 }

--- a/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
+++ b/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
@@ -442,8 +442,9 @@ EOF
 	git -C "$seed_dir" commit -m "stale issue-sync task addition" >/dev/null
 	git -C "$seed_dir" push origin HEAD:"$sync_ref" >/dev/null
 	git -C "$seed_dir" checkout main >/dev/null
-	perl -0pi -e 's/## First queue\n/## First queue\n\n- [ ] t9004 canonical task with richer metadata #priority:high ref:GH#9004\n\n- [>] t9005 current in-progress task ref:GH#9005\n/' \
+	perl -0pi -e 's/## First queue\n/## First queue\n\n- [ ] t9004 canonical task with richer metadata #priority:high ref:GH#9004\n/' \
 		"$seed_dir/TODO.md"
+	printf '\n- [>] t9005 current in-progress task ref:GH#9005\n' >>"$seed_dir/TODO.md"
 	git -C "$seed_dir" add TODO.md
 	git -C "$seed_dir" commit -m "reviewed canonical task addition" >/dev/null
 	git -C "$seed_dir" push origin main >/dev/null
@@ -510,6 +511,44 @@ EOF
 		fail "task ID snapshots parse live rows with controlled failures"
 	else
 		pass "task ID snapshots parse live rows with controlled failures"
+	fi
+	return 0
+}
+
+test_same_hunk_pseudo_task_preserves_live_branch_addition() {
+	local ancestor_file="$TMP/pseudo-ancestor.md"
+	local current_file="$TMP/pseudo-current.md"
+	local incoming_file="$TMP/pseudo-incoming.md"
+	local state_dir="$TMP/pseudo-state"
+	cat >"$ancestor_file" <<'EOF'
+## Queue
+
+- [ ] t9013 existing task ref:GH#9013
+EOF
+	cp "$ancestor_file" "$current_file"
+	cp "$ancestor_file" "$incoming_file"
+	cat >>"$current_file" <<'EOF'
+
+```text
+- [ ] t9014 fenced example ref:GH#9014
+```
+EOF
+	printf '\n- [ ] t9014 live stale-branch task ref:GH#9014\n' >>"$incoming_file"
+	mkdir -p "$state_dir"
+	if ! (
+		# shellcheck source=../issue-sync-git-push-helper.sh
+		source "$HELPER"
+		issue_sync_find_branch_task_additions "$ancestor_file" "$incoming_file" "$state_dir"
+		issue_sync_seed_branch_task_additions "$current_file" "$incoming_file" "$state_dir"
+		issue_sync_merge_todo_file "$current_file" "$ancestor_file" "$incoming_file"
+		issue_sync_dedupe_concurrent_task_additions "$current_file" "$state_dir"
+	); then
+		fail "same-hunk pseudo tasks do not replace live branch additions"
+	elif [[ "$(<"$current_file")" != *"t9014 fenced example"* ||
+	"$(<"$current_file")" != *"t9014 live stale-branch task"* ]]; then
+		fail "same-hunk pseudo tasks do not replace live branch additions"
+	else
+		pass "same-hunk pseudo tasks do not replace live branch additions"
 	fi
 	return 0
 }
@@ -842,6 +881,7 @@ test_rebase_conflict_neutralizes_cleanly
 test_protected_branch_uses_one_rebased_pr
 test_stale_pr_concurrent_task_addition_deduplicates
 test_task_id_snapshot_uses_only_live_rows
+test_same_hunk_pseudo_task_preserves_live_branch_addition
 test_shallow_checkout_recovers_stale_pr_history
 test_concurrent_pr_advance_rebuilds_snapshot
 test_pr_branch_deletion_during_fetch_rebuilds

--- a/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
+++ b/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
@@ -428,16 +428,21 @@ test_stale_pr_concurrent_task_addition_deduplicates() {
 	local output_file="$TMP/duplicate-output.log"
 	local sync_ref="refs/heads/aidevops/issue-sync-todo"
 	local remote_todo=""
-	local duplicate_count=0
+	local current_winner_count=0
+	local incoming_winner_count=0
 
 	create_origin "$origin_dir" "$seed_dir"
 	git -C "$seed_dir" checkout -b aidevops/issue-sync-todo >/dev/null
-	printf '\n- [ ] t9004 stale issue projection ref:GH#9004\n' >>"$seed_dir/TODO.md"
+	cat >>"$seed_dir/TODO.md" <<'EOF'
+
+- [ ] t9004 stale issue projection ref:GH#9004
+- [x] t9005 queued completion with proof ref:GH#9005 pr:#9005 completed:2026-08-07
+EOF
 	git -C "$seed_dir" add TODO.md
 	git -C "$seed_dir" commit -m "stale issue-sync task addition" >/dev/null
 	git -C "$seed_dir" push origin HEAD:"$sync_ref" >/dev/null
 	git -C "$seed_dir" checkout main >/dev/null
-	perl -0pi -e 's/## First queue\n/## First queue\n\n- [ ] t9004 canonical task with richer metadata #priority:high ref:GH#9004\n/' \
+	perl -0pi -e 's/## First queue\n/## First queue\n\n- [ ] t9004 canonical task with richer metadata #priority:high ref:GH#9004\n\n- [>] t9005 current in-progress task ref:GH#9005\n/' \
 		"$seed_dir/TODO.md"
 	git -C "$seed_dir" add TODO.md
 	git -C "$seed_dir" commit -m "reviewed canonical task addition" >/dev/null
@@ -456,15 +461,55 @@ test_stale_pr_concurrent_task_addition_deduplicates() {
 		return 0
 	fi
 	remote_todo=$(git --git-dir="$origin_dir" show "${sync_ref}:TODO.md")
-	duplicate_count=$(printf '%s\n' "$remote_todo" |
+	current_winner_count=$(printf '%s\n' "$remote_todo" |
 		grep -cE '^[[:space:]]*- \[[ x-]\][[:space:]]+t9004([[:space:]]|$)' || true)
-	if [[ "$duplicate_count" -ne 1 ||
+	incoming_winner_count=$(printf '%s\n' "$remote_todo" |
+		grep -cE '^[[:space:]]*- \[[ x>-]\][[:space:]]+t9005([[:space:]]|$)' || true)
+	if [[ "$current_winner_count" -ne 1 || "$incoming_winner_count" -ne 1 ||
 		"$remote_todo" != *"t9004 canonical task with richer metadata"* ||
 		"$remote_todo" == *"t9004 stale issue projection"* ||
+		"$remote_todo" != *"t9005 queued completion with proof"* ||
+		"$remote_todo" == *"t9005 current in-progress task"* ||
 		"$remote_todo" != *"t9002 current runner event"* ]]; then
 		fail "stale PR task additions defer to canonical task identity"
 	else
 		pass "stale PR task additions defer to canonical task identity"
+	fi
+	return 0
+}
+
+test_task_id_snapshot_uses_only_live_rows() {
+	local todo_file="$TMP/parser-todo.md"
+	local ids_file="$TMP/parser-task-ids"
+	cat >"$todo_file" <<'EOF'
+- [>] t9010 live in-progress task ref:GH#9010
+
+```text
+- [ ] t9011 fenced example ref:GH#9011
+```
+
+<!--
+- [ ] t9012 commented example ref:GH#9012
+-->
+EOF
+	if ! (
+		# shellcheck source=../issue-sync-git-push-helper.sh
+		source "$HELPER"
+		issue_sync_task_ids "$todo_file" >"$ids_file"
+	); then
+		fail "task ID snapshots parse live rows with controlled failures"
+		return 0
+	fi
+	if [[ "$(<"$ids_file")" != "t9010" ]]; then
+		fail "task ID snapshots parse live rows with controlled failures"
+	elif (
+		# shellcheck source=../issue-sync-git-push-helper.sh
+		source "$HELPER"
+		issue_sync_task_ids "$TMP/missing-todo.md" >/dev/null 2>&1
+	); then
+		fail "task ID snapshots parse live rows with controlled failures"
+	else
+		pass "task ID snapshots parse live rows with controlled failures"
 	fi
 	return 0
 }
@@ -796,6 +841,7 @@ test_successful_push
 test_rebase_conflict_neutralizes_cleanly
 test_protected_branch_uses_one_rebased_pr
 test_stale_pr_concurrent_task_addition_deduplicates
+test_task_id_snapshot_uses_only_live_rows
 test_shallow_checkout_recovers_stale_pr_history
 test_concurrent_pr_advance_rebuilds_snapshot
 test_pr_branch_deletion_during_fetch_rebuilds

--- a/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
+++ b/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
@@ -418,6 +418,57 @@ test_protected_branch_uses_one_rebased_pr() {
 	return 0
 }
 
+test_stale_pr_concurrent_task_addition_deduplicates() {
+	local origin_dir="$TMP/duplicate-origin.git"
+	local seed_dir="$TMP/duplicate-seed"
+	local work_dir="$TMP/duplicate-work"
+	local fake_bin="$TMP/duplicate-bin"
+	local gh_log="$TMP/duplicate-gh.log"
+	local pr_marker="$TMP/duplicate-pr.marker"
+	local output_file="$TMP/duplicate-output.log"
+	local sync_ref="refs/heads/aidevops/issue-sync-todo"
+	local remote_todo=""
+	local duplicate_count=0
+
+	create_origin "$origin_dir" "$seed_dir"
+	git -C "$seed_dir" checkout -b aidevops/issue-sync-todo >/dev/null
+	printf '\n- [ ] t9004 stale issue projection ref:GH#9004\n' >>"$seed_dir/TODO.md"
+	git -C "$seed_dir" add TODO.md
+	git -C "$seed_dir" commit -m "stale issue-sync task addition" >/dev/null
+	git -C "$seed_dir" push origin HEAD:"$sync_ref" >/dev/null
+	git -C "$seed_dir" checkout main >/dev/null
+	perl -0pi -e 's/## First queue\n/## First queue\n\n- [ ] t9004 canonical task with richer metadata #priority:high ref:GH#9004\n/' \
+		"$seed_dir/TODO.md"
+	git -C "$seed_dir" add TODO.md
+	git -C "$seed_dir" commit -m "reviewed canonical task addition" >/dev/null
+	git -C "$seed_dir" push origin main >/dev/null
+	git clone "$origin_dir" "$work_dir" >/dev/null 2>&1
+	git_init_repo "$work_dir"
+	write_fake_gh "$fake_bin"
+	install_main_rejection_hook "$origin_dir" gh006
+	: >"$gh_log"
+	: >"$pr_marker"
+	perl -0pi -e 's/t9002 second task/t9002 current runner event/' "$work_dir/TODO.md"
+	if ! run_issue_sync_helper "$work_dir" "$fake_bin" "$gh_log" "$pr_marker" \
+		"$TMP/duplicate-head" "$TMP/duplicate-title" "$output_file" 3; then
+		printf 'Concurrent task-addition output:\n%s\n' "$(<"$output_file")" >&2
+		fail "stale PR task additions defer to canonical task identity"
+		return 0
+	fi
+	remote_todo=$(git --git-dir="$origin_dir" show "${sync_ref}:TODO.md")
+	duplicate_count=$(printf '%s\n' "$remote_todo" |
+		grep -cE '^[[:space:]]*- \[[ x-]\][[:space:]]+t9004([[:space:]]|$)' || true)
+	if [[ "$duplicate_count" -ne 1 ||
+		"$remote_todo" != *"t9004 canonical task with richer metadata"* ||
+		"$remote_todo" == *"t9004 stale issue projection"* ||
+		"$remote_todo" != *"t9002 current runner event"* ]]; then
+		fail "stale PR task additions defer to canonical task identity"
+	else
+		pass "stale PR task additions defer to canonical task identity"
+	fi
+	return 0
+}
+
 test_shallow_checkout_recovers_stale_pr_history() {
 	local origin_dir="$TMP/shallow-origin.git"
 	local seed_dir="$TMP/shallow-seed"
@@ -744,6 +795,7 @@ test_noop_publishes_nothing() {
 test_successful_push
 test_rebase_conflict_neutralizes_cleanly
 test_protected_branch_uses_one_rebased_pr
+test_stale_pr_concurrent_task_addition_deduplicates
 test_shallow_checkout_recovers_stale_pr_history
 test_concurrent_pr_advance_rebuilds_snapshot
 test_pr_branch_deletion_during_fetch_rebuilds


### PR DESCRIPTION
## Summary

Implementation for issue #29679.

## Files Changed

.agents/scripts/issue-sync-git-push-helper.sh, .agents/scripts/tests/test-issue-sync-git-push-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #29679


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.232 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 5h 32m and 2,237,668 tokens on this with the user in an interactive session.