### PR TITLE
chore: sync GitHub issue state to TODO.md [skip ci]

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1226,7 +1226,7 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18209 Implement provider-neutral routing, observability, and completion feedback #feat #models #observability #interactive #priority:high ~4h tier:thinking ref:GH#29674 assignee:marcusquinn started:2026-08-07T02:34:27Z -> [todo/tasks/t18209-brief.md]
 
-- [ ] t18210 Verify protected issue-sync fallback and reconcile historical completion proof #bug #framework #interactive #no-auto-dispatch ref:GH#29679
+- [x] t18210 Verify protected issue-sync fallback and reconcile historical completion proof #bug #framework #interactive #no-auto-dispatch ref:GH#29679 pr:#29704 completed:2026-08-07
 
 ## In Progress
 


### PR DESCRIPTION
<!-- aidevops:issue-sync-todo-pr -->
## Issue-sync TODO publication

- Publishes the cumulative `TODO.md` projection through a pull request because `main` rejected direct publication with GH006.
- Uses the deterministic `aidevops/issue-sync-todo` branch so retries and concurrent events update one PR.
- Rebases the projection onto current `main` while preserving unrelated TODO changes already queued in this PR.
- Latest publication intent: `chore: mark t18210 complete (pr:#29704 completed:2026-08-07)`.

## Linkage

- Ref #29679
- Ref #29704
## Merge behaviour

- The PR title retains `[skip ci]` so the eventual squash commit does not start another issue-sync loop.
- The PR branch commit intentionally omits `[skip ci]` so required pull-request checks still run.
- Canonical task and forge linkage remains in the projected `ref:GH#...` and `pr:#...` metadata.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.232 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 6h 55m and 2,612,447 tokens on this with the user in an interactive session.