### PR TITLE
GH#29708: Preserve worker ownership through manual dispatch readiness

### DIFF
--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -70,6 +70,8 @@ _DSI_DISPATCH_BASE_BRANCH=""
 _DSI_STATE_RECOVERING="recovering"
 _DSI_UNKNOWN_VALUE="<unknown>"
 _DSI_JSON_TRUE="true"
+_DSI_DEFAULT_CANARY_TIMEOUT_SECONDS=180
+_DSI_READY_PREPARATION_ALLOWANCE_SECONDS=60
 _DSI_CLAIM_WON=0
 _DSI_CLAIM_COMMENT_ID=""
 _DSI_TARGET_JSON=""
@@ -925,6 +927,26 @@ _dsi_detached_runtime_log() {
 }
 
 #######################################
+# Resolve the bounded manual-dispatch readiness budget.
+# The detached worker may spend the full canary allowance before preparation
+# emits worker_started, so the default must cover canary plus setup overhead.
+# Stdout: timeout seconds
+#######################################
+_dsi_ready_timeout_seconds() {
+	local canary_timeout_s="${CANARY_TIMEOUT_SECONDS:-$_DSI_DEFAULT_CANARY_TIMEOUT_SECONDS}"
+	local configured_timeout_s="${AIDEVOPS_DSI_READY_TIMEOUT_SECONDS:-}"
+	if ! [[ "$canary_timeout_s" =~ ^[0-9]+$ ]]; then
+		canary_timeout_s="$_DSI_DEFAULT_CANARY_TIMEOUT_SECONDS"
+	fi
+	local default_timeout_s=$((canary_timeout_s + _DSI_READY_PREPARATION_ALLOWANCE_SECONDS))
+	if [[ -z "$configured_timeout_s" ]] || ! [[ "$configured_timeout_s" =~ ^[0-9]+$ ]]; then
+		configured_timeout_s="$default_timeout_s"
+	fi
+	printf '%s\n' "$configured_timeout_s"
+	return 0
+}
+
+#######################################
 # Wait until a detached worker reaches an observable readiness signal.
 #
 # The outer nohup wrapper can exit successfully before model selection,
@@ -949,14 +971,10 @@ _dsi_wait_for_worker_readiness() {
 	local launcher_log="$5"
 	local runtime_log
 	runtime_log=$(_dsi_detached_runtime_log "$session_key")
-	local timeout_s="${AIDEVOPS_DSI_READY_TIMEOUT_SECONDS:-20}"
+	local timeout_s
+	timeout_s=$(_dsi_ready_timeout_seconds)
 	local attempts=0
-	local max_attempts=200
-
-	if ! [[ "$timeout_s" =~ ^[0-9]+$ ]]; then
-		timeout_s=20
-	fi
-	max_attempts=$((timeout_s * 10))
+	local max_attempts=$((timeout_s * 10))
 
 	while [[ "$attempts" -le "$max_attempts" ]]; do
 		if [[ -s "$runtime_log" ]] &&

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -1247,6 +1247,26 @@ test_create_worktree_registration_warns_on_failure() {
 	return 0
 }
 
+test_readiness_timeout_tracks_canary_budget() {
+	local default_timeout="" custom_canary_timeout="" explicit_timeout="" invalid_timeout=""
+	default_timeout=$(
+		unset AIDEVOPS_DSI_READY_TIMEOUT_SECONDS CANARY_TIMEOUT_SECONDS
+		_dsi_ready_timeout_seconds
+	)
+	custom_canary_timeout=$(CANARY_TIMEOUT_SECONDS=42 _dsi_ready_timeout_seconds)
+	explicit_timeout=$(CANARY_TIMEOUT_SECONDS=180 AIDEVOPS_DSI_READY_TIMEOUT_SECONDS=0 _dsi_ready_timeout_seconds)
+	invalid_timeout=$(CANARY_TIMEOUT_SECONDS=invalid AIDEVOPS_DSI_READY_TIMEOUT_SECONDS=invalid _dsi_ready_timeout_seconds)
+
+	local passed=1
+	if [[ "$default_timeout" == "240" && "$custom_canary_timeout" == "102" &&
+		"$explicit_timeout" == "0" && "$invalid_timeout" == "240" ]]; then
+		passed=0
+	fi
+	print_result "readiness timeout covers canary budget and preserves overrides" "$passed" \
+		"default=$default_timeout custom=$custom_canary_timeout explicit=$explicit_timeout invalid=$invalid_timeout"
+	return 0
+}
+
 
 test_readiness_accepts_worker_started_marker() {
 	MOCK_LEDGER_RECORD=""
@@ -1463,6 +1483,7 @@ _run_tests() {
 	test_dispatch_base_ref_prefers_repo_configured_pr_base
 	test_dispatch_base_ref_prefers_explicit_env_ref
 	test_create_worktree_registration_warns_on_failure
+	test_readiness_timeout_tracks_canary_budget
 	test_readiness_accepts_worker_started_marker
 	test_readiness_rejects_live_child_without_ready_signal
 	test_readiness_rejects_ledger_without_worker_started

--- a/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-single-issue-helper.sh
@@ -1267,7 +1267,6 @@ test_readiness_timeout_tracks_canary_budget() {
 	return 0
 }
 
-
 test_readiness_accepts_worker_started_marker() {
 	MOCK_LEDGER_RECORD=""
 	local session_key="manual-cli-ready-$$"


### PR DESCRIPTION
## Summary

Derive the default manual-dispatch readiness timeout from the canary budget plus a bounded preparation allowance; preserve explicit zero overrides and safe fallbacks for invalid values.

## Files Changed

.agents/scripts/dispatch-single-issue-helper.sh, .agents/scripts/tests/test-dispatch-single-issue-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 78/78 dispatch helper tests under macOS /bin/bash 3.2; bash -n; ShellCheck; git diff --check; linters-local.sh; independent closeout review CLEAN.

Resolves #29708


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.232 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 13h 45m and 5,079,647 tokens on this with the user in an interactive session.