### PR TITLE
GH#29691: fix: skip cost breaker for completed issues

### DIFF
--- a/.agents/scripts/dispatch-dedup-cost.sh
+++ b/.agents/scripts/dispatch-dedup-cost.sh
@@ -340,6 +340,19 @@ _check_cost_budget() {
 		return 1
 	fi
 
+	# GH#29691: assignment inspection can run while completion reconciliation is
+	# still removing a task from the dispatch projection.  A completed worker's
+	# footer may exceed the budget, but terminal work cannot consume another
+	# dispatch and must not be relabelled or spawn a root-cause meta-issue.  Check
+	# the metadata already fetched by is_assigned() before the side-effectful cost
+	# path.  The direct diagnostic command omits metadata and retains its existing
+	# aggregation behaviour.
+	if [[ -n "$issue_meta_json" ]] && printf '%s' "$issue_meta_json" |
+		jq -e '((.state // "" | ascii_downcase) == "closed") or any(.labels[]?.name; . == "status:done" or . == "status:resolved")' \
+			>/dev/null 2>&1; then
+		return 1
+	fi
+
 	local budget
 	budget=$(_get_cost_budget_for_tier "$tier")
 	if [[ -z "$budget" ]] || ! [[ "$budget" =~ ^[0-9]+$ ]]; then

--- a/.agents/scripts/tests/test-cost-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-cost-circuit-breaker.sh
@@ -406,6 +406,26 @@ else
 	print_result "signed approval resets cost aggregation window" 1 "(got: '$sum_output')"
 fi
 
+# =============================================================================
+# Assertion 12 — completed issues never trigger cost-breaker side effects
+# =============================================================================
+# Completion reconciliation can inspect an issue after its successful worker
+# footer has crossed the token budget.  The assignment guard must not relabel
+# terminal work or file a circuit-breaker meta-issue during that window.
+: >"$STUB_LOG"
+write_fixture_issue '[{"name":"tier:thinking"},{"name":"status:done"}]' '[]' 'CLOSED'
+write_fixture_comments "948278"
+terminal_output=$(ISSUE_META_JSON="$(<"$FIXTURE_ISSUE_JSON")" \
+	"$DEDUP_HELPER" is-assigned 18012 "owner/repo" 2>/dev/null)
+terminal_rc=$?
+if [[ "$terminal_rc" -eq 1 && -z "$terminal_output" ]] &&
+	! grep -qE '^issue (edit|comment) ' "$STUB_LOG"; then
+	print_result "completed issue skips over-budget breaker side effects" 0
+else
+	print_result "completed issue skips over-budget breaker side effects" 1 \
+		"(rc=$terminal_rc output='$terminal_output' stub_log=$(tr '\n' ' ' <"$STUB_LOG" 2>/dev/null))"
+fi
+
 export PATH="$OLD_PATH"
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Root cause: dispatch-dedup-cost.sh::_check_cost_budget evaluated the successful worker's 948,278-token footer while original issue #29679 was already CLOSED with status:done, so assignment inspection applied status:blocked and filed a false t2007 meta-issue. Terminal state is now checked from the already-fetched assignment metadata before token aggregation or any breaker side effects. Resolves #29691.

## Files Changed

.agents/scripts/dispatch-dedup-cost.sh, .agents/scripts/tests/test-cost-circuit-breaker.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-cost-circuit-breaker.sh; bash .agents/scripts/tests/test-circuit-breaker-meta-filer.sh; bash .agents/scripts/tests/test-dispatch-dedup-stale-pagination.sh; .agents/scripts/linters-local.sh --changed; shellcheck .agents/scripts/dispatch-dedup-cost.sh .agents/scripts/tests/test-cost-circuit-breaker.sh

Resolves #29691


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.232 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 12m and 124,091 tokens on this as a headless worker.