### PR TITLE
GH#29712: keep unrelated tool updates explicit

### DIFF
--- a/.agents/scripts/aidevops-cli/aidevops-update-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-update-lib.sh
@@ -279,11 +279,6 @@ _update_check_planning() {
 _update_check_tools() {
 	echo ""
 	print_header "Checking Key Tools"
-	local tool_check_script="$AGENTS_DIR/scripts/tool-version-check.sh"
-	if [[ ! -f "$tool_check_script" ]]; then
-		print_info "Tool version check not available (run setup first)"
-		return 0
-	fi
 	local stale_count=0 stale_tools=""
 	local key_tool_cmds="opencode gh"
 	local key_tool_pkgs="opencode-ai brew:gh"
@@ -306,7 +301,7 @@ _update_check_tools() {
 		local pkg_ref
 		pkg_ref=$(echo "$key_tool_pkgs" | cut -d' ' -f$((idx + 1)))
 		idx=$((idx + 1))
-		local installed="" latest=""
+		local installed="" latest="" approved=""
 		command -v "$cmd_name" &>/dev/null || continue
 		installed=$("$cmd_name" --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
 		[[ -z "$installed" ]] && continue
@@ -319,8 +314,12 @@ _update_check_tools() {
 			elif [[ "$brew_pkg" == "gh" ]] && command -v gh &>/dev/null; then latest=$(get_public_release_tag "cli/cli"); fi
 		else latest=$(_timeout_cmd 30 npm view "$pkg_ref" version || true); fi
 		[[ -z "$latest" ]] && continue
-		[[ "$installed" != "$latest" ]] && {
-			stale_tools="${stale_tools:+$stale_tools, }$cmd_name ($installed -> $latest)"
+		approved="$latest"
+		if [[ "$cmd_name" == "opencode" && "${OPENCODE_PINNED_VERSION:-latest}" != "latest" ]]; then
+			approved="$OPENCODE_PINNED_VERSION"
+		fi
+		[[ "$installed" != "$approved" ]] && {
+			stale_tools="${stale_tools:+$stale_tools, }$cmd_name ($installed -> $approved)"
 			((++stale_count))
 		}
 	done
@@ -329,8 +328,7 @@ _update_check_tools() {
 	else
 		print_warning "$stale_count tool(s) have updates: $stale_tools"
 		echo ""
-		read -r -p "Run full tool update check? [y/N] " response
-		[[ "$response" =~ ^[Yy]$ ]] && bash "$tool_check_script" --update || print_info "Run 'aidevops update-tools --update' to update later"
+		print_info "No global tools were changed; run 'aidevops update-tools --update' to update explicitly"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-aidevops-update-tool-reporting.sh
+++ b/.agents/scripts/tests/test-aidevops-update-tool-reporting.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for GH#29712: the default aidevops update path reports
+# key-tool drift without prompting or mutating unrelated global tools.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+UPDATE_LIB="$REPO_ROOT/.agents/scripts/aidevops-cli/aidevops-update-lib.sh"
+TEST_TMP_PARENT="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+mkdir -p "$TEST_TMP_PARENT"
+SANDBOX="$(mktemp -d "${TEST_TMP_PARENT}/gh29712-XXXXXX")"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+SYSTEM_PATH="$PATH"
+PASS_COUNT=0
+FAIL_COUNT=0
+REPORT_OUTPUT=""
+REPORT_RC=0
+MUTATION_LOG="$SANDBOX/state/mutation-calls"
+
+pass() {
+	local name="$1"
+	printf 'PASS: %s\n' "$name"
+	PASS_COUNT=$((PASS_COUNT + 1))
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="$2"
+	printf 'FAIL: %s — %s\n' "$name" "$detail" >&2
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	return 0
+}
+
+assert_eq() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected ${expected}, got ${actual}"
+	fi
+	return 0
+}
+
+assert_contains() {
+	local name="$1"
+	local needle="$2"
+	local haystack="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		pass "$name"
+	else
+		fail "$name" "missing ${needle}"
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local name="$1"
+	local needle="$2"
+	local haystack="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		fail "$name" "unexpected ${needle}"
+	else
+		pass "$name"
+	fi
+	return 0
+}
+
+assert_no_mutation() {
+	local name="$1"
+	local calls=""
+	if [[ -s "$MUTATION_LOG" ]]; then
+		calls=$(<"$MUTATION_LOG")
+		fail "$name" "tool checker was invoked: ${calls}"
+	else
+		pass "$name"
+	fi
+	return 0
+}
+
+extract_function() {
+	local output_file="$1"
+	awk '
+		/^_update_check_tools\(\)[[:space:]]*\{/ { capturing = 1 }
+		capturing {
+			print
+			line = $0
+			open_count = gsub(/\{/, "", line)
+			line = $0
+			close_count = gsub(/\}/, "", line)
+			depth += open_count - close_count
+			if (depth == 0) exit
+		}
+	' "$UPDATE_LIB" >"$output_file"
+	if [[ ! -s "$output_file" ]]; then
+		printf 'FAIL: could not extract _update_check_tools\n' >&2
+		exit 1
+	fi
+	return 0
+}
+
+write_executable() {
+	local path="$1"
+	local body="$2"
+	mkdir -p "$(dirname "$path")"
+	printf '%s\n' "$body" >"$path"
+	chmod +x "$path"
+	return 0
+}
+
+set_versions() {
+	local opencode_installed="$1"
+	local opencode_registry="$2"
+	local gh_installed="$3"
+	local gh_registry="$4"
+	printf '%s\n' "$opencode_installed" >"$SANDBOX/state/opencode-installed"
+	printf '%s\n' "$opencode_registry" >"$SANDBOX/state/opencode-registry"
+	printf '%s\n' "$gh_installed" >"$SANDBOX/state/gh-installed"
+	printf '%s\n' "$gh_registry" >"$SANDBOX/state/gh-registry"
+	rm -f "$MUTATION_LOG"
+	return 0
+}
+
+run_report() {
+	local input="${1:-y}"
+	REPORT_RC=0
+	REPORT_OUTPUT=$(_update_check_tools <<<"$input" 2>&1) || REPORT_RC=$?
+	return 0
+}
+
+print_header() {
+	local message="$1"
+	printf 'HEADER %s\n' "$message"
+	return 0
+}
+
+print_info() {
+	local message="$1"
+	printf 'INFO %s\n' "$message"
+	return 0
+}
+
+print_warning() {
+	local message="$1"
+	printf 'WARN %s\n' "$message"
+	return 0
+}
+
+print_success() {
+	local message="$1"
+	printf 'OK %s\n' "$message"
+	return 0
+}
+
+_timeout_cmd() {
+	local timeout_seconds="$1"
+	shift
+	if [[ "$timeout_seconds" -lt 1 ]]; then
+		return 1
+	fi
+	if "$@"; then
+		return 0
+	fi
+	return 1
+}
+
+aidevops_gh_slurp_supported() {
+	return 0
+}
+
+get_public_release_tag() {
+	local repository="$1"
+	if [[ -n "$repository" ]]; then
+		return 1
+	fi
+	return 1
+}
+
+mkdir -p "$SANDBOX/state" "$SANDBOX/bin" "$SANDBOX/framework/scripts"
+export TOOL_REPORT_STATE_DIR="$SANDBOX/state"
+
+# shellcheck disable=SC2016 # Stub variables expand only when the generated script runs.
+write_executable "$SANDBOX/bin/opencode" '#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] || exit 1
+version=$(<"${TOOL_REPORT_STATE_DIR}/opencode-installed")
+printf "%s\n" "$version"'
+
+# shellcheck disable=SC2016 # Stub variables expand only when the generated script runs.
+write_executable "$SANDBOX/bin/gh" '#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] || exit 1
+version=$(<"${TOOL_REPORT_STATE_DIR}/gh-installed")
+printf "gh version %s\n" "$version"'
+
+# shellcheck disable=SC2016 # Stub variables expand only when the generated script runs.
+write_executable "$SANDBOX/bin/npm" '#!/usr/bin/env bash
+[[ "${1:-}" == "view" && "${2:-}" == "opencode-ai" ]] || exit 1
+latest=$(<"${TOOL_REPORT_STATE_DIR}/opencode-registry")
+[[ "$latest" != "failure" ]] || exit 1
+printf "%s\n" "$latest"'
+
+# shellcheck disable=SC2016 # Stub variables expand only when the generated script runs.
+write_executable "$SANDBOX/bin/brew" '#!/usr/bin/env bash
+[[ "${1:-}" == "info" && "${3:-}" == "gh" ]] || exit 1
+latest=$(<"${TOOL_REPORT_STATE_DIR}/gh-registry")
+[[ "$latest" != "failure" ]] || exit 1
+printf "{\"formulae\":[{\"versions\":{\"stable\":\"%s\"}}]}\n" "$latest"'
+
+# shellcheck disable=SC2016 # Stub variables expand only when the generated script runs.
+write_executable "$SANDBOX/framework/scripts/tool-version-check.sh" '#!/usr/bin/env bash
+printf "%s\n" "$*" >>"${TOOL_REPORT_STATE_DIR}/mutation-calls"'
+
+EXTRACTED_FUNCTION="$SANDBOX/update-check-tools.sh"
+extract_function "$EXTRACTED_FUNCTION"
+# shellcheck source=/dev/null
+source "$EXTRACTED_FUNCTION"
+FUNCTION_SOURCE=$(<"$EXTRACTED_FUNCTION")
+
+PATH="$SANDBOX/bin:$SYSTEM_PATH"
+export PATH
+AGENTS_DIR="$SANDBOX/framework"
+OPENCODE_PINNED_VERSION="1.18.9"
+
+assert_not_contains "source removes the interactive update prompt" \
+	'read -r -p "Run full tool update check?' "$FUNCTION_SOURCE"
+assert_not_contains "source removes the mutating tool-check call" \
+	"bash \"\$tool_check_script\" --update" "$FUNCTION_SOURCE"
+
+set_versions "1.18.9" "9.99.9" "2.99.0" "2.99.0"
+run_report "y"
+assert_eq "matching compatibility pin returns success" "0" "$REPORT_RC"
+assert_contains "matching compatibility pin is current" "OK Key tools are up to date" "$REPORT_OUTPUT"
+assert_not_contains "registry release does not override compatibility pin" "opencode (1.18.9 -> 9.99.9)" "$REPORT_OUTPUT"
+assert_no_mutation "matching compatibility pin does not mutate"
+
+set_versions "1.18.8" "9.99.9" "2.99.0" "2.99.0"
+run_report "y"
+assert_eq "older compatibility drift returns success" "0" "$REPORT_RC"
+assert_contains "older compatibility drift reports approved pin" "opencode (1.18.8 -> 1.18.9)" "$REPORT_OUTPUT"
+assert_contains "stale report names explicit update command" "aidevops update-tools --update" "$REPORT_OUTPUT"
+assert_contains "stale report confirms no mutation" "No global tools were changed" "$REPORT_OUTPUT"
+assert_not_contains "stale report has no full-update prompt" "Run full tool update check?" "$REPORT_OUTPUT"
+assert_no_mutation "affirmative stdin cannot trigger mutation"
+
+set_versions "1.19.0" "9.99.9" "2.99.0" "2.99.0"
+run_report "y"
+assert_contains "newer compatibility drift reports approved pin" "opencode (1.19.0 -> 1.18.9)" "$REPORT_OUTPUT"
+assert_no_mutation "newer compatibility drift does not mutate"
+
+set_versions "1.18.9" "9.99.9" "2.98.0" "2.99.0"
+run_report "y"
+assert_contains "GitHub CLI drift remains visible" "gh (2.98.0 -> 2.99.0)" "$REPORT_OUTPUT"
+assert_no_mutation "GitHub CLI drift does not mutate"
+
+set_versions "1.18.9" "failure" "2.99.0" "failure"
+run_report "y"
+assert_eq "registry lookup failures remain non-fatal" "0" "$REPORT_RC"
+assert_no_mutation "registry lookup failures do not mutate"
+
+printf '%s passed, %s failed\n' "$PASS_COUNT" "$FAIL_COUNT"
+if [[ "$FAIL_COUNT" -ne 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Keep default framework updates report-only for unrelated global tools, classify OpenCode against the approved compatibility pin, and preserve the explicit update-tools mutation route.

## Files Changed

.agents/scripts/aidevops-cli/aidevops-update-lib.sh, .agents/scripts/tests/test-aidevops-update-tool-reporting.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — 18 focused reporting assertions passed; 16 OpenCode compatibility assertions passed; 16 update transaction assertions passed; ShellCheck clean; linters-local.sh --changed passed.

Resolves #29712


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.232 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1d 18h and 6,254,831 tokens on this with the user in an interactive session.