### PR TITLE
GH#29714: fix: sign issue-close comments

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature-detection.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature-detection.mjs
@@ -50,10 +50,18 @@ function isCommentOrGitCommit(trimmedLine) {
   return trimmedLine.startsWith("#") || /\bgit\s+commit\b/.test(trimmedLine);
 }
 
-function lineHasGhWriteCommand(line, ghWritePattern) {
+function lineHasGhWriteCommand(line, ghWritePattern, ghIssueClosePattern) {
   const trimmed = line.trim();
   if (isCommentOrGitCommit(trimmed)) return false;
-  return ghWritePattern.test(stripQuotedStrings(trimmed));
+  const command = stripQuotedStrings(trimmed);
+  if (ghWritePattern.test(command)) return true;
+  // A close without a comment is a state-only mutation and must retain native
+  // behaviour. A close with --comment/-c publishes content and therefore needs
+  // the same signature gate as issue comment/create.
+  return (
+    ghIssueClosePattern.test(command) &&
+    /(?:^|\s)(?:--comment(?:=|\s)|-c(?:=|\s))/.test(command)
+  );
 }
 
 /**
@@ -65,9 +73,11 @@ export function isGhWriteCommand(cmd) {
   if (typeof cmd !== "string") return false;
   const ghWritePattern =
     /(^|[;&|(`!]|\$\()\s*(?:(?:sudo|time|env(?:\s+\w+=\S+)*)\s+)*gh\s+(pr\s+(create|comment)|issue\s+(create|comment))\b/;
+  const ghIssueClosePattern =
+    /(^|[;&|(`!]|\$\()\s*(?:(?:sudo|time|env(?:\s+\w+=\S+)*)\s+)*gh\s+issue\s+close\b/;
   return stripHeredocBodies(cmd)
     .split("\n")
-    .some((line) => lineHasGhWriteCommand(line, ghWritePattern));
+    .some((line) => lineHasGhWriteCommand(line, ghWritePattern, ghIssueClosePattern));
 }
 
 /**

--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
@@ -4,8 +4,9 @@
 // ---------------------------------------------------------------------------
 // Signature footer gate (GH#12805, t1755, t2685, t2893)
 // ---------------------------------------------------------------------------
-// Enforces that every `gh issue create|comment` and `gh pr create|comment`
-// command posts a body ending with the canonical aidevops signature footer.
+// Enforces that every `gh issue create|comment`, comment-bearing `gh issue
+// close`, and `gh pr create|comment` command posts content ending with the
+// canonical aidevops signature footer.
 // Extracted from quality-hooks.mjs (t2685) to keep the main module below
 // the qlty file-complexity ratchet.
 //
@@ -127,17 +128,17 @@ function _generateSignature(helperPath, bodyValue, log, options = {}) {
  * @returns {boolean}
  */
 function _hasUnparseableBody(cmd) {
-  const bodyStart = cmd.search(/--body(?:-file)?(?:=|\s)/);
+  const bodyStart = cmd.search(/(?:--(?:body(?:-file)?|comment)|-c)(?:=|\s)/);
   const afterBody = bodyStart === -1 ? "" : cmd.slice(bodyStart);
   return (
-    /--body(?:-file)?\s*=?\s*(?:<<-?\s*['"]?\w+|<\()/.test(cmd) ||
+    /(?:--(?:body(?:-file)?|comment)|-c)\s*=?\s*(?:<<-?\s*['"]?\w+|<\()/.test(cmd) ||
     afterBody.includes("$(") ||
     /`[^`]*`/.test(afterBody)
   );
 }
 
 /**
- * Match the `--body "value"` / `--body 'value'` / `--body=QUOTED` forms.
+ * Match `--body` and issue-close `--comment`/`-c` value forms.
  * Returns { match, bodyValue, quote } on the first match, or null.
  *
  * Returning null is "no body arg matched" — distinct from a structured
@@ -148,9 +149,9 @@ function _hasUnparseableBody(cmd) {
  */
 function _matchBodyArg(cmd) {
   const patterns = [
-    { re: /--body\s+"((?:[^"\\]|\\.)*)"/, quote: '"' },
-    { re: /--body\s+'((?:[^'\\]|\\.)*)'/, quote: "'" },
-    { re: /--body=(['"])((?:(?!\1).)*)\1/, quote: null },
+    { re: /(?:--(?:body|comment)|-c)\s+"((?:[^"\\]|\\.)*)"/, quote: '"' },
+    { re: /(?:--(?:body|comment)|-c)\s+'((?:[^'\\]|\\.)*)'/, quote: "'" },
+    { re: /(?:--(?:body|comment)|-c)=(['"])((?:(?!\1).)*)\1/, quote: null },
   ];
   for (const pat of patterns) {
     const m = cmd.match(pat.re);
@@ -163,8 +164,8 @@ function _matchBodyArg(cmd) {
 }
 
 /**
- * Repair a `--body "VALUE"` form by rewriting the command with sig-augmented
- * body.
+ * Repair an inline content form by rewriting it with a signature-augmented
+ * body/comment.
  *
  * Returns `{ status: "ok", cmd }` on success or
  * `{ status: "fail", reason, detail }` when the helper failed or the
@@ -199,7 +200,8 @@ function _repairBodyArg(cmd, parsed, helperPath, log, options = {}) {
 
 /**
  * Attempt to append the canonical signature footer to the command's body.
- * Handles `--body "value"`, `--body=value`, and `--body-file path` forms.
+ * Handles `--body "value"`, `--body=value`, `--body-file path`, and
+ * issue-close `--comment`/`-c` forms.
  *
  * Returns a structured result so the throw site can name the specific
  * failure cause:

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -71,6 +71,16 @@ describe("isGhWriteCommand", () => {
     assert.equal(isGhWriteCommand('gh issue create --title "t" --body "x"'), true);
   });
 
+  test("detects comment-bearing gh issue close forms", () => {
+    assert.equal(isGhWriteCommand('gh issue close 1 --comment "x"'), true);
+    assert.equal(isGhWriteCommand('gh issue close 1 --comment="x"'), true);
+    assert.equal(isGhWriteCommand('gh issue close 1 -c "x"'), true);
+  });
+
+  test("leaves comment-free gh issue close outside content enforcement", () => {
+    assert.equal(isGhWriteCommand('gh issue close 1 --reason completed'), false);
+  });
+
   test("detects gh pr create", () => {
     assert.equal(isGhWriteCommand('gh pr create --title "t" --body "x"'), true);
   });
@@ -300,6 +310,31 @@ describe("tryRepairSignature", () => {
     assert.equal(out.status, "ok");
     assert.ok(out.cmd.includes(SIG_MARKER));
     assert.ok(out.cmd.includes("hello"));
+  });
+
+  test("repairs all issue-close comment forms without changing close flags", () => {
+    const dir = setupStubHelper();
+    const { log } = makeLogger();
+    for (const cmd of [
+      'gh issue close 1 --repo o/r --reason completed --comment "hello"',
+      'gh issue close 1 --repo o/r --reason completed --comment="hello"',
+      'gh issue close 1 --repo o/r --reason completed -c "hello"',
+    ]) {
+      const out = tryRepairSignature(cmd, dir, log);
+      assert.equal(out.status, "ok");
+      assert.ok(out.cmd.includes(SIG_MARKER));
+      assert.ok(out.cmd.includes("--reason completed"));
+    }
+  });
+
+  test("repairs a chained issue close without splitting its one-shot mutation", () => {
+    const dir = setupStubHelper();
+    const { log } = makeLogger();
+    const cmd = 'git status --short && gh issue close 1 --repo o/r --comment "hello"';
+    const out = tryRepairSignature(cmd, dir, log);
+    assert.equal(out.status, "ok");
+    assert.ok(out.cmd.startsWith("git status --short && gh issue close"));
+    assert.ok(out.cmd.includes(SIG_MARKER));
   });
 
   test("appends sig to --body-file on disk", () => {
@@ -833,6 +868,15 @@ describe("tryRepairSignature structured failures (t2893)", () => {
     const dir = setupStubHelper();
     const { log } = makeLogger();
     const cmd = 'gh issue comment 1 --body-file <(echo "dynamic")';
+    const out = tryRepairSignature(cmd, dir, log);
+    assert.equal(out.status, "fail");
+    assert.equal(out.reason, FAIL_REASON.UNPARSEABLE_BODY);
+  });
+
+  test("UNPARSEABLE_BODY: command-substitution issue-close comment", () => {
+    const dir = setupStubHelper();
+    const { log } = makeLogger();
+    const cmd = 'gh issue close 1 --comment "$(build-comment)"';
     const out = tryRepairSignature(cmd, dir, log);
     assert.equal(out.status, "fail");
     assert.equal(out.reason, FAIL_REASON.UNPARSEABLE_BODY);

--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -6,9 +6,10 @@
 #            + GraphQL→REST read rewriting under low budget (t3037)
 # =============================================================================
 #
-# Intercepts GitHub content writes (`gh issue/pr create|edit|comment|review`
+# Intercepts GitHub content writes (`gh issue/pr create|edit|comment|close|review`
 # and selected `gh api` REST write endpoints), calls
 # gh-signature-helper.sh footer, and appends the footer to --body / --body-file
+# / issue-close --comment
 # when the canonical HTML marker `<!-- aidevops:sig -->` is missing. Every
 # other gh subcommand is passed straight through with minimal overhead.
 #
@@ -843,6 +844,9 @@ _body_eq=0
 _body_file_idx=-1
 _body_file_val=""
 _body_file_eq=0
+_comment_idx=-1
+_comment_val=""
+_comment_eq=0
 
 while [[ $_i -lt ${#_modified_args[@]} ]]; do
 	case "${_modified_args[_i]}" in
@@ -866,6 +870,26 @@ while [[ $_i -lt ${#_modified_args[@]} ]]; do
 		_body_file_val="${_modified_args[_i]#--body-file=}"
 		_body_file_eq=1
 		;;
+	--comment)
+		_comment_idx=$_i
+		_comment_val="${_modified_args[_i + 1]:-}"
+		_comment_eq=0
+		;;
+	--comment=*)
+		_comment_idx=$_i
+		_comment_val="${_modified_args[_i]#--comment=}"
+		_comment_eq=1
+		;;
+	-c)
+		_comment_idx=$_i
+		_comment_val="${_modified_args[_i + 1]:-}"
+		_comment_eq=0
+		;;
+	-c=*)
+		_comment_idx=$_i
+		_comment_val="${_modified_args[_i]#-c=}"
+		_comment_eq=1
+		;;
 	esac
 	_i=$((_i + 1))
 done
@@ -885,6 +909,25 @@ if [[ $_body_idx -ge 0 && -n "$_body_val" ]]; then
 				_modified_args[_body_idx]="--body=${_new_body}"
 			else
 				_modified_args[_body_idx + 1]="$_new_body"
+			fi
+		fi
+	fi
+fi
+
+# --- issue close --comment/-c case ------------------------------------------
+# Keep the close comment on the native close invocation so GitHub performs one
+# comment-and-close mutation. Splitting it into `issue comment && issue close`
+# would make retry recovery ambiguous if the first write succeeded and closure
+# failed. This mirrors --body signing while preserving every close-only flag.
+if [[ $_comment_idx -ge 0 && -n "$_comment_val" ]]; then
+	if ! grep -Fqx '<!-- aidevops:sig -->' <<<"$_comment_val"; then
+		_sig_footer=$("$SIG_HELPER" footer --body "$_comment_val" 2>/dev/null || echo "")
+		if [[ -n "$_sig_footer" ]]; then
+			_new_comment="${_comment_val}${_sig_footer}"
+			if [[ $_comment_eq -eq 1 ]]; then
+				_modified_args[_comment_idx]="--comment=${_new_comment}"
+			else
+				_modified_args[_comment_idx + 1]="$_new_comment"
 			fi
 		fi
 	fi

--- a/.agents/scripts/shared-gh-wrappers-safe-edit.sh
+++ b/.agents/scripts/shared-gh-wrappers-safe-edit.sh
@@ -423,12 +423,18 @@ gh_pr_edit_safe() {
 
 #######################################
 # gh_issue_close_safe — close a GitHub issue with audit logging.
-# Records before/after state in gh-audit.log.
+# Records before/after state in gh-audit.log. Comment-bearing close calls are
+# signed before the native one-shot close so retries cannot double-post.
 # All arguments are forwarded to gh issue close.
 # Returns the exit code of the underlying gh command.
 #######################################
 gh_issue_close_safe() {
+	_gh_wrapper_enter_cleanup_scope
 	gh_record_call graphql gh_issue_close_safe 2>/dev/null || true
+	if command -v _gh_wrapper_auto_sig >/dev/null 2>&1; then
+		_gh_wrapper_auto_sig "$@"
+		set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
+	fi
 	local _num _repo _before _after
 	_num="$(_gh_extract_number_from_args "$@")"
 	_repo="$(_gh_extract_repo_from_args "$@")"

--- a/.agents/scripts/shared-gh-wrappers-session.sh
+++ b/.agents/scripts/shared-gh-wrappers-session.sh
@@ -355,12 +355,17 @@ _gh_wrapper_auto_assignee() {
 	return 0
 }
 
-# t2115: Auto-append signature footer to --body/--body-file when missing.
+# t2115: Auto-append signature footer to --body/--body-file and issue-close
+# --comment/-c content when missing.
 # Populates global _GH_WRAPPER_SIG_MODIFIED_ARGS with the (possibly modified) args.
 # Callers should invoke _gh_wrapper_auto_sig "$@" then
 #   set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
 # Non-fatal: if signature generation fails, original args are preserved.
 _GH_WRAPPER_SIG_MODIFIED_ARGS=()
+_GH_WRAPPER_COMMENT_VAL=""
+_GH_WRAPPER_COMMENT_IDX=-1
+_GH_WRAPPER_COMMENT_IS_EQ=0
+_GH_WRAPPER_COMMENT_FLAG=""
 _gh_wrapper_abs_body_file_path() {
 	local body_file_path="$1"
 	[[ -z "$body_file_path" ]] && return 1
@@ -375,6 +380,63 @@ _gh_wrapper_abs_body_file_path() {
 	body_file_base=$(basename "$body_file_path") || return 1
 	body_file_dir=$(cd "$body_file_dir" 2>/dev/null && pwd) || return 1
 	printf '%s/%s\n' "$body_file_dir" "$body_file_base"
+	return 0
+}
+
+_gh_wrapper_collect_close_comment_arg() {
+	_GH_WRAPPER_COMMENT_VAL=""
+	_GH_WRAPPER_COMMENT_IDX=-1
+	_GH_WRAPPER_COMMENT_IS_EQ=0
+	_GH_WRAPPER_COMMENT_FLAG=""
+	local i=0
+	local -a args=("$@")
+	while [[ $i -lt ${#args[@]} ]]; do
+		case "${args[i]}" in
+		--comment)
+			_GH_WRAPPER_COMMENT_IDX=$i
+			_GH_WRAPPER_COMMENT_VAL="${args[i + 1]:-}"
+			_GH_WRAPPER_COMMENT_IS_EQ=0
+			_GH_WRAPPER_COMMENT_FLAG="--comment"
+			;;
+		--comment=*)
+			_GH_WRAPPER_COMMENT_IDX=$i
+			_GH_WRAPPER_COMMENT_VAL="${args[i]#--comment=}"
+			_GH_WRAPPER_COMMENT_IS_EQ=1
+			_GH_WRAPPER_COMMENT_FLAG="--comment"
+			;;
+		-c)
+			_GH_WRAPPER_COMMENT_IDX=$i
+			_GH_WRAPPER_COMMENT_VAL="${args[i + 1]:-}"
+			_GH_WRAPPER_COMMENT_IS_EQ=0
+			_GH_WRAPPER_COMMENT_FLAG="-c"
+			;;
+		-c=*)
+			_GH_WRAPPER_COMMENT_IDX=$i
+			_GH_WRAPPER_COMMENT_VAL="${args[i]#-c=}"
+			_GH_WRAPPER_COMMENT_IS_EQ=1
+			_GH_WRAPPER_COMMENT_FLAG="-c"
+			;;
+		esac
+		i=$((i + 1))
+	done
+	return 0
+}
+
+_gh_wrapper_auto_sig_close_comment() {
+	local sig_helper="$1"
+	shift
+	_gh_wrapper_collect_close_comment_arg "$@"
+	[[ $_GH_WRAPPER_COMMENT_IDX -ge 0 && -n "$_GH_WRAPPER_COMMENT_VAL" ]] || return 1
+	grep -Fqx '<!-- aidevops:sig -->' <<<"$_GH_WRAPPER_COMMENT_VAL" && return 0
+	local comment_sig_footer
+	comment_sig_footer=$("$sig_helper" footer --body "$_GH_WRAPPER_COMMENT_VAL" 2>/dev/null || echo "")
+	[[ -z "$comment_sig_footer" ]] && return 0
+	local new_comment="${_GH_WRAPPER_COMMENT_VAL}${comment_sig_footer}"
+	if [[ "$_GH_WRAPPER_COMMENT_IS_EQ" -eq 1 ]]; then
+		_GH_WRAPPER_SIG_MODIFIED_ARGS[_GH_WRAPPER_COMMENT_IDX]="${_GH_WRAPPER_COMMENT_FLAG}=${new_comment}"
+	else
+		_GH_WRAPPER_SIG_MODIFIED_ARGS[_GH_WRAPPER_COMMENT_IDX + 1]="$new_comment"
+	fi
 	return 0
 }
 
@@ -411,6 +473,13 @@ _gh_wrapper_auto_sig() {
 		esac
 		i=$((i + 1))
 	done
+
+	# gh issue close accepts comment text inline only. Keep its comment attached
+	# to the close request so a failed close cannot leave a separately-posted
+	# duplicate comment on retry.
+	if _gh_wrapper_auto_sig_close_comment "$sig_helper" "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"; then
+		return 0
+	fi
 
 	# Handle --body case
 	if [[ $body_idx -ge 0 && -n "$body_val" ]]; then

--- a/.agents/scripts/tests/test-gh-shim-core-cases.sh
+++ b/.agents/scripts/tests/test-gh-shim-core-cases.sh
@@ -56,6 +56,38 @@ else
 	_fail "--body original content preservation" "argv: $argv"
 fi
 
+# =============================================================================
+# Test 2b: issue-close comments use the same one-shot signature injection
+# =============================================================================
+echo ""
+echo "Test 2b: issue-close comments are signed without splitting close"
+for close_form in long equals short; do
+	_reset_log
+	case "$close_form" in
+	long) "$SHIM_RUN" issue close 123 --repo owner/repo --reason completed --comment "close evidence" 2>/dev/null ;;
+	equals) "$SHIM_RUN" issue close 123 --repo owner/repo --reason completed --comment="close evidence" 2>/dev/null ;;
+	short) "$SHIM_RUN" issue close 123 --repo owner/repo --reason completed -c "close evidence" 2>/dev/null ;;
+	esac
+	argv=$(_read_argv)
+	close_count=$(grep -c '^close$' "$STUB_GH_LOG" 2>/dev/null || true)
+	if [[ "$argv" == *"<!-- aidevops:sig -->"* && "$argv" == *"--reason"* &&
+		"$argv" == *"completed"* && "$close_count" -eq 1 ]]; then
+		_pass "${close_form} issue-close comment signs exactly one close mutation"
+	else
+		_fail "${close_form} issue-close comment signing" "argv: $argv"
+	fi
+done
+
+_reset_log
+"$SHIM_RUN" issue close 124 --repo owner/repo --reason completed 2>/dev/null
+argv=$(_read_argv)
+if [[ "$argv" == $'issue\nclose\n124\n--repo\nowner/repo\n--reason\ncompleted' ]] &&
+	[[ ! -s "$STUB_SIG_LOG" ]]; then
+	_pass "comment-free issue close passes through unchanged"
+else
+	_fail "comment-free issue close pass-through" "argv: $argv"
+fi
+
 # Inline marker prose is not a completed signature footer.
 echo ""
 echo "Test 2a: inline marker prose gets a standalone signature"
@@ -148,10 +180,10 @@ STUB_GH_EPHEMERAL_SOURCE="$ephemeral_body" \
 	2>"$TMP/ephemeral.err"
 argv=$(_read_argv)
 captured_body=$(<"$STUB_GH_BODY_LOG")
-if [[ "$argv" == *$'--body-file\n/dev/fd/9'* && \
-	"$captured_body" == *"validated review body"* && \
-	"$captured_body" == *"<!-- aidevops:sig -->"* && \
-	! -e "$ephemeral_body" && ! -L "$ephemeral_body" && \
+if [[ "$argv" == *$'--body-file\n/dev/fd/9'* &&
+	"$captured_body" == *"validated review body"* &&
+	"$captured_body" == *"<!-- aidevops:sig -->"* &&
+	! -e "$ephemeral_body" && ! -L "$ephemeral_body" &&
 	! -e "$ephemeral_parent" && ! -L "$ephemeral_parent" ]]; then
 	_pass "ephemeral body reaches native gh only after verified unlink"
 else
@@ -176,7 +208,7 @@ if STUB_GH_EPHEMERAL_SOURCE="$blocked_body" \
 	"$SHIM_RUN" issue comment 791 --repo owner/repo --body-file "$blocked_body" \
 	2>"$TMP/ephemeral-cleanup.err"; then
 	_fail "ephemeral cleanup failure gate" "shim returned success"
-elif [[ ! -s "$STUB_GH_MAIN_CALL_LOG" ]] && \
+elif [[ ! -s "$STUB_GH_MAIN_CALL_LOG" ]] &&
 	grep -q 'cleanup could not be verified before transport' "$TMP/ephemeral-cleanup.err"; then
 	_pass "ephemeral cleanup failure blocks native transport"
 else
@@ -195,7 +227,7 @@ if AIDEVOPS_GH_SHIM_DISABLE=1 \
 	"$SHIM_RUN" issue comment 792 --repo owner/repo --body-file "$bypass_body" \
 	2>"$TMP/ephemeral-bypass.err"; then
 	_fail "ephemeral shim bypass gate" "shim returned success"
-elif [[ ! -s "$STUB_GH_MAIN_CALL_LOG" && -f "$bypass_body" ]] && \
+elif [[ ! -s "$STUB_GH_MAIN_CALL_LOG" && -f "$bypass_body" ]] &&
 	grep -q 'cannot bypass the aidevops gh shim' "$TMP/ephemeral-bypass.err"; then
 	_pass "ephemeral transport blocks shim bypass before native gh"
 else

--- a/.agents/scripts/tests/test-gh-wrapper-auto-sig-body-file.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-auto-sig-body-file.sh
@@ -91,8 +91,14 @@ _ensure_origin_labels_for_args() { return 0; }
 _gh_should_fallback_to_rest() { return 1; }
 _rest_should_fallback() { return 1; }
 _gh_auto_link_sub_issue() { return 0; }
-session_origin_label() { printf '%s' "origin:worker"; return 0; }
-detect_session_origin() { printf '%s' "worker"; return 0; }
+session_origin_label() {
+	printf '%s' "origin:worker"
+	return 0
+}
+detect_session_origin() {
+	printf '%s' "worker"
+	return 0
+}
 
 reset_capture() {
 	: >"$GH_ARGV_RECORD_FILE"
@@ -235,12 +241,37 @@ assert_ephemeral_comment_uses_exact_shim_without_rest_retry() {
 	AIDEVOPS_GH_EPHEMERAL_BODY_FILE="$body_file" \
 		gh_issue_comment 1 --repo o/r --body-file "$body_file" \
 		>/dev/null 2>&1 || call_status=$?
-	if [[ "$call_status" -ne 0 && "$rest_calls" -eq 0 && \
+	if [[ "$call_status" -ne 0 && "$rest_calls" -eq 0 &&
 		"$exact_command" == "${TEST_SCRIPTS_DIR}/gh" && -f "$body_file" ]]; then
 		print_result "ephemeral comment requires exact shim and disables REST retry" 0
 	else
 		print_result "ephemeral comment requires exact shim and disables REST retry" 1 \
 			"status=${call_status}, rest_calls=${rest_calls}, command=${exact_command}, body_exists=$([[ -f "$body_file" ]] && printf yes || printf no)"
+	fi
+	return 0
+}
+
+assert_close_comment_signed_once() {
+	_gh_audit_fetch_issue_state_json() {
+		printf '%s\n' '{"capture_status":"ok"}'
+		return 0
+	}
+	_gh_audit_record_op() { return 0; }
+	local close_form="$1"
+	reset_capture
+	case "$close_form" in
+	long) gh_issue_close_safe 1 --repo o/r --reason completed --comment "verified close" >/dev/null 2>&1 ;;
+	equals) gh_issue_close_safe 1 --repo o/r --reason completed --comment="verified close" >/dev/null 2>&1 ;;
+	short) gh_issue_close_safe 1 --repo o/r --reason completed -c "verified close" >/dev/null 2>&1 ;;
+	esac
+	local close_count signature_count
+	close_count=$(grep -c '^<close>$' "$GH_ARGV_RECORD_FILE" 2>/dev/null || true)
+	signature_count=$(grep -c '<!-- aidevops:sig -->' "$GH_ARGV_RECORD_FILE" 2>/dev/null || true)
+	if [[ "$close_count" == "1" && "$signature_count" == "1" ]]; then
+		print_result "gh_issue_close_safe ${close_form} comment signs one native close" 0
+	else
+		print_result "gh_issue_close_safe ${close_form} comment signs one native close" 1 \
+			"close_count=${close_count}, signature_count=${signature_count}"
 	fi
 	return 0
 }
@@ -253,6 +284,9 @@ assert_missing_body_file_rejected_before_gh
 assert_signature_only_body_rejected_before_gh
 assert_signature_only_body_file_rejected_before_gh
 assert_ephemeral_comment_uses_exact_shim_without_rest_retry
+assert_close_comment_signed_once long
+assert_close_comment_signed_once equals
+assert_close_comment_signed_once short
 
 printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]]


### PR DESCRIPTION
## Summary

Signs --comment, --comment=, and -c issue-close content in OpenCode hooks, the PATH shim, and safe close wrappers without splitting the native close mutation.

## Files Changed

.agents/plugins/opencode-aidevops/quality-hooks-signature-detection.mjs, .agents/plugins/opencode-aidevops/quality-hooks-signature.mjs, .agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs, .agents/scripts/gh, .agents/scripts/shared-gh-wrappers-safe-edit.sh, .agents/scripts/shared-gh-wrappers-session.sh, .agents/scripts/tests/test-gh-shim-core-cases.sh, .agents/scripts/tests/test-gh-wrapper-auto-sig-body-file.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: executed the copied production PATH shim and safe-close wrapper against the hermetic native-gh transport stub; node --test signature footer gate; test-gh-shim.sh; test-gh-wrapper-auto-sig-body-file.sh; test-issue-sync-close-signature.sh; linters-local.sh

Resolves #29714


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.232 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 20m and 263,874 tokens on this as a headless worker.