### PR TITLE
GH#29693: Prevent stale debt issue recycling

### DIFF
--- a/.agents/scripts/pulse-dispatch-large-file-gate.sh
+++ b/.agents/scripts/pulse-dispatch-large-file-gate.sh
@@ -312,12 +312,73 @@ _large_file_gate_resolve_full_path() {
 }
 
 #######################################
+# Read the cited file's line count from the repository's current default
+# branch. This is the authoritative fallback when a runner's local checkout
+# may still predate a merged simplification PR.
+# Arguments: repo_slug, lf_path
+# Stdout: non-negative line count
+# Returns: 0 when verified, 1 when remote content is unavailable
+#######################################
+_large_file_gate_remote_default_line_count() {
+	local repo_slug="$1"
+	local lf_path="$2"
+	local default_branch=""
+	local content_json=""
+	local line_count=""
+
+	[[ "$repo_slug" == */* && -n "$lf_path" ]] || return 1
+	default_branch=$(gh api "repos/${repo_slug}" --jq '.default_branch // empty' 2>/dev/null) || return 1
+	[[ -n "$default_branch" ]] || return 1
+	content_json=$(gh api --method GET "repos/${repo_slug}/contents/${lf_path}" \
+		-f "ref=${default_branch}" 2>/dev/null) || return 1
+	line_count=$(printf '%s' "$content_json" | jq -er '
+		select(.type == "file" and .encoding == "base64" and (.content | type) == "string")
+		| (.content | gsub("\\s"; "") | @base64d) as $text
+		| if ($text | length) == 0 then 0
+		  else (($text | split("\n") | length) - (if ($text | endswith("\n")) then 1 else 0 end))
+		  end
+	' 2>/dev/null) || return 1
+	[[ "$line_count" =~ ^[0-9]+$ ]] || return 1
+	printf '%s' "$line_count"
+	return 0
+}
+
+#######################################
+# Verify that a local repository is currently at the remote default-branch
+# commit. Large-file measurements are unsafe when this check fails because a
+# just-merged split may not exist in the runner's canonical checkout yet.
+# Arguments: repo_path
+# Returns: 0 when exact, 1 when stale or unverifiable
+#######################################
+_large_file_gate_repo_matches_remote_default() {
+	local repo_path="$1"
+	local default_branch=""
+	local current_branch=""
+	local local_sha=""
+	local remote_line=""
+	local remote_sha=""
+
+	[[ -n "$repo_path" ]] || return 1
+	default_branch=$(git -C "$repo_path" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null) || return 1
+	default_branch="${default_branch#origin/}"
+	[[ -n "$default_branch" ]] || return 1
+	current_branch=$(git -C "$repo_path" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
+	[[ "$current_branch" == "$default_branch" ]] || return 1
+	local_sha=$(git -C "$repo_path" rev-parse HEAD 2>/dev/null) || return 1
+	remote_line=$(git -C "$repo_path" ls-remote --heads origin "refs/heads/${default_branch}" 2>/dev/null) || return 1
+	[[ -n "$remote_line" && "$remote_line" != *$'\n'* ]] || return 1
+	remote_sha="${remote_line%%[[:space:]]*}"
+	[[ "$remote_sha" =~ ^[0-9a-fA-F]{40}$ && "$local_sha" == "$remote_sha" ]]
+	return $?
+}
+
+#######################################
 # t2164 — verify whether a closed file-size-debt issue's PR actually
 # reduced the file below threshold. Returns:
-#   0 — "continuation is valid" (file now under threshold OR measurement
-#       unavailable; caller should emit the continuation reference)
-#   1 — file still over threshold; caller should reopen the canonical debt
-#       issue, and this helper has already logged the decision to $LOGFILE
+#   0 — "continuation is valid" (current default branch is under threshold OR
+#       authoritative measurement is unavailable; caller should not reopen)
+#   1 — current default branch is still over threshold; caller should reopen
+#       the canonical debt issue, and this helper logged the decision
 #
 # t2169: When the issue carries the `simplification-incomplete` label
 # (applied by the Simplification Outcome Check workflow when a merged PR
@@ -365,8 +426,22 @@ _large_file_gate_verify_prior_reduced_size() {
 		return 0
 	fi
 	if [[ "$_verify_lines" -ge "$LARGE_FILE_LINE_THRESHOLD" ]]; then
-		# File still over threshold — preserve one durable issue per path.
-		echo "[pulse-wrapper] Large-file gate: prior file-size-debt #${existing_issue} closed but ${lf_path} still ${_verify_lines} lines (threshold ${LARGE_FILE_LINE_THRESHOLD}); reopening canonical debt issue" >>"$LOGFILE"
+		# A local checkout can lag a just-merged simplification PR even after the
+		# best-effort canonical refresh. Never reopen a solved debt issue from
+		# stale disk state: verify the current remote default-branch blob first.
+		local _remote_lines=""
+		_remote_lines=$(_large_file_gate_remote_default_line_count "$repo_slug" "$lf_path") || _remote_lines=""
+		if [[ -z "$_remote_lines" ]]; then
+			echo "[pulse-wrapper] Large-file gate: local ${lf_path} is ${_verify_lines} lines but current remote content could not be verified; deferring canonical debt reopen for #${existing_issue}" >>"$LOGFILE"
+			return 0
+		fi
+		if [[ "$_remote_lines" -lt "$LARGE_FILE_LINE_THRESHOLD" ]]; then
+			echo "[pulse-wrapper] Large-file gate: stale local checkout reports ${lf_path} at ${_verify_lines} lines; remote default branch is ${_remote_lines} lines, so solved debt #${existing_issue} stays closed" >>"$LOGFILE"
+			return 0
+		fi
+		# Current remote content is still over threshold — preserve one durable
+		# issue per path and reopen only from this authoritative evidence.
+		echo "[pulse-wrapper] Large-file gate: prior file-size-debt #${existing_issue} closed but remote ${lf_path} still ${_remote_lines} lines (threshold ${LARGE_FILE_LINE_THRESHOLD}); reopening canonical debt issue" >>"$LOGFILE"
 		return 1
 	fi
 	# wc -l returned 0 (empty file / read error) — treat same as unavailable.
@@ -983,7 +1058,7 @@ _large_file_gate_issue_labels() {
 #   $5 - force_recheck (optional, default "false"; t1998 re-eval bypass)
 #
 # Exit codes:
-#   0 - gate applied (dispatch blocked)
+#   0 - gate applied or safely deferred (dispatch blocked)
 #   1 - gate not applied (dispatch may proceed)
 #######################################
 _issue_targets_large_files() {
@@ -1051,6 +1126,17 @@ _issue_targets_large_files() {
 			_large_file_gate_clear_stale_label "$issue_number" "$repo_slug" || return 0
 		fi
 		return 1
+	fi
+
+	# `_pulse_refresh_repo` is best-effort and canonical recovery may be delayed
+	# or unavailable on a contributor runner. When the pulse orchestration is
+	# loaded, require exact remote-default freshness before any local wc -l.
+	# A stale/unverifiable checkout blocks this candidate for one cycle without
+	# mutating issue labels or reopening debt issues.
+	if declare -F _pulse_refresh_repo >/dev/null 2>&1 \
+		&& ! _large_file_gate_repo_matches_remote_default "$repo_path"; then
+		echo "[pulse-wrapper] Large-file gate: deferring #${issue_number} (${repo_slug}); ${repo_path} is not at the verified remote default-branch commit" >>"$LOGFILE"
+		return 0
 	fi
 
 	_large_file_gate_collect_large_files "$all_paths" "$repo_path" "$issue_number"

--- a/.agents/scripts/pulse-triage-dispatch.sh
+++ b/.agents/scripts/pulse-triage-dispatch.sh
@@ -770,10 +770,12 @@ _consolidation_count_merged_children() {
 # parent issue's work is already resolved, BEFORE any cross-runner lock is
 # acquired or child created.
 #
-# Three abort conditions (cheapest-first):
+# Five abort conditions (cheapest-first):
 #   1. Parent has `dispatch-blocked:committed-to-main` label (t2955 cache).
-#   2. Parent is CLOSED with stateReason=NOT_PLANNED.
-#   3. ≥80% of #NNN refs in the parent body are merged PRs.
+#   2. Parent carries terminal completion labels.
+#   3. Parent has a structurally linked merged closing PR.
+#   4. Parent is CLOSED with stateReason=NOT_PLANNED.
+#   5. ≥80% of #NNN refs in the parent body are merged PRs.
 #
 # Each abort path posts an idempotent <!-- consolidation-skipped --> marker
 # via _consolidation_emit_skip. Fail-open: API errors return 1 (proceed).
@@ -791,9 +793,10 @@ _consolidation_skip_if_resolved() {
 	local repo_slug="$2"
 	# t2863: init all multi-var locals at declaration time so set -u is safe.
 	local parent_json="" state="" reason="" labels="" body=""
+	local closing_pr="" closing_pr_merged_at=""
 	local counts="" merged="" total="" list="" pct=""
 	parent_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
-		--json state,stateReason,labels,body 2>/dev/null) || parent_json=""
+		--json state,stateReason,labels,body,closedByPullRequestsReferences 2>/dev/null) || parent_json=""
 	if [[ -z "$parent_json" ]]; then
 		echo "[pulse-wrapper] _consolidation_skip_if_resolved: API error #${issue_number} ${repo_slug} — failing open (t3050)" >>"$LOGFILE"
 		return 1
@@ -809,14 +812,35 @@ _consolidation_skip_if_resolved() {
 			"dispatch-blocked:committed-to-main"
 		return 0
 	fi
-	# Gate 2: CLOSED with stateReason=NOT_PLANNED.
+	# Gate 2: completion labels survive accidental reopen/normalization paths and
+	# are sufficient to prevent a solved issue becoming a consolidation task.
+	if printf ',%s,' "$labels" | grep -Eq ',(status:done|solved:[^,]+),'; then
+		_consolidation_emit_skip "$issue_number" "$repo_slug" \
+			"parent carries terminal completion evidence." \
+			"terminal completion label"
+		return 0
+	fi
+	# Gate 3: GitHub retains the structural closing relationship after an
+	# accidental reopen. Verify the linked PR actually merged before skipping.
+	while IFS= read -r closing_pr; do
+		[[ "$closing_pr" =~ ^[0-9]+$ ]] || continue
+		closing_pr_merged_at=$(gh api "repos/${repo_slug}/pulls/${closing_pr}" \
+			--jq '.merged_at // empty' 2>/dev/null) || closing_pr_merged_at=""
+		if [[ -n "$closing_pr_merged_at" ]]; then
+			_consolidation_emit_skip "$issue_number" "$repo_slug" \
+				"parent already resolved by structurally linked merged PR #${closing_pr}." \
+				"merged closing PR #${closing_pr}"
+			return 0
+		fi
+	done < <(printf '%s' "$parent_json" | jq -r '.closedByPullRequestsReferences[]?.number' 2>/dev/null)
+	# Gate 4: CLOSED with stateReason=NOT_PLANNED.
 	if [[ "$state" == "CLOSED" && "$reason" == "NOT_PLANNED" ]]; then
 		_consolidation_emit_skip "$issue_number" "$repo_slug" \
 			"parent closed as not_planned. If consolidation is genuinely needed, reopen the parent or file a fresh issue." \
 			"CLOSED/NOT_PLANNED"
 		return 0
 	fi
-	# Gate 3: ≥80% of #NNN refs in body are merged PRs.
+	# Gate 5: ≥80% of #NNN refs in body are merged PRs.
 	counts=$(_consolidation_count_merged_children "$issue_number" "$repo_slug" "$body")
 	merged=$(printf '%s' "$counts" | awk '{print $1}')
 	total=$(printf '%s' "$counts" | awk '{print $2}')

--- a/.agents/scripts/tests/test-consolidation-skip-resolved.sh
+++ b/.agents/scripts/tests/test-consolidation-skip-resolved.sh
@@ -7,13 +7,15 @@
 # Covers the pre-flight resolved-parent gate added to
 # _dispatch_issue_consolidation:
 #   1. Gate 1: dispatch-blocked:committed-to-main label triggers skip
-#   2. Gate 2: state=CLOSED + stateReason=NOT_PLANNED triggers skip
-#   3. Gate 3a: ≥80% of #NNN refs in body are merged PRs triggers skip
-#   4. Gate 3b: <80% of #NNN refs are merged PRs proceeds (returns 1)
-#   5. Default proceed: no gate fires when parent is OPEN with no merged children
-#   6. Fail-open: gh API error proceeds rather than skipping
-#   7. Self-reference exclusion: parent's own #N not counted in Gate 3
-#   8. Skip marker comment is posted via _gh_idempotent_comment
+#   2. Gate 2: terminal completion labels trigger skip after accidental reopen
+#   3. Gate 3: a structurally linked merged closing PR triggers skip
+#   4. Gate 4: state=CLOSED + stateReason=NOT_PLANNED triggers skip
+#   5. Gate 5a: ≥80% of #NNN refs in body are merged PRs triggers skip
+#   6. Gate 5b: <80% of #NNN refs are merged PRs proceeds (returns 1)
+#   7. Default proceed: no gate fires when parent is OPEN with no merged children
+#   8. Fail-open: gh API error proceeds rather than skipping
+#   9. Self-reference exclusion: parent's own #N not counted in Gate 5
+#   10. Skip marker comment is posted via _gh_idempotent_comment
 #
 # Strategy: source pulse-triage.sh with a stubbed `gh` binary on PATH that
 # records every invocation and returns canned responses driven by env vars.
@@ -184,12 +186,52 @@ _make_issue_json() {
 	local state_reason="$2"
 	local labels_csv="$3"
 	local body="$4"
+	local closing_pr="${5:-}"
 	# Build labels array from CSV.
 	local labels_json
 	labels_json=$(printf '%s' "$labels_csv" | jq -Rc 'split(",") | map(select(length > 0) | {name: .})')
-	jq -n --arg state "$state" --arg sr "$state_reason" \
+	jq -n --arg state "$state" --arg sr "$state_reason" --arg closing_pr "$closing_pr" \
 		--argjson labels "$labels_json" --arg body "$body" \
-		'{state: $state, stateReason: $sr, labels: $labels, body: $body}'
+		'{state: $state, stateReason: $sr, labels: $labels, body: $body,
+		  closedByPullRequestsReferences: (if $closing_pr == "" then [] else [{number: ($closing_pr | tonumber)}] end)}'
+	return 0
+}
+
+test_gate2_terminal_completion_label() {
+	setup_stub
+	GH_ISSUE_JSON=$(_make_issue_json "OPEN" "" \
+		"auto-dispatch,solved:worker,file-size-debt" "Solved issue accidentally reopened.")
+	export GH_ISSUE_JSON
+
+	local rc=0
+	_consolidation_skip_if_resolved 150 "owner/repo" || rc=$?
+
+	if [[ "$rc" -eq 0 ]] && grep -q 'terminal completion label' "$LOGFILE" 2>/dev/null; then
+		print_result "Gate 2: solved label on reopened issue → skip" 0
+	else
+		print_result "Gate 2: solved label on reopened issue → skip" 1 \
+			"rc=$rc; pulse log: $(cat "$LOGFILE")"
+	fi
+	teardown_stub
+	return 0
+}
+
+test_gate3_merged_closing_pr() {
+	setup_stub
+	GH_ISSUE_JSON=$(_make_issue_json "OPEN" "" "auto-dispatch,file-size-debt" \
+		"No narrative PR references." "29702")
+	export GH_ISSUE_JSON GH_PR_29702_MERGED_AT="2026-08-07T08:21:59Z"
+
+	local rc=0
+	_consolidation_skip_if_resolved 151 "owner/repo" || rc=$?
+
+	if [[ "$rc" -eq 0 ]] && grep -q 'merged closing PR #29702' "$LOGFILE" 2>/dev/null; then
+		print_result "Gate 3: structurally linked merged closing PR → skip" 0
+	else
+		print_result "Gate 3: structurally linked merged closing PR → skip" 1 \
+			"rc=$rc; pulse log: $(cat "$LOGFILE")"
+	fi
+	teardown_stub
 	return 0
 }
 
@@ -424,6 +466,8 @@ test_count_merged_children_direct() {
 main() {
 	printf 'Running t3050 consolidator pre-flight gate tests\n\n'
 	test_gate1_committed_to_main_label
+	test_gate2_terminal_completion_label
+	test_gate3_merged_closing_pr
 	test_gate2_closed_not_planned
 	test_gate2_closed_completed_proceeds
 	test_gate3_high_merge_rate_skips

--- a/.agents/scripts/tests/test-gate-pull-before-measure.sh
+++ b/.agents/scripts/tests/test-gate-pull-before-measure.sh
@@ -4,17 +4,17 @@
 #
 # test-gate-pull-before-measure.sh — t2433/GH#20071 regression guard.
 #
-# Verifies that _pulse_refresh_repo pulls from remote BEFORE the large-file
-# gate measures wc -l on local files. Without the fix, the gate fires on
-# stale pre-split line counts after a split PR merges on GitHub but the
-# local repo hasn't pulled yet.
+# Verifies that the large-file gate never measures a stale canonical checkout.
+# `_pulse_refresh_repo` uses guarded canonical recovery and may legitimately
+# leave a runner stale; the gate must detect that state and defer without issue
+# mutations instead of trusting pre-split line counts.
 #
 # Tests:
 #   test_refresh_pulls_before_gate_measures
 #       Sandboxed git repo with a 2500-line file committed. A "remote" bare
 #       clone has the file shrunk to 500 lines. The local repo has NOT pulled.
-#       Calling _pulse_refresh_repo then measuring wc -l should see 500 lines
-#       (post-pull size), not 2500 (stale local size).
+#       Calling _pulse_refresh_repo may leave 2500 lines locally, but the
+#       remote-default freshness check must reject that checkout.
 #
 #   test_sentinel_prevents_double_pull
 #       After _pulse_refresh_repo is called once for a path, calling it again
@@ -27,9 +27,8 @@
 #       Path that is not a git work-tree returns 0 without errors.
 #
 #   test_triage_refresh_before_issue_targets_large_files
-#       Simulates _reevaluate_simplification_labels calling _pulse_refresh_repo
-#       in the outer repo loop, verifying the line count seen by
-#       _issue_targets_large_files reflects the post-pull state.
+#       Simulates triage after a guarded refresh cannot converge and verifies
+#       _issue_targets_large_files blocks for retry before measuring or mutating.
 #
 # Cross-references: GH#20071 (root cause), t2433 (this fix),
 #   GH#19964-#20023 (6 false-positive debt issues triggered by stale local copy)
@@ -178,8 +177,8 @@ test_refresh_pulls_before_gate_measures() {
 		return 0
 	fi
 
-	# Load _pulse_refresh_repo from pulse-wrapper.sh in a clean subshell to
-	# avoid contaminating the sentinel for other tests.
+	# Load the pulse and gate helpers in a clean subshell. Guarded canonical
+	# recovery may refuse this unregistered sandbox, which is expected.
 	# shellcheck disable=SC1090
 	local result
 	result=$(
@@ -187,14 +186,18 @@ test_refresh_pulls_before_gate_measures() {
 		source "${WRAPPER_SCRIPT}" --self-check >/dev/null 2>&1 || true
 		declare -A _PULSE_REFRESHED_THIS_CYCLE=()
 		_pulse_refresh_repo "$sandbox" 2>>"$LOGFILE"
-		wc -l <"${sandbox}/large-target.sh" | tr -d ' '
+		if _large_file_gate_repo_matches_remote_default "$sandbox"; then
+			printf 'fresh\n'
+		else
+			printf 'stale\n'
+		fi
 	)
 
-	if [[ "${result:-0}" -lt 2000 ]]; then
+	if [[ "$result" == "stale" ]]; then
 		print_result "test_refresh_pulls_before_gate_measures" 0
 	else
 		print_result "test_refresh_pulls_before_gate_measures" 1 \
-			"expected <2000 lines post-pull, got ${result:-?} (gate would false-positive)"
+			"expected stale checkout rejection, got ${result:-?}"
 	fi
 	return 0
 }
@@ -294,9 +297,10 @@ test_triage_refresh_before_issue_targets_large_files() {
 		return 0
 	}
 
-	# Simulate the scenario: before refresh, wc -l is >2000 (stale).
-	# After _pulse_refresh_repo, wc -l should be <500 (post-split).
-	local pre_pull_count post_pull_count
+	# Simulate triage with a stale pre-split checkout. Metadata reads are stubbed
+	# so this remains a local regression test with no GitHub writes.
+	local pre_pull_count post_pull_count gate_rc=0
+	local measure_marker="${TMP}/stale-measure-called"
 	pre_pull_count=$(wc -l <"${sandbox}/large-target.sh" | tr -d ' ')
 
 	# Run refresh in a subshell
@@ -305,17 +309,27 @@ test_triage_refresh_before_issue_targets_large_files() {
 		source "${WRAPPER_SCRIPT}" --self-check >/dev/null 2>&1 || true
 		declare -A _PULSE_REFRESHED_THIS_CYCLE=()
 		_pulse_refresh_repo "$sandbox" 2>>"$LOGFILE"
+		_large_file_gate_issue_labels() { printf ''; return 0; }
+		_large_file_gate_issue_title() { printf 'Issue 9999'; return 0; }
+		_large_file_gate_collect_large_files() {
+			printf 'called\n' >"$measure_marker"
+			return 0
+		}
+		_issue_targets_large_files "9999" "owner/repo" \
+			"## How"$'\n'"- EDIT: \`large-target.sh\`" "$sandbox" "true"
 	)
+	gate_rc=$?
 
 	post_pull_count=$(wc -l <"${sandbox}/large-target.sh" | tr -d ' ')
 
-	# The gate uses wc -l on the local file after refresh.
-	# post_pull_count should now be below threshold (500 < 2000).
-	if [[ "${pre_pull_count:-0}" -ge 2000 && "${post_pull_count:-9999}" -lt 2000 ]]; then
+	# Exit 0 blocks/defer-retries the candidate. The stale file remains untouched,
+	# and the collection marker proves no local line-count decision was made.
+	if [[ "${pre_pull_count:-0}" -ge 2000 && "${post_pull_count:-0}" -ge 2000 \
+		&& "$gate_rc" -eq 0 && ! -e "$measure_marker" ]]; then
 		print_result "test_triage_refresh_before_issue_targets_large_files" 0
 	else
 		print_result "test_triage_refresh_before_issue_targets_large_files" 1 \
-			"pre=${pre_pull_count} post=${post_pull_count} — expected pre>=2000 and post<2000"
+			"pre=${pre_pull_count} post=${post_pull_count} gate_rc=${gate_rc} — expected stale defer"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-large-file-gate-continuation-verify.sh
+++ b/.agents/scripts/tests/test-large-file-gate-continuation-verify.sh
@@ -33,13 +33,21 @@
 #   1. Closed exists, file UNDER threshold, repo_path provided
 #      → returns "(recently-closed — continuation)"
 #   2. Closed exists, file OVER threshold, repo_path provided
-#      → does NOT create a successor; reopens the canonical issue
-#   3. Closed exists, no repo_path
+#      → verifies remote content; reopens only when remote is also over
+#   3. Local file OVER threshold but remote file UNDER threshold
+#      → keeps the solved canonical issue closed
+#   4. Local file OVER threshold but remote verification unavailable
+#      → defers reopening
+#   5. Closed exists, no repo_path
 #      → returns "(recently-closed — continuation)" (backward-compat fallback)
-#   4. Closed exists, repo_path set but file not on disk
+#   6. Closed exists, repo_path set but file not on disk
 #      → returns "(recently-closed — continuation)" (measurement unavailable)
-#   5. No open, no closed match
+#   7. No open, no closed match
 #      → returns "(new)"
+#   8. Open match exists
+#      → returns "(existing)"
+#   9. Pulse orchestration sees a stale local default branch
+#      → blocks for the cycle without measuring or mutating issue state
 #
 # Cross-references: GH#19415 / t2152 (the blocked investigation that
 # surfaced this bug), GH#18960 (the dedup the bug exists inside),
@@ -84,6 +92,8 @@ GH_OPEN_RESPONSE=""   # what the open-issue search returns
 GH_CLOSED_RESPONSE="" # what the closed-issue search returns
 GH_CALLS_LOG="${TMP}/gh_calls.log"
 GH_CREATE_RESPONSE_URL=""
+GH_REMOTE_CONTENT_RESPONSE=""
+GH_REMOTE_CONTENT_FAIL=""
 : >"$GH_CALLS_LOG"
 
 # =============================================================================
@@ -128,6 +138,15 @@ gh() {
 		closed) saw_closed="true" ;;
 		esac
 	done
+	if [[ "$1" == "api" && "$2" == "repos/owner/repo" ]]; then
+		printf 'main\n'
+		return 0
+	fi
+	if [[ "$1" == "api" && "$2" == "--method" && "$3" == "GET" && "$4" == repos/owner/repo/contents/* ]]; then
+		[[ -z "$GH_REMOTE_CONTENT_FAIL" ]] || return 1
+		printf '%s\n' "$GH_REMOTE_CONTENT_RESPONSE"
+		return 0
+	fi
 	if [[ "$1" == "issue" && "$2" == "list" && "$saw_open" == "false" && "$saw_closed" == "false" ]]; then
 		if [[ -n "$GH_OPEN_RESPONSE" ]]; then
 			printf '[{"number":%s,"state":"OPEN","body":"generator=large-file-simplification-gate cited_file=under.sh threshold=2000 generator=large-file-simplification-gate cited_file=over.sh threshold=2000 generator=large-file-simplification-gate cited_file=missing.sh threshold=2000"}]\n' "$GH_OPEN_RESPONSE"
@@ -170,6 +189,14 @@ gh() {
 	fi
 
 	# Anything else — silent no-op
+	return 0
+}
+
+_remote_content_json() {
+	local file_path="$1"
+	local encoded=""
+	encoded=$(base64 <"$file_path" | tr -d '\n') || return 1
+	jq -cn --arg content "$encoded" '{type:"file",encoding:"base64",content:$content}'
 	return 0
 }
 
@@ -238,6 +265,8 @@ assert_eq \
 GH_OPEN_RESPONSE=""
 GH_CLOSED_RESPONSE="18706"
 GH_CREATE_RESPONSE_URL=""
+GH_REMOTE_CONTENT_RESPONSE=$(_remote_content_json "$OVER_FILE")
+GH_REMOTE_CONTENT_FAIL=""
 out=$(_large_file_gate_create_debt_issue "over.sh" "9999" "owner/repo" "$TMP")
 assert_eq \
 	"closed + file over threshold → reopen canonical issue" \
@@ -245,24 +274,55 @@ assert_eq \
 	"$out"
 assert_contains \
 	"file-over-threshold path logs canonical reopen" \
-	"prior file-size-debt #18706 closed but over.sh still 2050 lines" \
+	"prior file-size-debt #18706 closed but remote over.sh still 2050 lines" \
 	"$(cat "$LOGFILE")"
 assert_contains \
 	"file-over-threshold path calls gh issue reopen" \
 	"gh issue reopen 18706 --repo owner/repo" \
 	"$(cat "$GH_CALLS_LOG")"
 
-# ---- Test 3 — closed exists, no repo_path → backward-compat continuation ----
+# ---- Test 3 — stale local OVER, remote UNDER → keep solved issue closed ----
+GH_OPEN_RESPONSE=""
+GH_CLOSED_RESPONSE="18706"
+GH_REMOTE_CONTENT_RESPONSE=$(_remote_content_json "$UNDER_FILE")
+GH_REMOTE_CONTENT_FAIL=""
+out=$(_large_file_gate_create_debt_issue "over.sh" "9999" "owner/repo" "$TMP")
+assert_eq \
+	"stale local over + remote under → continuation" \
+	"#18706 (recently-closed — continuation)" \
+	"$out"
+assert_contains \
+	"stale local measurement is diagnosed" \
+	"stale local checkout reports over.sh at 2050 lines; remote default branch is 100 lines" \
+	"$(cat "$LOGFILE")"
+
+# ---- Test 4 — local OVER, remote unavailable → fail closed without reopen ----
+GH_OPEN_RESPONSE=""
+GH_CLOSED_RESPONSE="18706"
+GH_REMOTE_CONTENT_RESPONSE=""
+GH_REMOTE_CONTENT_FAIL="1"
+out=$(_large_file_gate_create_debt_issue "over.sh" "9999" "owner/repo" "$TMP")
+assert_eq \
+	"local over + remote unavailable → defer reopen" \
+	"#18706 (recently-closed — continuation)" \
+	"$out"
+assert_contains \
+	"remote verification failure is diagnosed" \
+	"current remote content could not be verified; deferring canonical debt reopen" \
+	"$(cat "$LOGFILE")"
+
+# ---- Test 5 — closed exists, no repo_path → backward-compat continuation ----
 GH_OPEN_RESPONSE=""
 GH_CLOSED_RESPONSE="18706"
 GH_CREATE_RESPONSE_URL=""
+GH_REMOTE_CONTENT_FAIL=""
 out=$(_large_file_gate_create_debt_issue "over.sh" "9999" "owner/repo")
 assert_eq \
 	"closed + no repo_path → continuation (backward-compat fallback)" \
 	"#18706 (recently-closed — continuation)" \
 	"$out"
 
-# ---- Test 4 — closed exists, repo_path set but file missing → continuation ----
+# ---- Test 6 — closed exists, repo_path set but file missing → continuation ----
 GH_OPEN_RESPONSE=""
 GH_CLOSED_RESPONSE="18706"
 GH_CREATE_RESPONSE_URL=""
@@ -272,7 +332,7 @@ assert_eq \
 	"#18706 (recently-closed — continuation)" \
 	"$out"
 
-# ---- Test 5 — no open, no closed → creates new ----
+# ---- Test 7 — no open, no closed → creates new ----
 GH_OPEN_RESPONSE=""
 GH_CLOSED_RESPONSE=""
 GH_CREATE_RESPONSE_URL="https://github.com/owner/repo/issues/88888"
@@ -282,7 +342,7 @@ assert_eq \
 	"#88888 (new)" \
 	"$out"
 
-# ---- Test 6 — open exists → existing (short-circuit before continuation logic) ----
+# ---- Test 8 — open exists → existing (short-circuit before continuation logic) ----
 GH_OPEN_RESPONSE="55555"
 GH_CLOSED_RESPONSE=""
 GH_CREATE_RESPONSE_URL=""
@@ -291,6 +351,31 @@ assert_eq \
 	"open exists → existing (short-circuit)" \
 	"#55555 (existing)" \
 	"$out"
+
+# ---- Test 9 — stale pulse checkout → defer before local measurement ----
+_pulse_refresh_repo() { return 0; }
+_large_file_gate_repo_matches_remote_default() { return 1; }
+GH_OPEN_RESPONSE=""
+GH_CLOSED_RESPONSE="18706"
+GH_REMOTE_CONTENT_RESPONSE=$(_remote_content_json "$UNDER_FILE")
+GH_REMOTE_CONTENT_FAIL=""
+before_calls=$(wc -l <"$GH_CALLS_LOG" | tr -d ' ')
+rc=0
+_issue_targets_large_files "9993" "owner/repo" \
+	"## How"$'\n'"- EDIT: \`over.sh\`" "$TMP" "false" || rc=$?
+after_calls=$(wc -l <"$GH_CALLS_LOG" | tr -d ' ')
+assert_eq \
+	"stale pulse checkout → dispatch remains blocked for retry" \
+	"0" \
+	"$rc"
+assert_eq \
+	"stale pulse checkout → no debt mutation calls" \
+	"$before_calls" \
+	"$after_calls"
+assert_contains \
+	"stale pulse checkout → explicit defer diagnostic" \
+	"is not at the verified remote default-branch commit" \
+	"$(cat "$LOGFILE")"
 
 printf '\n%d run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 


### PR DESCRIPTION
## Summary

Require a checkout matching the current remote default branch before measuring large-file debt, verify remote content before reopening closed debt, and skip consolidation for terminal labels or merged closing PRs.

## Files Changed

.agents/scripts/pulse-dispatch-large-file-gate.sh, .agents/scripts/pulse-triage-dispatch.sh, .agents/scripts/tests/test-consolidation-skip-resolved.sh, .agents/scripts/tests/test-gate-pull-before-measure.sh, .agents/scripts/tests/test-large-file-gate-continuation-verify.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Passed targeted large-file and consolidation suites (77 assertions total), ShellCheck, secret scanning, Bash 3.2 compatibility, portability, complexity gates, and git diff whitespace validation via linters-local.sh --changed.

Resolves #29693


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.232 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 21m and 389,024 tokens on this with the user in an interactive session.