### PR TITLE
GH#29724: Preserve terminal trailers in merge bodies

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -835,7 +835,9 @@ fi
 # -----------------------------------------------------------------------------
 # Scan args for --body / --body-file and inject signature if missing.
 # Mirrors _gh_wrapper_auto_sig in shared-gh-wrappers.sh. Marker-based dedup
-# means idempotent: running the shim twice on the same args is a no-op.
+# means idempotent: running the shim twice on the same args is a no-op. A PR
+# merge body becomes a Git commit message, so it must remain byte-for-byte
+# caller supplied to preserve terminal Git trailers (GH#29724).
 # -----------------------------------------------------------------------------
 _i=0
 _body_idx=-1
@@ -900,7 +902,8 @@ done
 # exact aidevops shim and must not retry the consumed descriptor through REST.
 
 # --- --body case -------------------------------------------------------------
-if [[ $_body_idx -ge 0 && -n "$_body_val" ]]; then
+if [[ "${_modified_args[0]:-}:${_modified_args[1]:-}" != "pr:merge" &&
+	$_body_idx -ge 0 && -n "$_body_val" ]]; then
 	if ! grep -Fqx '<!-- aidevops:sig -->' <<<"$_body_val"; then
 		_sig_footer=$("$SIG_HELPER" footer --body "$_body_val" 2>/dev/null || echo "")
 		if [[ -n "$_sig_footer" ]]; then
@@ -938,7 +941,8 @@ fi
 # to the user's source. The user's brief on disk stays byte-identical after the
 # gh call. The temp file is cleaned up by a background reaper because the native
 # transport may outlive setup-time shell traps.
-if [[ $_body_file_idx -ge 0 && -n "$_body_file_val" && -f "$_body_file_val" ]]; then
+if [[ "${_modified_args[0]:-}:${_modified_args[1]:-}" != "pr:merge" &&
+	$_body_file_idx -ge 0 && -n "$_body_file_val" && -f "$_body_file_val" ]]; then
 	if ! grep -Fqx '<!-- aidevops:sig -->' "$_body_file_val" 2>/dev/null; then
 		_file_content=$(<"$_body_file_val") || _file_content=""
 		_sig_footer=$("$SIG_HELPER" footer --body "$_file_content" 2>/dev/null || echo "")

--- a/.agents/scripts/tests/test-gh-shim-core-cases.sh
+++ b/.agents/scripts/tests/test-gh-shim-core-cases.sh
@@ -356,6 +356,40 @@ else
 fi
 
 # =============================================================================
+# Test 9a: pr merge bodies preserve terminal Git trailers byte-for-byte
+# =============================================================================
+echo ""
+echo "Test 9a: pr merge bodies preserve terminal trailers"
+merge_body='Preserve release provenance.
+
+Aidevops-Release-Aggregator-PR: #29629
+Aidevops-Release-Aggregates: #29629
+Aidevops-Release-Aggregates: #29630'
+for merge_body_form in separated equals; do
+	_reset_log
+	if [[ "$merge_body_form" == "separated" ]]; then
+		"$SHIM_RUN" pr merge 123 --repo owner/repo --squash --body "$merge_body" 2>/dev/null
+	else
+		"$SHIM_RUN" pr merge 123 --repo owner/repo --squash "--body=${merge_body}" 2>/dev/null
+	fi
+	argv=$(_read_argv)
+	merge_native_body=$(printf '%s\n' "$argv" | awk 'seen { print } $0 == "--body" { seen = 1 }')
+	if [[ "$merge_body_form" == "equals" ]]; then
+		merge_native_body="${argv##*--body=}"
+	fi
+	merge_trailers=$(printf '%s\n' "$merge_native_body" | git interpret-trailers --parse)
+	if [[ "$argv" != *"<!-- aidevops:sig -->"* &&
+		"$merge_native_body" == "$merge_body" &&
+		"$merge_trailers" == *"Aidevops-Release-Aggregator-PR: #29629"* &&
+		"$merge_trailers" == *"Aidevops-Release-Aggregates: #29629"* &&
+		"$merge_trailers" == *"Aidevops-Release-Aggregates: #29630"* ]]; then
+		_pass "${merge_body_form} pr merge body remains unsigned and trailer-parseable"
+	else
+		_fail "${merge_body_form} pr merge body preservation" "argv: $argv trailers: $merge_trailers"
+	fi
+done
+
+# =============================================================================
 # Test 10: gh api (arbitrary subcommand) passes through
 # =============================================================================
 echo ""

--- a/.agents/scripts/tests/test-gh-shim-routing-cases.sh
+++ b/.agents/scripts/tests/test-gh-shim-routing-cases.sh
@@ -385,6 +385,18 @@ else
 fi
 
 _reset_log
+if AIDEVOPS_HEADLESS=1 "$SHIM_RUN" pr merge 789 --repo external/repo --squash --body "uninstigated" 2>"$TMP/guard-merge.err"; then
+	_fail "headless pr merge guard" "write unexpectedly passed"
+else
+	argv=$(_read_argv)
+	if [[ -z "$argv" ]] && grep -q "external-write-guard" "$TMP/guard-merge.err"; then
+		_pass "headless pr merge to contributor repo is blocked before gh exec"
+	else
+		_fail "headless pr merge guard" "argv: $argv err: $(cat "$TMP/guard-merge.err" 2>/dev/null || true)"
+	fi
+fi
+
+_reset_log
 if AIDEVOPS_SESSION_ORIGIN=pulse "$SHIM_RUN" pr comment 456 --repo external/repo --body "uninstigated" 2>"$TMP/guard-pr.err"; then
 	_fail "headless pr comment guard" "write unexpectedly passed"
 else
@@ -434,6 +446,17 @@ if [[ "$argv" == *"<!-- aidevops:sig -->"* ]]; then
 	_pass "explicit per-repo headless allowance permits normal signature handling"
 else
 	_fail "explicit headless external allowance" "argv: $argv"
+fi
+
+_reset_log
+AIDEVOPS_HEADLESS=1 AIDEVOPS_USER_INSTIGATED_EXTERNAL_GH_WRITE=external/repo "$SHIM_RUN" \
+	pr merge 456 --repo external/repo --squash --body "allowed merge" 2>/dev/null
+argv=$(_read_argv)
+if [[ "$argv" == *$'pr\nmerge\n456'* && "$argv" == *"allowed merge"* &&
+	"$argv" != *"<!-- aidevops:sig -->"* ]]; then
+	_pass "explicit headless allowance permits unsigned pr merge transport"
+else
+	_fail "explicit headless pr merge allowance" "argv: $argv"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Preserve `gh pr merge` bodies byte-for-byte so terminal Git trailers remain parseable.
- Keep the headless external-write guard and all other merge interception intact.
- Add hermetic signature, trailer, and routing regressions.

Resolves #29724

## Testing

- `bash .agents/scripts/tests/test-gh-shim.sh`
- `shellcheck .agents/scripts/gh .agents/scripts/gh-write-policy-lib.sh .agents/scripts/tests/test-gh-shim-core-cases.sh .agents/scripts/tests/test-gh-shim-routing-cases.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.232 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra
