### PR TITLE
GH#29733: fix: Preserve explicit full-loop merge bodies

### DIFF
--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -28,6 +28,7 @@
 [[ -n "${_FULL_LOOP_MERGE_LIB_LOADED:-}" ]] && return 0
 _FULL_LOOP_MERGE_LIB_LOADED=1
 FULL_LOOP_MERGE_SUBJECT_FLAG="--subject"
+FULL_LOOP_MERGE_BODY_FILE_FLAG="--body-file"
 
 # Defensive SCRIPT_DIR fallback
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
@@ -196,6 +197,7 @@ _merge_try_interactive_admin_auto_fallback() {
 	local merge_output="$4"
 	local expected_head_sha="$5"
 	local squash_subject="${6:-}"
+	local merge_body_file="${7:-}"
 
 	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo" ]] || return 1
 	! _merge_is_headless_session || return 1
@@ -208,6 +210,7 @@ _merge_try_interactive_admin_auto_fallback() {
 	print_info "Auto-merge is blocked only by review-required branch policy/self-approval; interactive maintainer session is using --admin merge after gates passed."
 	local subject_flags=()
 	[[ -n "$squash_subject" ]] && subject_flags+=("$FULL_LOOP_MERGE_SUBJECT_FLAG" "$squash_subject")
+	[[ -n "$merge_body_file" ]] && subject_flags+=("$FULL_LOOP_MERGE_BODY_FILE_FLAG" "$merge_body_file")
 	if gh pr merge "$pr_number" --repo "$repo" "$merge_method" --admin --match-head-commit "$expected_head_sha" ${subject_flags[@]+"${subject_flags[@]}"} 2>&1; then
 		print_success "PR #${pr_number} merged with interactive --admin fallback"
 		_signal_admin_merge_fallback "$pr_number" "$repo" "$merge_method" "$merge_output"
@@ -730,7 +733,7 @@ _merge_guard_prospective_todo() (
 # limited. The REST endpoint still enforces branch protection and mergeability;
 # failures remain failures.
 #
-# Args: pr_number repo merge_method expected_head_sha [squash_subject]
+# Args: pr_number repo merge_method expected_head_sha [squash_subject] [merge_body_file]
 # Returns: 0 = merged, 1 = REST merge failed
 _merge_rest_fallback() {
 	local pr_number="$1"
@@ -738,6 +741,7 @@ _merge_rest_fallback() {
 	local merge_method="$3"
 	local expected_head_sha="$4"
 	local squash_subject="${5:-}"
+	local merge_body_file="${6:-}"
 	local rest_method="${merge_method#--}"
 	local rest_out="" rest_rc=0
 
@@ -757,6 +761,7 @@ _merge_rest_fallback() {
 	print_info "GraphQL rate limit blocked gh pr merge; retrying via REST pull merge endpoint with verified head SHA ${expected_head_sha}..."
 	local rest_args=(-f "sha=${expected_head_sha}" -f "merge_method=${rest_method}")
 	[[ -n "$squash_subject" ]] && rest_args+=(-f "commit_title=${squash_subject}")
+	[[ -n "$merge_body_file" ]] && rest_args+=(-F "commit_message=@${merge_body_file}")
 	if rest_out=$(gh api -X PUT "repos/${repo}/pulls/${pr_number}/merge" \
 		${rest_args[@]+"${rest_args[@]}"} 2>&1); then
 		rest_rc=0
@@ -787,7 +792,7 @@ _merge_rest_fallback() {
 # Bash 3.2 note: `"${arr[@]}"` raises "unbound variable" under set -u when the
 # array is empty. The `${arr[@]+"${arr[@]}"}` form expands to zero words safely.
 #
-# Args: pr_number repo merge_method has_admin has_auto
+# Args: pr_number repo merge_method has_admin has_auto [merge_body_file]
 # Returns: 0 = merged or queued, 1 = failed
 _merge_resolve_match_head() {
 	local pr_number="$1"
@@ -907,19 +912,34 @@ _merge_resolve_subject_for_method() {
 	return $?
 }
 
+_merge_describe_flags() {
+	local merge_method="$1"
+	local has_admin="$2"
+	local has_auto="$3"
+	local squash_subject="$4"
+	local merge_body_file="$5"
+	local merge_desc="$merge_method"
+	[[ "$has_admin" -eq 1 ]] && merge_desc+=" --admin"
+	[[ "$has_auto" -eq 1 ]] && merge_desc+=" --auto"
+	[[ -n "$squash_subject" ]] && merge_desc+=" ${FULL_LOOP_MERGE_SUBJECT_FLAG} <validated>"
+	[[ -n "$merge_body_file" ]] && merge_desc+=" ${FULL_LOOP_MERGE_BODY_FILE_FLAG} <validated>"
+	printf '%s\n' "$merge_desc"
+	return 0
+}
+
 _merge_execute() {
 	local pr_number="$1" repo="$2" merge_method="$3"
 	local has_admin="$4" has_auto="$5" squash_subject=""
+	local merge_body_file="${6:-}"
 	squash_subject=$(_merge_resolve_subject_for_method "$pr_number" "$repo" "$merge_method") || return 1
-
-	# Reconstruct flags array from boolean sentinels (avoids passing arrays across function calls).
 	local merge_flags=()
 	[[ "$has_admin" -eq 1 ]] && merge_flags+=("--admin")
 	[[ "$has_auto" -eq 1 ]] && merge_flags+=("--auto")
 	[[ -n "$squash_subject" ]] && merge_flags+=("$FULL_LOOP_MERGE_SUBJECT_FLAG" "$squash_subject")
+	[[ -n "$merge_body_file" ]] && merge_flags+=("$FULL_LOOP_MERGE_BODY_FILE_FLAG" "$merge_body_file")
 
-	local merge_desc="$merge_method"
-	[[ ${#merge_flags[@]} -gt 0 ]] && merge_desc+=" ${merge_flags[*]}"
+	local merge_desc=""
+	merge_desc=$(_merge_describe_flags "$merge_method" "$has_admin" "$has_auto" "$squash_subject" "$merge_body_file") || return 1
 	print_info "Merging PR #${pr_number} in ${repo} (${merge_desc})..."
 
 	local match_head_sha=""
@@ -965,11 +985,11 @@ ${_merge_retry_out}"
 		# caller reached the merge execution stage (cmd_merge runs review-bot-gate
 		# first). Do not turn --auto into an immediate REST merge.
 		if [[ $has_auto -eq 0 ]] && _merge_output_is_graphql_rate_limit "$_merge_out"; then
-			_merge_rest_fallback "$pr_number" "$repo" "$merge_method" "$match_head_sha" "$squash_subject" && return 0
+			_merge_rest_fallback "$pr_number" "$repo" "$merge_method" "$match_head_sha" "$squash_subject" "$merge_body_file" && return 0
 			return 1
 		elif [[ $has_admin -eq 0 && $has_auto -eq 1 ]]; then
 			local auto_admin_rc=0
-			_merge_try_interactive_admin_auto_fallback "$pr_number" "$repo" "$merge_method" "$_merge_out" "$match_head_sha" "$squash_subject" || auto_admin_rc=$?
+			_merge_try_interactive_admin_auto_fallback "$pr_number" "$repo" "$merge_method" "$_merge_out" "$match_head_sha" "$squash_subject" "$merge_body_file" || auto_admin_rc=$?
 			[[ "$auto_admin_rc" -eq 0 ]] && return 0
 			[[ "$auto_admin_rc" -eq 2 ]] && return 1
 			print_error "Merge failed for PR #${pr_number}"
@@ -981,6 +1001,7 @@ ${_merge_retry_out}"
 			print_info "Branch protection blocked plain merge; retrying with --admin (workers share the maintainer's gh auth per GH#18538)..."
 			local subject_flags=()
 			[[ -n "$squash_subject" ]] && subject_flags+=("$FULL_LOOP_MERGE_SUBJECT_FLAG" "$squash_subject")
+			[[ -n "$merge_body_file" ]] && subject_flags+=("$FULL_LOOP_MERGE_BODY_FILE_FLAG" "$merge_body_file")
 			if gh pr merge "$pr_number" --repo "$repo" "$merge_method" --admin --match-head-commit "$match_head_sha" ${subject_flags[@]+"${subject_flags[@]}"} 2>&1; then
 				print_success "PR #${pr_number} merged with --admin fallback"
 				# t2247: Signal that admin-merge fallback was used — three artifacts:
@@ -1580,46 +1601,57 @@ _merge_finalize_post_merge() {
 # Single command that replaces the multi-step protocol (wait + merge).
 # Workers call this instead of bare `gh pr merge`.
 #
-# Usage: full-loop-helper.sh merge <PR_NUMBER> [REPO] [--squash|--merge|--rebase] [--admin] [--auto]
+# Usage: full-loop-helper.sh merge <PR_NUMBER> [REPO] [--squash|--merge|--rebase] [--admin] [--auto] [--body-file PATH]
 #   --admin  pass --admin to gh pr merge (GH#18731 — owner-only bypass of
 #            branch protection for self-authored PRs on personal-account
 #            repos; skips the error-retry path since intent is explicit)
 #   --auto   pass --auto to gh pr merge (GH#18731 — queues auto-merge to
 #            run when required checks pass, rather than merging now)
+#   --body-file pass an exact caller-supplied merge commit body through every
+#               merge transport; the path must name a readable regular file
 # Note: --admin and --auto are mutually exclusive at the gh CLI level
 # (GH#19310 / t2141). When both are passed, --admin wins (it already implies
 # "merge now", so --auto adds no value); --auto is dropped silently with an
 # informational message rather than failing the merge.
 # Exit codes: 0 = merged (or queued, with --auto), 1 = gate failed or merge failed
-cmd_merge() {
-	local pr_number="${1:-}"
-	local repo=""
-	local merge_method="--squash"
-	local has_admin=0
-	local has_auto=0
-
-	if [[ -z "$pr_number" ]]; then
-		print_error "Usage: full-loop-helper.sh merge <PR_NUMBER> [REPO] [--squash|--merge|--rebase] [--admin] [--auto]"
-		return 1
-	fi
-	shift
-
-	# Parse optional repo, merge method, and gh pass-through flags.
-	# --admin / --auto (GH#18731) pass straight through to `gh pr merge`.
-	for arg in "$@"; do
+_merge_parse_command_args() {
+	FULL_LOOP_MERGE_PARSED_REPO=""
+	FULL_LOOP_MERGE_PARSED_METHOD="--squash"
+	FULL_LOOP_MERGE_PARSED_ADMIN=0
+	FULL_LOOP_MERGE_PARSED_AUTO=0
+	FULL_LOOP_MERGE_PARSED_BODY_FILE=""
+	local arg=""
+	while [[ $# -gt 0 ]]; do
+		arg="$1"
+		shift
 		case "$arg" in
 		--squash | --merge | --rebase)
-			merge_method="$arg"
+			FULL_LOOP_MERGE_PARSED_METHOD="$arg"
 			;;
 		--admin)
-			has_admin=1
+			FULL_LOOP_MERGE_PARSED_ADMIN=1
 			;;
 		--auto)
-			has_auto=1
+			FULL_LOOP_MERGE_PARSED_AUTO=1
+			;;
+		"$FULL_LOOP_MERGE_BODY_FILE_FLAG")
+			if [[ $# -eq 0 || -n "$FULL_LOOP_MERGE_PARSED_BODY_FILE" ]]; then
+				print_error "--body-file requires exactly one path"
+				return 1
+			fi
+			FULL_LOOP_MERGE_PARSED_BODY_FILE="$1"
+			shift
+			;;
+		--body-file=*)
+			if [[ -n "$FULL_LOOP_MERGE_PARSED_BODY_FILE" || -z "${arg#--body-file=}" ]]; then
+				print_error "--body-file requires exactly one path"
+				return 1
+			fi
+			FULL_LOOP_MERGE_PARSED_BODY_FILE="${arg#--body-file=}"
 			;;
 		*)
-			if [[ -z "$repo" ]]; then
-				repo="$arg"
+			if [[ -z "$FULL_LOOP_MERGE_PARSED_REPO" ]]; then
+				FULL_LOOP_MERGE_PARSED_REPO="$arg"
 			else
 				print_error "Unknown argument: $arg"
 				return 1
@@ -1627,6 +1659,31 @@ cmd_merge() {
 			;;
 		esac
 	done
+
+	if [[ -n "$FULL_LOOP_MERGE_PARSED_BODY_FILE" &&
+		(! -f "$FULL_LOOP_MERGE_PARSED_BODY_FILE" || ! -r "$FULL_LOOP_MERGE_PARSED_BODY_FILE") ]]; then
+		print_error "Merge body file must be a readable regular file: ${FULL_LOOP_MERGE_PARSED_BODY_FILE}"
+		return 1
+	fi
+	return 0
+}
+
+cmd_merge() {
+	local pr_number="${1:-}"
+	if [[ -z "$pr_number" ]]; then
+		print_error "Usage: full-loop-helper.sh merge <PR_NUMBER> [REPO] [--squash|--merge|--rebase] [--admin] [--auto] [--body-file PATH]"
+		return 1
+	fi
+	shift
+
+	# Parse optional repo, merge method, and gh pass-through flags.
+	# --admin / --auto (GH#18731) pass straight through to `gh pr merge`.
+	_merge_parse_command_args "$@" || return 1
+	local repo="$FULL_LOOP_MERGE_PARSED_REPO"
+	local merge_method="$FULL_LOOP_MERGE_PARSED_METHOD"
+	local has_admin="$FULL_LOOP_MERGE_PARSED_ADMIN"
+	local has_auto="$FULL_LOOP_MERGE_PARSED_AUTO"
+	local merge_body_file="$FULL_LOOP_MERGE_PARSED_BODY_FILE"
 
 	# GH#19310 (t2141): `gh pr merge` rejects --admin and --auto together with:
 	#   "specify only one of `--auto`, `--disable-auto`, or `--admin`"
@@ -1666,7 +1723,7 @@ cmd_merge() {
 	# (t2412 / GH#20005)
 	_retarget_stacked_children_interactive "$pr_number" "$repo"
 
-	_merge_execute "$pr_number" "$repo" "$merge_method" "$has_admin" "$has_auto" || return 1
+	_merge_execute "$pr_number" "$repo" "$merge_method" "$has_admin" "$has_auto" "$merge_body_file" || return 1
 	if ! _merge_verify_completed_state "$pr_number" "$repo"; then
 		if [[ "$has_auto" -eq 1 ]]; then
 			print_info "LIFECYCLE_STATE=REMOTE_VERIFIED"

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -264,10 +264,12 @@ Commands:
                 [--no-rebase]              Explicit recovery mode after a failed/aborted rebase
   pre-merge-gate <PR> [REPO]    Check review bot gate before merge (GH#17541)
   wait-checks <PR> [options]     Wait with transition-only required-check output
-  merge <PR> [REPO] [--squash|--merge|--rebase] [--admin] [--auto]
+  merge <PR> [REPO] [--squash|--merge|--rebase] [--admin] [--auto] [--body-file PATH]
                                  Gate-enforced merge (runs pre-merge-gate first).
                                  --admin / --auto pass through to gh pr merge
                                  for branch-protected personal-account repos (GH#18731).
+                                 --body-file passes an exact merge commit body through all
+                                 merge transports after validating a readable regular file.
                                  --admin and --auto are mutually exclusive at the
                                  gh CLI level; if both are given, --admin wins and
                                   --auto is dropped (GH#19310).

--- a/.agents/scripts/tests/test-full-loop-merge-body-file.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-body-file.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 2
+AGENTS_SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)" || exit 2
+TEST_ROOT=""
+TEST_MODE="normal"
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local status="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		printf 'PASS %s\n' "$test_name"
+	else
+		printf 'FAIL %s\n' "$test_name"
+		[[ -n "$detail" ]] && printf '  %s\n' "$detail"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+capture_body_file_arg() {
+	local previous=""
+	local argument=""
+	for argument in "$@"; do
+		if [[ "$previous" == "--body-file" ]]; then
+			cp "$argument" "${TEST_ROOT}/captured-body"
+			return $?
+		fi
+		previous="$argument"
+	done
+	return 1
+}
+
+capture_rest_body_field() {
+	local argument=""
+	for argument in "$@"; do
+		case "$argument" in
+		commit_message=@*)
+			cp "${argument#commit_message=@}" "${TEST_ROOT}/captured-body"
+			return $?
+			;;
+		esac
+	done
+	return 1
+}
+
+gh() {
+	local command="${1:-}"
+	local subcommand="${2:-}"
+	if [[ "$command" == "pr" && "$subcommand" == "view" && "$*" == *"--json title,commits"* ]]; then
+		printf '%s\n' '{"title":"GH#29733: fix: preserve explicit merge bodies","commits":[{"messageHeadline":"fix: preserve explicit merge bodies"}]}'
+		return 0
+	fi
+	if [[ "$command" == "pr" && "$subcommand" == "merge" ]]; then
+		if [[ "$TEST_MODE" != "rest" ]]; then
+			capture_body_file_arg "$@" || true
+		fi
+		case "$TEST_MODE" in
+		admin)
+			if [[ "$*" != *"--admin"* ]]; then
+				printf '%s\n' 'At least 1 approving review is required' >&2
+				return 1
+			fi
+			;;
+		rest)
+			printf '%s\n' 'GraphQL: API rate limit already exceeded (rateLimitExceeded)' >&2
+			return 1
+			;;
+		esac
+		return 0
+	fi
+	if [[ "$command" == "api" && "$*" == *"pulls/42/merge"* ]]; then
+		capture_rest_body_field "$@" || return 1
+		printf '%s\n' '{"merged":true}'
+		return 0
+	fi
+	return 0
+}
+
+cmd_pre_merge_gate() {
+	return 0
+}
+
+setup_subject() {
+	TEST_ROOT=$(mktemp -d)
+	trap teardown EXIT
+	SCRIPT_DIR="$AGENTS_SCRIPTS_DIR"
+	# shellcheck source=../shared-constants.sh
+	source "${AGENTS_SCRIPTS_DIR}/shared-constants.sh"
+	# shellcheck source=../full-loop-helper-merge.sh
+	source "${AGENTS_SCRIPTS_DIR}/full-loop-helper-merge.sh"
+	_merge_resolve_match_head() {
+		printf '%s\n' 'fixture-head-sha'
+		return 0
+	}
+	_merge_review_state_still_clear() {
+		return 0
+	}
+	_merge_guard_admin_merge_maintainer_review() {
+		return 0
+	}
+	_merge_guard_prospective_todo() {
+		return 0
+	}
+	return 0
+}
+
+write_fixture_body() {
+	local body_file="$1"
+	printf '%s\n' \
+		'Aidevops-Signature: fixture' \
+		'Aidevops-Release-Aggregator-PR: 42' \
+		'Aidevops-Release-Aggregates: 29721@d53b458a6ee82e3dccd922c3791b9f9f088efa8f' >"$body_file"
+	return 0
+}
+
+assert_transport_preserves_body() {
+	local mode="$1"
+	local label="$2"
+	local body_file="${TEST_ROOT}/merge-body"
+	local rc=0
+	TEST_MODE="$mode"
+	rm -f "${TEST_ROOT}/captured-body"
+	write_fixture_body "$body_file"
+	_merge_execute 42 testorg/testrepo --squash 0 0 "$body_file" >/dev/null 2>&1 || rc=$?
+	if [[ "$rc" -eq 0 && -f "${TEST_ROOT}/captured-body" ]] && cmp -s "$body_file" "${TEST_ROOT}/captured-body"; then
+		print_result "$label preserves exact body bytes" 0
+	else
+		print_result "$label preserves exact body bytes" 1 "rc=${rc}"
+	fi
+	return 0
+}
+
+test_invalid_body_files_fail_before_gate() {
+	local missing="${TEST_ROOT}/missing-body"
+	local unreadable="${TEST_ROOT}/unreadable-body"
+	local gate_marker="${TEST_ROOT}/gate-called"
+	local rc=0
+	cmd_pre_merge_gate() {
+		: >"$gate_marker"
+		return 0
+	}
+
+	rm -f "$gate_marker"
+	cmd_merge 42 testorg/testrepo --body-file "$missing" >/dev/null 2>&1 || rc=$?
+	if [[ "$rc" -ne 0 && ! -e "$gate_marker" ]]; then
+		print_result "missing body file fails before merge gate" 0
+	else
+		print_result "missing body file fails before merge gate" 1 "rc=${rc}"
+	fi
+
+	printf '%s\n' 'unreadable' >"$unreadable"
+	chmod 000 "$unreadable"
+	rc=0
+	rm -f "$gate_marker"
+	cmd_merge 42 testorg/testrepo --body-file "$unreadable" >/dev/null 2>&1 || rc=$?
+	chmod 600 "$unreadable"
+	if [[ "$rc" -ne 0 && ! -e "$gate_marker" ]]; then
+		print_result "unreadable body file fails before merge gate" 0
+	else
+		print_result "unreadable body file fails before merge gate" 1 "rc=${rc}"
+	fi
+
+	rc=0
+	rm -f "$gate_marker"
+	cmd_merge 42 testorg/testrepo --body-file >/dev/null 2>&1 || rc=$?
+	if [[ "$rc" -ne 0 && ! -e "$gate_marker" ]]; then
+		print_result "body-file without a path fails before merge gate" 0
+	else
+		print_result "body-file without a path fails before merge gate" 1 "rc=${rc}"
+	fi
+	return 0
+}
+
+main() {
+	setup_subject
+	assert_transport_preserves_body normal "normal gh merge"
+	assert_transport_preserves_body admin "admin fallback"
+	assert_transport_preserves_body rest "REST fallback"
+	test_invalid_body_files_fail_before_gate
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]]
+	return $?
+}
+
+main "$@"

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -228,6 +228,8 @@ Verify it posted: `gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --jq '[.[
 full-loop-helper.sh merge "$PR_NUMBER" "$REPO"
 ```
 
+When the exact squash commit body is itself audited evidence, such as a release-aggregation signature and terminal trailer block, write that complete body to a regular file and pass `--body-file "$MERGE_BODY_FILE"`. The wrapper validates the file before remote mutation and preserves it across normal, admin-fallback, and REST-fallback merge transports; do not recreate the body inline or call `gh pr merge` directly.
+
 If the merge command reports that required checks are pending, do not run raw `gh pr checks --watch` or replay unchanged snapshots. Wait through the delta-aware exact-head path, then rerun `merge` only after terminal success:
 
 ```bash

--- a/TODO.md
+++ b/TODO.md
@@ -1230,6 +1230,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18211 Harden npm and Bun dependency supply-chain controls #security ref:GH#29717
 
+- [ ] t18213 Allow full-loop merges to preserve explicit commit bodies #bug ref:GH#29733
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Add validated --body-file parsing to the mandatory full-loop merge command and preserve the caller body across normal CLI merges, stale-auth retries, explicit/admin fallbacks, interactive auto-to-admin fallback, and GraphQL-to-REST fallback. Document the audited release-aggregation use case and add byte-exact transport regressions.

## Files Changed

.agents/scripts/full-loop-helper-merge.sh, .agents/scripts/full-loop-helper.sh, .agents/scripts/tests/test-full-loop-merge-body-file.sh, .agents/workflows/full-loop.md, TODO.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: focused body transport suite (6/6); core full-loop merge suite (76/76); gh shim suite (128/128); worktree cleanup suite (15/15); efficient orchestration and gate parity suites; ShellCheck; bash -n; git diff --check; .agents/scripts/linters-local.sh including string-literal, Bash 3.2, function-complexity, nesting, secret, and targeted-test gates. Known base failures: test-full-loop-merge-flag-conflict.sh (3) and test-full-loop-merge-authority-guard.sh (3) also fail unchanged at origin/main because fixtures return invalid squash-title metadata.

Resolves #29733


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.232 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h 57m and 994,855 tokens on this with the user in an interactive session.