### PR TITLE
GH#29736: fix: reserve Pulse REST core quota

### DIFF
--- a/.agents/configs/pulse-rate-limit.conf
+++ b/.agents/configs/pulse-rate-limit.conf
@@ -44,6 +44,22 @@
 # Env var AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD takes precedence if already set.
 AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD=0.05
 
+# ── REST core reserve (GH#29736) ────────────────────────────────────────────
+#
+# Keep this many REST-core requests available for an authenticated maintainer.
+# Pulse defers API-heavy optional stages once the authoritative response-header
+# probe reports this principal at or below the reserve. The probe is cached
+# briefly and expires at GitHub's reset epoch so a new rate-limit window
+# recovers automatically.
+#
+# Env var AIDEVOPS_PULSE_REST_CORE_RESERVE takes precedence. Set to 0 only for
+# a bounded diagnostic run; production automation should preserve this reserve.
+AIDEVOPS_PULSE_REST_CORE_RESERVE=500
+
+# Seconds that an authoritative REST response-header observation may be reused.
+# The reset epoch always takes precedence, so this cannot delay recovery.
+AIDEVOPS_PULSE_REST_CORE_PROBE_TTL=20
+
 # ── Cross-issue no_work rate circuit breaker (GH#20640, t2770) ────────────────
 #
 # Detects population-wide no_work storms (many DIFFERENT issues all returning

--- a/.agents/scripts/pulse-merge-routine.sh
+++ b/.agents/scripts/pulse-merge-routine.sh
@@ -116,6 +116,8 @@ fi
 
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/pulse-wrapper-config.sh"
+# shellcheck source=./pulse-rate-limit-circuit-breaker.sh
+source "${SCRIPT_DIR}/pulse-rate-limit-circuit-breaker.sh"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/pulse-repo-meta.sh"
 # GH#28207: pulse-merge.sh reconciles dependants after verified issue closure,
@@ -268,6 +270,19 @@ _pmr_graphql_budget_allows_run() {
 	[[ "$remaining" =~ ^[0-9]+$ ]] || remaining=0
 	if [[ "$remaining" -lt "$threshold" ]]; then
 		_pmr_log WARN "GraphQL budget depleted (${remaining} remaining < ${threshold}); deferring merge pass to next cycle (GH#24904)"
+		return 1
+	fi
+	return 0
+}
+
+_pmr_rest_core_reserve_allows_run() {
+	if ! declare -F pulse_rest_core_reserve_allows >/dev/null 2>&1; then
+		return 0
+	fi
+	local reserve_rc=0
+	pulse_rest_core_reserve_allows || reserve_rc=$?
+	if [[ "$reserve_rc" -ne 0 ]]; then
+		_pmr_log WARN "REST-core reserve unavailable or exhausted (rc=${reserve_rc}); deferring merge pass to preserve interactive maintainer quota (GH#29736)"
 		return 1
 	fi
 	return 0
@@ -454,6 +469,10 @@ cmd_run() {
 		date +%s >"$PULSE_MERGE_ROUTINE_LAST_RUN" 2>/dev/null || true
 		return 0
 	fi
+	if ! _pmr_rest_core_reserve_allows_run; then
+		date +%s >"$PULSE_MERGE_ROUTINE_LAST_RUN" 2>/dev/null || true
+		return 0
+	fi
 
 	# Wrap merge_ready_prs_all_repos with a hard timeout ceiling (t3041, GH#21708).
 	# Whatever the underlying hang site (gh API call, flock deadlock, infinite
@@ -524,6 +543,9 @@ cmd_dry_run() {
 		return 1
 	fi
 	if ! _pmr_graphql_budget_allows_run; then
+		return 0
+	fi
+	if ! _pmr_rest_core_reserve_allows_run; then
 		return 0
 	fi
 

--- a/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
@@ -91,6 +91,14 @@ _CB_RL_CACHE_FILE="${AIDEVOPS_PULSE_RATE_LIMIT_CACHE:-${HOME}/.aidevops/cache/pu
 _CB_RL_CACHE_TTL="${AIDEVOPS_PULSE_RATE_LIMIT_CACHE_TTL:-20}"
 _CB_RL_MODE_CACHED_ONLY="cached-only"
 
+# REST-core observations deliberately use a separate cache: the /rate_limit
+# projection can describe a different principal from the one serving a routed
+# REST request. A response header is authoritative for the request principal.
+_CB_REST_CORE_CACHE_FILE="${AIDEVOPS_PULSE_REST_CORE_CACHE:-${HOME}/.aidevops/cache/pulse-rest-core.json}"
+_CB_REST_CORE_PROBE_TTL="${AIDEVOPS_PULSE_REST_CORE_PROBE_TTL:-20}"
+_CB_REST_CORE_RESOURCE="core"
+_CB_REST_CORE_UNKNOWN="unknown"
+
 # Log prefix for all messages from this module.
 _CB_RL_LOG_PREFIX="[circuit-breaker-rl]"
 
@@ -155,6 +163,82 @@ _cb_rate_limit_json() {
 }
 
 #######################################
+# Probe REST core using response headers from the active gh principal.
+#
+# Stdout: the final HTTP response block, including headers. `-i` is essential:
+# rate_limit JSON is a projection and can identify a different principal.
+#######################################
+_cb_rest_core_probe() {
+	_cb_gh_read gh api -i user
+	return $?
+}
+
+#######################################
+# Extract one response-header value from the final HTTP response block.
+#######################################
+_cb_rest_core_header() {
+	local response="$1"
+	local name="$2"
+	printf '%s\n' "$response" | awk -v wanted="$name" '
+		BEGIN { IGNORECASE=1 }
+		/^HTTP\// { value=""; next }
+		{
+			line=$0
+			sub(/\r$/, "", line)
+			if (tolower(line) ~ "^" tolower(wanted) ":[[:space:]]*") {
+				sub(/^[^:]*:[[:space:]]*/, "", line)
+				value=line
+			}
+		}
+		END { print value }
+	'
+	return 0
+}
+
+#######################################
+# Return whether the active REST principal retains the configured reserve.
+#
+# Returns: 0 sufficient; 1 at/below reserve; 2 unavailable/malformed evidence.
+# Cached observations are never used past their TTL or GitHub reset epoch.
+#######################################
+pulse_rest_core_reserve_allows() {
+	local reserve="${AIDEVOPS_PULSE_REST_CORE_RESERVE:-${AIDEVOPS_PULSE_REST_DISPATCH_MIN_CORE_REMAINING:-500}}"
+	local ttl="$_CB_REST_CORE_PROBE_TTL"
+	local now observed=0 remaining limit reset resource
+	[[ "$reserve" =~ ^[0-9]+$ ]] || reserve=500
+	[[ "$ttl" =~ ^[0-9]+$ ]] || ttl=20
+	[[ "$reserve" -eq 0 ]] && return 0
+	now=$(date +%s 2>/dev/null) || now=0
+	[[ "$now" =~ ^[0-9]+$ ]] || now=0
+
+	if [[ -f "$_CB_REST_CORE_CACHE_FILE" ]]; then
+		read -r observed remaining limit reset resource < <(jq -r --arg unknown "$_CB_REST_CORE_UNKNOWN" '[.observed // 0, .remaining // $unknown, .limit // $unknown, .reset // 0, .resource // $unknown] | @tsv' "$_CB_REST_CORE_CACHE_FILE" 2>/dev/null) || true
+		if [[ "$observed" =~ ^[0-9]+$ && "$remaining" =~ ^[0-9]+$ && "$limit" =~ ^[0-9]+$ && "$reset" =~ ^[0-9]+$ &&
+			"$resource" == "$_CB_REST_CORE_RESOURCE" && "$now" -lt "$reset" && $((now - observed)) -le "$ttl" ]]; then
+			[[ "$remaining" -gt "$reserve" ]] && return 0
+			return 1
+		fi
+	fi
+
+	local response
+	response=$(_cb_rest_core_probe) || return 2
+	remaining=$(_cb_rest_core_header "$response" "X-RateLimit-Remaining")
+	limit=$(_cb_rest_core_header "$response" "X-RateLimit-Limit")
+	reset=$(_cb_rest_core_header "$response" "X-RateLimit-Reset")
+	resource=$(_cb_rest_core_header "$response" "X-RateLimit-Resource")
+	if [[ ! "$remaining" =~ ^[0-9]+$ || ! "$limit" =~ ^[0-9]+$ || ! "$reset" =~ ^[0-9]+$ || "$resource" != "$_CB_REST_CORE_RESOURCE" || "$reset" -le "$now" ]]; then
+		return 2
+	fi
+	mkdir -p "$(dirname "$_CB_REST_CORE_CACHE_FILE")" 2>/dev/null || true
+	jq -cn --arg resource "$_CB_REST_CORE_RESOURCE" --argjson observed "$now" --argjson remaining "$remaining" \
+		--argjson limit "$limit" --argjson reset "$reset" \
+		'{observed: $observed, remaining: $remaining, limit: $limit, reset: $reset, resource: $resource}' \
+		>"$_CB_REST_CORE_CACHE_FILE" 2>/dev/null || true
+	[[ "$remaining" -gt "$reserve" ]] && return 0
+	return 1
+}
+
+#######################################
 # Allow degraded dispatch when only GraphQL is exhausted.
 #
 # Args:
@@ -177,24 +261,17 @@ _cb_allow_dispatch_with_rest_fallback() {
 		return 1
 	fi
 
-	local core_remaining="" core_limit="" min_core=""
-	core_remaining=$(printf '%s' "$rate_json" | jq -r '.resources.core.remaining // ""') || core_remaining=""
-	core_limit=$(printf '%s' "$rate_json" | jq -r '.resources.core.limit // ""') || core_limit=""
-	min_core="${AIDEVOPS_PULSE_REST_DISPATCH_MIN_CORE_REMAINING:-250}"
-
-	if [[ ! "$core_remaining" =~ ^[0-9]+$ ]] || [[ ! "$core_limit" =~ ^[0-9]+$ ]] || [[ ! "$min_core" =~ ^[0-9]+$ ]]; then
-		return 1
-	fi
-
-	if [[ "$core_remaining" -lt "$min_core" ]]; then
-		echo "${_CB_RL_LOG_PREFIX} GraphQL budget exhausted and REST fallback unavailable: core remaining=${core_remaining}/${core_limit} < min_core=${min_core}" >>"$LOGFILE"
+	local core_rc=0
+	pulse_rest_core_reserve_allows || core_rc=$?
+	if [[ "$core_rc" -ne 0 ]]; then
+		echo "${_CB_RL_LOG_PREFIX} GraphQL budget exhausted and REST fallback unavailable: authoritative REST-core reserve is unavailable or exhausted (rc=${core_rc})" >>"$LOGFILE"
 		return 1
 	fi
 
 	export AIDEVOPS_GH_FORCE_REST_READS=1
 	export AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK_ACTIVE=1
-	export AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK_CORE_REMAINING="$core_remaining"
-	echo "${_CB_RL_LOG_PREFIX} GraphQL budget EXHAUSTED: remaining=${graphql_remaining}/${graphql_limit} (threshold=${graphql_threshold_count}, configured=${threshold}) — dispatch_rest_fallback=true; proceeding with REST-backed dispatch reads (core=${core_remaining}/${core_limit}, min_core=${min_core})" >>"$LOGFILE"
+	export AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK_CORE_REMAINING="header-authorized"
+	echo "${_CB_RL_LOG_PREFIX} GraphQL budget EXHAUSTED: remaining=${graphql_remaining}/${graphql_limit} (threshold=${graphql_threshold_count}, configured=${threshold}) — dispatch_rest_fallback=true; proceeding with header-authorized REST-backed dispatch reads" >>"$LOGFILE"
 	if declare -F pulse_stats_increment >/dev/null 2>&1; then
 		pulse_stats_increment "pulse_dispatch_rest_fallback" 2>/dev/null || true
 	fi

--- a/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
@@ -86,9 +86,24 @@ export -f pulse_stats_increment pulse_stats_get_24h
 #   STUB_GH_REMAINING — GraphQL remaining value (default 5000)
 #   STUB_GH_LIMIT     — GraphQL limit value (default 5000)
 #   STUB_GH_CORE_REMAINING — REST core remaining value (unset omits core budget)
+#   STUB_GH_CORE_RESET — REST core reset epoch (default: now+3600)
 #   STUB_GH_RESET     — GraphQL reset epoch (default: now+3600)
 #   STUB_GH_FAIL      — 1 to make gh api rate_limit fail entirely
 gh() {
+	if [[ "$1" == "api" && "$2" == "-i" && "$3" == "user" ]]; then
+		if [[ "${STUB_GH_FAIL:-0}" == "1" ]]; then
+			return 1
+		fi
+		# Omitted core state simulates an unavailable authoritative probe so the
+		# legacy GraphQL-only breaker cases remain independent of REST fallback.
+		[[ -n "${STUB_GH_CORE_REMAINING:-}" ]] || return 0
+		local core_remaining="$STUB_GH_CORE_REMAINING"
+		local core_limit="${STUB_GH_CORE_LIMIT:-5000}"
+		local core_reset="${STUB_GH_CORE_RESET:-$(($(date +%s) + 3600))}"
+		printf 'HTTP/2 200\nx-ratelimit-resource: core\nx-ratelimit-remaining: %s\nx-ratelimit-limit: %s\nx-ratelimit-reset: %s\n\n{}\n' \
+			"$core_remaining" "$core_limit" "$core_reset"
+		return 0
+	fi
 	if [[ "$1" == "api" && "$2" == "rate_limit" ]]; then
 		printf 'rate-limit\n' >>"$GH_RATE_CALLS"
 		[[ "${STUB_GH_DELAY:-0}" == "0" ]] || sleep "$STUB_GH_DELAY"
@@ -154,6 +169,7 @@ reset_test_state() {
 	: >"$GH_RATE_CALLS"
 	rm -f "${HOME}/.aidevops/logs/pulse-graphql-circuit-breaker.state"
 	rm -f "${HOME}/.aidevops/cache/pulse-graphql-rate-limit.json"
+	rm -f "${HOME}/.aidevops/cache/pulse-rest-core.json"
 	unset AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER 2>/dev/null || true
 	unset AIDEVOPS_PULSE_RATE_LIMIT_CACHE_TTL 2>/dev/null || true
 	unset AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK 2>/dev/null || true
@@ -161,11 +177,13 @@ reset_test_state() {
 	unset AIDEVOPS_GH_FORCE_REST_READS 2>/dev/null || true
 	unset STUB_GH_CORE_REMAINING 2>/dev/null || true
 	unset STUB_GH_CORE_LIMIT 2>/dev/null || true
+	unset STUB_GH_CORE_RESET 2>/dev/null || true
 	unset STUB_GH_FAIL 2>/dev/null || true
 	unset STUB_GH_DELAY 2>/dev/null || true
 	STUB_GH_REMAINING=5000
 	STUB_GH_LIMIT=5000
 	export AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD="0.05"
+	export AIDEVOPS_PULSE_REST_CORE_RESERVE=500
 	return 0
 }
 
@@ -450,6 +468,38 @@ test_graphql_exhausted_rest_fallback_disabled_blocks_dispatch() {
 		pass "GraphQL exhausted blocks dispatch when REST fallback is disabled"
 	else
 		fail "disabled REST fallback should not allow dispatch" "rc=$rc active=${AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK_ACTIVE:-unset} force_rest=${AIDEVOPS_GH_FORCE_REST_READS:-unset}"
+	fi
+	return 0
+}
+
+# --- Test 18: Cached response-header probe avoids a second REST request ---
+test_rest_core_probe_cache_reuse() {
+	reset_test_state
+	STUB_GH_REMAINING=0
+	STUB_GH_CORE_REMAINING=900
+	is_graphql_budget_sufficient || true
+	STUB_GH_CORE_REMAINING=1
+	is_graphql_budget_sufficient || true
+	if [[ "${AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK_ACTIVE:-0}" == "1" ]]; then
+		pass "REST core reserve reuses fresh response-header probe"
+	else
+		fail "REST core reserve should reuse fresh response-header probe"
+	fi
+	return 0
+}
+
+# --- Test 19: Expired response-header observation cannot authorize fallback ---
+test_rest_core_probe_reset_forces_recheck() {
+	reset_test_state
+	STUB_GH_REMAINING=0
+	STUB_GH_CORE_REMAINING=900
+	STUB_GH_CORE_RESET=$(($(date +%s) - 1))
+	local rc=0
+	is_graphql_budget_sufficient || rc=$?
+	if [[ "$rc" -eq 1 ]]; then
+		pass "expired REST core header observation blocks fallback"
+	else
+		fail "expired REST core header observation should block fallback" "rc=$rc"
 	fi
 	return 0
 }
@@ -794,6 +844,8 @@ test_log_message_on_trip
 test_graphql_exhausted_rest_core_healthy_allows_dispatch
 test_graphql_exhausted_rest_core_low_blocks_dispatch
 test_graphql_exhausted_rest_fallback_disabled_blocks_dispatch
+test_rest_core_probe_cache_reuse
+test_rest_core_probe_reset_forces_recheck
 test_shared_rate_probe_coalesces_consumers
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Adds a header-authoritative REST-core reserve, short-lived reset-aware cache, and merge routine gate.

## Files Changed

.agents/configs/pulse-rate-limit.conf, .agents/scripts/pulse-merge-routine.sh, .agents/scripts/pulse-rate-limit-circuit-breaker.sh, .agents/scripts/tests/test-rate-limit-circuit-breaker.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-rate-limit-circuit-breaker.sh; bash .agents/scripts/tests/test-pulse-merge-routine-standalone.sh; .agents/scripts/linters-local.sh

Resolves #29736


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.232 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 11m and 104,061 tokens on this as a headless worker.