### PR TITLE
GH#29736: Preserve REST core quota for maintainer operations

### DIFF
--- a/.agents/configs/pulse-rate-limit.conf
+++ b/.agents/configs/pulse-rate-limit.conf
@@ -44,6 +44,11 @@
 # Env var AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD takes precedence if already set.
 AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD=0.05
 
+# REST core reserve retained for interactive maintainer operations. Pulse probes
+# the actual request principal's response headers and defers nonessential API
+# stages at or below this floor. Set to 0 only for emergency diagnostics.
+AIDEVOPS_PULSE_CORE_RESERVE=1000
+
 # ── Cross-issue no_work rate circuit breaker (GH#20640, t2770) ────────────────
 #
 # Detects population-wide no_work storms (many DIFFERENT issues all returning

--- a/.agents/scripts/pulse-merge-routine.sh
+++ b/.agents/scripts/pulse-merge-routine.sh
@@ -116,6 +116,8 @@ fi
 
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/pulse-wrapper-config.sh"
+# shellcheck source=./pulse-rate-limit-circuit-breaker.sh
+source "${SCRIPT_DIR}/pulse-rate-limit-circuit-breaker.sh"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/pulse-repo-meta.sh"
 # GH#28207: pulse-merge.sh reconciles dependants after verified issue closure,
@@ -261,6 +263,12 @@ _pmr_graphql_remaining() {
 }
 
 _pmr_graphql_budget_allows_run() {
+	local core_rc=0
+	is_core_budget_sufficient || core_rc=$?
+	if [[ "$core_rc" -eq 1 ]]; then
+		_pmr_log WARN "REST core reserve reached; deferring merge pass to preserve interactive maintainer quota (GH#29736)"
+		return 1
+	fi
 	local threshold="${AIDEVOPS_PULSE_MERGE_GRAPHQL_MIN_REMAINING:-500}"
 	[[ "$threshold" =~ ^[0-9]+$ ]] || threshold=500
 	local remaining=""

--- a/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# pulse-rate-limit-circuit-breaker.sh — Pulse-level circuit breaker for GraphQL rate-limit budget (t2690, GH#20310)
+# pulse-rate-limit-circuit-breaker.sh — Pulse-level circuit breakers for GitHub API budgets (t2690, GH#20310, GH#29736)
 #
-# Proactive defence: pauses worker dispatch when the GitHub GraphQL rate-limit
+# Proactive defence: pauses Pulse work when the GitHub GraphQL or REST core
 # budget is exhausted or nearly exhausted. Without this, the pulse keeps spawning
 # workers that fail at step 1 (issue read / PR create / issue edit), burning
 # $0.05–$0.25 per doomed dispatch and triggering watchdog kills.
@@ -54,6 +54,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+_CB_RL_THRESHOLD_WAS_SET="${AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD+x}"
+_CB_RL_THRESHOLD_OVERRIDE="${AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD:-}"
+_CB_RL_CORE_RESERVE_WAS_SET="${AIDEVOPS_PULSE_CORE_RESERVE+x}"
+_CB_RL_CORE_RESERVE_OVERRIDE="${AIDEVOPS_PULSE_CORE_RESERVE:-}"
 
 # shellcheck source=./shared-gh-request-state.sh
 if [[ -f "${SCRIPT_DIR}/shared-gh-request-state.sh" ]]; then
@@ -77,12 +81,21 @@ if [[ -z "${AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD+x}" ]] && [[ -f "$_CB_RL_CO
 	# shellcheck disable=SC1090
 	source "$_CB_RL_CONF"
 fi
+if [[ -n "$_CB_RL_THRESHOLD_WAS_SET" ]]; then
+	AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD="$_CB_RL_THRESHOLD_OVERRIDE"
+fi
+if [[ -n "$_CB_RL_CORE_RESERVE_WAS_SET" ]]; then
+	AIDEVOPS_PULSE_CORE_RESERVE="$_CB_RL_CORE_RESERVE_OVERRIDE"
+fi
+unset _CB_RL_THRESHOLD_WAS_SET _CB_RL_THRESHOLD_OVERRIDE
+unset _CB_RL_CORE_RESERVE_WAS_SET _CB_RL_CORE_RESERVE_OVERRIDE
 
 # LOGFILE for sourced-mode usage (caller sets it; standalone mode defines a default).
 LOGFILE="${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}"
 
 # State file for tracking when the breaker last tripped (for status reporting).
 _CIRCUIT_BREAKER_STATE_FILE="${HOME}/.aidevops/logs/pulse-graphql-circuit-breaker.state"
+_CORE_CIRCUIT_BREAKER_STATE_FILE="${HOME}/.aidevops/logs/pulse-core-circuit-breaker.state"
 
 # Short-lived cache for the free rate_limit endpoint. The dispatch loop can ask
 # for budget state once per candidate; caching keeps diagnostics and in-loop
@@ -126,10 +139,80 @@ _cb_gh_read() {
 }
 
 #######################################
+# Parse authoritative REST core quota headers from a framed API response.
+#
+# Args:
+#   $1 - `gh api --include --silent` response headers
+#
+# Stdout: compact JSON with remaining, limit, and reset.
+#######################################
+_cb_core_headers_json() {
+	local response="$1"
+	local parsed=""
+	local status=""
+	local remaining=""
+	local limit=""
+	local reset=""
+	local resource=""
+	parsed=$(printf '%s\n' "$response" | awk '
+		{ sub(/\r$/, "", $0) }
+		$1 ~ /^HTTP\// {
+			status = $2
+			remaining = ""
+			limit = ""
+			reset = ""
+			resource = ""
+		}
+		tolower($1) == "x-ratelimit-remaining:" { remaining = $2 }
+		tolower($1) == "x-ratelimit-limit:" { limit = $2 }
+		tolower($1) == "x-ratelimit-reset:" { reset = $2 }
+		tolower($1) == "x-ratelimit-resource:" { resource = tolower($2) }
+		END {
+			if ((status ~ /^2[0-9][0-9]$/ || status == "403" || status == "429") &&
+				resource == "core" && remaining ~ /^[0-9]+$/ && limit ~ /^[0-9]+$/ && reset ~ /^[0-9]+$/) {
+				printf "%s\t%s\t%s", remaining, limit, reset
+				exit 0
+			}
+			exit 1
+		}') || parsed=""
+	[[ -n "$parsed" ]] || return 1
+	IFS=$'\t' read -r remaining limit reset <<<"$parsed"
+	[[ "$remaining" =~ ^[0-9]+$ && "$limit" =~ ^[0-9]+$ && "$reset" =~ ^[0-9]+$ ]] || return 1
+	jq -cn --argjson remaining "$remaining" --argjson limit "$limit" --argjson reset "$reset" \
+		'{remaining:$remaining,limit:$limit,reset:$reset,source:"response-headers"}'
+	return $?
+}
+
+#######################################
 # Fetch the full rate-limit projection through the circuit breaker's timeout.
 #######################################
 _cb_rate_limit_transport() {
-	_cb_gh_read gh api rate_limit
+	local rate_json="" header_response="" header_core=""
+	local projected_remaining="" projected_reset="" header_remaining="" header_reset=""
+	rate_json=$(_cb_gh_read gh api rate_limit) || return 1
+	if [[ "${AIDEVOPS_PULSE_CORE_AUTHORITATIVE_PROBE:-1}" != "1" ]]; then
+		printf '%s\n' "$rate_json"
+		return 0
+	fi
+
+	# `/rate_limit` can report a different principal/window from the credential
+	# used by ordinary REST calls. One cached `/user` request supplies the actual
+	# response headers for the transport principal that Pulse is consuming.
+	header_response=$(_cb_gh_read gh api user --include --silent 2>/dev/null) || true
+	header_core=$(_cb_core_headers_json "$header_response" 2>/dev/null) || header_core=""
+	if [[ -z "$header_core" ]]; then
+		printf '%s\n' "$rate_json"
+		return 0
+	fi
+
+	projected_remaining=$(printf '%s' "$rate_json" | jq -r '.resources.core.remaining // ""' 2>/dev/null) || projected_remaining=""
+	projected_reset=$(printf '%s' "$rate_json" | jq -r '.resources.core.reset // ""' 2>/dev/null) || projected_reset=""
+	header_remaining=$(printf '%s' "$header_core" | jq -r '.remaining') || header_remaining=""
+	header_reset=$(printf '%s' "$header_core" | jq -r '.reset') || header_reset=""
+	if [[ "$projected_remaining" != "$header_remaining" || "$projected_reset" != "$header_reset" ]]; then
+		echo "${_CB_RL_LOG_PREFIX} REST core projection mismatch: rate_limit=${projected_remaining:-?}@${projected_reset:-?} response_headers=${header_remaining:-?}@${header_reset:-?}; using response headers (GH#29736)" >>"$LOGFILE"
+	fi
+	jq -c --argjson core "$header_core" '.resources.core = $core' <<<"$rate_json"
 	return $?
 }
 
@@ -152,6 +235,54 @@ _cb_rate_limit_json() {
 	[[ "$mode" == "$_CB_RL_MODE_CACHED_ONLY" ]] && return 1
 	_cb_rate_limit_transport
 	return $?
+}
+
+#######################################
+# Check whether the authenticated REST core budget preserves maintainer headroom.
+#
+# Returns: 0 when Pulse may proceed, 1 when it must defer, 2 on probe error.
+#######################################
+is_core_budget_sufficient() {
+	if [[ "${AIDEVOPS_SKIP_PULSE_CORE_CIRCUIT_BREAKER:-0}" == "1" ]]; then
+		echo "${_CB_RL_LOG_PREFIX} AIDEVOPS_SKIP_PULSE_CORE_CIRCUIT_BREAKER=1 — bypassing REST core check" >>"$LOGFILE"
+		return 0
+	fi
+
+	local reserve="${AIDEVOPS_PULSE_CORE_RESERVE:-1000}"
+	[[ "$reserve" =~ ^[0-9]+$ ]] || reserve=1000
+	[[ "$reserve" -gt 0 ]] || return 0
+
+	local rate_json=""
+	local remaining=""
+	local limit=""
+	local reset=""
+	rate_json=$(_cb_rate_limit_json normal) || rate_json=""
+	if [[ -z "$rate_json" ]]; then
+		echo "${_CB_RL_LOG_PREFIX} WARNING: REST core quota probe failed — proceeding fail-open" >>"$LOGFILE"
+		return 2
+	fi
+	remaining=$(printf '%s' "$rate_json" | jq -r '.resources.core.remaining // ""') || remaining=""
+	limit=$(printf '%s' "$rate_json" | jq -r '.resources.core.limit // ""') || limit=""
+	reset=$(printf '%s' "$rate_json" | jq -r '.resources.core.reset // ""') || reset=""
+	if [[ ! "$remaining" =~ ^[0-9]+$ || ! "$limit" =~ ^[0-9]+$ || ! "$reset" =~ ^[0-9]+$ ]]; then
+		echo "${_CB_RL_LOG_PREFIX} WARNING: could not parse REST core quota — proceeding fail-open" >>"$LOGFILE"
+		return 2
+	fi
+
+	if [[ "$remaining" -le "$reserve" ]]; then
+		echo "${_CB_RL_LOG_PREFIX} REST core reserve reached: remaining=${remaining}/${limit} <= reserve=${reserve}, reset=${reset} — deferring nonessential Pulse work (GH#29736)" >>"$LOGFILE"
+		printf '%s %s %s %s\n' "$(date +%s)" "$remaining" "$limit" "$reset" >"$_CORE_CIRCUIT_BREAKER_STATE_FILE" 2>/dev/null || true
+		if declare -F pulse_stats_increment >/dev/null 2>&1; then
+			pulse_stats_increment "pulse_core_circuit_broken" 2>/dev/null || true
+		fi
+		return 1
+	fi
+
+	if [[ -f "$_CORE_CIRCUIT_BREAKER_STATE_FILE" ]]; then
+		echo "${_CB_RL_LOG_PREFIX} REST core budget recovered: remaining=${remaining}/${limit} > reserve=${reserve}" >>"$LOGFILE"
+		rm -f "$_CORE_CIRCUIT_BREAKER_STATE_FILE" 2>/dev/null || true
+	fi
+	return 0
 }
 
 #######################################
@@ -209,9 +340,15 @@ _cb_allow_dispatch_with_rest_fallback() {
 # Returns: 0 when dispatch may proceed, 1 when dispatch should defer, 2 on API error.
 #######################################
 is_graphql_budget_sufficient() {
-	# Emergency bypass.
+	# The REST core reserve is independent: bypassing the GraphQL breaker must
+	# never consume quota reserved for interactive maintainer operations.
+	local core_rc=0
+	is_core_budget_sufficient || core_rc=$?
+	[[ "$core_rc" -ne 1 ]] || return 1
+
+	# GraphQL-only emergency bypass.
 	if [[ "${AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER:-0}" == "1" ]]; then
-		echo "${_CB_RL_LOG_PREFIX} AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER=1 — bypassing rate-limit check" >>"$LOGFILE"
+		echo "${_CB_RL_LOG_PREFIX} AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER=1 — bypassing GraphQL rate-limit check" >>"$LOGFILE"
 		return 0
 	fi
 

--- a/.agents/scripts/pulse-wrapper-bootstrap.sh
+++ b/.agents/scripts/pulse-wrapper-bootstrap.sh
@@ -188,6 +188,9 @@ _pulse_run_merge_only() {
 	local _mo_lockdir="${HOME}/.aidevops/locks/pulse-merge-instance.lock"
 	local _mo_log="${HOME}/.aidevops/logs/pulse-merge.log"
 	local _mo_last_run="${HOME}/.aidevops/logs/pulse-merge-routine-last-run"
+	if declare -F _pulse_core_budget_gate >/dev/null 2>&1 && ! _pulse_core_budget_gate; then
+		return 0
+	fi
 
 	mkdir -p "${HOME}/.aidevops/locks" "$(dirname "$_mo_log")" 2>/dev/null || true
 

--- a/.agents/scripts/pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/pulse-wrapper-cycle-gates.sh
@@ -39,6 +39,21 @@ _PULSE_EFFICIENCY_CONTRACT_VERSION=2
 _PULSE_EFFICIENCY_COVERAGE_GENERATION=2
 _PULSE_LEGACY_CYCLE_OUTCOME_PENDING=0
 
+_pulse_core_budget_gate() {
+	local core_rc=0
+	if ! declare -F is_core_budget_sufficient >/dev/null 2>&1; then
+		return 0
+	fi
+	is_core_budget_sufficient || core_rc=$?
+	if [[ "$core_rc" -eq 1 ]]; then
+		printf '[pulse-wrapper] REST core reserve reached; deferring API-heavy cycle stages (GH#29736)\n' \
+			>>"${LOGFILE:-/dev/null}"
+		return 1
+	fi
+	# Probe errors fail open to preserve existing availability semantics.
+	return 0
+}
+
 _pulse_efficiency_record() {
 	local name="$1"
 	local value="${2:-1}"

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1221,6 +1221,10 @@ source "${SCRIPT_DIR}/pulse-wrapper-cycle-gates.sh"
 # ---------------------------------------------------------------------------
 _pulse_run_deterministic_pipeline() {
 	_pulse_drain_prefetch_counters # t3027: bridge subshell counters
+	if ! _pulse_core_budget_gate; then
+		_pulse_cycle_state_note_blocker core-rate-limit pulse-wrapper rest-core-reserve || true
+		return 0
+	fi
 	if [[ -f "$STOP_FLAG" ]]; then
 		_pulse_cycle_state_note_blocker stop-requested pulse-wrapper stop-flag || true
 	fi
@@ -1746,6 +1750,11 @@ main() {
 	if [[ "${PULSE_DRY_RUN:-0}" != "1" ]]; then
 		_pulse_cycle_state_start
 		write_pulse_health_file || true
+	fi
+	if ! _pulse_core_budget_gate; then
+		_pulse_cycle_state_note_blocker core-rate-limit pulse-wrapper rest-core-reserve || true
+		_pulse_cycle_state_finish_if_needed blocked
+		return 0
 	fi
 
 	# GH#22631: `circuit-breaker-helper.sh status` can report an overdue

--- a/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
@@ -89,6 +89,13 @@ export -f pulse_stats_increment pulse_stats_get_24h
 #   STUB_GH_RESET     — GraphQL reset epoch (default: now+3600)
 #   STUB_GH_FAIL      — 1 to make gh api rate_limit fail entirely
 gh() {
+	if [[ "$1" == "api" && "$2" == "user" ]]; then
+		[[ -n "${STUB_GH_CORE_HEADER_REMAINING:-}" ]] || return 0
+		printf 'HTTP/2.0 200 OK\nX-Ratelimit-Limit: %s\nX-Ratelimit-Remaining: %s\nX-Ratelimit-Reset: %s\nX-Ratelimit-Resource: core\n' \
+			"${STUB_GH_CORE_HEADER_LIMIT:-5000}" "${STUB_GH_CORE_HEADER_REMAINING}" \
+			"${STUB_GH_CORE_HEADER_RESET:-$(($(date +%s) + 3600))}"
+		return 0
+	fi
 	if [[ "$1" == "api" && "$2" == "rate_limit" ]]; then
 		printf 'rate-limit\n' >>"$GH_RATE_CALLS"
 		[[ "${STUB_GH_DELAY:-0}" == "0" ]] || sleep "$STUB_GH_DELAY"
@@ -153,6 +160,7 @@ reset_test_state() {
 	: >"$STATS_COUNTER_FILE"
 	: >"$GH_RATE_CALLS"
 	rm -f "${HOME}/.aidevops/logs/pulse-graphql-circuit-breaker.state"
+	rm -f "${HOME}/.aidevops/logs/pulse-core-circuit-breaker.state"
 	rm -f "${HOME}/.aidevops/cache/pulse-graphql-rate-limit.json"
 	unset AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER 2>/dev/null || true
 	unset AIDEVOPS_PULSE_RATE_LIMIT_CACHE_TTL 2>/dev/null || true
@@ -163,6 +171,8 @@ reset_test_state() {
 	unset STUB_GH_CORE_LIMIT 2>/dev/null || true
 	unset STUB_GH_FAIL 2>/dev/null || true
 	unset STUB_GH_DELAY 2>/dev/null || true
+	unset STUB_GH_CORE_HEADER_REMAINING STUB_GH_CORE_HEADER_LIMIT STUB_GH_CORE_HEADER_RESET 2>/dev/null || true
+	unset AIDEVOPS_PULSE_CORE_RESERVE AIDEVOPS_SKIP_PULSE_CORE_CIRCUIT_BREAKER 2>/dev/null || true
 	STUB_GH_REMAINING=5000
 	STUB_GH_LIMIT=5000
 	export AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD="0.05"
@@ -773,6 +783,72 @@ test_shared_rate_probe_coalesces_consumers() {
 	return 0
 }
 
+test_core_breaker_uses_authoritative_headers() {
+	reset_test_state
+	export STUB_GH_CORE_REMAINING=4997
+	export STUB_GH_CORE_HEADER_REMAINING=900
+	export AIDEVOPS_PULSE_CORE_RESERVE=1000
+	local rc=0
+	is_core_budget_sufficient || rc=$?
+	if [[ "$rc" -eq 1 ]]; then
+		pass "REST core breaker trusts active-principal response headers over rate_limit projection"
+	else
+		fail "REST core breaker should trip on authoritative remaining=900 (rc=$rc)"
+	fi
+	return 0
+}
+
+test_core_breaker_passes_above_reserve() {
+	reset_test_state
+	export STUB_GH_CORE_REMAINING=900
+	export STUB_GH_CORE_HEADER_REMAINING=4000
+	export AIDEVOPS_PULSE_CORE_RESERVE=1000
+	local rc=0
+	is_core_budget_sufficient || rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		pass "REST core breaker passes when authoritative budget exceeds reserve"
+	else
+		fail "REST core breaker should pass on authoritative remaining=4000 (rc=$rc)"
+	fi
+	return 0
+}
+
+test_core_breaker_recovers_after_reset() {
+	reset_test_state
+	export STUB_GH_CORE_HEADER_REMAINING=500
+	export AIDEVOPS_PULSE_CORE_RESERVE=1000
+	is_core_budget_sufficient >/dev/null 2>&1 || true
+	if [[ ! -f "${HOME}/.aidevops/logs/pulse-core-circuit-breaker.state" ]]; then
+		fail "REST core breaker should write state on trip"
+		return 0
+	fi
+	rm -f "${HOME}/.aidevops/cache/pulse-graphql-rate-limit.json"
+	export STUB_GH_CORE_HEADER_REMAINING=4500
+	local rc=0
+	is_core_budget_sufficient || rc=$?
+	if [[ "$rc" -eq 0 && ! -f "${HOME}/.aidevops/logs/pulse-core-circuit-breaker.state" ]]; then
+		pass "REST core breaker clears state after budget reset"
+	else
+		fail "REST core breaker should recover after reset (rc=$rc)"
+	fi
+	return 0
+}
+
+test_graphql_bypass_preserves_core_reserve() {
+	reset_test_state
+	export STUB_GH_CORE_HEADER_REMAINING=500
+	export AIDEVOPS_PULSE_CORE_RESERVE=1000
+	export AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER=1
+	local rc=0
+	is_graphql_budget_sufficient || rc=$?
+	if [[ "$rc" -eq 1 ]]; then
+		pass "GraphQL emergency bypass does not bypass REST core reserve"
+	else
+		fail "GraphQL bypass must retain REST core protection (rc=$rc)"
+	fi
+	return 0
+}
+
 # =============================================================================
 # Run all tests
 # =============================================================================
@@ -795,6 +871,10 @@ test_graphql_exhausted_rest_core_healthy_allows_dispatch
 test_graphql_exhausted_rest_core_low_blocks_dispatch
 test_graphql_exhausted_rest_fallback_disabled_blocks_dispatch
 test_shared_rate_probe_coalesces_consumers
+test_core_breaker_uses_authoritative_headers
+test_core_breaker_passes_above_reserve
+test_core_breaker_recovers_after_reset
+test_graphql_bypass_preserves_core_reserve
 
 # =============================================================================
 # Summary


### PR DESCRIPTION
## Summary

Use authoritative same-principal REST response headers and gate Pulse dispatch, merge, reconciliation, and routine work at a configurable reserve.

## Files Changed

.agents/configs/pulse-rate-limit.conf, .agents/scripts/pulse-merge-routine.sh, .agents/scripts/pulse-rate-limit-circuit-breaker.sh, .agents/scripts/pulse-wrapper-bootstrap.sh, .agents/scripts/pulse-wrapper-cycle-gates.sh, .agents/scripts/pulse-wrapper.sh, .agents/scripts/tests/test-rate-limit-circuit-breaker.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: live check detected the observed /rate_limit versus /user mismatch and tripped at 3185 remaining with a 4500 test reserve; rate-limit suite 36/36, merge routine 32/32, cycle gates 19/19, dry-run 7/7, characterization 42/42, ShellCheck and linters-local passed.

Resolves #29736


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.232 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 2h 6m and 974,729 tokens on this with the user in an interactive session.