### PR TITLE
GH#29742: Prioritize Pulse REST work and adapt the maintainer quota reserve

### DIFF
--- a/.agents/configs/pulse-rate-limit.conf
+++ b/.agents/configs/pulse-rate-limit.conf
@@ -44,17 +44,24 @@
 # Env var AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD takes precedence if already set.
 AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD=0.05
 
-# ── REST core reserve (GH#29736) ────────────────────────────────────────────
+# ── REST core adaptive priority reserve (GH#29736, GH#29742) ────────────────
 #
-# Keep this many REST-core requests available for an authenticated maintainer.
-# Pulse defers API-heavy optional stages once the authoritative response-header
-# probe reports this principal at or below the reserve. The probe is cached
-# briefly and expires at GitHub's reset epoch so a new rate-limit window
-# recovers automatically.
+# Maximum early-window soft reserve for authenticated REST-core requests. Pulse
+# linearly decays this threshold toward the hard floor as reset approaches.
+# Deferrable stages pause at the adaptive threshold; progress stages continue
+# until the hard floor. Shared interactive wrappers are not globally gated.
 #
 # Env var AIDEVOPS_PULSE_REST_CORE_RESERVE takes precedence. Set to 0 only for
-# a bounded diagnostic run; production automation should preserve this reserve.
+# a bounded diagnostic run; it disables both REST priority thresholds.
 AIDEVOPS_PULSE_REST_CORE_RESERVE=500
+
+# Emergency floor retained for maintainer intervention and safety operations.
+# API-heavy Pulse progress stages defer at or below this value.
+AIDEVOPS_PULSE_REST_CORE_HARD_FLOOR=100
+
+# GitHub REST core uses an hourly window. The soft reserve decays linearly over
+# this many seconds and is clamped to [hard floor, soft cap].
+AIDEVOPS_PULSE_REST_CORE_ADAPTIVE_WINDOW_SECONDS=3600
 
 # Seconds that an authoritative REST response-header observation may be reused.
 # The reset epoch always takes precedence, so this cannot delay recovery.

--- a/.agents/configs/pulse-rate-limit.conf
+++ b/.agents/configs/pulse-rate-limit.conf
@@ -40,7 +40,10 @@
 #         real failures (set back to 0.30 here, redeploy).
 
 # Fraction of total GraphQL budget below which the rate-limit circuit breaker trips.
-# Set to 0 to disable entirely.
+# Set to 0 to disable the GraphQL floor only. REST-core priority gating below
+# remains active and keeps unknown quota evidence fail-closed until a later
+# authoritative probe succeeds. AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER=1 is the
+# explicit emergency bypass for both pools.
 # Env var AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD takes precedence if already set.
 AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD=0.05
 

--- a/.agents/scripts/pulse-budget-priority.sh
+++ b/.agents/scripts/pulse-budget-priority.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Pulse stage-boundary scheduler for GraphQL and REST-core budgets (GH#22479, GH#29742).
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+
+[[ -n "${_PULSE_BUDGET_PRIORITY_LOADED:-}" ]] && return 0
+_PULSE_BUDGET_PRIORITY_LOADED=1
+
+_PULSE_BUDGET_MODE_UNKNOWN="unknown"
+_PULSE_BUDGET_MODE_RESERVE="reserve"
+_PULSE_BUDGET_PRIORITY_DEFERRABLE="deferrable"
+_PULSE_BUDGET_PREFETCH_STAGE="preflight_prefetch_and_scope"
+
+#######################################
+# Read the GraphQL rate-limit projection through a bounded shared transport.
+#######################################
+_pulse_gh_rate_limit_json() {
+	local rate_json=""
+	local rc=0
+	local secs="${AIDEVOPS_GH_READ_TIMEOUT:-15}"
+	[[ "$secs" =~ ^[0-9]+$ ]] || secs=15
+
+	if declare -F _cb_rate_limit_json >/dev/null 2>&1; then
+		rate_json=$(_cb_rate_limit_json normal 2>/dev/null) || rc=$?
+	elif declare -F _gh_with_timeout >/dev/null 2>&1; then
+		rate_json=$(_gh_with_timeout read gh api rate_limit 2>/dev/null) || rc=$?
+	elif declare -F timeout_sec >/dev/null 2>&1; then
+		rate_json=$(timeout_sec "$secs" gh api rate_limit 2>/dev/null) || rc=$?
+	elif command -v timeout >/dev/null 2>&1; then
+		rate_json=$(timeout "$secs" gh api rate_limit 2>/dev/null) || rc=$?
+	elif command -v gtimeout >/dev/null 2>&1; then
+		rate_json=$(gtimeout "$secs" gh api rate_limit 2>/dev/null) || rc=$?
+	else
+		return 1
+	fi
+
+	[[ "$rc" -eq 0 ]] || return "$rc"
+	[[ -n "$rate_json" ]] || return 1
+	printf '%s\n' "$rate_json"
+	return 0
+}
+
+#######################################
+# Classify GraphQL headroom for optional-stage scheduling.
+# Stdout: "<mode> <remaining> <limit> <threshold>".
+#######################################
+_pulse_graphql_budget_priority_decision() {
+	local threshold="${AIDEVOPS_PULSE_OPTIONAL_BUDGET_THRESHOLD:-${AIDEVOPS_PULSE_PREFETCH_BUDGET_THRESHOLD:-1250}}"
+	[[ "$threshold" =~ ^[0-9]+$ ]] || threshold=1250
+	local rate_json=""
+	rate_json=$(_pulse_gh_rate_limit_json) || rate_json=""
+	if [[ -z "$rate_json" ]]; then
+		printf 'unknown ? ? %s\n' "$threshold"
+		return 0
+	fi
+	local remaining limit
+	remaining=$(printf '%s' "$rate_json" | jq -r '.resources.graphql.remaining // ""' 2>/dev/null) || remaining=""
+	limit=$(printf '%s' "$rate_json" | jq -r '.resources.graphql.limit // ""' 2>/dev/null) || limit=""
+	if [[ ! "$remaining" =~ ^[0-9]+$ ]] || [[ ! "$limit" =~ ^[0-9]+$ ]]; then
+		printf 'unknown ? ? %s\n' "$threshold"
+		return 0
+	fi
+	if [[ "$remaining" -lt "$threshold" ]]; then
+		printf 'reserve %s %s %s\n' "$remaining" "$limit" "$threshold"
+		return 0
+	fi
+	printf 'normal %s %s %s\n' "$remaining" "$limit" "$threshold"
+	return 0
+}
+
+#######################################
+# Export the current GraphQL mode. Pass "quiet" to suppress per-stage logs.
+#######################################
+_pulse_set_graphql_budget_priority() {
+	local log_mode="${1:-log}"
+	local decision budget_class remaining limit threshold
+	decision=$(_pulse_graphql_budget_priority_decision)
+	read -r budget_class remaining limit threshold <<<"$decision"
+	[[ -n "$budget_class" ]] || budget_class="$_PULSE_BUDGET_MODE_UNKNOWN"
+	export AIDEVOPS_PULSE_GRAPHQL_BUDGET_CLASS="$budget_class"
+	export AIDEVOPS_PULSE_GRAPHQL_BUDGET_REMAINING="$remaining"
+	export AIDEVOPS_PULSE_GRAPHQL_BUDGET_LIMIT="$limit"
+	export AIDEVOPS_PULSE_GRAPHQL_BUDGET_THRESHOLD="$threshold"
+	[[ "$log_mode" == "quiet" ]] && return 0
+	if [[ "$budget_class" == "$_PULSE_BUDGET_MODE_RESERVE" ]]; then
+		echo "[pulse-wrapper] GraphQL budget reserve mode: remaining=${remaining}/${limit} < optional_threshold=${threshold}; deferring optional stages, preserving merge/dispatch budget (GH#22479)" >>"$LOGFILE"
+		if declare -F pulse_stats_increment >/dev/null 2>&1; then
+			pulse_stats_increment "pulse_graphql_budget_reserve_mode" 2>/dev/null || true
+		fi
+	elif [[ "$budget_class" == "$_PULSE_BUDGET_MODE_UNKNOWN" ]]; then
+		echo "[pulse-wrapper] GraphQL budget priority unknown — proceeding fail-open for optional stages (GH#22479)" >>"$LOGFILE"
+	fi
+	return 0
+}
+
+#######################################
+# Read the authoritative REST-core priority mode.
+# Stdout: "<mode> <remaining> <limit> <adaptive> <soft> <hard> <reset>".
+#######################################
+_pulse_rest_core_budget_priority_decision() {
+	if ! declare -F pulse_rest_core_priority_snapshot >/dev/null 2>&1; then
+		printf 'unknown ? ? ? ? ? ?\n'
+		return 0
+	fi
+	local decision
+	decision=$(pulse_rest_core_priority_snapshot 2>/dev/null) || decision=""
+	[[ -n "$decision" ]] || decision="${_PULSE_BUDGET_MODE_UNKNOWN} ? ? ? ? ? ?"
+	printf '%s\n' "$decision"
+	return 0
+}
+
+#######################################
+# Export the current REST mode. Pass "quiet" to suppress per-stage logs.
+#######################################
+_pulse_set_rest_core_budget_priority() {
+	local log_mode="${1:-log}"
+	local decision budget_class remaining limit adaptive soft_cap hard_floor reset_epoch
+	decision=$(_pulse_rest_core_budget_priority_decision)
+	read -r budget_class remaining limit adaptive soft_cap hard_floor reset_epoch <<<"$decision"
+	[[ -n "$budget_class" ]] || budget_class="$_PULSE_BUDGET_MODE_UNKNOWN"
+	export AIDEVOPS_PULSE_REST_CORE_BUDGET_CLASS="$budget_class"
+	export AIDEVOPS_PULSE_REST_CORE_BUDGET_REMAINING="$remaining"
+	export AIDEVOPS_PULSE_REST_CORE_BUDGET_LIMIT="$limit"
+	export AIDEVOPS_PULSE_REST_CORE_BUDGET_ADAPTIVE_THRESHOLD="$adaptive"
+	export AIDEVOPS_PULSE_REST_CORE_BUDGET_SOFT_CAP="$soft_cap"
+	export AIDEVOPS_PULSE_REST_CORE_BUDGET_HARD_FLOOR="$hard_floor"
+	export AIDEVOPS_PULSE_REST_CORE_BUDGET_RESET="$reset_epoch"
+	[[ "$log_mode" == "quiet" ]] && return 0
+	case "$budget_class" in
+	reserve | emergency)
+		echo "[pulse-wrapper] REST-core budget ${budget_class} mode: remaining=${remaining}/${limit} adaptive=${adaptive} soft_cap=${soft_cap} hard_floor=${hard_floor} reset=${reset_epoch} (GH#29742)" >>"$LOGFILE"
+		if declare -F pulse_stats_increment >/dev/null 2>&1; then
+			pulse_stats_increment "pulse_rest_core_budget_${budget_class}_mode" 2>/dev/null || true
+		fi
+		;;
+	unknown)
+		echo "[pulse-wrapper] REST-core budget priority unknown — conservatively deferring non-critical API stages (GH#29742)" >>"$LOGFILE"
+		if declare -F pulse_stats_increment >/dev/null 2>&1; then
+			pulse_stats_increment "pulse_rest_core_budget_unknown_mode" 2>/dev/null || true
+		fi
+		;;
+	esac
+	return 0
+}
+
+#######################################
+# Return the deterministic priority class for a Pulse stage.
+#######################################
+_pulse_stage_priority_class() {
+	local stage="$1"
+	case "$stage" in
+	cache_prime | fix_the_fixer_detector | coderabbit_review | post_merge_scanner | pr_review_thread_response | auto_decomposer_scanner | dedup_cleanup | fast_fail_prune_expired | evaluate_routines | dependabot_alert_monitor | canonical_maintenance | dashboard_freshness_check | llm_supervisor | dirty_pr_sweep | stale_blocked_reconcile | sync_todo_refs_all_repos | build_dependency_graph_cache | refresh_blocked_status_from_graph | preflight_label_maintenance | preflight_trusted_nmr_reconcile | "$_PULSE_BUDGET_PREFETCH_STAGE")
+		printf 'deferrable\n'
+		;;
+	approval_merge_trigger | deterministic_merge_pass | dispatch_max | preflight_early_dispatch | preflight_post_label_refill)
+		printf 'progress\n'
+		;;
+	*)
+		printf 'critical\n'
+		;;
+	esac
+	return 0
+}
+
+#######################################
+# Return 0 when a mapped stage should defer at its current budget class.
+#######################################
+_pulse_should_defer_budget_priority_stage() {
+	local stage="$1"
+	local priority
+	priority=$(_pulse_stage_priority_class "$stage")
+	[[ "$priority" != "critical" ]] || return 1
+
+	_pulse_set_graphql_budget_priority quiet
+	_pulse_set_rest_core_budget_priority quiet
+	if [[ "$priority" == "$_PULSE_BUDGET_PRIORITY_DEFERRABLE" && "${AIDEVOPS_PULSE_GRAPHQL_BUDGET_CLASS:-normal}" == "$_PULSE_BUDGET_MODE_RESERVE" ]]; then
+		if [[ "$stage" != "$_PULSE_BUDGET_PREFETCH_STAGE" || "${AIDEVOPS_SKIP_PULSE_PREFETCH_BUDGET_GATE:-0}" != "1" ]]; then
+			return 0
+		fi
+	fi
+
+	local rest_mode="${AIDEVOPS_PULSE_REST_CORE_BUDGET_CLASS:-$_PULSE_BUDGET_MODE_UNKNOWN}"
+	case "${rest_mode}:${priority}" in
+	reserve:deferrable | emergency:deferrable | unknown:deferrable | emergency:progress | unknown:progress)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+#######################################
+# Record a stage-boundary deferral with pool-specific counters.
+#######################################
+_pulse_defer_budget_priority_stage() {
+	local stage="$1"
+	local priority
+	priority=$(_pulse_stage_priority_class "$stage")
+	local graphql_mode="${AIDEVOPS_PULSE_GRAPHQL_BUDGET_CLASS:-$_PULSE_BUDGET_MODE_UNKNOWN}"
+	local rest_mode="${AIDEVOPS_PULSE_REST_CORE_BUDGET_CLASS:-$_PULSE_BUDGET_MODE_UNKNOWN}"
+	echo "[pulse-wrapper] budget-priority: deferred ${priority} stage '${stage}' (graphql=${graphql_mode}:${AIDEVOPS_PULSE_GRAPHQL_BUDGET_REMAINING:-?}/${AIDEVOPS_PULSE_GRAPHQL_BUDGET_LIMIT:-?}@${AIDEVOPS_PULSE_GRAPHQL_BUDGET_THRESHOLD:-?}, rest=${rest_mode}:${AIDEVOPS_PULSE_REST_CORE_BUDGET_REMAINING:-?}/${AIDEVOPS_PULSE_REST_CORE_BUDGET_LIMIT:-?}@${AIDEVOPS_PULSE_REST_CORE_BUDGET_ADAPTIVE_THRESHOLD:-?}, hard_floor=${AIDEVOPS_PULSE_REST_CORE_BUDGET_HARD_FLOOR:-?})" >>"$LOGFILE"
+	if ! declare -F pulse_stats_increment >/dev/null 2>&1; then
+		return 0
+	fi
+	pulse_stats_increment "pulse_budget_priority_stage_deferred" 2>/dev/null || true
+	pulse_stats_increment "pulse_budget_priority_stage_deferred_${stage}" 2>/dev/null || true
+	if [[ "$priority" == "$_PULSE_BUDGET_PRIORITY_DEFERRABLE" && "$graphql_mode" == "$_PULSE_BUDGET_MODE_RESERVE" ]]; then
+		if [[ "$stage" != "$_PULSE_BUDGET_PREFETCH_STAGE" || "${AIDEVOPS_SKIP_PULSE_PREFETCH_BUDGET_GATE:-0}" != "1" ]]; then
+			pulse_stats_increment "pulse_graphql_budget_stage_deferred" 2>/dev/null || true
+			pulse_stats_increment "pulse_graphql_budget_stage_deferred_${stage}" 2>/dev/null || true
+		fi
+	fi
+	case "$rest_mode" in
+	reserve | emergency | unknown)
+		pulse_stats_increment "pulse_rest_core_budget_stage_deferred" 2>/dev/null || true
+		pulse_stats_increment "pulse_rest_core_budget_stage_deferred_${stage}" 2>/dev/null || true
+		;;
+	esac
+	return 0
+}
+
+#######################################
+# Run a stage only when its priority class is currently eligible.
+#######################################
+_pulse_run_budget_priority_stage() {
+	local stage="$1"
+	shift
+	if _pulse_should_defer_budget_priority_stage "$stage"; then
+		_pulse_defer_budget_priority_stage "$stage"
+		return 0
+	fi
+	"$@"
+	return $?
+}
+
+#######################################
+# Run a timeout-wrapped stage only when its priority class is eligible.
+#######################################
+_pulse_run_budget_priority_stage_with_timeout() {
+	local stage="$1"
+	local timeout_seconds="$2"
+	shift 2
+	if _pulse_should_defer_budget_priority_stage "$stage"; then
+		_pulse_defer_budget_priority_stage "$stage"
+		return 0
+	fi
+	run_stage_with_timeout "$stage" "$timeout_seconds" "$@"
+	return $?
+}
+
+# Backward-compatible names for existing optional-stage callers.
+_pulse_run_optional_stage() {
+	_pulse_run_budget_priority_stage "$@"
+	return $?
+}
+
+_pulse_run_optional_stage_with_timeout() {
+	_pulse_run_budget_priority_stage_with_timeout "$@"
+	return $?
+}

--- a/.agents/scripts/pulse-budget-priority.sh
+++ b/.agents/scripts/pulse-budget-priority.sh
@@ -55,7 +55,8 @@ _pulse_graphql_budget_priority_decision() {
 		printf 'unknown ? ? %s\n' "$threshold"
 		return 0
 	fi
-	local remaining limit
+	local remaining
+	local limit
 	remaining=$(printf '%s' "$rate_json" | jq -r '.resources.graphql.remaining // ""' 2>/dev/null) || remaining=""
 	limit=$(printf '%s' "$rate_json" | jq -r '.resources.graphql.limit // ""' 2>/dev/null) || limit=""
 	if [[ ! "$remaining" =~ ^[0-9]+$ ]] || [[ ! "$limit" =~ ^[0-9]+$ ]]; then
@@ -75,7 +76,11 @@ _pulse_graphql_budget_priority_decision() {
 #######################################
 _pulse_set_graphql_budget_priority() {
 	local log_mode="${1:-log}"
-	local decision budget_class remaining limit threshold
+	local decision
+	local budget_class
+	local remaining
+	local limit
+	local threshold
 	decision=$(_pulse_graphql_budget_priority_decision)
 	read -r budget_class remaining limit threshold <<<"$decision"
 	[[ -n "$budget_class" ]] || budget_class="$_PULSE_BUDGET_MODE_UNKNOWN"
@@ -116,7 +121,14 @@ _pulse_rest_core_budget_priority_decision() {
 #######################################
 _pulse_set_rest_core_budget_priority() {
 	local log_mode="${1:-log}"
-	local decision budget_class remaining limit adaptive soft_cap hard_floor reset_epoch
+	local decision
+	local budget_class
+	local remaining
+	local limit
+	local adaptive
+	local soft_cap
+	local hard_floor
+	local reset_epoch
 	decision=$(_pulse_rest_core_budget_priority_decision)
 	read -r budget_class remaining limit adaptive soft_cap hard_floor reset_epoch <<<"$decision"
 	[[ -n "$budget_class" ]] || budget_class="$_PULSE_BUDGET_MODE_UNKNOWN"

--- a/.agents/scripts/pulse-budget-priority.sh
+++ b/.agents/scripts/pulse-budget-priority.sh
@@ -177,6 +177,20 @@ _pulse_stage_priority_class() {
 }
 
 #######################################
+# Return 0 when GraphQL reserve mode defers this deferrable stage.
+#######################################
+_pulse_graphql_budget_defers_stage() {
+	local stage="$1"
+	local priority="$2"
+	[[ "$priority" == "$_PULSE_BUDGET_PRIORITY_DEFERRABLE" ]] || return 1
+	[[ "${AIDEVOPS_PULSE_GRAPHQL_BUDGET_CLASS:-normal}" == "$_PULSE_BUDGET_MODE_RESERVE" ]] || return 1
+	if [[ "$stage" == "$_PULSE_BUDGET_PREFETCH_STAGE" && "${AIDEVOPS_SKIP_PULSE_PREFETCH_BUDGET_GATE:-0}" == "1" ]]; then
+		return 1
+	fi
+	return 0
+}
+
+#######################################
 # Return 0 when a mapped stage should defer at its current budget class.
 #######################################
 _pulse_should_defer_budget_priority_stage() {
@@ -187,12 +201,13 @@ _pulse_should_defer_budget_priority_stage() {
 
 	_pulse_set_graphql_budget_priority quiet
 	_pulse_set_rest_core_budget_priority quiet
-	if [[ "$priority" == "$_PULSE_BUDGET_PRIORITY_DEFERRABLE" && "${AIDEVOPS_PULSE_GRAPHQL_BUDGET_CLASS:-normal}" == "$_PULSE_BUDGET_MODE_RESERVE" ]]; then
-		if [[ "$stage" != "$_PULSE_BUDGET_PREFETCH_STAGE" || "${AIDEVOPS_SKIP_PULSE_PREFETCH_BUDGET_GATE:-0}" != "1" ]]; then
-			return 0
-		fi
+	if _pulse_graphql_budget_defers_stage "$stage" "$priority"; then
+		return 0
 	fi
 
+	# Unknown REST evidence intentionally keeps non-critical work fail-closed.
+	# Later cycles repeat the bounded authoritative probe; elapsed time alone must
+	# never turn missing quota evidence into permission to spend maintainer quota.
 	local rest_mode="${AIDEVOPS_PULSE_REST_CORE_BUDGET_CLASS:-$_PULSE_BUDGET_MODE_UNKNOWN}"
 	case "${rest_mode}:${priority}" in
 	reserve:deferrable | emergency:deferrable | unknown:deferrable | emergency:progress | unknown:progress)
@@ -219,11 +234,9 @@ _pulse_defer_budget_priority_stage() {
 	fi
 	pulse_stats_increment "pulse_budget_priority_stage_deferred" 2>/dev/null || true
 	pulse_stats_increment "pulse_budget_priority_stage_deferred_${stage}" 2>/dev/null || true
-	if [[ "$priority" == "$_PULSE_BUDGET_PRIORITY_DEFERRABLE" && "$graphql_mode" == "$_PULSE_BUDGET_MODE_RESERVE" ]]; then
-		if [[ "$stage" != "$_PULSE_BUDGET_PREFETCH_STAGE" || "${AIDEVOPS_SKIP_PULSE_PREFETCH_BUDGET_GATE:-0}" != "1" ]]; then
-			pulse_stats_increment "pulse_graphql_budget_stage_deferred" 2>/dev/null || true
-			pulse_stats_increment "pulse_graphql_budget_stage_deferred_${stage}" 2>/dev/null || true
-		fi
+	if _pulse_graphql_budget_defers_stage "$stage" "$priority"; then
+		pulse_stats_increment "pulse_graphql_budget_stage_deferred" 2>/dev/null || true
+		pulse_stats_increment "pulse_graphql_budget_stage_deferred_${stage}" 2>/dev/null || true
 	fi
 	case "$rest_mode" in
 	reserve | emergency | unknown)

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -1454,7 +1454,7 @@ _run_preflight_stages() {
 	# side retains AIDEVOPS_SKIP_PULSE_PREFETCH_BUDGET_GATE=1 compatibility,
 	# while REST safety still applies.
 	local _budget_gate_skip=0
-	local _budget_prefetch_stage="preflight_prefetch_and_scope"
+	local _budget_prefetch_stage="${_PULSE_BUDGET_PREFETCH_STAGE:-preflight_prefetch_and_scope}"
 	if _pulse_should_defer_budget_priority_stage "$_budget_prefetch_stage"; then
 		_pulse_defer_budget_priority_stage "$_budget_prefetch_stage"
 		_PULSE_HEALTH_PREFETCH_THROTTLED=$((_PULSE_HEALTH_PREFETCH_THROTTLED + 1))

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -1427,18 +1427,18 @@ _run_preflight_stages() {
 	# provide the safety net. Timing is still logged for observability.
 	local _pflt_ed_start=$SECONDS
 	local _pflt_ed_rc=0
-	_preflight_early_dispatch || _pflt_ed_rc=$?
+	_pulse_run_budget_priority_stage "preflight_early_dispatch" _preflight_early_dispatch || _pflt_ed_rc=$?
 	_log_substage_timing "preflight_early_dispatch" "$_pflt_ed_start" "$_pflt_ed_rc"
 	# GH#28880: cross-repository label maintenance can take 3-5 minutes. Run it
 	# after the initial fill so already-eligible workers boot in parallel. Then
 	# normalize trusted-author NMR residue and refill once so every newly unblocked
 	# candidate remains dispatchable this cycle.
-	run_stage_with_timeout "preflight_label_maintenance" "$_pflt_timeout" \
+	_pulse_run_budget_priority_stage_with_timeout "preflight_label_maintenance" "$_pflt_timeout" \
 		_preflight_label_maintenance || true
-	_preflight_trusted_nmr_reconcile || true
+	_pulse_run_budget_priority_stage "preflight_trusted_nmr_reconcile" _preflight_trusted_nmr_reconcile || true
 	local _pflt_refill_start=$SECONDS
 	local _pflt_refill_rc=0
-	_preflight_post_label_refill || _pflt_refill_rc=$?
+	_pulse_run_budget_priority_stage "preflight_post_label_refill" _preflight_post_label_refill || _pflt_refill_rc=$?
 	_log_substage_timing "preflight_post_label_refill" "$_pflt_refill_start" "$_pflt_refill_rc"
 	# t3055: Post-dispatch housekeeping runs under a separate async lock by
 	# default. These stages do not protect the immediate worker claim/ledger
@@ -1447,31 +1447,21 @@ _run_preflight_stages() {
 	# AIDEVOPS_PULSE_ASYNC_POST_DISPATCH_HOUSEKEEPING=0 to restore the legacy
 	# synchronous path for debugging.
 	_pulse_start_post_dispatch_housekeeping "$_pflt_timeout"
-	# t3027 (GH#21584): GraphQL budget gate.
-	# prefetch_state is the largest single GraphQL consumer in the pulse
-	# cycle (~170s avg, 3 calls per repo × 13 repos). When budget is
-	# critically low (< AIDEVOPS_PULSE_PREFETCH_BUDGET_THRESHOLD points,
-	# default 1250 = 25% of the 5000/hr GraphQL floor), defer prefetch
-	# entirely and let the cycle proceed with stale STATE_FILE rather
-	# than burn the remaining budget on what may be an idle cycle anyway.
-	# Complementary to the t2690 dispatch breaker (5% floor): t2690 stops
-	# new dispatches; this gate stops the prefetch that PRECEDES dispatch.
-	# Bypass: AIDEVOPS_SKIP_PULSE_PREFETCH_BUDGET_GATE=1.
-	# Counter incremented: _PULSE_HEALTH_PREFETCH_THROTTLED.
+	# t3027/GH#29742: prefetch is a deferrable, high-fanout API stage. Reuse
+	# the shared stage policy so GraphQL reserve mode or REST reserve/emergency
+	# mode preserves quota for merge and dispatch. Existing STATE_FILE state is
+	# the retry mechanism; no delayed request queue is introduced. The GraphQL
+	# side retains AIDEVOPS_SKIP_PULSE_PREFETCH_BUDGET_GATE=1 compatibility,
+	# while REST safety still applies.
 	local _budget_gate_skip=0
-	if [[ "${AIDEVOPS_SKIP_PULSE_PREFETCH_BUDGET_GATE:-0}" != "1" ]]; then
-		local _bg_threshold="${AIDEVOPS_PULSE_PREFETCH_BUDGET_THRESHOLD:-1250}"
-		local _bg_remaining
-		_bg_remaining=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || echo "5000")
-		[[ "$_bg_remaining" =~ ^[0-9]+$ ]] || _bg_remaining=5000
-		if [[ "$_bg_remaining" -lt "$_bg_threshold" ]]; then
-			echo "[pulse-wrapper] prefetch_budget_gate: GraphQL remaining=${_bg_remaining} < threshold=${_bg_threshold} — deferring prefetch_state, using stale STATE_FILE (t3027)" >>"$LOGFILE"
-			_PULSE_HEALTH_PREFETCH_THROTTLED=$((_PULSE_HEALTH_PREFETCH_THROTTLED + 1))
-			if declare -F pulse_stats_increment >/dev/null 2>&1; then
-				pulse_stats_increment "pulse_prefetch_budget_throttled" 2>/dev/null || true
-			fi
-			_budget_gate_skip=1
+	local _budget_prefetch_stage="preflight_prefetch_and_scope"
+	if _pulse_should_defer_budget_priority_stage "$_budget_prefetch_stage"; then
+		_pulse_defer_budget_priority_stage "$_budget_prefetch_stage"
+		_PULSE_HEALTH_PREFETCH_THROTTLED=$((_PULSE_HEALTH_PREFETCH_THROTTLED + 1))
+		if declare -F pulse_stats_increment >/dev/null 2>&1; then
+			pulse_stats_increment "pulse_prefetch_budget_throttled" 2>/dev/null || true
 		fi
+		_budget_gate_skip=1
 	fi
 
 	# prefetch_and_scope is the only preflight stage whose failure aborts
@@ -1482,7 +1472,7 @@ _run_preflight_stages() {
 	# first cycle), downstream stages handle it gracefully (LLM session
 	# sees empty state, deterministic merges/cleanup degrade quietly).
 	if [[ "$_budget_gate_skip" -eq 0 ]]; then
-		if ! run_stage_with_timeout "preflight_prefetch_and_scope" "$_pflt_timeout" \
+		if ! run_stage_with_timeout "$_budget_prefetch_stage" "$_pflt_timeout" \
 			_preflight_prefetch_and_scope; then
 			return 1
 		fi

--- a/.agents/scripts/pulse-merge-routine.sh
+++ b/.agents/scripts/pulse-merge-routine.sh
@@ -275,14 +275,17 @@ _pmr_graphql_budget_allows_run() {
 	return 0
 }
 
-_pmr_rest_core_reserve_allows_run() {
-	if ! declare -F pulse_rest_core_reserve_allows >/dev/null 2>&1; then
+_pmr_rest_core_progress_allows_run() {
+	local progress_rc=0
+	if declare -F pulse_rest_core_priority_allows >/dev/null 2>&1; then
+		pulse_rest_core_priority_allows progress || progress_rc=$?
+	elif declare -F pulse_rest_core_reserve_allows >/dev/null 2>&1; then
+		pulse_rest_core_reserve_allows || progress_rc=$?
+	else
 		return 0
 	fi
-	local reserve_rc=0
-	pulse_rest_core_reserve_allows || reserve_rc=$?
-	if [[ "$reserve_rc" -ne 0 ]]; then
-		_pmr_log WARN "REST-core reserve unavailable or exhausted (rc=${reserve_rc}); deferring merge pass to preserve interactive maintainer quota (GH#29736)"
+	if [[ "$progress_rc" -ne 0 ]]; then
+		_pmr_log WARN "REST-core progress floor unavailable or exhausted (rc=${progress_rc}); deferring merge pass while preserving critical maintainer quota (GH#29742)"
 		return 1
 	fi
 	return 0
@@ -469,7 +472,7 @@ cmd_run() {
 		date +%s >"$PULSE_MERGE_ROUTINE_LAST_RUN" 2>/dev/null || true
 		return 0
 	fi
-	if ! _pmr_rest_core_reserve_allows_run; then
+	if ! _pmr_rest_core_progress_allows_run; then
 		date +%s >"$PULSE_MERGE_ROUTINE_LAST_RUN" 2>/dev/null || true
 		return 0
 	fi
@@ -545,7 +548,7 @@ cmd_dry_run() {
 	if ! _pmr_graphql_budget_allows_run; then
 		return 0
 	fi
-	if ! _pmr_rest_core_reserve_allows_run; then
+	if ! _pmr_rest_core_progress_allows_run; then
 		return 0
 	fi
 

--- a/.agents/scripts/pulse-merge-routine.sh
+++ b/.agents/scripts/pulse-merge-routine.sh
@@ -275,6 +275,8 @@ _pmr_graphql_budget_allows_run() {
 	return 0
 }
 
+# Unknown quota evidence remains fail-closed until a later authoritative probe
+# succeeds; unlike a known floor, it is logged as an availability/evidence fault.
 _pmr_rest_core_progress_allows_run() {
 	local progress_rc=0
 	if declare -F pulse_rest_core_priority_allows >/dev/null 2>&1; then
@@ -284,11 +286,21 @@ _pmr_rest_core_progress_allows_run() {
 	else
 		return 0
 	fi
-	if [[ "$progress_rc" -ne 0 ]]; then
-		_pmr_log WARN "REST-core progress floor unavailable or exhausted (rc=${progress_rc}); deferring merge pass while preserving critical maintainer quota (GH#29742)"
-		return 1
-	fi
-	return 0
+	case "$progress_rc" in
+	0)
+		return 0
+		;;
+	1)
+		_pmr_log WARN "Known REST-core progress floor reached (rc=1); deferring merge pass until a later authoritative probe allows progress while preserving critical maintainer quota (GH#29742)"
+		;;
+	2)
+		_pmr_log WARN "REST-core quota evidence unavailable (rc=2); deferring merge pass fail-closed until a later authoritative probe succeeds while preserving critical maintainer quota (GH#29742)"
+		;;
+	*)
+		_pmr_log WARN "Unexpected REST-core progress decision (rc=${progress_rc}); deferring merge pass fail-closed while preserving critical maintainer quota (GH#29742)"
+		;;
+	esac
+	return 1
 }
 
 _pmr_require_gh_auth() {

--- a/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# pulse-rate-limit-circuit-breaker.sh — Pulse-level circuit breaker for GraphQL rate-limit budget (t2690, GH#20310)
+# pulse-rate-limit-circuit-breaker.sh — Pulse GraphQL breaker and REST priority budget (t2690, GH#20310, GH#29742)
 #
 # Proactive defence: pauses worker dispatch when the GitHub GraphQL rate-limit
 # budget is exhausted or nearly exhausted. Without this, the pulse keeps spawning
@@ -23,7 +23,8 @@
 # Environment overrides:
 #   AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD — fraction of total budget below
 #     which the breaker trips (default 0.05 = 5% = 250/5000). Set to 0 to
-#     disable entirely. Tuned as an emergency floor (t2896): the previous
+#     disable the GraphQL check; REST priority gating remains active. Tuned as
+#     an emergency floor (t2896): the previous
 #     0.30 raise (t2744) was justified to "preserve headroom for in-flight
 #     reads", but t2689 shipped read-side REST fallback after t2744 — reads
 #     now route through the 5000/hr REST core pool when GraphQL is low.
@@ -49,7 +50,8 @@
 # Multi-runner: concurrent local runners share a short-lived, auth-scoped rate
 # snapshot and single-flight probe. Remote runners retain independent local state.
 #
-# Cost: `gh api rate_limit` is a free endpoint (not counted against quotas).
+# Cost: `gh api rate_limit` is free. The authoritative REST `user` probe costs
+# at most one core request per cache TTL across local concurrent runners.
 
 set -euo pipefail
 
@@ -196,27 +198,84 @@ _cb_rest_core_header() {
 }
 
 #######################################
-# Return whether the active REST principal retains the configured reserve.
+# Return normalized REST-core priority bounds.
 #
-# Returns: 0 sufficient; 1 at/below reserve; 2 unavailable/malformed evidence.
+# Stdout: "<soft-cap> <hard-floor> <window-seconds>".
+#######################################
+_cb_rest_core_bounds() {
+	local soft_cap="${AIDEVOPS_PULSE_REST_CORE_RESERVE:-${AIDEVOPS_PULSE_REST_DISPATCH_MIN_CORE_REMAINING:-500}}"
+	local hard_floor="${AIDEVOPS_PULSE_REST_CORE_HARD_FLOOR:-100}"
+	local window_seconds="${AIDEVOPS_PULSE_REST_CORE_ADAPTIVE_WINDOW_SECONDS:-3600}"
+	[[ "$soft_cap" =~ ^[0-9]+$ ]] || soft_cap=500
+	[[ "$hard_floor" =~ ^[0-9]+$ ]] || hard_floor=100
+	[[ "$window_seconds" =~ ^[1-9][0-9]*$ ]] || window_seconds=3600
+	if [[ "$soft_cap" -eq 0 ]]; then
+		hard_floor=0
+	elif [[ "$hard_floor" -gt "$soft_cap" ]]; then
+		hard_floor="$soft_cap"
+	fi
+	printf '%s %s %s\n' "$soft_cap" "$hard_floor" "$window_seconds"
+	return 0
+}
+
+#######################################
+# Compute the adaptive REST-core soft threshold for a reset epoch.
+#
+# Args:
+#   $1 - reset epoch
+#   $2 - current epoch
+#
+# Stdout: "<adaptive-threshold> <soft-cap> <hard-floor>".
+#######################################
+_cb_rest_core_thresholds() {
+	local reset_epoch="$1"
+	local now_epoch="$2"
+	local soft_cap hard_floor window_seconds
+	read -r soft_cap hard_floor window_seconds < <(_cb_rest_core_bounds)
+	[[ "$reset_epoch" =~ ^[0-9]+$ ]] || return 1
+	[[ "$now_epoch" =~ ^[0-9]+$ ]] || return 1
+	if [[ "$soft_cap" -eq 0 ]]; then
+		printf '0 0 0\n'
+		return 0
+	fi
+
+	local seconds_until_reset=0
+	if [[ "$reset_epoch" -gt "$now_epoch" ]]; then
+		seconds_until_reset=$((reset_epoch - now_epoch))
+	fi
+	[[ "$seconds_until_reset" -le "$window_seconds" ]] || seconds_until_reset="$window_seconds"
+
+	local reserve_span=$((soft_cap - hard_floor))
+	local adaptive_threshold=$((hard_floor + (reserve_span * seconds_until_reset + window_seconds - 1) / window_seconds))
+	[[ "$adaptive_threshold" -ge "$hard_floor" ]] || adaptive_threshold="$hard_floor"
+	[[ "$adaptive_threshold" -le "$soft_cap" ]] || adaptive_threshold="$soft_cap"
+	printf '%s %s %s\n' "$adaptive_threshold" "$soft_cap" "$hard_floor"
+	return 0
+}
+
+#######################################
+# Read an authoritative REST-core observation from cache or response headers.
+#
+# Stdout: "<remaining> <limit> <reset-epoch>".
+# Returns: 0 on valid evidence; 2 on unavailable or malformed evidence.
 # Cached observations are never used past their TTL or GitHub reset epoch.
 #######################################
-pulse_rest_core_reserve_allows() {
-	local reserve="${AIDEVOPS_PULSE_REST_CORE_RESERVE:-${AIDEVOPS_PULSE_REST_DISPATCH_MIN_CORE_REMAINING:-500}}"
+_cb_rest_core_observation() {
 	local ttl="$_CB_REST_CORE_PROBE_TTL"
 	local now observed=0 remaining limit reset resource
-	[[ "$reserve" =~ ^[0-9]+$ ]] || reserve=500
 	[[ "$ttl" =~ ^[0-9]+$ ]] || ttl=20
-	[[ "$reserve" -eq 0 ]] && return 0
 	now=$(date +%s 2>/dev/null) || now=0
 	[[ "$now" =~ ^[0-9]+$ ]] || now=0
 
 	if [[ -f "$_CB_REST_CORE_CACHE_FILE" ]]; then
 		read -r observed remaining limit reset resource < <(jq -r --arg unknown "$_CB_REST_CORE_UNKNOWN" '[.observed // 0, .remaining // $unknown, .limit // $unknown, .reset // 0, .resource // $unknown] | @tsv' "$_CB_REST_CORE_CACHE_FILE" 2>/dev/null) || true
 		if [[ "$observed" =~ ^[0-9]+$ && "$remaining" =~ ^[0-9]+$ && "$limit" =~ ^[0-9]+$ && "$reset" =~ ^[0-9]+$ &&
-			"$resource" == "$_CB_REST_CORE_RESOURCE" && "$now" -lt "$reset" && $((now - observed)) -le "$ttl" ]]; then
-			[[ "$remaining" -gt "$reserve" ]] && return 0
-			return 1
+			"$resource" == "$_CB_REST_CORE_RESOURCE" && "$now" -ge "$observed" && "$now" -lt "$reset" ]]; then
+			local cache_age=$((now - observed))
+			if [[ "$cache_age" -le "$ttl" ]]; then
+				printf '%s %s %s\n' "$remaining" "$limit" "$reset"
+				return 0
+			fi
 		fi
 	fi
 
@@ -229,12 +288,152 @@ pulse_rest_core_reserve_allows() {
 	if [[ ! "$remaining" =~ ^[0-9]+$ || ! "$limit" =~ ^[0-9]+$ || ! "$reset" =~ ^[0-9]+$ || "$resource" != "$_CB_REST_CORE_RESOURCE" || "$reset" -le "$now" ]]; then
 		return 2
 	fi
-	mkdir -p "$(dirname "$_CB_REST_CORE_CACHE_FILE")" 2>/dev/null || true
-	jq -cn --arg resource "$_CB_REST_CORE_RESOURCE" --argjson observed "$now" --argjson remaining "$remaining" \
+	local cache_dir cache_tmp
+	cache_dir=$(dirname "$_CB_REST_CORE_CACHE_FILE")
+	cache_tmp="${_CB_REST_CORE_CACHE_FILE}.tmp.$$"
+	mkdir -p "$cache_dir" 2>/dev/null || true
+	if jq -cn --arg resource "$_CB_REST_CORE_RESOURCE" --argjson observed "$now" --argjson remaining "$remaining" \
 		--argjson limit "$limit" --argjson reset "$reset" \
 		'{observed: $observed, remaining: $remaining, limit: $limit, reset: $reset, resource: $resource}' \
-		>"$_CB_REST_CORE_CACHE_FILE" 2>/dev/null || true
-	[[ "$remaining" -gt "$reserve" ]] && return 0
+		>"$cache_tmp" 2>/dev/null; then
+		mv "$cache_tmp" "$_CB_REST_CORE_CACHE_FILE" 2>/dev/null || rm -f "$cache_tmp" 2>/dev/null || true
+	else
+		rm -f "$cache_tmp" 2>/dev/null || true
+	fi
+	printf '%s %s %s\n' "$remaining" "$limit" "$reset"
+	return 0
+}
+
+#######################################
+# Classify authoritative REST-core headroom for stage-boundary scheduling.
+#
+# Stdout:
+#   "<mode> <remaining> <limit> <adaptive> <soft-cap> <hard-floor> <reset>"
+# Modes: normal, reserve, emergency, disabled, unknown.
+#######################################
+pulse_rest_core_priority_snapshot() {
+	local soft_cap hard_floor window_seconds
+	read -r soft_cap hard_floor window_seconds < <(_cb_rest_core_bounds)
+	if [[ "${AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER:-0}" == "1" || "$soft_cap" -eq 0 ]]; then
+		printf 'disabled ? ? 0 %s %s ?\n' "$soft_cap" "$hard_floor"
+		return 0
+	fi
+
+	local observation remaining limit reset_epoch
+	observation=$(_cb_rest_core_observation) || observation=""
+	if [[ -z "$observation" ]]; then
+		printf 'unknown ? ? ? %s %s ?\n' "$soft_cap" "$hard_floor"
+		return 0
+	fi
+	read -r remaining limit reset_epoch <<<"$observation"
+
+	local adaptive_threshold=""
+	local now_epoch
+	now_epoch=$(date +%s 2>/dev/null) || now_epoch=0
+	if [[ ! "$reset_epoch" =~ ^[0-9]+$ || "$reset_epoch" -le "$now_epoch" ]]; then
+		printf 'unknown ? ? ? %s %s ?\n' "$soft_cap" "$hard_floor"
+		return 0
+	fi
+	read -r adaptive_threshold soft_cap hard_floor < <(_cb_rest_core_thresholds "$reset_epoch" "$now_epoch") || adaptive_threshold=""
+	if [[ ! "$remaining" =~ ^[0-9]+$ || ! "$limit" =~ ^[0-9]+$ || ! "$adaptive_threshold" =~ ^[0-9]+$ ]]; then
+		printf 'unknown ? ? ? %s %s ?\n' "$soft_cap" "$hard_floor"
+		return 0
+	fi
+
+	local mode="normal"
+	if [[ "$remaining" -le "$hard_floor" ]]; then
+		mode="emergency"
+	elif [[ "$remaining" -le "$adaptive_threshold" ]]; then
+		mode="reserve"
+	fi
+	printf '%s %s %s %s %s %s %s\n' "$mode" "$remaining" "$limit" "$adaptive_threshold" "$soft_cap" "$hard_floor" "$reset_epoch"
+	return 0
+}
+
+#######################################
+# Apply a REST priority class to one already-observed budget snapshot.
+#
+# Args:
+#   $1 - critical, progress, or deferrable.
+#   $2 - output from pulse_rest_core_priority_snapshot.
+# Returns: 0 allowed; 1 deferred by threshold; 2 unknown/invalid evidence.
+#######################################
+_cb_rest_core_priority_decision_allows() {
+	local priority="$1"
+	local decision="$2"
+	case "$priority" in
+	critical)
+		return 0
+		;;
+	progress | deferrable) ;;
+	*) return 2 ;;
+	esac
+
+	local mode remaining limit adaptive soft_cap hard_floor reset_epoch
+	read -r mode remaining limit adaptive soft_cap hard_floor reset_epoch <<<"$decision"
+	case "$mode" in
+	disabled | normal)
+		return 0
+		;;
+	reserve)
+		[[ "$priority" == "progress" ]] && return 0
+		return 1
+		;;
+	emergency)
+		return 1
+		;;
+	*)
+		return 2
+		;;
+	esac
+}
+
+#######################################
+# Return whether a REST priority class may start new API-heavy work.
+#
+# Args: $1 - critical, progress, or deferrable.
+# Returns: 0 allowed; 1 deferred by threshold; 2 unknown/invalid evidence.
+#######################################
+pulse_rest_core_priority_allows() {
+	local priority="$1"
+	case "$priority" in
+	critical)
+		return 0
+		;;
+	progress | deferrable) ;;
+	*) return 2 ;;
+	esac
+
+	local decision
+	decision=$(pulse_rest_core_priority_snapshot)
+	_cb_rest_core_priority_decision_allows "$priority" "$decision"
+	return $?
+}
+
+#######################################
+# Backward-compatible optional-work reserve entrypoint.
+#######################################
+pulse_rest_core_reserve_allows() {
+	pulse_rest_core_priority_allows deferrable
+	return $?
+}
+
+#######################################
+# Gate new dispatch work at the hard floor and on unknown REST evidence.
+#######################################
+_cb_rest_core_progress_allows_dispatch() {
+	local decision mode remaining limit adaptive soft_cap hard_floor reset_epoch
+	decision=$(pulse_rest_core_priority_snapshot)
+	local progress_rc=0
+	_cb_rest_core_priority_decision_allows progress "$decision" || progress_rc=$?
+	[[ "$progress_rc" -eq 0 ]] && return 0
+
+	read -r mode remaining limit adaptive soft_cap hard_floor reset_epoch <<<"$decision"
+	echo "${_CB_RL_LOG_PREFIX} REST-core progress gate blocked: mode=${mode} remaining=${remaining}/${limit} adaptive=${adaptive} soft_cap=${soft_cap} hard_floor=${hard_floor} reset=${reset_epoch} rc=${progress_rc} (GH#29742)" >>"$LOGFILE"
+	if declare -F pulse_stats_increment >/dev/null 2>&1; then
+		pulse_stats_increment "pulse_rest_core_progress_blocked" 2>/dev/null || true
+		pulse_stats_increment "pulse_rest_core_progress_blocked_${mode}" 2>/dev/null || true
+	fi
 	return 1
 }
 
@@ -262,9 +461,9 @@ _cb_allow_dispatch_with_rest_fallback() {
 	fi
 
 	local core_rc=0
-	pulse_rest_core_reserve_allows || core_rc=$?
+	pulse_rest_core_priority_allows progress || core_rc=$?
 	if [[ "$core_rc" -ne 0 ]]; then
-		echo "${_CB_RL_LOG_PREFIX} GraphQL budget exhausted and REST fallback unavailable: authoritative REST-core reserve is unavailable or exhausted (rc=${core_rc})" >>"$LOGFILE"
+		echo "${_CB_RL_LOG_PREFIX} GraphQL budget exhausted and REST fallback unavailable: REST-core progress floor is unavailable or exhausted (rc=${core_rc})" >>"$LOGFILE"
 		return 1
 	fi
 
@@ -283,7 +482,8 @@ _cb_allow_dispatch_with_rest_fallback() {
 # Falls back to REST-backed dispatch when GraphQL is exhausted but REST core has
 # enough headroom for issue/comment/label operations.
 #
-# Returns: 0 when dispatch may proceed, 1 when dispatch should defer, 2 on API error.
+# Returns: 0 when dispatch may proceed, 1 when a known floor or unknown REST
+# observation should defer, 2 when the GraphQL projection itself is unavailable.
 #######################################
 is_graphql_budget_sufficient() {
 	# Emergency bypass.
@@ -296,7 +496,8 @@ is_graphql_budget_sufficient() {
 
 	# Disabled if threshold is explicitly 0 (any zero representation).
 	if awk -v t="$threshold" 'BEGIN { exit (t + 0 == 0) ? 0 : 1 }' 2>/dev/null; then
-		return 0
+		_cb_rest_core_progress_allows_dispatch
+		return $?
 	fi
 
 	# Query rate limit (free endpoint, short-TTL cached).
@@ -352,7 +553,8 @@ is_graphql_budget_sufficient() {
 		rm -f "$_CIRCUIT_BREAKER_STATE_FILE" 2>/dev/null || true
 	fi
 
-	return 0
+	_cb_rest_core_progress_allows_dispatch
+	return $?
 }
 
 #######################################
@@ -604,7 +806,7 @@ _main() {
 		return 0
 		;;
 	help | --help | -h)
-		echo "pulse-rate-limit-circuit-breaker.sh — Pulse-level GraphQL rate-limit circuit breaker (t2690) + Actions queue saturation (t3211)"
+		echo "pulse-rate-limit-circuit-breaker.sh — Pulse GraphQL breaker + REST priority budget + Actions queue saturation"
 		echo ""
 		echo "Usage:"
 		echo "  pulse-rate-limit-circuit-breaker.sh check                          # exit 0=OK, 1=tripped, 2=API error"
@@ -615,6 +817,9 @@ _main() {
 		echo "  AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD  fraction threshold (default 0.05 = 5%)"
 		echo "  AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER=1     emergency bypass"
 		echo "  AIDEVOPS_PULSE_RATE_LIMIT_CACHE_TTL       rate_limit cache TTL seconds (default 20)"
+		echo "  AIDEVOPS_PULSE_REST_CORE_RESERVE          REST soft-cap maximum (default 500; 0 disables)"
+		echo "  AIDEVOPS_PULSE_REST_CORE_HARD_FLOOR       REST emergency floor (default 100)"
+		echo "  AIDEVOPS_PULSE_REST_CORE_ADAPTIVE_WINDOW_SECONDS  soft-cap decay window (default 3600)"
 		echo ""
 		echo "Environment (Actions queue, t3211):"
 		echo "  AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN  min queued runs (default 50; 0 disables)"

--- a/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
@@ -230,7 +230,9 @@ _cb_rest_core_bounds() {
 _cb_rest_core_thresholds() {
 	local reset_epoch="$1"
 	local now_epoch="$2"
-	local soft_cap hard_floor window_seconds
+	local soft_cap
+	local hard_floor
+	local window_seconds
 	read -r soft_cap hard_floor window_seconds < <(_cb_rest_core_bounds)
 	[[ "$reset_epoch" =~ ^[0-9]+$ ]] || return 1
 	[[ "$now_epoch" =~ ^[0-9]+$ ]] || return 1
@@ -288,7 +290,8 @@ _cb_rest_core_observation() {
 	if [[ ! "$remaining" =~ ^[0-9]+$ || ! "$limit" =~ ^[0-9]+$ || ! "$reset" =~ ^[0-9]+$ || "$resource" != "$_CB_REST_CORE_RESOURCE" || "$reset" -le "$now" ]]; then
 		return 2
 	fi
-	local cache_dir cache_tmp
+	local cache_dir
+	local cache_tmp
 	cache_dir=$(dirname "$_CB_REST_CORE_CACHE_FILE")
 	cache_tmp="${_CB_REST_CORE_CACHE_FILE}.tmp.$$"
 	mkdir -p "$cache_dir" 2>/dev/null || true
@@ -312,14 +315,19 @@ _cb_rest_core_observation() {
 # Modes: normal, reserve, emergency, disabled, unknown.
 #######################################
 pulse_rest_core_priority_snapshot() {
-	local soft_cap hard_floor window_seconds
+	local soft_cap
+	local hard_floor
+	local window_seconds
 	read -r soft_cap hard_floor window_seconds < <(_cb_rest_core_bounds)
 	if [[ "${AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER:-0}" == "1" || "$soft_cap" -eq 0 ]]; then
 		printf 'disabled ? ? 0 %s %s ?\n' "$soft_cap" "$hard_floor"
 		return 0
 	fi
 
-	local observation remaining limit reset_epoch
+	local observation
+	local remaining
+	local limit
+	local reset_epoch
 	observation=$(_cb_rest_core_observation) || observation=""
 	if [[ -z "$observation" ]]; then
 		printf 'unknown ? ? ? %s %s ?\n' "$soft_cap" "$hard_floor"
@@ -369,7 +377,13 @@ _cb_rest_core_priority_decision_allows() {
 	*) return 2 ;;
 	esac
 
-	local mode remaining limit adaptive soft_cap hard_floor reset_epoch
+	local mode
+	local remaining
+	local limit
+	local adaptive
+	local soft_cap
+	local hard_floor
+	local reset_epoch
 	read -r mode remaining limit adaptive soft_cap hard_floor reset_epoch <<<"$decision"
 	case "$mode" in
 	disabled | normal)
@@ -422,7 +436,14 @@ pulse_rest_core_reserve_allows() {
 # Gate new dispatch work at the hard floor and on unknown REST evidence.
 #######################################
 _cb_rest_core_progress_allows_dispatch() {
-	local decision mode remaining limit adaptive soft_cap hard_floor reset_epoch
+	local decision
+	local mode
+	local remaining
+	local limit
+	local adaptive
+	local soft_cap
+	local hard_floor
+	local reset_epoch
 	decision=$(pulse_rest_core_priority_snapshot)
 	local progress_rc=0
 	_cb_rest_core_priority_decision_allows progress "$decision" || progress_rc=$?

--- a/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
@@ -433,7 +433,24 @@ pulse_rest_core_reserve_allows() {
 }
 
 #######################################
+# Describe why the REST-core progress policy rejected a stage.
+#######################################
+_cb_rest_core_progress_block_reason() {
+	local progress_rc="$1"
+	case "$progress_rc" in
+	1) printf 'known REST-core progress floor reached\n' ;;
+	2) printf 'authoritative REST-core quota evidence unavailable\n' ;;
+	*) printf 'unexpected REST-core progress decision (rc=%s)\n' "$progress_rc" ;;
+	esac
+	return 0
+}
+
+#######################################
 # Gate new dispatch work at the hard floor and on unknown REST evidence.
+# Unknown evidence deliberately remains fail-closed without a time-based
+# downgrade: every later call retries the bounded authoritative probe, and
+# progress resumes only after valid evidence returns or an operator selects the
+# explicit emergency bypass.
 #######################################
 _cb_rest_core_progress_allows_dispatch() {
 	local decision
@@ -450,7 +467,9 @@ _cb_rest_core_progress_allows_dispatch() {
 	[[ "$progress_rc" -eq 0 ]] && return 0
 
 	read -r mode remaining limit adaptive soft_cap hard_floor reset_epoch <<<"$decision"
-	echo "${_CB_RL_LOG_PREFIX} REST-core progress gate blocked: mode=${mode} remaining=${remaining}/${limit} adaptive=${adaptive} soft_cap=${soft_cap} hard_floor=${hard_floor} reset=${reset_epoch} rc=${progress_rc} (GH#29742)" >>"$LOGFILE"
+	local block_reason
+	block_reason=$(_cb_rest_core_progress_block_reason "$progress_rc")
+	echo "${_CB_RL_LOG_PREFIX} REST-core progress gate blocked: ${block_reason}; deferring until a later authoritative probe allows progress; mode=${mode} remaining=${remaining}/${limit} adaptive=${adaptive} soft_cap=${soft_cap} hard_floor=${hard_floor} reset=${reset_epoch} rc=${progress_rc} (GH#29742)" >>"$LOGFILE"
 	if declare -F pulse_stats_increment >/dev/null 2>&1; then
 		pulse_stats_increment "pulse_rest_core_progress_blocked" 2>/dev/null || true
 		pulse_stats_increment "pulse_rest_core_progress_blocked_${mode}" 2>/dev/null || true
@@ -484,7 +503,9 @@ _cb_allow_dispatch_with_rest_fallback() {
 	local core_rc=0
 	pulse_rest_core_priority_allows progress || core_rc=$?
 	if [[ "$core_rc" -ne 0 ]]; then
-		echo "${_CB_RL_LOG_PREFIX} GraphQL budget exhausted and REST fallback unavailable: REST-core progress floor is unavailable or exhausted (rc=${core_rc})" >>"$LOGFILE"
+		local block_reason
+		block_reason=$(_cb_rest_core_progress_block_reason "$core_rc")
+		echo "${_CB_RL_LOG_PREFIX} GraphQL budget exhausted and REST fallback unavailable: ${block_reason}; deferring until a later authoritative probe allows progress (rc=${core_rc})" >>"$LOGFILE"
 		return 1
 	fi
 
@@ -515,7 +536,9 @@ is_graphql_budget_sufficient() {
 
 	local threshold="${AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD:-0.05}"
 
-	# Disabled if threshold is explicitly 0 (any zero representation).
+	# A zero threshold disables only the GraphQL floor. The independent REST-core
+	# gate still protects its hard floor and remains fail-closed on unknown quota
+	# evidence; AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER=1 bypasses both explicitly.
 	if awk -v t="$threshold" 'BEGIN { exit (t + 0 == 0) ? 0 : 1 }' 2>/dev/null; then
 		_cb_rest_core_progress_allows_dispatch
 		return $?

--- a/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
@@ -15,8 +15,8 @@
 #
 # Subcommands:
 #   check   — exit 0 if budget is sufficient (dispatch may proceed),
-#             exit 1 if tripped (dispatch should be deferred),
-#             exit 2 on API error (fail-open: dispatch proceeds with warning)
+#             exit 1 if tripped or REST evidence blocks dispatch,
+#             exit 2 when GraphQL is unavailable after REST authorizes fail-open
 #   status  — print human-readable status to stdout (for `aidevops status`)
 #   help    — usage information
 #
@@ -520,12 +520,32 @@ _cb_allow_dispatch_with_rest_fallback() {
 }
 
 #######################################
+# Gate GraphQL projection failures through independent REST-core evidence.
+#
+# Args:
+#   $1 - diagnostic reason the GraphQL projection is unusable.
+#
+# Returns: 1 when REST blocks dispatch; 2 when REST authorizes GraphQL fail-open.
+#######################################
+_cb_graphql_projection_unavailable() {
+	local reason="$1"
+	echo "${_CB_RL_LOG_PREFIX} WARNING: ${reason}; checking the independent REST-core progress gate before GraphQL fail-open" >>"$LOGFILE"
+	if ! _cb_rest_core_progress_allows_dispatch; then
+		return 1
+	fi
+
+	echo "${_CB_RL_LOG_PREFIX} WARNING: GraphQL projection unavailable but authoritative REST-core evidence permits progress — proceeding with dispatch (fail-open)" >>"$LOGFILE"
+	return 2
+}
+
+#######################################
 # Check whether the GitHub GraphQL rate-limit budget is sufficient for dispatch.
 # Falls back to REST-backed dispatch when GraphQL is exhausted but REST core has
 # enough headroom for issue/comment/label operations.
 #
 # Returns: 0 when dispatch may proceed, 1 when a known floor or unknown REST
-# observation should defer, 2 when the GraphQL projection itself is unavailable.
+# observation should defer, 2 when GraphQL is unavailable after REST authorizes
+# fail-open dispatch.
 #######################################
 is_graphql_budget_sufficient() {
 	# Emergency bypass.
@@ -549,8 +569,8 @@ is_graphql_budget_sufficient() {
 	rate_json=$(_cb_rate_limit_json normal) || rate_json=""
 
 	if [[ -z "$rate_json" ]]; then
-		echo "${_CB_RL_LOG_PREFIX} WARNING: gh api rate_limit failed — proceeding with dispatch (fail-open)" >>"$LOGFILE"
-		return 2
+		_cb_graphql_projection_unavailable "gh api rate_limit failed"
+		return $?
 	fi
 
 	local remaining="" limit=""
@@ -558,14 +578,14 @@ is_graphql_budget_sufficient() {
 	limit=$(printf '%s' "$rate_json" | jq -r '.resources.graphql.limit // ""') || limit=""
 
 	if [[ ! "$remaining" =~ ^[0-9]+$ ]] || [[ ! "$limit" =~ ^[0-9]+$ ]]; then
-		echo "${_CB_RL_LOG_PREFIX} WARNING: could not parse GraphQL rate-limit response (remaining='${remaining}', limit='${limit}') — proceeding (fail-open)" >>"$LOGFILE"
-		return 2
+		_cb_graphql_projection_unavailable "could not parse GraphQL rate-limit response (remaining='${remaining}', limit='${limit}')"
+		return $?
 	fi
 
 	# Avoid division by zero.
 	if [[ "$limit" -eq 0 ]]; then
-		echo "${_CB_RL_LOG_PREFIX} WARNING: GraphQL limit is 0 — proceeding (fail-open)" >>"$LOGFILE"
-		return 2
+		_cb_graphql_projection_unavailable "GraphQL limit is 0"
+		return $?
 	fi
 
 	# Compute threshold as integer: threshold_count = ceil(threshold * limit).
@@ -853,7 +873,7 @@ _main() {
 		echo "pulse-rate-limit-circuit-breaker.sh — Pulse GraphQL breaker + REST priority budget + Actions queue saturation"
 		echo ""
 		echo "Usage:"
-		echo "  pulse-rate-limit-circuit-breaker.sh check                          # exit 0=OK, 1=tripped, 2=API error"
+		echo "  pulse-rate-limit-circuit-breaker.sh check                          # exit 0=OK, 1=blocked, 2=GraphQL unavailable after REST allows"
 		echo "  pulse-rate-limit-circuit-breaker.sh check-actions-queue OWNER/REPO # KEY=VALUE: queued/in_progress/ratio/saturated"
 		echo "  pulse-rate-limit-circuit-breaker.sh status [--cached]              # human-readable status line"
 		echo ""

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -434,129 +434,9 @@ if ! type config_get >/dev/null 2>&1; then
 	}
 fi
 
-# ---------------------------------------------------------------------------
-# GraphQL budget priority scheduler (GH#22479)
-#
-# Defines lightweight helpers before the extracted pulse modules are sourced so
-# modules such as pulse-dispatch-engine.sh can call them at runtime. Low budget
-# reserves GraphQL for merge readiness, dispatch capacity checks, and worker
-# launch safety gates; optional enrichment/dashboard/routine/cache stages defer.
-# ---------------------------------------------------------------------------
-_pulse_gh_rate_limit_json() {
-	local _rate_json=""
-	local _rc=0
-	local _secs="${AIDEVOPS_GH_READ_TIMEOUT:-15}"
-	[[ "$_secs" =~ ^[0-9]+$ ]] || _secs=15
-
-	if declare -F _cb_rate_limit_json >/dev/null 2>&1; then
-		_rate_json=$(_cb_rate_limit_json normal 2>/dev/null) || _rc=$?
-	elif declare -F _gh_with_timeout >/dev/null 2>&1; then
-		_rate_json=$(_gh_with_timeout read gh api rate_limit 2>/dev/null) || _rc=$?
-	elif declare -F timeout_sec >/dev/null 2>&1; then
-		_rate_json=$(timeout_sec "$_secs" gh api rate_limit 2>/dev/null) || _rc=$?
-	elif command -v timeout >/dev/null 2>&1; then
-		_rate_json=$(timeout "$_secs" gh api rate_limit 2>/dev/null) || _rc=$?
-	elif command -v gtimeout >/dev/null 2>&1; then
-		_rate_json=$(gtimeout "$_secs" gh api rate_limit 2>/dev/null) || _rc=$?
-	else
-		return 1
-	fi
-
-	[[ "$_rc" -eq 0 ]] || return "$_rc"
-	[[ -n "$_rate_json" ]] || return 1
-	printf '%s\n' "$_rate_json"
-	return 0
-}
-
-_pulse_graphql_budget_priority_decision() {
-	local _threshold="${AIDEVOPS_PULSE_OPTIONAL_BUDGET_THRESHOLD:-${AIDEVOPS_PULSE_PREFETCH_BUDGET_THRESHOLD:-1250}}"
-	[[ "$_threshold" =~ ^[0-9]+$ ]] || _threshold=1250
-	local _rate_json=""
-	_rate_json=$(_pulse_gh_rate_limit_json) || _rate_json=""
-	if [[ -z "$_rate_json" ]]; then
-		printf 'unknown ? ? %s\n' "$_threshold"
-		return 0
-	fi
-	local _remaining="" _limit=""
-	_remaining=$(printf '%s' "$_rate_json" | jq -r '.resources.graphql.remaining // ""' 2>/dev/null) || _remaining=""
-	_limit=$(printf '%s' "$_rate_json" | jq -r '.resources.graphql.limit // ""' 2>/dev/null) || _limit=""
-	if [[ ! "$_remaining" =~ ^[0-9]+$ ]] || [[ ! "$_limit" =~ ^[0-9]+$ ]]; then
-		printf 'unknown ? ? %s\n' "$_threshold"
-		return 0
-	fi
-	if [[ "$_remaining" -lt "$_threshold" ]]; then
-		printf 'reserve %s %s %s\n' "$_remaining" "$_limit" "$_threshold"
-		return 0
-	fi
-	printf 'normal %s %s %s\n' "$_remaining" "$_limit" "$_threshold"
-	return 0
-}
-
-_pulse_set_graphql_budget_priority() {
-	local _decision="" _class="" _remaining="" _limit="" _threshold=""
-	_decision=$(_pulse_graphql_budget_priority_decision)
-	read -r _class _remaining _limit _threshold <<<"$_decision"
-	[[ -n "$_class" ]] || _class="unknown"
-	export AIDEVOPS_PULSE_GRAPHQL_BUDGET_CLASS="$_class"
-	export AIDEVOPS_PULSE_GRAPHQL_BUDGET_REMAINING="$_remaining"
-	export AIDEVOPS_PULSE_GRAPHQL_BUDGET_LIMIT="$_limit"
-	export AIDEVOPS_PULSE_GRAPHQL_BUDGET_THRESHOLD="$_threshold"
-	if [[ "$_class" == "reserve" ]]; then
-		echo "[pulse-wrapper] GraphQL budget reserve mode: remaining=${_remaining}/${_limit} < optional_threshold=${_threshold}; deferring optional stages, preserving merge/dispatch budget (GH#22479)" >>"$LOGFILE"
-		if declare -F pulse_stats_increment >/dev/null 2>&1; then
-			pulse_stats_increment "pulse_graphql_budget_reserve_mode" 2>/dev/null || true
-		fi
-	elif [[ "$_class" == "unknown" ]]; then
-		echo "[pulse-wrapper] GraphQL budget priority unknown — proceeding fail-open for optional stages (GH#22479)" >>"$LOGFILE"
-	fi
-	return 0
-}
-
-_pulse_should_defer_budget_priority_stage() {
-	local _stage="$1"
-	[[ "${AIDEVOPS_PULSE_GRAPHQL_BUDGET_CLASS:-normal}" == "reserve" ]] || return 1
-	case "$_stage" in
-	cache_prime | fix_the_fixer_detector | coderabbit_review | post_merge_scanner | pr_review_thread_response | auto_decomposer_scanner | dedup_cleanup | fast_fail_prune_expired | evaluate_routines | dependabot_alert_monitor | canonical_maintenance | dashboard_freshness_check | llm_supervisor)
-		return 0
-		;;
-	*)
-		return 1
-		;;
-	esac
-}
-
-_pulse_defer_budget_priority_stage() {
-	local _stage="$1"
-	echo "[pulse-wrapper] budget-priority: deferred optional stage '${_stage}' (class=${AIDEVOPS_PULSE_GRAPHQL_BUDGET_CLASS:-unknown}, remaining=${AIDEVOPS_PULSE_GRAPHQL_BUDGET_REMAINING:-?}/${AIDEVOPS_PULSE_GRAPHQL_BUDGET_LIMIT:-?}, threshold=${AIDEVOPS_PULSE_GRAPHQL_BUDGET_THRESHOLD:-?})" >>"$LOGFILE"
-	if declare -F pulse_stats_increment >/dev/null 2>&1; then
-		pulse_stats_increment "pulse_graphql_budget_stage_deferred" 2>/dev/null || true
-		pulse_stats_increment "pulse_graphql_budget_stage_deferred_${_stage}" 2>/dev/null || true
-	fi
-	return 0
-}
-
-_pulse_run_optional_stage() {
-	local _stage="$1"
-	shift
-	if _pulse_should_defer_budget_priority_stage "$_stage"; then
-		_pulse_defer_budget_priority_stage "$_stage"
-		return 0
-	fi
-	"$@"
-	return $?
-}
-
-_pulse_run_optional_stage_with_timeout() {
-	local _stage="$1"
-	local _timeout="$2"
-	shift 2
-	if _pulse_should_defer_budget_priority_stage "$_stage"; then
-		_pulse_defer_budget_priority_stage "$_stage"
-		return 0
-	fi
-	run_stage_with_timeout "$_stage" "$_timeout" "$@"
-	return $?
-}
+# Stage-boundary GraphQL/REST priority scheduler (GH#22479, GH#29742).
+# shellcheck source=./pulse-budget-priority.sh
+source "${SCRIPT_DIR}/pulse-budget-priority.sh"
 
 # Configuration defaults, validation, path constants, and per-cycle health
 # counters extracted to pulse-wrapper-config.sh (GH#20781).
@@ -957,6 +837,10 @@ _pulse_execute_self_check() {
 		_pulse_run_deterministic_pipeline
 		_pulse_maybe_run_llm_supervisor
 		_pulse_set_graphql_budget_priority
+		_pulse_set_rest_core_budget_priority
+		_pulse_stage_priority_class
+		_pulse_run_budget_priority_stage
+		_pulse_run_budget_priority_stage_with_timeout
 		_pulse_run_optional_stage
 		_pulse_run_optional_stage_with_timeout
 		_carry_forward_pr_diff
@@ -991,6 +875,7 @@ _pulse_execute_self_check() {
 	# GH#19836: pulse-merge.sh further split into three modules (conflict + feedback extracted).
 	# GH#20781: config block extracted to pulse-wrapper-config.sh.
 	local _sc_expected_guards=(
+		_PULSE_BUDGET_PRIORITY_LOADED
 		_PULSE_WRAPPER_CONFIG_LOADED
 		_PULSE_MODEL_ROUTING_LOADED
 		_PULSE_INSTANCE_LOCK_LOADED
@@ -1275,7 +1160,7 @@ _pulse_run_deterministic_pipeline() {
 		fi
 	fi
 	if [[ "$_pmr_skip" -eq 0 ]]; then
-		run_stage_with_timeout "deterministic_merge_pass" "$PRE_RUN_STAGE_TIMEOUT" \
+		_pulse_run_budget_priority_stage_with_timeout "deterministic_merge_pass" "$PRE_RUN_STAGE_TIMEOUT" \
 			merge_ready_prs_all_repos || true
 	fi
 
@@ -1287,7 +1172,7 @@ _pulse_run_deterministic_pipeline() {
 	if [[ -f "$STOP_FLAG" ]]; then
 		echo "[pulse-wrapper] Stop flag appeared — skipping dirty-pr-sweep" >>"$LOGFILE"
 	else
-		run_stage_with_timeout "dirty_pr_sweep" "$PRE_RUN_STAGE_TIMEOUT" \
+		_pulse_run_budget_priority_stage_with_timeout "dirty_pr_sweep" "$PRE_RUN_STAGE_TIMEOUT" \
 			dirty_pr_sweep_all_repos || true
 	fi
 	# Accumulate health counters written by merge_ready_prs_all_repos (GH#18571, GH#15107).
@@ -1314,7 +1199,7 @@ _pulse_run_deterministic_pipeline() {
 	if [[ -f "$STOP_FLAG" ]]; then
 		echo "[pulse-wrapper] Stop flag appeared — skipping GitHub issue-state sync" >>"$LOGFILE"
 	else
-		run_stage_with_timeout "sync_todo_refs_all_repos" "$PRE_RUN_STAGE_TIMEOUT" \
+		_pulse_run_budget_priority_stage_with_timeout "sync_todo_refs_all_repos" "$PRE_RUN_STAGE_TIMEOUT" \
 			sync_todo_refs_all_repos || true
 	fi
 
@@ -1326,7 +1211,7 @@ _pulse_run_deterministic_pipeline() {
 	if [[ -f "$STOP_FLAG" ]]; then
 		echo "[pulse-wrapper] Stop flag appeared — skipping dependency graph cache build" >>"$LOGFILE"
 	else
-		PULSE_DEP_GRAPH_FORCE_REBUILD=1 run_stage_with_timeout "build_dependency_graph_cache" "$PRE_RUN_STAGE_TIMEOUT" \
+		PULSE_DEP_GRAPH_FORCE_REBUILD=1 _pulse_run_budget_priority_stage_with_timeout "build_dependency_graph_cache" "$PRE_RUN_STAGE_TIMEOUT" \
 			build_dependency_graph_cache || true
 	fi
 
@@ -1336,7 +1221,7 @@ _pulse_run_deterministic_pipeline() {
 	if [[ -f "$STOP_FLAG" ]]; then
 		echo "[pulse-wrapper] Stop flag appeared — skipping blocked-status refresh" >>"$LOGFILE"
 	else
-		run_stage_with_timeout "refresh_blocked_status_from_graph" "$PRE_RUN_STAGE_TIMEOUT" \
+		_pulse_run_budget_priority_stage_with_timeout "refresh_blocked_status_from_graph" "$PRE_RUN_STAGE_TIMEOUT" \
 			refresh_blocked_status_from_graph || true
 	fi
 
@@ -1375,7 +1260,7 @@ _pulse_run_deterministic_pipeline() {
 				pulse_stats_increment "dispatch_candidate_failed_reason_runner_health_circuit_breaker" 2>/dev/null || true
 			fi
 		else
-			apply_dispatch_max
+			_pulse_run_budget_priority_stage "dispatch_max" apply_dispatch_max
 		fi
 	fi
 
@@ -1385,7 +1270,7 @@ _pulse_run_deterministic_pipeline() {
 	if [[ -f "$STOP_FLAG" ]]; then
 		echo "[pulse-wrapper] Stop flag appeared — skipping routine evaluation" >>"$LOGFILE"
 	else
-		run_stage_with_timeout "evaluate_routines" "$PRE_RUN_STAGE_TIMEOUT" \
+		_pulse_run_budget_priority_stage_with_timeout "evaluate_routines" "$PRE_RUN_STAGE_TIMEOUT" \
 			evaluate_routines || true
 	fi
 
@@ -1406,7 +1291,7 @@ _pulse_run_deterministic_pipeline() {
 	if [[ -f "$STOP_FLAG" ]]; then
 		echo "[pulse-wrapper] Stop flag appeared — skipping canonical maintenance" >>"$LOGFILE"
 	else
-		run_stage_with_timeout "canonical_maintenance" "$PRE_RUN_STAGE_TIMEOUT" \
+		_pulse_run_budget_priority_stage_with_timeout "canonical_maintenance" "$PRE_RUN_STAGE_TIMEOUT" \
 			run_canonical_maintenance || true
 	fi
 
@@ -1426,7 +1311,7 @@ _pulse_run_deterministic_pipeline() {
 		echo "[pulse-wrapper] Stop flag appeared — skipping dashboard freshness check" >>"$LOGFILE"
 	fi
 	if [[ ! -f "$STOP_FLAG" && -x "$_dfc_script" ]]; then
-		run_stage_with_timeout "dashboard_freshness_check" "$PRE_RUN_STAGE_TIMEOUT" \
+		_pulse_run_budget_priority_stage_with_timeout "dashboard_freshness_check" "$PRE_RUN_STAGE_TIMEOUT" \
 			bash "$_dfc_script" scan || true
 	fi
 
@@ -1770,6 +1655,7 @@ main() {
 	# defer in reserve mode. The t2690 dispatch breaker still fail-closes actual
 	# worker launch at the emergency floor.
 	_pulse_set_graphql_budget_priority
+	_pulse_set_rest_core_budget_priority
 	local _cycle_dispatch_before
 	_cycle_dispatch_before=$(_pulse_capture_dispatch_total)
 	if [[ "${PULSE_DRY_RUN:-0}" != "1" ]]; then
@@ -1812,7 +1698,7 @@ main() {
 
 	# Recover dependency close events missed by async merge/issue-close races.
 	# Sentinel-gated to bound API use; the reconciler itself fails closed.
-	_pulse_reconcile_stale_blocked_if_due || true
+	_pulse_run_budget_priority_stage "stale_blocked_reconcile" _pulse_reconcile_stale_blocked_if_due || true
 
 	# t3077: LLM-driven fix-the-fixer detector. Classifies new auto-dispatch
 	# issues — when the work itself touches the worker dispatch system,
@@ -1863,7 +1749,7 @@ main() {
 	# approval landed since the last merge-only tick, we pick it up here
 	# rather than waiting for the next 60s cycle. Best-effort — never aborts
 	# the cycle. See pulse-wrapper-bootstrap.sh::_drain_merge_trigger_file_if_present.
-	_drain_merge_trigger_file_if_present || true
+	_pulse_run_budget_priority_stage "approval_merge_trigger" _drain_merge_trigger_file_if_present || true
 
 	# Run pre-flight stages (cleanup, prefetch, normalization)
 	if ! _run_preflight_stages; then

--- a/.agents/scripts/tests/test-dispatch-max-parallel.sh
+++ b/.agents/scripts/tests/test-dispatch-max-parallel.sh
@@ -57,6 +57,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 # shellcheck source=../pulse-dispatch-engine.sh
 source "${SCRIPT_DIR}/pulse-dispatch-engine.sh"
 
+# Keep loop tests isolated from live API budget evidence. The dedicated budget
+# gate case below overrides this helper to verify the stop path explicitly.
+_dispatch_graphql_budget_allows_next() {
+	return 0
+}
+
 # =============================================================================
 # Test 1: _dispatch_max_compute_parallel honours DISPATCH_MAX_PARALLEL
 # =============================================================================
@@ -433,7 +439,7 @@ test_parallel_loop_graphql_budget_aborts() {
 		return 0
 	}
 	# shellcheck disable=SC2317  # called via name resolution from loop
-	is_graphql_budget_sufficient() {
+	_dispatch_graphql_budget_allows_next() {
 		return 1
 	}
 
@@ -449,7 +455,10 @@ test_parallel_loop_graphql_budget_aborts() {
 	local result
 	result=$(_dispatch_max_loop "$candidate_file" 10 10 "test_user" 4 "$outcomes_file")
 	rm -f "$candidate_file" "$outcomes_file"
-	unset -f is_graphql_budget_sufficient
+	# Restore the default test isolation stub for later loop cases.
+	_dispatch_graphql_budget_allows_next() {
+		return 0
+	}
 
 	if [[ "$result" == "0 1" ]]; then
 		print_result "parallel_loop: GraphQL budget gate aborts before launch" 0

--- a/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
@@ -273,7 +273,7 @@ assert_grep \
 	"$ENGINE"
 assert_grep \
 	"9b: label maintenance is an independently timed preflight stage" \
-	'run_stage_with_timeout "preflight_label_maintenance"' \
+	'_pulse_run_budget_priority_stage_with_timeout "preflight_label_maintenance"' \
 	"$ENGINE"
 assert_grep \
 	"9c: capacity and label maintenance use separate helper functions" \
@@ -290,26 +290,26 @@ assert_grep \
 assert_order \
 	"9e: capacity completes before the initial fill" \
 	'^[[:space:]]*run_stage_with_timeout "preflight_capacity"' \
-	'^[[:space:]]*_preflight_early_dispatch([[:space:]]|$)' \
+	'^[[:space:]]*_pulse_run_budget_priority_stage "preflight_early_dispatch"' \
 	"$ENGINE"
 assert_order \
 	"9f: initial fill precedes label maintenance" \
-	'^[[:space:]]*_preflight_early_dispatch([[:space:]]|$)' \
-	'^[[:space:]]*run_stage_with_timeout "preflight_label_maintenance"' \
+	'^[[:space:]]*_pulse_run_budget_priority_stage "preflight_early_dispatch"' \
+	'^[[:space:]]*_pulse_run_budget_priority_stage_with_timeout "preflight_label_maintenance"' \
 	"$ENGINE"
 assert_order \
 	"9g: label maintenance precedes trusted NMR reconciliation" \
-	'^[[:space:]]*run_stage_with_timeout "preflight_label_maintenance"' \
-	'^[[:space:]]*_preflight_trusted_nmr_reconcile([[:space:]]|$)' \
+	'^[[:space:]]*_pulse_run_budget_priority_stage_with_timeout "preflight_label_maintenance"' \
+	'^[[:space:]]*_pulse_run_budget_priority_stage "preflight_trusted_nmr_reconcile"' \
 	"$ENGINE"
 assert_order \
 	"9g2: trusted NMR reconciliation precedes the same-cycle refill" \
-	'^[[:space:]]*_preflight_trusted_nmr_reconcile([[:space:]]|$)' \
-	'^[[:space:]]*_preflight_post_label_refill([[:space:]]|$)' \
+	'^[[:space:]]*_pulse_run_budget_priority_stage "preflight_trusted_nmr_reconcile"' \
+	'^[[:space:]]*_pulse_run_budget_priority_stage "preflight_post_label_refill"' \
 	"$ENGINE"
 assert_order \
 	"9h: post-label refill precedes async housekeeping" \
-	'^[[:space:]]*_preflight_post_label_refill([[:space:]]|$)' \
+	'^[[:space:]]*_pulse_run_budget_priority_stage "preflight_post_label_refill"' \
 	'^[[:space:]]*_pulse_start_post_dispatch_housekeeping([[:space:]]|$)' \
 	"$ENGINE"
 assert_not_grep \

--- a/.agents/scripts/tests/test-pulse-graphql-budget-priority.sh
+++ b/.agents/scripts/tests/test-pulse-graphql-budget-priority.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -14,26 +14,34 @@ export LOGFILE="${HOME}/.aidevops/logs/pulse.log"
 export WRAPPER_LOGFILE="$LOGFILE"
 mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/cache" "${HOME}/.aidevops/.agent-workspace/supervisor"
 
-STUB_DIR="${TMP_DIR}/bin"
-mkdir -p "$STUB_DIR"
-cat >"${STUB_DIR}/gh" <<'STUB'
-#!/usr/bin/env bash
-if [[ "$1" == "api" && "${2:-}" == "user" ]]; then
-	printf '{"login":"test-user"}\n'
-	exit 0
-fi
-if [[ "$1" == "api" && "${2:-}" == "rate_limit" ]]; then
-	printf '{"resources":{"graphql":{"remaining":%s,"limit":5000}}}\n' "${GH_GRAPHQL_REMAINING:-5000}"
-	exit 0
-fi
-printf '[]\n'
-exit 0
-STUB
-chmod +x "${STUB_DIR}/gh"
-export PATH="${STUB_DIR}:${PATH}"
+gh() {
+	local command_name="${1:-}"
+	local first_arg="${2:-}"
+	local second_arg="${3:-}"
+	if [[ "$command_name" == "api" && "$first_arg" == "-i" && "$second_arg" == "user" ]]; then
+		if [[ "${GH_REST_CORE_UNKNOWN:-0}" == "1" ]]; then
+			printf '{}\n'
+			return 0
+		fi
+		printf 'HTTP/2 200\nx-ratelimit-resource: core\nx-ratelimit-remaining: %s\nx-ratelimit-limit: 5000\nx-ratelimit-reset: %s\n\n{}\n' \
+			"${GH_REST_CORE_REMAINING:-5000}" "${GH_REST_CORE_RESET:-$(($(date +%s) + 3600))}"
+		return 0
+	fi
+	if [[ "$command_name" == "api" && "$first_arg" == "user" ]]; then
+		printf '{"login":"test-user"}\n'
+		return 0
+	fi
+	if [[ "$command_name" == "api" && "$first_arg" == "rate_limit" ]]; then
+		printf '{"resources":{"graphql":{"remaining":%s,"limit":5000}}}\n' "${GH_GRAPHQL_REMAINING:-5000}"
+		return 0
+	fi
+	printf '[]\n'
+	return 0
+}
+export -f gh
 
 # shellcheck source=/dev/null
-source "${SCRIPT_DIR}/../pulse-wrapper.sh" >/dev/null 2>&1
+source "${TEST_SCRIPT_DIR}/../pulse-wrapper.sh" >/dev/null 2>&1
 
 pulse_stats_increment() {
 	local counter_name="$1"
@@ -49,12 +57,25 @@ _cb_rate_limit_json() {
 }
 
 export AIDEVOPS_PULSE_OPTIONAL_BUDGET_THRESHOLD=1250
+export AIDEVOPS_PULSE_REST_CORE_RESERVE=500
+export AIDEVOPS_PULSE_REST_CORE_HARD_FLOOR=100
+export AIDEVOPS_PULSE_REST_CORE_ADAPTIVE_WINDOW_SECONDS=3600
 export GH_GRAPHQL_REMAINING=100
+export GH_REST_CORE_REMAINING=5000
+export GH_REST_CORE_RESET="$(($(date +%s) + 3600))"
 _pulse_set_graphql_budget_priority
+_pulse_set_rest_core_budget_priority
 [[ "${AIDEVOPS_PULSE_GRAPHQL_BUDGET_CLASS}" == "reserve" ]]
+[[ "${AIDEVOPS_PULSE_REST_CORE_BUDGET_CLASS}" == "normal" ]]
 _pulse_should_defer_budget_priority_stage "dashboard_freshness_check"
 _pulse_should_defer_budget_priority_stage "evaluate_routines"
 _pulse_should_defer_budget_priority_stage "pr_review_thread_response"
+export AIDEVOPS_SKIP_PULSE_PREFETCH_BUDGET_GATE=1
+if _pulse_should_defer_budget_priority_stage "preflight_prefetch_and_scope"; then
+	printf 'FAIL: GraphQL prefetch bypass did not preserve healthy-REST prefetch\n' >&2
+	exit 1
+fi
+unset AIDEVOPS_SKIP_PULSE_PREFETCH_BUDGET_GATE
 if _pulse_should_defer_budget_priority_stage "deterministic_merge_pass"; then
 	printf 'FAIL: merge-critical stage was deferred\n' >&2
 	exit 1
@@ -67,7 +88,7 @@ fi
 _pulse_defer_budget_priority_stage "dashboard_freshness_check"
 grep -q 'pulse_graphql_budget_reserve_mode' "${TMP_DIR}/counters.log"
 grep -q 'pulse_graphql_budget_stage_deferred_dashboard_freshness_check' "${TMP_DIR}/counters.log"
-grep -q 'budget-priority: deferred optional stage' "$LOGFILE"
+grep -q 'budget-priority: deferred deferrable stage' "$LOGFILE"
 
 export GH_GRAPHQL_REMAINING=3000
 _pulse_set_graphql_budget_priority
@@ -76,6 +97,76 @@ if _pulse_should_defer_budget_priority_stage "dashboard_freshness_check"; then
 	printf 'FAIL: optional stage deferred with healthy budget\n' >&2
 	exit 1
 fi
+
+[[ "$(_pulse_stage_priority_class "dashboard_freshness_check")" == "deferrable" ]]
+[[ "$(_pulse_stage_priority_class "preflight_prefetch_and_scope")" == "deferrable" ]]
+[[ "$(_pulse_stage_priority_class "preflight_label_maintenance")" == "deferrable" ]]
+[[ "$(_pulse_stage_priority_class "preflight_trusted_nmr_reconcile")" == "deferrable" ]]
+[[ "$(_pulse_stage_priority_class "stale_blocked_reconcile")" == "deferrable" ]]
+[[ "$(_pulse_stage_priority_class "sync_todo_refs_all_repos")" == "deferrable" ]]
+[[ "$(_pulse_stage_priority_class "build_dependency_graph_cache")" == "deferrable" ]]
+[[ "$(_pulse_stage_priority_class "refresh_blocked_status_from_graph")" == "deferrable" ]]
+[[ "$(_pulse_stage_priority_class "approval_merge_trigger")" == "progress" ]]
+[[ "$(_pulse_stage_priority_class "deterministic_merge_pass")" == "progress" ]]
+[[ "$(_pulse_stage_priority_class "preflight_early_dispatch")" == "progress" ]]
+[[ "$(_pulse_stage_priority_class "preflight_post_label_refill")" == "progress" ]]
+[[ "$(_pulse_stage_priority_class "reap_orphan_workers")" == "critical" ]]
+
+export GH_REST_CORE_REMAINING=400
+rm -f "${HOME}/.aidevops/cache/pulse-rest-core.json"
+_pulse_set_rest_core_budget_priority
+[[ "${AIDEVOPS_PULSE_REST_CORE_BUDGET_CLASS}" == "reserve" ]]
+_pulse_should_defer_budget_priority_stage "dashboard_freshness_check"
+_pulse_should_defer_budget_priority_stage "preflight_label_maintenance"
+_pulse_should_defer_budget_priority_stage "build_dependency_graph_cache"
+_pulse_should_defer_budget_priority_stage "stale_blocked_reconcile"
+export AIDEVOPS_SKIP_PULSE_PREFETCH_BUDGET_GATE=1
+_pulse_should_defer_budget_priority_stage "preflight_prefetch_and_scope"
+unset AIDEVOPS_SKIP_PULSE_PREFETCH_BUDGET_GATE
+if _pulse_should_defer_budget_priority_stage "deterministic_merge_pass"; then
+	printf 'FAIL: progress stage deferred above REST hard floor\n' >&2
+	exit 1
+fi
+if _pulse_should_defer_budget_priority_stage "approval_merge_trigger"; then
+	printf 'FAIL: approval-trigger merge deferred above REST hard floor\n' >&2
+	exit 1
+fi
+if _pulse_should_defer_budget_priority_stage "reap_orphan_workers"; then
+	printf 'FAIL: critical stage deferred in REST reserve mode\n' >&2
+	exit 1
+fi
+grep -q '_pulse_run_budget_priority_stage "stale_blocked_reconcile" _pulse_reconcile_stale_blocked_if_due' "${TEST_SCRIPT_DIR}/../pulse-wrapper.sh"
+grep -q '_pulse_run_budget_priority_stage "approval_merge_trigger" _drain_merge_trigger_file_if_present' "${TEST_SCRIPT_DIR}/../pulse-wrapper.sh"
+_pulse_defer_budget_priority_stage "dashboard_freshness_check"
+grep -q 'pulse_rest_core_budget_reserve_mode' "${TMP_DIR}/counters.log"
+grep -q 'pulse_rest_core_budget_stage_deferred_dashboard_freshness_check' "${TMP_DIR}/counters.log"
+
+export GH_REST_CORE_REMAINING=100
+rm -f "${HOME}/.aidevops/cache/pulse-rest-core.json"
+_pulse_set_rest_core_budget_priority
+[[ "${AIDEVOPS_PULSE_REST_CORE_BUDGET_CLASS}" == "emergency" ]]
+_pulse_should_defer_budget_priority_stage "deterministic_merge_pass"
+_pulse_should_defer_budget_priority_stage "approval_merge_trigger"
+_pulse_should_defer_budget_priority_stage "dashboard_freshness_check"
+if _pulse_should_defer_budget_priority_stage "reap_orphan_workers"; then
+	printf 'FAIL: critical stage deferred at REST hard floor\n' >&2
+	exit 1
+fi
+
+export GH_REST_CORE_UNKNOWN=1
+rm -f "${HOME}/.aidevops/cache/pulse-rest-core.json"
+_pulse_set_rest_core_budget_priority
+[[ "${AIDEVOPS_PULSE_REST_CORE_BUDGET_CLASS}" == "unknown" ]]
+_pulse_should_defer_budget_priority_stage "deterministic_merge_pass"
+_pulse_should_defer_budget_priority_stage "dashboard_freshness_check"
+if _pulse_should_defer_budget_priority_stage "reap_orphan_workers"; then
+	printf 'FAIL: critical stage deferred with unknown REST evidence\n' >&2
+	exit 1
+fi
+
+unset GH_REST_CORE_UNKNOWN
+export GH_REST_CORE_REMAINING=5000
+rm -f "${HOME}/.aidevops/cache/pulse-rest-core.json"
 
 unset -f _cb_rate_limit_json
 TIMEOUT_CALL_LOG="${TMP_DIR}/timeout-calls.log"

--- a/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
+++ b/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
@@ -521,6 +521,13 @@ else
 	fail "17b: merge routine uses REST progress priority instead of the optional-work reserve"
 fi
 
+if grep -qF 'Known REST-core progress floor reached' "$ROUTINE_FILE" &&
+	grep -qF 'REST-core quota evidence unavailable' "$ROUTINE_FILE"; then
+	pass "17c: merge routine distinguishes known REST floor from unavailable evidence"
+else
+	fail "17c: merge routine distinguishes known REST floor from unavailable evidence"
+fi
+
 printf '\n=== Standalone post-merge provider regression guards ===\n'
 
 SOURCE_CHAIN_TEST_HOME=$(mktemp -d "${TMPDIR:-/tmp}/pmr-source-chain-home-XXXXXX")

--- a/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
+++ b/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
@@ -515,6 +515,12 @@ else
 		"harness rc=${budget_rc}, output=${budget_output}"
 fi
 
+if grep -q 'pulse_rest_core_priority_allows progress' "$ROUTINE_FILE"; then
+	pass "17b: merge routine uses REST progress priority instead of the optional-work reserve"
+else
+	fail "17b: merge routine uses REST progress priority instead of the optional-work reserve"
+fi
+
 printf '\n=== Standalone post-merge provider regression guards ===\n'
 
 SOURCE_CHAIN_TEST_HOME=$(mktemp -d "${TMPDIR:-/tmp}/pmr-source-chain-home-XXXXXX")

--- a/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
@@ -7,7 +7,7 @@
 # Asserts the pulse-level GraphQL rate-limit circuit breaker:
 #   1. Trips when remaining <= threshold (e.g. 4/5000 at 5% threshold)
 #   2. Does NOT trip when remaining > threshold (e.g. 1000/5000)
-#   3. Fails open on API error (gh api rate_limit unreachable)
+#   3. GraphQL API errors fail open only after authoritative REST evidence allows
 #   4. Emergency bypass via AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER=1
 #   5. GraphQL floor disabled when threshold=0 while REST safety remains active
 #   6. Status output includes correct state
@@ -89,7 +89,9 @@ export -f pulse_stats_increment pulse_stats_get_24h
 #   STUB_GH_CORE_REMAINING — REST core remaining value (unset omits core budget)
 #   STUB_GH_CORE_RESET — REST core reset epoch (default: now+3600)
 #   STUB_GH_RESET     — GraphQL reset epoch (default: now+3600)
-#   STUB_GH_FAIL      — 1 to make gh api rate_limit fail entirely
+#   STUB_GH_FAIL      — 1 to make all gh API probes fail
+#   STUB_GH_RATE_FAIL — 1 to make only gh api rate_limit fail
+#   STUB_GH_RATE_JSON — raw gh api rate_limit response override
 gh() {
 	if [[ "$1" == "api" && "$2" == "-i" && "$3" == "user" ]]; then
 		printf 'rest-core\n' >>"$GH_REST_CALLS"
@@ -109,8 +111,12 @@ gh() {
 	if [[ "$1" == "api" && "$2" == "rate_limit" ]]; then
 		printf 'rate-limit\n' >>"$GH_RATE_CALLS"
 		[[ "${STUB_GH_DELAY:-0}" == "0" ]] || sleep "$STUB_GH_DELAY"
-		if [[ "${STUB_GH_FAIL:-0}" == "1" ]]; then
+		if [[ "${STUB_GH_FAIL:-0}" == "1" || "${STUB_GH_RATE_FAIL:-0}" == "1" ]]; then
 			return 1
+		fi
+		if [[ -n "${STUB_GH_RATE_JSON:-}" ]]; then
+			printf '%s\n' "$STUB_GH_RATE_JSON"
+			return 0
 		fi
 		local remaining="${STUB_GH_REMAINING:-5000}"
 		local limit="${STUB_GH_LIMIT:-5000}"
@@ -182,6 +188,8 @@ reset_test_state() {
 	unset STUB_GH_CORE_LIMIT 2>/dev/null || true
 	unset STUB_GH_CORE_RESET 2>/dev/null || true
 	unset STUB_GH_FAIL 2>/dev/null || true
+	unset STUB_GH_RATE_FAIL 2>/dev/null || true
+	unset STUB_GH_RATE_JSON 2>/dev/null || true
 	unset STUB_GH_DELAY 2>/dev/null || true
 	STUB_GH_REMAINING=5000
 	STUB_GH_LIMIT=5000
@@ -258,16 +266,75 @@ test_breaker_passes_just_above_threshold() {
 	return 0
 }
 
-# --- Test 5: Fail-open on API error ---
-test_fail_open_on_api_error() {
+# --- Test 5: A total API outage leaves REST evidence unknown and fails closed ---
+test_api_error_with_unknown_rest_fails_closed() {
 	reset_test_state
 	STUB_GH_FAIL=1
 	local rc=0
 	is_graphql_budget_sufficient || rc=$?
-	if [[ "$rc" -eq 2 ]]; then
-		pass "fails open on API error (rc=2)"
+	if [[ "$rc" -eq 1 ]] && grep -qF 'authoritative REST-core quota evidence unavailable' "$LOGFILE"; then
+		pass "GraphQL API error fails closed when REST evidence is unavailable"
 	else
-		fail "should fail open on API error (rc=$rc, expected 2)"
+		fail "GraphQL API error should not bypass unknown REST evidence" "rc=$rc"
+	fi
+	return 0
+}
+
+# --- Test 5b: GraphQL API failure keeps fail-open only with healthy REST ---
+test_graphql_api_error_with_healthy_rest_fails_open() {
+	reset_test_state
+	STUB_GH_RATE_FAIL=1
+	local rc=0
+	is_graphql_budget_sufficient || rc=$?
+	if [[ "$rc" -eq 2 ]] && grep -qF 'authoritative REST-core evidence permits progress' "$LOGFILE"; then
+		pass "GraphQL API error fails open only after healthy REST authorization"
+	else
+		fail "healthy REST should authorize GraphQL fail-open" "rc=$rc"
+	fi
+	return 0
+}
+
+# --- Test 5c: GraphQL API failure cannot bypass the REST hard floor ---
+test_graphql_api_error_respects_rest_hard_floor() {
+	reset_test_state
+	STUB_GH_RATE_FAIL=1
+	STUB_GH_CORE_REMAINING=10
+	local rc=0
+	is_graphql_budget_sufficient || rc=$?
+	if [[ "$rc" -eq 1 ]] && grep -qF 'known REST-core progress floor reached' "$LOGFILE"; then
+		pass "GraphQL API error respects the REST hard floor"
+	else
+		fail "GraphQL API error should not bypass the REST hard floor" "rc=$rc"
+	fi
+	return 0
+}
+
+# --- Test 5d: Malformed GraphQL projection cannot bypass the REST hard floor ---
+test_malformed_graphql_projection_respects_rest_hard_floor() {
+	reset_test_state
+	STUB_GH_RATE_JSON='{"resources":{"graphql":{"remaining":"bad","limit":5000}}}'
+	STUB_GH_CORE_REMAINING=10
+	local rc=0
+	is_graphql_budget_sufficient || rc=$?
+	if [[ "$rc" -eq 1 ]] && grep -qF 'known REST-core progress floor reached' "$LOGFILE"; then
+		pass "malformed GraphQL projection respects the REST hard floor"
+	else
+		fail "malformed GraphQL projection should not bypass the REST hard floor" "rc=$rc"
+	fi
+	return 0
+}
+
+# --- Test 5e: Zero GraphQL limit cannot bypass the REST hard floor ---
+test_zero_graphql_limit_respects_rest_hard_floor() {
+	reset_test_state
+	STUB_GH_LIMIT=0
+	STUB_GH_CORE_REMAINING=10
+	local rc=0
+	is_graphql_budget_sufficient || rc=$?
+	if [[ "$rc" -eq 1 ]] && grep -qF 'GraphQL limit is 0' "$LOGFILE"; then
+		pass "zero GraphQL limit respects the REST hard floor"
+	else
+		fail "zero GraphQL limit should not bypass the REST hard floor" "rc=$rc"
 	fi
 	return 0
 }
@@ -1016,7 +1083,11 @@ test_breaker_trips_below_threshold
 test_breaker_trips_at_threshold
 test_breaker_passes_above_threshold
 test_breaker_passes_just_above_threshold
-test_fail_open_on_api_error
+test_api_error_with_unknown_rest_fails_closed
+test_graphql_api_error_with_healthy_rest_fails_open
+test_graphql_api_error_respects_rest_hard_floor
+test_malformed_graphql_projection_respects_rest_hard_floor
+test_zero_graphql_limit_respects_rest_hard_floor
 test_emergency_bypass
 test_disabled_at_zero_threshold
 test_zero_graphql_threshold_keeps_rest_safety

--- a/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
@@ -65,7 +65,8 @@ mkdir -p "${HOME}/.aidevops/logs"
 # Stub pulse-stats-helper.sh — track counter increments.
 STATS_COUNTER_FILE="${TMP}/stats-counter.log"
 GH_RATE_CALLS="${TMP}/rate-calls.log"
-export GH_RATE_CALLS
+GH_REST_CALLS="${TMP}/rest-calls.log"
+export GH_RATE_CALLS GH_REST_CALLS
 pulse_stats_increment() {
 	local counter_name="$1"
 	printf '%s\n' "$counter_name" >>"$STATS_COUNTER_FILE"
@@ -91,6 +92,7 @@ export -f pulse_stats_increment pulse_stats_get_24h
 #   STUB_GH_FAIL      — 1 to make gh api rate_limit fail entirely
 gh() {
 	if [[ "$1" == "api" && "$2" == "-i" && "$3" == "user" ]]; then
+		printf 'rest-core\n' >>"$GH_REST_CALLS"
 		if [[ "${STUB_GH_FAIL:-0}" == "1" ]]; then
 			return 1
 		fi
@@ -167,6 +169,7 @@ reset_test_state() {
 	: >"$LOGFILE"
 	: >"$STATS_COUNTER_FILE"
 	: >"$GH_RATE_CALLS"
+	: >"$GH_REST_CALLS"
 	rm -f "${HOME}/.aidevops/logs/pulse-graphql-circuit-breaker.state"
 	rm -f "${HOME}/.aidevops/cache/pulse-graphql-rate-limit.json"
 	rm -f "${HOME}/.aidevops/cache/pulse-rest-core.json"
@@ -182,8 +185,14 @@ reset_test_state() {
 	unset STUB_GH_DELAY 2>/dev/null || true
 	STUB_GH_REMAINING=5000
 	STUB_GH_LIMIT=5000
+	export STUB_GH_CORE_REMAINING=5000
+	export STUB_GH_CORE_LIMIT=5000
+	export STUB_GH_CORE_RESET="$(($(date +%s) + 3600))"
 	export AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD="0.05"
+	export AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK=0
 	export AIDEVOPS_PULSE_REST_CORE_RESERVE=500
+	export AIDEVOPS_PULSE_REST_CORE_HARD_FLOOR=100
+	export AIDEVOPS_PULSE_REST_CORE_ADAPTIVE_WINDOW_SECONDS=3600
 	return 0
 }
 
@@ -427,6 +436,7 @@ test_log_message_on_trip() {
 # --- Test 15: GraphQL exhausted proceeds with REST fallback when core is healthy ---
 test_graphql_exhausted_rest_core_healthy_allows_dispatch() {
 	reset_test_state
+	export AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK=1
 	STUB_GH_REMAINING=0
 	STUB_GH_CORE_REMAINING=4994
 	local rc=0
@@ -444,6 +454,7 @@ test_graphql_exhausted_rest_core_healthy_allows_dispatch() {
 # --- Test 16: GraphQL exhausted still blocks when REST core is low ---
 test_graphql_exhausted_rest_core_low_blocks_dispatch() {
 	reset_test_state
+	export AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK=1
 	STUB_GH_REMAINING=0
 	STUB_GH_CORE_REMAINING=10
 	local rc=0
@@ -475,6 +486,7 @@ test_graphql_exhausted_rest_fallback_disabled_blocks_dispatch() {
 # --- Test 18: Cached response-header probe avoids a second REST request ---
 test_rest_core_probe_cache_reuse() {
 	reset_test_state
+	export AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK=1
 	STUB_GH_REMAINING=0
 	STUB_GH_CORE_REMAINING=900
 	is_graphql_budget_sufficient || true
@@ -491,6 +503,7 @@ test_rest_core_probe_cache_reuse() {
 # --- Test 19: Expired response-header observation cannot authorize fallback ---
 test_rest_core_probe_reset_forces_recheck() {
 	reset_test_state
+	export AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK=1
 	STUB_GH_REMAINING=0
 	STUB_GH_CORE_REMAINING=900
 	STUB_GH_CORE_RESET=$(($(date +%s) - 1))
@@ -500,6 +513,144 @@ test_rest_core_probe_reset_forces_recheck() {
 		pass "expired REST core header observation blocks fallback"
 	else
 		fail "expired REST core header observation should block fallback" "rc=$rc"
+	fi
+	return 0
+}
+
+# --- Test 20: Adaptive threshold decays monotonically toward the hard floor ---
+test_rest_core_adaptive_threshold_math() {
+	reset_test_state
+	local now early mid near
+	now=$(date +%s)
+	early=$(_cb_rest_core_thresholds "$((now + 3600))" "$now")
+	mid=$(_cb_rest_core_thresholds "$((now + 1800))" "$now")
+	near=$(_cb_rest_core_thresholds "$((now + 1))" "$now")
+	if [[ "$early" == "500 500 100" && "$mid" == "300 500 100" && "$near" == "101 500 100" ]]; then
+		pass "REST adaptive threshold decays from soft cap toward hard floor"
+	else
+		fail "REST adaptive threshold should be monotonic and clamped" "early=${early} mid=${mid} near=${near}"
+	fi
+	return 0
+}
+
+# --- Test 21: REST priority classes split at adaptive and hard boundaries ---
+test_rest_core_priority_boundaries() {
+	reset_test_state
+	local mode_normal mode_reserve mode_emergency
+	export STUB_GH_CORE_REMAINING=501
+	rm -f "$_CB_REST_CORE_CACHE_FILE"
+	mode_normal=$(pulse_rest_core_priority_snapshot)
+	export STUB_GH_CORE_REMAINING=500
+	rm -f "$_CB_REST_CORE_CACHE_FILE"
+	mode_reserve=$(pulse_rest_core_priority_snapshot)
+	export STUB_GH_CORE_REMAINING=100
+	rm -f "$_CB_REST_CORE_CACHE_FILE"
+	mode_emergency=$(pulse_rest_core_priority_snapshot)
+	if [[ "$mode_normal" == normal\ 501\ 5000\ 500\ 500\ 100\ * &&
+		"$mode_reserve" == reserve\ 500\ 5000\ 500\ 500\ 100\ * &&
+		"$mode_emergency" == emergency\ 100\ 5000\ 500\ 500\ 100\ * ]]; then
+		pass "REST priority modes honor adaptive soft and hard-floor boundaries"
+	else
+		fail "REST priority boundary classification mismatch" "normal=${mode_normal}; reserve=${mode_reserve}; emergency=${mode_emergency}"
+	fi
+	return 0
+}
+
+# --- Test 22: Reserve mode allows progress but not deferrable work ---
+test_rest_core_priority_class_eligibility() {
+	reset_test_state
+	export STUB_GH_CORE_REMAINING=400
+	rm -f "$_CB_REST_CORE_CACHE_FILE"
+	local progress_rc=0 deferrable_rc=0
+	pulse_rest_core_priority_allows progress || progress_rc=$?
+	pulse_rest_core_priority_allows deferrable || deferrable_rc=$?
+	if [[ "$progress_rc" -eq 0 && "$deferrable_rc" -eq 1 ]]; then
+		pass "REST reserve mode preserves progress while deferring optional work"
+	else
+		fail "REST reserve class eligibility mismatch" "progress_rc=${progress_rc} deferrable_rc=${deferrable_rc}"
+	fi
+	return 0
+}
+
+# --- Test 23: Hard floor blocks progress while critical work remains eligible ---
+test_rest_core_hard_floor_eligibility() {
+	reset_test_state
+	export STUB_GH_CORE_REMAINING=100
+	rm -f "$_CB_REST_CORE_CACHE_FILE"
+	local critical_rc=0 progress_rc=0
+	pulse_rest_core_priority_allows critical || critical_rc=$?
+	pulse_rest_core_priority_allows progress || progress_rc=$?
+	if [[ "$critical_rc" -eq 0 && "$progress_rc" -eq 1 ]]; then
+		pass "REST hard floor blocks new progress without globally blocking critical work"
+	else
+		fail "REST hard-floor class eligibility mismatch" "critical_rc=${critical_rc} progress_rc=${progress_rc}"
+	fi
+	return 0
+}
+
+# --- Test 24: Unknown REST evidence conservatively blocks non-critical work ---
+test_rest_core_unknown_evidence() {
+	reset_test_state
+	unset STUB_GH_CORE_REMAINING
+	rm -f "$_CB_REST_CORE_CACHE_FILE"
+	local progress_rc=0 deferrable_rc=0 critical_rc=0
+	pulse_rest_core_priority_allows progress || progress_rc=$?
+	pulse_rest_core_priority_allows deferrable || deferrable_rc=$?
+	pulse_rest_core_priority_allows critical || critical_rc=$?
+	if [[ "$progress_rc" -eq 2 && "$deferrable_rc" -eq 2 && "$critical_rc" -eq 0 ]]; then
+		pass "unknown REST evidence defers progress and optional stages only"
+	else
+		fail "unknown REST evidence eligibility mismatch" "critical_rc=${critical_rc} progress_rc=${progress_rc} deferrable_rc=${deferrable_rc}"
+	fi
+	return 0
+}
+
+# --- Test 25: Legacy soft-cap override and zero-disable remain compatible ---
+test_rest_core_legacy_override_compatibility() {
+	reset_test_state
+	export AIDEVOPS_PULSE_REST_CORE_RESERVE=300
+	export STUB_GH_CORE_REMAINING=300
+	rm -f "$_CB_REST_CORE_CACHE_FILE"
+	local overridden disabled_rc=0
+	overridden=$(pulse_rest_core_priority_snapshot)
+	export AIDEVOPS_PULSE_REST_CORE_RESERVE=0
+	unset STUB_GH_CORE_REMAINING
+	rm -f "$_CB_REST_CORE_CACHE_FILE"
+	pulse_rest_core_reserve_allows || disabled_rc=$?
+	if [[ "$overridden" == reserve\ 300\ 5000\ 300\ 300\ 100\ * && "$disabled_rc" -eq 0 ]]; then
+		pass "legacy REST reserve override remains the soft cap and zero disables gating"
+	else
+		fail "legacy REST reserve compatibility mismatch" "snapshot=${overridden} disabled_rc=${disabled_rc}"
+	fi
+	return 0
+}
+
+# --- Test 26: Malformed cache metadata is ignored without set -u crashes ---
+test_rest_core_malformed_cache_recovers() {
+	reset_test_state
+	mkdir -p "$(dirname "$_CB_REST_CORE_CACHE_FILE")"
+	printf '{"observed":"malformed","remaining":"bad","limit":5000,"reset":0,"resource":"core"}\n' >"$_CB_REST_CORE_CACHE_FILE"
+	local snapshot
+	snapshot=$(pulse_rest_core_priority_snapshot)
+	if [[ "$snapshot" == normal\ 5000\ 5000\ 500\ 500\ 100\ * ]]; then
+		pass "malformed REST cache is ignored and refreshed from authoritative headers"
+	else
+		fail "malformed REST cache should recover without crashing" "snapshot=${snapshot}"
+	fi
+	return 0
+}
+
+# --- Test 27: Unknown REST evidence is classified and logged from one probe ---
+test_rest_core_unknown_dispatch_uses_single_probe() {
+	reset_test_state
+	unset STUB_GH_CORE_REMAINING
+	local rc=0 rest_calls=0
+	is_graphql_budget_sufficient || rc=$?
+	rest_calls=$(grep -c '^rest-core$' "$GH_REST_CALLS" 2>/dev/null) || rest_calls=0
+	if [[ "$rc" -eq 1 && "$rest_calls" -eq 1 ]]; then
+		pass "unknown REST dispatch evidence uses one authoritative probe"
+	else
+		fail "unknown REST dispatch evidence should not trigger a duplicate probe" "rc=${rc} rest_calls=${rest_calls}"
 	fi
 	return 0
 }
@@ -846,6 +997,14 @@ test_graphql_exhausted_rest_core_low_blocks_dispatch
 test_graphql_exhausted_rest_fallback_disabled_blocks_dispatch
 test_rest_core_probe_cache_reuse
 test_rest_core_probe_reset_forces_recheck
+test_rest_core_adaptive_threshold_math
+test_rest_core_priority_boundaries
+test_rest_core_priority_class_eligibility
+test_rest_core_hard_floor_eligibility
+test_rest_core_unknown_evidence
+test_rest_core_legacy_override_compatibility
+test_rest_core_malformed_cache_recovers
+test_rest_core_unknown_dispatch_uses_single_probe
 test_shared_rate_probe_coalesces_consumers
 
 # =============================================================================

--- a/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
@@ -9,7 +9,7 @@
 #   2. Does NOT trip when remaining > threshold (e.g. 1000/5000)
 #   3. Fails open on API error (gh api rate_limit unreachable)
 #   4. Emergency bypass via AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER=1
-#   5. Disabled when threshold=0
+#   5. GraphQL floor disabled when threshold=0 while REST safety remains active
 #   6. Status output includes correct state
 #   7. Custom threshold works (e.g. 10% = 500/5000)
 #   8. Stats counter increments on trip
@@ -287,7 +287,7 @@ test_emergency_bypass() {
 	return 0
 }
 
-# --- Test 7: Disabled when threshold=0 ---
+# --- Test 7: GraphQL floor is disabled when threshold=0 and REST is healthy ---
 test_disabled_at_zero_threshold() {
 	reset_test_state
 	STUB_GH_REMAINING=0
@@ -295,9 +295,25 @@ test_disabled_at_zero_threshold() {
 	local rc=0
 	is_graphql_budget_sufficient || rc=$?
 	if [[ "$rc" -eq 0 ]]; then
-		pass "disabled when threshold=0 (remaining=0 still passes)"
+		pass "GraphQL floor disabled at threshold=0 while healthy REST still passes"
 	else
-		fail "should be disabled when threshold=0 (rc=$rc, expected 0)"
+		fail "GraphQL floor should be disabled at threshold=0 with healthy REST" "rc=$rc, expected 0"
+	fi
+	return 0
+}
+
+# --- Test 7b: GraphQL threshold=0 does not bypass unknown REST evidence ---
+test_zero_graphql_threshold_keeps_rest_safety() {
+	reset_test_state
+	export AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD=0
+	unset STUB_GH_CORE_REMAINING
+	rm -f "$_CB_REST_CORE_CACHE_FILE"
+	local rc=0
+	is_graphql_budget_sufficient || rc=$?
+	if [[ "$rc" -eq 1 ]] && grep -qF 'authoritative REST-core quota evidence unavailable' "$LOGFILE"; then
+		pass "GraphQL threshold=0 retains fail-closed unknown REST safety"
+	else
+		fail "GraphQL threshold=0 should not bypass unknown REST evidence" "rc=${rc}"
 	fi
 	return 0
 }
@@ -459,7 +475,8 @@ test_graphql_exhausted_rest_core_low_blocks_dispatch() {
 	STUB_GH_CORE_REMAINING=10
 	local rc=0
 	is_graphql_budget_sufficient || rc=$?
-	if [[ "$rc" -eq 1 && "${AIDEVOPS_GH_FORCE_REST_READS:-0}" != "1" ]]; then
+	if [[ "$rc" -eq 1 && "${AIDEVOPS_GH_FORCE_REST_READS:-0}" != "1" ]] &&
+		grep -qF 'known REST-core progress floor reached' "$LOGFILE"; then
 		pass "GraphQL exhausted with low REST core still blocks dispatch"
 	else
 		fail "low REST core should not allow fallback" "rc=$rc force_rest=${AIDEVOPS_GH_FORCE_REST_READS:-unset}"
@@ -625,6 +642,23 @@ test_rest_core_legacy_override_compatibility() {
 	return 0
 }
 
+# --- Test 25b: Hard floor above the soft cap is clamped to the soft cap ---
+test_rest_core_hard_floor_clamped_to_soft_cap() {
+	reset_test_state
+	export AIDEVOPS_PULSE_REST_CORE_RESERVE=200
+	export AIDEVOPS_PULSE_REST_CORE_HARD_FLOOR=1000
+	export STUB_GH_CORE_REMAINING=200
+	rm -f "$_CB_REST_CORE_CACHE_FILE"
+	local snapshot
+	snapshot=$(pulse_rest_core_priority_snapshot)
+	if [[ "$snapshot" == emergency\ 200\ 5000\ 200\ 200\ 200\ * ]]; then
+		pass "REST hard floor above the soft cap is clamped to the soft cap"
+	else
+		fail "REST hard-floor clamp mismatch" "snapshot=${snapshot}"
+	fi
+	return 0
+}
+
 # --- Test 26: Malformed cache metadata is ignored without set -u crashes ---
 test_rest_core_malformed_cache_recovers() {
 	reset_test_state
@@ -647,7 +681,8 @@ test_rest_core_unknown_dispatch_uses_single_probe() {
 	local rc=0 rest_calls=0
 	is_graphql_budget_sufficient || rc=$?
 	rest_calls=$(grep -c '^rest-core$' "$GH_REST_CALLS" 2>/dev/null) || rest_calls=0
-	if [[ "$rc" -eq 1 && "$rest_calls" -eq 1 ]]; then
+	if [[ "$rc" -eq 1 && "$rest_calls" -eq 1 ]] &&
+		grep -qF 'authoritative REST-core quota evidence unavailable' "$LOGFILE"; then
 		pass "unknown REST dispatch evidence uses one authoritative probe"
 	else
 		fail "unknown REST dispatch evidence should not trigger a duplicate probe" "rc=${rc} rest_calls=${rest_calls}"
@@ -984,6 +1019,7 @@ test_breaker_passes_just_above_threshold
 test_fail_open_on_api_error
 test_emergency_bypass
 test_disabled_at_zero_threshold
+test_zero_graphql_threshold_keeps_rest_safety
 test_custom_threshold_10_percent
 test_stats_counter_increments
 test_stats_counter_no_increment_on_pass
@@ -1003,6 +1039,7 @@ test_rest_core_priority_class_eligibility
 test_rest_core_hard_floor_eligibility
 test_rest_core_unknown_evidence
 test_rest_core_legacy_override_compatibility
+test_rest_core_hard_floor_clamped_to_soft_cap
 test_rest_core_malformed_cache_recovers
 test_rest_core_unknown_dispatch_uses_single_probe
 test_shared_rate_probe_coalesces_consumers


### PR DESCRIPTION
## Summary

Add adaptive REST-core soft and hard floors, deterministic Pulse stage priorities, conservative unknown-evidence handling, and reset-aware observability. GraphQL projection failures now fail open only after authoritative REST-core evidence permits progress.

## Files Changed

- `.agents/configs/pulse-rate-limit.conf`
- `.agents/scripts/pulse-budget-priority.sh`
- `.agents/scripts/pulse-dispatch-engine.sh`
- `.agents/scripts/pulse-merge-routine.sh`
- `.agents/scripts/pulse-rate-limit-circuit-breaker.sh`
- `.agents/scripts/pulse-wrapper.sh`
- `.agents/scripts/tests/test-dispatch-max-parallel.sh`
- `.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh`
- `.agents/scripts/tests/test-pulse-graphql-budget-priority.sh`
- `.agents/scripts/tests/test-pulse-merge-routine-standalone.sh`
- `.agents/scripts/tests/test-rate-limit-circuit-breaker.sh`

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified
- Circuit breaker: `48/48`
- Parallel dispatch: `24/24`
- Dispatch stage wiring: `41/41`
- Standalone merge: `25/25`
- Budget priority, timeout, canary, characterization, dry-run, event-refill, and current-state regressions passed.
- ShellCheck, Pulse unbound-variable scan, changed-file lint, protected required checks, and the full PR workflow completed successfully.
- CodeRabbit independently verified exact head `66c762766` and confirmed the prior quota-safety finding is addressed.

Resolves #29742
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.233 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 4h 52m and 3,452,237 tokens on this with the user in an interactive session.