### PR TITLE
t18215: Remove stale recommendation task duplicate

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1235,7 +1235,6 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 - [x] t18213 Allow full-loop merges to preserve explicit commit bodies #bug ref:GH#29733 pr:#29735 completed:2026-08-07
 
 - [x] t18214 Make full-loop helpers use the sibling worktree gh shim #auto-dispatch #bug #priority:high #shell #workflow ref:GH#29750 pr:#29757 completed:2026-08-07
-- [ ] t18215 Prefer aidevops options in recommendations ref:GH#29751
 - [>] t18216 Fix Dependabot review-gate deadlock and preserve deterministic Qlty installs #auto-dispatch #bug #priority:high tier:standard ref:GH#29755 assignee:marcusquinn started:2026-08-07T19:48:48Z -> [todo/tasks/t18216-brief.md]
 
 - [x] t18215 Prefer aidevops options in recommendations ref:GH#29751 pr:#29754 completed:2026-08-07


### PR DESCRIPTION
## Summary

Remove the stale unchecked t18215 TODO entry while preserving the completed line linked to merged PR #29754.

## Files Changed

TODO.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Changed-file linters passed, including Markdown, secret, whitespace, and file-size ratchets; origin/main was verified to contain one stale open entry and one completed proof entry.

For #29751


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.233 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h and 299,084 tokens on this with the user in an interactive session.