### PR TITLE
GH#29756: preserve held status during post-merge healing

### DIFF
--- a/.agents/scripts/interactive-session-helper-postmerge.sh
+++ b/.agents/scripts/interactive-session-helper-postmerge.sh
@@ -34,6 +34,9 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _lib_path
 fi
 
+# shellcheck source=./issue-hold-marker-lib.sh
+source "${SCRIPT_DIR}/issue-hold-marker-lib.sh"
+
 # -----------------------------------------------------------------------------
 # Subcommand: post-merge (t2225)
 # -----------------------------------------------------------------------------
@@ -80,21 +83,27 @@ _isc_post_merge_heal_status_done() {
 		[[ -n "$issue_num" ]] || continue
 		[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
 
-		local issue_json issue_state has_done
-		issue_json=$(gh issue view "$issue_num" --repo "$slug" --json state,labels 2>/dev/null) || continue
+		local issue_json issue_state issue_body has_done restore_status
+		issue_json=$(gh issue view "$issue_num" --repo "$slug" --json state,labels,body 2>/dev/null) || continue
 		issue_state=$(printf '%s' "$issue_json" | jq -r '.state // ""' 2>/dev/null) || continue
 		[[ "$issue_state" == "OPEN" ]] || continue
 
 		has_done=$(printf '%s' "$issue_json" | jq -r '[.labels[].name] | map(select(. == "status:done")) | length' 2>/dev/null) || continue
 		[[ "${has_done:-0}" -gt 0 ]] || continue
 
-		_isc_info "post-merge: healing false status:done on #$issue_num (t2219, For/Ref in PR #$pr_number)"
+		issue_body=$(printf '%s' "$issue_json" | jq -r '.body // ""' 2>/dev/null) || continue
+		restore_status="status:available"
+		if [[ "$(issue_body_has_defer_marker "$issue_body")" == "true" ]]; then
+			restore_status="status:blocked"
+		fi
+
+		_isc_info "post-merge: healing false status:done on #$issue_num to $restore_status (t2219, For/Ref in PR #$pr_number)"
 		gh issue edit "$issue_num" --repo "$slug" \
 			--remove-label "status:done" \
-			--add-label "status:available" >/dev/null 2>&1 || continue
+			--add-label "$restore_status" >/dev/null 2>&1 || continue
 
 		gh_issue_comment "$issue_num" --repo "$slug" --body \
-			"Reset \`status:done\` → \`status:available\` — PR #${pr_number} referenced this via \`For\`/\`Ref\` (planning convention), not \`Closes\`/\`Resolves\`. Workaround for [t2219](../issues/19719) (\`issue-sync.yml\` title-fallback false-positive)." \
+			"Reset \`status:done\` → \`${restore_status}\` — PR #${pr_number} referenced this via \`For\`/\`Ref\` (planning convention), not \`Closes\`/\`Resolves\`. Workaround for [t2219](../issues/19719) (\`issue-sync.yml\` title-fallback false-positive)." \
 			>/dev/null 2>&1 || true
 
 		healed=$((healed + 1))

--- a/.agents/scripts/issue-hold-marker-lib.sh
+++ b/.agents/scripts/issue-hold-marker-lib.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Shared issue-body hold/defer marker detection.
+
+[[ -n "${_ISSUE_HOLD_MARKER_LIB_LOADED:-}" ]] && return 0
+_ISSUE_HOLD_MARKER_LIB_LOADED=1
+
+# issue_body_has_defer_marker — detect an explicit non-dispatch hold in issue text.
+# Args: $1=issue body
+# Output: true or false
+issue_body_has_defer_marker() {
+	local body="$1"
+	if printf '%s' "$body" | grep -qiE 'defer until|do[-[:space:]]not[-[:space:]]dispatch|on[-[:space:]]hold|HUMAN_UNBLOCK_REQUIRED|hold for |paused[[:space:]:]'; then
+		printf 'true\n'
+	else
+		printf 'false\n'
+	fi
+	return 0
+}

--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -36,29 +36,9 @@ _pulse_dep_graph_dir="${BASH_SOURCE[0]%/*}"
 [[ "$_pulse_dep_graph_dir" == "${BASH_SOURCE[0]}" ]] && _pulse_dep_graph_dir="."
 # shellcheck source=./task-identity-lib.sh
 source "${_pulse_dep_graph_dir}/task-identity-lib.sh"
+# shellcheck source=./issue-hold-marker-lib.sh
+source "${_pulse_dep_graph_dir}/issue-hold-marker-lib.sh"
 unset _pulse_dep_graph_dir
-
-#######################################
-# Body defer/hold marker detection (t2031)
-#
-# A `status:blocked` label may have been applied for reasons other than
-# the blocked-by chain — most commonly a human-imposed hold phrased in
-# the issue body like "Defer until X" or "On hold". The refresh routine
-# must not auto-unblock those. This helper runs at cache build time and
-# at assertion time in the regression test; keep the regex in sync
-# across both copies.
-#
-# Arguments: $1 - issue body text
-# Outputs:   boolean text on stdout
-#######################################
-_body_has_defer_marker() {
-	local body="$1"
-	if printf '%s' "$body" | grep -qiE 'defer until|do[-[:space:]]not[-[:space:]]dispatch|on[-[:space:]]hold|HUMAN_UNBLOCK_REQUIRED|hold for |paused[[:space:]:]'; then
-		echo "true"
-	else
-		echo "${DEP_FALSE}"
-	fi
-}
 
 #######################################
 # Parse a single issue for the dep-graph cache (t2031 refactor)
@@ -134,7 +114,7 @@ _dep_graph_process_issue_json() {
 
 	# Body defer/hold marker detection (t2031).
 	local has_defer_marker
-	has_defer_marker=$(_body_has_defer_marker "$body")
+	has_defer_marker=$(issue_body_has_defer_marker "$body")
 
 	# Single jq call merges every accumulator update in one pass.
 	# Keeps the shell shorter and guarantees compact single-line output.

--- a/.agents/scripts/tests/test-interactive-session-post-merge.sh
+++ b/.agents/scripts/tests/test-interactive-session-post-merge.sh
@@ -5,12 +5,13 @@
 #
 # Covers:
 #   1. Positive t2219: For #X + OPEN + status:done → removes status:done, adds status:available
-#   2. Negative t2219: Closes #X + OPEN + status:done → NOT touched (legitimate close)
-#   3. Positive t2218: For #X + OPEN + origin:interactive + auto-dispatch + assignee=author → unassigns
-#   4. Negative t2218: For #X + OPEN + origin:interactive + auto-dispatch + status:in-review → NOT unassigned
-#   5. Idempotency: second run on already-healthy PR makes no edits
-#   6. Fail-open: unmerged PR → returns 0 without editing
-#   7. Both heals fire in same run when applicable
+#   2. Temporal hold: For #X + OPEN + status:done + hold body → restores status:blocked
+#   3. Negative t2219: Closes #X + OPEN + status:done → NOT touched (legitimate close)
+#   4. Positive t2218: For #X + OPEN + origin:interactive + auto-dispatch + assignee=author → unassigns
+#   5. Negative t2218: For #X + OPEN + origin:interactive + auto-dispatch + status:in-review → NOT unassigned
+#   6. Idempotency: second run on already-healthy PR makes no edits
+#   7. Fail-open: unmerged PR → returns 0 without editing
+#   8. Both heals fire in same run when applicable
 
 set -euo pipefail
 
@@ -116,6 +117,7 @@ _build_obj_json_array() {
 #   issue_state  — OPEN or CLOSED (default OPEN)
 #   issue_labels — comma-separated label names (default "status:available")
 #   issue_assignees — comma-separated assignee logins (default "")
+#   issue_body    — issue body text (default "")
 create_gh_stub() {
 	local pr_body="${1:-}"
 	local pr_state="${2:-MERGED}"
@@ -124,14 +126,16 @@ create_gh_stub() {
 	local issue_state="${5:-OPEN}"
 	local issue_labels_csv="${6:-status:available}"
 	local issue_assignees_csv="${7:-}"
+	local issue_body="${8:-}"
 
 	local labels_json assignees_json
 	labels_json=$(_build_obj_json_array "name" "$issue_labels_csv")
 	assignees_json=$(_build_obj_json_array "login" "$issue_assignees_csv")
 
 	# Escape the PR body for embedding in the shell heredoc
-	local escaped_body
+	local escaped_body escaped_issue_body
 	escaped_body=$(printf '%s' "$pr_body" | sed "s/'/'\\''/g")
+	escaped_issue_body=$(printf '%s' "$issue_body" | sed "s/'/'\\''/g")
 
 	local merged_at=""
 	if [[ "$pr_state" == "MERGED" ]]; then
@@ -167,7 +171,7 @@ fi
 
 # issue view — return issue metadata for any issue number
 if [[ "\${1:-}" == "issue" && "\${2:-}" == "view" ]]; then
-	printf '%s\n' '{"state":"${issue_state}","labels":${labels_json},"assignees":${assignees_json}}'
+	printf '%s\n' '{"state":"${issue_state}","labels":${labels_json},"assignees":${assignees_json},"body":"${escaped_issue_body}"}'
 	exit 0
 fi
 
@@ -200,16 +204,35 @@ test_t2219_for_ref_open_statusdone_healed() {
 
 	bash "$HELPER_SCRIPT" post-merge 100 testorg/testrepo >/dev/null 2>&1 || true
 
-	if grep -q "\-\-remove-label" "$GH_EDIT_LOG" && grep -q "status:done" "$GH_EDIT_LOG"; then
-		print_result "t2219: For #42 + OPEN + status:done → status:done removed" 0
+	if grep -q "\-\-remove-label status:done" "$GH_EDIT_LOG" && grep -q "\-\-add-label status:available" "$GH_EDIT_LOG"; then
+		print_result "t2219: ordinary For #42 false-positive → status:available" 0
 	else
-		print_result "t2219: For #42 + OPEN + status:done → status:done removed" 1 \
-			"Expected gh issue edit --remove-label status:done; got: $(cat "$GH_EDIT_LOG")"
+		print_result "t2219: ordinary For #42 false-positive → status:available" 1 \
+			"Expected status:done → status:available edit; got: $(cat "$GH_EDIT_LOG")"
 	fi
 	return 0
 }
 
-# ─── Test 2: Negative t2219 — Closes #X + OPEN + status:done → NOT touched ──
+# ─── Test 2: Temporal hold restores status:blocked ───────────────────────────
+test_t2219_temporal_hold_restores_blocked() {
+	local pr_body="For #42"
+	create_gh_stub "$pr_body" "MERGED" "testauthor" "42" "OPEN" \
+		"status:done,auto-dispatch" "" "Do not dispatch until 2026-09-01."
+
+	bash "$HELPER_SCRIPT" post-merge 100 testorg/testrepo >/dev/null 2>&1 || true
+
+	if grep -q "\-\-remove-label status:done" "$GH_EDIT_LOG" &&
+		grep -q "\-\-add-label status:blocked" "$GH_EDIT_LOG" &&
+		grep -q 'status:blocked' "$GH_COMMENT_LOG"; then
+		print_result "t2219: explicit temporal hold → status:blocked" 0
+	else
+		print_result "t2219: explicit temporal hold → status:blocked" 1 \
+			"Expected blocked restoration and audit comment; edit=$(cat "$GH_EDIT_LOG") comment=$(cat "$GH_COMMENT_LOG")"
+	fi
+	return 0
+}
+
+# ─── Test 3: Negative t2219 — Closes #X + OPEN + status:done → NOT touched ──
 test_t2219_closes_open_statusdone_not_touched() {
 	local pr_body="Closes #42"
 	create_gh_stub "$pr_body" "MERGED" "testauthor" "42" "OPEN" "status:done,auto-dispatch"
@@ -226,7 +249,7 @@ test_t2219_closes_open_statusdone_not_touched() {
 	return 0
 }
 
-# ─── Test 3: Positive t2218 — For #42 + origin:interactive + auto-dispatch + assignee → unassigned ─
+# ─── Test 4: Positive t2218 — For #42 + origin:interactive + auto-dispatch + assignee → unassigned ─
 test_t2218_for_ref_interactive_autodispatch_healed() {
 	local pr_body="For #42"
 	create_gh_stub "$pr_body" "MERGED" "testauthor" "42" "OPEN" \
@@ -243,7 +266,7 @@ test_t2218_for_ref_interactive_autodispatch_healed() {
 	return 0
 }
 
-# ─── Test 4: Negative t2218 — status:in-review present → NOT unassigned ─────
+# ─── Test 5: Negative t2218 — status:in-review present → NOT unassigned ─────
 test_t2218_in_review_not_unassigned() {
 	local pr_body="For #42"
 	create_gh_stub "$pr_body" "MERGED" "testauthor" "42" "OPEN" \
@@ -260,7 +283,7 @@ test_t2218_in_review_not_unassigned() {
 	return 0
 }
 
-# ─── Test 5: Idempotency — no status:done, no stale assign → no edits ────────
+# ─── Test 6: Idempotency — no status:done, no stale assign → no edits ────────
 test_idempotency_no_edits_needed() {
 	local pr_body="For #42"
 	# Clean issue: no status:done, no stale self-assign (not assigned at all)
@@ -286,7 +309,7 @@ test_idempotency_no_edits_needed() {
 	return 0
 }
 
-# ─── Test 6: Fail-open — unmerged PR → exit 0, no edits ─────────────────────
+# ─── Test 7: Fail-open — unmerged PR → exit 0, no edits ─────────────────────
 test_failopen_unmerged_pr() {
 	local pr_body="For #42"
 	create_gh_stub "$pr_body" "OPEN" "testauthor" "42" "OPEN" "status:done"
@@ -307,7 +330,7 @@ test_failopen_unmerged_pr() {
 	return 0
 }
 
-# ─── Test 7: Both heals fire in same run ─────────────────────────────────────
+# ─── Test 8: Both heals fire in same run ─────────────────────────────────────
 test_both_heals_fire_together() {
 	# PR references same issue via For #42; issue has BOTH status:done AND is
 	# self-assigned with auto-dispatch + origin:interactive (no active status)
@@ -340,6 +363,7 @@ main() {
 	printf 'Running post-merge regression tests (t2225)...\n\n'
 
 	test_t2219_for_ref_open_statusdone_healed
+	test_t2219_temporal_hold_restores_blocked
 	test_t2219_closes_open_statusdone_not_touched
 	test_t2218_for_ref_interactive_autodispatch_healed
 	test_t2218_in_review_not_unassigned

--- a/.agents/scripts/tests/test-pulse-dep-graph-non-dep-block.sh
+++ b/.agents/scripts/tests/test-pulse-dep-graph-non-dep-block.sh
@@ -26,6 +26,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 DEP_GRAPH="$REPO_ROOT/.agents/scripts/pulse-dep-graph.sh"
+HOLD_MARKER_LIB="$REPO_ROOT/.agents/scripts/issue-hold-marker-lib.sh"
 
 if [[ ! -f "$DEP_GRAPH" ]]; then
 	echo "FAIL: cannot locate pulse-dep-graph.sh at $DEP_GRAPH" >&2
@@ -44,44 +45,37 @@ assert_eq() {
 		printf 'FAIL: %s\n  want=%q\n  got=%q\n' "$label" "$want" "$got" >&2
 		fail_count=$((fail_count + 1))
 	fi
+	return 0
 }
 
 ###############################################################################
 # Part 1: body defer marker detection (pure function, no network)
 #
-# Mirror of the block in pulse-dep-graph.sh:143-155 — keep this regex
-# byte-identical. If the helper regex changes, update the mirror and this
-# test together.
+# Exercise the shared predicate used by Pulse and post-merge healing.
 ###############################################################################
 
-body_has_defer_marker() {
-	local body="$1"
-	if printf '%s' "$body" | grep -qiE 'defer until|do[-[:space:]]not[-[:space:]]dispatch|on[-[:space:]]hold|HUMAN_UNBLOCK_REQUIRED|hold for |paused[[:space:]:]'; then
-		echo "true"
-	else
-		echo "false"
-	fi
-}
+# shellcheck disable=SC1090
+source "$HOLD_MARKER_LIB"
 
 printf '\n== Body defer marker detection ==\n'
 
-assert_eq 'defer until phrase' 'true' "$(body_has_defer_marker 'Defer until Phase 1-6 are working end-to-end @alexey')"
-assert_eq 'do not dispatch' 'true' "$(body_has_defer_marker 'Please do not dispatch this yet.')"
-assert_eq 'do-not-dispatch' 'true' "$(body_has_defer_marker 'Tagged do-not-dispatch until owner reviews.')"
-assert_eq 'on-hold hyphenated' 'true' "$(body_has_defer_marker 'This task is on-hold.')"
-assert_eq 'on hold spaced' 'true' "$(body_has_defer_marker 'This task is on hold.')"
-assert_eq 'ON HOLD uppercase' 'true' "$(body_has_defer_marker 'ON HOLD: waiting for legal.')"
-assert_eq 'HUMAN_UNBLOCK_REQD' 'true' "$(body_has_defer_marker 'HUMAN_UNBLOCK_REQUIRED — see comment thread.')"
-assert_eq 'hold for trailing' 'true' "$(body_has_defer_marker 'hold for Q2 release cycle')"
-assert_eq 'paused colon' 'true' "$(body_has_defer_marker 'paused: waiting on vendor')"
-assert_eq 'paused space' 'true' "$(body_has_defer_marker 'paused pending review')"
+assert_eq 'defer until phrase' 'true' "$(issue_body_has_defer_marker 'Defer until Phase 1-6 are working end-to-end @alexey')"
+assert_eq 'do not dispatch' 'true' "$(issue_body_has_defer_marker 'Please do not dispatch this yet.')"
+assert_eq 'do-not-dispatch' 'true' "$(issue_body_has_defer_marker 'Tagged do-not-dispatch until owner reviews.')"
+assert_eq 'on-hold hyphenated' 'true' "$(issue_body_has_defer_marker 'This task is on-hold.')"
+assert_eq 'on hold spaced' 'true' "$(issue_body_has_defer_marker 'This task is on hold.')"
+assert_eq 'ON HOLD uppercase' 'true' "$(issue_body_has_defer_marker 'ON HOLD: waiting for legal.')"
+assert_eq 'HUMAN_UNBLOCK_REQD' 'true' "$(issue_body_has_defer_marker 'HUMAN_UNBLOCK_REQUIRED — see comment thread.')"
+assert_eq 'hold for trailing' 'true' "$(issue_body_has_defer_marker 'hold for Q2 release cycle')"
+assert_eq 'paused colon' 'true' "$(issue_body_has_defer_marker 'paused: waiting on vendor')"
+assert_eq 'paused space' 'true' "$(issue_body_has_defer_marker 'paused pending review')"
 
 # No-match baselines — must NOT match anything.
-assert_eq 'clean body' 'false' "$(body_has_defer_marker 'Normal task body with no markers.')"
-assert_eq 'blocked-by only' 'false' "$(body_has_defer_marker 'blocked-by:t143,t200 should not trip the defer check')"
-assert_eq 'word defer in prose' 'false' "$(body_has_defer_marker 'We should not defer this; ship it now.')"
-assert_eq 'dispatch without prefix' 'false' "$(body_has_defer_marker 'Dispatch the worker once ready.')"
-assert_eq 'hold without for' 'false' "$(body_has_defer_marker 'please hold this comment until later')"
+assert_eq 'clean body' 'false' "$(issue_body_has_defer_marker 'Normal task body with no markers.')"
+assert_eq 'blocked-by only' 'false' "$(issue_body_has_defer_marker 'blocked-by:t143,t200 should not trip the defer check')"
+assert_eq 'word defer in prose' 'false' "$(issue_body_has_defer_marker 'We should not defer this; ship it now.')"
+assert_eq 'dispatch without prefix' 'false' "$(issue_body_has_defer_marker 'Dispatch the worker once ready.')"
+assert_eq 'hold without for' 'false' "$(issue_body_has_defer_marker 'please hold this comment until later')"
 
 ###############################################################################
 # Part 2: non-dep BLOCKED comment marker detection (pure regex)
@@ -99,6 +93,7 @@ comment_has_marker() {
 	else
 		echo "false"
 	fi
+	return 0
 }
 
 printf '\n== Comment BLOCKED marker detection ==\n'


### PR DESCRIPTION
## Summary

Restore status:blocked when post-merge healing finds explicit issue hold metadata, while preserving status:available as the normal fallback. Share the hold predicate with Pulse to keep both safety paths consistent.

## Files Changed

.agents/scripts/interactive-session-helper-postmerge.sh, .agents/scripts/issue-hold-marker-lib.sh, .agents/scripts/pulse-dep-graph.sh, .agents/scripts/tests/test-interactive-session-post-merge.sh, .agents/scripts/tests/test-pulse-dep-graph-non-dep-block.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified — post-merge command exercised end to end with stubbed GitHub issue state: 8/8 tests, including temporal status:done to status:blocked and ordinary status:done to status:available. Pulse hold tests 32/32; interactive-session suite 55/55; issue-sync suite passed; ShellCheck and local linters passed; review bundle 5ecab1c5de9e29bcf999a89bd01069154d5b8accde1e39d74a73c45d1687a08f

Resolves #29756


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.233 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 31m and 384,806 tokens on this with the user in an interactive session.