### PR TITLE
GH#29742: protect Pulse REST hard-floor admission

### DIFF
--- a/.agents/configs/pulse-rate-limit.conf
+++ b/.agents/configs/pulse-rate-limit.conf
@@ -51,8 +51,10 @@ AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD=0.05
 #
 # Maximum early-window soft reserve for authenticated REST-core requests. Pulse
 # linearly decays this threshold toward the hard floor as reset approaches.
-# Deferrable stages pause at the adaptive threshold; progress stages continue
-# until the hard floor. Shared interactive wrappers are not globally gated.
+# Deferrable stages pause at the adaptive threshold; progress stages retain a
+# bounded launch allowance above the hard floor so already-admitted API work
+# cannot consume the maintainer reserve. Shared interactive wrappers are not
+# globally gated.
 #
 # Env var AIDEVOPS_PULSE_REST_CORE_RESERVE takes precedence. Set to 0 only for
 # a bounded diagnostic run; it disables both REST priority thresholds.
@@ -62,6 +64,12 @@ AIDEVOPS_PULSE_REST_CORE_RESERVE=500
 # API-heavy Pulse progress stages defer at or below this value.
 AIDEVOPS_PULSE_REST_CORE_HARD_FLOOR=100
 
+# Headroom reserved for one bounded unit of already-admitted Pulse work plus
+# overlapping progress producers. New progress work starts only above
+# hard_floor + this allowance. The default is roughly twice the 132-request
+# overshoot observed in the GH#29742 live canary.
+AIDEVOPS_PULSE_REST_CORE_IN_FLIGHT_ALLOWANCE=250
+
 # GitHub REST core uses an hourly window. The soft reserve decays linearly over
 # this many seconds and is clamped to [hard floor, soft cap].
 AIDEVOPS_PULSE_REST_CORE_ADAPTIVE_WINDOW_SECONDS=3600
@@ -69,6 +77,11 @@ AIDEVOPS_PULSE_REST_CORE_ADAPTIVE_WINDOW_SECONDS=3600
 # Seconds that an authoritative REST response-header observation may be reused.
 # The reset epoch always takes precedence, so this cannot delay recovery.
 AIDEVOPS_PULSE_REST_CORE_PROBE_TTL=20
+
+# Stage and intra-stage launch gates need fresher evidence than status probes.
+# A short cache still coalesces concurrent checks without allowing a long stage
+# to rely on a stale pre-stage observation.
+AIDEVOPS_PULSE_REST_CORE_GATE_PROBE_TTL=2
 
 # ── Cross-issue no_work rate circuit breaker (GH#20640, t2770) ────────────────
 #

--- a/.agents/scripts/pulse-budget-priority.sh
+++ b/.agents/scripts/pulse-budget-priority.sh
@@ -110,7 +110,11 @@ _pulse_rest_core_budget_priority_decision() {
 		return 0
 	fi
 	local decision
-	decision=$(pulse_rest_core_priority_snapshot 2>/dev/null) || decision=""
+	local gate_ttl=""
+	if declare -F _cb_rest_core_gate_probe_ttl >/dev/null 2>&1; then
+		gate_ttl=$(_cb_rest_core_gate_probe_ttl)
+	fi
+	decision=$(pulse_rest_core_priority_snapshot "$gate_ttl" 2>/dev/null) || decision=""
 	[[ -n "$decision" ]] || decision="${_PULSE_BUDGET_MODE_UNKNOWN} ? ? ? ? ? ?"
 	printf '%s\n' "$decision"
 	return 0
@@ -129,6 +133,8 @@ _pulse_set_rest_core_budget_priority() {
 	local soft_cap
 	local hard_floor
 	local reset_epoch
+	local in_flight_allowance="?"
+	local progress_start_floor="?"
 	decision=$(_pulse_rest_core_budget_priority_decision)
 	read -r budget_class remaining limit adaptive soft_cap hard_floor reset_epoch <<<"$decision"
 	[[ -n "$budget_class" ]] || budget_class="$_PULSE_BUDGET_MODE_UNKNOWN"
@@ -139,10 +145,18 @@ _pulse_set_rest_core_budget_priority() {
 	export AIDEVOPS_PULSE_REST_CORE_BUDGET_SOFT_CAP="$soft_cap"
 	export AIDEVOPS_PULSE_REST_CORE_BUDGET_HARD_FLOOR="$hard_floor"
 	export AIDEVOPS_PULSE_REST_CORE_BUDGET_RESET="$reset_epoch"
+	if declare -F _cb_rest_core_in_flight_allowance >/dev/null 2>&1; then
+		in_flight_allowance=$(_cb_rest_core_in_flight_allowance)
+	fi
+	if declare -F _cb_rest_core_progress_start_floor >/dev/null 2>&1 && [[ "$hard_floor" =~ ^[0-9]+$ && "$soft_cap" =~ ^[0-9]+$ ]]; then
+		progress_start_floor=$(_cb_rest_core_progress_start_floor "$hard_floor" "$soft_cap") || progress_start_floor="?"
+	fi
+	export AIDEVOPS_PULSE_REST_CORE_BUDGET_IN_FLIGHT_ALLOWANCE="$in_flight_allowance"
+	export AIDEVOPS_PULSE_REST_CORE_BUDGET_PROGRESS_START_FLOOR="$progress_start_floor"
 	[[ "$log_mode" == "quiet" ]] && return 0
 	case "$budget_class" in
 	reserve | emergency)
-		echo "[pulse-wrapper] REST-core budget ${budget_class} mode: remaining=${remaining}/${limit} adaptive=${adaptive} soft_cap=${soft_cap} hard_floor=${hard_floor} reset=${reset_epoch} (GH#29742)" >>"$LOGFILE"
+		echo "[pulse-wrapper] REST-core budget ${budget_class} mode: remaining=${remaining}/${limit} adaptive=${adaptive} soft_cap=${soft_cap} hard_floor=${hard_floor} in_flight_allowance=${in_flight_allowance} progress_start_floor=${progress_start_floor} reset=${reset_epoch} (GH#29742)" >>"$LOGFILE"
 		if declare -F pulse_stats_increment >/dev/null 2>&1; then
 			pulse_stats_increment "pulse_rest_core_budget_${budget_class}_mode" 2>/dev/null || true
 		fi
@@ -191,6 +205,32 @@ _pulse_graphql_budget_defers_stage() {
 }
 
 #######################################
+# Return 0 when REST-core policy defers this non-critical priority class.
+#######################################
+_pulse_rest_core_budget_defers_priority() {
+	local priority="$1"
+	[[ "$priority" != "critical" ]] || return 1
+
+	local rest_mode="${AIDEVOPS_PULSE_REST_CORE_BUDGET_CLASS:-$_PULSE_BUDGET_MODE_UNKNOWN}"
+	if declare -F _cb_rest_core_priority_decision_allows >/dev/null 2>&1; then
+		local decision="${rest_mode} ${AIDEVOPS_PULSE_REST_CORE_BUDGET_REMAINING:-?} ${AIDEVOPS_PULSE_REST_CORE_BUDGET_LIMIT:-?} ${AIDEVOPS_PULSE_REST_CORE_BUDGET_ADAPTIVE_THRESHOLD:-?} ${AIDEVOPS_PULSE_REST_CORE_BUDGET_SOFT_CAP:-?} ${AIDEVOPS_PULSE_REST_CORE_BUDGET_HARD_FLOOR:-?} ${AIDEVOPS_PULSE_REST_CORE_BUDGET_RESET:-?}"
+		local rest_rc=0
+		_cb_rest_core_priority_decision_allows "$priority" "$decision" || rest_rc=$?
+		[[ "$rest_rc" -ne 0 ]] && return 0
+		return 1
+	fi
+
+	case "${rest_mode}:${priority}" in
+	reserve:deferrable | emergency:deferrable | unknown:deferrable | emergency:progress | unknown:progress)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+#######################################
 # Return 0 when a mapped stage should defer at its current budget class.
 #######################################
 _pulse_should_defer_budget_priority_stage() {
@@ -208,15 +248,10 @@ _pulse_should_defer_budget_priority_stage() {
 	# Unknown REST evidence intentionally keeps non-critical work fail-closed.
 	# Later cycles repeat the bounded authoritative probe; elapsed time alone must
 	# never turn missing quota evidence into permission to spend maintainer quota.
-	local rest_mode="${AIDEVOPS_PULSE_REST_CORE_BUDGET_CLASS:-$_PULSE_BUDGET_MODE_UNKNOWN}"
-	case "${rest_mode}:${priority}" in
-	reserve:deferrable | emergency:deferrable | unknown:deferrable | emergency:progress | unknown:progress)
+	if _pulse_rest_core_budget_defers_priority "$priority"; then
 		return 0
-		;;
-	*)
-		return 1
-		;;
-	esac
+	fi
+	return 1
 }
 
 #######################################
@@ -228,7 +263,7 @@ _pulse_defer_budget_priority_stage() {
 	priority=$(_pulse_stage_priority_class "$stage")
 	local graphql_mode="${AIDEVOPS_PULSE_GRAPHQL_BUDGET_CLASS:-$_PULSE_BUDGET_MODE_UNKNOWN}"
 	local rest_mode="${AIDEVOPS_PULSE_REST_CORE_BUDGET_CLASS:-$_PULSE_BUDGET_MODE_UNKNOWN}"
-	echo "[pulse-wrapper] budget-priority: deferred ${priority} stage '${stage}' (graphql=${graphql_mode}:${AIDEVOPS_PULSE_GRAPHQL_BUDGET_REMAINING:-?}/${AIDEVOPS_PULSE_GRAPHQL_BUDGET_LIMIT:-?}@${AIDEVOPS_PULSE_GRAPHQL_BUDGET_THRESHOLD:-?}, rest=${rest_mode}:${AIDEVOPS_PULSE_REST_CORE_BUDGET_REMAINING:-?}/${AIDEVOPS_PULSE_REST_CORE_BUDGET_LIMIT:-?}@${AIDEVOPS_PULSE_REST_CORE_BUDGET_ADAPTIVE_THRESHOLD:-?}, hard_floor=${AIDEVOPS_PULSE_REST_CORE_BUDGET_HARD_FLOOR:-?})" >>"$LOGFILE"
+	echo "[pulse-wrapper] budget-priority: deferred ${priority} stage '${stage}' (graphql=${graphql_mode}:${AIDEVOPS_PULSE_GRAPHQL_BUDGET_REMAINING:-?}/${AIDEVOPS_PULSE_GRAPHQL_BUDGET_LIMIT:-?}@${AIDEVOPS_PULSE_GRAPHQL_BUDGET_THRESHOLD:-?}, rest=${rest_mode}:${AIDEVOPS_PULSE_REST_CORE_BUDGET_REMAINING:-?}/${AIDEVOPS_PULSE_REST_CORE_BUDGET_LIMIT:-?}@${AIDEVOPS_PULSE_REST_CORE_BUDGET_ADAPTIVE_THRESHOLD:-?}, hard_floor=${AIDEVOPS_PULSE_REST_CORE_BUDGET_HARD_FLOOR:-?}, progress_start_floor=${AIDEVOPS_PULSE_REST_CORE_BUDGET_PROGRESS_START_FLOOR:-?})" >>"$LOGFILE"
 	if ! declare -F pulse_stats_increment >/dev/null 2>&1; then
 		return 0
 	fi
@@ -238,12 +273,10 @@ _pulse_defer_budget_priority_stage() {
 		pulse_stats_increment "pulse_graphql_budget_stage_deferred" 2>/dev/null || true
 		pulse_stats_increment "pulse_graphql_budget_stage_deferred_${stage}" 2>/dev/null || true
 	fi
-	case "$rest_mode" in
-	reserve | emergency | unknown)
+	if _pulse_rest_core_budget_defers_priority "$priority"; then
 		pulse_stats_increment "pulse_rest_core_budget_stage_deferred" 2>/dev/null || true
 		pulse_stats_increment "pulse_rest_core_budget_stage_deferred_${stage}" 2>/dev/null || true
-		;;
-	esac
+	fi
 	return 0
 }
 

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -528,6 +528,11 @@ dispatch_max() {
 		echo 0
 		return 0
 	fi
+	if ! _dispatch_rest_core_progress_allows_next "dispatch_post_ranking"; then
+		echo "[pulse-wrapper] Dispatch_max stopped after candidate ranking: REST-core launch headroom is unavailable" >>"$LOGFILE"
+		echo 0
+		return 0
+	fi
 
 	local self_login
 	self_login=$(gh api user --jq '.login' 2>/dev/null || echo "")
@@ -550,6 +555,11 @@ dispatch_max() {
 	[[ "$triage_attempted" =~ ^[0-9]+$ ]] || triage_attempted=0
 	[[ "$triage_infrastructure_failed" =~ ^[0-9]+$ ]] || triage_infrastructure_failed=0
 	pulse_dispatch_debug_log "post-prepasses available_slots=${available_slots} triage_attempted=${triage_attempted} triage_infrastructure_failed=${triage_infrastructure_failed}"
+	if ! _dispatch_rest_core_progress_allows_next "dispatch_post_prepasses"; then
+		echo "[pulse-wrapper] Dispatch_max stopped after prepasses: REST-core launch headroom is unavailable" >>"$LOGFILE"
+		echo 0
+		return 0
+	fi
 	candidates_json=$(_dispatch_order_idle_borrowing_candidates "$candidates_json" "$available_slots")
 
 	# Reset module-level round state before the dispatch loop (t1959).

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -1021,6 +1021,10 @@ _dispatch_compute_capacity() {
 		echo "[pulse-wrapper] Dispatch_max skipped: stop flag present" >>"$LOGFILE"
 		return 1
 	fi
+	if ! _dispatch_rest_core_progress_allows_next "dispatch_capacity"; then
+		echo "[pulse-wrapper] Dispatch_max skipped: REST-core launch headroom is unavailable" >>"$LOGFILE"
+		return 1
+	fi
 
 	# t2690/t3424: Proactive rate-limit circuit breaker — pause dispatch when
 	# GraphQL budget is nearly exhausted unless REST-backed dispatch fallback is
@@ -1134,6 +1138,10 @@ _dispatch_run_prepasses() {
 	fi
 
 	if [[ "$run_triage" -eq 1 ]]; then
+		if ! _dispatch_rest_core_progress_allows_next "dispatch_triage_prepass"; then
+			printf '%s %s %s\n' "$available_slots" "$triage_attempted" "$triage_infrastructure_failed"
+			return 0
+		fi
 		if [[ "$refresh_state" -eq 1 ]] && \
 			{ ! command -v refresh_triage_review_state >/dev/null 2>&1 || ! refresh_triage_review_state; }; then
 			echo "[pulse-wrapper] Dispatch_max: triage state refresh failed — preserving prior snapshot and recording one infrastructure failure" >>"$LOGFILE"
@@ -1162,6 +1170,10 @@ _dispatch_run_prepasses() {
 	fi
 
 	local enrichment_remaining
+	if ! _dispatch_rest_core_progress_allows_next "dispatch_enrichment_prepass"; then
+		printf '%s %s %s\n' "$available_slots" "$triage_attempted" "$triage_infrastructure_failed"
+		return 0
+	fi
 	enrichment_remaining=$(dispatch_enrichment_workers "$available_slots" 2>>"$LOGFILE") || enrichment_remaining="$available_slots"
 	[[ "$enrichment_remaining" =~ ^[0-9]+$ ]] || enrichment_remaining="$available_slots"
 	local enrichment_dispatched=$((available_slots - enrichment_remaining))
@@ -1629,6 +1641,55 @@ _dispatch_with_timeout() {
 }
 
 #######################################
+# Stop dispatch loops when REST-core launch headroom is unavailable.
+#######################################
+_dispatch_rest_core_progress_allows_next() {
+	local context="$1"
+	local budget_rc=0
+	if declare -F pulse_rest_core_priority_allows_next >/dev/null 2>&1; then
+		pulse_rest_core_priority_allows_next progress "$context" || budget_rc=$?
+	elif declare -F pulse_rest_core_priority_allows >/dev/null 2>&1; then
+		pulse_rest_core_priority_allows progress || budget_rc=$?
+	else
+		return 0
+	fi
+	[[ "$budget_rc" -eq 0 ]] && return 0
+	_dispatch_stats_increment "dispatch_rest_core_circuit_blocked"
+	_dispatch_stats_increment_candidate_failed "rest_core_circuit_breaker"
+	return 1
+}
+
+#######################################
+# Return 0 when dispatch ceremony should be serialized near the REST reserve.
+# The serial zone includes the soft cap plus the in-flight allowance so a large
+# parallel batch cannot arrive at the progress launch floor simultaneously.
+#######################################
+_dispatch_rest_core_requires_serial() {
+	declare -F pulse_rest_core_priority_snapshot >/dev/null 2>&1 || return 1
+	local gate_ttl=""
+	if declare -F _cb_rest_core_gate_probe_ttl >/dev/null 2>&1; then
+		gate_ttl=$(_cb_rest_core_gate_probe_ttl)
+	fi
+	local decision mode remaining limit adaptive soft_cap hard_floor reset_epoch
+	decision=$(pulse_rest_core_priority_snapshot "$gate_ttl") || decision="unknown ? ? ? ? ? ?"
+	read -r mode remaining limit adaptive soft_cap hard_floor reset_epoch <<<"$decision"
+	case "$mode" in
+	disabled) return 1 ;;
+	unknown | reserve | emergency) return 0 ;;
+	esac
+	if [[ ! "$remaining" =~ ^[0-9]+$ || ! "$soft_cap" =~ ^[0-9]+$ ]]; then
+		return 0
+	fi
+	local allowance=250
+	if declare -F _cb_rest_core_in_flight_allowance >/dev/null 2>&1; then
+		allowance=$(_cb_rest_core_in_flight_allowance)
+	fi
+	[[ "$allowance" =~ ^[0-9]+$ ]] || allowance=250
+	[[ "$remaining" -le $((soft_cap + allowance)) ]] && return 0
+	return 1
+}
+
+#######################################
 # Stop dispatch loops when the GraphQL reserve is already below the circuit
 # breaker threshold. The rate_limit endpoint is free, so this protects the
 # high-fanout loop without spending additional GraphQL points.
@@ -1980,6 +2041,10 @@ _dispatch_max_compute_parallel() {
 	if [[ -f "$_DISPATCH_THROTTLE_FILE" && "${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-0}" != "1" ]]; then
 		max_parallel=1
 	fi
+	if _dispatch_rest_core_requires_serial; then
+		max_parallel=1
+		echo "[pulse-wrapper] Dispatch_max: REST-core reserve-adjacent mode forces serial launch ceremony (GH#29742)" >>"$LOGFILE"
+	fi
 	((max_parallel < 1)) && max_parallel=1
 	printf '%d\n' "$max_parallel"
 	return 0
@@ -2021,6 +2086,10 @@ _dispatch_floor_loop() {
 		fi
 		if ! _dispatch_graphql_budget_allows_next; then
 			echo "[pulse-wrapper] Dispatch_max stopping early: GraphQL circuit breaker tripped during serial loop" >>"$LOGFILE"
+			break
+		fi
+		if ! _dispatch_rest_core_progress_allows_next "dispatch_serial_candidate"; then
+			echo "[pulse-wrapper] Dispatch_max stopping early: REST-core launch headroom unavailable during serial loop" >>"$LOGFILE"
 			break
 		fi
 		local _dispatch_proc_rc=0
@@ -2184,6 +2253,10 @@ _dispatch_max_should_stop() {
 	fi
 	if ! _dispatch_graphql_budget_allows_next; then
 		echo "[pulse-wrapper] Dispatch_max stopping early: GraphQL circuit breaker tripped during parallel loop" >>"$LOGFILE"
+		return 0
+	fi
+	if ! _dispatch_rest_core_progress_allows_next "dispatch_parallel_candidate"; then
+		echo "[pulse-wrapper] Dispatch_max stopping early: REST-core launch headroom unavailable during parallel loop" >>"$LOGFILE"
 		return 0
 	fi
 	return 1

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -1670,7 +1670,7 @@ _dispatch_rest_core_requires_serial() {
 	if declare -F _cb_rest_core_gate_probe_ttl >/dev/null 2>&1; then
 		gate_ttl=$(_cb_rest_core_gate_probe_ttl)
 	fi
-	local decision mode remaining limit adaptive soft_cap hard_floor reset_epoch
+	local decision="" mode="" remaining="" limit="" adaptive="" soft_cap="" hard_floor="" reset_epoch=""
 	decision=$(pulse_rest_core_priority_snapshot "$gate_ttl") || decision="unknown ? ? ? ? ? ?"
 	read -r mode remaining limit adaptive soft_cap hard_floor reset_epoch <<<"$decision"
 	case "$mode" in

--- a/.agents/scripts/pulse-dispatch-preflight-lib.sh
+++ b/.agents/scripts/pulse-dispatch-preflight-lib.sh
@@ -287,6 +287,24 @@ _preflight_capacity() {
 }
 
 #######################################
+# Return whether another deferrable preflight work unit may start.
+#######################################
+_preflight_rest_core_allows_next() {
+	local context="$1"
+	local budget_rc=0
+	if declare -F pulse_rest_core_priority_allows_next >/dev/null 2>&1; then
+		pulse_rest_core_priority_allows_next deferrable "$context" || budget_rc=$?
+	elif declare -F pulse_rest_core_priority_allows >/dev/null 2>&1; then
+		pulse_rest_core_priority_allows deferrable || budget_rc=$?
+	else
+		return 0
+	fi
+	[[ "$budget_rc" -eq 0 ]] && return 0
+	echo "[pulse-wrapper] preflight: REST-core reserve reached at ${context}; remaining deferrable work deferred (GH#29742)" >>"$LOGFILE"
+	return 1
+}
+
+#######################################
 # Cross-repository needs-* label maintenance. Runs after the first dispatch so
 # already-eligible work can boot while these idempotent sweeps expose additional
 # candidates for the post-maintenance refill.
@@ -300,6 +318,7 @@ _preflight_label_maintenance() {
 	# current filter. Auto-clearing here makes them dispatchable in this cycle
 	# instead of stuck forever behind a label that list_dispatchable_issue_candidates_json
 	# filters out (needs-* exclusion at line 6703).
+	_preflight_rest_core_allows_next "label_maintenance_consolidation_reevaluate" || return 0
 	local _ss0=$SECONDS
 	_reevaluate_consolidation_labels
 	_log_substage_timing "substage:label_maintenance/reevaluate_consolidation_labels" "$_ss0" 0
@@ -308,10 +327,12 @@ _preflight_label_maintenance() {
 	# got a consolidation-task child created (pre-t1982 dispatches just
 	# labelled and returned). Dispatches a child retroactively so the
 	# parent can actually be consolidated instead of sitting forever.
+	_preflight_rest_core_allows_next "label_maintenance_consolidation_backfill" || return 0
 	local _ss1=$SECONDS
 	_backfill_stale_consolidation_labels
 	_log_substage_timing "substage:label_maintenance/backfill_consolidation_labels" "$_ss1" 0
 
+	_preflight_rest_core_allows_next "label_maintenance_simplification_reevaluate" || return 0
 	local _ss2=$SECONDS
 	_reevaluate_simplification_labels
 	_log_substage_timing "substage:label_maintenance/reevaluate_simplification_labels" "$_ss2" 0
@@ -359,7 +380,9 @@ _preflight_early_dispatch() {
 	# Routine comment responses: scan routine-tracking issues for unanswered
 	# user comments and dispatch lightweight Haiku workers to respond.
 	# Runs before heavy housekeeping so responses are fast.
-	dispatch_routine_comment_responses || true
+	if _preflight_rest_core_allows_next "routine_comment_responses"; then
+		dispatch_routine_comment_responses || true
+	fi
 	return 0
 }
 

--- a/.agents/scripts/pulse-merge-pass.sh
+++ b/.agents/scripts/pulse-merge-pass.sh
@@ -232,6 +232,26 @@ _pmp_merge_diagnostics_budget_exhausted() {
 	return 0
 }
 
+#######################################
+# Return whether one merge-pass REST work unit may start.
+# Args: $1=priority, $2=static context.
+#######################################
+_pmp_rest_core_priority_allows_next() {
+	local priority="$1"
+	local context="$2"
+	local budget_rc=0
+	if declare -F pulse_rest_core_priority_allows_next >/dev/null 2>&1; then
+		pulse_rest_core_priority_allows_next "$priority" "$context" || budget_rc=$?
+	elif declare -F pulse_rest_core_priority_allows >/dev/null 2>&1; then
+		pulse_rest_core_priority_allows "$priority" || budget_rc=$?
+	else
+		return 0
+	fi
+	[[ "$budget_rc" -eq 0 ]] && return 0
+	echo "[pulse-wrapper] Merge pass: REST-core ${priority} unit deferred context=${context} rc=${budget_rc} (GH#29742)" >>"${LOGFILE:-/dev/null}"
+	return 1
+}
+
 _pmp_pause_merge_pr_cursor() {
 	local repo_slug="$1"
 	local pr_json="$2"
@@ -258,6 +278,9 @@ _pmp_pause_merge_pr_cursor() {
 		;;
 	cooldown)
 		echo "[pulse-wrapper] Merge pass: GitHub cooldown active for ${repo_slug}; pausing remaining PR processing" >>"$logfile"
+		;;
+	rest-core)
+		echo "[pulse-wrapper] Merge pass: REST-core launch headroom unavailable for ${repo_slug}; pausing at PR cursor index=${cursor_index} next_pr=${next_pr:-none}" >>"$logfile"
 		;;
 	stop) ;;
 	esac
@@ -307,11 +330,16 @@ _pmp_pause_merge_enrichment_cursor() {
 	local pr_json="$2"
 	local cursor_index="$3"
 	local cursor_file="$4"
+	local pause_reason="${5:-budget}"
 	local next_pr="" last_pr=""
 	next_pr=$(_pmp_pr_number_at_index "$pr_json" "$cursor_index") || next_pr=""
 	_pmp_read_merge_pr_cursor_last "$cursor_file" "$repo_slug" last_pr || last_pr=""
 	_pmp_write_merge_pr_cursor "$cursor_file" "$repo_slug" "$cursor_index" "$last_pr" "$next_pr"
-	echo "[pulse-wrapper] Merge pass: graceful time budget exhausted during enrichment for ${repo_slug}; pausing at enrichment cursor index=${cursor_index} next_pr=${next_pr:-none}" >>"${LOGFILE:-/dev/null}"
+	if [[ "$pause_reason" == "rest-core" ]]; then
+		echo "[pulse-wrapper] Merge pass: REST-core launch headroom unavailable during enrichment for ${repo_slug}; pausing at enrichment cursor index=${cursor_index} next_pr=${next_pr:-none}" >>"${LOGFILE:-/dev/null}"
+	else
+		echo "[pulse-wrapper] Merge pass: graceful time budget exhausted during enrichment for ${repo_slug}; pausing at enrichment cursor index=${cursor_index} next_pr=${next_pr:-none}" >>"${LOGFILE:-/dev/null}"
+	fi
 	return 5
 }
 
@@ -360,10 +388,16 @@ _pmp_prepare_enriched_pr_backlog() {
 		pr_obj=$(_pmp_pr_object_at_index "$fresh_json" "$cursor_index")
 		cached_obj=$(jq -cn --argjson cache "$filtered_cache" --argjson pr "$pr_obj" '$cache | map(select(.number == $pr.number and ((.headRefOid // "") == ($pr.headRefOid // "")))) | last // empty') || cached_obj=""
 		if [[ -z "$cached_obj" ]]; then
+			if ! _pmp_rest_core_priority_allows_next progress "merge_backlog_enrichment:${repo_slug}"; then
+				_pmp_pause_merge_enrichment_cursor "$repo_slug" "$fresh_json" "$cursor_index" "$cursor_file" rest-core
+				return $?
+			fi
 			enrichment_rc=0
 			enriched_obj=$(_pmp_enrich_single_pr_for_processing "$repo_slug" "$pr_obj") || enrichment_rc=$?
-			if [[ "$enrichment_rc" -eq 5 ]]; then
-				_pmp_pause_merge_enrichment_cursor "$repo_slug" "$fresh_json" "$cursor_index" "$cursor_file"
+			if [[ "$enrichment_rc" -eq 5 || "$enrichment_rc" -eq 6 ]]; then
+				local pause_reason="budget"
+				[[ "$enrichment_rc" -eq 6 ]] && pause_reason="rest-core"
+				_pmp_pause_merge_enrichment_cursor "$repo_slug" "$fresh_json" "$cursor_index" "$cursor_file" "$pause_reason"
 				return $?
 			fi
 			[[ "$enrichment_rc" -eq 0 && -n "$enriched_obj" ]] || enriched_obj=$(printf '%s' "$pr_obj" | jq -c '. + {mergeable:"UNKNOWN", reviewDecision:"UNKNOWN", statusCheckRollup:[]}') || return 1
@@ -683,6 +717,11 @@ _pmp_run_stuck_diagnostics_for_repos() {
 			echo "[pulse-wrapper] Merge diagnostics: separate graceful budget exhausted before ${repo_slug}; remaining diagnostics deferred" >>"$logfile"
 			break
 		fi
+		if ! _pmp_rest_core_priority_allows_next deferrable "merge_diagnostics:${repo_slug}"; then
+			complete=0
+			echo "[pulse-wrapper] Merge diagnostics: REST-core reserve reached before ${repo_slug}; remaining diagnostics deferred" >>"$logfile"
+			break
+		fi
 		stuck_start=$(_pmp_now_epoch)
 		repo_complete=1
 		if declare -F pulse_merge_stuck_run_pass >/dev/null 2>&1; then
@@ -777,6 +816,11 @@ _pmp_process_merge_repo_for_pass() {
 		|| ! repo_allows_pulse_write_actions "$repo_slug"; then
 		echo "[pulse-wrapper] Deterministic merge pass skipped ${repo_slug}: repo role is contributor/read-only" >>"$logfile"
 		_pmp_write_merge_checkpoint "$checkpoint_file" "$repo_slug"
+		return 0
+	fi
+	if ! _pmp_rest_core_priority_allows_next progress "merge_repo:${repo_slug}"; then
+		echo "[pulse-wrapper] Deterministic merge pass paused before ${repo_slug}: REST-core launch headroom unavailable; checkpoint retained" >>"$logfile"
+		printf -v "$completed_all_var" '%s' '0'
 		return 0
 	fi
 

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -312,9 +312,9 @@ _PULSE_MERGE_PROCESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${_PULSE_MERGE_PROCESS_DIR}/pulse-merge-duplicate-consolidation.sh"
 
 #######################################
-# Enrich one PR inside the durable PR-cursor boundary. A budget edge after any
-# potentially blocking enrichment phase returns 5 so the caller persists the
-# current PR as the next item rather than starting another network phase.
+# Enrich one PR inside the durable PR-cursor boundary. A time-budget edge returns
+# 5 and a REST-core launch-floor edge returns 6 after any potentially blocking
+# phase so the caller persists the current PR before another network phase.
 # Args: $1=repo slug, $2=PR object
 # Stdout: enriched PR object
 #######################################
@@ -327,10 +327,13 @@ _pmp_enrich_single_pr_for_processing() {
 	enriched_json=$(jq -cn --argjson pr "$pr_obj" '[$pr]' 2>/dev/null) || return 1
 	enriched_json=$(_pmp_enrich_prs_with_mergeability "$repo_slug" "$enriched_json") || return 1
 	_pmp_merge_pass_budget_exhausted && return 5
+	_pmp_rest_core_priority_allows_next progress "merge_enrichment_mergeability:${repo_slug}" || return 6
 	enriched_json=$(_pmp_enrich_prs_with_rest_check_status "$repo_slug" "$enriched_json") || return 1
 	_pmp_merge_pass_budget_exhausted && return 5
+	_pmp_rest_core_priority_allows_next progress "merge_enrichment_checks:${repo_slug}" || return 6
 	enriched_json=$(_pmp_enrich_prs_with_review_decisions "$repo_slug" "$enriched_json") || return 1
 	_pmp_merge_pass_budget_exhausted && return 5
+	_pmp_rest_core_priority_allows_next progress "merge_enrichment_reviews:${repo_slug}" || return 6
 
 	printf '%s' "$enriched_json" | jq -c '.[0] // empty' 2>/dev/null || return 1
 	return 0
@@ -370,6 +373,10 @@ _pmp_prepare_pr_at_cursor() {
 		_pmp_pause_merge_pr_cursor "$repo_slug" "$pr_json" "$cursor_index" cooldown "$merged_var" "$closed_var" "$failed_var" "$merged_count" "$closed_count" "$failed_count" "$required_contexts_cache_dir" "$author_permission_cache_dir"
 		return $?
 	fi
+	if ! _pmp_rest_core_priority_allows_next progress "merge_pr:${repo_slug}"; then
+		_pmp_pause_merge_pr_cursor "$repo_slug" "$pr_json" "$cursor_index" rest-core "$merged_var" "$closed_var" "$failed_var" "$merged_count" "$closed_count" "$failed_count" "$required_contexts_cache_dir" "$author_permission_cache_dir"
+		return $?
+	fi
 
 	prepared_pr_obj=$(_pmp_pr_object_at_index "$pr_json" "$cursor_index")
 	if [[ -n "$prepared_pr_obj" ]]; then
@@ -378,8 +385,10 @@ _pmp_prepare_pr_at_cursor() {
 		# eligibility state from bounded REST endpoints.
 		prepared_pr_obj=$(printf '%s' "$prepared_pr_obj" | jq -c 'del(.mergeable, .reviewDecision, .statusCheckRollup)') || return 1
 		enriched_pr_obj=$(_pmp_enrich_single_pr_for_processing "$repo_slug" "$prepared_pr_obj") || enrichment_rc=$?
-		if [[ "$enrichment_rc" -eq 5 ]]; then
-			_pmp_pause_merge_pr_cursor "$repo_slug" "$pr_json" "$cursor_index" budget "$merged_var" "$closed_var" "$failed_var" "$merged_count" "$closed_count" "$failed_count" "$required_contexts_cache_dir" "$author_permission_cache_dir"
+		if [[ "$enrichment_rc" -eq 5 || "$enrichment_rc" -eq 6 ]]; then
+			local pause_reason="budget"
+			[[ "$enrichment_rc" -eq 6 ]] && pause_reason="rest-core"
+			_pmp_pause_merge_pr_cursor "$repo_slug" "$pr_json" "$cursor_index" "$pause_reason" "$merged_var" "$closed_var" "$failed_var" "$merged_count" "$closed_count" "$failed_count" "$required_contexts_cache_dir" "$author_permission_cache_dir"
 			return $?
 		fi
 		if [[ "$enrichment_rc" -ne 0 || -z "$enriched_pr_obj" ]]; then

--- a/.agents/scripts/pulse-merge-routine.sh
+++ b/.agents/scripts/pulse-merge-routine.sh
@@ -279,7 +279,9 @@ _pmr_graphql_budget_allows_run() {
 # succeeds; unlike a known floor, it is logged as an availability/evidence fault.
 _pmr_rest_core_progress_allows_run() {
 	local progress_rc=0
-	if declare -F pulse_rest_core_priority_allows >/dev/null 2>&1; then
+	if declare -F pulse_rest_core_priority_allows_next >/dev/null 2>&1; then
+		pulse_rest_core_priority_allows_next progress "merge_routine_start" || progress_rc=$?
+	elif declare -F pulse_rest_core_priority_allows >/dev/null 2>&1; then
 		pulse_rest_core_priority_allows progress || progress_rc=$?
 	elif declare -F pulse_rest_core_reserve_allows >/dev/null 2>&1; then
 		pulse_rest_core_reserve_allows || progress_rc=$?
@@ -291,7 +293,7 @@ _pmr_rest_core_progress_allows_run() {
 		return 0
 		;;
 	1)
-		_pmr_log WARN "Known REST-core progress floor reached (rc=1); deferring merge pass until a later authoritative probe allows progress while preserving critical maintainer quota (GH#29742)"
+		_pmr_log WARN "Known REST-core progress launch floor reached (rc=1); deferring merge pass until a later authoritative probe allows progress while preserving critical maintainer quota (GH#29742)"
 		;;
 	2)
 		_pmr_log WARN "REST-core quota evidence unavailable (rc=2); deferring merge pass fail-closed until a later authoritative probe succeeds while preserving critical maintainer quota (GH#29742)"

--- a/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
@@ -219,6 +219,45 @@ _cb_rest_core_bounds() {
 }
 
 #######################################
+# Return normalized headroom reserved for already-admitted REST work.
+#######################################
+_cb_rest_core_in_flight_allowance() {
+	local allowance="${AIDEVOPS_PULSE_REST_CORE_IN_FLIGHT_ALLOWANCE:-250}"
+	[[ "$allowance" =~ ^[0-9]+$ ]] || allowance=250
+	printf '%s\n' "$allowance"
+	return 0
+}
+
+#######################################
+# Return the minimum remaining budget required to launch progress work.
+# Args: $1=hard floor, $2=soft cap
+#######################################
+_cb_rest_core_progress_start_floor() {
+	local hard_floor="$1"
+	local soft_cap="$2"
+	[[ "$hard_floor" =~ ^[0-9]+$ ]] || return 1
+	[[ "$soft_cap" =~ ^[0-9]+$ ]] || return 1
+	if [[ "$soft_cap" -eq 0 ]]; then
+		printf '0\n'
+		return 0
+	fi
+	local allowance
+	allowance=$(_cb_rest_core_in_flight_allowance)
+	printf '%s\n' "$((hard_floor + allowance))"
+	return 0
+}
+
+#######################################
+# Return normalized cache TTL for launch-gate observations.
+#######################################
+_cb_rest_core_gate_probe_ttl() {
+	local ttl="${AIDEVOPS_PULSE_REST_CORE_GATE_PROBE_TTL:-2}"
+	[[ "$ttl" =~ ^[0-9]+$ ]] || ttl=2
+	printf '%s\n' "$ttl"
+	return 0
+}
+
+#######################################
 # Compute the adaptive REST-core soft threshold for a reset epoch.
 #
 # Args:
@@ -263,7 +302,7 @@ _cb_rest_core_thresholds() {
 # Cached observations are never used past their TTL or GitHub reset epoch.
 #######################################
 _cb_rest_core_observation() {
-	local ttl="$_CB_REST_CORE_PROBE_TTL"
+	local ttl="${1:-$_CB_REST_CORE_PROBE_TTL}"
 	local now observed=0 remaining limit reset resource
 	[[ "$ttl" =~ ^[0-9]+$ ]] || ttl=20
 	now=$(date +%s 2>/dev/null) || now=0
@@ -309,12 +348,14 @@ _cb_rest_core_observation() {
 
 #######################################
 # Classify authoritative REST-core headroom for stage-boundary scheduling.
+# Args: $1=optional cache TTL override.
 #
 # Stdout:
 #   "<mode> <remaining> <limit> <adaptive> <soft-cap> <hard-floor> <reset>"
 # Modes: normal, reserve, emergency, disabled, unknown.
 #######################################
 pulse_rest_core_priority_snapshot() {
+	local observation_ttl="${1:-}"
 	local soft_cap
 	local hard_floor
 	local window_seconds
@@ -328,7 +369,7 @@ pulse_rest_core_priority_snapshot() {
 	local remaining
 	local limit
 	local reset_epoch
-	observation=$(_cb_rest_core_observation) || observation=""
+	observation=$(_cb_rest_core_observation "$observation_ttl") || observation=""
 	if [[ -z "$observation" ]]; then
 		printf 'unknown ? ? ? %s %s ?\n' "$soft_cap" "$hard_floor"
 		return 0
@@ -386,20 +427,31 @@ _cb_rest_core_priority_decision_allows() {
 	local reset_epoch
 	read -r mode remaining limit adaptive soft_cap hard_floor reset_epoch <<<"$decision"
 	case "$mode" in
-	disabled | normal)
+	disabled)
 		return 0
 		;;
-	reserve)
-		[[ "$priority" == "progress" ]] && return 0
-		return 1
-		;;
-	emergency)
-		return 1
-		;;
+	normal | reserve | emergency) ;;
 	*)
 		return 2
 		;;
 	esac
+	if [[ ! "$remaining" =~ ^[0-9]+$ || ! "$adaptive" =~ ^[0-9]+$ || ! "$soft_cap" =~ ^[0-9]+$ || ! "$hard_floor" =~ ^[0-9]+$ ]]; then
+		return 2
+	fi
+
+	local progress_start_floor
+	progress_start_floor=$(_cb_rest_core_progress_start_floor "$hard_floor" "$soft_cap") || return 2
+	if [[ "$priority" == "progress" ]]; then
+		[[ "$remaining" -gt "$progress_start_floor" ]] && return 0
+		return 1
+	fi
+
+	local deferrable_start_floor="$adaptive"
+	if [[ "$progress_start_floor" -gt "$deferrable_start_floor" ]]; then
+		deferrable_start_floor="$progress_start_floor"
+	fi
+	[[ "$remaining" -gt "$deferrable_start_floor" ]] && return 0
+	return 1
 }
 
 #######################################
@@ -425,6 +477,44 @@ pulse_rest_core_priority_allows() {
 }
 
 #######################################
+# Return whether one new API-heavy work unit may start using a fresh-enough
+# authoritative observation. Repeated checks share the short gate cache.
+# Args: $1=priority, $2=static log context (optional).
+# Returns: 0 allowed; 1 threshold block; 2 unknown/invalid evidence.
+#######################################
+pulse_rest_core_priority_allows_next() {
+	local priority="$1"
+	local context="${2:-unspecified}"
+	case "$priority" in
+	critical)
+		return 0
+		;;
+	progress | deferrable) ;;
+	*) return 2 ;;
+	esac
+
+	local decision
+	local gate_ttl
+	local decision_rc=0
+	gate_ttl=$(_cb_rest_core_gate_probe_ttl)
+	decision=$(pulse_rest_core_priority_snapshot "$gate_ttl")
+	_cb_rest_core_priority_decision_allows "$priority" "$decision" || decision_rc=$?
+	[[ "$decision_rc" -eq 0 ]] && return 0
+
+	local mode remaining limit adaptive soft_cap hard_floor reset_epoch progress_start_floor="?"
+	read -r mode remaining limit adaptive soft_cap hard_floor reset_epoch <<<"$decision"
+	if [[ "$hard_floor" =~ ^[0-9]+$ && "$soft_cap" =~ ^[0-9]+$ ]]; then
+		progress_start_floor=$(_cb_rest_core_progress_start_floor "$hard_floor" "$soft_cap") || progress_start_floor="?"
+	fi
+	echo "${_CB_RL_LOG_PREFIX} REST-core ${priority} unit blocked: context=${context} mode=${mode} remaining=${remaining}/${limit} adaptive=${adaptive} progress_start_floor=${progress_start_floor} reset=${reset_epoch} rc=${decision_rc} (GH#29742)" >>"$LOGFILE"
+	if declare -F pulse_stats_increment >/dev/null 2>&1; then
+		pulse_stats_increment "pulse_rest_core_unit_blocked" 2>/dev/null || true
+		pulse_stats_increment "pulse_rest_core_unit_blocked_${priority}" 2>/dev/null || true
+	fi
+	return "$decision_rc"
+}
+
+#######################################
 # Backward-compatible optional-work reserve entrypoint.
 #######################################
 pulse_rest_core_reserve_allows() {
@@ -438,7 +528,7 @@ pulse_rest_core_reserve_allows() {
 _cb_rest_core_progress_block_reason() {
 	local progress_rc="$1"
 	case "$progress_rc" in
-	1) printf 'known REST-core progress floor reached\n' ;;
+	1) printf 'known REST-core progress launch floor reached\n' ;;
 	2) printf 'authoritative REST-core quota evidence unavailable\n' ;;
 	*) printf 'unexpected REST-core progress decision (rc=%s)\n' "$progress_rc" ;;
 	esac
@@ -461,7 +551,7 @@ _cb_rest_core_progress_allows_dispatch() {
 	local soft_cap
 	local hard_floor
 	local reset_epoch
-	decision=$(pulse_rest_core_priority_snapshot)
+	decision=$(pulse_rest_core_priority_snapshot "$(_cb_rest_core_gate_probe_ttl)")
 	local progress_rc=0
 	_cb_rest_core_priority_decision_allows progress "$decision" || progress_rc=$?
 	[[ "$progress_rc" -eq 0 ]] && return 0
@@ -469,7 +559,11 @@ _cb_rest_core_progress_allows_dispatch() {
 	read -r mode remaining limit adaptive soft_cap hard_floor reset_epoch <<<"$decision"
 	local block_reason
 	block_reason=$(_cb_rest_core_progress_block_reason "$progress_rc")
-	echo "${_CB_RL_LOG_PREFIX} REST-core progress gate blocked: ${block_reason}; deferring until a later authoritative probe allows progress; mode=${mode} remaining=${remaining}/${limit} adaptive=${adaptive} soft_cap=${soft_cap} hard_floor=${hard_floor} reset=${reset_epoch} rc=${progress_rc} (GH#29742)" >>"$LOGFILE"
+	local progress_start_floor="?"
+	if [[ "$hard_floor" =~ ^[0-9]+$ && "$soft_cap" =~ ^[0-9]+$ ]]; then
+		progress_start_floor=$(_cb_rest_core_progress_start_floor "$hard_floor" "$soft_cap") || progress_start_floor="?"
+	fi
+	echo "${_CB_RL_LOG_PREFIX} REST-core progress gate blocked: ${block_reason}; deferring until a later authoritative probe allows progress; mode=${mode} remaining=${remaining}/${limit} adaptive=${adaptive} soft_cap=${soft_cap} hard_floor=${hard_floor} progress_start_floor=${progress_start_floor} reset=${reset_epoch} rc=${progress_rc} (GH#29742)" >>"$LOGFILE"
 	if declare -F pulse_stats_increment >/dev/null 2>&1; then
 		pulse_stats_increment "pulse_rest_core_progress_blocked" 2>/dev/null || true
 		pulse_stats_increment "pulse_rest_core_progress_blocked_${mode}" 2>/dev/null || true
@@ -501,7 +595,11 @@ _cb_allow_dispatch_with_rest_fallback() {
 	fi
 
 	local core_rc=0
-	pulse_rest_core_priority_allows progress || core_rc=$?
+	if declare -F pulse_rest_core_priority_allows_next >/dev/null 2>&1; then
+		pulse_rest_core_priority_allows_next progress "graphql_rest_fallback" || core_rc=$?
+	else
+		pulse_rest_core_priority_allows progress || core_rc=$?
+	fi
 	if [[ "$core_rc" -ne 0 ]]; then
 		local block_reason
 		block_reason=$(_cb_rest_core_progress_block_reason "$core_rc")

--- a/.agents/scripts/pulse-routines.sh
+++ b/.agents/scripts/pulse-routines.sh
@@ -614,6 +614,24 @@ _routine_schedule_is_due() {
 }
 
 #######################################
+# Return whether another deferrable routine work unit may start.
+#######################################
+_routine_rest_core_allows_next() {
+	local context="$1"
+	local budget_rc=0
+	if declare -F pulse_rest_core_priority_allows_next >/dev/null 2>&1; then
+		pulse_rest_core_priority_allows_next deferrable "$context" || budget_rc=$?
+	elif declare -F pulse_rest_core_priority_allows >/dev/null 2>&1; then
+		pulse_rest_core_priority_allows deferrable || budget_rc=$?
+	else
+		return 0
+	fi
+	[[ "$budget_rc" -eq 0 ]] && return 0
+	echo "[pulse-wrapper] evaluate_routines: REST-core reserve reached at ${context}; remaining routine work deferred (GH#29742)" >>"$LOGFILE"
+	return 1
+}
+
+#######################################
 # Evaluate routines across all pulse-enabled repos
 #
 # Reads TODO.md from each pulse-enabled repo, extracts enabled routines
@@ -622,6 +640,9 @@ _routine_schedule_is_due() {
 evaluate_routines() {
 	local publication_worker="${SCRIPT_DIR}/task-publication-worker-helper.sh"
 	if [[ -x "$publication_worker" ]]; then
+		if ! _routine_rest_core_allows_next "routine_publication_worker"; then
+			return 0
+		fi
 		"$publication_worker" run >>"$LOGFILE" 2>&1 || echo "[pulse-wrapper] publication worker pass failed" >>"$LOGFILE"
 	fi
 	if [[ ! -x "$ROUTINE_SCHEDULE_HELPER" ]]; then
@@ -679,6 +700,9 @@ evaluate_routines() {
 			timezone_context="${_RPL_TIMEZONE:-inherited}"
 
 			if _routine_schedule_is_due "$_RPL_REPEAT" "$last_epoch" "$_RPL_TIMEZONE"; then
+				if ! _routine_rest_core_allows_next "routine_execute:${_RPL_ID}"; then
+					return 0
+				fi
 				echo "[pulse-wrapper] routine ${_RPL_ID} is due (expr=${_RPL_REPEAT}, timezone=${timezone_context}, last_run_epoch=${last_epoch})" >>"$LOGFILE"
 				_routine_execute "$_RPL_ID" "$_RPL_DESC" "$_RPL_RUN" "$_RPL_AGENT" "$repo_path"
 				routines_dispatched=$((routines_dispatched + 1))

--- a/.agents/scripts/pulse-triage-dispatch.sh
+++ b/.agents/scripts/pulse-triage-dispatch.sh
@@ -609,15 +609,17 @@ _backfill_stale_consolidation_labels() {
 	local repos_json="$REPOS_JSON"
 	[[ -f "$repos_json" ]] || return 0
 
-	local total_backfilled=0
-	local total_cleared_stale=0
-	local total_locks_expired=0
-	local maintenance_flag="" pulse_flag=""
+	local total_backfilled=0 total_cleared_stale=0 total_locks_expired=0
+	local maintenance_flag="" pulse_flag="" rest_deferred=0
 	while IFS='|' read -r slug rpath maintenance_flag pulse_flag; do
 		[[ -n "$slug" ]] || continue
 		if ! declare -F repo_allows_pulse_write_actions >/dev/null 2>&1 \
 			|| ! repo_allows_pulse_write_actions "$slug"; then
 			continue
+		fi
+		if ! _pte_rest_core_deferrable_allows_next "consolidation_backfill_repo:${slug}"; then
+			rest_deferred=1
+			break
 		fi
 
 		# t2151: TTL sweep for stuck `consolidation-in-progress` labels.
@@ -632,11 +634,20 @@ _backfill_stale_consolidation_labels() {
 		local locked_num
 		while IFS= read -r locked_num; do
 			[[ "$locked_num" =~ ^[0-9]+$ ]] || continue
+			if ! _pte_rest_core_deferrable_allows_next "consolidation_lock_issue:${slug}#${locked_num}"; then
+				rest_deferred=1
+				break
+			fi
 			if _consolidation_ttl_sweep_one "$slug" "$locked_num"; then
 				total_locks_expired=$((total_locks_expired + 1))
 			fi
 		done < <(printf '%s' "$locked_issues_json" | jq -r '.[]?.number // ""' 2>/dev/null)
+		[[ "$rest_deferred" -eq 0 ]] || break
 		[[ "$maintenance_flag" == "false" || "$pulse_flag" != "true" ]] && continue
+		if ! _pte_rest_core_deferrable_allows_next "consolidation_backfill_scan:${slug}"; then
+			rest_deferred=1
+			break
+		fi
 
 		local issues_json
 		issues_json=$(gh_issue_list --repo "$slug" --state open \
@@ -645,6 +656,10 @@ _backfill_stale_consolidation_labels() {
 
 		while IFS='|' read -r num labels_csv; do
 			[[ "$num" =~ ^[0-9]+$ ]] || continue
+			if ! _pte_rest_core_deferrable_allows_next "consolidation_backfill_issue:${slug}#${num}"; then
+				rest_deferred=1
+				break
+			fi
 
 			# t2144 (A3): Defense in depth — skip and auto-clear if the
 			# parent already carries `consolidated`. _issue_needs_consolidation
@@ -677,6 +692,7 @@ _backfill_stale_consolidation_labels() {
 				total_backfilled=$((total_backfilled + 1))
 			fi
 		done < <(printf '%s' "$issues_json" | jq -r '.[] | "\(.number)|\([.labels[].name] | join(","))"' 2>/dev/null)
+		[[ "$rest_deferred" -eq 0 ]] || break
 	done < <(jq -r '.initialized_repos[] | select((.local_only // false) == false and .slug != "") | "\(.slug)|\(.path // "")|\(if .maintenance == false then false else true end)|\(.pulse // false)"' "$repos_json" 2>/dev/null)
 
 	if [[ "$total_backfilled" -gt 0 ]]; then

--- a/.agents/scripts/pulse-triage-evaluation.sh
+++ b/.agents/scripts/pulse-triage-evaluation.sh
@@ -48,6 +48,24 @@ fi
 
 # --- Functions ---
 
+#######################################
+# Return whether another deferrable label-maintenance unit may start.
+#######################################
+_pte_rest_core_deferrable_allows_next() {
+	local context="$1"
+	local budget_rc=0
+	if declare -F pulse_rest_core_priority_allows_next >/dev/null 2>&1; then
+		pulse_rest_core_priority_allows_next deferrable "$context" || budget_rc=$?
+	elif declare -F pulse_rest_core_priority_allows >/dev/null 2>&1; then
+		pulse_rest_core_priority_allows deferrable || budget_rc=$?
+	else
+		return 0
+	fi
+	[[ "$budget_rc" -eq 0 ]] && return 0
+	echo "[pulse-wrapper] Label maintenance: REST-core reserve reached at ${context}; remaining work deferred (GH#29742)" >>"${LOGFILE:-/dev/null}"
+	return 1
+}
+
 # t2161: Idempotently remove the `needs-consolidation` label from an issue
 # and log the reason. Used by `_issue_needs_consolidation`'s two auto-clear
 # branches (in-flight resolving PR + post-filter substantive_count drop).
@@ -77,9 +95,13 @@ _reevaluate_consolidation_labels() {
 	local repos_json="$REPOS_JSON"
 	[[ -f "$repos_json" ]] || return 0
 
-	local total_cleared=0
+	local total_cleared=0 rest_deferred=0
 	while IFS= read -r slug; do
 		[[ -n "$slug" ]] || continue
+		if ! _pte_rest_core_deferrable_allows_next "consolidation_repo:${slug}"; then
+			rest_deferred=1
+			break
+		fi
 		local issues_json
 		issues_json=$(gh_issue_list --repo "$slug" --state open \
 			--label "needs-consolidation" \
@@ -87,12 +109,17 @@ _reevaluate_consolidation_labels() {
 
 		while IFS= read -r num; do
 			[[ "$num" =~ ^[0-9]+$ ]] || continue
+			if ! _pte_rest_core_deferrable_allows_next "consolidation_issue:${slug}#${num}"; then
+				rest_deferred=1
+				break
+			fi
 			# _issue_needs_consolidation returns 1 (no consolidation needed)
 			# AND auto-clears the label when was_already_labeled=true
 			if ! _issue_needs_consolidation "$num" "$slug"; then
 				total_cleared=$((total_cleared + 1))
 			fi
 		done < <(printf '%s' "$issues_json" | jq -r '.[]?.number // ""')
+		[[ "$rest_deferred" -eq 0 ]] || break
 	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null)
 
 	if [[ "$total_cleared" -gt 0 ]]; then
@@ -205,6 +232,10 @@ _reevaluate_stale_continuations() {
 	local cont_num
 	while IFS= read -r cont_num; do
 		[[ "$cont_num" =~ ^[0-9]+$ ]] || continue
+		if ! _pte_rest_core_deferrable_allows_next "simplification_continuation:${repo_slug}#${issue_number}:${cont_num}"; then
+			all_stale="false"
+			break
+		fi
 
 		local cont_info cont_state cont_labels
 		cont_info=$(gh issue view "$cont_num" --repo "$repo_slug" \
@@ -284,6 +315,10 @@ _backfill_simplification_auto_dispatch_labels() {
 		printf '0\n'
 		return 0
 	}
+	if ! _pte_rest_core_deferrable_allows_next "simplification_backfill_repo:${slug}"; then
+		printf '0\n'
+		return 0
+	fi
 
 	issues_json=$(gh_issue_list --repo "$slug" --state open \
 		--label "function-complexity-debt" --label "status:available" \
@@ -292,6 +327,7 @@ _backfill_simplification_auto_dispatch_labels() {
 	local num="" labels_to_add=""
 	while IFS=$'\t' read -r num labels_to_add; do
 		[[ "$num" =~ ^[0-9]+$ ]] || continue
+		_pte_rest_core_deferrable_allows_next "simplification_backfill_issue:${slug}#${num}" || break
 		[[ -n "$labels_to_add" ]] || labels_to_add="auto-dispatch"
 		if gh issue edit "$num" --repo "$slug" \
 			--add-label "$labels_to_add" >/dev/null 2>&1; then
@@ -335,8 +371,13 @@ _reevaluate_simplification_labels() {
 
 	local total_cleared=0
 	local total_backfilled=0
+	local rest_deferred=0
 	while IFS='|' read -r slug rpath; do
 		[[ -n "$slug" && -n "$rpath" ]] || continue
+		if ! _pte_rest_core_deferrable_allows_next "simplification_repo:${slug}"; then
+			rest_deferred=1
+			break
+		fi
 
 		# t2433/GH#20071: Pull repo to latest remote state before measuring
 		# file sizes. Without this, a stale local copy causes
@@ -350,6 +391,10 @@ _reevaluate_simplification_labels() {
 		backfilled_count=$(_backfill_simplification_auto_dispatch_labels "$slug") || backfilled_count=0
 		[[ "$backfilled_count" =~ ^[0-9]+$ ]] || backfilled_count=0
 		total_backfilled=$((total_backfilled + backfilled_count))
+		if ! _pte_rest_core_deferrable_allows_next "simplification_repo_after_backfill:${slug}"; then
+			rest_deferred=1
+			break
+		fi
 
 		local issues_json
 		issues_json=$(gh_issue_list --repo "$slug" --state open \
@@ -358,6 +403,10 @@ _reevaluate_simplification_labels() {
 
 		while IFS= read -r num; do
 			[[ "$num" =~ ^[0-9]+$ ]] || continue
+			if ! _pte_rest_core_deferrable_allows_next "simplification_issue:${slug}#${num}"; then
+				rest_deferred=1
+				break
+			fi
 			local body
 			body=$(gh issue view "$num" --repo "$slug" \
 				--json body --jq '.body // ""' 2>/dev/null) || body=""
@@ -384,6 +433,7 @@ _reevaluate_simplification_labels() {
 				fi
 			fi
 		done < <(printf '%s' "$issues_json" | jq -r '.[]?.number // ""')
+		[[ "$rest_deferred" -eq 0 ]] || break
 	done < <(jq -r '.initialized_repos[] | select(.maintenance != false and .pulse == true and (.local_only // false) == false and .slug != "" and .path != "") | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null)
 
 	if [[ "$total_cleared" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-dispatch-max-parallel.sh
+++ b/.agents/scripts/tests/test-dispatch-max-parallel.sh
@@ -57,6 +57,16 @@ SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 # shellcheck source=../pulse-dispatch-engine.sh
 source "${SCRIPT_DIR}/pulse-dispatch-engine.sh"
 
+# Keep REST launch checks isolated from live GitHub evidence. Dedicated cases
+# below override these stubs to exercise reserve serialization and loop stops.
+pulse_rest_core_priority_snapshot() {
+	printf 'disabled ? ? 0 0 0 ?\n'
+	return 0
+}
+_dispatch_rest_core_progress_allows_next() {
+	return 0
+}
+
 # Keep loop tests isolated from live API budget evidence. The dedicated budget
 # gate case below overrides this helper to verify the stop path explicitly.
 _dispatch_graphql_budget_allows_next() {
@@ -148,6 +158,32 @@ test_compute_max_parallel_invalid_var() {
 		print_result "compute_max_parallel: invalid env falls back to 6" 1 "got=${result}"
 	fi
 	unset DISPATCH_MAX_PARALLEL || true
+	return 0
+}
+
+test_compute_max_parallel_rest_reserve_forces_serial() {
+	export DISPATCH_MAX_PARALLEL=6
+	rm -f "$_DISPATCH_THROTTLE_FILE"
+	pulse_rest_core_priority_snapshot() {
+		printf 'normal 700 5000 200 500 100 9999999999\n'
+		return 0
+	}
+	local reserve_result healthy_result
+	reserve_result=$(_dispatch_max_compute_parallel 24)
+	pulse_rest_core_priority_snapshot() {
+		printf 'normal 751 5000 200 500 100 9999999999\n'
+		return 0
+	}
+	healthy_result=$(_dispatch_max_compute_parallel 24)
+	pulse_rest_core_priority_snapshot() {
+		printf 'disabled ? ? 0 0 0 ?\n'
+		return 0
+	}
+	if [[ "$reserve_result" == "1" && "$healthy_result" == "6" ]]; then
+		print_result "compute_max_parallel: REST reserve-adjacent zone forces serial" 0
+	else
+		print_result "compute_max_parallel: REST reserve-adjacent zone forces serial" 1 "reserve=${reserve_result} healthy=${healthy_result}"
+	fi
 	return 0
 }
 
@@ -468,6 +504,34 @@ test_parallel_loop_graphql_budget_aborts() {
 	return 0
 }
 
+test_parallel_loop_rest_budget_aborts() {
+	_dispatch_process_candidate() {
+		return 0
+	}
+	_dispatch_rest_core_progress_allows_next() {
+		return 1
+	}
+
+	local candidate_file outcomes_file result
+	candidate_file=$(mktemp)
+	outcomes_file=$(mktemp)
+	printf '%s\n' '{"number":325,"repo_slug":"o/r","repo_path":"/t","url":"u","title":"t","labels":[]}' >"$candidate_file"
+	: >"$outcomes_file"
+	rm -f "$STOP_FLAG"
+	result=$(_dispatch_max_loop "$candidate_file" 10 10 "test_user" 4 "$outcomes_file")
+	rm -f "$candidate_file" "$outcomes_file"
+	_dispatch_rest_core_progress_allows_next() {
+		return 0
+	}
+
+	if [[ "$result" == "0 1" ]]; then
+		print_result "parallel_loop: REST launch gate aborts before launch" 0
+	else
+		print_result "parallel_loop: REST launch gate aborts before launch" 1 "got=${result}"
+	fi
+	return 0
+}
+
 test_dispatch_with_timeout_noop_outcome() {
 	local capture_dir old_path rc capture
 	capture_dir=$(mktemp -d)
@@ -647,6 +711,7 @@ test_compute_max_parallel_override
 test_compute_max_parallel_caps_at_slots
 test_compute_max_parallel_throttle_forces_serial
 test_compute_max_parallel_invalid_var
+test_compute_max_parallel_rest_reserve_forces_serial
 test_count_outcomes_success_and_fail
 test_count_outcomes_empty_file
 test_wait_tracked_pids_suppresses_stale_child
@@ -657,6 +722,7 @@ test_parallel_loop_end_to_end
 test_parallel_loop_respects_budget
 test_parallel_loop_stop_flag_aborts
 test_parallel_loop_graphql_budget_aborts
+test_parallel_loop_rest_budget_aborts
 test_dispatch_with_timeout_noop_outcome
 test_serial_loop_basic
 test_serial_loop_isolates_candidate_stdout

--- a/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
@@ -161,12 +161,114 @@ assert_refill_runtime_contract() {
 	return 0
 }
 
+assert_routine_comment_rest_block_contract() {
+	local label="$1"
+	local actual_events="" expected_events="dispatch:skip;gate:deferrable:routine_comment_responses;"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	actual_events=$(
+		(
+			unset _PULSE_DISPATCH_PREFLIGHT_LIB_LOADED
+			# shellcheck source=../pulse-dispatch-preflight-lib.sh
+			source "$PREFLIGHT_LIB"
+			REST_EVENTS=""
+			STOP_FLAG=""
+			LOGFILE="/dev/null"
+
+			apply_dispatch_max() {
+				local dependency_normalization_mode="${1:-normalize}"
+				REST_EVENTS="${REST_EVENTS}dispatch:${dependency_normalization_mode};"
+				return 0
+			}
+
+			pulse_rest_core_priority_allows_next() {
+				local priority="$1"
+				local context="$2"
+				REST_EVENTS="${REST_EVENTS}gate:${priority}:${context};"
+				return 1
+			}
+
+			dispatch_routine_comment_responses() {
+				REST_EVENTS="${REST_EVENTS}routine;"
+				return 0
+			}
+
+			_preflight_early_dispatch
+			printf '%s\n' "$REST_EVENTS"
+		)
+	)
+	if [[ "$actual_events" == "$expected_events" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected events: $expected_events"
+		echo "  actual events:   ${actual_events:-none}"
+	fi
+	return 0
+}
+
+assert_label_maintenance_rest_block_contract() {
+	local label="$1"
+	local expected_events="gate:deferrable:label_maintenance_consolidation_reevaluate;reevaluate;gate:deferrable:label_maintenance_consolidation_backfill;"
+	local actual_events=""
+	TESTS_RUN=$((TESTS_RUN + 1))
+	actual_events=$(
+		(
+			unset _PULSE_DISPATCH_PREFLIGHT_LIB_LOADED
+			# shellcheck source=../pulse-dispatch-preflight-lib.sh
+			source "$PREFLIGHT_LIB"
+			REST_EVENTS=""
+			LOGFILE="/dev/null"
+
+			pulse_rest_core_priority_allows_next() {
+				local priority="$1"
+				local context="$2"
+				REST_EVENTS="${REST_EVENTS}gate:${priority}:${context};"
+				[[ "$context" != "label_maintenance_consolidation_backfill" ]]
+				return $?
+			}
+
+			_reevaluate_consolidation_labels() {
+				REST_EVENTS="${REST_EVENTS}reevaluate;"
+				return 0
+			}
+
+			_backfill_stale_consolidation_labels() {
+				REST_EVENTS="${REST_EVENTS}backfill;"
+				return 0
+			}
+
+			_reevaluate_simplification_labels() {
+				REST_EVENTS="${REST_EVENTS}simplification;"
+				return 0
+			}
+
+			_log_substage_timing() { return 0; }
+
+			_preflight_label_maintenance
+			printf '%s\n' "$REST_EVENTS"
+		)
+	)
+	if [[ "$actual_events" == "$expected_events" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected events: $expected_events"
+		echo "  actual events:   ${actual_events:-none}"
+	fi
+	return 0
+}
+
 # Resolve paths relative to this test file
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ENGINE="$SCRIPT_DIR/pulse-dispatch-engine.sh"
 CORE="$SCRIPT_DIR/pulse-dispatch-core.sh"
 DISPATCH_LIB="$SCRIPT_DIR/pulse-dispatch-lib.sh"
 PREFLIGHT_LIB="$SCRIPT_DIR/pulse-dispatch-preflight-lib.sh"
+ROUTINES="$SCRIPT_DIR/pulse-routines.sh"
+TRIAGE_EVALUATION="$SCRIPT_DIR/pulse-triage-evaluation.sh"
+TRIAGE_DISPATCH="$SCRIPT_DIR/pulse-triage-dispatch.sh"
 
 echo "=== t2443 + t2903: pulse-dispatch-engine stage wiring regression tests ==="
 echo "Engine: $ENGINE"
@@ -279,6 +381,11 @@ assert_grep \
 	"9c: capacity and label maintenance use separate helper functions" \
 	'^_preflight_label_maintenance\(\)' \
 	"$PREFLIGHT_LIB"
+assert_match_count \
+	"9c2: every label-maintenance substage has a fresh REST launch gate" \
+	'^[[:space:]]*_preflight_rest_core_allows_next "label_maintenance_' \
+	3 \
+	"$PREFLIGHT_LIB"
 assert_grep \
 	"9d: post-label refill has a dedicated helper" \
 	'^_preflight_post_label_refill\(\)' \
@@ -332,6 +439,47 @@ assert_match_count \
 	"$PREFLIGHT_LIB"
 assert_refill_runtime_contract \
 	"9l: trusted NMR reconciliation completes before the normalized refill"
+assert_routine_comment_rest_block_contract \
+	"9l2: blocked REST evidence suppresses the routine-comment API scan"
+assert_label_maintenance_rest_block_contract \
+	"9l3: blocked REST evidence stops label maintenance before the next API substage"
+assert_order \
+	"9m: routine-comment REST gate precedes its API scan" \
+	'_preflight_rest_core_allows_next "routine_comment_responses"' \
+	'^[[:space:]]*dispatch_routine_comment_responses[[:space:]]*\|\|' \
+	"$PREFLIGHT_LIB"
+assert_grep \
+	"9n: dispatch rechecks REST launch headroom after candidate ranking" \
+	'_dispatch_rest_core_progress_allows_next "dispatch_post_ranking"' \
+	"$ENGINE"
+assert_grep \
+	"9o: dispatch rechecks REST launch headroom after prepasses" \
+	'_dispatch_rest_core_progress_allows_next "dispatch_post_prepasses"' \
+	"$ENGINE"
+assert_grep \
+	"9p: routine execution has a per-unit REST gate" \
+	'_routine_rest_core_allows_next "routine_execute:\$\{_RPL_ID\}"' \
+	"$ROUTINES"
+assert_grep \
+	"9q: publication work has a per-unit REST gate" \
+	'_routine_rest_core_allows_next "routine_publication_worker"' \
+	"$ROUTINES"
+assert_grep \
+	"9r: consolidation re-evaluation gates each repository" \
+	'_pte_rest_core_deferrable_allows_next "consolidation_repo:\$\{slug\}"' \
+	"$TRIAGE_EVALUATION"
+assert_grep \
+	"9s: consolidation re-evaluation gates each issue" \
+	'_pte_rest_core_deferrable_allows_next "consolidation_issue:\$\{slug\}#\$\{num\}"' \
+	"$TRIAGE_EVALUATION"
+assert_grep \
+	"9t: simplification re-evaluation gates each issue" \
+	'_pte_rest_core_deferrable_allows_next "simplification_issue:\$\{slug\}#\$\{num\}"' \
+	"$TRIAGE_EVALUATION"
+assert_grep \
+	"9u: consolidation backfill gates each issue" \
+	'_pte_rest_core_deferrable_allows_next "consolidation_backfill_issue:\$\{slug\}#\$\{num\}"' \
+	"$TRIAGE_DISPATCH"
 
 # --- Benign expected dispatch blocks must not be surfaced as generic stage failures ---
 

--- a/.agents/scripts/tests/test-pulse-graphql-budget-priority.sh
+++ b/.agents/scripts/tests/test-pulse-graphql-budget-priority.sh
@@ -59,7 +59,9 @@ _cb_rate_limit_json() {
 export AIDEVOPS_PULSE_OPTIONAL_BUDGET_THRESHOLD=1250
 export AIDEVOPS_PULSE_REST_CORE_RESERVE=500
 export AIDEVOPS_PULSE_REST_CORE_HARD_FLOOR=100
+export AIDEVOPS_PULSE_REST_CORE_IN_FLIGHT_ALLOWANCE=250
 export AIDEVOPS_PULSE_REST_CORE_ADAPTIVE_WINDOW_SECONDS=3600
+export AIDEVOPS_PULSE_REST_CORE_GATE_PROBE_TTL=2
 export GH_GRAPHQL_REMAINING=100
 export GH_REST_CORE_REMAINING=5000
 export GH_REST_CORE_RESET="$(($(date +%s) + 3600))"
@@ -124,11 +126,11 @@ export AIDEVOPS_SKIP_PULSE_PREFETCH_BUDGET_GATE=1
 _pulse_should_defer_budget_priority_stage "preflight_prefetch_and_scope"
 unset AIDEVOPS_SKIP_PULSE_PREFETCH_BUDGET_GATE
 if _pulse_should_defer_budget_priority_stage "deterministic_merge_pass"; then
-	printf 'FAIL: progress stage deferred above REST hard floor\n' >&2
+	printf 'FAIL: progress stage deferred above REST launch floor\n' >&2
 	exit 1
 fi
 if _pulse_should_defer_budget_priority_stage "approval_merge_trigger"; then
-	printf 'FAIL: approval-trigger merge deferred above REST hard floor\n' >&2
+	printf 'FAIL: approval-trigger merge deferred above REST launch floor\n' >&2
 	exit 1
 fi
 if _pulse_should_defer_budget_priority_stage "reap_orphan_workers"; then
@@ -140,6 +142,30 @@ grep -q '_pulse_run_budget_priority_stage "approval_merge_trigger" _drain_merge_
 _pulse_defer_budget_priority_stage "dashboard_freshness_check"
 grep -q 'pulse_rest_core_budget_reserve_mode' "${TMP_DIR}/counters.log"
 grep -q 'pulse_rest_core_budget_stage_deferred_dashboard_freshness_check' "${TMP_DIR}/counters.log"
+
+export GH_REST_CORE_RESET="$(($(date +%s) + 60))"
+export GH_REST_CORE_REMAINING=350
+rm -f "${HOME}/.aidevops/cache/pulse-rest-core.json"
+_pulse_set_rest_core_budget_priority
+[[ "${AIDEVOPS_PULSE_REST_CORE_BUDGET_CLASS}" == "normal" ]]
+if ! _pulse_should_defer_budget_priority_stage "deterministic_merge_pass"; then
+	printf 'FAIL: progress stage was admitted at REST launch floor\n' >&2
+	exit 1
+fi
+_pulse_defer_budget_priority_stage "deterministic_merge_pass"
+grep -q 'progress_start_floor=350' "$LOGFILE"
+if _pulse_should_defer_budget_priority_stage "reap_orphan_workers"; then
+	printf 'FAIL: critical stage deferred at REST launch floor\n' >&2
+	exit 1
+fi
+
+export GH_REST_CORE_REMAINING=351
+rm -f "${HOME}/.aidevops/cache/pulse-rest-core.json"
+if _pulse_should_defer_budget_priority_stage "deterministic_merge_pass"; then
+	printf 'FAIL: progress stage deferred above REST launch floor\n' >&2
+	exit 1
+fi
+export GH_REST_CORE_RESET="$(($(date +%s) + 3600))"
 
 export GH_REST_CORE_REMAINING=100
 rm -f "${HOME}/.aidevops/cache/pulse-rest-core.json"

--- a/.agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh
+++ b/.agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh
@@ -77,6 +77,15 @@ PROCESSED_REPOS=""
 ZERO_PROGRESS_CALLS=""
 STOP_AFTER_REPO=""
 MERGE_ON_REPO=""
+REST_BLOCK_CONTEXT=""
+
+pulse_rest_core_priority_allows_next() {
+	local priority="$1"
+	local context="$2"
+	[[ -n "$priority" ]] || return 1
+	[[ -z "$REST_BLOCK_CONTEXT" || "$context" != "$REST_BLOCK_CONTEXT" ]] || return 1
+	return 0
+}
 
 repo_allows_pulse_write_actions() {
 	local repo_slug="$1"
@@ -174,6 +183,27 @@ ZERO_PROGRESS_CALLS=""
 merge_ready_prs_all_repos
 assert_equals "interrupted pass records conclusive merge progress without a partial denominator" "0:1:0 " "$ZERO_PROGRESS_CALLS"
 rm -f "$STOP_FLAG"
+
+rm -f "$PULSE_MERGE_CHECKPOINT_FILE"
+STOP_AFTER_REPO=""
+MERGE_ON_REPO=""
+PROCESSED_REPOS=""
+ZERO_PROGRESS_CALLS=""
+REST_BLOCK_CONTEXT="merge_repo:org/two"
+merge_ready_prs_all_repos
+assert_equals "REST launch gate stops before the blocked repository" "org/one " "$PROCESSED_REPOS"
+assert_equals "REST launch gate preserves the last completed repository checkpoint" "org/one" "$(tr -d '\n' <"$PULSE_MERGE_CHECKPOINT_FILE")"
+assert_equals "REST-paused partial pass does not record zero-progress aggregate" "" "$ZERO_PROGRESS_CALLS"
+
+REST_BLOCK_CONTEXT=""
+PROCESSED_REPOS=""
+merge_ready_prs_all_repos
+assert_equals "REST-paused pass resumes after the completed repository" "org/two org/three " "$PROCESSED_REPOS"
+if [[ ! -f "$PULSE_MERGE_CHECKPOINT_FILE" ]]; then
+	pass "REST-paused checkpoint clears after resumed tail completes"
+else
+	fail "REST-paused checkpoint clears after resumed tail completes" "checkpoint still exists"
+fi
 
 if [[ "$TESTS_FAILED" -eq 0 ]]; then
 	printf '\n%sAll %s tests passed%s\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_NC"

--- a/.agents/scripts/tests/test-pulse-merge-pr-cursor-resume.sh
+++ b/.agents/scripts/tests/test-pulse-merge-pr-cursor-resume.sh
@@ -61,6 +61,7 @@ set +o pipefail 2>/dev/null || true
 FAKE_NOW=100
 PROCESSED_PRS=""
 ENRICH_TRIGGER_PHASE=""
+REST_BLOCK_AFTER_PHASE=""
 ENRICH_PHASE_LOG="${TMPDIR_TEST}/enrichment-phases.log"
 ENRICH_PHASE_STATE="${TMPDIR_TEST}/enrichment-phase.state"
 
@@ -91,6 +92,20 @@ record_enrichment_phase() {
 	local phase="$1"
 	printf '%s ' "$phase" >>"$ENRICH_PHASE_LOG"
 	printf '%s' "$phase" >"$ENRICH_PHASE_STATE"
+	return 0
+}
+
+pulse_rest_core_priority_allows_next() {
+	local priority="$1"
+	local context="$2"
+	local current_phase=""
+	[[ "$priority" == "progress" || "$priority" == "deferrable" ]] || return 0
+	if [[ -f "$ENRICH_PHASE_STATE" ]]; then
+		current_phase=$(<"$ENRICH_PHASE_STATE")
+	fi
+	if [[ -n "$REST_BLOCK_AFTER_PHASE" && "$current_phase" == "$REST_BLOCK_AFTER_PHASE" && "$context" == merge_enrichment_* ]]; then
+		return 1
+	fi
 	return 0
 }
 
@@ -208,6 +223,29 @@ assert_budget_pause_after_phase() {
 assert_budget_pause_after_phase mergeability "mergeability "
 assert_budget_pause_after_phase checks "mergeability checks "
 assert_budget_pause_after_phase reviews "mergeability checks reviews "
+
+assert_rest_pause_after_phase() {
+	local phase="$1"
+	local expected_phases="$2"
+	local pass_rc=0
+	PROCESSED_PRS=""
+	ENRICH_TRIGGER_PHASE=""
+	REST_BLOCK_AFTER_PHASE="$phase"
+	FAKE_NOW=100
+	rm -f "$ENRICH_PHASE_LOG" "$ENRICH_PHASE_STATE" "$PULSE_MERGE_PR_CURSOR_FILE" "$PULSE_MERGE_ENRICHMENT_CACHE_FILE" "$PULSE_MERGE_ENRICHMENT_CURSOR_FILE"
+	_PMP_MERGE_PASS_DEADLINE_EPOCH=0
+	_merge_ready_prs_for_repo "org/repo" merged closed failed pr_count "" || pass_rc=$?
+	assert_eq "REST pause after ${phase} enrichment returns resumable status" "5" "$pass_rc"
+	assert_eq "REST pause after ${phase} enrichment processes no incomplete PR" "" "$PROCESSED_PRS"
+	assert_eq "REST pause after ${phase} enrichment persists the current PR" "org/repo|0||101" "$(tr -d '\n' <"$PULSE_MERGE_ENRICHMENT_CURSOR_FILE")"
+	assert_eq "REST pause stops after ${phase} enrichment" "$expected_phases" "$(<"$ENRICH_PHASE_LOG")"
+	return 0
+}
+
+assert_rest_pause_after_phase mergeability "mergeability "
+assert_rest_pause_after_phase checks "mergeability checks "
+assert_rest_pause_after_phase reviews "mergeability checks reviews "
+REST_BLOCK_AFTER_PHASE=""
 
 # The next cycle starts from the durable current-PR cursor and re-enriches from
 # the fresh list response. No partial enrichment cache is required for progress.

--- a/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
+++ b/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
@@ -515,13 +515,13 @@ else
 		"harness rc=${budget_rc}, output=${budget_output}"
 fi
 
-if grep -q 'pulse_rest_core_priority_allows progress' "$ROUTINE_FILE"; then
+if grep -q 'pulse_rest_core_priority_allows_next progress "merge_routine_start"' "$ROUTINE_FILE"; then
 	pass "17b: merge routine uses REST progress priority instead of the optional-work reserve"
 else
 	fail "17b: merge routine uses REST progress priority instead of the optional-work reserve"
 fi
 
-if grep -qF 'Known REST-core progress floor reached' "$ROUTINE_FILE" &&
+if grep -qF 'Known REST-core progress launch floor reached' "$ROUTINE_FILE" &&
 	grep -qF 'REST-core quota evidence unavailable' "$ROUTINE_FILE"; then
 	pass "17c: merge routine distinguishes known REST floor from unavailable evidence"
 else

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
@@ -550,6 +550,14 @@ _setup_dispatch_stub() {
 		return 0
 	}
 
+	# Keep prepass tests isolated from live REST-core evidence. Dedicated coverage
+	# below overrides this helper to verify the blocked launch path.
+	_dispatch_rest_core_progress_allows_next() {
+		local context="$1"
+		[[ -n "$context" ]] || return 1
+		return 0
+	}
+
 	return 0
 }
 
@@ -887,6 +895,53 @@ test_triage_prepass_has_independent_once_per_cycle_budget() {
 	return 0
 }
 
+test_triage_prepass_rest_gate_blocks_before_review_api() {
+	local repos_json="" state_file="" outcome="" dispatch_count="" gate_calls=""
+	local enrichment_definition="" gate_definition="" marker=""
+	_set_valid_triage_test_metadata
+	repos_json=$(_make_repos_json "owner/repo" "/tmp/repo")
+	state_file=$(_make_state_file "## owner/repo
+
+- Issue #812: REST blocked [status: **needs-review**] [created: 2026-01-03T00:00:00Z]
+")
+	STATE_FILE="$state_file"
+	TRIAGE_STATE_FILE="$state_file"
+	DISPATCH_LOG_FILE="${TEST_ROOT}/dispatch-prepass-rest-block.log"
+	local gate_log="${TEST_ROOT}/dispatch-prepass-rest-gate.log"
+	: >"$DISPATCH_LOG_FILE"
+	: >"$gate_log"
+	_PULSE_CYCLE_ID="triage-prepass-rest-block"
+	PULSE_TRIAGE_BUDGET_PER_CYCLE=2
+	enrichment_definition=$(declare -f dispatch_enrichment_workers)
+	gate_definition=$(declare -f _dispatch_rest_core_progress_allows_next)
+	dispatch_enrichment_workers() {
+		local available_slots="$1"
+		printf 'enrichment:%s\n' "$available_slots" >>"$DISPATCH_LOG_FILE"
+		printf '%s\n' "$available_slots"
+		return 0
+	}
+	_dispatch_rest_core_progress_allows_next() {
+		local context="$1"
+		printf '%s\n' "$context" >>"$gate_log"
+		[[ "$context" != "dispatch_triage_prepass" ]]
+		return $?
+	}
+	outcome=$(_dispatch_run_prepasses 5)
+	eval "$enrichment_definition"
+	eval "$gate_definition"
+	dispatch_count=$(wc -l <"$DISPATCH_LOG_FILE" | tr -d ' ')
+	gate_calls=$(tr '\n' ' ' <"$gate_log")
+	marker=$(_dispatch_cycle_cache_path "pulse-triage-prepass" ".done")
+	if [[ "$outcome" == "5 0 0" && "$dispatch_count" == "0" && \
+		"$gate_calls" == "dispatch_triage_prepass " && ! -e "$marker" ]]; then
+		print_result "REST launch gate blocks triage and enrichment prepasses before API work" 0
+		return 0
+	fi
+	print_result "REST launch gate blocks triage and enrichment prepasses before API work" 1 \
+		"outcome=${outcome} dispatch_count=${dispatch_count} gate_calls=${gate_calls} marker=${marker}"
+	return 0
+}
+
 test_triage_fallback_outcome_is_valid() {
 	local outcome=""
 	outcome=$(_dispatch_triage_fallback_outcome 1)
@@ -1069,6 +1124,7 @@ main() {
 	test_dispatch_triage_reviews_rejects_malformed_metadata
 	test_dispatch_triage_reviews_types_infrastructure_failures
 	test_triage_prepass_has_independent_once_per_cycle_budget
+	test_triage_prepass_rest_gate_blocks_before_review_api
 	test_triage_fallback_outcome_is_valid
 	test_triage_candidates_prioritize_known_contributors
 	test_triage_prepass_refreshes_zero_attempt_snapshot

--- a/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
@@ -200,7 +200,9 @@ reset_test_state() {
 	export AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK=0
 	export AIDEVOPS_PULSE_REST_CORE_RESERVE=500
 	export AIDEVOPS_PULSE_REST_CORE_HARD_FLOOR=100
+	export AIDEVOPS_PULSE_REST_CORE_IN_FLIGHT_ALLOWANCE=250
 	export AIDEVOPS_PULSE_REST_CORE_ADAPTIVE_WINDOW_SECONDS=3600
+	export AIDEVOPS_PULSE_REST_CORE_GATE_PROBE_TTL=2
 	return 0
 }
 
@@ -301,7 +303,7 @@ test_graphql_api_error_respects_rest_hard_floor() {
 	STUB_GH_CORE_REMAINING=10
 	local rc=0
 	is_graphql_budget_sufficient || rc=$?
-	if [[ "$rc" -eq 1 ]] && grep -qF 'known REST-core progress floor reached' "$LOGFILE"; then
+	if [[ "$rc" -eq 1 ]] && grep -qF 'known REST-core progress launch floor reached' "$LOGFILE"; then
 		pass "GraphQL API error respects the REST hard floor"
 	else
 		fail "GraphQL API error should not bypass the REST hard floor" "rc=$rc"
@@ -316,7 +318,7 @@ test_malformed_graphql_projection_respects_rest_hard_floor() {
 	STUB_GH_CORE_REMAINING=10
 	local rc=0
 	is_graphql_budget_sufficient || rc=$?
-	if [[ "$rc" -eq 1 ]] && grep -qF 'known REST-core progress floor reached' "$LOGFILE"; then
+	if [[ "$rc" -eq 1 ]] && grep -qF 'known REST-core progress launch floor reached' "$LOGFILE"; then
 		pass "malformed GraphQL projection respects the REST hard floor"
 	else
 		fail "malformed GraphQL projection should not bypass the REST hard floor" "rc=$rc"
@@ -543,7 +545,7 @@ test_graphql_exhausted_rest_core_low_blocks_dispatch() {
 	local rc=0
 	is_graphql_budget_sufficient || rc=$?
 	if [[ "$rc" -eq 1 && "${AIDEVOPS_GH_FORCE_REST_READS:-0}" != "1" ]] &&
-		grep -qF 'known REST-core progress floor reached' "$LOGFILE"; then
+		grep -qF 'known REST-core progress launch floor reached' "$LOGFILE"; then
 		pass "GraphQL exhausted with low REST core still blocks dispatch"
 	else
 		fail "low REST core should not allow fallback" "rc=$rc force_rest=${AIDEVOPS_GH_FORCE_REST_READS:-unset}"
@@ -652,6 +654,49 @@ test_rest_core_priority_class_eligibility() {
 		pass "REST reserve mode preserves progress while deferring optional work"
 	else
 		fail "REST reserve class eligibility mismatch" "progress_rc=${progress_rc} deferrable_rc=${deferrable_rc}"
+	fi
+	return 0
+}
+
+# --- Test 22b: In-flight allowance raises the progress launch boundary ---
+test_rest_core_in_flight_allowance_boundary() {
+	reset_test_state
+	export STUB_GH_CORE_RESET="$(($(date +%s) + 60))"
+	export STUB_GH_CORE_REMAINING=350
+	rm -f "$_CB_REST_CORE_CACHE_FILE"
+	local blocked_snapshot blocked_rc=0 allowed_rc=0 critical_rc=0 start_floor=""
+	blocked_snapshot=$(pulse_rest_core_priority_snapshot)
+	pulse_rest_core_priority_allows progress || blocked_rc=$?
+	pulse_rest_core_priority_allows critical || critical_rc=$?
+	start_floor=$(_cb_rest_core_progress_start_floor 100 500)
+
+	export STUB_GH_CORE_REMAINING=351
+	rm -f "$_CB_REST_CORE_CACHE_FILE"
+	pulse_rest_core_priority_allows progress || allowed_rc=$?
+	if [[ "$blocked_snapshot" == normal\ 350\ 5000\ * && "$start_floor" == "350" && "$blocked_rc" -eq 1 && "$allowed_rc" -eq 0 && "$critical_rc" -eq 0 ]]; then
+		pass "REST in-flight allowance blocks progress at 350 and permits it at 351"
+	else
+		fail "REST in-flight allowance launch boundary mismatch" "snapshot=${blocked_snapshot} start_floor=${start_floor} blocked_rc=${blocked_rc} allowed_rc=${allowed_rc} critical_rc=${critical_rc}"
+	fi
+	return 0
+}
+
+# --- Test 22c: Unit gates reject a stale high cache after a fresh low probe ---
+test_rest_core_unit_gate_refreshes_stale_observation() {
+	reset_test_state
+	local now rc=0 rest_calls=0
+	now=$(date +%s)
+	mkdir -p "$(dirname "$_CB_REST_CORE_CACHE_FILE")"
+	jq -cn --argjson observed "$((now - 3))" --argjson remaining 500 --argjson limit 5000 \
+		--argjson reset "$((now + 3600))" \
+		'{observed:$observed,remaining:$remaining,limit:$limit,reset:$reset,resource:"core"}' >"$_CB_REST_CORE_CACHE_FILE"
+	export STUB_GH_CORE_REMAINING=350
+	pulse_rest_core_priority_allows_next progress "test_stale_unit_gate" || rc=$?
+	rest_calls=$(grep -c '^rest-core$' "$GH_REST_CALLS" 2>/dev/null) || rest_calls=0
+	if [[ "$rc" -eq 1 && "$rest_calls" -eq 1 ]] && grep -qF 'context=test_stale_unit_gate' "$LOGFILE"; then
+		pass "REST unit gate refreshes stale observations before launching work"
+	else
+		fail "REST unit gate should refresh stale launch evidence" "rc=${rc} rest_calls=${rest_calls}"
 	fi
 	return 0
 }
@@ -1107,6 +1152,8 @@ test_rest_core_probe_reset_forces_recheck
 test_rest_core_adaptive_threshold_math
 test_rest_core_priority_boundaries
 test_rest_core_priority_class_eligibility
+test_rest_core_in_flight_allowance_boundary
+test_rest_core_unit_gate_refreshes_stale_observation
 test_rest_core_hard_floor_eligibility
 test_rest_core_unknown_evidence
 test_rest_core_legacy_override_compatibility


### PR DESCRIPTION
## Summary

Protect the maintainer REST-core quota by adding an in-flight launch allowance, fresh bounded-unit admission checks, reserve-adjacent dispatch serialization, and resumable merge pauses.

## Files Changed

.agents/configs/pulse-rate-limit.conf, .agents/scripts/pulse-budget-priority.sh, .agents/scripts/pulse-dispatch-engine.sh, .agents/scripts/pulse-dispatch-lib.sh, .agents/scripts/pulse-dispatch-preflight-lib.sh, .agents/scripts/pulse-merge-pass.sh, .agents/scripts/pulse-merge-process.sh, .agents/scripts/pulse-merge-routine.sh, .agents/scripts/pulse-rate-limit-circuit-breaker.sh, .agents/scripts/pulse-routines.sh, .agents/scripts/pulse-triage-dispatch.sh, .agents/scripts/pulse-triage-evaluation.sh, .agents/scripts/tests/test-dispatch-max-parallel.sh, .agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh, .agents/scripts/tests/test-pulse-graphql-budget-priority.sh, .agents/scripts/tests/test-pulse-merge-checkpoint-resume.sh, .agents/scripts/tests/test-pulse-merge-pr-cursor-resume.sh, .agents/scripts/tests/test-pulse-merge-routine-standalone.sh, .agents/scripts/tests/test-rate-limit-circuit-breaker.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Local changed-file quality gate passed; ShellCheck and Bash syntax passed; focused circuit-breaker, dispatch, merge cursor/checkpoint, routine, maintenance, consolidation, and pulse-wrapper regressions passed.

Resolves #29742


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.233 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 6h 10m and 4,953,330 tokens on this with the user in an interactive session.