### PR TITLE
GH#29766: preserve Pulse rate-limit override precedence

### DIFF
--- a/.agents/configs/pulse-rate-limit.conf
+++ b/.agents/configs/pulse-rate-limit.conf
@@ -8,11 +8,12 @@
 #   AGENTS.md                           0.30  (docs)
 # Consolidated here at GH#20638 / t2768 so all launch paths use the same value.
 #
-# Format: KEY=VALUE (no spaces around =, no quotes needed)
+# Format: KEY=${KEY-default} (no spaces around =, no quotes needed). This
+# default-only assignment keeps a caller-provided value intact on every source.
 # Lines starting with # are comments.
 # Sourceable by bash: source .agents/configs/pulse-rate-limit.conf
-# Env var AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD takes precedence over this file —
-# consumers check whether the env var is already set before sourcing.
+# Every pre-existing variable takes precedence over this file, including partial
+# override sets. Consumers may therefore source the whole file in any order.
 #
 # Change history:
 #   0.05  Original value (t2690) — fired only after 95% of budget was already spent.
@@ -45,7 +46,7 @@
 # authoritative probe succeeds. AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER=1 is the
 # explicit emergency bypass for both pools.
 # Env var AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD takes precedence if already set.
-AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD=0.05
+AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD=${AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD-0.05}
 
 # ── REST core adaptive priority reserve (GH#29736, GH#29742) ────────────────
 #
@@ -58,30 +59,30 @@ AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD=0.05
 #
 # Env var AIDEVOPS_PULSE_REST_CORE_RESERVE takes precedence. Set to 0 only for
 # a bounded diagnostic run; it disables both REST priority thresholds.
-AIDEVOPS_PULSE_REST_CORE_RESERVE=500
+AIDEVOPS_PULSE_REST_CORE_RESERVE=${AIDEVOPS_PULSE_REST_CORE_RESERVE-500}
 
 # Emergency floor retained for maintainer intervention and safety operations.
 # API-heavy Pulse progress stages defer at or below this value.
-AIDEVOPS_PULSE_REST_CORE_HARD_FLOOR=100
+AIDEVOPS_PULSE_REST_CORE_HARD_FLOOR=${AIDEVOPS_PULSE_REST_CORE_HARD_FLOOR-100}
 
 # Headroom reserved for one bounded unit of already-admitted Pulse work plus
 # overlapping progress producers. New progress work starts only above
 # hard_floor + this allowance. The default is roughly twice the 132-request
 # overshoot observed in the GH#29742 live canary.
-AIDEVOPS_PULSE_REST_CORE_IN_FLIGHT_ALLOWANCE=250
+AIDEVOPS_PULSE_REST_CORE_IN_FLIGHT_ALLOWANCE=${AIDEVOPS_PULSE_REST_CORE_IN_FLIGHT_ALLOWANCE-250}
 
 # GitHub REST core uses an hourly window. The soft reserve decays linearly over
 # this many seconds and is clamped to [hard floor, soft cap].
-AIDEVOPS_PULSE_REST_CORE_ADAPTIVE_WINDOW_SECONDS=3600
+AIDEVOPS_PULSE_REST_CORE_ADAPTIVE_WINDOW_SECONDS=${AIDEVOPS_PULSE_REST_CORE_ADAPTIVE_WINDOW_SECONDS-3600}
 
 # Seconds that an authoritative REST response-header observation may be reused.
 # The reset epoch always takes precedence, so this cannot delay recovery.
-AIDEVOPS_PULSE_REST_CORE_PROBE_TTL=20
+AIDEVOPS_PULSE_REST_CORE_PROBE_TTL=${AIDEVOPS_PULSE_REST_CORE_PROBE_TTL-20}
 
 # Stage and intra-stage launch gates need fresher evidence than status probes.
 # A short cache still coalesces concurrent checks without allowing a long stage
 # to rely on a stale pre-stage observation.
-AIDEVOPS_PULSE_REST_CORE_GATE_PROBE_TTL=2
+AIDEVOPS_PULSE_REST_CORE_GATE_PROBE_TTL=${AIDEVOPS_PULSE_REST_CORE_GATE_PROBE_TTL-2}
 
 # ── Cross-issue no_work rate circuit breaker (GH#20640, t2770) ────────────────
 #
@@ -105,11 +106,11 @@ AIDEVOPS_PULSE_REST_CORE_GATE_PROBE_TTL=2
 #   AIDEVOPS_SKIP_NO_WORK_BREAKER=1 — emergency bypass (dispatch proceeds)
 
 # Rolling window duration in seconds (default 10 minutes).
-NO_WORK_WINDOW_SECS=600
+NO_WORK_WINDOW_SECS=${NO_WORK_WINDOW_SECS-600}
 
 # Maximum no_work events allowed within the window before the breaker trips.
 # Set to 0 to disable entirely.
-NO_WORK_WINDOW_MAX=10
+NO_WORK_WINDOW_MAX=${NO_WORK_WINDOW_MAX-10}
 
 # ── Wall-clock timeouts for gh CLI invocations (t2913) ────────────────────────
 #
@@ -144,10 +145,10 @@ NO_WORK_WINDOW_MAX=10
 # immediately on coreutils.
 
 # Wall-clock seconds before a wrapped `gh` read returns with rc=124.
-AIDEVOPS_GH_READ_TIMEOUT=15
+AIDEVOPS_GH_READ_TIMEOUT=${AIDEVOPS_GH_READ_TIMEOUT-15}
 
 # Wall-clock seconds before a wrapped `gh` write returns with rc=124.
-AIDEVOPS_GH_WRITE_TIMEOUT=45
+AIDEVOPS_GH_WRITE_TIMEOUT=${AIDEVOPS_GH_WRITE_TIMEOUT-45}
 
 # ── L1 events ETag tickle (t2830, GH#20868) ───────────────────────────────────
 #
@@ -168,7 +169,7 @@ AIDEVOPS_GH_WRITE_TIMEOUT=45
 #
 # Set to 0 to disable the tickle and always run batch search unconditionally.
 # Env var PULSE_EVENTS_TICKLE_ENABLED takes precedence if already set.
-PULSE_EVENTS_TICKLE_ENABLED=1
+PULSE_EVENTS_TICKLE_ENABLED=${PULSE_EVENTS_TICKLE_ENABLED-1}
 
 # ── Pulse batch Search API last-resort mode ───────────────────────────────────
 #
@@ -181,10 +182,8 @@ PULSE_EVENTS_TICKLE_ENABLED=1
 # Set to 0 only for a bounded diagnostic run where owner-wide search semantics
 # are required and secondary cooldown is known clear.
 #
-# This file assigns PULSE_BATCH_SEARCH_LAST_RESORT directly. Consumers that
-# need to preserve a pre-existing environment override must save and restore it
-# around sourcing this config.
-PULSE_BATCH_SEARCH_LAST_RESORT=1
+# A pre-existing environment override remains authoritative across every source.
+PULSE_BATCH_SEARCH_LAST_RESORT=${PULSE_BATCH_SEARCH_LAST_RESORT-1}
 
 # ── GitHub Actions runner queue saturation (t3211, GH#21942) ──────────────────
 #
@@ -222,9 +221,9 @@ PULSE_BATCH_SEARCH_LAST_RESORT=1
 
 # Minimum queued workflow runs for saturation. Below this, never saturated
 # regardless of the ratio.
-AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN=50
+AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN=${AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN-50}
 
 # Minimum integer ratio of queued / max(in_progress, 1) for saturation.
 # Below this, traffic is assumed normal even with high absolute queue depth
 # (large in-progress count means the runner pool is keeping up).
-AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN=10
+AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN=${AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN-10}

--- a/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
@@ -71,11 +71,11 @@ if [[ -f "${SCRIPT_DIR}/pulse-stats-helper.sh" ]]; then
 fi
 
 # Source canonical circuit-breaker threshold from conf file (GH#20638, t2768).
-# Env var takes precedence; conf supplies the default; 0.05 is the hardcoded fallback
-# if the conf file is missing (graceful degradation). Sourced here so standalone
-# invocations (not via pulse-wrapper.sh) also use the canonical value.
+# Existing values take precedence; the conf fills every missing default; 0.05
+# is the hardcoded fallback if the conf file is missing (graceful degradation).
+# Sourced here so standalone invocations also receive partial-config defaults.
 _CB_RL_CONF="${SCRIPT_DIR}/../configs/pulse-rate-limit.conf"
-if [[ -z "${AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD+x}" ]] && [[ -f "$_CB_RL_CONF" ]]; then
+if [[ -f "$_CB_RL_CONF" ]]; then
 	# shellcheck disable=SC1090
 	source "$_CB_RL_CONF"
 fi

--- a/.agents/scripts/pulse-wrapper-config.sh
+++ b/.agents/scripts/pulse-wrapper-config.sh
@@ -161,10 +161,10 @@ PULSE_PREFETCH_ISSUE_LIMIT="${PULSE_PREFETCH_ISSUE_LIMIT:-200}"                 
 PULSE_PREFETCH_CACHE_FILE="${PULSE_PREFETCH_CACHE_FILE:-${HOME}/.aidevops/logs/pulse-prefetch-cache.json}" # Delta prefetch state cache (GH#15286)
 PULSE_RATE_LIMIT_FLAG="${PULSE_RATE_LIMIT_FLAG:-${HOME}/.aidevops/logs/pulse-graphql-rate-limited.flag}"   # GH#18979: set by prefetch on detected GraphQL rate-limit exhaustion; checked by _preflight_prefetch_and_scope to abort cycle cleanly
 # Source canonical circuit-breaker threshold from conf file (GH#20638, t2768).
-# Env var takes precedence; conf supplies the default; 0.30 is the hardcoded fallback
-# if the conf file is missing (graceful degradation).
+# Existing values take precedence; the conf fills every missing default; 0.30
+# is the hardcoded fallback if the conf file is missing (graceful degradation).
 _PULSE_RL_CONF="${SCRIPT_DIR}/../configs/pulse-rate-limit.conf"
-if [[ -z "${AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD+x}" ]] && [[ -f "$_PULSE_RL_CONF" ]]; then
+if [[ -f "$_PULSE_RL_CONF" ]]; then
 	# shellcheck disable=SC1090
 	source "$_PULSE_RL_CONF"
 fi

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -179,14 +179,11 @@ fi
 # update loop (Ultimate-Multisite/gratis-ai-agent#1192).
 #
 # Precedence: env var > pulse-rate-limit.conf > hardcoded fallback (15/45).
-# Match the pattern at pulse-wrapper-config.sh:99-105 for AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD:
-# only source the conf file if the env var is unset, so an explicit env
-# override (e.g. for a slow-network runner) is never silently overwritten.
+# The config uses default-only assignments for every variable, so sourcing it
+# always fills partial configuration without replacing unrelated overrides.
 if [[ -n "$_SHARED_GH_WRAPPERS_DIR" && -f "$_SHARED_GH_WRAPPERS_DIR/../configs/pulse-rate-limit.conf" ]]; then
-	if [[ -z "${AIDEVOPS_GH_READ_TIMEOUT+x}" ]] && [[ -z "${AIDEVOPS_GH_WRITE_TIMEOUT+x}" ]]; then
-		# shellcheck disable=SC1091
-		source "$_SHARED_GH_WRAPPERS_DIR/../configs/pulse-rate-limit.conf"
-	fi
+	# shellcheck disable=SC1091
+	source "$_SHARED_GH_WRAPPERS_DIR/../configs/pulse-rate-limit.conf"
 fi
 : "${AIDEVOPS_GH_READ_TIMEOUT:=15}"
 : "${AIDEVOPS_GH_WRITE_TIMEOUT:=45}"

--- a/.agents/scripts/tests/test-pulse-rate-limit-config-precedence.sh
+++ b/.agents/scripts/tests/test-pulse-rate-limit-config-precedence.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+export HOME="${TMP_DIR}/home"
+mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/cache"
+TESTS_RUN=0
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	exit 1
+}
+
+assert_value() {
+	local actual="$1"
+	local expected="$2"
+	local label="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	[[ "$actual" == "$expected" ]] || fail "${label}: expected ${expected}, got ${actual}"
+	return 0
+}
+
+clear_rate_limit_config() {
+	unset AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD
+	unset AIDEVOPS_PULSE_REST_CORE_RESERVE
+	unset AIDEVOPS_PULSE_REST_CORE_HARD_FLOOR
+	unset AIDEVOPS_PULSE_REST_CORE_IN_FLIGHT_ALLOWANCE
+	unset AIDEVOPS_PULSE_REST_CORE_ADAPTIVE_WINDOW_SECONDS
+	unset AIDEVOPS_PULSE_REST_CORE_PROBE_TTL
+	unset AIDEVOPS_PULSE_REST_CORE_GATE_PROBE_TTL
+	unset AIDEVOPS_GH_READ_TIMEOUT
+	unset AIDEVOPS_GH_WRITE_TIMEOUT
+	unset NO_WORK_WINDOW_SECS
+	unset NO_WORK_WINDOW_MAX
+	unset PULSE_EVENTS_TICKLE_ENABLED
+	unset PULSE_BATCH_SEARCH_LAST_RESORT
+	unset AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN
+	unset AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN
+	return 0
+}
+
+assert_production_defaults() {
+	local label="$1"
+	assert_value "$AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD" "0.05" "${label} GraphQL threshold"
+	assert_value "$AIDEVOPS_PULSE_REST_CORE_RESERVE" "500" "${label} REST reserve"
+	assert_value "$AIDEVOPS_PULSE_REST_CORE_HARD_FLOOR" "100" "${label} REST hard floor"
+	assert_value "$AIDEVOPS_PULSE_REST_CORE_IN_FLIGHT_ALLOWANCE" "250" "${label} in-flight allowance"
+	assert_value "$AIDEVOPS_PULSE_REST_CORE_ADAPTIVE_WINDOW_SECONDS" "3600" "${label} adaptive window"
+	assert_value "$AIDEVOPS_PULSE_REST_CORE_PROBE_TTL" "20" "${label} probe TTL"
+	assert_value "$AIDEVOPS_PULSE_REST_CORE_GATE_PROBE_TTL" "2" "${label} gate probe TTL"
+	assert_value "$AIDEVOPS_GH_READ_TIMEOUT" "15" "${label} read timeout"
+	assert_value "$AIDEVOPS_GH_WRITE_TIMEOUT" "45" "${label} write timeout"
+	assert_value "$NO_WORK_WINDOW_SECS" "600" "${label} no-work window"
+	assert_value "$NO_WORK_WINDOW_MAX" "10" "${label} no-work maximum"
+	assert_value "$PULSE_EVENTS_TICKLE_ENABLED" "1" "${label} events tickle"
+	assert_value "$PULSE_BATCH_SEARCH_LAST_RESORT" "1" "${label} batch search mode"
+	assert_value "$AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN" "50" "${label} Actions queue minimum"
+	assert_value "$AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN" "10" "${label} Actions queue ratio"
+	return 0
+}
+
+set_explicit_overrides() {
+	export AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD=0
+	export AIDEVOPS_PULSE_REST_CORE_RESERVE=5000
+	export AIDEVOPS_PULSE_REST_CORE_HARD_FLOOR=4999
+	export AIDEVOPS_PULSE_REST_CORE_IN_FLIGHT_ALLOWANCE=1
+	export AIDEVOPS_PULSE_REST_CORE_ADAPTIVE_WINDOW_SECONDS=17
+	export AIDEVOPS_PULSE_REST_CORE_PROBE_TTL=19
+	export AIDEVOPS_PULSE_REST_CORE_GATE_PROBE_TTL=1
+	export AIDEVOPS_GH_READ_TIMEOUT=91
+	export AIDEVOPS_GH_WRITE_TIMEOUT=92
+	export NO_WORK_WINDOW_SECS=601
+	export NO_WORK_WINDOW_MAX=11
+	export PULSE_EVENTS_TICKLE_ENABLED=0
+	export PULSE_BATCH_SEARCH_LAST_RESORT=0
+	export AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN=51
+	export AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN=12
+	return 0
+}
+
+assert_explicit_overrides() {
+	local label="$1"
+	assert_value "$AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD" "0" "${label} GraphQL threshold"
+	assert_value "$AIDEVOPS_PULSE_REST_CORE_RESERVE" "5000" "${label} REST reserve"
+	assert_value "$AIDEVOPS_PULSE_REST_CORE_HARD_FLOOR" "4999" "${label} REST hard floor"
+	assert_value "$AIDEVOPS_PULSE_REST_CORE_IN_FLIGHT_ALLOWANCE" "1" "${label} in-flight allowance"
+	assert_value "$AIDEVOPS_PULSE_REST_CORE_ADAPTIVE_WINDOW_SECONDS" "17" "${label} adaptive window"
+	assert_value "$AIDEVOPS_PULSE_REST_CORE_PROBE_TTL" "19" "${label} probe TTL"
+	assert_value "$AIDEVOPS_PULSE_REST_CORE_GATE_PROBE_TTL" "1" "${label} gate probe TTL"
+	assert_value "$AIDEVOPS_GH_READ_TIMEOUT" "91" "${label} read timeout"
+	assert_value "$AIDEVOPS_GH_WRITE_TIMEOUT" "92" "${label} write timeout"
+	assert_value "$NO_WORK_WINDOW_SECS" "601" "${label} no-work window"
+	assert_value "$NO_WORK_WINDOW_MAX" "11" "${label} no-work maximum"
+	assert_value "$PULSE_EVENTS_TICKLE_ENABLED" "0" "${label} events tickle"
+	assert_value "$PULSE_BATCH_SEARCH_LAST_RESORT" "0" "${label} batch search mode"
+	assert_value "$AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN" "51" "${label} Actions queue minimum"
+	assert_value "$AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN" "12" "${label} Actions queue ratio"
+	return 0
+}
+
+clear_rate_limit_config
+# shellcheck disable=SC1090
+source "${SCRIPTS_DIR}/shared-gh-wrappers.sh"
+assert_production_defaults "shared GitHub wrapper first"
+
+set_explicit_overrides
+# shellcheck disable=SC1090
+source "${SCRIPTS_DIR}/pulse-rate-limit-circuit-breaker.sh"
+assert_explicit_overrides "circuit breaker after shared wrapper"
+
+unset AIDEVOPS_GH_WRITE_TIMEOUT
+config_get() {
+	local key="$1"
+	local fallback="$2"
+	printf '%s\n' "$fallback"
+	return 0
+}
+_validate_int() {
+	local name="$1"
+	local value="$2"
+	printf '%s\n' "$value"
+	return 0
+}
+unset _PULSE_WRAPPER_CONFIG_LOADED
+# shellcheck disable=SC1090
+source "${SCRIPTS_DIR}/pulse-wrapper-config.sh"
+assert_value "$AIDEVOPS_GH_WRITE_TIMEOUT" "45" "Pulse wrapper fills missing write timeout"
+assert_value "$AIDEVOPS_GH_READ_TIMEOUT" "91" "Pulse wrapper retains read timeout"
+assert_value "$AIDEVOPS_PULSE_REST_CORE_HARD_FLOOR" "4999" "Pulse wrapper retains hard floor"
+
+printf 'PASS: %s Pulse rate-limit config precedence assertions\n' "$TESTS_RUN"


### PR DESCRIPTION
Resolves #29766

## Summary

- make every assignment in `.agents/configs/pulse-rate-limit.conf` default-only so partial environment overrides survive repeated sourcing
- make shared GitHub, Pulse wrapper, and standalone circuit-breaker consumers source the canonical configuration consistently
- add a clean-environment consumer-order regression matrix, including `/bin/bash` re-exec coverage

## Target files and pattern

- `.agents/configs/pulse-rate-limit.conf`: `KEY=${KEY-default}` precedence contract
- `.agents/scripts/{shared-gh-wrappers,pulse-wrapper-config,pulse-rate-limit-circuit-breaker}.sh`: unconditional safe sourcing
- `.agents/scripts/tests/test-pulse-rate-limit-config-precedence.sh`: defaults, explicit overrides, and partial overrides

## Verification

- `bash .agents/scripts/tests/test-pulse-rate-limit-config-precedence.sh`
- `/bin/bash .agents/scripts/tests/test-pulse-rate-limit-config-precedence.sh`
- `shellcheck .agents/scripts/shared-gh-wrappers.sh .agents/scripts/pulse-wrapper-config.sh .agents/scripts/pulse-rate-limit-circuit-breaker.sh .agents/scripts/tests/test-pulse-rate-limit-config-precedence.sh`

Draft checkpoint: broader focused suites and changed-file lint remain in progress.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.233 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 8m and 128,414 tokens on this as a headless worker.