### PR TITLE
GH#29683: Fix linked-worktree patch authorization in OpenCode

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -329,6 +329,7 @@ export async function AidevopsPlugin({ directory, client }) {
     activeScriptsDir: join(ACTIVE_AGENTS_DIR, "scripts"),
     scriptsDir: SCRIPTS_DIR,
     logsDir: LOGS_DIR,
+    repositoryDir: directory,
     continuationGuard,
     resolveSessionModel: (sessionId) => sessionModels.resolve(sessionId),
   });

--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -243,7 +243,7 @@ function recordChildSubagent(taskId, scriptsDir, log) {
 
 /**
  * Create the quality hook functions (toolExecuteBefore, toolExecuteAfter).
- * @param {object} deps - { scriptsDir, logsDir }
+ * @param {object} deps - { scriptsDir, logsDir, repositoryDir }
  * @returns {{ toolExecuteBefore: Function, toolExecuteAfter: Function, qualityLog: Function }}
  */
 /**
@@ -255,7 +255,7 @@ function recordChildSubagent(taskId, scriptsDir, log) {
  */
 function enforceDirectFileMutationSafety(ctx, input, output) {
   if (!isDirectFileMutationTool(input.tool)) return;
-  const writeCwd = output.args?.workdir || output.args?.cwd || process.cwd();
+  const writeCwd = output.args?.workdir || output.args?.cwd || ctx.repositoryDir || process.cwd();
   const filePath = output.args?.filePath || output.args?.file_path || output.args?.path || "";
   const rawPatchText = output.args?.patchText || output.args?.patch_text || "";
   const patchText = isApplyPatchMutationTool(input.tool)
@@ -410,6 +410,7 @@ export function createQualityHooks(deps) {
     qualityLogPath,
     detailLogPath,
     detailMaxBytes,
+    repositoryDir: deps.repositoryDir,
     continuationGuard,
     resolveSessionModel: typeof deps.resolveSessionModel === "function"
       ? deps.resolveSessionModel

--- a/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs
@@ -23,6 +23,7 @@ import {
   checkCommandSafetyGate,
   isDirectFileMutationTool,
 } from "../quality-hooks-git-safety.mjs";
+import { createQualityHooks } from "../quality-hooks.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const scriptsDir = join(here, "..", "..", "..", "scripts");
@@ -102,6 +103,33 @@ test("classifies every apply-patch target instead of trusting linked cwd", () =>
     assert.throws(
       () => checkCanonicalWriteSafetyGate("", scriptsDir, repo, mixedPatch),
       /canonical write policy.*read-only session mirrors/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("uses the plugin repository directory when mutation tools omit workdir", async () => {
+  const { root, repo, linked } = setupRepo();
+  try {
+    const hooks = createQualityHooks({ scriptsDir, logsDir: root, repositoryDir: repo });
+    const linkedPatch = `*** Begin Patch\n*** Add File: ${join(linked, "plugin-context.md")}\n+safe\n*** End Patch\n`;
+    await assert.doesNotReject(
+      () => hooks.toolExecuteBefore(
+        { tool: "functions.apply_patch" },
+        { args: { patchText: linkedPatch } },
+      ),
+      "the plugin project directory must establish same-repository linked-worktree identity",
+    );
+
+    const canonicalPatch = "*** Begin Patch\n*** Update File: README.md\n@@\n-seed\n+unsafe\n*** End Patch\n";
+    await assert.rejects(
+      () => hooks.toolExecuteBefore(
+        { tool: "functions.apply_patch" },
+        { args: { patchText: canonicalPatch } },
+      ),
+      /canonical write policy.*read-only session mirrors/,
+      "relative mutation targets must resolve from the plugin project directory",
     );
   } finally {
     rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Thread the plugin-supplied project directory into quality hooks so workdir-less mutations classify relative and linked targets against the authoritative OpenCode project instead of process.cwd(); add adapter-level regression coverage.

## Files Changed

.agents/plugins/opencode-aidevops/index.mjs, .agents/plugins/opencode-aidevops/quality-hooks.mjs, .agents/plugins/opencode-aidevops/tests/test-git-safety-gate.mjs

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — node safety tests: 23 passed; Python git safety guard: 20 passed; OpenCode plugin suite: 603 passed; changed-file linters passed

Resolves #29683


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.233 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 7h 32m and 5,711,250 tokens on this with the user in an interactive session.