### PR TITLE
GH#28223: Fix metadata-sensitive absolute Qlty scans

### DIFF
--- a/.agents/scripts/qlty-smell-threshold-helper.sh
+++ b/.agents/scripts/qlty-smell-threshold-helper.sh
@@ -8,6 +8,9 @@ set -u
 
 SCRIPT_NAME=$(basename "$0")
 UNKNOWN_VALUE="unknown"
+SCAN_GIT_BIN=""
+SCAN_TMP=""
+SCAN_DIR=""
 
 log() {
 	local _msg="$1"
@@ -25,6 +28,57 @@ find_qlty() {
 		return 0
 	fi
 	return 1
+}
+
+resolve_git() {
+	local _candidate=""
+	if [ -n "${AIDEVOPS_REAL_GIT_BIN:-}" ] && [ -x "$AIDEVOPS_REAL_GIT_BIN" ]; then
+		printf '%s\n' "$AIDEVOPS_REAL_GIT_BIN"
+		return 0
+	fi
+	while IFS= read -r _candidate; do
+		case "$_candidate" in
+		*/.aidevops/*/agents/scripts/git | */.aidevops/agents/scripts/git | */.aidevops/bin/git | */.agents/scripts/git) continue ;;
+		esac
+		printf '%s\n' "$_candidate"
+		return 0
+	done < <(type -a -p git 2>/dev/null || true)
+	return 1
+}
+
+create_scan_clone() {
+	local _destination="$1"
+	local _sha="$2"
+	local _repo_root="$3"
+	local _git_bin="$4"
+	"$_git_bin" clone --quiet --shared --no-checkout "$_repo_root" "$_destination" || return 1
+	"$_git_bin" -C "$_destination" checkout --detach --quiet "$_sha" || return 1
+	return 0
+}
+
+prepare_scan_clone() {
+	local _repo_root=""
+	local _head_sha=""
+	SCAN_GIT_BIN=$(resolve_git) || {
+		printf '::error::native git executable not found\n'
+		return 1
+	}
+	_repo_root=$("$SCAN_GIT_BIN" rev-parse --show-toplevel 2>/dev/null) || {
+		printf '::error::repository root not found for isolated qlty scan\n'
+		return 1
+	}
+	_head_sha=$("$SCAN_GIT_BIN" rev-parse HEAD 2>/dev/null) || {
+		printf '::error::HEAD not found for isolated qlty scan\n'
+		return 1
+	}
+	SCAN_TMP=$(mktemp -d "${TMPDIR:-/tmp}/qlty-smell-scan.XXXXXX") || return 1
+	SCAN_DIR="$SCAN_TMP/repository"
+	if ! create_scan_clone "$SCAN_DIR" "$_head_sha" "$_repo_root" "$SCAN_GIT_BIN"; then
+		rm -rf "$SCAN_TMP"
+		printf '::error::failed to create isolated qlty scan clone\n'
+		return 1
+	fi
+	return 0
 }
 
 qlty_version() {
@@ -48,14 +102,16 @@ verify_qlty_version() {
 emit_valid_scan_metadata() {
 	local _qlty_version="$1"
 	local _sarif="$2"
+	local _scan_dir="$3"
+	local _git_bin="$4"
 	local _commit="$UNKNOWN_VALUE"
 	local _tree="$UNKNOWN_VALUE"
 	local _config="none"
-	local _mode="${QLTY_SCAN_MODE:-direct-checkout}"
+	local _mode="${QLTY_SCAN_MODE:-isolated-clone}"
 	local _count="0"
-	_commit=$(git rev-parse HEAD 2>/dev/null) || _commit="$UNKNOWN_VALUE"
-	_tree=$(git rev-parse 'HEAD^{tree}' 2>/dev/null) || _tree="$UNKNOWN_VALUE"
-	if [ -f .qlty/qlty.toml ]; then
+	_commit=$("$_git_bin" -C "$_scan_dir" rev-parse HEAD 2>/dev/null) || _commit="$UNKNOWN_VALUE"
+	_tree=$("$_git_bin" -C "$_scan_dir" rev-parse 'HEAD^{tree}' 2>/dev/null) || _tree="$UNKNOWN_VALUE"
+	if [ -f "$_scan_dir/.qlty/qlty.toml" ]; then
 		_config=".qlty/qlty.toml"
 	fi
 	_count=$(printf '%s\n' "$_sarif" | jq '.runs[0].results | length')
@@ -167,15 +223,17 @@ run_threshold_check() {
 	local _conf="${1:-.agents/configs/complexity-thresholds.conf}"
 	local _threshold=""
 	local _qlty_bin=""
+	local _git_bin=""
 	local _cache_dir=""
 	local _diag_file=""
 	local _warmup_file=""
+	local _scan_tmp=""
+	local _scan_dir=""
 	local _sarif=""
 	local _count=""
 	local _headroom=""
 	local _qlty_rc="0"
 	local _qlty_version=""
-
 	_threshold=$(read_threshold "$_conf")
 	if [ "$_threshold" -eq 0 ]; then
 		printf '::warning::QLTY_SMELL_THRESHOLD not set in %s — skipping check\n' "$_conf"
@@ -189,41 +247,55 @@ run_threshold_check() {
 	_qlty_version=$(qlty_version "$_qlty_bin")
 	verify_qlty_version "$_qlty_version" || return 1
 
+	printf 'Creating standalone clone for authoritative qlty scan...\n'
+	prepare_scan_clone || return 1
+	_git_bin="$SCAN_GIT_BIN"
+	_scan_tmp="$SCAN_TMP"
+	_scan_dir="$SCAN_DIR"
 	printf 'Warming isolated qlty cache before authoritative scan...\n'
-	_diag_file=$(mktemp "${TMPDIR:-/tmp}/qlty-smell-threshold.XXXXXX") || return 1
+	_diag_file=$(mktemp "${TMPDIR:-/tmp}/qlty-smell-threshold.XXXXXX") || {
+		rm -rf "$_scan_tmp"
+		return 1
+	}
 	_warmup_file=$(mktemp "${TMPDIR:-/tmp}/qlty-smell-warmup.XXXXXX") || {
 		rm -f "$_diag_file"
+		rm -rf "$_scan_tmp"
 		return 1
 	}
 	_cache_dir=$(mktemp -d "${TMPDIR:-/tmp}/qlty-smell-cache.XXXXXX") || {
 		rm -f "$_diag_file" "$_warmup_file"
+		rm -rf "$_scan_tmp"
 		return 1
 	}
-	XDG_CACHE_HOME="$_cache_dir" "$_qlty_bin" smells --all --sarif --no-snippets --quiet \
+	(cd "$_scan_dir" && XDG_CACHE_HOME="$_cache_dir" "$_qlty_bin" smells --all --sarif --no-snippets --quiet) \
 		>"$_warmup_file" 2>/dev/null || true
 	printf 'Counting total qlty smells across all files...\n'
-	_sarif=$(XDG_CACHE_HOME="$_cache_dir" "$_qlty_bin" smells --all --sarif --no-snippets --quiet 2>"$_diag_file")
+	_sarif=$(cd "$_scan_dir" && XDG_CACHE_HOME="$_cache_dir" "$_qlty_bin" smells --all --sarif --no-snippets --quiet 2>"$_diag_file")
 	_qlty_rc=$?
 	rm -f "$_warmup_file"
 	rm -rf "$_cache_dir"
 	if is_blank_output "$_sarif"; then
 		emit_sarif_warning "empty" "$_diag_file" "$_qlty_bin" "" "$_qlty_rc"
 		rm -f "$_diag_file"
+		rm -rf "$_scan_tmp"
 		return 0
 	fi
 	if ! is_valid_sarif_results "$_sarif"; then
 		emit_sarif_warning "invalid" "$_diag_file" "$_qlty_bin" "$_sarif" "$_qlty_rc"
 		rm -f "$_diag_file"
+		rm -rf "$_scan_tmp"
 		return 0
 	fi
 	rm -f "$_diag_file"
 
 	_count=$(printf '%s\n' "$_sarif" | jq '.runs[0].results | length' 2>/dev/null || true)
 	if ! is_non_negative_integer "$_count"; then
+		rm -rf "$_scan_tmp"
 		printf '::error::Failed to parse smell count from SARIF output\n'
 		return 1
 	fi
-	emit_valid_scan_metadata "$_qlty_version" "$_sarif"
+	emit_valid_scan_metadata "$_qlty_version" "$_sarif" "$_scan_dir" "$_git_bin"
+	rm -rf "$_scan_tmp"
 
 	printf '\n'
 	printf 'Total qlty smells: %s\n' "$_count"

--- a/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
+++ b/.agents/scripts/tests/test-qlty-smell-threshold-helper.sh
@@ -107,6 +107,14 @@ case "${QLTY_STUB_MODE:-empty}" in
 		fi
 		exit 0
 		;;
+	topology-sensitive)
+		if [ -d .git ]; then
+			printf '{"runs":[{"results":[{"ruleId":"file-complexity","locations":[{"physicalLocation":{"artifactLocation":{"uri":"stable.py"}}}]}]}]}'
+		else
+			printf '{"runs":[{"results":[{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"direct-a.py"}}}]},{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"direct-b.py"}}}]},{"ruleId":"qlty:similar-code","locations":[{"physicalLocation":{"artifactLocation":{"uri":"direct-c.py"}}}]}]}]}'
+		fi
+		exit 0
+		;;
 	fail)
 		printf '{"runs":[{"results":[{"ruleId":"file-complexity","locations":[{"physicalLocation":{"artifactLocation":{"uri":"a.py"}}}]},{"ruleId":"function-complexity","locations":[{"physicalLocation":{"artifactLocation":{"uri":"b.py"}}}]},{"ruleId":"function-complexity","locations":[{"physicalLocation":{"artifactLocation":{"uri":"b.py"}}}]}]}]}'
 		exit 0
@@ -183,7 +191,7 @@ pass_rc=$?
 assert_rc "valid SARIF below threshold passes" "0" "$pass_rc"
 assert_contains "valid SARIF reports headroom" "Within threshold" "$pass_output"
 assert_contains "valid SARIF reports qlty version" "Qlty version: qlty test-stub" "$pass_output"
-assert_contains "valid SARIF reports scan mode" "Scan mode: direct-checkout" "$pass_output"
+assert_contains "valid SARIF reports scan mode" "Scan mode: isolated-clone" "$pass_output"
 assert_contains "valid SARIF reports logical root" "Scan root: repository-root" "$pass_output"
 assert_contains "valid SARIF reports normalized count" "Normalized result count: 1" "$pass_output"
 assert_contains "valid SARIF reports per-rule counts" $'  1\tfile-complexity' "$pass_output"
@@ -200,6 +208,14 @@ repeated_cache_output=$($HELPER "$CONF" 2>&1)
 repeated_cache_rc=$?
 assert_rc "repeated isolated-cache scan remains stable" "0" "$repeated_cache_rc"
 assert_contains "repeated scan retains stable count" "Normalized result count: 1" "$repeated_cache_output"
+
+write_stub_qlty topology-sensitive "$BIN_DIR"
+topology_sensitive_output=$($HELPER "$CONF" 2>&1)
+topology_sensitive_rc=$?
+assert_rc "direct-checkout-only similar-code findings do not affect the gate" "0" "$topology_sensitive_rc"
+assert_contains "absolute scan uses standalone clone topology" "Creating standalone clone" "$topology_sensitive_output"
+assert_contains "standalone clone retains stable count" "Normalized result count: 1" "$topology_sensitive_output"
+assert_not_contains "direct-checkout-only identities are excluded" "direct-a.py" "$topology_sensitive_output"
 
 write_stub_qlty fail "$BIN_DIR"
 fail_output=$("$HELPER" "$CONF" 2>&1)


### PR DESCRIPTION
## Summary

Run the absolute Qlty threshold scan in a standalone shared clone so its topology matches the deterministic regression gate and metadata-only release commits cannot introduce direct-checkout-only duplicate findings.

## Files Changed

.agents/scripts/qlty-smell-threshold-helper.sh, .agents/scripts/tests/test-qlty-smell-threshold-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 47 absolute-helper assertions and 27 regression-helper assertions pass; ShellCheck and changed strict lint pass; Qlty 0.636.0 reports 49 findings at the unchanged threshold of 49 on the exact committed head.

Resolves #28223


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.234 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 11m and 143,113 tokens on this with the user in an interactive session.