### PR TITLE
GH#29775: Fix Cloudron release monitoring schedule

### DIFF
--- a/.agents/scripts/cloudron-package-monitor-helper.sh
+++ b/.agents/scripts/cloudron-package-monitor-helper.sh
@@ -48,7 +48,7 @@ _cloudron_monitor_fetch_releases() {
 	local endpoint="/repos/${upstream_slug}/releases?per_page=100"
 	local response=""
 	local api_rc=0
-	response=$(_gh_with_timeout read gh api -i "$endpoint" --paginate 2>/dev/null) || api_rc=$?
+	response=$(_gh_with_timeout read gh api -i "$endpoint" --paginate --jq '.' 2>/dev/null) || api_rc=$?
 	if [[ "$api_rc" -eq 75 ]] || _gh_secondary_cooldown_active; then
 		_cloudron_monitor_deferred
 		return $?
@@ -57,7 +57,16 @@ _cloudron_monitor_fetch_releases() {
 		_cloudron_monitor_error "Could not fetch paginated GitHub releases for $upstream_slug."
 		return 1
 	fi
-	_cloudron_monitor_response_bodies "$response"
+	if ! _cloudron_monitor_response_bodies "$response" | jq -sc '
+		if all(.[]; type == "array") then
+			add // []
+		else
+			error("expected release page arrays")
+		end
+	'; then
+		_cloudron_monitor_error "Could not normalize paginated GitHub releases for $upstream_slug."
+		return 1
+	fi
 	return 0
 }
 

--- a/.agents/scripts/routines/core-routines.sh
+++ b/.agents/scripts/routines/core-routines.sh
@@ -31,7 +31,7 @@ r912| |Dashboard server|repeat:persistent|~0s|server/index.ts|service
 r913|x|Weekly opencode DB maintenance|repeat:weekly(sun@04:00)|~2m|scripts/opencode-db-maintenance-helper.sh auto|script
 r914|x|Repo aidevops health — bump stale .aidevops.json, detect drift|repeat:daily(@03:30)|~2m|scripts/repo-aidevops-health-helper.sh run|script
 r915|x|Pulse check — worker utilisation and self-improvement recommendations|repeat:daily(@06:20)|~5m|scripts/pulse-check-helper.sh apply|script
-r916|x|Cloudron packages — check upstream releases|repeat:daily(@00:30)|~2m|scripts/cloudron-package-monitor-helper.sh upstream --apply|script|UTC
+r916|x|Cloudron packages — check upstream releases|repeat:daily(@01:30)|~2m|scripts/cloudron-package-monitor-helper.sh upstream --apply|script|UTC
 r917|x|Cloudron packages — audit compatibility|repeat:weekly(sun@07:40)|~5m|scripts/cloudron-package-monitor-helper.sh compatibility --apply|script
 ENTRIES
 	return 0
@@ -924,21 +924,21 @@ describe_r916() {
 
 ## Overview
 
-Daily read-only comparison of registered Cloudron package upstream versions at 00:30 UTC.
+Daily read-only comparison of registered Cloudron package upstream versions at 01:30 UTC.
 New releases become deduplicated, worker-ready issues in the package repository.
 
 ## Schedule
 
 | Field | Value |
 |-------|-------|
-| Frequency | Daily at 00:30 UTC |
+| Frequency | Daily at 01:30 UTC |
 | Type | script |
 | Expected duration | ~2 minutes |
 | Script | \`scripts/cloudron-package-monitor-helper.sh upstream --apply\` |
-$(_scheduler_row_pulse "repeat:daily(@00:30) timezone:UTC")
+$(_scheduler_row_pulse "repeat:daily(@01:30) timezone:UTC")
 
 Pulse reads the enabled routine from registered \`TODO.md\` files and evaluates
-the version-controlled \`repeat:daily(@00:30) timezone:UTC\` contract; r916 has no
+the version-controlled \`repeat:daily(@01:30) timezone:UTC\` contract; r916 has no
 dedicated platform unit.
 
 ## Safety rails

--- a/.agents/scripts/tests/test-cloudron-package-monitor.sh
+++ b/.agents/scripts/tests/test-cloudron-package-monitor.sh
@@ -44,6 +44,7 @@ if [[ "${1:-}" == "api" && "$*" == *releases\?per_page=100* ]]; then
         [[ "$arg" == /repos/*/releases\?per_page=100 ]] && endpoint="$arg"
     done
     printf 'API %s\n' "$endpoint" >>"${MONITOR_API_LOG:-/dev/null}"
+    printf 'ARGS %s\n' "$*" >>"${MONITOR_API_LOG:-/dev/null}"
     case "${MONITOR_RATE_FIXTURE:-}" in
         primary-403-reset)
             printf 'HTTP/2 403\r\nX-RateLimit-Remaining: 0\r\nX-RateLimit-Reset: 9999999999\r\n\r\n{"message":"API rate limit exceeded"}\n'
@@ -191,16 +192,18 @@ test_monitor_deduplicates_and_preserves_source() {
 	local repo_dir="${TEST_ROOT}/package"
 	local bin_dir="${TEST_ROOT}/bin"
 	local log_file="${TEST_ROOT}/issues.log"
+	local api_log="${TEST_ROOT}/api.log"
 	write_fake_commands "$bin_dir"
 	write_fixture "$home_dir" "$repo_dir"
 	local manifest_before=""
 	manifest_before=$(cksum "${repo_dir}/CloudronManifest.json")
 
-	HOME="$home_dir" PATH="${bin_dir}:$PATH" MONITOR_TEST_LOG="$log_file" CLOUDRON_PACKAGE_ISSUE_WRAPPER="${bin_dir}/gh_create_issue" bash "$HELPER" upstream --apply >/dev/null
-	HOME="$home_dir" PATH="${bin_dir}:$PATH" MONITOR_TEST_LOG="$log_file" CLOUDRON_PACKAGE_ISSUE_WRAPPER="${bin_dir}/gh_create_issue" bash "$HELPER" upstream --apply >/dev/null
+	HOME="$home_dir" PATH="${bin_dir}:$PATH" MONITOR_TEST_LOG="$log_file" MONITOR_API_LOG="$api_log" CLOUDRON_PACKAGE_ISSUE_WRAPPER="${bin_dir}/gh_create_issue" bash "$HELPER" upstream --apply >/dev/null
+	HOME="$home_dir" PATH="${bin_dir}:$PATH" MONITOR_TEST_LOG="$log_file" MONITOR_API_LOG="$api_log" CLOUDRON_PACKAGE_ISSUE_WRAPPER="${bin_dir}/gh_create_issue" bash "$HELPER" upstream --apply >/dev/null
 	assert_equal 1 "$(grep -c '^CALL exampleorg/example-package$' "$log_file")" "new upstream release creates one target-local issue"
 	assert_equal 1 "$(grep -c '^TITLE Example Package upstream v2.0.0 is available$' "$log_file")" "upstream issue title uses package manifest title"
 	grep -Fq 'upstream-v2.0.0' "$log_file" && assert_equal true true "upstream issue carries stable fingerprint" || assert_equal true false "upstream issue carries stable fingerprint"
+	grep -Fq -- '--paginate --jq .' "$api_log" && assert_equal true true "paginated release reads request page-delimited JSON" || assert_equal true false "paginated release reads request page-delimited JSON"
 	assert_equal "$manifest_before" "$(cksum "${repo_dir}/CloudronManifest.json")" "upstream monitor does not mutate manifest"
 
 	HOME="$home_dir" PATH="${bin_dir}:$PATH" MONITOR_TEST_LOG="$log_file" CLOUDRON_PACKAGE_ISSUE_WRAPPER="${bin_dir}/gh_create_issue" bash "$HELPER" compatibility --apply >/dev/null

--- a/.agents/scripts/tests/test-cloudron-package-routines.sh
+++ b/.agents/scripts/tests/test-cloudron-package-routines.sh
@@ -51,7 +51,7 @@ main() {
 	source "$CORE_ROUTINES"
 	local entries=""
 	entries=$(get_core_routine_entries)
-	assert_contains "$entries" 'r916|x|Cloudron packages — check upstream releases|repeat:daily(@00:30)|~2m|scripts/cloudron-package-monitor-helper.sh upstream --apply|script|UTC' "daily UTC upstream routine registered"
+	assert_contains "$entries" 'r916|x|Cloudron packages — check upstream releases|repeat:daily(@01:30)|~2m|scripts/cloudron-package-monitor-helper.sh upstream --apply|script|UTC' "daily UTC upstream routine registered"
 	assert_contains "$entries" 'r917|x|Cloudron packages — audit compatibility|repeat:weekly(sun@07:40)|~5m|scripts/cloudron-package-monitor-helper.sh compatibility --apply|script' "weekly compatibility routine registered"
 	local r916_description=""
 	local r917_description=""
@@ -60,8 +60,8 @@ main() {
 	assert_contains "$r916_description" 'cloudron-package-monitor-helper.sh upstream --apply' "r916 description exposes exact command"
 	assert_contains "$r917_description" 'cloudron-package-monitor-helper.sh compatibility --apply' "r917 description exposes exact command"
 	# shellcheck disable=SC2016  # Markdown backticks are literal expected output.
-	assert_contains "$r916_description" 'Supervisor Pulse evaluates version-controlled `repeat:daily(@00:30) timezone:UTC`' "r916 exposes full UTC scheduling contract"
-	assert_contains "$r916_description" 'Daily at 00:30 UTC' "r916 describes its fixed UTC schedule"
+	assert_contains "$r916_description" 'Supervisor Pulse evaluates version-controlled `repeat:daily(@01:30) timezone:UTC`' "r916 exposes full UTC scheduling contract"
+	assert_contains "$r916_description" 'Daily at 01:30 UTC' "r916 describes its fixed UTC schedule"
 	# shellcheck disable=SC2016  # Markdown backticks are literal expected output.
 	assert_contains "$r917_description" 'Supervisor Pulse evaluates version-controlled `repeat:weekly(sun@07:40)`' "r917 names Pulse as scheduler"
 	assert_contains "$r916_description" 'systemctl --user status sh.aidevops.pulse' "r916 exposes shared Pulse diagnostics"
@@ -78,7 +78,7 @@ main() {
 	local r917_line=""
 	generated_todo=$(<"${TEST_ROOT}/TODO.md")
 	r917_line=$(printf '%s\n' "$generated_todo" | grep '^- \[x\] r917 ')
-	assert_contains "$generated_todo" '- [x] r916 Cloudron packages — check upstream releases repeat:daily(@00:30) timezone:UTC ~2m run:scripts/cloudron-package-monitor-helper.sh upstream --apply' "generated r916 TODO line places UTC after repeat expression"
+	assert_contains "$generated_todo" '- [x] r916 Cloudron packages — check upstream releases repeat:daily(@01:30) timezone:UTC ~2m run:scripts/cloudron-package-monitor-helper.sh upstream --apply' "generated r916 TODO line places UTC after repeat expression"
 	assert_not_contains "$r917_line" 'timezone:' "generated routines without overrides remain timezone-free"
 	assert_contains "$generated_todo" 'timezone: -- optional per-routine IANA timezone override' "generated TODO header documents timezone field"
 	printf '\nRan %d tests, %d failed.\n' "$((PASSED + FAILED))" "$FAILED"

--- a/.agents/tools/deployment/cloudron-app-packaging.md
+++ b/.agents/tools/deployment/cloudron-app-packaging.md
@@ -318,7 +318,7 @@ changelog entry, and the exact pinned final Cloudron base image.
 Core routines provide ongoing reporting:
 
 - `r916` runs `cloudron-package-monitor-helper.sh upstream --apply` daily at
-  `00:30 UTC` using its version-controlled per-routine timezone override.
+  `01:30 UTC` using its version-controlled per-routine timezone override.
 - `r917` runs `cloudron-package-monitor-helper.sh compatibility --apply` weekly.
 
 Both routines deduplicate package-local issues, require maintainer-equivalent

--- a/TODO.md
+++ b/TODO.md
@@ -1240,6 +1240,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t18215 Prefer aidevops options in recommendations ref:GH#29751 pr:#29754 completed:2026-08-07
 
+- [ ] t18218 Move Cloudron monitor later and repair paginated release reads #bug ref:GH#29775
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

- normalize paginated GitHub release pages before Cloudron upstream comparison
- retain response headers for rate-limit cooldown diagnostics
- move r916 from 00:30 UTC to 01:30 UTC and update generated schedule contracts

## Evidence

The deployed r916 routine recorded 37 consecutive failures because `gh api -i --paginate` concatenated page arrays into invalid JSON. The corrected command emits one JSON document per page, and a live two-page Buzz release read normalized 109 releases with `desktop-v0.5.7` first.

## Verification

```bash
bash .agents/scripts/tests/test-cloudron-package-monitor.sh
bash .agents/scripts/tests/test-cloudron-package-routines.sh
shellcheck .agents/scripts/cloudron-package-monitor-helper.sh .agents/scripts/routines/core-routines.sh .agents/scripts/tests/test-cloudron-package-monitor.sh .agents/scripts/tests/test-cloudron-package-routines.sh
git diff --check
```

Resolves #29775

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.234 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 19m and 181,742 tokens on this with the user in an interactive session.