### PR TITLE
GH#29405: Restore strict broad-ratchet schema compatibility

### DIFF
--- a/.agents/configs/ratchets.json
+++ b/.agents/configs/ratchets.json
@@ -1,32 +1,60 @@
 {
-  "version": 1,
-  "updated": "2026-04-04T00:00:00Z",
-  "description": "Ratchet baselines for code quality regression prevention. Counts can only stay the same or decrease — never increase. Run linters-local.sh --update-baseline to lock in improvements.",
+  "version": 2,
+  "counter_version": 2,
+  "updated": "2026-08-08T00:13:09Z",
+  "description": "Compatibility snapshot with verified provenance; active checks compare the working tree with its default-branch merge-base.",
+  "comparison": {
+    "mode": "merge-base",
+    "fail_closed_without_base": true
+  },
+  "provenance": {
+    "source_commit": "9fa629d359df6059f370908864378b1ff183b60c",
+    "scripts_tree": "3b9fff748b128a289f8ddfba5cb1c775d752e6c5",
+    "comparison_base_commit": "9fa629d359df6059f370908864378b1ff183b60c",
+    "migration": {
+      "reason": "Migrate the 2026-04-04 schema-v1 compatibility snapshot after PR #29407 introduced counter-v2 merge-base comparisons; preserve the historical counts while binding current compatibility counts to the verified default-branch scripts tree.",
+      "previous_source_commit": "441813092cdcfa97b172953d890c1a063eb0e421",
+      "previous_schema_version": 1,
+      "previous_counter_version": 1
+    },
+    "previous_snapshot": {
+      "schema_version": 1,
+      "counter_version": 1,
+      "source_commit": "441813092cdcfa97b172953d890c1a063eb0e421",
+      "updated": "2026-04-04T00:00:00Z",
+      "counts": {
+        "bare_positional_params": 4687,
+        "hardcoded_aidevops_path": 309,
+        "broad_catch_or_true": 2233,
+        "silent_errors": 5589,
+        "missing_return_files": 2
+      }
+    }
+  },
   "ratchets": {
     "bare_positional_params": {
-      "count": 4687,
-      "description": "$1/$2 etc. used directly in function bodies (should use local var=\"$1\")",
-      "pattern": "\\$[1-9]",
-      "exclude": "local.*=.*\\$[1-9]"
+      "count": 4776,
+      "description": "Direct positional parameters in function bodies",
+      "pattern": "positional_parameter"
     },
     "hardcoded_aidevops_path": {
-      "count": 309,
-      "description": "Literal ~/.aidevops or /Users/ instead of ${HOME}/.aidevops or variable",
-      "pattern": "~/.aidevops|/Users/"
+      "count": 452,
+      "description": "Literal user-specific framework paths",
+      "pattern": "hardcoded_user_path"
     },
     "broad_catch_or_true": {
-      "count": 2233,
-      "description": "|| true used to suppress errors without specific handling",
-      "pattern": "\\|\\| true"
+      "count": 8171,
+      "description": "Broad success fallback",
+      "pattern": "broad_success_fallback"
     },
     "silent_errors": {
-      "count": 5589,
-      "description": "2>/dev/null used to silently discard errors without handling",
-      "pattern": "2>/dev/null"
+      "count": 16455,
+      "description": "Discarded standard error",
+      "pattern": "discarded_standard_error"
     },
     "missing_return_files": {
-      "count": 2,
-      "description": "Files containing functions without explicit return 0 or return 1",
+      "count": 427,
+      "description": "Files containing a function without an explicit return",
       "pattern": "functions_without_return"
     }
   }

--- a/.agents/scripts/tests/test-linters-local-ratchet-timeout.sh
+++ b/.agents/scripts/tests/test-linters-local-ratchet-timeout.sh
@@ -154,8 +154,8 @@ test_each_ratchet_blocks_regression_and_allows_improvement() {
 		regressed_count=$(ratchet_fixture_count "$pattern_name" "${tmp_dir}/${pattern_name}/regressed")
 		regression_rc=0
 		improvement_rc=0
-		_ratchet_check_pattern "$pattern_name" "$regressed_count" "$clean_count" 0 true > /dev/null 2>&1 || regression_rc=$?
-		_ratchet_check_pattern "$pattern_name" "$clean_count" "$regressed_count" 0 true > /dev/null 2>&1 || improvement_rc=$?
+		_ratchet_check_pattern "$pattern_name" "$regressed_count" "$clean_count" 0 true >/dev/null 2>&1 || regression_rc=$?
+		_ratchet_check_pattern "$pattern_name" "$clean_count" "$regressed_count" 0 true >/dev/null 2>&1 || improvement_rc=$?
 		if [[ "$clean_count" -eq 0 && "$regressed_count" -eq 1 && "$regression_rc" -eq 1 && "$improvement_rc" -eq 0 ]]; then
 			print_result "ratchet delta: ${pattern_name} blocks +1 and permits -1" 0
 		else
@@ -167,11 +167,47 @@ test_each_ratchet_blocks_regression_and_allows_improvement() {
 	return 0
 }
 
+test_schema_one_snapshot_migrates_with_provenance() {
+	source_ratchet_helpers
+	local tmp_dir old_file migrated_file migration_json migrated_json old_rc=0 migrated_rc=0
+	tmp_dir=$(mktemp -d)
+	old_file="${tmp_dir}/schema-v1.json"
+	migrated_file="${tmp_dir}/schema-v2.json"
+	printf '%s\n' '{"version":1,"ratchets":{"bare_positional_params":{"count":4}}}' >"$old_file"
+	_ratchet_validate_baseline_config "$old_file" >/dev/null 2>&1 || old_rc=$?
+	migration_json='{"reason":"verified fixture migration","previous_source_commit":"old-source","previous_schema_version":1,"previous_counter_version":1}'
+	migrated_json=$(_ratchet_build_baseline_json \
+		"2026-08-08T00:00:00Z" "new-source" "scripts-tree" "base-source" \
+		"5 4 3 2 1" "1" "1" "old-source" "2026-04-04T00:00:00Z" \
+		"4 3 2 1 0" "$migration_json") || migrated_rc=$?
+	if [[ "$migrated_rc" -eq 0 ]]; then
+		_ratchet_write_json_atomically "$migrated_file" "$migrated_json" || migrated_rc=$?
+	fi
+	if [[ "$migrated_rc" -eq 0 ]]; then
+		_ratchet_validate_baseline_config "$migrated_file" >/dev/null 2>&1 || migrated_rc=$?
+	fi
+	if [[ "$old_rc" -eq 1 && "$migrated_rc" -eq 0 ]] && jq -e '
+		.version == 2 and .counter_version == 2 and
+		.provenance.source_commit == "new-source" and
+		.provenance.previous_snapshot.schema_version == 1 and
+		.provenance.previous_snapshot.counts.bare_positional_params == 4 and
+		.provenance.migration.reason == "verified fixture migration"
+	' "$migrated_file" >/dev/null; then
+		print_result "ratchet migration: schema-v1 snapshot becomes validated schema-v2 provenance" 0
+	else
+		print_result "ratchet migration: schema-v1 snapshot becomes validated schema-v2 provenance" 1 \
+			"old_rc=$old_rc migrated_rc=$migrated_rc"
+	fi
+	rm -rf "$tmp_dir"
+	return 0
+}
+
 main() {
 	test_ratchet_counter_times_out_with_diagnostic
 	test_ratchet_counter_reports_progress_and_value
 	test_missing_return_counter_scans_inventory_once
 	test_each_ratchet_blocks_regression_and_allows_improvement
+	test_schema_one_snapshot_migrates_with_provenance
 
 	echo ""
 	if [ "$TESTS_FAILED" -eq 0 ]; then


### PR DESCRIPTION
## Summary

Migrate ratchets.json from schema 1 to the schema-2/counter-2 provenance contract introduced by PR #29407, preserving the April snapshot and binding compatibility counts to the verified current main scripts tree.

## Files Changed

.agents/configs/ratchets.json, .agents/scripts/tests/test-linters-local-ratchet-timeout.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — All 9 focused ratchet tests, 10 changed-mode tests, and 9 pre-commit ratchet tests pass; ShellCheck, shfmt, changed strict lint, and full strict lint pass; full strict reports all five broad ratchets unchanged against merge base 9fa629d.

Resolves #29405


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.234 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 34m and 206,580 tokens on this with the user in an interactive session.