### PR TITLE
GH#29777: Make Buzz OpenCode ACP compatibility release-independent

### DIFF
--- a/.agents/bin/opencode-acp
+++ b/.agents/bin/opencode-acp
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Stable Buzz Desktop launcher for OpenCode's ACP server mode.
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+self_path="${BASH_SOURCE[0]}"
+opencode_real=""
+path_candidate=""
+
+if [[ -n "${AIDEVOPS_OPENCODE_REAL:-}" ]]; then
+	opencode_real="$AIDEVOPS_OPENCODE_REAL"
+else
+	path_candidate="$(command -v opencode 2>/dev/null || true)"
+	for candidate in "$path_candidate" /opt/homebrew/bin/opencode /usr/local/bin/opencode "${HOME}/.local/bin/opencode"; do
+		[[ -n "$candidate" && -x "$candidate" ]] || continue
+		[[ "$candidate" -ef "$self_path" ]] && continue
+		opencode_real="$candidate"
+		break
+	done
+fi
+
+if [[ -z "$opencode_real" || ! -x "$opencode_real" || "$opencode_real" -ef "$self_path" ]]; then
+	printf 'opencode-acp: unable to resolve a non-self OpenCode executable\n' >&2
+	exit 127
+fi
+
+if [[ "${1:-}" == "acp" ]]; then
+	exec "$opencode_real" "$@"
+fi
+exec "$opencode_real" acp "$@"

--- a/.agents/scripts/buzz-desktop-helper.sh
+++ b/.agents/scripts/buzz-desktop-helper.sh
@@ -16,8 +16,14 @@ BUZZ_STATE_DIR="${AIDEVOPS_BUZZ_STATE_DIR:-${HOME}/.aidevops/state}"
 BUZZ_STATE_FILE="${AIDEVOPS_BUZZ_STATE_FILE:-${BUZZ_STATE_DIR}/buzz-opencode-acp-fix.json}"
 BUZZ_BACKUP_DIR="${AIDEVOPS_BUZZ_BACKUP_DIR:-${HOME}/.aidevops/buzz-backups}"
 BUZZ_LOCK_DIR="${AIDEVOPS_BUZZ_LOCK_DIR:-${HOME}/.aidevops/locks/buzz-opencode-acp-fix.lock}"
+BUZZ_WRAPPER_PATH="${AIDEVOPS_BUZZ_WRAPPER_PATH:-${HOME}/.aidevops/bin/opencode-acp}"
 BUZZ_BACKUP_RETAIN="${AIDEVOPS_BUZZ_BACKUP_RETAIN:-3}"
 BUZZ_ACP_ARG="acp"
+BUZZ_OPENCODE_NAME="opencode"
+BUZZ_JSON_TYPE_ARRAY="array"
+BUZZ_JSON_TYPE_STRING="string"
+BUZZ_STATE_SCHEMA_V1="aidevops-buzz-opencode-acp-fix/v1"
+BUZZ_STATE_SCHEMA_V2="aidevops-buzz-opencode-acp-fix/v2"
 BUZZ_PLATFORM_DARWIN="Darwin"
 BUZZ_LOCK_HELD=0
 BUZZ_QUIET=false
@@ -74,14 +80,6 @@ _buzz_is_running() {
 	return $?
 }
 
-_buzz_is_affected_version() {
-	local version="$1"
-	case "$version" in
-	0.5.4 | 0.5.5) return 0 ;;
-	*) return 1 ;;
-	esac
-}
-
 _buzz_validate_private_file() {
 	local path="$1"
 	local label="$2"
@@ -107,27 +105,49 @@ _buzz_validate_private_file() {
 	return 0
 }
 
+_buzz_validate_wrapper() {
+	if [[ ! -f "$BUZZ_WRAPPER_PATH" || ! -x "$BUZZ_WRAPPER_PATH" ]]; then
+		print_error "Buzz OpenCode ACP wrapper is missing or not executable; run aidevops update"
+		return 1
+	fi
+	local owner=""
+	owner=$(_file_owner "$BUZZ_WRAPPER_PATH")
+	if [[ "$owner" != "$(id -un)" ]]; then
+		print_error "Buzz OpenCode ACP wrapper is not owned by the current user"
+		return 1
+	fi
+	return 0
+}
+
 _buzz_validate_store() {
 	command -v jq >/dev/null 2>&1 || {
 		print_error "jq is required for Buzz Desktop compatibility reconciliation"
 		return 1
 	}
 	_buzz_validate_private_file "$BUZZ_STORE_PATH" "Buzz managed-agent store" || return 1
-	jq -e '
-		def is_array: type == "array";
-		def is_string: type == "string";
+	jq -e --arg wrapper "$BUZZ_WRAPPER_PATH" \
+		--arg opencode "$BUZZ_OPENCODE_NAME" \
+		--arg array_type "$BUZZ_JSON_TYPE_ARRAY" \
+		--arg string_type "$BUZZ_JSON_TYPE_STRING" '
+		def is_array: type == $array_type;
+		def is_string: type == $string_type;
 		def command_basename:
-			if is_string then (split("/") | last) else "" end;
-		def needs_patch:
+			if is_string then (split("/") | last) else empty end;
+		def recognized_original:
 			([.agent_command, .agent_command_override]
 				| map(command_basename)
-				| any(. == "opencode")) and
-			(((.agent_args // []) | length) == 0);
+				| any(. == $opencode));
+		def structurally_managed:
+			(recognized_original or (.agent_command_override == $wrapper)) and
+			(((.agent_args // []) == []) or ((.agent_args // []) == ["acp"]));
 		is_array and
 		all(.[];
 			type == "object" and
-			((.agent_args == null) or (.agent_args | is_array)) and
-			((needs_patch | not) or
+			((.agent_command == null) or (.agent_command | is_string)) and
+			((.agent_command_override == null) or (.agent_command_override | is_string)) and
+			((.agent_args == null) or
+				((.agent_args | is_array) and all(.agent_args[]; is_string))) and
+			((structurally_managed | not) or
 				((.pubkey | is_string) and (.pubkey | length) > 0))
 		)
 	' "$BUZZ_STORE_PATH" >/dev/null 2>&1 || {
@@ -137,7 +157,7 @@ _buzz_validate_store() {
 	return 0
 }
 
-_buzz_target_filter() {
+_buzz_original_target_filter() {
 	printf '%s\n' '
     def command_basename:
       if type == "string" then (split("/") | last) else "" end;
@@ -148,27 +168,25 @@ _buzz_target_filter() {
 
 _buzz_eligible_count() {
 	local filter=""
-	filter=$(_buzz_target_filter)
-	jq "
+	filter=$(_buzz_original_target_filter)
+	jq --arg acp "$BUZZ_ACP_ARG" "
 		[
 			.[]
 			| select(${filter})
-			| select(((.agent_args // []) | length) == 0)
+			| select(((.agent_args // []) == []) or ((.agent_args // []) == [\$acp]))
 		] | length
 	" "$BUZZ_STORE_PATH"
 	return $?
 }
 
 _buzz_fixed_count() {
-	local filter=""
-	filter=$(_buzz_target_filter)
-	jq --arg acp "$BUZZ_ACP_ARG" "
+	jq --arg acp "$BUZZ_ACP_ARG" --arg wrapper "$BUZZ_WRAPPER_PATH" '
 		[
 			.[]
-			| select(${filter})
-			| select((.agent_args // []) == [\$acp])
+			| select(.agent_command_override == $wrapper)
+			| select((.agent_args // []) == [$acp])
 		] | length
-	" "$BUZZ_STORE_PATH"
+	' "$BUZZ_STORE_PATH"
 	return $?
 }
 
@@ -221,24 +239,35 @@ _buzz_write_apply_manifest() {
 	local version="$2"
 	local backup="$3"
 	local filter=""
-	filter=$(_buzz_target_filter)
+	filter=$(_buzz_original_target_filter)
 	jq \
 		--arg version "$version" \
 		--arg store "$BUZZ_STORE_PATH" \
 		--arg backup "$backup" \
+		--arg wrapper "$BUZZ_WRAPPER_PATH" \
+		--arg acp "$BUZZ_ACP_ARG" \
 		--arg applied_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
 		"
 		{
-			schema: \"aidevops-buzz-opencode-acp-fix/v1\",
+			schema: \"${BUZZ_STATE_SCHEMA_V2}\",
 			app_version: \$version,
 			store_path: \$store,
+			wrapper_path: \$wrapper,
 			backup_path: \$backup,
 			applied_at: \$applied_at,
 			records: [
 				.[]
 				| select(${filter})
-				| select(((.agent_args // []) | length) == 0)
-				| {pubkey: .pubkey, original_args: (.agent_args // [])}
+				| select(((.agent_args // []) == []) or ((.agent_args // []) == [\$acp]))
+				| {
+					pubkey: .pubkey,
+					original_command_override_present: has(\"agent_command_override\"),
+					original_command_override: (.agent_command_override // null),
+					original_args_present: has(\"agent_args\"),
+					original_args: (.agent_args // []),
+					managed_command_override: \$wrapper,
+					managed_args: [\$acp]
+				  }
 			]
 		}
 		" "$BUZZ_STORE_PATH" >"$destination"
@@ -249,11 +278,12 @@ _buzz_write_apply_manifest() {
 _buzz_write_applied_store() {
 	local destination="$1"
 	local filter=""
-	filter=$(_buzz_target_filter)
-	jq --arg acp "$BUZZ_ACP_ARG" "
+	filter=$(_buzz_original_target_filter)
+	jq --arg acp "$BUZZ_ACP_ARG" --arg wrapper "$BUZZ_WRAPPER_PATH" "
 		map(
-			if (${filter}) and (((.agent_args // []) | length) == 0)
-			then .agent_args = [\$acp]
+			if (${filter}) and
+				(((.agent_args // []) == []) or ((.agent_args // []) == [\$acp]))
+			then .agent_command_override = \$wrapper | .agent_args = [\$acp]
 			else .
 			end
 		)
@@ -321,10 +351,6 @@ cmd_apply() {
 		_buzz_info "Buzz Desktop is not installed; no changes needed"
 		return 0
 	}
-	if ! _buzz_is_affected_version "$version"; then
-		_buzz_info "Buzz Desktop ${version} is not in the verified affected-version registry"
-		return 0
-	fi
 	[[ -f "$BUZZ_STATE_FILE" ]] && {
 		_buzz_info "Buzz OpenCode ACP compatibility fix is already managed by aidevops"
 		return 0
@@ -334,6 +360,7 @@ cmd_apply() {
 		return 0
 	}
 	_buzz_validate_store || return 1
+	_buzz_validate_wrapper || return 1
 	_buzz_acquire_lock || return 1
 	_buzz_apply_locked "$version"
 	local rc=$?
@@ -345,7 +372,31 @@ _buzz_validate_state() {
 	_buzz_validate_private_file "$BUZZ_STATE_FILE" "Buzz compatibility state" || return 1
 	jq -e \
 		--arg store "$BUZZ_STORE_PATH" \
-		'.schema == "aidevops-buzz-opencode-acp-fix/v1" and .store_path == $store and (.records | type == "array")' \
+		--arg wrapper "$BUZZ_WRAPPER_PATH" \
+		--arg v1 "$BUZZ_STATE_SCHEMA_V1" \
+		--arg v2 "$BUZZ_STATE_SCHEMA_V2" \
+		--arg array_type "$BUZZ_JSON_TYPE_ARRAY" \
+		--arg string_type "$BUZZ_JSON_TYPE_STRING" '
+		.store_path == $store and
+		(.records | type == $array_type) and
+		((.records | length) == ([.records[].pubkey] | unique | length)) and
+		if .schema == $v1 then
+			all(.records[];
+				(.pubkey | type == $string_type) and (.pubkey | length > 0) and
+				(.original_args | type == $array_type))
+		elif .schema == $v2 then
+			.wrapper_path == $wrapper and
+			all(.records[];
+				(.pubkey | type == $string_type) and (.pubkey | length > 0) and
+				(.original_command_override_present | type == "boolean") and
+				((.original_command_override == null) or
+					(.original_command_override | type == $string_type)) and
+				(.original_args_present | type == "boolean") and
+				(.original_args | type == $array_type) and
+				(.managed_command_override == $wrapper) and
+				(.managed_args == ["acp"]))
+		else false
+		end' \
 		"$BUZZ_STATE_FILE" >/dev/null 2>&1 || {
 		print_error "Buzz compatibility state is malformed or belongs to another store"
 		return 1
@@ -353,40 +404,134 @@ _buzz_validate_state() {
 	return 0
 }
 
+_buzz_state_schema() {
+	jq -r '.schema' "$BUZZ_STATE_FILE"
+	return $?
+}
+
+_buzz_migrate_state_v1_locked() {
+	local version="$1"
+	local schema=""
+	schema=$(_buzz_state_schema) || return 1
+	[[ "$schema" == "$BUZZ_STATE_SCHEMA_V1" ]] || return 0
+	if _buzz_is_running; then
+		print_warning "Buzz Desktop is running; close it and run: aidevops buzz reconcile"
+		return 2
+	fi
+	local state_tmp=""
+	state_tmp=$(mktemp "${BUZZ_STATE_DIR}/buzz-opencode-acp-fix.XXXXXX")
+	if ! jq -e \
+		--arg version "$version" \
+		--arg wrapper "$BUZZ_WRAPPER_PATH" \
+		--arg schema "$BUZZ_STATE_SCHEMA_V2" \
+		--arg opencode "$BUZZ_OPENCODE_NAME" \
+		--arg string_type "$BUZZ_JSON_TYPE_STRING" \
+		--arg migrated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+		--slurpfile store "$BUZZ_STORE_PATH" '
+		def command_basename:
+			if type == $string_type then (split("/") | last) else empty end;
+		def recognized_original:
+			([.agent_command, .agent_command_override]
+				| map(command_basename) | any(. == $opencode));
+		.records as $legacy_records
+		| ($legacy_records | map(
+			. as $legacy
+			| ([$store[0][] | select(.pubkey == $legacy.pubkey)] | first) as $live
+			| select($live != null and ($live | recognized_original))
+			| {
+				pubkey: $legacy.pubkey,
+				original_command_override_present: ($live | has("agent_command_override")),
+				original_command_override: ($live.agent_command_override // null),
+				original_args_present: true,
+				original_args: $legacy.original_args,
+				managed_command_override: $wrapper,
+				managed_args: ["acp"]
+			  }
+		  )) as $migrated
+		| if ($migrated | length) != ($legacy_records | length) then
+			error("legacy Buzz state does not match the live structural schema")
+		  else {
+			schema: $schema,
+			app_version: $version,
+			store_path: .store_path,
+			wrapper_path: $wrapper,
+			backup_path: .backup_path,
+			applied_at: .applied_at,
+			migrated_at: $migrated_at,
+			records: $migrated
+		  } end' "$BUZZ_STATE_FILE" >"$state_tmp"; then
+		rm -f "$state_tmp"
+		print_error "Buzz compatibility state cannot be safely migrated"
+		return 1
+	fi
+	chmod 600 "$state_tmp"
+	if _buzz_is_running; then
+		rm -f "$state_tmp"
+		print_warning "Buzz Desktop started during state migration; no changes were applied"
+		return 2
+	fi
+	mv "$state_tmp" "$BUZZ_STATE_FILE"
+	_buzz_info "Migrated legacy Buzz compatibility state to structural ownership"
+	return 0
+}
+
 _buzz_managed_drift_count() {
-	local filter=""
-	filter=$(_buzz_target_filter)
-	jq --slurpfile state "$BUZZ_STATE_FILE" "
+	jq --arg acp "$BUZZ_ACP_ARG" --arg wrapper "$BUZZ_WRAPPER_PATH" \
+		--arg opencode "$BUZZ_OPENCODE_NAME" --arg string_type "$BUZZ_JSON_TYPE_STRING" \
+		--slurpfile state "$BUZZ_STATE_FILE" '
+		def command_basename:
+			if type == $string_type then (split("/") | last) else empty end;
+		def recognized_original:
+			([.agent_command, .agent_command_override]
+				| map(command_basename) | any(. == $opencode));
 		[
-			.[] as \$record
-			| select(\$record | ${filter})
-			| select(((\$record.agent_args // []) | length) == 0)
-			| select(([\$state[0].records[] | select(.pubkey == \$record.pubkey)] | length) > 0)
+			.[] as $record
+			| ([$state[0].records[] | select(.pubkey == $record.pubkey)] | first) as $owned
+			| select($owned != null)
+			| select(
+				(($record | recognized_original) and
+					((($record.agent_args // []) == []) or
+					 (($record.agent_args // []) == [$acp]))) or
+				($record.agent_command_override == $wrapper and
+					(($record.agent_args // []) == []))
+			  )
 		] | length
-	" "$BUZZ_STORE_PATH"
+	' "$BUZZ_STORE_PATH"
 	return $?
 }
 
 _buzz_write_reconciled_store() {
 	local destination="$1"
-	local filter=""
-	filter=$(_buzz_target_filter)
-	jq --arg acp "$BUZZ_ACP_ARG" --slurpfile state "$BUZZ_STATE_FILE" "
+	jq --arg acp "$BUZZ_ACP_ARG" --arg wrapper "$BUZZ_WRAPPER_PATH" \
+		--arg opencode "$BUZZ_OPENCODE_NAME" --arg string_type "$BUZZ_JSON_TYPE_STRING" \
+		--slurpfile state "$BUZZ_STATE_FILE" '
+		def command_basename:
+			if type == $string_type then (split("/") | last) else empty end;
+		def recognized_original:
+			([.agent_command, .agent_command_override]
+				| map(command_basename) | any(. == $opencode));
 		map(
-			. as \$record
-			| ([\$state[0].records[] | select(.pubkey == \$record.pubkey)] | first) as \$owned
-			| if (\$owned != null) and (\$record | ${filter}) and
-				(((\$record.agent_args // []) | length) == 0)
-			  then .agent_args = [\$acp]
+			. as $record
+			| ([$state[0].records[] | select(.pubkey == $record.pubkey)] | first) as $owned
+			| if ($owned != null) and (
+				(($record | recognized_original) and
+					((($record.agent_args // []) == []) or
+					 (($record.agent_args // []) == [$acp]))) or
+				($record.agent_command_override == $wrapper and
+					(($record.agent_args // []) == []))
+			  )
+			  then .agent_command_override = $wrapper | .agent_args = [$acp]
 			  else .
 			  end
 		)
-	" "$BUZZ_STORE_PATH" >"$destination"
+	' "$BUZZ_STORE_PATH" >"$destination"
 	chmod 600 "$destination"
 	return 0
 }
 
 _buzz_reconcile_managed_locked() {
+	local version="$1"
+	_buzz_migrate_state_v1_locked "$version" || return $?
 	local drifted=""
 	drifted=$(_buzz_managed_drift_count) || return 1
 	if [[ "$drifted" -eq 0 ]]; then
@@ -418,13 +563,26 @@ _buzz_reconcile_managed_locked() {
 
 _buzz_write_rollback_store() {
 	local destination="$1"
-	jq --arg acp "$BUZZ_ACP_ARG" --slurpfile state "$BUZZ_STATE_FILE" '
+	jq --arg acp "$BUZZ_ACP_ARG" --arg v1 "$BUZZ_STATE_SCHEMA_V1" \
+		--slurpfile state "$BUZZ_STATE_FILE" '
 		map(
 			. as $record
 			| ([$state[0].records[] | select(.pubkey == $record.pubkey)] | first) as $owned
-			| if ($owned != null and ((.agent_args // []) == [$acp]))
-			  then .agent_args = $owned.original_args
-			  else .
+			| if $state[0].schema == $v1 then
+				if ($owned != null and ((.agent_args // []) == [$acp]))
+				then .agent_args = $owned.original_args else . end
+			  else
+				(if ($owned != null and
+					 .agent_command_override == $owned.managed_command_override)
+				 then if $owned.original_command_override_present
+					then .agent_command_override = $owned.original_command_override
+					else del(.agent_command_override) end
+				 else . end)
+				| (if ($owned != null and (.agent_args // []) == $owned.managed_args)
+				   then if $owned.original_args_present
+					then .agent_args = $owned.original_args
+					else del(.agent_args) end
+				   else . end)
 			  end
 		)
 	' "$BUZZ_STORE_PATH" >"$destination"
@@ -479,12 +637,11 @@ cmd_status() {
 		_buzz_validate_store || return 1
 		_buzz_validate_state || return 1
 		local fixed=""
+		local drifted=""
 		fixed=$(_buzz_fixed_count) || return 1
-		printf 'Buzz Desktop %s compatibility: managed (%s OpenCode record(s))\n' "$version" "$fixed"
-		return 0
-	fi
-	if ! _buzz_is_affected_version "$version"; then
-		printf 'Buzz Desktop %s compatibility: version not in affected registry\n' "$version"
+		drifted=$(_buzz_managed_drift_count) || return 1
+		printf 'Buzz Desktop %s compatibility: managed (%s OpenCode record(s), %s need reconciliation)\n' \
+			"$version" "$fixed" "$drifted"
 		return 0
 	fi
 	[[ -f "$BUZZ_STORE_PATH" ]] || {
@@ -512,14 +669,11 @@ cmd_reconcile() {
 		_buzz_info "Buzz Desktop is not installed; no changes needed"
 		return 0
 	}
-	if ! _buzz_is_affected_version "$version"; then
-		_buzz_info "Buzz Desktop ${version} is not in the verified affected-version registry"
-		return 0
-	fi
 	_buzz_validate_store || return 1
+	_buzz_validate_wrapper || return 1
 	_buzz_validate_state || return 1
 	_buzz_acquire_lock || return 1
-	_buzz_reconcile_managed_locked
+	_buzz_reconcile_managed_locked "$version"
 	local rc=$?
 	_buzz_release_lock
 	return "$rc"
@@ -529,15 +683,15 @@ show_help() {
 	cat <<'EOF'
 Usage: aidevops buzz <status|apply|rollback|reconcile> [--quiet]
 
-Manage the reversible Buzz Desktop 0.5.4-0.5.5 OpenCode ACP compatibility fix.
+Manage a reversible, structurally validated Buzz Desktop OpenCode ACP compatibility fix.
 
 Commands:
   status      Report whether the installed Buzz version/agents need remediation
-  apply       Add the missing `acp` argument to eligible OpenCode agent records
+  apply       Route eligible OpenCode records through the stable ACP wrapper
   rollback    Restore only unchanged fields previously managed by aidevops
-  reconcile   Idempotently apply the verified version-specific remediation
+  reconcile   Idempotently repair structurally recognized managed drift
 
-Buzz must be closed for apply or rollback. The helper never prints agent-store
+Buzz must be closed for apply, reconcile, or rollback. The helper never prints agent-store
 contents and keeps private rollback state and bounded backups with mode 600.
 EOF
 	return 0

--- a/.agents/scripts/tests/test-agent-bin-shim-sync.sh
+++ b/.agents/scripts/tests/test-agent-bin-shim-sync.sh
@@ -88,11 +88,13 @@ trap 'rm -rf "$tmp_home"' EXIT
 mkdir -p "${tmp_target}/bin" "${tmp_target}/scripts" "${tmp_home}/.aidevops/bin" "${tmp_home}/elsewhere"
 printf '#!/usr/bin/env bash\n' >"${tmp_target}/bin/gh_create_pr"
 printf '#!/usr/bin/env bash\n' >"${tmp_target}/bin/gh_create_issue"
+printf '#!/usr/bin/env bash\n' >"${tmp_target}/bin/opencode-acp"
 printf '#!/usr/bin/env bash\n' >"${tmp_target}/bin/aidevops-auto-update"
 printf '#!/usr/bin/env bash\n' >"${tmp_target}/bin/aidevops-repo-sync"
 printf '#!/usr/bin/env bash\n' >"${tmp_target}/scripts/auto-update-helper.sh"
 printf '#!/usr/bin/env bash\n' >"${tmp_target}/scripts/repo-sync-helper.sh"
 chmod +x "${tmp_target}/bin/gh_create_pr" "${tmp_target}/bin/gh_create_issue" \
+	"${tmp_target}/bin/opencode-acp" \
 	"${tmp_target}/bin/aidevops-auto-update" "${tmp_target}/bin/aidevops-repo-sync" \
 	"${tmp_target}/scripts/auto-update-helper.sh" "${tmp_target}/scripts/repo-sync-helper.sh"
 
@@ -115,6 +117,8 @@ assert_symlink_target "gh_create_pr shim is linked into user PATH bin" \
 	"${tmp_home}/.aidevops/bin/gh_create_pr" "${tmp_target}/bin/gh_create_pr"
 assert_symlink_target "gh_create_issue shim is linked into user PATH bin" \
 	"${tmp_home}/.aidevops/bin/gh_create_issue" "${tmp_target}/bin/gh_create_issue"
+assert_symlink_target "OpenCode ACP shim is linked into user PATH bin" \
+	"${tmp_home}/.aidevops/bin/opencode-acp" "${tmp_target}/bin/opencode-acp"
 assert_symlink_target "auto-update launchd display link is preserved" \
 	"${tmp_home}/.aidevops/bin/aidevops-auto-update" "${tmp_target}/scripts/auto-update-helper.sh"
 assert_symlink_target "repo-sync launchd display link is preserved" \

--- a/.agents/tests/test-buzz-desktop-helper.sh
+++ b/.agents/tests/test-buzz-desktop-helper.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${TEST_DIR}/../.." && pwd)"
 HELPER="${REPO_ROOT}/.agents/scripts/buzz-desktop-helper.sh"
+WRAPPER="${REPO_ROOT}/.agents/bin/opencode-acp"
 SETUP_FILE="${REPO_ROOT}/setup.sh"
 CLI_FILE="${REPO_ROOT}/aidevops.sh"
 TEST_ROOT=$(mktemp -d)
@@ -158,6 +159,7 @@ run_helper() {
 		AIDEVOPS_BUZZ_STATE_FILE="$TEST_STATE_FILE" \
 		AIDEVOPS_BUZZ_BACKUP_DIR="$TEST_BACKUP_DIR" \
 		AIDEVOPS_BUZZ_LOCK_DIR="$TEST_LOCK_DIR" \
+		AIDEVOPS_BUZZ_WRAPPER_PATH="$WRAPPER" \
 		bash "$HELPER" "$@"
 	return $?
 }
@@ -176,6 +178,10 @@ test_apply_is_bounded_and_private() {
 	run_helper apply >/dev/null
 	assert_eq "apply updates only eligible OpenCode records" \
 		"$(jq '[.[] | select(.agent_args == ["acp"])] | length' "$TEST_STORE")" "2"
+	assert_eq "apply routes eligible records through the stable wrapper" \
+		"$(jq --arg wrapper "$WRAPPER" '[.[] | select(.agent_command_override == $wrapper)] | length' "$TEST_STORE")" "2"
+	assert_eq "apply records structural state schema" \
+		"$(jq -r '.schema' "$TEST_STATE_FILE")" "aidevops-buzz-opencode-acp-fix/v2"
 	assert_eq "apply preserves custom arguments" \
 		"$(jq -c '.[] | select(.pubkey == "pub-custom") | .agent_args' "$TEST_STORE")" \
 		'["acp","--cwd","/project"]'
@@ -260,8 +266,11 @@ test_rollback_restores_owned_fields() {
 	run_helper rollback --quiet
 	assert_eq "rollback restores originally empty arguments" \
 		"$(jq -c '.[] | select(.pubkey == "pub-empty-path") | .agent_args' "$TEST_STORE")" '[]'
-	assert_eq "rollback restores an originally absent argument field as empty" \
-		"$(jq -c '.[] | select(.pubkey == "pub-missing-args") | .agent_args' "$TEST_STORE")" '[]'
+	assert_eq "rollback restores the original command override" \
+		"$(jq -r '.[] | select(.pubkey == "pub-empty-path") | .agent_command_override' "$TEST_STORE")" \
+		'/opt/homebrew/bin/opencode'
+	assert_eq "rollback removes an originally absent argument field" \
+		"$(jq -c '.[] | select(.pubkey == "pub-missing-args") | .agent_args' "$TEST_STORE")" 'null'
 	assert_eq "rollback leaves custom arguments unchanged" \
 		"$(jq -c '.[] | select(.pubkey == "pub-custom") | .agent_args' "$TEST_STORE")" \
 		'["acp","--cwd","/project"]'
@@ -296,18 +305,64 @@ test_running_app_refuses_mutation() {
 	return 0
 }
 
-test_verified_and_unknown_versions_are_bounded() {
+test_future_versions_use_structural_detection() {
 	reset_fixture
-	TEST_VERSION=0.5.5 run_helper reconcile --quiet
-	assert_eq "verified Buzz 0.5.5 release is remediated" \
-		"$(jq '[.[] | select(.agent_args == ["acp"])] | length' "$TEST_STORE")" "2"
+	TEST_VERSION=0.5.7 run_helper reconcile --quiet
+	assert_eq "Buzz 0.5.7 is remediated structurally" \
+		"$(jq --arg wrapper "$WRAPPER" '[.[] | select(.agent_command_override == $wrapper)] | length' "$TEST_STORE")" "2"
+	reset_fixture
+	TEST_VERSION=9.9.9 run_helper reconcile --quiet
+	assert_eq "future Buzz versions use the same validated structure" \
+		"$(jq --arg wrapper "$WRAPPER" '[.[] | select(.agent_command_override == $wrapper)] | length' "$TEST_STORE")" "2"
 	reset_fixture
 	local before=""
 	before=$(file_hash "$TEST_STORE")
-	TEST_VERSION=0.5.6 run_helper reconcile --quiet
-	assert_eq "unknown future Buzz version is not guessed affected" "$(file_hash "$TEST_STORE")" "$before"
 	TEST_PLATFORM=Linux run_helper reconcile --quiet
 	assert_eq "non-macOS platform is unchanged" "$(file_hash "$TEST_STORE")" "$before"
+	return 0
+}
+
+test_legacy_state_migrates_before_reconciliation() {
+	reset_fixture
+	mkdir -p "$TEST_STATE_DIR"
+	jq 'map(if ((.agent_command // "") | endswith("opencode")) then .agent_args = ["acp"] else . end)' \
+		"$TEST_STORE" >"${TEST_STORE}.edited"
+	mv "${TEST_STORE}.edited" "$TEST_STORE"
+	chmod 600 "$TEST_STORE"
+	cat >"$TEST_STATE_FILE" <<JSON
+{
+  "schema": "aidevops-buzz-opencode-acp-fix/v1",
+  "app_version": "0.5.5",
+  "store_path": "${TEST_STORE}",
+  "backup_path": "${TEST_BACKUP_DIR}/legacy.json",
+  "applied_at": "2026-08-01T00:00:00Z",
+  "records": [
+    {"pubkey": "pub-empty-path", "original_args": []},
+    {"pubkey": "pub-missing-args", "original_args": []}
+  ]
+}
+JSON
+	chmod 600 "$TEST_STATE_FILE"
+	TEST_VERSION=0.5.7 run_helper reconcile --quiet
+	assert_eq "legacy state migrates to structural schema" \
+		"$(jq -r '.schema' "$TEST_STATE_FILE")" 'aidevops-buzz-opencode-acp-fix/v2'
+	assert_eq "migrated records route through the wrapper" \
+		"$(jq --arg wrapper "$WRAPPER" '[.[] | select(.agent_command_override == $wrapper)] | length' "$TEST_STORE")" "2"
+	return 0
+}
+
+test_wrapper_injects_acp_once() {
+	reset_fixture
+	local fake_opencode="${TEST_ROOT}/fake-opencode"
+	cat >"$fake_opencode" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*"
+SH
+	chmod +x "$fake_opencode"
+	assert_eq "wrapper injects ACP for a bare invocation" \
+		"$(AIDEVOPS_OPENCODE_REAL="$fake_opencode" "$WRAPPER" --model test)" 'acp --model test'
+	assert_eq "wrapper preserves an existing ACP prefix" \
+		"$(AIDEVOPS_OPENCODE_REAL="$fake_opencode" "$WRAPPER" acp --model test)" 'acp --model test'
 	return 0
 }
 
@@ -379,7 +434,9 @@ main() {
 	test_rollback_restores_owned_fields
 	test_rollback_preserves_later_user_edit
 	test_running_app_refuses_mutation
-	test_verified_and_unknown_versions_are_bounded
+	test_future_versions_use_structural_detection
+	test_legacy_state_migrates_before_reconciliation
+	test_wrapper_injects_acp_once
 	test_symlink_store_fails_closed
 	test_malformed_record_fails_closed
 	test_cli_and_setup_wiring


### PR DESCRIPTION
## Summary

Replace per-release Buzz gating with fail-closed structural reconciliation, migrate legacy private state, and route managed OpenCode agents through an idempotent ACP wrapper deployed via the existing bin-shim path.

## Files Changed

.agents/bin/opencode-acp, .agents/scripts/buzz-desktop-helper.sh, .agents/scripts/tests/test-agent-bin-shim-sync.sh, .agents/tests/test-buzz-desktop-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 41 Buzz helper tests and 10 bin-shim tests pass; ShellCheck and changed-file quality gates pass; live Buzz 0.5.7 double restart kept three records managed and Fizz connected/online without startup errors.

Resolves #29777


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.234 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 3d 5h and 3,862,229 tokens on this with the user in an interactive session.