### PR TITLE
GH#29661: Fix Actions saturation evidence fixtures

### DIFF
--- a/.agents/scripts/tests/test-actions-queue-saturation.sh
+++ b/.agents/scripts/tests/test-actions-queue-saturation.sh
@@ -246,6 +246,7 @@ _reset_env() {
 	unset GH_SHIM_FAIL
 	unset GH_SHIM_PR_VIEW_JSON
 	unset GH_SHIM_CHECK_RUNS_JSON
+	unset GH_SHIM_SAME_PASS_CHECK_RUNS_JSON
 	return 0
 }
 
@@ -447,14 +448,26 @@ _pmrc_snapshot_checks_json() {
 	return 0
 }
 
-# 5a: is_saturated=1 + current-head REST checks include QUEUED → saturation.
+_pmp_same_pass_check_evidence_get() {
+	local repo_slug="$1"
+	local head_sha="$2"
+	[[ -n "$repo_slug" && -n "$head_sha" ]] || return 1
+	[[ -n "${GH_SHIM_SAME_PASS_CHECK_RUNS_JSON+x}" ]] || return 1
+	printf '%s\n' "$GH_SHIM_SAME_PASS_CHECK_RUNS_JSON"
+	return 0
+}
+
+# 5a: is_saturated=1 + first-priority same-pass checks include QUEUED →
+# saturation. The conflicting fallback fixture proves same-pass precedence.
 _reset_env
 set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha123"}' \
-	'GH_SHIM_CHECK_RUNS_JSON=[{"name":"Maintainer Gate","status":"queued","conclusion":null,"app":{"slug":"github-actions"}}]'
+	'GH_SHIM_SAME_PASS_CHECK_RUNS_JSON=[{"name":"Maintainer Gate","status":"queued","conclusion":null,"app":{"slug":"github-actions"}}]' \
+	'GH_SHIM_CHECK_RUNS_JSON=[{"name":"Lint","status":"completed","conclusion":"failure","app":{"slug":"github-actions"}}]'
 classification=$(_classify_stuck_pr "12345" "marcusquinn/aidevops" "1")
-assert_eq "saturated+queued check: classification" "STUCK_RUNNER_QUEUE_SATURATION" "$classification"
+assert_eq "saturated+same-pass queued check: classification" "STUCK_RUNNER_QUEUE_SATURATION" "$classification"
 
-# 5b: an external app queued during an Actions incident is not runner saturation.
+# 5b: reset removes same-pass evidence, so an external app queued in the
+# fallback fixture during an Actions incident is not runner saturation.
 _reset_env
 set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","headRefOid":"sha123"}' \
 	'GH_SHIM_CHECK_RUNS_JSON=[{"name":"Codacy","status":"queued","conclusion":null,"app":{"slug":"codacy-production"}}]'

--- a/.agents/scripts/tests/test-pulse-merge-primary-first-diagnostics.sh
+++ b/.agents/scripts/tests/test-pulse-merge-primary-first-diagnostics.sh
@@ -85,6 +85,13 @@ repo_allows_pulse_write_actions() {
 	return 0
 }
 
+_pmp_rest_core_priority_allows_next() {
+	local priority="$1"
+	local context="$2"
+	[[ -n "$priority" && -n "$context" ]] || return 1
+	return 0
+}
+
 _merge_ready_prs_for_repo() {
 	local repo_slug="$1"
 	local merged_var="$2"


### PR DESCRIPTION
## Summary

Make the Actions queue-saturation regression fixture explicitly model first-priority same-pass check evidence, reset that evidence between cases, and isolate the primary-first diagnostics suite from live REST-core admission checks.

## Files Changed

.agents/scripts/tests/test-actions-queue-saturation.sh, .agents/scripts/tests/test-pulse-merge-primary-first-diagnostics.sh

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — 40 Actions saturation assertions, 68 merge-stuck assertions, and 14 primary-first diagnostics assertions pass; ShellCheck, shfmt, git diff check, and changed strict lint pass.

Resolves #29661


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.234 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 50m and 263,486 tokens on this with the user in an interactive session.