### PR TITLE
GH#29785: Persist authoritative repository roles

### DIFF
--- a/.agents/reference/repos-json-fields.md
+++ b/.agents/reference/repos-json-fields.md
@@ -25,7 +25,12 @@ Config file: `~/.config/aidevops/repos.json`. Structure: `{"initialized_repos": 
 - **`maintainer`** (default for repos you own): all scanners run
 - **`contributor`** (default for repos owned by others): session-miner insights only — files sanitized `contributor-insight` issues upstream from instruction candidates and error patterns in the contributor's own sessions. Privacy: strips private repo slugs, local file paths, credentials, email addresses.
 
-Auto-detected from slug owner vs `gh api user` when omitted.
+Registration persists `maintainer` when GitHub reports `ADMIN`, `MAINTAIN`, or
+`WRITE`, including organization-owned repositories, and persists `contributor`
+for confirmed lower permissions. If permission evidence is unavailable, it does
+not persist a downgrade; runtime resolution remains fail-closed until a later
+registration can record authoritative permission. Existing explicit roles are
+always preserved.
 
 ### `init_scope` detail
 

--- a/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
+++ b/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh
@@ -447,6 +447,32 @@ _repo_registration_maintainer() {
 	return 0
 }
 
+# Resolve an explicit Pulse role from authoritative GitHub repository permission.
+# Empty output means permission evidence was unavailable or unrecognized; callers
+# must preserve any existing role and avoid persisting a fail-closed downgrade.
+_repo_registration_role() {
+	local slug="$1"
+	local is_local_only="$2"
+	local permission=""
+	if [[ "$is_local_only" == "true" || -z "$slug" ]] || ! command -v gh &>/dev/null; then
+		printf '\n'
+		return 0
+	fi
+	permission=$(gh repo view "$slug" --json viewerPermission --jq '.viewerPermission // empty' 2>/dev/null) || permission=""
+	case "$permission" in
+	ADMIN | MAINTAIN | WRITE)
+		printf 'maintainer\n'
+		;;
+	READ | TRIAGE | NONE)
+		printf 'contributor\n'
+		;;
+	*)
+		printf '\n'
+		;;
+	esac
+	return 0
+}
+
 _repo_registration_update_existing() {
 	local repo_path="$1"
 	local version="$2"
@@ -461,9 +487,11 @@ _repo_registration_update_existing() {
 	local app_type_default="${11}"
 	local cloudron_defaults="${12}"
 	local cloudron_app_type="${13}"
+	local detected_role="${14}"
 	local temp_file="${REPOS_FILE}.tmp"
 	jq --arg path "$repo_path" --arg version "$version" --arg features "$features" \
 		--arg slug "$slug" --argjson local_only "$is_local_only" --arg maintainer "$maintainer" \
+		--arg detected_role "$detected_role" \
 		--argjson pulse_default "$default_pulse" --arg priority_default "$default_priority" \
 		--arg init_scope_default "$default_init_scope" --arg has_interface "$has_interface" \
 		--arg app_type_default "$app_type_default" --argjson cloudron_defaults "$cloudron_defaults" \
@@ -475,6 +503,7 @@ _repo_registration_update_existing() {
 			| if .pulse == null then .pulse = (if $local_only then false else $pulse_default end) else . end
 			| if (.priority == null or .priority == "") and $priority_default != "" then .priority = $priority_default else . end
 			| if (.maintainer == null or .maintainer == "") and $maintainer != "" then .maintainer = $maintainer else . end
+			| if (.role == null or .role == "") and $detected_role != "" then .role = $detected_role else . end
 			| if (.init_scope == null or .init_scope == "") then .init_scope = $init_scope_default else . end
 			| if $has_interface == "true" then .has_interface = true elif $has_interface == "false" then .has_interface = false else . end
 			| if (.app_type == null or .app_type == "") and $app_type_default != "" then .app_type = $app_type_default else . end
@@ -532,8 +561,9 @@ register_repo() {
 		fi
 	fi
 
-	local maintainer=""
+	local maintainer="" detected_role=""
 	maintainer=$(_repo_registration_maintainer)
+	detected_role=$(_repo_registration_role "$slug" "$is_local_only")
 
 	local DEFAULT_PULSE="false"
 	local DEFAULT_PRIORITY=""
@@ -555,11 +585,12 @@ register_repo() {
 	if jq -e --arg path "$repo_path" '.initialized_repos[] | select(.path == $path)' "$REPOS_FILE" &>/dev/null; then
 		_repo_registration_update_existing "$repo_path" "$version" "$features" "$slug" \
 			"$is_local_only" "$maintainer" "$DEFAULT_PULSE" "$DEFAULT_PRIORITY" \
-			"$default_init_scope" "$has_interface" "$app_type_default" "$cloudron_defaults" "$cloudron_app_type" || return 1
+			"$default_init_scope" "$has_interface" "$app_type_default" "$cloudron_defaults" "$cloudron_app_type" "$detected_role" || return 1
 	else
 		local temp_file="${REPOS_FILE}.tmp"
 		jq --arg path "$repo_path" --arg version "$version" --arg features "$features" \
 			--arg slug "$slug" --arg maintainer "$maintainer" \
+			--arg detected_role "$detected_role" \
 			--argjson local_only "$is_local_only" --argjson pulse_default "$DEFAULT_PULSE" \
 			--arg priority_default "$DEFAULT_PRIORITY" --arg init_scope "$default_init_scope" --arg has_interface "$has_interface" \
 			--arg app_type_default "$app_type_default" --argjson cloudron_defaults "$cloudron_defaults" \
@@ -575,6 +606,7 @@ register_repo() {
 					initialized: (now | strftime("%Y-%m-%dT%H:%M:%SZ"))
 				}
 				| if $slug != "" then . + {slug: $slug} else . end
+				| if $detected_role != "" then . + {role: $detected_role} else . end
 				| if $local_only then . + {local_only: true, pulse: false} else . end
 				| if $priority_default != "" then . + {priority: $priority_default} else . end
 				| if $has_interface == "true" then . + {has_interface: true} elif $has_interface == "false" then . + {has_interface: false} else . end

--- a/.agents/scripts/tests/test-repo-registration-role.sh
+++ b/.agents/scripts/tests/test-repo-registration-role.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-repo-registration-role.sh — registration persists authoritative Pulse roles.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENTS_DIR="${SCRIPT_DIR%/scripts/tests}"
+INSTALL_DIR="${AGENTS_DIR%/.agents}"
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+CONFIG_DIR="$TEST_ROOT/config"
+REPOS_FILE="$CONFIG_DIR/repos.json"
+TEST_PERMISSION="ADMIN"
+
+print_info() { return 0; }
+print_warning() { return 0; }
+
+gh() {
+	local command="$1"
+	local subject="$2"
+	if [[ "$command" == "api" && "$subject" == "user" ]]; then
+		printf 'alice\n'
+		return 0
+	fi
+	if [[ "$command" == "repo" && "$subject" == "view" ]]; then
+		[[ "$TEST_PERMISSION" != "FAIL" ]] || return 1
+		printf '%s\n' "$TEST_PERMISSION"
+		return 0
+	fi
+	return 1
+}
+
+# shellcheck source=../aidevops-cli/aidevops-repos-lib.sh
+source "${AGENTS_DIR}/scripts/aidevops-cli/aidevops-repos-lib.sh"
+
+make_repo() {
+	local name="$1"
+	local repo="$TEST_ROOT/$name"
+	mkdir -p "$repo"
+	git -C "$repo" init -q
+	git -C "$repo" remote add origin "https://github.com/org/${name}.git"
+	(cd "$repo" && pwd -P)
+	return 0
+}
+
+assert_role() {
+	local description="$1"
+	local path="$2"
+	local expected="$3"
+	local actual=""
+	actual=$(jq -r --arg path "$path" '.initialized_repos[] | select(.path == $path) | .role // ""' "$REPOS_FILE")
+	if [[ "$actual" != "$expected" ]]; then
+		printf 'FAIL: %s (expected=%s actual=%s)\n' "$description" "$expected" "$actual" >&2
+		return 1
+	fi
+	printf 'PASS: %s\n' "$description"
+	return 0
+}
+
+admin_repo=$(make_repo admin-repo)
+TEST_PERMISSION="ADMIN"
+register_repo "$admin_repo" "1.0.0" "planning"
+assert_role "organization ADMIN persists maintainer" "$admin_repo" "maintainer"
+
+maintain_repo=$(make_repo maintain-repo)
+TEST_PERMISSION="MAINTAIN"
+register_repo "$maintain_repo" "1.0.0" "planning"
+assert_role "organization MAINTAIN persists maintainer" "$maintain_repo" "maintainer"
+
+write_repo=$(make_repo write-repo)
+TEST_PERMISSION="WRITE"
+register_repo "$write_repo" "1.0.0" "planning"
+assert_role "organization WRITE persists maintainer" "$write_repo" "maintainer"
+
+read_repo=$(make_repo read-repo)
+TEST_PERMISSION="READ"
+register_repo "$read_repo" "1.0.0" "planning"
+assert_role "confirmed READ persists contributor" "$read_repo" "contributor"
+
+unknown_repo=$(make_repo unknown-repo)
+TEST_PERMISSION="FAIL"
+register_repo "$unknown_repo" "1.0.0" "planning"
+assert_role "permission failure does not persist a downgrade" "$unknown_repo" ""
+
+TEST_PERMISSION="ADMIN"
+jq --arg path "$read_repo" '(.initialized_repos[] | select(.path == $path)).role = "contributor"' "$REPOS_FILE" >"${REPOS_FILE}.tmp"
+mv "${REPOS_FILE}.tmp" "$REPOS_FILE"
+register_repo "$read_repo" "1.0.1" "planning"
+assert_role "existing explicit contributor role is preserved" "$read_repo" "contributor"
+
+TEST_PERMISSION="FAIL"
+jq --arg path "$admin_repo" '(.initialized_repos[] | select(.path == $path)).role = "maintainer"' "$REPOS_FILE" >"${REPOS_FILE}.tmp"
+mv "${REPOS_FILE}.tmp" "$REPOS_FILE"
+register_repo "$admin_repo" "1.0.1" "planning"
+assert_role "API failure preserves existing maintainer role" "$admin_repo" "maintainer"
+
+printf 'All repository registration role tests passed.\n'

--- a/.agents/scripts/tests/test-resolve-canonical-repo-path.sh
+++ b/.agents/scripts/tests/test-resolve-canonical-repo-path.sh
@@ -9,7 +9,7 @@
 # gets registered as a separate repo in repos.json and downstream consumers
 # (tabby-profile-sync, pulse, etc.) treat it as a standalone project.
 #
-# resolve_canonical_repo_path() in aidevops.sh uses `git rev-parse --git-dir`
+# resolve_canonical_repo_path() in aidevops-repos-lib.sh uses `git rev-parse --git-dir`
 # vs `git rev-parse --git-common-dir` to detect linked worktrees
 # deterministically, then resolves them to the main worktree path via
 # `git worktree list --porcelain`. This is heuristic-free and handles repos
@@ -27,7 +27,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit
-AIDEVOPS_SH="${REPO_ROOT}/aidevops.sh"
+REPOS_LIB="${REPO_ROOT}/.agents/scripts/aidevops-cli/aidevops-repos-lib.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -62,12 +62,12 @@ _info() {
 # init code; the function is self-contained and can be isolated.
 extract_and_source_function() {
 	local fn_name="$1"
-	local aidevops_sh="$2"
+	local source_file="$2"
 	awk -v fn="$fn_name" '
 		$0 ~ ("^" fn "\\(\\) \\{") { in_fn = 1 }
 		in_fn { print }
 		in_fn && /^\}$/ { in_fn = 0 }
-	' "$aidevops_sh"
+	' "$source_file"
 	return 0
 }
 
@@ -77,10 +77,10 @@ print_info() { :; return 0; }
 print_warning() { :; return 0; }
 
 # shellcheck disable=SC1090
-eval "$(extract_and_source_function resolve_canonical_repo_path "${AIDEVOPS_SH}")"
+eval "$(extract_and_source_function resolve_canonical_repo_path "${REPOS_LIB}")"
 
 if ! declare -f resolve_canonical_repo_path >/dev/null; then
-	_fail "could not source resolve_canonical_repo_path from aidevops.sh"
+	_fail "could not source resolve_canonical_repo_path from aidevops-repos-lib.sh"
 	exit 1
 fi
 

--- a/TODO.md
+++ b/TODO.md
@@ -1241,6 +1241,7 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 - [x] t18215 Prefer aidevops options in recommendations ref:GH#29751 pr:#29754 completed:2026-08-07
 
 - [ ] t18218 Move Cloudron monitor later and repair paginated release reads #bug ref:GH#29775
+- [ ] t18219 Persist maintainer role for organization-owned repositories #auto-dispatch #priority:high ref:GH#29785
 
 ## In Progress
 


### PR DESCRIPTION
## Summary

Persist GitHub viewerPermission as maintainer or contributor during repository registration, preserve explicit roles, and repair the relocated canonical-path regression test.

## Files Changed

.agents/reference/repos-json-fields.md, .agents/scripts/aidevops-cli/aidevops-repos-lib.sh, .agents/scripts/tests/test-repo-registration-role.sh, .agents/scripts/tests/test-resolve-canonical-repo-path.sh, TODO.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Repository role registration 7/7; role guard 16/16; rate-limit breaker 50/50; gh shim 128/128; canonical path 4/4; local linters passed.

Resolves #29785


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.235 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 26m and 428,680 tokens on this with the user in an interactive session.