### PR TITLE
GH#29793: coalesce redundant dispatch lease renewal comments

### DIFF
--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -1479,11 +1479,13 @@ cmd_transition() {
 			ttl="$DISPATCH_READY_LEASE_TTL"
 		fi
 	fi
-	local active_claims="" current_phase="" claim_record="" claim_author="" claim_device="" claim_session="" current_login="" current_device=""
+	local active_claims="" current_phase="" current_expires_at="" claim_record="" claim_author="" claim_device="" claim_session="" current_login="" current_device=""
 	active_claims=$(_fetch_claims "$issue_number" "$repo_slug") || return 1
 	claim_record=$(printf '%s' "$active_claims" | jq -c --arg token "$lease_token" '[.[] | select(.lease_token == $token)] | last // empty' 2>/dev/null) || claim_record=""
 	current_phase=$(printf '%s' "$claim_record" | jq -r '.lease_phase // ""' 2>/dev/null) || current_phase=""
 	[[ -n "$current_phase" ]] || return 1
+	current_expires_at=$(printf '%s' "$claim_record" | jq -r '.lease_expires_at // 0' 2>/dev/null) || return 1
+	[[ "$current_expires_at" =~ ^[0-9]+$ ]] || return 1
 	claim_author=$(printf '%s' "$claim_record" | jq -r '.claim_author // ""') || return 1
 	claim_device=$(printf '%s' "$claim_record" | jq -r '.device // ""') || return 1
 	claim_session=$(printf '%s' "$claim_record" | jq -r '.session // ""') || return 1
@@ -1498,6 +1500,12 @@ cmd_transition() {
 	[[ "$attempt_id" =~ ^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$ ]] || attempt_id="unknown"
 	now_epoch=$(_now_epoch)
 	[[ "$phase" == "terminal" ]] || expires_at="$((now_epoch + ttl))"
+	# A dispatcher and its worker both protect the prelaunch handoff. Avoid a
+	# redundant public transition when the existing lease already covers the
+	# requested window, and never let a later renewal shorten effective expiry.
+	if [[ "$phase" == "$LEASE_PHASE_PRELAUNCH" && "$expires_at" -le "$current_expires_at" ]]; then
+		return 0
+	fi
 	body="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
 DISPATCH_LEASE phase=${phase} lease_token=${lease_token} device=$(_resolve_device_id) session=${session_key:-issue-${issue_number}} expires_at=${expires_at} ts=$(_now_utc) attempt_id=${attempt_id}
 <!-- ops:end -->"

--- a/.agents/scripts/tests/test-dispatch-atomic-lease.sh
+++ b/.agents/scripts/tests/test-dispatch-atomic-lease.sh
@@ -419,9 +419,50 @@ test_prelaunch_renewal_covers_slow_startup() {
 		fail "renewed prelaunch lease did not survive slow startup"
 	# shellcheck disable=SC2016 # Match the literal runtime variable in the helper source.
 	renewal_call='_hrw_renew_dispatch_prelaunch_lease "$session_key"'
-	grep -Fq "$renewal_call" "${SCRIPTS_DIR}/headless-runtime-helper.sh" ||
+	grep -Fq "$renewal_call" "${SCRIPTS_DIR}/headless-runtime-run.sh" ||
 		fail "worker does not renew its prelaunch lease before canary"
 	pass "worker prelaunch renewal covers slow startup before ready transition"
+	return 0
+}
+
+test_prelaunch_renewal_is_monotonic_and_coalesced() {
+	local root="${TMP_DIR}/renewal-coalescing" token="" initial_expiry="" extended_expiry=""
+	local comment_count=""
+	create_mock_gh "$root"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
+		DISPATCH_CLAIM_WINDOW=0 DISPATCH_CLAIM_ORPHAN_GRACE=30 \
+		"$CLAIM" claim 51 owner/repo shared-login >"$root/claim.out" 2>&1
+	token=$(claim_token "$root/claim.out")
+	[[ -n "$token" ]] || fail "coalescing claim token missing"
+	initial_expiry=$(jq -sr 'last.body | capture("expires_at=(?<value>[0-9]+)").value | tonumber' \
+		"$root/state/comments.jsonl")
+
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
+		"$CLAIM" transition prelaunch 51 owner/repo "$token" issue-51 10 ||
+		fail "covered prelaunch renewal did not succeed"
+	comment_count=$(wc -l <"$root/state/comments.jsonl" | tr -d ' ')
+	[[ "$comment_count" == "1" ]] || fail "covered prelaunch renewal posted a redundant comment"
+
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
+		"$CLAIM" transition prelaunch 51 owner/repo "$token" issue-51 60 ||
+		fail "extending prelaunch renewal failed"
+	comment_count=$(wc -l <"$root/state/comments.jsonl" | tr -d ' ')
+	[[ "$comment_count" == "2" ]] || fail "extending prelaunch renewal did not post exactly once"
+	extended_expiry=$(jq -sr '[.[] | select(.body | contains("DISPATCH_LEASE phase=prelaunch"))] | last.body | capture("expires_at=(?<value>[0-9]+)").value | tonumber' \
+		"$root/state/comments.jsonl")
+	[[ "$extended_expiry" -gt "$initial_expiry" ]] || fail "prelaunch renewal did not extend expiry"
+
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
+		"$CLAIM" transition prelaunch 51 owner/repo "$token" issue-51 5 ||
+		fail "regressive prelaunch renewal did not succeed as a no-op"
+	comment_count=$(wc -l <"$root/state/comments.jsonl" | tr -d ' ')
+	[[ "$comment_count" == "2" ]] || fail "regressive prelaunch renewal posted a comment"
+	PATH="$root/bin:$PATH" MOCK_GH_STATE="$root/state" AIDEVOPS_DEVICE_ID=device-a \
+		"$CLAIM" transition ready 51 owner/repo "$token" issue-51 90 ||
+		fail "ready transition failed after coalesced renewal"
+	comment_count=$(wc -l <"$root/state/comments.jsonl" | tr -d ' ')
+	[[ "$comment_count" == "3" ]] || fail "ready transition was incorrectly coalesced"
+	pass "prelaunch renewals are monotonic and redundant comments are coalesced"
 	return 0
 }
 
@@ -458,6 +499,7 @@ test_untrusted_dispatch_identity_cannot_replace_active_lock
 test_correlated_terminal_before_dispatch_releases_exact_attempt
 test_large_comment_history_avoids_argv_limits
 test_prelaunch_renewal_covers_slow_startup
+test_prelaunch_renewal_is_monotonic_and_coalesced
 test_invalid_device_not_public
 test_takeover_recheck_precedes_mutation
 printf '\nAtomic lease concurrency tests passed\n'


### PR DESCRIPTION
## Summary

Skip non-extending prelaunch lease comments while preserving meaningful append-only dispatch transitions.

## Files Changed

.agents/scripts/dispatch-claim-helper.sh, .agents/scripts/tests/test-dispatch-atomic-lease.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Atomic lease concurrency suite passed; ShellCheck passed; changed-file local linter suite passed; review bundle e41a59e87d8ab9300fba48192c320f1deeae0702869113a326b94f7cc96be565 inspected clean.

Resolves #29793


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.236 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 24m and 156,580 tokens on this with the user in an interactive session.