### PR TITLE
GH#29795: auto-dispatch trusted quality audit findings

### DIFF
--- a/.agents/configs/trusted-code-quality-bots.txt
+++ b/.agents/configs/trusted-code-quality-bots.txt
@@ -1,0 +1,10 @@
+# Exact GitHub App identities whose review findings may create auto-dispatch work.
+# This is an authority allowlist, not a bot-noise list. Keep matching exact and
+# fail closed when the file or an identity is unknown.
+coderabbitai[bot]
+gemini-code-assist[bot]
+augmentcode[bot]
+codacy-production[bot]
+sonarqubecloud[bot]
+codefactor-io[bot]
+qltybot[bot]

--- a/.agents/scripts/quality-feedback-issues-lib.sh
+++ b/.agents/scripts/quality-feedback-issues-lib.sh
@@ -591,7 +591,7 @@ _create_or_append_file_issue() {
 		# PR numbers are monotonically increasing within a repository. Never append
 		# older review feedback to debt opened from a newer PR: the newer change may
 		# already supersede the older finding (GH#27703).
-		if [[ "$pr_num" =~ ^[0-9]+$ && "$existing_file_issue_pr" =~ ^[0-9]+$ && \
+		if [[ "$pr_num" =~ ^[0-9]+$ && "$existing_file_issue_pr" =~ ^[0-9]+$ &&
 			"$pr_num" -lt "$existing_file_issue_pr" ]]; then
 			echo "  Skipping superseded PR #${pr_num} feedback; #${existing_file_issue} already tracks newer PR #${existing_file_issue_pr} for ${file}" >&2
 			echo "0"
@@ -608,6 +608,43 @@ _create_or_append_file_issue() {
 		"$repo_slug" "$pr_num" "$file" "$issue_title" "$max_severity" \
 		"$reviewers" "$file_finding_count" "$finding_details" "$is_maintainer_pr"
 	return $?
+}
+
+# _quality_findings_are_trusted_automation: GH#29795
+#
+# Quality-debt issues are maintainer-controlled scanner output. Findings from
+# explicitly trusted code-quality apps are therefore authorized for worker
+# triage regardless of who authored the merged source PR. This keeps source
+# provenance separate from task authority: an external or dependency-bot PR
+# does not turn a trusted audit finding into an external contribution.
+#
+# Every reviewer identity must match the exact allowlist. Missing configuration,
+# malformed findings, mixed human/bot findings, and lookalike bot names fail
+# closed so the existing source-author trust check remains the fallback.
+#
+# Args:
+#   $1 - findings JSON array
+#
+# Returns:
+#   0 if every finding came from trusted quality automation
+#   1 otherwise
+_quality_findings_are_trusted_automation() {
+	local findings="$1"
+	local trust_file="${AIDEVOPS_TRUSTED_CODE_QUALITY_BOTS_FILE:-${BASH_SOURCE[0]%/*}/../configs/trusted-code-quality-bots.txt}"
+	local reviewer_logins=""
+	local reviewer_login=""
+
+	[[ -f "$trust_file" ]] || return 1
+	reviewer_logins=$(printf '%s' "$findings" | jq -r \
+		'[.[].reviewer_login // ""] | unique | .[]' 2>/dev/null) || return 1
+	[[ -n "$reviewer_logins" ]] || return 1
+
+	while IFS= read -r reviewer_login; do
+		[[ -n "$reviewer_login" ]] || return 1
+		grep -Fqx -- "$reviewer_login" "$trust_file" || return 1
+	done <<<"$reviewer_logins"
+
+	return 0
 }
 
 # _is_maintainer_equivalent_author: GH#17916 (t2686)
@@ -680,6 +717,25 @@ _is_maintainer_equivalent_author() {
 	return 1
 }
 
+# _quality_feedback_dispatch_authorized: resolve generated-task authority.
+# Arguments: $1=findings JSON $2=repo slug $3=source PR number
+# Returns: 0 when trusted audit identity or source-author authority is verified.
+_quality_feedback_dispatch_authorized() {
+	local findings="$1"
+	local repo_slug="$2"
+	local pr_num="$3"
+	local pr_author=""
+
+	if _quality_findings_are_trusted_automation "$findings"; then
+		echo "[quality-feedback] trusted quality-app findings on PR #${pr_num} — authorizing worker triage" >&2
+		return 0
+	fi
+
+	pr_author=$(gh pr view "$pr_num" --repo "$repo_slug" --json author --jq '.author.login' 2>/dev/null || echo "")
+	_is_maintainer_equivalent_author "$pr_author" "$repo_slug"
+	return $?
+}
+
 _create_quality_debt_issues() {
 	local repo_slug="$1"
 	local pr_num="$2"
@@ -696,14 +752,12 @@ _create_quality_debt_issues() {
 		return 0
 	fi
 
-	# GH#17916 (t2686): Determine if the source PR was authored by someone
-	# trusted enough to skip the NMR approval gate. Delegated to
-	# _is_maintainer_equivalent_author — see that helper's docstring for the
-	# full trust-bar rationale and two-stage check.
+	# GH#29795: The scanner's trusted quality-app identity authorizes worker
+	# triage independently of the merged source PR author. For findings from
+	# humans or unknown automation, retain the source-author trust fallback and
+	# fail closed to the external approval gate.
 	local is_maintainer_pr="false"
-	local pr_author=""
-	pr_author=$(gh pr view "$pr_num" --repo "$repo_slug" --json author --jq '.author.login' 2>/dev/null || echo "")
-	if _is_maintainer_equivalent_author "$pr_author" "$repo_slug"; then
+	if _quality_feedback_dispatch_authorized "$findings" "$repo_slug" "$pr_num"; then
 		is_maintainer_pr="true"
 	fi
 

--- a/.agents/scripts/tests/test-quality-feedback-trust-bar.sh
+++ b/.agents/scripts/tests/test-quality-feedback-trust-bar.sh
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# Tests for `_is_maintainer_equivalent_author` in quality-feedback-issues-lib.sh
-# (GH#17916 / t2686).
+# Tests for quality-feedback dispatch authority in quality-feedback-issues-lib.sh
+# (GH#17916 / t2686 / GH#29795).
 #
 # t2686 background: the pre-fix trust check used strict equality against
 # repos.json .maintainer, which missed admin collaborators entirely. On
@@ -13,6 +13,9 @@
 # (t2411 criterion 2, t2449 criterion 2).
 #
 # Post-fix semantics:
+#   - Trusted code-quality app findings authorize worker triage independently
+#     of the merged source PR author
+#   - Reviewer identities use an exact, fail-closed allowlist
 #   - Stage 1: maintainer fast-path (repos.json .maintainer or slug owner)
 #   - Stage 2: collaborator permission probe (admin/maintain/write → trusted)
 #   - Fail-closed on API errors, read-only permission, unknown user
@@ -65,6 +68,8 @@ setup_test_env() {
 	# the gh stub exit non-zero (simulating 404/403/network error).
 	export PERMISSION_FIXTURE="${TEST_ROOT}/permission.json"
 	printf '{"permission":"none"}\n' >"$PERMISSION_FIXTURE"
+	export AIDEVOPS_TRUSTED_CODE_QUALITY_BOTS_FILE="${TEST_ROOT}/trusted-code-quality-bots.txt"
+	printf '%s\n' 'coderabbitai[bot]' 'codacy-production[bot]' >"$AIDEVOPS_TRUSTED_CODE_QUALITY_BOTS_FILE"
 
 	# gh stub — only collaborators/{user}/permission is needed.
 	cat >"${TEST_ROOT}/bin/gh" <<'STUB'
@@ -117,6 +122,7 @@ teardown_test_env() {
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
 		rm -rf "$TEST_ROOT"
 	fi
+	unset AIDEVOPS_TRUSTED_CODE_QUALITY_BOTS_FILE
 	return 0
 }
 
@@ -131,7 +137,9 @@ set_permission_fixture() {
 define_helpers_under_test() {
 	local trust_src
 	trust_src=$(awk '
+		/^_quality_findings_are_trusted_automation\(\) \{/,/^}$/ { print }
 		/^_is_maintainer_equivalent_author\(\) \{/,/^}$/ { print }
+		/^_quality_feedback_dispatch_authorized\(\) \{/,/^}$/ { print }
 	' "$QF_SCRIPT")
 	if [[ -z "$trust_src" ]]; then
 		printf 'ERROR: could not extract _is_maintainer_equivalent_author from %s\n' "$QF_SCRIPT" >&2
@@ -151,6 +159,55 @@ define_helpers_under_test() {
 # ---------------------------------------------------------------------------
 # Test cases
 # ---------------------------------------------------------------------------
+
+test_trusted_quality_apps_authorize_findings() {
+	local findings='[{"reviewer_login":"coderabbitai[bot]"},{"reviewer_login":"codacy-production[bot]"}]'
+	if _quality_findings_are_trusted_automation "$findings"; then
+		print_result "trusted quality apps authorize generated worker triage (GH#29795)" 0
+		return 0
+	fi
+	print_result "trusted quality apps authorize generated worker triage (GH#29795)" 1
+	return 0
+}
+
+test_trusted_quality_app_on_dependency_pr_is_source_independent() {
+	local findings='[{"reviewer_login":"coderabbitai[bot]"}]'
+	set_permission_fixture '{"permission":"none"}'
+	# The gh stub deliberately rejects `gh pr view`, so success proves the
+	# trusted audit path never consults the dependency-bot source author.
+	if _quality_feedback_dispatch_authorized "$findings" "exampleorg/examplerepo" "42"; then
+		print_result "trusted audit authority does not depend on source PR author (GH#29795)" 0
+		return 0
+	fi
+	print_result "trusted audit authority does not depend on source PR author (GH#29795)" 1
+	return 0
+}
+
+test_mixed_or_lookalike_reviewers_fail_closed() {
+	local mixed='[{"reviewer_login":"coderabbitai[bot]"},{"reviewer_login":"external-user"}]'
+	local lookalike='[{"reviewer_login":"not-coderabbitai[bot]"}]'
+	if ! _quality_findings_are_trusted_automation "$mixed" &&
+		! _quality_findings_are_trusted_automation "$lookalike"; then
+		print_result "mixed and lookalike reviewer identities fail closed (GH#29795)" 0
+		return 0
+	fi
+	print_result "mixed and lookalike reviewer identities fail closed (GH#29795)" 1
+	return 0
+}
+
+test_missing_quality_app_allowlist_fails_closed() {
+	local findings='[{"reviewer_login":"coderabbitai[bot]"}]'
+	local saved_trust_file="$AIDEVOPS_TRUSTED_CODE_QUALITY_BOTS_FILE"
+	AIDEVOPS_TRUSTED_CODE_QUALITY_BOTS_FILE="${TEST_ROOT}/missing-trust-file"
+	if ! _quality_findings_are_trusted_automation "$findings"; then
+		AIDEVOPS_TRUSTED_CODE_QUALITY_BOTS_FILE="$saved_trust_file"
+		print_result "missing quality-app allowlist fails closed (GH#29795)" 0
+		return 0
+	fi
+	AIDEVOPS_TRUSTED_CODE_QUALITY_BOTS_FILE="$saved_trust_file"
+	print_result "missing quality-app allowlist fails closed (GH#29795)" 1
+	return 0
+}
 
 test_maintainer_fast_path_matches() {
 	# Stage 1: PR author matches repos.json .maintainer → trusted, no API call.
@@ -272,6 +329,10 @@ main() {
 		return 1
 	fi
 
+	test_trusted_quality_apps_authorize_findings
+	test_trusted_quality_app_on_dependency_pr_is_source_independent
+	test_mixed_or_lookalike_reviewers_fail_closed
+	test_missing_quality_app_allowlist_fails_closed
 	test_maintainer_fast_path_matches
 	test_admin_collaborator_is_trusted
 	test_maintain_collaborator_is_trusted


### PR DESCRIPTION
## Summary

Separate trusted code-quality app authority from merged source-PR authorship so maintainer-controlled audit findings remain auto-dispatchable; preserve fail-closed gates for unknown, mixed, and lookalike reviewer identities.

## Files Changed

.agents/configs/trusted-code-quality-bots.txt, .agents/scripts/quality-feedback-issues-lib.sh, .agents/scripts/tests/test-quality-feedback-trust-bar.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — quality-feedback suite 87/87; trust-bar 12/12; generated-label 27/27; NMR normalization; ShellCheck; shfmt; local linters

Resolves #29795


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.237 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 11m and 194,992 tokens on this with the user in an interactive session.