### PR TITLE
GH#29799: fix: bound unknown REST progress

### DIFF
--- a/.agents/configs/pulse-rate-limit.conf
+++ b/.agents/configs/pulse-rate-limit.conf
@@ -42,9 +42,10 @@
 
 # Fraction of total GraphQL budget below which the rate-limit circuit breaker trips.
 # Set to 0 to disable the GraphQL floor only. REST-core priority gating below
-# remains active and keeps unknown quota evidence fail-closed until a later
-# authoritative probe succeeds. AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER=1 is the
-# explicit emergency bypass for both pools.
+# remains active. Unknown REST evidence initially fails closed, then permits
+# only progress work after the configured bounded probe streak. Deferrable work
+# remains deferred. AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER=1 is the explicit
+# emergency bypass for both pools.
 # Env var AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD takes precedence if already set.
 AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD=${AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD-0.05}
 
@@ -83,6 +84,11 @@ AIDEVOPS_PULSE_REST_CORE_PROBE_TTL=${AIDEVOPS_PULSE_REST_CORE_PROBE_TTL-20}
 # A short cache still coalesces concurrent checks without allowing a long stage
 # to rely on a stale pre-stage observation.
 AIDEVOPS_PULSE_REST_CORE_GATE_PROBE_TTL=${AIDEVOPS_PULSE_REST_CORE_GATE_PROBE_TTL-2}
+
+# Consecutive unknown REST-core gate-probe slots before progress work may resume.
+# Set to 0 to retain permanent fail-closed behavior. The counter resets after
+# every valid REST-core observation; deferrable work always remains deferred.
+AIDEVOPS_PULSE_REST_CORE_UNKNOWN_PROGRESS_LIMIT=${AIDEVOPS_PULSE_REST_CORE_UNKNOWN_PROGRESS_LIMIT-3}
 
 # ── Cross-issue no_work rate circuit breaker (GH#20640, t2770) ────────────────
 #

--- a/.agents/scripts/pulse-budget-priority.sh
+++ b/.agents/scripts/pulse-budget-priority.sh
@@ -286,8 +286,10 @@ _pulse_defer_budget_priority_stage() {
 _pulse_run_budget_priority_stage() {
 	local stage="$1"
 	shift
+	_PULSE_BUDGET_STAGE_DEFERRED=0
 	if _pulse_should_defer_budget_priority_stage "$stage"; then
 		_pulse_defer_budget_priority_stage "$stage"
+		_PULSE_BUDGET_STAGE_DEFERRED=1
 		return 0
 	fi
 	"$@"
@@ -301,8 +303,10 @@ _pulse_run_budget_priority_stage_with_timeout() {
 	local stage="$1"
 	local timeout_seconds="$2"
 	shift 2
+	_PULSE_BUDGET_STAGE_DEFERRED=0
 	if _pulse_should_defer_budget_priority_stage "$stage"; then
 		_pulse_defer_budget_priority_stage "$stage"
+		_PULSE_BUDGET_STAGE_DEFERRED=1
 		return 0
 	fi
 	run_stage_with_timeout "$stage" "$timeout_seconds" "$@"

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -1437,8 +1437,10 @@ _run_preflight_stages() {
 	# provide the safety net. Timing is still logged for observability.
 	local _pflt_ed_start=$SECONDS
 	local _pflt_ed_rc=0
+	local _pflt_ed_outcome=""
 	_pulse_run_budget_priority_stage "preflight_early_dispatch" _preflight_early_dispatch || _pflt_ed_rc=$?
-	_log_substage_timing "preflight_early_dispatch" "$_pflt_ed_start" "$_pflt_ed_rc"
+	[[ "${_PULSE_BUDGET_STAGE_DEFERRED:-0}" == "1" ]] && _pflt_ed_outcome="skipped"
+	_log_substage_timing "preflight_early_dispatch" "$_pflt_ed_start" "$_pflt_ed_rc" "$_pflt_ed_outcome"
 	# GH#28880: cross-repository label maintenance can take 3-5 minutes. Run it
 	# after the initial fill so already-eligible workers boot in parallel. Then
 	# normalize trusted-author NMR residue and refill once so every newly unblocked
@@ -1448,8 +1450,10 @@ _run_preflight_stages() {
 	_pulse_run_budget_priority_stage "preflight_trusted_nmr_reconcile" _preflight_trusted_nmr_reconcile || true
 	local _pflt_refill_start=$SECONDS
 	local _pflt_refill_rc=0
+	local _pflt_refill_outcome=""
 	_pulse_run_budget_priority_stage "preflight_post_label_refill" _preflight_post_label_refill || _pflt_refill_rc=$?
-	_log_substage_timing "preflight_post_label_refill" "$_pflt_refill_start" "$_pflt_refill_rc"
+	[[ "${_PULSE_BUDGET_STAGE_DEFERRED:-0}" == "1" ]] && _pflt_refill_outcome="skipped"
+	_log_substage_timing "preflight_post_label_refill" "$_pflt_refill_start" "$_pflt_refill_rc" "$_pflt_refill_outcome"
 	# t3055: Post-dispatch housekeeping runs under a separate async lock by
 	# default. These stages do not protect the immediate worker claim/ledger
 	# safety boundary, so blocking the dispatch lock on them lets a 24-worker

--- a/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
@@ -100,6 +100,7 @@ _CB_REST_CORE_CACHE_FILE="${AIDEVOPS_PULSE_REST_CORE_CACHE:-${HOME}/.aidevops/ca
 _CB_REST_CORE_PROBE_TTL="${AIDEVOPS_PULSE_REST_CORE_PROBE_TTL:-20}"
 _CB_REST_CORE_RESOURCE="core"
 _CB_REST_CORE_UNKNOWN="unknown"
+_CB_REST_CORE_UNKNOWN_STATE_FILE="${AIDEVOPS_PULSE_REST_CORE_UNKNOWN_STATE:-${HOME}/.aidevops/cache/pulse-rest-core-unknown.state}"
 
 # Log prefix for all messages from this module.
 _CB_RL_LOG_PREFIX="[circuit-breaker-rl]"
@@ -400,6 +401,52 @@ pulse_rest_core_priority_snapshot() {
 }
 
 #######################################
+# Reset the bounded unknown-evidence streak after an authoritative observation.
+#######################################
+_cb_rest_core_reset_unknown_progress_streak() {
+	rm -f "$_CB_REST_CORE_UNKNOWN_STATE_FILE" 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Permit progress after a bounded streak of distinct unknown gate-probe slots.
+# Deferrable work never calls this helper and remains fail-closed.
+#######################################
+_cb_rest_core_unknown_progress_allows() {
+	local limit="${AIDEVOPS_PULSE_REST_CORE_UNKNOWN_PROGRESS_LIMIT:-3}"
+	local gate_ttl
+	local now
+	local slot
+	local state_dir
+	local state_slot=""
+	local state_count=0
+	local lock_dir
+	[[ "$limit" =~ ^[0-9]+$ ]] || limit=3
+	[[ "$limit" -gt 0 ]] || return 2
+	gate_ttl=$(_cb_rest_core_gate_probe_ttl)
+	[[ "$gate_ttl" =~ ^[1-9][0-9]*$ ]] || gate_ttl=1
+	now=$(date +%s 2>/dev/null) || now=0
+	[[ "$now" =~ ^[0-9]+$ ]] || return 2
+	slot=$((now / gate_ttl))
+	state_dir=$(dirname "$_CB_REST_CORE_UNKNOWN_STATE_FILE")
+	lock_dir="${_CB_REST_CORE_UNKNOWN_STATE_FILE}.lock"
+	mkdir -p "$state_dir" 2>/dev/null || return 2
+	mkdir "$lock_dir" 2>/dev/null || return 2
+	if [[ -f "$_CB_REST_CORE_UNKNOWN_STATE_FILE" ]]; then
+		read -r state_slot state_count <"$_CB_REST_CORE_UNKNOWN_STATE_FILE" || true
+	fi
+	[[ "$state_count" =~ ^[0-9]+$ ]] || state_count=0
+	if [[ "$state_slot" != "$slot" ]]; then
+		state_count=$((state_count + 1))
+		printf '%s %s\n' "$slot" "$state_count" >"${_CB_REST_CORE_UNKNOWN_STATE_FILE}.tmp.$$" &&
+			mv "${_CB_REST_CORE_UNKNOWN_STATE_FILE}.tmp.$$" "$_CB_REST_CORE_UNKNOWN_STATE_FILE" 2>/dev/null || true
+	fi
+	rmdir "$lock_dir" 2>/dev/null || true
+	[[ "$state_count" -ge "$limit" ]] && return 0
+	return 2
+}
+
+#######################################
 # Apply a REST priority class to one already-observed budget snapshot.
 #
 # Args:
@@ -428,9 +475,17 @@ _cb_rest_core_priority_decision_allows() {
 	read -r mode remaining limit adaptive soft_cap hard_floor reset_epoch <<<"$decision"
 	case "$mode" in
 	disabled)
+		_cb_rest_core_reset_unknown_progress_streak
 		return 0
 		;;
-	normal | reserve | emergency) ;;
+	normal | reserve | emergency)
+		_cb_rest_core_reset_unknown_progress_streak
+		;;
+	unknown)
+		[[ "$priority" == "progress" ]] || return 2
+		_cb_rest_core_unknown_progress_allows
+		return $?
+		;;
 	*)
 		return 2
 		;;
@@ -536,11 +591,11 @@ _cb_rest_core_progress_block_reason() {
 }
 
 #######################################
-# Gate new dispatch work at the hard floor and on unknown REST evidence.
-# Unknown evidence deliberately remains fail-closed without a time-based
-# downgrade: every later call retries the bounded authoritative probe, and
-# progress resumes only after valid evidence returns or an operator selects the
-# explicit emergency bypass.
+# Gate new dispatch work at the hard floor and on unknown REST evidence. Unknown
+# evidence fails closed until AIDEVOPS_PULSE_REST_CORE_UNKNOWN_PROGRESS_LIMIT
+# distinct gate-probe slots are unknown; then only progress work resumes.
+# A limit of 0 preserves permanent fail-closed behavior, and a valid observation
+# resets the streak. Deferrable work remains deferred throughout.
 #######################################
 _cb_rest_core_progress_allows_dispatch() {
 	local decision

--- a/.agents/scripts/pulse-watchdog.sh
+++ b/.agents/scripts/pulse-watchdog.sh
@@ -317,10 +317,13 @@ _log_substage_timing() {
 	local substage_name="$1"
 	local start_secs="${2:-0}"
 	local exit_code="${3:-0}"
-	local duration=$(( SECONDS - start_secs ))
+	local outcome="${4:-}"
+	local display_code="$exit_code"
+	local duration=$((SECONDS - start_secs))
 	local executor_pid=""
+	[[ "$outcome" == "skipped" ]] && display_code="skipped"
 	[[ "$duration" =~ ^[0-9]+$ ]] || duration=0
-	echo "[pulse-wrapper] Substage: ${substage_name} (${exit_code}, ${duration}s)" >>"${LOGFILE:-/dev/null}"
+	echo "[pulse-wrapper] Substage: ${substage_name} (${display_code}, ${duration}s)" >>"${LOGFILE:-/dev/null}"
 	if [[ -n "${PULSE_STAGE_TIMINGS_LOG:-}" ]]; then
 		if _pulse_resolve_executor_pid "${BASHPID:-}"; then
 			executor_pid="$_PULSE_EXECUTOR_PID"

--- a/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
@@ -179,6 +179,7 @@ reset_test_state() {
 	rm -f "${HOME}/.aidevops/logs/pulse-graphql-circuit-breaker.state"
 	rm -f "${HOME}/.aidevops/cache/pulse-graphql-rate-limit.json"
 	rm -f "${HOME}/.aidevops/cache/pulse-rest-core.json"
+	rm -f "${HOME}/.aidevops/cache/pulse-rest-core-unknown.state"
 	unset AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER 2>/dev/null || true
 	unset AIDEVOPS_PULSE_RATE_LIMIT_CACHE_TTL 2>/dev/null || true
 	unset AIDEVOPS_PULSE_DISPATCH_REST_FALLBACK 2>/dev/null || true
@@ -203,6 +204,7 @@ reset_test_state() {
 	export AIDEVOPS_PULSE_REST_CORE_IN_FLIGHT_ALLOWANCE=250
 	export AIDEVOPS_PULSE_REST_CORE_ADAPTIVE_WINDOW_SECONDS=3600
 	export AIDEVOPS_PULSE_REST_CORE_GATE_PROBE_TTL=2
+	export AIDEVOPS_PULSE_REST_CORE_UNKNOWN_PROGRESS_LIMIT=3
 	return 0
 }
 
@@ -734,6 +736,23 @@ test_rest_core_unknown_evidence() {
 	return 0
 }
 
+# --- Test 24b: Bounded unknown evidence resumes progress but not deferrable work ---
+test_rest_core_unknown_progress_bound() {
+	reset_test_state
+	export AIDEVOPS_PULSE_REST_CORE_UNKNOWN_PROGRESS_LIMIT=1
+	unset STUB_GH_CORE_REMAINING
+	rm -f "$_CB_REST_CORE_CACHE_FILE"
+	local progress_rc=0 deferrable_rc=0
+	pulse_rest_core_priority_allows progress || progress_rc=$?
+	pulse_rest_core_priority_allows deferrable || deferrable_rc=$?
+	if [[ "$progress_rc" -eq 0 && "$deferrable_rc" -eq 2 ]]; then
+		pass "bounded unknown REST evidence resumes progress only"
+	else
+		fail "unknown REST progress bound eligibility mismatch" "progress_rc=${progress_rc} deferrable_rc=${deferrable_rc}"
+	fi
+	return 0
+}
+
 # --- Test 25: Legacy soft-cap override and zero-disable remain compatible ---
 test_rest_core_legacy_override_compatibility() {
 	reset_test_state
@@ -1156,6 +1175,7 @@ test_rest_core_in_flight_allowance_boundary
 test_rest_core_unit_gate_refreshes_stale_observation
 test_rest_core_hard_floor_eligibility
 test_rest_core_unknown_evidence
+test_rest_core_unknown_progress_bound
 test_rest_core_legacy_override_compatibility
 test_rest_core_hard_floor_clamped_to_soft_cap
 test_rest_core_malformed_cache_recovers


### PR DESCRIPTION
## Summary

Bounds repeated unknown REST evidence, preserves deferrable safety, and marks deferred preflight timing as skipped.

## Files Changed

.agents/configs/pulse-rate-limit.conf, .agents/scripts/pulse-budget-priority.sh, .agents/scripts/pulse-dispatch-engine.sh, .agents/scripts/pulse-rate-limit-circuit-breaker.sh, .agents/scripts/pulse-watchdog.sh, .agents/scripts/tests/test-rate-limit-circuit-breaker.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — .agents/scripts/linters-local.sh; .agents/scripts/tests/test-rate-limit-circuit-breaker.sh; .agents/scripts/tests/test-pulse-graphql-budget-priority.sh; .agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh

Resolves #29799


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.237 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 8m and 244,293 tokens on this as a headless worker.