### PR TITLE
GH#29802: Fix solved attribution across completion paths

### DIFF
--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -991,6 +991,7 @@ either live output growth or completed work attributed to workers:
 pulse-current-state-helper.sh --window 15m
 worker-activity-helper.sh summary --since 1h --repo <owner/repo> --no-pr-check
 worker-activity-helper.sh providers --since 1h
+solved-attribution-helper.sh report --since 2026-08-01 --repo <owner/repo>
 ```
 
 The current-state helper is the cheapest live signal: local logs + cached
@@ -1001,6 +1002,18 @@ budget available. Use the `providers` subcommand for recent provider/model
 usage and redacted OAuth account-pool availability. Treat `origin:worker` PR
 counts as branch-creation telemetry only; they are not sufficient evidence of
 worker productivity.
+
+Before comparing worker and interactive throughput, check solved-attribution
+coverage for the same window. A low percentage means `solved:*` counts are
+conservative lower bounds, not a complete comparison. Historical repair is
+dry-run by default and only accepts one unambiguous merged closing PR with an
+explicit `origin:*` label:
+
+```bash
+solved-attribution-helper.sh backfill --since 2026-08-01 --repo <owner/repo>
+# Review the output, then apply the same bounded selection explicitly:
+solved-attribution-helper.sh backfill --since 2026-08-01 --repo <owner/repo> --apply
+```
 
 Routine operational questions should not start with broad recursive searches
 over `~/.aidevops/logs` or `~/.local/share/opencode`. Reach for the bounded

--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -418,6 +418,8 @@ _do_close() {
 	if gh "${close_args[@]}" 2>/dev/null; then
 		if _is_cancelled_or_deferred "$task_line"; then
 			_gh_edit_labels "add" "$repo" "$issue_number" "not-planned"
+		elif [[ "$pr_num" =~ ^[0-9]+$ ]]; then
+			set_solved_label_from_merged_pr "$issue_number" "$repo" "$pr_num" || true
 		fi
 		_mark_issue_done "$repo" "$issue_number"
 		_mark_todo_done "$task_id" "$todo_file"

--- a/.agents/scripts/pulse-issue-reconcile-actions.sh
+++ b/.agents/scripts/pulse-issue-reconcile-actions.sh
@@ -1180,6 +1180,7 @@ _action_ciw_single() {
 	gh issue close "$issue_num" --repo "$slug" \
 		--comment "Closing: work completed via merged PR ${pr_ref:-"(detected by dedup helper)"} (merged at ${merged_at:-unknown}). Issue was open but dedup guard was blocking re-dispatch." \
 		>/dev/null 2>&1 || return 1
+	[[ "$pr_num" =~ ^[0-9]+$ ]] && set_solved_label_from_merged_pr "$issue_num" "$slug" "$pr_num" || true
 
 	fast_fail_reset "$issue_num" "$slug" || true
 	unlock_issue_after_worker "$issue_num" "$slug"
@@ -1226,6 +1227,7 @@ _action_rsd_single() {
 		gh issue close "$issue_num" --repo "$slug" \
 			--comment "Closing: work completed via merged PR ${pr_ref:-"(detected by dedup)"} (merged at ${merged_at:-unknown})." \
 			>/dev/null 2>&1 || return 1
+		[[ "$pr_num" =~ ^[0-9]+$ ]] && set_solved_label_from_merged_pr "$issue_num" "$slug" "$pr_num" || true
 
 		fast_fail_reset "$issue_num" "$slug" || true
 		unlock_issue_after_worker "$issue_num" "$slug"
@@ -1355,6 +1357,7 @@ _action_oimp_single() {
 	gh issue close "$issue_num" --repo "$slug" \
 		--comment "$close_comment" \
 		>/dev/null 2>&1 || return 1
+	set_solved_label_from_merged_pr "$issue_num" "$slug" "$merged_pr_num" || true
 
 	if declare -F fast_fail_reset >/dev/null 2>&1; then
 		fast_fail_reset "$issue_num" "$slug" || true

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1142,11 +1142,9 @@ _handle_post_merge_actions() {
 				pr_labels=$(gh_pr_view "$pr_number" --repo "$repo_slug" \
 					--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || pr_labels=""
 			fi
-			local _solved_actor="interactive"
-			case ",${pr_labels}," in
-			*,origin:worker,* | *,origin:worker-takeover,*) _solved_actor="worker" ;;
-			esac
-			set_solved_label "$linked_issue" "$repo_slug" "$_solved_actor" || true
+			local _solved_actor=""
+			_solved_actor=$(solved_actor_from_pr_labels "$pr_labels") || _solved_actor=""
+			[[ -n "$_solved_actor" ]] && set_solved_label "$linked_issue" "$repo_slug" "$_solved_actor" || true
 			clear_terminal_issue_dispatch_labels "$linked_issue" "$repo_slug" "post-merge-pr-${pr_number}" || true
 			if _gh_with_timeout write gh issue close "$linked_issue" --repo "$repo_slug" 2>/dev/null; then
 				# Closing is not a status transition in GitHub's label model. Converge
@@ -1188,11 +1186,9 @@ _handle_post_merge_actions() {
 			fi
 
 			if [[ "$_sup_parent_guard" -eq 0 ]]; then
-				local _sup_solved_actor="interactive"
-				case ",${pr_labels}," in
-				*,origin:worker,* | *,origin:worker-takeover,*) _sup_solved_actor="worker" ;;
-				esac
-				set_solved_label "$_superseded_original_issue" "$repo_slug" "$_sup_solved_actor" || true
+				local _sup_solved_actor=""
+				_sup_solved_actor=$(solved_actor_from_pr_labels "$pr_labels") || _sup_solved_actor=""
+				[[ -n "$_sup_solved_actor" ]] && set_solved_label "$_superseded_original_issue" "$repo_slug" "$_sup_solved_actor" || true
 				clear_terminal_issue_dispatch_labels "$_superseded_original_issue" "$repo_slug" "post-merge-superseded-pr-${pr_number}" || true
 				if _gh_with_timeout write gh issue close "$_superseded_original_issue" --repo "$repo_slug" 2>/dev/null; then
 					set_issue_status "$_superseded_original_issue" "$repo_slug" "done" || true

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -1002,16 +1002,35 @@ ensure_solved_labels_exist() {
 #######################################
 solved_actor_from_pr_labels() {
 	local labels_csv="$1"
+	local has_worker=0 has_takeover=0 has_interactive=0
 	case ",${labels_csv}," in
-	*,origin:worker,* | *,origin:worker-takeover,*)
+	*,origin:worker,*) has_worker=1 ;;
+	esac
+	case ",${labels_csv}," in
+	*,origin:worker-takeover,*) has_takeover=1 ;;
+	esac
+	case ",${labels_csv}," in
+	*,origin:interactive,*) has_interactive=1 ;;
+	esac
+
+	# Takeover is explicit evidence that a worker ultimately solved work that may
+	# retain interactive provenance for audit history. Other dual-origin states
+	# are contradictory and remain unattributed.
+	if [[ "$has_takeover" -eq 1 ]]; then
 		printf 'worker\n'
 		return 0
-		;;
-	*,origin:interactive,*)
+	fi
+	if [[ "$has_worker" -eq 1 && "$has_interactive" -eq 1 ]]; then
+		return 1
+	fi
+	if [[ "$has_worker" -eq 1 ]]; then
+		printf 'worker\n'
+		return 0
+	fi
+	if [[ "$has_interactive" -eq 1 ]]; then
 		printf 'interactive\n'
 		return 0
-		;;
-	esac
+	fi
 	return 1
 }
 

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -994,6 +994,57 @@ ensure_solved_labels_exist() {
 }
 
 #######################################
+# Resolve completion attribution from a merged PR's origin labels.
+# Unknown or contradictory provenance is deliberately not guessed.
+# Args: $1 — comma-separated PR label names
+# Stdout: worker|interactive
+# Returns: 0 on unambiguous attribution, 1 otherwise.
+#######################################
+solved_actor_from_pr_labels() {
+	local labels_csv="$1"
+	case ",${labels_csv}," in
+	*,origin:worker,* | *,origin:worker-takeover,*)
+		printf 'worker\n'
+		return 0
+		;;
+	*,origin:interactive,*)
+		printf 'interactive\n'
+		return 0
+		;;
+	esac
+	return 1
+}
+
+#######################################
+# Attribute an issue from an explicitly identified merged PR.
+# The live mergedAt read prevents unmerged/closed PRs from being counted as
+# solved work. PR origin is authoritative; issue origin is never consulted.
+# Args: $1=issue number, $2=repo slug, $3=PR number
+# Returns: 0 on attribution, 1 on missing/ambiguous evidence, 2 on bad args.
+#######################################
+set_solved_label_from_merged_pr() {
+	local issue_num="$1"
+	local repo_slug="$2"
+	local pr_num="$3"
+	if [[ ! "$issue_num" =~ ^[0-9]+$ || -z "$repo_slug" || ! "$pr_num" =~ ^[0-9]+$ ]]; then
+		return 2
+	fi
+
+	local pr_evidence=""
+	pr_evidence=$(gh pr view "$pr_num" --repo "$repo_slug" \
+		--json mergedAt,labels \
+		--jq '[.mergedAt // "", ([.labels[].name] | join(","))] | @tsv' 2>/dev/null) || return 1
+	local merged_at="${pr_evidence%%$'\t'*}"
+	local pr_labels="${pr_evidence#*$'\t'}"
+	[[ -n "$merged_at" && "$pr_evidence" == *$'\t'* ]] || return 1
+
+	local solved_actor=""
+	solved_actor=$(solved_actor_from_pr_labels "$pr_labels") || return 1
+	set_solved_label "$issue_num" "$repo_slug" "$solved_actor"
+	return $?
+}
+
+#######################################
 # Transition an issue to a solved:* attribution label atomically.
 #
 # This is separate from origin:*: origin says who created the issue/PR;

--- a/.agents/scripts/solved-attribution-helper.sh
+++ b/.agents/scripts/solved-attribution-helper.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Report and safely backfill solved:* completion attribution from merged PRs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+SAH_REPO=""
+SAH_SINCE=""
+SAH_LIMIT=100
+SAH_APPLY=0
+SAH_JSON=0
+SAH_MIN_COVERAGE=""
+
+_sah_usage() {
+	printf '%s\n' \
+		'Usage: solved-attribution-helper.sh report|backfill [options]' \
+		'' \
+		'Options:' \
+		'  --repo OWNER/REPO       Repository (defaults to current repository)' \
+		'  --since YYYY-MM-DD      Closed-at lower bound (default: 30 days ago)' \
+		'  --limit N               Backfill candidate limit (default: 100)' \
+		'  --apply                 Apply labels; backfill is dry-run by default' \
+		'  --json                  Emit report as JSON' \
+		'  --min-coverage PERCENT  Fail report when coverage is below threshold'
+	return 0
+}
+
+_sah_default_since() {
+	if date -u -v-30d +%Y-%m-%d >/dev/null 2>&1; then
+		date -u -v-30d +%Y-%m-%d
+	else
+		date -u -d '30 days ago' +%Y-%m-%d
+	fi
+	return 0
+}
+
+_sah_resolve_repo() {
+	if [[ -n "$SAH_REPO" ]]; then
+		return 0
+	fi
+	SAH_REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) || SAH_REPO=""
+	[[ -n "$SAH_REPO" ]] || return 1
+	return 0
+}
+
+_sah_parse_options() {
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--repo)
+			SAH_REPO="${2:-}"
+			shift 2
+			;;
+		--since)
+			SAH_SINCE="${2:-}"
+			shift 2
+			;;
+		--limit)
+			SAH_LIMIT="${2:-}"
+			shift 2
+			;;
+		--apply)
+			SAH_APPLY=1
+			shift
+			;;
+		--json)
+			SAH_JSON=1
+			shift
+			;;
+		--min-coverage)
+			SAH_MIN_COVERAGE="${2:-}"
+			shift 2
+			;;
+		-h | --help)
+			_sah_usage
+			exit 0
+			;;
+		*)
+			printf 'Unknown option: %s\n' "$1" >&2
+			return 1
+			;;
+		esac
+	done
+	[[ "$SAH_LIMIT" =~ ^[1-9][0-9]*$ ]] || return 1
+	[[ -z "$SAH_SINCE" || "$SAH_SINCE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || return 1
+	[[ -z "$SAH_MIN_COVERAGE" || "$SAH_MIN_COVERAGE" =~ ^[0-9]+([.][0-9]+)?$ ]] || return 1
+	return 0
+}
+
+_sah_completion_search() {
+	local since="$1"
+	printf 'closed:>=%s -label:duplicate -label:not-planned -label:already-fixed -label:wontfix' "$since"
+	return 0
+}
+
+_sah_count_issues() {
+	local search_query="$1"
+	local payload=""
+	payload=$(gh issue list --repo "$SAH_REPO" --state closed --search "$search_query" \
+		--limit 1000 --json number 2>/dev/null) || return 1
+	printf '%s' "$payload" | jq -er 'if type == "array" then length else error("invalid issue list") end'
+	return $?
+}
+
+_sah_report() {
+	local base_search="$1"
+	local worker_count=0 interactive_count=0 conflict_count=0 missing_count=0 attributed_count=0 population=0
+	worker_count=$(_sah_count_issues "${base_search} label:solved:worker -label:solved:interactive") || return 1
+	interactive_count=$(_sah_count_issues "${base_search} label:solved:interactive -label:solved:worker") || return 1
+	conflict_count=$(_sah_count_issues "${base_search} label:solved:worker label:solved:interactive") || return 1
+	missing_count=$(_sah_count_issues "${base_search} -label:solved:worker -label:solved:interactive") || return 1
+	attributed_count=$((worker_count + interactive_count))
+	population=$((attributed_count + conflict_count + missing_count))
+
+	local coverage="0.00"
+	if [[ "$population" -gt 0 ]]; then
+		coverage=$(awk -v attributed="$attributed_count" -v population="$population" \
+			'BEGIN { printf "%.2f", (attributed * 100) / population }')
+	fi
+	local capped=false
+	if [[ "$worker_count" -ge 1000 || "$interactive_count" -ge 1000 || "$conflict_count" -ge 1000 || "$missing_count" -ge 1000 ]]; then
+		capped=true
+	fi
+
+	if [[ "$SAH_JSON" -eq 1 ]]; then
+		jq -n --arg repo "$SAH_REPO" --arg since "$SAH_SINCE" --argjson worker "$worker_count" \
+			--argjson interactive "$interactive_count" --argjson conflicting "$conflict_count" --argjson missing "$missing_count" \
+			--argjson coverage "$coverage" --argjson capped "$capped" \
+			'{repo:$repo,since:$since,solved_worker:$worker,solved_interactive:$interactive,conflicting:$conflicting,unattributed:$missing,coverage_percent:$coverage,capped:$capped}'
+	else
+		printf 'Solved attribution coverage for %s since %s\n' "$SAH_REPO" "$SAH_SINCE"
+		printf '  solved:worker      %d\n' "$worker_count"
+		printf '  solved:interactive %d\n' "$interactive_count"
+		printf '  conflicting        %d\n' "$conflict_count"
+		printf '  unattributed       %d\n' "$missing_count"
+		printf '  coverage           %s%%\n' "$coverage"
+		[[ "$capped" == true ]] && printf '  warning            one or more counts reached the 1000-result GitHub cap\n'
+	fi
+
+	if [[ -n "$SAH_MIN_COVERAGE" ]] && awk -v actual="$coverage" -v minimum="$SAH_MIN_COVERAGE" \
+		'BEGIN { exit !(actual < minimum) }'; then
+		printf 'Coverage %s%% is below required %s%%\n' "$coverage" "$SAH_MIN_COVERAGE" >&2
+		return 1
+	fi
+	return 0
+}
+
+_sah_backfill_one() {
+	local issue_json="$1"
+	local issue_num="" state_reason="" pr_count=0 pr_num=""
+	issue_num=$(printf '%s' "$issue_json" | jq -r '.number // empty')
+	state_reason=$(printf '%s' "$issue_json" | jq -r '.stateReason // empty')
+	pr_count=$(printf '%s' "$issue_json" | jq -r '[.closedByPullRequestsReferences[]?] | length')
+	[[ "$issue_num" =~ ^[0-9]+$ && "$state_reason" == "COMPLETED" && "$pr_count" -eq 1 ]] || return 1
+	pr_num=$(printf '%s' "$issue_json" | jq -r '.closedByPullRequestsReferences[0].number // empty')
+	[[ "$pr_num" =~ ^[0-9]+$ ]] || return 1
+
+	local pr_evidence="" merged_at="" pr_labels="" solved_actor=""
+	pr_evidence=$(gh pr view "$pr_num" --repo "$SAH_REPO" --json mergedAt,labels \
+		--jq '[.mergedAt // "", ([.labels[].name] | join(","))] | @tsv' 2>/dev/null) || return 1
+	merged_at="${pr_evidence%%$'\t'*}"
+	pr_labels="${pr_evidence#*$'\t'}"
+	[[ -n "$merged_at" && "$pr_evidence" == *$'\t'* ]] || return 1
+	solved_actor=$(solved_actor_from_pr_labels "$pr_labels") || return 1
+
+	if [[ "$SAH_APPLY" -eq 1 ]]; then
+		set_solved_label "$issue_num" "$SAH_REPO" "$solved_actor" || return 1
+		printf 'Applied solved:%s to issue #%s from merged PR #%s\n' "$solved_actor" "$issue_num" "$pr_num"
+	else
+		printf '[DRY-RUN] issue #%s <- solved:%s from merged PR #%s\n' "$issue_num" "$solved_actor" "$pr_num"
+	fi
+	return 0
+}
+
+_sah_backfill() {
+	local base_search="$1"
+	local candidates=""
+	candidates=$(gh issue list --repo "$SAH_REPO" --state closed \
+		--search "${base_search} -label:solved:worker -label:solved:interactive" \
+		--limit "$SAH_LIMIT" --json number,stateReason,closedByPullRequestsReferences 2>/dev/null) || return 1
+
+	local applied=0 skipped=0 issue_json=""
+	while IFS= read -r issue_json; do
+		[[ -n "$issue_json" ]] || continue
+		if _sah_backfill_one "$issue_json"; then
+			applied=$((applied + 1))
+		else
+			skipped=$((skipped + 1))
+		fi
+	done < <(printf '%s' "$candidates" | jq -c '.[]')
+	printf 'Backfill %s: attributable=%d skipped_or_ambiguous=%d\n' \
+		"$([[ "$SAH_APPLY" -eq 1 ]] && printf 'applied' || printf 'dry-run')" "$applied" "$skipped"
+	return 0
+}
+
+main() {
+	local command="${1:-}"
+	[[ -n "$command" ]] && shift || true
+	case "$command" in
+	report | backfill) ;;
+	help | -h | --help | "")
+		_sah_usage
+		return 0
+		;;
+	*)
+		printf 'Unknown command: %s\n' "$command" >&2
+		return 1
+		;;
+	esac
+
+	_sah_parse_options "$@" || return 1
+	_sah_resolve_repo || return 1
+	[[ -n "$SAH_SINCE" ]] || SAH_SINCE=$(_sah_default_since)
+	local base_search=""
+	base_search=$(_sah_completion_search "$SAH_SINCE")
+	case "$command" in
+	report) _sah_report "$base_search" ;;
+	backfill) _sah_backfill "$base_search" ;;
+	esac
+	return $?
+}
+
+main "$@"

--- a/.agents/scripts/task-complete-helper.sh
+++ b/.agents/scripts/task-complete-helper.sh
@@ -329,11 +329,11 @@ annotate_solved_label_for_pr() {
 
 	[[ -z "$pr_number" ]] && return 0
 
-	local -a gh_view_args=("pr" "view" "$pr_number" "--json" "title,body,labels" "--jq" '
+	local -a gh_view_args=("pr" "view" "$pr_number" "--json" "title,body" "--jq" '
 		def linked:
 			((.body // "") | match("(?i)(close[ds]?|fix(es|ed)?|resolve[ds]?)[[:space:]]*#([0-9]+)") | .captures[-1].string) //
 			((.title // "") | match("GH#([0-9]+)") | .captures[0].string) // "";
-		[linked, ([.labels[].name] | join(","))] | @tsv
+		linked
 	')
 	if [[ -n "$gh_repo" ]]; then
 		gh_view_args+=("--repo" "$gh_repo")
@@ -347,14 +347,8 @@ annotate_solved_label_for_pr() {
 	fi
 	[[ -z "$pr_output" ]] && return 0
 
-	local linked_issue="${pr_output%%$'\t'*}"
-	local pr_labels="${pr_output#*$'\t'}"
+	local linked_issue="$pr_output"
 	[[ "$linked_issue" =~ ^[0-9]+$ ]] || return 0
-
-	local solved_actor="interactive"
-	case ",${pr_labels}," in
-	*,origin:worker,* | *,origin:worker-takeover,*) solved_actor="worker" ;;
-	esac
 
 	local repo_slug="$gh_repo"
 	if [[ -z "$repo_slug" && -n "$repo_path" ]]; then
@@ -368,7 +362,7 @@ annotate_solved_label_for_pr() {
 	fi
 	[[ -z "$repo_slug" ]] && return 0
 
-	set_solved_label "$linked_issue" "$repo_slug" "$solved_actor" || true
+	set_solved_label_from_merged_pr "$linked_issue" "$repo_slug" "$pr_number" || true
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh
@@ -240,6 +240,15 @@ install_helper_stubs() {
 		printf '%s %s %s\n' "$issue" "$repo" "$actor" >>"$SOLVED_LABEL_LOG"
 		return 0
 	}
+	solved_actor_from_pr_labels() {
+		local labels_csv="$1"
+		case ",${labels_csv}," in
+		*,origin:worker,* | *,origin:worker-takeover,*) printf 'worker\n' ;;
+		*,origin:interactive,*) printf 'interactive\n' ;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
 	clear_terminal_issue_dispatch_labels() {
 		local issue="$1"
 		local repo="$2"
@@ -261,6 +270,7 @@ install_helper_stubs() {
 	auto_file_next_phase() { return 0; }
 	_unblock_circuit_breaker_meta_pr() { return 0; }
 	_pm_handle_partial_parent_closeout() { return 0; }
+	_pm_routing_feedback() { return 1; }
 	sleep() { return 0; }
 	return 0
 }
@@ -298,8 +308,8 @@ test_provided_empty_pr_labels_skip_refetch() {
 
 	assert_log_not_contains "$GH_CALL_LOG" "pr view" \
 		"provided empty pr_labels skips fallback fetch"
-	assert_log_contains "$SOLVED_LABEL_LOG" "22219 marcusquinn/aidevops interactive" \
-		"provided empty pr_labels keeps interactive solved attribution"
+	assert_log_not_contains "$SOLVED_LABEL_LOG" "22219 marcusquinn/aidevops" \
+		"provided empty pr_labels remains unattributed instead of guessing"
 	assert_log_contains "$GH_CALL_LOG" "cleanup 22219 marcusquinn/aidevops post-merge-pr-22585" \
 		"post-merge close strips terminal dispatch labels"
 	assert_log_contains "$GH_CALL_LOG" "status 22219 marcusquinn/aidevops done" \

--- a/.agents/scripts/tests/test-solved-attribution-helper.sh
+++ b/.agents/scripts/tests/test-solved-attribution-helper.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Integration coverage for solved-attribution report and guarded dry-run backfill.
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${TEST_DIR}/../solved-attribution-helper.sh"
+TMP_ROOT=$(mktemp -d -t solved-attribution.XXXXXX) || exit 1
+trap 'rm -rf "$TMP_ROOT"' EXIT
+STUB_DIR="${TMP_ROOT}/bin"
+mkdir -p "$STUB_DIR"
+
+cat >"${STUB_DIR}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -u
+if [[ "$1" == "issue" && "$2" == "list" ]]; then
+	case " $* " in
+	*" --json number,stateReason,closedByPullRequestsReferences "*)
+		printf '%s\n' '[{"number":101,"stateReason":"COMPLETED","closedByPullRequestsReferences":[{"number":11}]},{"number":102,"stateReason":"COMPLETED","closedByPullRequestsReferences":[{"number":12},{"number":13}]}]'
+		;;
+	*" label:solved:worker label:solved:interactive "*) printf '%s\n' '[{"number":5}]' ;;
+	*" label:solved:worker -label:solved:interactive "*) printf '%s\n' '[{"number":1},{"number":2}]' ;;
+	*" label:solved:interactive -label:solved:worker "*) printf '%s\n' '[{"number":3}]' ;;
+	*" -label:solved:worker -label:solved:interactive "*) printf '%s\n' '[{"number":4}]' ;;
+	*) printf '%s\n' '[]' ;;
+	esac
+	exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "view" && "$3" == "11" ]]; then
+	printf '2026-08-01T00:00:00Z\torigin:worker,bug\n'
+	exit 0
+fi
+printf '%s\n' '[]'
+exit 0
+STUB
+chmod +x "${STUB_DIR}/gh"
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+	local name="$1"
+	local needle="$2"
+	local haystack="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		PASS=$((PASS + 1))
+		printf 'PASS: %s\n' "$name"
+	else
+		FAIL=$((FAIL + 1))
+		printf 'FAIL: %s (missing %s)\n' "$name" "$needle" >&2
+	fi
+	return 0
+}
+
+REPORT=$(PATH="${STUB_DIR}:$PATH" "$HELPER" report --repo owner/repo --since 2026-08-01 --json)
+assert_contains "report counts worker attribution" '"solved_worker": 2' "$REPORT"
+assert_contains "report counts interactive attribution" '"solved_interactive": 1' "$REPORT"
+assert_contains "report isolates conflicting attribution" '"conflicting": 1' "$REPORT"
+assert_contains "report counts missing attribution" '"unattributed": 1' "$REPORT"
+assert_contains "report calculates coverage" '"coverage_percent": 60' "$REPORT"
+
+BACKFILL=$(PATH="${STUB_DIR}:$PATH" "$HELPER" backfill --repo owner/repo --since 2026-08-01 --limit 10)
+assert_contains "dry-run attributes unambiguous merged worker PR" '[DRY-RUN] issue #101 <- solved:worker from merged PR #11' "$BACKFILL"
+assert_contains "dry-run skips ambiguous multiple-PR evidence" 'skipped_or_ambiguous=1' "$BACKFILL"
+
+if PATH="${STUB_DIR}:$PATH" "$HELPER" report --repo owner/repo --since 2026-08-01 --min-coverage 80 >/dev/null 2>&1; then
+	FAIL=$((FAIL + 1))
+	printf 'FAIL: minimum coverage gate should fail below threshold\n' >&2
+else
+	PASS=$((PASS + 1))
+	printf 'PASS: minimum coverage gate fails below threshold\n'
+fi
+
+printf 'Results: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/.agents/scripts/tests/test-solved-label-attribution.sh
+++ b/.agents/scripts/tests/test-solved-label-attribution.sh
@@ -5,8 +5,7 @@
 # test-solved-label-attribution.sh — regression guard for GH#22117 / t3376.
 #
 # Verifies the solved:* attribution dimension stays separate from origin:* and
-# that pulse-merge applies solved:worker for worker evidence and
-# solved:interactive for interactive PRs.
+# that actor derivation fails closed when PR provenance is absent.
 
 set -u
 
@@ -57,6 +56,9 @@ export GH_LOG
 
 gh() {
 	printf '%s\n' "$*" >>"$GH_LOG"
+	if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+		printf '%s\n' "${TEST_PR_EVIDENCE:-}"
+	fi
 	return 0
 }
 export -f gh
@@ -74,13 +76,56 @@ interactive_call="$(<"$GH_LOG")"
 assert_contains "interactive attribution adds solved:interactive" "--add-label solved:interactive" "$interactive_call"
 assert_contains "interactive attribution removes solved:worker" "--remove-label solved:worker" "$interactive_call"
 
+assert_contains "worker PR provenance resolves to worker" "worker" \
+	"$(solved_actor_from_pr_labels "bug,origin:worker")"
+assert_contains "worker takeover provenance resolves to worker" "worker" \
+	"$(solved_actor_from_pr_labels "origin:worker-takeover")"
+assert_contains "interactive PR provenance resolves to interactive" "interactive" \
+	"$(solved_actor_from_pr_labels "origin:interactive,tier:standard")"
+if solved_actor_from_pr_labels "bug,tier:standard" >/dev/null; then
+	fail "missing PR provenance remains unattributed" "unexpected actor"
+else
+	pass "missing PR provenance remains unattributed"
+fi
+
+: >"$GH_LOG"
+TEST_PR_EVIDENCE=$'2026-08-08T00:00:00Z\torigin:worker'
+set_solved_label_from_merged_pr 125 owner/repo 225
+assert_contains "merged PR evidence attributes its linked issue" \
+	"issue edit 125 --repo owner/repo" "$(<"$GH_LOG")"
+
+: >"$GH_LOG"
+TEST_PR_EVIDENCE=$'\torigin:interactive'
+if set_solved_label_from_merged_pr 126 owner/repo 226; then
+	fail "unmerged PR is never treated as solved" "unexpected attribution"
+else
+	pass "unmerged PR is never treated as solved"
+fi
+
 pulse_source="$(<"$SCRIPT_DIR/pulse-merge.sh")"
 # shellcheck disable=SC2016  # Static source assertion; variables are intentionally literal.
 literal_solved_call='set_solved_label "$linked_issue" "$repo_slug" "$_solved_actor"'
 assert_contains "pulse merge applies solved label on linked issue" \
 	"$literal_solved_call" "$pulse_source"
-assert_contains "pulse merge treats origin:worker-takeover as worker-solved" \
-	"*,origin:worker,* | *,origin:worker-takeover,*) _solved_actor=\"worker\"" "$pulse_source"
+
+# shellcheck disable=SC2016 # Static source assertion; variables are intentionally literal.
+assert_contains "pulse merge uses canonical actor derivation" \
+	'solved_actor_from_pr_labels "$pr_labels"' "$pulse_source"
+
+issue_sync_source="$(<"$SCRIPT_DIR/issue-sync-helper-close.sh")"
+# shellcheck disable=SC2016 # Static source assertion; variables are intentionally literal.
+assert_contains "issue-sync completion attributes from merged PR evidence" \
+	'set_solved_label_from_merged_pr "$issue_number" "$repo" "$pr_num"' "$issue_sync_source"
+
+reconcile_source="$(<"$SCRIPT_DIR/pulse-issue-reconcile-actions.sh")"
+# shellcheck disable=SC2016 # Static source assertion; variables are intentionally literal.
+assert_contains "reconcile completion attributes from merged PR evidence" \
+	'set_solved_label_from_merged_pr "$issue_num" "$slug" "$merged_pr_num"' "$reconcile_source"
+
+workflow_source="$(<"$SCRIPT_DIR/../../.github/workflows/issue-sync-reusable.yml")"
+# shellcheck disable=SC2016 # Static source assertion; variables are intentionally literal.
+assert_contains "native merge hygiene applies solved attribution" \
+	'set_solved_label "$ISSUE_NUM" "$REPO" "$SOLVED_ACTOR"' "$workflow_source"
 
 if [[ $TESTS_FAILED -eq 0 ]]; then
 	printf '%sPASS%s: test-solved-label-attribution — %d assertions\n' \

--- a/.agents/scripts/tests/test-solved-label-attribution.sh
+++ b/.agents/scripts/tests/test-solved-label-attribution.sh
@@ -82,6 +82,13 @@ assert_contains "worker takeover provenance resolves to worker" "worker" \
 	"$(solved_actor_from_pr_labels "origin:worker-takeover")"
 assert_contains "interactive PR provenance resolves to interactive" "interactive" \
 	"$(solved_actor_from_pr_labels "origin:interactive,tier:standard")"
+assert_contains "takeover provenance overrides retained interactive origin" "worker" \
+	"$(solved_actor_from_pr_labels "origin:interactive,origin:worker-takeover")"
+if solved_actor_from_pr_labels "origin:worker,origin:interactive" >/dev/null; then
+	fail "contradictory PR provenance remains unattributed" "unexpected actor"
+else
+	pass "contradictory PR provenance remains unattributed"
+fi
 if solved_actor_from_pr_labels "bug,tier:standard" >/dev/null; then
 	fail "missing PR provenance remains unattributed" "unexpected actor"
 else

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -951,7 +951,13 @@ jobs:
 
           # GH#28464: completion blockers use the shared semantic resolver.
           # shellcheck source=/dev/null
+          source __aidevops/.agents/scripts/shared-constants.sh
+          # shellcheck source=/dev/null
           source __aidevops/.agents/scripts/dependency-event-reconciler.sh
+
+          PR_LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels \
+            --jq '[.labels[].name] | join(",")' 2>/dev/null || true)
+          SOLVED_ACTOR=$(solved_actor_from_pr_labels "$PR_LABELS" 2>/dev/null || true)
 
           echo "Processing issues: $ALL_ISSUES"
 
@@ -1032,6 +1038,13 @@ jobs:
             if [[ "$IS_REJECTED" == "true" ]]; then
               echo "Skipping status:done on #$ISSUE_NUM — has rejection label: $REJECTION_MATCH"
               continue
+            fi
+
+            if [[ -n "$SOLVED_ACTOR" ]]; then
+              set_solved_label "$ISSUE_NUM" "$REPO" "$SOLVED_ACTOR" || \
+                echo "Warning: failed to apply solved:${SOLVED_ACTOR} to #$ISSUE_NUM"
+            else
+              echo "Warning: PR #$PR_NUMBER has no unambiguous origin label; leaving #$ISSUE_NUM unattributed"
             fi
 
             # Apply status:done label atomically (create if needed).


### PR DESCRIPTION
## Summary

Derive completion attribution from verified merged PR provenance, wire every closeout path, and add guarded reporting/backfill tooling that isolates ambiguous evidence.

## Files Changed

.agents/reference/worker-diagnostics.md, .agents/scripts/issue-sync-helper-close.sh, .agents/scripts/pulse-issue-reconcile-actions.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/shared-gh-wrappers.sh, .agents/scripts/solved-attribution-helper.sh, .agents/scripts/task-complete-helper.sh, .agents/scripts/tests/test-pulse-merge-post-merge-label-fetch.sh, .agents/scripts/tests/test-solved-attribution-helper.sh, .agents/scripts/tests/test-solved-label-attribution.sh, .github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — ShellCheck and actionlint passed; targeted attribution, issue-sync, task-complete, Pulse reconciliation/merge, and worker-activity suites passed; full local lint completed with only pre-existing broad-debt advisories.

Resolves #29802


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.238 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 32m and 488,812 tokens on this with the user in an interactive session.