### PR TITLE
GH#29803: Add compact worktree archives

### DIFF
--- a/.agents/scripts/tests/test-worktree-archive-helper.sh
+++ b/.agents/scripts/tests/test-worktree-archive-helper.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../worktree-archive-helper.sh"
+TEST_ROOT="$(mktemp -d)"
+TESTS_RUN=0
+TESTS_FAILED=0
+
+cleanup() {
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+result() {
+	local name="$1"
+	local rc="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+	else
+		printf 'FAIL %s\n' "$name"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+setup_repo() {
+	local name="$1"
+	local bare="$TEST_ROOT/${name}.git"
+	local canonical="$TEST_ROOT/${name}-canonical"
+	local worktree="$TEST_ROOT/${name}-worktree"
+	git init -q --bare "$bare" || return 1
+	git clone -q "$bare" "$canonical" || return 1
+	git -C "$canonical" config user.email test@example.invalid || return 1
+	git -C "$canonical" config user.name Test || return 1
+	git -C "$canonical" config commit.gpgsign false || return 1
+	git -C "$canonical" checkout -q -b main || return 1
+	printf 'base\n' >"$canonical/file.txt"
+	git -C "$canonical" add file.txt || return 1
+	git -C "$canonical" commit -q -m base || return 1
+	git -C "$canonical" push -q -u origin main || return 1
+	git -C "$bare" symbolic-ref HEAD refs/heads/main || return 1
+	git -C "$canonical" remote set-head origin main || return 1
+	git -C "$canonical" worktree add -q -b feature/archive "$worktree" main || return 1
+	git -C "$worktree" config user.email test@example.invalid || return 1
+	git -C "$worktree" config user.name Test || return 1
+	printf '%s\t%s\n' "$canonical" "$worktree"
+	return 0
+}
+
+test_clean_archive() {
+	local paths canonical worktree archive_root archive rc=0
+	paths=$(setup_repo clean) || return 1
+	IFS=$'\t' read -r canonical worktree <<<"$paths"
+	archive_root="$TEST_ROOT/clean-archives"
+	archive=$(bash "$HELPER" archive "$worktree" --repo owner/repo --issue 10 \
+		--reason post-pr-cleanup --base-branch main --output-root "$archive_root") || return 1
+	[[ -f "$archive/manifest.json" && ! -f "$archive/commits.bundle" ]] || rc=1
+	python3 - "$archive/manifest.json" <<'PY' || rc=1
+import json, sys
+m = json.load(open(sys.argv[1], encoding="utf-8"))
+assert m["dirty_state"] == "clean"
+assert m["base_branch"] == "main"
+assert m["base_sha"] == m["head_sha"]
+assert m["default_branch"] == "main"
+PY
+	bash "$HELPER" verify "$archive" >/dev/null || rc=1
+	[[ "$(bash "$HELPER" list --repo owner/repo --issue 10 --output-root "$archive_root" | wc -l | tr -d ' ')" == "1" ]] || rc=1
+	result "clean archive records exact base metadata and verifies" "$rc"
+	return 0
+}
+
+test_restore_commits_dirty_and_untracked() {
+	local paths canonical worktree archive_root archive target rc=0
+	paths=$(setup_repo restore) || return 1
+	IFS=$'\t' read -r canonical worktree <<<"$paths"
+	archive_root="$TEST_ROOT/restore-archives"
+	printf 'commit\n' >>"$worktree/file.txt"
+	git -C "$worktree" commit -qam local || return 1
+	printf 'staged\n' >"$worktree/staged.txt"
+	git -C "$worktree" add staged.txt || return 1
+	printf 'dirty\n' >>"$worktree/file.txt"
+	mkdir -p "$worktree/local"
+	printf 'untracked\n' >"$worktree/local/note.txt"
+	ln -s ../file.txt "$worktree/local/file-link"
+	archive=$(bash "$HELPER" archive "$worktree" --repo owner/repo --issue 11 \
+		--reason failed-worker --base-branch main --output-root "$archive_root") || return 1
+	[[ -s "$archive/commits.bundle" && -s "$archive/diff.patch" && -s "$archive/staged.patch" ]] || rc=1
+	[[ -s "$archive/untracked.tar.gz" && -s "$archive/untracked-files.txt" ]] || rc=1
+	target="$TEST_ROOT/restored-worktree"
+	bash "$HELPER" restore "$archive" --target "$target" >/dev/null || rc=1
+	grep -q '^commit$' "$target/file.txt" || rc=1
+	grep -q '^dirty$' "$target/file.txt" || rc=1
+	[[ "$(git -C "$target" show :staged.txt)" == "staged" ]] || rc=1
+	[[ "$(cat "$target/local/note.txt")" == "untracked" ]] || rc=1
+	[[ -L "$target/local/file-link" && "$(readlink "$target/local/file-link")" == "../file.txt" ]] || rc=1
+	[[ "$(git -C "$target" log -1 --format=%s)" == "local" ]] || rc=1
+	result "restore recovers bundle commits, staged and unstaged patches, and untracked files" "$rc"
+	return 0
+}
+
+test_verify_detects_tamper() {
+	local paths canonical worktree archive rc=0
+	paths=$(setup_repo verify) || return 1
+	IFS=$'\t' read -r canonical worktree <<<"$paths"
+	printf 'dirty\n' >>"$worktree/file.txt"
+	archive=$(bash "$HELPER" archive "$worktree" --repo owner/repo --issue 12 \
+		--reason failed-worker --base-branch main --output-root "$TEST_ROOT/verify-archives") || return 1
+	printf 'tamper\n' >>"$archive/diff.patch"
+	if bash "$HELPER" verify "$archive" >/dev/null 2>&1; then rc=1; fi
+	result "verify rejects artifact tampering" "$rc"
+	return 0
+}
+
+test_prune_modes() {
+	local paths canonical worktree root archive old_archive rc=0
+	paths=$(setup_repo prune) || return 1
+	IFS=$'\t' read -r canonical worktree <<<"$paths"
+	root="$TEST_ROOT/prune-archives"
+	archive=$(bash "$HELPER" archive "$worktree" --repo owner/repo --issue 13 \
+		--reason post-pr-cleanup --base-branch main --output-root "$root") || return 1
+	old_archive="$archive"
+	python3 - "$old_archive/manifest.json" <<'PY'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1])
+m = json.loads(p.read_text(encoding="utf-8"))
+m["created_at"] = "2000-01-01T00:00:00Z"
+p.write_text(json.dumps(m, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+	bash "$HELPER" prune --older-than 14d --max-total-size 20G --dry-run --output-root "$root" | grep -q "$old_archive" || rc=1
+	[[ -d "$old_archive" ]] || rc=1
+	bash "$HELPER" prune --older-than 14d --max-total-size 20G --apply --output-root "$root" >/dev/null || rc=1
+	[[ ! -e "$old_archive" ]] || rc=1
+	result "prune dry-run reports and apply removes expired archives" "$rc"
+	return 0
+}
+
+test_invalid_arguments() {
+	local paths canonical worktree rc=0
+	paths=$(setup_repo invalid) || return 1
+	IFS=$'\t' read -r canonical worktree <<<"$paths"
+	if bash "$HELPER" archive "$worktree" --repo bad --issue 1 --reason failed-worker --base-branch main >/dev/null 2>&1; then rc=1; fi
+	if bash "$HELPER" archive "$worktree" --repo owner/repo --issue 0 --reason failed-worker --base-branch main >/dev/null 2>&1; then rc=1; fi
+	if bash "$HELPER" prune --older-than fourteen --max-total-size 20G --dry-run >/dev/null 2>&1; then rc=1; fi
+	if bash "$HELPER" prune --older-than 14d --max-total-size 20G >/dev/null 2>&1; then rc=1; fi
+	if bash "$HELPER" restore "$TEST_ROOT/missing" --target "$TEST_ROOT/target" >/dev/null 2>&1; then rc=1; fi
+	result "invalid arguments fail safely" "$rc"
+	return 0
+}
+
+test_clean_archive
+test_restore_commits_dirty_and_untracked
+test_verify_detects_tamper
+test_prune_modes
+test_invalid_arguments
+
+printf '%s tests, %s failures\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/worktree-archive-helper.md
+++ b/.agents/scripts/worktree-archive-helper.md
@@ -1,0 +1,84 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Compact worktree archives
+
+`worktree-archive-helper.sh` preserves recovery evidence without retaining a full worker worktree. Archives default to `~/.aidevops/recovery/archives/` and are recovery artifacts, not backups of remote GitHub state.
+
+## Commands
+
+```bash
+# Archive a worker worktree. The command prints the new archive directory.
+worktree-archive-helper.sh archive <worktree-path> \
+  --repo owner/repo --issue 123 --reason failed-worker \
+  --base-branch develop [--base-sha <commit>] \
+  [--output-root <directory>] [--failure-log <file>]
+
+# Verify the manifest, artifact hashes, bundle, and untracked payload safety.
+worktree-archive-helper.sh verify <archive-directory>
+
+# Restore to a new linked worktree path. The target must not exist.
+worktree-archive-helper.sh restore <archive-directory> \
+  --target <new-worktree-path>
+
+# List all archives, or filter by repository and/or issue.
+worktree-archive-helper.sh list [--repo owner/repo] [--issue 123] \
+  [--output-root <directory>]
+
+# Preview or apply retention. Exactly one mode is required.
+worktree-archive-helper.sh prune --older-than 14d --max-total-size 20G \
+  [--dry-run|--apply] [--output-root <directory>]
+```
+
+`--reason` accepts only `failed-worker` or `post-pr-cleanup`. Untracked capture defaults to at most 10,000 paths and 1 GiB; override those bounds with `AIDEVOPS_WORKTREE_ARCHIVE_MAX_UNTRACKED_FILES` and `AIDEVOPS_WORKTREE_ARCHIVE_MAX_UNTRACKED_BYTES`. `AIDEVOPS_WORKTREE_ARCHIVE_ROOT` changes the default root.
+
+## Archive layout
+
+The path is `<root>/<owner>__<repo>/<issue>/<UTC timestamp>/`:
+
+| Artifact | Purpose |
+|---|---|
+| `manifest.json` | Schema, source and Git metadata, artifact sizes/SHA-256 hashes, and restore command |
+| `commits.bundle` | Incremental Git bundle when `HEAD` contains commits beyond the exact base SHA |
+| `diff.patch` | Binary-safe unstaged tracked changes; present even when empty |
+| `staged.patch` | Binary-safe staged changes; present even when empty |
+| `untracked-files.txt` | Human-readable escaped inventory; present even when empty |
+| `untracked.tar.gz` | Bounded untracked regular files and symlinks, when any exist |
+| `failure.log` | Optional final 256 KiB excerpt supplied with `--failure-log` |
+
+The manifest records the repository, issue, reason, creation time, source worktree, source Git common directory, branch, `HEAD`, base branch and exact base SHA, default branch, remote branch state, dirty state, artifacts, and restore instructions. `verify` rejects missing, changed, or unsafe artifacts.
+
+## Base selection
+
+The caller must select the semantic base in this order:
+
+1. the PR `baseRefName`;
+2. dispatch metadata's target branch;
+3. the repository integration branch, or its default branch.
+
+Pass that name with `--base-branch`. Pass the already-observed commit with `--base-sha` whenever available. Without `--base-sha`, the helper resolves `origin/<base-branch>` first and then the local branch. It always stores the resolved commit, because the base is not necessarily `main` and a moving branch name is insufficient recovery evidence.
+
+## Restore workflow
+
+1. Run `verify <archive-directory>` before trusting the archive.
+2. Ensure the source repository named by `source_git_common_dir` still exists. Incremental commit bundles deliberately depend on that repository's base objects.
+3. Run `restore ... --target <new-path>`. The helper imports bundled commits, creates a uniquely named linked branch at the archived `HEAD`, applies the staged patch to the index, applies the unstaged patch, and safely expands the untracked payload.
+4. Inspect `git status`, compare the restored `HEAD` and `base_sha`, and publish a branch/PR before deleting either recovery copy.
+
+Restore never overwrites an existing path. If restoration stops after creating a worktree, preserve it for inspection and use normal guarded worktree cleanup after resolving the cause.
+
+## Retention
+
+The recommended policy is `--older-than 14d --max-total-size 20G`. `prune` selects every archive older than the age limit, then oldest remaining archives until retained size is at or below the cap. It ignores malformed directories rather than deleting unverified data. Always inspect `--dry-run` output before using `--apply` in a manual operation.
+
+## Future pulse and worker integration
+
+Pulse/worker integration is explicitly a follow-up after this standalone helper is verified. No cleanup path calls it yet.
+
+That follow-up may:
+
+- archive before deleting terminal failed worker worktrees that have no PR;
+- delete clean, pushed PR worktrees as disposable runtime cache;
+- prune compact archives and legacy full recovery worktrees by age and total-size caps.
+
+Continue preserving full worktrees for interactive/manual owners, security incidents, a `preserve-forensics` marker or label, repeated unexplained failures, and any archive or verification failure. Archive failure must stop only deletion of that worktree, not broader safe cleanup.

--- a/.agents/scripts/worktree-archive-helper.sh
+++ b/.agents/scripts/worktree-archive-helper.sh
@@ -1,0 +1,510 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+ARCHIVE_ROOT="${AIDEVOPS_WORKTREE_ARCHIVE_ROOT:-${HOME}/.aidevops/recovery/archives}"
+MAX_UNTRACKED_FILES="${AIDEVOPS_WORKTREE_ARCHIVE_MAX_UNTRACKED_FILES:-10000}"
+MAX_UNTRACKED_BYTES="${AIDEVOPS_WORKTREE_ARCHIVE_MAX_UNTRACKED_BYTES:-1073741824}"
+ARCHIVE_SCHEMA="aidevops-worktree-archive-v1"
+
+usage() {
+	cat <<'USAGE'
+Usage: worktree-archive-helper.sh <command> [options]
+
+Commands:
+  archive WORKTREE --repo OWNER/REPO --issue N
+      --reason failed-worker|post-pr-cleanup --base-branch BRANCH
+      [--base-sha SHA] [--output-root DIR] [--failure-log FILE]
+  restore ARCHIVE_DIR --target NEW_WORKTREE_PATH
+  list [--repo OWNER/REPO] [--issue N] [--output-root DIR]
+  verify ARCHIVE_DIR
+  prune --older-than 14d --max-total-size 20G [--dry-run|--apply]
+      [--output-root DIR]
+
+Environment:
+  AIDEVOPS_WORKTREE_ARCHIVE_ROOT                Override the archive root.
+  AIDEVOPS_WORKTREE_ARCHIVE_MAX_UNTRACKED_FILES Maximum untracked paths (10000).
+  AIDEVOPS_WORKTREE_ARCHIVE_MAX_UNTRACKED_BYTES Maximum untracked bytes (1 GiB).
+USAGE
+	return 0
+}
+
+die() {
+	local message="$1"
+	printf 'Error: %s\n' "$message" >&2
+	return 1
+}
+
+require_value() {
+	local option="$1"
+	local value="${2:-}"
+	if [[ -z "$value" ]]; then
+		die "$option requires a value"
+		return 1
+	fi
+	return 0
+}
+
+validate_repo() {
+	local repo="$1"
+	if [[ ! "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+		die "invalid repository slug: $repo"
+		return 1
+	fi
+	return 0
+}
+
+validate_issue() {
+	local issue="$1"
+	if [[ ! "$issue" =~ ^[1-9][0-9]*$ ]]; then
+		die "issue must be a positive integer"
+		return 1
+	fi
+	return 0
+}
+
+validate_branch() {
+	local branch="$1"
+	if ! git check-ref-format --branch "$branch" >/dev/null 2>&1; then
+		die "invalid base branch: $branch"
+		return 1
+	fi
+	return 0
+}
+
+validate_archive_dir() {
+	local archive_dir="$1"
+	if [[ ! -d "$archive_dir" || ! -f "$archive_dir/manifest.json" ]]; then
+		die "archive manifest not found: $archive_dir"
+		return 1
+	fi
+	return 0
+}
+
+timestamp_utc() {
+	date -u '+%Y%m%dT%H%M%SZ'
+	return 0
+}
+
+iso_utc() {
+	date -u '+%Y-%m-%dT%H:%M:%SZ'
+	return 0
+}
+
+resolve_base_sha() {
+	local worktree="$1"
+	local base_branch="$2"
+	local requested_sha="$3"
+	local resolved=""
+	if [[ -n "$requested_sha" ]]; then
+		resolved=$(git -C "$worktree" rev-parse --verify "${requested_sha}^{commit}" 2>/dev/null) || return 1
+	else
+		resolved=$(git -C "$worktree" rev-parse --verify "refs/remotes/origin/${base_branch}^{commit}" 2>/dev/null || true)
+		if [[ -z "$resolved" ]]; then
+			resolved=$(git -C "$worktree" rev-parse --verify "refs/heads/${base_branch}^{commit}" 2>/dev/null) || return 1
+		fi
+	fi
+	printf '%s\n' "$resolved"
+	return 0
+}
+
+capture_untracked() {
+	local worktree="$1"
+	local archive_dir="$2"
+	local inventory="$archive_dir/untracked-files.nul"
+	git -C "$worktree" ls-files --others --exclude-standard -z >"$inventory" || return 1
+	python3 - "$worktree" "$inventory" "$archive_dir" "$MAX_UNTRACKED_FILES" "$MAX_UNTRACKED_BYTES" <<'PY'
+import os
+import pathlib
+import sys
+import tarfile
+
+root = pathlib.Path(sys.argv[1]).resolve()
+inventory = pathlib.Path(sys.argv[2])
+archive = pathlib.Path(sys.argv[3])
+limit_files = int(sys.argv[4])
+limit_bytes = int(sys.argv[5])
+raw_paths = [p for p in inventory.read_bytes().split(b"\0") if p]
+display = []
+total = 0
+paths = []
+for raw in raw_paths:
+    rel = pathlib.PurePosixPath(os.fsdecode(raw))
+    if rel.is_absolute() or ".." in rel.parts:
+        raise SystemExit("unsafe untracked path")
+    target = root.joinpath(*rel.parts)
+    if not target.is_file() and not target.is_symlink():
+        raise SystemExit("unsupported untracked path type")
+    total += target.lstat().st_size
+    paths.append((raw, rel, target))
+    display.append(os.fsdecode(raw).replace("\\", "\\\\").replace("\n", "\\n"))
+if len(paths) > limit_files or total > limit_bytes:
+    raise SystemExit("untracked payload exceeds configured limit")
+(archive / "untracked-files.txt").write_text("".join(path + "\n" for path in display), encoding='utf-8')
+inventory.unlink()
+if paths:
+    with tarfile.open(archive / "untracked.tar.gz", "w:gz") as output:
+        for _, rel, target in paths:
+            output.add(target, arcname=str(rel), recursive=False)
+PY
+	return $?
+}
+
+write_manifest() {
+	local archive_dir="$1"
+	local repo="$2"
+	local issue="$3"
+	local reason="$4"
+	local created_at="$5"
+	local worktree="$6"
+	local branch="$7"
+	local head_sha="$8"
+	local base_branch="$9"
+	local base_sha="${10}"
+	local default_branch="${11}"
+	local remote_state="${12}"
+	local dirty_state="${13}"
+	local git_common_dir="${14}"
+	python3 - "$archive_dir" "$repo" "$issue" "$reason" "$created_at" "$worktree" "$branch" "$head_sha" "$base_branch" "$base_sha" "$default_branch" "$remote_state" "$dirty_state" "$git_common_dir" "$ARCHIVE_SCHEMA" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+archive = pathlib.Path(sys.argv[1])
+names = sorted(path.name for path in archive.iterdir() if path.name != 'manifest.json')
+artifacts = []
+for name in names:
+    path = archive / name
+    if not path.is_file():
+        continue
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    artifacts.append({'name': name, "size": path.stat().st_size, "sha256": digest})
+manifest = {
+    'schema': sys.argv[15],
+    'repo': sys.argv[2],
+    'issue': int(sys.argv[3]),
+    "reason": sys.argv[4],
+    "created_at": sys.argv[5],
+    "source_worktree": sys.argv[6],
+    'source_git_common_dir': sys.argv[14],
+    "branch": sys.argv[7],
+    "head_sha": sys.argv[8],
+    "base_branch": sys.argv[9],
+    "base_sha": sys.argv[10],
+    "default_branch": sys.argv[11],
+    "remote_branch_state": sys.argv[12],
+    "dirty_state": sys.argv[13],
+    "artifacts": artifacts,
+    "restore_instructions": f"worktree-archive-helper.sh restore {archive} --target <new-worktree-path>",
+}
+(archive / 'manifest.json').write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding='utf-8')
+PY
+	return $?
+}
+
+archive_worktree() {
+	local worktree="${1:-}"
+	shift || true
+	local repo="" issue="" reason="" base_branch="" base_sha="" output_root="$ARCHIVE_ROOT" failure_log=""
+	local created_at timestamp repo_path archive_dir branch head_sha default_branch remote_state dirty_state git_common_dir commit_count
+	[[ -n "$worktree" ]] || { usage >&2; return 1; }
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--repo) require_value "$1" "${2:-}" || return 1; repo="$2"; shift 2 ;;
+		--issue) require_value "$1" "${2:-}" || return 1; issue="$2"; shift 2 ;;
+		--reason) require_value "$1" "${2:-}" || return 1; reason="$2"; shift 2 ;;
+		--base-branch) require_value "$1" "${2:-}" || return 1; base_branch="$2"; shift 2 ;;
+		--base-sha) require_value "$1" "${2:-}" || return 1; base_sha="$2"; shift 2 ;;
+		--output-root) require_value "$1" "${2:-}" || return 1; output_root="$2"; shift 2 ;;
+		--failure-log) require_value "$1" "${2:-}" || return 1; failure_log="$2"; shift 2 ;;
+		*) die "unknown archive option: $1"; return 1 ;;
+		esac
+	done
+	validate_repo "$repo" || return 1
+	validate_issue "$issue" || return 1
+	[[ "$reason" == "failed-worker" || "$reason" == "post-pr-cleanup" ]] || { die "invalid archive reason"; return 1; }
+	validate_branch "$base_branch" || return 1
+	[[ -d "$worktree" ]] || { die "worktree does not exist: $worktree"; return 1; }
+	git -C "$worktree" rev-parse --is-inside-work-tree >/dev/null 2>&1 || { die "not a Git worktree: $worktree"; return 1; }
+	worktree=$(cd "$worktree" && pwd -P) || return 1
+	base_sha=$(resolve_base_sha "$worktree" "$base_branch" "$base_sha") || { die "cannot resolve base SHA"; return 1; }
+	head_sha=$(git -C "$worktree" rev-parse HEAD) || return 1
+	branch=$(git -C "$worktree" symbolic-ref --short -q HEAD 2>/dev/null || printf 'detached')
+	default_branch=$(git -C "$worktree" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)
+	default_branch=${default_branch#origin/}
+	[[ -n "$default_branch" ]] || default_branch="$base_branch"
+	remote_state="unknown"
+	if [[ "$branch" != "detached" ]]; then
+		local remote_rc=0
+		git -C "$worktree" ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1 || remote_rc=$?
+		if [[ "$remote_rc" -eq 0 ]]; then
+			remote_state="present"
+		elif [[ "$remote_rc" -eq 2 ]]; then
+			remote_state="missing"
+		fi
+	fi
+	dirty_state=$(git -C "$worktree" status --porcelain=v1)
+	if [[ -n "$dirty_state" ]]; then dirty_state="dirty"; else dirty_state="clean"; fi
+	git_common_dir=$(git -C "$worktree" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || git -C "$worktree" rev-parse --git-common-dir) || return 1
+	timestamp=$(timestamp_utc)
+	created_at=$(iso_utc)
+	repo_path="${repo//\//__}"
+	archive_dir="${output_root%/}/${repo_path}/${issue}/${timestamp}"
+	if [[ -e "$archive_dir" ]]; then archive_dir="${archive_dir}-$$"; fi
+	mkdir -p "$archive_dir" || return 1
+	git -C "$worktree" diff --binary >"$archive_dir/diff.patch" || return 1
+	git -C "$worktree" diff --cached --binary >"$archive_dir/staged.patch" || return 1
+	commit_count=$(git -C "$worktree" rev-list --count "${base_sha}..${head_sha}") || return 1
+	if [[ "$commit_count" -gt 0 ]]; then
+		git -C "$worktree" bundle create "$archive_dir/commits.bundle" HEAD "^${base_sha}" || return 1
+	fi
+	capture_untracked "$worktree" "$archive_dir" || return 1
+	if [[ -n "$failure_log" ]]; then
+		[[ -f "$failure_log" ]] || { die "failure log does not exist"; return 1; }
+		python3 - "$failure_log" "$archive_dir/failure.log" <<'PY'
+import pathlib
+import sys
+source = pathlib.Path(sys.argv[1])
+target = pathlib.Path(sys.argv[2])
+with source.open("rb") as handle:
+    handle.seek(max(0, source.stat().st_size - 262144))
+    target.write_bytes(handle.read())
+PY
+	fi
+	write_manifest "$archive_dir" "$repo" "$issue" "$reason" "$created_at" "$worktree" "$branch" "$head_sha" "$base_branch" "$base_sha" "$default_branch" "$remote_state" "$dirty_state" "$git_common_dir" || return 1
+	printf '%s\n' "$archive_dir"
+	return 0
+}
+
+verify_archive() {
+	local archive_dir="$1"
+	validate_archive_dir "$archive_dir" || return 1
+	python3 - "$archive_dir" "$ARCHIVE_SCHEMA" <<'PY'
+import hashlib
+import json
+import pathlib
+import posixpath
+import subprocess
+import sys
+import tarfile
+
+archive = pathlib.Path(sys.argv[1]).resolve()
+manifest = json.loads((archive / 'manifest.json').read_text(encoding='utf-8'))
+required = ('repo', 'issue', "reason", 'created_at', "source_worktree", "branch", "head_sha", "base_branch", "base_sha", "default_branch", "remote_branch_state", "dirty_state", 'artifacts', "restore_instructions")
+missing = [key for key in required if key not in manifest]
+if manifest.get('schema') != sys.argv[2] or missing:
+    raise SystemExit("invalid manifest schema or missing fields: " + ", ".join(missing))
+for artifact in manifest['artifacts']:
+    path = archive / artifact['name']
+    if path.parent != archive or not path.is_file():
+        raise SystemExit("missing or unsafe artifact: " + artifact['name'])
+    if path.stat().st_size != artifact["size"] or hashlib.sha256(path.read_bytes()).hexdigest() != artifact["sha256"]:
+        raise SystemExit("artifact integrity mismatch: " + artifact['name'])
+bundle = archive / "commits.bundle"
+if bundle.exists():
+    common_dir = manifest.get('source_git_common_dir', "")
+    command = ["git"]
+    if common_dir and pathlib.Path(common_dir).is_dir():
+        command.append(f"--git-dir={common_dir}")
+    command.extend(["bundle", "verify", str(bundle)])
+    subprocess.run(command, check=True, stdout=subprocess.DEVNULL)
+payload = archive / "untracked.tar.gz"
+if payload.exists():
+    with tarfile.open(payload, "r:gz") as source:
+        for member in source.getmembers():
+            path = pathlib.PurePosixPath(member.name)
+            link = pathlib.PurePosixPath(member.linkname) if member.issym() else None
+            resolved_link = pathlib.PurePosixPath(posixpath.normpath(str(path.parent / link))) if link else None
+            if (path.is_absolute() or ".." in path.parts or member.isdev() or
+                    member.islnk() or (link and link.is_absolute()) or
+                    (resolved_link and ".." in resolved_link.parts)):
+                raise SystemExit("unsafe untracked archive member")
+print(f"verified {archive}")
+PY
+	return $?
+}
+
+restore_archive() {
+	local archive_dir="${1:-}"
+	shift || true
+	local target="" common_dir head_sha branch restore_branch
+	validate_archive_dir "$archive_dir" || return 1
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--target) require_value "$1" "${2:-}" || return 1; target="$2"; shift 2 ;;
+		*) die "unknown restore option: $1"; return 1 ;;
+		esac
+	done
+	[[ -n "$target" && ! -e "$target" ]] || { die "restore target must not exist"; return 1; }
+	verify_archive "$archive_dir" >/dev/null || return 1
+	IFS=$'\t' read -r common_dir head_sha branch < <(python3 - "$archive_dir/manifest.json" <<'PY'
+import json, sys
+m = json.load(open(sys.argv[1], encoding='utf-8'))
+print(m.get('source_git_common_dir', ""), m["head_sha"], m["branch"], sep=chr(9))
+PY
+	)
+	[[ -d "$common_dir" ]] || { die "source Git repository is unavailable: $common_dir"; return 1; }
+	if [[ -f "$archive_dir/commits.bundle" ]]; then
+		git --git-dir="$common_dir" fetch "$archive_dir/commits.bundle" HEAD >/dev/null || return 1
+	fi
+	restore_branch="archive-restore-$(date -u '+%Y%m%d%H%M%S')-$$"
+	git --git-dir="$common_dir" worktree add -b "$restore_branch" "$target" "$head_sha" >/dev/null || return 1
+	if [[ -s "$archive_dir/staged.patch" ]]; then git -C "$target" apply --index "$archive_dir/staged.patch" || return 1; fi
+	if [[ -s "$archive_dir/diff.patch" ]]; then git -C "$target" apply "$archive_dir/diff.patch" || return 1; fi
+	if [[ -f "$archive_dir/untracked.tar.gz" ]]; then
+		python3 - "$archive_dir/untracked.tar.gz" "$target" <<'PY'
+import pathlib
+import os
+import posixpath
+import shutil
+import sys
+import tarfile
+source = pathlib.Path(sys.argv[1])
+target = pathlib.Path(sys.argv[2]).resolve()
+with tarfile.open(source, "r:gz") as payload:
+    for member in payload.getmembers():
+        path = pathlib.PurePosixPath(member.name)
+        link = pathlib.PurePosixPath(member.linkname) if member.issym() else None
+        resolved_link = pathlib.PurePosixPath(posixpath.normpath(str(path.parent / link))) if link else None
+        if (path.is_absolute() or ".." in path.parts or member.isdev() or
+                member.islnk() or (link and link.is_absolute()) or
+                (resolved_link and ".." in resolved_link.parts)):
+            raise SystemExit("unsafe untracked archive member")
+        destination = target.joinpath(*path.parts)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if os.path.commonpath((str(target), str(destination.parent.resolve()))) != str(target):
+            raise SystemExit("untracked archive escaped restore target")
+        if member.isdir():
+            destination.mkdir(exist_ok=True)
+        elif member.issym():
+            destination.symlink_to(member.linkname)
+        elif member.isfile():
+            source_file = payload.extractfile(member)
+            if source_file is None:
+                raise SystemExit("missing untracked file payload")
+            with destination.open("wb") as output:
+                shutil.copyfileobj(source_file, output)
+            destination.chmod(member.mode & 0o777)
+        else:
+            raise SystemExit("unsupported untracked archive member")
+PY
+	fi
+	printf '%s\n' "$target"
+	return 0
+}
+
+list_archives() {
+	local repo="" issue="" output_root="$ARCHIVE_ROOT"
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--repo) require_value "$1" "${2:-}" || return 1; repo="$2"; shift 2 ;;
+		--issue) require_value "$1" "${2:-}" || return 1; issue="$2"; shift 2 ;;
+		--output-root) require_value "$1" "${2:-}" || return 1; output_root="$2"; shift 2 ;;
+		*) die "unknown list option: $1"; return 1 ;;
+		esac
+	done
+	[[ -z "$repo" ]] || validate_repo "$repo" || return 1
+	[[ -z "$issue" ]] || validate_issue "$issue" || return 1
+	python3 - "$output_root" "$repo" "$issue" <<'PY'
+import json
+import pathlib
+import sys
+root = pathlib.Path(sys.argv[1])
+repo_filter, issue_filter = sys.argv[2:]
+if root.is_dir():
+    for manifest_path in sorted(root.glob("*/*/*/manifest.json")):
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+        except (OSError, ValueError):
+            continue
+        if repo_filter and manifest.get('repo') != repo_filter:
+            continue
+        if issue_filter and str(manifest.get('issue')) != issue_filter:
+            continue
+        print(f"{manifest.get('created_at', '-')}\t{manifest.get('repo', '-')}#{manifest.get('issue', '-')}\t{manifest.get('reason', '-')}\t{manifest_path.parent}")
+PY
+	return $?
+}
+
+prune_archives() {
+	local older_than="" max_total="" mode="" output_root="$ARCHIVE_ROOT"
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--older-than) require_value "$1" "${2:-}" || return 1; older_than="$2"; shift 2 ;;
+		--max-total-size) require_value "$1" "${2:-}" || return 1; max_total="$2"; shift 2 ;;
+		--dry-run) [[ -z "$mode" ]] || { die "choose only one prune mode"; return 1; }; mode="dry-run"; shift ;;
+		--apply) [[ -z "$mode" ]] || { die "choose only one prune mode"; return 1; }; mode="apply"; shift ;;
+		--output-root) require_value "$1" "${2:-}" || return 1; output_root="$2"; shift 2 ;;
+		*) die "unknown prune option: $1"; return 1 ;;
+		esac
+	done
+	[[ "$older_than" =~ ^[1-9][0-9]*d$ ]] || { die "--older-than must use positive day syntax such as 14d"; return 1; }
+	[[ "$max_total" =~ ^[1-9][0-9]*([KMGTP])?$ ]] || { die "invalid --max-total-size"; return 1; }
+	[[ -n "$mode" ]] || { die "prune requires --dry-run or --apply"; return 1; }
+	python3 - "$output_root" "${older_than%d}" "$max_total" "$mode" "$ARCHIVE_SCHEMA" <<'PY'
+import datetime
+import json
+import pathlib
+import shutil
+import sys
+
+root = pathlib.Path(sys.argv[1]).resolve()
+days = int(sys.argv[2])
+raw_limit = sys.argv[3]
+mode = sys.argv[4]
+units = {"K": 1024, "M": 1024**2, "G": 1024**3, "T": 1024**4, "P": 1024**5}
+limit = int(raw_limit[:-1]) * units[raw_limit[-1]] if raw_limit[-1] in units else int(raw_limit)
+now = datetime.datetime.now(datetime.timezone.utc)
+entries = []
+if root.is_dir():
+    for manifest_path in root.glob("*/*/*/manifest.json"):
+        directory = manifest_path.parent
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+            if manifest.get('schema') != sys.argv[5]:
+                continue
+            created = datetime.datetime.fromisoformat(manifest['created_at'].replace("Z", "+00:00"))
+        except (OSError, ValueError, KeyError):
+            continue
+        size = sum(path.stat().st_size for path in directory.rglob("*") if path.is_file())
+        entries.append([created, size, directory, (now - created).days >= days])
+total = sum(entry[1] for entry in entries)
+selected = {entry[2] for entry in entries if entry[3]}
+remaining = sorted((entry for entry in entries if entry[2] not in selected), key=lambda item: item[0])
+remaining_total = total - sum(entry[1] for entry in entries if entry[2] in selected)
+for entry in remaining:
+    if remaining_total <= limit:
+        break
+    selected.add(entry[2])
+    remaining_total -= entry[1]
+for directory in sorted(selected):
+    print(f"{mode}\t{directory}")
+    if mode == "apply":
+        shutil.rmtree(directory)
+PY
+	return $?
+}
+
+main() {
+	local command="${1:-help}"
+	shift || true
+	case "$command" in
+	archive) archive_worktree "$@" ;;
+	restore) restore_archive "$@" ;;
+	list) list_archives "$@" ;;
+	verify) [[ $# -eq 1 ]] || { usage >&2; return 1; }; verify_archive "$1" ;;
+	prune) prune_archives "$@" ;;
+	help|-h|--help) usage ;;
+	*) usage >&2; return 1 ;;
+	esac
+	return $?
+}
+
+main "$@"

--- a/.agents/workflows/worktree-cleanup.md
+++ b/.agents/workflows/worktree-cleanup.md
@@ -34,6 +34,12 @@ git branch -D "$BRANCH_NAME" 2>/dev/null || true
 
 Cleanup failures are non-fatal — the PR is already merged.
 
+## Compact Recovery Archives
+
+Use [`../scripts/worktree-archive-helper.md`](../scripts/worktree-archive-helper.md) for the standalone archive, restore, list, verify, and retention commands. The helper preserves local commits, tracked/staged changes, bounded untracked files, and exact base metadata under `~/.aidevops/recovery/archives/`.
+
+Pulse and worker cleanup do **not** invoke the helper yet. Integrating archive-before-delete for terminal failures, disposable clean pushed-PR worktrees, and archive/full-worktree retention is a follow-up after the helper has been verified. Full worktrees remain required for manual owners, security/forensics cases, repeated unexplained failures, and archive safety failures.
+
 ## Manual Cleanup (interactive sessions)
 
 ```bash


### PR DESCRIPTION
## Summary

- add the compact worktree archive/restore helper checkpoint
- preserve local commits, tracked changes, staged changes, and bounded untracked files
- add focused shell coverage; documentation and final hardening remain in progress

## Files

- `.agents/scripts/worktree-archive-helper.sh`
- `.agents/scripts/tests/test-worktree-archive-helper.sh`
- `.agents/scripts/commands/worktree-cleanup.md` (planned)

## Verification

- `shellcheck .agents/scripts/worktree-archive-helper.sh .agents/scripts/tests/test-worktree-archive-helper.sh`
- `.agents/scripts/tests/test-worktree-archive-helper.sh`

Resolves #29803

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.238 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol
