### PR TITLE
GH#29810: Fix worker Bun PATH and JS dependency bootstrap

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1514,11 +1514,39 @@ _dlw_validate_worktree_for_launch() {
 _dlw_append_node_tool_env() {
 	local repo_path="$1"
 	local node_tool_bin="${repo_path}/node_modules/.bin"
-	[[ -d "$node_tool_bin" && ! -L "$node_tool_bin" ]] || return 0
-	[[ "$node_tool_bin" != *:* && "$node_tool_bin" != *$'\n'* ]] || return 0
-	# Expose only executable package entrypoints through PATH. Do not place a
-	# canonical-checkout symlink inside the worktree or grant broad file access.
-	worker_cmd+=(PATH="${node_tool_bin}:${PATH:-/usr/bin:/bin}")
+	local inherited_path="${PATH:-/usr/bin:/bin}"
+	local worker_path=""
+	local seen=""
+	local candidate=""
+	local IFS=':'
+
+	# Keep canonical package entrypoints first, followed by stable existing user
+	# tool installs needed by non-interactive workers. Never place symlinks inside
+	# the worktree or grant broad file access to the canonical checkout.
+	for candidate in \
+		"$node_tool_bin" \
+		"${HOME:+${HOME}/.bun/bin}" \
+		"${HOME:+${HOME}/.local/bin}" \
+		"${HOME:+${HOME}/.aidevops/bin}" \
+		"${HOME:+${HOME}/.aidevops/agents/scripts}"; do
+		[[ -d "$candidate" ]] || continue
+		[[ "$candidate" != *:* && "$candidate" != *$'\n'* ]] || continue
+		[[ "$candidate" != "$node_tool_bin" || ! -L "$candidate" ]] || continue
+		case ":$seen:" in
+		*":${candidate}:"*) continue ;;
+		esac
+		seen="${seen:+${seen}:}${candidate}"
+		worker_path="${worker_path:+${worker_path}:}${candidate}"
+	done
+	for candidate in $inherited_path; do
+		[[ -n "$candidate" && "$candidate" != *$'\n'* ]] || continue
+		case ":$seen:" in
+		*":${candidate}:"*) continue ;;
+		esac
+		seen="${seen:+${seen}:}${candidate}"
+		worker_path="${worker_path:+${worker_path}:}${candidate}"
+	done
+	worker_cmd+=(PATH="${worker_path:-/usr/bin:/bin}")
 	return 0
 }
 

--- a/.agents/scripts/setup/modules/schedulers.sh
+++ b/.agents/scripts/setup/modules/schedulers.sh
@@ -39,7 +39,7 @@ if ! declare -F aidevops_launchd_sanitized_path >/dev/null 2>&1; then
 		local input_path="${1:-${PATH:-}}"
 		local stable_path=""
 		if [[ -n "${HOME:-}" ]]; then
-			stable_path="${HOME}/.local/bin:${HOME}/.aidevops/agents/scripts:${HOME}/.aidevops/bin"
+			stable_path="${HOME}/.bun/bin:${HOME}/.local/bin:${HOME}/.aidevops/agents/scripts:${HOME}/.aidevops/bin"
 		fi
 		local default_path="${stable_path:+${stable_path}:}/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 		local result=""

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -445,7 +445,7 @@ aidevops_launchd_sanitized_path() {
 	local input_path="${1:-${PATH:-}}"
 	local stable_path=""
 	if [[ -n "${HOME:-}" ]]; then
-		stable_path="${HOME}/.local/bin:${HOME}/.aidevops/agents/scripts:${HOME}/.aidevops/bin"
+		stable_path="${HOME}/.bun/bin:${HOME}/.local/bin:${HOME}/.aidevops/agents/scripts:${HOME}/.aidevops/bin"
 	fi
 	local default_path="${stable_path:+${stable_path}:}/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 	local _aidevops_launchd_path_result=""

--- a/.agents/scripts/tests/test-launchd-sanitized-path.sh
+++ b/.agents/scripts/tests/test-launchd-sanitized-path.sh
@@ -72,13 +72,14 @@ assert_not_contains() {
 
 test_sanitized_path_filters_unsafe_entries() {
 	local test_home="$TEST_DIR/home"
+	local stable_bun_bin="$test_home/.bun/bin"
 	local stable_local_bin="$test_home/.local/bin"
 	local stable_scripts="$test_home/.aidevops/agents/scripts"
 	local stable_bin="$test_home/.aidevops/bin"
 	local stale_bundle="$test_home/.aidevops/runtime-bundles/old/agents/scripts"
 	local existing_dir="$TEST_DIR/existing-bin"
 	local missing_dir="$TEST_DIR/missing-bin"
-	mkdir -p "$stable_local_bin" "$stable_scripts" "$stable_bin" \
+	mkdir -p "$stable_bun_bin" "$stable_local_bin" "$stable_scripts" "$stable_bin" \
 		"$stale_bundle" "$existing_dir"
 
 	local polluted_path result
@@ -86,7 +87,7 @@ test_sanitized_path_filters_unsafe_entries() {
 	result=$(HOME="$test_home" aidevops_launchd_sanitized_path "$polluted_path")
 
 	local ok=0 stable_scripts_count=0
-	[[ "$result" == "${stable_local_bin}:${stable_scripts}:${stable_bin}:"* ]] || ok=1
+	[[ "$result" == "${stable_bun_bin}:${stable_local_bin}:${stable_scripts}:${stable_bin}:"* ]] || ok=1
 	[[ "$result" == *"$existing_dir"* ]] || ok=1
 	[[ "$result" == *"/usr/bin"* ]] || ok=1
 	stable_scripts_count=$(printf '%s' "$result" | tr ':' '\n' | grep -Fxc "$stable_scripts" || true)

--- a/.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh
@@ -80,10 +80,17 @@ if ! declare -F _dlw_append_node_tool_env >/dev/null 2>&1; then
 	fail "worker launch does not provide a local command path for canonical Node tools"
 fi
 worker_cmd=(env)
-_dlw_append_node_tool_env "$repo_dir"
-expected_tool_path="PATH=${repo_dir}/node_modules/.bin:${PATH}"
-if [[ "${worker_cmd[1]:-}" != "$expected_tool_path" ]]; then
-	fail "worker launch did not prepend only the canonical node_modules .bin directory"
+worker_home="${TEST_TMP}/home"
+mkdir -p "${worker_home}/.bun/bin" "${worker_home}/.local/bin" \
+	"${worker_home}/.aidevops/bin" "${worker_home}/.aidevops/agents/scripts"
+HOME="$worker_home" PATH="${worker_home}/.bun/bin:${PATH}" _dlw_append_node_tool_env "$repo_dir"
+expected_tool_prefix="PATH=${repo_dir}/node_modules/.bin:${worker_home}/.bun/bin:${worker_home}/.local/bin:${worker_home}/.aidevops/bin:${worker_home}/.aidevops/agents/scripts:"
+if [[ "${worker_cmd[1]:-}" != "$expected_tool_prefix"* ]]; then
+	fail "worker launch did not prepend canonical Node and stable user tool directories"
+fi
+bun_path_count=$(printf '%s' "${worker_cmd[1]}" | tr ':' '\n' | grep -Fxc "${worker_home}/.bun/bin" || true)
+if [[ "$bun_path_count" -ne 1 ]]; then
+	fail "worker launch did not deduplicate the stable Bun directory"
 fi
 tool_output=$("${worker_cmd[@]}" prettier) || fail "dispatcher-provided Node tool did not execute"
 if [[ "$tool_output" != "fixture-tool" ]]; then

--- a/.agents/scripts/tests/test-worktree-js-dependency-bootstrap.sh
+++ b/.agents/scripts/tests/test-worktree-js-dependency-bootstrap.sh
@@ -23,8 +23,11 @@ source "$ADD_HELPER"
 
 FAKE_BIN="${ROOT}/bin"
 WORKTREE="${ROOT}/aidevops-worktree"
+HOME_WORKTREE="${ROOT}/aidevops-home-bun-worktree"
 ORDINARY="${ROOT}/ordinary-worktree"
-mkdir -p "$FAKE_BIN" "$WORKTREE/.agents/scripts" "$ORDINARY/.agents/scripts"
+FAKE_HOME="${ROOT}/home"
+mkdir -p "$FAKE_BIN" "$WORKTREE/.agents/scripts" "$HOME_WORKTREE/.agents/scripts" \
+	"$ORDINARY/.agents/scripts" "$FAKE_HOME/.bun/bin"
 cat >"${FAKE_BIN}/bun" <<'BUN'
 #!/usr/bin/env bash
 mkdir -p node_modules/.bin
@@ -50,6 +53,22 @@ _bootstrap_aidevops_worktree_js_deps "$WORKTREE"
 	exit 1
 }
 printf 'PASS aidevops worktree bootstraps locked dependencies without lifecycle scripts\n'
+
+cp "${FAKE_BIN}/bun" "$FAKE_HOME/.bun/bin/bun"
+printf '{ "name": "aidevops", "devDependencies": { "typescript": "^5.0.0" } }\n' >"${HOME_WORKTREE}/package.json"
+printf '{}\n' >"${HOME_WORKTREE}/bun.lock"
+printf '#!/usr/bin/env bash\n' >"${HOME_WORKTREE}/aidevops.sh"
+rm -f "$BUN_ARGS_LOG"
+HOME="$FAKE_HOME" PATH="/usr/bin:/bin" _bootstrap_aidevops_worktree_js_deps "$HOME_WORKTREE"
+[[ -x "${HOME_WORKTREE}/node_modules/.bin/tsc" ]] || {
+	printf 'FAIL fixed HOME Bun path did not bootstrap tsc when bun was absent from PATH\n'
+	exit 1
+}
+[[ "$(cat "$BUN_ARGS_LOG")" == "install --frozen-lockfile --ignore-scripts" ]] || {
+	printf 'FAIL fixed HOME Bun path used unexpected arguments\n'
+	exit 1
+}
+printf 'PASS executable HOME Bun bootstraps dependencies when absent from PATH\n'
 
 rm -f "$BUN_ARGS_LOG"
 printf '{ "name": "ordinary-project", "devDependencies": { "typescript": "^5.0.0" } }\n' >"${ORDINARY}/package.json"

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -422,6 +422,7 @@ _restore_worktree_node_modules() {
 _bootstrap_aidevops_worktree_js_deps() {
 	local wt_path="$1"
 	local package_file="${wt_path}/package.json"
+	local bun_bin=""
 
 	[[ "$AIDEVOPS_WORKTREE_JS_BOOTSTRAP_ENABLED" == "1" ]] || return 0
 	[[ -f "$package_file" && -f "${wt_path}/bun.lock" ]] || return 0
@@ -429,14 +430,18 @@ _bootstrap_aidevops_worktree_js_deps() {
 	grep -Eq '"name"[[:space:]]*:[[:space:]]*"aidevops"' "$package_file" 2>/dev/null || return 0
 	[[ ! -x "${wt_path}/node_modules/.bin/tsc" ]] || return 0
 
-	if ! command -v bun >/dev/null 2>&1; then
+	bun_bin=$(command -v bun 2>/dev/null || true)
+	if [[ -z "$bun_bin" && -n "${HOME:-}" && -x "${HOME}/.bun/bin/bun" ]]; then
+		bun_bin="${HOME}/.bun/bin/bun"
+	fi
+	if [[ -z "$bun_bin" ]]; then
 		print_warning "aidevops JavaScript dev dependencies are missing in ${wt_path}"
 		print_warning "Run: (cd \"${wt_path}\" && bun install --frozen-lockfile --ignore-scripts)"
 		return 0
 	fi
 
 	print_info "Installing aidevops JavaScript dev dependencies in ${wt_path}..."
-	if (cd "$wt_path" && bun install --frozen-lockfile --ignore-scripts); then
+	if (cd "$wt_path" && "$bun_bin" install --frozen-lockfile --ignore-scripts); then
 		if [[ -x "${wt_path}/node_modules/.bin/tsc" ]]; then
 			print_success "Bootstrapped aidevops JavaScript dev dependencies"
 			return 0


### PR DESCRIPTION
## Summary

- resolve Bun from the existing `$HOME/.bun/bin/bun` install when shell PATH omits it
- expose stable existing user tool directories to worker and scheduler PATHs while preserving repository Node tool precedence
- add focused regression coverage for worktree bootstrap, worker PATH ordering/deduplication, and launchd PATH generation

## Verification

- `bash .agents/scripts/tests/test-worktree-js-dependency-bootstrap.sh`
- `bash .agents/scripts/tests/test-pulse-dispatch-worker-launch-lock.sh`
- `bash .agents/scripts/tests/test-launchd-sanitized-path.sh`
- `bash .agents/scripts/tests/test-launchd-install-if-changed.sh`
- targeted `shellcheck`
- `.agents/scripts/linters-local.sh`

Resolves #29810
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.238 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 10m and 160,653 tokens on this as a headless worker.