### PR TITLE
GH#29815: feat: show delegated child counts in routing feedback

### DIFF
--- a/.agents/plugins/opencode-aidevops/tests/test-observability-routing-join.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-observability-routing-join.mjs
@@ -47,6 +47,8 @@ test("completed child responses join queued routing decisions to parent feedback
     const summary = observability.getRoutingFeedback("root-session");
     assert.equal(summary.requestCount, 1);
     assert.deepEqual(summary.tierPath, ["simple"]);
+    assert.equal(summary.delegationCount, 1);
+    assert.deepEqual(summary.delegationTiers, { simple: 1, standard: 0, thinking: 0 });
     assert.equal(summary.tokensTotal, 17);
     assert.equal(summary.models[0], "openai/gpt-5.6-luna");
   } finally {

--- a/.agents/plugins/opencode-aidevops/tests/test-routing-feedback-handler.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-routing-feedback-handler.mjs
@@ -13,7 +13,7 @@ function event(type, sessionID = "root") {
 
 test("routing feedback handler emits changed idle summaries once", async () => {
   const toasts = [];
-  let requests = [{ session_id: "child", routing_tier: "simple", tokens_total: 10 }];
+  let requests = [{ session_id: "child-a", parent_session_id: "root", routing_tier: "simple", tokens_total: 10 }];
   const handler = createRoutingFeedbackHandler({
     client: { tui: { showToast: async (toast) => toasts.push(toast) } },
     isHeadless: () => false,
@@ -23,12 +23,13 @@ test("routing feedback handler emits changed idle summaries once", async () => {
   await handler(event("message.updated"));
   await handler(event("session.idle"));
   await handler(event("session.idle"));
-  requests = [...requests, { session_id: "child", routing_tier: "standard", routing_escalated: 1 }];
+  requests = [...requests, { session_id: "child-b", parent_session_id: "root", routing_tier: "standard", tokens_total: 10 }];
   await handler(event("session.idle"));
 
   assert.equal(toasts.length, 2);
   assert.equal(toasts[0].body.title, "Routing feedback");
-  assert.match(toasts[1].body.message, /simple → standard/);
+  assert.match(toasts[0].body.message, /1 delegated child \(1 simple\)/);
+  assert.match(toasts[1].body.message, /2 delegated children \(1 simple, 1 standard\)/);
 });
 
 test("routing feedback handler stays silent headlessly and without routed data", async () => {

--- a/.agents/plugins/opencode-aidevops/tests/test-routing-feedback.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-routing-feedback.mjs
@@ -84,6 +84,27 @@ describe("routing feedback analysis", () => {
     assert.match(summary.recommendations[0], /No routing change/);
   });
 
+  test("counts distinct delegated children by their first valid tier", () => {
+    const summary = summarizeRoutingFeedback({
+      requests: [
+        { session_id: "child-a", parent_session_id: "root", routing_tier: "simple" },
+        { session_id: "child-a", parent_session_id: "root", routing_tier: "standard", routing_escalated: 1 },
+        { session_id: "child-b", parent_session_id: "root", routing_tier: "standard" },
+        { session_id: "parentless", routing_tier: "thinking" },
+        { parent_session_id: "root", routing_tier: "thinking" },
+      ],
+    });
+    const firstChildOnly = summarizeRoutingFeedback({
+      requests: [{ session_id: "child-a", parent_session_id: "root", routing_tier: "simple" }],
+    });
+
+    assert.equal(summary.delegationCount, 2);
+    assert.deepEqual(summary.delegationTiers, { simple: 1, standard: 1, thinking: 0 });
+    assert.match(formatRoutingFeedbackMarkdown(summary), /2 delegated children \(1 simple, 1 standard\)/);
+    assert.match(formatRoutingFeedbackToast(summary), /2 delegated children \(1 simple, 1 standard\)/);
+    assert.notEqual(routingFeedbackFingerprint(summary), routingFeedbackFingerprint(firstChildOnly));
+  });
+
   test("joins persisted requests and headless attempts under one session key", () => {
     const summary = summarizeRoutingFeedback({
       requests: [{ session_id: "ses-a", routing_tier: "standard" }],

--- a/.agents/scripts/routing-feedback-summary.mjs
+++ b/.agents/scripts/routing-feedback-summary.mjs
@@ -73,6 +73,32 @@ function tierCounts(records) {
   return counts;
 }
 
+function delegationCounts(records) {
+  const children = new Map();
+  for (const record of records) {
+    const parentSessionID = firstValue(record, "parent_session_id", "parentSessionID");
+    const childSessionID = firstValue(record, "session_id", "sessionID");
+    const tier = normalizedTier(record);
+    if (!parentSessionID || !childSessionID || !tier) continue;
+
+    const parentChildren = children.get(String(parentSessionID)) || new Map();
+    if (!parentChildren.has(String(childSessionID))) {
+      parentChildren.set(String(childSessionID), tier);
+    }
+    children.set(String(parentSessionID), parentChildren);
+  }
+
+  const delegationTiers = Object.fromEntries(TIER_ORDER.map((tier) => [tier, 0]));
+  let delegationCount = 0;
+  for (const parentChildren of children.values()) {
+    for (const tier of parentChildren.values()) {
+      delegationCount += 1;
+      delegationTiers[tier] += 1;
+    }
+  }
+  return { delegationCount, delegationTiers };
+}
+
 function requestFailed(record) {
   return Boolean(firstValue(record, "error_type", "errorType", "error_message", "errorMessage"));
 }
@@ -119,6 +145,7 @@ export function summarizeRoutingMetrics({ requests = [], attempts = [] } = {}) {
   const routedAttempts = attempts.filter((record) => normalizedTier(record));
   const routeRecords = routedAttempts.length > 0 ? routedAttempts : routedRequests;
   const counts = tierCounts(routeRecords);
+  const delegations = delegationCounts(routedRequests);
   const tiersUsed = TIER_ORDER.filter((tier) => counts[tier] > 0);
   const dominantTier = tiersUsed.reduce(
     (best, tier) => (!best || counts[tier] > counts[best] ? tier : best),
@@ -137,6 +164,7 @@ export function summarizeRoutingMetrics({ requests = [], attempts = [] } = {}) {
     routeEventCount: routeRecords.length,
     distinctSessionCount: sessions.size,
     tiers: counts,
+    ...delegations,
     tiersUsed,
     tierPath: routePath(routeRecords),
     dominantTier,

--- a/.agents/scripts/routing-feedback.mjs
+++ b/.agents/scripts/routing-feedback.mjs
@@ -98,12 +98,25 @@ function routeLabel(summary) {
     .join(" → ");
 }
 
+function delegationLabel(summary) {
+  const count = Number(summary.delegationCount) || 0;
+  if (count <= 0) return "";
+  const tiers = TIER_ORDER
+    .map((tier) => [tier, Number(summary.delegationTiers?.[tier]) || 0])
+    .filter(([, tierCount]) => tierCount > 0)
+    .map(([tier, tierCount]) => `${tierCount} ${tier}`);
+  const detail = tiers.length > 0 ? ` (${tiers.join(", ")})` : "";
+  return `${plural(count, "delegated child", "delegated children")}${detail}`;
+}
+
 /** Format a bounded GitHub/routine body section. */
 export function formatRoutingFeedbackMarkdown(summary, { headingLevel = 3 } = {}) {
   if (!summary?.hasData) return "";
   const counts = [];
   if (summary.attemptCount > 0) counts.push(plural(summary.attemptCount, "attempt"));
   if (summary.requestCount > 0) counts.push(plural(summary.requestCount, "LLM request"));
+  const delegations = delegationLabel(summary);
+  if (delegations) counts.push(delegations);
   counts.push(plural(summary.escalationCount, "capability escalation"));
   counts.push(plural(summary.candidateFallbackCount, "same-tier fallback"));
 
@@ -127,8 +140,10 @@ export function formatRoutingFeedbackToast(summary) {
   const sampleCount = summary.attemptCount || summary.requestCount;
   const sampleLabel = summary.attemptCount > 0 ? "attempts" : "requests";
   const usage = summary.costTotal > 0 ? `, $${summary.costTotal.toFixed(4)}` : "";
+  const delegations = delegationLabel(summary);
+  const delegationText = delegations ? `, ${delegations}` : "";
   return [
-    `Route ${routeLabel(summary).replaceAll("`", "")}: ${sampleCount} ${sampleLabel}${usage}, ${summary.escalationCount} escalations.`,
+    `Route ${routeLabel(summary).replaceAll("`", "")}: ${sampleCount} ${sampleLabel}${usage}${delegationText}, ${summary.escalationCount} escalations.`,
     summary.recommendations[0],
   ].join(" ");
 }
@@ -142,6 +157,8 @@ export function routingFeedbackFingerprint(summary) {
     summary.tierPath,
     summary.candidateFallbackCount,
     summary.escalationCount,
+    summary.delegationCount || 0,
+    ...TIER_ORDER.map((tier) => summary.delegationTiers?.[tier] || 0),
     summary.requestErrorCount,
     summary.failedAttemptCount,
     summary.tokensTotal,


### PR DESCRIPTION
## Summary

Derive distinct parent/child delegation counts and first-tier distributions from routed requests, then surface them in routing Markdown and idle toasts with fingerprint-aware deduplication.

## Files Changed

.agents/plugins/opencode-aidevops/tests/test-observability-routing-join.mjs, .agents/plugins/opencode-aidevops/tests/test-routing-feedback-handler.mjs, .agents/plugins/opencode-aidevops/tests/test-routing-feedback.mjs, .agents/scripts/routing-feedback-summary.mjs, .agents/scripts/routing-feedback.mjs

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --test focused routing feedback suites; routing shell consumers; npm plugin suite with --test-concurrency=1; changed-file linters

Resolves #29815


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.238 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 8m and 87,283 tokens on this as a headless worker.