### PR TITLE
GH#29818: fix: deploy releases over validated ancestors

### DIFF
--- a/.agents/scripts/tests/test-agent-auto-sync.sh
+++ b/.agents/scripts/tests/test-agent-auto-sync.sh
@@ -597,6 +597,38 @@ test_release_sync_rejects_stale_sentinel() {
 	return 0
 }
 
+test_release_sync_deploys_validated_active_ancestor() {
+	local repo_path
+	local active_sha=""
+	local release_sha=""
+	local deployed_sha=""
+	local output=""
+	repo_path=$(create_fake_repo "release-active-ancestor" "https://github.com/marcusquinn/aidevops.git")
+	active_sha=$(PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" rev-parse HEAD)
+	if ! invoke_release_sync "$repo_path" >/dev/null 2>&1; then
+		print_result "release sync deploys over a validated active ancestor" 1 "Could not prepare active ancestor $active_sha"
+		return 0
+	fi
+
+	printf '9.9.10\n' >"$repo_path/VERSION"
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" add VERSION
+	PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" commit -qm "bump release version"
+	release_sha=$(PATH=/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin git -C "$repo_path" rev-parse HEAD)
+	: >"$TEST_DIR/sync.log"
+
+	if output=$(invoke_release_sync "$repo_path" 2>&1); then
+		IFS= read -r deployed_sha <"$TEST_HOME/.aidevops/.deployed-sha" || deployed_sha=""
+	fi
+	if [[ "$deployed_sha" == "$release_sha" ]] &&
+		grep -q -- "--repo $repo_path --quiet --expected-sha $release_sha" "$TEST_DIR/sync.log" &&
+		[[ "$output" == *"deployment and CLI convergence completed"* ]]; then
+		print_result "release sync deploys over a validated active ancestor" 0
+	else
+		print_result "release sync deploys over a validated active ancestor" 1 "Expected deployment from active $active_sha to release $release_sha: $output"
+	fi
+	return 0
+}
+
 test_release_sync_accepts_validated_same_tree_descendant() {
 	local repo_path
 	local release_sha=""
@@ -744,6 +776,7 @@ main() {
 	test_release_sync_rejects_stale_active_bundle
 	test_release_sync_rejects_stale_deployed_sha
 	test_release_sync_rejects_stale_sentinel
+	test_release_sync_deploys_validated_active_ancestor
 	test_release_sync_accepts_validated_same_tree_descendant
 	test_release_sync_rejects_changed_tree_descendant
 	test_release_sync_rejects_unrelated_active_commit

--- a/.agents/scripts/version-manager-release.sh
+++ b/.agents/scripts/version-manager-release.sh
@@ -577,6 +577,9 @@ _verify_active_release_preservation_merge() {
 		return 1
 	fi
 	[[ "$active_sha" != "$release_sha" ]] || return 0
+	if git -C "$sync_repo_root" merge-base --is-ancestor "$active_sha" "$release_sha" 2>/dev/null; then
+		return 0
+	fi
 
 	if ! git -C "$sync_repo_root" merge-base --is-ancestor "$release_sha" "$active_sha" 2>/dev/null; then
 		print_error "Post-release deployment gate rejected active source ${active_sha:0:12}: it is not a descendant of release ${release_sha:0:12}"


### PR DESCRIPTION
## Summary

- Allow exact-tag post-release deployment when the validated active runtime is an ancestor of the signed release commit.
- Preserve the existing exact-SHA deploy path, validated same-tree descendant no-op, and unrelated/changed-tree rejection paths.
- Add an integrated regression test that deploys an active ancestor, creates a release descendant, and verifies exact-SHA runtime convergence.

Resolves #29818

## Testing

- `bash .agents/scripts/tests/test-agent-auto-sync.sh` — 24/24 passed.
- `shellcheck .agents/scripts/version-manager-release.sh .agents/scripts/tests/test-agent-auto-sync.sh` — clean.
- `.agents/scripts/linters-local.sh` changed-file bundle — all local checks passed, including Bash 3.2, function complexity, nesting, portability, and secret checks.

## Runtime Testing

`runtime-verified`: the production v3.32.239 reconciliation failure established the active-ancestor/release-descendant topology, and the integrated fixture now exercises that same deployment call chain through `run_post_release_agent_sync` with exact bundle/stamp convergence.

## Risk

High because this changes the release deployment gate. The new path is limited to Git-proven ancestor relationships; unrelated active commits and changed-tree preservation descendants remain fail-closed.

## Review Evidence

Bundle digest: `13b53f6ef6214c55b174e11753ffec50721e694bb39ce160f5cd888771a510b8`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.239 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 3h 53m and 1,080,899 tokens on this with the user in an interactive session.