### PR TITLE
GH#29821: fix: report observability token costs

### DIFF
--- a/.agents/reports/token-use.md
+++ b/.agents/reports/token-use.md
@@ -43,8 +43,8 @@ only after the helper has written the local evidence bundle.
 
 | Runtime | Primary source | Notes |
 |---|---|---|
-| OpenCode | `~/.local/share/opencode/opencode.db` | Uses `session.parent_id` to aggregate compacted child sessions with their root session. |
-| OpenCode tools | `~/.aidevops/.agent-workspace/observability/llm-requests.db` | Adds model request counts, tool-call counts, and observed MCP tool names when available. |
+| OpenCode | `~/.local/share/opencode/opencode.db` | Uses `session.parent_id` to aggregate compacted child sessions with their root session and supplies legacy cost fallback. |
+| OpenCode tools | `~/.aidevops/.agent-workspace/observability/llm-requests.db` | Adds model request counts, tool-call counts, observed MCP names, request costs, routed-child lineage, and compaction-agent evidence when available. |
 | Claude fallback | `~/.aidevops/.agent-workspace/observability/metrics.jsonl` | Best-effort token totals; compaction and MCP fields may be empty. |
 
 ## Report Fields
@@ -55,6 +55,8 @@ only after the helper has written the local evidence bundle.
 - Compaction count and child session count.
 - Configured MCP servers and observed MCP tools.
 - Date-time started and date-time finished.
+- JSON provenance fields for cost, lineage, and compactions. `unavailable` means
+  coverage is unavailable; it is never reported as a measured zero.
 
 Net token total is input + output + reasoning + cache-write tokens. Cache reads
 are excluded from net totals and retained in raw totals for context-volume review.

--- a/.agents/scripts/report-token-use-helper.py
+++ b/.agents/scripts/report-token-use-helper.py
@@ -73,6 +73,9 @@ class SessionReport:
     request_count: int
     tool_call_count: int
     source_session_ids: list[str] = field(default_factory=list)
+    cost_provenance: str = "unavailable"
+    lineage_provenance: str = "unavailable"
+    compaction_provenance: str = "unavailable"
 
 
 @dataclass
@@ -97,6 +100,7 @@ class OpencodeReportContext:
     conn: sqlite3.Connection
     obs_db: Path
     configured_mcps: list[str]
+    observed_parents: dict[str, str]
 
 
 def _make_session_report(**values: Any) -> SessionReport:
@@ -121,6 +125,12 @@ def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
         "SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1", (table,)
     ).fetchone()
     return row is not None
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    if not _table_exists(conn, table):
+        return set()
+    return {str(row["name"]) for row in conn.execute(f"PRAGMA table_info({table})")}
 
 
 def _parse_since(value: str | None) -> datetime | None:
@@ -203,23 +213,30 @@ def _read_sessions(conn: sqlite3.Connection) -> list[SessionRow]:
     return sessions
 
 
-def _root_for(session_id: str, by_id: dict[str, SessionRow]) -> str:
+def _root_for(
+    session_id: str,
+    by_id: dict[str, SessionRow],
+    observed_parents: dict[str, str] | None = None,
+) -> str:
     seen: set[str] = set()
     current = session_id
-    while current in by_id and by_id[current].parent_id and current not in seen:
+    while current not in seen:
         seen.add(current)
-        parent = by_id[current].parent_id
-        if not parent or parent not in by_id:
+        parent = by_id.get(current).parent_id if current in by_id else None
+        parent = parent or (observed_parents or {}).get(current)
+        if not parent:
             break
         current = parent
     return current
 
 
-def _children_by_root(sessions: list[SessionRow]) -> dict[str, list[SessionRow]]:
+def _children_by_root(
+    sessions: list[SessionRow], observed_parents: dict[str, str] | None = None
+) -> dict[str, list[SessionRow]]:
     by_id = {row.session_id: row for row in sessions}
     grouped: dict[str, list[SessionRow]] = {}
     for row in sessions:
-        root = _root_for(row.session_id, by_id)
+        root = _root_for(row.session_id, by_id, observed_parents)
         grouped.setdefault(root, []).append(row)
     return grouped
 
@@ -328,21 +345,87 @@ def _mcp_name_from_tool(tool: str, configured_mcps: list[str]) -> str:
     return ""
 
 
+def _observed_parents(obs_db: Path) -> dict[str, str]:
+    conn = _connect(obs_db)
+    if conn is None:
+        return {}
+    try:
+        columns = _table_columns(conn, "llm_requests")
+        if not {"session_id", "parent_session_id"}.issubset(columns):
+            return {}
+        rows = conn.execute(
+            "SELECT session_id, parent_session_id FROM llm_requests "
+            "WHERE session_id IS NOT NULL AND parent_session_id IS NOT NULL "
+            "AND session_id != '' AND parent_session_id != ''"
+        ).fetchall()
+        return {
+            str(row["session_id"]): str(row["parent_session_id"])
+            for row in rows
+            if row["session_id"] != row["parent_session_id"]
+        }
+    finally:
+        conn.close()
+
+
+def _observability_session_ids_by_root(
+    observed_parents: dict[str, str], by_id: dict[str, SessionRow], roots: set[str]
+) -> dict[str, set[str]]:
+    grouped: dict[str, set[str]] = defaultdict(set)
+    for session_id in observed_parents:
+        root = _root_for(session_id, by_id, observed_parents)
+        if root in roots:
+            grouped[root].add(session_id)
+    return grouped
+
+
+def _observability_request_rows(
+    conn: sqlite3.Connection, columns: set[str], session_ids: list[str]
+) -> list[sqlite3.Row]:
+    if not session_ids or not {"session_id", "model_id"}.issubset(columns):
+        return []
+    selected = ["session_id", "model_id"]
+    for column in ("cost", "parent_session_id", "agent"):
+        if column in columns:
+            selected.append(column)
+    placeholders = ",".join("?" for _ in session_ids)
+    query = "SELECT " + ", ".join(selected) + " FROM llm_requests WHERE session_id IN (" + placeholders + ")"
+    return conn.execute(query, session_ids).fetchall()
+
+
+def _add_observability_request(result: dict[str, Any], row: sqlite3.Row, columns: set[str]) -> float:
+    if row["model_id"]:
+        result["models"].add(str(row["model_id"]))
+    result["requests"] += 1
+    if "parent_session_id" in columns and row["parent_session_id"]:
+        result["has_lineage"] = True
+    if "agent" in columns:
+        result["has_compaction_evidence"] = True
+        if "compact" in str(row["agent"] or "").lower():
+            result["compaction_session_ids"].add(str(row["session_id"]))
+    return float(row["cost"] or 0) if "cost" in columns else 0.0
+
+
 def _observability_for(obs_db: Path, session_ids: list[str], configured_mcps: list[str]) -> dict[str, Any]:
-    result: dict[str, Any] = {"models": set(), "requests": 0, "tool_calls": 0, "observed_mcps": set()}
+    result: dict[str, Any] = {
+        "models": set(),
+        "requests": 0,
+        "tool_calls": 0,
+        "observed_mcps": set(),
+        "cost_usd": None,
+        "compaction_session_ids": set(),
+        "has_lineage": False,
+        "has_compaction_evidence": False,
+    }
     conn = _connect(obs_db)
     if conn is None:
         return result
     try:
         placeholders = ",".join("?" for _ in session_ids)
-        if placeholders and _table_exists(conn, "llm_requests"):
-            for row in conn.execute(
-                f"SELECT model_id, COUNT(*) AS n FROM llm_requests WHERE session_id IN ({placeholders}) GROUP BY model_id",
-                session_ids,
-            ):
-                if row["model_id"]:
-                    result["models"].add(str(row["model_id"]))
-                result["requests"] += int(row["n"] or 0)
+        columns = _table_columns(conn, "llm_requests")
+        request_rows = _observability_request_rows(conn, columns, session_ids)
+        costs = [_add_observability_request(result, row, columns) for row in request_rows]
+        if "cost" in columns and request_rows:
+            result["cost_usd"] = round(sum(costs), 6)
         if placeholders and _table_exists(conn, "tool_calls"):
             for row in conn.execute(
                 f"SELECT tool_name, COUNT(*) AS n FROM tool_calls WHERE session_id IN ({placeholders}) GROUP BY tool_name",
@@ -414,9 +497,29 @@ def _opencode_report_from_group(
     root: SessionRow,
     group: list[SessionRow],
 ) -> SessionReport:
-    session_ids = [row.session_id for row in group]
+    group_session_ids = {row.session_id for row in group}
+    source_session_ids = group_session_ids | _observability_session_ids_by_root(
+        context.observed_parents, {row.session_id: row for row in group}, {root_id}
+    ).get(root_id, set())
+    session_ids = sorted(source_session_ids)
     obs = _observability_for(context.obs_db, session_ids, context.configured_mcps)
     tokens = _tokens_for_group(group)
+    compacted_session_ids = {
+        row.session_id for row in group if row.parent_id or row.time_compacting
+    } | obs["compaction_session_ids"]
+    session_cost = round(sum(row.cost for row in group), 6)
+    cost_from_observability = obs["cost_usd"] is not None
+    has_opencode_lineage = any(row.parent_id for row in group)
+    lineage_provenance = "opencode_session.parent_id"
+    if context.observed_parents:
+        lineage_provenance = (
+            "combined: session.parent_id + llm_requests.parent_session_id"
+            if has_opencode_lineage
+            else "observability: llm_requests.parent_session_id"
+        )
+    compaction_provenance = "opencode_session.parent_id,time_compacting"
+    if obs["has_compaction_evidence"]:
+        compaction_provenance = "combined: opencode_session + llm_requests.agent"
     return _make_session_report(
         session_id=root_id,
         session_name=_safe_title(root.title),
@@ -430,16 +533,21 @@ def _opencode_report_from_group(
         tokens_cache_write=tokens["cache_write"],
         raw_tokens_total=tokens["raw_total"],
         net_tokens_total=tokens["net_total"],
-        child_session_count=max(len(group) - 1, 0),
-        compaction_count=sum(1 for row in group if row.parent_id or row.time_compacting),
+        child_session_count=max(len(source_session_ids) - 1, 0),
+        compaction_count=len(compacted_session_ids),
         mcps_active=context.configured_mcps,
         mcps_observed=sorted(obs["observed_mcps"]),
         started_at=_ms_to_iso(min(row.time_created for row in group)),
         finished_at=_ms_to_iso(max(row.time_updated for row in group)),
-        cost_usd=round(sum(row.cost for row in group), 6),
+        cost_usd=obs["cost_usd"] if cost_from_observability else session_cost,
         request_count=int(obs["requests"]),
         tool_call_count=int(obs["tool_calls"]),
-        source_session_ids=sorted(session_ids),
+        source_session_ids=session_ids,
+        cost_provenance=(
+            "observability: llm_requests.cost" if cost_from_observability else "opencode_session.cost"
+        ),
+        lineage_provenance=lineage_provenance,
+        compaction_provenance=compaction_provenance,
     )
 
 
@@ -451,11 +559,17 @@ def _opencode_reports(args: argparse.Namespace) -> list[SessionReport]:
         return []
     try:
         sessions = _read_sessions(conn)
-        grouped = _children_by_root(sessions)
         by_id = {row.session_id: row for row in sessions}
+        observed_parents = _observed_parents(obs_db)
+        grouped = _children_by_root(sessions, observed_parents)
         since_dt = _parse_since(args.since)
         since_ms = int(since_dt.timestamp() * 1000) if since_dt else None
-        context = OpencodeReportContext(conn=conn, obs_db=obs_db, configured_mcps=_configured_mcps())
+        context = OpencodeReportContext(
+            conn=conn,
+            obs_db=obs_db,
+            configured_mcps=_configured_mcps(),
+            observed_parents=observed_parents,
+        )
         reports: list[SessionReport] = []
         for root_id, group in grouped.items():
             if not _session_in_scope(group, args.session, since_ms):
@@ -556,6 +670,9 @@ def _claude_report_from_group(session_id: str, data: dict[str, Any]) -> SessionR
         request_count=data["requests"],
         tool_call_count=0,
         source_session_ids=[session_id],
+        cost_provenance="claude_metrics.cost_total",
+        lineage_provenance="unavailable",
+        compaction_provenance="unavailable",
     )
 
 

--- a/.agents/scripts/report_token_use_render.py
+++ b/.agents/scripts/report_token_use_render.py
@@ -52,6 +52,9 @@ def as_dict(report: Any) -> dict[str, Any]:
         "request_count": report.request_count,
         "tool_call_count": report.tool_call_count,
         "source_session_ids": report.source_session_ids,
+        "cost_provenance": report.cost_provenance,
+        "lineage_provenance": report.lineage_provenance,
+        "compaction_provenance": report.compaction_provenance,
     }
 
 
@@ -126,7 +129,8 @@ def write_markdown(reports: list[Any], daily_usage: list[Any], output_dir: Path,
             "- Net tokens are input + output + reasoning + cache-write tokens, excluding cache reads so the main total tracks paid/metered work more closely.",
             "- Raw tokens include cache reads for context volume analysis. Provider-specific cached-read billing discounts are best represented by the Cost column when available.",
             "- Session type is inferred from runtime metadata. OpenCode sessions under the runtime temporary work directory are reported as headless worker sessions; other local sessions are reported as interactive.",
-            "- OpenCode rows recursively include child sessions via `session.parent_id` so compacted sessions are counted with their root session.",
+            "- OpenCode rows recursively include child sessions via `session.parent_id` and, when available, `llm_requests.parent_session_id` so compacted sessions are counted with their root session.",
+            "- JSON session fields `cost_provenance`, `lineage_provenance`, and `compaction_provenance` identify the source used for each derived value; `unavailable` is not a measured zero.",
             "- MCPs configured lists configured OpenCode MCP server names at report time. MCPs observed are inferred from session tool-call names when available and are the better proxy for actual use.",
         ]
     )

--- a/.agents/scripts/tests/test-report-token-use-helper.sh
+++ b/.agents/scripts/tests/test-report-token-use-helper.sh
@@ -98,7 +98,8 @@ assert_json_field() {
 	local _expected="$3"
 	local _label="$4"
 	local _actual
-	_actual=$(python3 - "$_json_file" "$_expr" <<'PY'
+	_actual=$(
+		python3 - "$_json_file" "$_expr" <<'PY'
 import json
 import sys
 
@@ -115,7 +116,38 @@ for part in expr.split('.'):
         value = value[part]
 print(value)
 PY
-)
+	)
+	if [[ "$_actual" == "$_expected" ]]; then
+		print_result "$_label" 0
+		return 0
+	fi
+	print_result "$_label" 1 "expected '${_expected}', got '${_actual}'"
+	return 0
+}
+
+assert_session_field() {
+	local _json_file="$1"
+	local _session_id="$2"
+	local _field="$3"
+	local _expected="$4"
+	local _label="$5"
+	local _actual
+	_actual=$(
+		python3 - "$_json_file" "$_session_id" "$_field" <<'PY'
+import json
+import sys
+
+path, session_id, field = sys.argv[1:]
+with open(path, encoding="utf-8") as handle:
+    sessions = json.load(handle)["sessions"]
+for session in sessions:
+    if session["session_id"] == session_id:
+        print(session[field])
+        break
+else:
+    raise SystemExit(f"session {session_id!r} not found")
+PY
+	)
 	if [[ "$_actual" == "$_expected" ]]; then
 		print_result "$_label" 0
 		return 0
@@ -133,12 +165,13 @@ test_report_aggregates_compacted_sessions() {
 		AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_CONFIG="${TEST_ROOT}/opencode.json" \
 		"$HELPER_SH" report --limit 5 --daily-days 2000 --json)
 	local _json_path
-	_json_path=$(python3 - <<PY
+	_json_path=$(
+		python3 - <<PY
 import json
 data = json.loads('''${_output}''')
 print(data['report_json'])
 PY
-)
+	)
 	assert_json_field "$_json_path" "session_count" "1" "Report groups root and compacted child"
 	assert_json_field "$_json_path" "sessions[0].tokens_input" "150" "Report sums input tokens"
 	assert_json_field "$_json_path" "sessions[0].tokens_output" "30" "Report sums output tokens"
@@ -149,6 +182,8 @@ PY
 	assert_json_field "$_json_path" "usage_by_session_kind[0].session_kind" "interactive" "Report summarizes interactive usage"
 	assert_json_field "$_json_path" "sessions[0].compaction_count" "1" "Report counts child compaction"
 	assert_json_field "$_json_path" "sessions[0].mcps_observed[0]" "context7" "Report infers observed MCP"
+	assert_json_field "$_json_path" "sessions[0].cost_usd" "0.35" "Report retains session cost fallback without observability cost"
+	assert_json_field "$_json_path" "sessions[0].cost_provenance" "opencode_session.cost" "Report identifies session cost fallback"
 	assert_json_field "$_json_path" "daily_usage[0].date" "2023-11-14" "Report includes daily usage date"
 	assert_json_field "$_json_path" "daily_usage[0].net_tokens_total" "192" "Report sums daily net tokens"
 	assert_json_field "$_json_path" "daily_usage[0].interactive_net_tokens_total" "192" "Report sums daily interactive net tokens"
@@ -184,9 +219,36 @@ SQL
 	return 0
 }
 
+test_report_uses_observability_cost_and_lineage() {
+	create_fixture_dbs
+	sqlite3 "${TEST_ROOT}/opencode.db" <<'SQL'
+INSERT INTO session VALUES ('ses_obs_root', NULL, 'Observability Root', '', 10, 2, 0, 0, 0, 0, 1700000300000, 1700000400000, NULL, '/repo', '/repo', 'Build+');
+INSERT INTO session VALUES ('ses_obs_child', NULL, 'Observability Child', '', 5, 1, 0, 0, 0, 0, 1700000400000, 1700000500000, NULL, '/repo', '/repo', 'Compaction');
+SQL
+	sqlite3 "${TEST_ROOT}/llm-requests.db" <<'SQL'
+ALTER TABLE llm_requests ADD COLUMN cost real;
+ALTER TABLE llm_requests ADD COLUMN parent_session_id text;
+ALTER TABLE llm_requests ADD COLUMN agent text;
+INSERT INTO llm_requests (session_id, model_id, cost, parent_session_id, agent) VALUES ('ses_obs_root', 'gpt-5.6', 0.4, NULL, 'Build+');
+INSERT INTO llm_requests (session_id, model_id, cost, parent_session_id, agent) VALUES ('ses_obs_child', 'gpt-5.6', 0.2, 'ses_obs_root', 'Compaction agent');
+SQL
+	local _json_path="${TEST_ROOT}/data.json"
+	AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_DB="${TEST_ROOT}/opencode.db" \
+		AIDEVOPS_REPORT_TOKEN_USE_OBS_DB="${TEST_ROOT}/llm-requests.db" \
+		AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_CONFIG="${TEST_ROOT}/opencode.json" \
+		"$HELPER_SH" data --limit 10 --daily-days 2000 --json >"$_json_path"
+	assert_session_field "$_json_path" "ses_obs_root" "child_session_count" "1" "Report uses observability child lineage"
+	assert_session_field "$_json_path" "ses_obs_root" "compaction_count" "1" "Report counts observability compaction agent"
+	assert_session_field "$_json_path" "ses_obs_root" "cost_usd" "0.6" "Report uses observability request costs"
+	assert_session_field "$_json_path" "ses_obs_root" "cost_provenance" "observability: llm_requests.cost" "Report records observability cost provenance"
+	assert_session_field "$_json_path" "ses_obs_root" "lineage_provenance" "observability: llm_requests.parent_session_id" "Report records observability lineage provenance"
+	assert_session_field "$_json_path" "ses_obs_root" "compaction_provenance" "combined: opencode_session + llm_requests.agent" "Report records compaction provenance"
+	return 0
+}
+
 test_session_report_defaults_source_ids() {
 	local _helper_py="${SCRIPT_DIR}/../report-token-use-helper.py"
-	if python3 - "$_helper_py" <<'PY'
+	if python3 - "$_helper_py" <<'PY'; then
 import importlib.util
 import sys
 from pathlib import Path
@@ -226,7 +288,6 @@ report = module._make_session_report(
 if report.source_session_ids != []:
     raise SystemExit(f"expected default list, got {report.source_session_ids!r}")
 PY
-	then
 		print_result "SessionReport initializes default source_session_ids" 0
 		return 0
 	fi
@@ -239,6 +300,7 @@ main() {
 	trap teardown_test_env EXIT
 	test_report_aggregates_compacted_sessions
 	test_report_summarizes_headless_workers
+	test_report_uses_observability_cost_and_lineage
 	test_session_report_defaults_source_ids
 	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Aggregate plugin request costs, routed child lineage, and compaction-agent evidence into OpenCode token reports without double counting, while exposing per-metric provenance and retaining legacy session-cost fallback.

## Files Changed

.agents/reports/token-use.md, .agents/scripts/report-token-use-helper.py, .agents/scripts/report_token_use_render.py, .agents/scripts/tests/test-report-token-use-helper.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: bash .agents/scripts/report-token-use-helper.sh data --limit 1 --daily-days 0 --runtime opencode --json rendered OpenCode report data successfully; bash .agents/scripts/tests/test-report-token-use-helper.sh; python3 -m py_compile .agents/scripts/report-token-use-helper.py .agents/scripts/report_token_use_render.py; bash .agents/scripts/linters-local.sh

Resolves #29821


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.239 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 9m and 113,044 tokens on this as a headless worker.