### PR TITLE
GH#29822: feat: add compact token report data

### DIFF
--- a/.agents/reports/token-use.md
+++ b/.agents/reports/token-use.md
@@ -27,6 +27,7 @@ only after the helper has written the local evidence bundle.
 ~/.aidevops/agents/scripts/report-token-use-helper.sh report --session ses_abc123 --open
 ~/.aidevops/agents/scripts/report-token-use-helper.sh report --daily-days 90
 ~/.aidevops/agents/scripts/report-token-use-helper.sh data --json --since 7d
+~/.aidevops/agents/scripts/report-token-use-helper.sh data --full --json --since 7d
 ```
 
 ## Output Contract
@@ -38,6 +39,12 @@ only after the helper has written the local evidence bundle.
   `--open` is supplied.
 - Daily usage covers the last 90 days by default; use `--daily-days N` to change
   the window or `--daily-days 0` to disable it.
+- `data` defaults to a compact JSON schema for model consumption: aggregate token
+  and cost totals, session-kind routing, evidence coverage, one configured-MCP
+  list, and compact per-session rows. It omits daily history unless
+  `--daily-days N` is supplied.
+- Use `data --full` for the complete legacy-compatible JSON payload, including
+  per-session configured MCP arrays and the default 90-day daily series.
 
 ## Data Sources
 

--- a/.agents/scripts/report-token-use-helper.py
+++ b/.agents/scripts/report-token-use-helper.py
@@ -772,13 +772,69 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--daily-days", type=int, default=90, help="days to include in the daily usage summary; 0 disables")
 
 
-def cmd_data(args: argparse.Namespace) -> int:
-    reports = _collect_reports(args)
-    payload = {
-        "daily_usage": [as_dict(row) for row in _collect_daily_usage(args)],
-        "usage_by_session_kind": session_kind_summary(reports),
-        "sessions": [as_dict(row) for row in reports],
+def _compact_session(report: SessionReport) -> dict[str, Any]:
+    return {
+        "session_id": report.session_id,
+        "runtime": report.runtime,
+        "session_kind": report.session_kind,
+        "models_used": report.models_used,
+        "raw_tokens_total": report.raw_tokens_total,
+        "net_tokens_total": report.net_tokens_total,
+        "cost_usd": report.cost_usd,
+        "request_count": report.request_count,
+        "tool_call_count": report.tool_call_count,
+        "child_session_count": report.child_session_count,
+        "compaction_count": report.compaction_count,
+        "mcps_observed": report.mcps_observed,
+        "started_at": report.started_at,
+        "finished_at": report.finished_at,
     }
+
+
+def _evidence_coverage(reports: list[SessionReport]) -> dict[str, dict[str, int]]:
+    provenance_fields = {
+        "cost": "cost_provenance",
+        "lineage": "lineage_provenance",
+        "compaction": "compaction_provenance",
+    }
+    return {
+        name: {
+            "available_session_count": sum(getattr(report, field) != "unavailable" for report in reports),
+            "unavailable_session_count": sum(getattr(report, field) == "unavailable" for report in reports),
+        }
+        for name, field in provenance_fields.items()
+    }
+
+
+def _compact_data_payload(reports: list[SessionReport], daily_usage: list[DailyUsage]) -> dict[str, Any]:
+    return {
+        "summary": {
+            "session_count": len(reports),
+            "raw_tokens_total": sum(report.raw_tokens_total for report in reports),
+            "net_tokens_total": sum(report.net_tokens_total for report in reports),
+            "cost_usd": round(sum(report.cost_usd for report in reports), 6),
+            "evidence_coverage": _evidence_coverage(reports),
+        },
+        "configured_mcps": sorted({mcp for report in reports for mcp in report.mcps_active}),
+        "usage_by_session_kind": session_kind_summary(reports),
+        "sessions": [_compact_session(report) for report in reports],
+        "daily_usage": [as_dict(row) for row in daily_usage],
+    }
+
+
+def cmd_data(args: argparse.Namespace) -> int:
+    if args.daily_days is None:
+        args.daily_days = 0 if args.compact else 90
+    reports = _collect_reports(args)
+    daily_usage = _collect_daily_usage(args)
+    if args.compact:
+        payload = _compact_data_payload(reports, daily_usage)
+    else:
+        payload = {
+            "daily_usage": [as_dict(row) for row in daily_usage],
+            "usage_by_session_kind": session_kind_summary(reports),
+            "sessions": [as_dict(row) for row in reports],
+        }
     print(json.dumps(payload, indent=2, sort_keys=True))
     return 0
 
@@ -823,10 +879,13 @@ def main(argv: list[str] | None = None) -> int:
     report_parser.add_argument("--json", action="store_true", help="print artifact paths as JSON")
     report_parser.add_argument("--open", action="store_true", help="open the generated HTML report")
     report_parser.set_defaults(func=cmd_report)
-    data_parser = subparsers.add_parser("data", help="print raw session report data as JSON")
+    data_parser = subparsers.add_parser("data", help="print compact session report data as JSON")
     _add_common_args(data_parser)
     data_parser.add_argument("--json", action="store_true", help="accepted for command symmetry")
-    data_parser.set_defaults(func=cmd_data)
+    data_mode = data_parser.add_mutually_exclusive_group()
+    data_mode.add_argument("--compact", dest="compact", action="store_true", help="print the compact model-consumption schema (default)")
+    data_mode.add_argument("--full", dest="compact", action="store_false", help="print the complete legacy-compatible session schema")
+    data_parser.set_defaults(func=cmd_data, compact=True, daily_days=None)
     args = parser.parse_args(argv)
     if args.limit < 1:
         _die("--limit must be positive")

--- a/.agents/scripts/tests/test-report-token-use-helper.sh
+++ b/.agents/scripts/tests/test-report-token-use-helper.sh
@@ -205,7 +205,7 @@ SQL
 	AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_DB="${TEST_ROOT}/opencode.db" \
 		AIDEVOPS_REPORT_TOKEN_USE_OBS_DB="${TEST_ROOT}/llm-requests.db" \
 		AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_CONFIG="${TEST_ROOT}/opencode.json" \
-		"$HELPER_SH" data --limit 10 --daily-days 2000 --json >"$_json_path"
+		"$HELPER_SH" data --full --limit 10 --daily-days 2000 --json >"$_json_path"
 	assert_json_field "$_json_path" "usage_by_session_kind[1].session_kind" "headless_worker" "Report summarizes headless worker usage"
 	assert_json_field "$_json_path" "usage_by_session_kind[1].net_tokens_total" "45" "Report sums headless worker net tokens"
 	assert_json_field "$_json_path" "daily_usage[0].headless_worker_net_tokens_total" "45" "Report sums daily headless worker net tokens"
@@ -236,7 +236,7 @@ SQL
 	AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_DB="${TEST_ROOT}/opencode.db" \
 		AIDEVOPS_REPORT_TOKEN_USE_OBS_DB="${TEST_ROOT}/llm-requests.db" \
 		AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_CONFIG="${TEST_ROOT}/opencode.json" \
-		"$HELPER_SH" data --limit 10 --daily-days 2000 --json >"$_json_path"
+		"$HELPER_SH" data --full --limit 10 --daily-days 2000 --json >"$_json_path"
 	assert_session_field "$_json_path" "ses_obs_root" "child_session_count" "1" "Report uses observability child lineage"
 	assert_session_field "$_json_path" "ses_obs_root" "compaction_count" "1" "Report counts observability compaction agent"
 	assert_session_field "$_json_path" "ses_obs_root" "cost_usd" "0.6" "Report uses observability request costs"
@@ -295,6 +295,51 @@ PY
 	return 0
 }
 
+test_data_defaults_to_compact_schema() {
+	create_fixture_dbs
+	sqlite3 "${TEST_ROOT}/opencode.db" <<'SQL'
+INSERT INTO session VALUES ('ses_peer', NULL, 'Peer Session', '{"id":"gpt-5.5","providerID":"openai"}', 20, 5, 0, 5, 1, 0.05, 1700000200000, 1700000300000, NULL, '/repo', '/repo', 'Build+');
+SQL
+	local _compact_path="${TEST_ROOT}/compact.json"
+	local _full_path="${TEST_ROOT}/full.json"
+	AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_DB="${TEST_ROOT}/opencode.db" \
+		AIDEVOPS_REPORT_TOKEN_USE_OBS_DB="${TEST_ROOT}/llm-requests.db" \
+		AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_CONFIG="${TEST_ROOT}/opencode.json" \
+		"$HELPER_SH" data --limit 10 --daily-days 0 --json >"$_compact_path"
+	AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_DB="${TEST_ROOT}/opencode.db" \
+		AIDEVOPS_REPORT_TOKEN_USE_OBS_DB="${TEST_ROOT}/llm-requests.db" \
+		AIDEVOPS_REPORT_TOKEN_USE_OPENCODE_CONFIG="${TEST_ROOT}/opencode.json" \
+		"$HELPER_SH" data --full --limit 10 --daily-days 0 --json >"$_full_path"
+	assert_json_field "$_compact_path" "summary.session_count" "2" "Compact data includes aggregate session count"
+	assert_json_field "$_compact_path" "summary.net_tokens_total" "218" "Compact data includes aggregate tokens"
+	assert_json_field "$_compact_path" "summary.cost_usd" "0.4" "Compact data includes aggregate cost"
+	assert_json_field "$_compact_path" "summary.evidence_coverage.cost.available_session_count" "2" "Compact data includes evidence coverage"
+	assert_json_field "$_compact_path" "usage_by_session_kind[0].session_kind" "interactive" "Compact data retains routing fields"
+	assert_json_field "$_compact_path" "configured_mcps[0]" "context7" "Compact data emits configured MCPs once"
+	if python3 - "$_compact_path" "$_full_path" <<'PY'; then
+import json
+import sys
+from pathlib import Path
+
+compact_path, full_path = map(Path, sys.argv[1:])
+compact = json.loads(compact_path.read_text(encoding="utf-8"))
+full = json.loads(full_path.read_text(encoding="utf-8"))
+if "mcps_active" in compact["sessions"][0]:
+    raise SystemExit("compact session repeats configured MCPs")
+if "source_session_ids" in compact["sessions"][0]:
+    raise SystemExit("compact session includes full source session IDs")
+if set(full) != {"daily_usage", "usage_by_session_kind", "sessions"}:
+    raise SystemExit(f"full output schema changed: {sorted(full)}")
+if compact_path.stat().st_size >= full_path.stat().st_size:
+    raise SystemExit("compact output is not smaller than full output")
+PY
+		print_result "Compact data omits repeated invariant arrays and is smaller" 0
+	else
+		print_result "Compact data omits repeated invariant arrays and is smaller" 1
+	fi
+	return 0
+}
+
 main() {
 	setup_test_env
 	trap teardown_test_env EXIT
@@ -302,6 +347,7 @@ main() {
 	test_report_summarizes_headless_workers
 	test_report_uses_observability_cost_and_lineage
 	test_session_report_defaults_source_ids
+	test_data_defaults_to_compact_schema
 	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then
 		return 1


### PR DESCRIPTION
## Summary

Default data output is compact and bounded; --full preserves the legacy detailed schema.

## Files Changed

.agents/reports/token-use.md, .agents/scripts/report-token-use-helper.py, .agents/scripts/tests/test-report-token-use-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — bash .agents/scripts/tests/test-report-token-use-helper.sh; ruff check .agents/scripts/report-token-use-helper.py

Resolves #29822


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.239 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 4m and 73,492 tokens on this as a headless worker.