### PR TITLE
GH#29828: Make persistent operator dashboards truthful and proportionate

### DIFF
--- a/.agents/scripts/stats-health-dashboard-data.sh
+++ b/.agents/scripts/stats-health-dashboard-data.sh
@@ -646,25 +646,34 @@ BODY
 #   $2 - repo_slug
 #   $3 - runner_prefix
 #   $4 - pr_count
-#   $5 - pr_label
-#   $6 - assigned_issue_count
-#   $7 - worker_count
-#   $8 - worker_label
+#   $5 - assigned_issue_count
+#   $6 - worker_count
+#   $7 - snapshot timestamp (ISO8601 UTC)
 #######################################
 _update_health_issue_title() {
 	local health_issue_number="$1"
 	local repo_slug="$2"
 	local runner_prefix="$3"
 	local pr_count="$4"
-	local pr_label="$5"
-	local assigned_issue_count="$6"
-	local worker_count="$7"
-	local worker_label="$8"
+	local assigned_issue_count="$5"
+	local worker_count="$6"
+	local snapshot_iso="$7"
 
-	local title_parts="${pr_count} ${pr_label}, ${assigned_issue_count} assigned, ${worker_count} ${worker_label}"
-	local title_time
-	title_time=$(date -u +"%H:%M")
-	local health_title="${runner_prefix} ${title_parts} at ${title_time} UTC"
+	local pr_label="open PRs"
+	[[ "${pr_count:-0}" -eq 1 ]] && pr_label="open PR"
+	local issue_label="issues assigned"
+	[[ "${assigned_issue_count:-0}" -eq 1 ]] && issue_label="issue assigned"
+	local worker_label="local workers"
+	[[ "${worker_count:-0}" -eq 1 ]] && worker_label="local worker"
+
+	local title_parts="${pr_count} ${pr_label}, ${assigned_issue_count} ${issue_label}, ${worker_count} ${worker_label}"
+	local title_time="${snapshot_iso%:*}"
+	title_time="${title_time/T/ }"
+	if [[ ! "$title_time" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}[[:space:]][0-9]{2}:[0-9]{2}$ ]]; then
+		title_time=$(date -u +"%Y-%m-%d %H:%M")
+	fi
+	local title_stats="${runner_prefix} ${title_parts}"
+	local health_title="${title_stats} — changed ${title_time} UTC"
 
 	local current_title=""
 	local view_output
@@ -676,9 +685,9 @@ _update_health_issue_title() {
 		echo "[stats] Health issue: failed to view title for #${health_issue_number}: ${view_output}" >>"$LOGFILE"
 	fi
 
-	local current_stats="${current_title% at [0-9][0-9]:[0-9][0-9] UTC}"
-	local new_stats="${health_title% at [0-9][0-9]:[0-9][0-9] UTC}"
-	if [[ "$current_stats" != "$new_stats" ]]; then
+	local current_stats="${current_title%% — changed *}"
+	current_stats="${current_stats% at [0-9][0-9]:[0-9][0-9] UTC}"
+	if [[ "$current_stats" != "$title_stats" ]]; then
 		local title_edit_stderr
 		title_edit_stderr=$(gh_issue_edit_safe "$health_issue_number" --repo "$repo_slug" --title "$health_title" 2>&1 >/dev/null)
 		local title_edit_exit_code=$?

--- a/.agents/scripts/stats-health-dashboard-issue.sh
+++ b/.agents/scripts/stats-health-dashboard-issue.sh
@@ -30,8 +30,11 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	unset _lib_path
 fi
 
-# Role constant — avoids repeated-string-literal lint finding across functions
+# Shared constants — avoid repeated-string-literal lint findings across functions
 _ROLE_SUPERVISOR="supervisor"
+_ROLE_CONTRIBUTOR="contributor"
+_HEALTH_PERSISTENT_LABEL="persistent"
+_HEALTH_OPERATOR_LABEL_PREFIX="operator:"
 
 # --- Functions ---
 
@@ -78,16 +81,18 @@ _list_health_issues_by_canonical_identity() {
 	local identity_aliases="$3"
 
 	local issues_json rc=0
+	# Query the durable management label instead of source:health-dashboard so
+	# pre-source-label dashboards are included in canonical identity dedup.
 	issues_json=$(gh_issue_list --repo "$repo_slug" \
-		--label "source:health-dashboard" \
-		--state open --json number,title,labels --limit 100 2>/dev/null) || rc=$?
+		--label "$_HEALTH_PERSISTENT_LABEL" \
+		--state open --json number,title,labels --limit 500 2>/dev/null) || rc=$?
 	if [[ $rc -ne 0 ]]; then
 		return "$rc"
 	fi
 
 	local aliases_json
 	aliases_json=$(printf '%s\n%s\n' "$canonical_identity" "$identity_aliases" | jq -R 'select(length > 0)' | jq -s 'unique')
-	local canonical_label="operator:${canonical_identity}"
+	local canonical_label="${_HEALTH_OPERATOR_LABEL_PREFIX}${canonical_identity}"
 	printf '%s' "${issues_json:-[]}" | jq \
 		--argjson aliases "$aliases_json" \
 		--arg canonical_label "$canonical_label" \
@@ -106,6 +111,73 @@ _list_health_issues_by_canonical_identity() {
 }
 
 #######################################
+# Converge dashboard labels and remove task lifecycle labels. Persistent health
+# issues are observability surfaces, never dispatchable work items.
+# Arguments:
+#   $1 - issue number
+#   $2 - repo slug
+#   $3 - current runner user
+#   $4 - current runner role
+#   $5 - canonical operator identity
+#######################################
+_normalize_health_issue_labels() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local runner_user="$3"
+	local runner_role="$4"
+	local canonical_identity="$5"
+
+	local labels_json rc=0
+	labels_json=$(gh_issue_view "$issue_number" --repo "$repo_slug" --json labels 2>/dev/null) || rc=$?
+	if [[ $rc -ne 0 || -z "$labels_json" ]]; then
+		echo "[stats] Health issue: label normalization skipped for #${issue_number} in ${repo_slug} (rc=${rc})" \
+			>>"${LOGFILE:-/dev/null}"
+		return 0
+	fi
+
+	local label_names
+	label_names=$(printf '%s' "$labels_json" | jq -r '(.labels // []) | map(.name) | .[]' 2>/dev/null) || return 0
+	local expected_role_label="$_ROLE_CONTRIBUTOR"
+	local opposite_role_label="$_ROLE_SUPERVISOR"
+	if [[ "$runner_role" == "$_ROLE_SUPERVISOR" ]]; then
+		expected_role_label="$_ROLE_SUPERVISOR"
+		opposite_role_label="$_ROLE_CONTRIBUTOR"
+	fi
+	local canonical_label="${_HEALTH_OPERATOR_LABEL_PREFIX}${canonical_identity}"
+
+	local -a edit_args=()
+	local expected_label
+	for expected_label in \
+		"$_HEALTH_PERSISTENT_LABEL" "source:health-dashboard" "$expected_role_label" \
+		"$runner_user" "$canonical_label" "origin:worker"; do
+		if ! printf '%s\n' "$label_names" | grep -Fxq "$expected_label"; then
+			edit_args+=(--add-label "$expected_label")
+		fi
+	done
+
+	local stale_label
+	while IFS= read -r stale_label; do
+		[[ -n "$stale_label" ]] && edit_args+=(--remove-label "$stale_label")
+	done < <(printf '%s\n' "$label_names" | jq -Rr \
+		--arg opposite "$opposite_role_label" \
+		'select(
+			. == $opposite
+			or . == "auto-dispatch"
+			or . == "no-auto-dispatch"
+			or . == "origin:interactive"
+			or . == "origin:worker-takeover"
+			or startswith("status:")
+		)')
+
+	[[ ${#edit_args[@]} -eq 0 ]] && return 0
+	if ! gh_issue_edit_safe "$issue_number" --repo "$repo_slug" "${edit_args[@]}" >/dev/null 2>&1; then
+		echo "[stats] Health issue: failed to normalize labels for #${issue_number} in ${repo_slug}" \
+			>>"${LOGFILE:-/dev/null}"
+	fi
+	return 0
+}
+
+#######################################
 # Return success when issue metadata has no operator label for another identity.
 # Arguments:
 #   $1 - issue JSON with labels
@@ -114,7 +186,7 @@ _list_health_issues_by_canonical_identity() {
 _health_issue_operator_label_allows_identity() {
 	local issue_json="$1"
 	local canonical_identity="$2"
-	local canonical_label="operator:${canonical_identity}"
+	local canonical_label="${_HEALTH_OPERATOR_LABEL_PREFIX}${canonical_identity}"
 	local issue_json_input="${issue_json}"
 	case "$issue_json_input" in
 		""|[Oo][Pp][Ee][Nn]|[Cc][Ll][Oo][Ss][Ee][Dd]) issue_json_input='{}' ;;
@@ -316,7 +388,7 @@ _close_health_issue_identity_duplicates() {
 _try_title_health_issue_fallback() {
 	local runner_prefix="$1" repo_slug="$2" runner_user="$3" role_label="$4" role_display="$5"
 	local canonical_identity="${6:-$runner_user}"
-	local canonical_label="operator:${canonical_identity}"
+	local canonical_label="${_HEALTH_OPERATOR_LABEL_PREFIX}${canonical_identity}"
 
 	local title_result rc=0
 	title_result=$(gh_issue_list --repo "$repo_slug" \
@@ -436,7 +508,7 @@ _create_health_issue() {
 	local canonical_identity="${9:-$runner_user}"
 	local identity_aliases="${10:-$runner_user}"
 	local runner_label_color="0E8A16"
-	local operator_label="operator:${canonical_identity}"
+	local operator_label="${_HEALTH_OPERATOR_LABEL_PREFIX}${canonical_identity}"
 
 	gh label create "$role_label" --repo "$repo_slug" --color "$role_label_color" \
 		--description "$role_label_desc" --force 2>/dev/null || true
@@ -449,7 +521,7 @@ _create_health_issue() {
 	# t1890: health dashboard issues are management issues that should never be
 	# closed or dispatched. Add the "persistent" label for consistency with the
 	# quality review issue, so the dispatch filter only needs one label check.
-	gh label create "persistent" --repo "$repo_slug" --color "FBCA04" \
+	gh label create "$_HEALTH_PERSISTENT_LABEL" --repo "$repo_slug" --color "FBCA04" \
 		--description "Persistent issue — do not close" --force 2>/dev/null || true
 
 	local aliases_csv
@@ -469,7 +541,7 @@ _create_health_issue() {
 	health_issue_number=$(AIDEVOPS_SESSION_ORIGIN=worker gh_create_issue --repo "$repo_slug" \
 		--title "${runner_prefix} starting..." \
 		--body "$health_body" \
-		--label "$role_label" --label "$runner_user" --label "$operator_label" --label "source:health-dashboard" --label "persistent" 2>/dev/null || echo "")
+		--label "$role_label" --label "$runner_user" --label "$operator_label" --label "source:health-dashboard" --label "$_HEALTH_PERSISTENT_LABEL" 2>/dev/null || echo "")
 	health_issue_number=$(_health_issue_number_from_text "$health_issue_number")
 
 	if [[ -z "$health_issue_number" ]]; then
@@ -695,7 +767,7 @@ _resolve_runner_role_config() {
 		role_display="Supervisor"
 	else
 		runner_prefix="[Contributor:${runner_user}]"
-		role_label="contributor"
+		role_label="$_ROLE_CONTRIBUTOR"
 		role_label_color="A2EEEF"
 		role_label_desc="Contributor health dashboard"
 		role_display="Contributor"

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -40,6 +40,9 @@ _STATS_HEALTH_DASHBOARD_LOADED=1
 # see existing ones.
 readonly _HEALTH_QUERY_FAILED_SENTINEL="__QUERY_FAILED__"
 readonly _HEALTH_CROSS_REPO_MAX_REPOS=30
+readonly _HEALTH_IDLE_REFRESH_INTERVAL_DEFAULT=43200
+readonly _HEALTH_ACTIVITY_STATE_ACTIVE="active"
+readonly _HEALTH_ACTIVITY_STATE_IDLE="idle"
 
 # Defensive SCRIPT_DIR fallback
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
@@ -94,7 +97,10 @@ _resolve_current_gh_login_or_fallback() {
 
 #######################################
 # Activity guard — returns 0 to proceed, 1 to skip.
-# Only runs when the cached health-issue file is absent (would create a new one).
+# Active repositories refresh on the hourly stats cadence. Idle repositories
+# publish their transition to idle immediately, then refresh every 12 hours by
+# default. This keeps the dashboard well inside the 48-hour freshness watchdog
+# while avoiding full activity scans and GitHub writes for unchanged idle repos.
 #######################################
 _check_health_issue_activity_guard() {
 	local repo_slug="$1"
@@ -102,36 +108,87 @@ _check_health_issue_activity_guard() {
 	local runner_user="$3"
 	local health_issue_file="$4"
 
-	[[ -f "$health_issue_file" ]] && return 0
-
 	local guard_pr_count guard_assigned_count guard_auto_dispatch_count guard_worker_count
 	local _guard_fields=()
+	_HEALTH_ISSUE_ACTIVITY_STATE="$_HEALTH_ACTIVITY_STATE_ACTIVE"
 	while IFS= read -r -d '' _gf; do
 		_guard_fields+=("$_gf")
 	done < <(_scan_active_workers "${repo_path:-}")
 	guard_worker_count="${_guard_fields[1]:-0}"
 	[[ "${guard_worker_count:-0}" -gt 0 ]] && return 0
 
+	local guard_rc=0
 	guard_pr_count=$(gh_pr_list --repo "$repo_slug" --state open \
-		--json number --jq 'length' 2>/dev/null || echo "0")
+		--json number --jq 'length' 2>/dev/null) || guard_rc=$?
+	[[ $guard_rc -ne 0 ]] && return 0
 	[[ "$guard_pr_count" =~ ^[0-9]+$ ]] || guard_pr_count="0"
 	[[ "${guard_pr_count:-0}" -gt 0 ]] && return 0
 
+	guard_rc=0
 	guard_assigned_count=$(gh_issue_list --repo "$repo_slug" \
 		--assignee "$runner_user" --state open \
-		--json number --jq 'length' 2>/dev/null || echo "0")
+		--json number --jq 'length' 2>/dev/null) || guard_rc=$?
+	[[ $guard_rc -ne 0 ]] && return 0
 	[[ "$guard_assigned_count" =~ ^[0-9]+$ ]] || guard_assigned_count="0"
 	[[ "${guard_assigned_count:-0}" -gt 0 ]] && return 0
 
+	guard_rc=0
 	guard_auto_dispatch_count=$(gh_issue_list --repo "$repo_slug" \
 		--label "auto-dispatch" --state open \
-		--json number --jq 'length' 2>/dev/null || echo "0")
+		--json number --jq 'length' 2>/dev/null) || guard_rc=$?
+	[[ $guard_rc -ne 0 ]] && return 0
 	[[ "$guard_auto_dispatch_count" =~ ^[0-9]+$ ]] || guard_auto_dispatch_count="0"
 	[[ "${guard_auto_dispatch_count:-0}" -gt 0 ]] && return 0
 
-	echo "[stats] Health issue: skipping creation for ${repo_slug} — no active PRs, assigned issues, auto-dispatch work, or workers" \
+	_HEALTH_ISSUE_ACTIVITY_STATE="$_HEALTH_ACTIVITY_STATE_IDLE"
+	if [[ ! -f "$health_issue_file" ]]; then
+		echo "[stats] Health issue: skipping creation for ${repo_slug} — no active PRs, assigned issues, auto-dispatch work, or workers" \
+			>>"${LOGFILE:-/dev/null}"
+		return 1
+	fi
+
+	local refresh_state_file="${health_issue_file}.refresh-state"
+	local previous_state="" previous_epoch="0"
+	if [[ -f "$refresh_state_file" ]]; then
+		IFS='|' read -r previous_state previous_epoch <"$refresh_state_file" 2>/dev/null || {
+			previous_state=""
+			previous_epoch="0"
+		}
+	fi
+	[[ "$previous_epoch" =~ ^[0-9]+$ ]] || previous_epoch="0"
+
+	# Missing/active state means this is the first observed idle cycle. Publish
+	# the transition now so titles never advertise workers or queue activity for
+	# the entire idle backoff window.
+	[[ "$previous_state" != "$_HEALTH_ACTIVITY_STATE_IDLE" ]] && return 0
+
+	local idle_interval="${HEALTH_IDLE_REFRESH_INTERVAL:-$_HEALTH_IDLE_REFRESH_INTERVAL_DEFAULT}"
+	[[ "$idle_interval" =~ ^[0-9]+$ ]] || idle_interval="$_HEALTH_IDLE_REFRESH_INTERVAL_DEFAULT"
+	local now_epoch
+	now_epoch=$(date +%s)
+	if [[ $((now_epoch - previous_epoch)) -ge $idle_interval ]]; then
+		return 0
+	fi
+
+	echo "[stats] Health issue: deferring unchanged idle dashboard for ${repo_slug} (interval=${idle_interval}s)" \
 		>>"${LOGFILE:-/dev/null}"
 	return 1
+}
+
+#######################################
+# Record the activity state only after a dashboard body update succeeds.
+# Arguments:
+#   $1 - health issue cache file
+#   $2 - activity state (active|idle)
+#######################################
+_record_health_issue_refresh_state() {
+	local health_issue_file="$1"
+	local activity_state="$2"
+	[[ "$activity_state" == "$_HEALTH_ACTIVITY_STATE_ACTIVE" \
+		|| "$activity_state" == "$_HEALTH_ACTIVITY_STATE_IDLE" ]] \
+		|| activity_state="$_HEALTH_ACTIVITY_STATE_ACTIVE"
+	printf '%s|%s\n' "$activity_state" "$(date +%s)" >"${health_issue_file}.refresh-state"
+	return 0
 }
 
 #######################################
@@ -185,12 +242,14 @@ _update_health_issue_body_or_fail() {
 #   $2 - repo slug
 #   $3 - runner title prefix
 #   $4 - rendered issue body
+#   $5 - snapshot timestamp (ISO8601 UTC)
 #######################################
 _refresh_health_issue_title_from_body() {
 	local health_issue_number="$1"
 	local repo_slug="$2"
 	local runner_prefix="$3"
 	local body="$4"
+	local snapshot_iso="$5"
 	local counts_raw pr_count assigned_issue_count worker_count
 
 	# Re-extract headline counts from the rendered body to build the title.
@@ -198,15 +257,9 @@ _refresh_health_issue_title_from_body() {
 	counts_raw=$(_extract_body_counts "$body")
 	IFS='|' read -r pr_count assigned_issue_count worker_count <<<"$counts_raw"
 
-	local pr_label="PRs"
-	[[ "${pr_count:-0}" -eq 1 ]] && pr_label="PR"
-	local worker_label="workers"
-	[[ "${worker_count:-0}" -eq 1 ]] && worker_label="worker"
-
 	_update_health_issue_title \
 		"$health_issue_number" "$repo_slug" "$runner_prefix" \
-		"$pr_count" "$pr_label" "$assigned_issue_count" \
-		"$worker_count" "$worker_label"
+		"$pr_count" "$assigned_issue_count" "$worker_count" "$snapshot_iso"
 	return 0
 }
 
@@ -270,8 +323,10 @@ _update_health_issue_for_repo() {
 	local health_issue_file="${cache_dir}/health-issue-${canonical_identity_cache_safe}-${slug_safe}"
 	mkdir -p "$cache_dir"
 
+	_HEALTH_ISSUE_ACTIVITY_STATE="$_HEALTH_ACTIVITY_STATE_ACTIVE"
 	_check_health_issue_activity_guard \
 		"$repo_slug" "$repo_path" "$runner_user" "$health_issue_file" || return 0
+	local activity_state="${_HEALTH_ISSUE_ACTIVITY_STATE:-$_HEALTH_ACTIVITY_STATE_ACTIVE}"
 
 	local health_issue_number
 	health_issue_number=$(_resolve_health_issue_number \
@@ -290,6 +345,9 @@ _update_health_issue_for_repo() {
 		"$repo_slug" "$runner_user" "$runner_role" \
 		"$role_label" "$role_display" "$health_issue_number" \
 		"$canonical_identity" "$identity_aliases"
+	_normalize_health_issue_labels \
+		"$health_issue_number" "$repo_slug" "$runner_user" \
+		"$runner_role" "$canonical_identity"
 
 	if [[ "$runner_role" == "supervisor" ]]; then
 		_ensure_health_issue_pinned "$health_issue_number" "$repo_slug" "$runner_user"
@@ -308,7 +366,9 @@ _update_health_issue_for_repo() {
 		"$canonical_identity" "$identity_aliases")
 
 	_update_health_issue_body_or_fail "$health_issue_number" "$repo_slug" "$body" || return 1
-	_refresh_health_issue_title_from_body "$health_issue_number" "$repo_slug" "$runner_prefix" "$body"
+	_refresh_health_issue_title_from_body \
+		"$health_issue_number" "$repo_slug" "$runner_prefix" "$body" "$now_iso"
+	_record_health_issue_refresh_state "$health_issue_file" "$activity_state"
 
 	return 0
 }

--- a/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
+++ b/.agents/scripts/tests/test-health-dashboard-identity-aliases.sh
@@ -40,7 +40,7 @@ gh() {
 			printf '%s' '{"message":"API rate limit exceeded", "status":"403"}' >&2
 			return 1
 			;;
-		conflicting_operator:*"issue list --repo owner/repo --label source:health-dashboard"*)
+		conflicting_operator:*"issue list --repo owner/repo --label persistent"*)
 			printf '%s' '[{"number":4643,"title":"[Supervisor:marcusquinn] stale dashboard","labels":[{"name":"source:health-dashboard"},{"name":"operator:alex-solovyev"},{"name":"alex-solovyev"},{"name":"supervisor"}]}]'
 			return 0
 			;;
@@ -48,7 +48,7 @@ gh() {
 			printf '%s' '[{"number":4643,"title":"[Supervisor:marcusquinn] stale dashboard","labels":[{"name":"source:health-dashboard"},{"name":"operator:alex-solovyev"},{"name":"alex-solovyev"},{"name":"supervisor"}]}]'
 			return 0
 			;;
-		legacy_title:*"issue list --repo owner/repo --label source:health-dashboard"*)
+		legacy_title:*"issue list --repo owner/repo --label persistent"*)
 			printf '%s' '[{"number":555,"title":"[Supervisor:github-user] legacy dashboard","labels":[{"name":"source:health-dashboard"},{"name":"supervisor"},{"name":"github-user"}]}]'
 			return 0
 			;;
@@ -80,7 +80,7 @@ gh() {
 			printf '%s' '0'
 			return 0
 			;;
-		:*"issue list --repo owner/repo --label source:health-dashboard"*)
+		:*"issue list --repo owner/repo --label persistent"*)
 			printf '%s' '[{"number":20408,"title":"[Supervisor:github-user] 1 PR at 10:00 UTC","labels":[{"name":"source:health-dashboard"},{"name":"supervisor"},{"name":"github-user"}],"createdAt":"2026-05-01T10:00:00Z"},{"number":18669,"title":"[Contributor:local-user] 0 PRs at 09:00 UTC","labels":[{"name":"source:health-dashboard"},{"name":"contributor"},{"name":"local-user"}],"createdAt":"2026-04-01T09:00:00Z"}]'
 			return 0
 			;;
@@ -398,6 +398,94 @@ else
 	fi
 fi
 unset HEALTH_FIXTURE
+
+cache_file="${HOME}/.aidevops/logs/health-issue-idle-owner-repo"
+printf '%s\n' '20408' >"$cache_file"
+: >"$GH_CALLS"
+: >"$LOGFILE"
+export HEALTH_FIXTURE=activity_guard_idle
+if _check_health_issue_activity_guard "owner/repo" "$TMP" "github-user" "$cache_file" \
+	&& [[ "$_HEALTH_ISSUE_ACTIVITY_STATE" == "idle" ]]; then
+	pass "cached dashboard publishes first observed idle transition"
+else
+	fail "cached dashboard publishes first observed idle transition" "state=${_HEALTH_ISSUE_ACTIVITY_STATE:-}; log=$(tr '\n' ';' <"$LOGFILE")"
+fi
+
+_record_health_issue_refresh_state "$cache_file" "idle"
+: >"$LOGFILE"
+if _check_health_issue_activity_guard "owner/repo" "$TMP" "github-user" "$cache_file"; then
+	fail "cached idle dashboard defers full refresh inside idle interval" "log=$(tr '\n' ';' <"$LOGFILE")"
+else
+	if grep -q 'deferring unchanged idle dashboard' "$LOGFILE"; then
+		pass "cached idle dashboard defers full refresh inside idle interval"
+	else
+		fail "cached idle dashboard deferral is observable" "log=$(tr '\n' ';' <"$LOGFILE")"
+	fi
+fi
+
+_record_health_issue_refresh_state "$cache_file" "active"
+if _check_health_issue_activity_guard "owner/repo" "$TMP" "github-user" "$cache_file"; then
+	pass "cached dashboard publishes active-to-idle transition immediately"
+else
+	fail "cached dashboard publishes active-to-idle transition immediately" "log=$(tr '\n' ';' <"$LOGFILE")"
+fi
+unset HEALTH_FIXTURE
+
+: >"$GH_CALLS"
+export HEALTH_FIXTURE=label_hygiene
+gh() {
+	local call="$*"
+	printf '%s\n' "$call" >>"$GH_CALLS"
+	if [[ "$call" == *"issue view 20408 --repo owner/repo --json labels"* ]]; then
+		printf '%s' '{"labels":[{"name":"persistent"},{"name":"source:health-dashboard"},{"name":"supervisor"},{"name":"github-user"},{"name":"operator:canonical-operator"},{"name":"origin:worker"},{"name":"origin:interactive"},{"name":"origin:worker-takeover"},{"name":"auto-dispatch"},{"name":"status:available"}]}'
+	fi
+	return 0
+}
+_normalize_health_issue_labels "20408" "owner/repo" "github-user" "supervisor" "canonical-operator"
+if grep -q -- '--remove-label auto-dispatch' "$GH_CALLS" \
+	&& grep -q -- '--remove-label status:available' "$GH_CALLS" \
+	&& grep -q -- '--remove-label origin:interactive' "$GH_CALLS" \
+	&& grep -q -- '--remove-label origin:worker-takeover' "$GH_CALLS"; then
+	pass "dashboard label normalization removes task lifecycle labels"
+else
+	fail "dashboard label normalization removes task lifecycle labels" "calls=$(tr '\n' ';' <"$GH_CALLS")"
+fi
+
+: >"$GH_CALLS"
+gh() {
+	local call="$*"
+	printf '%s\n' "$call" >>"$GH_CALLS"
+	if [[ "$call" == *"issue view 20408 --repo owner/repo --json title"* ]]; then
+		printf '%s' '[Supervisor:github-user] 1 PR, 0 assigned, 0 workers at 10:00 UTC'
+	fi
+	return 0
+}
+_update_health_issue_title \
+	"20408" "owner/repo" "[Supervisor:github-user]" "1" "0" "0" \
+	"2026-08-09T05:30:00Z"
+if grep -q -- '--title \[Supervisor:github-user\] 1 open PR, 0 issues assigned, 0 local workers — changed 2026-08-09 05:30 UTC' "$GH_CALLS"; then
+	pass "dashboard title explains metric scope and dates the changed snapshot"
+else
+	fail "dashboard title explains metric scope and dates the changed snapshot" "calls=$(tr '\n' ';' <"$GH_CALLS")"
+fi
+
+: >"$GH_CALLS"
+gh() {
+	local call="$*"
+	printf '%s\n' "$call" >>"$GH_CALLS"
+	if [[ "$call" == *"issue view 20408 --repo owner/repo --json title"* ]]; then
+		printf '%s' '[Supervisor:github-user] 1 open PR, 0 issues assigned, 0 local workers — changed 2026-08-09 05:30 UTC'
+	fi
+	return 0
+}
+_update_health_issue_title \
+	"20408" "owner/repo" "[Supervisor:github-user]" "1" "0" "0" \
+	"2026-08-09T06:30:00Z"
+if ! grep -q 'issue edit' "$GH_CALLS"; then
+	pass "unchanged dashboard metrics preserve the existing changed timestamp"
+else
+	fail "unchanged dashboard metrics preserve the existing changed timestamp" "calls=$(tr '\n' ';' <"$GH_CALLS")"
+fi
 
 printf '\n== Summary ==\n'
 if ((TESTS_FAILED > 0)); then


### PR DESCRIPTION
## Summary

Add dated metric-scope titles, canonical legacy deduplication, lifecycle-label normalization, and 12-hour idle dashboard backoff.

## Files Changed

.agents/scripts/stats-health-dashboard-data.sh, .agents/scripts/stats-health-dashboard-issue.sh, .agents/scripts/stats-health-dashboard.sh, .agents/scripts/tests/test-health-dashboard-identity-aliases.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 30 focused identity/dashboard tests, 2 sentinel tests, 13 stats characterization tests, ShellCheck, and linters-local.sh pass.

Resolves #29828


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.240 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 17m and 404,609 tokens on this with the user in an interactive session.