### PR TITLE
GH#29836: Enforce stats wrapper hard timeout

### DIFF
--- a/.agents/scripts/stats-wrapper.sh
+++ b/.agents/scripts/stats-wrapper.sh
@@ -164,11 +164,27 @@ check_stats_dedup() {
 #######################################
 _stats_wrapper_on_exit() {
 	local ec=$?
-	rm -f "$STATS_PIDFILE" 2>/dev/null || true
+	_stats_wrapper_remove_own_pidfile
 	if [[ "$ec" -ne 0 ]]; then
 		echo "[stats-wrapper] HEALTH-DASHBOARD-FAIL exit=${ec} at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$STATS_LOGFILE"
 	fi
 	return "$ec"
+}
+
+# A timed-out predecessor can finish its EXIT trap after a later scheduler
+# invocation has replaced the PID file. Only remove the file when it still
+# records this wrapper's PID, so that cleanup cannot disable deduplication for
+# the healthy successor.
+_stats_wrapper_remove_own_pidfile() {
+	local pidfile_pid="" pidfile_epoch=""
+	if [[ ! -f "$STATS_PIDFILE" ]]; then
+		return 0
+	fi
+	read -r pidfile_pid pidfile_epoch <"$STATS_PIDFILE" 2>/dev/null || return 0
+	if [[ "$pidfile_pid" == "$$" ]]; then
+		rm -f "$STATS_PIDFILE" 2>/dev/null || true
+	fi
+	return 0
 }
 
 _stats_wrapper_run_health_update() {
@@ -190,6 +206,54 @@ _stats_wrapper_run_health_update() {
 		return "$update_ec"
 		;;
 	esac
+}
+
+# Execute the potentially slow work in a child so the wrapper can enforce its
+# own wall-clock ceiling rather than relying on the next scheduler tick to
+# detect a stale PID file.
+_stats_wrapper_run_work() {
+	# Source stats-functions.sh for health dashboard and quality sweep functions.
+	# After t1431, these functions live in their own file instead of pulse-wrapper.sh.
+	# LOGFILE is set to STATS_LOGFILE so all function logging goes to stats.log.
+	LOGFILE="$STATS_LOGFILE"
+	# shellcheck source=stats-functions.sh
+	source "${SCRIPT_DIR}/stats-functions.sh" || {
+		echo "[stats-wrapper] Failed to source stats-functions.sh" >>"$STATS_LOGFILE"
+		return 1
+	}
+
+	run_daily_quality_sweep || {
+		local sweep_ec=$?
+		echo "[stats-wrapper] QUALITY-SWEEP-FAIL exit=${sweep_ec} at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$STATS_LOGFILE"
+	}
+	_stats_wrapper_run_health_update
+	return $?
+}
+
+_stats_wrapper_run_with_timeout() {
+	local start_epoch="" now="" elapsed="" child_pid=""
+	start_epoch=$(date +%s)
+	_stats_wrapper_run_work &
+	child_pid=$!
+
+	while kill -0 "$child_pid" 2>/dev/null; do
+		now=$(date +%s)
+		elapsed=$((now - start_epoch))
+		if [[ "$elapsed" -ge "$STATS_TIMEOUT" ]]; then
+			echo "[stats-wrapper] STATS-TIMEOUT elapsed=${elapsed}s ceiling=${STATS_TIMEOUT}s pid=${child_pid}; killing process tree" >>"$STATS_LOGFILE"
+			_kill_tree "$child_pid" || true
+			sleep 2
+			if kill -0 "$child_pid" 2>/dev/null; then
+				_force_kill_tree "$child_pid" || true
+			fi
+			wait "$child_pid" 2>/dev/null || true
+			return 124
+		fi
+		sleep 2
+	done
+
+	wait "$child_pid"
+	return $?
 }
 
 #######################################
@@ -273,21 +337,7 @@ main() {
 
 	echo "[stats-wrapper] Starting at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$STATS_LOGFILE"
 
-	# Source stats-functions.sh for health dashboard and quality sweep functions.
-	# After t1431, these functions live in their own file instead of pulse-wrapper.sh.
-	# LOGFILE is set to STATS_LOGFILE so all function logging goes to stats.log.
-	LOGFILE="$STATS_LOGFILE"
-	# shellcheck source=stats-functions.sh
-	source "${SCRIPT_DIR}/stats-functions.sh" || {
-		echo "[stats-wrapper] Failed to source stats-functions.sh" >>"$STATS_LOGFILE"
-		return 1
-	}
-
-	run_daily_quality_sweep || {
-		local sweep_ec=$?
-		echo "[stats-wrapper] QUALITY-SWEEP-FAIL exit=${sweep_ec} at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$STATS_LOGFILE"
-	}
-	_stats_wrapper_run_health_update
+	_stats_wrapper_run_with_timeout
 
 	echo "[stats-wrapper] Finished at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$STATS_LOGFILE"
 	return 0

--- a/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
+++ b/.agents/scripts/tests/test-stats-wrapper-headless-export.sh
@@ -159,9 +159,12 @@ test_export_before_self_check() {
 test_dashboard_update_failure_not_swallowed() {
 	local production_snippet
 	production_snippet=$(awk '
+		# The scheduler now invokes the work via _stats_wrapper_run_with_timeout,
+		# so inspect the actual work body rather than relying on its former
+		# placement inline in main().
 		/^[[:space:]]*run_daily_quality_sweep \|\| \{/ { in_production=1 }
 		in_production { print }
-		in_production && /^[[:space:]]*echo "\[stats-wrapper\] Finished/ { exit }
+		in_production && /^[[:space:]]*_stats_wrapper_run_health_update[[:space:]]*$/ { exit }
 	' "$WRAPPER_SCRIPT")
 	if printf '%s' "$production_snippet" | grep -qE '^[[:space:]]*update_health_issues[[:space:]]*\|\|[[:space:]]*true'; then
 		print_result "dashboard update failures propagate to stats-wrapper trap" 1 \
@@ -184,8 +187,8 @@ test_transient_dashboard_tempfail_is_deferred() {
 		in_helper { print }
 		in_helper && /^[[:space:]]*}$/ { exit }
 	' "$WRAPPER_SCRIPT")
-	if printf '%s' "$helper_snippet" | grep -qE '^[[:space:]]*75\)' && \
-		printf '%s' "$helper_snippet" | grep -qF 'HEALTH-DASHBOARD-DEFERRED' && \
+	if printf '%s' "$helper_snippet" | grep -qE '^[[:space:]]*75\)' &&
+		printf '%s' "$helper_snippet" | grep -qF 'HEALTH-DASHBOARD-DEFERRED' &&
 		printf '%s' "$helper_snippet" | grep -qE "^[[:space:]]*return \"\\\$update_ec\""; then
 		print_result "stats-wrapper defers EX_TEMPFAIL but propagates other dashboard failures" 0
 		return 0

--- a/.agents/scripts/tests/test-stats-wrapper-timeout.sh
+++ b/.agents/scripts/tests/test-stats-wrapper-timeout.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for GH#29836: stats-wrapper.sh must enforce its hard
+# ceiling within the current scheduler invocation and preserve successor PID
+# ownership during EXIT-trap cleanup.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+WRAPPER_SCRIPT="${SCRIPT_DIR}/../stats-wrapper.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s: %s\n' "$name" "$detail"
+	return 0
+}
+
+run_harness() {
+	local mode="$1"
+	local harness="" output="" rc=0
+	harness=$(mktemp "${TMPDIR:-/tmp}/stats-wrapper-timeout-XXXXXX") || return 1
+	cat >"$harness" <<HARNESS
+#!/usr/bin/env bash
+set -euo pipefail
+source "$WRAPPER_SCRIPT"
+STATS_PIDFILE="\$1/stats.pid"
+STATS_LOGFILE="\$1/stats.log"
+HARNESS_TEMP_DIR="\$1"
+STATS_TIMEOUT=1
+_stats_wrapper_run_work() {
+	case "$mode" in
+	timeout)
+		printf '%s\\n' "\$BASHPID" >"\$HARNESS_TEMP_DIR/child.pid"
+		sleep 30
+		;;
+	normal)
+		return 0
+		;;
+	esac
+	return 0
+}
+main
+HARNESS
+	chmod +x "$harness"
+	local temp_dir=""
+	temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/stats-wrapper-timeout-dir-XXXXXX") || {
+		rm -f "$harness"
+		return 1
+	}
+	output=$(timeout 12 bash "$harness" "$temp_dir" 2>&1) || rc=$?
+	printf '%s\n' "$rc" >"$temp_dir/rc"
+	printf '%s\n' "$output" >"$temp_dir/output"
+	printf '%s\n' "$temp_dir"
+	rm -f "$harness"
+	return 0
+}
+
+test_timeout_kills_work_and_cleans_pidfile() {
+	local temp_dir="" rc="" child_pid=""
+	temp_dir=$(run_harness timeout) || {
+		fail "timeout harness starts" "could not create harness"
+		return 0
+	}
+	rc=$(<"$temp_dir/rc")
+	if [[ "$rc" -ne 124 ]]; then
+		fail "timeout returns 124" "got rc=$rc"
+	elif [[ -f "$temp_dir/stats.pid" ]]; then
+		fail "timeout cleans its PID file" "pidfile remains"
+	elif ! grep -q 'STATS-TIMEOUT' "$temp_dir/stats.log" || ! grep -q 'HEALTH-DASHBOARD-FAIL exit=124' "$temp_dir/stats.log"; then
+		fail "timeout emits terminal diagnostics" "missing timeout or EXIT-trap record"
+	elif [[ ! -f "$temp_dir/child.pid" ]]; then
+		fail "timeout starts bounded child" "child PID was not recorded"
+	else
+		child_pid=$(<"$temp_dir/child.pid")
+		if kill -0 "$child_pid" 2>/dev/null; then
+			fail "timeout terminates wrapper child" "child $child_pid remains alive"
+		else
+			pass "timeout kills work, cleans PID file, and records terminal diagnostics"
+		fi
+	fi
+	rm -rf "$temp_dir"
+	return 0
+}
+
+test_normal_completion_cleans_pidfile() {
+	local temp_dir="" rc=""
+	temp_dir=$(run_harness normal) || {
+		fail "normal harness starts" "could not create harness"
+		return 0
+	}
+	rc=$(<"$temp_dir/rc")
+	if [[ "$rc" -eq 0 ]] && [[ ! -f "$temp_dir/stats.pid" ]] && grep -q 'Finished' "$temp_dir/stats.log"; then
+		pass "healthy run completes and cleans its PID file"
+	else
+		fail "healthy run completes and cleans its PID file" "rc=$rc, pidfile=$([[ -f "$temp_dir/stats.pid" ]] && printf present || printf absent)"
+	fi
+	rm -rf "$temp_dir"
+	return 0
+}
+
+test_cleanup_preserves_successor_pidfile() {
+	local temp_dir=""
+	temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/stats-wrapper-ownership-XXXXXX") || {
+		fail "ownership harness starts" "could not create temp directory"
+		return 0
+	}
+	if bash -c "source '$WRAPPER_SCRIPT'; STATS_PIDFILE='$temp_dir/stats.pid'; printf '%s %s\\n' 999999 1 >\"\$STATS_PIDFILE\"; _stats_wrapper_remove_own_pidfile; test -f \"\$STATS_PIDFILE\""; then
+		pass "EXIT cleanup preserves a successor PID file"
+	else
+		fail "EXIT cleanup preserves a successor PID file" "cleanup removed a foreign PID file"
+	fi
+	rm -rf "$temp_dir"
+	return 0
+}
+
+main_test() {
+	test_timeout_kills_work_and_cleans_pidfile
+	test_normal_completion_cleans_pidfile
+	test_cleanup_preserves_successor_pidfile
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]]
+}
+
+main_test "$@"


### PR DESCRIPTION
Resolves #29836

## Summary

- Run stats work in a child process with an invocation-local hard timeout.
- Terminate timed-out child process trees and retain explicit timeout diagnostics.
- Guard EXIT cleanup so it removes only the PID file owned by the exiting wrapper.

## Verification

- `bash .agents/scripts/tests/test-stats-wrapper-timeout.sh`
- `shellcheck .agents/scripts/stats-wrapper.sh .agents/scripts/tests/test-stats-wrapper-timeout.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.242 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra
