### PR TITLE
GH#29844: fix: verify full-loop audit handoffs

### DIFF
--- a/.agents/scripts/gh-audit-anomaly-filter.jq
+++ b/.agents/scripts/gh-audit-anomaly-filter.jq
@@ -69,6 +69,26 @@ def expected_trusted_author_nmr_transition:
   and ((.before.labels // []) | index($nmr) != null)
   and ((.after.labels // []) | index($nmr) == null);
 
+def expected_full_loop_review_transition:
+  comparable_state
+  and .op == $issue_edit
+  and (
+    (.caller_function == "_label_issue_in_review"
+      and framework_script($full_loop_commit_script))
+    or (.caller_function == "main"
+      and framework_script($full_loop_script))
+  )
+  and .flags.pr_review_handoff_verified == "v1-current-state"
+  and .suspicious == ["protected_label_removed:status:in-progress"]
+  and (.delta.labels_removed // []) == ["status:in-progress"]
+  and (.delta.labels_added // []) == ["status:in-review"]
+  and (.delta.title_delta_pct == 0)
+  and (.delta.body_delta_pct == 0)
+  and ((.before.labels // []) | index("status:in-progress") != null)
+  and ((.before.labels // []) | index("status:in-review") == null)
+  and ((.after.labels // []) | index("status:in-progress") == null)
+  and ((.after.labels // []) | index("status:in-review") != null);
+
 # Snapshot-read failures are observability degradation, not evidence of a
 # destructive mutation. Keep them in the immutable audit log, but do not file a
 # security-anomaly issue unless the same entry contains another suspicious
@@ -93,5 +113,6 @@ select(try ((.suspicious | length) > 0) catch true)
   expected_approval_transition
   or expected_permission_block_transition
   or expected_trusted_author_nmr_transition
+  or expected_full_loop_review_transition
   or unavailable_capture_only
 ) catch false) | not)

--- a/.agents/scripts/gh-audit-anomaly-helper.sh
+++ b/.agents/scripts/gh-audit-anomaly-helper.sh
@@ -235,6 +235,8 @@ _cmd_scan_collect_anomalies() {
 				--arg issue_edit "issue_edit" --arg approval_script "approval-helper.sh" \
 				--arg permission_script "worker-permission-helper.sh" \
 				--arg nmr_script "pulse-nmr-approval.sh" \
+				--arg full_loop_commit_script "full-loop-helper-commit.sh" \
+				--arg full_loop_script "full-loop-helper.sh" \
 				-f "${SCRIPT_DIR}/gh-audit-anomaly-filter.jq" >"$filtered_file" 2>/dev/null; then
 			rm -f "$filtered_file"
 			_ga_warn "Malformed audit NDJSON detected — checkpoint not advanced"

--- a/.agents/scripts/shared-gh-wrappers-safe-edit.sh
+++ b/.agents/scripts/shared-gh-wrappers-safe-edit.sh
@@ -288,6 +288,19 @@ _gh_audit_record_op() {
 		_gh_audit_verify_trusted_author_nmr_transition "$repo" "$number" "$before_json" "$after_json"; then
 		flags_json='{"trusted_author_nmr_verified":"v1-current-state"}'
 	fi
+	# aidevops:trust-boundary — a PR handoff removes an active worker status only
+	# after full-loop opened a reviewable PR. Restrict the audit exemption to that
+	# framework path and independently verify the resulting live lifecycle state.
+	if [[ "$op" == "$_GH_AUDIT_ISSUE_EDIT_OP" ]] &&
+		{ { [[ "$caller_function" == "_label_issue_in_review" ]] &&
+			[[ "$caller_script" == */agents/scripts/full-loop-helper-commit.sh ||
+				"$caller_script" == */.agents/scripts/full-loop-helper-commit.sh ]]; } ||
+			{ [[ "$caller_function" == "main" ]] &&
+				[[ "$caller_script" == */agents/scripts/full-loop-helper.sh ||
+					"$caller_script" == */.agents/scripts/full-loop-helper.sh ]]; }; } &&
+		_gh_audit_verify_full_loop_review_transition "$repo" "$number" "$before_json" "$after_json"; then
+		flags_json='{"pr_review_handoff_verified":"v1-current-state"}'
+	fi
 
 	GH_AUDIT_QUIET=true "$audit_helper" record \
 		--op "$op" \
@@ -301,6 +314,43 @@ _gh_audit_record_op() {
 		--flags-json "$flags_json" \
 		2>/dev/null || true
 
+	return 0
+}
+
+#######################################
+# Verify that a full-loop PR handoff changed only the active worker status.
+# Args: repo, issue number, before JSON, after JSON
+# Returns: 0 only for a comparable in-progress -> in-review transition whose
+# current remote state still reflects the completed handoff.
+#######################################
+_gh_audit_verify_full_loop_review_transition() {
+	local repo="$1"
+	local number="$2"
+	local before_json="$3"
+	local after_json="$4"
+	local issue_json=""
+	local active_status="status:in-progress"
+	local review_status="status:in-review"
+	local capture_ok="ok"
+	local open_state="open"
+
+	[[ -n "$repo" && "$number" =~ ^[0-9]+$ ]] || return 1
+	jq -e -n --arg active "$active_status" --arg review "$review_status" --arg capture_ok "$capture_ok" \
+		--argjson before "$before_json" --argjson after "$after_json" '
+		($before.capture_status // $capture_ok) == $capture_ok
+		and ($after.capture_status // $capture_ok) == $capture_ok
+		and ([$before.labels[]?] | index($active) != null)
+		and ([$before.labels[]?] | index($review) == null)
+		and ([$after.labels[]?] | index($active) == null)
+		and ([$after.labels[]?] | index($review) != null)
+	' >/dev/null 2>&1 || return 1
+
+	issue_json=$(gh api "repos/${repo}/issues/${number}" 2>/dev/null) || return 1
+	printf '%s\n' "$issue_json" | jq -e --arg active "$active_status" --arg review "$review_status" --arg open "$open_state" '
+		(.state | strings | ascii_downcase) == $open
+		and ([.labels[]?.name] | index($review) != null)
+		and ([.labels[]?.name] | index($active) == null)
+	' >/dev/null 2>&1 || return 1
 	return 0
 }
 

--- a/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
+++ b/.agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh
@@ -65,12 +65,15 @@ cat >"$LOG_FILE" <<'EOF'
 {"ts":"2026-07-31T00:16:00Z","op":"issue_edit","repo":"example/repo","number":17,"caller_script":"/workspace/.agents/scripts/pulse-nmr-approval.sh","caller_function":"_nmr_edit_issue_labels","flags":{"trusted_author_nmr_verified":"v1-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["needs-maintainer-review"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["hold-for-review"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["needs-maintainer-review"],"labels_added":["hold-for-review"]},"suspicious":["protected_label_removed:needs-maintainer-review"]}
 {"ts":"2026-07-31T00:17:00Z","op":"issue_edit","repo":"example/repo","number":18,"caller_script":"/runtime/agents/scripts/routine-log-helper.sh","caller_function":"_update_tracking_issue","before":{"capture_status":"unavailable","title_len":null,"body_len":null,"labels":null},"after":{"capture_status":"unavailable","title_len":null,"body_len":null,"labels":null},"delta":{"comparable":false,"title_delta_pct":null,"body_delta_pct":null,"labels_removed":null,"labels_added":null},"suspicious":["state_capture_unavailable:before","state_capture_unavailable:after"]}
 {"ts":"2026-07-31T00:18:00Z","op":"issue_edit","repo":"example/repo","number":19,"caller_script":"/runtime/agents/scripts/routine-log-helper.sh","caller_function":"_update_tracking_issue","before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["monitoring"]},"after":{"capture_status":"unavailable","title_len":null,"body_len":null,"labels":null},"delta":{"comparable":false,"title_delta_pct":null,"body_delta_pct":null,"labels_removed":null,"labels_added":null},"suspicious":["state_capture_unavailable:after","body_delta_pct=-100"]}
+{"ts":"2026-07-31T00:19:00Z","op":"issue_edit","repo":"example/repo","number":20,"caller_script":"/runtime/agents/scripts/full-loop-helper-commit.sh","caller_function":"_label_issue_in_review","flags":{"pr_review_handoff_verified":"v1-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-progress"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-review"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["status:in-progress"],"labels_added":["status:in-review"]},"suspicious":["protected_label_removed:status:in-progress"]}
+{"ts":"2026-07-31T00:20:00Z","op":"issue_edit","repo":"example/repo","number":21,"caller_script":"/runtime/agents/scripts/full-loop-helper-commit.sh","caller_function":"_label_issue_in_review","flags":{},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-progress"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-review"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["status:in-progress"],"labels_added":["status:in-review"]},"suspicious":["protected_label_removed:status:in-progress"]}
+{"ts":"2026-07-31T00:21:00Z","op":"issue_edit","repo":"example/repo","number":22,"caller_script":"/runtime/agents/scripts/full-loop-helper.sh","caller_function":"main","flags":{"pr_review_handoff_verified":"v1-current-state"},"before":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-progress"]},"after":{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-review"]},"delta":{"comparable":true,"title_delta_pct":0,"body_delta_pct":0,"labels_removed":["status:in-progress"],"labels_added":["status:in-review"]},"suspicious":["protected_label_removed:status:in-progress"]}
 EOF
 
 output=$(GH_AUDIT_LOG_FILE="$LOG_FILE" GH_ANOMALY_STATE_FILE="${TEST_ROOT}/state.json" \
 	GH_AUDIT_QUIET=true "$HELPER" scan --all --dry-run)
 
-[[ "$output" == *"**Anomalies found:** 11"* ]] || fail "expected transitions were not excluded exactly"
+[[ "$output" == *"**Anomalies found:** 12"* ]] || fail "expected transitions were not excluded exactly"
 [[ "$output" == *"| #3 |"* ]] || fail "unexpected lifecycle transition was hidden"
 [[ "$output" == *"| #4 |"* ]] || fail "approval transition with an additional signal was hidden"
 [[ "$output" == *"| #5 |"* ]] || fail "malformed provenance was dropped instead of retained"
@@ -82,6 +85,7 @@ output=$(GH_AUDIT_LOG_FILE="$LOG_FILE" GH_ANOMALY_STATE_FILE="${TEST_ROOT}/state
 [[ "$output" == *"| #15 |"* ]] || fail "unverified trusted-author NMR removal was hidden"
 [[ "$output" == *"| #16 |"* ]] || fail "trusted-author NMR transition with an additional signal was hidden"
 [[ "$output" == *"| #19 |"* ]] || fail "unavailable capture with an additional destructive signal was hidden"
+[[ "$output" == *"| #21 |"* ]] || fail "unverified full-loop handoff was hidden"
 [[ "$output" == *"The audit log stores lengths, not content."* ]] || fail "recovery guidance overclaimed audit content"
 [[ "$output" != *"private/repo"* ]] || fail "private repository name leaked into the report"
 [[ "$output" != *"inaccessible/repo"* ]] || fail "unverified repository name leaked into the report"
@@ -89,7 +93,7 @@ output=$(GH_AUDIT_LOG_FILE="$LOG_FILE" GH_ANOMALY_STATE_FILE="${TEST_ROOT}/state
 [[ "$output" == *"public/repo"* ]] || fail "verified public repository name was redacted"
 [[ "$output" != *"| #1 |"* && "$output" != *"| #2 |"* && "$output" != *"| #7 |"* && "$output" != *"| #9 |"* &&
 	"$output" != *"| #12 |"* && "$output" != *"| #14 |"* && "$output" != *"| #17 |"* &&
-	"$output" != *"| #18 |"* ]] ||
+	"$output" != *"| #18 |"* && "$output" != *"| #20 |"* && "$output" != *"| #22 |"* ]] ||
 	fail "an exact expected transition remained actionable"
 
 MALFORMED_LOG="${TEST_ROOT}/malformed-audit.log"
@@ -203,6 +207,23 @@ jq -e -s 'map(select(.number == 27))[0].flags == {}' "$PROOF_LOG" >/dev/null ||
 	fail "read-only current actor produced trusted-author audit proof"
 unset CURRENT_ACTOR
 unset GH_AUDIT_LOG_FILE
+
+gh() {
+	local command="$1"
+	local resource="${2:-}"
+	[[ "$command" == "api" && "$resource" == "repos/example/repo/issues/28" ]] || return 1
+	printf '%s\n' '{"state":"open","labels":[{"name":"status:in-review"}]}'
+	return 0
+}
+HANDOFF_LOG="${TEST_ROOT}/handoff-audit.log"
+GH_AUDIT_LOG_FILE="$HANDOFF_LOG" _gh_audit_record_op \
+	"issue_edit" "example/repo" "28" \
+	'{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-progress"]}' \
+	'{"capture_status":"ok","title_len":1,"body_len":1,"labels":["status:in-review"]}' \
+	"/runtime/agents/scripts/full-loop-helper-commit.sh" \
+	"_label_issue_in_review" "1"
+jq -e 'select(.number == 28) | .flags.pr_review_handoff_verified == "v1-current-state"' "$HANDOFF_LOG" >/dev/null ||
+	fail "verified full-loop handoff did not produce audit proof"
 
 gh_issue_view() {
 	printf '%s\n' '{"title":"REST issue snapshot","body":"Protected body","labels":[{"name":"monitoring"}]}'


### PR DESCRIPTION
## Summary

Verified full-loop review transitions are retained in the audit log but excluded from anomaly reports only after provenance and live-state validation.

## Files Changed

.agents/scripts/gh-audit-anomaly-filter.jq, .agents/scripts/gh-audit-anomaly-helper.sh, .agents/scripts/shared-gh-wrappers-safe-edit.sh, .agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-gh-audit-anomaly-expected-transitions.sh; ShellCheck changed shell files

Resolves #29844


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.243 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 13m and 179,650 tokens on this as a headless worker.