### PR TITLE
GH#29845: Fix deployed Buzz anchor symlink handling

### DIFF
--- a/.agents/scripts/_team_interface_buzz_runtime_agents.py
+++ b/.agents/scripts/_team_interface_buzz_runtime_agents.py
@@ -1,0 +1,31 @@
+"""Sanitize deployed agent trees before immutable Buzz runtime anchoring."""
+
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+from functools import partial
+from pathlib import Path
+import shutil
+
+
+GENERATED_PLUGIN_DEPENDENCIES = Path("plugins/opencode-aidevops/node_modules")
+TRANSIENT_AGENT_IGNORE = shutil.ignore_patterns(".DS_Store", "__pycache__", "*.pyc")
+
+
+def pinned_agents_copy_ignore(source_agents, directory, names):
+    """Ignore transient files and the deployed plugin's separately pinned dependencies."""
+    ignored = set(TRANSIENT_AGENT_IGNORE(directory, names))
+    relative_directory = Path(directory).relative_to(source_agents)
+    if relative_directory == GENERATED_PLUGIN_DEPENDENCIES.parent:
+        ignored.add(GENERATED_PLUGIN_DEPENDENCIES.name)
+    return ignored
+
+
+def copy_pinned_agents(source_agents, destination):
+    """Copy one agent tree without its generated external dependency link."""
+    shutil.copytree(
+        source_agents,
+        destination,
+        symlinks=True,
+        ignore=partial(pinned_agents_copy_ignore, source_agents),
+    )

--- a/.agents/scripts/_team_interface_buzz_runtime_anchor.py
+++ b/.agents/scripts/_team_interface_buzz_runtime_anchor.py
@@ -48,6 +48,7 @@ PINNED_NODE_PACKAGES = (
     "zod",
 )
 OPENCODE_PLUGIN_PACKAGES = {"@opencode-ai/plugin", "@opencode-ai/sdk", "zod"}
+PINNED_AGENT_EXCLUDED_PATHS = (Path("plugins/opencode-aidevops/node_modules"),)
 
 
 def git_common_node_modules():
@@ -127,16 +128,31 @@ def pinned_node_package_sources(config_source):
     return sources
 
 
-def hash_pinned_agents(source_agents, node_packages):
+def hash_pinned_agents(source_agents, node_packages, ignored_agent_paths=()):
     """Hash agent files and their closed runtime dependency set."""
     digest = hashlib.sha256()
-    digest.update(hash_runtime_tree(source_agents).encode("ascii"))
+    digest.update(hash_runtime_tree(source_agents, ignored_agent_paths).encode("ascii"))
     for package, source in sorted(node_packages.items()):
         digest.update(b"\0")
         digest.update(package.encode("utf-8"))
         digest.update(b"\0")
         digest.update(hash_runtime_tree(source).encode("ascii"))
     return digest.hexdigest()
+
+
+def pinned_agents_copy_ignore(source_agents):
+    """Return a copytree filter for transient and separately pinned dependency paths."""
+    transient_ignore = shutil.ignore_patterns(".DS_Store", "__pycache__", "*.pyc")
+
+    def ignore(directory, names):
+        ignored = set(transient_ignore(directory, names))
+        relative_directory = Path(directory).relative_to(source_agents)
+        for name in names:
+            if relative_directory / name in PINNED_AGENT_EXCLUDED_PATHS:
+                ignored.add(name)
+        return ignored
+
+    return ignore
 
 
 def opencode_config_source():
@@ -265,7 +281,11 @@ def materialize_pinned_runtime(profile):
     source_agents = AGENTS_DIR.resolve(strict=True)
     source_config = opencode_config_source()
     node_packages = pinned_node_package_sources(source_config)
-    agents_digest = hash_pinned_agents(source_agents, node_packages)
+    agents_digest = hash_pinned_agents(
+        source_agents,
+        node_packages,
+        PINNED_AGENT_EXCLUDED_PATHS,
+    )
     config_digest = hash_opencode_config(source_config)
     parent = require_safe_directory_chain(
         Path.home() / ".aidevops" / "buzz-runtimes" / profile["id"]
@@ -298,7 +318,7 @@ def materialize_pinned_runtime(profile):
             source_agents,
             staging / "agents",
             symlinks=True,
-            ignore=shutil.ignore_patterns(".DS_Store", "__pycache__", "*.pyc"),
+            ignore=pinned_agents_copy_ignore(source_agents),
         )
         for package, source in node_packages.items():
             shutil.copytree(

--- a/.agents/scripts/_team_interface_buzz_runtime_anchor.py
+++ b/.agents/scripts/_team_interface_buzz_runtime_anchor.py
@@ -12,6 +12,7 @@ import stat
 import subprocess
 import tempfile
 
+from _team_interface_buzz_runtime_agents import copy_pinned_agents
 from _team_interface_buzz_runtime_config import (
     config_contains_private_fields,
     expected_command_payloads,
@@ -48,7 +49,6 @@ PINNED_NODE_PACKAGES = (
     "zod",
 )
 OPENCODE_PLUGIN_PACKAGES = {"@opencode-ai/plugin", "@opencode-ai/sdk", "zod"}
-PINNED_AGENT_EXCLUDED_PATHS = (Path("plugins/opencode-aidevops/node_modules"),)
 
 
 def git_common_node_modules():
@@ -128,31 +128,16 @@ def pinned_node_package_sources(config_source):
     return sources
 
 
-def hash_pinned_agents(source_agents, node_packages, ignored_agent_paths=()):
+def hash_pinned_agents(source_agents, node_packages):
     """Hash agent files and their closed runtime dependency set."""
     digest = hashlib.sha256()
-    digest.update(hash_runtime_tree(source_agents, ignored_agent_paths).encode("ascii"))
+    digest.update(hash_runtime_tree(source_agents).encode("ascii"))
     for package, source in sorted(node_packages.items()):
         digest.update(b"\0")
         digest.update(package.encode("utf-8"))
         digest.update(b"\0")
         digest.update(hash_runtime_tree(source).encode("ascii"))
     return digest.hexdigest()
-
-
-def pinned_agents_copy_ignore(source_agents):
-    """Return a copytree filter for transient and separately pinned dependency paths."""
-    transient_ignore = shutil.ignore_patterns(".DS_Store", "__pycache__", "*.pyc")
-
-    def ignore(directory, names):
-        ignored = set(transient_ignore(directory, names))
-        relative_directory = Path(directory).relative_to(source_agents)
-        for name in names:
-            if relative_directory / name in PINNED_AGENT_EXCLUDED_PATHS:
-                ignored.add(name)
-        return ignored
-
-    return ignore
 
 
 def opencode_config_source():
@@ -281,11 +266,6 @@ def materialize_pinned_runtime(profile):
     source_agents = AGENTS_DIR.resolve(strict=True)
     source_config = opencode_config_source()
     node_packages = pinned_node_package_sources(source_config)
-    agents_digest = hash_pinned_agents(
-        source_agents,
-        node_packages,
-        PINNED_AGENT_EXCLUDED_PATHS,
-    )
     config_digest = hash_opencode_config(source_config)
     parent = require_safe_directory_chain(
         Path.home() / ".aidevops" / "buzz-runtimes" / profile["id"]
@@ -293,33 +273,31 @@ def materialize_pinned_runtime(profile):
     parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     require_safe_directory_chain(parent)
     os.chmod(parent, 0o700)
-    root = parent / f"v{PINNED_RUNTIME_SCHEMA_VERSION}-{agents_digest[:16]}-{config_digest[:16]}"
-    pinned_agents = root / "agents"
-    expected_config = pinned_opencode_config(source_config, source_agents, pinned_agents)
-    expected_commands = expected_command_payloads(source_config, source_agents, pinned_agents)
-    expectation = {
-        "commands": expected_commands,
-        "config": expected_config,
-        "marker": {
-            "agents_digest": agents_digest,
-            "config_digest": config_digest,
-            "content_digest": pinned_content_digest(
-                agents_digest, expected_config, expected_commands
-            ),
-            "runtime_id": profile["id"],
-            "schema_version": PINNED_RUNTIME_SCHEMA_VERSION,
-        },
-    }
-    if root.exists() or root.is_symlink():
-        return validate_pinned_runtime(root, profile, expectation)
     staging = Path(tempfile.mkdtemp(prefix=".staging-", dir=parent))
     try:
-        shutil.copytree(
-            source_agents,
-            staging / "agents",
-            symlinks=True,
-            ignore=pinned_agents_copy_ignore(source_agents),
+        copy_pinned_agents(source_agents, staging / "agents")
+        agents_digest = hash_pinned_agents(staging / "agents", node_packages)
+        root = parent / (
+            f"v{PINNED_RUNTIME_SCHEMA_VERSION}-{agents_digest[:16]}-{config_digest[:16]}"
         )
+        pinned_agents = root / "agents"
+        expected_config = pinned_opencode_config(source_config, source_agents, pinned_agents)
+        expected_commands = expected_command_payloads(source_config, source_agents, pinned_agents)
+        expectation = {
+            "commands": expected_commands,
+            "config": expected_config,
+            "marker": {
+                "agents_digest": agents_digest,
+                "config_digest": config_digest,
+                "content_digest": pinned_content_digest(
+                    agents_digest, expected_config, expected_commands
+                ),
+                "runtime_id": profile["id"],
+                "schema_version": PINNED_RUNTIME_SCHEMA_VERSION,
+            },
+        }
+        if root.exists() or root.is_symlink():
+            return validate_pinned_runtime(root, profile, expectation)
         for package, source in node_packages.items():
             shutil.copytree(
                 source,

--- a/.agents/scripts/_team_interface_buzz_runtime_io.py
+++ b/.agents/scripts/_team_interface_buzz_runtime_io.py
@@ -87,12 +87,17 @@ def hash_file_into(digest, path):
             digest.update(chunk)
 
 
-def hash_runtime_tree(root):
-    """Hash one trusted runtime tree without transient Python artifacts."""
+def hash_runtime_tree(root, ignored_relative_paths=()):
+    """Hash one trusted runtime tree without transient or caller-excluded paths."""
     digest = hashlib.sha256()
     canonical_root = root.resolve(strict=True)
+    ignored_paths = {Path(value) for value in ignored_relative_paths}
+    if any(path.is_absolute() or ".." in path.parts for path in ignored_paths):
+        raise RuntimeError("runtime tree exclusions must be safe relative paths")
     for path in sorted(root.rglob("*"), key=lambda item: item.relative_to(root).as_posix()):
         relative = path.relative_to(root)
+        if any(relative == ignored or ignored in relative.parents for ignored in ignored_paths):
+            continue
         if any(part in IGNORED_RUNTIME_NAMES for part in relative.parts) or path.suffix == ".pyc":
             continue
         metadata = path.lstat()

--- a/.agents/scripts/_team_interface_buzz_runtime_io.py
+++ b/.agents/scripts/_team_interface_buzz_runtime_io.py
@@ -87,17 +87,12 @@ def hash_file_into(digest, path):
             digest.update(chunk)
 
 
-def hash_runtime_tree(root, ignored_relative_paths=()):
-    """Hash one trusted runtime tree without transient or caller-excluded paths."""
+def hash_runtime_tree(root):
+    """Hash one trusted runtime tree without transient Python artifacts."""
     digest = hashlib.sha256()
     canonical_root = root.resolve(strict=True)
-    ignored_paths = {Path(value) for value in ignored_relative_paths}
-    if any(path.is_absolute() or ".." in path.parts for path in ignored_paths):
-        raise RuntimeError("runtime tree exclusions must be safe relative paths")
     for path in sorted(root.rglob("*"), key=lambda item: item.relative_to(root).as_posix()):
         relative = path.relative_to(root)
-        if any(relative == ignored or ignored in relative.parents for ignored in ignored_paths):
-            continue
         if any(part in IGNORED_RUNTIME_NAMES for part in relative.parts) or path.suffix == ".pyc":
             continue
         metadata = path.lstat()

--- a/.agents/scripts/tests/test-team-interface-buzz-runtime.mjs
+++ b/.agents/scripts/tests/test-team-interface-buzz-runtime.mjs
@@ -166,6 +166,96 @@ try {
     );
   }
 
+  const deployedPluginDirectory = path.join(
+    deployedAgentsDirectory,
+    "plugins/opencode-aidevops",
+  );
+  const deployedInteractiveCommand = path.join(
+    deployedAgentsDirectory,
+    "bin/aidevops-buzz-acp-interactive",
+  );
+  fs.mkdirSync(deployedPluginDirectory, {recursive: true, mode: 0o700});
+  fs.mkdirSync(path.dirname(deployedInteractiveCommand), {recursive: true, mode: 0o700});
+  fs.writeFileSync(path.join(deployedPluginDirectory, "index.mjs"), "export default {};\n");
+  fs.writeFileSync(deployedInteractiveCommand, "#!/usr/bin/env bash\nexit 0\n", {mode: 0o700});
+  fs.symlinkSync(
+    deployedOpenCodeModules,
+    path.join(deployedPluginDirectory, "node_modules"),
+  );
+  const deployedMaterialization = requireSuccess(spawnSync("python3", [
+    "-c",
+    [
+      "import sys",
+      "from pathlib import Path",
+      `sys.path.insert(0, ${JSON.stringify(path.join(agentsDirectory, "scripts"))})`,
+      "import _team_interface_buzz_runtime_anchor as anchor",
+      "anchor.AGENTS_DIR = Path(sys.argv[1])",
+      "profile = {'command': 'aidevops-buzz-acp-interactive', 'id': 'aidevops-interactive-v1'}",
+      "print(anchor.materialize_pinned_runtime(profile))",
+    ].join("; "),
+    deployedAgentsDirectory,
+  ], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      AIDEVOPS_BUZZ_OPENCODE_NODE_MODULES_DIR: deployedOpenCodeModules,
+      HOME: fixtureHome,
+    },
+  }), "deployed runtime materialization with generated dependency symlink");
+  const deployedRuntimeAnchor = deployedMaterialization.stdout.trim();
+  assert.equal(
+    fs.existsSync(path.join(
+      deployedRuntimeAnchor,
+      "agents/plugins/opencode-aidevops/node_modules",
+    )),
+    false,
+    "generated deployed dependency symlink was copied into the immutable anchor",
+  );
+  requireSuccess(
+    runHelper(["verify-anchor", "--root", deployedRuntimeAnchor, "--runtime", "interactive"], {
+      env: {...process.env, HOME: fixtureHome},
+    }),
+    "deployed runtime standalone anchor verification",
+  );
+  const injectedAnchorDependencyLink = path.join(
+    deployedRuntimeAnchor,
+    "agents/plugins/opencode-aidevops/node_modules",
+  );
+  fs.symlinkSync(deployedOpenCodeModules, injectedAnchorDependencyLink);
+  const injectedAnchorVerification = runHelper([
+    "verify-anchor", "--root", deployedRuntimeAnchor, "--runtime", "interactive",
+  ], {env: {...process.env, HOME: fixtureHome}});
+  assert.notEqual(injectedAnchorVerification.status, 0);
+  assert.match(injectedAnchorVerification.stderr, /absolute symbolic link/);
+  fs.rmSync(injectedAnchorDependencyLink);
+  const unrelatedAbsoluteTarget = path.join(fixtureRoot, "unrelated-absolute-target");
+  const unrelatedAbsoluteLink = path.join(deployedAgentsDirectory, "unrelated-absolute-link");
+  fs.mkdirSync(unrelatedAbsoluteTarget, {mode: 0o700});
+  fs.symlinkSync(unrelatedAbsoluteTarget, unrelatedAbsoluteLink);
+  const unsafeDeployedMaterialization = spawnSync("python3", [
+    "-c",
+    [
+      "import sys",
+      "from pathlib import Path",
+      `sys.path.insert(0, ${JSON.stringify(path.join(agentsDirectory, "scripts"))})`,
+      "import _team_interface_buzz_runtime_anchor as anchor",
+      "anchor.AGENTS_DIR = Path(sys.argv[1])",
+      "profile = {'command': 'aidevops-buzz-acp-interactive', 'id': 'aidevops-interactive-v1'}",
+      "anchor.materialize_pinned_runtime(profile)",
+    ].join("; "),
+    deployedAgentsDirectory,
+  ], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      AIDEVOPS_BUZZ_OPENCODE_NODE_MODULES_DIR: deployedOpenCodeModules,
+      HOME: fixtureHome,
+    },
+  });
+  assert.notEqual(unsafeDeployedMaterialization.status, 0);
+  assert.match(unsafeDeployedMaterialization.stderr, /absolute symbolic link/);
+  fs.rmSync(unrelatedAbsoluteLink);
+
   const sourceManifest = JSON.parse(fs.readFileSync(canonicalManifest, "utf8"));
   assert.deepEqual(Object.keys(sourceManifest).sort(), [
     "args", "command", "env", "id", "installHint", "installInstructionsUrl", "label",


### PR DESCRIPTION
## Summary

- Exclude the generated deployed `plugins/opencode-aidevops/node_modules` link from immutable Buzz agent hashing and copying.
- Continue hashing and copying the independently validated closed Node dependency set.
- Keep anchor validation fail-closed for injected or unrelated absolute symlinks.

## Files changed

- `.agents/scripts/_team_interface_buzz_runtime_anchor.py`
- `.agents/scripts/_team_interface_buzz_runtime_agents.py`
- `.agents/scripts/tests/test-team-interface-buzz-runtime.mjs`

## Verification

- `node .agents/scripts/tests/test-team-interface-buzz-runtime.mjs`
- `python3 -m py_compile .agents/scripts/_team_interface_buzz_runtime_agents.py .agents/scripts/_team_interface_buzz_runtime_anchor.py`
- `.agents/scripts/linters-local.sh --changed`
- `TMPDIR="$HOME/.aidevops/.agent-workspace/tmp" .agents/scripts/qlty-smell-threshold-helper.sh`
- `.agents/hooks/task-id-collision-guard.sh check-pr 29847`

The regression fixture models a deployed bundle with an absolute generated plugin dependency link, verifies successful materialization and standalone anchor validation, confirms the generated link is absent from the anchor, and confirms other absolute links remain rejected.

Resolves #29845
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.243 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1d 17h and 11,756,104 tokens on this with the user in an interactive session.