### PR TITLE
GH#29856: Preserve OpenCode session purpose and restore exact Tabby sessions

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -53,6 +53,7 @@ import {
 } from "./subagent-effort.mjs";
 import { loadModelRouting } from "./model-routing.mjs";
 import { createSessionContinuationGuard } from "./session-continuation-guard.mjs";
+import { createSessionRecoveryMarkerHandler } from "./session-recovery-marker.mjs";
 import { createPermissionBroker } from "./permission-broker.mjs";
 import { createSubagentCancellationReceipt } from "./subagent-cancellation-receipt.mjs";
 import { createRoutingFeedbackHandler } from "./routing-feedback-handler.mjs";
@@ -468,6 +469,11 @@ export async function AidevopsPlugin({ directory, client }) {
     agentsDir: ACTIVE_AGENTS_DIR,
     client,
   });
+  const sessionRecoveryMarkerHandler = createSessionRecoveryMarkerHandler({
+    directory,
+    dataDir: process.env.XDG_DATA_HOME || "",
+    workDir: process.env.AIDEVOPS_WORK_DIR || join(WORKSPACE_DIR, "work"),
+  });
 
   const debugEventError = (label, err) => {
     if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
@@ -541,6 +547,7 @@ export async function AidevopsPlugin({ directory, client }) {
         routingFeedbackHandler(input).catch((err) => debugEventError("routing feedback handler", err)),
         sessionTitleSuffixHandler(input).catch((err) => debugEventError("title suffix handler", err)),
         sessionTitleFallbackHandler(input).catch((err) => debugEventError("title fallback handler", err)),
+        sessionRecoveryMarkerHandler(input).catch((err) => debugEventError("session recovery marker", err)),
         greetingHandler(input).catch((err) => debugEventError("greeting handler", err)),
       ]);
     },

--- a/.agents/plugins/opencode-aidevops/session-recovery-marker.mjs
+++ b/.agents/plugins/opencode-aidevops/session-recovery-marker.mjs
@@ -19,6 +19,7 @@ import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
 
 const SESSION_ID_RE = /^ses_[A-Za-z0-9]{6,128}$/;
 const CONTROL_CHAR_RE = /[\u0000-\u001F\u007F]/;
@@ -250,14 +251,15 @@ export function createSessionRecoveryMarkerHandler({
 }
 
 function parseCliArgs(argv) {
-  const values = { cwd: "", workDir: "" };
-  for (let index = 0; index < argv.length; index += 1) {
-    const option = argv[index];
-    if (option === "--cwd" && argv[index + 1]) values.cwd = argv[++index];
-    else if (option === "--work-dir" && argv[index + 1]) values.workDir = argv[++index];
-    else throw new Error(`Unknown recovery resolver option: ${option}`);
-  }
-  return values;
+  const parsed = parseArgs({
+    args: argv,
+    options: {
+      cwd: { type: "string" },
+      "work-dir": { type: "string" },
+    },
+    strict: true,
+  });
+  return { cwd: parsed.values.cwd || "", workDir: parsed.values["work-dir"] || "" };
 }
 
 function runCli(argv) {

--- a/.agents/plugins/opencode-aidevops/session-recovery-marker.mjs
+++ b/.agents/plugins/opencode-aidevops/session-recovery-marker.mjs
@@ -140,23 +140,22 @@ function querySessionDirectory(databasePath, sessionID) {
   return rows[0];
 }
 
-export function resolveSessionRecoveryMarker({ cwd, workDir }) {
-  assertSafeText(cwd, "recovered working directory");
-  assertSafeText(workDir, "aidevops work directory");
-  if (!isAbsolute(cwd) || !isAbsolute(workDir)) throw new Error("Recovery paths must be absolute");
-
+function canonicalMarkerDirectory(cwd, workDir, uid) {
   const root = recoveryRoot(resolve(workDir));
   if (!existsSync(root)) return null;
+  if (lstatSync(root).isSymbolicLink()) throw new Error("Invalid recovery marker root");
   const canonicalRoot = realpathSync(root);
   const canonicalCwd = realpathSync(cwd);
   if (!pathIsInside(canonicalRoot, canonicalCwd)) return null;
 
-  const uid = process.getuid();
   if (lstatSync(cwd).isSymbolicLink()) throw new Error("Invalid recovery marker location");
   assertPrivateDirectory(canonicalRoot, uid);
   assertPrivateDirectory(canonicalCwd, uid);
   if (dirname(canonicalCwd) !== canonicalRoot) throw new Error("Invalid recovery marker location");
+  return canonicalCwd;
+}
 
+function readRecoveryMarker(canonicalCwd, uid) {
   const markerPath = join(canonicalCwd, MARKER_BASENAME);
   assertPrivateFile(markerPath, uid);
   const marker = JSON.parse(readFileSync(markerPath, "utf8"));
@@ -164,11 +163,10 @@ export function resolveSessionRecoveryMarker({ cwd, workDir }) {
     throw new Error("Invalid recovery marker schema");
   }
   if (basename(canonicalCwd) !== marker.session_id) throw new Error("Recovery marker session mismatch");
+  return marker;
+}
 
-  const directory = assertSafeText(marker.directory, "marker session directory");
-  const dataDir = assertSafeText(marker.data_dir, "marker OpenCode data directory");
-  if (!isAbsolute(directory) || !isAbsolute(dataDir)) throw new Error("Recovery marker paths must be absolute");
-  const canonicalDirectory = realpathSync(directory);
+function canonicalRecoveryDataDir(dataDir, workDir, uid) {
   const dataDirStat = lstatSync(dataDir);
   if (!dataDirStat.isDirectory() || dataDirStat.isSymbolicLink() || dataDirStat.uid !== uid) {
     throw new Error("Unsafe OpenCode recovery data directory");
@@ -183,16 +181,36 @@ export function resolveSessionRecoveryMarker({ cwd, workDir }) {
   if (!pathIsInside(isolatedRoot, canonicalDataDir) || canonicalDataDir === isolatedRoot) {
     throw new Error("Recovery marker data directory is outside isolated storage");
   }
+  return canonicalDataDir;
+}
 
+function validateRecoveryDatabase(canonicalDataDir, sessionID, canonicalDirectory, uid) {
   const databasePath = join(canonicalDataDir, "opencode", "opencode.db");
   const databaseStat = lstatSync(databasePath);
   if (!databaseStat.isFile() || databaseStat.isSymbolicLink() || databaseStat.uid !== uid) {
     throw new Error("Unsafe OpenCode recovery database");
   }
-  const databaseDirectory = querySessionDirectory(databasePath, marker.session_id);
+  const databaseDirectory = querySessionDirectory(databasePath, sessionID);
   if (realpathSync(databaseDirectory) !== canonicalDirectory) {
     throw new Error("Recovery marker directory does not match the OpenCode session");
   }
+}
+
+export function resolveSessionRecoveryMarker({ cwd, workDir }) {
+  assertSafeText(cwd, "recovered working directory");
+  assertSafeText(workDir, "aidevops work directory");
+  if (!isAbsolute(cwd) || !isAbsolute(workDir)) throw new Error("Recovery paths must be absolute");
+
+  const uid = process.getuid();
+  const canonicalCwd = canonicalMarkerDirectory(cwd, workDir, uid);
+  if (!canonicalCwd) return null;
+  const marker = readRecoveryMarker(canonicalCwd, uid);
+  const directory = assertSafeText(marker.directory, "marker session directory");
+  const dataDir = assertSafeText(marker.data_dir, "marker OpenCode data directory");
+  if (!isAbsolute(directory) || !isAbsolute(dataDir)) throw new Error("Recovery marker paths must be absolute");
+  const canonicalDirectory = realpathSync(directory);
+  const canonicalDataDir = canonicalRecoveryDataDir(dataDir, workDir, uid);
+  validateRecoveryDatabase(canonicalDataDir, marker.session_id, canonicalDirectory, uid);
 
   return {
     sessionID: marker.session_id,

--- a/.agents/plugins/opencode-aidevops/session-recovery-marker.mjs
+++ b/.agents/plugins/opencode-aidevops/session-recovery-marker.mjs
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const SESSION_ID_RE = /^ses_[A-Za-z0-9]{6,128}$/;
+const CONTROL_CHAR_RE = /[\u0000-\u001F\u007F]/;
+const MARKER_BASENAME = "recovery.json";
+
+function pathIsInside(parent, candidate) {
+  const child = relative(parent, candidate);
+  return child === "" || (!child.startsWith("..") && !isAbsolute(child));
+}
+
+function assertSafeText(value, label) {
+  if (typeof value !== "string" || !value || CONTROL_CHAR_RE.test(value)) {
+    throw new Error(`Invalid ${label}`);
+  }
+  return value;
+}
+
+function assertPrivateDirectory(path, uid) {
+  const stat = lstatSync(path);
+  if (!stat.isDirectory() || stat.isSymbolicLink() || stat.uid !== uid || (stat.mode & 0o077) !== 0) {
+    throw new Error("Unsafe recovery marker directory");
+  }
+}
+
+function assertPrivateFile(path, uid) {
+  const stat = lstatSync(path);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.uid !== uid || (stat.mode & 0o077) !== 0) {
+    throw new Error("Unsafe recovery marker file");
+  }
+}
+
+function ensurePrivateDirectory(path) {
+  if (existsSync(path)) {
+    const stat = lstatSync(path);
+    if (!stat.isDirectory() || stat.isSymbolicLink() || stat.uid !== process.getuid()) {
+      throw new Error("Unsafe recovery marker directory");
+    }
+  } else {
+    mkdirSync(path, { recursive: true, mode: 0o700 });
+  }
+  chmodSync(path, 0o700);
+  assertPrivateDirectory(path, process.getuid());
+}
+
+export function recoveryRoot(workDir) {
+  return join(workDir, "opencode-tabby-recovery");
+}
+
+export function currentDirectorySequence(directory) {
+  const safeDirectory = assertSafeText(directory, "terminal recovery directory");
+  return `\u001B]1337;CurrentDir=${safeDirectory}\u0007`;
+}
+
+export function writeCurrentDirectory(directory) {
+  const sequence = currentDirectorySequence(directory);
+  let ttyFd;
+  try {
+    ttyFd = openSync("/dev/tty", "w");
+    writeSync(ttyFd, sequence);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (ttyFd !== undefined) {
+      try {
+        closeSync(ttyFd);
+      } catch {
+        // Tabby recovery synchronization is best-effort while OpenCode is live.
+      }
+    }
+  }
+}
+
+export function writeSessionRecoveryMarker({ sessionID, directory, dataDir, workDir }) {
+  if (!SESSION_ID_RE.test(sessionID)) throw new Error("Invalid OpenCode session ID");
+  assertSafeText(directory, "session directory");
+  assertSafeText(dataDir, "OpenCode data directory");
+  assertSafeText(workDir, "aidevops work directory");
+  if (!isAbsolute(directory) || !isAbsolute(dataDir) || !isAbsolute(workDir)) {
+    throw new Error("Recovery marker paths must be absolute");
+  }
+
+  const canonicalDirectory = realpathSync(directory);
+  const canonicalDataDir = realpathSync(dataDir);
+  const root = recoveryRoot(resolve(workDir));
+  const markerDirectory = join(root, sessionID);
+  ensurePrivateDirectory(root);
+  ensurePrivateDirectory(markerDirectory);
+
+  const markerPath = join(markerDirectory, MARKER_BASENAME);
+  const temporaryPath = join(markerDirectory, `.recovery.${process.pid}.${Date.now()}.tmp`);
+  const payload = `${JSON.stringify({
+    schema_version: 1,
+    session_id: sessionID,
+    directory: canonicalDirectory,
+    data_dir: canonicalDataDir,
+  })}\n`;
+
+  try {
+    writeFileSync(temporaryPath, payload, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    renameSync(temporaryPath, markerPath);
+    chmodSync(markerPath, 0o600);
+  } finally {
+    rmSync(temporaryPath, { force: true });
+  }
+  assertPrivateFile(markerPath, process.getuid());
+  return markerDirectory;
+}
+
+function querySessionDirectory(databasePath, sessionID) {
+  const sql = `SELECT directory FROM session WHERE id='${sessionID}' AND parent_id IS NULL LIMIT 2;`;
+  const result = spawnSync("sqlite3", ["-readonly", databasePath, sql], {
+    encoding: "utf8",
+    timeout: 5000,
+  });
+  if (result.error || result.status !== 0) throw new Error("Could not validate OpenCode recovery database");
+  const rows = result.stdout.trimEnd().split("\n").filter(Boolean);
+  if (rows.length !== 1) throw new Error("OpenCode recovery session was not found");
+  return rows[0];
+}
+
+export function resolveSessionRecoveryMarker({ cwd, workDir }) {
+  assertSafeText(cwd, "recovered working directory");
+  assertSafeText(workDir, "aidevops work directory");
+  if (!isAbsolute(cwd) || !isAbsolute(workDir)) throw new Error("Recovery paths must be absolute");
+
+  const root = recoveryRoot(resolve(workDir));
+  if (!existsSync(root)) return null;
+  const canonicalRoot = realpathSync(root);
+  const canonicalCwd = realpathSync(cwd);
+  if (!pathIsInside(canonicalRoot, canonicalCwd)) return null;
+
+  const uid = process.getuid();
+  if (lstatSync(cwd).isSymbolicLink()) throw new Error("Invalid recovery marker location");
+  assertPrivateDirectory(canonicalRoot, uid);
+  assertPrivateDirectory(canonicalCwd, uid);
+  if (dirname(canonicalCwd) !== canonicalRoot) throw new Error("Invalid recovery marker location");
+
+  const markerPath = join(canonicalCwd, MARKER_BASENAME);
+  assertPrivateFile(markerPath, uid);
+  const marker = JSON.parse(readFileSync(markerPath, "utf8"));
+  if (marker.schema_version !== 1 || !SESSION_ID_RE.test(marker.session_id)) {
+    throw new Error("Invalid recovery marker schema");
+  }
+  if (basename(canonicalCwd) !== marker.session_id) throw new Error("Recovery marker session mismatch");
+
+  const directory = assertSafeText(marker.directory, "marker session directory");
+  const dataDir = assertSafeText(marker.data_dir, "marker OpenCode data directory");
+  if (!isAbsolute(directory) || !isAbsolute(dataDir)) throw new Error("Recovery marker paths must be absolute");
+  const canonicalDirectory = realpathSync(directory);
+  const dataDirStat = lstatSync(dataDir);
+  if (!dataDirStat.isDirectory() || dataDirStat.isSymbolicLink() || dataDirStat.uid !== uid) {
+    throw new Error("Unsafe OpenCode recovery data directory");
+  }
+  const canonicalDataDir = realpathSync(dataDir);
+  const isolatedRootPath = join(resolve(workDir), "opencode-interactive");
+  const isolatedRootStat = lstatSync(isolatedRootPath);
+  if (!isolatedRootStat.isDirectory() || isolatedRootStat.isSymbolicLink() || isolatedRootStat.uid !== uid) {
+    throw new Error("Unsafe OpenCode isolated storage root");
+  }
+  const isolatedRoot = realpathSync(isolatedRootPath);
+  if (!pathIsInside(isolatedRoot, canonicalDataDir) || canonicalDataDir === isolatedRoot) {
+    throw new Error("Recovery marker data directory is outside isolated storage");
+  }
+
+  const databasePath = join(canonicalDataDir, "opencode", "opencode.db");
+  const databaseStat = lstatSync(databasePath);
+  if (!databaseStat.isFile() || databaseStat.isSymbolicLink() || databaseStat.uid !== uid) {
+    throw new Error("Unsafe OpenCode recovery database");
+  }
+  const databaseDirectory = querySessionDirectory(databasePath, marker.session_id);
+  if (realpathSync(databaseDirectory) !== canonicalDirectory) {
+    throw new Error("Recovery marker directory does not match the OpenCode session");
+  }
+
+  return {
+    sessionID: marker.session_id,
+    directory: canonicalDirectory,
+    dataDir: canonicalDataDir,
+    markerDirectory: canonicalCwd,
+  };
+}
+
+function eventSessionInfo(event) {
+  return event?.properties?.info || event?.properties?.session || null;
+}
+
+function eventSessionID(event, info) {
+  return String(info?.id || info?.sessionID || event?.properties?.sessionID || "");
+}
+
+export function createSessionRecoveryMarkerHandler({
+  directory,
+  dataDir,
+  workDir,
+  isEnabled = () => process.env.AIDEVOPS_TABBY_SESSION_RECOVERY === "1",
+  writeMarker = writeSessionRecoveryMarker,
+  writeDirectory = writeCurrentDirectory,
+}) {
+  const emitted = new Set();
+  return async ({ event } = {}) => {
+    if (!isEnabled() || !event || !["session.created", "session.updated"].includes(event.type)) return;
+    const info = eventSessionInfo(event);
+    if (info?.parentID) return;
+    const sessionID = eventSessionID(event, info);
+    if (!SESSION_ID_RE.test(sessionID) || emitted.has(sessionID)) return;
+    const markerDirectory = writeMarker({ sessionID, directory, dataDir, workDir });
+    writeDirectory(markerDirectory);
+    emitted.add(sessionID);
+  };
+}
+
+function parseCliArgs(argv) {
+  const values = { cwd: "", workDir: "" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const option = argv[index];
+    if (option === "--cwd" && argv[index + 1]) values.cwd = argv[++index];
+    else if (option === "--work-dir" && argv[index + 1]) values.workDir = argv[++index];
+    else throw new Error(`Unknown recovery resolver option: ${option}`);
+  }
+  return values;
+}
+
+function runCli(argv) {
+  const [command, ...options] = argv;
+  if (command !== "resolve") throw new Error("Expected recovery resolver command");
+  const parsed = parseCliArgs(options);
+  const workDir = parsed.workDir || join(homedir(), ".aidevops", ".agent-workspace", "work");
+  const result = resolveSessionRecoveryMarker({ cwd: parsed.cwd, workDir });
+  if (!result) return 2;
+  process.stdout.write(`${result.directory}\t${result.dataDir}\t${result.sessionID}\n`);
+  return 0;
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  try {
+    process.exitCode = runCli(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`Session recovery marker rejected: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/.agents/reference/session.md
+++ b/.agents/reference/session.md
@@ -44,7 +44,7 @@ Context compaction is a handoff to another model, not a reduced transcript. Its 
 ## Git Workflow Detail
 
 - Before edits: run the pre-edit check from `AGENTS.md`.
-- After branch creation: check `TODO.md` for matching tasks, record `started:`, and set a long, descriptive session title. With issue/PR context, use `Issue #123: <complete issue title> — <action context>` or `PR #456: <complete PR title> — <action context>`; never use a bare number or impose an arbitrary character limit. Otherwise use a full task summary, then read `workflows/git-workflow.md`. Use `session-rename_sync_branch` only when no meaningful task context exists.
+- After branch creation: check `TODO.md` for matching tasks and record `started:`. Keep the first meaningful session title as its stable overall purpose; do not replace it with a branch, implementation phase, review, release, or other transient state. If no meaningful title exists, issue/PR work uses `Issue #123: <complete issue title>` or `PR #456: <complete PR title>` and other work uses the full task summary. Append evolving detail only as `— Current: <context>` and replace the stable purpose only after an explicit user redirect. Use `session-rename_sync_branch` only when no meaningful task context exists.
 - Canonical checkout with unexpected state: keep implementation in a linked worktree; never stash/reset/clean it directly. Explicit mirror synchronization uses the verified preserve-clean-sync route in `reference/dirty-worktree-preservation.md`.
 
 Worktrees are preferred for parallel work:

--- a/.agents/reference/tabby-profiles.md
+++ b/.agents/reference/tabby-profiles.md
@@ -37,9 +37,23 @@ command: /bin/zsh
 args:
   - '-l'
   - '-c'
-  - 'opencode; exec zsh'
+  - 'exec aidevops opencode --tabby-shell'
 env: {}
 ```
+
+`--tabby-shell` enables exact crash restoration for managed profiles. The
+OpenCode plugin creates a private marker for the root session and reports that
+marker as Tabby's current directory with `OSC 1337`. When Tabby restores the
+tab, the launcher validates marker ownership and permissions, isolated-storage
+containment, the session ID, original directory, and the matching SQLite row
+before running `opencode --session <id>`. Invalid markers fail closed. A normal
+OpenCode exit returns to a login zsh in the original project directory.
+
+Recovery markers live under
+`~/.aidevops/.agent-workspace/work/opencode-tabby-recovery/`. They contain only
+the OpenCode session ID and local directory references, use owner-only
+permissions, and are inert unless Tabby starts the launcher from that exact
+marker directory.
 
 For manual one-off profiles that should run OpenCode and then leave a shell open,
 use the same non-interactive login command instead of mixing `-i` and `-c`:
@@ -49,5 +63,5 @@ command: /bin/zsh
 args:
   - '-l'
   - '-c'
-  - 'opencode; exec zsh'
+  - 'exec aidevops opencode --tabby-shell'
 ```

--- a/.agents/scripts/opencode-launcher-helper.sh
+++ b/.agents/scripts/opencode-launcher-helper.sh
@@ -47,6 +47,7 @@ Options:
   --shared-db          Use OpenCode's normal shared data directory
   --dir PATH           Working directory for OpenCode (default: current dir)
   --session-id ID      Explicit isolated DB name (default: stable per-project shard)
+  --tabby-shell        Restore Tabby's exact saved session, then leave zsh open
   --dry-run            Print the environment/command without executing
   -h, --help           Show this help
 
@@ -208,6 +209,87 @@ validate_launch_directory() {
         return 1
     fi
     return 0
+}
+
+resolve_tabby_recovery() {
+    local recovered_cwd="$1"
+    local work_dir="$2"
+    local resolver="${SCRIPT_DIR}/../plugins/opencode-aidevops/session-recovery-marker.mjs"
+    local resolution=""
+    local resolver_status=0
+
+    require_node_cli || return 1
+    if resolution=$(node "${resolver}" resolve --cwd "${recovered_cwd}" --work-dir "${work_dir}"); then
+        IFS=$'\t' read -r TABBY_RECOVERY_LAUNCH_DIR TABBY_RECOVERY_DATA_DIR TABBY_RECOVERY_SESSION_ID <<<"${resolution}"
+        if [[ -z "${TABBY_RECOVERY_LAUNCH_DIR}" || -z "${TABBY_RECOVERY_DATA_DIR}" || -z "${TABBY_RECOVERY_SESSION_ID}" ]]; then
+            print_error "Tabby session recovery returned incomplete data"
+            return 1
+        fi
+        return 0
+    else
+        resolver_status=$?
+    fi
+    ((resolver_status == 2)) && return 2
+    print_error "Tabby session recovery marker validation failed"
+    return 1
+}
+
+emit_tabby_current_directory() {
+    local directory="$1"
+
+    [[ "${directory}" != *$'\n'* && "${directory}" != *$'\r'* ]] || return 1
+    printf '\033]1337;CurrentDir=%s\007' "${directory}" >/dev/tty 2>/dev/null || true
+    return 0
+}
+
+opencode_args_contain_session() {
+    local argument=""
+
+    for argument in "$@"; do
+        case "${argument}" in
+        --session | --session=*) return 0 ;;
+        esac
+    done
+    return 1
+}
+
+run_isolated_tui() {
+    local launch_dir="$1"
+    local data_dir="$2"
+    local tabby_shell="$3"
+    local dry_run="$4"
+    shift 4
+    local -a opencode_args=("$@")
+
+    if ((dry_run == 1)); then
+        printf 'cd %q && TMPDIR=%q TMP=%q TEMP=%q XDG_DATA_HOME=%q AIDEVOPS_OPENCODE_ISOLATED_DB=1' "${launch_dir}" "${TMPDIR}" "${TMP}" "${TEMP}" "${data_dir}"
+        ((tabby_shell == 1)) && printf ' AIDEVOPS_TABBY_SESSION_RECOVERY=1'
+        printf ' opencode'
+        printf ' %q' "${opencode_args[@]}"
+        ((tabby_shell == 1)) && printf '; cd %q && exec /bin/zsh -l' "${launch_dir}"
+        printf '\n'
+        return 0
+    fi
+
+    mkdir -p "${data_dir}/opencode" || return 1
+    # Keep stdout/stderr clean before exec: OpenCode's TUI is sensitive to any
+    # pre-launch terminal output and can leave visible redraw artifacts.
+    copy_auth_json "${data_dir}" || true
+    prewarm_opencode_data_dir "${data_dir}"
+
+    cd "${launch_dir}" || return 1
+    export XDG_DATA_HOME="${data_dir}"
+    export AIDEVOPS_OPENCODE_ISOLATED_DB=1
+    if ((tabby_shell == 1)); then
+        export AIDEVOPS_TABBY_SESSION_RECOVERY=1
+        opencode "${opencode_args[@]}" || true
+        cd "${launch_dir}" || return 1
+        emit_tabby_current_directory "${launch_dir}" || true
+        exec /bin/zsh -l
+        return 1
+    fi
+    exec opencode "${opencode_args[@]}"
+    return 1
 }
 
 require_opencode_cli() {
@@ -1153,9 +1235,13 @@ cmd_attach() {
 
 cmd_tui_launch() {
     local use_shared_db=0
+    local tabby_shell=0
     local dry_run=0
     local launch_dir="$PWD"
+    local invocation_dir="$PWD"
     local session_id=""
+    local data_dir=""
+    local recovery_status=0
     local -a opencode_args=()
 
     while (($# > 0)); do
@@ -1173,6 +1259,10 @@ cmd_tui_launch() {
             [[ $# -ge 2 ]] || { print_error "${ERR_SESSION_ID_REQUIRES_VALUE}"; return 1; }
             session_id="$2"
             shift 2
+            ;;
+        --tabby-shell)
+            tabby_shell=1
+            shift
             ;;
         --dry-run)
             dry_run=1
@@ -1196,6 +1286,27 @@ cmd_tui_launch() {
 
     validate_launch_directory "${launch_dir}" || return 1
     require_opencode_cli || return 1
+    if ((tabby_shell == 1 && use_shared_db == 1)); then
+        print_error "--tabby-shell requires aidevops isolated OpenCode storage"
+        return 1
+    fi
+    if ((tabby_shell == 1)); then
+        if resolve_tabby_recovery \
+            "${invocation_dir}" \
+            "${AIDEVOPS_WORK_DIR:-${HOME}/.aidevops/.agent-workspace/work}"; then
+            if opencode_args_contain_session "${opencode_args[@]}"; then
+                print_error "Tabby recovery rejects an additional OpenCode --session argument"
+                return 1
+            fi
+            launch_dir="${TABBY_RECOVERY_LAUNCH_DIR}"
+            data_dir="${TABBY_RECOVERY_DATA_DIR}"
+            opencode_args=(--session "${TABBY_RECOVERY_SESSION_ID}" "${opencode_args[@]}")
+        else
+            recovery_status=$?
+            ((recovery_status == 2)) || return 1
+        fi
+    fi
+    validate_launch_directory "${launch_dir}" || return 1
     if [[ -z "${session_id}" ]]; then
         session_id=$(build_project_session_id "${launch_dir}")
     fi
@@ -1216,27 +1327,12 @@ cmd_tui_launch() {
         return 1
     fi
 
-    local data_dir
-    data_dir=$(build_session_data_dir "${session_id}")
-
-    if ((dry_run == 1)); then
-        printf 'cd %q && TMPDIR=%q TMP=%q TEMP=%q XDG_DATA_HOME=%q AIDEVOPS_OPENCODE_ISOLATED_DB=1 opencode' "${launch_dir}" "${TMPDIR}" "${TMP}" "${TEMP}" "${data_dir}"
-        printf ' %q' "${opencode_args[@]}"
-        printf '\n'
-        return 0
+    if [[ -z "${data_dir}" ]]; then
+        data_dir=$(build_session_data_dir "${session_id}")
     fi
 
-    mkdir -p "${data_dir}/opencode" || return 1
-    # Keep stdout/stderr clean before exec: OpenCode's TUI is sensitive to any
-    # pre-launch terminal output and can leave visible redraw artifacts.
-    copy_auth_json "${data_dir}" || true
-    prewarm_opencode_data_dir "${data_dir}"
-
-    cd "${launch_dir}" || return 1
-    export XDG_DATA_HOME="${data_dir}"
-    export AIDEVOPS_OPENCODE_ISOLATED_DB=1
-    exec opencode "${opencode_args[@]}"
-    return 1
+    run_isolated_tui "${launch_dir}" "${data_dir}" "${tabby_shell}" "${dry_run}" "${opencode_args[@]}"
+    return $?
 }
 
 run_conversation_session() {

--- a/.agents/scripts/opencode-launcher-helper.sh
+++ b/.agents/scripts/opencode-launcher-helper.sh
@@ -238,7 +238,7 @@ emit_tabby_current_directory() {
     local directory="$1"
 
     [[ "${directory}" != *$'\n'* && "${directory}" != *$'\r'* ]] || return 1
-    printf '\033]1337;CurrentDir=%s\007' "${directory}" >/dev/tty 2>/dev/null || true
+    printf '\033]1337;CurrentDir=%s\007' "${directory}" >/dev/tty || return 1
     return 0
 }
 
@@ -282,9 +282,13 @@ run_isolated_tui() {
     export AIDEVOPS_OPENCODE_ISOLATED_DB=1
     if ((tabby_shell == 1)); then
         export AIDEVOPS_TABBY_SESSION_RECOVERY=1
-        opencode "${opencode_args[@]}" || true
+        if ! opencode "${opencode_args[@]}"; then
+            : # Preserve the existing profile behavior: leave a shell open after any TUI exit.
+        fi
         cd "${launch_dir}" || return 1
-        emit_tabby_current_directory "${launch_dir}" || true
+        if ! emit_tabby_current_directory "${launch_dir}"; then
+            : # Shell startup will report the real project directory to Tabby.
+        fi
         exec /bin/zsh -l
         return 1
     fi

--- a/.agents/scripts/tabby_profile_utils.py
+++ b/.agents/scripts/tabby_profile_utils.py
@@ -77,14 +77,12 @@ def _is_command_field_opencode(value: str) -> bool:
     """Return True for the Tabby command-field shape that Tabby cannot exec."""
     value = value.strip()
     normalised = _normalise_yaml_scalar(value)
-    return (
-        value == TABBY_COMMAND_FIELD_OPENCODE
-        or value == PRE_RECOVERY_TABBY_COMMAND_FIELD_OPENCODE
-        or value == LEGACY_TABBY_COMMAND_FIELD_OPENCODE
-        or normalised == TABBY_COMMAND_FIELD_OPENCODE
-        or normalised == PRE_RECOVERY_TABBY_COMMAND_FIELD_OPENCODE
-        or normalised == LEGACY_TABBY_COMMAND_FIELD_OPENCODE
+    opencode_commands = (
+        TABBY_COMMAND_FIELD_OPENCODE,
+        PRE_RECOVERY_TABBY_COMMAND_FIELD_OPENCODE,
+        LEGACY_TABBY_COMMAND_FIELD_OPENCODE,
     )
+    return value in opencode_commands or normalised in opencode_commands
 
 
 def _is_legacy_direct_opencode_args(args: list[str]) -> bool:

--- a/.agents/scripts/tabby_profile_utils.py
+++ b/.agents/scripts/tabby_profile_utils.py
@@ -8,8 +8,12 @@ from __future__ import annotations
 import re
 
 
-TABBY_OPENCODE_LAUNCH = "aidevops opencode; exec zsh"
+TABBY_OPENCODE_LAUNCH = "exec aidevops opencode --tabby-shell"
 TABBY_COMMAND_FIELD_OPENCODE = f"/bin/zsh -l -c '{TABBY_OPENCODE_LAUNCH}'"
+PRE_RECOVERY_TABBY_OPENCODE_LAUNCH = "aidevops opencode; exec zsh"
+PRE_RECOVERY_TABBY_COMMAND_FIELD_OPENCODE = (
+    f"/bin/zsh -l -c '{PRE_RECOVERY_TABBY_OPENCODE_LAUNCH}'"
+)
 LEGACY_TABBY_OPENCODE_LAUNCH = "opencode; exec zsh"
 LEGACY_TABBY_COMMAND_FIELD_OPENCODE = "/bin/zsh -l -c 'opencode; exec zsh'"
 
@@ -75,15 +79,20 @@ def _is_command_field_opencode(value: str) -> bool:
     normalised = _normalise_yaml_scalar(value)
     return (
         value == TABBY_COMMAND_FIELD_OPENCODE
+        or value == PRE_RECOVERY_TABBY_COMMAND_FIELD_OPENCODE
         or value == LEGACY_TABBY_COMMAND_FIELD_OPENCODE
         or normalised == TABBY_COMMAND_FIELD_OPENCODE
+        or normalised == PRE_RECOVERY_TABBY_COMMAND_FIELD_OPENCODE
         or normalised == LEGACY_TABBY_COMMAND_FIELD_OPENCODE
     )
 
 
 def _is_legacy_direct_opencode_args(args: list[str]) -> bool:
     """Return True for direct OpenCode args that still use the shared DB."""
-    return args == ["-l", "-c", LEGACY_TABBY_OPENCODE_LAUNCH]
+    return args in (
+        ["-l", "-c", PRE_RECOVERY_TABBY_OPENCODE_LAUNCH],
+        ["-l", "-c", LEGACY_TABBY_OPENCODE_LAUNCH],
+    )
 
 
 def _direct_opencode_args_block(args_indent: str, include_env: bool) -> list[str]:

--- a/.agents/scripts/tests/test-opencode-launcher-helper.sh
+++ b/.agents/scripts/tests/test-opencode-launcher-helper.sh
@@ -245,6 +245,53 @@ else
     _fail "TUI dry-run mutated state or output an unexpected command: ${output}"
 fi
 
+tabby_output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
+    "${HELPER}" --tabby-shell --dir "${launch_dir}" --session-id tabby-first-launch --dry-run 2>&1)
+if [[ "${tabby_output}" == *"AIDEVOPS_TABBY_SESSION_RECOVERY=1 opencode"* ]] \
+    && [[ "${tabby_output}" == *"exec /bin/zsh -l"* ]] \
+    && [[ "${tabby_output}" != *"--session ses_"* ]]; then
+    _pass "Tabby first launch enables recovery and leaves a shell open"
+else
+    _fail "Tabby first-launch command unexpected: ${tabby_output}"
+fi
+
+tabby_session_id="ses_0123456789TabbyRestore"
+tabby_data_dir="${work_dir}/opencode-interactive/tabby-restore"
+tabby_marker_dir="${work_dir}/opencode-tabby-recovery/${tabby_session_id}"
+mkdir -p "${tabby_data_dir}/opencode" "${tabby_marker_dir}"
+chmod 700 "${work_dir}/opencode-tabby-recovery" "${tabby_marker_dir}"
+sqlite3 "${tabby_data_dir}/opencode/opencode.db" \
+    "CREATE TABLE session (id text PRIMARY KEY, parent_id text, directory text NOT NULL); INSERT INTO session VALUES ('${tabby_session_id}', NULL, '${launch_dir}');"
+python3 - "${tabby_marker_dir}/recovery.json" "${tabby_session_id}" "${launch_dir}" "${tabby_data_dir}" <<'PY'
+import json
+import os
+import sys
+
+marker_path, session_id, directory, data_dir = sys.argv[1:]
+with open(marker_path, "w") as handle:
+    json.dump(
+        {
+            "schema_version": 1,
+            "session_id": session_id,
+            "directory": directory,
+            "data_dir": data_dir,
+        },
+        handle,
+    )
+os.chmod(marker_path, 0o600)
+PY
+tabby_output=$(cd "${tabby_marker_dir}" && \
+    PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
+    "${HELPER}" --tabby-shell --dry-run 2>&1)
+if [[ "${tabby_output}" == *"cd ${launch_dir}"* ]] \
+    && [[ "${tabby_output}" == *"XDG_DATA_HOME=${tabby_data_dir}"* ]] \
+    && [[ "${tabby_output}" == *"opencode --session ${tabby_session_id}"* ]] \
+    && [[ "${tabby_output}" == *"exec /bin/zsh -l"* ]]; then
+    _pass "Tabby recovery resumes the exact validated OpenCode session"
+else
+    _fail "Tabby recovered command unexpected: ${tabby_output}"
+fi
+
 output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
     "${HELPER}" --shared-db --dir "${launch_dir}" -- --version 2>&1)
 if [[ "${output}" == *"AIDEVOPS_OPENCODE_ISOLATED_DB="* ]] \

--- a/.agents/scripts/tests/test-session-recovery-marker.mjs
+++ b/.agents/scripts/tests/test-session-recovery-marker.mjs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import {
+  createSessionRecoveryMarkerHandler,
+  currentDirectorySequence,
+  resolveSessionRecoveryMarker,
+  writeSessionRecoveryMarker,
+} from "../../plugins/opencode-aidevops/session-recovery-marker.mjs";
+
+const root = mkdtempSync(join(tmpdir(), "aidevops-session-recovery-"));
+const workDir = join(root, "work");
+const directory = join(root, "repo");
+const dataDir = join(workDir, "opencode-interactive", "project-repo-test");
+const databaseDir = join(dataDir, "opencode");
+const databasePath = join(databaseDir, "opencode.db");
+const sessionID = "ses_0123456789AbCdEf";
+mkdirSync(directory, { recursive: true });
+mkdirSync(databaseDir, { recursive: true });
+
+const sql = [
+  "CREATE TABLE session (id text PRIMARY KEY, parent_id text, directory text NOT NULL);",
+  `INSERT INTO session (id, parent_id, directory) VALUES ('${sessionID}', NULL, '${directory}');`,
+].join(" ");
+const sqlite = spawnSync("sqlite3", [databasePath, sql], { encoding: "utf8" });
+assert.equal(sqlite.status, 0, sqlite.stderr);
+
+assert.equal(
+  currentDirectorySequence("/safe path"),
+  "\u001B]1337;CurrentDir=/safe path\u0007",
+  "Tabby CurrentDir sequence should carry the exact marker path",
+);
+assert.throws(() => currentDirectorySequence("/unsafe\npath"), /Invalid terminal recovery directory/);
+
+const markerDirectory = writeSessionRecoveryMarker({ sessionID, directory, dataDir, workDir });
+assert.deepEqual(resolveSessionRecoveryMarker({ cwd: markerDirectory, workDir }), {
+  sessionID,
+  directory: realpathSync(directory),
+  dataDir: realpathSync(dataDir),
+  markerDirectory: realpathSync(markerDirectory),
+});
+assert.equal(resolveSessionRecoveryMarker({ cwd: directory, workDir }), null);
+
+const emitted = [];
+const handler = createSessionRecoveryMarkerHandler({
+  directory,
+  dataDir,
+  workDir,
+  isEnabled: () => true,
+  writeMarker: (marker) => {
+    emitted.push(marker);
+    return markerDirectory;
+  },
+  writeDirectory: (path) => emitted.push(path),
+});
+await handler({ event: { type: "session.created", properties: { info: { id: sessionID } } } });
+await handler({ event: { type: "session.updated", properties: { info: { id: sessionID } } } });
+await handler({
+  event: {
+    type: "session.created",
+    properties: { info: { id: "ses_AnotherSession123", parentID: sessionID } },
+  },
+});
+assert.equal(emitted.length, 2, "root session marker should be emitted exactly once");
+assert.equal(emitted[0].sessionID, sessionID);
+assert.equal(emitted[1], markerDirectory);
+
+chmodSync(join(markerDirectory, "recovery.json"), 0o644);
+assert.throws(
+  () => resolveSessionRecoveryMarker({ cwd: markerDirectory, workDir }),
+  /Unsafe recovery marker file/,
+);
+chmodSync(join(markerDirectory, "recovery.json"), 0o600);
+
+const linkedMarker = join(workDir, "opencode-tabby-recovery", "ses_LinkedMarker123");
+symlinkSync(markerDirectory, linkedMarker);
+assert.throws(
+  () => resolveSessionRecoveryMarker({ cwd: linkedMarker, workDir }),
+  /Invalid recovery marker location|session mismatch/,
+);
+
+writeFileSync(
+  join(markerDirectory, "recovery.json"),
+  `${JSON.stringify({
+    schema_version: 1,
+    session_id: sessionID,
+    directory: join(root, "other-repo"),
+    data_dir: dataDir,
+  })}\n`,
+  { mode: 0o600 },
+);
+assert.throws(
+  () => resolveSessionRecoveryMarker({ cwd: markerDirectory, workDir }),
+  /ENOENT|does not match/,
+);
+
+console.log("All session recovery marker tests passed");

--- a/.agents/scripts/tests/test-session-recovery-marker.mjs
+++ b/.agents/scripts/tests/test-session-recovery-marker.mjs
@@ -85,6 +85,14 @@ assert.throws(
   /Invalid recovery marker location|session mismatch/,
 );
 
+const linkedWorkDir = join(root, "linked-work");
+mkdirSync(linkedWorkDir);
+symlinkSync(join(workDir, "opencode-tabby-recovery"), join(linkedWorkDir, "opencode-tabby-recovery"));
+assert.throws(
+  () => resolveSessionRecoveryMarker({ cwd: markerDirectory, workDir: linkedWorkDir }),
+  /Invalid recovery marker root/,
+);
+
 writeFileSync(
   join(markerDirectory, "recovery.json"),
   `${JSON.stringify({

--- a/.agents/scripts/tests/test-session-rename-ts.mjs
+++ b/.agents/scripts/tests/test-session-rename-ts.mjs
@@ -20,7 +20,7 @@ import { join } from "node:path";
 // dependencies so it loads cleanly under `bun run` without the OpenCode
 // plugin runtime. session-rename.ts re-exports these symbols for callers
 // that already import from it.
-const { isDefaultBranchTitle, isTitleOverwritable } = await import(
+const { isDefaultBranchTitle, isTitleOverwritable, purposePreservingTitle } = await import(
   "../../../.opencode/lib/session-rename-guards.ts"
 );
 const { getDbPath } = await import("../../../.opencode/lib/opencode-db-path.ts");
@@ -164,8 +164,39 @@ assertEq(
 );
 assertEq("terminal title emit defaults to enabled", true, isTerminalTitleEnabled({}));
 
+// --- stable session purpose -------------------------------------------------
+console.log("\nGroup 4: stable session purpose");
+assertEq(
+  "default title accepts the requested purpose",
+  "Investigate crash restoration",
+  purposePreservingTitle("New Session", "Investigate crash restoration"),
+);
+assertEq(
+  "later phase preserves the original purpose",
+  "Investigate crash restoration — Current: implement the Tabby marker",
+  purposePreservingTitle("Investigate crash restoration · AIDevOps 3.32.243", "implement the Tabby marker"),
+);
+assertEq(
+  "later phase replaces only the prior Current context",
+  "Investigate crash restoration — Current: release for testing",
+  purposePreservingTitle(
+    "Investigate crash restoration — Current: implement the Tabby marker · AIDevOps 3.32.243",
+    "release for testing",
+  ),
+);
+assertEq(
+  "a requested title already containing the purpose is not duplicated",
+  "Investigate crash restoration — verification",
+  purposePreservingTitle("Investigate crash restoration", "Investigate crash restoration — verification"),
+);
+assertEq(
+  "explicit repurpose replaces the stable purpose",
+  "Review an unrelated deployment",
+  purposePreservingTitle("Investigate crash restoration", "Review an unrelated deployment", true),
+);
+
 // --- AIDevOps session title suffix helpers ----------------------------------
-console.log("\nGroup 4: AIDevOps session title suffix helpers");
+console.log("\nGroup 5: AIDevOps session title suffix helpers");
 assertEq(
   "suffix is appended",
   "Issue #123: concise title · AIDevOps 9.8.7",
@@ -223,7 +254,7 @@ try {
 }
 
 // --- OpenCode DB path helpers ------------------------------------------------
-console.log("\nGroup 5: OpenCode DB path helpers");
+console.log("\nGroup 6: OpenCode DB path helpers");
 assertEq(
   "XDG_DATA_HOME selects isolated OpenCode DB",
   "/tmp/aidevops-opencode/opencode/opencode.db",

--- a/.agents/scripts/tests/test-tabby-profile-sync.sh
+++ b/.agents/scripts/tests/test-tabby-profile-sync.sh
@@ -79,7 +79,7 @@ assert count == 1, count
 assert \"- '-i'\" not in repaired, repaired
 assert 'TABBY_AUTORUN: opencode' not in repaired, repaired
 assert \"- '-l'\" in repaired and \"- '-c'\" in repaired, repaired
-assert 'aidevops opencode; exec zsh' in repaired, repaired
+assert 'exec aidevops opencode --tabby-shell' in repaired, repaired
 assert 'env: {}' in repaired, repaired
 "
 
@@ -90,7 +90,7 @@ repaired, count = mod.repair_broken_opencode_launch_profiles(config)
 assert count == 1, count
 assert \"args: ['-l', '-i', '-c', opencode]\" not in repaired, repaired
 assert 'TABBY_AUTORUN: opencode' not in repaired, repaired
-assert 'aidevops opencode; exec zsh' in repaired, repaired
+assert 'exec aidevops opencode --tabby-shell' in repaired, repaired
 "
 
 _info "Test 3: generated profiles use aidevops OpenCode launcher"
@@ -100,7 +100,7 @@ profile = mod.build_profile_yaml('aidevops', '/tmp/aidevops', '#123456', scheme,
 assert \"- '-i'\" not in profile, profile
 assert 'TABBY_AUTORUN: opencode' not in profile, profile
 assert \"- '-l'\" in profile and \"- '-c'\" in profile, profile
-assert \"- 'aidevops opencode; exec zsh'\" in profile, profile
+assert \"- 'exec aidevops opencode --tabby-shell'\" in profile, profile
 assert 'env: {}' in profile, profile
 "
 
@@ -121,7 +121,7 @@ repaired, count = mod.repair_broken_opencode_launch_profiles(config)
 assert count == 1, count
 assert \"- '-i'\" not in repaired, repaired
 assert 'TABBY_AUTORUN: opencode' not in repaired, repaired
-assert 'aidevops opencode; exec zsh' in repaired, repaired
+assert 'exec aidevops opencode --tabby-shell' in repaired, repaired
 assert 'env: {}' in repaired, repaired
 "
 
@@ -140,7 +140,7 @@ assert count == 1, count
 assert 'command: /bin/zsh -l -c \'opencode; exec zsh\'' not in repaired, repaired
 assert 'args: []' not in repaired, repaired
 assert \"- '-l'\" in repaired and \"- '-c'\" in repaired, repaired
-assert 'aidevops opencode; exec zsh' in repaired, repaired
+assert 'exec aidevops opencode --tabby-shell' in repaired, repaired
 assert repaired.count('      env: {}') == 1, repaired
 "
 
@@ -178,7 +178,7 @@ repaired, count = mod.repair_broken_opencode_launch_profiles(config)
 assert count == 1, count
 assert repaired.count('      env: {}') == 1, repaired
 assert 'TABBY_AUTORUN: opencode' not in repaired, repaired
-assert 'aidevops opencode; exec zsh' in repaired, repaired
+assert 'exec aidevops opencode --tabby-shell' in repaired, repaired
 "
 
 _info "Test 8: comments do not hide broken command-field profiles or env blocks"
@@ -196,7 +196,7 @@ repaired, count = mod.repair_broken_opencode_launch_profiles(config)
 assert count == 1, count
 assert 'command: /bin/zsh -l -c' not in repaired, repaired
 assert repaired.count('      env: {}') == 1, repaired
-assert \"- 'aidevops opencode; exec zsh'\" in repaired, repaired
+assert \"- 'exec aidevops opencode --tabby-shell'\" in repaired, repaired
 "
 
 _info "Test 9: custom non-OpenCode webserver profiles remain byte-for-byte unchanged"
@@ -256,7 +256,7 @@ with open(tabby_config, "w") as handle:
 """)
 PY
 sync_output=$(PYTHONPATH="${REPO_ROOT}/.agents/scripts" python3 "${HELPER}" --repos-json "${repos_json}" --tabby-config "${tabby_config}")
-if [[ "${sync_output}" == *"Repaired 1 existing Tabby profile(s)."* ]] && grep -q -- "aidevops opencode; exec zsh" "${tabby_config}" && ! grep -q -- "TABBY_AUTORUN: opencode" "${tabby_config}"; then
+if [[ "${sync_output}" == *"Repaired 1 existing Tabby profile(s)."* ]] && grep -q -- "exec aidevops opencode --tabby-shell" "${tabby_config}" && ! grep -q -- "TABBY_AUTORUN: opencode" "${tabby_config}"; then
 	_pass "sync repairs existing broken profile"
 else
 	_fail "sync did not repair existing profile: ${sync_output}"

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -89,7 +89,7 @@ User-facing instructions must say "create a safe linked worktree for ...". Treat
 
 Non-git artifacts (`.venv/`, `node_modules/`, `dist/`, `.env`) don't transfer between worktrees — recreate in each. See `workflows/worktree.md`.
 
-**Session-Worktree Tracking**: After creating a worktree for issue/PR work, give the session a long, descriptive title with the work item first (`Issue #123: <complete issue title> — <action context>` or `PR #456: <complete PR title> — <action context>`) so Tabby tabs and OpenCode search group by number while remaining distinguishable. Never use a bare issue/PR number or impose an arbitrary character limit. Use `session-rename_sync_branch` only when there is no issue/PR context or meaningful task title.
+**Session-Worktree Tracking**: Keep the first meaningful session title as the stable overall purpose. When no meaningful title exists, issue/PR work starts with `Issue #123: <complete issue title>` or `PR #456: <complete PR title>` so Tabby tabs and OpenCode search group by number while remaining distinguishable. Never replace that purpose with a branch, implementation phase, review, release, or other transient state; append evolving detail only as `— Current: <context>`, and replace the purpose only after an explicit user redirect. Never use a bare issue/PR number or impose an arbitrary character limit. Use `session-rename_sync_branch` only when there is no issue/PR context or meaningful task title.
 
 **Scope Monitoring**: When work evolves significantly from the worktree ref/purpose, offer to create a safe linked worktree for the new scope, continue on current, or pause and preserve changes.
 

--- a/.opencode/command/rename.md
+++ b/.opencode/command/rename.md
@@ -7,10 +7,15 @@ description: Rename this session
 
 Rename this session to: $ARGUMENTS
 
-Use the session-rename tool to update the session title.
+Use the session-rename tool to update the session title. Preserve the first
+meaningful title as the stable overall purpose. Later phases should update only
+the trailing current context and must not replace that purpose.
+
+Set `replace_purpose: true` only when the user explicitly asks to repurpose the
+whole session, including this `/rename` command.
 
 For issue/PR work, keep the work item at the beginning and include the issue/PR title or a recognizable title-based summary: `Issue #123: Fix dispatch title prefix` or `PR #456: Refresh auth workflow tests`.
 
-For generic follow-up work, preserve the source title and add the action at the end when useful: `PR #456: Refresh auth workflow tests — review thread`, not just `PR #456: review-thread response`.
+For generic follow-up work, preserve the source title and add the action at the end when useful: `PR #456: Refresh auth workflow tests — Current: review thread`, not just `PR #456: review-thread response`.
 
 Do not impose an arbitrary length limit; prefer a title that is meaningfully distinguishable in the UI. Keep the automatically appended `· AIDevOps x.y.z` suffix.

--- a/.opencode/lib/session-rename-guards.ts
+++ b/.opencode/lib/session-rename-guards.ts
@@ -13,6 +13,9 @@
 
 import type { Database } from "bun:sqlite"
 
+const AIDEVOPS_TITLE_SUFFIX_RE = /\s+· AIDevOps \d+\.\d+\.\d+$/
+const CURRENT_CONTEXT_SEPARATOR = " — Current: "
+
 /**
  * Check whether a branch name is a default (non-feature) branch.
  *
@@ -70,4 +73,27 @@ export function isTitleOverwritable(db: Database, sessionID: string): boolean {
     default:
       return false
   }
+}
+
+/**
+ * Preserve the first meaningful session purpose while allowing the current
+ * phase to evolve. Explicit replacement is reserved for a user-directed
+ * repurpose of the whole session.
+ */
+export function purposePreservingTitle(
+  currentTitle: string,
+  requestedTitle: string,
+  replacePurpose = false,
+): string {
+  const currentBase = currentTitle.replace(AIDEVOPS_TITLE_SUFFIX_RE, "").trim()
+  const requestedBase = requestedTitle.replace(AIDEVOPS_TITLE_SUFFIX_RE, "").trim()
+
+  if (!currentBase || isDefaultBranchTitle(currentBase) || currentBase === "New Session") {
+    return requestedBase
+  }
+  if (replacePurpose) return requestedBase
+
+  const purpose = currentBase.split(CURRENT_CONTEXT_SEPARATOR, 1)[0].trim()
+  if (!purpose || requestedBase.includes(purpose)) return requestedBase
+  return `${purpose}${CURRENT_CONTEXT_SEPARATOR}${requestedBase}`
 }

--- a/.opencode/tool/session-rename.ts
+++ b/.opencode/tool/session-rename.ts
@@ -1,7 +1,11 @@
 import { Database } from "bun:sqlite"
 import { tool } from "@opencode-ai/plugin"
 import { getDbPath } from "../lib/opencode-db-path"
-import { isDefaultBranchTitle, isTitleOverwritable } from "../lib/session-rename-guards"
+import {
+  isDefaultBranchTitle,
+  isTitleOverwritable,
+  purposePreservingTitle,
+} from "../lib/session-rename-guards"
 import { withAidevopsTitleSuffix } from "../lib/session-title-suffix"
 import { emitTerminalTitle } from "../lib/terminal-title"
 
@@ -12,13 +16,21 @@ import { emitTerminalTitle } from "../lib/terminal-title"
  * Drizzle ORM call that writes to the local SQLite DB. The TUI reads from the
  * same DB and picks up changes immediately (verified empirically).
  */
-function renameSession(sessionID: string, title: string): { success: boolean; message: string } {
+function renameSession(
+  sessionID: string,
+  title: string,
+  replacePurpose = false,
+): { success: boolean; message: string } {
   const dbPath = getDbPath()
-  const displayTitle = withAidevopsTitleSuffix(title)
 
   try {
     const db = new Database(dbPath)
     try {
+      const current = db
+        .query("SELECT COALESCE(title, '') AS title FROM session WHERE id = ?")
+        .get(sessionID) as { title: string } | null
+      const preservedTitle = purposePreservingTitle(current?.title || "", title, replacePurpose)
+      const displayTitle = withAidevopsTitleSuffix(preservedTitle)
       const nowMs = Date.now()
       const result = db.run(
         "UPDATE session SET title = ?, time_updated = ? WHERE id = ?",
@@ -96,20 +108,21 @@ function syncSessionWithBranch(
 
 export default tool({
   description:
-    "Rename the current session to a long, descriptive title. For issue/PR work, start with the issue or PR marker and include the complete issue/PR title plus useful action context (for example, 'Issue #123: Fix dispatch title prefix — implementation and release' or 'PR #456: Refresh auth workflow tests — review thread'). Never use only an issue/PR number and do not impose an arbitrary character limit; OpenCode can display long titles. The AIDevOps version suffix is appended automatically and should remain present.",
+    "Set or extend the current session title without losing its original overall purpose. The first meaningful purpose remains the stable prefix; later phases become a trailing '— Current: ...' context. Do not rename for branches, implementation phases, reviews, releases, or other transient state when the existing title already identifies the session. Set replace_purpose only when the user explicitly repurposes the whole session. For issue/PR work, keep the complete issue/PR identity at the beginning. Long titles are supported and the AIDevOps version suffix is automatic.",
   args: {
     title: tool.schema
       .string()
-      .describe("Long, descriptive session title (for issue/PR work, use 'Issue #123: <complete issue title> — <action context>' or 'PR #456: <complete PR title> — <action context>'; never use a bare issue/PR number or an arbitrary character limit; otherwise summarize the task fully; keep the automatically appended AIDevOps version suffix)"),
+      .describe("Long title or current-context description; the tool preserves the existing stable purpose unless replace_purpose is explicitly authorised"),
+    replace_purpose: tool.schema
+      .boolean()
+      .optional()
+      .describe("Replace the stable original purpose only when the user explicitly redirects or repurposes the whole session"),
   },
   async execute(args, context) {
     const { sessionID } = context
-    const { title } = args
+    const { title, replace_purpose: replacePurpose = false } = args
 
-    // Explicit rename is a manual override — no guards. Matches the
-    // session-rename-helper.sh contract where `rename` is unguarded but
-    // `sync-branch` enforces the meaningful-title invariants (t2039/t2252).
-    const result = renameSession(sessionID, title)
+    const result = renameSession(sessionID, title, replacePurpose)
 
     if (result.success) {
       emitTerminalTitle(result.message)

--- a/tests/test-tabby-profile-sync.py
+++ b/tests/test-tabby-profile-sync.py
@@ -316,7 +316,7 @@ class TestGetProfileTargets(unittest.TestCase):
         profile = profiles[0][1]
         self.assertIn("  - name: Buzz", profile)
         self.assertIn(f"      cwd: {buzz_path}", profile)
-        self.assertIn("        - 'aidevops opencode; exec zsh'", profile)
+        self.assertIn("        - 'exec aidevops opencode --tabby-shell'", profile)
 
     def test_registered_buzz_path_is_not_duplicated(self):
         buzz_path = self.root / ".buzz"
@@ -350,8 +350,8 @@ class TestRepairBrokenOpenCodeLaunchProfiles(unittest.TestCase):
             group_id="group-1",
         )
 
-        self.assertIn("        - 'aidevops opencode; exec zsh'", profile)
-        self.assertNotIn("        - aidevops opencode; exec zsh", profile)
+        self.assertIn("        - 'exec aidevops opencode --tabby-shell'", profile)
+        self.assertNotIn("        - exec aidevops opencode --tabby-shell", profile)
         self.assertIn("    disableDynamicTitle: false", profile)
 
     def test_existing_opencode_profile_enables_dynamic_title(self):
@@ -370,6 +370,7 @@ class TestRepairBrokenOpenCodeLaunchProfiles(unittest.TestCase):
         )
 
         self.assertEqual(repairs, 1)
+        self.assertIn("        - 'exec aidevops opencode --tabby-shell'", repaired)
         self.assertIn("    disableDynamicTitle: false", repaired)
         self.assertNotIn("    disableDynamicTitle: true", repaired)
 
@@ -413,7 +414,7 @@ class TestRepairBrokenOpenCodeLaunchProfiles(unittest.TestCase):
 
         self.assertEqual(repairs, 1)
         self.assertIn("      command: /bin/zsh", repaired)
-        self.assertIn("        - 'aidevops opencode; exec zsh'", repaired)
+        self.assertIn("        - 'exec aidevops opencode --tabby-shell'", repaired)
 
     def test_inline_args_blank_line_before_env_does_not_duplicate_env(self):
         repaired, repairs = tabby_profile_sync.repair_broken_opencode_launch_profiles(
@@ -429,7 +430,7 @@ class TestRepairBrokenOpenCodeLaunchProfiles(unittest.TestCase):
 
         self.assertEqual(repairs, 1)
         self.assertEqual(repaired.count("      env:"), 1)
-        self.assertIn("        - 'aidevops opencode; exec zsh'", repaired)
+        self.assertIn("        - 'exec aidevops opencode --tabby-shell'", repaired)
 
     def test_block_args_comment_before_env_does_not_duplicate_env(self):
         repaired, repairs = tabby_profile_sync.repair_broken_opencode_launch_profiles(


### PR DESCRIPTION
## Summary

- preserve each OpenCode session's original purpose while allowing later work to append current context
- restore the exact isolated OpenCode session after a Tabby crash and return to the original repository shell
- validate private recovery markers, filesystem ownership, path containment, and the matching top-level SQLite session before resuming

## Testing

- `bun .agents/scripts/tests/test-session-rename-ts.mjs`
- `bun .agents/scripts/tests/test-session-recovery-marker.mjs`
- `.agents/scripts/tests/test-opencode-launcher-helper.sh`
- `.agents/scripts/tests/test-tabby-profile-sync.sh`
- `python3 -m unittest tests.test-tabby-profile-sync`
- `.agents/scripts/linters-local.sh --full --strict`
- `.agents/scripts/linters-local.sh` after rebasing onto `origin/main`

## Runtime testing

- Risk: medium
- Evidence: runtime-verified through real temporary SQLite databases, filesystem permission/symlink fixtures, OSC marker output, and isolated launcher-shell fixtures
- Manual post-deployment validation remains part of the authorised release loop

## Review evidence

- Bundle SHA-256: `3d837eef109553bafd1b87b4aaf422df8e3856a9685e181b6af675435dfdd489`
- Prompt-injection scan: clean
- Head: `255d8e8497c7843a3713c8e748df84018e04a87a`

Resolves #29856

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.243 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 52m and 724,131 tokens on this with the user in an interactive session.
