### PR TITLE
GH#29860: Normalize OpenCode Task child session metadata

### DIFF
--- a/.agents/plugins/opencode-aidevops/subagent-cancellation-receipt.mjs
+++ b/.agents/plugins/opencode-aidevops/subagent-cancellation-receipt.mjs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 
 import { SubagentCancellationLedger, shortSessionHash } from "./subagent-cancellation-ledger.mjs";
-import { SubagentLifecycleTracker } from "./subagent-lifecycle-tracker.mjs";
+import { SubagentLifecycleTracker, scalarSessionID } from "./subagent-lifecycle-tracker.mjs";
 import { classifySideEffect, safeToolName } from "./subagent-side-effect-classifier.mjs";
 
 export { classifySideEffect };
@@ -123,7 +123,7 @@ class SubagentCancellationReceipt {
     try {
       recorded = Boolean(this.recordReceipt?.(receipt, {
         childSessionID: childID,
-        parentSessionID: String(input?.sessionID || ""),
+        parentSessionID: scalarSessionID(input?.sessionID),
       }));
     } catch (error) {
       this.ledger.safeLog(

--- a/.agents/plugins/opencode-aidevops/subagent-effort-escalation.mjs
+++ b/.agents/plugins/opencode-aidevops/subagent-effort-escalation.mjs
@@ -250,6 +250,12 @@ class InteractiveSubagentEscalator {
   async afterTool(input, output) {
     if (!this.enabled() || !TASK_TOOLS.has(safeToolName(input?.tool))) return null;
     const identity = this.lifecycle.takeChildIdentity(input, output);
+    if (!identity.childID) {
+      output.metadata = {
+        ...output.metadata,
+        aidevopsRoutingIdentity: { reason: identity.reason },
+      };
+    }
     try {
       return await this.escalateTask(output, identity.childID);
     } finally {

--- a/.agents/plugins/opencode-aidevops/subagent-lifecycle-tracker.mjs
+++ b/.agents/plugins/opencode-aidevops/subagent-lifecycle-tracker.mjs
@@ -6,6 +6,19 @@ const TERMINAL_SESSION_STATES = new Set([
   "aborted", "cancelled", "canceled", "completed", "deleted", "end_turn", "error", "idle", "stop",
 ]);
 
+/** Return a non-empty scalar session ID without coercing aggregate metadata. */
+export function scalarSessionID(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function metadataChildSessionID(metadata) {
+  const values = [metadata?.sessionId, metadata?.sessionID, metadata?.session_id]
+    .filter((value) => value !== undefined && value !== null && value !== "");
+  if (values.some((value) => typeof value !== "string")) return "";
+  const ids = [...new Set(values.map(scalarSessionID).filter(Boolean))];
+  return ids.length === 1 ? ids[0] : "";
+}
+
 function capMap(map, maximum = MAX_SESSION_STATES) {
   while (map.size > maximum) map.delete(map.keys().next().value);
 }
@@ -17,7 +30,7 @@ export function eventSessionID(event) {
     event?.properties?.info?.id,
     event?.properties?.part?.sessionID,
   ];
-  return String(candidates.find(Boolean) || "");
+  return candidates.map(scalarSessionID).find(Boolean) || "";
 }
 
 export class SubagentLifecycleTracker {
@@ -29,23 +42,25 @@ export class SubagentLifecycleTracker {
   }
 
   beforeTask(callID, parentID) {
-    this.taskCalls.set(callID, { parentID, startSequence: ++this.sequence });
+    this.taskCalls.set(callID, { parentID: scalarSessionID(parentID), startSequence: ++this.sequence });
     capMap(this.taskCalls, MAX_SESSION_STATES * 2);
   }
 
   rememberSession(info) {
-    if (!info?.id) return;
-    const previous = this.sessions.get(info.id) || {};
-    this.sessions.set(info.id, {
+    const sessionID = scalarSessionID(info?.id);
+    if (!sessionID) return;
+    const previous = this.sessions.get(sessionID) || {};
+    this.sessions.set(sessionID, {
       ...previous,
       observed: true,
-      parentID: info.parentID || previous.parentID || "",
+      parentID: scalarSessionID(info?.parentID) || previous.parentID || "",
       sequence: previous.sequence || ++this.sequence,
     });
     capMap(this.sessions);
   }
 
   rememberStatus(sessionID, status) {
+    sessionID = scalarSessionID(sessionID);
     if (!sessionID) return;
     const previous = this.sessions.get(sessionID) || { observed: false, parentID: "", sequence: ++this.sequence };
     this.sessions.set(sessionID, { ...previous, status: String(status || "").toLowerCase() });
@@ -83,8 +98,8 @@ export class SubagentLifecycleTracker {
     const taskCall = this.taskCalls.get(callID);
     this.taskCalls.delete(callID);
     const metadata = output?.metadata || {};
-    const explicit = String(metadata.sessionId || metadata.sessionID || metadata.session_id || "");
-    const parentID = String(input?.sessionID || taskCall?.parentID || "");
+    const explicit = metadataChildSessionID(metadata);
+    const parentID = scalarSessionID(input?.sessionID) || taskCall?.parentID || "";
     let identity = { childID: "", reason: "child_identity_missing" };
     if (explicit) {
       const known = this.sessions.get(explicit);

--- a/.agents/plugins/opencode-aidevops/tests/test-subagent-cancellation-receipt.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-subagent-cancellation-receipt.mjs
@@ -180,6 +180,45 @@ test("missing lifecycle events and telemetry produce an explicit incomplete unkn
   assert.equal(receipt.ledger[0].status, "unknown");
 });
 
+test("aggregate cancellation Task metadata remains intact and reports missing child identity", async () => {
+  let abortCalls = 0;
+  let persistedParentID = "not-recorded";
+  const lifecycle = createSubagentCancellationReceipt({
+    session: {
+      abort: async () => {
+        abortCalls += 1;
+        return { data: true };
+      },
+    },
+  }, {
+    maxWaitMs: 0,
+    recordReceipt: (_receipt, context) => {
+      persistedParentID = context.parentSessionID;
+      return true;
+    },
+  });
+  lifecycle.beforeTool(
+    { tool: "task", sessionID: "parent-aggregate", callID: "aggregate-cancel" },
+    { args: {} },
+  );
+  const output = {
+    output: "Task aborted",
+    metadata: { sessionID: ["child-aggregate"], status: "aborted", hostValue: { preserved: true } },
+  };
+
+  const receipt = await lifecycle.afterTool(
+    { tool: "task", sessionID: "parent-aggregate", callID: "aggregate-cancel" },
+    output,
+  );
+
+  assert.equal(abortCalls, 0);
+  assert.equal(receipt.termination, "unconfirmed");
+  assert.ok(receipt.incomplete_reasons.includes("child_identity_missing"));
+  assert.equal(persistedParentID, "parent-aggregate");
+  assert.deepEqual(output.metadata.sessionID, ["child-aggregate"]);
+  assert.deepEqual(output.metadata.hostValue, { preserved: true });
+});
+
 test("abort and receipt persistence failures are logged for diagnostics", async () => {
   const logs = [];
   const lifecycle = createSubagentCancellationReceipt({

--- a/.agents/plugins/opencode-aidevops/tests/test-subagent-effort.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-subagent-effort.mjs
@@ -12,12 +12,83 @@ import {
   resolveTierReasoning,
 } from "../subagent-effort.mjs";
 import { capabilityEscalationEvidence } from "../subagent-effort-escalation.mjs";
+import { SubagentLifecycleTracker, eventSessionID } from "../subagent-lifecycle-tracker.mjs";
 
 const TIER_REASONING = {
   simple: { openai: "low" },
   standard: { openai: "max" },
   thinking: { openai: "xhigh" },
 };
+
+test("aggregate Task session metadata falls back without coercing child identity", () => {
+  const lifecycle = new SubagentLifecycleTracker();
+  lifecycle.beforeTask("aggregate-call", "parent");
+  lifecycle.handleEvent({
+    type: "session.created",
+    properties: { info: { id: "child", parentID: "parent" } },
+  });
+
+  const identity = lifecycle.takeChildIdentity(
+    { callID: "aggregate-call", sessionID: "parent" },
+    { metadata: { sessionID: { aggregate: "child" } } },
+  );
+
+  assert.deepEqual(identity, {
+    callID: "aggregate-call",
+    childID: "child",
+    reason: "lifecycle",
+  });
+  assert.equal(eventSessionID({ properties: { sessionID: ["child"] } }), "");
+});
+
+test("only one matching scalar Task child identity is accepted", () => {
+  const lifecycle = new SubagentLifecycleTracker();
+  lifecycle.beforeTask("scalar-call", "parent");
+  assert.deepEqual(
+    lifecycle.takeChildIdentity(
+      { callID: "scalar-call", sessionID: "parent" },
+      { metadata: { sessionId: "child", sessionID: "child", session_id: "child" } },
+    ),
+    { callID: "scalar-call", childID: "child", reason: "metadata" },
+  );
+
+  lifecycle.beforeTask("mismatch-call", "parent");
+  lifecycle.handleEvent({
+    type: "session.created",
+    properties: { info: { id: "other-parent-child", parentID: "other-parent" } },
+  });
+  assert.deepEqual(
+    lifecycle.takeChildIdentity(
+      { callID: "mismatch-call", sessionID: "parent" },
+      { metadata: { sessionId: "other-parent-child" } },
+    ),
+    { callID: "mismatch-call", childID: "", reason: "child_parent_mismatch" },
+  );
+});
+
+test("aggregate Task metadata preserves host fields and records routing evidence", async () => {
+  const hooks = createSubagentEffortHooks({ session: { prompt: async () => ({}) } }, {
+    modelRouting: { tiers: {} },
+    isHeadless: () => false,
+  });
+  hooks.beforeTool(
+    { tool: "task", callID: "aggregate-evidence", sessionID: "parent" },
+    { args: {} },
+  );
+  const output = {
+    output: "Task result",
+    metadata: { session_id: [], hostValue: { preserved: true } },
+  };
+
+  await hooks.afterTool(
+    { tool: "task", callID: "aggregate-evidence", sessionID: "parent" },
+    output,
+  );
+
+  assert.deepEqual(output.metadata.session_id, []);
+  assert.deepEqual(output.metadata.hostValue, { preserved: true });
+  assert.deepEqual(output.metadata.aidevopsRoutingIdentity, { reason: "child_identity_missing" });
+});
 
 test("only provider-neutral workload tiers are recognized", () => {
   assert.equal(normalizeEffortTier("simple"), "simple");


### PR DESCRIPTION
## Summary

- reject aggregate Task session metadata rather than coercing it into a child ID
- fall back to lifecycle correlation or explicit missing-identity receipts
- cover scalar, aggregate, parent-mismatch, escalation, and cancellation paths

## Verification

- `node --test .agents/plugins/opencode-aidevops/tests/test-subagent-effort.mjs .agents/plugins/opencode-aidevops/tests/test-subagent-cancellation-receipt.mjs`
- `.agents/scripts/linters-local.sh --changed`

Resolves #29860

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.245 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra
