### PR TITLE
GH#29861: Prevent empty OpenCode argument in Tabby dry-runs

### DIFF
--- a/.agents/scripts/opencode-launcher-helper.sh
+++ b/.agents/scripts/opencode-launcher-helper.sh
@@ -265,7 +265,7 @@ run_isolated_tui() {
         printf 'cd %q && TMPDIR=%q TMP=%q TEMP=%q XDG_DATA_HOME=%q AIDEVOPS_OPENCODE_ISOLATED_DB=1' "${launch_dir}" "${TMPDIR}" "${TMP}" "${TEMP}" "${data_dir}"
         ((tabby_shell == 1)) && printf ' AIDEVOPS_TABBY_SESSION_RECOVERY=1'
         printf ' opencode'
-        printf ' %q' "${opencode_args[@]}"
+        ((${#opencode_args[@]} == 0)) || printf ' %q' "${opencode_args[@]}"
         ((tabby_shell == 1)) && printf '; cd %q && exec /bin/zsh -l' "${launch_dir}"
         printf '\n'
         return 0
@@ -1322,7 +1322,7 @@ cmd_tui_launch() {
     if ((use_shared_db == 1)); then
         if ((dry_run == 1)); then
             printf 'cd %q && TMPDIR=%q TMP=%q TEMP=%q opencode' "${launch_dir}" "${TMPDIR}" "${TMP}" "${TEMP}"
-            printf ' %q' "${opencode_args[@]}"
+            ((${#opencode_args[@]} == 0)) || printf ' %q' "${opencode_args[@]}"
             printf '\n'
             return 0
         fi

--- a/.agents/scripts/tests/test-opencode-launcher-helper.sh
+++ b/.agents/scripts/tests/test-opencode-launcher-helper.sh
@@ -249,6 +249,7 @@ tabby_output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${
     "${HELPER}" --tabby-shell --dir "${launch_dir}" --session-id tabby-first-launch --dry-run 2>&1)
 if [[ "${tabby_output}" == *"AIDEVOPS_TABBY_SESSION_RECOVERY=1 opencode"* ]] \
     && [[ "${tabby_output}" == *"exec /bin/zsh -l"* ]] \
+    && [[ "${tabby_output}" != *"opencode ''"* ]] \
     && [[ "${tabby_output}" != *"--session ses_"* ]]; then
     _pass "Tabby first launch enables recovery and leaves a shell open"
 else
@@ -290,6 +291,14 @@ if [[ "${tabby_output}" == *"cd ${launch_dir}"* ]] \
     _pass "Tabby recovery resumes the exact validated OpenCode session"
 else
     _fail "Tabby recovered command unexpected: ${tabby_output}"
+fi
+
+output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
+    "${HELPER}" --shared-db --dir "${launch_dir}" --dry-run 2>&1)
+if [[ "${output}" == *"opencode" ]] && [[ "${output}" != *"opencode ''"* ]]; then
+    _pass "shared-db dry-run omits a synthetic empty argument"
+else
+    _fail "shared-db dry-run command unexpected: ${output}"
 fi
 
 output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \


### PR DESCRIPTION
## Summary

- omit `%q` rendering when no OpenCode passthrough arguments exist
- keep both isolated/Tabby and shared-database dry-run commands faithful to the real invocation
- cover first-launch Tabby and shared-database zero-argument dry-runs

## Testing

- `.agents/scripts/tests/test-opencode-launcher-helper.sh` — 24 tests passed
- `.agents/scripts/linters-local.sh`
- branch runtime smoke: `opencode; ...` with no synthetic `''`

## Review evidence

- Bundle SHA-256: `b11eecda9b786a35d3532e0af87d69ca93fea8b78b53217b55a578690f93d462`
- Prompt-injection scan: clean
- Head: `56e83ba0fa4be2e2facb6f7c44aae6fdc1736f56`

Resolves #29861

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.245 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 2h 6m and 1,041,388 tokens on this with the user in an interactive session.
