### PR TITLE
GH#29869: Recover unpublished releases through reviewed aggregation

### DIFF
--- a/.agents/reference/release-aggregation-recovery.md
+++ b/.agents/reference/release-aggregation-recovery.md
@@ -1,0 +1,67 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Unpublished Release Aggregation Recovery
+
+Use this path only when a protected-main release created a signed local tag but
+publication stopped before the tag reached any remote or package channel. It is
+not a remote-tag rewrite mechanism.
+
+## Command
+
+After the complete source set is merged through an exact-tip reviewed aggregation:
+
+```bash
+aidevops release recover-aggregate <original-source-pr> --tag <vX.Y.Z> \
+  --expected-sources <pr[,pr...]>
+```
+
+The original source PR must own the active release lane. Every expected source
+must appear once in the aggregate commit trailers at its verified merge SHA.
+
+## Preconditions
+
+- The existing tag is an annotated, locally verifiable signed tag for the same
+  semantic version and active source operation.
+- The tag is absent from every remote, GitHub Releases, npm, and the Homebrew tap.
+- No terminal release receipt exists.
+- `origin/main` is the reviewed aggregation merge itself, not an arbitrary
+  descendant.
+- The persisted authorization is an exact subset of the reviewed aggregate.
+- The lane is in `remote-publication` or `reconcile-required` for the same source
+  and tag.
+
+Any unavailable channel read is uncertainty, not absence, and blocks recovery.
+
+## Transaction
+
+1. Verify the provisional tag and all channel-absence evidence.
+2. Resolve the exact aggregate and normalize every source to `PR@MERGE_SHA`.
+3. Persist the expanded authorization and rotate the release-lane token into
+   `aggregation-recovery`, fencing the prior process. Both records embed their
+   exact pre-transaction JSON for compare-and-swap restoration.
+4. Create an empty `chore(release): bump version to X.Y.Z` commit whose parent is
+   the exact aggregate. The tree and semantic version do not change.
+5. Replace only the local tag with a newly signed aggregate-bound tag and run the
+   ordinary protected-main publication queue.
+6. Record `.aggregate-recovery.json` evidence and return the lane to
+   `remote-publication` for normal reconciliation.
+
+## Rollback and interruption
+
+Before a durable queue exists, any failure restores the exact original tag
+object, authorization manifest, and release-lane JSON. Recovery uses compare-and-
+swap lane writes, so a concurrent owner change fails closed rather than being
+overwritten.
+
+Once the protected release PR or remote tag is durable, do not restore or mutate
+the provisional state. Resume with `aidevops release reconcile <source-pr>`; the
+normal verifier and channel convergence gates own completion.
+
+Rerunning `recover-aggregate` after an interruption reloads the persisted
+snapshots. If the replacement aggregate-bound tag already exists, the command
+enters normal reconciliation without replacing the tag or creating another bump
+commit. Inconsistent or incomplete recovery state fails closed.
+
+The recovery command never force-pushes, rewrites a remote tag, increments the
+version, or infers publication authority from commit ancestry.

--- a/.agents/reference/release-publication-controls.md
+++ b/.agents/reference/release-publication-controls.md
@@ -13,6 +13,7 @@ maintainer operation approval.
 | Chapter | Use it for |
 |---|---|
 | [Controls and history](release-publication-controls/controls-and-history.md) | Signed-tag provenance, aggregation and supersession recovery, Actions permissions, approved live state, and the audited rollout sequence. |
+| [Unpublished aggregation recovery](release-aggregation-recovery.md) | Transactionally rebinding a local-only provisional tag after a reviewed exact-tip aggregation. |
 
 ## Non-negotiable boundary
 

--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -328,6 +328,33 @@ _full_loop_read_release_authorization() {
 	return $?
 }
 
+_full_loop_read_release_authorization_record() {
+	local repo="$1"
+	local pr_number="$2"
+	local authorization_path=""
+	authorization_path=$(_full_loop_release_authorization_path "$repo" "$pr_number") || return 1
+	[[ -f "$authorization_path" ]] || return 2
+	jq -ce --arg repo "$repo" --argjson pr "$pr_number" '
+		select(.schema_version == 1 and .repository == $repo and .requested_pr == $pr)
+	' "$authorization_path"
+	return $?
+}
+
+_full_loop_write_release_authorization_snapshot() {
+	local repo="$1"
+	local pr_number="$2"
+	local snapshot_json="$3"
+	local authorization_path=""
+	jq -e --arg repo "$repo" --argjson pr "$pr_number" '
+		.schema_version == 1 and .repository == $repo and .requested_pr == $pr
+	' <<<"$snapshot_json" >/dev/null || return 1
+	authorization_path=$(_full_loop_release_authorization_path "$repo" "$pr_number") || return 1
+	mkdir -p "${authorization_path%/*}" || return 1
+	printf '%s\n' "$snapshot_json" >"${authorization_path}.tmp.$$" || return 1
+	mv "${authorization_path}.tmp.$$" "$authorization_path" || return 1
+	return 0
+}
+
 _full_loop_persist_release_authorization() {
 	local repo="$1"
 	local pr_number="$2"
@@ -355,6 +382,79 @@ _full_loop_persist_release_authorization() {
 		>"${authorization_path}.tmp.$$" || return 1
 	mv "${authorization_path}.tmp.$$" "$authorization_path" || return 1
 	return 0
+}
+
+_full_loop_write_release_authorization_record() {
+	local repo="$1"
+	local pr_number="$2"
+	local expected_sources="$3"
+	local previous_record="${4:-null}"
+	local authorization_path=""
+	local expected_json=""
+	expected_json=$(release_authorization_manifest_json "$expected_sources") || return 1
+	if [[ "$previous_record" != "null" ]]; then
+		jq -e --arg repo "$repo" --argjson pr "$pr_number" '
+			.schema_version == 1 and .repository == $repo and .requested_pr == $pr
+		' <<<"$previous_record" >/dev/null || return 1
+	fi
+	authorization_path=$(_full_loop_release_authorization_path "$repo" "$pr_number") || return 1
+	mkdir -p "${authorization_path%/*}" || return 1
+	jq -cn --arg repo "$repo" --argjson requested_pr "$pr_number" --argjson expected "$expected_json" \
+		--argjson previous "$previous_record" --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" '
+		{schema_version:1,repository:$repo,requested_pr:$requested_pr,expected_sources:$expected,recorded_at:$now}
+		+ (if $previous == null then {} else {aggregate_recovery:{previous_authorization:$previous}} end)
+	' >"${authorization_path}.tmp.$$" || return 1
+	mv "${authorization_path}.tmp.$$" "$authorization_path" || return 1
+	return 0
+}
+
+_full_loop_read_release_authorization_recovery_snapshot() {
+	local repo="$1"
+	local pr_number="$2"
+	local record=""
+	record=$(_full_loop_read_release_authorization_record "$repo" "$pr_number") || return 1
+	jq -ce --arg repo "$repo" --argjson pr "$pr_number" '
+		.aggregate_recovery.previous_authorization
+		| select(.schema_version == 1 and .repository == $repo and .requested_pr == $pr)
+	' <<<"$record"
+	return $?
+}
+
+_full_loop_expand_release_authorization_for_aggregate() {
+	local repo="$1"
+	local pr_number="$2"
+	local previous_sources="$3"
+	local expected_sources="$4"
+	local existing=""
+	local previous_record=""
+	previous_sources=$(release_authorization_manifest_string "$previous_sources") || return 1
+	expected_sources=$(release_authorization_manifest_string "$expected_sources") || return 1
+	existing=$(_full_loop_read_release_authorization "$repo" "$pr_number") || return 1
+	[[ "$existing" == "$previous_sources" ]] || return 1
+	release_authorization_subset "$previous_sources" "$expected_sources" || return 1
+	previous_record=$(_full_loop_read_release_authorization_record "$repo" "$pr_number") || return 1
+	_full_loop_write_release_authorization_record "$repo" "$pr_number" "$expected_sources" "$previous_record"
+	return $?
+}
+
+_full_loop_restore_release_authorization_after_aggregate() {
+	local repo="$1"
+	local pr_number="$2"
+	local recovery_sources="$3"
+	local previous_sources="$4"
+	local existing=""
+	local snapshot=""
+	local snapshot_sources=""
+	recovery_sources=$(release_authorization_manifest_string "$recovery_sources") || return 1
+	previous_sources=$(release_authorization_manifest_string "$previous_sources") || return 1
+	existing=$(_full_loop_read_release_authorization "$repo" "$pr_number") || return 1
+	[[ "$existing" == "$recovery_sources" ]] || return 1
+	snapshot=$(_full_loop_read_release_authorization_recovery_snapshot "$repo" "$pr_number") || return 1
+	snapshot_sources=$(jq -r '.expected_sources | sort_by(.pr) | map("\(.pr)@\(.merge)") | join(",")' \
+		<<<"$snapshot") || return 1
+	[[ "$snapshot_sources" == "$previous_sources" ]] || return 1
+	_full_loop_write_release_authorization_snapshot "$repo" "$pr_number" "$snapshot"
+	return $?
 }
 
 _full_loop_write_release_authorization_gap_evidence() {

--- a/.agents/scripts/full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/full-loop-release-aggregate-recovery.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Transactional recovery for a signed release tag that never reached a remote.
+
+[[ -n "${_FULL_LOOP_RELEASE_AGGREGATE_RECOVERY_LOADED:-}" ]] && return 0
+_FULL_LOOP_RELEASE_AGGREGATE_RECOVERY_LOADED=1
+
+_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT=""
+_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED=""
+_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH=""
+_FULL_LOOP_AGGREGATE_RECOVERY_LANE_SNAPSHOT=""
+_FULL_LOOP_AGGREGATE_RECOVERY_TAG_SOURCE_JSON=""
+
+_full_loop_recovery_http_status() {
+	local endpoint="$1"
+	local response=""
+	local status_line=""
+	local status_code=""
+	response=$(gh api --include --silent "$endpoint" 2>/dev/null || true)
+	status_line="${response%%$'\n'*}"
+	status_code=$(printf '%s' "$status_line" | cut -d ' ' -f 2)
+	[[ "$status_code" =~ ^[0-9]{3}$ ]] || return 1
+	printf '%s\n' "$status_code"
+	return 0
+}
+
+_full_loop_recovery_verify_github_release_absent() {
+	local repo="$1"
+	local tag_name="$2"
+	local status_code=""
+	status_code=$(_full_loop_recovery_http_status "repos/${repo}/releases/tags/${tag_name}") || return 1
+	[[ "$status_code" == "404" ]] || {
+		printf 'Aggregate recovery refused: GitHub release state for %s is HTTP %s\n' "$tag_name" "$status_code" >&2
+		return 1
+	}
+	return 0
+}
+
+_full_loop_recovery_verify_npm_absent() {
+	local tag_name="$1"
+	local version="${tag_name#v}"
+	local npm_error=""
+	command -v npm >/dev/null 2>&1 || return 1
+	if npm_error=$(npm view "aidevops@${version}" version --json 2>&1); then
+		printf 'Aggregate recovery refused: npm already contains aidevops@%s\n' "$version" >&2
+		return 1
+	fi
+	[[ "$npm_error" == *"E404"* || "$npm_error" == *'"code":"E404"'* || "$npm_error" == *"404 Not Found"* ]] || return 1
+	npm view aidevops version --json >/dev/null 2>&1 || return 1
+	return 0
+}
+
+_full_loop_recovery_verify_homebrew_absent() {
+	local repo="$1"
+	local tag_name="$2"
+	local owner="${repo%%/*}"
+	local formula=""
+	formula=$(gh api "repos/${owner}/homebrew-tap/contents/Formula/aidevops.rb" \
+		--jq '.content | @base64d' 2>/dev/null) || return 1
+	if [[ "$formula" == *"$tag_name"* ]]; then
+		printf 'Aggregate recovery refused: Homebrew already references %s\n' "$tag_name" >&2
+		return 1
+	fi
+	return 0
+}
+
+_full_loop_recovery_verify_all_remote_tags_absent() {
+	local tag_name="$1"
+	local tag_ref="refs/tags/${tag_name}"
+	local remotes=""
+	local remote=""
+	local remote_rc=0
+	remotes=$(git -C "$REPO_ROOT" remote) || return 1
+	[[ -n "$remotes" ]] || return 1
+	while IFS= read -r remote; do
+		[[ -n "$remote" ]] || continue
+		remote_rc=0
+		git -C "$REPO_ROOT" ls-remote -q --exit-code --tags "$remote" "$tag_ref" >/dev/null 2>&1 || remote_rc=$?
+		[[ "$remote_rc" -eq 2 ]] || return 1
+	done <<<"$remotes"
+	return 0
+}
+
+_full_loop_recovery_verify_channels_absent() {
+	local repo="$1"
+	local tag_name="$2"
+	_full_loop_recovery_verify_all_remote_tags_absent "$tag_name" || return 1
+	_full_loop_recovery_verify_github_release_absent "$repo" "$tag_name" || return 1
+	_full_loop_recovery_verify_npm_absent "$tag_name" || return 1
+	_full_loop_recovery_verify_homebrew_absent "$repo" "$tag_name" || return 1
+	return 0
+}
+
+_full_loop_recovery_validate_receipt() {
+	local repo="$1"
+	local source_pr="$2"
+	local receipt_path=""
+	local status=""
+	receipt_path=$(_full_loop_release_receipt_path "$repo" "$source_pr") || return 1
+	[[ -f "$receipt_path" ]] && IFS= read -r status <"$receipt_path" || true
+	case "$status" in
+	"" | "$_FULL_LOOP_PHASE_FAILED") return 0 ;;
+	esac
+	printf 'Aggregate recovery refused: release receipt is terminal (%s)\n' "$status" >&2
+	return 1
+}
+
+_full_loop_recovery_validate_existing_tag() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local source_json=""
+	local requested_present=""
+	_full_loop_release_verify_protected_source_provenance "$repo" "$tag_name" || return 1
+	source_json=$(_full_loop_release_source_json_from_tag "$tag_name") || return 1
+	requested_present=$(jq -r --argjson requested "$source_pr" \
+		'([.source_pr] + [.aggregated_sources[].pr]) | any(. == $requested)' <<<"$source_json") || return 1
+	[[ "$requested_present" == "true" ]] || return 1
+	_FULL_LOOP_AGGREGATE_RECOVERY_TAG_SOURCE_JSON="$source_json"
+	_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT=$(git -C "$REPO_ROOT" rev-parse "refs/tags/${tag_name}") || return 1
+	_full_loop_release_reset_tag_worktree || return 1
+	return 0
+}
+
+_full_loop_recovery_tag_sources() {
+	local expected_json=""
+	local observed_json=""
+	expected_json=$(release_authorization_manifest_json "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED") || return 1
+	observed_json=$(release_authorization_observed_sources_json "$expected_json" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_TAG_SOURCE_JSON") || return 1
+	jq -r 'map("\(.pr)@\(.merge)") | join(",")' <<<"$observed_json"
+	return $?
+}
+
+_full_loop_recovery_tag_is_bound_to_current_aggregate() {
+	local tag_name="$1"
+	local tag_parent=""
+	local aggregate_merge="${_FULL_LOOP_RESOLVED_SOURCE_MERGE:-}"
+	[[ "$aggregate_merge" =~ ^[0-9a-f]{40}$ ]] || return 1
+	tag_parent=$(git -C "$REPO_ROOT" rev-parse "${tag_name}^{commit}^" 2>/dev/null) || return 1
+	[[ "$tag_parent" == "$aggregate_merge" ]]
+	return $?
+}
+
+_full_loop_recovery_load_existing_state_transaction() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local existing=""
+	local previous_record=""
+	existing=$(_full_loop_read_release_authorization "$repo" "$source_pr") || return 1
+	[[ "$existing" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]] || return 1
+	previous_record=$(_full_loop_read_release_authorization_recovery_snapshot "$repo" "$source_pr") || return 1
+	_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH=$(jq -r '
+		.expected_sources | sort_by(.pr) | map("\(.pr)@\(.merge)") | join(",")
+	' <<<"$previous_record") || return 1
+	release_authorization_subset "$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+	release_lane_read "$repo" || return 1
+	jq -e --argjson source_pr "$source_pr" --arg tag "$tag_name" \
+		--arg expected "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" '
+		.active == true and .source_pr == $source_pr and .tag == $tag
+		and .expected_sources == $expected
+		and (.phase == "aggregation-recovery" or .phase == "remote-publication")
+		and ((.terminal_receipt // null) == null)
+		and (.aggregate_recovery.provisional_tag_object | test("^[0-9a-f]{40}$"))
+		and (.aggregate_recovery.previous_state.schema_version == 1)
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	_FULL_LOOP_AGGREGATE_RECOVERY_LANE_SNAPSHOT=$(jq -ce '.aggregate_recovery.previous_state' \
+		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT=$(jq -er '.aggregate_recovery.provisional_tag_object' \
+		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	_AIDEVOPS_RELEASE_LANE_TOKEN=$(jq -er '.operation_token' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	return 0
+}
+
+_full_loop_recovery_prepare_aggregate() {
+	local repo="$1"
+	local source_pr="$2"
+	local expected_sources="$3"
+	local worktree_base="${AIDEVOPS_WORKTREE_BASE_DIR:-${HOME}/Git/_worktrees}"
+	local resolver=""
+	[[ -d "$worktree_base" ]] || return 1
+	git -C "$REPO_ROOT" fetch origin main >/dev/null || return 1
+	_FULL_LOOP_RELEASE_PATH="${worktree_base}/aidevops-release-aggregate-recovery-${source_pr}-$$"
+	git -C "$REPO_ROOT" worktree add --detach "$_FULL_LOOP_RELEASE_PATH" origin/main >/dev/null || return 1
+	trap 'cleanup_release_worktree' EXIT
+	resolver="$_FULL_LOOP_RELEASE_PATH/.agents/scripts/release-provenance-helper.sh"
+	_full_loop_resolve_requested_release_source "$repo" "$source_pr" "$_FULL_LOOP_RELEASE_PATH" "$resolver" "$expected_sources" || return 1
+	[[ "$(jq -r '.mode' <<<"$_FULL_LOOP_RESOLVED_SOURCE_JSON")" == "aggregate" ]] || return 1
+	_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="$_FULL_LOOP_RESOLVED_EXPECTED_SOURCES"
+	return 0
+}
+
+_full_loop_recovery_begin_state_transaction() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local lane_expected=""
+	local existing=""
+	existing=$(_full_loop_read_release_authorization "$repo" "$source_pr") || return 1
+	if [[ "$existing" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]]; then
+		_full_loop_recovery_load_existing_state_transaction "$repo" "$source_pr" "$tag_name" && return 0
+		if _full_loop_read_release_authorization_recovery_snapshot "$repo" "$source_pr" >/dev/null 2>&1; then
+			_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH=$(
+				_full_loop_read_release_authorization_recovery_snapshot "$repo" "$source_pr" |
+					jq -r '.expected_sources | sort_by(.pr) | map("\(.pr)@\(.merge)") | join(",")'
+			) || return 1
+		else
+			_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH="$existing"
+			_full_loop_expand_release_authorization_for_aggregate "$repo" "$source_pr" \
+				"$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+		fi
+	else
+		_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH="$existing"
+		release_authorization_subset "$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" \
+			"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+		_full_loop_expand_release_authorization_for_aggregate "$repo" "$source_pr" \
+			"$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+	fi
+	if ! release_lane_read "$repo"; then
+		_full_loop_restore_release_authorization_after_aggregate "$repo" "$source_pr" \
+			"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" || true
+		return 1
+	fi
+	if ! lane_expected=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON"); then
+		_full_loop_restore_release_authorization_after_aggregate "$repo" "$source_pr" \
+			"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" || true
+		return 1
+	fi
+	if ! release_lane_begin_aggregate_recovery "$repo" "$source_pr" "$tag_name" "$lane_expected" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT"; then
+		_full_loop_restore_release_authorization_after_aggregate "$repo" "$source_pr" \
+			"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" || true
+		return 1
+	fi
+	_FULL_LOOP_AGGREGATE_RECOVERY_LANE_SNAPSHOT="$_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT"
+	return 0
+}
+
+_full_loop_recovery_resume_publication() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local new_tag_object=""
+	local reconcile_rc=0
+	new_tag_object=$(git -C "$REPO_ROOT" rev-parse "refs/tags/${tag_name}") || return 1
+	_full_loop_recovery_write_evidence "$repo" "$source_pr" "$tag_name" "$new_tag_object" || return 1
+	_full_loop_release_existing_with_lane reconcile "$source_pr" || reconcile_rc=$?
+	case "$reconcile_rc" in
+	0 | 8) return "$reconcile_rc" ;;
+	esac
+	return 1
+}
+
+_full_loop_recovery_restore_state_transaction() {
+	local repo="$1"
+	local source_pr="$2"
+	local restored=0
+	release_lane_restore_aggregate_recovery "$repo" "$source_pr" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_LANE_SNAPSHOT" || restored=1
+	_full_loop_restore_release_authorization_after_aggregate "$repo" "$source_pr" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" || restored=1
+	[[ "$restored" -eq 0 ]]
+	return $?
+}
+
+_full_loop_recovery_write_evidence() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local new_tag_object="$4"
+	local receipt_path=""
+	local evidence_path=""
+	receipt_path=$(_full_loop_release_receipt_path "$repo" "$source_pr") || return 1
+	evidence_path="${receipt_path%.status}.aggregate-recovery.json"
+	jq -cn --arg repo "$repo" --argjson requested_pr "$source_pr" --arg tag "$tag_name" \
+		--arg old "$_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT" --arg new "$new_tag_object" \
+		--argjson source "$_FULL_LOOP_RESOLVED_SOURCE_JSON" --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+		'{schema_version:1,status:"queued",repository:$repo,requested_pr:$requested_pr,tag:$tag,
+		  provisional_tag_object:$old,replacement_tag_object:$new,aggregate_source:$source,recorded_at:$now}' \
+		>"${evidence_path}.tmp.$$" || return 1
+	mv "${evidence_path}.tmp.$$" "$evidence_path" || return 1
+	return 0
+}
+
+_full_loop_recovery_run_version_manager() {
+	local source_pr="$1"
+	local tag_name="$2"
+	local version_manager="$_FULL_LOOP_RELEASE_PATH/.agents/scripts/version-manager.sh"
+	local recovery_rc=0
+	(
+		cd "$_FULL_LOOP_RELEASE_PATH" || exit 1
+		AIDEVOPS_RELEASE_INTENT_TRUSTED=1 bash "$version_manager" recover-aggregate \
+			--tag "$tag_name" --source-pr "$source_pr" \
+			--expected-sources "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" \
+			--old-tag-object "$_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT"
+	) || recovery_rc=$?
+	case "$recovery_rc" in
+	0 | 8) return "$recovery_rc" ;;
+	esac
+	return 1
+}
+
+_full_loop_recovery_tag_rollback_safe() {
+	local repo="$1"
+	local tag_name="$2"
+	local current_object=""
+	current_object=$(git -C "$REPO_ROOT" rev-parse "refs/tags/${tag_name}" 2>/dev/null) || return 1
+	[[ "$current_object" == "$_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT" ]] || return 1
+	_full_loop_recovery_verify_channels_absent "$repo" "$tag_name" || return 1
+	return 0
+}
+
+_full_loop_release_recover_aggregate() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local expected_sources="$4"
+	local recovery_rc=0
+	local new_tag_object=""
+	local tag_sources=""
+	_full_loop_recovery_validate_receipt "$repo" "$source_pr" || return 1
+	_full_loop_recovery_validate_existing_tag "$repo" "$source_pr" "$tag_name" || return 1
+	_full_loop_recovery_prepare_aggregate "$repo" "$source_pr" "$expected_sources" || return 1
+	tag_sources=$(_full_loop_recovery_tag_sources) || return 1
+	if [[ "$tag_sources" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]]; then
+		if _full_loop_recovery_load_existing_state_transaction "$repo" "$source_pr" "$tag_name"; then
+			_full_loop_recovery_resume_publication "$repo" "$source_pr" "$tag_name"
+			return $?
+		fi
+		_full_loop_recovery_tag_is_bound_to_current_aggregate "$tag_name" && return 1
+	fi
+	release_authorization_subset "$tag_sources" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+	_full_loop_recovery_verify_channels_absent "$repo" "$tag_name" || return 1
+	_full_loop_recovery_begin_state_transaction "$repo" "$source_pr" "$tag_name" || return 1
+	_full_loop_recovery_run_version_manager "$source_pr" "$tag_name" || recovery_rc=$?
+	if [[ "$recovery_rc" -ne 0 && "$recovery_rc" -ne 8 ]]; then
+		if _full_loop_recovery_tag_rollback_safe "$repo" "$tag_name"; then
+			_full_loop_recovery_restore_state_transaction "$repo" "$source_pr" || true
+		else
+			printf 'Aggregate recovery failed after tag state changed; expanded recovery state was retained for reconciliation\n' >&2
+		fi
+		return 1
+	fi
+	new_tag_object=$(git -C "$REPO_ROOT" rev-parse "refs/tags/${tag_name}") || return 1
+	_full_loop_recovery_write_evidence "$repo" "$source_pr" "$tag_name" "$new_tag_object" || return 1
+	release_lane_update "$repo" "$source_pr" remote-publication "$tag_name" || return 1
+	printf 'release:aggregate-recovery queued tag=%s source_pr=%s\n' "$tag_name" "$source_pr"
+	return 8
+}

--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -94,6 +94,8 @@ source "${SCRIPT_DIR}/full-loop-helper-state.sh"
 source "${SCRIPT_DIR}/release-lane-helper.sh"
 # shellcheck source=./full-loop-release-reconcile.sh
 source "${SCRIPT_DIR}/full-loop-release-reconcile.sh"
+# shellcheck source=./full-loop-release-aggregate-recovery.sh
+source "${SCRIPT_DIR}/full-loop-release-aggregate-recovery.sh"
 
 _FULL_LOOP_RESOLVED_SOURCE_JSON=""
 _FULL_LOOP_RESOLVED_SOURCE_PR=""
@@ -280,6 +282,7 @@ Usage:
   aidevops release [patch|minor|major] SOURCE_PR [incremental|full] [--expected-sources PR[,PR...]]
   aidevops release status SOURCE_PR
   aidevops release reconcile SOURCE_PR
+  aidevops release recover-aggregate SOURCE_PR --tag TAG --expected-sources PR[,PR...]
   aidevops release authorization-gap SOURCE_PR --tag TAG --expected-sources PR@SHA[,PR@SHA...] --reason TEXT
 
 Release publication is provenance-bound and normally unattended. `status` is
@@ -460,6 +463,17 @@ main() {
 		}
 		_full_loop_release_bind_repo_context || return 1
 		_full_loop_release_existing_with_lane "$release_type" "$source_pr"
+		return $?
+		;;
+	recover-aggregate)
+		[[ "$source_pr" =~ ^[0-9]+$ && "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && -n "$expected_sources" ]] || {
+			_full_loop_release_usage >&2
+			return 1
+		}
+		_full_loop_release_bind_repo_context || return 1
+		local recovery_repo=""
+		recovery_repo=$(_full_loop_resolve_repo "${AIDEVOPS_FULL_LOOP_REPO:-}") || return 1
+		_full_loop_release_recover_aggregate "$recovery_repo" "$source_pr" "$tag_name" "$expected_sources"
 		return $?
 		;;
 	authorization-gap)

--- a/.agents/scripts/release-authorization-manifest-helper.sh
+++ b/.agents/scripts/release-authorization-manifest-helper.sh
@@ -72,6 +72,19 @@ release_authorization_compare() {
 	return $?
 }
 
+release_authorization_subset() {
+	local subset="$1"
+	local complete="$2"
+	local subset_json=""
+	local complete_json=""
+	subset_json=$(release_authorization_manifest_json "$subset") || return 1
+	complete_json=$(release_authorization_manifest_json "$complete") || return 1
+	jq -e --argjson subset "$subset_json" --argjson complete "$complete_json" '
+		all($subset[]; . as $entry | any($complete[]; . == $entry))
+	' <<<"$complete_json" >/dev/null
+	return $?
+}
+
 _release_authorization_usage() {
 	printf '%s\n' 'Usage: release-authorization-manifest-helper.sh normalize MANIFEST'
 	return 0

--- a/.agents/scripts/release-lane-helper.sh
+++ b/.agents/scripts/release-lane-helper.sh
@@ -12,8 +12,11 @@ _AIDEVOPS_RELEASE_LANE_HEAD=""
 _AIDEVOPS_RELEASE_LANE_JSON=""
 _AIDEVOPS_RELEASE_LANE_RESULT=""
 _AIDEVOPS_RELEASE_LANE_TOKEN=""
+_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT=""
 _AIDEVOPS_RELEASE_LANE_PHASE_RESERVED="reserved"
 _AIDEVOPS_RELEASE_LANE_JSON_STRING_TYPE="string"
+_AIDEVOPS_RELEASE_LANE_TOKEN_PREFIX="lane-"
+_AIDEVOPS_RELEASE_LANE_OWNER_PREFIX="process-"
 
 _release_lane_cache_path() {
 	local repo="$1"
@@ -158,8 +161,8 @@ _release_lane_reclaim_same_source() {
 	local state_json=""
 	local operation_token=""
 	_release_lane_stale_prepublication "$_AIDEVOPS_RELEASE_LANE_JSON" || return 3
-	operation_token="lane-$(date +%s)-$$-${RANDOM:-0}"
-	state_json=$(jq -c --arg owner "process-$$" --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+	operation_token="${_AIDEVOPS_RELEASE_LANE_TOKEN_PREFIX}$(date +%s)-$$-${RANDOM:-0}"
+	state_json=$(jq -c --arg owner "${_AIDEVOPS_RELEASE_LANE_OWNER_PREFIX}$$" --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
 		--arg reserved "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" --arg token "$operation_token" \
 		'.owner=$owner | .operation_token=$token | .updated_at=$now | .phase=$reserved' \
 		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
@@ -207,9 +210,9 @@ release_lane_acquire() {
 	*) return 1 ;;
 	esac
 	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
-	operation_token="lane-$(date +%s)-$$-${RANDOM:-0}"
+	operation_token="${_AIDEVOPS_RELEASE_LANE_TOKEN_PREFIX}$(date +%s)-$$-${RANDOM:-0}"
 	state_json=$(jq -cn --arg repo "$repo" --argjson source_pr "$source_pr" --arg expected_sources "$expected_sources" \
-		--arg now "$now" --arg owner "process-$$" --arg reserved "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" \
+		--arg now "$now" --arg owner "${_AIDEVOPS_RELEASE_LANE_OWNER_PREFIX}$$" --arg reserved "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" \
 		--arg token "$operation_token" \
 		'{schema_version:1,repository:$repo,active:true,
 		source_pr:$source_pr,expected_sources:$expected_sources,phase:$reserved,tag:null,owner:$owner,operation_token:$token,
@@ -217,6 +220,60 @@ release_lane_acquire() {
 	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || return $?
 	_AIDEVOPS_RELEASE_LANE_TOKEN="$operation_token"
 	_AIDEVOPS_RELEASE_LANE_RESULT="acquired"
+	return 0
+}
+
+release_lane_begin_aggregate_recovery() {
+	local repo="$1"
+	local source_pr="$2"
+	local tag_name="$3"
+	local previous_sources="$4"
+	local expected_sources="$5"
+	local provisional_tag_object="${6:-}"
+	local operation_token=""
+	local state_json=""
+	local snapshot_json=""
+	[[ "$provisional_tag_object" =~ ^[0-9a-f]{40}$ ]] || return 1
+	release_lane_read "$repo" || return 1
+	jq -e --argjson source_pr "$source_pr" --arg tag "$tag_name" --arg previous "$previous_sources" '
+		.active == true and .source_pr == $source_pr and .tag == $tag
+		and .expected_sources == $previous
+		and (.phase == "remote-publication" or .phase == "reconcile-required")
+		and ((.terminal_receipt // null) == null)
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT="$_AIDEVOPS_RELEASE_LANE_JSON"
+	snapshot_json="$_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT"
+	operation_token="${_AIDEVOPS_RELEASE_LANE_TOKEN_PREFIX}$(date +%s)-$$-${RANDOM:-0}"
+	state_json=$(jq -c --arg expected "$expected_sources" --arg token "$operation_token" \
+		--arg owner "${_AIDEVOPS_RELEASE_LANE_OWNER_PREFIX}$$" --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+		--arg provisional "$provisional_tag_object" --argjson previous "$snapshot_json" '
+		.expected_sources=$expected | .operation_token=$token | .owner=$owner
+		| .phase="aggregation-recovery" | .updated_at=$now
+		| .aggregate_recovery={previous_state:$previous,provisional_tag_object:$provisional}
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || return $?
+	_AIDEVOPS_RELEASE_LANE_TOKEN="$operation_token"
+	return 0
+}
+
+release_lane_restore_aggregate_recovery() {
+	local repo="$1"
+	local source_pr="$2"
+	local snapshot_json="$3"
+	release_lane_read "$repo" || return 1
+	jq -e --argjson source_pr "$source_pr" --arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" '
+		.active == true and .source_pr == $source_pr and .phase == "aggregation-recovery"
+		and .operation_token == $token
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	if [[ -z "$snapshot_json" ]]; then
+		snapshot_json=$(jq -ce '.aggregate_recovery.previous_state' \
+			<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	fi
+	jq -e --argjson source_pr "$source_pr" '
+		.schema_version == 1 and .active == true and .source_pr == $source_pr
+	' <<<"$snapshot_json" >/dev/null || return 1
+	_release_lane_write "$repo" "$snapshot_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || return $?
+	_AIDEVOPS_RELEASE_LANE_TOKEN=$(jq -r '.operation_token' <<<"$snapshot_json") || return 1
 	return 0
 }
 

--- a/.agents/scripts/tests/test-full-loop-cleanup-receipt.sh
+++ b/.agents/scripts/tests/test-full-loop-cleanup-receipt.sh
@@ -398,6 +398,19 @@ if _full_loop_persist_release_authorization example/repo 29040 "$observed_source
 fi
 [[ "$(_full_loop_read_release_authorization example/repo 29040)" == "$expected_sources" ]]
 printf 'PASS retries reuse persisted release authorization and reject conflicting intent\n'
+authorization_path=$(_full_loop_release_authorization_path example/repo 29040)
+cp "$authorization_path" "${TEST_ROOT}/authorization-original.json"
+expanded_sources="${expected_sources},29014@1111111111111111111111111111111111111111"
+_full_loop_expand_release_authorization_for_aggregate example/repo 29040 "$expected_sources" "$expanded_sources"
+[[ "$(_full_loop_read_release_authorization example/repo 29040)" == "$expanded_sources" ]]
+_full_loop_restore_release_authorization_after_aggregate example/repo 29040 "$expanded_sources" "$expected_sources"
+[[ "$(_full_loop_read_release_authorization example/repo 29040)" == "$expected_sources" ]]
+cmp -s "$authorization_path" "${TEST_ROOT}/authorization-original.json"
+if _full_loop_expand_release_authorization_for_aggregate example/repo 29040 "$expected_sources" "$observed_sources"; then
+	printf 'FAIL aggregate recovery narrowed trusted release authorization\n'
+	exit 1
+fi
+printf 'PASS reviewed aggregate recovery expands and transactionally restores authorization\n'
 _full_loop_write_release_authorization_gap_evidence example/repo 29010 "$expected_sources" "$observed_sources" \
 	1901024bf5b675e4c6b680a801ea402b75f1f355 0050022840d6ab7df25608a8a16e50b54e12efec \
 	'published tag omitted explicitly authorized sources'

--- a/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export REPO_ROOT="$TEST_ROOT"
+source "${SCRIPT_DIR}/full-loop-release-aggregate-recovery.sh"
+
+CHANNEL_MODE="absent"
+
+_full_loop_recovery_verify_all_remote_tags_absent() {
+	[[ "$CHANNEL_MODE" != "remote-tag" ]]
+	return $?
+}
+
+gh() {
+	if [[ " $* " == *" --include "* ]]; then
+		if [[ "$CHANNEL_MODE" == "github-release" ]]; then
+			printf 'HTTP/2.0 200 OK\n\n'
+		else
+			printf 'HTTP/2.0 404 Not Found\n\n'
+		fi
+		return 0
+	fi
+	if [[ "$CHANNEL_MODE" == "homebrew" ]]; then
+		printf 'url "https://example.invalid/refs/tags/v1.2.3.tar.gz"\n'
+	else
+		printf 'url "https://example.invalid/refs/tags/v1.2.2.tar.gz"\n'
+	fi
+	return 0
+}
+
+npm() {
+	if [[ "${2:-}" == "aidevops@1.2.3" ]]; then
+		if [[ "$CHANNEL_MODE" == "npm" ]]; then
+			printf '"1.2.3"\n'
+			return 0
+		fi
+		printf 'npm error code E404\n' >&2
+		return 1
+	fi
+	return 0
+}
+
+CHANNEL_MODE=absent
+_full_loop_recovery_verify_channels_absent test/repo v1.2.3
+printf 'PASS recovery accepts only confirmed absent remote channels\n'
+
+for CHANNEL_MODE in remote-tag github-release npm homebrew; do
+	if _full_loop_recovery_verify_channels_absent test/repo v1.2.3 >/dev/null 2>&1; then
+		printf 'FAIL recovery accepted published channel mode %s\n' "$CHANNEL_MODE"
+		exit 1
+	fi
+done
+printf 'PASS recovery rejects remote tag, GitHub, npm, and Homebrew publication\n'
+
+(
+	git() {
+		printf '1111111111111111111111111111111111111111\n'
+		return 0
+	}
+	_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT=1111111111111111111111111111111111111111
+	CHANNEL_MODE=absent
+	_full_loop_recovery_tag_rollback_safe test/repo v1.2.3
+	CHANNEL_MODE=npm
+	if _full_loop_recovery_tag_rollback_safe test/repo v1.2.3 >/dev/null 2>&1; then
+		exit 1
+	fi
+)
+printf 'PASS rollback requires every publication channel to remain absent\n'
+
+_FULL_LOOP_PHASE_FAILED=failed
+_full_loop_release_receipt_path() {
+	printf '%s/release.status\n' "$TEST_ROOT"
+	return 0
+}
+printf 'published\n' >"${TEST_ROOT}/release.status"
+if _full_loop_recovery_validate_receipt test/repo 42 >/dev/null 2>&1; then
+	printf 'FAIL recovery accepted a terminal release receipt\n'
+	exit 1
+fi
+printf 'failed\n' >"${TEST_ROOT}/release.status"
+_full_loop_recovery_validate_receipt test/repo 42
+printf 'PASS recovery rejects terminal receipts and permits failed retries\n'
+
+STATE_LOG="${TEST_ROOT}/state.log"
+: >"$STATE_LOG"
+_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="42@2222222222222222222222222222222222222222,43@3333333333333333333333333333333333333333"
+_full_loop_read_release_authorization() {
+	printf '42@2222222222222222222222222222222222222222\n'
+	return 0
+}
+release_authorization_subset() { return 0; }
+_full_loop_expand_release_authorization_for_aggregate() {
+	printf 'expand\n' >>"$STATE_LOG"
+	return 0
+}
+release_lane_read() { return 1; }
+_full_loop_restore_release_authorization_after_aggregate() {
+	printf 'restore-auth\n' >>"$STATE_LOG"
+	return 0
+}
+if _full_loop_recovery_begin_state_transaction test/repo 42 v1.2.3; then
+	printf 'FAIL lane read failure retained expanded authorization\n'
+	exit 1
+fi
+[[ "$(tr '\n' ' ' <"$STATE_LOG")" == "expand restore-auth " ]]
+printf 'PASS lane uncertainty restores the pre-transaction authorization\n'
+
+_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="42@2222222222222222222222222222222222222222,43@3333333333333333333333333333333333333333"
+_full_loop_read_release_authorization() {
+	printf '%s\n' "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED"
+	return 0
+}
+_full_loop_read_release_authorization_recovery_snapshot() {
+	printf '%s\n' '{"schema_version":1,"repository":"test/repo","requested_pr":42,"expected_sources":[{"pr":42,"merge":"2222222222222222222222222222222222222222"}],"recorded_at":"2026-08-09T00:00:00Z"}'
+	return 0
+}
+release_lane_read() {
+	_AIDEVOPS_RELEASE_LANE_JSON='{"schema_version":1,"repository":"test/repo","active":true,"source_pr":42,"expected_sources":"42@2222222222222222222222222222222222222222,43@3333333333333333333333333333333333333333","phase":"aggregation-recovery","tag":"v1.2.3","operation_token":"lane-new","aggregate_recovery":{"provisional_tag_object":"1111111111111111111111111111111111111111","previous_state":{"schema_version":1,"repository":"test/repo","active":true,"source_pr":42,"expected_sources":"42","phase":"remote-publication","tag":"v1.2.3","operation_token":"lane-old"}}}'
+	return 0
+}
+_full_loop_recovery_load_existing_state_transaction test/repo 42 v1.2.3
+[[ "$_FULL_LOOP_AGGREGATE_RECOVERY_PREVIOUS_AUTH" == "42@2222222222222222222222222222222222222222" ]]
+[[ "$_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT" == 1111111111111111111111111111111111111111 ]]
+[[ "$_AIDEVOPS_RELEASE_LANE_TOKEN" == "lane-new" ]]
+printf 'PASS interrupted recovery reloads exact authorization and lane snapshots\n'
+
+CALL_LOG="${TEST_ROOT}/calls.log"
+: >"$CALL_LOG"
+_full_loop_recovery_validate_receipt() {
+	printf 'receipt\n' >>"$CALL_LOG"
+	return 0
+}
+_full_loop_recovery_validate_existing_tag() {
+	_FULL_LOOP_AGGREGATE_RECOVERY_OLD_TAG_OBJECT="1111111111111111111111111111111111111111"
+	printf 'tag\n' >>"$CALL_LOG"
+	return 0
+}
+_full_loop_recovery_verify_channels_absent() {
+	printf 'channels\n' >>"$CALL_LOG"
+	return 0
+}
+_full_loop_recovery_prepare_aggregate() {
+	_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="42@2222222222222222222222222222222222222222,43@3333333333333333333333333333333333333333"
+	_FULL_LOOP_RESOLVED_SOURCE_JSON='{"mode":"aggregate","source_pr":99,"source_merge":"4444444444444444444444444444444444444444","aggregated_sources":[{"pr":42,"merge":"2222222222222222222222222222222222222222"},{"pr":43,"merge":"3333333333333333333333333333333333333333"}]}'
+	printf 'aggregate\n' >>"$CALL_LOG"
+	return 0
+}
+_full_loop_recovery_tag_sources() {
+	printf '42@2222222222222222222222222222222222222222\n'
+	return 0
+}
+_full_loop_recovery_begin_state_transaction() {
+	printf 'begin\n' >>"$CALL_LOG"
+	return 0
+}
+_full_loop_recovery_restore_state_transaction() {
+	printf 'restore\n' >>"$CALL_LOG"
+	return 0
+}
+_full_loop_recovery_tag_rollback_safe() { return 0; }
+_full_loop_recovery_write_evidence() {
+	printf 'evidence\n' >>"$CALL_LOG"
+	return 0
+}
+release_lane_update() {
+	printf 'lane\n' >>"$CALL_LOG"
+	return 0
+}
+git() {
+	printf '4444444444444444444444444444444444444444\n'
+	return 0
+}
+
+_full_loop_recovery_run_version_manager() {
+	printf 'version-manager\n' >>"$CALL_LOG"
+	return 8
+}
+success_rc=0
+_full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 || success_rc=$?
+[[ "$success_rc" -eq 8 ]]
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "receipt tag aggregate channels begin version-manager evidence lane " ]]
+printf 'PASS queued recovery records evidence and retains the expanded transaction\n'
+
+: >"$CALL_LOG"
+_full_loop_recovery_tag_sources() {
+	printf '%s\n' "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED"
+	return 0
+}
+_full_loop_recovery_load_existing_state_transaction() {
+	printf 'load\n' >>"$CALL_LOG"
+	return 1
+}
+_full_loop_recovery_tag_is_bound_to_current_aggregate() { return 1; }
+same_sources_rc=0
+_full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 || same_sources_rc=$?
+[[ "$same_sources_rc" -eq 8 ]]
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "receipt tag aggregate load channels begin version-manager evidence lane " ]]
+printf 'PASS fresh same-source aggregation still replaces the historical tag\n'
+
+: >"$CALL_LOG"
+_full_loop_recovery_load_existing_state_transaction() {
+	printf 'load\n' >>"$CALL_LOG"
+	return 0
+}
+_full_loop_recovery_resume_publication() {
+	printf 'resume\n' >>"$CALL_LOG"
+	return 8
+}
+resume_rc=0
+_full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 || resume_rc=$?
+[[ "$resume_rc" -eq 8 ]]
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "receipt tag aggregate load resume " ]]
+printf 'PASS interrupted aggregate recovery resumes without another tag replacement\n'
+
+: >"$CALL_LOG"
+_full_loop_recovery_tag_sources() {
+	printf '42@2222222222222222222222222222222222222222\n'
+	return 0
+}
+_full_loop_recovery_run_version_manager() {
+	printf 'version-manager\n' >>"$CALL_LOG"
+	return 1
+}
+if _full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 >/dev/null 2>&1; then
+	printf 'FAIL failed recovery returned success\n'
+	exit 1
+fi
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "receipt tag aggregate channels begin version-manager restore " ]]
+printf 'PASS failed recovery restores authorization and release-lane state\n'
+
+: >"$CALL_LOG"
+_full_loop_recovery_tag_rollback_safe() { return 1; }
+if _full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 >/dev/null 2>&1; then
+	printf 'FAIL unsafe failed recovery returned success\n'
+	exit 1
+fi
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "receipt tag aggregate channels begin version-manager " ]]
+printf 'PASS uncertain tag rollback retains expanded state for reconciliation\n'
+
+exit 0

--- a/.agents/scripts/tests/test-release-lane.sh
+++ b/.agents/scripts/tests/test-release-lane.sh
@@ -157,6 +157,60 @@ run_stale_same_source_recovery_test() (
 	return 0
 )
 
+run_aggregate_recovery_rotation_test() (
+	local state='{"schema_version":1,"repository":"test/repo","active":true,"source_pr":101,"expected_sources":"101","phase":"remote-publication","tag":"v1.2.3","updated_at":"2026-08-09T00:00:00Z","operation_token":"token-old"}'
+	local old_state="$state"
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON="$state"
+		_AIDEVOPS_RELEASE_LANE_HEAD="1111111111111111111111111111111111111111"
+		return 0
+	}
+	_release_lane_write() {
+		local repo="$1"
+		local state_json="$2"
+		local expected_head="$3"
+		[[ "$repo" == "test/repo" && "$expected_head" == "1111111111111111111111111111111111111111" ]] || return 1
+		state="$state_json"
+		return 0
+	}
+	release_lane_begin_aggregate_recovery test/repo 101 v1.2.3 101 \
+		'101@1111111111111111111111111111111111111111,102@2222222222222222222222222222222222222222' \
+		3333333333333333333333333333333333333333 || return 1
+	[[ "$(jq -r '.phase' <<<"$state")" == "aggregation-recovery" &&
+	"$(jq -r '.expected_sources' <<<"$state")" == 101@1111111111111111111111111111111111111111,102@2222222222222222222222222222222222222222 &&
+	"$(jq -r '.operation_token' <<<"$state")" != "token-old" &&
+	"$(jq -r '.aggregate_recovery.provisional_tag_object' <<<"$state")" == 3333333333333333333333333333333333333333 &&
+	"$(jq -c '.aggregate_recovery.previous_state' <<<"$state")" == "$old_state" ]] || return 1
+	release_lane_restore_aggregate_recovery test/repo 101 "$old_state" || return 1
+	[[ "$state" == "$old_state" ]]
+	return $?
+)
+
+run_aggregate_recovery_rejection_test() (
+	local state_mode="competing"
+	release_lane_read() {
+		if [[ "$state_mode" == "terminal" ]]; then
+			_AIDEVOPS_RELEASE_LANE_JSON='{"schema_version":1,"repository":"test/repo","active":true,"source_pr":101,"expected_sources":"101","phase":"remote-publication","tag":"v1.2.3","updated_at":"2026-08-09T00:00:00Z","operation_token":"token-old","terminal_receipt":{"status":"published"}}'
+		else
+			_AIDEVOPS_RELEASE_LANE_JSON='{"schema_version":1,"repository":"test/repo","active":true,"source_pr":202,"expected_sources":"202","phase":"remote-publication","tag":"v1.2.3","updated_at":"2026-08-09T00:00:00Z","operation_token":"token-old"}'
+		fi
+		_AIDEVOPS_RELEASE_LANE_HEAD="1111111111111111111111111111111111111111"
+		return 0
+	}
+	if release_lane_begin_aggregate_recovery test/repo 101 v1.2.3 101 \
+		'101@1111111111111111111111111111111111111111' \
+		3333333333333333333333333333333333333333; then
+		return 1
+	fi
+	state_mode="terminal"
+	if release_lane_begin_aggregate_recovery test/repo 101 v1.2.3 101 \
+		'101@1111111111111111111111111111111111111111' \
+		3333333333333333333333333333333333333333; then
+		return 1
+	fi
+	return 0
+)
+
 if run_competing_source_test; then assert_result 'competing source receives active lane and reconcile action' true; else assert_result 'competing source receives active lane and reconcile action' false; fi
 if run_same_source_adoption_test; then assert_result 'same source adopts durable lane without another bump' true; else assert_result 'same source adopts durable lane without another bump' false; fi
 if run_terminal_lane_reacquire_test; then assert_result 'terminal lane can be atomically reserved by a later source' true; else assert_result 'terminal lane can be atomically reserved by a later source' false; fi
@@ -164,6 +218,8 @@ if run_setup_guard_test; then assert_result 'exact-tag deployment blocks generic
 if run_http_classification_test; then assert_result 'only verified HTTP 404 is classified as an absent lane' true; else assert_result 'only verified HTTP 404 is classified as an absent lane' false; fi
 if run_legacy_and_api_failure_test; then assert_result 'legacy absent lane remains compatible while API uncertainty blocks setup' true; else assert_result 'legacy absent lane remains compatible while API uncertainty blocks setup' false; fi
 if run_stale_same_source_recovery_test; then assert_result 'stale recovery rotates its token and fences the prior owner' true; else assert_result 'stale recovery rotates its token and fences the prior owner' false; fi
+if run_aggregate_recovery_rotation_test; then assert_result 'reviewed aggregate recovery rotates and can restore its lane transaction' true; else assert_result 'reviewed aggregate recovery rotates and can restore its lane transaction' false; fi
+if run_aggregate_recovery_rejection_test; then assert_result 'aggregate recovery rejects competing owners and terminal lanes' true; else assert_result 'aggregate recovery rejects competing owners and terminal lanes' false; fi
 
 printf '\nTests run: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-version-manager-aggregate-recovery.sh
+++ b/.agents/scripts/tests/test-version-manager-aggregate-recovery.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+PATH="/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+REMOTE="${TEST_ROOT}/remote.git"
+REPO="${TEST_ROOT}/repo"
+RECOVERY="${TEST_ROOT}/recovery"
+
+git init -q --bare "$REMOTE"
+git clone -q "$REMOTE" "$REPO"
+git -C "$REPO" switch -q -c main
+git -C "$REPO" config user.name Test
+git -C "$REPO" config user.email test@example.invalid
+printf '1.2.3\n' >"${REPO}/VERSION"
+printf '{"name":"aidevops","version":"1.2.3"}\n' >"${REPO}/package.json"
+git -C "$REPO" add VERSION package.json
+git -C "$REPO" commit -q -m 'authorized source merge'
+SOURCE_MERGE=$(git -C "$REPO" rev-parse HEAD)
+git -C "$REPO" commit -q --allow-empty -m 'chore(release): bump version to 1.2.3'
+git -C "$REPO" tag -a v1.2.3 -m "Release v1.2.3 - provisional
+
+Aidevops-Version: 1.2.3
+Aidevops-Source-PR: 42
+Aidevops-Source-Merge: ${SOURCE_MERGE}"
+OLD_TAG_OBJECT=$(git -C "$REPO" rev-parse refs/tags/v1.2.3)
+git -C "$REPO" reset -q --hard "$SOURCE_MERGE"
+git -C "$REPO" commit -q --allow-empty -m "reviewed aggregate
+
+Aidevops-Release-Aggregator-PR: 99
+Aidevops-Release-Aggregates: 42@${SOURCE_MERGE}"
+AGGREGATE_MERGE=$(git -C "$REPO" rev-parse HEAD)
+git -C "$REPO" push -q -u origin main
+git -C "$REPO" worktree add -q --detach "$RECOVERY" origin/main
+
+print_error() { return 0; }
+print_info() { return 0; }
+print_warning() { return 0; }
+print_success() { return 0; }
+cd "$RECOVERY" || exit 1
+source "${SCRIPT_DIR}/version-manager.sh"
+
+assert_release_linked_worktree() { return 0; }
+check_working_tree_clean() {
+	git -C "$REPO_ROOT" diff --quiet && git -C "$REPO_ROOT" diff --cached --quiet
+	return $?
+}
+verify_remote_sync() {
+	[[ "$(git -C "$REPO_ROOT" rev-parse HEAD)" == "$(git -C "$REPO_ROOT" rev-parse origin/main)" ]]
+	return $?
+}
+verify_release_source_pr() {
+	VERSION_MANAGER_SOURCE_PR=99
+	VERSION_MANAGER_SOURCE_MERGE_SHA=$(git -C "$REPO_ROOT" rev-parse HEAD)
+	VERSION_MANAGER_AGGREGATED_SOURCES="42@${SOURCE_MERGE}"
+	return 0
+}
+validate_version_consistency() { return 0; }
+_verify_recovered_aggregate_tag() { return 0; }
+release_source_pr_required() { return 0; }
+_release_contains_efficiency_change() { return 1; }
+push_changes() { return "${PUSH_RC:-8}"; }
+git() {
+	if [[ "${1:-}" == "verify-tag" ]]; then
+		return 0
+	fi
+	if [[ "${1:-}" == "tag" && "${2:-}" == "-s" ]]; then
+		shift 2
+		command git tag -a "$@"
+		return $?
+	fi
+	command git "$@"
+	return $?
+}
+
+tag_name=""
+source_pr=""
+expected_sources=""
+old_tag_object=""
+_parse_aggregate_recovery_args --tag v1.2.3 --source-pr 42 \
+	--expected-sources "42@${SOURCE_MERGE}" --old-tag-object "$OLD_TAG_OBJECT"
+_validate_aggregate_recovery_context "$tag_name" "$source_pr" "$expected_sources" "$old_tag_object"
+recovery_rc=0
+_execute_aggregate_recovery "$tag_name" "$old_tag_object" || recovery_rc=$?
+[[ "$recovery_rc" -eq 8 ]]
+NEW_TAG_OBJECT=$(git -C "$RECOVERY" rev-parse refs/tags/v1.2.3)
+[[ "$NEW_TAG_OBJECT" != "$OLD_TAG_OBJECT" ]]
+[[ "$(git -C "$RECOVERY" rev-parse "v1.2.3^")" == "$AGGREGATE_MERGE" ]]
+[[ "$(git -C "$RECOVERY" show v1.2.3:VERSION)" == "1.2.3" ]]
+git -C "$RECOVERY" for-each-ref --format='%(contents)' refs/tags/v1.2.3 | grep -q "Aidevops-Source-PR: 99"
+printf 'PASS aggregate recovery replaces a local-only tag without incrementing the version\n'
+
+restore_unpublished_aggregate_tag 1.2.3 "$OLD_TAG_OBJECT"
+git -C "$RECOVERY" reset -q --hard "$AGGREGATE_MERGE"
+PUSH_RC=1
+failed_rc=0
+_main_recover_aggregate --tag v1.2.3 --source-pr 42 \
+	--expected-sources "42@${SOURCE_MERGE}" --old-tag-object "$OLD_TAG_OBJECT" || failed_rc=$?
+[[ "$failed_rc" -eq 1 ]]
+[[ "$(git -C "$RECOVERY" rev-parse refs/tags/v1.2.3)" == "$OLD_TAG_OBJECT" ]]
+printf 'PASS failed aggregate recovery restores the exact provisional tag object\n'
+
+exit 0

--- a/.agents/scripts/version-manager-git.sh
+++ b/.agents/scripts/version-manager-git.sh
@@ -497,6 +497,26 @@ _verify_bump_commit_at_ref() {
 	return 0
 }
 
+_create_aggregate_recovery_bump_commit() {
+	local version="$1"
+	local expected_parent="$2"
+	local current_head=""
+	local remote_head=""
+	local actual_parent=""
+	local commit_subject=""
+	[[ "$expected_parent" =~ ^[0-9a-f]{40}$ ]] || return 1
+	current_head=$(git rev-parse HEAD 2>/dev/null) || return 1
+	remote_head=$(git rev-parse origin/main 2>/dev/null) || return 1
+	[[ "$current_head" == "$expected_parent" && "$remote_head" == "$expected_parent" ]] || return 1
+	git diff --quiet && git diff --cached --quiet || return 1
+	commit_subject=$(_bump_commit_subject "$version") || return 1
+	git commit --allow-empty --no-verify -m "$commit_subject" >/dev/null || return 1
+	_verify_bump_commit_at_ref HEAD "$version" || return 1
+	actual_parent=$(git rev-parse HEAD^ 2>/dev/null) || return 1
+	[[ "$actual_parent" == "$expected_parent" ]]
+	return $?
+}
+
 # Run commit_version_changes with strict return-code semantics and verify
 # that HEAD ended up as the expected bump commit afterward.
 #

--- a/.agents/scripts/version-manager-release.sh
+++ b/.agents/scripts/version-manager-release.sh
@@ -32,6 +32,34 @@
 [[ -n "${_VERSION_MANAGER_RELEASE_LOADED:-}" ]] && return 0
 _VERSION_MANAGER_RELEASE_LOADED=1
 
+_version_manager_tag_name() {
+	local version="$1"
+	printf 'v%s\n' "$version"
+	return 0
+}
+
+_version_manager_tag_ref() {
+	local tag_name="$1"
+	printf 'refs/tags/%s\n' "$tag_name"
+	return 0
+}
+
+_version_manager_tag_absent_from_all_remotes() {
+	local tag_ref="$1"
+	local remotes=""
+	local remote=""
+	local remote_rc=0
+	remotes=$(git remote) || return 1
+	[[ -n "$remotes" ]] || return 1
+	while IFS= read -r remote; do
+		[[ -n "$remote" ]] || continue
+		remote_rc=0
+		git ls-remote -q --exit-code --tags "$remote" "$tag_ref" >/dev/null 2>&1 || remote_rc=$?
+		[[ "$remote_rc" -eq 2 ]] || return 1
+	done <<<"$remotes"
+	return 0
+}
+
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	_lib_path="${BASH_SOURCE[0]%/*}"
 	[[ "$_lib_path" == "${BASH_SOURCE[0]}" ]] && _lib_path="."
@@ -375,6 +403,63 @@ create_git_tag() {
 		print_error "Failed to create git tag"
 		return 1
 	fi
+	return 0
+}
+
+_restore_unpublished_release_tag() {
+	local tag_name="$1"
+	local original_object="$2"
+	local tag_ref=""
+	tag_ref=$(_version_manager_tag_ref "$tag_name") || return 1
+	git update-ref "$tag_ref" "$original_object" || return 1
+	return 0
+}
+
+replace_unpublished_aggregate_tag() {
+	local version="$1"
+	local original_object="$2"
+	local tag_name=""
+	local tag_ref=""
+	local observed_object=""
+	local replacement_object=""
+	tag_name=$(_version_manager_tag_name "$version") || return 1
+	tag_ref=$(_version_manager_tag_ref "$tag_name") || return 1
+	[[ "$original_object" =~ ^[0-9a-f]{40}$ ]] || return 1
+	observed_object=$(git rev-parse "$tag_ref" 2>/dev/null) || return 1
+	[[ "$observed_object" == "$original_object" ]] || return 1
+	git verify-tag "$tag_name" >/dev/null 2>&1 || return 1
+	_version_manager_tag_absent_from_all_remotes "$tag_ref" || return 1
+	git update-ref -d "$tag_ref" "$original_object" || return 1
+	if ! create_git_tag "$version"; then
+		_restore_unpublished_release_tag "$tag_name" "$original_object" || true
+		return 1
+	fi
+	if ! replacement_object=$(git rev-parse "$tag_ref" 2>/dev/null); then
+		restore_unpublished_aggregate_tag "$version" "$original_object" || true
+		return 1
+	fi
+	if [[ "$replacement_object" == "$original_object" ]] || ! git verify-tag "$tag_name" >/dev/null 2>&1; then
+		git update-ref -d "$tag_ref" "$replacement_object" || true
+		_restore_unpublished_release_tag "$tag_name" "$original_object" || true
+		return 1
+	fi
+	return 0
+}
+
+restore_unpublished_aggregate_tag() {
+	local version="$1"
+	local original_object="$2"
+	local tag_name=""
+	local tag_ref=""
+	local current_object=""
+	tag_name=$(_version_manager_tag_name "$version") || return 1
+	tag_ref=$(_version_manager_tag_ref "$tag_name") || return 1
+	_version_manager_tag_absent_from_all_remotes "$tag_ref" || return 1
+	current_object=$(git rev-parse "$tag_ref" 2>/dev/null || true)
+	if [[ -n "$current_object" ]]; then
+		git update-ref -d "$tag_ref" "$current_object" || return 1
+	fi
+	_restore_unpublished_release_tag "$tag_name" "$original_object" || return 1
 	return 0
 }
 

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -34,6 +34,7 @@ else
 fi
 VERSION_FILE="$REPO_ROOT/VERSION"
 _VERSION_MANAGER_ACTION_RELEASE="release"
+_VERSION_MANAGER_ACTION_RECOVER_AGGREGATE="recover-aggregate"
 
 _version_manager_marker_is_truthy() {
 	local marker=""
@@ -109,7 +110,8 @@ _version_manager_guard_headless_release_scope() {
 	shift || true
 
 	_version_manager_action_is_read_only "$action" "$@" && return 0
-	[[ "$action" == "$_VERSION_MANAGER_ACTION_RELEASE" || "$action" == "post-release" ]] || {
+	[[ "$action" == "$_VERSION_MANAGER_ACTION_RELEASE" || "$action" == "post-release" ||
+		"$action" == "$_VERSION_MANAGER_ACTION_RECOVER_AGGREGATE" ]] || {
 		_version_manager_is_headless_task_worker || return 0
 	}
 
@@ -618,6 +620,98 @@ _main_release() {
 	return 0
 }
 
+_parse_aggregate_recovery_args() {
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--tag)
+			tag_name="${2:-}"
+			shift 2
+			;;
+		--source-pr)
+			source_pr="${2:-}"
+			shift 2
+			;;
+		--expected-sources)
+			expected_sources="${2:-}"
+			shift 2
+			;;
+		--old-tag-object)
+			old_tag_object="${2:-}"
+			shift 2
+			;;
+		*)
+			print_error "Unknown aggregate recovery option: $1"
+			return 1
+			;;
+		esac
+	done
+	[[ "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && "$source_pr" =~ ^[0-9]+$ ]] || return 1
+	[[ -n "$expected_sources" && "$old_tag_object" =~ ^[0-9a-f]{40}$ ]] || return 1
+	return 0
+}
+
+_validate_aggregate_recovery_context() {
+	local tag_name="$1"
+	local source_pr="$2"
+	local expected_sources="$3"
+	local old_tag_object="$4"
+	local version=""
+	local current_object=""
+	assert_release_linked_worktree || return 1
+	verify_remote_sync main || return 1
+	check_working_tree_clean || return 1
+	version=$(get_current_version) || return 1
+	[[ "$tag_name" == "v${version}" ]] || return 1
+	current_object=$(git rev-parse "refs/tags/${tag_name}" 2>/dev/null) || return 1
+	[[ "$current_object" == "$old_tag_object" ]] || return 1
+	verify_release_source_pr "$source_pr" main "" "$expected_sources" || return 1
+	[[ -n "${VERSION_MANAGER_AGGREGATED_SOURCES:-}" ]] || return 1
+	[[ "${VERSION_MANAGER_SOURCE_MERGE_SHA:-}" == "$(git rev-parse HEAD 2>/dev/null)" ]] || return 1
+	validate_version_consistency "$version" || return 1
+	return 0
+}
+
+_verify_recovered_aggregate_tag() {
+	local tag_name="$1"
+	local repo_slug="${2:-}"
+	local resolver="${AIDEVOPS_RELEASE_SOURCE_RESOLVER:-${SCRIPT_DIR}/release-provenance-helper.sh}"
+	[[ -n "$repo_slug" ]] || repo_slug=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null) || return 1
+	[[ -x "$resolver" ]] || return 1
+	(cd "$REPO_ROOT" && bash "$resolver" verify-local-source --tag "$tag_name" --repo "$repo_slug" >/dev/null)
+	return $?
+}
+
+_execute_aggregate_recovery() {
+	local tag_name="$1"
+	local old_tag_object="$2"
+	local version="${tag_name#v}"
+	local source_merge="${VERSION_MANAGER_SOURCE_MERGE_SHA:-}"
+	local push_rc=0
+	_create_aggregate_recovery_bump_commit "$version" "$source_merge" || return 1
+	replace_unpublished_aggregate_tag "$version" "$old_tag_object" || return 1
+	if ! _verify_recovered_aggregate_tag "$tag_name"; then
+		restore_unpublished_aggregate_tag "$version" "$old_tag_object" || true
+		return 1
+	fi
+	push_changes "$version" || push_rc=$?
+	case "$push_rc" in
+	0 | 8) return "$push_rc" ;;
+	esac
+	restore_unpublished_aggregate_tag "$version" "$old_tag_object" || true
+	return 1
+}
+
+_main_recover_aggregate() {
+	local tag_name=""
+	local source_pr=""
+	local expected_sources=""
+	local old_tag_object=""
+	_parse_aggregate_recovery_args "$@" || return 1
+	_validate_aggregate_recovery_context "$tag_name" "$source_pr" "$expected_sources" "$old_tag_object" || return 1
+	_execute_aggregate_recovery "$tag_name" "$old_tag_object"
+	return $?
+}
+
 # Print usage/help text.
 _main_usage() {
 	echo "AI DevOps Framework Version Manager"
@@ -632,6 +726,8 @@ _main_usage() {
 	echo "  post-release [--hotfix]       Retry post-publication propagation and deployment gates"
 	echo "  release [major|minor|patch] --source-pr N [--expected-sources PR[,PR...]]"
 	echo "                                 Bump version (default: patch), tag, publish, and deploy from a verified merged PR"
+	echo "  recover-aggregate --tag TAG --source-pr N --expected-sources PR@SHA[,PR@SHA...] --old-tag-object SHA"
+	echo "                                 Replace an unpublished provisional tag after exact-tip reviewed aggregation"
 	echo "  release patch --hotfix       Patch release with hotfix signal for immediate runner propagation"
 	echo "  preflight [major|minor|patch] Run release preflight checks only"
 	echo "  validate                      Validate version consistency across all files"
@@ -690,6 +786,9 @@ main() {
 		else
 			_main_release "${bump_type:-patch}" "${@:3}"
 		fi
+		;;
+	"$_VERSION_MANAGER_ACTION_RECOVER_AGGREGATE")
+		_main_recover_aggregate "${@:2}"
 		;;
 	"github-release")
 		local version

--- a/.agents/workflows/release.md
+++ b/.agents/workflows/release.md
@@ -76,6 +76,24 @@ PR published, and marks included source receipts superseded with immutable
 release links. Arbitrary descendants and unreviewed direct commits remain
 blocked.
 
+If an unpublished signed tag and active remote-publication lane already exist,
+use the explicit transactional recovery command instead of the ordinary retry:
+
+```bash
+aidevops release recover-aggregate <original-source-pr> --tag <vX.Y.Z> \
+  --expected-sources <pr[,pr...]>
+```
+
+The command requires the reviewed aggregate at the exact `origin/main` tip,
+confirms the tag is absent from the remote, GitHub Releases, npm, and Homebrew,
+and verifies the existing authorization is an exact subset of the aggregate.
+It then rotates the lane token, expands authorization, creates a same-version
+empty bump commit over the aggregate, and replaces only the local unpublished
+tag. A failure before durable publication restores the exact previous tag
+object, authorization manifest, and lane state. Remote tags are never rewritten.
+See `reference/release-aggregation-recovery.md` for the state and rollback
+contract.
+
 Protected-main reconciliation rechecks the exact tree immediately before pushing the preserved tag. A descendant with a different tree is `aggregation-required` and stops before tag or package mutation, even when it contains the signed release commit. During exact-tag deployment, generic `setup.sh --non-interactive` is blocked by the release lane; only setup carrying the matching source PR and tag may enter the existing setup mutex. The acquisition order is release lane, then setup lock.
 
 For an already-published immutable tag with an authorization gap, do not retag,


### PR DESCRIPTION
## Summary

Add an explicit fail-closed recovery command that rebinds a local-only signed release tag to an exact-tip reviewed aggregation without changing the semantic version. Persist exact authorization and lane snapshots so rollback and interruption are idempotent, and verify all remotes plus GitHub Releases, npm, and Homebrew before mutation.

## Files Changed

.agents/reference/release-aggregation-recovery.md, .agents/reference/release-publication-controls.md, .agents/scripts/full-loop-helper-state.sh, .agents/scripts/full-loop-release-aggregate-recovery.sh, .agents/scripts/full-loop-release-helper.sh, .agents/scripts/release-authorization-manifest-helper.sh, .agents/scripts/release-lane-helper.sh, .agents/scripts/tests/test-full-loop-cleanup-receipt.sh, .agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh, .agents/scripts/tests/test-release-lane.sh, .agents/scripts/tests/test-version-manager-aggregate-recovery.sh, .agents/scripts/version-manager-git.sh, .agents/scripts/version-manager-release.sh, .agents/scripts/version-manager.sh, .agents/workflows/release.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Ran .agents/scripts/linters-local.sh and the focused release-helper, reconciliation, provenance, release-lane, aggregate-recovery, protected-publication, and protected-main fallback suites.

Resolves #29869


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.246 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 3h 47m and 1,877,932 tokens on this with the user in an interactive session.