### PR TITLE
GH#29881: Improve completion summaries with session outcomes

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -63,7 +63,7 @@ Skip if you lack Edit/Write/Bash tools. Otherwise, before any file modification 
 - Stuck: replan, inspect current state, and use `session-introspect-helper.sh patterns` when loops appear.
 - Safety stops and fuses pause only the unsafe execution path, never the objective. Preserve a durable checkpoint, keep remaining criteria open, and continue through a safer route; see `reference/safety-stop-recovery.md`.
 - Before declaring completion, scan conversation for unfulfilled commitments, unnotified external parties, and displaced requests.
-- Completed-session messages: concise bullets of delivered changes; omit routine-owned cleanup unless user action is required or work is at risk. Details: `reference/session.md`.
+- Completion messages: state aim and solved outcome, then delivery bullets; omit routine-owned cleanup unless user action is required or work is at risk. See `reference/session.md`.
 - Memory recall is mandatory before non-trivial edits, debugging, PR review, git side effects, or design decisions: CLI `memory-helper.sh recall --query "<task keywords>" --limit 5`; OpenCode tool `aidevops_memory` with `{action:"recall", query:"<task keywords>", limit:"5"}`. Store only concrete reusable lessons: `{action:"store", content:"<lesson with evidence>", confidence:"medium"}`. Empty `aidevops_memory` calls are invalid; never use them as placeholders.
 - Before non-trivial code changes, run one duplicate/collision check: `prework-discovery-helper.sh --keywords "<task>" --files "<targets>" [--repo owner/repo]`.
 - Before changing third-party API/error-code mappings, verify the installed dependency version and local exported symbols first; brief authors include this checklist via `templates/brief-template.md`.

--- a/.agents/reference/session.md
+++ b/.agents/reference/session.md
@@ -13,6 +13,7 @@ Full PTY access: run any CLI (`vim`, `psql`, `ssh`, `htop`, dev servers). Long-r
 
 - Run `/session-review` before ending.
 - Suggest a new session after PR merge, domain switch, or 3+ hours.
+- At completion, lead with one short outcome statement that reconnects the delivered work to the session aim or problem, then list concise, evidence-backed delivery bullets.
 - Leave linked-worktree removal to the guarded post-exit routine. Do not attempt or report normal deferred cleanup; mention only failures requiring user action or putting unpublished work at risk.
 - Full docs: `workflows/session-manager.md`.
 

--- a/.agents/scripts/tests/test-session-completion-summary-policy.sh
+++ b/.agents/scripts/tests/test-session-completion-summary-policy.sh
@@ -23,6 +23,10 @@ require_literal() {
 }
 
 main() {
+	require_literal 'state aim and solved outcome' \
+		"$AGENTS_DOC" 'always-loaded completion guidance omits the session aim and solved outcome' || return 1
+	require_literal 'reconnects the delivered work to the session aim or problem' \
+		"$SESSION_DOC" 'session completion detail omits reader reorientation context' || return 1
 	require_literal 'omit routine-owned cleanup unless user action is required or work is at risk' \
 		"$AGENTS_DOC" 'always-loaded completion guidance does not suppress routine cleanup noise' || return 1
 	require_literal 'Do not attempt or report normal deferred cleanup' \


### PR DESCRIPTION
## Summary

Make completion messages reconnect the original session aim or problem to the solved outcome before listing concise delivery evidence, improving reorientation across long-running and concurrent sessions.

## Files Changed

.agents/AGENTS.md, .agents/reference/session.md, .agents/scripts/tests/test-session-completion-summary-policy.sh

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Focused completion-summary policy test, Bash syntax, ShellCheck, changed-file lint suite, 23,999-byte AGENTS.md size check, signed commit verification, and branch review bundle f4df6615f34bbe6b9d7c461eb3f64f5c293aea21e358d7d89845345a87d2294e.

Resolves #29881


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.246 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 2h 6m and 1,483,775 tokens on this with the user in an interactive session.