### PR TITLE
GH#29879: Add optional LM Studio Buzz provisioning

### DIFF
--- a/.agents/bin/aidevops-buzz-lm-studio-acp
+++ b/.agents/bin/aidevops-buzz-lm-studio-acp
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON_BIN="${AIDEVOPS_PYTHON_BIN:-python3}"
+
+exec "$PYTHON_BIN" "${SCRIPT_DIR}/../scripts/team-interface-buzz-lm-studio.py" exec -- "$@"

--- a/.agents/configs/buzz-runtime-aidevops-lm-studio-v1.json
+++ b/.agents/configs/buzz-runtime-aidevops-lm-studio-v1.json
@@ -1,0 +1,9 @@
+{
+  "args": [],
+  "command": "aidevops-buzz-lm-studio-acp",
+  "env": {},
+  "id": "aidevops-lm-studio-v1",
+  "installHint": "Installed by aidevops when LM Studio has a running local server and loaded LLM.",
+  "installInstructionsUrl": "https://aidevops.sh/docs",
+  "label": "Aidevops Local LM Studio V1"
+}

--- a/.agents/reference/team-interface-buzz-provisioning.md
+++ b/.agents/reference/team-interface-buzz-provisioning.md
@@ -8,33 +8,43 @@ read-only `adapter.buzz` described in `team-interface-buzz.md`. It generates one
 portable `buzz-team-snapshot` from the canonical aidevops roster. Fourteen
 imported members use the full `aidevops-interactive-v1` OpenCode runtime while
 Private AI uses the reviewed `buzz-agent`/`relay-mesh`/`auto` shared-compute
-route. Buzz remains the ingress and identity authority. Import the snapshot with Buzz Desktop's native
+route. When the official LM Studio CLI reports a running local server and exactly
+one loaded LLM, generation adds a separate `private-lm-studio-<host>` member using
+the fail-closed `aidevops-lm-studio-v1` runtime. Buzz remains the ingress and
+identity authority. Import the snapshot with Buzz Desktop's native
 preview-and-confirm flow, or queue the same preview through the optional local
 owner-review broker. The helper never confirms an import, reads Buzz credentials,
-edits Buzz identity/team stores, selects a model/provider, or calls a relay.
+edits Buzz identity/team stores, downloads or loads a model, or calls a relay.
 
 The earlier `aidevops-conversation-v1` runtime remains available as a read-only
 diagnostic profile. Team snapshots do not select it.
 
 ## Generate and inspect
 
-Generate a mode-0600 snapshot for inspection:
+Generate a mode-0600 snapshot in the user-facing Downloads folder:
 
 ```bash
-~/.aidevops/agents/scripts/buzz-team-provision-helper.sh generate \
-  --output "$HOME/aidevops.team.json"
+~/.aidevops/agents/scripts/buzz-team-provision-helper.sh generate
 ```
+
+The default path is `~/Downloads/aidevops.team.json`. Use `--output FILE` for a
+different reviewed destination or `--stdout` for an explicit pipeline. Internal
+`.agent-workspace` storage remains reserved for `submit`'s ephemeral broker file
+and other headless/pipeline artifacts.
 
 Generation resolves `.agents/scripts/team-interface-agent-roster.py`; the roster
 remains the only discovery and stable-identity source. Current output contains
 14 primary specialists and the framework guide, sorted by display name in the
 **AI DevOps** team. Additions, removals, workload tiers, source references, and
 source digests flow from canonical discovery rather than a duplicated provider
-list.
+list. The optional LM Studio member is derived from the canonical Private AI
+source without becoming a second roster entry.
 
 Member names use lowercase dashed `role-host` identifiers so mentions reveal the
 provisioning host. The host suffix is not proof of local or on-device execution;
-Private AI uses shared compute. On macOS, generation normalizes the
+Private AI uses shared compute. The separately named LM Studio member represents
+local inference only when its runtime revalidates the loopback server and loaded
+model. On macOS, generation normalizes the
 system `LocalHostName`; for example, `Marcus-MacBook-Pro-01` produces
 `aidevops-marcus-macbook-pro-01`, `build-plus-marcus-macbook-pro-01`, and
 `seo-marcus-macbook-pro-01`. Use `--host-slug NAME` only for an explicit stable
@@ -46,9 +56,13 @@ a reviewed logical runtime requirement, and a pointer containing
 the deployment-relative `agents:<filename>` source, exact source digest, and
 portable workload tier. Canonical instruction bodies, absolute paths, models,
 providers, commands, environment values, relay URLs, identities, auth tags,
-private keys, and memory are excluded. Private AI alone includes reviewed
+private keys, and memory are excluded. Private AI includes reviewed
 `provider: relay-mesh` and `model: auto` fields with `runtime: buzz-agent`; the
-other fourteen members omit provider/model and use `aidevops-interactive-v1`.
+other fourteen baseline members omit provider/model and use
+`aidevops-interactive-v1`. When ready, Private LM Studio includes the exact
+loaded identifier with `provider: openai` and `runtime: aidevops-lm-studio-v1`.
+No endpoint, placeholder API key, command, environment value, or LM Studio
+credential enters the portable snapshot.
 
 The avatar geometry matches the canonical circular terminal-prompt avatar from
 the aidevops website. A reviewed hue is assigned by stable `agent_id` across the
@@ -68,6 +82,37 @@ Native import does not require the local control broker:
 The preview states that Buzz creates a new team with fresh keypairs. Cancel if
 the roster, owner-only response policy, or `aidevops-interactive-v1` runtime is
 not exactly as expected.
+
+## Enable the optional LM Studio member
+
+LM Studio's supported `lms` interface must report both a running local server and
+a loaded LLM. Application presence alone is insufficient, and embedding models
+do not qualify:
+
+```bash
+~/.aidevops/agents/scripts/buzz-team-provision-helper.sh lm-studio-status
+```
+
+If multiple LLMs are loaded, set `AIDEVOPS_LM_STUDIO_MODEL` to one exact loaded
+identifier before generation. Use `--lm-studio required` to fail generation
+instead of producing the 15-member baseline when local inference is not ready;
+use `--lm-studio off` for deterministic pipeline output.
+
+Before importing a snapshot that includes Private LM Studio, quit Buzz and
+install its local runtime beside the interactive runtime:
+
+```bash
+~/.aidevops/agents/scripts/buzz-team-provision-helper.sh runtime-install \
+  --project-root "$HOME/Git/aidevops" \
+  --runtime lm-studio
+```
+
+At every launch, `aidevops-buzz-lm-studio-acp` re-runs the bounded CLI checks,
+connects Buzz Agent only to the CLI-reported port on `127.0.0.1`, selects the
+OpenAI-compatible chat route, and uses the reviewed loaded identifier. It fails
+closed if the server stopped, no LLM is loaded, multiple models are ambiguous,
+or the selected model changed. The runtime does not start the server, load a
+model, enable LAN access, or persist an endpoint.
 
 ## Queue Desktop review through the optional broker
 
@@ -169,7 +214,9 @@ is **Aidevops Restricted Conversation V1**.
   `aidevops-interactive-v1` logical runtime, which fails closed until the full
   harness is explicitly registered. Private AI alone uses the reviewed
   `buzz-agent`/`relay-mesh`/`auto` route; shared compute must never be represented
-  as proof of local, private, or on-device execution.
+  as proof of local, private, or on-device execution. The optional Private LM
+  Studio member is the only member that may claim local inference, and only while
+  its runtime revalidates the loopback server and exact loaded LLM.
 - The full runtime preserves the normal aidevops permission profile and native
   compaction; it does not turn a Buzz message into destructive, billing,
   publication, release, credential, or administrator authority. Those actions
@@ -195,6 +242,7 @@ is **Aidevops Restricted Conversation V1**.
 
 ```bash
 node --test .agents/scripts/tests/test-team-interface-buzz-team-snapshot.mjs
+node --test .agents/scripts/tests/test-team-interface-buzz-lm-studio.mjs
 node --test .agents/scripts/tests/test-team-interface-buzz-runtime.mjs
 node --test .agents/scripts/tests/test-team-interface-acp-cwd-proxy.mjs
 node --test .agents/scripts/tests/test-team-interface-buzz-worktree.mjs
@@ -204,6 +252,7 @@ node --test .agents/scripts/tests/test-team-interface-agent-roster.mjs
 node --test .agents/scripts/tests/test-team-interface-buzz-adapter.mjs
 shellcheck .agents/bin/aidevops-buzz-acp \
   .agents/bin/aidevops-buzz-acp-interactive \
+  .agents/bin/aidevops-buzz-lm-studio-acp \
   .agents/scripts/buzz-team-provision-helper.sh \
   .agents/scripts/team-interface-buzz-worktree.sh
 .agents/scripts/linters-local.sh --changed

--- a/.agents/scripts/_team_interface_buzz_avatar.py
+++ b/.agents/scripts/_team_interface_buzz_avatar.py
@@ -28,6 +28,7 @@ AVATAR_HUE_BY_AGENT_ID = {
     "agent.legal": 242,
     "agent.marketing-sales": 10,
     "agent.pr": 139,
+    "agent.private-lm-studio": 205,
     "agent.private-local-ai": 190,
     "agent.product": 268,
     "agent.reports": 36,

--- a/.agents/scripts/_team_interface_buzz_lm_studio_cli.py
+++ b/.agents/scripts/_team_interface_buzz_lm_studio_cli.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Validate and query LM Studio's supported local CLI surfaces."""
+
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+import subprocess
+
+
+COMMAND_TIMEOUT_SECONDS = 15
+MAX_JSON_BYTES = 1024 * 1024
+MODEL_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/@:+-]{0,255}$")
+
+
+class LMStudioError(ValueError):
+    """Raised when LM Studio's supported local interface is unsafe or unusable."""
+
+
+def validate_executable(candidate, label):
+    """Return one trusted local executable path or raise for an explicit override."""
+    path = Path(os.path.expanduser(candidate))
+    if not path.is_absolute():
+        raise LMStudioError(f"{label} must be an absolute path")
+    try:
+        resolved = path.resolve(strict=True)
+        metadata = resolved.lstat()
+    except OSError as error:
+        raise LMStudioError(f"{label} is unavailable") from error
+    if not stat.S_ISREG(metadata.st_mode) or not os.access(resolved, os.X_OK):
+        raise LMStudioError(f"{label} must be an executable regular file")
+    if metadata.st_uid not in (0, os.getuid()) or stat.S_IMODE(metadata.st_mode) & 0o022:
+        raise LMStudioError(f"{label} permissions are unsafe")
+    return resolved
+
+
+def resolve_lms_cli():
+    """Resolve LM Studio's supported CLI without launching the GUI application."""
+    configured = os.environ.get("AIDEVOPS_LM_STUDIO_CLI")
+    if configured:
+        return validate_executable(configured, "AIDEVOPS_LM_STUDIO_CLI")
+    candidates = []
+    path_candidate = shutil.which("lms")
+    if path_candidate:
+        candidates.append(path_candidate)
+    candidates.append(str(Path.home() / ".lmstudio" / "bin" / "lms"))
+    for candidate in candidates:
+        try:
+            return validate_executable(candidate, "LM Studio CLI")
+        except LMStudioError:
+            continue
+    return None
+
+
+def run_json_command(executable, arguments, label):
+    """Run one bounded fixed-argument JSON command."""
+    try:
+        result = subprocess.run(  # nosec B603 -- validated executable and fixed argv
+            [str(executable), *arguments],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=COMMAND_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise LMStudioError(f"{label} failed") from error
+    if result.returncode != 0:
+        raise LMStudioError(f"{label} exited unsuccessfully")
+    if len(result.stdout.encode("utf-8")) > MAX_JSON_BYTES:
+        raise LMStudioError(f"{label} output exceeded its size limit")
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise LMStudioError(f"{label} returned invalid JSON") from error
+
+
+def validated_model_identifier(value):
+    """Return one prompt-safe LM Studio model identifier."""
+    if not isinstance(value, str) or not MODEL_IDENTIFIER_PATTERN.fullmatch(value):
+        return None
+    return value
+
+
+def loaded_llm_identifiers(value):
+    """Extract sorted unique identifiers for currently loaded LLMs."""
+    if not isinstance(value, list):
+        raise LMStudioError("LM Studio loaded-model response has an unexpected shape")
+    identifiers = set()
+    for record in value:
+        if not isinstance(record, dict) or str(record.get("type", "")).casefold() != "llm":
+            continue
+        identifier = validated_model_identifier(
+            record.get("identifier") or record.get("modelKey") or record.get("modelIdentifier")
+        )
+        if identifier:
+            identifiers.add(identifier)
+    return sorted(identifiers, key=lambda item: (item.casefold(), item))

--- a/.agents/scripts/_team_interface_buzz_lm_studio_member.py
+++ b/.agents/scripts/_team_interface_buzz_lm_studio_member.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Build the optional LM Studio member for an aidevops Buzz team snapshot."""
+
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import importlib.util
+from pathlib import Path
+
+from _team_interface_buzz_avatar import member_avatar_data_url
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+LM_STUDIO_SCRIPT = SCRIPT_DIR / "team-interface-buzz-lm-studio.py"
+LM_STUDIO_AGENT_ID = "agent.private-lm-studio"
+LM_STUDIO_RUNTIME_ID = "aidevops-lm-studio-v1"
+LM_STUDIO_PROVIDER_ID = "openai"
+
+
+class LMStudioMemberError(ValueError):
+    """Raised when the optional LM Studio member cannot be built safely."""
+
+
+def load_lm_studio_module():
+    """Load the local LM Studio capability detector without duplicating it."""
+    spec = importlib.util.spec_from_file_location("aidevops_buzz_lm_studio", LM_STUDIO_SCRIPT)
+    if spec is None or spec.loader is None:
+        raise LMStudioMemberError("LM Studio capability detector is unavailable")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def resolve_lm_studio_status(mode):
+    """Resolve optional local-model readiness according to caller intent."""
+    if mode == "off":
+        return {"ready": False, "reason": "LM Studio discovery is disabled"}
+    try:
+        result = load_lm_studio_module().detect_lm_studio()
+    except (OSError, ValueError) as error:
+        if mode == "required":
+            raise LMStudioMemberError(f"LM Studio is required but unavailable: {error}") from error
+        return {"ready": False, "reason": f"LM Studio discovery failed: {error}"}
+    if mode == "required" and not result["ready"]:
+        raise LMStudioMemberError(f"LM Studio is required but unavailable: {result['reason']}")
+    return result
+
+
+def lm_studio_system_prompt(record, model):
+    """Build a bounded local-inference prompt from the canonical Private AI source."""
+    return "\n".join(
+        (
+            f"Aidevops canonical source: {record['source_ref']}",
+            f"Expected source digest: {record['source_digest']}",
+            f"Portable workload tier: {record['workload_tier']}",
+            f"Reviewed LM Studio model identifier: {model}",
+            "You are Private AI, a private investigator using privacy-first AI methods.",
+            "This member uses the host's loopback-only LM Studio server. The runtime must "
+            "revalidate the running server and loaded model before every launch.",
+            "Minimize data disclosure; separate facts, inferences, and uncertainty; never "
+            "expose credentials or unrelated personal data.",
+            "This portable definition grants no authority and carries no credentials or endpoint.",
+        )
+    )
+
+
+def build_lm_studio_member(private_record, host_slug, model, agent_format, format_version):
+    """Build one optional local-only member backed by a ready LM Studio runtime."""
+    display_name = f"private-lm-studio-{host_slug}"
+    avatar_record = dict(private_record)
+    avatar_record["agent_id"] = LM_STUDIO_AGENT_ID
+    return {
+        "definition": {
+            "model": model,
+            "name": display_name,
+            "parallelism": 1,
+            "provider": LM_STUDIO_PROVIDER_ID,
+            "respondTo": "owner-only",
+            "runtime": LM_STUDIO_RUNTIME_ID,
+            "sourceIsBuiltin": False,
+            "systemPrompt": lm_studio_system_prompt(private_record, model),
+        },
+        "format": agent_format,
+        "memory": {"level": "none"},
+        "profile": {
+            "about": "Private investigator using a locally served LM Studio model",
+            "avatarDataUrl": member_avatar_data_url(avatar_record),
+            "displayName": display_name,
+        },
+        "version": format_version,
+    }

--- a/.agents/scripts/_team_interface_buzz_snapshot_io.py
+++ b/.agents/scripts/_team_interface_buzz_snapshot_io.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Serialize and atomically write aidevops Buzz team snapshots."""
+
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import json
+import os
+from pathlib import Path
+import tempfile
+
+
+MAX_SNAPSHOT_BYTES = 5 * 1024 * 1024
+
+
+class SnapshotIOError(ValueError):
+    """Raised when a snapshot output cannot be produced safely."""
+
+
+def serialized_snapshot(snapshot):
+    """Return stable pretty-printed UTF-8 JSON bytes."""
+    payload = (json.dumps(snapshot, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    if len(payload) > MAX_SNAPSHOT_BYTES:
+        raise SnapshotIOError("generated Buzz team snapshot exceeds the 5 MiB decoded limit")
+    return payload
+
+
+def validate_output_path(output_path, agents_dir, ensure_output_is_not_source):
+    """Validate an explicit caller-owned output without following a target symlink."""
+    expanded = Path(os.path.expanduser(output_path))
+    if expanded.is_symlink():
+        raise SnapshotIOError("output must not replace a symbolic link")
+    parent = expanded.parent.resolve()
+    if not parent.is_dir():
+        raise SnapshotIOError("output parent directory is unavailable")
+    resolved = parent / expanded.name
+    ensure_output_is_not_source(resolved, agents_dir)
+    return resolved
+
+
+def downloads_output_path(agents_dir, ensure_output_is_not_source):
+    """Resolve the user-facing native-import destination under Downloads."""
+    configured = os.environ.get("AIDEVOPS_DOWNLOADS_DIR")
+    downloads = Path(os.path.expanduser(configured)) if configured else Path.home() / "Downloads"
+    if not downloads.is_absolute():
+        raise SnapshotIOError("AIDEVOPS_DOWNLOADS_DIR must be absolute")
+    downloads.mkdir(mode=0o700, parents=False, exist_ok=True)
+    return validate_output_path(
+        downloads / "aidevops.team.json", agents_dir, ensure_output_is_not_source
+    )
+
+
+def atomic_write(output_path, payload):
+    """Atomically replace one explicit output with an owner-only regular file."""
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{output_path.name}.", dir=output_path.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        descriptor = -1
+        os.replace(temporary_path, output_path)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        temporary_path.unlink(missing_ok=True)

--- a/.agents/scripts/buzz-team-provision-helper.sh
+++ b/.agents/scripts/buzz-team-provision-helper.sh
@@ -11,6 +11,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/shared-constants.sh"
 
 GENERATOR="${SCRIPT_DIR}/team-interface-buzz-team-snapshot.py"
+LM_STUDIO_HELPER="${SCRIPT_DIR}/team-interface-buzz-lm-studio.py"
 RUNTIME_HELPER="${SCRIPT_DIR}/team-interface-buzz-runtime.py"
 PYTHON_BIN="${AIDEVOPS_PYTHON_BIN:-python3}"
 
@@ -18,15 +19,35 @@ usage() {
 	printf '%s\n' \
 		'Usage:' \
 		'  buzz-team-provision-helper.sh status' \
-		'  buzz-team-provision-helper.sh generate [--agents-dir DIR] [--host-slug NAME] [--output FILE]' \
+		'  buzz-team-provision-helper.sh generate [--agents-dir DIR] [--host-slug NAME] [--output FILE|--stdout]' \
 		'  buzz-team-provision-helper.sh submit [--agents-dir DIR] [--host-slug NAME]' \
+		'  buzz-team-provision-helper.sh lm-studio-status [--require]' \
 		'  buzz-team-provision-helper.sh runtime-manifest --project-root DIR [--output FILE]' \
 		'  buzz-team-provision-helper.sh runtime-install --project-root DIR [--app-data-dir DIR] [--replace]' \
-		'  Add --runtime interactive for the full OpenCode runtime used by team snapshots.' \
+		'  Add --runtime interactive or --runtime lm-studio for snapshot runtimes.' \
 		'' \
-		'generate and runtime-manifest are local-only. submit queues one deterministic' \
+		'generate defaults to ~/Downloads/aidevops.team.json; use --stdout for pipelines.' \
+		'runtime-manifest is local-only. submit queues one deterministic' \
 		'draft for explicit review. runtime-install requires Buzz to be stopped.'
 	return 0
+}
+
+generate_snapshot() {
+	local has_destination="false"
+	local argument=""
+	for argument in "$@"; do
+		case "$argument" in
+		--output | --stdout | --downloads)
+			has_destination="true"
+			;;
+		esac
+	done
+	if [[ "$has_destination" == "true" ]]; then
+		"$PYTHON_BIN" "$GENERATOR" generate "$@"
+		return $?
+	fi
+	"$PYTHON_BIN" "$GENERATOR" generate "$@" --downloads
+	return $?
 }
 
 main() {
@@ -37,8 +58,16 @@ main() {
 	local command="$1"
 	shift
 	case "$command" in
-	status | generate | submit)
+	status | submit)
 		"$PYTHON_BIN" "$GENERATOR" "$command" "$@"
+		return $?
+		;;
+	generate)
+		generate_snapshot "$@"
+		return $?
+		;;
+	lm-studio-status)
+		"$PYTHON_BIN" "$LM_STUDIO_HELPER" status "$@"
 		return $?
 		;;
 	runtime-manifest)

--- a/.agents/scripts/team-interface-buzz-lm-studio.py
+++ b/.agents/scripts/team-interface-buzz-lm-studio.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Detect a ready LM Studio runtime and launch Buzz Agent against it."""
+
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+from _team_interface_buzz_lm_studio_cli import (
+    LMStudioError,
+    loaded_llm_identifiers,
+    resolve_lms_cli,
+    run_json_command,
+    validate_executable,
+    validated_model_identifier,
+)
+
+
+def running_server_port(status_value):
+    """Return the validated port for a running server, or None when stopped."""
+    if not isinstance(status_value, dict) or not isinstance(status_value.get("running"), bool):
+        raise LMStudioError("LM Studio server status has an unexpected shape")
+    port = None
+    if status_value["running"]:
+        port = status_value.get("port")
+        if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
+            raise LMStudioError("LM Studio server did not report a valid local port")
+    return port
+
+
+def select_loaded_model(identifiers):
+    """Select one reviewed loaded LLM and return it with any skip reason."""
+    selected = None
+    reason = None
+    configured_model = os.environ.get("AIDEVOPS_LM_STUDIO_MODEL")
+    if not identifiers:
+        reason = "LM Studio has no loaded LLM"
+    elif configured_model:
+        configured_model = validated_model_identifier(configured_model)
+        if configured_model is None:
+            raise LMStudioError("AIDEVOPS_LM_STUDIO_MODEL is invalid")
+        if configured_model in identifiers:
+            selected = configured_model
+        else:
+            reason = "configured LM Studio model is not loaded"
+    elif len(identifiers) == 1:
+        selected = identifiers[0]
+    else:
+        reason = "multiple LM Studio LLMs are loaded; set AIDEVOPS_LM_STUDIO_MODEL explicitly"
+    return selected, reason
+
+
+def detect_lm_studio():
+    """Return a bounded readiness result from the official local CLI surfaces."""
+    cli = resolve_lms_cli()
+    result = {
+        "ready": False,
+        "reason": "LM Studio CLI is unavailable; open LM Studio once to install lms",
+    }
+    if cli is None:
+        return result
+    status_value = run_json_command(
+        cli, ["server", "status", "--json", "--quiet"], "LM Studio server status"
+    )
+    port = running_server_port(status_value)
+    if port is None:
+        result["reason"] = "LM Studio server is not running"
+    else:
+        loaded_value = run_json_command(cli, ["ps", "--json"], "LM Studio loaded-model query")
+        selected, reason = select_loaded_model(loaded_llm_identifiers(loaded_value))
+        if selected:
+            result = {"model": selected, "port": port, "ready": True, "reason": "ready"}
+        else:
+            result["reason"] = reason
+    return result
+
+
+def resolve_buzz_agent():
+    """Resolve the bundled Buzz Agent command inherited through Buzz Desktop PATH."""
+    configured = os.environ.get("AIDEVOPS_BUZZ_AGENT_BIN")
+    if configured:
+        return validate_executable(configured, "AIDEVOPS_BUZZ_AGENT_BIN")
+    candidate = shutil.which("buzz-agent")
+    if not candidate:
+        raise LMStudioError("buzz-agent is unavailable in the Buzz runtime PATH")
+    return validate_executable(candidate, "buzz-agent")
+
+
+def exec_buzz_agent(arguments):
+    """Fail closed unless LM Studio is ready, then replace this process with Buzz Agent."""
+    status_value = detect_lm_studio()
+    if not status_value["ready"]:
+        raise LMStudioError(status_value["reason"])
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "BUZZ_AGENT_PROVIDER": "openai",
+            "OPENAI_COMPAT_API": "chat",
+            "OPENAI_COMPAT_API_KEY": "lm-studio",
+            "OPENAI_COMPAT_BASE_URL": f"http://127.0.0.1:{status_value['port']}/v1",
+            "OPENAI_COMPAT_MODEL": status_value["model"],
+        }
+    )
+    executable = resolve_buzz_agent()
+    os.execve(executable, [str(executable), *arguments], environment)
+
+
+def parse_args(argv=None):
+    """Parse the status and runtime entry points."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    status_command = commands.add_parser("status", help="report bounded LM Studio readiness")
+    status_command.add_argument("--require", action="store_true", help="exit non-zero unless ready")
+    exec_command = commands.add_parser("exec", help="launch Buzz Agent against ready LM Studio")
+    exec_command.add_argument("agent_args", nargs=argparse.REMAINDER)
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    """Report readiness or launch the local Buzz Agent runtime."""
+    args = parse_args(argv)
+    if args.command == "exec":
+        agent_args = args.agent_args[1:] if args.agent_args[:1] == ["--"] else args.agent_args
+        exec_buzz_agent(agent_args)
+        return 0
+    status_value = detect_lm_studio()
+    print(json.dumps(status_value, sort_keys=True, separators=(",", ":")))
+    if args.require and not status_value["ready"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (LMStudioError, OSError, subprocess.SubprocessError, ValueError) as error:
+        print(f"team-interface-buzz-lm-studio: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/.agents/scripts/team-interface-buzz-runtime.py
+++ b/.agents/scripts/team-interface-buzz-runtime.py
@@ -40,6 +40,11 @@ RUNTIME_PROFILES = {
         "id": "aidevops-interactive-v1",
         "manifest": AGENTS_DIR / "configs" / "buzz-runtime-aidevops-interactive-v1.json",
     },
+    "lm-studio": {
+        "command": "aidevops-buzz-lm-studio-acp",
+        "id": "aidevops-lm-studio-v1",
+        "manifest": AGENTS_DIR / "configs" / "buzz-runtime-aidevops-lm-studio-v1.json",
+    },
 }
 EXPECTED_MANIFEST_KEYS = {
     "args",

--- a/.agents/scripts/team-interface-buzz-team-snapshot.py
+++ b/.agents/scripts/team-interface-buzz-team-snapshot.py
@@ -6,7 +6,6 @@
 
 import argparse
 import importlib.util
-import json
 import os
 from pathlib import Path
 import re
@@ -18,6 +17,18 @@ import sys
 import tempfile
 
 from _team_interface_buzz_avatar import member_avatar_data_url
+from _team_interface_buzz_lm_studio_member import (
+    LMStudioMemberError,
+    build_lm_studio_member,
+    resolve_lm_studio_status,
+)
+from _team_interface_buzz_snapshot_io import (
+    SnapshotIOError,
+    atomic_write,
+    downloads_output_path as resolve_downloads_output_path,
+    serialized_snapshot,
+    validate_output_path as validate_snapshot_output_path,
+)
 
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -29,7 +40,6 @@ BUZZ_TEAM_FORMAT = "buzz-team-snapshot"
 BUZZ_AGENT_FORMAT = "buzz-agent-snapshot"
 FORMAT_VERSION = 1
 CLI_TIMEOUT_SECONDS = 30
-MAX_SNAPSHOT_BYTES = 5 * 1024 * 1024
 AIDEVOPS_RUNTIME_ID = "aidevops-interactive-v1"
 PRIVATE_AGENT_ID = "agent.private-local-ai"
 PRIVATE_RUNTIME_ID = "buzz-agent"
@@ -166,8 +176,8 @@ def build_member(record, host_slug):
     }
 
 
-def build_team_snapshot(agents_dir, host_slug=None):
-    """Resolve the canonical roster and build one deterministic team snapshot."""
+def build_team_snapshot_with_status(agents_dir, host_slug=None, lm_studio_mode="auto"):
+    """Build one snapshot plus its bounded optional LM Studio detection result."""
     resolved_host_slug = resolve_host_slug(host_slug)
     roster_module = load_roster_module()
     roster = roster_module.build_roster(agents_dir)
@@ -186,9 +196,25 @@ def build_team_snapshot(agents_dir, host_slug=None):
         roster["agents"],
         key=lambda record: (buzz_display_name(record, resolved_host_slug), record["agent_id"]),
     )
-    return {
+    members = [build_member(record, resolved_host_slug) for record in records]
+    lm_studio_status = resolve_lm_studio_status(lm_studio_mode)
+    if lm_studio_status["ready"]:
+        private_record = next(record for record in records if record["agent_id"] == PRIVATE_AGENT_ID)
+        members.append(
+            build_lm_studio_member(
+                private_record,
+                resolved_host_slug,
+                lm_studio_status["model"],
+                BUZZ_AGENT_FORMAT,
+                FORMAT_VERSION,
+            )
+        )
+    members.sort(key=lambda member: member["profile"]["displayName"])
+    if len(members) != len({member["profile"]["displayName"] for member in members}):
+        raise ProvisioningError("generated snapshot contains duplicate Buzz display names")
+    snapshot = {
         "format": BUZZ_TEAM_FORMAT,
-        "members": [build_member(record, resolved_host_slug) for record in records],
+        "members": members,
         "team": {
             "description": "Canonical aidevops specialists generated from the installed roster.",
             "instructions": (
@@ -197,52 +223,34 @@ def build_team_snapshot(agents_dir, host_slug=None):
                 "verification, isolated persistent worktree and session storage, and Buzz "
                 "credential separation. Private AI uses reviewed Buzz shared-compute routing, "
                 "which does not prove local or on-device execution. Buzz access policy controls "
-                "ingress; aidevops security, approval, destructive-operation, publication, and "
+                "ingress. When present, Private LM Studio uses only the runtime-revalidated "
+                "loopback server and loaded model. "
+                "Aidevops security, approval, destructive-operation, publication, and "
                 "release rules remain authoritative."
             ),
             "name": TEAM_NAME,
         },
         "version": FORMAT_VERSION,
     }
+    return snapshot, lm_studio_status
 
 
-def serialized_snapshot(snapshot):
-    """Return stable pretty-printed UTF-8 JSON bytes."""
-    payload = (json.dumps(snapshot, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
-    if len(payload) > MAX_SNAPSHOT_BYTES:
-        raise ProvisioningError("generated Buzz team snapshot exceeds the 5 MiB decoded limit")
-    return payload
+def build_team_snapshot(agents_dir, host_slug=None, lm_studio_mode="auto"):
+    """Resolve the canonical roster and build one deterministic team snapshot."""
+    snapshot, _status = build_team_snapshot_with_status(agents_dir, host_slug, lm_studio_mode)
+    return snapshot
 
 
 def validate_output_path(output_path, agents_dir):
     """Validate an explicit caller-owned output without following a target symlink."""
-    expanded = Path(os.path.expanduser(output_path))
-    if expanded.is_symlink():
-        raise ProvisioningError("output must not replace a symbolic link")
-    parent = expanded.parent.resolve()
-    if not parent.is_dir():
-        raise ProvisioningError("output parent directory is unavailable")
-    resolved = parent / expanded.name
-    load_roster_module().ensure_output_is_not_source(resolved, agents_dir)
-    return resolved
+    source_guard = load_roster_module().ensure_output_is_not_source
+    return validate_snapshot_output_path(output_path, agents_dir, source_guard)
 
 
-def atomic_write(output_path, payload):
-    """Atomically replace one explicit output with an owner-only regular file."""
-    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{output_path.name}.", dir=output_path.parent)
-    temporary_path = Path(temporary_name)
-    try:
-        os.fchmod(descriptor, 0o600)
-        with os.fdopen(descriptor, "wb") as handle:
-            handle.write(payload)
-            handle.flush()
-            os.fsync(handle.fileno())
-        descriptor = -1
-        os.replace(temporary_path, output_path)
-    finally:
-        if descriptor >= 0:
-            os.close(descriptor)
-        temporary_path.unlink(missing_ok=True)
+def downloads_output_path(agents_dir):
+    """Resolve the user-facing native-import destination under Downloads."""
+    source_guard = load_roster_module().ensure_output_is_not_source
+    return resolve_downloads_output_path(agents_dir, source_guard)
 
 
 def resolve_buzz_cli():
@@ -294,9 +302,13 @@ def require_private_temp_root():
     return root
 
 
-def submit_snapshot(agents_dir, host_slug=None):
+def submit_snapshot(agents_dir, host_slug=None, lm_studio_mode="auto"):
     """Queue one generated snapshot for explicit owner review in Buzz Desktop."""
-    payload = serialized_snapshot(build_team_snapshot(agents_dir, host_slug))
+    snapshot, lm_studio_status = build_team_snapshot_with_status(
+        agents_dir, host_slug, lm_studio_mode
+    )
+    report_lm_studio_status(lm_studio_status)
+    payload = serialized_snapshot(snapshot)
     cli = resolve_buzz_cli()
     run_buzz_cli(cli, ["desktop", "status"])
     temp_root = require_private_temp_root()
@@ -316,14 +328,35 @@ def parse_args(argv=None):
     generate = commands.add_parser("generate", help="generate a deterministic team snapshot")
     generate.add_argument("--agents-dir", default=DEFAULT_AGENTS_DIR)
     generate.add_argument("--host-slug")
-    generate.add_argument("--output", help="optional atomic mode-600 output path")
+    generate.add_argument(
+        "--lm-studio",
+        choices=("auto", "off", "required"),
+        default=os.environ.get("AIDEVOPS_BUZZ_LM_STUDIO", "auto"),
+    )
+    destination = generate.add_mutually_exclusive_group()
+    destination.add_argument("--output", help="atomic mode-600 output path")
+    destination.add_argument("--downloads", action="store_true", help="write to ~/Downloads")
+    destination.add_argument("--stdout", action="store_true", help="write JSON to stdout")
 
     commands.add_parser("status", help="check the local Buzz Desktop broker")
 
     submit = commands.add_parser("submit", help="queue a generated snapshot for Desktop review")
     submit.add_argument("--agents-dir", default=DEFAULT_AGENTS_DIR)
     submit.add_argument("--host-slug")
+    submit.add_argument(
+        "--lm-studio",
+        choices=("auto", "off", "required"),
+        default=os.environ.get("AIDEVOPS_BUZZ_LM_STUDIO", "auto"),
+    )
     return parser.parse_args(argv)
+
+
+def report_lm_studio_status(status_value):
+    """Report why the optional local member was included or skipped."""
+    if status_value["ready"]:
+        print(f"LM Studio member included with loaded model: {status_value['model']}", file=sys.stderr)
+    else:
+        print(f"LM Studio member skipped: {status_value['reason']}", file=sys.stderr)
 
 
 def main(argv=None):
@@ -338,13 +371,23 @@ def main(argv=None):
         raise ProvisioningError(f"agents directory does not exist: {args.agents_dir}")
 
     if args.command == "submit":
-        submit_snapshot(agents_dir, args.host_slug)
+        submit_snapshot(agents_dir, args.host_slug, args.lm_studio)
         return 0
 
-    payload = serialized_snapshot(build_team_snapshot(agents_dir, args.host_slug))
+    snapshot, lm_studio_status = build_team_snapshot_with_status(
+        agents_dir, args.host_slug, args.lm_studio
+    )
+    report_lm_studio_status(lm_studio_status)
+    payload = serialized_snapshot(snapshot)
     if args.output:
         output_path = validate_output_path(args.output, agents_dir)
         atomic_write(output_path, payload)
+        print(f"Generated Buzz team snapshot: {output_path}", file=sys.stderr)
+        return 0
+    if args.downloads:
+        output_path = downloads_output_path(agents_dir)
+        atomic_write(output_path, payload)
+        print(f"Generated Buzz team snapshot: {output_path}", file=sys.stderr)
         return 0
     sys.stdout.buffer.write(payload)
     return 0
@@ -353,6 +396,6 @@ def main(argv=None):
 if __name__ == "__main__":
     try:
         raise SystemExit(main())
-    except (OSError, ProvisioningError, ValueError) as error:
+    except (LMStudioMemberError, OSError, ProvisioningError, SnapshotIOError, ValueError) as error:
         print(f"team-interface-buzz-team-snapshot: {error}", file=sys.stderr)
         raise SystemExit(1) from error

--- a/.agents/scripts/tests/test-agent-bin-shim-sync.sh
+++ b/.agents/scripts/tests/test-agent-bin-shim-sync.sh
@@ -91,6 +91,7 @@ printf '#!/usr/bin/env bash\n' >"${tmp_target}/bin/gh_create_issue"
 printf '#!/usr/bin/env bash\n' >"${tmp_target}/bin/opencode-acp"
 printf '#!/usr/bin/env bash\n' >"${tmp_target}/bin/aidevops-buzz-acp"
 printf '#!/usr/bin/env bash\n' >"${tmp_target}/bin/aidevops-buzz-acp-interactive"
+printf '#!/usr/bin/env bash\n' >"${tmp_target}/bin/aidevops-buzz-lm-studio-acp"
 printf '#!/usr/bin/env bash\n' >"${tmp_target}/bin/aidevops-auto-update"
 printf '#!/usr/bin/env bash\n' >"${tmp_target}/bin/aidevops-repo-sync"
 printf '#!/usr/bin/env bash\n' >"${tmp_target}/scripts/auto-update-helper.sh"
@@ -99,6 +100,7 @@ chmod +x "${tmp_target}/bin/gh_create_pr" "${tmp_target}/bin/gh_create_issue" \
 	"${tmp_target}/bin/opencode-acp" \
 	"${tmp_target}/bin/aidevops-buzz-acp" \
 	"${tmp_target}/bin/aidevops-buzz-acp-interactive" \
+	"${tmp_target}/bin/aidevops-buzz-lm-studio-acp" \
 	"${tmp_target}/bin/aidevops-auto-update" "${tmp_target}/bin/aidevops-repo-sync" \
 	"${tmp_target}/scripts/auto-update-helper.sh" "${tmp_target}/scripts/repo-sync-helper.sh"
 
@@ -127,6 +129,8 @@ assert_symlink_target "restricted Buzz ACP shim is linked into user PATH bin" \
 	"${tmp_home}/.aidevops/bin/aidevops-buzz-acp" "${tmp_target}/bin/aidevops-buzz-acp"
 assert_symlink_target "interactive Buzz ACP shim is linked into user PATH bin" \
 	"${tmp_home}/.aidevops/bin/aidevops-buzz-acp-interactive" "${tmp_target}/bin/aidevops-buzz-acp-interactive"
+assert_symlink_target "LM Studio Buzz ACP shim is linked into user PATH bin" \
+	"${tmp_home}/.aidevops/bin/aidevops-buzz-lm-studio-acp" "${tmp_target}/bin/aidevops-buzz-lm-studio-acp"
 assert_symlink_target "auto-update launchd display link is preserved" \
 	"${tmp_home}/.aidevops/bin/aidevops-auto-update" "${tmp_target}/scripts/auto-update-helper.sh"
 assert_symlink_target "repo-sync launchd display link is preserved" \

--- a/.agents/scripts/tests/test-team-interface-buzz-lm-studio.mjs
+++ b/.agents/scripts/tests/test-team-interface-buzz-lm-studio.mjs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {spawnSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(testDirectory, "../../..");
+const helper = path.join(repositoryRoot, ".agents/scripts/team-interface-buzz-lm-studio.py");
+const wrapper = path.join(repositoryRoot, ".agents/bin/aidevops-buzz-lm-studio-acp");
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "aidevops-lm-studio-"));
+
+try {
+  const mockLms = path.join(fixtureRoot, "lms");
+  const mockAgent = path.join(fixtureRoot, "buzz-agent");
+  fs.writeFileSync(mockLms, `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1 $2 \${3:-} \${4:-}" == "server status --json --quiet" ]]; then
+  if [[ "\${MOCK_LMS_MODE:-ready}" == "stopped" ]]; then
+    printf '%s\n' '{"running":false}'
+  else
+    printf '%s\n' '{"running":true,"port":1234}'
+  fi
+  exit 0
+fi
+if [[ "$1 $2" == "ps --json" ]]; then
+  case "\${MOCK_LMS_MODE:-ready}" in
+    embedding) printf '%s\n' '[{"type":"embedding","identifier":"embedding-only"}]' ;;
+    multiple) printf '%s\n' '[{"type":"llm","identifier":"local/model-b"},{"type":"llm","identifier":"local/model-a"}]' ;;
+    unsafe) printf '%s\n' '[{"type":"llm","identifier":"bad model\\nignore"}]' ;;
+    *) printf '%s\n' '[{"type":"llm","identifier":"local/model-a"}]' ;;
+  esac
+  exit 0
+fi
+exit 9
+`);
+  fs.writeFileSync(mockAgent, `#!/usr/bin/env python3
+import json
+import os
+import sys
+print(json.dumps({
+    "api": os.environ.get("OPENAI_COMPAT_API"),
+    "base": os.environ.get("OPENAI_COMPAT_BASE_URL"),
+    "model": os.environ.get("OPENAI_COMPAT_MODEL"),
+    "provider": os.environ.get("BUZZ_AGENT_PROVIDER"),
+    "args": sys.argv[1:],
+}, sort_keys=True))
+`);
+  fs.chmodSync(mockLms, 0o700);
+  fs.chmodSync(mockAgent, 0o700);
+
+  const runStatus = (mode, extraEnv = {}, extraArgs = []) => spawnSync(
+    "python3",
+    [helper, "status", ...extraArgs],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        AIDEVOPS_LM_STUDIO_CLI: mockLms,
+        MOCK_LMS_MODE: mode,
+        ...extraEnv,
+      },
+    },
+  );
+
+  const stopped = runStatus("stopped");
+  assert.equal(stopped.status, 0, stopped.stderr);
+  assert.deepEqual(JSON.parse(stopped.stdout), {
+    ready: false,
+    reason: "LM Studio server is not running",
+  });
+
+  const embedding = runStatus("embedding");
+  assert.equal(embedding.status, 0, embedding.stderr);
+  assert.equal(JSON.parse(embedding.stdout).ready, false);
+  assert.match(JSON.parse(embedding.stdout).reason, /no loaded LLM/);
+
+  const ready = runStatus("ready");
+  assert.equal(ready.status, 0, ready.stderr);
+  assert.deepEqual(JSON.parse(ready.stdout), {
+    model: "local/model-a",
+    port: 1234,
+    ready: true,
+    reason: "ready",
+  });
+
+  const multiple = runStatus("multiple");
+  assert.equal(multiple.status, 0, multiple.stderr);
+  assert.match(JSON.parse(multiple.stdout).reason, /set AIDEVOPS_LM_STUDIO_MODEL/);
+  const selected = runStatus("multiple", {AIDEVOPS_LM_STUDIO_MODEL: "local/model-b"});
+  assert.equal(selected.status, 0, selected.stderr);
+  assert.equal(JSON.parse(selected.stdout).model, "local/model-b");
+
+  const required = runStatus("stopped", {}, ["--require"]);
+  assert.equal(required.status, 1);
+  const unsafe = runStatus("unsafe", {}, ["--require"]);
+  assert.equal(unsafe.status, 1);
+
+  const launched = spawnSync(wrapper, ["--fixture-argument"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      AIDEVOPS_BUZZ_AGENT_BIN: mockAgent,
+      AIDEVOPS_LM_STUDIO_CLI: mockLms,
+      MOCK_LMS_MODE: "ready",
+    },
+  });
+  assert.equal(launched.status, 0, launched.stderr);
+  assert.deepEqual(JSON.parse(launched.stdout), {
+    api: "chat",
+    args: ["--fixture-argument"],
+    base: "http://127.0.0.1:1234/v1",
+    model: "local/model-a",
+    provider: "openai",
+  });
+} finally {
+  fs.rmSync(fixtureRoot, {recursive: true, force: true});
+}
+
+console.log("PASS: LM Studio Buzz runtime requires a running server and one reviewed loaded LLM");

--- a/.agents/scripts/tests/test-team-interface-buzz-runtime.mjs
+++ b/.agents/scripts/tests/test-team-interface-buzz-runtime.mjs
@@ -17,6 +17,10 @@ const interactiveRuntimeWrapper = path.join(
   agentsDirectory,
   "bin/aidevops-buzz-acp-interactive",
 );
+const lmStudioRuntimeWrapper = path.join(
+  agentsDirectory,
+  "bin/aidevops-buzz-lm-studio-acp",
+);
 const snapshotGenerator = path.join(
   agentsDirectory,
   "scripts/team-interface-buzz-team-snapshot.py",
@@ -28,6 +32,10 @@ const canonicalManifest = path.join(
 const interactiveCanonicalManifest = path.join(
   agentsDirectory,
   "configs/buzz-runtime-aidevops-interactive-v1.json",
+);
+const lmStudioCanonicalManifest = path.join(
+  agentsDirectory,
+  "configs/buzz-runtime-aidevops-lm-studio-v1.json",
 );
 const opencodeNodeModules = path.join(os.homedir(), ".config/opencode/node_modules");
 
@@ -97,9 +105,14 @@ try {
     stableBinDirectory,
     "aidevops-buzz-acp-interactive",
   );
+  const stableLmStudioRuntimeCommand = path.join(
+    stableBinDirectory,
+    "aidevops-buzz-lm-studio-acp",
+  );
   fs.mkdirSync(stableBinDirectory, {recursive: true, mode: 0o700});
   fs.symlinkSync(runtimeWrapper, stableRuntimeCommand);
   fs.symlinkSync(interactiveRuntimeWrapper, stableInteractiveRuntimeCommand);
+  fs.symlinkSync(lmStudioRuntimeWrapper, stableLmStudioRuntimeCommand);
   fs.mkdirSync(projectRoot, {mode: 0o700});
   requireSuccess(
     spawnSync("/usr/bin/git", ["-C", projectRoot, "init", "--quiet"], {encoding: "utf8"}),
@@ -274,6 +287,14 @@ try {
   assert.equal(interactiveSourceManifest.label, "Aidevops Full Interactive V1");
   assert.deepEqual(interactiveSourceManifest.env, {});
 
+  const lmStudioSourceManifest = JSON.parse(
+    fs.readFileSync(lmStudioCanonicalManifest, "utf8"),
+  );
+  assert.equal(lmStudioSourceManifest.command, "aidevops-buzz-lm-studio-acp");
+  assert.equal(lmStudioSourceManifest.id, "aidevops-lm-studio-v1");
+  assert.equal(lmStudioSourceManifest.label, "Aidevops Local LM Studio V1");
+  assert.deepEqual(lmStudioSourceManifest.env, {});
+
   const materialized = requireSuccess(
     runHelper(["manifest", "--project-root", projectRoot, "--repos", reposPath], {
       env: {...process.env, HOME: fixtureHome},
@@ -305,6 +326,26 @@ try {
   assert.equal(interactiveMaterializedManifest.command, stableInteractiveRuntimeCommand);
   assert.equal(interactiveMaterializedManifest.id, "aidevops-interactive-v1");
   assert.deepEqual(interactiveMaterializedManifest.env, {
+    AIDEVOPS_BUZZ_PROJECT_ROOT: projectRoot,
+    BUZZ_ACP_CWD: projectRoot,
+  });
+
+  const lmStudioMaterialized = requireSuccess(
+    runHelper([
+      "manifest",
+      "--runtime",
+      "lm-studio",
+      "--project-root",
+      projectRoot,
+      "--repos",
+      reposPath,
+    ], {env: {...process.env, HOME: fixtureHome}}),
+    "LM Studio runtime manifest materialization",
+  );
+  const lmStudioMaterializedManifest = JSON.parse(lmStudioMaterialized.stdout);
+  assert.equal(lmStudioMaterializedManifest.command, stableLmStudioRuntimeCommand);
+  assert.equal(lmStudioMaterializedManifest.id, "aidevops-lm-studio-v1");
+  assert.deepEqual(lmStudioMaterializedManifest.env, {
     AIDEVOPS_BUZZ_PROJECT_ROOT: projectRoot,
     BUZZ_ACP_CWD: projectRoot,
   });
@@ -370,6 +411,30 @@ try {
     AIDEVOPS_REMOTE_REQUIRE_PINNED_RUNTIME: "1",
     BUZZ_ACP_CWD: projectRoot,
   });
+
+  requireSuccess(
+    runHelper([
+      "install",
+      "--runtime",
+      "lm-studio",
+      "--project-root",
+      projectRoot,
+      "--repos",
+      reposPath,
+      "--app-data-dir",
+      appDataDirectory,
+    ], {env: installEnvironment}),
+    "LM Studio runtime installation",
+  );
+  const installedLmStudioPath = path.join(
+    appDataDirectory,
+    "custom_harnesses/aidevops-lm-studio-v1.json",
+  );
+  assert.equal(fs.statSync(installedLmStudioPath).mode & 0o777, 0o600);
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(installedLmStudioPath, "utf8")),
+    lmStudioMaterializedManifest,
+  );
   const anchorMarker = JSON.parse(fs.readFileSync(
     path.join(runtimeAnchor, "buzz-runtime-anchor-v1.json"),
     "utf8",

--- a/.agents/scripts/tests/test-team-interface-buzz-team-snapshot.mjs
+++ b/.agents/scripts/tests/test-team-interface-buzz-team-snapshot.mjs
@@ -16,7 +16,11 @@ const helper = path.join(repositoryRoot, ".agents/scripts/buzz-team-provision-he
 function runGenerator(argumentsList, options = {}) {
   return spawnSync("python3", [generator, ...argumentsList], {
     encoding: "utf8",
-    env: {...process.env, AIDEVOPS_BUZZ_HOST_SLUG: "test-host-01"},
+    env: {
+      ...process.env,
+      AIDEVOPS_BUZZ_HOST_SLUG: "test-host-01",
+      AIDEVOPS_BUZZ_LM_STUDIO: "off",
+    },
     ...options,
   });
 }
@@ -188,6 +192,44 @@ try {
     new Set(fixtureFirst.members.map(({profile}) => profile.avatarDataUrl)).size,
     fixtureFirst.members.length,
   );
+
+  const mockLms = path.join(fixtureRoot, "lms-mock.sh");
+  fs.writeFileSync(mockLms, `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1 $2 \${3:-} \${4:-}" == "server status --json --quiet" ]]; then
+  printf '%s\n' '{"running":true,"port":1234}'
+  exit 0
+fi
+if [[ "$1 $2" == "ps --json" ]]; then
+  printf '%s\n' '[{"type":"llm","identifier":"local/tool-model"}]'
+  exit 0
+fi
+exit 9
+`);
+  fs.chmodSync(mockLms, 0o700);
+  const localSnapshot = requireSuccess(
+    runGenerator(
+      ["generate", "--agents-dir", agentsDirectory, "--lm-studio", "required"],
+      {
+        env: {
+          ...process.env,
+          AIDEVOPS_BUZZ_HOST_SLUG: "test-host-01",
+          AIDEVOPS_LM_STUDIO_CLI: mockLms,
+        },
+      },
+    ),
+    "LM Studio snapshot generation",
+  );
+  const localMember = localSnapshot.members.find(
+    ({profile}) => profile.displayName === "private-lm-studio-test-host-01",
+  );
+  assert.ok(localMember, "ready LM Studio did not add its separate local member");
+  assert.equal(localMember.definition.runtime, "aidevops-lm-studio-v1");
+  assert.equal(localMember.definition.provider, "openai");
+  assert.equal(localMember.definition.model, "local/tool-model");
+  assert.match(localMember.definition.systemPrompt, /loopback-only LM Studio server/);
+  assert.doesNotMatch(JSON.stringify(localMember), /127\.0\.0\.1|localhost|OPENAI_COMPAT/);
+  assert.equal(localSnapshot.members.length, fixtureFirst.members.length + 1);
   assert.match(
     fixtureFirst.members.find(
       ({profile}) => profile.displayName === "automate-test-host-01",
@@ -221,6 +263,31 @@ try {
   assert.equal(outputResult.status, 0, outputResult.stderr);
   assert.equal(fs.statSync(outputPath).mode & 0o777, 0o600);
   assert.deepEqual(JSON.parse(fs.readFileSync(outputPath, "utf8")), changed);
+
+  const downloadsDirectory = path.join(fixtureRoot, "Downloads");
+  fs.mkdirSync(downloadsDirectory, {mode: 0o700});
+  const defaultDownload = spawnSync(
+    helper,
+    ["generate", "--agents-dir", agentsDirectory, "--host-slug", "test-host-01", "--lm-studio", "off"],
+    {
+      encoding: "utf8",
+      env: {...process.env, AIDEVOPS_DOWNLOADS_DIR: downloadsDirectory},
+    },
+  );
+  assert.equal(defaultDownload.status, 0, defaultDownload.stderr);
+  assert.equal(defaultDownload.stdout, "", "interactive helper default must not dump JSON to stdout");
+  const downloadedSnapshotPath = path.join(downloadsDirectory, "aidevops.team.json");
+  assert.equal(fs.statSync(downloadedSnapshotPath).mode & 0o777, 0o600);
+  assert.deepEqual(JSON.parse(fs.readFileSync(downloadedSnapshotPath, "utf8")), changed);
+  assert.match(defaultDownload.stderr, /Generated Buzz team snapshot:/);
+
+  const explicitStdout = spawnSync(
+    helper,
+    ["generate", "--agents-dir", agentsDirectory, "--host-slug", "test-host-01", "--lm-studio", "off", "--stdout"],
+    {encoding: "utf8", env: process.env},
+  );
+  assert.equal(explicitStdout.status, 0, explicitStdout.stderr);
+  assert.deepEqual(JSON.parse(explicitStdout.stdout), changed);
 
   const symlinkPath = path.join(fixtureRoot, "snapshot-link.json");
   fs.symlinkSync(outputPath, symlinkPath);
@@ -259,6 +326,7 @@ printf '{"queued":true}\\n'
         ...process.env,
         AIDEVOPS_BUZZ_CLI: mockBuzz,
         AIDEVOPS_BUZZ_HOST_SLUG: "test-host-01",
+        AIDEVOPS_BUZZ_LM_STUDIO: "off",
         AIDEVOPS_TEMP_DIR: managedTemp,
         MOCK_BUZZ_LOG: brokerLog,
         MOCK_BUZZ_SNAPSHOT: brokerSnapshot,
@@ -283,6 +351,7 @@ printf '{"queued":true}\\n'
         ...process.env,
         AIDEVOPS_BUZZ_CLI: mockBuzz,
         AIDEVOPS_BUZZ_HOST_SLUG: "test-host-01",
+        AIDEVOPS_BUZZ_LM_STUDIO: "off",
         AIDEVOPS_TEMP_DIR: managedTemp,
         MOCK_BUZZ_FAIL_STATUS: "1",
         MOCK_BUZZ_LOG: brokerLog,


### PR DESCRIPTION
## Summary

Add a fail-closed LM Studio Buzz runtime that is included only when the official lms CLI reports a running server and one reviewed loaded LLM. Default interactive team snapshots to ~/Downloads while preserving explicit pipeline output, 0600 permissions, the existing Private AI member, and secret-free serialization.

## Files Changed

.agents/bin/aidevops-buzz-lm-studio-acp, .agents/configs/buzz-runtime-aidevops-lm-studio-v1.json, .agents/reference/team-interface-buzz-provisioning.md, .agents/scripts/_team_interface_buzz_avatar.py, .agents/scripts/buzz-team-provision-helper.sh, .agents/scripts/team-interface-buzz-lm-studio.py, .agents/scripts/team-interface-buzz-runtime.py, .agents/scripts/team-interface-buzz-team-snapshot.py, .agents/scripts/tests/test-agent-bin-shim-sync.sh, .agents/scripts/tests/test-team-interface-buzz-lm-studio.mjs, .agents/scripts/tests/test-team-interface-buzz-runtime.mjs, .agents/scripts/tests/test-team-interface-buzz-team-snapshot.mjs

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — node --test .agents/scripts/tests/test-team-interface-buzz-lm-studio.mjs; node --test .agents/scripts/tests/test-team-interface-buzz-team-snapshot.mjs; node --test .agents/scripts/tests/test-team-interface-buzz-runtime.mjs; bash .agents/scripts/tests/test-agent-bin-shim-sync.sh; shellcheck changed shell files; git diff --check; .agents/scripts/linters-local.sh --changed

Resolves #29879


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.246 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1d 23h and 14,651,518 tokens on this with the user in an interactive session.