### PR TITLE
GH#29890: Reconcile authorized aggregate release receipts

### DIFF
--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -297,7 +297,7 @@ _full_loop_release_evidence_path() {
 	local pr_number="$2"
 	local evidence_type="$3"
 	local receipt_path=""
-	case "$evidence_type" in aggregate | authorization-gap | failure | successor) ;; *) return 1 ;; esac
+	case "$evidence_type" in aggregate | authorization-gap | failure | inclusion | successor) ;; *) return 1 ;; esac
 	receipt_path=$(_full_loop_release_receipt_path "$repo" "$pr_number") || return 1
 	printf '%s.%s.json\n' "${receipt_path%.status}" "$evidence_type"
 	return 0
@@ -577,6 +577,49 @@ _full_loop_write_superseded_release_receipt() {
 	_full_loop_write_release_receipt "$repo" "$pr_number" "$_FULL_LOOP_RELEASE_SUPERSEDED" || return 1
 	_full_loop_update_superseded_cleanup_receipt "$repo" "$pr_number"
 	return $?
+}
+
+_full_loop_write_authorized_aggregate_inclusion() {
+	local repo="$1"
+	local pr_number="$2"
+	local source_merge="$3"
+	local aggregate_pr="$4"
+	local aggregate_merge="$5"
+	local tag_name="$6"
+	local tag_commit="$7"
+	local evidence_path=""
+	local now=""
+	[[ "$pr_number" =~ ^[0-9]+$ && "$aggregate_pr" =~ ^[0-9]+$ ]] || return 1
+	[[ "$source_merge" =~ $_FULL_LOOP_SHA40_REGEX && "$aggregate_merge" =~ $_FULL_LOOP_SHA40_REGEX && "$tag_commit" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+	[[ "$tag_name" =~ $_FULL_LOOP_VERSION_TAG_REGEX ]] || return 1
+	evidence_path=$(_full_loop_release_evidence_path "$repo" "$pr_number" inclusion) || return 1
+	if [[ -f "$evidence_path" ]]; then
+		jq -e --arg repo "$repo" --argjson pr_number "$pr_number" \
+			--arg source_merge "$source_merge" --argjson aggregate_pr "$aggregate_pr" \
+			--arg aggregate_merge "$aggregate_merge" --arg tag "$tag_name" \
+			--arg tag_commit "$tag_commit" --arg prior_status "$_FULL_LOOP_RELEASE_NOT_REQUESTED" '
+			.schema_version == 1 and .evidence_type == "authorized-aggregate-inclusion"
+			and .status == "included" and .prior_release_status == $prior_status
+			and .repository == $repo and .pr_number == $pr_number
+			and .source_merge == $source_merge and .aggregate_pr == $aggregate_pr
+			and .aggregate_merge == $aggregate_merge and .release_tag == $tag
+			and .release_commit == $tag_commit
+		' "$evidence_path" >/dev/null 2>&1
+		return $?
+	fi
+	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+	mkdir -p "${evidence_path%/*}" || return 1
+	jq -cn --arg repo "$repo" --argjson pr_number "$pr_number" \
+		--arg source_merge "$source_merge" --argjson aggregate_pr "$aggregate_pr" \
+		--arg aggregate_merge "$aggregate_merge" --arg tag "$tag_name" \
+		--arg tag_commit "$tag_commit" --arg prior_status "$_FULL_LOOP_RELEASE_NOT_REQUESTED" --arg now "$now" '
+		{schema_version:1,evidence_type:"authorized-aggregate-inclusion",status:"included",
+		 prior_release_status:$prior_status,repository:$repo,pr_number:$pr_number,
+		 source_merge:$source_merge,aggregate_pr:$aggregate_pr,aggregate_merge:$aggregate_merge,
+		 release_tag:$tag,release_commit:$tag_commit,recorded_at:$now}
+	' >"${evidence_path}.tmp.$$" || return 1
+	mv "${evidence_path}.tmp.$$" "$evidence_path" || return 1
+	return 0
 }
 
 _full_loop_update_superseded_cleanup_receipt() {

--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -171,6 +171,15 @@ _full_loop_validate_release_candidates() {
 		[[ -f "$candidate_receipt" ]] && IFS= read -r candidate_status <"$candidate_receipt" || true
 		case "$candidate_status" in
 		"" | "$_FULL_LOOP_PHASE_FAILED") ;;
+		"$_FULL_LOOP_RELEASE_NOT_REQUESTED")
+			jq -e --argjson candidate_pr "$candidate_pr" '
+				.mode == "aggregate"
+				and any(.aggregated_sources[]?; .pr == $candidate_pr)
+			' <<<"$source_json" >/dev/null || {
+				printf 'Cannot aggregate terminal release:%s evidence for PR #%s\n' "$candidate_status" "$candidate_pr" >&2
+				return 1
+			}
+			;;
 		*)
 			printf 'Cannot aggregate terminal release:%s evidence for PR #%s\n' "$candidate_status" "$candidate_pr" >&2
 			return 1
@@ -191,13 +200,23 @@ _full_loop_persist_release_success() {
 	local tag_commit=""
 	local aggregated_pr=""
 	local aggregated_merge=""
+	local aggregated_receipt=""
+	local aggregated_status=""
 	IFS= read -r version <"$release_path/VERSION" || return 1
 	tag_name="v${version}"
 	tag_commit=$(git -C "$release_path" rev-parse "refs/tags/${tag_name}^{commit}" 2>/dev/null) || return 1
 	while IFS=$'\t' read -r aggregated_pr aggregated_merge; do
 		[[ -n "$aggregated_pr" ]] || continue
-		_full_loop_write_superseded_release_receipt "$repo" "$aggregated_pr" "$aggregated_merge" \
-			"$release_source_pr" "$release_source_merge" "$tag_name" "$tag_commit" || return 1
+		aggregated_receipt=$(_full_loop_release_receipt_path "$repo" "$aggregated_pr") || return 1
+		aggregated_status=""
+		[[ -f "$aggregated_receipt" ]] && IFS= read -r aggregated_status <"$aggregated_receipt" || true
+		if [[ "$aggregated_status" == "$_FULL_LOOP_RELEASE_NOT_REQUESTED" ]]; then
+			_full_loop_write_authorized_aggregate_inclusion "$repo" "$aggregated_pr" "$aggregated_merge" \
+				"$release_source_pr" "$release_source_merge" "$tag_name" "$tag_commit" || return 1
+		else
+			_full_loop_write_superseded_release_receipt "$repo" "$aggregated_pr" "$aggregated_merge" \
+				"$release_source_pr" "$release_source_merge" "$tag_name" "$tag_commit" || return 1
+		fi
 	done < <(jq -r '.aggregated_sources[] | [.pr,.merge] | @tsv' <<<"$source_json")
 	_full_loop_write_release_receipt "$repo" "$release_source_pr" "$_FULL_LOOP_RELEASE_PUBLISHED"
 	return $?

--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -351,6 +351,8 @@ _full_loop_release_find_workflow_run() {
 	local push_runs=""
 	local recovery_runs=""
 	local display_title="Publish ${tag_name}"
+	local selection_mode="${4:-latest}"
+	[[ "$selection_mode" == "latest" || "$selection_mode" == "successful" ]] || return 1
 
 	_FULL_LOOP_RELEASE_RUN_JSON=""
 	push_runs=$(gh api --method GET "repos/${repo}/actions/workflows/publish-packages.yml/runs" \
@@ -362,6 +364,8 @@ _full_loop_release_find_workflow_run() {
 	_FULL_LOOP_RELEASE_RUN_JSON=$(jq -cn --arg sha "$tag_commit" --arg tag "$tag_name" --arg title "$display_title" \
 		--arg push_event "$_FULL_LOOP_RELEASE_EVENT_PUSH" \
 		--arg recovery_event "$_FULL_LOOP_RELEASE_EVENT_RECOVERY" \
+		--arg selection_mode "$selection_mode" --arg completed "$_FULL_LOOP_RELEASE_STATUS_COMPLETED" \
+		--arg success "$_FULL_LOOP_RELEASE_CONCLUSION_SUCCESS" \
 		--arg string_type "$_FULL_LOOP_RELEASE_JSON_STRING_TYPE" \
 		--argjson push "$push_runs" --argjson recovery "$recovery_runs" '
 		([($push.workflow_runs[]? | select(.event == $push_event and .head_branch == $tag and .head_sha == $sha))]
@@ -370,6 +374,9 @@ _full_loop_release_find_workflow_run() {
 				and ((.head_sha | type) == $string_type)
 				and (.head_sha | test("^[0-9a-f]{40}$"))
 				and .display_title == ($title + " [" + $sha + "." + .head_sha + "]")))])
+		| if $selection_mode == "successful" then
+			map(select(.status == $completed and .conclusion == $success))
+		  else . end
 		| sort_by(.created_at // "") | last // empty
 	') || return 1
 	[[ -n "$_FULL_LOOP_RELEASE_RUN_JSON" && "$_FULL_LOOP_RELEASE_RUN_JSON" != "null" ]] || return 3
@@ -687,6 +694,14 @@ _full_loop_release_inspect_remote() {
 		return 8
 	fi
 	if [[ "$run_conclusion" != "success" ]]; then
+		if _full_loop_release_find_workflow_run "$repo" "$tag_name" "$tag_commit" successful; then
+			run_url=$(jq -r '.html_url // ""' <<<"$_FULL_LOOP_RELEASE_RUN_JSON") || return 1
+			[[ -z "$run_url" ]] || printf 'RECOVERED_WORKFLOW_URL=%s\n' "$run_url"
+			if _full_loop_release_verify_channels "$repo" "$tag_name"; then
+				printf 'RELEASE_REMOTE_STATE=published\n'
+				return 0
+			fi
+		fi
 		printf 'WORKFLOW_CONCLUSION=%s\n' "${run_conclusion:-unknown}"
 		return 4
 	fi

--- a/.agents/scripts/tests/test-full-loop-release-aggregate-receipts.sh
+++ b/.agents/scripts/tests/test-full-loop-release-aggregate-receipts.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Aggregate release receipt reconciliation regression tests.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+mkdir -p "${TEST_ROOT}/receipts" "${TEST_ROOT}/release"
+
+# shellcheck source=../full-loop-release-helper.sh
+source "${SCRIPT_DIR}/full-loop-release-helper.sh" help >/dev/null
+
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="${TEST_ROOT}/receipts"
+export AIDEVOPS_FULL_LOOP_RECEIPT_DIR
+
+sha90=$(printf '%040d' 90)
+sha91=$(printf '%040d' 91)
+sha99=$(printf '%040d' 99)
+expected_tag_commit=$(printf '%040d' 123)
+source_json=$(jq -cn --arg sha90 "$sha90" --arg sha91 "$sha91" --arg sha99 "$sha99" '
+	{mode:"aggregate",source_pr:99,source_merge:$sha99,
+	 aggregated_sources:[{pr:90,merge:$sha90},{pr:91,merge:$sha91}]}
+')
+
+printf 'not-requested\n' >"${TEST_ROOT}/receipts/test_repo-90.status"
+_full_loop_validate_release_candidates test/repo "$source_json" || {
+	printf 'FAIL authorized aggregate rejected prior release:not-requested evidence\n'
+	exit 1
+}
+
+direct_json=$(jq -cn --arg sha90 "$sha90" '{mode:"direct",source_pr:90,source_merge:$sha90,aggregated_sources:[]}')
+if _full_loop_validate_release_candidates test/repo "$direct_json" >/dev/null 2>&1; then
+	printf 'FAIL direct release replaced terminal release:not-requested evidence\n'
+	exit 1
+fi
+printf 'PASS only exact aggregate members may retain release:not-requested evidence\n'
+
+printf 'published\n' >"${TEST_ROOT}/receipts/test_repo-91.status"
+if _full_loop_validate_release_candidates test/repo "$source_json" >/dev/null 2>&1; then
+	printf 'FAIL aggregate accepted an already published source receipt\n'
+	exit 1
+fi
+rm -f "${TEST_ROOT}/receipts/test_repo-91.status"
+
+printf '1.2.3\n' >"${TEST_ROOT}/release/VERSION"
+git() {
+	local args="$*"
+	if [[ "$args" == *" rev-parse refs/tags/v1.2.3^{commit}"* ]]; then
+		printf '%s\n' "$expected_tag_commit"
+		return 0
+	fi
+	return 1
+}
+_full_loop_update_superseded_cleanup_receipt() {
+	return 0
+}
+
+_full_loop_persist_release_success test/repo "${TEST_ROOT}/release" "$source_json" 99 "$sha99" || {
+	printf 'FAIL authorized aggregate release receipts did not persist\n'
+	exit 1
+}
+_full_loop_persist_release_success test/repo "${TEST_ROOT}/release" "$source_json" 99 "$sha99" || {
+	printf 'FAIL authorized aggregate release receipt persistence was not idempotent\n'
+	exit 1
+}
+
+if [[ "$(<"${TEST_ROOT}/receipts/test_repo-90.status")" != "not-requested" ]] ||
+	[[ "$(<"${TEST_ROOT}/receipts/test_repo-91.status")" != "superseded" ]] ||
+	[[ "$(<"${TEST_ROOT}/receipts/test_repo-99.status")" != "published" ]]; then
+	printf 'FAIL aggregate reconciliation rewrote historical receipt semantics\n'
+	exit 1
+fi
+jq -e --arg source_merge "$sha90" --arg aggregate_merge "$sha99" \
+	--arg release_commit "$expected_tag_commit" '
+	.evidence_type == "authorized-aggregate-inclusion" and .status == "included"
+	and .prior_release_status == "not-requested" and .pr_number == 90
+	and .source_merge == $source_merge and .aggregate_pr == 99
+	and .aggregate_merge == $aggregate_merge and .release_tag == "v1.2.3"
+	and .release_commit == $release_commit
+' "${TEST_ROOT}/receipts/test_repo-90.inclusion.json" >/dev/null || {
+	printf 'FAIL authorized aggregate inclusion evidence was incomplete\n'
+	exit 1
+}
+
+printf 'PASS aggregate publication preserves no-release receipts with auditable inclusion evidence\n'
+exit 0

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -527,11 +527,17 @@ if [[ "$args" == *" -f event=push "* ]]; then
 fi
 if [[ "$args" == *" -f event=workflow_dispatch "* ]]; then
 	correlated_title='Publish v1.2.3 [3333333333333333333333333333333333333333.4444444444444444444444444444444444444444]'
+	recovery_status='queued'
+	recovery_conclusion='null'
 	if [[ "${FAKE_RECOVERY_CORRELATION_MODE:-valid}" == "mismatch" ]]; then
 		correlated_title='Publish v1.2.3 [3333333333333333333333333333333333333333.5555555555555555555555555555555555555555]'
 	fi
-	printf '{"workflow_runs":[{"id":11,"event":"workflow_dispatch","head_branch":"main","head_sha":"4444444444444444444444444444444444444444","status":"queued","conclusion":null,"created_at":"2026-07-27T00:01:00Z","display_title":"%s","html_url":"recovery-url"}]}\n' \
-		"$correlated_title"
+	if [[ "${FAKE_RECOVERY_RUN_MODE:-pending}" == "failed" ]]; then
+		recovery_status='completed'
+		recovery_conclusion='"failure"'
+	fi
+	printf '{"workflow_runs":[{"id":11,"event":"workflow_dispatch","head_branch":"main","head_sha":"4444444444444444444444444444444444444444","status":"%s","conclusion":%s,"created_at":"2026-07-27T00:01:00Z","display_title":"%s","html_url":"recovery-url"}]}\n' \
+		"$recovery_status" "$recovery_conclusion" "$correlated_title"
 	exit 0
 fi
 if [[ "$args" == *"releases/tags/v1.2.3"* ]]; then
@@ -598,6 +604,7 @@ chmod +x "${TEST_ROOT}/bin/git" "${TEST_ROOT}/bin/npm" "${TEST_ROOT}/bin/curl"
 PATH="${TEST_ROOT}/bin:${PATH}"
 export FAKE_RUN_SCHEMA_MODE=valid
 export FAKE_RECOVERY_CORRELATION_MODE=valid
+export FAKE_RECOVERY_RUN_MODE=pending
 export FAKE_PUSH_BRANCH_MODE=valid
 export FAKE_RELEASE_DRAFT=0
 export FAKE_NPM_VERSION=1.2.3
@@ -648,6 +655,21 @@ if [[ "$(jq -r '.id' <<<"$_FULL_LOOP_RELEASE_RUN_JSON")" != "11" ]]; then
 	exit 1
 fi
 printf 'PASS exact push and recovery workflow runs are correlated durably\n'
+
+export FAKE_RECOVERY_RUN_MODE=failed
+recovered_run_output="${TEST_ROOT}/recovered-run-output.txt"
+_full_loop_release_inspect_remote test/repo v1.2.3 >"$recovered_run_output" || {
+	printf 'FAIL successful exact-tag publication was downgraded by a later transient recovery failure\n'
+	exit 1
+}
+if [[ "$(jq -r '.id' <<<"$_FULL_LOOP_RELEASE_RUN_JSON")" != "10" ]] ||
+	! grep -qx 'RECOVERED_WORKFLOW_URL=push-url' "$recovered_run_output" ||
+	! grep -qx 'RELEASE_REMOTE_STATE=published' "$recovered_run_output"; then
+	printf 'FAIL exact-tag reconciliation did not preserve the prior successful workflow evidence\n'
+	exit 1
+fi
+export FAKE_RECOVERY_RUN_MODE=pending
+printf 'PASS later transient recovery failures cannot downgrade verified publication\n'
 
 export FAKE_RECOVERY_CORRELATION_MODE=mismatch
 _full_loop_release_find_workflow_run test/repo v1.2.3 3333333333333333333333333333333333333333


### PR DESCRIPTION
## Summary

Preserve terminal release:not-requested receipts through authorised aggregate publication, write exact inclusion evidence, and prefer a prior successful exact-tag workflow over a later transient duplicate failure.

## Files Changed

.agents/scripts/full-loop-helper-state.sh, .agents/scripts/full-loop-release-helper.sh, .agents/scripts/full-loop-release-reconcile.sh, .agents/scripts/tests/test-full-loop-release-aggregate-receipts.sh, .agents/scripts/tests/test-full-loop-release-reconcile.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: focused aggregate receipt and release reconciliation regressions passed; ShellCheck and linters-local.sh passed on all five changed shell files.

Resolves #29890


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.246 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 6h 52m and 3,395,064 tokens on this with the user in an interactive session.