### PR TITLE
GH#29891: Restrict terminal receipt recovery to post-publication reconciliation

### DIFF
--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -27,6 +27,9 @@ _FULL_LOOP_STATE_LIB_LOADED=1
 _FULL_LOOP_RELEASE_NOT_REQUESTED="not-requested"
 _FULL_LOOP_RELEASE_PUBLISHED="published"
 _FULL_LOOP_RELEASE_SUPERSEDED="superseded"
+_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED="published-reconcile"
+_FULL_LOOP_RELEASE_EVIDENCE_RECEIPT_CONFLICT="receipt-conflict"
+_FULL_LOOP_RELEASE_ROLE_AGGREGATED="aggregated"
 _FULL_LOOP_SHA40_REGEX='^[0-9a-f]{40}$'
 _FULL_LOOP_VERSION_TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+$'
 _FULL_LOOP_JSON_NUMBER_TYPE="number"
@@ -297,7 +300,7 @@ _full_loop_release_evidence_path() {
 	local pr_number="$2"
 	local evidence_type="$3"
 	local receipt_path=""
-	case "$evidence_type" in aggregate | authorization-gap | failure | successor) ;; *) return 1 ;; esac
+	case "$evidence_type" in aggregate | authorization-gap | failure | receipt-conflict | successor) ;; *) return 1 ;; esac
 	receipt_path=$(_full_loop_release_receipt_path "$repo" "$pr_number") || return 1
 	printf '%s.%s.json\n' "${receipt_path%.status}" "$evidence_type"
 	return 0
@@ -498,6 +501,224 @@ _full_loop_write_release_authorization_gap_evidence() {
 	return 0
 }
 
+_full_loop_release_candidate_evidence_matches() {
+	local repo="$1"
+	local pr_number="$2"
+	local source_merge="$3"
+	local aggregate_pr="$4"
+	local aggregate_merge="$5"
+	local tag_name="$6"
+	local tag_commit="$7"
+	local evidence_type="$8"
+	local evidence_path=""
+	evidence_path=$(_full_loop_release_evidence_path "$repo" "$pr_number" "$evidence_type") || return 1
+	[[ -f "$evidence_path" ]] || return 1
+	if [[ "$evidence_type" == "aggregate" ]]; then
+		_full_loop_verify_aggregate_superseded_release_evidence \
+			"$evidence_path" "$repo" "$pr_number" || return 1
+	elif [[ "$evidence_type" == "$_FULL_LOOP_RELEASE_EVIDENCE_RECEIPT_CONFLICT" ]]; then
+		jq -e --arg repo "$repo" --argjson pr_number "$pr_number" \
+			--arg source_merge "$source_merge" --argjson aggregate_pr "$aggregate_pr" \
+			--arg aggregate_merge "$aggregate_merge" --arg tag_name "$tag_name" \
+			--arg tag_commit "$tag_commit" --arg evidence_status "$_FULL_LOOP_RELEASE_EVIDENCE_RECEIPT_CONFLICT" \
+			--arg preserved_status "$_FULL_LOOP_RELEASE_NOT_REQUESTED" '
+			.schema_version == 1 and .evidence_type == "published-aggregate-terminal-receipt-conflict"
+			and .status == $evidence_status and .repository == $repo and .pr_number == $pr_number
+			and .source_merge == $source_merge and .aggregate_pr == $aggregate_pr
+			and .aggregate_merge == $aggregate_merge and .release_tag == $tag_name
+			and .release_commit == $tag_commit and .preserved_receipt_status == $preserved_status
+			and (.terminal_cleanup_evidence | not)
+		' "$evidence_path" >/dev/null 2>&1
+		return $?
+	else
+		return 1
+	fi
+	jq -e --arg source_merge "$source_merge" --argjson aggregate_pr "$aggregate_pr" \
+		--arg aggregate_merge "$aggregate_merge" --arg tag_name "$tag_name" \
+		--arg tag_commit "$tag_commit" '
+		.source_merge == $source_merge and .aggregate_pr == $aggregate_pr
+		and .aggregate_merge == $aggregate_merge and .release_tag == $tag_name
+		and .release_commit == $tag_commit
+	' "$evidence_path" >/dev/null 2>&1
+	return $?
+}
+
+_full_loop_write_release_receipt_conflict_evidence() {
+	local repo="$1"
+	local pr_number="$2"
+	local source_merge="$3"
+	local aggregate_pr="$4"
+	local aggregate_merge="$5"
+	local tag_name="$6"
+	local tag_commit="$7"
+	local receipt_path=""
+	local receipt_status=""
+	local evidence_path=""
+	local now=""
+	[[ "$pr_number" =~ ^[0-9]+$ && "$aggregate_pr" =~ ^[0-9]+$ ]] || return 1
+	[[ "$source_merge" =~ $_FULL_LOOP_SHA40_REGEX && "$aggregate_merge" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+	[[ "$tag_name" =~ $_FULL_LOOP_VERSION_TAG_REGEX && "$tag_commit" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+	receipt_path=$(_full_loop_release_receipt_path "$repo" "$pr_number") || return 1
+	[[ -f "$receipt_path" ]] || return 1
+	IFS= read -r receipt_status <"$receipt_path" || return 1
+	[[ "$receipt_status" == "$_FULL_LOOP_RELEASE_NOT_REQUESTED" ]] || return 1
+	evidence_path=$(_full_loop_release_evidence_path "$repo" "$pr_number" "$_FULL_LOOP_RELEASE_EVIDENCE_RECEIPT_CONFLICT") || return 1
+	if [[ -f "$evidence_path" ]]; then
+		_full_loop_release_candidate_evidence_matches "$repo" "$pr_number" "$source_merge" \
+			"$aggregate_pr" "$aggregate_merge" "$tag_name" "$tag_commit" \
+			"$_FULL_LOOP_RELEASE_EVIDENCE_RECEIPT_CONFLICT"
+		return $?
+	fi
+	now=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+	mkdir -p "${evidence_path%/*}" || return 1
+	jq -cn --arg repo "$repo" --argjson pr_number "$pr_number" --arg source_merge "$source_merge" \
+		--argjson aggregate_pr "$aggregate_pr" --arg aggregate_merge "$aggregate_merge" \
+		--arg tag_name "$tag_name" --arg tag_commit "$tag_commit" \
+		--arg evidence_status "$_FULL_LOOP_RELEASE_EVIDENCE_RECEIPT_CONFLICT" \
+		--arg preserved_status "$_FULL_LOOP_RELEASE_NOT_REQUESTED" --argjson terminal_cleanup_evidence false \
+		--arg now "$now" '
+		{schema_version:1,evidence_type:"published-aggregate-terminal-receipt-conflict",
+		 status:$evidence_status,repository:$repo,pr_number:$pr_number,source_merge:$source_merge,
+		 aggregate_pr:$aggregate_pr,aggregate_merge:$aggregate_merge,release_tag:$tag_name,
+		 release_commit:$tag_commit,preserved_receipt_status:$preserved_status,recorded_at:$now,
+		 terminal_cleanup_evidence:$terminal_cleanup_evidence}
+	' >"${evidence_path}.tmp.$$" || return 1
+	mv "${evidence_path}.tmp.$$" "$evidence_path" || return 1
+	return 0
+}
+
+_full_loop_read_release_receipt_status() {
+	local receipt_path="$1"
+	local receipt_status=""
+	[[ -n "$receipt_path" ]] || return 1
+	if [[ ! -e "$receipt_path" && ! -L "$receipt_path" ]]; then
+		printf '\n'
+		return 0
+	fi
+	[[ -f "$receipt_path" ]] || return 1
+	IFS= read -r receipt_status <"$receipt_path" || return 1
+	[[ -n "$receipt_status" ]] || return 1
+	printf '%s\n' "$receipt_status"
+	return 0
+}
+
+_full_loop_validate_release_candidates() {
+	local repo="$1"
+	local source_json="$2"
+	local mode="${3:-strict}"
+	local tag_name="${4:-}"
+	local tag_commit="${5:-}"
+	local source_pr=""
+	local source_merge=""
+	local candidate_rows=""
+	local candidate_pr=""
+	local candidate_merge=""
+	local candidate_role=""
+	local candidate_status=""
+	local candidate_receipt=""
+	local conflict_path=""
+	source_pr=$(jq -er '.source_pr' <<<"$source_json") || return 1
+	source_merge=$(jq -er '.source_merge' <<<"$source_json") || return 1
+	candidate_rows=$(jq -er --arg aggregate_role "$_FULL_LOOP_RELEASE_ROLE_AGGREGATED" \
+		'[{pr:.source_pr,merge:.source_merge,role:"source"}]
+		+ [.aggregated_sources[] | {pr,merge,role:$aggregate_role}]
+		| .[] | [.pr,.merge,.role] | @tsv' <<<"$source_json") || return 1
+	if [[ "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" ]]; then
+		[[ "$tag_name" =~ $_FULL_LOOP_VERSION_TAG_REGEX && "$tag_commit" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+	elif [[ "$mode" != "strict" ]]; then
+		return 1
+	fi
+	while IFS=$'\t' read -r candidate_pr candidate_merge candidate_role; do
+		[[ "$candidate_pr" =~ ^[0-9]+$ && "$candidate_merge" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+		candidate_receipt=$(_full_loop_release_receipt_path "$repo" "$candidate_pr") || return 1
+		candidate_status=$(_full_loop_read_release_receipt_status "$candidate_receipt") || return 1
+		case "$candidate_status" in
+		"" | "$_FULL_LOOP_PHASE_FAILED") ;;
+		"$_FULL_LOOP_RELEASE_NOT_REQUESTED")
+			[[ "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" && "$candidate_role" == "$_FULL_LOOP_RELEASE_ROLE_AGGREGATED" ]] || {
+				printf 'Cannot aggregate terminal release:%s evidence for PR #%s\n' "$candidate_status" "$candidate_pr" >&2
+				return 1
+			}
+			conflict_path=$(_full_loop_release_evidence_path "$repo" "$candidate_pr" "$_FULL_LOOP_RELEASE_EVIDENCE_RECEIPT_CONFLICT") || return 1
+			if [[ -f "$conflict_path" ]]; then
+				_full_loop_release_candidate_evidence_matches "$repo" "$candidate_pr" "$candidate_merge" \
+					"$source_pr" "$source_merge" "$tag_name" "$tag_commit" \
+					"$_FULL_LOOP_RELEASE_EVIDENCE_RECEIPT_CONFLICT" || return 1
+			fi
+			;;
+		"$_FULL_LOOP_RELEASE_SUPERSEDED")
+			[[ "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" && "$candidate_role" == "$_FULL_LOOP_RELEASE_ROLE_AGGREGATED" ]] || return 1
+			_full_loop_release_candidate_evidence_matches "$repo" "$candidate_pr" "$candidate_merge" \
+				"$source_pr" "$source_merge" "$tag_name" "$tag_commit" aggregate || return 1
+			;;
+		"$_FULL_LOOP_RELEASE_PUBLISHED")
+			[[ "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" && "$candidate_role" == "source" ]] || return 1
+			;;
+		*)
+			printf 'Cannot aggregate terminal release:%s evidence for PR #%s\n' "$candidate_status" "$candidate_pr" >&2
+			return 1
+			;;
+		esac
+	done <<<"$candidate_rows"
+	return 0
+}
+
+_full_loop_persist_release_success() {
+	local repo="$1"
+	local release_path="$2"
+	local source_json="$3"
+	local release_source_pr="$4"
+	local release_source_merge="$5"
+	local mode="${6:-strict}"
+	local version=""
+	local tag_name=""
+	local tag_commit=""
+	local aggregated_rows=""
+	local aggregated_pr=""
+	local aggregated_merge=""
+	local receipt_path=""
+	local receipt_status=""
+	IFS= read -r version <"$release_path/VERSION" || return 1
+	tag_name="v${version}"
+	tag_commit=$(git -C "$release_path" rev-parse "refs/tags/${tag_name}^{commit}" 2>/dev/null) || return 1
+	aggregated_rows=$(jq -r '.aggregated_sources[] | [.pr,.merge] | @tsv' <<<"$source_json") || return 1
+	while IFS=$'\t' read -r aggregated_pr aggregated_merge; do
+		[[ -n "$aggregated_pr" ]] || continue
+		receipt_path=$(_full_loop_release_receipt_path "$repo" "$aggregated_pr") || return 1
+		receipt_status=$(_full_loop_read_release_receipt_status "$receipt_path") || return 1
+		case "$receipt_status" in
+		"" | "$_FULL_LOOP_PHASE_FAILED")
+			_full_loop_write_superseded_release_receipt "$repo" "$aggregated_pr" "$aggregated_merge" \
+				"$release_source_pr" "$release_source_merge" "$tag_name" "$tag_commit" || return 1
+			;;
+		"$_FULL_LOOP_RELEASE_NOT_REQUESTED")
+			[[ "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" ]] || return 1
+			_full_loop_write_release_receipt_conflict_evidence "$repo" "$aggregated_pr" "$aggregated_merge" \
+				"$release_source_pr" "$release_source_merge" "$tag_name" "$tag_commit" || return 1
+			;;
+		"$_FULL_LOOP_RELEASE_SUPERSEDED")
+			[[ "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" ]] || return 1
+			_full_loop_release_candidate_evidence_matches "$repo" "$aggregated_pr" "$aggregated_merge" \
+				"$release_source_pr" "$release_source_merge" "$tag_name" "$tag_commit" aggregate || return 1
+			_full_loop_update_superseded_cleanup_receipt "$repo" "$aggregated_pr" || return 1
+			;;
+		*) return 1 ;;
+		esac
+	done <<<"$aggregated_rows"
+	receipt_path=$(_full_loop_release_receipt_path "$repo" "$release_source_pr") || return 1
+	receipt_status=$(_full_loop_read_release_receipt_status "$receipt_path") || return 1
+	case "$receipt_status" in
+	"" | "$_FULL_LOOP_PHASE_FAILED")
+		_full_loop_write_release_receipt "$repo" "$release_source_pr" "$_FULL_LOOP_RELEASE_PUBLISHED" || return 1
+		;;
+	"$_FULL_LOOP_RELEASE_PUBLISHED")
+		[[ "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" ]] || return 1
+		;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
 _full_loop_write_release_receipt() {
 	local repo="$1"
 	local pr_number="$2"
@@ -508,7 +729,7 @@ _full_loop_write_release_receipt() {
 	local current_status=""
 	receipt_path=$(_full_loop_release_receipt_path "$repo" "$pr_number") || return 1
 	mkdir -p "${receipt_path%/*}" || return 1
-	[[ -f "$receipt_path" ]] && IFS= read -r current_status <"$receipt_path" || true
+	current_status=$(_full_loop_read_release_receipt_status "$receipt_path") || return 1
 	case "$current_status" in
 	"$_FULL_LOOP_RELEASE_NOT_REQUESTED" | "$_FULL_LOOP_RELEASE_PUBLISHED" | "$_FULL_LOOP_RELEASE_SUPERSEDED")
 		[[ "$current_status" == "$status" ]] || return 1

--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -158,51 +158,6 @@ _full_loop_resolve_requested_release_source() {
 	return 0
 }
 
-_full_loop_validate_release_candidates() {
-	local repo="$1"
-	local source_json="$2"
-	local candidate_pr=""
-	local candidate_status=""
-	local candidate_receipt=""
-	while IFS= read -r candidate_pr; do
-		[[ "$candidate_pr" =~ ^[0-9]+$ ]] || return 1
-		candidate_receipt=$(_full_loop_release_receipt_path "$repo" "$candidate_pr") || return 1
-		candidate_status=""
-		[[ -f "$candidate_receipt" ]] && IFS= read -r candidate_status <"$candidate_receipt" || true
-		case "$candidate_status" in
-		"" | "$_FULL_LOOP_PHASE_FAILED") ;;
-		*)
-			printf 'Cannot aggregate terminal release:%s evidence for PR #%s\n' "$candidate_status" "$candidate_pr" >&2
-			return 1
-			;;
-		esac
-	done < <(jq -r '[.source_pr] + [.aggregated_sources[].pr] | unique[]' <<<"$source_json")
-	return 0
-}
-
-_full_loop_persist_release_success() {
-	local repo="$1"
-	local release_path="$2"
-	local source_json="$3"
-	local release_source_pr="$4"
-	local release_source_merge="$5"
-	local version=""
-	local tag_name=""
-	local tag_commit=""
-	local aggregated_pr=""
-	local aggregated_merge=""
-	IFS= read -r version <"$release_path/VERSION" || return 1
-	tag_name="v${version}"
-	tag_commit=$(git -C "$release_path" rev-parse "refs/tags/${tag_name}^{commit}" 2>/dev/null) || return 1
-	while IFS=$'\t' read -r aggregated_pr aggregated_merge; do
-		[[ -n "$aggregated_pr" ]] || continue
-		_full_loop_write_superseded_release_receipt "$repo" "$aggregated_pr" "$aggregated_merge" \
-			"$release_source_pr" "$release_source_merge" "$tag_name" "$tag_commit" || return 1
-	done < <(jq -r '.aggregated_sources[] | [.pr,.merge] | @tsv' <<<"$source_json")
-	_full_loop_write_release_receipt "$repo" "$release_source_pr" "$_FULL_LOOP_RELEASE_PUBLISHED"
-	return $?
-}
-
 _full_loop_release_validate_existing_tag_authorization() {
 	local repo="$1"
 	local source_pr="$2"

--- a/.agents/scripts/full-loop-release-reconcile.sh
+++ b/.agents/scripts/full-loop-release-reconcile.sh
@@ -767,6 +767,7 @@ _full_loop_release_finalize_reconciliation() {
 	local source_pr=""
 	local source_merge=""
 	local requested_present=""
+	local tag_commit=""
 	local version_manager=""
 	local deploy_helper=""
 
@@ -776,7 +777,9 @@ _full_loop_release_finalize_reconciliation() {
 	requested_present=$(jq -r --argjson requested "$requested_pr" \
 		'([.source_pr] + [.aggregated_sources[].pr]) | any(. == $requested)' <<<"$source_json") || return 1
 	[[ "$requested_present" == "$_FULL_LOOP_RELEASE_TRUE" ]] || return 1
-	_full_loop_validate_release_candidates "$repo" "$source_json" || return 1
+	tag_commit=$(_full_loop_release_resolve_tag_commit "$tag_name") || return 1
+	_full_loop_validate_release_candidates "$repo" "$source_json" \
+		"$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" "$tag_name" "$tag_commit" || return 1
 	_full_loop_release_prepare_tag_worktree "$tag_name" || return 1
 	if declare -F release_lane_update_if_owned >/dev/null 2>&1; then
 		release_lane_update_if_owned "$repo" "$requested_pr" "exact-tag-deployment" "$tag_name" || return 1
@@ -796,7 +799,7 @@ _full_loop_release_finalize_reconciliation() {
 			bash "$version_manager" post-release
 	) || return 1
 	_full_loop_persist_release_success "$repo" "$_FULL_LOOP_RELEASE_PATH" "$source_json" \
-		"$source_pr" "$source_merge"
+		"$source_pr" "$source_merge" "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED"
 	return $?
 }
 

--- a/.agents/scripts/tests/test-full-loop-release-reconcile.sh
+++ b/.agents/scripts/tests/test-full-loop-release-reconcile.sh
@@ -12,6 +12,7 @@ _FULL_LOOP_PHASE_FAILED="failed"
 _FULL_LOOP_RELEASE_PUBLISHED="published"
 _FULL_LOOP_RELEASE_SUPERSEDED="superseded"
 _FULL_LOOP_RELEASE_NOT_REQUESTED="not-requested"
+_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED="published-reconcile"
 TEST_ROOT=$(mktemp -d)
 trap 'rm -rf "$TEST_ROOT"' EXIT
 mkdir -p "${TEST_ROOT}/bin" "${TEST_ROOT}/receipts"
@@ -216,6 +217,87 @@ printf 'PASS signed tag trailers reconstruct release provenance\n'
 	[[ ! -f "${AIDEVOPS_FULL_LOOP_RECEIPT_DIR}/test_repo-29010.status" ]]
 )
 printf 'PASS historical authorization gaps use idempotent detached production evidence\n'
+
+(
+	export AIDEVOPS_FULL_LOOP_RECEIPT_DIR="${TEST_ROOT}/receipt-conflict-receipts"
+	# shellcheck source=../full-loop-helper-state.sh
+	source "${SCRIPT_DIR}/full-loop-helper-state.sh"
+	conflict_release_path="${TEST_ROOT}/receipt-conflict-release"
+	mkdir -p "$conflict_release_path"
+	printf '1.2.5\n' >"${conflict_release_path}/VERSION"
+	conflict_tag_commit="4444444444444444444444444444444444444444"
+	conflict_source_json=$(jq -cn '
+		{source_pr:90,source_merge:"1111111111111111111111111111111111111111",
+		 aggregated_sources:[
+		  {pr:89,merge:"2222222222222222222222222222222222222222"},
+		  {pr:88,merge:"3333333333333333333333333333333333333333"}
+		 ]}
+	')
+	conflict_receipt=$(_full_loop_release_receipt_path test/repo 89)
+	mkdir -p "${conflict_receipt%/*}"
+	git() {
+		local args="$*"
+		case "$args" in
+		*"rev-parse refs/tags/v1.2.5^{commit}"*) printf '%s\n' "$conflict_tag_commit" ;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
+	_full_loop_update_superseded_cleanup_receipt() {
+		return 0
+	}
+	: >"$conflict_receipt"
+	if _full_loop_validate_release_candidates test/repo "$conflict_source_json" \
+		"$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" v1.2.5 "$conflict_tag_commit" >/dev/null 2>&1; then
+		printf 'FAIL published reconciliation accepted an empty receipt\n'
+		exit 1
+	fi
+	if _full_loop_persist_release_success test/repo "$conflict_release_path" "$conflict_source_json" \
+		90 1111111111111111111111111111111111111111 "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" \
+		>/dev/null 2>&1; then
+		printf 'FAIL published reconciliation replaced an empty receipt\n'
+		exit 1
+	fi
+	[[ ! -s "$conflict_receipt" ]]
+	printf '%s\n' "$_FULL_LOOP_RELEASE_NOT_REQUESTED" >"$conflict_receipt"
+	cp "$conflict_receipt" "${TEST_ROOT}/receipt-conflict-original.status"
+	if _full_loop_validate_release_candidates test/repo "$conflict_source_json" >/dev/null 2>&1; then
+		printf 'FAIL release preparation accepted terminal no-release evidence\n'
+		exit 1
+	fi
+	_full_loop_validate_release_candidates test/repo "$conflict_source_json" \
+		"$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" v1.2.5 "$conflict_tag_commit"
+	_full_loop_persist_release_success test/repo "$conflict_release_path" "$conflict_source_json" \
+		90 1111111111111111111111111111111111111111 "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED"
+	cmp -s "$conflict_receipt" "${TEST_ROOT}/receipt-conflict-original.status"
+	grep -qx "$_FULL_LOOP_RELEASE_NOT_REQUESTED" "$conflict_receipt"
+	grep -qx "$_FULL_LOOP_RELEASE_SUPERSEDED" \
+		"${AIDEVOPS_FULL_LOOP_RECEIPT_DIR}/test_repo-88.status"
+	grep -qx "$_FULL_LOOP_RELEASE_PUBLISHED" \
+		"${AIDEVOPS_FULL_LOOP_RECEIPT_DIR}/test_repo-90.status"
+	conflict_evidence=$(_full_loop_release_evidence_path test/repo 89 receipt-conflict)
+	jq -e --arg tag_commit "$conflict_tag_commit" '
+		.evidence_type == "published-aggregate-terminal-receipt-conflict"
+		and .status == "receipt-conflict" and .pr_number == 89 and .aggregate_pr == 90
+		and .preserved_receipt_status == "not-requested" and .release_commit == $tag_commit
+		and (.terminal_cleanup_evidence | not)
+	' "$conflict_evidence" >/dev/null
+	cp "$conflict_evidence" "${TEST_ROOT}/receipt-conflict-original.json"
+	_full_loop_validate_release_candidates test/repo "$conflict_source_json" \
+		"$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" v1.2.5 "$conflict_tag_commit"
+	_full_loop_persist_release_success test/repo "$conflict_release_path" "$conflict_source_json" \
+		90 1111111111111111111111111111111111111111 "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED"
+	cmp -s "$conflict_receipt" "${TEST_ROOT}/receipt-conflict-original.status"
+	cmp -s "$conflict_evidence" "${TEST_ROOT}/receipt-conflict-original.json"
+	conflicting_source_json=$(jq '.aggregated_sources[0].merge = "5555555555555555555555555555555555555555"' \
+		<<<"$conflict_source_json")
+	if _full_loop_validate_release_candidates test/repo "$conflicting_source_json" \
+		"$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" v1.2.5 "$conflict_tag_commit" >/dev/null 2>&1; then
+		printf 'FAIL conflicting receipt-conflict replay replaced immutable evidence\n'
+		exit 1
+	fi
+)
+printf 'PASS published aggregate reconciliation preserves terminal no-release receipts\n'
 
 legacy_source_json_file="${TEST_ROOT}/legacy-source.json"
 (
@@ -464,8 +546,18 @@ printf 'PASS remote and protected-source provenance verification run from the de
 _full_loop_validate_release_candidates() {
 	local repo="$1"
 	local source_json="$2"
-	[[ -n "$repo" && -n "$source_json" ]]
+	local mode="$3"
+	local tag_name="$4"
+	local tag_commit="$5"
+	[[ -n "$repo" && -n "$source_json" && "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" ]] || return 1
+	[[ "$tag_name" == "v1.2.3" && "$tag_commit" == "3333333333333333333333333333333333333333" ]]
 	return $?
+}
+_full_loop_release_resolve_tag_commit() {
+	local tag_name="$1"
+	[[ "$tag_name" == "v1.2.3" ]] || return 1
+	printf '%s\n' '3333333333333333333333333333333333333333'
+	return 0
 }
 _full_loop_persist_release_success() {
 	local repo="$1"
@@ -473,8 +565,10 @@ _full_loop_persist_release_success() {
 	local source_json="$3"
 	local source_pr="$4"
 	local source_merge="$5"
-	printf '%s|%s|%s|%s|%s\n' \
-		"$repo" "$release_path" "$source_json" "$source_pr" "$source_merge" \
+	local mode="$6"
+	[[ "$mode" == "$_FULL_LOOP_RELEASE_RECONCILE_PUBLISHED" ]] || return 1
+	printf '%s|%s|%s|%s|%s|%s\n' \
+		"$repo" "$release_path" "$source_json" "$source_pr" "$source_merge" "$mode" \
 		>"$FAKE_PERSIST_LOG"
 	return 0
 }

--- a/.agents/workflows/release.md
+++ b/.agents/workflows/release.md
@@ -124,6 +124,14 @@ tag and channels, and the latest source's terminal published receipt. It never
 dispatches or deploys the stale tag and does not fabricate aggregate provenance.
 See `reference/release-publication-controls.md` "Post-publication supersession".
 
+If a provenance-valid aggregate was already published before reconciliation
+discovers an included PR's terminal `release:not-requested` receipt, preserve
+that receipt unchanged. Reconciliation may finish only after re-verifying the
+signed tag, exact aggregate membership, publication channels, and release
+ancestry; it records detached `receipt-conflict` evidence for that member rather
+than fabricating `release:superseded`. Preparation of any new release continues
+to reject terminal receipts before publication.
+
 **DO NOT** run separate bump/tag/push commands. **Prerequisites**: terminal-success PR checks/reviews, observed merged state/SHA, authenticated `gh`, an accessible aidevops repository, and unreleased changelog content (or changelog-only `--force`). The helper fetches `origin/main` and creates its own detached release worktree; it does not require or mutate a clean canonical checkout.
 
 **Related**: `workflows/version-bump.md` · `workflows/changelog.md` · `workflows/postflight.md` · `reference/release-artifact-provenance.md` · `.agents/scripts/validate-version-consistency.sh`


### PR DESCRIPTION
## Summary

Keep release preparation strict while allowing only provenance-verified, already-published aggregate reconciliation to preserve terminal release:not-requested receipts. Record exact detached receipt-conflict evidence, reject malformed existing receipts, and retain the prior-success workflow recovery merged in #29892.

## Files Changed

.agents/scripts/full-loop-helper-state.sh, .agents/scripts/full-loop-release-helper.sh, .agents/scripts/full-loop-release-reconcile.sh, .agents/scripts/tests/test-full-loop-release-aggregate-receipts.sh, .agents/scripts/tests/test-full-loop-release-reconcile.sh, .agents/workflows/release.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — bash .agents/scripts/tests/test-full-loop-release-helper.sh; bash .agents/scripts/tests/test-full-loop-release-aggregate-receipts.sh; bash .agents/scripts/tests/test-full-loop-release-reconcile.sh; bash .agents/scripts/tests/test-release-lane.sh; bash .agents/scripts/tests/test-release-provenance-helper.sh; .agents/scripts/linters-local.sh --changed

Resolves #29891


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.246 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 2d and 15,245,455 tokens on this with the user in an interactive session.