### PR TITLE
GH#29873: fix: scope worker activity metrics by repo

### DIFF
--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -165,12 +165,12 @@ OWNER_PROCESS_START=$(_test_process_start_token "$$")
 #                      missing, but historical != null and != "" semantics
 #                      counted false as a non-empty runtime error marker.
 {
-	printf '{"ts":%d,"role":"worker","session_key":"issue-1","result":"success","exit_code":0,"duration_ms":1000,"load_1min":2.0,"load_per_cpu":0.25}\n' "$T_5MIN_AGO"
+	printf '{"ts":%d,"role":"worker","repo_slug":"example/repo-a","session_key":"issue-1","result":"success","exit_code":0,"duration_ms":1000,"load_1min":2.0,"load_per_cpu":0.25}\n' "$T_5MIN_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-2","result":"success","exit_code":0}\n' "$T_2H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-3","session_id":"ses_3","issue_number":22349,"repo_slug":"marcusquinn/aidevops","work_dir":"/tmp/wt-3","output_file":"/tmp/excerpt-3.log","result":"watchdog_stall_killed","failure_reason":"watchdog_stall_killed","launch_failure_cause":"stall_hard_killed","kill_reason":"hard_kill_stall","next_action":"redispatch_worker","exit_code":79}\n' "$T_2H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-4","result":"watchdog_stall_continue","exit_code":0}\n' "$T_5MIN_AGO"
-	printf '{"ts":%d,"role":"worker","session_key":"issue-5","model":"openai/gpt-5.5","provider":"openai","result":"rate_limit","failure_reason":"rate_limit","provider_error_type":"rate_limit","provider_status":"429","classification_source":"output_pattern","classification_pattern":"rate_limit|rate_limit|429|too_many_requests|quota_exceeded","exit_code":1}\n' "$T_2H_AGO"
-	printf '{"ts":%d,"role":"worker","session_key":"issue-6","model":"openai/gpt-5.5","provider":"openai","result":"provider_error","failure_reason":"provider_error","provider_error_type":"server_error","provider_status":"500","classification_source":"output_pattern","classification_pattern":"server_error|5xx|connection_failure|overloaded","launch_failure_cause":"provider_error","next_action":"inspect_failure_excerpt","exit_code":2}\n' "$T_2H_AGO"
+	printf '{"ts":%d,"role":"worker","repo_slug":"example/repo-b","session_key":"issue-5","model":"openai/gpt-5.5","provider":"openai","result":"rate_limit","failure_reason":"rate_limit","provider_error_type":"rate_limit","provider_status":"429","classification_source":"output_pattern","classification_pattern":"rate_limit|rate_limit|429|too_many_requests|quota_exceeded","exit_code":1}\n' "$T_2H_AGO"
+	printf '{"ts":%d,"role":"worker","repo_slug":"example/repo-a","session_key":"issue-6","model":"openai/gpt-5.5","provider":"openai","result":"provider_error","failure_reason":"provider_error","provider_error_type":"server_error","provider_status":"500","classification_source":"output_pattern","classification_pattern":"server_error|5xx|connection_failure|overloaded","launch_failure_cause":"provider_error","next_action":"inspect_failure_excerpt","exit_code":2}\n' "$T_2H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-7","result":"success","exit_code":0}\n' "$T_25H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-8","result":"watchdog_stall_continue","exit_code":124}\n' "$T_2H_AGO"
 	printf '{"ts":%d,"role":"worker","session_key":"issue-9","result":"success","exit_code":0}\n' "$T_FUTURE_SENTINEL"
@@ -394,6 +394,10 @@ assert_eq "2k: missing key returns 0" "0" \
 	"$(printf '%s' "$JSON" | jq -r '.pulse_stats.dispatch_backoff_skipped')"
 assert_eq "2l: nwbreaker = 1" "1" \
 	"$(printf '%s' "$JSON" | jq -r '.pulse_stats.pulse_dispatch_no_work_breaker_tripped')"
+assert_eq "2l2: unfiltered metrics declare global scope" "global" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.scope')"
+assert_eq "2l3: unfiltered Pulse counters declare global scope" "global" \
+	"$(printf '%s' "$JSON" | jq -r '.pulse_stats.scope')"
 
 # PR check skipped → null + state=skipped.
 assert_eq "2m: pr count is null when skipped" "null" \
@@ -424,6 +428,30 @@ assert_eq "2w: mismatched PID identity is not treated as a live owner" "1" \
 	"$(printf '%s' "$JSON" | jq -r '[.progress_blockers.retained_unverified[] | select(.session_key == "routine-pid-reuse")] | length')"
 assert_eq "2x: legacy PID-only ownership remains unverified" "1" \
 	"$(printf '%s' "$JSON" | jq -r '[.progress_blockers.retained_unverified[] | select(.session_key == "routine-legacy")] | length')"
+
+# --repo must scope every repo-attributable runtime surface while keeping
+# unscoped legacy data visible as excluded evidence and Pulse counters global.
+JSON=$(env "${RUN_ENV[@]}" "$HELPER" summary --since 24h --repo example/repo-a --no-pr-check --json 2>&1)
+assert_eq "2y: scoped metrics declare repository scope" "repository" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.scope')"
+assert_eq "2z: scoped raw total contains only repo-a events" "3" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.total')"
+assert_eq "2z1: scoped terminal total contains only repo-a outcomes" "3" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.terminal_session_total')"
+assert_eq "2z2: scoped examples contain only repo-a" "0" \
+	"$(printf '%s' "$JSON" | jq -r '[.metrics.recent_examples[] | select(.repo_slug != "example/repo-a")] | length')"
+assert_eq "2z3: scoped failure groups contain only repo-a" "0" \
+	"$(printf '%s' "$JSON" | jq -r '[.metrics.failure_groups[] | select(.repo_slug != "example/repo-a")] | length')"
+assert_eq "2z4: scoped summary discloses unscoped legacy events" "11" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.unscoped_event_total')"
+assert_eq "2z5: scoped summary reports all excluded events" "15" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.excluded_event_total')"
+assert_eq "2z6: scoped Pulse counters remain global" "global" \
+	"$(printf '%s' "$JSON" | jq -r '.pulse_stats.scope')"
+
+OUT=$(env "${RUN_ENV[@]}" "$HELPER" summary --since 24h --repo example/repo-a --no-pr-check 2>&1)
+assert_contains "2z7: human scoped output distinguishes repository metrics" "repository-scoped metrics" "$OUT"
+assert_contains "2z8: human scoped output labels global Pulse counters" "scope: global" "$OUT"
 
 # ---------------------------------------------------------------------------
 # Section 3: 1h window narrows correctly.
@@ -601,7 +629,7 @@ assert_eq "7e: delivered success uses solved closed issues" "2" \
 	"$(printf '%s' "$JSON" | jq -r '.delivery_stages.delivered_successes')"
 assert_eq "7f: metrics succeeded means delivered success" "2" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.succeeded')"
-assert_eq "7g: runtime handoffs remain distinct from delivery" "5" \
+assert_eq "7g: scoped runtime handoffs remain distinct from delivery" "0" \
 	"$(printf '%s' "$JSON" | jq -r '.metrics.runtime_handoffs')"
 assert_contains "7h: issue query uses solved:worker label" "label:solved:worker" \
 	"$(<"$GH_CALL_LOG")"

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -161,12 +161,14 @@ _wah_objective_outcomes_json() {
 #
 # $1 — cutoff_epoch (entries with ts < cutoff are dropped).
 # $2 — optional now_epoch (entries with ts > now are dropped).
+# $3 — optional repository slug; excludes unscoped and other-repo events.
 # stdout — eight space-separated integers:
 #   raw_total terminal_total succeeded watchdog_killed watchdog_continued service_interrupted rate_limited other_failure
 #######################################
 _wah_aggregate_metrics() {
 	local cutoff_epoch="$1"
 	local metrics="$WAH_METRICS_FILE"
+	local repo_slug="${3:-}"
 	local now_epoch
 
 	if [[ ! -f "$metrics" ]]; then
@@ -195,7 +197,12 @@ _wah_aggregate_metrics() {
 	local jq_program
 	# shellcheck disable=SC2016 # jq variables are evaluated by jq, not the shell
 	jq_program=$WAH_SESSION_OUTCOME_JQ'
-		[inputs | select(.role == $worker_role and (.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $events
+		[inputs | select(
+			.role == $worker_role
+			and (.ts // 0) >= $cutoff
+			and (.ts // 0) <= $now
+			and ($repo_slug == "" or ((.repo_slug // "") == $repo_slug))
+		)] as $events
 		| ($events | _wah_session_outcomes) as $w | {
 			total:  ($events | length),
 			terminal: ($w | length),
@@ -213,7 +220,7 @@ _wah_aggregate_metrics() {
 			)] | length)
 		} | "\(.total) \(.terminal) \(.succ) \(.wk) \(.wc) \(.sic) \(.rl) \(.of)"
 	'
-	result=$(jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --argjson objective_outcomes "$objective_outcomes" --arg worker_role "$WAH_RUNTIME_ROLE" --arg outcome_failed "$WAH_DELIVERY_FAILED" --arg service_result "$service_result" --arg watchdog_killed_result "$watchdog_killed_result" --arg rate_limit_result "$rate_limit_result" "$jq_program" <"$metrics" 2>/dev/null) || result="0 0 0 0 0 0 0 0"
+	result=$(jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --argjson objective_outcomes "$objective_outcomes" --arg worker_role "$WAH_RUNTIME_ROLE" --arg outcome_failed "$WAH_DELIVERY_FAILED" --arg service_result "$service_result" --arg watchdog_killed_result "$watchdog_killed_result" --arg rate_limit_result "$rate_limit_result" --arg repo_slug "$repo_slug" "$jq_program" <"$metrics" 2>/dev/null) || result="0 0 0 0 0 0 0 0"
 
 	[[ -n "$result" ]] || result="0 0 0 0 0 0 0 0"
 	printf '%s\n' "$result"
@@ -225,15 +232,17 @@ _wah_aggregate_metrics() {
 #
 # $1 — cutoff_epoch (entries with ts < cutoff are dropped).
 # $2 — optional now_epoch (entries with ts > now are dropped).
+# $3 — optional repository slug; excludes unscoped and other-repo events.
 # stdout — JSON object containing result counts, duration summary, and examples.
 #######################################
 _wah_metric_details_json() {
 	local cutoff_epoch="$1"
 	local metrics="$WAH_METRICS_FILE"
+	local repo_slug="${3:-}"
 	local now_epoch
 
 	if [[ ! -f "$metrics" ]]; then
-		printf '{"result_counts":{},"diagnostic_focus":{},"timing_ms":{"avg":0,"max":0,"samples":0},"recent_examples":[],"failure_groups":[],"failure_families":[]}'
+		printf '{"event_total":0,"unscoped_event_total":0,"excluded_event_total":0,"result_counts":{},"diagnostic_focus":{},"timing_ms":{"avg":0,"max":0,"samples":0},"recent_examples":[],"failure_groups":[],"failure_families":[]}'
 		return 0
 	fi
 	now_epoch="${2:-$(date +%s)}"
@@ -242,12 +251,21 @@ _wah_metric_details_json() {
 	objective_outcomes=$(_wah_objective_outcomes_json)
 	# shellcheck disable=SC2016 # jq variables are evaluated by jq, not the shell
 	jq_program=$WAH_SESSION_OUTCOME_JQ$WAH_FAILURE_FAMILY_JQ'
-		[inputs | select(.role == $worker_role and (.ts // 0) >= $cutoff and (.ts // 0) <= $now)] as $events
+		[inputs | select(
+			.role == $worker_role
+			and (.ts // 0) >= $cutoff
+			and (.ts // 0) <= $now
+		)] as $window_events
+		| ($window_events | map(select(
+			$repo_slug == "" or ((.repo_slug // "") == $repo_slug)
+		))) as $events
 		| ($events | _wah_session_outcomes) as $w
 		| ($w | map(.duration_ms // 0)) as $durations
 		| ($w | map(select(_wah_effective_failure))) as $failures
 		| {
 			event_total: ($events | length),
+			unscoped_event_total: (if $repo_slug == "" then 0 else ([$window_events[] | select((.repo_slug // "") == "")] | length) end),
+			excluded_event_total: (($window_events | length) - ($events | length)),
 			continuation_events: ($events | map(select(_wah_nonterminal)) | length),
 			result_counts: (reduce $w[] as $row ({}; .[$row.result // "unknown"] += 1)),
 			event_result_counts: (reduce $events[] as $row ({}; .[$row.result // "unknown"] += 1)),
@@ -317,8 +335,8 @@ _wah_metric_details_json() {
 				| sort_by(.count) | reverse | .[0:10]),
 			failure_families: ($failures | _wah_failure_family_summary)
 		}'
-	jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --argjson objective_outcomes "$objective_outcomes" --arg worker_role "$WAH_RUNTIME_ROLE" --arg outcome_failed "$WAH_DELIVERY_FAILED" --arg watchdog_killed_result "$WAH_RESULT_WATCHDOG_STALL_KILLED" --arg local_kill_result "$WAH_RESULT_LOCAL_KILL" "$jq_program" <"$metrics" 2>/dev/null ||
-		printf '{"result_counts":{},"diagnostic_focus":{},"timing_ms":{"avg":0,"max":0,"samples":0},"recent_examples":[],"failure_groups":[],"failure_families":[]}'
+	jq -rn --argjson cutoff "$cutoff_epoch" --argjson now "$now_epoch" --argjson objective_outcomes "$objective_outcomes" --arg worker_role "$WAH_RUNTIME_ROLE" --arg outcome_failed "$WAH_DELIVERY_FAILED" --arg watchdog_killed_result "$WAH_RESULT_WATCHDOG_STALL_KILLED" --arg local_kill_result "$WAH_RESULT_LOCAL_KILL" --arg repo_slug "$repo_slug" "$jq_program" <"$metrics" 2>/dev/null ||
+		printf '{"event_total":0,"unscoped_event_total":0,"excluded_event_total":0,"result_counts":{},"diagnostic_focus":{},"timing_ms":{"avg":0,"max":0,"samples":0},"recent_examples":[],"failure_groups":[],"failure_families":[]}'
 	return 0
 }
 
@@ -665,10 +683,15 @@ _wah_emit_human() {
 
 	printf '%s\n' "$divider"
 	printf 'Worker activity reporting window: previous %s (cutoff: %s; observation only, not a worker runtime limit)\n' "$since_label" "$cutoff_iso"
-	[[ -n "$repo_label" ]] && printf 'Repo: %s\n' "$repo_label"
+	if [[ -n "$repo_label" ]]; then
+		printf 'Repo: %s (repository-scoped metrics; unscoped legacy events excluded: %s)\n' "$repo_label" \
+			"$(printf '%s' "$details_json" | jq -r '.unscoped_event_total // 0' 2>/dev/null || printf '0')"
+	else
+		printf 'Repo scope: global (all repositories and unscoped legacy events)\n'
+	fi
 	printf '%s\n' "$divider"
 	printf '\n'
-	printf 'headless-runtime-metrics.jsonl (canonical worker outcomes):\n'
+	printf 'headless-runtime-metrics.jsonl (canonical worker outcomes; scope: %s):\n' "$(if [[ -n "$repo_label" ]]; then printf 'repository'; else printf 'global'; fi)"
 	printf '  Raw attempt/events:          %d\n' "$total"
 	printf '  Terminal session outcomes:   %d\n' "$terminal_total"
 	printf '  Runtime handoffs:            %d  (%s of terminal)\n' "$succ" "$handoff_rate_pct"
@@ -686,8 +709,11 @@ _wah_emit_human() {
 	printf '  Provider/model usage:        worker-activity-helper.sh providers --since %s\n' "$since_label"
 	printf '  Failure groups:             %s\n' "$(printf '%s' "$details_json" | jq -c '.failure_groups // []' 2>/dev/null || printf '[]')"
 	printf '  Failure families:           %s\n' "$(printf '%s' "$details_json" | jq -c '.failure_families // []' 2>/dev/null || printf '[]')"
+	[[ -n "$repo_label" ]] && printf '  Excluded events:            %s (unscoped: %s)\n' \
+		"$(printf '%s' "$details_json" | jq -r '.excluded_event_total // 0' 2>/dev/null || printf '0')" \
+		"$(printf '%s' "$details_json" | jq -r '.unscoped_event_total // 0' 2>/dev/null || printf '0')"
 	printf '\n'
-	printf 'worker-progress-blockers.jsonl (bounded progress holds):\n'
+	printf 'worker-progress-blockers.jsonl (bounded progress holds; scope: %s):\n' "$(if [[ -n "$repo_label" ]]; then printf 'repository'; else printf 'global'; fi)"
 	printf '  Events in window:            %s\n' "$(printf '%s' "$blocker_json" | jq -r '.event_total // 0' 2>/dev/null || printf '0')"
 	printf '  Proven current:              %s\n' "$(printf '%s' "$blocker_json" | jq -r '.active_total // 0' 2>/dev/null || printf '0')"
 	printf '  Retained/unverified:         %s\n' "$(printf '%s' "$blocker_json" | jq -r '.retained_unverified_total // 0' 2>/dev/null || printf '0')"
@@ -695,13 +721,13 @@ _wah_emit_human() {
 	printf '  Active blockers:             %s\n' "$(printf '%s' "$blocker_json" | jq -c '.active_blockers // []' 2>/dev/null || printf '[]')"
 	printf '  Retained blockers:           %s\n' "$(printf '%s' "$blocker_json" | jq -c '.retained_unverified // []' 2>/dev/null || printf '[]')"
 	printf '\n'
-	printf 'pulse-stats.json (dispatch-side counters):\n'
+	printf 'pulse-stats.json (global dispatch-side counters; scope: global):\n'
 	printf '  pulse_dispatch_circuit_broken:           %d\n' "$cb"
 	printf '  pulse_cycle_skipped_graphql_low:         %d\n' "$gqlow"
 	printf '  dispatch_backoff_skipped:                %d\n' "$db_skip"
 	printf '  pulse_dispatch_no_work_breaker_tripped:  %d\n' "$nwbreaker"
 	printf '\n'
-	printf 'GitHub delivery stages (external truth):\n'
+	printf 'GitHub delivery stages (external truth; scope: %s):\n' "$(if [[ -n "$repo_label" ]]; then printf 'repository'; else printf 'global'; fi)"
 	printf '  PRs opened:                  %s\n' "$pr_opened"
 	printf '  PRs merged:                  %s\n' "$pr_merged"
 	printf '  Issues solved and closed:    %s\n' "$issue_solved"
@@ -785,9 +811,12 @@ _wah_emit_json() {
 			window: { since: $since, cutoff_iso: $cutoff_iso, cutoff_epoch: $cutoff_epoch, semantics: "historical_observation_only", worker_runtime_limit: null },
 			repo: (if $repo == "" then null else $repo end),
 			metrics: {
+				scope: (if $repo == "" then "global" else "repository" end),
 				total: $total,
 				terminal_session_total: $terminal_total,
 				event_total: ($details.event_total // $total),
+				unscoped_event_total: ($details.unscoped_event_total // 0),
+				excluded_event_total: ($details.excluded_event_total // 0),
 				continuation_events: ($details.continuation_events // 0),
 				runtime_handoffs: $succ,
 				succeeded: ($delivery.delivered_successes // null),
@@ -806,6 +835,7 @@ _wah_emit_json() {
 				failure_families: ($details.failure_families // [])
 			},
 			pulse_stats: {
+				scope: "global",
 				pulse_dispatch_circuit_broken: $cb,
 				pulse_cycle_skipped_graphql_low: $gqlow,
 				dispatch_backoff_skipped: $db_skip,
@@ -874,9 +904,9 @@ cmd_summary() {
 
 	# Aggregate metrics (single jq+awk pass).
 	local agg total terminal_total succ wk wc sic rl of details_json blocker_json live_blocker_sessions_json
-	agg=$(_wah_aggregate_metrics "$cutoff_epoch" "$now_epoch")
+	agg=$(_wah_aggregate_metrics "$cutoff_epoch" "$now_epoch" "$repo_label")
 	read -r total terminal_total succ wk wc sic rl of <<<"$agg"
-	details_json=$(_wah_metric_details_json "$cutoff_epoch" "$now_epoch")
+	details_json=$(_wah_metric_details_json "$cutoff_epoch" "$now_epoch" "$repo_label")
 	live_blocker_sessions_json=$(_wah_live_blocker_sessions_json "$repo_label")
 	blocker_json=$(_wah_blocker_details_json "$cutoff_epoch" "$now_epoch" "$repo_label" "$live_blocker_sessions_json")
 
@@ -996,7 +1026,10 @@ Options:
   --pr-check                 Query opened/merged worker PRs and solved issues
                              (three GitHub search calls; disabled by default)
   --no-pr-check              Explicitly keep delivery-stage queries skipped (default)
-  --repo OWNER/REPO          Constrain delivery-stage queries to a single repo
+  --repo OWNER/REPO           Scope repo-attributable metrics, blockers, and
+                              delivery-stage queries to a single repo; legacy
+                              unscoped metric events are excluded and disclosed
+                              while Pulse counters remain explicitly global
 
 Sources read (in canonical-precedence order):
   1. ~/.aidevops/logs/headless-runtime-metrics.jsonl  (worker outcomes)


### PR DESCRIPTION
## Summary

Scopes worker runtime aggregates, examples, and failure groups to --repo; discloses excluded legacy rows and labels global Pulse counters.

## Files Changed

.agents/scripts/tests/test-worker-activity-helper.sh, .agents/scripts/worker-activity-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-worker-activity-helper.sh; shellcheck .agents/scripts/worker-activity-helper.sh .agents/scripts/tests/test-worker-activity-helper.sh

Resolves #29873


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.247 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 7m and 99,135 tokens on this as a headless worker.