### PR TITLE
GH#29899: Add standalone LM Studio Buzz agent snapshots

### DIFF
--- a/.agents/reference/team-interface-buzz-provisioning.md
+++ b/.agents/reference/team-interface-buzz-provisioning.md
@@ -98,6 +98,23 @@ identifier before generation. Use `--lm-studio required` to fail generation
 instead of producing the 15-member baseline when local inference is not ready;
 use `--lm-studio off` for deterministic pipeline output.
 
+To add LM Studio after importing the baseline team, generate only its standalone
+agent snapshot:
+
+```bash
+~/.aidevops/agents/scripts/buzz-team-provision-helper.sh generate-lm-studio-agent
+```
+
+This command always requires a running server and one unambiguous loaded LLM. It
+fails without writing an artifact when readiness cannot be proven. The default
+mode-0600 output is
+`~/Downloads/private-lm-studio-<host>.agent.json`; `--output FILE` and
+`--stdout` remain available for reviewed destinations and explicit pipelines.
+In Buzz Desktop, use **Agents** → **Import snapshot** and select the generated
+`.agent.json`. Buzz imports a brand-new agent with a fresh identity; existing
+teams and identities are not modified, and team membership remains a separate
+owner-reviewed Buzz action.
+
 Before importing a snapshot that includes Private LM Studio, quit Buzz and
 install its local runtime beside the interactive runtime:
 

--- a/.agents/scripts/_team_interface_buzz_snapshot_io.py
+++ b/.agents/scripts/_team_interface_buzz_snapshot_io.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Serialize and atomically write aidevops Buzz team snapshots."""
+"""Serialize and atomically write aidevops Buzz snapshots."""
 
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
@@ -21,7 +21,7 @@ def serialized_snapshot(snapshot):
     """Return stable pretty-printed UTF-8 JSON bytes."""
     payload = (json.dumps(snapshot, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
     if len(payload) > MAX_SNAPSHOT_BYTES:
-        raise SnapshotIOError("generated Buzz team snapshot exceeds the 5 MiB decoded limit")
+        raise SnapshotIOError("generated Buzz snapshot exceeds the 5 MiB decoded limit")
     return payload
 
 
@@ -38,16 +38,16 @@ def validate_output_path(output_path, agents_dir, ensure_output_is_not_source):
     return resolved
 
 
-def downloads_output_path(agents_dir, ensure_output_is_not_source):
+def downloads_output_path(agents_dir, ensure_output_is_not_source, filename="aidevops.team.json"):
     """Resolve the user-facing native-import destination under Downloads."""
+    if not filename or Path(filename).name != filename:
+        raise SnapshotIOError("Downloads snapshot filename must be one plain filename")
     configured = os.environ.get("AIDEVOPS_DOWNLOADS_DIR")
     downloads = Path(os.path.expanduser(configured)) if configured else Path.home() / "Downloads"
     if not downloads.is_absolute():
         raise SnapshotIOError("AIDEVOPS_DOWNLOADS_DIR must be absolute")
     downloads.mkdir(mode=0o700, parents=False, exist_ok=True)
-    return validate_output_path(
-        downloads / "aidevops.team.json", agents_dir, ensure_output_is_not_source
-    )
+    return validate_output_path(downloads / filename, agents_dir, ensure_output_is_not_source)
 
 
 def atomic_write(output_path, payload):

--- a/.agents/scripts/buzz-team-provision-helper.sh
+++ b/.agents/scripts/buzz-team-provision-helper.sh
@@ -20,19 +20,24 @@ usage() {
 		'Usage:' \
 		'  buzz-team-provision-helper.sh status' \
 		'  buzz-team-provision-helper.sh generate [--agents-dir DIR] [--host-slug NAME] [--output FILE|--stdout]' \
+		'  buzz-team-provision-helper.sh generate-lm-studio-agent [--agents-dir DIR] [--host-slug NAME] [--output FILE|--stdout]' \
 		'  buzz-team-provision-helper.sh submit [--agents-dir DIR] [--host-slug NAME]' \
 		'  buzz-team-provision-helper.sh lm-studio-status [--require]' \
 		'  buzz-team-provision-helper.sh runtime-manifest --project-root DIR [--output FILE]' \
 		'  buzz-team-provision-helper.sh runtime-install --project-root DIR [--app-data-dir DIR] [--replace]' \
 		'  Add --runtime interactive or --runtime lm-studio for snapshot runtimes.' \
 		'' \
-		'generate defaults to ~/Downloads/aidevops.team.json; use --stdout for pipelines.' \
+		'generate defaults to ~/Downloads/aidevops.team.json.' \
+		'generate-lm-studio-agent defaults to a host-qualified .agent.json in Downloads.' \
+		'Use --stdout for explicit pipelines.' \
 		'runtime-manifest is local-only. submit queues one deterministic' \
 		'draft for explicit review. runtime-install requires Buzz to be stopped.'
 	return 0
 }
 
 generate_snapshot() {
+	local generator_command="$1"
+	shift
 	local has_destination="false"
 	local argument=""
 	for argument in "$@"; do
@@ -43,10 +48,10 @@ generate_snapshot() {
 		esac
 	done
 	if [[ "$has_destination" == "true" ]]; then
-		"$PYTHON_BIN" "$GENERATOR" generate "$@"
+		"$PYTHON_BIN" "$GENERATOR" "$generator_command" "$@"
 		return $?
 	fi
-	"$PYTHON_BIN" "$GENERATOR" generate "$@" --downloads
+	"$PYTHON_BIN" "$GENERATOR" "$generator_command" "$@" --downloads
 	return $?
 }
 
@@ -63,7 +68,11 @@ main() {
 		return $?
 		;;
 	generate)
-		generate_snapshot "$@"
+		generate_snapshot generate "$@"
+		return $?
+		;;
+	generate-lm-studio-agent)
+		generate_snapshot generate-lm-studio-agent "$@"
 		return $?
 		;;
 	lm-studio-status)

--- a/.agents/scripts/team-interface-buzz-team-snapshot.py
+++ b/.agents/scripts/team-interface-buzz-team-snapshot.py
@@ -241,16 +241,36 @@ def build_team_snapshot(agents_dir, host_slug=None, lm_studio_mode="auto"):
     return snapshot
 
 
+def build_lm_studio_agent_snapshot(agents_dir, host_slug=None):
+    """Build one standalone LM Studio agent snapshot from canonical Private AI."""
+    resolved_host_slug = resolve_host_slug(host_slug)
+    roster = load_roster_module().build_roster(agents_dir)
+    private_records = [
+        record for record in roster["agents"] if record["agent_id"] == PRIVATE_AGENT_ID
+    ]
+    if len(private_records) != 1:
+        raise ProvisioningError("canonical roster must contain exactly one Private AI member")
+    lm_studio_status = resolve_lm_studio_status("required")
+    snapshot = build_lm_studio_member(
+        private_records[0],
+        resolved_host_slug,
+        lm_studio_status["model"],
+        BUZZ_AGENT_FORMAT,
+        FORMAT_VERSION,
+    )
+    return snapshot, lm_studio_status
+
+
 def validate_output_path(output_path, agents_dir):
     """Validate an explicit caller-owned output without following a target symlink."""
     source_guard = load_roster_module().ensure_output_is_not_source
     return validate_snapshot_output_path(output_path, agents_dir, source_guard)
 
 
-def downloads_output_path(agents_dir):
+def downloads_output_path(agents_dir, filename="aidevops.team.json"):
     """Resolve the user-facing native-import destination under Downloads."""
     source_guard = load_roster_module().ensure_output_is_not_source
-    return resolve_downloads_output_path(agents_dir, source_guard)
+    return resolve_downloads_output_path(agents_dir, source_guard, filename)
 
 
 def resolve_buzz_cli():
@@ -338,6 +358,17 @@ def parse_args(argv=None):
     destination.add_argument("--downloads", action="store_true", help="write to ~/Downloads")
     destination.add_argument("--stdout", action="store_true", help="write JSON to stdout")
 
+    generate_lm_studio_agent = commands.add_parser(
+        "generate-lm-studio-agent",
+        help="generate one ready LM Studio agent snapshot",
+    )
+    generate_lm_studio_agent.add_argument("--agents-dir", default=DEFAULT_AGENTS_DIR)
+    generate_lm_studio_agent.add_argument("--host-slug")
+    agent_destination = generate_lm_studio_agent.add_mutually_exclusive_group()
+    agent_destination.add_argument("--output", help="atomic mode-600 output path")
+    agent_destination.add_argument("--downloads", action="store_true", help="write to ~/Downloads")
+    agent_destination.add_argument("--stdout", action="store_true", help="write JSON to stdout")
+
     commands.add_parser("status", help="check the local Buzz Desktop broker")
 
     submit = commands.add_parser("submit", help="queue a generated snapshot for Desktop review")
@@ -374,20 +405,30 @@ def main(argv=None):
         submit_snapshot(agents_dir, args.host_slug, args.lm_studio)
         return 0
 
-    snapshot, lm_studio_status = build_team_snapshot_with_status(
-        agents_dir, args.host_slug, args.lm_studio
-    )
+    standalone_agent = args.command == "generate-lm-studio-agent"
+    if standalone_agent:
+        snapshot, lm_studio_status = build_lm_studio_agent_snapshot(agents_dir, args.host_slug)
+    else:
+        snapshot, lm_studio_status = build_team_snapshot_with_status(
+            agents_dir, args.host_slug, args.lm_studio
+        )
     report_lm_studio_status(lm_studio_status)
     payload = serialized_snapshot(snapshot)
+    snapshot_kind = "Buzz LM Studio agent" if standalone_agent else "Buzz team"
     if args.output:
         output_path = validate_output_path(args.output, agents_dir)
         atomic_write(output_path, payload)
-        print(f"Generated Buzz team snapshot: {output_path}", file=sys.stderr)
+        print(f"Generated {snapshot_kind} snapshot: {output_path}", file=sys.stderr)
         return 0
     if args.downloads:
-        output_path = downloads_output_path(agents_dir)
+        filename = (
+            f"{snapshot['profile']['displayName']}.agent.json"
+            if standalone_agent
+            else "aidevops.team.json"
+        )
+        output_path = downloads_output_path(agents_dir, filename)
         atomic_write(output_path, payload)
-        print(f"Generated Buzz team snapshot: {output_path}", file=sys.stderr)
+        print(f"Generated {snapshot_kind} snapshot: {output_path}", file=sys.stderr)
         return 0
     sys.stdout.buffer.write(payload)
     return 0

--- a/.agents/scripts/tests/test-team-interface-buzz-team-snapshot.mjs
+++ b/.agents/scripts/tests/test-team-interface-buzz-team-snapshot.mjs
@@ -230,6 +230,33 @@ exit 9
   assert.match(localMember.definition.systemPrompt, /loopback-only LM Studio server/);
   assert.doesNotMatch(JSON.stringify(localMember), /127\.0\.0\.1|localhost|OPENAI_COMPAT/);
   assert.equal(localSnapshot.members.length, fixtureFirst.members.length + 1);
+  const standaloneLocalMember = requireSuccess(
+    runGenerator(
+      ["generate-lm-studio-agent", "--agents-dir", agentsDirectory],
+      {
+        env: {
+          ...process.env,
+          AIDEVOPS_BUZZ_HOST_SLUG: "test-host-01",
+          AIDEVOPS_LM_STUDIO_CLI: mockLms,
+        },
+      },
+    ),
+    "standalone LM Studio agent snapshot generation",
+  );
+  assert.equal(standaloneLocalMember.format, "buzz-agent-snapshot");
+  assert.equal(standaloneLocalMember.version, 1);
+  assert.equal(standaloneLocalMember.profile.displayName, "private-lm-studio-test-host-01");
+  assert.equal(standaloneLocalMember.definition.runtime, "aidevops-lm-studio-v1");
+  assert.equal(standaloneLocalMember.definition.provider, "openai");
+  assert.equal(standaloneLocalMember.definition.model, "local/tool-model");
+  assert.equal(standaloneLocalMember.definition.respondTo, "owner-only");
+  assert.equal("members" in standaloneLocalMember, false);
+  assert.equal("team" in standaloneLocalMember, false);
+  assert.deepEqual(standaloneLocalMember, localMember);
+  assert.doesNotMatch(
+    JSON.stringify(standaloneLocalMember),
+    /127\.0\.0\.1|localhost|OPENAI_COMPAT|private_key|auth_tag|relay_url/i,
+  );
   assert.match(
     fixtureFirst.members.find(
       ({profile}) => profile.displayName === "automate-test-host-01",
@@ -280,6 +307,57 @@ exit 9
   assert.equal(fs.statSync(downloadedSnapshotPath).mode & 0o777, 0o600);
   assert.deepEqual(JSON.parse(fs.readFileSync(downloadedSnapshotPath, "utf8")), changed);
   assert.match(defaultDownload.stderr, /Generated Buzz team snapshot:/);
+
+  const standaloneDownload = spawnSync(
+    helper,
+    ["generate-lm-studio-agent", "--agents-dir", agentsDirectory, "--host-slug", "test-host-01"],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        AIDEVOPS_DOWNLOADS_DIR: downloadsDirectory,
+        AIDEVOPS_LM_STUDIO_CLI: mockLms,
+      },
+    },
+  );
+  assert.equal(standaloneDownload.status, 0, standaloneDownload.stderr);
+  assert.equal(standaloneDownload.stdout, "", "interactive standalone helper must not dump JSON");
+  const downloadedAgentPath = path.join(
+    downloadsDirectory,
+    "private-lm-studio-test-host-01.agent.json",
+  );
+  assert.equal(fs.statSync(downloadedAgentPath).mode & 0o777, 0o600);
+  assert.deepEqual(JSON.parse(fs.readFileSync(downloadedAgentPath, "utf8")), standaloneLocalMember);
+  assert.match(standaloneDownload.stderr, /Generated Buzz LM Studio agent snapshot:/);
+
+  const unreadyLms = path.join(fixtureRoot, "lms-unready-mock.sh");
+  fs.writeFileSync(unreadyLms, `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1 $2 \${3:-} \${4:-}" == "server status --json --quiet" ]]; then
+  printf '%s\n' '{"running":false}'
+  exit 0
+fi
+exit 9
+`);
+  fs.chmodSync(unreadyLms, 0o700);
+  const unavailableOutput = path.join(fixtureRoot, "unavailable.agent.json");
+  const unavailableStandalone = runGenerator(
+    [
+      "generate-lm-studio-agent",
+      "--agents-dir", agentsDirectory,
+      "--output", unavailableOutput,
+    ],
+    {
+      env: {
+        ...process.env,
+        AIDEVOPS_BUZZ_HOST_SLUG: "test-host-01",
+        AIDEVOPS_LM_STUDIO_CLI: unreadyLms,
+      },
+    },
+  );
+  assert.notEqual(unavailableStandalone.status, 0);
+  assert.match(unavailableStandalone.stderr, /LM Studio is required but unavailable/);
+  assert.equal(fs.existsSync(unavailableOutput), false, "unready LM Studio must write no artifact");
 
   const explicitStdout = spawnSync(
     helper,


### PR DESCRIPTION
## Summary

Implementation for issue #29899.

## Files Changed

.agents/reference/team-interface-buzz-provisioning.md, .agents/scripts/_team_interface_buzz_snapshot_io.py, .agents/scripts/buzz-team-provision-helper.sh, .agents/scripts/team-interface-buzz-team-snapshot.py, .agents/scripts/tests/test-team-interface-buzz-team-snapshot.mjs

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #29899


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.247 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 2d 2h and 15,952,541 tokens on this with the user in an interactive session.