### PR TITLE
GH#29897: release interactive-origin worker claims

### DIFF
--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1284,10 +1284,11 @@ _source_shared_module_with_retry "${_SC_SELF%/*}/shared-gh-wrappers.sh"
 # worker completion, with dead PIDs (one case was PID 11742 reused by
 # Brave Browser — see t2421).
 #
-# Defensive: skips entirely if origin:interactive is present. Workers
-# should never hold the claim on interactive issues (dispatch-dedup
-# blocks that), but if we find one, we never touch interactive-session
-# ownership state (t2056).
+# Origin labels are provenance only. An interactive session may create an
+# auto-dispatch issue that a headless worker validly claims, so release must
+# not skip cleanup solely because origin:interactive is present (GH#29897).
+# The exact worker_login removal and linked-PR safeguards below preserve live
+# interactive ownership and completed-work audit state.
 #
 # Args:
 #   $1 — issue number
@@ -1295,7 +1296,7 @@ _source_shared_module_with_retry "${_SC_SELF%/*}/shared-gh-wrappers.sh"
 #   $3 — worker login to remove as assignee (optional; empty = no assignee change)
 #
 # Returns:
-#   0 on success, including idempotent no-ops and defensive skips
+#   0 on success, including idempotent no-ops
 #   1 on gh failure (logged by gh to stderr; suppressed here)
 #
 # Example:
@@ -1310,16 +1311,9 @@ clear_active_status_on_release() {
 		return 0
 	fi
 
-	# Defensive: don't touch interactive-session-owned issues.
-	# A single fetch is cheap — only fires on claim release, not hot path.
 	local labels_json=""
 	labels_json=$(gh issue view "$issue_num" --repo "$repo_slug" \
 		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || labels_json=""
-	case ",${labels_json}," in
-	*,origin:interactive,*)
-		return 0
-		;;
-	esac
 
 	# Defensive: if a linked PR exists for this issue (OPEN or MERGED),
 	# preserve the worker's assignee and status:in-review.

--- a/.agents/scripts/tests/test-claim-release-label-mutation.sh
+++ b/.agents/scripts/tests/test-claim-release-label-mutation.sh
@@ -13,8 +13,8 @@
 #   3. Adds status:available when no linked PR owns the issue
 #   4. Removes the worker_login as assignee when provided
 #   5. Skips assignee mutation when worker_login is empty
-#   6. Defensively skips entirely when origin:interactive is present,
-#      preserving interactive-session ownership (t2056)
+#   6. Cleans valid worker claims on interactive-origin auto-dispatch issues
+#      because origin labels are provenance, not workflow permission
 #   7. Returns 0 on empty issue_num or repo_slug (idempotent no-op)
 #
 # Failure history motivating this test: production observation 2026-04-20
@@ -158,17 +158,14 @@ assert_not_grep "remove-assignee" "no assignee mutation when empty"
 assert_grep "remove-label status:queued" "labels still cleared when worker_login empty"
 
 # -------------------------------------------------------------------
-# Case 4: defensively skips entirely when origin:interactive present
+# Case 4: cleans a worker claim on an interactive-origin auto-dispatch issue
 # -------------------------------------------------------------------
 reset_stub
-printf 'bug,origin:interactive,tier:standard' >"$GH_VIEW_LABELS"
+printf 'auto-dispatch,bug,origin:interactive,status:in-progress,tier:standard' >"$GH_VIEW_LABELS"
 clear_active_status_on_release 20026 owner/repo alice
-# No `gh issue edit` call should have been recorded (view is skipped by stub)
-if ! grep -q "issue edit" "$GH_CALLS_FILE" 2>/dev/null; then
-	print_result "skips edit on origin:interactive" 0
-else
-	print_result "skips edit on origin:interactive" 1 "gh issue edit was called"
-fi
+assert_grep "remove-label status:in-progress" "clears worker status on interactive-origin auto-dispatch issue"
+assert_grep "add-label status:available" "requeues interactive-origin auto-dispatch issue"
+assert_grep "remove-assignee alice" "removes worker from interactive-origin auto-dispatch issue"
 
 # -------------------------------------------------------------------
 # Case 5: empty issue_num returns 0 without gh call
@@ -195,8 +192,7 @@ else
 fi
 
 # -------------------------------------------------------------------
-# Case 7: labels not matching interactive substring don't trigger defensive skip
-# (e.g., a label named "interactive-candidate" or "origin:worker-takeover")
+# Case 7: worker-takeover provenance follows the same release cleanup path
 # -------------------------------------------------------------------
 reset_stub
 printf 'bug,origin:worker-takeover,tier:standard' >"$GH_VIEW_LABELS"


### PR DESCRIPTION
## Summary

Remove the obsolete origin:interactive release bypass so failed headless claims return to status:available and drop the exact worker assignee while linked-PR safeguards remain intact.

## Files Changed

.agents/scripts/shared-constants.sh, .agents/scripts/tests/test-claim-release-label-mutation.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — 17-case claim-release regression suite, no-PR and merged-PR safeguards, release-unlock and completion tests, ShellCheck, Bash syntax, local changed-file linters, and live recovery plus fresh redispatch of #29887.

Resolves #29897


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.247 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 46m and 863,187 tokens on this with the user in an interactive session.