### PR TITLE
GH#29902: Preserve proven existing worker signing

### DIFF
--- a/.agents/reference/git-signing.md
+++ b/.agents/reference/git-signing.md
@@ -35,6 +35,11 @@ Headless runtime wrappers inject the worker key through `GIT_CONFIG_COUNT` proce
 configuration, inherited by model Git commands and exit-time recovery. They first
 probe an unattached signed commit and stop before model launch if signing is unusable.
 
+During migration, a runner without the dedicated key path may continue using its
+existing effective signing configuration only when that same noninteractive signed-
+commit probe succeeds. This compatibility path never permits unsigned commits or
+generates keys automatically; configure the dedicated signing-only key when practical.
+
 Upload each public key to the matching GitHub key category. Reusing one public key
 for authentication and signing is supported by GitHub, but role separation makes
 revocation, agent availability, and incident response clearer.

--- a/.agents/scripts/headless-runtime-attempt.sh
+++ b/.agents/scripts/headless-runtime-attempt.sh
@@ -66,8 +66,10 @@ _append_headless_worker_git_config_env() {
 }
 
 # Keep the user's passphrase-protected interactive key as the global Git
-# default. Worker processes receive the dedicated signing-only key through
+# default. Worker processes prefer the dedicated signing-only key through
 # process-scoped Git config inherited by the runtime and exit-trap Git commands.
+# During migration, an existing effective signing configuration remains valid
+# only when the same noninteractive signed-commit probe succeeds (GH#29902).
 _configure_headless_worker_signing_env() {
 	local work_dir="$1"
 	[[ "${_AIDEVOPS_HEADLESS_SIGNING_ENV_CONFIGURED:-0}" == "1" ]] && return 0
@@ -75,7 +77,11 @@ _configure_headless_worker_signing_env() {
 	signing_required=$(git -C "$work_dir" config --bool commit.gpgsign 2>/dev/null || true)
 	[[ "$signing_required" == "$_HEADLESS_SIGNING_TRUE" ]] || return 0
 	local signing_public_key="${AIDEVOPS_HEADLESS_SIGNING_PUBLIC_KEY:-${HOME}/.ssh/id_ed25519_signing.pub}"
-	[[ -r "$signing_public_key" ]] || return 1
+	if [[ ! -r "$signing_public_key" ]]; then
+		_headless_worker_signing_commit_probe "$work_dir" || return 1
+		export _AIDEVOPS_HEADLESS_SIGNING_ENV_CONFIGURED=1
+		return 0
+	fi
 	_append_headless_worker_git_config_env "gpg.format" "ssh" || return 1
 	_append_headless_worker_git_config_env "user.signingkey" "$signing_public_key" || return 1
 	_append_headless_worker_git_config_env "commit.gpgsign" "$_HEADLESS_SIGNING_TRUE" || return 1

--- a/.agents/scripts/tests/test-headless-runtime-contract-tests.sh
+++ b/.agents/scripts/tests/test-headless-runtime-contract-tests.sh
@@ -296,21 +296,53 @@ test_worker_signing_config_is_process_scoped_and_idempotent() {
 	return 0
 }
 
-test_worker_signing_config_requires_dedicated_key_for_signed_repositories() {
+test_worker_signing_preflight_accepts_proven_existing_signing() {
+	local result="" status=0
+	result=$(
+		local probe_count=0
+		git() {
+			[[ "$*" == *"config --bool commit.gpgsign"* ]] && printf 'true\n'
+			return 0
+		}
+		_headless_worker_signing_commit_probe() {
+			probe_count=$((probe_count + 1))
+			return 0
+		}
+		unset _AIDEVOPS_HEADLESS_SIGNING_ENV_CONFIGURED 2>/dev/null || true
+		unset GIT_CONFIG_COUNT 2>/dev/null || true
+		AIDEVOPS_HEADLESS_SIGNING_PUBLIC_KEY="${TEST_ROOT}/missing-worker-signing-key.pub" \
+			_configure_headless_worker_signing_env "$TEST_ROOT"
+		AIDEVOPS_HEADLESS_SIGNING_KEY="${TEST_ROOT}/missing-worker-signing-key" \
+			_prepare_headless_worker_signing "$TEST_ROOT"
+		printf 'configured=%s probes=%s config_count=%s\n' \
+			"${_AIDEVOPS_HEADLESS_SIGNING_ENV_CONFIGURED:-0}" "$probe_count" "${GIT_CONFIG_COUNT:-0}"
+	) || status=$?
+	if [[ "$status" -eq 0 && "$result" == "configured=1 probes=2 config_count=0" ]]; then
+		print_result "worker signing migration accepts a proven existing signing configuration" 0
+	else
+		print_result "worker signing migration accepts a proven existing signing configuration" 1 \
+			"status=$status result=${result:-<empty>}"
+	fi
+	return 0
+}
+
+test_worker_signing_config_rejects_unusable_existing_signing() {
 	local status=0
 	(
 		git() {
 			[[ "$*" == *"config --bool commit.gpgsign"* ]] && printf 'true\n'
 			return 0
 		}
+		_headless_worker_signing_commit_probe() { return 1; }
 		unset _AIDEVOPS_HEADLESS_SIGNING_ENV_CONFIGURED 2>/dev/null || true
 		AIDEVOPS_HEADLESS_SIGNING_PUBLIC_KEY="${TEST_ROOT}/missing-worker-signing-key.pub" \
 			_configure_headless_worker_signing_env "$TEST_ROOT"
 	) || status=$?
 	if [[ "$status" -eq 1 ]]; then
-		print_result "signed repositories require the dedicated headless public key" 0
+		print_result "worker signing migration rejects an unusable existing signing configuration" 0
 	else
-		print_result "signed repositories require the dedicated headless public key" 1 "status=$status"
+		print_result "worker signing migration rejects an unusable existing signing configuration" 1 \
+			"status=$status"
 	fi
 	return 0
 }
@@ -378,7 +410,8 @@ test_worker_signing_preflight_fails_before_runtime_attempt() {
 run_worker_signing_contract_tests() {
 	test_worker_signing_preflight_skips_unsigned_repositories
 	test_worker_signing_config_is_process_scoped_and_idempotent
-	test_worker_signing_config_requires_dedicated_key_for_signed_repositories
+	test_worker_signing_preflight_accepts_proven_existing_signing
+	test_worker_signing_config_rejects_unusable_existing_signing
 	test_worker_signing_preflight_self_heals_agent_once
 	test_worker_signing_preflight_fails_before_runtime_attempt
 	return 0


### PR DESCRIPTION
## Summary

Allow mixed-version headless runners to retain an already-functional effective signing configuration when the dedicated signing key is not yet provisioned, while requiring the same noninteractive signed-commit probe and retaining fail-closed behavior.

## Files Changed

.agents/reference/git-signing.md, .agents/scripts/headless-runtime-attempt.sh, .agents/scripts/tests/test-headless-runtime-contract-tests.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Headless runtime contract tests pass; ShellCheck and Bash syntax checks pass; markdownlint passes; local changed-file quality suite passes; independent closeout review found no actionable defects.

Resolves #29902


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.247 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h 19m and 1,128,953 tokens on this with the user in an interactive session.