### PR TITLE
GH#29872: test: fix headless PR handoff fixtures

### DIFF
--- a/.agents/scripts/tests/test-headless-runtime-checkpoint-tests.sh
+++ b/.agents/scripts/tests/test-headless-runtime-checkpoint-tests.sh
@@ -17,18 +17,23 @@ test_post_pr_handoff_detects_open_pending_pr() {
 	local expected_head
 	expected_head=$(git -C "$work_dir" rev-parse HEAD)
 
-	gh() {
+	gh_pr_list() {
 		local args="$*"
-		if [[ "$args" == *"pr list"* && "$args" == *"--state all"* && "$args" == *"--head feature/auto-test-issue-99999"* ]]; then
+		if [[ "$args" == *"--state all"* && "$args" == *"--head feature/auto-test-issue-99999"* ]]; then
 			printf '[{"number":123,"state":"OPEN","isDraft":false,"mergedAt":null,"headRefOid":"%s","labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]' "$expected_head"
-			return 0
-		fi
-		if [[ "$args" == *"api --paginate"* && "$args" == *"/issues/123/comments"* ]]; then
-			printf '%s' '[[{"body":"<!-- MERGE_SUMMARY -->"}]]'
 			return 0
 		fi
 		printf '[]'
 		return 0
+	}
+
+	gh() {
+		local args="$*"
+		if [[ "$args" == *"api --paginate"* && "$args" == *"/issues/123/comments"* ]]; then
+			printf '%s' '[[{"body":"<!-- MERGE_SUMMARY -->"}]]'
+			return 0
+		fi
+		return 1
 	}
 
 	if _worker_post_pr_handoff_confirmed "issue-99999" "$work_dir"; then
@@ -39,6 +44,7 @@ test_post_pr_handoff_detects_open_pending_pr() {
 	fi
 
 	unset DISPATCH_REPO_SLUG 2>/dev/null || true
+	unset -f gh_pr_list 2>/dev/null || true
 	unset -f gh 2>/dev/null || true
 	return 0
 }
@@ -74,18 +80,18 @@ test_post_pr_handoff_treats_ci_as_monitoring_state() {
 	local rollup_json=""
 	local fixture_label=""
 
+	gh_pr_list() {
+		printf '[{"number":126,"state":"OPEN","isDraft":false,"mergedAt":null,"headRefOid":"%s","labels":[{"name":"origin:worker"}],"statusCheckRollup":%s}]' "$expected_head" "$rollup_json"
+		return 0
+	}
+
 	gh() {
 		local args="$*"
-		if [[ "$args" == *"pr list"* ]]; then
-			printf '[{"number":126,"state":"OPEN","isDraft":false,"mergedAt":null,"headRefOid":"%s","labels":[{"name":"origin:worker"}],"statusCheckRollup":%s}]' "$expected_head" "$rollup_json"
-			return 0
-		fi
 		if [[ "$args" == *"api --paginate"* && "$args" == *"/issues/126/comments"* ]]; then
 			printf '%s' '[[{"body":"<!-- MERGE_SUMMARY -->"}]]'
 			return 0
 		fi
-		printf '[]'
-		return 0
+		return 1
 	}
 
 	while IFS=$'\t' read -r fixture_label rollup_json; do
@@ -103,6 +109,7 @@ pending only	[{"name":"tests","status":"IN_PROGRESS","conclusion":null}]
 EOF
 
 	unset DISPATCH_REPO_SLUG 2>/dev/null || true
+	unset -f gh_pr_list 2>/dev/null || true
 	unset -f gh 2>/dev/null || true
 	return 0
 }
@@ -119,12 +126,13 @@ test_post_pr_handoff_rejects_mismatched_head_or_missing_summary() {
 	local summary_count=1
 	local remote_is_draft="false"
 
+	gh_pr_list() {
+		printf '[{"number":125,"state":"OPEN","isDraft":%s,"mergedAt":null,"headRefOid":"%s","labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]' "$remote_is_draft" "$remote_head"
+		return 0
+	}
+
 	gh() {
 		local args="$*"
-		if [[ "$args" == *"pr list"* ]]; then
-			printf '[{"number":125,"state":"OPEN","isDraft":%s,"mergedAt":null,"headRefOid":"%s","labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]' "$remote_is_draft" "$remote_head"
-			return 0
-		fi
 		if [[ "$args" == *"api --paginate"* ]]; then
 			if [[ "$summary_count" -gt 0 ]]; then
 				printf '%s' '[[{"body":"<!-- MERGE_SUMMARY -->"}]]'
@@ -133,8 +141,7 @@ test_post_pr_handoff_rejects_mismatched_head_or_missing_summary() {
 			fi
 			return 0
 		fi
-		printf '[]'
-		return 0
+		return 1
 	}
 
 	if _worker_post_pr_handoff_confirmed "issue-99999" "$work_dir"; then
@@ -158,6 +165,7 @@ test_post_pr_handoff_rejects_mismatched_head_or_missing_summary() {
 	fi
 
 	unset DISPATCH_REPO_SLUG 2>/dev/null || true
+	unset -f gh_pr_list 2>/dev/null || true
 	unset -f gh 2>/dev/null || true
 	return 0
 }
@@ -429,7 +437,7 @@ test_post_pr_handoff_rejects_pre_pr_stall() {
 	git -C "$work_dir" checkout -q -b "feature/auto-test-issue-99999"
 	DISPATCH_REPO_SLUG="test-owner/test-repo"
 
-	gh() {
+	gh_pr_list() {
 		printf '[]'
 		return 0
 	}
@@ -442,7 +450,7 @@ test_post_pr_handoff_rejects_pre_pr_stall() {
 	fi
 
 	unset DISPATCH_REPO_SLUG 2>/dev/null || true
-	unset -f gh 2>/dev/null || true
+	unset -f gh_pr_list 2>/dev/null || true
 	return 0
 }
 
@@ -455,18 +463,18 @@ test_post_pr_handoff_overrides_watchdog_next_action() {
 	local expected_head
 	expected_head=$(git -C "$work_dir" rev-parse HEAD)
 
+	gh_pr_list() {
+		printf '[{"number":124,"state":"OPEN","isDraft":false,"mergedAt":null,"headRefOid":"%s","labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]' "$expected_head"
+		return 0
+	}
+
 	gh() {
 		local args="$*"
-		if [[ "$args" == *"pr list"* && "$args" == *"--state all"* ]]; then
-			printf '[{"number":124,"state":"OPEN","isDraft":false,"mergedAt":null,"headRefOid":"%s","labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]' "$expected_head"
-			return 0
-		fi
 		if [[ "$args" == *"api --paginate"* && "$args" == *"/issues/124/comments"* ]]; then
 			printf '%s' '[[{"body":"<!-- MERGE_SUMMARY -->"}]]'
 			return 0
 		fi
-		printf '[]'
-		return 0
+		return 1
 	}
 
 	local evidence_fields="" launch_failure_cause="" next_action=""
@@ -479,6 +487,7 @@ test_post_pr_handoff_overrides_watchdog_next_action() {
 	fi
 
 	unset DISPATCH_REPO_SLUG 2>/dev/null || true
+	unset -f gh_pr_list 2>/dev/null || true
 	unset -f gh 2>/dev/null || true
 
 	if [[ "$launch_failure_cause" == "post_pr_pending_ci_handoff" && "$next_action" == "monitor_open_pr" ]]; then

--- a/.agents/scripts/tests/test-headless-runtime-completion-tests.sh
+++ b/.agents/scripts/tests/test-headless-runtime-completion-tests.sh
@@ -122,14 +122,14 @@ test_worker_produced_output_branch_no_pr_returns_branch_orphan() {
 	local work_dir="${TEST_ROOT}/repo-orphan"
 	_setup_test_git_repo "$work_dir" 1
 	git -C "$work_dir" push -q origin "feature/auto-test-issue-99999"
-	# Set DISPATCH_REPO_SLUG and stub gh to return 0 PRs
+	# Set DISPATCH_REPO_SLUG and stub the PR-list wrapper to return no PRs.
 	DISPATCH_REPO_SLUG="test-owner/test-repo"
-	gh() { printf '0'; return 0; }
+	gh_pr_list() { printf '[]'; return 0; }
 
 	local classification
 	classification=$(_worker_produced_output "issue-99999" "$work_dir")
 	unset DISPATCH_REPO_SLUG 2>/dev/null || true
-	unset -f gh 2>/dev/null || true
+	unset -f gh_pr_list 2>/dev/null || true
 
 	if [[ "$classification" == "branch_orphan" ]]; then
 		print_result "_worker_produced_output returns 'branch_orphan' (commits + branch, no PR)" 0
@@ -145,12 +145,12 @@ test_worker_produced_output_local_branch_no_remote_returns_local_branch_unpushed
 	_setup_test_git_repo "$work_dir" 1
 	# Do not push the feature branch: local commits exist, remote branch absent.
 	DISPATCH_REPO_SLUG="test-owner/test-repo"
-	gh() { printf '0'; return 0; }
+	gh_pr_list() { printf '[]'; return 0; }
 
 	local classification
 	classification=$(_worker_produced_output "issue-99999" "$work_dir")
 	unset DISPATCH_REPO_SLUG 2>/dev/null || true
-	unset -f gh 2>/dev/null || true
+	unset -f gh_pr_list 2>/dev/null || true
 
 	if [[ "$classification" == "local_branch_unpushed" ]]; then
 		print_result "_worker_produced_output returns 'local_branch_unpushed' for local-only committed branch" 0
@@ -169,13 +169,15 @@ test_worker_produced_output_branch_with_pr_returns_pr_exists() {
 	DISPATCH_REPO_SLUG="test-owner/test-repo"
 	local expected_head
 	expected_head=$(git -C "$work_dir" rev-parse HEAD)
+	gh_pr_list() {
+		printf '[{"number":123,"state":"OPEN","isDraft":false,"mergedAt":null,"headRefOid":"%s","labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]\n' "$expected_head"
+		return 0
+	}
 	gh() {
 		if [[ "${*}" == *"api --paginate"* && "${*}" == *"/issues/123/comments"* ]]; then
 			printf '%s\n' '[[{"body":"<!-- MERGE_SUMMARY -->"}]]'
-		elif [[ "${*}" == *"--head"* && "${*}" == *"statusCheckRollup"* ]]; then
-			printf '[{"number":123,"state":"OPEN","isDraft":false,"mergedAt":null,"headRefOid":"%s","labels":[{"name":"origin:worker"}],"statusCheckRollup":[]}]\n' "$expected_head"
 		else
-			printf '%s\n' '[]'
+			return 1
 		fi
 		return 0
 	}
@@ -183,6 +185,7 @@ test_worker_produced_output_branch_with_pr_returns_pr_exists() {
 	local classification
 	classification=$(_worker_produced_output "issue-99999" "$work_dir")
 	unset DISPATCH_REPO_SLUG 2>/dev/null || true
+	unset -f gh_pr_list 2>/dev/null || true
 	unset -f gh 2>/dev/null || true
 
 	if [[ "$classification" == "pr_exists" ]]; then


### PR DESCRIPTION
## Summary

Route headless runtime PR-handoff fixtures through gh_pr_list while keeping merge-summary API doubles separate; make absent, mismatched, draft, CI-state, watchdog, and confirmed-PR classifications deterministic and offline.

## Files Changed

.agents/scripts/tests/test-headless-runtime-checkpoint-tests.sh, .agents/scripts/tests/test-headless-runtime-completion-tests.sh

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Clean environment: bash .agents/scripts/tests/test-headless-runtime-helper.sh; shellcheck .agents/scripts/tests/test-headless-runtime-checkpoint-tests.sh .agents/scripts/tests/test-headless-runtime-completion-tests.sh .agents/scripts/tests/test-headless-runtime-helper.sh

Resolves #29872


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.247 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 7m and 115,139 tokens on this as a headless worker.