### PR TITLE
GH#29874: fix: bound Unicode arrows in brief transport checks

### DIFF
--- a/.agents/scripts/log-issue-helper.sh
+++ b/.agents/scripts/log-issue-helper.sh
@@ -397,7 +397,8 @@ _brief_asserts_transport_cause() {
 	local rate_limit='(^|[^[:alnum:]_])rate[[:space:]_-]?limit([^[:alnum:]_]|$)'
 	local stalled='(^|[^[:alnum:]_])(hang|hung|timeout)([^[:alnum:]_]|$)'
 	local causal='because|due to|root cause|cause(d|s)?|results? in|leads? to|triggers?'
-	if grep -Eqi "(${causal}).{0,120}(${failure})|(${failure}).{0,120}(${causal})|(${rate_limit}).{0,120}(${stalled})|[→]" <<<"$body"; then
+	local arrow='[→]'
+	if grep -Eqi "(${causal}).{0,120}(${failure})|(${failure}).{0,120}(${causal})|(${rate_limit}).{0,120}(${stalled})|(${failure}).{0,120}(${arrow})|(${arrow}).{0,120}(${failure})" <<<"$body"; then
 		return 0
 	fi
 	return 1

--- a/.agents/scripts/tests/test-verify-brief.sh
+++ b/.agents/scripts/tests/test-verify-brief.sh
@@ -533,6 +533,40 @@ else
 	fail "G1 transport token boundaries" "expected rc=0, got rc=$rc; output: $output"
 fi
 
+cat >"$TMP/brief-ordinary-arrow.md" <<'BRIEF'
+## Reproducer
+**Symptom command**: `aidevops review`
+**Actual output**: `reviewDecision=CHANGES_REQUESTED`
+**Causal status**: confirmed
+**Production entry point**: review.sh:42 reads the review decision
+**Call chain**: read_decision → classify_review
+**Integrated verification**: test-review.sh exercises the confirmed path
+BRIEF
+
+output=$(bash "$HELPER" validate-brief "$TMP/brief-ordinary-arrow.md" 2>&1)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+	pass "G2 ordinary call-chain arrows do not require transport evidence"
+else
+	fail "G2 ordinary call-chain arrow" "expected rc=0, got rc=$rc; output: $output"
+fi
+
+cat >"$TMP/brief-arrow-transport-claim.md" <<'BRIEF'
+## Reproducer
+**Symptom command**: `aidevops pulse`
+**Actual output**: the operation stopped
+**Causal status**: confirmed
+**Call chain**: scheduler → timeout
+BRIEF
+
+output=$(bash "$HELPER" validate-brief "$TMP/brief-arrow-transport-claim.md" 2>&1)
+rc=$?
+if [[ $rc -ne 0 && "$output" == *"require **Blocked command** and **Backend state**"* ]]; then
+	pass "G3 arrow-based transport claims are rejected without evidence"
+else
+	fail "G3 arrow-based transport claim" "expected transport-evidence rejection, got rc=$rc; output: $output"
+fi
+
 for transport_claim in \
 	"The root cause is a hang." \
 	"The worker HUNG because the scheduler stopped." \
@@ -551,9 +585,9 @@ BRIEF
 	output=$(bash "$HELPER" validate-brief "$TMP/brief-real-transport-claim.md" 2>&1)
 	rc=$?
 	if [[ $rc -ne 0 && "$output" == *"require **Blocked command** and **Backend state**"* ]]; then
-		pass "G2 genuine transport claim is rejected without evidence: $transport_claim"
+		pass "G4 genuine transport claim is rejected without evidence: $transport_claim"
 	else
-		fail "G2 genuine transport claim detection: $transport_claim" "expected transport-evidence rejection, got rc=$rc; output: $output"
+		fail "G4 genuine transport claim detection: $transport_claim" "expected transport-evidence rejection, got rc=$rc; output: $output"
 	fi
 done
 

--- a/.agents/scripts/verify-brief-helper.sh
+++ b/.agents/scripts/verify-brief-helper.sh
@@ -84,14 +84,14 @@ _parse_verify_blocks() {
 
 	while IFS= read -r line; do
 		# Detect start of a yaml fenced block
-		if [[ $in_yaml_block -eq 0 ]] && echo "$line" | grep -qE '^\s*```ya?ml\s*$'; then
+		if [[ $in_yaml_block -eq 0 ]] && echo "$line" | grep -qE '^[[:space:]]*```ya?ml[[:space:]]*$'; then
 			in_yaml_block=1
 			block_content=""
 			continue
 		fi
 
 		# Detect end of fenced block
-		if [[ $in_yaml_block -eq 1 ]] && echo "$line" | grep -qE '^\s*```\s*$'; then
+		if [[ $in_yaml_block -eq 1 ]] && echo "$line" | grep -qE '^[[:space:]]*```[[:space:]]*$'; then
 			in_yaml_block=0
 
 			# Check if block contains verify:
@@ -100,16 +100,16 @@ _parse_verify_blocks() {
 
 				# Extract method (|| true guards against set -e in process substitution)
 				local method=""
-				method=$(echo "$block_content" | grep -oE 'method:\s*\S+' | head -1 | sed 's/method:\s*//' || true)
+				method=$(echo "$block_content" | grep -oE 'method:[[:space:]]*[^[:space:]]+' | head -1 | sed 's/method:[[:space:]]*//' || true)
 
 				# Extract run: value (everything after run: with surrounding quotes stripped)
 				# Handles inline strings and YAML block scalars (| or >)
 				local run_value=""
 				local run_line=""
-				run_line=$(echo "$block_content" | { grep '^\s*run:' || true; } | head -1)
+				run_line=$(echo "$block_content" | { grep '^[[:space:]]*run:' || true; } | head -1)
 				if [[ -n "$run_line" ]]; then
 					local raw_value=""
-					raw_value=$(echo "$run_line" | sed 's/^\s*run:\s*//')
+					raw_value=$(echo "$run_line" | sed 's/^[[:space:]]*run:[[:space:]]*//')
 					# Detect YAML block scalar indicators (| or >)
 					if [[ "$raw_value" == "|" || "$raw_value" == ">" || "$raw_value" == "|-" || "$raw_value" == ">-" ]]; then
 						# Collect indented continuation lines after run:
@@ -118,10 +118,10 @@ _parse_verify_blocks() {
 						local multiline=""
 						while IFS= read -r bline; do
 							if [[ $collecting -eq 1 ]]; then
-								if echo "$bline" | grep -qE '^\s+'; then
+								if echo "$bline" | grep -qE '^[[:space:]]+'; then
 									# Strip common leading whitespace (up to 6 spaces)
 									local stripped=""
-									stripped=$(echo "$bline" | sed 's/^\s\{1,6\}//')
+									stripped=$(echo "$bline" | sed 's/^[[:space:]]\{1,6\}//')
 									if [[ -n "$stripped" ]]; then
 										if [[ -n "$multiline" ]]; then
 											multiline="${multiline}; ${stripped}"
@@ -133,7 +133,7 @@ _parse_verify_blocks() {
 									break
 								fi
 							fi
-							if echo "$bline" | grep -qE '^\s*run:'; then
+							if echo "$bline" | grep -qE '^[[:space:]]*run:'; then
 								collecting=1
 							fi
 						done <<<"$block_content"
@@ -146,7 +146,7 @@ _parse_verify_blocks() {
 
 				# Extract prompt: value (for manual blocks)
 				local prompt_value=""
-				prompt_value=$(echo "$block_content" | { grep '^\s*prompt:' || true; } | head -1 | sed 's/^\s*prompt:\s*//' | sed 's/^"\(.*\)"$/\1/' | sed "s/^'\(.*\)'$/\1/")
+				prompt_value=$(echo "$block_content" | { grep '^[[:space:]]*prompt:' || true; } | head -1 | sed 's/^[[:space:]]*prompt:[[:space:]]*//' | sed 's/^"\(.*\)"$/\1/' | sed "s/^'\(.*\)'$/\1/")
 
 				local value="$run_value"
 				if [[ -z "$value" ]]; then


### PR DESCRIPTION
## Summary

Bound arrow detection to nearby transport terms, added arrow regression coverage, and restored portable verification-block parsing.

## Files Changed

.agents/scripts/log-issue-helper.sh, .agents/scripts/tests/test-verify-brief.sh, .agents/scripts/verify-brief-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-verify-brief.sh; shellcheck .agents/scripts/log-issue-helper.sh .agents/scripts/verify-brief-helper.sh .agents/scripts/tests/test-verify-brief.sh

Resolves #29874


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.247 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 6m and 86,802 tokens on this as a headless worker.