### PR TITLE
GH#29887: feat: make session mining incremental

### DIFF
--- a/.agents/scripts/session-miner/compress.py
+++ b/.agents/scripts/session-miner/compress.py
@@ -142,7 +142,7 @@ def normalize_for_dedup(text: str) -> str:
     return t[:200]  # First 200 chars for comparison
 
 
-def _extract_steerage_signal(record: dict, seen: set):
+def _extract_steerage_signal(record: dict):
     """Extract a cleaned, deduplicated signal from a steerage record.
 
     Returns a signal dict or None if the record should be skipped.
@@ -158,28 +158,32 @@ def _extract_steerage_signal(record: dict, seen: set):
     if len(clean_text) < 20:
         return None
 
-    norm = normalize_for_dedup(clean_text)
-    if norm in seen:
-        return None
-    seen.add(norm)
-
     return {
         "text": clean_text[:1000],
         "context": record.get("preceding_context", "")[:200],
+        "source_hash": record.get("source_hash", ""),
     }
 
 
 def compress_steerage(chunks_dir: Path) -> dict:
     """Compress all steerage chunks into category-grouped unique signals."""
     categories = defaultdict(list)
-    seen = set()
+    seen_by_category: dict[str, set[str]] = defaultdict(set)
 
     for chunk in _iter_chunks(chunks_dir, "steerage_*.json"):
-        category = chunk.get("category", "unknown")
-
         for record in chunk.get("records", []):
-            signal = _extract_steerage_signal(record, seen)
-            if signal is not None:
+            signal = _extract_steerage_signal(record)
+            if signal is None:
+                continue
+            record_categories = {
+                classification.get("category", "unknown")
+                for classification in record.get("classifications", [])
+            } or {chunk.get("category", "unknown")}
+            norm = normalize_for_dedup(signal["text"])
+            for category in record_categories:
+                if norm in seen_by_category[category]:
+                    continue
+                seen_by_category[category].add(norm)
                 categories[category].append(signal)
 
     return dict(categories)
@@ -337,16 +341,11 @@ def compress_git_correlation(chunks_dir: Path) -> dict:
     }
 
 
-def _extract_instruction_candidate(record: dict, seen: set[str]):
+def _extract_instruction_candidate(record: dict):
     """Extract a deduplicated instruction-candidate payload."""
     raw_text = record.get("text", "")
     if not raw_text or len(raw_text) < 20:
         return None
-
-    norm = normalize_for_dedup(raw_text)
-    if norm in seen:
-        return None
-    seen.add(norm)
 
     target_file = record.get("target_file", ".agents/AGENTS.md")
     raw_display_text = record.get("display_text") or raw_text
@@ -357,6 +356,15 @@ def _extract_instruction_candidate(record: dict, seen: set[str]):
         "confidence": record.get("confidence", 0.5),
         "category": record.get("category", "general"),
         "session_title": record.get("session_title", "")[:80],
+        "session_id": record.get("session_id", ""),
+        "timestamp": record.get("timestamp"),
+        "source_hash": record.get("source_hash", ""),
+        "fingerprint": record.get("fingerprint") or normalize_for_dedup(raw_text),
+        "polarity": record.get("polarity", "positive"),
+        # Historical chunk files predate qualification metadata. Preserve their
+        # prior readability while new extractors enforce evidence thresholds.
+        "explicit_persistence": bool(record.get("explicit_persistence"))
+        if "explicit_persistence" in record else True,
     }
 
 
@@ -366,21 +374,39 @@ def compress_instruction_candidates(chunks_dir: Path) -> dict:
     Groups by target file, deduplicates near-identical texts, and ranks by
     confidence score. Returns a dict keyed by target file with candidate lists.
     """
-    by_target: dict[str, list[dict]] = defaultdict(list)
-    seen: set[str] = set()
+    clusters: dict[tuple[str, str], list[dict]] = defaultdict(list)
 
     for record in _iter_chunk_records(chunks_dir, "instruction_candidate_*.json"):
-        extracted = _extract_instruction_candidate(record, seen)
+        extracted = _extract_instruction_candidate(record)
         if extracted is None:
             continue
         target_file, candidate = extracted
-        by_target[target_file].append(candidate)
+        clusters[(target_file, candidate["fingerprint"])].append(candidate)
 
     # Sort each target's candidates by confidence descending
     result: dict[str, list[dict]] = {}
-    for target_file, candidates in sorted(by_target.items()):
-        candidates.sort(key=lambda x: -x["confidence"])
-        result[target_file] = candidates
+    for (target_file, _fingerprint), observations in sorted(clusters.items()):
+        distinct_sessions = sorted({item["session_id"] for item in observations if item["session_id"]})
+        explicit = any(item["explicit_persistence"] for item in observations)
+        polarities = {item["polarity"] for item in observations}
+        timestamps = [item["timestamp"] for item in observations if item["timestamp"] is not None]
+        representative = max(observations, key=lambda item: item["confidence"])
+        support = len(distinct_sessions)
+        candidate = {
+            **representative,
+            "support": support,
+            "first_seen": min(timestamps) if timestamps else None,
+            "last_seen": max(timestamps) if timestamps else None,
+            "qualification_basis": "explicit_persistence" if explicit else "recurring" if support >= 2 else "insufficient_support",
+            "requires_judgment": len(polarities) > 1,
+            "contradictions": sorted(polarities) if len(polarities) > 1 else [],
+        }
+        if candidate["qualification_basis"] == "insufficient_support":
+            continue
+        result.setdefault(target_file, []).append(candidate)
+
+    for target_file, candidates in result.items():
+        candidates.sort(key=lambda item: (-item["support"], -item["confidence"]))
 
     return result
 

--- a/.agents/scripts/session-miner/extract.py
+++ b/.agents/scripts/session-miner/extract.py
@@ -26,6 +26,7 @@ Usage:
 """
 
 import argparse
+import hashlib
 import json
 import re
 import sqlite3
@@ -39,7 +40,12 @@ from typing import Any, Optional
 from extract_chunking import ChunkConfig, build_chunks
 from extract_errors import extract_error_stats, extract_errors
 from extract_git import extract_git_correlation
-from extract_shared import repo_scope_clause, repo_scope_params, sanitize_path as _sanitize_path
+from extract_shared import (
+    extraction_scope_params,
+    repo_scope_clause,
+    sanitize_path as _sanitize_path,
+    time_scope_clause,
+)
 from extract_steerage import (
     STEERAGE_PATTERNS,
     extract_steerage,
@@ -193,7 +199,9 @@ def classify_instruction_candidate(text: str) -> Optional[dict[str, Any]]:
     }
 
 
-def _build_instruction_candidate_query(limit: Optional[int], repo_dir: Optional[str] = None) -> str:
+def _build_instruction_candidate_query(
+    limit: Optional[int], repo_dir: Optional[str] = None, since_ms: Optional[int] = None,
+) -> str:
     """Return the SQL query used to scan user messages for instructions."""
     query = """
     SELECT
@@ -208,6 +216,7 @@ def _build_instruction_candidate_query(limit: Optional[int], repo_dir: Optional[
     WHERE json_extract(m.data, '$.role') = 'user'
     """
     query += repo_scope_clause(repo_dir)
+    query += time_scope_clause(since_ms, "m.time_created")
     query += "\n    ORDER BY m.time_created ASC\n    "
     if limit:
         query += f" LIMIT {int(limit) * 10}"
@@ -231,18 +240,41 @@ def _build_instruction_candidate_record(
     if classification is None:
         return None
 
+    explicit_persistence = any(pattern.search(text) for pattern in _INSTRUCTION_COMPILED[:2])
+    fingerprint = re.sub(
+        r"\b(always|never|prefer|please|should|must|do not|don't|use)\b", "", text.lower(),
+    )
+    fingerprint = re.sub(r"[^\w\s]", "", fingerprint)
+    fingerprint = re.sub(r"\s+", " ", fingerprint).strip()[:200]
+    polarity = "negative" if re.search(r"\b(never|avoid|do not|don't|skip)\b", text, re.IGNORECASE) else "positive"
     return {
         "type": "instruction_candidate",
         "session_id": row["session_id"],
+        "message_id": row["message_id"],
         "session_title": row["session_title"] or "",
         "session_dir": _sanitize_path(row["session_dir"] or ""),
         "timestamp": row["msg_time"],
         "text": text[:2000],
         "display_text": redact_instruction_candidate_text(text[:2000]),
+        "source_hash": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        "fingerprint": fingerprint,
+        "polarity": polarity,
+        "explicit_persistence": explicit_persistence,
         "confidence": classification["confidence"],
         "target_file": classification["target_file"],
         "category": classification["category"],
     }
+
+
+def extract_instruction_windows(text: str) -> list[str]:
+    """Return atomic local windows eligible for instruction-candidate scoring."""
+    windows = []
+    for paragraph in re.split(r"\n\s*\n", text):
+        for sentence in re.split(r"(?<=[.!?])\s+(?=[A-Z])", paragraph):
+            window = sentence.strip()
+            if window and not window.startswith((">", "```", "BEGIN PROMPT", "BEGIN INSTRUCTIONS")):
+                windows.append(window[:1000])
+    return windows
 
 
 def _extract_message_instruction_candidates(
@@ -256,15 +288,17 @@ def _extract_message_instruction_candidates(
         if not _mark_instruction_text_seen(text, seen_texts):
             continue
 
-        record = _build_instruction_candidate_record(row, text)
-        if record is not None:
-            records.append(record)
+        for window in extract_instruction_windows(text):
+            record = _build_instruction_candidate_record(row, window)
+            if record is not None:
+                records.append(record)
 
     return records
 
 
 def extract_instruction_candidates(
     conn: sqlite3.Connection, limit: Optional[int] = None, repo_dir: Optional[str] = None,
+    since_ms: Optional[int] = None,
 ) -> list[dict]:
     """Extract instruction candidate signals from user messages.
 
@@ -283,7 +317,8 @@ def extract_instruction_candidates(
     candidates: list[dict] = []
     seen_texts: set[int] = set()
 
-    for row in conn.execute(_build_instruction_candidate_query(limit, repo_dir), repo_scope_params(repo_dir)):
+    query = _build_instruction_candidate_query(limit, repo_dir, since_ms)
+    for row in conn.execute(query, extraction_scope_params(repo_dir, since_ms)):
         candidates.extend(
             _extract_message_instruction_candidates(conn, row, seen_texts),
         )
@@ -329,7 +364,10 @@ def resolve_managed_history_db(db_path: Path) -> Path:
     return Path(result.stdout.strip())
 
 
-def write_output(data: list[dict], output_dir: Path, fmt: str = "jsonl") -> Path:
+def write_output(
+    data: list[dict], output_dir: Path, fmt: str = "jsonl",
+    extraction_metadata: Optional[dict[str, Optional[int]]] = None,
+) -> Path:
     """Write extracted data to output files."""
     output_dir.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -361,11 +399,42 @@ def write_output(data: list[dict], output_dir: Path, fmt: str = "jsonl") -> Path
                 for c in data
             ],
             "created": timestamp,
+            "extraction_metadata": extraction_metadata or {},
         }
         with open(out_path / "manifest.json", "w", encoding="utf-8") as f:
             json.dump(manifest, f, indent=2)
 
     return out_path
+
+
+def _nonnegative_epoch_ms(value: str) -> int:
+    """Parse a nonnegative epoch timestamp, rejecting unsafe silent fallbacks."""
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("--since-ms must be an integer epoch in milliseconds") from error
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("--since-ms must be a nonnegative epoch in milliseconds")
+    return parsed
+
+
+def _extraction_metadata(
+    since_ms: Optional[int], steerage: list[dict], errors: list[dict],
+    instruction_candidates: list[dict], git_correlations: Optional[list[dict]],
+) -> dict[str, Optional[int]]:
+    """Return an additive run watermark without mutating any scheduler state."""
+    timestamps = [
+        record["timestamp"] for record in steerage + errors + instruction_candidates
+        if record.get("timestamp") is not None
+    ]
+    if git_correlations:
+        timestamps.extend(record["session_end"] for record in git_correlations if record.get("session_end") is not None)
+    high_water = max(timestamps) if timestamps else None
+    return {
+        "window_start_ms": since_ms,
+        "window_end_ms": high_water,
+        "source_high_water_ms": high_water,
+    }
 
 
 def main():
@@ -382,6 +451,8 @@ def main():
                         help="Skip git correlation extraction")
     parser.add_argument("--repo-dir", type=str, default=None,
                         help="Only extract sessions whose directory is this repo or a subdirectory")
+    parser.add_argument("--since-ms", type=_nonnegative_epoch_ms, default=None,
+                        help="Only process records newer than this epoch timestamp in milliseconds")
     args = parser.parse_args()
     args.db = resolve_managed_history_db(args.db)
 
@@ -392,26 +463,36 @@ def main():
     print(f"  DB size: {args.db.stat().st_size / 1024 / 1024:.1f} MB", file=sys.stderr)
     if args.repo_dir:
         print(f"  Repo scope: {args.repo_dir}", file=sys.stderr)
+    if args.since_ms is not None:
+        print(f"  High-water start: {args.since_ms}", file=sys.stderr)
 
     conn = connect_db(args.db)
 
     try:
         # Phase 1a: Extract steerage
-        steerage = extract_steerage(conn, limit=args.limit, repo_dir=args.repo_dir)
+        steerage = extract_steerage(conn, limit=args.limit, repo_dir=args.repo_dir, since_ms=args.since_ms)
 
         # Phase 1b: Extract errors
-        errors = extract_errors(conn, limit=args.limit, repo_dir=args.repo_dir)
+        errors = extract_errors(conn, limit=args.limit, repo_dir=args.repo_dir, since_ms=args.since_ms)
 
         # Phase 1c: Aggregate stats
-        stats = extract_error_stats(conn, repo_dir=args.repo_dir)
+        stats = extract_error_stats(conn, repo_dir=args.repo_dir, since_ms=args.since_ms)
 
         # Phase 1d: Extract git correlation (unless disabled)
         git_correlations = None
         if not args.no_git:
-            git_correlations = extract_git_correlation(conn, limit=args.limit, repo_dir=args.repo_dir)
+            git_correlations = extract_git_correlation(
+                conn, limit=args.limit, repo_dir=args.repo_dir, since_ms=args.since_ms,
+            )
 
         # Phase 1e: Extract instruction candidates
-        instruction_candidates = extract_instruction_candidates(conn, limit=args.limit, repo_dir=args.repo_dir)
+        instruction_candidates = extract_instruction_candidates(
+            conn, limit=args.limit, repo_dir=args.repo_dir, since_ms=args.since_ms,
+        )
+        extraction_metadata = _extraction_metadata(
+            args.since_ms, steerage, errors, instruction_candidates, git_correlations,
+        )
+        stats["extraction_metadata"] = extraction_metadata
 
         # Phase 2: Build chunks for model analysis
         if args.format == "chunks":
@@ -421,7 +502,9 @@ def main():
                 instruction_candidates=instruction_candidates,
             )
             chunks = build_chunks(steerage, errors, chunk_config)
-            out_path = write_output(chunks, args.output, fmt="chunks")
+            out_path = write_output(
+                chunks, args.output, fmt="chunks", extraction_metadata=extraction_metadata,
+            )
             print(f"\nOutput: {out_path}/", file=sys.stderr)
             print(f"  {len(chunks)} chunks written", file=sys.stderr)
             print(f"  {len(steerage)} steerage signals", file=sys.stderr)
@@ -435,7 +518,9 @@ def main():
             if git_correlations:
                 all_records.extend(git_correlations)
             all_records.extend(instruction_candidates)
-            out_path = write_output(all_records, args.output, fmt="jsonl")
+            out_path = write_output(
+                all_records, args.output, fmt="jsonl", extraction_metadata=extraction_metadata,
+            )
             print(f"\nOutput: {out_path}", file=sys.stderr)
             print(f"  {len(steerage)} steerage + {len(errors)} errors + {len(instruction_candidates)} instruction candidates", file=sys.stderr)
 
@@ -455,6 +540,7 @@ def main():
             ),
             "error_categories": stats.get("error_categories", {}),
             "output": str(out_path),
+            "extraction_metadata": extraction_metadata,
         }
         if git_correlations is not None:
             productive = [c for c in git_correlations if c["commits_count"] > 0]

--- a/.agents/scripts/session-miner/extract_chunking.py
+++ b/.agents/scripts/session-miner/extract_chunking.py
@@ -81,15 +81,6 @@ def _build_git_summary_chunk(git_correlations: list[dict]) -> dict:
     }
 
 
-def _group_steerage_records(steerage: list[dict]) -> dict[str, list[dict]]:
-    """Group steerage records by classification category."""
-    grouped: dict[str, list[dict]] = defaultdict(list)
-    for record in steerage:
-        for classification in record["classifications"]:
-            grouped[classification["category"]].append(record)
-    return grouped
-
-
 def _group_error_records(errors: list[dict]) -> dict[str, list[dict]]:
     """Group error records by error category."""
     grouped: dict[str, list[dict]] = defaultdict(list)
@@ -114,8 +105,9 @@ def build_chunks(steerage: list[dict], errors: list[dict], config: ChunkConfig) 
         "data": config.stats,
     }]
 
-    for category, records in _group_steerage_records(steerage).items():
-        _chunk_records(records, "steerage", category, chunks, config.max_chunk_bytes)
+    # One steerage record can have several classifications. Store it once and
+    # retain all memberships on the record so no category loses a valid signal.
+    _chunk_records(steerage, "steerage", "all", chunks, config.max_chunk_bytes)
 
     for category, records in _group_error_records(errors).items():
         _chunk_records(records, "error", category, chunks, config.max_chunk_bytes)

--- a/.agents/scripts/session-miner/extract_errors.py
+++ b/.agents/scripts/session-miner/extract_errors.py
@@ -10,7 +10,13 @@ import sys
 from collections import defaultdict
 from typing import Any, Optional
 
-from extract_shared import repo_scope_clause, repo_scope_params, sanitize_path, summarize_tool_input
+from extract_shared import (
+    extraction_scope_params,
+    repo_scope_clause,
+    sanitize_path,
+    summarize_tool_input,
+    time_scope_clause,
+)
 
 
 ERROR_CATEGORIES = {
@@ -102,6 +108,7 @@ def _find_user_response_after(
 
 def extract_errors(
     conn: sqlite3.Connection, limit: Optional[int] = None, repo_dir: Optional[str] = None,
+    since_ms: Optional[int] = None,
 ) -> list[dict]:
     """Extract tool error sequences with surrounding context."""
     print("Extracting error sequences...", file=sys.stderr)
@@ -125,12 +132,13 @@ def extract_errors(
       AND json_extract(p.data, '$.state.status') = 'error'
     """
     query += repo_scope_clause(repo_dir)
+    query += time_scope_clause(since_ms, "p.time_created")
     query += "\n    ORDER BY p.time_created DESC\n    "
     if limit:
         query += f" LIMIT {int(limit)}"
 
     records = []
-    for row in conn.execute(query, repo_scope_params(repo_dir)):
+    for row in conn.execute(query, extraction_scope_params(repo_dir, since_ms)):
         error_text = row["error_text"] or ""
         tool_name = row["tool_name"] or "unknown"
         tool_input = _parse_json_safe(row["tool_input_json"])
@@ -152,11 +160,13 @@ def extract_errors(
     return records
 
 
-def extract_error_stats(conn: sqlite3.Connection, repo_dir: Optional[str] = None) -> dict:
+def extract_error_stats(
+    conn: sqlite3.Connection, repo_dir: Optional[str] = None, since_ms: Optional[int] = None,
+) -> dict:
     """Extract aggregate error statistics for the summary."""
     stats = {}
 
-    params = repo_scope_params(repo_dir)
+    params = extraction_scope_params(repo_dir, since_ms)
     tool_rows = conn.execute("""
         SELECT
             json_extract(p.data, '$.tool') as tool,
@@ -165,7 +175,7 @@ def extract_error_stats(conn: sqlite3.Connection, repo_dir: Optional[str] = None
         FROM part p
         JOIN session s ON p.session_id = s.id
         WHERE json_extract(p.data, '$.type') = 'tool'
-    """ + repo_scope_clause(repo_dir) + """
+    """ + repo_scope_clause(repo_dir) + time_scope_clause(since_ms, "p.time_created") + """
         GROUP BY tool
         ORDER BY total DESC
     """, params).fetchall()
@@ -185,7 +195,7 @@ def extract_error_stats(conn: sqlite3.Connection, repo_dir: Optional[str] = None
         JOIN session s ON p.session_id = s.id
         WHERE json_extract(p.data, '$.type') = 'tool'
           AND json_extract(p.data, '$.state.status') = 'error'
-    """ + repo_scope_clause(repo_dir), params).fetchall()
+    """ + repo_scope_clause(repo_dir) + time_scope_clause(since_ms, "p.time_created"), params).fetchall()
     category_counts = defaultdict(int)
     for row in error_rows:
         category_counts[classify_error(row["err"] or "")] += 1
@@ -196,7 +206,7 @@ def extract_error_stats(conn: sqlite3.Connection, repo_dir: Optional[str] = None
         FROM message m
         JOIN session s ON m.session_id = s.id
         WHERE json_extract(m.data, '$.role') = 'assistant'
-    """ + repo_scope_clause(repo_dir) + """
+    """ + repo_scope_clause(repo_dir) + time_scope_clause(since_ms, "m.time_created") + """
         GROUP BY model
         ORDER BY cnt DESC
         LIMIT 10
@@ -209,7 +219,7 @@ def extract_error_stats(conn: sqlite3.Connection, repo_dir: Optional[str] = None
                MAX(time_created) as latest
         FROM session s
         WHERE 1 = 1
-    """ + repo_scope_clause(repo_dir), params).fetchone()
+    """ + repo_scope_clause(repo_dir) + time_scope_clause(since_ms, "s.time_updated"), params).fetchone()
     stats["sessions"] = {
         "total": session_row["cnt"],
         "earliest": session_row["earliest"],

--- a/.agents/scripts/session-miner/extract_git.py
+++ b/.agents/scripts/session-miner/extract_git.py
@@ -11,7 +11,7 @@ import sys
 from datetime import datetime
 from typing import Optional
 
-from extract_shared import repo_scope_clause, repo_scope_params, sanitize_path
+from extract_shared import extraction_scope_params, repo_scope_clause, sanitize_path, time_scope_clause
 
 
 def _find_git_root(directory: str) -> Optional[str]:
@@ -147,6 +147,7 @@ def _build_correlation_record(row: sqlite3.Row, commits: list[dict]) -> dict:
 
 def extract_git_correlation(
     conn: sqlite3.Connection, limit: Optional[int] = None, repo_dir: Optional[str] = None,
+    since_ms: Optional[int] = None,
 ) -> list[dict]:
     """Extract git-commit correlation data for sessions."""
     print("Extracting git correlation data...", file=sys.stderr)
@@ -165,6 +166,7 @@ def extract_git_correlation(
     WHERE s.directory IS NOT NULL AND s.directory != ''
     """
     query += repo_scope_clause(repo_dir)
+    query += time_scope_clause(since_ms, "s.time_updated")
     query += """
     GROUP BY s.id
     ORDER BY s.time_created DESC
@@ -176,7 +178,7 @@ def extract_git_correlation(
     correlations = []
     skipped = 0
 
-    for row in conn.execute(query, repo_scope_params(repo_dir)):
+    for row in conn.execute(query, extraction_scope_params(repo_dir, since_ms)):
         session_dir = row["session_dir"]
         if not session_dir or not os.path.isdir(session_dir):
             skipped += 1

--- a/.agents/scripts/session-miner/extract_shared.py
+++ b/.agents/scripts/session-miner/extract_shared.py
@@ -31,6 +31,21 @@ def repo_scope_params(repo_dir: Optional[str]) -> dict[str, str]:
     return {"repo_dir": normalized, "repo_dir_prefix": f"{normalized}/%"}
 
 
+def time_scope_clause(since_ms: Optional[int], column: str) -> str:
+    """Return a SQL fragment selecting rows strictly newer than *since_ms*."""
+    if since_ms is None:
+        return ""
+    return f" AND {column} > :since_ms"
+
+
+def extraction_scope_params(repo_dir: Optional[str], since_ms: Optional[int]) -> dict[str, Any]:
+    """Return the combined repository and high-water query parameters."""
+    params: dict[str, Any] = repo_scope_params(repo_dir)
+    if since_ms is not None:
+        params["since_ms"] = since_ms
+    return params
+
+
 def sanitize_path(path: str) -> str:
     """Strip user-specific path components, keeping project-relevant parts."""
     if not path:

--- a/.agents/scripts/session-miner/extract_steerage.py
+++ b/.agents/scripts/session-miner/extract_steerage.py
@@ -3,12 +3,18 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 """Steerage extraction helpers for session-miner."""
 
+import hashlib
 import re
 import sqlite3
 import sys
 from typing import Any, Optional
 
-from extract_shared import repo_scope_clause, repo_scope_params, sanitize_path
+from extract_shared import (
+    extraction_scope_params,
+    repo_scope_clause,
+    sanitize_path,
+    time_scope_clause,
+)
 
 
 STEERAGE_PATTERNS = {
@@ -58,14 +64,57 @@ COMPILED_PATTERNS = {
     for category, patterns in STEERAGE_PATTERNS.items()
 }
 
-_AUTOMATED_PREFIXES = ("/full-loop", '"You are the supervisor')
+_AUTOMATED_PREFIXES = (
+    "/full-loop",
+    '"You are the supervisor',
+    "Continue if you have next steps",
+    "Review the following potential duplicate",
+    "Analyze the changes made since",
+    "<file>",
+    "diff --git",
+)
+_QUOTED_PAYLOAD_PREFIXES = (">", "```", "BEGIN PROMPT", "BEGIN INSTRUCTIONS")
+_DIRECTIVE_CONTEXT = re.compile(
+    r"\b(always|never|please|must|should|remember|make sure|before|after|first|do not|don't)\b"
+    r"|^(run|use|avoid|skip|lint|test|verify)\b",
+    re.IGNORECASE,
+)
 
 
 def is_automated_or_short(text: Optional[str]) -> bool:
     """Return True if *text* should be skipped (None, too short, or templated)."""
     if not text or len(text) < 20:
         return True
-    return any(text.startswith(prefix) for prefix in _AUTOMATED_PREFIXES)
+    stripped = text.lstrip()
+    return any(stripped.startswith(prefix) for prefix in _AUTOMATED_PREFIXES + _QUOTED_PAYLOAD_PREFIXES)
+
+
+def _sentence_windows(text: str) -> list[str]:
+    """Return bounded, human-authored sentence or paragraph windows from *text*."""
+    windows: list[str] = []
+    for paragraph in re.split(r"\n\s*\n", text):
+        paragraph = paragraph.strip()
+        if not paragraph or paragraph.startswith(_QUOTED_PAYLOAD_PREFIXES):
+            continue
+        sentences = re.split(r"(?<=[.!?])\s+(?=[A-Z])", paragraph)
+        windows.extend(sentence.strip() for sentence in sentences if sentence.strip())
+    return windows
+
+
+def extract_guidance_windows(text: str) -> list[dict[str, Any]]:
+    """Return classified atomic guidance windows rather than a whole user turn."""
+    if is_automated_or_short(text):
+        return []
+
+    windows: list[dict[str, Any]] = []
+    for window in _sentence_windows(text):
+        classifications = classify_steerage(window)
+        # Broad quality keywords such as "lint" are useful only in a directive,
+        # otherwise long explanatory turns would become false steerage signals.
+        is_correction = any(item["category"] == "correction" for item in classifications)
+        if classifications and (is_correction or _DIRECTIVE_CONTEXT.search(window)):
+            windows.append({"text": window[:1000], "classifications": classifications})
+    return windows
 
 
 def fetch_text_parts(conn: sqlite3.Connection, message_id: str) -> list[str]:
@@ -120,21 +169,21 @@ def classify_steerage(text: str) -> list[dict[str, Any]]:
     return matches
 
 
-def _classify_and_build_steerage(
-    conn: sqlite3.Connection, row: sqlite3.Row, text: str,
-) -> Optional[dict]:
-    """Classify *text* and build a steerage record, or ``None`` if not steerage."""
-    classifications = classify_steerage(text)
-    if not classifications:
-        return None
-
+def _build_steerage_record(
+    conn: sqlite3.Connection, row: sqlite3.Row, window: dict[str, Any], source_text: str,
+) -> dict:
+    """Build a provenance-aware steerage record for one atomic guidance window."""
+    window_text = window["text"]
     return {
         "type": "steerage",
+        "session_id": row["session_id"],
+        "message_id": row["message_id"],
         "session_title": row["session_title"] or "",
         "session_dir": sanitize_path(row["session_dir"] or ""),
         "timestamp": row["msg_time"],
-        "user_text": text[:2000],
-        "classifications": classifications,
+        "user_text": window_text,
+        "source_hash": hashlib.sha256(source_text.encode("utf-8")).hexdigest(),
+        "classifications": window["classifications"],
         "preceding_context": _fetch_preceding_assistant_text(conn, row["session_id"], row["msg_time"]),
     }
 
@@ -153,14 +202,14 @@ def _collect_steerage_from_message(
             continue
         seen_texts.add(text_hash)
 
-        record = _classify_and_build_steerage(conn, row, text)
-        if record is not None:
-            records.append(record)
+        for window in extract_guidance_windows(text):
+            records.append(_build_steerage_record(conn, row, window, text))
     return records
 
 
 def extract_steerage(
     conn: sqlite3.Connection, limit: Optional[int] = None, repo_dir: Optional[str] = None,
+    since_ms: Optional[int] = None,
 ) -> list[dict]:
     """Extract user steerage signals from sessions."""
     print("Extracting user steerage signals...", file=sys.stderr)
@@ -179,13 +228,14 @@ def extract_steerage(
     WHERE json_extract(m.data, '$.role') = 'user'
     """
     query += repo_scope_clause(repo_dir)
+    query += time_scope_clause(since_ms, "m.time_created")
     query += "\n    ORDER BY m.time_created ASC\n    "
     if limit:
         query += f" LIMIT {int(limit) * 10}"
 
     records: list[dict] = []
     seen_texts: set[int] = set()
-    for row in conn.execute(query, repo_scope_params(repo_dir)):
+    for row in conn.execute(query, extraction_scope_params(repo_dir, since_ms)):
         records.extend(_collect_steerage_from_message(conn, row, seen_texts))
         if limit and len(records) >= limit:
             records = records[:limit]

--- a/.agents/scripts/tests/test-session-miner-repo-scope.sh
+++ b/.agents/scripts/tests/test-session-miner-repo-scope.sh
@@ -41,16 +41,18 @@ INSERT INTO session VALUES ('s-target', 'target session', '${TARGET_REPO}/subdir
 INSERT INTO session VALUES ('s-other', 'other session', '${OTHER_REPO}', 3000, 4000);
 INSERT INTO message VALUES ('m-target', 's-target', '{"role":"user","modelID":"test-model"}', 1100);
 INSERT INTO message VALUES ('m-other', 's-other', '{"role":"user","modelID":"test-model"}', 3100);
+INSERT INTO message VALUES ('m-target-new', 's-target', '{"role":"user","modelID":"test-model"}', 2100);
 INSERT INTO part VALUES ('p-target', 's-target', 'm-target', '{"type":"text","text":"Always use target repo scoped insights for contributor reports."}', 1100);
 INSERT INTO part VALUES ('p-other', 's-other', 'm-other', '{"type":"text","text":"Always use unrelated other project insights for contributor reports."}', 3100);
+INSERT INTO part VALUES ('p-target-new', 's-target', 'm-target-new', '{"type":"text","text":"Always use newly observed target repo insights for contributor reports."}', 2100);
 SQL
 
 python3 "${REPO_ROOT}/.agents/scripts/session-miner/extract.py" \
-  --db "${DB_PATH}" \
-  --format jsonl \
-  --output "${OUTPUT_DIR}" \
-  --repo-dir "${TARGET_REPO}" \
-  --no-git >/dev/null
+	--db "${DB_PATH}" \
+	--format jsonl \
+	--output "${OUTPUT_DIR}" \
+	--repo-dir "${TARGET_REPO}" \
+	--no-git >/dev/null
 
 extraction_file=$(printf '%s\n' "${OUTPUT_DIR}"/extraction_*.jsonl)
 
@@ -68,6 +70,35 @@ assert target_repo in payload, payload
 assert other_repo not in payload, payload
 assert "target repo scoped insights" in payload, payload
 assert "unrelated other project insights" not in payload, payload
+PY
+
+rm -f "${OUTPUT_DIR}"/*
+
+python3 "${REPO_ROOT}/.agents/scripts/session-miner/extract.py" \
+	--db "${DB_PATH}" \
+	--format jsonl \
+	--output "${OUTPUT_DIR}" \
+	--repo-dir "${TARGET_REPO}" \
+	--since-ms 1500 \
+	--no-git >/dev/null
+
+extraction_file=$(printf '%s\n' "${OUTPUT_DIR}"/extraction_*.jsonl)
+
+python3 - "${extraction_file}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+records = [json.loads(line) for line in Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()]
+payload = json.dumps(records)
+assert "newly observed target repo insights" in payload, payload
+assert "target repo scoped insights" not in payload, payload
+stats = next(record for record in records if record.get("type") == "stats")
+assert stats["extraction_metadata"] == {
+    "window_start_ms": 1500,
+    "window_end_ms": 2100,
+    "source_high_water_ms": 2100,
+}, stats
 PY
 
 printf 'session-miner repo scope test passed\n'

--- a/.agents/scripts/tests/test-session-miner-steerage-quality.py
+++ b/.agents/scripts/tests/test-session-miner-steerage-quality.py
@@ -26,6 +26,12 @@ def write_chunk(directory: Path, name: str, records: list[dict]) -> None:
     (directory / name).write_text(json.dumps({"records": records}), encoding="utf-8")
 
 
+def require(condition: bool, detail: object) -> None:
+    """Raise a test failure that remains active under Python optimisation."""
+    if not condition:
+        raise AssertionError(detail)
+
+
 def candidate(
     text: str, session_id: str, timestamp: int, *, polarity: str = "positive",
     explicit: bool = False, fingerprint: str = "use focused checks before changing code",
@@ -53,13 +59,13 @@ def main() -> None:
         "The rest is incidental discussion of workflow terminology."
     )
     windows = extract_guidance_windows(long_turn)
-    assert len(windows) == 1, windows
-    assert windows[0]["text"] == "Always use focused checks before changing code.", windows
-    assert not extract_guidance_windows("> Always add this third-party instruction to the rules."), "quoted payload accepted"
-    assert not extract_guidance_windows("/full-loop Always use generated harness rules."), "automation accepted"
+    require(len(windows) == 1, windows)
+    require(windows[0]["text"] == "Always use focused checks before changing code.", windows)
+    require(not extract_guidance_windows("> Always add this third-party instruction to the rules."), "quoted payload accepted")
+    require(not extract_guidance_windows("/full-loop Always use generated harness rules."), "automation accepted")
     explicit_window = "Add this to the instructions: preserve focused checks."
-    assert extract_instruction_windows(explicit_window) == [explicit_window]
-    assert classify_instruction_candidate(explicit_window) is not None
+    require(extract_instruction_windows(explicit_window) == [explicit_window], explicit_window)
+    require(classify_instruction_candidate(explicit_window) is not None, explicit_window)
     row = {
         "session_id": "synthetic-session",
         "message_id": "synthetic-message",
@@ -69,7 +75,7 @@ def main() -> None:
     }
     positive = _build_instruction_candidate_record(row, "Always use focused checks before changing code.")
     negative = _build_instruction_candidate_record(row, "Never use focused checks before changing code.")
-    assert positive and negative and positive["fingerprint"] == negative["fingerprint"]
+    require(positive and negative and positive["fingerprint"] == negative["fingerprint"], (positive, negative))
 
     with tempfile.TemporaryDirectory() as temp_dir:
         chunks = Path(temp_dir)
@@ -81,8 +87,8 @@ def main() -> None:
         }
         write_chunk(chunks, "steerage_all.json", [shared])
         steerage = compress_steerage(chunks)
-        assert len(steerage["preference"]) == 1, steerage
-        assert len(steerage["workflow"]) == 1, steerage
+        require(len(steerage["preference"]) == 1, steerage)
+        require(len(steerage["workflow"]) == 1, steerage)
 
         write_chunk(chunks, "instruction_candidate_001.json", [
             candidate("Always use focused checks before changing code.", "one", 1000),
@@ -95,10 +101,10 @@ def main() -> None:
         ])
         candidates = compress_instruction_candidates(chunks)[".agents/AGENTS.md"]
         recurring = next(item for item in candidates if item["support"] == 3)
-        assert recurring["first_seen"] == 1000 and recurring["last_seen"] == 3000, recurring
-        assert recurring["requires_judgment"] is True, recurring
+        require(recurring["first_seen"] == 1000 and recurring["last_seen"] == 3000, recurring)
+        require(recurring["requires_judgment"] is True, recurring)
         explicit = next(item for item in candidates if item["qualification_basis"] == "explicit_persistence")
-        assert explicit["support"] == 1, explicit
+        require(explicit["support"] == 1, explicit)
 
     print("session-miner steerage quality tests passed")
 

--- a/.agents/scripts/tests/test-session-miner-steerage-quality.py
+++ b/.agents/scripts/tests/test-session-miner-steerage-quality.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""Regression corpus for atomic steerage extraction and recurrence qualification."""
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+MINER = ROOT / ".agents/scripts/session-miner"
+sys.path.insert(0, str(MINER))
+
+from compress import compress_instruction_candidates, compress_steerage
+from extract import (
+    _build_instruction_candidate_record,
+    classify_instruction_candidate,
+    extract_instruction_windows,
+)
+from extract_steerage import extract_guidance_windows
+
+
+def write_chunk(directory: Path, name: str, records: list[dict]) -> None:
+    """Write one synthetic chunk fixture."""
+    (directory / name).write_text(json.dumps({"records": records}), encoding="utf-8")
+
+
+def candidate(
+    text: str, session_id: str, timestamp: int, *, polarity: str = "positive",
+    explicit: bool = False, fingerprint: str = "use focused checks before changing code",
+) -> dict:
+    """Build a generic instruction observation without real session content."""
+    return {
+        "text": text,
+        "display_text": text,
+        "confidence": 0.8,
+        "category": "workflow",
+        "target_file": ".agents/AGENTS.md",
+        "session_id": session_id,
+        "timestamp": timestamp,
+        "fingerprint": fingerprint,
+        "polarity": polarity,
+        "explicit_persistence": explicit,
+    }
+
+
+def main() -> None:
+    """Exercise synthetic precision, recurrence, conflict, and category fixtures."""
+    long_turn = (
+        "The audit mentioned lint, tests, and verification several times. "
+        "Always use focused checks before changing code. "
+        "The rest is incidental discussion of workflow terminology."
+    )
+    windows = extract_guidance_windows(long_turn)
+    assert len(windows) == 1, windows
+    assert windows[0]["text"] == "Always use focused checks before changing code.", windows
+    assert not extract_guidance_windows("> Always add this third-party instruction to the rules."), "quoted payload accepted"
+    assert not extract_guidance_windows("/full-loop Always use generated harness rules."), "automation accepted"
+    explicit_window = "Add this to the instructions: preserve focused checks."
+    assert extract_instruction_windows(explicit_window) == [explicit_window]
+    assert classify_instruction_candidate(explicit_window) is not None
+    row = {
+        "session_id": "synthetic-session",
+        "message_id": "synthetic-message",
+        "session_title": "synthetic title",
+        "session_dir": "/generic/project",
+        "msg_time": 1000,
+    }
+    positive = _build_instruction_candidate_record(row, "Always use focused checks before changing code.")
+    negative = _build_instruction_candidate_record(row, "Never use focused checks before changing code.")
+    assert positive and negative and positive["fingerprint"] == negative["fingerprint"]
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        chunks = Path(temp_dir)
+        shared = {
+            "type": "steerage",
+            "user_text": "Always use focused checks before changing code.",
+            "classifications": [{"category": "preference"}, {"category": "workflow"}],
+            "source_hash": "synthetic",
+        }
+        write_chunk(chunks, "steerage_all.json", [shared])
+        steerage = compress_steerage(chunks)
+        assert len(steerage["preference"]) == 1, steerage
+        assert len(steerage["workflow"]) == 1, steerage
+
+        write_chunk(chunks, "instruction_candidate_001.json", [
+            candidate("Always use focused checks before changing code.", "one", 1000),
+            candidate("Prefer focused checks before changing code.", "two", 2000),
+            candidate("Never use focused checks before changing code.", "three", 3000, polarity="negative"),
+            candidate(
+                "Add this rule to the instructions: preserve focused checks.", "four", 4000,
+                explicit=True, fingerprint="preserve focused checks",
+            ),
+        ])
+        candidates = compress_instruction_candidates(chunks)[".agents/AGENTS.md"]
+        recurring = next(item for item in candidates if item["support"] == 3)
+        assert recurring["first_seen"] == 1000 and recurring["last_seen"] == 3000, recurring
+        assert recurring["requires_judgment"] is True, recurring
+        explicit = next(item for item in candidates if item["qualification_basis"] == "explicit_persistence")
+        assert explicit["support"] == 1, explicit
+
+    print("session-miner steerage quality tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Extracts atomic, provenance-aware steerage with high-water filtering, recurrence qualification, contradiction evidence, and category-safe compression.

## Files Changed

.agents/scripts/session-miner/compress.py, .agents/scripts/session-miner/extract.py, .agents/scripts/session-miner/extract_chunking.py, .agents/scripts/session-miner/extract_errors.py, .agents/scripts/session-miner/extract_git.py, .agents/scripts/session-miner/extract_shared.py, .agents/scripts/session-miner/extract_steerage.py, .agents/scripts/tests/test-session-miner-repo-scope.sh, .agents/scripts/tests/test-session-miner-steerage-quality.py

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: bounded extraction against the local OpenCode schema completed with --limit 1 --no-git; synthetic steerage-quality, repo-scope, error-classification, and instruction-redaction tests passed; all session-miner Python modules compiled; .agents/scripts/linters-local.sh --changed passed.

Resolves #29887


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.247 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 4m and 94,526 tokens on this as a headless worker.