### PR TITLE
t18223: Self-heal stale Tabby recovery tokens

### DIFF
--- a/.agents/reference/tabby-profiles.md
+++ b/.agents/reference/tabby-profiles.md
@@ -49,6 +49,13 @@ containment, the session ID, original directory, and the matching SQLite row
 before running `opencode --session <id>`. Invalid markers fail closed. A normal
 OpenCode exit returns to a login zsh in the original project directory.
 
+Tabby stores a snapshot of each recovered tab's profile command. Tabs saved
+before the managed profile migration may therefore keep launching plain
+`aidevops opencode` even after `config.yaml` contains `--tabby-shell`. The
+launcher detects Tabby's `TERM_PROGRAM` and config-directory environment in
+isolated mode and implicitly enables the same recovery path, allowing those
+stale recovery tokens to self-heal after one launch.
+
 Recovery markers live under
 `~/.aidevops/.agent-workspace/work/opencode-tabby-recovery/`. They contain only
 the OpenCode session ID and local directory references, use owner-only

--- a/.agents/scripts/opencode-launcher-helper.sh
+++ b/.agents/scripts/opencode-launcher-helper.sh
@@ -253,6 +253,21 @@ opencode_args_contain_session() {
     return 1
 }
 
+tabby_shell_mode() {
+    local requested_mode="$1"
+    local use_shared_db="$2"
+
+    # Tabby recovery tokens contain a snapshot of the profile command. Tokens
+    # saved before --tabby-shell was deployed keep launching plain
+    # `aidevops opencode`; detect Tabby's environment so they self-heal.
+    if ((requested_mode == 0 && use_shared_db == 0)) \
+        && [[ "${TERM_PROGRAM:-}" == "Tabby" && -n "${TABBY_CONFIG_DIRECTORY:-}" ]]; then
+        requested_mode=1
+    fi
+    printf '%s' "${requested_mode}"
+    return 0
+}
+
 run_isolated_tui() {
     local launch_dir="$1"
     local data_dir="$2"
@@ -1290,6 +1305,7 @@ cmd_tui_launch() {
 
     validate_launch_directory "${launch_dir}" || return 1
     require_opencode_cli || return 1
+    tabby_shell=$(tabby_shell_mode "${tabby_shell}" "${use_shared_db}")
     if ((tabby_shell == 1 && use_shared_db == 1)); then
         print_error "--tabby-shell requires aidevops isolated OpenCode storage"
         return 1
@@ -1313,10 +1329,6 @@ cmd_tui_launch() {
     validate_launch_directory "${launch_dir}" || return 1
     if [[ -z "${session_id}" ]]; then
         session_id=$(build_project_session_id "${launch_dir}")
-    fi
-
-    if ((${#opencode_args[@]} == 0)); then
-        opencode_args=()
     fi
 
     if ((use_shared_db == 1)); then

--- a/.agents/scripts/tests/test-opencode-launcher-helper.sh
+++ b/.agents/scripts/tests/test-opencode-launcher-helper.sh
@@ -325,12 +325,16 @@ else
     _fail "Tabby recovered command unexpected: ${tabby_output}"
 fi
 
-output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
+output=$(TERM_PROGRAM=Tabby TABBY_CONFIG_DIRECTORY="${tmp_root}/tabby" \
+    PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
     "${HELPER}" --shared-db --dir "${launch_dir}" --dry-run 2>&1)
-if [[ "${output}" == *"opencode" ]] && [[ "${output}" != *"opencode ''"* ]]; then
-    _pass "shared-db dry-run omits a synthetic empty argument"
+if [[ "${output}" == *"opencode" ]] \
+    && [[ "${output}" != *"AIDEVOPS_TABBY_SESSION_RECOVERY=1"* ]] \
+    && [[ "${output}" != *"exec /bin/zsh -l"* ]] \
+    && [[ "${output}" != *"opencode ''"* ]]; then
+    _pass "implicit Tabby detection preserves shared-db mode"
 else
-    _fail "shared-db dry-run command unexpected: ${output}"
+    _fail "implicit Tabby shared-db command unexpected: ${output}"
 fi
 
 output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \

--- a/.agents/scripts/tests/test-opencode-launcher-helper.sh
+++ b/.agents/scripts/tests/test-opencode-launcher-helper.sh
@@ -234,7 +234,7 @@ else
 fi
 
 tui_dry_run_log="${tmp_root}/tui-dry-run-opencode.log"
-output=$(PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${tui_dry_run_work_dir}" \
+output=$(TERM_PROGRAM='' TABBY_CONFIG_DIRECTORY='' PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${tui_dry_run_work_dir}" \
     FAKE_OPENCODE_LOG="${tui_dry_run_log}" \
     "${HELPER}" --dir "${launch_dir}" --session-id dry-run-only --dry-run 2>&1)
 if [[ "${output}" == *"XDG_DATA_HOME=${tui_dry_run_work_dir}/opencode-interactive/dry-run-only"* ]] \
@@ -254,6 +254,27 @@ if [[ "${tabby_output}" == *"AIDEVOPS_TABBY_SESSION_RECOVERY=1 opencode"* ]] \
     _pass "Tabby first launch enables recovery and leaves a shell open"
 else
     _fail "Tabby first-launch command unexpected: ${tabby_output}"
+fi
+
+tabby_output=$(TERM_PROGRAM=Tabby TABBY_CONFIG_DIRECTORY="${tmp_root}/tabby" \
+    PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
+    "${HELPER}" --dir "${launch_dir}" --session-id tabby-stale-token --dry-run 2>&1)
+if [[ "${tabby_output}" == *"AIDEVOPS_TABBY_SESSION_RECOVERY=1 opencode"* ]] \
+    && [[ "${tabby_output}" == *"exec /bin/zsh -l"* ]] \
+    && [[ "${tabby_output}" != *"--session ses_"* ]]; then
+    _pass "stale Tabby profile command implicitly enables exact-session recovery"
+else
+    _fail "stale Tabby profile recovery command unexpected: ${tabby_output}"
+fi
+
+tabby_output=$(TERM_PROGRAM=Other TABBY_CONFIG_DIRECTORY="${tmp_root}/tabby" \
+    PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
+    "${HELPER}" --dir "${launch_dir}" --session-id non-tabby-terminal --dry-run 2>&1)
+if [[ "${tabby_output}" != *"AIDEVOPS_TABBY_SESSION_RECOVERY=1"* ]] \
+    && [[ "${tabby_output}" != *"exec /bin/zsh -l"* ]]; then
+    _pass "non-Tabby terminal does not implicitly enable recovery"
+else
+    _fail "non-Tabby terminal unexpectedly enabled recovery: ${tabby_output}"
 fi
 
 tabby_session_id="ses_0123456789TabbyRestore"

--- a/.agents/scripts/tests/test-opencode-launcher-helper.sh
+++ b/.agents/scripts/tests/test-opencode-launcher-helper.sh
@@ -277,6 +277,16 @@ else
     _fail "non-Tabby terminal unexpectedly enabled recovery: ${tabby_output}"
 fi
 
+if output=$(TERM_PROGRAM=Tabby TABBY_CONFIG_DIRECTORY="${tmp_root}/tabby" \
+    PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
+    "${HELPER}" --tabby-shell --shared-db --dir "${launch_dir}" --dry-run 2>&1); then
+    _fail "explicit Tabby shared-db mode unexpectedly succeeded: ${output}"
+elif [[ "${output}" == *"--tabby-shell requires aidevops isolated OpenCode storage"* ]]; then
+    _pass "explicit Tabby shared-db mode fails closed"
+else
+    _fail "explicit Tabby shared-db rejection was unexpected: ${output}"
+fi
+
 tabby_session_id="ses_0123456789TabbyRestore"
 tabby_data_dir="${work_dir}/opencode-interactive/tabby-restore"
 tabby_marker_dir="${work_dir}/opencode-tabby-recovery/${tabby_session_id}"
@@ -303,13 +313,14 @@ with open(marker_path, "w") as handle:
 os.chmod(marker_path, 0o600)
 PY
 tabby_output=$(cd "${tabby_marker_dir}" && \
+    TERM_PROGRAM=Tabby TABBY_CONFIG_DIRECTORY="${tmp_root}/tabby" \
     PATH="${fake_bin}:$PATH" HOME="${home_dir}" AIDEVOPS_WORK_DIR="${work_dir}" \
-    "${HELPER}" --tabby-shell --dry-run 2>&1)
+    "${HELPER}" --dry-run 2>&1)
 if [[ "${tabby_output}" == *"cd ${launch_dir}"* ]] \
     && [[ "${tabby_output}" == *"XDG_DATA_HOME=${tabby_data_dir}"* ]] \
     && [[ "${tabby_output}" == *"opencode --session ${tabby_session_id}"* ]] \
     && [[ "${tabby_output}" == *"exec /bin/zsh -l"* ]]; then
-    _pass "Tabby recovery resumes the exact validated OpenCode session"
+    _pass "stale Tabby profile recovery resumes the exact validated OpenCode session"
 else
     _fail "Tabby recovered command unexpected: ${tabby_output}"
 fi

--- a/TODO.md
+++ b/TODO.md
@@ -1244,6 +1244,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 - [ ] t18219 Persist maintainer role for organization-owned repositories #auto-dispatch #priority:high ref:GH#29785
 
 
+- [ ] t18223 Self-heal stale Tabby recovery tokens #bug ref:GH#29922
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22

--- a/TODO.md
+++ b/TODO.md
@@ -1244,7 +1244,7 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 - [ ] t18219 Persist maintainer role for organization-owned repositories #auto-dispatch #priority:high ref:GH#29785
 
 
-- [ ] t18223 Self-heal stale Tabby recovery tokens #bug ref:GH#29922
+- [ ] t18223 Self-heal stale Tabby recovery tokens #bug ref:GH#29922 pr:#29923
 
 ## In Progress
 


### PR DESCRIPTION
## Summary

Detect isolated Tabby shells even when restored recovery tokens contain stale profile commands, then reuse the existing exact-session recovery path while preserving shared-database safeguards. Add focused regression coverage, user guidance, and task bookkeeping.

## Files Changed

.agents/reference/tabby-profiles.md, .agents/scripts/opencode-launcher-helper.sh, .agents/scripts/tests/test-opencode-launcher-helper.sh, TODO.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified: 26 focused launcher tests passed; ShellCheck reported zero violations for the launcher and test script; the repository local linter gate passed; a deployed Tabby dry-run resolved the exact OpenCode session ID from its recovery marker.

Resolves #29922


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.247 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 24m and 392,510 tokens on this with the user in an interactive session.