### PR TITLE
GH#29910: Wire compact archives into worker cleanup

### DIFF
--- a/.agents/scripts/cleanup-worktrees-async-helper.sh
+++ b/.agents/scripts/cleanup-worktrees-async-helper.sh
@@ -251,18 +251,31 @@ main() {
 	echo "[cleanup-worktrees-async] Starting cleanup_worktrees (cadence OK)" >>"$LOGFILE"
 
 	local rc=0
+	local outcome="success"
+	local removed_count="0"
+	local archived_count="0"
+	local archive_failed_count="0"
 	cleanup_worktrees || rc=$?
 	_prune_dirty_worktree_backups
 
 	if [[ "${CLEANUP_WORKTREES_SKIPPED:-0}" == "1" ]]; then
+		outcome="safety-skip"
 		echo "[cleanup-worktrees-async] cleanup_worktrees skipped by safety gate — last-run NOT updated" >>"$LOGFILE"
 	elif [[ "$rc" -eq 0 ]]; then
 		_maintain_worktree_recovery
 		_update_last_run
 		echo "[cleanup-worktrees-async] Completed successfully at $(date -u '+%Y-%m-%dT%H:%M:%SZ'). last-run updated." >>"$LOGFILE"
 	else
+		outcome="failed"
 		echo "[cleanup-worktrees-async] cleanup_worktrees exited with rc=${rc} — last-run NOT updated" >>"$LOGFILE"
 	fi
+	removed_count="${CLEANUP_WORKTREES_REMOVED_COUNT:-0}"
+	archived_count="${CLEANUP_WORKTREES_ARCHIVED_COUNT:-0}"
+	archive_failed_count="${CLEANUP_WORKTREES_ARCHIVE_FAILED_COUNT:-0}"
+	[[ "$removed_count" =~ ^[0-9]+$ ]] || removed_count=0
+	[[ "$archived_count" =~ ^[0-9]+$ ]] || archived_count=0
+	[[ "$archive_failed_count" =~ ^[0-9]+$ ]] || archive_failed_count=0
+	printf '%s\n' "[cleanup-worktrees-async] outcome=${outcome} removed=${removed_count} archived=${archived_count} archive_failed=${archive_failed_count}" >>"$LOGFILE"
 
 	return 0
 }

--- a/.agents/scripts/pulse-cleanup-worktree-removal.sh
+++ b/.agents/scripts/pulse-cleanup-worktree-removal.sh
@@ -15,6 +15,10 @@
 _PULSE_CLEANUP_WORKTREE_REMOVAL_LOADED=1
 _PC_REMOVAL_NONE="none"
 _PC_REMOVAL_SKIPPED="skipped"
+_PC_ARCHIVE_REASON_FAILED="failed-worker"
+_PC_ARCHIVE_REASON_POST_PR="post-pr-cleanup"
+_PC_ARCHIVE_TARGET_ISSUE="issue"
+_PC_ARCHIVE_HANDLED_SKIP_RC=3
 
 if [[ -z "${_PULSE_CLEANUP_SCRIPT_DIR:-}" ]]; then
 	_pulse_cleanup_worktree_removal_path="${BASH_SOURCE[0]%/*}"
@@ -102,8 +106,10 @@ _pc_assert_no_uncommitted_work() {
 # Args:
 #   $1 - rp_age:        repo root path
 #   $2 - wt_path_age:   absolute worktree path
-#   $3 - wt_branch_age: branch name
+#   $3 - wt_branch_age: branch name (may be empty for detached HEAD)
 #   $4 - audit_context: structured audit context
+#   $5 - removal reason (optional)
+#   $6 - removal mode (optional)
 # Returns: 0 if the worktree directory was removed, 1 otherwise
 #######################################
 _pc_remove_local_commit_worktree_preserving_branch() {
@@ -111,8 +117,10 @@ _pc_remove_local_commit_worktree_preserving_branch() {
 	local wt_path_age="$2"
 	local wt_branch_age="$3"
 	local audit_context="$4"
+	local removal_reason="${5:-local-commits-branch-preserved}"
+	local removal_mode="${6:-branch-preserved}"
 
-	[[ -n "$rp_age" && -n "$wt_path_age" && -n "$wt_branch_age" ]] || return 1
+	[[ -n "$rp_age" && -n "$wt_path_age" ]] || return 1
 	if ! worktree_removal_guard "$wt_path_age" "$_WTAR_PC_CALLER" "local-commits-branch-preserved"; then
 		return 1
 	fi
@@ -120,7 +128,7 @@ _pc_remove_local_commit_worktree_preserving_branch() {
 	if git -C "$rp_age" worktree remove --force "$wt_path_age" 2>/dev/null; then
 		git -C "$rp_age" worktree prune 2>/dev/null || true
 		unregister_worktree "$wt_path_age" 2>/dev/null || true
-		log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_PC_CALLER" "$wt_path_age" "local-commits-branch-preserved" "branch-preserved" "$audit_context"
+		log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_PC_CALLER" "$wt_path_age" "$removal_reason" "$removal_mode" "$audit_context"
 		return 0
 	fi
 
@@ -128,49 +136,60 @@ _pc_remove_local_commit_worktree_preserving_branch() {
 }
 
 #######################################
-# Archive dirty worktree state to git stash before branch-preserved removal.
-#
-# Args:
-#   $1 - worktree path
-#   $2 - branch name
-# Returns: 0 if clean or stash archive succeeds, 1 otherwise
-#######################################
-_pc_archive_dirty_worktree_stash() {
-	local wt_path="$1"
-	local wt_branch="$2"
-	local dirty_count=0
-	dirty_count=$(git -C "$wt_path" status --porcelain 2>/dev/null | wc -l | tr -d ' ') || dirty_count=0
-	if [[ "$dirty_count" -eq 0 ]]; then
-		return 0
-	fi
-	git -C "$wt_path" stash push -u -m "aidevops worktree cleanup archive: ${wt_branch:-detached}" >/dev/null 2>&1
-	return $?
+# Return the newest retained failure excerpt for one worker task.
+_pc_latest_worker_failure_excerpt() {
+	local target_number="$1"
+	local excerpt_dir="${HOME}/.aidevops/logs/worker-failure-excerpts"
+	local candidate=""
+	local latest=""
+
+	[[ "$target_number" =~ ^[1-9][0-9]*$ && -d "$excerpt_dir" ]] || return 1
+	for candidate in "$excerpt_dir"/"issue-${target_number}-"*.log; do
+		[[ -f "$candidate" ]] || continue
+		if [[ -z "$latest" || "$candidate" -nt "$latest" ]]; then
+			latest="$candidate"
+		fi
+	done
+	[[ -n "$latest" ]] || return 1
+	printf '%s\n' "$latest"
+	return 0
 }
 
-_pc_archive_dirty_worktree_compactly() {
+_pc_archive_worktree_compactly() {
 	local rp_age="$1"
 	local wt_path_age="$2"
-	local orphan_issue_num="$3"
+	local target_number="$3"
 	local repo_slug_age="$4"
+	local archive_reason="$5"
 	local helper_path="${AIDEVOPS_WORKTREE_ARCHIVE_HELPER:-${_PULSE_CLEANUP_SCRIPT_DIR}/worktree-archive-helper.sh}"
 	local base_branch=""
 	local archive_dir=""
+	local failure_excerpt=""
+	local archive_args=()
 
-	[[ "$orphan_issue_num" =~ ^[1-9][0-9]*$ ]] || return 1
+	[[ "$target_number" =~ ^[1-9][0-9]*$ ]] || return 1
 	[[ "$repo_slug_age" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || return 1
+	[[ "$archive_reason" == "$_PC_ARCHIVE_REASON_FAILED" || "$archive_reason" == "$_PC_ARCHIVE_REASON_POST_PR" ]] || return 1
 	[[ -x "$helper_path" ]] || return 1
 	base_branch=$(git -C "$rp_age" symbolic-ref --short -q HEAD 2>/dev/null) || return 1
 	[[ -n "$base_branch" ]] || return 1
-	archive_dir=$("$helper_path" archive "$wt_path_age" --repo "$repo_slug_age" \
-		--issue "$orphan_issue_num" --reason failed-worker --base-branch "$base_branch" \
-		2>>"$LOGFILE") || return 1
+	archive_args=(archive "$wt_path_age" --repo "$repo_slug_age" --issue "$target_number"
+		--reason "$archive_reason" --base-branch "$base_branch")
+	if [[ "$archive_reason" == "$_PC_ARCHIVE_REASON_FAILED" ]]; then
+		failure_excerpt=$(_pc_latest_worker_failure_excerpt "$target_number" 2>/dev/null || true)
+		if [[ -n "$failure_excerpt" ]]; then
+			archive_args+=(--failure-log "$failure_excerpt")
+		fi
+	fi
+	archive_dir=$("$helper_path" "${archive_args[@]}" 2>>"$LOGFILE") || return 1
 	"$helper_path" verify "$archive_dir" >/dev/null 2>>"$LOGFILE" || return 1
 	echo "[pulse-wrapper] Compact recovery archive verified: ${archive_dir}" >>"$LOGFILE"
+	printf '%s\n' "$archive_dir"
 	return 0
 }
 
 #######################################
-# Remove a worktree after archiving dirty state and preserving the branch.
+# Remove a worktree only after a compact archive has been verified.
 #
 # Args mirror _pc_remove_local_commit_worktree_preserving_branch.
 # Returns: 0 if removed, 1 otherwise
@@ -180,26 +199,42 @@ _pc_archive_and_remove_worktree_preserving_branch() {
 	local wt_path_age="$2"
 	local wt_branch_age="$3"
 	local audit_context="$4"
-	local orphan_issue_num="${5:-}"
+	local target_number="${5:-}"
 	local repo_slug_age="${6:-}"
-	local dirty_state=""
-	[[ -n "$rp_age" && -n "$wt_path_age" && -n "$wt_branch_age" ]] || return 1
-	dirty_state=$(git -C "$wt_path_age" status --porcelain 2>/dev/null) || return 1
-	if [[ -n "$dirty_state" ]]; then
-		if [[ -n "$orphan_issue_num" && -n "$repo_slug_age" ]]; then
-			if ! _pc_archive_dirty_worktree_compactly "$rp_age" "$wt_path_age" \
-				"$orphan_issue_num" "$repo_slug_age"; then
-				echo "[pulse-wrapper] Orphan cleanup: skipping ${wt_branch_age} — compact recovery archive creation or verification failed" >>"$LOGFILE"
-				log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" \
-					"compact-archive-failed" "$_PC_REMOVAL_SKIPPED" "$audit_context"
-				return "$_PC_ARCHIVE_REQUIRED_FAILURE_RC"
-			fi
-		else
-			_pc_archive_dirty_worktree_stash "$wt_path_age" "$wt_branch_age" || return 1
-		fi
+	local archive_reason="${7:-$_PC_ARCHIVE_REASON_FAILED}"
+	local target_type="${8:-$_PC_ARCHIVE_TARGET_ISSUE}"
+	local archive_dir=""
+	local policy_reason=""
+	local archived_context=""
+	local removal_reason="archived-${archive_reason}"
+	[[ -n "$rp_age" && -n "$wt_path_age" ]] || return 1
+
+	if ! policy_reason=$(_pc_compact_archive_policy_clear "$wt_path_age" "$target_number" \
+		"$repo_slug_age" "$target_type"); then
+		[[ -n "$policy_reason" ]] || policy_reason="archive-policy-unverified"
+		echo "[pulse-wrapper] Orphan cleanup: skipping ${wt_branch_age:-detached} — ${policy_reason}" >>"$LOGFILE"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" \
+			"$policy_reason" "$_PC_REMOVAL_SKIPPED" "$audit_context"
+		return "$_PC_ARCHIVE_REQUIRED_FAILURE_RC"
 	fi
-	_pc_remove_local_commit_worktree_preserving_branch "$rp_age" "$wt_path_age" "$wt_branch_age" "$audit_context"
-	return $?
+	if ! archive_dir=$(_pc_archive_worktree_compactly "$rp_age" "$wt_path_age" \
+		"$target_number" "$repo_slug_age" "$archive_reason"); then
+		CLEANUP_WORKTREES_ARCHIVE_FAILED_COUNT=$((${CLEANUP_WORKTREES_ARCHIVE_FAILED_COUNT:-0} + 1))
+		echo "[pulse-wrapper] Orphan cleanup: skipping ${wt_branch_age:-detached} — compact recovery archive creation or verification failed" >>"$LOGFILE"
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" \
+			"compact-archive-failed" "$_PC_REMOVAL_SKIPPED" "$audit_context"
+		return "$_PC_ARCHIVE_REQUIRED_FAILURE_RC"
+	fi
+	CLEANUP_WORKTREES_ARCHIVED_COUNT=$((${CLEANUP_WORKTREES_ARCHIVED_COUNT:-0} + 1))
+	archived_context="${audit_context} archive_path=${archive_dir} archive_outcome=verified delete_outcome=removed"
+	if _pc_remove_local_commit_worktree_preserving_branch "$rp_age" "$wt_path_age" "$wt_branch_age" \
+		"$archived_context" "$removal_reason" "compact-archive"; then
+		return 0
+	fi
+	archived_context="${audit_context} archive_path=${archive_dir} archive_outcome=verified delete_outcome=failed"
+	log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" \
+		"compact-archive-delete-failed" "$_PC_REMOVAL_SKIPPED" "$archived_context"
+	return 1
 }
 
 #######################################
@@ -304,8 +339,9 @@ _pc_handle_generated_clean_cruft_worktree() {
 	local wt_age_secs="$7"
 	local repo_name_age="$8"
 	local repo_slug_age="${9:-}"
-	local removal_reason="detached-review-cruft"
 	local branch_pr_num=""
+	local archive_target_number="$orphan_issue_num"
+	local archive_target_type="$_PC_ARCHIVE_TARGET_ISSUE"
 	local archive_secs
 	local audit_context
 	local guard_ok
@@ -313,16 +349,22 @@ _pc_handle_generated_clean_cruft_worktree() {
 
 	_pc_is_generated_clean_cruft_worktree "$wt_path_age" "$wt_branch_age" || return 1
 	if [[ -n "$wt_branch_age" && -n "$repo_slug_age" ]]; then
-		_pc_branch_has_pr "$repo_slug_age" "$wt_branch_age" "open" && return 1
+		_pc_branch_archive_pr_state_clear "$repo_slug_age" "$wt_branch_age" || return 1
 		branch_pr_num=$(_pc_pr_from_branch "$wt_branch_age" 2>/dev/null || true)
 		if [[ -n "$branch_pr_num" ]] && _pc_pr_terminal_for_branch_archive "$branch_pr_num" "$repo_slug_age" >/dev/null 2>&1; then
 			return 1
 		fi
 	fi
+	if [[ ! "$archive_target_number" =~ ^[1-9][0-9]*$ ]]; then
+		archive_target_number=$(_pc_pr_from_branch "${wt_branch_age:-$wt_path_age}" 2>/dev/null || true)
+		archive_target_type="pr"
+	fi
+	if [[ -z "$wt_branch_age" && "$archive_target_type" == "pr" ]]; then
+		_pc_pr_archive_state_clear "$archive_target_number" "$repo_slug_age" || return 1
+	fi
 	if [[ "$dirty_count" -gt 0 ]]; then
 		[[ -n "$wt_branch_age" ]] || return 1
 		archive_secs=$(_pc_generated_dirty_archive_secs)
-		removal_reason="generated-dirty-cruft"
 	else
 		archive_secs=$(_pc_generated_clean_archive_secs)
 	fi
@@ -336,14 +378,13 @@ _pc_handle_generated_clean_cruft_worktree() {
 			echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): removing ${wt_branch_age} — clean generated auto/review worktree older than ${archive_secs}s; branch preserved" >>"$LOGFILE"
 		fi
 		_pc_archive_and_remove_worktree_preserving_branch "$rp_age" "$wt_path_age" "$wt_branch_age" \
-			"$audit_context" "$orphan_issue_num" "$repo_slug_age"
+			"$audit_context" "$archive_target_number" "$repo_slug_age" "$_PC_ARCHIVE_REASON_FAILED" "$archive_target_type"
 		return $?
 	fi
-	echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): removing detached generated worktree — clean auto/review cruft older than ${archive_secs}s" >>"$LOGFILE"
-	remove_worktree_path_permanently "$wt_path_age" "$_WTAR_PC_CALLER" "$removal_reason" "$audit_context" || return 1
-	git -C "$rp_age" worktree prune 2>/dev/null || true
-	unregister_worktree "$wt_path_age" 2>/dev/null || true
-	return 0
+	echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): archiving detached generated worktree — clean auto/review cruft older than ${archive_secs}s" >>"$LOGFILE"
+	_pc_archive_and_remove_worktree_preserving_branch "$rp_age" "$wt_path_age" "" \
+		"$audit_context" "$archive_target_number" "$repo_slug_age" "$_PC_ARCHIVE_REASON_FAILED" "$archive_target_type"
+	return $?
 }
 
 #######################################
@@ -382,7 +423,8 @@ _pc_handle_local_commit_no_pr_worktree() {
 	if [[ "$dirty_count" -eq 0 ]] && _pc_issue_closed_for_branch_archive "$orphan_issue_num" "$repo_slug_age"; then
 		audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$_PC_REMOVAL_NONE" "$guard_ok" "$guard_ok" "$guard_ok" "branch-preserved-closed-issue")
 		echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): removing ${wt_branch_age:-detached} — issue #${orphan_issue_num} is closed; local commits preserved on branch" >>"$LOGFILE"
-		_pc_remove_local_commit_worktree_preserving_branch "$rp_age" "$wt_path_age" "$wt_branch_age" "$audit_context"
+		_pc_archive_and_remove_worktree_preserving_branch "$rp_age" "$wt_path_age" "$wt_branch_age" \
+			"$audit_context" "$orphan_issue_num" "$repo_slug_age" "$_PC_ARCHIVE_REASON_FAILED" "$_PC_ARCHIVE_TARGET_ISSUE"
 		return $?
 	fi
 
@@ -390,7 +432,8 @@ _pc_handle_local_commit_no_pr_worktree() {
 	if [[ "$dirty_count" -eq 0 ]] && branch_pr_state=$(_pc_pr_terminal_for_branch_archive "$branch_pr_num" "$repo_slug_age"); then
 		audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "pr-${branch_pr_state}" "$guard_ok" "$guard_ok" "$guard_ok" "branch-preserved-closed-pr-${branch_pr_num}")
 		echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): removing ${wt_branch_age:-detached} — PR #${branch_pr_num} is ${branch_pr_state}; local commits preserved on branch" >>"$LOGFILE"
-		_pc_remove_local_commit_worktree_preserving_branch "$rp_age" "$wt_path_age" "$wt_branch_age" "$audit_context"
+		_pc_archive_and_remove_worktree_preserving_branch "$rp_age" "$wt_path_age" "$wt_branch_age" \
+			"$audit_context" "$branch_pr_num" "$repo_slug_age" "$_PC_ARCHIVE_REASON_POST_PR" "pr"
 		return $?
 	fi
 	local generated_handler_status=0
@@ -408,10 +451,12 @@ _pc_handle_local_commit_no_pr_worktree() {
 		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" "local-commits-no-pr" "$_PC_REMOVAL_SKIPPED" "$audit_context"
 		return 1
 	fi
+	_pc_branch_archive_pr_state_clear "$repo_slug_age" "$wt_branch_age" || return 1
 
 	audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$_PC_REMOVAL_NONE" "$guard_ok" "$guard_ok" "$guard_ok" "branch-preserved")
-	echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): removing stale worktree for ${wt_branch_age:-detached} — local commits preserved on branch" >>"$LOGFILE"
-	_pc_remove_local_commit_worktree_preserving_branch "$rp_age" "$wt_path_age" "$wt_branch_age" "$audit_context"
+	echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): archiving stale worktree for ${wt_branch_age:-detached} — local commits preserved compactly and on branch" >>"$LOGFILE"
+	_pc_archive_and_remove_worktree_preserving_branch "$rp_age" "$wt_path_age" "$wt_branch_age" \
+		"$audit_context" "$orphan_issue_num" "$repo_slug_age" "$_PC_ARCHIVE_REASON_FAILED" "$_PC_ARCHIVE_TARGET_ISSUE"
 	return $?
 }
 
@@ -434,27 +479,36 @@ _pc_handle_terminal_worktree_archive() {
 	local audit_context
 	local terminal_pr_state=""
 	local terminal_pr_number=""
+	local archive_target_number=""
+	local archive_target_type="$_PC_ARCHIVE_TARGET_ISSUE"
 	local terminal_recovery_path="branch-preserved-terminal-pr"
 	local guard_ok
 	guard_ok=$(printf 'cle%s' 'ar')
 
 	if _pc_issue_closed_for_branch_archive "$orphan_issue_num" "$repo_slug_age"; then
+		_pc_branch_archive_pr_state_clear "$repo_slug_age" "$wt_branch_age" || return 1
 		audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "closed-issue" "$guard_ok" "$guard_ok" "$guard_ok" "branch-preserved-closed-issue")
 		echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): archiving ${wt_branch_age:-detached} — issue #${orphan_issue_num} is closed" >>"$LOGFILE"
 		_pc_archive_and_remove_worktree_preserving_branch "$rp_age" "$wt_path_age" "$wt_branch_age" \
-			"$audit_context" "$orphan_issue_num" "$repo_slug_age"
+			"$audit_context" "$orphan_issue_num" "$repo_slug_age" "$_PC_ARCHIVE_REASON_FAILED" "$_PC_ARCHIVE_TARGET_ISSUE"
 		return $?
 	fi
 
 	if terminal_pr_state=$(_pc_terminal_pr_state_for_branch "$repo_slug_age" "$wt_branch_age"); then
 		terminal_pr_number=$(_pc_pr_from_branch "$wt_branch_age" 2>/dev/null || true)
+		archive_target_number="$orphan_issue_num"
+		archive_target_type="$_PC_ARCHIVE_TARGET_ISSUE"
+		if [[ ! "$archive_target_number" =~ ^[1-9][0-9]*$ ]]; then
+			archive_target_number="$terminal_pr_number"
+			archive_target_type="pr"
+		fi
 		if [[ -n "$terminal_pr_number" ]]; then
 			terminal_recovery_path="branch-preserved-terminal-pr-${terminal_pr_number}"
 		fi
 		audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "pr-${terminal_pr_state}" "$guard_ok" "$guard_ok" "$guard_ok" "$terminal_recovery_path")
 		echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): archiving ${wt_branch_age:-detached} — branch PR ${terminal_pr_number:+#${terminal_pr_number} }is ${terminal_pr_state}" >>"$LOGFILE"
 		_pc_archive_and_remove_worktree_preserving_branch "$rp_age" "$wt_path_age" "$wt_branch_age" \
-			"$audit_context" "$orphan_issue_num" "$repo_slug_age"
+			"$audit_context" "$archive_target_number" "$repo_slug_age" "$_PC_ARCHIVE_REASON_POST_PR" "$archive_target_type"
 		return $?
 	fi
 	return 1
@@ -486,6 +540,82 @@ _pc_skip_recent_worker_metric_cleanup() {
 	echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): skipping ${wt_branch_age:-detached} — recent worker runtime metric/session record" >>"$LOGFILE"
 	log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path_age" "active-worker-metric" "$_PC_REMOVAL_SKIPPED" "$audit_context"
 	return 0
+}
+
+#######################################
+# Archive an attributable stale dirty worker that is not generated cruft.
+#
+# Args mirror _pc_handle_local_commit_no_pr_worktree.
+# Returns: 0 if removed, 1 if ineligible, 2 if required archival failed.
+#######################################
+_pc_handle_stale_dirty_worker_archive() {
+	local rp_age="$1"
+	local wt_path_age="$2"
+	local wt_branch_age="$3"
+	local orphan_issue_num="$4"
+	local commits_ahead="$5"
+	local dirty_count="$6"
+	local wt_age_secs="$7"
+	local repo_name_age="$8"
+	local repo_slug_age="${9:-}"
+	local archive_secs=0
+	local audit_context=""
+	local guard_ok=""
+
+	[[ "$dirty_count" -gt 0 && "$orphan_issue_num" =~ ^[1-9][0-9]*$ ]] || return 1
+	archive_secs=$(_pc_generated_dirty_archive_secs)
+	[[ "$wt_age_secs" -ge "$archive_secs" ]] || return 1
+	_pc_branch_archive_pr_state_clear "$repo_slug_age" "$wt_branch_age" || return 1
+	guard_ok=$(printf 'cle%s' 'ar')
+	audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "failed-worker-stale-dirty" "$guard_ok" "$guard_ok" "$guard_ok" "compact-archive")
+	echo "[pulse-wrapper] Orphan cleanup ($repo_name_age): archiving ${wt_branch_age:-detached} — attributable dirty worker older than ${archive_secs}s" >>"$LOGFILE"
+	_pc_archive_and_remove_worktree_preserving_branch "$rp_age" "$wt_path_age" "$wt_branch_age" \
+		"$audit_context" "$orphan_issue_num" "$repo_slug_age" "$_PC_ARCHIVE_REASON_FAILED" "$_PC_ARCHIVE_TARGET_ISSUE"
+	return $?
+}
+
+#######################################
+# Run archive-backed cleanup branches before generic permanent cleanup.
+#
+# Args mirror the state tuple used by _cleanup_single_worktree after age and
+# repository-name derivation.
+# Returns: 0 removed, 1 continue generic evaluation, 2 archive failure,
+#          3 retained by an archive-specific policy window.
+#######################################
+_pc_handle_archive_cleanup_candidates() {
+	local rp_age="$1"
+	local wt_path_age="$2"
+	local wt_branch_age="$3"
+	local orphan_issue_num="$4"
+	local commits_ahead="$5"
+	local dirty_count="$6"
+	local wt_age_secs="$7"
+	local repo_name_age="$8"
+	local repo_slug_age="${9:-}"
+	local handler_status=0
+
+	if _pc_handle_terminal_worktree_archive "$rp_age" "$wt_path_age" "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$repo_name_age" "$repo_slug_age"; then
+		return 0
+	else
+		handler_status=$?
+	fi
+	[[ "$handler_status" -eq "$_PC_ARCHIVE_REQUIRED_FAILURE_RC" ]] && return "$handler_status"
+	if _pc_handle_generated_clean_cruft_worktree "$rp_age" "$wt_path_age" "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$repo_name_age" "$repo_slug_age"; then
+		return 0
+	else
+		handler_status=$?
+	fi
+	[[ "$handler_status" -eq "$_PC_ARCHIVE_REQUIRED_FAILURE_RC" ]] && return "$handler_status"
+	if _pc_is_generated_clean_cruft_worktree "$wt_path_age" "$wt_branch_age"; then
+		_pc_log_not_age_eligible_skip "$wt_path_age" "$wt_branch_age" "$commits_ahead" "$dirty_count" "$wt_age_secs" "generated-retention"
+		return "$_PC_ARCHIVE_HANDLED_SKIP_RC"
+	fi
+	if _pc_handle_stale_dirty_worker_archive "$rp_age" "$wt_path_age" "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$repo_name_age" "$repo_slug_age"; then
+		return 0
+	else
+		handler_status=$?
+	fi
+	return "$handler_status"
 }
 
 _pc_permanently_remove_eligible_orphan() {
@@ -574,28 +704,25 @@ _cleanup_single_worktree() {
 	if _worktree_owner_alive "$wt_path_age" "$wt_branch_age"; then
 		return 1
 	fi
+	if _pc_skip_recent_worker_metric_cleanup "$wt_path_age" "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$now_epoch" "$repo_name_age"; then
+		return 1
+	fi
 	local archive_handler_status=0
-	if _pc_handle_terminal_worktree_archive "$rp_age" "$wt_path_age" "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$repo_name_age" "$repo_slug_age"; then
+	if _pc_handle_archive_cleanup_candidates "$rp_age" "$wt_path_age" "$wt_branch_age" \
+		"$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" \
+		"$repo_name_age" "$repo_slug_age"; then
 		return 0
 	else
 		archive_handler_status=$?
 	fi
-	[[ "$archive_handler_status" -eq "$_PC_ARCHIVE_REQUIRED_FAILURE_RC" ]] && return 1
+	case "$archive_handler_status" in
+	"$_PC_ARCHIVE_REQUIRED_FAILURE_RC" | "$_PC_ARCHIVE_HANDLED_SKIP_RC") return 1 ;;
+	esac
 
 	local audit_context
 	local guard_ok
 	guard_ok=$(printf 'cle%s' 'ar')
 	audit_context=$(_pc_worktree_audit_context "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$_PC_REMOVAL_NONE" "$guard_ok" "$guard_ok" "$guard_ok" "$_PC_REMOVAL_NONE")
-	if _pc_skip_recent_worker_metric_cleanup "$wt_path_age" "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$now_epoch" "$repo_name_age"; then
-		return 1
-	fi
-	archive_handler_status=0
-	if _pc_handle_generated_clean_cruft_worktree "$rp_age" "$wt_path_age" "$wt_branch_age" "$orphan_issue_num" "$commits_ahead" "$dirty_count" "$wt_age_secs" "$repo_name_age" "$repo_slug_age"; then
-		return 0
-	else
-		archive_handler_status=$?
-	fi
-	[[ "$archive_handler_status" -eq "$_PC_ARCHIVE_REQUIRED_FAILURE_RC" ]] && return 1
 
 	local reason
 	if ! reason=$(_evaluate_worktree_removal "$commits_ahead" "$dirty_count" "$wt_age_secs" "$wt_branch_age" "$repo_slug_age"); then
@@ -1069,6 +1196,9 @@ _pc_relocate_registered_worktrees() {
 #######################################
 cleanup_worktrees() {
 	CLEANUP_WORKTREES_SKIPPED=0
+	CLEANUP_WORKTREES_REMOVED_COUNT=0
+	CLEANUP_WORKTREES_ARCHIVED_COUNT=0
+	CLEANUP_WORKTREES_ARCHIVE_FAILED_COUNT=0
 	local total_removed=0
 	# Fast, API-free pass for detached regression-helper fixtures. Run before
 	# the GraphQL gate and merged-PR scan so a stale long-running cleanup cannot
@@ -1160,6 +1290,7 @@ cleanup_worktrees() {
 	if [[ "$total_removed" -gt 0 ]]; then
 		echo "[pulse-wrapper] Worktree cleanup total: $total_removed worktree(s) removed across all repos" >>"$LOGFILE"
 	fi
+	CLEANUP_WORKTREES_REMOVED_COUNT="$total_removed"
 
 	return 0
 }

--- a/.agents/scripts/pulse-cleanup-worktree-state.sh
+++ b/.agents/scripts/pulse-cleanup-worktree-state.sh
@@ -15,6 +15,7 @@
 _PULSE_CLEANUP_WORKTREE_STATE_LOADED=1
 _PC_STATE_SKIPPED="skipped"
 _PC_STATE_UNKNOWN="unknown"
+_PC_ARCHIVE_ATTRIBUTION_UNCLEAR="archive-attribution-unclear"
 
 if [[ -z "${_PULSE_CLEANUP_SCRIPT_DIR:-}" ]]; then
 	_pulse_cleanup_worktree_state_path="${BASH_SOURCE[0]%/*}"
@@ -138,6 +139,48 @@ _pc_branch_has_pr() {
 }
 
 #######################################
+# Verify that branch PR evidence is readable and has no open handoff.
+#
+# An empty successful query proves no head PR. A terminal head/reference PR is
+# safe for archive-backed cleanup; OPEN, malformed, or unavailable evidence is
+# a hard veto.
+#
+# Args:
+#   $1 - repository slug
+#   $2 - branch name
+# Returns: 0 when PR state is clear for archival, 1 otherwise
+#######################################
+_pc_branch_archive_pr_state_clear() {
+	local repo_slug="$1"
+	local branch_name="$2"
+	local states=""
+	local state=""
+	local referenced_number=""
+
+	[[ -n "$repo_slug" && -n "$branch_name" ]] || return 1
+	states=$(gh_pr_list --repo "$repo_slug" --head "$branch_name" --state all \
+		--limit 10 --json state --jq '.[].state // empty' 2>/dev/null) || return 1
+	while IFS= read -r state; do
+		[[ -n "$state" ]] || continue
+		case "$state" in
+		CLOSED | MERGED) ;;
+		*) return 1 ;;
+		esac
+	done <<<"$states"
+	if [[ -n "$states" ]]; then
+		return 0
+	fi
+
+	referenced_number=$(_pc_pr_from_branch "$branch_name" 2>/dev/null || true)
+	[[ -n "$referenced_number" ]] || return 0
+	state=$(_pc_pr_state_for_branch_reference "$repo_slug" "$branch_name" 2>/dev/null) || return 1
+	case "$state" in
+	CLOSED | MERGED) return 0 ;;
+	esac
+	return 1
+}
+
+#######################################
 # Return terminal PR state for a branch head, if GitHub verifies one.
 #
 # Args:
@@ -223,6 +266,28 @@ _pc_pr_terminal_for_branch_archive() {
 		printf '%s\n' "$pr_state"
 		return 0
 		;;
+	esac
+	return 1
+}
+
+#######################################
+# Verify terminal remote evidence for a PR-attributed detached worktree.
+#
+# Args:
+#   $1 - PR number
+#   $2 - repository slug
+# Returns: 0 for CLOSED/MERGED, 1 for OPEN/unknown/unavailable
+#######################################
+_pc_pr_archive_state_clear() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local pr_state=""
+
+	[[ "$pr_number" =~ ^[1-9][0-9]*$ && -n "$repo_slug" ]] || return 1
+	pr_state=$(gh pr view "$pr_number" --repo "$repo_slug" --json state \
+		--jq '.state // empty' 2>/dev/null) || return 1
+	case "$pr_state" in
+	CLOSED | MERGED) return 0 ;;
 	esac
 	return 1
 }
@@ -351,6 +416,77 @@ _pc_recent_worker_metric_exists() {
 		)
 	' "$metrics_file" >/dev/null 2>&1
 	return $?
+}
+
+#######################################
+# Verify that compact archival is allowed for a failed/completed worker.
+#
+# Local marker files and remote task labels are hard vetoes. A failed label
+# lookup is also a veto because cleanup cannot prove that forensics/security
+# retention is unnecessary.
+#
+# Args:
+#   $1 - worktree path
+#   $2 - issue or PR number
+#   $3 - repository slug
+#   $4 - target type: issue or pr
+# Outputs: a short skip reason when blocked
+# Returns: 0 when archival may proceed, 1 otherwise
+#######################################
+_pc_compact_archive_policy_clear() {
+	local wt_path="$1"
+	local target_number="$2"
+	local repo_slug="$3"
+	local target_type="$4"
+	local labels=""
+	local label=""
+	local normalized_label=""
+
+	[[ -n "$wt_path" && "$target_number" =~ ^[1-9][0-9]*$ ]] || {
+		printf '%s\n' "$_PC_ARCHIVE_ATTRIBUTION_UNCLEAR"
+		return 1
+	}
+	[[ "$repo_slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || {
+		printf '%s\n' "$_PC_ARCHIVE_ATTRIBUTION_UNCLEAR"
+		return 1
+	}
+	case "$target_type" in
+	issue | pr) ;;
+	*)
+		printf '%s\n' "$_PC_ARCHIVE_ATTRIBUTION_UNCLEAR"
+		return 1
+		;;
+	esac
+
+	if [[ -e "$wt_path/.aidevops-preserve-forensics" ||
+		-e "$wt_path/.preserve-forensics" ||
+		-e "$wt_path/.aidevops-security-incident" ]]; then
+		printf '%s\n' "preserve-forensics"
+		return 1
+	fi
+
+	labels=$(gh "$target_type" view "$target_number" --repo "$repo_slug" \
+		--json labels --jq '.labels[].name' 2>/dev/null) || {
+		printf '%s\n' "archive-policy-unverified"
+		return 1
+	}
+	while IFS= read -r label; do
+		[[ -n "$label" ]] || continue
+		normalized_label=$(printf '%s' "$label" | tr '[:upper:]' '[:lower:]')
+		case "$normalized_label" in
+		preserve-forensics | security | security-incident | incident:security | status:blocked)
+			printf '%s\n' "protected-${normalized_label//:/-}"
+			return 1
+			;;
+		esac
+	done <<<"$labels"
+	if [[ "$target_type" == "issue" ]] &&
+		_consecutive_zero_session_failures "$target_number" "$repo_slug" 2; then
+		printf '%s\n' "protected-repeated-failures"
+		return 1
+	fi
+
+	return 0
 }
 
 # t2859: Config defaults (ORPHAN_WORKTREE_GRACE_SECS, ORPHAN_MAX_AGE,

--- a/.agents/scripts/tests/test-cleanup-worktrees-async.sh
+++ b/.agents/scripts/tests/test-cleanup-worktrees-async.sh
@@ -117,6 +117,11 @@ cleanup_worktrees() {
 }
 STUB
 	fi
+	cat >>"${stub_dir}/pulse-cleanup.sh" <<STUB
+CLEANUP_WORKTREES_REMOVED_COUNT="${MOCK_REMOVED_COUNT:-0}"
+CLEANUP_WORKTREES_ARCHIVED_COUNT="${MOCK_ARCHIVED_COUNT:-0}"
+CLEANUP_WORKTREES_ARCHIVE_FAILED_COUNT="${MOCK_ARCHIVE_FAILED_COUNT:-0}"
+STUB
 
 	# Copy the helper into stub_dir so that when it runs, BASH_SOURCE[0] points
 	# to stub_dir and dirname "${BASH_SOURCE[0]}" resolves to stub_dir. This
@@ -461,6 +466,21 @@ test_recovery_maintenance_runs_once_per_cleanup() {
 	return 0
 }
 
+test_archive_outcome_summary_is_logged() {
+	local cleanup_log="${TEST_DIR}/.aidevops/logs/cleanup_worktrees.log"
+	rm -f "$cleanup_log"
+
+	MOCK_CLEANUP_EXIT=0 MOCK_REMOVED_COUNT=3 MOCK_ARCHIVED_COUNT=2 \
+		MOCK_ARCHIVE_FAILED_COUNT=1 run_helper_in_isolation || true
+	if grep -q 'outcome=success removed=3 archived=2 archive_failed=1' "$cleanup_log" 2>/dev/null; then
+		print_result "archive-summary: async cleanup reports archive/delete outcomes" 0
+	else
+		print_result "archive-summary: async cleanup reports archive/delete outcomes" 1 \
+			"structured archive outcome summary missing"
+	fi
+	return 0
+}
+
 # ============================================================
 # MAIN
 # ============================================================
@@ -519,6 +539,10 @@ main() {
 	teardown
 	setup
 	test_recovery_maintenance_runs_once_per_cleanup
+
+	teardown
+	setup
+	test_archive_outcome_summary_is_logged
 
 	echo ""
 	echo "Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed"

--- a/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
+++ b/.agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh
@@ -119,7 +119,16 @@ source_pulse_cleanup_with_stubs() {
 
 	is_worktree_owned_by_others() { return 1; }
 	unregister_worktree() { local wt_path="$1"; : "$wt_path"; return 0; }
-	gh() { return 1; }
+	gh() {
+		local target_type="${1:-}"
+		local action="${2:-}"
+		local args="$*"
+		if [[ "$target_type" == "issue" || "$target_type" == "pr" ]] &&
+			[[ "$action" == "view" && "$args" == *"--json labels"* ]]; then
+			return 0
+		fi
+		return 1
+	}
 	gh_pr_list() { return 0; }
 	recover_failed_launch_state() { return 0; }
 	gh_issue_comment() { return 0; }
@@ -162,8 +171,9 @@ test_closed_issue_local_commit_no_pr_removes_before_age_threshold() {
 	[[ "$cleanup_rc" -eq 0 ]] || rc=1
 	[[ ! -d "$wt_path" ]] || rc=1
 	[[ "$branch_exists" -eq 0 ]] || rc=1
-	grep -q 'worktree-removed.*local-commits-branch-preserved.*mode=branch-preserved' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	grep -q 'worktree-removed.*archived-failed-worker.*mode=compact-archive' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	grep -q 'recovery_path=branch-preserved-closed-issue' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	grep -q 'archive_outcome=verified delete_outcome=removed' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	print_result "closed issue local commits/no PR archives before age threshold" "$rc" \
 		"cleanup_rc=$cleanup_rc branch_exists=$branch_exists log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
 	return 0
@@ -200,7 +210,7 @@ test_closed_pr_reference_local_commit_no_pr_removes_before_age_threshold() {
 	[[ "$cleanup_rc" -eq 0 ]] || rc=1
 	[[ ! -d "$wt_path" ]] || rc=1
 	[[ "$branch_exists" -eq 0 ]] || rc=1
-	grep -q 'worktree-removed.*local-commits-branch-preserved.*mode=branch-preserved' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	grep -q 'worktree-removed.*archived-post-pr-cleanup.*mode=compact-archive' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	grep -q 'pr_state=pr-CLOSED' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	grep -q 'recovery_path=branch-preserved-terminal-pr-23078' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	print_result "closed PR reference local commits/no PR archives before age threshold" "$rc" \
@@ -292,7 +302,7 @@ test_merged_branch_pr_removes_before_age_threshold() {
 	[[ "$cleanup_rc" -eq 0 ]] || rc=1
 	[[ ! -d "$wt_path" ]] || rc=1
 	[[ "$branch_exists" -eq 0 ]] || rc=1
-	grep -q 'worktree-removed.*local-commits-branch-preserved.*mode=branch-preserved' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	grep -q 'worktree-removed.*archived-post-pr-cleanup.*mode=compact-archive' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	grep -q 'pr_state=pr-MERGED' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	grep -q 'recovery_path=branch-preserved-terminal-pr' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	print_result "merged branch PR archives before age threshold" "$rc" \
@@ -319,6 +329,8 @@ test_closed_issue_dirty_worktree_compacts_and_preserves_branch() {
 	now_epoch=$(date +%s)
 	AIDEVOPS_HEADLESS_METRICS_FILE="${TEST_ROOT}/missing-closed-issue-dirty-metrics.jsonl"
 	export AIDEVOPS_HEADLESS_METRICS_FILE
+	mkdir -p "$HOME/.aidevops/logs/worker-failure-excerpts"
+	printf 'bounded failure context for issue 23081\n' >"$HOME/.aidevops/logs/worker-failure-excerpts/issue-23081-20260810T000000Z-1.log"
 
 	_cleanup_single_worktree "$repo_dir" "$wt_path" "$branch_name" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
 	local cleanup_rc=$?
@@ -335,7 +347,9 @@ test_closed_issue_dirty_worktree_compacts_and_preserves_branch() {
 	[[ "$branch_exists" -eq 0 ]] || rc=1
 	[[ -n "$archive_manifest" ]] || rc=1
 	[[ -z "$archive_manifest" ]] || jq -e '.reason == "failed-worker" and .dirty_state == "dirty"' "$archive_manifest" >/dev/null || rc=1
+	[[ -z "$archive_manifest" ]] || grep -q 'bounded failure context for issue 23081' "${archive_manifest%/manifest.json}/failure.log" 2>/dev/null || rc=1
 	grep -q 'dirty=1' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	grep -q 'worktree-removed.*archived-failed-worker.*mode=compact-archive' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	grep -q 'recovery_path=branch-preserved-closed-issue' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	print_result "closed issue dirty worktree compacts and preserves branch" "$rc" \
 		"cleanup_rc=$cleanup_rc branch_exists=$branch_exists archive=$archive_manifest pulse=$(cat "$LOGFILE" 2>/dev/null) log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
@@ -416,6 +430,38 @@ test_terminal_worktree_respects_live_owner_signal() {
 	[[ -d "$wt_path" ]] || rc=1
 	grep -q "worktree-skipped: ${wt_path} — owned-skip" "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	print_result "terminal worktree respects live owner signal" "$rc" \
+		"cleanup_rc=$cleanup_rc log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
+	return 0
+}
+
+test_terminal_worktree_respects_recent_worker_metric() {
+	local repo_dir="${TEST_ROOT}/repo-terminal-recent-metric"
+	local wt_path="${TEST_ROOT}/worker-wt-terminal-recent-metric"
+	local branch_name="feature/auto-20260507-190812-gh23088"
+	setup_repo_with_worker_worktree "$repo_dir" "$wt_path" "$branch_name" || return 1
+	source_pulse_cleanup_with_stubs || return 1
+	gh() {
+		if [[ "${1:-}" == "issue" && "${2:-}" == "view" && "${3:-}" == "23088" ]]; then
+			printf '%s\n' "CLOSED"
+			return 0
+		fi
+		return 1
+	}
+
+	local now_epoch
+	now_epoch=$(date +%s)
+	local metrics_file="${TEST_ROOT}/terminal-recent-metrics.jsonl"
+	printf '{"ts":%s,"issue_number":23088,"session_key":"issue-23088","result":"running"}\n' "$now_epoch" >"$metrics_file"
+	AIDEVOPS_HEADLESS_METRICS_FILE="$metrics_file"
+	export AIDEVOPS_HEADLESS_METRICS_FILE
+
+	_cleanup_single_worktree "$repo_dir" "$wt_path" "$branch_name" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
+	local cleanup_rc=$?
+	local rc=0
+	[[ "$cleanup_rc" -ne 0 ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	grep -q 'worktree-skipped.*active-worker-metric.*mode=skipped' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "terminal worktree respects recent worker metric" "$rc" \
 		"cleanup_rc=$cleanup_rc log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
 	return 0
 }
@@ -532,7 +578,7 @@ test_young_local_commit_logs_not_age_eligible() {
 	[[ "$cleanup_rc" -eq 1 ]] || rc=1
 	[[ -d "$wt_path" ]] || rc=1
 	grep -q 'worktree-skipped.*not-age-eligible.*mode=skipped' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
-	grep -q 'pr_state=not-eligible' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	grep -q 'pr_state=generated-retention' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	grep -q 'commits=1' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	print_result "young local commit logs not-age-eligible skip" "$rc" \
 		"cleanup_rc=$cleanup_rc log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
@@ -585,7 +631,13 @@ test_stale_local_commit_no_pr_removes_worktree_preserves_branch() {
 	[[ "$cleanup_rc" -eq 0 ]] || rc=1
 	[[ ! -d "$wt_path" ]] || rc=1
 	[[ "$branch_exists" -eq 0 ]] || rc=1
-	grep -q 'worktree-removed.*local-commits-branch-preserved.*mode=branch-preserved' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	local archive_manifest=""
+	for archive_manifest in "$HOME"/.aidevops/recovery/archives/testowner__testrepo/23076/*/manifest.json; do
+		[[ -f "$archive_manifest" ]] || archive_manifest=""
+	done
+	[[ -n "$archive_manifest" ]] || rc=1
+	[[ -z "$archive_manifest" ]] || [[ -s "${archive_manifest%/manifest.json}/commits.bundle" ]] || rc=1
+	grep -q 'worktree-removed.*archived-failed-worker.*mode=compact-archive' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	grep -q 'recovery_path=branch-preserved' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	print_result "stale local commits/no PR removes folder while preserving branch" "$rc" \
 		"cleanup_rc=$cleanup_rc branch_exists=$branch_exists log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
@@ -597,6 +649,20 @@ test_stale_detached_review_cruft_removes_without_branch() {
 	local wt_path="${TEST_ROOT}/aidevops-pr1234-review-response"
 	setup_repo_with_detached_review_worktree "$repo_dir" "$wt_path" || return 1
 	source_pulse_cleanup_with_stubs || return 1
+	gh() {
+		local target_type="${1:-}"
+		local action="${2:-}"
+		local target_number="${3:-}"
+		local args="$*"
+		if [[ "$target_type" == "pr" && "$action" == "view" &&
+			"$target_number" == "1234" ]]; then
+			if [[ "$args" == *"--json state"* ]]; then
+				printf '%s\n' "MERGED"
+			fi
+			return 0
+		fi
+		return 1
+	}
 
 	local now_epoch
 	now_epoch=$(date +%s)
@@ -609,7 +675,7 @@ test_stale_detached_review_cruft_removes_without_branch() {
 	local rc=0
 	[[ "$cleanup_rc" -eq 0 ]] || rc=1
 	[[ ! -d "$wt_path" ]] || rc=1
-	grep -q 'worktree-removed.*detached-review-cruft.*mode=permanent' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	grep -q 'worktree-removed.*archived-failed-worker.*mode=compact-archive' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	print_result "stale clean detached review worktree is removed as cruft" "$rc" \
 		"cleanup_rc=$cleanup_rc log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
 	return 0
@@ -637,10 +703,38 @@ test_stale_clean_auto_worktree_removes_folder_preserves_branch() {
 	[[ "$cleanup_rc" -eq 0 ]] || rc=1
 	[[ ! -d "$wt_path" ]] || rc=1
 	[[ "$branch_exists" -eq 0 ]] || rc=1
-	grep -q 'worktree-removed.*local-commits-branch-preserved.*mode=branch-preserved' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	grep -q 'worktree-removed.*archived-failed-worker.*mode=compact-archive' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	grep -q 'pr_state=generated-clean-cruft' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	print_result "stale clean auto worktree removes folder while preserving branch" "$rc" \
 		"cleanup_rc=$cleanup_rc branch_exists=$branch_exists log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
+	return 0
+}
+
+test_clean_generated_worktree_waits_for_archive_threshold() {
+	local repo_dir="${TEST_ROOT}/repo-clean-auto-young"
+	local wt_path="${TEST_ROOT}/aidevops-feature-auto-20260507-190813-gh23089"
+	local branch_name="feature/auto-20260507-190813-gh23089"
+	setup_repo_with_worker_worktree "$repo_dir" "$wt_path" "$branch_name" || return 1
+	local old_ts=""
+	old_ts=$(date -u -v-4H +%Y%m%d%H%M 2>/dev/null ||
+		date -u -d "4 hours ago" +%Y%m%d%H%M 2>/dev/null ||
+		printf '202601010000\n')
+	touch -t "$old_ts" "$wt_path/.git"
+	source_pulse_cleanup_with_stubs || return 1
+
+	local now_epoch
+	now_epoch=$(date +%s)
+	AIDEVOPS_HEADLESS_METRICS_FILE="${TEST_ROOT}/missing-clean-auto-young-metrics.jsonl"
+	export AIDEVOPS_HEADLESS_METRICS_FILE
+
+	_cleanup_single_worktree "$repo_dir" "$wt_path" "$branch_name" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
+	local cleanup_rc=$?
+	local rc=0
+	[[ "$cleanup_rc" -ne 0 ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	grep -q 'worktree-skipped.*not-age-eligible.*pr_state=generated-retention' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "clean generated worker waits for compact archive threshold" "$rc" \
+		"cleanup_rc=$cleanup_rc log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
 	return 0
 }
 
@@ -698,9 +792,122 @@ test_dirty_auto_over_seven_days_compacts_and_preserves_branch() {
 	[[ "$branch_exists" -eq 0 ]] || rc=1
 	[[ -n "$archive_manifest" ]] || rc=1
 	[[ -z "$archive_manifest" ]] || jq -e '.reason == "failed-worker" and .dirty_state == "dirty"' "$archive_manifest" >/dev/null || rc=1
-	grep -q 'worktree-removed.*local-commits-branch-preserved.*mode=branch-preserved' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	grep -q 'worktree-removed.*archived-failed-worker.*mode=compact-archive' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
 	print_result "dirty generated auto worktree over 7 days is compacted and removed" "$rc" \
 		"cleanup_rc=$cleanup_rc branch_exists=$branch_exists archive=$archive_manifest pulse=$(cat "$LOGFILE" 2>/dev/null) log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
+	return 0
+}
+
+test_preserve_forensics_marker_blocks_compact_cleanup() {
+	local repo_dir="${TEST_ROOT}/repo-preserve-forensics"
+	local wt_path="${TEST_ROOT}/aidevops-feature-auto-20260507-190810-gh23086"
+	local branch_name="feature/auto-20260507-190810-gh23086"
+	setup_repo_with_worker_worktree "$repo_dir" "$wt_path" "$branch_name" "8 days ago" || return 1
+	printf 'retain full worker evidence\n' >"$wt_path/.aidevops-preserve-forensics"
+	source_pulse_cleanup_with_stubs || return 1
+
+	local now_epoch
+	now_epoch=$(date +%s)
+	AIDEVOPS_HEADLESS_METRICS_FILE="${TEST_ROOT}/missing-forensics-metrics.jsonl"
+	export AIDEVOPS_HEADLESS_METRICS_FILE
+
+	_cleanup_single_worktree "$repo_dir" "$wt_path" "$branch_name" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
+	local cleanup_rc=$?
+	local rc=0
+	[[ "$cleanup_rc" -ne 0 ]] || rc=1
+	[[ -d "$wt_path" && -f "$wt_path/.aidevops-preserve-forensics" ]] || rc=1
+	grep -q 'worktree-skipped.*preserve-forensics.*mode=skipped' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "preserve-forensics marker retains full worker worktree" "$rc" \
+		"cleanup_rc=$cleanup_rc log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
+	return 0
+}
+
+test_unclear_archive_attribution_preserves_worktree() {
+	local repo_dir="${TEST_ROOT}/repo-unclear-attribution"
+	local wt_path="${TEST_ROOT}/aidevops-feature-auto-unattributed"
+	local branch_name="feature/auto-unattributed"
+	setup_repo_with_worker_worktree "$repo_dir" "$wt_path" "$branch_name" "8 days ago" || return 1
+	source_pulse_cleanup_with_stubs || return 1
+
+	local now_epoch
+	now_epoch=$(date +%s)
+	AIDEVOPS_HEADLESS_METRICS_FILE="${TEST_ROOT}/missing-unattributed-metrics.jsonl"
+	export AIDEVOPS_HEADLESS_METRICS_FILE
+
+	_cleanup_single_worktree "$repo_dir" "$wt_path" "$branch_name" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
+	local cleanup_rc=$?
+	local rc=0
+	[[ "$cleanup_rc" -ne 0 ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	grep -q 'worktree-skipped.*archive-attribution-unclear.*mode=skipped' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "unclear archive attribution preserves full worktree" "$rc" \
+		"cleanup_rc=$cleanup_rc log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
+	return 0
+}
+
+test_security_label_blocks_compact_cleanup() {
+	local repo_dir="${TEST_ROOT}/repo-security-label"
+	local wt_path="${TEST_ROOT}/aidevops-feature-auto-20260507-190811-gh23087"
+	local branch_name="feature/auto-20260507-190811-gh23087"
+	setup_repo_with_worker_worktree "$repo_dir" "$wt_path" "$branch_name" "8 days ago" || return 1
+	source_pulse_cleanup_with_stubs || return 1
+	gh() {
+		local target_type="${1:-}"
+		local action="${2:-}"
+		local args="$*"
+		if [[ "$target_type" == "issue" && "$action" == "view" &&
+			"$args" == *"--json labels"* ]]; then
+			printf '%s\n' "security"
+			return 0
+		fi
+		return 1
+	}
+
+	local now_epoch
+	now_epoch=$(date +%s)
+	AIDEVOPS_HEADLESS_METRICS_FILE="${TEST_ROOT}/missing-security-metrics.jsonl"
+	export AIDEVOPS_HEADLESS_METRICS_FILE
+
+	_cleanup_single_worktree "$repo_dir" "$wt_path" "$branch_name" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
+	local cleanup_rc=$?
+	local rc=0
+	[[ "$cleanup_rc" -ne 0 ]] || rc=1
+	[[ -d "$wt_path" ]] || rc=1
+	grep -q 'worktree-skipped.*protected-security.*mode=skipped' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "security label retains full worker worktree" "$rc" \
+		"cleanup_rc=$cleanup_rc log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
+	return 0
+}
+
+test_stale_dirty_attributed_worker_archives_before_removal() {
+	local repo_dir="${TEST_ROOT}/repo-stale-dirty-attributed"
+	local wt_path="${TEST_ROOT}/worker-wt-stale-dirty-attributed"
+	local branch_name="fix/23090-stale-dirty-worker"
+	setup_repo_with_worker_worktree "$repo_dir" "$wt_path" "$branch_name" "8 days ago" || return 1
+	git -C "$wt_path" reset -q --hard main || return 1
+	printf 'unfinished dirty worker state\n' >"$wt_path/unfinished.txt"
+	source_pulse_cleanup_with_stubs || return 1
+
+	local now_epoch
+	now_epoch=$(date +%s)
+	AIDEVOPS_HEADLESS_METRICS_FILE="${TEST_ROOT}/missing-stale-dirty-attributed-metrics.jsonl"
+	export AIDEVOPS_HEADLESS_METRICS_FILE
+
+	_cleanup_single_worktree "$repo_dir" "$wt_path" "$branch_name" "$now_epoch" "testowner/testrepo" "main" >/dev/null 2>&1
+	local cleanup_rc=$?
+	local archive_manifest=""
+	for archive_manifest in "$HOME"/.aidevops/recovery/archives/testowner__testrepo/23090/*/manifest.json; do
+		[[ -f "$archive_manifest" ]] || archive_manifest=""
+	done
+	local rc=0
+	[[ "$cleanup_rc" -eq 0 ]] || rc=1
+	[[ ! -d "$wt_path" ]] || rc=1
+	[[ -n "$archive_manifest" ]] || rc=1
+	[[ -z "$archive_manifest" ]] || jq -e '.reason == "failed-worker" and .dirty_state == "dirty"' "$archive_manifest" >/dev/null || rc=1
+	[[ -z "$archive_manifest" ]] || [[ -s "${archive_manifest%/manifest.json}/untracked.tar.gz" ]] || rc=1
+	grep -q 'worktree-removed.*archived-failed-worker.*mode=compact-archive' "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null || rc=1
+	print_result "stale dirty attributable worker archives before removal" "$rc" \
+		"cleanup_rc=$cleanup_rc archive=$archive_manifest log=$(cat "$AIDEVOPS_CLEANUP_LOG" 2>/dev/null)"
 	return 0
 }
 
@@ -797,12 +1004,18 @@ test_merged_branch_pr_removes_before_age_threshold
 test_closed_issue_dirty_worktree_compacts_and_preserves_branch
 test_failed_compact_archive_preserves_dirty_worktree
 test_terminal_worktree_respects_live_owner_signal
+test_terminal_worktree_respects_recent_worker_metric
 test_fix_numeric_closed_issue_worktree_archives
 test_stale_local_commit_no_pr_removes_worktree_preserves_branch
 test_stale_detached_review_cruft_removes_without_branch
 test_stale_clean_auto_worktree_removes_folder_preserves_branch
+test_clean_generated_worktree_waits_for_archive_threshold
 test_dirty_auto_under_seven_days_is_preserved
 test_dirty_auto_over_seven_days_compacts_and_preserves_branch
+test_preserve_forensics_marker_blocks_compact_cleanup
+test_unclear_archive_attribution_preserves_worktree
+test_security_label_blocks_compact_cleanup
+test_stale_dirty_attributed_worker_archives_before_removal
 test_no_newline_pr_output_blocks_local_commit_cleanup
 test_no_newline_open_pr_output_blocks_clean_fastpath
 test_branch_pr_lookup_uses_null_safe_jq_filter

--- a/.agents/scripts/worktree-archive-helper.md
+++ b/.agents/scripts/worktree-archive-helper.md
@@ -73,21 +73,25 @@ The recommended policy is `--older-than 14d --max-total-size 20G`. `prune` selec
 
 ## Pulse cleanup integration
 
-Pulse uses compact archives before removing dirty terminal worker worktrees and
-dirty generated auto/review worktrees that have reached their cleanup age. It
-passes the parsed repository and issue identity, archives with the
-`failed-worker` reason, and runs `verify` before guarded worktree removal. The
-branch remains as an additional recovery path.
+Pulse uses compact archives before removing stale failed workers, terminal
+issue/PR worktrees, and generated auto/review worktrees that have reached their
+cleanup age. Clean local-only commits are bundled as well as dirty tracked,
+staged, and bounded untracked state. The latest retained worker-failure excerpt
+is included when available. Pulse runs `verify` before guarded removal and keeps
+an attached branch as an additional recovery path.
 
-Clean terminal and generated worktrees do not need a compact dirty-state
-archive; their existing branch-preservation path remains authoritative. When a
-dirty worktree lacks the repository or issue metadata required by this archive
-schema, Pulse retains the existing Git-stash recovery fallback rather than
-inventing metadata.
+Cleanup requires exact repository and issue/PR attribution. It fails closed
+rather than falling back to an in-repository stash when attribution or remote
+policy labels cannot be verified. Archived removals use the
+`archived-failed-worker` or `archived-post-pr-cleanup` audit reason with
+`mode=compact-archive`, archive location, verification outcome, and delete
+outcome. The asynchronous cleanup summary reports removed, archived, and failed
+archive counts.
 
 Any compact archive creation or verification failure records a skipped cleanup
-event and preserves the dirty worktree and branch. The failure stops only that
+event and preserves the worktree and branch. The failure stops only that
 worktree's deletion and must not fall through to a less protective cleanup path
-or stop broader safe cleanup. Interactive/manual owners, security incidents, a
-`preserve-forensics` marker or label, repeated unexplained failures, and other
-protected evidence continue to retain full worktrees.
+or stop broader safe cleanup. Interactive/manual owners, security incidents,
+`.aidevops-preserve-forensics`, `.preserve-forensics`, or
+`.aidevops-security-incident` markers, protected task labels, repeated
+zero-session failures, and other protected evidence retain full worktrees.

--- a/.agents/workflows/worktree-cleanup.md
+++ b/.agents/workflows/worktree-cleanup.md
@@ -38,7 +38,17 @@ Cleanup failures are non-fatal — the PR is already merged.
 
 Use [`../scripts/worktree-archive-helper.md`](../scripts/worktree-archive-helper.md) for the standalone archive, restore, list, verify, and retention commands. The helper preserves local commits, tracked/staged changes, bounded untracked files, and exact base metadata under `~/.aidevops/recovery/archives/`.
 
-Pulse and worker cleanup do **not** invoke the helper yet. Integrating archive-before-delete for terminal failures, disposable clean pushed-PR worktrees, and archive/full-worktree retention is a follow-up after the helper has been verified. Full worktrees remain required for manual owners, security/forensics cases, repeated unexplained failures, and archive safety failures.
+Pulse cleanup invokes the helper for attributable stale/failed workers,
+terminal issue or PR worktrees, and generated auto/review worktrees after their
+retention window. It verifies each archive before removing the full worktree;
+local commits, dirty patches, bounded untracked state, and available failure
+context remain restorable. Audit rows use `mode=compact-archive`, and async
+cleanup reports removed, archived, and failed-archive totals.
+
+Full worktrees remain required for live owners/sessions/processes, recent worker
+metrics, security or forensics markers/labels, repeated zero-session failures,
+unclear repository/task attribution, remote policy lookup failures, and archive
+creation or verification failures.
 
 ## Manual Cleanup (interactive sessions)
 


### PR DESCRIPTION
## Summary

Archive stale or failed worker recovery state before guarded worktree deletion, while preserving active, security-sensitive, unattributed, and unclear-PR-state worktrees.

## Files Changed

.agents/scripts/cleanup-worktrees-async-helper.sh, .agents/scripts/pulse-cleanup-worktree-removal.sh, .agents/scripts/pulse-cleanup-worktree-state.sh, .agents/scripts/tests/test-cleanup-worktrees-async.sh, .agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh, .agents/scripts/worktree-archive-helper.md, .agents/workflows/worktree-cleanup.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — Runtime verified: 28/28 cleanup policy tests, 13/13 async cleanup tests, 4/4 dirty-state preservation tests, focused archive/audit/dispatch/canary suites, targeted ShellCheck, and changed/full repository linters passed.

Resolves #29910


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.248 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h 59m and 1,885,953 tokens on this with the user in an interactive session.