### PR TITLE
GH#29929: fix: recover reserved release lanes after aggregation

### DIFF
--- a/.agents/scripts/full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/full-loop-release-aggregate-recovery.sh
@@ -193,6 +193,46 @@ _full_loop_recovery_prepare_aggregate() {
 	return 0
 }
 
+_full_loop_recovery_expand_reserved_authorization() {
+	local repo="$1"
+	local source_pr="$2"
+	local expected_sources="$3"
+	local previous_auth=""
+	local existing_tag_rc=0
+	_full_loop_recovery_validate_receipt "$repo" "$source_pr" || return 1
+	_full_loop_release_find_tag_for_pr "$repo" "$source_pr" || existing_tag_rc=$?
+	[[ "$existing_tag_rc" -eq 2 ]] || return 1
+	_full_loop_recovery_prepare_aggregate "$repo" "$source_pr" "$expected_sources" || return 1
+	_full_loop_validate_release_candidates "$repo" "$_FULL_LOOP_RESOLVED_SOURCE_JSON" || return 1
+	_full_loop_release_reset_tag_worktree || return 1
+	previous_auth=$(_full_loop_read_release_authorization "$repo" "$source_pr") || return 1
+	release_authorization_subset "$previous_auth" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+	release_lane_read "$repo" || return 1
+	jq -e --argjson source_pr "$source_pr" --arg previous "$previous_auth" '
+		.active == true and .source_pr == $source_pr and .phase == "reserved"
+		and .tag == null and .expected_sources == $previous
+		and ((.terminal_receipt // null) == null)
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	release_lane_acquire "$repo" "$source_pr" "$previous_auth" || return $?
+	[[ "$_AIDEVOPS_RELEASE_LANE_RESULT" == "acquired" ]] || return 1
+	if [[ "$previous_auth" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]]; then
+		printf 'Reserved release authorization already matches the reviewed aggregate for PR #%s\n' "$source_pr"
+		return 0
+	fi
+	_full_loop_expand_release_authorization_for_aggregate "$repo" "$source_pr" \
+		"$previous_auth" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+	if ! release_lane_expand_reserved_authorization "$repo" "$source_pr" "$previous_auth" \
+		"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED"; then
+		release_lane_restore_reserved_authorization "$repo" "$source_pr" \
+			"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT" || true
+		_full_loop_restore_release_authorization_after_aggregate "$repo" "$source_pr" \
+			"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$previous_auth" || return 1
+		return 1
+	fi
+	printf 'Expanded side-effect-free reserved release authorization for reviewed aggregate PR #%s\n' "$source_pr"
+	return 0
+}
+
 _full_loop_recovery_begin_state_transaction() {
 	local repo="$1"
 	local source_pr="$2"

--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -370,6 +370,65 @@ _full_loop_release_guard_competing_lane() {
 	return 0
 }
 
+_FULL_LOOP_RESERVED_RECOVERY_EXPECTED=""
+_FULL_LOOP_RESERVED_RECOVERY_COMPLETED=false
+
+_full_loop_release_resolve_persisted_intent() {
+	local repo="$1"
+	local source_pr="$2"
+	local requested_sources="$3"
+	local persisted_sources="$4"
+	local persisted_prs=""
+	local requested_prs=""
+	_FULL_LOOP_RESERVED_RECOVERY_EXPECTED="$requested_sources"
+	_FULL_LOOP_RESERVED_RECOVERY_COMPLETED=false
+	if [[ -z "$requested_sources" ]]; then
+		_FULL_LOOP_RESERVED_RECOVERY_EXPECTED="$persisted_sources"
+		return 0
+	fi
+	requested_prs=$(release_authorization_intent_json "$requested_sources" | jq -c 'map(.pr)') || return 1
+	persisted_prs=$(release_authorization_intent_json "$persisted_sources" | jq -c 'map(.pr)') || return 1
+	[[ "$requested_prs" != "$persisted_prs" ]] || return 0
+	_full_loop_recovery_expand_reserved_authorization "$repo" "$source_pr" "$requested_sources" || return $?
+	_FULL_LOOP_RESERVED_RECOVERY_EXPECTED="$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED"
+	_FULL_LOOP_RESERVED_RECOVERY_COMPLETED=true
+	return 0
+}
+
+_full_loop_release_start_new() {
+	local repo="$1"
+	local source_pr="$2"
+	local release_type="$3"
+	local deployment_scope="$4"
+	local expected_sources="$5"
+	local existing_state_rc=0
+	local persisted_expected=""
+	_full_loop_release_guard_competing_lane "$repo" "$source_pr" || return $?
+	if persisted_expected=$(_full_loop_read_release_authorization "$repo" "$source_pr"); then
+		_full_loop_release_resolve_persisted_intent "$repo" "$source_pr" "$expected_sources" \
+			"$persisted_expected" || return $?
+		expected_sources="$_FULL_LOOP_RESERVED_RECOVERY_EXPECTED"
+	fi
+	_full_loop_release_guard_existing "$repo" "$source_pr" "${expected_sources:-$source_pr}" || existing_state_rc=$?
+	case "$existing_state_rc" in
+	0) return 0 ;;
+	2) ;;
+	*) return "$existing_state_rc" ;;
+	esac
+	if [[ "$_FULL_LOOP_RESERVED_RECOVERY_COMPLETED" == "true" ]]; then
+		_full_loop_release_run_new "$repo" "$source_pr" "$release_type" "$deployment_scope" "$expected_sources"
+		return $?
+	fi
+	release_lane_acquire "$repo" "$source_pr" "${expected_sources:-$source_pr}" || return $?
+	if [[ "$_AIDEVOPS_RELEASE_LANE_RESULT" == "adopted" ]]; then
+		printf 'Release lane already belongs to PR #%s; reconcile instead of creating another version bump\n' "$source_pr"
+		return 8
+	fi
+	_full_loop_release_run_new "$repo" "$source_pr" "$release_type" "$deployment_scope" \
+		"${expected_sources:-$source_pr}"
+	return $?
+}
+
 main() {
 	local release_type="${1:-patch}"
 	local source_pr="${2:-}"
@@ -449,26 +508,8 @@ main() {
 	[[ "$source_pr" =~ ^[0-9]+$ ]] || return 1
 	_full_loop_release_bind_repo_context || return 1
 	local repo=""
-	local existing_state_rc=0
-	local persisted_expected=""
 	repo=$(_full_loop_resolve_repo "${AIDEVOPS_FULL_LOOP_REPO:-}") || return 1
-	_full_loop_release_guard_competing_lane "$repo" "$source_pr" || return $?
-	if persisted_expected=$(_full_loop_read_release_authorization "$repo" "$source_pr"); then
-		[[ -n "$expected_sources" ]] || expected_sources="$persisted_expected"
-	fi
-	_full_loop_release_guard_existing "$repo" "$source_pr" "${expected_sources:-$source_pr}" || existing_state_rc=$?
-	case "$existing_state_rc" in
-	0) return 0 ;;
-	2) ;;
-	*) return "$existing_state_rc" ;;
-	esac
-	release_lane_acquire "$repo" "$source_pr" "${expected_sources:-$source_pr}" || return $?
-	if [[ "$_AIDEVOPS_RELEASE_LANE_RESULT" == "adopted" ]]; then
-		printf 'Release lane already belongs to PR #%s; reconcile instead of creating another version bump\n' "$source_pr"
-		return 8
-	fi
-	_full_loop_release_run_new "$repo" "$source_pr" "$release_type" "$deployment_scope" \
-		"${expected_sources:-$source_pr}"
+	_full_loop_release_start_new "$repo" "$source_pr" "$release_type" "$deployment_scope" "$expected_sources"
 	return $?
 }
 

--- a/.agents/scripts/release-lane-helper.sh
+++ b/.agents/scripts/release-lane-helper.sh
@@ -256,6 +256,48 @@ release_lane_begin_aggregate_recovery() {
 	return 0
 }
 
+release_lane_expand_reserved_authorization() {
+	local repo="$1"
+	local source_pr="$2"
+	local previous_sources="$3"
+	local expected_sources="$4"
+	local state_json=""
+	[[ -n "$_AIDEVOPS_RELEASE_LANE_TOKEN" ]] || return 1
+	release_lane_read "$repo" || return 1
+	jq -e --argjson source_pr "$source_pr" --arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" \
+		--arg previous "$previous_sources" --arg reserved "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" '
+		.active == true and .source_pr == $source_pr and .operation_token == $token
+		and .phase == $reserved and .tag == null and .expected_sources == $previous
+		and ((.terminal_receipt // null) == null)
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT="$_AIDEVOPS_RELEASE_LANE_JSON"
+	state_json=$(jq -c --arg expected "$expected_sources" --arg now "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+		'.expected_sources=$expected | .updated_at=$now' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	_release_lane_write "$repo" "$state_json" "$_AIDEVOPS_RELEASE_LANE_HEAD"
+	return $?
+}
+
+release_lane_restore_reserved_authorization() {
+	local repo="$1"
+	local source_pr="$2"
+	local expected_sources="$3"
+	local snapshot_json="$4"
+	release_lane_read "$repo" || return 1
+	jq -e --argjson source_pr "$source_pr" --arg token "$_AIDEVOPS_RELEASE_LANE_TOKEN" \
+		--arg expected "$expected_sources" --arg reserved "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" '
+		.active == true and .source_pr == $source_pr and .operation_token == $token
+		and .phase == $reserved and .tag == null and .expected_sources == $expected
+		and ((.terminal_receipt // null) == null)
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
+	jq -e --argjson source_pr "$source_pr" --arg reserved "$_AIDEVOPS_RELEASE_LANE_PHASE_RESERVED" '
+		.schema_version == 1 and .active == true and .source_pr == $source_pr
+		and .phase == $reserved and .tag == null
+	' <<<"$snapshot_json" >/dev/null || return 1
+	_release_lane_write "$repo" "$snapshot_json" "$_AIDEVOPS_RELEASE_LANE_HEAD" || return $?
+	_AIDEVOPS_RELEASE_LANE_TOKEN=$(jq -r '.operation_token' <<<"$snapshot_json") || return 1
+	return 0
+}
+
 release_lane_restore_aggregate_recovery() {
 	local repo="$1"
 	local source_pr="$2"

--- a/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
@@ -244,4 +244,95 @@ fi
 [[ "$(tr '\n' ' ' <"$CALL_LOG")" == "receipt tag aggregate channels begin version-manager " ]]
 printf 'PASS uncertain tag rollback retains expanded state for reconciliation\n'
 
+(
+	unset _FULL_LOOP_RELEASE_AGGREGATE_RECOVERY_LOADED
+	source "${SCRIPT_DIR}/full-loop-release-aggregate-recovery.sh"
+	RESERVED_LOG="${TEST_ROOT}/reserved.log"
+	: >"$RESERVED_LOG"
+	old_manifest='42@2222222222222222222222222222222222222222'
+	expanded_manifest="${old_manifest},43@3333333333333333333333333333333333333333"
+	_full_loop_recovery_validate_receipt() { return 0; }
+	_full_loop_release_find_tag_for_pr() { return 2; }
+	_full_loop_recovery_prepare_aggregate() {
+		_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="$expanded_manifest"
+		_FULL_LOOP_RESOLVED_SOURCE_JSON='{"mode":"aggregate"}'
+		return 0
+	}
+	_full_loop_validate_release_candidates() {
+		printf 'validate\n' >>"$RESERVED_LOG"
+		return 0
+	}
+	_full_loop_release_reset_tag_worktree() { return 0; }
+	_full_loop_read_release_authorization() {
+		printf '%s\n' "$old_manifest"
+		return 0
+	}
+	release_authorization_subset() { return 0; }
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg previous "$old_manifest" \
+			'{active:true,source_pr:42,phase:"reserved",tag:null,expected_sources:$previous,terminal_receipt:null}')
+		return 0
+	}
+	release_lane_acquire() {
+		_AIDEVOPS_RELEASE_LANE_RESULT=acquired
+		_AIDEVOPS_RELEASE_LANE_TOKEN=owned
+		return 0
+	}
+	_full_loop_expand_release_authorization_for_aggregate() {
+		printf 'expand-auth\n' >>"$RESERVED_LOG"
+		return 0
+	}
+	release_lane_expand_reserved_authorization() {
+		_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT='{"phase":"reserved"}'
+		printf 'expand-lane\n' >>"$RESERVED_LOG"
+		return 0
+	}
+	_full_loop_recovery_expand_reserved_authorization test/repo 42 42,43
+	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "validate expand-auth expand-lane " ]]
+	printf 'PASS reserved recovery validates the reviewed aggregate before transactional expansion\n'
+
+	: >"$RESERVED_LOG"
+	_full_loop_read_release_authorization() {
+		printf '%s\n' "$expanded_manifest"
+		return 0
+	}
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg expected "$expanded_manifest" \
+			'{active:true,source_pr:42,phase:"reserved",tag:null,expected_sources:$expected,terminal_receipt:null}')
+		return 0
+	}
+	_full_loop_recovery_expand_reserved_authorization test/repo 42 42,43 >/dev/null
+	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "validate " ]]
+	printf 'PASS reserved recovery recognizes an already-converged authorization and lane\n'
+
+	: >"$RESERVED_LOG"
+	_full_loop_read_release_authorization() {
+		printf '%s\n' "$old_manifest"
+		return 0
+	}
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg previous "$old_manifest" \
+			'{active:true,source_pr:42,phase:"reserved",tag:null,expected_sources:$previous,terminal_receipt:null}')
+		return 0
+	}
+	release_lane_expand_reserved_authorization() {
+		_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT='{"phase":"reserved"}'
+		printf 'expand-lane\n' >>"$RESERVED_LOG"
+		return 1
+	}
+	release_lane_restore_reserved_authorization() {
+		printf 'restore-lane\n' >>"$RESERVED_LOG"
+		return 0
+	}
+	_full_loop_restore_release_authorization_after_aggregate() {
+		printf 'restore-auth\n' >>"$RESERVED_LOG"
+		return 0
+	}
+	if _full_loop_recovery_expand_reserved_authorization test/repo 42 42,43 >/dev/null 2>&1; then
+		exit 1
+	fi
+	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "validate expand-auth expand-lane restore-lane restore-auth " ]]
+	printf 'PASS reserved recovery restores lane and authorization after a partial write\n'
+)
+
 exit 0

--- a/.agents/scripts/tests/test-release-lane.sh
+++ b/.agents/scripts/tests/test-release-lane.sh
@@ -211,6 +211,42 @@ run_aggregate_recovery_rejection_test() (
 	return 0
 )
 
+run_reserved_aggregate_authorization_test() (
+	local old_state='{"schema_version":1,"repository":"test/repo","active":true,"source_pr":101,"expected_sources":"101@1111111111111111111111111111111111111111","phase":"reserved","tag":null,"updated_at":"2026-08-09T00:00:00Z","operation_token":"token-owned","terminal_receipt":null}'
+	local state="$old_state"
+	local expanded='101@1111111111111111111111111111111111111111,102@2222222222222222222222222222222222222222'
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON="$state"
+		_AIDEVOPS_RELEASE_LANE_HEAD="1111111111111111111111111111111111111111"
+		return 0
+	}
+	_release_lane_write() {
+		local repo="$1"
+		local state_json="$2"
+		local expected_head="$3"
+		[[ "$repo" == "test/repo" && "$expected_head" == "1111111111111111111111111111111111111111" ]] || return 1
+		state="$state_json"
+		return 0
+	}
+	_AIDEVOPS_RELEASE_LANE_TOKEN="token-owned"
+	release_lane_expand_reserved_authorization test/repo 101 \
+		'101@1111111111111111111111111111111111111111' "$expanded" || return 1
+	[[ "$(jq -r '.expected_sources' <<<"$state")" == "$expanded" ]] || return 1
+	release_lane_restore_reserved_authorization test/repo 101 "$expanded" "$old_state" || return 1
+	[[ "$state" == "$old_state" ]] || return 1
+	state=$(jq -c '.tag="v1.2.3"' <<<"$old_state") || return 1
+	if release_lane_expand_reserved_authorization test/repo 101 \
+		'101@1111111111111111111111111111111111111111' "$expanded"; then
+		return 1
+	fi
+	state=$(jq -c '.tag=null | .terminal_receipt={status:"published"}' <<<"$old_state") || return 1
+	if release_lane_expand_reserved_authorization test/repo 101 \
+		'101@1111111111111111111111111111111111111111' "$expanded"; then
+		return 1
+	fi
+	return 0
+)
+
 if run_competing_source_test; then assert_result 'competing source receives active lane and reconcile action' true; else assert_result 'competing source receives active lane and reconcile action' false; fi
 if run_same_source_adoption_test; then assert_result 'same source adopts durable lane without another bump' true; else assert_result 'same source adopts durable lane without another bump' false; fi
 if run_terminal_lane_reacquire_test; then assert_result 'terminal lane can be atomically reserved by a later source' true; else assert_result 'terminal lane can be atomically reserved by a later source' false; fi
@@ -220,6 +256,7 @@ if run_legacy_and_api_failure_test; then assert_result 'legacy absent lane remai
 if run_stale_same_source_recovery_test; then assert_result 'stale recovery rotates its token and fences the prior owner' true; else assert_result 'stale recovery rotates its token and fences the prior owner' false; fi
 if run_aggregate_recovery_rotation_test; then assert_result 'reviewed aggregate recovery rotates and can restore its lane transaction' true; else assert_result 'reviewed aggregate recovery rotates and can restore its lane transaction' false; fi
 if run_aggregate_recovery_rejection_test; then assert_result 'aggregate recovery rejects competing owners and terminal lanes' true; else assert_result 'aggregate recovery rejects competing owners and terminal lanes' false; fi
+if run_reserved_aggregate_authorization_test; then assert_result 'reserved aggregate authorization uses owned CAS expansion and exact rollback' true; else assert_result 'reserved aggregate authorization uses owned CAS expansion and exact rollback' false; fi
 
 printf '\nTests run: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/workflows/release.md
+++ b/.agents/workflows/release.md
@@ -47,7 +47,14 @@ version manager independently require exact equality with the direct or reviewed
 aggregation manifest. Missing, extra, duplicate, malformed, and SHA-mismatched
 sources fail before a bump, tag, package, or terminal receipt. Omitting the option
 retains singleton compatibility by treating the requested source PR as the
-expected set. A retry reuses the persisted manifest and rejects conflicting intent.
+expected set. A retry reuses the persisted manifest. When the same source owns a
+stale, side-effect-free `reserved` lane with no tag or terminal receipt, an exact
+reviewed aggregate at the current `origin/main` tip may transactionally expand a
+persisted subset authorization. The helper validates every candidate and terminal
+receipt first, rotates the fencing token, updates the authorization and lane with
+compare-and-swap semantics, restores prior snapshots after a partial failure, and
+then continues the ordinary release command. Other conflicting intent remains
+immutable.
 
 ```bash
 aidevops release status <merged-pr-number>     # read-only remote/channel state


### PR DESCRIPTION
## Summary

Add fail-closed reserved-lane authorization recovery for exact reviewed aggregates

## Files Changed

.agents/scripts/full-loop-release-aggregate-recovery.sh, .agents/scripts/full-loop-release-helper.sh, .agents/scripts/release-lane-helper.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — ShellCheck plus targeted release-lane, aggregate-recovery, and release-helper tests passed

Resolves #29929


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.248 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 7m and 88,418 tokens on this as a headless worker.