### PR TITLE
GH#29936: fix: normalize legacy reserved release intents

### DIFF
--- a/.agents/scripts/full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/full-loop-release-aggregate-recovery.sh
@@ -193,11 +193,34 @@ _full_loop_recovery_prepare_aggregate() {
 	return 0
 }
 
+_full_loop_recovery_resolve_lane_authorization() {
+	local lane_sources="$1"
+	local reviewed_sources="$2"
+	local lane_intent_json=""
+	local reviewed_json=""
+	lane_intent_json=$(release_authorization_intent_json "$lane_sources") || return 1
+	reviewed_json=$(release_authorization_manifest_json "$reviewed_sources") || return 1
+	jq -cern --argjson intent "$lane_intent_json" --argjson reviewed "$reviewed_json" '
+		$intent | map(. as $candidate
+			| ($reviewed | map(select(.pr == $candidate.pr))) as $matches
+			| if (($matches | length) == 1
+				and ($candidate.merge == null or $candidate.merge == $matches[0].merge))
+				then $matches[0]
+				else error("reserved lane intent does not match reviewed aggregate")
+			  end)
+		| map("\(.pr)@\(.merge)") | join(",")
+	' 2>/dev/null
+	return $?
+}
+
 _full_loop_recovery_expand_reserved_authorization() {
 	local repo="$1"
 	local source_pr="$2"
 	local expected_sources="$3"
 	local previous_auth=""
+	local lane_sources=""
+	local normalized_lane_sources=""
+	local authorization_expanded=false
 	local existing_tag_rc=0
 	_full_loop_recovery_validate_receipt "$repo" "$source_pr" || return 1
 	_full_loop_release_find_tag_for_pr "$repo" "$source_pr" || existing_tag_rc=$?
@@ -208,25 +231,45 @@ _full_loop_recovery_expand_reserved_authorization() {
 	previous_auth=$(_full_loop_read_release_authorization "$repo" "$source_pr") || return 1
 	release_authorization_subset "$previous_auth" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
 	release_lane_read "$repo" || return 1
-	jq -e --argjson source_pr "$source_pr" --arg previous "$previous_auth" '
+	jq -e --argjson source_pr "$source_pr" '
 		.active == true and .source_pr == $source_pr and .phase == "reserved"
-		and .tag == null and .expected_sources == $previous
+		and .tag == null and (.expected_sources | type) == "string"
 		and ((.terminal_receipt // null) == null)
-	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || return 1
-	release_lane_acquire "$repo" "$source_pr" "$previous_auth" || return $?
+	' <<<"$_AIDEVOPS_RELEASE_LANE_JSON" >/dev/null || {
+		printf 'Reserved release lane is not eligible for legacy authorization normalization for PR #%s\n' "$source_pr" >&2
+		return 1
+	}
+	lane_sources=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	normalized_lane_sources=$(_full_loop_recovery_resolve_lane_authorization \
+		"$lane_sources" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED") || {
+		printf 'Reserved release lane authorization cannot be normalized against reviewed aggregate PR #%s\n' "$source_pr" >&2
+		return 1
+	}
+	if ! release_authorization_compare "$normalized_lane_sources" "$previous_auth"; then
+		printf 'Reserved release lane and persisted authorization identify different sources for PR #%s\n' "$source_pr" >&2
+		return 1
+	fi
+	release_lane_acquire "$repo" "$source_pr" "$lane_sources" || return $?
 	[[ "$_AIDEVOPS_RELEASE_LANE_RESULT" == "acquired" ]] || return 1
-	if [[ "$previous_auth" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]]; then
+	if [[ "$previous_auth" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" &&
+		"$lane_sources" == "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]]; then
 		printf 'Reserved release authorization already matches the reviewed aggregate for PR #%s\n' "$source_pr"
 		return 0
 	fi
-	_full_loop_expand_release_authorization_for_aggregate "$repo" "$source_pr" \
-		"$previous_auth" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
-	if ! release_lane_expand_reserved_authorization "$repo" "$source_pr" "$previous_auth" \
+	if [[ "$previous_auth" != "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]]; then
+		_full_loop_expand_release_authorization_for_aggregate "$repo" "$source_pr" \
+			"$previous_auth" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+		authorization_expanded=true
+	fi
+	if ! release_lane_expand_reserved_authorization "$repo" "$source_pr" "$lane_sources" \
 		"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED"; then
 		release_lane_restore_reserved_authorization "$repo" "$source_pr" \
 			"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT" || true
-		_full_loop_restore_release_authorization_after_aggregate "$repo" "$source_pr" \
-			"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$previous_auth" || return 1
+		if [[ "$authorization_expanded" == "true" ]]; then
+			_full_loop_restore_release_authorization_after_aggregate "$repo" "$source_pr" \
+				"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$previous_auth" || return 1
+		fi
+		printf 'Reserved release lane authorization migration failed for PR #%s; prior state was restored\n' "$source_pr" >&2
 		return 1
 	fi
 	printf 'Expanded side-effect-free reserved release authorization for reviewed aggregate PR #%s\n' "$source_pr"

--- a/.agents/scripts/release-lane-helper.sh
+++ b/.agents/scripts/release-lane-helper.sh
@@ -259,6 +259,8 @@ release_lane_begin_aggregate_recovery() {
 release_lane_expand_reserved_authorization() {
 	local repo="$1"
 	local source_pr="$2"
+	# Keep this value byte-exact: supported older lanes may contain PR-only intent,
+	# and rollback must restore that representation rather than a resolved manifest.
 	local previous_sources="$3"
 	local expected_sources="$4"
 	local state_json=""

--- a/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
@@ -246,10 +246,12 @@ printf 'PASS uncertain tag rollback retains expanded state for reconciliation\n'
 
 (
 	unset _FULL_LOOP_RELEASE_AGGREGATE_RECOVERY_LOADED
+	source "${SCRIPT_DIR}/release-authorization-manifest-helper.sh"
 	source "${SCRIPT_DIR}/full-loop-release-aggregate-recovery.sh"
 	RESERVED_LOG="${TEST_ROOT}/reserved.log"
 	: >"$RESERVED_LOG"
 	old_manifest='42@2222222222222222222222222222222222222222'
+	legacy_lane_intent='42'
 	expanded_manifest="${old_manifest},43@3333333333333333333333333333333333333333"
 	_full_loop_recovery_validate_receipt() { return 0; }
 	_full_loop_release_find_tag_for_pr() { return 2; }
@@ -269,7 +271,7 @@ printf 'PASS uncertain tag rollback retains expanded state for reconciliation\n'
 	}
 	release_authorization_subset() { return 0; }
 	release_lane_read() {
-		_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg previous "$old_manifest" \
+		_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg previous "$legacy_lane_intent" \
 			'{active:true,source_pr:42,phase:"reserved",tag:null,expected_sources:$previous,terminal_receipt:null}')
 		return 0
 	}
@@ -283,13 +285,14 @@ printf 'PASS uncertain tag rollback retains expanded state for reconciliation\n'
 		return 0
 	}
 	release_lane_expand_reserved_authorization() {
+		[[ "$3" == "$legacy_lane_intent" ]] || return 1
 		_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT='{"phase":"reserved"}'
 		printf 'expand-lane\n' >>"$RESERVED_LOG"
 		return 0
 	}
 	_full_loop_recovery_expand_reserved_authorization test/repo 42 42,43
 	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "validate expand-auth expand-lane " ]]
-	printf 'PASS reserved recovery validates the reviewed aggregate before transactional expansion\n'
+	printf 'PASS reserved recovery normalizes legacy lane intent before transactional expansion\n'
 
 	: >"$RESERVED_LOG"
 	_full_loop_read_release_authorization() {
@@ -306,12 +309,25 @@ printf 'PASS uncertain tag rollback retains expanded state for reconciliation\n'
 	printf 'PASS reserved recovery recognizes an already-converged authorization and lane\n'
 
 	: >"$RESERVED_LOG"
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn \
+			'{active:true,source_pr:42,phase:"reserved",tag:null,expected_sources:"44",terminal_receipt:null}')
+		return 0
+	}
+	if _full_loop_recovery_expand_reserved_authorization test/repo 42 42,43 >"${TEST_ROOT}/legacy-mismatch.out" 2>&1; then
+		exit 1
+	fi
+	grep -q 'cannot be normalized against reviewed aggregate' "${TEST_ROOT}/legacy-mismatch.out"
+	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "validate " ]]
+	printf 'PASS reserved recovery rejects non-equivalent legacy PR identities without mutation\n'
+
+	: >"$RESERVED_LOG"
 	_full_loop_read_release_authorization() {
 		printf '%s\n' "$old_manifest"
 		return 0
 	}
 	release_lane_read() {
-		_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg previous "$old_manifest" \
+		_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg previous "$legacy_lane_intent" \
 			'{active:true,source_pr:42,phase:"reserved",tag:null,expected_sources:$previous,terminal_receipt:null}')
 		return 0
 	}

--- a/.agents/scripts/tests/test-release-lane.sh
+++ b/.agents/scripts/tests/test-release-lane.sh
@@ -212,9 +212,10 @@ run_aggregate_recovery_rejection_test() (
 )
 
 run_reserved_aggregate_authorization_test() (
-	local old_state='{"schema_version":1,"repository":"test/repo","active":true,"source_pr":101,"expected_sources":"101@1111111111111111111111111111111111111111","phase":"reserved","tag":null,"updated_at":"2026-08-09T00:00:00Z","operation_token":"token-owned","terminal_receipt":null}'
+	local old_state='{"schema_version":1,"repository":"test/repo","active":true,"source_pr":101,"expected_sources":"101","phase":"reserved","tag":null,"updated_at":"2026-08-09T00:00:00Z","operation_token":"token-owned","terminal_receipt":null}'
 	local state="$old_state"
 	local expanded='101@1111111111111111111111111111111111111111,102@2222222222222222222222222222222222222222'
+	local write_conflict=false
 	release_lane_read() {
 		_AIDEVOPS_RELEASE_LANE_JSON="$state"
 		_AIDEVOPS_RELEASE_LANE_HEAD="1111111111111111111111111111111111111111"
@@ -225,23 +226,30 @@ run_reserved_aggregate_authorization_test() (
 		local state_json="$2"
 		local expected_head="$3"
 		[[ "$repo" == "test/repo" && "$expected_head" == "1111111111111111111111111111111111111111" ]] || return 1
+		[[ "$write_conflict" == "false" ]] || return 2
 		state="$state_json"
 		return 0
 	}
 	_AIDEVOPS_RELEASE_LANE_TOKEN="token-owned"
 	release_lane_expand_reserved_authorization test/repo 101 \
-		'101@1111111111111111111111111111111111111111' "$expanded" || return 1
+		'101' "$expanded" || return 1
 	[[ "$(jq -r '.expected_sources' <<<"$state")" == "$expanded" ]] || return 1
 	release_lane_restore_reserved_authorization test/repo 101 "$expanded" "$old_state" || return 1
 	[[ "$state" == "$old_state" ]] || return 1
+	write_conflict=true
+	if release_lane_expand_reserved_authorization test/repo 101 '101' "$expanded"; then
+		return 1
+	fi
+	[[ "$state" == "$old_state" ]] || return 1
+	write_conflict=false
 	state=$(jq -c '.tag="v1.2.3"' <<<"$old_state") || return 1
 	if release_lane_expand_reserved_authorization test/repo 101 \
-		'101@1111111111111111111111111111111111111111' "$expanded"; then
+		'101' "$expanded"; then
 		return 1
 	fi
 	state=$(jq -c '.tag=null | .terminal_receipt={status:"published"}' <<<"$old_state") || return 1
 	if release_lane_expand_reserved_authorization test/repo 101 \
-		'101@1111111111111111111111111111111111111111' "$expanded"; then
+		'101' "$expanded"; then
 		return 1
 	fi
 	return 0

--- a/.agents/workflows/release.md
+++ b/.agents/workflows/release.md
@@ -53,8 +53,10 @@ reviewed aggregate at the current `origin/main` tip may transactionally expand a
 persisted subset authorization. The helper validates every candidate and terminal
 receipt first, rotates the fencing token, updates the authorization and lane with
 compare-and-swap semantics, restores prior snapshots after a partial failure, and
-then continues the ordinary release command. Other conflicting intent remains
-immutable.
+then continues the ordinary release command. Reserved lanes written by supported
+older versions may contain PR-only intent; recovery resolves those identities
+against the reviewed aggregate and migrates them to the canonical `PR@SHA`
+manifest inside the same transaction. Other conflicting intent remains immutable.
 
 ```bash
 aidevops release status <merged-pr-number>     # read-only remote/channel state


### PR DESCRIPTION
## Summary

Normalize PR-only reserved-lane intent against reviewed aggregate PR identities, then migrate the lane through existing CAS and rollback primitives.

## Files Changed

.agents/scripts/full-loop-release-aggregate-recovery.sh, .agents/scripts/release-lane-helper.sh, .agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh, .agents/scripts/tests/test-release-lane.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: focused aggregate recovery and release-lane suites passed against the production helper path; ShellCheck passed for all changed shell files

Resolves #29936


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.249 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 8m and 111,652 tokens on this as a headless worker.