### PR TITLE
GH#29938: Verify manual published release receipts

### DIFF
--- a/.agents/scripts/full-loop-helper-state.sh
+++ b/.agents/scripts/full-loop-helper-state.sh
@@ -38,6 +38,7 @@ _FULL_LOOP_EXECUTOR_IN_PROGRESS="in-progress"
 _FULL_LOOP_PHASE_FAILED="failed"
 _FULL_LOOP_PHASE_RUNNING="running"
 _FULL_LOOP_PHASE_WAITING="waiting"
+_FULL_LOOP_PHASE_COMPLETED="completed"
 _FULL_LOOP_PHASE_TASK="task"
 _FULL_LOOP_RESOURCE_NONE="none"
 FULL_LOOP_TRANSITION_LOCK_TOKEN=""
@@ -1652,10 +1653,10 @@ cmd_resume() {
 	}
 	print_info "Resuming from phase: $CURRENT_PHASE"
 	MANUAL_RESUME_COUNT=$((MANUAL_RESUME_COUNT + 1))
-	PHASE_STATUS="completed"
+	PHASE_STATUS="$_FULL_LOOP_PHASE_COMPLETED"
 	PHASE_ENDED_AT="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 	TERMINAL_EVIDENCE="manual-resume"
-	_full_loop_append_event "phase.completed" "completed"
+	_full_loop_append_event "phase.completed" "$_FULL_LOOP_PHASE_COMPLETED"
 	local transition
 	transition=$(_next_phase "$CURRENT_PHASE") || {
 		print_error "Unknown phase: $CURRENT_PHASE"
@@ -1972,6 +1973,52 @@ _full_loop_verify_merged_pr() {
 	return $?
 }
 
+_full_loop_resolve_remote_release_tag_commit() {
+	local repo="$1"
+	local tag_name="$2"
+	local ref_json=""
+	local object_type=""
+	local object_sha=""
+	local tag_json=""
+
+	[[ "$repo" == */* && "$tag_name" =~ $_FULL_LOOP_VERSION_TAG_REGEX ]] || return 1
+	ref_json=$(gh api "repos/${repo}/git/ref/tags/${tag_name}" 2>/dev/null) || return 1
+	object_type=$(jq -er 'select(.ref == ("refs/tags/" + $tag_name) and (.object.type == "commit" or .object.type == "tag")) | .object.type' \
+		--arg tag_name "$tag_name" <<<"$ref_json") || return 1
+	object_sha=$(jq -er '.object.sha' <<<"$ref_json") || return 1
+	[[ "$object_sha" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+	if [[ "$object_type" == "tag" ]]; then
+		tag_json=$(gh api "repos/${repo}/git/tags/${object_sha}" 2>/dev/null) || return 1
+		object_sha=$(jq -er '.object.type == "commit" | .object.sha' <<<"$tag_json") || return 1
+	fi
+	[[ "$object_sha" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+	printf '%s\n' "$object_sha"
+	return 0
+}
+
+_full_loop_verify_published_release() {
+	local repo="$1"
+	local tag_name="$2"
+	local merge_commit="$3"
+	local tag_commit=""
+	local release_json=""
+	local workflow_runs_json=""
+
+	[[ "$repo" == */* && "$tag_name" =~ $_FULL_LOOP_VERSION_TAG_REGEX && "$merge_commit" =~ $_FULL_LOOP_SHA40_REGEX ]] || return 1
+	tag_commit=$(_full_loop_resolve_remote_release_tag_commit "$repo" "$tag_name") || return 1
+	[[ "$tag_commit" == "$merge_commit" ]] || return 1
+	release_json=$(gh api "repos/${repo}/releases/tags/${tag_name}" 2>/dev/null) || return 1
+	jq -e --arg tag_name "$tag_name" '.tag_name == $tag_name and .draft == false' <<<"$release_json" >/dev/null || return 1
+	workflow_runs_json=$(gh api "repos/${repo}/actions/runs?event=release&status=success&per_page=100" 2>/dev/null) || return 1
+	jq -e --arg tag_name "$tag_name" --arg merge_commit "$merge_commit" --arg completed "$_FULL_LOOP_PHASE_COMPLETED" '
+		[.workflow_runs[]? | select(
+			.event == "release" and .status == $completed and .conclusion == "success"
+			and .head_branch == $tag_name and .head_sha == $merge_commit
+		)] | length > 0
+	' <<<"$workflow_runs_json" >/dev/null || return 1
+	return 0
+}
+
 cmd_record_no_release() {
 	local pr_number="${1:-}"
 	local repo_arg="${2:-}"
@@ -2017,6 +2064,63 @@ cmd_record_no_release() {
 		full_loop_update_cleanup_release_status "$repo" "$pr_number" "$_FULL_LOOP_RELEASE_NOT_REQUESTED" || return 1
 	fi
 	print_success "release:not-requested recorded for merged PR #${pr_number}"
+	return 0
+}
+
+cmd_record_published_release() {
+	local pr_number="${1:-}"
+	local tag_name="${2:-}"
+	local repo_arg="${3:-}"
+	local repo=""
+	local pr_json=""
+	local merge_commit=""
+	local receipt_path=""
+	local release_status=""
+	local status=0
+	if [[ $# -lt 2 || $# -gt 3 ]] || [[ ! "$pr_number" =~ ^[0-9]+$ ]] || [[ ! "$tag_name" =~ $_FULL_LOOP_VERSION_TAG_REGEX ]]; then
+		print_error "Usage: full-loop-helper.sh record-published-release <PR> <TAG> [REPO]"
+		return 1
+	fi
+	repo=$(_full_loop_resolve_repo "$repo_arg") || {
+		print_error "Cannot resolve repository for release evidence"
+		return 1
+	}
+	pr_json=$(_full_loop_read_fresh_merged_pr_json "$pr_number" "$repo") || {
+		print_error "Cannot record release:published: PR #${pr_number} lacks merged evidence"
+		return 1
+	}
+	merge_commit=$(jq -er '.mergeCommit.oid' <<<"$pr_json") || return 1
+	[[ "$merge_commit" =~ $_FULL_LOOP_SHA40_REGEX ]] || {
+		print_error "Cannot record release:published: PR #${pr_number} merge commit is invalid"
+		return 1
+	}
+	_full_loop_verify_published_release "$repo" "$tag_name" "$merge_commit" || {
+		print_error "Cannot record release:published: release, tag, and successful release workflow evidence do not match PR #${pr_number}"
+		return 1
+	}
+	_full_loop_acquire_transition_lock || return 1
+	receipt_path=$(_full_loop_release_receipt_path "$repo" "$pr_number") || status=1
+	if [[ "$status" -eq 0 && -f "$receipt_path" ]]; then
+		IFS= read -r release_status <"$receipt_path" || status=1
+	fi
+	if [[ "$status" -eq 0 ]]; then
+		case "$release_status" in
+		"" | "$_FULL_LOOP_PHASE_FAILED" | "$_FULL_LOOP_RELEASE_PUBLISHED") ;;
+		*)
+			print_error "Cannot replace terminal release:${release_status} evidence for PR #${pr_number}"
+			status=1
+			;;
+		esac
+	fi
+	if [[ "$status" -eq 0 ]]; then
+		_full_loop_write_release_receipt "$repo" "$pr_number" "$_FULL_LOOP_RELEASE_PUBLISHED" || status=1
+	fi
+	if [[ "$status" -eq 0 ]] && declare -F full_loop_update_cleanup_release_status >/dev/null 2>&1; then
+		full_loop_update_cleanup_release_status "$repo" "$pr_number" "$_FULL_LOOP_RELEASE_PUBLISHED" || status=1
+	fi
+	_full_loop_release_transition_lock
+	[[ "$status" -eq 0 ]] || return 1
+	print_success "release:published recorded for merged PR #${pr_number} (tag=${tag_name})"
 	return 0
 }
 

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -286,6 +286,8 @@ Commands:
                                  gh CLI level; if both are given, --admin wins and
                                   --auto is dropped (GH#19310).
   record-no-release <PR> [REPO]  Verify merged evidence and record release:not-requested.
+  record-published-release <PR> <TAG> [REPO]
+                                  Verify a GitHub release and record release:published.
   adopt-merged-receipt <PR> [REPO]
                                  Adopt an externally merged exact-head worktree into cleanup.
   finalize-receipt <PR> [REPO]   Finalize a direct-merge cleanup receipt without local state.
@@ -325,6 +327,7 @@ main() {
 	wait-checks) cmd_wait_checks "$@" ;;
 	merge) cmd_merge "$@" ;;
 	record-no-release) cmd_record_no_release "$@" ;;
+	record-published-release) cmd_record_published_release "$@" ;;
 	adopt-merged-receipt) cmd_adopt_merged_receipt "$@" ;;
 	finalize-receipt) cmd_finalize_receipt "$@" ;;
 	migrate-repository-receipt) cmd_migrate_repository_receipt "$@" ;;

--- a/.agents/scripts/tests/test-full-loop-completion-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-completion-evidence.sh
@@ -14,12 +14,45 @@ cleanup_receipt_dir="${ROOT}/cleanup-receipts"
 
 cat >"${ROOT}/bin/gh" <<'STUB'
 #!/usr/bin/env bash
+merge_sha="${COMPLETION_PR_MERGE_SHA:-1111111111111111111111111111111111111111}"
+release_mode="${COMPLETION_RELEASE_MODE:-valid}"
+if [[ "$*" == *"repos/marcusquinn/aidevops/git/ref/tags/v3.0.0"* ]]; then
+	if [[ "$release_mode" == "wrong-tag-commit" ]]; then
+		printf '%s\n' '{"ref":"refs/tags/v3.0.0","object":{"type":"commit","sha":"2222222222222222222222222222222222222222"}}'
+	else
+		jq -cn --arg sha "$merge_sha" '{ref:"refs/tags/v3.0.0",object:{type:"commit",sha:$sha}}'
+	fi
+	exit 0
+fi
+if [[ "$*" == *"repos/marcusquinn/aidevops/releases/tags/v3.0.0"* ]]; then
+	if [[ "$release_mode" == "draft-release" ]]; then
+		printf '%s\n' '{"tag_name":"v3.0.0","draft":true}'
+	else
+		printf '%s\n' '{"tag_name":"v3.0.0","draft":false}'
+	fi
+	exit 0
+fi
+if [[ "$*" == *"repos/marcusquinn/aidevops/actions/runs?event=release"* ]]; then
+	case "$release_mode" in
+	failed-workflow)
+		jq -cn --arg sha "$merge_sha" '{workflow_runs:[{event:"release",status:"completed",conclusion:"failure",head_branch:"v3.0.0",head_sha:$sha}]}'
+		;;
+	wrong-workflow-tag)
+		jq -cn --arg sha "$merge_sha" '{workflow_runs:[{event:"release",status:"completed",conclusion:"success",head_branch:"v3.0.1",head_sha:$sha}]}'
+		;;
+	*)
+		jq -cn --arg sha "$merge_sha" '{workflow_runs:[{event:"release",status:"completed",conclusion:"success",head_branch:"v3.0.0",head_sha:$sha}]}'
+		;;
+	esac
+	exit 0
+fi
 if [[ "$*" == *"state,mergedAt,mergeCommit,headRefName,headRefOid,headRepository,isCrossRepository"* ]]; then
 	jq -cn \
 		--arg head_ref "${COMPLETION_PR_HEAD_REF:-}" \
 		--arg head_oid "${COMPLETION_PR_HEAD_OID:-}" \
 		--arg head_repo "${COMPLETION_PR_HEAD_REPO:-}" \
-		'{state:"MERGED",mergedAt:"2026-07-11T00:00:00Z",mergeCommit:{oid:"merge123"},
+		--arg merge_sha "$merge_sha" \
+		'{state:"MERGED",mergedAt:"2026-07-11T00:00:00Z",mergeCommit:{oid:$merge_sha},
 		  headRefName:$head_ref,headRefOid:$head_oid,headRepository:{nameWithOwner:$head_repo},isCrossRepository:false}'
 	exit 0
 fi
@@ -43,7 +76,7 @@ if [[ "${COMPLETION_PR_STATE:-MERGED}" == "API_FAILURE" ]]; then
 	exit 70
 elif [[ "${COMPLETION_PR_STATE:-MERGED}" == "MERGED" ]] ||
 	[[ "${COMPLETION_PR_STATE:-MERGED}" == "STALE_THEN_MERGED" && "$call_count" -gt 1 ]]; then
-	printf '%s\n' '{"state":"MERGED","mergedAt":"2026-07-11T00:00:00Z","mergeCommit":{"oid":"merge123"}}'
+	jq -cn --arg merge_sha "$merge_sha" '{state:"MERGED",mergedAt:"2026-07-11T00:00:00Z",mergeCommit:{oid:$merge_sha}}'
 else
 	printf '%s\n' '{"state":"OPEN","mergedAt":null,"mergeCommit":null}'
 fi
@@ -119,6 +152,23 @@ cmd_record_no_release "\$@"
 RUNNER
 chmod +x "$record_runner"
 
+published_record_runner="${ROOT}/published-record-runner.sh"
+cat >"$published_record_runner" <<RUNNER
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR='${SCRIPTS_DIR}'
+STATE_DIR='${ROOT}/state'
+STATE_FILE='${ROOT}/state/full-loop.state'
+DEFAULT_MAX_TASK_ITERATIONS=50
+DEFAULT_MAX_PREFLIGHT_ITERATIONS=5
+DEFAULT_MAX_PR_ITERATIONS=20
+HEADLESS=false
+source '${SCRIPTS_DIR}/shared-constants.sh'
+source '${SCRIPTS_DIR}/full-loop-helper-state.sh'
+cmd_record_published_release "\$@"
+RUNNER
+chmod +x "$published_record_runner"
+
 finalize_runner="${ROOT}/finalize-runner.sh"
 cat >"$finalize_runner" <<RUNNER
 #!/usr/bin/env bash
@@ -158,6 +208,51 @@ AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" PATH="${ROOT}/bin:/opt/homebrew/bi
 grep -qx 'not-requested' "${receipt_dir}/marcusquinn_aidevops-42.status"
 AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$record_runner" 42 marcusquinn/aidevops >/dev/null
 printf 'PASS direct merge-only lifecycle records idempotent no-release evidence\n'
+
+published_worktree="${ROOT}/published-release-worktree"
+mkdir -p "$published_worktree"
+published_cleanup_receipt=$(full_loop_write_cleanup_deferred marcusquinn/aidevops 58 "$published_worktree" \
+	feature/published-release "$$" published-release-session pending FINALIZATION_PENDING)
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$published_record_runner" 58 v3.0.0 marcusquinn/aidevops >/dev/null
+grep -qx 'published' "${receipt_dir}/marcusquinn_aidevops-58.status"
+jq -e '.release_status == "published"' "$published_cleanup_receipt" >/dev/null
+cp "$published_cleanup_receipt" "${ROOT}/published-release-receipt-before.json"
+AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$published_record_runner" 58 v3.0.0 marcusquinn/aidevops >/dev/null
+cmp -s "$published_cleanup_receipt" "${ROOT}/published-release-receipt-before.json"
+printf 'PASS verified manual release records published evidence and reconciles cleanup idempotently\n'
+
+for invalid_release_mode in wrong-tag-commit draft-release failed-workflow wrong-workflow-tag; do
+	invalid_published_worktree="${ROOT}/invalid-published-${invalid_release_mode}"
+	invalid_published_pr=59
+	mkdir -p "$invalid_published_worktree"
+	invalid_published_cleanup_receipt=$(full_loop_write_cleanup_deferred marcusquinn/aidevops "$invalid_published_pr" \
+		"$invalid_published_worktree" feature/invalid-published "$$" invalid-published-session pending FINALIZATION_PENDING)
+	cp "$invalid_published_cleanup_receipt" "${ROOT}/invalid-published-${invalid_release_mode}-before.json"
+	if COMPLETION_RELEASE_MODE="$invalid_release_mode" AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" \
+		AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+		bash "$published_record_runner" "$invalid_published_pr" v3.0.0 marcusquinn/aidevops >/dev/null 2>&1; then
+		printf 'FAIL %s evidence recorded a published release\n' "$invalid_release_mode"
+		exit 1
+	fi
+	[[ ! -e "${receipt_dir}/marcusquinn_aidevops-${invalid_published_pr}.status" ]]
+	cmp -s "$invalid_published_cleanup_receipt" "${ROOT}/invalid-published-${invalid_release_mode}-before.json"
+	rm -f "$invalid_published_cleanup_receipt" "${ROOT}/invalid-published-${invalid_release_mode}-before.json"
+done
+printf 'PASS forged tags, draft releases, and non-successful release workflows leave receipts unchanged\n'
+
+printf '%s\n' not-requested >"${receipt_dir}/marcusquinn_aidevops-60.status"
+if AIDEVOPS_FULL_LOOP_RECEIPT_DIR="$receipt_dir" AIDEVOPS_FULL_LOOP_CLEANUP_DIR="$cleanup_receipt_dir" \
+	PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" \
+	bash "$published_record_runner" 60 v3.0.0 marcusquinn/aidevops >/dev/null 2>&1; then
+	printf 'FAIL conflicting terminal release receipt was replaced by published evidence\n'
+	exit 1
+fi
+grep -qx 'not-requested' "${receipt_dir}/marcusquinn_aidevops-60.status"
+printf 'PASS conflicting terminal receipts cannot be replaced by manual publication evidence\n'
 
 direct_worktree="${ROOT}/direct-merge-worktree"
 mkdir -p "$direct_worktree"


### PR DESCRIPTION
## Summary

Adds verified manual release receipt recording for non-aidevops repositories.

## Files Changed

.agents/scripts/full-loop-helper-state.sh, .agents/scripts/full-loop-helper.sh, .agents/scripts/tests/test-full-loop-completion-evidence.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — ShellCheck and full-loop completion, cleanup, and release reconciliation tests pass.

Resolves #29938


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.249 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 8m and 145,626 tokens on this as a headless worker.