### PR TITLE
GH#29941: fix(profile): recover publication worktree cleanup

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -138,17 +138,76 @@ _profile_publication_worktree_helper() {
 	return 0
 }
 
+_profile_publication_worktree_has_no_active_owner() {
+	local worktree_path="$1"
+	local owner_state=""
+
+	# Source the registry in a subprocess so its shared command helpers cannot
+	# alter this long-running publication helper's globals.
+	owner_state=$( (
+		# shellcheck source=shared-constants.sh
+		source "${SCRIPT_DIR}/shared-constants.sh" || exit 1
+		if is_worktree_owned_by_others "$worktree_path"; then
+			printf '%s\n' "owned"
+		else
+			printf '%s\n' "clear"
+		fi
+	) ) || return 1
+	[[ "$owner_state" == "clear" ]] || return 1
+	return 0
+}
+
+_profile_publication_worktree_recovery_is_safe() {
+	local worktree_path="$1"
+	local canonical_head=""
+	local canonical_status=""
+	local canonical_common_dir=""
+	local worktree_common_dir=""
+	local worktree_parent=""
+	local worktree_basename=""
+
+	[[ -n "$worktree_path" && "$worktree_path" == "${PROFILE_PUBLICATION_WORKTREE:-}" ]] || return 1
+	[[ -n "${PROFILE_PUBLICATION_CANONICAL_REPO:-}" && -n "${PROFILE_PUBLICATION_WORKTREE_BASE:-}" &&
+		-n "${PROFILE_PUBLICATION_CANONICAL_HEAD:-}" && -d "$worktree_path" ]] || return 1
+	worktree_parent=$(cd "${worktree_path%/*}" 2>/dev/null && pwd -P) || return 1
+	[[ "$worktree_parent" == "$PROFILE_PUBLICATION_WORKTREE_BASE" ]] || return 1
+	worktree_basename="${worktree_path##*/}"
+	[[ "$worktree_basename" == "$(basename "$PROFILE_PUBLICATION_CANONICAL_REPO")-profile-readme-"* ]] || return 1
+	git -C "$worktree_path" symbolic-ref -q HEAD >/dev/null 2>&1 && return 1
+	canonical_common_dir=$(git -C "$PROFILE_PUBLICATION_CANONICAL_REPO" rev-parse --git-common-dir 2>/dev/null) || return 1
+	worktree_common_dir=$(git -C "$worktree_path" rev-parse --git-common-dir 2>/dev/null) || return 1
+	case "$canonical_common_dir" in
+	/*) ;;
+	*) canonical_common_dir=$(cd "$PROFILE_PUBLICATION_CANONICAL_REPO/$canonical_common_dir" 2>/dev/null && pwd -P) || return 1 ;;
+	esac
+	case "$worktree_common_dir" in
+	/*) ;;
+	*) worktree_common_dir=$(cd "$worktree_path/$worktree_common_dir" 2>/dev/null && pwd -P) || return 1 ;;
+	esac
+	[[ "$canonical_common_dir" == "$worktree_common_dir" ]] || return 1
+	canonical_head=$(git -C "$PROFILE_PUBLICATION_CANONICAL_REPO" rev-parse HEAD 2>/dev/null) || return 1
+	[[ "$canonical_head" == "$PROFILE_PUBLICATION_CANONICAL_HEAD" ]] || return 1
+	canonical_status=$(git -C "$PROFILE_PUBLICATION_CANONICAL_REPO" status --porcelain --untracked-files=all) || return 1
+	[[ -z "$canonical_status" ]] || return 1
+	_profile_publication_worktree_has_no_active_owner "$worktree_path" || return 1
+	return 0
+}
+
 _archive_and_remove_profile_publication_worktree() {
 	local worktree_path="$1"
 	local archive_path=""
 	local caller="profile-readme-helper.sh"
-	local context="recovery_path=profile-publication-archive"
+	local context="recovery_path=profile-publication-archive profile_scratch=true"
 
+	_profile_publication_worktree_recovery_is_safe "$worktree_path" || return 1
 	archive_worktree_path_recoverably "$worktree_path" "$caller" "$context" || return 1
 	archive_path="$WORKTREE_RECOVERABLE_ARCHIVE_PATH"
 	[[ -n "$archive_path" ]] || return 1
+	# Recheck after copying so a changed canonical checkout or newly claimed
+	# worktree remains recoverable instead of being removed.
+	_profile_publication_worktree_recovery_is_safe "$worktree_path" || return 1
 	remove_archived_worktree_path "$worktree_path" "$archive_path" "$caller" \
-		"profile-publication" "$context" "true" "false" || return 1
+		"profile-publication" "$context" "true" "true" || return 1
 	log_worktree_removal_event "$_WTAR_REMOVED" "$caller" "$worktree_path" \
 		"profile-publication" "recoverable" "$context"
 	return 0
@@ -1767,6 +1826,8 @@ _profile_run_in_worktree() {
 	fi
 	PROFILE_PUBLICATION_WORKTREE="$worktree_path"
 	PROFILE_PUBLICATION_CANONICAL_REPO="$canonical_repo"
+	PROFILE_PUBLICATION_WORKTREE_BASE=$(cd "$worktree_base" 2>/dev/null && pwd -P) || return 1
+	PROFILE_PUBLICATION_CANONICAL_HEAD="$canonical_head_before"
 
 	local default_branch=""
 	default_branch=$(_profile_default_branch "$canonical_repo")

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -80,6 +80,9 @@ install_helper_with_libs() {
 	cp "${SOURCE_DATA_LIB}" "${helper_dir}/profile-readme-data-lib.sh"
 	cp "${SOURCE_RENDER_LIB}" "${helper_dir}/profile-readme-render-lib.sh"
 	cp "${SOURCE_HELPER%/*}/audit-worktree-removal-helper.sh" \
+		"${SOURCE_HELPER%/*}/shared-constants.sh" \
+		"${SOURCE_HELPER%/*}/shared-sqlite-backup.sh" \
+		"${SOURCE_HELPER%/*}/shared-worktree-registry.sh" \
 		"${SOURCE_HELPER%/*}/portable-stat.sh" \
 		"${SOURCE_HELPER%/*}/screen-time-interval-engine.py" \
 		"${SOURCE_HELPER%/*}/screen_time_interval_common.py" \
@@ -284,6 +287,55 @@ test_update_preserves_manual_sections() {
 	fi
 
 	print_result "${test_name}" 0
+	return 0
+}
+
+test_update_recovers_dirty_profile_publication_worktree() {
+	local test_name="profile update recoverably removes its dirty scratch worktree after guarded cleanup refusal"
+	TEST_DIR=$(mktemp -d)
+	local fixture_home="${TEST_DIR}/home"
+	local fixture_repo="${TEST_DIR}/profile-repo"
+	local fixture_remote="${TEST_DIR}/profile-remote.git"
+	local helper_dir="${TEST_DIR}/helper"
+	local helper_path="${helper_dir}/profile-readme-helper.sh"
+	local refusing_helper="${helper_dir}/refusing-worktree-helper.sh"
+	local recovery_root="${TEST_DIR}/recovery"
+	local output_file="${TEST_DIR}/update-output"
+
+	mkdir -p "$helper_dir" "$fixture_home"
+	install_helper_with_libs "$helper_dir"
+	write_stub_dependencies "$helper_dir"
+	create_profile_repo_fixture "$fixture_home" "$fixture_repo" "$fixture_remote"
+	cat >"$refusing_helper" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+target="${2:-}"
+[[ -n "$target" ]] || exit 1
+printf '%s\n' "recoverable fixture state" >"${target}/.profile-publication-fixture"
+exit 1
+EOF
+	chmod +x "$refusing_helper"
+
+	if ! HOME="$fixture_home" \
+		PATH="${SOURCE_HELPER%/*}:${PATH}" \
+		AIDEVOPS_REPOS_FILE="${fixture_home}/.config/aidevops/repos.json" \
+		AIDEVOPS_WORKTREE_BASE_DIR="${TEST_DIR}/worktrees" \
+		AIDEVOPS_WORKTREE_TRASH_ROOT="$recovery_root" \
+		AIDEVOPS_PROFILE_WORKTREE_HELPER="$refusing_helper" \
+		bash "$helper_path" update >"$output_file" 2>&1; then
+		print_helper_failure "$test_name" "helper update command failed" "$output_file"
+		return 0
+	fi
+
+	if [[ "$(git -C "$fixture_repo" worktree list --porcelain | grep -c '^worktree ' || true)" != "1" ]] ||
+		[[ ! -d "$recovery_root" ]] ||
+		[[ -n "$(git -C "$fixture_repo" status --porcelain --untracked-files=all)" ]]; then
+		print_helper_failure "$test_name" "scratch worktree leaked, recovery archive missing, or canonical checkout changed" "$output_file"
+		return 0
+	fi
+
+	print_result "$test_name" 0
 	return 0
 }
 
@@ -1309,6 +1361,8 @@ main() {
 
 	if [[ "$mode" != "--unit-only" ]]; then
 		test_update_preserves_manual_sections
+		teardown
+		test_update_recovers_dirty_profile_publication_worktree
 		teardown
 		test_update_dry_run_is_canonical_safe
 		teardown


### PR DESCRIPTION
## Summary

Recover helper-created detached profile publication scratch worktrees through an archive-first forced removal only after canonical identity, clean canonical state, detached membership, and registry-owner checks succeed.

## Files Changed

.agents/scripts/profile-readme-helper.sh, .agents/scripts/tests/test-profile-readme-boundary.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Passed: bash .agents/scripts/tests/test-profile-readme-boundary.sh (21/21); shellcheck .agents/scripts/profile-readme-helper.sh .agents/scripts/tests/test-profile-readme-boundary.sh. Baseline note: test-worktree-removal-audit.sh has seven terminal failures while every involved file matches origin/main.

Resolves #29941


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.249 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 10m and 137,617 tokens on this as a headless worker.