### PR TITLE
t18224: Fix symlinked OpenCode session recovery resolver

### DIFF
--- a/.agents/plugins/opencode-aidevops/session-recovery-marker.mjs
+++ b/.agents/plugins/opencode-aidevops/session-recovery-marker.mjs
@@ -274,7 +274,8 @@ function runCli(argv) {
 }
 
 const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
-if (invokedPath === fileURLToPath(import.meta.url)) {
+const modulePath = fileURLToPath(import.meta.url);
+if (invokedPath && realpathSync(invokedPath) === realpathSync(modulePath)) {
   try {
     process.exitCode = runCli(process.argv.slice(2));
   } catch (error) {

--- a/.agents/scripts/tests/test-session-recovery-marker.mjs
+++ b/.agents/scripts/tests/test-session-recovery-marker.mjs
@@ -6,6 +6,7 @@ import { chmodSync, mkdirSync, mkdtempSync, realpathSync, symlinkSync, writeFile
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
 import {
   createSessionRecoveryMarkerHandler,
@@ -46,6 +47,29 @@ assert.deepEqual(resolveSessionRecoveryMarker({ cwd: markerDirectory, workDir })
   markerDirectory: realpathSync(markerDirectory),
 });
 assert.equal(resolveSessionRecoveryMarker({ cwd: directory, workDir }), null);
+
+const resolverPath = fileURLToPath(
+  new URL("../../plugins/opencode-aidevops/session-recovery-marker.mjs", import.meta.url),
+);
+const linkedResolverPath = join(root, "session-recovery-marker.mjs");
+symlinkSync(resolverPath, linkedResolverPath);
+const resolvedCli = spawnSync(
+  process.execPath,
+  [linkedResolverPath, "resolve", "--cwd", markerDirectory, "--work-dir", workDir],
+  { encoding: "utf8" },
+);
+assert.equal(resolvedCli.status, 0, resolvedCli.stderr);
+assert.equal(
+  resolvedCli.stdout,
+  `${realpathSync(directory)}\t${realpathSync(dataDir)}\t${sessionID}\n`,
+  "resolver CLI should execute when invoked through the deployed agents symlink",
+);
+const missingCli = spawnSync(
+  process.execPath,
+  [linkedResolverPath, "resolve", "--cwd", directory, "--work-dir", workDir],
+  { encoding: "utf8" },
+);
+assert.equal(missingCli.status, 2, "resolver CLI should preserve the no-marker status through a symlink");
 
 const emitted = [];
 const handler = createSessionRecoveryMarkerHandler({

--- a/TODO.md
+++ b/TODO.md
@@ -1246,6 +1246,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18223 Self-heal stale Tabby recovery tokens #bug ref:GH#29922 pr:#29925
 
+- [ ] t18224 Fix symlinked OpenCode session recovery resolver #bug #framework ref:GH#29946
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Canonicalize the resolver entry path so the deployed agents activation symlink executes CLI recovery, with regression coverage for exact-session success and no-marker status.

## Files Changed

.agents/plugins/opencode-aidevops/session-recovery-marker.mjs, .agents/scripts/tests/test-session-recovery-marker.mjs, TODO.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Local linter suite passed; session recovery marker tests passed; all 27 OpenCode launcher tests passed; node syntax checks passed; patched resolver restored the current real marker to its exact project, isolated data directory, and session ID.

Resolves #29946


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.249 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 28m and 180,768 tokens on this with the user in an interactive session.