### PR TITLE
GH#29952: align pulse TODO-sync timeout with stage ceiling

### DIFF
--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -674,9 +674,9 @@ _pulse_todo_sync_parallelism() {
 
 _pulse_todo_sync_repo_timeout() {
 	local stage_timeout="${PRE_RUN_STAGE_TIMEOUT:-600}"
-	local repo_timeout="${PULSE_TODO_SYNC_REPO_TIMEOUT:-180}"
+	local repo_timeout="${PULSE_TODO_SYNC_REPO_TIMEOUT:-600}"
 	[[ "$stage_timeout" =~ ^[1-9][0-9]*$ ]] || stage_timeout=600
-	[[ "$repo_timeout" =~ ^[1-9][0-9]*$ ]] || repo_timeout=180
+	[[ "$repo_timeout" =~ ^[1-9][0-9]*$ ]] || repo_timeout=600
 	if [[ "$repo_timeout" -gt "$stage_timeout" ]]; then
 		repo_timeout="$stage_timeout"
 	fi

--- a/.agents/scripts/tests/test-pulse-todo-sync-parallel.sh
+++ b/.agents/scripts/tests/test-pulse-todo-sync-parallel.sh
@@ -115,6 +115,13 @@ export PULSE_TODO_SYNC_PARALLELISM=2
 export PULSE_TODO_SYNC_REPO_TIMEOUT=7
 export PRE_RUN_STAGE_TIMEOUT=30
 
+unset PULSE_TODO_SYNC_REPO_TIMEOUT
+[[ "$(_pulse_todo_sync_repo_timeout)" -eq 30 ]] || {
+	printf 'FAIL default per-repo timeout did not inherit the enclosing stage ceiling\n' >&2
+	exit 1
+}
+export PULSE_TODO_SYNC_REPO_TIMEOUT=7
+
 sync_rc=0
 sync_todo_refs_all_repos || sync_rc=$?
 call_count=$(wc -l <"$CALL_LOG" | tr -d ' ')


### PR DESCRIPTION
## Summary

- Let each repository TODO-sync job use the enclosing pulse-stage timeout by default instead of an independent 180-second ceiling.
- Preserve explicit `PULSE_TODO_SYNC_REPO_TIMEOUT` overrides and the existing stage-timeout cap.
- Add regression coverage proving the default inherits the enclosing stage ceiling.

## Evidence

- `sync_todo_refs_repo_1` and `_2` timed out after 181–183 seconds on every observed cycle.
- The affected jobs were still actively processing `issue-sync-helper.sh reopen` when terminated.

## Verification

- `bash .agents/scripts/tests/test-pulse-todo-sync-parallel.sh`
- `shellcheck .agents/scripts/pulse-wrapper-cycle.sh .agents/scripts/tests/test-pulse-todo-sync-parallel.sh`
- `.agents/scripts/linters-local.sh`

## Deployment verification

- Deploy with `./setup.sh --non-interactive` after merge.
- Confirm a subsequent cycle reports no timeout for `sync_todo_refs_repo_1` or `_2` via `pulse-diagnose-helper.sh cycle-health --window 1h`.

Resolves #29952

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.250 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 28m and 150,498 tokens on this with the user in an interactive session.