### PR TITLE
GH#29954: Allow read-only bundle verification

### DIFF
--- a/.agents/scripts/canonical_git_readonly.py
+++ b/.agents/scripts/canonical_git_readonly.py
@@ -80,8 +80,20 @@ def _clean_is_read_only(args: list[str]) -> bool:
     )
 
 
+def _bundle_is_read_only(args: list[str]) -> bool:
+    if not args or args[0] != "verify":
+        return False
+    bundle_args = args[1:]
+    if not bundle_args:
+        return False
+    allowed_flags = {"-q", "--quiet"}
+    paths = [arg for arg in bundle_args if arg not in allowed_flags]
+    return len(paths) == 1 and not paths[0].startswith("-")
+
+
 CANONICAL_CHECKS: dict[str, Callable[[list[str]], bool]] = {
     "branch": _branch_is_read_only,
+    "bundle": _bundle_is_read_only,
     "config": _config_is_read_only,
     "clean": _clean_is_read_only,
     **REF_QUERY_CHECKS,

--- a/.agents/scripts/tests/test-canonical-git-command-guard.sh
+++ b/.agents/scripts/tests/test-canonical-git-command-guard.sh
@@ -132,6 +132,8 @@ assert_blocked "blocks wrapped canonical switch" "env TEST=1 command git switch 
 assert_blocked "blocks nested absolute Git bypass" "bash -c '/usr/bin/git switch --detach main'"
 assert_blocked "blocks chained canonical mutation" "git status && git branch -M renamed"
 assert_blocked "blocks canonical update-ref plumbing" "/usr/bin/git update-ref refs/heads/main HEAD"
+assert_blocked "blocks canonical bundle creation" "git bundle create '$TEST_ROOT/commits.bundle' HEAD"
+assert_blocked "blocks canonical bundle unbundle" "git bundle unbundle '$TEST_ROOT/commits.bundle'"
 assert_blocked "blocks merge-tree writes in a canonical checkout" \
 	"git merge-tree --write-tree '$INITIAL_HEAD' '$INITIAL_HEAD'"
 assert_blocked "blocks destructive clean with exclude containing n" "git clean --force --exclude=nope"
@@ -197,6 +199,8 @@ assert_allowed "allows canonical symbolic-ref query" "$REPO" "git symbolic-ref r
 assert_allowed "allows canonical short symbolic-ref query" "$REPO" "git symbolic-ref --short refs/remotes/origin/HEAD"
 assert_allowed "allows reordered canonical symbolic-ref query flags" "$REPO" "git symbolic-ref refs/remotes/origin/HEAD --quiet --short"
 assert_allowed "allows canonical non-recursive symbolic-ref query" "$REPO" "git symbolic-ref --no-recurse refs/remotes/origin/HEAD"
+assert_allowed "allows canonical bundle verification" "$REPO" "git bundle verify '$TEST_ROOT/commits.bundle'"
+assert_allowed "allows quiet canonical bundle verification" "$REPO" "git bundle verify --quiet '$TEST_ROOT/commits.bundle'"
 assert_allowed "allows canonical worktree creation" "$REPO" "git worktree add '$LINKED' -b feature/example"
 
 PROSPECTIVE_CONTEXT=$(mktemp -d "${TEST_ROOT}/aidevops-prospective-todo.XXXXXX")


### PR DESCRIPTION
## Summary

- Allow the canonical Git guard to classify `git bundle verify <bundle>` as read-only.
- Keep mutating bundle operations such as `git bundle create` and `git bundle unbundle` blocked in canonical checkouts.
- Add guard regression coverage for allowed verification and blocked bundle mutations.

## Verification

```bash
.agents/scripts/tests/test-canonical-git-command-guard.sh
python3 -m py_compile .agents/scripts/canonical_git_readonly.py .agents/scripts/canonical_git_policy.py .agents/scripts/canonical-git-command-guard.py
shellcheck .agents/scripts/tests/test-canonical-git-command-guard.sh
```

Also checked the failing cleanup command shape from GH#29954:

```bash
python3 .agents/scripts/canonical-git-command-guard.py --cwd <canonical-repo> --command "git --git-dir=<canonical-repo>/.git bundle verify <archive>/commits.bundle"
python3 .agents/scripts/canonical-git-command-guard.py --cwd <canonical-repo> --command "git --git-dir=<canonical-repo>/.git bundle create <archive>/commits.bundle HEAD"
```

`bundle verify` is allowed; `bundle create` remains blocked.

Resolves #29954
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.250 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.5 spent 24m and 59,158 tokens on this with the user in an interactive session.