### PR TITLE
t18225: Stop recurring GitHub Actions failure notifications

### DIFF
--- a/.agents/hooks/task-id-collision-guard.sh
+++ b/.agents/hooks/task-id-collision-guard.sh
@@ -97,10 +97,10 @@ _read_counter_at_ref() {
 # Resolve the current task counter by taking the MAX across multiple known-good
 # sources. .task-counter is monotonically increasing so max == most current.
 #
-# This prevents stale-worktree false positives: when a worktree is created
-# before a subsequent claim-task-id.sh run bumps the counter on origin/main,
-# the merge-base holds a stale value. Reading from origin/main tip directly
-# returns the authoritative counter, regardless of merge-base age.
+# This prevents stale-worktree false positives: claims may advance either the
+# dedicated task-id-counter CAS branch or the default branch after a worktree
+# was created. Reading both remote tips returns the authoritative counter,
+# regardless of merge-base age or counter-branch rollout state.
 #
 # Returns the integer counter string (no newline), or empty string on failure.
 # ---------------------------------------------------------------------------
@@ -109,7 +109,8 @@ _resolve_current_counter() {
 	local val ref
 	# Priority sources, highest-freshness first. We take the MAX across all,
 	# not the first — .task-counter is monotonic so max == most current.
-	for ref in "origin/main" "origin/master" "main" "master" "HEAD"; do
+	for ref in "origin/task-id-counter" "task-id-counter" \
+		"origin/main" "origin/master" "main" "master" "HEAD"; do
 		if git rev-parse --verify "$ref" >/dev/null 2>&1; then
 			val=$(git show "${ref}:.task-counter" 2>/dev/null | tr -d '[:space:]')
 			if [[ "$val" =~ ^[0-9]+$ ]]; then

--- a/.agents/plugins/opencode-aidevops/tests/test-quickfile-mcp-registry.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-quickfile-mcp-registry.mjs
@@ -3,11 +3,30 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
 import { registerMcpServers } from "../mcp-registry.mjs";
 
-test("QuickFile MCP uses the least-privilege secret launcher", () => {
+test("QuickFile MCP uses the least-privilege secret launcher", (t) => {
+  const binDir = mkdtempSync(join(tmpdir(), "aidevops-quickfile-registry-"));
+  const originalPath = process.env.PATH;
+  const executable = join(
+    binDir,
+    process.platform === "win32" ? "aidevops.CMD" : "aidevops",
+  );
+  writeFileSync(
+    executable,
+    process.platform === "win32" ? "@exit /b 0\r\n" : "#!/bin/sh\nexit 0\n",
+    { mode: 0o755 },
+  );
+  process.env.PATH = `${binDir}${delimiter}${originalPath || ""}`;
+  t.after(() => {
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+    rmSync(binDir, { recursive: true, force: true });
+  });
+
   const config = { mcp: {}, tools: {} };
   registerMcpServers(config);
 

--- a/.agents/scripts/issue-sync-git-push-helper.sh
+++ b/.agents/scripts/issue-sync-git-push-helper.sh
@@ -9,6 +9,27 @@ set -euo pipefail
 ISSUE_SYNC_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 # shellcheck source=./planning-publisher.sh
 source "${ISSUE_SYNC_SCRIPT_DIR}/planning-publisher.sh"
+
+# Public-write wrappers require a valid local private-entity registry. Hosted
+# GitHub Actions jobs intentionally have no user repos.json, so give this
+# narrowly generated issue-sync publication an explicit empty registry while
+# retaining the wrapper's target-privacy, local-path, and secret scans.
+issue_sync_prepare_ci_privacy_inventory() {
+	local default_config="${HOME}/.config/aidevops/repos.json"
+	local temp_root=""
+	local inventory=""
+	[[ "${GITHUB_ACTIONS:-}" == "true" ]] || return 0
+	[[ -n "${PRIVACY_REPOS_CONFIG:-}" || -f "$default_config" ]] && return 0
+	temp_root="${RUNNER_TEMP:-${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}}"
+	mkdir -p "$temp_root" || return 1
+	inventory=$(mktemp "${temp_root%/}/aidevops-issue-sync-public-repos.XXXXXX") || return 1
+	printf '%s\n' '{"initialized_repos":[]}' >"$inventory" || return 1
+	export PRIVACY_REPOS_CONFIG="$inventory"
+	printf '%s\n' '::notice::Issue Sync is using an empty ephemeral private-entity registry for this isolated CI job.'
+	return 0
+}
+
+issue_sync_prepare_ci_privacy_inventory
 # shellcheck source=./shared-gh-wrappers.sh
 source "${ISSUE_SYNC_SCRIPT_DIR}/shared-gh-wrappers.sh"
 # shellcheck source=./issue-sync-lib-parse.sh

--- a/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
+++ b/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
@@ -134,6 +134,15 @@ if [[ "${1:-}" == "label" ]]; then
 	exit 0
 fi
 
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/example/repo" ]]; then
+	printf 'false\n'
+	exit 0
+fi
+
 if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
 	if [[ -f "${GH_STUB_PR_MARKER:?}" ]]; then
 		printf 'https://github.com/example/repo/pull/1\n'
@@ -308,9 +317,14 @@ run_issue_sync_helper() {
 	local fallback_token="${10:-}"
 	local reject_pr_token="${11:-}"
 	local trusted_git="${12:-}"
+	local ci_home="${output_file}.home"
+	local runner_temp="${output_file}.runner"
+	mkdir -p "$ci_home" "$runner_temp"
 	(
 		cd "$work_dir" || exit 1
 		PATH="${fake_bin}:$PATH" \
+			HOME="$ci_home" \
+			RUNNER_TEMP="$runner_temp" \
 			GITHUB_ACTIONS=true \
 			GITHUB_REPOSITORY="example/repo" \
 			GH_TOKEN="$primary_token" \
@@ -407,6 +421,8 @@ test_protected_branch_uses_one_rebased_pr() {
 		fail "issue-sync PR title preserves merge-loop prevention"
 	elif [[ "$(<"${title_file}.body")" != *"Ref #9001"* ]]; then
 		fail "issue-sync PR body preserves changed-task linkage"
+	elif [[ "$(<"$output_a")" != *"empty ephemeral private-entity registry"* ]]; then
+		fail "GitHub Actions publication declares its isolated privacy inventory"
 	elif [[ "$branch_message" == *"[skip ci]"* ]]; then
 		fail "issue-sync PR branch still runs required checks"
 	elif [[ "$(git -C "$work_a" status --short)" != *"TODO.md"* ||

--- a/.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh
+++ b/.agents/scripts/tests/test-maintainer-gate-trusted-origin-exemption.sh
@@ -171,6 +171,8 @@ else
 fi
 assert_contains "rerun_maintainer_gate_with_retry" \
 	"Job 3 defines bounded rerun scheduling"
+assert_contains "confirm_maintainer_gate_rerun_started" \
+	"Job 3 reconciles asynchronously accepted reruns"
 assert_contains "per_page=100" \
 	"Job 3 queries multiple exact-head workflow runs"
 assert_contains 'select\(\.status == "completed" and \(\.conclusion != null\)\)' \
@@ -240,8 +242,8 @@ gh() {
 		failure) return 1 ;;
 		missing) printf '{"completed":null,"active":null}\n' ;;
 		active) printf '{"completed":null,"active":{"id":502,"status":"in_progress"}}\n' ;;
-		active-and-completed) printf '{"completed":{"id":501,"status":"completed","conclusion":"success"},"active":{"id":502,"status":"in_progress"}}\n' ;;
-		*) printf '{"completed":{"id":501,"status":"completed","conclusion":"success"},"active":null}\n' ;;
+		active-and-completed) printf '{"completed":{"id":501,"status":"completed","conclusion":"success","run_attempt":1},"active":{"id":502,"status":"in_progress"}}\n' ;;
+		*) printf '{"completed":{"id":501,"status":"completed","conclusion":"success","run_attempt":1},"active":null}\n' ;;
 		esac
 		return 0
 	fi
@@ -254,6 +256,14 @@ gh() {
 			return 0
 		fi
 		return 1
+	fi
+	if [[ "$command" == "api" && "$subcommand" == "repos/owner/repo/actions/runs/501" ]]; then
+		if [[ "$FIXTURE_LOOKUP_MODE" == "delayed-rerun" ]]; then
+			printf '%s\n' '{"status":"queued","run_attempt":2}'
+		else
+			printf '%s\n' '{"status":"completed","run_attempt":1}'
+		fi
+		return 0
 	fi
 	return 1
 }
@@ -316,6 +326,7 @@ else
 	run_job3_fixture "accepted rerun" "NONE" '[]' "" 0 "found" 0 "pending" 1
 	run_job3_fixture "completed run selected behind active run" "NONE" '[]' "" 0 "active-and-completed" 0 "pending" 1
 	run_job3_fixture "transient rerun rejection retries" "NONE" '[]' "" 2 "found" 0 "pending" 3
+	run_job3_fixture "delayed rerun acceptance is reconciled" "NONE" '[]' "" 3 "delayed-rerun" 0 "pending" 3
 	run_job3_fixture "exhausted rerun becomes terminal" "NONE" '[]' "" 3 "found" 1 "error,pending" 3
 	run_job3_fixture "active run remains status owner" "NONE" '[]' "" 0 "active" 0 "" 0
 	run_job3_fixture "missing run becomes terminal without pending" "NONE" '[]' "" 0 "missing" 1 "error" 0

--- a/.agents/scripts/tests/test-task-id-collision-guard.sh
+++ b/.agents/scripts/tests/test-task-id-collision-guard.sh
@@ -26,6 +26,7 @@
 #  19. Allow: cached branch-subject range claim is read even when it is the final line (GH#22558)
 #  22. Allow: push squash commit uses its associated PR body as linked-issue proof (GH#29591)
 #  23. Reject: push commit above the counter without associated issue proof (GH#29591)
+#  24. Allow: check-pr sees claims stored on the dedicated task-id-counter branch
 
 set -u
 
@@ -39,6 +40,7 @@ ERRORS=""
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GUARD="${SCRIPT_DIR}/../../hooks/task-id-collision-guard.sh"
+WORKFLOW="${SCRIPT_DIR}/../../../.github/workflows/task-id-collision-check.yml"
 DEPLOYED_GUARD="$HOME/.aidevops/agents/hooks/task-id-collision-guard.sh"
 
 # Prefer deployed if repo copy not found
@@ -1119,6 +1121,73 @@ GHEOF
 }
 
 # ---------------------------------------------------------------------------
+# Case 24: Allow — the dedicated CAS counter branch is authoritative in CI.
+# The default branch can lag while claim-task-id.sh has already committed both
+# the higher counter and claim proof to origin/task-id-counter.
+# ---------------------------------------------------------------------------
+test_check_pr_uses_dedicated_counter_branch() {
+	local name="case-24: check-pr accepts a claim from origin/task-id-counter"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	local base_repo="${tmpdir}/base"
+	mkdir -p "$base_repo"
+	git -C "$base_repo" init -q -b main
+	git -C "$base_repo" config user.email "test@test.local"
+	git -C "$base_repo" config user.name "Test"
+	git -C "$base_repo" config commit.gpgsign false
+	git -C "$base_repo" config tag.gpgsign false
+	printf '100' >"${base_repo}/.task-counter"
+	git -C "$base_repo" add .task-counter
+	git -C "$base_repo" commit -q -m "init: main counter=100"
+
+	git -C "$base_repo" checkout -q -b task-id-counter
+	printf '102' >"${base_repo}/.task-counter"
+	git -C "$base_repo" add .task-counter
+	git -C "$base_repo" commit -q -m "chore: claim t101 [test-nonce]"
+	git -C "$base_repo" checkout -q main
+
+	local work_repo="${tmpdir}/work"
+	git clone -q --single-branch --branch main "$base_repo" "$work_repo" 2>/dev/null
+	git -C "$work_repo" config user.email "test@test.local"
+	git -C "$work_repo" config user.name "Test"
+	git -C "$work_repo" config commit.gpgsign false
+	git -C "$work_repo" config tag.gpgsign false
+	git -C "$work_repo" fetch -q origin \
+		'+refs/heads/task-id-counter:refs/remotes/origin/task-id-counter'
+	git -C "$work_repo" checkout -q -b feature/test-counter-claim
+	printf 'feature' >"${work_repo}/feature.txt"
+	git -C "$work_repo" add feature.txt
+	git -C "$work_repo" commit -q -m "t101: implement claimed task"
+
+	local fake_bin="${tmpdir}/bin"
+	mkdir -p "$fake_bin"
+	printf '#!/usr/bin/env bash\nexit 1\n' >"${fake_bin}/gh"
+	chmod +x "${fake_bin}/gh"
+
+	local rc=0
+	(
+		cd "$work_repo" || exit 1
+		PATH="${fake_bin}:$PATH" bash "$GUARD" check-pr 9999 2>/dev/null
+	) || rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exit 0 (dedicated counter claim is authoritative), got $rc"
+	fi
+
+	name="case-24: CI fetches the dedicated counter branch"
+	if grep -Fq '+refs/heads/task-id-counter:refs/remotes/origin/task-id-counter' "$WORKFLOW"; then
+		pass "$name"
+	else
+		fail "$name" "task-id collision workflow does not fetch task-id-counter"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 main() {
@@ -1146,6 +1215,7 @@ main() {
 	test_check_pr_allows_canonical_task_brief_path
 	test_check_pr_rejects_malformed_task_brief_path
 	test_check_push_associated_pr_issue_proof
+	test_check_pr_uses_dedicated_counter_branch
 
 	printf '\n'
 	printf 'Results: %s passed, %s failed\n' "$PASS" "$FAIL"

--- a/.github/workflows/maintainer-gate-reusable.yml
+++ b/.github/workflows/maintainer-gate-reusable.yml
@@ -773,6 +773,32 @@ jobs:
             return 1
           }
 
+          confirm_maintainer_gate_rerun_started() {
+            local run_id="$1"
+            local prior_attempt="$2"
+            local pr_number="$3"
+            local run_state=""
+            local current_attempt=""
+            local current_status=""
+
+            # GitHub can accept a rerun asynchronously after the POST client
+            # has already reported a transient rejection. Reconcile once after
+            # the bounded retries before publishing a false terminal failure.
+            sleep 5
+            run_state=$(gh api "repos/${REPO}/actions/runs/${run_id}" \
+              --jq '{status: .status, run_attempt: .run_attempt}' \
+              2>/dev/null) || return 1
+            current_attempt=$(printf '%s' "$run_state" | jq -r '.run_attempt // empty' 2>/dev/null || true)
+            current_status=$(printf '%s' "$run_state" | jq -r '.status // empty' 2>/dev/null || true)
+            if [[ "$current_attempt" =~ ^[0-9]+$ ]] &&
+               [[ "$prior_attempt" =~ ^[0-9]+$ ]] &&
+               [[ "$current_attempt" -gt "$prior_attempt" ]]; then
+              echo "Job 1 rerun observed asynchronously for PR #$pr_number (attempt $current_attempt, status ${current_status:-unknown})"
+              return 0
+            fi
+            return 1
+          }
+
           mark_rerun_scheduling_failure() {
             local pr_number="$1"
             local description="$2"
@@ -987,7 +1013,7 @@ jobs:
             if ! RUN_LOOKUP=$(gh api \
               "repos/${REPO}/actions/workflows/maintainer-gate.yml/runs?head_sha=${HEAD_SHA}&event=pull_request_target&per_page=100" \
               --jq '{
-                completed: ([.workflow_runs[] | select(.status == "completed" and (.conclusion != null)) | {id, status, conclusion}][0] // null),
+                completed: ([.workflow_runs[] | select(.status == "completed" and (.conclusion != null)) | {id, status, conclusion, run_attempt}][0] // null),
                 active: ([.workflow_runs[] | select(.status != "completed") | {id, status}][0] // null)
               }' \
               2>/dev/null); then
@@ -1026,9 +1052,12 @@ jobs:
             fi
 
             RUN_CONCLUSION=$(printf '%s' "$RUN_LOOKUP" | jq -r '.completed.conclusion // empty')
-            echo "Triggering Job 1 rerun (run_id=$RUN_ID, prior=$RUN_CONCLUSION) for PR #$PR_NUM"
+            RUN_ATTEMPT=$(printf '%s' "$RUN_LOOKUP" | jq -r '.completed.run_attempt // 0')
+            echo "Triggering Job 1 rerun (run_id=$RUN_ID, prior=$RUN_CONCLUSION, attempt=$RUN_ATTEMPT) for PR #$PR_NUM"
             if ! rerun_maintainer_gate_with_retry "$RUN_ID" "$PR_NUM"; then
-              mark_rerun_scheduling_failure "$PR_NUM" "Maintainer-gate refresh scheduling failed after bounded retries"
+              if ! confirm_maintainer_gate_rerun_started "$RUN_ID" "$RUN_ATTEMPT" "$PR_NUM"; then
+                mark_rerun_scheduling_failure "$PR_NUM" "Maintainer-gate refresh scheduling failed after bounded retries"
+              fi
             fi
           done
 

--- a/.github/workflows/task-id-collision-check.yml
+++ b/.github/workflows/task-id-collision-check.yml
@@ -48,10 +48,11 @@ jobs:
         with:
           fetch-depth: 0  # Full history needed for merge-base detection
 
-      - name: Fetch main branch for merge-base comparison
+      - name: Fetch comparison and task counter branches
         run: |
           git fetch origin main --depth=100 2>/dev/null || true
           git fetch origin develop --depth=100 2>/dev/null || true
+          git fetch origin '+refs/heads/task-id-counter:refs/remotes/origin/task-id-counter' --depth=100 2>/dev/null || true
 
       - name: Run task-id collision check
         env:

--- a/TODO.md
+++ b/TODO.md
@@ -1248,7 +1248,7 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18224 Fix symlinked OpenCode session recovery resolver #bug #framework ref:GH#29946
 
-- [ ] t18225 Stop environment-dependent GitHub Actions failures #bug #ci #priority:high ref:GH#29956
+- [ ] t18225 Stop recurring GitHub Actions failure notifications #bug #ci #priority:high ref:GH#29956
 
 ## In Progress
 

--- a/TODO.md
+++ b/TODO.md
@@ -1248,6 +1248,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18224 Fix symlinked OpenCode session recovery resolver #bug #framework ref:GH#29946
 
+- [ ] t18225 Stop environment-dependent GitHub Actions failures #bug #ci #priority:high ref:GH#29956
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary
- make the QuickFile registry test deterministic when `aidevops` is absent from the runner PATH without weakening the production `requiresBinary` guard
- provide Issue Sync with an explicit empty CI-only privacy inventory while retaining public-target, local-path, and secret scans
- reconcile delayed Maintainer Gate rerun acceptance before publishing a false terminal failure
- read task claims from the dedicated counter branch so CI does not reject valid IDs against stale `main`

## Verification
- `PATH=/opt/homebrew/bin:/usr/bin:/bin node --test .agents/plugins/opencode-aidevops/tests/test-quickfile-mcp-registry.mjs`
- `bash .agents/scripts/tests/test-issue-sync-git-push-helper.sh`
- public privacy guard suites: 15/15 and 6/6
- maintainer gate suites: 47/47, 5/5, 13/13, and 36/36
- `.agents/scripts/linters-local.sh --changed`
- task-ID collision suite: 25/25; live `check-pr 29958` validation passed with counter `18226`

Resolves #29956

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.250 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 24m and 571,268 tokens on this with the user in an interactive session.
