### PR TITLE
GH#29954: Allow guarded linked worktree removal

### DIFF
--- a/.agents/scripts/canonical_git_policy.py
+++ b/.agents/scripts/canonical_git_policy.py
@@ -210,17 +210,29 @@ def _is_linked_worktree_remove_for_canonical(
         target_common_dir, target_git_dir, target_top = _git_repo_identity(
             real_git_path, target_real, []
         )
-        allowed = bool(
+        required_paths = [
+            canonical_common_dir,
+            canonical_top,
+            target_common_dir,
+            target_git_dir,
+            target_top,
+        ]
+        same_common_dir = os.path.realpath(target_common_dir) == os.path.realpath(
             canonical_common_dir
-            and canonical_top
-            and target_common_dir
-            and target_git_dir
-            and target_top
-            and os.path.realpath(target_common_dir)
-            == os.path.realpath(canonical_common_dir)
-            and os.path.realpath(target_git_dir) != os.path.realpath(target_common_dir)
-            and os.path.realpath(target_top) == target_real
-            and target_real != os.path.realpath(canonical_top)
+        )
+        separate_git_dir = os.path.realpath(target_git_dir) != os.path.realpath(
+            target_common_dir
+        )
+        target_is_toplevel = os.path.realpath(target_top) == target_real
+        target_is_not_canonical = target_real != os.path.realpath(canonical_top)
+        allowed = all(
+            [
+                all(required_paths),
+                same_common_dir,
+                separate_git_dir,
+                target_is_toplevel,
+                target_is_not_canonical,
+            ]
         )
     return allowed
 

--- a/.agents/scripts/canonical_git_policy.py
+++ b/.agents/scripts/canonical_git_policy.py
@@ -134,6 +134,61 @@ def _is_isolated_routines_publisher(
     )
 
 
+def _worktree_remove_target(args: list[str]) -> str:
+    """Return the single remove target when args are in the safe subset."""
+    target = ""
+    invalid = not args or args[0] != "remove"
+    option_terminator = False
+    for arg in ([] if invalid else args[1:]):
+        if option_terminator:
+            if target:
+                invalid = True
+            else:
+                target = arg
+        elif arg == "--":
+            option_terminator = True
+        elif arg in {"-f", "--force"}:
+            continue
+        elif arg.startswith("-"):
+            invalid = True
+        elif target:
+            invalid = True
+        else:
+            target = arg
+    return "" if invalid else target
+
+
+def _git_repo_identity(
+    real_git_path: str, cwd: str, prefix: list[str]
+) -> tuple[str, str, str]:
+    """Return common dir, git dir, and top-level for a Git target."""
+    common_dir = _git_output(
+        real_git_path,
+        cwd,
+        *prefix,
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-common-dir",
+    )
+    git_dir = _git_output(
+        real_git_path,
+        cwd,
+        *prefix,
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-dir",
+    )
+    top = _git_output(
+        real_git_path,
+        cwd,
+        *prefix,
+        "rev-parse",
+        "--path-format=absolute",
+        "--show-toplevel",
+    )
+    return common_dir, git_dir, top
+
+
 def _is_linked_worktree_remove_for_canonical(
     real_git_path: str,
     effective_cwd: str,
@@ -141,81 +196,33 @@ def _is_linked_worktree_remove_for_canonical(
     args: list[str],
 ) -> bool:
     """Allow removing only linked worktrees that belong to this canonical repo."""
-    if not args or args[0] != "remove":
-        return False
+    target = _worktree_remove_target(args)
+    allowed = False
 
-    target = ""
-    option_terminator = False
-    for arg in args[1:]:
-        if option_terminator:
-            if target:
-                return False
-            target = arg
-        elif arg == "--":
-            option_terminator = True
-        elif arg in {"-f", "--force"}:
-            continue
-        elif arg.startswith("-"):
-            return False
-        elif target:
-            return False
-        else:
-            target = arg
-    if not target:
-        return False
-
-    canonical_common_dir = _git_output(
-        real_git_path,
-        effective_cwd,
-        *prefix,
-        "rev-parse",
-        "--path-format=absolute",
-        "--git-common-dir",
-    )
-    canonical_top = _git_output(
-        real_git_path,
-        effective_cwd,
-        *prefix,
-        "rev-parse",
-        "--path-format=absolute",
-        "--show-toplevel",
-    )
-    if not canonical_common_dir or not canonical_top:
-        return False
-
-    target_path = Path(target).expanduser()
-    if not target_path.is_absolute():
-        target_path = Path(effective_cwd) / target_path
-    target_real = os.path.realpath(target_path)
-    target_common_dir = _git_output(
-        real_git_path,
-        target_real,
-        "rev-parse",
-        "--path-format=absolute",
-        "--git-common-dir",
-    )
-    target_git_dir = _git_output(
-        real_git_path,
-        target_real,
-        "rev-parse",
-        "--path-format=absolute",
-        "--git-dir",
-    )
-    target_top = _git_output(
-        real_git_path,
-        target_real,
-        "rev-parse",
-        "--path-format=absolute",
-        "--show-toplevel",
-    )
-    if not target_common_dir or not target_git_dir or not target_top:
-        return False
-    return bool(
-        os.path.realpath(target_common_dir) == os.path.realpath(canonical_common_dir)
-        and os.path.realpath(target_git_dir) != os.path.realpath(target_common_dir)
-        and os.path.realpath(target_top) == target_real
-        and target_real != os.path.realpath(canonical_top)
-    )
+    if target:
+        canonical_common_dir, _canonical_git_dir, canonical_top = _git_repo_identity(
+            real_git_path, effective_cwd, prefix
+        )
+        target_path = Path(target).expanduser()
+        if not target_path.is_absolute():
+            target_path = Path(effective_cwd) / target_path
+        target_real = os.path.realpath(target_path)
+        target_common_dir, target_git_dir, target_top = _git_repo_identity(
+            real_git_path, target_real, []
+        )
+        allowed = bool(
+            canonical_common_dir
+            and canonical_top
+            and target_common_dir
+            and target_git_dir
+            and target_top
+            and os.path.realpath(target_common_dir)
+            == os.path.realpath(canonical_common_dir)
+            and os.path.realpath(target_git_dir) != os.path.realpath(target_common_dir)
+            and os.path.realpath(target_top) == target_real
+            and target_real != os.path.realpath(canonical_top)
+        )
+    return allowed
 
 
 def classify_git_argv(

--- a/.agents/scripts/canonical_git_policy.py
+++ b/.agents/scripts/canonical_git_policy.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import os
 import re
 import tempfile
+from pathlib import Path
 
 from canonical_git_invocation import repository_values, split_invocation
 from canonical_git_readonly import CANONICAL_CHECKS
@@ -133,6 +134,90 @@ def _is_isolated_routines_publisher(
     )
 
 
+def _is_linked_worktree_remove_for_canonical(
+    real_git_path: str,
+    effective_cwd: str,
+    prefix: list[str],
+    args: list[str],
+) -> bool:
+    """Allow removing only linked worktrees that belong to this canonical repo."""
+    if not args or args[0] != "remove":
+        return False
+
+    target = ""
+    option_terminator = False
+    for arg in args[1:]:
+        if option_terminator:
+            if target:
+                return False
+            target = arg
+        elif arg == "--":
+            option_terminator = True
+        elif arg in {"-f", "--force"}:
+            continue
+        elif arg.startswith("-"):
+            return False
+        elif target:
+            return False
+        else:
+            target = arg
+    if not target:
+        return False
+
+    canonical_common_dir = _git_output(
+        real_git_path,
+        effective_cwd,
+        *prefix,
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-common-dir",
+    )
+    canonical_top = _git_output(
+        real_git_path,
+        effective_cwd,
+        *prefix,
+        "rev-parse",
+        "--path-format=absolute",
+        "--show-toplevel",
+    )
+    if not canonical_common_dir or not canonical_top:
+        return False
+
+    target_path = Path(target).expanduser()
+    if not target_path.is_absolute():
+        target_path = Path(effective_cwd) / target_path
+    target_real = os.path.realpath(target_path)
+    target_common_dir = _git_output(
+        real_git_path,
+        target_real,
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-common-dir",
+    )
+    target_git_dir = _git_output(
+        real_git_path,
+        target_real,
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-dir",
+    )
+    target_top = _git_output(
+        real_git_path,
+        target_real,
+        "rev-parse",
+        "--path-format=absolute",
+        "--show-toplevel",
+    )
+    if not target_common_dir or not target_git_dir or not target_top:
+        return False
+    return bool(
+        os.path.realpath(target_common_dir) == os.path.realpath(canonical_common_dir)
+        and os.path.realpath(target_git_dir) != os.path.realpath(target_common_dir)
+        and os.path.realpath(target_top) == target_real
+        and target_real != os.path.realpath(canonical_top)
+    )
+
+
 def classify_git_argv(
     argv: list[str], cwd: str, real_git_path: str, check_unresolved: bool = False
 ) -> tuple[bool, str]:
@@ -161,6 +246,10 @@ def classify_git_argv(
             real_git_path, effective_cwd, prefix, subcommand
         ):
             result = True, "isolated routines publisher mutation"
+        elif subcommand == "worktree" and _is_linked_worktree_remove_for_canonical(
+            real_git_path, effective_cwd, prefix, args
+        ):
+            result = True, "linked-worktree removal for canonical repository"
         elif _is_allowed_canonical(subcommand, args):
             result = True, "read-only canonical operation or linked-worktree creation"
         else:

--- a/.agents/scripts/tests/test-canonical-git-command-guard.sh
+++ b/.agents/scripts/tests/test-canonical-git-command-guard.sh
@@ -212,6 +212,10 @@ assert_allowed "allows unrelated writes in an unmanaged isolated bare temp repo"
 	"$REPO" "git -C '$PROSPECTIVE_REPO' update-ref refs/heads/main '$INITIAL_HEAD'"
 
 git -C "$REPO" worktree add -q -b feature/example "$LINKED"
+assert_allowed "allows canonical linked worktree removal" "$REPO" "git worktree remove --force '$LINKED'"
+assert_allowed "allows canonical linked worktree removal with option terminator" "$REPO" "git worktree remove -f -- '$LINKED'"
+assert_blocked "blocks canonical worktree removal of canonical root" "git worktree remove --force '$REPO'"
+assert_blocked "blocks canonical worktree removal with unsupported options" "git worktree remove --force --expire now '$LINKED'"
 assert_allowed "allows normal Git mutation in linked worktree" "$LINKED" "git switch -c feature/linked-child"
 assert_allowed "allows rev-list query in linked worktree" "$LINKED" "git rev-list --count HEAD"
 LINKED_GIT_DIR=$(git -C "$LINKED" rev-parse --path-format=absolute --git-dir)


### PR DESCRIPTION
## Summary

- allow `git worktree remove` from a canonical checkout only when the target resolves to a linked worktree for the same canonical repository
- keep canonical-root removal and unsupported worktree-remove options blocked
- add regression coverage for the cleanup path exposed after #29957

For #29954.

## Evidence

- Post-#29957 cleanup log shows compact archive verification succeeds, e.g. `<recovery-archive>/commits.bundle is okay` and `Compact recovery archive verified`
- The next failure is `compact-archive-delete-failed`, matching `.agents/scripts/pulse-cleanup-worktree-removal.sh` calling `git -C "$rp_age" worktree remove --force "$wt_path_age"`
- The affected private application worktree count remained above the cleanup cap after the fixed verification run

## Verification

- `.agents/scripts/tests/test-canonical-git-command-guard.sh`
- `python3 -m py_compile .agents/scripts/canonical_git_policy.py .agents/scripts/canonical_git_readonly.py .agents/scripts/canonical-git-command-guard.py`
- `shellcheck .agents/scripts/tests/test-canonical-git-command-guard.sh`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.250 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.5 spent 1h 12m and 59,158 tokens on this with the user in an interactive session.