### PR TITLE
GH#29959: fetch exact release tag during canonical updates

### DIFF
--- a/.agents/scripts/canonical-recovery-helper.sh
+++ b/.agents/scripts/canonical-recovery-helper.sh
@@ -526,6 +526,30 @@ restore_quarantined_rebase_state() {
 	return 0
 }
 
+# Fetch only the release tag required by the post-update source-access stage.
+# The caller has already pinned and validated the canonical remote. Existing
+# refs are never rewritten; source-access owns signature and ancestry checks.
+fetch_aidevops_release_tag() {
+	local repo="$1"
+	local remote="$2"
+	local version=""
+	local tag_ref=""
+
+	[[ -r "$repo/VERSION" ]] || return 1
+	IFS= read -r version <"$repo/VERSION" || return 1
+	[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+	tag_ref="refs/tags/v${version}"
+	if "$REAL_GIT" -C "$repo" show-ref --verify --quiet "$tag_ref"; then
+		return 0
+	fi
+	if ! "$REAL_GIT" -C "$repo" fetch --no-tags "$remote" \
+		"${tag_ref}:${tag_ref}" >/dev/null 2>&1; then
+		return 1
+	fi
+	"$REAL_GIT" -C "$repo" show-ref --verify --quiet "$tag_ref"
+	return $?
+}
+
 usage() {
 	printf '%s\n' \
 		'Usage:' \
@@ -1325,6 +1349,11 @@ if [[ "$cmd" == "$FAST_FORWARD_CMD" || "$cmd" == "$SYNC_MIRROR_CMD" ]]; then
 	[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${local_ref}^{commit}")" == "$target_sha" ]] || exit 1
 	[[ "$("$REAL_GIT" -C "$repo_path" rev-parse --verify "${remote_ref}^{commit}")" == "$target_sha" ]] || exit 1
 	[[ -z "$("$REAL_GIT" -C "$repo_path" status --porcelain)" ]] || exit 1
+	if [[ "$maintenance_reason" == "$AIDEVOPS_UPDATE_REASON" ]] &&
+		! fetch_aidevops_release_tag "$repo_path" "$canonical_remote"; then
+		printf 'WARNING: exact release tag for the updated VERSION is not available from %s\n' \
+			"$canonical_remote" >&2
+	fi
 	if [[ "$cmd" == "$SYNC_MIRROR_CMD" ]]; then
 		if [[ "$maintenance_reason" == "$AIDEVOPS_UPDATE_REASON" && -n "$sync_backup_id" ]]; then
 			retention_days="${AIDEVOPS_DIRTY_BACKUP_RETENTION_DAYS:-30}"

--- a/.agents/scripts/setup/modules/source-access.sh
+++ b/.agents/scripts/setup/modules/source-access.sh
@@ -49,6 +49,30 @@ _source_access_verify_release_tag() {
 	return 0
 }
 
+_source_access_ensure_release_tag() {
+	local repo_root="$1"
+	local version=""
+	local tag_ref=""
+	local current_branch=""
+	local recovery_helper="${repo_root}/.agents/scripts/canonical-recovery-helper.sh"
+
+	[[ -r "$repo_root/VERSION" ]] || return 1
+	IFS= read -r version <"$repo_root/VERSION" || return 1
+	[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+	tag_ref="refs/tags/v${version}"
+	if _source_access_git -C "$repo_root" show-ref --verify --quiet "$tag_ref"; then
+		return 0
+	fi
+	[[ -f "$recovery_helper" ]] || return 1
+	current_branch=$(_source_access_git -C "$repo_root" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
+	[[ -n "$current_branch" ]] || return 1
+	AIDEVOPS_REAL_GIT_BIN=/usr/bin/git bash "$recovery_helper" fast-forward-current \
+		--repo "$repo_root" --branch "$current_branch" --reason aidevops-update \
+		--confirm FAST_FORWARD_CANONICAL_BRANCH >/dev/null || return 1
+	_source_access_git -C "$repo_root" show-ref --verify --quiet "$tag_ref"
+	return $?
+}
+
 _source_access_release_commit() {
 	local repo_root="$1"
 	local version=""
@@ -339,6 +363,10 @@ setup_source_access_broker() {
 	local privilege_rc=0
 	local trust_rc=0
 
+	_source_access_ensure_release_tag "$repo_root" || {
+		print_warning "Source-access broker deferred: the installed release tag is unavailable from the official remote"
+		return 1
+	}
 	tag_commit=$(_source_access_release_commit "$repo_root") || {
 		print_warning "Source-access broker deferred: the installed release tag could not be verified"
 		return 1

--- a/.agents/scripts/tests/test-aidevops-update-transaction.sh
+++ b/.agents/scripts/tests/test-aidevops-update-transaction.sh
@@ -362,6 +362,9 @@ REMOTE_SHA=$(/usr/bin/git -C "$INTEGRATION_PEER" rev-parse HEAD)
 
 /usr/bin/git clone -q "$INTEGRATION_REMOTE" "$REAL_HELPER_REPO"
 /usr/bin/git -C "$REAL_HELPER_REPO" reset -q --hard "$BASE_SHA"
+/usr/bin/git -C "$INTEGRATION_PEER" tag -a v1.0.0 -m "release 1.0.0"
+/usr/bin/git -C "$INTEGRATION_PEER" push -q origin refs/tags/v1.0.0
+RELEASE_TAG_OBJECT=$(/usr/bin/git -C "$INTEGRATION_REMOTE" rev-parse refs/tags/v1.0.0)
 FRAMEWORK_URL="https://github.com/marcusquinn/aidevops.git"
 FRAMEWORK_SSH_URL="ssh://git@github.com/marcusquinn/aidevops.git"
 /usr/bin/git -C "$REAL_HELPER_REPO" config "url.${INTEGRATION_REMOTE}.insteadOf" "$FRAMEWORK_URL"
@@ -375,6 +378,7 @@ if AIDEVOPS_REPOS_CONFIG="$TEST_ROOT/missing-repos.json" AIDEVOPS_REAL_GIT_BIN=/
 	_update_fetch_main main &&
 	[[ "$(/usr/bin/git -C "$REAL_HELPER_REPO" rev-parse HEAD)" == "$REMOTE_SHA" ]] &&
 	[[ "$(/usr/bin/git -C "$REAL_HELPER_REPO" rev-parse refs/remotes/origin/main)" == "$REMOTE_SHA" ]] &&
+	[[ "$(/usr/bin/git -C "$REAL_HELPER_REPO" rev-parse refs/tags/v1.0.0)" == "$RELEASE_TAG_OBJECT" ]] &&
 	! /usr/bin/git -C "$REAL_HELPER_REPO" show-ref --verify --quiet refs/remotes/official-ssh/main &&
 	grep -q '"reason":"aidevops-update"' \
 		"$HOME/.aidevops/logs/canonical-recovery-audit.jsonl" &&
@@ -436,7 +440,10 @@ if [[ "$command_name" == "sync-mirror" ]]; then
 	rm "$repo/$untracked_path"
 	done < <(/usr/bin/git -C "$repo" ls-files --others --exclude-standard)
 fi
-/usr/bin/git -C "$repo" fetch origin "$branch" --tags --quiet
+/usr/bin/git -C "$repo" fetch --no-tags origin "$branch" --quiet
+IFS= read -r version <"$repo/VERSION"
+/usr/bin/git -C "$repo" fetch --no-tags origin \
+	"refs/tags/v${version}:refs/tags/v${version}" --quiet
 /usr/bin/git -C "$repo" merge --ff-only "origin/$branch" --quiet
 EOF
 chmod +x "$UPDATE_HELPER_DIR/canonical-recovery-helper.sh"

--- a/.agents/scripts/tests/test-setup-source-access-broker.sh
+++ b/.agents/scripts/tests/test-setup-source-access-broker.sh
@@ -54,6 +54,41 @@ if ! grep -qF "readonly TRUSTED_EMAIL=\"${production_release_signer_identity}\""
 fi
 
 expected_commit=$(git -C "$fixture_repo" rev-parse 'v1.2.3^{commit}')
+release_tag_object=$(git -C "$fixture_repo" rev-parse refs/tags/v1.2.3)
+tag_fetch_calls="$TEST_DIR/tag-fetch-calls"
+cat >"$fixture_repo/.agents/scripts/canonical-recovery-helper.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+repo=""
+printf '%s\n' "$*" >>"$TEST_SOURCE_ACCESS_TAG_FETCH_CALLS"
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--repo) repo="$2"; shift 2 ;;
+	*) shift ;;
+	esac
+done
+/usr/bin/git -C "$repo" update-ref refs/tags/v1.2.3 "$TEST_SOURCE_ACCESS_TAG_OBJECT"
+SH
+chmod +x "$fixture_repo/.agents/scripts/canonical-recovery-helper.sh"
+export TEST_SOURCE_ACCESS_TAG_FETCH_CALLS="$tag_fetch_calls"
+export TEST_SOURCE_ACCESS_TAG_OBJECT="$release_tag_object"
+git -C "$fixture_repo" update-ref -d refs/tags/v1.2.3
+if ! _source_access_ensure_release_tag "$fixture_repo" ||
+	[[ "$(git -C "$fixture_repo" rev-parse refs/tags/v1.2.3)" != "$release_tag_object" ]] ||
+	! grep -qF -- '--reason aidevops-update' "$tag_fetch_calls"; then
+	printf 'FAIL: missing release tag was not recovered through the audited update helper\n' >&2
+	exit 1
+fi
+
+# An existing conflicting/lightweight ref must never be replaced by recovery.
+git -C "$fixture_repo" update-ref refs/tags/v1.2.3 "$expected_commit"
+: >"$tag_fetch_calls"
+if ! _source_access_ensure_release_tag "$fixture_repo" || [[ -s "$tag_fetch_calls" ]] ||
+	_source_access_release_commit "$fixture_repo" >/dev/null 2>&1; then
+	printf 'FAIL: existing conflicting release tag was fetched over or accepted\n' >&2
+	exit 1
+fi
+git -C "$fixture_repo" update-ref refs/tags/v1.2.3 "$release_tag_object"
 resolved_commit=$(_source_access_release_commit "$fixture_repo")
 if [[ "$resolved_commit" != "$expected_commit" ]]; then
 	printf 'FAIL: source-access setup did not resolve the annotated release tag\n' >&2


### PR DESCRIPTION
## Summary

Fetch only the post-update VERSION tag from the validated canonical remote and retry that audited path during source-access bootstrap.

## Files Changed

.agents/scripts/canonical-recovery-helper.sh, .agents/scripts/setup/modules/source-access.sh, .agents/scripts/tests/test-aidevops-update-transaction.sh, .agents/scripts/tests/test-setup-source-access-broker.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Runtime-verified: ShellCheck; update transaction 16/16; canonical recovery; source-access broker; linters-local; review bundle 0d09170a2a72bc19fc29561244c37d4324cbd12c3087e34825df406b170ed8bb.

Resolves #29959


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.250 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 21m and 205,195 tokens on this with the user in an interactive session.