### PR TITLE
GH#29954: Allow compact cleanup after degraded CWD scan

### DIFF
--- a/.agents/scripts/pulse-cleanup-worktree-removal.sh
+++ b/.agents/scripts/pulse-cleanup-worktree-removal.sh
@@ -119,13 +119,18 @@ _pc_remove_local_commit_worktree_preserving_branch() {
 	local audit_context="$4"
 	local removal_reason="${5:-local-commits-branch-preserved}"
 	local removal_mode="${6:-branch-preserved}"
+	local guard_status=0
 
 	[[ -n "$rp_age" && -n "$wt_path_age" ]] || return 1
-	if ! worktree_removal_guard "$wt_path_age" "$_WTAR_PC_CALLER" "local-commits-branch-preserved"; then
-		return 1
+	if worktree_removal_guard "$wt_path_age" "$_WTAR_PC_CALLER" "local-commits-branch-preserved"; then
+		guard_status=0
+	else
+		guard_status=$?
 	fi
+	[[ "$guard_status" -eq 0 || "$guard_status" -eq "$_WT_CWD_CAPTURE_DEGRADED_RC" ]] || return 1
 
-	if git -C "$rp_age" worktree remove --force "$wt_path_age" 2>/dev/null; then
+	if _worktree_remove_with_native_git "$wt_path_age" "$_WTAR_PC_CALLER" \
+		"$audit_context" "$_WTAR_BOOL_TRUE"; then
 		git -C "$rp_age" worktree prune 2>/dev/null || true
 		unregister_worktree "$wt_path_age" 2>/dev/null || true
 		log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_PC_CALLER" "$wt_path_age" "$removal_reason" "$removal_mode" "$audit_context"


### PR DESCRIPTION
## Summary
- Allows pulse compact-archive cleanup to continue after `worktree_removal_guard` returns the recoverable `cwd-visibility-degraded` status.
- Replaces direct `git -C <canonical> worktree remove --force <worktree>` with the audited native Git removal helper used by cleanup code paths.
- Keeps Git lock/metadata rechecks before removal, then prunes and unregisters only after native removal succeeds.

For #29954.

## Evidence
- Live cleanup after #29960 verified compact archives but still logged `compact-archive-delete-failed` with prior `cwd-visibility-degraded` entries.
- A direct guarded `git worktree remove --force <linked-worktree>` succeeded after #29960, proving the remaining failure was the pulse helper path.

## Verification
- `bash .agents/scripts/tests/test-pulse-cleanup-worker-owned-no-pr.sh` — 28/28 passed.
- `shellcheck .agents/scripts/pulse-cleanup-worktree-removal.sh` — passed.
- Push hook: `bun run typecheck` — passed.

## Known unrelated observation
- `bash .agents/scripts/tests/test-pulse-cleanup-unregister.sh` currently fails at `eligible orphan worktree was not removed`; this failed before the compact archive patch and covers the permanent-removal path, not the compact archive regression fixed here.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.250 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.5 spent 2h 34m and 59,158 tokens on this with the user in an interactive session.