### PR TITLE
GH#29962: guard OpenCode plugin import argv

### DIFF
--- a/.agents/plugins/opencode-aidevops/session-recovery-marker.mjs
+++ b/.agents/plugins/opencode-aidevops/session-recovery-marker.mjs
@@ -275,7 +275,7 @@ function runCli(argv) {
 
 const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
 const modulePath = fileURLToPath(import.meta.url);
-if (invokedPath && realpathSync(invokedPath) === realpathSync(modulePath)) {
+if (invokedPath && existsSync(invokedPath) && realpathSync(invokedPath) === realpathSync(modulePath)) {
   try {
     process.exitCode = runCli(process.argv.slice(2));
   } catch (error) {

--- a/.agents/scripts/tests/test-session-recovery-marker.mjs
+++ b/.agents/scripts/tests/test-session-recovery-marker.mjs
@@ -71,6 +71,22 @@ const missingCli = spawnSync(
 );
 assert.equal(missingCli.status, 2, "resolver CLI should preserve the no-marker status through a symlink");
 
+const pluginIndexUrl = new URL("../../plugins/opencode-aidevops/index.mjs", import.meta.url).href;
+const subcommandImport = spawnSync(
+  process.execPath,
+  [
+    "--input-type=module",
+    "--eval",
+    `process.argv[1] = "run"; await import(${JSON.stringify(pluginIndexUrl)});`,
+  ],
+  { encoding: "utf8" },
+);
+assert.equal(
+  subcommandImport.status,
+  0,
+  `plugin import should ignore non-path CLI subcommands: ${subcommandImport.stderr}`,
+);
+
 const emitted = [];
 const handler = createSessionRecoveryMarkerHandler({
   directory,


### PR DESCRIPTION
## Summary

Prevent non-path OpenCode CLI subcommands from crashing plugin module import while preserving direct symlink resolver execution.

## Files Changed

.agents/plugins/opencode-aidevops/session-recovery-marker.mjs, .agents/scripts/tests/test-session-recovery-marker.mjs

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: exact process.argv[1]=run plugin import prints loaded; session recovery marker tests pass; OpenCode plugin suite passes 619/619; review bundle ff733ea70333937b260a8dde47660e5e7caf214b72953e5491aeb91ded035d98.

Resolves #29962


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.250 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 44m and 95,799 tokens on this with the user in an interactive session.