### PR TITLE
GH#29961: block unpublished planning dispatch

### DIFF
--- a/.agents/reference/dispatch-blockers.md
+++ b/.agents/reference/dispatch-blockers.md
@@ -16,6 +16,7 @@ Applied to GitHub issues. The pulse checks these before spawning a worker.
 |-------|-------------|-----------|
 | `parent-task` | `dispatch-dedup-helper.sh` `_is_assigned_check_parent_task` | Epics/trackers — children implement, not this issue. Permanent until explicitly removed; review-label normalization cannot override it (t2211). |
 | `meta` | Same as `parent-task` — treated as an alias | Alternative spelling of `parent-task`. |
+| `publication:pending` | `pulse-wrapper-cycle-gates.sh`, `dispatch-dedup-helper.sh` `_is_assigned_check_publication_pending`, and `pulse-dispatch-core.sh` `_has_publication_pending_label` | Canonical TODO/brief publication is still pending. It blocks candidate discovery, dedup, and direct dispatch until exact default-branch reconciliation validates the task/issue mapping and removes it last. |
 | `no-auto-dispatch` | `dispatch-dedup-helper.sh` `_is_assigned_check_no_auto_dispatch` (t2832), `issue-sync-lib.sh`, `interactive-session-helper.sh` lockdown | Durable explicit manual hold for issues. Blocks dispatch (`NO_AUTO_DISPATCH_BLOCKED`), ordinary/bulk/pulse enrich, and decomposition. Routine interactive ownership uses `status:in-review` + assignment instead. The explicit maintainer-only `issue-sync-helper.sh sync-body tNNN` exception can update only the authoritative body while continuously verifying the hold and all metadata; it cannot dispatch, change labels, or bypass a genuine claim. Applied by `interactive-session-helper.sh lockdown`. |
 | `hold-for-review` | `dispatch-dedup-helper.sh` `_is_assigned_check_hold_for_review`, `issue-sync-lib.sh`; PR merge checks below | Confirmed unresolved internal, manual, policy, or security review hold backed by explicit durable decision evidence. On issues, same dispatch-block intent as `no-auto-dispatch` (`HOLD_FOR_REVIEW_BLOCKED` signal). On PRs, blocks auto-merge until a maintainer removes the label. It does not represent missing author authority and needs no cryptographic self-approval. Label actor, timing, or missing automation provenance alone is insufficient. Scanner availability, temporary-file, input, and execution failures are infrastructure retries and must not apply this label. |
 | `needs-maintainer-review` | `pulse-nmr-approval.sh` `auto_approve_maintainer_issues`, external-author workflows | External-author authority gate. Authors without verified write authority require maintainer cryptographic approval (`sudo aidevops approve issue <N>`) before dispatch. Write-authorized authors never self-approve: explicit durable human-decision evidence normalizes to `hold-for-review`, machine-breaker evidence becomes `status:blocked`, and unreasoned residue is removed without replacing active `status:*`. Unknown authority or incomplete required evidence fails closed by retaining NMR unchanged. |
@@ -63,6 +64,7 @@ These are not labels — they are runtime state signals checked by `dispatch-ded
 | Signal | Exit code | Meaning |
 |--------|-----------|---------|
 | `PARENT_TASK_BLOCKED` | 0 (blocked) | `parent-task` / `meta` label — unconditional block |
+| `PUBLICATION_PENDING_BLOCKED` | 0 (blocked) | `publication:pending` label — canonical planning publication is incomplete |
 | `NO_AUTO_DISPATCH_BLOCKED` | 0 (blocked) | `no-auto-dispatch` label — unconditional block (t2832) |
 | `HOLD_FOR_REVIEW_BLOCKED` | 0 (blocked) | `hold-for-review` label — unconditional issue dispatch block and PR auto-merge hold |
 | `ASSIGNED: issue #N in repo` | 0 (blocked) | Active assignee with blocking claim state |
@@ -95,7 +97,7 @@ To add a new label-level dispatch blocker:
 
 1. **Register in `label-sync-helper.sh`** — add to `SYSTEM_LABELS` array with a description starting "Opt-out:" or "Block:". The `cmd_sync` command will create it on all admin repos.
 2. **Protect in `issue-sync-helper.sh`** — add to `_is_protected_label()` exact-match list so the enrich path cannot strip it.
-3. **Enforce in `dispatch-dedup-helper.sh`** (if unconditional) — add label check to the pre-assignee block, before `_is_assigned_compute_blocking`. Or for conditional blockers, update `_has_active_claim`.
+3. **Enforce in `dispatch-dedup-helper.sh`** (if unconditional) — add label check to the pre-assignee block, before `_is_assigned_compute_blocking`, plus candidate and direct-dispatch guards when the label prevents launch. Or for conditional blockers, update `_has_active_claim`.
 4. **Document here** — add a row to the relevant table above with the enforcement point.
 
 ---

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -806,6 +806,7 @@ _has_active_claim() {
 #   exit 1 if unassigned or assigned only to self (safe to dispatch)
 # Outputs: one of the following signals on stdout when blocking:
 #   PARENT_TASK_BLOCKED (label=<name>)      — unconditional parent-task / meta block
+#   PUBLICATION_PENDING_BLOCKED (label=...) — canonical planning publication has not landed
 #   NO_AUTO_DISPATCH_BLOCKED (label=...)    — unconditional no-auto-dispatch block (t2832)
 #   INFRASTRUCTURE_BLOCKED (label=...)      — infrastructure / billing / runner advisory block
 #   COST_BUDGET_EXCEEDED (...)              — token spend circuit breaker
@@ -869,6 +870,26 @@ _is_assigned_check_parent_task() {
 		return 0
 	fi
 	return 1
+}
+
+#######################################
+# is_assigned helper: block issues whose canonical planning publication has not
+# landed on the default branch. The label is applied before an issue can exist
+# ahead of its TODO.md row/brief and is removed only by exact-SHA reconciliation.
+#
+# Args:
+#   $1 = issue metadata JSON (from `gh issue view --json ...,labels`)
+#   $2 = (optional) issue number — included in GUARD_UNCERTAIN output
+#   $3 = (optional) repo slug — included in GUARD_UNCERTAIN output
+# Returns: exit 0 if publication:pending is present or jq fails (prints signal),
+#          exit 1 if the label is absent and jq succeeds
+#######################################
+_is_assigned_check_publication_pending() {
+	local meta_json="$1"
+	local issue_number="${2:-unknown}"
+	local repo_slug="${3:-unknown}"
+	_is_assigned_check_label_block "$meta_json" "$issue_number" "$repo_slug" \
+		"publication:pending" "PUBLICATION_PENDING_BLOCKED" "publication-pending-check"
 }
 
 #######################################
@@ -1808,8 +1829,11 @@ _is_assigned_pre_assignee_guard_blocks() {
 	local issue_number="$2"
 	local repo_slug="$3"
 
-	# t1986/t2832: parent-task and no-auto-dispatch are unconditional blocks.
+	# Parent-task, pending publication, and no-auto-dispatch are unconditional blocks.
 	if _is_assigned_check_parent_task "$issue_meta_json" "$issue_number" "$repo_slug"; then
+		return 0
+	fi
+	if _is_assigned_check_publication_pending "$issue_meta_json" "$issue_number" "$repo_slug"; then
 		return 0
 	fi
 	if _is_assigned_check_no_auto_dispatch "$issue_meta_json" "$issue_number" "$repo_slug"; then
@@ -1971,8 +1995,8 @@ is_assigned_read_only() {
 # enumerate_blockers — report ALL structural dispatch blockers for an issue.
 #
 # Unlike is_assigned() which short-circuits on the first match, this function
-# runs every unconditional structural check (parent-task, no-auto-dispatch,
-# infrastructure, hold-for-review)
+# runs every unconditional structural check (parent-task, pending publication,
+# no-auto-dispatch, infrastructure, hold-for-review)
 # and emits ALL matching signals as newline-separated tokens on stdout.
 #
 # Intentionally excludes cost-budget, hydration window, and assignee checks —
@@ -2032,35 +2056,42 @@ enumerate_blockers() {
 		_found=true
 	fi
 
-	# Check 2: no-auto-dispatch unconditional block (t2832).
+	# Check 2: canonical planning publication has not landed.
+	_blocker_out=$(_is_assigned_check_publication_pending "$issue_meta_json" "$issue_number" "$repo_slug" 2>/dev/null) || true
+	if [[ -n "$_blocker_out" ]]; then
+		printf '%s\n' "$_blocker_out"
+		_found=true
+	fi
+
+	# Check 3: no-auto-dispatch unconditional block (t2832).
 	_blocker_out=$(_is_assigned_check_no_auto_dispatch "$issue_meta_json" "$issue_number" "$repo_slug" 2>/dev/null) || true
 	if [[ -n "$_blocker_out" ]]; then
 		printf '%s\n' "$_blocker_out"
 		_found=true
 	fi
 
-	# Check 3: request-specific signed worker permission hold.
+	# Check 4: request-specific signed worker permission hold.
 	_blocker_out=$(_is_assigned_check_maintainer_permissions "$issue_meta_json" "$issue_number" "$repo_slug" 2>/dev/null) || true
 	if [[ -n "$_blocker_out" ]]; then
 		printf '%s\n' "$_blocker_out"
 		_found=true
 	fi
 
-	# Check 4: infrastructure advisory/operator block.
+	# Check 5: infrastructure advisory/operator block.
 	_blocker_out=$(_is_assigned_check_infrastructure "$issue_meta_json" "$issue_number" "$repo_slug" 2>/dev/null) || true
 	if [[ -n "$_blocker_out" ]]; then
 		printf '%s\n' "$_blocker_out"
 		_found=true
 	fi
 
-	# Check 5: hold-for-review unconditional maintainer hold.
+	# Check 6: hold-for-review unconditional maintainer hold.
 	_blocker_out=$(_is_assigned_check_hold_for_review "$issue_meta_json" "$issue_number" "$repo_slug" 2>/dev/null) || true
 	if [[ -n "$_blocker_out" ]]; then
 		printf '%s\n' "$_blocker_out"
 		_found=true
 	fi
 
-	# Check 6: t3197 dispatch cooldown after no_worker_process launch failure.
+	# Check 7: t3197 dispatch cooldown after no_worker_process launch failure.
 	_blocker_out=$(_is_assigned_check_dispatch_cooldown "$issue_number" "$repo_slug" 2>/dev/null) || true
 	if [[ -n "$_blocker_out" ]]; then
 		printf '%s\n' "$_blocker_out"
@@ -2547,6 +2578,10 @@ _classify_structural_dispatch_blocker_reason() {
 			printf 'parent_task\n'
 			return 0
 			;;
+		*publication_pending_blocked* | *publication:pending*)
+			printf 'publication_pending\n'
+			return 0
+			;;
 		*infrastructure_blocked* | *label=infrastructure* | *hold_for_review_blocked* | *hold-for-review* | *external*author*gate* | *nmr*gate* | *approval*required*)
 			printf 'policy_gate\n'
 			return 0
@@ -2665,7 +2700,8 @@ Usage:
   dispatch-dedup-helper.sh is-assigned-read-only <issue> <slug> [self-login]  Inspect without recovery writes
   dispatch-dedup-helper.sh enumerate-blockers <issue> <slug> [runner]
                                                        Report ALL structural label blockers (exit 0=blocked, 1=none)
-                                                       Emits newline-separated tokens: PARENT_TASK_BLOCKED,
+                                                        Emits newline-separated tokens: PARENT_TASK_BLOCKED,
+                                                        PUBLICATION_PENDING_BLOCKED,
                                                        NO_AUTO_DISPATCH_BLOCKED, GUARD_UNCERTAIN. Unlike is-assigned,
                                                        does not short-circuit on first match. t2894.
   dispatch-dedup-helper.sh classify-blocker <signal>

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -2700,9 +2700,8 @@ Usage:
   dispatch-dedup-helper.sh is-assigned-read-only <issue> <slug> [self-login]  Inspect without recovery writes
   dispatch-dedup-helper.sh enumerate-blockers <issue> <slug> [runner]
                                                        Report ALL structural label blockers (exit 0=blocked, 1=none)
-                                                        Emits newline-separated tokens: PARENT_TASK_BLOCKED,
-                                                        PUBLICATION_PENDING_BLOCKED,
-                                                       NO_AUTO_DISPATCH_BLOCKED, GUARD_UNCERTAIN. Unlike is-assigned,
+                                                        Emits newline-separated tokens: PARENT_TASK_BLOCKED, NO_AUTO_DISPATCH_BLOCKED,
+                                                        GUARD_UNCERTAIN. Unlike is-assigned,
                                                        does not short-circuit on first match. t2894.
   dispatch-dedup-helper.sh classify-blocker <signal>
                                                        Classify a blocker signal into a stable metric reason.

--- a/.agents/scripts/issue-sync-helper-labels.sh
+++ b/.agents/scripts/issue-sync-helper-labels.sh
@@ -219,7 +219,7 @@ _is_protected_label() {
 	case "$lbl" in
 	persistent | needs-maintainer-review | needs-maintainer-permissions | not-planned | duplicate | wontfix | \
 		already-fixed | "good first issue" | "help wanted" | \
-		parent-task | meta | auto-dispatch | no-auto-dispatch | no-takeover | \
+	parent-task | meta | auto-dispatch | publication:pending | no-auto-dispatch | no-takeover | \
 		hold-for-review | needs-credentials | \
 		consolidation-in-progress | coderabbit-nits-ok | ratchet-bump | \
 		new-file-smell-ok)

--- a/.agents/scripts/label-sync-helper.sh
+++ b/.agents/scripts/label-sync-helper.sh
@@ -107,6 +107,7 @@ DISPATCH_LABELS=(
 # --- aidevops System Labels ---
 SYSTEM_LABELS=(
 	"auto-dispatch|0E8A16|Eligible for automated worker dispatch"
+	"publication:pending|FBCA04|Block: planning exists locally but is not yet published on the default branch"
 	"no-auto-dispatch|EDEDED|Opt-out: block all auto-dispatch on this issue"
 	"hold-for-review|D73A4A|Opt-out: block issue auto-dispatch or PR auto-merge for maintainer review"
 	"needs-credentials|FBCA04|Opt-out: block auto-dispatch — requires credentials or account access"

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -25,6 +25,7 @@
 #   - _check_nmr_approval_gate
 #   - _check_commit_subject_dedup_gate
 #   - _has_force_dispatch_label
+#   - _has_publication_pending_label
 #   - _is_bot_generated_cleanup_issue
 #   - _is_task_committed_to_main
 #   - _dispatch_target_is_pull_request
@@ -926,6 +927,29 @@ _has_force_dispatch_label() {
 }
 
 #######################################
+# Detect the publication hold label before any claim or worker launch.
+#
+# `publication:pending` represents an issue that was intentionally created
+# before its TODO.md entry and worker brief/stub reached the default branch.
+# This dedicated pre-launch check remains effective if candidate filtering or
+# the dispatch-dedup helper is bypassed. Malformed metadata fails closed.
+#
+# Args:
+#   $1 - issue metadata JSON with a .labels array
+# Exit codes:
+#   0 - publication is pending or metadata cannot be safely read
+#   1 - publication is not pending
+#######################################
+_has_publication_pending_label() {
+	local issue_meta_json="$1"
+	local label_state=""
+	[[ -n "$issue_meta_json" ]] || return 0
+	label_state=$(printf '%s' "$issue_meta_json" |
+		jq -r 'if ((.labels // []) | map(.name) | index("publication:pending")) != null then "pending" else "published" end' 2>/dev/null) || return 0
+	[[ "$label_state" == "pending" ]]
+}
+
+#######################################
 # t2955: Detect the `dispatch-blocked:committed-to-main` cache label.
 #
 # Purpose: cache fast-path for `_check_commit_subject_dedup_gate`. When
@@ -1314,6 +1338,15 @@ _dispatch_dedup_check_layers() {
 	if [[ "$target_state" != "OPEN" ]]; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: issue state is ${target_state:-unknown}" >>"$LOGFILE"
 		_ds_record "$issue_number" "$repo_slug" "dedup.state_check" "$_dss_t0"
+		return 1
+	fi
+
+	# publication:pending is an unconditional hold while canonical planning is
+	# absent from the default branch. It is checked here as defence-in-depth
+	# before direct-dispatch paths can claim or launch a worker.
+	if _has_publication_pending_label "$issue_meta_json"; then
+		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: publication:pending label present" >>"$LOGFILE"
+		_ds_record "$issue_number" "$repo_slug" "dedup.publication_pending" "$_dss_t0"
 		return 1
 	fi
 

--- a/.agents/scripts/pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/pulse-wrapper-cycle-gates.sh
@@ -218,7 +218,7 @@ _pulse_available_auto_dispatch_work_exists() {
 		_count=""
 		_query_rc=0
 		_count=$(timeout_sec "$_remaining" gh api -X GET search/issues \
-			-f "q=repo:${_slug} is:issue is:open label:auto-dispatch label:status:available -label:needs-maintainer-review -label:needs-maintainer-permissions -label:infrastructure no:assignee" \
+			-f "q=repo:${_slug} is:issue is:open label:auto-dispatch label:status:available -label:publication:pending -label:needs-maintainer-review -label:needs-maintainer-permissions -label:infrastructure no:assignee" \
 			-f per_page=1 \
 			--jq '.total_count // 0' 2>/dev/null) || _query_rc=$?
 		if [[ "$_query_rc" -eq 124 ]]; then

--- a/.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh
+++ b/.agents/scripts/tests/test-dispatch-candidate-failure-reasons.sh
@@ -37,6 +37,7 @@ assert_reason 'pre-dispatch validator failed: missing worker context; needs-brie
 assert_reason 'dedup.worktree_cap blocked by max worktree count' 'local_capacity_gate'
 assert_reason 'dedup guard blocked #303 in some-org/infrastructure' 'dedup_active_claim'
 assert_reason 'PARENT_TASK_BLOCKED (label=parent-task)' 'parent_task'
+assert_reason 'PUBLICATION_PENDING_BLOCKED (label=publication:pending)' 'publication_pending'
 assert_reason 'NO_AUTO_DISPATCH_BLOCKED (label=no-auto-dispatch)' 'no_auto_dispatch'
 assert_reason 'FOOTPRINT_OVERLAP path=.agents/scripts/pulse-dispatch-engine.sh issue=#25229' 'footprint_overlap'
 assert_reason '[dispatch_with_dedup] Hard-stop before worker bootstrap for #25233 in marcusquinn/aidevops: unresolved blocked-by dependency (GH#23932)' 'blocked_by_unresolved'

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh
@@ -182,6 +182,29 @@ test_parent_task_only() {
 }
 
 # -------------------------------------------------------------------
+# Test: publication:pending is an unconditional blocker even when positive
+# dispatch labels are already present through a partial API mutation.
+# -------------------------------------------------------------------
+test_publication_pending_only() {
+	create_gh_stub "publication:pending,auto-dispatch,status:available,tier:standard"
+
+	local output exit_code=0
+	output=$("$HELPER_SCRIPT" enumerate-blockers 100 marcusquinn/aidevops 2>/dev/null) || exit_code=$?
+
+	if [[ "$exit_code" -ne 0 ]]; then
+		print_result "publication:pending blocks positive dispatch labels" 1 "Expected exit 0 but got exit ${exit_code}"
+		return 0
+	fi
+
+	if printf '%s\n' "$output" | grep -q 'PUBLICATION_PENDING_BLOCKED'; then
+		print_result "publication:pending emits PUBLICATION_PENDING_BLOCKED" 0
+	else
+		print_result "publication:pending emits PUBLICATION_PENDING_BLOCKED" 1 "Signal not in output: '${output}'"
+	fi
+	return 0
+}
+
+# -------------------------------------------------------------------
 # Test: only no-auto-dispatch → exit 0, NO_AUTO_DISPATCH_BLOCKED emitted
 # -------------------------------------------------------------------
 test_no_auto_dispatch_only() {
@@ -252,7 +275,7 @@ test_infrastructure_only() {
 # This is the core multi-blocker regression guard (t2894).
 # -------------------------------------------------------------------
 test_multi_blocker_both_signals_emitted() {
-	create_gh_stub "parent-task,no-auto-dispatch,infrastructure,hold-for-review,tier:standard"
+	create_gh_stub "parent-task,publication:pending,no-auto-dispatch,infrastructure,hold-for-review,tier:standard"
 
 	local output exit_code=0
 	output=$("$HELPER_SCRIPT" enumerate-blockers 100 marcusquinn/aidevops 2>/dev/null) || exit_code=$?
@@ -263,9 +286,12 @@ test_multi_blocker_both_signals_emitted() {
 		return 0
 	fi
 
-	local parent_found=false nad_found=false infra_found=false hfr_found=false
+	local parent_found=false publication_found=false nad_found=false infra_found=false hfr_found=false
 	if printf '%s\n' "$output" | grep -q 'PARENT_TASK_BLOCKED'; then
 		parent_found=true
+	fi
+	if printf '%s\n' "$output" | grep -q 'PUBLICATION_PENDING_BLOCKED'; then
+		publication_found=true
 	fi
 	if printf '%s\n' "$output" | grep -q 'NO_AUTO_DISPATCH_BLOCKED'; then
 		nad_found=true
@@ -277,21 +303,21 @@ test_multi_blocker_both_signals_emitted() {
 		hfr_found=true
 	fi
 
-	if [[ "$parent_found" == "true" && "$nad_found" == "true" && "$infra_found" == "true" && "$hfr_found" == "true" ]]; then
-		print_result "multi-blocker: parent/no-auto/infrastructure/hold signals emitted" 0
+	if [[ "$parent_found" == "true" && "$publication_found" == "true" && "$nad_found" == "true" && "$infra_found" == "true" && "$hfr_found" == "true" ]]; then
+		print_result "multi-blocker: parent/publication/no-auto/infrastructure/hold signals emitted" 0
 	else
-		print_result "multi-blocker: parent/no-auto/infrastructure/hold signals emitted" 1 \
-			"Missing signals — parent_found=${parent_found} nad_found=${nad_found} infra_found=${infra_found} hfr_found=${hfr_found}; output: '${output}'"
+		print_result "multi-blocker: parent/publication/no-auto/infrastructure/hold signals emitted" 1 \
+			"Missing signals — parent_found=${parent_found} publication_found=${publication_found} nad_found=${nad_found} infra_found=${infra_found} hfr_found=${hfr_found}; output: '${output}'"
 	fi
 
-	# Count lines — must be exactly 4
+	# Count lines — must be exactly 5
 	local line_count
 	line_count=$(printf '%s\n' "$output" | grep -c '.' 2>/dev/null || true)
-	if [[ "$line_count" -eq 4 ]]; then
-		print_result "multi-blocker: exactly 4 lines emitted (one per signal)" 0
+	if [[ "$line_count" -eq 5 ]]; then
+		print_result "multi-blocker: exactly 5 lines emitted (one per signal)" 0
 	else
-		print_result "multi-blocker: exactly 4 lines emitted (one per signal)" 1 \
-			"Expected 4 lines, got ${line_count}; output: '${output}'"
+		print_result "multi-blocker: exactly 5 lines emitted (one per signal)" 1 \
+			"Expected 5 lines, got ${line_count}; output: '${output}'"
 	fi
 	return 0
 }
@@ -380,6 +406,7 @@ main() {
 
 	test_no_blockers_returns_safe
 	test_parent_task_only
+	test_publication_pending_only
 	test_no_auto_dispatch_only
 	test_hold_for_review_only
 	test_infrastructure_only

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh
@@ -486,6 +486,23 @@ test_owner_assigned_with_origin_interactive_auto_dispatch_allows() {
 	return 0
 }
 
+test_publication_pending_blocks_unassigned_issue() {
+	create_gh_stub "" "publication:pending,auto-dispatch,status:available"
+
+	local output=""
+	if output=$("$HELPER_SCRIPT" is-assigned 100 marcusquinn/aidevops runner1 2>/dev/null); then
+		if [[ "$output" == *"PUBLICATION_PENDING_BLOCKED"* ]]; then
+			print_result "publication:pending blocks an otherwise dispatchable unassigned issue" 0
+			return 0
+		fi
+		print_result "publication:pending blocks an otherwise dispatchable unassigned issue" 1 "Unexpected output: ${output}"
+		return 0
+	fi
+
+	print_result "publication:pending blocks an otherwise dispatchable unassigned issue" 1 "Expected exit 0 (blocked) but got exit 1 (safe)"
+	return 0
+}
+
 test_maintainer_assigned_with_origin_interactive_auto_dispatch_allows() {
 	create_gh_stub "marcusquinn-bot" "origin:interactive,auto-dispatch,bug"
 
@@ -649,6 +666,7 @@ main() {
 	test_maintainer_assigned_with_origin_interactive_blocks
 	test_owner_assigned_with_origin_interactive_auto_dispatch_allows
 	test_maintainer_assigned_with_origin_interactive_auto_dispatch_allows
+	test_publication_pending_blocks_unassigned_issue
 	test_owner_assigned_no_status_no_origin_allows_dispatch
 	test_override_ignore_preserves_self_assignee
 	test_peer_quarantine_preserves_self_assignee

--- a/.agents/scripts/tests/test-enrich-dedup-guard.sh
+++ b/.agents/scripts/tests/test-enrich-dedup-guard.sh
@@ -49,8 +49,10 @@ mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/.agent-workspace/supervisor
 source "${TEST_SCRIPTS_DIR}/issue-sync-helper.sh" >/dev/null 2>&1
 set +e
 
-# Labels that MUST be protected (coordination signals from GH#19856)
-for lbl in "no-auto-dispatch" "no-takeover" "consolidation-in-progress" \
+# Labels that MUST be protected (coordination signals from GH#19856).
+# publication:pending must survive enrich until default-branch reconciliation
+# validates its canonical TODO/brief mapping and removes the hold last.
+for lbl in "no-auto-dispatch" "publication:pending" "no-takeover" "consolidation-in-progress" \
 	"coderabbit-nits-ok" "ratchet-bump" "new-file-smell-ok"; do
 	if _is_protected_label "$lbl"; then
 		print_result "_is_protected_label protects '$lbl'" 0
@@ -118,6 +120,10 @@ _main() {
 	fi
 	if [[ "\$cmd" == "api" ]]; then
 		[[ "${fail_reads}" == "true" ]] && return 1
+		if [[ "\${2:-}" == /repos/*/issues/* || "\${2:-}" == repos/*/issues/* ]]; then
+			echo '${payload}'
+			return 0
+		fi
 		echo '{"login": "testbot"}'
 		return 0
 	fi

--- a/.agents/scripts/tests/test-pulse-dispatch-core-publication-pending.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-publication-pending.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Verifies the direct-dispatch defence-in-depth guard for issues whose planning
+# files have not yet reached the default branch.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+CORE_SCRIPT="${SCRIPT_DIR}/../pulse-dispatch-core.sh"
+
+extract_helper() {
+	awk '/^_has_publication_pending_label\(\) \{/,/^}$/ { print }' "$CORE_SCRIPT"
+}
+
+helper_src=$(extract_helper)
+if [[ -z "$helper_src" ]]; then
+	printf 'FAIL missing _has_publication_pending_label in %s\n' "$CORE_SCRIPT" >&2
+	exit 1
+fi
+# shellcheck disable=SC1090 # The exact helper is extracted from the source under test.
+eval "$helper_src"
+
+pending='{"labels":[{"name":"auto-dispatch"},{"name":"status:available"},{"name":"publication:pending"}]}'
+published='{"labels":[{"name":"auto-dispatch"},{"name":"status:available"}]}'
+
+if _has_publication_pending_label "$pending"; then
+	printf 'PASS direct-dispatch guard blocks publication:pending\n'
+else
+	printf 'FAIL direct-dispatch guard did not block publication:pending\n' >&2
+	exit 1
+fi
+
+if _has_publication_pending_label "$published"; then
+	printf 'FAIL direct-dispatch guard blocked published task\n' >&2
+	exit 1
+fi
+printf 'PASS direct-dispatch guard permits published task\n'
+
+if _has_publication_pending_label '{not-json'; then
+	printf 'PASS direct-dispatch guard fails closed on malformed metadata\n'
+else
+	printf 'FAIL direct-dispatch guard failed open on malformed metadata\n' >&2
+	exit 1
+fi

--- a/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-cycle-gates.sh
@@ -118,6 +118,12 @@ else
 	fail "idle-work query excludes infrastructure advisory issues" "query=$(<"$GH_QUERY_FILE")"
 fi
 
+if grep -q -- '-label:publication:pending' "$GH_QUERY_FILE"; then
+	pass "idle-work query excludes unpublished planning issues"
+else
+	fail "idle-work query excludes unpublished planning issues" "query=$(<"$GH_QUERY_FILE")"
+fi
+
 timeout_value=$(<"$TIMEOUT_CALL_FILE")
 if grep -q 'AIDEVOPS_PULSE_IDLE_AVAILABLE_WORK_TIMEOUT:-30' "$SOURCE_SCRIPT" &&
 	[[ "$timeout_value" =~ ^[0-9]+$ ]] &&


### PR DESCRIPTION
For #29961

## Summary

- Register `publication:pending` as a canonical, enrich-preserved label.
- Block pending planning publications during candidate discovery, dedup, and direct pre-launch dispatch.
- Cover positive-dispatch-label races and malformed metadata with focused shell tests.

## Verification

- `shellcheck` on all changed shell sources and tests
- dispatch-dedup, pulse cycle-gate, direct-dispatch, failure-reason, and issue-sync orphan suites
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.250 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 7m and 172,536 tokens on this as a headless worker.