### PR TITLE
GH#29956: Complete hosted Issue Sync context repair

### DIFF
--- a/.agents/scripts/issue-sync-ci-context.sh
+++ b/.agents/scripts/issue-sync-ci-context.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Narrow, repository-scoped runtime context for Issue Sync in GitHub Actions.
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+
+[[ -n "${_ISSUE_SYNC_CI_CONTEXT_LOADED:-}" ]] && return 0
+_ISSUE_SYNC_CI_CONTEXT_LOADED=1
+
+issue_sync_prepare_ci_context() {
+	local default_config="${HOME}/.config/aidevops/repos.json"
+	local temp_root=""
+	local inventory=""
+	local repo="${GITHUB_REPOSITORY:-}"
+
+	[[ "${GITHUB_ACTIONS:-}" == "true" ]] || return 0
+	if [[ ! "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+		printf '%s\n' '::error::Issue Sync cannot establish the current GitHub Actions repository context.' >&2
+		return 1
+	fi
+	if [[ -n "${PRIVACY_REPOS_CONFIG:-}" && -n "${AIDEVOPS_REPOS_JSON:-}" ]]; then
+		return 0
+	fi
+	if [[ -f "$default_config" ]]; then
+		[[ -n "${PRIVACY_REPOS_CONFIG:-}" ]] || export PRIVACY_REPOS_CONFIG="$default_config"
+		[[ -n "${AIDEVOPS_REPOS_JSON:-}" ]] || export AIDEVOPS_REPOS_JSON="$default_config"
+		return 0
+	fi
+
+	# GITHUB_REPOSITORY is runner-owned event metadata and GITHUB_TOKEN is scoped
+	# to that repository. Record only that current target: it authorizes no
+	# cross-repository write and exposes no user-owned private inventory.
+	temp_root="${RUNNER_TEMP:-${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}}"
+	mkdir -p "$temp_root" || return 1
+	inventory=$(mktemp "${temp_root%/}/aidevops-issue-sync-ci-context.XXXXXX") || return 1
+	printf '{"initialized_repos":[{"slug":"%s","role":"maintainer"}]}\n' "$repo" >"$inventory" || return 1
+	chmod 600 "$inventory" 2>/dev/null || true
+	[[ -n "${PRIVACY_REPOS_CONFIG:-}" ]] || export PRIVACY_REPOS_CONFIG="$inventory"
+	[[ -n "${AIDEVOPS_REPOS_JSON:-}" ]] || export AIDEVOPS_REPOS_JSON="$inventory"
+	export ISSUE_SYNC_CI_CONTEXT_INVENTORY="$inventory"
+	printf '%s\n' '::notice::Issue Sync is using an ephemeral repository-scoped CI privacy and write-policy inventory.'
+	return 0
+}
+
+issue_sync_write_ci_context_env() {
+	local env_file="${1:-${GITHUB_ENV:-}}"
+	issue_sync_prepare_ci_context || return 1
+	[[ "${GITHUB_ACTIONS:-}" == "true" ]] || return 0
+	if [[ -z "$env_file" || "$env_file" == *$'\n'* || "$env_file" == *$'\r'* ||
+		"${PRIVACY_REPOS_CONFIG:-}" == *$'\n'* || "${PRIVACY_REPOS_CONFIG:-}" == *$'\r'* ||
+		"${AIDEVOPS_REPOS_JSON:-}" == *$'\n'* || "${AIDEVOPS_REPOS_JSON:-}" == *$'\r'* ]]; then
+		printf '%s\n' '::error::Issue Sync refused an unsafe GitHub Actions environment path.' >&2
+		return 1
+	fi
+	{
+		printf 'PRIVACY_REPOS_CONFIG=%s\n' "$PRIVACY_REPOS_CONFIG"
+		printf 'AIDEVOPS_REPOS_JSON=%s\n' "$AIDEVOPS_REPOS_JSON"
+	} >>"$env_file" || return 1
+	return 0
+}

--- a/.agents/scripts/issue-sync-git-push-helper.sh
+++ b/.agents/scripts/issue-sync-git-push-helper.sh
@@ -7,29 +7,11 @@
 set -euo pipefail
 
 ISSUE_SYNC_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=./issue-sync-ci-context.sh
+source "${ISSUE_SYNC_SCRIPT_DIR}/issue-sync-ci-context.sh"
+issue_sync_prepare_ci_context
 # shellcheck source=./planning-publisher.sh
 source "${ISSUE_SYNC_SCRIPT_DIR}/planning-publisher.sh"
-
-# Public-write wrappers require a valid local private-entity registry. Hosted
-# GitHub Actions jobs intentionally have no user repos.json, so give this
-# narrowly generated issue-sync publication an explicit empty registry while
-# retaining the wrapper's target-privacy, local-path, and secret scans.
-issue_sync_prepare_ci_privacy_inventory() {
-	local default_config="${HOME}/.config/aidevops/repos.json"
-	local temp_root=""
-	local inventory=""
-	[[ "${GITHUB_ACTIONS:-}" == "true" ]] || return 0
-	[[ -n "${PRIVACY_REPOS_CONFIG:-}" || -f "$default_config" ]] && return 0
-	temp_root="${RUNNER_TEMP:-${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}}"
-	mkdir -p "$temp_root" || return 1
-	inventory=$(mktemp "${temp_root%/}/aidevops-issue-sync-public-repos.XXXXXX") || return 1
-	printf '%s\n' '{"initialized_repos":[]}' >"$inventory" || return 1
-	export PRIVACY_REPOS_CONFIG="$inventory"
-	printf '%s\n' '::notice::Issue Sync is using an empty ephemeral private-entity registry for this isolated CI job.'
-	return 0
-}
-
-issue_sync_prepare_ci_privacy_inventory
 # shellcheck source=./shared-gh-wrappers.sh
 source "${ISSUE_SYNC_SCRIPT_DIR}/shared-gh-wrappers.sh"
 # shellcheck source=./issue-sync-lib-parse.sh

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -61,6 +61,12 @@ unset _issue_sync_path_input _issue_sync_path_tail _issue_sync_path_component
 # Keep SCRIPT_DIR for the public source contract, but use the private directory
 # for sibling loading so later modules cannot affect this helper's source chain.
 SCRIPT_DIR="$_issue_sync_script_dir"
+# Hosted runners do not have the user's repos.json. Establish a narrowly
+# scoped current-repository inventory before shared-constants loads the GitHub
+# write and privacy wrappers.
+# shellcheck source=./issue-sync-ci-context.sh
+source "${_issue_sync_script_dir}/issue-sync-ci-context.sh"
+issue_sync_prepare_ci_context
 source "${_issue_sync_script_dir}/shared-constants.sh"
 # shellcheck source=issue-sync-lib.sh
 source "${_issue_sync_script_dir}/issue-sync-lib.sh"

--- a/.agents/scripts/tests/test-issue-sync-ci-context.sh
+++ b/.agents/scripts/tests/test-issue-sync-ci-context.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${TEST_DIR}/.."
+CONTEXT_LIB="${SCRIPTS_DIR}/issue-sync-ci-context.sh"
+ISSUE_SYNC_HELPER="${SCRIPTS_DIR}/issue-sync-helper.sh"
+WORKFLOW="$(cd "${SCRIPTS_DIR}/../.." && pwd)/.github/workflows/issue-sync-reusable.yml"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+pass() {
+	printf 'PASS: %s\n' "$1"
+	return 0
+}
+fail() {
+	printf 'FAIL: %s\n' "$1" >&2
+	exit 1
+}
+
+if (
+	unset GITHUB_ACTIONS GITHUB_REPOSITORY PRIVACY_REPOS_CONFIG AIDEVOPS_REPOS_JSON
+	# shellcheck source=../issue-sync-ci-context.sh
+	source "$CONTEXT_LIB"
+	issue_sync_prepare_ci_context
+	[[ -z "${PRIVACY_REPOS_CONFIG:-}" && -z "${AIDEVOPS_REPOS_JSON:-}" ]]
+); then
+	pass "non-CI callers retain their existing repository context"
+else
+	fail "non-CI caller context changed"
+fi
+
+CI_HOME="$TMP/home"
+CI_TEMP="$TMP/runner"
+CI_ENV="$TMP/github-env"
+mkdir -p "$CI_HOME" "$CI_TEMP"
+if (
+	export HOME="$CI_HOME"
+	export RUNNER_TEMP="$CI_TEMP"
+	export GITHUB_ACTIONS=true
+	export GITHUB_REPOSITORY=example/repo
+	unset PRIVACY_REPOS_CONFIG AIDEVOPS_REPOS_JSON
+	# shellcheck source=../issue-sync-ci-context.sh
+	source "$CONTEXT_LIB"
+	issue_sync_write_ci_context_env "$CI_ENV"
+	[[ "$PRIVACY_REPOS_CONFIG" == "$AIDEVOPS_REPOS_JSON" ]]
+	jq -e '.initialized_repos == [{"slug":"example/repo","role":"maintainer"}]' \
+		"$PRIVACY_REPOS_CONFIG" >/dev/null
+	[[ "$(stat -c '%a' "$PRIVACY_REPOS_CONFIG" 2>/dev/null || stat -f '%Lp' "$PRIVACY_REPOS_CONFIG")" == "600" ]]
+	grep -Fxq "PRIVACY_REPOS_CONFIG=$PRIVACY_REPOS_CONFIG" "$CI_ENV"
+	grep -Fxq "AIDEVOPS_REPOS_JSON=$AIDEVOPS_REPOS_JSON" "$CI_ENV"
+); then
+	pass "hosted CI receives one current-repository privacy and write-policy inventory"
+else
+	fail "hosted CI inventory was missing, broad, or not private"
+fi
+
+if (
+	export HOME="$TMP/role-home"
+	export RUNNER_TEMP="$TMP/role-runner"
+	export GITHUB_ACTIONS=true
+	export GITHUB_REPOSITORY=example/repo
+	unset PRIVACY_REPOS_CONFIG AIDEVOPS_REPOS_JSON _ISSUE_SYNC_CI_CONTEXT_LOADED _GH_WRITE_POLICY_LIB_LOADED
+	mkdir -p "$HOME" "$RUNNER_TEMP"
+	# shellcheck source=../issue-sync-ci-context.sh
+	source "$CONTEXT_LIB"
+	issue_sync_prepare_ci_context >/dev/null
+	_SHIM_DIR="$SCRIPTS_DIR"
+	# shellcheck source=../gh-write-policy-lib.sh
+	source "${SCRIPTS_DIR}/gh-write-policy-lib.sh"
+	[[ "$(_shim_repo_role example/repo)" == "maintainer" ]]
+); then
+	pass "generated CI context authorizes only the workflow's current repository"
+else
+	fail "current repository remained classified as external in hosted CI"
+fi
+
+HELP_HOME="$TMP/help-home"
+HELP_TEMP="$TMP/help-runner"
+mkdir -p "$HELP_HOME" "$HELP_TEMP"
+if HOME="$HELP_HOME" RUNNER_TEMP="$HELP_TEMP" GITHUB_ACTIONS=true GITHUB_REPOSITORY=example/repo \
+	bash "$ISSUE_SYNC_HELPER" help >"$TMP/help.out" 2>"$TMP/help.err" &&
+	grep -q 'repository-scoped CI privacy and write-policy inventory' "$TMP/help.out" &&
+	jq -e '.initialized_repos[0].slug == "example/repo" and .initialized_repos[0].role == "maintainer"' \
+		"$HELP_TEMP"/aidevops-issue-sync-ci-context.* >/dev/null 2>&1; then
+	pass "Issue Sync prepares CI context before loading shared GitHub wrappers"
+else
+	fail "Issue Sync orchestrator did not establish CI context before wrapper loading"
+fi
+
+SETUP_LINE=$(awk '/name: Setup gh shim/{line=NR} END{print line}' "$WORKFLOW")
+# shellcheck disable=SC2016 # Match literal GitHub workflow shell variables.
+CONTEXT_LINE=$(awk '/issue_sync_write_ci_context_env "\$GITHUB_ENV"/{line=NR} END{print line}' "$WORKFLOW")
+# shellcheck disable=SC2016 # Match literal GitHub workflow shell variables.
+PATH_LINE=$(awk '/echo "\$\{SHIM_DIR\}" >> "\$GITHUB_PATH"/{line=NR} END{print line}' "$WORKFLOW")
+if [[ -n "$SETUP_LINE" && -n "$CONTEXT_LINE" && -n "$PATH_LINE" &&
+	"$SETUP_LINE" -lt "$CONTEXT_LINE" && "$CONTEXT_LINE" -lt "$PATH_LINE" ]]; then
+	pass "PR-merge inline writes inherit CI context before the gh shim activates"
+else
+	fail "PR-merge gh shim activated without a persisted current-repository context"
+fi
+
+if (
+	export HOME="$TMP/bad-home"
+	export RUNNER_TEMP="$TMP/bad-runner"
+	export GITHUB_ACTIONS=true
+	export GITHUB_REPOSITORY='not-a-slug'
+	unset PRIVACY_REPOS_CONFIG AIDEVOPS_REPOS_JSON _ISSUE_SYNC_CI_CONTEXT_LOADED
+	mkdir -p "$HOME" "$RUNNER_TEMP"
+	# shellcheck source=../issue-sync-ci-context.sh
+	source "$CONTEXT_LIB"
+	! issue_sync_prepare_ci_context >/dev/null 2>&1
+); then
+	pass "malformed CI repository identity fails closed"
+else
+	fail "malformed CI repository identity was accepted"
+fi
+
+printf 'PASS: issue sync CI context regressions\n'

--- a/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
+++ b/.agents/scripts/tests/test-issue-sync-git-push-helper.sh
@@ -421,8 +421,11 @@ test_protected_branch_uses_one_rebased_pr() {
 		fail "issue-sync PR title preserves merge-loop prevention"
 	elif [[ "$(<"${title_file}.body")" != *"Ref #9001"* ]]; then
 		fail "issue-sync PR body preserves changed-task linkage"
-	elif [[ "$(<"$output_a")" != *"empty ephemeral private-entity registry"* ]]; then
-		fail "GitHub Actions publication declares its isolated privacy inventory"
+	elif [[ "$(<"$output_a")" != *"repository-scoped CI privacy and write-policy inventory"* ]]; then
+		fail "GitHub Actions publication declares its scoped CI inventory"
+	elif ! jq -e '.initialized_repos == [{"slug":"example/repo","role":"maintainer"}]' \
+		"$output_a.runner"/aidevops-issue-sync-ci-context.* >/dev/null 2>&1; then
+		fail "GitHub Actions publication scopes write policy to the current repository"
 	elif [[ "$branch_message" == *"[skip ci]"* ]]; then
 		fail "issue-sync PR branch still runs required checks"
 	elif [[ "$(git -C "$work_a" status --short)" != *"TODO.md"* ||

--- a/.agents/scripts/tests/test-issue-sync-push-failures.sh
+++ b/.agents/scripts/tests/test-issue-sync-push-failures.sh
@@ -64,7 +64,16 @@ WORKFLOW="$ROOT_DIR/.github/workflows/issue-sync-reusable.yml"
 grep -q 'id: relationship-sync' "$WORKFLOW" || fail "workflow omitted explicit relationship recovery"
 grep -q 'issue-sync-helper.sh relationships --verbose' "$WORKFLOW" || fail "workflow did not retry durable relationship work"
 grep -q "steps.relationship-sync.outputs.pending == 'true'" "$WORKFLOW" || fail "workflow did not report unresolved relationships after persisting refs"
-pass "workflow persists refs before reporting unresolved relationship recovery"
+if awk '/name: Report deferred relationship sync/{capture=1} capture && /exit 1/{found=1} capture && /^      - name:/{if (++steps > 1) exit} END{exit found ? 0 : 1}' "$WORKFLOW"; then
+	fail "workflow treated expected deferred relationship work as a terminal CI failure"
+fi
+pass "workflow persists refs and reports expected relationship deferral without failing CI"
+
+# shellcheck disable=SC2016 # Assert the literal reusable-workflow expression.
+if grep -Fq 'GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}' "$WORKFLOW"; then
+	fail "workflow used the contents-only SYNC_PAT for issue API operations"
+fi
+pass "workflow reserves SYNC_PAT for contents publication and PR fallback"
 
 cat >"$TMPDIR_TEST/gh" <<'GH_EOF'
 #!/usr/bin/env bash

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -238,9 +238,9 @@ jobs:
           echo "=== Closing issues for completed tasks ==="
           bash __aidevops/.agents/scripts/issue-sync-helper.sh close --verbose || true
         env:
-          # t2166: SYNC_PAT || GITHUB_TOKEN so any downstream push inside the
-          # helper also gets PAT auth when available.
-          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+          # Issue API work uses the job-scoped token. SYNC_PAT is intentionally
+          # limited to contents publication and the bounded PR fallback.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push new tasks as issues
         if: steps.check-author.outputs.skip != 'true'
@@ -254,7 +254,7 @@ jobs:
             exit "$push_rc"
           fi
         env:
-          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # t1984: override origin detection and assignee target so issues
           # created from human-triggered TODO.md pushes get origin:interactive
           # and are assigned to the human pusher, not github-actions[bot].
@@ -278,7 +278,7 @@ jobs:
             echo "pending=true" >> "$GITHUB_OUTPUT"
           fi
         env:
-          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enrich plan-linked issues
         if: steps.check-author.outputs.skip != 'true'
@@ -286,7 +286,7 @@ jobs:
           echo "=== Enriching plan-linked issues ==="
           bash __aidevops/.agents/scripts/issue-sync-helper.sh enrich --verbose || true
         env:
-          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Push/release runs share a 20-minute budget with close/push/pull and
           # TODO.md push. Keep routine enrichment bounded; manual dispatch still
           # runs full `enrich` because these env vars are not set there.
@@ -299,7 +299,7 @@ jobs:
           echo "=== Pulling issue refs to TODO.md ==="
           bash __aidevops/.agents/scripts/issue-sync-helper.sh pull --verbose || true
         env:
-          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish TODO.md updates
         if: steps.check-author.outputs.skip != 'true'
@@ -319,13 +319,12 @@ jobs:
         run: |
           bash __aidevops/.agents/scripts/issue-sync-helper.sh status || true
         env:
-          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Report pending relationship sync
+      - name: Report deferred relationship sync
         if: steps.relationship-sync.outputs.pending == 'true'
         run: |
-          echo "Relationship sync remains pending after durable TODO.md ref persistence"
-          exit 1
+          echo "::warning::Relationship sync remains pending after durable TODO.md ref persistence; a later bounded reconciliation will retry it."
 
   sync-on-issue:
     name: Sync GitHub Issue → TODO.md
@@ -401,7 +400,7 @@ jobs:
       - name: Sync issue ref to TODO.md
         if: steps.check-issue.outputs.sync == 'true'
         env:
-          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TASK_ID: ${{ steps.check-issue.outputs.task_id }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
@@ -683,7 +682,7 @@ jobs:
 
       - name: Run sync command
         env:
-          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SYNC_COMMAND: ${{ inputs.command }}
         run: |
           chmod +x __aidevops/.agents/scripts/issue-sync-helper.sh
@@ -788,6 +787,11 @@ jobs:
                    "${SHIM_DIR}/gh-signature-helper.sh" \
                    "${SHIM_DIR}/aidevops-git-guard" \
                    2>/dev/null || true
+          # The shim is active before later inline issue writes, so persist the
+          # same current-repository privacy and write-policy context used by the
+          # standalone Issue Sync helpers.
+          source "${SHIM_DIR}/issue-sync-ci-context.sh"
+          issue_sync_write_ci_context_env "$GITHUB_ENV"
           echo "${SHIM_DIR}" >> "$GITHUB_PATH"
 
       - name: Extract task ID and collect linked issues


### PR DESCRIPTION
## Summary

- establish one ephemeral, current-repository CI inventory before Issue Sync loads privacy and GitHub write-policy wrappers
- persist that context before the PR-merge job activates its `gh` shim, preventing self-targeted writes from being classified as external
- use the job-scoped token for issue API work while reserving `SYNC_PAT` for contents publication and the bounded protected-branch PR fallback
- report bounded relationship reconciliation as deferred work instead of turning expected pending state into a terminal CI failure

## Evidence

- Post-merge push run `31432476912` logged missing `repos.json` privacy inventory and issue mutations rejected by the contents-oriented PAT.
- Post-merge PR-target run `31432475629` reached the protected-branch fallback, then the external-write guard blocked the job token before the PAT fallback failed `createPullRequest`.
- The shared setup now lives in `.agents/scripts/issue-sync-ci-context.sh`; both Issue Sync entry points load it before wrappers, and `.github/workflows/issue-sync-reusable.yml` persists it for inline PR-merge writes.

## Verification

- `bash .agents/scripts/tests/test-issue-sync-ci-context.sh`
- `bash .agents/scripts/tests/test-issue-sync-git-push-helper.sh`
- `bash .agents/scripts/tests/test-issue-sync-push-failures.sh`
- `bash .agents/scripts/tests/test-issue-sync-auth-capability.sh`
- `bash .agents/scripts/tests/test-issue-sync-pr-merge-checkout-order.sh`
- `bash .agents/scripts/tests/test-issue-sync-relationship-deadline.sh`
- `bash .agents/scripts/tests/test-issue-sync-relationship-resume.sh`
- `bash .agents/scripts/tests/test-reusable-workflow-caller.sh`
- `actionlint .github/workflows/issue-sync-reusable.yml`
- `.agents/scripts/linters-local.sh --changed`

Resolves #29956

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.250 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 21s and 24,174 tokens on this with the user in an interactive session.