### PR TITLE
GH#29965: stream large worktree recovery plans

### DIFF
--- a/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
+++ b/.agents/scripts/tests/test-worktree-recovery-lifecycle.sh
@@ -988,6 +988,89 @@ test_automatic_maintenance_rejects_symlink_cursor() {
 	return 0
 }
 
+test_large_plan_avoids_json_argv_limits() {
+	local output_path="${TEST_DIR}/large-plan.json"
+	local second_output_path="${TEST_DIR}/large-plan-second.json"
+	local padding=""
+	local detail=""
+	local output_size=0
+	local apply_entries=""
+	local apply_metadata=""
+	local expected_journal=""
+	local journal_path="${TEST_DIR}/large-apply-journal.json"
+	local rc=0
+
+	padding=$(printf '%060000d' 0) || rc=1
+	worktree_recovery_lifecycle_json() {
+		printf '%s\n' '{"error":"synthetic-incomplete","buckets":['
+		printf '%s\n' \
+			'{"role":"current","state":"unknown","path":"/recovery/bucket-1","bytes":null,"sizing_confidence":"unavailable"},' \
+			'{"role":"current","state":"unknown","path":"/recovery/bucket-2","bytes":null,"sizing_confidence":"unavailable"},' \
+			'{"role":"current","state":"unknown","path":"/recovery/bucket-3","bytes":null,"sizing_confidence":"unavailable"},' \
+			'{"role":"legacy","state":"unknown","path":"/recovery/bucket-4","bytes":null,"sizing_confidence":"unavailable"},' \
+			'{"role":"legacy","state":"unknown","path":"/recovery/bucket-5","bytes":null,"sizing_confidence":"unavailable"},' \
+			'{"role":"legacy","state":"unknown","path":"/recovery/bucket-6","bytes":null,"sizing_confidence":"unavailable"}'
+		printf '%s\n' ']}'
+		return 0
+	}
+	_worktree_recovery_plan_unknown_entry_json() {
+		local role="$1"
+		local bucket_path="$2"
+		local ignored_bytes="$3"
+		local reason="$4"
+		: "$ignored_bytes"
+		jq -cn --arg role "$role" --arg path "$bucket_path" --arg reason "$reason" \
+			--arg padding "$padding" \
+			'{role:$role,path:$path,archive_path:$path,expected_allocated_bytes:null,
+			disposition:"unknown",reasons:[$reason],evidence:{padding:$padding}}'
+		return $?
+	}
+	cmd_recovery plan --output "$output_path" >/dev/null || {
+		detail="first oversized plan write failed"
+		rc=1
+	}
+	cmd_recovery plan --output "$second_output_path" >/dev/null || {
+		detail="second oversized plan write failed"
+		rc=1
+	}
+	if [[ -f "$output_path" ]]; then
+		output_size=$(wc -c <"$output_path") || rc=1
+	fi
+	if [[ "$output_size" -le 300000 ]]; then
+		detail="oversized plan was only ${output_size} bytes"
+		rc=1
+	fi
+	jq -e '.entry_count == 6 and .candidate_count == 0 and .unknown_count == 6' \
+		"$output_path" >/dev/null || {
+		detail="oversized plan counts were invalid"
+		rc=1
+	}
+	if [[ "$(jq -r '.plan_id' "$output_path")" != "$(jq -r '.plan_id' "$second_output_path")" ]]; then
+		detail="oversized plan digest was not deterministic"
+		rc=1
+	fi
+	apply_entries=$(jq -c '[.entries | to_entries[] | {
+		index:.key,role:.value.role,original_path:.value.path,
+		staged_path:("/recovery/.trash/transaction/" + (.key | tostring)),
+		archive_name:("bucket-" + (.key | tostring)),
+		expected_allocated_bytes:.value.expected_allocated_bytes,
+		identity:.value.identity,evidence:.value.evidence,reasons:.value.reasons,
+		maintenance:null,state:"planned"}]' "$output_path") || rc=1
+	apply_metadata=$(jq -c '{plan_id,plan_digest:(.plan_id | sub("^sha256:"; "")),
+		confirmation:.confirmation_token,automatic_policy:null}' "$output_path") || rc=1
+	expected_journal=$(_worktree_recovery_apply_expected_journal \
+		"large-transaction" "$apply_metadata" "$apply_entries" "2026-08-10T00:00:00Z") || rc=1
+	printf '%s\n' "$expected_journal" >"$journal_path" || rc=1
+	_worktree_recovery_apply_validate_existing_journal \
+		"$journal_path" "$expected_journal" || {
+		detail="oversized apply journal validation failed"
+		rc=1
+	}
+	print_result "large_plan_avoids_json_argv_limits" "$rc" \
+		"${detail:-Expected a deterministic oversized plan without jq argv transport}"
+	return 0
+}
+
 # shellcheck source=../audit-worktree-removal-helper.sh
 source "${SCRIPTS_DIR}/audit-worktree-removal-helper.sh"
 # shellcheck source=../worktree-recovery-lifecycle-helper.sh
@@ -1018,5 +1101,6 @@ test_apply_handles_attributable_legacy_root_transaction
 test_automatic_maintenance_is_bounded_and_policy_bound
 test_automatic_maintenance_resumes_interrupted_apply
 test_automatic_maintenance_rejects_symlink_cursor
+test_large_plan_avoids_json_argv_limits
 printf '\nResults: %s run, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 [[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/worktree-recovery-apply-helper.sh
+++ b/.agents/scripts/worktree-recovery-apply-helper.sh
@@ -661,14 +661,14 @@ _worktree_recovery_apply_expected_journal() {
 	local entries_json="$3"
 	local started_at="$4"
 
-	jq -cn --arg schema "$WORKTREE_RECOVERY_APPLY_TRANSACTION_SCHEMA" \
+	printf '%s\n' "$entries_json" | jq -c --arg schema "$WORKTREE_RECOVERY_APPLY_TRANSACTION_SCHEMA" \
 		--arg transaction_id "$transaction_id" \
 		--arg plan_id "$(printf '%s\n' "$apply_metadata" | jq -r '.plan_id')" \
 		--arg plan_digest "$(printf '%s\n' "$apply_metadata" | jq -r '.plan_digest')" \
 		--arg confirmation "$(printf '%s\n' "$apply_metadata" | jq -r '.confirmation')" \
-		--arg started_at "$started_at" --argjson entries "$entries_json" \
+		--arg started_at "$started_at" \
 		--argjson automatic_policy "$(printf '%s\n' "$apply_metadata" | jq -c '.automatic_policy // null')" \
-		'({schema:$schema,transaction_id:$transaction_id,plan_id:$plan_id,
+		'. as $entries | ({schema:$schema,transaction_id:$transaction_id,plan_id:$plan_id,
 		plan_digest:$plan_digest,confirmation:$confirmation,started_at:$started_at,entries:$entries} +
 		(if $automatic_policy == null then {} else {automatic_policy:$automatic_policy} end))'
 	return $?
@@ -679,11 +679,12 @@ _worktree_recovery_apply_validate_existing_journal() {
 	local expected_journal="$2"
 
 	[[ -f "$journal_path" && ! -L "$journal_path" ]] || return 1
-	jq -e --argjson expected "$expected_journal" \
+	printf '%s\n' "$expected_journal" | jq -e --slurpfile actual "$journal_path" \
 		--arg planned "$WORKTREE_RECOVERY_APPLY_STATE_PLANNED" \
 		--arg staged "$WORKTREE_RECOVERY_APPLY_STATE_STAGED" \
 		--arg removed "$WORKTREE_RECOVERY_APPLY_STATE_REMOVED" \
 		--arg string_type "$WORKTREE_RECOVERY_APPLY_JSON_TYPE_STRING" '
+		. as $expected | $actual[0] |
 		.schema == $expected.schema and .transaction_id == $expected.transaction_id and
 		.plan_id == $expected.plan_id and .plan_digest == $expected.plan_digest and
 		.confirmation == $expected.confirmation and (.started_at | type == $string_type) and
@@ -693,7 +694,7 @@ _worktree_recovery_apply_validate_existing_journal() {
 			expected_allocated_bytes,identity,evidence,reasons,maintenance}] ==
 			 [$expected.entries[] | {index,role,original_path,staged_path,archive_name,
 			expected_allocated_bytes,identity,evidence,reasons,maintenance}])
-	' "$journal_path" >/dev/null 2>&1
+	' >/dev/null 2>&1
 	return $?
 }
 

--- a/.agents/scripts/worktree-recovery-lifecycle-helper.sh
+++ b/.agents/scripts/worktree-recovery-lifecycle-helper.sh
@@ -832,8 +832,8 @@ _worktree_recovery_plan_entries_json() {
 		entries_json=$(jq -sc 'sort_by(.path)' "$entries_file") || result_status=1
 	fi
 	if [[ "$result_status" -eq 0 ]]; then
-		jq -cn --arg error "$inventory_error" --argjson entries "$entries_json" \
-			'{inventory_complete:($error == ""),inventory_error:(if $error == "" then null else $error end),entries:$entries}' || result_status=1
+		printf '%s\n' "$entries_json" | jq -c --arg error "$inventory_error" \
+			'. as $entries | {inventory_complete:($error == ""),inventory_error:(if $error == "" then null else $error end),entries:$entries}' || result_status=1
 	fi
 	rm -f "$entries_file" "$rows_file"
 	return "$result_status"
@@ -853,21 +853,20 @@ worktree_recovery_plan_json() {
 	entries_json=$(printf '%s\n' "$entries_bundle" | jq -c '.entries') || return 1
 	inventory_complete=$(printf '%s\n' "$entries_bundle" | jq -c '.inventory_complete') || return 1
 	inventory_error=$(printf '%s\n' "$entries_bundle" | jq -r '.inventory_error // empty') || return 1
-	plan_material=$(jq -cn --arg schema "$WORKTREE_RECOVERY_PLAN_SCHEMA" \
+	plan_material=$(printf '%s\n' "$entries_json" | jq -c --arg schema "$WORKTREE_RECOVERY_PLAN_SCHEMA" \
 		--arg error "$inventory_error" --argjson complete "$inventory_complete" \
-		--argjson entries "$entries_json" \
-		'{schema:$schema,inventory_complete:$complete,inventory_error:(if $error == "" then null else $error end),entries:$entries}') || return 1
+		'. as $entries | {schema:$schema,inventory_complete:$complete,inventory_error:(if $error == "" then null else $error end),entries:$entries}') || return 1
 	plan_digest=$(_worktree_recovery_plan_sha256_text "$plan_material") || return 1
 	generated_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
-	plan_json=$(jq -cn --arg schema "$WORKTREE_RECOVERY_PLAN_SCHEMA" \
+	plan_json=$(printf '%s\n' "$entries_json" | jq -c --arg schema "$WORKTREE_RECOVERY_PLAN_SCHEMA" \
 		--arg plan_id "sha256:$plan_digest" --arg generated_at "$generated_at" \
 		--arg producer "$WORKTREE_RECOVERY_PRODUCER" \
 		--arg candidate "$WORKTREE_RECOVERY_PLAN_DISPOSITION_CANDIDATE" \
 		--arg protected "$WORKTREE_RECOVERY_PLAN_DISPOSITION_PROTECTED" \
 		--arg unknown "$WORKTREE_RECOVERY_PLAN_DISPOSITION_UNKNOWN" \
-		--arg error "$inventory_error" --argjson complete "$inventory_complete" \
-		--argjson entries "$entries_json" '
+		--arg error "$inventory_error" --argjson complete "$inventory_complete" '
 		def parent_path: .[0:rindex("/")];
+		. as $entries |
 		{schema:$schema,producer:$producer,plan_id:$plan_id,generated_at:$generated_at,read_only:true,
 		inventory_complete:$complete,inventory_error:(if $error == "" then null else $error end),
 		source_roots:([$entries[].path | parent_path] | unique),


### PR DESCRIPTION
## Summary

Replace unbounded jq argv transport in recovery planning and apply journal validation with stdin/slurpfile input while preserving deterministic manifests and fail-closed behavior.

## Files Changed

.agents/scripts/tests/test-worktree-recovery-lifecycle.sh, .agents/scripts/worktree-recovery-apply-helper.sh, .agents/scripts/worktree-recovery-lifecycle-helper.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified: worktree recovery lifecycle suite passes 20/20 including real plan/apply removal and a deterministic >300KB plan/apply journal regression; ShellCheck passes on all changed shell files; review bundle 2dd78a4b7ea6244afdac68e77ada9391c1122c41fcfc08d779a8ed42c6efa011 (prompt scan medium is the literal JSON role fixture, manually verified non-instructional).

Resolves #29965


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.250 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 5m and 189,278 tokens on this with the user in an interactive session.