### PR TITLE
GH#29956: trust generated Issue Sync review gates

### DIFF
--- a/.agents/reference/review-bot-gate.md
+++ b/.agents/reference/review-bot-gate.md
@@ -118,6 +118,11 @@ The review add-on check runs after the `origin:interactive` (t2411) and
   project CI and independent trust gates pass; bot response time is irrelevant.
 - **Strict repositories**: `completion_behavior: strict` requires settled review
   evidence. `min_edit_lag_seconds` still protects CodeRabbit's two-phase pattern.
+- **Repository-generated Issue Sync PRs**: GitHub reports the official Actions bot
+  as `CONTRIBUTOR`. The reusable gate normalizes it as internal only when the
+  immutable bot ID/type, same-repository head and base, deterministic
+  `aidevops/issue-sync-todo` branch, and generated body marker all match. Any
+  missing or mismatched field remains external and fail-closed.
 - **External contributors**: advisory, rate-limit, and skip outcomes remain
   fail-closed; completed review evidence is required in addition to independent
   maintainer/cryptographic authority.

--- a/.agents/scripts/tests/test-linked-issue-guidance.sh
+++ b/.agents/scripts/tests/test-linked-issue-guidance.sh
@@ -62,7 +62,9 @@ assert_contains ".github/workflows/linked-issue-check-reusable.yml" 'body\.match
 assert_contains ".github/workflows/linked-issue-check-reusable.yml" '#aidevops:trust-boundary GH#17671/GH#28567' "linked issue trust check carries boundary marker"
 assert_not_contains ".github/workflows/linked-issue-check-reusable.yml" 'if \(/\^\(t\\d' "untrusted linked issue path has no title-only exemption"
 
-assert_contains ".github/workflows/pr-triage-gate.yml" "const trustedRoles = \\['OWNER', 'MEMBER', 'COLLABORATOR'\\]" "PR triage preserves trusted author controls"
+assert_contains ".github/workflows/pr-triage-gate.yml" "const trustedRoles = \\['OWNER', 'MEMBER'\\]" "PR triage preserves owner and member trust controls"
+assert_contains ".github/workflows/pr-triage-gate.yml" "association === 'COLLABORATOR'" "PR triage verifies collaborator authority"
+assert_contains ".github/workflows/pr-triage-gate.yml" "\\['admin', 'maintain', 'write'\\]\\.includes" "PR triage requires collaborator write authority"
 assert_contains ".github/workflows/pr-triage-gate.yml" "pr.user.type === 'Bot'" "PR triage preserves bot control"
 assert_contains ".github/workflows/pr-triage-gate.yml" '#aidevops:trust-boundary GH#17671/GH#28567' "PR triage trust check carries boundary marker"
 assert_not_contains ".github/workflows/pr-triage-gate.yml" 'const title = pr\.title|/\^t\\d|/\^GH#\\d' "PR triage gives tNNN and GH#NNN titles no trust"

--- a/.agents/scripts/tests/test-review-bot-gate-issue-sync-trust.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-issue-sync-trust.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Verify the reusable review gate's exact repository-generated Issue Sync trust
+# classifier without duplicating its security-sensitive shell logic.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+WORKFLOW_FILE="${REPO_ROOT}/.github/workflows/review-bot-gate-reusable.yml"
+STATE_DIR="$(mktemp -d)"
+trap 'rm -rf "${STATE_DIR}"' EXIT
+
+START_COUNT=$(grep -Fc '# aidevops:review-gate-trust-start' "${WORKFLOW_FILE}")
+END_COUNT=$(grep -Fc '# aidevops:review-gate-trust-end' "${WORKFLOW_FILE}")
+if [[ "${START_COUNT}" -ne 1 || "${END_COUNT}" -ne 1 ]]; then
+	printf 'FAIL: expected one review-gate trust classifier block\n' >&2
+	exit 1
+fi
+
+CLASSIFIER=$(awk '
+	/# aidevops:review-gate-trust-start/ { capture = 1; next }
+	/# aidevops:review-gate-trust-end/ { capture = 0 }
+	capture { sub(/^          /, ""); print }
+' "${WORKFLOW_FILE}")
+if [[ -z "${CLASSIFIER}" ]]; then
+	printf 'FAIL: review-gate trust classifier extraction was empty\n' >&2
+	exit 1
+fi
+
+assert_output() {
+	local output_file="$1"
+	local key="$2"
+	local expected="$3"
+	local case_name="$4"
+	if ! grep -Fxq "${key}=${expected}" "${output_file}"; then
+		printf 'FAIL: %s expected %s=%s\n' "${case_name}" "${key}" "${expected}" >&2
+		return 1
+	fi
+	return 0
+}
+
+CASE_INDEX=0
+run_case() {
+	local case_name="$1"
+	local expected_external="$2"
+	local expected_trusted="$3"
+	local expected_association="$4"
+	local expected_rate_limit="$5"
+	local expected_completion="$6"
+	local author_association="$7"
+	local author_login="$8"
+	local author_id="$9"
+	local author_type="${10}"
+	local head_repository="${11}"
+	local base_repository="${12}"
+	local head_ref="${13}"
+	local pr_body="${14}"
+	local output_file=""
+
+	CASE_INDEX=$((CASE_INDEX + 1))
+	output_file="${STATE_DIR}/case-${CASE_INDEX}.out"
+	if ! GITHUB_OUTPUT="${output_file}" \
+		REPO="marcusquinn/aidevops" \
+		REVIEW_GATE_AUTHOR_ASSOCIATION="${author_association}" \
+		REVIEW_GATE_PR_AUTHOR_LOGIN="${author_login}" \
+		REVIEW_GATE_PR_AUTHOR_ID="${author_id}" \
+		REVIEW_GATE_PR_AUTHOR_TYPE="${author_type}" \
+		REVIEW_GATE_PR_HEAD_REPOSITORY="${head_repository}" \
+		REVIEW_GATE_PR_BASE_REPOSITORY="${base_repository}" \
+		REVIEW_GATE_PR_HEAD_REF="${head_ref}" \
+		REVIEW_GATE_PR_BODY="${pr_body}" \
+		REVIEW_GATE_RATE_LIMIT_BEHAVIOR=pass \
+		REVIEW_GATE_COMPLETION_BEHAVIOR=fast \
+		bash -c "${CLASSIFIER}" >/dev/null; then
+		printf 'FAIL: %s classifier execution failed\n' "${case_name}" >&2
+		return 1
+	fi
+
+	assert_output "${output_file}" is_external_pr "${expected_external}" "${case_name}"
+	assert_output "${output_file}" trusted_issue_sync_pr "${expected_trusted}" "${case_name}"
+	assert_output "${output_file}" effective_author_association "${expected_association}" "${case_name}"
+	assert_output "${output_file}" effective_rate_limit_behavior "${expected_rate_limit}" "${case_name}"
+	assert_output "${output_file}" effective_completion_behavior "${expected_completion}" "${case_name}"
+	printf 'PASS: %s\n' "${case_name}"
+	return 0
+}
+
+MARKER='<!-- aidevops:issue-sync-todo-pr -->'
+
+run_case \
+	'official same-repository Issue Sync bot is trusted' \
+	false true COLLABORATOR pass fast \
+	CONTRIBUTOR 'github-actions[bot]' 41898282 Bot \
+	'marcusquinn/aidevops' 'marcusquinn/aidevops' \
+	'aidevops/issue-sync-todo' "${MARKER}"
+
+run_case \
+	'owner association remains trusted without automation normalization' \
+	false false OWNER pass fast \
+	OWNER maintainer 123 User \
+	'marcusquinn/aidevops' 'marcusquinn/aidevops' \
+	'feature/example' 'ordinary pull request'
+
+run_case \
+	'external user cannot spoof marker and deterministic branch' \
+	true false CONTRIBUTOR wait strict \
+	CONTRIBUTOR attacker 999 User \
+	'marcusquinn/aidevops' 'marcusquinn/aidevops' \
+	'aidevops/issue-sync-todo' "${MARKER}"
+
+run_case \
+	'lookalike bot ID remains external' \
+	true false CONTRIBUTOR wait strict \
+	CONTRIBUTOR 'github-actions[bot]' 999 Bot \
+	'marcusquinn/aidevops' 'marcusquinn/aidevops' \
+	'aidevops/issue-sync-todo' "${MARKER}"
+
+run_case \
+	'forked Issue Sync branch remains external' \
+	true false CONTRIBUTOR wait strict \
+	CONTRIBUTOR 'github-actions[bot]' 41898282 Bot \
+	'attacker/aidevops' 'marcusquinn/aidevops' \
+	'aidevops/issue-sync-todo' "${MARKER}"
+
+run_case \
+	'wrong same-repository branch remains external' \
+	true false CONTRIBUTOR wait strict \
+	CONTRIBUTOR 'github-actions[bot]' 41898282 Bot \
+	'marcusquinn/aidevops' 'marcusquinn/aidevops' \
+	'feature/not-issue-sync' "${MARKER}"
+
+run_case \
+	'missing generated marker remains external' \
+	true false CONTRIBUTOR wait strict \
+	CONTRIBUTOR 'github-actions[bot]' 41898282 Bot \
+	'marcusquinn/aidevops' 'marcusquinn/aidevops' \
+	'aidevops/issue-sync-todo' 'ordinary pull request'
+
+printf 'All review-bot Issue Sync trust tests passed.\n'

--- a/.github/workflows/review-bot-gate-reusable.yml
+++ b/.github/workflows/review-bot-gate-reusable.yml
@@ -131,13 +131,40 @@ jobs:
           REVIEW_GATE_EVIDENCE_HEAD_SHA: ${{ github.event.review.commit_id || github.event.comment.commit_id || '' }}
           REVIEW_GATE_EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
           REVIEW_GATE_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association || github.event.issue.author_association || '' }}
+          REVIEW_GATE_PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login || github.event.issue.user.login || '' }}
+          REVIEW_GATE_PR_AUTHOR_ID: ${{ github.event.pull_request.user.id || github.event.issue.user.id || '' }}
+          REVIEW_GATE_PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type || github.event.issue.user.type || '' }}
+          REVIEW_GATE_PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || '' }}
+          REVIEW_GATE_PR_BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name || '' }}
+          REVIEW_GATE_PR_HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
+          REVIEW_GATE_PR_BODY: ${{ github.event.pull_request.body || github.event.issue.body || '' }}
           REVIEW_GATE_RATE_LIMIT_BEHAVIOR: ${{ inputs.rate_limit_behavior }}
           REVIEW_GATE_COMPLETION_BEHAVIOR: ${{ inputs.completion_behavior }}
         run: |
           echo "Checking PR #${PR_NUMBER} for AI review bot activity..."
 
+          # GitHub reports its official Actions bot as CONTRIBUTOR even when a
+          # repository workflow creates a same-repository PR. Normalize only the
+          # deterministic Issue Sync identity: official immutable bot ID/type,
+          # same repository on both sides, fixed branch, and generated body marker.
+          # Any missing or mismatched field remains external and fail-closed.
+          # aidevops:review-gate-trust-start
+          TRUSTED_ISSUE_SYNC_PR=false
+          #aidevops:trust-boundary
+          if [[ "${REVIEW_GATE_PR_AUTHOR_LOGIN}" == "github-actions[bot]" ]] &&
+            [[ "${REVIEW_GATE_PR_AUTHOR_ID}" == "41898282" ]] &&
+            [[ "${REVIEW_GATE_PR_AUTHOR_TYPE}" == "Bot" ]] &&
+            [[ "${REVIEW_GATE_PR_HEAD_REPOSITORY}" == "${REPO}" ]] &&
+            [[ "${REVIEW_GATE_PR_BASE_REPOSITORY}" == "${REPO}" ]] &&
+            [[ "${REVIEW_GATE_PR_HEAD_REF}" == "aidevops/issue-sync-todo" ]] &&
+            [[ "${REVIEW_GATE_PR_BODY}" == *"<!-- aidevops:issue-sync-todo-pr -->"* ]]; then
+            TRUSTED_ISSUE_SYNC_PR=true
+          fi
+
           # Check if this is an external contributor PR using immutable event
-          # evidence, so API exhaustion cannot accidentally grant trust.
+          # evidence, so API exhaustion cannot accidentally grant trust. The
+          # normalized association is exported because the fetched helper
+          # independently enforces the same external-author boundary.
           # GH#17671: external-contributor PRs retain defence-in-depth review;
           # advisory completion and rate-limit grace are both disabled.
           #aidevops:trust-boundary
@@ -146,14 +173,25 @@ jobs:
             IS_EXTERNAL_PR=false
             ;;
           *)
-            IS_EXTERNAL_PR=true
-            echo "External contributor PR detected — advisory review bypass DISABLED"
-            #aidevops:trust-boundary
-            export REVIEW_GATE_RATE_LIMIT_BEHAVIOR=wait
-            export REVIEW_GATE_COMPLETION_BEHAVIOR=strict
+            if [[ "${TRUSTED_ISSUE_SYNC_PR}" == "true" ]]; then
+              export REVIEW_GATE_AUTHOR_ASSOCIATION=COLLABORATOR
+              IS_EXTERNAL_PR=false
+              echo "Trusted repository-generated Issue Sync PR detected — applying internal advisory policy"
+            else
+              IS_EXTERNAL_PR=true
+              echo "External contributor PR detected — advisory review bypass DISABLED"
+              #aidevops:trust-boundary
+              export REVIEW_GATE_RATE_LIMIT_BEHAVIOR=wait
+              export REVIEW_GATE_COMPLETION_BEHAVIOR=strict
+            fi
             ;;
           esac
           echo "is_external_pr=${IS_EXTERNAL_PR}" >> "${GITHUB_OUTPUT}"
+          echo "trusted_issue_sync_pr=${TRUSTED_ISSUE_SYNC_PR}" >> "${GITHUB_OUTPUT}"
+          echo "effective_author_association=${REVIEW_GATE_AUTHOR_ASSOCIATION}" >> "${GITHUB_OUTPUT}"
+          echo "effective_rate_limit_behavior=${REVIEW_GATE_RATE_LIMIT_BEHAVIOR}" >> "${GITHUB_OUTPUT}"
+          echo "effective_completion_behavior=${REVIEW_GATE_COMPLETION_BEHAVIOR}" >> "${GITHUB_OUTPUT}"
+          # aidevops:review-gate-trust-end
 
           # Invoke the framework helper (runtime-fetched via __aidevops/).
           # All gate logic lives in the helper:


### PR DESCRIPTION
## Summary

Normalize only the official same-repository GitHub Actions Issue Sync PR identity as trusted so default advisory review policy can apply without weakening external contributor gates.

## Files Changed

.agents/reference/review-bot-gate.md, .agents/scripts/tests/test-linked-issue-guidance.sh, .agents/scripts/tests/test-review-bot-gate-issue-sync-trust.sh, .github/workflows/review-bot-gate-reusable.yml

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — Focused seven-case trust matrix, review-gate completion and API snapshot suites, reusable-workflow checks, PR-triage fail-closed checks, Actionlint, ShellCheck, and linters-local --changed all pass.

Resolves #29956


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.250 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 17m and 798,352 tokens on this with the user in an interactive session.