### PR TITLE
GH#29963: report effective OpenCode plugin health

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -85,6 +85,7 @@ import { startCursorProxy, ensureCursorProxyServer } from "./cursor-proxy.mjs";
 import { startGoogleProxy, ensureGoogleProxyServer } from "./google-proxy.mjs";
 import { startClaudeProxy } from "./claude-proxy.mjs";
 import { isHeadless } from "./proxy-lifecycle.mjs";
+import { recordPluginHealthStage } from "./plugin-health.mjs";
 
 // ---------------------------------------------------------------------------
 // Directory constants
@@ -111,6 +112,8 @@ const SCRIPTS_DIR = join(AGENTS_DIR, "scripts");
 const PLUGIN_DIR = join(AGENTS_DIR, "plugins", "opencode-aidevops");
 const WORKSPACE_DIR = join(HOME, ".aidevops", ".agent-workspace");
 const LOGS_DIR = join(HOME, ".aidevops", "logs");
+
+recordPluginHealthStage("imported");
 
 // Keep the immutable bundle backing this process until OpenCode exits. Setup
 // also applies an age floor for sessions started before lease support existed.
@@ -481,6 +484,11 @@ export async function AidevopsPlugin({ directory, client }) {
     }
   };
 
+  recordPluginHealthStage("factory_initialized", {
+    config_hook: true,
+    terminal_title_status: true,
+  });
+
   return {
     // Config: agent index, MCP registration, OAuth pool injection
     config: async (config) => {
@@ -488,7 +496,12 @@ export async function AidevopsPlugin({ directory, client }) {
       // on client.auth.set() inside the config hook. Fire-and-forget so
       // the config hook can complete and the session becomes responsive.
       initPoolAuth(client).catch(() => {});
-      return configHook(config);
+      const result = await configHook(config);
+      recordPluginHealthStage("config_applied", {
+        gpt56_limits: config.provider?.openai?.models?.["gpt-5.6-sol"]?.limit || null,
+        terminal_title_status: true,
+      });
+      return result;
     },
 
     // Custom tools + pool management

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -85,7 +85,7 @@ import { startCursorProxy, ensureCursorProxyServer } from "./cursor-proxy.mjs";
 import { startGoogleProxy, ensureGoogleProxyServer } from "./google-proxy.mjs";
 import { startClaudeProxy } from "./claude-proxy.mjs";
 import { isHeadless } from "./proxy-lifecycle.mjs";
-import { recordPluginHealthStage } from "./plugin-health.mjs";
+import { pluginHealthProbeRequested, recordPluginHealthStage } from "./plugin-health.mjs";
 
 // ---------------------------------------------------------------------------
 // Directory constants
@@ -294,7 +294,7 @@ export async function AidevopsPlugin({ directory, client }) {
     return createConversationHooks({client, conversation, directory});
   }
 
-  if (process.env.AIDEVOPS_PLUGIN_HEALTH_PROBE_ONLY === "1") {
+  if (pluginHealthProbeRequested()) {
     const modelRouting = loadModelRouting([
       process.env.AIDEVOPS_MODEL_ROUTING_TABLE,
       join(AGENTS_DIR, "custom", "configs", "model-routing-table.json"),

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -294,6 +294,39 @@ export async function AidevopsPlugin({ directory, client }) {
     return createConversationHooks({client, conversation, directory});
   }
 
+  if (process.env.AIDEVOPS_PLUGIN_HEALTH_PROBE_ONLY === "1") {
+    const modelRouting = loadModelRouting([
+      process.env.AIDEVOPS_MODEL_ROUTING_TABLE,
+      join(AGENTS_DIR, "custom", "configs", "model-routing-table.json"),
+      join(AGENTS_DIR, "configs", "model-routing-table.json"),
+    ]);
+    const configHook = createConfigHook({
+      agentsDir: AGENTS_DIR,
+      workspaceDir: WORKSPACE_DIR,
+      pluginDir: PLUGIN_DIR,
+      repositoryDir: directory,
+      conversation,
+      modelRouting,
+      agentRoutingState: { tiers: new Map(), pinned: new Set() },
+    });
+    const sessionTitleStatusHandler = createSessionTitleStatusHandler({ isHeadless });
+    recordPluginHealthStage("factory_initialized", {
+      config_hook: true,
+      terminal_title_status: true,
+    });
+    return {
+      config: async (config) => {
+        const result = await configHook(config);
+        recordPluginHealthStage("config_applied", {
+          gpt56_limits: config.provider?.openai?.models?.["gpt-5.6-sol"]?.limit || null,
+          terminal_title_status: true,
+        });
+        return result;
+      },
+      event: sessionTitleStatusHandler,
+    };
+  }
+
   // Initialise LLM observability
   initObservability({ aidevopsVersion: currentAidevopsVersion() });
 

--- a/.agents/plugins/opencode-aidevops/plugin-health.mjs
+++ b/.agents/plugins/opencode-aidevops/plugin-health.mjs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+
+export const PLUGIN_HEALTH_SCHEMA = "aidevops.opencode-plugin-health/v1";
+
+function probeTarget(env) {
+  const filePath = env.AIDEVOPS_PLUGIN_HEALTH_PROBE_FILE || "";
+  const nonce = env.AIDEVOPS_PLUGIN_HEALTH_PROBE_NONCE || "";
+  if (!filePath || !/^[a-zA-Z0-9._:-]{16,128}$/.test(nonce)) return null;
+
+  const tempRoot = resolve(
+    env.AIDEVOPS_TEMP_DIR || join(homedir(), ".aidevops", ".agent-workspace", "tmp"),
+  );
+  try {
+    const root = realpathSync(tempRoot);
+    const parent = realpathSync(dirname(filePath));
+    const relativeParent = relative(root, parent);
+    if (relativeParent === ".." || relativeParent.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`)) {
+      return null;
+    }
+    const metadata = lstatSync(filePath);
+    if (!metadata.isFile() || metadata.isSymbolicLink() || (metadata.mode & 0o077) !== 0) return null;
+    return { filePath: realpathSync(filePath), nonce };
+  } catch {
+    return null;
+  }
+}
+
+export function recordPluginHealthStage(stage, details = {}, env = process.env) {
+  const target = probeTarget(env);
+  if (!target || !/^[a-z_]{3,32}$/.test(stage)) return false;
+
+  let current;
+  try {
+    current = JSON.parse(readFileSync(target.filePath, "utf8"));
+  } catch {
+    return false;
+  }
+  if (current?.nonce !== target.nonce) return false;
+
+  const stages = Array.isArray(current.stages) ? current.stages.filter((value) => typeof value === "string") : [];
+  if (!stages.includes(stage)) stages.push(stage);
+  const next = {
+    schema: PLUGIN_HEALTH_SCHEMA,
+    nonce: target.nonce,
+    stages,
+    details: { ...(current.details || {}), [stage]: details },
+  };
+  const tempPath = `${target.filePath}.next-${process.pid}`;
+  try {
+    if (existsSync(tempPath)) rmSync(tempPath);
+    writeFileSync(tempPath, `${JSON.stringify(next)}\n`, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    chmodSync(tempPath, 0o600);
+    renameSync(tempPath, target.filePath);
+    return true;
+  } catch {
+    try {
+      rmSync(tempPath);
+    } catch {
+      // Probe reporting is diagnostic-only and must never break plugin startup.
+    }
+    return false;
+  }
+}

--- a/.agents/plugins/opencode-aidevops/plugin-health.mjs
+++ b/.agents/plugins/opencode-aidevops/plugin-health.mjs
@@ -39,6 +39,10 @@ function probeTarget(env) {
   }
 }
 
+export function pluginHealthProbeRequested(env = process.env) {
+  return env.AIDEVOPS_PLUGIN_HEALTH_PROBE_ONLY === "1" && Boolean(probeTarget(env));
+}
+
 export function recordPluginHealthStage(stage, details = {}, env = process.env) {
   const target = probeTarget(env);
   if (!target || !/^[a-z_]{3,32}$/.test(stage)) return false;

--- a/.agents/plugins/opencode-aidevops/tests/test-plugin-health.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-plugin-health.mjs
@@ -5,6 +5,7 @@ import assert from "node:assert/strict";
 import { chmodSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 
 import { PLUGIN_HEALTH_SCHEMA, recordPluginHealthStage } from "../plugin-health.mjs";
@@ -47,5 +48,45 @@ test("plugin health rejects nonce mismatch, loose modes, and symlinks", () => {
   chmodSync(receipt, 0o600);
   symlinkSync(receipt, linked);
   assert.equal(recordPluginHealthStage("imported", {}, { ...baseEnv, AIDEVOPS_PLUGIN_HEALTH_PROBE_FILE: linked }), false);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("probe-only plugin factory registers config and terminal-title health", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-plugin-health-factory-"));
+  const receipt = join(root, "receipt.json");
+  const nonce = "probe-factory-0123456789";
+  const pluginUrl = new URL("../index.mjs", import.meta.url).href;
+  writeFileSync(receipt, `${JSON.stringify({ nonce, stages: [], details: {} })}\n`, { mode: 0o600 });
+
+  const child = spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      `const plugin = await import(${JSON.stringify(pluginUrl)});
+       const hooks = await plugin.AidevopsPlugin({directory: process.cwd(), client: {}});
+       await hooks.config({});`,
+    ],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        AIDEVOPS_TEMP_DIR: root,
+        AIDEVOPS_PLUGIN_HEALTH_PROBE_FILE: receipt,
+        AIDEVOPS_PLUGIN_HEALTH_PROBE_NONCE: nonce,
+        AIDEVOPS_PLUGIN_HEALTH_PROBE_ONLY: "1",
+      },
+    },
+  );
+  assert.equal(child.status, 0, child.stderr);
+  const result = JSON.parse(readFileSync(receipt, "utf8"));
+  assert.deepEqual(result.stages, ["imported", "factory_initialized", "config_applied"]);
+  assert.equal(result.details.factory_initialized.terminal_title_status, true);
+  assert.deepEqual(result.details.config_applied.gpt56_limits, {
+    output: 128000,
+    context: 300000,
+    input: 260000,
+  });
   rmSync(root, { recursive: true, force: true });
 });

--- a/.agents/plugins/opencode-aidevops/tests/test-plugin-health.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-plugin-health.mjs
@@ -8,7 +8,11 @@ import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 
-import { PLUGIN_HEALTH_SCHEMA, recordPluginHealthStage } from "../plugin-health.mjs";
+import {
+  PLUGIN_HEALTH_SCHEMA,
+  pluginHealthProbeRequested,
+  recordPluginHealthStage,
+} from "../plugin-health.mjs";
 
 test("plugin health stages are nonce-bound and atomically accumulated", () => {
   const root = mkdtempSync(join(tmpdir(), "aidevops-plugin-health-"));
@@ -21,6 +25,8 @@ test("plugin health stages are nonce-bound and atomically accumulated", () => {
     AIDEVOPS_PLUGIN_HEALTH_PROBE_NONCE: nonce,
   };
 
+  assert.equal(pluginHealthProbeRequested({ ...env, AIDEVOPS_PLUGIN_HEALTH_PROBE_ONLY: "1" }), true);
+  assert.equal(pluginHealthProbeRequested({ AIDEVOPS_PLUGIN_HEALTH_PROBE_ONLY: "1" }), false);
   assert.equal(recordPluginHealthStage("imported", {}, env), true);
   assert.equal(recordPluginHealthStage("config_applied", { gpt56_limits: { context: 300000 } }, env), true);
   const result = JSON.parse(readFileSync(receipt, "utf8"));

--- a/.agents/plugins/opencode-aidevops/tests/test-plugin-health.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-plugin-health.mjs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { PLUGIN_HEALTH_SCHEMA, recordPluginHealthStage } from "../plugin-health.mjs";
+
+test("plugin health stages are nonce-bound and atomically accumulated", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-plugin-health-"));
+  const receipt = join(root, "receipt.json");
+  const nonce = "probe-0123456789abcdef";
+  writeFileSync(receipt, `${JSON.stringify({ nonce, stages: [], details: {} })}\n`, { mode: 0o600 });
+  const env = {
+    AIDEVOPS_TEMP_DIR: root,
+    AIDEVOPS_PLUGIN_HEALTH_PROBE_FILE: receipt,
+    AIDEVOPS_PLUGIN_HEALTH_PROBE_NONCE: nonce,
+  };
+
+  assert.equal(recordPluginHealthStage("imported", {}, env), true);
+  assert.equal(recordPluginHealthStage("config_applied", { gpt56_limits: { context: 300000 } }, env), true);
+  const result = JSON.parse(readFileSync(receipt, "utf8"));
+  assert.equal(result.schema, PLUGIN_HEALTH_SCHEMA);
+  assert.deepEqual(result.stages, ["imported", "config_applied"]);
+  assert.equal(result.details.config_applied.gpt56_limits.context, 300000);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("plugin health rejects nonce mismatch, loose modes, and symlinks", () => {
+  const root = mkdtempSync(join(tmpdir(), "aidevops-plugin-health-deny-"));
+  const receipt = join(root, "receipt.json");
+  const linked = join(root, "linked.json");
+  const nonce = "probe-fedcba9876543210";
+  writeFileSync(receipt, `${JSON.stringify({ nonce, stages: [] })}\n`, { mode: 0o600 });
+  const baseEnv = {
+    AIDEVOPS_TEMP_DIR: root,
+    AIDEVOPS_PLUGIN_HEALTH_PROBE_FILE: receipt,
+    AIDEVOPS_PLUGIN_HEALTH_PROBE_NONCE: nonce,
+  };
+
+  assert.equal(recordPluginHealthStage("imported", {}, { ...baseEnv, AIDEVOPS_PLUGIN_HEALTH_PROBE_NONCE: "probe-wrongwrongwrong1" }), false);
+  chmodSync(receipt, 0o644);
+  assert.equal(recordPluginHealthStage("imported", {}, baseEnv), false);
+  chmodSync(receipt, 0o600);
+  symlinkSync(receipt, linked);
+  assert.equal(recordPluginHealthStage("imported", {}, { ...baseEnv, AIDEVOPS_PLUGIN_HEALTH_PROBE_FILE: linked }), false);
+  rmSync(root, { recursive: true, force: true });
+});

--- a/.agents/scripts/gpt56-context-helper.sh
+++ b/.agents/scripts/gpt56-context-helper.sh
@@ -76,6 +76,7 @@ show_status() {
 	if [[ "$configured" == true && -f "$PLUGIN_ENTRY" && ! -L "$PLUGIN_ENTRY" ]]; then
 		if AIDEVOPS_PLUGIN_HEALTH_PROBE_FILE="$probe_file" \
 			AIDEVOPS_PLUGIN_HEALTH_PROBE_NONCE="$probe_nonce" \
+			AIDEVOPS_PLUGIN_HEALTH_PROBE_ONLY=1 \
 			"$NODE_BIN" --input-type=module --eval '
 				const plugin = await import(process.argv[1]);
 				const hooks = await plugin.AidevopsPlugin({directory: process.argv[2], client: {}});

--- a/.agents/scripts/gpt56-context-helper.sh
+++ b/.agents/scripts/gpt56-context-helper.sh
@@ -6,6 +6,10 @@ set -euo pipefail
 
 SETTINGS_FILE="${AIDEVOPS_SETTINGS_FILE:-${HOME}/.config/aidevops/settings.json}"
 BOOLEAN_TRUE="true"
+PLUGIN_HEALTH_SCHEMA="aidevops.opencode-plugin-health/v1"
+OPENCODE_BIN="${OPENCODE_BIN:-opencode}"
+NODE_BIN="${NODE_BIN:-node}"
+PLUGIN_ENTRY="${AIDEVOPS_PLUGIN_ENTRY:-${HOME}/.aidevops/agents/plugins/opencode-aidevops/index.mjs}"
 
 usage() {
 	cat <<'EOF'
@@ -40,11 +44,79 @@ is_enabled() {
 }
 
 show_status() {
+	local requested="disabled"
+	local temp_root="${AIDEVOPS_TEMP_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
+	local probe_dir="" probe_file="" probe_nonce="" probe_output="" probe_error=""
+	local probe_status=0 configured=false
+	local stages="" context="" input="" output="" failure=""
+
 	if is_enabled; then
-		printf '%s\n' "GPT-5.6 OpenCode context cap: enabled (300K; auto-compaction near 240K)"
-	else
-		printf '%s\n' "GPT-5.6 OpenCode context cap: disabled (native provider limit)"
+		requested="enabled"
 	fi
+	printf '%s\n' "GPT-5.6 OpenCode context cap requested: ${requested}"
+	if ! command -v "$OPENCODE_BIN" >/dev/null 2>&1 || ! command -v "$NODE_BIN" >/dev/null 2>&1; then
+		printf '%s\n' "OpenCode plugin effective state: unavailable (OpenCode is not installed)"
+		return 0
+	fi
+	mkdir -p "$temp_root"
+	chmod 700 "$temp_root" 2>/dev/null || true
+	probe_dir=$(mktemp -d "${temp_root}/aidevops-plugin-health.XXXXXX") || return 1
+	chmod 700 "$probe_dir"
+	probe_file="${probe_dir}/receipt.json"
+	probe_output="${probe_dir}/models.txt"
+	probe_error="${probe_dir}/error.txt"
+	probe_nonce="probe-$$-$(date -u '+%Y%m%d%H%M%S')"
+	jq -cn --arg nonce "$probe_nonce" '{nonce:$nonce,stages:[],details:{}}' >"$probe_file"
+	chmod 600 "$probe_file"
+	if "$OPENCODE_BIN" debug config >"$probe_output" 2>"$probe_error" &&
+		grep -Fq "$PLUGIN_ENTRY" "$probe_output"; then
+		configured=true
+	fi
+	printf '%s\n' "OpenCode plugin configured/discovered: ${configured}"
+	if [[ "$configured" == true && -f "$PLUGIN_ENTRY" && ! -L "$PLUGIN_ENTRY" ]]; then
+		if AIDEVOPS_PLUGIN_HEALTH_PROBE_FILE="$probe_file" \
+			AIDEVOPS_PLUGIN_HEALTH_PROBE_NONCE="$probe_nonce" \
+			"$NODE_BIN" --input-type=module --eval '
+				const plugin = await import(process.argv[1]);
+				const hooks = await plugin.AidevopsPlugin({directory: process.argv[2], client: {}});
+				await hooks.config({});
+			' "$PLUGIN_ENTRY" "$PWD" >>"$probe_output" 2>>"$probe_error"; then
+			probe_status=0
+		else
+			probe_status=$?
+		fi
+	else
+		probe_status=2
+	fi
+	if jq -e --arg schema "$PLUGIN_HEALTH_SCHEMA" --arg nonce "$probe_nonce" \
+		'.schema == $schema and .nonce == $nonce and
+		(["imported","factory_initialized","config_applied"] - .stages | length == 0) and
+		.details.factory_initialized.terminal_title_status == true and
+		.details.config_applied.terminal_title_status == true' \
+		"$probe_file" >/dev/null 2>&1; then
+		stages=$(jq -r '.stages | join(", ")' "$probe_file")
+		context=$(jq -r '.details.config_applied.gpt56_limits.context // empty' "$probe_file")
+		input=$(jq -r '.details.config_applied.gpt56_limits.input // empty' "$probe_file")
+		output=$(jq -r '.details.config_applied.gpt56_limits.output // empty' "$probe_file")
+		printf '%s\n' "OpenCode plugin effective state: active (${stages})"
+		printf '%s\n' "Terminal-title status hook: registered"
+		if [[ -n "$context" && -n "$input" && -n "$output" ]]; then
+			printf '%s\n' "Effective GPT-5.6 limits: context=${context}, input=${input}, output=${output}"
+		elif [[ "$requested" == "disabled" ]]; then
+			printf '%s\n' "Effective GPT-5.6 limits: native provider metadata (cap disabled)"
+		else
+			printf '%s\n' "Effective GPT-5.6 limits: unavailable (config hook did not register limits)"
+		fi
+	else
+		printf '%s\n' "OpenCode plugin effective state: inactive or initialization failed"
+		if [[ -s "$probe_error" ]]; then
+			failure=$(tr '\n' ' ' <"$probe_error" | cut -c1-240)
+			failure="${failure//${HOME}/\$HOME}"
+			printf '%s\n' "Probe failure (exit ${probe_status}): ${failure}"
+		fi
+		printf '%s\n' "Effective GPT-5.6 limits: unavailable (requested state not confirmed)"
+	fi
+	rm -rf "$probe_dir"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-gpt56-context-helper.sh
+++ b/.agents/scripts/tests/test-gpt56-context-helper.sh
@@ -9,6 +9,33 @@ HELPER="${SCRIPT_DIR}/../gpt56-context-helper.sh"
 TEST_HOME="$(mktemp -d)"
 trap 'rm -rf "$TEST_HOME"' EXIT
 export HOME="$TEST_HOME"
+MOCK_BIN="${TEST_HOME}/bin"
+PLUGIN_ENTRY="${TEST_HOME}/agents/plugins/opencode-aidevops/index.mjs"
+mkdir -p "$MOCK_BIN" "${PLUGIN_ENTRY%/*}"
+printf '%s\n' '// mock plugin entry' >"$PLUGIN_ENTRY"
+
+cat >"${MOCK_BIN}/opencode" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{"plugin":["file://%s"]}\n' "${AIDEVOPS_PLUGIN_ENTRY:?}"
+MOCK
+cat >"${MOCK_BIN}/node" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${MOCK_PLUGIN_ACTIVE:-1}" != "1" ]]; then
+	printf '%s\n' 'mock plugin import failed at $HOME/plugin.mjs' >&2
+	exit 1
+fi
+jq -cn --arg nonce "${AIDEVOPS_PLUGIN_HEALTH_PROBE_NONCE:?}" \
+	'{schema:"aidevops.opencode-plugin-health/v1",nonce:$nonce,
+	stages:["imported","factory_initialized","config_applied"],details:{
+	factory_initialized:{config_hook:true,terminal_title_status:true},
+	config_applied:{terminal_title_status:true,gpt56_limits:{context:300000,input:260000,output:128000}}}}' \
+	>"${AIDEVOPS_PLUGIN_HEALTH_PROBE_FILE:?}"
+MOCK
+chmod +x "${MOCK_BIN}/opencode" "${MOCK_BIN}/node"
+export PATH="${MOCK_BIN}:${PATH}"
+export AIDEVOPS_PLUGIN_ENTRY="$PLUGIN_ENTRY"
 
 assert_contains() {
 	local haystack="$1"
@@ -21,12 +48,24 @@ assert_contains() {
 }
 
 output=$(bash "$HELPER" status)
-assert_contains "$output" "enabled (300K"
+assert_contains "$output" "requested: enabled"
+assert_contains "$output" "configured/discovered: true"
+assert_contains "$output" "effective state: active"
+assert_contains "$output" "context=300000, input=260000, output=128000"
+assert_contains "$output" "Terminal-title status hook: registered"
+
+output=$(MOCK_PLUGIN_ACTIVE=0 bash "$HELPER" status)
+assert_contains "$output" "inactive or initialization failed"
+assert_contains "$output" "mock plugin import failed at \$HOME/plugin.mjs"
+assert_contains "$output" "requested state not confirmed"
+
+output=$(OPENCODE_BIN="${TEST_HOME}/missing-opencode" bash "$HELPER" status)
+assert_contains "$output" "unavailable (OpenCode is not installed)"
 
 bash "$HELPER" disable >/dev/null
 [[ "$(jq -r '.runtime.opencode.gpt56_context_cap' "$HOME/.config/aidevops/settings.json")" == "false" ]]
 output=$(bash "$HELPER" status)
-assert_contains "$output" "disabled"
+assert_contains "$output" "requested: disabled"
 
 bash "$HELPER" enable >/dev/null
 [[ "$(jq -r '.runtime.opencode.gpt56_context_cap' "$HOME/.config/aidevops/settings.json")" == "true" ]]

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ the required notices and preferred credit text.
 - `aidevops update` - Update framework
 - `aidevops auto-update` - Automatic update polling (enable/disable/status)
 - `aidevops runtime-bundle list` - List retained validated runtime bundles; use `rollback --bundle-id <id> --reason <text>` for an explicit audited rollback
-- `aidevops gpt56-context [enable|disable|status]` - Keep GPT-5.6 at a 300K advertised context window in OpenCode (enabled by default), so 80% auto-compaction runs near 240K before long-context pricing; disable to use native provider limits
+- `aidevops gpt56-context [enable|disable|status]` - Keep GPT-5.6 at a 300K advertised context window in OpenCode (enabled by default), so 80% auto-compaction runs near 240K before long-context pricing; `status` verifies plugin discovery, initialization, hook registration, and effective limits
 - `aidevops buzz [status|apply|rollback]` - Inspect or manage Buzz Desktop OpenCode ACP compatibility
 - `~/.aidevops/agents/scripts/team-interface-helper.sh [providers|detect|status|doctor|plan]` - Inspect registered collaboration providers, persist read-only observations, or emit deterministic dry-run plans; no provider-write command is exposed
 - `aidevops opencode conversation --overlay FILE --dir PATH` - Launch fixed-argv OpenCode ACP with a schema-validated ephemeral team-interface overlay and a final read-only capability guard; see `.agents/reference/team-interface-opencode-overlays.md`


### PR DESCRIPTION
## Summary

Distinguish requested, configured, imported, factory-initialized, hook-registered, and effective GPT-5.6 state with a private nonce-bound probe.

## Files Changed

.agents/plugins/opencode-aidevops/index.mjs, .agents/plugins/opencode-aidevops/plugin-health.mjs, .agents/plugins/opencode-aidevops/tests/test-plugin-health.mjs, .agents/scripts/gpt56-context-helper.sh, .agents/scripts/tests/test-gpt56-context-helper.sh, README.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified: live worktree status probe reports configured/imported/factory/config stages, terminal-title registration, and context/input/output 300000/260000/128000; shell helper tests pass; OpenCode plugin suite passes 623/623; review bundle 92b32ef54a685a9c25f92fa0fb1cefd4627eff7c738f6c1f176eefbc5b0f97c5.

Resolves #29963


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.250 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 2m and 72,716 tokens on this with the user in an interactive session.