### PR TITLE
GH#29974: classify OpenCode gateway denials

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -57,6 +57,7 @@ import { createSessionRecoveryMarkerHandler } from "./session-recovery-marker.mj
 import { createPermissionBroker } from "./permission-broker.mjs";
 import { createSubagentCancellationReceipt } from "./subagent-cancellation-receipt.mjs";
 import { createRoutingFeedbackHandler } from "./routing-feedback-handler.mjs";
+import { createProviderErrorHandler } from "./provider-error-diagnostics.mjs";
 import {
   appendConversationSystemContext,
   applyConversationRootVariant,
@@ -465,6 +466,11 @@ export async function AidevopsPlugin({ directory, client }) {
   });
   const sessionTitleStatusHandler = createSessionTitleStatusHandler({ isHeadless });
   const routingFeedbackHandler = createRoutingFeedbackHandler({ client, isHeadless, getFeedback: getRoutingFeedback });
+  const providerErrorHandler = createProviderErrorHandler({
+    client,
+    isHeadless,
+    resolveSessionModel: (sessionId) => sessionModels.resolve(sessionId),
+  });
   const sessionTitleFallbackHandler = createSessionTitleFallbackHandler({
     agentsDir: ACTIVE_AGENTS_DIR,
     client,
@@ -538,13 +544,14 @@ export async function AidevopsPlugin({ directory, client }) {
     event: async (input) => {
       // Fire both in parallel — neither depends on the other's result.
       await Promise.all([
-        handleEvent(input),
+        handleEvent(input, { resolveSessionModel: (sessionId) => sessionModels.resolve(sessionId) }),
         Promise.resolve(subagentEffortHooks.handleEvent(input)),
         compactionContinuation.handleEvent(input),
         Promise.resolve(cancellationReceipt.handleEvent(input)),
         permissionBroker.handleEvent(input).catch((err) => debugEventError("permission broker", err)),
         sessionTitleStatusHandler(input).catch((err) => debugEventError("title status handler", err)),
         routingFeedbackHandler(input).catch((err) => debugEventError("routing feedback handler", err)),
+        providerErrorHandler(input).catch((err) => debugEventError("provider error handler", err)),
         sessionTitleSuffixHandler(input).catch((err) => debugEventError("title suffix handler", err)),
         sessionTitleFallbackHandler(input).catch((err) => debugEventError("title fallback handler", err)),
         sessionRecoveryMarkerHandler(input).catch((err) => debugEventError("session recovery marker", err)),

--- a/.agents/plugins/opencode-aidevops/observability.mjs
+++ b/.agents/plugins/opencode-aidevops/observability.mjs
@@ -55,6 +55,7 @@ import {
   recordRoutingDecision,
   rememberRoutingFeedback,
 } from "./observability-routing.mjs";
+import { normalizeProviderError } from "./provider-error-diagnostics.mjs";
 
 const HOME = homedir();
 const DEFAULT_OBS_DIR = join(HOME, ".aidevops", ".agent-workspace", "observability");
@@ -241,15 +242,16 @@ export function initObservability(options = {}) {
  * Filters for assistant message completions and records metadata.
  *
  * @param {{ event: import("@opencode-ai/sdk").Event }} input
+ * @param {{ resolveSessionModel?: (sessionId: string) => string }} [context]
  */
-export function handleEvent(input) {
+export function handleEvent(input, context = {}) {
   if (!dbReady) return;
 
   const event = input.event;
   if (!event || !event.type) return;
 
   if (event.type === "message.updated") {
-    handleMessageUpdated(event);
+    handleMessageUpdated(event, context);
     return;
   }
 
@@ -258,7 +260,7 @@ export function handleEvent(input) {
   // into the eventual message.completed envelope.
   if (partStreamSummaries.observe(event)) return;
 
-  recordOpenCodeRuntimeEvent(event);
+  recordOpenCodeRuntimeEvent(event, event.type, {}, context);
 }
 
 function projectRuntimeEvent(envelope) {
@@ -270,7 +272,7 @@ function firstTruthy(values, fallback = null) {
   return values.find(Boolean) || fallback;
 }
 
-function recordOpenCodeRuntimeEvent(event, eventType = event.type, additionalPayload = {}) {
+function recordOpenCodeRuntimeEvent(event, eventType = event.type, additionalPayload = {}, context = {}) {
   const properties = event.properties || {};
   const info = properties.info || {};
   const part = properties.part || {};
@@ -280,6 +282,29 @@ function recordOpenCodeRuntimeEvent(event, eventType = event.type, additionalPay
   const subjectId = firstTruthy([
     info.id, part.id, part.messageID, part.messageId, properties.id, sessionId,
   ], "runtime:opencode");
+  const error = info.error || properties.error || part.error || part.state?.error;
+  const providerError = normalizeProviderError(error);
+  const route = String(context.resolveSessionModel?.(sessionId) || "");
+  const routeSeparator = route.indexOf("/");
+  const routeProvider = routeSeparator > 0 ? route.slice(0, routeSeparator) : null;
+  const routeModel = routeSeparator > 0 ? route.slice(routeSeparator + 1) : route || null;
+  const payload = {
+    error_type: firstTruthy([
+      info.error?.name, properties.error?.name, part.error?.name, part.state?.error?.name,
+    ]),
+    finish_reason: info.finish || part.finish || part.state?.status || null,
+    model_id: info.modelID || routeModel,
+    provider_id: info.providerID || routeProvider,
+    role: info.role || null,
+    source: "opencode",
+    ...additionalPayload,
+  };
+  if (providerError) {
+    payload.observation = {
+      ...(additionalPayload.observation || {}),
+      provider_error: providerError,
+    };
+  }
   const envelope = appendRuntimeEvent({
     eventType,
     subjectId,
@@ -288,17 +313,7 @@ function recordOpenCodeRuntimeEvent(event, eventType = event.type, additionalPay
     causationId: properties.causationID,
     rootEventId: properties.rootEventID,
     parentEventId: properties.parentEventID,
-    payload: {
-      error_type: firstTruthy([
-        info.error?.name, properties.error?.name, part.error?.name, part.state?.error?.name,
-      ]),
-      finish_reason: info.finish || part.finish || part.state?.status || null,
-      model_id: info.modelID || null,
-      provider_id: info.providerID || null,
-      role: info.role || null,
-      source: "opencode",
-      ...additionalPayload,
-    },
+    payload,
   });
   projectRuntimeEvent(envelope);
 }
@@ -309,7 +324,7 @@ function recordOpenCodeRuntimeEvent(event, eventType = event.type, additionalPay
  *
  * @param {{ type: string, properties: { info: object } }} event
  */
-function handleMessageUpdated(event) {
+function handleMessageUpdated(event, context = {}) {
   const msg = event.properties?.info;
   if (!msg) return;
 
@@ -332,7 +347,7 @@ function handleMessageUpdated(event) {
     routing_reason: routing.reason || null,
     routing_escalated: routing.escalated === 1,
     aidevops_version: aidevopsVersion || null,
-  });
+  }, context);
 
   // Prevent unbounded memory growth — prune old entries periodically
   if (recordedMessages.size > 10000) {

--- a/.agents/plugins/opencode-aidevops/provider-error-diagnostics.mjs
+++ b/.agents/plugins/opencode-aidevops/provider-error-diagnostics.mjs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+const REQUEST_ID_HEADERS = [
+  "x-request-id",
+  "request-id",
+  "cf-ray",
+  "traceparent",
+];
+
+function statusCode(error) {
+  const value = Number(error?.data?.statusCode);
+  return Number.isInteger(value) && value >= 100 && value <= 599 ? value : null;
+}
+
+function responseBodyKind(body) {
+  if (body === undefined || body === null) return "unavailable";
+  if (typeof body !== "string") return "unknown";
+  const trimmed = body.trim();
+  if (!trimmed) return "empty";
+  if (/^(?:<!doctype\s+html|<html\b)/i.test(trimmed)) return "html";
+  try {
+    JSON.parse(trimmed);
+    return "json";
+  } catch {
+    return "text";
+  }
+}
+
+function requestIdentity(headers) {
+  if (!headers || typeof headers !== "object") return {};
+  const normalized = new Map(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
+  );
+  for (const header of REQUEST_ID_HEADERS) {
+    const value = normalized.get(header);
+    if (typeof value === "string" && value.trim()) {
+      return { request_id: value.trim().slice(0, 256), request_id_source: header };
+    }
+  }
+  return {};
+}
+
+function endpointOrigin(metadata) {
+  if (!metadata || typeof metadata !== "object") return null;
+  const candidate = metadata.url || metadata.requestURL || metadata.requestUrl || metadata.endpoint;
+  if (typeof candidate !== "string") return null;
+  try {
+    const url = new URL(candidate);
+    return url.protocol === "https:" || url.protocol === "http:" ? url.origin : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Reduce an OpenCode provider error to safe, provider-neutral diagnostics. */
+export function normalizeProviderError(error) {
+  if (!error || typeof error !== "object" || error.name !== "APIError") return null;
+  const status = statusCode(error);
+  const bodyKind = responseBodyKind(error.data?.responseBody);
+  const message = String(error.data?.message || "").toLowerCase();
+  let classification = "provider_error";
+  if (status === 403 && (bodyKind === "html" || /gateway|proxy/.test(message))) {
+    classification = "gateway_denied";
+  } else if (status === 403) {
+    classification = "access_denied";
+  } else if (status === 401) {
+    classification = "authentication_failed";
+  } else if (status === 429) {
+    classification = "rate_limited";
+  } else if (status !== null && status >= 500) {
+    classification = "provider_unavailable";
+  }
+
+  return {
+    classification,
+    status_code: status,
+    response_body_kind: bodyKind,
+    is_retryable: error.data?.isRetryable === true,
+    endpoint_origin: endpointOrigin(error.data?.metadata),
+    ...requestIdentity(error.data?.responseHeaders),
+  };
+}
+
+function providerLabel(modelIdentity) {
+  const provider = String(modelIdentity || "").split("/", 1)[0];
+  return provider || "The provider";
+}
+
+function toastMessage(diagnostic, modelIdentity) {
+  const provider = providerLabel(modelIdentity);
+  if (diagnostic.classification === "gateway_denied") {
+    return `${provider} returned HTTP 403 with an HTML gateway response. This is an edge/proxy denial, not proof that your account lost permission. Retry once; if it repeats, switch model/provider. Safe diagnostics were recorded.`;
+  }
+  return `${provider} returned HTTP 403. This can indicate model, account, or policy access. No credential rotation was attempted; try an alternate route or check provider access. Safe diagnostics were recorded.`;
+}
+
+/** Explain provider 403 failures without exposing response bodies or headers. */
+export function createProviderErrorHandler({ client, isHeadless, resolveSessionModel, now = Date.now }) {
+  const emitted = new Map();
+  return async function providerErrorHandler(input) {
+    if (isHeadless()) return;
+    const event = input?.event || input || {};
+    const sessionID = event.properties?.sessionID || event.properties?.info?.id || "";
+    if (event.type === "session.deleted") {
+      emitted.delete(sessionID);
+      return;
+    }
+    if (event.type !== "session.error" || !sessionID) return;
+    const diagnostic = normalizeProviderError(event.properties?.error);
+    if (!diagnostic || !["gateway_denied", "access_denied"].includes(diagnostic.classification)) return;
+    const timestamp = now();
+    const previousTimestamp = emitted.get(sessionID) || 0;
+    if (timestamp - previousTimestamp < 30000) return;
+    emitted.set(sessionID, timestamp);
+    const modelIdentity = resolveSessionModel?.(sessionID) || "";
+    try {
+      await client.tui.showToast({
+        body: {
+          title: "Provider request denied",
+          message: toastMessage(diagnostic, modelIdentity),
+          variant: "warning",
+          duration: 15000,
+        },
+      });
+    } catch (error) {
+      if (emitted.get(sessionID) === timestamp) {
+        if (previousTimestamp) emitted.set(sessionID, previousTimestamp);
+        else emitted.delete(sessionID);
+      }
+      throw error;
+    }
+  };
+}

--- a/.agents/plugins/opencode-aidevops/tests/test-provider-error-diagnostics.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-provider-error-diagnostics.mjs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createProviderErrorHandler,
+  normalizeProviderError,
+} from "../provider-error-diagnostics.mjs";
+
+function apiError(overrides = {}) {
+  return {
+    name: "APIError",
+    data: {
+      message: "Forbidden",
+      statusCode: 403,
+      isRetryable: false,
+      responseBody: "<!doctype html><title>Forbidden</title>",
+      responseHeaders: {
+        authorization: "Bearer secret-value",
+        cookie: "private-cookie",
+        "x-request-id": "req-safe-123",
+      },
+      metadata: { url: "https://api.example.test/v1/responses?secret=value" },
+      ...overrides,
+    },
+  };
+}
+
+test("normalizes HTML 403 without retaining raw response data", () => {
+  const diagnostic = normalizeProviderError(apiError());
+  assert.deepEqual(diagnostic, {
+    classification: "gateway_denied",
+    status_code: 403,
+    response_body_kind: "html",
+    is_retryable: false,
+    endpoint_origin: "https://api.example.test",
+    request_id: "req-safe-123",
+    request_id_source: "x-request-id",
+  });
+  assert.doesNotMatch(JSON.stringify(diagnostic), /secret-value|private-cookie|doctype/);
+});
+
+test("keeps JSON, text, and empty 403 responses distinguishable", () => {
+  assert.equal(normalizeProviderError(apiError({ responseBody: '{"error":"denied"}' })).response_body_kind, "json");
+  assert.equal(normalizeProviderError(apiError({ responseBody: "denied" })).response_body_kind, "text");
+  assert.equal(normalizeProviderError(apiError({ responseBody: "  " })).response_body_kind, "empty");
+  assert.equal(normalizeProviderError(apiError({ responseBody: undefined })).response_body_kind, "unavailable");
+  assert.equal(normalizeProviderError(apiError({ responseBody: "denied" })).classification, "access_denied");
+});
+
+test("ignores non-API SDK errors", () => {
+  for (const name of ["ProviderAuthError", "UnknownError", "MessageAbortedError"]) {
+    assert.equal(normalizeProviderError({ name, data: { message: "Aborted" } }), null);
+  }
+});
+
+test("explains gateway denial once per session without claiming lost permission", async () => {
+  const toasts = [];
+  let timestamp = 100000;
+  const handler = createProviderErrorHandler({
+    client: { tui: { showToast: async (toast) => toasts.push(toast) } },
+    isHeadless: () => false,
+    resolveSessionModel: () => "openai/gpt-test",
+    now: () => timestamp,
+  });
+  const event = { event: { type: "session.error", properties: { sessionID: "session-1", error: apiError() } } };
+  await handler(event);
+  await handler(event);
+  timestamp += 30001;
+  await handler(event);
+  assert.equal(toasts.length, 2);
+  assert.match(toasts[0].body.message, /edge\/proxy denial, not proof/);
+  assert.doesNotMatch(toasts[0].body.message, /secret-value|private-cookie/);
+});
+
+test("does not emit interactive diagnostics in headless mode", async () => {
+  const toasts = [];
+  const handler = createProviderErrorHandler({
+    client: { tui: { showToast: async (toast) => toasts.push(toast) } },
+    isHeadless: () => true,
+    resolveSessionModel: () => "openai/gpt-test",
+  });
+  await handler({ event: { type: "session.error", properties: { sessionID: "session-1", error: apiError() } } });
+  assert.equal(toasts.length, 0);
+});
+
+test("clears deduplication for SDK-shaped deletion events", async () => {
+  const toasts = [];
+  let timestamp = 100000;
+  const handler = createProviderErrorHandler({
+    client: { tui: { showToast: async (toast) => toasts.push(toast) } },
+    isHeadless: () => false,
+    resolveSessionModel: () => "openai/gpt-test",
+    now: () => timestamp,
+  });
+  const denied = { event: { type: "session.error", properties: { sessionID: "session-1", error: apiError() } } };
+  await handler(denied);
+  await handler({ event: { type: "session.deleted", properties: { info: { id: "session-1" } } } });
+  timestamp += 1;
+  await handler(denied);
+  assert.equal(toasts.length, 2);
+});
+
+test("reserves concurrent delivery and retries after a failed toast", async () => {
+  const toasts = [];
+  let fail = false;
+  const handler = createProviderErrorHandler({
+    client: { tui: { showToast: async (toast) => {
+      if (fail) throw new Error("toast unavailable");
+      toasts.push(toast);
+    } } },
+    isHeadless: () => false,
+    resolveSessionModel: () => "openai/gpt-test",
+    now: () => 100000,
+  });
+  const denied = { event: { type: "session.error", properties: { sessionID: "session-1", error: apiError() } } };
+  await Promise.all([handler(denied), handler(denied)]);
+  assert.equal(toasts.length, 1);
+
+  const retryHandler = createProviderErrorHandler({
+    client: { tui: { showToast: async (toast) => {
+      if (fail) throw new Error("toast unavailable");
+      toasts.push(toast);
+    } } },
+    isHeadless: () => false,
+    resolveSessionModel: () => "openai/gpt-test",
+    now: () => 200000,
+  });
+  fail = true;
+  await assert.rejects(retryHandler(denied), /toast unavailable/);
+  fail = false;
+  await retryHandler(denied);
+  assert.equal(toasts.length, 2);
+});

--- a/.agents/plugins/opencode-aidevops/tests/test-runtime-events.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-runtime-events.mjs
@@ -488,6 +488,20 @@ test("OpenCode observability emits runtime evidence without changing legacy tabl
         tokens: { input: 2, output: 3, total: 5, cache: { read: 0, write: 0 } },
       } },
     } });
+    observability.handleEvent({ event: {
+      type: "session.error",
+      properties: {
+        sessionID: "session:1",
+        error: {
+          name: "APIError",
+          data: {
+            message: "Forbidden", statusCode: 403, isRetryable: false,
+            responseBody: "<!doctype html><title>Forbidden</title>",
+            responseHeaders: { authorization: "Bearer private", "x-request-id": "req-safe" },
+          },
+        },
+      },
+    } }, { resolveSessionModel: () => "openai/test-model" });
     observability.recordToolCall(
       { tool: "Read", sessionID: "session:1", callID: "call:1" },
       { output: "ok", metadata: { bytes: 1 } },
@@ -523,11 +537,17 @@ test("OpenCode observability emits runtime evidence without changing legacy tabl
         (SELECT json_extract(payload_json, '$.suppressed_part_events')
           FROM runtime_events WHERE event_type = 'message.completed'),
         (SELECT json_extract(payload_json, '$.error_type')
-          FROM runtime_events WHERE event_type = 'message.part.updated');
+          FROM runtime_events WHERE event_type = 'message.part.updated'),
+        (SELECT json_extract(payload_json, '$.observation.provider_error.classification')
+          FROM runtime_events WHERE event_type = 'session.error'),
+        (SELECT json_extract(payload_json, '$.observation.provider_error.request_id')
+          FROM runtime_events WHERE event_type = 'session.error'),
+        (SELECT payload_json NOT LIKE '%private%' AND payload_json NOT LIKE '%doctype%'
+          FROM runtime_events WHERE event_type = 'session.error');
     `], { encoding: "utf8" }).trim();
     assert.equal(
       counts,
-      "1|1|5|session.created,message.part.updated,message.completed,tool.completed,subagent.cancellation.receipt|100|PartFailure",
+      "1|1|6|session.created,message.part.updated,message.completed,session.error,tool.completed,subagent.cancellation.receipt|100|PartFailure|gateway_denied|req-safe|1",
     );
   } finally {
     rmSync(tempDir, { force: true, recursive: true });

--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -944,7 +944,7 @@ _hrff_retry_class_for_reason() {
 	local session_count="$2"
 	case "$reason" in
 	opencode_version_pin_failed | canary_failed | worker_prepare_failed | duplicate_session | \
-		worker_noop_zero_output | crash_during_startup | rate_limit* | provider_error | \
+		worker_noop_zero_output | crash_during_startup | access_denied | rate_limit* | provider_error | \
 		startup_no_model_activity | service_interruption_exhausted | worker_runtime_not_invoked | \
 		worker_sensitive_temp_preflight_failed | worker_ownership_lost | worker_ledger_ready_failed | \
 		worker_claim_ready_transition_failed)

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -525,6 +525,10 @@ _derive_worker_failure_evidence() {
 		launch_failure_cause="provider_rate_limited"
 		next_action="rotate_provider_or_wait_for_reset"
 		;;
+	access_denied)
+		launch_failure_cause="provider_access_denied"
+		next_action="switch_provider_or_check_access"
+		;;
 	blocked | brief_recovery)
 		launch_failure_cause="model_reported_blocker"
 		next_action="recover_brief_or_escalate_with_evidence"

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -130,60 +130,8 @@ source "${SCRIPT_DIR}/headless-runtime-provider.sh"
 
 _classify_trusted_provider_failure() {
 	local file_path="$1"
-	if python3 - "$file_path" <<'PY'; then
-import json
-import re
-import sys
-from pathlib import Path
-
-trusted_chunks = []
-provider_line = re.compile(r"\b(openai|anthropic|claude|provider|api)\b", re.I)
-runtime_line = re.compile(r"\[(worker_exit_diagnostics|provider_error|runtime_error)\]", re.I)
-auth_runtime_line = re.compile(r"\b(token refresh failed|invalid_grant|invalid refresh token)\b", re.I)
-
-for raw_line in Path(sys.argv[1]).read_text(errors='ignore').splitlines():
-    line = raw_line.strip()
-    if not line:
-        continue
-    trusted = False
-    if line.startswith("{"):
-        try:
-            obj = json.loads(line)
-        except Exception:
-            obj = None
-        if isinstance(obj, dict):
-            has_provider = bool(obj.get('provider') or obj.get('provider_error_type') or obj.get('provider_status'))
-            has_error_record = any(key in obj for key in ('error', 'status', 'provider_error_type', 'provider_status'))
-            if has_provider and has_error_record:
-                trusted = True
-    elif provider_line.search(line) or runtime_line.search(line) or auth_runtime_line.search(line):
-        trusted = True
-    if trusted:
-        trusted_chunks.append(line)
-
-text = '\n'.join(trusted_chunks).lower()
-if not text:
-    sys.exit(0)
-
-def emit(reason, provider_type, status, pattern):
-    print('\t'.join([reason, provider_type, status, 'trusted_provider', pattern]))
-
-if any(token in text for token in ('insufficient_quota', 'insufficient quota', 'quota_exceeded', 'quota exceeded', 'exceeded your current quota', 'credit_exhausted', 'credit exhausted', 'exhausted your credit')):
-    emit('quota_exceeded', 'quota_exceeded', '429', 'trusted_quota|insufficient_quota|quota_exceeded|credit_exhausted')
-elif any(token in text for token in ('rate limit', 'rate_limit', 'too many requests')) or re.search(r'\b429\b', text):
-    emit('rate_limit', 'rate_limit', '429', 'trusted_rate_limit|429|too_many_requests')
-elif re.search(r'\b(500|502|503|504)\b', text) or any(token in text for token in ('server_error', 'internal server error', 'service unavailable', 'bad gateway', 'gateway timeout', 'connection refused', 'connection reset', 'overloaded')):
-    status = '500'
-    if '504' in text or 'gateway timeout' in text:
-        status = '504'
-    elif '503' in text or 'service unavailable' in text:
-        status = '503'
-    elif '502' in text or 'bad gateway' in text:
-        status = '502'
-    emit('provider_error', 'server_error', status, 'trusted_server_error|5xx|connection_failure|overloaded')
-elif re.search(r'\b(401)\b', text) or any(token in text for token in ('unauthorized', 'invalid api key', 'authentication failed', 'token refresh failed', 'invalid_grant', 'invalid refresh token')) or ('auth' in text and 'failed' in text):
-    emit('auth_error', 'auth_error', '401', 'trusted_auth_error|401|token_refresh|invalid_grant')
-PY
+	local classifier="${SCRIPT_DIR}/headless-runtime-provider-classifier.py"
+	if [[ -f "$classifier" ]] && python3 "$classifier" "$file_path"; then
 		return 0
 	fi
 	return 1
@@ -1627,7 +1575,7 @@ _classify_canary_failure_reason() {
 	local reason
 	reason=$(classify_failure_reason "$output_file")
 	case "$reason" in
-		auth_error | quota_exceeded | rate_limit | provider_error)
+		access_denied | auth_error | quota_exceeded | rate_limit | provider_error)
 			printf '%s' "$reason"
 			return 0
 			;;
@@ -1651,7 +1599,7 @@ _record_canary_provider_backoff() {
 	local canary_reason="$2"
 	local canary_output="$3"
 	case "$canary_reason" in
-	auth_error | quota_exceeded | rate_limit | provider_error)
+	access_denied | auth_error | quota_exceeded | rate_limit | provider_error)
 		local canary_provider
 		canary_provider=$(extract_provider "$canary_model" 2>/dev/null || printf '%s' "")
 		if [[ -n "$canary_provider" ]]; then

--- a/.agents/scripts/headless-runtime-provider-classifier.py
+++ b/.agents/scripts/headless-runtime-provider-classifier.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+"""Classify trusted provider failures from one OpenCode output file."""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+RUNTIME_LINE = re.compile(r"\[(worker_exit_diagnostics|provider_error|runtime_error)\]", re.I)
+AUTH_RUNTIME_LINE = re.compile(r"\b(token refresh failed|invalid_grant|invalid refresh token)\b", re.I)
+PROVIDER_RUNTIME_LINE = re.compile(
+    r"^(?:(?:openai|anthropic|claude) (?:provider )?(?:error|authentication failed)|provider returned http \d{3}:)",
+    re.I,
+)
+PROVIDER_STATUS_LINE = re.compile(
+    r"^(?:openai|anthropic|claude)\s+(?:http\s+)?(?:429|5\d\d)\b.*(?:rate limit|service unavailable|server error|overloaded)",
+    re.I,
+)
+OPENCODE_ERROR_LOG = re.compile(r"^timestamp=.*\blevel=error\b.*\bproviderid=", re.I)
+GATEWAY_DISPLAY = re.compile(r"^forbidden: request was blocked by a gateway or proxy\.?", re.I)
+
+
+def structured_api_error(obj):
+    error = obj.get("error")
+    if obj.get("type") != "error" or not isinstance(error, dict):
+        return None
+    error_name = error.get("name") or error.get("type")
+    data = error.get("data") if isinstance(error.get("data"), dict) else {}
+    status = data.get("statusCode")
+    if error_name != "APIError" or not isinstance(status, int) or isinstance(status, bool):
+        return None
+    body = data.get("responseBody")
+    body_kind = "unavailable"
+    if isinstance(body, str):
+        stripped = body.lstrip().lower()
+        body_kind = "html" if stripped.startswith(("<!doctype", "<html")) else "other"
+    return {
+        "status": status,
+        "message": data.get("message", "") if isinstance(data.get("message"), str) else "",
+        "body": body if isinstance(body, str) else "",
+        "body_kind": body_kind,
+    }
+
+
+def trusted_plaintext(line):
+    return any(pattern.search(line) for pattern in (
+        RUNTIME_LINE,
+        AUTH_RUNTIME_LINE,
+        PROVIDER_RUNTIME_LINE,
+        PROVIDER_STATUS_LINE,
+        OPENCODE_ERROR_LOG,
+        GATEWAY_DISPLAY,
+    ))
+
+
+def trusted_legacy_record(obj):
+    has_provider = bool(obj.get("provider") or obj.get("provider_error_type") or obj.get("provider_status"))
+    has_error = any(key in obj for key in ("error", "status", "provider_error_type", "provider_status"))
+    return has_provider and has_error
+
+
+def collect(path):
+    trusted_chunks = []
+    structured_errors = []
+    for raw_line in path.read_text(errors="ignore").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("{"):
+            try:
+                obj = json.loads(line)
+            except Exception:
+                obj = None
+            if isinstance(obj, dict):
+                structured = structured_api_error(obj)
+                if structured:
+                    structured_errors.append(structured)
+                    continue
+                if trusted_legacy_record(obj):
+                    trusted_chunks.append(line)
+            continue
+        if trusted_plaintext(line):
+            trusted_chunks.append(line)
+    return trusted_chunks, structured_errors
+
+
+def emit(reason, provider_type, status, pattern):
+    print("\t".join([reason, provider_type, status, "trusted_provider", pattern]))
+
+
+def classify_structured(record):
+    status = record["status"]
+    details = f"{record['message']}\n{record['body']}".lower()
+    if status == 403:
+        if record["body_kind"] == "html" or any(token in details for token in ("gateway", "proxy")):
+            return "provider_error", "gateway_denied", "403", "structured_api_error|html_403"
+        return "access_denied", "access_denied", "403", "structured_api_error|403"
+    if status == 401:
+        return "auth_error", "auth_error", "401", "structured_api_error|401"
+    if status == 429:
+        quota_tokens = (
+            "insufficient_quota", "insufficient quota", "quota_exceeded", "quota exceeded",
+            "credit_exhausted", "credit exhausted", "exhausted your credit",
+        )
+        if any(token in details for token in quota_tokens):
+            return "quota_exceeded", "quota_exceeded", "429", "structured_api_error|quota"
+        return "rate_limit", "rate_limit", "429", "structured_api_error|429"
+    if 500 <= status <= 599:
+        return "provider_error", "server_error", str(status), "structured_api_error|5xx"
+    return "provider_error", "api_error", str(status), "structured_api_error|http_status"
+
+
+def classify_plaintext(text):
+    quota = (
+        "insufficient_quota", "insufficient quota", "quota_exceeded", "quota exceeded",
+        "exceeded your current quota", "credit_exhausted", "credit exhausted", "exhausted your credit",
+    )
+    if any(token in text for token in quota):
+        return "quota_exceeded", "quota_exceeded", "429", "trusted_quota|insufficient_quota|quota_exceeded|credit_exhausted"
+    if any(token in text for token in ("rate limit", "rate_limit", "too many requests")) or re.search(r"\b429\b", text):
+        return "rate_limit", "rate_limit", "429", "trusted_rate_limit|429|too_many_requests"
+    if any(token in text for token in ("blocked by a gateway or proxy", "html gateway response")):
+        return "provider_error", "gateway_denied", "403", "trusted_gateway_denied|html_403"
+    if re.search(r"\b403\b", text) or any(token in text for token in ("forbidden", "access_denied", "access denied")):
+        return "access_denied", "access_denied", "403", "trusted_access_denied|403|forbidden"
+    server = re.search(r"\b(500|502|503|504)\b", text)
+    if server or any(token in text for token in ("server_error", "internal server error", "service unavailable", "bad gateway", "gateway timeout", "connection refused", "connection reset", "overloaded")):
+        status = "500"
+        if "504" in text or "gateway timeout" in text:
+            status = "504"
+        elif "503" in text or "service unavailable" in text:
+            status = "503"
+        elif "502" in text or "bad gateway" in text:
+            status = "502"
+        return "provider_error", "server_error", status, "trusted_server_error|5xx|connection_failure|overloaded"
+    auth = ("unauthorized", "invalid api key", "authentication failed", "token refresh failed", "invalid_grant", "invalid refresh token")
+    if re.search(r"\b401\b", text) or any(token in text for token in auth) or ("auth" in text and "failed" in text):
+        return "auth_error", "auth_error", "401", "trusted_auth_error|401|token_refresh|invalid_grant"
+    return None
+
+
+def main(argv):
+    if len(argv) != 2:
+        return 2
+    trusted_chunks, structured_errors = collect(Path(argv[1]))
+    result = classify_structured(structured_errors[-1]) if structured_errors else classify_plaintext("\n".join(trusted_chunks).lower())
+    if result:
+        emit(*result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.agents/scripts/headless-runtime-worker-prepare.sh
+++ b/.agents/scripts/headless-runtime-worker-prepare.sh
@@ -415,7 +415,7 @@ _cmd_run_prepare_retry() {
 		return 0
 	fi
 
-	if [[ "$_run_failure_reason" != "auth_error" && "$_run_failure_reason" != "rate_limit" && \
+	if [[ "$_run_failure_reason" != "access_denied" && "$_run_failure_reason" != "auth_error" && "$_run_failure_reason" != "rate_limit" && \
 		"$_run_failure_reason" != "provider_error" && "$_run_failure_reason" != "startup_no_model_activity" ]]; then
 		_cmd_run_finish "$session_key" "$_HRW_STATUS_FAIL"
 		return "$attempt_exit"

--- a/.agents/scripts/tests/test-headless-runtime-checkpoint-tests.sh
+++ b/.agents/scripts/tests/test-headless-runtime-checkpoint-tests.sh
@@ -599,6 +599,21 @@ test_completion_infrastructure_resumes_without_implementation_penalty() {
 	return 0
 }
 
+test_access_denied_has_provider_failure_evidence() {
+	local evidence_fields="" launch_failure_cause="" next_action=""
+	evidence_fields=$(_derive_worker_failure_evidence "access_denied" "1" "1" "natural" "access_denied")
+	launch_failure_cause="${evidence_fields%%$'\t'*}"
+	next_action="${evidence_fields#*$'\t'}"
+	if [[ "$launch_failure_cause" == "provider_access_denied" && \
+		"$next_action" == "switch_provider_or_check_access" ]]; then
+		print_result "access denied emits provider failure evidence" 0
+	else
+		print_result "access denied emits provider failure evidence" 1 \
+			"cause='${launch_failure_cause}' next='${next_action}'"
+	fi
+	return 0
+}
+
 test_pr_checkpoint_lifecycle_cases() {
 	test_post_pr_handoff_detects_open_pending_pr
 	test_post_pr_handoff_propagates_classifier_failure
@@ -616,5 +631,6 @@ test_pr_checkpoint_lifecycle_cases() {
 	test_failed_ci_ready_pr_is_durable_handoff
 	test_closed_unmerged_pr_is_failed_not_completed
 	test_failed_worker_ready_pr_remains_completed_handoff
+	test_access_denied_has_provider_failure_evidence
 	return 0
 }

--- a/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
+++ b/.agents/scripts/tests/test-headless-runtime-failure-classification.sh
@@ -103,6 +103,47 @@ check_classification \
 	"auth_error" "auth_error" "401" "" "trusted_provider"
 
 check_classification \
+	"gateway_forbidden" \
+	'OpenAI provider error: Forbidden: request was blocked by a gateway or proxy' \
+	"provider_error" "gateway_denied" "403" "" "trusted_provider"
+
+check_classification \
+	"opencode_html_gateway_denied" \
+	'{"type":"error","error":{"name":"APIError","data":{"message":"Forbidden","statusCode":403,"isRetryable":false,"responseBody":"<!doctype html><title>Forbidden</title>"}}}' \
+	"provider_error" "gateway_denied" "403" "" "trusted_provider"
+
+check_classification \
+	"opencode_json_access_denied" \
+	'{"type":"error","error":{"name":"APIError","data":{"message":"Forbidden","statusCode":403,"isRetryable":false,"responseBody":"denied"}}}' \
+	"access_denied" "access_denied" "403" "" "trusted_provider"
+
+check_classification \
+	"opencode_html_401_is_auth" \
+	'{"type":"error","error":{"name":"APIError","data":{"message":"Unauthorized","statusCode":401,"isRetryable":false,"responseBody":"<!doctype html><title>Unauthorized</title>"}}}' \
+	"auth_error" "auth_error" "401" "" "trusted_provider"
+
+check_classification \
+	"opencode_html_502_is_server_error" \
+	'{"type":"error","error":{"name":"APIError","data":{"message":"Bad Gateway","statusCode":502,"isRetryable":true,"responseBody":"<!doctype html><title>Bad Gateway</title>"}}}' \
+	"provider_error" "server_error" "502" "" "trusted_provider"
+
+check_classification \
+	"opencode_403_rate_text_remains_access_denied" \
+	'{"type":"error","error":{"name":"APIError","data":{"message":"Rate limit policy forbids this model","statusCode":403,"isRetryable":false,"responseBody":"denied"}}}' \
+	"access_denied" "access_denied" "403" "" "trusted_provider"
+
+check_classification \
+	"opencode_last_structured_error_is_authoritative" \
+	'{"type":"error","error":{"name":"APIError","data":{"message":"Forbidden","statusCode":403,"isRetryable":false,"responseBody":"denied"}}}
+{"type":"error","error":{"name":"APIError","data":{"message":"Bad Gateway","statusCode":502,"isRetryable":true,"responseBody":"upstream unavailable"}}}' \
+	"provider_error" "server_error" "502" "" "trusted_provider"
+
+check_classification \
+	"untrusted_provider_note_mentions_403" \
+	'Provider documentation note: clients can receive 403 Forbidden responses.' \
+	"local_error" "" "" "" "default_local"
+
+check_classification \
 	"opencode_sqlite_crash" \
 	'failed to list snapshot files in /tmp/opencode/snapshot
 fatal: not a git repository
@@ -141,6 +182,10 @@ assert_eq "metric provider_status persisted" "500" \
 	"$(jq -r '.provider_status' "$METRICS_FILE")"
 assert_eq "metric classification_source persisted" "output_pattern" \
 	"$(jq -r '.classification_source' "$METRICS_FILE")"
+assert_eq "access denied is retryable infrastructure without provider rotation" \
+	"$_HRFF_RETRY_CLASS_INFRASTRUCTURE" "$(_hrff_retry_class_for_reason "access_denied" "0")"
+assert_eq "access denied remains infrastructure after session creation" \
+	"$_HRFF_RETRY_CLASS_INFRASTRUCTURE" "$(_hrff_retry_class_for_reason "access_denied" "1")"
 
 write_retry_fixture() {
 	local name="$1"

--- a/TODO.md
+++ b/TODO.md
@@ -1250,6 +1250,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t18225 Stop recurring GitHub Actions failure notifications #bug #ci #priority:high ref:GH#29956
 
+- [ ] t18226 Diagnose and classify OpenCode gateway 403 failures #auto-dispatch #priority:high #type:bug ref:GH#29974
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Capture redacted structured provider-error evidence, explain transient HTML 403 gateway denials accurately in interactive OpenCode sessions, and route headless 403 failures without credential rotation.

## Files Changed

.agents/plugins/opencode-aidevops/index.mjs, .agents/plugins/opencode-aidevops/observability.mjs, .agents/plugins/opencode-aidevops/provider-error-diagnostics.mjs, .agents/plugins/opencode-aidevops/tests/test-provider-error-diagnostics.mjs, .agents/plugins/opencode-aidevops/tests/test-runtime-events.mjs, .agents/scripts/headless-runtime-failure.sh, .agents/scripts/headless-runtime-helper.sh, .agents/scripts/headless-runtime-lib.sh, .agents/scripts/headless-runtime-provider-classifier.py, .agents/scripts/headless-runtime-worker-prepare.sh, .agents/scripts/tests/test-headless-runtime-checkpoint-tests.sh, .agents/scripts/tests/test-headless-runtime-failure-classification.sh, TODO.md

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Runtime-verified with 627 OpenCode plugin tests, including live plugin event/SQLite integration; 106 provider-classification assertions against the headless runtime; full headless-runtime helper suite; ShellCheck; Python compile; linters-local; independent closeout review CLEAN.

Resolves #29974


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.250 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 6m and 96,271 tokens on this with the user in an interactive session.