### PR TITLE
GH#29961: create unpublished tasks in pending state

### DIFF
--- a/.agents/scripts/claim-task-id-issue.sh
+++ b/.agents/scripts/claim-task-id-issue.sh
@@ -304,6 +304,29 @@ _interactive_session_auto_claim_new_task() {
 # Issue Creation Helpers
 # =============================================================================
 
+# Project intended planning labels into the safe pre-publication issue state.
+# TODO.md retains the original labels so exact default-branch reconciliation can
+# apply them later; only positive dispatch labels are withheld from the issue.
+_publication_pending_labels() {
+	local labels="$1"
+	local projected="" label=""
+	while IFS= read -r label; do
+		[[ -z "$label" || "$label" == "auto-dispatch" || "$label" == "status:available" || "$label" == "publication:pending" ]] && continue
+		projected="${projected:+${projected},}${label}"
+	done < <(printf '%s\n' "$labels" | tr ',' '\n')
+	printf '%s\n' "${projected:+${projected},}publication:pending"
+	return 0
+}
+
+_verify_publication_pending_label() {
+	local issue_num="$1"
+	local repo="$2"
+	[[ -n "$issue_num" && -n "$repo" ]] || return 1
+	gh issue view "$issue_num" --repo "$repo" --json labels \
+		--jq 'any(.labels[]?; .name == "publication:pending")' 2>/dev/null |
+		grep -qx true
+}
+
 # Try delegating issue creation to issue-sync-helper.sh for rich bodies,
 # proper labels (including auto-dispatch), and duplicate detection (t1324).
 # Echoes the issue number on success, returns 1 if delegation unavailable/failed.

--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -12,6 +12,9 @@
 #   --description "Details"    Task description (required for issue creation unless
 #                              a brief file exists at todo/tasks/{task_id}-brief.md)
 #   --labels "label1,label2"   Comma-separated labels (optional)
+#   --publication-state STATE  Issue/planning state: pending (default) withholds
+#                              dispatch labels; canonical is for verified
+#                              default-branch creation only
 #   --count N                  Allocate N consecutive IDs (default: 1)
 #                              Creates one GitHub/GitLab issue per ID using
 #                              the same --title. Output includes ref_tNNN=GH#NNN
@@ -139,6 +142,8 @@ NO_BLOCKED_BY=false
 TASK_TITLE=""
 TASK_DESCRIPTION=""
 TASK_LABELS=""
+TASK_PUBLICATION_STATE="pending"
+TASK_COUNTER_STATUS_FALLBACK="fallback"
 # t2838: populated by --parent-issue N; read by _compose_issue_body for body
 # injection and create_github_issue / _try_issue_sync_delegation for explicit
 # addSubIssue mutation after issue creation.
@@ -268,6 +273,14 @@ parse_args() {
 			;;
 		--labels)
 			TASK_LABELS="$2"
+			shift 2
+			;;
+		--publication-state)
+			TASK_PUBLICATION_STATE="${2:-}"
+			if [[ "$TASK_PUBLICATION_STATE" != "pending" && "$TASK_PUBLICATION_STATE" != "canonical" ]]; then
+				log_error "--publication-state must be pending or canonical"
+				exit 1
+			fi
 			shift 2
 			;;
 		--count)
@@ -539,7 +552,8 @@ create_github_issue() {
 
 	# Try rich delegation first (t1324)
 	local issue_num
-	if issue_num=$(_try_issue_sync_delegation "$title" "$repo_path"); then
+	if issue_num=$(AIDEVOPS_PLANNING_PUBLICATION_STATE="$TASK_PUBLICATION_STATE" \
+		_try_issue_sync_delegation "$title" "$repo_path"); then
 		_auto_assign_issue "$issue_num" "$repo_path"
 		_interactive_session_auto_claim_new_task "$issue_num" "$repo_path"
 		_lock_maintainer_issue_at_creation "$issue_num" "$repo_path"
@@ -573,6 +587,11 @@ create_github_issue() {
 		# parseable number. The duplicate lookup then recovers the issue number;
 		# stamp/verify TODO.md before reporting success so dispatchability sees
 		# the same state as the returned issue number.
+		if [[ "$TASK_PUBLICATION_STATE" == "pending" ]] &&
+			! _verify_publication_pending_label "$issue_num" "$_slug_for_warn"; then
+			log_warn "Recovered issue #${issue_num}, but publication:pending could not be verified"
+			return 1
+		fi
 		if ! _converge_created_issue_ref \
 			"$_task_id_for_todo" "$issue_num" "$title" "$labels" "$repo_path"; then
 			log_warn "Recovered issue #${issue_num}, but failed to persist task mapping for ${_task_id_for_todo}"
@@ -604,14 +623,21 @@ create_github_issue() {
 	fi
 	create_args+=(--body "$body")
 
-	# t2789: Ensure new issues are immediately dispatchable by applying
+	# Published tasks retain the historical status default. Tasks created before
+	# their planning reaches the default branch withhold positive dispatch labels
+	# and carry an independently enforced publication blocker instead.
+	if [[ "$TASK_PUBLICATION_STATE" == "pending" ]]; then
+		labels=$(_publication_pending_labels "$labels")
+	fi
+
+	# t2789: Ensure canonical new issues are immediately dispatchable by applying
 	# status:available when the caller did not specify any status:* label.
 	# Without this default, new issues have no status label, and the pulse
 	# dispatcher's candidate filter (which requires status:available) skips
 	# them entirely until a human or downstream process labels them.
 	# Callers that pass an explicit status:* (e.g. status:queued, status:blocked,
 	# status:in-review) are respected verbatim — this only fills the gap.
-	if [[ ",${labels}," != *",status:"* ]]; then
+	if [[ "$TASK_PUBLICATION_STATE" == "canonical" && ",${labels}," != *",status:"* ]]; then
 		if [[ -n "$labels" ]]; then
 			labels="${labels},status:available"
 		else
@@ -641,6 +667,11 @@ create_github_issue() {
 
 	if [[ -z "$issue_num" ]]; then
 		log_warn "Failed to extract issue number from: $issue_url"
+		return 1
+	fi
+	if [[ "$TASK_PUBLICATION_STATE" == "pending" ]] &&
+		! _verify_publication_pending_label "$issue_num" "$_slug_for_warn"; then
+		log_warn "Created issue #${issue_num}, but publication:pending could not be verified"
 		return 1
 	fi
 
@@ -989,13 +1020,13 @@ _main_resolve_allocation() {
 				return 1
 			fi
 			log_warn "Online allocation failed; using automatic auditable offline fallback (CAS_EXHAUSTION_FATAL=0)"
-			_task_counter_status "fallback" "offline_offset"
-			allocation_status="fallback"
+			_task_counter_status "$TASK_COUNTER_STATUS_FALLBACK" "offline_offset"
+			allocation_status="$TASK_COUNTER_STATUS_FALLBACK"
 			is_offline_out="true"
 		fi
 	else
 		is_offline_out="true"
-		allocation_status="fallback"
+		allocation_status="$TASK_COUNTER_STATUS_FALLBACK"
 	fi
 
 	if [[ "$is_offline_out" == "true" ]]; then

--- a/.agents/scripts/issue-sync-helper-push.sh
+++ b/.agents/scripts/issue-sync-helper-push.sh
@@ -31,6 +31,11 @@
 [[ -n "${_ISSUE_SYNC_HELPER_PUSH_LOADED:-}" ]] && return 0
 _ISSUE_SYNC_HELPER_PUSH_LOADED=1
 
+_PUSH_PUBLICATION_PENDING="pending"
+_PUSH_PUBLICATION_CANONICAL="canonical"
+_PUSH_STATUS_AVAILABLE="status:available"
+_PUSH_BOOLEAN_TRUE="true"
+
 # Defensive SCRIPT_DIR fallback
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	_lib_path="${BASH_SOURCE[0]%/*}"
@@ -123,17 +128,10 @@ _push_create_issue() {
 	local task_id="$1" repo="$2" todo_file="$3" title="$4" body="$5" labels="$6" assignee="$7"
 	_PUSH_CREATED_NUM=""
 
-	[[ -n "$labels" ]] && ensure_labels_exist "$labels" "$repo"
-	local status_label="status:available"
-	[[ -n "$assignee" ]] && {
-		status_label="status:claimed"
-		gh_create_label "$repo" "status:claimed" "D93F0B" "Task is claimed"
-	}
-	# Add session origin label (origin:worker or origin:interactive)
-	local origin_label
-	origin_label=$(session_origin_label)
-	gh_create_label "$repo" "$origin_label" "C5DEF5" "Created from ${origin_label#origin:} session"
-	local all_labels="${labels:+${labels},}${status_label},${origin_label}"
+	_push_prepare_creation_labels "$labels" "$assignee" "$repo" || return 2
+	local publication_state="$_PUSH_CREATION_STATE"
+	local origin_label="$_PUSH_CREATION_ORIGIN"
+	local all_labels="$_PUSH_CREATION_ALL_LABELS"
 
 	# cool — belt-and-suspenders race guard right before creation
 	local recheck
@@ -168,7 +166,7 @@ _push_create_issue() {
 			gh_exit=$?
 		} || true
 	fi
-	if [[ $gh_exit -ne 0 && "$combined" == *"repository.labels"* ]]; then
+	if [[ $gh_exit -ne 0 && "$combined" == *"repository.labels"* && "$publication_state" == "$_PUSH_PUBLICATION_CANONICAL" ]]; then
 		print_warning "Label lookup failed for $task_id; retrying issue creation without labels"
 		{
 			combined=$(_push_create_issue_without_labels "$repo" "$title" "$body" "$assignee")
@@ -188,11 +186,8 @@ _push_create_issue() {
 			print_warning "gh create exited $gh_exit but issue found via recovery: #$recovery"
 			log_verbose "gh output: ${combined:0:200}"
 			_PUSH_CREATED_NUM="$recovery"
-			add_gh_ref_to_todo "$task_id" "$recovery" "$todo_file"
-			if ! require_task_issue_mapping "$task_id" "$todo_file" "$repo" "$recovery"; then
-				print_error "Recovered #${recovery}, but immutable mapping validation failed"
-				return 2
-			fi
+			_push_verify_created_mapping "$task_id" "$repo" "$todo_file" \
+				"$recovery" "$publication_state" "Recovered" || return 2
 			return 0
 		fi
 		print_error "Failed to create issue for $task_id (exit $gh_exit): ${combined:0:200}"
@@ -203,11 +198,8 @@ _push_create_issue() {
 	num=$(echo "$url" | grep -oE '[0-9]+$' || echo "")
 	[[ -n "$num" ]] && _PUSH_CREATED_NUM="$num"
 	if [[ -n "$num" ]]; then
-		add_gh_ref_to_todo "$task_id" "$num" "$todo_file"
-		if ! require_task_issue_mapping "$task_id" "$todo_file" "$repo" "$num"; then
-			print_error "Created #${num}, but immutable mapping validation failed"
-			return 2
-		fi
+		_push_verify_created_mapping "$task_id" "$repo" "$todo_file" \
+			"$num" "$publication_state" "Created" || return 2
 	fi
 
 	# t1970/t1984/t2157: auto-assign interactive origin issues (not auto-dispatch).
@@ -218,6 +210,68 @@ _push_create_issue() {
 	# Mapping validation above must precede this lock mutation.
 	[[ -n "$num" ]] && _push_lock_created_issue "$num" "$repo" "$origin_label"
 	return 0
+}
+
+_push_prepare_creation_labels() {
+	local labels="$1" assignee="$2" repo="$3"
+	_PUSH_CREATION_STATE="${AIDEVOPS_PLANNING_PUBLICATION_STATE:-$_PUSH_PUBLICATION_CANONICAL}"
+	if [[ "$_PUSH_CREATION_STATE" != "$_PUSH_PUBLICATION_PENDING" &&
+		"$_PUSH_CREATION_STATE" != "$_PUSH_PUBLICATION_CANONICAL" ]]; then
+		print_error "Invalid planning publication state: $_PUSH_CREATION_STATE"
+		return 1
+	fi
+	if [[ "$_PUSH_CREATION_STATE" == "$_PUSH_PUBLICATION_PENDING" ]]; then
+		labels=$(_push_pending_publication_labels "$labels")
+	fi
+	[[ -n "$labels" ]] && ensure_labels_exist "$labels" "$repo"
+	local status_label="$_PUSH_STATUS_AVAILABLE"
+	if [[ -n "$assignee" ]]; then
+		status_label="status:claimed"
+		gh_create_label "$repo" "$status_label" "D93F0B" "Task is claimed"
+	fi
+	_PUSH_CREATION_ORIGIN=$(session_origin_label)
+	gh_create_label "$repo" "$_PUSH_CREATION_ORIGIN" "C5DEF5" \
+		"Created from ${_PUSH_CREATION_ORIGIN#origin:} session"
+	_PUSH_CREATION_ALL_LABELS="${labels:+${labels},}${_PUSH_CREATION_ORIGIN}"
+	if [[ "$_PUSH_CREATION_STATE" == "$_PUSH_PUBLICATION_CANONICAL" ||
+		"$status_label" != "$_PUSH_STATUS_AVAILABLE" ]]; then
+		_PUSH_CREATION_ALL_LABELS="${_PUSH_CREATION_ALL_LABELS},${status_label}"
+	fi
+	return 0
+}
+
+_push_verify_created_mapping() {
+	local task_id="$1" repo="$2" todo_file="$3" issue_num="$4" publication_state="$5" verb="$6"
+	if [[ "$publication_state" == "$_PUSH_PUBLICATION_PENDING" ]] &&
+		! _push_verify_publication_pending "$issue_num" "$repo"; then
+		print_error "${verb} #${issue_num}, but publication:pending could not be verified"
+		return 1
+	fi
+	add_gh_ref_to_todo "$task_id" "$issue_num" "$todo_file"
+	if ! require_task_issue_mapping "$task_id" "$todo_file" "$repo" "$issue_num"; then
+		print_error "${verb} #${issue_num}, but immutable mapping validation failed"
+		return 1
+	fi
+	return 0
+}
+
+_push_pending_publication_labels() {
+	local labels="$1"
+	local projected="" label=""
+	while IFS= read -r label; do
+		[[ -z "$label" || "$label" == "auto-dispatch" || "$label" == "$_PUSH_STATUS_AVAILABLE" || "$label" == "publication:pending" ]] && continue
+		projected="${projected:+${projected},}${label}"
+	done < <(printf '%s\n' "$labels" | tr ',' '\n')
+	printf '%s\n' "${projected:+${projected},}publication:pending"
+	return 0
+}
+
+_push_verify_publication_pending() {
+	local issue_num="$1"
+	local repo="$2"
+	gh issue view "$issue_num" --repo "$repo" --json labels \
+		--jq 'any(.labels[]?; .name == "publication:pending")' 2>/dev/null |
+		grep -qx true
 }
 
 # GH#18041 (t1957): Collision detection — warn if a merged PR already uses
@@ -243,6 +297,13 @@ _push_warn_if_task_id_collides() {
 
 cmd_push() {
 	local target_task="${1:-}"
+	if [[ -z "${AIDEVOPS_PLANNING_PUBLICATION_STATE:-}" ]]; then
+		if [[ "${GITHUB_ACTIONS:-}" == "$_PUSH_BOOLEAN_TRUE" && -z "$target_task" ]]; then
+			AIDEVOPS_PLANNING_PUBLICATION_STATE="$_PUSH_PUBLICATION_CANONICAL"
+		else
+			AIDEVOPS_PLANNING_PUBLICATION_STATE="$_PUSH_PUBLICATION_PENDING"
+		fi
+	fi
 	_init_cmd || return 1
 	local repo="$_CMD_REPO" todo_file="$_CMD_TODO" project_root="$_CMD_ROOT"
 
@@ -258,12 +319,12 @@ cmd_push() {
 	#
 	# Fix: bulk push (no target_task) is CI-only unless --force-push is passed.
 	# Single-task push (claim-task-id.sh path) is always allowed.
-	if [[ -z "$target_task" && "${GITHUB_ACTIONS:-}" != "true" && "$FORCE_PUSH" != "true" ]]; then
+	if [[ -z "$target_task" && "${GITHUB_ACTIONS:-}" != "$_PUSH_BOOLEAN_TRUE" && "$FORCE_PUSH" != "$_PUSH_BOOLEAN_TRUE" ]]; then
 		print_info "Bulk push skipped — CI is the single authority for issue creation from TODO.md"
 		print_info "Use 'issue-sync-helper.sh push <task_id>' for single tasks, or --force-push to override"
 		return 0
 	fi
-	if [[ "$FORCE_PUSH" == "true" && -z "$target_task" ]]; then
+	if [[ "$FORCE_PUSH" == "$_PUSH_BOOLEAN_TRUE" && -z "$target_task" ]]; then
 		print_info "FORCE_PUSH active — bypassing CI-only gate for bulk push (GH#20146 audit)"
 	fi
 
@@ -278,7 +339,7 @@ cmd_push() {
 	}
 
 	print_info "Processing ${#tasks[@]} task(s) for push to $repo"
-	gh_create_label "$repo" "status:available" "0E8A16" "Task is available for claiming"
+	gh_create_label "$repo" "$_PUSH_STATUS_AVAILABLE" "0E8A16" "Task is available for claiming"
 
 	local created=0 skipped=0 failed=0 relationships_pending=0
 	for task_id in "${tasks[@]}"; do

--- a/.agents/scripts/new-task-helper.sh
+++ b/.agents/scripts/new-task-helper.sh
@@ -217,7 +217,8 @@ _resolve_pending_task_ref() {
 		log_error "Cannot resolve $task_id ref:none — issue-sync-helper.sh is missing"
 		return 1
 	fi
-	if ! (cd "$repo_path" && "$sync_helper" push "$task_id" >/dev/null); then
+	if ! (cd "$repo_path" && AIDEVOPS_PLANNING_PUBLICATION_STATE=pending \
+		"$sync_helper" push "$task_id" >/dev/null); then
 		log_error "Tracker issue creation failed for $task_id"
 		return 1
 	fi
@@ -380,7 +381,7 @@ _allocate_one_task() {
 	local repo_path="$5"
 	local claim_script="$6"
 
-	local -a claim_args=(--title "$title" --repo-path "$repo_path")
+	local -a claim_args=(--title "$title" --repo-path "$repo_path" --publication-state pending)
 	[[ -n "$labels" ]] && claim_args+=(--labels "$labels")
 	[[ "$no_issue" == "true" ]] && claim_args+=(--no-issue)
 	[[ "$offline" == "true" ]] && claim_args+=(--offline)

--- a/.agents/scripts/tests/test-claim-task-id-no-orphan.sh
+++ b/.agents/scripts/tests/test-claim-task-id-no-orphan.sh
@@ -81,6 +81,11 @@ if ! declare -F _ensure_todo_entry_written >/dev/null 2>&1; then
 	exit 1
 fi
 
+# Issue creation now requires a verified publication blocker before local
+# planning lands. These persistence tests isolate TODO/ref convergence; the
+# blocker failure path is covered by test-issue-sync-publication-pending.sh.
+_verify_publication_pending_label() { return 0; }
+
 printf '%sRunning _ensure_todo_entry_written tests (t2548)%s\n' "$BLUE" "$NC"
 
 # ---------------------------------------------------------------------------

--- a/.agents/scripts/tests/test-claim-task-id-status-default.sh
+++ b/.agents/scripts/tests/test-claim-task-id-status-default.sh
@@ -4,9 +4,8 @@
 #
 # test-claim-task-id-status-default.sh — GH#20714/t2789 regression guard.
 #
-# Verifies that claim-task-id.sh's bare GitHub issue creation path applies
-# status:available when callers provide no lifecycle status label, while
-# preserving explicit status:* labels unchanged.
+# Verifies pending creation withholds positive dispatch labels and canonical
+# creation retains the historical status:available default.
 
 set -uo pipefail
 
@@ -109,6 +108,10 @@ _setup() {
 		return 0
 	}
 
+	_verify_publication_pending_label() {
+		return 0
+	}
+
 	_auto_assign_issue() {
 		return 0
 	}
@@ -138,6 +141,8 @@ _setup() {
 
 run_create() {
 	local labels="$1"
+	local state="${2:-pending}"
+	TASK_PUBLICATION_STATE="$state"
 	: >"$CREATE_ARGS_FILE"
 	create_github_issue "t2789: test default status label" "body" "$labels" "${STUB_DIR}/repo" >/dev/null
 	local create_args=""
@@ -149,18 +154,20 @@ run_create() {
 _setup
 
 args_default=$(run_create 'auto-dispatch,tier:standard,bug')
-assert_contains "default_status_available_added" "$args_default" '--label auto-dispatch,tier:standard,bug,status:available'
+assert_contains "pending_blocker_added" "$args_default" '--label tier:standard,bug,publication:pending'
+assert_not_contains "pending_auto_dispatch_withheld" "$args_default" 'auto-dispatch'
+assert_not_contains "pending_status_available_withheld" "$args_default" 'status:available'
 
 args_empty=$(run_create '')
-assert_contains "empty_labels_status_available_added" "$args_empty" '--label status:available'
+assert_contains "empty_labels_pending_blocker_added" "$args_empty" '--label publication:pending'
 
 args_explicit=$(run_create 'auto-dispatch,status:blocked,tier:standard')
-assert_contains "explicit_status_preserved" "$args_explicit" '--label auto-dispatch,status:blocked,tier:standard'
+assert_contains "explicit_blocked_status_preserved" "$args_explicit" '--label status:blocked,tier:standard,publication:pending'
 assert_not_contains "explicit_status_no_default" "$args_explicit" 'status:available'
 
-args_duplicate=$(run_create 'auto-dispatch,tier:standard,auto-dispatch,status:available,tier:standard')
-assert_contains "duplicate_labels_collapsed" "$args_duplicate" '--label auto-dispatch,tier:standard,status:available'
-assert_not_contains "duplicate_labels_no_repeat" "$args_duplicate" 'auto-dispatch,tier:standard,auto-dispatch'
+args_canonical=$(run_create 'auto-dispatch,tier:standard,bug' canonical)
+assert_contains "canonical_status_available_added" "$args_canonical" '--label auto-dispatch,tier:standard,bug,status:available'
+assert_not_contains "canonical_has_no_pending_blocker" "$args_canonical" 'publication:pending'
 
 if [[ $FAIL -eq 0 ]]; then
 	printf '%sAll claim-task-id status default tests passed%s (%d assertions)\n' "$GREEN" "$NC" "$PASS"

--- a/.agents/scripts/tests/test-issue-sync-publication-pending.sh
+++ b/.agents/scripts/tests/test-issue-sync-publication-pending.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${SCRIPT_DIR}/.."
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+GH_CALLS="${TMP_DIR}/gh-calls"
+
+print_info() { return 0; }
+print_warning() { return 0; }
+print_error() { return 0; }
+log_verbose() { return 0; }
+ensure_labels_exist() { return 0; }
+gh_create_label() { return 0; }
+gh_find_issue_by_title() { return 0; }
+add_gh_ref_to_todo() { return 0; }
+require_task_issue_mapping() { return 0; }
+session_origin_label() { printf '%s\n' 'origin:interactive'; }
+_rest_should_fallback() { return 1; }
+
+# shellcheck source=../issue-sync-helper-push.sh
+source "${SCRIPTS_DIR}/issue-sync-helper-push.sh"
+
+gh() {
+	printf '%s\n' "$*" >>"$GH_CALLS"
+	if [[ "$1 $2" == "issue create" ]]; then
+		printf '%s\n' 'https://github.com/owner/repo/issues/77'
+		return 0
+	fi
+	if [[ "$1 $2" == "issue view" ]]; then
+		printf '%s\n' "${PENDING_LABEL_VISIBLE:-true}"
+		return 0
+	fi
+	return 0
+}
+
+run_create() {
+	: >"$GH_CALLS"
+	_PUSH_CREATED_NUM=""
+	AIDEVOPS_PLANNING_PUBLICATION_STATE="$1" \
+		_push_create_issue t9000 owner/repo "${TMP_DIR}/TODO.md" \
+		"t9000: publication test" body "auto-dispatch,tier:standard,status:available" ""
+}
+
+run_create pending
+pending_args=$(grep '^issue create' "$GH_CALLS")
+[[ "$pending_args" == *'tier:standard,publication:pending,origin:interactive'* ]]
+[[ "$pending_args" != *'auto-dispatch'* ]]
+[[ "$pending_args" != *'status:available'* ]]
+printf 'PASS pending issue creation withholds positive dispatch labels\n'
+
+run_create canonical
+canonical_args=$(grep '^issue create' "$GH_CALLS")
+[[ "$canonical_args" == *'auto-dispatch,tier:standard,status:available,origin:interactive,status:available'* ]]
+[[ "$canonical_args" != *'publication:pending'* ]]
+printf 'PASS canonical issue creation retains dispatch projection\n'
+
+if PENDING_LABEL_VISIBLE=false run_create pending; then
+	printf 'FAIL pending creation succeeded without verified blocker\n' >&2
+	exit 1
+fi
+printf 'PASS pending issue creation fails when blocker verification fails\n'
+
+grep -Fq 'AIDEVOPS_PLANNING_PUBLICATION_STATE=pending' "${SCRIPTS_DIR}/new-task-helper.sh"
+grep -Fq -- '--publication-state pending' "${SCRIPTS_DIR}/new-task-helper.sh"
+grep -Fq '#auto-dispatch' "${SCRIPTS_DIR}/new-task-helper.sh"
+printf 'PASS batch planning retains intent while creating pending issues\n'
+
+grep -Fq "'publication:pending'" \
+	"${SCRIPTS_DIR}/../../.github/workflows/apply-status-available-default.yml"
+printf 'PASS platform status default excludes pending publication\n'

--- a/.github/workflows/apply-status-available-default.yml
+++ b/.github/workflows/apply-status-available-default.yml
@@ -59,6 +59,7 @@ jobs:
               'persistent',
               'consolidation-task',
               'routine-tracking',
+              'publication:pending',
               'no-auto-dispatch'
             ];
             if (labels.some(l => excluded.includes(l))) {


### PR DESCRIPTION
## Summary

Implement publication lifecycle phase 2: local rich, fallback, REST, and batch task creators apply publication:pending, withhold auto-dispatch/status:available, verify the blocker, and preserve intended planning labels for later reconciliation.

## Files Changed

.agents/scripts/claim-task-id-issue.sh, .agents/scripts/claim-task-id.sh, .agents/scripts/issue-sync-helper-push.sh, .agents/scripts/new-task-helper.sh, .agents/scripts/tests/test-claim-task-id-no-orphan.sh, .agents/scripts/tests/test-claim-task-id-status-default.sh, .agents/scripts/tests/test-issue-sync-publication-pending.sh, .github/workflows/apply-status-available-default.yml

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: executable creator fixtures run the production shell helpers with isolated GitHub transport and confirm pending, canonical, and failed-verification behavior; local linters pass; claim status tests 8/8; no-orphan tests 13/13; auto-assign tests 6/6; focused publication tests 5/5; issue-sync failure suite passes; phase-1 pulse publication guards remain green; review bundle fb9e16077a8d74877a7a535e51304cccb2990c8c8e0fa684eaca32ab03387f13.

For #29961


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.250 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 6m and 168,009 tokens on this with the user in an interactive session.
