### PR TITLE
GH#29961: reconcile exact planning publications

### DIFF
--- a/.agents/scripts/planning-publication-reconcile.sh
+++ b/.agents/scripts/planning-publication-reconcile.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Reconcile issue-first planning only after its exact default-branch snapshot lands.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+# shellcheck source=./issue-sync-lib.sh
+source "${SCRIPT_DIR}/issue-sync-lib.sh"
+
+PUBLICATION_PENDING_LABEL="publication:pending"
+PUBLICATION_AVAILABLE_LABEL="status:available"
+PUBLICATION_AUTO_LABEL="auto-dispatch"
+PUBLICATION_LIMIT="${AIDEVOPS_PUBLICATION_RECONCILE_LIMIT:-100}"
+
+_publication_usage() {
+	printf 'Usage: planning-publication-reconcile.sh reconcile --repo owner/repo --sha SHA [--task tNNN]\n'
+}
+
+_publication_exact_default_snapshot() {
+	local expected_sha="$1"
+	local default_branch="$2"
+	local head_sha="" remote_sha=""
+	[[ "$expected_sha" =~ ^[0-9a-f]{40}$ ]] || return 1
+	head_sha=$(git rev-parse HEAD 2>/dev/null) || return 1
+	[[ "$head_sha" == "$expected_sha" ]] || return 1
+	remote_sha=$(git rev-parse "refs/remotes/origin/${default_branch}" 2>/dev/null) || return 1
+	[[ "$remote_sha" == "$expected_sha" ]]
+}
+
+_publication_task_line() {
+	local task_id="$1"
+	local task_re="${task_id//./\\.}"
+	local matches=""
+	matches=$(grep -E "^[[:space:]]*-[[:space:]]+\[[ x]\][[:space:]]+${task_re}[[:space:]]" TODO.md || true)
+	[[ "$(printf '%s\n' "$matches" | grep -c . || true)" -eq 1 ]] || return 1
+	printf '%s\n' "$matches"
+}
+
+_publication_desired_labels() {
+	local task_line="$1"
+	local parsed="" tags="" labels=""
+	parsed=$(parse_task_line "$task_line") || return 1
+	tags=$(printf '%s\n' "$parsed" | grep '^tags=' | cut -d= -f2-)
+	labels=$(map_tags_to_labels "$tags")
+	{
+		printf '%s\n' "$labels" | tr ',' '\n' |
+		grep -v -E "^(${PUBLICATION_PENDING_LABEL}|${PUBLICATION_AVAILABLE_LABEL})$" |
+		grep -v '^$' | LC_ALL=C sort -u | paste -sd, -
+	} || true
+	return 0
+}
+
+_publication_status_label() {
+	local desired_labels="$1"
+	local fenced=",${desired_labels},"
+	if [[ "$fenced" == *",${PUBLICATION_AUTO_LABEL},"* &&
+		"$fenced" != *",parent-task,"* && "$fenced" != *",meta,"* &&
+		"$fenced" != *",status:blocked,"* && "$fenced" != *",status:in-review,"* &&
+		"$fenced" != *",no-auto-dispatch,"* && "$fenced" != *",hold-for-review,"* ]]; then
+		printf '%s\n' "$PUBLICATION_AVAILABLE_LABEL"
+	fi
+	return 0
+}
+
+_publication_issue_has_labels() {
+	local issue_json="$1"
+	local labels_csv="$2"
+	local label=""
+	while IFS= read -r label; do
+		[[ -n "$label" ]] || continue
+		jq -e --arg label "$label" 'any(.labels[]?; .name == $label)' \
+			<<<"$issue_json" >/dev/null || return 1
+	done < <(printf '%s\n' "$labels_csv" | tr ',' '\n')
+	return 0
+}
+
+_publication_validate_mapping() {
+	local task_id="$1" issue_num="$2"
+	local task_line="" brief_path="todo/tasks/${task_id}-brief.md"
+	task_line=$(_publication_task_line "$task_id") || return 1
+	[[ "$task_line" =~ (^|[[:space:]])ref:GH#${issue_num}($|[[:space:]]) ]] || return 1
+	[[ -f "$brief_path" && ! -L "$brief_path" ]] || return 1
+	"${SCRIPT_DIR}/verify-brief-helper.sh" check-readiness "$brief_path" >/dev/null 2>&1 || return 1
+	printf '%s\n' "$task_line"
+}
+
+_publication_reconcile_one() {
+	local repo="$1" task_id="$2" issue_num="$3"
+	local task_line="" desired_labels="" status_label="" projected_labels="" issue_json=""
+	task_line=$(_publication_validate_mapping "$task_id" "$issue_num") || {
+		print_warning "${task_id}/#${issue_num}: canonical task, ref, or brief validation failed; retaining ${PUBLICATION_PENDING_LABEL}"
+		return 1
+	}
+	desired_labels=$(_publication_desired_labels "$task_line") || return 1
+	status_label=$(_publication_status_label "$desired_labels")
+	projected_labels="$desired_labels"
+	[[ -n "$status_label" ]] && projected_labels="${projected_labels:+${projected_labels},}${status_label}"
+
+	if [[ -n "$projected_labels" ]]; then
+		"${SCRIPT_DIR}/gh-write-helper.sh" issue edit "$issue_num" --repo "$repo" \
+			--add-label "$projected_labels" >/dev/null || return 1
+	fi
+	issue_json=$(gh issue view "$issue_num" --repo "$repo" --json number,title,state,labels) || return 1
+	jq -e --arg task_prefix "${task_id}:" \
+		'.state == "OPEN" and (.title | startswith($task_prefix))' \
+		<<<"$issue_json" >/dev/null || return 1
+	_publication_issue_has_labels "$issue_json" "$projected_labels" || return 1
+	_publication_issue_has_labels "$issue_json" "$PUBLICATION_PENDING_LABEL" || return 1
+
+	# The blocker is intentionally the final mutation. Every prior failure leaves
+	# the issue undispatchable and safely retryable.
+	"${SCRIPT_DIR}/gh-write-helper.sh" issue edit "$issue_num" --repo "$repo" \
+		--remove-label "$PUBLICATION_PENDING_LABEL" >/dev/null || return 1
+	issue_json=$(gh issue view "$issue_num" --repo "$repo" --json labels) || return 1
+	if _publication_issue_has_labels "$issue_json" "$PUBLICATION_PENDING_LABEL"; then
+		return 1
+	fi
+	_publication_issue_has_labels "$issue_json" "$projected_labels" || return 1
+	print_success "${task_id}/#${issue_num}: planning publication reconciled"
+	return 0
+}
+
+cmd_reconcile() {
+	local repo="" expected_sha="" task_filter="" default_branch=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--repo) repo="${2:-}"; shift 2 ;;
+		--sha) expected_sha="${2:-}"; shift 2 ;;
+		--task) task_filter="${2:-}"; shift 2 ;;
+		*) _publication_usage >&2; return 2 ;;
+		esac
+	done
+	[[ "$repo" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || return 2
+	[[ -f TODO.md && ! -L TODO.md ]] || return 2
+	default_branch=$(gh repo view "$repo" --json defaultBranchRef --jq '.defaultBranchRef.name') || return 2
+	_publication_exact_default_snapshot "$expected_sha" "$default_branch" || {
+		print_error "Refusing reconciliation: HEAD is not exact origin/${default_branch} SHA ${expected_sha}"
+		return 1
+	}
+
+	local issues_json="" issue_num="" title="" task_id="" failed=0
+	issues_json=$(gh issue list --repo "$repo" --state open --label "$PUBLICATION_PENDING_LABEL" \
+		--limit "$PUBLICATION_LIMIT" --json number,title) || return 1
+	while IFS=$'\t' read -r issue_num title; do
+		[[ -n "$issue_num" ]] || continue
+		task_id=$(printf '%s\n' "$title" | grep -oE '^t[0-9]+(\.[0-9]+)*' || true)
+		[[ -n "$task_id" ]] || { failed=$((failed + 1)); continue; }
+		[[ -z "$task_filter" || "$task_id" == "$task_filter" ]] || continue
+		_publication_reconcile_one "$repo" "$task_id" "$issue_num" || failed=$((failed + 1))
+	done < <(jq -r '.[] | [.number, .title] | @tsv' <<<"$issues_json")
+	[[ "$failed" -eq 0 ]]
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	case "${1:-}" in
+	reconcile) shift; cmd_reconcile "$@" ;;
+	*) _publication_usage >&2; exit 2 ;;
+	esac
+fi

--- a/.agents/scripts/tests/test-planning-publication-reconcile.sh
+++ b/.agents/scripts/tests/test-planning-publication-reconcile.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RECONCILER="${SCRIPT_DIR}/../planning-publication-reconcile.sh"
+WORKFLOW="${SCRIPT_DIR}/../../../.github/workflows/issue-sync-reusable.yml"
+# Literal source snippets: dollar-prefixed names must not expand in this test.
+# shellcheck disable=SC2016
+REMOVE_PATTERN='--remove-label "$PUBLICATION_PENDING_LABEL"'
+# shellcheck disable=SC2016
+WORKFLOW_PATTERN='--repo "$PUBLICATION_REPO" --sha "$PUBLICATION_SHA"'
+# shellcheck disable=SC2016
+VERIFY_PATTERN='_publication_issue_has_labels "$issue_json" "$projected_labels"'
+
+# shellcheck source=../planning-publication-reconcile.sh
+source "$RECONCILER"
+
+task_line='- [ ] t9000 Reconcile publication #auto-dispatch #bug ~1h ref:GH#77 logged:2026-08-11'
+desired_labels=$(_publication_desired_labels "$task_line")
+[[ ",${desired_labels}," == *",auto-dispatch,"* ]]
+[[ ",${desired_labels}," == *",bug,"* ]]
+[[ "$(_publication_status_label "$desired_labels")" == "status:available" ]]
+issue_json='{"labels":[{"name":"auto-dispatch"},{"name":"bug"},{"name":"status:available"}]}'
+_publication_issue_has_labels "$issue_json" 'auto-dispatch,bug,status:available'
+[[ -z "$(_publication_desired_labels '- [ ] t9001 Manual task ~1h ref:GH#78 logged:2026-08-11')" ]]
+printf 'PASS production helpers project and verify intended labels\n'
+
+grep -Fq '_publication_exact_default_snapshot' "$RECONCILER"
+grep -Fq '_publication_validate_mapping' "$RECONCILER"
+grep -Fq 'verify-brief-helper.sh" check-readiness' "$RECONCILER"
+grep -Fq -- "$REMOVE_PATTERN" "$RECONCILER"
+grep -Fq 'Reconcile pending planning publication' "$WORKFLOW"
+grep -Fq -- "$WORKFLOW_PATTERN" "$WORKFLOW"
+
+remove_line=$(grep -n -- "$REMOVE_PATTERN" "$RECONCILER" | cut -d: -f1)
+verify_line=$(grep -n -m1 -- "$VERIFY_PATTERN" "$RECONCILER" | cut -d: -f1)
+[[ "$remove_line" -gt "$verify_line" ]]
+
+printf 'PASS exact-SHA mapping validation precedes blocker removal\n'
+printf 'PASS default-branch workflow invokes bounded reconciliation\n'

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -293,6 +293,16 @@ jobs:
           AIDEVOPS_ENRICH_MAX_ISSUES: '75'
           AIDEVOPS_ENRICH_MAX_SECONDS: '300'
 
+      - name: Reconcile pending planning publication
+        if: steps.check-author.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLICATION_SHA: ${{ github.sha }}
+          PUBLICATION_REPO: ${{ github.repository }}
+        run: |
+          bash __aidevops/.agents/scripts/planning-publication-reconcile.sh reconcile \
+            --repo "$PUBLICATION_REPO" --sha "$PUBLICATION_SHA"
+
       - name: Pull any missing refs back to TODO.md
         if: steps.check-author.outputs.skip != 'true'
         run: |


### PR DESCRIPTION
## Summary

Implement publication lifecycle phase 3 reconciliation: the default-branch workflow validates the exact event SHA, unique task/ref mapping, worker-ready brief, current issue identity, and intended labels before removing publication:pending as the final mutation.

## Files Changed

.agents/scripts/planning-publication-reconcile.sh, .agents/scripts/tests/test-planning-publication-reconcile.sh, .github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified: the focused test sources and executes production label projection/status/verification helpers, checks empty-label behavior and blocker-removal ordering; local linters pass; issue-sync failure suite passes; workflow YAML parses; review evidence is clean after rebase.

For #29961


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.250 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 25m and 254,034 tokens on this with the user in an interactive session.
