### PR TITLE
GH#29956: align shared Issue Sync review trust

### DIFF
--- a/.agents/reference/review-bot-gate.md
+++ b/.agents/reference/review-bot-gate.md
@@ -119,10 +119,13 @@ The review add-on check runs after the `origin:interactive` (t2411) and
 - **Strict repositories**: `completion_behavior: strict` requires settled review
   evidence. `min_edit_lag_seconds` still protects CodeRabbit's two-phase pattern.
 - **Repository-generated Issue Sync PRs**: GitHub reports the official Actions bot
-  as `CONTRIBUTOR`. The reusable gate normalizes it as internal only when the
-  immutable bot ID/type, same-repository head and base, deterministic
-  `aidevops/issue-sync-todo` branch, and generated body marker all match. Any
-  missing or mismatched field remains external and fail-closed.
+  as `CONTRIBUTOR`. The reusable CI gate and shared review helper normalize it as
+  internal only when the immutable bot ID/type, same-repository head and base,
+  deterministic `aidevops/issue-sync-todo` branch, and generated body marker all
+  match. For `issue_comment` events that omit head/base metadata, CI asks the
+  shared helper to classify one live REST pull payload. This keeps CI,
+  interactive merge, and Pulse decisions aligned. Any missing or mismatched
+  field remains external and fail-closed.
 - **External contributors**: advisory, rate-limit, and skip outcomes remain
   fail-closed; completed review evidence is required in addition to independent
   maintainer/cryptographic authority.

--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -6,6 +6,7 @@
 # Usage:
 #   review-bot-gate-helper.sh check         <PR_NUMBER> [REPO]
 #   review-bot-gate-helper.sh event-check
+#   review-bot-gate-helper.sh is-trusted-issue-sync-pr <PR_NUMBER> [REPO]
 #   review-bot-gate-helper.sh classify-infra-rate-limit <AUTHOR_ASSOCIATION> [REPO]
 #   review-bot-gate-helper.sh wait          <PR_NUMBER> [REPO] [MAX_WAIT_SECONDS]
 #   review-bot-gate-helper.sh list          <PR_NUMBER> [REPO]
@@ -18,6 +19,7 @@
 # Commands:
 #   check          — Check once, return PASS/PASS_ADVISORY/PASS_RATE_LIMITED/WAITING/SKIP
 #   event-check    — Accept trusted bot review evidence from the Actions event
+#   is-trusted-issue-sync-pr — Verify the exact generated PR identity from live REST metadata
 #   classify-infra-rate-limit — Classify API exhaustion from immutable event trust
 #   wait           — Poll until a bot posts or timeout (default 600s)
 #   list           — List all bot comments found on the PR
@@ -61,6 +63,8 @@
 #                                "tools": { "coderabbitai": { "completion_behavior": "fast" } } } }
 #   REVIEW_GATE_EVIDENCE_SNAPSHOT_DISABLE — Set to 1 to disable per-check reuse
 #                              of the three review/comment API collections.
+#   REVIEW_GATE_AUTHOR_ASSOCIATION_RESOLVED — Set to true only when the caller
+#                              already finalized immutable author trust evidence.
 #
 # t1382: https://github.com/marcusquinn/aidevops/issues/2735
 # GH#3827: Rate-limit grace period — pass gate after timeout when bots are
@@ -100,6 +104,9 @@ RBG_CODERABBIT_NITS_LABEL="coderabbit-nits-ok"
 RBG_RECONCILE_MODE_NITS="nits"
 RBG_RECONCILE_MODE_SUPERSEDED="superseded"
 RBG_AUTHOR_CLASS_TRUSTED="trusted"
+RBG_GITHUB_ACTIONS_BOT_ID="41898282"
+RBG_ISSUE_SYNC_PR_BRANCH="aidevops/issue-sync-todo"
+RBG_ISSUE_SYNC_PR_MARKER="<!-- aidevops:issue-sync-todo-pr -->"
 
 # Rate-limit / quota notice patterns — entries that indicate the bot tried to
 # review but was capacity-constrained. Used by grace-period logic
@@ -189,11 +196,12 @@ _RBG_EVIDENCE_SNAPSHOT_READY=0
 # --- Functions ---
 
 usage() {
-	echo "Usage: $(basename "$0") {check|event-check|classify-infra-rate-limit|wait|list|request-retry|status-json|batch-retry|reconcile-stale-coderabbit|dismiss-coderabbit-nits} <PR_NUMBER> [REPO] [EXTRA]"
+	echo "Usage: $(basename "$0") {check|event-check|is-trusted-issue-sync-pr|classify-infra-rate-limit|wait|list|request-retry|status-json|batch-retry|reconcile-stale-coderabbit|dismiss-coderabbit-nits} <PR_NUMBER> [REPO] [EXTRA]"
 	echo ""
 	echo "Commands:"
 	echo "  check          Check once for bot reviews (returns PASS/PASS_ADVISORY/PASS_RATE_LIMITED/WAITING/SKIP)"
 	echo "  event-check    Check trusted bot review evidence from REVIEW_GATE_EVENT_* variables"
+	echo "  is-trusted-issue-sync-pr  Return TRUSTED (0), UNTRUSTED (1), or API error (2) from live PR metadata"
 	echo "  classify-infra-rate-limit  Resolve trusted/default-advisory API exhaustion without another API call"
 	echo "  wait           Poll until bot reviews appear or timeout"
 	echo "  list           List all bot comments found"
@@ -1265,6 +1273,55 @@ any_bot_has_success_status() {
 	return 1
 }
 
+_rbg_is_trusted_issue_sync_pr_metadata() {
+	local repo="$1"
+	local pr_metadata_json="$2"
+
+	[[ -n "$repo" && -n "$pr_metadata_json" ]] || return 1
+	command -v jq >/dev/null 2>&1 || return 1
+
+	# GitHub assigns its official Actions bot CONTRIBUTOR association on PRs it
+	# creates. Normalize only the complete deterministic Issue Sync identity.
+	# Every field comes from one live REST pull payload; any parse failure or
+	# missing/mismatched value remains external.
+	#aidevops:trust-boundary
+	jq -e \
+		--arg repo "$repo" \
+		--argjson bot_id "$RBG_GITHUB_ACTIONS_BOT_ID" \
+		--arg branch "$RBG_ISSUE_SYNC_PR_BRANCH" \
+		--arg marker "$RBG_ISSUE_SYNC_PR_MARKER" '
+		try (
+			.user.login == "github-actions[bot]" and
+			.user.id == $bot_id and
+			.user.type == "Bot" and
+			.head.repo.full_name == $repo and
+			.base.repo.full_name == $repo and
+			.head.ref == $branch and
+			(.body | contains($marker))
+		) catch false
+	' <<<"$pr_metadata_json" >/dev/null 2>&1
+}
+
+do_is_trusted_issue_sync_pr() {
+	local pr_number="$1"
+	local repo="$2"
+	local pr_api=""
+	local pr_metadata_json=""
+
+	pr_api=$(printf 'repos/%s/pulls/%s' "$repo" "$pr_number")
+	pr_metadata_json=$(gh api "$pr_api") || {
+		echo "ERROR: Could not fetch live PR metadata for Issue Sync trust classification." >&2
+		return 2
+	}
+
+	if _rbg_is_trusted_issue_sync_pr_metadata "$repo" "$pr_metadata_json"; then
+		echo "TRUSTED"
+		return 0
+	fi
+	echo "UNTRUSTED"
+	return 1
+}
+
 _resolve_pr_author_association() {
 	local pr_number="$1"
 	local repo="$2"
@@ -1274,10 +1331,15 @@ _resolve_pr_author_association() {
 	local pr_api=""
 
 	# Internal callers can pass the live REST pull payload they already fetched.
-	# Only the REST field is authoritative; login, labels, and runner identity do
-	# not establish author trust.
-	if [[ -n "$pr_metadata_json" ]] &&
-		association=$(jq -r "$association_filter" <<<"$pr_metadata_json" 2>/dev/null); then
+	# The REST association remains authoritative except for the exact official
+	# Issue Sync identity independently validated above. Login, labels, or runner
+	# identity alone never establish trust.
+	if [[ -n "$pr_metadata_json" ]]; then
+		if _rbg_is_trusted_issue_sync_pr_metadata "$repo" "$pr_metadata_json"; then
+			printf '%s\n' "COLLABORATOR"
+			return 0
+		fi
+		association=$(jq -r "$association_filter" <<<"$pr_metadata_json" 2>/dev/null) || association=""
 		if [[ -n "$association" ]]; then
 			printf '%s\n' "$association"
 			return 0
@@ -1288,8 +1350,12 @@ _resolve_pr_author_association() {
 	# Reuse the canonical pull REST field and collapse all API/parse failures to
 	# unknown so the trust checks below continue to fail closed.
 	pr_api=$(printf 'repos/%s/pulls/%s' "$repo" "$pr_number")
-	association=$(gh api "$pr_api" \
-		--jq "$association_filter" 2>/dev/null) || association=""
+	pr_metadata_json=$(gh api "$pr_api" 2>/dev/null) || pr_metadata_json=""
+	if _rbg_is_trusted_issue_sync_pr_metadata "$repo" "$pr_metadata_json"; then
+		printf '%s\n' "COLLABORATOR"
+		return 0
+	fi
+	association=$(jq -r "$association_filter" <<<"$pr_metadata_json" 2>/dev/null) || association=""
 	printf '%s\n' "$association"
 	return 0
 }
@@ -1447,9 +1513,17 @@ do_check() {
 	local REVIEW_GATE_NON_REVIEW_BOTS=""
 	_rbg_reset_evidence_snapshot
 
-	if [[ -z "$REVIEW_GATE_AUTHOR_ASSOCIATION" ]]; then
-		REVIEW_GATE_AUTHOR_ASSOCIATION=$(_resolve_pr_author_association \
-			"$pr_number" "$repo" "$pr_metadata_json")
+	if [[ "${REVIEW_GATE_AUTHOR_ASSOCIATION_RESOLVED:-false}" != "true" ]]; then
+		case "$REVIEW_GATE_AUTHOR_ASSOCIATION" in
+		OWNER | MEMBER | COLLABORATOR) ;;
+		*)
+			local resolved_author_association=""
+			resolved_author_association=$(_resolve_pr_author_association \
+				"$pr_number" "$repo" "$pr_metadata_json")
+			[[ -n "$resolved_author_association" ]] &&
+				REVIEW_GATE_AUTHOR_ASSOCIATION="$resolved_author_association"
+			;;
+		esac
 	fi
 
 	# #aidevops:trust-boundary — skip labels are an internal exception. Resolve
@@ -1970,6 +2044,9 @@ main() {
 	case "$command" in
 	check)
 		do_check "$pr_number" "$repo"
+		;;
+	is-trusted-issue-sync-pr)
+		do_is_trusted_issue_sync_pr "$pr_number" "$repo"
 		;;
 	wait)
 		do_wait "$pr_number" "$repo" "$max_wait"

--- a/.agents/scripts/tests/test-review-bot-gate-api-snapshot.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-api-snapshot.sh
@@ -75,7 +75,11 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 mode="snapshot"
-[[ -n "$jq_filter" ]] && mode="direct"
+if [[ -n "$jq_filter" ]]; then
+	mode="direct"
+elif [[ "$endpoint" == "repos/testorg/testrepo/pulls/123" ]]; then
+	mode="metadata"
+fi
 printf '%s:%s\n' "$mode" "$endpoint" >>"$call_log"
 
 if [[ "$scenario" == "fail-once" && "$mode" == "snapshot" &&
@@ -212,7 +216,7 @@ test_preloaded_metadata_avoids_duplicate_lookups() {
 	IFS= read -r output <"$output_file" || true
 	calls=$(call_count)
 	command_calls=$(matching_call_count 'command:')
-	pull_metadata_calls=$(exact_call_count 'direct:repos/testorg/testrepo/pulls/123')
+	pull_metadata_calls=$(exact_call_count 'metadata:repos/testorg/testrepo/pulls/123')
 	status_calls=$(exact_call_count 'direct:repos/testorg/testrepo/commits/head-123/status?per_page=100')
 	check_calls=$(exact_call_count 'direct:repos/testorg/testrepo/commits/head-123/check-runs?per_page=100')
 	if [[ "$status" -eq 0 && "$output" == "PASS" && "$calls" == "5" &&
@@ -305,7 +309,7 @@ test_missing_metadata_uses_rest_association_without_graphql_projection() {
 	local calls command_calls pull_metadata_calls
 	calls=$(call_count)
 	command_calls=$(matching_call_count 'command:')
-	pull_metadata_calls=$(exact_call_count 'direct:repos/testorg/testrepo/pulls/123')
+	pull_metadata_calls=$(exact_call_count 'metadata:repos/testorg/testrepo/pulls/123')
 	if [[ "$RUN_STATUS" -eq 0 && "$RUN_OUTPUT" == "PASS" && "$calls" == "4" &&
 		"$command_calls" == "0" && "$pull_metadata_calls" == "1" ]]; then
 		print_result "missing association uses one REST pull lookup without gh pr projection" 0
@@ -322,13 +326,39 @@ test_rest_association_failure_remains_blocked() {
 	local calls command_calls pull_metadata_calls
 	calls=$(call_count)
 	command_calls=$(matching_call_count 'command:')
-	pull_metadata_calls=$(exact_call_count 'direct:repos/testorg/testrepo/pulls/123')
+	pull_metadata_calls=$(exact_call_count 'metadata:repos/testorg/testrepo/pulls/123')
 	if [[ "$RUN_STATUS" -eq 1 && "$RUN_OUTPUT" == "WAITING" && "$calls" == "4" &&
 		"$command_calls" == "0" && "$pull_metadata_calls" == "1" ]]; then
 		print_result "REST association failure keeps unknown authors blocked" 0
 	else
 		print_result "REST association failure keeps unknown authors blocked" 1 \
 			"status=${RUN_STATUS} output=${RUN_OUTPUT} calls=${calls} command=${command_calls} pull=${pull_metadata_calls}"
+	fi
+	return 0
+}
+
+test_finalized_external_association_avoids_metadata_retry() {
+	local output_file="${TEST_ROOT}/resolved-external-output"
+	local status=0 output="" calls pull_metadata_calls
+	printf '%s\n' empty >"$SCENARIO_FILE"
+	: >"$CALL_LOG"
+	if REVIEW_GATE_AUTHOR_ASSOCIATION=CONTRIBUTOR \
+		REVIEW_GATE_AUTHOR_ASSOCIATION_RESOLVED=true \
+		REVIEW_GATE_EVIDENCE_SNAPSHOT_DISABLE=0 \
+		do_check 123 'testorg/testrepo' >"$output_file" 2>/dev/null; then
+		status=0
+	else
+		status=$?
+	fi
+	IFS= read -r output <"$output_file" || true
+	calls=$(call_count)
+	pull_metadata_calls=$(exact_call_count 'metadata:repos/testorg/testrepo/pulls/123')
+	if [[ "$status" -eq 1 && "$output" == "WAITING" && "$calls" == "3" &&
+		"$pull_metadata_calls" == "0" ]]; then
+		print_result "finalized external association avoids a duplicate REST metadata lookup" 0
+	else
+		print_result "finalized external association avoids a duplicate REST metadata lookup" 1 \
+			"status=${status} output=${output} calls=${calls} pull=${pull_metadata_calls}"
 	fi
 	return 0
 }
@@ -359,6 +389,7 @@ test_disable_toggle_restores_direct_queries
 test_snapshot_failure_falls_back_without_losing_capability
 test_missing_metadata_uses_rest_association_without_graphql_projection
 test_rest_association_failure_remains_blocked
+test_finalized_external_association_avoids_metadata_retry
 
 printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -729,7 +729,7 @@ test_trusted_default_does_not_require_completed_review() {
 test_owner_rest_association_does_not_require_completed_review() {
 	gh() {
 		if [[ "${1:-}" == "api" && "${2:-}" == "repos/testorg/otherrepo/pulls/123" ]]; then
-			printf '%s\n' 'OWNER'
+			printf '%s\n' '{"author_association":"OWNER"}'
 			return 0
 		fi
 		return 2
@@ -744,6 +744,89 @@ test_owner_rest_association_does_not_require_completed_review() {
 	else
 		print_result "REST resolver restores trusted OWNER advisory behavior" 1 \
 			"association=${association:-<empty>}"
+	fi
+	return 0
+}
+
+test_issue_sync_bot_metadata_normalizes_trust() {
+	local pr_metadata='{"author_association":"CONTRIBUTOR","user":{"login":"github-actions[bot]","id":41898282,"type":"Bot"},"head":{"ref":"aidevops/issue-sync-todo","repo":{"full_name":"testorg/otherrepo"}},"base":{"repo":{"full_name":"testorg/otherrepo"}},"body":"<!-- aidevops:issue-sync-todo-pr -->"}'
+	local association=""
+
+	association=$(_resolve_pr_author_association 123 'testorg/otherrepo' "$pr_metadata")
+	if [[ "$association" == "COLLABORATOR" ]] &&
+		! REVIEW_GATE_AUTHOR_ASSOCIATION="$association" _review_gate_requires_completed_review 'testorg/otherrepo'; then
+		print_result "exact Issue Sync bot metadata restores trusted advisory behavior" 0
+	else
+		print_result "exact Issue Sync bot metadata restores trusted advisory behavior" 1 \
+			"association=${association:-<empty>}"
+	fi
+	return 0
+}
+
+test_issue_sync_bot_metadata_mismatches_fail_closed() {
+	local pr_metadata='{"author_association":"CONTRIBUTOR","user":{"login":"github-actions[bot]","id":41898282,"type":"Bot"},"head":{"ref":"aidevops/issue-sync-todo","repo":{"full_name":"testorg/otherrepo"}},"base":{"repo":{"full_name":"testorg/otherrepo"}},"body":"<!-- aidevops:issue-sync-todo-pr -->"}'
+	local filter=""
+	local candidate=""
+	local association=""
+	local failures=""
+	local -a mismatch_filters=(
+		'.user.login = "lookalike[bot]"'
+		'.user.id = 999'
+		'.user.id = "41898282"'
+		'.user.type = "User"'
+		'.head.repo.full_name = "attacker/otherrepo"'
+		'.base.repo.full_name = "attacker/otherrepo"'
+		'.head.ref = "feature/not-issue-sync"'
+		'.body = "ordinary pull request"'
+		'del(.user.id)'
+		'.head = "not-an-object"'
+		'.body = null'
+	)
+
+	for filter in "${mismatch_filters[@]}"; do
+		candidate=$(jq -c "$filter" <<<"$pr_metadata")
+		association=$(_resolve_pr_author_association 123 'testorg/otherrepo' "$candidate")
+		if [[ "$association" != "CONTRIBUTOR" ]] ||
+			! REVIEW_GATE_AUTHOR_ASSOCIATION="$association" _review_gate_requires_completed_review 'testorg/otherrepo'; then
+			failures="${failures}${filter}; "
+		fi
+	done
+
+	if [[ -z "$failures" ]]; then
+		print_result "Issue Sync bot metadata mismatches remain external" 0
+	else
+		print_result "Issue Sync bot metadata mismatches remain external" 1 "$failures"
+	fi
+	return 0
+}
+
+test_issue_sync_bot_check_uses_advisory_default() {
+	local output=""
+	local rc=0
+
+	if output=$(
+		gh() {
+			if [[ "${1:-}" == "api" && "${2:-}" == "repos/testorg/otherrepo/pulls/123" ]]; then
+				printf '%s\n' '{"author_association":"CONTRIBUTOR","user":{"login":"github-actions[bot]","id":41898282,"type":"Bot"},"head":{"ref":"aidevops/issue-sync-todo","repo":{"full_name":"testorg/otherrepo"}},"base":{"repo":{"full_name":"testorg/otherrepo"}},"body":"<!-- aidevops:issue-sync-todo-pr -->"}'
+				return 0
+			fi
+			return 2
+		}
+		check_for_skip_label() { return 1; }
+		get_all_bot_commenters() { return 0; }
+		_get_success_status_contexts() { return 0; }
+		REVIEW_GATE_AUTHOR_ASSOCIATION=CONTRIBUTOR do_check 123 'testorg/otherrepo' 2>/dev/null
+	); then
+		rc=0
+	else
+		rc=$?
+	fi
+
+	if [[ "$rc" -eq 0 && "$output" == "PASS_ADVISORY" ]]; then
+		print_result "full helper check applies advisory default to exact Issue Sync bot" 0
+	else
+		print_result "full helper check applies advisory default to exact Issue Sync bot" 1 \
+			"rc=${rc} output=${output:-<empty>}"
 	fi
 	return 0
 }
@@ -1498,6 +1581,9 @@ test_status_json_fails_closed_without_pr_metadata() {
 run_completion_requirement_tests() {
 	test_trusted_default_does_not_require_completed_review
 	test_owner_rest_association_does_not_require_completed_review
+	test_issue_sync_bot_metadata_normalizes_trust
+	test_issue_sync_bot_metadata_mismatches_fail_closed
+	test_issue_sync_bot_check_uses_advisory_default
 	test_trusted_strict_repo_requires_completed_review
 	test_trusted_retired_tool_policy_does_not_require_completed_review
 	test_external_default_requires_completed_review

--- a/.agents/scripts/tests/test-review-bot-gate-issue-sync-trust.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-issue-sync-trust.sh
@@ -10,8 +10,25 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
 WORKFLOW_FILE="${REPO_ROOT}/.github/workflows/review-bot-gate-reusable.yml"
+HELPER_FILE="${REPO_ROOT}/.agents/scripts/review-bot-gate-helper.sh"
 STATE_DIR="$(mktemp -d)"
 trap 'rm -rf "${STATE_DIR}"' EXIT
+mkdir -p "${STATE_DIR}/bin"
+cat >"${STATE_DIR}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "api" ]] || exit 2
+[[ "${2:-}" == "repos/marcusquinn/aidevops/pulls/123" ]] || exit 2
+case "${REVIEW_GATE_LIVE_TRUSTED:-false}" in
+true)
+	printf '%s\n' '{"author_association":"CONTRIBUTOR","user":{"login":"github-actions[bot]","id":41898282,"type":"Bot"},"head":{"ref":"aidevops/issue-sync-todo","repo":{"full_name":"marcusquinn/aidevops"}},"base":{"repo":{"full_name":"marcusquinn/aidevops"}},"body":"<!-- aidevops:issue-sync-todo-pr -->"}'
+	;;
+error) exit 42 ;;
+*)
+	printf '%s\n' '{"author_association":"CONTRIBUTOR","user":{"login":"github-actions[bot]","id":999,"type":"Bot"}}'
+	;;
+esac
+EOF
+chmod +x "${STATE_DIR}/bin/gh"
 
 START_COUNT=$(grep -Fc '# aidevops:review-gate-trust-start' "${WORKFLOW_FILE}")
 END_COUNT=$(grep -Fc '# aidevops:review-gate-trust-end' "${WORKFLOW_FILE}")
@@ -58,12 +75,17 @@ run_case() {
 	local base_repository="${12}"
 	local head_ref="${13}"
 	local pr_body="${14}"
+	local live_trusted="${15:-false}"
 	local output_file=""
 
 	CASE_INDEX=$((CASE_INDEX + 1))
 	output_file="${STATE_DIR}/case-${CASE_INDEX}.out"
 	if ! GITHUB_OUTPUT="${output_file}" \
+		HELPER="${HELPER_FILE}" \
+		PATH="${STATE_DIR}/bin:${PATH}" \
+		PR_NUMBER=123 \
 		REPO="marcusquinn/aidevops" \
+		REVIEW_GATE_LIVE_TRUSTED="${live_trusted}" \
 		REVIEW_GATE_AUTHOR_ASSOCIATION="${author_association}" \
 		REVIEW_GATE_PR_AUTHOR_LOGIN="${author_login}" \
 		REVIEW_GATE_PR_AUTHOR_ID="${author_id}" \
@@ -105,6 +127,12 @@ run_case \
 	'feature/example' 'ordinary pull request'
 
 run_case \
+	'issue_comment metadata omission uses the live shared classifier' \
+	false true COLLABORATOR pass fast \
+	CONTRIBUTOR 'github-actions[bot]' 41898282 Bot \
+	'' '' '' "${MARKER}" true
+
+run_case \
 	'external user cannot spoof marker and deterministic branch' \
 	true false CONTRIBUTOR wait strict \
 	CONTRIBUTOR attacker 999 User \
@@ -138,5 +166,25 @@ run_case \
 	CONTRIBUTOR 'github-actions[bot]' 41898282 Bot \
 	'marcusquinn/aidevops' 'marcusquinn/aidevops' \
 	'aidevops/issue-sync-todo' 'ordinary pull request'
+
+LIVE_ERROR_STATUS=0
+if REVIEW_GATE_LIVE_TRUSTED=error PATH="${STATE_DIR}/bin:${PATH}" \
+	bash "${HELPER_FILE}" is-trusted-issue-sync-pr 123 marcusquinn/aidevops >/dev/null 2>&1; then
+	LIVE_ERROR_STATUS=0
+else
+	LIVE_ERROR_STATUS=$?
+fi
+if [[ "${LIVE_ERROR_STATUS}" -ne 2 ]]; then
+	printf 'FAIL: live helper API failure expected exit 2, got %s\n' "${LIVE_ERROR_STATUS}" >&2
+	exit 1
+fi
+printf 'PASS: live helper API failures remain distinct and fail-closed\n'
+
+HELP_OUTPUT=$(bash "${HELPER_FILE}" help 2>/dev/null || true)
+if [[ "${HELP_OUTPUT}" != *"is-trusted-issue-sync-pr"* ]]; then
+	printf 'FAIL: runtime help omits is-trusted-issue-sync-pr\n' >&2
+	exit 1
+fi
+printf 'PASS: runtime help documents the live Issue Sync classifier\n'
 
 printf 'All review-bot Issue Sync trust tests passed.\n'

--- a/.github/workflows/review-bot-gate-reusable.yml
+++ b/.github/workflows/review-bot-gate-reusable.yml
@@ -148,6 +148,7 @@ jobs:
           # deterministic Issue Sync identity: official immutable bot ID/type,
           # same repository on both sides, fixed branch, and generated body marker.
           # Any missing or mismatched field remains external and fail-closed.
+          HELPER="${GITHUB_WORKSPACE}/__aidevops/.agents/scripts/review-bot-gate-helper.sh"
           # aidevops:review-gate-trust-start
           TRUSTED_ISSUE_SYNC_PR=false
           #aidevops:trust-boundary
@@ -159,6 +160,20 @@ jobs:
             [[ "${REVIEW_GATE_PR_HEAD_REF}" == "aidevops/issue-sync-todo" ]] &&
             [[ "${REVIEW_GATE_PR_BODY}" == *"<!-- aidevops:issue-sync-todo-pr -->"* ]]; then
             TRUSTED_ISSUE_SYNC_PR=true
+          fi
+
+          # issue_comment payloads omit the PR head/base metadata. For the exact
+          # official-bot candidate only, recover those fields from one live REST
+          # pull payload and apply the shared fail-closed classifier.
+          #aidevops:trust-boundary
+          if [[ "${TRUSTED_ISSUE_SYNC_PR}" != "true" ]] &&
+            [[ "${REVIEW_GATE_PR_AUTHOR_LOGIN}" == "github-actions[bot]" ]] &&
+            [[ "${REVIEW_GATE_PR_AUTHOR_ID}" == "41898282" ]] &&
+            [[ "${REVIEW_GATE_PR_AUTHOR_TYPE}" == "Bot" ]] &&
+            [[ "${REVIEW_GATE_PR_BODY}" == *"<!-- aidevops:issue-sync-todo-pr -->"* ]] &&
+            bash "${HELPER}" is-trusted-issue-sync-pr "${PR_NUMBER}" "${REPO}" >/dev/null; then
+            TRUSTED_ISSUE_SYNC_PR=true
+            echo "Trusted Issue Sync PR confirmed from live metadata omitted by the event"
           fi
 
           # Check if this is an external contributor PR using immutable event
@@ -186,6 +201,9 @@ jobs:
             fi
             ;;
           esac
+          # The workflow has finalized immutable event/live author evidence.
+          # Prevent the helper from repeating a failed live metadata lookup.
+          export REVIEW_GATE_AUTHOR_ASSOCIATION_RESOLVED=true
           echo "is_external_pr=${IS_EXTERNAL_PR}" >> "${GITHUB_OUTPUT}"
           echo "trusted_issue_sync_pr=${TRUSTED_ISSUE_SYNC_PR}" >> "${GITHUB_OUTPUT}"
           echo "effective_author_association=${REVIEW_GATE_AUTHOR_ASSOCIATION}" >> "${GITHUB_OUTPUT}"
@@ -201,7 +219,6 @@ jobs:
           #   - rate-limit behaviour (configurable via repos.json or env var)
           # Output values: PASS / PASS_ADVISORY / PASS_RATE_LIMITED / WAITING / SKIP
           # Exit codes:    0 = PASS/PASS_ADVISORY/PASS_RATE_LIMITED/SKIP  1 = WAITING  2 = error
-          HELPER="${GITHUB_WORKSPACE}/__aidevops/.agents/scripts/review-bot-gate-helper.sh"
           RESULT=""
           HELPER_EXIT=0
           HELPER_STDERR=$(mktemp)


### PR DESCRIPTION
## Summary

Align reusable CI, the shared review helper, interactive merge, and Pulse trust classification for deterministic Issue Sync pull requests, including issue_comment metadata fallback and duplicate-lookup prevention.

## Files Changed

.agents/reference/review-bot-gate.md, .agents/scripts/review-bot-gate-helper.sh, .agents/scripts/tests/test-review-bot-gate-api-snapshot.sh, .agents/scripts/tests/test-review-bot-gate-completion-signal.sh, .agents/scripts/tests/test-review-bot-gate-issue-sync-trust.sh, .github/workflows/review-bot-gate-reusable.yml

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — runtime-verified with 74 completion-signal tests, 8 API-snapshot tests, the real-helper Issue Sync trust matrix under Bash 3.2 and modern Bash, ShellCheck, and linters-local --changed

Resolves #29956


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.250 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 32m and 285,806 tokens on this with the user in an interactive session.