### PR TITLE
GH#29997: enforce interactive gh shim

### DIFF
--- a/.agents/scripts/opencode-launcher-helper.sh
+++ b/.agents/scripts/opencode-launcher-helper.sh
@@ -336,6 +336,20 @@ require_opencode_cli() {
     return 0
 }
 
+prepend_aidevops_gh_shim() {
+    local shim_path="${SCRIPT_DIR}/gh"
+
+    if [[ ! -x "${shim_path}" ]]; then
+        print_error "aidevops gh shim is unavailable: ${shim_path}"
+        return 1
+    fi
+    case ":${PATH}:" in
+    *":${SCRIPT_DIR}:"*) ;;
+    *) export PATH="${SCRIPT_DIR}:${PATH}" ;;
+    esac
+    return 0
+}
+
 require_node_cli() {
     if ! command -v node >/dev/null 2>&1; then
         print_error "node not found in PATH"
@@ -1637,6 +1651,7 @@ cmd_remote_interactive() {
 
 main() {
     aidevops_init_temp_workspace || { print_error "Could not initialize aidevops temporary workspace"; return 1; }
+    prepend_aidevops_gh_shim || return 1
     TMP="${TMP:-${TMPDIR}}"
     TEMP="${TEMP:-${TMPDIR}}"
     export TMP TEMP

--- a/.agents/scripts/shared-gh-wrappers-checks.sh
+++ b/.agents/scripts/shared-gh-wrappers-checks.sh
@@ -51,14 +51,20 @@
 # Part of aidevops framework: https://aidevops.sh
 
 # Apply strict mode only when executed directly (not when sourced)
-[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+[[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]] && set -euo pipefail
 
 # Include guard
 [[ -n "${_SHARED_GH_WRAPPERS_CHECKS_LIB_LOADED:-}" ]] && return 0
 _SHARED_GH_WRAPPERS_CHECKS_LIB_LOADED=1
 
-_gh_checks_lib_dir="${BASH_SOURCE[0]%/*}"
-[[ "$_gh_checks_lib_dir" == "${BASH_SOURCE[0]}" ]] && _gh_checks_lib_dir="."
+_gh_checks_lib_dir="${_SHARED_GH_WRAPPERS_DIR:-}"
+if [[ -z "$_gh_checks_lib_dir" && -n "${BASH_SOURCE[0]:-}" ]]; then
+	_gh_checks_lib_dir="${BASH_SOURCE[0]%/*}"
+	[[ "$_gh_checks_lib_dir" == "${BASH_SOURCE[0]}" ]] && _gh_checks_lib_dir="."
+elif [[ -z "$_gh_checks_lib_dir" && -n "${ZSH_VERSION:-}" && -f "${0:-}" ]]; then
+	_gh_checks_lib_dir="${0%/*}"
+	[[ "$_gh_checks_lib_dir" == "$0" ]] && _gh_checks_lib_dir="."
+fi
 if ! declare -F gh_request_state_singleflight_begin >/dev/null 2>&1 && [[ -f "${_gh_checks_lib_dir}/shared-gh-request-state.sh" ]]; then
 	# shellcheck source=./shared-gh-request-state.sh
 	# shellcheck disable=SC1091

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -31,18 +31,23 @@
 _SHARED_GH_WRAPPERS_CREATE_LIB_LOADED=1
 _GH_CREATE_AUTO_DISPATCH_LABEL="auto-dispatch"
 
-# Defensive SCRIPT_DIR fallback
-if [[ -z "${SCRIPT_DIR:-}" ]]; then
-	_lib_path="${BASH_SOURCE[0]%/*}"
-	[[ "$_lib_path" == "${BASH_SOURCE[0]}" ]] && _lib_path="."
-	SCRIPT_DIR="$(cd "$_lib_path" && pwd)"
-	unset _lib_path
+# Resolve this module's directory rather than trusting a caller-owned
+# SCRIPT_DIR. Recovery shells commonly export SCRIPT_DIR for their own helper.
+_GH_WRAPPERS_CREATE_SOURCE="${BASH_SOURCE[0]:-${0:-}}"
+_GH_WRAPPERS_CREATE_DIR="$(cd "$(dirname "${_GH_WRAPPERS_CREATE_SOURCE}")" 2>/dev/null && pwd)" || _GH_WRAPPERS_CREATE_DIR=""
+if [[ -z "${_GH_WRAPPERS_CREATE_DIR}" || ! -f "${_GH_WRAPPERS_CREATE_DIR}/privacy-guard-helper.sh" ]]; then
+	printf 'shared-gh-wrappers-create: cannot load privacy-guard-helper.sh from this module directory\n' >&2
+	return 1
 fi
 
-if ! command -v privacy_guard_public_write >/dev/null 2>&1 && [[ -f "${SCRIPT_DIR}/privacy-guard-helper.sh" ]]; then
+if ! command -v privacy_guard_public_write >/dev/null 2>&1; then
 	# shellcheck source=privacy-guard-helper.sh
-	# shellcheck disable=SC1091  # resolved from SCRIPT_DIR at runtime
-	source "${SCRIPT_DIR}/privacy-guard-helper.sh"
+	# shellcheck disable=SC1091  # resolved from this module's directory at runtime
+	source "${_GH_WRAPPERS_CREATE_DIR}/privacy-guard-helper.sh"
+fi
+if ! command -v privacy_guard_public_write >/dev/null 2>&1; then
+	printf 'shared-gh-wrappers-create: privacy_guard_public_write did not load\n' >&2
+	return 1
 fi
 
 #######################################

--- a/.agents/scripts/shared-gh-wrappers-safe-edit.sh
+++ b/.agents/scripts/shared-gh-wrappers-safe-edit.sh
@@ -21,7 +21,7 @@
 # Part of aidevops framework: https://aidevops.sh
 
 # Apply strict mode only when executed directly (not when sourced)
-[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+[[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]] && set -euo pipefail
 
 # Include guard
 [[ -n "${_SHARED_GH_WRAPPERS_SAFE_EDIT_LIB_LOADED:-}" ]] && return 0
@@ -29,36 +29,37 @@ _SHARED_GH_WRAPPERS_SAFE_EDIT_LIB_LOADED=1
 _GH_AUDIT_ISSUE_EDIT_OP="issue_edit"
 _GH_AUDIT_NMR_LABEL="needs-maintainer-review"
 
-# Defensive SCRIPT_DIR fallback
-if [[ -z "${SCRIPT_DIR:-}" ]]; then
-	_lib_path="${BASH_SOURCE[0]%/*}"
-	[[ "$_lib_path" == "${BASH_SOURCE[0]}" ]] && _lib_path="."
-	SCRIPT_DIR="$(cd "$_lib_path" && pwd)"
-	unset _lib_path
+# Resolve this module's dependencies from its own location. Do not inherit a
+# caller-owned SCRIPT_DIR from an interactive recovery shell.
+_SHARED_GH_WRAPPERS_SAFE_EDIT_DIR="${_SHARED_GH_WRAPPERS_DIR:-}"
+if [[ -z "${_SHARED_GH_WRAPPERS_SAFE_EDIT_DIR}" && -n "${BASH_SOURCE[0]:-}" ]]; then
+	_SHARED_GH_WRAPPERS_SAFE_EDIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || _SHARED_GH_WRAPPERS_SAFE_EDIT_DIR=""
+elif [[ -z "${_SHARED_GH_WRAPPERS_SAFE_EDIT_DIR}" && -n "${ZSH_VERSION:-}" && -f "${0:-}" ]]; then
+	_SHARED_GH_WRAPPERS_SAFE_EDIT_DIR="$(cd "$(dirname "${0}")" 2>/dev/null && pwd)" || _SHARED_GH_WRAPPERS_SAFE_EDIT_DIR=""
 fi
 
 # Load dependencies when this focused module is sourced directly instead of via
 # shared-gh-wrappers.sh. Set our include guard before this block so the
 # orchestrator can safely source this file without recursive redefinition.
 if ! command -v _gh_validate_edit_args >/dev/null 2>&1; then
-	if [[ -f "${SCRIPT_DIR}/shared-gh-wrappers.sh" ]]; then
+	if [[ -f "${_SHARED_GH_WRAPPERS_SAFE_EDIT_DIR}/shared-gh-wrappers.sh" ]]; then
 		# shellcheck source=shared-gh-wrappers.sh
-		# shellcheck disable=SC1091  # resolved from SCRIPT_DIR at runtime
-		source "${SCRIPT_DIR}/shared-gh-wrappers.sh"
+		# shellcheck disable=SC1091  # resolved from this module's directory at runtime
+		source "${_SHARED_GH_WRAPPERS_SAFE_EDIT_DIR}/shared-gh-wrappers.sh"
 	fi
 fi
 if ! command -v _rest_should_fallback >/dev/null 2>&1 ||
 	! command -v _rest_issue_edit >/dev/null 2>&1; then
-	if [[ -f "${SCRIPT_DIR}/shared-gh-wrappers-rest-fallback.sh" ]]; then
+	if [[ -f "${_SHARED_GH_WRAPPERS_SAFE_EDIT_DIR}/shared-gh-wrappers-rest-fallback.sh" ]]; then
 		# shellcheck source=shared-gh-wrappers-rest-fallback.sh
-		# shellcheck disable=SC1091  # resolved from SCRIPT_DIR at runtime
-		source "${SCRIPT_DIR}/shared-gh-wrappers-rest-fallback.sh"
+		# shellcheck disable=SC1091  # resolved from this module's directory at runtime
+		source "${_SHARED_GH_WRAPPERS_SAFE_EDIT_DIR}/shared-gh-wrappers-rest-fallback.sh"
 	fi
 fi
-if ! command -v _gh_guard_public_write_args >/dev/null 2>&1 && [[ -f "${SCRIPT_DIR}/shared-gh-wrappers-create.sh" ]]; then
+if ! command -v _gh_guard_public_write_args >/dev/null 2>&1 && [[ -f "${_SHARED_GH_WRAPPERS_SAFE_EDIT_DIR}/shared-gh-wrappers-create.sh" ]]; then
 	# shellcheck source=shared-gh-wrappers-create.sh
-	# shellcheck disable=SC1091  # resolved from SCRIPT_DIR at runtime
-	source "${SCRIPT_DIR}/shared-gh-wrappers-create.sh"
+	# shellcheck disable=SC1091  # resolved from this module's directory at runtime
+	source "${_SHARED_GH_WRAPPERS_SAFE_EDIT_DIR}/shared-gh-wrappers-create.sh"
 fi
 
 #######################################
@@ -463,6 +464,10 @@ gh_pr_edit_safe() {
 		return 1
 	fi
 	set -- "${_GH_WRAPPER_BODY_FILE_ARGS[@]}"
+	if command -v _gh_wrapper_auto_sig >/dev/null 2>&1; then
+		_gh_wrapper_auto_sig "$@"
+		set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
+	fi
 	if ! _gh_validate_edit_args "$@"; then
 		_gh_edit_audit_rejection "gh pr edit" "$_GH_EDIT_REJECTION_REASON" "$@"
 		return 1

--- a/.agents/scripts/shared-gh-wrappers-session.sh
+++ b/.agents/scripts/shared-gh-wrappers-session.sh
@@ -16,7 +16,7 @@
 # Part of aidevops framework: https://aidevops.sh
 
 # Apply strict mode only when executed directly (not when sourced)
-[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+[[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]] && set -euo pipefail
 
 # Include guard
 [[ -n "${_SHARED_GH_WRAPPERS_SESSION_LIB_LOADED:-}" ]] && return 0

--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -21,7 +21,7 @@
 # Part of aidevops framework: https://aidevops.sh
 
 # Apply strict mode only when executed directly (not when sourced)
-[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+[[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]] && set -euo pipefail
 
 # Include guard
 [[ -n "${_SHARED_GH_WRAPPERS_STATUS_LIB_LOADED:-}" ]] && return 0

--- a/.agents/scripts/tests/lib/test-helpers.sh
+++ b/.agents/scripts/tests/lib/test-helpers.sh
@@ -201,11 +201,11 @@ _test_copy_shared_deps() {
 			fi
 			dep_queue+=("$sub_dep")
 		done < <(awk '
-			/source.*shared-gh-wrappers-[a-z]/ {
+			/source.*(shared-gh-wrappers-[a-z][a-z-]*|privacy-guard-helper)\.sh/ {
 				line = $0
 				sub(/.*\//, "", line)
 				sub(/".*/, "", line)
-				if (line != "" && line ~ /^shared-gh-wrappers-/) print line
+				if (line != "" && (line ~ /^shared-gh-wrappers-/ || line == "privacy-guard-helper.sh")) print line
 			}
 		' "${dest_dir}/${sibling}" 2>/dev/null || true)
 	done

--- a/.agents/scripts/tests/test-gh-shim-native-resolution.sh
+++ b/.agents/scripts/tests/test-gh-shim-native-resolution.sh
@@ -95,6 +95,14 @@ run_case "installed ordinary passthrough" "$TMP/home/.aidevops/agents/scripts/gh
 run_case "repository intercepted command" "$TMP/repo/.agents/scripts/gh" "issue" "view"
 
 : >"$TMP/native.log"
+if NATIVE_GH_LOG="$TMP/native.log" PATH="$TMP/repo/.agents/scripts:$TMP/native-linux:/usr/bin:/bin" \
+	"$TMP/repo/.agents/scripts/gh" --version && [[ $(wc -l <"$TMP/native.log" | tr -d ' ') -eq 1 ]]; then
+	pass "interactive shim-first PATH reaches native gh without recursion"
+else
+	fail "interactive shim-first PATH native resolution failed"
+fi
+
+: >"$TMP/native.log"
 if NATIVE_GH_LOG="$TMP/native.log" AIDEVOPS_GH_SHIM_DISABLE=1 \
 	PATH="$TMP/runtime-bundles/old/agents/scripts:$TMP/home/.aidevops/agents/scripts:$TMP/repo/.agents/scripts:$TMP/home/.aidevops/bin:$TMP/native-linux:/usr/bin:/bin" \
 	"$TMP/runtime-bundles/old/agents/scripts/gh" --version; then

--- a/.agents/scripts/tests/test-gh-wrapper-auto-sig-body-file.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-auto-sig-body-file.sh
@@ -132,6 +132,20 @@ assert_body_file_signed() {
 	return 0
 }
 
+assert_pr_edit_body_file_signed() {
+	local body_file="${TEST_ROOT}/pr-edit.md"
+	printf '## Edited summary\n\nBody\n' >"$body_file"
+	reset_capture
+	gh_pr_edit_safe 1 --repo o/r --body-file "$body_file" >/dev/null 2>&1
+	if [[ "$(count_captured_signatures)" == "1" ]] && ! grep -q '<!-- aidevops:sig -->' "$body_file"; then
+		print_result "gh_pr_edit_safe --body-file signs posted copy without mutating source" 0
+	else
+		print_result "gh_pr_edit_safe --body-file signs posted copy without mutating source" 1 \
+			"captured signatures=$(count_captured_signatures), original_mutated=$(grep -c '<!-- aidevops:sig -->' "$body_file" 2>/dev/null || printf '0')"
+	fi
+	return 0
+}
+
 assert_existing_signature_not_duplicated() {
 	local body_file="${TEST_ROOT}/already-signed.md"
 	printf '## Summary\n\nBody\n\n<!-- aidevops:sig -->\n---\n[aidevops.sh](https://aidevops.sh) existing\n' >"$body_file"
@@ -281,6 +295,7 @@ assert_close_comment_signed_once() {
 
 assert_body_file_signed "gh_create_pr --body-file signs temp body" "pr-create"
 assert_body_file_signed "gh_pr_comment --body-file signs temp body" "pr-comment"
+assert_pr_edit_body_file_signed
 assert_existing_signature_not_duplicated
 assert_signed_relative_body_file_normalized
 assert_missing_body_file_rejected_before_gh

--- a/.agents/scripts/tests/test-opencode-launcher-helper.sh
+++ b/.agents/scripts/tests/test-opencode-launcher-helper.sh
@@ -101,6 +101,7 @@ printf 'AIDEVOPS_TEMP_DIR=%s\n' "${AIDEVOPS_TEMP_DIR:-}"
 printf 'TMPDIR=%s\n' "${TMPDIR:-}"
 printf 'TMP=%s\n' "${TMP:-}"
 printf 'TEMP=%s\n' "${TEMP:-}"
+printf 'GH_PATH=%s\n' "$(command -v gh || true)"
 printf 'PWD=%s\n' "$PWD"
 printf 'ARGS=%s\n' "$*"
 SH
@@ -207,13 +208,14 @@ if [[ "${output}" == *"AIDEVOPS_OPENCODE_ISOLATED_DB=1"* ]] \
     && [[ "${output}" == *"TMPDIR=/host/tmpdir"* ]] \
     && [[ "${output}" == *"TMP=/host/tmp"* ]] \
     && [[ "${output}" == *"TEMP=/host/temp"* ]] \
+    && [[ "${output}" == *"GH_PATH=${REPO_ROOT}/.agents/scripts/gh"* ]] \
     && [[ "${output}" == *"PWD=${launch_dir}"* ]] \
     && [[ "${project_auth_count}" == "1" ]] \
     && [[ "${line_count}" == "2" ]] \
     && [[ "${prewarm_line}" == *"|db path" ]] \
     && [[ ! -e "${work_dir}/opencode-launcher/last-data-dir" ]] \
     && [[ "${output}" != *"sqlite-migration"* ]]; then
-    _pass "isolated launcher sets per-session data dir and copies auth"
+    _pass "isolated launcher sets per-session data dir, copies auth, and exports the gh shim"
 else
     _fail "isolated launcher output unexpected: ${output}"
 fi

--- a/.agents/scripts/tests/test-shared-gh-wrappers-standalone.sh
+++ b/.agents/scripts/tests/test-shared-gh-wrappers-standalone.sh
@@ -164,6 +164,24 @@ else
 fi
 
 # =============================================================================
+# Test 4b: caller-owned SCRIPT_DIR cannot skip the public-write privacy guard.
+# =============================================================================
+bash_privacy_guard=$(SCRIPT_DIR="${SCRIPT_DIR_TEST}/missing-caller-dir" bash -c "
+source '${WRAPPERS_FILE}' 2>/dev/null
+if command -v privacy_guard_public_write >/dev/null 2>&1; then
+    printf 'DEFINED\\n'
+else
+    printf 'MISSING\\n'
+fi
+" 2>&1)
+if [[ "$bash_privacy_guard" == *"DEFINED"* ]]; then
+	pass "4b: bash: caller SCRIPT_DIR cannot skip public-write privacy dependency"
+else
+	fail "4b: bash: caller SCRIPT_DIR cannot skip public-write privacy dependency" \
+		"output: $(printf '%q' "$bash_privacy_guard")"
+fi
+
+# =============================================================================
 # Test 5: bash — sourcing constants FIRST then wrappers keeps canonical print_info
 #          (stubs do NOT override the canonical implementation)
 # =============================================================================
@@ -253,6 +271,22 @@ fi
 	else
 		fail "8: zsh: all major wrapper functions defined after standalone sourcing" \
 			"output: $(printf '%q' "$zsh_wrappers")"
+	fi
+
+	# Test 8b: zsh must also load the privacy guard with a caller-owned SCRIPT_DIR.
+	zsh_privacy_guard=$(SCRIPT_DIR="${SCRIPT_DIR_TEST}/missing-caller-dir" zsh -c "
+source '${WRAPPERS_FILE}' 2>/dev/null
+if (( \${+functions[privacy_guard_public_write]} )); then
+    printf 'DEFINED\\n'
+else
+    printf 'MISSING\\n'
+fi
+" 2>&1)
+	if [[ "$zsh_privacy_guard" == *"DEFINED"* ]]; then
+		pass "8b: zsh: caller SCRIPT_DIR cannot skip public-write privacy dependency"
+	else
+		fail "8b: zsh: caller SCRIPT_DIR cannot skip public-write privacy dependency" \
+			"output: $(printf '%q' "$zsh_privacy_guard")"
 	fi
 
 	# Test 9: zsh — gh_create_pr --help should exercise the wrapper entry path

--- a/.agents/scripts/tests/test-test-helpers.sh
+++ b/.agents/scripts/tests/test-test-helpers.sh
@@ -102,6 +102,7 @@ while IFS= read -r sibling; do
 		missing=$((missing + 1))
 	fi
 done <<<"$deps_output"
+
 assert_eq "all discovered siblings exist on disk" "0" "$missing"
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -142,6 +143,14 @@ while IFS= read -r sibling; do
 	fi
 done <<<"$deps_output"
 
+if [[ -f "${tmpdir}/privacy-guard-helper.sh" ]]; then
+	echo "  PASS: privacy-guard-helper.sh landed in tmpdir"
+	PASS=$((PASS + 1))
+else
+	echo "  FAIL: privacy-guard-helper.sh missing from tmpdir"
+	FAIL=$((FAIL + 1))
+fi
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 4: sourcing the copy succeeds and wrappers are callable
 # ─────────────────────────────────────────────────────────────────────────────
@@ -160,6 +169,7 @@ assert_func_defined "gh_create_issue defined after source" "gh_create_issue"
 assert_func_defined "gh_issue_comment defined after source" "gh_issue_comment"
 assert_func_defined "gh_pr_comment defined after source" "gh_pr_comment"
 assert_func_defined "_gh_wrapper_auto_sig defined after source" "_gh_wrapper_auto_sig"
+assert_func_defined "privacy_guard_public_write defined after source" "privacy_guard_public_write"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 5: copy fails loudly when a dep is missing (simulate future split with


### PR DESCRIPTION
## Summary

- route framework-launched OpenCode sessions through the aidevops GitHub shim
- resolve wrapper privacy dependencies from their defining modules
- cover signed immutable PR edit body files and Bash/zsh standalone sourcing

Resolves #29997
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.251 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 7m and 185,405 tokens on this as a headless worker.