### PR TITLE
GH#29996: validate aggregate release recovery

### DIFF
--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -982,6 +982,33 @@ _merge_remove_body_snapshot() {
 	return 0
 }
 
+# Release provenance later reads merge commit trailers with `git
+# interpret-trailers --parse`. Reject an aggregation body whose raw trailers
+# would be hidden by a non-terminal signature divider before it reaches any
+# merge transport.
+_merge_validate_release_aggregation_body() {
+	local body_file="$1"
+	local raw_aggregator=""
+	local raw_aggregates=""
+	local parsed_trailers=""
+	local parsed_aggregator=""
+	local parsed_aggregates=""
+
+	raw_aggregator=$(awk '/^Aidevops-Release-Aggregator-PR: / { print substr($0, 33) }' "$body_file") || return 1
+	raw_aggregates=$(awk '/^Aidevops-Release-Aggregates: / { print substr($0, 30) }' "$body_file") || return 1
+	[[ -n "$raw_aggregator" || -n "$raw_aggregates" ]] || return 0
+
+	parsed_trailers=$(git interpret-trailers --parse <"$body_file") || return 1
+	parsed_aggregator=$(awk '/^Aidevops-Release-Aggregator-PR: / { print substr($0, 33) }' <<<"$parsed_trailers") || return 1
+	parsed_aggregates=$(awk '/^Aidevops-Release-Aggregates: / { print substr($0, 30) }' <<<"$parsed_trailers") || return 1
+	if [[ "$raw_aggregator" != "$parsed_aggregator" || "$raw_aggregates" != "$parsed_aggregates" ||
+		! "$parsed_aggregator" =~ ^[0-9]+$ || -z "$parsed_aggregates" ]]; then
+		print_error "Release-aggregation trailers must be a terminal parseable block; place any signature footer and --- before the Aidevops-Release trailers."
+		return 1
+	fi
+	return 0
+}
+
 _merge_execute() {
 	local pr_number="$1" repo="$2" merge_method="$3"
 	local has_admin="$4" has_auto="$5" squash_subject=""
@@ -1777,6 +1804,10 @@ cmd_merge() {
 	if [[ -n "$merge_body_file" ]]; then
 		_merge_body_snapshot=$(_merge_snapshot_body_file "$merge_body_file") || return 1
 		merge_body_file="$_merge_body_snapshot"
+		if ! _merge_validate_release_aggregation_body "$merge_body_file"; then
+			_merge_remove_body_snapshot "$_merge_body_snapshot"
+			return 1
+		fi
 	fi
 	# Retarget any open PRs stacked on this branch before the head branch is
 	# deleted post-merge. GitHub auto-closes stacked children when their base

--- a/.agents/scripts/full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/full-loop-release-aggregate-recovery.sh
@@ -402,6 +402,7 @@ _full_loop_release_recover_aggregate() {
 	local tag_name="$3"
 	local expected_sources="$4"
 	local recovery_rc=0
+	local resume_rc=0
 	local new_tag_object=""
 	local tag_sources=""
 	_full_loop_recovery_validate_receipt "$repo" "$source_pr" || return 1
@@ -420,6 +421,19 @@ _full_loop_release_recover_aggregate() {
 	_full_loop_recovery_begin_state_transaction "$repo" "$source_pr" "$tag_name" || return 1
 	_full_loop_recovery_run_version_manager "$source_pr" "$tag_name" || recovery_rc=$?
 	if [[ "$recovery_rc" -ne 0 && "$recovery_rc" -ne 8 ]]; then
+		# A protected-main PR can be created after the replacement tag is durable
+		# but before version-manager reports its normal queued exit. Reconcile the
+		# exact tag before treating that post-mutation state as a failure.
+		_full_loop_recovery_resume_publication "$repo" "$source_pr" "$tag_name" || resume_rc=$?
+		case "$resume_rc" in
+		0) return 0 ;;
+		8)
+			printf 'release:aggregate-recovery queued tag=%s source_pr=%s\n' "$tag_name" "$source_pr"
+			printf 'Resume with: aidevops release status %s\n' "$source_pr"
+			printf 'Resume with: aidevops release reconcile %s\n' "$source_pr"
+			return 8
+			;;
+		esac
 		if _full_loop_recovery_tag_rollback_safe "$repo" "$tag_name"; then
 			_full_loop_recovery_restore_state_transaction "$repo" "$source_pr" || true
 		else
@@ -431,5 +445,7 @@ _full_loop_release_recover_aggregate() {
 	_full_loop_recovery_write_evidence "$repo" "$source_pr" "$tag_name" "$new_tag_object" || return 1
 	release_lane_update "$repo" "$source_pr" remote-publication "$tag_name" || return 1
 	printf 'release:aggregate-recovery queued tag=%s source_pr=%s\n' "$tag_name" "$source_pr"
+	printf 'Resume with: aidevops release status %s\n' "$source_pr"
+	printf 'Resume with: aidevops release reconcile %s\n' "$source_pr"
 	return 8
 }

--- a/.agents/scripts/tests/test-full-loop-merge-body-file.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-body-file.sh
@@ -178,8 +178,23 @@ write_fixture_body() {
 	local body_file="$1"
 	printf '%s\n' \
 		'Aidevops-Signature: fixture' \
+		'' \
 		'Aidevops-Release-Aggregator-PR: 42' \
 		'Aidevops-Release-Aggregates: 29721@d53b458a6ee82e3dccd922c3791b9f9f088efa8f' >"$body_file"
+	return 0
+}
+
+write_hidden_aggregation_body() {
+	local body_file="$1"
+	printf '%s\n' \
+		'Release aggregation' \
+		'' \
+		'Aidevops-Release-Aggregator-PR: 42' \
+		'Aidevops-Release-Aggregates: 29721@d53b458a6ee82e3dccd922c3791b9f9f088efa8f' \
+		'' \
+		'<!-- aidevops:sig -->' \
+		'---' \
+		'aidevops signature footer' >"$body_file"
 	return 0
 }
 
@@ -282,6 +297,24 @@ test_invalid_body_files_fail_before_gate() {
 	return 0
 }
 
+test_hidden_aggregation_trailers_fail_before_merge_write() {
+	local body_file="${TEST_ROOT}/hidden-aggregation-body"
+	local output=""
+	local rc=0
+	TEST_MODE="normal"
+	cmd_pre_merge_gate() { return 0; }
+	rm -f "${TEST_ROOT}/capture-count" "${TEST_ROOT}/snapshot-paths"
+	write_hidden_aggregation_body "$body_file"
+	output=$(cmd_merge 42 testorg/testrepo --body-file "$body_file" 2>&1) || rc=$?
+	if [[ "$rc" -ne 0 && ! -e "${TEST_ROOT}/capture-count" &&
+		"$output" == *"terminal parseable block"* ]]; then
+		print_result "signature-hidden aggregation trailers fail before merge write" 0
+	else
+		print_result "signature-hidden aggregation trailers fail before merge write" 1 "rc=${rc}; output=${output}"
+	fi
+	return 0
+}
+
 main() {
 	setup_subject
 	assert_transport_preserves_body normal "normal gh merge" 1
@@ -291,6 +324,7 @@ main() {
 	assert_transport_preserves_body stale-401 "stale-auth retry" 2
 	assert_transport_preserves_body rest "REST fallback" 1
 	test_invalid_body_files_fail_before_gate
+	test_hidden_aggregation_trailers_fail_before_merge_write
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]
 	return $?

--- a/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
@@ -228,11 +228,15 @@ _full_loop_recovery_run_version_manager() {
 	printf 'version-manager\n' >>"$CALL_LOG"
 	return 1
 }
+_full_loop_recovery_resume_publication() {
+	printf 'resume\n' >>"$CALL_LOG"
+	return 1
+}
 if _full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 >/dev/null 2>&1; then
 	printf 'FAIL failed recovery returned success\n'
 	exit 1
 fi
-[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "receipt tag aggregate channels begin version-manager restore " ]]
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "receipt tag aggregate channels begin version-manager resume restore " ]]
 printf 'PASS failed recovery restores authorization and release-lane state\n'
 
 : >"$CALL_LOG"
@@ -241,8 +245,22 @@ if _full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 >/dev/null 2>&
 	printf 'FAIL unsafe failed recovery returned success\n'
 	exit 1
 fi
-[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "receipt tag aggregate channels begin version-manager " ]]
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "receipt tag aggregate channels begin version-manager resume " ]]
 printf 'PASS uncertain tag rollback retains expanded state for reconciliation\n'
+
+: >"$CALL_LOG"
+_full_loop_recovery_resume_publication() {
+	printf 'resume\n' >>"$CALL_LOG"
+	return 8
+}
+durable_queue_rc=0
+durable_queue_output=$(_full_loop_release_recover_aggregate test/repo 42 v1.2.3 42,43 2>&1) || durable_queue_rc=$?
+[[ "$durable_queue_rc" -eq 8 ]]
+[[ "$(tr '\n' ' ' <"$CALL_LOG")" == "receipt tag aggregate channels begin version-manager resume " ]]
+[[ "$durable_queue_output" == *"aidevops release status 42"* ]]
+[[ "$durable_queue_output" == *"aidevops release reconcile 42"* ]]
+[[ "$durable_queue_output" != *"Aggregate recovery failed after tag state changed"* ]]
+printf 'PASS durable protected-main queue remains pending after version-manager uncertainty\n'
 
 (
 	unset _FULL_LOOP_RELEASE_AGGREGATE_RECOVERY_LOADED


### PR DESCRIPTION
## Summary

Reject non-terminal release aggregation trailers and preserve durable protected-main recovery queues.

## Files Changed

.agents/scripts/full-loop-helper-merge.sh, .agents/scripts/full-loop-release-aggregate-recovery.sh, .agents/scripts/tests/test-full-loop-merge-body-file.sh, .agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — ShellCheck; .agents/scripts/linters-local.sh; targeted merge, aggregate-recovery, version-manager, and provenance suites.

Resolves #29996


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.251 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 7m and 181,017 tokens on this as a headless worker.