### PR TITLE
GH#29998: fix: coordinate exact-tip release merges

### DIFF
--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -49,6 +49,10 @@ source "${SCRIPT_DIR}/shared-phase-filing.sh"
 # shellcheck disable=SC1091  # sub-library resolved at runtime via SCRIPT_DIR
 source "${SCRIPT_DIR}/gh-merge-cache-remediation-lib.sh"
 
+# shellcheck source=./release-lane-helper.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via SCRIPT_DIR
+source "${SCRIPT_DIR}/release-lane-helper.sh"
+
 if [[ -f "${SCRIPT_DIR}/full-loop-cleanup-receipt.sh" ]]; then
 	# shellcheck source=./full-loop-cleanup-receipt.sh
 	source "${SCRIPT_DIR}/full-loop-cleanup-receipt.sh"
@@ -1787,6 +1791,21 @@ cmd_merge() {
 		print_error "Merge blocked by review bot gate. Address bot findings or wait for reviews."
 		return 1
 	}
+	if [[ "$repo" == "${AIDEVOPS_RELEASE_LANE_COORDINATED_REPO:-marcusquinn/aidevops}" ]]; then
+		local _release_lane_pr_refs=""
+		local _release_lane_base_ref=""
+		local _release_lane_head_ref=""
+		local _release_lane_pr_endpoint="repos/${repo}/pulls"
+		_release_lane_pr_refs=$(gh api "${_release_lane_pr_endpoint}/${pr_number}" --jq '[.base.ref, .head.ref] | @tsv' 2>/dev/null) || {
+			print_error "Merge blocked: cannot verify release-lane PR identity"
+			return 1
+		}
+		IFS=$'\t' read -r _release_lane_base_ref _release_lane_head_ref <<<"$_release_lane_pr_refs"
+		release_lane_merge_guard "$repo" "$pr_number" "$_release_lane_base_ref" "$_release_lane_head_ref" || {
+			print_error "Merge deferred by active exact-tip release lane"
+			return 1
+		}
+	fi
 	local _cleanup_target=""
 	local _cleanup_worktree=""
 	local _cleanup_branch=""

--- a/.agents/scripts/full-loop-release-helper.sh
+++ b/.agents/scripts/full-loop-release-helper.sh
@@ -340,7 +340,15 @@ _full_loop_release_existing_with_lane() {
 	_full_loop_release_existing_command "$release_type" "$source_pr" || existing_rc=$?
 	if [[ "$release_type" == "reconcile" && "$lane_owned" == "true" ]]; then
 		if [[ "$existing_rc" -eq 0 ]]; then
-			release_lane_finalize "$existing_repo" "$source_pr" "published" || return 1
+			local receipt_path=""
+			local receipt_status=""
+			receipt_path=$(_full_loop_release_receipt_path "$existing_repo" "$source_pr") || return 1
+			[[ -f "$receipt_path" ]] && IFS= read -r receipt_status <"$receipt_path" || true
+			case "$receipt_status" in
+			"$_FULL_LOOP_RELEASE_PUBLISHED" | "$_FULL_LOOP_RELEASE_SUPERSEDED") ;;
+			*) return 1 ;;
+			esac
+			release_lane_finalize "$existing_repo" "$source_pr" "$receipt_status" || return 1
 		elif [[ "$existing_rc" -eq 8 ]]; then
 			release_lane_update "$existing_repo" "$source_pr" "remote-publication" || return 1
 		fi

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -241,6 +241,10 @@ source "${_PULSE_MERGE_DIR}/pr-supersession-helper.sh"
 # shellcheck disable=SC1091  # sub-library resolved at runtime via _PULSE_MERGE_DIR
 source "${_PULSE_MERGE_DIR}/gh-merge-cache-remediation-lib.sh"
 
+# shellcheck source=./release-lane-helper.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via _PULSE_MERGE_DIR
+source "${_PULSE_MERGE_DIR}/release-lane-helper.sh"
+
 readonly _PM_PARENT_TASK_LABEL_NEEDLE=",parent-task,"
 
 # Source author permission check helpers (GH#21426 — extracted to bring
@@ -1393,6 +1397,12 @@ _process_single_ready_pr() {
 	if _pmp_is_protected_release_pr "$pr_head_ref_name" "$pr_labels"; then
 		echo "[pulse-wrapper] Merge pass: deferring protected release PR #${pr_number} in ${repo_slug} to provenance-preserving exact-merge reconciliation" >>"$LOGFILE"
 		return 4
+	fi
+	if [[ "$repo_slug" == "${AIDEVOPS_RELEASE_LANE_COORDINATED_REPO:-marcusquinn/aidevops}" ]]; then
+		if ! release_lane_merge_guard "$repo_slug" "$pr_number" "$pr_base_ref_name" "$pr_head_ref_name"; then
+			echo "[pulse-wrapper] Merge pass: deferring PR #${pr_number} in ${repo_slug} for active exact-tip release lane" >>"$LOGFILE"
+			return 1
+		fi
 	fi
 
 	# REST-first PR lists cannot preserve GraphQL-only mergeable state, so a

--- a/.agents/scripts/release-lane-helper.sh
+++ b/.agents/scripts/release-lane-helper.sh
@@ -380,6 +380,51 @@ release_lane_finalize() {
 	return $?
 }
 
+release_lane_merge_guard() {
+	local repo="$1"
+	local pr_number="$2"
+	local base_ref="$3"
+	local head_ref="$4"
+	local coordinated_repo="${AIDEVOPS_RELEASE_LANE_COORDINATED_REPO:-marcusquinn/aidevops}"
+	local read_rc=0
+	local active=""
+	local phase=""
+	local source_pr=""
+	local tag_name=""
+	local terminal_receipt=""
+
+	[[ "$repo" == "$coordinated_repo" && "$base_ref" == "main" ]] || return 0
+	[[ "$pr_number" =~ ^[0-9]+$ ]] || return 1
+	release_lane_read "$repo" || read_rc=$?
+	case "$read_rc" in
+	2) return 0 ;;
+	0) ;;
+	*)
+		printf 'Cannot verify repository release lane; ordinary merge is blocked\n' >&2
+		return 75
+		;;
+	esac
+	active=$(jq -r '.active' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	phase=$(jq -r '.phase' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	terminal_receipt=$(jq -r 'if .terminal_receipt == null then "" elif (.terminal_receipt | type) == "string" then .terminal_receipt else .terminal_receipt.status // "" end' \
+		<<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	if [[ "$active" == "false" || "$phase" == "terminal" || "$terminal_receipt" == "published" || "$terminal_receipt" == "superseded" || "$terminal_receipt" == "recovered" ]]; then
+		return 0
+	fi
+	case "$phase" in
+	remote-publication | exact-tag-deployment) ;;
+	*) return 0 ;;
+	esac
+	source_pr=$(jq -r '.source_pr' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	tag_name=$(jq -r '.tag // ""' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
+	if [[ "$pr_number" == "$source_pr" || (-n "$tag_name" && "$head_ref" == "chore/release-${tag_name}-provenance") ]]; then
+		return 0
+	fi
+	printf 'ACTIVE_RELEASE_LANE_MERGE_BLOCKED source_pr=%s phase=%s tag=%s\n' \
+		"$source_pr" "$phase" "${tag_name:-pending}" >&2
+	return 75
+}
+
 release_lane_setup_guard() {
 	local repo="$1"
 	local source_pr="${AIDEVOPS_RELEASE_LANE_SOURCE_PR:-}"

--- a/.agents/scripts/tests/test-release-lane.sh
+++ b/.agents/scripts/tests/test-release-lane.sh
@@ -88,6 +88,36 @@ run_setup_guard_test() {
 	return $?
 }
 
+run_merge_guard_test() (
+	local state='{"schema_version":1,"repository":"test/repo","active":true,"source_pr":101,"phase":"remote-publication","tag":"v1.2.3","operation_token":"token-old"}'
+	local output=""
+	local rc=0
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON="$state"
+		return 0
+	}
+	output=$(AIDEVOPS_RELEASE_LANE_COORDINATED_REPO=test/repo \
+		release_lane_merge_guard test/repo 202 main feature/ordinary 2>&1) || rc=$?
+	[[ "$rc" -eq 75 && "$output" == *"source_pr=101"* && "$output" == *"phase=remote-publication"* ]] || return 1
+	AIDEVOPS_RELEASE_LANE_COORDINATED_REPO=test/repo \
+		release_lane_merge_guard test/repo 101 main feature/release-owner || return 1
+	AIDEVOPS_RELEASE_LANE_COORDINATED_REPO=test/repo \
+		release_lane_merge_guard test/repo 303 main chore/release-v1.2.3-provenance || return 1
+	state='{"schema_version":1,"repository":"test/repo","active":false,"source_pr":101,"phase":"terminal","tag":"v1.2.3","operation_token":"token-old","terminal_receipt":"superseded"}'
+	AIDEVOPS_RELEASE_LANE_COORDINATED_REPO=test/repo \
+		release_lane_merge_guard test/repo 202 main feature/ordinary || return 1
+	return 0
+)
+
+run_merge_guard_api_uncertainty_test() (
+	release_lane_read() { return 1; }
+	if AIDEVOPS_RELEASE_LANE_COORDINATED_REPO=test/repo \
+		release_lane_merge_guard test/repo 202 main feature/ordinary >/dev/null 2>&1; then
+		return 1
+	fi
+	return 0
+)
+
 run_http_classification_test() (
 	local mode="missing"
 	local rc=0
@@ -259,6 +289,8 @@ if run_competing_source_test; then assert_result 'competing source receives acti
 if run_same_source_adoption_test; then assert_result 'same source adopts durable lane without another bump' true; else assert_result 'same source adopts durable lane without another bump' false; fi
 if run_terminal_lane_reacquire_test; then assert_result 'terminal lane can be atomically reserved by a later source' true; else assert_result 'terminal lane can be atomically reserved by a later source' false; fi
 if run_setup_guard_test; then assert_result 'exact-tag deployment blocks generic setup and permits matching owner' true; else assert_result 'exact-tag deployment blocks generic setup and permits matching owner' false; fi
+if run_merge_guard_test; then assert_result 'exact-tip lane blocks ordinary merges while preserving release ownership and terminal recovery' true; else assert_result 'exact-tip lane blocks ordinary merges while preserving release ownership and terminal recovery' false; fi
+if run_merge_guard_api_uncertainty_test; then assert_result 'merge coordination fails closed when lane state is unavailable' true; else assert_result 'merge coordination fails closed when lane state is unavailable' false; fi
 if run_http_classification_test; then assert_result 'only verified HTTP 404 is classified as an absent lane' true; else assert_result 'only verified HTTP 404 is classified as an absent lane' false; fi
 if run_legacy_and_api_failure_test; then assert_result 'legacy absent lane remains compatible while API uncertainty blocks setup' true; else assert_result 'legacy absent lane remains compatible while API uncertainty blocks setup' false; fi
 if run_stale_same_source_recovery_test; then assert_result 'stale recovery rotates its token and fences the prior owner' true; else assert_result 'stale recovery rotates its token and fences the prior owner' false; fi


### PR DESCRIPTION
## Summary

Blocks ordinary main merges during remote publication or exact-tag deployment while allowing the source/protected provenance path and finalizing superseded lanes accurately.

## Files Changed

.agents/scripts/full-loop-helper-merge.sh, .agents/scripts/full-loop-release-helper.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/release-lane-helper.sh, .agents/scripts/tests/test-release-lane.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-release-lane.sh; bash .agents/scripts/tests/test-pulse-merge-ci-repair-routing.sh; bash .agents/scripts/tests/test-full-loop-release-helper.sh; bash .agents/scripts/tests/test-full-loop-release-reconcile.sh; .agents/scripts/linters-local.sh

Resolves #29998


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.251 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 15m and 202,722 tokens on this as a headless worker.