### PR TITLE
GH#30002: fix packaged OpenCode virtual argv import

### DIFF
--- a/.agents/plugins/opencode-aidevops/session-recovery-marker.mjs
+++ b/.agents/plugins/opencode-aidevops/session-recovery-marker.mjs
@@ -273,9 +273,18 @@ function runCli(argv) {
   return 0;
 }
 
+export function pathsReferenceSameFile(candidatePath, expectedPath, canonicalize = realpathSync) {
+  if (!candidatePath || !expectedPath) return false;
+  try {
+    return canonicalize(candidatePath) === canonicalize(expectedPath);
+  } catch {
+    return false;
+  }
+}
+
 const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
 const modulePath = fileURLToPath(import.meta.url);
-if (invokedPath && existsSync(invokedPath) && realpathSync(invokedPath) === realpathSync(modulePath)) {
+if (pathsReferenceSameFile(invokedPath, modulePath)) {
   try {
     process.exitCode = runCli(process.argv.slice(2));
   } catch (error) {

--- a/.agents/scripts/gpt56-context-helper.sh
+++ b/.agents/scripts/gpt56-context-helper.sh
@@ -8,7 +8,6 @@ SETTINGS_FILE="${AIDEVOPS_SETTINGS_FILE:-${HOME}/.config/aidevops/settings.json}
 BOOLEAN_TRUE="true"
 PLUGIN_HEALTH_SCHEMA="aidevops.opencode-plugin-health/v1"
 OPENCODE_BIN="${OPENCODE_BIN:-opencode}"
-NODE_BIN="${NODE_BIN:-node}"
 PLUGIN_ENTRY="${AIDEVOPS_PLUGIN_ENTRY:-${HOME}/.aidevops/agents/plugins/opencode-aidevops/index.mjs}"
 
 usage() {
@@ -54,7 +53,7 @@ show_status() {
 		requested="enabled"
 	fi
 	printf '%s\n' "GPT-5.6 OpenCode context cap requested: ${requested}"
-	if ! command -v "$OPENCODE_BIN" >/dev/null 2>&1 || ! command -v "$NODE_BIN" >/dev/null 2>&1; then
+	if ! command -v "$OPENCODE_BIN" >/dev/null 2>&1; then
 		printf '%s\n' "OpenCode plugin effective state: unavailable (OpenCode is not installed)"
 		return 0
 	fi
@@ -77,11 +76,7 @@ show_status() {
 		if AIDEVOPS_PLUGIN_HEALTH_PROBE_FILE="$probe_file" \
 			AIDEVOPS_PLUGIN_HEALTH_PROBE_NONCE="$probe_nonce" \
 			AIDEVOPS_PLUGIN_HEALTH_PROBE_ONLY=1 \
-			"$NODE_BIN" --input-type=module --eval '
-				const plugin = await import(process.argv[1]);
-				const hooks = await plugin.AidevopsPlugin({directory: process.argv[2], client: {}});
-				await hooks.config({});
-			' "$PLUGIN_ENTRY" "$PWD" >>"$probe_output" 2>>"$probe_error"; then
+			"$OPENCODE_BIN" models openai --verbose >>"$probe_output" 2>>"$probe_error"; then
 			probe_status=0
 		else
 			probe_status=$?

--- a/.agents/scripts/tests/test-gpt56-context-helper.sh
+++ b/.agents/scripts/tests/test-gpt56-context-helper.sh
@@ -17,13 +17,16 @@ printf '%s\n' '// mock plugin entry' >"$PLUGIN_ENTRY"
 cat >"${MOCK_BIN}/opencode" <<'MOCK'
 #!/usr/bin/env bash
 set -euo pipefail
-printf '{"plugin":["file://%s"]}\n' "${AIDEVOPS_PLUGIN_ENTRY:?}"
-MOCK
-cat >"${MOCK_BIN}/node" <<'MOCK'
-#!/usr/bin/env bash
-set -euo pipefail
+if [[ "${1:-}" == "debug" && "${2:-}" == "config" ]]; then
+	printf '{"plugin":["file://%s"]}\n' "${AIDEVOPS_PLUGIN_ENTRY:?}"
+	exit 0
+fi
+if [[ "${1:-}" != "models" || "${2:-}" != "openai" || "${3:-}" != "--verbose" ]]; then
+	printf '%s\n' "unexpected packaged OpenCode invocation: $*" >&2
+	exit 2
+fi
 if [[ "${MOCK_PLUGIN_ACTIVE:-1}" != "1" ]]; then
-	printf '%s\n' 'mock plugin import failed at $HOME/plugin.mjs' >&2
+	printf '%s\n' 'mock packaged OpenCode plugin import failed at $HOME/plugin.mjs' >&2
 	exit 1
 fi
 jq -cn --arg nonce "${AIDEVOPS_PLUGIN_HEALTH_PROBE_NONCE:?}" \
@@ -32,8 +35,9 @@ jq -cn --arg nonce "${AIDEVOPS_PLUGIN_HEALTH_PROBE_NONCE:?}" \
 	factory_initialized:{config_hook:true,terminal_title_status:true},
 	config_applied:{terminal_title_status:true,gpt56_limits:{context:300000,input:260000,output:128000}}}}' \
 	>"${AIDEVOPS_PLUGIN_HEALTH_PROBE_FILE:?}"
+printf '%s\n' 'openai/gpt-5.6-sol limit: context=300000 input=260000 output=128000'
 MOCK
-chmod +x "${MOCK_BIN}/opencode" "${MOCK_BIN}/node"
+chmod +x "${MOCK_BIN}/opencode"
 export PATH="${MOCK_BIN}:${PATH}"
 export AIDEVOPS_PLUGIN_ENTRY="$PLUGIN_ENTRY"
 
@@ -56,7 +60,7 @@ assert_contains "$output" "Terminal-title status hook: registered"
 
 output=$(MOCK_PLUGIN_ACTIVE=0 bash "$HELPER" status)
 assert_contains "$output" "inactive or initialization failed"
-assert_contains "$output" "mock plugin import failed at \$HOME/plugin.mjs"
+assert_contains "$output" "mock packaged OpenCode plugin import failed at \$HOME/plugin.mjs"
 assert_contains "$output" "requested state not confirmed"
 
 output=$(OPENCODE_BIN="${TEST_HOME}/missing-opencode" bash "$HELPER" status)

--- a/.agents/scripts/tests/test-session-recovery-marker.mjs
+++ b/.agents/scripts/tests/test-session-recovery-marker.mjs
@@ -11,6 +11,7 @@ import { fileURLToPath } from "node:url";
 import {
   createSessionRecoveryMarkerHandler,
   currentDirectorySequence,
+  pathsReferenceSameFile,
   resolveSessionRecoveryMarker,
   writeSessionRecoveryMarker,
 } from "../../plugins/opencode-aidevops/session-recovery-marker.mjs";
@@ -85,6 +86,19 @@ assert.equal(
   subcommandImport.status,
   0,
   `plugin import should ignore non-path CLI subcommands: ${subcommandImport.stderr}`,
+);
+const bunVirtualPath = "/$bunfs/root/src/index.js";
+assert.equal(
+  pathsReferenceSameFile(bunVirtualPath, resolverPath, (candidate) => {
+    if (candidate === bunVirtualPath) {
+      const error = new Error(`ENOENT: no such file or directory, lstat '${candidate}'`);
+      error.code = "ENOENT";
+      throw error;
+    }
+    return realpathSync(candidate);
+  }),
+  false,
+  "Bun virtual argv paths must not break plugin module evaluation when canonicalization fails",
 );
 
 const emitted = [];


### PR DESCRIPTION
## Summary

Make session-recovery direct-execution detection exception-safe and verify GPT-5.6 plugin health through the packaged OpenCode loader.

## Files Changed

.agents/plugins/opencode-aidevops/session-recovery-marker.mjs, .agents/scripts/gpt56-context-helper.sh, .agents/scripts/tests/test-gpt56-context-helper.sh, .agents/scripts/tests/test-session-recovery-marker.mjs

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: focused session-recovery and GPT-5.6 helper tests pass; OpenCode plugin suite passes 633/633; local linters pass; packaged OpenCode runtime reports 300000/260000/128000.

Resolves #30002


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.251 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 11m and 199,210 tokens on this with the user in an interactive session.