### PR TITLE
GH#29956: fix: harden Issue Sync merge authority

### DIFF
--- a/.agents/reference/review-bot-gate.md
+++ b/.agents/reference/review-bot-gate.md
@@ -124,7 +124,11 @@ The review add-on check runs after the `origin:interactive` (t2411) and
   deterministic `aidevops/issue-sync-todo` branch, and generated body marker all
   match. For `issue_comment` events that omit head/base metadata, CI asks the
   shared helper to classify one live REST pull payload. This keeps CI,
-  interactive merge, and Pulse decisions aligned. Any missing or mismatched
+  interactive merge, and Pulse decisions aligned. Full-loop and Pulse bind the
+  same classifier to the already verified merge head before granting generated
+  PR authority or approval. Pulse creates approvals with REST `commit_id` bound
+  to that head and verifies the response; full-loop refreshes mutable authority
+  before every retry or fallback merge transport. Any missing or mismatched
   field remains external and fail-closed.
 - **External contributors**: advisory, rate-limit, and skip outcomes remain
   fail-closed; completed review evidence is required in addition to independent

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -214,9 +214,9 @@ _merge_try_interactive_admin_auto_fallback() {
 	_merge_output_is_review_policy_block "$merge_output" || return 1
 	_merge_pr_ready_for_interactive_admin_bypass "$pr_number" "$repo" || return 1
 
-	#aidevops:trust-boundary -- interactive admin fallback re-checks exact-head
-	# authority immediately before bypassing review-count protection.
-	_merge_guard_admin_merge_maintainer_review "$pr_number" "$repo" "$expected_head_sha" || return 2
+	#aidevops:trust-boundary -- interactive admin fallback refreshes every mutable
+	# authority input immediately before bypassing review-count protection.
+	_merge_revalidate_transport_authority "$pr_number" "$repo" "$expected_head_sha" || return 2
 	print_info "Auto-merge is blocked only by review-required branch policy/self-approval; interactive maintainer session is using --admin merge after gates passed."
 	local subject_flags=()
 	[[ -n "$squash_subject" ]] && subject_flags+=("$FULL_LOOP_MERGE_SUBJECT_FLAG" "$squash_subject")
@@ -365,6 +365,21 @@ _merge_target_crypto_approved() {
 	return $?
 }
 
+_merge_is_trusted_issue_sync_pr() {
+	local pr_number="$1"
+	local repo="$2"
+	local expected_head_sha="$3"
+	local rbg_helper=""
+
+	[[ -n "$expected_head_sha" ]] || return 1
+	rbg_helper=$(_full_loop_review_bot_gate_helper_path) || return 1
+	#aidevops:trust-boundary -- bind the exact generated Issue Sync identity to
+	# the already verified merge head; helper/API failures remain external.
+	bash "$rbg_helper" is-trusted-issue-sync-pr \
+		"$pr_number" "$repo" "$expected_head_sha" >/dev/null 2>&1
+	return $?
+}
+
 # Returns 0 for live admin/maintain/write authority, 1 for a confirmed external
 # author, and 2 when GitHub cannot provide a trustworthy verdict.
 _merge_author_has_write_authority() {
@@ -423,7 +438,7 @@ _merge_guard_admin_merge_maintainer_review() {
 	local expected_head_sha="${3:-}"
 	local pr_json="" pr_author="" current_head_sha="" labels_csv="" labels_padded="" is_fork="false"
 	local issue_numbers=""
-	local author_rc=0 treat_as_external=0 trusted_dependabot=0
+	local author_rc=0 treat_as_external=0 trusted_dependabot=0 trusted_issue_sync=0
 
 	if ! pr_json=$(gh pr view "$pr_number" --repo "$repo" \
 		--json author,labels,isCrossRepository,headRefOid,closingIssuesReferences,body 2>/dev/null); then
@@ -461,14 +476,14 @@ _merge_guard_admin_merge_maintainer_review() {
 		return 1
 	fi
 
-	#aidevops:trust-boundary -- GitHub Dependabot may lack collaborator
-	# permission even for same-repository branches. The shared predicate verifies
-	# immutable bot identity, exact head, repository ownership, commit authors,
-	# dependency-only files, explicit allowlisting, and security status. A live
-	# NMR labels remain unconditional holds and all normal pre-merge gates still
-	# run before this authority-only exception. Linked-issue holds are validated
-	# below before the trusted-bot result can return success.
-	if _is_trusted_dependabot_update_pr "$pr_number" "$repo" "$pr_author" "$current_head_sha"; then
+	#aidevops:trust-boundary -- repository-generated Issue Sync and Dependabot
+	# PRs may lack collaborator permission. Both narrow predicates bind immutable
+	# bot identity and repository ownership to the exact current head. Live PR and
+	# linked-issue NMR labels remain unconditional holds.
+	if [[ "$pr_author" == "app/github-actions" || "$pr_author" == "github-actions[bot]" ]] &&
+		_merge_is_trusted_issue_sync_pr "$pr_number" "$repo" "$current_head_sha"; then
+		trusted_issue_sync=1
+	elif _is_trusted_dependabot_update_pr "$pr_number" "$repo" "$pr_author" "$current_head_sha"; then
 		trusted_dependabot=1
 	else
 		_merge_author_has_write_authority "$pr_author" "$repo" || author_rc=$?
@@ -490,6 +505,10 @@ _merge_guard_admin_merge_maintainer_review() {
 	_merge_linked_issue_authority_clear "$issue_numbers" "$repo" "$treat_as_external" || return 1
 	if [[ "$trusted_dependabot" -eq 1 ]]; then
 		print_info "Trusted Dependabot authority verified for PR #${pr_number} at ${current_head_sha}"
+		return 0
+	fi
+	if [[ "$trusted_issue_sync" -eq 1 ]]; then
+		print_info "Trusted repository-generated Issue Sync authority verified for PR #${pr_number} at ${current_head_sha}"
 		return 0
 	fi
 
@@ -793,6 +812,10 @@ _merge_rest_fallback() {
 		;;
 	esac
 
+	#aidevops:trust-boundary -- GraphQL transport failure does not preserve a
+	# mutable authority snapshot for the later REST mutation.
+	_merge_revalidate_transport_authority "$pr_number" "$repo" "$expected_head_sha" || return 1
+
 	print_info "GraphQL rate limit blocked gh pr merge; retrying via REST pull merge endpoint with verified head SHA ${expected_head_sha}..."
 	local rest_args=(-f "sha=${expected_head_sha}" -f "merge_method=${rest_method}")
 	[[ -n "$squash_subject" ]] && rest_args+=(-f "commit_title=${squash_subject}")
@@ -871,6 +894,17 @@ _merge_review_state_still_clear() {
 		print_error "PR #${pr_number} review or head state changed after readiness verification; refusing merge"
 		return 1
 	fi
+	return 0
+}
+
+_merge_revalidate_transport_authority() {
+	local pr_number="$1"
+	local repo="$2"
+	local expected_head_sha="$3"
+
+	_merge_review_state_still_clear "$pr_number" "$repo" "$expected_head_sha" || return 1
+	_merge_guard_admin_merge_maintainer_review "$pr_number" "$repo" "$expected_head_sha" || return 1
+	_merge_guard_prospective_todo "$pr_number" "$repo" || return 1
 	return 0
 }
 
@@ -1033,12 +1067,10 @@ _merge_execute() {
 		print_error "Cannot bind merge to a remotely verified PR head SHA"
 		return 1
 	}
-	_merge_review_state_still_clear "$pr_number" "$repo" "$match_head_sha" || return 1
 	#aidevops:trust-boundary GH#17671/GH#28622 -- every merge mode, including
 	# --auto and the non-admin REST transport fallback, must pass the same live
 	# external/fork and exact-head cryptographic authority check.
-	_merge_guard_admin_merge_maintainer_review "$pr_number" "$repo" "$match_head_sha" || return 1
-	_merge_guard_prospective_todo "$pr_number" "$repo" || return 1
+	_merge_revalidate_transport_authority "$pr_number" "$repo" "$match_head_sha" || return 1
 	merge_flags+=("--match-head-commit" "$match_head_sha")
 
 	# Capture output AND exit code under set -e. A bare assignment `out=$(cmd)`
@@ -1053,6 +1085,7 @@ _merge_execute() {
 	if [[ $_merge_rc -ne 0 ]] && gh_merge_remediate_stale_auth_cache "$_merge_out" "full-loop PR #${pr_number} in ${repo}" ""; then
 		local _merge_retry_out="" _merge_original_out="$_merge_out"
 		print_info "gh pr merge returned 401 while live gh auth succeeds; quarantined stale gh cache entries and retrying once..."
+		_merge_revalidate_transport_authority "$pr_number" "$repo" "$match_head_sha" || return 1
 		if _merge_retry_out=$(gh pr merge "$pr_number" --repo "$repo" "$merge_method" ${merge_flags[@]+"${merge_flags[@]}"} 2>&1); then
 			_merge_out="$_merge_retry_out"
 			_merge_rc=0
@@ -1083,7 +1116,7 @@ ${_merge_retry_out}"
 		# Only fall back to --admin when caller passed neither --admin nor --auto.
 		elif [[ $has_admin -eq 0 && $has_auto -eq 0 ]] &&
 			printf '%s' "$_merge_out" | grep -qE 'base branch policy prohibits|Required status checks? (is|are) expected|At least [0-9]+ approving review'; then
-			_merge_guard_admin_merge_maintainer_review "$pr_number" "$repo" "$match_head_sha" || return 1
+			_merge_revalidate_transport_authority "$pr_number" "$repo" "$match_head_sha" || return 1
 			print_info "Branch protection blocked plain merge; retrying with --admin (workers share the maintainer's gh auth per GH#18538)..."
 			local subject_flags=()
 			[[ -n "$squash_subject" ]] && subject_flags+=("$FULL_LOOP_MERGE_SUBJECT_FLAG" "$squash_subject")

--- a/.agents/scripts/pulse-merge-gates.sh
+++ b/.agents/scripts/pulse-merge-gates.sh
@@ -49,6 +49,48 @@ source "${_PULSE_MERGE_DIR:-${BASH_SOURCE[0]%/*}}/trusted-dependabot-lib.sh"
 
 # --- Functions ---
 
+_pulse_is_trusted_issue_sync_pr() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local expected_head_sha="$3"
+	local rbg_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/review-bot-gate-helper.sh"
+
+	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" && -n "$expected_head_sha" ]] || return 1
+	[[ -f "$rbg_helper" ]] || return 1
+	#aidevops:trust-boundary -- use the shared exact generated-PR predicate and
+	# bind it to the current merge head. Missing helpers/API evidence fail closed.
+	bash "$rbg_helper" is-trusted-issue-sync-pr \
+		"$pr_number" "$repo_slug" "$expected_head_sha" >/dev/null 2>&1
+	return $?
+}
+
+_pulse_merge_classify_final_authority() {
+	local pr_number="$1" repo_slug="$2" pr_author="$3" current_head_sha="$4"
+	local labels_str="$5" is_fork="$6" author_collab_rc=0
+	_PULSE_FINAL_TRUSTED_ISSUE_SYNC=0
+
+	if [[ "$pr_author" == "github-actions" || "$pr_author" == "app/github-actions" || "$pr_author" == "github-actions[bot]" ]] &&
+		_pulse_is_trusted_issue_sync_pr "$pr_number" "$repo_slug" "$current_head_sha"; then
+		_PULSE_FINAL_TRUSTED_ISSUE_SYNC=1
+		return 0
+	fi
+	_is_collaborator_author "$pr_author" "$repo_slug" || author_collab_rc=$?
+	if [[ "$author_collab_rc" -eq 2 ]]; then
+		echo "[pulse-merge] DEFENSE-IN-DEPTH: REFUSING merge of PR #${pr_number} in ${repo_slug} — final collaborator permission lookup failed for ${pr_author}" >>"$LOGFILE"
+		return 2
+	fi
+	if [[ ",${labels_str}," == *",external-contributor,"* ]]; then
+		return 1
+	elif [[ "$is_fork" == "true" ]]; then
+		echo "[pulse-merge] DEFENSE-IN-DEPTH: PR #${pr_number} in ${repo_slug} — fork PR missing external-contributor label (label-system race or failure), treating as external (t2934)" >>"$LOGFILE"
+		return 1
+	elif [[ "$author_collab_rc" -ne 0 ]]; then
+		echo "[pulse-merge] DEFENSE-IN-DEPTH: PR #${pr_number} in ${repo_slug} — non-collaborator PR missing external-contributor label, treating as external (GH#17671)" >>"$LOGFILE"
+		return 1
+	fi
+	return 0
+}
+
 #######################################
 # Read PR conversation comments through the issue-comments REST endpoint.
 # Native `gh pr view --json comments` is GraphQL-only and cannot return its
@@ -468,23 +510,14 @@ _pulse_merge_admin_safety_check() {
 		return 1
 	fi
 
-	local treat_as_external=0 author_collab_rc=0
-	# #aidevops:trust-boundary — labels and fork metadata are not authority.
-	# Re-check the author's live permission at the final merge boundary.
-	_is_collaborator_author "$pr_author" "$repo_slug" || author_collab_rc=$?
-	if [[ "$author_collab_rc" -eq 2 ]]; then
-		echo "[pulse-merge] DEFENSE-IN-DEPTH: REFUSING merge of PR #${pr_number} in ${repo_slug} — final collaborator permission lookup failed for ${pr_author}" >>"$LOGFILE"
-		return 1
-	fi
-	if [[ ",${labels_str}," == *",external-contributor,"* ]]; then
-		treat_as_external=1
-	elif [[ "$is_fork" == "true" ]]; then
-		treat_as_external=1
-		echo "[pulse-merge] DEFENSE-IN-DEPTH: PR #${pr_number} in ${repo_slug} — fork PR missing external-contributor label (label-system race or failure), treating as external (t2934)" >>"$LOGFILE"
-	elif [[ "$author_collab_rc" -ne 0 ]]; then
-		treat_as_external=1
-		echo "[pulse-merge] DEFENSE-IN-DEPTH: PR #${pr_number} in ${repo_slug} — non-collaborator PR missing external-contributor label, treating as external (GH#17671)" >>"$LOGFILE"
-	fi
+	local treat_as_external=0 trusted_issue_sync=0 authority_rc=0
+	#aidevops:trust-boundary -- classify live collaborator, external, or exact
+	# generated-automation authority before linked-issue checks.
+	_pulse_merge_classify_final_authority "$pr_number" "$repo_slug" "$pr_author" \
+		"$current_head_sha" "$labels_str" "$is_fork" || authority_rc=$?
+	[[ "$authority_rc" -eq 2 ]] && return 1
+	[[ "$authority_rc" -eq 1 ]] && treat_as_external=1
+	trusted_issue_sync="${_PULSE_FINAL_TRUSTED_ISSUE_SYNC:-0}"
 
 	# A linked issue's live NMR state is a final-call hold for every PR, not only
 	# external PRs. Fail closed if a linked issue was found but cannot be read.
@@ -502,6 +535,9 @@ _pulse_merge_admin_safety_check() {
 	fi
 
 	if [[ "$treat_as_external" -eq 0 ]]; then
+		if [[ "$trusted_issue_sync" -eq 1 ]]; then
+			echo "[pulse-merge] Trusted repository-generated Issue Sync authority verified for PR #${pr_number} at ${current_head_sha}" >>"$LOGFILE"
+		fi
 		_PULSE_FINAL_REQUIRES_SYNCHRONOUS_MERGE=0
 		return 0
 	fi
@@ -632,6 +668,39 @@ _trusted_existing_approver() {
 }
 
 #######################################
+# Submit an approval bound to the reviewed PR head when one is available.
+#
+# #aidevops:trust-boundary -- `gh pr review --approve` always targets the
+# current head and cannot reject a head change between authority validation and
+# review creation. The REST review mutation accepts commit_id, so production
+# callers bind the approval to the exact head already used by the merge gates.
+# Args: $1=repo_slug, $2=pr_number, $3=approval body, $4=expected head SHA
+# Returns: 0=approved at the expected head, 1=mutation failed/mismatched
+#######################################
+_pulse_approve_pr_at_head() {
+	local repo_slug="$1"
+	local pr_number="$2"
+	local approval_body="$3"
+	local expected_head_sha="${4:-}"
+	local approval_response=""
+	local approval_state=""
+	local approval_head_sha=""
+
+	if [[ -z "$expected_head_sha" ]]; then
+		gh pr review "$pr_number" --repo "$repo_slug" --approve --body "$approval_body"
+		return $?
+	fi
+
+	approval_response=$(gh api -X POST "repos/${repo_slug}/pulls/${pr_number}/reviews" \
+		-f 'event=APPROVE' -f "body=${approval_body}" \
+		-f "commit_id=${expected_head_sha}" 2>&1) || return 1
+	approval_state=$(printf '%s' "$approval_response" | jq -r '.state // ""' 2>/dev/null) || return 1
+	approval_head_sha=$(printf '%s' "$approval_response" | jq -r '.commit_id // ""' 2>/dev/null) || return 1
+	[[ "$approval_state" == "APPROVED" && "$approval_head_sha" == "$expected_head_sha" ]]
+	return $?
+}
+
+#######################################
 # Auto-approve a collaborator's PR before merging (GH#10522, t1691)
 #
 # Branch protection requires required_approving_review_count=1.
@@ -644,6 +713,12 @@ _trusted_existing_approver() {
 #
 # Idempotent — if the current head already has a trusted approving review,
 # this is a no-op across all pulse identities.
+#
+# Defense-in-depth: author authority is rechecked at this function boundary so
+# a future caller cannot bypass GH#17671 protections. The t3063 path accepts
+# exact-head maintainer crypto authority as a stronger trust signal without
+# weakening the external-author default. Case P in the focused guard suite pins
+# CONTRIBUTOR + no crypto = refuse.
 #
 # Arguments:
 #   $1 - PR number
@@ -694,24 +769,6 @@ approve_collaborator_pr() {
 		fi
 	fi
 
-	# Defense-in-depth: refuse to approve when the PR author is not a
-	# collaborator on this repo. The merge cycle's _check_pr_merge_gates
-	# already short-circuits on this condition, but a future
-	# refactor could remove that gate. Self-protecting at the function
-	# boundary closes the regression window. (GH#17671 post-mortem,
-	# t2933.) The misleading "collaborator PR" approval body shipped for
-	# years until the surrounding gates landed; a lone caller would
-	# re-introduce the supply-chain hole.
-	#
-	# #aidevops:trust-boundary — t3063 crypto-approval bypass:
-	# A verified maintainer signature on the PR or its linked issue is a
-	# stronger trust signal than author-association: it requires a
-	# root-owned SSH private key that workers cannot forge. This bypass is
-	# symmetric with t3052 (PR #21767) which extended the worker-briefed
-	# gate the same way. The GH#17671 four-layer defence is preserved —
-	# crypto-approval is an additional path through the author gate, not a
-	# removal of the gate. Case B (CONTRIBUTOR + no crypto = refuse) is
-	# pinned by test-pulse-merge-approve-collaborator-guard.sh Case P.
 	local approval_body
 	approval_body="Auto-approved by pulse runner @${current_user:-unknown} — author @${pr_author} confirmed collaborator, pre-merge gates passed."
 	local _author_collab_rc=0
@@ -721,12 +778,15 @@ approve_collaborator_pr() {
 	else
 		_author_collab_rc=0
 	fi
-	if [[ "$_author_collab_rc" -eq 2 ]]; then
-		echo "[pulse-wrapper] approve_collaborator_pr: permission check failed for PR #$pr_number author (@$pr_author) on $repo_slug (HTTP ${_PULSE_AUTHOR_PERMISSION_HTTP:-unknown}) — refusing to auto-approve" >>"$LOGFILE"
-		return 0
-	fi
 	if [[ "$_author_collab_rc" -ne 0 ]]; then
-		if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author" "$pr_head_sha"; then
+		if [[ "$pr_author" == "app/github-actions" || "$pr_author" == "github-actions[bot]" ]] &&
+			_pulse_is_trusted_issue_sync_pr "$pr_number" "$repo_slug" "$pr_head_sha"; then
+			approval_body="Auto-approved by pulse runner @${current_user:-unknown} — trusted repository-generated Issue Sync PR verified from immutable bot identity, same-repository deterministic branch, generated body marker, exact current head, and pre-merge gates."
+			echo "[pulse-wrapper] approve_collaborator_pr: PR #$pr_number author (@$pr_author) is trusted repository-generated Issue Sync automation — proceeding" >>"$LOGFILE"
+		elif [[ "$_author_collab_rc" -eq 2 ]]; then
+			echo "[pulse-wrapper] approve_collaborator_pr: permission check failed for PR #$pr_number author (@$pr_author) on $repo_slug (HTTP ${_PULSE_AUTHOR_PERMISSION_HTTP:-unknown}) — refusing to auto-approve" >>"$LOGFILE"
+			return 0
+		elif _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author" "$pr_head_sha"; then
 			approval_body="Auto-approved by pulse runner @${current_user:-unknown} — trusted Dependabot dependency update verified: GitHub bot identity, same-repo branch, dependabot-authored commits, dependency-file-only diff, maintainer allowlist, no security-scan failures, and pre-merge gates passed."
 			echo "[pulse-wrapper] approve_collaborator_pr: PR #$pr_number author (@$pr_author) is trusted Dependabot with allowlisted dependency update — proceeding (GH#24473)" >>"$LOGFILE"
 		elif _has_maintainer_crypto_approval "$pr_number" "$repo_slug" "$pr_head_sha"; then
@@ -741,9 +801,14 @@ approve_collaborator_pr() {
 	# Approve the PR — body now states the actual checks performed
 	# (author confirmed collaborator + pulse runner has write access),
 	# not just the misleading "collaborator PR" claim.
-	local approve_output
-	approve_output=$(gh pr review "$pr_number" --repo "$repo_slug" --approve --body "$approval_body" 2>&1)
-	local approve_exit=$?
+	local approve_output=""
+	local approve_exit=0
+	if approve_output=$(_pulse_approve_pr_at_head "$repo_slug" "$pr_number" \
+		"$approval_body" "$pr_head_sha" 2>&1); then
+		approve_exit=0
+	else
+		approve_exit=$?
+	fi
 
 	if [[ $approve_exit -eq 0 ]]; then
 		echo "[pulse-wrapper] approve_collaborator_pr: approved PR #$pr_number in $repo_slug (author: $pr_author, runner: ${current_user:-unknown})" >>"$LOGFILE"

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -436,18 +436,26 @@ _check_pr_merge_gates() {
 	# or its linked issue is a stronger trust signal than author-association
 	# (requires root-owned SSH key that workers cannot forge). Symmetric with
 	# t3052 which extended the worker-briefed gate the same way (PR #21767).
-	local _author_collab_rc=0
-	_is_collaborator_author "$pr_author" "$repo_slug"
-	_author_collab_rc=$?
-	local _author_collab_permission="${_PULSE_AUTHOR_PERMISSION_VALUE:-}"
-	if [[ "$_author_collab_rc" -eq 2 ]]; then
+	local _author_collab_rc=0 _trusted_issue_sync=0
+	local _author_collab_permission=""
+	if [[ "$pr_author" == "app/github-actions" || "$pr_author" == "github-actions[bot]" ]] &&
+		_pulse_is_trusted_issue_sync_pr "$pr_number" "$repo_slug" "$expected_head_sha"; then
+		_trusted_issue_sync=1
+		_author_collab_permission="write"
+		echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — author ${pr_author} is trusted repository-generated Issue Sync automation, proceeding" >>"$LOGFILE"
+	else
+		_is_collaborator_author "$pr_author" "$repo_slug"
+		_author_collab_rc=$?
+		_author_collab_permission="${_PULSE_AUTHOR_PERMISSION_VALUE:-}"
+	fi
+	if [[ "$_trusted_issue_sync" -eq 0 && "$_author_collab_rc" -eq 2 ]]; then
 		if [[ "${DRY_RUN:-0}" != "1" ]]; then
 			check_permission_failure_pr "$pr_number" "$repo_slug" "$pr_author" "${_PULSE_AUTHOR_PERMISSION_HTTP:-unknown}" || true
 		fi
 		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — permission check failed for author ${pr_author} (HTTP ${_PULSE_AUTHOR_PERMISSION_HTTP:-unknown})" >>"$LOGFILE"
 		return 1
 	fi
-	if [[ "$_author_collab_rc" -ne 0 ]]; then
+	if [[ "$_trusted_issue_sync" -eq 0 && "$_author_collab_rc" -ne 0 ]]; then
 		if _is_trusted_dependabot_update_pr "$pr_number" "$repo_slug" "$pr_author" "$expected_head_sha"; then
 			echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — author ${pr_author} is trusted Dependabot with allowlisted dependency update, proceeding (GH#24473)" >>"$LOGFILE"
 		elif _has_maintainer_crypto_approval "$pr_number" "$repo_slug" "$expected_head_sha"; then
@@ -485,7 +493,7 @@ _check_pr_merge_gates() {
 	local pr_labels_for_ext
 	pr_labels_for_ext=$(gh_pr_view "$pr_number" --repo "$repo_slug" --json labels \
 		--jq '[.labels[].name] | join(",")' 2>/dev/null) || pr_labels_for_ext=""
-	if [[ "$pr_labels_for_ext" == *"external-contributor"* ]]; then
+	if [[ "$_trusted_issue_sync" -eq 0 && "$pr_labels_for_ext" == *"external-contributor"* ]]; then
 		if ! _external_pr_has_linked_issue "$pr_number" "$repo_slug"; then
 			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — external-contributor PR has no linked issue (t1958)" >>"$LOGFILE"
 			return 1

--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -6,7 +6,7 @@
 # Usage:
 #   review-bot-gate-helper.sh check         <PR_NUMBER> [REPO]
 #   review-bot-gate-helper.sh event-check
-#   review-bot-gate-helper.sh is-trusted-issue-sync-pr <PR_NUMBER> [REPO]
+#   review-bot-gate-helper.sh is-trusted-issue-sync-pr <PR_NUMBER> [REPO] [EXPECTED_HEAD_SHA]
 #   review-bot-gate-helper.sh classify-infra-rate-limit <AUTHOR_ASSOCIATION> [REPO]
 #   review-bot-gate-helper.sh wait          <PR_NUMBER> [REPO] [MAX_WAIT_SECONDS]
 #   review-bot-gate-helper.sh list          <PR_NUMBER> [REPO]
@@ -19,7 +19,7 @@
 # Commands:
 #   check          — Check once, return PASS/PASS_ADVISORY/PASS_RATE_LIMITED/WAITING/SKIP
 #   event-check    — Accept trusted bot review evidence from the Actions event
-#   is-trusted-issue-sync-pr — Verify the exact generated PR identity from live REST metadata
+#   is-trusted-issue-sync-pr — Verify the exact generated PR identity and optional head
 #   classify-infra-rate-limit — Classify API exhaustion from immutable event trust
 #   wait           — Poll until a bot posts or timeout (default 600s)
 #   list           — List all bot comments found on the PR
@@ -1276,6 +1276,7 @@ any_bot_has_success_status() {
 _rbg_is_trusted_issue_sync_pr_metadata() {
 	local repo="$1"
 	local pr_metadata_json="$2"
+	local expected_head_sha="${3:-}"
 
 	[[ -n "$repo" && -n "$pr_metadata_json" ]] || return 1
 	command -v jq >/dev/null 2>&1 || return 1
@@ -1289,6 +1290,7 @@ _rbg_is_trusted_issue_sync_pr_metadata() {
 		--arg repo "$repo" \
 		--argjson bot_id "$RBG_GITHUB_ACTIONS_BOT_ID" \
 		--arg branch "$RBG_ISSUE_SYNC_PR_BRANCH" \
+		--arg expected_head "$expected_head_sha" \
 		--arg marker "$RBG_ISSUE_SYNC_PR_MARKER" '
 		try (
 			.user.login == "github-actions[bot]" and
@@ -1297,6 +1299,7 @@ _rbg_is_trusted_issue_sync_pr_metadata() {
 			.head.repo.full_name == $repo and
 			.base.repo.full_name == $repo and
 			.head.ref == $branch and
+			(($expected_head | length) == 0 or .head.sha == $expected_head) and
 			(.body | contains($marker))
 		) catch false
 	' <<<"$pr_metadata_json" >/dev/null 2>&1
@@ -1305,6 +1308,7 @@ _rbg_is_trusted_issue_sync_pr_metadata() {
 do_is_trusted_issue_sync_pr() {
 	local pr_number="$1"
 	local repo="$2"
+	local expected_head_sha="${3:-}"
 	local pr_api=""
 	local pr_metadata_json=""
 
@@ -1314,7 +1318,7 @@ do_is_trusted_issue_sync_pr() {
 		return 2
 	}
 
-	if _rbg_is_trusted_issue_sync_pr_metadata "$repo" "$pr_metadata_json"; then
+	if _rbg_is_trusted_issue_sync_pr_metadata "$repo" "$pr_metadata_json" "$expected_head_sha"; then
 		echo "TRUSTED"
 		return 0
 	fi
@@ -2046,7 +2050,7 @@ main() {
 		do_check "$pr_number" "$repo"
 		;;
 	is-trusted-issue-sync-pr)
-		do_is_trusted_issue_sync_pr "$pr_number" "$repo"
+		do_is_trusted_issue_sync_pr "$pr_number" "$repo" "$max_wait"
 		;;
 	wait)
 		do_wait "$pr_number" "$repo" "$max_wait"

--- a/.agents/scripts/tests/test-full-loop-merge-authority-guard.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-authority-guard.sh
@@ -15,6 +15,15 @@ CRYPTO_CALLS="${TEST_ROOT}/crypto-calls.log"
 MERGE_CALLS="${TEST_ROOT}/merge-calls.log"
 GUARD_CALLS="${TEST_ROOT}/guard-calls.log"
 TRUSTED_CALLS="${TEST_ROOT}/trusted-calls.log"
+ISSUE_SYNC_TRUST_CALLS="${TEST_ROOT}/issue-sync-trust-calls.log"
+ISSUE_SYNC_HELPER="${TEST_ROOT}/review-bot-gate-helper.sh"
+export ISSUE_SYNC_TRUST_CALLS
+cat >"$ISSUE_SYNC_HELPER" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${ISSUE_SYNC_TRUST_CALLS}"
+[[ "${1:-}" == "is-trusted-issue-sync-pr" && -n "${4:-}" && "${FIXTURE_TRUSTED_ISSUE_SYNC:-0}" == "1" ]]
+EOF
+chmod +x "$ISSUE_SYNC_HELPER"
 TESTS_RUN=0
 TESTS_FAILED=0
 
@@ -55,12 +64,15 @@ load_functions() {
 	extract_function _merge_linked_issue_numbers
 	extract_function _merge_issue_requires_maintainer_review
 	extract_function _merge_author_has_write_authority
+	extract_function _merge_is_trusted_issue_sync_pr
 	extract_function _merge_linked_issue_authority_clear
 	extract_function _merge_guard_admin_merge_maintainer_review
 	extract_function _merge_resolve_conventional_type_from_commits
 	extract_function _merge_resolve_squash_subject
 	extract_function _merge_resolve_subject_for_method
 	extract_function _merge_describe_flags
+	extract_function _merge_rest_fallback
+	extract_function _merge_revalidate_transport_authority
 	extract_function _merge_execute
 	# shellcheck source=/dev/null
 	source "$EXTRACTED"
@@ -77,7 +89,10 @@ FIXTURE_ISSUE_APPROVED=0
 FIXTURE_PR_APPROVED=0
 FIXTURE_GH_MODE="guard"
 FIXTURE_TRUSTED_DEPENDABOT=0
+FIXTURE_TRUSTED_ISSUE_SYNC=0
+export FIXTURE_TRUSTED_ISSUE_SYNC
 AUTHORITY_GUARD_PASS=1
+AUTHORITY_GUARD_FAIL_ON_CALL=0
 FULL_LOOP_MERGE_SUBJECT_FLAG="--subject"
 
 print_error() {
@@ -168,6 +183,11 @@ _is_trusted_dependabot_update_pr() {
 	return $?
 }
 
+_full_loop_review_bot_gate_helper_path() {
+	printf '%s\n' "$ISSUE_SYNC_HELPER"
+	return 0
+}
+
 set_pr_fixture() {
 	local author="$1"
 	local labels_json="$2"
@@ -196,12 +216,64 @@ reset_fixture() {
 	FIXTURE_PR_APPROVED=0
 	FIXTURE_GH_MODE="guard"
 	FIXTURE_TRUSTED_DEPENDABOT=0
+	FIXTURE_TRUSTED_ISSUE_SYNC=0
+	export FIXTURE_TRUSTED_ISSUE_SYNC
 	AUTHORITY_GUARD_PASS=1
+	AUTHORITY_GUARD_FAIL_ON_CALL=0
 	: >"$CRYPTO_CALLS"
 	: >"$MERGE_CALLS"
 	: >"$GUARD_CALLS"
 	: >"$TRUSTED_CALLS"
+	: >"$ISSUE_SYNC_TRUST_CALLS"
 	set_pr_fixture maintainer '[]' false '[]' ''
+	return 0
+}
+
+test_trusted_issue_sync_authority() {
+	reset_fixture
+	set_pr_fixture 'app/github-actions' '[]' false '[]' '<!-- aidevops:issue-sync-todo-pr -->'
+	FIXTURE_PERMISSION="none"
+	FIXTURE_TRUSTED_ISSUE_SYNC=1
+	export FIXTURE_TRUSTED_ISSUE_SYNC
+	expect_guard_result "exact-head repository-generated Issue Sync PR passes without linked issue or crypto" 0
+	if grep -q '^is-trusted-issue-sync-pr 900 owner/repo head-current$' "$ISSUE_SYNC_TRUST_CALLS" && [[ ! -s "$CRYPTO_CALLS" ]]; then
+		print_result "trusted Issue Sync authority is bound to the exact PR head" 0
+	else
+		print_result "trusted Issue Sync authority is bound to the exact PR head" 1 \
+			"trust=$(<"$ISSUE_SYNC_TRUST_CALLS") crypto=$(<"$CRYPTO_CALLS")"
+	fi
+
+	reset_fixture
+	set_pr_fixture 'app/github-actions' '[{"name":"needs-maintainer-review"}]' false '[]' '<!-- aidevops:issue-sync-todo-pr -->'
+	FIXTURE_PERMISSION="none"
+	FIXTURE_TRUSTED_ISSUE_SYNC=1
+	export FIXTURE_TRUSTED_ISSUE_SYNC
+	expect_guard_result "live PR NMR still blocks trusted Issue Sync automation" 1
+	if [[ ! -s "$ISSUE_SYNC_TRUST_CALLS" ]]; then
+		print_result "NMR hold is evaluated before the Issue Sync exception" 0
+	else
+		print_result "NMR hold is evaluated before the Issue Sync exception" 1 "unexpected trust call"
+	fi
+
+	reset_fixture
+	set_pr_fixture 'app/github-actions' '[]' false '[]' '<!-- aidevops:issue-sync-todo-pr -->'
+	FIXTURE_PERMISSION="none"
+	expect_guard_result "unverified Actions automation remains on fail-closed external path" 1
+
+	reset_fixture
+	set_pr_fixture 'app/github-actions' '[]' false '[{"number":42}]' 'Resolves #42'
+	FIXTURE_PERMISSION="none"
+	FIXTURE_TRUSTED_ISSUE_SYNC=1
+	export FIXTURE_TRUSTED_ISSUE_SYNC
+	FIXTURE_ISSUE_LABELS="needs-maintainer-review"
+	expect_guard_result "linked issue NMR still blocks trusted Issue Sync automation" 1
+
+	reset_fixture
+	set_pr_fixture 'app/github-actions' '[]' false '[]' '<!-- aidevops:issue-sync-todo-pr -->'
+	FIXTURE_PERMISSION="none"
+	FIXTURE_TRUSTED_ISSUE_SYNC=1
+	export FIXTURE_TRUSTED_ISSUE_SYNC
+	expect_guard_result "head drift blocks before Issue Sync trust reuse" 1 head-stale
 	return 0
 }
 
@@ -310,7 +382,7 @@ test_authority_guard() {
 	FIXTURE_ISSUE_APPROVED=1
 	FIXTURE_PR_APPROVED=1
 	expect_guard_result "external PR with issue and exact-head authority passes" 0
-	if grep -q '^issue 42 owner/repo ' "$CRYPTO_CALLS" && \
+	if grep -q '^issue 42 owner/repo ' "$CRYPTO_CALLS" &&
 		grep -q '^pr 900 owner/repo head-current$' "$CRYPTO_CALLS"; then
 		print_result "external success verifies issue and exact PR head" 0
 	else
@@ -348,7 +420,14 @@ _merge_guard_admin_merge_maintainer_review_for_mode_test() {
 	local pr_number="$1"
 	local repo="$2"
 	local expected_head_sha="${3:-}"
+	local guard_call_count=0
 	printf '%s %s %s\n' "$pr_number" "$repo" "$expected_head_sha" >>"$GUARD_CALLS"
+	guard_call_count=$(wc -l <"$GUARD_CALLS")
+	guard_call_count="${guard_call_count//[[:space:]]/}"
+	if [[ "$AUTHORITY_GUARD_FAIL_ON_CALL" -gt 0 &&
+		"$guard_call_count" -eq "$AUTHORITY_GUARD_FAIL_ON_CALL" ]]; then
+		return 1
+	fi
 	[[ "$AUTHORITY_GUARD_PASS" -eq 1 ]]
 	return $?
 }
@@ -367,6 +446,81 @@ test_merge_mode() {
 		print_result "$name" 0
 	else
 		print_result "$name" 1 "rc=$actual_rc guard=$(<"$GUARD_CALLS") merge=$(<"$MERGE_CALLS")"
+	fi
+	return 0
+}
+
+test_secondary_merge_transports_refresh_authority() {
+	local transport_mode=""
+	local actual_rc=0
+
+	gh() {
+		local command="${1:-}"
+		local subcommand="${2:-}"
+		local merge_call_count=0
+		if [[ "$command" == "pr" && "$subcommand" == "view" && "$*" == *"--json title"* ]]; then
+			printf '%s\n' '{"title":"GH#28622: preserve exact-head merge authority","commits":[{"messageHeadline":"fix: preserve exact-head merge authority"}]}'
+			return 0
+		fi
+		if [[ "$command" == "pr" && "$subcommand" == "merge" ]]; then
+			printf '%s\n' "$*" >>"$MERGE_CALLS"
+			merge_call_count=$(wc -l <"$MERGE_CALLS")
+			if [[ "$transport_mode" == "cache" && "$merge_call_count" -eq 1 ]]; then
+				printf 'HTTP 401: Bad credentials\n'
+				return 1
+			fi
+			if [[ "$transport_mode" == "rest" ]]; then
+				printf 'GraphQL: API rate limit exceeded\n'
+				return 1
+			fi
+			printf 'merged\n'
+			return 0
+		fi
+		if [[ "$command" == "api" && "$*" == *"/pulls/900/merge"* ]]; then
+			printf 'REST %s\n' "$*" >>"$MERGE_CALLS"
+			printf '{"merged":true}\n'
+			return 0
+		fi
+		return 1
+	}
+	gh_merge_remediate_stale_auth_cache() {
+		[[ "$transport_mode" == "cache" ]]
+		return $?
+	}
+	_merge_output_is_graphql_rate_limit() {
+		[[ "$transport_mode" == "rest" ]]
+		return $?
+	}
+
+	: >"$GUARD_CALLS"
+	: >"$MERGE_CALLS"
+	transport_mode="cache"
+	AUTHORITY_GUARD_PASS=1
+	AUTHORITY_GUARD_FAIL_ON_CALL=2
+	actual_rc=0
+	_merge_execute 900 owner/repo --squash 0 0 >/dev/null 2>&1 || actual_rc=$?
+	if [[ "$actual_rc" -eq 1 && "$(wc -l <"$GUARD_CALLS")" -eq 2 &&
+		"$(wc -l <"$MERGE_CALLS")" -eq 1 ]]; then
+		print_result "stale-cache retry refreshes and honors revoked authority" 0
+	else
+		print_result "stale-cache retry refreshes and honors revoked authority" 1 \
+			"rc=$actual_rc guard=$(<"$GUARD_CALLS") merge=$(<"$MERGE_CALLS")"
+	fi
+
+	: >"$GUARD_CALLS"
+	: >"$MERGE_CALLS"
+	transport_mode="rest"
+	AUTHORITY_GUARD_PASS=1
+	AUTHORITY_GUARD_FAIL_ON_CALL=2
+	actual_rc=0
+	_merge_execute 900 owner/repo --squash 0 0 >/dev/null 2>&1 || actual_rc=$?
+	if [[ "$actual_rc" -eq 1 && "$(wc -l <"$GUARD_CALLS")" -eq 2 &&
+		"$(wc -l <"$MERGE_CALLS")" -eq 1 ]] &&
+		! grep -q '^REST ' "$MERGE_CALLS"; then
+		print_result "REST fallback refreshes and honors revoked authority" 0
+	else
+		print_result "REST fallback refreshes and honors revoked authority" 1 \
+			"rc=$actual_rc guard=$(<"$GUARD_CALLS") merge=$(<"$MERGE_CALLS")"
 	fi
 	return 0
 }
@@ -413,9 +567,11 @@ test_all_merge_modes_use_guard() {
 
 main() {
 	load_functions
+	test_trusted_issue_sync_authority
 	test_trusted_dependabot_authority
 	test_authority_guard
 	test_all_merge_modes_use_guard
+	test_secondary_merge_transports_refresh_authority
 	printf '\nTests run: %d\nTests failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
 	[[ "$TESTS_FAILED" -eq 0 ]]
 	return $?

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -257,6 +257,13 @@ write_gh_stub_api() {
 
 if [[ "\$_gh_cmd" == "api" ]]; then
 	echo "gh api \$*" >> "${TEST_ROOT}/logs/gh-api-calls.txt"
+	# The comment wrapper's public-write guard must know target visibility. Keep
+	# this synthetic repository private so the signaling test exercises comment
+	# transport without depending on the host's privacy cache or entity inventory.
+	if [[ "\${2:-}" == "repos/testorg/testrepo" && "\$*" == *".private"* ]]; then
+		echo 'true'
+		exit 0
+	fi
 	if [[ "\$*" == "user" ]]; then
 		echo '{"login":"tester"}'
 		exit 0

--- a/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
+++ b/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
@@ -41,6 +41,7 @@ source "${SCRIPT_DIR}/../pulse-merge-required-checks.sh"
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
 readonly TEST_RESET='\033[0m'
+readonly ISSUE_SYNC_GRAPHQL_AUTHOR="github-actions"
 
 TESTS_RUN=0
 TESTS_FAILED=0
@@ -74,6 +75,7 @@ set_fixture() {
 	local issue_approval_result="$4"
 	local pr_approval_result="${5:-$issue_approval_result}"
 	local pr_author="${6:-}"
+	rm -f "${TEST_ROOT}/issue-sync-trusted"
 	if [[ -z "$pr_author" ]]; then
 		if [[ "$labels_json" == *"external-contributor"* || "$is_cross_repo" == "true" ]]; then
 			pr_author="external-contributor"
@@ -168,7 +170,7 @@ exit 0
 GHEOF
 	chmod +x "${TEST_ROOT}/bin/gh"
 
-# Mock approval-helper.sh — PR V2 authority is distinct from issue authority.
+	# Mock approval-helper.sh — PR V2 authority is distinct from issue authority.
 	export AGENTS_DIR="${TEST_ROOT}/agents"
 	cat >"${TEST_ROOT}/agents/scripts/approval-helper.sh" <<'AHEOF'
 #!/usr/bin/env bash
@@ -181,9 +183,18 @@ AHEOF
 	chmod +x "${TEST_ROOT}/agents/scripts/approval-helper.sh"
 	cat >"${TEST_ROOT}/agents/scripts/review-bot-gate-helper.sh" <<'RBEOF'
 #!/usr/bin/env bash
-[[ "${1:-}" == "status-json" ]] || exit 1
-cat "${TEST_ROOT}/review-evidence.json"
-exit 0
+printf '%s\n' "review-helper $*" >>"${GH_LOG:-/dev/null}"
+case "${1:-}" in
+status-json)
+	cat "${TEST_ROOT}/review-evidence.json"
+	exit 0
+	;;
+is-trusted-issue-sync-pr)
+	[[ -f "${TEST_ROOT}/issue-sync-trusted" && "${4:-}" == "head-current" ]]
+	exit $?
+	;;
+*) exit 1 ;;
+esac
 RBEOF
 	chmod +x "${TEST_ROOT}/agents/scripts/review-bot-gate-helper.sh"
 	return 0
@@ -213,6 +224,8 @@ define_helpers_under_test() {
 		/^_extract_linked_issue\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
 	gates_src=$(awk '
+		/^_pulse_is_trusted_issue_sync_pr\(\) \{/,/^}$/ { print }
+		/^_pulse_merge_classify_final_authority\(\) \{/,/^}$/ { print }
 		/^_pulse_merge_admin_pr_json_graphql\(\) \{/,/^}$/ { print }
 		/^_external_pr_has_linked_issue\(\) \{/,/^}$/ { print }
 		/^_external_pr_linked_issue_crypto_approved\(\) \{/,/^}$/ { print }
@@ -239,7 +252,7 @@ define_helpers_under_test() {
 		local author="$1"
 		local repo_slug="$2"
 		[[ -n "$repo_slug" ]] || return 2
-		[[ "$author" == "external-contributor" ]] && return 1
+		[[ "$author" == "external-contributor" || "$author" == "$ISSUE_SYNC_GRAPHQL_AUTHOR" ]] && return 1
 		return 0
 	}
 	_is_trusted_dependabot_update_pr() {
@@ -545,6 +558,41 @@ test_case_i_unlabeled_non_collaborator_is_external() {
 	return 0
 }
 
+test_case_t_trusted_issue_sync_is_internal() {
+	: >"$LOGFILE"
+	: >"$GH_LOG"
+	set_fixture '[{"name":"external-contributor"}]' 'false' \
+		'<!-- aidevops:issue-sync-todo-pr -->' 'NOT_VERIFIED' 'NO_APPROVAL' "$ISSUE_SYNC_GRAPHQL_AUTHOR"
+	touch "${TEST_ROOT}/issue-sync-trusted"
+
+	local result=0
+	_pulse_merge_admin_safety_check "950" "owner/repo" "head-current" || result=$?
+	if [[ "$result" -eq 0 ]] &&
+		grep -qF "review-helper is-trusted-issue-sync-pr 950 owner/repo head-current" "$GH_LOG" &&
+		grep -qF "Trusted repository-generated Issue Sync authority verified" "$LOGFILE"; then
+		print_result "Case T: exact-head Issue Sync automation bypasses external-author authority only" 0
+		return 0
+	fi
+	print_result "Case T: exact-head Issue Sync automation is trusted" 1 "rc=${result}; calls=$(cat "$GH_LOG"); log=$(cat "$LOGFILE")"
+	return 0
+}
+
+test_case_u_unverified_issue_sync_candidate_fails_closed() {
+	: >"$LOGFILE"
+	: >"$GH_LOG"
+	set_fixture '[]' 'false' '<!-- aidevops:issue-sync-todo-pr -->' \
+		'NOT_VERIFIED' 'NO_APPROVAL' "$ISSUE_SYNC_GRAPHQL_AUTHOR"
+
+	local result=0
+	_pulse_merge_admin_safety_check "951" "owner/repo" "head-current" || result=$?
+	if [[ "$result" -eq 1 ]] && grep -qF "external/fork PR has no linked issue" "$LOGFILE"; then
+		print_result "Case U: unverified Actions automation remains external and fail-closed" 0
+		return 0
+	fi
+	print_result "Case U: unverified Actions automation remains blocked" 1 "rc=${result}; log=$(cat "$LOGFILE")"
+	return 0
+}
+
 test_case_j_final_gate_rejects_stale_cached_review_evidence() {
 	: >"$LOGFILE"
 	set_fixture '[{"name":"bug"}]' 'false' \
@@ -669,6 +717,8 @@ main() {
 	test_case_g_issue_approval_without_pr_v2_is_blocked
 	test_case_h_live_nmr_blocks_even_with_v2_approval
 	test_case_i_unlabeled_non_collaborator_is_external
+	test_case_t_trusted_issue_sync_is_internal
+	test_case_u_unverified_issue_sync_candidate_fails_closed
 	test_case_j_final_gate_rejects_stale_cached_review_evidence
 	test_case_k_final_gate_refreshes_current_review_evidence
 	test_case_l_collaborator_linked_issue_nmr_blocks_final_gate

--- a/.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
+++ b/.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
@@ -91,6 +91,26 @@ EOF
 	echo "999" >"${TEST_ROOT}/linked-issue.txt"
 	# Default: no current-head V2 PR approval.
 	echo "NO_APPROVAL" >"${TEST_ROOT}/crypto-approval-result.txt"
+	rm -f "${TEST_ROOT}/approval-response-head.txt" "${TEST_ROOT}/issue-sync-trusted"
+	return 0
+}
+
+write_approval_helper_mocks() {
+	# Marker presence alone has no authority; fixtures emit explicit V2 states.
+	export AGENTS_DIR="${TEST_ROOT}/mock-agents"
+	mkdir -p "${AGENTS_DIR}/scripts"
+	cat >"${AGENTS_DIR}/scripts/approval-helper.sh" <<'AHEOF'
+#!/usr/bin/env bash
+cat "${TEST_ROOT}/crypto-approval-result.txt"
+return 0 2>/dev/null || exit 0
+AHEOF
+	chmod +x "${AGENTS_DIR}/scripts/approval-helper.sh"
+	cat >"${AGENTS_DIR}/scripts/review-bot-gate-helper.sh" <<'RBEOF'
+#!/usr/bin/env bash
+printf '%s\n' "review-helper $*" >>"${GH_LOG:-/dev/null}"
+[[ "${1:-}" == "is-trusted-issue-sync-pr" && -f "${TEST_ROOT}/issue-sync-trusted" && -n "${4:-}" ]]
+RBEOF
+	chmod +x "${AGENTS_DIR}/scripts/review-bot-gate-helper.sh"
 	return 0
 }
 
@@ -103,16 +123,7 @@ setup_test_env() {
 	GH_LOG="${TEST_ROOT}/gh-calls.log"
 	: >"$GH_LOG"
 	export TEST_ROOT GH_LOG
-	# Point AGENTS_DIR to a mock directory whose approval-helper fixture emits
-	# explicit V2 verification states. Marker presence alone has no authority.
-	export AGENTS_DIR="${TEST_ROOT}/mock-agents"
-	mkdir -p "${AGENTS_DIR}/scripts"
-	cat >"${AGENTS_DIR}/scripts/approval-helper.sh" <<'AHEOF'
-#!/usr/bin/env bash
-cat "${TEST_ROOT}/crypto-approval-result.txt"
-return 0 2>/dev/null || exit 0
-AHEOF
-	chmod +x "${AGENTS_DIR}/scripts/approval-helper.sh"
+	write_approval_helper_mocks
 
 	# Mock gh: logs every call and answers the five endpoints that
 	# `approve_collaborator_pr`, `_is_collaborator_author`, and
@@ -153,7 +164,25 @@ if [[ "${1:-}" == "api" && "$*" == *"/collaborators/"*"/permission"* && "$*" == 
 	exit 0
 fi
 
-# `gh api repos/SLUG/pulls/N/reviews --jq ...` — existing trusted approval
+# `gh api -X POST repos/SLUG/pulls/N/reviews ... commit_id=SHA` — exact-head
+# approval mutation. Return the requested commit unless a race fixture overrides
+# the response, allowing the caller's post-mutation binding check to be pinned.
+if [[ "${1:-}" == "api" && "${2:-}" == "-X" && "${3:-}" == "POST" &&
+	"${4:-}" == repos/*/pulls/*/reviews ]]; then
+	_response_head=""
+	for _arg in "$@"; do
+		case "$_arg" in
+		commit_id=*) _response_head="${_arg#commit_id=}" ;;
+		esac
+	done
+	if [[ -s "${TEST_ROOT}/approval-response-head.txt" ]]; then
+		_response_head=$(<"${TEST_ROOT}/approval-response-head.txt")
+	fi
+	printf '{"state":"APPROVED","commit_id":"%s"}\n' "$_response_head"
+	exit 0
+fi
+
+# `gh api repos/SLUG/pulls/N/reviews` — existing trusted approval
 if [[ "${1:-}" == "api" && "$*" == *"/pulls/"*"/reviews"* ]]; then
 	_reviews_exit_code=$(<"${TEST_ROOT}/reviews-exit-code.txt")
 	if [[ "$_reviews_exit_code" -ne 0 ]]; then
@@ -203,6 +232,8 @@ define_helpers_under_test() {
 	local crypto_src
 	local current_head_crypto_src
 	local trusted_approval_src
+	local issue_sync_src
+	local exact_head_approval_src
 	approve_src=$(awk '
 		/^approve_collaborator_pr\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
@@ -218,6 +249,12 @@ define_helpers_under_test() {
 	' "$MERGE_SCRIPT")
 	trusted_approval_src=$(awk '
 		/^_trusted_existing_approver\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	issue_sync_src=$(awk '
+		/^_pulse_is_trusted_issue_sync_pr\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	exact_head_approval_src=$(awk '
+		/^_pulse_approve_pr_at_head\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
 
 	if [[ -z "$approve_src" ]]; then
@@ -238,6 +275,14 @@ define_helpers_under_test() {
 	fi
 	if [[ -z "$trusted_approval_src" ]]; then
 		printf 'ERROR: could not extract _trusted_existing_approver from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	if [[ -z "$issue_sync_src" ]]; then
+		printf 'ERROR: could not extract _pulse_is_trusted_issue_sync_pr from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	if [[ -z "$exact_head_approval_src" ]]; then
+		printf 'ERROR: could not extract _pulse_approve_pr_at_head from %s\n' "$MERGE_SCRIPT" >&2
 		return 1
 	fi
 
@@ -263,13 +308,17 @@ define_helpers_under_test() {
 	# shellcheck disable=SC1090
 	eval "$trusted_approval_src"
 	# shellcheck disable=SC1090
+	eval "$issue_sync_src"
+	# shellcheck disable=SC1090
+	eval "$exact_head_approval_src"
+	# shellcheck disable=SC1090
 	eval "$approve_src"
 	return 0
 }
 
-# Helper: count "gh pr review ... --approve" calls in the log.
+# Helper: count legacy or exact-head approval mutations in the log.
 count_approve_calls() {
-	grep -cF "pr review" "$GH_LOG" 2>/dev/null || true
+	grep -Ec 'gh pr review|gh api -X POST repos/.*/pulls/[0-9]+/reviews' "$GH_LOG" 2>/dev/null || true
 }
 
 # =============================================================================
@@ -649,6 +698,57 @@ test_case_p_contributor_no_crypto_still_refused() {
 	return 0
 }
 
+test_case_q_trusted_issue_sync_can_be_approved() {
+	reset_mock_state
+	touch "${TEST_ROOT}/issue-sync-trusted"
+
+	local result=0
+	approve_collaborator_pr "940" "owner/repo" "app/github-actions" "head-940" || result=$?
+	if [[ "$result" -eq 0 && "$(count_approve_calls)" -eq 1 ]] &&
+		grep -qF "review-helper is-trusted-issue-sync-pr 940 owner/repo head-940" "$GH_LOG" &&
+		grep -qF "commit_id=head-940" "$GH_LOG" &&
+		grep -qF "trusted repository-generated Issue Sync PR verified" "$GH_LOG"; then
+		print_result "Case Q: exact-head Issue Sync automation receives head-bound approval" 0
+		return 0
+	fi
+	print_result "Case Q: exact-head Issue Sync automation is approved" 1 \
+		"rc=${result}; approve=$(count_approve_calls); calls=$(cat "$GH_LOG"); log=$(cat "$LOGFILE")"
+	return 0
+}
+
+test_case_s_issue_sync_approval_response_mismatch_fails() {
+	reset_mock_state
+	touch "${TEST_ROOT}/issue-sync-trusted"
+	printf 'raced-head\n' >"${TEST_ROOT}/approval-response-head.txt"
+
+	local result=0
+	approve_collaborator_pr "942" "owner/repo" "app/github-actions" "head-942" || result=$?
+	if [[ "$result" -eq 1 && "$(count_approve_calls)" -eq 1 ]] &&
+		grep -qF "commit_id=head-942" "$GH_LOG" &&
+		grep -qF "failed to approve PR #942" "$LOGFILE"; then
+		print_result "Case S: mismatched approval response fails closed" 0
+		return 0
+	fi
+	print_result "Case S: mismatched approval response is rejected" 1 \
+		"rc=${result}; approve=$(count_approve_calls); calls=$(cat "$GH_LOG"); log=$(cat "$LOGFILE")"
+	return 0
+}
+
+test_case_r_unverified_issue_sync_is_not_approved() {
+	reset_mock_state
+
+	local result=0
+	approve_collaborator_pr "941" "owner/repo" "app/github-actions" "head-941" || result=$?
+	if [[ "$result" -eq 0 && "$(count_approve_calls)" -eq 0 ]] &&
+		grep -qF "GH#17671 defense-in-depth" "$LOGFILE"; then
+		print_result "Case R: unverified Actions automation remains blocked from approval" 0
+		return 0
+	fi
+	print_result "Case R: unverified Actions automation is not approved" 1 \
+		"rc=${result}; approve=$(count_approve_calls); log=$(cat "$LOGFILE")"
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -669,6 +769,9 @@ main() {
 	test_case_n_contributor_with_crypto_on_pr
 	test_case_o_contributor_with_crypto_on_linked_issue
 	test_case_p_contributor_no_crypto_still_refused
+	test_case_q_trusted_issue_sync_can_be_approved
+	test_case_r_unverified_issue_sync_is_not_approved
+	test_case_s_issue_sync_approval_response_mismatch_fails
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-issue-sync-authority.sh
+++ b/.agents/scripts/tests/test-pulse-merge-issue-sync-authority.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+# Verify Pulse's early merge gate recognizes only exact-head Issue Sync automation.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 2
+MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+TEST_ROOT="$(mktemp -d)"
+LOGFILE="${TEST_ROOT}/pulse.log"
+AGENTS_DIR="${TEST_ROOT}/agents"
+TRUST_CALLS="${TEST_ROOT}/trust-calls.log"
+TESTS_RUN=0
+TESTS_FAILED=0
+FIXTURE_TRUSTED=0
+FIXTURE_LABELS=""
+PULSE_UNKNOWN_STATE="UNKNOWN"
+PULSE_REVIEW_EVIDENCE_SCHEMA="aidevops.review-gate-evidence/v1"
+export LOGFILE AGENTS_DIR
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+mkdir -p "${AGENTS_DIR}/scripts"
+: >"${AGENTS_DIR}/scripts/review-bot-gate-helper.sh"
+
+print_result() {
+	local name="$1"
+	local passed="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+		return 0
+	fi
+	printf 'FAIL %s' "$name"
+	[[ -n "$detail" ]] && printf ': %s' "$detail"
+	printf '\n'
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+gate_src=$(awk '/^_check_pr_merge_gates\(\) \{/,/^}$/ { print }' "$MERGE_SCRIPT")
+[[ -n "$gate_src" ]] || {
+	printf 'FAIL could not extract _check_pr_merge_gates\n' >&2
+	exit 1
+}
+
+_handle_changes_requested_review_gate() { return 0; }
+_pulse_is_trusted_issue_sync_pr() {
+	printf '%s %s %s\n' "$1" "$2" "$3" >>"$TRUST_CALLS"
+	[[ "$FIXTURE_TRUSTED" -eq 1 && "$3" == "head-current" ]]
+}
+_is_collaborator_author() {
+	_PULSE_AUTHOR_PERMISSION_VALUE="none"
+	return 1
+}
+_is_trusted_dependabot_update_pr() { return 1; }
+_has_maintainer_crypto_approval() { return 1; }
+check_permission_failure_pr() { return 0; }
+check_pr_modifies_workflows() { return 1; }
+check_gh_workflow_scope() { return 0; }
+_pm_issue_api() { printf 'repos/%s/issues/%s\n' "$1" "$2"; }
+_attempt_worker_briefed_auto_merge() { return 0; }
+_check_interactive_pr_gates() { return 0; }
+gh() { return 0; }
+gh_pr_view() {
+	if [[ "$*" == *"labels,isDraft"* ]]; then
+		if [[ "$FIXTURE_LABELS" == "external-contributor" ]]; then
+			printf '%s\n' '{"labels":[{"name":"external-contributor"}],"isDraft":false}'
+		else
+			printf '%s\n' '{"labels":[],"isDraft":false}'
+		fi
+	else
+		printf '%s\n' "$FIXTURE_LABELS"
+	fi
+	return 0
+}
+bash() {
+	printf '%s\n' '{"schema":"aidevops.review-gate-evidence/v1","repo":"owner/repo","pr":"950","head_sha":"head-current","status":"PASS_ADVISORY","author":{"login":"github-actions[bot]","association":"COLLABORATOR","class":"trusted"},"permitted":true,"reason":"trusted_advisory_default","state":"pass","merge_gate":"clear","exit_code":0}'
+	return 0
+}
+
+# shellcheck disable=SC1090
+eval "$gate_src"
+
+run_gate() {
+	local expected_head="${1:-head-current}"
+	local rc=0
+	_check_pr_merge_gates 950 owner/repo app/github-actions APPROVED "" \
+		"$FIXTURE_LABELS" "$expected_head" merge || rc=$?
+	printf '%s\n' "$rc"
+}
+
+FIXTURE_TRUSTED=1
+FIXTURE_LABELS="external-contributor"
+: >"$TRUST_CALLS"
+result=$(run_gate)
+if [[ "$result" -eq 0 ]] && grep -q '^950 owner/repo head-current$' "$TRUST_CALLS"; then
+	print_result "exact-head Issue Sync automation passes Pulse's early authority gate" 0
+else
+	print_result "exact-head Issue Sync automation passes Pulse's early authority gate" 1 \
+		"rc=${result} calls=$(cat "$TRUST_CALLS") log=$(cat "$LOGFILE")"
+fi
+
+FIXTURE_TRUSTED=0
+FIXTURE_LABELS=""
+: >"$TRUST_CALLS"
+: >"$LOGFILE"
+result=$(run_gate)
+if [[ "$result" -eq 1 ]] && grep -qF "author app/github-actions is not a collaborator" "$LOGFILE"; then
+	print_result "unverified Actions automation remains blocked as external" 0
+else
+	print_result "unverified Actions automation remains blocked as external" 1 \
+		"rc=${result} log=$(cat "$LOGFILE")"
+fi
+
+FIXTURE_TRUSTED=1
+FIXTURE_LABELS=""
+: >"$TRUST_CALLS"
+: >"$LOGFILE"
+result=$(run_gate stale-head)
+if [[ "$result" -eq 1 ]] && grep -q '^950 owner/repo stale-head$' "$TRUST_CALLS"; then
+	print_result "stale-head Issue Sync trust evidence fails closed" 0
+else
+	print_result "stale-head Issue Sync trust evidence fails closed" 1 \
+		"rc=${result} calls=$(cat "$TRUST_CALLS")"
+fi
+
+printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
+++ b/.agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh
@@ -151,6 +151,18 @@ if [[ "${1:-}" == "api" && "$*" == *"/collaborators/"*"/permission"* && "$*" == 
 	exit 0
 fi
 
+if [[ "${1:-}" == "api" && "${2:-}" == "-X" && "${3:-}" == "POST" &&
+	"${4:-}" == repos/*/pulls/*/reviews ]]; then
+	_commit_id=""
+	for _arg in "$@"; do
+		case "$_arg" in
+		commit_id=*) _commit_id="${_arg#commit_id=}" ;;
+		esac
+	done
+	printf '{"state":"APPROVED","commit_id":"%s"}\n' "$_commit_id"
+	exit 0
+fi
+
 if [[ "${1:-}" == "api" && "$*" == *"/pulls/"*"/reviews"* ]]; then
 	printf '[]\n'
 	exit 0
@@ -177,10 +189,13 @@ define_helpers_under_test() {
 	local approve_src=""
 	local runner_src=""
 	local trusted_approval_src=""
+	local exact_head_approval_src=""
 	approve_src=$(awk '/^approve_collaborator_pr\(\) \{/,/^}$/ { print }' "$GATES_SCRIPT")
 	runner_src=$(awk '/^_approve_collaborator_runner_has_write\(\) \{/,/^}$/ { print }' "$GATES_SCRIPT")
 	trusted_approval_src=$(awk '/^_trusted_existing_approver\(\) \{/,/^}$/ { print }' "$GATES_SCRIPT")
-	[[ -n "$approve_src" && -n "$runner_src" && -n "$trusted_approval_src" ]] || return 1
+	exact_head_approval_src=$(awk '/^_pulse_approve_pr_at_head\(\) \{/,/^}$/ { print }' "$GATES_SCRIPT")
+	[[ -n "$approve_src" && -n "$runner_src" && -n "$trusted_approval_src" &&
+		-n "$exact_head_approval_src" ]] || return 1
 
 	_has_maintainer_crypto_approval() { return 1; }
 	# shellcheck source=../pulse-merge-author-checks.sh
@@ -191,6 +206,8 @@ define_helpers_under_test() {
 	eval "$runner_src"
 	# shellcheck disable=SC1090
 	eval "$trusted_approval_src"
+	# shellcheck disable=SC1090
+	eval "$exact_head_approval_src"
 	# shellcheck disable=SC1090
 	eval "$approve_src"
 	return 0
@@ -361,10 +378,13 @@ test_unallowlisted_dependency_fails() {
 
 test_trusted_dependabot_can_be_approved() {
 	write_pr_fixture "dependabot" "dependabot[bot]" "requirements-lock.txt" "SUCCESS"
+	: >"$GH_LOG"
 	approve_collaborator_pr "24473" "owner/repo" "dependabot[bot]" "head-current" >/dev/null || true
-	if grep -qF 'pr review 24473' "$GH_LOG" \
-		&& grep -qF 'trusted Dependabot dependency update verified' "$GH_LOG"; then
-		print_result "trusted Dependabot PR receives accurate auto-approval" 0
+	if grep -qF 'api -X POST repos/owner/repo/pulls/24473/reviews' "$GH_LOG" &&
+		grep -qF 'event=APPROVE' "$GH_LOG" &&
+		grep -qF 'commit_id=head-current' "$GH_LOG" &&
+		grep -qF 'trusted Dependabot dependency update verified' "$GH_LOG"; then
+		print_result "trusted Dependabot PR receives accurate head-bound auto-approval" 0
 		return 0
 	fi
 	print_result "trusted Dependabot PR receives accurate auto-approval" 1 "Expected approval call. gh log: $(<"$GH_LOG")"

--- a/.agents/scripts/tests/test-review-bot-gate-issue-sync-trust.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-issue-sync-trust.sh
@@ -20,7 +20,10 @@ cat >"${STATE_DIR}/bin/gh" <<'EOF'
 [[ "${2:-}" == "repos/marcusquinn/aidevops/pulls/123" ]] || exit 2
 case "${REVIEW_GATE_LIVE_TRUSTED:-false}" in
 true)
-	printf '%s\n' '{"author_association":"CONTRIBUTOR","user":{"login":"github-actions[bot]","id":41898282,"type":"Bot"},"head":{"ref":"aidevops/issue-sync-todo","repo":{"full_name":"marcusquinn/aidevops"}},"base":{"repo":{"full_name":"marcusquinn/aidevops"}},"body":"<!-- aidevops:issue-sync-todo-pr -->"}'
+	printf '%s\n' '{"author_association":"CONTRIBUTOR","user":{"login":"github-actions[bot]","id":41898282,"type":"Bot"},"head":{"ref":"aidevops/issue-sync-todo","sha":"head-123","repo":{"full_name":"marcusquinn/aidevops"}},"base":{"repo":{"full_name":"marcusquinn/aidevops"}},"body":"<!-- aidevops:issue-sync-todo-pr -->"}'
+	;;
+json)
+	printf '%s\n' "${REVIEW_GATE_LIVE_JSON:-}"
 	;;
 error) exit 42 ;;
 *)
@@ -179,6 +182,51 @@ if [[ "${LIVE_ERROR_STATUS}" -ne 2 ]]; then
 	exit 1
 fi
 printf 'PASS: live helper API failures remain distinct and fail-closed\n'
+
+LIVE_BASE_JSON='{"author_association":"CONTRIBUTOR","user":{"login":"github-actions[bot]","id":41898282,"type":"Bot"},"head":{"ref":"aidevops/issue-sync-todo","sha":"head-123","repo":{"full_name":"marcusquinn/aidevops"}},"base":{"repo":{"full_name":"marcusquinn/aidevops"}},"body":"<!-- aidevops:issue-sync-todo-pr -->"}'
+
+assert_live_rejected() {
+	local case_name="$1"
+	local payload="$2"
+	if REVIEW_GATE_LIVE_TRUSTED=json REVIEW_GATE_LIVE_JSON="$payload" \
+		PATH="${STATE_DIR}/bin:${PATH}" \
+		bash "${HELPER_FILE}" is-trusted-issue-sync-pr \
+			123 marcusquinn/aidevops head-123 >/dev/null 2>&1; then
+		printf 'FAIL: live helper accepted %s\n' "$case_name" >&2
+		return 1
+	fi
+	printf 'PASS: live helper rejects %s\n' "$case_name"
+	return 0
+}
+
+assert_live_rejected 'wrong bot login' \
+	"$(printf '%s' "$LIVE_BASE_JSON" | jq -c '.user.login = "github-actions"')"
+assert_live_rejected 'wrong bot ID' \
+	"$(printf '%s' "$LIVE_BASE_JSON" | jq -c '.user.id = 999')"
+assert_live_rejected 'wrong actor type' \
+	"$(printf '%s' "$LIVE_BASE_JSON" | jq -c '.user.type = "User"')"
+assert_live_rejected 'different head repository' \
+	"$(printf '%s' "$LIVE_BASE_JSON" | jq -c '.head.repo.full_name = "attacker/aidevops"')"
+assert_live_rejected 'different base repository' \
+	"$(printf '%s' "$LIVE_BASE_JSON" | jq -c '.base.repo.full_name = "other/aidevops"')"
+assert_live_rejected 'different generated branch' \
+	"$(printf '%s' "$LIVE_BASE_JSON" | jq -c '.head.ref = "feature/not-issue-sync"')"
+assert_live_rejected 'missing generated body marker' \
+	"$(printf '%s' "$LIVE_BASE_JSON" | jq -c '.body = "ordinary pull request"')"
+assert_live_rejected 'different live head SHA' \
+	"$(printf '%s' "$LIVE_BASE_JSON" | jq -c '.head.sha = "other-head"')"
+
+if ! REVIEW_GATE_LIVE_TRUSTED=true PATH="${STATE_DIR}/bin:${PATH}" \
+	bash "${HELPER_FILE}" is-trusted-issue-sync-pr 123 marcusquinn/aidevops head-123 >/dev/null; then
+	printf 'FAIL: live helper rejected the exact expected PR head\n' >&2
+	exit 1
+fi
+if REVIEW_GATE_LIVE_TRUSTED=true PATH="${STATE_DIR}/bin:${PATH}" \
+	bash "${HELPER_FILE}" is-trusted-issue-sync-pr 123 marcusquinn/aidevops stale-head >/dev/null; then
+	printf 'FAIL: live helper accepted a stale expected PR head\n' >&2
+	exit 1
+fi
+printf 'PASS: live helper trust is optionally bound to the exact PR head\n'
 
 HELP_OUTPUT=$(bash "${HELPER_FILE}" help 2>/dev/null || true)
 if [[ "${HELP_OUTPUT}" != *"is-trusted-issue-sync-pr"* ]]; then


### PR DESCRIPTION
## Summary

Trust only the exact repository-generated Issue Sync PR across Full Loop and Pulse, revalidate its immutable authority before retry and fallback transports, and bind automated approvals to the verified current head.

## Files Changed

.agents/reference/review-bot-gate.md, .agents/scripts/full-loop-helper-merge.sh, .agents/scripts/pulse-merge-gates.sh, .agents/scripts/pulse-merge.sh, .agents/scripts/review-bot-gate-helper.sh, .agents/scripts/tests/test-full-loop-merge-authority-guard.sh, .agents/scripts/tests/test-full-loop-merge.sh, .agents/scripts/tests/test-pulse-merge-admin-safety-check.sh, .agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh, .agents/scripts/tests/test-pulse-merge-issue-sync-authority.sh, .agents/scripts/tests/test-pulse-merge-trusted-dependabot.sh, .agents/scripts/tests/test-review-bot-gate-issue-sync-trust.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — Focused authority suites pass (36 Full Loop authority, 76 Full Loop merge, 21 Pulse admin safety, 14 approval guard, 3 Pulse early authority, 17 trusted Dependabot, and 19 Issue Sync classifier tests); ShellCheck and changed-file linters pass; Qlty is 48/49 with regression delta 0; independent security review returned CLEAN.

Resolves #29956


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.251 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 29m and 307,721 tokens on this with the user in an interactive session.