### PR TITLE
GH#30017: fix: extend manual Issue Sync enrich timeout

### DIFF
--- a/.agents/scripts/tests/test-issue-sync-enrich-bounds.sh
+++ b/.agents/scripts/tests/test-issue-sync-enrich-bounds.sh
@@ -67,12 +67,30 @@ _enrich_prefetch_issues_map() {
 }
 
 test_workflow_push_sets_bounded_enrich() {
-	if grep -q 'AIDEVOPS_ENRICH_MAX_ISSUES' "$WORKFLOW_FILE" \
-		&& grep -q 'AIDEVOPS_ENRICH_MAX_SECONDS' "$WORKFLOW_FILE" \
-		&& grep -q 'manual dispatch still' "$WORKFLOW_FILE"; then
+	if grep -q 'AIDEVOPS_ENRICH_MAX_ISSUES' "$WORKFLOW_FILE" &&
+		grep -q 'AIDEVOPS_ENRICH_MAX_SECONDS' "$WORKFLOW_FILE" &&
+		grep -q 'manual dispatch still' "$WORKFLOW_FILE"; then
 		print_result "push workflow configures bounded enrich while documenting manual full enrich" 0
 	else
 		print_result "push workflow configures bounded enrich while documenting manual full enrich" 1
+	fi
+	return 0
+}
+
+test_workflow_manual_enrich_has_full_pass_headroom() {
+	local manual_job
+	manual_job=$(awk '
+		/^  manual-sync:/ { capture = 1 }
+		capture && /^  [[:alnum:]_-]+:/ && $0 !~ /^  manual-sync:/ { exit }
+		capture { print }
+	' "$WORKFLOW_FILE")
+	if grep -q '^    timeout-minutes: 30$' <<<"$manual_job" &&
+		[[ "$manual_job" != *"AIDEVOPS_ENRICH_MAX_ISSUES"* ]] &&
+		[[ "$manual_job" != *"AIDEVOPS_ENRICH_MAX_SECONDS"* ]]; then
+		print_result "manual full enrich has 30-minute headroom without routine bounds" 0
+	else
+		printf '%s\n' "$manual_job"
+		print_result "manual full enrich has 30-minute headroom without routine bounds" 1
 	fi
 	return 0
 }
@@ -163,6 +181,7 @@ test_elapsed_bound_tolerates_date_failure() {
 
 main() {
 	test_workflow_push_sets_bounded_enrich
+	test_workflow_manual_enrich_has_full_pass_headroom
 	test_max_issues_bounds_enrich_loop
 	test_target_task_ignores_routine_bounds
 	test_invalid_bounds_are_ignored

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -645,7 +645,11 @@ jobs:
     name: Manual Sync
     if: github.event_name == 'workflow_dispatch' && inputs.command != 'event' && inputs.command != 'reconcile' && inputs.command != 'audit'
     runs-on: ${{ inputs.runner }}
-    timeout-minutes: 10
+    # GH#30017: manual enrich intentionally traverses the full backlog without
+    # routine bounds. Run 31500070848 made healthy progress through 114 tasks
+    # until the old 10-minute deadline cancelled it; 30 minutes covers the
+    # previously observed ~18-minute cold pass while retaining useful headroom.
+    timeout-minutes: 30
     concurrency:
       group: issue-sync-manual
       cancel-in-progress: false


### PR DESCRIPTION
## Summary

Give the intentionally unbounded manual Issue Sync enrichment lane enough time to finish a full backlog while leaving routine push and release bounds unchanged.

## Files Changed

.agents/scripts/tests/test-issue-sync-enrich-bounds.sh, .github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — The enrich bounds suite passes 7/7; ShellCheck, shfmt, actionlint, git diff check, and changed-file linters pass; independent review returned CLEAN.

Resolves #30017


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.251 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 4m and 58,451 tokens on this with the user in an interactive session.