### PR TITLE
GH#30025: test: accept current Ajv dependency

### DIFF
--- a/.agents/scripts/tests/test-post-merge-verify-report.sh
+++ b/.agents/scripts/tests/test-post-merge-verify-report.sh
@@ -82,7 +82,20 @@ fi
 
 if grep -qF 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6' "$WORKFLOW" &&
 	grep -qF 'bun install --frozen-lockfile --ignore-scripts' "$WORKFLOW" &&
-	grep -qF '"ajv": "^8.18.0"' "$PACKAGE_JSON"; then
+	python3 - "$PACKAGE_JSON" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as package_file:
+    package_json = json.load(package_file)
+
+for dependency_group in ("dependencies", "devDependencies"):
+    if "ajv" in package_json.get(dependency_group, {}):
+        raise SystemExit(0)
+
+raise SystemExit(1)
+PY
+then
 	pass "post-merge verification installs locked JavaScript dependencies without lifecycle scripts"
 else
 	fail "post-merge JavaScript dependency bootstrap" "missing direct Ajv dependency, pinned Bun setup, or locked install"


### PR DESCRIPTION
## Summary

- Replaces the stale hardcoded `"ajv": "^8.18.0"` assertion in `test-post-merge-verify-report.sh` with a JSON-aware direct dependency check.
- Keeps the existing checks for pinned Bun setup, locked/no-script install, ripgrep, Qlty, base-ref pinning, and managed follow-up creation.

## Reproducer

Before this change, the closed-task audit observed:

```bash
bash .agents/scripts/tests/test-post-merge-verify-report.sh
```

failing at `post-merge JavaScript dependency bootstrap` because root `package.json` now contains `"ajv": "8.20.0"`, while the test still expected `"ajv": "^8.18.0"`.

## Verification

```bash
bash .agents/scripts/tests/test-post-merge-verify-report.sh
shellcheck .agents/scripts/tests/test-post-merge-verify-report.sh
bun run typecheck
```

Results observed locally:

- `test-post-merge-verify-report.sh`: 9 passed, 0 failed
- `shellcheck`: no output
- `bun run typecheck`: passed

Resolves #30025

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.251 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.5 spent 2h and 175,393 tokens on this with the user in an interactive session.