### PR TITLE
GH#30033: fix: normalize auto-dispatch tier labels

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile-normalize.sh
+++ b/.agents/scripts/pulse-issue-reconcile-normalize.sh
@@ -48,6 +48,8 @@ _PULSE_ISSUE_RECONCILE_NORMALIZE_LOADED=1
 #   2. At most one `tier:*` label. Rank matches
 #      .github/workflows/dedup-tier-labels.yml so this pass is idempotent
 #      with the GH Action: rank `reasoning > standard > simple`.
+#      Auto-dispatch issues with no tier receive conservative `tier:standard`
+#      without changing their dispatch, review, or hold labels.
 #
 # Also counts (but does not auto-fix) triage-missing issues — those with
 # `origin:interactive` label AND no `tier:*` AND no `auto-dispatch` AND no
@@ -250,6 +252,16 @@ _normalize_label_invariants_for_repo() {
 		if [[ "$tier_count" -gt 1 ]] &&
 			_enforce_tier_invariant_one_issue "$issue_num" "$slug" "${tier_arr[@]}"; then
 			_LI_TIER_FIXED=$((_LI_TIER_FIXED + 1))
+		fi
+		# An existing auto-dispatch label is the only authority needed for this
+		# conservative metadata repair. Do not add auto-dispatch, clear holds, or
+		# alter needs-maintainer-review; this only makes already-authorized work
+		# routable with the framework's default tier before pickup.
+		if [[ "$has_auto" == "true" && "$tier_count" -eq 0 ]]; then
+			if gh issue edit "$issue_num" --repo "$slug" --add-label "tier:standard" >/dev/null 2>&1; then
+				_LI_TIER_FIXED=$((_LI_TIER_FIXED + 1))
+				echo "[pulse-wrapper] label_invariants: backfilled tier:standard on auto-dispatch #${issue_num} in ${slug}" >>"$LOGFILE"
+			fi
 		fi
 
 		# Triage-missing count (flag only, no auto-fix). origin:interactive

--- a/.agents/scripts/tests/test-label-invariants.sh
+++ b/.agents/scripts/tests/test-label-invariants.sh
@@ -318,6 +318,9 @@ export PULSE_QUEUED_SCAN_LIMIT=100
 #   #9: triage-missing shape but routine-tracking non-task → not counted
 #   #10: triage-missing shape but supervisor non-task → not counted
 #   #11/#12: null/missing labels → no jq error and no edits
+#   #13: auto-dispatch missing tier → conservative tier:standard backfill
+#   #14: auto-dispatch + no-auto-dispatch missing tier → backfill without
+#         clearing the explicit hold
 OLD_ISO=$(date -u -d '-1 hour' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null ||
 	TZ=UTC date -v-1H '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "2026-04-13T00:00:00Z")
 NEW_ISO=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -336,7 +339,9 @@ ISSUES_JSON=$(
 	{"number":9,"labels":[{"name":"origin:interactive"},{"name":"routine-tracking"}],"createdAt":"${OLD_ISO}"},
 	{"number":10,"labels":[{"name":"origin:interactive"},{"name":"supervisor"}],"createdAt":"${OLD_ISO}"},
 	{"number":11,"labels":null,"createdAt":"${OLD_ISO}"},
-	{"number":12,"createdAt":"${OLD_ISO}"}
+	{"number":12,"createdAt":"${OLD_ISO}"},
+	{"number":13,"labels":[{"name":"auto-dispatch"},{"name":"needs-maintainer-review"}],"createdAt":"${OLD_ISO}"},
+	{"number":14,"labels":[{"name":"auto-dispatch"},{"name":"no-auto-dispatch"}],"createdAt":"${OLD_ISO}"}
 ]
 JSON
 )
@@ -477,6 +482,22 @@ else
 	print_result "reconciler tolerates null and missing labels" 1 "(edits: #11=$n11 #12=$n12)"
 fi
 
+# Already-authorized auto-dispatch work missing a tier is routable after the
+# pass. This must not mutate review or explicit no-auto-dispatch safeguards.
+edit13=$(grep "^issue edit 13 " "$GH_CALLS" | head -1)
+if [[ "$edit13" == *"--add-label tier:standard"* && "$edit13" != *"--remove-label needs-maintainer-review"* ]]; then
+	print_result "reconciler backfills a missing auto-dispatch tier without clearing review" 0
+else
+	print_result "reconciler backfills a missing auto-dispatch tier without clearing review" 1 "(line: '$edit13')"
+fi
+
+edit14=$(grep "^issue edit 14 " "$GH_CALLS" | head -1)
+if [[ "$edit14" == *"--add-label tier:standard"* && "$edit14" != *"--remove-label no-auto-dispatch"* ]]; then
+	print_result "reconciler backfills a missing tier without clearing explicit hold" 0
+else
+	print_result "reconciler backfills a missing tier without clearing explicit hold" 1 "(line: '$edit14')"
+fi
+
 # Counter file must be written with exact numbers
 COUNTER_FILE="${HOME}/.aidevops/cache/pulse-label-invariants.$(hostname -s 2>/dev/null || echo unknown).json"
 if [[ -f "$COUNTER_FILE" ]]; then
@@ -497,11 +518,11 @@ if [[ -f "$COUNTER_FILE" ]]; then
 		print_result "counter status_fixed=3 (issues #1, #2, #4)" 1 "(got: $status_fixed)"
 	fi
 
-	# tier_fixed: #3 → 1
-	if [[ "$tier_fixed" -eq 1 ]]; then
-		print_result "counter tier_fixed=1 (issue #3)" 0
+	# tier_fixed: #3 dedup plus #13/#14 missing-tier backfill → 3
+	if [[ "$tier_fixed" -eq 3 ]]; then
+		print_result "counter tier_fixed=3 (issues #3, #13, #14)" 0
 	else
-		print_result "counter tier_fixed=1 (issue #3)" 1 "(got: $tier_fixed)"
+		print_result "counter tier_fixed=3 (issues #3, #13, #14)" 1 "(got: $tier_fixed)"
 	fi
 
 	# triage_missing: #6 only (#7 is recent, #8 has a tier, #9/#10 are non-task labels)


### PR DESCRIPTION
## Summary

Backfilled tier:standard only on existing auto-dispatch issues missing a tier, while preserving review and hold labels.

## Files Changed

.agents/scripts/pulse-issue-reconcile-normalize.sh, .agents/scripts/tests/test-label-invariants.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash .agents/scripts/tests/test-label-invariants.sh; shellcheck .agents/scripts/pulse-issue-reconcile-normalize.sh .agents/scripts/tests/test-label-invariants.sh; git diff --check

Resolves #30033


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.251 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 5m and 123,714 tokens on this as a headless worker.