### PR TITLE
GH#30032: fix: recover dispatch worktree capacity

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -33,6 +33,10 @@
 #   - _dispatch_waiting_for_maintainer_permission
 #   - _dispatch_permission_history_requires_grant
 #   - _dispatch_has_interactive_hold
+#   - _dispatch_registered_worktree_count
+#   - _dispatch_run_guarded_worktree_cleanup
+#   - _dispatch_cleanup_worktree_capacity
+#   - _dispatch_worktree_capacity_gate
 #   - _dispatch_dedup_check_layers  (t1999: extracted from dispatch_with_dedup)
 #   - dispatch_with_dedup           (t1999: thin orchestrator, <80 lines)
 #   - _ensure_issue_body_has_brief
@@ -1274,6 +1278,87 @@ _dispatch_has_interactive_hold() {
 #   1 - blocked (reason logged to LOGFILE by the failing gate)
 #   3 - expected benign dispatch block with structured DISPATCH_BLOCK_REASON
 #######################################
+_dispatch_registered_worktree_count() {
+	local repo_path="$1"
+	local worktree_list=""
+	local count=""
+	worktree_list=$(git -C "$repo_path" worktree list 2>/dev/null) || return 1
+	[[ -n "$worktree_list" ]] || return 1
+	count=$(printf '%s\n' "$worktree_list" | wc -l | tr -d ' ')
+	[[ "$count" =~ ^[0-9]+$ ]] || return 1
+	printf '%s\n' "$count"
+	return 0
+}
+
+_dispatch_run_guarded_worktree_cleanup() {
+	local repo_path="$1"
+	local helper="$2"
+	(
+		cd -- "$repo_path" || exit 125
+		bash "$helper" clean --auto --force-merged
+	) >>"${LOGFILE:-/dev/null}" 2>&1
+}
+
+# At the dispatch worktree cap, synchronously give the existing guarded cleanup
+# one bounded chance to recover capacity. The helper remains responsible for
+# preserving dirty, active, open-PR, unmerged, and externally-owned worktrees.
+_dispatch_cleanup_worktree_capacity() {
+	local repo_path="$1"
+	local issue_number="$2"
+	local repo_slug="$3"
+	local before_count="$4"
+	local max_count="$5"
+	local helper="${AIDEVOPS_WORKTREE_HELPER:-${BASH_SOURCE[0]%/*}/worktree-helper.sh}"
+	local cleanup_timeout="${AIDEVOPS_DISPATCH_WORKTREE_CLEANUP_TIMEOUT:-60}"
+	local cleanup_rc=0
+	local after_count=""
+
+	[[ "$cleanup_timeout" =~ ^[0-9]+$ ]] || cleanup_timeout=60
+	[[ "$cleanup_timeout" -ge 1 ]] || cleanup_timeout=1
+	if [[ ! -x "$helper" ]]; then
+		echo "[dispatch_with_dedup] Capacity cleanup unavailable for #${issue_number} in ${repo_slug}: guarded helper not executable (${helper}); count remains ${before_count}/${max_count}" >>"$LOGFILE"
+		return 1
+	fi
+	if ! declare -F run_stage_with_timeout >/dev/null 2>&1; then
+		echo "[dispatch_with_dedup] Capacity cleanup unavailable for #${issue_number} in ${repo_slug}: bounded stage runner missing; count remains ${before_count}/${max_count}" >>"$LOGFILE"
+		return 1
+	fi
+
+	echo "[dispatch_with_dedup] Worktree count ${before_count} >= cap ${max_count} for #${issue_number} in ${repo_slug}; attempting guarded cleanup (timeout ${cleanup_timeout}s)" >>"$LOGFILE"
+	run_stage_with_timeout "dispatch_worktree_capacity_cleanup" "$cleanup_timeout" \
+		_dispatch_run_guarded_worktree_cleanup "$repo_path" "$helper" || cleanup_rc=$?
+	if ! after_count=$(_dispatch_registered_worktree_count "$repo_path"); then
+		echo "[dispatch_with_dedup] Guarded capacity cleanup could not verify the post-cleanup worktree count for #${issue_number} in ${repo_slug} (before ${before_count}, cap ${max_count}, cleanup_rc=${cleanup_rc}); dispatch remains fail-closed" >>"$LOGFILE"
+		return 1
+	fi
+	if [[ "$after_count" =~ ^[0-9]+$ ]] && [[ "$after_count" -lt "$max_count" ]]; then
+		echo "[dispatch_with_dedup] Guarded capacity cleanup recovered dispatch capacity for #${issue_number} in ${repo_slug}: ${before_count} -> ${after_count} worktrees (cap ${max_count}, cleanup_rc=${cleanup_rc})" >>"$LOGFILE"
+		return 0
+	fi
+
+	[[ "$after_count" =~ ^[0-9]+$ ]] || after_count="$before_count"
+	echo "[dispatch_with_dedup] Guarded capacity cleanup could not recover dispatch capacity for #${issue_number} in ${repo_slug}: ${before_count} -> ${after_count} worktrees (cap ${max_count}, cleanup_rc=${cleanup_rc}); existing cleanup safety gates preserved remaining worktrees" >>"$LOGFILE"
+	return 1
+}
+
+_dispatch_worktree_capacity_gate() {
+	local repo_path="$1"
+	local issue_number="$2"
+	local repo_slug="$3"
+	local max_count="$4"
+	local count=""
+
+	if ! count=$(_dispatch_registered_worktree_count "$repo_path"); then
+		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: unable to verify registered worktree count; capacity gate remains fail-closed" >>"$LOGFILE"
+		return 1
+	fi
+	if [[ "$count" -lt "$max_count" ]]; then
+		return 0
+	fi
+	_dispatch_cleanup_worktree_capacity "$repo_path" "$issue_number" "$repo_slug" "$count" "$max_count"
+	return $?
+}
+
 _dispatch_dedup_check_layers() {
 	local issue_number="$1"
 	local repo_slug="$2"
@@ -1324,11 +1409,11 @@ _dispatch_dedup_check_layers() {
 	# registered git worktrees. At that scale, new worktrees risk consuming
 	# tens of GB; stale merged ones should be cleaned before adding more.
 	_dss_t0=$(_ds_now_ns)
-	local _wt_count="" _wt_max=""
+	local _wt_max=""
 	_wt_max="${AIDEVOPS_MAX_WORKTREES:-200}"
-	_wt_count=$(git -C "$repo_path" worktree list 2>/dev/null | wc -l | tr -d ' ')
-	if [[ -n "$_wt_count" ]] && [[ "$_wt_count" -ge "$_wt_max" ]]; then
-		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: worktree count ${_wt_count} >= cap ${_wt_max}. Run: worktree-helper.sh clean --auto --force-merged" >>"$LOGFILE"
+	[[ "$_wt_max" =~ ^[1-9][0-9]*$ ]] || _wt_max=200
+	if ! _dispatch_worktree_capacity_gate "$repo_path" "$issue_number" "$repo_slug" "$_wt_max"; then
+		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: worktree capacity remains unavailable after bounded guarded cleanup" >>"$LOGFILE"
 		_ds_record "$issue_number" "$repo_slug" "dedup.worktree_cap" "$_dss_t0"
 		return 1
 	fi

--- a/.agents/scripts/tests/test-pulse-dispatch-worktree-cap-cleanup.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-worktree-cap-cleanup.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression coverage for guarded cleanup at the Pulse worktree cap (GH#30032).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+CORE_SCRIPT="${SCRIPT_DIR}/../pulse-dispatch-core.sh"
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+LOGFILE="${TEST_ROOT}/pulse.log"
+AIDEVOPS_WORKTREE_HELPER="${TEST_ROOT}/worktree-helper.sh"
+FAKE_ARGS_FILE="${TEST_ROOT}/helper.args"
+FAKE_COUNT_FILE="${TEST_ROOT}/worktree.count"
+# shellcheck disable=SC2016 # The generated fixture expands these variables when executed.
+printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >"$FAKE_ARGS_FILE"\nif [[ "${FAKE_REMOVE_COUNT:-0}" == "1" ]]; then rm -f "$FAKE_COUNT_FILE"; elif [[ -n "${FAKE_AFTER_COUNT:-}" ]]; then printf "%%s\\n" "$FAKE_AFTER_COUNT" >"$FAKE_COUNT_FILE"; fi\nexit 0\n' >"$AIDEVOPS_WORKTREE_HELPER"
+chmod +x "$AIDEVOPS_WORKTREE_HELPER"
+export FAKE_ARGS_FILE FAKE_COUNT_FILE
+
+TESTS_RUN=0
+TESTS_FAILED=0
+COUNT_FAIL=0
+GIT_MODE="valid"
+STAGE_TIMEOUT=""
+STAGE_RC=0
+
+print_result() {
+	local name="$1"
+	local status="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+	else
+		printf 'FAIL %s\n' "$name"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+extract_helper() {
+	local name="$1"
+	awk -v function_name="$name" '
+		$0 ~ "^" function_name "\\(\\) \\{" { capture=1 }
+		capture { print }
+		capture && /^}$/ { exit }
+	' "$CORE_SCRIPT"
+	return 0
+}
+
+PRODUCTION_COUNT_HELPER=$(extract_helper _dispatch_registered_worktree_count)
+eval "$PRODUCTION_COUNT_HELPER"
+eval "${PRODUCTION_COUNT_HELPER/_dispatch_registered_worktree_count/_production_dispatch_registered_worktree_count}"
+eval "$(extract_helper _dispatch_run_guarded_worktree_cleanup)"
+eval "$(extract_helper _dispatch_cleanup_worktree_capacity)"
+eval "$(extract_helper _dispatch_worktree_capacity_gate)"
+
+git() {
+	case "$GIT_MODE" in
+	nonzero) return 2 ;;
+	empty) return 0 ;;
+	valid) printf '/repo/main\n/repo/linked\n' ;;
+	*) return 3 ;;
+	esac
+}
+
+_dispatch_registered_worktree_count() {
+	[[ "$COUNT_FAIL" -eq 0 ]] || return 1
+	[[ -f "$FAKE_COUNT_FILE" ]] || return 1
+	local count=""
+	count=$(<"$FAKE_COUNT_FILE")
+	printf '%s\n' "$count"
+	return 0
+}
+
+run_stage_with_timeout() {
+	local stage_name="$1"
+	local rc=0
+	STAGE_TIMEOUT="$2"
+	shift 2
+	[[ "$stage_name" == "dispatch_worktree_capacity_cleanup" ]] || return 2
+	[[ "$STAGE_RC" -eq 0 ]] || return "$STAGE_RC"
+	"$@" || rc=$?
+	return "$rc"
+}
+
+test_cleanup_recovers_capacity() {
+	printf '200\n' >"$FAKE_COUNT_FILE"
+	FAKE_AFTER_COUNT=199
+	FAKE_REMOVE_COUNT=0
+	export FAKE_AFTER_COUNT FAKE_REMOVE_COUNT
+	COUNT_FAIL=0
+	STAGE_TIMEOUT=""
+	STAGE_RC=0
+	rm -f "$FAKE_ARGS_FILE"
+	AIDEVOPS_DISPATCH_WORKTREE_CLEANUP_TIMEOUT=17
+	if _dispatch_worktree_capacity_gate "$TEST_ROOT" 30032 "owner/repo" 200 &&
+		[[ "$STAGE_TIMEOUT" == "17" ]] &&
+		[[ "$(<"$FAKE_ARGS_FILE")" == "clean --auto --force-merged" ]] &&
+		[[ "$(<"$FAKE_COUNT_FILE")" == "199" ]] &&
+		grep -q "recovered dispatch capacity.*200 -> 199" "$LOGFILE"; then
+		print_result "cap gate invokes guarded cleanup and proceeds after recount" 0
+	else
+		print_result "cap gate invokes guarded cleanup and proceeds after recount" 1
+	fi
+	return 0
+}
+
+test_cleanup_fails_closed_without_reduction() {
+	printf '200\n' >"$FAKE_COUNT_FILE"
+	FAKE_AFTER_COUNT=200
+	FAKE_REMOVE_COUNT=0
+	export FAKE_AFTER_COUNT FAKE_REMOVE_COUNT
+	COUNT_FAIL=0
+	STAGE_RC=0
+	if _dispatch_worktree_capacity_gate "$TEST_ROOT" 30032 "owner/repo" 200; then
+		print_result "cleanup remains fail-closed when count stays at cap" 1
+	elif grep -q "could not recover dispatch capacity.*200 -> 200.*safety gates preserved" "$LOGFILE"; then
+		print_result "cleanup remains fail-closed when count stays at cap" 0
+	else
+		print_result "cleanup remains fail-closed when count stays at cap" 1
+	fi
+	return 0
+}
+
+test_timeout_remains_fail_closed() {
+	printf '200\n' >"$FAKE_COUNT_FILE"
+	FAKE_AFTER_COUNT=""
+	FAKE_REMOVE_COUNT=0
+	export FAKE_AFTER_COUNT FAKE_REMOVE_COUNT
+	COUNT_FAIL=0
+	STAGE_RC=124
+	if _dispatch_worktree_capacity_gate "$TEST_ROOT" 30032 "owner/repo" 200; then
+		print_result "timed-out cleanup remains fail-closed" 1
+	elif grep -q "cleanup_rc=124" "$LOGFILE"; then
+		print_result "timed-out cleanup remains fail-closed" 0
+	else
+		print_result "timed-out cleanup remains fail-closed" 1
+	fi
+	STAGE_RC=0
+	return 0
+}
+
+test_production_count_probe_validation() {
+	local count=""
+	GIT_MODE="valid"
+	count=$(_production_dispatch_registered_worktree_count "$TEST_ROOT") || count="failed"
+	if [[ "$count" == "2" ]]; then
+		print_result "production counter counts verified Git inventory" 0
+	else
+		print_result "production counter counts verified Git inventory" 1
+	fi
+	GIT_MODE="empty"
+	if _production_dispatch_registered_worktree_count "$TEST_ROOT" >/dev/null; then
+		print_result "production counter rejects empty Git inventory" 1
+	else
+		print_result "production counter rejects empty Git inventory" 0
+	fi
+	GIT_MODE="nonzero"
+	if _production_dispatch_registered_worktree_count "$TEST_ROOT" >/dev/null; then
+		print_result "production counter propagates Git failure" 1
+	else
+		print_result "production counter propagates Git failure" 0
+	fi
+	GIT_MODE="valid"
+	return 0
+}
+
+test_post_cleanup_recount_failure_remains_fail_closed() {
+	printf '200\n' >"$FAKE_COUNT_FILE"
+	FAKE_AFTER_COUNT=""
+	FAKE_REMOVE_COUNT=1
+	export FAKE_AFTER_COUNT FAKE_REMOVE_COUNT
+	COUNT_FAIL=0
+	STAGE_RC=0
+	if _dispatch_worktree_capacity_gate "$TEST_ROOT" 30032 "owner/repo" 200; then
+		print_result "post-cleanup recount failure remains fail-closed" 1
+	elif grep -q "could not verify the post-cleanup worktree count" "$LOGFILE"; then
+		print_result "post-cleanup recount failure remains fail-closed" 0
+	else
+		print_result "post-cleanup recount failure remains fail-closed" 1
+	fi
+	FAKE_REMOVE_COUNT=0
+	export FAKE_REMOVE_COUNT
+	return 0
+}
+
+test_count_probe_failure_remains_fail_closed() {
+	COUNT_FAIL=1
+	if _dispatch_worktree_capacity_gate "$TEST_ROOT" 30032 "owner/repo" 200; then
+		print_result "worktree count probe failure remains fail-closed" 1
+	elif grep -q "unable to verify registered worktree count" "$LOGFILE"; then
+		print_result "worktree count probe failure remains fail-closed" 0
+	else
+		print_result "worktree count probe failure remains fail-closed" 1
+	fi
+	COUNT_FAIL=0
+	return 0
+}
+
+test_missing_bounded_runner_fails_closed() {
+	local runner_definition
+	runner_definition=$(declare -f run_stage_with_timeout)
+	unset -f run_stage_with_timeout
+	printf '200\n' >"$FAKE_COUNT_FILE"
+	if _dispatch_cleanup_worktree_capacity "$TEST_ROOT" 30032 "owner/repo" 200 200; then
+		print_result "missing bounded runner fails closed" 1
+	elif grep -q "bounded stage runner missing" "$LOGFILE"; then
+		print_result "missing bounded runner fails closed" 0
+	else
+		print_result "missing bounded runner fails closed" 1
+	fi
+	eval "$runner_definition"
+	return 0
+}
+
+main() {
+	test_cleanup_recovers_capacity
+	test_cleanup_fails_closed_without_reduction
+	test_timeout_remains_fail_closed
+	test_production_count_probe_validation
+	test_post_cleanup_recount_failure_remains_fail_closed
+	test_count_probe_failure_remains_fail_closed
+	test_missing_bounded_runner_fails_closed
+
+	printf 'Ran %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -eq 0 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Run one bounded guarded worktree cleanup at the Pulse dispatch cap, recount, and proceed only when capacity is recovered; otherwise retain fail-closed evidence.

## Files Changed

.agents/scripts/pulse-dispatch-core.sh, .agents/scripts/tests/test-pulse-dispatch-worktree-cap-cleanup.sh

## Runtime Testing

- **Risk level:** High
- **Verification:** runtime-verified — Focused cap cleanup regression (3 cases), ShellCheck on changed scripts, and git diff --check.

Resolves #30032


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.251 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 6m and 105,383 tokens on this as a headless worker.