### PR TITLE
GH#30047: fix: narrow stale release reservations

### DIFF
--- a/.agents/scripts/full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/full-loop-release-aggregate-recovery.sh
@@ -213,6 +213,63 @@ _full_loop_recovery_resolve_lane_authorization() {
 	return $?
 }
 
+_full_loop_recovery_validate_reserved_authorization_narrowing() {
+	local repo="$1"
+	local previous_sources="$2"
+	local reviewed_sources="$3"
+	local previous_json=""
+	local reviewed_json=""
+	local removed_prs=""
+	local removed_pr=""
+	local receipt_path=""
+	local receipt_status=""
+	previous_json=$(release_authorization_manifest_json "$previous_sources") || return 1
+	reviewed_json=$(release_authorization_manifest_json "$reviewed_sources") || return 1
+	jq -en --argjson previous "$previous_json" --argjson reviewed "$reviewed_json" '
+		all($previous[]; . as $candidate
+			| ([$reviewed[] | select(.pr == $candidate.pr)]) as $matches
+			| (($matches | length) == 0
+				or (($matches | length) == 1 and $matches[0] == $candidate)))
+	' >/dev/null || {
+		printf 'Reserved release authorization narrowing changed an existing source merge identity\n' >&2
+		return 1
+	}
+	removed_prs=$(jq -rn --argjson previous "$previous_json" --argjson reviewed "$reviewed_json" '
+		$previous[] as $candidate
+		| select(([$reviewed[] | select(.pr == $candidate.pr)] | length) == 0)
+		| $candidate.pr
+	') || return 1
+	[[ -n "$removed_prs" ]] || return 1
+	while IFS= read -r removed_pr; do
+		[[ "$removed_pr" =~ ^[0-9]+$ ]] || return 1
+		receipt_path=$(_full_loop_release_receipt_path "$repo" "$removed_pr") || return 1
+		receipt_status=""
+		[[ -f "$receipt_path" ]] && IFS= read -r receipt_status <"$receipt_path" || true
+		if [[ "$receipt_status" != "$_FULL_LOOP_RELEASE_NOT_REQUESTED" ]]; then
+			printf 'Reserved release authorization cannot remove PR #%s with release:%s\n' \
+				"$removed_pr" "${receipt_status:-missing}" >&2
+			return 1
+		fi
+	done <<<"$removed_prs"
+	return 0
+}
+
+_full_loop_recovery_write_reserved_authorization() {
+	local repo="$1"
+	local source_pr="$2"
+	local previous_sources="$3"
+	local reviewed_sources="$4"
+	local existing=""
+	local previous_record=""
+	previous_sources=$(release_authorization_manifest_string "$previous_sources") || return 1
+	reviewed_sources=$(release_authorization_manifest_string "$reviewed_sources") || return 1
+	existing=$(_full_loop_read_release_authorization "$repo" "$source_pr") || return 1
+	[[ "$existing" == "$previous_sources" ]] || return 1
+	previous_record=$(_full_loop_read_release_authorization_record "$repo" "$source_pr") || return 1
+	_full_loop_write_release_authorization_record "$repo" "$source_pr" "$reviewed_sources" "$previous_record"
+	return $?
+}
+
 _full_loop_recovery_expand_reserved_authorization() {
 	local repo="$1"
 	local source_pr="$2"
@@ -220,7 +277,8 @@ _full_loop_recovery_expand_reserved_authorization() {
 	local previous_auth=""
 	local lane_sources=""
 	local normalized_lane_sources=""
-	local authorization_expanded=false
+	local authorization_changed=0
+	local authorization_narrowed=0
 	local existing_tag_rc=0
 	_full_loop_recovery_validate_receipt "$repo" "$source_pr" || return 1
 	_full_loop_release_find_tag_for_pr "$repo" "$source_pr" || existing_tag_rc=$?
@@ -229,7 +287,11 @@ _full_loop_recovery_expand_reserved_authorization() {
 	_full_loop_validate_release_candidates "$repo" "$_FULL_LOOP_RESOLVED_SOURCE_JSON" || return 1
 	_full_loop_release_reset_tag_worktree || return 1
 	previous_auth=$(_full_loop_read_release_authorization "$repo" "$source_pr") || return 1
-	release_authorization_subset "$previous_auth" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+	if ! release_authorization_subset "$previous_auth" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED"; then
+		_full_loop_recovery_validate_reserved_authorization_narrowing "$repo" "$previous_auth" \
+			"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+		authorization_narrowed=1
+	fi
 	release_lane_read "$repo" || return 1
 	jq -e --argjson source_pr "$source_pr" '
 		.active == true and .source_pr == $source_pr and .phase == "reserved"
@@ -241,8 +303,8 @@ _full_loop_recovery_expand_reserved_authorization() {
 	}
 	lane_sources=$(jq -er '.expected_sources' <<<"$_AIDEVOPS_RELEASE_LANE_JSON") || return 1
 	normalized_lane_sources=$(_full_loop_recovery_resolve_lane_authorization \
-		"$lane_sources" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED") || {
-		printf 'Reserved release lane authorization cannot be normalized against reviewed aggregate PR #%s\n' "$source_pr" >&2
+		"$lane_sources" "$previous_auth") || {
+		printf 'Reserved release lane authorization cannot be normalized against persisted authorization for PR #%s\n' "$source_pr" >&2
 		return 1
 	}
 	if ! release_authorization_compare "$normalized_lane_sources" "$previous_auth"; then
@@ -257,22 +319,27 @@ _full_loop_recovery_expand_reserved_authorization() {
 		return 0
 	fi
 	if [[ "$previous_auth" != "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" ]]; then
-		_full_loop_expand_release_authorization_for_aggregate "$repo" "$source_pr" \
-			"$previous_auth" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
-		authorization_expanded=true
+		if [[ "$authorization_narrowed" -eq 1 ]]; then
+			_full_loop_recovery_write_reserved_authorization "$repo" "$source_pr" \
+				"$previous_auth" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+		else
+			_full_loop_expand_release_authorization_for_aggregate "$repo" "$source_pr" \
+				"$previous_auth" "$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" || return 1
+		fi
+		authorization_changed=1
 	fi
 	if ! release_lane_expand_reserved_authorization "$repo" "$source_pr" "$lane_sources" \
 		"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED"; then
 		release_lane_restore_reserved_authorization "$repo" "$source_pr" \
 			"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT" || true
-		if [[ "$authorization_expanded" == "true" ]]; then
+		if [[ "$authorization_changed" -eq 1 ]]; then
 			_full_loop_restore_release_authorization_after_aggregate "$repo" "$source_pr" \
 				"$_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED" "$previous_auth" || return 1
 		fi
 		printf 'Reserved release lane authorization migration failed for PR #%s; prior state was restored\n' "$source_pr" >&2
 		return 1
 	fi
-	printf 'Expanded side-effect-free reserved release authorization for reviewed aggregate PR #%s\n' "$source_pr"
+	printf 'Reconciled side-effect-free reserved release authorization for reviewed aggregate PR #%s\n' "$source_pr"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
+++ b/.agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh
@@ -266,6 +266,136 @@ printf 'PASS durable protected-main queue remains pending after version-manager 
 	unset _FULL_LOOP_RELEASE_AGGREGATE_RECOVERY_LOADED
 	source "${SCRIPT_DIR}/release-authorization-manifest-helper.sh"
 	source "${SCRIPT_DIR}/full-loop-release-aggregate-recovery.sh"
+	_FULL_LOOP_RELEASE_NOT_REQUESTED=not-requested
+	narrow_receipt_dir="${TEST_ROOT}/narrow-receipts"
+	mkdir -p "$narrow_receipt_dir"
+	previous_manifest='42@2222222222222222222222222222222222222222,43@3333333333333333333333333333333333333333'
+	reviewed_manifest='42@2222222222222222222222222222222222222222,44@4444444444444444444444444444444444444444'
+	_full_loop_release_receipt_path() {
+		printf '%s/%s.status\n' "$narrow_receipt_dir" "$2"
+		return 0
+	}
+	printf 'not-requested\n' >"${narrow_receipt_dir}/43.status"
+	_full_loop_recovery_validate_reserved_authorization_narrowing \
+		test/repo "$previous_manifest" "$reviewed_manifest"
+	printf 'PASS reserved narrowing accepts only removed terminal no-release sources\n'
+
+	rm -f "${narrow_receipt_dir}/43.status"
+	if _full_loop_recovery_validate_reserved_authorization_narrowing \
+		test/repo "$previous_manifest" "$reviewed_manifest" >/dev/null 2>&1; then
+		printf 'FAIL reserved narrowing accepted a missing release receipt\n'
+		exit 1
+	fi
+	for rejected_status in failed published superseded unexpected; do
+		printf '%s\n' "$rejected_status" >"${narrow_receipt_dir}/43.status"
+		if _full_loop_recovery_validate_reserved_authorization_narrowing \
+			test/repo "$previous_manifest" "$reviewed_manifest" >/dev/null 2>&1; then
+			printf 'FAIL reserved narrowing accepted release:%s\n' "$rejected_status"
+			exit 1
+		fi
+	done
+	printf 'PASS reserved narrowing rejects missing and non-no-release receipts\n'
+
+	printf 'not-requested\n' >"${narrow_receipt_dir}/43.status"
+	changed_merge_manifest='42@2222222222222222222222222222222222222222,43@4444444444444444444444444444444444444444'
+	if _full_loop_recovery_validate_reserved_authorization_narrowing \
+		test/repo "$previous_manifest" "$changed_merge_manifest" >/dev/null 2>&1; then
+		printf 'FAIL reserved narrowing accepted a changed source merge identity\n'
+		exit 1
+	fi
+	printf 'PASS reserved narrowing rejects changed source merge identities\n'
+
+	NARROW_LOG="${TEST_ROOT}/narrow.log"
+	: >"$NARROW_LOG"
+	_FULL_LOOP_PHASE_FAILED=failed
+	_full_loop_recovery_validate_receipt() { return 0; }
+	_full_loop_release_find_tag_for_pr() { return 2; }
+	_full_loop_recovery_prepare_aggregate() {
+		_FULL_LOOP_AGGREGATE_RECOVERY_EXPECTED="$reviewed_manifest"
+		_FULL_LOOP_RESOLVED_SOURCE_JSON='{"mode":"aggregate"}'
+		return 0
+	}
+	_full_loop_validate_release_candidates() {
+		printf 'validate\n' >>"$NARROW_LOG"
+		return 0
+	}
+	_full_loop_release_reset_tag_worktree() { return 0; }
+	_full_loop_read_release_authorization() {
+		printf '%s\n' "$previous_manifest"
+		return 0
+	}
+	LANE_PHASE=reserved
+	LANE_TAG=null
+	release_lane_read() {
+		_AIDEVOPS_RELEASE_LANE_JSON=$(jq -cn --arg phase "$LANE_PHASE" --argjson tag "$LANE_TAG" \
+			'{active:true,source_pr:42,phase:$phase,tag:$tag,expected_sources:"42,43",terminal_receipt:null}')
+		return 0
+	}
+	release_lane_acquire() {
+		_AIDEVOPS_RELEASE_LANE_RESULT=acquired
+		_AIDEVOPS_RELEASE_LANE_TOKEN=owned
+		return 0
+	}
+	_full_loop_expand_release_authorization_for_aggregate() {
+		printf 'unexpected-expand\n' >>"$NARROW_LOG"
+		return 1
+	}
+	_full_loop_recovery_write_reserved_authorization() {
+		printf 'reconcile-auth\n' >>"$NARROW_LOG"
+		return 0
+	}
+	release_lane_expand_reserved_authorization() {
+		_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT='{"phase":"reserved"}'
+		printf 'reconcile-lane\n' >>"$NARROW_LOG"
+		return 0
+	}
+	_full_loop_recovery_expand_reserved_authorization test/repo 42 42,44 >/dev/null
+	[[ "$(tr '\n' ' ' <"$NARROW_LOG")" == "validate reconcile-auth reconcile-lane " ]]
+	printf 'PASS reserved recovery transaction narrows reviewed no-release sources\n'
+
+	: >"$NARROW_LOG"
+	release_lane_expand_reserved_authorization() {
+		_AIDEVOPS_RELEASE_LANE_RECOVERY_SNAPSHOT='{"phase":"reserved"}'
+		printf 'reconcile-lane\n' >>"$NARROW_LOG"
+		return 1
+	}
+	release_lane_restore_reserved_authorization() {
+		printf 'restore-lane\n' >>"$NARROW_LOG"
+		return 0
+	}
+	_full_loop_restore_release_authorization_after_aggregate() {
+		printf 'restore-auth\n' >>"$NARROW_LOG"
+		return 0
+	}
+	if _full_loop_recovery_expand_reserved_authorization test/repo 42 42,44 >/dev/null 2>&1; then
+		printf 'FAIL failed narrowing transaction returned success\n'
+		exit 1
+	fi
+	[[ "$(tr '\n' ' ' <"$NARROW_LOG")" == "validate reconcile-auth reconcile-lane restore-lane restore-auth " ]]
+	printf 'PASS failed reserved narrowing restores lane and authorization snapshots\n'
+
+	for unsafe_lane in preparing tagged; do
+		: >"$NARROW_LOG"
+		LANE_PHASE=reserved
+		LANE_TAG=null
+		if [[ "$unsafe_lane" == preparing ]]; then
+			LANE_PHASE=preparing
+		else
+			LANE_TAG='"v1.2.3"'
+		fi
+		if _full_loop_recovery_expand_reserved_authorization test/repo 42 42,44 >/dev/null 2>&1; then
+			printf 'FAIL reserved narrowing accepted unsafe lane state %s\n' "$unsafe_lane"
+			exit 1
+		fi
+		[[ "$(tr '\n' ' ' <"$NARROW_LOG")" == "validate " ]]
+	done
+	printf 'PASS reserved narrowing rejects post-reservation phases and assigned tags\n'
+)
+
+(
+	unset _FULL_LOOP_RELEASE_AGGREGATE_RECOVERY_LOADED
+	source "${SCRIPT_DIR}/release-authorization-manifest-helper.sh"
+	source "${SCRIPT_DIR}/full-loop-release-aggregate-recovery.sh"
 	RESERVED_LOG="${TEST_ROOT}/reserved.log"
 	: >"$RESERVED_LOG"
 	old_manifest='42@2222222222222222222222222222222222222222'
@@ -335,7 +465,7 @@ printf 'PASS durable protected-main queue remains pending after version-manager 
 	if _full_loop_recovery_expand_reserved_authorization test/repo 42 42,43 >"${TEST_ROOT}/legacy-mismatch.out" 2>&1; then
 		exit 1
 	fi
-	grep -q 'cannot be normalized against reviewed aggregate' "${TEST_ROOT}/legacy-mismatch.out"
+	grep -q 'cannot be normalized against persisted authorization' "${TEST_ROOT}/legacy-mismatch.out"
 	[[ "$(tr '\n' ' ' <"$RESERVED_LOG")" == "validate " ]]
 	printf 'PASS reserved recovery rejects non-equivalent legacy PR identities without mutation\n'
 


### PR DESCRIPTION
## Summary

Allow a reviewed exact-tip aggregate to narrow a stale side-effect-free release reservation only for sources with terminal no-release receipts.

## Files Changed

.agents/scripts/full-loop-release-aggregate-recovery.sh, .agents/scripts/tests/test-full-loop-release-aggregate-recovery.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: focused aggregate-recovery state-machine tests execute narrowing, rejection, unsafe-phase, and transactional rollback paths; release-lane and provenance suites pass; full local lint passes.

Resolves #30047


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.251 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-luna spent 38m on this with the user in an interactive session.