### PR TITLE
GH#30015: preserve merge cooldown diagnosis

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -95,6 +95,8 @@ _full_loop_query_required_checks() {
 	FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="required-context resolution failed"
 	FULL_LOOP_REQUIRED_CHECKS_SUCCESS_EVIDENCE="required-checks-pass"
 	FULL_LOOP_REQUIRED_CHECKS_SUCCESS_SUMMARY="required checks are terminal-success"
+	FULL_LOOP_PRE_MERGE_BLOCKER_KIND=""
+	FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL=""
 
 	required_contexts=$(_required_contexts_for_default_branch "$repo") || required_contexts_rc=$?
 	if [[ "$required_contexts_rc" -eq 0 && -z "$required_contexts" ]]; then
@@ -114,6 +116,19 @@ _full_loop_query_required_checks() {
 	required_checks_stderr=$(<"$required_checks_stderr_file")
 	rm -f "$required_checks_stderr_file"
 	FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="exact check read exit ${required_rc}"
+	if [[ "$required_checks_stderr" == *"error_kind=github-api-cooldown"* ]]; then
+		FULL_LOOP_PRE_MERGE_BLOCKER_KIND="github-api-cooldown"
+		FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL="unknown"
+		if [[ "$required_checks_stderr" =~ expires_at=([0-9]+) ]]; then
+			FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL="${BASH_REMATCH[1]}"
+		fi
+		FULL_LOOP_REQUIRED_CHECKS_ERROR_EVIDENCE="github-api-cooldown"
+		if [[ "$FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL" =~ ^[0-9]+$ ]]; then
+			FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="GitHub API cooldown is active until epoch ${FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL}"
+		else
+			FULL_LOOP_REQUIRED_CHECKS_ERROR_DETAIL="GitHub API cooldown is active"
+		fi
+	fi
 
 	if [[ "$required_rc" -eq 1 && -z "$required_checks" && -n "$pr_head_ref" && "$required_checks_stderr" == "$expected_no_required_checks" ]]; then
 		required_checks="[]"
@@ -322,6 +337,8 @@ _full_loop_verify_pr_readiness() {
 cmd_pre_merge_gate() {
 	local pr_number="${1:-}"
 	local repo="${2:-}"
+	FULL_LOOP_PRE_MERGE_BLOCKER_KIND=""
+	FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL=""
 
 	if [[ -z "$pr_number" ]]; then
 		print_error "Usage: full-loop-helper.sh pre-merge-gate <PR_NUMBER> [REPO]"
@@ -341,6 +358,7 @@ cmd_pre_merge_gate() {
 
 	local rbg_helper=""
 	if ! rbg_helper=$(_full_loop_review_bot_gate_helper_path); then
+		FULL_LOOP_PRE_MERGE_BLOCKER_KIND="review-bot"
 		print_error "review-bot-gate-helper.sh not found — refusing an unreviewed merge"
 		return 1
 	fi
@@ -361,6 +379,7 @@ cmd_pre_merge_gate() {
 		return 0
 		;;
 	*)
+		FULL_LOOP_PRE_MERGE_BLOCKER_KIND="review-bot"
 		print_error "Review bot gate: ${rbg_status:-FAILED} — do NOT merge PR #${pr_number}"
 		printf '%s\n' "$rbg_result" | tail -5
 		return 1

--- a/.agents/scripts/full-loop-helper-merge.sh
+++ b/.agents/scripts/full-loop-helper-merge.sh
@@ -1788,6 +1788,25 @@ _merge_parse_command_args() {
 	return 0
 }
 
+_merge_report_pre_merge_gate_failure() {
+	case "${FULL_LOOP_PRE_MERGE_BLOCKER_KIND:-}" in
+	github-api-cooldown)
+		if [[ "${FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL:-}" =~ ^[0-9]+$ ]]; then
+			print_error "Merge deferred: GitHub API cooldown is active; retry after epoch ${FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL}."
+		else
+			print_error "Merge deferred: GitHub API cooldown is active; retry after the cooldown expires."
+		fi
+		;;
+	review-bot)
+		print_error "Merge blocked by review bot gate. Address bot findings or wait for reviews."
+		;;
+	*)
+		print_error "Merge blocked by the pre-merge safety gate. Address the diagnostic above before retrying."
+		;;
+	esac
+	return 0
+}
+
 cmd_merge() {
 	local pr_number="${1:-}"
 	if [[ -z "$pr_number" ]]; then
@@ -1821,7 +1840,7 @@ cmd_merge() {
 
 	# Gate: enforce review-bot-gate before merge.
 	cmd_pre_merge_gate "$pr_number" "$repo" || {
-		print_error "Merge blocked by review bot gate. Address bot findings or wait for reviews."
+		_merge_report_pre_merge_gate_failure
 		return 1
 	}
 	if [[ "$repo" == "${AIDEVOPS_RELEASE_LANE_COORDINATED_REPO:-marcusquinn/aidevops}" ]]; then

--- a/.agents/scripts/shared-gh-wrappers-checks.sh
+++ b/.agents/scripts/shared-gh-wrappers-checks.sh
@@ -503,6 +503,35 @@ _gh_pr_checks_exact_error() {
 }
 
 #######################################
+# Preserve a cooldown classification while keeping the public exact-check
+# helper contract at exit 2 for API/parse failures.
+# Args: $1=operation detail, $2=read exit
+#######################################
+_gh_pr_checks_exact_read_error() {
+	local operation="$1"
+	local read_exit="$2"
+	local expires_at="unknown"
+
+	if [[ "$read_exit" -eq 75 ]] &&
+		declare -F _gh_secondary_cooldown_active >/dev/null 2>&1 &&
+		_gh_secondary_cooldown_active; then
+		if declare -F _gh_secondary_cooldown_expires_at >/dev/null 2>&1; then
+			expires_at="$(_gh_secondary_cooldown_expires_at 2>/dev/null || printf 'unknown')"
+		fi
+		[[ "$expires_at" =~ ^[0-9]+$ ]] || expires_at="unknown"
+		_gh_pr_checks_exact_error "error_kind=github-api-cooldown expires_at=${expires_at} operation=${operation}"
+		return 0
+	fi
+	if [[ "$read_exit" -eq 75 ]]; then
+		_gh_pr_checks_exact_error "error_kind=github-api-read-deferred operation=${operation}"
+		return 0
+	fi
+
+	_gh_pr_checks_exact_error "${operation} failed"
+	return 0
+}
+
+#######################################
 # Normalize and deduplicate collected status-rollup pages like gh CLI 2.96.0.
 # The newest StatusContext wins by context name. The newest CheckRun wins by
 # name/workflow/event. Deduplication happens before required-only filtering.
@@ -586,15 +615,17 @@ _gh_pr_checks_exact_identity() {
 	local slug="$1"
 	local pr_number="$2"
 	local identity_json="" identity=""
+	local identity_exit=0
 	local object_type='object'
 	local string_type='string'
 
 	identity_json=$(AIDEVOPS_GH_QUOTA_COST=1 \
 		AIDEVOPS_GH_ROUTE_DECISION="gh-pr-checks-identity-rest" \
-		_gh_checks_api_read "repos/${slug}/pulls/${pr_number}" 2>/dev/null) || {
-		_gh_pr_checks_exact_error "pull-request identity read failed"
+		_gh_checks_api_read "repos/${slug}/pulls/${pr_number}" 2>/dev/null) || identity_exit=$?
+	if [[ "$identity_exit" -ne 0 ]]; then
+		_gh_pr_checks_exact_read_error "pull-request-identity-read" "$identity_exit"
 		return 2
-	}
+	fi
 	identity=$(printf '%s' "$identity_json" | jq -er --argjson expected "$pr_number" \
 		--arg object_type "$object_type" --arg string_type "$string_type" '
 		select(type == $object_type and .number == $expected)
@@ -719,13 +750,15 @@ _gh_pr_checks_exact_collect_pages() {
 			cursor_flag="-F"
 			cursor_field="endCursor=null"
 		fi
+		local response_exit=0
 		response=$(AIDEVOPS_GH_GRAPHQL_COST_FROM_RESPONSE=1 \
 			AIDEVOPS_GH_ROUTE_DECISION="gh-pr-checks-status-rollup-exact-cost" \
-			_gh_checks_api_read graphql -f id="$node_id" "$cursor_flag" "$cursor_field" -f query="$query" 2>/dev/null) || {
+			_gh_checks_api_read graphql -f id="$node_id" "$cursor_flag" "$cursor_field" -f query="$query" 2>/dev/null) || response_exit=$?
+		if [[ "$response_exit" -ne 0 ]]; then
 			rm -f "$pages_file"
-			_gh_pr_checks_exact_error "status-rollup page ${page_number} read failed"
+			_gh_pr_checks_exact_read_error "status-rollup-page-${page_number}-read" "$response_exit"
 			return 2
-		}
+		fi
 		page_meta=$(_gh_pr_checks_exact_page_meta "$response") || page_meta=""
 		if [[ -z "$page_meta" ]]; then
 			_gh_pr_checks_exact_error "status-rollup page ${page_number} response was partial or malformed"

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -383,11 +383,13 @@ RUNNER_EOF
 }
 
 # Run cmd_merge in an isolated subprocess with a controlled review-bot gate.
-# Args: pr_number repo gate_rc
+# Args: pr_number repo gate_rc [gate_kind] [gate_detail]
 run_cmd_merge_with_gate() {
 	local pr_number="$1"
 	local repo="$2"
 	local gate_rc="$3"
+	local gate_kind="${4:-review-bot}"
+	local gate_detail="${5:-}"
 	local scripts_dir="${SCRIPT_DIR}/.."
 	local tmp_runner=""
 	tmp_runner=$(mktemp)
@@ -397,7 +399,11 @@ set -euo pipefail
 SCRIPT_DIR='${scripts_dir}'
 source '${scripts_dir}/shared-constants.sh'
 source '${scripts_dir}/full-loop-helper-merge.sh'
-cmd_pre_merge_gate() { return '${gate_rc}'; }
+cmd_pre_merge_gate() {
+	FULL_LOOP_PRE_MERGE_BLOCKER_KIND='${gate_kind}'
+	FULL_LOOP_PRE_MERGE_BLOCKER_DETAIL='${gate_detail}'
+	return '${gate_rc}'
+}
 _merge_guard_prospective_todo() { return 0; }
 _retarget_stacked_children_interactive() { return 0; }
 release_interactive_claim_on_merge() { return 0; }
@@ -683,6 +689,31 @@ test_review_gate_failure_blocks_rest_fallback() {
 	[[ -f "${TEST_ROOT}/logs/gh-api-calls.txt" ]] && rest_called=1
 	print_result "review gate failure: REST fallback not called" "$rest_called"
 
+	return 0
+}
+
+# Test 7a: A cooldown-classified gate failure reports the real blocker.
+test_cooldown_gate_failure_reports_cooldown() {
+	rm -f "${TEST_ROOT}/logs/"*.txt
+	create_gh_stub "graphql-rate-limit"
+
+	local exit_code=0
+	local output=""
+	output=$(run_cmd_merge_with_gate "42" "testorg/testrepo" "1" \
+		"github-api-cooldown" "1893456000" 2>&1) || exit_code=$?
+	print_result "cooldown gate failure: cmd_merge exits non-zero" "$((exit_code == 0 ? 1 : 0))"
+	print_result "cooldown gate failure: truthful expiry guidance" \
+		"$([[ "$output" == *"Merge deferred: GitHub API cooldown is active; retry after epoch 1893456000."* ]] && printf '0' || printf '1')" \
+		"output=$output"
+	print_result "cooldown gate failure: no review-bot remediation" \
+		"$([[ "$output" != *"Address bot findings"* ]] && printf '0' || printf '1')" \
+		"output=$output"
+
+	local merge_called=0
+	if [[ -f "${TEST_ROOT}/logs/gh-calls.txt" ]] && grep -q "pr merge" "${TEST_ROOT}/logs/gh-calls.txt"; then
+		merge_called=1
+	fi
+	print_result "cooldown gate failure: merge is not attempted" "$merge_called"
 	return 0
 }
 
@@ -1439,6 +1470,7 @@ main() {
 	test_graphql_rate_limit_cmd_merge_phase_autofile
 	test_graphql_rate_limit_auto_no_rest_fallback
 	test_review_gate_failure_blocks_rest_fallback
+	test_cooldown_gate_failure_reports_cooldown
 	test_auto_review_required_interactive_admin_fallback
 	test_auto_review_required_headless_no_admin_fallback
 	test_stale_cache_401_retry

--- a/.agents/scripts/tests/test-full-loop-remote-evidence.sh
+++ b/.agents/scripts/tests/test-full-loop-remote-evidence.sh
@@ -117,6 +117,7 @@ chmod +x "${ROOT}/bin/gh"
 
 run_gate() {
 	local mode="$1"
+	local output_mode="${2:-quiet}"
 	local runner="${ROOT}/runner-${mode}.sh"
 	cat >"$runner" <<RUNNER
 #!/usr/bin/env bash
@@ -149,6 +150,10 @@ gh_pr_checks_exact_json() {
 			printf '%s\n' 'exact check read unavailable' >&2
 			return 2
 			;;
+		cooldown)
+			printf '%s\n' 'gh_pr_checks_exact_json: error_kind=github-api-cooldown expires_at=1893456000 operation=pull-request-identity-read' >&2
+			return 2
+			;;
 		changed-wording)
 			printf "%s\n" "no required checks configured for the 'remote-branch' branch" >&2
 			return 1
@@ -170,8 +175,13 @@ gh_pr_checks_exact_json() {
 cmd_pre_merge_gate 42 testorg/testrepo
 RUNNER
 	chmod +x "$runner"
-	GH_TEST_MODE="$mode" REVIEW_GATE_TEST_RESULT="${REVIEW_GATE_TEST_RESULT:-PASS}" \
-		PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" >/dev/null 2>&1
+	if [[ "$output_mode" == "visible" ]]; then
+		GH_TEST_MODE="$mode" REVIEW_GATE_TEST_RESULT="${REVIEW_GATE_TEST_RESULT:-PASS}" \
+			PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner"
+	else
+		GH_TEST_MODE="$mode" REVIEW_GATE_TEST_RESULT="${REVIEW_GATE_TEST_RESULT:-PASS}" \
+			PATH="${ROOT}/bin:/opt/homebrew/bin:/usr/bin:/bin" bash "$runner" >/dev/null 2>&1
+	fi
 	return $?
 }
 
@@ -212,5 +222,14 @@ for mode in draft pending changes closed api-error changed-wording malformed emp
 	fi
 	printf 'PASS unsafe remote state is blocked: %s\n' "$mode"
 done
+
+cooldown_rc=0
+cooldown_output=$(run_gate cooldown visible 2>&1) || cooldown_rc=$?
+if [[ "$cooldown_rc" -ne 0 && "$cooldown_output" == *"GitHub API cooldown is active until epoch 1893456000"* ]]; then
+	printf 'PASS cooldown evidence remains truthful through the readiness gate\n'
+else
+	printf 'FAIL cooldown evidence was collapsed: rc=%s output=%s\n' "$cooldown_rc" "$cooldown_output"
+	exit 1
+fi
 
 exit 0

--- a/.agents/scripts/tests/test-gh-pr-checks-exact-json.sh
+++ b/.agents/scripts/tests/test-gh-pr-checks-exact-json.sh
@@ -28,6 +28,10 @@ if [[ "$endpoint" == "repos/owner/repo/pulls/42" ]]; then
 	if [[ "${GH_TEST_MODE:-multipage}" == "identity-error" ]]; then
 		exit 1
 	fi
+	if [[ "${GH_TEST_MODE:-multipage}" == "identity-cooldown" ||
+		"${GH_TEST_MODE:-multipage}" == "identity-read-deferred" ]]; then
+		exit 75
+	fi
 	if [[ "${GH_TEST_MODE:-multipage}" == "identity-malformed" ]]; then
 		printf '%s\n' '{"number":42,"node_id":"","head":{"ref":"feature/test","sha":"bad"}}'
 		exit 0
@@ -49,6 +53,9 @@ args="$*"
 page=1
 [[ "$args" == *"endCursor=CURSOR1"* ]] && page=2
 
+if [[ "$mode" == "graphql-cooldown" ]]; then
+	exit 75
+fi
 if [[ "$mode" == "graphql-error" ]]; then
 	printf '%s\n' '{"data":{"node":null,"rateLimit":{"cost":2}},"errors":[{"message":"field unavailable"}]}'
 	exit 0
@@ -135,6 +142,16 @@ export CALL_LOG
 export PATH="${TEST_ROOT}/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 # shellcheck source=../shared-gh-wrappers-checks.sh
 source "$LIB"
+
+_gh_secondary_cooldown_expires_at() {
+	printf '1893456000'
+	return 0
+}
+
+_gh_secondary_cooldown_active() {
+	[[ "${GH_TEST_MODE:-}" == *"cooldown"* ]] || return 1
+	return 0
+}
 
 PASS_COUNT=0
 FAIL_COUNT=0
@@ -254,6 +271,21 @@ for failure_mode in identity-error identity-malformed missing-cost zero-cost gra
 	assert_eq "${failure_mode} fails indeterminate" "2" "$CASE_RC"
 	assert_eq "${failure_mode} emits no JSON" "" "$CASE_OUT"
 done
+
+run_case identity-cooldown required
+assert_eq "cooldown identity read keeps the exact-check public exit contract" "2" "$CASE_RC"
+assert_contains "cooldown identity read preserves a stable classification" \
+	"error_kind=github-api-cooldown expires_at=1893456000 operation=pull-request-identity-read" "$CASE_ERR"
+
+run_case graphql-cooldown required
+assert_eq "cooldown status-rollup read keeps the exact-check public exit contract" "2" "$CASE_RC"
+assert_contains "cooldown status-rollup read preserves a stable classification" \
+	"error_kind=github-api-cooldown expires_at=1893456000 operation=status-rollup-page-1-read" "$CASE_ERR"
+
+run_case identity-read-deferred required
+assert_eq "non-cooldown read deferral keeps the exact-check public exit contract" "2" "$CASE_RC"
+assert_contains "non-cooldown read deferral is not mislabeled as a cooldown" \
+	"error_kind=github-api-read-deferred operation=pull-request-identity-read" "$CASE_ERR"
 
 run_case multipage required 1
 assert_eq "page bound fails closed" "2" "$CASE_RC"


### PR DESCRIPTION
## Summary

Preserve active GitHub cooldown provenance through exact-check and pre-merge gates so full-loop reports truthful retry guidance instead of review-bot remediation.

## Files Changed

.agents/scripts/full-loop-helper-commit.sh, .agents/scripts/full-loop-helper-merge.sh, .agents/scripts/shared-gh-wrappers-checks.sh, .agents/scripts/tests/test-full-loop-merge.sh, .agents/scripts/tests/test-full-loop-remote-evidence.sh, .agents/scripts/tests/test-gh-pr-checks-exact-json.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — 41 exact-check tests, remote-evidence regression, 80 merge tests, ShellCheck, linters-local.sh; runtime self-assessed with isolated production-path stubs.

Resolves #30015


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.251 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-sol spent 1h 23m and 262,064 tokens on this with the user in an interactive session.