### PR TITLE
GH#30051: fix v3.32.252 aggregate provenance ordering

### DIFF
--- a/.agents/scripts/release-provenance-helper.sh
+++ b/.agents/scripts/release-provenance-helper.sh
@@ -524,7 +524,7 @@ _release_provenance_verify_aggregate_manifest() {
 		_RELEASE_PROVENANCE_AGGREGATED_SOURCES="$manifest_json"
 		return 0
 	fi
-	if [[ "$(jq -cS . <<<"$manifest_json")" != "$(jq -cS . <<<"$_RELEASE_PROVENANCE_AGGREGATED_SOURCES")" ]]; then
+	if [[ "$(jq -cS 'sort_by(.pr)' <<<"$manifest_json")" != "$(jq -cS 'sort_by(.pr)' <<<"$_RELEASE_PROVENANCE_AGGREGATED_SOURCES")" ]]; then
 		_release_provenance_error "tag aggregated sources differ from the reviewed aggregation manifest"
 		return 1
 	fi

--- a/.agents/scripts/tests/test-release-provenance-helper.sh
+++ b/.agents/scripts/tests/test-release-provenance-helper.sh
@@ -246,10 +246,10 @@ printf 'PASS duplicate, malformed, and SHA-mismatched expected sources are rejec
 git -C "$AGG_REPO" commit -q --allow-empty -m "complete reviewed aggregate source
 
 Aidevops-Release-Aggregator-PR: 100
+Aidevops-Release-Aggregates: 45@${AGG_FOURTH}
 Aidevops-Release-Aggregates: 42@${AGG_ORIGINAL}
-Aidevops-Release-Aggregates: 43@${AGG_SECOND}
 Aidevops-Release-Aggregates: 44@${AGG_THIRD}
-Aidevops-Release-Aggregates: 45@${AGG_FOURTH}"
+Aidevops-Release-Aggregates: 43@${AGG_SECOND}"
 COMPLETE_AGGREGATE_MERGE=$(git -C "$AGG_REPO" rev-parse HEAD)
 export COMPLETE_AGGREGATE_MERGE
 git -C "$AGG_REPO" push -q --force origin HEAD:main
@@ -291,7 +291,7 @@ if (
 	exit 1
 fi
 printf 'PASS unreviewed direct commit cannot aggregate release authority\n'
-git -C "$AGG_REPO" switch -q --detach "$AGGREGATE_MERGE"
+git -C "$AGG_REPO" switch -q --detach "$COMPLETE_AGGREGATE_MERGE"
 
 printf '2.0.0\n' >"${AGG_REPO}/VERSION"
 printf '{"name":"fixture","version":"2.0.0"}\n' >"${AGG_REPO}/package.json"
@@ -302,9 +302,12 @@ export AGG_TAG_COMMIT
 git -C "$AGG_REPO" tag -a v2.0.0 -m "Release v2.0.0 - aggregate fixture
 
 Aidevops-Version: 2.0.0
-Aidevops-Source-PR: 99
-Aidevops-Source-Merge: ${AGGREGATE_MERGE}
-Aidevops-Aggregated-Source: 42@${AGG_ORIGINAL}"
+Aidevops-Source-PR: 100
+Aidevops-Source-Merge: ${COMPLETE_AGGREGATE_MERGE}
+Aidevops-Aggregated-Source: 42@${AGG_ORIGINAL}
+Aidevops-Aggregated-Source: 43@${AGG_SECOND}
+Aidevops-Aggregated-Source: 44@${AGG_THIRD}
+Aidevops-Aggregated-Source: 45@${AGG_FOURTH}"
 git -C "$AGG_REPO" push -q origin HEAD:main --tags
 tag_authorization_json=$(
 	cd "$AGG_REPO" || exit 1
@@ -319,14 +322,14 @@ printf 'PASS immutable-tag authorization resolves every trusted PR to its verifi
 	PATH="${AGG_BIN}:/opt/homebrew/bin:/usr/bin:/bin" \
 		bash "$HELPER" verify --tag v2.0.0 --repo test/aggregate >/dev/null
 )
-printf 'PASS immutable tag provenance verifies the reviewed aggregate and every included source\n'
+printf 'PASS immutable tag provenance compares aggregate source sets independent of trailer order\n'
 
 git -C "$AGG_REPO" tag -d v2.0.0 >/dev/null
 git -C "$AGG_REPO" tag -a v2.0.0 -m "Release v2.0.0 - tampered aggregate fixture
 
 Aidevops-Version: 2.0.0
-Aidevops-Source-PR: 99
-Aidevops-Source-Merge: ${AGGREGATE_MERGE}"
+Aidevops-Source-PR: 100
+Aidevops-Source-Merge: ${COMPLETE_AGGREGATE_MERGE}"
 
 (
 	cd "$AGG_REPO" || exit 1
@@ -339,8 +342,8 @@ git -C "$AGG_REPO" tag -d v2.0.0 >/dev/null
 git -C "$AGG_REPO" tag -a v2.0.0 -m "Release v2.0.0 - conflicting aggregate fixture
 
 Aidevops-Version: 2.0.0
-Aidevops-Source-PR: 99
-Aidevops-Source-Merge: ${AGGREGATE_MERGE}
+Aidevops-Source-PR: 100
+Aidevops-Source-Merge: ${COMPLETE_AGGREGATE_MERGE}
 Aidevops-Aggregated-Source: 42@0000000000000000000000000000000000000000"
 if (
 	cd "$AGG_REPO" || exit 1


### PR DESCRIPTION
## Summary

- Compare validated aggregate provenance manifests after normalizing both arrays by PR number.
- Preserve all existing duplicate, shape, membership, merge-SHA, and ancestry checks.
- Extend the integration fixture so reviewed commit trailers and signed tag trailers contain the same four sources in different orders.

## Root cause

The verifier sorted JSON object keys but compared arrays in insertion order. Version generation normalizes tag sources while reviewed aggregation commits preserve their trailer order, so equivalent immutable source sets could fail publication.

This recovery-branch PR supersedes #30052 because the active exact-tip release lane intentionally permits only `chore/release-v3.32.252-provenance` to merge the provenance fix needed by the queued immutable tag.

## Verification

- `bash .agents/scripts/tests/test-release-provenance-helper.sh`
- `.agents/scripts/linters-local.sh`
- The fixed helper verifies the existing local `v3.32.252` signed tag from PR #30048.

## Runtime Testing

Runtime-verified against both the integration fixture and the blocked local v3.32.252 tag.

Resolves #30051

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.251 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-sol spent 1h 6m and 397,782 tokens on this with the user in an interactive session.
