### PR TITLE
GH#30056: preserve contributor issue origin provenance

### DIFF
--- a/.agents/scripts/gh-signature-helper.sh
+++ b/.agents/scripts/gh-signature-helper.sh
@@ -422,9 +422,18 @@ cmd_footer() {
 	local sig
 	# ${args[@]+"${args[@]}"} handles empty array under set -u (Bash 3.2 compat)
 	sig=$(cmd_generate ${args[@]+"${args[@]}"})
+	local session_type
+	session_type=$(_detect_session_type)
+	local origin_marker=""
+	case "$session_type" in
+	interactive) origin_marker=$'<!-- aidevops:origin:interactive -->\n' ;;
+	worker | routine) origin_marker=$'<!-- aidevops:origin:worker -->\n' ;;
+	esac
 	# HTML comment marker lets workers/tooling identify and skip signature blocks
-	# (see AGENTS.md — signature footer skip when reading)
-	printf '\n<!-- aidevops:sig -->\n---\n%s\n' "$sig"
+	# (see AGENTS.md — signature footer skip when reading). The adjacent origin
+	# marker lets repository-side automation restore provenance when a contributor
+	# can create an issue but lacks permission to apply labels.
+	printf '\n%s<!-- aidevops:sig -->\n---\n%s\n' "$origin_marker" "$sig"
 	return 0
 }
 

--- a/.agents/scripts/pulse-issue-reconcile-actions.sh
+++ b/.agents/scripts/pulse-issue-reconcile-actions.sh
@@ -1077,13 +1077,15 @@ _should_cpt() {
 }
 
 # Stage 5 predicate: issue is an aidevops-shaped labelless candidate.
-# Title must match tNNN: or GH#NNN: AND no origin:/tier:/status: labels.
-# Args: $1 = issue_title, $2 = labels_csv
+# A task-shaped title or an aidevops origin marker qualifies, provided no
+# origin:/tier:/status: label has already established provenance/lifecycle.
+# Args: $1 = issue_title, $2 = labels_csv, $3 = issue_body
 _should_lia() {
 	local issue_title="$1"
 	local labels_csv="$2"
-	# Title must match aidevops task shape
-	if ! printf '%s' "$issue_title" | grep -qE '^(t[0-9]+(\.[0-9]+)*|GH#[0-9]+): '; then
+	local issue_body="${3:-}"
+	if ! printf '%s' "$issue_title" | grep -qE '^(t[0-9]+(\.[0-9]+)*|GH#[0-9]+): ' &&
+		! printf '%s\n' "$issue_body" | grep -Eq '^<!-- aidevops:origin:(interactive|worker) -->$'; then
 		return 1
 	fi
 	# Must have no origin:/tier:/status: labels (unquoted patterns avoid ratchet)

--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -923,17 +923,15 @@ normalize_active_issue_assignments() {
 # t2112: backfill labelless aidevops-shaped issues.
 #
 # Scans each pulse:true repo for open issues whose titles match the aidevops
-# shape (`^tNNN(\.NNN)*: ` or `^GH#NNN: `) but that have ZERO labels in any
-# aidevops namespace (origin:*, tier:*, status:*). Such issues were created
-# via a bare `gh issue create` call that bypassed the `gh_create_issue`
-# wrapper — they are invisible to the enrichment pipeline (which keys off
-# TODO.md entries) and unreachable by the dedup / dispatch guards.
+# task shape or whose signed body carries an aidevops origin marker, but that
+# have ZERO labels in any aidevops namespace (origin:*, tier:*, status:*).
+# This covers bare wrapper bypasses and contributor-created reports whose
+# GitHub role could not apply labels at creation time.
 #
 # Backfill steps per candidate:
-#   1. Add `origin:worker` + `tier:standard` as conservative defaults. The
-#      origin label is the conservative choice: a labelless issue almost
-#      always signals automation, and if the creator was actually interactive
-#      they would have used the wrapper.
+#   1. Restore a signed origin marker when present. Trusted legacy task-shaped
+#      issues fall back to `origin:worker` + `tier:standard`; external authors
+#      retain NMR + external-contributor and receive no tier until approval.
 #   2. Extract hashtag labels from the body (#tag on its own or end-of-line,
 #      3+ chars, not a pure number which would be an issue ref) and apply
 #      them via `ensure_labels_exist` + `gh issue edit --add-label`.
@@ -1018,12 +1016,13 @@ This comment is idempotent; the HTML sentinel prevents duplicates on subsequent 
 		fi
 		[[ -n "$issues_json" && "$issues_json" != "null" ]] || continue
 
-		# jq filter: title starts with tNNN(.NNN)*: OR GH#NNN:, AND no label
-		# in the aidevops namespaces. Cap at 10 candidates per repo per cycle.
+		# A task-shaped title or signed aidevops origin marker qualifies when no
+		# origin/tier/status label has already established provenance/lifecycle.
 		local candidates
 		candidates=$(printf '%s' "$issues_json" | jq -c '
 			[.[] |
-			 select((.title | test("^(t[0-9]+(\\.[0-9]+)*|GH#[0-9]+): ")) and
+			 select(((.title | test("^(t[0-9]+(\\.[0-9]+)*|GH#[0-9]+): ")) or
+			         ((.body // "") | test("(^|\\n)<!-- aidevops:origin:(interactive|worker) -->(\\n|$)"))) and
 			        ((.labels // []) |
 			         map(.name) |
 			         map(select(test("^(origin:|tier:|status:)"))) |
@@ -1094,7 +1093,7 @@ This issue was created via a bare \`${_raw_cmd}\` call that bypassed the \`${_wr
 This comment is idempotent; the HTML sentinel prevents duplicates on subsequent pulse cycles."
 	local external_comment_template
 	external_comment_template="${external_sentinel}
-Thanks for filing this issue. Because it was created by a contributor outside the maintainer team, the framework's reconcile pass (\`reconcile_labelless_aidevops_issues\` in \`pulse-issue-reconcile.sh\`, t2450) has applied \`needs-maintainer-review\` and extracted hashtag labels from the body — but intentionally withheld the \`origin:*\` and \`tier:*\` labels that would otherwise make this issue dispatchable to an automated worker.
+Thanks for filing this issue. Because it was created by a contributor outside the maintainer team, the framework's reconcile pass (\`reconcile_labelless_aidevops_issues\` in \`pulse-issue-reconcile.sh\`, t2450) has applied \`needs-maintainer-review\` and \`external-contributor\`, restored signed \`origin:*\` composition provenance when present, and withheld \`tier:*\` dispatch metadata until approval.
 
 **What happens next:** a maintainer will triage this issue and either
 
@@ -1119,6 +1118,13 @@ This comment is idempotent; the HTML sentinel prevents duplicates on subsequent 
 	assoc=$(printf '%s' "$issue_json" | jq -r '.author_association // "NONE"' 2>/dev/null || echo "NONE")
 	author_type=$(printf '%s' "$issue_json" | jq -r '.user.type // ""' 2>/dev/null || echo "")
 	author_login=$(printf '%s' "$issue_json" | jq -r '.user.login // ""' 2>/dev/null || echo "")
+	local origin_interactive="origin:interactive" origin_worker="origin:worker"
+	local reported_origin=""
+	if printf '%s\n' "$issue_body" | grep -Fqx '<!-- aidevops:origin:interactive -->'; then
+		reported_origin="$origin_interactive"
+	elif printf '%s\n' "$issue_body" | grep -Fqx '<!-- aidevops:origin:worker -->'; then
+		reported_origin="$origin_worker"
+	fi
 	local is_external="$_PIR_BOOL_TRUE"
 	if [[ "$author_type" == "Bot" ]]; then
 		is_external="$_PIR_BOOL_FALSE"
@@ -1165,15 +1171,23 @@ This comment is idempotent; the HTML sentinel prevents duplicates on subsequent 
 	local -a add_args
 	local labels_csv_lia comment_template_use
 	if [[ "$is_external" == "$_PIR_BOOL_TRUE" ]]; then
-		add_args=("$_PIR_ADD_LABEL_FLAG" "$_PIR_NMR_LABEL")
-		labels_csv_lia="$_PIR_NMR_LABEL"
+		add_args=("$_PIR_ADD_LABEL_FLAG" "$_PIR_NMR_LABEL"
+			"$_PIR_ADD_LABEL_FLAG" "external-contributor")
+		labels_csv_lia="$_PIR_NMR_LABEL,external-contributor"
+		if [[ -n "$reported_origin" ]]; then
+			add_args+=("$_PIR_ADD_LABEL_FLAG" "$reported_origin")
+			labels_csv_lia="${labels_csv_lia},${reported_origin}"
+		fi
 		comment_template_use="$external_comment_template"
 	else
-		add_args=("$_PIR_ADD_LABEL_FLAG" "origin:worker"
-			"$_PIR_REMOVE_LABEL_FLAG" "origin:interactive"
+		local internal_origin="${reported_origin:-$origin_worker}"
+		local opposite_origin="$origin_interactive"
+		[[ "$internal_origin" == "$origin_interactive" ]] && opposite_origin="$origin_worker"
+		add_args=("$_PIR_ADD_LABEL_FLAG" "$internal_origin"
+			"$_PIR_REMOVE_LABEL_FLAG" "$opposite_origin"
 			"$_PIR_REMOVE_LABEL_FLAG" "origin:worker-takeover"
 			"$_PIR_ADD_LABEL_FLAG" "$_PIR_TIER_STANDARD")
-		labels_csv_lia="origin:worker,$_PIR_TIER_STANDARD"
+		labels_csv_lia="${internal_origin},$_PIR_TIER_STANDARD"
 		comment_template_use="$comment_template"
 	fi
 	if [[ -n "$body_tags" ]]; then
@@ -1608,7 +1622,7 @@ reconcile_issues_single_pass() {
 
 			# Stage 5: backfill labelless aidevops-shaped issues (per-repo cap)
 			if [[ "$lia_per_repo" -lt "$lia_max_repo" ]] && \
-				_should_lia "$issue_title" "$labels_csv"; then
+				_should_lia "$issue_title" "$labels_csv" "$issue_body"; then
 				if _action_lia_single "$slug" "$issue_num" "$issue_title" "$issue_body" "$issue_sync_helper"; then
 					lia_fixed=$((lia_fixed + 1))
 					lia_per_repo=$((lia_per_repo + 1))

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -115,6 +115,10 @@ assert_contains "contains HTML sig marker" "<!-- aidevops:sig -->" "$result"
 assert_contains "contains ---" "---" "$result"
 assert_contains "contains signature" "plugin for [OpenCode](https://opencode.ai) v1.0.0" "$result"
 assert_contains "contains tokens" "5,000 tokens on this" "$result"
+result=$(AIDEVOPS_SESSION_ORIGIN=interactive "$HELPER" footer --cli "OpenCode" --tokens 0)
+assert_contains "interactive footer records issue origin provenance" "<!-- aidevops:origin:interactive -->" "$result"
+result=$(AIDEVOPS_SESSION_ORIGIN=worker "$HELPER" footer --cli "OpenCode" --tokens 0)
+assert_contains "worker footer records issue origin provenance" "<!-- aidevops:origin:worker -->" "$result"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 6: comma formatting for various numbers

--- a/.agents/scripts/tests/test-issue-triage-gate-fail-closed.sh
+++ b/.agents/scripts/tests/test-issue-triage-gate-fail-closed.sh
@@ -60,6 +60,14 @@ main() {
 		"trusted bots run through stale-NMR cleanup instead of returning early"
 	check_pattern "hasExternalAuthoritySource = issueLabels\.has\('external-contributor'\)" \
 		"trusted automation preserves explicit external-source authority gates"
+	check_pattern "aidevops:origin:\(interactive\|worker\)" \
+		"signed aidevops origin provenance is parsed from contributor issue bodies"
+	check_pattern "const triageLabels = \['needs-maintainer-review', 'external-contributor'\]" \
+		"external contributor authority and NMR labels are applied together"
+	check_pattern "triageLabels\.push\(reportedOrigin\)" \
+		"reported interactive or worker origin is restored by repository automation"
+	check_pattern "reportedOrigin !== 'origin:worker'" \
+		"unproven external worker labels are still stripped"
 	check_pattern "collaborators/\{username\}/permission" \
 		"collaborator authority uses the repository permission endpoint"
 	check_pattern "Run trusted-author cleanup first" \

--- a/.agents/scripts/tests/test-pulse-issue-reconcile.sh
+++ b/.agents/scripts/tests/test-pulse-issue-reconcile.sh
@@ -304,6 +304,7 @@ test_should_predicates() {
 		_should_lia 'GH#567: fix' ''          && echo 'lia-gh:1' || echo 'lia-gh:0'
 		_should_lia 't1234: fix' 'origin:worker' && echo 'lia-labeled:1' || echo 'lia-labeled:0'
 		_should_lia 'not a task title' ''     && echo 'lia-badtitle:1' || echo 'lia-badtitle:0'
+		_should_lia 'normal contributor report' '' '<!-- aidevops:origin:interactive -->' && echo 'lia-signed:1' || echo 'lia-signed:0'
 	" 2>/dev/null)
 
 	local all_ok=1
@@ -337,8 +338,10 @@ test_should_predicates() {
 		"_should_lia: labeled issue should return 1" || all_ok=0
 	_assert_should_predicate_result "$result" 'lia-badtitle:0' \
 		"_should_lia: non-task title should return 1" || all_ok=0
+	_assert_should_predicate_result "$result" 'lia-signed:1' \
+		"_should_lia: signed contributor report should return 0" || all_ok=0
 
-	[[ "$all_ok" == "1" ]] && _pass "_should_* predicates: all 14 cases correct"
+	[[ "$all_ok" == "1" ]] && _pass "_should_* predicates: all 15 cases correct"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-labelless-reconcile.sh
+++ b/.agents/scripts/tests/test-pulse-labelless-reconcile.sh
@@ -11,8 +11,8 @@
 #   #500 — aidevops-shaped + labelless + MEMBER author          (MUST be blessed internal)
 #   #501 — non-aidevops shape (random bug title)                (MUST be ignored)
 #   #502 — aidevops-shaped + already has origin:worker          (MUST be ignored)
-#   #503 — aidevops-shaped + labelless + CONTRIBUTOR author     (MUST be gated external, t2450)
-#   #504 — aidevops-shaped + labelless + NONE author, no tags   (MUST be gated external, t2450)
+#   #503 — signed interactive + normal title + CONTRIBUTOR      (MUST restore origin + gate)
+#   #504 — signed worker + task title + NONE author              (MUST restore origin + gate)
 #   #505 — aidevops-shaped + labelless + read collaborator       (MUST be gated external)
 #   #506 — aidevops-shaped + labelless + write collaborator      (MUST be blessed internal)
 #   #507 — aidevops-shaped + labelless + trusted bot             (MUST be blessed internal)
@@ -23,8 +23,8 @@
 #   - #501/#502 neither edited nor commented
 #
 # Assertions — external path (t2450):
-#   - #503/#504 edits add needs-maintainer-review; body tags still applied (#503)
-#   - #503/#504 edits DO NOT add origin:worker, tier:simple, tier:standard, tier:thinking
+#   - #503/#504 edits add needs-maintainer-review + external-contributor
+#   - signed origins are restored, while tier labels remain withheld
 #   - #503/#504 comments contain the EXTERNAL sentinel (labelless-backfill-external)
 
 set -u
@@ -84,14 +84,14 @@ FIXTURE_ISSUES_JSON=$(
   },
   {
     "number": 503,
-    "title": "t2548: Fix orphan-task-id bug",
-    "body": "External CONTRIBUTOR-authored labelless aidevops-shaped issue.\n\n## Tags inline: #ai #security\n",
+    "title": "Fix orphan-task-id bug",
+    "body": "External CONTRIBUTOR-authored signed aidevops issue.\n\n## Tags inline: #ai #security\n\n<!-- aidevops:origin:interactive -->\n<!-- aidevops:sig -->\n",
     "labels": []
   },
   {
     "number": 504,
     "title": "GH#9999: propose additional dedup layer",
-    "body": "External NONE-authored labelless aidevops-shaped issue with no body tags.",
+    "body": "External NONE-authored labelless aidevops-shaped issue with no body tags.\n\n<!-- aidevops:origin:worker -->\n<!-- aidevops:sig -->\n",
     "labels": []
   },
   {
@@ -265,7 +265,7 @@ fi
 # GH#29394: COLLABORATOR must be live permission-checked, while trusted bots
 # retain the automation fast path.
 edit_line_505=$(grep '^gh issue edit 505 --repo test/repo' "$TRACE_FILE" | head -1)
-if [[ "$edit_line_505" != *"--add-label needs-maintainer-review"* || "$edit_line_505" == *"--add-label origin:worker"* ]]; then
+if [[ "$edit_line_505" != *"--add-label needs-maintainer-review"* || "$edit_line_505" == *"--add-label origin:"* ]]; then
 	printf 'FAIL: #505 read collaborator did not retain the external-authority gate\n'
 	printf '  got: %s\n' "$edit_line_505"
 	failed=1
@@ -345,7 +345,12 @@ else
 		printf '  got: %s\n' "$edit_line_503"
 		failed=1
 	fi
-	# MUST NOT apply maintainer-trust labels for an external author
+	if [[ "$edit_line_503" != *"--add-label external-contributor"* || "$edit_line_503" != *"--add-label origin:interactive"* ]]; then
+		printf 'FAIL: #503 edit missing external or interactive provenance labels\n'
+		printf '  got: %s\n' "$edit_line_503"
+		failed=1
+	fi
+	# Origin is provenance, not trust; tier metadata remains withheld.
 	for forbidden in "origin:worker" "tier:simple" "tier:standard" "tier:thinking"; do
 		if [[ "$edit_line_503" == *"--add-label $forbidden"* ]]; then
 			printf 'FAIL: #503 edit added forbidden label %s for external author\n' "$forbidden"
@@ -394,7 +399,12 @@ else
 		printf '  got: %s\n' "$edit_line_504"
 		failed=1
 	fi
-	for forbidden in "origin:worker" "tier:simple" "tier:standard" "tier:thinking"; do
+	if [[ "$edit_line_504" != *"--add-label external-contributor"* || "$edit_line_504" != *"--add-label origin:worker"* ]]; then
+		printf 'FAIL: #504 edit missing external or worker provenance labels\n'
+		printf '  got: %s\n' "$edit_line_504"
+		failed=1
+	fi
+	for forbidden in "tier:simple" "tier:standard" "tier:thinking"; do
 		if [[ "$edit_line_504" == *"--add-label $forbidden"* ]]; then
 			printf 'FAIL: #504 edit added forbidden label %s for external author\n' "$forbidden"
 			printf '  got: %s\n' "$edit_line_504"

--- a/.agents/workflows/log-issue-aidevops.md
+++ b/.agents/workflows/log-issue-aidevops.md
@@ -341,6 +341,12 @@ The same shim deterministically normalizes mutually exclusive dispatch intent:
 explicit `no-auto-dispatch` hold wins a same-command conflict; adding either
 label to an existing issue removes its opposite without blocking the edit.
 
+The signature footer also records `origin:interactive` or `origin:worker` in a
+hidden provenance marker. Contributors may lack permission to apply repository
+labels during creation; repository triage restores the matching `origin:*`
+label while retaining `external-contributor` + `needs-maintainer-review` as the
+authority gate.
+
 ```bash
 gh issue create -R marcusquinn/aidevops \
   --title "TITLE" \

--- a/.github/workflows/issue-triage-gate.yml
+++ b/.github/workflows/issue-triage-gate.yml
@@ -23,6 +23,10 @@ jobs:
             const author = issue.user.login;
             const association = issue.author_association;
             const issueLabels = new Set((issue.labels || []).map(label => label.name));
+            const originMatch = (issue.body || '').match(
+              /^<!-- aidevops:origin:(interactive|worker) -->$/m
+            );
+            const reportedOrigin = originMatch ? `origin:${originMatch[1]}` : null;
 
             // OWNER/MEMBER are authoritative associations. COLLABORATOR can
             // represent read/triage access, so require a live write-level lookup.
@@ -83,7 +87,15 @@ jobs:
 
             console.log(`Author ${author} has role ${association} — applying triage gate`);
 
-            // Apply the critical trust label before cleanup/comment calls. Only
+            // #aidevops:trust-boundary — the body marker records composition
+            // provenance only. External authority remains gated by NMR and the
+            // external-contributor label even when an origin marker is present.
+            const triageLabels = ['needs-maintainer-review', 'external-contributor'];
+            if (reportedOrigin) {
+              triageLabels.push(reportedOrigin);
+            }
+
+            // Apply the critical trust label and provenance before cleanup/comment calls. Only
             // attempt label creation after addLabels reports a missing/invalid
             // label and getLabel independently confirms a 404.
             try {
@@ -91,7 +103,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                labels: ['needs-maintainer-review']
+                labels: triageLabels
               });
             } catch (addError) {
               if (![404, 422].includes(addError.status)) {
@@ -125,7 +137,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                labels: ['needs-maintainer-review']
+                labels: triageLabels
               });
             }
 
@@ -133,10 +145,9 @@ jobs:
             // machine-generated. A non-maintainer creating one is either a mistake or an
             // attempt to bypass the assignee gate. Strip the label and apply needs-maintainer-review.
             //
-            // GH#18623: origin:worker is ALSO machine-only — strip it independently of
-            // file-size-debt/function-complexity-debt. A non-maintainer opening an issue with
-            // only the origin:worker label would previously keep that label, since the stripping
-            // logic was nested inside the debt-label check.
+            // GH#18623: an unproven origin:worker label is machine-only. Preserve it only
+            // when the aidevops footer reports worker composition; NMR and
+            // external-contributor still prevent dispatch before approval.
             const debtLabels = ['file-size-debt', 'function-complexity-debt'];
             for (const debtLabel of debtLabels) {
               if (issueLabels.has(debtLabel)) {
@@ -153,8 +164,8 @@ jobs:
                 }
               }
             }
-            if (issueLabels.has('origin:worker')) {
-              console.log(`Non-maintainer ${author} created issue with origin:worker label — stripping label`);
+            if (issueLabels.has('origin:worker') && reportedOrigin !== 'origin:worker') {
+              console.log(`Non-maintainer ${author} created issue with unproven origin:worker label — stripping label`);
               try {
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,


### PR DESCRIPTION
## Summary

- embed a hidden signed session-origin marker in aidevops-composed issue bodies
- restore `origin:interactive` or `origin:worker` during trusted server-side triage and reconciliation
- preserve the external-contributor trust boundary and withhold dispatch-tier metadata pending maintainer approval

Resolves #30056

## Implementation context

- Marker generation: `.agents/scripts/gh-signature-helper.sh`
- Immediate reconciliation: `.github/workflows/issue-triage-gate.yml`
- Periodic reconciliation: `.agents/scripts/pulse-issue-reconcile.sh` and `.agents/scripts/pulse-issue-reconcile-actions.sh`
- Reference pattern: signed `<!-- aidevops:origin:* -->` provenance is metadata only; contributor authority remains external until independently verified

## Verification

- `.agents/scripts/tests/test-gh-signature-helper.sh`
- `.agents/scripts/tests/test-issue-triage-gate-fail-closed.sh`
- `.agents/scripts/tests/test-pulse-labelless-reconcile.sh`
- `.agents/scripts/tests/test-pulse-issue-reconcile.sh`
- ShellCheck on changed shell scripts
- `.agents/scripts/linters-local.sh`
- `git diff --check origin/main...HEAD`

## Runtime Testing

- Risk: medium
- Evidence: self-assessed through the workflow fixtures and mocked GitHub reconciliation tests above; no live contributor issue was created to avoid production metadata noise

## Key decisions

- Origin provenance records how aidevops composed a report, not whether its author is trusted.
- Contributor-created issues retain `external-contributor` and `needs-maintainer-review` even after origin restoration.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.251 plugin for [OpenCode](https://opencode.ai) v1.18.16 with gpt-5.6-sol spent 18m and 367,605 tokens on this with the user in an interactive session.
